### PR TITLE
fix(share): stop ShareDialog effect from wedging the scheduler in prod

### DIFF
--- a/web/src/lib/components/ShareDialog.svelte
+++ b/web/src/lib/components/ShareDialog.svelte
@@ -33,8 +33,12 @@
 	let newlyCreatedLinkId = $state<string | null>(null);
 	let deletingLinkId = $state<string | null>(null);
 
-	// Track previous open state to detect open transitions
-	let prevOpen = $state(false);
+	// Track previous open state to detect open transitions. This is a PLAIN
+	// variable (not $state) on purpose: it's only read/written inside the
+	// effect below for edge-detection. Making it $state turned the effect
+	// into a self-invalidating loop (it writes a state it reads), which in a
+	// production build silently wedges Svelte's effect scheduler on close.
+	let prevOpen = false;
 
 	$effect.pre(() => {
 		if (open && !prevOpen) {


### PR DESCRIPTION
## Summary
`ShareDialog.svelte` tracked its open/close transition with `let prevOpen = $state(false)` plus an `$effect.pre` that **both read and wrote `prevOpen`** — a self-invalidating effect that re-schedules itself every run.

In a **dev** build Svelte catches this with `effect_update_depth_exceeded`. In the **production** bundle the guard behaves differently and it instead **silently wedges Svelte's global effect scheduler** the moment `open` flips to false on close. After that, `$effect`s stop flushing app-wide: DOM events and timers keep working, but nothing re-renders and SvelteKit client navigation stops completing — so clicking a card changed the URL but never opened the item. No console error, no CPU spin.

## Fix
Make `prevOpen` a plain `let` (not `$state`). It's only used for edge-detection inside the effect, so the effect now depends solely on `open` and never invalidates itself. One-line change.

## How it was diagnosed
Instrumented a `$state` probe bumped every 500ms alongside a `setInterval` heartbeat: at dialog close the probe's `$effect` stopped firing while the heartbeat kept counting — proving the **effect scheduler** wedged (not the main thread, not an overlay, not a loop, no thrown error).

## Scope / context
- Latent bug in `ShareDialog`; **unrelated** to the PLAN-1677 anonymous-share-view work — that was just what was being exercised when it surfaced.
- Fixes `BUG-1687`.
- A follow-up sweep is running for other `$effect`s that write a `$state` they read (same trap).

## Test plan
- [x] `cd web && npm run build` — clean
- [x] Manually verified on a production `make install` build: open Share dialog → close → click a card now navigates/opens normally; page stays responsive; create/delete share link still works.