### PR TITLE
feat(artifact): server export + import endpoints for playbooks & conventions

### DIFF
--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -723,6 +723,18 @@ func serveCmd() *cobra.Command {
 				}
 			}
 
+			// Single-artifact import cap. Default is 1 MiB inside
+			// internal/server; PAD_IMPORT_ARTIFACT_MAX_BYTES lets
+			// operators raise the ceiling without recompiling.
+			if v := os.Getenv("PAD_IMPORT_ARTIFACT_MAX_BYTES"); v != "" {
+				if n, perr := strconv.ParseInt(v, 10, 64); perr == nil && n > 0 {
+					srv.SetImportArtifactMaxBytes(n)
+					slog.Info("Import artifact cap overridden", "max_bytes", n)
+				} else {
+					slog.Warn("PAD_IMPORT_ARTIFACT_MAX_BYTES ignored — not a positive integer", "value", v)
+				}
+			}
+
 			// Orphan GC (TASK-886). Periodic sweep that reclaims
 			// attachments tombstoned past the grace period, plus
 			// uploads that were never associated with an item.

--- a/internal/server/artifact_import.go
+++ b/internal/server/artifact_import.go
@@ -1,0 +1,196 @@
+package server
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"go.yaml.in/yaml/v4"
+
+	"github.com/PerpetualSoftware/pad/internal/artifact"
+)
+
+// defaultImportArtifactMaxBytes caps a single artifact import body. A
+// playbook/convention artifact is a small Markdown file (frontmatter + a
+// few KB of body); 1 MiB is several orders of magnitude above any real
+// artifact while still cheap to hold in memory. Overridable via
+// Server.SetImportArtifactMaxBytes (PAD_IMPORT_ARTIFACT_MAX_BYTES).
+const defaultImportArtifactMaxBytes int64 = 1 << 20 // 1 MiB
+
+// YAML-bomb guard limits. The frontmatter region is parsed into a yaml.Node
+// tree and walked BEFORE any struct decode so a malicious artifact can't
+// blow up memory/CPU via billion-laughs (alias expansion), deeply-nested
+// collections, or a huge flat node count.
+const (
+	// maxFrontmatterDepth bounds nesting depth. A real artifact's
+	// frontmatter is shallow (top-level map + the arguments sequence of
+	// small maps → depth ~4). 32 is generous headroom that still stops
+	// pathological deep-nesting documents.
+	maxFrontmatterDepth = 32
+
+	// maxFrontmatterNodes bounds the total node count in the frontmatter
+	// tree. Defeats a flat document with an enormous number of keys/items
+	// designed to exhaust memory. A real artifact has well under 100 nodes.
+	maxFrontmatterNodes = 10000
+
+	// maxFrontmatterAliases bounds YAML alias nodes. The artifact format
+	// never legitimately uses anchors/aliases, so any alias is a billion-
+	// laughs signal — reject outright (cap of 0).
+	maxFrontmatterAliases = 0
+)
+
+// ErrArtifactTooLarge is returned when the request body exceeds the
+// configured artifact size cap.
+var ErrArtifactTooLarge = errors.New("artifact import: body exceeds size limit")
+
+// ErrArtifactUnsafeYAML is returned when the frontmatter region trips one of
+// the YAML-bomb guard limits (node count, nesting depth, or anchors/aliases).
+var ErrArtifactUnsafeYAML = errors.New("artifact import: frontmatter rejected by safety limits")
+
+// parseArtifactRequest is the guarded HTTP-boundary parse used by the import
+// handler. It applies three checks IN ORDER:
+//
+//  1. Byte cap on the raw body (http.MaxBytesReader), so an oversized body is
+//     rejected before full materialization.
+//  2. YAML-bomb guard: the frontmatter region is parsed into a yaml.Node tree
+//     and walked, enforcing maxFrontmatterNodes / maxFrontmatterDepth /
+//     maxFrontmatterAliases. This runs BEFORE the struct decode so an alias-
+//     storm or deep-nesting document never reaches the expanding unmarshaler.
+//  3. artifact.Decode, which produces the typed Artifact.
+//
+// Returns the decoded Artifact or a typed error: ErrArtifactTooLarge,
+// ErrArtifactUnsafeYAML, or an artifact.* sentinel (ErrMalformed /
+// ErrUnknownKind / ErrUnsupportedVersion) wrapped for context. The import
+// handler maps these to HTTP statuses.
+func parseArtifactRequest(w http.ResponseWriter, r *http.Request, maxBytes int64) (artifact.Artifact, error) {
+	if maxBytes <= 0 {
+		maxBytes = defaultImportArtifactMaxBytes
+	}
+
+	// (1) Byte cap. MaxBytesReader makes ReadAll return an error once the
+	// cap is exceeded, so we never materialize an oversized body.
+	limited := http.MaxBytesReader(w, r.Body, maxBytes)
+	data, err := io.ReadAll(limited)
+	if err != nil {
+		// http.MaxBytesReader surfaces a *http.MaxBytesError when the cap
+		// is hit; any read error here means the body is too big or broken.
+		var mbErr *http.MaxBytesError
+		if errors.As(err, &mbErr) {
+			return artifact.Artifact{}, ErrArtifactTooLarge
+		}
+		return artifact.Artifact{}, fmt.Errorf("artifact import: read body: %w", err)
+	}
+
+	// (2) YAML-bomb guard on the frontmatter region only.
+	if err := guardArtifactFrontmatter(data); err != nil {
+		return artifact.Artifact{}, err
+	}
+
+	// (3) Typed decode.
+	art, err := artifact.Decode(data)
+	if err != nil {
+		return artifact.Artifact{}, err
+	}
+	return art, nil
+}
+
+// guardArtifactFrontmatter extracts the leading "---\n...\n---" frontmatter
+// region from the artifact bytes and walks it as a yaml.Node tree to enforce
+// the YAML-bomb limits. It deliberately re-parses just the frontmatter (not
+// the whole document) so the guard runs before artifact.Decode's struct
+// unmarshal — the unmarshal is where alias expansion would otherwise blow up.
+//
+// A missing/malformed fence is NOT rejected here; that's left to
+// artifact.Decode so the caller gets the canonical ErrMalformed. The guard
+// only fires on a present-but-dangerous frontmatter.
+func guardArtifactFrontmatter(data []byte) error {
+	fm, ok := extractFrontmatterRegion(string(data))
+	if !ok {
+		// No parseable fence — defer to artifact.Decode for the canonical
+		// malformed-frontmatter error.
+		return nil
+	}
+
+	var root yaml.Node
+	if err := yaml.Unmarshal([]byte(fm), &root); err != nil {
+		// Unparseable YAML — defer to artifact.Decode, which wraps it as
+		// ErrMalformed. The node-tree unmarshal does not expand aliases
+		// (that happens at the typed-decode step), so this is safe.
+		return nil
+	}
+
+	var nodes, aliases int
+	if err := walkArtifactNode(&root, 0, &nodes, &aliases); err != nil {
+		return err
+	}
+	return nil
+}
+
+// walkArtifactNode recursively walks a yaml.Node tree enforcing the depth,
+// node-count, and alias limits. It increments *nodes per visited node and
+// *aliases per AliasNode, and returns ErrArtifactUnsafeYAML on the first
+// breach.
+func walkArtifactNode(n *yaml.Node, depth int, nodes, aliases *int) error {
+	if n == nil {
+		return nil
+	}
+	if depth > maxFrontmatterDepth {
+		return fmt.Errorf("%w: nesting depth exceeds %d", ErrArtifactUnsafeYAML, maxFrontmatterDepth)
+	}
+
+	*nodes++
+	if *nodes > maxFrontmatterNodes {
+		return fmt.Errorf("%w: node count exceeds %d", ErrArtifactUnsafeYAML, maxFrontmatterNodes)
+	}
+
+	// Reject anchors and aliases. The artifact format never uses them, so
+	// their presence is a billion-laughs signal. Counting both an anchored
+	// node's definition and any alias referencing it keeps the cap tight.
+	if n.Anchor != "" || n.Kind == yaml.AliasNode {
+		*aliases++
+		if *aliases > maxFrontmatterAliases {
+			return fmt.Errorf("%w: anchors/aliases are not allowed", ErrArtifactUnsafeYAML)
+		}
+	}
+
+	for _, child := range n.Content {
+		if err := walkArtifactNode(child, depth+1, nodes, aliases); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// extractFrontmatterRegion returns the YAML text between the leading "---\n"
+// fence and the next line equal to "---". Returns ("", false) when the
+// opening or closing fence is absent. CRLF is normalized to LF first so the
+// guard sees the same canonical text artifact.Decode does.
+func extractFrontmatterRegion(s string) (string, bool) {
+	s = strings.ReplaceAll(s, "\r\n", "\n")
+	const fence = "---"
+	if !strings.HasPrefix(s, fence+"\n") {
+		return "", false
+	}
+	rest := s[len(fence)+1:]
+
+	offset := 0
+	for {
+		line := rest[offset:]
+		nl := strings.IndexByte(line, '\n')
+		var cur string
+		if nl >= 0 {
+			cur = line[:nl]
+		} else {
+			cur = line
+		}
+		if strings.TrimRight(cur, " \t\r") == fence {
+			return rest[:offset], true
+		}
+		if nl < 0 {
+			return "", false
+		}
+		offset += nl + 1
+	}
+}

--- a/internal/server/handlers_artifact_export.go
+++ b/internal/server/handlers_artifact_export.go
@@ -1,0 +1,124 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/PerpetualSoftware/pad/internal/artifact"
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// kindForCollectionSlug maps a collection slug to the artifact Kind it
+// exports as. Only the playbooks and conventions collections carry the
+// structured frontmatter the artifact format understands; everything else
+// is not exportable as an artifact. Returns (kind, true) for a supported
+// slug, ("", false) otherwise.
+func kindForCollectionSlug(slug string) (artifact.Kind, bool) {
+	switch slug {
+	case "playbooks":
+		return artifact.KindPlaybook, true
+	case "conventions":
+		return artifact.KindConvention, true
+	default:
+		return "", false
+	}
+}
+
+// handleExportItemArtifact serializes a single playbook or convention item to
+// the portable artifact form (Markdown body + YAML frontmatter) and returns it
+// as a downloadable attachment.
+//
+// Auth: per-item visibility only (requireItemVisible) — a viewer who can see
+// the item may export it. This is deliberately NOT the workspace-export owner
+// gate; an artifact is a single item the requester already has read access to.
+func (s *Server) handleExportItemArtifact(w http.ResponseWriter, r *http.Request) {
+	ws, ok := s.getWorkspace(w, r)
+	if !ok {
+		return
+	}
+
+	itemSlug := chi.URLParam(r, "itemSlug")
+	item, err := s.store.ResolveItem(ws.ID, itemSlug)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	if item == nil {
+		writeError(w, http.StatusNotFound, "not_found", "Item not found")
+		return
+	}
+	if !s.requireItemVisible(w, r, ws.ID, item) {
+		return
+	}
+
+	// Resolve the item's collection so we can map it to an artifact kind.
+	coll, err := s.store.GetCollection(item.CollectionID)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	if coll == nil {
+		writeInternalError(w, fmt.Errorf("export: item %s has no collection", item.Slug))
+		return
+	}
+	kind, ok := kindForCollectionSlug(coll.Slug)
+	if !ok {
+		writeError(w, http.StatusBadRequest, "unsupported_collection",
+			"Only playbooks and conventions can be exported as artifacts")
+		return
+	}
+
+	// Parse the item's structured fields into a map for the artifact.
+	fields := map[string]any{}
+	if item.Fields != "" {
+		if err := json.Unmarshal([]byte(item.Fields), &fields); err != nil {
+			writeInternalError(w, fmt.Errorf("export: parse item fields: %w", err))
+			return
+		}
+	}
+
+	author := ""
+	if u := currentUser(r); u != nil {
+		if u.Name != "" {
+			author = u.Name
+		} else {
+			author = u.Email
+		}
+	}
+
+	art := artifact.Artifact{
+		Kind:          kind,
+		FormatVersion: artifact.FormatVersion,
+		Title:         item.Title,
+		Fields:        fields,
+		Body:          item.Content,
+		Provenance: artifact.Provenance{
+			Workspace:     ws.Slug,
+			ExportedAt:    time.Now().UTC().Format(time.RFC3339),
+			Author:        author,
+			FormatVersion: artifact.FormatVersion,
+		},
+	}
+
+	out, err := artifact.Encode(art)
+	if err != nil {
+		writeInternalError(w, fmt.Errorf("export: encode artifact: %w", err))
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/markdown; charset=utf-8")
+	w.Header().Set("Content-Disposition",
+		fmt.Sprintf("attachment; filename=%q", artifactExportFilename(item)))
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(out)
+}
+
+// artifactExportFilename builds the download filename for an exported item:
+// "<slug>.pad.md".
+func artifactExportFilename(item *models.Item) string {
+	return item.Slug + ".pad.md"
+}

--- a/internal/server/handlers_artifact_import.go
+++ b/internal/server/handlers_artifact_import.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/PerpetualSoftware/pad/internal/artifact"
 	"github.com/PerpetualSoftware/pad/internal/models"
@@ -51,6 +52,15 @@ func (s *Server) handleImportArtifact(w http.ResponseWriter, r *http.Request) {
 	art, err := parseArtifactRequest(w, r, s.importArtifactMaxBytes)
 	if err != nil {
 		writeArtifactParseError(w, err)
+		return
+	}
+
+	// Require a title, matching handleCreateItem's "Title is required" gate.
+	// artifact.Decode tolerates a missing title (producing an "untitled"
+	// item), so we enforce it here so an import can't diverge from the normal
+	// create path's validation.
+	if strings.TrimSpace(art.Title) == "" {
+		writeError(w, http.StatusBadRequest, "bad_request", "Title is required")
 		return
 	}
 
@@ -123,6 +133,13 @@ func (s *Server) handleImportArtifact(w http.ResponseWriter, r *http.Request) {
 	// matching every other create path.
 	if u := currentUser(r); u != nil {
 		input.CreatedBy = u.ID
+	}
+
+	// Enforce the workspace item-count limit (workspace-scoped), identical to
+	// handleCreateItem. Writes the 403 plan_limit_exceeded response itself when
+	// the cap is hit; no-op in self-hosted mode.
+	if !s.enforcePlanLimit(w, workspaceID, "items_per_workspace") {
+		return
 	}
 
 	item, cerr := s.createItemChecked(r, workspaceID, coll, schema, input, fields, "")

--- a/internal/server/handlers_artifact_import.go
+++ b/internal/server/handlers_artifact_import.go
@@ -1,0 +1,286 @@
+package server
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/PerpetualSoftware/pad/internal/artifact"
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// artifactImportResponse is the JSON body returned by a successful import.
+type artifactImportResponse struct {
+	Ref      string   `json:"ref"`
+	Slug     string   `json:"slug"`
+	Warnings []string `json:"warnings"`
+}
+
+// collectionSlugForKind maps an artifact Kind to the destination collection
+// slug in a workspace.
+func collectionSlugForKind(k artifact.Kind) (string, bool) {
+	switch k {
+	case artifact.KindPlaybook:
+		return "playbooks", true
+	case artifact.KindConvention:
+		return "conventions", true
+	default:
+		return "", false
+	}
+}
+
+// handleImportArtifact imports a single playbook/convention artifact (Markdown
+// body + YAML frontmatter) into the workspace's playbooks/conventions
+// collection.
+//
+// Auth: editor+ (item-create permission) plus destination-collection
+// visibility — the same gate handleCreateItem applies to a write.
+//
+// Pipeline: guarded safe-parse (parseArtifactRequest) → map Kind to the
+// destination collection → forgiving preprocess (blank foreign select values,
+// force status=draft, de-collide invocation_slug) → createItemChecked.
+func (s *Server) handleImportArtifact(w http.ResponseWriter, r *http.Request) {
+	workspaceID, ok := s.getWorkspaceID(w, r)
+	if !ok {
+		return
+	}
+
+	// Safe-parse first so a malformed/oversized/bomb body is rejected before
+	// we touch the store.
+	art, err := parseArtifactRequest(w, r, s.importArtifactMaxBytes)
+	if err != nil {
+		writeArtifactParseError(w, err)
+		return
+	}
+
+	collSlug, ok := collectionSlugForKind(art.Kind)
+	if !ok {
+		// Decode already validates the kind, so this is defensive.
+		writeError(w, http.StatusBadRequest, "unknown_kind", "Unknown artifact kind")
+		return
+	}
+
+	coll, err := s.store.GetCollectionBySlug(workspaceID, collSlug)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	if coll == nil {
+		writeError(w, http.StatusNotFound, "not_found",
+			fmt.Sprintf("This workspace has no %q collection to import into", collSlug))
+		return
+	}
+
+	// Edit permission (grant-aware for guests) + collection visibility,
+	// mirroring handleCreateItem's write gate.
+	if !s.requireEditPermission(w, r, workspaceID, "", coll.ID) {
+		return
+	}
+	visibleIDs, visErr := s.visibleCollectionIDs(r, workspaceID)
+	if visErr != nil {
+		writeInternalError(w, visErr)
+		return
+	}
+	if !isCollectionVisible(coll.ID, visibleIDs) {
+		writeError(w, http.StatusNotFound, "not_found", "Collection not found")
+		return
+	}
+
+	var schema models.CollectionSchema
+	if err := json.Unmarshal([]byte(coll.Schema), &schema); err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to parse collection schema")
+		return
+	}
+
+	// Copy the artifact fields so the preprocess never mutates the decoded
+	// value (keeps the parse layer's output immutable from the handler's POV).
+	fields := make(map[string]any, len(art.Fields))
+	for k, v := range art.Fields {
+		fields[k] = v
+	}
+
+	warnings := s.preprocessArtifactFields(workspaceID, coll, art.Kind, schema, fields)
+
+	fieldsJSON, err := json.Marshal(fields)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to marshal fields")
+		return
+	}
+
+	body := art.Body
+	if footer := artifactProvenanceFooter(art.Provenance); footer != "" {
+		body = body + footer
+	}
+
+	input := models.ItemCreate{
+		Title:   art.Title,
+		Content: body,
+		Fields:  string(fieldsJSON),
+	}
+	// Attribution: a normal agent/api create. Source is left blank here so
+	// createItemChecked stamps it from the request auth context (cli/web),
+	// matching every other create path.
+	if u := currentUser(r); u != nil {
+		input.CreatedBy = u.ID
+	}
+
+	item, cerr := s.createItemChecked(r, workspaceID, coll, schema, input, fields, "")
+	if cerr != nil {
+		writeError(w, cerr.status, cerr.code, cerr.message)
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, artifactImportResponse{
+		Ref:      item.Ref,
+		Slug:     item.Slug,
+		Warnings: warnings,
+	})
+}
+
+// preprocessArtifactFields applies the forgiving import coercions, mutating
+// fields in place and returning the accumulated warnings:
+//
+//   - Any select field whose imported value is not among the destination
+//     schema's options is blanked (so the create's strict ValidateFields
+//     doesn't 400 the whole import on a foreign vocabulary value).
+//   - status is forced to "draft" regardless of the artifact's value.
+//   - For playbooks, a non-empty invocation_slug that's already taken in the
+//     destination collection is suffixed (-2, -3, …) until free.
+func (s *Server) preprocessArtifactFields(workspaceID string, coll *models.Collection, kind artifact.Kind, schema models.CollectionSchema, fields map[string]any) []string {
+	var warnings []string
+
+	// Blank foreign select values (trigger/scope/priority and any other
+	// select field the artifact carried).
+	for _, def := range schema.Fields {
+		if def.Type != "select" {
+			continue
+		}
+		raw, ok := fields[def.Key]
+		if !ok || raw == nil {
+			continue
+		}
+		val, ok := raw.(string)
+		if !ok || val == "" {
+			continue
+		}
+		if !optionAllowed(def.Options, val) {
+			fields[def.Key] = ""
+			warnings = append(warnings,
+				fmt.Sprintf("field %q value %q is not a valid option in this workspace; cleared on import", def.Key, val))
+		}
+	}
+
+	// Force status=draft. The artifact may have been exported as active; an
+	// import should never silently activate a playbook/convention.
+	if cur, _ := fields["status"].(string); cur != "draft" {
+		fields["status"] = "draft"
+		if cur != "" {
+			warnings = append(warnings,
+				fmt.Sprintf("status %q reset to \"draft\" on import", cur))
+		}
+	}
+
+	// De-collide invocation_slug for playbooks.
+	if kind == artifact.KindPlaybook {
+		if slug, _ := fields["invocation_slug"].(string); slug != "" {
+			free, changed := s.freeInvocationSlug(workspaceID, coll.ID, slug)
+			if changed {
+				fields["invocation_slug"] = free
+				warnings = append(warnings,
+					fmt.Sprintf("invocation_slug %q was already in use; imported as %q", slug, free))
+			}
+		}
+	}
+
+	return warnings
+}
+
+// freeInvocationSlug returns an invocation_slug that's free in the destination
+// collection. If the requested slug is already taken it appends -2, -3, …
+// until an unused value is found. Returns (slug, changed).
+func (s *Server) freeInvocationSlug(workspaceID, collectionID, requested string) (string, bool) {
+	candidate := requested
+	for n := 2; ; n++ {
+		taken, err := s.invocationSlugTaken(workspaceID, collectionID, candidate)
+		if err != nil {
+			// On a query error, fall back to the requested slug and let the
+			// create-time uniqueness precheck/constraint surface a conflict.
+			return requested, candidate != requested
+		}
+		if !taken {
+			return candidate, candidate != requested
+		}
+		candidate = fmt.Sprintf("%s-%d", requested, n)
+	}
+}
+
+// invocationSlugTaken reports whether an item with the given invocation_slug
+// already exists (non-archived) in the destination collection.
+func (s *Server) invocationSlugTaken(workspaceID, collectionID, slug string) (bool, error) {
+	existing, err := s.store.ListItems(workspaceID, models.ItemListParams{
+		CollectionIDs: []string{collectionID},
+		Fields:        map[string]string{"invocation_slug": slug},
+		Limit:         1,
+	})
+	if err != nil {
+		return false, err
+	}
+	return len(existing) > 0, nil
+}
+
+// optionAllowed reports whether val is among options. An empty options list
+// means the field is unconstrained (any value allowed).
+func optionAllowed(options []string, val string) bool {
+	if len(options) == 0 {
+		return true
+	}
+	for _, o := range options {
+		if o == val {
+			return true
+		}
+	}
+	return false
+}
+
+// artifactProvenanceFooter renders an optional Markdown footer recording where
+// an imported artifact came from. Returns "" when there's nothing useful to
+// record.
+func artifactProvenanceFooter(p artifact.Provenance) string {
+	if p.Workspace == "" && p.Author == "" && p.ExportedAt == "" {
+		return ""
+	}
+	footer := "\n\n---\n\n_Imported artifact"
+	if p.Workspace != "" {
+		footer += fmt.Sprintf(" from workspace `%s`", p.Workspace)
+	}
+	if p.Author != "" {
+		footer += fmt.Sprintf(", exported by %s", p.Author)
+	}
+	if p.ExportedAt != "" {
+		footer += fmt.Sprintf(" at %s", p.ExportedAt)
+	}
+	footer += "._\n"
+	return footer
+}
+
+// writeArtifactParseError maps the typed errors from parseArtifactRequest to
+// HTTP responses.
+func writeArtifactParseError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, ErrArtifactTooLarge):
+		writeError(w, http.StatusRequestEntityTooLarge, "too_large",
+			"Artifact body exceeds the size limit")
+	case errors.Is(err, ErrArtifactUnsafeYAML):
+		writeError(w, http.StatusBadRequest, "unsafe_yaml",
+			"Artifact frontmatter was rejected by the import safety limits")
+	case errors.Is(err, artifact.ErrMalformed):
+		writeError(w, http.StatusBadRequest, "malformed_artifact", err.Error())
+	case errors.Is(err, artifact.ErrUnknownKind):
+		writeError(w, http.StatusBadRequest, "unknown_kind", err.Error())
+	case errors.Is(err, artifact.ErrUnsupportedVersion):
+		writeError(w, http.StatusBadRequest, "unsupported_version", err.Error())
+	default:
+		writeError(w, http.StatusBadRequest, "bad_request", "Could not parse artifact: "+err.Error())
+	}
+}

