### PR TITLE
fix(editor): symmetric table cut/paste — structural row cut, TSV cell reconstruction (BUG-1247)

### DIFF
--- a/web/src/lib/components/editor/Editor.svelte
+++ b/web/src/lib/components/editor/Editor.svelte
@@ -369,22 +369,29 @@
 		// Then REVERSE the list before dispatching so each tr.replaceWith only
 		// shifts positions that are later in the document (already processed).
 		//
-		// WHY FORWARD FIRST WITH DEDUP: TableMap.positionAt returns the same
-		// physical cell position for every visual slot a rowspan/colspan covers.
-		// Without deduplication, the paste loop would write that physical cell once
-		// per covered slot, corrupting its content (e.g. 'NEW00NEW01' instead of
-		// 'NEW00'). By deduplicating on the first (top-left) encounter in forward
-		// order, we ensure the top-left grid value writes the merged cell —
-		// matching spreadsheet convention.
+		// WHY map.map[] NOT positionAt(): positionAt(row, col, table) SKIPS covered
+		// slots — for a visual slot covered by a rowspan from above it advances to
+		// the next physical cell in that row, causing column misalignment. Example:
+		// 2-col table, (0,0) has rowspan=2. positionAt(1,0) skips the covered slot
+		// and returns cell C (col 1), so grid[1][0] (a col-0 value) lands in a
+		// col-1 cell. map.map[row * width + col] returns the OWNING cell's offset
+		// for every visual slot — covered or not — which matches the serializer's
+		// slot-by-slot walk and produces correct column alignment.
+		//
+		// WHY FORWARD FIRST WITH DEDUP: map.map[] returns the same offset for every
+		// slot the owning cell covers. Without a dedup Set the paste loop would
+		// write that physical cell once per covered slot, corrupting its content.
+		// By deduplicating on the FIRST (top-left origin) encounter in forward
+		// order, the covered slot's grid value is dropped and the origin receives
+		// the top-left grid value — matching spreadsheet convention.
 		//
 		// WHY ALSO REVERSE: each tr.replaceWith shifts all doc positions AFTER the
-		// replaced range. Forward iteration (high-to-low doc address last) would
-		// make later cellPos values stale after earlier replaceWith calls. Reverse
-		// iteration means each write only displaces positions we have already
-		// processed. The dedup Set makes the collected list position-unique, so
+		// replaced range. Forward iteration would make later cellPos values stale.
+		// Reverse iteration means each write only displaces already-processed
+		// positions. The dedup Set makes the collected list position-unique, so
 		// the combined collect-forward/dedup/reverse approach is correct.
