### PR TITLE
feat(web): per-item reorder context menu in all views (IDEA-1898)

### DIFF
--- a/web/src/lib/collections/reorder.test.ts
+++ b/web/src/lib/collections/reorder.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest';
+import type { Item } from '$lib/types';
+import { reorderGroup, reorderedList, disabledDirections } from './reorder';
+
+// Minimal Item stand-in — reorder only touches `id` and `sort_order`.
+function item(id: string, sort_order: number): Item {
+	return { id, sort_order } as unknown as Item;
+}
+
+// Build a group whose sort_order matches its index (the steady state after
+// any prior reorder).
+function dense(ids: string[]): Item[] {
+	return ids.map((id, i) => item(id, i));
+}
+
+describe('reorderedList', () => {
+	it('moves an item to the top', () => {
+		const g = dense(['a', 'b', 'c', 'd']);
+		expect(reorderedList(g, 'c', 'top').map((i) => i.id)).toEqual(['c', 'a', 'b', 'd']);
+	});
+
+	it('moves an item to the bottom', () => {
+		const g = dense(['a', 'b', 'c', 'd']);
+		expect(reorderedList(g, 'b', 'bottom').map((i) => i.id)).toEqual(['a', 'c', 'd', 'b']);
+	});
+
+	it('moves up and down by one', () => {
+		const g = dense(['a', 'b', 'c', 'd']);
+		expect(reorderedList(g, 'c', 'up').map((i) => i.id)).toEqual(['a', 'c', 'b', 'd']);
+		expect(reorderedList(g, 'c', 'down').map((i) => i.id)).toEqual(['a', 'b', 'd', 'c']);
+	});
+
+	it('returns the same reference on a no-op (already at edge / unknown id)', () => {
+		const g = dense(['a', 'b', 'c']);
+		expect(reorderedList(g, 'a', 'up')).toBe(g);
+		expect(reorderedList(g, 'a', 'top')).toBe(g);
+		expect(reorderedList(g, 'c', 'down')).toBe(g);
+		expect(reorderedList(g, 'zzz', 'top')).toBe(g);
+	});
+});
+
+describe('reorderGroup', () => {
+	it('returns only the rows whose sort_order changed', () => {
+		const g = dense(['a', 'b', 'c', 'd']);
+		// Move c up: c and b swap → exactly two rows change.
+		const updates = reorderGroup(g, 'c', 'up');
+		expect(updates.map((u) => [u.item.id, u.sort_order])).toEqual([
+			['c', 1],
+			['b', 2]
+		]);
+	});
+
+	it('reindexes densely on move-to-top (every later row shifts)', () => {
+		const g = dense(['a', 'b', 'c', 'd']);
+		const updates = reorderGroup(g, 'd', 'top');
+		// d→0, then a/b/c each shift down one.
+		expect(updates.map((u) => [u.item.id, u.sort_order])).toEqual([
+			['d', 0],
+			['a', 1],
+			['b', 2],
+			['c', 3]
+		]);
+	});
+
+	it('is collision-safe when every item shares a sort_order', () => {
+		// A freshly-created collection: all sort_order === 0, displayed in
+		// array order. A naive neighbour swap would be a visual no-op; the
+		// dense reindex must still produce distinct, ordered values.
+		const g = [item('a', 0), item('b', 0), item('c', 0)];
+		const updates = reorderGroup(g, 'c', 'top');
+		// New order [c, a, b] reindexes to c=0, a=1, b=2. c was already 0, so
+		// it's (correctly) omitted; a and b shift down to make room. The net
+		// persisted state is distinct & ordered — c floats to the top.
+		expect(updates.map((u) => [u.item.id, u.sort_order])).toEqual([
+			['a', 1],
+			['b', 2]
+		]);
+	});
+
+	it('returns no updates for a no-op move', () => {
+		const g = dense(['a', 'b', 'c']);
+		expect(reorderGroup(g, 'a', 'up')).toEqual([]);
+		expect(reorderGroup(g, 'c', 'bottom')).toEqual([]);
+	});
+});
+
+describe('disabledDirections', () => {
+	it('disables up/top for the first item', () => {
+		const d = disabledDirections(0, 4);
+		expect([...d].sort()).toEqual(['top', 'up']);
+	});
+
+	it('disables down/bottom for the last item', () => {
+		const d = disabledDirections(3, 4);
+		expect([...d].sort()).toEqual(['bottom', 'down']);
+	});
+
+	it('disables every direction for a lone item', () => {
+		const d = disabledDirections(0, 1);
+		expect([...d].sort()).toEqual(['bottom', 'down', 'top', 'up']);
+	});
+
+	it('disables nothing for a middle item', () => {
+		expect(disabledDirections(1, 4).size).toBe(0);
+	});
+});

