### PR TITLE
feat(artifact): MD+frontmatter export/import core for playbooks & conventions

### DIFF
--- a/internal/artifact/artifact.go
+++ b/internal/artifact/artifact.go
@@ -1,0 +1,77 @@
+// Package artifact defines a portable, self-contained format for exporting
+// and importing a single playbook or convention item as Markdown body +
+// YAML frontmatter.
+//
+// This package is the Phase-1 core: it does encode/decode only. Server-side
+// validation, forgiving coercion, slug-collision handling, and input-size
+// limits live at the HTTP boundary in a later phase. Keep this package a
+// clean pure parse/serialize layer with no HTTP, store, or dialect deps.
+package artifact
+
+import "errors"
+
+// FormatVersion is the current artifact format version.
+const FormatVersion = 1
+
+// Kind identifies which item type an artifact carries.
+type Kind string
+
+const (
+	// KindPlaybook is a playbook artifact.
+	KindPlaybook Kind = "playbook"
+	// KindConvention is a convention artifact.
+	KindConvention Kind = "convention"
+)
+
+// Sentinel errors. Wrap with context via fmt.Errorf("...: %w", Err...).
+var (
+	// ErrMalformed indicates the frontmatter is missing or unparseable.
+	ErrMalformed = errors.New("artifact: malformed frontmatter")
+	// ErrUnknownKind indicates pad_artifact is not playbook or convention.
+	ErrUnknownKind = errors.New("artifact: unknown kind")
+	// ErrUnsupportedVersion indicates format_version is not 1.
+	ErrUnsupportedVersion = errors.New("artifact: unsupported format version")
+)
+
+// Provenance records where an artifact came from.
+type Provenance struct {
+	Workspace     string `yaml:"workspace"`
+	ExportedAt    string `yaml:"exported_at"`
+	Author        string `yaml:"author"`
+	FormatVersion int    `yaml:"format_version"`
+}
+
+// Artifact is a decoded export of one playbook or convention item.
+type Artifact struct {
+	Kind          Kind
+	FormatVersion int
+	Title         string
+	// Fields holds the item's structured field values keyed by field key.
+	Fields     map[string]any
+	Body       string
+	Provenance Provenance
+}
+
+// playbookFieldKeys are the item fields that ride in a playbook's frontmatter.
+var playbookFieldKeys = []string{"status", "trigger", "scope", "invocation_slug", "arguments"}
+
+// conventionFieldKeys are the item fields that ride in a convention's frontmatter.
+var conventionFieldKeys = []string{"status", "trigger", "scope", "priority", "role"}
+
+// FieldKeysForKind returns the frontmatter field keys for the given kind, or
+// ErrUnknownKind if the kind is not recognized. A later phase's server code
+// consumes this.
+func FieldKeysForKind(k Kind) ([]string, error) {
+	switch k {
+	case KindPlaybook:
+		out := make([]string, len(playbookFieldKeys))
+		copy(out, playbookFieldKeys)
+		return out, nil
+	case KindConvention:
+		out := make([]string, len(conventionFieldKeys))
+		copy(out, conventionFieldKeys)
+		return out, nil
+	default:
+		return nil, ErrUnknownKind
+	}
+}

