### PR TITLE
feat(artifact): pad item export/import CLI commands

### DIFF
--- a/cmd/pad/artifact_export_test.go
+++ b/cmd/pad/artifact_export_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestWriteFileAtomic_WritesContent is the smoke test for the export
+// command's atomic writer: the bytes land at the destination intact and
+// the file carries the requested mode. The atomic temp-then-rename
+// guarantee itself (no truncation on partial failure) is exercised by
+// the os.Rename semantics; here we just confirm the happy path writes
+// the file correctly so `pad item export` behaves like os.WriteFile did.
+func TestWriteFileAtomic_WritesContent(t *testing.T) {
+	dir := t.TempDir()
+	dst := filepath.Join(dir, "ship.pad.md")
+	body := []byte("---\nkind: playbook\n---\n# Ship\n")
+
+	if err := writeFileAtomic(dst, body, 0o644); err != nil {
+		t.Fatalf("writeFileAtomic: %v", err)
+	}
+
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if string(got) != string(body) {
+		t.Errorf("content = %q, want %q", got, body)
+	}
+
+	info, err := os.Stat(dst)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o644 {
+		t.Errorf("mode = %v, want 0644", perm)
+	}
+
+	// No leftover temp files in the directory.
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	if len(entries) != 1 {
+		var names []string
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Errorf("dir entries = %v, want only the destination file", names)
+	}
+}
+
+// TestWriteFileAtomic_OverwritesExisting confirms the writer replaces an
+// existing destination (deliberate overwrite semantics, matching the
+// attachment download path).
+func TestWriteFileAtomic_OverwritesExisting(t *testing.T) {
+	dir := t.TempDir()
+	dst := filepath.Join(dir, "out.pad.md")
+	if err := os.WriteFile(dst, []byte("old contents that are longer"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	body := []byte("new")
+	if err := writeFileAtomic(dst, body, 0o644); err != nil {
+		t.Fatalf("writeFileAtomic: %v", err)
+	}
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if string(got) != "new" {
+		t.Errorf("content = %q, want %q", got, "new")
+	}
+}

--- a/cmd/pad/groups.go
+++ b/cmd/pad/groups.go
@@ -91,6 +91,8 @@ func itemCmd() *cobra.Command {
 		deleteCmd(),
 		restoreCmd(),
 		moveCmd(),
+		itemExportCmd(),
+		itemImportCmd(),
 		editCmd(),
 		searchCmd(),
 		bulkUpdateCmd(),

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -3985,6 +3985,112 @@ Examples:
 	return cmd
 }
 
+// --- artifact export / import ---
+
+func itemExportCmd() *cobra.Command {
+	var outPath string
+	cmd := &cobra.Command{
+		Use:   "export <ref>",
+		Short: "Export a playbook or convention as a portable artifact",
+		Long: `Export a single playbook or convention item to a portable artifact
+(Markdown body + YAML frontmatter) that can be imported into another workspace.
+
+Only playbooks and conventions are exportable as artifacts; any other item
+type is rejected by the server.
+
+Items can be referenced by issue ID (e.g. PLAYB-3) or slug.
+
+Examples:
+  pad item export PLAYB-3                  # Write PLAYB-3 to <slug>.pad.md
+  pad item export ship -o ship.pad.md      # Write to a specific path
+  pad item export CONVE-7 -o -             # Write the artifact to stdout`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, _ := getClient()
+			ws := getWorkspace()
+
+			res, err := client.ExportItemArtifact(ws, args[0])
+			if err != nil {
+				return err
+			}
+
+			// `-o -` streams the artifact to stdout with no confirmation line.
+			if outPath == "-" {
+				_, err := os.Stdout.Write(res.Body)
+				return err
+			}
+
+			// Default filename: the server-suggested Content-Disposition
+			// filename (<slug>.pad.md), falling back to the ref when the
+			// header is missing.
+			if outPath == "" {
+				if res.Filename != "" {
+					outPath = res.Filename
+				} else {
+					outPath = args[0] + ".pad.md"
+				}
+			}
+
+			if err := os.WriteFile(outPath, res.Body, 0o644); err != nil {
+				return fmt.Errorf("write artifact: %w", err)
+			}
+			fmt.Printf("Exported %s to %s\n", args[0], outPath)
+			return nil
+		},
+	}
+	cmd.Flags().StringVarP(&outPath, "output", "o", "", "output file path (default <slug>.pad.md; use - for stdout)")
+	return cmd
+}
+
+func itemImportCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "import <file>",
+		Short: "Import a playbook or convention artifact into the workspace",
+		Long: `Import a portable artifact (Markdown body + YAML frontmatter) as a new
+playbook or convention in the current workspace.
+
+The item is always imported as a draft — review and activate it afterward.
+The server may emit warnings (e.g. a foreign select value cleared, or an
+invocation_slug de-collided); each is printed on its own line.
+
+Use - to read the artifact from stdin.
+
+Examples:
+  pad item import ship.pad.md     # Import from a file
+  cat ship.pad.md | pad item import -   # Import from stdin`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, _ := getClient()
+			ws := getWorkspace()
+
+			var (
+				body []byte
+				err  error
+			)
+			if args[0] == "-" {
+				body, err = io.ReadAll(os.Stdin)
+			} else {
+				body, err = os.ReadFile(args[0])
+			}
+			if err != nil {
+				return fmt.Errorf("read artifact: %w", err)
+			}
+
+			res, err := client.ImportArtifact(ws, body)
+			if err != nil {
+				return err
+			}
+
+			fmt.Printf("Imported %s (%s) as a draft\n", res.Ref, res.Slug)
+			for _, warning := range res.Warnings {
+				fmt.Printf("⚠ %s\n", warning)
+			}
+			return nil
+		},
+	}
+	return cmd
+}
+
 // --- comments ---
 
 func commentCmd() *cobra.Command {

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -4031,7 +4031,7 @@ Examples:
 				}
 			}
 
