### PR TITLE
feat(web): graph.getFocused client + truncated field for focus mode (TASK-1782)

### DIFF
--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -1003,7 +1003,26 @@ export const api = {
 		get: (ws: string, includeTerminal = false) =>
 			request<GraphResponse>(
 				`/workspaces/${ws}/graph${includeTerminal ? '?include_terminal=true' : ''}`
-			)
+			),
+
+		/**
+		 * Focused neighborhood around a single item (PLAN-1780): the nodes
+		 * reachable within `depth` hops (server default 2, clamped [1,5])
+		 * plus the edges among them. The response's `truncated` flag is set
+		 * when the neighborhood hit the server's node cap. includeTerminal
+		 * pulls done items into the neighborhood (the focused item itself is
+		 * always returned, even when terminal).
+		 */
+		getFocused: (
+			ws: string,
+			focusRef: string,
+			opts: { depth?: number; includeTerminal?: boolean } = {}
+		) => {
+			const params = new URLSearchParams({ focus: focusRef });
+			if (opts.depth != null) params.set('depth', String(opts.depth));
+			if (opts.includeTerminal) params.set('include_terminal', 'true');
+			return request<GraphResponse>(`/workspaces/${ws}/graph?${params}`);
+		}
 	},
 
 	// ── Project Report (PLAN-1628 / TASK-1630) ────────────────────────────────

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -1013,6 +1013,13 @@ export interface GraphEdge {
 export interface GraphResponse {
 	nodes: GraphNode[];
 	edges: GraphEdge[];
+	/**
+	 * Focus mode only (PLAN-1780): true when the neighborhood hit the
+	 * server's node cap and BFS expansion stopped early — the client
+	 * should offer expand-on-click rather than treat the graph as
+	 * complete. Absent (falsy) for the whole-workspace view.
+	 */
+	truncated?: boolean;
 }
 
 // ─── Project Report (PLAN-1628 / TASK-1630) ──────────────────────────────────


### PR DESCRIPTION
## Summary
Surfaces the TASK-1781 backend focus mode to the TypeScript web client.

- `GraphResponse` gains an optional `truncated?: boolean` — focus-mode-only; absent for the whole-workspace view.
- New `api.graph.getFocused(ws, focusRef, { depth?, includeTerminal? })` builds `?focus=REF&depth=N[&include_terminal=true]` (uses `URLSearchParams` for safe encoding).
- Existing `api.graph.get` is untouched, so the 3D view keeps working.

## Context
Implements `TASK-1782` under `PLAN-1780`. Backend (`TASK-1781`) merged in #718; the renderer (`TASK-1783`) consumes `getFocused` next.

## Test plan
- [x] cd web && npm run build — clean
- [n/a] go tests — no Go changes