### PR TITLE
Fix SQLite NOT NULL on api_tokens.workspace_id (account-token 500)

### DIFF
--- a/internal/store/api_tokens_test.go
+++ b/internal/store/api_tokens_test.go
@@ -6,6 +6,41 @@ import (
 	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
+// TestCreateAPITokenUserScoped covers the account-settings path
+// (handleCreateUserToken), which creates a workspace-agnostic token with no
+// WorkspaceID set. The store inserts NULL for workspace_id; this must succeed
+// and the token must validate. Regression test for the SQLite-only NOT NULL
+// constraint on api_tokens.workspace_id fixed in migration
+// 068_api_tokens_workspace_nullable.sql (Postgres already allowed NULL).
+func TestCreateAPITokenUserScoped(t *testing.T) {
+	s := testStore(t)
+	u := createTestUser(t, s, "test@test.com", "Test", "password123")
+
+	token, err := s.CreateAPIToken(u.ID, models.APITokenCreate{
+		Name: "user-scoped",
+	}, 90, 0)
+	if err != nil {
+		t.Fatalf("CreateAPIToken (no workspace) error: %v", err)
+	}
+	if token.Token == "" {
+		t.Fatal("expected plaintext token")
+	}
+	if token.WorkspaceID != "" {
+		t.Errorf("expected empty workspace, got %q", token.WorkspaceID)
+	}
+
+	validated, err := s.ValidateToken(token.Token)
+	if err != nil {
+		t.Fatalf("ValidateToken error: %v", err)
+	}
+	if validated == nil {
+		t.Fatal("expected user-scoped token to validate")
+	}
+	if validated.WorkspaceID != "" {
+		t.Errorf("expected empty workspace on validate, got %q", validated.WorkspaceID)
+	}
+}
+
 func TestCreateAPITokenWithExpiry(t *testing.T) {
 	s := testStore(t)
 	u := createTestUser(t, s, "test@test.com", "Test", "password123")

--- a/internal/store/migrations/068_api_tokens_workspace_nullable.sql
+++ b/internal/store/migrations/068_api_tokens_workspace_nullable.sql
@@ -1,0 +1,53 @@
+-- BUG: creating a user-scoped (workspace-agnostic) API token via the account
+-- settings page (POST /api/v1/auth/tokens -> handleCreateUserToken) fails on
+-- SQLite with "NOT NULL constraint failed: api_tokens.workspace_id".
+--
+-- Root cause: 011_api_tokens.sql declared workspace_id NOT NULL, but
+--   * the Postgres schema (pgmigrations/001_initial.sql) declares it nullable,
+--   * the Go layer treats it as nullable end-to-end: models.APIToken,
+--     store.CreateAPIToken inserts NULL for unscoped tokens, and getAPIToken /
+--     ValidateToken scan workspace_id into *string.
+-- So only SQLite deployments are affected. The account-settings path never
+-- sets a workspace, so the INSERT always trips the constraint and the handler
+-- returns a 500 ("An internal error occurred").
+--
+-- Fix: rebuild api_tokens with workspace_id nullable, matching Postgres and
+-- the application contract. SQLite has no ALTER COLUMN ... DROP NOT NULL, so
+-- the table is rebuilt via the standard recipe (cf. 055_collections_settings_
+-- not_null.sql). Nothing references api_tokens(id) via a foreign key, so there
+-- are no inbound references to recreate; foreign_keys is toggled OFF for the
+-- rebuild per the established pattern (the migration runner applies an
+-- foreign_keys=OFF pragma before the transaction and restores it after).
+
+PRAGMA foreign_keys = OFF;
+
+DROP TABLE IF EXISTS api_tokens_new;
+
+CREATE TABLE api_tokens_new (
+    id           TEXT PRIMARY KEY,
+    workspace_id TEXT,
+    user_id      TEXT,
+    name         TEXT NOT NULL,
+    token_hash   TEXT NOT NULL,
+    prefix       TEXT NOT NULL,
+    scopes       TEXT NOT NULL DEFAULT '["*"]',
+    expires_at   TEXT,
+    last_used_at TEXT,
+    created_at   TEXT NOT NULL DEFAULT (datetime('now')),
+    FOREIGN KEY (workspace_id) REFERENCES workspaces(id),
+    FOREIGN KEY (user_id) REFERENCES users(id)
+);
+
+INSERT INTO api_tokens_new (
+    id, workspace_id, user_id, name, token_hash, prefix, scopes,
+    expires_at, last_used_at, created_at
+)
+SELECT
+    id, workspace_id, user_id, name, token_hash, prefix, scopes,
+    expires_at, last_used_at, created_at
+FROM api_tokens;
+
+DROP TABLE api_tokens;
+ALTER TABLE api_tokens_new RENAME TO api_tokens;
+
+PRAGMA foreign_keys = ON;


### PR DESCRIPTION
Fixes #731.

## Problem
On **SQLite** deployments, creating a personal/account API token from the settings page (`POST /api/v1/auth/tokens` → `handleCreateUserToken`) returns a 500:

```
error="insert api token: constraint failed: NOT NULL constraint failed: api_tokens.workspace_id (1299)"
```

`handleCreateUserToken` creates a workspace-agnostic token and never sets `WorkspaceID`, so `Store.CreateAPIToken` inserts `NULL` into `workspace_id`. But `migrations/011_api_tokens.sql` declared that column `NOT NULL` — diverging from:
- **Postgres**: `pgmigrations/001_initial.sql` declares `workspace_id TEXT REFERENCES workspaces(id)` (nullable), and
- **the Go layer**: `getAPIToken` / `ValidateToken` already scan `workspace_id` into `*string`.

Postgres is therefore unaffected; this is SQLite-only. The path was untested — every case in `api_tokens_test.go` passes a `WorkspaceID`.

## Fix
- **`migrations/068_api_tokens_workspace_nullable.sql`** — rebuild `api_tokens` with `workspace_id` nullable. SQLite has no `ALTER COLUMN ... DROP NOT NULL`, so it uses the established table-rebuild recipe (cf. `055_collections_settings_not_null.sql`), including the `PRAGMA foreign_keys = OFF/ON` toggle the migration runner explicitly supports. No table FK-references `api_tokens(id)`, so there are no inbound references to recreate. No Go changes needed.
- **`api_tokens_test.go`** — `TestCreateAPITokenUserScoped`: regression test for the workspace-agnostic path (create + validate with no workspace).

## Verification
Reproduced the exact failure and confirmed the fix against SQLite 3.50.4: pre-migration insert of a NULL-workspace token fails with the reported error; post-migration the existing scoped rows are preserved, the unscoped insert succeeds (`workspace_id` = NULL), and `name` remains `NOT NULL`.

> Note: I couldn't run the full Go suite in my environment (no Go toolchain), but the new test only uses existing helpers (`testStore`, `createTestUser`) and mirrors the surrounding cases.