### PR TITLE
fix(items): surface archived items instead of masking them as missing (BUG-1791)

### DIFF
--- a/internal/cli/format.go
+++ b/internal/cli/format.go
@@ -156,6 +156,9 @@ func PrintItemTable(items []models.Item) {
 		} else {
 			titlePart = Bold.Sprint(item.Title)
 		}
+		if item.DeletedAt != nil {
+			titlePart += "  " + Dim.Sprint("(archived)")
+		}
 		collLabel := item.CollectionName
 		if item.CollectionIcon != "" {
 			collLabel = item.CollectionIcon + " " + collLabel
@@ -241,6 +244,11 @@ func PrintItemMeta(item *models.Item) {
 		fmt.Printf("%s  %s\n", BoldCyan.Sprint(ref), Bold.Sprint(item.Title))
 	} else {
 		fmt.Printf("%s\n", Bold.Sprint(item.Title))
+	}
+
+	if item.DeletedAt != nil {
+		fmt.Printf("%s %s\n", label.Sprint("Archived:  "),
+			color.New(color.FgYellow, color.Bold).Sprintf("⚠ yes (soft-deleted %s) — restore before editing", RelativeTime(*item.DeletedAt)))
 	}
 
 	if item.CollectionName != "" {

--- a/internal/server/bug1791_archived_visibility_test.go
+++ b/internal/server/bug1791_archived_visibility_test.go
@@ -1,0 +1,69 @@
+package server
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// TestArchivedItem_Get200WithMarker_Update409 pins BUG-1791. An archived
+// (soft-deleted) item still appears in include-archived list results, so the
+// API must let a caller fetch it read-only (GET 200 + deleted_at) and, when
+// they try to mutate it, return a clear "archived" conflict instead of a bare
+// 404 that reads as data loss / index corruption.
+func TestArchivedItem_Get200WithMarker_Update409(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	rr := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections/tasks/items", map[string]interface{}{
+		"title": "Doomed task",
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create item: expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var created models.Item
+	parseJSON(t, rr, &created)
+
+	// Archive (soft-delete) it.
+	rr = doRequest(srv, "DELETE", "/api/v1/workspaces/"+slug+"/items/"+created.Slug, nil)
+	if rr.Code != http.StatusOK && rr.Code != http.StatusNoContent {
+		t.Fatalf("delete item: expected 200/204, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	// GET must return the archived item (200) with deleted_at populated, so an
+	// agent can read it and see that it is archived.
+	rr = doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/items/"+created.Slug, nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("get archived item: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var got models.Item
+	parseJSON(t, rr, &got)
+	if got.DeletedAt == nil {
+		t.Errorf("expected deleted_at populated on archived GET, got nil (body=%s)", rr.Body.String())
+	}
+
+	// UPDATE must return a clear archived conflict (409, code "archived").
+	rr = doRequest(srv, "PATCH", "/api/v1/workspaces/"+slug+"/items/"+created.Slug, map[string]interface{}{})
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("update archived item: expected 409, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var errResp map[string]map[string]string
+	parseJSON(t, rr, &errResp)
+	if errResp["error"]["code"] != "archived" {
+		t.Errorf("expected error code 'archived', got %q (body=%s)", errResp["error"]["code"], rr.Body.String())
+	}
+
+	// MOVE must likewise return the archived conflict, not a bare 404
+	// (Codex round 1: the move path is a peer mutation and was missed).
+	rr = doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/items/"+created.Slug+"/move", map[string]interface{}{
+		"target_collection": "ideas",
+	})
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("move archived item: expected 409, got %d: %s", rr.Code, rr.Body.String())
+	}
+	parseJSON(t, rr, &errResp)
+	if errResp["error"]["code"] != "archived" {
+		t.Errorf("move: expected error code 'archived', got %q (body=%s)", errResp["error"]["code"], rr.Body.String())
+	}
+}

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -684,6 +684,23 @@ func (s *Server) handleCreateItem(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusCreated, item)
 }
 
+// writeItemResolveError distinguishes a soft-deleted (archived) item from a
+// genuinely-missing one for mutation handlers. An archived item still appears
+// in include-archived list results and can be fetched read-only via GET, so a
+// bare "Item not found" here misled callers into thinking the data was lost or
+// corrupt (BUG-1791). Visibility is enforced exactly as the active path, so an
+// archived item is never revealed to a caller who could not otherwise see it.
+func (s *Server) writeItemResolveError(w http.ResponseWriter, r *http.Request, workspaceID, ref string) {
+	if archived, err := s.store.ResolveItemIncludeDeleted(workspaceID, ref); err == nil && archived != nil && archived.DeletedAt != nil {
+		if visible, verr := s.checkItemVisible(workspaceID, archived, currentUser(r), workspaceRole(r)); verr == nil && visible {
+			writeError(w, http.StatusConflict, "archived",
+				fmt.Sprintf("%q is archived. Fetch it read-only with GET, or restore it before editing.", ref))
+			return
+		}
+	}
+	writeError(w, http.StatusNotFound, "not_found", "Item not found")
+}
+
 // handleGetItem retrieves a single item by slug.
 func (s *Server) handleGetItem(w http.ResponseWriter, r *http.Request) {
 	workspaceID, ok := s.getWorkspaceID(w, r)
@@ -692,7 +709,7 @@ func (s *Server) handleGetItem(w http.ResponseWriter, r *http.Request) {
 	}
 
 	itemSlug := chi.URLParam(r, "itemSlug")
-	item, err := s.store.ResolveItem(workspaceID, itemSlug)
+	item, err := s.store.ResolveItemIncludeDeleted(workspaceID, itemSlug)
 	if err != nil {
 		writeInternalError(w, err)
 		return
@@ -728,7 +745,7 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if item == nil {
-		writeError(w, http.StatusNotFound, "not_found", "Item not found")
+		s.writeItemResolveError(w, r, workspaceID, itemSlug)
 		return
 	}
 	if !s.requireItemVisible(w, r, workspaceID, item) {
@@ -1284,7 +1301,7 @@ func (s *Server) handleDeleteItem(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if item == nil {
-		writeError(w, http.StatusNotFound, "not_found", "Item not found")
+		s.writeItemResolveError(w, r, workspaceID, itemSlug)
 		return
 	}
 	if !s.requireItemVisible(w, r, workspaceID, item) {
@@ -1384,8 +1401,12 @@ func (s *Server) handleMoveItem(w http.ResponseWriter, r *http.Request) {
 
 	itemSlug := chi.URLParam(r, "itemSlug")
 	item, err := s.store.ResolveItem(workspaceID, itemSlug)
-	if err != nil || item == nil {
-		writeError(w, http.StatusNotFound, "not_found", "Item not found")
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	if item == nil {
+		s.writeItemResolveError(w, r, workspaceID, itemSlug)
 		return
 	}
 	if !s.requireItemVisible(w, r, workspaceID, item) {

--- a/internal/store/bug1791_archived_marker_test.go
+++ b/internal/store/bug1791_archived_marker_test.go
@@ -1,0 +1,54 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// TestListItems_IncludeArchived_PopulatesDeletedAt pins BUG-1791. An archived
+// (soft-deleted) item must (a) stay out of the default active-only list and
+// (b) appear in the include-archived list WITH DeletedAt populated — that
+// marker is what lets a caller tell an archived row apart from a live one.
+// Before the fix, ListItems' shared scanner dropped deleted_at, so an item
+// surfaced by `all=true` looked identical to a live row, which read as
+// corruption when it then 404'd on get/update.
+func TestListItems_IncludeArchived_PopulatesDeletedAt(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+
+	item := createTestItem(t, s, ws.ID, col.ID, "Doomed", "")
+	if err := s.DeleteItem(item.ID); err != nil {
+		t.Fatalf("DeleteItem: %v", err)
+	}
+
+	// Default (active-only) list must exclude the archived item.
+	active, err := s.ListItems(ws.ID, models.ItemListParams{CollectionSlug: col.Slug})
+	if err != nil {
+		t.Fatalf("ListItems active: %v", err)
+	}
+	for _, it := range active {
+		if it.ID == item.ID {
+			t.Fatalf("archived item leaked into the default active-only list")
+		}
+	}
+
+	// IncludeArchived must return it AND populate DeletedAt.
+	all, err := s.ListItems(ws.ID, models.ItemListParams{CollectionSlug: col.Slug, IncludeArchived: true})
+	if err != nil {
+		t.Fatalf("ListItems include-archived: %v", err)
+	}
+	var found *models.Item
+	for i := range all {
+		if all[i].ID == item.ID {
+			found = &all[i]
+		}
+	}
+	if found == nil {
+		t.Fatalf("archived item missing from the include-archived list")
+	}
+	if found.DeletedAt == nil {
+		t.Errorf("DeletedAt not populated for archived item in include-archived list (BUG-1791 marker missing)")
+	}
+}

--- a/internal/store/item_stars.go
+++ b/internal/store/item_stars.go
@@ -101,7 +101,7 @@ func (s *Store) ListStarredItems(userID, workspaceID string, includeTerminal boo
 		       i.item_number, i.seq, i.created_at, i.updated_at,
 		       c.slug, c.name, c.icon, c.prefix,
 		       COALESCE(au.name, ''), COALESCE(au.email, ''),
-		       COALESCE(ar.name, ''), COALESCE(ar.slug, ''), COALESCE(ar.icon, '')
+		       COALESCE(ar.name, ''), COALESCE(ar.slug, ''), COALESCE(ar.icon, ''), i.deleted_at
 		FROM item_stars s
 		JOIN items i ON i.id = s.item_id
 		JOIN collections c ON c.id = i.collection_id

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -718,7 +718,7 @@ func (s *Store) ListItems(workspaceID string, params models.ItemListParams) ([]m
 		       i.item_number, i.seq, i.created_at, i.updated_at,
 		       c.slug, c.name, c.icon, c.prefix,
 		       COALESCE(au.name, ''), COALESCE(au.email, ''),
-		       COALESCE(ar.name, ''), COALESCE(ar.slug, ''), COALESCE(ar.icon, '')
+		       COALESCE(ar.name, ''), COALESCE(ar.slug, ''), COALESCE(ar.icon, ''), i.deleted_at
 		FROM items i
 		JOIN collections c ON c.id = i.collection_id
 		LEFT JOIN users au ON au.id = i.assigned_user_id
@@ -1432,7 +1432,7 @@ func (s *Store) listItemsFTS(workspaceID string, params models.ItemListParams) (
 			       i.item_number, i.seq, i.created_at, i.updated_at,
 			       c.slug, c.name, c.icon, c.prefix,
 			       COALESCE(au.name, ''), COALESCE(au.email, ''),
-			       COALESCE(ar.name, ''), COALESCE(ar.slug, ''), COALESCE(ar.icon, '')
+			       COALESCE(ar.name, ''), COALESCE(ar.slug, ''), COALESCE(ar.icon, ''), i.deleted_at
 			FROM items i
 			JOIN collections c ON c.id = i.collection_id
 			LEFT JOIN users au ON au.id = i.assigned_user_id
@@ -1458,7 +1458,7 @@ func (s *Store) listItemsFTS(workspaceID string, params models.ItemListParams) (
 			       i.item_number, i.seq, i.created_at, i.updated_at,
 			       c.slug, c.name, c.icon, c.prefix,
 			       COALESCE(au.name, ''), COALESCE(au.email, ''),
-			       COALESCE(ar.name, ''), COALESCE(ar.slug, ''), COALESCE(ar.icon, '')
+			       COALESCE(ar.name, ''), COALESCE(ar.slug, ''), COALESCE(ar.icon, ''), i.deleted_at
 			FROM items i
 			JOIN items_fts fts ON i.rowid = fts.rowid
 			JOIN collections c ON c.id = i.collection_id
@@ -3108,7 +3108,7 @@ func (s *Store) getChildItems(q childQueryer, parentItemID string) ([]models.Ite
 		       i.item_number, i.seq, i.created_at, i.updated_at,
 		       c.slug, c.name, c.icon, c.prefix,
 		       COALESCE(au.name, ''), COALESCE(au.email, ''),
-		       COALESCE(ar.name, ''), COALESCE(ar.slug, ''), COALESCE(ar.icon, '')
+		       COALESCE(ar.name, ''), COALESCE(ar.slug, ''), COALESCE(ar.icon, ''), i.deleted_at
 		FROM items i
 		JOIN collections c ON c.id = i.collection_id
 		JOIN item_links il ON il.source_id = i.id AND il.link_type IN (%s) AND il.target_id = ?
@@ -3504,6 +3504,7 @@ func scanItems(rows *sql.Rows) ([]models.Item, error) {
 	for rows.Next() {
 		var item models.Item
 		var createdAt, updatedAt string
+		var deletedAt *string
 		var pinned bool
 		if err := rows.Scan(
 			&item.ID, &item.WorkspaceID, &item.CollectionID, &item.Title, &item.Slug,
@@ -3514,12 +3515,14 @@ func scanItems(rows *sql.Rows) ([]models.Item, error) {
 			&item.CollectionSlug, &item.CollectionName, &item.CollectionIcon, &item.CollectionPrefix,
 			&item.AssignedUserName, &item.AssignedUserEmail,
 			&item.AgentRoleName, &item.AgentRoleSlug, &item.AgentRoleIcon,
+			&deletedAt,
 		); err != nil {
 			return nil, err
 		}
 		item.Pinned = pinned
 		item.CreatedAt = parseTime(createdAt)
 		item.UpdatedAt = parseTime(updatedAt)
+		item.DeletedAt = parseTimePtr(deletedAt)
 		hydrateItemComputedMetadata(&item)
 		items = append(items, item)
 	}
@@ -3546,7 +3549,7 @@ func (s *Store) ItemsModifiedSince(workspaceID string, since time.Time) (updated
 		       i.item_number, i.seq, i.created_at, i.updated_at,
 		       c.slug, c.name, c.icon, c.prefix,
 		       COALESCE(au.name, ''), COALESCE(au.email, ''),
-		       COALESCE(ar.name, ''), COALESCE(ar.slug, ''), COALESCE(ar.icon, '')
+		       COALESCE(ar.name, ''), COALESCE(ar.slug, ''), COALESCE(ar.icon, ''), i.deleted_at
 		FROM items i
 		JOIN collections c ON c.id = i.collection_id
 		LEFT JOIN users au ON au.id = i.assigned_user_id


### PR DESCRIPTION
## Summary

Fixes BUG-1791. An external user reported (via the hosted MCP) that an item appeared in a collection list (`all=true`) yet was unresolvable by ref, absent from search, and 404'd on get/update — diagnosed in the report as an "index/FTS desync, needs re-index."

**It is not a desync.** The item was simply **soft-deleted (archived)**. `all=true` (`IncludeArchived`) is the *only* read path that includes archived rows; every other path (`GetItemByRef`, FTS, status-filtered list) correctly filters `deleted_at IS NULL`. The real defect is **observability**: archived rows came back from `all=true` with no marker, and get/update returned a bare "Item not found", so an archived item looked like corrupted / lost data.

## Root cause

- `scanItems` (the shared list scanner) didn't select `deleted_at`, so archived rows returned by `all=true` were byte-for-byte indistinguishable from live rows.
- `GET` / `UPDATE` / `DELETE` / `MOVE` resolved active-only and returned a generic 404 for an archived ref.

## Changes

- **Store:** `scanItems` now scans `i.deleted_at`; all six feeding SELECTs select it (`ListItems`, `listItemsFTS` x2 dialects, `getChildItems`, `ItemsModifiedSince`, `ListStarredItems`). The `deleted_at IS NULL`-filtered paths are unaffected (value stays NULL there).
- **API:** `GET` resolves include-deleted, so an archived item is returned **read-only (200) with its `deleted_at` marker** instead of 404. `UPDATE` / `DELETE` / `MOVE` of an archived ref return a clear **409 `archived`** ("restore first"), visibility-gated identically to the active path (no existence leak).
- **CLI:** `(archived)` marker in `item list`; an `Archived:` line in `item show`.

## Tests

- Store: `IncludeArchived` returns the archived row with `DeletedAt` populated; the default (active-only) list excludes it.
- Server: `GET` archived -> 200 + `deleted_at`; `UPDATE` / `MOVE` archived -> 409 `archived`.
- Gates: `make check` and `make test-pg` (dual-dialect Postgres) green. Codex review loop converged to CLEAN (round 1 caught the move path; fixed).

## Notes / follow-up

- The reporter's "it appeared in a `status=todo` list earlier in the same session" can't be reproduced locally and contradicts the code (an archived row can't match a status-filtered list); likely a misread or a pad-cloud cache/replica artifact — confirming would need the tolkien-workspace row.
- No agent-facing restore yet (`pad item restore` / `pad_item action=restore`) — restore is web-UI / REST only. Filing a follow-up so the "restore first" guidance becomes self-serve for agents.

Closes BUG-1791.
