### PR TITLE
fix(web): harden WebMCP scalar param readers against malformed types (TASK-1895)

### DIFF
--- a/web/src/lib/webmcp/dispatch.test.ts
+++ b/web/src/lib/webmcp/dispatch.test.ts
@@ -764,6 +764,28 @@ describe('dispatch — result envelope + errors', () => {
 		expect(parse(result).text).toMatch(/action/);
 	});
 
+	// Regression for the round-1 codex finding: the `action` read happens
+	// via str(), which now throws on a malformed type. It must stay inside
+	// dispatch()'s try/catch so a bad `action` resolves to an error envelope
+	// — the same contract as every other malformed-scalar case — rather than
+	// rejecting the returned promise (register.ts assumes dispatch() always
+	// resolves). `.resolves` makes a promise rejection fail the assertion
+	// instead of throwing out of the test, so this distinguishes the two.
+	it('resolves with an error envelope (not a rejected promise) on a numeric `action`', async () => {
+		const api = mockApi();
+		const promise = run(api, 'pad_item', { action: 1 });
+		await expect(promise).resolves.toEqual(expect.objectContaining({ isError: true }));
+		expect(parse(await promise).text).toMatch(/action/i);
+		expect(api.items.list).not.toHaveBeenCalled();
+	});
+
+	it('resolves with an error envelope (not a rejected promise) on an object `action`', async () => {
+		const api = mockApi();
+		const promise = run(api, 'pad_item', { action: {} });
+		await expect(promise).resolves.toEqual(expect.objectContaining({ isError: true }));
+		expect(parse(await promise).text).toMatch(/action/i);
+	});
+
 	it('errors for a catalog action with no browser mapping (pad_project.standup)', async () => {
 		const api = mockApi();
 		const result = await run(api, 'pad_project', { action: 'standup' });

--- a/web/src/lib/webmcp/dispatch.test.ts
+++ b/web/src/lib/webmcp/dispatch.test.ts
@@ -392,6 +392,116 @@ describe('dispatch — pad_item writes', () => {
 	});
 });
 