-		// DO NOT remove either the dedup Set or the reverse without re-running
-		// the verification scripts (verify-paste.cjs, verify-paste3.cjs).
+		// DO NOT change map.map[] back to positionAt(), remove the dedup Set, or
+		// remove the reverse — see verify-paste.cjs, verify-paste4.cjs.
 		const seenCellOffsets = new Set<number>();
 		const cellsToFill: Array<{ cellPos: number; value: string }> = [];
 		for (let r = 0; r < grid.length; r++) {
@@ -393,12 +400,11 @@
 			for (let c = 0; c < grid[r].length; c++) {
 				const targetCol = startCol + c;
 				if (targetCol >= map.width) break; // clamp at right edge
-				// positionAt returns the table-relative offset of the physical cell
-				// at this visual slot. For merged cells (rowspan/colspan > 1),
-				// positionAt skips covered slots in the same row and returns the
-				// same offset for all slots the cell covers.
-				const cellOffset = map.positionAt(targetRow, targetCol, table);
-				if (seenCellOffsets.has(cellOffset)) continue; // merged slot — origin already collected
+				// map.map[] gives the owning cell's table-relative offset for every
+				// visual slot including covered ones. positionAt() would skip covered
+				// slots and misalign columns — see comment block above.
+				const cellOffset = map.map[(targetRow) * map.width + targetCol];
+				if (seenCellOffsets.has(cellOffset)) continue; // covered slot — grid value belongs to origin, already collected
 				seenCellOffsets.add(cellOffset);
 				cellsToFill.push({ cellPos: tableStart + cellOffset, value: grid[r][c] });
 			}

--- a/web/src/lib/components/editor/Editor.svelte
+++ b/web/src/lib/components/editor/Editor.svelte
@@ -318,41 +318,56 @@
 		const startRow = anchorCellRect.top;
 		const startCol = anchorCellRect.left;
 
-		// Build a transaction that fills each target cell with the pasted text.
-		let tr = state.tr;
-		let changed = false;
-
+		// Collect all (row, col, value) entries to fill, then reverse them so we
+		// process bottom-right → top-left in document order.
+		//
+		// WHY REVERSE: each tr.replaceWith shifts all doc positions AFTER the
+		// replaced range. Iterating forward would make every subsequent cellPos
+		// (computed from the original pre-transaction map) point into a document
+		// that has already shifted — wrong cells get written, or replaceWith
+		// throws a RangeError on size-delta mismatches. Reverse order means each
+		// replacement only shifts positions that come LATER in the document (higher
+		// address), which are cells we have already processed. The remaining
+		// unprocessed cells sit at lower doc positions and are untouched.
+		// DO NOT change this back to forward order without re-running verify-paste.cjs.
+		const cellsToFill: Array<{ targetRow: number; targetCol: number; value: string }> = [];
 		for (let r = 0; r < grid.length; r++) {
 			const targetRow = startRow + r;
 			if (targetRow >= map.height) break; // clamp at bottom edge
-
 			for (let c = 0; c < grid[r].length; c++) {
 				const targetCol = startCol + c;
 				if (targetCol >= map.width) break; // clamp at right edge
-
-				// positionAt returns the position *before* the cell node, relative
-				// to the start of the table. Add tableStart to get the doc position.
-				const cellPos = tableStart + map.positionAt(targetRow, targetCol, table);
-
-				// Find the cell node and its content range.
-				// The cell is always one level above a paragraph/block content node.
-				const cellNode = tr.doc.nodeAt(cellPos);
-				if (!cellNode) continue;
-
-				const cellContentStart = cellPos + 1; // first position inside the cell
-				const cellContentEnd = cellPos + cellNode.nodeSize - 1; // last position inside the cell
-
-				// Replace the entire cell content with a single paragraph containing
-				// the pasted text. Empty paste cells write an empty paragraph —
-				// intentional: preserves cut→paste round-trip fidelity.
-				const cellValue = grid[r][c];
-				const paraContent = cellValue
-					? [state.schema.text(cellValue)]
-					: [];
-				const para = state.schema.nodes.paragraph.create({}, paraContent);
-				tr = tr.replaceWith(cellContentStart, cellContentEnd, para);
-				changed = true;
+				cellsToFill.push({ targetRow, targetCol, value: grid[r][c] });
 			}
+		}
+		cellsToFill.reverse();
+
+		let tr = state.tr;
+		let changed = false;
+
+		for (const { targetRow, targetCol, value } of cellsToFill) {
+			// positionAt returns the offset from the table's content start.
+			// tableStart is the position of the table's first content token,
+			// so tableStart + positionAt(...) is the doc position before the cell.
+			const cellPos = tableStart + map.positionAt(targetRow, targetCol, table);
+
+			// Re-read the cell node from tr.doc at the (still-valid) cellPos.
+			// Because we iterate in reverse, positions of unprocessed cells have
+			// not been displaced yet, so cellPos is accurate for tr.doc.
+			const cellNode = tr.doc.nodeAt(cellPos);
+			if (!cellNode) continue;
+
+			const cellContentStart = cellPos + 1; // first position inside the cell
+			const cellContentEnd = cellPos + cellNode.nodeSize - 1; // last position inside
+
+			// Replace the entire cell content with a single paragraph.
+			// Empty paste cells write an empty paragraph — intentional: preserves
+			// cut→paste round-trip fidelity and matches spreadsheet convention
+			// (Excel pastes blanks as blanks).
+			const paraContent = value ? [state.schema.text(value)] : [];
+			const para = state.schema.nodes.paragraph.create({}, paraContent);
+			tr = tr.replaceWith(cellContentStart, cellContentEnd, para);
+			changed = true;
 		}
 
 		if (!changed) return false;

--- a/web/src/lib/components/editor/Editor.svelte
+++ b/web/src/lib/components/editor/Editor.svelte
@@ -172,21 +172,46 @@
 		let text: string | null = null;
 
 		if (selection instanceof CellSelection) {
-			// Multi-cell selection — iterate cells, group by row, build TSV.
+			// Multi-cell selection — emit a RECTANGULAR TSV by walking the
+			// visual grid slot-by-slot using the TableMap.
+			//
+			// WHY NOT forEachCell: forEachCell (and cellsInRect) deduplicates
+			// physical cells, yielding one entry per merged cell. That makes
+			// the row field-count non-rectangular when merged cells are present
+			// (a colspan=2 cell in a 2-col selection would emit one field for
+			// that row, not two). The resulting TSV misaligns columns on paste.
+			//
+			// Instead we walk every visual (row, col) slot in the selection
+			// rect. For each slot we check whether it is the ORIGIN of its
+			// physical cell (cellRect.top === row && cellRect.left === col).
+			// Origin slots emit the cell's text; covered slots emit '' (empty
+			// field). This guarantees every TSV row has the same field count.
+			const selectionTable = selection.$anchorCell.node(-1);
+			const selectionMap = TableMap.get(selectionTable);
+			const selectionTableStart = selection.$anchorCell.start(-1);
+			const selectionRect = selectionMap.rectBetween(
+				selection.$anchorCell.pos - selectionTableStart,
+				selection.$headCell.pos - selectionTableStart,
+			);
 			const rows: string[][] = [];
-			let currentRow: string[] = [];
-			let prevRow: any = null;
-			selection.forEachCell((cellNode: any, cellPos: number) => {
-				const resolvedCellPos = state.doc.resolve(cellPos);
-				const row = resolvedCellPos.parent;
-				if (row !== prevRow) {
-					if (currentRow.length) rows.push(currentRow);
-					currentRow = [];
-					prevRow = row;
+			for (let row = selectionRect.top; row < selectionRect.bottom; row++) {
+				const cols: string[] = [];
+				for (let col = selectionRect.left; col < selectionRect.right; col++) {
+					const slotIndex = row * selectionMap.width + col;
+					const cellOffset = selectionMap.map[slotIndex];
+					const cellRect = selectionMap.findCell(cellOffset);
+					const isOrigin = cellRect.top === row && cellRect.left === col;
+					if (isOrigin) {
+						const cellNode = selectionTable.nodeAt(cellOffset);
+						cols.push((cellNode?.textContent ?? '').replace(/\s+$/g, ''));
+					} else {
+						// Covered slot of a merged cell: emit empty field so
+						// every TSV row has an equal number of columns.
+						cols.push('');
+					}
 				}
-				currentRow.push((cellNode.textContent ?? '').replace(/\s+$/g, ''));
-			});
-			if (currentRow.length) rows.push(currentRow);
+				rows.push(cols);
+			}
 			text = rows.map(r => r.join('\t')).join('\n');
 		} else {
 			// Plain text selection — must be entirely inside a single table.
@@ -339,26 +364,43 @@
 		const startRow = anchorCellRect.top;
 		const startCol = anchorCellRect.left;
 
-		// Collect all (row, col, value) entries to fill, then reverse them so we
-		// process bottom-right → top-left in document order.
+		// Collect cells to fill in FORWARD (top-left → bottom-right) visual order,
+		// deduplicating by physical position so merged cells are written once.
+		// Then REVERSE the list before dispatching so each tr.replaceWith only
+		// shifts positions that are later in the document (already processed).
 		//
-		// WHY REVERSE: each tr.replaceWith shifts all doc positions AFTER the
-		// replaced range. Iterating forward would make every subsequent cellPos
-		// (computed from the original pre-transaction map) point into a document
-		// that has already shifted — wrong cells get written, or replaceWith
-		// throws a RangeError on size-delta mismatches. Reverse order means each
-		// replacement only shifts positions that come LATER in the document (higher
-		// address), which are cells we have already processed. The remaining
-		// unprocessed cells sit at lower doc positions and are untouched.
-		// DO NOT change this back to forward order without re-running verify-paste.cjs.
-		const cellsToFill: Array<{ targetRow: number; targetCol: number; value: string }> = [];
+		// WHY FORWARD FIRST WITH DEDUP: TableMap.positionAt returns the same
+		// physical cell position for every visual slot a rowspan/colspan covers.
+		// Without deduplication, the paste loop would write that physical cell once
+		// per covered slot, corrupting its content (e.g. 'NEW00NEW01' instead of
+		// 'NEW00'). By deduplicating on the first (top-left) encounter in forward
+		// order, we ensure the top-left grid value writes the merged cell —
+		// matching spreadsheet convention.
+		//
+		// WHY ALSO REVERSE: each tr.replaceWith shifts all doc positions AFTER the
+		// replaced range. Forward iteration (high-to-low doc address last) would
+		// make later cellPos values stale after earlier replaceWith calls. Reverse
+		// iteration means each write only displaces positions we have already
+		// processed. The dedup Set makes the collected list position-unique, so
+		// the combined collect-forward/dedup/reverse approach is correct.
+		// DO NOT remove either the dedup Set or the reverse without re-running
+		// the verification scripts (verify-paste.cjs, verify-paste3.cjs).
+		const seenCellOffsets = new Set<number>();
+		const cellsToFill: Array<{ cellPos: number; value: string }> = [];
 		for (let r = 0; r < grid.length; r++) {
 			const targetRow = startRow + r;
 			if (targetRow >= map.height) break; // clamp at bottom edge
 			for (let c = 0; c < grid[r].length; c++) {
 				const targetCol = startCol + c;
 				if (targetCol >= map.width) break; // clamp at right edge
-				cellsToFill.push({ targetRow, targetCol, value: grid[r][c] });
+				// positionAt returns the table-relative offset of the physical cell
+				// at this visual slot. For merged cells (rowspan/colspan > 1),
+				// positionAt skips covered slots in the same row and returns the
+				// same offset for all slots the cell covers.
+				const cellOffset = map.positionAt(targetRow, targetCol, table);
+				if (seenCellOffsets.has(cellOffset)) continue; // merged slot — origin already collected
+				seenCellOffsets.add(cellOffset);
+				cellsToFill.push({ cellPos: tableStart + cellOffset, value: grid[r][c] });
 			}
 		}
 		cellsToFill.reverse();
@@ -366,12 +408,7 @@
 		let tr = state.tr;
 		let changed = false;
 
-		for (const { targetRow, targetCol, value } of cellsToFill) {
-			// positionAt returns the offset from the table's content start.
-			// tableStart is the position of the table's first content token,
-			// so tableStart + positionAt(...) is the doc position before the cell.
-			const cellPos = tableStart + map.positionAt(targetRow, targetCol, table);
-
+		for (const { cellPos, value } of cellsToFill) {
 			// Re-read the cell node from tr.doc at the (still-valid) cellPos.
 			// Because we iterate in reverse, positions of unprocessed cells have
 			// not been displaced yet, so cellPos is accurate for tr.doc.

--- a/web/src/lib/components/editor/Editor.svelte
+++ b/web/src/lib/components/editor/Editor.svelte
@@ -12,7 +12,15 @@
 	import TaskList from '@tiptap/extension-task-list';
 	import TaskItem from '@tiptap/extension-task-item';
 	import { Table, TableRow, TableCell, TableHeader } from '@tiptap/extension-table';
-	import { CellSelection } from '@tiptap/pm/tables';
+	import {
+		CellSelection,
+		deleteRow,
+		deleteTable,
+		isInTable,
+		selectionCell,
+		findTable,
+		TableMap,
+	} from '@tiptap/pm/tables';
 	import Link from '@tiptap/extension-link';
 	import CodeBlock from '@tiptap/extension-code-block';
 	import Placeholder from '@tiptap/extension-placeholder';
@@ -149,6 +157,7 @@
 			handleDOMEvents: {
 				copy: (view, event) => writeTableClipboard(view, event as ClipboardEvent, false),
 				cut: (view, event) => writeTableClipboard(view, event as ClipboardEvent, true),
+				paste: (view, event) => readTablePasteClipboard(view, event as ClipboardEvent),
 			},
 		},
 	});
@@ -203,9 +212,153 @@
 		event.clipboardData.setData('text/html', '');
 
 		if (isCut) {
-			const tr = state.tr.deleteSelection();
-			view.dispatch(tr);
+			if (selection instanceof CellSelection && selection.isRowSelection()) {
+				// Whole-row selection: prefer structural row removal so undo restores
+				// the rows intact in one step.
+				//
+				// Edge case: if the selection covers every row in the table, deleteRow
+				// refuses (prosemirror-tables intentionally prevents making a zero-row
+				// table). In that case we fall through to deleteTable so the user's
+				// mental model ("I cut everything → it's gone") is honoured.
+				const table = selection.$anchorCell.node(-1);
+				const map = TableMap.get(table);
+				// Compute the row extent of this selection via the map.
+				const anchorPos = selection.$anchorCell.pos - selection.$anchorCell.start(-1);
+				const headPos = selection.$headCell.pos - selection.$headCell.start(-1);
+				const anchorRect = map.findCell(anchorPos);
+				const headRect = map.findCell(headPos);
+				const selTop = Math.min(anchorRect.top, headRect.top);
+				const selBottom = Math.max(anchorRect.bottom, headRect.bottom);
+				const allRows = selTop === 0 && selBottom === map.height;
+
+				if (allRows) {
+					// Deleting all rows ≡ deleting the table.
+					deleteTable(state, view.dispatch);
+				} else {
+					// deleteRow reads the CellSelection from state.selection and
+					// removes only the rows that are fully covered.
+					deleteRow(state, view.dispatch);
+				}
+			} else {
+				// Partial cell selection or plain-text range within a table:
+				// clear cell content but keep the row/cell structure intact.
+				// This is the correct ProseMirror semantic for partial cuts.
+				const tr = state.tr.deleteSelection();
+				view.dispatch(tr);
+			}
 		}
+		return true;
+	}
+
+	// ProseMirror plugin handler: reconstruct table cells from tab-separated
+	// clipboard text when the paste target is inside a table cell.
+	//
+	// Returns true (and calls event.preventDefault) only when ALL of:
+	//   1. Anchor is inside a table cell.
+	//   2. text/plain contains \t or \n (multi-cell TSV content).
+	//   3. text/html does NOT contain a <table> element (spreadsheet pastes
+	//      that carry <table> HTML are left for ProseMirror's HTML handler,
+	//      which already reconstructs cells correctly).
+	//
+	// Falls through (returns false) on every non-matching path so default
+	// paste and tiptap-markdown's transform are unaffected.
+	//
+	// Known limitations:
+	//   - RFC-4180 quoted cells ("a\nb" spanning multiple lines) are NOT
+	//     parsed. The grid is split naively on \n then \t. A quoted
+	//     multi-line cell will be split across rows. Full RFC-4180 is a
+	//     follow-on task.
+	//   - Paste data wider or taller than the remaining table is clamped
+	//     and dropped (table is NOT grown).
+	//   - Empty cells in the paste grid CLEAR the target cell (write an
+	//     empty paragraph). This is intentional: it preserves cut→paste
+	//     round-trip fidelity and matches spreadsheet convention.
+	function readTablePasteClipboard(view: any, event: ClipboardEvent): boolean {
+		if (!event.clipboardData) return false;
+		const { state } = view;
+
+		// Guard 1: anchor must be inside a table.
+		if (!isInTable(state)) return false;
+
+		// Guard 2: if the HTML clipboard carries a <table>, let ProseMirror's
+		// existing HTML paste handler take over (spreadsheet paste path).
+		const htmlData = event.clipboardData.getData('text/html');
+		if (/<table[\s>]/i.test(htmlData)) return false;
+
+		// Guard 3: plain text must look like multi-cell TSV (has \t or \n).
+		const plainText = event.clipboardData.getData('text/plain');
+		if (!plainText.includes('\t') && !plainText.includes('\n')) return false;
+
+		// Parse the plain text into a 2D array of cell strings.
+		// Strip trailing \r from each line (Windows line endings from spreadsheets).
+		// Empty trailing rows (blank line at end of clipboard) are dropped.
+		const grid: string[][] = plainText
+			.split('\n')
+			.map((line) => line.replace(/\r$/, '').split('\t'))
+			.filter((row, i, arr) => !(i === arr.length - 1 && row.length === 1 && row[0] === ''));
+
+		if (grid.length === 0) return false;
+
+		// Find the anchor cell and the containing table.
+		// selectionCell is marked @internal in prosemirror-tables but is the
+		// canonical helper to resolve the anchor cell from any selection type;
+		// we're pinned to a specific version so a breakage here is visible.
+		// Note: ProseMirror names resolved positions with a $ prefix by convention;
+		// Svelte 5 runes mode reserves $ for reactive primitives, so we use
+		// `anchorCell` (no prefix) instead.
+		const anchorCell = selectionCell(state);
+		const tableInfo = findTable(anchorCell);
+		if (!tableInfo) return false;
+		const { node: table, start: tableStart } = tableInfo;
+		const map = TableMap.get(table);
+
+		// Determine the anchor cell's position in the map.
+		const anchorOffset = anchorCell.pos - tableStart;
+		const anchorCellRect = map.findCell(anchorOffset);
+		const startRow = anchorCellRect.top;
+		const startCol = anchorCellRect.left;
+
+		// Build a transaction that fills each target cell with the pasted text.
+		let tr = state.tr;
+		let changed = false;
+
+		for (let r = 0; r < grid.length; r++) {
+			const targetRow = startRow + r;
+			if (targetRow >= map.height) break; // clamp at bottom edge
+
+			for (let c = 0; c < grid[r].length; c++) {
+				const targetCol = startCol + c;
+				if (targetCol >= map.width) break; // clamp at right edge
+
+				// positionAt returns the position *before* the cell node, relative
+				// to the start of the table. Add tableStart to get the doc position.
+				const cellPos = tableStart + map.positionAt(targetRow, targetCol, table);
+
+				// Find the cell node and its content range.
+				// The cell is always one level above a paragraph/block content node.
+				const cellNode = tr.doc.nodeAt(cellPos);
+				if (!cellNode) continue;
+
+				const cellContentStart = cellPos + 1; // first position inside the cell
+				const cellContentEnd = cellPos + cellNode.nodeSize - 1; // last position inside the cell
+
+				// Replace the entire cell content with a single paragraph containing
+				// the pasted text. Empty paste cells write an empty paragraph —
+				// intentional: preserves cut→paste round-trip fidelity.
+				const cellValue = grid[r][c];
+				const paraContent = cellValue
+					? [state.schema.text(cellValue)]
+					: [];
+				const para = state.schema.nodes.paragraph.create({}, paraContent);
+				tr = tr.replaceWith(cellContentStart, cellContentEnd, para);
+				changed = true;
+			}
+		}
+
+		if (!changed) return false;
+
+		event.preventDefault();
+		view.dispatch(tr);
 		return true;
 	}
 

--- a/web/src/lib/components/editor/Editor.svelte
+++ b/web/src/lib/components/editor/Editor.svelte
@@ -365,9 +365,7 @@
 		const startCol = anchorCellRect.left;
 
 		// Collect cells to fill in FORWARD (top-left → bottom-right) visual order,
-		// deduplicating by physical position so merged cells are written once.
-		// Then REVERSE the list before dispatching so each tr.replaceWith only
-		// shifts positions that are later in the document (already processed).
+		// skipping covered slots by origin-check, then REVERSE for safe dispatch.
 		//
 		// WHY map.map[] NOT positionAt(): positionAt(row, col, table) SKIPS covered
 		// slots — for a visual slot covered by a rowspan from above it advances to
@@ -375,23 +373,24 @@
 		// 2-col table, (0,0) has rowspan=2. positionAt(1,0) skips the covered slot
 		// and returns cell C (col 1), so grid[1][0] (a col-0 value) lands in a
 		// col-1 cell. map.map[row * width + col] returns the OWNING cell's offset
-		// for every visual slot — covered or not — which matches the serializer's
-		// slot-by-slot walk and produces correct column alignment.
+		// for every visual slot — covered or not — matching the serializer.
 		//
-		// WHY FORWARD FIRST WITH DEDUP: map.map[] returns the same offset for every
-		// slot the owning cell covers. Without a dedup Set the paste loop would
-		// write that physical cell once per covered slot, corrupting its content.
-		// By deduplicating on the FIRST (top-left origin) encounter in forward
-		// order, the covered slot's grid value is dropped and the origin receives
-		// the top-left grid value — matching spreadsheet convention.
+		// WHY ORIGIN-CHECK: map.map[] returns the owning cell's offset even when
+		// that cell's top-left origin is OUTSIDE the paste rectangle. Without the
+		// origin-check, a covered slot whose owner lives above or left of the
+		// anchor would silently overwrite a cell the user never selected. The fix:
+		// only write a cell when the current (targetRow, targetCol) is exactly the
+		// cell's origin (cellRect.top === targetRow && cellRect.left === targetCol).
+		// This skips covered slots structurally — intra-rect and partial-intersection
+		// alike. The dedup Set below is now a redundant-but-cheap invariant guard
+		// (an origin can recur only via colspan > table-width, which is malformed);
+		// it is kept to document intent and protect against future edits.
 		//
 		// WHY ALSO REVERSE: each tr.replaceWith shifts all doc positions AFTER the
 		// replaced range. Forward iteration would make later cellPos values stale.
 		// Reverse iteration means each write only displaces already-processed
-		// positions. The dedup Set makes the collected list position-unique, so
-		// the combined collect-forward/dedup/reverse approach is correct.
-		// DO NOT change map.map[] back to positionAt(), remove the dedup Set, or
-		// remove the reverse — see verify-paste.cjs, verify-paste4.cjs.
+		// positions. DO NOT change map.map[] back to positionAt(), remove the
+		// origin-check, or remove the reverse — see verify-paste.cjs, verify-paste5.cjs.
 		const seenCellOffsets = new Set<number>();
 		const cellsToFill: Array<{ cellPos: number; value: string }> = [];
 		for (let r = 0; r < grid.length; r++) {
@@ -403,8 +402,14 @@
 				// map.map[] gives the owning cell's table-relative offset for every
 				// visual slot including covered ones. positionAt() would skip covered
 				// slots and misalign columns — see comment block above.
-				const cellOffset = map.map[(targetRow) * map.width + targetCol];
-				if (seenCellOffsets.has(cellOffset)) continue; // covered slot — grid value belongs to origin, already collected
+				const cellOffset = map.map[targetRow * map.width + targetCol];
+				// Origin-check: only write a cell at its top-left origin slot.
+				// Covered slots (whether intra-rect or with origin outside the rect)
+				// resolve to the owning cell's offset; their origin row/col won't
+				// match targetRow/targetCol, so they are dropped here.
+				const cellRect = map.findCell(cellOffset);
+				if (cellRect.top !== targetRow || cellRect.left !== targetCol) continue;
+				if (seenCellOffsets.has(cellOffset)) continue; // invariant guard
 				seenCellOffsets.add(cellOffset);
 				cellsToFill.push({ cellPos: tableStart + cellOffset, value: grid[r][c] });
 			}

--- a/web/src/lib/components/editor/Editor.svelte
+++ b/web/src/lib/components/editor/Editor.svelte
@@ -216,6 +216,15 @@
 				// Whole-row selection: prefer structural row removal so undo restores
 				// the rows intact in one step.
 				//
+				// Header-row cut (selTop === 0, !allRows): deleteRow is safe here.
+				// The tiptap Table extension schema is `table: { content: "tableRow+" }`
+				// and `tableRow: { content: "(tableCell | tableHeader)*" }` — no leading
+				// header row is required by the schema (verified in
+				// node_modules/@tiptap/extension-table/src/table/table.ts:270 and
+				// src/row/table-row.ts:27). Row 0 is a "header row" only because its
+				// cells happen to be tableHeader (th) nodes; the schema does not enforce
+				// a mandatory first row, so removing it yields a valid table.
+				//
 				// Edge case: if the selection covers every row in the table, deleteRow
 				// refuses (prosemirror-tables intentionally prevents making a zero-row
 				// table). In that case we fall through to deleteTable so the user's
@@ -255,13 +264,23 @@
 	//
 	// Returns true (and calls event.preventDefault) only when ALL of:
 	//   1. Anchor is inside a table cell.
-	//   2. text/plain contains \t or \n (multi-cell TSV content).
+	//   2. text/plain contains \t (tab character — the TSV discriminator).
 	//   3. text/html does NOT contain a <table> element (spreadsheet pastes
 	//      that carry <table> HTML are left for ProseMirror's HTML handler,
 	//      which already reconstructs cells correctly).
 	//
 	// Falls through (returns false) on every non-matching path so default
 	// paste and tiptap-markdown's transform are unaffected.
+	//
+	// TSV discriminator rationale: we require \t, not (\t OR \n). Newline-
+	// only text (multi-line prose, code snippets, addresses) must NOT trigger
+	// this handler — it would silently overwrite cells downward. The tradeoff:
+	// our own editor's single-column cut writes tab-free TSV (one cell per
+	// line, no \t), so that cut output won't round-trip through this handler;
+	// it lands as multi-line text in the anchor cell via default paste.
+	// Spreadsheet single-column pastes are handled correctly via their
+	// text/html <table> path (guard 3). Do not change this to (\t OR \n)
+	// without also writing table HTML on the cut side.
 	//
 	// Known limitations:
 	//   - RFC-4180 quoted cells ("a\nb" spanning multiple lines) are NOT
@@ -285,9 +304,11 @@
 		const htmlData = event.clipboardData.getData('text/html');
 		if (/<table[\s>]/i.test(htmlData)) return false;
 
-		// Guard 3: plain text must look like multi-cell TSV (has \t or \n).
+		// Guard 3: plain text must contain a tab — the TSV discriminator.
+		// Newline-only text (prose, code) must fall through to default paste;
+		// see the comment block above for the full rationale.
 		const plainText = event.clipboardData.getData('text/plain');
-		if (!plainText.includes('\t') && !plainText.includes('\n')) return false;
+		if (!plainText.includes('\t')) return false;
 
 		// Parse the plain text into a 2D array of cell strings.
 		// Strip trailing \r from each line (Windows line endings from spreadsheets).


### PR DESCRIPTION
## Summary
Table multi-cell cut/paste was lossy in both directions (docapp BUG-1247, surfaced by the TASK-1245 Yjs spike):
- **Cut** cleared cell contents but left empty rows behind.
- **Paste** collapsed tab-separated multi-cell text into the one focused cell.

Now: whole-row CellSelection cut structurally removes the rows (`deleteRow`); all-rows selection removes the table (`deleteTable`); partial selections keep the content-clear semantic. Paste into a table cell reconstructs cells from TSV clipboard text, clamped at table edges.

## Correctness notes (the subtle parts)
- **Positions**: paste targets are collected forward (top-left value wins for merged cells) and applied in REVERSE document order so earlier positions stay valid across replacements.
- **Merged cells**: visual slots resolve via raw `map.map[]` (not `positionAt`, which skips covered slots and shifts columns); an origin-check guard skips covered slots entirely, so merged-cell origins OUTSIDE the paste rect are never touched.
- **TSV shape**: the serializer now emits a rectangular grid for merged regions (origin slot gets the text, covered slots get empty fields) — previously ragged rows misaligned columns on round-trip.
- **Paste guard**: requires a TAB in text/plain; text/html containing `<table>` falls through to ProseMirror's HTML handler (spreadsheet paste unchanged); newline-only text falls through to default paste.
- **Header rows**: schema check confirmed `content: 'tableRow+'` with no positional header constraint — structural cut of row 0 is valid and deliberate (cited in code comments).

## Documented limitations
- RFC-4180 quoted multi-line cells not parsed (naive \n/\t split).
- Paste overflow clamps at table edges (table is not grown).
- The editor's own single-COLUMN cut emits tab-free text and won't structurally round-trip (tradeoff of the tab-required guard); spreadsheet single-column pastes still reconstruct via their HTML path.
- Covered-slot grid values are dropped when pasting across merged cells (origin-only writes, spreadsheet convention).

## Test plan
- [x] `npm run check` — 0 errors (7 pre-existing warnings, unchanged)
- [x] `npm run build` — passes
- [x] Runtime verification: throwaway ProseMirror simulation (prosemirror-model + prosemirror-tables from the repo's own deps), 26 assertions across TSV serialization, grid fill, merged-cell dedup, covered-slot semantics, partial-intersection guard — including reproduce-the-old-bug tests for each fixed defect
- [x] Codex review: 5 framing-rotated rounds (r1: 2 findings, r2: 2, r3: 1, r4: 1 — all fixed; r5: CLEAN, converged)
- [ ] No E2E spec: the Playwright harness has no editor-interaction patterns and clipboard simulation needs a purpose-built fixture — deliberately not forced in this PR

## Refs
Fixes docapp BUG-1247. Related: IDEA-1244 (Yjs collab), TASK-1245 (spike that surfaced this).