### PR TITLE
feat(auth): accept provider=apple in cloud oauth-login/link/unlink (TASK-1773)

### DIFF
--- a/internal/server/handlers_cloud.go
+++ b/internal/server/handlers_cloud.go
@@ -17,6 +17,24 @@ import (
 	"github.com/PerpetualSoftware/pad/internal/store"
 )
 
+// supportedOAuthProviders is the set of OAuth providers pad accepts for
+// cloud login/linking. The pad-cloud sidecar verifies the provider response
+// (GitHub/Google via the browser redirect flow; Apple via native
+// identity-token verification — PLAN-1772) before calling these endpoints,
+// so this is a defense-in-depth allowlist, not the primary trust boundary.
+// Storage (users.oauth_providers) is a free-form JSON array with no DB
+// constraint, so adding a provider here is the only gate to widen.
+var supportedOAuthProviders = map[string]bool{
+	"github": true,
+	"google": true,
+	"apple":  true,
+}
+
+// isSupportedOAuthProvider reports whether provider is one pad accepts.
+func isSupportedOAuthProvider(provider string) bool {
+	return supportedOAuthProviders[provider]
+}
+
 // validateCloudSecret checks the cloud_secret field in a JSON request body
 // against the server's configured cloud secret. Returns true if the secret
 // matches; writes a 403 error and returns false otherwise.
@@ -161,8 +179,8 @@ func (s *Server) handleOAuthLogin(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "bad_request", "provider is required")
 		return
 	}