--- a/internal/server/handlers_artifact_test.go
+++ b/internal/server/handlers_artifact_test.go
@@ -1,0 +1,443 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/artifact"
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// doArtifactRequest posts a raw (non-JSON) body to an artifact-import endpoint.
+func doArtifactRequest(srv *Server, method, path string, body []byte) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(method, path, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "text/markdown")
+	req.RemoteAddr = "192.0.2.1:1234"
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	return rr
+}
+
+// ---- Export ----
+
+func TestExportPlaybookArtifactRoundTrip(t *testing.T) {
+	srv := testServer(t)
+	ws := createWSForTest(t, srv)
+
+	pb := createItem(t, srv, ws, "playbooks", map[string]interface{}{
+		"title":   "Ship It",
+		"content": "## Steps\n\n1. Build\n2. Ship\n",
+		"fields":  `{"status":"active","trigger":"on-release","scope":"all","invocation_slug":"ship-it"}`,
+	})
+
+	rr := doRequest(srv, "GET", "/api/v1/workspaces/"+ws+"/items/"+pb.Slug+"/export", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("export: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if ct := rr.Header().Get("Content-Type"); ct != "text/markdown; charset=utf-8" {
+		t.Errorf("unexpected Content-Type %q", ct)
+	}
+	if cd := rr.Header().Get("Content-Disposition"); !strings.Contains(cd, pb.Slug+".pad.md") {
+		t.Errorf("unexpected Content-Disposition %q", cd)
+	}
+
+	art, err := artifact.Decode(rr.Body.Bytes())
+	if err != nil {
+		t.Fatalf("decode exported artifact: %v", err)
+	}
+	if art.Kind != artifact.KindPlaybook {
+		t.Errorf("expected kind playbook, got %q", art.Kind)
+	}
+	if art.Title != "Ship It" {
+		t.Errorf("expected title 'Ship It', got %q", art.Title)
+	}
+	if art.Fields["status"] != "active" {
+		t.Errorf("expected status active, got %v", art.Fields["status"])
+	}
+	if art.Fields["invocation_slug"] != "ship-it" {
+		t.Errorf("expected invocation_slug ship-it, got %v", art.Fields["invocation_slug"])
+	}
+	if art.Provenance.Workspace != ws {
+		t.Errorf("expected provenance workspace %q, got %q", ws, art.Provenance.Workspace)
+	}
+	if art.Provenance.ExportedAt == "" {
+		t.Error("expected non-empty exported_at")
+	}
+}
+
+func TestExportConventionArtifactRoundTrip(t *testing.T) {
+	srv := testServer(t)
+	ws := createWSForTest(t, srv)
+
+	cv := createItem(t, srv, ws, "conventions", map[string]interface{}{
+		"title":   "Always Test",
+		"content": "Run the test suite before committing.\n",
+		"fields":  `{"status":"active","trigger":"on-commit","scope":"all","priority":"must"}`,
+	})
+
+	rr := doRequest(srv, "GET", "/api/v1/workspaces/"+ws+"/items/"+cv.Slug+"/export", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("export: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	art, err := artifact.Decode(rr.Body.Bytes())
+	if err != nil {
+		t.Fatalf("decode exported artifact: %v", err)
+	}
+	if art.Kind != artifact.KindConvention {
+		t.Errorf("expected kind convention, got %q", art.Kind)
+	}
+	if art.Title != "Always Test" {
+		t.Errorf("expected title 'Always Test', got %q", art.Title)
+	}
+	if art.Fields["priority"] != "must" {
+		t.Errorf("expected priority must, got %v", art.Fields["priority"])
+	}
+}
+
+func TestExportNonArtifactCollectionRejected(t *testing.T) {
+	srv := testServer(t)
+	ws := createWSForTest(t, srv)
+
+	task := createItem(t, srv, ws, "tasks", map[string]interface{}{
+		"title":  "A task",
+		"fields": `{"status":"open"}`,
+	})
+
+	rr := doRequest(srv, "GET", "/api/v1/workspaces/"+ws+"/items/"+task.Slug+"/export", nil)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("export task: expected 400, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestExportInvisibleItemNotAuthorized(t *testing.T) {
+	srv := testServer(t)
+	// Activate auth so per-item visibility is enforced.
+	bootstrapFirstUser(t, srv, "admin@test.com", "Admin")
+
+	// A guest (non-member) with an item grant on an unrelated task can see
+	// only that task — not a playbook in the system playbooks collection.
+	// Guests, unlike restricted members, do NOT get the system-collection
+	// access union, so the playbook is genuinely invisible to them.
+	ws, err := srv.store.CreateWorkspace(models.WorkspaceCreate{Name: "GuestExport"})
+	if err != nil {
+		t.Fatalf("CreateWorkspace: %v", err)
+	}
+	if err := srv.store.SeedCollectionsFromTemplate(ws.ID, ""); err != nil {
+		t.Fatalf("seed collections: %v", err)
+	}
+	tasks, err := srv.store.GetCollectionBySlug(ws.ID, "tasks")
+	if err != nil || tasks == nil {
+		t.Fatalf("get tasks collection: %v", err)
+	}
+	grantedTask, err := srv.store.CreateItem(ws.ID, tasks.ID, models.ItemCreate{
+		Title: "Granted Task", Fields: `{}`,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem task: %v", err)
+	}
+	playbooks, err := srv.store.GetCollectionBySlug(ws.ID, "playbooks")
+	if err != nil || playbooks == nil {
+		t.Fatalf("get playbooks collection: %v", err)
+	}
+	pb, err := srv.store.CreateItem(ws.ID, playbooks.ID, models.ItemCreate{
+		Title: "Secret", Fields: `{"status":"draft"}`,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem playbook: %v", err)
+	}
+
+	guest, err := srv.store.CreateUser(models.UserCreate{
+		Email:    "guest@test.com",
+		Name:     "Guest",
+		Password: "correct-horse-battery-staple",
+		Role:     "member",
+	})
+	if err != nil {
+		t.Fatalf("CreateUser guest: %v", err)
+	}
+	if _, err := srv.store.CreateItemGrant(ws.ID, grantedTask.ID, guest.ID, "edit", guest.ID); err != nil {
+		t.Fatalf("CreateItemGrant: %v", err)
+	}
+	token, err := srv.store.CreateSession(guest.ID, "go-test", "127.0.0.1", "go-test", 24*time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	// Target playbook → 404 (guest can't see it).
+	req := httptest.NewRequest("GET",
+		"/api/v1/workspaces/"+ws.Slug+"/items/"+pb.Slug+"/export", nil)
+	req.AddCookie(&http.Cookie{Name: "pad_session", Value: token})
+	req.RemoteAddr = "192.0.2.1:1234"
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("export invisible item: expected 404, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+// ---- Safety layer ----
+
+func TestImportArtifactOversizedRejected(t *testing.T) {
+	srv := testServer(t)
+	ws := createWSForTest(t, srv)
+	srv.SetImportArtifactMaxBytes(256) // tiny cap for the test
+
+	big := "---\npad_artifact: convention\nformat_version: 1\ntitle: " +
+		strings.Repeat("A", 1024) + "\n---\n\nbody\n"
+
+	rr := doArtifactRequest(srv, "POST", "/api/v1/workspaces/"+ws+"/import-artifact", []byte(big))
+	if rr.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("oversized import: expected 413, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestImportArtifactBillionLaughsRejected(t *testing.T) {
+	srv := testServer(t)
+	ws := createWSForTest(t, srv)
+
+	// Classic alias-storm. Anchors/aliases are disallowed by the guard, so
+	// this is rejected before artifact.Decode ever expands it.
+	bomb := `---
+pad_artifact: convention
+format_version: 1
+title: bomb
+a: &a ["x","x","x","x","x","x","x","x","x"]
+b: &b [*a,*a,*a,*a,*a,*a,*a,*a,*a]
+c: &c [*b,*b,*b,*b,*b,*b,*b,*b,*b]
+---
+
+body
+`
+	rr := doArtifactRequest(srv, "POST", "/api/v1/workspaces/"+ws+"/import-artifact", []byte(bomb))
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("billion-laughs: expected 400, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "unsafe_yaml") {
+		t.Errorf("expected unsafe_yaml error code, got: %s", rr.Body.String())
+	}
+}
+
+func TestImportArtifactDeepNestingRejected(t *testing.T) {
+	srv := testServer(t)
+	ws := createWSForTest(t, srv)
+
+	// Build a deeply-nested flow sequence that exceeds maxFrontmatterDepth.
+	var b strings.Builder
+	b.WriteString("---\npad_artifact: convention\nformat_version: 1\ntitle: deep\ndeep: ")
+	depth := maxFrontmatterDepth + 5
+	b.WriteString(strings.Repeat("[", depth))
+	b.WriteString("1")
+	b.WriteString(strings.Repeat("]", depth))
+	b.WriteString("\n---\n\nbody\n")
+
+	rr := doArtifactRequest(srv, "POST", "/api/v1/workspaces/"+ws+"/import-artifact", []byte(b.String()))
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("deep-nesting: expected 400, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "unsafe_yaml") {
+		t.Errorf("expected unsafe_yaml error code, got: %s", rr.Body.String())
+	}
+}
+
+func TestImportArtifactNormalPasses(t *testing.T) {
+	srv := testServer(t)
+	ws := createWSForTest(t, srv)
+
+	art := artifact.Artifact{
+		Kind:          artifact.KindConvention,
+		FormatVersion: artifact.FormatVersion,
+		Title:         "Clean Convention",
+		Fields:        map[string]any{"status": "active", "trigger": "on-commit", "scope": "all", "priority": "must"},
+		Body:          "A clean convention.\n",
+	}
+	data, err := artifact.Encode(art)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+
+	rr := doArtifactRequest(srv, "POST", "/api/v1/workspaces/"+ws+"/import-artifact", data)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("normal import: expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+// ---- Import ----
+
+func TestImportArtifactForcesStatusDraft(t *testing.T) {
+	srv := testServer(t)
+	ws := createWSForTest(t, srv)
+
+	art := artifact.Artifact{
+		Kind:          artifact.KindConvention,
+		FormatVersion: artifact.FormatVersion,
+		Title:         "Was Active",
+		Fields:        map[string]any{"status": "active", "trigger": "on-commit", "scope": "all", "priority": "should"},
+		Body:          "x\n",
+	}
+	data, _ := artifact.Encode(art)
+
+	rr := doArtifactRequest(srv, "POST", "/api/v1/workspaces/"+ws+"/import-artifact", data)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("import: expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var resp artifactImportResponse
+	parseJSON(t, rr, &resp)
+	if resp.Ref == "" {
+		t.Error("expected a non-empty ref")
+	}
+
+	created := getItem(t, srv, ws, resp.Slug)
+	if got := fieldString(t, created.Fields, "status"); got != "draft" {
+		t.Errorf("expected status forced to draft, got %q", got)
+	}
+}
+
+func TestImportArtifactBlanksForeignSelectValue(t *testing.T) {
+	srv := testServer(t)
+	ws := createWSForTest(t, srv)
+
+	art := artifact.Artifact{
+		Kind:          artifact.KindConvention,
+		FormatVersion: artifact.FormatVersion,
+		Title:         "Foreign Trigger",
+		// "on-candidate-advance" is a hiring-template trigger, not in the
+		// software convention vocabulary this workspace ships.
+		Fields: map[string]any{"status": "active", "trigger": "on-candidate-advance", "scope": "all"},
+		Body:   "x\n",
+	}
+	data, _ := artifact.Encode(art)
+
+	rr := doArtifactRequest(srv, "POST", "/api/v1/workspaces/"+ws+"/import-artifact", data)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("import: expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var resp artifactImportResponse
+	parseJSON(t, rr, &resp)
+	if len(resp.Warnings) == 0 {
+		t.Fatal("expected a warning about the foreign trigger value")
+	}
+	foundWarn := false
+	for _, wmsg := range resp.Warnings {
+		if strings.Contains(wmsg, "trigger") {
+			foundWarn = true
+		}
+	}
+	if !foundWarn {
+		t.Errorf("expected a trigger warning, got %v", resp.Warnings)
+	}
+
+	created := getItem(t, srv, ws, resp.Slug)
+	if got := fieldString(t, created.Fields, "trigger"); got != "" {
+		t.Errorf("expected trigger blanked, got %q", got)
+	}
+}
+
+func TestImportArtifactInvocationSlugCollision(t *testing.T) {
+	srv := testServer(t)
+	ws := createWSForTest(t, srv)
+
+	// Seed an existing playbook that already owns the "ship" slug.
+	createItem(t, srv, ws, "playbooks", map[string]interface{}{
+		"title":  "Existing Ship",
+		"fields": `{"status":"active","invocation_slug":"ship"}`,
+	})
+
+	art := artifact.Artifact{
+		Kind:          artifact.KindPlaybook,
+		FormatVersion: artifact.FormatVersion,
+		Title:         "Imported Ship",
+		Fields:        map[string]any{"status": "active", "invocation_slug": "ship"},
+		Body:          "x\n",
+	}
+	data, _ := artifact.Encode(art)
+
+	rr := doArtifactRequest(srv, "POST", "/api/v1/workspaces/"+ws+"/import-artifact", data)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("import: expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var resp artifactImportResponse
+	parseJSON(t, rr, &resp)
+
+	if len(resp.Warnings) == 0 {
+		t.Fatal("expected a slug-collision warning")
+	}
+
+	created := getItem(t, srv, ws, resp.Slug)
+	if got := fieldString(t, created.Fields, "invocation_slug"); got != "ship-2" {
+		t.Errorf("expected invocation_slug suffixed to ship-2, got %q", got)
+	}
+}
+
+func TestImportArtifactCreateSideEffectsFire(t *testing.T) {
+	srv := testServer(t)
+	ws := createWSForTest(t, srv)
+
+	art := artifact.Artifact{
+		Kind:          artifact.KindPlaybook,
+		FormatVersion: artifact.FormatVersion,
+		Title:         "With Activity",
+		Fields:        map[string]any{"status": "active", "invocation_slug": "with-activity"},
+		Body:          "x\n",
+	}
+	data, _ := artifact.Encode(art)
+
+	rr := doArtifactRequest(srv, "POST", "/api/v1/workspaces/"+ws+"/import-artifact", data)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("import: expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var resp artifactImportResponse
+	parseJSON(t, rr, &resp)
+
+	// The created item must have a "created" activity entry, exactly like
+	// any other create path — confirming createItemChecked's side effects
+	// (activity log) ran for the import.
+	rr = doRequest(srv, "GET", "/api/v1/workspaces/"+ws+"/items/"+resp.Slug+"/activity", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("activity: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var activities []models.Activity
+	parseJSON(t, rr, &activities)
+	foundCreated := false
+	for _, a := range activities {
+		if a.Action == "created" {
+			foundCreated = true
+		}
+	}
+	if !foundCreated {
+		t.Errorf("expected a 'created' activity entry, got %+v", activities)
+	}
+}
+
+// ---- helpers ----
+
+func getItem(t *testing.T, srv *Server, ws, slug string) models.Item {
+	t.Helper()
+	rr := doRequest(srv, "GET", "/api/v1/workspaces/"+ws+"/items/"+slug, nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("get item %s: expected 200, got %d: %s", slug, rr.Code, rr.Body.String())
+	}
+	var item models.Item
+	parseJSON(t, rr, &item)
+	return item
+}
+
+// fieldString parses an item's fields JSON and returns the string value at
+// key (or "" if absent).
+func fieldString(t *testing.T, fieldsJSON, key string) string {
+	t.Helper()
+	if fieldsJSON == "" {
+		return ""
+	}
+	var m map[string]any
+	if err := json.Unmarshal([]byte(fieldsJSON), &m); err != nil {
+		t.Fatalf("parse fields JSON: %v", err)
+	}
+	s, _ := m[key].(string)
+	return s
+}

--- a/internal/server/handlers_artifact_test.go
+++ b/internal/server/handlers_artifact_test.go
@@ -23,6 +23,22 @@ func doArtifactRequest(srv *Server, method, path string, body []byte) *httptest.
 	return rr
 }
 
+// doArtifactRequestWithCookie is doArtifactRequest with session + CSRF cookies,
+// for the cloud-mode paths that require authentication.
+func doArtifactRequestWithCookie(srv *Server, method, path string, body []byte, token string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(method, path, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "text/markdown")
+	req.RemoteAddr = "192.0.2.1:1234"
+	req.AddCookie(&http.Cookie{Name: "pad_session", Value: token})
+	// Double-submit CSRF cookie/header — any fixed 64-char hex string works.
+	const testCSRF = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	req.AddCookie(&http.Cookie{Name: "pad_csrf", Value: testCSRF})
+	req.Header.Set("X-CSRF-Token", testCSRF)
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	return rr
+}
+
 // ---- Export ----
 
 func TestExportPlaybookArtifactRoundTrip(t *testing.T) {
@@ -264,6 +280,86 @@ func TestImportArtifactNormalPasses(t *testing.T) {
 	rr := doArtifactRequest(srv, "POST", "/api/v1/workspaces/"+ws+"/import-artifact", data)
 	if rr.Code != http.StatusCreated {
 		t.Fatalf("normal import: expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+// ---- Import: validation parity with the create path ----
+
+// TestImportArtifactEmptyTitleRejected confirms an artifact with no title is
+// rejected with 400, matching handleCreateItem's "Title is required" gate.
+// artifact.Decode tolerates a missing/blank title (it would otherwise produce
+// an "untitled" item), so the import handler must enforce it explicitly.
+func TestImportArtifactEmptyTitleRejected(t *testing.T) {
+	srv := testServer(t)
+	ws := createWSForTest(t, srv)
+
+	// Whitespace-only title — must be treated the same as empty.
+	art := artifact.Artifact{
+		Kind:          artifact.KindConvention,
+		FormatVersion: artifact.FormatVersion,
+		Title:         "   ",
+		Fields:        map[string]any{"status": "active", "trigger": "on-commit", "scope": "all"},
+		Body:          "x\n",
+	}
+	data, err := artifact.Encode(art)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+
+	rr := doArtifactRequest(srv, "POST", "/api/v1/workspaces/"+ws+"/import-artifact", data)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("empty-title import: expected 400, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "Title is required") {
+		t.Errorf("expected 'Title is required' message, got: %s", rr.Body.String())
+	}
+}
+
+// TestImportArtifactRejectedWhenOverWorkspaceItemQuota confirms the import path
+// enforces the same workspace item-count limit handleCreateItem does, returning
+// the same 403 plan_limit_exceeded response when the cap is hit.
+func TestImportArtifactRejectedWhenOverWorkspaceItemQuota(t *testing.T) {
+	srv := testServer(t)
+
+	// Bootstrap the first admin (before cloud mode — bootstrap is disabled in
+	// cloud mode) and create a workspace they own.
+	token := bootstrapFirstUser(t, srv, "admin@test.com", "Admin")
+	rr := doRequestWithCookie(srv, "POST", "/api/v1/workspaces", map[string]string{"name": "Quota"}, token)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create workspace: expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var ws models.Workspace
+	parseJSON(t, rr, &ws)
+
+	// Pin the workspace owner to a zero item-per-workspace limit, then turn on
+	// cloud mode so enforcePlanLimit actually runs (it's a no-op self-hosted).
+	owner, err := srv.store.GetUserByEmail("admin@test.com")
+	if err != nil || owner == nil {
+		t.Fatalf("get owner: %v", err)
+	}
+	if err := srv.store.SetUserPlanOverrides(owner.ID, `{"items_per_workspace":0}`); err != nil {
+		t.Fatalf("set plan overrides: %v", err)
+	}
+	srv.SetCloudMode("cloud-secret")
+
+	art := artifact.Artifact{
+		Kind:          artifact.KindConvention,
+		FormatVersion: artifact.FormatVersion,
+		Title:         "Over Quota",
+		Fields:        map[string]any{"status": "active", "trigger": "on-commit", "scope": "all"},
+		Body:          "x\n",
+	}
+	data, err := artifact.Encode(art)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+
+	rr = doArtifactRequestWithCookie(srv, "POST", "/api/v1/workspaces/"+ws.Slug+"/import-artifact", data, token)
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("over-quota import: expected 403, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "plan_limit_exceeded") {
+		t.Errorf("expected plan_limit_exceeded error code, got: %s", rr.Body.String())
 	}
 }
 

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -615,21 +615,64 @@ func (s *Server) handleCreateItem(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if err := items.ValidateFields(fieldMap, schema); err != nil {
-		writeError(w, http.StatusBadRequest, "validation_error", err.Error())
+	item, cerr := s.createItemChecked(r, workspaceID, coll, schema, input, fieldMap, parentValue)
+	if cerr != nil {
+		writeError(w, cerr.status, cerr.code, cerr.message)
 		return
 	}
 
-	if err := s.checkUniqueFields(workspaceID, coll.ID, "", schema, fieldMap); err != nil {
-		writeError(w, http.StatusConflict, "conflict", err.Error())
+	createVisIDs, _ := s.visibleCollectionIDs(r, workspaceID)
+	if err := s.enrichItemForResponse(item, createVisIDs); err != nil {
+		writeInternalError(w, err)
 		return
+	}
+
+	writeJSON(w, http.StatusCreated, item)
+}
+
+// itemCreateError carries an HTTP-status hint out of createItemChecked so
+// callers (handleCreateItem and the artifact-import handler) can map the
+// failure to a response without re-classifying it. Mirrors the
+// importStatusError pattern in handlers_import_bundle.go.
+type itemCreateError struct {
+	status  int
+	code    string
+	message string
+}
+
+func (e *itemCreateError) Error() string { return e.message }
+
+// createItemChecked is the shared item-create core: schema-field validation →
+// workspace-unique-field precheck → persist → optional parent link → activity
+// log + SSE event + webhook dispatch. Both handleCreateItem and the
+// artifact-import handler call it so neither path can drop straight to
+// store.CreateItem and skip validation, the uniqueness precheck, or the
+// create side effects.
+//
+// The caller owns everything upstream of the validate step: resolving the
+// collection, enforcing edit permission + collection visibility, decoding the
+// request body, enforcing plan limits, and resolving + visibility-gating any
+// parent (passed in as parentValue, an already-resolved item ID or "").
+// fieldMap is the parsed-but-not-yet-validated structured fields; this helper
+// validates it against schema, marshals the validated/defaulted result back
+// into input.Fields, and stamps input.Source from the request auth context
+// when the caller left it blank.
+//
+// Returns the created item (Ref/Slug populated by the store) or an
+// *itemCreateError with a status hint.
+func (s *Server) createItemChecked(r *http.Request, workspaceID string, coll *models.Collection, schema models.CollectionSchema, input models.ItemCreate, fieldMap map[string]any, parentValue string) (*models.Item, *itemCreateError) {
+	if err := items.ValidateFields(fieldMap, schema); err != nil {
+		return nil, &itemCreateError{http.StatusBadRequest, "validation_error", err.Error()}
+	}
+
+	if err := s.checkUniqueFields(workspaceID, coll.ID, "", schema, fieldMap); err != nil {
+		return nil, &itemCreateError{http.StatusConflict, "conflict", err.Error()}
 	}
 
 	// Marshal validated/defaulted fields back
 	validatedFields, err := json.Marshal(fieldMap)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to marshal validated fields")
-		return
+		return nil, &itemCreateError{http.StatusInternalServerError, "internal_error", "Failed to marshal validated fields"}
 	}
 	input.Fields = string(validatedFields)
 
@@ -654,34 +697,26 @@ func (s *Server) handleCreateItem(w http.ResponseWriter, r *http.Request) {
 			// message generic so it covers both — the application-layer
 			// pre-check (checkUniqueFields) catches the common case with a
 			// targeted error message; only a true concurrent race lands here.
-			writeError(w, http.StatusConflict, "conflict", "An item conflicts with an existing record (duplicate slug, title, or invocation slug)")
-			return
+			return nil, &itemCreateError{http.StatusConflict, "conflict", "An item conflicts with an existing record (duplicate slug, title, or invocation slug)"}
 		}
-		writeInternalError(w, err)
-		return
+		slog.Error("createItemChecked: store.CreateItem failed", "error", err)
+		return nil, &itemCreateError{http.StatusInternalServerError, "internal_error", "An internal error occurred"}
 	}
 
 	// Create parent link if specified
 	if parentValue != "" {
 		actor, _ := actorFromRequest(r)
 		if _, err := s.store.SetParentLink(workspaceID, item.ID, parentValue, actor); err != nil {
-			writeError(w, http.StatusInternalServerError, "internal_error", fmt.Sprintf("item created but parent link failed: %v", err))
-			return
+			return nil, &itemCreateError{http.StatusInternalServerError, "internal_error", fmt.Sprintf("item created but parent link failed: %v", err)}
 		}
 	}
 
 	actor, source := actorFromRequest(r)
 	s.logActivity(workspaceID, item.ID, "created", r)
-	s.publishItemEventWithName(events.ItemCreated, workspaceID, item.ID, item.Title, collSlug, actor, actorNameFromRequest(r), source, item.Seq)
+	s.publishItemEventWithName(events.ItemCreated, workspaceID, item.ID, item.Title, coll.Slug, actor, actorNameFromRequest(r), source, item.Seq)
 	s.dispatchWebhook(workspaceID, "item.created", item)
 
-	createVisIDs, _ := s.visibleCollectionIDs(r, workspaceID)
-	if err := s.enrichItemForResponse(item, createVisIDs); err != nil {
-		writeInternalError(w, err)
-		return
-	}
-
-	writeJSON(w, http.StatusCreated, item)
+	return item, nil
 }
 
 // writeItemResolveError distinguishes a soft-deleted (archived) item from a

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -143,6 +143,14 @@ type Server struct {
 	// exports can opt in without recompiling.
 	importBundleMaxBytes int64
 
+	// importArtifactMaxBytes caps a single playbook/convention artifact
+	// import (POST /workspaces/{ws}/import-artifact). 0 →
+	// defaultImportArtifactMaxBytes (1 MiB). A single artifact is tiny;
+	// the cap is the first line of defense against an oversized body
+	// being materialized before the YAML-bomb guard runs. Set via
+	// SetImportArtifactMaxBytes from cmd/pad/main.go.
+	importArtifactMaxBytes int64
+
 	// orphanGC holds the periodic-sweep config + lifecycle for the
 	// attachment orphan garbage collector (TASK-886). Configured via
 	// SetOrphanGCConfig and started via StartOrphanGC. Stop() signals
@@ -531,6 +539,13 @@ func (s *Server) uploadInFlight(hash string) bool {
 // flight at a time, ≤25 MiB) for a longer import wall-clock.
 func (s *Server) SetImportBundleMaxBytes(n int64) {
 	s.importBundleMaxBytes = n
+}
+
+// SetImportArtifactMaxBytes overrides the default 1 MiB cap on a single
+// playbook/convention artifact import. Set to 0 to fall back to the
+// default. Wired from PAD_IMPORT_ARTIFACT_MAX_BYTES in cmd/pad/main.go.
+func (s *Server) SetImportArtifactMaxBytes(n int64) {
+	s.importArtifactMaxBytes = n
 }
 
 // SetSecureCookies enables the Secure flag on all cookies.
@@ -1023,6 +1038,11 @@ func (s *Server) setupRouter() {
 					r.Patch("/", s.handleUpdateWorkspace)
 					r.Delete("/", s.handleDeleteWorkspace)
 					r.Get("/export", s.handleExportWorkspace)
+					// Import a single playbook/convention artifact (Markdown
+					// + YAML frontmatter) into this workspace. Editor+ gate
+					// is enforced inside the handler against the destination
+					// collection.
+					r.Post("/import-artifact", s.handleImportArtifact)
 
 					// Activity (workspace level)
 					r.Get("/activity", s.handleListWorkspaceActivity)
@@ -1127,6 +1147,12 @@ func (s *Server) setupRouter() {
 						r.Delete("/", s.handleDeleteItem)
 						r.Post("/restore", s.handleRestoreItem)
 						r.Post("/move", s.handleMoveItem)
+						// Export a single playbook/convention item as a
+						// portable artifact (Markdown + YAML frontmatter).
+						// Gated by per-item visibility, not the workspace-
+						// export owner gate — a viewer who can see the item
+						// may export it.
+						r.Get("/export", s.handleExportItemArtifact)
 						r.Get("/versions", s.handleListItemVersions)
 						r.Get("/versions/{versionID}", s.handleGetItemVersion)
 						r.Post("/versions/{versionID}/restore", s.handleRestoreItemVersion)


### PR DESCRIPTION
Phase 2 of **PLAN-1867** — the REST surface for the export/import primitive. Builds on the Phase-1 `internal/artifact` package (#754).

## Endpoints
- **`GET /workspaces/{ws}/items/{ref}/export`** — encodes a playbook/convention item to a Markdown+frontmatter artifact. Gated on **per-item visibility** (a viewer who can see the item can export it), not the workspace-export owner gate.
- **`POST /workspaces/{ws}/import-artifact`** — editor-gated. Byte-capped + YAML-bomb-guarded parse → forgiving preprocess (foreign `select` values blanked + warned, `invocation_slug` de-collided, `status` forced `draft`) → shared create path. Returns `{ ref, slug, warnings }`.

## Internals
- Extracted **`createItemChecked`** from `handleCreateItem` so import inherits validation, `invocation_slug` uniqueness, edit-permission, item-quota, and activity/event/webhook side effects — no direct `store.CreateItem`.
- YAML safety (`artifact_import.go`): `http.MaxBytesReader` (1 MiB default, `PAD_IMPORT_ARTIFACT_MAX_BYTES`) → `yaml.Node` walk (depth ≤32, ≤10k nodes, aliases rejected) → `artifact.Decode`.

## Decisions / Codex
Implements DR-4 (shared create path), DR-7 (preprocess before validate), DR-8 (per-item-visibility export auth) and the three Codex P2 notes. Codex review: **CLEAN** after fixing two findings (import now enforces `items_per_workspace`; empty titles rejected 400). Custom-field round-trip fidelity tracked as IDEA-1875.

## Gates
`go build`, `go vet`, `golangci`, `go test ./internal/server/... ./internal/artifact/...` all green (full server suite). No store/dialect/migration/collab change.

Closes TASK-1871, TASK-1872, TASK-1873, TASK-1874.

https://claude.ai/code/session_01KmxkPxLksjf1pmrZDpsnTJ