### PR TITLE
fix(web): kanban board height accounts for workspace top bar (BUG-1844)

### DIFF
--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -2266,7 +2266,16 @@
 	.collection-page.board-active {
 		max-width: none;
 		padding: var(--space-6) var(--space-6);
-		height: 100vh;
+		/*
+			Fill the scrollable .main-content region, NOT the viewport.
+			.main-content (root +layout) already sizes itself below the
+			workspace TopBar via flexbox, so `height: 100%` resolves to
+			exactly the available space whether the TopBar is shown or
+			hidden. The old `height: 100vh` claimed the full viewport and
+			overflowed .main-content by the TopBar's height whenever the
+			bar was visible — the extra scrollable space in BUG-1844.
+		*/
+		height: 100%;
 		display: flex;
 		flex-direction: column;
 		overflow: hidden;


### PR DESCRIPTION
## BUG-1844

The main content area had extra scrollable space on collection pages in **Kanban board view** — lanes were slightly too tall. Worked fine only when the workspace top bar was hidden.

## Root cause

`.collection-page.board-active` hardcoded `height: 100vh` (the full viewport). But the page renders inside `.main-content`, which the root layout already sizes to fill the space *below* the workspace TopBar via flexbox (`.app-layout` is `100vh` flex-column → TopBar + `.app-shell` `flex:1` → `.main-content` `flex:1`). When the TopBar was visible, the board claimed the full `100vh` and overflowed `.main-content` by exactly the bar's height. With the bar hidden, `100vh` coincidentally matched — so it looked fine.

## Fix

Use `height: 100%` so the board fills `.main-content` in both states. `BoardView` already sizes via `flex: 1; min-height: 0` from its parent, so no other changes needed.

## Verification

- `cd web && npm run build` — passes
- `make install` + visual check: board lanes fit flush with the top bar shown and hidden (⌘\ toggles both ways)
- Codex CLI review (CONVE-735): **CLEAN**, no findings