### PR TITLE
feat(onboard): capture workspace intent at creation, warm the onboard run (TASK-1855)

### DIFF
--- a/internal/collections/playbook_library_onboard.go
+++ b/internal/collections/playbook_library_onboard.go
@@ -72,6 +72,8 @@ seeded to the project at hand.
 
 1. **Load the bootstrap blob.** ` + "`pad bootstrap --format json`" + ` (CLI) or the ` + "`pad_meta.action: bootstrap`" + ` MCP action. This is one round-trip and gives you everything you need: workspace name, user, collections (with schemas), conventions, playbooks, roles, dashboard, recent activity.
 
+   **Read ` + "`workspace.description`" + ` if present** — it's the free-text "what are you tracking?" the user gave at workspace creation. Treat it as the user's stated intent: it seeds the interview so you don't have to open with "what is this project?". Reflect it back to confirm rather than asking cold (see B1).
+
 2. **Detect mode.** Inspect the bootstrap to pick the right path:
    - **build** — workspace has only the two system collections (` + "`conventions`" + `, ` + "`playbooks`" + `) AND no user-created items AND no seeded conventions/playbooks (beyond this onboard playbook itself). This is the ` + "`blank`" + ` template path.
    - **audit** — workspace has a template's seeded user-facing collections (Tasks/Ideas/Plans/Docs/Backlog/Sprints/etc.) and possibly seeded conventions/playbooks, but no user-created items yet. This is the non-blank templates path. The user picked an opinionated starting point; your job is to make it fit.
