### PR TITLE
fix(web): show issue ID and status pills in activity log (BUG-1748)

### DIFF
--- a/internal/models/activity.go
+++ b/internal/models/activity.go
@@ -74,6 +74,7 @@ type Activity struct {
 	// Enrichment fields — populated by handlers, not stored in DB
 	ItemTitle      string `json:"item_title,omitempty"`
 	ItemSlug       string `json:"item_slug,omitempty"`
+	ItemRef        string `json:"item_ref,omitempty"` // e.g. "BUG-1748" — computed from the referenced item
 	CollectionSlug string `json:"collection_slug,omitempty"`
 	ActorName      string `json:"actor_name,omitempty"`
 }

--- a/internal/server/handlers_activity.go
+++ b/internal/server/handlers_activity.go
@@ -157,8 +157,10 @@ func (s *Server) enrichActivities(activities []models.Activity) {
 		if err != nil || item == nil {
 			continue
 		}
+		item.ComputeRef()
 		activities[i].ItemTitle = item.Title
 		activities[i].ItemSlug = item.Slug
+		activities[i].ItemRef = item.Ref
 		activities[i].CollectionSlug = item.CollectionSlug
 	}
 }

--- a/internal/server/handlers_dashboard.go
+++ b/internal/server/handlers_dashboard.go
@@ -116,6 +116,7 @@ type DashboardActivity struct {
 	CreatedAt      string `json:"created_at"`
 	ItemTitle      string `json:"item_title,omitempty"`
 	ItemSlug       string `json:"item_slug,omitempty"`
+	ItemRef        string `json:"item_ref,omitempty"` // e.g. "BUG-1748"
 	CollectionSlug string `json:"collection_slug,omitempty"`
 	Metadata       string `json:"metadata,omitempty"`
 }
@@ -724,8 +725,10 @@ func (s *Server) buildDashboardResponse(workspaceID string, r *http.Request) (*D
 				if !s.isItemVisibleToGuest(r, workspaceID, item, dashFullCollIDs, dashGrantedItemIDs) {
 					continue
 				}
+				item.ComputeRef()
 				da.ItemTitle = item.Title
 				da.ItemSlug = item.Slug
+				da.ItemRef = item.Ref
 				da.CollectionSlug = item.CollectionSlug
 			} else if workspaceRole(r) == "guest" {
 				// Workspace-level activity (no item) — skip for guests since

--- a/web/src/lib/components/timeline/TimelineActivityCard.svelte
+++ b/web/src/lib/components/timeline/TimelineActivityCard.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import type { Activity } from '$lib/types';
 	import { relativeTime } from '$lib/utils/markdown';
+	import { parseFieldChanges } from '$lib/utils/activityChanges';
 
 	let { activity }: { activity: Activity } = $props();
 
@@ -12,30 +13,8 @@
 		}
 	}
 
-	interface Change {
-		field: string;
-		from: string;
-		to: string;
-	}
-
-	function parseChanges(changesStr: string): Change[] {
-		if (!changesStr) return [];
-		return changesStr.split(';').map((part) => {
-			const trimmed = part.trim();
-			const colonIdx = trimmed.indexOf(':');
-			if (colonIdx === -1) return null;
-			const field = trimmed.slice(0, colonIdx).trim();
-			const valuePart = trimmed.slice(colonIdx + 1).trim();
-			const arrowParts = valuePart.split('\u2192');
-			if (arrowParts.length === 2) {
-				return { field, from: arrowParts[0].trim(), to: arrowParts[1].trim() };
-			}
-			return null;
-		}).filter((c): c is Change => c !== null);
-	}
-
 	const metadata = $derived(parseMetadata(activity.metadata));
