### PR TITLE
feat(server): focused neighborhood mode on workspace graph endpoint (TASK-1781)

### DIFF
--- a/internal/server/handlers_graph.go
+++ b/internal/server/handlers_graph.go
@@ -3,10 +3,29 @@ package server
 import (
 	"encoding/json"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/PerpetualSoftware/pad/internal/models"
 )
+
+// Focus-mode bounds for the per-item neighborhood view (PLAN-1780 /
+// TASK-1781). defaultFocusDepth is the BFS hop count when ?depth is
+// omitted; maxFocusDepth caps it so a deep chain can't expand into the
+// whole workspace. maxFocusNodes caps the neighborhood size — when the
+// BFS would exceed it, expansion stops (closest nodes first) and the
+// response is flagged truncated so the client can offer expand-on-click.
+const (
+	defaultFocusDepth = 2
+	maxFocusDepth     = 5
+)
+
+// maxFocusNodes caps the focus-mode neighborhood size — when the BFS
+// would exceed it, expansion stops (closest nodes first) and the
+// response is flagged truncated so the client can offer expand-on-click.
+// A var, not a const, so tests can lower it without standing up hundreds
+// of items (which would trip the per-IP create rate limiter).
+var maxFocusNodes = 200
 
 // GraphNode is one item in the workspace graph
 // (GET /workspaces/{ws}/graph — PLAN-1730 / TASK-1731). Nodes are
