### PR TITLE
feat(auth): surface server version on /auth/session (TASK-1839)

### DIFF
--- a/internal/server/handlers_auth.go
+++ b/internal/server/handlers_auth.go
@@ -132,6 +132,7 @@ func (s *Server) setupStatePayload(setupMethod string) map[string]interface{} {
 		"cloud_mode":        s.cloudMode,
 		"mcp_public_url":    s.mcpPublicURL,
 		"billing_available": s.cloudMode && s.billingAvailable,
+		"version":           s.version,
 	}
 }
 
@@ -152,6 +153,13 @@ func (s *Server) sessionStatePayload(authenticated bool, user *models.User) map[
 		"cloud_mode":        s.cloudMode,
 		"mcp_public_url":    s.mcpPublicURL,
 		"billing_available": s.cloudMode && s.billingAvailable,
+		// version is the server build version (same source as /health),
+		// surfaced here so the mobile shells can read it in the
+		// /auth/session call they already make on connect and warn when a
+		// server is below their minimum supported version (IDEA-1826).
+		// Empty string only on builds with no version stamped; release
+		// builds carry a semver, dev builds carry "dev".
+		"version": s.version,
 	}
 	if authenticated {
 		payload["user"] = sessionUserPayload(user)

--- a/internal/server/handlers_auth_test.go
+++ b/internal/server/handlers_auth_test.go
@@ -148,6 +148,41 @@ func TestAuthSessionBillingAvailable(t *testing.T) {
 	}
 }
 
+// version is surfaced on /auth/session (IDEA-1826 / TASK-1839) so the mobile
+// shells can read the server build version in the call they already make on
+// connect and warn when it's below their minimum. It must appear in BOTH the
+// pre-setup payload (no users yet — the shell validates fresh servers too) and
+// the post-setup authenticated/unauthenticated payload.
+func TestAuthSessionEmitsVersion(t *testing.T) {
+	srv := testServer(t)
+	srv.version = "1.2.3"
+
+	// Pre-setup (no users): setupStatePayload must carry version.
+	rr := doRequest(srv, "GET", "/api/v1/auth/session", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("session check: expected 200, got %d", rr.Code)
+	}
+	var session map[string]interface{}
+	parseJSON(t, rr, &session)
+	if session["setup_required"] != true {
+		t.Fatal("expected setup_required=true when no users exist")
+	}
+	if got := session["version"]; got != "1.2.3" {
+		t.Errorf("expected version=1.2.3 in setup-state payload, got %v", got)
+	}
+
+	// Post-setup, authenticated: sessionStatePayload must carry version too.
+	token := bootstrapFirstUser(t, srv, "admin@test.com", "Admin")
+	rr = doRequestWithCookie(srv, "GET", "/api/v1/auth/session", nil, token)
+	parseJSON(t, rr, &session)
+	if session["authenticated"] != true {
+		t.Fatal("expected authenticated=true after bootstrap")
+	}
+	if got := session["version"]; got != "1.2.3" {
+		t.Errorf("expected version=1.2.3 in authenticated payload, got %v", got)
+	}
+}
+
 func TestAuthBootstrapRequiresLoopback(t *testing.T) {
 	srv := testServer(t)
 

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -332,6 +332,11 @@ export interface AuthSession {
 	// AND the deployment is in cloud mode. Use authStore.billingAvailable rather
 	// than reading this field directly. TASK-800.
 	billing_available?: boolean;
+	// version is the server build version (same value as HealthResponse.version),
+	// surfaced on /auth/session so clients — notably the mobile shells — can read
+	// it in the call they already make on connect (IDEA-1826). Empty string only
+	// when no version was stamped at build time; "dev" on dev builds.
+	version?: string;
 	user?: { id: string; email: string; username: string; name: string; role: string; plan?: string };
 }
 


### PR DESCRIPTION
## What

Add the server build version to both the setup-state and authenticated `/auth/session` payloads (same source as `/health`).

## Why

The mobile shells call `/auth/session` on connect. Surfacing `version` there lets them read it in the round-trip they already make and warn when a server is below their minimum supported version — without a second request (IDEA-1826).

## Changes

- `internal/server/handlers_auth.go` — emit `version` in both `setupStatePayload` and `sessionStatePayload`.
- `internal/server/handlers_auth_test.go` — assert `version` appears in the pre-setup and post-setup (authenticated) payloads.
- `web/src/lib/api/client.ts` — add `version?: string` to the `AuthSession` type (CONVE-1741).

Rebased onto current main (post-#739); builds, auth tests, and web build all pass.

https://claude.ai/code/session_01KmxkPxLksjf1pmrZDpsnTJ