--- a/internal/artifact/decode.go
+++ b/internal/artifact/decode.go
@@ -1,0 +1,132 @@
+package artifact
+
+import (
+	"fmt"
+	"strings"
+
+	"go.yaml.in/yaml/v4"
+)
+
+// Decode parses an artifact's portable on-disk form back into an Artifact.
+//
+// It splits a leading "---\n ... \n---" frontmatter block from the body,
+// unmarshals the frontmatter, validates pad_artifact and format_version, and
+// reconstructs Fields from only the keys valid for the kind (omitting
+// empty/zero values). The body is everything after the closing fence with the
+// single separating blank line trimmed.
+func Decode(data []byte) (Artifact, error) {
+	fmText, body, err := splitFrontmatter(string(data))
+	if err != nil {
+		return Artifact{}, err
+	}
+
+	var fm frontmatter
+	if err := yaml.Unmarshal([]byte(fmText), &fm); err != nil {
+		return Artifact{}, fmt.Errorf("decode: unmarshal frontmatter: %w", ErrMalformed)
+	}
+
+	if _, err := FieldKeysForKind(fm.PadArtifact); err != nil {
+		return Artifact{}, fmt.Errorf("decode: pad_artifact %q: %w", fm.PadArtifact, ErrUnknownKind)
+	}
+	if fm.FormatVersion != FormatVersion {
+		return Artifact{}, fmt.Errorf("decode: format_version %d: %w", fm.FormatVersion, ErrUnsupportedVersion)
+	}
+
+	a := Artifact{
+		Kind:          fm.PadArtifact,
+		FormatVersion: fm.FormatVersion,
+		Title:         fm.Title,
+		Fields:        map[string]any{},
+		Body:          body,
+		Provenance:    fm.Provenance,
+	}
+
+	keys, _ := FieldKeysForKind(fm.PadArtifact)
+	for _, k := range keys {
+		switch k {
+		case "status":
+			putString(a.Fields, k, fm.Status)
+		case "trigger":
+			putString(a.Fields, k, fm.Trigger)
+		case "scope":
+			putString(a.Fields, k, fm.Scope)
+		case "invocation_slug":
+			putString(a.Fields, k, fm.InvocationSlug)
+		case "priority":
+			putString(a.Fields, k, fm.Priority)
+		case "role":
+			putString(a.Fields, k, fm.Role)
+		case "arguments":
+			if len(fm.Arguments) > 0 {
+				a.Fields[k] = fm.Arguments
+			}
+		}
+	}
+
+	return a, nil
+}
+
+func putString(m map[string]any, k, v string) {
+	if v != "" {
+		m[k] = v
+	}
+}
+
+// splitFrontmatter separates a leading "---\n...\n---" block from the body.
+// Returns ErrMalformed if the opening or closing fence is missing or the
+// frontmatter block is empty. The returned body has the single separating
+// blank line (if present) trimmed; the rest is preserved.
+func splitFrontmatter(s string) (fm, body string, err error) {
+	// Require the opening fence at the very start.
+	const fence = "---"
+	if !strings.HasPrefix(s, fence+"\n") {
+		return "", "", fmt.Errorf("decode: missing opening fence: %w", ErrMalformed)
+	}
+	rest := s[len(fence)+1:]
+
+	// Find the closing fence: a line containing exactly "---".
+	idx := indexClosingFence(rest)
+	if idx < 0 {
+		return "", "", fmt.Errorf("decode: missing closing fence: %w", ErrMalformed)
+	}
+	fm = rest[:idx]
+	if strings.TrimSpace(fm) == "" {
+		return "", "", fmt.Errorf("decode: empty frontmatter: %w", ErrMalformed)
+	}
+
+	// Advance past the closing fence line.
+	after := rest[idx:]
+	if nl := strings.IndexByte(after, '\n'); nl >= 0 {
+		after = after[nl+1:]
+	} else {
+		after = ""
+	}
+
+	// Trim exactly one leading blank line between fence and body.
+	after = strings.TrimPrefix(after, "\n")
+
+	return fm, after, nil
+}
+
+// indexClosingFence returns the byte offset within s of the start of the first
+// line equal to "---" (optionally with trailing whitespace), or -1.
+func indexClosingFence(s string) int {
+	offset := 0
+	for {
+		line := s[offset:]
+		nl := strings.IndexByte(line, '\n')
+		var cur string
+		if nl >= 0 {
+			cur = line[:nl]
+		} else {
+			cur = line
+		}
+		if strings.TrimRight(cur, " \t\r") == "---" {
+			return offset
+		}
+		if nl < 0 {
+			return -1
+		}
+		offset += nl + 1
+	}
+}

