### PR TITLE
feat(cli): headless admin bootstrap via --email/--name/--password (BUG-988)

### DIFF
--- a/cmd/pad/init.go
+++ b/cmd/pad/init.go
@@ -23,6 +23,10 @@ import (
 func padInitCmd() *cobra.Command {
 	var templateFlag string
 	var cliPromptFlag bool
+	// Headless bootstrap flags (BUG-988). All three must be supplied
+	// together when any one is present. They drive the bootstrap step only;
+	// the rest of init (workspace creation, skill install) still runs.
+	var emailFlag, nameFlag, passwordFlag string
 
 	cmd := &cobra.Command{
 		Use:   "init [name]",
@@ -138,55 +142,106 @@ Examples:
 			}
 
 			if session.SetupRequired {
-				// Only local mode can bootstrap inline
-				if cfg.Mode != config.ModeLocal && cfg.Mode != "" {
-					printSetupRequiredHint(cfg)
-					return fmt.Errorf("this Pad instance has not been initialized yet")
-				}
+				// Headless path: all three flags must be present when any one
+				// is supplied (BUG-988). Checked BEFORE the local-only mode
+				// guard so an agent running on a remote server host can bootstrap
+				// it; the loopback gate is enforced server-side.
+				// This branch runs the bootstrap step only; the rest of init
+				// (workspace, skills) continues below.
+				//
+				// NOTE: --password appears in the process argument list and is
+				// therefore visible in `ps` output. This is acceptable for the
+				// headless-agent use case. Env-var bootstrap (PAD_ADMIN_*)
+				// is the tracked follow-up (Option A, deferred).
+				headless := emailFlag != "" || nameFlag != "" || passwordFlag != ""
+				if headless {
+					if emailFlag == "" {
+						return fmt.Errorf("--email is required when using headless bootstrap (--name and --password were provided)")
+					}
+					if nameFlag == "" {
+						return fmt.Errorf("--name is required when using headless bootstrap (--email and --password were provided)")
+					}
+					if passwordFlag == "" {
+						return fmt.Errorf("--password is required when using headless bootstrap (--email and --name were provided)")
+					}
 
-				if !canPromptForConfig() {
-					printSetupRequiredHint(cfg)
-					return fmt.Errorf("this Pad instance has not been initialized yet (run 'pad auth setup' in an interactive terminal)")
-				}
+					if actioned {
+						fmt.Println(bold.Sprint("Step 2: Create admin account"))
+					} else {
+						fmt.Println(bold.Sprint("Create admin account"))
+					}
+					fmt.Println()
 
-				if actioned {
-					fmt.Println(bold.Sprint("Step 2: Create admin account"))
-				} else {
-					fmt.Println(bold.Sprint("Create admin account"))
-				}
-				fmt.Println()
-
-				if cliPromptFlag {
-					// Legacy --cli-prompt path: in-terminal email/name/password
-					// prompts. Same Bootstrap call the pre-TASK-1217 flow used,
-					// kept verbatim as a zero-cost hedge per IDEA-1179.
-					resp, err := promptAndBootstrap(client)
+					resp, err := client.Bootstrap(emailFlag, nameFlag, passwordFlag)
 					if err != nil {
-						return err
+						var apiErr *cli.APIError
+						if errors.As(err, &apiErr) && apiErr.Code == "conflict" {
+							return fmt.Errorf("setup failed: %s (Pad is already initialized — run 'pad auth login' to sign in)", apiErr.Message)
+						}
+						return fmt.Errorf("setup failed: %w", err)
 					}
 					if err := saveCredentials(cfg, resp); err != nil {
 						return err
 					}
+					client.SetAuthToken(resp.Token)
 					green.Print("✓ ")
 					fmt.Printf("Admin account created — logged in as %s (%s)\n", resp.User.Name, resp.User.Email)
 					fmt.Println()
+				} else if cfg.Mode != config.ModeLocal && cfg.Mode != "" {
+					// Non-headless paths (browser / --cli-prompt) only work when
+					// the operator is running locally — a remote browser flow
+					// requires a browser on the remote server host, and
+					// --cli-prompt requires a TTY there too. Use --email/--name/
+					// --password to bootstrap a remote instance non-interactively.
+					printSetupRequiredHint(cfg)
+					return fmt.Errorf("this Pad instance has not been initialized yet")
+				} else if !canPromptForConfig() {
+					printSetupRequiredHint(cfg)
+					return fmt.Errorf(
+						"this Pad instance has not been initialized yet.\n" +
+							"Run with --email, --name, and --password for non-interactive bootstrap:\n" +
+							"  pad init --email you@example.com --name \"Your Name\" --password <pass>\n" +
+							"Or run 'pad auth setup' in an interactive terminal.")
 				} else {
-					// Default browser path: a SINGLE handoff that creates the
-					// admin account AND authorizes this CLI in the same
-					// browser tab. runBrowserSetup mints the pending CLI auth
-					// session first, hands /setup a next= target pointing at
-					// its approval page, then polls until approved — so the
-					// operator never has to return to the terminal to copy a
-					// second URL. BUG-1843.
-					//
-					// SIGINT is already handled by installInitCancelHandler
-					// at the top of this RunE (os.Exit(130)); runBrowserSetup
-					// installs a redundant handler of its own, which is
-					// harmless.
-					if err := runBrowserSetup(context.Background(), cfg, client); err != nil {
-						return err
+					if actioned {
+						fmt.Println(bold.Sprint("Step 2: Create admin account"))
+					} else {
+						fmt.Println(bold.Sprint("Create admin account"))
 					}
 					fmt.Println()
+
+					if cliPromptFlag {
+						// Legacy --cli-prompt path: in-terminal email/name/password
+						// prompts. Same Bootstrap call the pre-TASK-1217 flow used,
+						// kept verbatim as a zero-cost hedge per IDEA-1179.
+						resp, err := promptAndBootstrap(client)
+						if err != nil {
+							return err
+						}
+						if err := saveCredentials(cfg, resp); err != nil {
+							return err
+						}
+						green.Print("✓ ")
+						fmt.Printf("Admin account created — logged in as %s (%s)\n", resp.User.Name, resp.User.Email)
+						fmt.Println()
+					} else {
+						// Default browser path: a SINGLE handoff that creates the
+						// admin account AND authorizes this CLI in the same
+						// browser tab. runBrowserSetup mints the pending CLI auth
+						// session first, hands /setup a next= target pointing at
+						// its approval page, then polls until approved — so the
+						// operator never has to return to the terminal to copy a
+						// second URL. BUG-1843.
+						//
+						// SIGINT is already handled by installInitCancelHandler
+						// at the top of this RunE (os.Exit(130)); runBrowserSetup
+						// installs a redundant handler of its own, which is
+						// harmless.
+						if err := runBrowserSetup(context.Background(), cfg, client); err != nil {
+							return err
+						}
+						fmt.Println()
+					}
 				}
 
 				// Refresh client with credentials
@@ -274,6 +329,13 @@ Examples:
 	// terminal email/name/password prompts for the admin-creation step.
 	// Workspace creation (cwd-bound) stays CLI in either case.
 	cmd.Flags().BoolVar(&cliPromptFlag, "cli-prompt", false, "Use the legacy in-terminal email/name/password prompts for the admin-account step instead of the browser /setup flow.")
+	// Headless bootstrap flags for non-interactive (agent) use (BUG-988).
+	// All three must be supplied together; any one implies the other two.
+	// Only active when setup is required; ignored on already-initialized instances.
+	cmd.Flags().StringVar(&emailFlag, "email", "", "Admin email address (headless bootstrap — requires --name and --password)")
+	cmd.Flags().StringVar(&nameFlag, "name", "", "Admin display name (headless bootstrap — requires --email and --password)")
+	// NOTE: argv passwords are visible in process listings; see comment in RunE.
+	cmd.Flags().StringVar(&passwordFlag, "password", "", "Admin password (headless bootstrap — requires --email and --name)")
 	return cmd
 }
 

--- a/cmd/pad/init.go
+++ b/cmd/pad/init.go
@@ -165,6 +165,14 @@ Examples:
 						return fmt.Errorf("--password is required when using headless bootstrap (--email and --name were provided)")
 					}
 
+					// doHeadlessBootstrap reads the on-disk first-run token,
+					// calls BootstrapWithToken (X-Bootstrap-Token header set
+					// when a token is present), saves credentials, and calls
+					// client.SetAuthToken. BUG-988 / round-1 finding #1.
+					//
+					// pad init is a multi-step flow; the human-readable step
+					// header is always printed. For machine-readable bootstrap
+					// output use `pad auth setup --email … --format json`.
 					if actioned {
 						fmt.Println(bold.Sprint("Step 2: Create admin account"))
 					} else {
@@ -172,7 +180,7 @@ Examples:
 					}
 					fmt.Println()
 
-					resp, err := client.Bootstrap(emailFlag, nameFlag, passwordFlag)
+					resp, err := doHeadlessBootstrap(cfg, client, emailFlag, nameFlag, passwordFlag)
 					if err != nil {
 						var apiErr *cli.APIError
 						if errors.As(err, &apiErr) && apiErr.Code == "conflict" {
@@ -180,10 +188,6 @@ Examples:
 						}
 						return fmt.Errorf("setup failed: %w", err)
 					}
-					if err := saveCredentials(cfg, resp); err != nil {
-						return err
-					}
-					client.SetAuthToken(resp.Token)
 					green.Print("✓ ")
 					fmt.Printf("Admin account created — logged in as %s (%s)\n", resp.User.Name, resp.User.Email)
 					fmt.Println()

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -1133,20 +1133,14 @@ By default the CLI hands the operator a deep link into the browser-based
 /setup form (which uses password managers, HTML5 email validation, and the
 live strength meter). If the browser path won't work — headless server
 without an SSH tunnel, broken X11, etc. — re-run with --cli-prompt for the
-legacy in-terminal email/name/password prompts.`,
+legacy in-terminal email/name/password prompts, or supply --email/--name/
+--password for fully non-interactive (agent) use.`,
 		RunE: func(cmd *cobra.Command, args []string) (retErr error) {
 			cfg := getConfig()
 			if !cfg.IsConfigured() {
 				// Allow host-local bootstrap on a pristine machine before the
 				// client has been explicitly configured.
 				cfg.Mode = config.ModeLocal
-			}
-
-			if cfg.IsConfigured() {
-				switch cfg.Mode {
-				case config.ModeRemote, config.ModeCloud:
-					return fmt.Errorf("remote Pad instances must be initialized on the server host with 'pad auth setup'")
-				}
 			}
 
 			// Honour the same Cancelled. + exit-130 path as login when the
@@ -1156,6 +1150,48 @@ legacy in-terminal email/name/password prompts.`,
 					cancelInit()
 				}
 			}()
+
+			// Headless path: all three flags required when any one is present
+			// (BUG-988). Drives the existing POST /api/v1/auth/bootstrap
+			// endpoint directly — no browser, no stdin reads. Checked BEFORE
+			// the remote-mode guard so an agent running on a remote server
+			// host can bootstrap it; the loopback gate is enforced server-side.
+			//
+			// NOTE: --password appears in the process argument list and is
+			// therefore visible in `ps` output. This is acceptable for the
+			// headless-agent use case this flag targets. Env-var bootstrap
+			// (PAD_ADMIN_EMAIL / PAD_ADMIN_PASSWORD / PAD_ADMIN_NAME) is the
+			// tracked follow-up (Option A, deferred to a later task).
+			headlessEmail, _ := cmd.Flags().GetString("email")
+			headlessName, _ := cmd.Flags().GetString("name")
+			headlessPassword, _ := cmd.Flags().GetString("password")
+			if headlessEmail != "" || headlessName != "" || headlessPassword != "" {
+				if headlessEmail == "" {
+					return fmt.Errorf("--email is required when using headless bootstrap (--name and --password were provided)")
+				}
+				if headlessName == "" {
+					return fmt.Errorf("--name is required when using headless bootstrap (--email and --password were provided)")
+				}
+				if headlessPassword == "" {
+					return fmt.Errorf("--password is required when using headless bootstrap (--email and --name were provided)")
+				}
+				if err := cli.EnsureServer(cfg); err != nil {
+					return err
+				}
+				client := cli.NewClientFromURL(cfg.BaseURL())
+				return runHeadlessSetup(cfg, client, headlessEmail, headlessName, headlessPassword)
+			}
+
+			// Non-headless paths (browser / --cli-prompt) only work when the
+			// operator is running locally — a remote browser flow would need
+			// the browser on the remote host, and the --cli-prompt path needs
+			// a TTY on the server host.
+			if cfg.IsConfigured() {
+				switch cfg.Mode {
+				case config.ModeRemote, config.ModeCloud:
+					return fmt.Errorf("remote Pad instances must be initialized on the server host with 'pad auth setup'")
+				}
+			}
 
 			if err := cli.EnsureServer(cfg); err != nil {
 				return err
@@ -1194,6 +1230,12 @@ legacy in-terminal email/name/password prompts.`,
 	// concrete blocker shows up. Each --cli-prompt usage is a signal we
 	// should rethink the assumption.
 	cmd.Flags().Bool("cli-prompt", false, "Use the legacy in-terminal email/name/password prompts instead of the browser /setup flow.")
+	// Headless flags for non-interactive (agent) bootstrap (BUG-988).
+	// All three must be supplied together; any one implies the other two.
+	cmd.Flags().String("email", "", "Admin email address (headless bootstrap — requires --name and --password)")
+	cmd.Flags().String("name", "", "Admin display name (headless bootstrap — requires --email and --password)")
+	// NOTE: argv passwords are visible in process listings; see comment in RunE.
+	cmd.Flags().String("password", "", "Admin password (headless bootstrap — requires --email and --name)")
 	return cmd
 }
 
@@ -1265,6 +1307,55 @@ func runCLISetup(cfg *config.Config, client *cli.Client) error {
 	}
 	if err := saveCredentials(cfg, resp); err != nil {
 		return err
+	}
+
+	green := color.New(color.FgGreen).SprintFunc()
+	fmt.Printf("%s First admin account created\n", green("✓"))
+	fmt.Printf("%s Logged in as %s (%s)\n", green("✓"), resp.User.Name, resp.User.Email)
+	printPostSetupNextStepsHint()
+	return nil
+}
+
+// runHeadlessSetup drives the non-interactive (agent) admin bootstrap
+// introduced by BUG-988. It calls the existing POST /api/v1/auth/bootstrap
+// endpoint directly with the supplied credentials and saves the returned
+// session token, bypassing both the browser handoff (TASK-1216) and any
+// interactive prompt. Callers must validate that all three of email/name/
+// password are non-empty before calling here.
+//
+// Output respects --format json: on success it emits a LoginResponse-shaped
+// JSON object (user + token) so agent callers can parse the result. On a
+// non-json format it prints the same human-readable lines as runCLISetup.
+//
+// "already initialized" (conflict from the server) is surfaced as a clean
+// error rather than a raw 409 body; agents can distinguish it by message text.
+func runHeadlessSetup(cfg *config.Config, client *cli.Client, email, name, password string) error {
+	resp, err := client.Bootstrap(email, name, password)
+	if err != nil {
+		// Map the conflict code to a clear human message so agents (and
+		// humans) know what happened without parsing an HTTP status.
+		var apiErr *cli.APIError
+		if errors.As(err, &apiErr) && apiErr.Code == "conflict" {
+			if formatFlag == "json" {
+				outputJSON(map[string]interface{}{
+					"error": map[string]interface{}{
+						"code":    "already_initialized",
+						"message": apiErr.Message,
+					},
+				})
+			}
+			return fmt.Errorf("setup failed: %s (Pad is already initialized — run 'pad auth login' to sign in)", apiErr.Message)
+		}
+		return fmt.Errorf("setup failed: %w", err)
+	}
+
+	if err := saveCredentials(cfg, resp); err != nil {
+		return err
+	}
+
+	if formatFlag == "json" {
+		outputJSON(resp)
+		return nil
 	}
 
 	green := color.New(color.FgGreen).SprintFunc()
@@ -1558,6 +1649,17 @@ const maxAccountSetupAttempts = 5
 // rarely rejects them and re-typing them on every weak-password retry
 // is the primary UX complaint behind BUG-1155.
 func promptAndBootstrap(client *cli.Client) (*cli.LoginResponse, error) {
+	// Guard: refuse to block on a pipe read. An agent or script that
+	// reaches this path without a TTY would hang indefinitely on
+	// reader.ReadString('\n'). Fail fast with a hint pointing at the
+	// headless flags instead (BUG-988).
+	if !term.IsTerminal(int(os.Stdin.Fd())) {
+		return nil, fmt.Errorf(
+			"stdin is not a terminal — cannot prompt for admin credentials.\n" +
+				"Run with --email, --name, and --password for non-interactive bootstrap:\n" +
+				"  pad auth setup --email you@example.com --name \"Your Name\" --password <pass>")
+	}
+
 	reader := bufio.NewReader(os.Stdin)
 
 	fmt.Print("  Email: ")
@@ -1655,15 +1757,18 @@ func printSetupRequiredHint(cfg *config.Config) {
 
 func readPassword() (string, error) {
 	fd := int(os.Stdin.Fd())
+	// Guard: if stdin is not a terminal, term.ReadPassword will fail and
+	// the bufio fallback would block indefinitely on an empty pipe. Fail
+	// fast with a generic error. Callers on the bootstrap path (promptAndBootstrap)
+	// have their own earlier guard that emits bootstrap-specific help text;
+	// this generic guard protects any other caller (e.g. login --interactive)
+	// without leaking bootstrap-specific flag names into an unrelated flow.
+	if !term.IsTerminal(fd) {
+		return "", fmt.Errorf("cannot read password: stdin is not a terminal")
+	}
 	pw, err := term.ReadPassword(fd)
 	if err != nil {
-		// Fallback for non-terminal (pipes, tests)
-		reader := bufio.NewReader(os.Stdin)
-		line, err := reader.ReadString('\n')
-		if err != nil {
-			return "", err
-		}
-		return strings.TrimSpace(line), nil
+		return "", err
 	}
 	return string(pw), nil
 }

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -1321,12 +1321,16 @@ func runCLISetup(cfg *config.Config, client *cli.Client) error {
 // through here, which ensures token reading, the Bootstrap call, credential
 // saving, and SetAuthToken all happen in exactly one place.
 //
-// It reads the on-disk bootstrap token best-effort (absent or unreadable →
-// empty token → loopback-only gate still protects the pure-local case). When
-// present, the token is forwarded as the X-Bootstrap-Token header so the
+// It reads the on-disk bootstrap token with partial best-effort semantics:
+// absent (ErrNotExist) → empty token → loopback gate still guards the
+// pure-local case; any other read error (permissions, corrupt file) is
+// surfaced so the operator can diagnose rather than get a silent 403.
+// When present, the token is forwarded as the X-Bootstrap-Token header so the
 // self-host deployment path (setup_method=logs_token, TASK-1167) works without
 // requiring a separate browser step. Callers must validate that email/name/
 // password are all non-empty before calling here.
+// A 403/forbidden from the server is wrapped with an actionable hint pointing
+// at the loopback gate, token-file path, and PAD_BYPASS_SETUP_TOKEN.
 //
 // On success the caller's client is authenticated (SetAuthToken applied) and
 // credentials are persisted; the LoginResponse is returned so callers can
@@ -1335,12 +1339,24 @@ func runCLISetup(cfg *config.Config, client *cli.Client) error {
 // The "already initialized" conflict is mapped to a clean APIError so callers
 // can detect it via errors.As without parsing HTTP status codes.
 func doHeadlessBootstrap(cfg *config.Config, client *cli.Client, email, name, password string) (*cli.LoginResponse, error) {
-	// Read the on-disk first-run token. Absent or unreadable → empty token →
-	// request proceeds without the header (loopback gate still guards it).
-	bootstrapToken, _ := cli.ReadBootstrapToken(cfg.DataDir)
+	// Read the on-disk first-run token (best-effort).
+	// Absent (os.ErrNotExist) → proceed without the header; the server's
+	// loopback gate still guards pure-local deployments.
+	// Any other error (file exists but unreadable, permissions, etc.) →
+	// surface it so operators can diagnose instead of getting a confusing 403.
+	bootstrapToken, tokenErr := cli.ReadBootstrapToken(cfg.DataDir)
+	if tokenErr != nil && !errors.Is(tokenErr, os.ErrNotExist) {
+		tokenPath := filepath.Join(cfg.DataDir, ".bootstrap-token")
+		return nil, fmt.Errorf("could not read bootstrap token %s: %w", tokenPath, tokenErr)
+	}
 
 	resp, err := client.BootstrapWithToken(email, name, password, bootstrapToken)
 	if err != nil {
+		var apiErr *cli.APIError
+		if errors.As(err, &apiErr) && apiErr.Code == "forbidden" {
+			tokenPath := filepath.Join(cfg.DataDir, ".bootstrap-token")
+			return nil, fmt.Errorf("%w\n\nhint: bootstrap was rejected — this may mean:\n  • the CLI is not running on the server host (loopback gate)\n  • the bootstrap token file is missing or unreadable (%s)\n  • the server started without PAD_BYPASS_SETUP_TOKEN=true\nRe-run on the server host, or ensure the token file is readable", err, tokenPath)
+		}
 		return nil, err
 	}
 	if err := saveCredentials(cfg, resp); err != nil {

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -1316,21 +1316,53 @@ func runCLISetup(cfg *config.Config, client *cli.Client) error {
 	return nil
 }
 
-// runHeadlessSetup drives the non-interactive (agent) admin bootstrap
-// introduced by BUG-988. It calls the existing POST /api/v1/auth/bootstrap
-// endpoint directly with the supplied credentials and saves the returned
-// session token, bypassing both the browser handoff (TASK-1216) and any
-// interactive prompt. Callers must validate that all three of email/name/
-// password are non-empty before calling here.
+// doHeadlessBootstrap is the shared core of the non-interactive (agent)
+// admin bootstrap introduced by BUG-988. Both setupCmd and padInitCmd funnel
+// through here, which ensures token reading, the Bootstrap call, credential
+// saving, and SetAuthToken all happen in exactly one place.
+//
+// It reads the on-disk bootstrap token best-effort (absent or unreadable →
+// empty token → loopback-only gate still protects the pure-local case). When
+// present, the token is forwarded as the X-Bootstrap-Token header so the
+// self-host deployment path (setup_method=logs_token, TASK-1167) works without
+// requiring a separate browser step. Callers must validate that email/name/
+// password are all non-empty before calling here.
+//
+// On success the caller's client is authenticated (SetAuthToken applied) and
+// credentials are persisted; the LoginResponse is returned so callers can
+// format output as they see fit.
+//
+// The "already initialized" conflict is mapped to a clean APIError so callers
+// can detect it via errors.As without parsing HTTP status codes.
+func doHeadlessBootstrap(cfg *config.Config, client *cli.Client, email, name, password string) (*cli.LoginResponse, error) {
+	// Read the on-disk first-run token. Absent or unreadable → empty token →
+	// request proceeds without the header (loopback gate still guards it).
+	bootstrapToken, _ := cli.ReadBootstrapToken(cfg.DataDir)
+
+	resp, err := client.BootstrapWithToken(email, name, password, bootstrapToken)
+	if err != nil {
+		return nil, err
+	}
+	if err := saveCredentials(cfg, resp); err != nil {
+		return nil, err
+	}
+	client.SetAuthToken(resp.Token)
+	return resp, nil
+}
+
+// runHeadlessSetup drives the output layer for `pad auth setup --email …`.
+// It delegates the actual work to doHeadlessBootstrap and then prints the
+// result (respecting --format json) or a clean error.
 //
 // Output respects --format json: on success it emits a LoginResponse-shaped
 // JSON object (user + token) so agent callers can parse the result. On a
 // non-json format it prints the same human-readable lines as runCLISetup.
 //
 // "already initialized" (conflict from the server) is surfaced as a clean
-// error rather than a raw 409 body; agents can distinguish it by message text.
+// error + structured JSON error object (under --format json) so agents get
+// deterministic output in both the fresh and already-initialized cases.
 func runHeadlessSetup(cfg *config.Config, client *cli.Client, email, name, password string) error {
-	resp, err := client.Bootstrap(email, name, password)
+	resp, err := doHeadlessBootstrap(cfg, client, email, name, password)
 	if err != nil {
 		// Map the conflict code to a clear human message so agents (and
 		// humans) know what happened without parsing an HTTP status.
@@ -1347,10 +1379,6 @@ func runHeadlessSetup(cfg *config.Config, client *cli.Client, email, name, passw
 			return fmt.Errorf("setup failed: %s (Pad is already initialized — run 'pad auth login' to sign in)", apiErr.Message)
 		}
 		return fmt.Errorf("setup failed: %w", err)
-	}
-
-	if err := saveCredentials(cfg, resp); err != nil {
-		return err
 	}
 
 	if formatFlag == "json" {
@@ -1757,18 +1785,20 @@ func printSetupRequiredHint(cfg *config.Config) {
 
 func readPassword() (string, error) {
 	fd := int(os.Stdin.Fd())
-	// Guard: if stdin is not a terminal, term.ReadPassword will fail and
-	// the bufio fallback would block indefinitely on an empty pipe. Fail
-	// fast with a generic error. Callers on the bootstrap path (promptAndBootstrap)
-	// have their own earlier guard that emits bootstrap-specific help text;
-	// this generic guard protects any other caller (e.g. login --interactive)
-	// without leaking bootstrap-specific flag names into an unrelated flow.
-	if !term.IsTerminal(fd) {
-		return "", fmt.Errorf("cannot read password: stdin is not a terminal")
-	}
 	pw, err := term.ReadPassword(fd)
 	if err != nil {
-		return "", err
+		// Fallback for non-terminal (pipes, tests). Note: callers on the
+		// bootstrap path reach this only via promptAndBootstrap, which has
+		// an earlier non-TTY guard that returns a clear error before any
+		// read is attempted — so this fallback is never reached for bootstrap.
+		// It remains available for other callers (e.g. login --interactive
+		// used in scripted environments that pipe a password via stdin).
+		reader := bufio.NewReader(os.Stdin)
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			return "", err
+		}
+		return strings.TrimSpace(line), nil
 	}
 	return string(pw), nil
 }

--- a/cmd/pad/setup_headless_test.go
+++ b/cmd/pad/setup_headless_test.go
@@ -1,0 +1,452 @@
+package main
+
+// Tests for the headless (non-interactive) admin bootstrap path introduced by
+// BUG-988. Each test spins up an httptest.Server so no real server process is
+// needed. The cfg is wired in Remote mode so cli.EnsureServer no-ops.
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/PerpetualSoftware/pad/internal/cli"
+	"github.com/PerpetualSoftware/pad/internal/config"
+)
+
+// headlessTestServer builds an httptest.Server that speaks the minimal subset
+// of the Pad API that the headless bootstrap path touches:
+//
+//   - GET  /api/v1/auth/session  → setup_required controlled by setupRequired
+//   - GET  /api/v1/health        → 200 (so EnsureServer sees a live server)
+//   - POST /api/v1/auth/bootstrap → 201 with token+user, or 409 conflict when
+//     alreadyInitialised is true
+func headlessTestServer(t *testing.T, setupRequired bool, alreadyInitialised bool) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/health":
+			w.WriteHeader(http.StatusOK)
+
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/auth/session":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"setup_required": setupRequired,
+				"authenticated":  false,
+				"setup_method":   "local_cli",
+			})
+
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/auth/bootstrap":
+			w.Header().Set("Content-Type", "application/json")
+			if alreadyInitialised {
+				w.WriteHeader(http.StatusConflict)
+				_ = json.NewEncoder(w).Encode(map[string]interface{}{
+					"error": map[string]interface{}{
+						"code":    "conflict",
+						"message": "This Pad instance has already been initialized",
+					},
+				})
+				return
+			}
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"token": "padsess_headless_test",
+				"user": map[string]interface{}{
+					"id":    "user-1",
+					"email": "admin@example.com",
+					"name":  "Test Admin",
+					"role":  "admin",
+				},
+			})
+
+		default:
+			t.Logf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+}
+
+// remoteHeadlessCfg builds a Config wired to point at the given httptest
+// server URL in Remote mode. Remote mode makes EnsureServer a no-op.
+func remoteHeadlessCfg(serverURL string) *config.Config {
+	cfg := config.DefaultConfig()
+	cfg.Mode = config.ModeRemote
+	cfg.URL = serverURL
+	cfg.LoadedFromFile = true
+	return cfg
+}
+
+// isolateHome redirects HOME to a temp dir and chdirs to a fresh temp
+// project dir so credential writes and .pad.toml detection don't leak into
+// the real user environment. Returns the project dir.
+func isolateHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	project := t.TempDir()
+	prev, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(project); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(prev) })
+	return project
+}
+
+// TestHeadlessSetupSuccess verifies the happy path: all three flags supplied,
+// server returns a 201, credentials are saved, and --format json emits a
+// LoginResponse-shaped object containing the expected user and token.
+func TestHeadlessSetupSuccess(t *testing.T) {
+	isolateHome(t)
+	srv := headlessTestServer(t, true /* setup_required */, false)
+	defer srv.Close()
+
+	cfg := remoteHeadlessCfg(srv.URL)
+	client := cli.NewClientFromURL(srv.URL)
+
+	// Capture stdout for JSON assertion
+	orig := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	// Set global formatFlag so runHeadlessSetup emits JSON
+	prevFormat := formatFlag
+	formatFlag = "json"
+	t.Cleanup(func() {
+		formatFlag = prevFormat
+		os.Stdout = orig
+	})
+
+	err := runHeadlessSetup(cfg, client, "admin@example.com", "Test Admin", "correct-horse-battery-staple")
+	w.Close()
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+	os.Stdout = orig
+
+	if err != nil {
+		t.Fatalf("runHeadlessSetup: unexpected error: %v", err)
+	}
+
+	// Verify JSON output shape
+	var result map[string]interface{}
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("json parse of output: %v\noutput was: %s", err, buf.String())
+	}
+	user, ok := result["user"].(map[string]interface{})
+	if !ok || user == nil {
+		t.Fatalf("expected 'user' in JSON output, got: %s", buf.String())
+	}
+	if user["role"] != "admin" {
+		t.Errorf("expected role=admin, got %v", user["role"])
+	}
+	if result["token"] == "" || result["token"] == nil {
+		t.Errorf("expected non-empty token in JSON output, got: %v", result["token"])
+	}
+
+	// Verify credentials were saved
+	store, err := cli.LoadStore()
+	if err != nil {
+		t.Fatalf("load store: %v", err)
+	}
+	creds := store.Get(srv.URL)
+	if creds == nil || creds.Token == "" {
+		t.Error("expected credentials to be saved after headless bootstrap")
+	}
+}
+
+// TestHeadlessSetupMissingFlag verifies that supplying any one or two of the
+// three headless flags — but not all three — produces a clear error naming
+// the missing flag(s), rather than falling through to an interactive prompt
+// or a panic.
+func TestHeadlessSetupMissingFlag(t *testing.T) {
+	cases := []struct {
+		name    string
+		email   string
+		uname   string
+		pass    string
+		wantErr string
+	}{
+		{
+			name:    "only email",
+			email:   "a@b.com",
+			wantErr: "--name is required",
+		},
+		{
+			name:    "only name",
+			uname:   "Admin",
+			wantErr: "--email is required",
+		},
+		{
+			name:    "only password",
+			pass:    "hunter2",
+			wantErr: "--email is required",
+		},
+		{
+			name:    "email and name, missing password",
+			email:   "a@b.com",
+			uname:   "Admin",
+			wantErr: "--password is required",
+		},
+		{
+			name:    "email and password, missing name",
+			email:   "a@b.com",
+			pass:    "hunter2",
+			wantErr: "--name is required",
+		},
+		{
+			name:    "name and password, missing email",
+			uname:   "Admin",
+			pass:    "hunter2",
+			wantErr: "--email is required",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			isolateHome(t)
+			srv := headlessTestServer(t, true, false)
+			defer srv.Close()
+
+			// Build and execute setupCmd with only partial flags
+			cmd := setupCmd()
+			root := &cobra.Command{Use: "pad"}
+			// Attach persistent flags that getConfig/formatFlag reads
+			root.PersistentFlags().StringVar(&formatFlag, "format", "table", "output format")
+			root.PersistentFlags().StringVar(&urlFlag, "url", "", "server URL")
+			root.AddCommand(cmd)
+
+			// Pass --url as a top-level flag so getConfig() picks it up via
+			// urlFlag (which is bound to the root persistent flag).
+			args := []string{"--url", srv.URL, "setup"}
+			if tc.email != "" {
+				args = append(args, "--email", tc.email)
+			}
+			if tc.uname != "" {
+				args = append(args, "--name", tc.uname)
+			}
+			if tc.pass != "" {
+				args = append(args, "--password", tc.pass)
+			}
+			root.SetArgs(args)
+
+			err := root.Execute()
+			if err == nil {
+				t.Fatal("expected error for missing flag, got nil")
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("error %q does not contain expected hint %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestHeadlessSetupNonTTYWithoutFlags verifies that running --cli-prompt on a
+// non-TTY stdin (simulated via a closed pipe) exits with a clear error
+// pointing at the new headless flags rather than blocking on a pipe read.
+func TestHeadlessSetupNonTTYWithoutFlags(t *testing.T) {
+	isolateHome(t)
+	srv := headlessTestServer(t, true, false)
+	defer srv.Close()
+
+	// Replace stdin with a closed reader so term.IsTerminal returns false
+	// and any bufio.ReadString call would hit EOF immediately.
+	pr, pw, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	pw.Close() // EOF immediately on any read
+
+	origStdin := os.Stdin
+	os.Stdin = pr
+	t.Cleanup(func() {
+		os.Stdin = origStdin
+		pr.Close()
+	})
+
+	cfg := remoteHeadlessCfg(srv.URL)
+	client := cli.NewClientFromURL(srv.URL)
+
+	// promptAndBootstrap (reached via runCLISetup) should now reject without
+	// blocking because stdin is not a TTY.
+	_, gotErr := promptAndBootstrap(client)
+	if gotErr == nil {
+		t.Fatal("expected error when stdin is not a terminal, got nil")
+	}
+	if !strings.Contains(gotErr.Error(), "stdin is not a terminal") {
+		t.Errorf("error %q should mention 'stdin is not a terminal'", gotErr.Error())
+	}
+	// Must also point at the headless flags so the agent knows what to use
+	if !strings.Contains(gotErr.Error(), "--email") {
+		t.Errorf("error %q should mention --email flag", gotErr.Error())
+	}
+	_ = cfg // kept for documentation — cfg used indirectly via promptAndBootstrap's error text
+}
+
+// TestHeadlessSetupAlreadyInitialised verifies that when the server reports the
+// instance is already set up (409 conflict), runHeadlessSetup returns a clear
+// error and — under --format json — emits a parseable error object rather than
+// bare output or a raw HTTP body.
+func TestHeadlessSetupAlreadyInitialised(t *testing.T) {
+	isolateHome(t)
+	// alreadyInitialised=true makes the mock bootstrap endpoint return 409
+	srv := headlessTestServer(t, true, true)
+	defer srv.Close()
+
+	cfg := remoteHeadlessCfg(srv.URL)
+	client := cli.NewClientFromURL(srv.URL)
+
+	// Capture stdout
+	origOut := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	prevFormat := formatFlag
+	formatFlag = "json"
+	t.Cleanup(func() {
+		formatFlag = prevFormat
+		os.Stdout = origOut
+	})
+
+	err := runHeadlessSetup(cfg, client, "admin@example.com", "Test Admin", "correct-horse-battery-staple")
+	w.Close()
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+	os.Stdout = origOut
+
+	if err == nil {
+		t.Fatal("expected error for already-initialized instance, got nil")
+	}
+	if !strings.Contains(err.Error(), "already initialized") {
+		t.Errorf("error %q should mention 'already initialized'", err.Error())
+	}
+
+	// JSON output must be parseable and contain an error marker
+	if buf.Len() > 0 {
+		var result map[string]interface{}
+		if jerr := json.Unmarshal(buf.Bytes(), &result); jerr != nil {
+			t.Fatalf("json parse of error output: %v\noutput was: %s", jerr, buf.String())
+		}
+		errObj, ok := result["error"].(map[string]interface{})
+		if !ok || errObj == nil {
+			t.Errorf("expected 'error' object in JSON output, got: %s", buf.String())
+		}
+		if code, _ := errObj["code"].(string); code != "already_initialized" {
+			t.Errorf("expected error.code=already_initialized, got %q", code)
+		}
+	}
+}
+
+// TestHeadlessInitPathSuccess verifies that `pad init` with all three headless
+// flags drives the bootstrap step and then falls through to complete the rest
+// of init — specifically that a workspace is created. An accidental early
+// return after the bootstrap would mean the workspace step never runs, and
+// this test catches that.
+func TestHeadlessInitPathSuccess(t *testing.T) {
+	project := isolateHome(t)
+
+	workspaceCreated := false
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/health":
+			w.WriteHeader(http.StatusOK)
+
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/auth/session":
+			// First call: setup_required. Subsequent calls (after bootstrap):
+			// authenticated so pad init doesn't try to browser-login again.
+			// We detect "after bootstrap" by whether workspaceCreated has
+			// been set yet — simpler: just always return authenticated after
+			// the bootstrap call, which we mark via workspaceCreated-adjacent
+			// state. Use a closure bool instead.
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"setup_required": !workspaceCreated,
+				"authenticated":  workspaceCreated,
+				"setup_method":   "local_cli",
+			})
+
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/auth/bootstrap":
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"token": "padsess_init_test",
+				"user": map[string]interface{}{
+					"id":    "user-1",
+					"email": "admin@example.com",
+					"name":  "Init Admin",
+					"role":  "admin",
+				},
+			})
+
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/workspaces":
+			_ = json.NewEncoder(w).Encode([]interface{}{})
+
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/workspaces":
+			workspaceCreated = true
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"id":   "ws-1",
+				"slug": "test-project",
+				"name": "test-project",
+			})
+
+		default:
+			// Workspace GET, skills, etc. — return safe empty responses
+			t.Logf("init test: %s %s", r.Method, r.URL.Path)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{})
+		}
+	}))
+	defer srv.Close()
+
+	prevFormat := formatFlag
+	formatFlag = "table"
+	t.Cleanup(func() { formatFlag = prevFormat })
+
+	cmd := padInitCmd()
+	root := &cobra.Command{Use: "pad"}
+	root.PersistentFlags().StringVar(&workspaceFlag, "workspace", "", "workspace slug")
+	root.PersistentFlags().StringVar(&urlFlag, "url", "", "server URL")
+	root.PersistentFlags().StringVar(&formatFlag, "format", "table", "output format")
+	root.AddCommand(cmd)
+
+	root.SetArgs([]string{
+		"--url", srv.URL,
+		"init",
+		"test-project",
+		"--email", "admin@example.com",
+		"--name", "Init Admin",
+		"--password", "correct-horse-battery-staple",
+		"--template", "startup",
+	})
+
+	// Suppress output during test
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("pad init: unexpected error: %v (output: %s)", err, out.String())
+	}
+
+	if !workspaceCreated {
+		t.Error("expected workspace to be created after headless bootstrap; got workspaceCreated=false — likely an accidental early return")
+	}
+
+	// Verify credentials saved
+	store, serr := cli.LoadStore()
+	if serr != nil {
+		t.Fatalf("load store: %v", serr)
+	}
+	creds := store.Get(srv.URL)
+	if creds == nil || creds.Token == "" {
+		t.Error("expected credentials to be saved after headless init bootstrap")
+	}
+
+	_ = project // used implicitly by os.Chdir in isolateHome
+}