-	const changes = $derived(parseChanges(metadata.changes ?? ''));
+	const changes = $derived(parseFieldChanges(metadata.changes ?? ''));
 
 	const actionLabels: Record<string, string> = {
 		created: 'created',

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -902,6 +902,7 @@ export interface Activity {
 	created_at: string;
 	item_title?: string;
 	item_slug?: string;
+	item_ref?: string;
 	collection_slug?: string;
 }
 
@@ -947,6 +948,7 @@ export interface DashboardResponse {
 		created_at: string;
 		item_title?: string;
 		item_slug?: string;
+		item_ref?: string;
 		collection_slug?: string;
 		metadata?: string;
 	}[];

--- a/web/src/lib/utils/activityChanges.ts
+++ b/web/src/lib/utils/activityChanges.ts
@@ -1,0 +1,33 @@
+// Parsing for the activity-metadata `changes` string the server emits, e.g.
+// "status: open → fixing; priority: low → high". The "; " separator and the
+// "→" arrow are produced by diffFields/appendChange in the Go backend
+// (internal/server/handlers_documents.go) — keep this in sync if those change.
+
+export interface FieldChange {
+	field: string;
+	from: string;
+	to: string;
+}
+
+// Split the server's "; "-joined "field: from → to" change string into
+// structured entries. Segments that don't carry a "from → to" transition
+// (e.g. a newly-set field rendered as "field: → value") are dropped so the
+// caller can render clean two-sided pills; use the raw string for those.
+export function parseFieldChanges(changesStr: string | undefined | null): FieldChange[] {
+	if (!changesStr) return [];
+	return changesStr
+		.split(';')
+		.map((part): FieldChange | null => {
+			const trimmed = part.trim();
+			const colonIdx = trimmed.indexOf(':');
+			if (colonIdx === -1) return null;
+			const field = trimmed.slice(0, colonIdx).trim();
+			const valuePart = trimmed.slice(colonIdx + 1).trim();
+			const arrowParts = valuePart.split('→');
+			if (arrowParts.length === 2) {
+				return { field, from: arrowParts[0].trim(), to: arrowParts[1].trim() };
+			}
+			return null;
+		})
+		.filter((c): c is FieldChange => c !== null);
+}

--- a/web/src/routes/[username]/[workspace]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/+page.svelte
@@ -589,6 +589,9 @@
 							{/if}
 							<span class="activity-dot" style="color: {activity.action === 'created' ? 'var(--accent-green)' : activity.action === 'archived' ? 'var(--text-muted)' : 'var(--accent-blue)'};">{activityIcon(activity.action)}</span>
 							<span class="activity-verb">{activityVerb(activity.action)}</span>
+							{#if activity.item_ref}
+								<span class="activity-ref">{activity.item_ref}</span>
+							{/if}
 							{#if activity.item_title}
 								<a href="/{username}/{wsSlug}/{activity.collection_slug}/{activity.item_slug}" class="activity-item">{activity.item_title}</a>
 							{/if}
@@ -1184,6 +1187,12 @@
 	.activity-verb {
 		white-space: nowrap;
 		color: var(--text-secondary);
+	}
+	.activity-ref {
+		font-family: var(--font-mono);
+		font-size: 0.8em;
+		color: var(--text-muted);
+		white-space: nowrap;
 	}
 	.activity-item {
 		font-weight: 600;

--- a/web/src/routes/[username]/[workspace]/activity/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/activity/+page.svelte
@@ -5,6 +5,7 @@
 	import { workspaceStore } from '$lib/stores/workspace.svelte';
 	import { titleStore } from '$lib/stores/title.svelte';
 	import { relativeTime } from '$lib/utils/markdown';
+	import { parseFieldChanges } from '$lib/utils/activityChanges';
 	import { createScrollRestoration } from '$lib/scroll/restore.svelte';
 	import type { Activity, Collection } from '$lib/types';
 
@@ -329,7 +330,9 @@
 							{@const meta = parseMeta(activity.metadata)}
 							{@const itemTitle = activity.item_title || meta.item_title || meta.title}
 							{@const itemSlug = activity.item_slug || meta.item_slug}
+							{@const itemRef = activity.item_ref || meta.item_ref}
 							{@const collSlug = activity.collection_slug || meta.collection_slug}
+							{@const fieldChanges = parseFieldChanges(meta.changes)}
 							{@const src = getSourceLabel(activity.source, activity.actor, activity.actor_name)}
 							<div class="entry {borderClass(activity.source, activity.actor)}">
 								<span
@@ -341,6 +344,9 @@
 								<div class="entry-content">
 									<div class="entry-main">
 										<span class="entry-verb">{activityVerb(activity.action)}</span>
+										{#if itemRef}
+											<span class="entry-ref">{itemRef}</span>
+										{/if}
 										{#if itemTitle && itemSlug && collSlug}
 											<a
 												href="/{username}/{wsSlug}/{collSlug}/{itemSlug}"
@@ -353,8 +359,19 @@
 											<span class="entry-collection">{collSlug}</span>
 										{/if}
 									</div>
-									{#if meta.changes}
-										<div class="entry-detail">{meta.changes}</div>
+									{#if fieldChanges.length > 0}
+										<div class="entry-detail">
+											{#each fieldChanges as change, i (i)}
+												<span class="change-pill">
+													<span class="change-field">{change.field}:</span>
+													<span class="change-from">{change.from}</span>
+													<span class="change-arrow">&rarr;</span>
+													<span class="change-to">{change.to}</span>
+												</span>
+											{/each}
+										</div>
+									{:else if meta.changes}
+										<div class="entry-detail entry-detail-raw">{meta.changes}</div>
 									{/if}
 								</div>
 								<div class="entry-meta">
@@ -555,6 +572,12 @@
 		color: var(--text-secondary);
 		white-space: nowrap;
 	}
+	.entry-ref {
+		font-family: var(--font-mono);
+		font-size: 0.9em;
+		color: var(--text-muted);
+		white-space: nowrap;
+	}
 	.entry-item-link {
 		font-weight: 600;
 		color: var(--text-primary);
@@ -583,11 +606,36 @@
 		white-space: nowrap;
 	}
 	.entry-detail {
+		display: flex;
+		flex-wrap: wrap;
+		gap: var(--space-1);
 		font-size: 0.8em;
 		color: var(--text-muted);
+	}
+	.entry-detail-raw {
 		overflow: hidden;
 		text-overflow: ellipsis;
 		white-space: nowrap;
+	}
+	.change-pill {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.3em;
+		padding: 1px 8px;
+		background: var(--bg-tertiary);
+		border-radius: var(--radius-sm);
+		color: var(--text-muted);
+		white-space: nowrap;
+	}
+	.change-field {
+		font-weight: 600;
+		color: var(--text-primary);
+	}
+	.change-arrow {
+		opacity: 0.5;
+	}
+	.change-to {
+		color: var(--text-primary);
 	}
 
 	.entry-meta {


### PR DESCRIPTION
## Summary

Fixes **BUG-1748** — activity-log rows showed only the item title, never the issue ID.

- **Issue ID badge** on every activity row, on both the dedicated Activity page and the dashboard's Recent Activity list. The ref (e.g. `BUG-1748`) rides on the per-row item lookup that already fetches the title, so there are **zero new DB queries** — just one small field added to the response (`item_ref` on `models.Activity`, `DashboardActivity`, and the matching TS types).
- **Status-change pills** on the Activity page (`status: open → fixing`) replacing the raw change string, via a new shared `parseFieldChanges` util that also dedups the private copy previously living in `TimelineActivityCard`.

The status-transition detail was already present in the activity `metadata.changes` payload (pure frontend); only the issue ID required a backend touch, and that touch added no query load.

## Verification

- `go test ./internal/server/ ./internal/models/` ✓ · `go vet` ✓ · `gofmt` clean
- `svelte-check` 0 errors · `make web` ✓ · `make install` ✓
- Live API confirms `item_ref` on every row (created/updated/archived)
- Headless-browser render confirms the badges + pills on both surfaces

https://claude.ai/code/session_01HxBkAMiFBtCRJ2tKSCt3ST