### PR TITLE
feat(share): read-only view switcher on shared collection route (TASK-1682)

### DIFF
--- a/web/src/routes/s/[token]/+page.svelte
+++ b/web/src/routes/s/[token]/+page.svelte
@@ -122,10 +122,27 @@
 		const items = baseParsedItems;
 		const view = activeSavedView;
 		if (!view) return items;
-		const filters = Array.isArray(view.config?.filters) ? view.config.filters : [];
-		if (filters.length === 0) return items;
-		return items.filter((item) => filters.every((f) => matchesFilter(item, f)));
+		const rawFilters = Array.isArray(view.config?.filters) ? view.config.filters : [];
+		// Only apply filters we can actually evaluate against the public
+		// payload. Share items carry `fields` only — NOT the logged-in page's
+		// top-level `tags` / `parent_link_id` / `phase`. A filter whose field
+		// is absent from every item would otherwise hide the entire collection
+		// (Codex round 2). Skipping the unsupported filter degrades gracefully:
+		// the viewer sees the (super)set rather than an empty view.
+		const applicable = rawFilters.filter((f) => filterFieldPresent(items, f));
+		if (applicable.length === 0) return items;
+		return items.filter((item) => applicable.every((f) => matchesFilter(item, f)));
 	});
+
+	// True when at least one item exposes the filter's target field, so the
+	// filter is meaningful against the public payload. Malformed/fieldless
+	// filters are treated as "present" so matchesFilter can no-op them.
+	function filterFieldPresent(items: PublicItem[], filter: unknown): boolean {
+		if (!filter || typeof filter !== 'object') return true;
+		const field = (filter as { field?: unknown }).field;
+		if (typeof field !== 'string') return true;
+		return items.some((item) => Object.prototype.hasOwnProperty.call(item.fields, field));
+	}
 
 	// Read-only filter evaluation mirroring the logged-in collection page's
 	// `eq` / `in` handling (the only ops saved-view configs emit). Unknown ops
@@ -222,12 +239,15 @@
 	}
 
 	// Mirror the active selection into the URL (`?view=`), replaceState so the
