### PR TITLE
fix(collab): dedup binary frames by content in replay-cursor test (BUG-1924)

### DIFF
--- a/internal/collab/manager_test.go
+++ b/internal/collab/manager_test.go
@@ -1497,7 +1497,23 @@ func TestRoomManagerCursorSuppressedDuringReplay(t *testing.T) {
 	// (3 replayed + 1 live) and the post-replay + live cursor
 	// frames. If a cursor frame for id=4 arrives BEFORE all
 	// binary frames are accounted for, this is the regression.
-	binarySeen := 0
+	//
+	// We count DISTINCT op payloads rather than raw frames because
+	// runConn (manager.go:497-514) deliberately starts the writer
+	// before replayTo so live broadcasts during a long replay aren't
+	// lost; the documented trade-off is that an op appended during
+	// the replay window can be delivered twice — once via the live
+	// bus subscription, once via replayTo sweeping it out of the op
+	// log — which Yjs update application tolerates idempotently.
+	// That's a legitimate outcome of the race, not a bug: don't
+	// "fix" this back to a raw frame count. Dedup by exact byte
+	// content is safe here because every one of the 4 expected ops
+	// has a distinguishable payload (seeded ops carry 0x01/0x02/0x03,
+	// the live op carries 0xFF), so a genuinely dropped op still
+	// caps distinctSeen at 3, not 4 — only a true duplicate is
+	// tolerated.
+	seen := map[string]int{}
+	distinctSeen := 0
 	deadline := time.Now().Add(2 * time.Second)
 	for {
 		b.SetReadDeadline(deadline)
@@ -1506,7 +1522,11 @@ func TestRoomManagerCursorSuppressedDuringReplay(t *testing.T) {
 			break
 		}
 		if mt == websocket.BinaryMessage {
-			binarySeen++
+			key := string(data)
+			if seen[key] == 0 {
+				distinctSeen++
+			}
+			seen[key]++
 			continue
 		}
 		if mt != websocket.TextMessage {
@@ -1520,13 +1540,13 @@ func TestRoomManagerCursorSuppressedDuringReplay(t *testing.T) {
 			continue
 		}
 		// A live cursor with id=4 must only arrive AFTER all 4
-		// binary frames are accounted for; otherwise replay-mid
-		// cursor advancement leaked through.
-		if msg.OpLogID == 4 && binarySeen < 4 {
-			t.Errorf("cursor id=4 arrived after only %d/4 binary frames; replay-mid cursor leaked", binarySeen)
+		// distinct binary ops are accounted for; otherwise
+		// replay-mid cursor advancement leaked through.
+		if msg.OpLogID == 4 && distinctSeen < 4 {
+			t.Errorf("cursor id=4 arrived after only %d/4 distinct binary ops; replay-mid cursor leaked", distinctSeen)
 		}
 	}
-	if binarySeen != 4 {
-		t.Errorf("binary frames seen: want 4, got %d", binarySeen)
+	if distinctSeen != 4 {
+		t.Errorf("distinct binary ops seen: want 4, got %d", distinctSeen)
 	}
 }


### PR DESCRIPTION
## Summary

`TestRoomManagerCursorSuppressedDuringReplay` flaked on main (run 28679940189, both Go jobs, "binary frames seen: want 4, got 5"), turning the #793 merge run red with no code cause. Root cause is a designed race, not a product bug: `runConn` (manager.go:497-514) deliberately starts the writer before `replayTo` so live broadcasts during a long replay aren't lost — the documented tradeoff is that an op appended during the replay window can be delivered twice (once live, once via replay), tolerated by Yjs idempotency. The test's raw frame count encoded only one outcome of that race.

The test now counts **distinct** binary payloads (each of the 4 expected ops has a unique payload: seeded 0x01/0x02/0x03 + live 0xFF), so the designed duplicate is tolerated while a genuinely dropped op still caps the count at 3 and fails. A comment block cites the design so nobody reverts to raw counting.

## Invariants preserved (independently reviewed)

- Dropped-op detection: distinct-count still requires all 4 unique ops.
- Replay-mid cursor-leak detection (the test's reason to exist): cursor id=4 arriving before all 4 distinct ops still fails — and is now *stronger*, since a duplicate can no longer pad the count toward 4.
- Deliberately given up: flagging duplicate delivery itself as a failure — that's the documented designed behavior.

## Test plan

- [x] `go test ./internal/collab/ -run TestRoomManagerCursorSuppressedDuringReplay -count=200 -race` — 200/200 pass (401s)
- [x] `go test ./internal/collab/ -race` and full `go test ./...` — green
- [x] `golangci-lint run ./...` — 0 issues
- [x] Test-only diff; no production or store surface

## Review trail

Codex R1 (assertion-semantics lens): converged, no defects; sole informational note is the documented tradeoff above.

Refs: BUG-1924 (docapp). Context: flake surfaced during the #792-#794 bearer/visibility merge train.

https://claude.ai/code/session_01CL1pBjNpPUX6SWkuAuYXHS