### PR TITLE
feat(web): WebMCP browser module — register catalog tools (read dispatch)

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -52,7 +52,8 @@
 				"svelte": "^5.55.5",
 				"svelte-check": "^4.4.7",
 				"typescript": "^6.0.3",
-				"vite": "^8.0.11"
+				"vite": "^8.0.11",
+				"vitest": "3.2.6"
 			}
 		},
 		"node_modules/@antfu/install-pkg": {
@@ -136,6 +137,448 @@
 			"optional": true,
 			"dependencies": {
 				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@esbuild/aix-ppc64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+			"integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"aix"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-arm": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+			"integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+			"integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+			"integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/darwin-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+			"integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/darwin-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+			"integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/freebsd-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+			"integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/freebsd-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+			"integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-arm": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+			"integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+			"integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-ia32": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+			"integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-loong64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+			"integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-mips64el": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+			"integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+			"cpu": [
+				"mips64el"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-ppc64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+			"integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-riscv64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+			"integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-s390x": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+			"integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+			"integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/netbsd-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+			"integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/netbsd-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+			"integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openbsd-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+			"integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openbsd-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+			"integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openharmony-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+			"integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/sunos-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+			"integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"sunos"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+			"integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-ia32": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+			"integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+			"integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/@floating-ui/core": {
@@ -567,6 +1010,395 @@
 			"integrity": "sha512-CUY5Mnhe64xQBGZEEXQ5WyZwsc1JU3vAZLIxtrsBt3LO6UOb+C8GunVKqe9sT8NeWb4lqSaoJtp2xo6GxT1MNw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/@rollup/rollup-android-arm-eabi": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+			"integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			]
+		},
+		"node_modules/@rollup/rollup-android-arm64": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+			"integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			]
+		},
+		"node_modules/@rollup/rollup-darwin-arm64": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+			"integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@rollup/rollup-darwin-x64": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+			"integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@rollup/rollup-freebsd-arm64": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+			"integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			]
+		},
+		"node_modules/@rollup/rollup-freebsd-x64": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+			"integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+			"integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-arm-musleabihf": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+			"integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-arm64-gnu": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+			"integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-arm64-musl": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+			"integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-loong64-gnu": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+			"integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-loong64-musl": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+			"integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-ppc64-gnu": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+			"integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-ppc64-musl": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+			"integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-riscv64-gnu": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+			"integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-riscv64-musl": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+			"integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-s390x-gnu": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+			"integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-x64-gnu": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+			"integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-x64-musl": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+			"integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-openbsd-x64": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+			"integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			]
+		},
+		"node_modules/@rollup/rollup-openharmony-arm64": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+			"integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			]
+		},
+		"node_modules/@rollup/rollup-win32-arm64-msvc": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+			"integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@rollup/rollup-win32-ia32-msvc": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+			"integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@rollup/rollup-win32-x64-gnu": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+			"integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@rollup/rollup-win32-x64-msvc": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+			"integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
 		},
 		"node_modules/@standard-schema/spec": {
 			"version": "1.1.0",
@@ -1202,6 +2034,17 @@
 				"tslib": "^2.4.0"
 			}
 		},
+		"node_modules/@types/chai": {
+			"version": "5.2.3",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+			"integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/deep-eql": "*",
+				"assertion-error": "^2.0.1"
+			}
+		},
 		"node_modules/@types/cookie": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
@@ -1462,6 +2305,13 @@
 				"@types/d3-selection": "*"
 			}
 		},
+		"node_modules/@types/deep-eql": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+			"integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@types/estree": {
 			"version": "1.0.9",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
@@ -1547,6 +2397,94 @@
 				"d3-transition": "^3.0.1"
 			}
 		},
+		"node_modules/@vitest/expect": {
+			"version": "3.2.6",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.6.tgz",
+			"integrity": "sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/chai": "^5.2.2",
+				"@vitest/spy": "3.2.6",
+				"@vitest/utils": "3.2.6",
+				"chai": "^5.2.0",
+				"tinyrainbow": "^2.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/pretty-format": {
+			"version": "3.2.6",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.6.tgz",
+			"integrity": "sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tinyrainbow": "^2.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/runner": {
+			"version": "3.2.6",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.6.tgz",
+			"integrity": "sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/utils": "3.2.6",
+				"pathe": "^2.0.3",
+				"strip-literal": "^3.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/snapshot": {
+			"version": "3.2.6",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.6.tgz",
+			"integrity": "sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "3.2.6",
+				"magic-string": "^0.30.17",
+				"pathe": "^2.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/spy": {
+			"version": "3.2.6",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.6.tgz",
+			"integrity": "sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tinyspy": "^4.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/utils": {
+			"version": "3.2.6",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.6.tgz",
+			"integrity": "sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "3.2.6",
+				"loupe": "^3.1.4",
+				"tinyrainbow": "^2.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
 		"node_modules/3d-force-graph": {
 			"version": "1.80.0",
 			"resolved": "https://registry.npmjs.org/3d-force-graph/-/3d-force-graph-1.80.0.tgz",
@@ -1623,6 +2561,16 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/assertion-error": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+			"integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/axobject-query": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
@@ -1632,6 +2580,16 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/cac": {
+			"version": "6.7.14",
+			"resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+			"integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/camelcase": {
 			"version": "5.3.1",
 			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
@@ -1639,6 +2597,33 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/chai": {
+			"version": "5.3.3",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+			"integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"assertion-error": "^2.0.1",
+				"check-error": "^2.1.1",
+				"deep-eql": "^5.0.1",
+				"loupe": "^3.1.0",
+				"pathval": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/check-error": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+			"integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 16"
 			}
 		},
 		"node_modules/chokidar": {
@@ -2268,6 +3253,24 @@
 			"integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
 			"license": "MIT"
 		},
+		"node_modules/debug": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/decamelize": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
@@ -2275,6 +3278,16 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/deep-eql": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+			"integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/deepmerge": {
@@ -2376,6 +3389,13 @@
 				"url": "https://github.com/fb55/entities?sponsor=1"
 			}
 		},
+		"node_modules/es-module-lexer": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+			"integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/es-toolkit": {
 			"version": "1.46.1",
 			"resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.1.tgz",
@@ -2385,6 +3405,48 @@
 				"docs",
 				"benchmarks"
 			]
+		},
+		"node_modules/esbuild": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+			"integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"bin": {
+				"esbuild": "bin/esbuild"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"optionalDependencies": {
+				"@esbuild/aix-ppc64": "0.28.1",
+				"@esbuild/android-arm": "0.28.1",
+				"@esbuild/android-arm64": "0.28.1",
+				"@esbuild/android-x64": "0.28.1",
+				"@esbuild/darwin-arm64": "0.28.1",
+				"@esbuild/darwin-x64": "0.28.1",
+				"@esbuild/freebsd-arm64": "0.28.1",
+				"@esbuild/freebsd-x64": "0.28.1",
+				"@esbuild/linux-arm": "0.28.1",
+				"@esbuild/linux-arm64": "0.28.1",
+				"@esbuild/linux-ia32": "0.28.1",
+				"@esbuild/linux-loong64": "0.28.1",
+				"@esbuild/linux-mips64el": "0.28.1",
+				"@esbuild/linux-ppc64": "0.28.1",
+				"@esbuild/linux-riscv64": "0.28.1",
+				"@esbuild/linux-s390x": "0.28.1",
+				"@esbuild/linux-x64": "0.28.1",
+				"@esbuild/netbsd-arm64": "0.28.1",
+				"@esbuild/netbsd-x64": "0.28.1",
+				"@esbuild/openbsd-arm64": "0.28.1",
+				"@esbuild/openbsd-x64": "0.28.1",
+				"@esbuild/openharmony-arm64": "0.28.1",
+				"@esbuild/sunos-x64": "0.28.1",
+				"@esbuild/win32-arm64": "0.28.1",
+				"@esbuild/win32-ia32": "0.28.1",
+				"@esbuild/win32-x64": "0.28.1"
+			}
 		},
 		"node_modules/esm-env": {
 			"version": "1.2.2",
@@ -2407,6 +3469,26 @@
 				"@typescript-eslint/types": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/estree-walker": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0"
+			}
+		},
+		"node_modules/expect-type": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+			"integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=12.0.0"
 			}
 		},
 		"node_modules/fdir": {
@@ -2557,6 +3639,13 @@
 				"type": "GitHub Sponsors ❤",
 				"url": "https://github.com/sponsors/dmonad"
 			}
