### PR TITLE
fix(admin): stop leaking 2FA secret via GET /admin/settings (BUG-1909)

### DIFF
--- a/internal/server/handlers_admin.go
+++ b/internal/server/handlers_admin.go
@@ -25,8 +25,30 @@ const (
 	settingWebMCPEnabled = "webmcp_enabled"
 )
 
-// handleGetPlatformSettings returns all platform settings.
-// Admin-only. Sensitive values (API keys) are masked.
+// adminManagedSettings is the canonical allowlist of admin-editable platform
+// settings. It gates BOTH the read (handleGetPlatformSettings) and the write
+// (handleUpdatePlatformSettings) so the two can't drift.
+//
+// Deny-by-default is load-bearing for security: the platform_settings table also
+// holds server secrets (2fa_challenge_secret — the 2FA challenge HMAC key) and
+// plan-limit rows (plan_limits_*). Returning the whole table leaked the 2FA
+// secret to any admin client (BUG-1909). GET emits only these keys; a value that
+// is settable but sensitive (maileroo_api_key) is additionally masked. Any key
+// not listed here is neither exposed nor writable through this endpoint.
+var adminManagedSettings = map[string]bool{
+	settingEmailProvider:          true,
+	settingMailerooAPIKey:         true,
+	settingEmailFrom:              true,
+	settingEmailFromName:          true,
+	settingPlatformName:           true,
+	settingTokenDefaultExpiryDays: true,
+	settingTokenMaxLifetimeDays:   true,
+	settingWebMCPEnabled:          true,
+}
+
+// handleGetPlatformSettings returns the admin-managed platform settings.
+// Admin-only. Only allowlisted keys are returned (deny-by-default — see
+// adminManagedSettings); sensitive values (API keys) are masked.
 func (s *Server) handleGetPlatformSettings(w http.ResponseWriter, r *http.Request) {
 	user := currentUser(r)
 	if user == nil || user.Role != "admin" {
@@ -34,10 +56,19 @@ func (s *Server) handleGetPlatformSettings(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	settings, err := s.store.GetPlatformSettings()
+	stored, err := s.store.GetPlatformSettings()
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to load settings")
 		return
+	}
+
+	// Project only the admin-managed keys — never the 2FA secret or plan-limit
+	// rows that also live in platform_settings (BUG-1909).
+	settings := make(map[string]string, len(adminManagedSettings))
+	for key := range adminManagedSettings {
+		if v, ok := stored[key]; ok {
+			settings[key] = v
+		}
 	}
 
 	// Surface webmcp_enabled with an explicit default so the admin UI toggle
@@ -84,20 +115,11 @@ func (s *Server) handleUpdatePlatformSettings(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	// Whitelist known settings
-	allowed := map[string]bool{
-		settingEmailProvider:          true,
-		settingMailerooAPIKey:         true,
-		settingEmailFrom:              true,
-		settingEmailFromName:          true,
-		settingPlatformName:           true,
-		settingTokenDefaultExpiryDays: true,
-		settingTokenMaxLifetimeDays:   true,
-		settingWebMCPEnabled:          true,
-	}
-
+	// Whitelist known settings — same canonical set the GET handler exposes, so a
+	// caller can neither read nor write server secrets (2fa_challenge_secret) or
+	// plan-limit rows through this endpoint (BUG-1909 / BUG-1890).
 	for key, value := range input {
-		if !allowed[key] {
+		if !adminManagedSettings[key] {
 			continue
 		}
 		// Defensive guard against BUG-1890: the GET handler returns the API key
@@ -133,7 +155,7 @@ func (s *Server) handleUpdatePlatformSettings(w http.ResponseWriter, r *http.Req
 	// Log which settings were changed (keys only, not values for security)
 	var keys []string
 	for key := range input {
-		if allowed[key] {
+		if adminManagedSettings[key] {
 			keys = append(keys, key)
 		}
 	}

--- a/internal/server/handlers_admin_settings_test.go
+++ b/internal/server/handlers_admin_settings_test.go
@@ -3,10 +3,94 @@ package server
 import (
 	"encoding/json"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/PerpetualSoftware/pad/internal/email"
 )
+
+// TestAdminSettings_SecretsNotExposed is the BUG-1909 regression: GET
+// /admin/settings must return ONLY admin-managed keys. The platform_settings
+// table also holds the 2FA challenge signing secret and plan-limit rows; neither
+// may leak to the admin client.
+func TestAdminSettings_SecretsNotExposed(t *testing.T) {
+	srv := testServer(t)
+	adminToken := bootstrapFirstUser(t, srv, "admin@test.com", "Admin")
+
+	// Seed the kinds of rows that live in platform_settings alongside the
+	// admin-managed keys: a server secret and a plan-limit row.
+	const secret = "5FTmIeLVxG3wC+NwjOdSch79IQASkY0ybmRHU65ufAc="
+	if err := srv.store.SetPlatformSetting("2fa_challenge_secret", secret); err != nil {
+		t.Fatalf("seed 2fa secret: %v", err)
+	}
+	if err := srv.store.SetPlatformSetting("plan_limits_free_workspaces", "3"); err != nil {
+		t.Fatalf("seed limit row: %v", err)
+	}
+	// And a legitimate admin-managed key to prove the allowlist still passes those.
+	if err := srv.store.SetPlatformSetting(settingPlatformName, "Acme Pad"); err != nil {
+		t.Fatalf("seed platform_name: %v", err)
+	}
+
+	rr := doRequestWithCookie(srv, "GET", "/api/v1/admin/settings", nil, adminToken)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("get: status=%d body=%s", rr.Code, rr.Body.String())
+	}
+
+	// Raw-body check: the secret must not appear anywhere in the response, even
+	// as a substring (guards against future serialization changes).
+	if body := rr.Body.String(); strings.Contains(body, secret) {
+		t.Fatalf("2fa_challenge_secret leaked in GET /admin/settings body: %s", body)
+	}
+
+	var got map[string]string
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if _, ok := got["2fa_challenge_secret"]; ok {
+		t.Error("2fa_challenge_secret present as a key in GET /admin/settings")
+	}
+	if _, ok := got["plan_limits_free_workspaces"]; ok {
+		t.Error("plan_limits_* row leaked into GET /admin/settings")
+	}
+	if got[settingPlatformName] != "Acme Pad" {
+		t.Errorf("admin-managed platform_name missing/wrong: %q", got[settingPlatformName])
+	}
+	// Every returned key must be in the allowlist.
+	for k := range got {
+		if !adminManagedSettings[k] {
+			t.Errorf("GET returned non-allowlisted key %q", k)
+		}
+	}
+}
+
+// TestAdminSettings_SecretNotWritable pins the write side of deny-by-default: a
+// PATCH cannot overwrite the 2FA secret (or any non-allowlisted key) through the
+// settings endpoint.
+func TestAdminSettings_SecretNotWritable(t *testing.T) {
+	srv := testServer(t)
+	adminToken := bootstrapFirstUser(t, srv, "admin@test.com", "Admin")
+
+	const secret = "original-2fa-secret-value"
+	if err := srv.store.SetPlatformSetting("2fa_challenge_secret", secret); err != nil {
+		t.Fatalf("seed 2fa secret: %v", err)
+	}
+
+	body := map[string]any{
+		"2fa_challenge_secret":        "attacker-controlled",
+		"plan_limits_free_workspaces": "9999",
+	}
+	rr := doRequestWithCookie(srv, "PATCH", "/api/v1/admin/settings", body, adminToken)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("patch: status=%d body=%s", rr.Code, rr.Body.String())
+	}
+
+	if stored, _ := srv.store.GetPlatformSetting("2fa_challenge_secret"); stored != secret {
+		t.Errorf("2fa_challenge_secret was overwritten via settings PATCH: got %q, want %q", stored, secret)
+	}
+	if stored, _ := srv.store.GetPlatformSetting("plan_limits_free_workspaces"); stored != "" {
+		t.Errorf("plan_limits row was written via settings PATCH: got %q", stored)
+	}
+}
 
 // TestMaskAPIKey pins the single source of truth for the sensitive-value mask
 // (BUG-1890). GET /admin/settings emits this form and the update handler compares


### PR DESCRIPTION
## Problem (security — secret exposure)

`platform_settings` is a key/value table holding admin-editable UI settings **and** server internals: `2fa_challenge_secret` (the base64 HMAC key used to sign 2FA challenge tokens) and `plan_limits_*` rows. `GET /api/v1/admin/settings` (`handleGetPlatformSettings`) returned the **entire table**, so any admin client received the 2FA signing secret in plaintext.

Not corruptible (the secret isn't in the write whitelist), but a genuine read-side exposure: the secret lands in browser memory / devtools / any proxy in front of the admin UI. Found while verifying the BUG-1890 fix against a live instance.

## Fix — deny-by-default allowlist

- New package var `adminManagedSettings`: the canonical allowlist of the 8 admin-editable keys, **shared** by read and write so they can't drift.
- `GET` now projects only those keys (masking `maileroo_api_key` via `maskAPIKey`). The 2FA secret, plan-limit rows, and any future internal secret added to `platform_settings` are never exposed.
- `PATCH` gates writes on the same set (unchanged behavior, now sourced from the shared allowlist).

The admin settings page reads exactly the 5 keys still returned (`email_provider`, `maileroo_api_key`, `email_from`, `email_from_name`, `webmcp_enabled`) plus the managed `platform_name` / token-policy keys — no UI regression.

## Tests (`internal/server/handlers_admin_settings_test.go`)
- `TestAdminSettings_SecretsNotExposed` — seeds `2fa_challenge_secret` + a `plan_limits_*` row + a real admin key; asserts the secret is absent from the response (both as a key and as a raw-body substring), limit rows absent, admin key present, and every returned key is allowlisted.
- `TestAdminSettings_SecretNotWritable` — a PATCH cannot overwrite the 2FA secret or write a `plan_limits_*` row through the settings endpoint.

Full `go test ./...` green; `make install` (web + Go) clean; verified live (`2fa_challenge_secret` no longer in the response).

## Audit
Ran a codebase-wide secret-exposure audit (HTTP serialization, logging/errors, bootstrap, MCP resources, SSE) with adversarial verification. **No other confirmed leak surfaces.** Two candidates were surfaced and dismissed as working-as-designed: the self-host password-reset-token log line (documented recovery channel, cloud-gated, hashed + 1h + one-time) and the email test-error message (API key is header-only, only diagnostics reach the invoking admin).

https://claude.ai/code/session_01HxBkAMiFBtCRJ2tKSCt3ST
