### PR TITLE
feat(web): live SSE updates in the dependency-graph drawer (TASK-1785)

### DIFF
--- a/web/src/lib/components/graph/ItemGraph.svelte
+++ b/web/src/lib/components/graph/ItemGraph.svelte
@@ -300,21 +300,26 @@
 	}
 
 	function handleItemEvent(event: ItemEvent) {
+		// Only react to items in the CURRENT neighborhood — an edit to an
+		// unrelated item elsewhere in the workspace must not trigger a refetch
+		// (the SSE stream is workspace-wide and chatty). A brand-new item isn't
+		// in view and has no links to us yet, so item_created no-ops here; when
+		// it's actually linked into the neighborhood, the visible endpoint gets
+		// an item_updated, which is in-view and refetches — surfacing the new
+		// neighbor then.
+		if (!refForUuid(event.item_id)) return;
 		switch (event.type) {
 			case 'item_updated':
-				touch(event.item_id); // snappy glow
-				scheduleRefetch(); // status/title/terminal may have changed
-				break;
-			case 'item_created':
 			case 'item_archived':
 			case 'item_restored':
-				// Structural: a node may need to appear or disappear.
-				scheduleRefetch();
+				touch(event.item_id); // snappy glow
+				scheduleRefetch(); // status/title/terminal/structure may have changed
 				break;
 			case 'comment_created':
 				touch(event.item_id); // ambient liveness, glow only
 				break;
-			// Ignore comment_updated/deleted, reaction_*, workspace_updated, etc.
+			// Ignore item_created (not in view), comment_updated/deleted,
+			// reaction_*, workspace_updated, etc.
 		}
 	}
 
@@ -327,6 +332,9 @@
 			unsubEvent();
 			unsubSync();
 			if (refetchTimer) clearTimeout(refetchTimer);
+			// Invalidate any in-flight load so it can't commit $state (or queue a
+			// fitView) after the drawer closes / component unmounts.
+			loadToken++;
 		};
 	});
 

--- a/web/src/lib/components/graph/ItemGraph.svelte
+++ b/web/src/lib/components/graph/ItemGraph.svelte
@@ -239,6 +239,12 @@
 			contentBounds = laid.bounds;
 			loadState = 'ready';
 			if (!background) queueFit(); // don't yank the view on ambient updates
