### PR TITLE
fix(web): default logged-out /join visitors to register mode (BUG-1930)

### DIFF
--- a/web/src/routes/join/[code]/+page.svelte
+++ b/web/src/routes/join/[code]/+page.svelte
@@ -48,13 +48,22 @@
 				setupMethod = session.setup_method;
 				status = 'setup';
 			} else {
-				// Users exist, not logged in — show login (with option to register)
-				mode = 'login';
+				// Logged out. Default to REGISTER, not login: a never-registered
+				// invitee has no account to sign into, and the register submit
+				// (below) passes the invitation code, which bypasses the normal
+				// registration gate and auto-accepts the invite in one step. The
+				// "already have an account? sign in" switch still lets a
+				// returning user flip to login. Do NOT change this default back
+				// to 'login' — that's BUG-1930 (dead-ends every fresh invitee
+				// in a login-a-nonexistent-account loop). See IDEA-1927 §B3.
+				mode = 'register';
 				status = 'login';
 			}
 		} catch {
+			// Session probe itself failed — same reasoning as above: don't
+			// assume "returning user" here either. See BUG-1930.
 			status = 'login';
-			mode = 'login';
+			mode = 'register';
 		}
 	});
 


### PR DESCRIPTION
## Summary

`/join/<code>` defaulted every logged-out visitor to login mode, so a never-registered invitee tried to sign into a nonexistent account, got a 401, and dead-ended (IDEA-1927 §B3). The working path — register mode passes the invitation code, bypassing the registration gate and auto-accepting the invite — was hidden behind a "Create one" toggle. Logged-out visitors now default to register mode; the "already have an account? sign in" switch is unchanged and bidirectional.

## Plus

- Both copies of the override fixed (the not-authenticated else-branch AND the session-probe catch block), each with an anti-revert comment citing the bug — the previous default *looked* reasonable, which is exactly how it would come back.
- Composes with #800: a returning user who flips to login and typos their password now sees the real error inline instead of being bounced.
- §B5 (show/prefill invited email) deliberately excluded: no client-reachable endpoint returns the invited email today; doing it right needs new API surface. Stays tracked in IDEA-1927.

## Observable behavior changes

- Invited, logged-out visitor: lands on "Create account & join" (was "Sign in & join").
- Logged-in visitors, setup mode, invalid codes: unchanged (flow-traced in review).

## Review trail

Codex R1 (state-trace lens: returning user / expired session / setup / invalid code): CLEAN, converged. Single round — right-sized for a 2-line default change.

## Test plan

- [x] `npm test` — 120/120
- [x] `npm run check` — 0 errors
- [x] `npm run build` — clean
- [x] No test harness exists for this route (no join E2E spec); the fix is two explicit assignments with revert-guard comments

Refs: BUG-1930 (docapp), parent IDEA-1927 §B3. Companions: #800 (B2), BUG-1931 (B4, open), TASK-1932 (B6-B9).

https://claude.ai/code/session_01CL1pBjNpPUX6SWkuAuYXHS