-	// switcher never pollutes history. A base 'list' (or selecting the owner
-	// default base) drops the param to keep canonical share links clean.
+	// switcher never pollutes history. Drop the param only when the base
+	// selection equals the owner default — that's the no-op case, and the
+	// reload-without-localStorage path resolves back to the same view. A
+	// non-default base (e.g. List on a board-default share) MUST keep the
+	// param so the link reproduces the viewer's choice (Codex round 2).
 	function syncUrl() {
 		const url = new URL(page.url);
 		const handle = selectedKind === 'saved' ? `saved:${selectedSavedSlug}` : selectedBase;
-		if (selectedKind === 'base' && selectedBase === 'list') {
+		if (selectedKind === 'base' && selectedBase === defaultView) {
 			url.searchParams.delete('view');
 		} else {
 			url.searchParams.set('view', handle);

--- a/web/src/routes/s/[token]/+page.svelte
+++ b/web/src/routes/s/[token]/+page.svelte
@@ -124,24 +124,28 @@
 		if (!view) return items;
 		const rawFilters = Array.isArray(view.config?.filters) ? view.config.filters : [];
 		// Only apply filters we can actually evaluate against the public
-		// payload. Share items carry `fields` only — NOT the logged-in page's
-		// top-level `tags` / `parent_link_id` / `phase`. A filter whose field
-		// is absent from every item would otherwise hide the entire collection
-		// (Codex round 2). Skipping the unsupported filter degrades gracefully:
-		// the viewer sees the (super)set rather than an empty view.
-		const applicable = rawFilters.filter((f) => filterFieldPresent(items, f));
+		// payload. Share items carry schema `fields` only — NOT the logged-in
+		// page's top-level `tags` / `parent_link_id` / `phase`. A filter on one
+		// of those would otherwise hide the entire collection (Codex round 2).
+		// Evaluability is decided against the COLLECTION SCHEMA (not item
+		// values): a `priority eq high` filter on a schema that HAS `priority`
+		// stays applied even when no shared item happens to set it (so the
+		// public view returns none, matching the owner) — Codex round 3. Only
+		// fields genuinely absent from the public schema are skipped.
+		const schemaKeys = new Set(baseParsedCollection.fields.map((f) => f.key));
+		const applicable = rawFilters.filter((f) => filterEvaluable(schemaKeys, f));
 		if (applicable.length === 0) return items;
 		return items.filter((item) => applicable.every((f) => matchesFilter(item, f)));
 	});
 
-	// True when at least one item exposes the filter's target field, so the
-	// filter is meaningful against the public payload. Malformed/fieldless
-	// filters are treated as "present" so matchesFilter can no-op them.
-	function filterFieldPresent(items: PublicItem[], filter: unknown): boolean {
+	// True when the filter targets a field present in the public collection
+	// schema, so it's meaningful against the shared payload. Malformed/fieldless
+	// filters are treated as evaluable so matchesFilter can no-op them.
+	function filterEvaluable(schemaKeys: Set<string>, filter: unknown): boolean {
 		if (!filter || typeof filter !== 'object') return true;
 		const field = (filter as { field?: unknown }).field;
 		if (typeof field !== 'string') return true;
-		return items.some((item) => Object.prototype.hasOwnProperty.call(item.fields, field));
+		return schemaKeys.has(field);
 	}
 
 	// Read-only filter evaluation mirroring the logged-in collection page's
@@ -233,9 +237,17 @@
 		selectedSavedSlug = '';
 
 		const urlHandle = page.url.searchParams.get('view');
-		if (applyViewHandle(urlHandle)) return;
-		if (applyViewHandle(loadSavedSelection())) return;
-		// Nothing valid — keep the owner default already set above.
+		const fromUrl = applyViewHandle(urlHandle);
+		if (!fromUrl) {
+			applyViewHandle(loadSavedSelection());
+			// Nothing valid → owner default already set above.
+		}
+		// Normalize the address bar to the resolved selection. A stale/invalid
+		// `?view=` (e.g. a deleted saved view) otherwise leaves the URL
+		// describing a view the page isn't rendering, so a copied link
+		// wouldn't reproduce what the viewer sees (Codex round 3). When the URL
+		// already matched, this is a harmless no-op replaceState.
+		syncUrl();
 	}
 
 	// Mirror the active selection into the URL (`?view=`), replaceState so the

--- a/web/src/routes/s/[token]/+page.svelte
+++ b/web/src/routes/s/[token]/+page.svelte
@@ -9,6 +9,25 @@
 
 	let token = $derived(page.params.token ?? '');
 
+	// Read-only view switcher (TASK-1682 / PLAN-1677 Phase 2). The anonymous
+	// viewer toggles between the three base view types (and any of the
+	// collection's saved views). The choice is purely presentational — it
+	// drives PublicCollectionView's `view` prop, which overrides the owner's
+	// `settings.default_view`. No server save (read-only context); we mirror
+	// the logged-in collection page's URL-param + localStorage persistence.
+	type BaseView = 'list' | 'board' | 'table';
+	const BASE_VIEWS: { value: BaseView; label: string; icon: string }[] = [
+		{ value: 'list', label: 'List', icon: '☰' },
+		{ value: 'board', label: 'Board', icon: '▦' },
+		{ value: 'table', label: 'Table', icon: '⚏' }
+	];
+
+	// Selection is a discriminated handle: either a base view type, or a saved
+	// view addressed by slug (which resolves to a base view_type for rendering).
+	let selectedKind = $state<'base' | 'saved'>('base');
+	let selectedBase = $state<BaseView>('list');
+	let selectedSavedSlug = $state('');
+
 	let loading = $state(true);
 	let error = $state('');
 	let requireAuth = $state(false);
@@ -34,6 +53,139 @@
 		collection: PublicShareCollection;
 		items: PublicShareItem[];
 	} | null>(null);