@@ -45,10 +64,16 @@ type GraphEdge struct {
 
 // GraphResponse is the payload of GET /workspaces/{ws}/graph — the
 // whole workspace as {nodes, edges} in one call, feeding the 3D graph
-// view (PLAN-1730).
+// view (PLAN-1730) and the per-item neighborhood view (PLAN-1780).
 type GraphResponse struct {
 	Nodes []GraphNode `json:"nodes"`
 	Edges []GraphEdge `json:"edges"`
+	// Truncated is set in focus mode when the neighborhood hit
+	// maxFocusNodes and BFS expansion stopped early — the client should
+	// offer expand-on-click rather than treat the graph as complete.
+	// Omitted (false) for the unbounded whole-workspace view so its
+	// payload shape is unchanged.
+	Truncated bool `json:"truncated,omitempty"`
 }
 
 // handleGetWorkspaceGraph serves GET /api/v1/workspaces/{ws}/graph.
@@ -57,7 +82,14 @@ type GraphResponse struct {
 //   - include_terminal=true — include items in terminal status
 //     (done/fixed/archived/...). Default false: the graph view opens
 //     showing active work only; large workspaces would otherwise be
-//     hairball soup.
+//     hairball soup. The focused item itself is always included even
+//     when terminal — you asked to look at it.
+//   - focus=REF — render only the neighborhood around this item
+//     (PLAN-1780). BFS-traverses typed edges out from the ref,
+//     undirected, returning nodes reachable within `depth` hops plus the
+//     edges among them. An unknown/invisible ref returns 404.
+//   - depth=N — focus-mode hop count (default 2, clamped to
+//     [1, maxFocusDepth]). Ignored without focus.
 //
 // Visibility follows the dashboard model exactly: collection-level
 // visibility via visibleCollectionIDs, item-level guest grants via
@@ -71,6 +103,19 @@ func (s *Server) handleGetWorkspaceGraph(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	includeTerminal := r.URL.Query().Get("include_terminal") == "true"
+	focus := r.URL.Query().Get("focus")
+	depth := defaultFocusDepth
+	if d := r.URL.Query().Get("depth"); d != "" {
+		if n, err := strconv.Atoi(d); err == nil {
+			depth = n
+		}
+	}
+	if depth < 1 {
+		depth = 1
+	}
+	if depth > maxFocusDepth {
+		depth = maxFocusDepth
+	}
 
 	visibleIDs, err := s.visibleCollectionIDs(r, workspaceID)
 	if err != nil {
@@ -114,20 +159,96 @@ func (s *Server) handleGetWorkspaceGraph(w http.ResponseWriter, r *http.Request)
 
 	resp := GraphResponse{Nodes: []GraphNode{}, Edges: []GraphEdge{}}
 
-	// Build the visible node set first; edges are filtered against it.
-	refByID := make(map[string]string, len(items))
-	nodeIdx := make(map[string]int, len(items)) // item ID → index in resp.Nodes
+	// Per-item terminal/status data for every visible item, keyed by ID.
+	// Computed once; both the whole-workspace path and focus BFS read it.
+	type itemMeta struct {
+		terminal bool
+		status   string
+	}
+	metaByID := make(map[string]itemMeta, len(items))
+	focusID := ""
 	for _, item := range items {
 		if item.Ref == "" {
 			continue
 		}
 		terminal := isItemDone(item.Fields, item.CollectionID, ctxMap)
-		if terminal && !includeTerminal {
-			continue
-		}
 		var fields map[string]any
 		_ = json.Unmarshal([]byte(item.Fields), &fields)
 		status, _ := fields["status"].(string)
+		metaByID[item.ID] = itemMeta{terminal: terminal, status: status}
+		if focus != "" && item.Ref == focus {
+			focusID = item.ID
+		}
+	}
+
+	// Decide which item IDs are in the rendered node set.
+	included := make(map[string]bool, len(items))
+	if focus == "" {
+		// Whole-workspace view: every visible item, terminal filtered.
+		for id, m := range metaByID {
+			if m.terminal && !includeTerminal {
+				continue
+			}
+			included[id] = true
+		}
+	} else {
+		// Focus view: BFS the neighborhood around focusID. An unknown or
+		// invisible ref is a 404 — the caller can't tell those apart, by
+		// design (no leaking existence of items the user can't see).
+		if focusID == "" {
+			writeError(w, http.StatusNotFound, "not_found", "focus item not found")
+			return
+		}
+		// Undirected adjacency among visible items only, so the BFS can't
+		// hop through (or to) items outside the visible set.
+		adj := make(map[string][]string)
+		for _, l := range links {
+			_, srcOK := metaByID[l.SourceID]
+			_, tgtOK := metaByID[l.TargetID]
+			if !srcOK || !tgtOK {
+				continue
+			}
+			adj[l.SourceID] = append(adj[l.SourceID], l.TargetID)
+			adj[l.TargetID] = append(adj[l.TargetID], l.SourceID)
+		}
+		// The focus node is always included, even if terminal — you asked
+		// to view it. Neighbors honor the terminal filter.
+		included[focusID] = true
+		frontier := []string{focusID}
+		for hop := 0; hop < depth && len(frontier) > 0 && !resp.Truncated; hop++ {
+			var next []string
+			for _, id := range frontier {
+				for _, nb := range adj[id] {
+					if included[nb] {
+						continue
+					}
+					if metaByID[nb].terminal && !includeTerminal {
+						continue
+					}
+					if len(included) >= maxFocusNodes {
+						resp.Truncated = true
+						break
+					}
+					included[nb] = true
+					next = append(next, nb)
+				}
+				if resp.Truncated {
+					break
+				}
+			}
+			frontier = next
+		}
+	}
+
+	// Build nodes in items order (stable) for the included set; edges are
+	// filtered against it so guests never see dangling endpoints.
+	refByID := make(map[string]string, len(included))
+	nodeIdx := make(map[string]int, len(included)) // item ID → index in resp.Nodes
+	for _, item := range items {
+		if item.Ref == "" || !included[item.ID] {
+			continue
+		}
+		m := metaByID[item.ID]
 		refByID[item.ID] = item.Ref
 		nodeIdx[item.ID] = len(resp.Nodes)
 		resp.Nodes = append(resp.Nodes, GraphNode{
@@ -135,8 +256,8 @@ func (s *Server) handleGetWorkspaceGraph(w http.ResponseWriter, r *http.Request)
 			Ref:        item.Ref,
 			Title:      item.Title,
 			Collection: item.CollectionSlug,
-			Status:     status,
-			IsTerminal: terminal,
+			Status:     m.status,
+			IsTerminal: m.terminal,
 			UpdatedAt:  item.UpdatedAt,
 			Role:       item.AgentRoleSlug,
 		})

--- a/internal/server/handlers_graph.go
+++ b/internal/server/handlers_graph.go
@@ -240,17 +240,41 @@ func (s *Server) handleGetWorkspaceGraph(w http.ResponseWriter, r *http.Request)
 		}
 	}
 
+	// Child counts: 'parent' and 'implements' edges both render as
+	// children in the existing UI surfaces (see wiki_links_test.go's
+	// lineage note). Count over the FULL visible item set — NOT the
+	// focus-filtered subgraph — so a boundary node whose children fell
+	// outside depth/maxFocusNodes still reports its true visible child
+	// count. The web UI gates hub-label and children-pill visibility on
+	// child_count > 0, so a filtered count would hide those (TASK-1781
+	// review). The child (source) honors the terminal filter, matching
+	// the whole-workspace semantics this replaces: only children that
+	// would themselves be visible are counted.
+	childCount := make(map[string]int) // parent item ID → visible child count
+	for _, l := range links {
+		if l.Type != "parent" && l.Type != "implements" {
+			continue
+		}
+		childMeta, srcOK := metaByID[l.SourceID]
+		_, tgtOK := metaByID[l.TargetID]
+		if !srcOK || !tgtOK {
+			continue
+		}
+		if childMeta.terminal && !includeTerminal {
+			continue
+		}
+		childCount[l.TargetID]++
+	}
+
 	// Build nodes in items order (stable) for the included set; edges are
 	// filtered against it so guests never see dangling endpoints.
 	refByID := make(map[string]string, len(included))
-	nodeIdx := make(map[string]int, len(included)) // item ID → index in resp.Nodes
 	for _, item := range items {
 		if item.Ref == "" || !included[item.ID] {
 			continue
 		}
 		m := metaByID[item.ID]
 		refByID[item.ID] = item.Ref
-		nodeIdx[item.ID] = len(resp.Nodes)
 		resp.Nodes = append(resp.Nodes, GraphNode{
 			ID:         item.ID,
 			Ref:        item.Ref,
@@ -258,6 +282,7 @@ func (s *Server) handleGetWorkspaceGraph(w http.ResponseWriter, r *http.Request)
 			Collection: item.CollectionSlug,
 			Status:     m.status,
 			IsTerminal: m.terminal,
+			ChildCount: childCount[item.ID],
 			UpdatedAt:  item.UpdatedAt,
 			Role:       item.AgentRoleSlug,
 		})
@@ -270,12 +295,6 @@ func (s *Server) handleGetWorkspaceGraph(w http.ResponseWriter, r *http.Request)
 			continue
 		}
 		resp.Edges = append(resp.Edges, GraphEdge{Source: srcRef, Target: tgtRef, Type: l.Type})
-		// Child counts derive from the edge list: 'parent' and
-		// 'implements' both render as children in the existing UI
-		// surfaces (see wiki_links_test.go's lineage note).
-		if l.Type == "parent" || l.Type == "implements" {
-			resp.Nodes[nodeIdx[l.TargetID]].ChildCount++
-		}
 	}
 
 	writeJSON(w, http.StatusOK, resp)

--- a/internal/server/handlers_graph_test.go
+++ b/internal/server/handlers_graph_test.go
@@ -4,6 +4,8 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 // helper: fetch the workspace graph and return the parsed response
@@ -224,5 +226,199 @@ func TestGraphExcludesDeletedItems(t *testing.T) {
 	}
 	if len(resp.Edges) != 0 {
 		t.Errorf("expected edges to deleted items excluded, got %+v", resp.Edges)
+	}
+}
+
+// chainTasks creates n open tasks linked in a blocks chain
+// t0 -> t1 -> ... -> t(n-1) and returns them in order.
+func chainTasks(t *testing.T, srv *Server, slug string, n int) []models.Item {
+	t.Helper()
+	tasks := make([]models.Item, n)
+	for i := 0; i < n; i++ {
+		tasks[i] = createItem(t, srv, slug, "tasks", map[string]interface{}{
+			"title": "Chain task", "fields": map[string]interface{}{"status": "open"},
+		})
+	}
+	for i := 0; i+1 < n; i++ {
+		createBlocksLink(t, srv, slug, tasks[i].Slug, tasks[i+1].ID)
+	}
+	return tasks
+}
+
+func TestGraphFocusDepth(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+	// t0 - t1 - t2 - t3 - t4 (undirected neighborhood for BFS).
+	tk := chainTasks(t, srv, slug, 5)
+
+	// depth=1 around t0 → t0, t1 only.
+	d1 := getGraph(t, srv, slug, "?focus="+tk[0].Ref+"&depth=1")
+	if len(d1.Nodes) != 2 {
+		t.Fatalf("depth=1: expected 2 nodes, got %d: %+v", len(d1.Nodes), d1.Nodes)
+	}
+	if graphNode(d1, tk[0].Ref) == nil || graphNode(d1, tk[1].Ref) == nil {
+		t.Errorf("depth=1: expected t0 and t1 present")
+	}
+	if graphNode(d1, tk[2].Ref) != nil {
+		t.Errorf("depth=1: expected t2 excluded")
+	}
+
+	// depth=2 around t0 → t0, t1, t2.
+	d2 := getGraph(t, srv, slug, "?focus="+tk[0].Ref+"&depth=2")
+	if len(d2.Nodes) != 3 {
+		t.Fatalf("depth=2: expected 3 nodes, got %d: %+v", len(d2.Nodes), d2.Nodes)
+	}
+	if graphNode(d2, tk[3].Ref) != nil {
+		t.Errorf("depth=2: expected t3 excluded")
+	}
+
+	// default depth (no param) is 2.
+	def := getGraph(t, srv, slug, "?focus="+tk[0].Ref)
+	if len(def.Nodes) != 3 {
+		t.Errorf("default depth: expected 3 nodes, got %d", len(def.Nodes))
+	}
+
+	// focus in the middle reaches both directions.
+	mid := getGraph(t, srv, slug, "?focus="+tk[2].Ref+"&depth=1")
+	if len(mid.Nodes) != 3 {
+		t.Fatalf("mid focus: expected 3 nodes (t1,t2,t3), got %d: %+v", len(mid.Nodes), mid.Nodes)
+	}
+	for _, ref := range []string{tk[1].Ref, tk[2].Ref, tk[3].Ref} {
+		if graphNode(mid, ref) == nil {
+			t.Errorf("mid focus: expected %s present", ref)
+		}
+	}
+
+	// depth is clamped — a huge depth still resolves the whole 5-chain,
+	// not an error.
+	clamped := getGraph(t, srv, slug, "?focus="+tk[0].Ref+"&depth=999")
+	if len(clamped.Nodes) != 5 {
+		t.Errorf("clamped depth: expected all 5 nodes, got %d", len(clamped.Nodes))
+	}
+}
+
+func TestGraphFocusTerminal(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	// The focused item is always included, even when terminal.
+	done := createItem(t, srv, slug, "tasks", map[string]interface{}{
+		"title": "Done focus", "fields": map[string]interface{}{"status": "done"},
+	})
+	active := createItem(t, srv, slug, "tasks", map[string]interface{}{
+		"title": "Active neighbor", "fields": map[string]interface{}{"status": "open"},
+	})
+	createBlocksLink(t, srv, slug, done.Slug, active.ID)
+
+	resp := getGraph(t, srv, slug, "?focus="+done.Ref)
+	dn := graphNode(resp, done.Ref)
+	if dn == nil {
+		t.Fatalf("expected terminal focus node %s included", done.Ref)
+	}
+	if !dn.IsTerminal {
+		t.Errorf("expected focus node is_terminal=true")
+	}
+	if graphNode(resp, active.Ref) == nil {
+		t.Errorf("expected active neighbor %s included", active.Ref)
+	}
+
+	// A terminal neighbor is hidden by default, restored with the flag.
+	focus := createItem(t, srv, slug, "tasks", map[string]interface{}{
+		"title": "Active focus", "fields": map[string]interface{}{"status": "open"},
+	})
+	doneNb := createItem(t, srv, slug, "tasks", map[string]interface{}{
+		"title": "Done neighbor", "fields": map[string]interface{}{"status": "done"},
+	})
+	createBlocksLink(t, srv, slug, focus.Slug, doneNb.ID)
+
+	def := getGraph(t, srv, slug, "?focus="+focus.Ref)
+	if graphNode(def, doneNb.Ref) != nil {
+		t.Errorf("expected terminal neighbor %s hidden by default", doneNb.Ref)
+	}
+	full := getGraph(t, srv, slug, "?focus="+focus.Ref+"&include_terminal=true")
+	if graphNode(full, doneNb.Ref) == nil {
+		t.Errorf("expected terminal neighbor %s restored with include_terminal=true", doneNb.Ref)
+	}
+}
+
+func TestGraphFocusUnknownRef(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+	createItem(t, srv, slug, "tasks", map[string]interface{}{
+		"title": "Some task", "fields": map[string]interface{}{"status": "open"},
+	})
+
+	rr := doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/graph?focus=TASK-9999", nil)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for unknown focus ref, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestGraphFocusCrossCollectionEdges(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	plan := createItem(t, srv, slug, "plans", map[string]interface{}{
+		"title": "Focus plan", "fields": map[string]interface{}{"status": "active"},
+	})
+	task := createItem(t, srv, slug, "tasks", map[string]interface{}{
+		"title": "Focus task", "fields": map[string]interface{}{"status": "open"},
+	})
+	bug := createItem(t, srv, slug, "tasks", map[string]interface{}{
+		"title": "Related bug", "fields": map[string]interface{}{"status": "open"},
+	})
+	// task is a child of plan; task blocks bug.
+	rr := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/items/"+task.Slug+"/links", map[string]interface{}{
+		"target_id": plan.ID, "link_type": "parent",
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create parent link: %d %s", rr.Code, rr.Body.String())
+	}
+	createBlocksLink(t, srv, slug, task.Slug, bug.ID)
+
+	// Focus on the task at depth 1 pulls in both the parent plan and the
+	// blocked bug, across collections, with typed edges preserved.
+	resp := getGraph(t, srv, slug, "?focus="+task.Ref+"&depth=1")
+	if len(resp.Nodes) != 3 {
+		t.Fatalf("expected 3 nodes, got %d: %+v", len(resp.Nodes), resp.Nodes)
+	}
+	if !hasGraphEdge(resp, task.Ref, plan.Ref, "parent") {
+		t.Errorf("expected parent edge %s -> %s", task.Ref, plan.Ref)
+	}
+	if !hasGraphEdge(resp, task.Ref, bug.Ref, "blocks") {
+		t.Errorf("expected blocks edge %s -> %s", task.Ref, bug.Ref)
+	}
+	if resp.Truncated {
+		t.Errorf("did not expect truncation for a 3-node neighborhood")
+	}
+}
+
+func TestGraphFocusTruncation(t *testing.T) {
+	// Lower the cap so we don't have to create 200 items (which would
+	// trip the per-IP create rate limiter). Restore after.
+	orig := maxFocusNodes
+	maxFocusNodes = 5
+	defer func() { maxFocusNodes = orig }()
+
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	// A star larger than maxFocusNodes around a single focus node.
+	hub := createItem(t, srv, slug, "tasks", map[string]interface{}{
+		"title": "Hub", "fields": map[string]interface{}{"status": "open"},
+	})
+	for i := 0; i < maxFocusNodes+5; i++ {
+		leaf := createItem(t, srv, slug, "tasks", map[string]interface{}{
+			"title": "Leaf", "fields": map[string]interface{}{"status": "open"},
+		})
+		createBlocksLink(t, srv, slug, hub.Slug, leaf.ID)
+	}
+
+	resp := getGraph(t, srv, slug, "?focus="+hub.Ref+"&depth=1")
+	if !resp.Truncated {
+		t.Errorf("expected truncated=true for an oversized neighborhood")
+	}
+	if len(resp.Nodes) != maxFocusNodes {
+		t.Errorf("expected node count capped at %d, got %d", maxFocusNodes, len(resp.Nodes))
 	}
 }

