### PR TITLE
feat(web): NL-canonical onboarding banner copy (TASK-1851)

### DIFF
--- a/web/src/lib/components/OnboardingNudgeBanner.svelte
+++ b/web/src/lib/components/OnboardingNudgeBanner.svelte
@@ -58,8 +58,8 @@
 	<div class="nudge-body">
 		<span class="nudge-title">Set up your workspace</span>
 		<p class="nudge-text">
-			Your workspace is ready. Connect your agent and type
-			<code>/pad onboard</code> to walk through setting it up.
+			Your workspace is ready. Connect your agent, then just say
+			<code>set up my workspace</code> &mdash; it'll walk you through setup.
 		</p>
 	</div>
 	<span class="nudge-actions">


### PR DESCRIPTION
## Summary

`OnboardingNudgeBanner` hardcoded `/pad onboard`, contradicting the NL-canonical messaging shipped in #741 (TASK-1849) and wrong for non-Claude-Code agents (Codex `$pad`, MCP). Now leads with natural language — *"Connect your agent, then just say `set up my workspace`"* — the universal trigger.

`ConnectBanner` audited: no slug reference, left as-is. Per-surface shortcut rendering is deferred to the launchpad's surface-aware kickoff step (TASK-1852), where the chosen tool is known.

## Context
Implements `TASK-1851` under `PLAN-1847` (Phase 2, task A). Web copy only.

## Test plan
- [x] cd web && npm run build — clean

https://claude.ai/code/session_01KmxkPxLksjf1pmrZDpsnTJ