### PR TITLE
fix(store): cast jsonb metadata to text for Postgres LIKE + gofmt (BUG-1702)

### DIFF
--- a/internal/models/comment.go
+++ b/internal/models/comment.go
@@ -4,22 +4,22 @@ import "time"
 
 // Comment represents a comment on an item.
 type Comment struct {
-	ID          string    `json:"id"`
-	ItemID      string    `json:"item_id"`
-	WorkspaceID string    `json:"workspace_id"`
-	Author      string    `json:"author"`
+	ID          string `json:"id"`
+	ItemID      string `json:"item_id"`
+	WorkspaceID string `json:"workspace_id"`
+	Author      string `json:"author"`
 	// UserID is the authenticated user who authored the comment. Empty for
 	// pre-identity comments (created before TASK-1663) and agent/system
 	// comments; the comment-edit permission check treats empty as
 	// "no provable author" → admin-only.
-	UserID      string    `json:"user_id,omitempty"`
-	Body        string    `json:"body"`
-	CreatedBy   string    `json:"created_by"`
-	Source      string    `json:"source"`
-	ActivityID  string    `json:"activity_id,omitempty"`
-	ParentID    string    `json:"parent_id,omitempty"`
-	CreatedAt   time.Time `json:"created_at"`
-	UpdatedAt   time.Time `json:"updated_at"`
+	UserID     string    `json:"user_id,omitempty"`
+	Body       string    `json:"body"`
+	CreatedBy  string    `json:"created_by"`
+	Source     string    `json:"source"`
+	ActivityID string    `json:"activity_id,omitempty"`
+	ParentID   string    `json:"parent_id,omitempty"`
+	CreatedAt  time.Time `json:"created_at"`
+	UpdatedAt  time.Time `json:"updated_at"`
 
 	// Populated by joins (not stored)
 	ItemTitle string `json:"item_title,omitempty"`

--- a/internal/server/handlers_share_links_test.go
+++ b/internal/server/handlers_share_links_test.go
@@ -25,7 +25,7 @@ func TestResolveCollectionShareLink_EnrichedPayload(t *testing.T) {
 	rr := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections", map[string]interface{}{
 		"name":   "Roadmap",
 		"prefix": "ROAD",
-		"icon": "🗺️",
+		"icon":   "🗺️",
 		// schema is a JSON-encoded string on CollectionCreate.
 		"schema": `{"fields":[` +
 			`{"key":"status","label":"Status","type":"select","options":["open","doing","done"],"terminal_options":["done"]},` +

--- a/internal/store/status_transitions_backfill.go
+++ b/internal/store/status_transitions_backfill.go
@@ -208,12 +208,20 @@ func (s *Store) BackfillStatusTransitions() (*BackfillStatusTransitionsResult, e
 	// field change (every "key: a → b" segment contains the arrow). Order by
 	// created_at so multi-hop histories insert chronologically AND so the
 	// firstChangeFrom map below captures each item's earliest hop.
+	//
+	// metadata is jsonb on Postgres, where LIKE (~~) is undefined — cast to
+	// text first. SQLite stores it as TEXT, so no cast is needed there. Same
+	// dialect-guarded pattern as AttachmentReferenced in attachments.go.
+	metadataExpr := "a.metadata"
+	if s.dialect.Driver() == DriverPostgres {
+		metadataExpr = "a.metadata::text"
+	}
 	rows, err := s.db.Query(s.q(`
 		SELECT a.id, a.document_id, i.workspace_id, i.collection_id, a.metadata, a.created_at
 		FROM activities a
 		JOIN items i ON i.id = a.document_id
 		WHERE a.action = 'updated'
-		  AND a.metadata LIKE '%→%'
+		  AND ` + metadataExpr + ` LIKE '%→%'
 		ORDER BY a.created_at
 	`))
 	if err != nil {


### PR DESCRIPTION
Fixes CI, red on `main` across multiple commits. Two independent root causes — BUG-1702.

## 1. `Go (PostgreSQL)` job — `jsonb ~~` error (real bug)
`internal/store/status_transitions_backfill.go:216` used `a.metadata LIKE '%→%'`, but `activities.metadata` is `jsonb` on Postgres, where `LIKE` (`~~`) is undefined:

```
ERROR: operator does not exist: jsonb ~~ unknown (SQLSTATE 42883)
```

Passed on SQLite (TEXT column), failed only on the Postgres CI job — and **would error in any Postgres deployment**, not just tests. Now casts `a.metadata::text` on Postgres (dialect-guarded), matching the existing `AttachmentReferenced` pattern in `attachments.go`.

## 2. `golangci-lint` job — gofmt violations
`gofmt -w` on `internal/models/comment.go` and `internal/server/handlers_share_links_test.go`.

## Verification
- `TestBackfillStatusTransitions` + `_SeedSeqBelowHop` pass against Postgres 17.
- Full `internal/store` suite green against Postgres (219s).
- `gofmt -l` clean, `go build ./...` clean.