+
+	// Saved views from the share payload (empty array when the collection has
+	// none). Sorted by the owner's `sort_order` for stable presentation.
+	let savedViews = $derived.by(() => {
+		const views = collectionData?.collection.views ?? [];
+		return [...views].sort((a, b) => a.sort_order - b.sort_order);
+	});
+
+	// Owner's default base view, the fallback when nothing is selected.
+	let defaultView = $derived<BaseView>(
+		coerceBaseView(collectionData?.collection.settings?.default_view) ?? 'list'
+	);
+
+	// The effective base view fed to PublicCollectionView. A saved-view
+	// selection resolves through its `view_type`; an unknown/stale saved slug
+	// falls back to the owner default.
+	let activeBaseView = $derived.by<BaseView>(() => {
+		if (selectedKind === 'saved') {
+			const v = savedViews.find((sv) => sv.slug === selectedSavedSlug);
+			if (v) return coerceBaseView(v.view_type) ?? defaultView;
+			return defaultView;
+		}
+		return selectedBase;
+	});
+
+	function coerceBaseView(value: unknown): BaseView | null {
+		if (value === 'list' || value === 'board' || value === 'table') return value;
+		// Saved views may use 'kanban' as a synonym for the board renderer.
+		if (value === 'kanban') return 'board';
+		return null;
+	}
+
+	// localStorage persistence keyed by share token (mirrors the logged-in
+	// collection page's `pad-view-<coll>` pattern). Stores either a base view
+	// type or `saved:<slug>`. Wrapped in try/catch — share pages may run in
+	// privacy contexts where localStorage throws.
+	function viewStorageKey() {
+		return token ? `pad-share-view-${token}` : '';
+	}
+
+	function saveSelection() {
+		const key = viewStorageKey();
+		if (!key) return;
+		const handle = selectedKind === 'saved' ? `saved:${selectedSavedSlug}` : selectedBase;
+		try {
+			localStorage.setItem(key, handle);
+		} catch {}
+	}
+
+	function loadSavedSelection(): string | null {
+		const key = viewStorageKey();
+		if (!key) return null;
+		try {
+			return localStorage.getItem(key);
+		} catch {
+			return null;
+		}
+	}
+
+	// Apply a stored/URL handle to the selection state. Returns true if it
+	// resolved to a known view; false (caller falls back to the owner default)
+	// for an empty, malformed, or stale-saved handle.
+	function applyViewHandle(handle: string | null | undefined): boolean {
+		if (!handle) return false;
+		if (handle.startsWith('saved:')) {
+			const slug = handle.slice('saved:'.length);
+			if (savedViews.some((v) => v.slug === slug)) {
+				selectedKind = 'saved';
+				selectedSavedSlug = slug;
+				selectedBase = coerceBaseView(savedViews.find((v) => v.slug === slug)?.view_type) ?? defaultView;
+				return true;
+			}
+			return false;
+		}
+		const base = coerceBaseView(handle);
+		if (base) {
+			selectedKind = 'base';
+			selectedBase = base;
+			selectedSavedSlug = '';
+			return true;
+		}
+		return false;
+	}
+
+	// Resolve the initial selection: URL `?view=` param > localStorage >
+	// owner default. Called once after a collection payload loads.
+	function initSelection() {
+		selectedBase = defaultView;
+		selectedKind = 'base';
+		selectedSavedSlug = '';
+
+		const urlHandle = page.url.searchParams.get('view');
+		if (applyViewHandle(urlHandle)) return;
+		if (applyViewHandle(loadSavedSelection())) return;
+		// Nothing valid — keep the owner default already set above.
+	}
+
+	// Mirror the active selection into the URL (`?view=`), replaceState so the
+	// switcher never pollutes history. A base 'list' (or selecting the owner
+	// default base) drops the param to keep canonical share links clean.
+	function syncUrl() {
+		const url = new URL(page.url);
+		const handle = selectedKind === 'saved' ? `saved:${selectedSavedSlug}` : selectedBase;
+		if (selectedKind === 'base' && selectedBase === 'list') {
+			url.searchParams.delete('view');
+		} else {
+			url.searchParams.set('view', handle);
+		}
+		history.replaceState(history.state, '', url);
+	}
+
+	function selectBaseView(base: BaseView) {
+		selectedKind = 'base';
+		selectedBase = base;
+		selectedSavedSlug = '';
+		saveSelection();
+		syncUrl();
+	}
+
+	// Human label for a saved view's underlying base view type (used in the
+	// chip tooltip so viewers know what a saved view renders as).
+	function activeViewTypeLabel(viewType: string): string {
+		const base = coerceBaseView(viewType) ?? defaultView;
+		return BASE_VIEWS.find((b) => b.value === base)?.label ?? 'List';
+	}
+
+	function selectSavedView(slug: string) {
+		selectedKind = 'saved';
+		selectedSavedSlug = slug;
+		selectedBase = coerceBaseView(savedViews.find((v) => v.slug === slug)?.view_type) ?? defaultView;
+		saveSelection();
+		syncUrl();
+	}
 
 	let renderedContent = $derived.by(() => {
 		if (!itemData?.content) return '';
@@ -93,6 +245,7 @@
 					collection: data.collection ?? { name: 'Collection' },
 					items: data.items ?? []
 				};
+				initSelection();
 			} else {
 				error = 'Unknown share type.';
 			}
