### PR TITLE
feat(share): schema-driven colors + empty/large-collection states (TASK-1683)

### DIFF
--- a/web/src/lib/components/share/PublicBoardView.svelte
+++ b/web/src/lib/components/share/PublicBoardView.svelte
@@ -12,7 +12,7 @@
 		resolveGroupField,
 		groupItems,
 		formatLabel,
-		columnAccentClass
+		columnAccentClassFor
 	} from './shareView';
 	import PublicItemCard from './PublicItemCard.svelte';
 
@@ -27,14 +27,15 @@
 	let { collection, items, expandable = false, onactivate }: Props = $props();
 
 	let groupField = $derived(resolveGroupField(collection));
-	let optionOrder = $derived(findField(collection.fields, groupField)?.options ?? []);
+	let groupFieldDef = $derived(findField(collection.fields, groupField));
+	let optionOrder = $derived(groupFieldDef?.options ?? []);
 	let columns = $derived(groupItems(items, groupField, optionOrder));
 </script>
 
 <div class="public-board">
 	{#each columns as column (column.value)}
 		<section class="board-column" aria-label="{formatLabel(column.value) || 'Ungrouped'} column">
-			<header class="column-header {columnAccentClass(column.value)}">
+			<header class="column-header {columnAccentClassFor(groupFieldDef, column.value)}">
 				<span class="column-name">{formatLabel(column.value) || 'Ungrouped'}</span>
 				<span class="column-count">{column.items.length}</span>
 			</header>

--- a/web/src/lib/components/share/PublicCollectionView.svelte
+++ b/web/src/lib/components/share/PublicCollectionView.svelte
@@ -17,7 +17,7 @@
 	// Phase 2 / TASK-1680, will drive this); `onactivate` + `expandable` are
 	// forwarded to the leaf renderers for the deferred inline expand (TASK-1684).
 	import type { PublicCollection, PublicItem } from './shareView';
-	import { parsePublicCollection, parsePublicItems } from './shareView';
+	import { parsePublicCollection, parsePublicItems, capItems } from './shareView';
 	import PublicBoardView from './PublicBoardView.svelte';
 	import PublicListView from './PublicListView.svelte';
 	import PublicTableView from './PublicTableView.svelte';
@@ -51,6 +51,13 @@
 	let coll = $derived<PublicCollection>(parsedCollection ?? parsePublicCollection(collection));
 	let list = $derived<PublicItem[]>(parsedItems ?? parsePublicItems(items));
 	let activeView = $derived(view ?? coll.settings.default_view);
+
+	// Cap very large collections so an anonymous viewer's page (and the DOM)
+	// stays bounded. Applied AFTER any saved-view filtering the caller did, so
+	// the banner reflects the visible set the viewer is actually browsing. The
+	// cap is visible — never a silent truncation.
+	let capped = $derived(capItems(list));
+	let renderItems = $derived(capped.items);
 </script>
 
 <div class="public-collection">
@@ -63,13 +70,25 @@
 	{/if}
 
 	{#if list.length === 0}
-		<p class="collection-empty">No items in this collection.</p>
-	{:else if activeView === 'board'}
-		<PublicBoardView collection={coll} items={list} {expandable} {onactivate} />
-	{:else if activeView === 'table'}
-		<PublicTableView collection={coll} items={list} {expandable} {onactivate} />
+		<div class="collection-empty" role="status">
+			<span class="empty-icon" aria-hidden="true">{coll.icon || '📭'}</span>
+			<p class="empty-title">Nothing here yet</p>
+			<p class="empty-hint">This collection has no items to show.</p>
+		</div>
 	{:else}
-		<PublicListView collection={coll} items={list} {expandable} {onactivate} />
+		{#if capped.capped}
+			<p class="cap-notice" role="status">
+				Showing the first <strong>{capped.items.length}</strong> of
+				<strong>{capped.total}</strong> items.
+			</p>
+		{/if}
+		{#if activeView === 'board'}
+			<PublicBoardView collection={coll} items={renderItems} {expandable} {onactivate} />
+		{:else if activeView === 'table'}
+			<PublicTableView collection={coll} items={renderItems} {expandable} {onactivate} />
+		{:else}
+			<PublicListView collection={coll} items={renderItems} {expandable} {onactivate} />
+		{/if}
 	{/if}
 </div>
 
@@ -106,9 +125,48 @@
 	}
 
 	.collection-empty {
-		color: var(--text-muted);
-		font-size: 0.9em;
-		padding: var(--space-4) 0;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		text-align: center;
+		gap: var(--space-1);
+		padding: var(--space-8) var(--space-4);
+		border: 1px dashed var(--border);
+		border-radius: var(--radius-lg);
+		background: var(--bg-secondary);
+	}
+
+	.empty-icon {
+		font-size: 2em;
+		line-height: 1;
+		opacity: 0.7;
+		margin-bottom: var(--space-1);
+	}
+
+	.empty-title {
+		font-weight: 600;
+		color: var(--text-secondary);
 		margin: 0;
+	}
+
+	.empty-hint {
+		color: var(--text-muted);
+		font-size: 0.88em;
+		margin: 0;
+	}
+
+	.cap-notice {
+		color: var(--text-secondary);
+		font-size: 0.85em;
+		padding: var(--space-2) var(--space-3);
+		margin: 0;
+		background: var(--bg-secondary);
+		border: 1px solid var(--border-subtle, var(--border));
+		border-radius: var(--radius);
+	}
+
+	.cap-notice strong {
+		color: var(--text-primary);
+		font-weight: 600;
 	}
 </style>

--- a/web/src/lib/components/share/PublicItemCard.svelte
+++ b/web/src/lib/components/share/PublicItemCard.svelte
@@ -13,7 +13,7 @@
 	// default), the card is an inert <div> — no interactivity is implied.
 	import type { FieldDef } from '$lib/types';
 	import type { PublicItem } from './shareView';
-	import { findField, formatLabel, statusColor, priorityColor } from './shareView';
+	import { findField, formatLabel, fieldValueColor } from './shareView';
 
 	interface Props {
 		item: PublicItem;
@@ -76,13 +76,13 @@
 	{#if (statusFieldDef && status) || (priorityFieldDef && priority)}
 		<div class="card-meta">
 			{#if statusFieldDef && status}
-				<span class="meta-status" style:color={statusColor(status)}>
+				<span class="meta-status" style:color={fieldValueColor(statusFieldDef, status)}>
 					{formatLabel(status).toUpperCase()}
 				</span>
 			{/if}
 			{#if priorityFieldDef && priority}
 				{#if statusFieldDef && status}<span class="meta-sep">&middot;</span>{/if}
-				<span class="meta-priority" style:color={priorityColor(priority)}>
+				<span class="meta-priority" style:color={fieldValueColor(priorityFieldDef, priority)}>
 					{formatLabel(priority)}
 				</span>
 			{/if}

--- a/web/src/lib/components/share/PublicListView.svelte
+++ b/web/src/lib/components/share/PublicListView.svelte
@@ -13,8 +13,7 @@
 		findField,
 		groupItems,
 		formatLabel,
-		statusColor,
-		priorityColor
+		fieldValueColor
 	} from './shareView';
 
 	interface Props {
@@ -90,12 +89,12 @@
 					<span class="row-title">{item.title}</span>
 					<span class="row-meta">
 						{#if priorityFieldDef && priority}
-							<span class="row-priority" style:color={priorityColor(priority)}
+							<span class="row-priority" style:color={fieldValueColor(priorityFieldDef, priority)}
 								>{formatLabel(priority)}</span
 							>
 						{/if}
 						{#if statusFieldDef && status}
-							<span class="row-status" style:color={statusColor(status)}
+							<span class="row-status" style:color={fieldValueColor(statusFieldDef, status)}
 								>{formatLabel(status).toUpperCase()}</span
 							>
 						{/if}

--- a/web/src/lib/components/share/PublicTableView.svelte
+++ b/web/src/lib/components/share/PublicTableView.svelte
@@ -7,14 +7,9 @@
 	// no row links, no status cycling. Status/priority cells get the shared
 	// color vocabulary; rows are inert (or expand-only once TASK-1684 wires
 	// `onactivate`).
+	import type { FieldDef } from '$lib/types';
 	import type { PublicCollection, PublicItem } from './shareView';
-	import {
-		visibleFields,
-		formatLabel,
-		formatFieldValue,
-		statusColor,
-		priorityColor
-	} from './shareView';
+	import { visibleFields, formatLabel, formatFieldValue, fieldValueColor } from './shareView';
 
 	interface Props {
 		collection: PublicCollection;
@@ -38,9 +33,13 @@
 		].join(' ')
 	);
 
-	function cellColor(key: string, value: string): string | undefined {
-		if (key === 'status') return statusColor(value);
-		if (key === 'priority') return priorityColor(value);
+	// Color status/priority cells (and any other select-type field) using the
+	// schema-driven resolver so custom terminal vocabularies match the owner's
+	// palette. Non-select fields render plain text (no color).
+	function cellColor(field: FieldDef, value: string): string | undefined {
+		if (field.key === 'status' || field.key === 'priority' || field.type === 'select') {
+			return fieldValueColor(field, value);
+		}
 		return undefined;
 	}
 
@@ -83,7 +82,7 @@
 				{#each columns as field (field.key)}
 					{@const raw = item.fields[field.key]}
 					{@const text = formatFieldValue(raw)}
-					{@const color = typeof raw === 'string' ? cellColor(field.key, raw) : undefined}
+					{@const color = typeof raw === 'string' ? cellColor(field, raw) : undefined}
 					<div class="table-cell" role="cell">
 						{#if field.key === 'status' && text}
 							<span class="cell-status" style:color>{formatLabel(text).toUpperCase()}</span>

--- a/web/src/lib/components/share/shareView.ts
+++ b/web/src/lib/components/share/shareView.ts
@@ -159,6 +159,34 @@ export function parsePublicItems(raw: unknown): PublicItem[] {
 	return raw.map((item, i) => parsePublicItem(item, i));
 }
 
+// ── Large-collection cap ────────────────────────────────────────────────────
+
+/** Maximum items a public share view renders. A shared collection can hold
+ *  thousands of items; rendering them all would blow up an anonymous viewer's
+ *  page (and our DOM) for no benefit — the audience is reading a snapshot, not
+ *  triaging a backlog. We render the first N (the owner's `sort_order`, the
+ *  order the payload arrives in) and surface a visible "showing N of M" banner
+ *  so nothing is silently truncated. 200 comfortably covers real shared
+ *  collections while bounding the worst case. */
+export const PUBLIC_ITEM_CAP = 200;
+
+export interface CappedItems {
+	items: PublicItem[];
+	/** Total before capping. */
+	total: number;
+	/** True when `total > PUBLIC_ITEM_CAP` and `items` was trimmed. */
+	capped: boolean;
+}
+
+/** Trim an item list to PUBLIC_ITEM_CAP, reporting whether it was capped so
+ *  the renderer can show the "showing N of M" banner. */
+export function capItems(items: PublicItem[]): CappedItems {
+	if (items.length <= PUBLIC_ITEM_CAP) {
+		return { items, total: items.length, capped: false };
+	}
+	return { items: items.slice(0, PUBLIC_ITEM_CAP), total: items.length, capped: true };
+}
+
 // ── Field lookup ──────────────────────────────────────────────────────────
 
 export function findField(fields: FieldDef[], key: string): FieldDef | undefined {
@@ -220,6 +248,42 @@ export function statusColor(status: string): string {
 	}
 }
 
+/** Schema-driven color for a select-field value. Prefers the literal status
+ *  vocabulary (so the canonical open/in_progress/done/blocked palette matches
+ *  the owner exactly), then falls back to the schema's `terminal_options`: a
+ *  value the owner marked terminal (e.g. `shipped`, `closed`, `archived`)
+ *  reads as "done" green even though it isn't literally `done`. Non-terminal,
+ *  non-canonical values get the neutral muted tone. This keeps colors faithful
+ *  to the owner's view while honoring custom status vocabularies that the bare
+ *  literal switch would miss. */
+export function fieldValueColor(field: FieldDef | undefined, value: string): string {
+	if (!value) return 'var(--text-muted)';
+	if (field?.key === 'priority') return priorityColor(value);
+	// Canonical status palette first — exact owner match.
+	if (value === 'open' || value === 'in_progress' || value === 'done' || value === 'blocked') {
+		return statusColor(value);
+	}
+	// Custom vocabulary: terminal options read as "done".
+	if (field?.terminal_options?.includes(value)) return 'var(--accent-green)';
+	return 'var(--text-muted)';
+}
+
+/** Schema-driven board-column accent class. Literal status values map to the
+ *  in-app palette; a custom terminal option falls back to the `done` accent so
+ *  a "Shipped"/"Closed" column still reads as a finished lane. */
+export function columnAccentClassFor(field: FieldDef | undefined, value: string): string {
+	switch (value) {
+		case 'in_progress':
+			return 'col-in-progress';
+		case 'done':
+			return 'col-done';
+		case 'blocked':
+			return 'col-blocked';
+	}
+	if (value && field?.terminal_options?.includes(value)) return 'col-done';
+	return '';
+}
+
 /** Priority color — mirrors ItemCard.priorityColor. */
 export function priorityColor(priority: string): string {
 	switch (priority) {
@@ -233,20 +297,6 @@ export function priorityColor(priority: string): string {
 			return 'var(--text-muted)';
 		default:
 			return 'var(--text-muted)';
-	}
-}
-
-/** A board column's accent class, mirroring BoardView.columnCssClass. */
-export function columnAccentClass(value: string): string {
-	switch (value) {
-		case 'in_progress':
-			return 'col-in-progress';
-		case 'done':
-			return 'col-done';
-		case 'blocked':
-			return 'col-blocked';
-		default:
-			return '';
 	}
 }
 

--- a/web/src/routes/s/[token]/+page.svelte
+++ b/web/src/routes/s/[token]/+page.svelte
@@ -118,6 +118,16 @@
 		return { ...coll, settings };
 	});
 
+	// NOTE (sort deferral, TASK-1683 / carried from TASK-1682): saved-view
+	// `config.sort` and `settings.list_sort_by` remain a no-op here. The public
+	// item payload (title/ref/fields/content) carries no `sort_order`,
+	// `created_at`, or `updated_at` — the columns most `list_sort_by` values
+	// reference (created_at/updated_at/quarter/date) — so a faithful sort would
+	// need either a backend ordering change or timestamps in the payload (a
+	// PLAN-1677 backend decision, not frontend polish). The payload already
+	// arrives in the owner's `sort_order` (server `ListItems` default), so the
+	// default "manual" order IS honored; only explicit field sorts are skipped.
+	// Deferred deliberately to avoid silently diverging from the owner's order.
 	let effectiveItems = $derived.by<PublicItem[]>(() => {
 		const items = baseParsedItems;
 		const view = activeSavedView;


### PR DESCRIPTION
Phase 3 polish on the public shared collection view (`/s/[token]`). Strictly read-only; matches the owner's view type.

## Schema-driven labels & colors
- New `fieldValueColor(field, value)` in `shareView.ts`: canonical `open/in_progress/done/blocked` palette matches the owner exactly, then falls back to the schema's `terminal_options` so a **custom terminal value** (e.g. `shipped`, `closed`, `archived`) reads as "done" green even when it isn't literally `done`. Wired into cards, list rows, table cells, and board column accents (`columnAccentClassFor`).
- Table colors **any select-type column**, not just `status`/`priority`.
- Field labels/suffixes already came from the schema; the data model has no per-option custom labels (options are `string[]`), so `formatLabel` title-casing remains the label source — matching the in-app components.
- Removed the now-dead `columnAccentClass`; `fieldValueColor` delegates to `statusColor` to avoid duplicating the canonical switch.

## Edge states
- **Empty:** polished shared empty state (icon + title + hint, dashed card) replacing the bare `<p>`; per-view empty messages already existed.
- **Single item:** renders cleanly in all three views (no special-casing needed).
- **Large collections:** `PUBLIC_ITEM_CAP = 200` with a visible **"Showing the first N of M items"** banner — no silent truncation. Applied in `PublicCollectionView` *after* saved-view filtering, so the count reflects the visible set. The first N are the owner's `sort_order` (payload order).

## Sort (secondary) — deferred
`config.sort` / `settings.list_sort_by` stays a no-op. The public payload carries no `sort_order`/`created_at`/`updated_at` (the fields most `list_sort_by` values reference), so a faithful sort needs a backend/payload change — out of scope for frontend polish. The payload already arrives in the owner's `sort_order`, so the default order IS honored. Documented inline.

## Verification
- `cd web && npm run build` passes.
- `go test ./internal/server/` passes (covers the share-links handler).
- Svelte autofixer: clean.

Parent: PLAN-1677.