### PR TITLE
fix(web): reflow page content when sidebar collapses (BUG-1651)

### DIFF
--- a/web/src/lib/components/layout/Sidebar.svelte
+++ b/web/src/lib/components/layout/Sidebar.svelte
@@ -709,12 +709,24 @@
 		flex-direction: column;
 		height: 100%;
 		overflow: hidden;
-		transition: transform 0.25s ease;
+		transition: transform 0.25s ease, width 0.25s ease, min-width 0.25s ease;
 		transform: translateX(0);
 	}
 	.sidebar.collapsed {
 		transform: translateX(calc(var(--sidebar-width) * -1));
 		pointer-events: none;
+	}
+	/*
+		BUG-1651: on desktop the sidebar is a flex child of .app-shell, so the
+		collapsed transform alone slides it off-screen but leaves its width
+		reserved in the flex row — .main-content can't expand into the gap.
+		Releasing width/min-width lets the row reflow so content fills the
+		space. Excluded on mobile, where the sidebar is position: fixed (out of
+		flow) and the width drives the slide-in drawer.
+	*/
+	.sidebar.collapsed:not(.mobile) {
+		width: 0;
+		min-width: 0;
 	}
 	.sidebar.mobile {
 		position: fixed;


### PR DESCRIPTION
## Summary
Collapsing the desktop sidebar left a blank gap — page content didn't expand to fill the freed space (reported by Tomer, who tiles apps and keeps menus hidden).

**Root cause:** `.app-shell` is `display: flex` and the sidebar is a flex child with `width/min-width: var(--sidebar-width)`. The collapsed state only applied `transform: translateX(-100%)`, which slides the sidebar off-screen but keeps its column reserved in the flex row, so `.main-content` (`flex: 1`) had nothing to expand into.

**Fix:** release `width`/`min-width` on desktop-collapsed (`.sidebar.collapsed:not(.mobile)`) so the flex row reflows. Scoped `:not(.mobile)` because the mobile sidebar is `position: fixed` (out of flow) and uses its width to drive the slide-in drawer. Width animates alongside the existing transform transition for a smooth close.

CSS-only, one file.

## Test
Desktop-width window → toggle the sidebar (⌘\). Content now fills the freed space instead of leaving a gap. Mobile drawer slide-in unchanged.

Fixes BUG-1651.