+		},
+		"node_modules/js-tokens": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+			"integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/kapsule": {
 			"version": "1.16.3",
@@ -2968,6 +4057,13 @@
 			"integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
 			"license": "MIT"
 		},
+		"node_modules/loupe": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+			"integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/lowlight": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/lowlight/-/lowlight-3.3.0.tgz",
@@ -3101,6 +4197,13 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/nanoid": {
 			"version": "3.3.12",
 			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
@@ -3230,6 +4333,23 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/pathe": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/pathval": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+			"integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 14.16"
 			}
 		},
 		"node_modules/picocolors": {
@@ -3617,6 +4737,51 @@
 				"@rolldown/binding-win32-x64-msvc": "1.0.0-rc.18"
 			}
 		},
+		"node_modules/rollup": {
+			"version": "4.62.2",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+			"integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "1.0.9"
+			},
+			"bin": {
+				"rollup": "dist/bin/rollup"
+			},
+			"engines": {
+				"node": ">=18.0.0",
+				"npm": ">=8.0.0"
+			},
+			"optionalDependencies": {
+				"@rollup/rollup-android-arm-eabi": "4.62.2",
+				"@rollup/rollup-android-arm64": "4.62.2",
+				"@rollup/rollup-darwin-arm64": "4.62.2",
+				"@rollup/rollup-darwin-x64": "4.62.2",
+				"@rollup/rollup-freebsd-arm64": "4.62.2",
+				"@rollup/rollup-freebsd-x64": "4.62.2",
+				"@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+				"@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+				"@rollup/rollup-linux-arm64-gnu": "4.62.2",
+				"@rollup/rollup-linux-arm64-musl": "4.62.2",
+				"@rollup/rollup-linux-loong64-gnu": "4.62.2",
+				"@rollup/rollup-linux-loong64-musl": "4.62.2",
+				"@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+				"@rollup/rollup-linux-ppc64-musl": "4.62.2",
+				"@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+				"@rollup/rollup-linux-riscv64-musl": "4.62.2",
+				"@rollup/rollup-linux-s390x-gnu": "4.62.2",
+				"@rollup/rollup-linux-x64-gnu": "4.62.2",
+				"@rollup/rollup-linux-x64-musl": "4.62.2",
+				"@rollup/rollup-openbsd-x64": "4.62.2",
+				"@rollup/rollup-openharmony-arm64": "4.62.2",
+				"@rollup/rollup-win32-arm64-msvc": "4.62.2",
+				"@rollup/rollup-win32-ia32-msvc": "4.62.2",
+				"@rollup/rollup-win32-x64-gnu": "4.62.2",
+				"@rollup/rollup-win32-x64-msvc": "4.62.2",
+				"fsevents": "~2.3.2"
+			}
+		},
 		"node_modules/rope-sequence": {
 			"version": "1.3.4",
 			"resolved": "https://registry.npmjs.org/rope-sequence/-/rope-sequence-1.3.4.tgz",
@@ -3673,6 +4838,13 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/siginfo": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+			"integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+			"dev": true,
+			"license": "ISC"
+		},
 		"node_modules/sirv": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
@@ -3698,6 +4870,20 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/stackback": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+			"integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/std-env": {
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+			"integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/string-width": {
 			"version": "4.2.3",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -3722,6 +4908,19 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/strip-literal": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+			"integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"js-tokens": "^9.0.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/antfu"
 			}
 		},
 		"node_modules/stylis": {
@@ -3851,6 +5050,13 @@
 				"three": ">=0.86.0"
 			}
 		},
+		"node_modules/tinybench": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+			"integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/tinycolor2": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
@@ -3881,6 +5087,36 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/SuperchupuDev"
+			}
+		},
+		"node_modules/tinypool": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+			"integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18.0.0 || >=20.0.0"
+			}
+		},
+		"node_modules/tinyrainbow": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+			"integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/tinyspy": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+			"integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
 			}
 		},
 		"node_modules/tiptap-markdown": {
@@ -4045,6 +5281,119 @@
 				}
 			}
 		},
+		"node_modules/vite-node": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+			"integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cac": "^6.7.14",
+				"debug": "^4.4.1",
+				"es-module-lexer": "^1.7.0",
+				"pathe": "^2.0.3",
+				"vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+			},
+			"bin": {
+				"vite-node": "vite-node.mjs"
+			},
+			"engines": {
+				"node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/vite-node/node_modules/fsevents": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
+		},
+		"node_modules/vite-node/node_modules/vite": {
+			"version": "7.3.6",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+			"integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"esbuild": "^0.27.0 || ^0.28.0",
+				"fdir": "^6.5.0",
+				"picomatch": "^4.0.3",
+				"postcss": "^8.5.6",
+				"rollup": "^4.43.0",
+				"tinyglobby": "^0.2.15"
+			},
+			"bin": {
+				"vite": "bin/vite.js"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"funding": {
+				"url": "https://github.com/vitejs/vite?sponsor=1"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.3"
+			},
+			"peerDependencies": {
+				"@types/node": "^20.19.0 || >=22.12.0",
+				"jiti": ">=1.21.0",
+				"less": "^4.0.0",
+				"lightningcss": "^1.21.0",
+				"sass": "^1.70.0",
+				"sass-embedded": "^1.70.0",
+				"stylus": ">=0.54.8",
+				"sugarss": "^5.0.0",
+				"terser": "^5.16.0",
+				"tsx": "^4.8.1",
+				"yaml": "^2.4.2"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				},
+				"jiti": {
+					"optional": true
+				},
+				"less": {
+					"optional": true
+				},
+				"lightningcss": {
+					"optional": true
+				},
+				"sass": {
+					"optional": true
+				},
+				"sass-embedded": {
+					"optional": true
+				},
+				"stylus": {
+					"optional": true
+				},
+				"sugarss": {
+					"optional": true
+				},
+				"terser": {
+					"optional": true
+				},
+				"tsx": {
+					"optional": true
+				},
+				"yaml": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/vite/node_modules/fsevents": {
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -4080,6 +5429,203 @@
 				}
 			}
 		},
