### PR TITLE
feat(share): inline read-only row expand in public shared view (TASK-1684)

### DIFF
--- a/web/src/lib/components/share/PublicBoardView.svelte
+++ b/web/src/lib/components/share/PublicBoardView.svelte
@@ -19,12 +19,17 @@
 	interface Props {
 		collection: PublicCollection;
 		items: PublicItem[];
-		/** Forwarded to each card for the deferred inline-expand (TASK-1684). */
+		/** Forwarded to each card for the inline read-only expand (TASK-1684). */
 		expandable?: boolean;
 		onactivate?: (item: PublicItem) => void;
+		/** `key` of the currently-expanded item ('' = none). */
+		expandedKey?: string;
+		/** Returns pre-sanitized HTML for an item's markdown body (route-owned). */
+		renderContent?: (item: PublicItem) => string;
 	}
 
-	let { collection, items, expandable = false, onactivate }: Props = $props();
+	let { collection, items, expandable = false, onactivate, expandedKey = '', renderContent }: Props =
+		$props();
 
 	let groupField = $derived(resolveGroupField(collection));
 	let groupFieldDef = $derived(findField(collection.fields, groupField));
@@ -41,7 +46,14 @@
 			</header>
 			<div class="column-cards">
 				{#each column.items as item (item.key)}
-					<PublicItemCard {item} fields={collection.fields} {expandable} {onactivate} />
+					<PublicItemCard
+						{item}
+						fields={collection.fields}
+						{expandable}
+						{onactivate}
+						{expandedKey}
+						{renderContent}
+					/>
 				{/each}
 				{#if column.items.length === 0}
 					<p class="column-empty">No {(formatLabel(column.value) || 'ungrouped').toLowerCase()} items</p>

--- a/web/src/lib/components/share/PublicCollectionView.svelte
+++ b/web/src/lib/components/share/PublicCollectionView.svelte
@@ -33,9 +33,17 @@
 		parsedItems?: PublicItem[];
 		/** Override the rendered view; defaults to settings.default_view. */
 		view?: 'list' | 'board' | 'table';
-		/** Forwarded to leaf renderers for the deferred inline expand (TASK-1684). */
+		/** Forwarded to leaf renderers to enable the inline expand (TASK-1684). */
 		expandable?: boolean;
+		/** Fired when an expandable row/card is activated (toggle). */
 		onactivate?: (item: PublicItem) => void;
+		/** `key` of the currently-expanded item ('' = none). Drives the inline
+		 *  expansion panel in the leaf renderers. */
+		expandedKey?: string;
+		/** Returns pre-sanitized HTML for an item's markdown body. Owned by the
+		 *  route (single marked()+DOMPurify pipeline) so there's one {@html}
+		 *  source — no new XSS surface. */
+		renderContent?: (item: PublicItem) => string;
 	}
 
 	let {
@@ -45,7 +53,9 @@
 		parsedItems,
 		view,
 		expandable = false,
-		onactivate
+		onactivate,
+		expandedKey = '',
+		renderContent
 	}: Props = $props();
 
 	let coll = $derived<PublicCollection>(parsedCollection ?? parsePublicCollection(collection));
@@ -83,11 +93,32 @@
 			</p>
 		{/if}
 		{#if activeView === 'board'}
-			<PublicBoardView collection={coll} items={renderItems} {expandable} {onactivate} />
+			<PublicBoardView
+				collection={coll}
+				items={renderItems}
+				{expandable}
+				{onactivate}
+				{expandedKey}
+				{renderContent}
+			/>
 		{:else if activeView === 'table'}
-			<PublicTableView collection={coll} items={renderItems} {expandable} {onactivate} />
+			<PublicTableView
+				collection={coll}
+				items={renderItems}
+				{expandable}
+				{onactivate}
+				{expandedKey}
+				{renderContent}
+			/>
 		{:else}
-			<PublicListView collection={coll} items={renderItems} {expandable} {onactivate} />
+			<PublicListView
+				collection={coll}
+				items={renderItems}
+				{expandable}
+				{onactivate}
+				{expandedKey}
+				{renderContent}
+			/>
 		{/if}
 	{/if}
 </div>

--- a/web/src/lib/components/share/PublicItemCard.svelte
+++ b/web/src/lib/components/share/PublicItemCard.svelte
@@ -7,28 +7,38 @@
 	// (status/priority colors, uppercase status) without any of its coupling to
 	// page.params / mutation handlers.
 	//
-	// Designed for a future inline read-only expand (TASK-1684): the optional
-	// `onactivate` callback + `expandable` flag turn the card into a button-like
-	// affordance WITHOUT changing the markup contract. When omitted (the
-	// default), the card is an inert <div> — no interactivity is implied.
+	// Inline read-only expand (TASK-1684): the optional `onactivate` callback +
+	// `expandable` flag turn the card into a button-like toggle affordance. When
+	// activated, the card reveals the item's fields + sanitized markdown content
+	// inline (PublicItemExpansion). When `expandable`/`onactivate` are omitted
+	// (the default), the card is an inert <div> — no interactivity is implied.
 	import type { FieldDef } from '$lib/types';
 	import type { PublicItem } from './shareView';
 	import { findField, formatLabel, fieldValueColor } from './shareView';
+	import PublicItemExpansion from './PublicItemExpansion.svelte';
 
 	interface Props {
 		item: PublicItem;
 		fields: FieldDef[];
 		/** When true (and onactivate is set), the card advertises itself as an
-		 *  expand affordance. Wiring deferred to TASK-1684. */
+		 *  expand toggle affordance. */
 		expandable?: boolean;
-		/** Fired when an expandable card is activated (click / Enter / Space).
-		 *  Deferred wiring — TASK-1684. */
+		/** Fired when an expandable card is activated (click / Enter / Space). */
 		onactivate?: (item: PublicItem) => void;
+		/** `key` of the currently-expanded item; when it matches this card's
+		 *  item, the inline expansion renders. */
+		expandedKey?: string;
+		/** Returns pre-sanitized HTML for the item's markdown body (route-owned
+		 *  marked()+DOMPurify pipeline). */
+		renderContent?: (item: PublicItem) => string;
 	}
 
-	let { item, fields, expandable = false, onactivate }: Props = $props();
+	let { item, fields, expandable = false, onactivate, expandedKey = '', renderContent }: Props =
+		$props();
 
 	let interactive = $derived(expandable && !!onactivate);
+	let expanded = $derived(interactive && expandedKey === item.key);
+	let panelId = $derived(`pub-exp-${item.key.replace(/[^a-zA-Z0-9_-]/g, '-')}`);
 
 	let statusFieldDef = $derived(findField(fields, 'status'));
 	let priorityFieldDef = $derived(findField(fields, 'priority'));
@@ -52,45 +62,62 @@
 	}
 </script>
 
-<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
-<!-- `role` and `tabindex` are correlated at runtime: when tabindex is 0 the
-     role is always 'button' (both gated by `interactive`), so the element is
-     focusable only when it is genuinely interactive. The analyzer can't see
-     that correlation. Wiring lands in TASK-1684. -->
-<div
-	class="public-card"
-	class:interactive
-	role={interactive ? 'button' : undefined}
-	tabindex={interactive ? 0 : undefined}
-	onclick={interactive ? activate : undefined}
-	onkeydown={interactive ? onKey : undefined}
->
-	{#if item.ref}
-		<div class="card-top">
-			<span class="card-ref">{item.ref}</span>
-		</div>
-	{/if}
+<div class="public-card-wrap" class:expanded>
+	<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+	<!-- `role` and `tabindex` are correlated at runtime: when tabindex is 0 the
+	     role is always 'button' (both gated by `interactive`), so the element is
+	     focusable only when it is genuinely interactive. The analyzer can't see
+	     that correlation. -->
+	<div
+		class="public-card"
+		class:interactive
+		role={interactive ? 'button' : undefined}
+		tabindex={interactive ? 0 : undefined}
+		aria-expanded={interactive ? expanded : undefined}
+		aria-controls={interactive && expanded ? panelId : undefined}
+		onclick={interactive ? activate : undefined}
+		onkeydown={interactive ? onKey : undefined}
+	>
+		{#if item.ref}
+			<div class="card-top">
+				<span class="card-ref">{item.ref}</span>
+			</div>
+		{/if}
 
-	<div class="card-title">{item.title}</div>
+		<div class="card-title">{item.title}</div>
 
-	{#if (statusFieldDef && status) || (priorityFieldDef && priority)}
-		<div class="card-meta">
-			{#if statusFieldDef && status}
-				<span class="meta-status" style:color={fieldValueColor(statusFieldDef, status)}>
-					{formatLabel(status).toUpperCase()}
-				</span>
-			{/if}
-			{#if priorityFieldDef && priority}
-				{#if statusFieldDef && status}<span class="meta-sep">&middot;</span>{/if}
-				<span class="meta-priority" style:color={fieldValueColor(priorityFieldDef, priority)}>
-					{formatLabel(priority)}
-				</span>
-			{/if}
-		</div>
+		{#if (statusFieldDef && status) || (priorityFieldDef && priority)}
+			<div class="card-meta">
+				{#if statusFieldDef && status}
+					<span class="meta-status" style:color={fieldValueColor(statusFieldDef, status)}>
+						{formatLabel(status).toUpperCase()}
+					</span>
+				{/if}
+				{#if priorityFieldDef && priority}
+					{#if statusFieldDef && status}<span class="meta-sep">&middot;</span>{/if}
+					<span class="meta-priority" style:color={fieldValueColor(priorityFieldDef, priority)}>
+						{formatLabel(priority)}
+					</span>
+				{/if}
+			</div>
+		{/if}
+	</div>
+
+	{#if expanded}
+		<PublicItemExpansion
+			{item}
+			{fields}
+			html={renderContent?.(item) ?? ''}
+			id={panelId}
+		/>
 	{/if}
 </div>
 
 <style>
+	.public-card-wrap {
+		min-width: 0;
+	}
+
 	.public-card {
 		display: flex;
 		flex-direction: column;
@@ -100,6 +127,11 @@
 		border-radius: var(--radius);
 		padding: var(--space-3) var(--space-4);
 		min-width: 0;
+	}
+
+	.public-card-wrap.expanded .public-card {
+		border-bottom: none;
+		border-radius: var(--radius) var(--radius) 0 0;
 	}
 
 	.public-card.interactive {

--- a/web/src/lib/components/share/PublicItemExpansion.svelte
+++ b/web/src/lib/components/share/PublicItemExpansion.svelte
@@ -1,0 +1,215 @@
+<script lang="ts">
+	// Inline read-only expansion panel for a shared collection item (TASK-1684 /
+	// PLAN-1677 Phase 3).
+	//
+	// Renders an item's fields + sanitized markdown content INLINE on the
+	// `/s/[token]` page — no navigation (items aren't individually shared, so a
+	// link would 404 or bypass item-level share ACLs). Strictly read-only.
+	//
+	// The component does NOT sanitize: it receives already-sanitized HTML via the
+	// `html` prop, produced by the route's single marked()+DOMPurify pipeline
+	// (the same one the single-item share case uses). Keeping sanitization in one
+	// place avoids introducing a second, divergent {@html} source.
+	import type { FieldDef } from '$lib/types';
+	import type { PublicItem } from './shareView';
+	import { visibleFields, formatLabel, formatFieldValue, fieldValueColor } from './shareView';
+
+	interface Props {
+		item: PublicItem;
+		fields: FieldDef[];
+		/** Pre-sanitized HTML for the item's markdown body. Empty string when the
+		 *  item has no content (or rendering produced nothing). */
+		html: string;
+		/** DOM id, so the activating row/card can reference it via aria-controls. */
+		id?: string;
+	}
+
+	let { item, fields, html, id }: Props = $props();
+
+	// Schema fields that carry a value on this item, in schema order. Computed
+	// fields are dropped (visibleFields) — they aren't part of the shared
+	// snapshot's meaningful data.
+	let displayFields = $derived(
+		visibleFields(fields)
+			.map((f) => ({ field: f, value: formatFieldValue(item.fields[f.key]) }))
+			.filter((entry) => entry.value !== '')
+	);
+
+	function colorFor(field: FieldDef, value: string): string | undefined {
+		const raw = item.fields[field.key];
+		if (typeof raw !== 'string') return undefined;
+		if (field.key === 'status' || field.key === 'priority' || field.type === 'select') {
+			return fieldValueColor(field, raw);
+		}
+		return undefined;
+	}
+</script>
+
+<div class="item-expansion" {id} role="region" aria-label="{item.title} details">
+	{#if displayFields.length > 0}
+		<dl class="expansion-fields">
+			{#each displayFields as { field, value } (field.key)}
+				{@const color = colorFor(field, value)}
+				<div class="field-chip">
+					<dt class="field-chip-label">{field.label || formatLabel(field.key)}</dt>
+					<dd class="field-chip-value" style:color>
+						{field.key === 'status' ? formatLabel(value).toUpperCase() : formatLabel(value)}{field.suffix
+							? ` ${field.suffix}`
+							: ''}
+					</dd>
+				</div>
+			{/each}
+		</dl>
+	{/if}
+
+	{#if html}
+		<!-- `html` is pre-sanitized by the route's marked()+DOMPurify pipeline.
+		     No new XSS surface — same sanitized source as the single-item view. -->
+		<div class="expansion-content">
+			{@html html}
+		</div>
+	{:else if displayFields.length === 0}
+		<p class="expansion-empty">No additional details.</p>
+	{/if}
+</div>
+
+<style>
+	.item-expansion {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-4);
+		padding: var(--space-4);
+		background: var(--bg-primary);
+		border: 1px solid var(--border-subtle, var(--border));
+		border-top: none;
+		border-radius: 0 0 var(--radius) var(--radius);
+	}
+
+	.expansion-fields {
+		display: flex;
+		flex-wrap: wrap;
+		gap: var(--space-2);
+		margin: 0;
+	}
+
+	.field-chip {
+		display: inline-flex;
+		align-items: center;
+		gap: var(--space-1);
+		padding: var(--space-1) var(--space-3);
+		background: var(--bg-tertiary);
+		border-radius: 999px;
+		font-size: 0.82em;
+	}
+
+	.field-chip-label {
+		color: var(--text-muted);
+		font-weight: 500;
+		margin: 0;
+	}
+
+	.field-chip-value {
+		color: var(--text-primary);
+		margin: 0;
+	}
+
+	.expansion-empty {
+		color: var(--text-muted);
+		font-size: 0.88em;
+		margin: 0;
+	}
+
+	.expansion-content {
+		font-family: var(--font-content);
+		font-size: 0.95em;
+		line-height: 1.7;
+		color: var(--text-primary);
+		min-width: 0;
+		overflow-wrap: anywhere;
+	}
+
+	/* Markdown content styles — mirror the single-item share view so an expanded
+	   row reads identically to a directly-shared item. */
+	.expansion-content :global(h1) {
+		font-size: 1.5em;
+		font-weight: 700;
+		margin: 1.2em 0 0.5em;
+		line-height: 1.3;
+	}
+	.expansion-content :global(h2) {
+		font-size: 1.25em;
+		font-weight: 600;
+		margin: 1.1em 0 0.4em;
+		line-height: 1.3;
+	}
+	.expansion-content :global(h3) {
+		font-size: 1.05em;
+		font-weight: 600;
+		margin: 1em 0 0.3em;
+	}
+	.expansion-content :global(p) {
+		margin: 0.7em 0;
+	}
+	.expansion-content :global(ul),
+	.expansion-content :global(ol) {
+		margin: 0.7em 0;
+		padding-left: 1.5em;
+	}
+	.expansion-content :global(li) {
+		margin: 0.3em 0;
+	}
+	.expansion-content :global(pre) {
+		background: var(--bg-tertiary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+		padding: var(--space-3);
+		overflow-x: auto;
+		font-family: var(--font-mono);
+		font-size: 0.85em;
+		margin: 0.9em 0;
+	}
+	.expansion-content :global(code) {
+		font-family: var(--font-mono);
+		font-size: 0.9em;
+		background: var(--bg-tertiary);
+		padding: 0.15em 0.4em;
+		border-radius: var(--radius-sm);
+	}
+	.expansion-content :global(pre code) {
+		background: none;
+		padding: 0;
+	}
+	.expansion-content :global(blockquote) {
+		border-left: 3px solid var(--accent-blue);
+		padding-left: var(--space-4);
+		margin: 0.9em 0;
+		color: var(--text-secondary);
+	}
+	.expansion-content :global(table) {
+		width: 100%;
+		border-collapse: collapse;
+		margin: 0.9em 0;
+	}
+	.expansion-content :global(th),
+	.expansion-content :global(td) {
+		border: 1px solid var(--border);
+		padding: var(--space-2) var(--space-3);
+		text-align: left;
+	}
+	.expansion-content :global(th) {
+		background: var(--bg-secondary);
+		font-weight: 600;
+	}
+	.expansion-content :global(hr) {
+		border: none;
+		border-top: 1px solid var(--border);
+		margin: 1.3em 0;
+	}
+	.expansion-content :global(img) {
+		max-width: 100%;
+		border-radius: var(--radius);
+	}
+	.expansion-content :global(a) {
+		color: var(--accent-blue);
+	}
+</style>

--- a/web/src/lib/components/share/PublicItemExpansion.svelte
+++ b/web/src/lib/components/share/PublicItemExpansion.svelte
@@ -35,13 +35,30 @@
 			.filter((entry) => entry.value !== '')
 	);
 
-	function colorFor(field: FieldDef, value: string): string | undefined {
+	// Categorical fields (status/priority/select) carry kebab/snake option keys
+	// the owner sees as title-cased labels — so we label-format + color those.
+	// Everything else is a LITERAL value (dates, IDs, slugs, URLs, free text)
+	// and must render verbatim — title-casing `2026-05-31` or `api_token` would
+	// corrupt it. Mirrors the single-item share view, which renders field values
+	// raw.
+	function isCategorical(field: FieldDef): boolean {
+		return field.key === 'status' || field.key === 'priority' || field.type === 'select';
+	}
+
+	function colorFor(field: FieldDef): string | undefined {
 		const raw = item.fields[field.key];
 		if (typeof raw !== 'string') return undefined;
-		if (field.key === 'status' || field.key === 'priority' || field.type === 'select') {
-			return fieldValueColor(field, raw);
-		}
+		if (isCategorical(field)) return fieldValueColor(field, raw);
 		return undefined;
+	}
+
+	function displayValue(field: FieldDef, value: string): string {
+		const base = isCategorical(field)
+			? field.key === 'status'
+				? formatLabel(value).toUpperCase()
+				: formatLabel(value)
+			: value;
+		return field.suffix ? `${base} ${field.suffix}` : base;
 	}
 </script>
 
@@ -49,14 +66,10 @@
 	{#if displayFields.length > 0}
 		<dl class="expansion-fields">
 			{#each displayFields as { field, value } (field.key)}
-				{@const color = colorFor(field, value)}
+				{@const color = colorFor(field)}
 				<div class="field-chip">
 					<dt class="field-chip-label">{field.label || formatLabel(field.key)}</dt>
-					<dd class="field-chip-value" style:color>
-						{field.key === 'status' ? formatLabel(value).toUpperCase() : formatLabel(value)}{field.suffix
-							? ` ${field.suffix}`
-							: ''}
-					</dd>
+					<dd class="field-chip-value" style:color>{displayValue(field, value)}</dd>
 				</div>
 			{/each}
 		</dl>

--- a/web/src/lib/components/share/PublicListView.svelte
+++ b/web/src/lib/components/share/PublicListView.svelte
@@ -15,18 +15,28 @@
 		formatLabel,
 		fieldValueColor
 	} from './shareView';
+	import PublicItemExpansion from './PublicItemExpansion.svelte';
 
 	interface Props {
 		collection: PublicCollection;
 		items: PublicItem[];
-		/** Deferred inline-expand affordance (TASK-1684). */
+		/** Inline read-only expand affordance (TASK-1684). */
 		expandable?: boolean;
 		onactivate?: (item: PublicItem) => void;
+		/** `key` of the currently-expanded item ('' = none). */
+		expandedKey?: string;
+		/** Returns pre-sanitized HTML for an item's markdown body (route-owned). */
+		renderContent?: (item: PublicItem) => string;
 	}
 
-	let { collection, items, expandable = false, onactivate }: Props = $props();
+	let { collection, items, expandable = false, onactivate, expandedKey = '', renderContent }: Props =
+		$props();
 
 	let interactive = $derived(expandable && !!onactivate);
+
+	function panelIdFor(item: PublicItem): string {
+		return `pub-exp-${item.key.replace(/[^a-zA-Z0-9_-]/g, '-')}`;
+	}
 
 	let groupField = $derived.by(() => {
 		const key = collection.settings.list_group_by;
@@ -73,32 +83,44 @@
 			{#each group.items as item (item.key)}
 				{@const status = statusOf(item)}
 				{@const priority = priorityOf(item)}
-				<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
-				<!-- role + tabindex are runtime-correlated (both gated by
-				     `interactive`): focusable only when genuinely a button.
-				     Wiring lands in TASK-1684. -->
-				<div
-					class="list-row"
-					class:interactive
-					role={interactive ? 'button' : undefined}
-					tabindex={interactive ? 0 : undefined}
-					onclick={interactive ? () => activate(item) : undefined}
-					onkeydown={interactive ? (e) => onKey(e, item) : undefined}
-				>
-					{#if item.ref}<span class="row-ref">{item.ref}</span>{/if}
-					<span class="row-title">{item.title}</span>
-					<span class="row-meta">
-						{#if priorityFieldDef && priority}
-							<span class="row-priority" style:color={fieldValueColor(priorityFieldDef, priority)}
-								>{formatLabel(priority)}</span
-							>
-						{/if}
-						{#if statusFieldDef && status}
-							<span class="row-status" style:color={fieldValueColor(statusFieldDef, status)}
-								>{formatLabel(status).toUpperCase()}</span
-							>
-						{/if}
-					</span>
+				{@const expanded = interactive && expandedKey === item.key}
+				<div class="row-wrap" class:expanded>
+					<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+					<!-- role + tabindex are runtime-correlated (both gated by
+					     `interactive`): focusable only when genuinely a button. -->
+					<div
+						class="list-row"
+						class:interactive
+						role={interactive ? 'button' : undefined}
+						tabindex={interactive ? 0 : undefined}
+						aria-expanded={interactive ? expanded : undefined}
+						aria-controls={expanded ? panelIdFor(item) : undefined}
+						onclick={interactive ? () => activate(item) : undefined}
+						onkeydown={interactive ? (e) => onKey(e, item) : undefined}
+					>
+						{#if item.ref}<span class="row-ref">{item.ref}</span>{/if}
+						<span class="row-title">{item.title}</span>
+						<span class="row-meta">
+							{#if priorityFieldDef && priority}
+								<span class="row-priority" style:color={fieldValueColor(priorityFieldDef, priority)}
+									>{formatLabel(priority)}</span
+								>
+							{/if}
+							{#if statusFieldDef && status}
+								<span class="row-status" style:color={fieldValueColor(statusFieldDef, status)}
+									>{formatLabel(status).toUpperCase()}</span
+								>
+							{/if}
+						</span>
+					</div>
+					{#if expanded}
+						<PublicItemExpansion
+							{item}
+							fields={collection.fields}
+							html={renderContent?.(item) ?? ''}
+							id={panelIdFor(item)}
+						/>
+					{/if}
 				</div>
 			{/each}
 			{#if group.items.length === 0}
@@ -142,6 +164,12 @@
 		gap: var(--space-1);
 	}
 
+	.row-wrap {
+		display: flex;
+		flex-direction: column;
+		min-width: 0;
+	}
+
 	.list-row {
 		display: flex;
 		align-items: center;
@@ -151,6 +179,11 @@
 		border: 1px solid var(--border-subtle, var(--border));
 		border-radius: var(--radius);
 		min-width: 0;
+	}
+
+	.row-wrap.expanded .list-row {
+		border-bottom: none;
+		border-radius: var(--radius) var(--radius) 0 0;
 	}
 
 	.list-row.interactive {

--- a/web/src/lib/components/share/PublicTableView.svelte
+++ b/web/src/lib/components/share/PublicTableView.svelte
@@ -10,16 +10,22 @@
 	import type { FieldDef } from '$lib/types';
 	import type { PublicCollection, PublicItem } from './shareView';
 	import { visibleFields, formatLabel, formatFieldValue, fieldValueColor } from './shareView';
+	import PublicItemExpansion from './PublicItemExpansion.svelte';
 
 	interface Props {
 		collection: PublicCollection;
 		items: PublicItem[];
-		/** Deferred inline-expand affordance (TASK-1684). */
+		/** Inline read-only expand affordance (TASK-1684). */
 		expandable?: boolean;
 		onactivate?: (item: PublicItem) => void;
+		/** `key` of the currently-expanded item ('' = none). */
+		expandedKey?: string;
+		/** Returns pre-sanitized HTML for an item's markdown body (route-owned). */
+		renderContent?: (item: PublicItem) => string;
 	}
 
-	let { collection, items, expandable = false, onactivate }: Props = $props();
+	let { collection, items, expandable = false, onactivate, expandedKey = '', renderContent }: Props =
+		$props();
 
 	let interactive = $derived(expandable && !!onactivate);
 	let columns = $derived(visibleFields(collection.fields));
@@ -32,6 +38,10 @@
 			...columns.map(() => 'auto')
 		].join(' ')
 	);
+
+	function panelIdFor(item: PublicItem): string {
+		return `pub-exp-${item.key.replace(/[^a-zA-Z0-9_-]/g, '-')}`;
+	}
 
 	// Color status/priority cells (and any other select-type field) using the
 	// schema-driven resolver so custom terminal vocabularies match the owner's
@@ -65,11 +75,15 @@
 			{/each}
 		</div>
 		{#each items as item (item.key)}
+			{@const expanded = interactive && expandedKey === item.key}
 			<div
 				class="table-row"
 				class:interactive
+				class:expanded
 				role="row"
 				tabindex={interactive ? 0 : undefined}
+				aria-expanded={interactive ? expanded : undefined}
+				aria-controls={expanded ? panelIdFor(item) : undefined}
 				onclick={interactive ? () => activate(item) : undefined}
 				onkeydown={interactive ? (e) => onKey(e, item) : undefined}
 			>
@@ -94,6 +108,19 @@
 					</div>
 				{/each}
 			</div>
+			{#if expanded}
+				<!-- Expansion spans the full grid width; presentational row, not a
+				     data row, so role="presentation" keeps it out of the table
+				     semantics. -->
+				<div class="table-expansion-row" role="presentation">
+					<PublicItemExpansion
+						{item}
+						fields={collection.fields}
+						html={renderContent?.(item) ?? ''}
+						id={panelIdFor(item)}
+					/>
+				</div>
+			{/if}
 		{/each}
 	</div>
 </div>
@@ -145,6 +172,19 @@
 	.table-row.interactive:focus-visible {
 		outline: 2px solid var(--accent-blue);
 		outline-offset: -2px;
+	}
+
+	.table-row.expanded:not(.table-header) {
+		background: var(--bg-secondary);
+		border-bottom: none;
+	}
+
+	/* Full-width expansion row. Spans every grid column and opts out of subgrid
+	   so the panel lays out as a normal block, not against the column tracks. */
+	.table-expansion-row {
+		grid-column: 1 / -1;
+		border-bottom: 1px solid var(--border-subtle, var(--border));
+		min-width: 0;
 	}
 
 	.table-cell {

--- a/web/src/routes/s/[token]/+page.svelte
+++ b/web/src/routes/s/[token]/+page.svelte
@@ -281,6 +281,7 @@
 		selectedKind = 'base';
 		selectedBase = base;
 		selectedSavedSlug = '';
+		expandedKey = ''; // collapse any open row when switching views
 		saveSelection();
 		syncUrl();
 	}
@@ -296,21 +297,55 @@
 		selectedKind = 'saved';
 		selectedSavedSlug = slug;
 		selectedBase = coerceBaseView(savedViews.find((v) => v.slug === slug)?.view_type) ?? defaultView;
+		expandedKey = ''; // collapse any open row when switching views
 		saveSelection();
 		syncUrl();
 	}
 
-	let renderedContent = $derived.by(() => {
-		if (!itemData?.content) return '';
+	// Single sanitized markdown pipeline for the whole page: marked → DOMPurify.
+	// Used by both the single-ITEM share view (`renderedContent`) and the
+	// collection inline-expand (`renderItemContent`). Keeping ONE {@html} source
+	// means no second, divergent sanitization path — no new XSS surface.
+	function sanitizeMarkdown(content: string): string {
+		if (!content) return '';
 		try {
-			const raw = marked(itemData.content) as string;
+			const raw = marked(content) as string;
 			return typeof window !== 'undefined' ? DOMPurify.sanitize(raw) : raw;
 		} catch {
 			// Sanitize the fallback too — never pass user content to {@html} raw
-			const fallback = itemData.content;
-			return typeof window !== 'undefined' ? DOMPurify.sanitize(fallback) : fallback;
+			return typeof window !== 'undefined' ? DOMPurify.sanitize(content) : content;
 		}
+	}
+
+	let renderedContent = $derived.by(() => sanitizeMarkdown(itemData?.content ?? ''));
+
+	// Inline read-only expand (TASK-1684 / PLAN-1677 Phase 3). Clicking a row/
+	// card in the collection view expands the item's fields + content INLINE on
+	// this same page — items aren't individually shared, so there's no item
+	// route to navigate to (it would 404 or bypass item-level share ACLs).
+	// `expandedKey` is the active item's stable `key`; re-activating collapses.
+	let expandedKey = $state('');
+
+	function toggleExpanded(item: PublicItem) {
+		expandedKey = expandedKey === item.key ? '' : item.key;
+	}
+
+	// Memoize per-item sanitized HTML so toggling/re-rendering doesn't re-run
+	// marked()+DOMPurify on every keystroke or reactive pass. Keyed by the item's
+	// stable `key`. The map is rebuilt whenever the parsed item set changes.
+	let contentCache = $derived.by(() => {
+		// Touch the parsed items so the cache resets when the payload/view changes.
+		effectiveItems;
+		return new Map<string, string>();
 	});
+
+	function renderItemContent(item: PublicItem): string {
+		const cached = contentCache.get(item.key);
+		if (cached !== undefined) return cached;
+		const html = sanitizeMarkdown(item.content);
+		contentCache.set(item.key, html);
+		return html;
+	}
 
 	onMount(async () => {
 		if (!token) {
@@ -571,7 +606,10 @@
 				parsedCollection={effectiveCollection}
 				parsedItems={effectiveItems}
 				view={activeBaseView}
-				expandable={false}
+				expandable={true}
+				onactivate={toggleExpanded}
+				{expandedKey}
+				renderContent={renderItemContent}
 			/>
 		{/if}
 	</div>


### PR DESCRIPTION
## What

Clicking an item row/card in the public `/s/[token]` collection view now expands that item's **fields + sanitized markdown content INLINE** on the same page. No navigation — items aren't individually shared, so a link would 404 or bypass item-level share ACLs. Strictly read-only, gated by the same share link.

Implements PLAN-1677 Phase 3's item-row-interaction decision (per the design-decision comment on TASK-1684).

## How it works per view type

- **Board card** — the card becomes a button-toggle; the expansion panel renders below the card (header loses its bottom radius to join cleanly).
- **List row** — each row is wrapped; the expansion panel renders below the activated row.
- **Table row** — the expansion renders as a full-width `presentation` row spanning all grid columns (the data row keeps its table semantics).

All three: click / Enter / Space toggles, collapse on re-click, `aria-expanded` + `aria-controls` wired on the interactive element.

## Sanitization

The new `PublicItemExpansion` component does **not** sanitize. It receives pre-sanitized HTML via a `renderContent` callback that the route owns — the **same** `marked()` + `DOMPurify.sanitize()` pipeline the single-item share view already uses (refactored into a shared `sanitizeMarkdown` helper). One `{@html}` source, no new XSS surface. Per-item HTML is memoized; the cache resets when the rendered item set changes.

## Files

- `web/src/lib/components/share/PublicItemExpansion.svelte` (new)
- `PublicCollectionView` / `PublicBoardView` / `PublicListView` / `PublicTableView` / `PublicItemCard` — thread `expandedKey` + `renderContent`, render expansion, aria
- `web/src/routes/s/[token]/+page.svelte` — `expandable={true}`, toggle state, shared sanitize helper, memoized per-item render

## Verification

- `npm run build` passes
- `svelte-check`: 0 errors; Svelte autofixer clean on all components (only the expected, by-design `{@html}` note on the pre-sanitized panel)

Parent: PLAN-1677.