### PR TITLE
feat(web): show archived banner in-place on live archive (TASK-1833)

### DIFF
--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -338,7 +338,33 @@
 			// them on a non-existent item is worse than discarding the
 			// edit. Per Codex review round 2.
 			if (event.type === 'item_archived') {
-				goto(`/${username}/${wsSlug}/${collSlug}`);
+				// The open item was archived (another tab / user). GET still
+				// returns soft-deleted items (deleted_at set, #733), so re-fetch
+				// and show the in-place Archived banner instead of yanking the
+				// user back to the collection (TASK-1833). Two cases keep the
+				// prior redirect: mid-edit (an in-flight save will fail against
+				// the archived row and re-fetching would clobber the editor —
+				// the Codex-round-2 reasoning still holds there), and a re-fetch
+				// 404 (item hard-deleted — gone for real).
+				// editorStore.dirty catches unsaved content BEFORE the 1.2s
+				// debounced save flips saveStatus to 'saving' — without it a
+				// live archive in that window would re-fetch and clobber the
+				// user's in-progress edit (Codex P1).
+				if (saveStatus === 'saving' || editingTitle || editorStore.dirty) {
+					goto(`/${username}/${wsSlug}/${collSlug}`);
+					return;
+				}
+				const archItemId = item.id;
+				const archWsSlug = wsSlug;
+				const archItemSlug = itemSlug;
+				try {
+					const archived = await api.items.get(archWsSlug, archItemSlug);
+					if (!item || item.id !== archItemId) return;
+					item = withInflightTags(archived);
+				} catch {
+					if (!item || item.id !== archItemId) return;
+					goto(`/${username}/${wsSlug}/${collSlug}`);
+				}
 				return;
 			}
 
@@ -410,7 +436,31 @@
 			// Check this BEFORE the edit-conflict guard so a deleted item
 			// doesn't sit there gated by an in-flight save.
 			if (result.type === 'incremental' && result.changes.deleted.includes(item.id)) {
-				goto(`/${username}/${wsSlug}/${collSlug}`);
+				// Archived or hard-deleted while we were away. GET returns
+				// soft-deleted items (deleted_at set) but 404s on a hard delete,
+				// so re-fetch: an archived item shows the in-place banner, a
+				// hard-deleted one redirects (TASK-1833). Keep the prior redirect
+				// when mid-edit (don't clobber an in-flight save against a
+				// now-archived row).
+				// editorStore.dirty catches unsaved content BEFORE the 1.2s
+				// debounced save flips saveStatus to 'saving' — without it a
+				// live archive in that window would re-fetch and clobber the
+				// user's in-progress edit (Codex P1).
+				if (saveStatus === 'saving' || editingTitle || editorStore.dirty) {
+					goto(`/${username}/${wsSlug}/${collSlug}`);
+					return;
+				}
+				const delItemId = item.id;
+				const delWsSlug = wsSlug;
+				const delItemSlug = itemSlug;
+				try {
+					const refreshed = await api.items.get(delWsSlug, delItemSlug);
+					if (!item || item.id !== delItemId) return;
+					item = withInflightTags(refreshed);
+				} catch {
+					if (!item || item.id !== delItemId) return;
+					goto(`/${username}/${wsSlug}/${collSlug}`);
+				}
 				return;
 			}
 


### PR DESCRIPTION
## Summary

Closes **TASK-1833** (the deferred Codex-High from #735, folded in per request). Completes the in-place archived flow: when the OPEN item is archived *live* (another tab/user, or a sync resume), the detail route now shows the in-place Archived banner instead of redirecting back to the collection.

Before this, the in-place banner (from #735) only appeared on a fresh direct load of an already-archived item — the SSE `item_archived` and sync-resume `deleted` handlers still `goto()`'d away.

## Changes (one file: the detail route `+page.svelte`)

- **SSE `item_archived`:** re-fetch the item (GET returns soft-deleted items with `deleted_at`, #733) and show the banner in place, instead of `goto()`.
- **Sync-resume `deleted`:** re-fetch — an archived item (still resolvable, 200) shows the banner; a hard-deleted one (404) still redirects. This distinguishes archive from hard-delete without parsing the sync lists.
- **Mid-edit guard:** both keep the prior redirect when `saveStatus === 'saving' || editingTitle || editorStore.dirty`. The `editorStore.dirty` check is the key correctness bit — content edits set dirty immediately but the save is debounced 1.2s, so without it a live archive in that window would re-fetch and clobber unsaved content (Codex P1, round 1).
- Race guards mirror the handlers' existing pattern (capture item id before await, bail if navigated away).
- The actor's own archive still navigates via `handleDelete`'s `goto`; this only changes the someone-else-archived-it case.

## Tests

- `cd web && npm run check` (svelte-check): 0 errors.
- Production web build (`make web`) green.
- Codex review loop: CLEAN (round 1 → widen the mid-edit guard to include the editor dirty flag).

Final piece of the BUG-1791 follow-through (#733 / #734 / #735 + this).