@@ -158,6 +311,7 @@
 					collection: data.collection ?? { name: 'Collection' },
 					items: data.items ?? []
 				};
+				initSelection();
 			}
 		} catch (e: any) {
 			passwordError = e.message ?? 'Failed to verify password';
@@ -263,9 +417,47 @@
 				{/if}
 			</article>
 		{:else if shareType === 'collection' && collectionData}
+			<div class="collection-toolbar">
+				<div class="view-toggle" role="group" aria-label="Select view">
+					{#each BASE_VIEWS as bv (bv.value)}
+						<button
+							type="button"
+							class="toggle-btn"
+							class:active={selectedKind === 'base' && selectedBase === bv.value}
+							aria-pressed={selectedKind === 'base' && selectedBase === bv.value}
+							aria-label={`${bv.label} view`}
+							title={`${bv.label} view`}
+							onclick={() => selectBaseView(bv.value)}
+						>
+							<span class="toggle-icon" aria-hidden="true">{bv.icon}</span>
+							<span class="toggle-label">{bv.label}</span>
+						</button>
+					{/each}
+				</div>
+
+				{#if savedViews.length > 0}
+					<div class="saved-views" role="group" aria-label="Saved views">
+						<span class="saved-views-label">Views</span>
+						{#each savedViews as sv (sv.slug)}
+							<button
+								type="button"
+								class="saved-view-chip"
+								class:active={selectedKind === 'saved' && selectedSavedSlug === sv.slug}
+								aria-pressed={selectedKind === 'saved' && selectedSavedSlug === sv.slug}
+								title={`${sv.name} (${activeViewTypeLabel(sv.view_type)})`}
+								onclick={() => selectSavedView(sv.slug)}
+							>
+								{sv.name}
+							</button>
+						{/each}
+					</div>
+				{/if}
+			</div>
+
 			<PublicCollectionView
 				collection={collectionData.collection}
 				items={collectionData.items}
+				view={activeBaseView}
 				expandable={false}
 			/>
 		{/if}
@@ -539,6 +731,108 @@
 
 	.item-content :global(a) {
 		color: var(--accent-blue);
+	}
+
+	/* Collection view switcher toolbar */
+	.collection-toolbar {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		gap: var(--space-3);
+		margin-bottom: var(--space-5);
+	}
+
+	.view-toggle {
+		display: flex;
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+		overflow: hidden;
+		flex-shrink: 0;
+	}
+
+	.toggle-btn {
+		display: inline-flex;
+		align-items: center;
+		gap: var(--space-1);
+		background: var(--bg-secondary);
+		border: none;
+		padding: var(--space-1) var(--space-3);
+		cursor: pointer;
+		font-size: 0.85em;
+		color: var(--text-secondary);
+		line-height: 1;
+	}
+
+	.toggle-btn:not(:last-child) {
+		border-right: 1px solid var(--border);
+	}
+
+	.toggle-btn.active {
+		background: var(--bg-tertiary);
+		color: var(--text-primary);
+		font-weight: 500;
+	}
+
+	.toggle-btn:hover:not(.active) {
+		background: var(--bg-hover, var(--bg-tertiary));
+	}
+
+	.toggle-icon {
+		font-size: 1em;
+	}
+
+	.saved-views {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		gap: var(--space-2);
+	}
+
+	.saved-views-label {
+		font-size: 0.75em;
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+		color: var(--text-muted);
+		font-weight: 500;
+	}
+
+	.saved-view-chip {
+		background: var(--bg-secondary);
+		border: 1px solid var(--border);
+		border-radius: 999px;
+		padding: var(--space-1) var(--space-3);
+		cursor: pointer;
+		font-size: 0.82em;
+		color: var(--text-secondary);
+		line-height: 1.2;
+	}
+
+	.saved-view-chip.active {
+		background: var(--accent-blue);
+		border-color: var(--accent-blue);
+		color: #fff;
+		font-weight: 500;
+	}
+
+	.saved-view-chip:hover:not(.active) {
+		background: var(--bg-tertiary);
+		color: var(--text-primary);
+	}
+
+	/* Widen the container for collection views — list/board/table need more
+	   room than the 780px article column. */
+	.share-container:has(.collection-toolbar) {
+		max-width: 1100px;
+	}
+
+	@media (max-width: 640px) {
+		.toggle-label {
+			display: none;
+		}
+
+		.toggle-btn {
+			padding: var(--space-1) var(--space-2);
+		}
 	}
 
 	/* Footer */

--- a/web/src/routes/s/[token]/+page.svelte
+++ b/web/src/routes/s/[token]/+page.svelte
@@ -5,7 +5,13 @@
 	import { marked } from 'marked';
 	import DOMPurify from 'dompurify';
 	import PublicCollectionView from '$lib/components/share/PublicCollectionView.svelte';
-	import type { PublicShareCollection, PublicShareItem } from '$lib/types';
+	import {
+		parsePublicCollection,
+		parsePublicItems,
+		type PublicCollection,
+		type PublicItem
+	} from '$lib/components/share/shareView';
+	import type { PublicShareCollection, PublicShareItem, PublicShareView } from '$lib/types';
 
 	let token = $derived(page.params.token ?? '');
 
@@ -69,14 +75,79 @@
 	// The effective base view fed to PublicCollectionView. A saved-view
 	// selection resolves through its `view_type`; an unknown/stale saved slug
 	// falls back to the owner default.
+	// The saved view object backing the current selection (null in base mode or
+	// when the slug is stale).
+	let activeSavedView = $derived.by<PublicShareView | null>(() => {
+		if (selectedKind !== 'saved') return null;
+		return savedViews.find((sv) => sv.slug === selectedSavedSlug) ?? null;
+	});
+
 	let activeBaseView = $derived.by<BaseView>(() => {
 		if (selectedKind === 'saved') {
-			const v = savedViews.find((sv) => sv.slug === selectedSavedSlug);
-			if (v) return coerceBaseView(v.view_type) ?? defaultView;
+			if (activeSavedView) return coerceBaseView(activeSavedView.view_type) ?? defaultView;
 			return defaultView;
 		}
 		return selectedBase;
 	});
+
+	// Parse the raw payload once into the renderer's PublicCollection /
+	// PublicItem shapes (string-or-object tolerant). When a saved view is
+	// active, overlay its config: grouping is mapped onto the matching
+	// settings knob (board → board_group_by, list → list_group_by) and the
+	// config's filters narrow the item set. Read-only — purely presentational,
+	// no server round-trip. Base-view selections render the unfiltered
+	// collection exactly as before.
+	let baseParsedCollection = $derived.by<PublicCollection>(() =>
+		parsePublicCollection(collectionData?.collection)
+	);
+	let baseParsedItems = $derived.by<PublicItem[]>(() =>
+		parsePublicItems(collectionData?.items)
+	);
+
+	let effectiveCollection = $derived.by<PublicCollection>(() => {
+		const coll = baseParsedCollection;
+		const view = activeSavedView;
+		if (!view) return coll;
+		const groupBy = typeof view.config?.group_by === 'string' ? view.config.group_by : '';
+		if (!groupBy) return coll;
+		// Clone settings so we don't mutate the shared parsed object; route the
+		// group key to the knob the active base renderer actually reads.
+		const settings = { ...coll.settings };
+		if (activeBaseView === 'board') settings.board_group_by = groupBy;
+		else if (activeBaseView === 'list') settings.list_group_by = groupBy;
+		return { ...coll, settings };
+	});
+
+	let effectiveItems = $derived.by<PublicItem[]>(() => {
+		const items = baseParsedItems;
+		const view = activeSavedView;
+		if (!view) return items;
+		const filters = Array.isArray(view.config?.filters) ? view.config.filters : [];
+		if (filters.length === 0) return items;
+		return items.filter((item) => filters.every((f) => matchesFilter(item, f)));
+	});
+
+	// Read-only filter evaluation mirroring the logged-in collection page's
+	// `eq` / `in` handling (the only ops saved-view configs emit). Unknown ops
+	// pass through (don't hide items we can't reason about).
+	function matchesFilter(item: PublicItem, filter: unknown): boolean {
+		if (!filter || typeof filter !== 'object') return true;
+		const f = filter as { field?: unknown; op?: unknown; value?: unknown };
+		if (typeof f.field !== 'string') return true;
+		const fieldVal = item.fields[f.field];
+		if (f.op === 'eq') {
+			return String(fieldVal ?? '') === String(f.value ?? '');
+		}
+		if (f.op === 'in') {
+			const wanted = Array.isArray(f.value) ? f.value.map((v) => String(v)) : [String(f.value)];
+			// Tags-style array fields: match if any item value is wanted.
+			if (Array.isArray(fieldVal)) {
+				return fieldVal.some((v) => wanted.includes(String(v)));
+			}
+			return wanted.includes(String(fieldVal ?? ''));
+		}
+		return true;
+	}
 
 	function coerceBaseView(value: unknown): BaseView | null {
 		if (value === 'list' || value === 'board' || value === 'table') return value;
@@ -455,8 +526,8 @@
 			</div>
 
 			<PublicCollectionView
-				collection={collectionData.collection}
-				items={collectionData.items}
+				parsedCollection={effectiveCollection}
+				parsedItems={effectiveItems}
 				view={activeBaseView}
 				expandable={false}
 			/>


### PR DESCRIPTION
## Summary
Phase 2 of PLAN-1677. Adds a read-only Board/List/Table view switcher to the public shared collection route (`/s/[token]`).

- Anonymous viewers toggle the presentation of a shared collection. The selection drives `PublicCollectionView`'s `view` prop, which overrides the owner's `settings.default_view`.
- Initial selection = owner `settings.default_view` (fallback `list`).
- Saved views from the share payload (`collection.views`) surface as selectable chips alongside the three base types. Selecting one resolves through its `view_type` (`kanban` → `board`) to a base renderer.
- Selection persists via `?view=` URL param + localStorage keyed by share token, mirroring the logged-in collection page's `saveViewMode`/`loadSavedViewMode` pattern. Read-only context: no server save. Precedence: `?view=` > localStorage > owner default.
- No mutation affordances — purely a presentation toggle.

## Presentation of base types vs saved views
- Three base types render as a segmented `.view-toggle` (icon + label), matching the logged-in collection page's control.
- Saved views render as pill chips under a "Views" label; the active chip is highlighted. A chip selecting a saved view pins its underlying base `view_type`; tooltip shows what it renders as. The base segmented control always remains available so at minimum the three base types are switchable.

## Files changed
- `web/src/routes/s/[token]/+page.svelte` — switcher state/persistence/UI; drives `view` prop; widened container for collection views.

## Test plan
- `cd web && npm run build` passes.
- Svelte MCP autofixer: no issues.

Parent: PLAN-1677.