--- a/cmd/pad/setup_headless_test.go
+++ b/cmd/pad/setup_headless_test.go
@@ -546,12 +546,17 @@ func TestHeadlessSetupNoTokenFileOK(t *testing.T) {
 	}
 }
 
-// TestReadPasswordFallback verifies that readPassword still works when stdin
-// is a pipe (non-TTY) by falling back to a bufio read. This guards against
-// the regression introduced in round 1 where the fallback was removed. The
-// fallback is used by `pad auth login --interactive` in scripted environments
-// that pipe a password via stdin.
-func TestReadPasswordFallback(t *testing.T) {
+// TestReadPasswordBufioFallback verifies that readPassword's bufio fallback
+// returns a line from a non-TTY (pipe) reader. It exercises readPassword IN
+// ISOLATION only — it does NOT cover doInteractiveLogin end-to-end.
+//
+// Known limitation (BUG-1886): doInteractiveLogin constructs its own
+// bufio.Reader on stdin for the email prompt, then readPassword constructs a
+// second independent bufio.Reader on the same fd. Because bufio reads ahead in
+// chunks the first reader can consume bytes belonging to the password line,
+// breaking piped `pad auth login --interactive`. That bug predates BUG-988
+// and is tracked separately.
+func TestReadPasswordBufioFallback(t *testing.T) {
 	pr, pw, err := os.Pipe()
 	if err != nil {
 		t.Fatalf("pipe: %v", err)

--- a/cmd/pad/setup_headless_test.go
+++ b/cmd/pad/setup_headless_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -449,4 +450,131 @@ func TestHeadlessInitPathSuccess(t *testing.T) {
 	}
 
 	_ = project // used implicitly by os.Chdir in isolateHome
+}
+
+// TestHeadlessSetupSendsBootstrapToken verifies that when the DataDir contains
+// a .bootstrap-token file, doHeadlessBootstrap (and thus the headless path of
+// both setup and init) forwards it as the X-Bootstrap-Token header. This is
+// required for self-host deployments where the server uses setup_method=logs_token
+// and would otherwise reject the request with 403 (finding #1 from round-1 codex
+// review).
+func TestHeadlessSetupSendsBootstrapToken(t *testing.T) {
+	isolateHome(t)
+
+	tokenReceived := ""
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/health":
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/auth/bootstrap":
+			tokenReceived = r.Header.Get("X-Bootstrap-Token")
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"token": "padsess_token_test",
+				"user": map[string]interface{}{
+					"id": "u1", "email": "a@b.com", "name": "A", "role": "admin",
+				},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	cfg := remoteHeadlessCfg(srv.URL)
+	// Write a .bootstrap-token file into DataDir so ReadBootstrapToken finds it
+	if err := os.MkdirAll(cfg.DataDir, 0755); err != nil {
+		t.Fatalf("mkdir datadir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cfg.DataDir, ".bootstrap-token"), []byte("test-token-value\n"), 0600); err != nil {
+		t.Fatalf("write bootstrap token: %v", err)
+	}
+
+	client := cli.NewClientFromURL(srv.URL)
+	resp, err := doHeadlessBootstrap(cfg, client, "a@b.com", "A", "correct-horse-battery-staple")
+	if err != nil {
+		t.Fatalf("doHeadlessBootstrap: %v", err)
+	}
+	if resp == nil {
+		t.Fatal("expected non-nil response")
+	}
+	if tokenReceived != "test-token-value" {
+		t.Errorf("expected X-Bootstrap-Token=test-token-value, got %q", tokenReceived)
+	}
+}
+
+// TestHeadlessSetupNoTokenFileOK verifies that when no .bootstrap-token file
+// exists, doHeadlessBootstrap silently omits the header (best-effort) and the
+// request still succeeds — covering the pure-loopback case where no token is
+// required.
+func TestHeadlessSetupNoTokenFileOK(t *testing.T) {
+	isolateHome(t)
+
+	tokenReceived := "sentinel" // will be overwritten to "" if no header sent
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/health":
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/auth/bootstrap":
+			tokenReceived = r.Header.Get("X-Bootstrap-Token")
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"token": "padsess_notoken_test",
+				"user": map[string]interface{}{
+					"id": "u1", "email": "a@b.com", "name": "A", "role": "admin",
+				},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	cfg := remoteHeadlessCfg(srv.URL)
+	// DataDir does NOT contain a .bootstrap-token file
+	client := cli.NewClientFromURL(srv.URL)
+	_, err := doHeadlessBootstrap(cfg, client, "a@b.com", "A", "correct-horse-battery-staple")
+	if err != nil {
+		t.Fatalf("doHeadlessBootstrap without token file: %v", err)
+	}
+	if tokenReceived != "" {
+		t.Errorf("expected no X-Bootstrap-Token header when file absent, got %q", tokenReceived)
+	}
+}
+
+// TestReadPasswordFallback verifies that readPassword still works when stdin
+// is a pipe (non-TTY) by falling back to a bufio read. This guards against
+// the regression introduced in round 1 where the fallback was removed. The
+// fallback is used by `pad auth login --interactive` in scripted environments
+// that pipe a password via stdin.
+func TestReadPasswordFallback(t *testing.T) {
+	pr, pw, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+
+	// Write the password before switching stdin (pipe buffer is large enough)
+	if _, err := pw.WriteString("my-piped-password\n"); err != nil {
+		t.Fatalf("write password to pipe: %v", err)
+	}
+	pw.Close()
+
+	origStdin := os.Stdin
+	os.Stdin = pr
+	t.Cleanup(func() {
+		os.Stdin = origStdin
+		pr.Close()
+	})
+
+	got, err := readPassword()
+	if err != nil {
+		t.Fatalf("readPassword with piped input: %v", err)
+	}
+	if got != "my-piped-password" {
+		t.Errorf("readPassword = %q, want %q", got, "my-piped-password")
+	}
 }

--- a/internal/cli/bootstrap.go
+++ b/internal/cli/bootstrap.go
@@ -199,7 +199,10 @@ func ReadBootstrapToken(dataDir string) (string, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return "", fmt.Errorf("bootstrap token file %s not found — the server may have already consumed it, or token generation failed at startup. Re-run with --cli-prompt to use the legacy TTY flow", path)
+			// Wrap with %w so callers can errors.Is(err, os.ErrNotExist) to
+			// distinguish "file absent" from other read failures (e.g. to
+			// treat absence as best-effort rather than a hard error).
+			return "", fmt.Errorf("bootstrap token file %s not found (%w) — the server may have already consumed it, or token generation failed at startup. Re-run with --cli-prompt to use the legacy TTY flow", path, os.ErrNotExist)
 		}
 		return "", fmt.Errorf("read bootstrap token %s: %w (re-run with --cli-prompt to use the legacy TTY flow)", path, err)
 	}

--- a/internal/cli/bootstrap.go
+++ b/internal/cli/bootstrap.go
@@ -165,7 +165,7 @@ func buildBootstrapURL(cfg *config.Config, setupMethod, next string) (string, er
 
 	switch setupMethod {
 	case "logs_token":
-		token, err := readBootstrapToken(cfg.DataDir)
+		token, err := ReadBootstrapToken(cfg.DataDir)
 		if err != nil {
 			return "", err
 		}
@@ -182,7 +182,7 @@ func buildBootstrapURL(cfg *config.Config, setupMethod, next string) (string, er
 	}
 }
 
-// readBootstrapToken reads <DataDir>/.bootstrap-token. The file is created
+// ReadBootstrapToken reads <DataDir>/.bootstrap-token. The file is created
 // by EnsureBootstrapToken in internal/server/bootstrap.go with mode 0600
 // and contains the base64url-encoded token followed by a trailing newline.
 //
@@ -191,7 +191,10 @@ func buildBootstrapURL(cfg *config.Config, setupMethod, next string) (string, er
 // resolves to. The "--cli-prompt" hint is appended because that's the
 // recoverable fallback for every failure mode here (file consumed already,
 // permissions wrong, DataDir on a read-only mount).
-func readBootstrapToken(dataDir string) (string, error) {
+//
+// Callers that want a best-effort token (absent → empty, not an error) should
+// ignore the returned error and use the token only when non-empty.
+func ReadBootstrapToken(dataDir string) (string, error) {
 	path := filepath.Join(dataDir, bootstrapTokenFilename)
 	data, err := os.ReadFile(path)
 	if err != nil {

--- a/internal/cli/bootstrap_test.go
+++ b/internal/cli/bootstrap_test.go
@@ -48,7 +48,7 @@ func newTestConfig(t *testing.T, browserURL string) *config.Config {
 
 // writeBootstrapToken drops a token file at <dataDir>/.bootstrap-token in
 // the same shape EnsureBootstrapToken would produce — token + trailing
-// newline, mode 0600 — so readBootstrapToken sees what it expects.
+// newline, mode 0600 — so ReadBootstrapToken sees what it expects.
 func writeBootstrapToken(t *testing.T, dataDir, token string) {
 	t.Helper()
 	path := filepath.Join(dataDir, bootstrapTokenFilename)
@@ -373,11 +373,11 @@ func TestReadBootstrapToken_TrimsTrailingNewline(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, bootstrapTokenFilename), []byte("hello-token\n"), 0600); err != nil {
 		t.Fatalf("write token: %v", err)
 	}
-	got, err := readBootstrapToken(dir)
+	got, err := ReadBootstrapToken(dir)
 	if err != nil {
-		t.Fatalf("readBootstrapToken: %v", err)
+		t.Fatalf("ReadBootstrapToken: %v", err)
 	}
 	if got != "hello-token" {
-		t.Errorf("readBootstrapToken = %q, want %q", got, "hello-token")
+		t.Errorf("ReadBootstrapToken = %q, want %q", got, "hello-token")
 	}
 }

--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -875,13 +875,41 @@ func (c *Client) Register(email, name, password string) (*LoginResponse, error) 
 
 // Bootstrap creates the first admin account on a fresh instance.
 func (c *Client) Bootstrap(email, name, password string) (*LoginResponse, error) {
-	var result LoginResponse
-	err := c.post("/auth/bootstrap", map[string]string{
+	return c.BootstrapWithToken(email, name, password, "")
+}
+
+// BootstrapWithToken is like Bootstrap but sends token as the
+// X-Bootstrap-Token header when token is non-empty. This is required for
+// self-host deployments where the server generated a first-run token (the
+// "logs_token" setup_method path — TASK-1167). Pass an empty string on
+// pure-loopback deployments where the header is not required.
+func (c *Client) BootstrapWithToken(email, name, password, token string) (*LoginResponse, error) {
+	data, err := json.Marshal(map[string]string{
 		"email":    email,
 		"name":     name,
 		"password": password,
-	}, &result)
-	return &result, err
+	})
+	if err != nil {
+		return nil, err
+	}
+	req, err := c.newRequest("POST", "/auth/bootstrap", bytes.NewReader(data))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if token != "" {
+		req.Header.Set("X-Bootstrap-Token", token)
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	var result LoginResponse
+	if err := c.handleResponse(resp, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
 }
 
 // CLIAuthSessionResponse is the response from POST /auth/cli/sessions.


### PR DESCRIPTION
## Summary

Additive headless admin bootstrap for agents. Adds `--email/--name/--password` flags to `pad auth setup` and `pad init` that drive the existing `POST /api/v1/auth/bootstrap` endpoint (threading `X-Bootstrap-Token`), bypassing the browser handoff and interactive prompts. The browser-handoff flow (BUG-1843) remains the unchanged human default. Also includes non-TTY wedge hardening on the bootstrap path, `--format json` end-state on `pad auth setup`, and a shared `doHeadlessBootstrap` helper.

## Plus (architectural decisions)

- **Additive to BUG-1843 browser handoff** — the human default is untouched, byte-for-byte.
- **Shared `doHeadlessBootstrap` helper** — `setup` and `init` can't diverge.
- **X-Bootstrap-Token threaded** via new `cli.Client.BootstrapWithToken`; `Bootstrap` delegates with an empty token, giving an identical wire format for existing callers.
- **`ReadBootstrapToken` exported** + `%w`-wrapped `ErrNotExist` (all callers use `errors.Is`).
- **Non-TTY guard** lives only at the top of `promptAndBootstrap`; `readPassword` keeps its original `bufio` fallback.

## Observable behavior changes

- New flags (all three required together; `--email` implies `--name` + `--password`).
- Non-TTY without flags now errors with an actionable hint instead of wedging.
- `pad auth setup --format json` emits a `LoginResponse`-shaped object.
- Conflict (already-initialized) surfaces a clean error / `{"error":{"code":"already_initialized"}}` under json.
- 403 surfaces an actionable loopback / token / `PAD_BYPASS_SETUP_TOKEN` hint.

## Test plan

- [x] `go test ./...` (SQLite)
- [x] `make test-pg` (Postgres)
- [x] `make lint`
- [x] New tests: headless success + JSON shape
- [x] Missing-flag validation
- [x] Non-TTY guard
- [x] Already-initialized conflict
- [x] Full `pad init` headless end-to-end incl. workspace creation
- [x] `X-Bootstrap-Token` sent when token file present
- [x] Header absent when no file
- [x] `readPassword` bufio fallback in isolation

## Known limitations / follow-ups

- `--password` is visible in argv (acceptable for headless-agent use; env-var bootstrap `PAD_ADMIN_*` is the deferred Option A follow-up).
- `pad init --format json` intentionally does **not** emit machine-readable bootstrap output (multi-step flow — agents should use `pad auth setup --email… --format json`).
- Pre-existing `doInteractiveLogin` double-`bufio.Reader` bug filed as **BUG-1886** (predates this PR, out of scope).
- Minor: `doHeadlessBootstrap` builds the token path with a literal `.bootstrap-token` rather than the unexported `internal/cli` constant (cosmetic mirror).

## Refs

BUG-988; follow-up BUG-1886.