@@ -92,7 +94,7 @@ The user picked the blank template (or somehow ended up with a workspace that ha
 
 ### B1. Discover the domain
 
-Open question: "What is this workspace for?" Listen to the answer.
+If ` + "`workspace.description`" + ` was set at creation, lead by reflecting it back instead of asking cold: "You mentioned this workspace is for <description> — let's build around that. Tell me more about how you work?" Only fall back to the open question — "What is this workspace for?" — when no description was captured. Listen to the answer either way.
 
 Use the codebase context if you have it. Example: "I see a Go project with a Makefile and GitHub Actions — does this workspace track software development for that codebase?"
 

--- a/internal/server/handlers_bootstrap.go
+++ b/internal/server/handlers_bootstrap.go
@@ -235,10 +235,16 @@ func projectBootstrapRole(r models.AgentRole) BootstrapRole {
 
 // AgentBootstrapWorkspace is the minimal workspace projection (slug + name
 // + id) the agent needs to address the workspace in subsequent calls.
+// Description carries the free-text "what are you tracking?" captured at
+// workspace creation (PLAN-1847 Phase 3 / TASK-1855) so the onboard playbook
+// can start the interview warm instead of asking "what is this project?".
+// Omitted when empty — additive to the bootstrap contract, so existing
+// clients are unaffected.
 type AgentBootstrapWorkspace struct {
-	ID   string `json:"id"`
-	Slug string `json:"slug"`
-	Name string `json:"name"`
+	ID          string `json:"id"`
+	Slug        string `json:"slug"`
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
 }
 
 // AgentBootstrapUser is the calling user's projection. Email is included
@@ -376,9 +382,10 @@ func (s *Server) BuildAgentBootstrap(workspaceID string, user *models.User, r *h
 
 	out := &AgentBootstrap{
 		Workspace: AgentBootstrapWorkspace{
-			ID:   ws.ID,
-			Slug: ws.Slug,
-			Name: ws.Name,
+			ID:          ws.ID,
+			Slug:        ws.Slug,
+			Name:        ws.Name,
+			Description: ws.Description,
 		},
 	}
 	if user != nil {

--- a/web/src/lib/components/layout/CreateWorkspaceModal.svelte
+++ b/web/src/lib/components/layout/CreateWorkspaceModal.svelte
@@ -28,6 +28,10 @@
 	// Picking any template card replaces 'blank' with that template's name.
 	let mode = $state<'create' | 'import'>('create');
 	let newName = $state('');
+	// Optional "what are you tracking?" intent captured at creation. Stored as
+	// the workspace description and surfaced in the bootstrap blob so the
+	// onboard playbook starts the interview warm (PLAN-1847 Phase 3 / TASK-1855).
+	let newDescription = $state('');
 	let selectedTemplate = $state('blank');
 	// Independent of `selectedTemplate` — collapsed by default per IDEA-1516
 	// §2. Users who expand and pick a template flip `selectedTemplate` to
@@ -57,6 +61,7 @@
 			// Reset state on open
 			mode = 'create';
 			newName = '';
+			newDescription = '';
 			selectedTemplate = 'blank';
 			templatesExpanded = false;
 			importFile = null;
@@ -103,6 +108,7 @@
 		try {
 			const ws = await workspaceStore.create({
 				name: newName.trim(),
+				description: newDescription.trim() || undefined,
 				template: selectedTemplate || undefined
 			});
 			// Fire the Phase F hook BEFORE close + goto so the consumer can
@@ -218,6 +224,16 @@
 			/>
 
 			{#if mode === 'create'}
+				<label class="field-label" for="ws-create-desc">What are you tracking? <span class="field-optional">(optional)</span></label>
+				<textarea
+					id="ws-create-desc"
+					class="desc-input"
+					bind:value={newDescription}
+					rows="2"
+					placeholder="e.g. a SvelteKit SaaS app, my job search, a research project on…"
+				></textarea>
+				<p class="field-hint">Your agent uses this to set the workspace up for you.</p>
+
 				<!--
 					Primary "Start blank" card — visually selected when
 					selectedTemplate === 'blank'. Clicking it returns to
@@ -439,6 +455,31 @@
 		font-size: 0.9em;
 	}
 	.modal-body input:focus { outline: none; border-color: var(--accent-blue); }
+
+	.field-optional {
+		text-transform: none;
+		font-weight: 400;
+		letter-spacing: 0;
+		color: var(--text-muted);
+	}
+	.desc-input {
+		width: 100%;
+		box-sizing: border-box;
+		padding: var(--space-2) var(--space-3);
+		background: var(--bg-tertiary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+		color: var(--text-primary);
+		font-size: 0.9em;
+		font-family: inherit;
+		resize: vertical;
+	}
+	.desc-input:focus { outline: none; border-color: var(--accent-blue); }
+	.field-hint {
+		margin: calc(-1 * var(--space-1)) 0 0;
+		font-size: 0.78em;
+		color: var(--text-muted);
+	}
 
 	/* Primary "Start blank" card — bigger than a template card to anchor it
 	   as the recommended option. Same selection treatment (accent border +


### PR DESCRIPTION
## Summary

**Intent-as-seed** for the onboarding bridge. The workspace `description` column already existed end-to-end (DB, model, `WorkspaceCreate`, TS type) but nothing captured or surfaced it:

- **Web** — `CreateWorkspaceModal` gains an optional *"What are you tracking?"* textarea (create-only), sent as `description` on create.
- **Bootstrap** — `AgentBootstrapWorkspace` now carries `description` (`omitempty`, additive) so the onboard playbook can read the user's stated intent. Additive field → compatible, no `ToolSurfaceVersion` bump.
- **Onboard playbook** — pre-flight reads `workspace.description`; B1 reflects it back (*"You mentioned this is for X — let's build around that"*) instead of opening cold with *"what is this project?"*, falling back to the open question when absent.

Net effect: a user who types one line at creation gets an onboard interview that starts warm instead of from zero.

## Context
Implements `TASK-1855` under `PLAN-1847` (Phase 3).

## Test plan
- [x] go build ./... / go vet — clean
- [x] go test ./internal/server/... ./internal/collections/... — green
- [x] cd web && npm run build — clean

https://claude.ai/code/session_01KmxkPxLksjf1pmrZDpsnTJ