-			if err := os.WriteFile(outPath, res.Body, 0o644); err != nil {
+			if err := writeFileAtomic(outPath, res.Body, 0o644); err != nil {
 				return fmt.Errorf("write artifact: %w", err)
 			}
 			fmt.Printf("Exported %s to %s\n", args[0], outPath)
@@ -4040,6 +4040,47 @@ Examples:
 	}
 	cmd.Flags().StringVarP(&outPath, "output", "o", "", "output file path (default <slug>.pad.md; use - for stdout)")
 	return cmd
+}
+
+// writeFileAtomic writes data to a sibling temp file, fsyncs it, then
+// atomically renames it onto path. Unlike os.WriteFile it never
+// truncates an existing destination before the bytes are known-good, so
+// a failed/partial write can't leave a corrupt artifact behind. Mirrors
+// the temp-then-rename strategy used by downloadAttachmentToPath; like
+// that path it deliberately overwrites an existing destination on
+// success (os.Rename replaces atomically on every supported platform).
+func writeFileAtomic(path string, data []byte, perm os.FileMode) (err error) {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, "."+filepath.Base(path)+".*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temp in %s: %w", dir, err)
+	}
+	tmpPath := tmp.Name()
+	committed := false
+	defer func() {
+		tmp.Close()
+		if !committed {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+
+	if _, err := tmp.Write(data); err != nil {
+		return fmt.Errorf("write temp: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		return fmt.Errorf("sync temp: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp: %w", err)
+	}
+	if err := os.Chmod(tmpPath, perm); err != nil {
+		return fmt.Errorf("chmod temp: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("rename %s -> %s: %w", tmpPath, path, err)
+	}
+	committed = true
+	return nil
 }
 
 func itemImportCmd() *cobra.Command {

--- a/internal/cli/artifact_test.go
+++ b/internal/cli/artifact_test.go
@@ -129,7 +129,8 @@ func TestImportArtifact_ServerError(t *testing.T) {
 }
 
 // TestFilenameFromContentDisposition covers the header-parsing helper,
-// including the empty-header fallback path.
+// including the empty-header fallback path and path-traversal defense
+// (a hostile server filename must reduce to a safe base name).
 func TestFilenameFromContentDisposition(t *testing.T) {
 	cases := []struct {
 		header string
@@ -139,6 +140,15 @@ func TestFilenameFromContentDisposition(t *testing.T) {
 		{`attachment; filename=plain.pad.md`, "plain.pad.md"},
 		{"", ""},
 		{"attachment", ""},
+		// Path traversal / absolute path: must collapse to the base name.
+		{`attachment; filename="../../etc/x"`, "x"},
+		{`attachment; filename="/etc/passwd"`, "passwd"},
+		{`attachment; filename="../../../tmp/evil.pad.md"`, "evil.pad.md"},
+		// A filename that is nothing but traversal/separators is unusable;
+		// caller falls back to a synthetic name.
+		{`attachment; filename=".."`, ""},
+		{`attachment; filename="."`, ""},
+		{`attachment; filename="/"`, ""},
 	}
 	for _, tc := range cases {
 		if got := filenameFromContentDisposition(tc.header); got != tc.want {

--- a/internal/cli/artifact_test.go
+++ b/internal/cli/artifact_test.go
@@ -1,0 +1,148 @@
+package cli
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestExportItemArtifact_HappyPath confirms the client GETs the per-item
+// export endpoint, returns the artifact bytes verbatim, and lifts the
+// download filename from the Content-Disposition header.
+func TestExportItemArtifact_HappyPath(t *testing.T) {
+	const wantBody = "---\nkind: playbook\n---\n# Ship\n"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %s, want GET", r.Method)
+		}
+		if r.URL.Path != "/api/v1/workspaces/acme/items/PLAYB-3/export" {
+			t.Errorf("path = %s, want export path", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "text/markdown; charset=utf-8")
+		w.Header().Set("Content-Disposition", `attachment; filename="ship.pad.md"`)
+		_, _ = io.WriteString(w, wantBody)
+	}))
+	defer srv.Close()
+
+	client := NewClientFromURL(srv.URL)
+	res, err := client.ExportItemArtifact("acme", "PLAYB-3")
+	if err != nil {
+		t.Fatalf("ExportItemArtifact: %v", err)
+	}
+	if string(res.Body) != wantBody {
+		t.Errorf("body = %q, want %q", res.Body, wantBody)
+	}
+	if res.Filename != "ship.pad.md" {
+		t.Errorf("filename = %q, want ship.pad.md", res.Filename)
+	}
+}
+
+// TestExportItemArtifact_NonExportable confirms a 4xx server message (e.g. a
+// non-playbook/convention ref) is surfaced as the API error message.
+func TestExportItemArtifact_NonExportable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]string{
+				"code":    "unsupported_collection",
+				"message": "Only playbooks and conventions can be exported as artifacts",
+			},
+		})
+	}))
+	defer srv.Close()
+
+	client := NewClientFromURL(srv.URL)
+	_, err := client.ExportItemArtifact("acme", "TASK-5")
+	if err == nil {
+		t.Fatal("ExportItemArtifact returned nil error for a non-exportable ref")
+	}
+	if !strings.Contains(err.Error(), "Only playbooks and conventions") {
+		t.Errorf("err = %q, want the server message", err.Error())
+	}
+}
+
+// TestImportArtifact_HappyPath confirms the client POSTs the raw artifact
+// bytes (not a JSON wrapper) and decodes the {ref, slug, warnings} response.
+func TestImportArtifact_HappyPath(t *testing.T) {
+	const body = "---\nkind: playbook\ntitle: Ship\n---\n# Ship\n"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/api/v1/workspaces/acme/import-artifact" {
+			t.Errorf("path = %s, want import path", r.URL.Path)
+		}
+		got, _ := io.ReadAll(r.Body)
+		if string(got) != body {
+			t.Errorf("request body = %q, want the raw artifact %q", got, body)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ref":      "PLAYB-9",
+			"slug":     "ship",
+			"warnings": []string{"status \"active\" reset to \"draft\" on import"},
+		})
+	}))
+	defer srv.Close()
+
+	client := NewClientFromURL(srv.URL)
+	res, err := client.ImportArtifact("acme", []byte(body))
+	if err != nil {
+		t.Fatalf("ImportArtifact: %v", err)
+	}
+	if res.Ref != "PLAYB-9" || res.Slug != "ship" {
+		t.Errorf("got ref=%q slug=%q, want PLAYB-9/ship", res.Ref, res.Slug)
+	}
+	if len(res.Warnings) != 1 || !strings.Contains(res.Warnings[0], "draft") {
+		t.Errorf("warnings = %v, want one draft-reset warning", res.Warnings)
+	}
+}
+
+// TestImportArtifact_ServerError confirms a 4xx (e.g. malformed/oversized) is
+// surfaced cleanly as the server's error message.
+func TestImportArtifact_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusRequestEntityTooLarge)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]string{
+				"code":    "too_large",
+				"message": "Artifact body exceeds the size limit",
+			},
+		})
+	}))
+	defer srv.Close()
+
+	client := NewClientFromURL(srv.URL)
+	_, err := client.ImportArtifact("acme", []byte("whatever"))
+	if err == nil {
+		t.Fatal("ImportArtifact returned nil error for an oversized body")
+	}
+	if !strings.Contains(err.Error(), "exceeds the size limit") {
+		t.Errorf("err = %q, want the server message", err.Error())
+	}
+}
+
+// TestFilenameFromContentDisposition covers the header-parsing helper,
+// including the empty-header fallback path.
+func TestFilenameFromContentDisposition(t *testing.T) {
+	cases := []struct {
+		header string
+		want   string
+	}{
+		{`attachment; filename="ship.pad.md"`, "ship.pad.md"},
+		{`attachment; filename=plain.pad.md`, "plain.pad.md"},
+		{"", ""},
+		{"attachment", ""},
+	}
+	for _, tc := range cases {
+		if got := filenameFromContentDisposition(tc.header); got != tc.want {
+			t.Errorf("filenameFromContentDisposition(%q) = %q, want %q", tc.header, got, tc.want)
+		}
+	}
+}

