### PR TITLE
fix(server): gate share-link and grant minting on item/collection visibility (BUG-1920)

### DIFF
--- a/internal/server/handlers_grant_visibility_test.go
+++ b/internal/server/handlers_grant_visibility_test.go
@@ -1,0 +1,325 @@
+package server
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// restrictedOwnerVisibilityFixture seeds a workspace-role "owner" member who
+// is independently restricted via collection_access="specific" (BUG-1920:
+// requireMinRole("owner") only checks workspaceRole, which handleSetMember-
+// CollectionAccess can scope down regardless of role — there is no role
+// exclusion). One collection/item pair sits inside the member's visible
+// slice, one outside it. Provides both a bearer PAT and a session cookie
+// for the same user so every auth class is covered, mirroring
+// bearerGateItemFixture's shape (handlers_items_test.go, BUG-1918).
+type restrictedOwnerVisibilityFixture struct {
+	srv          *Server
+	ws           *models.Workspace
+	hiddenColl   *models.Collection
+	visibleColl  *models.Collection
+	hiddenItem   *models.Item
+	visibleItem  *models.Item
+	bearerToken  string
+	sessionToken string
+}
+
+func newRestrictedOwnerVisibilityFixture(t *testing.T) *restrictedOwnerVisibilityFixture {
+	t.Helper()
+	srv := testServer(t)
+
+	owner, err := srv.store.CreateUser(models.UserCreate{
+		Email: "restricted-owner@example.com", Name: "Restricted Owner", Username: "restricted-owner",
+		Password: "pw-test-12345",
+	})
+	if err != nil {
+		t.Fatalf("create owner: %v", err)
+	}
+	ws, err := srv.store.CreateWorkspace(models.WorkspaceCreate{Name: "GrantVisibility", OwnerID: owner.ID})
+	if err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	if err := srv.store.AddWorkspaceMember(ws.ID, owner.ID, "owner"); err != nil {
+		t.Fatalf("add member: %v", err)
+	}
+
+	schema := `{"fields":[{"key":"status","type":"select","options":["open","done"],"default":"open"}]}`
+	visible, err := srv.store.CreateCollection(ws.ID, models.CollectionCreate{
+		Name: "Visible", Slug: "visible", Prefix: "VIS", Schema: schema,
+	})
+	if err != nil {
+		t.Fatalf("create visible collection: %v", err)
+	}
+	hidden, err := srv.store.CreateCollection(ws.ID, models.CollectionCreate{
+		Name: "Hidden", Slug: "hidden", Prefix: "HID", Schema: schema,
+	})
+	if err != nil {
+		t.Fatalf("create hidden collection: %v", err)
+	}
+	visibleItem, err := srv.store.CreateItem(ws.ID, visible.ID, models.ItemCreate{
+		Title: "Visible item", Fields: `{"status":"open"}`,
+	})
+	if err != nil {
+		t.Fatalf("create visible item: %v", err)
+	}
+	hiddenItem, err := srv.store.CreateItem(ws.ID, hidden.ID, models.ItemCreate{
+		Title: "Hidden item", Fields: `{"status":"open"}`,
+	})
+	if err != nil {
+		t.Fatalf("create hidden item: %v", err)
+	}
+
+	// Scope the owner to "visible" only. member_collection_access has no
+	// role exclusion, so a workspace-role "owner" is restricted exactly
+	// like any other member.
+	if err := srv.store.SetMemberCollectionAccess(ws.ID, owner.ID, "specific", []string{visible.ID}); err != nil {
+		t.Fatalf("SetMemberCollectionAccess: %v", err)
+	}
+
+	tok, err := srv.store.CreateAPIToken(owner.ID, models.APITokenCreate{
+		Name: "owner-pat", WorkspaceID: ws.ID,
+	}, 0, 0)
+	if err != nil {
+		t.Fatalf("CreateAPIToken: %v", err)
+	}
+	sessTok, err := srv.store.CreateSession(owner.ID, "go-test", "192.0.2.1", "", 24*time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	return &restrictedOwnerVisibilityFixture{
+		srv: srv, ws: ws,
+		hiddenColl: hidden, visibleColl: visible,
+		hiddenItem: hiddenItem, visibleItem: visibleItem,
+		bearerToken: tok.Token, sessionToken: sessTok,
+	}
+}
+
+func (f *restrictedOwnerVisibilityFixture) bearerHeaders() map[string]string {
+	return map[string]string{"Authorization": "Bearer " + f.bearerToken}
+}
+
+// ─── handleCreateItemShareLink ──────────────────────────────────────────
+
+// TestCreateItemShareLink_RestrictedOwner_HiddenCollection404 pins BUG-1920:
+// a restricted owner can no longer mint a public share-link token for an
+// item in a collection hidden from them, over either auth class. An
+// unrestricted (visible-collection) item still succeeds.
+func TestCreateItemShareLink_RestrictedOwner_HiddenCollection404(t *testing.T) {
+	f := newRestrictedOwnerVisibilityFixture(t)
+
+	path := "/api/v1/workspaces/" + f.ws.Slug + "/items/" + f.hiddenItem.Slug + "/share-links"
+	rr := doRequestWithHeaders(f.srv, "POST", path, map[string]interface{}{}, f.bearerHeaders())
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("bearer restricted owner create share-link on hidden item: expected 404, got %d: %s", rr.Code, rr.Body.String())
+	}
+	rr = doRequestWithCookie(f.srv, "POST", path, map[string]interface{}{}, f.sessionToken)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("session restricted owner create share-link on hidden item: expected 404, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	visPath := "/api/v1/workspaces/" + f.ws.Slug + "/items/" + f.visibleItem.Slug + "/share-links"
+	rr = doRequestWithHeaders(f.srv, "POST", visPath, map[string]interface{}{}, f.bearerHeaders())
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("bearer restricted owner create share-link on visible item: expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+// TestListItemShareLinks_RestrictedOwner_HiddenCollection404 pins the
+// list-side of BUG-1920.
+func TestListItemShareLinks_RestrictedOwner_HiddenCollection404(t *testing.T) {
+	f := newRestrictedOwnerVisibilityFixture(t)
+
+	path := "/api/v1/workspaces/" + f.ws.Slug + "/items/" + f.hiddenItem.Slug + "/share-links"
+	rr := doRequestWithHeaders(f.srv, "GET", path, nil, f.bearerHeaders())
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("bearer restricted owner list share-links on hidden item: expected 404, got %d: %s", rr.Code, rr.Body.String())
+	}
+	rr = doRequestWithCookie(f.srv, "GET", path, nil, f.sessionToken)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("session restricted owner list share-links on hidden item: expected 404, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	visPath := "/api/v1/workspaces/" + f.ws.Slug + "/items/" + f.visibleItem.Slug + "/share-links"
+	rr = doRequestWithHeaders(f.srv, "GET", visPath, nil, f.bearerHeaders())
+	if rr.Code != http.StatusOK {
+		t.Fatalf("bearer restricted owner list share-links on visible item: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+// ─── handleCreateCollectionShareLink / handleListCollectionShareLinks ──
+
+// TestCollectionShareLinks_RestrictedOwner_HiddenCollection404 pins the
+// collection-level twin of BUG-1920: minting or listing a share link for a
+// collection hidden from the restricted owner must 404, over either auth
+// class.
+func TestCollectionShareLinks_RestrictedOwner_HiddenCollection404(t *testing.T) {
+	f := newRestrictedOwnerVisibilityFixture(t)
+
+	createPath := "/api/v1/workspaces/" + f.ws.Slug + "/collections/" + f.hiddenColl.Slug + "/share-links"
+	rr := doRequestWithHeaders(f.srv, "POST", createPath, map[string]interface{}{}, f.bearerHeaders())
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("bearer restricted owner create collection share-link on hidden collection: expected 404, got %d: %s", rr.Code, rr.Body.String())
+	}
+	rr = doRequestWithCookie(f.srv, "POST", createPath, map[string]interface{}{}, f.sessionToken)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("session restricted owner create collection share-link on hidden collection: expected 404, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	listPath := "/api/v1/workspaces/" + f.ws.Slug + "/collections/" + f.hiddenColl.Slug + "/share-links"
+	rr = doRequestWithHeaders(f.srv, "GET", listPath, nil, f.bearerHeaders())
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("bearer restricted owner list collection share-links on hidden collection: expected 404, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	visCreatePath := "/api/v1/workspaces/" + f.ws.Slug + "/collections/" + f.visibleColl.Slug + "/share-links"
+	rr = doRequestWithHeaders(f.srv, "POST", visCreatePath, map[string]interface{}{}, f.bearerHeaders())
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("bearer restricted owner create collection share-link on visible collection: expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+// ─── handleCreateItemGrant / handleListItemGrants ──────────────────────
+
+// TestCreateItemGrant_RestrictedOwner_HiddenCollection404 pins BUG-1920 for
+// item grants.
+func TestCreateItemGrant_RestrictedOwner_HiddenCollection404(t *testing.T) {
+	f := newRestrictedOwnerVisibilityFixture(t)
+
+	grantee, err := f.srv.store.CreateUser(models.UserCreate{
+		Email: "grantee@example.com", Name: "Grantee", Password: "pw-test-12345",
+	})
+	if err != nil {
+		t.Fatalf("create grantee: %v", err)
+	}
+
+	path := "/api/v1/workspaces/" + f.ws.Slug + "/items/" + f.hiddenItem.Slug + "/grants"
+	body := map[string]interface{}{"user_id": grantee.ID, "permission": "view"}
+	rr := doRequestWithHeaders(f.srv, "POST", path, body, f.bearerHeaders())
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("bearer restricted owner create item grant on hidden item: expected 404, got %d: %s", rr.Code, rr.Body.String())
+	}
+	rr = doRequestWithCookie(f.srv, "POST", path, body, f.sessionToken)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("session restricted owner create item grant on hidden item: expected 404, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	visPath := "/api/v1/workspaces/" + f.ws.Slug + "/items/" + f.visibleItem.Slug + "/grants"
+	rr = doRequestWithHeaders(f.srv, "POST", visPath, body, f.bearerHeaders())
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("bearer restricted owner create item grant on visible item: expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+// TestListItemGrants_RestrictedOwner_HiddenCollection404 pins the list-side
+// of BUG-1920 for item grants.
+func TestListItemGrants_RestrictedOwner_HiddenCollection404(t *testing.T) {
+	f := newRestrictedOwnerVisibilityFixture(t)
+
+	path := "/api/v1/workspaces/" + f.ws.Slug + "/items/" + f.hiddenItem.Slug + "/grants"
+	rr := doRequestWithHeaders(f.srv, "GET", path, nil, f.bearerHeaders())
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("bearer restricted owner list item grants on hidden item: expected 404, got %d: %s", rr.Code, rr.Body.String())
+	}
+	rr = doRequestWithCookie(f.srv, "GET", path, nil, f.sessionToken)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("session restricted owner list item grants on hidden item: expected 404, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	visPath := "/api/v1/workspaces/" + f.ws.Slug + "/items/" + f.visibleItem.Slug + "/grants"
+	rr = doRequestWithHeaders(f.srv, "GET", visPath, nil, f.bearerHeaders())
+	if rr.Code != http.StatusOK {
+		t.Fatalf("bearer restricted owner list item grants on visible item: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+// ─── handleCreateCollectionGrant / handleListCollectionGrants ──────────
+
+// TestCollectionGrants_RestrictedOwner_HiddenCollection404 pins the
+// collection-level twin of BUG-1920 for grants.
+func TestCollectionGrants_RestrictedOwner_HiddenCollection404(t *testing.T) {
+	f := newRestrictedOwnerVisibilityFixture(t)
+
+	grantee, err := f.srv.store.CreateUser(models.UserCreate{
+		Email: "grantee@example.com", Name: "Grantee", Password: "pw-test-12345",
+	})
+	if err != nil {
+		t.Fatalf("create grantee: %v", err)
+	}
+
+	createPath := "/api/v1/workspaces/" + f.ws.Slug + "/collections/" + f.hiddenColl.Slug + "/grants"
+	body := map[string]interface{}{"user_id": grantee.ID, "permission": "view"}
+	rr := doRequestWithHeaders(f.srv, "POST", createPath, body, f.bearerHeaders())
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("bearer restricted owner create collection grant on hidden collection: expected 404, got %d: %s", rr.Code, rr.Body.String())
+	}
+	rr = doRequestWithCookie(f.srv, "POST", createPath, body, f.sessionToken)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("session restricted owner create collection grant on hidden collection: expected 404, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	listPath := "/api/v1/workspaces/" + f.ws.Slug + "/collections/" + f.hiddenColl.Slug + "/grants"
+	rr = doRequestWithHeaders(f.srv, "GET", listPath, nil, f.bearerHeaders())
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("bearer restricted owner list collection grants on hidden collection: expected 404, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	visCreatePath := "/api/v1/workspaces/" + f.ws.Slug + "/collections/" + f.visibleColl.Slug + "/grants"
+	rr = doRequestWithHeaders(f.srv, "POST", visCreatePath, body, f.bearerHeaders())
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("bearer restricted owner create collection grant on visible collection: expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+// ─── Layering: requireMinRole (403) must run BEFORE visibility (404) ───
+
+// TestItemShareLinksAndGrants_NonOwner_403BeforeVisibility pins the
+// dispatcher-required layering: a non-owner member gets 403 from
+// requireMinRole regardless of item visibility — the visibility check
+// (404) never even runs for them. Exercised against the hidden item so a
+// regression that swapped the check order (visibility before role) would
+// surface as an incorrect 404 here instead of the expected 403.
+func TestItemShareLinksAndGrants_NonOwner_403BeforeVisibility(t *testing.T) {
+	f := newRestrictedOwnerVisibilityFixture(t)
+
+	editor, err := f.srv.store.CreateUser(models.UserCreate{
+		Email: "editor@example.com", Name: "Editor", Password: "pw-test-12345",
+	})
+	if err != nil {
+		t.Fatalf("create editor: %v", err)
+	}
+	if err := f.srv.store.AddWorkspaceMember(f.ws.ID, editor.ID, "editor"); err != nil {
+		t.Fatalf("add editor member: %v", err)
+	}
+	editorTok, err := f.srv.store.CreateAPIToken(editor.ID, models.APITokenCreate{
+		Name: "editor-pat", WorkspaceID: f.ws.ID,
+	}, 0, 0)
+	if err != nil {
+		t.Fatalf("CreateAPIToken editor: %v", err)
+	}
+	editorHeaders := map[string]string{"Authorization": "Bearer " + editorTok.Token}
+
+	cases := []struct {
+		name   string
+		method string
+		path   string
+	}{
+		{"create item share link", "POST", "/api/v1/workspaces/" + f.ws.Slug + "/items/" + f.hiddenItem.Slug + "/share-links"},
+		{"list item share links", "GET", "/api/v1/workspaces/" + f.ws.Slug + "/items/" + f.hiddenItem.Slug + "/share-links"},
+		{"create item grant", "POST", "/api/v1/workspaces/" + f.ws.Slug + "/items/" + f.hiddenItem.Slug + "/grants"},
+		{"list item grants", "GET", "/api/v1/workspaces/" + f.ws.Slug + "/items/" + f.hiddenItem.Slug + "/grants"},
+		{"create collection share link", "POST", "/api/v1/workspaces/" + f.ws.Slug + "/collections/" + f.hiddenColl.Slug + "/share-links"},
+		{"list collection share links", "GET", "/api/v1/workspaces/" + f.ws.Slug + "/collections/" + f.hiddenColl.Slug + "/share-links"},
+		{"create collection grant", "POST", "/api/v1/workspaces/" + f.ws.Slug + "/collections/" + f.hiddenColl.Slug + "/grants"},
+		{"list collection grants", "GET", "/api/v1/workspaces/" + f.ws.Slug + "/collections/" + f.hiddenColl.Slug + "/grants"},
+	}
+	for _, tc := range cases {
+		rr := doRequestWithHeaders(f.srv, tc.method, tc.path, map[string]interface{}{}, editorHeaders)
+		if rr.Code != http.StatusForbidden {
+			t.Errorf("%s: editor (non-owner) expected 403, got %d: %s", tc.name, rr.Code, rr.Body.String())
+		}
+	}
+}

--- a/internal/server/handlers_grant_visibility_test.go
+++ b/internal/server/handlers_grant_visibility_test.go
@@ -19,6 +19,7 @@ import (
 type restrictedOwnerVisibilityFixture struct {
 	srv          *Server
 	ws           *models.Workspace
+	ownerID      string
 	hiddenColl   *models.Collection
 	visibleColl  *models.Collection
 	hiddenItem   *models.Item
@@ -91,7 +92,7 @@ func newRestrictedOwnerVisibilityFixture(t *testing.T) *restrictedOwnerVisibilit
 	}
 
 	return &restrictedOwnerVisibilityFixture{
-		srv: srv, ws: ws,
+		srv: srv, ws: ws, ownerID: owner.ID,
 		hiddenColl: hidden, visibleColl: visible,
 		hiddenItem: hiddenItem, visibleItem: visibleItem,
 		bearerToken: tok.Token, sessionToken: sessTok,
@@ -100,6 +101,20 @@ func newRestrictedOwnerVisibilityFixture(t *testing.T) *restrictedOwnerVisibilit
 
 func (f *restrictedOwnerVisibilityFixture) bearerHeaders() map[string]string {
 	return map[string]string{"Authorization": "Bearer " + f.bearerToken}
+}
+
+// grantHiddenItemToOwner gives the fixture's restricted owner an item-level
+// grant on the hidden item, independent of their collection_access
+// restriction — the item-grant-only scenario from BUG-1920's codex R2
+// follow-up. VisibleCollectionIDs (workspace_members.go) folds
+// item-grant-derived collections into the nav-lenient visible set, but
+// requireCollectionFullyVisible must NOT treat an item grant as full access
+// to the collection it lives in.
+func (f *restrictedOwnerVisibilityFixture) grantHiddenItemToOwner(t *testing.T) {
+	t.Helper()
+	if _, err := f.srv.store.CreateItemGrant(f.ws.ID, f.hiddenItem.ID, f.ownerID, "view", f.ownerID); err != nil {
+		t.Fatalf("CreateItemGrant hidden item to owner: %v", err)
+	}
 }
 
 // ─── handleCreateItemShareLink ──────────────────────────────────────────
@@ -271,6 +286,94 @@ func TestCollectionGrants_RestrictedOwner_HiddenCollection404(t *testing.T) {
 	rr = doRequestWithHeaders(f.srv, "POST", visCreatePath, body, f.bearerHeaders())
 	if rr.Code != http.StatusCreated {
 		t.Fatalf("bearer restricted owner create collection grant on visible collection: expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+// ─── Item-grant-only must NOT promote to collection-wide access ───────
+
+// TestCollectionShareLinksAndGrants_ItemGrantOnly_HiddenCollection404 pins
+// codex R2's follow-up finding: VisibleCollectionIDs folds in collections
+// that are visible ONLY via an item-level grant ("so the collection appears
+// in navigation" — workspace_members.go), which made the original
+// requireCollectionVisible pass for a restricted owner holding nothing more
+// than an item grant on ONE item inside the hidden collection — letting
+// them mint/list a share link or grant for the ENTIRE hidden collection.
+// requireCollectionFullyVisible must narrow to full-collection-access
+// semantics and 404 here, over both auth classes, while the SAME owner's
+// item-level operations on the granted item itself keep working (an item
+// grant legitimately entitles the holder to act on that item).
+func TestCollectionShareLinksAndGrants_ItemGrantOnly_HiddenCollection404(t *testing.T) {
+	f := newRestrictedOwnerVisibilityFixture(t)
+	f.grantHiddenItemToOwner(t)
+
+	grantee, err := f.srv.store.CreateUser(models.UserCreate{
+		Email: "grantee@example.com", Name: "Grantee", Password: "pw-test-12345",
+	})
+	if err != nil {
+		t.Fatalf("create grantee: %v", err)
+	}
+	grantBody := map[string]interface{}{"user_id": grantee.ID, "permission": "view"}
+
+	// Collection-level share link create + list on the hidden collection:
+	// item grant on hiddenItem must NOT qualify as full collection access.
+	collSharePath := "/api/v1/workspaces/" + f.ws.Slug + "/collections/" + f.hiddenColl.Slug + "/share-links"
+	rr := doRequestWithHeaders(f.srv, "POST", collSharePath, map[string]interface{}{}, f.bearerHeaders())
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("bearer item-grant-only owner create collection share-link on hidden collection: expected 404, got %d: %s", rr.Code, rr.Body.String())
+	}
+	rr = doRequestWithCookie(f.srv, "POST", collSharePath, map[string]interface{}{}, f.sessionToken)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("session item-grant-only owner create collection share-link on hidden collection: expected 404, got %d: %s", rr.Code, rr.Body.String())
+	}
+	rr = doRequestWithHeaders(f.srv, "GET", collSharePath, nil, f.bearerHeaders())
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("bearer item-grant-only owner list collection share-links on hidden collection: expected 404, got %d: %s", rr.Code, rr.Body.String())
+	}
+	rr = doRequestWithCookie(f.srv, "GET", collSharePath, nil, f.sessionToken)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("session item-grant-only owner list collection share-links on hidden collection: expected 404, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	// Collection-level grant create + list on the hidden collection: same.
+	collGrantPath := "/api/v1/workspaces/" + f.ws.Slug + "/collections/" + f.hiddenColl.Slug + "/grants"
+	rr = doRequestWithHeaders(f.srv, "POST", collGrantPath, grantBody, f.bearerHeaders())
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("bearer item-grant-only owner create collection grant on hidden collection: expected 404, got %d: %s", rr.Code, rr.Body.String())
+	}
+	rr = doRequestWithCookie(f.srv, "POST", collGrantPath, grantBody, f.sessionToken)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("session item-grant-only owner create collection grant on hidden collection: expected 404, got %d: %s", rr.Code, rr.Body.String())
+	}
+	rr = doRequestWithHeaders(f.srv, "GET", collGrantPath, nil, f.bearerHeaders())
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("bearer item-grant-only owner list collection grants on hidden collection: expected 404, got %d: %s", rr.Code, rr.Body.String())
+	}
+	rr = doRequestWithCookie(f.srv, "GET", collGrantPath, nil, f.sessionToken)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("session item-grant-only owner list collection grants on hidden collection: expected 404, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	// Item-level operations on the granted item itself must still succeed
+	// (both auth classes) — an item grant legitimately entitles the holder
+	// to mint/list a share link or grant for that specific item.
+	itemSharePath := "/api/v1/workspaces/" + f.ws.Slug + "/items/" + f.hiddenItem.Slug + "/share-links"
+	rr = doRequestWithHeaders(f.srv, "POST", itemSharePath, map[string]interface{}{}, f.bearerHeaders())
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("bearer item-grant-only owner create item share-link on granted item: expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+	rr = doRequestWithCookie(f.srv, "GET", itemSharePath, nil, f.sessionToken)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("session item-grant-only owner list item share-links on granted item: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	itemGrantPath := "/api/v1/workspaces/" + f.ws.Slug + "/items/" + f.hiddenItem.Slug + "/grants"
+	rr = doRequestWithHeaders(f.srv, "POST", itemGrantPath, grantBody, f.bearerHeaders())
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("bearer item-grant-only owner create item grant on granted item: expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+	rr = doRequestWithCookie(f.srv, "GET", itemGrantPath, nil, f.sessionToken)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("session item-grant-only owner list item grants on granted item: expected 200, got %d: %s", rr.Code, rr.Body.String())
 	}
 }
 

--- a/internal/server/handlers_grants.go
+++ b/internal/server/handlers_grants.go
@@ -28,7 +28,7 @@ func (s *Server) handleListCollectionGrants(w http.ResponseWriter, r *http.Reque
 		writeError(w, http.StatusNotFound, "not_found", "Collection not found")
 		return
 	}
-	if !s.requireCollectionVisible(w, r, workspaceID, coll) {
+	if !s.requireCollectionFullyVisible(w, r, workspaceID, coll) {
 		return
 	}
 
@@ -62,7 +62,7 @@ func (s *Server) handleCreateCollectionGrant(w http.ResponseWriter, r *http.Requ
 		writeError(w, http.StatusNotFound, "not_found", "Collection not found")
 		return
 	}
-	if !s.requireCollectionVisible(w, r, workspaceID, coll) {
+	if !s.requireCollectionFullyVisible(w, r, workspaceID, coll) {
 		return
 	}
 

--- a/internal/server/handlers_grants.go
+++ b/internal/server/handlers_grants.go
@@ -28,6 +28,9 @@ func (s *Server) handleListCollectionGrants(w http.ResponseWriter, r *http.Reque
 		writeError(w, http.StatusNotFound, "not_found", "Collection not found")
 		return
 	}
+	if !s.requireCollectionVisible(w, r, workspaceID, coll) {
+		return
+	}
 
 	grants, err := s.store.ListCollectionGrants(coll.ID)
 	if err != nil {
@@ -57,6 +60,9 @@ func (s *Server) handleCreateCollectionGrant(w http.ResponseWriter, r *http.Requ
 	}
 	if coll == nil {
 		writeError(w, http.StatusNotFound, "not_found", "Collection not found")
+		return
+	}
+	if !s.requireCollectionVisible(w, r, workspaceID, coll) {
 		return
 	}
 
@@ -144,6 +150,9 @@ func (s *Server) handleListItemGrants(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, "not_found", "Item not found")
 		return
 	}
+	if !s.requireItemVisible(w, r, workspaceID, item) {
+		return
+	}
 
 	grants, err := s.store.ListItemGrants(item.ID)
 	if err != nil {
@@ -173,6 +182,9 @@ func (s *Server) handleCreateItemGrant(w http.ResponseWriter, r *http.Request) {
 	}
 	if item == nil {
 		s.writeItemResolveError(w, r, workspaceID, itemSlug)
+		return
+	}
+	if !s.requireItemVisible(w, r, workspaceID, item) {
 		return
 	}
 

--- a/internal/server/handlers_share_links.go
+++ b/internal/server/handlers_share_links.go
@@ -157,7 +157,7 @@ func (s *Server) handleCreateCollectionShareLink(w http.ResponseWriter, r *http.
 		writeError(w, http.StatusNotFound, "not_found", "Collection not found")
 		return
 	}
-	if !s.requireCollectionVisible(w, r, workspaceID, coll) {
+	if !s.requireCollectionFullyVisible(w, r, workspaceID, coll) {
 		return
 	}
 
@@ -262,7 +262,7 @@ func (s *Server) handleListCollectionShareLinks(w http.ResponseWriter, r *http.R
 		writeError(w, http.StatusNotFound, "not_found", "Collection not found")
 		return
 	}
-	if !s.requireCollectionVisible(w, r, workspaceID, coll) {
+	if !s.requireCollectionFullyVisible(w, r, workspaceID, coll) {
 		return
 	}
 

--- a/internal/server/handlers_share_links.go
+++ b/internal/server/handlers_share_links.go
@@ -84,6 +84,13 @@ func (s *Server) handleCreateItemShareLink(w http.ResponseWriter, r *http.Reques
 		s.writeItemResolveError(w, r, workspaceID, itemSlug)
 		return
 	}
+	// BUG-1920: a workspace-role "owner" can be independently restricted
+	// via collection_access="specific". Without this check, a restricted
+	// owner could mint a public share-link token for an item in a
+	// collection hidden from them — an exfiltration path.
+	if !s.requireItemVisible(w, r, workspaceID, item) {
+		return
+	}
 
 	var input struct {
 		Password        string  `json:"password,omitempty"`
@@ -148,6 +155,9 @@ func (s *Server) handleCreateCollectionShareLink(w http.ResponseWriter, r *http.
 	}
 	if coll == nil {
 		writeError(w, http.StatusNotFound, "not_found", "Collection not found")
+		return
+	}
+	if !s.requireCollectionVisible(w, r, workspaceID, coll) {
 		return
 	}
 
@@ -218,6 +228,9 @@ func (s *Server) handleListItemShareLinks(w http.ResponseWriter, r *http.Request
 		writeError(w, http.StatusNotFound, "not_found", "Item not found")
 		return
 	}
+	if !s.requireItemVisible(w, r, workspaceID, item) {
+		return
+	}
 
 	links, err := s.store.ListShareLinks("item", item.ID)
 	if err != nil {
@@ -247,6 +260,9 @@ func (s *Server) handleListCollectionShareLinks(w http.ResponseWriter, r *http.R
 	}
 	if coll == nil {
 		writeError(w, http.StatusNotFound, "not_found", "Collection not found")
+		return
+	}
+	if !s.requireCollectionVisible(w, r, workspaceID, coll) {
 		return
 	}
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1650,17 +1650,47 @@ func (s *Server) visibleCollectionIDs(r *http.Request, workspaceID string) ([]st
 	return s.store.VisibleCollectionIDs(workspaceID, user.ID)
 }
 
-// requireCollectionVisible checks that the collection itself is visible to
-// the requesting user (BUG-1920). Mirrors handleGetCollection's inline
-// visibleCollectionIDs + isCollectionVisible check so every handler that
-// resolves a collection by slug decides visibility identically. Writes a
-// 404 and returns false if not visible; callers should invoke this
+// requireCollectionFullyVisible checks that the collection is visible to the
+// requesting user under FULL-collection-access semantics (BUG-1920 —
+// codex R2 follow-up). This is deliberately STRICTER than
+// handleGetCollection's inline visibleCollectionIDs + isCollectionVisible
+// check: VisibleCollectionIDs (workspace_members.go) intentionally folds in
+// collections that are visible ONLY via an item-level grant, "so the
+// collection appears in navigation" — item-level filtering is left to the
+// handlers. That nav-lenient shape is correct for handleGetCollection
+// (viewing collection metadata), but WRONG here: this helper's only callers
+// are the four handlers that mint or list a collection-wide share link or
+// grant, where passing would hand out (or reveal) access to the ENTIRE
+// collection — an item grant on a single item inside it must NOT qualify.
+//
+// Mirrors reportVisibleCollections' fullCollIDs narrowing
+// (handlers_reports.go): when the caller holds any item-level grants, the
+// acceptable set narrows from the nav-lenient VisibleCollectionIDs set to
+// the full-access-only set (guestResourceFilter's fullCollIDs — collection
+// grants + member_collection_access + system collections, excluding
+// item-grant-only collections).
+//
+// Writes a 404 and returns false if not visible; callers should invoke this
 // immediately after resolving a collection by slug/ID.
-func (s *Server) requireCollectionVisible(w http.ResponseWriter, r *http.Request, workspaceID string, coll *models.Collection) bool {
+func (s *Server) requireCollectionFullyVisible(w http.ResponseWriter, r *http.Request, workspaceID string, coll *models.Collection) bool {
 	visibleIDs, err := s.visibleCollectionIDs(r, workspaceID)
 	if err != nil {
 		writeInternalError(w, err)
 		return false
+	}
+	if visibleIDs != nil {
+		// Restricted (non-nil visibleIDs): narrow to full-access
+		// collections only when the caller's restricted visibility
+		// includes any item-level grants, so an item-grant-only
+		// collection can't qualify for collection-wide operations.
+		fullCollIDs, grantedItemIDs, gErr := s.guestResourceFilter(r, workspaceID)
+		if gErr != nil {
+			writeInternalError(w, gErr)
+			return false
+		}
+		if len(grantedItemIDs) > 0 {
+			visibleIDs = fullCollIDs
+		}
 	}
 	if !isCollectionVisible(coll.ID, visibleIDs) {
 		writeError(w, http.StatusNotFound, "not_found", "Collection not found")

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1650,6 +1650,25 @@ func (s *Server) visibleCollectionIDs(r *http.Request, workspaceID string) ([]st
 	return s.store.VisibleCollectionIDs(workspaceID, user.ID)
 }
 
+// requireCollectionVisible checks that the collection itself is visible to
+// the requesting user (BUG-1920). Mirrors handleGetCollection's inline
+// visibleCollectionIDs + isCollectionVisible check so every handler that
+// resolves a collection by slug decides visibility identically. Writes a
+// 404 and returns false if not visible; callers should invoke this
+// immediately after resolving a collection by slug/ID.
+func (s *Server) requireCollectionVisible(w http.ResponseWriter, r *http.Request, workspaceID string, coll *models.Collection) bool {
+	visibleIDs, err := s.visibleCollectionIDs(r, workspaceID)
+	if err != nil {
+		writeInternalError(w, err)
+		return false
+	}
+	if !isCollectionVisible(coll.ID, visibleIDs) {
+		writeError(w, http.StatusNotFound, "not_found", "Collection not found")
+		return false
+	}
+	return true
+}
+
 // requireItemVisible checks that the item's collection is visible to the
 // requesting user. For guests with item-level grants, also verifies that the
 // specific item is granted (not just the collection). Writes a 404 and returns


### PR DESCRIPTION
## Summary

Fixes BUG-1920: all eight share-link and grant minting/listing handlers resolved their target item or collection and gated only on `requireMinRole("owner")` — no visibility check. A workspace-role owner independently restricted via `collection_access="specific"` could create or list share links and grants for items/collections hidden from them. Share links are public-read tokens, so minting one is an exfiltration path for hidden content; this wasn't bearer- or admin-specific (session-auth restricted owners hit it too).

Each handler now checks visibility immediately after resolve:

- Item level (`requireItemVisible`, bearer-aware via #792/#793): `handleCreateItemShareLink`, `handleListItemShareLinks`, `handleCreateItemGrant`, `handleListItemGrants`
- Collection level (new `requireCollectionVisible` helper — a pure extraction of `handleGetCollection`'s inline `visibleCollectionIDs` + `isCollectionVisible` idiom, so collection visibility is decided identically everywhere): `handleCreateCollectionShareLink`, `handleListCollectionShareLinks`, `handleCreateCollectionGrant`, `handleListCollectionGrants`

Layering preserved and pinned by test: `requireMinRole` first (403 for non-owners), visibility second (404 for hidden).

**Observable behavior change:** restricted owners (any auth class) can no longer create/list share links or grants for hidden-collection items or hidden collections (previously allowed). Unrestricted owners unchanged. Share-link *consumption* (`/s/{token}`) is untouched — public-read is that surface's design.

## Swept, found, filed separately

The recon classified all 29 `requireMinRole` call sites. Two same-family findings were descoped to their own bugs: **BUG-1921** (`handleUpdateCollection`/`handleDeleteCollection`, same missing check, different handler family) and **BUG-1922** (workspace export dumps hidden collections — structurally different fix and a design question about backup semantics). Delete/revoke handlers operate on link/grant IDs without resolving items — no oracle difference, not in scope.

## Review

2 codex rounds, rotated framing. R1 (plain): no findings against the diff itself; it flagged the ID-keyed delete/view-history handlers (`handleDeleteItemGrant`/`handleDeleteCollectionGrant`/`handleDeleteShareLink`/`handleShareLinkViews`) as the same vulnerability class — verified pre-existing (untouched by this commit, different fix shape: they must resolve the parent from the grant/link record before a visibility check is possible) and filed as **BUG-1923** (medium; grant/link IDs are unguessable UUIDs, unlike the sequential refs that made BUG-1918 urgent). R2 (legitimate-flow regression lens) caught a real gap the first commit introduced: the collection gate reused nav-lenient `visibleCollectionIDs`, which deliberately includes item-grant-only collections — so a restricted owner holding a single item grant could still mint a collection-wide share link. Fixed in 4bf263d: helper renamed to `requireCollectionFullyVisible` and narrowed to `guestResourceFilter`'s full-access set when item grants exist (mirroring `reportVisibleCollections`' pairing), with a dual-half pinning test (collection ops 404 for item-grant-only callers; the granted item's own operations still succeed) — revert-verified. `handleGetCollection`'s nav-lenient check is intentionally untouched (metadata viewing ≠ minting). R3 (convergence) verified the `guestResourceFilter` pairing and `fullCollIDs` narrowing are correct and that item grants still allow item-scoped operations without promoting to collection-wide access; its only finding was the BUG-1923 class again (pre-existing, ID-keyed handlers, traced to #87). Converged.

## Test plan

- [x] 7 new tests (`handlers_grant_visibility_test.go`): each of the 4 surfaces at item + collection level for a restricted owner (session AND bearer → 404 hidden, success visible), plus a non-owner 403-before-visibility layering pin across all 8 handlers
- [x] Revert-verified: `handleCreateItemShareLink`'s check disabled → test fails with 201-instead-of-404; restored → passes
- [x] `go test ./...` (SQLite) all green
- [x] `make test-pg` full suite green (verified untruncated)
- [x] `make lint` 0 issues
- [x] Frontend untouched (Go-only diff)

Refs: BUG-1920, BUG-1921, BUG-1922, BUG-1917, BUG-1918

https://claude.ai/code/session_01CL1pBjNpPUX6SWkuAuYXHS
