### PR TITLE
fix(server): gate collection update/delete on visibility (BUG-1921)

### DIFF
--- a/internal/server/handlers_collection_crud_visibility_test.go
+++ b/internal/server/handlers_collection_crud_visibility_test.go
@@ -1,0 +1,157 @@
+package server
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// BUG-1921: handleUpdateCollection and handleDeleteCollection resolve a
+// collection by slug and gated only on requireMinRole("owner") — no
+// requireCollectionFullyVisible check. A workspace-role owner restricted via
+// collection_access="specific" (member_collection_access has no role
+// exclusion, per BUG-1920) could rename, re-schema, or delete a collection
+// hidden from them. These tests reuse restrictedOwnerVisibilityFixture
+// (handlers_grant_visibility_test.go) — the fixture and its hidden/visible
+// collection pair are identical to BUG-1920's; only the endpoints under
+// test differ.
+
+// ─── handleUpdateCollection ─────────────────────────────────────────────
+
+// TestUpdateCollection_RestrictedOwner_HiddenCollection404 pins BUG-1921 for
+// PATCH: a restricted owner can no longer rename/re-schema a collection
+// hidden from them, over either auth class. The same owner can still PATCH
+// a visible collection.
+func TestUpdateCollection_RestrictedOwner_HiddenCollection404(t *testing.T) {
+	f := newRestrictedOwnerVisibilityFixture(t)
+
+	hiddenPath := "/api/v1/workspaces/" + f.ws.Slug + "/collections/" + f.hiddenColl.Slug
+	body := map[string]interface{}{"name": "Renamed Hidden"}
+	rr := doRequestWithHeaders(f.srv, "PATCH", hiddenPath, body, f.bearerHeaders())
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("bearer restricted owner PATCH hidden collection: expected 404, got %d: %s", rr.Code, rr.Body.String())
+	}
+	rr = doRequestWithCookie(f.srv, "PATCH", hiddenPath, body, f.sessionToken)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("session restricted owner PATCH hidden collection: expected 404, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	visPath := "/api/v1/workspaces/" + f.ws.Slug + "/collections/" + f.visibleColl.Slug
+	rr = doRequestWithHeaders(f.srv, "PATCH", visPath, map[string]interface{}{"name": "Renamed Visible"}, f.bearerHeaders())
+	if rr.Code != http.StatusOK {
+		t.Fatalf("bearer restricted owner PATCH visible collection: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+// ─── handleDeleteCollection ─────────────────────────────────────────────
+
+// TestDeleteCollection_RestrictedOwner_HiddenCollection404 pins BUG-1921 for
+// DELETE: a restricted owner can no longer delete a collection hidden from
+// them, over either auth class. A fresh fixture is used per sub-case so a
+// successful delete of the visible collection in one case doesn't affect
+// another.
+func TestDeleteCollection_RestrictedOwner_HiddenCollection404(t *testing.T) {
+	t.Run("bearer", func(t *testing.T) {
+		f := newRestrictedOwnerVisibilityFixture(t)
+		hiddenPath := "/api/v1/workspaces/" + f.ws.Slug + "/collections/" + f.hiddenColl.Slug
+		rr := doRequestWithHeaders(f.srv, "DELETE", hiddenPath, nil, f.bearerHeaders())
+		if rr.Code != http.StatusNotFound {
+			t.Fatalf("bearer restricted owner DELETE hidden collection: expected 404, got %d: %s", rr.Code, rr.Body.String())
+		}
+	})
+	t.Run("session", func(t *testing.T) {
+		f := newRestrictedOwnerVisibilityFixture(t)
+		hiddenPath := "/api/v1/workspaces/" + f.ws.Slug + "/collections/" + f.hiddenColl.Slug
+		rr := doRequestWithCookie(f.srv, "DELETE", hiddenPath, nil, f.sessionToken)
+		if rr.Code != http.StatusNotFound {
+			t.Fatalf("session restricted owner DELETE hidden collection: expected 404, got %d: %s", rr.Code, rr.Body.String())
+		}
+	})
+	t.Run("visible collection still deletable", func(t *testing.T) {
+		f := newRestrictedOwnerVisibilityFixture(t)
+		visPath := "/api/v1/workspaces/" + f.ws.Slug + "/collections/" + f.visibleColl.Slug
+		rr := doRequestWithHeaders(f.srv, "DELETE", visPath, nil, f.bearerHeaders())
+		if rr.Code != http.StatusNoContent {
+			t.Fatalf("bearer restricted owner DELETE visible collection: expected 204, got %d: %s", rr.Code, rr.Body.String())
+		}
+	})
+}
+
+// ─── Item-grant-only must NOT promote to collection-wide mutation rights ──
+
+// TestUpdateDeleteCollection_ItemGrantOnly_HiddenCollection404 mirrors
+// BUG-1920's codex R2 finding: VisibleCollectionIDs folds in collections
+// visible ONLY via an item-level grant ("so the collection appears in
+// navigation"), which would let a restricted owner holding nothing more
+// than an item grant on ONE item inside the hidden collection rename or
+// delete the ENTIRE hidden collection if the nav-lenient check were used
+// here instead of requireCollectionFullyVisible. This is the load-bearing
+// test of the set: it fails if handleUpdateCollection/handleDeleteCollection
+// were wired to the nav-lenient visibleCollectionIDs+isCollectionVisible
+// check (handleGetCollection's idiom) rather than the strict
+// requireCollectionFullyVisible helper.
+func TestUpdateDeleteCollection_ItemGrantOnly_HiddenCollection404(t *testing.T) {
+	f := newRestrictedOwnerVisibilityFixture(t)
+	f.grantHiddenItemToOwner(t)
+
+	hiddenPath := "/api/v1/workspaces/" + f.ws.Slug + "/collections/" + f.hiddenColl.Slug
+
+	rr := doRequestWithHeaders(f.srv, "PATCH", hiddenPath, map[string]interface{}{"name": "Renamed"}, f.bearerHeaders())
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("bearer item-grant-only owner PATCH hidden collection: expected 404, got %d: %s", rr.Code, rr.Body.String())
+	}
+	rr = doRequestWithCookie(f.srv, "PATCH", hiddenPath, map[string]interface{}{"name": "Renamed"}, f.sessionToken)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("session item-grant-only owner PATCH hidden collection: expected 404, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	rr = doRequestWithHeaders(f.srv, "DELETE", hiddenPath, nil, f.bearerHeaders())
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("bearer item-grant-only owner DELETE hidden collection: expected 404, got %d: %s", rr.Code, rr.Body.String())
+	}
+	rr = doRequestWithCookie(f.srv, "DELETE", hiddenPath, nil, f.sessionToken)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("session item-grant-only owner DELETE hidden collection: expected 404, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+// ─── Layering: requireMinRole (403) must run BEFORE visibility (404) ───
+
+// TestUpdateDeleteCollection_NonOwner_403BeforeVisibility pins the required
+// layering: a non-owner member gets 403 from requireMinRole regardless of
+// collection visibility — the visibility check (404) never even runs for
+// them. Exercised against the hidden collection so a regression that
+// swapped the check order (visibility before role) would surface as an
+// incorrect 404 here instead of the expected 403.
+func TestUpdateDeleteCollection_NonOwner_403BeforeVisibility(t *testing.T) {
+	f := newRestrictedOwnerVisibilityFixture(t)
+
+	editor, err := f.srv.store.CreateUser(models.UserCreate{
+		Email: "editor-crud@example.com", Name: "Editor", Password: "pw-test-12345",
+	})
+	if err != nil {
+		t.Fatalf("create editor: %v", err)
+	}
+	if err := f.srv.store.AddWorkspaceMember(f.ws.ID, editor.ID, "editor"); err != nil {
+		t.Fatalf("add editor member: %v", err)
+	}
+	editorTok, err := f.srv.store.CreateAPIToken(editor.ID, models.APITokenCreate{
+		Name: "editor-pat-crud", WorkspaceID: f.ws.ID,
+	}, 0, 0)
+	if err != nil {
+		t.Fatalf("CreateAPIToken editor: %v", err)
+	}
+	editorHeaders := map[string]string{"Authorization": "Bearer " + editorTok.Token}
+
+	hiddenPath := "/api/v1/workspaces/" + f.ws.Slug + "/collections/" + f.hiddenColl.Slug
+
+	rr := doRequestWithHeaders(f.srv, "PATCH", hiddenPath, map[string]interface{}{"name": "Renamed"}, editorHeaders)
+	if rr.Code != http.StatusForbidden {
+		t.Errorf("editor PATCH hidden collection: expected 403, got %d: %s", rr.Code, rr.Body.String())
+	}
+	rr = doRequestWithHeaders(f.srv, "DELETE", hiddenPath, nil, editorHeaders)
+	if rr.Code != http.StatusForbidden {
+		t.Errorf("editor DELETE hidden collection: expected 403, got %d: %s", rr.Code, rr.Body.String())
+	}
+}

--- a/internal/server/handlers_collections.go
+++ b/internal/server/handlers_collections.go
@@ -187,6 +187,9 @@ func (s *Server) handleUpdateCollection(w http.ResponseWriter, r *http.Request) 
 		writeError(w, http.StatusNotFound, "not_found", "Collection not found")
 		return
 	}
+	if !s.requireCollectionFullyVisible(w, r, workspaceID, coll) {
+		return
+	}
 
 	var input models.CollectionUpdate
 	if err := decodeJSON(r, &input); err != nil {
@@ -263,6 +266,9 @@ func (s *Server) handleDeleteCollection(w http.ResponseWriter, r *http.Request) 
 	}
 	if coll == nil {
 		writeError(w, http.StatusNotFound, "not_found", "Collection not found")
+		return
+	}
+	if !s.requireCollectionFullyVisible(w, r, workspaceID, coll) {
 		return
 	}
 


### PR DESCRIPTION
## Summary

`handleUpdateCollection` and `handleDeleteCollection` resolved a collection by slug and gated only on `requireMinRole("owner")` — no visibility check. A workspace-role owner restricted via `collection_access="specific"` could rename, re-schema, or delete a collection hidden from them. Both handlers now call `requireCollectionFullyVisible` (added in #794 for the share-link/grant minting twins) immediately after the existing nil-check: restricted owners get 404 on PATCH/DELETE of a hidden collection, after the pre-existing 403 role gate.

## Plus (architectural decisions)

- **Strict variant, deliberately:** this reuses BUG-1920's `requireCollectionFullyVisible`, NOT `handleGetCollection`'s nav-lenient `isCollectionVisible` check. An item-level grant on a single item inside a hidden collection must not qualify as authority to mutate the entire collection record — pinned by `TestUpdateDeleteCollection_ItemGrantOnly_HiddenCollection404`.
- **Downstream-consumer audit:** every other collSlug-resolving handler already gates (nav-lenient `isCollectionVisible` for read/item-scoped handlers, `requireCollectionFullyVisible` for the four minting/listing handlers from #794, `requireEditPermission` for item writes, target-collection checks for bulk/single move). Update/delete were the only ungated collection-record-mutation path.

## Observable behavior changes

- Restricted owner (session or bearer) PATCH/DELETE of a hidden collection: 200/204 → **404**.
- Unrestricted owners, and restricted owners on visible collections: unchanged.

## Review trail

Codex R1 (plain): CLEAN. R2 (bypass-route lens): 3 pre-existing gaps AROUND the gate, none introduced here — filed as BUG-1925 (member-access self-escalation, high) and confirmed against BUG-1923 (ID-keyed grant/link deletes, incl. `handleDeleteCollectionGrant`/`handleDeleteShareLink` — deliberately not fixed here). R3 (convergence): CLEAN.

## Test plan

- [x] `go test ./...` — full suite green (SQLite)
- [x] `golangci-lint run ./...` — 0 issues
- [x] 4 new tests: restricted-owner 404 on PATCH/DELETE (bearer + session), item-grant-only non-promotion, 403-before-visibility check order
- [x] No store/SQL surface touched (pure handler-level; Postgres covered by CI matrix)

Refs: BUG-1921 (docapp). Family: #792 (BUG-1917), #793 (BUG-1918), #794 (BUG-1920). Follow-ups filed: BUG-1923, BUG-1925.

https://claude.ai/code/session_01CL1pBjNpPUX6SWkuAuYXHS