--- a/web/src/lib/collections/reorder.ts
+++ b/web/src/lib/collections/reorder.ts
@@ -1,0 +1,107 @@
+// Menu-driven manual reordering (IDEA-1898).
+//
+// The companion to drag-to-reorder: a per-item context menu offers
+// "move to top / bottom / up / down" so an item can be repositioned
+// without a drag — essential on touch (board drag is disabled on
+// mobile) and in long lists where dragging across many rows is painful.
+//
+// Both surfaces persist the same `sort_order` field. This helper takes a
+// group of items in their CURRENT displayed order and returns the
+// `sort_order` updates needed to move one item in a direction. It always
+// produces a dense 0..n-1 reindex of the group, so it is collision-safe
+// even when siblings currently share a `sort_order` (a naive neighbour
+// swap would be a visual no-op in that case). Callers persist only the
+// rows that actually changed — the returned list is already filtered to
+// those.
+import type { Item } from '$lib/types';
+
+export type ReorderDirection = 'top' | 'bottom' | 'up' | 'down';
+
+export interface ReorderUpdate {
+	item: Item;
+	sort_order: number;
+}
+
+/**
+ * Return `ordered` with `itemId` moved one step or to an end per `dir`.
+ * Returns the SAME array reference when the move is a no-op (item already
+ * at the target edge, or not found) so callers can cheaply detect it.
+ */
+export function reorderedList(
+	ordered: Item[],
+	itemId: string,
+	dir: ReorderDirection
+): Item[] {
+	const from = ordered.findIndex((i) => i.id === itemId);
+	if (from === -1) return ordered;
+
+	let to: number;
+	switch (dir) {
+		case 'top':
+			to = 0;
+			break;
+		case 'bottom':
+			to = ordered.length - 1;
+			break;
+		case 'up':
+			to = from - 1;
+			break;
+		case 'down':
+			to = from + 1;
+			break;
+	}
+	to = Math.max(0, Math.min(ordered.length - 1, to));
+	if (to === from) return ordered;
+
+	const next = [...ordered];
+	const [moved] = next.splice(from, 1);
+	next.splice(to, 0, moved);
+	return next;
+}
+
+/**
+ * Compute the `sort_order` updates to move `itemId` within `ordered`
+ * (the group's items in their current displayed order) one step or to an
+ * end, per `dir`. Returns only the rows whose `sort_order` changes, each
+ * carrying the item and its new dense index. Empty when the move is a
+ * no-op (item already at the target edge, or not found).
+ */
+export function reorderGroup(
+	ordered: Item[],
+	itemId: string,
+	dir: ReorderDirection
+): ReorderUpdate[] {
+	const next = reorderedList(ordered, itemId, dir);
+	if (next === ordered) return [];
+
+	// Dense reindex the whole group, then keep only rows that moved. The
+	// dense reindex is what makes this collision-safe: even if every item
+	// currently shares sort_order=0 (a freshly-created collection), the
+	// result assigns distinct 0..n-1 values in the new visual order.
+	const updates: ReorderUpdate[] = [];
+	next.forEach((item, index) => {
+		if (item.sort_order !== index) {
+			updates.push({ item, sort_order: index });
+		}
+	});
+	return updates;
+}
+
+/**
+ * Which directions are unavailable for the item at `index` in a group of
+ * `length` items — used to hide no-op menu entries (first item can't move
+ * up / to top; last can't move down / to bottom; a lone item moves
+ * nowhere).
+ */
+export function disabledDirections(index: number, length: number): Set<ReorderDirection> {
+	const disabled = new Set<ReorderDirection>();
+	if (index <= 0) {
+		disabled.add('up');
+		disabled.add('top');
+	}
+	if (index >= length - 1) {
+		disabled.add('down');
+		disabled.add('bottom');
+	}
+	return disabled;
+}

--- a/web/src/lib/components/ChildItems.svelte
+++ b/web/src/lib/components/ChildItems.svelte
@@ -9,6 +9,13 @@
 	import { parseFields, formatItemRef } from '$lib/types';
 	import { dndzone, TRIGGERS, SHADOW_ITEM_MARKER_PROPERTY_NAME } from 'svelte-dnd-action';
 	import type { DndEvent } from 'svelte-dnd-action';
+	import {
+		reorderGroup,
+		reorderedList,
+		disabledDirections,
+		type ReorderDirection
+	} from '$lib/collections/reorder';
+	import ItemActionsMenu from './collections/ItemActionsMenu.svelte';
 	import ChildChart from './ChildChart.svelte';
 	import NestedChildren from './NestedChildren.svelte';
 
@@ -124,6 +131,32 @@
 		}
 	}
 
