### PR TITLE
fix(cli): share stdin reader in login so piped --interactive works (BUG-1886)

### DIFF
--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -1604,7 +1604,9 @@ func doInteractiveLogin(client *cli.Client, cfg *config.Config) error {
 	email = strings.TrimSpace(email)
 
 	fmt.Print("  Password: ")
-	password, err := readPassword()
+	// Share `reader` with the email/2FA reads above and below — a second
+	// bufio.Reader on os.Stdin would miss piped bytes already buffered (BUG-1886).
+	password, err := readPasswordFrom(reader)
 	if err != nil {
 		return fmt.Errorf("read password: %w", err)
 	}
@@ -1800,17 +1802,28 @@ func printSetupRequiredHint(cfg *config.Config) {
 }
 
 func readPassword() (string, error) {
+	return readPasswordFrom(bufio.NewReader(os.Stdin))
+}
+
+// readPasswordFrom reads a password without echo when stdin is a TTY, and
+// otherwise falls back to reading a line from the supplied bufio.Reader.
+//
+// Callers that ALSO read other lines from stdin (e.g. doInteractiveLogin reads
+// email and 2FA codes) MUST pass the SAME bufio.Reader they used for those
+// reads. A bufio.Reader buffers in chunks, so a second independent reader on
+// os.Stdin can miss bytes the first reader already buffered past its newline —
+// that double-reader bug broke piped `login --interactive` (BUG-1886). Sharing
+// one reader keeps the stream consistent across reads.
+//
+// On the bootstrap path this fallback is never reached: promptAndBootstrap has
+// an earlier non-TTY guard that returns a clear error before any read. The
+// fallback exists for non-TTY callers like scripted `login --interactive` that
+// pipe a password via stdin.
+func readPasswordFrom(fallback *bufio.Reader) (string, error) {
 	fd := int(os.Stdin.Fd())
 	pw, err := term.ReadPassword(fd)
 	if err != nil {
-		// Fallback for non-terminal (pipes, tests). Note: callers on the
-		// bootstrap path reach this only via promptAndBootstrap, which has
-		// an earlier non-TTY guard that returns a clear error before any
-		// read is attempted — so this fallback is never reached for bootstrap.
-		// It remains available for other callers (e.g. login --interactive
-		// used in scripted environments that pipe a password via stdin).
-		reader := bufio.NewReader(os.Stdin)
-		line, err := reader.ReadString('\n')
+		line, err := fallback.ReadString('\n')
 		if err != nil {
 			return "", err
 		}

--- a/cmd/pad/setup_headless_test.go
+++ b/cmd/pad/setup_headless_test.go
@@ -5,6 +5,7 @@ package main
 // needed. The cfg is wired in Remote mode so cli.EnsureServer no-ops.
 
 import (
+	"bufio"
 	"bytes"
 	"encoding/json"
 	"net/http"
@@ -547,15 +548,9 @@ func TestHeadlessSetupNoTokenFileOK(t *testing.T) {
 }
 
 // TestReadPasswordBufioFallback verifies that readPassword's bufio fallback
-// returns a line from a non-TTY (pipe) reader. It exercises readPassword IN
-// ISOLATION only — it does NOT cover doInteractiveLogin end-to-end.
-//
-// Known limitation (BUG-1886): doInteractiveLogin constructs its own
-// bufio.Reader on stdin for the email prompt, then readPassword constructs a
-// second independent bufio.Reader on the same fd. Because bufio reads ahead in
-// chunks the first reader can consume bytes belonging to the password line,
-// breaking piped `pad auth login --interactive`. That bug predates BUG-988
-// and is tracked separately.
+// returns a line from a non-TTY (pipe) reader, exercising readPassword in
+// isolation. The shared-reader integration (doInteractiveLogin's email-then-
+// password sequence) is covered by TestReadPasswordFromSharedReader below.
 func TestReadPasswordBufioFallback(t *testing.T) {
 	pr, pw, err := os.Pipe()
 	if err != nil {
@@ -581,5 +576,43 @@ func TestReadPasswordBufioFallback(t *testing.T) {
 	}
 	if got != "my-piped-password" {
 		t.Errorf("readPassword = %q, want %q", got, "my-piped-password")
+	}
+}
+
+// TestReadPasswordFromSharedReader reproduces the doInteractiveLogin sequence
+// that BUG-1886 broke: read an email line from a bufio.Reader, then read the
+// password from the SAME reader. With piped "email\npassword\n", the first
+// ReadString buffers past its newline (bufio reads in chunks), so a second
+// independent reader on os.Stdin would hit EOF and lose the password. Sharing
+// the reader via readPasswordFrom keeps the stream consistent.
+func TestReadPasswordFromSharedReader(t *testing.T) {
+	pr, pw, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	if _, err := pw.WriteString("user@example.com\nshared-secret\n"); err != nil {
+		t.Fatalf("write to pipe: %v", err)
+	}
+	pw.Close()
+
+	origStdin := os.Stdin
+	os.Stdin = pr
+	t.Cleanup(func() {
+		os.Stdin = origStdin
+		pr.Close()
+	})
+
+	reader := bufio.NewReader(os.Stdin)
+	email, _ := reader.ReadString('\n')
+	if got := strings.TrimSpace(email); got != "user@example.com" {
+		t.Fatalf("email = %q, want %q", got, "user@example.com")
+	}
+
+	got, err := readPasswordFrom(reader)
+	if err != nil {
+		t.Fatalf("readPasswordFrom after email read: %v", err)
+	}
+	if got != "shared-secret" {
+		t.Errorf("readPasswordFrom = %q, want %q (BUG-1886 regression — a fresh reader would lose this)", got, "shared-secret")
 	}
 }


### PR DESCRIPTION
## Summary
`doInteractiveLogin` read the email line with one `bufio.Reader`, then `readPassword` constructed a **second** independent `bufio.Reader` on `os.Stdin`. Because bufio reads in chunks, the first reader buffers past its newline and swallows the password line — breaking piped `pad auth login --interactive` (the password read sees EOF/empty).

Pre-existing bug (predates BUG-988; BUG-988 restored the fallback byte-for-byte, did not introduce it). Filed as BUG-1886 during the BUG-988 review and deferred for scope.

## Plus
- New `readPasswordFrom(fallback *bufio.Reader)`: TTY path uses `term.ReadPassword` **unchanged** (no echo); non-TTY path reads from the **supplied** reader instead of a new one.
- `doInteractiveLogin` now shares its single `reader` across email, password, and 2FA reads.
- `readPassword()` retained as a fresh-reader wrapper for `promptAndBootstrap`'s two (TTY-guarded) calls — behavior identical.

## Observable behavior change
- Piped `pad auth login --interactive` (`printf 'email\npassword\n' | pad auth login -i`) now reads the password correctly instead of failing.
- Interactive TTY login unchanged.

## Test plan
- [x] `go test ./...` (SQLite)
- [x] `make test-pg` (Postgres)
- [x] `make lint` (golangci-lint, 0 issues)
- [x] New `TestReadPasswordFromSharedReader` reproduces the email-then-password sequence (fails with a fresh reader, passes with the shared one)
- [x] `TestReadPasswordBufioFallback` retained (isolation), comment updated

## Refs
BUG-1886.

https://claude.ai/code/session_01WK9cUjxniBBAihGD5ygjDr