### PR TITLE
fix(timeline): resolve collab-snapshot diffs + collapse autosave bursts (BUG-1612)

### DIFF
--- a/internal/server/handlers_item_versions.go
+++ b/internal/server/handlers_item_versions.go
@@ -42,6 +42,44 @@ func (s *Server) handleListItemVersions(w http.ResponseWriter, r *http.Request) 
 	writeJSON(w, http.StatusOK, versions)
 }
 
+// handleGetItemVersion returns a single version with its diff resolved to full
+// content. The paginated timeline serves raw reverse-patch text (it can't resolve
+// a partial window), so the timeline card calls this to reconstruct real content
+// when a diff version is expanded — see BUG-1612.
+func (s *Server) handleGetItemVersion(w http.ResponseWriter, r *http.Request) {
+	workspaceID, ok := s.getWorkspaceID(w, r)
+	if !ok {
+		return
+	}
+
+	itemSlug := chi.URLParam(r, "itemSlug")
+	versionID := chi.URLParam(r, "versionID")
+	item, err := s.store.ResolveItem(workspaceID, itemSlug)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	if item == nil {
+		writeError(w, http.StatusNotFound, "not_found", "Item not found")
+		return
+	}
+	if !s.requireItemVisible(w, r, workspaceID, item) {
+		return
+	}
+
+	version, err := s.store.GetItemVersionResolved(item.ID, versionID, item.Content)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	if version == nil {
+		writeError(w, http.StatusNotFound, "not_found", "Version not found")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, version)
+}
+
 // handleRestoreItemVersion restores an item's content from a specific version.
 func (s *Server) handleRestoreItemVersion(w http.ResponseWriter, r *http.Request) {
 	workspaceID, ok := s.getWorkspaceID(w, r)

--- a/internal/server/handlers_timeline.go
+++ b/internal/server/handlers_timeline.go
@@ -237,5 +237,48 @@ func buildTimeline(comments []models.Comment, activities []models.Activity, vers
 		return entries[i].CreatedAt.After(entries[j].CreatedAt)
 	})
 
-	return entries
+	return collapseAutosaveBursts(entries)
+}
+
+// autosaveBurstWindow is how close two collab-snapshot versions must be (with no
+// other event between them) to collapse into a single timeline entry. The web
+// editor flushes a collab-snapshot every ~5s while a user types, so without this
+// every editing session litters the item timeline with near-identical "Content
+// updated" cards (BUG-1612). We keep the newest snapshot of each burst as the
+// restore point and drop the rest.
+const autosaveBurstWindow = 10 * time.Minute
+
+// isAutosaveVersion reports whether an entry is a collab-snapshot version row
+// (the web editor's 5s auto-flush). These are the only versions we collapse —
+// manual web/CLI/skill saves stay individual.
+func isAutosaveVersion(e models.TimelineEntry) bool {
+	return e.Kind == "version" && e.Version != nil && e.Version.Source == "collab-snapshot"
+}
+
+// collapseAutosaveBursts walks the newest-first entries and drops a
+// collab-snapshot version when the previous kept entry is also a collab-snapshot
+// version within autosaveBurstWindow — i.e. an uninterrupted burst of autosaves
+// collapses to its newest row. Any non-autosave entry between two autosaves
+// breaks the run, so each distinct editing session still leaves one restore point.
+func collapseAutosaveBursts(entries []models.TimelineEntry) []models.TimelineEntry {
+	if len(entries) == 0 {
+		return entries
+	}
+	kept := entries[:0:0]
+	var lastAutosaveAt time.Time
+	for _, e := range entries {
+		if isAutosaveVersion(e) {
+			if !lastAutosaveAt.IsZero() && lastAutosaveAt.Sub(e.CreatedAt) <= autosaveBurstWindow {
+				// Same burst as the autosave we already kept — skip this older one.
+				lastAutosaveAt = e.CreatedAt
+				continue
+			}
+			lastAutosaveAt = e.CreatedAt
+		} else {
+			// A non-autosave event ends the current burst.
+			lastAutosaveAt = time.Time{}
+		}
+		kept = append(kept, e)
+	}
+	return kept
 }

