### PR TITLE
fix(cli): detect machine-level agent tools, not just project-local (BUG-1156)

### DIFF
--- a/internal/cli/agents.go
+++ b/internal/cli/agents.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 )
@@ -17,6 +18,15 @@ type AgentTool struct {
 	Aliases []string
 	// DetectDirs are directories whose presence suggests this tool is in use.
 	DetectDirs []string
+	// DetectHomeDirs are directories (relative to $HOME) whose presence
+	// suggests this tool is installed on the machine, even outside the
+	// current project. Only populated for tools with an unambiguous home
+	// directory signal.
+	DetectHomeDirs []string
+	// DetectBinaries are executable names checked via exec.LookPath whose
+	// presence on PATH suggests this tool is installed on the machine. Only
+	// populated for tools with an unambiguous, unique binary name.
+	DetectBinaries []string
 	// SkillDir is the relative path from project root for the skill file directory.
 	SkillDir string
 	// SkillFile is the filename within SkillDir.
@@ -27,20 +37,24 @@ type AgentTool struct {
 // The "agents" target covers Codex, Cursor, and Windsurf via the shared .agents/skills/ directory.
 var SupportedTools = []AgentTool{
 	{
-		Name:       "claude",
-		Label:      "Claude Code",
-		Aliases:    nil,
-		DetectDirs: []string{".claude"},
-		SkillDir:   filepath.Join(".claude", "skills", "pad"),
-		SkillFile:  "SKILL.md",
+		Name:           "claude",
+		Label:          "Claude Code",
+		Aliases:        nil,
+		DetectDirs:     []string{".claude"},
+		DetectHomeDirs: []string{".claude"},
+		DetectBinaries: []string{"claude"},
+		SkillDir:       filepath.Join(".claude", "skills", "pad"),
+		SkillFile:      "SKILL.md",
 	},
 	{
-		Name:       "agents",
-		Label:      "Codex / Cursor / Windsurf",
-		Aliases:    []string{"codex", "cursor", "windsurf"},
-		DetectDirs: []string{".cursor", ".windsurf", ".codex", ".agents"},
-		SkillDir:   filepath.Join(".agents", "skills", "pad"),
-		SkillFile:  "SKILL.md",
+		Name:           "agents",
+		Label:          "Codex / Cursor / Windsurf",
+		Aliases:        []string{"codex", "cursor", "windsurf"},
+		DetectDirs:     []string{".cursor", ".windsurf", ".codex", ".agents"},
+		DetectHomeDirs: []string{".cursor", ".windsurf", ".codex", ".agents"},
+		DetectBinaries: []string{"codex", "cursor", "windsurf"},
+		SkillDir:       filepath.Join(".agents", "skills", "pad"),
+		SkillFile:      "SKILL.md",
 	},
 	{
 		Name:       "copilot",
@@ -85,29 +99,45 @@ func ResolveTool(nameOrAlias string) *AgentTool {
 	return nil
 }
 
-// DetectTools returns the tools that appear to be in use based on directory presence.
+// DetectTools returns the tools that appear to be in use, based on any of:
+// a project-local directory, a home-directory install, or a binary on PATH.
 func DetectTools() []AgentTool {
-	cwd, err := os.Getwd()
-	if err != nil {
-		return nil
-	}
+	cwd, cwdErr := os.Getwd()
+	homeDir, homeErr := os.UserHomeDir()
 
 	var detected []AgentTool
-	seen := map[string]bool{}
 	for _, tool := range SupportedTools {
-		if seen[tool.Name] {
+		switch {
+		case cwdErr == nil && dirPresent(cwd, tool.DetectDirs):
+		case homeErr == nil && dirPresent(homeDir, tool.DetectHomeDirs):
+		case binaryPresent(tool.DetectBinaries):
+		default:
 			continue
 		}
-		for _, dir := range tool.DetectDirs {
-			info, err := os.Stat(filepath.Join(cwd, dir))
-			if err == nil && info.IsDir() {
-				detected = append(detected, tool)
-				seen[tool.Name] = true
-				break
-			}
-		}
+		detected = append(detected, tool)
 	}
 	return detected
+}
+
+// dirPresent reports whether any of dirs (relative to base) exists as a directory.
+func dirPresent(base string, dirs []string) bool {
+	for _, dir := range dirs {
+		info, err := os.Stat(filepath.Join(base, dir))
+		if err == nil && info.IsDir() {
+			return true
+		}
+	}
+	return false
+}
+
+// binaryPresent reports whether any of the given executable names is found on PATH.
+func binaryPresent(bins []string) bool {
+	for _, bin := range bins {
+		if _, err := exec.LookPath(bin); err == nil {
+			return true
+		}
+	}
+	return false
 }
 
 // ToolSkillPath returns the full path where a tool's skill file would be installed.

--- a/internal/cli/agents_test.go
+++ b/internal/cli/agents_test.go
@@ -1,6 +1,9 @@
 package cli
 
 import (
+	"os"
+	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -151,6 +154,141 @@ func containsStr(s, sub string) bool {
 		}
 	}
 	return false
+}
+
+// isolateEnv points HOME and PATH at empty temp directories and chdirs into
+// an empty temp directory, so DetectTools sees none of this machine's real
+// signals (this dev machine has ~/.codex, ~/.claude, etc. — a naive test
+// would false-pass without this).
+func isolateEnv(t *testing.T) (home, bin string) {
+	t.Helper()
+	home = t.TempDir()
+	bin = t.TempDir()
+	cwd := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", bin)
+	t.Chdir(cwd)
+	return home, bin
+}
+
+// writeStubBinary creates an executable file named `name` in dir, so
+// exec.LookPath(name) succeeds against it.
+func writeStubBinary(t *testing.T, dir, name string) {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write stub binary %s: %v", path, err)
+	}
+}
+
+func detectedNames(tools []AgentTool) map[string]bool {
+	names := map[string]bool{}
+	for _, tool := range tools {
+		names[tool.Name] = true
+	}
+	return names
+}
+
+func TestDetectTools(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("stub binaries and HOME semantics differ on windows")
+	}
+
+	t.Run("no signal miss", func(t *testing.T) {
+		isolateEnv(t)
+		got := DetectTools()
+		if len(got) != 0 {
+			t.Errorf("DetectTools() = %v, want empty", got)
+		}
+	})
+
+	t.Run("home dir hit for agents via ~/.codex", func(t *testing.T) {
+		home, _ := isolateEnv(t)
+		if err := os.Mkdir(filepath.Join(home, ".codex"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		names := detectedNames(DetectTools())
+		if !names["agents"] {
+			t.Errorf("expected agents detected via ~/.codex, got %v", names)
+		}
+		if names["claude"] {
+			t.Errorf("claude should not be detected, got %v", names)
+		}
+	})
+
+	t.Run("home dir hit for claude via ~/.claude", func(t *testing.T) {
+		home, _ := isolateEnv(t)
+		if err := os.Mkdir(filepath.Join(home, ".claude"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		names := detectedNames(DetectTools())
+		if !names["claude"] {
+			t.Errorf("expected claude detected via ~/.claude, got %v", names)
+		}
+		if names["agents"] {
+			t.Errorf("agents should not be detected, got %v", names)
+		}
+	})
+
+	t.Run("binary hit for agents via codex on PATH", func(t *testing.T) {
+		_, bin := isolateEnv(t)
+		writeStubBinary(t, bin, "codex")
+		names := detectedNames(DetectTools())
+		if !names["agents"] {
+			t.Errorf("expected agents detected via codex binary, got %v", names)
+		}
+	})
+
+	t.Run("binary hit for claude via claude on PATH", func(t *testing.T) {
+		_, bin := isolateEnv(t)
+		writeStubBinary(t, bin, "claude")
+		names := detectedNames(DetectTools())
+		if !names["claude"] {
+			t.Errorf("expected claude detected via claude binary, got %v", names)
+		}
+	})
+
+	t.Run("project-local dir still works for tools with no machine signal", func(t *testing.T) {
+		isolateEnv(t)
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Mkdir(filepath.Join(cwd, ".junie"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		names := detectedNames(DetectTools())
+		if !names["junie"] {
+			t.Errorf("expected junie detected via project-local .junie, got %v", names)
+		}
+		if len(names) != 1 {
+			t.Errorf("expected only junie detected, got %v", names)
+		}
+	})
+
+	t.Run("project-local and home dir both present dedupes to one entry", func(t *testing.T) {
+		home, _ := isolateEnv(t)
+		if err := os.Mkdir(filepath.Join(home, ".claude"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Mkdir(filepath.Join(cwd, ".claude"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		got := DetectTools()
+		count := 0
+		for _, tool := range got {
+			if tool.Name == "claude" {
+				count++
+			}
+		}
+		if count != 1 {
+			t.Errorf("expected claude detected exactly once, got %d (in %v)", count, got)
+		}
+	})
 }
 
 func TestAllToolNames(t *testing.T) {


### PR DESCRIPTION
## Summary

`pad init` on a machine with codex installed only ever set up the Claude skill: `cli.DetectTools()` looked exclusively at *project-local* directories (`.codex`, `.cursor`, …), which don't exist in a fresh project even when the tool is installed machine-wide (`~/.codex`, `codex` on PATH). Fixes BUG-1156.

`DetectTools()` now ORs three signals per tool:
- project-local directory (existing behavior, unchanged)
- home-relative directory — new `AgentTool.DetectHomeDirs`
- binary on PATH via `exec.LookPath` — new `AgentTool.DetectBinaries`

Machine-level signals are populated **conservatively**: only `claude` (`~/.claude`, `claude`) and `agents` (`~/.codex`/`.cursor`/`.windsurf`/`.agents`; `codex`/`cursor`/`windsurf`). Copilot, Amazon Q, and Junie keep project-local-only detection — `gh`/`q` binaries are too ambiguous as install signals.

## Plus

- Install destinations are untouched — skills still land project-locally; only *detection* widened.
- `DetectTools()` no longer returns nil on `os.Getwd()` failure; it degrades to home/PATH signals.
- All six call sites audited (`ensureSkills`, `offerSkillInstall`, `pad agent install/--all/list`): each only widens which tools get project-local installs, which is the intended fix. `pad agent update` gates on existing project-local files and is unaffected.

## Observable behavior changes

- `pad init` / `pad workspace init` on a machine with codex (or cursor/windsurf) installed now also writes `.agents/skills/pad/SKILL.md`.
- `pad agent install --list` marks machine-installed tools as `(detected)`.

## Test plan

- [x] `go test ./...` full suite green (includes 7 new `TestDetectTools` subtests: home-dir hit, PATH-binary hit, no-signal miss, project-local regression, dedup)
- [x] Tests isolated from host machine state via `t.Setenv(HOME/PATH)` + `t.Chdir` temp dirs (this dev box has `~/.codex` — naive tests would false-pass)
- [x] `golangci-lint run` clean on touched packages (repo-wide `make lint` fails on pre-existing `internal/models/workspace.go` gofmt drift, identical on unmodified main)
- [x] Manual repro: fake `$HOME` containing only `.codex`, empty project dir → `pad agent install --list` shows Codex/Cursor/Windsurf `(detected)`
- [x] 2 codex review rounds (plain + adversarial framing), both CLEAN

Refs: BUG-1156

https://claude.ai/code/session_01CL1pBjNpPUX6SWkuAuYXHS