### PR TITLE
fix(web): don't mask/redirect on 401 from auth-form submissions (BUG-1929)

### DIFF
--- a/web/src/lib/api/client.test.ts
+++ b/web/src/lib/api/client.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { api } from './client';
+
+// The 401 interceptor branches on `typeof window !== 'undefined'`. The
+// vitest environment here is 'node' (see vitest.config.ts), so `window` is
+// absent by default — exactly like calling the client from a non-browser
+// context. Tests that need to observe the redirect side effect stub a
+// minimal `window` global and restore it afterward so other tests keep
+// running in the "no window" (no-op redirect) branch.
+function stubWindow(pathname: string, search = '') {
+	const win = {
+		location: {
+			pathname,
+			search,
+			href: '',
+		},
+	};
+	vi.stubGlobal('window', win);
+	return win;
+}
+
+function mockFetchOnce(status: number, body: unknown) {
+	vi.stubGlobal(
+		'fetch',
+		vi.fn(async () => ({
+			status,
+			ok: status >= 200 && status < 300,
+			json: async () => body,
+		}))
+	);
+}
+
+describe('api client 401 handling (BUG-1929)', () => {
+	beforeEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('surfaces the real server message for a bad /auth/login attempt, without redirecting', async () => {
+		const win = stubWindow('/login');
+		mockFetchOnce(401, { error: { code: 'unauthorized', message: 'Invalid email or password' } });
+
+		await expect(api.auth.login('a@b.com', 'wrong')).rejects.toMatchObject({
+			message: 'Invalid email or password',
+			code: 'unauthorized',
+		});
+		expect(win.location.href).toBe('');
+	});
+
+	it('surfaces the real server message for a bad /auth/2fa/login-verify attempt, without redirecting', async () => {
+		const win = stubWindow('/login');
+		mockFetchOnce(401, { error: { code: 'unauthorized', message: 'Invalid 2FA verification' } });
+
+		await expect(api.auth.verify2FA('challenge-token', '000000')).rejects.toMatchObject({
+			message: 'Invalid 2FA verification',
+			code: 'unauthorized',
+		});
+		expect(win.location.href).toBe('');
+	});
+
+	it('surfaces the real server message for a bad /auth/register attempt, without redirecting', async () => {
+		const win = stubWindow('/register');
+		mockFetchOnce(401, { error: { code: 'unauthorized', message: 'Registration failed' } });
+
+		await expect(api.auth.register('a@b.com', 'A', 'password123')).rejects.toMatchObject({
+			message: 'Registration failed',
+			code: 'unauthorized',
+		});
+		expect(win.location.href).toBe('');
+	});
+
+	it('still redirects to /login with a ?redirect= return-to path for a non-auth-form 401 (session expiry)', async () => {
+		const win = stubWindow('/some/workspace/items', '?foo=bar');
+		mockFetchOnce(401, { error: { code: 'unauthorized', message: 'Not logged in' } });
+
+		await expect(api.items.list('some-workspace')).rejects.toMatchObject({
+			message: 'Authentication required',
+			code: 'unauthorized',
+		});
+		expect(win.location.href).toBe(
+			`/login?redirect=${encodeURIComponent('/some/workspace/items?foo=bar')}`
+		);
+	});
+
+	it('does not redirect (or loop) when the 401 fires while already on /login', async () => {
+		const win = stubWindow('/login', '?redirect=%2Fconsole');
+		mockFetchOnce(401, { error: { code: 'unauthorized', message: 'Not logged in' } });
+
+		await expect(api.items.list('some-workspace')).rejects.toMatchObject({
+			message: 'Authentication required',
+		});
+		expect(win.location.href).toBe('');
+	});
+});

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -240,6 +240,21 @@ function getCSRFToken(): string | null {
 	return match ? match[1] : null;
 }
 
+/**
+ * Endpoints hit only from explicit, unauthenticated auth-form submissions
+ * (login, register, 2FA challenge). A 401 from these means "the
+ * credentials/code the user just typed were wrong", not "your session
+ * expired" — so the interceptor must NOT redirect or mask the response
+ * body here; the server's real message ("Invalid email or password",
+ * "Invalid 2FA verification", ...) needs to reach the form. Mirrors the
+ * grouping `middleware_ratelimit.go` already uses for these same three
+ * paths. BUG-1929 / IDEA-1927 §B2.
+ *
+ * `register` never actually 401s server-side today (only 400/403) but is
+ * included for defense-in-depth per the audit.
+ */
+const AUTH_FORM_401_PATHS = new Set(['/auth/login', '/auth/register', '/auth/2fa/login-verify']);
+
 async function request<T>(path: string, options?: RequestInit): Promise<T> {
 	const headers: Record<string, string> = { 'Content-Type': 'application/json' };
 
@@ -256,9 +271,20 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
 		...options
 	});
 	if (resp.status === 401) {
-		// Redirect to login page (avoid infinite loop)
+		const barePath = path.split('?')[0];
+		if (AUTH_FORM_401_PATHS.has(barePath)) {
+			const body = await resp.json().catch(() => null);
+			if (body?.error) throw new PadApiError(body.error);
+			throw new PadApiError({ code: 'unauthorized', message: 'Authentication failed' });
+		}
+		// Redirect to login page (avoid infinite loop), preserving the
+		// current location as a return-to target so a genuine session
+		// expiry doesn't strand the user wherever they were (BUG-1929 /
+		// IDEA-1927 §B2(c)) — /login already validates and consumes
+		// `?redirect=` (see $lib/auth/redirect.ts).
 		if (typeof window !== 'undefined' && !window.location.pathname.startsWith('/login')) {
-			window.location.href = '/login';
+			const target = window.location.pathname + window.location.search;
+			window.location.href = `/login?redirect=${encodeURIComponent(target)}`;
 		}
 		throw new PadApiError({ code: 'unauthorized', message: 'Authentication required' });
 	}

