### PR TITLE
fix(server): gate ref-resolver admin bypass on bearer auth (BUG-1618)

### DIFF
--- a/internal/server/handlers_ref_resolver.go
+++ b/internal/server/handlers_ref_resolver.go
@@ -200,6 +200,16 @@ func (s *Server) resolverWorkspaceRole(ws *models.Workspace, user *models.User, 
 	if err == nil && member != nil {
 		return member.Role
 	}
+	// Bearer-borne platform admin who isn't a member gets NO grant-based
+	// fallback — the membership-only stance (BUG-1616/1617/1618). Without
+	// this guard a single stray collection/item grant would yield "guest"
+	// below, and checkItemVisible's own `user.Role == "admin"` bypass
+	// (server.go) would then reopen full resolver access + 302 URL leakage
+	// for every item in the workspace. RequireWorkspaceAccess denies
+	// bearer-admin non-members before checking grants for the same reason.
+	if user.Role == "admin" && authIsBearer {
+		return ""
+	}
 	// Not a member — guest path requires at least one grant.
 	hasGrants, err := s.store.UserHasGrantsInWorkspace(ws.ID, user.ID)
 	if err == nil && hasGrants {

--- a/internal/server/handlers_ref_resolver.go
+++ b/internal/server/handlers_ref_resolver.go
@@ -167,8 +167,10 @@ func (s *Server) resolverItemVisible(r *http.Request, ws *models.Workspace, item
 		return false, nil
 	}
 
-	// Derive the role the same way RequireWorkspaceAccess does.
-	role := s.resolverWorkspaceRole(ws, user)
+	// Derive the role the same way RequireWorkspaceAccess does. Pass the
+	// bearer signal so a bearer-borne platform admin doesn't get a
+	// cross-workspace owner bypass (BUG-1618).
+	role := s.resolverWorkspaceRole(ws, user, isBearerAuth(r))
 	if role == "" {
 		// Not a member, no grants, not admin/owner. Not visible.
 		return false, nil
@@ -179,11 +181,19 @@ func (s *Server) resolverItemVisible(r *http.Request, ws *models.Workspace, item
 // resolverWorkspaceRole reproduces RequireWorkspaceAccess's role lookup
 // for a (workspace, user) pair without the *http.Request scaffolding.
 // Returns "" when the user has no role and no grants in the workspace.
-// The "owner" return value covers admins (admin gets owner-equivalent
-// access) AND the actual workspace owner — checkItemVisible treats
-// "owner" uniformly so the conflation is safe.
-func (s *Server) resolverWorkspaceRole(ws *models.Workspace, user *models.User) string {
-	if user.Role == "admin" || ws.OwnerID == user.ID {
+// The "owner" return value covers the actual workspace owner AND
+// cookie-session admins (admin gets owner-equivalent access) —
+// checkItemVisible treats "owner" uniformly so the conflation is safe.
+//
+// authIsBearer narrows the admin bypass: a platform admin authenticated
+// via a bearer surface (PAT / CLI / MCP) does NOT get cross-workspace
+// owner access — they fall through to the member-then-grants check, the
+// membership-only stance set by BUG-1616/1617. Cookie-session admins
+// keep the owner bypass so the web-UI affordance is preserved. The
+// workspace owner check is unconditional regardless of auth surface
+// (BUG-1618).
+func (s *Server) resolverWorkspaceRole(ws *models.Workspace, user *models.User, authIsBearer bool) string {
+	if ws.OwnerID == user.ID || (user.Role == "admin" && !authIsBearer) {
 		return "owner"
 	}
 	member, err := s.store.GetWorkspaceMember(ws.ID, user.ID)

--- a/internal/server/handlers_ref_resolver_test.go
+++ b/internal/server/handlers_ref_resolver_test.go
@@ -576,3 +576,72 @@ func TestRefResolver_RestrictedMemberWithCollectionGrant(t *testing.T) {
 		t.Errorf("expected redirect under /beta/, got %q", rr.Header().Get("Location"))
 	}
 }
+
+// TestRefResolver_AdminBearer_404OnNonMemberWorkspace pins the BUG-1618
+// fix at the third admin-bypass site enumerated under BUG-1617's audit:
+// resolverWorkspaceRole no longer returns "owner" for a platform admin
+// authenticated via a bearer surface (PAT / CLI / MCP). A bearer-borne
+// admin who isn't a member of the target workspace gets the same 404 the
+// resolver emits for a nonexistent ref — closing the existence/URL oracle
+// (workspace + ref + owner-username + collection-slug) the redirect would
+// otherwise leak. Membership-only stance, matching BUG-1616/1617.
+func TestRefResolver_AdminBearer_404OnNonMemberWorkspace(t *testing.T) {
+	f := newRefResolverFixture(t)
+	item := f.seedItem("decisions", "DECIS", "Orchestration model")
+
+	// Platform admin with NO membership row in the fixture workspace.
+	admin, err := f.srv.store.CreateUser(models.UserCreate{
+		Email: "admin@example.com", Name: "Admin", Username: "adminuser",
+		Password: "correct-horse-battery-staple", Role: "admin",
+	})
+	if err != nil {
+		t.Fatalf("create admin: %v", err)
+	}
+	// Workspace-scoped PAT satisfies the token's NOT NULL workspace_id;
+	// the user-owned-token shape (not a membership) is what the resolver
+	// keys on — scoping it to f.ws does NOT grant access.
+	adminTok, err := f.srv.store.CreateAPIToken(admin.ID, models.APITokenCreate{
+		Name: "admin-bearer", WorkspaceID: f.ws.ID,
+	}, 0, 0)
+	if err != nil {
+		t.Fatalf("CreateAPIToken: %v", err)
+	}
+
+	rr := f.doAuth(adminTok.Token, "GET", "/-/r/"+f.ws.Slug+"/"+item.Ref, nil)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("bearer admin on non-member workspace: got %d, want 404; body=%s",
+			rr.Code, rr.Body.String())
+	}
+}
+
+// TestRefResolver_AdminCookie_StillRedirects pins the other half of the
+// BUG-1618 gate: a cookie-session admin keeps the owner-equivalent bypass
+// so the web-UI affordance survives. Same admin, same non-member
+// workspace as the bearer case above — only the auth surface differs, and
+// the cookie path still 302s to the canonical item URL.
+func TestRefResolver_AdminCookie_StillRedirects(t *testing.T) {
+	f := newRefResolverFixture(t)
+	item := f.seedItem("decisions", "DECIS", "Orchestration model")
+
+	admin, err := f.srv.store.CreateUser(models.UserCreate{
+		Email: "admin@example.com", Name: "Admin", Username: "adminuser",
+		Password: "correct-horse-battery-staple", Role: "admin",
+	})
+	if err != nil {
+		t.Fatalf("create admin: %v", err)
+	}
+	// Cookie session bound to the same IP doRequestWithCookie sends from.
+	sessTok, err := f.srv.store.CreateSession(admin.ID, "web-test", "192.0.2.1", "", webSessionTTL)
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	rr := doRequestWithCookie(f.srv, "GET", "/-/r/"+f.ws.Slug+"/"+item.Ref, nil, sessTok)
+	if rr.Code != http.StatusFound {
+		t.Fatalf("cookie admin: expected 302, got %d body=%s", rr.Code, rr.Body.String())
+	}
+	want := "/owneruser/" + f.ws.Slug + "/decisions/" + item.Ref
+	if loc := rr.Header().Get("Location"); loc != want {
+		t.Errorf("cookie admin Location: got %q want %q", loc, want)
+	}
+}

--- a/internal/server/handlers_ref_resolver_test.go
+++ b/internal/server/handlers_ref_resolver_test.go
@@ -614,6 +614,48 @@ func TestRefResolver_AdminBearer_404OnNonMemberWorkspace(t *testing.T) {
 	}
 }
 
+// TestRefResolver_AdminBearer_404EvenWithGrant pins the membership-only
+// stance against the grant-fallback escape hatch (Codex round 1 on
+// BUG-1618). A bearer admin who is NOT a member but holds a single
+// collection grant must still get 404 — otherwise resolverWorkspaceRole
+// would return "guest" and checkItemVisible's own admin bypass would
+// reopen full resolver access + 302 URL leakage. Mirrors
+// TestSSESubscriberStillHasAccess_AdminBearer_DeniedEvenWithGrants.
+func TestRefResolver_AdminBearer_404EvenWithGrant(t *testing.T) {
+	f := newRefResolverFixture(t)
+	item := f.seedItem("decisions", "DECIS", "Orchestration model")
+
+	admin, err := f.srv.store.CreateUser(models.UserCreate{
+		Email: "admin@example.com", Name: "Admin", Username: "adminuser",
+		Password: "correct-horse-battery-staple", Role: "admin",
+	})
+	if err != nil {
+		t.Fatalf("create admin: %v", err)
+	}
+	// Grant the admin view access on the item's collection — but DON'T add
+	// a membership row. A non-admin guest with this grant would 302; the
+	// bearer admin must not.
+	coll, err := f.srv.store.GetCollectionBySlug(f.ws.ID, "decisions")
+	if err != nil {
+		t.Fatalf("GetCollectionBySlug: %v", err)
+	}
+	if _, err := f.srv.store.CreateCollectionGrant(f.ws.ID, coll.ID, admin.ID, "view", f.owner.ID); err != nil {
+		t.Fatalf("CreateCollectionGrant: %v", err)
+	}
+	adminTok, err := f.srv.store.CreateAPIToken(admin.ID, models.APITokenCreate{
+		Name: "admin-bearer-grant", WorkspaceID: f.ws.ID,
+	}, 0, 0)
+	if err != nil {
+		t.Fatalf("CreateAPIToken: %v", err)
+	}
+
+	rr := f.doAuth(adminTok.Token, "GET", "/-/r/"+f.ws.Slug+"/"+item.Ref, nil)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("bearer admin with stray grant: got %d, want 404; body=%s",
+			rr.Code, rr.Body.String())
+	}
+}
+
 // TestRefResolver_AdminCookie_StillRedirects pins the other half of the
 // BUG-1618 gate: a cookie-session admin keeps the owner-equivalent bypass
 // so the web-UI affordance survives. Same admin, same non-member

--- a/internal/server/handlers_workspaces.go
+++ b/internal/server/handlers_workspaces.go
@@ -197,8 +197,17 @@ func (s *Server) handleReorderWorkspaces(w http.ResponseWriter, r *http.Request)
 		if ws == nil {
 			continue
 		}
-		// Skip silently if user is not a member of this workspace
-		// (e.g. admin sees all workspaces but may not be joined to all)
+		// Skip silently if the user is not a member of this workspace.
+		// UpdateWorkspaceSortOrder is scoped to the caller's own
+		// workspace_members row (WHERE user_id = ? AND workspace_id = ?),
+		// so a non-member's PATCH touches zero rows and returns
+		// sql.ErrNoRows — there's no cross-workspace write or leak here
+		// even for an attacker-supplied slug list. (The old comment cited
+		// "admin sees all workspaces"; that rationale is stale —
+		// handleListWorkspaces returns membership-only for all
+		// authenticated users including admins since BUG-982, so the
+		// switcher never surfaces non-member workspaces to reorder.
+		// BUG-1618 confirmed this site needs no auth gate.)
 		if err := s.store.UpdateWorkspaceSortOrder(userID, ws.ID, item.SortOrder); err != nil {
 			if err == sql.ErrNoRows {
 				continue


### PR DESCRIPTION
## Summary
`resolverWorkspaceRole` returned `"owner"` for any platform admin regardless of auth surface, so a **bearer-borne admin** (PAT / CLI / MCP) could probe ref existence in workspaces they never joined via the `/-/r/{ws}/{ref}` 302 redirect — leaking workspace + ref existence plus the owner username and collection slug in the redirect target.

**Site 1 (fix):** thread `isBearerAuth(r)` into `resolverWorkspaceRole`; gate the admin branch on `!authIsBearer`. Workspace-owner check stays unconditional. Bearer-admins fall through to member→grants (membership-only stance, matching BUG-1616/1617); cookie-session admins keep the owner bypass so the web-UI affordance survives.

**Site 2 (audit, no logic change):** the workspace sort-order bulk-update silent-skip needs no auth gate — `UpdateWorkspaceSortOrder` is scoped `WHERE user_id = ? AND workspace_id = ?`, so a non-member's PATCH touches zero rows (no cross-ws write/leak), and `handleListWorkspaces` has been membership-only for all authenticated users incl. admins since BUG-982. Rewrote the stale comment to record both facts.

## Context
Implements `BUG-1618` — the two admin-bypass sites flagged during the BUG-1617 codex audit and deferred for scope. Parent: BUG-1617 (PR #633). Sibling: BUG-1616 (PR #632).

## Test plan
- [x] `go build ./...` — clean
- [x] `go vet ./internal/server/` — clean
- [x] `go test ./internal/server/` — all pass (incl. 2 new resolver tests)
  - `TestRefResolver_AdminBearer_404OnNonMemberWorkspace` — bearer admin → 404
  - `TestRefResolver_AdminCookie_StillRedirects` — cookie admin → 302