+		"node_modules/vitest": {
+			"version": "3.2.6",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.6.tgz",
+			"integrity": "sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/chai": "^5.2.2",
+				"@vitest/expect": "3.2.6",
+				"@vitest/mocker": "3.2.6",
+				"@vitest/pretty-format": "^3.2.6",
+				"@vitest/runner": "3.2.6",
+				"@vitest/snapshot": "3.2.6",
+				"@vitest/spy": "3.2.6",
+				"@vitest/utils": "3.2.6",
+				"chai": "^5.2.0",
+				"debug": "^4.4.1",
+				"expect-type": "^1.2.1",
+				"magic-string": "^0.30.17",
+				"pathe": "^2.0.3",
+				"picomatch": "^4.0.2",
+				"std-env": "^3.9.0",
+				"tinybench": "^2.9.0",
+				"tinyexec": "^0.3.2",
+				"tinyglobby": "^0.2.14",
+				"tinypool": "^1.1.1",
+				"tinyrainbow": "^2.0.0",
+				"vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+				"vite-node": "3.2.4",
+				"why-is-node-running": "^2.3.0"
+			},
+			"bin": {
+				"vitest": "vitest.mjs"
+			},
+			"engines": {
+				"node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"@edge-runtime/vm": "*",
+				"@types/debug": "^4.1.12",
+				"@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+				"@vitest/browser": "3.2.6",
+				"@vitest/ui": "3.2.6",
+				"happy-dom": "*",
+				"jsdom": "*"
+			},
+			"peerDependenciesMeta": {
+				"@edge-runtime/vm": {
+					"optional": true
+				},
+				"@types/debug": {
+					"optional": true
+				},
+				"@types/node": {
+					"optional": true
+				},
+				"@vitest/browser": {
+					"optional": true
+				},
+				"@vitest/ui": {
+					"optional": true
+				},
+				"happy-dom": {
+					"optional": true
+				},
+				"jsdom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/vitest/node_modules/@vitest/mocker": {
+			"version": "3.2.6",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.6.tgz",
+			"integrity": "sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/spy": "3.2.6",
+				"estree-walker": "^3.0.3",
+				"magic-string": "^0.30.17"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"msw": "^2.4.9",
+				"vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+			},
+			"peerDependenciesMeta": {
+				"msw": {
+					"optional": true
+				},
+				"vite": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/vitest/node_modules/fsevents": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
+		},
+		"node_modules/vitest/node_modules/tinyexec": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+			"integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/vitest/node_modules/vite": {
+			"version": "7.3.6",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+			"integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"esbuild": "^0.27.0 || ^0.28.0",
+				"fdir": "^6.5.0",
+				"picomatch": "^4.0.3",
+				"postcss": "^8.5.6",
+				"rollup": "^4.43.0",
+				"tinyglobby": "^0.2.15"
+			},
+			"bin": {
+				"vite": "bin/vite.js"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"funding": {
+				"url": "https://github.com/vitejs/vite?sponsor=1"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.3"
+			},
+			"peerDependencies": {
+				"@types/node": "^20.19.0 || >=22.12.0",
+				"jiti": ">=1.21.0",
+				"less": "^4.0.0",
+				"lightningcss": "^1.21.0",
+				"sass": "^1.70.0",
+				"sass-embedded": "^1.70.0",
+				"stylus": ">=0.54.8",
+				"sugarss": "^5.0.0",
+				"terser": "^5.16.0",
+				"tsx": "^4.8.1",
+				"yaml": "^2.4.2"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				},
+				"jiti": {
+					"optional": true
+				},
+				"less": {
+					"optional": true
+				},
+				"lightningcss": {
+					"optional": true
+				},
+				"sass": {
+					"optional": true
+				},
+				"sass-embedded": {
+					"optional": true
+				},
+				"stylus": {
+					"optional": true
+				},
+				"sugarss": {
+					"optional": true
+				},
+				"terser": {
+					"optional": true
+				},
+				"tsx": {
+					"optional": true
+				},
+				"yaml": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/w3c-keyname": {
 			"version": "2.2.8",
 			"resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
@@ -4091,6 +5637,23 @@
 			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
 			"integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
 			"license": "ISC"
+		},
+		"node_modules/why-is-node-running": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+			"integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"siginfo": "^2.0.0",
+				"stackback": "0.0.2"
+			},
+			"bin": {
+				"why-is-node-running": "cli.js"
+			},
+			"engines": {
+				"node": ">=8"
+			}
 		},
 		"node_modules/wrap-ansi": {
 			"version": "6.2.0",

--- a/web/package.json
+++ b/web/package.json
@@ -11,6 +11,8 @@
 		"prepare": "svelte-kit sync || echo ''",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
+		"test": "vitest run",
+		"test:watch": "vitest",
 		"test:e2e": "playwright test",
 		"test:e2e:ui": "playwright test --ui",
 		"test:e2e:install": "playwright install --with-deps chromium"
@@ -27,7 +29,8 @@
 		"svelte": "^5.55.5",
 		"svelte-check": "^4.4.7",
 		"typescript": "^6.0.3",
-		"vite": "^8.0.11"
+		"vite": "^8.0.11",
+		"vitest": "3.2.6"
 	},
 	"overrides": {
 		"cookie": "^0.7.2",

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -397,6 +397,54 @@ export interface AuthSession {
 	user?: { id: string; email: string; username: string; name: string; role: string; plan?: string };
 }
 
+// ── WebMCP tool-surface (PLAN-1888 / TASK-1892) ────────────────────────────
+// Mirrors internal/mcp/tool_surface.go's serialized payload. The browser
+// WebMCP module (web/src/lib/webmcp/) fetches this once per workspace entry
+// to build document.modelContext tool descriptors from the live catalog.
+
+/** One action of a catalog tool, with its read-only classification. */
+export interface ToolSurfaceAction {
+	name: string;
+	/** True when this action performs no mutation (DR-2 read set). */
+	read_only: boolean;
+}
+
+/** One parameter of a catalog tool's flat param union. */
+export interface ToolSurfaceParam {
+	name: string;
+	type: string;
+	description?: string;
+	enum?: string[];
+}
+
+/** One catalog tool (pad_item, pad_search, …) as served over REST. */
+export interface ToolSurfaceTool {
+	name: string;
+	description: string;
+	/**
+	 * True when the underlying ToolDef declared `Schema.Workspace` — i.e.
+	 * the serializer emitted a `workspace` param. The WebMCP builder MUST
+	 * strip that param and force the route wsSlug (DR-4).
+	 */
+	workspace: boolean;
+	actions: ToolSurfaceAction[];
+	params: ToolSurfaceParam[];
+}
+
+export interface ToolSurfaceResponse {
+	tool_surface_version: string;
+	rollout_status?: string;
+	tools: ToolSurfaceTool[];
+}
+
+/**
+ * Playbook metadata as returned by `GET /workspaces/{ws}/playbooks` — the
+ * same projection the bootstrap blob carries (ref, title, slug,
+ * invocation_slug, trigger, scope, status, has_arguments, summary). Loosely
+ * typed (Record) since the WebMCP read path forwards it verbatim as JSON.
+ */
+export type PlaybookMeta = Record<string, unknown>;
+
 // ImportURLResponse mirrors internal/server/handlers_import.go's
 // importURLResponse. Side-effect-free: no DB writes happen on the
 // server during this call; the editor decides whether to splice the
@@ -426,6 +474,29 @@ export const api = {
 
 	templates: {
 		list: () => request<WorkspaceTemplate[]>('/templates'),
+	},
+
+	// ── WebMCP tool-surface (PLAN-1888 / TASK-1892) ───────────────────────────
+
+	mcp: {
+		/**
+		 * The catalog tool-surface descriptor blob (`GET /api/v1/mcp/tool-surface`,
+		 * added in Phase 2). Session-authed; the browser WebMCP module fetches it
+		 * once per workspace entry to build document.modelContext tools.
+		 */
+		toolSurface: () => request<ToolSurfaceResponse>('/mcp/tool-surface'),
+	},
+
+	// ── Playbooks ─────────────────────────────────────────────────────────────
+
+	playbooks: {
+		/** Playbook metadata for the workspace (bootstrap-shaped projection). */
+		list: (ws: string) =>
+			request<PlaybookMeta[]>(`/workspaces/${ws}/playbooks`),
+
+		/** Full playbook item by ref / slug / invocation_slug. */
+		get: (ws: string, ref: string) =>
+			request<Item>(`/workspaces/${ws}/playbooks/${ref}`),
 	},
 
 	// ── Workspaces ────────────────────────────────────────────────────────────

--- a/web/src/lib/webmcp/descriptors.test.ts
+++ b/web/src/lib/webmcp/descriptors.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from 'vitest';
+import type { ToolSurfaceTool, ToolSurfaceResponse } from '$lib/api/client';
+import { buildDescriptor, buildDescriptors, isAllReadOnly } from './descriptors';
+
+// A no-op execute closure — the builder is pure aside from carrying it through.
+const noopExecute = async (): Promise<ModelContextToolResult> => ({
+	content: [{ type: 'text', text: '' }],
+});
+
+// pad_search: all-read tool that ALSO declares a `workspace` param — the
+// canonical DR-4 + DR-2 case.
+const padSearch: ToolSurfaceTool = {
+	name: 'pad_search',
+	description: 'Search items.',
+	workspace: true,
+	actions: [{ name: 'query', read_only: true }],
+	params: [
+		{ name: 'action', type: 'string', enum: ['query'] },
+		{ name: 'workspace', type: 'string', description: 'Workspace slug.' },
+		{ name: 'query', type: 'string', description: 'The search query.' },
+		{ name: 'limit', type: 'number' },
+	],
+};
+
+// pad_item: MIXED read + write tool. readOnlyHint must be ABSENT.
+const padItem: ToolSurfaceTool = {
+	name: 'pad_item',
+	description: 'Manage items.',
+	workspace: true,
+	actions: [
+		{ name: 'list', read_only: true },
+		{ name: 'get', read_only: true },
+		{ name: 'create', read_only: false },
+		{ name: 'delete', read_only: false },
+	],
+	params: [
+		{ name: 'action', type: 'string', enum: ['list', 'get', 'create', 'delete'] },
+		{ name: 'workspace', type: 'string' },
+		{ name: 'ref', type: 'ref' },
+		{ name: 'title', type: 'string' },
+	],
+};
+
+describe('isAllReadOnly (DR-2)', () => {
+	it('true when every action is read_only', () => {
+		expect(isAllReadOnly(padSearch)).toBe(true);
+	});
+
+	it('false for a mixed read/write tool', () => {
+		expect(isAllReadOnly(padItem)).toBe(false);
+	});
+
+	it('false when the tool has zero actions (conservative)', () => {
+		expect(isAllReadOnly({ ...padSearch, actions: [] })).toBe(false);
+	});
+});
+
+describe('buildDescriptor — workspace strip (DR-4)', () => {
+	it('strips the workspace param from the inputSchema', () => {
+		const { tool } = buildDescriptor(padSearch, noopExecute);
+		expect(tool.inputSchema.properties).toBeDefined();
+		expect('workspace' in (tool.inputSchema.properties ?? {})).toBe(false);
+		// other params survive
+		expect('query' in (tool.inputSchema.properties ?? {})).toBe(true);
+		expect('action' in (tool.inputSchema.properties ?? {})).toBe(true);
+	});
+
+	it('records hasWorkspaceParam when the source declared one', () => {
+		const { hasWorkspaceParam } = buildDescriptor(padSearch, noopExecute);
+		expect(hasWorkspaceParam).toBe(true);
+	});
+
+	it('keeps action required and leaves other params optional', () => {
+		const { tool } = buildDescriptor(padSearch, noopExecute);
+		expect(tool.inputSchema.required).toEqual(['action']);
+	});
+
+	it('strips workspace even for a mixed tool', () => {
+		const { tool } = buildDescriptor(padItem, noopExecute);
+		expect('workspace' in (tool.inputSchema.properties ?? {})).toBe(false);
+		expect('ref' in (tool.inputSchema.properties ?? {})).toBe(true);
+	});
+});
+
+describe('buildDescriptor — readOnlyHint (DR-2)', () => {
+	it('sets readOnlyHint=true for an all-read tool', () => {
+		const { tool } = buildDescriptor(padSearch, noopExecute);
+		expect(tool.annotations?.readOnlyHint).toBe(true);
+	});
+
+	it('omits annotations entirely for a mixed tool', () => {
+		const { tool } = buildDescriptor(padItem, noopExecute);
+		// No readOnlyHint at all → the host prompts for per-invocation consent.
+		expect(tool.annotations).toBeUndefined();
+	});
+});
+
+describe('buildDescriptor — param types & metadata', () => {
+	it('maps `flag` → boolean and `number` → number; ref/enum → string', () => {
+		const tool: ToolSurfaceTool = {
+			name: 'pad_x',
+			description: 'x',
+			workspace: false,
+			actions: [{ name: 'go', read_only: true }],
+			params: [
+				{ name: 'action', type: 'string', enum: ['go'] },
+				{ name: 'force', type: 'flag' },
+				{ name: 'count', type: 'number' },
+				{ name: 'ref', type: 'ref' },
+			],
+		};
+		const { tool: built } = buildDescriptor(tool, noopExecute);
+		const props = built.inputSchema.properties as Record<string, { type: string }>;
+		expect(props.force.type).toBe('boolean');
+		expect(props.count.type).toBe('number');
+		expect(props.ref.type).toBe('string');
+	});
+
+	it('carries the action enum through', () => {
+		const { tool } = buildDescriptor(padItem, noopExecute);
+		const props = tool.inputSchema.properties as Record<string, { enum?: string[] }>;
+		expect(props.action.enum).toEqual(['list', 'get', 'create', 'delete']);
+	});
+
+	it('exposes the action read-only map for the dispatcher', () => {
+		const { actions } = buildDescriptor(padItem, noopExecute);
+		expect(actions.get('get')).toBe(true);
+		expect(actions.get('create')).toBe(false);
+	});
+});
+
+describe('buildDescriptors', () => {
+	it('builds one descriptor per tool and wires executeFor by name', () => {
+		const surface: ToolSurfaceResponse = {
+			tool_surface_version: '0.7',
+			tools: [padSearch, padItem],
+		};
+		const seen: string[] = [];
+		const built = buildDescriptors(surface, (name) => {
+			seen.push(name);
+			return noopExecute;
+		});
+		expect(built.map((b) => b.tool.name)).toEqual(['pad_search', 'pad_item']);
+		expect(seen).toEqual(['pad_search', 'pad_item']);
+	});
+});

--- a/web/src/lib/webmcp/descriptors.ts
+++ b/web/src/lib/webmcp/descriptors.ts
@@ -1,0 +1,145 @@
+// descriptors.ts — pure tool-surface JSON → ModelContextTool descriptor
+// builder (PLAN-1888 / TASK-1892, pieces 3). No DOM, no fetch, no Svelte —
+// fully unit-testable. The lifecycle layer (register.ts) feeds it the
+// fetched tool-surface payload and registers the result.
+//
+// Two load-bearing correctness constraints, both unit-tested:
+//   - DR-4: STRIP the `workspace` param from every descriptor's inputSchema.
+//     The workspace must NOT be agent-settable; dispatch forces the route
+//     wsSlug. `workspace` is dropped here so the param never even appears in
+//     the schema the agent sees.
+//   - DR-2: `annotations.readOnlyHint = true` only when EVERY action the tool
+//     exposes is `read_only`. Mixed tools (e.g. pad_item) get no hint, so the
+//     host prompts for per-invocation consent on writes.
+
+import type {
+	ToolSurfaceTool,
+	ToolSurfaceParam,
+	ToolSurfaceResponse,
+} from '$lib/api/client';
+
+/**
+ * The descriptor a WebMCP tool registers with, paired with the metadata the
+ * dispatcher needs at call time. `tool` is the spec-shaped object handed to
+ * `registerTool`; `actions`/`hasWorkspaceParam` are retained so the
+ * dispatcher can validate/route without re-parsing the schema.
+ */
+export interface BuiltToolDescriptor {
+	tool: ModelContextTool;
+	/** Action names this tool exposes, with read-only classification. */
+	actions: Map<string, boolean>;
+	/** True when the source ToolDef declared a `workspace` param (now stripped). */
+	hasWorkspaceParam: boolean;
+}
+
+/** A single JSON-Schema property, derived from a tool-surface param. */
+interface SchemaProperty {
+	type: string;
+	description?: string;
+	enum?: string[];
+}
+
+// JSON-Schema `type` values the spec understands. The catalog emits CLI-ish
+// type names ("flag", "ref", …); map the ones that aren't already valid
+// JSON-Schema types so the descriptor is well-formed.
+function jsonSchemaType(catalogType: string): string {
+	switch (catalogType) {
+		case 'flag':
+			return 'boolean';
+		case 'number':
+			return 'number';
+		case 'string':
+		case 'ref':
+		case 'enum':
+		default:
+			// `ref`/`enum`/unknown all serialize as strings over the wire.
+			return 'string';
+	}
+}
+
+function paramToProperty(param: ToolSurfaceParam): SchemaProperty {
+	const prop: SchemaProperty = { type: jsonSchemaType(param.type) };
+	if (param.description) prop.description = param.description;
+	if (param.enum && param.enum.length > 0) prop.enum = [...param.enum];
+	return prop;
+}
+
+/**
+ * Derive `readOnlyHint` per DR-2: true only when the tool exposes at least one
+ * action AND every action is `read_only`. A tool with zero actions (shouldn't
+ * happen for catalog tools) returns false — the conservative direction.
+ */
+export function isAllReadOnly(tool: ToolSurfaceTool): boolean {
+	if (!tool.actions || tool.actions.length === 0) return false;
+	return tool.actions.every((a) => a.read_only);
+}
+
+/**
+ * Build a single ModelContextTool descriptor from a tool-surface tool.
+ *
+ * - STRIPS the `workspace` param (DR-4) — it is never placed in the schema.
+ * - `action` stays required (the catalog dispatch verb).
+ * - readOnlyHint applied per DR-2.
+ *
+ * `execute` is supplied by the caller (the dispatcher closure) so this stays
+ * pure and side-effect-free for testing.
+ */
+export function buildDescriptor(
+	tool: ToolSurfaceTool,
+	execute: (args: Record<string, unknown>) => Promise<ModelContextToolResult>,
+): BuiltToolDescriptor {
+	const properties: Record<string, SchemaProperty> = {};
+	const required: string[] = [];
+	let hasWorkspaceParam = tool.workspace === true;
+
+	for (const param of tool.params ?? []) {
+		// DR-4: the workspace is route-bound, never agent-settable. Drop it
+		// from the schema entirely so the agent can't even name it. (The
+		// dispatcher additionally rejects a supplied `workspace` arg as
+		// belt-and-suspenders.)
+		if (param.name === 'workspace') {
+			hasWorkspaceParam = true;
+			continue;
+		}
+		properties[param.name] = paramToProperty(param);
+		// `action` is the only required param the catalog emits; everything
+		// else is optional in the fat-tool union.
+		if (param.name === 'action') required.push('action');
+	}
+
+	const annotations: ModelContextToolAnnotations = {};
+	if (isAllReadOnly(tool)) annotations.readOnlyHint = true;
+
+	const descriptor: ModelContextTool = {
+		name: tool.name,
+		description: tool.description,
+		inputSchema: {
+			type: 'object',
+			properties,
+			...(required.length > 0 ? { required } : {}),
+		},
+		...(Object.keys(annotations).length > 0 ? { annotations } : {}),
+		execute,
+	};
+
+	const actions = new Map<string, boolean>();
+	for (const a of tool.actions ?? []) actions.set(a.name, a.read_only);
+
+	return { tool: descriptor, actions, hasWorkspaceParam };
+}
+
+/**
+ * Build descriptors for every tool in a tool-surface payload. `executeFor`
+ * returns the `execute` closure for a given tool name (the dispatcher binds
+ * the route wsSlug into it). Pure aside from invoking `executeFor`.
+ */
+export function buildDescriptors(
+	surface: ToolSurfaceResponse,
+	executeFor: (
+		toolName: string,
+	) => (args: Record<string, unknown>) => Promise<ModelContextToolResult>,
+): BuiltToolDescriptor[] {
+	return (surface.tools ?? []).map((tool) =>
+		buildDescriptor(tool, executeFor(tool.name)),
+	);
+}

--- a/web/src/lib/webmcp/dispatch.test.ts
+++ b/web/src/lib/webmcp/dispatch.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi } from 'vitest';
+import { dispatch } from './dispatch';
+import type { api as ApiClient } from '$lib/api/client';
+
+// Build a minimal mock of the api client. Only the methods the dispatch
+// table touches need to exist; cast through unknown to the full type.
+function mockApi() {
+	return {
+		search: vi.fn(async () => ({ results: [] })),
+		items: {
+			list: vi.fn(async () => []),
+			get: vi.fn(async () => ({ ref: 'TASK-1' })),
+			backlinks: vi.fn(async () => []),
+		},
+		dashboard: { get: vi.fn(async () => ({ ok: true })) },
+		collections: { list: vi.fn(async () => []) },
+		agentRoles: { list: vi.fn(async () => []) },
+		playbooks: { list: vi.fn(async () => []), get: vi.fn(async () => ({})) },
+		library: { get: vi.fn(async () => ({})) },
+		workspaces: { list: vi.fn(async () => []) },
+	};
+}
+
+type Api = typeof ApiClient;
+
+// All catalog read actions are read_only=true; writes false. The real
+// lookup comes from the served read set; here we hardcode the relevant ones.
+const READ = new Set([
+	'pad_search:query',
+	'pad_item:list',
+	'pad_item:get',
+	'pad_item:backlinks',
+	'pad_project:dashboard',
+	'pad_collection:list',
+	'pad_role:list',
+	'pad_playbook:list',
+	'pad_playbook:get',
+	'pad_library:list',
+	'pad_workspace:list',
+]);
+const isReadOnly = (tool: string, action: string): boolean | undefined => {
+	// Mirror the served read set: known reads → true, known writes → false.
+	if (READ.has(`${tool}:${action}`)) return true;
+	if (['create', 'update', 'delete', 'import'].includes(action)) return false;
+	return undefined;
+};
+
+const WS = 'my-workspace';
+
+function parse(result: { content: { text: string }[]; isError?: boolean }) {
+	return { isError: result.isError === true, text: result.content[0]?.text ?? '' };
+}
+
+describe('dispatch — wsSlug injection (DR-4)', () => {
+	it('passes the route wsSlug to a read handler, never an arg', async () => {
+		const api = mockApi();
+		await dispatch(api as unknown as Api, WS, isReadOnly, 'pad_item', {
+			action: 'list',
+			status: 'open',
+		});
+		expect(api.items.list).toHaveBeenCalledWith(WS, expect.objectContaining({ status: 'open' }));
+	});
+
+	it('injects wsSlug into search filters', async () => {
+		const api = mockApi();
+		await dispatch(api as unknown as Api, WS, isReadOnly, 'pad_search', {
+			action: 'query',
+			query: 'hello',
+		});
+		expect(api.search).toHaveBeenCalledWith('hello', expect.objectContaining({ workspace: WS }));
+	});
+
+	it('forwards ref to items.get', async () => {
+		const api = mockApi();
+		await dispatch(api as unknown as Api, WS, isReadOnly, 'pad_item', {
+			action: 'get',
+			ref: 'TASK-5',
+		});
+		expect(api.items.get).toHaveBeenCalledWith(WS, 'TASK-5');
+	});
+});
+
+describe('dispatch — supplied-workspace rejection (DR-4)', () => {
+	it('rejects an agent-supplied workspace arg outright', async () => {
+		const api = mockApi();
+		const result = await dispatch(api as unknown as Api, WS, isReadOnly, 'pad_item', {
+			action: 'list',
+			workspace: 'other-workspace',
+		});
+		const { isError, text } = parse(result);
+		expect(isError).toBe(true);
+		expect(text).toMatch(/workspace/i);
+		// And it never reached the handler.
+		expect(api.items.list).not.toHaveBeenCalled();
+	});
+
+	it('ignores an empty-string workspace arg (treated as not supplied)', async () => {
+		const api = mockApi();
+		const result = await dispatch(api as unknown as Api, WS, isReadOnly, 'pad_item', {
+			action: 'list',
+			workspace: '',
+		});
+		expect(parse(result).isError).toBe(false);
+		expect(api.items.list).toHaveBeenCalledWith(WS, expect.anything());
+	});
+
+	it('rejects even when the supplied workspace equals the route slug', async () => {
+		const api = mockApi();
+		const result = await dispatch(api as unknown as Api, WS, isReadOnly, 'pad_item', {
+			action: 'list',
+			workspace: WS,
+		});
+		expect(parse(result).isError).toBe(true);
+		expect(api.items.list).not.toHaveBeenCalled();
+	});
+});
+
+describe('dispatch — write actions (TASK-3b)', () => {
+	it('returns a precise not-wired error for a write action, no silent no-op', async () => {
+		const api = mockApi();
+		const result = await dispatch(api as unknown as Api, WS, isReadOnly, 'pad_item', {
+			action: 'delete',
+			ref: 'TASK-1',
+		});
+		const { isError, text } = parse(result);
+		expect(isError).toBe(true);
+		expect(text).toMatch(/TASK-3b/);
+	});
+});
+
+describe('dispatch — read action result envelope', () => {
+	it('wraps the client result as JSON text content', async () => {
+		const api = mockApi();
+		const result = await dispatch(api as unknown as Api, WS, isReadOnly, 'pad_project', {
+			action: 'dashboard',
+		});
+		const { isError, text } = parse(result);
+		expect(isError).toBe(false);
+		expect(JSON.parse(text)).toEqual({ ok: true });
+	});
+
+	it('errors clearly when action is missing', async () => {
+		const api = mockApi();
+		const result = await dispatch(api as unknown as Api, WS, isReadOnly, 'pad_item', {});
+		expect(parse(result).isError).toBe(true);
+		expect(parse(result).text).toMatch(/action/);
+	});
+
+	it('errors for a read action with no browser mapping (e.g. pad_project.standup)', async () => {
+		const api = mockApi();
+		// standup is read_only in the catalog but has no browser handler.
+		const isReadStandup = (t: string, a: string) =>
+			a === 'standup' ? true : isReadOnly(t, a);
+		const result = await dispatch(api as unknown as Api, WS, isReadStandup, 'pad_project', {
+			action: 'standup',
+		});
+		const { isError, text } = parse(result);
+		expect(isError).toBe(true);
+		expect(text).toMatch(/not available/i);
+	});
+
+	it('surfaces a thrown client error as an error result', async () => {
+		const api = mockApi();
+		api.dashboard.get.mockRejectedValueOnce(new Error('boom'));
+		const result = await dispatch(api as unknown as Api, WS, isReadOnly, 'pad_project', {
+			action: 'dashboard',
+		});
+		const { isError, text } = parse(result);
+		expect(isError).toBe(true);
+		expect(text).toMatch(/boom/);
+	});
+
+	it('errors when there is no active workspace', async () => {
+		const api = mockApi();
+		const result = await dispatch(api as unknown as Api, '', isReadOnly, 'pad_item', {
+			action: 'list',
+		});
+		expect(parse(result).isError).toBe(true);
+	});
+});

--- a/web/src/lib/webmcp/dispatch.ts
+++ b/web/src/lib/webmcp/dispatch.ts
@@ -1,0 +1,186 @@
+// dispatch.ts — the `(toolName, action, args) → client.ts` router for the
+// WebMCP surface (PLAN-1888 / TASK-1892, piece 4). Pure/injectable: takes the
+// `api` client + the route `wsSlug` as arguments so it's unit-testable with a
+// mocked client and no browser.
+//
+// Two correctness constraints, both unit-tested:
+//   - DR-4: the workspace is FROZEN to the route `wsSlug`. An agent-supplied
+//     `workspace` arg is REJECTED (not silently overridden) so a stray /
+//     malicious workspace can't slip through. Every read handler receives the
+//     route wsSlug, never an arg-derived one.
+//   - This task wires READ actions only. WRITE actions are recognized and
+//     return a clear "not yet wired (TASK-3b)" error — never a silent no-op.
+
+import type { api as ApiClient } from '$lib/api/client';
+
+type Api = typeof ApiClient;
+
+/** Result envelope the WebMCP host expects from `execute`. */
+export type DispatchResult = ModelContextToolResult;
+
+/** A read-action handler: pure call into the api client. */
+type ReadHandler = (
+	api: Api,
+	wsSlug: string,
+	args: Record<string, unknown>,
+) => Promise<unknown>;
+
+// ── helpers ────────────────────────────────────────────────────────────────
+
+function str(args: Record<string, unknown>, key: string): string | undefined {
+	const v = args[key];
+	if (typeof v === 'string' && v.length > 0) return v;
+	return undefined;
+}
+
+function num(args: Record<string, unknown>, key: string): number | undefined {
+	const v = args[key];
+	if (typeof v === 'number') return v;
+	if (typeof v === 'string' && v.trim() !== '' && !Number.isNaN(Number(v))) {
+		return Number(v);
+	}
+	return undefined;
+}
+
+function requireRef(args: Record<string, unknown>): string {
+	const ref = str(args, 'ref') ?? str(args, 'slug');
+	if (!ref) throw new Error("missing required arg 'ref'");
+	return ref;
+}
+
+function ok(result: unknown): DispatchResult {
+	return { content: [{ type: 'text', text: JSON.stringify(result) }] };
+}
+
+function errResult(message: string): DispatchResult {
+	return { content: [{ type: 'text', text: message }], isError: true };
+}
+
+// ── read dispatch table ──────────────────────────────────────────────────
+//
+// Keyed by `${toolName}:${action}`. Only READ actions appear here (this
+// task). Each handler receives the ROUTE wsSlug — never an arg-supplied one.
+// Project next/standup/changelog and pad_meta/bootstrap have no clean REST
+// read endpoint exposed to the browser today, so they're intentionally
+// absent and fall through to the "not available in browser" branch rather
+// than being faked.
+
+const READ_HANDLERS: Record<string, ReadHandler> = {
+	// pad_search
+	'pad_search:query': (api, ws, args) =>
+		api.search(str(args, 'query') ?? str(args, 'q') ?? '', {
+			workspace: ws,
+			collection: str(args, 'collection'),
+			status: str(args, 'status'),
+			priority: str(args, 'priority'),
+			limit: num(args, 'limit'),
+		}),
+
+	// pad_item reads
+	'pad_item:list': (api, ws, args) =>
+		api.items.list(ws, {
+			collection: str(args, 'collection'),
+			status: str(args, 'status'),
+			priority: str(args, 'priority'),
+			parent: str(args, 'parent'),
+			tag: str(args, 'tag'),
+			limit: num(args, 'limit'),
+		}),
+	'pad_item:get': (api, ws, args) => api.items.get(ws, requireRef(args)),
+	'pad_item:backlinks': (api, ws, args) =>
+		api.items.backlinks(ws, requireRef(args), {
+			limit: num(args, 'limit'),
+			offset: num(args, 'offset'),
+		}),
+
+	// pad_project reads — only dashboard has a browser REST endpoint today.
+	'pad_project:dashboard': (api, ws) => api.dashboard.get(ws),
+
+	// pad_collection reads
+	'pad_collection:list': (api, ws) => api.collections.list(ws),
+
+	// pad_role reads
+	'pad_role:list': (api, ws) => api.agentRoles.list(ws),
+
+	// pad_playbook reads
+	'pad_playbook:list': (api, ws) => api.playbooks.list(ws),
+	'pad_playbook:get': (api, ws, args) =>
+		api.playbooks.get(ws, requireRef(args)),
+
+	// pad_library reads
+	'pad_library:list': (api) => api.library.get(),
+	'pad_library:get': (api) => api.library.get(),
+
+	// pad_workspace reads
+	'pad_workspace:list': (api) => api.workspaces.list(),
+};
+
+// ── dispatcher ─────────────────────────────────────────────────────────────
+
+/**
+ * Route a WebMCP tool invocation to the api client.
+ *
+ * @param api      the singleton api client (injected for testability)
+ * @param wsSlug   the ROUTE workspace slug — the only workspace authority
+ * @param isReadOnlyAction  `(toolName, action) → boolean` from the descriptor's
+ *                          action map (the Go read set, served over the wire)
+ * @param toolName e.g. "pad_item"
+ * @param args     the raw args object from the agent (includes `action`)
+ *
+ * DR-4 rejection: a non-empty agent-supplied `workspace` arg is rejected
+ * outright. The route wsSlug is always used.
+ */
+export async function dispatch(
+	api: Api,
+	wsSlug: string,
+	isReadOnlyAction: (toolName: string, action: string) => boolean | undefined,
+	toolName: string,
+	args: Record<string, unknown>,
+): Promise<DispatchResult> {
+	// DR-4: the workspace is route-bound. Reject any attempt to set it.
+	if ('workspace' in args && args.workspace !== undefined && args.workspace !== '') {
+		return errResult(
+			"the 'workspace' argument is not accepted — WebMCP tools always " +
+				`operate on the current workspace (${wsSlug})`,
+		);
+	}
+
+	if (!wsSlug) {
+		return errResult('no active workspace');
+	}
+
+	const action = str(args, 'action');
+	if (!action) {
+		return errResult(`missing required arg 'action' for ${toolName}`);
+	}
+
+	const readOnly = isReadOnlyAction(toolName, action);
+
+	// Write actions: recognized but not yet wired (this task is read-only).
+	// Never a silent no-op — return a precise, actionable error.
+	if (readOnly === false) {
+		return errResult(
+			`${toolName}.${action} is a write action — not yet wired in the ` +
+				'browser WebMCP surface (follows in TASK-3b)',
+		);
+	}
+
+	const key = `${toolName}:${action}`;
+	const handler = READ_HANDLERS[key];
+	if (!handler) {
+		// A read action the catalog exposes but with no browser REST mapping
+		// (e.g. pad_project.standup, pad_meta.bootstrap). Honest error, not a
+		// fake result.
+		return errResult(
+			`${toolName}.${action} is not available in the browser WebMCP surface`,
+		);
+	}
+
+	try {
+		const result = await handler(api, wsSlug, args);
+		return ok(result);
+	} catch (e) {
+		const message = e instanceof Error ? e.message : String(e);
+		return errResult(`${toolName}.${action} failed: ${message}`);
+	}
+}

--- a/web/src/lib/webmcp/register.ts
+++ b/web/src/lib/webmcp/register.ts
@@ -1,0 +1,96 @@
+// register.ts — the WebMCP lifecycle entry point (PLAN-1888 / TASK-1892,
+// piece 5). Framework-light: a plain async function the workspace layout
+// calls from its `$effect`. Returns a teardown function (or a no-op when the
+// surface is unavailable). Registration is gated on:
+//   1. webmcp_enabled (the session flag, DR-6)
+//   2. feature detection — `document.modelContext` present (DR-6)
+//   3. an authenticated user
+// and unregistration rides an AbortSignal so workspace switch / unmount
+// tears every tool down in one shot (no per-tool handles, no leaks).
+
+import { api } from '$lib/api/client';
+import { authStore } from '$lib/stores/auth.svelte';
+import { buildDescriptors } from './descriptors';
+import { dispatch } from './dispatch';
+
+/**
+ * Feature-detect the WebMCP provider. Mirrors the
+ * `'locks' in navigator` pattern in sse.svelte.ts:101 — narrow `in` check,
+ * SSR-safe (`typeof document`).
+ */
+export function webmcpSupported(): boolean {
+	return typeof document !== 'undefined' && 'modelContext' in document;
+}
+
+/** A teardown handle. Idempotent. */
+export type WebMcpHandle = () => void;
+
+const NOOP: WebMcpHandle = () => {};
+
+/**
+ * Register Pad's catalog tools with `document.modelContext`, scoped to
+ * `wsSlug`. Returns a teardown function; calling it (or the layout aborting
+ * the supplied controller) unregisters every tool.
+ *
+ * No-ops (returns NOOP) when the flag is off, the API is absent, or no user
+ * is authenticated — with ZERO console noise, so a disabled instance has no
+ * observable WebMCP behaviour (acceptance criterion).
+ *
+ * Re-entrancy: the caller (the layout `$effect`) is responsible for tearing
+ * down the previous registration before calling again on workspace switch.
+ * Each call owns its own AbortController so registrations never overlap.
+ */
+export async function registerWorkspaceTools(wsSlug: string): Promise<WebMcpHandle> {
+	if (!wsSlug) return NOOP;
+
+	// Gate 1: opt-in session flag (default/absent → false).
+	if (!authStore.session?.webmcp_enabled) return NOOP;
+
+	// Gate 2: native feature detection. Degrade silently.
+	if (!webmcpSupported()) return NOOP;
+
+	// Gate 3: authenticated user — the tools execute as the web session.
+	if (!authStore.user) return NOOP;
+
+	const modelContext = document.modelContext;
+	if (!modelContext) return NOOP;
+
+	// One controller per registration → AbortSignal-driven teardown.
+	const controller = new AbortController();
+
+	let surface;
+	try {
+		surface = await api.mcp.toolSurface();
+	} catch {
+		// Endpoint unreachable / unauthorized — degrade silently, nothing
+		// registers. No console noise (acceptance criterion).
+		return NOOP;
+	}
+
+	// The caller may have torn us down while the fetch was in flight (fast
+	// workspace switch). Honour that and don't register stale tools.
+	if (controller.signal.aborted) return NOOP;
+
+	const descriptors = buildDescriptors(surface, (toolName) => {
+		// Per-tool action read-only lookup, captured from this tool's actions.
+		const tool = surface.tools.find((t) => t.name === toolName);
+		const readOnly = new Map<string, boolean>(
+			(tool?.actions ?? []).map((a) => [a.name, a.read_only]),
+		);
+		const isReadOnlyAction = (_name: string, action: string) =>
+			readOnly.get(action);
+		return (args: Record<string, unknown>) =>
+			dispatch(api, wsSlug, isReadOnlyAction, toolName, args);
+	});
+
+	for (const { tool } of descriptors) {
+		try {
+			modelContext.registerTool(tool, { signal: controller.signal });
+		} catch {
+			// A host that rejects a single tool shouldn't abort the rest;
+			// stay silent (acceptance: zero console noise).
+		}
+	}
+
+	return () => controller.abort();
+}

--- a/web/src/lib/webmcp/types.d.ts
+++ b/web/src/lib/webmcp/types.d.ts
@@ -1,0 +1,88 @@
+// WebMCP / `document.modelContext` ambient type declarations (PLAN-1888 /
+// TASK-1892).
+//
+// EXPERIMENTAL: `document.modelContext` is the browser-native WebMCP surface
+// (a.k.a. the W3C Web Model Context proposal). No browser ships it as a
+// stable API yet, and there are no `@types/*` packages for it. This stub
+// exists only so the WebMCP module type-checks under `strict` — it is NOT a
+// guarantee that the API is present at runtime. Every consumer MUST
+// feature-detect (`'modelContext' in document`) before touching it.
+//
+// Shape follows the WebMCP spec's `registerTool(tool, opts)` form:
+//   - tool: { name, description, inputSchema, annotations?, execute }
+//   - opts: { signal?, exposedTo? }
+// plus the `toolchange` event the host fires when the registered set
+// changes. Kept intentionally narrow — only the members the module uses.
+
+/** A JSON-Schema-ish input schema object for a WebMCP tool. */
+interface ModelContextToolInputSchema {
+	type: 'object';
+	properties?: Record<string, unknown>;
+	required?: string[];
+	[key: string]: unknown;
+}
+
+/** Per-tool behavioural hints surfaced to the agent / consent UI. */
+interface ModelContextToolAnnotations {
+	/**
+	 * True only when EVERY action the tool can perform is a pure read
+	 * (DR-2). Mixed read/write tools omit this so the host prompts for
+	 * per-invocation consent on every call.
+	 */
+	readOnlyHint?: boolean;
+	/**
+	 * Set when the tool's output can echo user-authored / untrusted
+	 * content, so the agent treats the result as untrusted input.
+	 */
+	untrustedContentHint?: boolean;
+	[key: string]: unknown;
+}
+
+/** One block of a tool-execution result. Only the text form is used here. */
+interface ModelContextContentBlock {
+	type: 'text';
+	text: string;
+}
+
+/** The value a tool's `execute` resolves to. */
+interface ModelContextToolResult {
+	content: ModelContextContentBlock[];
+	/** Optional flag the host inspects to surface the call as an error. */
+	isError?: boolean;
+}
+
+/** A tool descriptor passed to `registerTool`. */
+interface ModelContextTool {
+	name: string;
+	description: string;
+	inputSchema: ModelContextToolInputSchema;
+	annotations?: ModelContextToolAnnotations;
+	execute: (args: Record<string, unknown>) => Promise<ModelContextToolResult>;
+}
+
+/** Options for `registerTool`. */
+interface ModelContextRegisterToolOptions {
+	/**
+	 * Abort signal — when it fires, the host unregisters the tool. This is
+	 * the canonical teardown path (workspace switch / unmount), so the
+	 * module never has to track per-tool unregister handles.
+	 */
+	signal?: AbortSignal;
+	/** Which agent surfaces the tool is exposed to (host-defined). */
+	exposedTo?: string[];
+}
+
+/** The `document.modelContext` provider object. */
+interface ModelContextProvider extends EventTarget {
+	registerTool(tool: ModelContextTool, opts?: ModelContextRegisterToolOptions): void;
+	addEventListener(type: 'toolchange', listener: (ev: Event) => void): void;
+	removeEventListener(type: 'toolchange', listener: (ev: Event) => void): void;
+}
+
+interface Document {
+	/**
+	 * EXPERIMENTAL WebMCP provider. Optional — always feature-detect with
+	 * `'modelContext' in document` before use.
+	 */
+	readonly modelContext?: ModelContextProvider;
+}

--- a/web/src/routes/[username]/[workspace]/+layout.svelte
+++ b/web/src/routes/[username]/[workspace]/+layout.svelte
@@ -10,6 +10,7 @@
 	import { toastStore } from '$lib/stores/toast.svelte';
 	import { starredStore } from '$lib/stores/starred.svelte';
 	import { titleStore } from '$lib/stores/title.svelte';
+	import { registerWorkspaceTools, type WebMcpHandle } from '$lib/webmcp/register';
 	import ConnectBanner from '$lib/components/ConnectBanner.svelte';
 	import BottomNav from '$lib/components/layout/BottomNav.svelte';
 	import MobileContextBar from '$lib/components/layout/MobileContextBar.svelte';
@@ -20,6 +21,8 @@
 	let username = $derived(page.params.username ?? '');
 	let unsubscribeSSE: (() => void) | null = null;
 	let unsubscribeSync: (() => void) | null = null;
+	let webmcpTeardown: WebMcpHandle | null = null;
+	let webmcpToken = 0;
 
 	onMount(() => {
 		// Initialize the sync coordinator (sets up visibilitychange listener once)
@@ -41,6 +44,8 @@
 		unsubscribeSync?.();
 		sseService.disconnect();
 		titleStore.clearPageTitle();
+		webmcpTeardown?.();
+		webmcpTeardown = null;
 	});
 
 	// These two effects are split on purpose:
@@ -111,6 +116,7 @@
 				starredStore.load(wsSlug);
 				syncService.setWorkspace(wsSlug);
 				connectSSE();
+				connectWebMCP();
 			});
 		}
 	});
