### PR TITLE
fix(web): collection cards show real child-item progress; child-progress endpoint (BUG-1509)

### DIFF
--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -1715,8 +1715,9 @@ func (s *Server) collectionChildrenProgress(
 	visibleIDs []string,
 	fullCollIDs []string,
 	grantedItemIDs []string,
+	includeArchived bool,
 ) ([]store.ItemProgress, error) {
-	allProgress, err := s.store.GetAllItemProgress(workspaceID, collectionSlug)
+	allProgress, err := s.store.GetAllItemProgress(workspaceID, collectionSlug, includeArchived)
 	if err != nil {
 		return nil, err
 	}
@@ -1811,7 +1812,9 @@ func (s *Server) handlePlansProgress(w http.ResponseWriter, r *http.Request) {
 		if plansColl != nil {
 			collID = plansColl.ID
 		}
-		progress, err := s.collectionChildrenProgress(r, workspaceID, "plans", collID, visibleIDs, fullCollIDs, grantedItemIDs)
+		// /plans-progress does not support include_archived — plans are
+		// always queried without archived parents (false).
+		progress, err := s.collectionChildrenProgress(r, workspaceID, "plans", collID, visibleIDs, fullCollIDs, grantedItemIDs, false)
 		if err != nil {
 			writeInternalError(w, err)
 			return
@@ -1820,7 +1823,7 @@ func (s *Server) handlePlansProgress(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	progress, err := s.store.GetAllItemProgress(workspaceID, "plans")
+	progress, err := s.store.GetAllItemProgress(workspaceID, "plans", false)
 	if err != nil {
 		writeInternalError(w, err)
 		return
@@ -1829,9 +1832,11 @@ func (s *Server) handlePlansProgress(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleCollectionChildrenProgress returns child-item completion progress for
-// all non-deleted items in an arbitrary collection. It preserves the same
+// all items in an arbitrary collection. It preserves the same
 // visibility/guest-grant filtering semantics as handlePlansProgress so
 // restricted callers can't enumerate hidden child-item counts.
+// Supports ?include_archived=true to include soft-deleted parent rows,
+// matching the collection page's archived-items toggle.
 //
 // Route: GET /workspaces/{ws}/collections/{collSlug}/child-progress
 func (s *Server) handleCollectionChildrenProgress(w http.ResponseWriter, r *http.Request) {
@@ -1865,6 +1870,8 @@ func (s *Server) handleCollectionChildrenProgress(w http.ResponseWriter, r *http
 		return
 	}
 
+	includeArchived := r.URL.Query().Get("include_archived") == "true"
+
 	fullCollIDs, grantedItemIDs, grantErr := s.guestResourceFilter(r, workspaceID)
 	if grantErr != nil {
 		writeInternalError(w, grantErr)
@@ -1872,7 +1879,7 @@ func (s *Server) handleCollectionChildrenProgress(w http.ResponseWriter, r *http
 	}
 
 	if visibleIDs != nil {
-		progress, err := s.collectionChildrenProgress(r, workspaceID, collSlug, coll.ID, visibleIDs, fullCollIDs, grantedItemIDs)
+		progress, err := s.collectionChildrenProgress(r, workspaceID, collSlug, coll.ID, visibleIDs, fullCollIDs, grantedItemIDs, includeArchived)
 		if err != nil {
 			writeInternalError(w, err)
 			return
@@ -1881,7 +1888,7 @@ func (s *Server) handleCollectionChildrenProgress(w http.ResponseWriter, r *http
 		return
 	}
 
-	progress, err := s.store.GetAllItemProgress(workspaceID, collSlug)
+	progress, err := s.store.GetAllItemProgress(workspaceID, collSlug, includeArchived)
 	if err != nil {
 		writeInternalError(w, err)
 		return

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -1692,99 +1692,196 @@ func (s *Server) handleCollectionCheckboxProgress(w http.ResponseWriter, r *http
 	writeJSON(w, http.StatusOK, progress)
 }
 
-// handlePlansProgress returns child item completion progress for all non-deleted plans.
-// This is a backward-compat endpoint; the general form is per-item via /items/{slug}/children.
+// collectionChildrenProgress is the shared implementation for child-item
+// completion progress across any collection. It enforces the same
+// visibility/guest-grant filtering that the plans-specific path did,
+// generalised to an arbitrary collectionSlug.
+//
+// The caller is responsible for verifying that the collection exists and is
+// visible before calling this helper — the helper does NOT write HTTP
+// responses.
+//
+// N+1 note: the restricted-visibility recompute path issues one GetChildItems
+// query per parent item. For large collections (e.g. tasks with hundreds of
+// items and a guest caller) this can be expensive. The plans endpoint shared
+// the same trade-off; it was tolerable for small plan sets. Fixing this
+// requires a single-query recompute (e.g. a bulk join limited to visible
+// child collections) — tracked as a known limitation, deferred.
+func (s *Server) collectionChildrenProgress(
+	r *http.Request,
+	workspaceID string,
+	collectionSlug string,
+	collectionID string,
+	visibleIDs []string,
+	fullCollIDs []string,
+	grantedItemIDs []string,
+) ([]store.ItemProgress, error) {
+	allProgress, err := s.store.GetAllItemProgress(workspaceID, collectionSlug)
+	if err != nil {
+		return nil, err
+	}
+
+	// For guests with item-level grants, filter the parent items themselves
+	// so callers without a grant to a specific parent don't see its row.
+	if len(grantedItemIDs) > 0 {
+		grantedSet := make(map[string]bool, len(grantedItemIDs))
+		for _, id := range grantedItemIDs {
+			grantedSet[id] = true
+		}
+		fullSet := make(map[string]bool, len(fullCollIDs))
+		for _, id := range fullCollIDs {
+			fullSet[id] = true
+		}
+		// Check if this collection has a full grant (bypass item-level filter).
+		if !fullSet[collectionID] {
+			filtered := allProgress[:0]
+			for _, p := range allProgress {
+				if grantedSet[p.ItemID] {
+					filtered = append(filtered, p)
+				}
+			}
+			allProgress = filtered
+		}
+	}
+
+	// Build a done-context map once so each child is evaluated against its
+	// own collection's configured done field, not a global default.
+	// ListCollectionsMinimal avoids the per-collection COUNT queries that
+	// ListCollections would run — we only need schema + settings.
+	wsCollections, _ := s.store.ListCollectionsMinimal(workspaceID)
+	ctxMap := buildDoneContextMap(wsCollections)
+
+	// Recompute each parent's progress using only visible children so hidden
+	// child counts don't leak through the aggregate totals.
+	for i, p := range allProgress {
+		children, cerr := s.store.GetChildItems(p.ItemID)
+		if cerr != nil {
+			continue
+		}
+		total, done := 0, 0
+		for _, child := range children {
+			if !isCollectionVisible(child.CollectionID, visibleIDs) {
+				continue
+			}
+			if !s.isItemVisibleToGuest(r, workspaceID, &child, fullCollIDs, grantedItemIDs) {
+				continue
+			}
+			total++
+			if isItemDone(child.Fields, child.CollectionID, ctxMap) {
+				done++
+			}
+		}
+		allProgress[i].Total = total
+		allProgress[i].Done = done
+	}
+	return allProgress, nil
+}
+
+// handlePlansProgress returns child item completion progress for all
+// non-deleted plans. Kept as a backward-compat endpoint at /plans-progress;
+// delegates to collectionChildrenProgress for the shared visibility logic.
 func (s *Server) handlePlansProgress(w http.ResponseWriter, r *http.Request) {
 	workspaceID, ok := s.getWorkspaceID(w, r)
 	if !ok {
 		return
 	}
 
-	// Check that the plans collection is visible to this user
 	visibleIDs, err := s.visibleCollectionIDs(r, workspaceID)
 	if err != nil {
 		writeInternalError(w, err)
 		return
 	}
-	ppFullCollIDs, ppGrantedItemIDs, ppGrantErr := s.guestResourceFilter(r, workspaceID)
-	if ppGrantErr != nil {
-		writeInternalError(w, ppGrantErr)
+	fullCollIDs, grantedItemIDs, grantErr := s.guestResourceFilter(r, workspaceID)
+	if grantErr != nil {
+		writeInternalError(w, grantErr)
 		return
 	}
+
+	// Check that the plans collection is visible to this user.
+	plansColl, _ := s.store.GetCollectionBySlug(workspaceID, "plans")
 	if visibleIDs != nil {
-		plansColl, _ := s.store.GetCollectionBySlug(workspaceID, "plans")
 		if plansColl == nil || !isCollectionVisible(plansColl.ID, visibleIDs) {
 			writeJSON(w, http.StatusOK, []interface{}{})
 			return
 		}
 	}
 
-	// When user has restricted visibility, compute progress from visible
-	// children only so hidden child counts don't leak.
 	if visibleIDs != nil {
-		allProgress, err := s.store.GetAllItemProgress(workspaceID, "plans")
+		collID := ""
+		if plansColl != nil {
+			collID = plansColl.ID
+		}
+		progress, err := s.collectionChildrenProgress(r, workspaceID, "plans", collID, visibleIDs, fullCollIDs, grantedItemIDs)
 		if err != nil {
 			writeInternalError(w, err)
 			return
 		}
-
-		// For guests with item-level grants, filter plans themselves
-		if len(ppGrantedItemIDs) > 0 {
-			ppGrantedSet := make(map[string]bool, len(ppGrantedItemIDs))
-			for _, id := range ppGrantedItemIDs {
-				ppGrantedSet[id] = true
-			}
-			ppFullSet := make(map[string]bool, len(ppFullCollIDs))
-			for _, id := range ppFullCollIDs {
-				ppFullSet[id] = true
-			}
-			// Check if plans collection has a full grant
-			plansColl, _ := s.store.GetCollectionBySlug(workspaceID, "plans")
-			if plansColl != nil && !ppFullSet[plansColl.ID] {
-				filtered := allProgress[:0]
-				for _, p := range allProgress {
-					if ppGrantedSet[p.ItemID] {
-						filtered = append(filtered, p)
-					}
-				}
-				allProgress = filtered
-			}
-		}
-
-		// Build a done-context map once so each child is evaluated against
-		// its own collection's configured done field, not a global default.
-		// ListCollectionsMinimal avoids the per-collection COUNT queries
-		// that ListCollections would run — we only need schema + settings.
-		wsCollections, _ := s.store.ListCollectionsMinimal(workspaceID)
-		ctxMap := buildDoneContextMap(wsCollections)
-
-		// Recompute each plan's progress using only visible children
-		for i, p := range allProgress {
-			children, cerr := s.store.GetChildItems(p.ItemID)
-			if cerr != nil {
-				continue
-			}
-			total, done := 0, 0
-			for _, child := range children {
-				if !isCollectionVisible(child.CollectionID, visibleIDs) {
-					continue
-				}
-				if !s.isItemVisibleToGuest(r, workspaceID, &child, ppFullCollIDs, ppGrantedItemIDs) {
-					continue
-				}
-				total++
-				if isItemDone(child.Fields, child.CollectionID, ctxMap) {
-					done++
-				}
-			}
-			allProgress[i].Total = total
-			allProgress[i].Done = done
-		}
-		writeJSON(w, http.StatusOK, allProgress)
+		writeJSON(w, http.StatusOK, progress)
 		return
 	}
 
 	progress, err := s.store.GetAllItemProgress(workspaceID, "plans")
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, progress)
+}
+
+// handleCollectionChildrenProgress returns child-item completion progress for
+// all non-deleted items in an arbitrary collection. It preserves the same
+// visibility/guest-grant filtering semantics as handlePlansProgress so
+// restricted callers can't enumerate hidden child-item counts.
+//
+// Route: GET /workspaces/{ws}/collections/{collSlug}/child-progress
+func (s *Server) handleCollectionChildrenProgress(w http.ResponseWriter, r *http.Request) {
+	workspaceID, ok := s.getWorkspaceID(w, r)
+	if !ok {
+		return
+	}
+
+	collSlug := chi.URLParam(r, "collSlug")
+	coll, err := s.store.GetCollectionBySlug(workspaceID, collSlug)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	if coll == nil {
+		writeError(w, http.StatusNotFound, "not_found", "Collection not found")
+		return
+	}
+
+	// Collection-visibility gate: a restricted user without visibility into
+	// this collection must receive the same empty/denied shape they'd get
+	// from any other guarded endpoint — not child counts for a hidden
+	// collection.
+	visibleIDs, err := s.visibleCollectionIDs(r, workspaceID)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	if visibleIDs != nil && !isCollectionVisible(coll.ID, visibleIDs) {
+		writeJSON(w, http.StatusOK, []interface{}{})
+		return
+	}
+
+	fullCollIDs, grantedItemIDs, grantErr := s.guestResourceFilter(r, workspaceID)
+	if grantErr != nil {
+		writeInternalError(w, grantErr)
+		return
+	}
+
+	if visibleIDs != nil {
+		progress, err := s.collectionChildrenProgress(r, workspaceID, collSlug, coll.ID, visibleIDs, fullCollIDs, grantedItemIDs)
+		if err != nil {
+			writeInternalError(w, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, progress)
+		return
+	}
+
+	progress, err := s.store.GetAllItemProgress(workspaceID, collSlug)
 	if err != nil {
 		writeInternalError(w, err)
 		return

--- a/internal/server/handlers_items_test.go
+++ b/internal/server/handlers_items_test.go
@@ -2007,3 +2007,168 @@ func firstID(items []models.Item) string {
 	}
 	return items[0].ID
 }
+
+// TestCollectionChildProgress covers the /collections/{coll}/child-progress
+// endpoint introduced in BUG-1509. It verifies:
+//   - Happy path: items with linked children show correct total/done counts.
+//   - Items without linked children appear with total=0, done=0.
+//   - Unknown collection → 404.
+//   - Empty collection → 200 + [].
+//   - Visibility gate: a restricted member without access to the collection
+//     receives an empty response (not child counts for a hidden collection).
+func TestCollectionChildProgress(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	// Resolve workspace for direct store calls.
+	ws, err := srv.store.GetWorkspaceBySlug(slug)
+	if err != nil || ws == nil {
+		t.Fatalf("GetWorkspaceBySlug: %v", err)
+	}
+
+	// ── Happy path setup ─────────────────────────────────────────────────────
+
+	// parentA: a task with two linked children (one done, one open).
+	rr := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections/tasks/items", map[string]interface{}{
+		"title":  "Parent A",
+		"fields": `{"status":"open"}`,
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create parentA: expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var parentA models.Item
+	parseJSON(t, rr, &parentA)
+
+	rr = doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections/tasks/items", map[string]interface{}{
+		"title":  "Child Done",
+		"fields": `{"status":"done"}`,
+	})
+	var childDone models.Item
+	parseJSON(t, rr, &childDone)
+
+	rr = doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections/tasks/items", map[string]interface{}{
+		"title":  "Child Open",
+		"fields": `{"status":"open"}`,
+	})
+	var childOpen models.Item
+	parseJSON(t, rr, &childOpen)
+
+	// Link both children to parentA via "parent" link type.
+	for _, child := range []models.Item{childDone, childOpen} {
+		rr = doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/items/"+child.Slug+"/links", map[string]interface{}{
+			"target_id": parentA.ID,
+			"link_type": models.ItemLinkTypeParent,
+		})
+		if rr.Code != http.StatusCreated {
+			t.Fatalf("create parent link for %s: expected 201, got %d: %s", child.Title, rr.Code, rr.Body.String())
+		}
+	}
+
+	// parentB: a task with no linked children (checkbox-only control).
+	rr = doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections/tasks/items", map[string]interface{}{
+		"title":   "Parent B — checkboxes only",
+		"content": "- [ ] alpha\n- [x] beta\n",
+		"fields":  `{"status":"open"}`,
+	})
+	var parentB models.Item
+	parseJSON(t, rr, &parentB)
+
+	// ── Happy path assertions ─────────────────────────────────────────────────
+
+	type progressRow struct {
+		ItemID string `json:"item_id"`
+		Total  int    `json:"total"`
+		Done   int    `json:"done"`
+	}
+
+	rr = doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/collections/tasks/child-progress", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("child-progress: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var rows []progressRow
+	parseJSON(t, rr, &rows)
+
+	byID := map[string]progressRow{}
+	for _, r := range rows {
+		byID[r.ItemID] = r
+	}
+
+	// parentA must have total=2 (two linked children), done=1 (childDone).
+	if r, ok := byID[parentA.ID]; !ok {
+		t.Fatalf("parentA missing from child-progress response")
+	} else if r.Total != 2 || r.Done != 1 {
+		t.Fatalf("parentA: expected total=2, done=1; got total=%d, done=%d", r.Total, r.Done)
+	}
+
+	// parentB has no linked children → total=0, done=0 (present, but zero).
+	if r, ok := byID[parentB.ID]; !ok {
+		t.Fatalf("parentB missing from child-progress response (should be present with total=0)")
+	} else if r.Total != 0 || r.Done != 0 {
+		t.Fatalf("parentB: expected total=0, done=0; got total=%d, done=%d", r.Total, r.Done)
+	}
+
+	// ── Unknown collection → 404 ──────────────────────────────────────────────
+
+	rr = doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/collections/nonexistent/child-progress", nil)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for unknown collection, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	// ── Empty collection (ideas — no items, no children) → 200 + [] ──────────
+
+	rr = doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/collections/ideas/child-progress", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("child-progress empty: expected 200, got %d", rr.Code)
+	}
+	if !bytes.Contains(rr.Body.Bytes(), []byte(`[]`)) {
+		t.Fatalf("expected empty array for ideas, got %s", rr.Body.String())
+	}
+
+	// ── Visibility gate: restricted member without tasks access ───────────────
+	// Create a regular member, restrict them to only the "ideas" collection,
+	// then confirm that GET /child-progress for "tasks" returns [] (not a
+	// data leak of parentA's child counts).
+
+	restrictedUser, err := srv.store.CreateUser(models.UserCreate{
+		Email: "restricted@example.com", Name: "Restricted", Username: "restricted-user",
+		Password: "pw-test-12345",
+	})
+	if err != nil {
+		t.Fatalf("CreateUser restricted: %v", err)
+	}
+	if err := srv.store.AddWorkspaceMember(ws.ID, restrictedUser.ID, "editor"); err != nil {
+		t.Fatalf("AddWorkspaceMember: %v", err)
+	}
+
+	// Resolve ideas collection ID for the access grant via the store directly
+	// (the HTTP endpoint may require auth once a workspace owner exists).
+	ideasColl, err := srv.store.GetCollectionBySlug(ws.ID, "ideas")
+	if err != nil || ideasColl == nil {
+		t.Fatalf("GetCollectionBySlug ideas: %v", err)
+	}
+
+	if err := srv.store.SetMemberCollectionAccess(ws.ID, restrictedUser.ID, "specific", []string{ideasColl.ID}); err != nil {
+		t.Fatalf("SetMemberCollectionAccess: %v", err)
+	}
+	token, err := srv.store.CreateSession(restrictedUser.ID, "go-test", "192.0.2.1", "", 24*time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	// Restricted user must get an empty response for tasks, not parentA's data.
+	rr = doRequestWithCookie(srv, "GET", "/api/v1/workspaces/"+slug+"/collections/tasks/child-progress", nil, token)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("restricted/tasks child-progress: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var restricted []progressRow
+	parseJSON(t, rr, &restricted)
+	if len(restricted) != 0 {
+		t.Fatalf("restricted member should see no task child-progress; got %d rows: %+v", len(restricted), restricted)
+	}
+
+	// Restricted user CAN see ideas (within their grant).
+	rr = doRequestWithCookie(srv, "GET", "/api/v1/workspaces/"+slug+"/collections/ideas/child-progress", nil, token)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("restricted/ideas child-progress: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+}

--- a/internal/server/handlers_items_test.go
+++ b/internal/server/handlers_items_test.go
@@ -2124,6 +2124,45 @@ func TestCollectionChildProgress(t *testing.T) {
 		t.Fatalf("expected empty array for ideas, got %s", rr.Body.String())
 	}
 
+	// ── include_archived: archived parent with children ───────────────────────
+	// Archive parentA (soft-delete). Without include_archived it must
+	// disappear from the default response; with it the row reappears.
+
+	rr = doRequest(srv, "DELETE", "/api/v1/workspaces/"+slug+"/items/"+parentA.Slug, nil)
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("archive parentA: expected 204, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	// Default (no include_archived) — parentA must be absent.
+	rr = doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/collections/tasks/child-progress", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("child-progress after archive: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	rows = nil
+	parseJSON(t, rr, &rows)
+	for _, r := range rows {
+		if r.ItemID == parentA.ID {
+			t.Fatalf("archived parentA should not appear in default child-progress response")
+		}
+	}
+
+	// With include_archived=true — parentA must reappear with total=2, done=1.
+	rr = doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/collections/tasks/child-progress?include_archived=true", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("child-progress include_archived: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	rows = nil
+	parseJSON(t, rr, &rows)
+	byID = map[string]progressRow{}
+	for _, r := range rows {
+		byID[r.ItemID] = r
+	}
+	if r, ok := byID[parentA.ID]; !ok {
+		t.Fatalf("archived parentA missing from include_archived=true response")
+	} else if r.Total != 2 || r.Done != 1 {
+		t.Fatalf("archived parentA: expected total=2, done=1; got total=%d, done=%d", r.Total, r.Done)
+	}
+
 	// ── Visibility gate: restricted member without tasks access ───────────────
 	// Create a regular member, restrict them to only the "ideas" collection,
 	// then confirm that GET /child-progress for "tasks" returns [] (not a

--- a/internal/server/handlers_items_test.go
+++ b/internal/server/handlers_items_test.go
@@ -2163,6 +2163,107 @@ func TestCollectionChildProgress(t *testing.T) {
 		t.Fatalf("archived parentA: expected total=2, done=1; got total=%d, done=%d", r.Total, r.Done)
 	}
 
+	// ── include_archived: done-semantics must use archived parents' child
+	// collections (childrenDoneFiltersForCollection gap, codex round 3) ──────
+	//
+	// Create a custom "Widgets" collection whose done field is `state` with
+	// terminal value "shipped" — NOT the default `status` terminals. If
+	// childrenDoneFiltersForCollection still filters parents with
+	// `p.deleted_at IS NULL` while the main query includes archived parents,
+	// the widgets collection never enters the done-filter map, and the child
+	// done-check falls back to default status terminals → done=0 (bug).
+	// With the fix, the filter-discovery query also sees archived parents →
+	// widgets enters the map → done=1 (correct).
+	//
+	// Crucially: NO live task parent links into widgets. That would mask the
+	// bug by pulling widgets into the filter map via the live-parent path.
+
+	rr = doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections", map[string]interface{}{
+		"name": "Widgets",
+		// board_group_by=state causes TerminalValuesForDoneField to use the
+		// state field's terminal_options instead of the status field.
+		"schema":   `{"fields":[{"key":"state","label":"State","type":"select","options":["open","shipped"],"terminal_options":["shipped"],"default":"open"}]}`,
+		"settings": `{"board_group_by":"state"}`,
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create widgets collection: expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var widgetsColl models.Collection
+	parseJSON(t, rr, &widgetsColl)
+
+	// widgetDone: state=shipped → done under widgets' semantics.
+	rr = doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections/widgets/items", map[string]interface{}{
+		"title":  "Widget Done",
+		"fields": `{"state":"shipped"}`,
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create widget done: expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var widgetDone models.Item
+	parseJSON(t, rr, &widgetDone)
+
+	// widgetOpen: state=open → not done.
+	rr = doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections/widgets/items", map[string]interface{}{
+		"title":  "Widget Open",
+		"fields": `{"state":"open"}`,
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create widget open: expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var widgetOpen models.Item
+	parseJSON(t, rr, &widgetOpen)
+
+	// widgetParent: a task (in the tasks collection) that has NO live task
+	// children — only the two widget children. Will be archived immediately.
+	rr = doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections/tasks/items", map[string]interface{}{
+		"title":  "Widget Parent (tasks)",
+		"fields": `{"status":"done"}`,
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create widgetParent: expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var widgetParent models.Item
+	parseJSON(t, rr, &widgetParent)
+
+	// Link both widgets as children of widgetParent.
+	for _, w := range []models.Item{widgetDone, widgetOpen} {
+		rr = doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/items/"+w.Slug+"/links", map[string]interface{}{
+			"target_id": widgetParent.ID,
+			"link_type": models.ItemLinkTypeParent,
+		})
+		if rr.Code != http.StatusCreated {
+			t.Fatalf("link %s → widgetParent: expected 201, got %d: %s", w.Title, rr.Code, rr.Body.String())
+		}
+	}
+
+	// Archive widgetParent. Now NO live task parent links into widgets.
+	rr = doRequest(srv, "DELETE", "/api/v1/workspaces/"+slug+"/items/"+widgetParent.Slug, nil)
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("archive widgetParent: expected 204, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	// With include_archived=true: widgetParent must appear with total=2,
+	// done=1 (shipped widget). If childrenDoneFiltersForCollection still
+	// excludes archived parents, widgets drops from the filter map and the
+	// done check falls back to default status terminals — which would give
+	// done=0 because neither widget has a `status` field set to a terminal
+	// value (they have `state` instead). done=1 proves the fix is in effect.
+	rr = doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/collections/tasks/child-progress?include_archived=true", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("widgets include_archived: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	rows = nil
+	parseJSON(t, rr, &rows)
+	byID = map[string]progressRow{}
+	for _, r := range rows {
+		byID[r.ItemID] = r
+	}
+	if r, ok := byID[widgetParent.ID]; !ok {
+		t.Fatalf("archived widgetParent missing from include_archived=true response")
+	} else if r.Total != 2 || r.Done != 1 {
+		t.Fatalf("archived widgetParent: expected total=2 done=1 (state-based done); got total=%d done=%d (if done=0 the filter-discovery bug is live)", r.Total, r.Done)
+	}
+
 	// ── Visibility gate: restricted member without tasks access ───────────────
 	// Create a regular member, restrict them to only the "ideas" collection,
 	// then confirm that GET /child-progress for "tasks" returns [] (not a

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1070,6 +1070,10 @@ func (s *Server) setupRouter() {
 							// list/board/table progress badges without
 							// fetching item content (TASK-1349).
 							r.Get("/checkbox-progress", s.handleCollectionCheckboxProgress)
+							// Child-item completion progress for any collection
+							// (BUG-1509). Same visibility/guest-grant semantics
+							// as /plans-progress but collection-generic.
+							r.Get("/child-progress", s.handleCollectionChildrenProgress)
 							// Collection grants
 							r.Get("/grants", s.handleListCollectionGrants)
 							r.Post("/grants", s.handleCreateCollectionGrant)

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -2751,17 +2751,28 @@ func (s *Store) doneFiltersForWorkspace(workspaceID string) []collectionDoneFilt
 // childrenDoneFiltersForParent — callers count items regardless of their
 // collection's deleted_at, and we want items from soft-deleted
 // collections to still be evaluated against their own done rules.
-func (s *Store) childrenDoneFiltersForCollection(workspaceID, collectionSlug string) []collectionDoneFilter {
+//
+// includeArchived mirrors the same flag in GetAllItemProgress: when true,
+// the parent-row join does NOT filter out archived parents. This matters
+// because if a child collection's only parent links point to archived
+// parents, the collection would be absent from the filter map under the
+// live-only predicate — causing those children to fall back to default
+// done semantics and producing wrong done counts in the main query.
+func (s *Store) childrenDoneFiltersForCollection(workspaceID, collectionSlug string, includeArchived bool) []collectionDoneFilter {
+	parentDeletedFilter := "AND p.deleted_at IS NULL"
+	if includeArchived {
+		parentDeletedFilter = ""
+	}
 	rows, err := s.db.Query(s.q(fmt.Sprintf(`
 		SELECT DISTINCT c.id, c.schema, c.settings
 		FROM items t
 		JOIN collections c ON c.id = t.collection_id
 		JOIN item_links il ON il.source_id = t.id AND il.link_type IN (%s)
-		JOIN items p ON p.id = il.target_id AND p.deleted_at IS NULL
+		JOIN items p ON p.id = il.target_id %s
 		JOIN collections pc ON pc.id = p.collection_id AND pc.slug = ?
 		WHERE p.workspace_id = ?
 		  AND t.deleted_at IS NULL
-	`, childLinkTypeSQL())), collectionSlug, workspaceID)
+	`, childLinkTypeSQL(), parentDeletedFilter)), collectionSlug, workspaceID)
 	if err != nil {
 		return nil
 	}
@@ -2873,7 +2884,7 @@ type ItemProgress struct {
 // parents also appear — matching the archived-toggle semantics on the
 // collection page (mirrors CollectionCheckboxProgress's includeArchived param).
 func (s *Store) GetAllItemProgress(workspaceID, collectionSlug string, includeArchived bool) ([]ItemProgress, error) {
-	filters := s.childrenDoneFiltersForCollection(workspaceID, collectionSlug)
+	filters := s.childrenDoneFiltersForCollection(workspaceID, collectionSlug, includeArchived)
 	doneExpr, doneArgs := s.buildChildrenDoneExpr(filters, "t")
 	args := append(doneArgs, workspaceID, collectionSlug)
 	parentDeletedFilter := "AND p.deleted_at IS NULL"

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -2864,12 +2864,22 @@ type ItemProgress struct {
 	Done   int    `json:"done"`
 }
 
-// GetAllItemProgress returns child item completion counts for every non-deleted
-// item in the given collection within a workspace.
-func (s *Store) GetAllItemProgress(workspaceID, collectionSlug string) ([]ItemProgress, error) {
+// GetAllItemProgress returns child item completion counts for every item in
+// the given collection within a workspace.
+//
+// includeArchived controls whether soft-deleted parent items contribute rows.
+// When false (the default for /plans-progress) only live parents are returned.
+// When true (used by /child-progress with include_archived=true) archived
+// parents also appear — matching the archived-toggle semantics on the
+// collection page (mirrors CollectionCheckboxProgress's includeArchived param).
+func (s *Store) GetAllItemProgress(workspaceID, collectionSlug string, includeArchived bool) ([]ItemProgress, error) {
 	filters := s.childrenDoneFiltersForCollection(workspaceID, collectionSlug)
 	doneExpr, doneArgs := s.buildChildrenDoneExpr(filters, "t")
 	args := append(doneArgs, workspaceID, collectionSlug)
+	parentDeletedFilter := "AND p.deleted_at IS NULL"
+	if includeArchived {
+		parentDeletedFilter = ""
+	}
 	rows, err := s.db.Query(s.q(fmt.Sprintf(`
 		SELECT p.id,
 		       COUNT(t.id),
@@ -2881,9 +2891,9 @@ func (s *Store) GetAllItemProgress(workspaceID, collectionSlug string) ([]ItemPr
 		                  AND t.deleted_at IS NULL
 		WHERE p.workspace_id = ?
 		  AND pc.slug = ?
-		  AND p.deleted_at IS NULL
+		  %s
 		GROUP BY p.id
-	`, doneExpr, childLinkTypeSQL())), args...)
+	`, doneExpr, childLinkTypeSQL(), parentDeletedFilter)), args...)
 	if err != nil {
 		return nil, fmt.Errorf("get all item progress: %w", err)
 	}

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -810,6 +810,19 @@ export const api = {
 			request<{item_id: string; total: number; done: number}[]>(`/workspaces/${ws}/plans-progress`),
 
 		/**
+		 * Child-item completion progress for every item in a collection
+		 * (BUG-1509). Returns `{item_id, total, done}` for ALL items in
+		 * the collection — those with no linked children have total=0.
+		 * The server enforces the same visibility/guest-grant rules as
+		 * /plans-progress so restricted callers can't enumerate hidden
+		 * child counts.
+		 */
+		collectionChildProgress: (ws: string, coll: string) =>
+			request<{item_id: string; total: number; done: number}[]>(
+				`/workspaces/${ws}/collections/${coll}/child-progress`
+			),
+
+		/**
 		 * Markdown-checkbox progress for items in a single collection.
 		 * The server scans `- [ ]` / `- [x]` markers in each item's
 		 * `content` and returns `{item_id, total, done}` for items with

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -815,11 +815,14 @@ export const api = {
 		 * the collection — those with no linked children have total=0.
 		 * The server enforces the same visibility/guest-grant rules as
 		 * /plans-progress so restricted callers can't enumerate hidden
-		 * child counts.
+		 * child counts. Pass `includeArchived: true` to match the
+		 * collection page's archived-items toggle.
 		 */
-		collectionChildProgress: (ws: string, coll: string) =>
+		collectionChildProgress: (ws: string, coll: string, opts?: { includeArchived?: boolean }) =>
 			request<{item_id: string; total: number; done: number}[]>(
-				`/workspaces/${ws}/collections/${coll}/child-progress`
+				`/workspaces/${ws}/collections/${coll}/child-progress${qs({
+					include_archived: opts?.includeArchived ? 'true' : undefined,
+				})}`
 			),
 
 		/**

--- a/web/src/lib/components/ChildItems.svelte
+++ b/web/src/lib/components/ChildItems.svelte
@@ -180,7 +180,7 @@
 	}
 </script>
 
-{#if loading || children.length > 0}
+{#if loading || error || children.length > 0}
 <div class="child-items">
 	<div class="section-header">
 		<h3>Children</h3>

--- a/web/src/lib/components/collections/ItemCard.svelte
+++ b/web/src/lib/components/collections/ItemCard.svelte
@@ -13,7 +13,7 @@
 		showCollection?: boolean;
 		statusOptions?: string[];
 		onStatusClick?: (item: Item, newStatus: string) => void;
-		progress?: { total: number; done: number } | null;
+		progress?: { total: number; done: number; label?: string } | null;
 		progressLabel?: string;
 	}
 
@@ -202,7 +202,7 @@
 			<div class="card-progress-bar">
 				<div class="card-progress-fill" style:width="{Math.round((progress.done / progress.total) * 100)}%"></div>
 			</div>
-			<span class="card-progress-text">{progress.done}/{progress.total} {progressLabel}</span>
+			<span class="card-progress-text">{progress.done}/{progress.total} {progress.label ?? progressLabel}</span>
 		</div>
 	{/if}
 </a>

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -457,6 +457,7 @@
 				map[p.item_id] = { total: p.total, done: p.done };
 			}
 			itemProgress = map;
+			progressLabel = 'tasks';
 		} else {
 			// Non-plans collections: prefer child-item progress (real linked
 			// children) for items that have them; fall back to markdown-checkbox
@@ -466,10 +467,10 @@
 			// for those with no linked children, so we can distinguish "has
 			// children" from "no children" per item.
 			//
-			// Pass `includeArchived` to checkbox-progress so the toggle-on
-			// view keeps progress badges on archived items (PR #491 [P2]).
+			// Pass `includeArchived` to both endpoints so the archived-items
+			// toggle keeps progress badges on archived items (PR #491 [P2]).
 			const [childRows, checkboxRows] = await Promise.all([
-				api.items.collectionChildProgress(ws, coll).catch(() => [] as {item_id: string; total: number; done: number}[]),
+				api.items.collectionChildProgress(ws, coll, { includeArchived: showArchived }).catch(() => [] as {item_id: string; total: number; done: number}[]),
 				api.items.collectionCheckboxProgress(ws, coll, { includeArchived: showArchived }).catch(() => [] as {item_id: string; total: number; done: number}[]),
 			]);
 
@@ -544,7 +545,7 @@
 				// archived-items toggle keeps its badges (PR #491 [P2]).
 				try {
 					const [childRows, checkboxRows] = await Promise.all([
-						api.items.collectionChildProgress(ws, coll).catch(() => [] as {item_id: string; total: number; done: number}[]),
+						api.items.collectionChildProgress(ws, coll, { includeArchived }).catch(() => [] as {item_id: string; total: number; done: number}[]),
 						api.items.collectionCheckboxProgress(ws, coll, { includeArchived }).catch(() => [] as {item_id: string; total: number; done: number}[]),
 					]);
 
@@ -568,10 +569,10 @@
 						}
 					}
 					itemProgress = map;
+					progressLabel = 'done';
 				} catch {
 					itemProgress = {};
 				}
-				progressLabel = 'done';
 			}
 
 			// `relationLabels` is computed reactively below — no need

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -49,7 +49,7 @@
 	let selectedTags = $state<string[]>([]);
 	let searchQuery = $state('');
 	let showArchived = $state(false);
-	let itemProgress = $state<Record<string, { total: number; done: number }>>({});
+	let itemProgress = $state<Record<string, { total: number; done: number; label?: string }>>({});
 	let progressLabel = $state('tasks');
 	// `relationLabels` maps plan id → plan title for the task-card
 	// "relates to" badge. `$derived` so it picks up plans as they
@@ -452,29 +452,47 @@
 	async function refreshProgress(ws: string, coll: string, itemList: typeof items) {
 		if (coll === 'plans') {
 			const progress = await api.items.plansProgress(ws).catch(() => []);
-			const map: Record<string, { total: number; done: number }> = {};
+			const map: Record<string, { total: number; done: number; label?: string }> = {};
 			for (const p of progress) {
 				map[p.item_id] = { total: p.total, done: p.done };
 			}
 			itemProgress = map;
 		} else {
-			// Non-plans collections: pull markdown-checkbox progress from
-			// the new server-side endpoint. Pre-TASK-1349 this loop walked
-			// `it.content` client-side, but the skinny /items-index
-			// payload doesn't ship content. The server endpoint computes
-			// the same counts via LENGTH/REPLACE arithmetic on the
-			// stored rows — same shape `{item_id, total, done}` as
-			// /plans-progress.
+			// Non-plans collections: prefer child-item progress (real linked
+			// children) for items that have them; fall back to markdown-checkbox
+			// progress for items that don't. Fetched in parallel (BUG-1509).
 			//
-			// Pass `includeArchived` so the toggle-on view (which renders
-			// archived rows alongside live ones) still gets their
-			// progress badges. Per Codex round 2 [P2] on PR #491.
-			const map: Record<string, { total: number; done: number }> = {};
-			const progress = await api.items
-				.collectionCheckboxProgress(ws, coll, { includeArchived: showArchived })
-				.catch(() => []);
-			for (const p of progress) {
-				map[p.item_id] = { total: p.total, done: p.done };
+			// child-progress returns ALL items in the collection with total=0
+			// for those with no linked children, so we can distinguish "has
+			// children" from "no children" per item.
+			//
+			// Pass `includeArchived` to checkbox-progress so the toggle-on
+			// view keeps progress badges on archived items (PR #491 [P2]).
+			const [childRows, checkboxRows] = await Promise.all([
+				api.items.collectionChildProgress(ws, coll).catch(() => [] as {item_id: string; total: number; done: number}[]),
+				api.items.collectionCheckboxProgress(ws, coll, { includeArchived: showArchived }).catch(() => [] as {item_id: string; total: number; done: number}[]),
+			]);
+
+			const checkboxMap: Record<string, { total: number; done: number }> = {};
+			for (const p of checkboxRows) {
+				checkboxMap[p.item_id] = { total: p.total, done: p.done };
+			}
+
+			const map: Record<string, { total: number; done: number; label?: string }> = {};
+			for (const p of childRows) {
+				if (p.total > 0) {
+					map[p.item_id] = { total: p.total, done: p.done, label: 'tasks' };
+				} else if (checkboxMap[p.item_id]) {
+					map[p.item_id] = { ...checkboxMap[p.item_id], label: 'done' };
+				}
+			}
+			// Items that only have checkboxes (not in child-progress rows at
+			// all — shouldn't happen since child-progress covers all items —
+			// but be defensive).
+			for (const p of checkboxRows) {
+				if (!map[p.item_id]) {
+					map[p.item_id] = { total: p.total, done: p.done, label: 'done' };
+				}
 			}
 			itemProgress = map;
 		}
@@ -499,11 +517,11 @@
 			workspaceMembers = membersData.members ?? [];
 			activeViewId = null;
 
-			// Fetch plan progress if viewing plans collection
+			// Fetch progress badges for the collection's items.
 			if (coll === 'plans') {
 				try {
 					const progress = await api.items.plansProgress(ws);
-					const map: Record<string, { total: number; done: number }> = {};
+					const map: Record<string, { total: number; done: number; label?: string }> = {};
 					for (const p of progress) {
 						map[p.item_id] = { total: p.total, done: p.done };
 					}
@@ -513,20 +531,41 @@
 					itemProgress = {};
 				}
 			} else {
-				// Non-plans collections: pull progress from the new
-				// /collections/{coll}/checkbox-progress endpoint instead
-				// of parsing `item.content` client-side. /items-index
-				// doesn't ship content, so the old client-side parse
-				// would be a no-op; the server-side endpoint computes
-				// the same counts via LENGTH/REPLACE arithmetic on the
-				// stored rows. `includeArchived` is plumbed through so
-				// the toggle-on view keeps progress badges on archived
-				// items (per Codex round 2 [P2] on PR #491).
+				// Non-plans collections: prefer child-item progress (real
+				// linked children, label "tasks") per item; fall back to
+				// markdown-checkbox progress (label "done") for items that
+				// have no linked children (BUG-1509). Fetched in parallel.
+				//
+				// child-progress returns ALL items including those with
+				// total=0 (no linked children), so we can make the
+				// per-item decision without a second fetch.
+				//
+				// `includeArchived` is passed to checkbox-progress so the
+				// archived-items toggle keeps its badges (PR #491 [P2]).
 				try {
-					const progress = await api.items.collectionCheckboxProgress(ws, coll, { includeArchived });
-					const map: Record<string, { total: number; done: number }> = {};
-					for (const p of progress) {
-						map[p.item_id] = { total: p.total, done: p.done };
+					const [childRows, checkboxRows] = await Promise.all([
+						api.items.collectionChildProgress(ws, coll).catch(() => [] as {item_id: string; total: number; done: number}[]),
+						api.items.collectionCheckboxProgress(ws, coll, { includeArchived }).catch(() => [] as {item_id: string; total: number; done: number}[]),
+					]);
+
+					const checkboxMap: Record<string, { total: number; done: number }> = {};
+					for (const p of checkboxRows) {
+						checkboxMap[p.item_id] = { total: p.total, done: p.done };
+					}
+
+					const map: Record<string, { total: number; done: number; label?: string }> = {};
+					for (const p of childRows) {
+						if (p.total > 0) {
+							map[p.item_id] = { total: p.total, done: p.done, label: 'tasks' };
+						} else if (checkboxMap[p.item_id]) {
+							map[p.item_id] = { ...checkboxMap[p.item_id], label: 'done' };
+						}
+					}
+					// Defensive: cover any items only in checkbox-progress.
+					for (const p of checkboxRows) {
+						if (!map[p.item_id]) {
+							map[p.item_id] = { total: p.total, done: p.done, label: 'done' };
+						}
 					}
 					itemProgress = map;
 				} catch {


### PR DESCRIPTION
## Summary

Non-plan collection cards showed markdown-checkbox counts (label "done") while the item page's Children section showed linked child items — two unrelated data sources, so a task could show "0/5" on its card with no visible subtasks on the item page (or the inverse). Fixes docapp BUG-1509, root cause documented in its comments.

Changes:
1. New `GET /workspaces/{ws}/collections/{collSlug}/child-progress` endpoint generalizing the plans-progress logic (shared `collectionChildrenProgress` helper; `/plans-progress` unchanged, now a thin wrapper).
2. Collection page prefers real child-item progress (label "tasks") per item, falls back to checkbox progress (label "done").
3. `ChildItems.svelte` error state was unreachable behind the `loading || children.length > 0` gate — a failed `/children` fetch silently hid the section; now `error` renders.

## Plus (architectural decisions)

- Visibility/guest-grant filtering semantics preserved exactly and now shared between plans-progress and child-progress (restricted callers get the same empty shape — covered by a no-leak test).
- `include_archived` query param threaded end-to-end including `childrenDoneFiltersForCollection`'s discovery query (codex r3 found the discovery/aggregation inconsistency; the regression test was proven load-bearing by reverting the fix).

## Known limitation

The restricted-visibility recompute path issues one `GetChildItems` query per parent item (pre-existing trade-off from plans-progress, now generalized to potentially larger collections). Deferred; needs a bulk-join recompute.

## Test plan

- [x] `go test ./...` SQLite
- [x] `make test-pg` Postgres
- [x] `golangci-lint run ./...` 0 issues
- [x] `npm run check` 0 errors
- [x] `npm run build`
- [x] restricted-member no-leak test
- [x] archived-parent include_archived test (load-bearing, fails on revert)

## Refs

Fixes docapp BUG-1509. Review: 4 codex rounds (r1 CLEAN, r2 ×2 findings fixed, r3 ×1 finding fixed, r4 CLEAN — converged).
