### PR TITLE
fix(attachments): grant-aware upload auth so share-link editors can attach (BUG-1661)

### DIFF
--- a/internal/server/handlers_attachments.go
+++ b/internal/server/handlers_attachments.go
@@ -60,9 +60,6 @@ const multipartParseMemory = 1 << 20 // 1 MiB
 //     workspace owner's storage_bytes limit. Phase 2 will enforce.
 //  9. Return JSON {id, url, mime, size, width?, height?, filename, category, render_mode}.
 func (s *Server) handleUploadAttachment(w http.ResponseWriter, r *http.Request) {
-	if !requireMinRole(w, r, "editor") {
-		return
-	}
 	if s.attachments == nil {
 		writeError(w, http.StatusServiceUnavailable, "attachments_disabled",
 			"Attachment storage is not configured on this server")
@@ -70,6 +67,37 @@ func (s *Server) handleUploadAttachment(w http.ResponseWriter, r *http.Request) 
 	}
 	workspaceID, ok := s.getWorkspaceID(w, r)
 	if !ok {
+		return
+	}
+
+	// Authorize the upload. The surfaces that offer upload (rich item
+	// editor, comment composer) gate their affordance on grant-aware edit
+	// permission, so a guest holding an item/collection edit grant via a
+	// share link — but no workspace editor role — must be able to attach
+	// (BUG-1661). When the caller supplies an ?item_id we authorize against
+	// that item's grant chain via requireEditPermission. Free-floating
+	// uploads (new-item creation, storage settings) carry no item context,
+	// so they keep the flat workspace editor-role gate.
+	//
+	// We read item_id from the query string here (before spooling the
+	// multipart body) so a denied upload trips early; the value is also
+	// re-read from the form below for association. A bogus/unresolvable
+	// item_id falls back to the editor-role check rather than leaking item
+	// existence.
+	if authItemID := strings.TrimSpace(r.URL.Query().Get("item_id")); authItemID != "" {
+		item, err := s.store.ResolveItem(workspaceID, authItemID)
+		if err != nil {
+			writeInternalError(w, err)
+			return
+		}
+		if item != nil {
+			if !s.requireEditPermission(w, r, workspaceID, item.ID, item.CollectionID) {
+				return
+			}
+		} else if !requireMinRole(w, r, "editor") {
+			return
+		}
+	} else if !requireMinRole(w, r, "editor") {
 		return
 	}
 	// Attribution: prefer the logged-in user. On a fresh install (no

--- a/internal/server/handlers_attachments_test.go
+++ b/internal/server/handlers_attachments_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -118,6 +119,93 @@ func TestUpload_HappyPathPNG(t *testing.T) {
 	// the path itself.
 	if !strings.Contains(resp.URL, "/attachments/"+resp.ID) || !strings.Contains(resp.URL, "/workspaces/"+slug) {
 		t.Errorf("url = %q, want to contain workspace slug %q and attachment id %q", resp.URL, slug, resp.ID)
+	}
+}
+
+// uploadAsGuest drives handleUploadAttachment directly with a synthesized
+// request context (workspace + guest user + "guest" role), mirroring the
+// direct-handler pattern TestStorageUsage_RejectsGuests uses. itemID, when
+// non-empty, rides in the ?item_id query string so the handler authorizes
+// via the item's grant chain (BUG-1661).
+func uploadAsGuest(srv *Server, wsID, itemID string, guest *models.User, body []byte) *httptest.ResponseRecorder {
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	part, _ := mw.CreateFormFile("file", "shot.png")
+	part.Write(body)
+	mw.Close()
+
+	path := "/api/v1/workspaces/" + wsID + "/attachments"
+	if itemID != "" {
+		path += "?item_id=" + itemID
+	}
+	req := httptest.NewRequest("POST", path, &buf)
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	req.RemoteAddr = "127.0.0.1:1234"
+
+	ctx := req.Context()
+	ctx = context.WithValue(ctx, ctxResolvedWorkspaceID, wsID)
+	ctx = context.WithValue(ctx, ctxCurrentUser, guest)
+	ctx = context.WithValue(ctx, ctxWorkspaceRole, "guest")
+	req = req.WithContext(ctx)
+
+	rr := httptest.NewRecorder()
+	srv.handleUploadAttachment(rr, req)
+	return rr
+}
+
+// TestUpload_GrantBasedEditorCanAttach covers BUG-1661: a guest holding an
+// item-level edit grant (but no workspace editor role) can upload an
+// attachment when the request carries the granted item's ?item_id. The
+// old flat requireMinRole("editor") gate rejected this with 403 even though
+// the editor / comment composer offered the paste/drop affordance.
+//
+// The companion assertion (no item_id → 403) confirms the editor-role
+// fallback for free-floating uploads didn't widen guest access.
+func TestUpload_GrantBasedEditorCanAttach(t *testing.T) {
+	srv, _ := testServerWithAttachments(t)
+
+	ws, err := srv.store.CreateWorkspace(models.WorkspaceCreate{Name: "Grants"})
+	if err != nil {
+		t.Fatalf("CreateWorkspace: %v", err)
+	}
+	col, err := srv.store.CreateCollection(ws.ID, models.CollectionCreate{
+		Name: "Tasks", Schema: `{"fields":[]}`,
+	})
+	if err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	item, err := srv.store.CreateItem(ws.ID, col.ID, models.ItemCreate{
+		Title: "Granted", Fields: `{}`,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem: %v", err)
+	}
+
+	// Guest: not a workspace editor, holds an item edit grant only.
+	guest, err := srv.store.CreateUser(models.UserCreate{
+		Email:    "guest@test.com",
+		Name:     "Guest",
+		Password: "correct-horse-battery-staple",
+		Role:     "member",
+	})
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	if _, err := srv.store.CreateItemGrant(ws.ID, item.ID, guest.ID, "edit", guest.ID); err != nil {
+		t.Fatalf("CreateItemGrant: %v", err)
+	}
+
+	// With the granted item's ?item_id → authorized via the grant chain.
+	rr := uploadAsGuest(srv, ws.ID, item.ID, guest, realPNG())
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("granted upload: status = %d, want 201; body = %s", rr.Code, rr.Body.String())
+	}
+
+	// Without item context → falls back to the workspace editor-role gate,
+	// which this guest fails.
+	rr = uploadAsGuest(srv, ws.ID, "", guest, realPNG())
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("free-floating guest upload: status = %d, want 403; body = %s", rr.Code, rr.Body.String())
 	}
 }
 

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -1341,13 +1341,17 @@ export const api = {
 			} else {
 				fd.append('file', file, 'upload.bin');
 			}
