### PR TITLE
fix(web): de-reactify open-transition trackers in 3 more modals/banners

### DIFF
--- a/web/src/lib/components/ConnectBanner.svelte
+++ b/web/src/lib/components/ConnectBanner.svelte
@@ -97,8 +97,11 @@
 	// doesn't know which tab actually triggered the agent connection;
 	// any close is good-enough signal. Tracking `prevOpen` is the
 	// minimum reactive shape to detect the open → closed transition
-	// without re-firing on every render.
-	let prevOpen = $state(false);
+	// without re-firing on every render. PLAIN variable (not $state): it's
+	// only read/written for edge-detection inside the effect below — making
+	// it $state makes the effect self-invalidating, which silently wedges
+	// the effect scheduler in prod builds (see BUG-1687 / ShareDialog).
+	let prevOpen = false;
 	$effect.pre(() => {
 		if (prevOpen && !connectOpen) {
 			refreshHasAgentActivity(wsSlug);

--- a/web/src/lib/components/ConnectWorkspaceModal.svelte
+++ b/web/src/lib/components/ConnectWorkspaceModal.svelte
@@ -57,7 +57,10 @@
 	// user manually switched tabs, so we use a $state seeded by an $effect
 	// that fires only on the open→true transition.
 	let activeTab = $state<PrimaryTab>('cli');
-	let lastOpen = $state(false);
+	// PLAIN variable (not $state): only used for edge-detection inside the
+	// effect below. As $state it makes the effect self-invalidating, which
+	// silently wedges the effect scheduler in prod builds (BUG-1687).
+	let lastOpen = false;
 	$effect(() => {
 		if (open && !lastOpen) {
 			activeTab = mcpPublicUrl ? 'agent' : 'cli';

--- a/web/src/lib/components/collections/CreateCollectionModal.svelte
+++ b/web/src/lib/components/collections/CreateCollectionModal.svelte
@@ -108,8 +108,11 @@
 		}
 	});
 
-	// Track previous open state to detect open transitions
-	let prevOpen = $state(false);
+	// Track previous open state to detect open transitions. PLAIN variable
+	// (not $state): only used for edge-detection inside the effect below.
+	// As $state it makes the effect self-invalidating, silently wedging the
+	// effect scheduler in prod builds (see BUG-1687 / ShareDialog).
+	let prevOpen = false;
 
 	// Reset to step 1 whenever the modal opens (false -> true transition)
 	$effect.pre(() => {


### PR DESCRIPTION
## Summary
Follow-up sweep to **BUG-1687 / #686**. A codebase-wide audit for the same anti-pattern (an `$effect`/`$effect.pre` that reads **and** writes the same `$state`) found three more genuine instances — all open/close edge-detection trackers declared as `$state`:

- `ConnectBanner.svelte` — `prevOpen`
- `collections/CreateCollectionModal.svelte` — `prevOpen`
- `ConnectWorkspaceModal.svelte` — `lastOpen`

Each is the identical self-invalidating effect that silently wedges Svelte's global effect scheduler in **production** builds when the banner/modal closes (dev builds throw `effect_update_depth_exceeded`; prod doesn't, and the scheduler just stops flushing — see #686 for the full writeup).

## Fix
Make each tracker a plain `let` instead of `$state`. They're only read/written for edge-detection inside their effect, so the effects now depend solely on `open`/`connectOpen` and never re-trigger themselves.

## Audit scope
All 60 `.svelte`/`.svelte.ts` files using `$effect` were inspected. These three were the only HIGH-confidence matches. One MEDIUM (`PlaybookFormFields.svelte`, two-way args↔body sync) reads+writes the same `$state` but has convergence guards that settle in 1–2 runs — left as-is, noted for awareness. Everything else uses safe patterns (plain trackers, `untrack`, convergence guards, or async loaders).

## Test plan
- [x] `cd web && npm run build` — clean
- [ ] (low-risk; behavior identical, only removes self-retriggering) — would manually confirm each modal/banner still opens/resets/closes correctly