### PR TITLE
fix(web): treat CLI/MCP-created workspaces as agent-connected (BUG-1557)

### DIFF
--- a/internal/models/workspace.go
+++ b/internal/models/workspace.go
@@ -11,6 +11,12 @@ type Workspace struct {
 	IsGuest       bool              `json:"is_guest,omitempty"`       // True when user has grants but no membership
 	Description   string            `json:"description"`
 	Settings      string            `json:"settings"` // JSON
+	// Source records how the workspace was created — "web", "cli", or "mcp"
+	// (empty on rows predating migration 069). A cli/mcp origin means an
+	// agent surface created the workspace, so an agent is already wired up
+	// even before it creates its first item; the dashboard's
+	// has_agent_activity signal ORs this in (BUG-1557).
+	Source        string            `json:"source,omitempty"`
 	SortOrder     int               `json:"sort_order"`
 	Context       *WorkspaceContext `json:"context,omitempty"`
 	CreatedAt     time.Time         `json:"created_at"`
@@ -26,6 +32,14 @@ type WorkspaceCreate struct {
 	Settings    string            `json:"settings,omitempty"`
 	Context     *WorkspaceContext `json:"context,omitempty"`
 	Template    string            `json:"template,omitempty"` // workspace template name (e.g. "startup", "scrum", "product")
+	// Source is the creation surface — "web", "cli", or "mcp". It is set
+	// SERVER-SIDE ONLY: the HTTP create handler derives it authoritatively
+	// from the request's auth shape (actorFromRequest), so `json:"-"` keeps
+	// it out of the request body — a web client must not be able to spoof
+	// "cli" to self-suppress the connect-agent/onboarding prompts. Direct
+	// store callers (cloud auto-create, import) leave it "" so they aren't
+	// treated as agent-created. See BUG-1557.
+	Source string `json:"-"`
 }
 
 type WorkspaceUpdate struct {

--- a/internal/server/handlers_dashboard.go
+++ b/internal/server/handlers_dashboard.go
@@ -374,6 +374,22 @@ func (s *Server) buildDashboardResponse(workspaceID string, r *http.Request) (*D
 	if err != nil {
 		return nil, err
 	}
+	// A workspace created through an agent surface (`pad init`, `pad
+	// workspace init`, MCP pad_workspace.create — all persist source
+	// cli/mcp) already has an agent wired up before that agent creates its
+	// first item. Fold that in so the "connect an agent" banner and the
+	// onboarding launchpad's "Agent connected" step don't nag right after
+	// `pad init` (BUG-1557). Unlike WorkspaceHasAgentActivity this is a
+	// workspace-level property (not visibility-scoped), so it's OR'd in
+	// unconditionally — but only queried when the cheap item EXISTS check
+	// came up empty. A load failure is non-fatal: buildDashboardResponse
+	// also backs the bootstrap endpoint, and a missing source signal must
+	// not break the whole dashboard.
+	if !hasAgent {
+		if ws, wErr := s.store.GetWorkspaceByID(workspaceID); wErr == nil && ws != nil {
+			hasAgent = ws.Source == "cli" || ws.Source == "mcp"
+		}
+	}
 	resp.HasAgentActivity = hasAgent
 
 	// needs_onboarding mirrors AgentBootstrap.NeedsOnboarding (TASK-1504):

--- a/internal/server/handlers_dashboard_test.go
+++ b/internal/server/handlers_dashboard_test.go
@@ -48,6 +48,98 @@ func createBlocksLink(t *testing.T, srv *Server, wsSlug, sourceSlug, targetID st
 	return link
 }
 
+// TestDashboardHasAgentActivityFromWorkspaceSource covers BUG-1557: a
+// workspace created through an agent surface (CLI / MCP — both persist
+// source="cli") reports has_agent_activity=true even with zero items, so the
+// web UI stops nagging to "connect an agent" right after `pad init`. A
+// workspace created via the web (cookie session, no Authorization header)
+// still reports false until an agent actually creates an item.
+func TestDashboardHasAgentActivityFromWorkspaceSource(t *testing.T) {
+	srv := testServer(t)
+	sessionToken := bootstrapFirstUser(t, srv, "admin@example.com", "Admin")
+
+	getHasAgent := func(t *testing.T, slug string) bool {
+		t.Helper()
+		rr := doRequestWithCookie(srv, "GET", "/api/v1/workspaces/"+slug+"/dashboard", nil, sessionToken)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("dashboard: expected 200, got %d: %s", rr.Code, rr.Body.String())
+		}
+		var resp DashboardResponse
+		parseJSON(t, rr, &resp)
+		return resp.HasAgentActivity
+	}
+
+	t.Run("cli-created workspace is agent-connected with zero items", func(t *testing.T) {
+		// Authorization: Bearer simulates the CLI flow — actorFromRequest
+		// flips source to "cli". This is exactly the `pad init` case.
+		rr := doRequestWithHeaders(srv, "POST", "/api/v1/workspaces",
+			map[string]string{"name": "CLI Made"},
+			map[string]string{"Authorization": "Bearer " + sessionToken},
+		)
+		if rr.Code != http.StatusCreated {
+			t.Fatalf("create cli ws: expected 201, got %d: %s", rr.Code, rr.Body.String())
+		}
+		var ws models.Workspace
+		parseJSON(t, rr, &ws)
+		if ws.Source != "cli" {
+			t.Fatalf("expected workspace source=cli, got %q", ws.Source)
+		}
+		if !getHasAgent(t, ws.Slug) {
+			t.Fatalf("expected has_agent_activity=true for a CLI-created workspace with no items")
+		}
+	})
+
+	t.Run("web-created workspace is not agent-connected until an item exists", func(t *testing.T) {
+		rr := doRequestWithCookie(srv, "POST", "/api/v1/workspaces",
+			map[string]string{"name": "Web Made"}, sessionToken)
+		if rr.Code != http.StatusCreated {
+			t.Fatalf("create web ws: expected 201, got %d: %s", rr.Code, rr.Body.String())
+		}
+		var ws models.Workspace
+		parseJSON(t, rr, &ws)
+		if ws.Source != "web" {
+			t.Fatalf("expected workspace source=web, got %q", ws.Source)
+		}
+		if getHasAgent(t, ws.Slug) {
+			t.Fatalf("expected has_agent_activity=false for a web-created workspace with no items")
+		}
+
+		// The item-based signal still works: an agent (CLI) creating an
+		// item flips it true even though the workspace itself is web-origin.
+		itemRR := doRequestWithHeaders(srv, "POST",
+			"/api/v1/workspaces/"+ws.Slug+"/collections/tasks/items",
+			map[string]interface{}{"title": "agent item", "fields": `{"status":"open"}`},
+			map[string]string{"Authorization": "Bearer " + sessionToken},
+		)
+		if itemRR.Code != http.StatusCreated {
+			t.Fatalf("create item via cli: expected 201, got %d: %s", itemRR.Code, itemRR.Body.String())
+		}
+		if !getHasAgent(t, ws.Slug) {
+			t.Fatalf("expected has_agent_activity=true after a CLI-sourced item was created")
+		}
+	})
+
+	t.Run("web client cannot spoof source=cli via the request body", func(t *testing.T) {
+		// Source is attributed server-side from the request auth shape, not
+		// the body (WorkspaceCreate.Source is json:"-"). A cookie-session
+		// caller passing {"source":"cli"} must still be recorded as "web" so
+		// it can't self-suppress the connect-agent/onboarding prompts.
+		rr := doRequestWithCookie(srv, "POST", "/api/v1/workspaces",
+			map[string]string{"name": "Spoof Attempt", "source": "cli"}, sessionToken)
+		if rr.Code != http.StatusCreated {
+			t.Fatalf("create ws: expected 201, got %d: %s", rr.Code, rr.Body.String())
+		}
+		var ws models.Workspace
+		parseJSON(t, rr, &ws)
+		if ws.Source != "web" {
+			t.Fatalf("expected body-supplied source to be ignored (web), got %q", ws.Source)
+		}
+		if getHasAgent(t, ws.Slug) {
+			t.Fatalf("expected has_agent_activity=false — a spoofed body source must not mark the workspace agent-connected")
+		}
+	})
+}
+
 func TestDashboardEmpty(t *testing.T) {
 	srv := testServer(t)
 	slug := createWSWithCollections(t, srv)

--- a/internal/server/handlers_workspaces.go
+++ b/internal/server/handlers_workspaces.go
@@ -236,6 +236,16 @@ func (s *Server) handleCreateWorkspace(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Attribute the creation surface AUTHORITATIVELY from the request's auth
+	// shape — never from the request body (WorkspaceCreate.Source is
+	// `json:"-"` for exactly this reason). CLI and Remote MCP callers
+	// present a bearer token / api-token context => "cli"; cookie-session
+	// web callers => "web". A cli/mcp origin is what tells the dashboard an
+	// agent is already connected right after `pad init`, so a web client
+	// must not be able to spoof it to suppress the connect-agent/onboarding
+	// prompts (BUG-1557).
+	_, input.Source = actorFromRequest(r)
+
 	// Set owner to the authenticated user
 	if userID := currentUserID(r); userID != "" {
 		input.OwnerID = userID

--- a/internal/store/migrations/069_workspace_source.sql
+++ b/internal/store/migrations/069_workspace_source.sql
@@ -1,0 +1,19 @@
+-- Add `source` to workspaces: record how a workspace was created (web UI /
+-- CLI / MCP). Drives the dashboard's has_agent_activity signal — a workspace
+-- created through an agent surface (`pad init`, `pad workspace init`, MCP
+-- pad_workspace.create) already has an agent wired up before that agent
+-- creates its first item, so the "connect an agent" banner should not fire
+-- for it (BUG-1557).
+--
+-- Existing rows predate this tracking, so they default to '' ("unknown /
+-- legacy origin") — deliberately NOT 'web', since many pre-existing
+-- workspaces were created via `pad init` (CLI). An empty value means
+-- "provenance unknown" and is never treated as agent-created. New workspaces
+-- set 'web' | 'cli' | 'mcp' explicitly at creation time.
+--
+-- SQLite has no `ADD COLUMN IF NOT EXISTS`, so this is a bare ADD COLUMN. The
+-- migration runner tolerates the "duplicate column name" error for
+-- `ALTER TABLE ... ADD COLUMN`, so a partially-applied re-run is idempotent.
+-- Adding a NOT NULL column is legal here only because a constant DEFAULT is
+-- supplied.
+ALTER TABLE workspaces ADD COLUMN source TEXT NOT NULL DEFAULT '';

--- a/internal/store/pgmigrations/047_workspace_source.sql
+++ b/internal/store/pgmigrations/047_workspace_source.sql
@@ -1,0 +1,6 @@
+-- Postgres counterpart to migrations/069_workspace_source.sql.
+-- Add `source` to workspaces: record how a workspace was created (web UI /
+-- CLI / MCP). Existing rows default to '' ("unknown / legacy origin"); an
+-- empty value is never treated as agent-created. New workspaces set
+-- 'web' | 'cli' | 'mcp' explicitly at creation time. See BUG-1557.
+ALTER TABLE workspaces ADD COLUMN IF NOT EXISTS source TEXT NOT NULL DEFAULT '';

--- a/internal/store/workspace_members.go
+++ b/internal/store/workspace_members.go
@@ -371,7 +371,7 @@ func (s *Store) ListSystemCollectionIDs(workspaceID string) ([]string, error) {
 // workspace row timestamp.
 func (s *Store) GetUserMemberWorkspaces(userID string) ([]models.Workspace, error) {
 	rows, err := s.db.Query(s.q(`
-		SELECT w.id, w.name, w.slug, w.owner_id, COALESCE(ou.username, ''), w.description, w.settings, w.created_at, w.updated_at, w.deleted_at,
+		SELECT w.id, w.name, w.slug, w.owner_id, COALESCE(ou.username, ''), w.description, w.settings, w.source, w.created_at, w.updated_at, w.deleted_at,
 		       wm.sort_order
 		FROM workspaces w
 		JOIN workspace_members wm ON wm.workspace_id = w.id
@@ -390,7 +390,7 @@ func (s *Store) GetUserMemberWorkspaces(userID string) ([]models.Workspace, erro
 		var createdAt, updatedAt string
 		var deletedAt *string
 		if err := rows.Scan(
-			&ws.ID, &ws.Name, &ws.Slug, &ws.OwnerID, &ws.OwnerUsername, &ws.Description, &ws.Settings,
+			&ws.ID, &ws.Name, &ws.Slug, &ws.OwnerID, &ws.OwnerUsername, &ws.Description, &ws.Settings, &ws.Source,
 			&createdAt, &updatedAt, &deletedAt,
 			&ws.SortOrder,
 		); err != nil {
@@ -419,7 +419,7 @@ func (s *Store) GetUserWorkspaces(userID string) ([]models.Workspace, error) {
 	// short-circuits and behaves like an unrestricted MAX. The
 	// visibility rule mirrors VisibleCollectionIDs above.
 	rows, err := s.db.Query(s.q(`
-		SELECT w.id, w.name, w.slug, w.owner_id, COALESCE(ou.username, ''), w.description, w.settings, w.created_at, w.updated_at, w.deleted_at,
+		SELECT w.id, w.name, w.slug, w.owner_id, COALESCE(ou.username, ''), w.description, w.settings, w.source, w.created_at, w.updated_at, w.deleted_at,
 		       wm.sort_order,
 		       (
 		           SELECT MAX(i.updated_at) FROM items i
@@ -469,7 +469,7 @@ func (s *Store) GetUserWorkspaces(userID string) ([]models.Workspace, error) {
 		var deletedAt *string
 		var lastItemActivity sql.NullString
 		if err := rows.Scan(
-			&ws.ID, &ws.Name, &ws.Slug, &ws.OwnerID, &ws.OwnerUsername, &ws.Description, &ws.Settings,
+			&ws.ID, &ws.Name, &ws.Slug, &ws.OwnerID, &ws.OwnerUsername, &ws.Description, &ws.Settings, &ws.Source,
 			&createdAt, &updatedAt, &deletedAt,
 			&ws.SortOrder,
 			&lastItemActivity,
@@ -499,7 +499,7 @@ func (s *Store) GetUserWorkspaces(userID string) ([]models.Workspace, error) {
 	// items behind grants the guest doesn't hold. The visible-items
 	// subquery mirrors the WHERE-clause grant logic below.
 	guestRows, err := s.db.Query(s.q(`
-		SELECT DISTINCT w.id, w.name, w.slug, w.owner_id, COALESCE(ou.username, ''), w.description, w.settings, w.created_at, w.updated_at, w.deleted_at,
+		SELECT DISTINCT w.id, w.name, w.slug, w.owner_id, COALESCE(ou.username, ''), w.description, w.settings, w.source, w.created_at, w.updated_at, w.deleted_at,
 		       (
 		           SELECT MAX(i.updated_at) FROM items i
 		           JOIN collections c ON c.id = i.collection_id
@@ -549,7 +549,7 @@ func (s *Store) GetUserWorkspaces(userID string) ([]models.Workspace, error) {
 		var deletedAt *string
 		var lastItemActivity sql.NullString
 		if err := guestRows.Scan(
-			&ws.ID, &ws.Name, &ws.Slug, &ws.OwnerID, &ws.OwnerUsername, &ws.Description, &ws.Settings,
+			&ws.ID, &ws.Name, &ws.Slug, &ws.OwnerID, &ws.OwnerUsername, &ws.Description, &ws.Settings, &ws.Source,
 			&createdAt, &updatedAt, &deletedAt,
 			&lastItemActivity,
 		); err != nil {

--- a/internal/store/workspaces.go
+++ b/internal/store/workspaces.go
@@ -22,7 +22,7 @@ func (s *Store) ListWorkspaces() ([]models.Workspace, error) {
 	// renamed?". Done in two steps (scalar subquery + Go-side max) to
 	// stay portable across SQLite (no GREATEST) and Postgres.
 	rows, err := s.db.Query(s.q(`
-		SELECT w.id, w.name, w.slug, w.owner_id, COALESCE(ou.username, ''), w.description, w.settings, w.created_at, w.updated_at,
+		SELECT w.id, w.name, w.slug, w.owner_id, COALESCE(ou.username, ''), w.description, w.settings, w.source, w.created_at, w.updated_at,
 		       (SELECT MAX(i.updated_at) FROM items i WHERE i.workspace_id = w.id AND i.deleted_at IS NULL)
 		FROM workspaces w
 		LEFT JOIN users ou ON ou.id = w.owner_id
@@ -39,7 +39,7 @@ func (s *Store) ListWorkspaces() ([]models.Workspace, error) {
 		var w models.Workspace
 		var createdAt, updatedAt string
 		var lastItemActivity sql.NullString
-		if err := rows.Scan(&w.ID, &w.Name, &w.Slug, &w.OwnerID, &w.OwnerUsername, &w.Description, &w.Settings, &createdAt, &updatedAt, &lastItemActivity); err != nil {
+		if err := rows.Scan(&w.ID, &w.Name, &w.Slug, &w.OwnerID, &w.OwnerUsername, &w.Description, &w.Settings, &w.Source, &createdAt, &updatedAt, &lastItemActivity); err != nil {
 			return nil, err
 		}
 		w.CreatedAt = parseTime(createdAt)
@@ -98,9 +98,9 @@ func (s *Store) CreateWorkspace(input models.WorkspaceCreate) (*models.Workspace
 	}
 
 	_, err = s.db.Exec(s.q(`
-		INSERT INTO workspaces (id, name, slug, owner_id, description, settings, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-	`), id, input.Name, finalSlug, input.OwnerID, input.Description, settings, ts, ts)
+		INSERT INTO workspaces (id, name, slug, owner_id, description, settings, source, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`), id, input.Name, finalSlug, input.OwnerID, input.Description, settings, input.Source, ts, ts)
 	if err != nil {
 		return nil, fmt.Errorf("insert workspace: %w", err)
 	}
@@ -129,11 +129,11 @@ func (s *Store) GetWorkspaceBySlug(slug string) (*models.Workspace, error) {
 	var deletedAt *string
 
 	err := s.db.QueryRow(s.q(`
-		SELECT w.id, w.name, w.slug, w.owner_id, COALESCE(ou.username, ''), w.description, w.settings, w.created_at, w.updated_at, w.deleted_at
+		SELECT w.id, w.name, w.slug, w.owner_id, COALESCE(ou.username, ''), w.description, w.settings, w.source, w.created_at, w.updated_at, w.deleted_at
 		FROM workspaces w
 		LEFT JOIN users ou ON ou.id = w.owner_id
 		WHERE w.slug = ? AND w.deleted_at IS NULL
-	`), slug).Scan(&w.ID, &w.Name, &w.Slug, &w.OwnerID, &w.OwnerUsername, &w.Description, &w.Settings, &createdAt, &updatedAt, &deletedAt)
+	`), slug).Scan(&w.ID, &w.Name, &w.Slug, &w.OwnerID, &w.OwnerUsername, &w.Description, &w.Settings, &w.Source, &createdAt, &updatedAt, &deletedAt)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -154,11 +154,11 @@ func (s *Store) GetWorkspaceByID(id string) (*models.Workspace, error) {
 	var deletedAt *string
 
 	err := s.db.QueryRow(s.q(`
-		SELECT w.id, w.name, w.slug, w.owner_id, COALESCE(ou.username, ''), w.description, w.settings, w.created_at, w.updated_at, w.deleted_at
+		SELECT w.id, w.name, w.slug, w.owner_id, COALESCE(ou.username, ''), w.description, w.settings, w.source, w.created_at, w.updated_at, w.deleted_at
 		FROM workspaces w
 		LEFT JOIN users ou ON ou.id = w.owner_id
 		WHERE w.id = ? AND w.deleted_at IS NULL
-	`), id).Scan(&w.ID, &w.Name, &w.Slug, &w.OwnerID, &w.OwnerUsername, &w.Description, &w.Settings, &createdAt, &updatedAt, &deletedAt)
+	`), id).Scan(&w.ID, &w.Name, &w.Slug, &w.OwnerID, &w.OwnerUsername, &w.Description, &w.Settings, &w.Source, &createdAt, &updatedAt, &deletedAt)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -177,7 +177,7 @@ func (s *Store) GetWorkspaceByID(id string) (*models.Workspace, error) {
 // to the given user (owned, member, or guest with grants).
 func (s *Store) GetWorkspacesBySlugForUser(slug, userID string) ([]models.Workspace, error) {
 	rows, err := s.db.Query(s.q(`
-		SELECT DISTINCT w.id, w.name, w.slug, w.owner_id, COALESCE(ou.username, ''), w.description, w.settings, w.created_at, w.updated_at
+		SELECT DISTINCT w.id, w.name, w.slug, w.owner_id, COALESCE(ou.username, ''), w.description, w.settings, w.source, w.created_at, w.updated_at
 		FROM workspaces w
 		LEFT JOIN workspace_members wm ON wm.workspace_id = w.id AND wm.user_id = ?
 		LEFT JOIN collection_grants cg ON cg.workspace_id = w.id AND cg.user_id = ?
@@ -195,7 +195,7 @@ func (s *Store) GetWorkspacesBySlugForUser(slug, userID string) ([]models.Worksp
 	for rows.Next() {
 		var w models.Workspace
 		var createdAt, updatedAt string
-		if err := rows.Scan(&w.ID, &w.Name, &w.Slug, &w.OwnerID, &w.OwnerUsername, &w.Description, &w.Settings, &createdAt, &updatedAt); err != nil {
+		if err := rows.Scan(&w.ID, &w.Name, &w.Slug, &w.OwnerID, &w.OwnerUsername, &w.Description, &w.Settings, &w.Source, &createdAt, &updatedAt); err != nil {
 			return nil, err
 		}
 		w.CreatedAt = parseTime(createdAt)

--- a/internal/store/workspaces_source_test.go
+++ b/internal/store/workspaces_source_test.go
@@ -1,0 +1,58 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// TestWorkspaceSourcePersisted covers migration 069 / BUG-1557: the
+// workspaces.source column round-trips through CreateWorkspace and every
+// read that scans a models.Workspace. A missed scan site would surface here
+// (or as a "sql: expected N destination arguments" failure) rather than at
+// runtime.
+func TestWorkspaceSourcePersisted(t *testing.T) {
+	s := testStore(t)
+
+	cli, err := s.CreateWorkspace(models.WorkspaceCreate{Name: "Agent WS", Source: "cli"})
+	if err != nil {
+		t.Fatalf("create cli workspace: %v", err)
+	}
+	if cli.Source != "cli" {
+		t.Fatalf("CreateWorkspace return: expected source=cli, got %q", cli.Source)
+	}
+
+	// CreateWorkspace returns via GetWorkspaceBySlug, but assert the other
+	// single-row read (by ID) round-trips it too.
+	byID, err := s.GetWorkspaceByID(cli.ID)
+	if err != nil || byID == nil {
+		t.Fatalf("get by id: %v (nil=%v)", err, byID == nil)
+	}
+	if byID.Source != "cli" {
+		t.Fatalf("GetWorkspaceByID: expected source=cli, got %q", byID.Source)
+	}
+
+	// A workspace created without an explicit source (the common
+	// direct-store path — cloud auto-create, import, test helpers) stays
+	// "" so it is never treated as agent-created.
+	web := createTestWorkspace(t, s, "Web WS")
+	if web.Source != "" {
+		t.Fatalf("default CreateWorkspace: expected empty source, got %q", web.Source)
+	}
+
+	// ListWorkspaces (cross-tenant) round-trips source for every row.
+	all, err := s.ListWorkspaces()
+	if err != nil {
+		t.Fatalf("list workspaces: %v", err)
+	}
+	got := map[string]string{}
+	for _, w := range all {
+		got[w.ID] = w.Source
+	}
+	if got[cli.ID] != "cli" {
+		t.Fatalf("ListWorkspaces: expected cli workspace source=cli, got %q", got[cli.ID])
+	}
+	if got[web.ID] != "" {
+		t.Fatalf("ListWorkspaces: expected web workspace source=\"\", got %q", got[web.ID])
+	}
+}

--- a/web/src/lib/components/OnboardingLaunchpad.svelte
+++ b/web/src/lib/components/OnboardingLaunchpad.svelte
@@ -10,6 +10,11 @@
 	 *   ① connect an agent  ② tell it (in natural language) to set up
 	 *   ③ watch the result appear here live (via the page's SSE feed).
 	 *
+	 * Step ① adapts to `agentActive`: when an agent is already connected (e.g.
+	 * the workspace was created via a cli/mcp surface — BUG-1557), step ①
+	 * collapses to a "connected" confirmation and the emphasis shifts to
+	 * step ② as the primary next action.
+	 *
 	 * The flag flips to false the moment any real item exists, at which point
 	 * the parent swaps back to the normal dashboard — so this view is
 	 * inherently transient.
@@ -17,13 +22,17 @@
 	interface Props {
 		workspaceName: string;
 		/**
-		 * Whether an agent has already acted in this workspace
+		 * Whether an agent is connected to this workspace
 		 * (dashboard.has_agent_activity). Ticks the "Agent connected" checklist
-		 * step. Note: this signal flips on the first agent-CREATED item, which
-		 * also clears needs_onboarding and removes the launchpad — so in
-		 * practice the checklist is an orientation device (you're on step 1),
-		 * not a live mid-launchpad tracker. A distinct "connected but hasn't
-		 * acted yet" signal is deferred (see IDEA-1854).
+		 * step and collapses step ① to a confirmation. This now flips true in
+		 * two cases (BUG-1557): (a) the first agent-CREATED item — which also
+		 * clears needs_onboarding and removes the launchpad; and (b) the
+		 * workspace itself was created via a cli/mcp agent surface (`pad init`,
+		 * MCP), which reports has_agent_activity=true before any item exists.
+		 * Because of (b) the launchpad can legitimately render with
+		 * agentActive=true, so it is a live signal — step ① adapts to it — not
+		 * just the orientation device the pre-BUG-1557 code assumed (the
+		 * deferred "connected but hasn't acted yet" signal of IDEA-1854).
 		 */
 		agentActive?: boolean;
 		/** Opens the workspace's ConnectWorkspaceModal (mounted by the parent). */
@@ -72,20 +81,29 @@
 
 	<ol class="lp-steps">
 		<li class="lp-step">
-			<span class="lp-step-num" aria-hidden="true">1</span>
+			<span class="lp-step-num" class:done={agentActive} aria-hidden="true"
+				>{agentActive ? '✓' : '1'}</span
+			>
 			<div class="lp-step-body">
-				<h2 class="lp-step-title">Connect your agent</h2>
-				<p class="lp-step-text">
-					Add Pad to Claude Code, Cursor, Codex, or Claude Desktop — it takes a
-					few seconds.
-				</p>
-				<button class="lp-connect-btn" type="button" onclick={onconnect}>
-					Connect agent &rarr;
-				</button>
+				{#if agentActive}
+					<h2 class="lp-step-title">Agent connected</h2>
+					<p class="lp-step-text">
+						Your agent is already connected to this workspace.
+					</p>
+				{:else}
+					<h2 class="lp-step-title">Connect your agent</h2>
+					<p class="lp-step-text">
+						Add Pad to Claude Code, Cursor, Codex, or Claude Desktop — it takes a
+						few seconds.
+					</p>
+					<button class="lp-connect-btn" type="button" onclick={onconnect}>
+						Connect agent &rarr;
+					</button>
+				{/if}
 			</div>
 		</li>
 
-		<li class="lp-step">
+		<li class="lp-step" class:next={agentActive}>
 			<span class="lp-step-num" aria-hidden="true">2</span>
 			<div class="lp-step-body">
 				<h2 class="lp-step-title">Tell it to set up</h2>
@@ -202,6 +220,11 @@
 		border: 1px solid var(--border);
 		border-radius: var(--radius);
 	}
+	/* When step ① is already done (agent connected), step ② becomes the
+	   primary next action — accent its border. */
+	.lp-step.next {
+		border-color: var(--accent-blue);
+	}
 	.lp-step-num {
 		display: inline-flex;
 		align-items: center;
@@ -214,6 +237,12 @@
 		color: var(--accent-blue);
 		font-weight: 700;
 		font-size: 0.85em;
+	}
+	/* Completed step marker (agent already connected) — filled accent-blue
+	   check, matching the .lp-progress-item.done accent language. */
+	.lp-step-num.done {
+		background: var(--accent-blue);
+		color: #fff;
 	}
 	.lp-step-body {
 		flex: 1;


### PR DESCRIPTION
## BUG-1557

Running `pad init` connects an agent (installs the skill, stores credentials) **and** creates a workspace — but opening the web UI still showed the "connect an agent" banner and onboarding launchpad, nagging to connect an agent the user already had.

### Root cause
The only server signal for "agent connected" was `has_agent_activity` = *an item exists with `source IN ('cli','mcp')`*. A fresh `pad init` workspace has zero items, so the signal was false and every connect/onboarding surface fired.

### Fix
Give the server a truthful signal: **a workspace created through an agent surface already has an agent wired up**, before it creates any item.

- Add a `source` column to `workspaces` (`web` / `cli` / `mcp`), migrations `069` (SQLite) / `047` (Postgres), `NOT NULL DEFAULT ''` so legacy rows stay "unknown" (never treated as agent-created).
- Attribute `source` **authoritatively server-side** from the request auth shape (`actorFromRequest`) — never from the request body (`WorkspaceCreate.Source` is `json:"-"`), so a web client can't spoof `"cli"` to self-suppress the prompts.
- The dashboard ORs `source in (cli,mcp)` into `has_agent_activity` (only when the cheap item-EXISTS check comes up empty; workspace load failure is non-fatal since `buildDashboardResponse` also backs the bootstrap endpoint).
- `OnboardingLaunchpad` step ① collapses to "✓ Agent connected" when an agent is already wired up, shifting emphasis to *"tell it to set up"* — the state the component previously assumed impossible (its own comment cited deferred IDEA-1854).

### Surfaces audited (second half of the bug)
| Flow | source | agent connected? | UX |
|---|---|---|---|
| `pad init` / `pad workspace init` / `pad workspace create` (CLI) | `cli` | yes | banner suppressed ✅ |
| MCP `pad_workspace.create` (self-host + cloud) | `cli` | yes | banner suppressed ✅ |
| Web `/console` create modal | `web` | no | prompts to connect (correct) ✅ |
| Cloud OAuth signup auto-create | `''` (direct store call) | no | prompts to connect (correct) ✅ |

### Tests
- Store: `source` round-trips through `CreateWorkspace` and all workspace reads.
- Handler: cli-created workspace reports `has_agent_activity=true` with zero items; web-created stays false until an agent item exists; item-based signal still flips; **web body-spoofed `source` is ignored**.

### Verification
`go build ./...`, `go vet`, full `internal/store` + `internal/server` + `internal/cli` suites, and the SvelteKit production build — all green. Reviewed by a multi-lens adversarial pass and the Codex review loop (1 finding → fixed → CLEAN).

Fixes BUG-1557.

https://claude.ai/code/session_01HxBkAMiFBtCRJ2tKSCt3ST