@@ -190,6 +196,25 @@
 				}
 			}
 		});
+	}
+
+	function connectWebMCP() {
+		webmcpTeardown?.();
+		webmcpTeardown = null;
+		const token = ++webmcpToken;
+		if (!wsSlug) return;
+
+		registerWorkspaceTools(wsSlug)
+			.then((handle) => {
+				// A newer registration superseded this one while the async
+				// tool-surface fetch was in flight — discard the stale tools.
+				if (token !== webmcpToken) {
+					handle();
+					return;
+				}
+				webmcpTeardown = handle;
+			})
+			.catch(() => {});
 	}
 </script>
 

--- a/web/src/routes/[username]/[workspace]/+layout.svelte
+++ b/web/src/routes/[username]/[workspace]/+layout.svelte
@@ -10,6 +10,7 @@
 	import { toastStore } from '$lib/stores/toast.svelte';
 	import { starredStore } from '$lib/stores/starred.svelte';
 	import { titleStore } from '$lib/stores/title.svelte';
+	import { authStore } from '$lib/stores/auth.svelte';
 	import { registerWorkspaceTools, type WebMcpHandle } from '$lib/webmcp/register';
 	import ConnectBanner from '$lib/components/ConnectBanner.svelte';
 	import BottomNav from '$lib/components/layout/BottomNav.svelte';
