### PR TITLE
fix(ci): gofmt internal/models/workspace.go to unbreak Go job (BUG-1911)

### DIFF
--- a/internal/models/workspace.go
+++ b/internal/models/workspace.go
@@ -3,25 +3,25 @@ package models
 import "time"
 
 type Workspace struct {
-	ID            string            `json:"id"`
-	Name          string            `json:"name"`
-	Slug          string            `json:"slug"`
-	OwnerID       string            `json:"owner_id,omitempty"`       // User ID of workspace owner
-	OwnerUsername string            `json:"owner_username,omitempty"` // Populated by JOIN (not stored)
-	IsGuest       bool              `json:"is_guest,omitempty"`       // True when user has grants but no membership
-	Description   string            `json:"description"`
-	Settings      string            `json:"settings"` // JSON
+	ID            string `json:"id"`
+	Name          string `json:"name"`
+	Slug          string `json:"slug"`
+	OwnerID       string `json:"owner_id,omitempty"`       // User ID of workspace owner
+	OwnerUsername string `json:"owner_username,omitempty"` // Populated by JOIN (not stored)
+	IsGuest       bool   `json:"is_guest,omitempty"`       // True when user has grants but no membership
+	Description   string `json:"description"`
+	Settings      string `json:"settings"` // JSON
 	// Source records how the workspace was created — "web", "cli", or "mcp"
 	// (empty on rows predating migration 069). A cli/mcp origin means an
 	// agent surface created the workspace, so an agent is already wired up
 	// even before it creates its first item; the dashboard's
 	// has_agent_activity signal ORs this in (BUG-1557).
-	Source        string            `json:"source,omitempty"`
-	SortOrder     int               `json:"sort_order"`
-	Context       *WorkspaceContext `json:"context,omitempty"`
-	CreatedAt     time.Time         `json:"created_at"`
-	UpdatedAt     time.Time         `json:"updated_at"`
-	DeletedAt     *time.Time        `json:"deleted_at,omitempty"`
+	Source    string            `json:"source,omitempty"`
+	SortOrder int               `json:"sort_order"`
+	Context   *WorkspaceContext `json:"context,omitempty"`
+	CreatedAt time.Time         `json:"created_at"`
+	UpdatedAt time.Time         `json:"updated_at"`
+	DeletedAt *time.Time        `json:"deleted_at,omitempty"`
 }
 
 type WorkspaceCreate struct {


### PR DESCRIPTION
## Summary

Restores the Go CI job, red on main since #781. The mid-struct doc comment added there split the `Workspace` struct into two gofmt alignment groups; the file was committed without re-running gofmt, so golangci-lint's gofmt check fails on every PR — #780–#783 all merged over a red Go job, which masks real lint/test failures.

Machine-generated fix: `gofmt -w internal/models/workspace.go` (go1.26.4, matching CI's 1.26). Whitespace-only; no semantic change.

## Test plan

- [x] `gofmt -l ./internal/ ./cmd/` → clean tree
- [x] `make lint` → 0 issues (previously failed on exactly this file)
- [x] `go test ./internal/models/...` green
- [x] Go CI job on this PR is the end-to-end proof — it should go green for the first time since Jul 1

Refs: BUG-1911

https://claude.ai/code/session_01CL1pBjNpPUX6SWkuAuYXHS