### PR TITLE
feat(server): workspace graph endpoint — nodes + typed edges (TASK-1731)

### DIFF
--- a/internal/server/handlers_graph.go
+++ b/internal/server/handlers_graph.go
@@ -24,9 +24,12 @@ type GraphNode struct {
 
 // GraphEdge is one typed relationship between two graph nodes. Source
 // and target are refs. Type is one of 'parent' | 'blocks' |
-// 'implements' | 'related' | 'wiki-link'. For 'parent', source is the
-// child and target is the parent (matching item_links semantics); for
-// 'blocks', source blocks target.
+// 'implements' | 'related' | 'split-from' | 'supersedes' |
+// 'wiki-link' (the canonical item_links vocabulary, hyphenated — see
+// store.graphEdgeType — plus synthesized wiki-link edges from the
+// PLAN-1593 reverse index). For 'parent', source is the child and
+// target is the parent (matching item_links semantics); for 'blocks',
+// source blocks target.
 type GraphEdge struct {
 	Source string `json:"source"`
 	Target string `json:"target"`

--- a/internal/server/handlers_graph.go
+++ b/internal/server/handlers_graph.go
@@ -1,0 +1,149 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// GraphNode is one item in the workspace graph
+// (GET /workspaces/{ws}/graph — PLAN-1730 / TASK-1731). Nodes are
+// keyed by ref (TASK-5) rather than UUID: refs are what the web UI's
+// force-graph uses for display, deep links, and edge endpoints.
+type GraphNode struct {
+	Ref        string    `json:"ref"`
+	Title      string    `json:"title"`
+	Collection string    `json:"collection"`
+	Status     string    `json:"status,omitempty"`
+	IsTerminal bool      `json:"is_terminal"`
+	ChildCount int       `json:"child_count"`
+	UpdatedAt  time.Time `json:"updated_at"`
+}
+
+// GraphEdge is one typed relationship between two graph nodes. Source
+// and target are refs. Type is one of 'parent' | 'blocks' |
+// 'implements' | 'related' | 'wiki-link'. For 'parent', source is the
+// child and target is the parent (matching item_links semantics); for
+// 'blocks', source blocks target.
+type GraphEdge struct {
+	Source string `json:"source"`
+	Target string `json:"target"`
+	Type   string `json:"type"`
+}
+
+// GraphResponse is the payload of GET /workspaces/{ws}/graph — the
+// whole workspace as {nodes, edges} in one call, feeding the 3D graph
+// view (PLAN-1730).
+type GraphResponse struct {
+	Nodes []GraphNode `json:"nodes"`
+	Edges []GraphEdge `json:"edges"`
+}
+
+// handleGetWorkspaceGraph serves GET /api/v1/workspaces/{ws}/graph.
+//
+// Query params:
+//   - include_terminal=true — include items in terminal status
+//     (done/fixed/archived/...). Default false: the graph view opens
+//     showing active work only; large workspaces would otherwise be
+//     hairball soup.
+//
+// Visibility follows the dashboard model exactly: collection-level
+// visibility via visibleCollectionIDs, item-level guest grants via
+// guestResourceFilter, both pushed into ListItems. Edges are then
+// filtered to endpoints present in the visible node set, so a guest
+// can't infer the existence of items they can't see from dangling
+// edge endpoints.
+func (s *Server) handleGetWorkspaceGraph(w http.ResponseWriter, r *http.Request) {
+	workspaceID, ok := s.getWorkspaceID(w, r)
+	if !ok {
+		return
+	}
+	includeTerminal := r.URL.Query().Get("include_terminal") == "true"
+
+	visibleIDs, err := s.visibleCollectionIDs(r, workspaceID)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	fullCollIDs, grantedItemIDs, err := s.guestResourceFilter(r, workspaceID)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	collIDs := visibleIDs
+	var itemIDs []string
+	if len(grantedItemIDs) > 0 {
+		collIDs = fullCollIDs
+		itemIDs = grantedItemIDs
+	}
+
+	items, err := s.store.ListItems(workspaceID, models.ItemListParams{CollectionIDs: collIDs, ItemIDs: itemIDs})
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+
+	// Done-context map from ALL workspace collections (not the
+	// visibility-filtered set) so item-level grants from hidden
+	// collections still evaluate against their own done rules — same
+	// reasoning as buildDashboardResponse.
+	allCollections, err := s.store.ListCollectionsMinimal(workspaceID)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	ctxMap := buildDoneContextMap(allCollections)
+
+	links, err := s.store.ListWorkspaceGraphLinks(workspaceID)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+
+	resp := GraphResponse{Nodes: []GraphNode{}, Edges: []GraphEdge{}}
+
+	// Build the visible node set first; edges are filtered against it.
+	refByID := make(map[string]string, len(items))
+	nodeIdx := make(map[string]int, len(items)) // item ID → index in resp.Nodes
+	for _, item := range items {
+		if item.Ref == "" {
+			continue
+		}
+		terminal := isItemDone(item.Fields, item.CollectionID, ctxMap)
+		if terminal && !includeTerminal {
+			continue
+		}
+		var fields map[string]any
+		_ = json.Unmarshal([]byte(item.Fields), &fields)
+		status, _ := fields["status"].(string)
+		refByID[item.ID] = item.Ref
+		nodeIdx[item.ID] = len(resp.Nodes)
+		resp.Nodes = append(resp.Nodes, GraphNode{
+			Ref:        item.Ref,
+			Title:      item.Title,
+			Collection: item.CollectionSlug,
+			Status:     status,
+			IsTerminal: terminal,
+			UpdatedAt:  item.UpdatedAt,
+		})
+	}
+
+	for _, l := range links {
+		srcRef, srcOK := refByID[l.SourceID]
+		tgtRef, tgtOK := refByID[l.TargetID]
+		if !srcOK || !tgtOK {
+			continue
+		}
+		resp.Edges = append(resp.Edges, GraphEdge{Source: srcRef, Target: tgtRef, Type: l.Type})
+		// Child counts derive from the edge list: 'parent' and
+		// 'implements' both render as children in the existing UI
+		// surfaces (see wiki_links_test.go's lineage note).
+		if l.Type == "parent" || l.Type == "implements" {
+			resp.Nodes[nodeIdx[l.TargetID]].ChildCount++
+		}
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}

--- a/internal/server/handlers_graph_test.go
+++ b/internal/server/handlers_graph_test.go
@@ -1,0 +1,209 @@
+package server
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// helper: fetch the workspace graph and return the parsed response
+func getGraph(t *testing.T, srv *Server, wsSlug, query string) GraphResponse {
+	t.Helper()
+	rr := doRequest(srv, "GET", "/api/v1/workspaces/"+wsSlug+"/graph"+query, nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("graph: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var resp GraphResponse
+	parseJSON(t, rr, &resp)
+	return resp
+}
+
+func graphNode(resp GraphResponse, ref string) *GraphNode {
+	for i := range resp.Nodes {
+		if resp.Nodes[i].Ref == ref {
+			return &resp.Nodes[i]
+		}
+	}
+	return nil
+}
+
+func hasGraphEdge(resp GraphResponse, source, target, typ string) bool {
+	for _, e := range resp.Edges {
+		if e.Source == source && e.Target == target && e.Type == typ {
+			return true
+		}
+	}
+	return false
+}
+
+func TestGraphEmpty(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	resp := getGraph(t, srv, slug, "")
+	if len(resp.Nodes) != 0 {
+		t.Errorf("expected 0 nodes, got %d", len(resp.Nodes))
+	}
+	if len(resp.Edges) != 0 {
+		t.Errorf("expected 0 edges, got %d", len(resp.Edges))
+	}
+
+	// Arrays must serialize as [], not null.
+	rr := doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/graph", nil)
+	body := rr.Body.String()
+	if body == "" || body[0] != '{' {
+		t.Fatalf("unexpected body: %s", body)
+	}
+	for _, frag := range []string{`"nodes":[]`, `"edges":[]`} {
+		if !strings.Contains(body, frag) {
+			t.Errorf("expected body to contain %s, got %s", frag, body)
+		}
+	}
+}
+
+func TestGraphNodesAndTypedEdges(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	plan := createItem(t, srv, slug, "plans", map[string]interface{}{
+		"title": "Graph plan", "fields": map[string]interface{}{"status": "active"},
+	})
+	task := createItem(t, srv, slug, "tasks", map[string]interface{}{
+		"title": "Graph child task", "fields": map[string]interface{}{"status": "open"},
+	})
+	blocked := createItem(t, srv, slug, "tasks", map[string]interface{}{
+		"title": "Blocked task", "fields": map[string]interface{}{"status": "open"},
+	})
+
+	// task is a child of plan
+	rr := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/items/"+task.Slug+"/links", map[string]interface{}{
+		"target_id": plan.ID, "link_type": "parent",
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create parent link: expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+	// task blocks blocked
+	createBlocksLink(t, srv, slug, task.Slug, blocked.ID)
+
+	resp := getGraph(t, srv, slug, "")
+	if len(resp.Nodes) != 3 {
+		t.Fatalf("expected 3 nodes, got %d: %+v", len(resp.Nodes), resp.Nodes)
+	}
+
+	pn := graphNode(resp, plan.Ref)
+	if pn == nil {
+		t.Fatalf("plan node %s missing", plan.Ref)
+	}
+	if pn.Collection != "plans" {
+		t.Errorf("expected plan node collection=plans, got %s", pn.Collection)
+	}
+	if pn.Status != "active" {
+		t.Errorf("expected plan node status=active, got %s", pn.Status)
+	}
+	if pn.IsTerminal {
+		t.Errorf("expected plan node is_terminal=false")
+	}
+	if pn.ChildCount != 1 {
+		t.Errorf("expected plan child_count=1, got %d", pn.ChildCount)
+	}
+	tn := graphNode(resp, task.Ref)
+	if tn == nil || tn.ChildCount != 0 {
+		t.Errorf("expected task node with child_count=0, got %+v", tn)
+	}
+
+	if !hasGraphEdge(resp, task.Ref, plan.Ref, "parent") {
+		t.Errorf("expected parent edge %s -> %s, edges: %+v", task.Ref, plan.Ref, resp.Edges)
+	}
+	if !hasGraphEdge(resp, task.Ref, blocked.Ref, "blocks") {
+		t.Errorf("expected blocks edge %s -> %s, edges: %+v", task.Ref, blocked.Ref, resp.Edges)
+	}
+}
+
+func TestGraphWikiLinkEdges(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	target := createItem(t, srv, slug, "tasks", map[string]interface{}{
+		"title": "Wiki target", "fields": map[string]interface{}{"status": "open"},
+	})
+	// Mention the target by ref twice — must still produce ONE edge.
+	source := createItem(t, srv, slug, "docs", map[string]interface{}{
+		"title":   "Wiki source",
+		"content": "See [[" + target.Ref + "]] and again [[" + target.Ref + "]].",
+	})
+
+	resp := getGraph(t, srv, slug, "")
+	count := 0
+	for _, e := range resp.Edges {
+		if e.Source == source.Ref && e.Target == target.Ref && e.Type == "wiki-link" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected exactly 1 wiki-link edge %s -> %s, got %d (edges: %+v)",
+			source.Ref, target.Ref, count, resp.Edges)
+	}
+}
+
+func TestGraphTerminalFiltering(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	open := createItem(t, srv, slug, "tasks", map[string]interface{}{
+		"title": "Open task", "fields": map[string]interface{}{"status": "open"},
+	})
+	done := createItem(t, srv, slug, "tasks", map[string]interface{}{
+		"title": "Done task", "fields": map[string]interface{}{"status": "done"},
+	})
+	// Edge between them — must disappear with the terminal node.
+	createBlocksLink(t, srv, slug, done.Slug, open.ID)
+
+	resp := getGraph(t, srv, slug, "")
+	if graphNode(resp, open.Ref) == nil {
+		t.Errorf("expected open task %s in default graph", open.Ref)
+	}
+	if graphNode(resp, done.Ref) != nil {
+		t.Errorf("expected done task %s filtered from default graph", done.Ref)
+	}
+	if len(resp.Edges) != 0 {
+		t.Errorf("expected edges to terminal nodes filtered, got %+v", resp.Edges)
+	}
+
+	full := getGraph(t, srv, slug, "?include_terminal=true")
+	dn := graphNode(full, done.Ref)
+	if dn == nil {
+		t.Fatalf("expected done task %s with include_terminal=true", done.Ref)
+	}
+	if !dn.IsTerminal {
+		t.Errorf("expected done task is_terminal=true")
+	}
+	if !hasGraphEdge(full, done.Ref, open.Ref, "blocks") {
+		t.Errorf("expected blocks edge restored with include_terminal=true, edges: %+v", full.Edges)
+	}
+}
+
+func TestGraphExcludesDeletedItems(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	keep := createItem(t, srv, slug, "tasks", map[string]interface{}{
+		"title": "Kept task", "fields": map[string]interface{}{"status": "open"},
+	})
+	gone := createItem(t, srv, slug, "tasks", map[string]interface{}{
+		"title": "Deleted task", "fields": map[string]interface{}{"status": "open"},
+	})
+	createBlocksLink(t, srv, slug, keep.Slug, gone.ID)
+
+	rr := doRequest(srv, "DELETE", "/api/v1/workspaces/"+slug+"/items/"+gone.Slug, nil)
+	if rr.Code != http.StatusOK && rr.Code != http.StatusNoContent {
+		t.Fatalf("delete item: expected 200/204, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	resp := getGraph(t, srv, slug, "")
+	if graphNode(resp, gone.Ref) != nil {
+		t.Errorf("expected deleted item %s excluded", gone.Ref)
+	}
+	if len(resp.Edges) != 0 {
+		t.Errorf("expected edges to deleted items excluded, got %+v", resp.Edges)
+	}
+}

--- a/internal/server/handlers_graph_test.go
+++ b/internal/server/handlers_graph_test.go
@@ -84,6 +84,14 @@ func TestGraphNodesAndTypedEdges(t *testing.T) {
 	}
 	// task blocks blocked
 	createBlocksLink(t, srv, slug, task.Slug, blocked.ID)
+	// blocked split from plan — stored as split_from, must surface
+	// hyphenated per the advertised edge vocabulary.
+	rr2 := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/items/"+blocked.Slug+"/links", map[string]interface{}{
+		"target_id": plan.ID, "link_type": "split_from",
+	})
+	if rr2.Code != http.StatusCreated {
+		t.Fatalf("create split_from link: expected 201, got %d: %s", rr2.Code, rr2.Body.String())
+	}
 
 	resp := getGraph(t, srv, slug, "")
 	if len(resp.Nodes) != 3 {
@@ -117,6 +125,9 @@ func TestGraphNodesAndTypedEdges(t *testing.T) {
 	if !hasGraphEdge(resp, task.Ref, blocked.Ref, "blocks") {
 		t.Errorf("expected blocks edge %s -> %s, edges: %+v", task.Ref, blocked.Ref, resp.Edges)
 	}
+	if !hasGraphEdge(resp, blocked.Ref, plan.Ref, "split-from") {
+		t.Errorf("expected split-from edge %s -> %s, edges: %+v", blocked.Ref, plan.Ref, resp.Edges)
+	}
 }
 
 func TestGraphWikiLinkEdges(t *testing.T) {
@@ -131,6 +142,14 @@ func TestGraphWikiLinkEdges(t *testing.T) {
 		"title":   "Wiki source",
 		"content": "See [[" + target.Ref + "]] and again [[" + target.Ref + "]].",
 	})
+	// A stored wiki_link item_links row for the same pair normalizes to
+	// the same 'wiki-link' type and must dedupe with the parsed mention.
+	rr := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/items/"+source.Slug+"/links", map[string]interface{}{
+		"target_id": target.ID, "link_type": "wiki_link",
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create wiki_link link: expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
 
 	resp := getGraph(t, srv, slug, "")
 	count := 0

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1238,6 +1238,12 @@ func (s *Server) setupRouter() {
 					// Dashboard (v2)
 					r.Get("/dashboard", s.handleGetDashboard)
 
+					// Workspace graph — {nodes, edges} for the 3D
+					// graph view (PLAN-1730 / TASK-1731). Active
+					// items by default; ?include_terminal=true for
+					// the full history.
+					r.Get("/graph", s.handleGetWorkspaceGraph)
+
 					// Project report — windowed throughput/flow/status
 					// stats (PLAN-1628 / TASK-1630).
 					r.Get("/report", s.handleGetReport)

--- a/internal/store/graph.go
+++ b/internal/store/graph.go
@@ -2,6 +2,8 @@ package store
 
 import (
 	"fmt"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 // GraphLink is one typed edge in the workspace graph
@@ -14,21 +16,27 @@ type GraphLink struct {
 	Type     string // hyphenated graph edge type — see graphEdgeType
 }
 
-// graphEdgeType maps a stored item_links.link_type (canonical
-// underscore forms per models.NormalizeItemLinkType) to the
-// hyphenated edge vocabulary the graph API advertises. Synthesized
-// wiki-link edges from item_wiki_links use the same 'wiki-link'
-// spelling as stored wiki_link rows so the client sees one type.
-// Unknown future types pass through lowercased as-is rather than
-// being dropped — a renderer can still draw them as generic edges.
+// graphEdgeType maps a stored item_links.link_type to the hyphenated
+// edge vocabulary the graph API advertises. Stored values are first
+// canonicalized through models.NormalizeItemLinkType (handles aliases
+// and casing); anything it rejects — possible via the import path,
+// which inserts link types without a DB CHECK — degrades to 'related'
+// so the advertised enum stays closed while the edge still renders as
+// a generic relationship. Synthesized wiki-link edges from
+// item_wiki_links use the same 'wiki-link' spelling as stored
+// wiki_link rows so the client sees one type.
 func graphEdgeType(linkType string) string {
-	switch linkType {
-	case "wiki_link":
+	canonical, err := models.NormalizeItemLinkType(linkType)
+	if err != nil {
+		return models.ItemLinkTypeRelated
+	}
+	switch canonical {
+	case models.ItemLinkTypeWikiLink:
 		return "wiki-link"
-	case "split_from":
+	case models.ItemLinkTypeSplitFrom:
 		return "split-from"
 	default:
-		return linkType
+		return canonical
 	}
 }
 

--- a/internal/store/graph.go
+++ b/internal/store/graph.go
@@ -11,7 +11,25 @@ import (
 type GraphLink struct {
 	SourceID string
 	TargetID string
-	Type     string // 'parent' | 'blocks' | 'implements' | 'related' | 'wiki-link'
+	Type     string // hyphenated graph edge type — see graphEdgeType
+}
+
+// graphEdgeType maps a stored item_links.link_type (canonical
+// underscore forms per models.NormalizeItemLinkType) to the
+// hyphenated edge vocabulary the graph API advertises. Synthesized
+// wiki-link edges from item_wiki_links use the same 'wiki-link'
+// spelling as stored wiki_link rows so the client sees one type.
+// Unknown future types pass through lowercased as-is rather than
+// being dropped — a renderer can still draw them as generic edges.
+func graphEdgeType(linkType string) string {
+	switch linkType {
+	case "wiki_link":
+		return "wiki-link"
+	case "split_from":
+		return "split-from"
+	default:
+		return linkType
+	}
 }
 
 // ListWorkspaceGraphLinks returns every edge for the workspace graph view:
@@ -47,6 +65,7 @@ func (s *Store) ListWorkspaceGraphLinks(workspaceID string) ([]GraphLink, error)
 		if err := rows.Scan(&l.SourceID, &l.TargetID, &l.Type); err != nil {
 			return nil, fmt.Errorf("scan graph item link: %w", err)
 		}
+		l.Type = graphEdgeType(l.Type)
 		links = append(links, l)
 	}
 	if err := rows.Err(); err != nil {
@@ -78,5 +97,21 @@ func (s *Store) ListWorkspaceGraphLinks(workspaceID string) ([]GraphLink, error)
 		}
 		links = append(links, l)
 	}
-	return links, wikiRows.Err()
+	if err := wikiRows.Err(); err != nil {
+		return nil, err
+	}
+
+	// Dedupe (source, target, type) — a stored wiki_link item_links row
+	// and a parsed [[...]] mention of the same pair both normalize to
+	// 'wiki-link' and would otherwise emit twice.
+	seen := make(map[GraphLink]bool, len(links))
+	deduped := links[:0]
+	for _, l := range links {
+		if seen[l] {
+			continue
+		}
+		seen[l] = true
+		deduped = append(deduped, l)
+	}
+	return deduped, nil
 }

--- a/internal/store/graph.go
+++ b/internal/store/graph.go
@@ -1,0 +1,82 @@
+package store
+
+import (
+	"fmt"
+)
+
+// GraphLink is one typed edge in the workspace graph
+// (GET /workspaces/{ws}/graph — PLAN-1730 / TASK-1731). Source and
+// target are item IDs; the handler maps them to refs and applies
+// visibility filtering before they leave the server.
+type GraphLink struct {
+	SourceID string
+	TargetID string
+	Type     string // 'parent' | 'blocks' | 'implements' | 'related' | 'wiki-link'
+}
+
+// ListWorkspaceGraphLinks returns every edge for the workspace graph view:
+// all item_links rows (parent / blocks / implements / related) plus
+// resolved same-workspace wiki-links from the item_wiki_links reverse
+// index (PLAN-1593).
+//
+// Both queries exclude edges whose source or target item is soft-deleted,
+// matching GetParentMap's posture (BUG-734) — a dangling edge to an
+// archived item would render as a node the items query never returned.
+//
+// Wiki-link rows are deduplicated per (source, target) pair — an item
+// that mentions [[TASK-5]] three times is still one edge — and
+// self-links are dropped (an item linking to itself adds noise, not
+// structure). Unresolved rows (target_item_id IS NULL) and
+// cross-workspace rows are excluded: the graph renders one workspace.
+func (s *Store) ListWorkspaceGraphLinks(workspaceID string) ([]GraphLink, error) {
+	links := []GraphLink{}
+
+	rows, err := s.db.Query(s.q(`
+		SELECT il.source_id, il.target_id, il.link_type
+		FROM item_links il
+		JOIN items src ON src.id = il.source_id AND src.deleted_at IS NULL
+		JOIN items tgt ON tgt.id = il.target_id AND tgt.deleted_at IS NULL
+		WHERE il.workspace_id = ?
+	`), workspaceID)
+	if err != nil {
+		return nil, fmt.Errorf("list graph item links: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var l GraphLink
+		if err := rows.Scan(&l.SourceID, &l.TargetID, &l.Type); err != nil {
+			return nil, fmt.Errorf("scan graph item link: %w", err)
+		}
+		links = append(links, l)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	// Wiki-link edges. Scoped by the SOURCE item's workspace —
+	// item_wiki_links has no workspace_id column of its own, and
+	// target_workspace_id is only set on cross-workspace rows (which
+	// are excluded here anyway).
+	wikiRows, err := s.db.Query(s.q(`
+		SELECT DISTINCT wl.source_item_id, wl.target_item_id
+		FROM item_wiki_links wl
+		JOIN items src ON src.id = wl.source_item_id AND src.deleted_at IS NULL
+		JOIN items tgt ON tgt.id = wl.target_item_id AND tgt.deleted_at IS NULL
+		WHERE src.workspace_id = ?
+		  AND wl.target_item_id IS NOT NULL
+		  AND wl.target_workspace_id IS NULL
+		  AND wl.source_item_id != wl.target_item_id
+	`), workspaceID)
+	if err != nil {
+		return nil, fmt.Errorf("list graph wiki links: %w", err)
+	}
+	defer wikiRows.Close()
+	for wikiRows.Next() {
+		l := GraphLink{Type: "wiki-link"}
+		if err := wikiRows.Scan(&l.SourceID, &l.TargetID); err != nil {
+			return nil, fmt.Errorf("scan graph wiki link: %w", err)
+		}
+		links = append(links, l)
+	}
+	return links, wikiRows.Err()
+}


### PR DESCRIPTION
## Summary
New `GET /api/v1/workspaces/{ws}/graph` endpoint returning the whole workspace as `{nodes, edges}` in one call — the data layer for the 3D graph view (PLAN-1730).

- **Nodes:** ref, title, collection slug, status, `is_terminal` (per-collection done rules via the dashboard's done-context map), `child_count`, `updated_at`. Active items by default; `?include_terminal=true` for full history.
- **Edges:** typed — `parent` / `blocks` / `implements` / `related` from `item_links`, plus `wiki-link` from the PLAN-1593 reverse index (resolved same-workspace rows only, deduped per pair, self-links dropped).
- **Visibility:** mirrors the dashboard model (collection visibility + guest item-level grants); edges are filtered to the visible node set so hidden items can't be inferred from dangling endpoints.

## Context
Implements `TASK-1731` under `PLAN-1730` (3D workspace graph view). First of 8 tasks; TS types + client surfaces follow in TASK-1732.

## Test plan
- [x] go build ./... / go vet ./... — clean
- [x] go test ./... — all pass, incl. 5 new handler tests (shape, typed edges, wiki-link dedup, terminal filtering, deleted-item exclusion)
- [x] make check (lint + vuln + tests + web build) — green