--- a/internal/artifact/decode.go
+++ b/internal/artifact/decode.go
@@ -14,8 +14,13 @@ import (
 // reconstructs Fields from only the keys valid for the kind (omitting
 // empty/zero values). The body is everything after the closing fence with the
 // single separating blank line trimmed.
+//
+// CRLF line endings are normalized to LF up front so artifacts authored or
+// transported on Windows decode identically — fence detection and body
+// preservation both operate on canonical LF text.
 func Decode(data []byte) (Artifact, error) {
-	fmText, body, err := splitFrontmatter(string(data))
+	normalized := strings.ReplaceAll(string(data), "\r\n", "\n")
+	fmText, body, err := splitFrontmatter(normalized)
 	if err != nil {
 		return Artifact{}, err
 	}

--- a/internal/artifact/decode_test.go
+++ b/internal/artifact/decode_test.go
@@ -1,0 +1,97 @@
+package artifact
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+func TestRoundTripPlaybook(t *testing.T) {
+	want := samplePlaybook()
+	data, err := Encode(want)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	got, err := Decode(data)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("round-trip mismatch:\ngot:  %#v\nwant: %#v", got, want)
+	}
+}
+
+func TestRoundTripConvention(t *testing.T) {
+	want := sampleConvention()
+	data, err := Encode(want)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	got, err := Decode(data)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("round-trip mismatch:\ngot:  %#v\nwant: %#v", got, want)
+	}
+}
+
+func TestDecodeMissingFrontmatter(t *testing.T) {
+	cases := []string{
+		"no frontmatter here\n",
+		"---\nonly opening fence\n",
+		"---\n---\n\nbody\n", // empty frontmatter
+	}
+	for _, in := range cases {
+		_, err := Decode([]byte(in))
+		if !errors.Is(err, ErrMalformed) {
+			t.Errorf("input %q: got %v, want ErrMalformed", in, err)
+		}
+	}
+}
+
+func TestDecodeUnsupportedVersion(t *testing.T) {
+	in := "---\npad_artifact: playbook\nformat_version: 2\ntitle: x\nprovenance:\n  format_version: 1\n---\n\nbody\n"
+	_, err := Decode([]byte(in))
+	if !errors.Is(err, ErrUnsupportedVersion) {
+		t.Errorf("got %v, want ErrUnsupportedVersion", err)
+	}
+}
+
+func TestDecodeUnknownKind(t *testing.T) {
+	in := "---\npad_artifact: nonsense\nformat_version: 1\ntitle: x\n---\n\nbody\n"
+	_, err := Decode([]byte(in))
+	if !errors.Is(err, ErrUnknownKind) {
+		t.Errorf("got %v, want ErrUnknownKind", err)
+	}
+}
+
+func TestDecodeBodyPreserved(t *testing.T) {
+	body := "Line one\n\nLine three\n  indented\n"
+	a := sampleConvention()
+	a.Body = body
+	data, err := Encode(a)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	got, err := Decode(data)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if got.Body != body {
+		t.Errorf("body not preserved:\ngot:  %q\nwant: %q", got.Body, body)
+	}
+}
+
+func TestFieldKeysForKind(t *testing.T) {
+	if _, err := FieldKeysForKind("nonsense"); !errors.Is(err, ErrUnknownKind) {
+		t.Errorf("got %v, want ErrUnknownKind", err)
+	}
+	pb, err := FieldKeysForKind(KindPlaybook)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pb) != 5 {
+		t.Errorf("playbook keys: got %d, want 5", len(pb))
+	}
+}

--- a/internal/artifact/decode_test.go
+++ b/internal/artifact/decode_test.go
@@ -3,6 +3,7 @@ package artifact
 import (
 	"errors"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -80,6 +81,28 @@ func TestDecodeBodyPreserved(t *testing.T) {
 	}
 	if got.Body != body {
 		t.Errorf("body not preserved:\ngot:  %q\nwant: %q", got.Body, body)
+	}
+}
+
+func TestDecodeCRLFTolerant(t *testing.T) {
+	// An artifact authored/transported on Windows uses CRLF. Decoding it must
+	// yield the same result as the LF form: fences detected, body LF-normalized.
+	a := sampleConvention()
+	a.Body = "Line one\n\nLine three\n"
+	lf, err := Encode(a)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	crlf := strings.ReplaceAll(string(lf), "\n", "\r\n")
+	got, err := Decode([]byte(crlf))
+	if err != nil {
+		t.Fatalf("Decode(CRLF): %v", err)
+	}
+	if got.Kind != a.Kind || got.Title != a.Title {
+		t.Errorf("CRLF decode mismatch: got kind=%q title=%q", got.Kind, got.Title)
+	}
+	if got.Body != a.Body {
+		t.Errorf("CRLF body not LF-normalized:\ngot:  %q\nwant: %q", got.Body, a.Body)
 	}
 }
 

