### PR TITLE
feat(server): REST endpoints for project next/standup/changelog + WebMCP wiring (TASK-1894)

### DIFF
--- a/internal/mcp/dispatch_http_slice4.go
+++ b/internal/mcp/dispatch_http_slice4.go
@@ -26,6 +26,13 @@ import (
 // transport's response indistinguishable from project dashboard,
 // which the CLI no longer does. Catalog actions must produce the
 // same shape on both transports.
+//
+// KEEP IN SYNC — TASK-1894 added a THIRD reproduction of this same
+// contract: internal/server/handlers_project_intel.go's
+// handleGetProjectNext (browser REST + WebMCP surface). A follow-up
+// task will consolidate this dispatcher onto that REST endpoint; until
+// then, changes here need a matching change (or a noted divergence)
+// there.
 func (d *HTTPHandlerDispatcher) dispatchProjectNext(
 	ctx context.Context,
 	input map[string]any,
@@ -72,6 +79,13 @@ func (d *HTTPHandlerDispatcher) dispatchProjectNext(
 // schemas (registry.go strips them). Without the default, a missing
 // `days` input would zero-out the cutoff and report nothing as
 // "completed", surprising agents that omit the flag.
+//
+// KEEP IN SYNC — TASK-1894 added a THIRD reproduction of this same
+// contract: internal/server/handlers_project_intel.go's
+// handleGetProjectStandup (browser REST + WebMCP surface). A follow-up
+// task will consolidate this dispatcher onto that REST endpoint; until
+// then, changes here need a matching change (or a noted divergence)
+// there.
 func (d *HTTPHandlerDispatcher) dispatchProjectStandup(
 	ctx context.Context,
 	input map[string]any,
@@ -204,6 +218,13 @@ func (d *HTTPHandlerDispatcher) dispatchProjectStandup(
 // CLI defaults: --days 7, --since "" (overrides days), --parent "".
 // The dispatcher applies the same defaults in-process so MCP agents
 // don't need to know the cmdhelp-stripped defaults.
+//
+// KEEP IN SYNC — TASK-1894 added a THIRD reproduction of this same
+// contract: internal/server/handlers_project_intel.go's
+// handleGetProjectChangelog (browser REST + WebMCP surface). A
+// follow-up task will consolidate this dispatcher onto that REST
+// endpoint; until then, changes here need a matching change (or a
+// noted divergence) there.
 func (d *HTTPHandlerDispatcher) dispatchProjectChangelog(
 	ctx context.Context,
 	input map[string]any,

--- a/internal/server/handlers_project_intel.go
+++ b/internal/server/handlers_project_intel.go
@@ -25,6 +25,20 @@ import (
 // endpoints (route-table + delete the custom dispatchers) — until then,
 // changes here need a matching change (or an explicit noted divergence) in
 // both siblings above.
+//
+// Known asymmetry (TASK-1894 codex round 1): handleGetProjectStandup scopes
+// its own completed/in_progress ListItems calls through the bearer-aware
+// projectIntelVisibility (see below), but its dashboard-derived sections
+// (blockers, suggested_next) come from buildDashboardResponse, which is
+// NOT bearer-aware — same gap as handleGetProjectNext, which deliberately
+// stays on buildDashboardResponse's ungated visibility so it keeps exact
+// parity with dashboard.suggested_next (gating next but not dashboard would
+// break that parity for bearer admins and diverge next from both siblings).
+// Net effect: a bearer-authed platform admin who is only a restricted member
+// of the workspace gets correctly-scoped completed/in_progress from standup,
+// but ungated blockers/suggested_next — until the visibleCollectionIDs
+// bearer-gate bug filed from TASK-1894 review is fixed for
+// buildDashboardResponse itself, at which point this asymmetry resolves.
 
 // parseDaysParam reads a "days" query param with a fallback default. Mirrors
 // the CLI's `n > 0` gate (standupCmd/changelogCmd flag defaults) and the MCP
@@ -60,12 +74,46 @@ func itemMatchesParentFilter(item models.Item, parent string) bool {
 	return false
 }
 
-// projectIntelVisibility computes the same (collectionIDs, itemIDs)
-// visibility-scoping pair used by handleListItems / handleGetDashboard /
-// handleGetWorkspaceGraph, for the item-list calls the standup/changelog
-// handlers make directly (outside of buildDashboardResponse).
+// bearerAwareVisibleCollectionIDs mirrors visibleCollectionIDs (server.go)
+// but closes the gap reportVisibleCollections (handlers_reports.go) already
+// closes for the report endpoint (the BUG-1616/1617 pattern — see its doc
+// comment and handlers_admin_bearer_gate_test.go): a platform admin
+// authenticated via a bearer token (PAT/CLI/OAuth) who is only a restricted
+// member of THIS workspace must be scoped to their real membership, not
+// granted the unrestricted admin view a cookie-session admin gets.
+// visibleCollectionIDs itself — and everything still built directly on it
+// (buildDashboardResponse, handleListItems, handleGetWorkspaceGraph) — does
+// NOT have this gate; that's the visibleCollectionIDs bearer-gate bug filed
+// from TASK-1894 review, tracked separately from this fix.
+func (s *Server) bearerAwareVisibleCollectionIDs(r *http.Request, workspaceID string) ([]string, error) {
+	user := currentUser(r)
+	if user == nil || (user.Role == "admin" && !isBearerAuth(r)) {
+		return nil, nil // unrestricted, same as visibleCollectionIDs' nil-user/admin branch
+	}
+	return s.store.VisibleCollectionIDs(workspaceID, user.ID)
+}
+
+// projectIntelVisibility computes the (collectionIDs, itemIDs)
+// visibility-scoping pair for the item-list calls the standup/changelog
+// handlers make directly (outside of buildDashboardResponse), using
+// bearerAwareVisibleCollectionIDs rather than visibleCollectionIDs.
+//
+// This does NOT delegate to reportVisibleCollections despite the shared
+// admin-bypass gate: reportVisibleCollections returns (scopeToVisible bool,
+// ids []string) and deliberately drops item-level grant granularity, because
+// aggregate report counts have no item-level filtering (a collection is
+// either fully in-scope or fully excluded — see its doc comment). standup and
+// changelog list actual items, so they need the same item-level grant
+// filtering handleListItems applies (ItemListParams.ItemIDs) — hence the
+// (collIDs, itemIDs) shape and the guestResourceFilter call below, matching
+// handleListItems' pattern exactly except for the visibility call itself.
+//
+// visibleIDs == nil covers BOTH "unrestricted" (nil/cookie-admin user) and
+// "all-access member" (store.VisibleCollectionIDs returns nil) — both mean
+// "no collection filtering", identically to visibleCollectionIDs' contract,
+// so no separate branch is needed for the all-access-member case.
 func (s *Server) projectIntelVisibility(r *http.Request, workspaceID string) (collIDs, itemIDs []string, err error) {
-	visibleIDs, err := s.visibleCollectionIDs(r, workspaceID)
+	visibleIDs, err := s.bearerAwareVisibleCollectionIDs(r, workspaceID)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/server/handlers_project_intel.go
+++ b/internal/server/handlers_project_intel.go
@@ -36,9 +36,9 @@ import (
 // break that parity for bearer admins and diverge next from both siblings).
 // Net effect: a bearer-authed platform admin who is only a restricted member
 // of the workspace gets correctly-scoped completed/in_progress from standup,
-// but ungated blockers/suggested_next — until the visibleCollectionIDs
-// bearer-gate bug filed from TASK-1894 review is fixed for
-// buildDashboardResponse itself, at which point this asymmetry resolves.
+// but ungated blockers/suggested_next — until BUG-1917 (the
+// visibleCollectionIDs bearer-gate gap) is fixed for buildDashboardResponse
+// itself, at which point this asymmetry resolves.
 
 // parseDaysParam reads a "days" query param with a fallback default. Mirrors
 // the CLI's `n > 0` gate (standupCmd/changelogCmd flag defaults) and the MCP
@@ -83,8 +83,7 @@ func itemMatchesParentFilter(item models.Item, parent string) bool {
 // granted the unrestricted admin view a cookie-session admin gets.
 // visibleCollectionIDs itself — and everything still built directly on it
 // (buildDashboardResponse, handleListItems, handleGetWorkspaceGraph) — does
-// NOT have this gate; that's the visibleCollectionIDs bearer-gate bug filed
-// from TASK-1894 review, tracked separately from this fix.
+// NOT have this gate; that's BUG-1917, tracked separately from this fix.
 func (s *Server) bearerAwareVisibleCollectionIDs(r *http.Request, workspaceID string) ([]string, error) {
 	user := currentUser(r)
 	if user == nil || (user.Role == "admin" && !isBearerAuth(r)) {

--- a/internal/server/handlers_project_intel.go
+++ b/internal/server/handlers_project_intel.go
@@ -1,0 +1,386 @@
+package server
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// This file implements the browser/REST surface for the "project
+// intelligence" reads (PLAN-1888 / TASK-1894): next, standup, changelog.
+//
+// KEEP IN SYNC — these three handlers are the THIRD reproduction of this
+// reshaping contract, alongside:
+//   - cmd/pad/main.go: nextCmd / standupCmd / changelogCmd (the canonical
+//     CLI implementations `pad project next|standup|changelog --format json`)
+//   - internal/mcp/dispatch_http_slice4.go: dispatchProjectNext /
+//     dispatchProjectStandup / dispatchProjectChangelog (the MCP HTTP
+//     transport's reproduction of the same contract)
+//
+// All three must agree on defaults, per-status best-effort semantics, and
+// output shape. A follow-up task will consolidate slice4 onto these REST
+// endpoints (route-table + delete the custom dispatchers) — until then,
+// changes here need a matching change (or an explicit noted divergence) in
+// both siblings above.
+
+// parseDaysParam reads a "days" query param with a fallback default. Mirrors
+// the CLI's `n > 0` gate (standupCmd/changelogCmd flag defaults) and the MCP
+// HTTP transport's `numericInput(...) && n > 0` gate in dispatch_http_slice4.go:
+// absent, non-numeric, zero, or negative all silently fall back to the
+// default rather than erroring — this also matches this codebase's existing
+// REST convention for lenient numeric query params (handleGetWorkspaceGraph's
+// `depth`, GetReport's `window`), so days is not a divergence from either
+// sibling or the surrounding REST style.
+func parseDaysParam(r *http.Request, def int) int {
+	raw := strings.TrimSpace(r.URL.Query().Get("days"))
+	if raw == "" {
+		return def
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n <= 0 {
+		return def
+	}
+	return n
+}
+
+// itemMatchesParentFilter mirrors the CLI's parent-filter matching
+// (cmd/pad/main.go's changelogCmd) and dispatch_http_slice4.go's
+// itemMatchesParent: case-insensitive comparison against the item's parent
+// link id, parent ref, or parent title. Lets an agent/user pass a UUID, an
+// issue ref like "PLAN-3", or the human-readable title.
+func itemMatchesParentFilter(item models.Item, parent string) bool {
+	for _, v := range []string{item.ParentLinkID, item.ParentRef, item.ParentTitle} {
+		if v != "" && strings.EqualFold(v, parent) {
+			return true
+		}
+	}
+	return false
+}
+
+// projectIntelVisibility computes the same (collectionIDs, itemIDs)
+// visibility-scoping pair used by handleListItems / handleGetDashboard /
+// handleGetWorkspaceGraph, for the item-list calls the standup/changelog
+// handlers make directly (outside of buildDashboardResponse).
+func (s *Server) projectIntelVisibility(r *http.Request, workspaceID string) (collIDs, itemIDs []string, err error) {
+	visibleIDs, err := s.visibleCollectionIDs(r, workspaceID)
+	if err != nil {
+		return nil, nil, err
+	}
+	fullCollIDs, grantedItemIDs, err := s.guestResourceFilter(r, workspaceID)
+	if err != nil {
+		return nil, nil, err
+	}
+	collIDs = visibleIDs
+	if len(grantedItemIDs) > 0 {
+		collIDs = fullCollIDs
+		itemIDs = grantedItemIDs
+	}
+	return collIDs, itemIDs, nil
+}
+
+// listTerminalItemsSince fetches items in each of models.DefaultTerminalStatuses
+// (one ListItems call per status — mirrors the CLI/slice4 loop rather than
+// OR-ing statuses into a single query), keeping only items updated after
+// cutoff, up to limit items considered per status. A store error for one
+// status is swallowed and the loop continues — matches the CLI's and
+// slice4's best-effort semantics: a transient failure on one status must not
+// blank out the whole report.
+func (s *Server) listTerminalItemsSince(
+	workspaceID string, collIDs, itemIDs []string, cutoff time.Time, limit int,
+) []models.Item {
+	var out []models.Item
+	for _, status := range models.DefaultTerminalStatuses {
+		items, err := s.store.ListItems(workspaceID, models.ItemListParams{
+			CollectionIDs: collIDs,
+			ItemIDs:       itemIDs,
+			Fields:        map[string]string{"status": status},
+			Sort:          "updated_at:desc",
+			Limit:         limit,
+		})
+		if err != nil {
+			continue
+		}
+		for _, item := range items {
+			if item.UpdatedAt.After(cutoff) {
+				out = append(out, item)
+			}
+		}
+	}
+	return out
+}
+
+// --- GET /workspaces/{slug}/next ---
+
+// handleGetProjectNext returns the dashboard's suggested_next array — the
+// same data `pad project next --format json` prints (cmd/pad/main.go's
+// nextCmd, post BUG-987 bug 6: ONLY the suggested_next array, not the whole
+// dashboard) and dispatchProjectNext (dispatch_http_slice4.go) returns over
+// the MCP HTTP transport. Returned as a bare JSON array (matching the CLI's
+// `cli.PrintJSON(dash.SuggestedNext)` and the handleListItems bare-array
+// convention), never null (buildDashboardResponse initializes SuggestedNext
+// to []DashboardSuggestion{}).
+func (s *Server) handleGetProjectNext(w http.ResponseWriter, r *http.Request) {
+	workspaceID, ok := s.getWorkspaceID(w, r)
+	if !ok {
+		return
+	}
+	resp, err := s.buildDashboardResponse(workspaceID, r)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, resp.SuggestedNext)
+}
+
+// --- GET /workspaces/{slug}/standup ---
+
+// StandupItem is one row in a StandupResponse list. Field-for-field mirror
+// of cmd/pad/main.go's standupCmd `standupItem` JSON type and
+// dispatch_http_slice4.go's dispatchProjectStandup `standupItem` type.
+type StandupItem struct {
+	Ref      string `json:"ref"`
+	Title    string `json:"title"`
+	Status   string `json:"status,omitempty"`
+	Priority string `json:"priority,omitempty"`
+	Reason   string `json:"reason,omitempty"`
+}
+
+// StandupResponse mirrors cmd/pad/main.go's standupCmd `standupJSON` type
+// and dispatch_http_slice4.go's dispatchProjectStandup payload map exactly.
+type StandupResponse struct {
+	Date          string        `json:"date"`
+	Days          int           `json:"days"`
+	Completed     []StandupItem `json:"completed"`
+	InProgress    []StandupItem `json:"in_progress"`
+	Blockers      []StandupItem `json:"blockers"`
+	SuggestedNext []StandupItem `json:"suggested_next"`
+}
+
+// handleGetProjectStandup serves GET /workspaces/{slug}/standup?days=N.
+//
+//	days (optional, default 1) — lookback window for "completed" items.
+//	See parseDaysParam for the lenient-default semantics.
+//
+// Mirrors `pad project standup --format json` (cmd/pad/main.go standupCmd)
+// and dispatchProjectStandup (dispatch_http_slice4.go) exactly: dashboard
+// for active items / blockers / suggested-next, plus a per-terminal-status
+// ListItems loop (limit 20, best-effort) for "completed", plus an unbounded
+// in-progress ListItems call.
+func (s *Server) handleGetProjectStandup(w http.ResponseWriter, r *http.Request) {
+	workspaceID, ok := s.getWorkspaceID(w, r)
+	if !ok {
+		return
+	}
+	days := parseDaysParam(r, 1)
+	cutoff := time.Now().AddDate(0, 0, -days)
+
+	dash, err := s.buildDashboardResponse(workspaceID, r)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+
+	collIDs, itemIDs, err := s.projectIntelVisibility(r, workspaceID)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+
+	completed := s.listTerminalItemsSince(workspaceID, collIDs, itemIDs, cutoff, 20)
+
+	// In-progress items: unbounded, best-effort (a store error yields an
+	// empty list rather than failing the whole standup — matches the CLI's
+	// `inProgressItems = nil` fallback and slice4's identical tolerance).
+	inProgress, err := s.store.ListItems(workspaceID, models.ItemListParams{
+		CollectionIDs: collIDs,
+		ItemIDs:       itemIDs,
+		Fields:        map[string]string{"status": "in-progress"},
+		Sort:          "updated_at:desc",
+	})
+	if err != nil {
+		inProgress = nil
+	}
+
+	resp := StandupResponse{
+		Date:          time.Now().Format("2006-01-02"),
+		Days:          days,
+		Completed:     make([]StandupItem, 0, len(completed)),
+		InProgress:    make([]StandupItem, 0, len(inProgress)),
+		Blockers:      make([]StandupItem, 0, len(dash.Attention)),
+		SuggestedNext: make([]StandupItem, 0, len(dash.SuggestedNext)),
+	}
+	for _, item := range completed {
+		resp.Completed = append(resp.Completed, StandupItem{
+			Ref:    item.Ref,
+			Title:  item.Title,
+			Status: extractFieldValue(item.Fields, "status"),
+		})
+	}
+	for _, item := range inProgress {
+		resp.InProgress = append(resp.InProgress, StandupItem{
+			Ref:      item.Ref,
+			Title:    item.Title,
+			Priority: extractFieldValue(item.Fields, "priority"),
+		})
+	}
+	for _, a := range dash.Attention {
+		resp.Blockers = append(resp.Blockers, StandupItem{
+			Ref:    a.ItemRef,
+			Title:  a.ItemTitle,
+			Reason: a.Reason,
+		})
+	}
+	for _, sug := range dash.SuggestedNext {
+		resp.SuggestedNext = append(resp.SuggestedNext, StandupItem{
+			Ref:    sug.ItemRef,
+			Title:  sug.ItemTitle,
+			Reason: sug.Reason,
+		})
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// --- GET /workspaces/{slug}/changelog ---
+
+// ChangelogItem is one row in a ChangelogGroup. Field-for-field mirror of
+// cmd/pad/main.go's changelogCmd `changelogItem` JSON type and
+// dispatch_http_slice4.go's dispatchProjectChangelog `changelogItem` type.
+type ChangelogItem struct {
+	Ref    string `json:"ref"`
+	Title  string `json:"title"`
+	Status string `json:"status"`
+}
+
+// ChangelogGroup is one collection's bucket of completed items within the
+// changelog window. Mirrors changelogCmd's `changelogGroup` /
+// dispatchProjectChangelog's `changelogGroup`.
+type ChangelogGroup struct {
+	Collection string          `json:"collection"`
+	Icon       string          `json:"icon,omitempty"`
+	Count      int             `json:"count"`
+	Items      []ChangelogItem `json:"items"`
+}
+
+// ChangelogResponse mirrors changelogCmd's `changelogJSON` type and
+// dispatchProjectChangelog's payload map exactly.
+type ChangelogResponse struct {
+	Period string           `json:"period"`
+	Since  string           `json:"since"`
+	Total  int              `json:"total"`
+	Groups []ChangelogGroup `json:"groups"`
+}
+
+// handleGetProjectChangelog serves:
+//
+//	GET /workspaces/{slug}/changelog?days=N&since=YYYY-MM-DD&parent=REF
+//
+//	days   (optional, default 7) — lookback window. See parseDaysParam.
+//	since  (optional, YYYY-MM-DD) — takes precedence over days when both are
+//	       given (silent since-wins, matching the CLI's if/else and
+//	       dispatchProjectChangelog exactly — all three surfaces already
+//	       agree on this, REST doesn't get to be the odd one out). Malformed
+//	       since → 400 bad_request (matches the CLI's hard error and
+//	       dispatchProjectChangelog's validationFailedResult).
+//	parent (optional, ref/slug/UUID/title) — scope to items whose parent
+//	       matches, via itemMatchesParentFilter.
+//
+// Mirrors `pad project changelog --format json` (cmd/pad/main.go
+// changelogCmd) and dispatchProjectChangelog (dispatch_http_slice4.go)
+// exactly: a per-terminal-status ListItems loop (limit 100, best-effort),
+// cutoff + parent filtering, grouped by collection preserving first-seen
+// order.
+func (s *Server) handleGetProjectChangelog(w http.ResponseWriter, r *http.Request) {
+	workspaceID, ok := s.getWorkspaceID(w, r)
+	if !ok {
+		return
+	}
+
+	days := parseDaysParam(r, 7)
+	since := strings.TrimSpace(r.URL.Query().Get("since"))
+	parent := strings.TrimSpace(r.URL.Query().Get("parent"))
+
+	var cutoff time.Time
+	if since != "" {
+		parsed, err := time.Parse("2006-01-02", since)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "bad_request",
+				"invalid 'since' date (expected YYYY-MM-DD): "+err.Error())
+			return
+		}
+		cutoff = parsed
+	} else {
+		cutoff = time.Now().AddDate(0, 0, -days)
+	}
+
+	collIDs, itemIDs, err := s.projectIntelVisibility(r, workspaceID)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+
+	items := s.listTerminalItemsSince(workspaceID, collIDs, itemIDs, cutoff, 100)
+	if parent != "" {
+		// The parent filter needs the items' own parent-link metadata
+		// (parent_link_id / parent_ref / parent_title) populated —
+		// batch-enrich before filtering, same helper handleListItems uses.
+		s.enrichItemsWithParent(workspaceID, items, collIDs)
+		filtered := items[:0]
+		for _, item := range items {
+			if itemMatchesParentFilter(item, parent) {
+				filtered = append(filtered, item)
+			}
+		}
+		items = filtered
+	}
+
+	// Group by collection slug, preserving first-seen ordering (matches the
+	// CLI's groupOrder slice / dispatchProjectChangelog's identical approach).
+	groupOrder := make([]string, 0)
+	groups := make(map[string]*ChangelogGroup)
+	for _, item := range items {
+		key := item.CollectionSlug
+		if key == "" {
+			key = "other"
+		}
+		g, exists := groups[key]
+		if !exists {
+			name := item.CollectionName
+			if name == "" {
+				name = key
+			}
+			g = &ChangelogGroup{Collection: name, Icon: item.CollectionIcon, Items: []ChangelogItem{}}
+			groups[key] = g
+			groupOrder = append(groupOrder, key)
+		}
+		g.Items = append(g.Items, ChangelogItem{
+			Ref:    item.Ref,
+			Title:  item.Title,
+			Status: extractFieldValue(item.Fields, "status"),
+		})
+		g.Count = len(g.Items)
+	}
+
+	periodLabel := "last " + strconv.Itoa(days) + " days"
+	if since != "" {
+		periodLabel = "since " + since
+	}
+	if parent != "" {
+		periodLabel += " (parent: " + parent + ")"
+	}
+
+	resp := ChangelogResponse{
+		Period: periodLabel,
+		Since:  cutoff.Format("2006-01-02"),
+		Total:  len(items),
+		Groups: make([]ChangelogGroup, 0, len(groupOrder)),
+	}
+	for _, key := range groupOrder {
+		resp.Groups = append(resp.Groups, *groups[key])
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}

--- a/internal/server/handlers_project_intel_test.go
+++ b/internal/server/handlers_project_intel_test.go
@@ -1,0 +1,387 @@
+package server
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// ── next ─────────────────────────────────────────────────────────────────────
+
+// TestProjectNextEndpoint_MatchesDashboardSuggestedNext pins the "same data
+// the CLI computes" acceptance criterion: /next must return exactly the
+// dashboard's suggested_next array (that's all `pad project next` ever
+// showed, post BUG-987 bug 6).
+func TestProjectNextEndpoint_MatchesDashboardSuggestedNext(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	createItem(t, srv, slug, "tasks", map[string]interface{}{
+		"title":  "Fix the thing",
+		"fields": `{"status":"open","priority":"high"}`,
+	})
+
+	dash := getDashboard(t, srv, slug)
+	if len(dash.SuggestedNext) == 0 {
+		t.Fatal("expected dashboard to suggest the high-priority open task")
+	}
+
+	rr := doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/next", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("next: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var next []DashboardSuggestion
+	parseJSON(t, rr, &next)
+
+	if len(next) != len(dash.SuggestedNext) {
+		t.Fatalf("expected /next to mirror dashboard.suggested_next (%d entries), got %d",
+			len(dash.SuggestedNext), len(next))
+	}
+	for i := range next {
+		if next[i] != dash.SuggestedNext[i] {
+			t.Fatalf("suggestion %d mismatch: /next=%+v dashboard=%+v", i, next[i], dash.SuggestedNext[i])
+		}
+	}
+}
+
+// TestProjectNextEndpoint_EmptyWorkspaceReturnsEmptyArrayNotNull pins the
+// bare-array response shape (matches the CLI's `PrintJSON(dash.SuggestedNext)`
+// and the handleListItems bare-array convention) — never a null/undefined
+// body a client would have to special-case.
+func TestProjectNextEndpoint_EmptyWorkspaceReturnsEmptyArrayNotNull(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	rr := doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/next", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("next: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if body := strings.TrimSpace(rr.Body.String()); body != "[]" {
+		t.Fatalf("expected bare empty array '[]', got %q", body)
+	}
+}
+
+func TestProjectNextEndpoint_RequiresAuth(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+	bootstrapFirstUser(t, srv, "admin@example.com", "Admin")
+
+	rr := doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/next", nil)
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 without a session once users exist, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+// ── standup ──────────────────────────────────────────────────────────────────
+
+// backdateItemUpdatedAt directly rewrites an item's updated_at column so
+// cutoff-window tests don't depend on wall-clock sleeps. Mirrors the
+// backdate helpers already used in oplog_gc_test.go / orphan_gc_test.go /
+// internal/store/reports_test.go's backdateItem.
+func backdateItemUpdatedAt(t *testing.T, srv *Server, itemID string, daysAgo int) {
+	t.Helper()
+	ts := time.Now().AddDate(0, 0, -daysAgo).UTC().Format(time.RFC3339)
+	if _, err := srv.store.DB().Exec(`UPDATE items SET updated_at = ? WHERE id = ?`, ts, itemID); err != nil {
+		t.Fatalf("backdate item %s: %v", itemID, err)
+	}
+}
+
+func TestProjectStandupEndpoint_HappyPath(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	done := createItem(t, srv, slug, "tasks", map[string]interface{}{
+		"title":  "Shipped it",
+		"fields": `{"status":"done"}`,
+	})
+	createItem(t, srv, slug, "tasks", map[string]interface{}{
+		"title":  "Still working",
+		"fields": `{"status":"in-progress","priority":"medium"}`,
+	})
+
+	rr := doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/standup", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("standup: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var resp StandupResponse
+	parseJSON(t, rr, &resp)
+
+	if resp.Days != 1 {
+		t.Errorf("expected default days=1, got %d", resp.Days)
+	}
+	if resp.Date != time.Now().Format("2006-01-02") {
+		t.Errorf("expected date=%s, got %s", time.Now().Format("2006-01-02"), resp.Date)
+	}
+	if len(resp.Completed) != 1 || resp.Completed[0].Ref != done.Ref {
+		t.Fatalf("expected 1 completed item (%s), got %+v", done.Ref, resp.Completed)
+	}
+	if resp.Completed[0].Status != "done" {
+		t.Errorf("expected completed status=done, got %q", resp.Completed[0].Status)
+	}
+	if len(resp.InProgress) != 1 || resp.InProgress[0].Priority != "medium" {
+		t.Fatalf("expected 1 in-progress item with priority=medium, got %+v", resp.InProgress)
+	}
+}
+
+// TestProjectStandupEndpoint_DaysParam_FiltersOldCompletions pins the days
+// cutoff and the "malformed days silently falls back to the default"
+// semantics (matches dispatchProjectStandup's `numericInput(...) && n > 0`
+// gate and this codebase's REST convention for lenient numeric query params
+// — handleGetWorkspaceGraph's `depth`, GetReport's `window`).
+func TestProjectStandupEndpoint_DaysParam_FiltersOldCompletions(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	old := createItem(t, srv, slug, "tasks", map[string]interface{}{
+		"title":  "Shipped a while ago",
+		"fields": `{"status":"done"}`,
+	})
+	backdateItemUpdatedAt(t, srv, old.ID, 5)
+
+	// Default days=1: the 5-day-old completion must be excluded.
+	rr := doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/standup", nil)
+	var resp StandupResponse
+	parseJSON(t, rr, &resp)
+	if len(resp.Completed) != 0 {
+		t.Fatalf("expected 0 completed within default 1-day window, got %+v", resp.Completed)
+	}
+
+	// days=7: now in range.
+	rr = doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/standup?days=7", nil)
+	parseJSON(t, rr, &resp)
+	if resp.Days != 7 || len(resp.Completed) != 1 {
+		t.Fatalf("expected days=7 with 1 completed, got days=%d completed=%+v", resp.Days, resp.Completed)
+	}
+
+	// days=abc (malformed) and days=-3 (non-positive) both silently fall
+	// back to the default (1), NOT a 400 — matches dispatchProjectStandup's
+	// exact gate.
+	for _, malformed := range []string{"abc", "-3", "0"} {
+		rr = doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/standup?days="+malformed, nil)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("days=%s: expected 200 (lenient fallback, not a 400), got %d: %s", malformed, rr.Code, rr.Body.String())
+		}
+		parseJSON(t, rr, &resp)
+		if resp.Days != 1 {
+			t.Fatalf("days=%s: expected fallback to default 1, got %d", malformed, resp.Days)
+		}
+	}
+}
+
+func TestProjectStandupEndpoint_RequiresAuth(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+	bootstrapFirstUser(t, srv, "admin@example.com", "Admin")
+
+	rr := doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/standup", nil)
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 without a session once users exist, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+// ── changelog ────────────────────────────────────────────────────────────────
+
+func TestProjectChangelogEndpoint_HappyPath(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	task := createItem(t, srv, slug, "tasks", map[string]interface{}{
+		"title":  "Shipped it",
+		"fields": `{"status":"done"}`,
+	})
+	idea := createItem(t, srv, slug, "ideas", map[string]interface{}{
+		"title":  "Landed idea",
+		"fields": `{"status":"implemented"}`,
+	})
+	createItem(t, srv, slug, "tasks", map[string]interface{}{
+		"title":  "Still open",
+		"fields": `{"status":"open"}`,
+	})
+
+	rr := doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/changelog", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("changelog: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var resp ChangelogResponse
+	parseJSON(t, rr, &resp)
+
+	if resp.Total != 2 {
+		t.Fatalf("expected 2 completed items, got %d (%+v)", resp.Total, resp)
+	}
+	if resp.Period != "last 7 days" {
+		t.Errorf("expected default period 'last 7 days', got %q", resp.Period)
+	}
+	byCollection := map[string]ChangelogGroup{}
+	for _, g := range resp.Groups {
+		byCollection[g.Collection] = g
+	}
+	tasksGroup, ok := byCollection["Tasks"]
+	if !ok || tasksGroup.Count != 1 || tasksGroup.Items[0].Ref != task.Ref {
+		t.Fatalf("expected a 'Tasks' group with 1 item (%s), got %+v", task.Ref, byCollection)
+	}
+	ideasGroup, ok := byCollection["Ideas"]
+	if !ok || ideasGroup.Count != 1 || ideasGroup.Items[0].Ref != idea.Ref {
+		t.Fatalf("expected an 'Ideas' group with 1 item (%s), got %+v", idea.Ref, byCollection)
+	}
+}
+
+// TestProjectChangelogEndpoint_SinceOverridesDays pins the CLI's silent
+// since-wins behavior (cmd/pad/main.go changelogCmd's if/else and
+// dispatchProjectChangelog): both since and days given → since wins, no 400.
+func TestProjectChangelogEndpoint_SinceOverridesDays(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	createItem(t, srv, slug, "tasks", map[string]interface{}{
+		"title":  "Shipped it",
+		"fields": `{"status":"done"}`,
+	})
+
+	since := time.Now().AddDate(0, 0, -1).Format("2006-01-02")
+	rr := doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/changelog?days=9999&since="+since, nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("changelog: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var resp ChangelogResponse
+	parseJSON(t, rr, &resp)
+	if resp.Period != "since "+since {
+		t.Fatalf("expected since to override days in the period label, got %q", resp.Period)
+	}
+	if resp.Since != since {
+		t.Fatalf("expected since=%s, got %s", since, resp.Since)
+	}
+}
+
+func TestProjectChangelogEndpoint_InvalidSinceReturns400(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	rr := doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/changelog?since=not-a-date", nil)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for malformed since, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+// TestProjectChangelogEndpoint_ParentFilter pins the parent-ref filter,
+// matching itemMatchesParentFilter / dispatchProjectChangelog's
+// itemMatchesParent: case-insensitive match against the item's parent ref.
+func TestProjectChangelogEndpoint_ParentFilter(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	plan := createItem(t, srv, slug, "plans", map[string]interface{}{
+		"title":  "Q1 Launch",
+		"fields": `{"status":"active"}`,
+	})
+	child := createItem(t, srv, slug, "tasks", map[string]interface{}{
+		"title":  "Scoped to plan",
+		"fields": `{"status":"done","parent":"` + plan.Ref + `"}`,
+	})
+	createItem(t, srv, slug, "tasks", map[string]interface{}{
+		"title":  "Unrelated",
+		"fields": `{"status":"done"}`,
+	})
+
+	rr := doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/changelog?parent="+plan.Ref, nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("changelog: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var resp ChangelogResponse
+	parseJSON(t, rr, &resp)
+	if resp.Total != 1 {
+		t.Fatalf("expected 1 item scoped to parent %s, got %d (%+v)", plan.Ref, resp.Total, resp)
+	}
+	if len(resp.Groups) != 1 || len(resp.Groups[0].Items) != 1 || resp.Groups[0].Items[0].Ref != child.Ref {
+		t.Fatalf("expected only the child scoped to %s, got %+v", plan.Ref, resp.Groups)
+	}
+	if !strings.Contains(resp.Period, "parent: "+plan.Ref) {
+		t.Errorf("expected period label to note the parent scope, got %q", resp.Period)
+	}
+}
+
+func TestProjectChangelogEndpoint_RequiresAuth(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+	bootstrapFirstUser(t, srv, "admin@example.com", "Admin")
+
+	rr := doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/changelog", nil)
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 without a session once users exist, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+// ── ACL scoping ──────────────────────────────────────────────────────────────
+
+// TestProjectIntelEndpoints_ScopeToVisibleCollections pins collection
+// visibility on all three new endpoints in one pass: a member restricted to
+// the "ideas" collection must never see "tasks" data through /standup or
+// /changelog, mirroring the restricted-member pattern already used for
+// child-progress (handlers_items_test.go) and the report endpoint.
+func TestProjectIntelEndpoints_ScopeToVisibleCollections(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+	ws, err := srv.store.GetWorkspaceBySlug(slug)
+	if err != nil || ws == nil {
+		t.Fatalf("GetWorkspaceBySlug: %v", err)
+	}
+
+	createItem(t, srv, slug, "tasks", map[string]interface{}{
+		"title":  "Hidden completion",
+		"fields": `{"status":"done"}`,
+	})
+	visibleItem := createItem(t, srv, slug, "ideas", map[string]interface{}{
+		"title":  "Visible completion",
+		"fields": `{"status":"implemented"}`,
+	})
+
+	restrictedUser, err := srv.store.CreateUser(models.UserCreate{
+		Email: "restricted@example.com", Name: "Restricted", Username: "restricted-user",
+		Password: "pw-test-12345",
+	})
+	if err != nil {
+		t.Fatalf("CreateUser restricted: %v", err)
+	}
+	if err := srv.store.AddWorkspaceMember(ws.ID, restrictedUser.ID, "editor"); err != nil {
+		t.Fatalf("AddWorkspaceMember: %v", err)
+	}
+	ideasColl, err := srv.store.GetCollectionBySlug(ws.ID, "ideas")
+	if err != nil || ideasColl == nil {
+		t.Fatalf("GetCollectionBySlug ideas: %v", err)
+	}
+	if err := srv.store.SetMemberCollectionAccess(ws.ID, restrictedUser.ID, "specific", []string{ideasColl.ID}); err != nil {
+		t.Fatalf("SetMemberCollectionAccess: %v", err)
+	}
+	token, err := srv.store.CreateSession(restrictedUser.ID, "go-test", "192.0.2.1", "", 24*time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	rr := doRequestWithCookie(srv, "GET", "/api/v1/workspaces/"+slug+"/standup", nil, token)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("restricted standup: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var standup StandupResponse
+	parseJSON(t, rr, &standup)
+	if len(standup.Completed) != 1 || standup.Completed[0].Ref != visibleItem.Ref {
+		t.Fatalf("restricted standup should see only the visible completion (%s), got %+v",
+			visibleItem.Ref, standup.Completed)
+	}
+
+	rr = doRequestWithCookie(srv, "GET", "/api/v1/workspaces/"+slug+"/changelog", nil, token)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("restricted changelog: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var changelog ChangelogResponse
+	parseJSON(t, rr, &changelog)
+	if changelog.Total != 1 {
+		t.Fatalf("restricted changelog should see only 1 item, got %d (%+v)", changelog.Total, changelog)
+	}
+	for _, g := range changelog.Groups {
+		if g.Collection == "Tasks" {
+			t.Fatalf("restricted changelog leaked the hidden 'tasks' collection: %+v", changelog.Groups)
+		}
+	}
+}

--- a/internal/server/handlers_project_intel_test.go
+++ b/internal/server/handlers_project_intel_test.go
@@ -385,3 +385,108 @@ func TestProjectIntelEndpoints_ScopeToVisibleCollections(t *testing.T) {
 		}
 	}
 }
+
+// TestProjectIntelEndpoints_BearerAdminRestrictedMemberIsScoped pins the
+// codex round-1 finding: projectIntelVisibility must be bearer-aware
+// (mirrors reportVisibleCollections / the BUG-1616/1617 pattern —
+// handlers_admin_bearer_gate_test.go). A platform admin who is only a
+// RESTRICTED member of this workspace gets the full unrestricted view over
+// a cookie session (the web UI admin affordance) but must be scoped to
+// their actual grant over a bearer token (PAT/CLI/OAuth) — never leaking
+// the hidden collection's completions through standup or changelog.
+func TestProjectIntelEndpoints_BearerAdminRestrictedMemberIsScoped(t *testing.T) {
+	srv := testServer(t)
+
+	admin, err := srv.store.CreateUser(models.UserCreate{
+		Email: "admin@example.com", Name: "Admin", Password: "correct-horse-battery-staple", Role: "admin",
+	})
+	if err != nil {
+		t.Fatalf("create admin: %v", err)
+	}
+	ws, err := srv.store.CreateWorkspace(models.WorkspaceCreate{Name: "BearerScoped", OwnerID: admin.ID})
+	if err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	if err := srv.store.AddWorkspaceMember(ws.ID, admin.ID, "editor"); err != nil {
+		t.Fatalf("add member: %v", err)
+	}
+
+	schema := `{"fields":[{"key":"status","type":"select","options":["open","done"],"default":"open"}]}`
+	visible, err := srv.store.CreateCollection(ws.ID, models.CollectionCreate{
+		Name: "Visible", Slug: "visible", Prefix: "VIS", Schema: schema,
+	})
+	if err != nil {
+		t.Fatalf("create visible: %v", err)
+	}
+	hidden, err := srv.store.CreateCollection(ws.ID, models.CollectionCreate{
+		Name: "Hidden", Slug: "hidden", Prefix: "HID", Schema: schema,
+	})
+	if err != nil {
+		t.Fatalf("create hidden: %v", err)
+	}
+	visibleItem, err := srv.store.CreateItem(ws.ID, visible.ID, models.ItemCreate{
+		Title: "Visible completion", Fields: `{"status":"done"}`,
+	})
+	if err != nil {
+		t.Fatalf("create visible item: %v", err)
+	}
+	if _, err := srv.store.CreateItem(ws.ID, hidden.ID, models.ItemCreate{
+		Title: "Hidden completion", Fields: `{"status":"done"}`,
+	}); err != nil {
+		t.Fatalf("create hidden item: %v", err)
+	}
+	if err := srv.store.SetMemberCollectionAccess(ws.ID, admin.ID, "specific", []string{visible.ID}); err != nil {
+		t.Fatalf("set access: %v", err)
+	}
+	visibleItem.ComputeRef()
+
+	tok, err := srv.store.CreateAPIToken(admin.ID, models.APITokenCreate{
+		Name: "admin-pat", WorkspaceID: ws.ID,
+	}, 0, 0)
+	if err != nil {
+		t.Fatalf("CreateAPIToken: %v", err)
+	}
+
+	// Bearer admin → scoped: changelog sees only the visible completion.
+	rr := doRequestWithBearer(srv, "GET", "/api/v1/workspaces/"+ws.Slug+"/changelog", tok.Token, nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("bearer changelog: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var changelog ChangelogResponse
+	parseJSON(t, rr, &changelog)
+	if changelog.Total != 1 {
+		t.Fatalf("bearer admin changelog should be scoped to 1 item, got %d (%+v)", changelog.Total, changelog)
+	}
+	for _, g := range changelog.Groups {
+		if g.Collection == "Hidden" {
+			t.Fatalf("bearer admin changelog leaked the hidden collection: %+v", changelog.Groups)
+		}
+	}
+
+	// Bearer admin → standup's completed/in_progress are scoped too.
+	rr = doRequestWithBearer(srv, "GET", "/api/v1/workspaces/"+ws.Slug+"/standup", tok.Token, nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("bearer standup: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var standup StandupResponse
+	parseJSON(t, rr, &standup)
+	if len(standup.Completed) != 1 || standup.Completed[0].Ref != visibleItem.Ref {
+		t.Fatalf("bearer admin standup.completed should be scoped to the visible item (%s), got %+v",
+			visibleItem.Ref, standup.Completed)
+	}
+
+	// Cookie admin → unrestricted (the pre-existing web UI admin affordance):
+	// changelog sees both completions.
+	sessTok, err := srv.store.CreateSession(admin.ID, "web-test", "192.0.2.1", "", webSessionTTL)
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	rr = doRequestWithCookie(srv, "GET", "/api/v1/workspaces/"+ws.Slug+"/changelog", nil, sessTok)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("cookie changelog: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	parseJSON(t, rr, &changelog)
+	if changelog.Total != 2 {
+		t.Fatalf("cookie admin changelog should be unrestricted (2 items), got %d (%+v)", changelog.Total, changelog)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1306,6 +1306,16 @@ func (s *Server) setupRouter() {
 					r.Get("/report/layout", s.handleGetReportLayout)
 					r.Put("/report/layout", s.handleSaveReportLayout)
 
+					// Project intelligence reads — next/standup/changelog
+					// (PLAN-1888 / TASK-1894). Mirror `pad project
+					// next|standup|changelog` (cmd/pad/main.go) and the MCP
+					// HTTP transport's dispatchProjectNext/Standup/Changelog
+					// (internal/mcp/dispatch_http_slice4.go) — KEEP IN SYNC,
+					// see handlers_project_intel.go's doc comments.
+					r.Get("/next", s.handleGetProjectNext)
+					r.Get("/standup", s.handleGetProjectStandup)
+					r.Get("/changelog", s.handleGetProjectChangelog)
+
 					// Agent bootstrap (PLAN-1377 / TASK-1379) — single
 					// round-trip that returns workspace + user +
 					// collections + always-on conventions + roles +

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -22,6 +22,9 @@ import type {
 	CommentCreate,
 	Version,
 	DashboardResponse,
+	DashboardSuggestion,
+	StandupResponse,
+	ChangelogResponse,
 	GraphResponse,
 	ReportData,
 	ReportLayout,
@@ -1142,6 +1145,33 @@ export const api = {
 	dashboard: {
 		get: (ws: string) =>
 			request<DashboardResponse>(`/workspaces/${ws}/dashboard`)
+	},
+
+	// ── Project intelligence: next / standup / changelog (PLAN-1888 / TASK-1894) ──
+	// Same data `pad project next|standup|changelog` computes — see the Go
+	// handlers in internal/server/handlers_project_intel.go.
+
+	/** The dashboard's suggested_next array — a bare array, matching the CLI's
+	 *  `pad project next --format json` output. */
+	next: (ws: string) => request<DashboardSuggestion[]>(`/workspaces/${ws}/next`),
+
+	/** Daily standup report: recently completed, in-progress, blockers, suggested-next. */
+	standup: (ws: string, opts?: { days?: number }) => {
+		const params = new URLSearchParams();
+		if (opts?.days != null) params.set('days', String(opts.days));
+		const qs = params.toString();
+		return request<StandupResponse>(`/workspaces/${ws}/standup${qs ? `?${qs}` : ''}`);
+	},
+
+	/** Changelog of completed items, grouped by collection. `since` takes
+	 *  precedence over `days` when both are given (mirrors the CLI). */
+	changelog: (ws: string, opts?: { days?: number; since?: string; parent?: string }) => {
+		const params = new URLSearchParams();
+		if (opts?.days != null) params.set('days', String(opts.days));
+		if (opts?.since) params.set('since', opts.since);
+		if (opts?.parent) params.set('parent', opts.parent);
+		const qs = params.toString();
+		return request<ChangelogResponse>(`/workspaces/${ws}/changelog${qs ? `?${qs}` : ''}`);
 	},
 
 	// ── Agent bootstrap ───────────────────────────────────────────────────────

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -919,6 +919,16 @@ export interface DashboardActiveItem {
 	item_ref?: string;
 }
 
+/** One recommended-next entry — dashboard.suggested_next, and the bare-array
+ *  shape returned by GET /workspaces/{ws}/next (PLAN-1888 / TASK-1894). */
+export interface DashboardSuggestion {
+	item_slug: string;
+	item_ref?: string;
+	item_title: string;
+	collection: string;
+	reason: string;
+}
+
 export interface DashboardResponse {
 	summary: {
 		total_items: number;
@@ -952,12 +962,7 @@ export interface DashboardResponse {
 		collection_slug?: string;
 		metadata?: string;
 	}[];
-	suggested_next: {
-		item_slug: string;
-		item_title: string;
-		collection: string;
-		reason: string;
-	}[];
+	suggested_next: DashboardSuggestion[];
 	// has_agent_activity is true when any item in the workspace was created
 	// by an agent surface (CLI or Remote MCP — both persist source='cli'
 	// today; future MCP-distinct attribution lands as source='mcp', which
@@ -985,6 +990,52 @@ export interface DashboardResponse {
 		// (untouched) status — banner shows only when this is true.
 		active: boolean;
 	};
+}
+
+// ─── Project Intelligence: standup / changelog (PLAN-1888 / TASK-1894) ──────
+//
+// (next() reuses DashboardSuggestion[] directly — see above.)
+
+/** One row in a StandupResponse list. Mirrors the Go StandupItem type. */
+export interface StandupItem {
+	ref: string;
+	title: string;
+	status?: string;
+	priority?: string;
+	reason?: string;
+}
+
+/** GET /workspaces/{ws}/standup response. Mirrors the Go StandupResponse type. */
+export interface StandupResponse {
+	date: string;
+	days: number;
+	completed: StandupItem[];
+	in_progress: StandupItem[];
+	blockers: StandupItem[];
+	suggested_next: StandupItem[];
+}
+
+/** One row in a ChangelogGroup. Mirrors the Go ChangelogItem type. */
+export interface ChangelogItem {
+	ref: string;
+	title: string;
+	status: string;
+}
+
+/** One collection's bucket of completed items. Mirrors the Go ChangelogGroup type. */
+export interface ChangelogGroup {
+	collection: string;
+	icon?: string;
+	count: number;
+	items: ChangelogItem[];
+}
+
+/** GET /workspaces/{ws}/changelog response. Mirrors the Go ChangelogResponse type. */
+export interface ChangelogResponse {
+	period: string;
+	since: string;
+	total: number;
+	groups: ChangelogGroup[];
 }
 
 // ─── Workspace Graph (PLAN-1730 / TASK-1732) ─────────────────────────────────

--- a/web/src/lib/webmcp/dispatch.test.ts
+++ b/web/src/lib/webmcp/dispatch.test.ts
@@ -33,6 +33,9 @@ function mockApi() {
 			create: vi.fn(async () => ({ id: 'c-1' })),
 		},
 		dashboard: { get: vi.fn(async () => ({ ok: true })) },
+		next: vi.fn(async () => [{ item_slug: 'task-1', item_title: 'Do it', collection: 'tasks', reason: 'high priority' }]),
+		standup: vi.fn(async () => ({ date: '2026-01-01', days: 1, completed: [], in_progress: [], blockers: [], suggested_next: [] })),
+		changelog: vi.fn(async () => ({ period: 'last 7 days', since: '2026-01-01', total: 0, groups: [] })),
 		collections: {
 			list: vi.fn(async () => []),
 			create: vi.fn(async () => ({ slug: 'risks' })),
@@ -85,6 +88,9 @@ const READ = new Set([
 	'pad_item:backlinks',
 	'pad_item:export',
 	'pad_project:dashboard',
+	'pad_project:next',
+	'pad_project:standup',
+	'pad_project:changelog',
 	'pad_collection:list',
 	'pad_role:list',
 	'pad_playbook:list',
@@ -746,6 +752,72 @@ describe('dispatch — playbook/library/meta writes', () => {
 	});
 });
 
+// ── pad_project reads: next / standup / changelog (TASK-1894) ───────────────
+
+describe('dispatch — pad_project next/standup/changelog', () => {
+	it('next maps to api.next with the route ws, no args', async () => {
+		const api = mockApi();
+		const result = await run(api, 'pad_project', { action: 'next' });
+		expect(api.next).toHaveBeenCalledWith(WS);
+		expect(parse(result).isError).toBe(false);
+	});
+
+	it('standup passes days through to api.standup', async () => {
+		const api = mockApi();
+		const result = await run(api, 'pad_project', { action: 'standup', days: 3 });
+		expect(api.standup).toHaveBeenCalledWith(WS, { days: 3 });
+		expect(parse(result).isError).toBe(false);
+	});
+
+	it('standup omits days when not supplied', async () => {
+		const api = mockApi();
+		await run(api, 'pad_project', { action: 'standup' });
+		expect(api.standup).toHaveBeenCalledWith(WS, { days: undefined });
+	});
+
+	it('changelog passes days/since/parent through to api.changelog', async () => {
+		const api = mockApi();
+		const result = await run(api, 'pad_project', {
+			action: 'changelog',
+			days: 14,
+			since: '2026-01-01',
+			parent: 'PLAN-3',
+		});
+		expect(api.changelog).toHaveBeenCalledWith(WS, {
+			days: 14,
+			since: '2026-01-01',
+			parent: 'PLAN-3',
+		});
+		expect(parse(result).isError).toBe(false);
+	});
+
+	it('changelog with only since (no days) still dispatches', async () => {
+		const api = mockApi();
+		await run(api, 'pad_project', { action: 'changelog', since: '2026-01-01' });
+		expect(api.changelog).toHaveBeenCalledWith(WS, {
+			days: undefined,
+			since: '2026-01-01',
+			parent: undefined,
+		});
+	});
+
+	it('standup errors (no client call) on a malformed `days`', async () => {
+		const api = mockApi();
+		const result = await run(api, 'pad_project', { action: 'standup', days: 'abc' });
+		expect(parse(result).isError).toBe(true);
+		expect(api.standup).not.toHaveBeenCalled();
+	});
+
+	it('changelog surfaces a thrown client error (e.g. server 400 on bad since) as an error result', async () => {
+		const api = mockApi();
+		api.changelog.mockRejectedValueOnce(new Error("invalid 'since' date"));
+		const result = await run(api, 'pad_project', { action: 'changelog', since: 'not-a-date' });
+		const { isError, text } = parse(result);
+		expect(isError).toBe(true);
+		expect(text).toMatch(/since/);
+	});
+});
+
 // ── Envelope + error behaviour ───────────────────────────────────────────────
 
 describe('dispatch — result envelope + errors', () => {
@@ -786,9 +858,13 @@ describe('dispatch — result envelope + errors', () => {
 		expect(parse(await promise).text).toMatch(/action/i);
 	});
 
-	it('errors for a catalog action with no browser mapping (pad_project.standup)', async () => {
+	// pad_project.next/standup/changelog are wired as of TASK-1894 (see the
+	// "dispatch — pad_project next/standup/changelog" describe block above).
+	// `report` has no browser REST mapping yet — still exercises the "not
+	// available" fallback.
+	it('errors for a catalog action with no browser mapping (pad_project.report)', async () => {
 		const api = mockApi();
-		const result = await run(api, 'pad_project', { action: 'standup' });
+		const result = await run(api, 'pad_project', { action: 'report' });
 		const { isError, text } = parse(result);
 		expect(isError).toBe(true);
 		expect(text).toMatch(/not available/i);

--- a/web/src/lib/webmcp/dispatch.ts
+++ b/web/src/lib/webmcp/dispatch.ts
@@ -366,11 +366,6 @@ async function dispatchItemUnlink(
 // consent gate (DR-2), not by which table an action lives in. Each handler
 // receives the ROUTE wsSlug — never an arg-supplied one (DR-4).
 //
-// pad_project next/standup/changelog and any other catalog read with no
-// browser REST mapping are intentionally absent and fall through to the "not
-// available in browser" branch rather than being faked (TASK-1894 wires
-// next/standup/changelog once their backend endpoints exist).
-
 const HANDLERS: Record<string, Handler> = {
 	// ── pad_search ──
 	'pad_search:query': (api, ws, args) =>
@@ -500,8 +495,22 @@ const HANDLERS: Record<string, Handler> = {
 	'pad_item:import': (api, ws, args) =>
 		api.importArtifact(ws, requireArg(args, 'artifact')),
 
-	// ── pad_project reads — only dashboard has a browser REST endpoint today.
+	// ── pad_project reads ──
 	'pad_project:dashboard': (api, ws) => api.dashboard.get(ws),
+	'pad_project:next': (api, ws) => api.next(ws),
+	'pad_project:standup': (api, ws, args) => api.standup(ws, { days: num(args, 'days') }),
+	// since takes precedence over days when both are given — matches the
+	// CLI's silent since-wins (cmd/pad/main.go changelogCmd) and the MCP
+	// HTTP transport's dispatchProjectChangelog. A malformed since/parent
+	// type throws via str() (caught by dispatch()'s try/catch); a malformed
+	// server-side since VALUE (e.g. not a real date) surfaces as a 400 →
+	// thrown client error, also caught.
+	'pad_project:changelog': (api, ws, args) =>
+		api.changelog(ws, {
+			days: num(args, 'days'),
+			since: str(args, 'since'),
+			parent: str(args, 'parent'),
+		}),
 
 	// ── pad_collection ──
 	'pad_collection:list': (api, ws) => api.collections.list(ws),


### PR DESCRIPTION
## Summary

WebMCP Phase 3c (TASK-1894): the catalog actions `pad_project.next` / `.standup` / `.changelog` had no REST endpoint, so the browser WebMCP dispatcher returned honest "not available in the browser" errors. This adds three session-authed GET endpoints under the existing `/workspaces/{slug}` access-controlled group and wires the browser surface to them:

- `GET /workspaces/{slug}/next` — bare array, parity with `dashboard.suggested_next` (the CLI's exact contract post BUG-987)
- `GET /workspaces/{slug}/standup?days=N` (default 1)
- `GET /workspaces/{slug}/changelog?days=N&since=YYYY-MM-DD&parent=REF` (default 7; silent since-wins matching both siblings)

Frontend: `client.ts` gets top-level `next()/standup()/changelog()` methods; `dispatch.ts` HANDLERS replace the honest-error stubs; new TS types mirror the Go response shapes (extracting `DashboardSuggestion` also fixed its previously missing `item_ref` field).

## The third-sibling problem (deliberate)

These handlers are the **third** reproduction of this reshaping contract, alongside the CLI (`cmd/pad/main.go`) and the MCP HTTP dispatcher (`internal/mcp/dispatch_http_slice4.go`) — the latter exists only because these endpoints didn't. All three sites now carry KEEP IN SYNC cross-references (storetest-mirror precedent). TASK-1916 (filed, blocked by this PR) consolidates the MCP dispatcher onto these endpoints and deletes its custom reshaping.

Deliberate semantics, pinned by tests: days is lenient (absent/malformed/≤0 → default, matching both siblings and the REST convention for `depth`/`window`); malformed `since` → 400 (matching the CLI's hard error); parent filter matches ref/UUID/title case-insensitively via enriched parent fields (using `resolveParentFilter` instead would have silently dropped title matching vs both siblings).

## Review

2+ codex rounds, rotated framing. R1 (plain) caught a real ACL finding: the visibility helper reproduced the ungated `visibleCollectionIDs` admin bypass, so a bearer-authed platform admin who is only a restricted member would see unfiltered results. Investigation showed that pattern is **pre-existing and pervasive** (dashboard/bootstrap/items/graph all ungated on main; `reportVisibleCollections` is the one bearer-aware exception) — filed as BUG-1917. Fix in eaaef80, scoped to what this PR owns: standup's direct queries and all of changelog get the bearer-aware gate (mirroring `reportVisibleCollections`, keeping item-grant granularity); `next` and standup's dashboard-derived sections keep dashboard parity and inherit BUG-1917's resolution (asymmetry documented in the file header). The regression test was revert-verified (fails on the ungated code). R2 (cross-surface parity lens) confirmed no divergence in field names, day defaults, since precedence, terminal-status ordering, per-status best-effort behavior, group ordering, or limit values; its only two findings were restatements of the documented-deliberate scoping decisions from R1's fix. Converged.

## Test plan

- [x] `go test ./...` (SQLite) — all green, 14 new endpoint tests incl. bearer-admin scoping regression
- [x] `make test-pg` — full suite green (dual-driver mandatory: endpoints read the store)
- [x] `make lint` — 0 issues
- [x] `npm test` (109/109) / `npm run check` / `npm run build` — green

Refs: TASK-1894, TASK-1916, BUG-1917, TASK-1893

https://claude.ai/code/session_01CL1pBjNpPUX6SWkuAuYXHS