--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -9,6 +9,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/url"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -686,13 +687,28 @@ func (c *Client) ImportArtifact(wsSlug string, body []byte) (*ImportArtifactResu
 // filenameFromContentDisposition extracts the filename token from a
 // Content-Disposition header value (e.g. `attachment; filename="foo.pad.md"`).
 // Returns "" when the header is absent or carries no parseable filename.
+//
+// The result is always reduced to filepath.Base to defuse a hostile or
+// malformed server-supplied filename (e.g. "../../etc/x" or an absolute
+// path) that would otherwise become the export's default output path —
+// mirrors parseAttachmentFilename in the attachment download command.
+// A base that collapses to a path separator, "", ".", or ".." is treated
+// as unusable and "" is returned so the caller falls back to a safe name.
 func filenameFromContentDisposition(header string) string {
 	if header == "" {
 		return ""
 	}
 	if _, params, err := mime.ParseMediaType(header); err == nil {
 		if fn := params["filename"]; fn != "" {
-			return fn
+			// filepath.Base normalizes separators and strips directory
+			// components; the remaining special values can't be used as a
+			// real filename, so treat them as "no usable name".
+			base := filepath.Base(fn)
+			switch base {
+			case "", ".", "..", "/", `\`:
+				return ""
+			}
+			return base
 		}
 	}
 	return ""

--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"mime"
 	"mime/multipart"
 	"net/http"
 	"net/url"
@@ -617,6 +618,85 @@ func (c *Client) DeleteAgentRole(wsSlug, idOrSlug string) error {
 }
 
 // --- Export / Import ---
+
+// ExportItemArtifactResult holds the bytes of an exported artifact plus the
+// download filename the server suggested via Content-Disposition. The CLI uses
+// Filename to pick a default output path (`<slug>.pad.md`) when `-o` is omitted.
+type ExportItemArtifactResult struct {
+	Body     []byte
+	Filename string
+}
+
+// ExportItemArtifact GETs the single-item artifact export endpoint
+// (GET /workspaces/{ws}/items/{ref}/export) and returns the artifact bytes
+// (Markdown + YAML frontmatter) plus the server-suggested download filename.
+//
+// ref is an issue ID (e.g. PLAYB-3) or slug. A non-playbook/convention ref
+// comes back as a 4xx whose server message is surfaced via parseError.
+func (c *Client) ExportItemArtifact(wsSlug, ref string) (*ExportItemArtifactResult, error) {
+	req, err := c.newRequest("GET", "/workspaces/"+wsSlug+"/items/"+ref+"/export", nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		return nil, c.parseError(resp)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read export body: %w", err)
+	}
+	return &ExportItemArtifactResult{
+		Body:     body,
+		Filename: filenameFromContentDisposition(resp.Header.Get("Content-Disposition")),
+	}, nil
+}
+
+// ImportArtifactResult is the JSON body returned by a successful artifact
+// import (POST /workspaces/{ws}/import-artifact). Mirrors the server's
+// artifactImportResponse.
+type ImportArtifactResult struct {
+	Ref      string   `json:"ref"`
+	Slug     string   `json:"slug"`
+	Warnings []string `json:"warnings"`
+}
+
+// ImportArtifact POSTs the raw artifact bytes to the workspace import endpoint
+// (POST /workspaces/{ws}/import-artifact) and decodes the {ref, slug, warnings}
+// JSON. The request body is the raw artifact (Markdown + YAML frontmatter), not
+// a JSON wrapper — the server reads r.Body directly. Server errors (oversized /
+// malformed / over-quota) are surfaced via parseError.
+func (c *Client) ImportArtifact(wsSlug string, body []byte) (*ImportArtifactResult, error) {
+	var result ImportArtifactResult
+	if err := c.PostRawWithContentType(
+		"/workspaces/"+wsSlug+"/import-artifact",
+		body,
+		"text/markdown; charset=utf-8",
+		&result,
+	); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// filenameFromContentDisposition extracts the filename token from a
+// Content-Disposition header value (e.g. `attachment; filename="foo.pad.md"`).
+// Returns "" when the header is absent or carries no parseable filename.
+func filenameFromContentDisposition(header string) string {
+	if header == "" {
+		return ""
+	}
+	if _, params, err := mime.ParseMediaType(header); err == nil {
+		if fn := params["filename"]; fn != "" {
+			return fn
+		}
+	}
+	return ""
+}
 
 // RawGet fetches raw bytes from the API.
 //


### PR DESCRIPTION
Phase 3 of **PLAN-1867** — CLI surface for the export/import primitive (builds on #754, #755).

- **`pad item export <ref> [-o file]`** — writes a playbook/convention as a portable `<slug>.pad.md` artifact (or stdout via `-o -`). Atomic temp+rename write; server-supplied filename sanitized to `filepath.Base`.
- **`pad item import <file>`** — POSTs the artifact (or stdin via `-`), prints the new **draft** ref + slug and any server warnings (coerced fields, renamed slug).
- Adds `ExportItemArtifact` / `ImportArtifact` client methods.

Codex: **CLEAN** after hardening the file-write path (path-traversal + atomic write). Gates: `go build`/`vet`/`test` green.

Closes TASK-1876, TASK-1877.

https://claude.ai/code/session_01KmxkPxLksjf1pmrZDpsnTJ