### PR TITLE
fix(server): non-fatal UA session binding + sliding session renewal

### DIFF
--- a/internal/server/handlers_auth.go
+++ b/internal/server/handlers_auth.go
@@ -216,9 +216,14 @@ func requestIsLoopback(r *http.Request) bool {
 	return ip != nil && ip.IsLoopback()
 }
 
-// validateSessionCookie validates a session cookie including session binding
-// (User-Agent check). Returns the user if valid, nil otherwise. This must be
-// used instead of calling ValidateSession directly to ensure binding is enforced.
+// validateSessionCookie validates a session cookie and returns the user if
+// valid, nil otherwise. A User-Agent change is logged but NOT rejected — this
+// must stay in lockstep with the TokenAuth/SessionAuth middleware, which also
+// treats UA binding as log-only (see middleware_auth.go and BUG-1815).
+// Enforcing it here while the middleware allows it would split auth semantics:
+// the same session would be accepted on middleware-protected routes but
+// rejected on the helper-based routes (CLI-auth approval, account/2FA setup,
+// session check) that call this.
 func (s *Server) validateSessionCookie(r *http.Request) *models.User {
 	cookie, err := r.Cookie(sessionCookieName(s.secureCookies))
 	if err != nil {
@@ -232,9 +237,14 @@ func (s *Server) validateSessionCookie(r *http.Request) *models.User {
 	if session == nil || session.User == nil {
 		return nil
 	}
-	// Session binding: reject if User-Agent has changed
+	// Session binding: a User-Agent change is logged for visibility but not
+	// rejected. UA is client-supplied and weak as a binding, and false-positives
+	// on routine client churn (browser/WebView updates, DevTools device
+	// emulation, mobile-app rebuilds).
 	if session.UAHash != "" && sha256hex(r.UserAgent()) != session.UAHash {
-		return nil
+		slog.Warn("session binding mismatch: User-Agent changed (logged, request allowed)",
+			"session_ip", session.IPAddress,
+			"client_ip", clientIP(r))
 	}
 	return session.User
 }

--- a/internal/server/middleware_auth.go
+++ b/internal/server/middleware_auth.go
@@ -99,13 +99,18 @@ func (s *Server) TokenAuth(next http.Handler) http.Handler {
 				rejectInvalidBearer(w, r, next, "unauthorized", "Invalid or expired session")
 				return
 			}
-			// Session binding: validate User-Agent hasn't changed
+			// Session binding: log a User-Agent change for visibility but do
+			// NOT reject. The UA is client-supplied and trivially replayed by
+			// anyone who already stole the token, so hard-enforcing it adds
+			// little security while breaking legitimate clients (browser/WebView
+			// updates, DevTools device emulation, mobile-app rebuilds). This
+			// mirrors the default IP-change handling (logged, request allowed);
+			// strict rejection on IP change is still available via
+			// PAD_IP_CHANGE_ENFORCE=strict.
 			if session.UAHash != "" && sha256hex(r.UserAgent()) != session.UAHash {
-				slog.Warn("session binding mismatch: User-Agent changed",
+				slog.Warn("session binding mismatch: User-Agent changed (logged, request allowed)",
 					"session_ip", session.IPAddress,
 					"client_ip", clientIP(r))
-				writeError(w, http.StatusUnauthorized, "unauthorized", "Session expired")
-				return
 			}
 			// Session binding: detect IP changes. Log to audit log in all modes;
 			// reject only when PAD_IP_CHANGE_ENFORCE=strict.
@@ -125,6 +130,14 @@ func (s *Server) TokenAuth(next http.Handler) http.Handler {
 				writeError(w, http.StatusUnauthorized, "session_ip_changed",
 					"Session client IP changed — please log in again.")
 				return
+			}
+			// Sliding renewal: extend the session's expiry on activity so an
+			// actively-used token never hits the fixed TTL cliff. Bearer
+			// clients hold the token directly (no cookie to re-issue) — just
+			// push the row's expiry forward. Best-effort: a renewal error must
+			// not fail an otherwise-valid request.
+			if _, _, err := s.store.RenewSessionIfStale(token); err != nil {
+				slog.Warn("session renewal failed (request allowed)", "error", err)
 			}
 			ctx := context.WithValue(r.Context(), ctxCurrentUser, session.User)
 			next.ServeHTTP(w, r.WithContext(ctx))
@@ -206,13 +219,15 @@ func (s *Server) SessionAuth(next http.Handler) http.Handler {
 			return
 		}
 
-		// Session binding: validate User-Agent hasn't changed
+		// Session binding: log a User-Agent change for visibility but do NOT
+		// de-authenticate. See the matching note in TokenAuth above — UA is
+		// client-supplied, weak as a binding, and false-positives on routine
+		// client churn (browser/WebView updates, DevTools device emulation,
+		// mobile-app rebuilds). Logged-but-allowed, like the default IP path.
 		if session.UAHash != "" && sha256hex(r.UserAgent()) != session.UAHash {
-			slog.Warn("session binding mismatch: User-Agent changed",
+			slog.Warn("session binding mismatch: User-Agent changed (logged, request allowed)",
 				"session_ip", session.IPAddress,
 				"client_ip", clientIP(r))
-			next.ServeHTTP(w, r)
-			return
 		}
 
 		// Session binding: detect IP changes. Log to audit log in all modes;
@@ -227,10 +242,30 @@ func (s *Server) SessionAuth(next http.Handler) http.Handler {
 			return
 		}
 
+		// Sliding renewal: extend the session's expiry on activity and re-issue
+		// the session cookie (plus CSRF, to keep their lifetimes in sync) with a
+		// fresh Max-Age so an actively-used session never expires out from under
+		// the user at the fixed TTL. Best-effort: a renewal error must not fail
+		// an otherwise-valid request. When this re-issues the CSRF cookie it
+		// also covers the "missing CSRF cookie" case below.
+		renewed := false
+		if newExpiry, didRenew, err := s.store.RenewSessionIfStale(cookie.Value); err != nil {
+			slog.Warn("session renewal failed (request allowed)", "error", err)
+		} else if didRenew {
+			if maxAge := int(time.Until(newExpiry).Seconds()); maxAge > 0 {
+				setSessionCookie(w, cookie.Value, maxAge, s.secureCookies)
+				if !strings.HasPrefix(r.URL.Path, "/api/v1/auth/") {
+					setCSRFCookie(w, maxAge, s.secureCookies)
+				}
+				renewed = true
+			}
+		}
+
 		// Re-issue CSRF cookie if the session is valid but the cookie is missing.
 		// This can happen when cookies expire at different times or are selectively cleared.
 		// Skip for auth endpoints — they manage their own CSRF cookies (login sets, logout clears).
-		if !strings.HasPrefix(r.URL.Path, "/api/v1/auth/") {
+		// Skip when sliding renewal already re-issued the CSRF cookie above.
+		if !renewed && !strings.HasPrefix(r.URL.Path, "/api/v1/auth/") {
 			if _, csrfErr := r.Cookie(csrfCookieName(s.secureCookies)); csrfErr != nil {
 				setCSRFCookie(w, 7*24*60*60, s.secureCookies)
 			}
@@ -862,6 +897,23 @@ func (s *Server) handleSessionIPChange(w http.ResponseWriter, r *http.Request, s
 
 // clearSessionCookie expires the session cookie on the client so a
 // subsequent request doesn't keep presenting a now-revoked token.
+// setSessionCookie (re)issues the session cookie with the given value and
+// max-age (seconds). Used by the sliding-renewal path to push the cookie's
+// lifetime forward in lockstep with the extended server-side expiry. The
+// attributes mirror createAuthSession and clearSessionCookie so the cookie's
+// identity (name/path/flags) stays stable across issue, renew, and clear.
+func setSessionCookie(w http.ResponseWriter, value string, maxAge int, secure bool) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     sessionCookieName(secure),
+		Value:    value,
+		Path:     "/",
+		MaxAge:   maxAge,
+		HttpOnly: true,
+		Secure:   secure,
+		SameSite: http.SameSiteLaxMode,
+	})
+}
+
 func clearSessionCookie(w http.ResponseWriter, secure bool) {
 	http.SetCookie(w, &http.Cookie{
 		Name:     sessionCookieName(secure),

--- a/internal/store/migrations/067_session_renew_ttl.sql
+++ b/internal/store/migrations/067_session_renew_ttl.sql
@@ -1,0 +1,6 @@
+-- Sliding-session renewal: remember each session's renewal window so the auth
+-- middleware can extend expires_at on activity without re-deriving the TTL from
+-- device_info (which doesn't reliably encode web vs CLI lifetimes).
+-- 0 means "no sliding renewal" — legacy rows created before this migration keep
+-- their fixed expiry and naturally age out; new sessions store their TTL here.
+ALTER TABLE sessions ADD COLUMN renew_ttl_seconds INTEGER NOT NULL DEFAULT 0;

--- a/internal/store/pgmigrations/046_session_renew_ttl.sql
+++ b/internal/store/pgmigrations/046_session_renew_ttl.sql
@@ -1,0 +1,6 @@
+-- Sliding-session renewal: remember each session's renewal window so the auth
+-- middleware can extend expires_at on activity without re-deriving the TTL from
+-- device_info (which doesn't reliably encode web vs CLI lifetimes).
+-- 0 means "no sliding renewal" — legacy rows created before this migration keep
+-- their fixed expiry and naturally age out; new sessions store their TTL here.
+ALTER TABLE sessions ADD COLUMN IF NOT EXISTS renew_ttl_seconds INTEGER NOT NULL DEFAULT 0;

--- a/internal/store/sessions.go
+++ b/internal/store/sessions.go
@@ -46,9 +46,9 @@ func (s *Store) CreateSession(userID, deviceInfo, ipAddress, userAgent string, t
 	expiresAt := time.Now().UTC().Add(ttl).Format(time.RFC3339)
 
 	_, err := s.db.Exec(s.q(`
-		INSERT INTO sessions (id, user_id, token_hash, device_info, ip_address, ua_hash, expires_at, created_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-	`), id, userID, tokenHash, deviceInfo, ipAddress, uaHash, expiresAt, ts)
+		INSERT INTO sessions (id, user_id, token_hash, device_info, ip_address, ua_hash, expires_at, created_at, renew_ttl_seconds)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`), id, userID, tokenHash, deviceInfo, ipAddress, uaHash, expiresAt, ts, int64(ttl/time.Second))
 	if err != nil {
 		return "", fmt.Errorf("insert session: %w", err)
 	}
@@ -92,6 +92,90 @@ func (s *Store) ValidateSession(token string) (*SessionInfo, error) {
 		IPAddress: ipAddress,
 		UAHash:    uaHash,
 	}, nil
+}
+
+// SessionMaxLifetime caps the total sliding lifetime of a session measured
+// from its creation. Sliding renewal can push expires_at forward repeatedly
+// while a session is active, but never past created_at + SessionMaxLifetime —
+// so an indefinitely-active client still has to re-authenticate eventually.
+const SessionMaxLifetime = 90 * 24 * time.Hour
+
+// RenewSessionIfStale implements sliding-window expiration. When a session is
+// past its renewal threshold (less than half its renewal window remaining) it
+// extends expires_at to now + the session's renewal window, capped at
+// created_at + SessionMaxLifetime. It returns the resulting expiry and whether
+// a renewal was written.
+//
+// Sessions with renew_ttl_seconds <= 0 (legacy rows from before sliding
+// renewal, and rows created with a non-positive TTL) are never renewed — their
+// current expiry is returned with renewed=false.
+//
+// The threshold gate keeps writes rare: a 7-day window renews at most once
+// every ~3.5 days of activity, not on every request. The UPDATE is a
+// compare-and-set on the old expiry so concurrent requests don't double-write.
+//
+// Callers should treat this as best-effort: a renewal error must not fail an
+// otherwise-valid request (the session is still valid until its current
+// expiry).
+func (s *Store) RenewSessionIfStale(token string) (time.Time, bool, error) {
+	hash := sha256.Sum256([]byte(token))
+	tokenHash := hex.EncodeToString(hash[:])
+
+	var expiresAtStr, createdAtStr string
+	var renewSeconds int64
+	err := s.db.QueryRow(s.q(`
+		SELECT expires_at, created_at, renew_ttl_seconds FROM sessions WHERE token_hash = ?
+	`), tokenHash).Scan(&expiresAtStr, &createdAtStr, &renewSeconds)
+	if err == sql.ErrNoRows {
+		return time.Time{}, false, nil
+	}
+	if err != nil {
+		return time.Time{}, false, fmt.Errorf("read session for renewal: %w", err)
+	}
+
+	expiresAt := parseTime(expiresAtStr)
+	if renewSeconds <= 0 {
+		// Sliding renewal disabled for this session (legacy row).
+		return expiresAt, false, nil
+	}
+	renewWindow := time.Duration(renewSeconds) * time.Second
+
+	nowT := time.Now().UTC()
+	// Only renew once we're past the threshold (< half the window remaining).
+	if expiresAt.Sub(nowT) >= renewWindow/2 {
+		return expiresAt, false, nil
+	}
+
+	newExpiry := nowT.Add(renewWindow)
+	// Never let sliding renewal exceed the absolute lifetime cap.
+	if createdAt := parseTime(createdAtStr); !createdAt.IsZero() {
+		if cap := createdAt.Add(SessionMaxLifetime); newExpiry.After(cap) {
+			newExpiry = cap
+		}
+	}
+	// Never shorten an existing expiry (e.g. once the cap is reached).
+	if !newExpiry.After(expiresAt) {
+		return expiresAt, false, nil
+	}
+
+	newExpiryStr := newExpiry.Format(time.RFC3339)
+	res, err := s.db.Exec(s.q(`
+		UPDATE sessions SET expires_at = ? WHERE token_hash = ? AND expires_at = ?
+	`), newExpiryStr, tokenHash, expiresAtStr)
+	if err != nil {
+		return expiresAt, false, fmt.Errorf("renew session: %w", err)
+	}
+	// Only report a renewal when this request's CAS actually wrote the row.
+	// A zero-row update means we lost the race to a concurrent renewal (the
+	// session is still renewed, just not by us) or the session was deleted
+	// between the read and the write — in either case the caller must NOT
+	// reissue a cookie advertising an expiry it didn't set. Treat an
+	// unreliable RowsAffected as "not renewed" so we fail safe.
+	n, err := res.RowsAffected()
+	if err != nil || n == 0 {
+		return expiresAt, false, nil
+	}
+	return newExpiry, true, nil
 }
 
 // UpdateSessionIPIfEquals atomically rotates the stored IP on a session

--- a/internal/store/sessions_test.go
+++ b/internal/store/sessions_test.go
@@ -303,5 +303,123 @@ func TestCreateTestUserHelper(t *testing.T) {
 	}
 }
 
+// setSessionTimes backdates a session's expires_at (and optionally created_at)
+// so renewal-threshold and absolute-cap paths can be exercised deterministically
+// without sleeping. Targets by user_id since test users hold a single session.
+func setSessionTimes(t *testing.T, s *Store, userID string, expiresAt, createdAt time.Time) {
+	t.Helper()
+	if createdAt.IsZero() {
+		_, err := s.db.Exec(s.q(`UPDATE sessions SET expires_at = ? WHERE user_id = ?`),
+			expiresAt.UTC().Format(time.RFC3339), userID)
+		if err != nil {
+			t.Fatalf("backdate session expiry: %v", err)
+		}
+		return
+	}
+	_, err := s.db.Exec(s.q(`UPDATE sessions SET expires_at = ?, created_at = ? WHERE user_id = ?`),
+		expiresAt.UTC().Format(time.RFC3339), createdAt.UTC().Format(time.RFC3339), userID)
+	if err != nil {
+		t.Fatalf("backdate session times: %v", err)
+	}
+}
+
+func TestRenewSessionExtendsWhenStale(t *testing.T) {
+	s := testStore(t)
+	u := createTestUser(t, s, "renew@test.com", "Renew", "password123")
+
+	token, err := s.CreateSession(u.ID, "web", "127.0.0.1", "UA", 7*24*time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	// Drop remaining lifetime under the half-window threshold.
+	setSessionTimes(t, s, u.ID, time.Now().UTC().Add(1*time.Hour), time.Time{})
+
+	newExpiry, renewed, err := s.RenewSessionIfStale(token)
+	if err != nil {
+		t.Fatalf("RenewSessionIfStale: %v", err)
+	}
+	if !renewed {
+		t.Fatal("expected stale session to be renewed")
+	}
+	// Should have been pushed back out to ~now + full window.
+	want := time.Now().UTC().Add(7 * 24 * time.Hour)
+	if diff := newExpiry.Sub(want); diff > time.Minute || diff < -time.Minute {
+		t.Errorf("new expiry %v not within a minute of %v", newExpiry, want)
+	}
+	if s2, _ := s.ValidateSession(token); s2 == nil {
+		t.Error("session should still validate after renewal")
+	}
+}
+
+func TestRenewSessionSkipsWhenFresh(t *testing.T) {
+	s := testStore(t)
+	u := createTestUser(t, s, "fresh@test.com", "Fresh", "password123")
+
+	token, err := s.CreateSession(u.ID, "web", "127.0.0.1", "UA", 7*24*time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	// Fresh session has a full window remaining → no renewal.
+	_, renewed, err := s.RenewSessionIfStale(token)
+	if err != nil {
+		t.Fatalf("RenewSessionIfStale: %v", err)
+	}
+	if renewed {
+		t.Error("fresh session should not be renewed")
+	}
+}
+
+func TestRenewSessionRespectsMaxLifetime(t *testing.T) {
+	s := testStore(t)
+	u := createTestUser(t, s, "cap@test.com", "Cap", "password123")
+
+	token, err := s.CreateSession(u.ID, "web", "127.0.0.1", "UA", 7*24*time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	// Session created 89 days ago, nearly expired now: renewal must be capped
+	// at created_at + SessionMaxLifetime (~1 day out), not now + 7 days.
+	created := time.Now().UTC().Add(-89 * 24 * time.Hour)
+	setSessionTimes(t, s, u.ID, time.Now().UTC().Add(1*time.Hour), created)
+
+	newExpiry, renewed, err := s.RenewSessionIfStale(token)
+	if err != nil {
+		t.Fatalf("RenewSessionIfStale: %v", err)
+	}
+	if !renewed {
+		t.Fatal("expected renewal up to the cap")
+	}
+	cap := created.Add(SessionMaxLifetime)
+	if diff := newExpiry.Sub(cap); diff > time.Minute || diff < -time.Minute {
+		t.Errorf("expected expiry capped near %v, got %v", cap, newExpiry)
+	}
+}
+
+func TestRenewSessionLegacyZeroTTLNotRenewed(t *testing.T) {
+	s := testStore(t)
+	u := createTestUser(t, s, "legacy@test.com", "Legacy", "password123")
+
+	token, err := s.CreateSession(u.ID, "web", "127.0.0.1", "UA", 7*24*time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	// Simulate a pre-migration row: stale expiry but no renewal window.
+	setSessionTimes(t, s, u.ID, time.Now().UTC().Add(1*time.Hour), time.Time{})
+	if _, err := s.db.Exec(s.q(`UPDATE sessions SET renew_ttl_seconds = 0 WHERE user_id = ?`), u.ID); err != nil {
+		t.Fatalf("zero renew ttl: %v", err)
+	}
+
+	_, renewed, err := s.RenewSessionIfStale(token)
+	if err != nil {
+		t.Fatalf("RenewSessionIfStale: %v", err)
+	}
+	if renewed {
+		t.Error("legacy session (renew_ttl_seconds=0) should not be renewed")
+	}
+}
+
 // Suppress unused import warning — models is used in createTestUser
 var _ = models.UserCreate{}


### PR DESCRIPTION
## Why
Users were being logged out frequently on web and the mobile app. Two server-side root causes:

1. **UA session binding was unconditional and fatal.** Any User-Agent change (browser/WebView update, DevTools device emulation, mobile rebuild) silently de-authenticated the session. Evidence on the dev box: 206 "User-Agent changed" rejections vs 0 strict IP destroys.
2. **No sliding renewal.** Sessions had a fixed absolute TTL (7d web / 30d CLI) with no refresh on activity, so even active users hit the cliff.

## What
- UA binding is now **log-only** at all three enforcement sites: `TokenAuth`, `SessionAuth`, and the `validateSessionCookie` helper (CLI-auth approval, account/2FA setup, session check) — so auth semantics don't split between middleware- and helper-protected routes.
- **Sliding renewal**: `RenewSessionIfStale` extends `expires_at` when a session is past its half-window threshold, capped at `created_at + 90d` (`SessionMaxLifetime`). CAS-guarded; only reported as renewed when `RowsAffected()` confirms the write. `SessionAuth`/`TokenAuth` re-issue the session (+CSRF) cookie on renewal.
- New `renew_ttl_seconds` column (sqlite migration 067 + pg 046). Legacy rows (`0`) keep their fixed expiry and age out.

## Tracking
BUG-1815, TASK-1816.

## Verification
- `go build ./...`, `go test ./internal/store/ ./internal/server/` pass (4 new renewal tests).
- Reviewed by Codex review loop — CLEAN (2 findings fixed: split UA semantics, renewal CAS RowsAffected).