### PR TITLE
fix(server): filter handleListUserGrants through caller visibility (BUG-1928)

### DIFF
--- a/internal/server/handlers_grant_visibility_test.go
+++ b/internal/server/handlers_grant_visibility_test.go
@@ -1,7 +1,9 @@
 package server
 
 import (
+	"encoding/json"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -861,5 +863,155 @@ func TestItemShareLinksAndGrants_NonOwner_403BeforeVisibility(t *testing.T) {
 		if rr.Code != http.StatusForbidden {
 			t.Errorf("%s: editor (non-owner) expected 403, got %d: %s", tc.name, rr.Code, rr.Body.String())
 		}
+	}
+}
+
+// ─── handleListUserGrants (BUG-1928) ───────────────────────────────────
+
+// userGrantsResponse mirrors handleListUserGrants' JSON shape for test decoding.
+type userGrantsResponse struct {
+	CollectionGrants []models.CollectionGrant `json:"collection_grants"`
+	ItemGrants       []models.ItemGrant       `json:"item_grants"`
+}
+
+// decodeUserGrantsResponse requires a 200 and decodes the body, failing the
+// test otherwise.
+func decodeUserGrantsResponse(t *testing.T, rr *httptest.ResponseRecorder) userGrantsResponse {
+	t.Helper()
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var resp userGrantsResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	return resp
+}
+
+// TestListUserGrants_RestrictedOwner_FiltersHiddenResourceGrants pins
+// BUG-1928: a restricted owner (collection_access="specific") listing
+// ANOTHER user's grants must not see grants on resources hidden from the
+// CALLER, even though the grants belong to the target user. Exercised over
+// both auth classes (bearer PAT + session cookie), mirroring the fixture's
+// usual dual-auth coverage.
+func TestListUserGrants_RestrictedOwner_FiltersHiddenResourceGrants(t *testing.T) {
+	f := newRestrictedOwnerVisibilityFixture(t)
+	target := f.seedGrantee(t)
+
+	if _, err := f.srv.store.CreateCollectionGrant(f.ws.ID, f.hiddenColl.ID, target.ID, "view", f.ownerID); err != nil {
+		t.Fatalf("seed hidden collection grant: %v", err)
+	}
+	if _, err := f.srv.store.CreateCollectionGrant(f.ws.ID, f.visibleColl.ID, target.ID, "view", f.ownerID); err != nil {
+		t.Fatalf("seed visible collection grant: %v", err)
+	}
+	if _, err := f.srv.store.CreateItemGrant(f.ws.ID, f.hiddenItem.ID, target.ID, "view", f.ownerID); err != nil {
+		t.Fatalf("seed hidden item grant: %v", err)
+	}
+	if _, err := f.srv.store.CreateItemGrant(f.ws.ID, f.visibleItem.ID, target.ID, "view", f.ownerID); err != nil {
+		t.Fatalf("seed visible item grant: %v", err)
+	}
+
+	path := "/api/v1/workspaces/" + f.ws.Slug + "/users/" + target.ID + "/grants"
+
+	assertFiltered := func(t *testing.T, rr *httptest.ResponseRecorder) {
+		t.Helper()
+		resp := decodeUserGrantsResponse(t, rr)
+		if resp.CollectionGrants == nil {
+			t.Error("collection_grants must not be null (empty-slice semantics)")
+		}
+		if resp.ItemGrants == nil {
+			t.Error("item_grants must not be null (empty-slice semantics)")
+		}
+		if len(resp.CollectionGrants) != 1 || resp.CollectionGrants[0].CollectionID != f.visibleColl.ID {
+			t.Errorf("expected only the visible collection grant, got %+v", resp.CollectionGrants)
+		}
+		if len(resp.ItemGrants) != 1 || resp.ItemGrants[0].ItemID != f.visibleItem.ID {
+			t.Errorf("expected only the visible item grant, got %+v", resp.ItemGrants)
+		}
+	}
+
+	rr := doRequestWithHeaders(f.srv, "GET", path, nil, f.bearerHeaders())
+	assertFiltered(t, rr)
+
+	rr = doRequestWithCookie(f.srv, "GET", path, nil, f.sessionToken)
+	assertFiltered(t, rr)
+}
+
+// TestListUserGrants_SelfQuery_Unfiltered pins BUG-1928's self-query
+// carve-out: a restricted owner listing their OWN grants sees everything,
+// including an item-grant-only entry on a collection otherwise hidden from
+// them by collection_access="specific".
+func TestListUserGrants_SelfQuery_Unfiltered(t *testing.T) {
+	f := newRestrictedOwnerVisibilityFixture(t)
+	f.grantHiddenItemToOwner(t)
+
+	path := "/api/v1/workspaces/" + f.ws.Slug + "/users/" + f.ownerID + "/grants"
+	rr := doRequestWithHeaders(f.srv, "GET", path, nil, f.bearerHeaders())
+	resp := decodeUserGrantsResponse(t, rr)
+
+	found := false
+	for _, g := range resp.ItemGrants {
+		if g.ItemID == f.hiddenItem.ID {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("self-query must include the item grant on the hidden item unfiltered, got %+v", resp.ItemGrants)
+	}
+}
+
+// TestListUserGrants_UnrestrictedOwner_Unfiltered pins the cheap
+// short-circuit for unrestricted callers: a plain owner (no
+// collection_access restriction) listing another user's grants sees
+// everything, with no filtering applied.
+func TestListUserGrants_UnrestrictedOwner_Unfiltered(t *testing.T) {
+	srv := testServer(t)
+
+	owner, err := srv.store.CreateUser(models.UserCreate{
+		Email: "unrestricted-owner@example.com", Name: "Unrestricted Owner", Password: "pw-test-12345",
+	})
+	if err != nil {
+		t.Fatalf("create owner: %v", err)
+	}
+	ws, err := srv.store.CreateWorkspace(models.WorkspaceCreate{Name: "GrantVisibilityUnrestricted", OwnerID: owner.ID})
+	if err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	if err := srv.store.AddWorkspaceMember(ws.ID, owner.ID, "owner"); err != nil {
+		t.Fatalf("add member: %v", err)
+	}
+
+	schema := `{"fields":[{"key":"status","type":"select","options":["open","done"],"default":"open"}]}`
+	coll, err := srv.store.CreateCollection(ws.ID, models.CollectionCreate{
+		Name: "Coll", Slug: "coll", Prefix: "COL", Schema: schema,
+	})
+	if err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+
+	target, err := srv.store.CreateUser(models.UserCreate{
+		Email: "target@example.com", Name: "Target", Password: "pw-test-12345",
+	})
+	if err != nil {
+		t.Fatalf("create target: %v", err)
+	}
+	if _, err := srv.store.CreateCollectionGrant(ws.ID, coll.ID, target.ID, "view", owner.ID); err != nil {
+		t.Fatalf("seed collection grant: %v", err)
+	}
+
+	tok, err := srv.store.CreateAPIToken(owner.ID, models.APITokenCreate{
+		Name: "owner-pat", WorkspaceID: ws.ID,
+	}, 0, 0)
+	if err != nil {
+		t.Fatalf("CreateAPIToken: %v", err)
+	}
+	headers := map[string]string{"Authorization": "Bearer " + tok.Token}
+
+	path := "/api/v1/workspaces/" + ws.Slug + "/users/" + target.ID + "/grants"
+	rr := doRequestWithHeaders(srv, "GET", path, nil, headers)
+	resp := decodeUserGrantsResponse(t, rr)
+
+	if len(resp.CollectionGrants) != 1 || resp.CollectionGrants[0].CollectionID != coll.ID {
+		t.Errorf("unrestricted owner should see the target's grant unfiltered, got %+v", resp.CollectionGrants)
 	}
 }

--- a/internal/server/handlers_grants.go
+++ b/internal/server/handlers_grants.go
@@ -335,6 +335,19 @@ func (s *Server) handleListUserGrants(w http.ResponseWriter, r *http.Request) {
 		writeInternalError(w, err)
 		return
 	}
+
+	// BUG-1928: a caller other than the target user must not see grants on
+	// resources hidden from THEM — self-queries stay unfiltered (you can
+	// always see your own grants, including item-grant-only entries on
+	// collections you can't otherwise see).
+	if currentUserID(r) != userID {
+		collGrants, itemGrants, err = s.filterUserGrantsForCaller(r, workspaceID, collGrants, itemGrants)
+		if err != nil {
+			writeInternalError(w, err)
+			return
+		}
+	}
+
 	if collGrants == nil {
 		collGrants = []models.CollectionGrant{}
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1983,6 +1983,85 @@ func isCollectionVisible(collectionID string, visibleIDs []string) bool {
 	return false
 }
 
+// filterUserGrantsForCaller narrows collGrants/itemGrants — the TARGET
+// user's grants, already loaded by the caller — down to what the CALLER can
+// see. Only meaningful when caller != target; handleListUserGrants skips
+// calling this for self-queries (a user can always see their own grants).
+//
+// BUG-1928: handleListUserGrants returned the target's raw grants
+// (including collection_id/item_id) to any workspace owner unconditionally.
+// A restricted owner (collection_access="specific") could enumerate
+// hidden-resource IDs this way — the disclosure half of the primitive
+// BUG-1923's handlers fixed the action half of (know-the-ID → operate-on-it).
+//
+// Reuses the existing guestResourceFilter/isCollectionVisible/
+// isItemVisibleToGuest helpers rather than a bespoke visibility pass:
+// guestResourceFilter's fullCollIDs is already the STRICT full-access set
+// (member_collection_access ∪ system collections ∪ direct collection
+// grants, excluding item-grant-only collections) — the same strict set
+// requireCollectionFullyVisible narrows to — so collection grants are
+// filtered directly against it with no extra narrowing step.
+//
+// Filtering is pure ID-set membership: no parent collection/item lookup is
+// needed to decide visibility, so a grant on a soft- (or even hard-)
+// deleted parent is filtered the same as any other grant, matching #798's
+// "still revocable/inspectable" precedent for grants on archived resources.
+// The one exception is item grants, which only carry an item_id — those are
+// resolved to their collection_id via a single bulk GetItemCollectionRefs
+// call (state-agnostic; no deleted_at filter) rather than N per-grant
+// lookups.
+func (s *Server) filterUserGrantsForCaller(r *http.Request, workspaceID string, collGrants []models.CollectionGrant, itemGrants []models.ItemGrant) ([]models.CollectionGrant, []models.ItemGrant, error) {
+	fullCollIDs, grantedItemIDs, err := s.guestResourceFilter(r, workspaceID)
+	if err != nil {
+		return nil, nil, err
+	}
+	if fullCollIDs == nil && grantedItemIDs == nil {
+		// Unrestricted caller (admin/cookie session, or a member with
+		// full collection access) — no filtering, and no further store
+		// calls needed.
+		return collGrants, itemGrants, nil
+	}
+
+	filteredColl := make([]models.CollectionGrant, 0, len(collGrants))
+	for _, g := range collGrants {
+		if isCollectionVisible(g.CollectionID, fullCollIDs) {
+			filteredColl = append(filteredColl, g)
+		}
+	}
+
+	filteredItem := make([]models.ItemGrant, 0, len(itemGrants))
+	if len(itemGrants) > 0 {
+		itemIDs := make([]string, len(itemGrants))
+		for i, g := range itemGrants {
+			itemIDs[i] = g.ItemID
+		}
+		refs, err := s.store.GetItemCollectionRefs(workspaceID, itemIDs)
+		if err != nil {
+			return nil, nil, err
+		}
+		collByItem := make(map[string]string, len(refs))
+		for _, ref := range refs {
+			collByItem[ref.ID] = ref.CollectionID
+		}
+		for _, g := range itemGrants {
+			collID, ok := collByItem[g.ItemID]
+			if !ok {
+				// item_grants.item_id is ON DELETE CASCADE, so a grant
+				// row can't outlive its item — this should be
+				// unreachable. Exclude defensively rather than show a
+				// grant with no resolvable parent.
+				continue
+			}
+			item := &models.Item{ID: g.ItemID, CollectionID: collID}
+			if s.isItemVisibleToGuest(r, workspaceID, item, fullCollIDs, grantedItemIDs) {
+				filteredItem = append(filteredItem, g)
+			}
+		}
+	}
+
+	return filteredColl, filteredItem, nil
+}
+
 // requireEditPermission checks if the user has edit access to the given item.
 // For regular members (editor/owner), this uses the standard role check.
 // For members with insufficient roles (e.g., viewers), it falls back to

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -3602,7 +3602,23 @@ type ItemCollectionRef struct {
 
 // GetDeletedItemsWithCollection returns minimal item info (ID + CollectionID)
 // for soft-deleted items, used to filter deleted item IDs by collection visibility.
+//
+// Despite the name, this is just GetItemCollectionRefs under the hood — the
+// underlying query has no deleted_at filter, so it works for any item state.
+// The name is kept for this call site's existing meaning (its caller only
+// ever passes already-known-deleted IDs); BUG-1928 needed the same
+// state-agnostic lookup for live-or-deleted item grants, hence the rename
+// of the shared implementation to the more accurate GetItemCollectionRefs.
 func (s *Store) GetDeletedItemsWithCollection(workspaceID string, itemIDs []string) ([]ItemCollectionRef, error) {
+	return s.GetItemCollectionRefs(workspaceID, itemIDs)
+}
+
+// GetItemCollectionRefs returns minimal item info (ID + CollectionID) for the
+// given item IDs, scoped to the workspace. State-agnostic: the query has no
+// deleted_at filter, so it resolves live and soft-deleted items alike. Used
+// wherever a caller needs an item_id → collection_id mapping without paying
+// for a full item fetch (e.g. bulk visibility filtering).
+func (s *Store) GetItemCollectionRefs(workspaceID string, itemIDs []string) ([]ItemCollectionRef, error) {
 	if len(itemIDs) == 0 {
 		return nil, nil
 	}
@@ -3617,14 +3633,14 @@ func (s *Store) GetDeletedItemsWithCollection(workspaceID string, itemIDs []stri
 		WHERE workspace_id = ? AND id IN (%s)
 	`, strings.Join(placeholders, ","))), args...)
 	if err != nil {
-		return nil, fmt.Errorf("get deleted items with collection: %w", err)
+		return nil, fmt.Errorf("get item collection refs: %w", err)
 	}
 	defer rows.Close()
 	var results []ItemCollectionRef
 	for rows.Next() {
 		var r ItemCollectionRef
 		if err := rows.Scan(&r.ID, &r.CollectionID); err != nil {
-			return nil, fmt.Errorf("scan deleted item: %w", err)
+			return nil, fmt.Errorf("scan item collection ref: %w", err)
 		}
 		results = append(results, r)
 	}


### PR DESCRIPTION
## Summary

`handleListUserGrants` returned a target user's raw collection/item grants — including resource UUIDs — to any workspace owner, with no visibility filter on the caller. A restricted owner querying another member's grants learned hidden-resource existence and IDs: the disclosure half that composes with the ID-keyed action half fixed in #798. The response is now filtered through the caller's visibility when the caller is not the target user.

## Plus (architectural decisions)

- **Strict set, same as the family:** collection grants filter against `guestResourceFilter`'s full-access set (the `requireCollectionFullyVisible` narrowing — item-grant-only collections don't qualify); item grants through the existing `isItemVisibleToGuest` set-membership helper. Unrestricted callers short-circuit with zero extra store calls.
- **One bulk lookup, not N:** new `GetItemCollectionRefs` store method resolves all item→collection refs in a single state-agnostic query; `GetDeletedItemsWithCollection` (misnamed — it never filtered `deleted_at`) now delegates to it byte-identically. Rename deferred.
- **Self-queries unfiltered** (you always see your own grants — test-pinned, including item-grant-only entries on hidden collections). Empty-slice-vs-null JSON semantics preserved through the filter path (non-nil assertions in tests).
- **Consistent with #798 on soft-deleted parents:** listed grants remain revocable; set-membership filtering is deletion-state-independent.

## Observable behavior changes

- Restricted owner (session or bearer) listing ANOTHER member's grants: hidden-resource grants absent from the response. Self-queries, unrestricted callers: unchanged.

## Review trail

Codex R1 (plain): CLEAN. R2 (over-filter inversion; verified the synthetic `Item{ID, CollectionID}` against `isItemVisibleToGuest`'s actual field reads — only those two fields are read): CLEAN, converged.

## Test plan

- [x] `go test ./...` — SQLite, all packages green
- [x] `make test-pg` — Postgres full suite green (new store method → dual-driver)
- [x] `golangci-lint run ./...` — 0 issues
- [x] 3 new tests: restricted-owner filtering (bearer + cookie), self-query unfiltered, unrestricted unfiltered
- [x] Frontend audit: `listUserGrants()` client method has zero call sites; `handleGetMe` is self-scoped — no consumer breakage

Refs: BUG-1928 (docapp). Family: #792-#796, #798 (action half). Remaining family items are Dave-gated: BUG-1922, BUG-1925, BUG-1926.

https://claude.ai/code/session_01CL1pBjNpPUX6SWkuAuYXHS