### PR TITLE
fix(server): bearer-gate visibleCollectionIDs (BUG-1917)

### DIFF
--- a/internal/server/handlers_bootstrap_test.go
+++ b/internal/server/handlers_bootstrap_test.go
@@ -875,3 +875,89 @@ func TestPlaybookSummaryPrefersFirstParagraph(t *testing.T) {
 		t.Errorf("truncated summary missing ellipsis: %q", got)
 	}
 }
+
+// TestBootstrap_AdminBearer_RestrictedMemberIsScoped pins BUG-1917 for the
+// bootstrap endpoint (the agents' primary path — TASK-1379 has it call
+// buildDashboardResponse directly). A platform admin who is only a
+// restricted member (collection_access "specific") of a workspace must be
+// scoped to their actual membership over a bearer token (PAT/CLI/OAuth),
+// while a cookie session keeps the pre-existing unrestricted admin view.
+// Mirrors TestDashboard_AdminBearer_RestrictedMemberIsScoped's fixture.
+func TestBootstrap_AdminBearer_RestrictedMemberIsScoped(t *testing.T) {
+	srv := testServer(t)
+
+	admin, err := srv.store.CreateUser(models.UserCreate{
+		Email: "admin@example.com", Name: "Admin", Password: "correct-horse-battery-staple", Role: "admin",
+	})
+	if err != nil {
+		t.Fatalf("create admin: %v", err)
+	}
+	ws, err := srv.store.CreateWorkspace(models.WorkspaceCreate{Name: "BootstrapBearer", OwnerID: admin.ID})
+	if err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	if err := srv.store.AddWorkspaceMember(ws.ID, admin.ID, "editor"); err != nil {
+		t.Fatalf("add member: %v", err)
+	}
+
+	schema := `{"fields":[{"key":"status","type":"select","options":["open","done"],"default":"open"}]}`
+	visible, err := srv.store.CreateCollection(ws.ID, models.CollectionCreate{
+		Name: "Visible", Slug: "visible", Prefix: "VIS", Schema: schema,
+	})
+	if err != nil {
+		t.Fatalf("create visible collection: %v", err)
+	}
+	if _, err := srv.store.CreateCollection(ws.ID, models.CollectionCreate{
+		Name: "Hidden", Slug: "hidden", Prefix: "HID", Schema: schema,
+	}); err != nil {
+		t.Fatalf("create hidden collection: %v", err)
+	}
+	if err := srv.store.SetMemberCollectionAccess(ws.ID, admin.ID, "specific", []string{visible.ID}); err != nil {
+		t.Fatalf("set member collection access: %v", err)
+	}
+
+	tok, err := srv.store.CreateAPIToken(admin.ID, models.APITokenCreate{
+		Name: "admin-pat", WorkspaceID: ws.ID,
+	}, 0, 0)
+	if err != nil {
+		t.Fatalf("CreateAPIToken: %v", err)
+	}
+
+	hasCollection := func(bs AgentBootstrap, slug string) bool {
+		for _, c := range bs.Collections {
+			if c.Slug == slug {
+				return true
+			}
+		}
+		return false
+	}
+
+	// Bearer path — scoped: only the visible collection shows up.
+	rr := doRequestWithBearer(srv, "GET", "/api/v1/workspaces/"+ws.Slug+"/agent/bootstrap", tok.Token, nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("bearer bootstrap: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var bearerBS AgentBootstrap
+	parseJSON(t, rr, &bearerBS)
+	if hasCollection(bearerBS, "hidden") {
+		t.Errorf("bearer admin bootstrap leaked the hidden collection: %+v", bearerBS.Collections)
+	}
+	if !hasCollection(bearerBS, "visible") {
+		t.Errorf("bearer admin bootstrap missing the visible collection: %+v", bearerBS.Collections)
+	}
+
+	// Cookie path — unrestricted (the pre-existing web UI admin affordance).
+	sessTok, err := srv.store.CreateSession(admin.ID, "web-test", "192.0.2.1", "", webSessionTTL)
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	rr = doRequestWithCookie(srv, "GET", "/api/v1/workspaces/"+ws.Slug+"/agent/bootstrap", nil, sessTok)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("cookie bootstrap: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var cookieBS AgentBootstrap
+	parseJSON(t, rr, &cookieBS)
+	if !hasCollection(cookieBS, "hidden") {
+		t.Errorf("cookie admin bootstrap should be unrestricted (see hidden collection); got %+v", cookieBS.Collections)
+	}
+}

--- a/internal/server/handlers_dashboard_test.go
+++ b/internal/server/handlers_dashboard_test.go
@@ -1250,3 +1250,94 @@ func filterAttention(items []DashboardAttention, typ string) []DashboardAttentio
 	}
 	return result
 }
+
+// TestDashboard_AdminBearer_RestrictedMemberIsScoped pins BUG-1917: a
+// platform admin who is only a restricted member (collection_access
+// "specific") of a workspace gets the full unrestricted dashboard over a
+// cookie session (the pre-existing web UI admin affordance), but must be
+// scoped to their actual membership over a bearer token (PAT/CLI/OAuth) —
+// mirroring the BUG-1616/1617 pattern already enforced for
+// reportVisibleCollections and pinned for SSE/collab in
+// handlers_admin_bearer_gate_test.go. Before this fix, buildDashboardResponse
+// called the ungated visibleCollectionIDs and leaked the hidden collection's
+// items to a bearer-authed admin.
+func TestDashboard_AdminBearer_RestrictedMemberIsScoped(t *testing.T) {
+	srv := testServer(t)
+
+	admin, err := srv.store.CreateUser(models.UserCreate{
+		Email: "admin@example.com", Name: "Admin", Password: "correct-horse-battery-staple", Role: "admin",
+	})
+	if err != nil {
+		t.Fatalf("create admin: %v", err)
+	}
+	ws, err := srv.store.CreateWorkspace(models.WorkspaceCreate{Name: "DashBearer", OwnerID: admin.ID})
+	if err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	if err := srv.store.AddWorkspaceMember(ws.ID, admin.ID, "editor"); err != nil {
+		t.Fatalf("add member: %v", err)
+	}
+
+	schema := `{"fields":[{"key":"status","type":"select","options":["open","done"],"default":"open"}]}`
+	visible, err := srv.store.CreateCollection(ws.ID, models.CollectionCreate{
+		Name: "Visible", Slug: "visible", Prefix: "VIS", Schema: schema,
+	})
+	if err != nil {
+		t.Fatalf("create visible collection: %v", err)
+	}
+	hidden, err := srv.store.CreateCollection(ws.ID, models.CollectionCreate{
+		Name: "Hidden", Slug: "hidden", Prefix: "HID", Schema: schema,
+	})
+	if err != nil {
+		t.Fatalf("create hidden collection: %v", err)
+	}
+	if _, err := srv.store.CreateItem(ws.ID, visible.ID, models.ItemCreate{
+		Title: "Visible item", Fields: `{"status":"open"}`,
+	}); err != nil {
+		t.Fatalf("create visible item: %v", err)
+	}
+	if _, err := srv.store.CreateItem(ws.ID, hidden.ID, models.ItemCreate{
+		Title: "Hidden item", Fields: `{"status":"open"}`,
+	}); err != nil {
+		t.Fatalf("create hidden item: %v", err)
+	}
+	if err := srv.store.SetMemberCollectionAccess(ws.ID, admin.ID, "specific", []string{visible.ID}); err != nil {
+		t.Fatalf("set member collection access: %v", err)
+	}
+
+	tok, err := srv.store.CreateAPIToken(admin.ID, models.APITokenCreate{
+		Name: "admin-pat", WorkspaceID: ws.ID,
+	}, 0, 0)
+	if err != nil {
+		t.Fatalf("CreateAPIToken: %v", err)
+	}
+
+	// Bearer path — scoped to the visible collection only.
+	rr := doRequestWithBearer(srv, "GET", "/api/v1/workspaces/"+ws.Slug+"/dashboard", tok.Token, nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("bearer dashboard: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var bearerResp DashboardResponse
+	parseJSON(t, rr, &bearerResp)
+	if _, ok := bearerResp.Summary.ByCollection["hidden"]; ok {
+		t.Errorf("bearer admin dashboard leaked the hidden collection: %+v", bearerResp.Summary.ByCollection)
+	}
+	if _, ok := bearerResp.Summary.ByCollection["visible"]; !ok {
+		t.Errorf("bearer admin dashboard missing the visible collection: %+v", bearerResp.Summary.ByCollection)
+	}
+
+	// Cookie path — unrestricted (the pre-existing web UI admin affordance).
+	sessTok, err := srv.store.CreateSession(admin.ID, "web-test", "192.0.2.1", "", webSessionTTL)
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	rr = doRequestWithCookie(srv, "GET", "/api/v1/workspaces/"+ws.Slug+"/dashboard", nil, sessTok)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("cookie dashboard: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var cookieResp DashboardResponse
+	parseJSON(t, rr, &cookieResp)
+	if _, ok := cookieResp.Summary.ByCollection["hidden"]; !ok {
+		t.Errorf("cookie admin dashboard should be unrestricted (see hidden collection); got %+v", cookieResp.Summary.ByCollection)
+	}
+}

--- a/internal/server/handlers_graph_test.go
+++ b/internal/server/handlers_graph_test.go
@@ -458,3 +458,95 @@ func TestGraphFocusTruncation(t *testing.T) {
 		t.Errorf("expected node count capped at %d, got %d", maxFocusNodes, len(resp.Nodes))
 	}
 }
+
+// TestGraph_AdminBearer_RestrictedMemberIsScoped pins BUG-1917 for
+// handleGetWorkspaceGraph: a platform admin who is only a restricted member
+// (collection_access "specific") of a workspace gets the full unrestricted
+// graph over a cookie session (the pre-existing web UI admin affordance),
+// but must be scoped to their actual membership over a bearer token
+// (PAT/CLI/OAuth) — the hidden collection's node must not appear, nor leak
+// via a dangling edge endpoint.
+func TestGraph_AdminBearer_RestrictedMemberIsScoped(t *testing.T) {
+	srv := testServer(t)
+
+	admin, err := srv.store.CreateUser(models.UserCreate{
+		Email: "admin@example.com", Name: "Admin", Password: "correct-horse-battery-staple", Role: "admin",
+	})
+	if err != nil {
+		t.Fatalf("create admin: %v", err)
+	}
+	ws, err := srv.store.CreateWorkspace(models.WorkspaceCreate{Name: "GraphBearer", OwnerID: admin.ID})
+	if err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	if err := srv.store.AddWorkspaceMember(ws.ID, admin.ID, "editor"); err != nil {
+		t.Fatalf("add member: %v", err)
+	}
+
+	schema := `{"fields":[{"key":"status","type":"select","options":["open","done"],"default":"open"}]}`
+	visible, err := srv.store.CreateCollection(ws.ID, models.CollectionCreate{
+		Name: "Visible", Slug: "visible", Prefix: "VIS", Schema: schema,
+	})
+	if err != nil {
+		t.Fatalf("create visible collection: %v", err)
+	}
+	hidden, err := srv.store.CreateCollection(ws.ID, models.CollectionCreate{
+		Name: "Hidden", Slug: "hidden", Prefix: "HID", Schema: schema,
+	})
+	if err != nil {
+		t.Fatalf("create hidden collection: %v", err)
+	}
+	visItem, err := srv.store.CreateItem(ws.ID, visible.ID, models.ItemCreate{
+		Title: "Visible item", Fields: `{"status":"open"}`,
+	})
+	if err != nil {
+		t.Fatalf("create visible item: %v", err)
+	}
+	hidItem, err := srv.store.CreateItem(ws.ID, hidden.ID, models.ItemCreate{
+		Title: "Hidden item", Fields: `{"status":"open"}`,
+	})
+	if err != nil {
+		t.Fatalf("create hidden item: %v", err)
+	}
+	visItem.ComputeRef()
+	hidItem.ComputeRef()
+	if err := srv.store.SetMemberCollectionAccess(ws.ID, admin.ID, "specific", []string{visible.ID}); err != nil {
+		t.Fatalf("set member collection access: %v", err)
+	}
+
+	tok, err := srv.store.CreateAPIToken(admin.ID, models.APITokenCreate{
+		Name: "admin-pat", WorkspaceID: ws.ID,
+	}, 0, 0)
+	if err != nil {
+		t.Fatalf("CreateAPIToken: %v", err)
+	}
+
+	// Bearer path — scoped: hidden item's node must not appear.
+	rr := doRequestWithBearer(srv, "GET", "/api/v1/workspaces/"+ws.Slug+"/graph", tok.Token, nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("bearer graph: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var bearerResp GraphResponse
+	parseJSON(t, rr, &bearerResp)
+	if graphNode(bearerResp, hidItem.Ref) != nil {
+		t.Errorf("bearer admin graph leaked the hidden collection's node: %+v", bearerResp.Nodes)
+	}
+	if graphNode(bearerResp, visItem.Ref) == nil {
+		t.Errorf("bearer admin graph missing the visible collection's node: %+v", bearerResp.Nodes)
+	}
+
+	// Cookie path — unrestricted (the pre-existing web UI admin affordance).
+	sessTok, err := srv.store.CreateSession(admin.ID, "web-test", "192.0.2.1", "", webSessionTTL)
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	rr = doRequestWithCookie(srv, "GET", "/api/v1/workspaces/"+ws.Slug+"/graph", nil, sessTok)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("cookie graph: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var cookieResp GraphResponse
+	parseJSON(t, rr, &cookieResp)
+	if graphNode(cookieResp, hidItem.Ref) == nil {
+		t.Errorf("cookie admin graph should be unrestricted (see hidden node); got %+v", cookieResp.Nodes)
+	}
+}

--- a/internal/server/handlers_items_test.go
+++ b/internal/server/handlers_items_test.go
@@ -2312,3 +2312,170 @@ func TestCollectionChildProgress(t *testing.T) {
 		t.Fatalf("restricted/ideas child-progress: expected 200, got %d: %s", rr.Code, rr.Body.String())
 	}
 }
+
+// TestListItems_AdminBearer_RestrictedMemberIsScoped pins BUG-1917 for
+// handleListItems: a platform admin who is only a restricted member
+// (collection_access "specific") of a workspace gets the full unrestricted
+// item list over a cookie session (the pre-existing web UI admin
+// affordance), but must be scoped to their actual membership over a bearer
+// token (PAT/CLI/OAuth). Mirrors handlers_admin_bearer_gate_test.go's
+// fixture idiom.
+func TestListItems_AdminBearer_RestrictedMemberIsScoped(t *testing.T) {
+	srv := testServer(t)
+
+	admin, err := srv.store.CreateUser(models.UserCreate{
+		Email: "admin@example.com", Name: "Admin", Password: "correct-horse-battery-staple", Role: "admin",
+	})
+	if err != nil {
+		t.Fatalf("create admin: %v", err)
+	}
+	ws, err := srv.store.CreateWorkspace(models.WorkspaceCreate{Name: "ItemsBearer", OwnerID: admin.ID})
+	if err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	if err := srv.store.AddWorkspaceMember(ws.ID, admin.ID, "editor"); err != nil {
+		t.Fatalf("add member: %v", err)
+	}
+
+	schema := `{"fields":[{"key":"status","type":"select","options":["open","done"],"default":"open"}]}`
+	visible, err := srv.store.CreateCollection(ws.ID, models.CollectionCreate{
+		Name: "Visible", Slug: "visible", Prefix: "VIS", Schema: schema,
+	})
+	if err != nil {
+		t.Fatalf("create visible collection: %v", err)
+	}
+	hidden, err := srv.store.CreateCollection(ws.ID, models.CollectionCreate{
+		Name: "Hidden", Slug: "hidden", Prefix: "HID", Schema: schema,
+	})
+	if err != nil {
+		t.Fatalf("create hidden collection: %v", err)
+	}
+	if _, err := srv.store.CreateItem(ws.ID, visible.ID, models.ItemCreate{
+		Title: "Visible item", Fields: `{"status":"open"}`,
+	}); err != nil {
+		t.Fatalf("create visible item: %v", err)
+	}
+	if _, err := srv.store.CreateItem(ws.ID, hidden.ID, models.ItemCreate{
+		Title: "Hidden item", Fields: `{"status":"open"}`,
+	}); err != nil {
+		t.Fatalf("create hidden item: %v", err)
+	}
+	if err := srv.store.SetMemberCollectionAccess(ws.ID, admin.ID, "specific", []string{visible.ID}); err != nil {
+		t.Fatalf("set member collection access: %v", err)
+	}
+
+	tok, err := srv.store.CreateAPIToken(admin.ID, models.APITokenCreate{
+		Name: "admin-pat", WorkspaceID: ws.ID,
+	}, 0, 0)
+	if err != nil {
+		t.Fatalf("CreateAPIToken: %v", err)
+	}
+
+	// Bearer path — scoped to the visible collection only.
+	rr := doRequestWithHeaders(srv, "GET", "/api/v1/workspaces/"+ws.Slug+"/items", nil,
+		map[string]string{"Authorization": "Bearer " + tok.Token})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("bearer items: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var bearerItems []models.Item
+	parseJSON(t, rr, &bearerItems)
+	if len(bearerItems) != 1 || bearerItems[0].CollectionSlug != "visible" {
+		t.Fatalf("bearer admin items should be scoped to 1 visible-collection item, got %d: %+v", len(bearerItems), bearerItems)
+	}
+
+	// Cookie path — unrestricted (the pre-existing web UI admin affordance).
+	sessTok, err := srv.store.CreateSession(admin.ID, "web-test", "192.0.2.1", "", 24*time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	rr = doRequestWithCookie(srv, "GET", "/api/v1/workspaces/"+ws.Slug+"/items", nil, sessTok)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("cookie items: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var cookieItems []models.Item
+	parseJSON(t, rr, &cookieItems)
+	if len(cookieItems) != 2 {
+		t.Fatalf("cookie admin items should be unrestricted (2 items), got %d: %+v", len(cookieItems), cookieItems)
+	}
+}
+
+// TestCreateItem_AdminBearer_RestrictedMemberIsScoped pins the WRITE-path
+// side of BUG-1917: handleCreateItem gates its collection-visibility check
+// (handlers_items.go, "Check collection visibility") through the same
+// visibleCollectionIDs helper, so the fix applies symmetrically to writes,
+// not just the read surfaces. A bearer-authed admin who is a restricted
+// member (no grant on the target collection) attempting to create an item
+// there gets the same 404 an equivalent restricted member would see;
+// creating in their visible collection still succeeds. A cookie session
+// keeps the pre-existing unrestricted admin affordance on both collections.
+func TestCreateItem_AdminBearer_RestrictedMemberIsScoped(t *testing.T) {
+	srv := testServer(t)
+
+	admin, err := srv.store.CreateUser(models.UserCreate{
+		Email: "admin@example.com", Name: "Admin", Password: "correct-horse-battery-staple", Role: "admin",
+	})
+	if err != nil {
+		t.Fatalf("create admin: %v", err)
+	}
+	ws, err := srv.store.CreateWorkspace(models.WorkspaceCreate{Name: "CreateItemBearer", OwnerID: admin.ID})
+	if err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	if err := srv.store.AddWorkspaceMember(ws.ID, admin.ID, "editor"); err != nil {
+		t.Fatalf("add member: %v", err)
+	}
+
+	schema := `{"fields":[{"key":"status","type":"select","options":["open","done"],"default":"open"}]}`
+	visible, err := srv.store.CreateCollection(ws.ID, models.CollectionCreate{
+		Name: "Visible", Slug: "visible", Prefix: "VIS", Schema: schema,
+	})
+	if err != nil {
+		t.Fatalf("create visible collection: %v", err)
+	}
+	if _, err := srv.store.CreateCollection(ws.ID, models.CollectionCreate{
+		Name: "Hidden", Slug: "hidden", Prefix: "HID", Schema: schema,
+	}); err != nil {
+		t.Fatalf("create hidden collection: %v", err)
+	}
+	if err := srv.store.SetMemberCollectionAccess(ws.ID, admin.ID, "specific", []string{visible.ID}); err != nil {
+		t.Fatalf("set member collection access: %v", err)
+	}
+
+	tok, err := srv.store.CreateAPIToken(admin.ID, models.APITokenCreate{
+		Name: "admin-pat", WorkspaceID: ws.ID,
+	}, 0, 0)
+	if err != nil {
+		t.Fatalf("CreateAPIToken: %v", err)
+	}
+
+	// Bearer admin creating in the HIDDEN collection (outside their
+	// membership grant) must be rejected, same as a restricted member.
+	rr := doRequestWithHeaders(srv, "POST", "/api/v1/workspaces/"+ws.Slug+"/collections/hidden/items",
+		map[string]interface{}{"title": "Should be blocked", "fields": `{"status":"open"}`},
+		map[string]string{"Authorization": "Bearer " + tok.Token},
+	)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("bearer admin create in hidden collection: expected 404, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	// Bearer admin creating in their VISIBLE collection still succeeds.
+	rr = doRequestWithHeaders(srv, "POST", "/api/v1/workspaces/"+ws.Slug+"/collections/visible/items",
+		map[string]interface{}{"title": "Should succeed", "fields": `{"status":"open"}`},
+		map[string]string{"Authorization": "Bearer " + tok.Token},
+	)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("bearer admin create in visible collection: expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	// Cookie admin — unrestricted, can create in the hidden collection too
+	// (the pre-existing web UI admin affordance).
+	sessTok, err := srv.store.CreateSession(admin.ID, "web-test", "192.0.2.1", "", 24*time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	rr = doRequestWithCookie(srv, "POST", "/api/v1/workspaces/"+ws.Slug+"/collections/hidden/items",
+		map[string]interface{}{"title": "Cookie admin can create here", "fields": `{"status":"open"}`}, sessTok)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("cookie admin create in hidden collection: expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+}

--- a/internal/server/handlers_project_intel.go
+++ b/internal/server/handlers_project_intel.go
@@ -26,19 +26,16 @@ import (
 // changes here need a matching change (or an explicit noted divergence) in
 // both siblings above.
 //
-// Known asymmetry (TASK-1894 codex round 1): handleGetProjectStandup scopes
-// its own completed/in_progress ListItems calls through the bearer-aware
-// projectIntelVisibility (see below), but its dashboard-derived sections
-// (blockers, suggested_next) come from buildDashboardResponse, which is
-// NOT bearer-aware — same gap as handleGetProjectNext, which deliberately
-// stays on buildDashboardResponse's ungated visibility so it keeps exact
-// parity with dashboard.suggested_next (gating next but not dashboard would
-// break that parity for bearer admins and diverge next from both siblings).
-// Net effect: a bearer-authed platform admin who is only a restricted member
-// of the workspace gets correctly-scoped completed/in_progress from standup,
-// but ungated blockers/suggested_next — until BUG-1917 (the
-// visibleCollectionIDs bearer-gate gap) is fixed for buildDashboardResponse
-// itself, at which point this asymmetry resolves.
+// Asymmetry resolved (TASK-1894 codex round 1 / BUG-1917): handleGetProjectStandup
+// scopes its own completed/in_progress ListItems calls through
+// projectIntelVisibility (see below), and its dashboard-derived sections
+// (blockers, suggested_next) come from buildDashboardResponse — both now sit
+// on the same bearer-gated visibleCollectionIDs (server.go), so a bearer-authed
+// platform admin who is only a restricted member of the workspace gets
+// correctly-scoped completed/in_progress AND blockers/suggested_next from
+// standup. handleGetProjectNext stays on buildDashboardResponse's visibility
+// so it keeps exact parity with dashboard.suggested_next; that parity was the
+// reason the two couldn't diverge on gating in the first place.
 
 // parseDaysParam reads a "days" query param with a fallback default. Mirrors
 // the CLI's `n > 0` gate (standupCmd/changelogCmd flag defaults) and the MCP
@@ -74,28 +71,10 @@ func itemMatchesParentFilter(item models.Item, parent string) bool {
 	return false
 }
 
-// bearerAwareVisibleCollectionIDs mirrors visibleCollectionIDs (server.go)
-// but closes the gap reportVisibleCollections (handlers_reports.go) already
-// closes for the report endpoint (the BUG-1616/1617 pattern — see its doc
-// comment and handlers_admin_bearer_gate_test.go): a platform admin
-// authenticated via a bearer token (PAT/CLI/OAuth) who is only a restricted
-// member of THIS workspace must be scoped to their real membership, not
-// granted the unrestricted admin view a cookie-session admin gets.
-// visibleCollectionIDs itself — and everything still built directly on it
-// (buildDashboardResponse, handleListItems, handleGetWorkspaceGraph) — does
-// NOT have this gate; that's BUG-1917, tracked separately from this fix.
-func (s *Server) bearerAwareVisibleCollectionIDs(r *http.Request, workspaceID string) ([]string, error) {
-	user := currentUser(r)
-	if user == nil || (user.Role == "admin" && !isBearerAuth(r)) {
-		return nil, nil // unrestricted, same as visibleCollectionIDs' nil-user/admin branch
-	}
-	return s.store.VisibleCollectionIDs(workspaceID, user.ID)
-}
-
 // projectIntelVisibility computes the (collectionIDs, itemIDs)
 // visibility-scoping pair for the item-list calls the standup/changelog
 // handlers make directly (outside of buildDashboardResponse), using
-// bearerAwareVisibleCollectionIDs rather than visibleCollectionIDs.
+// visibleCollectionIDs (server.go), which is bearer-gated (BUG-1917).
 //
 // This does NOT delegate to reportVisibleCollections despite the shared
 // admin-bypass gate: reportVisibleCollections returns (scopeToVisible bool,
@@ -112,7 +91,7 @@ func (s *Server) bearerAwareVisibleCollectionIDs(r *http.Request, workspaceID st
 // "no collection filtering", identically to visibleCollectionIDs' contract,
 // so no separate branch is needed for the all-access-member case.
 func (s *Server) projectIntelVisibility(r *http.Request, workspaceID string) (collIDs, itemIDs []string, err error) {
-	visibleIDs, err := s.bearerAwareVisibleCollectionIDs(r, workspaceID)
+	visibleIDs, err := s.visibleCollectionIDs(r, workspaceID)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/server/handlers_project_intel_test.go
+++ b/internal/server/handlers_project_intel_test.go
@@ -435,6 +435,15 @@ func TestProjectIntelEndpoints_BearerAdminRestrictedMemberIsScoped(t *testing.T)
 	}); err != nil {
 		t.Fatalf("create hidden item: %v", err)
 	}
+	// An overdue task in the hidden collection surfaces in
+	// dashboard.attention (type "overdue") and, via buildDashboardResponse,
+	// in standup.blockers — the exact section the file-header "Known
+	// asymmetry" comment called out as staying ungated until BUG-1917.
+	if _, err := srv.store.CreateItem(ws.ID, hidden.ID, models.ItemCreate{
+		Title: "Hidden overdue blocker", Fields: `{"status":"open","due_date":"2020-01-01"}`,
+	}); err != nil {
+		t.Fatalf("create hidden overdue item: %v", err)
+	}
 	if err := srv.store.SetMemberCollectionAccess(ws.ID, admin.ID, "specific", []string{visible.ID}); err != nil {
 		t.Fatalf("set access: %v", err)
 	}
@@ -474,9 +483,18 @@ func TestProjectIntelEndpoints_BearerAdminRestrictedMemberIsScoped(t *testing.T)
 		t.Fatalf("bearer admin standup.completed should be scoped to the visible item (%s), got %+v",
 			visibleItem.Ref, standup.Completed)
 	}
+	// BUG-1917: standup's dashboard-derived blockers section must now be
+	// scoped too — this is the asymmetry the file-header comment on
+	// handlers_project_intel.go documented until this fix.
+	for _, b := range standup.Blockers {
+		if b.Title == "Hidden overdue blocker" {
+			t.Fatalf("bearer admin standup.blockers leaked the hidden collection's overdue item: %+v", standup.Blockers)
+		}
+	}
 
 	// Cookie admin → unrestricted (the pre-existing web UI admin affordance):
-	// changelog sees both completions.
+	// changelog sees both completions, and standup.blockers includes the
+	// hidden collection's overdue item too (checked below).
 	sessTok, err := srv.store.CreateSession(admin.ID, "web-test", "192.0.2.1", "", webSessionTTL)
 	if err != nil {
 		t.Fatalf("CreateSession: %v", err)
@@ -488,5 +506,20 @@ func TestProjectIntelEndpoints_BearerAdminRestrictedMemberIsScoped(t *testing.T)
 	parseJSON(t, rr, &changelog)
 	if changelog.Total != 2 {
 		t.Fatalf("cookie admin changelog should be unrestricted (2 items), got %d (%+v)", changelog.Total, changelog)
+	}
+
+	rr = doRequestWithCookie(srv, "GET", "/api/v1/workspaces/"+ws.Slug+"/standup", nil, sessTok)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("cookie standup: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	parseJSON(t, rr, &standup)
+	foundHiddenBlocker := false
+	for _, b := range standup.Blockers {
+		if b.Title == "Hidden overdue blocker" {
+			foundHiddenBlocker = true
+		}
+	}
+	if !foundHiddenBlocker {
+		t.Fatalf("cookie admin standup.blockers should be unrestricted (see hidden overdue item); got %+v", standup.Blockers)
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1632,12 +1632,20 @@ func (s *Server) getWorkspace(w http.ResponseWriter, r *http.Request) (*models.W
 
 // visibleCollectionIDs returns the set of collection IDs the current user can
 // see in the given workspace. Returns nil if the user has "all" access (no
-// filtering needed), or a non-nil slice for "specific" access. Admins and
-// unauthenticated users (fresh install) always get nil (all access).
+// filtering needed), or a non-nil slice for "specific" access. Unauthenticated
+// users (fresh install) always get nil (all access), as do platform admins —
+// but ONLY over a cookie session. Bearer-authed admins (CLI / PAT / MCP —
+// detected via isBearerAuth) fall through to the store lookup and are scoped
+// to their actual membership, matching RequireWorkspaceAccess's admin-bypass
+// suppression for bearer auth (BUG-1616/1617) and reportVisibleCollections'
+// gate (handlers_reports.go). Fixes BUG-1917 — this was the last of the
+// bearer-gate consumers (buildDashboardResponse, handleListItems, the graph
+// handler, handleCreateItem's collection-visibility check, and every other
+// direct caller) still granting a bearer admin an unrestricted view.
 func (s *Server) visibleCollectionIDs(r *http.Request, workspaceID string) ([]string, error) {
 	user := currentUser(r)
-	if user == nil || user.Role == "admin" {
-		return nil, nil // No filtering for admins or unauthenticated
+	if user == nil || (user.Role == "admin" && !isBearerAuth(r)) {
+		return nil, nil // No filtering for admins (cookie session) or unauthenticated
 	}
 	return s.store.VisibleCollectionIDs(workspaceID, user.ID)
 }


### PR DESCRIPTION
## Summary

Fixes BUG-1917: `visibleCollectionIDs` granted an unrestricted view to ANY platform admin, ignoring how they authenticated. Per the BUG-1616/1617 intent (and `reportVisibleCollections`' existing gate), bearer-authed admins (CLI / PAT / MCP) are supposed to fall through to membership semantics — `RequireWorkspaceAccess` already suppresses their admin bypass at the access layer, but the visibility helper behind ~30 handler call sites didn't, so a bearer admin who is only a restricted member saw (and could create into) all collections.

**The fix is one line** — the shared helper gains the same gate as `reportVisibleCollections`:

```go
if user == nil || (user.Role == "admin" && !isBearerAuth(r)) {
```

**Observable behavior change:** bearer-authed platform admins who are not full-access members of a workspace are now scoped to their actual membership on dashboard, bootstrap, items list/create, graph, search, views, activity, playbooks, stars, links, bulk ops, and the TASK-1894 project-intel endpoints (previously unrestricted). Cookie-session admins, unauthenticated local instances, and full-access members are unchanged by construction.

Also folds away `bearerAwareVisibleCollectionIDs` (TASK-1894's per-file stopgap, now redundant) and resolves the documented standup asymmetry — `blockers`/`suggested_next` are now scoped like `completed`/`in_progress`.

## Known remaining gap (filed, not in this PR)

`checkItemVisible` (single-item get/update/delete by ref) has its own ungated admin bypass — and refs are sequential/guessable, so the list-level scoping here is bypassable via direct ref enumeration until that lands. Filed as **BUG-1918** with the same fix shape; kept separate per one-PR-per-concern (different helper, different consumer audit).

## Review

Consumer audit at recon: all ~30 call sites use the return value as a plain collection-ID filter (none branch on nil for a second decision); the paired `guestResourceFilter` was already bearer-gated (BUG-1617), so the filter pair is now consistent.

Codex rounds, rotated framing: R1 (plain)'s only finding was the `checkItemVisible` sibling gap — independently confirming BUG-1918 (implementer's audit had already surfaced it; filed before review). R2 (who-relied-on-the-old-default lens) found no regressions in seeding, workspace/collection creation, or test masking; its only finding was BUG-1918 again, with concrete consumer paths (direct-ref GET, MCP `pad_item.get`/`pad_item.export`, artifact export) now appended to that bug's test plan. Converged.

## Test plan

- [x] 6 new/extended tests mirroring `handlers_admin_bearer_gate_test.go`'s idiom: dashboard, bootstrap, items list, item create (write path), graph, project-intel standup blockers — each asserting bearer-admin-restricted-member is scoped AND cookie-admin stays unrestricted
- [x] Revert-verified: with the gate removed, the dashboard test fails with the hidden-collection leak; restored, passes
- [x] `go test ./...` (SQLite) all green
- [x] `make test-pg` full suite green
- [x] `make lint` 0 issues
- [x] Frontend untouched (Go-only diff)

Refs: BUG-1917, BUG-1918, BUG-1616, BUG-1617, TASK-1894

https://claude.ai/code/session_01CL1pBjNpPUX6SWkuAuYXHS
