### PR TITLE
fix(server): consistent soft-delete handling across item sub-resources

### DIFF
--- a/internal/server/handlers_activity.go
+++ b/internal/server/handlers_activity.go
@@ -149,7 +149,11 @@ func (s *Server) enrichActivities(activities []models.Activity) {
 		if activities[i].DocumentID == "" {
 			continue
 		}
-		item, err := s.store.GetItem(activities[i].DocumentID)
+		// Include-deleted so an archived item's activity is enriched with its
+		// real title/slug/collection instead of staying blank — a blank row
+		// otherwise masquerades as workspace-level activity and bypasses the
+		// collection-visibility filter applied by the caller.
+		item, err := s.store.GetItemIncludeDeleted(activities[i].DocumentID)
 		if err != nil || item == nil {
 			continue
 		}

--- a/internal/server/handlers_artifact_export.go
+++ b/internal/server/handlers_artifact_export.go
@@ -42,7 +42,7 @@ func (s *Server) handleExportItemArtifact(w http.ResponseWriter, r *http.Request
 	}
 
 	itemSlug := chi.URLParam(r, "itemSlug")
-	item, err := s.store.ResolveItem(ws.ID, itemSlug)
+	item, err := s.store.ResolveItemIncludeDeleted(ws.ID, itemSlug)
 	if err != nil {
 		writeInternalError(w, err)
 		return

--- a/internal/server/handlers_backlinks.go
+++ b/internal/server/handlers_backlinks.go
@@ -48,7 +48,7 @@ func (s *Server) handleGetItemBacklinks(w http.ResponseWriter, r *http.Request) 
 	}
 
 	itemSlug := chi.URLParam(r, "itemSlug")
-	item, err := s.store.ResolveItem(workspaceID, itemSlug)
+	item, err := s.store.ResolveItemIncludeDeleted(workspaceID, itemSlug)
 	if err != nil {
 		writeInternalError(w, err)
 		return

--- a/internal/server/handlers_comments.go
+++ b/internal/server/handlers_comments.go
@@ -20,7 +20,7 @@ func (s *Server) handleListComments(w http.ResponseWriter, r *http.Request) {
 	}
 
 	itemSlug := chi.URLParam(r, "itemSlug")
-	item, err := s.store.ResolveItem(workspaceID, itemSlug)
+	item, err := s.store.ResolveItemIncludeDeleted(workspaceID, itemSlug)
 	if err != nil {
 		writeInternalError(w, err)
 		return
@@ -75,7 +75,7 @@ func (s *Server) handleCreateComment(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if item == nil {
-		writeError(w, http.StatusNotFound, "not_found", "Item not found")
+		s.writeItemResolveError(w, r, workspaceID, itemSlug)
 		return
 	}
 	if !s.requireItemVisible(w, r, workspaceID, item) {

--- a/internal/server/handlers_dashboard.go
+++ b/internal/server/handlers_dashboard.go
@@ -705,22 +705,28 @@ func (s *Server) buildDashboardResponse(workspaceID string, r *http.Request) (*D
 				CreatedAt: a.CreatedAt.Format("2006-01-02T15:04:05Z"),
 				Metadata:  a.Metadata,
 			}
-			// Look up item title if we have a document/item ID
+			// Look up item title if we have a document/item ID. Use the
+			// include-deleted lookup so an archived item's activity renders
+			// with its real title/slug — gated by the same visibility checks —
+			// instead of a blank "ghost" row that also skipped those gates.
+			// If the referenced item is gone entirely, drop the row rather
+			// than emit a blank entry.
 			if a.DocumentID != "" {
-				item, err := s.store.GetItem(a.DocumentID)
-				if err == nil && item != nil {
-					// Skip items in hidden collections
-					if visibleSlugSet != nil && !visibleSlugSet[item.CollectionSlug] {
-						continue
-					}
-					// For users with item grants: skip items not directly granted
-					if !s.isItemVisibleToGuest(r, workspaceID, item, dashFullCollIDs, dashGrantedItemIDs) {
-						continue
-					}
-					da.ItemTitle = item.Title
-					da.ItemSlug = item.Slug
-					da.CollectionSlug = item.CollectionSlug
+				item, err := s.store.GetItemIncludeDeleted(a.DocumentID)
+				if err != nil || item == nil {
+					continue
 				}
+				// Skip items in hidden collections
+				if visibleSlugSet != nil && !visibleSlugSet[item.CollectionSlug] {
+					continue
+				}
+				// For users with item grants: skip items not directly granted
+				if !s.isItemVisibleToGuest(r, workspaceID, item, dashFullCollIDs, dashGrantedItemIDs) {
+					continue
+				}
+				da.ItemTitle = item.Title
+				da.ItemSlug = item.Slug
+				da.CollectionSlug = item.CollectionSlug
 			} else if workspaceRole(r) == "guest" {
 				// Workspace-level activity (no item) — skip for guests since
 				// it may contain audit metadata (member invites, role changes).

--- a/internal/server/handlers_grants.go
+++ b/internal/server/handlers_grants.go
@@ -135,7 +135,7 @@ func (s *Server) handleListItemGrants(w http.ResponseWriter, r *http.Request) {
 	}
 
 	itemSlug := chi.URLParam(r, "itemSlug")
-	item, err := s.store.ResolveItem(workspaceID, itemSlug)
+	item, err := s.store.ResolveItemIncludeDeleted(workspaceID, itemSlug)
 	if err != nil {
 		writeInternalError(w, err)
 		return
@@ -172,7 +172,7 @@ func (s *Server) handleCreateItemGrant(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if item == nil {
-		writeError(w, http.StatusNotFound, "not_found", "Item not found")
+		s.writeItemResolveError(w, r, workspaceID, itemSlug)
 		return
 	}
 

--- a/internal/server/handlers_item_links.go
+++ b/internal/server/handlers_item_links.go
@@ -18,7 +18,7 @@ func (s *Server) handleGetItemLinks(w http.ResponseWriter, r *http.Request) {
 	}
 
 	itemSlug := chi.URLParam(r, "itemSlug")
-	item, err := s.store.ResolveItem(workspaceID, itemSlug)
+	item, err := s.store.ResolveItemIncludeDeleted(workspaceID, itemSlug)
 	if err != nil {
 		writeInternalError(w, err)
 		return
@@ -92,7 +92,7 @@ func (s *Server) handleCreateItemLink(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if item == nil {
-		writeError(w, http.StatusNotFound, "not_found", "Item not found")
+		s.writeItemResolveError(w, r, workspaceID, itemSlug)
 		return
 	}
 	if !s.requireItemVisible(w, r, workspaceID, item) {

--- a/internal/server/handlers_item_versions.go
+++ b/internal/server/handlers_item_versions.go
@@ -17,7 +17,7 @@ func (s *Server) handleListItemVersions(w http.ResponseWriter, r *http.Request) 
 	}
 
 	itemSlug := chi.URLParam(r, "itemSlug")
-	item, err := s.store.ResolveItem(workspaceID, itemSlug)
+	item, err := s.store.ResolveItemIncludeDeleted(workspaceID, itemSlug)
 	if err != nil {
 		writeInternalError(w, err)
 		return
@@ -54,7 +54,7 @@ func (s *Server) handleGetItemVersion(w http.ResponseWriter, r *http.Request) {
 
 	itemSlug := chi.URLParam(r, "itemSlug")
 	versionID := chi.URLParam(r, "versionID")
-	item, err := s.store.ResolveItem(workspaceID, itemSlug)
+	item, err := s.store.ResolveItemIncludeDeleted(workspaceID, itemSlug)
 	if err != nil {
 		writeInternalError(w, err)
 		return
@@ -96,7 +96,7 @@ func (s *Server) handleRestoreItemVersion(w http.ResponseWriter, r *http.Request
 		return
 	}
 	if item == nil {
-		writeError(w, http.StatusNotFound, "not_found", "Item not found")
+		s.writeItemResolveError(w, r, workspaceID, itemSlug)
 		return
 	}
 	if !s.requireItemVisible(w, r, workspaceID, item) {

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -1961,7 +1961,7 @@ func (s *Server) handleGetItemChildren(w http.ResponseWriter, r *http.Request) {
 	}
 
 	itemSlug := chi.URLParam(r, "itemSlug")
-	item, err := s.store.ResolveItem(workspaceID, itemSlug)
+	item, err := s.store.ResolveItemIncludeDeleted(workspaceID, itemSlug)
 	if err != nil {
 		writeInternalError(w, err)
 		return
@@ -2040,7 +2040,7 @@ func (s *Server) handleGetItemProgress(w http.ResponseWriter, r *http.Request) {
 	}
 
 	itemSlug := chi.URLParam(r, "itemSlug")
-	item, err := s.store.ResolveItem(workspaceID, itemSlug)
+	item, err := s.store.ResolveItemIncludeDeleted(workspaceID, itemSlug)
 	if err != nil {
 		writeInternalError(w, err)
 		return
@@ -2366,7 +2366,7 @@ func (s *Server) handleListItemActivity(w http.ResponseWriter, r *http.Request) 
 	}
 
 	itemSlug := chi.URLParam(r, "itemSlug")
-	item, err := s.store.ResolveItem(workspaceID, itemSlug)
+	item, err := s.store.ResolveItemIncludeDeleted(workspaceID, itemSlug)
 	if err != nil {
 		writeInternalError(w, err)
 		return

--- a/internal/server/handlers_share_links.go
+++ b/internal/server/handlers_share_links.go
@@ -72,7 +72,7 @@ func (s *Server) handleCreateItemShareLink(w http.ResponseWriter, r *http.Reques
 	}
 
 	itemSlug := chi.URLParam(r, "itemSlug")
-	item, err := s.store.ResolveItem(workspaceID, itemSlug)
+	item, err := s.store.ResolveItemIncludeDeleted(workspaceID, itemSlug)
 	if err != nil {
 		writeInternalError(w, err)
 		return
@@ -210,7 +210,7 @@ func (s *Server) handleListItemShareLinks(w http.ResponseWriter, r *http.Request
 		return
 	}
 	if item == nil {
-		writeError(w, http.StatusNotFound, "not_found", "Item not found")
+		s.writeItemResolveError(w, r, workspaceID, itemSlug)
 		return
 	}
 

--- a/internal/server/handlers_share_links.go
+++ b/internal/server/handlers_share_links.go
@@ -72,13 +72,16 @@ func (s *Server) handleCreateItemShareLink(w http.ResponseWriter, r *http.Reques
 	}
 
 	itemSlug := chi.URLParam(r, "itemSlug")
-	item, err := s.store.ResolveItemIncludeDeleted(workspaceID, itemSlug)
+	// Creating a share link is a mutation: reject archived items with 409
+	// (a public link to an archived item would 404 at resolve time anyway,
+	// since the public resolver excludes soft-deleted items).
+	item, err := s.store.ResolveItem(workspaceID, itemSlug)
 	if err != nil {
 		writeInternalError(w, err)
 		return
 	}
 	if item == nil {
-		writeError(w, http.StatusNotFound, "not_found", "Item not found")
+		s.writeItemResolveError(w, r, workspaceID, itemSlug)
 		return
 	}
 
@@ -204,13 +207,15 @@ func (s *Server) handleListItemShareLinks(w http.ResponseWriter, r *http.Request
 	}
 
 	itemSlug := chi.URLParam(r, "itemSlug")
-	item, err := s.store.ResolveItem(workspaceID, itemSlug)
+	// Listing share links is read-only, so an archived item resolves (200)
+	// like the main GET; a genuinely-missing item still 404s.
+	item, err := s.store.ResolveItemIncludeDeleted(workspaceID, itemSlug)
 	if err != nil {
 		writeInternalError(w, err)
 		return
 	}
 	if item == nil {
-		s.writeItemResolveError(w, r, workspaceID, itemSlug)
+		writeError(w, http.StatusNotFound, "not_found", "Item not found")
 		return
 	}
 

--- a/internal/server/handlers_stars.go
+++ b/internal/server/handlers_stars.go
@@ -24,7 +24,7 @@ func (s *Server) handleStarItem(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if item == nil {
-		writeError(w, http.StatusNotFound, "not_found", "Item not found")
+		s.writeItemResolveError(w, r, workspaceID, itemSlug)
 		return
 	}
 
@@ -87,7 +87,7 @@ func (s *Server) handleUnstarItem(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if item == nil {
-		writeError(w, http.StatusNotFound, "not_found", "Item not found")
+		s.writeItemResolveError(w, r, workspaceID, itemSlug)
 		return
 	}
 
@@ -222,7 +222,7 @@ func (s *Server) handleGetItemStarStatus(w http.ResponseWriter, r *http.Request)
 	}
 
 	itemSlug := chi.URLParam(r, "itemSlug")
-	item, err := s.store.ResolveItem(workspaceID, itemSlug)
+	item, err := s.store.ResolveItemIncludeDeleted(workspaceID, itemSlug)
 	if err != nil {
 		writeInternalError(w, err)
 		return

--- a/internal/server/handlers_timeline.go
+++ b/internal/server/handlers_timeline.go
@@ -21,7 +21,7 @@ func (s *Server) handleListItemTimeline(w http.ResponseWriter, r *http.Request) 
 	}
 
 	itemSlug := chi.URLParam(r, "itemSlug")
-	item, err := s.store.ResolveItem(workspaceID, itemSlug)
+	item, err := s.store.ResolveItemIncludeDeleted(workspaceID, itemSlug)
 	if err != nil || item == nil {
 		writeError(w, http.StatusNotFound, "not_found", "Item not found")
 		return


### PR DESCRIPTION
## Problem

The main item `GET` returns archived (soft-deleted) items read-only (200) and `PATCH`/`DELETE` reject them with `409 archived` (BUG-1791) — but every **item sub-resource** still resolved through the `deleted_at`-filtering `ResolveItem` and returned a misleading **404**. This broke the archived-item detail page itself, which loads `/links`, `/progress`, `/timeline`, etc. against the archived slug. An adversarial audit (3 parallel investigators + verifier) confirmed the divergence and ruled out the suspected "leaks" (dashboard/activity rows were blanked, not leaked).

Behavior for an archived item, before:

| Endpoint | Before | After |
|---|---|---|
| `GET /items/{slug}` | 200 | 200 |
| read sub-resources (progress, children, links, backlinks, timeline, comments, versions, activity, export, star-status, item-grants, share-links list) | **404** | **200** |
| write sub-resources (create comment/link, version restore, star/unstar, create grant, create share-link) | **404** | **409 archived** |

## Fix

Mirror the GET/PATCH policy across the whole item surface — **reads behave like GET (200), writes behave like PATCH (409)**:

- **Read sub-resources** resolve via `ResolveItemIncludeDeleted` + the same `requireItemVisible` gate (no visibility change — an archived item is never revealed to someone who couldn't already see it).
- **Write sub-resources** route the nil case through `writeItemResolveError` → `409 archived` instead of a misleading 404.
- **Dashboard recent-activity + workspace activity feed** resolve referenced items include-deleted so archived-item activity renders with its real title/slug (gated by the same checks) instead of blank "ghost" rows — also closing a minor case where a deleted-item row bypassed the collection-visibility filter.

## Review

- Codex review loop: round 1 caught a real bug — the two share-link handlers had their read/write treatment swapped (create would mint a public link to an archived item that 404s at resolve time); fixed. Round 2 CLEAN.
- `go build ./...`, `go vet ./internal/server`, `go test ./internal/server ./internal/store` all green. `make install` verified the binary builds + the server restarts.

https://claude.ai/code/session_01HxBkAMiFBtCRJ2tKSCt3ST