### PR TITLE
fix(web): collapse WorkspaceSheet switcher list when the sheet closes (IDEA-1720)

### DIFF
--- a/web/src/lib/components/layout/WorkspaceSheet.svelte
+++ b/web/src/lib/components/layout/WorkspaceSheet.svelte
@@ -43,7 +43,17 @@
 		collectionStore.collections.filter((c) => agentSlugs.includes(c.slug))
 	);
 
-	let switching = $state(false);
+	// Inline switcher list expansion. Reassignable $derived (Svelte 5.25+)
+	// instead of $state: the card's onclick toggles it by reassignment, and
+	// it snaps back to collapsed whenever `open` changes. This state lives
+	// here (not in DockedSheet's children, which unmount on close), so plain
+	// $state would survive close/reopen and the list would come back stale —
+	// including via backdrop/swipe dismissal, which no handler in this
+	// component sees (IDEA-1720).
+	let switching = $derived.by(() => {
+		void open;
+		return false;
+	});
 
 	// Close on navigation (the switcher card navigates on select).
 	afterNavigate((nav) => {


### PR DESCRIPTION
## Summary
On mobile, expanding the workspace switcher list inside the Workspace sheet and then switching (or dismissing the sheet) left the list expanded on the next open. The `switching` state lives in `WorkspaceSheet`, which stays mounted — `DockedSheet` unmounts its children on close, but the state survives in the parent scope.

## Fix
Replace the plain `$state(false)` with a reassignable `$derived.by` keyed on the `open` prop (Svelte 5.25+ writable-derived idiom). The card toggle still works by reassignment; the list snaps back to collapsed on any `open` change — including backdrop/swipe dismissal, which no handler in the component observes (the parent owns `open`).

## Test plan
- [x] `npm run check` — 0 errors (7 pre-existing warnings, unchanged)
- [x] `npm run build` — succeeds
- [x] Svelte MCP autofixer — clean (it flagged the initial $effect-based approach; the writable-derived idiom resolved it)
- [x] Codex review — 1 round, CLEAN, converged

## Refs
Fixes docapp IDEA-1720.