### PR TITLE
perf(test): wire mcp/oauth/metrics helpers onto the storetest fixture (TASK-1915)

### DIFF
--- a/internal/mcp/dispatch_http_test.go
+++ b/internal/mcp/dispatch_http_test.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -16,6 +15,7 @@ import (
 	"github.com/PerpetualSoftware/pad/internal/models"
 	"github.com/PerpetualSoftware/pad/internal/server"
 	"github.com/PerpetualSoftware/pad/internal/store"
+	"github.com/PerpetualSoftware/pad/internal/store/storetest"
 )
 
 // fixedUserResolver is a tiny helper for the unit tests that need a
@@ -934,25 +934,26 @@ func TestHTTPHandlerDispatcher_Integration(t *testing.T) {
 }
 
 // newPadServer stands up the same *server.Server that production
-// uses, wired to a temp SQLite store. Mirrors testServer in
-// internal/server/server_test.go but accessible from this package.
+// uses, wired to a fast fixture SQLite store (storetest.NewSQLite,
+// IDEA-1914). Mirrors testServer in internal/server/server_test.go
+// but accessible from this package.
 //
-// Cleanup drains the server's background goroutines before closing
-// the store to avoid the WAL/SHM races BUG-842 fixed (see comment in
-// internal/server/server_test.go).
+// storetest.NewSQLite already registers its own t.Cleanup(store.Close);
+// because t.Cleanup runs LIFO, registering the Stop()+sleep cleanup
+// here AFTER that call still runs it BEFORE the store closes, so the
+// server's background goroutines drain — and the belt-and-braces
+// sleep still elapses — before storetest closes the store and
+// t.TempDir's RemoveAll runs, avoiding the WAL/SHM races BUG-842 fixed
+// (see comment in internal/server/server_test.go).
 func newPadServer(t *testing.T) (*server.Server, *store.Store) {
 	t.Helper()
-	dir := t.TempDir()
-	st, err := store.New(filepath.Join(dir, "test.db"))
-	if err != nil {
-		t.Fatalf("store.New: %v", err)
-	}
+	st := storetest.NewSQLite(t)
 	srv := server.New(st)
 	t.Cleanup(func() {
 		srv.Stop()
-		st.Close()
 		// Belt-and-braces: brief sleep gives any straggler timers a
-		// chance to wind down before t.TempDir's RemoveAll runs.
+		// chance to wind down before storetest closes the store and
+		// t.TempDir's RemoveAll runs.
 		time.Sleep(10 * time.Millisecond)
 	})
 	return srv, st

--- a/internal/mcp/main_test.go
+++ b/internal/mcp/main_test.go
@@ -1,0 +1,17 @@
+package mcp
+
+import (
+	"os"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/store/storetest"
+)
+
+// TestMain tears down storetest's process-wide template DB (IDEA-1914)
+// after the suite finishes, so the lazily-built template file doesn't
+// linger past this binary's lifetime.
+func TestMain(m *testing.M) {
+	code := m.Run()
+	storetest.Cleanup()
+	os.Exit(code)
+}

--- a/internal/oauth/main_test.go
+++ b/internal/oauth/main_test.go
@@ -1,0 +1,17 @@
+package oauth
+
+import (
+	"os"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/store/storetest"
+)
+
+// TestMain tears down storetest's process-wide template DB (IDEA-1914)
+// after the suite finishes, so the lazily-built template file doesn't
+// linger past this binary's lifetime.
+func TestMain(m *testing.M) {
+	code := m.Run()
+	storetest.Cleanup()
+	os.Exit(code)
+}

--- a/internal/oauth/server_test.go
+++ b/internal/oauth/server_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"net/url"
-	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -13,6 +12,7 @@ import (
 
 	"github.com/PerpetualSoftware/pad/internal/models"
 	"github.com/PerpetualSoftware/pad/internal/store"
+	"github.com/PerpetualSoftware/pad/internal/store/storetest"
 )
 
 // Tests for the OAuth server constructor + audience strategy +
@@ -32,20 +32,14 @@ import (
 // constructor + adapter contracts so sub-PR C can rely on them
 // without re-asserting fosite's behaviour on every handler test.
 
-// testStoreOAuth produces a *store.Store with the migrations applied
-// — same pattern internal/store/oauth_test.go uses, but importing
-// /internal/store would create a test-only cycle. Inline a tiny
-// helper here that opens a fresh SQLite in t.TempDir.
+// testStoreOAuth produces a *store.Store with the migrations applied,
+// via storetest.NewSQLite (IDEA-1914) — the migration chain runs at
+// most once per test binary instead of once per call. See its package
+// doc for why /internal/store's own white-box tests can't share this
+// helper (import cycle); this package has no such constraint.
 func testStoreOAuth(t *testing.T) *store.Store {
 	t.Helper()
-	dir := t.TempDir()
-	dbPath := filepath.Join(dir, "test.db")
-	s, err := store.New(dbPath)
-	if err != nil {
-		t.Fatalf("store.New: %v", err)
-	}
-	t.Cleanup(func() { _ = s.Close() })
-	return s
+	return storetest.NewSQLite(t)
 }
 
 // =====================================================================

--- a/internal/server/metrics_auth_test.go
+++ b/internal/server/metrics_auth_test.go
@@ -3,30 +3,27 @@ package server
 import (
 	"net/http"
 	"net/http/httptest"
-	"path/filepath"
 	"testing"
 
 	"github.com/PerpetualSoftware/pad/internal/metrics"
-	"github.com/PerpetualSoftware/pad/internal/store"
+	"github.com/PerpetualSoftware/pad/internal/store/storetest"
 )
 
 // newMetricsTestServer builds a Server with metrics enabled and the given
-// static token. Uses a unique SQLite DB per test so tests never share state.
+// static token, via storetest.NewSQLite (IDEA-1914) — see testServer in
+// server_test.go for why this is fast (once-per-binary migration chain).
 func newMetricsTestServer(t *testing.T, token string) *Server {
 	t.Helper()
-	dir := t.TempDir()
-	s, err := store.New(filepath.Join(dir, "test.db"))
-	if err != nil {
-		t.Fatalf("store.New: %v", err)
-	}
+	s := storetest.NewSQLite(t)
 	srv := New(s)
 	srv.SetMetrics(metrics.New())
 	srv.SetMetricsToken(token)
-	// Drain background goroutines BEFORE closing the store — see
-	// testServer in server_test.go for the BUG-842 race details.
+	// storetest.NewSQLite already registers t.Cleanup(store.Close); since
+	// t.Cleanup runs LIFO, registering Stop() here afterward still drains
+	// background goroutines BEFORE the store closes — see testServer in
+	// server_test.go for the BUG-842 race details.
 	t.Cleanup(func() {
 		srv.Stop()
-		s.Close()
 	})
 	return srv
 }


### PR DESCRIPTION
## Summary

Follow-up to #788 (IDEA-1914): three test helpers were left on the slow path, each still replaying the full migration chain (~2.7s under `-race`) per store construction. This wires all three onto `storetest.NewSQLite` and adds the two missing `TestMain`s so those binaries release the process-wide template DB, matching `internal/server`'s existing pattern.

- `newPadServer` — internal/mcp/dispatch_http_test.go (9 call sites)
- `testStoreOAuth` — internal/oauth/server_test.go (17 call sites)
- `newMetricsTestServer` — internal/server/metrics_auth_test.go (3 call sites)

**Measured (`-race`, same machine, before → after):** internal/mcp 56.5s → 36.7s; internal/oauth 46.6s → 5.4s; internal/server `-run TestMetricsAuth` 9.3s → 4.1s.

Test-only diff; zero production code changes.

## Notes

- Cleanup ordering: `storetest.NewSQLite` registers its own `t.Cleanup(store.Close)`; the helpers register `Stop()` afterward, so LIFO preserves the BUG-842 drain-then-close contract (comments updated at both wired-server sites). The mcp helper's 10ms belt-and-braces sleep now elapses after `Stop()` and before storetest's `Close` — `t.TempDir`'s `RemoveAll` still runs last overall; deliberate reordering, comment updated.
- New `internal/mcp/main_test.go` and `internal/oauth/main_test.go` are minimal (`m.Run()` → `storetest.Cleanup()` → `os.Exit`), no server-specific setup.
- Deliberately NOT here: lowering #787's 45m race-step CI timeout — wants a couple of days of post-#788 soak evidence first (one green main run at the new speed as of writing).
- `internal/store`'s white-box `testStore` mirror untouched (import-cycle constraint, see KEEP IN SYNC comments).

## Review

2 codex rounds, rotated framing: R1 plain-diff CLEAN → R2 lifecycle lens (t.Cleanup LIFO, TestMain/Cleanup interaction, t.Parallel, goroutine teardown) CLEAN — R2 independently traced all 29 call sites, verified the LIFO drain-then-close claims against server.Stop's WaitGroup logic, and checked storetest.Cleanup's template locking. Converged; R3 skipped (contract-blast-radius framing n/a — no contract touched, test-only diff).

## Test plan

- [x] `go test -race ./internal/mcp/... ./internal/oauth/...` PASS with timings above
- [x] `go test ./...` (SQLite) all green
- [x] `make test-pg` full suite green (helpers were and remain SQLite-only; no Postgres divergence)
- [x] `make lint` 0 issues

Refs: TASK-1915, IDEA-1914

https://claude.ai/code/session_01CL1pBjNpPUX6SWkuAuYXHS