+			// A mutation that arrived mid-load was deferred; now that we're ready,
+			// reconcile it (the just-committed response may predate it).
+			if (pendingRefetch) {
+				pendingRefetch = false;
+				scheduleRefetch();
+			}
 		} catch (err) {
 			if (token !== loadToken) return;
 			if (!background) {
@@ -278,6 +284,10 @@
 	// event, not the first). Tracked so teardown can cancel them — otherwise a
 	// timeout could fire and write touchedRefs on a destroyed component.
 	const glowTimers = new Map<string, ReturnType<typeof setTimeout>>();
+	// Set when a refetch is requested before the first graph is ready; flushed
+	// once load() commits a ready graph, so a mutation that lands mid-initial-load
+	// (and may not be reflected in that first response) still gets reconciled.
+	let pendingRefetch = false;
 
 	function refForUuid(uuid: string): string | undefined {
 		return renderNodes.find((n) => n.id === uuid)?.ref;
@@ -307,9 +317,12 @@
 		// Before that (initial load in flight, or an error/idle state), a
 		// background load would cancel the foreground load's token while skipping
 		// fit + error handling — leaving the view un-fitted or stuck on the
-		// spinner. The in-flight initial load already fetches the latest data, so
-		// dropping events here loses nothing.
-		if (loadState !== 'ready') return;
+		// spinner. Defer instead of drop: the initial load may have been issued
+		// before this mutation, so we flush a refetch once it reaches ready.
+		if (loadState !== 'ready') {
+			pendingRefetch = true;
+			return;
+		}
 		if (refetchTimer) clearTimeout(refetchTimer);
 		refetchTimer = setTimeout(() => {
 			refetchTimer = null;

--- a/web/src/lib/components/graph/ItemGraph.svelte
+++ b/web/src/lib/components/graph/ItemGraph.svelte
@@ -273,9 +273,11 @@
 	const REFETCH_DEBOUNCE_MS = 400;
 	let touchedRefs = $state(new Set<string>());
 	let refetchTimer: ReturnType<typeof setTimeout> | null = null;
-	// Pending glow-clear timers, tracked so teardown can cancel them — otherwise
-	// a timeout could fire and write touchedRefs on a destroyed component.
-	const glowTimers = new Set<ReturnType<typeof setTimeout>>();
+	// Pending glow-clear timers, keyed by ref so a re-touch RESETS that ref's
+	// window (a burst keeps it lit; the fade starts GLOW_MS after the LAST
+	// event, not the first). Tracked so teardown can cancel them — otherwise a
+	// timeout could fire and write touchedRefs on a destroyed component.
+	const glowTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
 	function refForUuid(uuid: string): string | undefined {
 		return renderNodes.find((n) => n.id === uuid)?.ref;
@@ -284,16 +286,20 @@
 	function touch(uuid: string) {
 		const ref = refForUuid(uuid);
 		if (!ref) return;
-		const next = new Set(touchedRefs);
-		next.add(ref);
-		touchedRefs = next;
+		const existing = glowTimers.get(ref);
+		if (existing) clearTimeout(existing); // reset this ref's fade window
+		if (!touchedRefs.has(ref)) {
+			const next = new Set(touchedRefs);
+			next.add(ref);
+			touchedRefs = next;
+		}
 		const handle = setTimeout(() => {
-			glowTimers.delete(handle);
+			glowTimers.delete(ref);
 			const after = new Set(touchedRefs);
 			after.delete(ref);
 			touchedRefs = after;
 		}, GLOW_MS);
-		glowTimers.add(handle);
+		glowTimers.set(ref, handle);
 	}
 
 	function scheduleRefetch() {
@@ -337,7 +343,7 @@
 			unsubEvent();
 			unsubSync();
 			if (refetchTimer) clearTimeout(refetchTimer);
-			for (const h of glowTimers) clearTimeout(h);
+			for (const h of glowTimers.values()) clearTimeout(h);
 			glowTimers.clear();
 			// Invalidate any in-flight load so it can't commit $state (or queue a
 			// fitView) after the drawer closes / component unmounts.
@@ -764,7 +770,7 @@
 	}
 	.node-bg {
 		stroke-width: 1.5;
-		transition: stroke-width 0.12s;
+		transition: stroke-width 0.12s, filter 0.5s ease-out;
 	}
 	.node.focus .node-bg {
 		stroke-width: 3;
@@ -782,19 +788,12 @@
 	.node:focus-visible .node-bg {
 		stroke-width: 3;
 	}
-	/* Transient glow when an item changes live (SSE). */
+	/* Transient glow when an item changes live (SSE). Transition-based (not a
+	   one-shot keyframe) so a burst of events keeps the node lit and it fades
+	   out via the .node-bg filter transition once the ref leaves touchedRefs. */
 	.node.touched .node-bg {
-		animation: node-pulse 2.5s ease-out;
-	}
-	@keyframes node-pulse {
-		0% {
-			filter: drop-shadow(0 0 0 color-mix(in srgb, #fff 90%, transparent));
-			stroke-width: 3.5;
-		}
-		100% {
-			filter: drop-shadow(0 0 10px color-mix(in srgb, #fff 0%, transparent));
-			stroke-width: 1.5;
-		}
+		filter: drop-shadow(0 0 9px color-mix(in srgb, #fff 80%, transparent));
+		stroke-width: 3;
 	}
 	.node-ref {
 		font-family: var(--font-mono, ui-monospace, monospace);

--- a/web/src/lib/components/graph/ItemGraph.svelte
+++ b/web/src/lib/components/graph/ItemGraph.svelte
@@ -303,6 +303,13 @@
 	}
 
 	function scheduleRefetch() {
+		// Background refetch only makes sense once a graph is committed on screen.
+		// Before that (initial load in flight, or an error/idle state), a
+		// background load would cancel the foreground load's token while skipping
+		// fit + error handling — leaving the view un-fitted or stuck on the
+		// spinner. The in-flight initial load already fetches the latest data, so
+		// dropping events here loses nothing.
+		if (loadState !== 'ready') return;
 		if (refetchTimer) clearTimeout(refetchTimer);
 		refetchTimer = setTimeout(() => {
 			refetchTimer = null;

--- a/web/src/lib/components/graph/ItemGraph.svelte
+++ b/web/src/lib/components/graph/ItemGraph.svelte
@@ -105,6 +105,11 @@
 	// matches — discarding stale in-flight responses without re-reading committed
 	// $state inside the effect's reactive frame.
 	let loadToken = 0;
+	// True while any load() is awaiting. Used to COALESCE background refetches:
+	// starting a new one mid-flight would bump loadToken and invalidate the
+	// in-flight response, so a steady event stream could starve updates forever.
+	// Instead we defer until the current load settles, then run exactly one.
+	let loadInFlight = false;
 
 	async function runLayout(payload: GraphResponse): Promise<{
 		nodes: RenderNode[];
@@ -220,6 +225,7 @@
 		const term = includeTerminal;
 
 		const token = ++loadToken;
+		loadInFlight = true;
 		if (background) {
 			refreshing = true;
 		} else {
@@ -247,12 +253,6 @@
 			contentBounds = laid.bounds;
 			loadState = 'ready';
 			if (!background) queueFit(); // don't yank the view on ambient updates
-			// A mutation that arrived mid-load was deferred; now that we're ready,
-			// reconcile it (the just-committed response may predate it).
-			if (pendingRefetch) {
-				pendingRefetch = false;
-				scheduleRefetch();
-			}
 		} catch (err) {
 			if (token !== loadToken) return;
 			if (!background) {
@@ -261,7 +261,20 @@
 			}
 			// background failures: keep the last good graph, try again next event
 		} finally {
-			if (token === loadToken) refreshing = false;
+			// Only the latest load owns the shared flags — a stale (superseded)
+			// load must not clear them out from under the newer one.
+			if (token === loadToken) {
+				refreshing = false;
+				loadInFlight = false;
+				// Flush a coalesced/deferred refetch now that we're idle. runRefetch
+				// re-decides foreground (error recovery) vs background (ready) — so a
+				// mid-load mutation reconciles, and a failed load can still recover
+				// on the next event instead of getting stuck.
+				if (pendingRefetch) {
+					pendingRefetch = false;
+					scheduleRefetch();
+				}
+			}
 		}
 	}
 
@@ -321,28 +334,29 @@
 	}
 
 	function scheduleRefetch() {
-		// Background refetch only makes sense once a graph is committed on screen.
-		// Before that (initial load in flight, or an error/idle state), a
-		// background load would cancel the foreground load's token while skipping
-		// fit + error handling — leaving the view un-fitted or stuck on the
-		// spinner. Defer instead of drop: the initial load may have been issued
-		// before this mutation, so we flush a refetch once it reaches ready.
-		if (loadState !== 'ready') {
+		if (refetchTimer) clearTimeout(refetchTimer);
+		refetchTimer = setTimeout(runRefetch, REFETCH_DEBOUNCE_MS);
+	}
+
+	// Fire a refetch, choosing the right mode for the current state. Deferring
+	// (pendingRefetch) is flushed from load()'s finally once it settles, so no
+	// signal is lost and no second load runs concurrently.
+	function runRefetch() {
+		refetchTimer = null;
+		if (loadInFlight) {
+			// Coalesce — a load is already awaiting; run one after it settles.
 			pendingRefetch = true;
 			return;
 		}
-		if (refetchTimer) clearTimeout(refetchTimer);
-		refetchTimer = setTimeout(() => {
-			refetchTimer = null;
-			// Re-check at fire time: state may have left 'ready' since scheduling
-			// (e.g. a foreground reroot started, or an error). Defer rather than
-			// clobber the foreground load.
-			if (loadState !== 'ready') {
-				pendingRefetch = true;
-				return;
-			}
-			void load(true);
-		}, REFETCH_DEBOUNCE_MS);
+		if (loadState === 'ready') {
+			void load(true); // background: keep the current graph visible
+		} else if (loadState === 'error') {
+			void load(false); // recover from a transient failure on the next event
+		} else {
+			// 'loading'/'idle' with nothing in flight shouldn't happen, but defer
+			// to be safe rather than start an unguarded load.
+			pendingRefetch = true;
+		}
 	}
 
 	function handleItemEvent(event: ItemEvent) {

--- a/web/src/lib/components/graph/ItemGraph.svelte
+++ b/web/src/lib/components/graph/ItemGraph.svelte
@@ -346,26 +346,28 @@
 	}
 
 	function handleItemEvent(event: ItemEvent) {
-		// Only react to items in the CURRENT neighborhood — an edit to an
-		// unrelated item elsewhere in the workspace must not trigger a refetch
-		// (the SSE stream is workspace-wide and chatty). A brand-new item isn't
-		// in view and has no links to us yet, so item_created no-ops here; when
-		// it's actually linked into the neighborhood, the visible endpoint gets
-		// an item_updated, which is in-view and refetches — surfacing the new
-		// neighbor then.
-		if (!refForUuid(event.item_id)) return;
 		switch (event.type) {
 			case 'item_updated':
+			case 'item_created':
 			case 'item_archived':
 			case 'item_restored':
-				touch(event.item_id); // snappy glow
-				scheduleRefetch(); // status/title/terminal/structure may have changed
+				// Glow only applies to nodes already on screen — touch() no-ops for
+				// off-view items (nothing to light up).
+				touch(event.item_id);
+				// Refetch regardless of whether the item is currently in view.
+				// Structural changes that add/remove a neighbor (a new child under a
+				// visible parent, or a reparent) are published by the server on the
+				// CHILD — which may be off-view — and the event carries no link info
+				// to distinguish a reparent from a plain field edit. So we can't
+				// gate on in-view without missing newly-attached neighbors. The cost
+				// is bounded: the 400ms debounce collapses bursts into one small
+				// getFocused call and the drawer is only open transiently.
+				scheduleRefetch();
 				break;
 			case 'comment_created':
 				touch(event.item_id); // ambient liveness, glow only
 				break;
-			// Ignore item_created (not in view), comment_updated/deleted,
-			// reaction_*, workspace_updated, etc.
+			// Ignore comment_updated/deleted, reaction_*, workspace_updated, etc.
 		}
 	}
 

--- a/web/src/lib/components/graph/ItemGraph.svelte
+++ b/web/src/lib/components/graph/ItemGraph.svelte
@@ -12,10 +12,11 @@
 	// Styling mirrors the 3D graph's control/detail surfaces (color-mix
 	// translucency, backdrop-blur) so it reads as the same UI inside a drawer.
 
-	import { untrack } from 'svelte';
+	import { onMount, untrack } from 'svelte';
 	import { api } from '$lib/api/client';
 	import type { GraphEdge, GraphNode, GraphResponse } from '$lib/types';
 	import { createCollectionColorMap } from '$lib/graph/palette';
+	import { sseService, type ItemEvent } from '$lib/services/sse.svelte';
 
 	let {
 		workspace,
@@ -63,6 +64,7 @@
 
 	// ── Rendered model ────────────────────────────────────────────────────────────
 	interface RenderNode {
+		id: string; // item UUID — bridges SSE item events (item_id) to nodes
 		ref: string;
 		title: string;
 		collection: string;
@@ -156,6 +158,7 @@
 			if (!pos) continue;
 			const color = palette.colorForCollection(n.collection);
 			nodes.push({
+				id: n.id,
 				ref: n.ref,
 				title: n.title,
 				collection: n.collection,
@@ -202,56 +205,130 @@
 		return { nodes, edges, legend: legendEntries, bounds };
 	}
 
-	// ── Data-loading effect ───────────────────────────────────────────────────────
-	// Separate from the prop-sync effect (CONVE-606). Depends on workspace,
-	// currentFocus, depth, includeTerminal. Uses the loadToken guard so it never
-	// reads+writes the same committed $state in one reactive pass (CONVE-1688).
-	$effect(() => {
+	let refreshing = $state(false);
+
+	// Fetch + lay out the current (workspace, currentFocus, depth, includeTerminal).
+	// `background` mode (SSE-driven refetch) keeps the existing graph visible — no
+	// loading spinner, no view-refit, and errors are swallowed so an ambient blip
+	// never replaces a good graph with an error card. The loadToken guard discards
+	// stale in-flight responses (CONVE-1688: never read+write the same committed
+	// $state inside one reactive pass — the token is a plain local, not a rune).
+	async function load(background: boolean) {
 		const ws = workspace;
 		const focus = currentFocus;
 		const d = depth;
 		const term = includeTerminal;
-		void retryNonce; // dependency only — retry() bumps it to force a re-run
 
 		const token = ++loadToken;
-		loadState = 'loading';
-		errorMessage = '';
+		if (background) {
+			refreshing = true;
+		} else {
+			loadState = 'loading';
+			errorMessage = '';
+		}
 
-		let cancelled = false;
-		(async () => {
-			try {
-				const payload = await api.graph.getFocused(ws, focus, {
-					depth: d,
-					includeTerminal: term
-				});
-				if (cancelled || token !== loadToken) return;
-				const laid = await runLayout(payload);
-				if (cancelled || token !== loadToken) return;
-				renderNodes = laid.nodes;
-				renderEdges = laid.edges;
-				legend = laid.legend;
-				truncated = payload.truncated ?? false;
-				contentBounds = laid.bounds;
-				loadState = 'ready';
-				// Re-fit the view to the freshly laid-out content.
-				queueFit();
-			} catch (err) {
-				if (cancelled || token !== loadToken) return;
+		try {
+			const payload = await api.graph.getFocused(ws, focus, { depth: d, includeTerminal: term });
+			if (token !== loadToken) return;
+			const laid = await runLayout(payload);
+			if (token !== loadToken) return;
+			renderNodes = laid.nodes;
+			renderEdges = laid.edges;
+			legend = laid.legend;
+			truncated = payload.truncated ?? false;
+			contentBounds = laid.bounds;
+			loadState = 'ready';
+			if (!background) queueFit(); // don't yank the view on ambient updates
+		} catch (err) {
+			if (token !== loadToken) return;
+			if (!background) {
 				errorMessage = err instanceof Error ? err.message : 'Failed to load the graph.';
 				loadState = 'error';
 			}
-		})();
+			// background failures: keep the last good graph, try again next event
+		} finally {
+			if (token === loadToken) refreshing = false;
+		}
+	}
 
-		return () => {
-			cancelled = true;
-		};
+	// ── Data-loading effect ───────────────────────────────────────────────────────
+	// Separate from the prop-sync effect (CONVE-606). load() reads workspace,
+	// currentFocus, depth, includeTerminal synchronously (before its first await),
+	// so they register as this effect's dependencies; retryNonce is read here to
+	// force a re-run after an error without changing a real input.
+	$effect(() => {
+		void retryNonce;
+		void load(false);
 	});
 
 	function retry() {
-		// Force the load effect to re-run without changing any real input —
-		// re-rooting to the same ref wouldn't register as a change.
 		retryNonce++;
 	}
+
+	// ── Live updates (SSE) ──────────────────────────────────────────────────────────
+	// The workspace layout owns sseService.connect(); the open drawer only
+	// subscribes. Events are workspace-scoped — we correlate to the visible
+	// neighborhood by item UUID (node.id); events for items not in view no-op.
+	const GLOW_MS = 2500;
+	const REFETCH_DEBOUNCE_MS = 400;
+	let touchedRefs = $state(new Set<string>());
+	let refetchTimer: ReturnType<typeof setTimeout> | null = null;
+
+	function refForUuid(uuid: string): string | undefined {
+		return renderNodes.find((n) => n.id === uuid)?.ref;
+	}
+
+	function touch(uuid: string) {
+		const ref = refForUuid(uuid);
+		if (!ref) return;
+		const next = new Set(touchedRefs);
+		next.add(ref);
+		touchedRefs = next;
+		setTimeout(() => {
+			const after = new Set(touchedRefs);
+			after.delete(ref);
+			touchedRefs = after;
+		}, GLOW_MS);
+	}
+
+	function scheduleRefetch() {
+		if (refetchTimer) clearTimeout(refetchTimer);
+		refetchTimer = setTimeout(() => {
+			refetchTimer = null;
+			void load(true);
+		}, REFETCH_DEBOUNCE_MS);
+	}
+
+	function handleItemEvent(event: ItemEvent) {
+		switch (event.type) {
+			case 'item_updated':
+				touch(event.item_id); // snappy glow
+				scheduleRefetch(); // status/title/terminal may have changed
+				break;
+			case 'item_created':
+			case 'item_archived':
+			case 'item_restored':
+				// Structural: a node may need to appear or disappear.
+				scheduleRefetch();
+				break;
+			case 'comment_created':
+				touch(event.item_id); // ambient liveness, glow only
+				break;
+			// Ignore comment_updated/deleted, reaction_*, workspace_updated, etc.
+		}
+	}
+
+	onMount(() => {
+		const unsubEvent = sseService.onItemEvent(handleItemEvent);
+		// Bulk updates / replay-gap backfills route through onSyncRequired, not
+		// onItemEvent — fold them into the same debounced refetch.
+		const unsubSync = sseService.onSyncRequired(() => scheduleRefetch());
+		return () => {
+			unsubEvent();
+			unsubSync();
+			if (refetchTimer) clearTimeout(refetchTimer);
+		};
+	});
 
 	// ── Pan / zoom ────────────────────────────────────────────────────────────────
 	let viewport = $state<HTMLDivElement | null>(null);
@@ -468,6 +545,7 @@
 							class="node"
 							class:focus={isFocus}
 							class:terminal={n.isTerminal}
+							class:touched={touchedRefs.has(n.ref)}
 							transform="translate({n.x - NODE_W / 2} {n.y - NODE_H / 2})"
 							role="button"
 							tabindex="0"
@@ -524,6 +602,14 @@
 		{#if truncated && loadState === 'ready'}
 			<div class="truncated-note">
 				Showing the closest {renderNodes.length} items — click a node to explore further.
+			</div>
+		{/if}
+
+		<!-- Live-refresh indicator (SSE-driven background reload). -->
+		{#if refreshing && loadState === 'ready'}
+			<div class="live-note" aria-live="polite">
+				<span class="live-dot" aria-hidden="true"></span>
+				updating…
 			</div>
 		{/if}
 	</div>
@@ -681,6 +767,20 @@
 	.node:focus-visible .node-bg {
 		stroke-width: 3;
 	}
+	/* Transient glow when an item changes live (SSE). */
+	.node.touched .node-bg {
+		animation: node-pulse 2.5s ease-out;
+	}
+	@keyframes node-pulse {
+		0% {
+			filter: drop-shadow(0 0 0 color-mix(in srgb, #fff 90%, transparent));
+			stroke-width: 3.5;
+		}
+		100% {
+			filter: drop-shadow(0 0 10px color-mix(in srgb, #fff 0%, transparent));
+			stroke-width: 1.5;
+		}
+	}
 	.node-ref {
 		font-family: var(--font-mono, ui-monospace, monospace);
 		font-size: 11px;
@@ -784,5 +884,38 @@
 		border: 1px solid var(--border);
 		border-radius: var(--radius);
 		backdrop-filter: blur(6px);
+	}
+
+	.live-note {
+		position: absolute;
+		top: var(--space-3);
+		right: var(--space-3);
+		z-index: 4;
+		display: flex;
+		align-items: center;
+		gap: 6px;
+		padding: 2px var(--space-2);
+		font-size: 0.72em;
+		color: var(--text-muted);
+		background: color-mix(in srgb, var(--bg-secondary) 90%, transparent);
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+		backdrop-filter: blur(6px);
+	}
+	.live-dot {
+		width: 7px;
+		height: 7px;
+		border-radius: 50%;
+		background: #10b981;
+		animation: live-blink 1s ease-in-out infinite;
+	}
+	@keyframes live-blink {
+		0%,
+		100% {
+			opacity: 1;
+		}
+		50% {
+			opacity: 0.3;
+		}
 	}
 </style>

--- a/web/src/lib/components/graph/ItemGraph.svelte
+++ b/web/src/lib/components/graph/ItemGraph.svelte
@@ -223,6 +223,14 @@
 		if (background) {
 			refreshing = true;
 		} else {
+			// A foreground load (initial, reroot, depth/term change) supersedes any
+			// armed background refetch — cancel its timer so the delayed callback
+			// can't fire later and bump loadToken, cancelling THIS load and
+			// (on a background failure) leaving the view stuck on the spinner.
+			if (refetchTimer) {
+				clearTimeout(refetchTimer);
+				refetchTimer = null;
+			}
 			loadState = 'loading';
 			errorMessage = '';
 		}
@@ -326,6 +334,13 @@
 		if (refetchTimer) clearTimeout(refetchTimer);
 		refetchTimer = setTimeout(() => {
 			refetchTimer = null;
+			// Re-check at fire time: state may have left 'ready' since scheduling
+			// (e.g. a foreground reroot started, or an error). Defer rather than
+			// clobber the foreground load.
+			if (loadState !== 'ready') {
+				pendingRefetch = true;
+				return;
+			}
 			void load(true);
 		}, REFETCH_DEBOUNCE_MS);
 	}

--- a/web/src/lib/components/graph/ItemGraph.svelte
+++ b/web/src/lib/components/graph/ItemGraph.svelte
@@ -273,6 +273,9 @@
 	const REFETCH_DEBOUNCE_MS = 400;
 	let touchedRefs = $state(new Set<string>());
 	let refetchTimer: ReturnType<typeof setTimeout> | null = null;
+	// Pending glow-clear timers, tracked so teardown can cancel them — otherwise
+	// a timeout could fire and write touchedRefs on a destroyed component.
+	const glowTimers = new Set<ReturnType<typeof setTimeout>>();
 
 	function refForUuid(uuid: string): string | undefined {
 		return renderNodes.find((n) => n.id === uuid)?.ref;
@@ -284,11 +287,13 @@
 		const next = new Set(touchedRefs);
 		next.add(ref);
 		touchedRefs = next;
-		setTimeout(() => {
+		const handle = setTimeout(() => {
+			glowTimers.delete(handle);
 			const after = new Set(touchedRefs);
 			after.delete(ref);
 			touchedRefs = after;
 		}, GLOW_MS);
+		glowTimers.add(handle);
 	}
 
 	function scheduleRefetch() {
@@ -332,6 +337,8 @@
 			unsubEvent();
 			unsubSync();
 			if (refetchTimer) clearTimeout(refetchTimer);
+			for (const h of glowTimers) clearTimeout(h);
+			glowTimers.clear();
 			// Invalidate any in-flight load so it can't commit $state (or queue a
 			// fitView) after the drawer closes / component unmounts.
 			loadToken++;


### PR DESCRIPTION
## Summary
Makes the per-item dependency graph drawer live: while it's open, `ItemGraph` subscribes to the workspace SSE stream and reflects changes as they happen.

- Correlates events to visible nodes by **item UUID** (added `id` to the rendered node model).
- `item_updated` → glow the node + **debounced background refetch** (no spinner, no view-refit) to pick up status/title/terminal changes.
- `item_created` / `item_archived` / `item_restored` → debounced refetch (structural; a node may appear/disappear).
- `comment_created` → glow only (ambient liveness).
- `onSyncRequired` (bulk updates / replay-gap backfills) → folded into the same debounced refetch.

The load path was refactored into `load(background)`: **background mode keeps the last good graph visible and swallows errors**, so an ambient blip never replaces a working view with an error card. Transient node glow auto-clears after 2.5s; a small "updating…" indicator shows during a background reload. The subscription is set up in `onMount` and torn down on close (drawer-scoped — no listeners when closed).

## Context
Implements `TASK-1785` under `PLAN-1780`. Builds on the drawer (#721). Reuses the existing `sseService` the workspace layout already connects.

## Test plan
- [x] cd web && npm run check — 0 errors (preexisting unrelated warnings only)
- [x] cd web && npm run build — clean
- [x] Svelte MCP autofixer — issues: [] (only style suggestions / known false positives)
- [n/a] go tests — no Go changes