### PR TITLE
feat(web): NL-canonical playbook invocation in the editor + library (TASK-1860)

### DIFF
--- a/web/src/lib/components/playbooks/PlaybookFormFields.svelte
+++ b/web/src/lib/components/playbooks/PlaybookFormFields.svelte
@@ -560,6 +560,22 @@
 
 		<div class="invocation-block">
 			<div class="invocation-header">
+				<span class="invocation-label">Natural language <span class="invocation-canonical">— works anywhere</span></span>
+				<button
+					type="button"
+					class="copy-btn"
+					onclick={() => copyToClipboard('nl', invocation.nl)}
+				>
+					{copiedKey === 'nl' ? 'Copied!' : 'Copy'}
+				</button>
+			</div>
+			<pre class="invocation-code">{invocation.nl}</pre>
+		</div>
+
+		<p class="invocation-shortcuts-note">Or use the shortcut for your agent:</p>
+
+		<div class="invocation-block">
+			<div class="invocation-header">
 				<span class="invocation-label">Claude Code</span>
 				<button
 					type="button"
@@ -795,6 +811,17 @@
 		text-transform: uppercase;
 		letter-spacing: 0.05em;
 		color: var(--text-secondary);
+	}
+	.invocation-canonical {
+		font-weight: 600;
+		text-transform: none;
+		letter-spacing: 0;
+		color: var(--accent-blue);
+	}
+	.invocation-shortcuts-note {
+		margin: var(--space-3) 0 0;
+		font-size: 0.78em;
+		color: var(--text-muted);
 	}
 	.copy-btn {
 		padding: 2px var(--space-2);

--- a/web/src/lib/playbooks/arguments.ts
+++ b/web/src/lib/playbooks/arguments.ts
@@ -400,6 +400,12 @@ export function argumentsFromJSON(raw: unknown): PlaybookArgument[] {
  * the rendered command doesn't show empty=`= ` pairs.
  */
 export interface TestInvocationRendering {
+	/**
+	 * The canonical, surface-neutral form: plain natural language. Works on
+	 * every agent surface (PLAN-1858 / IDEA-1846). The other fields are
+	 * per-surface shortcuts that resolve to the same playbook.
+	 */
+	nl: string;
 	claude: string;
 	cli: string;
 	mcp: string;
@@ -439,6 +445,7 @@ export function buildTestInvocation(
 	}
 
 	return {
+		nl: `run the ${safeSlug} playbook${claudeTokens.length ? ' ' + claudeTokens.join(' ') : ''}`,
 		claude: `/pad ${safeSlug}${claudeTokens.length ? ' ' + claudeTokens.join(' ') : ''}`,
 		cli: `pad playbook run ${safeSlug}${cliTokens.length ? ' ' + cliTokens.join(' ') : ''}`,
 		mcp: JSON.stringify(

--- a/web/src/routes/[username]/[workspace]/library/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/library/+page.svelte
@@ -229,7 +229,7 @@
 									<h3 class="card-title">{playbook.title}</h3>
 									<div class="badges">
 										{#if playbook.invocation_slug}
-											<span class="badge slug" title={`Invoke via /pad ${playbook.invocation_slug}`}>/pad {playbook.invocation_slug}</span>
+											<span class="badge slug" title={`Run it by saying "run the ${playbook.invocation_slug} playbook" — or the shortcut for your agent: /pad ${playbook.invocation_slug} (Claude Code), $pad ${playbook.invocation_slug} (Codex), pad_playbook action=run ref=${playbook.invocation_slug} (MCP)`}>▶ {playbook.invocation_slug}</span>
 										{/if}
 										<span class="badge trigger">{playbook.trigger}</span>
 										<span class="badge scope">{playbook.scope}</span>


### PR DESCRIPTION
## Summary

Makes natural language the canonical framing in the two web surfaces that talk about playbook invocation.

- **`buildTestInvocation`** (`arguments.ts`) now returns a surface-neutral **`nl`** form (*"run the <slug> playbook …"*) as the first/canonical field, alongside the existing claude/cli/mcp shortcuts.
- **Playbook editor "Test invocation" helper** (`PlaybookFormFields.svelte`) leads with a **"Natural language — works anywhere"** block, then frames Claude Code / CLI / MCP under *"Or use the shortcut for your agent:"*.
- **Library card chip** changes from `/pad <slug>` to **`▶ <slug>`** with an NL-canonical tooltip that lists the per-surface shortcuts. The web UI can't detect which agent the user runs, so this is honest reframing rather than a per-tool chip.

## Context
Implements `TASK-1860` under `PLAN-1858`. Web only. No external tests asserted `buildTestInvocation`'s shape.

## Test plan
- [x] cd web && npm run build — clean

https://claude.ai/code/session_01KmxkPxLksjf1pmrZDpsnTJ