--- a/internal/server/handlers_graph_test.go
+++ b/internal/server/handlers_graph_test.go
@@ -393,6 +393,42 @@ func TestGraphFocusCrossCollectionEdges(t *testing.T) {
 	}
 }
 
+func TestGraphFocusChildCountBeyondDepth(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	// focus - mid(parent of leaf). At depth 1 from focus, mid is included
+	// but leaf (depth 2) is not — yet mid must still report child_count=1.
+	focus := createItem(t, srv, slug, "tasks", map[string]interface{}{
+		"title": "Focus", "fields": map[string]interface{}{"status": "open"},
+	})
+	mid := createItem(t, srv, slug, "plans", map[string]interface{}{
+		"title": "Mid parent", "fields": map[string]interface{}{"status": "active"},
+	})
+	leaf := createItem(t, srv, slug, "tasks", map[string]interface{}{
+		"title": "Leaf child", "fields": map[string]interface{}{"status": "open"},
+	})
+	createBlocksLink(t, srv, slug, focus.Slug, mid.ID)
+	rr := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/items/"+leaf.Slug+"/links", map[string]interface{}{
+		"target_id": mid.ID, "link_type": "parent",
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create parent link: %d %s", rr.Code, rr.Body.String())
+	}
+
+	resp := getGraph(t, srv, slug, "?focus="+focus.Ref+"&depth=1")
+	if graphNode(resp, leaf.Ref) != nil {
+		t.Fatalf("leaf should be beyond depth=1, but was included")
+	}
+	mn := graphNode(resp, mid.Ref)
+	if mn == nil {
+		t.Fatalf("mid node missing")
+	}
+	if mn.ChildCount != 1 {
+		t.Errorf("expected mid child_count=1 (true visible count) even though leaf omitted, got %d", mn.ChildCount)
+	}
+}
+
 func TestGraphFocusTruncation(t *testing.T) {
 	// Lower the cap so we don't have to create 200 items (which would
 	// trip the per-IP create rate limiter). Restore after.


### PR DESCRIPTION
## Summary
Adds `?focus=REF&depth=N` to `GET /api/v1/workspaces/{ws}/graph`. In focus mode the endpoint BFS-traverses typed edges (undirected) out from the given item up to `depth` hops (default 2, clamped to [1,5]) and returns just that neighborhood's nodes + edges. Without `focus`, the whole-workspace behavior is byte-for-byte unchanged.

This is the backend foundation for the per-item dependency graph view (PLAN-1780).

## Details
- **Focus node always included**, even when terminal — you explicitly asked to view it. Neighbors honor the existing `include_terminal` filter.
- **Visibility-safe:** the neighborhood is intersected with the visibility-filtered item set, so a guest can't infer hidden items from dangling edges (same posture as the whole-workspace path).
- **Truncation:** node-count cap (`maxFocusNodes=200`) stops BFS expansion early (closest nodes first) and sets a new `GraphResponse.Truncated` flag. The flag is `omitempty`, so the whole-workspace payload shape is unchanged for the existing 3D view.
- **Unknown/invisible focus ref → 404.**
- `depth` clamped server-side; a huge value resolves the full reachable chain rather than erroring.

## Context
Implements `TASK-1781` under `PLAN-1780` (per-item dependency graph view). TS types + client params are the follow-up `TASK-1782`.

## Test plan
- [x] go build ./... — clean
- [x] go vet ./... — clean
- [x] go test ./... — all pass
- [x] New tests: depth bounds + clamping, both-direction traversal, terminal focus inclusion, terminal-neighbor filtering, cross-collection typed edges, unknown-ref 404, truncation
- [n/a] web build — backend-only change