### PR TITLE
perf(test): build the SQLite migration chain once per test binary (IDEA-1914)

### DIFF
--- a/internal/server/main_test.go
+++ b/internal/server/main_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/PerpetualSoftware/pad/internal/store"
+	"github.com/PerpetualSoftware/pad/internal/store/storetest"
 	"golang.org/x/crypto/bcrypt"
 )
 
@@ -12,7 +13,13 @@ import (
 // the suite's many bootstrapFirstUser calls run bcrypt at the production
 // cost under -race (~3s per call), pushing cumulative race-step time past
 // the CI 30m timeout. See BUG-1371.
+//
+// It also tears down storetest's process-wide template DB (IDEA-1914)
+// after the suite finishes, so the lazily-built template file doesn't
+// linger past this binary's lifetime.
 func TestMain(m *testing.M) {
 	store.SetBcryptCostForTesting(bcrypt.MinCost)
-	os.Exit(m.Run())
+	code := m.Run()
+	storetest.Cleanup()
+	os.Exit(code)
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"path/filepath"
 	"runtime"
 	"sync/atomic"
 	"testing"
@@ -14,25 +13,26 @@ import (
 
 	"github.com/PerpetualSoftware/pad/internal/models"
 	"github.com/PerpetualSoftware/pad/internal/store"
+	"github.com/PerpetualSoftware/pad/internal/store/storetest"
 )
 
 func testServer(t *testing.T) *Server {
 	t.Helper()
-	dir := t.TempDir()
-	dbPath := filepath.Join(dir, "test.db")
-	s, err := store.New(dbPath)
-	if err != nil {
-		t.Fatalf("failed to create store: %v", err)
-	}
+	// storetest.NewSQLite (IDEA-1914) runs the full migration chain at
+	// most once per test binary instead of once per call — see its
+	// package doc. It already registers its own t.Cleanup(s.Close);
+	// because testing.T runs cleanups LIFO, registering srv.Stop() here
+	// AFTER that call still runs Stop() BEFORE Close(), preserving the
+	// BUG-842 drain-then-close ordering below.
+	s := storetest.NewSQLite(t)
 	srv := New(s)
-	// Drain background goroutines BEFORE closing the store. Without this,
+	// Drain background goroutines BEFORE the store closes. Without this,
 	// fire-and-forget writes spawned by request middleware (e.g.
 	// TouchUserActivity in middleware_auth) can race the SQLite WAL/SHM
 	// file removal in t.TempDir's cleanup, causing
 	// "TempDir RemoveAll cleanup: directory not empty" — see BUG-842.
 	t.Cleanup(func() {
 		srv.Stop()
-		s.Close()
 	})
 	return srv
 }
@@ -426,13 +426,9 @@ func TestServer_Stop_DrainsRateLimiterCleanup(t *testing.T) {
 
 	const cycles = 5
 	for i := 0; i < cycles; i++ {
-		// Use the bare New(s) constructor (not testServer) so we control
-		// when Stop runs and don't entangle with t.Cleanup ordering.
-		dir := t.TempDir()
-		s, err := store.New(filepath.Join(dir, "test.db"))
-		if err != nil {
-			t.Fatalf("store.New: %v", err)
-		}
+		// Use storetest.NewSQLiteUnmanaged (not testServer) so we control
+		// when Stop/Close run and don't entangle with t.Cleanup ordering.
+		s := storetest.NewSQLiteUnmanaged(t)
 		srv := New(s)
 
 		// Each NewRateLimiters spawns 9 cleanup goroutines.

--- a/internal/store/main_test.go
+++ b/internal/store/main_test.go
@@ -10,7 +10,12 @@ import (
 // TestMain lowers the bcrypt cost for the whole package. See BUG-1371
 // and internal/server/main_test.go for context — the same reasoning
 // applies to internal/store tests that call CreateUser directly.
+//
+// It also tears down testStoreSQLite's process-wide template DB
+// (IDEA-1914, store_test.go) after the suite finishes.
 func TestMain(m *testing.M) {
 	SetBcryptCostForTesting(bcrypt.MinCost)
-	os.Exit(m.Run())
+	code := m.Run()
+	removeSQLiteTemplate()
+	os.Exit(code)
 }

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -41,6 +41,9 @@ func testStore(t *testing.T) *Store {
 // buildTemplate/NewSQLite IN SYNC — see that file's package doc for the
 // full rationale.
 var (
+	// sqliteTemplateMu guards sqliteTemplatePath against removeSQLiteTemplate
+	// racing an in-flight build/copy — mirrors storetest.go's templateMu.
+	sqliteTemplateMu   sync.RWMutex
 	sqliteTemplateOnce sync.Once
 	sqliteTemplatePath string
 	sqliteTemplateErr  error
@@ -49,16 +52,9 @@ var (
 func testStoreSQLite(t *testing.T) *Store {
 	t.Helper()
 
-	sqliteTemplateOnce.Do(func() {
-		sqliteTemplatePath, sqliteTemplateErr = buildSQLiteTemplate()
-	})
-	if sqliteTemplateErr != nil {
-		t.Fatalf("build template db: %v", sqliteTemplateErr)
-	}
-
 	dst := filepath.Join(t.TempDir(), "test.db")
-	if err := copyTemplateFile(sqliteTemplatePath, dst); err != nil {
-		t.Fatalf("copy template db: %v", err)
+	if err := lockedCopyFromSQLiteTemplate(dst); err != nil {
+		t.Fatalf("%v", err)
 	}
 
 	s, err := New(dst)
@@ -69,15 +65,47 @@ func testStoreSQLite(t *testing.T) *Store {
 	return s
 }
 
+// lockedCopyFromSQLiteTemplate builds the template (once) and copies it
+// to dst, holding sqliteTemplateMu for read across both steps so
+// removeSQLiteTemplate (which takes the write lock) can't remove the
+// template out from under an in-flight build or copy. Mirrors
+// storetest.go's lockedCopyFromTemplate.
+func lockedCopyFromSQLiteTemplate(dst string) error {
+	sqliteTemplateMu.RLock()
+	defer sqliteTemplateMu.RUnlock()
+
+	sqliteTemplateOnce.Do(func() {
+		sqliteTemplatePath, sqliteTemplateErr = buildSQLiteTemplate()
+	})
+	if sqliteTemplateErr != nil {
+		return fmt.Errorf("build template db: %w", sqliteTemplateErr)
+	}
+	if err := copyTemplateFile(sqliteTemplatePath, dst); err != nil {
+		return fmt.Errorf("copy template db: %w", err)
+	}
+	return nil
+}
+
 // buildSQLiteTemplate runs the full migration chain once into a
 // process-wide temp file. The template is checkpointed and left in
 // DELETE journal mode (no -wal/-shm sidecars), so testStoreSQLite's copy
 // is a single-file operation.
+//
+// The template dir is removed on any error path (MkdirTemp succeeded but
+// a later step failed) so a failed build doesn't leak a /tmp directory;
+// mirrors storetest.go's buildTemplate.
 func buildSQLiteTemplate() (string, error) {
 	dir, err := os.MkdirTemp("", "pad-store-template-*")
 	if err != nil {
 		return "", fmt.Errorf("mkdir template dir: %w", err)
 	}
+	ok := false
+	defer func() {
+		if !ok {
+			_ = os.RemoveAll(dir)
+		}
+	}()
+
 	path := filepath.Join(dir, "template.db")
 
 	s, err := New(path)
@@ -92,6 +120,7 @@ func buildSQLiteTemplate() (string, error) {
 	if _, err := s.DB().Exec("PRAGMA journal_mode=DELETE"); err != nil {
 		return "", fmt.Errorf("set template journal_mode=DELETE: %w", err)
 	}
+	ok = true
 	return path, nil
 }
 
@@ -117,6 +146,8 @@ func copyTemplateFile(src, dst string) error {
 // removeSQLiteTemplate deletes the template directory built by
 // buildSQLiteTemplate, if any. Called from TestMain after m.Run().
 func removeSQLiteTemplate() {
+	sqliteTemplateMu.Lock()
+	defer sqliteTemplateMu.Unlock()
 	if sqliteTemplatePath != "" {
 		_ = os.RemoveAll(filepath.Dir(sqliteTemplatePath))
 	}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -3,6 +3,7 @@ package store
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sync"
@@ -15,8 +16,8 @@ import (
 
 // testStore creates a Store for testing. When PAD_TEST_POSTGRES_URL is set,
 // it creates an isolated PostgreSQL database; otherwise it falls back to a
-// temporary SQLite file. Every test gets its own database so tests never
-// interfere with each other.
+// fast SQLite fixture (see testStoreSQLite). Every test gets its own
+// database so tests never interfere with each other.
 func testStore(t *testing.T) *Store {
 	t.Helper()
 
@@ -24,14 +25,101 @@ func testStore(t *testing.T) *Store {
 		return testStorePostgres(t, pgURL)
 	}
 
-	dir := t.TempDir()
-	dbPath := filepath.Join(dir, "test.db")
-	s, err := New(dbPath)
+	return testStoreSQLite(t)
+}
+
+// testStoreSQLite mirrors internal/store/storetest's NewSQLite (IDEA-1914):
+// the full migration chain runs at most once per test binary (a
+// sync.Once-guarded template DB), and every call gets a plain file copy
+// of it, opened via New like any other test store.
+//
+// This logic is DUPLICATED from internal/store/storetest/storetest.go
+// rather than shared, because internal/store's own white-box tests
+// (package store, this file) cannot import a package that itself imports
+// store — Go rejects that as an import cycle ("import cycle not allowed
+// in test", verified). KEEP THIS FUNCTION AND storetest.go's
+// buildTemplate/NewSQLite IN SYNC — see that file's package doc for the
+// full rationale.
+var (
+	sqliteTemplateOnce sync.Once
+	sqliteTemplatePath string
+	sqliteTemplateErr  error
+)
+
+func testStoreSQLite(t *testing.T) *Store {
+	t.Helper()
+
+	sqliteTemplateOnce.Do(func() {
+		sqliteTemplatePath, sqliteTemplateErr = buildSQLiteTemplate()
+	})
+	if sqliteTemplateErr != nil {
+		t.Fatalf("build template db: %v", sqliteTemplateErr)
+	}
+
+	dst := filepath.Join(t.TempDir(), "test.db")
+	if err := copyTemplateFile(sqliteTemplatePath, dst); err != nil {
+		t.Fatalf("copy template db: %v", err)
+	}
+
+	s, err := New(dst)
 	if err != nil {
 		t.Fatalf("failed to create store: %v", err)
 	}
 	t.Cleanup(func() { s.Close() })
 	return s
+}
+
+// buildSQLiteTemplate runs the full migration chain once into a
+// process-wide temp file. The template is checkpointed and left in
+// DELETE journal mode (no -wal/-shm sidecars), so testStoreSQLite's copy
+// is a single-file operation.
+func buildSQLiteTemplate() (string, error) {
+	dir, err := os.MkdirTemp("", "pad-store-template-*")
+	if err != nil {
+		return "", fmt.Errorf("mkdir template dir: %w", err)
+	}
+	path := filepath.Join(dir, "template.db")
+
+	s, err := New(path)
+	if err != nil {
+		return "", fmt.Errorf("build template store: %w", err)
+	}
+	defer s.Close()
+
+	if _, err := s.DB().Exec("PRAGMA wal_checkpoint(TRUNCATE)"); err != nil {
+		return "", fmt.Errorf("checkpoint template: %w", err)
+	}
+	if _, err := s.DB().Exec("PRAGMA journal_mode=DELETE"); err != nil {
+		return "", fmt.Errorf("set template journal_mode=DELETE: %w", err)
+	}
+	return path, nil
+}
+
+func copyTemplateFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("open %s: %w", src, err)
+	}
+	defer in.Close()
+
+	out, err := os.Create(dst)
+	if err != nil {
+		return fmt.Errorf("create %s: %w", dst, err)
+	}
+	defer out.Close()
+
+	if _, err := io.Copy(out, in); err != nil {
+		return fmt.Errorf("copy %s -> %s: %w", src, dst, err)
+	}
+	return out.Close()
+}
+
+// removeSQLiteTemplate deletes the template directory built by
+// buildSQLiteTemplate, if any. Called from TestMain after m.Run().
+func removeSQLiteTemplate() {
+	if sqliteTemplatePath != "" {
+		_ = os.RemoveAll(filepath.Dir(sqliteTemplatePath))
+	}
 }
 
 // testStorePostgres creates an isolated test database on the PostgreSQL server.

--- a/internal/store/storetest/storetest.go
+++ b/internal/store/storetest/storetest.go
@@ -36,6 +36,12 @@ import (
 )
 
 var (
+	// templateMu guards templatePath against Cleanup racing an in-flight
+	// build/copy: newFromTemplate holds it for read across the build +
+	// copy, Cleanup takes the write lock before removing the template
+	// dir. Near-theoretical in the normal TestMain lifecycle (m.Run joins
+	// all tests before Cleanup runs), but cheap to make deterministic.
+	templateMu   sync.RWMutex
 	templateOnce sync.Once
 	templatePath string
 	templateErr  error
@@ -69,16 +75,9 @@ func NewSQLiteUnmanaged(t *testing.T) *store.Store {
 func newFromTemplate(t *testing.T) *store.Store {
 	t.Helper()
 
-	templateOnce.Do(func() {
-		templatePath, templateErr = buildTemplate()
-	})
-	if templateErr != nil {
-		t.Fatalf("storetest: build template db: %v", templateErr)
-	}
-
 	dst := filepath.Join(t.TempDir(), "test.db")
-	if err := copyFile(templatePath, dst); err != nil {
-		t.Fatalf("storetest: copy template db: %v", err)
+	if err := lockedCopyFromTemplate(dst); err != nil {
+		t.Fatalf("storetest: %v", err)
 	}
 
 	s, err := store.New(dst)
@@ -88,10 +87,32 @@ func newFromTemplate(t *testing.T) *store.Store {
 	return s
 }
 
+// lockedCopyFromTemplate builds the template (once) and copies it to
+// dst, holding templateMu for read across both steps so Cleanup (which
+// takes the write lock) can't remove the template out from under an
+// in-flight build or copy.
+func lockedCopyFromTemplate(dst string) error {
+	templateMu.RLock()
+	defer templateMu.RUnlock()
+
+	templateOnce.Do(func() {
+		templatePath, templateErr = buildTemplate()
+	})
+	if templateErr != nil {
+		return fmt.Errorf("build template db: %w", templateErr)
+	}
+	if err := copyFile(templatePath, dst); err != nil {
+		return fmt.Errorf("copy template db: %w", err)
+	}
+	return nil
+}
+
 // Cleanup removes the process-wide template database, if one was built.
 // Call it from TestMain after m.Run() so a lazily-built template file
 // doesn't linger past the test binary's lifetime.
 func Cleanup() {
+	templateMu.Lock()
+	defer templateMu.Unlock()
 	if templatePath != "" {
 		_ = os.RemoveAll(filepath.Dir(templatePath))
 	}
@@ -101,6 +122,11 @@ func Cleanup() {
 // temp file and returns its path. The template is checkpointed and left
 // in DELETE journal mode (no -wal/-shm sidecars), so NewSQLite's copy is
 // a single-file operation with no sidecar bookkeeping to get wrong.
+//
+// The template dir is removed on any error path (MkdirTemp succeeded but
+// a later step failed) so a failed build doesn't leak a /tmp directory;
+// the deferred cleanup is disarmed only once buildTemplate returns
+// successfully.
 func buildTemplate() (string, error) {
 	atomic.AddInt32(&buildCount, 1)
 
@@ -108,6 +134,13 @@ func buildTemplate() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("mkdir template dir: %w", err)
 	}
+	ok := false
+	defer func() {
+		if !ok {
+			_ = os.RemoveAll(dir)
+		}
+	}()
+
 	path := filepath.Join(dir, "template.db")
 
 	s, err := store.New(path)
@@ -122,6 +155,7 @@ func buildTemplate() (string, error) {
 	if _, err := s.DB().Exec("PRAGMA journal_mode=DELETE"); err != nil {
 		return "", fmt.Errorf("set template journal_mode=DELETE: %w", err)
 	}
+	ok = true
 	return path, nil
 }
 

--- a/internal/store/storetest/storetest.go
+++ b/internal/store/storetest/storetest.go
@@ -1,0 +1,145 @@
+// Package storetest provides a fast, fully-migrated SQLite *store.Store
+// fixture for tests outside internal/store.
+//
+// It exists to fix BUG-1913 / IDEA-1914: every store-backed test used to
+// pay the full migration chain (69 SQLite migrations + 3 backfills, ~2.7s
+// under -race) via store.New, and internal/server's suite alone summed
+// that cost across ~600 tests to roughly 30 minutes wall clock.
+//
+// NewSQLite runs that migration chain at most ONCE per test binary (a
+// sync.Once-guarded template database), then hands every caller a plain
+// file copy of the template, opened via store.New like any other test
+// store. The copy's own migrate() call is a fast no-op — schema_migrations
+// is already populated (store.go:272) — rather than skipped outright, so
+// no production code changes were needed to support this.
+//
+// internal/store's OWN tests cannot import this package: storetest imports
+// store, so store's white-box tests (package store) importing storetest
+// would form an import cycle that Go rejects ("import cycle not allowed
+// in test" — verified empirically, not assumed). internal/store/store_test.go
+// therefore carries a deliberately duplicated, minimal copy of this same
+// template+copy logic (testStoreSQLite/buildSQLiteTemplate/copyTemplateFile).
+// KEEP THE TWO IN SYNC — this file and internal/store/store_test.go both
+// carry a cross-reference comment to that effect.
+package storetest
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/store"
+)
+
+var (
+	templateOnce sync.Once
+	templatePath string
+	templateErr  error
+	buildCount   int32 // atomic; test-only instrumentation, see storetest_test.go
+)
+
+// NewSQLite returns a *store.Store backed by a fresh SQLite file in
+// t.TempDir(), fully migrated. See the package doc for the template+copy
+// mechanism. Store.Close is registered via t.Cleanup.
+func NewSQLite(t *testing.T) *store.Store {
+	t.Helper()
+	s := newFromTemplate(t)
+	t.Cleanup(func() { _ = s.Close() })
+	return s
+}
+
+// NewSQLiteUnmanaged behaves like NewSQLite but does NOT register a
+// t.Cleanup to close the store — the caller owns Store.Close() and must
+// call it explicitly. Use this only when a test needs precise manual
+// control over close/cleanup ordering that NewSQLite's automatic
+// t.Cleanup would get in the way of (e.g. a goroutine-leak assertion
+// around repeated construct/Stop/Close cycles within a single test).
+func NewSQLiteUnmanaged(t *testing.T) *store.Store {
+	t.Helper()
+	return newFromTemplate(t)
+}
+
+// newFromTemplate builds (once) and copies the template DB, then opens
+// the copy via store.New. Shared by NewSQLite and NewSQLiteUnmanaged;
+// the only difference between the two is who owns Store.Close().
+func newFromTemplate(t *testing.T) *store.Store {
+	t.Helper()
+
+	templateOnce.Do(func() {
+		templatePath, templateErr = buildTemplate()
+	})
+	if templateErr != nil {
+		t.Fatalf("storetest: build template db: %v", templateErr)
+	}
+
+	dst := filepath.Join(t.TempDir(), "test.db")
+	if err := copyFile(templatePath, dst); err != nil {
+		t.Fatalf("storetest: copy template db: %v", err)
+	}
+
+	s, err := store.New(dst)
+	if err != nil {
+		t.Fatalf("storetest: open copied db: %v", err)
+	}
+	return s
+}
+
+// Cleanup removes the process-wide template database, if one was built.
+// Call it from TestMain after m.Run() so a lazily-built template file
+// doesn't linger past the test binary's lifetime.
+func Cleanup() {
+	if templatePath != "" {
+		_ = os.RemoveAll(filepath.Dir(templatePath))
+	}
+}
+
+// buildTemplate runs the full migration chain once into a process-wide
+// temp file and returns its path. The template is checkpointed and left
+// in DELETE journal mode (no -wal/-shm sidecars), so NewSQLite's copy is
+// a single-file operation with no sidecar bookkeeping to get wrong.
+func buildTemplate() (string, error) {
+	atomic.AddInt32(&buildCount, 1)
+
+	dir, err := os.MkdirTemp("", "pad-storetest-template-*")
+	if err != nil {
+		return "", fmt.Errorf("mkdir template dir: %w", err)
+	}
+	path := filepath.Join(dir, "template.db")
+
+	s, err := store.New(path)
+	if err != nil {
+		return "", fmt.Errorf("build template store: %w", err)
+	}
+	defer s.Close()
+
+	if _, err := s.DB().Exec("PRAGMA wal_checkpoint(TRUNCATE)"); err != nil {
+		return "", fmt.Errorf("checkpoint template: %w", err)
+	}
+	if _, err := s.DB().Exec("PRAGMA journal_mode=DELETE"); err != nil {
+		return "", fmt.Errorf("set template journal_mode=DELETE: %w", err)
+	}
+	return path, nil
+}
+
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("open %s: %w", src, err)
+	}
+	defer in.Close()
+
+	out, err := os.Create(dst)
+	if err != nil {
+		return fmt.Errorf("create %s: %w", dst, err)
+	}
+	defer out.Close()
+
+	if _, err := io.Copy(out, in); err != nil {
+		return fmt.Errorf("copy %s -> %s: %w", src, dst, err)
+	}
+	return out.Close()
+}

--- a/internal/store/storetest/storetest_test.go
+++ b/internal/store/storetest/storetest_test.go
@@ -1,0 +1,95 @@
+package storetest
+
+import (
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/store"
+	"golang.org/x/crypto/bcrypt"
+)
+
+func TestMain(m *testing.M) {
+	// See internal/server/main_test.go for the full BUG-1371 rationale —
+	// this package's own probe test creates a user, and there's no
+	// reason to pay the production bcrypt cost for it.
+	store.SetBcryptCostForTesting(bcrypt.MinCost)
+	code := m.Run()
+	Cleanup()
+	os.Exit(code)
+}
+
+// TestNewSQLite_TemplateBuildsOnce asserts the migration chain (store.New
+// on the template path) runs at most once per test binary regardless of
+// how many times NewSQLite is called — the whole point of BUG-1913's
+// fix. buildCount is monotonic and capped at 1 by templateOnce, so
+// checking it's exactly 1 after at least one NewSQLite call is valid
+// irrespective of what ran before this test in the binary.
+func TestNewSQLite_TemplateBuildsOnce(t *testing.T) {
+	_ = NewSQLite(t)
+	_ = NewSQLite(t)
+	_ = NewSQLite(t)
+
+	if got := atomic.LoadInt32(&buildCount); got != 1 {
+		t.Fatalf("buildTemplate ran %d times total, want exactly 1 (sync.Once)", got)
+	}
+}
+
+// TestNewSQLite_NoWALSidecars asserts the template directory contains
+// only the template file itself — the checkpoint + journal_mode=DELETE
+// sequence in buildTemplate must leave no -wal/-shm sidecars for
+// NewSQLite's plain file copy to lose track of.
+func TestNewSQLite_NoWALSidecars(t *testing.T) {
+	_ = NewSQLite(t)
+
+	if templatePath == "" {
+		t.Fatal("templatePath unset after NewSQLite")
+	}
+	entries, err := os.ReadDir(filepath.Dir(templatePath))
+	if err != nil {
+		t.Fatalf("read template dir: %v", err)
+	}
+	if len(entries) != 1 || entries[0].Name() != filepath.Base(templatePath) {
+		names := make([]string, len(entries))
+		for i, e := range entries {
+			names[i] = e.Name()
+		}
+		t.Fatalf("template dir contains %v, want exactly [%s]", names, filepath.Base(templatePath))
+	}
+}
+
+// TestNewSQLite_CopiesAreIsolatedAndFunctional proves each NewSQLite call
+// returns its own writable, working copy: writes to one copy (a real
+// end-to-end op, not just a file-existence check) must not be visible
+// from another.
+func TestNewSQLite_CopiesAreIsolatedAndFunctional(t *testing.T) {
+	sA := NewSQLite(t)
+
+	u, err := sA.CreateUser(models.UserCreate{
+		Email:    "storetest-probe@example.com",
+		Username: "storetest-probe",
+		Name:     "Storetest Probe",
+		Password: "correcthorsebattery",
+		Role:     "admin",
+	})
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	ws, err := sA.CreateWorkspace(models.WorkspaceCreate{Name: "Probe", Slug: "storetest-probe", OwnerID: u.ID})
+	if err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	got, err := sA.GetWorkspaceBySlug(ws.Slug)
+	if err != nil || got == nil {
+		t.Fatalf("workspace not readable back from its own copy: got=%v err=%v", got, err)
+	}
+
+	sB := NewSQLite(t)
+	if leaked, err := sB.GetWorkspaceBySlug(ws.Slug); err != nil {
+		t.Fatalf("query store B: %v", err)
+	} else if leaked != nil {
+		t.Fatal("workspace created in store A is visible in store B's copy; copies are not isolated")
+	}
+}


### PR DESCRIPTION
## Summary

Every store-backed test paid ~2.7s under `-race` to replay all 69 SQLite migrations + 3 backfills on a fresh DB (`store.New` per test). `internal/server` alone summed that to ~30 minutes — the direct cause of the BUG-1913 CI timeout flake (mitigated by #787's 45m bump; this PR removes most of the underlying cost).

**Measured: `go test -race ./internal/server/` drops from 1819.4s to 184.8s (~9.9×).**

## How

New `internal/store/storetest` package: a template DB is built once per test binary (`sync.Once`), checkpointed and switched to `journal_mode=DELETE` so it's a single file (no -wal/-shm sidecar bookkeeping), then file-copied (~3.5ms) into each test's `t.TempDir` and opened via plain `store.New` — the copy's `migrate()` is a natural no-op against the populated `schema_migrations` table, so **zero production code changes**.

- `internal/server`'s `testServer` (408 call sites converge there) uses `storetest.NewSQLite`; `t.Cleanup` LIFO ordering preserves the BUG-842 drain-then-close contract (documented inline).
- `internal/store`'s own `testStore` can't import storetest (Go rejects the import cycle in white-box tests), so it carries a deliberately duplicated minimal mirror — loud KEEP IN SYNC cross-references at both sites.
- `NewSQLiteUnmanaged` (no auto-cleanup) serves `TestServer_Stop_DrainsRateLimiterCleanup`, which needs manual Stop/Close ordering and was the suite's slowest test (13.4s → sub-second construction).
- Postgres test paths untouched; `make test-pg` verified green.

## Review

3 codex rounds, rotated framing: R1 plain CLEAN → R2 lifecycle lens found 2 real warnings (error-path template-dir leak in both mirrors; `Cleanup()` unsynchronized with in-flight copies) → fixed in 248cdb6 (disarm-on-success defer; RWMutex across build+copy vs write-locked cleanup) → R3 verified fixes deadlock-free + mirrors in sync, CLEAN. Converged. Final `-race` run over both packages: PASS, no races, no measurable overhead from the fixes.

## Left on the slow path (future wiring candidates)

`newPadServer` (internal/mcp/dispatch_http_test.go, 9 sites), `testStoreOAuth` (internal/oauth/server_test.go, 17 sites), `newMetricsTestServer` (internal/server/metrics_auth_test.go, 3 sites).

A follow-up can consider lowering #787's 45m CI timeout once this soaks.

## Test plan

- [x] `go test -race ./internal/server/` 184.8s PASS (was 1819.4s)
- [x] `go test -race ./internal/store/...` PASS, no data races
- [x] `go test ./...` (SQLite) all green incl. 3 new fixture tests (build-once, no sidecars, isolated + functional copies)
- [x] `make lint` 0 issues
- [x] `make test-pg` full suite green (fixture is SQLite-only; no Postgres regression)

Refs: IDEA-1914, BUG-1913

https://claude.ai/code/session_01CL1pBjNpPUX6SWkuAuYXHS