### PR TITLE
fix(admin): don't persist masked Maileroo API key on email settings save (BUG-1890)

### DIFF
--- a/internal/server/handlers_admin.go
+++ b/internal/server/handlers_admin.go
@@ -47,13 +47,26 @@ func (s *Server) handleGetPlatformSettings(w http.ResponseWriter, r *http.Reques
 	}
 
 	// Mask sensitive values
-	if key, ok := settings[settingMailerooAPIKey]; ok && len(key) > 8 {
-		settings[settingMailerooAPIKey] = key[:4] + "..." + key[len(key)-4:]
-	} else if ok && key != "" {
-		settings[settingMailerooAPIKey] = "****"
+	if key, ok := settings[settingMailerooAPIKey]; ok && key != "" {
+		settings[settingMailerooAPIKey] = maskAPIKey(key)
 	}
 
 	writeJSON(w, http.StatusOK, settings)
+}
+
+// maskAPIKey returns the display form of a sensitive setting value. Keys longer
+// than 8 chars show their first and last 4 chars (abcd...wxyz); shorter non-empty
+// keys collapse to "****". Empty stays empty. This is the single source of truth
+// for the mask format — handleGetPlatformSettings emits it and
+// handleUpdatePlatformSettings uses it to detect an unchanged (echoed-back) key.
+func maskAPIKey(key string) string {
+	if len(key) > 8 {
+		return key[:4] + "..." + key[len(key)-4:]
+	}
+	if key != "" {
+		return "****"
+	}
+	return ""
 }
 
 // handleUpdatePlatformSettings updates one or more platform settings.