@@ -44,6 +45,7 @@
 		unsubscribeSync?.();
 		sseService.disconnect();
 		titleStore.clearPageTitle();
+		webmcpToken++;        // invalidate any in-flight registration
 		webmcpTeardown?.();
 		webmcpTeardown = null;
 	});
@@ -119,6 +121,23 @@
 				connectWebMCP();
 			});
 		}
+	});
+
+	// Re-attempt WebMCP registration when the auth gate resolves. The
+	// workspace $effect above runs inside untrack() (so a workspace switch
+	// doesn't drag in the whole workspaces array as a dep), which means it
+	// does NOT react to auth loading. On a cold load where auth resolves
+	// after the workspace effect has already run, this effect re-runs
+	// connectWebMCP() once `webmcp_enabled` + `user` are present. Reading
+	// both here establishes the reactive deps; connectWebMCP() is
+	// idempotent (tears down any prior registration) and re-gated inside
+	// registerWorkspaceTools(), so re-running it is safe.
+	$effect(() => {
+		// Establish reactive deps on the auth gate.
+		const enabled = authStore.session?.webmcp_enabled;
+		const user = authStore.user;
+		if (!enabled || !user) return;
+		connectWebMCP();
 	});
 
 	function connectSSE() {

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config';
+import { fileURLToPath } from 'node:url';
+
+// Standalone vitest config (kept separate from vite.config.ts so the
+// SvelteKit plugin doesn't run during unit tests — the WebMCP unit suite is
+// plain TS, no Svelte components). `$lib` is aliased so any future test that
+// imports a `$lib/...` module resolves; the current WebMCP modules import
+// `$lib/...` only in type positions (erased at runtime).
+export default defineConfig({
+	resolve: {
+		alias: {
+			$lib: fileURLToPath(new URL('./src/lib', import.meta.url)),
+		},
+	},
+	test: {
+		include: ['src/**/*.test.ts'],
+		environment: 'node',
+	},
+});


### PR DESCRIPTION
## Summary

Phase 3 of **PLAN-1888** (TASK-1892): the browser-side WebMCP on-ramp. Adds `web/src/lib/webmcp/` — a feature-detected, `webmcp_enabled`-gated module that registers Pad's MCP catalog tools (built from `GET /api/v1/mcp/tool-surface`, Phase 2) via `document.modelContext.registerTool()`, scoped to the current-route workspace, dispatching **READ** actions to `web/src/lib/api/client.ts` as the logged-in session. Write actions are registered-aware but return a precise "wired in TASK-3b" error.

Builds on the merged Phase 1 (`webmcp_enabled` session flag, #763) and Phase 2 (`/api/v1/mcp/tool-surface` endpoint, #764).

## What's in it

- **`types.d.ts`** — experimental ambient stub for `document.modelContext` (`registerTool(tool, opts)`, `ModelContextTool`, annotations, `toolchange`) so strict TS compiles. Not a runtime guarantee — every caller feature-detects.
- **`api.mcp.toolSurface()`** + `ToolSurface*` types in `client.ts`; plus thin `api.playbooks.list/get` (the only read actions that lacked a client method but had a REST endpoint).
- **`descriptors.ts`** (pure, unit-tested) — tool-surface JSON → `ModelContextTool[]`. **STRIPS the `workspace` param** (DR-4) and sets `readOnlyHint` only when **every** action is `read_only` (DR-2). Maps CLI param types (`flag`→boolean, etc.) to JSON-Schema.
- **`dispatch.ts`** (pure, injectable, unit-tested) — `(tool, action, args) → client`. **Forces the route `wsSlug`** and **rejects any agent-supplied `workspace` arg** (DR-4). Wraps results as `{content:[{type:'text',text:JSON…}]}`.
- **`register.ts`** — lifecycle entry; gated on `webmcp_enabled` + feature-detection + auth; AbortSignal teardown; silent no-op (zero console noise) when unavailable.
- **`+layout.svelte`** — registers on the workspace `$effect`, tears down on switch / `onDestroy` with a token guard; a separate auth-gated `$effect` re-registers when auth resolves on cold load (per CONVE-606).
- **vitest** wired (config + scripts); **25 unit tests**.

## Write-action strategy

**Registered-but-erroring** (the task's primary option, not the gate-out alternative): all catalog tools register so the surface is complete, but the dispatcher returns a precise, non-silent error for write actions (`"<tool>.<action> is a write action — not yet wired in the browser WebMCP surface (follows in TASK-3b)"`). The read/write split is driven by the served per-action `read_only` flag, not a hardcoded TS list. Read actions with no browser REST mapping (e.g. `pad_project.standup`, `pad_meta.bootstrap`) return an honest "not available in the browser" error rather than a faked result — wiring them needs backend endpoints (out of scope, one concern per PR).

## Acceptance criteria

- ✅ `webmcp_enabled=false` OR no `document.modelContext` → nothing registers, zero console noise, no behavior change.
- ✅ Both on → tools register on workspace entry, unregister on leave/switch; reads execute against the API as the logged-in user, return JSON.
- ✅ `workspace` param absent from every registered tool's inputSchema; agent-supplied `workspace` ignored in favor of route `wsSlug` (rejected, unit-tested incl. the equals-route-slug case).
- ✅ Vitest unit tests for the descriptor builder (workspace strip; readOnlyHint all-read vs mixed) and dispatch arg-mapping (wsSlug injection; supplied-workspace rejection).

## Gates

- `cd web && npm run check` — **0 errors**, 8 pre-existing warnings (unrelated files).
- `make check` — **green** (Go tests + govulncheck + npm audit `--omit=dev` + web build + svelte-check). vitest is a devDependency so it doesn't enter the prod audit.
- `cd web && npm run test` (vitest) — **25 passed**.
- No `make test-pg` (no store schema change).

## Codex review

**CLEAN after 2 rounds.** Round 1 found two P1/P2 lifecycle issues (in-flight registration leak on unmount; cold-load auth gating permanently skipping registration) — both fixed (onDestroy bumps the token before teardown; a separate auth-gated `$effect` re-registers once `webmcp_enabled`+`user` resolve). Round 2: VERDICT CLEAN.

Refs TASK-1892 / PLAN-1888

https://claude.ai/code/session_01KmxkPxLksjf1pmrZDpsnTJ