+// ── malformed scalar params (str/num/bool) — no silent drop/coercion ────────
+//
+// Mirrors the strArray hardening above: a present-but-wrong-typed scalar
+// throws a precise tool error instead of silently vanishing from the write.
+// Absent (undefined/null) and empty-string params stay non-erroring — that
+// looseness is existing behavior, not new, and is covered by the regression
+// cases at the end of this block.
+
+describe('dispatch — malformed scalar params', () => {
+	it('create errors (no client call) on a numeric `title` (string expected)', async () => {
+		const api = mockApi();
+		const result = await run(api, 'pad_item', {
+			action: 'create',
+			collection: 'tasks',
+			title: 5,
+		});
+		expect(parse(result).isError).toBe(true);
+		expect(parse(result).text).toMatch(/title/i);
+		expect(api.items.create).not.toHaveBeenCalled();
+	});
+
+	it('search errors on a boolean `limit` (number expected)', async () => {
+		const api = mockApi();
+		const result = await run(api, 'pad_search', { action: 'query', query: 'x', limit: true });
+		expect(parse(result).isError).toBe(true);
+		expect(parse(result).text).toMatch(/limit/i);
+		expect(api.search).not.toHaveBeenCalled();
+	});
+
+	it('list errors on an object `limit` (number expected)', async () => {
+		const api = mockApi();
+		const result = await run(api, 'pad_item', { action: 'list', limit: {} });
+		expect(parse(result).isError).toBe(true);
+		expect(parse(result).text).toMatch(/limit/i);
+		expect(api.items.list).not.toHaveBeenCalled();
+	});
+
+	it('update errors (no partial write) on a numeric `force` (boolean expected)', async () => {
+		const api = mockApi();
+		const result = await run(api, 'pad_item', { action: 'update', ref: 'TASK-1', force: 1 });
+		expect(parse(result).isError).toBe(true);
+		expect(parse(result).text).toMatch(/force/i);
+		expect(api.items.update).not.toHaveBeenCalled();
+	});
+
+	it('bulk-update errors on an array `force` (boolean expected)', async () => {
+		const api = mockApi();
+		const result = await run(api, 'pad_item', {
+			action: 'bulk-update',
+			refs: ['TASK-1'],
+			status: 'done',
+			force: [],
+		});
+		expect(parse(result).isError).toBe(true);
+		expect(api.items.bulk).not.toHaveBeenCalled();
+	});
+
+	it('collection update errors on a non-numeric `sort_order` string — malformed, not absent', async () => {
+		const api = mockApi();
+		const result = await run(api, 'pad_collection', {
+			action: 'update',
+			slug: 'risks',
+			sort_order: 'abc',
+		});
+		expect(parse(result).isError).toBe(true);
+		expect(parse(result).text).toMatch(/sort_order/i);
+		expect(api.collections.update).not.toHaveBeenCalled();
+	});
+
+	it('create errors on an array `title` (string expected)', async () => {
+		const api = mockApi();
+		const result = await run(api, 'pad_item', {
+			action: 'create',
+			collection: 'tasks',
+			title: ['not', 'a', 'string'],
+		});
+		expect(parse(result).isError).toBe(true);
+		expect(api.items.create).not.toHaveBeenCalled();
+	});
+
+	// ── regression: absent-vs-malformed line stays where it was ──────────────
+
+	it('update still accepts a null `content` as absent (no error, fields untouched)', async () => {
+		const api = mockApi();
+		await run(api, 'pad_item', { action: 'update', ref: 'TASK-1', content: null });
+		const data = (api.items.update.mock.calls[0] as unknown as [string, string, any])[2];
+		expect(data.content).toBeUndefined();
+	});
+
+	it('update still accepts a null `force` as absent (no error, force untouched)', async () => {
+		const api = mockApi();
+		await run(api, 'pad_item', { action: 'update', ref: 'TASK-1', force: null });
+		const data = (api.items.update.mock.calls[0] as unknown as [string, string, any])[2];
+		expect(data.force).toBeUndefined();
+	});
+
+	it('update still works with `force` omitted entirely (no error)', async () => {
+		const api = mockApi();
+		const result = await run(api, 'pad_item', { action: 'update', ref: 'TASK-1', title: 'X' });
+		expect(parse(result).isError).toBe(false);
+		expect(api.items.update).toHaveBeenCalledTimes(1);
+	});
+
+	it('search still accepts a numeric-string `limit` (transport leniency preserved)', async () => {
+		const api = mockApi();
+		await run(api, 'pad_search', { action: 'query', query: 'x', limit: '42' });
+		expect(api.search).toHaveBeenCalledWith('x', expect.objectContaining({ limit: 42 }));
+	});
+});
+
 // ── pad_item link / unlink ───────────────────────────────────────────────────
 
 describe('dispatch — pad_item link/unlink', () => {

--- a/web/src/lib/webmcp/dispatch.ts
+++ b/web/src/lib/webmcp/dispatch.ts
@@ -39,27 +39,62 @@ type Handler = (
 
 // ── helpers ────────────────────────────────────────────────────────────────
 
+/**
+ * Read a string param. Absent (undefined/null) returns undefined — not an
+ * error, matching strArray's absent-vs-malformed line. A present value of any
+ * other type (number, boolean, object, array) throws a precise tool error
+ * rather than silently dropping it. An empty string is still treated as
+ * absent (existing looseness, preserved: an agent sending `title: ""` behaves
+ * like the arg wasn't supplied at all).
+ */
 function str(args: Record<string, unknown>, key: string): string | undefined {
 	const v = args[key];
-	if (typeof v === 'string' && v.length > 0) return v;
-	return undefined;
+	if (v === undefined || v === null) return undefined;
+	if (typeof v !== 'string') {
+		throw new Error(`'${key}' must be a string (got ${JSON.stringify(v)})`);
+	}
+	return v.length > 0 ? v : undefined;
 }
 
+/**
+ * Read a number param. Absent (undefined/null) returns undefined. Accepts a
+ * numeric string (the MCP transport may deliver numbers as strings) — an
+ * empty/blank string is still treated as absent. Any other present value
+ * (boolean, object, array, a non-numeric string like "abc", or a bare NaN —
+ * reachable here since WebMCP args arrive via structured clone rather than
+ * JSON.parse, which can't produce NaN) throws rather than silently dropping.
+ */
 function num(args: Record<string, unknown>, key: string): number | undefined {
 	const v = args[key];
-	if (typeof v === 'number') return v;
-	if (typeof v === 'string' && v.trim() !== '' && !Number.isNaN(Number(v))) {
-		return Number(v);
+	if (v === undefined || v === null) return undefined;
+	if (typeof v === 'number') {
+		if (Number.isNaN(v)) throw new Error(`'${key}' must be a number (got NaN)`);
+		return v;
 	}
-	return undefined;
+	if (typeof v === 'string') {
+		if (v.trim() === '') return undefined;
+		const n = Number(v);
+		if (Number.isNaN(n)) {
+			throw new Error(`'${key}' must be a number (got ${JSON.stringify(v)})`);
+		}
+		return n;
+	}
+	throw new Error(`'${key}' must be a number (got ${JSON.stringify(v)})`);
 }
 
+/**
+ * Read a boolean param. Absent (undefined/null) returns undefined. Accepts
+ * the literal strings "true"/"false" (transport leniency). Any other present
+ * value (number, object, array, any other string) throws rather than
+ * silently dropping.
+ */
 function bool(args: Record<string, unknown>, key: string): boolean | undefined {
 	const v = args[key];
+	if (v === undefined || v === null) return undefined;
 	if (typeof v === 'boolean') return v;
 	if (v === 'true') return true;
 	if (v === 'false') return false;
-	return undefined;
+	throw new Error(`'${key}' must be a boolean (got ${JSON.stringify(v)})`);
 }
 
 function requireRef(args: Record<string, unknown>): string {

--- a/web/src/lib/webmcp/dispatch.ts
+++ b/web/src/lib/webmcp/dispatch.ts
@@ -617,27 +617,37 @@ export async function dispatch(
 		return errResult('no active workspace');
 	}
 
-	const action = str(args, 'action');
-	if (!action) {
-		return errResult(`missing required arg 'action' for ${toolName}`);
-	}
-
-	const key = `${toolName}:${action}`;
-	const handler = HANDLERS[key];
-	if (!handler) {
-		// A catalog action with no browser mapping (e.g. pad_project.standup,
-		// pending TASK-1894). Honest error, never a fake result or silent
-		// no-op.
-		return errResult(
-			`${toolName}.${action} is not available in the browser WebMCP surface`,
-		);
-	}
-
+	// The action read (str() can now throw on a malformed `action`, e.g.
+	// `action: 1`) is inside this try/catch — along with everything else that
+	// touches `args` — so a malformed scalar anywhere in the dispatch path
+	// returns an error envelope rather than rejecting the promise. Callers
+	// (register.ts) expect `dispatch()` to always resolve to a DispatchResult.
+	let action: string | undefined;
 	try {
+		action = str(args, 'action');
+		if (!action) {
+			return errResult(`missing required arg 'action' for ${toolName}`);
+		}
+
+		const key = `${toolName}:${action}`;
+		const handler = HANDLERS[key];
+		if (!handler) {
+			// A catalog action with no browser mapping (e.g. pad_project.standup,
+			// pending TASK-1894). Honest error, never a fake result or silent
+			// no-op.
+			return errResult(
+				`${toolName}.${action} is not available in the browser WebMCP surface`,
+			);
+		}
+
 		const result = await handler(api, wsSlug, args);
 		return ok(result);
 	} catch (e) {
 		const message = e instanceof Error ? e.message : String(e);
-		return errResult(`${toolName}.${action} failed: ${message}`);
+		return errResult(
+			action
+				? `${toolName}.${action} failed: ${message}`
+				: `${toolName} dispatch failed: ${message}`,
+		);
 	}
 }


### PR DESCRIPTION
## Summary

Closes the scalar-validation residual from TASK-1893's review loop (WebMCP Phase 3d): the `str`/`num`/`bool` param readers in `web/src/lib/webmcp/dispatch.ts` silently returned `undefined` on a type mismatch, so a malformed agent-supplied param (numeric title, boolean limit, `sort_order: "abc"`) was dropped or partially applied instead of rejected — the same class `strArray` was already hardened against.

All three readers now throw a precise `'<key>' must be a <type> (got <value>)` error on a present-but-malformed value, surfaced through `dispatch()`'s try/catch as a tool error envelope.

**Deliberately preserved looseness** (behavior-pinning tests included):
- Absent (`undefined`/`null`) still returns `undefined` — matches `strArray`'s absent-vs-malformed line; `content: null` etc. keep their semantics.
- Empty/blank strings still read as absent for `str`/`num` (existing behavior).
- Transport leniency kept: `num` accepts numeric strings (`"42"`), `bool` accepts `"true"`/`"false"`.
- New NaN guard in `num`: WebMCP args arrive via structured clone (not `JSON.parse`), so a bare `NaN` is reachable at runtime — it now throws instead of passing through.

This is client-side defensive robustness; the server remains the real validation boundary (per the item).

## Review

2 codex rounds, rotated framing. R1 (plain) caught a real regression in the first commit: `str(args, 'action')` sat outside `dispatch()`'s try/catch, so a malformed `action` (e.g. `action: 1`) rejected the promise instead of returning the `DispatchResult` error envelope callers expect. Fixed in d61b311 by widening the try to cover the action read; tests assert envelope-vs-rejection via `.resolves`. Implementer re-scan of all 43 reader call sites confirmed it was the only unguarded one. R2 (throw-path blast-radius lens) CLEAN — traced all call sites under the widened try, confirmed register.ts is the only external caller, confirmed no test matches exact scalar error text, and cross-checked the Go-side catalog/route definitions for cross-transport coupling to the new throw behavior. Converged.

## Test plan

- [x] `npm test` — 102/102 (11 malformed/regression cases for the readers + 2 action-envelope cases added)
- [x] `npm run check` — 0 errors (8 pre-existing unrelated warnings)
- [x] `npm run build` — green
- [x] Go untouched (frontend-only diff)

Refs: TASK-1895, TASK-1893

https://claude.ai/code/session_01CL1pBjNpPUX6SWkuAuYXHS