-	if input.Provider != "github" && input.Provider != "google" {
-		writeError(w, http.StatusBadRequest, "bad_request", "provider must be 'github' or 'google'")
+	if !isSupportedOAuthProvider(input.Provider) {
+		writeError(w, http.StatusBadRequest, "bad_request", "provider must be 'github', 'google', or 'apple'")
 		return
 	}
 
@@ -385,8 +403,8 @@ func (s *Server) handleOAuthLink(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// 2. Validate provider
-	if input.Provider != "github" && input.Provider != "google" {
-		writeError(w, http.StatusBadRequest, "bad_request", "provider must be 'github' or 'google'")
+	if !isSupportedOAuthProvider(input.Provider) {
+		writeError(w, http.StatusBadRequest, "bad_request", "provider must be 'github', 'google', or 'apple'")
 		return
 	}
 
@@ -457,8 +475,8 @@ func (s *Server) handleOAuthUnlink(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if input.Provider != "github" && input.Provider != "google" {
-		writeError(w, http.StatusBadRequest, "bad_request", "provider must be 'github' or 'google'")
+	if !isSupportedOAuthProvider(input.Provider) {
+		writeError(w, http.StatusBadRequest, "bad_request", "provider must be 'github', 'google', or 'apple'")
 		return
 	}
 

--- a/internal/server/handlers_oauth_provider_test.go
+++ b/internal/server/handlers_oauth_provider_test.go
@@ -94,6 +94,45 @@ func TestOAuthLogin_AppleProvider_StillRequiresVerifiedEmail(t *testing.T) {
 	}
 }
 
+// TestOAuthLink_AppleProvider_Links exercises the second allowlist site
+// (handleOAuthLink) through the real handler, proving the shared helper was
+// wired there too — not just in oauth-login. (oauth-unlink shares the same
+// isSupportedOAuthProvider gate; it's covered by the unit test.)
+func TestOAuthLink_AppleProvider_Links(t *testing.T) {
+	srv := testServer(t)
+	srv.SetCloudMode(oauthProviderTestSecret)
+
+	// Create the account first via a google login, then link apple to it.
+	if rr := postOAuthLogin(t, srv, map[string]interface{}{
+		"provider":       "google",
+		"email":          "linker@example.com",
+		"name":           "Linker",
+		"email_verified": true,
+	}); rr.Code != http.StatusOK {
+		t.Fatalf("seed google login: got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	req := cloudAdminReq(t, "POST", "/api/v1/auth/oauth-link", map[string]interface{}{
+		"provider":       "apple",
+		"email":          "linker@example.com",
+		"email_verified": true,
+		"cloud_secret":   oauthProviderTestSecret,
+	}, map[string]string{"X-Cloud-Secret": oauthProviderTestSecret})
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("oauth-link apple: got %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+
+	user, err := srv.store.GetUserByEmail("linker@example.com")
+	if err != nil || user == nil {
+		t.Fatalf("user lookup: %v", err)
+	}
+	if !user.HasOAuthProvider("apple") {
+		t.Errorf("apple not linked via oauth-link: %q", user.OAuthProviders)
+	}
+}
+
 func TestOAuthLogin_UnknownProvider_Rejected(t *testing.T) {
 	srv := testServer(t)
 	srv.SetCloudMode(oauthProviderTestSecret)

--- a/internal/server/handlers_oauth_provider_test.go
+++ b/internal/server/handlers_oauth_provider_test.go
@@ -1,0 +1,122 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// Tests for the oauth-login provider allowlist (PLAN-1772 / TASK-1773).
+// Apple joins github/google as an accepted provider; the find-or-create +
+// provider-link path is provider-agnostic, so a fresh apple login must
+// create and link a user exactly like the others, while unknown providers
+// stay rejected.
+
+const oauthProviderTestSecret = "shh-its-a-secret"
+
+// postOAuthLogin fires a cloud-secret-authenticated oauth-login request and
+// returns the recorder. The cloud secret rides the JSON body (the same
+// channel validateCloudSecret reads).
+func postOAuthLogin(t *testing.T, srv *Server, body map[string]interface{}) *httptest.ResponseRecorder {
+	t.Helper()
+	body["cloud_secret"] = oauthProviderTestSecret
+	req := cloudAdminReq(t, "POST", "/api/v1/auth/oauth-login", body,
+		map[string]string{"X-Cloud-Secret": oauthProviderTestSecret})
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	return rr
+}
+
+func TestOAuthLogin_AppleProvider_CreatesAndLinksUser(t *testing.T) {
+	srv := testServer(t)
+	srv.SetCloudMode(oauthProviderTestSecret)
+
+	rr := postOAuthLogin(t, srv, map[string]interface{}{
+		"provider":       "apple",
+		"email":          "applefan@example.com",
+		"name":           "Apple Fan",
+		"email_verified": true,
+	})
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("apple oauth-login: got %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		Token   string `json:"token"`
+		NewUser bool   `json:"new_user"`
+		User    struct {
+			Email string `json:"email"`
+		} `json:"user"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Token == "" {
+		t.Error("expected a session token in the response")
+	}
+	if !resp.NewUser {
+		t.Error("first apple login should create a new user")
+	}
+
+	// The provider must have been linked, otherwise a second apple login
+	// would hit the oauth_provider_not_linked gate.
+	user, err := srv.store.GetUserByEmail("applefan@example.com")
+	if err != nil || user == nil {
+		t.Fatalf("user not created: %v", err)
+	}
+	if !user.HasOAuthProvider("apple") {
+		t.Errorf("apple provider not linked on the new user: %q", user.OAuthProviders)
+	}
+
+	// And a returning apple login resolves the same account (no 403).
+	rr2 := postOAuthLogin(t, srv, map[string]interface{}{
+		"provider":       "apple",
+		"email":          "applefan@example.com",
+		"email_verified": true,
+	})
+	if rr2.Code != http.StatusOK {
+		t.Fatalf("returning apple login: got %d, want 200: %s", rr2.Code, rr2.Body.String())
+	}
+}
+
+func TestOAuthLogin_AppleProvider_StillRequiresVerifiedEmail(t *testing.T) {
+	srv := testServer(t)
+	srv.SetCloudMode(oauthProviderTestSecret)
+
+	rr := postOAuthLogin(t, srv, map[string]interface{}{
+		"provider":       "apple",
+		"email":          "unverified@example.com",
+		"email_verified": false,
+	})
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("unverified apple email: got %d, want 403: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestOAuthLogin_UnknownProvider_Rejected(t *testing.T) {
+	srv := testServer(t)
+	srv.SetCloudMode(oauthProviderTestSecret)
+
+	rr := postOAuthLogin(t, srv, map[string]interface{}{
+		"provider":       "facebook",
+		"email":          "someone@example.com",
+		"email_verified": true,
+	})
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("unknown provider: got %d, want 400: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestIsSupportedOAuthProvider(t *testing.T) {
+	for _, p := range []string{"github", "google", "apple"} {
+		if !isSupportedOAuthProvider(p) {
+			t.Errorf("%q should be supported", p)
+		}
+	}
+	for _, p := range []string{"", "facebook", "Apple", "GITHUB", "twitter"} {
+		if isSupportedOAuthProvider(p) {
+			t.Errorf("%q must not be supported (allowlist is exact-match)", p)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

T1 of PLAN-1772 (Sign in with Apple for iOS — App Store Guideline 4.8). Lets pad recognize `apple` as an OAuth provider so the upcoming pad-cloud `/auth/apple/native` endpoint (TASK-1774) can call oauth-login with `provider=apple`.

Three handlers (`handleOAuthLogin`, `handleOAuthLink`, `handleOAuthUnlink` in `internal/server/handlers_cloud.go`) each hard-rejected anything but `github`/`google`. Replaced the triplicated literal with a shared `supportedOAuthProviders` map + `isSupportedOAuthProvider` helper, now including `apple`.

The rest of the path is already provider-agnostic and unchanged: find-or-create user, auto-link, the `oauth_provider_not_linked` gate for existing accounts, the verified-email requirement. Storage (`users.oauth_providers`) is a free-form JSON array with no DB constraint — **no migration**.

## Trust boundary unchanged

These endpoints are cloud-secret-authenticated; the pad-cloud sidecar verifies the provider response before calling (GitHub/Google via the browser redirect; Apple via identity-token JWT verification, TASK-1774). Widening the allowlist doesn't move the boundary.

## Tests

`handlers_oauth_provider_test.go`: apple login creates+links a new user and a returning apple login resolves it; apple still requires a verified email (403); unknown provider 400; `oauth-link` accepts apple (proves the second call site); `isSupportedOAuthProvider` unit table (exact-match: rejects `""`, `Apple`, `GITHUB`, `facebook`). `make check` clean (lint + all Go tests + web build).

## Review

Codex (CONVE-735): no server security regression; confirmed the refactor is consistent across all three sites. Findings actioned:
- nit (link/unlink not exercised) → added the oauth-link apple test.
- 2× P2 on the **web console** (settings hides an Apple link; login page can't represent apple) → tracked as **TASK-1777**, not expanded into this server PR. Under the iOS-only scope there's no web Apple flow, so the fix is "show-if-linked, no Connect button" — its own change, must land before App Store submission.

Prerequisite for TASK-1774 (pad-cloud Apple endpoint). Server deploys manually (same as PLAN-1753).