### PR TITLE
feat(server): expose MCP tool-surface over authed REST endpoint

### DIFF
--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -415,6 +415,16 @@ func serveCmd() *cobra.Command {
 			srv.SetIPChangeEnforce(cfg.IPChangeEnforce)
 			srv.SetSSELimits(cfg.SSEMaxConnections, cfg.SSEMaxPerWorkspace)
 
+			// MCP tool-surface descriptor endpoint (PLAN-1888 / TASK-1891).
+			// Inject the cycle-free catalog→JSON serializer so the authed
+			// GET /api/v1/mcp/tool-surface route can serve it. Wired here
+			// (not in the cloud block) because the browser-side WebMCP layer
+			// needs the descriptors on BOTH cloud and self-host. Mirrors the
+			// SetMCPTransport injection: internal/server can't import
+			// internal/mcp (cycle), so cmd/pad — which imports both — hands
+			// the serializer down. Must be set before setupRouter runs.
+			srv.SetToolSurfaceHandler(mcpserver.ToolSurfaceJSON)
+
 			// Billing CTA gate (TASK-800). PAD_BILLING_AVAILABLE=true when
 			// the pad-cloud sidecar has Stripe keys configured so the web UI
 			// can show "Upgrade to Pro" buttons. Defaults to false so a fresh

--- a/internal/mcp/catalog_meta.go
+++ b/internal/mcp/catalog_meta.go
@@ -150,77 +150,15 @@ func actionMetaBootstrap(ctx context.Context, input map[string]any, env ActionEn
 // docs generators: they don't have to reproduce buildToolFromDef's
 // implicit-param logic separately.
 func actionMetaToolSurface(_ context.Context, _ map[string]any, env ActionEnv) (*mcp.CallToolResult, error) {
-	type actionSummary struct {
-		Name string `json:"name"`
-	}
-	type paramSummary struct {
-		Name        string   `json:"name"`
-		Type        string   `json:"type"`
-		Description string   `json:"description,omitempty"`
-		Enum        []string `json:"enum,omitempty"`
-	}
-	type toolSummary struct {
-		Name        string          `json:"name"`
-		Description string          `json:"description"`
-		Workspace   bool            `json:"workspace"`
-		Actions     []actionSummary `json:"actions"`
-		Params      []paramSummary  `json:"params"`
-	}
-	tools := make([]toolSummary, 0, len(env.Catalog))
-	for _, def := range env.Catalog {
-		actions := make([]actionSummary, 0, len(def.Actions))
-		for _, name := range sortedActionNames(def) {
-			actions = append(actions, actionSummary{Name: name})
-		}
-		// `action` is always present and always required — buildToolFromDef
-		// injects it into the schema. Synthesize it here so consumers
-		// reading tool-surface get the full param picture without having
-		// to know about that injection. Enum mirrors sortedActionNames.
-		params := []paramSummary{{
-			Name:        "action",
-			Type:        "string",
-			Description: "The action to perform. Required.",
-			Enum:        sortedActionNames(def),
-		}}
-		if def.Schema.Workspace {
-			params = append(params, paramSummary{
-				Name: "workspace",
-				Type: "string",
-				Description: "Workspace slug. Defaults to the session workspace " +
-					"set via pad_set_workspace, then to the CWD-linked workspace " +
-					"from .pad.toml.",
-			})
-		}
-		for _, p := range def.Schema.Params {
-			params = append(params, paramSummary{
-				Name:        p.Name,
-				Type:        p.Type,
-				Description: p.Description,
-				Enum:        p.Enum,
-			})
-		}
-		tools = append(tools, toolSummary{
-			Name:        def.Name,
-			Description: def.Description,
-			Workspace:   def.Schema.Workspace,
-			Actions:     actions,
-			Params:      params,
-		})
-	}
-	// rollout_status is "complete" only after TASK-981 retires the
-	// cmdhelp walker and the catalog is the sole tools/list source.
-	// Before then, "in-progress" signals to consumers that the catalog
-	// is a strict subset of the advertised surface and they should
-	// read tools/list directly if they need everything.
-	rolloutStatus := "in-progress"
-	if ToolSurfaceVersion != "0.1" {
-		rolloutStatus = "complete"
-	}
-	payload := map[string]any{
-		"tool_surface_version": ToolSurfaceVersion,
-		"rollout_status":       rolloutStatus,
-		"tools":                tools,
-	}
+	// Shared serializer (TASK-1891): buildToolSurfacePayload is the
+	// single source of truth for the tool-surface shape, consumed by
+	// both this MCP action and the cycle-free ToolSurfaceJSON() that
+	// backs GET /api/v1/mcp/tool-surface. env.Catalog is the same slice
+	// as the package-global Catalog at registration time; passing it
+	// explicitly keeps the action reading the env it was wired with.
+	// Each action now carries a `read_only` bool — additive metadata,
+	// so consumers that ignore unknown keys are unaffected.
+	payload := buildToolSurfacePayload(env.Catalog)
 	body, err := json.Marshal(payload)
 	if err != nil {
 		return mcp.NewToolResultErrorf("pad_meta.tool-surface: marshal: %s", err.Error()), nil

--- a/internal/mcp/tool_surface.go
+++ b/internal/mcp/tool_surface.go
@@ -1,0 +1,219 @@
+package mcp
+
+import "encoding/json"
+
+// tool_surface.go — the cycle-free catalog→JSON serializer (PLAN-1888 /
+// TASK-1891, DR-3). Builds the same tool-surface descriptor blob that
+// pad_meta.action: tool-surface emits, PLUS a per-action `read_only`
+// bool, directly from the package-global Catalog. No server types, no
+// ActionEnv — so cmd/pad/main.go can build an http.Handler from this
+// and inject it into *server.Server without internal/server having to
+// import internal/mcp (which would close the import cycle —
+// internal/mcp already imports internal/server via dispatch_http.go).
+//
+// Why a per-action read_only flag (DR-2): WebMCP's readOnlyHint is
+// per-TOOL, but the fat catalog tools straddle read+write (pad_item
+// mixes show/list AND create/update/delete). The browser layer
+// (Phase 3) derives readOnlyHint=true only when EVERY action a tool
+// exposes is a read. Emitting the per-action bool here keeps that
+// derivation a lookup rather than a re-derivation of the read set in
+// TypeScript. The read set lives in Go (readOnlyActions below) as the
+// single source of truth.
+
+// toolSurfaceActionSummary is one action entry in the serialized
+// surface. Adds `read_only` to the existing {name} shape — additive,
+// so any consumer of pad_meta.action: tool-surface that ignores unknown
+// keys is unaffected (DR-7: no ToolSurfaceVersion bump).
+type toolSurfaceActionSummary struct {
+	Name     string `json:"name"`
+	ReadOnly bool   `json:"read_only"`
+}
+
+type toolSurfaceParamSummary struct {
+	Name        string   `json:"name"`
+	Type        string   `json:"type"`
+	Description string   `json:"description,omitempty"`
+	Enum        []string `json:"enum,omitempty"`
+}
+
+type toolSurfaceToolSummary struct {
+	Name        string                     `json:"name"`
+	Description string                     `json:"description"`
+	Workspace   bool                       `json:"workspace"`
+	Actions     []toolSurfaceActionSummary `json:"actions"`
+	Params      []toolSurfaceParamSummary  `json:"params"`
+}
+
+// readOnlyActions is the allowlist of (tool, action) pairs that perform
+// no mutation — pure reads / introspection. Co-located with the catalog
+// (DR-2) and consulted by the serializer to stamp each action's
+// `read_only` bool. Keyed by tool name → set of read-only action names.
+//
+// Anything NOT listed here is treated as a write (the safe default —
+// a missing entry produces read_only=false, so a forgotten mutating
+// action never silently advertises as read-only). Confirmed against the
+// catalog_*.go ToolDefs:
+//
+//   - pad_item:       get/list/deps/starred/list-comments/backlinks/export read;
+//     create/update/delete/move/restore/link/unlink/star/unstar/
+//     comment/bulk-update/note/decide/import write.
+//   - pad_workspace:  list/members/storage/audit-log read; invite/create/claim write.
+//   - pad_collection: list read; create/update/delete write.
+//   - pad_project:    all read (dashboard/next/standup/changelog/report).
+//   - pad_role:       list read; create/update/delete write.
+//   - pad_search:     query read.
+//   - pad_playbook:   list/get read; run is side-effect-free (returns the
+//     body + bound args for the agent to execute) → read.
+//   - pad_library:    list/get read; activate mutates workspace state → write.
+//   - pad_meta:       server-info/version/tool-surface/bootstrap all read.
+var readOnlyActions = map[string]map[string]bool{
+	"pad_item": {
+		"get":           true,
+		"list":          true,
+		"deps":          true,
+		"starred":       true,
+		"list-comments": true,
+		"backlinks":     true,
+		"export":        true,
+	},
+	"pad_workspace": {
+		"list":      true,
+		"members":   true,
+		"storage":   true,
+		"audit-log": true,
+	},
+	"pad_collection": {
+		"list": true,
+	},
+	"pad_project": {
+		"dashboard": true,
+		"next":      true,
+		"standup":   true,
+		"changelog": true,
+		"report":    true,
+	},
+	"pad_role": {
+		"list": true,
+	},
+	"pad_search": {
+		"query": true,
+	},
+	"pad_playbook": {
+		"list": true,
+		"get":  true,
+		"run":  true,
+	},
+	"pad_library": {
+		"list": true,
+		"get":  true,
+	},
+	"pad_meta": {
+		"server-info":  true,
+		"version":      true,
+		"tool-surface": true,
+		"bootstrap":    true,
+	},
+}
+
+// isReadOnlyAction reports whether (toolName, action) performs no
+// mutation. Defaults to false (write) for any pair not in the
+// allowlist — the conservative direction.
+func isReadOnlyAction(toolName, action string) bool {
+	actions, ok := readOnlyActions[toolName]
+	if !ok {
+		return false
+	}
+	return actions[action]
+}
+
+// buildToolSurfaceTools projects a catalog slice into the serialized
+// per-tool summaries. Shared by ToolSurfaceJSON (the REST/browser path)
+// and actionMetaToolSurface (the MCP path) so the two surfaces can't
+// drift. The synthesized param list mirrors buildToolFromDef's
+// implicit-param logic (action enum first, optional workspace, then the
+// declared ParamDefs) so the dump is self-contained for consumers.
+func buildToolSurfaceTools(catalog []ToolDef) []toolSurfaceToolSummary {
+	tools := make([]toolSurfaceToolSummary, 0, len(catalog))
+	for _, def := range catalog {
+		actionNames := sortedActionNames(def)
+		actions := make([]toolSurfaceActionSummary, 0, len(actionNames))
+		for _, name := range actionNames {
+			actions = append(actions, toolSurfaceActionSummary{
+				Name:     name,
+				ReadOnly: isReadOnlyAction(def.Name, name),
+			})
+		}
+		// `action` is always present and always required — buildToolFromDef
+		// injects it into the schema. Synthesize it here so consumers get
+		// the full param picture. Enum mirrors sortedActionNames.
+		params := []toolSurfaceParamSummary{{
+			Name:        "action",
+			Type:        "string",
+			Description: "The action to perform. Required.",
+			Enum:        actionNames,
+		}}
+		if def.Schema.Workspace {
+			params = append(params, toolSurfaceParamSummary{
+				Name: "workspace",
+				Type: "string",
+				Description: "Workspace slug. Defaults to the session workspace " +
+					"set via pad_set_workspace, then to the CWD-linked workspace " +
+					"from .pad.toml.",
+			})
+		}
+		for _, p := range def.Schema.Params {
+			params = append(params, toolSurfaceParamSummary{
+				Name:        p.Name,
+				Type:        p.Type,
+				Description: p.Description,
+				Enum:        p.Enum,
+			})
+		}
+		tools = append(tools, toolSurfaceToolSummary{
+			Name:        def.Name,
+			Description: def.Description,
+			Workspace:   def.Schema.Workspace,
+			Actions:     actions,
+			Params:      params,
+		})
+	}
+	return tools
+}
+
+// buildToolSurfacePayload assembles the full tool-surface document
+// (version + rollout status + tools) from a catalog slice. The payload
+// shape is identical to what actionMetaToolSurface emitted pre-TASK-1891
+// except every action now carries `read_only`.
+func buildToolSurfacePayload(catalog []ToolDef) map[string]any {
+	// rollout_status mirrors the historical actionMetaToolSurface logic:
+	// "complete" once the cmdhelp leaf walker retired (any version past
+	// the initial 0.1). Kept for backwards compatibility with consumers
+	// that branched on it during the v0.1→v0.2 retirement.
+	rolloutStatus := "in-progress"
+	if ToolSurfaceVersion != "0.1" {
+		rolloutStatus = "complete"
+	}
+	return map[string]any{
+		"tool_surface_version": ToolSurfaceVersion,
+		"rollout_status":       rolloutStatus,
+		"tools":                buildToolSurfaceTools(catalog),
+	}
+}
+
+// ToolSurfaceJSON serializes the package-global Catalog into the
+// tool-surface descriptor JSON — the same blob pad_meta.action:
+// tool-surface emits, plus a per-action `read_only` bool. Cycle-free:
+// reads only the in-package Catalog + readOnlyActions, no server types.
+//
+// cmd/pad/main.go builds an http.Handler from this and injects it into
+// *server.Server (the SetMCPTransport pattern) so the
+// GET /api/v1/mcp/tool-surface endpoint can serve it without
+// internal/server importing internal/mcp.
+//
+// Scope is the nine env.Catalog tools (pad_item, pad_workspace,
+// pad_collection, pad_project, pad_role, pad_search, pad_playbook,
+// pad_meta, pad_library). pad_set_workspace is registered separately
+// (registry.go) and is NOT in Catalog, so it's naturally excluded.
+func ToolSurfaceJSON() ([]byte, error) {
+	return json.Marshal(buildToolSurfacePayload(Catalog))
+}

--- a/internal/mcp/tool_surface_test.go
+++ b/internal/mcp/tool_surface_test.go
@@ -1,0 +1,189 @@
+package mcp
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// toolSurfaceDoc is the decoded shape of ToolSurfaceJSON's output —
+// just the fields these tests assert on.
+type toolSurfaceDoc struct {
+	ToolSurfaceVersion string `json:"tool_surface_version"`
+	RolloutStatus      string `json:"rollout_status"`
+	Tools              []struct {
+		Name      string `json:"name"`
+		Workspace bool   `json:"workspace"`
+		Actions   []struct {
+			Name     string `json:"name"`
+			ReadOnly bool   `json:"read_only"`
+		} `json:"actions"`
+		Params []struct {
+			Name string   `json:"name"`
+			Type string   `json:"type"`
+			Enum []string `json:"enum,omitempty"`
+		} `json:"params"`
+	} `json:"tools"`
+}
+
+func decodeToolSurface(t *testing.T) toolSurfaceDoc {
+	t.Helper()
+	body, err := ToolSurfaceJSON()
+	if err != nil {
+		t.Fatalf("ToolSurfaceJSON: %v", err)
+	}
+	var doc toolSurfaceDoc
+	if err := json.Unmarshal(body, &doc); err != nil {
+		t.Fatalf("unmarshal: %v\nbody: %s", err, body)
+	}
+	return doc
+}
+
+// TestToolSurfaceJSON_MirrorsCatalog locks the cycle-free serializer to
+// the package-global Catalog: one entry per tool, version stamped,
+// pad_set_workspace excluded (it's not in Catalog).
+func TestToolSurfaceJSON_MirrorsCatalog(t *testing.T) {
+	doc := decodeToolSurface(t)
+
+	if doc.ToolSurfaceVersion != ToolSurfaceVersion {
+		t.Errorf("tool_surface_version = %q, want %q", doc.ToolSurfaceVersion, ToolSurfaceVersion)
+	}
+	if len(doc.Tools) != len(Catalog) {
+		t.Fatalf("tools length = %d, want %d (one per Catalog entry)", len(doc.Tools), len(Catalog))
+	}
+	for _, tl := range doc.Tools {
+		if tl.Name == "pad_set_workspace" {
+			t.Errorf("pad_set_workspace must not appear (registered separately, not in Catalog)")
+		}
+	}
+	// Every Catalog entry must be present by name.
+	byName := map[string]bool{}
+	for _, tl := range doc.Tools {
+		byName[tl.Name] = true
+	}
+	for _, def := range Catalog {
+		if !byName[def.Name] {
+			t.Errorf("Catalog tool %q missing from ToolSurfaceJSON output", def.Name)
+		}
+	}
+}
+
+// TestToolSurfaceJSON_ReadOnlyFlags asserts each action carries a
+// read_only bool that matches the readOnlyActions allowlist — and
+// spot-checks a few known read vs write actions so the set can't drift
+// silently. Mixed tools (pad_item) must expose BOTH a read-only=true and
+// a read-only=false action so the Phase 3 browser layer correctly
+// withholds the readOnlyHint.
+func TestToolSurfaceJSON_ReadOnlyFlags(t *testing.T) {
+	doc := decodeToolSurface(t)
+
+	// Build (tool, action) → read_only from the serialized output.
+	got := map[[2]string]bool{}
+	for _, tl := range doc.Tools {
+		for _, a := range tl.Actions {
+			got[[2]string{tl.Name, a.Name}] = a.ReadOnly
+			// Every action's read_only must equal the allowlist lookup —
+			// proves the serializer consults readOnlyActions, not some
+			// other (drifting) source.
+			if want := isReadOnlyAction(tl.Name, a.Name); a.ReadOnly != want {
+				t.Errorf("%s.%s read_only = %v, want %v (per readOnlyActions)",
+					tl.Name, a.Name, a.ReadOnly, want)
+			}
+		}
+	}
+
+	// Spot-check known reads.
+	reads := [][2]string{
+		{"pad_item", "get"},
+		{"pad_item", "list"},
+		{"pad_item", "backlinks"},
+		{"pad_item", "export"},
+		{"pad_project", "dashboard"},
+		{"pad_search", "query"},
+		{"pad_meta", "tool-surface"},
+		{"pad_library", "get"},
+		{"pad_playbook", "run"},
+	}
+	for _, k := range reads {
+		v, ok := got[k]
+		if !ok {
+			t.Errorf("%s.%s absent from surface", k[0], k[1])
+			continue
+		}
+		if !v {
+			t.Errorf("%s.%s expected read_only=true", k[0], k[1])
+		}
+	}
+
+	// Spot-check known writes.
+	writes := [][2]string{
+		{"pad_item", "create"},
+		{"pad_item", "delete"},
+		{"pad_item", "import"},
+		{"pad_collection", "create"},
+		{"pad_workspace", "invite"},
+		{"pad_library", "activate"},
+	}
+	for _, k := range writes {
+		v, ok := got[k]
+		if !ok {
+			t.Errorf("%s.%s absent from surface", k[0], k[1])
+			continue
+		}
+		if v {
+			t.Errorf("%s.%s expected read_only=false", k[0], k[1])
+		}
+	}
+
+	// pad_item is a mixed tool — it must carry at least one read AND one
+	// write so DR-2's "all-read ⇒ readOnlyHint" derivation withholds the
+	// hint for it.
+	var sawRead, sawWrite bool
+	for _, tl := range doc.Tools {
+		if tl.Name != "pad_item" {
+			continue
+		}
+		for _, a := range tl.Actions {
+			if a.ReadOnly {
+				sawRead = true
+			} else {
+				sawWrite = true
+			}
+		}
+	}
+	if !sawRead || !sawWrite {
+		t.Errorf("pad_item should be mixed: sawRead=%v sawWrite=%v", sawRead, sawWrite)
+	}
+}
+
+// TestReadOnlyActions_NoStaleEntries guards against drift: readOnlyActions
+// is an allowlist (only reads listed; absence ⇒ write), so we can't
+// require every action to appear. We CAN require the reverse — every
+// (tool, action) listed as read-only must still exist in the live
+// Catalog, so a removed/renamed read action doesn't leave a stale
+// entry silently advertising a non-existent action as read-only.
+func TestReadOnlyActions_NoStaleEntries(t *testing.T) {
+	live := map[[2]string]bool{}
+	knownTool := map[string]bool{}
+	for _, def := range Catalog {
+		knownTool[def.Name] = true
+		for action := range def.Actions {
+			live[[2]string{def.Name, action}] = true
+		}
+	}
+	for tool, set := range readOnlyActions {
+		if !knownTool[tool] {
+			t.Errorf("readOnlyActions has tool %q not in Catalog (stale entry)", tool)
+			continue
+		}
+		for action, ro := range set {
+			if !ro {
+				t.Errorf("readOnlyActions[%s][%s] is false — the allowlist should only list reads (omit writes)",
+					tool, action)
+			}
+			if !live[[2]string{tool, action}] {
+				t.Errorf("readOnlyActions[%s][%s] has no matching Catalog action (stale entry)",
+					tool, action)
+			}
+		}
+	}
+}

--- a/internal/server/handlers_mcp.go
+++ b/internal/server/handlers_mcp.go
@@ -85,6 +85,49 @@ func (s *Server) SetMCPTransport(transport http.Handler, mcpPublicURL, authServe
 	s.startMCPSessionTracker()
 }
 
+// SetToolSurfaceHandler wires the MCP catalog→JSON serializer onto the
+// server (PLAN-1888 / TASK-1891). Called once at startup by
+// cmd/pad/main.go with mcp.ToolSurfaceJSON.
+//
+// Why injection rather than a direct import: internal/mcp imports
+// internal/server (dispatch_http.go), so internal/server cannot import
+// internal/mcp to build the catalog descriptor JSON itself — that would
+// close the import cycle. This is the exact SetMCPTransport pattern:
+// cmd/pad/main.go imports both packages and hands the serializer down.
+//
+// Unlike SetMCPTransport, the tool-surface endpoint mounts
+// unconditionally inside the authed API group (it's available on both
+// cloud and self-host — the browser WebMCP layer needs it everywhere),
+// so this can be called any time before the first request. When the
+// serializer is nil (never injected), handleMCPToolSurface returns 404.
+func (s *Server) SetToolSurfaceHandler(fn func() ([]byte, error)) {
+	s.toolSurfaceJSON = fn
+}
+
+// handleMCPToolSurface serves the MCP tool-surface descriptor JSON —
+// the nine catalog tools, their actions (each with a read_only bool),
+// and their input schemas. Backs GET /api/v1/mcp/tool-surface, mounted
+// in the authed API group so it inherits the session/token auth chain.
+//
+// The body is built entirely by the injected serializer
+// (mcp.ToolSurfaceJSON), which reads only the static MCP catalog. No
+// request state, route table, or other server internals reach the
+// response — the endpoint exposes catalog descriptors and nothing else.
+func (s *Server) handleMCPToolSurface(w http.ResponseWriter, _ *http.Request) {
+	if s.toolSurfaceJSON == nil {
+		writeError(w, http.StatusNotFound, "not_found", "MCP tool surface not available")
+		return
+	}
+	body, err := s.toolSurfaceJSON()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "failed to serialize MCP tool surface")
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(body)
+}
+
 // registerMCPRoutes installs the /mcp + /.well-known endpoints on r,
 // gated by cloud mode. Called from setupRouter at infrastructure-
 // middleware level (NOT inside the API group), because:

--- a/internal/server/handlers_mcp_tool_surface_test.go
+++ b/internal/server/handlers_mcp_tool_surface_test.go
@@ -1,0 +1,167 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+// toolSurfaceFixture is a minimal stand-in for the real
+// mcp.ToolSurfaceJSON serializer. internal/server can't import
+// internal/mcp (import cycle — see SetToolSurfaceHandler), so the test
+// injects its own serializer producing the same shape: the catalog's
+// nine tools, each action carrying a read_only bool. This validates the
+// endpoint wiring (auth gating, injection, JSON passthrough, no
+// leakage) independently of the real catalog's contents — exactly the
+// boundary the production injection crosses.
+func toolSurfaceFixture() ([]byte, error) {
+	// Shape mirrors mcp/tool_surface.go's buildToolSurfacePayload: the
+	// nine env.Catalog tools (pad_set_workspace is registered separately
+	// and excluded), each with read_only-annotated actions.
+	type action struct {
+		Name     string `json:"name"`
+		ReadOnly bool   `json:"read_only"`
+	}
+	type tool struct {
+		Name    string   `json:"name"`
+		Actions []action `json:"actions"`
+	}
+	names := []string{
+		"pad_item", "pad_workspace", "pad_collection", "pad_project",
+		"pad_role", "pad_search", "pad_meta", "pad_playbook", "pad_library",
+	}
+	tools := make([]tool, 0, len(names))
+	for _, n := range names {
+		tools = append(tools, tool{
+			Name:    n,
+			Actions: []action{{Name: "list", ReadOnly: true}, {Name: "create", ReadOnly: false}},
+		})
+	}
+	return json.Marshal(map[string]any{
+		"tool_surface_version": "0.7",
+		"rollout_status":       "complete",
+		"tools":                tools,
+	})
+}
+
+// TestMCPToolSurface_RequiresAuth pins the auth gate: with a user
+// present (no fresh-install bypass), an unauthenticated GET must 401.
+func TestMCPToolSurface_RequiresAuth(t *testing.T) {
+	srv := testServer(t)
+	srv.SetToolSurfaceHandler(toolSurfaceFixture)
+
+	// Create the first admin so RequireAuth no longer waves everything
+	// through under the fresh-install (UserCount==0) bypass.
+	bootstrapFirstUser(t, srv, "admin@test.com", "Admin")
+
+	rr := doRequest(srv, "GET", "/api/v1/mcp/tool-surface", nil)
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("unauthenticated: expected 401, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+// TestMCPToolSurface_AuthedReturnsCatalog pins the happy path: an
+// authenticated caller gets 200 with the nine catalog tools and
+// read_only flags present on every action.
+func TestMCPToolSurface_AuthedReturnsCatalog(t *testing.T) {
+	srv := testServer(t)
+	srv.SetToolSurfaceHandler(toolSurfaceFixture)
+
+	token := bootstrapFirstUser(t, srv, "admin@test.com", "Admin")
+
+	rr := doRequestWithCookie(srv, "GET", "/api/v1/mcp/tool-surface", nil, token)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("authed: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var resp struct {
+		ToolSurfaceVersion string `json:"tool_surface_version"`
+		Tools              []struct {
+			Name    string `json:"name"`
+			Actions []struct {
+				Name     string `json:"name"`
+				ReadOnly bool   `json:"read_only"`
+			} `json:"actions"`
+		} `json:"tools"`
+	}
+	parseJSON(t, rr, &resp)
+
+	if resp.ToolSurfaceVersion == "" {
+		t.Error("expected tool_surface_version in payload")
+	}
+
+	// Exactly the nine env.Catalog tools — pad_set_workspace excluded.
+	const wantTools = 9
+	if len(resp.Tools) != wantTools {
+		t.Fatalf("expected %d catalog tools, got %d", wantTools, len(resp.Tools))
+	}
+	expected := map[string]bool{
+		"pad_item": false, "pad_workspace": false, "pad_collection": false,
+		"pad_project": false, "pad_role": false, "pad_search": false,
+		"pad_meta": false, "pad_playbook": false, "pad_library": false,
+	}
+	for _, tl := range resp.Tools {
+		if _, ok := expected[tl.Name]; !ok {
+			t.Errorf("unexpected tool %q in surface", tl.Name)
+			continue
+		}
+		expected[tl.Name] = true
+		if len(tl.Actions) == 0 {
+			t.Errorf("tool %q: expected at least one action", tl.Name)
+		}
+		// pad_set_workspace must never appear.
+		if tl.Name == "pad_set_workspace" {
+			t.Errorf("pad_set_workspace leaked into the catalog surface")
+		}
+	}
+	for name, seen := range expected {
+		if !seen {
+			t.Errorf("expected catalog tool %q missing from surface", name)
+		}
+	}
+}
+
+// TestMCPToolSurface_NoLeakage asserts the response carries only catalog
+// descriptors — no internal route table, handler internals, or other
+// server state. The fixture body is a closed set of keys; the endpoint
+// must pass it through verbatim and add nothing.
+func TestMCPToolSurface_NoLeakage(t *testing.T) {
+	srv := testServer(t)
+	srv.SetToolSurfaceHandler(toolSurfaceFixture)
+
+	token := bootstrapFirstUser(t, srv, "admin@test.com", "Admin")
+
+	rr := doRequestWithCookie(srv, "GET", "/api/v1/mcp/tool-surface", nil, token)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("authed: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var top map[string]json.RawMessage
+	parseJSON(t, rr, &top)
+
+	allowed := map[string]bool{
+		"tool_surface_version": true,
+		"rollout_status":       true,
+		"tools":                true,
+	}
+	for k := range top {
+		if !allowed[k] {
+			t.Errorf("unexpected top-level key %q in tool-surface response (possible state leak)", k)
+		}
+	}
+}
+
+// TestMCPToolSurface_NotWired pins the nil-serializer path: when
+// SetToolSurfaceHandler was never called, the endpoint 404s rather than
+// panicking or returning an empty 200.
+func TestMCPToolSurface_NotWired(t *testing.T) {
+	srv := testServer(t)
+	// Intentionally NOT calling SetToolSurfaceHandler.
+
+	token := bootstrapFirstUser(t, srv, "admin@test.com", "Admin")
+
+	rr := doRequestWithCookie(srv, "GET", "/api/v1/mcp/tool-surface", nil, token)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("not-wired: expected 404, got %d: %s", rr.Code, rr.Body.String())
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -86,6 +86,15 @@ type Server struct {
 	mcpPublicURL     string // canonical public URL of the MCP vhost (e.g. https://mcp.getpad.dev)
 	mcpAuthServerURL string // canonical URL of the OAuth auth server (e.g. https://app.getpad.dev), TASK-951
 
+	// MCP tool-surface descriptor source (PLAN-1888 / TASK-1891). Wired
+	// via SetToolSurfaceHandler at startup from mcp.ToolSurfaceJSON. The
+	// injection mirrors SetMCPTransport and exists for the same reason:
+	// internal/mcp imports internal/server (dispatch_http.go), so this
+	// package CANNOT import internal/mcp to build the catalog JSON
+	// itself. cmd/pad/main.go imports both and injects the serializer.
+	// nil → GET /api/v1/mcp/tool-surface returns 404 (handler not wired).
+	toolSurfaceJSON func() ([]byte, error)
+
 	// OAuth 2.1 authorization server (PLAN-943 TASK-1024 sub-PR B,
 	// HTTP handlers in TASK-1025 sub-PR C). Wired via SetOAuthServer
 	// at startup when the deployment is in cloud mode + has the
@@ -1309,6 +1318,18 @@ func (s *Server) setupRouter() {
 
 			// Search
 			r.Get("/search", s.handleSearch)
+
+			// MCP tool-surface descriptor (PLAN-1888 / TASK-1891). Serves
+			// the catalog JSON (the nine env.Catalog tools + per-action
+			// read_only flags) for the browser-side WebMCP layer to build
+			// tool descriptors. Inside the authed group so it inherits
+			// TokenAuth/SessionAuth/CSRFProtect/RequireAuth — same-origin
+			// session/token only, NOT the bearer-gated /mcp infra path.
+			// The handler nil-checks toolSurfaceJSON: 404 when the
+			// serializer hasn't been injected (mirrors the SetMCPTransport
+			// gating). Exposes only catalog descriptors — no route table,
+			// handler internals, or other server state.
+			r.Get("/mcp/tool-surface", s.handleMCPToolSurface)
 		})
 
 		// Cross-workspace wiki-link resolver (IDEA-1492). Resolves


### PR DESCRIPTION
## Summary

Adds `GET /api/v1/mcp/tool-surface`, a session/token-authenticated same-origin endpoint that serves the MCP catalog descriptor JSON — the nine `env.Catalog` tools (`pad_item`, `pad_workspace`, `pad_collection`, `pad_project`, `pad_role`, `pad_search`, `pad_meta`, `pad_playbook`, `pad_library`), their actions, and input schemas — with a new **per-action `read_only` bool**. Backs Phase 2 of the WebMCP plan (PLAN-1888): the browser-side layer fetches this once and derives `readOnlyHint` from `read_only` instead of re-deriving the read set in TypeScript.

## How (import-cycle constraint, DR-3)

`internal/mcp` already imports `internal/server` (`dispatch_http.go`), so `internal/server` **cannot** import `internal/mcp`. Wired via the established `SetMCPTransport` injection pattern:

- `internal/mcp/tool_surface.go` — new cycle-free `ToolSurfaceJSON()` builds the descriptor blob from the package-global `Catalog` plus a co-located `readOnlyActions` allowlist (consulted by the serializer). No server types.
- `internal/server` — new injectable `toolSurfaceJSON func() ([]byte, error)` field + `SetToolSurfaceHandler` setter + `handleMCPToolSurface`; route mounted in the **authed API group** (inherits `TokenAuth`/`SessionAuth`/`CSRFProtect`/`RequireAuth`) — NOT the bearer-gated `/mcp` infra path. nil serializer → 404.
- `cmd/pad/main.go` — injects `mcp.ToolSurfaceJSON` via `SetToolSurfaceHandler` before `setupRouter`, same ordering contract as `SetMCPTransport`. Wired unconditionally (both cloud and self-host, per DR-6).
- The existing `actionMetaToolSurface` (`pad_meta action=tool-surface`) now shares the same serializer, so MCP and REST can't drift; it gains the additive `read_only` flag too.

## Acceptance criteria met

- Authenticated GET returns the 9 catalog tools (pad_set_workspace excluded), each action carrying `read_only`.
- Unauthenticated GET → 401 (inherits the API group's auth).
- Exposes only catalog descriptors — no route table / handler internals / server state.
- `internal/server` still does not import `internal/mcp`: verified with `go list -deps github.com/PerpetualSoftware/pad/internal/server | grep internal/mcp` → no match; build passes.
- DR-7: **no `ToolSurfaceVersion` bump** — adding `read_only` is additive metadata; names/actions/params unchanged.

## Tests

- `internal/server/handlers_mcp_tool_surface_test.go` — 401 unauth, 200 authed (9 tools, read_only present), no-leakage (closed top-level key set), 404 when serializer not wired.
- `internal/mcp/tool_surface_test.go` — serializer mirrors Catalog, read_only flags match the allowlist (spot-checked reads/writes + pad_item is mixed), no stale allowlist entries.

## Gate results

- `make check` = **PASS** (golangci-lint clean, all `go test ./...` ok, govulncheck "No vulnerabilities found", web-check 0 errors).
- `cd web && npm run check` = **PASS** (0 errors).
- No `make test-pg` (no store/migration change).
- Codex self-review: **VERDICT: CLEAN** (round 1).

Refs TASK-1891 / PLAN-1888

https://claude.ai/code/session_01KmxkPxLksjf1pmrZDpsnTJ