### PR TITLE
feat(auth): localhost password recovery for locked-out self-host admins

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,7 +77,7 @@ REST API at `/api/v1/`. Key endpoints:
 - `GET /api/v1/collab/{itemID}?schema_version=N` — WebSocket upgrade for real-time collaborative editing (Yjs binary protocol; client must announce schema version)
 - `GET /workspaces/{ws}/members` — list members + pending invitations
 - `POST /workspaces/{ws}/members/invite` — invite user to workspace
-- `GET /api/v1/auth/session` — auth status (`setup_required`, `setup_method`, `auth_method`, `authenticated`, `user`)
+- `GET /api/v1/auth/session` — auth status (`setup_required`, `setup_method`, `auth_method`, `authenticated`, `email_configured`, `user`)
 - `POST /api/v1/auth/bootstrap` — create the first admin account from localhost on a fresh instance
 - `POST /api/v1/auth/register` — create account (admin-created or invitation-based after setup)
 - `POST /api/v1/auth/login` — email/password login (returns session token)
@@ -85,6 +85,7 @@ REST API at `/api/v1/`. Key endpoints:
 - `GET/PATCH /api/v1/auth/me` — current user profile (GET) and update name/password (PATCH)
 - `POST /api/v1/auth/forgot-password` — request password reset email
 - `POST /api/v1/auth/reset-password` — reset password with token
+- `POST /api/v1/auth/local-reset` — localhost-only account recovery (self-host, non-cloud). Loopback-gated, no auth — the bootstrap trust model. Returns a single-use reset link, or a temp password with `{"temp_password": true}`. Backs `pad auth reset-password`.
 - `GET/POST/DELETE /api/v1/auth/tokens` — user-scoped API tokens
 - `GET/PATCH /api/v1/admin/settings` — platform settings (admin-only)
 - `POST /api/v1/admin/test-email` — send test email (admin-only)
@@ -103,11 +104,23 @@ pad auth setup         # Create the first admin account on the server host
 pad auth login         # Email + password prompt
 pad auth whoami        # Show current user
 pad auth logout        # Sign out