@@ -86,6 +99,27 @@ func (s *Server) handleUpdatePlatformSettings(w http.ResponseWriter, r *http.Req
 	for key, value := range input {
 		if !allowed[key] {
 			continue
+		}
+		// Defensive guard against BUG-1890: the GET handler returns the API key
+		// masked (abcd...wxyz / ****). If a client echoes that mask back unchanged
+		// (e.g. an admin saving the email form without re-typing the key), persisting
+		// it would corrupt the real key and silently break email. Treat an incoming
+		// value that equals the mask of the stored key as "unchanged" and skip it.
+		//
+		// This is a best-effort backstop; the authoritative fix is client-side (the
+		// web form omits the key unless the admin actually edits it). It recognizes
+		// the mask of the *current* key, so a mask captured before a concurrent key
+		// change by another admin wouldn't be caught — an accepted, negligible gap
+		// for the backstop given the client never sends the mask on a no-op save.
+		if key == settingMailerooAPIKey && value != "" {
+			current, err := s.store.GetPlatformSetting(settingMailerooAPIKey)
+			if err != nil {
+				writeError(w, http.StatusInternalServerError, "internal_error", "Failed to load setting: "+key)
+				return
+			}
+			if current != "" && value == maskAPIKey(current) {
+				continue
+			}
 		}
 		if err := s.store.SetPlatformSetting(key, value); err != nil {
 			writeError(w, http.StatusInternalServerError, "internal_error", "Failed to save setting: "+key)

--- a/internal/server/handlers_admin_settings_test.go
+++ b/internal/server/handlers_admin_settings_test.go
@@ -1,0 +1,169 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+// TestMaskAPIKey pins the single source of truth for the sensitive-value mask
+// (BUG-1890). GET /admin/settings emits this form and the update handler compares
+// against it to detect an echoed-back (unchanged) key.
+func TestMaskAPIKey(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"short", "abc", "****"},
+		{"exactly-8", "abcd1234", "****"},
+		{"long", "mlr-1234567890abcdef", "mlr-...cdef"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := maskAPIKey(tc.in); got != tc.want {
+				t.Errorf("maskAPIKey(%q)=%q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestAdminSettings_MaskedKeyNotPersisted is the core BUG-1890 regression: the
+// admin GETs settings (key comes back masked), then PATCHes the whole object back
+// without re-typing the key. The masked placeholder must NOT overwrite the real
+// stored key.
+func TestAdminSettings_MaskedKeyNotPersisted(t *testing.T) {
+	srv := testServer(t)
+	adminToken := bootstrapFirstUser(t, srv, "admin@test.com", "Admin")
+
+	const realKey = "mlr-liveSecret-9f8e7d6c5b4a"
+	if err := srv.store.SetPlatformSetting(settingMailerooAPIKey, realKey); err != nil {
+		t.Fatalf("seed key: %v", err)
+	}
+
+	// GET returns the masked form.
+	rr := doRequestWithCookie(srv, "GET", "/api/v1/admin/settings", nil, adminToken)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("get: status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	var got map[string]string
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode get: %v body=%s", err, rr.Body.String())
+	}
+	masked := got[settingMailerooAPIKey]
+	if masked == realKey {
+		t.Fatalf("GET returned the raw key %q — should be masked", masked)
+	}
+	if masked != maskAPIKey(realKey) {
+		t.Fatalf("GET mask=%q, want %q", masked, maskAPIKey(realKey))
+	}
+
+	// PATCH the masked value straight back (the pre-fix client behaviour).
+	body := map[string]any{
+		settingEmailProvider:  "maileroo",
+		settingMailerooAPIKey: masked,
+		settingEmailFrom:      "noreply@example.com",
+		settingEmailFromName:  "Pad",
+	}
+	rr = doRequestWithCookie(srv, "PATCH", "/api/v1/admin/settings", body, adminToken)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("patch: status=%d body=%s", rr.Code, rr.Body.String())
+	}
+
+	// The real key must survive — the guard treated the mask as "unchanged".
+	stored, err := srv.store.GetPlatformSetting(settingMailerooAPIKey)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if stored != realKey {
+		t.Errorf("stored key corrupted: got %q, want %q", stored, realKey)
+	}
+
+	// The other email fields the admin *did* set should still round-trip.
+	if from, _ := srv.store.GetPlatformSetting(settingEmailFrom); from != "noreply@example.com" {
+		t.Errorf("email_from=%q, want noreply@example.com", from)
+	}
+}
+
+// TestAdminSettings_ShortKeyMaskNotPersisted covers the other mask branch: a key
+// of <=8 chars masks to the literal "****". Echoing "****" back must not overwrite
+// the real short key. (The guard is format-agnostic string equality, but this pins
+// the "****" HTTP round-trip explicitly.)
+func TestAdminSettings_ShortKeyMaskNotPersisted(t *testing.T) {
+	srv := testServer(t)
+	adminToken := bootstrapFirstUser(t, srv, "admin@test.com", "Admin")
+
+	const realKey = "short123" // 8 chars -> masks to "****"
+	if err := srv.store.SetPlatformSetting(settingMailerooAPIKey, realKey); err != nil {
+		t.Fatalf("seed key: %v", err)
+	}
+	if maskAPIKey(realKey) != "****" {
+		t.Fatalf("precondition: maskAPIKey(%q)=%q, want ****", realKey, maskAPIKey(realKey))
+	}
+
+	body := map[string]any{settingMailerooAPIKey: "****"}
+	rr := doRequestWithCookie(srv, "PATCH", "/api/v1/admin/settings", body, adminToken)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("patch: status=%d body=%s", rr.Code, rr.Body.String())
+	}
+
+	stored, err := srv.store.GetPlatformSetting(settingMailerooAPIKey)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if stored != realKey {
+		t.Errorf("short key corrupted: got %q, want %q", stored, realKey)
+	}
+}
+
+// TestAdminSettings_RealKeyUpdateWins confirms the guard only skips the mask, not
+// a genuine new key: a real value entered by the admin replaces the stored key.
+func TestAdminSettings_RealKeyUpdateWins(t *testing.T) {
+	srv := testServer(t)
+	adminToken := bootstrapFirstUser(t, srv, "admin@test.com", "Admin")
+
+	if err := srv.store.SetPlatformSetting(settingMailerooAPIKey, "mlr-old-0000111122223333"); err != nil {
+		t.Fatalf("seed key: %v", err)
+	}
+
+	const newKey = "mlr-new-4444555566667777"
+	body := map[string]any{settingMailerooAPIKey: newKey}
+	rr := doRequestWithCookie(srv, "PATCH", "/api/v1/admin/settings", body, adminToken)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("patch: status=%d body=%s", rr.Code, rr.Body.String())
+	}
+
+	stored, err := srv.store.GetPlatformSetting(settingMailerooAPIKey)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if stored != newKey {
+		t.Errorf("new key not persisted: got %q, want %q", stored, newKey)
+	}
+}
+
+// TestAdminSettings_EmptyKeyClears confirms an explicit empty value still clears
+// the key (the "disable email" path) — the guard only skips a non-empty mask.
+func TestAdminSettings_EmptyKeyClears(t *testing.T) {
+	srv := testServer(t)
+	adminToken := bootstrapFirstUser(t, srv, "admin@test.com", "Admin")
+
+	if err := srv.store.SetPlatformSetting(settingMailerooAPIKey, "mlr-to-be-cleared-8888"); err != nil {
+		t.Fatalf("seed key: %v", err)
+	}
+
+	body := map[string]any{settingMailerooAPIKey: ""}
+	rr := doRequestWithCookie(srv, "PATCH", "/api/v1/admin/settings", body, adminToken)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("patch: status=%d body=%s", rr.Code, rr.Body.String())
+	}
+
+	stored, err := srv.store.GetPlatformSetting(settingMailerooAPIKey)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if stored != "" {
+		t.Errorf("key not cleared: got %q, want empty", stored)
+	}
+}

--- a/internal/server/handlers_admin_settings_test.go
+++ b/internal/server/handlers_admin_settings_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/email"
 )
 
 // TestMaskAPIKey pins the single source of truth for the sensitive-value mask
@@ -140,6 +142,60 @@ func TestAdminSettings_RealKeyUpdateWins(t *testing.T) {
 	}
 	if stored != newKey {
 		t.Errorf("new key not persisted: got %q, want %q", stored, newKey)
+	}
+}
+
+// TestAdminSettings_DisableTearsDownLiveSender pins the BUG-1890 follow-up: when a
+// UI-configured (no env) instance disables email by clearing the key, the live
+// in-memory sender must be torn down — not just the DB row — so mail actually
+// stops without a restart.
+func TestAdminSettings_DisableTearsDownLiveSender(t *testing.T) {
+	srv := testServer(t)
+	adminToken := bootstrapFirstUser(t, srv, "admin@test.com", "Admin")
+
+	// Configure email through the platform-settings path (no env sender).
+	body := map[string]any{
+		settingEmailProvider:  "maileroo",
+		settingMailerooAPIKey: "mlr-live-configured-123456",
+		settingEmailFrom:      "noreply@example.com",
+	}
+	rr := doRequestWithCookie(srv, "PATCH", "/api/v1/admin/settings", body, adminToken)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("configure patch: status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	if srv.email == nil {
+		t.Fatal("expected live email sender after configuring a key")
+	}
+
+	// Disable: provider None + cleared key (what the fixed client sends).
+	body = map[string]any{settingEmailProvider: "", settingMailerooAPIKey: ""}
+	rr = doRequestWithCookie(srv, "PATCH", "/api/v1/admin/settings", body, adminToken)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("disable patch: status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	if srv.email != nil {
+		t.Error("live sender not torn down after clearing key — email still active until restart")
+	}
+	if srv.emailAPIKey != "" {
+		t.Errorf("emailAPIKey=%q after disable, want empty", srv.emailAPIKey)
+	}
+}
+
+// TestReconfigureEmail_EnvSenderPreserved is the counterpart guard: an env-wired
+// sender (the deployment baseline) must survive a reconfigure when platform
+// settings carry no key — the admin UI doesn't disable env-configured email.
+func TestReconfigureEmail_EnvSenderPreserved(t *testing.T) {
+	srv := testServer(t)
+
+	srv.SetEmailSender(email.NewSender("env-key-abcdef", "env@example.com", "Pad", "http://localhost"), "env-key-abcdef")
+	if srv.email == nil {
+		t.Fatal("precondition: env sender should be set")
+	}
+
+	// No platform-settings key stored; reconfigure must not wipe the env sender.
+	srv.reconfigureEmail()
+	if srv.email == nil {
+		t.Error("env-configured sender was torn down by reconfigureEmail with empty platform key")
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -44,6 +44,7 @@ type Server struct {
 	webhooks              *webhooks.Dispatcher // webhook dispatcher (optional)
 	email                 *email.Sender        // transactional email sender (optional)
 	emailAPIKey           string               // Maileroo API key (used for unsubscribe HMAC)
+	emailEnvConfigured    bool                 // email was wired from env vars (SetEmailSender); reconfigureEmail must not tear this down when platform settings clear the key
 	rateLimiters          *RateLimiters        // per-endpoint rate limiters
 	baseURL               string               // public base URL for generating links (e.g. invite URLs)
 	corsOrigins           string               // comma-separated CORS origins (empty = localhost defaults)
@@ -471,6 +472,10 @@ func (s *Server) SetWebhookDispatcher(d *webhooks.Dispatcher) {
 // either order.
 func (s *Server) SetEmailSender(e *email.Sender, apiKey ...string) {
 	s.email = e
+	// A sender wired here comes from an out-of-band source (env vars at startup).
+	// Mark it so reconfigureEmail leaves it in place when platform settings carry
+	// no key — env is the deployment baseline, not something the admin UI disables.
+	s.emailEnvConfigured = e != nil
 	if len(apiKey) > 0 {
 		s.emailAPIKey = apiKey[0]
 	}
@@ -685,7 +690,16 @@ func (s *Server) reconfigureEmail() {
 	fromName, _ := s.store.GetPlatformSetting(settingEmailFromName)
 
 	if apiKey == "" {
-		return // No API key — leave email as-is (may still have env var config)
+		// No platform-settings key. If email was wired from env vars, leave that
+		// sender in place — env is the deployment baseline. Otherwise the admin
+		// cleared the only email config (e.g. selecting provider "None"), so tear
+		// down the live sender: clearing the DB key alone left the running process
+		// sending mail until restart (BUG-1890).
+		if !s.emailEnvConfigured {
+			s.email = nil
+			s.emailAPIKey = ""
+		}
+		return
 	}
 
 	s.emailAPIKey = apiKey

--- a/web/src/routes/console/admin/settings/+page.svelte
+++ b/web/src/routes/console/admin/settings/+page.svelte
@@ -26,6 +26,10 @@
 
 	// Email settings
 	let platformSettings = $state<Record<string, string>>({});
+	// GET /admin/settings returns the Maileroo key masked (abcd...wxyz / ****).
+	// Track whether the admin actually re-typed it so we never persist the mask
+	// back over the real stored key (BUG-1890).
+	let apiKeyEdited = $state(false);
 	let savingPlatform = $state(false);
 	let platformStatus = $state<'idle' | 'saved' | 'error'>('idle');
 	let savingIntegrations = $state(false);
@@ -73,7 +77,20 @@
 		savingPlatform = true;
 		platformStatus = 'idle';
 		try {
-			await adminPatch('/admin/settings', platformSettings);
+			// Scope the PATCH to the fields this email form owns (mirrors the
+			// Integrations save). Only include the API key when the admin actually
+			// edited it — otherwise the field still holds the masked placeholder
+			// from GET /admin/settings, and saving it would corrupt the real
+			// stored key, silently breaking email (BUG-1890).
+			const payload: Record<string, string> = {
+				email_provider: platformSettings.email_provider ?? '',
+				email_from: platformSettings.email_from ?? '',
+				email_from_name: platformSettings.email_from_name ?? ''
+			};
+			if (apiKeyEdited) {
+				payload.maileroo_api_key = platformSettings.maileroo_api_key ?? '';
+			}
+			await adminPatch('/admin/settings', payload);
 			platformStatus = 'saved';
 		} catch {
 			platformStatus = 'error';
@@ -202,6 +219,7 @@
 							type="password"
 							value={platformSettings.maileroo_api_key ?? ''}
 							oninput={(e) => {
+								apiKeyEdited = true;
 								platformSettings = {
 									...platformSettings,
 									maileroo_api_key: e.currentTarget.value

--- a/web/src/routes/console/admin/settings/+page.svelte
+++ b/web/src/routes/console/admin/settings/+page.svelte
@@ -78,16 +78,23 @@
 		platformStatus = 'idle';
 		try {
 			// Scope the PATCH to the fields this email form owns (mirrors the
-			// Integrations save). Only include the API key when the admin actually
-			// edited it — otherwise the field still holds the masked placeholder
-			// from GET /admin/settings, and saving it would corrupt the real
-			// stored key, silently breaking email (BUG-1890).
+			// Integrations save).
 			const payload: Record<string, string> = {
 				email_provider: platformSettings.email_provider ?? '',
 				email_from: platformSettings.email_from ?? '',
 				email_from_name: platformSettings.email_from_name ?? ''
 			};
-			if (apiKeyEdited) {
+			if (payload.email_provider !== 'maileroo') {
+				// Disabling the provider: clear the stored key so email actually
+				// turns off. The server keys email enablement off the presence of
+				// maileroo_api_key (reconfigureEmail ignores email_provider), so
+				// leaving a stale key would keep sending mail after "None".
+				payload.maileroo_api_key = '';
+			} else if (apiKeyEdited) {
+				// Provider is Maileroo: only send the key when the admin actually
+				// edited it — otherwise the field still holds the masked placeholder
+				// from GET /admin/settings, and saving it would corrupt the real
+				// stored key, silently breaking email (BUG-1890).
 				payload.maileroo_api_key = platformSettings.maileroo_api_key ?? '';
 			}
 			await adminPatch('/admin/settings', payload);


### PR DESCRIPTION
## Problem

The admin settings page "Save Email Settings" button PATCHed the **whole** `platformSettings` object. `GET /admin/settings` returns the Maileroo API key **masked** (`abcd...wxyz` for keys > 8 chars, `****` otherwise). So an admin who saved the email section without re-typing the key persisted the masked placeholder over the real key — silently breaking transactional email until the real key was re-entered.

TASK-1889 (WebMCP) dodged this for the Integrations save by scoping its PATCH to `{webmcp_enabled}`; the email path never got the same treatment. Found during the TASK-1889 Codex review, scoped out per one-concern-per-PR.

## Fix

**1. Masked key never persisted (the reported bug)**
- **Client:** track whether the API-key field was edited (`apiKeyEdited`); scope `savePlatformSettings()` to the email fields, including `maileroo_api_key` only when edited.
- **Server:** extract `maskAPIKey()` (single source of truth) and skip persisting `maileroo_api_key` when the incoming non-empty value equals the mask of the stored key — a best-effort backstop for non-web/old clients.

**2. Disabling the provider actually disables email (Codex review, round 1)**
`reconfigureEmail` keys email enablement off the *presence* of `maileroo_api_key` and ignores `email_provider` (nothing server-side reads it). The scoped payload meant selecting Provider "None" without touching the key left the stored key, so email stayed on. Now the client sends an explicit empty key whenever the provider isn't Maileroo.

**3. Clearing the key tears down the live sender (Codex review, round 2)**
`reconfigureEmail`'s empty-key branch returned early without clearing the in-memory `s.email`, so a UI-configured instance kept sending mail until restart. Now it tears the sender down when platform settings carry no key — unless email was wired from **env vars** (`emailEnvConfigured`), the deployment baseline the admin UI doesn't disable.

## Tests (`internal/server/handlers_admin_settings_test.go`)
- `TestMaskAPIKey` — mask format unit cases (empty / short / exactly-8 / long).
- `TestAdminSettings_MaskedKeyNotPersisted` — core regression (long mask round-trip).
- `TestAdminSettings_ShortKeyMaskNotPersisted` — `****` short-key branch.
- `TestAdminSettings_RealKeyUpdateWins` — a genuine new key still replaces the stored key.
- `TestAdminSettings_DisableTearsDownLiveSender` — clearing the key nils `s.email`.
- `TestReconfigureEmail_EnvSenderPreserved` — env-wired sender survives an empty-platform-key reconfigure.
- `TestAdminSettings_EmptyKeyClears` — explicit empty value clears the key.

Full `go test ./...` green; `make install` (web + Go) clean; Codex review CLEAN.

## Out of scope / follow-up
- The server backstop matches the mask of the *current* key, so a mask captured before a concurrent key change by another admin wouldn't be caught. Negligible given the client never sends the mask on a no-op save; documented inline.
- **Separate observation:** `GET /admin/settings` also returns `2fa_challenge_secret` **unmasked** in plaintext to the admin client. Not corruptible (not in the update whitelist) but a secret-exposure concern — worth a separate BUG.

https://claude.ai/code/session_01HxBkAMiFBtCRJ2tKSCt3ST