### PR TITLE
fix(artifact): import field-map normalization for json fields (BUG-1883)

### DIFF
--- a/internal/server/handlers_artifact_import.go
+++ b/internal/server/handlers_artifact_import.go
@@ -118,6 +118,18 @@ func (s *Server) handleImportArtifact(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Normalize the field map through JSON so its nested types match what the
+	// normal create path validates. handleCreateItem builds its fieldMap by
+	// unmarshalling the JSON request body, so structured values are canonical
+	// JSON types ([]any, map[string]any). The artifact decode produces Go-native
+	// types (e.g. arguments as []map[string]any), which ValidateFields' json case
+	// rejects — round-tripping fixes that without special-casing any field.
+	normalizedFields := make(map[string]any)
+	if err := json.Unmarshal(fieldsJSON, &normalizedFields); err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to normalize fields")
+		return
+	}
+
 	body := art.Body
 	if footer := artifactProvenanceFooter(art.Provenance); footer != "" {
 		body = body + footer
@@ -142,7 +154,7 @@ func (s *Server) handleImportArtifact(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	item, cerr := s.createItemChecked(r, workspaceID, coll, schema, input, fields, "")
+	item, cerr := s.createItemChecked(r, workspaceID, coll, schema, input, normalizedFields, "")
 	if cerr != nil {
 		writeError(w, cerr.status, cerr.code, cerr.message)
 		return

--- a/internal/server/handlers_artifact_test.go
+++ b/internal/server/handlers_artifact_test.go
@@ -283,6 +283,42 @@ func TestImportArtifactNormalPasses(t *testing.T) {
 	}
 }
 
+// TestImportArtifactWithArguments is the regression for BUG-1883: a playbook
+// artifact carrying an `arguments` array (a json-typed field) must import
+// cleanly. artifact.Decode normalizes arguments to []map[string]any, which the
+// json case of ValidateFields rejects unless the handler normalizes the field
+// map through JSON first (matching the wire create path's []any shape).
+func TestImportArtifactWithArguments(t *testing.T) {
+	srv := testServer(t)
+	ws := createWSForTest(t, srv)
+
+	art := artifact.Artifact{
+		Kind:          artifact.KindPlaybook,
+		FormatVersion: artifact.FormatVersion,
+		Title:         "Playbook With Args",
+		Fields: map[string]any{
+			"status":          "active",
+			"trigger":         "manual",
+			"scope":           "all",
+			"invocation_slug": "with-args",
+			"arguments": []map[string]any{
+				{"name": "target", "type": "ref", "required": true, "description": "the thing"},
+				{"name": "dry-run", "type": "flag", "required": false, "default": false},
+			},
+		},
+		Body: "Do the thing.\n",
+	}
+	data, err := artifact.Encode(art)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+
+	rr := doArtifactRequest(srv, "POST", "/api/v1/workspaces/"+ws+"/import-artifact", data)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("import with arguments: expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
 // ---- Import: validation parity with the create path ----
 
 // TestImportArtifactEmptyTitleRejected confirms an artifact with no title is


### PR DESCRIPTION
Fixes **BUG-1883**, found verifying [[PLAN-1867]] end-to-end: importing a playbook artifact with an `arguments` array failed with `field "arguments" must be a JSON object, array, or null`.

`artifact.Decode` produces `[]map[string]any` for `arguments`, but `ValidateFields`' `json` case only accepts `map[string]any`/`[]any`/`nil`. `handleCreateItem` never hits this — its field map comes from JSON-unmarshalling the request body (canonical `[]any`). The import handler built the map in Go.

**Fix:** JSON round-trip the import field map (marshal→unmarshal) before `createItemChecked`, yielding canonical types — matches the wire path, no per-field special-casing. Preprocess mutations (status→draft, slug suffix, select coercion) happen before the round-trip and are preserved. Regression test round-trips a playbook with arguments. Verified live (`pad item export` → `import` now succeeds with the expected warnings).

Codex: CLEAN.

Closes BUG-1883.

https://claude.ai/code/session_01KmxkPxLksjf1pmrZDpsnTJ