### PR TITLE
feat(server): add webmcp_enabled platform setting + session flag

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -232,7 +232,7 @@ Both are also returned by `pad://_meta/version` and `pad_meta.action: version`.
 **Dispatchers.** Two ship in `internal/mcp/`:
 
 - `ExecDispatcher` — shells out to the `pad` binary; subprocess inherits credentials from `~/.pad/credentials.json`. Used by `pad mcp serve` for local stdio MCP.
-- `HTTPHandlerDispatcher` — calls pad-cloud's HTTP handlers in-process with the requesting user attached via `server.WithCurrentUser`. Used by the future `/mcp` endpoint (PLAN-943) where the dispatcher serves multiple OAuth users from a single process. Tools are wired into the route table at `internal/mcp/dispatch_http.go` (`routeTable`); add a `RouteMapper` per command — `mapItemCreate` is the seed entry from TASK-965.
+- `HTTPHandlerDispatcher` — calls pad-cloud's HTTP handlers in-process with the requesting user attached via `server.WithCurrentUser`. Backs the **live** remote MCP server on the dedicated `mcp.getpad.dev` vhost (PLAN-943), where the dispatcher serves multiple OAuth users from a single process. The Streamable HTTP transport is mounted by `Server.SetMCPTransport` / `registerMCPRoutes` (cloud-mode-gated; self-hosted binaries leave it unmounted) — see `internal/server/handlers_mcp.go`. Tools are wired into the route table at `internal/mcp/dispatch_http.go` (`routeTable`); add a `RouteMapper` per command — `mapItemCreate` is the seed entry from TASK-965.
 
 Code lives in `internal/mcp/` (built on `github.com/mark3labs/mcp-go`). Public docs at `getpad.dev/mcp/local`.
 

--- a/internal/server/handlers_admin.go
+++ b/internal/server/handlers_admin.go
@@ -19,6 +19,10 @@ const (
 	// Token policy settings
 	settingTokenDefaultExpiryDays = "token_default_expiry_days" // Default: 90
 	settingTokenMaxLifetimeDays   = "token_max_lifetime_days"   // Default: 0 (no limit)
+
+	// WebMCP opt-in. "true" enables the browser-side WebMCP surface; any other
+	// value (including unset) means disabled. Default off (PLAN-1888 DR-6).
+	settingWebMCPEnabled = "webmcp_enabled"
 )
 
 // handleGetPlatformSettings returns all platform settings.
@@ -34,6 +38,12 @@ func (s *Server) handleGetPlatformSettings(w http.ResponseWriter, r *http.Reques
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to load settings")
 		return
+	}
+
+	// Surface webmcp_enabled with an explicit default so the admin UI toggle
+	// always has a value to bind to on a fresh instance (PLAN-1888 DR-6).
+	if _, ok := settings[settingWebMCPEnabled]; !ok {
+		settings[settingWebMCPEnabled] = "false"
 	}
 
 	// Mask sensitive values
@@ -70,6 +80,7 @@ func (s *Server) handleUpdatePlatformSettings(w http.ResponseWriter, r *http.Req
 		settingPlatformName:           true,
 		settingTokenDefaultExpiryDays: true,
 		settingTokenMaxLifetimeDays:   true,
+		settingWebMCPEnabled:          true,
 	}
 
 	for key, value := range input {

--- a/internal/server/handlers_auth.go
+++ b/internal/server/handlers_auth.go
@@ -137,6 +137,17 @@ func (s *Server) setupStatePayload(setupMethod string) map[string]interface{} {
 	}
 }
 