--- a/internal/server/handlers_timeline_collapse_test.go
+++ b/internal/server/handlers_timeline_collapse_test.go
@@ -1,0 +1,121 @@
+package server
+
+import (
+	"testing"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// TestCollapseAutosaveBursts guards the BUG-1612 clutter fix: the web editor
+// flushes a collab-snapshot version every ~5s while typing, so an uninterrupted
+// burst should collapse to its single newest entry in the item timeline. Manual
+// saves (web/cli) and any non-autosave event between two autosaves break the run.
+func autosaveEntry(id string, at time.Time) models.TimelineEntry {
+	return models.TimelineEntry{
+		ID:        id,
+		Kind:      "version",
+		CreatedAt: at,
+		Source:    "collab-snapshot",
+		Version:   &models.Version{ID: id, Source: "collab-snapshot", IsDiff: true},
+	}
+}
+
+func versionEntry(id string, at time.Time, source string) models.TimelineEntry {
+	return models.TimelineEntry{
+		ID:        id,
+		Kind:      "version",
+		CreatedAt: at,
+		Source:    source,
+		Version:   &models.Version{ID: id, Source: source},
+	}
+}
+
+func commentEntry(id string, at time.Time) models.TimelineEntry {
+	return models.TimelineEntry{ID: id, Kind: "comment", CreatedAt: at, Source: "web"}
+}
+
+func idsOf(entries []models.TimelineEntry) []string {
+	out := make([]string, len(entries))
+	for i, e := range entries {
+		out[i] = e.ID
+	}
+	return out
+}
+
+func equalIDs(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestCollapseAutosaveBursts(t *testing.T) {
+	base := time.Date(2026, 6, 2, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name string
+		// entries are newest-first, mirroring buildTimeline's post-sort order.
+		in   []models.TimelineEntry
+		want []string
+	}{
+		{
+			name: "uninterrupted burst collapses to newest",
+			in: []models.TimelineEntry{
+				autosaveEntry("a3", base),
+				autosaveEntry("a2", base.Add(-5*time.Second)),
+				autosaveEntry("a1", base.Add(-10*time.Second)),
+			},
+			want: []string{"a3"},
+		},
+		{
+			name: "non-autosave event between autosaves breaks the run",
+			in: []models.TimelineEntry{
+				autosaveEntry("a2", base),
+				commentEntry("c1", base.Add(-30*time.Second)),
+				autosaveEntry("a1", base.Add(-60*time.Second)),
+			},
+			want: []string{"a2", "c1", "a1"},
+		},
+		{
+			name: "autosaves more than the window apart are kept separately",
+			in: []models.TimelineEntry{
+				autosaveEntry("a2", base),
+				autosaveEntry("a1", base.Add(-11*time.Minute)),
+			},
+			want: []string{"a2", "a1"},
+		},
+		{
+			name: "manual web saves are never collapsed",
+			in: []models.TimelineEntry{
+				versionEntry("v2", base, "web"),
+				versionEntry("v1", base.Add(-5*time.Second), "web"),
+			},
+			want: []string{"v2", "v1"},
+		},
+		{
+			name: "long burst chains across the window from its newest edge",
+			in: []models.TimelineEntry{
+				autosaveEntry("a4", base),
+				autosaveEntry("a3", base.Add(-5*time.Second)),
+				autosaveEntry("a2", base.Add(-10*time.Second)),
+				autosaveEntry("a1", base.Add(-15*time.Second)),
+			},
+			want: []string{"a4"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := idsOf(collapseAutosaveBursts(tc.in))
+			if !equalIDs(got, tc.want) {
+				t.Fatalf("collapseAutosaveBursts() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1124,6 +1124,7 @@ func (s *Server) setupRouter() {
 						r.Post("/restore", s.handleRestoreItem)
 						r.Post("/move", s.handleMoveItem)
 						r.Get("/versions", s.handleListItemVersions)
+						r.Get("/versions/{versionID}", s.handleGetItemVersion)
 						r.Post("/versions/{versionID}/restore", s.handleRestoreItemVersion)
 						r.Get("/activity", s.handleListItemActivity)
 						r.Get("/links", s.handleGetItemLinks)

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -3386,6 +3386,25 @@ func (s *Store) ListItemVersionsResolved(itemID, currentContent string) ([]model
 	return versions, nil
 }
 
+// GetItemVersionResolved returns a single version with its diff resolved to
+// full content. Reverse-patch versions can only be reconstructed by walking the
+// chain from current content newest→oldest, so this resolves the whole chain and
+// returns the requested row. Used by the timeline's lazy "resolve on expand" path
+// (BUG-1612) — the paginated timeline serves raw patch text, so the card fetches
+// real content only when a diff version is expanded. Returns nil if not found.
+func (s *Store) GetItemVersionResolved(itemID, versionID, currentContent string) (*models.Version, error) {
+	versions, err := s.ListItemVersionsResolved(itemID, currentContent)
+	if err != nil {
+		return nil, err
+	}
+	for i := range versions {
+		if versions[i].ID == versionID {
+			return &versions[i], nil
+		}
+	}
+	return nil, nil
+}
+
 // ListItemVersionsBeforeTime returns versions for an item created before the given time,
 // ordered newest-first, limited to `limit` results. Used for cursor-based timeline pagination.
 //

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -855,6 +855,14 @@ export const api = {
 		list: (ws: string, itemSlug: string) =>
 			request<Version[]>(`/workspaces/${ws}/items/${itemSlug}/versions`),
 
+		/**
+		 * Fetch a single version with its diff resolved to full content. The
+		 * timeline serves raw reverse-patch text for diff versions; the version
+		 * card calls this to reconstruct real content when expanded (BUG-1612).
+		 */
+		get: (ws: string, itemSlug: string, versionId: string) =>
+			request<Version>(`/workspaces/${ws}/items/${itemSlug}/versions/${versionId}`),
+
 		restore: (ws: string, itemSlug: string, versionId: string) =>
 			request<Item>(`/workspaces/${ws}/items/${itemSlug}/versions/${versionId}/restore`, {
 				method: 'POST'

--- a/web/src/lib/components/timeline/TimelineVersionCard.svelte
+++ b/web/src/lib/components/timeline/TimelineVersionCard.svelte
@@ -18,10 +18,35 @@
 	let confirming = $state(false);
 	let restoring = $state(false);
 
+	// The timeline endpoint serves raw reverse-patch text for diff versions
+	// (is_diff), so version.content is unreadable patch data, not real content.
+	// Resolve it lazily the first time the card is expanded (BUG-1612). Non-diff
+	// versions already carry full content, so displayContent falls straight through.
+	let fetchedContent = $state<string | null>(null);
+	let resolveError = $state(false);
+	let resolving = $state(false);
+	let displayContent = $derived(version.is_diff ? fetchedContent : version.content);
+
+	async function ensureResolved() {
+		if (!version.is_diff || fetchedContent !== null || resolving) return;
+		resolving = true;
+		resolveError = false;
+		try {
+			const full = await api.versions.get(wsSlug, itemSlug, version.id);
+			fetchedContent = full.content;
+		} catch {
+			resolveError = true;
+		} finally {
+			resolving = false;
+		}
+	}
+
 	function toggle() {
 		expanded = !expanded;
 		if (!expanded) {
 			confirming = false;
+		} else {
+			ensureResolved();
 		}
 	}
 
@@ -52,7 +77,8 @@
 		const labels: Record<string, string> = {
 			cli: 'CLI',
 			web: 'Web',
-			skill: 'Skill'
+			skill: 'Skill',
+			'collab-snapshot': 'Autosave'
 		};
 		return labels[source] ?? source;
 	}
@@ -88,7 +114,13 @@
 	{#if expanded}
 		<div class="card-body">
 			<div class="diff-container">
-				<DiffView oldContent={version.content} newContent={currentContent} />
+				{#if resolving}
+					<p class="diff-status">Loading version…</p>
+				{:else if resolveError}
+					<p class="diff-status">Couldn't load this version's content.</p>
+				{:else if displayContent !== null}
+					<DiffView oldContent={displayContent} newContent={currentContent} />
+				{/if}
 			</div>
 
 			<div class="restore-area">
@@ -184,6 +216,13 @@
 		white-space: nowrap;
 		overflow: hidden;
 		text-overflow: ellipsis;
+	}
+
+	.diff-status {
+		margin: 0;
+		padding: var(--space-2);
+		font-size: 0.85em;
+		color: var(--text-muted);
 	}
 
 	.badges {


### PR DESCRIPTION
## What & why

Fixes **BUG-1612** — items accumulate "collab snapshot" timeline entries that render as artifacts.

### 1. Artifacts (the bug)
The item **timeline** (`GET /items/{slug}/timeline` → `ListItemVersionsBeforeTime`) served diff-compressed versions **unresolved**, so `TimelineVersionCard` fed raw diff-match-patch patch text (`@@ -141,17 +141,16 @@ flakes:%0A`) into `DiffView`. Version History didn't have this because it uses the resolved endpoint. The timeline is cursor-paginated, so a partial window can't resolve the patch chain in place.

**Fix — lazy-resolve on expand:** new `GET /items/{slug}/versions/{versionID}` (`handleGetItemVersion` → `Store.GetItemVersionResolved`) returns a single version with its diff resolved; the card fetches it the first time a diff version is expanded (loading/error states added). Non-diff versions fall straight through.

### 2. Clutter
Every ~5s web-editor session auto-flushes a `collab-snapshot` version (empty `change_summary`), rendered with a raw `collab-snapshot` badge.
- `buildTimeline` collapses uninterrupted `collab-snapshot` bursts (within 10 min, no intervening event) to their newest entry — `collapseAutosaveBursts` + `TestCollapseAutosaveBursts`. Manual web/CLI saves are never collapsed.
- Source badge now reads **"Autosave"**.

## Testing
- `go test ./internal/server/ ./internal/store/` — pass
- `cd web && npm run build` — clean; Svelte autofixer clean
- Verified end-to-end against a live instance: a stored reverse-patch resolves to readable markdown via the new endpoint

## Known limitation (accepted)
Collapse is page-local, so a 150+ cross-actor autosave chain could leak one row per "Load more" page. Gated by the 1h version throttle (single-actor bursts can't form), degrades gracefully. Flagged by Codex (P2), accepted as out of scope for this fix.