### PR TITLE
chore: bump Go toolchain to 1.26.4 (TASK-1739)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/PerpetualSoftware/pad
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/BurntSushi/toml v1.6.0


### PR DESCRIPTION
## Summary
Bumps the go.mod toolchain to 1.26.4 to clear two stdlib vulnerabilities flagged by govulncheck — GO-2026-5039 (net/textproto) and GO-2026-5037 (crypto/x509). Both are reachable from our call graph, so the CI govulncheck gate fails every PR until this lands.

## Context
Implements `TASK-1739`. Discovered while shipping `PLAN-1730` — the gate blocks all merges, so this goes first.

## Test plan
- [x] make vuln — clean (was: 2 affecting vulnerabilities)
- [x] go build ./... — clean on 1.26.4
- [x] go vet ./... — clean
- [x] go test ./... — all tests pass