--- a/web/src/lib/auth/redirect.test.ts
+++ b/web/src/lib/auth/redirect.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { DEFAULT_REDIRECT, validateRedirect } from './redirect';
+
+// Regression pins for the open-redirect guard in validateRedirect (BUG-1929
+// follow-up, Codex R2). A bare `startsWith('/')` check is not enough — these
+// are the concrete bypass shapes a browser or an upstream redirect handler
+// can end up treating as cross-origin, so each MUST fall through to
+// DEFAULT_REDIRECT rather than being echoed back as a safe target.
+describe('validateRedirect — hostile input rejection', () => {
+	const hostileValues = [
+		'//host', // protocol-relative — browsers treat this as same-scheme, different host
+		'%2F%2Fhost', // percent-encoded protocol-relative (also fails the leading-'/' check outright)
+		'/%2Fhost', // single-encoded second slash — decodes to //host
+		'/\\host', // backslash form — some browsers/redirect handlers normalize \\ to /
+		'/%5Chost' // percent-encoded backslash form — decodes to /\host
+	];
+
+	for (const value of hostileValues) {
+		it(`rejects ${JSON.stringify(value)}`, () => {
+			expect(validateRedirect(value)).toBe(DEFAULT_REDIRECT);
+		});
+	}
+
+	it('still accepts a legitimate same-origin path', () => {
+		expect(validateRedirect('/join/abc123')).toBe('/join/abc123');
+	});
+});

--- a/web/src/lib/auth/redirect.ts
+++ b/web/src/lib/auth/redirect.ts
@@ -108,13 +108,23 @@ export async function navigateToRedirectTarget(target: string): Promise<void> {
  * potentially-cross-origin values. Callers can compare the return
  * value against DEFAULT_REDIRECT to detect "no real redirect requested"
  * without re-parsing.
+ *
+ * Beyond the literal `//` and `/\` prefixes, also reject any percent-encoded
+ * slash or backslash (`%2f`, `%5c`, case-insensitive) anywhere in the value.
+ * `page.url.searchParams.get()` already decodes standard query-string
+ * encoding once, so these normally can't reach here still encoded — but a
+ * caller that hands this function an already-decoded-once value (or any
+ * future caller that doesn't go through URLSearchParams) could. Rejecting
+ * them defensively costs nothing: no legitimate SPA route ever contains a
+ * literal `%2f`/`%5c` sequence. BUG-1929 follow-up (Codex R2).
  */
 export function validateRedirect(raw: string | null | undefined): string {
 	if (
 		raw &&
 		raw.startsWith('/') &&
 		!raw.startsWith('//') &&
-		!raw.startsWith('/\\')
+		!raw.startsWith('/\\') &&
+		!/%2f|%5c/i.test(raw)
 	) {
 		return raw;
 	}


### PR DESCRIPTION
## Summary

The client's global 401 interceptor hard-redirected to /login and threw a hardcoded "Authentication required" for every 401 — including bad-credentials responses from login, register, and 2FA verification — masking the server's real error and stranding /join invitees (IDEA-1927 §B2, the audit's highest-impact finding). Auth-form 401s now surface the server's actual message inline; session-expiry 401s elsewhere are unchanged except the redirect now carries an encoded `?redirect=` return-to that /login already validates and consumes.

## Plus (architectural decisions)

- **Path allowlist** (`/auth/login`, `/auth/register`, `/auth/2fa/login-verify`) mirrors the exact grouping `middleware_ratelimit.go` already uses for these endpoints. Register never 401s today — included for defense-in-depth per the audit.
- **Zero form changes needed:** all three forms already render `err.message` inline; the fix is entirely in the interceptor.
- **Ruled in/out by server status codes:** acceptInvitation's 401 is genuine session loss (stays on the redirect path, now with return-to); bootstrap/resetPassword never 401; the five hand-rolled 401 blocks on workspace operations are correctly untouched.
- **Bonus hardening from review:** writing hostile-value pins for `validateRedirect` exposed that percent-encoded separators (`/%2Fhost`, `/%5Chost`) passed the literal-prefix check. Not browser-exploitable (encoded chars in a path segment aren't re-decoded into separators by navigation), but the validator contract now rejects them (2-line case-insensitive check). Trade-off accepted: a legitimate return-to containing an encoded slash in its query string now falls back to the default landing page — fail-safe direction.

## Observable behavior changes

- Wrong password / bad 2FA code: inline server message on the form (was: bounce to /login with generic text).
- Genuine session expiry mid-flow: redirect to `/login?redirect=<where-you-were>` (was: return-to discarded).

## Review trail

Codex R1 (plain): CLEAN. R2 (open-redirect/abuse lens): converged — no bypass; validateRedirect verified against encoded and protocol-relative forms; its one nit (hostile-value test pins) produced the validator hardening above.

## Test plan

- [x] `npm test` — 120/120 (11 new: 5 interceptor cases incl. no-loop + encoded round-trip; 6 validateRedirect pins)
- [x] `npm run check` — 0 errors
- [x] `npm run build` — clean
- [x] Frontend-only; no Go/store surface

Refs: BUG-1929 (docapp), parent IDEA-1927 §B2. Companions filed: BUG-1930 (B3), BUG-1931 (B4), TASK-1932 (B6-B9).

https://claude.ai/code/session_01CL1pBjNpPUX6SWkuAuYXHS