+			// item_id also rides in the query string (not just the form
+			// body) so the server can authorize the upload via the item's
+			// grant chain BEFORE spooling the multipart payload (BUG-1661).
 			if (itemId) fd.append('item_id', itemId);
 
 			const headers: Record<string, string> = {};
 			const csrf = getCSRFToken();
 			if (csrf) headers['X-CSRF-Token'] = csrf;
 
-			const resp = await fetch(`${BASE}/workspaces/${workspaceSlug}/attachments`, {
+			const qs = itemId ? `?item_id=${encodeURIComponent(itemId)}` : '';
+			const resp = await fetch(`${BASE}/workspaces/${workspaceSlug}/attachments${qs}`, {
 				method: 'POST',
 				headers,
 				credentials: 'same-origin',

--- a/web/src/lib/components/CommentEditor.svelte
+++ b/web/src/lib/components/CommentEditor.svelte
@@ -33,6 +33,14 @@
 		placeholder?: string;
 		/** Workspace slug — required for attachment upload + image URLs. */
 		wsSlug: string;
+		/**
+		 * UUID of the item this comment belongs to. Sent with attachment
+		 * uploads so the server can authorize against the item's grant chain
+		 * — a grant-based editor (share-link guest, no workspace editor role)
+		 * can attach instead of hitting a 403 (BUG-1661). Optional; without
+		 * it uploads fall back to the workspace editor-role gate.
+		 */
+		itemId?: string;
 		/** Label for the submit button (e.g. "Comment", "Reply", "Save"). */
 		submitLabel?: string;
 		/** External busy flag (network in flight in the host). */
@@ -52,6 +60,7 @@
 		content = '',
 		placeholder = 'Write a comment…',
 		wsSlug,
+		itemId,
 		submitLabel = 'Comment',
 		submitting = false,
 		autofocus = false,
@@ -123,7 +132,7 @@
 						}
 						pendingUploads += 1;
 						try {
-							return await api.attachments.upload(wsSlug, file);
+							return await api.attachments.upload(wsSlug, file, itemId);
 						} finally {
 							pendingUploads -= 1;
 						}

--- a/web/src/lib/components/editor/Editor.svelte
+++ b/web/src/lib/components/editor/Editor.svelte
@@ -349,6 +349,7 @@
 	let {
 		content = '',
 		editable = true,
+		itemId,
 		ydoc,
 		awareness,
 		collabUser,
@@ -358,6 +359,14 @@
 	}: {
 		content?: string;
 		editable?: boolean;
+		/**
+		 * UUID of the item being edited. Sent with attachment uploads so the
+		 * server can authorize against the item's grant chain — a grant-based
+		 * editor (share-link guest with no workspace editor role) can attach
+		 * instead of hitting a 403 (BUG-1661). Optional; without it uploads
+		 * fall back to the workspace editor-role gate.
+		 */
+		itemId?: string;
 		/**
 		 * Optional Yjs document to bind this editor to via the Tiptap
 		 * Collaboration extension (PLAN-1248). When set, the y-tiptap
@@ -681,7 +690,7 @@
 						// than leaving a silent stuck spinner.
 						throw new Error('No workspace context — drop a file from inside a workspace.');
 					}
-					return api.attachments.upload(wsSlug, file);
+					return api.attachments.upload(wsSlug, file, itemId);
 				},
 				onError: (filename, message) => {
 					// Surface upload failures to the user. The editor's

--- a/web/src/lib/components/timeline/ItemTimeline.svelte
+++ b/web/src/lib/components/timeline/ItemTimeline.svelte
@@ -359,6 +359,7 @@
 		<div class="compose">
 			<CommentEditor
 				{wsSlug}
+				{itemId}
 				placeholder="Write a comment… (paste or drop an image to attach)"
 				submitLabel="Comment"
 				{submitting}

--- a/web/src/lib/components/timeline/TimelineCommentCard.svelte
+++ b/web/src/lib/components/timeline/TimelineCommentCard.svelte
@@ -208,6 +208,7 @@
 		<div class="edit-compose">
 			<CommentEditor
 				{wsSlug}
+				itemId={comment.item_id}
 				content={comment.body}
 				placeholder="Edit comment…"
 				submitLabel="Save"
@@ -257,6 +258,7 @@
 		<div class="reply-compose">
 			<CommentEditor
 				{wsSlug}
+				itemId={comment.item_id}
 				placeholder="Write a reply… (paste or drop an image to attach)"
 				submitLabel="Reply"
 				autofocus
@@ -309,6 +311,7 @@
 						<div class="edit-compose">
 							<CommentEditor
 								{wsSlug}
+								itemId={comment.item_id}
 								content={reply.body}
 								placeholder="Edit reply…"
 								submitLabel="Save"

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -2729,6 +2729,7 @@
 								content={editorContent}
 								onUpdate={handleContentUpdate}
 								editable={false}
+								itemId={item.id}
 								onEditor={(e) => editorInstance = e}
 								onImportInserted={handleImportInserted}
 							/>
@@ -2763,6 +2764,7 @@
 									content={editorContent}
 									onUpdate={handleContentUpdate}
 									editable={true}
+									itemId={item.id}
 									ydoc={ydoc}
 									awareness={collabProvider?.awareness}
 									collabUser={collabUserState}


### PR DESCRIPTION
## What

Fixes **BUG-1661**. `handleUploadAttachment` gated on `requireMinRole(w, r, "editor")` — a workspace-level role check — but the rich item editor and comment composer offer the paste/drop upload affordance based on **grant-aware** edit permission. So a grant-based editor (a guest with an item/collection edit grant via a share link, but no workspace editor role) could type/post text and edit content, yet a pasted/dropped image upload failed with **403**.

## How

**Server** (`internal/server/handlers_attachments.go`)
- Read `?item_id` from the query string early — before spooling the multipart body.
- When present and resolvable, authorize via the grant-aware `requireEditPermission` against the item's collection grant chain; otherwise (and for free-floating uploads like new-item creation / storage settings) fall back to the original `requireMinRole("editor")` gate.
- Reordered the attachments-nil and `getWorkspaceID` checks above auth so `workspaceID` is available.

**Client** (`web/src/lib/api/client.ts`)
- `upload()` now also sends `item_id` as a query param (not just the form field) so the server can authorize before spooling.

**Plumbing** — threaded the item UUID into both upload surfaces:
- `editor/Editor.svelte` — new `itemId` prop, passed at both mount sites (`item.id`).
- `CommentEditor.svelte` — new `itemId` prop; `ItemTimeline` composer passes `itemId`, the three `TimelineCommentCard` composers pass `comment.item_id`.

## Test

`TestUpload_GrantBasedEditorCanAttach` — a guest with an item edit grant (no workspace editor role) gets **201** with `?item_id` and **403** without it, confirming the editor-role fallback didn't widen access for free-floating uploads.

## Verification
- `go test ./internal/server/ ./internal/store/` — pass
- `npx svelte-check` — 0 errors
- `make build` (web + Go binary) — clean
- Codex CLI review — CLEAN (round 1, no findings)