+	// Menu-driven reorder (IDEA-1898) — the non-drag counterpart, scoped to
+	// the child's status group. Unlike List/Board (which persist through the
+	// page's optimistic local index), ChildItems owns its own `children`
+	// state, so it updates the displayed group optimistically here and
+	// persists the changed rows via the same per-child update loop the drag
+	// path uses. A canonical reload (SSE/sync) settles it afterward.
+	async function reorderChild(status: string, child: Item, dir: ReorderDirection) {
+		const grp = (groupData[status] ?? []).filter(
+			(i: any) => !i[SHADOW_ITEM_MARKER_PROPERTY_NAME]
+		);
+		const reordered = reorderedList(grp, child.id, dir);
+		if (reordered === grp) return; // no-op (edge of group)
+
+		// Optimistic: show the new order immediately with dense sort_order.
+		groupData[status] = reordered.map((it, idx) => ({ ...it, sort_order: idx }));
+
+		const updates = reorderGroup(grp, child.id, dir);
+		try {
+			for (const u of updates) {
+				await api.items.update(wsSlug, u.item.id, { sort_order: u.sort_order });
+			}
+		} catch (e) {
+			console.error('Failed to persist reorder:', e);
+		}
+	}
+
 	// ── Data loading ─────────────────────────────────────────────────────────
 
 	async function loadChildren() {
@@ -219,7 +252,7 @@
 					onconsider={(e) => handleConsider(status, e)}
 					onfinalize={(e) => handleFinalize(status, e)}
 				>
-					{#each groupData[status] ?? [] as child (child.id)}
+					{#each groupData[status] ?? [] as child, i (child.id)}
 						{@const fields = parseFields(child)}
 						{@const isDone = terminal.includes(fields.status)}
 						{@const isExpanded = expandedIds.has(child.id)}
@@ -244,6 +277,14 @@
 										</span>
 									{/if}
 								</a>
+								{#if canEdit}
+									<ItemActionsMenu
+										item={child}
+										label={child.title}
+										disabledDirs={disabledDirections(i, (groupData[status] ?? []).length)}
+										onReorder={(dir) => reorderChild(status, child, dir)}
+									/>
+								{/if}
 							</div>
 							{#if canExpand && isExpanded}
 								<NestedChildren {wsSlug} {username} parentSlug={child.slug} depth={1} maxDepth={3} {terminalStatuses} />
@@ -384,6 +425,10 @@
 		border-radius: var(--radius-sm);
 	}
 
+	.child-row-container :global(.item-actions-menu) {
+		padding: 0 var(--space-1);
+	}
+
 	.child-row {
 		display: flex;
 		align-items: center;
@@ -397,6 +442,10 @@
 		-webkit-touch-callout: none;
 		-webkit-user-select: none;
 		user-select: none;
+		/* Fill the row so the reorder kebab (a sibling of this <a> in the
+		   flex container) sits flush right. */
+		flex: 1;
+		min-width: 0;
 	}
 
 	.child-row:hover {
@@ -407,7 +456,7 @@
 		cursor: grabbing;
 	}
 
-	.child-row:last-child {
+	.child-item-wrapper:last-child .child-row {
 		border-bottom: none;
 	}
 

--- a/web/src/lib/components/collections/BoardView.svelte
+++ b/web/src/lib/components/collections/BoardView.svelte
@@ -2,6 +2,7 @@
 	import type { Item, Collection } from '$lib/types';
 	import { parseSchema, parseFields } from '$lib/types';
 	import { itemComparator, type SortMode } from '$lib/collections/itemSort';
+	import { reorderGroup, disabledDirections, type ReorderDirection } from '$lib/collections/reorder';
 	import { dndzone, TRIGGERS, SHADOW_ITEM_MARKER_PROPERTY_NAME } from 'svelte-dnd-action';
 	import type { DndEvent } from 'svelte-dnd-action';
 	import ItemCard from './ItemCard.svelte';
@@ -327,6 +328,28 @@
 		return value.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
 	}
 
+	// Menu-driven reorder (IDEA-1898), lane-relative — the non-drag
+	// counterpart for touch (board drag is disabled on mobile) and long
+	// lanes. Scope is the item's own lane, matching the drag handler.
+	function reorderItem(columnValue: string, item: Item, dir: ReorderDirection) {
+		if (!onReorder) return;
+		const grp = (columnData[columnValue] ?? []).filter(
+			(i: any) => !i[SHADOW_ITEM_MARKER_PROPERTY_NAME]
+		);
+		const updates = reorderGroup(grp, item.id, dir);
+		if (updates.length > 0) {
+			onReorder(updates.map((u) => ({ slug: u.item.id, sort_order: u.sort_order })));
+		}
+	}
+
+	// Per-lane gate: edit permission, not search-preserving order, and the
+	// lane is in manual sort (its override, else page sort). Deliberately
+	// NOT gated on isMobile — unlike drag (disabled on mobile), the menu IS
+	// the mobile reorder mechanism.
+	function canReorderLane(columnValue: string): boolean {
+		return canEdit && !preserveOrder && laneSortFor(columnValue) === 'manual';
+	}
+
 	function columnCssClass(value: string): string {
 		switch (value) {
 			case 'in_progress':
@@ -481,7 +504,7 @@
 				onfinalize={(e) => handleFinalize(colValue, e)}
 				oncontextmenu={(e) => e.preventDefault()}
 			>
-				{#each colItems as item (item.id)}
+				{#each colItems as item, i (item.id)}
 					<div class="card-wrapper" class:no-drag={isMobile}>
 						<ItemCard
 							{item}
@@ -492,6 +515,8 @@
 							onStatusClick={onStatusChange}
 							progress={itemProgress?.[item.id] ?? null}
 							{progressLabel}
+							onReorderItem={canReorderLane(colValue) ? (it, dir) => reorderItem(colValue, it, dir) : undefined}
+							reorderDisabledDirs={canReorderLane(colValue) ? disabledDirections(i, colItems.length) : undefined}
 						/>
 					</div>
 				{/each}

--- a/web/src/lib/components/collections/ItemActionsMenu.svelte
+++ b/web/src/lib/components/collections/ItemActionsMenu.svelte
@@ -1,0 +1,301 @@
+<!--
+	ItemActionsMenu — per-item reorder kebab (IDEA-1898).
+
+	A small top-right menu on each item with move-to-top / up / down /
+	move-to-bottom. The menu-driven counterpart to drag-to-reorder: works
+	on touch (board drag is disabled on mobile) and in long lists where
+	dragging across many rows is painful.
+
+	The host (ListView / BoardView / TableView / ChildItems) owns all
+	ordering context — it passes a bound `onReorder(dir)` and the set of
+	`disabledDirs` for this item's position. This component is purely the
+	menu surface: open/close, positioning, a11y, and emitting the chosen
+	direction.
+
+	Why a dedicated component (not QuickActionsMenu): QuickActionsMenu is
+	coupled to prompt-template quick actions (resolve/copy, inline create
+	form, emoji picker). This is a tiny fixed 4-action menu, so a focused
+	component is simpler than bending that one.
+-->
+<script lang="ts">
+	import { tick } from 'svelte';
+	import type { Item } from '$lib/types';
+	import type { ReorderDirection } from '$lib/collections/reorder';
+
+	interface Props {
+		item: Item;
+		/** Fire the reorder. The host has the item + group context bound. */
+		onReorder: (dir: ReorderDirection) => void;
+		/** Directions to hide (edge of group) — see disabledDirections(). */
+		disabledDirs?: Set<ReorderDirection>;
+		/** Accessible label suffix, e.g. the item title. */
+		label?: string;
+	}
+
+	let { item, onReorder, disabledDirs, label }: Props = $props();
+
+	interface Action {
+		dir: ReorderDirection;
+		icon: string;
+		text: string;
+	}
+	const ALL_ACTIONS: Action[] = [
+		{ dir: 'top', icon: '⤒', text: 'Move to top' },
+		{ dir: 'up', icon: '↑', text: 'Move up' },
+		{ dir: 'down', icon: '↓', text: 'Move down' },
+		{ dir: 'bottom', icon: '⤓', text: 'Move to bottom' }
+	];
+	let actions = $derived(ALL_ACTIONS.filter((a) => !disabledDirs?.has(a.dir)));
+
+	let open = $state(false);
+	let triggerEl = $state<HTMLButtonElement>();
+	let panelEl = $state<HTMLDivElement>();
+	let x = $state(0);
+	let y = $state(0);
+	let activeIndex = $state(0);
+
+	const PANEL_W = 188;
+	const ROW_H = 38;
+
+	/**
+	 * Portal the desktop panel to <body>. ItemCard's host rows establish
+	 * paint containment via `content-visibility: auto` (ListView rows,
+	 * BoardView cards, TableView rows — all for off-screen virtualization),
+	 * which clips descendant overflow to the row box. An absolutely-
+	 * positioned dropdown would be sheared off at ~36–60px; a body-level
+	 * portal with fixed coords escapes the containment entirely. Mirrors
+	 * the EmojiPickerButton pattern.
+	 */
+	function portal(node: HTMLElement) {
+		document.body.appendChild(node);
+		return {
+			destroy() {
+				node.remove();
+			}
+		};
+	}
+
+	function openMenu() {
+		if (!triggerEl || actions.length === 0) return;
+		const r = triggerEl.getBoundingClientRect();
+		// Right-align the panel under the trigger; flip above if it would
+		// leave the viewport, clamp to the left edge. The small fixed
+		// dropdown works on every viewport (it fits a 188px panel even on a
+		// 320px phone), so there's no separate mobile sheet — a sheet for a
+		// 4-item menu read as "taking over the card".
+		let left = r.right - PANEL_W;
+		if (left < 8) left = 8;
+		const estH = actions.length * ROW_H + 8;
+		let top = r.bottom + 4;
+		if (top + estH > window.innerHeight - 8) {
+			top = Math.max(8, r.top - estH - 4);
+		}
+		x = left;
+		y = top;
+		open = true;
+		activeIndex = 0;
+		tick().then(() => focusItem(0));
+	}
+
+	function closeMenu(returnFocus = true) {
+		open = false;
+		if (returnFocus) triggerEl?.focus();
+	}
+
+	function pick(dir: ReorderDirection) {
+		if (disabledDirs?.has(dir)) return;
+		// Close before firing so the menu can't be machine-gunned against
+		// the optimistic reorder state — a second move needs a reopen, by
+		// which point the new order has settled. (Drag is naturally
+		// debounced; menu clicks are not.)
+		closeMenu(false);
+		onReorder(dir);
+	}
+
+	function onTriggerClick(e: MouseEvent) {
+		// The trigger lives inside the card's <a>; stop the click from
+		// navigating (mirrors toggleStar in ItemCard).
+		e.preventDefault();
+		e.stopPropagation();
+		if (open) closeMenu();
+		else openMenu();
+	}
+
+	function focusItem(i: number) {
+		const btns = panelEl?.querySelectorAll<HTMLButtonElement>('.iam-item');
+		btns?.[i]?.focus();
+	}
+
+	function onPanelKeydown(e: KeyboardEvent) {
+		if (e.key === 'Escape') {
+			e.preventDefault();
+			closeMenu();
+		} else if (e.key === 'ArrowDown') {
+			e.preventDefault();
+			activeIndex = (activeIndex + 1) % actions.length;
+			focusItem(activeIndex);
+		} else if (e.key === 'ArrowUp') {
+			e.preventDefault();
+			activeIndex = (activeIndex - 1 + actions.length) % actions.length;
+			focusItem(activeIndex);
+		} else if (e.key === 'Home') {
+			e.preventDefault();
+			activeIndex = 0;
+			focusItem(0);
+		} else if (e.key === 'End') {
+			e.preventDefault();
+			activeIndex = actions.length - 1;
+			focusItem(activeIndex);
+		}
+	}
+
+	// Instance-scoped outside-click: don't match a shared class (that would
+	// also match OTHER item menus' triggers and keep this one open when
+	// another opens). Check this instance's own trigger + portaled panel.
+	function onWindowClick(e: MouseEvent) {
+		if (!open) return;
+		const t = e.target as Node | null;
+		if (!t) return;
+		if (triggerEl?.contains(t) || panelEl?.contains(t)) return;
+		closeMenu(false);
+	}
+
+	// A scroll while open detaches the fixed panel from its row — close it.
+	// Capture catches inner scroll containers (board column, table scroll)
+	// in addition to the window. Only listens while open.
+	$effect(() => {
+		if (!open) return;
+		const onScroll = () => closeMenu(false);
+		window.addEventListener('scroll', onScroll, true);
+		return () => window.removeEventListener('scroll', onScroll, true);
+	});
+</script>
+
+<svelte:window onclick={onWindowClick} />
+
+{#if actions.length > 0}
+	<span class="item-actions-menu">
+		<button
+			bind:this={triggerEl}
+			type="button"
+			class="iam-trigger"
+			class:open
+			aria-haspopup="menu"
+			aria-expanded={open}
+			aria-label={label ? `Reorder ${label}` : 'Reorder item'}
+			title="Reorder"
+			onclick={onTriggerClick}
+		>
+			⋮
+		</button>
+
+		{#if open}
+			<div
+				bind:this={panelEl}
+				class="iam-panel"
+				role="menu"
+				tabindex="-1"
+				use:portal
+				style="position:fixed; left:{x}px; top:{y}px; z-index:99999;"
+				onkeydown={onPanelKeydown}
+			>
+				{#each actions as a, i (a.dir)}
+					<button
+						type="button"
+						class="iam-item"
+						role="menuitem"
+						tabindex={i === activeIndex ? 0 : -1}
+						onclick={() => pick(a.dir)}
+					>
+						<span class="iam-icon" aria-hidden="true">{a.icon}</span>
+						{a.text}
+					</button>
+				{/each}
+			</div>
+		{/if}
+	</span>
+{/if}
+
+<style>
+	.item-actions-menu {
+		display: inline-flex;
+		flex-shrink: 0;
+	}
+
+	.iam-trigger {
+		border: none;
+		background: none;
+		cursor: pointer;
+		padding: 0 2px;
+		font-size: 1em;
+		line-height: 1;
+		color: var(--text-muted);
+		/* Steady (not hover-only) opacity so it stays reachable on touch,
+		   where the menu is the only reorder mechanism. */
+		opacity: 0.5;
+		border-radius: var(--radius-sm);
+		transition: opacity 0.15s, color 0.15s;
+	}
+
+	.iam-trigger:hover,
+	.iam-trigger.open {
+		opacity: 1;
+		color: var(--text-primary);
+	}
+
+	.iam-trigger:focus-visible {
+		opacity: 1;
+		outline: 2px solid var(--accent-blue);
+		outline-offset: 1px;
+	}
+
+	/* Portaled panel lives at <body>, so it can't rely on any ancestor
+	   variables being in scope — it uses the same global custom props the
+	   rest of the app's surfaces use. */
+	:global(.iam-panel) {
+		min-width: 188px;
+		padding: var(--space-1);
+		background: var(--bg-primary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius-md);
+		box-shadow: var(--shadow-md, 0 4px 12px rgba(0, 0, 0, 0.15));
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+	}
+
+	:global(.iam-item) {
+		display: flex;
+		align-items: center;
+		gap: var(--space-2);
+		width: 100%;
+		padding: 8px 10px;
+		background: none;
+		border: none;
+		border-radius: var(--radius-sm);
+		color: var(--text-primary);
+		font-size: 0.875em;
+		text-align: left;
+		cursor: pointer;
+	}
+
+	:global(.iam-item:hover),
+	:global(.iam-item:focus-visible) {
+		background: var(--bg-hover);
+		outline: none;
+	}
+
+	:global(.iam-icon) {
+		width: 1.1em;
+		text-align: center;
+		flex-shrink: 0;
+		color: var(--text-muted);
+	}
+
+	/* Comfortable tap targets on touch without a separate sheet. */
+	@media (pointer: coarse) {
+		:global(.iam-item) {
+			padding: 12px 12px;
+		}
+	}
+</style>

--- a/web/src/lib/components/collections/ItemCard.svelte
+++ b/web/src/lib/components/collections/ItemCard.svelte
@@ -4,6 +4,8 @@
 	import type { Item, Collection } from '$lib/types';
 	import { parseFields, parseSchema, parseTags, formatItemRef, itemUrlId } from '$lib/types';
 	import { starredStore } from '$lib/stores/starred.svelte';
+	import ItemActionsMenu from './ItemActionsMenu.svelte';
+	import type { ReorderDirection } from '$lib/collections/reorder';
 
 	interface Props {
 		item: Item;
@@ -15,9 +17,19 @@
 		onStatusClick?: (item: Item, newStatus: string) => void;
 		progress?: { total: number; done: number; label?: string } | null;
 		progressLabel?: string;
+		/**
+		 * Opt-in per-item reorder menu (IDEA-1898). The host (ListView /
+		 * BoardView / TableView) passes a bound handler + the disabled
+		 * directions for this item's position in its group. When omitted —
+		 * the default — no menu renders, so read-only / aggregation views
+		 * (share pages, starred, tags, dashboard) get nothing. ItemCard
+		 * stays dumb: it forwards these, it has no ordering context.
+		 */
+		onReorderItem?: (item: Item, dir: ReorderDirection) => void;
+		reorderDisabledDirs?: Set<ReorderDirection>;
 	}
 
-	let { item, collection, compact = false, focused = false, showCollection = false, statusOptions, onStatusClick, progress = null, progressLabel = 'tasks' }: Props = $props();
+	let { item, collection, compact = false, focused = false, showCollection = false, statusOptions, onStatusClick, progress = null, progressLabel = 'tasks', onReorderItem, reorderDisabledDirs }: Props = $props();
 
 	let wsSlug = $derived(page.params.workspace ?? '');
 	let username = $derived(page.params.username ?? '');
@@ -141,6 +153,14 @@
 			</span>
 		{/if}
 		{#if itemRef}<span class="item-ref">{itemRef}</span>{/if}
+		{#if onReorderItem}
+			<ItemActionsMenu
+				{item}
+				disabledDirs={reorderDisabledDirs}
+				label={item.title}
+				onReorder={(dir) => onReorderItem?.(item, dir)}
+			/>
+		{/if}
 	</div>
 
 	<div class="card-title">
@@ -276,6 +296,13 @@
 		display: flex;
 		align-items: center;
 		gap: var(--space-2);
+	}
+
+	/* Reorder kebab sits at the far right of the top row. When a PR badge
+	   is present the `.has-pr` padding-right reservation keeps it clear of
+	   the absolutely-positioned badge (kebab lands just left of it). */
+	.card-top-row :global(.item-actions-menu) {
+		margin-left: auto;
 	}
 
 	/* Reserve horizontal room on the right of the top row for the

--- a/web/src/lib/components/collections/ListView.svelte
+++ b/web/src/lib/components/collections/ListView.svelte
@@ -2,6 +2,7 @@
 	import type { Item, Collection } from '$lib/types';
 	import { parseSchema, parseFields } from '$lib/types';
 	import { itemComparator, type SortMode } from '$lib/collections/itemSort';
+	import { reorderGroup, disabledDirections, type ReorderDirection } from '$lib/collections/reorder';
 	import { SvelteSet } from 'svelte/reactivity';
 	import { dndzone, TRIGGERS, SHADOW_ITEM_MARKER_PROPERTY_NAME } from 'svelte-dnd-action';
 	import type { DndEvent } from 'svelte-dnd-action';
@@ -224,6 +225,23 @@
 		return groupItems.filter((i: any) => !i[SHADOW_ITEM_MARKER_PROPERTY_NAME]).length;
 	}
 
+	// Menu-driven reorder (IDEA-1898) — the non-drag counterpart. Gated on
+	// the same conditions as item drag: edit permission, manual sort
+	// (sort_order is only honored then), and not while search is
+	// preserving relevance order.
+	let canReorderItems = $derived(canEdit && sortMode === 'manual' && !preserveOrder);
+
+	function reorderItem(groupName: string, item: Item, dir: ReorderDirection) {
+		if (!onReorder) return;
+		const grp = (groupData[groupName] ?? []).filter(
+			(i: any) => !i[SHADOW_ITEM_MARKER_PROPERTY_NAME]
+		);
+		const updates = reorderGroup(grp, item.id, dir);
+		if (updates.length > 0) {
+			onReorder(updates.map((u) => ({ slug: u.item.id, sort_order: u.sort_order })));
+		}
+	}
+
 	function toggleGroup(groupName: string) {
 		if (collapsedGroups.has(groupName)) {
 			collapsedGroups.delete(groupName);
@@ -329,7 +347,7 @@
 						onfinalize={(e) => handleFinalize(groupName, e)}
 						oncontextmenu={(e) => e.preventDefault()}
 					>
-						{#each grpItems as item (item.id)}
+						{#each grpItems as item, i (item.id)}
 							<div class="list-row" class:kb-focused={focusedItemId === item.id}>
 								<ItemCard
 									{item}
@@ -340,6 +358,8 @@
 									onStatusClick={onStatusChange}
 									progress={itemProgress?.[item.id] ?? null}
 									{progressLabel}
+									onReorderItem={canReorderItems ? (it, dir) => reorderItem(groupName, it, dir) : undefined}
+									reorderDisabledDirs={canReorderItems ? disabledDirections(i, grpItems.length) : undefined}
 								/>
 							</div>
 						{/each}

--- a/web/src/lib/components/collections/TableView.svelte
+++ b/web/src/lib/components/collections/TableView.svelte
@@ -1,8 +1,11 @@
 <script lang="ts">
 	import type { Item, Collection } from '$lib/types';
 	import { parseSchema, parseFields, formatItemRef, itemUrlId } from '$lib/types';
+	import { itemComparator, type SortMode } from '$lib/collections/itemSort';
+	import { reorderGroup, disabledDirections, type ReorderDirection } from '$lib/collections/reorder';
 	import { page } from '$app/state';
 	import EmptyState from '../common/EmptyState.svelte';
+	import ItemActionsMenu from './ItemActionsMenu.svelte';
 
 	interface Props {
 		items: Item[];
@@ -12,6 +15,17 @@
 		oncreate?: () => void;
 		itemProgress?: Record<string, { total: number; done: number }>;
 		progressLabel?: string;
+		/**
+		 * Reorder plumbing (IDEA-1898). Unlike List/Board, the table had no
+		 * manual-order surface — it only column-header-sorts ephemerally. To
+		 * support the reorder menu it now honors the page-wide `sortMode`
+		 * (manual ⇒ stored sort_order) when no column-header sort is active,
+		 * and persists moves through `onReorder`.
+		 */
+		onReorder?: (updates: { slug: string; sort_order: number }[]) => void;
+		canEdit?: boolean;
+		preserveOrder?: boolean;
+		sortMode?: SortMode;
 	}
 
 	let {
@@ -21,7 +35,11 @@
 		onStatusChange,
 		oncreate,
 		itemProgress,
-		progressLabel
+		progressLabel,
+		onReorder,
+		canEdit = true,
+		preserveOrder = false,
+		sortMode = 'manual'
 	}: Props = $props();
 
 	let resolvedWsSlug = $derived(wsSlug || page.params.workspace || '');
@@ -33,7 +51,13 @@
 	let sortDir = $state<'asc' | 'desc'>('asc');
 
 	let sortedItems = $derived.by(() => {
-		if (!sortKey) return items;
+		// No column-header sort active: fall back to the page-wide sort so
+		// the table reflects the same order as List/Board (manual ⇒ stored
+		// sort_order). `preserveOrder` (search active) keeps the parent's
+		// relevance order untouched.
+		if (!sortKey) {
+			return preserveOrder ? items : [...items].sort(itemComparator(sortMode, collection));
+		}
 
 		const sorted = [...items].sort((a, b) => {
 			let aVal: any;
@@ -68,6 +92,22 @@
 		} else {
 			sortKey = key;
 			sortDir = 'asc';
+		}
+	}
+
+	// Reorder is only meaningful in manual sort with no column-header
+	// override (a column sort would immediately re-order the rows) and not
+	// while search preserves relevance order. A column-header click thus
+	// transparently hides the menu until the user clears it back to the
+	// default (manual) order. The table is a flat list, so the group is the
+	// whole displayed set.
+	let canReorder = $derived(canEdit && sortMode === 'manual' && !sortKey && !preserveOrder && !!onReorder);
+
+	function reorderItem(item: Item, dir: ReorderDirection) {
+		if (!onReorder) return;
+		const updates = reorderGroup(sortedItems, item.id, dir);
+		if (updates.length > 0) {
+			onReorder(updates.map((u) => ({ slug: u.item.id, sort_order: u.sort_order })));
 		}
 	}
 
@@ -124,7 +164,13 @@
 	 * field columns, matching the pre-refactor `.col-*` widths.
 	 */
 	let gridTemplate = $derived(
-		['70px', 'minmax(200px, 1fr)', ...visibleFields.map(() => 'auto'), '90px'].join(' ')
+		[
+			'70px',
+			'minmax(200px, 1fr)',
+			...visibleFields.map(() => 'auto'),
+			'90px',
+			...(canReorder ? ['44px'] : [])
+		].join(' ')
 	);
 </script>
 
@@ -148,8 +194,11 @@
 				</div>
 			{/each}
 			<div class="table-cell col-updated" role="columnheader">Updated</div>
+			{#if canReorder}
+				<div class="table-cell col-actions" role="columnheader"><span class="sr-only">Reorder</span></div>
+			{/if}
 		</div>
-		{#each sortedItems as item (item.id)}
+		{#each sortedItems as item, i (item.id)}
 			{@const fields = parseFields(item)}
 			<div class="table-row" role="row">
 				<div class="table-cell col-ref" role="cell"><span class="ref">{formatItemRef(item) ?? ''}</span></div>
@@ -175,6 +224,16 @@
 					</div>
 				{/each}
 				<div class="table-cell col-updated" role="cell"><span class="cell-date">{relativeTime(item.updated_at)}</span></div>
+				{#if canReorder}
+					<div class="table-cell col-actions" role="cell">
+						<ItemActionsMenu
+							{item}
+							label={item.title}
+							disabledDirs={disabledDirections(i, sortedItems.length)}
+							onReorder={(dir) => reorderItem(item, dir)}
+						/>
+					</div>
+				{/if}
 			</div>
 		{/each}
 	</div>
@@ -352,5 +411,23 @@
 	.cell-progress-text {
 		font-size: 0.7em;
 		color: var(--text-muted);
+	}
+
+	.col-actions {
+		justify-content: center;
+		padding-left: 0;
+		padding-right: var(--space-2);
+	}
+
+	.sr-only {
+		position: absolute;
+		width: 1px;
+		height: 1px;
+		padding: 0;
+		margin: -1px;
+		overflow: hidden;
+		clip: rect(0, 0, 0, 0);
+		white-space: nowrap;
+		border: 0;
 	}
 </style>

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -2117,9 +2117,13 @@
 				{collection}
 				{wsSlug}
 				onStatusChange={handleStatusChange}
+				onReorder={handleReorder}
 				oncreate={canEditThisCollection ? openQuickCreate : undefined}
 				{itemProgress}
 				{progressLabel}
+				canEdit={canEditThisCollection}
+				preserveOrder={searchQuery.trim() !== ''}
+				{sortMode}
 			/>
 		{:else}
 			<ListView


### PR DESCRIPTION
## What

Adds a small kebab menu to the top-right of each item with manual reorder actions — **move to top / up / down / move to bottom** — the menu-driven counterpart to drag-to-reorder. Works on touch (board drag is disabled on mobile) and in long lists where dragging across many rows is painful. Web UI only; reuses the existing `sort_order` field (no backend, no migration).

## How

- **`lib/collections/reorder.ts`** — pure, collision-safe dense-reindex helper (always reindexes the group densely, so it works even when siblings share a `sort_order`). Unit-tested (`reorder.test.ts`, 12 cases).
- **`ItemActionsMenu.svelte`** — small dropdown portaled to `<body>` so it escapes the `content-visibility` paint-clipping on virtualized list/board/table rows. Positions on-screen on any viewport (clamps + flips above near the bottom edge); `aria-haspopup`/`expanded` + arrow-key nav + focus return; close-on-pick concurrency guard.
- Wired into **ItemCard** (opt-in `onReorderItem` / `reorderDisabledDirs`), **ListView**, **BoardView** (lane-relative; menu enabled on mobile where drag is off), **ChildItems** (own optimistic reorder + update loop), and **TableView** (now honors manual `sort_order` + `onReorder` + an actions column; a column-header sort transparently hides the menu).

## Gating

Mirrors the existing drag gate everywhere: `canEdit && manual sort && !search`. Read-only / aggregation views (share pages, starred, tags, role board) pass no callback, so no menu renders there.

## Verification

- `svelte-check` 0 errors · `vitest` 12/12 · `npm run build` ✓
- Codex review: CLEAN
- Browser-verified (Playwright) at 1366px and 390px: small dropdown, dismisses on outside click, edge directions correctly hidden, and a Move-down persists across reload.

https://claude.ai/code/session_01HxBkAMiFBtCRJ2tKSCt3ST