-pad auth reset-password user@example.com  # Generate reset link (admin fallback)
+pad auth reset-password user@example.com  # Recover a locked-out account (run ON THE SERVER HOST)
+pad auth reset-password user@example.com --temp-password  # ...set a temp password instead of a reset link
 
 # Credentials stored in ~/.pad/credentials.json (0600 permissions)
 # CLI auto-attaches auth token to all API requests
 ```
+
+### Locked-out account recovery (self-host, no email)
+
+When a self-hosted instance has no email provider, a forgotten password can't be reset by email. Two host-side recovery paths (both require shell access to the server — the same trust boundary as `pad auth setup`):
+
+- **`pad auth reset-password <email>`** — run it **on the server host**. It calls the loopback-only `/api/v1/auth/local-reset` endpoint (no login required — that's the point) and prints a single-use reset link. Add `--temp-password` to instead set a random temporary password printed to the terminal (headless boxes with no browser). The endpoint refuses proxied/remote requests and is disabled in cloud mode.
+- **Server log** — if a user submits the web `/forgot-password` form on a non-cloud instance with no email, the server logs the reset path (`slog.Info ... reset_path=/reset-password/<token>`). Paste it after the instance's base URL to finish the reset by hand.
+
+The web `/forgot-password` page detects `email_configured == false` (from the session payload) and shows the `pad auth reset-password` recovery instructions instead of a dead "we emailed you a link" message.
+
+Code: `internal/server/handlers_auth.go::handleLocalReset` (loopback + non-cloud gates), `cmd/pad/main.go::resetPasswordCmd`, `web/src/routes/forgot-password/+page.svelte`.
 
 After any workspace is created (via `pad init` or `pad workspace init` — note that `pad auth setup` only creates the admin account, not a workspace), the success output points new users at the canonical onboarding entry point. Open a fresh agent session in the workspace's directory and say:
 

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -2169,29 +2169,74 @@ the response 'note' field explains.`,
 // --- reset-password ---
 
 func resetPasswordCmd() *cobra.Command {
-	return &cobra.Command{
+	var tempPassword bool
+	cmd := &cobra.Command{
 		Use:   "reset-password <email>",
-		Short: "Generate a password reset link (admin only)",
-		Long:  "Generate a password reset token and print the reset URL. Use this when email is not configured or a user is locked out.",
-		Args:  cobra.ExactArgs(1),
+		Short: "Recover a locked-out account from the server host",
+		Long: `Recover an account when you're locked out and email isn't configured.
+
+Run this ON THE SERVER HOST. It talks to the local Pad instance over
+loopback — the same trust model as 'pad auth setup' — so it needs no
+login (the whole point is that you can't log in). The endpoint refuses
+proxied or remote requests and is disabled entirely in cloud mode.
+
+By default it prints a single-use reset link; open it in a browser to
+choose a new password. Use --temp-password to instead set a random
+temporary password printed to this terminal — handy on a headless box.
+Rotate it right after you log in.`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			client, _ := getClient()
+			_, cfg := getClient()
 			emailAddr := args[0]
 
-			// Request a reset token via the forgot-password endpoint
-			body, _ := json.Marshal(map[string]string{"email": emailAddr})
-			var result map[string]interface{}
-			if err := client.PostRaw("/auth/forgot-password", body, &result); err != nil {
-				return fmt.Errorf("failed to request password reset: %w", err)
+			// Always talk to the local server over loopback, regardless of
+			// the client's configured base URL. On a self-host instance the
+			// CLI is usually pointed at the public hostname, which routes
+			// through the reverse proxy and is rejected by the server's
+			// loopback gate — defeating the whole recovery path. Targeting
+			// 127.0.0.1:<port> directly is the only request the gate accepts.
+			localURL := fmt.Sprintf("http://127.0.0.1:%d", cfg.Port)
+			client := cli.NewClientFromURL(localURL)
+
+			body, _ := json.Marshal(map[string]interface{}{
+				"email":         emailAddr,
+				"temp_password": tempPassword,
+			})
+			var result struct {
+				Method       string `json:"method"`
+				ResetPath    string `json:"reset_path"`
+				ResetURL     string `json:"reset_url"`
+				TempPassword string `json:"temp_password"`
+				Email        string `json:"email"`
+			}
+			if err := client.PostRaw("/auth/local-reset", body, &result); err != nil {
+				if apiErr, ok := err.(*cli.APIError); ok && apiErr.Code == "forbidden" {
+					return fmt.Errorf("%s\n\nThis command must run on the server host — it uses a loopback-only recovery endpoint.\nIf you still have a working admin account, reset other users from the web UI under Admin → Users instead", apiErr.Message)
+				}
+				return fmt.Errorf("failed to reset password: %w", err)
 			}
 
 			green := color.New(color.FgGreen).SprintFunc()
-			fmt.Printf("%s Password reset requested for %s\n", green("✓"), emailAddr)
-			fmt.Println("If email is configured, a reset link has been sent.")
-			fmt.Println("If not, check the server logs for the reset token.")
+			if result.Method == "temp_password" {
+				fmt.Printf("%s Temporary password set for %s:\n\n    %s\n\n", green("✓"), result.Email, result.TempPassword)
+				fmt.Println("Log in with it now, then change it immediately. All existing sessions were signed out.")
+				return nil
+			}
+
+			// Prefer the server's absolute link (built from its public base
+			// URL, so it's shareable/openable from anywhere). Fall back to the
+			// loopback URL we just used when the server has no base URL set.
+			resetURL := result.ResetURL
+			if resetURL == "" {
+				resetURL = localURL + result.ResetPath
+			}
+			fmt.Printf("%s Reset link generated for %s:\n\n    %s\n\n", green("✓"), result.Email, resetURL)
+			fmt.Println("Open it in a browser to choose a new password. The link is single-use and expires.")
 			return nil
 		},
 	}
+	cmd.Flags().BoolVar(&tempPassword, "temp-password", false, "Set a random temporary password instead of printing a reset link")
+	return cmd
 }
 
 // --- init ---

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -103,6 +103,36 @@ Email enables sending workspace invitation links. Without it, users can still jo
 | `PAD_EMAIL_FROM` | `noreply@getpad.dev` | Sender email address |
 | `PAD_EMAIL_FROM_NAME` | `Pad` | Sender display name |
 
+### Password recovery (when email is not configured)
+
+Without an email provider, the web "Forgot password" flow can't send a reset
+link — the page says so and points users at the host-side recovery below.
+Recover a locked-out account **from the server host** (the same trust model
+as `pad auth setup` — shell access to the box):
+
+```bash
+# Print a single-use reset link (open it in a browser to choose a new password)
+pad auth reset-password admin@example.com
+
+# Or set a random temporary password, printed to the terminal (headless boxes).
+# Log in with it, then change it immediately — all existing sessions are signed out.
+pad auth reset-password admin@example.com --temp-password
+```
+
+This calls a loopback-only endpoint (`POST /api/v1/auth/local-reset`): it
+needs no login (you're locked out, after all), but it **only** works for a
+direct request from the server itself — proxied or remote requests are
+refused, and it's disabled entirely in cloud mode.
+
+Alternatively, if a user submits the web reset form, the server logs the
+reset path on a non-cloud instance with no email configured:
+
+```
+password reset generated (email not configured) ... reset_path=/reset-password/<token>
+```
+
+Open `<base-url>/reset-password/<token>` to finish the reset by hand.
+
 ## Deployment Options
 
 ### Single Binary (SQLite)

--- a/internal/server/handlers_admin_users.go
+++ b/internal/server/handlers_admin_users.go
@@ -498,6 +498,17 @@ func (s *Server) handleAdminUpdateUser(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// generateTempPassword returns a random hex temporary password for an
+// operator-initiated reset (16 bytes → 32 hex chars). Shared by the admin
+// reset endpoint and the localhost recovery endpoint.
+func generateTempPassword() (string, error) {
+	raw := make([]byte, 16)
+	if _, err := rand.Read(raw); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(raw), nil
+}
+
 // handleAdminResetPassword force-resets a user's password.
 // If email is configured, sends a reset link. Otherwise returns a temporary password.
 // POST /api/v1/admin/users/{userID}/reset-password
@@ -545,12 +556,11 @@ func (s *Server) handleAdminResetPassword(w http.ResponseWriter, r *http.Request
 	}
 
 	// No email: generate a temporary password
-	raw := make([]byte, 16)
-	if _, err := rand.Read(raw); err != nil {
+	tempPassword, err := generateTempPassword()
+	if err != nil {
 		writeInternalError(w, err)
 		return
 	}
-	tempPassword := hex.EncodeToString(raw)
 
 	pwd := tempPassword
 	if _, err := s.store.UpdateUser(userID, models.UserUpdate{Password: &pwd}); err != nil {

--- a/internal/server/handlers_auth.go
+++ b/internal/server/handlers_auth.go
@@ -130,6 +130,7 @@ func (s *Server) setupStatePayload(setupMethod string) map[string]interface{} {
 		"setup_method":      setupMethod,
 		"auth_method":       authMethodPassword,
 		"cloud_mode":        s.cloudMode,
+		"email_configured":  s.email != nil,
 		"mcp_public_url":    s.mcpPublicURL,
 		"billing_available": s.cloudMode && s.billingAvailable,
 		"version":           s.version,
@@ -147,10 +148,16 @@ func (s *Server) sessionStatePayload(authenticated bool, user *models.User) map[
 	// deployment is in cloud mode. Used by the web UI to show/hide Stripe
 	// Checkout CTAs. TASK-800.
 	payload := map[string]interface{}{
-		"authenticated":     authenticated,
-		"setup_required":    false,
-		"auth_method":       authMethodPassword,
-		"cloud_mode":        s.cloudMode,
+		"authenticated":  authenticated,
+		"setup_required": false,
+		"auth_method":    authMethodPassword,
+		"cloud_mode":     s.cloudMode,
+		// email_configured tells the web UI whether transactional email is
+		// wired. The /forgot-password page uses it to swap its "we emailed
+		// you a link" copy for host-recovery guidance when false (self-host
+		// with no Maileroo key). Low-sensitivity deployment config, same
+		// class as cloud_mode/mcp_public_url.
+		"email_configured":  s.email != nil,
 		"mcp_public_url":    s.mcpPublicURL,
 		"billing_available": s.cloudMode && s.billingAvailable,
 		// version is the server build version (same source as /health),
@@ -1038,11 +1045,132 @@ func (s *Server) handleForgotPassword(w http.ResponseWriter, r *http.Request) {
 				slog.Error("failed to send password reset email", "error", err)
 			}
 		})
+	} else if !s.cloudMode {
+		// Self-host with no email provider: the server log is the recovery
+		// channel. Emit the path an operator pastes after the base URL to
+		// complete the reset by hand. Gated on !cloudMode so a cloud
+		// deployment never writes a live reset token to its logs.
+		slog.Info("password reset generated (email not configured) — open this path on the server to finish",
+			"reset_path", "/reset-password/"+token)
 	} else {
 		slog.Info("password reset token generated (email not configured)")
 	}
 
 	writeJSON(w, http.StatusOK, okResponse)
+}
+
+// handleLocalReset is the self-host account-recovery escape hatch for an
+// operator who is locked out — forgot the only admin password and has no
+// email provider configured. It is the password-reset analogue of
+// bootstrap: authorization IS proof of access to the server host,
+// established by the strict loopback check, so it deliberately requires no
+// session (the whole point is that the caller cannot log in).
+//
+// Two hard gates, both required:
+//
+//   - NOT cloud mode. On Pad Cloud the host process must never be able to
+//     reset an arbitrary tenant's password; cloud always has email plus
+//     admin tooling, so the escape hatch is pure downside there.
+//   - requestIsLoopback — a direct loopback TCP connection with no proxy
+//     headers. A reverse proxy forwarding public traffic always sets
+//     X-Forwarded-For / X-Real-IP and is rejected, so this cannot be
+//     reached from off-box. Same invariant bootstrap relies on.
+//
+// POST /api/v1/auth/local-reset  {email, temp_password?}
+// Default: returns a single-use reset token+path the operator opens in a
+// browser to choose a new password. temp_password=true instead force-sets
+// a random temporary password and returns it (headless-friendly).
+func (s *Server) handleLocalReset(w http.ResponseWriter, r *http.Request) {
+	if s.cloudMode {
+		writeError(w, http.StatusForbidden, "forbidden", "Local password reset is disabled in cloud mode")
+		return
+	}
+	if !requestIsLoopback(r) {
+		writeError(w, http.StatusForbidden, "forbidden", "Local password reset is only allowed from localhost on the server host")
+		return
+	}
+
+	var input struct {
+		Email        string `json:"email"`
+		TempPassword bool   `json:"temp_password"`
+	}
+	if err := decodeJSON(r, &input); err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", "Invalid request body")
+		return
+	}
+	input.Email = strings.TrimSpace(input.Email)
+	if input.Email == "" {
+		writeError(w, http.StatusBadRequest, "validation_error", "Email is required")
+		return
+	}
+
+	// Unlike forgot-password, we DO reveal whether the account exists: the
+	// caller already holds shell-equivalent access to the host, so there is
+	// no enumeration boundary left to defend, and a clear "no such account"
+	// beats a silent no-op for an operator mid-recovery.
+	user, err := s.store.GetUserByEmail(input.Email)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	if user == nil {
+		writeError(w, http.StatusNotFound, "not_found", "No account found with that email")
+		return
+	}
+
+	if input.TempPassword {
+		tempPassword, err := generateTempPassword()
+		if err != nil {
+			writeInternalError(w, err)
+			return
+		}
+		pwd := tempPassword
+		if _, err := s.store.UpdateUser(user.ID, models.UserUpdate{Password: &pwd}); err != nil {
+			writeInternalError(w, err)
+			return
+		}
+		// Force re-login everywhere with the new credential.
+		if err := s.store.DeleteUserSessions(user.ID); err != nil {
+			writeInternalError(w, err)
+			return
+		}
+		s.logAuditEvent(models.ActionPasswordResetByAdmin, r, auditMeta(map[string]string{
+			"target_user_id": user.ID,
+			"method":         "localhost_temp_password",
+		}))
+		writeJSON(w, http.StatusOK, map[string]interface{}{
+			"ok":            true,
+			"method":        "temp_password",
+			"temp_password": tempPassword,
+			"email":         user.Email,
+		})
+		return
+	}
+
+	token, err := s.store.CreatePasswordReset(user.ID)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	s.logAuditEvent(models.ActionPasswordResetByAdmin, r, auditMeta(map[string]string{
+		"target_user_id": user.ID,
+		"method":         "localhost_reset_link",
+	}))
+	resetPath := "/reset-password/" + token
+	resp := map[string]interface{}{
+		"ok":         true,
+		"method":     "reset_url",
+		"reset_path": resetPath,
+		"email":      user.Email,
+	}
+	// The request reaches us over loopback, but the operator may need to
+	// open or share the link from the instance's real hostname. When the
+	// server knows its public base URL, hand back a ready-to-use absolute
+	// link so the CLI doesn't have to print a loopback-only one.
+	if s.baseURL != "" {
+		resp["reset_url"] = s.baseURL + resetPath
+	}
+	writeJSON(w, http.StatusOK, resp)
 }
 
 // handleResetPassword validates a reset token and sets a new password.

--- a/internal/server/handlers_auth_local_reset_test.go
+++ b/internal/server/handlers_auth_local_reset_test.go
@@ -1,0 +1,133 @@
+package server
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// The localhost recovery endpoint (POST /api/v1/auth/local-reset) is the
+// self-host escape hatch for a locked-out operator. Its entire security
+// model is two gates: not-cloud-mode and strict-loopback. These tests pin
+// both gates plus the two output modes (reset link / temp password).
+
+func TestLocalReset_RejectsRemoteRequest(t *testing.T) {
+	srv := testServer(t)
+	bootstrapFirstUser(t, srv, "admin@test.com", "Admin")
+
+	// Non-loopback peer: must be refused even though the body is valid.
+	rr := doRequest(srv, "POST", "/api/v1/auth/local-reset", map[string]interface{}{
+		"email": "admin@test.com",
+	})
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("remote local-reset: expected 403, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestLocalReset_DisabledInCloudMode(t *testing.T) {
+	srv := testServer(t)
+	srv.cloudMode = true
+	bootstrapFirstUser(t, srv, "admin@test.com", "Admin")
+
+	// Even from loopback, cloud mode must refuse: the host process must
+	// never be able to reset an arbitrary tenant's password.
+	rr := doLoopbackRequest(srv, "POST", "/api/v1/auth/local-reset", map[string]interface{}{
+		"email": "admin@test.com",
+	})
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("cloud-mode local-reset: expected 403, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestLocalReset_UnknownEmail(t *testing.T) {
+	srv := testServer(t)
+	bootstrapFirstUser(t, srv, "admin@test.com", "Admin")
+
+	rr := doLoopbackRequest(srv, "POST", "/api/v1/auth/local-reset", map[string]interface{}{
+		"email": "nobody@test.com",
+	})
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("unknown-email local-reset: expected 404, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestLocalReset_ResetLinkCompletesLogin(t *testing.T) {
+	srv := testServer(t)
+	// A configured public base URL must come back as an absolute, shareable
+	// reset_url — not just the path.
+	srv.baseURL = "https://pad.example.com"
+	bootstrapFirstUser(t, srv, "admin@test.com", "Admin")
+
+	// Loopback, default mode → single-use reset link.
+	rr := doLoopbackRequest(srv, "POST", "/api/v1/auth/local-reset", map[string]interface{}{
+		"email": "admin@test.com",
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("local-reset link: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		Method    string `json:"method"`
+		ResetPath string `json:"reset_path"`
+		ResetURL  string `json:"reset_url"`
+		Email     string `json:"email"`
+	}
+	parseJSON(t, rr, &resp)
+	if resp.Method != "reset_url" {
+		t.Fatalf("expected method=reset_url, got %q", resp.Method)
+	}
+	token := strings.TrimPrefix(resp.ResetPath, "/reset-password/")
+	if token == "" || token == resp.ResetPath {
+		t.Fatalf("expected reset_path of form /reset-password/<token>, got %q", resp.ResetPath)
+	}
+	if want := "https://pad.example.com" + resp.ResetPath; resp.ResetURL != want {
+		t.Fatalf("expected reset_url %q, got %q", want, resp.ResetURL)
+	}
+
+	// The returned token must drive the existing reset flow end to end.
+	const newPassword = "tr0ubadour-fresh-x9-pass"
+	rr = doLoopbackRequest(srv, "POST", "/api/v1/auth/reset-password", map[string]interface{}{
+		"token":    token,
+		"password": newPassword,
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("reset-password with local-reset token: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	// And the operator can now log in with the new password.
+	rr = doLoopbackRequest(srv, "POST", "/api/v1/auth/login", map[string]interface{}{
+		"email":    "admin@test.com",
+		"password": newPassword,
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("login after reset: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestLocalReset_TempPasswordLogsIn(t *testing.T) {
+	srv := testServer(t)
+	bootstrapFirstUser(t, srv, "admin@test.com", "Admin")
+
+	rr := doLoopbackRequest(srv, "POST", "/api/v1/auth/local-reset", map[string]interface{}{
+		"email":         "admin@test.com",
+		"temp_password": true,
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("local-reset temp: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		Method       string `json:"method"`
+		TempPassword string `json:"temp_password"`
+	}
+	parseJSON(t, rr, &resp)
+	if resp.Method != "temp_password" || resp.TempPassword == "" {
+		t.Fatalf("expected a temp_password payload, got %+v", resp)
+	}
+
+	rr = doLoopbackRequest(srv, "POST", "/api/v1/auth/login", map[string]interface{}{
+		"email":    "admin@test.com",
+		"password": resp.TempPassword,
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("login with temp password: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+}

--- a/internal/server/middleware_ratelimit.go
+++ b/internal/server/middleware_ratelimit.go
@@ -344,7 +344,7 @@ func (s *Server) RateLimit(next http.Handler) http.Handler {
 			switch {
 			case path == "/api/v1/auth/login" || path == "/api/v1/auth/bootstrap" || path == "/api/v1/auth/2fa/login-verify":
 				limiter = s.rateLimiters.Auth
-			case path == "/api/v1/auth/forgot-password" || path == "/api/v1/auth/reset-password":
+			case path == "/api/v1/auth/forgot-password" || path == "/api/v1/auth/reset-password" || path == "/api/v1/auth/local-reset":
 				limiter = s.rateLimiters.PasswordReset
 			case path == "/api/v1/auth/register":
 				limiter = s.rateLimiters.Register

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -857,6 +857,8 @@ func (s *Server) setupRouter() {
 				// Password reset
 				r.Post("/forgot-password", s.handleForgotPassword)
 				r.Post("/reset-password", s.handleResetPassword)
+				// Localhost-only recovery escape hatch (self-host, non-cloud).
+				r.Post("/local-reset", s.handleLocalReset)
 
 				// Two-factor authentication
 				r.Post("/2fa/setup", s.handleTOTPSetup)

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -379,6 +379,11 @@ export interface AuthSession {
 	// AND the deployment is in cloud mode. Use authStore.billingAvailable rather
 	// than reading this field directly. TASK-800.
 	billing_available?: boolean;
+	// email_configured is false when the self-host server has no transactional
+	// email provider (no Maileroo key). The /forgot-password page reads it to
+	// replace "we emailed you a link" with host-recovery guidance, since no
+	// email can actually be sent. Absent on older servers — treat as true.
+	email_configured?: boolean;
 	// version is the server build version (same value as HealthResponse.version),
 	// surfaced on /auth/session so clients — notably the mobile shells — can read
 	// it in the call they already make on connect (IDEA-1826). Empty string only

--- a/web/src/lib/stores/auth.svelte.ts
+++ b/web/src/lib/stores/auth.svelte.ts
@@ -29,6 +29,12 @@ export const authStore = {
 	// this value — false means the CTA is hidden entirely, not just disabled.
 	// TASK-800.
 	get billingAvailable() { return session?.billing_available ?? false; },
+	// emailConfigured is false on a self-host instance with no transactional
+	// email provider wired. Defaults to true when absent (older servers, or
+	// before the session loads) so reset/invite flows keep their normal copy
+	// unless the server explicitly says email is off. The /forgot-password
+	// page swaps to host-recovery guidance when this is false.
+	get emailConfigured() { return session?.email_configured ?? true; },
 	get loading() { return loading; },
 
 	async load() {

--- a/web/src/routes/forgot-password/+page.svelte
+++ b/web/src/routes/forgot-password/+page.svelte
@@ -10,6 +10,13 @@
 	let loading = $state(false);
 	let sent = $state(false);
 
+	// When a self-host instance has no email provider, no reset link can be
+	// sent — so we hide the form and explain the host-side recovery path
+	// instead of letting the user submit into a void. Cloud always has email,
+	// and emailConfigured defaults to true until the session loads, so the
+	// normal form is what renders first / on cloud.
+	const noEmailRecovery = $derived(!authStore.cloudMode && !authStore.emailConfigured);
+
 	onMount(() => {
 		// Re-populate authStore if a prior logout cleared it (see auth.svelte.ts
 		// ensureLoaded). Without this, authStore.cloudMode would stay false here
@@ -56,7 +63,22 @@
 			<h1 class="logo">Pad</h1>
 		{/if}
 
-		{#if sent}
+		{#if noEmailRecovery}
+			<p class="subtitle">Reset your password</p>
+			<p class="message">
+				This Pad instance has no email provider configured, so it can't send reset
+				links. Ask whoever runs the server to recover your account from the host:
+			</p>
+			<pre class="recovery-cmd">pad auth reset-password {email || 'you@example.com'}</pre>
+			<p class="message">
+				That prints a one-time reset link (or, with <code>--temp-password</code>, a
+				temporary password) for them to share with you. It only works when run on
+				the server itself.
+			</p>
+			<p class="back-link">
+				<a href="/login">Back to sign in</a>
+			</p>
+		{:else if sent}
 			<p class="subtitle">Check your email</p>
 			<p class="message">
 				If an account with that email exists, we've sent a password reset link. Check your inbox and spam folder.
@@ -175,6 +197,28 @@
 		color: #ef4444;
 		font-size: 0.85rem;
 		text-align: left;
+	}
+
+	.recovery-cmd {
+		text-align: left;
+		background: var(--bg-tertiary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+		padding: var(--space-3) var(--space-4);
+		margin-bottom: var(--space-6);
+		font-family: var(--font-mono, monospace);
+		font-size: 0.82rem;
+		color: var(--text-primary);
+		white-space: pre-wrap;
+		word-break: break-all;
+	}
+
+	.message code {
+		font-family: var(--font-mono, monospace);
+		font-size: 0.82rem;
+		background: var(--bg-tertiary);
+		padding: 0.1em 0.35em;
+		border-radius: var(--radius-sm, 4px);
 	}
 
 	button {


### PR DESCRIPTION
## Problem

On a self-hosted instance with no email provider, a forgotten password was effectively unrecoverable. `pad auth reset-password` just hit `/auth/forgot-password`, which generated a token but **never logged or returned it** (the token is stored only as a SHA-256 hash), so the documented "check the server logs for the reset token" advice didn't actually work. The only recovery was hand-editing the SQLite DB.

## What this does

Adds a proper localhost recovery escape hatch — the password-reset analogue of `pad auth setup`.

- **`POST /api/v1/auth/local-reset`** — loopback-gated, **non-cloud**, no auth required (authorization *is* proof of access to the server host, same trust model as bootstrap). Returns a single-use reset link, or a temporary password with `{"temp_password": true}`.
- **`pad auth reset-password <email> [--temp-password]`** — now targets the local server over `http://127.0.0.1:<port>` **directly**, not the configured public URL. This matters: on a configured self-host the CLI usually points at the public hostname, which routes through the reverse proxy and gets rejected by the loopback gate — so the command would otherwise fail on the very host it's meant to run on. Prints the server's shareable `reset_url` when a public base URL is known, else the loopback link.
- **Web `/forgot-password`** reads a new `email_configured` field from the session payload and, on a self-host instance with no provider, shows host-recovery instructions instead of a dead "we emailed you a link" message.
- **`/forgot-password` server log** now emits the reset path (`reset_path=/reset-password/<token>`) on non-cloud instances, so operators can recover from logs too — gated on `!cloudMode` so cloud never writes a live token to its logs.
- **Docs:** `CLAUDE.md` + `docs/deployment.md` recovery sections. (Public docs updated separately in pad-web.)

## Security

Two hard gates, both tested:
- `requestIsLoopback` — rejects anything proxied (`X-Forwarded-For`/`X-Real-IP`) or off-box.
- `cloudMode` → `403` — the host process can never reset an arbitrary tenant's password on Pad Cloud.

Enumeration (404 on unknown email) is *intentionally* allowed on this loopback+non-cloud endpoint only — loopback access already implies shell-equivalent trust. The public `/forgot-password` keeps its anti-enumeration generic response.

## Tests

`internal/server/handlers_auth_local_reset_test.go` covers: remote request rejected, cloud-mode disabled, unknown email, reset-link → reset → login, temp-password → login, and the shareable `reset_url`.

## Review

Reviewed via Codex loop — one High finding (the CLI targeting the public URL instead of loopback) fixed; re-review CLEAN.