### PR TITLE
fix(server): gate ID-keyed grant/share-link handlers on target visibility (BUG-1923)

### DIFF
--- a/internal/server/handlers_grant_visibility_test.go
+++ b/internal/server/handlers_grant_visibility_test.go
@@ -117,6 +117,23 @@ func (f *restrictedOwnerVisibilityFixture) grantHiddenItemToOwner(t *testing.T) 
 	}
 }
 
+// seedGrantee creates a throwaway user to be the recipient of a grant, for
+// tests that need a real grant/link ID on a hidden or visible resource
+// (BUG-1923's delete/view-history handlers operate on IDs directly, so the
+// setup for these tests bypasses the HTTP layer via direct store calls —
+// mirroring how the resource would have been minted before the caller lost
+// visibility to it).
+func (f *restrictedOwnerVisibilityFixture) seedGrantee(t *testing.T) *models.User {
+	t.Helper()
+	grantee, err := f.srv.store.CreateUser(models.UserCreate{
+		Email: "grantee2@example.com", Name: "Grantee2", Password: "pw-test-12345",
+	})
+	if err != nil {
+		t.Fatalf("create grantee: %v", err)
+	}
+	return grantee
+}
+
 // ─── handleCreateItemShareLink ──────────────────────────────────────────
 
 // TestCreateItemShareLink_RestrictedOwner_HiddenCollection404 pins BUG-1920:
@@ -374,6 +391,295 @@ func TestCollectionShareLinksAndGrants_ItemGrantOnly_HiddenCollection404(t *test
 	rr = doRequestWithCookie(f.srv, "GET", itemGrantPath, nil, f.sessionToken)
 	if rr.Code != http.StatusOK {
 		t.Fatalf("session item-grant-only owner list item grants on granted item: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+// ─── handleDeleteCollectionGrant / handleDeleteItemGrant (BUG-1923) ────
+
+// TestDeleteCollectionGrant_RestrictedOwner_HiddenCollection404 pins
+// BUG-1923: unlike its create/list siblings, handleDeleteCollectionGrant
+// operated on the grant ID directly with no visibility check on the
+// underlying collection — a restricted owner who knew a grant ID could
+// revoke a grant on a collection hidden from them. The grant is seeded
+// directly via the store (as if minted before the owner's access was
+// restricted), so the delete attempt exercises only the gate under test;
+// since the gate 404s before deleting, the same grant ID can be re-used for
+// both auth classes.
+func TestDeleteCollectionGrant_RestrictedOwner_HiddenCollection404(t *testing.T) {
+	f := newRestrictedOwnerVisibilityFixture(t)
+	grantee := f.seedGrantee(t)
+
+	hiddenGrant, err := f.srv.store.CreateCollectionGrant(f.ws.ID, f.hiddenColl.ID, grantee.ID, "view", f.ownerID)
+	if err != nil {
+		t.Fatalf("seed hidden collection grant: %v", err)
+	}
+	visibleGrant, err := f.srv.store.CreateCollectionGrant(f.ws.ID, f.visibleColl.ID, grantee.ID, "view", f.ownerID)
+	if err != nil {
+		t.Fatalf("seed visible collection grant: %v", err)
+	}
+
+	hiddenPath := "/api/v1/workspaces/" + f.ws.Slug + "/collections/" + f.hiddenColl.Slug + "/grants/" + hiddenGrant.ID
+	rr := doRequestWithHeaders(f.srv, "DELETE", hiddenPath, nil, f.bearerHeaders())
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("bearer restricted owner delete grant on hidden collection: expected 404, got %d: %s", rr.Code, rr.Body.String())
+	}
+	rr = doRequestWithCookie(f.srv, "DELETE", hiddenPath, nil, f.sessionToken)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("session restricted owner delete grant on hidden collection: expected 404, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if g, err := f.srv.store.GetCollectionGrant(hiddenGrant.ID); err != nil || g == nil {
+		t.Fatalf("hidden grant should NOT have been deleted by the 404'd attempts: %v, %v", g, err)
+	}
+
+	visiblePath := "/api/v1/workspaces/" + f.ws.Slug + "/collections/" + f.visibleColl.Slug + "/grants/" + visibleGrant.ID
+	rr = doRequestWithHeaders(f.srv, "DELETE", visiblePath, nil, f.bearerHeaders())
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("bearer restricted owner delete grant on visible collection: expected 204, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+// TestDeleteItemGrant_RestrictedOwner_HiddenCollection404 pins the item-grant
+// twin of BUG-1923's delete-side fix.
+func TestDeleteItemGrant_RestrictedOwner_HiddenCollection404(t *testing.T) {
+	f := newRestrictedOwnerVisibilityFixture(t)
+	grantee := f.seedGrantee(t)
+
+	hiddenGrant, err := f.srv.store.CreateItemGrant(f.ws.ID, f.hiddenItem.ID, grantee.ID, "view", f.ownerID)
+	if err != nil {
+		t.Fatalf("seed hidden item grant: %v", err)
+	}
+	visibleGrant, err := f.srv.store.CreateItemGrant(f.ws.ID, f.visibleItem.ID, grantee.ID, "view", f.ownerID)
+	if err != nil {
+		t.Fatalf("seed visible item grant: %v", err)
+	}
+
+	hiddenPath := "/api/v1/workspaces/" + f.ws.Slug + "/items/" + f.hiddenItem.Slug + "/grants/" + hiddenGrant.ID
+	rr := doRequestWithHeaders(f.srv, "DELETE", hiddenPath, nil, f.bearerHeaders())
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("bearer restricted owner delete grant on hidden item: expected 404, got %d: %s", rr.Code, rr.Body.String())
+	}
+	rr = doRequestWithCookie(f.srv, "DELETE", hiddenPath, nil, f.sessionToken)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("session restricted owner delete grant on hidden item: expected 404, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if g, err := f.srv.store.GetItemGrant(hiddenGrant.ID); err != nil || g == nil {
+		t.Fatalf("hidden grant should NOT have been deleted by the 404'd attempts: %v, %v", g, err)
+	}
+
+	visiblePath := "/api/v1/workspaces/" + f.ws.Slug + "/items/" + f.visibleItem.Slug + "/grants/" + visibleGrant.ID
+	rr = doRequestWithHeaders(f.srv, "DELETE", visiblePath, nil, f.bearerHeaders())
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("bearer restricted owner delete grant on visible item: expected 204, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+// ─── handleDeleteShareLink / handleShareLinkViews (BUG-1923) ───────────
+
+// TestDeleteShareLink_RestrictedOwner_HiddenTarget404 pins BUG-1923 for both
+// share-link target classes: handleDeleteShareLink operated on the link ID
+// directly with no check on the underlying item/collection.
+func TestDeleteShareLink_RestrictedOwner_HiddenTarget404(t *testing.T) {
+	f := newRestrictedOwnerVisibilityFixture(t)
+
+	hiddenItemLink, err := f.srv.store.CreateShareLink(f.ws.ID, "item", f.hiddenItem.ID, "view", f.ownerID, nil)
+	if err != nil {
+		t.Fatalf("seed hidden item share link: %v", err)
+	}
+	hiddenCollLink, err := f.srv.store.CreateShareLink(f.ws.ID, "collection", f.hiddenColl.ID, "view", f.ownerID, nil)
+	if err != nil {
+		t.Fatalf("seed hidden collection share link: %v", err)
+	}
+	visibleItemLink, err := f.srv.store.CreateShareLink(f.ws.ID, "item", f.visibleItem.ID, "view", f.ownerID, nil)
+	if err != nil {
+		t.Fatalf("seed visible item share link: %v", err)
+	}
+
+	deletePath := "/api/v1/workspaces/" + f.ws.Slug + "/share-links/"
+
+	rr := doRequestWithHeaders(f.srv, "DELETE", deletePath+hiddenItemLink.ID, nil, f.bearerHeaders())
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("bearer restricted owner delete share link on hidden item: expected 404, got %d: %s", rr.Code, rr.Body.String())
+	}
+	rr = doRequestWithCookie(f.srv, "DELETE", deletePath+hiddenItemLink.ID, nil, f.sessionToken)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("session restricted owner delete share link on hidden item: expected 404, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	rr = doRequestWithHeaders(f.srv, "DELETE", deletePath+hiddenCollLink.ID, nil, f.bearerHeaders())
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("bearer restricted owner delete share link on hidden collection: expected 404, got %d: %s", rr.Code, rr.Body.String())
+	}
+	rr = doRequestWithCookie(f.srv, "DELETE", deletePath+hiddenCollLink.ID, nil, f.sessionToken)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("session restricted owner delete share link on hidden collection: expected 404, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	if link, err := f.srv.store.GetShareLink(hiddenItemLink.ID); err != nil || link == nil {
+		t.Fatalf("hidden item share link should NOT have been deleted by the 404'd attempts: %v, %v", link, err)
+	}
+
+	rr = doRequestWithHeaders(f.srv, "DELETE", deletePath+visibleItemLink.ID, nil, f.bearerHeaders())
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("bearer restricted owner delete share link on visible item: expected 204, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+// TestShareLinkViews_RestrictedOwner_HiddenTarget404 pins BUG-1923 for the
+// view-history GET: handleShareLinkViews already resolved and
+// workspace-scoped the link but never checked visibility on its target.
+func TestShareLinkViews_RestrictedOwner_HiddenTarget404(t *testing.T) {
+	f := newRestrictedOwnerVisibilityFixture(t)
+
+	hiddenItemLink, err := f.srv.store.CreateShareLink(f.ws.ID, "item", f.hiddenItem.ID, "view", f.ownerID, nil)
+	if err != nil {
+		t.Fatalf("seed hidden item share link: %v", err)
+	}
+	hiddenCollLink, err := f.srv.store.CreateShareLink(f.ws.ID, "collection", f.hiddenColl.ID, "view", f.ownerID, nil)
+	if err != nil {
+		t.Fatalf("seed hidden collection share link: %v", err)
+	}
+	visibleItemLink, err := f.srv.store.CreateShareLink(f.ws.ID, "item", f.visibleItem.ID, "view", f.ownerID, nil)
+	if err != nil {
+		t.Fatalf("seed visible item share link: %v", err)
+	}
+
+	viewsPath := "/api/v1/workspaces/" + f.ws.Slug + "/share-links/"
+
+	rr := doRequestWithHeaders(f.srv, "GET", viewsPath+hiddenItemLink.ID+"/views", nil, f.bearerHeaders())
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("bearer restricted owner view-history on hidden item link: expected 404, got %d: %s", rr.Code, rr.Body.String())
+	}
+	rr = doRequestWithCookie(f.srv, "GET", viewsPath+hiddenItemLink.ID+"/views", nil, f.sessionToken)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("session restricted owner view-history on hidden item link: expected 404, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	rr = doRequestWithHeaders(f.srv, "GET", viewsPath+hiddenCollLink.ID+"/views", nil, f.bearerHeaders())
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("bearer restricted owner view-history on hidden collection link: expected 404, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	rr = doRequestWithHeaders(f.srv, "GET", viewsPath+visibleItemLink.ID+"/views", nil, f.bearerHeaders())
+	if rr.Code != http.StatusOK {
+		t.Fatalf("bearer restricted owner view-history on visible item link: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+// ─── Item-grant-only must NOT promote to collection-wide delete/views ─
+
+// TestCollectionGrantAndShareLinkDelete_ItemGrantOnly_HiddenCollection404
+// extends the item-grant-only non-promotion rule (see
+// TestCollectionShareLinksAndGrants_ItemGrantOnly_HiddenCollection404 above)
+// to the BUG-1923 delete/view-history handlers: an item-level grant on ONE
+// item inside the hidden collection must not let the owner delete a
+// collection-scoped grant/share-link for that collection, while delete
+// operations scoped to the granted item itself keep working.
+func TestCollectionGrantAndShareLinkDelete_ItemGrantOnly_HiddenCollection404(t *testing.T) {
+	f := newRestrictedOwnerVisibilityFixture(t)
+	f.grantHiddenItemToOwner(t)
+	grantee := f.seedGrantee(t)
+
+	collGrant, err := f.srv.store.CreateCollectionGrant(f.ws.ID, f.hiddenColl.ID, grantee.ID, "view", f.ownerID)
+	if err != nil {
+		t.Fatalf("seed hidden collection grant: %v", err)
+	}
+	collLink, err := f.srv.store.CreateShareLink(f.ws.ID, "collection", f.hiddenColl.ID, "view", f.ownerID, nil)
+	if err != nil {
+		t.Fatalf("seed hidden collection share link: %v", err)
+	}
+
+	collGrantPath := "/api/v1/workspaces/" + f.ws.Slug + "/collections/" + f.hiddenColl.Slug + "/grants/" + collGrant.ID
+	rr := doRequestWithHeaders(f.srv, "DELETE", collGrantPath, nil, f.bearerHeaders())
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("bearer item-grant-only owner delete collection grant on hidden collection: expected 404, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	linkDeletePath := "/api/v1/workspaces/" + f.ws.Slug + "/share-links/" + collLink.ID
+	rr = doRequestWithHeaders(f.srv, "DELETE", linkDeletePath, nil, f.bearerHeaders())
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("bearer item-grant-only owner delete collection share-link on hidden collection: expected 404, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	// Item-scoped grant/share-link on the granted item itself must still
+	// be deletable by the item-grant-only owner.
+	itemGrant, err := f.srv.store.CreateItemGrant(f.ws.ID, f.hiddenItem.ID, grantee.ID, "view", f.ownerID)
+	if err != nil {
+		t.Fatalf("seed item grant on granted item: %v", err)
+	}
+	itemLink, err := f.srv.store.CreateShareLink(f.ws.ID, "item", f.hiddenItem.ID, "view", f.ownerID, nil)
+	if err != nil {
+		t.Fatalf("seed item share link on granted item: %v", err)
+	}
+
+	itemGrantPath := "/api/v1/workspaces/" + f.ws.Slug + "/items/" + f.hiddenItem.Slug + "/grants/" + itemGrant.ID
+	rr = doRequestWithHeaders(f.srv, "DELETE", itemGrantPath, nil, f.bearerHeaders())
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("bearer item-grant-only owner delete item grant on granted item: expected 204, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	itemLinkPath := "/api/v1/workspaces/" + f.ws.Slug + "/share-links/" + itemLink.ID
+	rr = doRequestWithHeaders(f.srv, "DELETE", itemLinkPath, nil, f.bearerHeaders())
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("bearer item-grant-only owner delete item share-link on granted item: expected 204, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+// ─── Layering: requireMinRole (403) must run BEFORE visibility (404),
+//     ID-keyed delete/views handlers (BUG-1923) ──────────────────────────
+
+// TestShareLinkAndGrantDeleteViews_NonOwner_403BeforeVisibility extends the
+// 403-before-404 layering guarantee to the four ID-keyed handlers fixed by
+// BUG-1923: a non-owner member gets 403 from requireMinRole regardless of
+// the target's visibility or existence.
+func TestShareLinkAndGrantDeleteViews_NonOwner_403BeforeVisibility(t *testing.T) {
+	f := newRestrictedOwnerVisibilityFixture(t)
+	grantee := f.seedGrantee(t)
+
+	editor, err := f.srv.store.CreateUser(models.UserCreate{
+		Email: "editor2@example.com", Name: "Editor2", Password: "pw-test-12345",
+	})
+	if err != nil {
+		t.Fatalf("create editor: %v", err)
+	}
+	if err := f.srv.store.AddWorkspaceMember(f.ws.ID, editor.ID, "editor"); err != nil {
+		t.Fatalf("add editor member: %v", err)
+	}
+	editorTok, err := f.srv.store.CreateAPIToken(editor.ID, models.APITokenCreate{
+		Name: "editor2-pat", WorkspaceID: f.ws.ID,
+	}, 0, 0)
+	if err != nil {
+		t.Fatalf("CreateAPIToken editor: %v", err)
+	}
+	editorHeaders := map[string]string{"Authorization": "Bearer " + editorTok.Token}
+
+	collGrant, err := f.srv.store.CreateCollectionGrant(f.ws.ID, f.hiddenColl.ID, grantee.ID, "view", f.ownerID)
+	if err != nil {
+		t.Fatalf("seed collection grant: %v", err)
+	}
+	itemGrant, err := f.srv.store.CreateItemGrant(f.ws.ID, f.hiddenItem.ID, grantee.ID, "view", f.ownerID)
+	if err != nil {
+		t.Fatalf("seed item grant: %v", err)
+	}
+	link, err := f.srv.store.CreateShareLink(f.ws.ID, "item", f.hiddenItem.ID, "view", f.ownerID, nil)
+	if err != nil {
+		t.Fatalf("seed share link: %v", err)
+	}
+
+	cases := []struct {
+		name   string
+		method string
+		path   string
+	}{
+		{"delete collection grant", "DELETE", "/api/v1/workspaces/" + f.ws.Slug + "/collections/" + f.hiddenColl.Slug + "/grants/" + collGrant.ID},
+		{"delete item grant", "DELETE", "/api/v1/workspaces/" + f.ws.Slug + "/items/" + f.hiddenItem.Slug + "/grants/" + itemGrant.ID},
+		{"delete share link", "DELETE", "/api/v1/workspaces/" + f.ws.Slug + "/share-links/" + link.ID},
+		{"share link views", "GET", "/api/v1/workspaces/" + f.ws.Slug + "/share-links/" + link.ID + "/views"},
+	}
+	for _, tc := range cases {
+		rr := doRequestWithHeaders(f.srv, tc.method, tc.path, nil, editorHeaders)
+		if rr.Code != http.StatusForbidden {
+			t.Errorf("%s: editor (non-owner) expected 403, got %d: %s", tc.name, rr.Code, rr.Body.String())
+		}
 	}
 }
 

--- a/internal/server/handlers_grant_visibility_test.go
+++ b/internal/server/handlers_grant_visibility_test.go
@@ -624,6 +624,137 @@ func TestCollectionGrantAndShareLinkDelete_ItemGrantOnly_HiddenCollection404(t *
 	}
 }
 
+// ─── Soft-deleted collection parent must not permanently strand
+//     collection-scoped grants/share-links (BUG-1923 round-3 regression) ──
+
+// TestDeleteCollectionGrant_SoftDeletedCollection_StillRevocable pins a
+// regression codex R3 found in the initial BUG-1923 fix: resolving the
+// grant/link's parent via GetCollection (`deleted_at IS NULL`) would 404 the
+// delete/view-history handlers the instant the collection is soft-deleted,
+// since DeleteCollection does NOT cascade-delete collection_grants or
+// share_links (collections.go DeleteCollection) — the row would become
+// permanently un-revocable via the API. Fixed by resolving through
+// GetCollectionAnyState instead (mirrors the item-side GetItemIncludeDeleted
+// choice).
+//
+// Exercises a restricted owner whose member_collection_access already
+// included the collection before it was archived: visibility is preserved
+// post-soft-delete because GetMemberCollectionAccess reads the raw
+// member_collection_access table with no deleted_at join — confirmed by
+// tracing requireCollectionFullyVisible → visibleCollectionIDs /
+// guestResourceFilter → GetMemberCollectionAccess.
+func TestDeleteCollectionGrant_SoftDeletedCollection_StillRevocable(t *testing.T) {
+	f := newRestrictedOwnerVisibilityFixture(t)
+	grantee := f.seedGrantee(t)
+
+	if err := f.srv.store.DeleteCollection(f.visibleColl.ID); err != nil {
+		t.Fatalf("soft-delete visible collection: %v", err)
+	}
+
+	grant, err := f.srv.store.CreateCollectionGrant(f.ws.ID, f.visibleColl.ID, grantee.ID, "view", f.ownerID)
+	if err != nil {
+		t.Fatalf("seed grant on soft-deleted collection: %v", err)
+	}
+	link, err := f.srv.store.CreateShareLink(f.ws.ID, "collection", f.visibleColl.ID, "view", f.ownerID, nil)
+	if err != nil {
+		t.Fatalf("seed share link on soft-deleted collection: %v", err)
+	}
+
+	grantPath := "/api/v1/workspaces/" + f.ws.Slug + "/collections/" + f.visibleColl.Slug + "/grants/" + grant.ID
+	rr := doRequestWithHeaders(f.srv, "DELETE", grantPath, nil, f.bearerHeaders())
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("restricted owner delete grant on soft-deleted (previously visible) collection: expected 204, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	viewsPath := "/api/v1/workspaces/" + f.ws.Slug + "/share-links/" + link.ID + "/views"
+	rr = doRequestWithHeaders(f.srv, "GET", viewsPath, nil, f.bearerHeaders())
+	if rr.Code != http.StatusOK {
+		t.Fatalf("restricted owner view-history on soft-deleted (previously visible) collection's link: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	deletePath := "/api/v1/workspaces/" + f.ws.Slug + "/share-links/" + link.ID
+	rr = doRequestWithHeaders(f.srv, "DELETE", deletePath, nil, f.bearerHeaders())
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("restricted owner delete share link on soft-deleted (previously visible) collection: expected 204, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+// TestDeleteCollectionGrant_SoftDeletedCollection_UnrestrictedOwnerStillRevokes
+// pins the MAIN regression case codex R3 flagged: an UNRESTRICTED owner
+// (member.CollectionAccess == "all" → visibleCollectionIDs == nil) must be
+// able to revoke a grant/share-link and read view-history for ANY
+// soft-deleted collection — this is the common case (most owners are
+// unrestricted) and was fully broken by the GetCollection-based lookup.
+func TestDeleteCollectionGrant_SoftDeletedCollection_UnrestrictedOwnerStillRevokes(t *testing.T) {
+	srv := testServer(t)
+	owner, err := srv.store.CreateUser(models.UserCreate{
+		Email: "unrestricted-owner@example.com", Name: "Unrestricted Owner", Password: "pw-test-12345",
+	})
+	if err != nil {
+		t.Fatalf("create owner: %v", err)
+	}
+	ws, err := srv.store.CreateWorkspace(models.WorkspaceCreate{Name: "SoftDeleteRegression", OwnerID: owner.ID})
+	if err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	if err := srv.store.AddWorkspaceMember(ws.ID, owner.ID, "owner"); err != nil {
+		t.Fatalf("add member: %v", err)
+	}
+	schema := `{"fields":[{"key":"status","type":"select","options":["open","done"],"default":"open"}]}`
+	coll, err := srv.store.CreateCollection(ws.ID, models.CollectionCreate{
+		Name: "Archivable", Slug: "archivable", Prefix: "ARC", Schema: schema,
+	})
+	if err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	grantee, err := srv.store.CreateUser(models.UserCreate{
+		Email: "grantee3@example.com", Name: "Grantee3", Password: "pw-test-12345",
+	})
+	if err != nil {
+		t.Fatalf("create grantee: %v", err)
+	}
+	grant, err := srv.store.CreateCollectionGrant(ws.ID, coll.ID, grantee.ID, "view", owner.ID)
+	if err != nil {
+		t.Fatalf("create collection grant: %v", err)
+	}
+	link, err := srv.store.CreateShareLink(ws.ID, "collection", coll.ID, "view", owner.ID, nil)
+	if err != nil {
+		t.Fatalf("create share link: %v", err)
+	}
+	tok, err := srv.store.CreateAPIToken(owner.ID, models.APITokenCreate{
+		Name: "owner-pat", WorkspaceID: ws.ID,
+	}, 0, 0)
+	if err != nil {
+		t.Fatalf("CreateAPIToken: %v", err)
+	}
+	headers := map[string]string{"Authorization": "Bearer " + tok.Token}
+
+	// Soft-delete AFTER seeding the grant/link, mirroring the real
+	// sequence: mint on a live collection, then the collection gets
+	// archived out from under them.
+	if err := srv.store.DeleteCollection(coll.ID); err != nil {
+		t.Fatalf("soft-delete collection: %v", err)
+	}
+
+	grantPath := "/api/v1/workspaces/" + ws.Slug + "/collections/" + coll.Slug + "/grants/" + grant.ID
+	rr := doRequestWithHeaders(srv, "DELETE", grantPath, nil, headers)
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("unrestricted owner delete grant on soft-deleted collection: expected 204, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	viewsPath := "/api/v1/workspaces/" + ws.Slug + "/share-links/" + link.ID + "/views"
+	rr = doRequestWithHeaders(srv, "GET", viewsPath, nil, headers)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("unrestricted owner view-history on soft-deleted collection's link: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	deletePath := "/api/v1/workspaces/" + ws.Slug + "/share-links/" + link.ID
+	rr = doRequestWithHeaders(srv, "DELETE", deletePath, nil, headers)
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("unrestricted owner delete share link on soft-deleted collection: expected 204, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
 // ─── Layering: requireMinRole (403) must run BEFORE visibility (404),
 //     ID-keyed delete/views handlers (BUG-1923) ──────────────────────────
 

--- a/internal/server/handlers_grants.go
+++ b/internal/server/handlers_grants.go
@@ -139,7 +139,14 @@ func (s *Server) handleDeleteCollectionGrant(w http.ResponseWriter, r *http.Requ
 		writeError(w, http.StatusNotFound, "not_found", "Grant not found")
 		return
 	}
-	coll, err := s.store.GetCollection(grant.CollectionID)
+	// GetCollectionAnyState (not GetCollection) — a grant on a
+	// soft-deleted collection must stay revocable. DeleteCollection
+	// soft-deletes and does NOT cascade-delete collection_grants, so
+	// gating on GetCollection's `deleted_at IS NULL` filter would 404
+	// every delete attempt the moment the collection is archived,
+	// permanently stranding the grant row. Mirrors the item-grant
+	// handler's GetItemIncludeDeleted choice below.
+	coll, err := s.store.GetCollectionAnyState(grant.CollectionID)
 	if err != nil {
 		writeInternalError(w, err)
 		return

--- a/internal/server/handlers_grants.go
+++ b/internal/server/handlers_grants.go
@@ -122,6 +122,36 @@ func (s *Server) handleDeleteCollectionGrant(w http.ResponseWriter, r *http.Requ
 	}
 
 	grantID := chi.URLParam(r, "grantID")
+
+	// BUG-1923: this handler operates on the grant ID directly, so unlike
+	// the slug-resolving create/list siblings above it never had a parent
+	// resource to gate on — a restricted owner who knew a grant ID could
+	// revoke a grant on a collection hidden from them. Resolve the grant's
+	// collection first and apply the same requireCollectionFullyVisible
+	// gate the minting/listing handlers use (STRICT — an item-level grant
+	// must not qualify for collection-wide operations).
+	grant, err := s.store.GetCollectionGrant(grantID)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	if grant == nil || grant.WorkspaceID != workspaceID {
+		writeError(w, http.StatusNotFound, "not_found", "Grant not found")
+		return
+	}
+	coll, err := s.store.GetCollection(grant.CollectionID)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	if coll == nil {
+		writeError(w, http.StatusNotFound, "not_found", "Grant not found")
+		return
+	}
+	if !s.requireCollectionFullyVisible(w, r, workspaceID, coll) {
+		return
+	}
+
 	if err := s.store.DeleteCollectionGrant(grantID, workspaceID); err != nil {
 		writeError(w, http.StatusNotFound, "not_found", "Grant not found")
 		return
@@ -243,6 +273,33 @@ func (s *Server) handleDeleteItemGrant(w http.ResponseWriter, r *http.Request) {
 	}
 
 	grantID := chi.URLParam(r, "grantID")
+
+	// BUG-1923: resolve the grant's item and gate on visibility before
+	// deleting — mirrors the collection-grant fix above. GetItemIncludeDeleted
+	// (not GetItem) matches handleListItemGrants' ResolveItemIncludeDeleted:
+	// a grant on a trashed-but-still-visible item stays revocable.
+	grant, err := s.store.GetItemGrant(grantID)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	if grant == nil || grant.WorkspaceID != workspaceID {
+		writeError(w, http.StatusNotFound, "not_found", "Grant not found")
+		return
+	}
+	item, err := s.store.GetItemIncludeDeleted(grant.ItemID)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	if item == nil {
+		writeError(w, http.StatusNotFound, "not_found", "Grant not found")
+		return
+	}
+	if !s.requireItemVisible(w, r, workspaceID, item) {
+		return
+	}
+
 	if err := s.store.DeleteItemGrant(grantID, workspaceID); err != nil {
 		writeError(w, http.StatusNotFound, "not_found", "Grant not found")
 		return

--- a/internal/server/handlers_share_links.go
+++ b/internal/server/handlers_share_links.go
@@ -323,8 +323,17 @@ func (s *Server) handleDeleteShareLink(w http.ResponseWriter, r *http.Request) {
 // go through the STRICTER requireCollectionFullyVisible, matching the
 // minting/listing gates (BUG-1920) so an item-level grant can't promote to
 // collection-wide share-link operations. Writes a 404 and returns false if
-// the target is missing/deleted or not visible; callers should invoke this
-// immediately after confirming the link belongs to the workspace.
+// the target is missing (never existed / wrong workspace) or not visible;
+// callers should invoke this immediately after confirming the link belongs
+// to the workspace.
+//
+// Both target lookups deliberately include soft-deleted parents
+// (GetItemIncludeDeleted / GetCollectionAnyState, not their deleted_at-
+// filtered counterparts): DeleteItem/DeleteCollection soft-delete and do
+// NOT cascade-delete share_links, so a share link on an archived item or
+// collection must stay both revocable (handleDeleteShareLink) and
+// inspectable (handleShareLinkViews) — gating on the filtered getters would
+// permanently strand the link the moment its target is archived.
 func (s *Server) requireShareLinkTargetVisible(w http.ResponseWriter, r *http.Request, workspaceID string, link *models.ShareLink) bool {
 	switch link.TargetType {
 	case "item":
@@ -339,7 +348,7 @@ func (s *Server) requireShareLinkTargetVisible(w http.ResponseWriter, r *http.Re
 		}
 		return s.requireItemVisible(w, r, workspaceID, item)
 	case "collection":
-		coll, err := s.store.GetCollection(link.TargetID)
+		coll, err := s.store.GetCollectionAnyState(link.TargetID)
 		if err != nil {
 			writeInternalError(w, err)
 			return false

--- a/internal/server/handlers_share_links.go
+++ b/internal/server/handlers_share_links.go
@@ -288,6 +288,24 @@ func (s *Server) handleDeleteShareLink(w http.ResponseWriter, r *http.Request) {
 	}
 
 	linkID := chi.URLParam(r, "linkID")
+
+	// BUG-1923: this handler operated on the link ID directly with no
+	// visibility check on the underlying target — a restricted owner who
+	// knew a link ID could delete a share link on a hidden item/collection.
+	// Resolve the link and its target before deleting.
+	link, err := s.store.GetShareLink(linkID)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	if link == nil || link.WorkspaceID != workspaceID {
+		writeError(w, http.StatusNotFound, "not_found", "Share link not found")
+		return
+	}
+	if !s.requireShareLinkTargetVisible(w, r, workspaceID, link) {
+		return
+	}
+
 	if err := s.store.DeleteShareLink(linkID, workspaceID); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			writeError(w, http.StatusNotFound, "not_found", "Share link not found")
@@ -297,6 +315,46 @@ func (s *Server) handleDeleteShareLink(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// requireShareLinkTargetVisible resolves a share link's target (item or
+// collection) and gates on the appropriate visibility check (BUG-1923).
+// Item-scoped links go through requireItemVisible; collection-scoped links
+// go through the STRICTER requireCollectionFullyVisible, matching the
+// minting/listing gates (BUG-1920) so an item-level grant can't promote to
+// collection-wide share-link operations. Writes a 404 and returns false if
+// the target is missing/deleted or not visible; callers should invoke this
+// immediately after confirming the link belongs to the workspace.
+func (s *Server) requireShareLinkTargetVisible(w http.ResponseWriter, r *http.Request, workspaceID string, link *models.ShareLink) bool {
+	switch link.TargetType {
+	case "item":
+		item, err := s.store.GetItemIncludeDeleted(link.TargetID)
+		if err != nil {
+			writeInternalError(w, err)
+			return false
+		}
+		if item == nil {
+			writeError(w, http.StatusNotFound, "not_found", "Share link not found")
+			return false
+		}
+		return s.requireItemVisible(w, r, workspaceID, item)
+	case "collection":
+		coll, err := s.store.GetCollection(link.TargetID)
+		if err != nil {
+			writeInternalError(w, err)
+			return false
+		}
+		if coll == nil {
+			writeError(w, http.StatusNotFound, "not_found", "Share link not found")
+			return false
+		}
+		return s.requireCollectionFullyVisible(w, r, workspaceID, coll)
+	default:
+		// Fail closed on an unrecognized target type rather than assume
+		// visibility — the model only allows "item"/"collection" today.
+		writeError(w, http.StatusNotFound, "not_found", "Share link not found")
+		return false
+	}
 }
 
 // handleResolveShareLink is the /s/{token} route. It resolves a share link
@@ -522,6 +580,12 @@ func (s *Server) handleShareLinkViews(w http.ResponseWriter, r *http.Request) {
 	}
 	if link == nil || link.WorkspaceID != workspaceID {
 		writeError(w, http.StatusNotFound, "not_found", "Share link not found")
+		return
+	}
+	// BUG-1923: this handler already resolved the link but never checked
+	// visibility on its target — a restricted owner who knew a link ID
+	// could read view-history metadata for a hidden item/collection.
+	if !s.requireShareLinkTargetVisible(w, r, workspaceID, link) {
 		return
 	}
 


### PR DESCRIPTION
## Summary

`handleDeleteCollectionGrant`, `handleDeleteItemGrant`, `handleDeleteShareLink`, and `handleShareLinkViews` operated on grant/link IDs with only `requireMinRole(owner)` — unlike their slug-resolving create/list siblings (fixed in #794), they never resolved the parent resource, so the visibility gate never ran. A restricted owner who knew an ID could revoke grants/links on (or read view-history of) hidden resources. Each handler now resolves the record → parent → visibility gate before acting.

## Plus (architectural decisions)

- **Per-class gate split:** collection-scoped records go through strict `requireCollectionFullyVisible` (no item-grant promotion, matching #794/#795); item-scoped through `requireItemVisible`. New shared helper `requireShareLinkTargetVisible` switches on TargetType with a fail-closed `default:` 404.
- **Trashed-but-visible stays revocable:** item lookups use `GetItemIncludeDeleted` (matching `handleListItemGrants` precedent); collection lookups use the existing `GetCollectionAnyState`. The latter was a mid-review fix: codex R3 caught that live-only `GetCollection` resolution made grants/links on soft-deleted collections permanently un-revocable (collection deletes don't cascade grant/link rows). Pinned by tests including "unrestricted owner still revokes on a soft-deleted collection."
- **Restricted-owner semantics traced and test-pinned:** `member_collection_access` has no `deleted_at` join, so a restricted owner's previously-visible collection remains revocable after soft-delete.
- **Error-message note (considered, accepted):** visibility 404s say "Collection/Item not found" vs the record checks' "Grant/Share link not found" — a message-text oracle in principle, but exploiting it requires possessing a valid record UUID (the actual secret), so messages stay consistent with the family's shared helpers.

## Observable behavior changes

- Restricted owner (session or bearer) deleting a grant/share-link, or reading share-link view-history, tied to a hidden resource: success → **404**.
- Unrestricted owners: unchanged, including on soft-deleted collections.
- Double-delete of the same ID: still 404 (unchanged).

## Review trail

Codex R1 (plain): CLEAN. R2 (caller blast-radius): CLEAN — only ShareDialog calls these endpoints; CLI/MCP don't expose them. R3 (cascade lens): **found the soft-deleted-collection regression** → fixed in dc82e60. R4 (inverse lens, AnyState blast radius): CLEAN, converged.

## Test plan

- [x] `go test ./...` — SQLite, all packages green (both commits)
- [x] Postgres full suite via docker-compose harness — green (store-layer call-site touch → PATTE-39 dual-driver)
- [x] `golangci-lint run ./...` — 0 issues
- [x] 8 new tests: per-handler hidden-target 404s (bearer + session), item-grant non-promotion both directions, 403-before-404 layering, soft-deleted-collection revocability ×2

Refs: BUG-1923 (docapp). Family: #792-#796. Follow-up filed from audit: BUG-1928 (handleListUserGrants metadata leak — the disclosure half; this PR closes the action half).

https://claude.ai/code/session_01CL1pBjNpPUX6SWkuAuYXHS