--- a/internal/artifact/encode.go
+++ b/internal/artifact/encode.go
@@ -1,0 +1,137 @@
+package artifact
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	"go.yaml.in/yaml/v4"
+)
+
+// Encode serializes an Artifact to its portable on-disk form:
+//
+//	---
+//	<yaml frontmatter>
+//	---
+//
+//	<body>
+//
+// Output is deterministic: two Encode calls on the same Artifact produce
+// byte-identical output. The body is emitted verbatim, normalized to end with
+// exactly one trailing newline, separated from the closing fence by exactly
+// one blank line.
+func Encode(a Artifact) ([]byte, error) {
+	keys, err := FieldKeysForKind(a.Kind)
+	if err != nil {
+		return nil, fmt.Errorf("encode: %w", err)
+	}
+
+	fm := frontmatter{
+		PadArtifact:   a.Kind,
+		FormatVersion: a.FormatVersion,
+		Title:         a.Title,
+		Provenance:    a.Provenance,
+	}
+	if fm.FormatVersion == 0 {
+		fm.FormatVersion = FormatVersion
+	}
+	if fm.Provenance.FormatVersion == 0 {
+		fm.Provenance.FormatVersion = FormatVersion
+	}
+
+	for _, k := range keys {
+		v, ok := a.Fields[k]
+		if !ok || v == nil {
+			continue
+		}
+		switch k {
+		case "status":
+			fm.Status = toString(v)
+		case "trigger":
+			fm.Trigger = toString(v)
+		case "scope":
+			fm.Scope = toString(v)
+		case "invocation_slug":
+			fm.InvocationSlug = toString(v)
+		case "priority":
+			fm.Priority = toString(v)
+		case "role":
+			fm.Role = toString(v)
+		case "arguments":
+			fm.Arguments = normalizeArguments(v)
+		}
+	}
+
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	if err := enc.Encode(&fm); err != nil {
+		return nil, fmt.Errorf("encode: marshal frontmatter: %w", err)
+	}
+	if err := enc.Close(); err != nil {
+		return nil, fmt.Errorf("encode: close encoder: %w", err)
+	}
+
+	body := normalizeBody(a.Body)
+
+	var out bytes.Buffer
+	out.WriteString("---\n")
+	out.Write(buf.Bytes())
+	out.WriteString("---\n\n")
+	out.WriteString(body)
+	return out.Bytes(), nil
+}
+
+// normalizeBody trims a trailing run of whitespace/newlines and ensures the
+// body ends with exactly one trailing "\n". An empty body becomes "\n".
+func normalizeBody(body string) string {
+	trimmed := strings.TrimRight(body, "\n")
+	return trimmed + "\n"
+}
+
+// toString coerces a scalar frontmatter value to string. Values originate as
+// strings in practice; non-strings are rendered defensively.
+func toString(v any) string {
+	switch s := v.(type) {
+	case string:
+		return s
+	case nil:
+		return ""
+	default:
+		return fmt.Sprintf("%v", v)
+	}
+}
+
+// normalizeArguments coerces the arguments value into []map[string]any so it
+// serializes as a stable YAML sequence of maps. Accepts []map[string]any or
+// []any (e.g. JSON-decoded) whose elements are map[string]any. Anything it
+// cannot interpret as a map is skipped.
+func normalizeArguments(v any) []map[string]any {
+	switch xs := v.(type) {
+	case []map[string]any:
+		if len(xs) == 0 {
+			return nil
+		}
+		return xs
+	case []any:
+		out := make([]map[string]any, 0, len(xs))
+		for _, el := range xs {
+			if m := toStringMap(el); m != nil {
+				out = append(out, m)
+			}
+		}
+		if len(out) == 0 {
+			return nil
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+func toStringMap(v any) map[string]any {
+	if m, ok := v.(map[string]any); ok {
+		return m
+	}
+	return nil
+}

--- a/internal/artifact/encode_test.go
+++ b/internal/artifact/encode_test.go
@@ -1,0 +1,127 @@
+package artifact
+
+import (
+	"bytes"
+	"flag"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+var update = flag.Bool("update", false, "update golden files")
+
+func samplePlaybook() Artifact {
+	return Artifact{
+		Kind:          KindPlaybook,
+		FormatVersion: FormatVersion,
+		Title:         "Ship a change",
+		Fields: map[string]any{
+			"status":          "active",
+			"trigger":         "on-intent",
+			"scope":           "workspace",
+			"invocation_slug": "ship",
+			"arguments": []map[string]any{
+				{"name": "ref", "type": "ref", "required": true, "description": "the item to ship"},
+				{"name": "merge-strategy", "type": "enum", "required": false, "default": "squash"},
+			},
+		},
+		Body: "## Steps\n\n1. Run the tests\n2. Open a PR\n",
+		Provenance: Provenance{
+			Workspace:     "demo",
+			ExportedAt:    "2026-06-22T00:00:00Z",
+			Author:        "xarmian",
+			FormatVersion: FormatVersion,
+		},
+	}
+}
+
+func sampleConvention() Artifact {
+	return Artifact{
+		Kind:          KindConvention,
+		FormatVersion: FormatVersion,
+		Title:         "Run the test suite before pushing",
+		Fields: map[string]any{
+			"status":   "active",
+			"trigger":  "on-commit",
+			"scope":    "repo",
+			"priority": "high",
+			"role":     "engineer",
+		},
+		Body: "Always run `make test` before pushing to main.\n",
+		Provenance: Provenance{
+			Workspace:     "demo",
+			ExportedAt:    "2026-06-22T00:00:00Z",
+			Author:        "xarmian",
+			FormatVersion: FormatVersion,
+		},
+	}
+}
+
+func TestEncodeGolden(t *testing.T) {
+	cases := []struct {
+		name     string
+		artifact Artifact
+		golden   string
+	}{
+		{"playbook", samplePlaybook(), "playbook.golden.md"},
+		{"convention", sampleConvention(), "convention.golden.md"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := Encode(tc.artifact)
+			if err != nil {
+				t.Fatalf("Encode: %v", err)
+			}
+			path := filepath.Join("testdata", tc.golden)
+			if *update {
+				if err := os.WriteFile(path, got, 0o644); err != nil {
+					t.Fatalf("write golden: %v", err)
+				}
+				return
+			}
+			want, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("read golden (run -update to create): %v", err)
+			}
+			if !bytes.Equal(got, want) {
+				t.Errorf("Encode output mismatch with %s\n--- got ---\n%s\n--- want ---\n%s", tc.golden, got, want)
+			}
+		})
+	}
+}
+
+func TestEncodeDeterministic(t *testing.T) {
+	for _, a := range []Artifact{samplePlaybook(), sampleConvention()} {
+		first, err := Encode(a)
+		if err != nil {
+			t.Fatalf("Encode 1: %v", err)
+		}
+		second, err := Encode(a)
+		if err != nil {
+			t.Fatalf("Encode 2: %v", err)
+		}
+		if !bytes.Equal(first, second) {
+			t.Errorf("Encode not deterministic for %s:\n%s\nvs\n%s", a.Kind, first, second)
+		}
+	}
+}
+
+func TestEncodeUnknownKind(t *testing.T) {
+	_, err := Encode(Artifact{Kind: "nonsense"})
+	if err == nil {
+		t.Fatal("expected error for unknown kind")
+	}
+}
+
+func TestEncodeDefaultsVersion(t *testing.T) {
+	a := samplePlaybook()
+	a.FormatVersion = 0
+	a.Provenance.FormatVersion = 0
+	out, err := Encode(a)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	if !bytes.Contains(out, []byte("format_version: 1")) {
+		t.Errorf("expected default format_version: 1 in output:\n%s", out)
+	}
+}

--- a/internal/artifact/frontmatter.go
+++ b/internal/artifact/frontmatter.go
@@ -1,0 +1,30 @@
+package artifact
+
+// frontmatter is the typed YAML frontmatter representation. Using a struct
+// (not a map) guarantees stable, deterministic key order on encode.
+//
+// Key order on the wire MUST be:
+//
+//	pad_artifact, format_version, title, status, trigger, scope,
+//	invocation_slug, arguments, priority, role, provenance
+//
+// The kind-specific field keys carry omitempty so a convention artifact does
+// not emit empty playbook keys and vice-versa.
+type frontmatter struct {
+	PadArtifact   Kind   `yaml:"pad_artifact"`
+	FormatVersion int    `yaml:"format_version"`
+	Title         string `yaml:"title"`
+
+	// Playbook keys.
+	Status         string           `yaml:"status,omitempty"`
+	Trigger        string           `yaml:"trigger,omitempty"`
+	Scope          string           `yaml:"scope,omitempty"`
+	InvocationSlug string           `yaml:"invocation_slug,omitempty"`
+	Arguments      []map[string]any `yaml:"arguments,omitempty"`
+
+	// Convention-only keys (status/trigger/scope are shared above).
+	Priority string `yaml:"priority,omitempty"`
+	Role     string `yaml:"role,omitempty"`
+
+	Provenance Provenance `yaml:"provenance"`
+}

--- a/internal/artifact/testdata/convention.golden.md
+++ b/internal/artifact/testdata/convention.golden.md
@@ -1,0 +1,17 @@
+---
+pad_artifact: convention
+format_version: 1
+title: Run the test suite before pushing
+status: active
+trigger: on-commit
+scope: repo
+priority: high
+role: engineer
+provenance:
+  workspace: demo
+  exported_at: "2026-06-22T00:00:00Z"
+  author: xarmian
+  format_version: 1
+---
+
+Always run `make test` before pushing to main.

--- a/internal/artifact/testdata/playbook.golden.md
+++ b/internal/artifact/testdata/playbook.golden.md
@@ -1,0 +1,28 @@
+---
+pad_artifact: playbook
+format_version: 1
+title: Ship a change
+status: active
+trigger: on-intent
+scope: workspace
+invocation_slug: ship
+arguments:
+  - description: the item to ship
+    name: ref
+    required: true
+    type: ref
+  - default: squash
+    name: merge-strategy
+    required: false
+    type: enum
+provenance:
+  workspace: demo
+  exported_at: "2026-06-22T00:00:00Z"
+  author: xarmian
+  format_version: 1
+---
+
+## Steps
+
+1. Run the tests
+2. Open a PR


### PR DESCRIPTION
Phase 1 of **PLAN-1867** — the pure-Go `internal/artifact` package that encodes/decodes a single playbook or convention item to a portable **Markdown + YAML-frontmatter** artifact. Foundation for the export/import primitive (IDEA-1845) and the marketplace follow-on (IDEA-1864).

## What's in it
- `Encode(Artifact) → []byte` / `Decode([]byte) → Artifact` with a deterministic, struct-driven frontmatter key order and a `provenance` block.
- Field-key tables per kind (playbook: status/trigger/scope/invocation_slug/arguments; convention: status/trigger/scope/priority/role); `FieldKeysForKind` exported for the Phase-2 server layer.
- Typed sentinel errors (`ErrMalformed`, `ErrUnknownKind`, `ErrUnsupportedVersion`).
- CRLF-tolerant decode (normalizes to LF up front).
- Round-trip + golden-fixture + determinism + error-case + CRLF tests.

## Out of scope (Phase 2, HTTP boundary)
Server-side validation, forgiving select/slug coercion, slug-collision handling, and YAML byte/depth/alias input limits.

## Gates
`go build ./...`, `go vet`, `go test ./...`, and `golangci-lint run ./internal/artifact/...` all clean. Pure Go — no store/dialect/migration/collab impact. Codex review: CLEAN (after a CRLF P2 fix).

Closes TASK-1868, TASK-1869, TASK-1870.

https://claude.ai/code/session_01KmxkPxLksjf1pmrZDpsnTJ