### PR TITLE
feat(items): expose item restore via CLI + MCP (TASK-1828)

### DIFF
--- a/cmd/pad/groups.go
+++ b/cmd/pad/groups.go
@@ -89,6 +89,7 @@ func itemCmd() *cobra.Command {
 		showCmd(),
 		updateCmd(),
 		deleteCmd(),
+		restoreCmd(),
 		moveCmd(),
 		editCmd(),
 		searchCmd(),

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -3828,6 +3828,46 @@ func deleteCmd() *cobra.Command {
 	}
 }
 
+// --- restore ---
+
+func restoreCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "restore <ref>",
+		Short: "Restore (un-archive) a soft-deleted item",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, _ := getClient()
+			ws := getWorkspace()
+
+			// The restore endpoint resolves the (archived) ref server-side
+			// with include-deleted semantics and returns the restored item.
+			item, err := client.RestoreItem(ws, args[0])
+			if err != nil {
+				return err
+			}
+
+			ref := cli.ItemRef(*item)
+
+			// JSON branch: mirror delete's structured envelope so MCP agents
+			// can confirm the restore landed without scraping text.
+			if formatFlag == "json" {
+				return cli.PrintJSON(map[string]any{
+					"ref":      ref,
+					"title":    item.Title,
+					"restored": true,
+				})
+			}
+
+			if ref != "" {
+				fmt.Printf("Restored %s %q\n", ref, item.Title)
+			} else {
+				fmt.Printf("Restored %q\n", args[0])
+			}
+			return nil
+		},
+	}
+}
+
 // --- move ---
 
 func moveCmd() *cobra.Command {

--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -222,6 +222,14 @@ func (c *Client) DeleteItem(wsSlug, itemSlug string) error {
 	return c.delete("/workspaces/" + wsSlug + "/items/" + itemSlug)
 }
 
+// RestoreItem un-archives a soft-deleted item via the restore endpoint, which
+// resolves the ref/slug with include-deleted semantics server-side (the normal
+// resolver 404s on archived items). Returns the restored item.
+func (c *Client) RestoreItem(wsSlug, itemSlug string) (*models.Item, error) {
+	var result models.Item
+	return &result, c.post("/workspaces/"+wsSlug+"/items/"+itemSlug+"/restore", nil, &result)
+}
+
 // StarItem stars an item for the current user.
 func (c *Client) StarItem(wsSlug, itemSlug string) error {
 	return c.post("/workspaces/"+wsSlug+"/items/"+itemSlug+"/star", nil, nil)

--- a/internal/mcp/catalog_item.go
+++ b/internal/mcp/catalog_item.go
@@ -40,12 +40,13 @@ var padItemTool = ToolDef{
 	},
 	Actions: map[string]ActionFn{
 		// Lifecycle
-		"create": passThrough([]string{"item", "create"}),
-		"update": passThrough([]string{"item", "update"}),
-		"delete": passThrough([]string{"item", "delete"}),
-		"get":    passThrough([]string{"item", "show"}),
-		"list":   passThrough([]string{"item", "list"}),
-		"move":   passThrough([]string{"item", "move"}),
+		"create":  passThrough([]string{"item", "create"}),
+		"update":  passThrough([]string{"item", "update"}),
+		"delete":  passThrough([]string{"item", "delete"}),
+		"get":     passThrough([]string{"item", "show"}),
+		"list":    passThrough([]string{"item", "list"}),
+		"move":    passThrough([]string{"item", "move"}),
+		"restore": passThrough([]string{"item", "restore"}),
 
 		// Relationships — link/unlink fan out to per-type cmdPaths.
 		"link":   actionItemLink,
@@ -94,7 +95,7 @@ var padItemTool = ToolDef{
 // keeping the schema simple to maintain.
 var padItemSchemaParams = []ParamDef{
 	// ── Targeting ──
-	{Name: "ref", Type: "string", Description: "Item reference (e.g. TASK-5, IDEA-12). Required for: update, delete, get, move, link, unlink, deps, star, unstar, comment, list-comments, note, decide. NOT used for bulk-update — pass `refs` (array) instead."},
+	{Name: "ref", Type: "string", Description: "Item reference (e.g. TASK-5, IDEA-12). Required for: update, delete, restore, get, move, link, unlink, deps, star, unstar, comment, list-comments, note, decide. NOT used for bulk-update — pass `refs` (array) instead."},
 	{Name: "refs", Type: "array<string>", Description: "Item references for batch operations. Required for: bulk-update (one or more refs)."},
 	{Name: "target", Type: "string", Description: "The OTHER end of a relationship. Required for: link, unlink (paired with `ref` and `link_type`). For link_type=blocks, target is the item being blocked; for blocked-by it's the blocker; for supersedes it's the superseded item; etc."},
 	{Name: "link_type", Type: "string", Description: "Type of relationship for action=link/unlink.", Enum: []string{"blocks", "blocked-by", "supersedes", "implements", "split-from"}},
@@ -190,6 +191,8 @@ Actions:
                   Optional: title, status, priority, content, role, assign, parent, comment, tags.
                   Same placement rules as create.
   delete        — Archive an item.
+                  Required: ref.
+  restore       — Un-archive (restore) a soft-deleted item by ref.
                   Required: ref.
   get           — Read an item.
                   Required: ref.

--- a/internal/mcp/catalog_readonly_test.go
+++ b/internal/mcp/catalog_readonly_test.go
@@ -113,6 +113,7 @@ func TestReadOnlyCatalog_ActionsMatchCmdhelp(t *testing.T) {
 		{"pad_item", "get"}:           {"item", "show"},
 		{"pad_item", "list"}:          {"item", "list"},
 		{"pad_item", "move"}:          {"item", "move"},
+		{"pad_item", "restore"}:       {"item", "restore"},
 		{"pad_item", "deps"}:          {"item", "deps"},
 		{"pad_item", "star"}:          {"item", "star"},
 		{"pad_item", "unstar"}:        {"item", "unstar"},
@@ -250,6 +251,7 @@ func TestReadOnlyCatalog_ActionsDispatchExpectedCmdPath(t *testing.T) {
 		{"pad_item", "get"}:           {"item", "show"},
 		{"pad_item", "list"}:          {"item", "list"},
 		{"pad_item", "move"}:          {"item", "move"},
+		{"pad_item", "restore"}:       {"item", "restore"},
 		{"pad_item", "deps"}:          {"item", "deps"},
 		{"pad_item", "star"}:          {"item", "star"},
 		{"pad_item", "unstar"}:        {"item", "unstar"},
@@ -547,6 +549,11 @@ func liveCmdhelpDoc(t *testing.T) *cmdhelp.Document {
 			},
 			"item delete": {
 				Summary: "delete item",
+				Args:    mkArgs("ref"),
+				Flags:   mkFlags("workspace"),
+			},
+			"item restore": {
+				Summary: "restore item",
 				Args:    mkArgs("ref"),
 				Flags:   mkFlags("workspace"),
 			},

--- a/internal/mcp/dispatch_http_routes.go
+++ b/internal/mcp/dispatch_http_routes.go
@@ -206,6 +206,10 @@ func init() {
 			method:       http.MethodDelete,
 			pathTemplate: "/api/v1/workspaces/{workspace}/items/{ref}",
 		}.toRouteMapper(),
+		"item restore": routeSpec{
+			method:       http.MethodPost,
+			pathTemplate: "/api/v1/workspaces/{workspace}/items/{ref}/restore",
+		}.toRouteMapper(),
 		"item list":   mapItemList,
 		"item move":   mapItemMove,
 		"item search": mapItemSearch,

--- a/internal/mcp/dispatch_http_routes_test.go
+++ b/internal/mcp/dispatch_http_routes_test.go
@@ -631,7 +631,7 @@ func TestRoute_RoleList(t *testing.T) {
 // rather than silently flipping a tool back to "not yet implemented."
 func TestRouteTable_ContainsExpectedCommands(t *testing.T) {
 	want := []string{
-		"item create", "item show", "item list", "item delete",
+		"item create", "item show", "item list", "item delete", "item restore",
 		"item move", "item search", "item comment", "item comments",
 		"project dashboard", "collection list", "role list",
 	}
@@ -644,6 +644,16 @@ func TestRouteTable_ContainsExpectedCommands(t *testing.T) {
 	if len(missing) > 0 {
 		sort.Strings(missing)
 		t.Errorf("routeTable missing entries: %v", missing)
+	}
+}
+
+func TestRoute_ItemRestore(t *testing.T) {
+	m, p, _, err := routeTable["item restore"](map[string]any{"workspace": "docapp", "ref": "TASK-5"})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if m != http.MethodPost || p != "/api/v1/workspaces/docapp/items/TASK-5/restore" {
+		t.Errorf("got %s %s", m, p)
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes **TASK-1828** (child of BUG-1791). Adds the agent-facing **restore** surface so an archived item discovered via `pad item list --all` can be recovered without dropping to the web UI.

The server already had restore end-to-end — `Store.RestoreItem` + `handleRestoreItem` at `POST /items/{ref}/restore`, used by the web UI and bulk ops. This wires the two missing surfaces:

- **CLI:** `pad item restore <ref>` (`internal/cli/client.go` `RestoreItem` → the existing endpoint, which resolves the ref with include-deleted semantics server-side — the normal resolver 404s on archived items). Mirrors `pad item delete`'s structured JSON envelope: `{ref, title, restored: true}`.
- **MCP:** `pad_item action=restore` for both transports — `passThrough(["item","restore"])` for stdio, plus a `routeTable` entry (`POST .../items/{ref}/restore`) for the HTTP transport so cloud/HTTP MCP clients work too. Restore is non-destructive (it un-deletes), so it's safe to expose — unlike a hard delete. The action auto-joins the schema's action enum (derived from the Actions map), is documented in the tool description, and `ref` is listed as required for it.

Conflict case (slug / `invocation_slug` reclaimed while the item was archived) is already handled by `handleRestoreItem` (409) and surfaced cleanly by the CLI client's `handleResponse`.

## Tests

- The single-item restore endpoint is already covered (`handlers_items_test.go`).
- MCP contract: `restore` added to the catalog ⇄ cmdhelp bijection + dispatch tests (`catalog_readonly_test.go`).
- `make check` green.

Part of the BUG-1791 follow-through: TASK-1827 shipped in #733; TASK-1829 (web direct-access recovery) next.
