### PR TITLE
feat(web): graph TS types + API client method (TASK-1732)

### DIFF
--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -22,6 +22,7 @@ import type {
 	CommentCreate,
 	Version,
 	DashboardResponse,
+	GraphResponse,
 	ReportData,
 	ReportLayout,
 	ReportWindow,
@@ -974,6 +975,19 @@ export const api = {
 	dashboard: {
 		get: (ws: string) =>
 			request<DashboardResponse>(`/workspaces/${ws}/dashboard`)
+	},
+
+	// ── Workspace Graph (PLAN-1730 / TASK-1732) ───────────────────────────────
+
+	graph: {
+		/**
+		 * Whole-workspace graph: nodes + typed edges. Active items only by
+		 * default; includeTerminal=true returns the full history.
+		 */
+		get: (ws: string, includeTerminal = false) =>
+			request<GraphResponse>(
+				`/workspaces/${ws}/graph${includeTerminal ? '?include_terminal=true' : ''}`
+			)
 	},
 
 	// ── Project Report (PLAN-1628 / TASK-1630) ────────────────────────────────

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -971,6 +971,46 @@ export interface DashboardResponse {
 	};
 }
 
+// ─── Workspace Graph (PLAN-1730 / TASK-1732) ─────────────────────────────────
+
+/** One item in the workspace graph. Keyed by ref (e.g. "TASK-5"). */
+export interface GraphNode {
+	ref: string;
+	title: string;
+	/** collection slug */
+	collection: string;
+	status?: string;
+	/** true when the item is in a terminal status for its collection */
+	is_terminal: boolean;
+	/** number of child items (parent + implements links pointing here) */
+	child_count: number;
+	updated_at: string;
+}
+
+/**
+ * One typed relationship between two graph nodes. Source/target are
+ * refs. For 'parent', source is the child and target is the parent;
+ * for 'blocks', source blocks target.
+ */
+export interface GraphEdge {
+	source: string;
+	target: string;
+	type:
+		| 'parent'
+		| 'blocks'
+		| 'implements'
+		| 'related'
+		| 'split-from'
+		| 'supersedes'
+		| 'wiki-link';
+}
+
+/** GET /workspaces/{ws}/graph — the whole workspace as {nodes, edges}. */
+export interface GraphResponse {
+	nodes: GraphNode[];
+	edges: GraphEdge[];
+}
+
 // ─── Project Report (PLAN-1628 / TASK-1630) ──────────────────────────────────
 
 export type ReportWindow = 'day' | 'week' | '2wk' | 'month';


### PR DESCRIPTION
## Summary
TypeScript surfaces for the workspace graph endpoint shipped in #699: `GraphNode` / `GraphEdge` / `GraphResponse` in `web/src/lib/types/index.ts`, and `apiClient.graph.get(ws, includeTerminal)` in `web/src/lib/api/client.ts`.

Scope note: deliberately web-only — no CLI command or MCP action (the payload is a rendering data feed for the upcoming `/graph` route, not an agent surface).

## Context
Implements `TASK-1732` under `PLAN-1730`. Consumed by TASK-1733 (`/graph` route MVP) next.

## Test plan
- [x] cd web && npm run build — clean
- [x] go build ./... — untouched (no Go changes)