+// webMCPEnabled reports whether the WebMCP browser surface is opted in via the
+// webmcp_enabled platform setting. Fails closed: any read error or an unset/
+// non-"true" value yields false (PLAN-1888 DR-6).
+func (s *Server) webMCPEnabled() bool {
+	v, err := s.store.GetPlatformSetting(settingWebMCPEnabled)
+	if err != nil {
+		return false
+	}
+	return v == "true"
+}
+
 func (s *Server) sessionStatePayload(authenticated bool, user *models.User) map[string]interface{} {
 	// mcp_public_url is the canonical URL clients paste into their MCP-capable
 	// agent (e.g. "https://mcp.getpad.dev"). Empty string when PAD_MCP_PUBLIC_URL
@@ -160,6 +171,11 @@ func (s *Server) sessionStatePayload(authenticated bool, user *models.User) map[
 		"email_configured":  s.email != nil,
 		"mcp_public_url":    s.mcpPublicURL,
 		"billing_available": s.cloudMode && s.billingAvailable,
+		// webmcp_enabled gates the browser-side WebMCP surface. Read from the
+		// platform_settings kv table; default false when unset/absent or on
+		// any read error (fail closed). The web client uses it to decide
+		// whether to register tools via document.modelContext (PLAN-1888 DR-6).
+		"webmcp_enabled": s.webMCPEnabled(),
 		// version is the server build version (same source as /health),
 		// surfaced here so the mobile shells can read it in the
 		// /auth/session call they already make on connect and warn when a

--- a/internal/server/handlers_webmcp_setting_test.go
+++ b/internal/server/handlers_webmcp_setting_test.go
@@ -1,0 +1,113 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+// TestWebMCPSetting_AdminPatchPersistsAndSessionReflects pins TASK-1889 /
+// PLAN-1888 Phase 1: the webmcp_enabled platform setting is admin-writable
+// through the settings whitelist, defaults to false on a fresh instance, and
+// is surfaced in the /api/v1/auth/session payload reflecting the stored value.
+func TestWebMCPSetting_AdminPatchPersistsAndSessionReflects(t *testing.T) {
+	srv := testServer(t)
+	adminToken := bootstrapFirstUser(t, srv, "admin@test.com", "Admin")
+
+	// Fresh instance: session must report webmcp_enabled=false.
+	rr := doRequestWithCookie(srv, "GET", "/api/v1/auth/session", nil, adminToken)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("session: status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	enabled, ok := sessionWebMCPEnabled(t, rr.Body.Bytes())
+	if !ok {
+		t.Fatalf("session payload missing webmcp_enabled; body=%s", rr.Body.String())
+	}
+	if enabled {
+		t.Errorf("fresh instance: webmcp_enabled=%v, want false", enabled)
+	}
+
+	// Admin GET /admin/settings should surface the default explicitly.
+	rr = doRequestWithCookie(srv, "GET", "/api/v1/admin/settings", nil, adminToken)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("get settings: status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	var settings map[string]string
+	if err := json.Unmarshal(rr.Body.Bytes(), &settings); err != nil {
+		t.Fatalf("decode settings: %v body=%s", err, rr.Body.String())
+	}
+	if settings["webmcp_enabled"] != "false" {
+		t.Errorf("get settings: webmcp_enabled=%q, want \"false\"", settings["webmcp_enabled"])
+	}
+
+	// Admin PATCH enables it.
+	rr = doRequestWithCookie(srv, "PATCH", "/api/v1/admin/settings",
+		map[string]any{"webmcp_enabled": "true"}, adminToken)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("patch settings: status=%d body=%s", rr.Code, rr.Body.String())
+	}
+
+	// Stored value should now be "true".
+	got, err := srv.store.GetPlatformSetting("webmcp_enabled")
+	if err != nil {
+		t.Fatalf("GetPlatformSetting: %v", err)
+	}
+	if got != "true" {
+		t.Errorf("stored webmcp_enabled=%q, want \"true\"", got)
+	}
+
+	// Session now reflects the enabled value.
+	rr = doRequestWithCookie(srv, "GET", "/api/v1/auth/session", nil, adminToken)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("session after enable: status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	enabled, ok = sessionWebMCPEnabled(t, rr.Body.Bytes())
+	if !ok {
+		t.Fatalf("session payload missing webmcp_enabled after enable; body=%s", rr.Body.String())
+	}
+	if !enabled {
+		t.Errorf("after enable: webmcp_enabled=%v, want true", enabled)
+	}
+}
+
+// TestWebMCPSetting_NonAdminForbidden pins that a non-admin can't toggle the
+// webmcp_enabled setting through the admin PATCH endpoint.
+func TestWebMCPSetting_NonAdminForbidden(t *testing.T) {
+	srv := testServer(t)
+	bootstrapFirstUser(t, srv, "admin@test.com", "Admin")
+	memberToken := registerNonAdmin(t, srv, "member@test.com", "Member")
+
+	rr := doRequestWithCookie(srv, "PATCH", "/api/v1/admin/settings",
+		map[string]any{"webmcp_enabled": "true"}, memberToken)
+	if rr.Code != http.StatusForbidden {
+		t.Errorf("non-admin patch: status=%d, want 403", rr.Code)
+	}
+
+	// The setting must remain unset (fail-closed default false).
+	got, err := srv.store.GetPlatformSetting("webmcp_enabled")
+	if err != nil {
+		t.Fatalf("GetPlatformSetting: %v", err)
+	}
+	if got == "true" {
+		t.Errorf("webmcp_enabled persisted=%q after forbidden patch, want unset/false", got)
+	}
+}
+
+// sessionWebMCPEnabled extracts the webmcp_enabled bool from a session payload.
+// The second return value reports whether the key was present.
+func sessionWebMCPEnabled(t *testing.T, body []byte) (bool, bool) {
+	t.Helper()
+	var payload map[string]any
+	if err := json.Unmarshal(body, &payload); err != nil {
+		t.Fatalf("decode session payload: %v body=%s", err, body)
+	}
+	raw, ok := payload["webmcp_enabled"]
+	if !ok {
+		return false, false
+	}
+	enabled, isBool := raw.(bool)
+	if !isBool {
+		t.Fatalf("webmcp_enabled is %T, want bool", raw)
+	}
+	return enabled, true
+}

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -389,6 +389,11 @@ export interface AuthSession {
 	// it in the call they already make on connect (IDEA-1826). Empty string only
 	// when no version was stamped at build time; "dev" on dev builds.
 	version?: string;
+	// webmcp_enabled gates the browser-side WebMCP surface (PLAN-1888 DR-6).
+	// The web client registers document.modelContext tools only when true.
+	// Absent on older servers and default false on fresh instances — treat
+	// absent as false.
+	webmcp_enabled?: boolean;
 	user?: { id: string; email: string; username: string; name: string; role: string; plan?: string };
 }
 

--- a/web/src/routes/console/admin/settings/+page.svelte
+++ b/web/src/routes/console/admin/settings/+page.svelte
@@ -28,6 +28,8 @@
 	let platformSettings = $state<Record<string, string>>({});
 	let savingPlatform = $state(false);
 	let platformStatus = $state<'idle' | 'saved' | 'error'>('idle');
+	let savingIntegrations = $state(false);
+	let integrationsStatus = $state<'idle' | 'saved' | 'error'>('idle');
 	let testingEmail = $state(false);
 	let testEmailResult = $state<{ message: string; type: 'success' | 'error' } | null>(null);
 
@@ -77,6 +79,19 @@
 			platformStatus = 'error';
 		} finally {
 			savingPlatform = false;
+		}
+	}
+
+	async function saveIntegrations() {
+		savingIntegrations = true;
+		integrationsStatus = 'idle';
+		try {
+			await adminPatch('/admin/settings', { webmcp_enabled: platformSettings.webmcp_enabled ?? 'false' });
+			integrationsStatus = 'saved';
+		} catch {
+			integrationsStatus = 'error';
+		} finally {
+			savingIntegrations = false;
 		}
 	}
 
@@ -251,6 +266,43 @@
 				</div>
 			{/if}
 		</section>
+
+		<section class="section">
+			<h2 class="section-title">Integrations</h2>
+			<p class="section-desc">
+				WebMCP lets browser-based AI agents invoke Pad tools — including item create, update,
+				delete, and import — under your full logged-in web session. Per-invocation browser consent is
+				the only WebMCP-specific guard on destructive actions, and platform-admin sessions reach all
+				workspaces. Disabled by default; enable only if you understand the risk.
+			</p>
+
+			<div class="email-card">
+				<label class="toggle-row">
+					<input
+						type="checkbox"
+						checked={platformSettings.webmcp_enabled === 'true'}
+						onchange={(e) => {
+							platformSettings = {
+								...platformSettings,
+								webmcp_enabled: e.currentTarget.checked ? 'true' : 'false'
+							};
+						}}
+					/>
+					<span>Enable WebMCP (browser AI agent tools)</span>
+				</label>
+
+				<div class="edit-actions">
+					<button class="btn primary" disabled={savingIntegrations} onclick={saveIntegrations}>
+						{savingIntegrations ? 'Saving...' : 'Save Integrations'}
+					</button>
+					{#if integrationsStatus === 'saved'}
+						<span class="save-msg">Saved</span>
+					{:else if integrationsStatus === 'error'}
+						<span class="save-msg">Failed to save</span>
+					{/if}
+				</div>
+			</div>
+		</section>
 	{/if}
 </div>
 
@@ -403,5 +455,17 @@
 		font-weight: 600;
 		color: var(--text-primary);
 		margin: 0;
+	}
+
+	.toggle-row {
+		display: flex;
+		align-items: center;
+		gap: var(--space-2);
+		font-size: 0.85rem;
+		color: var(--text-primary);
+		cursor: pointer;
+	}
+	.toggle-row input[type='checkbox'] {
+		cursor: pointer;
 	}
 </style>


### PR DESCRIPTION
## Summary

Phase 1 of [[WebMCP]] (PLAN-1888, TASK-1889): introduce the opt-in gate for the browser-side WebMCP surface. No browser code yet — just the kill switch (DR-6, default off).

Adds a `webmcp_enabled` platform setting:
- **Default off**, admin-writable via the existing `/api/v1/admin/settings` PATCH whitelist.
- Surfaced to the web client via the `/api/v1/auth/session` payload so future client-side tool registration can gate on it.

## Changes

- `internal/server/handlers_admin.go` — add `settingWebMCPEnabled` to the admin-PATCH **whitelist** (else silently dropped) + serialize a `"false"` default in the GET settings response so the admin UI toggle always has a value to bind.
- `internal/server/handlers_auth.go` — emit `webmcp_enabled` in the session payload via a fail-closed `webMCPEnabled()` helper (false on unset/absent/read error).
- `web/src/lib/api/client.ts` — add `webmcp_enabled?: boolean` to the `AuthSession` type.
- `web/.../console/admin/settings/+page.svelte` — new "Integrations" section with a WebMCP toggle + the Phase 4 security-warning copy (browser agents invoke create/update/delete/import under the full web session; per-invocation consent is the only WebMCP-specific guard; admin sessions reach all workspaces). The Integrations Save PATCHes **only** `{webmcp_enabled}` so it can't overwrite the masked `maileroo_api_key` placeholder (Codex review fix).
- `internal/server/handlers_webmcp_setting_test.go` — new Go tests.

No migration — `platform_settings` is an existing kv table.

## Acceptance criteria met

- [x] `PATCH /api/v1/admin/settings {"webmcp_enabled":"true"}` as admin persists; non-admin gets 403.
- [x] `GET /api/v1/auth/session` returns `webmcp_enabled` reflecting the stored value (default false on a fresh instance).
- [x] `AuthSession` TS type compiles with the new field; admin UI toggle round-trips.
- [x] Go test covering the admin PATCH whitelist + session payload field.

## Gates

- `make check` → **PASS** (golangci-lint, `go test ./...`, vuln, web-check). The only vuln output is pre-existing dompurify/markdown-it npm advisories (unrelated; non-fatal, exit 0).
- `cd web && npm run check` → **PASS** (0 errors).
- No `make test-pg` needed (no store schema change).

## Review

Codex CLI review: **VERDICT: CLEAN** after 2 rounds. Round 1 caught a real P1 — the Integrations Save initially PATCHed the whole `platformSettings` object, which would persist the masked `maileroo_api_key` placeholder and corrupt the real key. Fixed by sending only `{webmcp_enabled}` from the Integrations save path.

Refs TASK-1889 / PLAN-1888

https://claude.ai/code/session_01KmxkPxLksjf1pmrZDpsnTJ