### PR TITLE
fix(server): invitation-preview endpoint + read-only email prefill on /join (BUG-1934)

### DIFF
--- a/internal/server/handlers_invitation_preview_test.go
+++ b/internal/server/handlers_invitation_preview_test.go
@@ -1,0 +1,161 @@
+package server
+
+// BUG-1934 — GET /api/v1/invitations/{code}/preview is a non-consuming,
+// public (pre-auth), always-200, rate-limited endpoint that lets the /join
+// page prefill the invited email read-only and pick register-vs-login mode.
+// These tests pin the load-bearing properties: it never accepts the invite,
+// it never 404s (enumeration safety), and it's wired to a rate limiter.
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// previewResp mirrors the handler's success and not-found shapes.
+type previewResp struct {
+	Found         bool   `json:"found"`
+	Email         string `json:"email"`
+	WorkspaceName string `json:"workspace_name"`
+	HasAccount    bool   `json:"has_account"`
+}
+
+const previewBadCode = "deadbeefdeadbeefdeadbeefdeadbeef" // 32 hex chars, never issued
+
+// seedOwnerWorkspace bootstraps the first admin (so RequireAuth is active and
+// users exist) and returns the owner plus a fresh workspace they own.
+func seedOwnerWorkspace(t *testing.T, srv *Server, wsName string) (*models.User, *models.Workspace) {
+	t.Helper()
+	bootstrapFirstUser(t, srv, "owner@example.com", "Owner")
+	owner, err := srv.store.GetUserByEmail("owner@example.com")
+	if err != nil || owner == nil {
+		t.Fatalf("get owner: %v", err)
+	}
+	ws, err := srv.store.CreateWorkspace(models.WorkspaceCreate{Name: wsName, OwnerID: owner.ID})
+	if err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	return owner, ws
+}
+
+// TestPreviewInvitation_ReturnsMetadataWithoutConsuming is the canonical
+// happy path: an unauthenticated caller gets the invited email + workspace
+// name, and the invitation stays pending afterward.
+func TestPreviewInvitation_ReturnsMetadataWithoutConsuming(t *testing.T) {
+	srv := testServer(t)
+	owner, ws := seedOwnerWorkspace(t, srv, "Acme HQ")
+
+	inv, err := srv.store.CreateInvitation(ws.ID, "invitee@example.com", "editor", owner.ID)
+	if err != nil {
+		t.Fatalf("create invitation: %v", err)
+	}
+
+	// Unauthenticated (no session/token), non-loopback IP.
+	rr := doRequest(srv, "GET", "/api/v1/invitations/"+inv.Code+"/preview", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("preview: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var resp previewResp
+	parseJSON(t, rr, &resp)
+	if !resp.Found {
+		t.Fatalf("expected found=true, got %+v", resp)
+	}
+	if resp.Email != "invitee@example.com" {
+		t.Errorf("expected email invitee@example.com, got %q", resp.Email)
+	}
+	if resp.WorkspaceName != "Acme HQ" {
+		t.Errorf("expected workspace_name 'Acme HQ', got %q", resp.WorkspaceName)
+	}
+	if resp.HasAccount {
+		t.Errorf("expected has_account=false (no account for invitee), got true")
+	}
+
+	// Non-consuming: the invitation must still be pending and resolvable.
+	still, err := srv.store.GetInvitationByCode(inv.Code)
+	if err != nil {
+		t.Fatalf("re-lookup invitation: %v", err)
+	}
+	if still == nil {
+		t.Fatal("preview consumed the invitation (GetInvitationByCode now returns nil)")
+	}
+	if still.AcceptedAt != nil {
+		t.Fatal("preview marked the invitation as accepted")
+	}
+}
+
+// TestPreviewInvitation_HasAccountTrue flips has_account when an account
+// already exists for the invited address — the signal the /join page uses to
+// default to login mode.
+func TestPreviewInvitation_HasAccountTrue(t *testing.T) {
+	srv := testServer(t)
+	owner, ws := seedOwnerWorkspace(t, srv, "Beta")
+
+	if _, err := srv.store.CreateUser(models.UserCreate{
+		Email:    "member@example.com",
+		Name:     "Member",
+		Password: "correct-horse-battery-staple",
+	}); err != nil {
+		t.Fatalf("create existing user: %v", err)
+	}
+	inv, err := srv.store.CreateInvitation(ws.ID, "member@example.com", "editor", owner.ID)
+	if err != nil {
+		t.Fatalf("create invitation: %v", err)
+	}
+
+	rr := doRequest(srv, "GET", "/api/v1/invitations/"+inv.Code+"/preview", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("preview: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var resp previewResp
+	parseJSON(t, rr, &resp)
+	if !resp.Found || !resp.HasAccount {
+		t.Fatalf("expected found=true & has_account=true, got %+v", resp)
+	}
+}
+
+// TestPreviewInvitation_UnknownCodeIsFoundFalse pins enumeration safety: an
+// unknown code returns 200 with {found:false} and leaks no email — the same
+// shape a valid-but-expired or deleted-workspace code would return, so the
+// response can't be used to probe which codes are real.
+func TestPreviewInvitation_UnknownCodeIsFoundFalse(t *testing.T) {
+	srv := testServer(t)
+	// Users exist (RequireAuth active) — the endpoint must still be public.
+	bootstrapFirstUser(t, srv, "owner@example.com", "Owner")
+
+	rr := doRequest(srv, "GET", "/api/v1/invitations/"+previewBadCode+"/preview", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("unknown code: expected 200 (never 404), got %d: %s", rr.Code, rr.Body.String())
+	}
+	var resp previewResp
+	parseJSON(t, rr, &resp)
+	if resp.Found {
+		t.Errorf("expected found=false for unknown code, got %+v", resp)
+	}
+	if resp.Email != "" {
+		t.Errorf("unknown code leaked an email: %q", resp.Email)
+	}
+}
+
+// TestPreviewInvitation_RateLimited proves the endpoint is wired to its
+// dedicated per-IP limiter (burst 20) so it can't be used to enumerate the
+// code space at speed.
+func TestPreviewInvitation_RateLimited(t *testing.T) {
+	srv := testServer(t)
+	const ip = "203.0.113.55:1"
+
+	got429 := false
+	for i := 0; i < 25; i++ {
+		rr := doRequestFromRemoteAddr(srv, "GET", "/api/v1/invitations/"+previewBadCode+"/preview", nil, ip)
+		if rr.Code == http.StatusTooManyRequests {
+			got429 = true
+			break
+		}
+		if rr.Code != http.StatusOK {
+			t.Fatalf("request %d: expected 200 or 429, got %d: %s", i, rr.Code, rr.Body.String())
+		}
+	}
+	if !got429 {
+		t.Fatal("expected the preview endpoint to rate-limit after its burst is exhausted")
+	}
+}

--- a/internal/server/handlers_members.go
+++ b/internal/server/handlers_members.go
@@ -353,6 +353,72 @@ func (s *Server) handleAcceptInvitation(w http.ResponseWriter, r *http.Request) 
 	})
 }
 
+// handlePreviewInvitation returns non-consuming metadata about an invitation
+// so the /join page can prefill the invited email (read-only) and pick
+// register-vs-login mode. Unlike handleAcceptInvitation it never mutates
+// state — no membership add, no accepted_at write.
+//
+// Enumeration safety: this endpoint is public (pre-auth) and reveals whether
+// a code maps to a live invitation, so it is engineered against invite-code
+// enumeration on two fronts:
+//   - Always HTTP 200. Invalid, expired, missing, or dangling-workspace codes
+//     all return the SAME {"found": false} shape — no 404/410/403 status
+//     signal to distinguish "wrong code" from "valid code" (matches the
+//     always-200 posture of the auth reset/verify endpoints). A genuine DB
+//     fault still 500s, but that outcome is code-independent (identical for
+//     every code) so it leaks nothing about which codes are valid.
+//   - Rate limited. The route is wired to a dedicated per-IP limiter in
+//     middleware_ratelimit.go so an attacker can't grind the code space.
+//     (Codes are 128-bit random anyway — see CreateInvitation — so brute
+//     force is already infeasible; the limiter is defense in depth.)
+func (s *Server) handlePreviewInvitation(w http.ResponseWriter, r *http.Request) {
+	code := chi.URLParam(r, "code")
+
+	notFound := func() {
+		writeJSON(w, http.StatusOK, map[string]interface{}{"found": false})
+	}
+
+	inv, err := s.store.GetInvitationByCode(code)
+	if err != nil {
+		// Genuine backend fault (DB down, etc.) — not a code-validity signal.
+		writeInternalError(w, err)
+		return
+	}
+	// Treat missing and expired invitations identically to an unknown code so
+	// the response can't be used to probe which codes were ever real.
+	if inv == nil || inv.IsExpired() {
+		notFound()
+		return
+	}
+
+	// A live invitation to a since-deleted workspace has nothing to join.
+	ws, err := s.store.GetWorkspaceByID(inv.WorkspaceID)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	if ws == nil {
+		notFound()
+		return
+	}
+
+	// has_account: does an account already exist for the invited address?
+	// Lets the client default to login instead of register. GetUserByEmail
+	// returns (nil, nil) when no such user exists.
+	existingUser, err := s.store.GetUserByEmail(inv.Email)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"found":          true,
+		"email":          inv.Email,
+		"workspace_name": ws.Name,
+		"has_account":    existingUser != nil,
+	})
+}
+
 // handleGetMemberCollectionAccess returns a member's collection access mode and granted IDs.
 func (s *Server) handleGetMemberCollectionAccess(w http.ResponseWriter, r *http.Request) {
 	workspaceID, ok := s.getWorkspaceID(w, r)

--- a/internal/server/middleware_auth.go
+++ b/internal/server/middleware_auth.go
@@ -307,6 +307,13 @@ func isPublicAPIPath(path string) bool {
 		strings.HasPrefix(path, "/api/v1/health/") ||
 		strings.HasPrefix(path, "/api/v1/s/") ||
 		path == "/api/v1/plan-limits" ||
+		// Non-consuming invitation preview (BUG-1934). A logged-out invitee
+		// hits /join/{code} before authenticating, and the page fetches the
+		// invited email + workspace name to prefill the form. Read-only and
+		// always-200 (enumeration-safe); the accept path (/accept) stays
+		// auth-gated. Matches only the trailing /preview segment so
+		// /invitations/{code}/accept is unaffected.
+		(strings.HasPrefix(path, "/api/v1/invitations/") && strings.HasSuffix(path, "/preview")) ||
 		// Server capability profile (TASK-878). The editor reads this
 		// before login on shared-item preview surfaces, and the
 		// handler is intentionally read-only (no DB writes, no

--- a/internal/server/middleware_ratelimit.go
+++ b/internal/server/middleware_ratelimit.go
@@ -142,6 +142,15 @@ type RateLimiters struct {
 	API *ipRateLimiter
 	// Search: per-user or per-IP
 	Search *ipRateLimiter
+	// InvitationPreview: per-IP limiter for the public, pre-auth
+	// GET /api/v1/invitations/{code}/preview endpoint (BUG-1934). The
+	// endpoint is always-200 by design, so the status code can't be used
+	// to distinguish valid from invalid codes — this limiter is the second
+	// enumeration defense, capping how fast an attacker can probe the code
+	// space. Invite codes are 128-bit random (see CreateInvitation) so brute
+	// force is already infeasible; this is defense in depth. Per-IP because
+	// the caller is unauthenticated.
+	InvitationPreview *ipRateLimiter
 	// RecoveryCode caps how many recovery codes can be tried against a
 	// single 2FA challenge token. Without it an attacker who captures a
 	// valid challenge_token can grind through the small recovery-code
@@ -222,6 +231,14 @@ func NewRateLimiters() *RateLimiters {
 			Rate:  rate.Limit(30.0 / 60.0),
 			Burst: 10,
 		}),
+		// InvitationPreview: 20 requests per minute per IP (= 20/60 per second,
+		// burst 20). The /join page fetches this once on mount, so the ceiling
+		// is generous enough for a shared-NAT team onboarding in a batch while
+		// still capping code-enumeration probes at 20/min/IP (BUG-1934).
+		InvitationPreview: newIPRateLimiter(rateLimitConfig{
+			Rate:  rate.Limit(20.0 / 60.0),
+			Burst: 20,
+		}),
 		// RecoveryCode: up to 6 attempts per challenge token before lockout.
 		// Challenge tokens live for 5 minutes, so we only need the limiter to
 		// remember that long — but retention defaults to 30 minutes so we
@@ -286,6 +303,7 @@ func (rls *RateLimiters) Stop() {
 		rls.CloudAdmin,
 		rls.API,
 		rls.Search,
+		rls.InvitationPreview,
 		rls.RecoveryCode,
 		rls.MCPPerToken,
 	} {
@@ -381,6 +399,23 @@ func (s *Server) RateLimit(next http.Handler) http.Handler {
 				}
 			}
 			// Other admin endpoints fall through to general API limit below
+		}
+
+		// Invitation preview (BUG-1934): public, pre-auth,
+		// GET /api/v1/invitations/{code}/preview. Rate-limit per IP on a
+		// dedicated strict bucket so it can't be used to enumerate invite
+		// codes — the endpoint is always-200 so the status can't leak
+		// validity, making the rate cap the primary volume defense. Matches
+		// only the trailing /preview segment; /invitations/{code}/accept is
+		// authenticated and falls through to the general API limit.
+		if strings.HasPrefix(path, "/api/v1/invitations/") && strings.HasSuffix(path, "/preview") {
+			if !s.rateLimiters.InvitationPreview.getLimiter(ip).Allow() {
+				slog.Warn("rate limited", "ip", ip, "path", path, "limiter", "invitation_preview")
+				writeRateLimitResponse(w, s.rateLimiters.InvitationPreview.config)
+				return
+			}
+			next.ServeHTTP(w, r)
+			return
 		}
 
 		// Search endpoint

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1022,6 +1022,13 @@ func (s *Server) setupRouter() {
 			// Invitations (outside workspace scope)
 			r.Post("/invitations/{code}/accept", s.handleAcceptInvitation)
 
+			// Non-consuming invitation preview (BUG-1934). Public/pre-auth
+			// (exempted in isPublicAPIPath) so the logged-out /join page can
+			// prefill the invited email read-only and pick register-vs-login
+			// mode. Always HTTP 200 + rate limited (see middleware_ratelimit.go)
+			// so it can't be used to enumerate invite codes.
+			r.Get("/invitations/{code}/preview", s.handlePreviewInvitation)
+
 			// OAuth client public-info (PLAN-943 TASK-1027 sub-PR E).
 			// Read-only consent-screen support for OAuth clients
 			// registered via /oauth/register. Auth-required (inherits

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -494,6 +494,16 @@ export interface LoginResponse {
 	challenge_token?: string;
 }
 
+// Non-consuming invitation preview (BUG-1934). `found` is false for
+// invalid/expired/missing codes (the endpoint is always-200 for enumeration
+// safety); the other fields are only present when `found` is true.
+export interface InvitationPreview {
+	found: boolean;
+	email?: string;
+	workspace_name?: string;
+	has_account?: boolean;
+}
+
 export const api = {
 	// ── Health / Version ──────────────────────────────────────────────────────
 
@@ -1438,6 +1448,11 @@ export const api = {
 			request<{ accepted: boolean; workspace_id: string; role: string }>(`/invitations/${code}/accept`, {
 				method: 'POST'
 			}),
+		// Non-consuming, public preview of an invitation (BUG-1934). Used by the
+		// /join page to prefill the invited email read-only and pick
+		// register-vs-login mode. Always resolves (HTTP 200); check `found`.
+		previewInvitation: (code: string) =>
+			request<InvitationPreview>(`/invitations/${encodeURIComponent(code)}/preview`),
 		getMemberCollectionAccess: (ws: string, userId: string) =>
 			request<{ collection_access: string; collection_ids: string[] }>(`/workspaces/${ws}/members/${userId}/collection-access`),
 		setMemberCollectionAccess: (ws: string, userId: string, mode: string, collectionIDs: string[]) =>

--- a/web/src/routes/join/[code]/+page.svelte
+++ b/web/src/routes/join/[code]/+page.svelte
@@ -2,7 +2,7 @@
 	import { onMount } from 'svelte';
 	import { goto } from '$app/navigation';
 	import { page } from '$app/state';
-	import { api } from '$lib/api/client';
+	import { api, type InvitationPreview } from '$lib/api/client';
 	import { authStore } from '$lib/stores/auth.svelte';
 	import SetupRequiredNotice from '$lib/components/auth/SetupRequiredNotice.svelte';
 	import AuthHeader from '$lib/components/auth/AuthHeader.svelte';
@@ -16,6 +16,12 @@
 	// Auth form state
 	let mode = $state<'login' | 'register'>('register');
 	let email = $state('');
+	// When the non-consuming preview (BUG-1934) resolves the invited address,
+	// we prefill `email` and lock the field: the backend binds the invite to
+	// this exact address (register 403s on mismatch; accept requires the
+	// signed-in account to match), so letting the invitee retype it only
+	// invites the confusing invitation_email_mismatch rejection this fixes.
+	let invitedEmail = $state<string | null>(null);
 	let name = $state('');
 	let username = $state('');
 	let password = $state('');
@@ -39,33 +45,53 @@
 		// fetch is mid-flight, and it lights up once authStore resolves.
 		authStore.ensureLoaded().catch(() => {});
 
+		// Kick off the non-consuming invitation preview (BUG-1934) in parallel
+		// with the session probe. It's always-200 and never accepts the invite;
+		// it just tells us the invited email (to prefill read-only) and whether
+		// an account already exists (to pick login vs register). Best-effort: on
+		// failure we fall back to a blank, editable email field.
+		const previewPromise = api.members.previewInvitation(code).catch(() => null);
+
 		try {
 			const session = await api.auth.session();
 			if (session.authenticated) {
 				// Already logged in — try to accept directly
 				await acceptInvitation();
-			} else if (session.setup_required) {
+				return;
+			}
+			if (session.setup_required) {
 				setupMethod = session.setup_method;
 				status = 'setup';
-			} else {
-				// Logged out. Default to REGISTER, not login: a never-registered
-				// invitee has no account to sign into, and the register submit
-				// (below) passes the invitation code, which bypasses the normal
-				// registration gate and auto-accepts the invite in one step. The
-				// "already have an account? sign in" switch still lets a
-				// returning user flip to login. Do NOT change this default back
-				// to 'login' — that's BUG-1930 (dead-ends every fresh invitee
-				// in a login-a-nonexistent-account loop). See IDEA-1927 §B3.
-				mode = 'register';
-				status = 'login';
+				return;
 			}
-		} catch {
-			// Session probe itself failed — same reasoning as above: don't
-			// assume "returning user" here either. See BUG-1930.
+			// Logged out — show the auth form.
+			await applyPreview(previewPromise);
 			status = 'login';
-			mode = 'register';
+		} catch {
+			// Session probe itself failed — still show the form (defaulting to
+			// register unless the preview says an account exists). See BUG-1930.
+			await applyPreview(previewPromise);
+			status = 'login';
 		}
 	});
+
+	// Apply the invitation preview to the auth form: prefill + lock the invited
+	// email, and default the mode by whether an account already exists. When
+	// the preview is unavailable (invalid/expired code, or the request failed)
+	// we keep the register default — a never-registered invitee has no account
+	// to sign into, and register passes the code to auto-accept in one step
+	// (BUG-1930). The "already have an account? sign in" switch still lets a
+	// returning user flip to login.
+	async function applyPreview(previewPromise: Promise<InvitationPreview | null>) {
+		const preview = await previewPromise;
+		if (preview?.found && preview.email) {
+			email = preview.email;
+			invitedEmail = preview.email;
+			mode = preview.has_account ? 'login' : 'register';
+		} else {
+			mode = 'register';
+		}
+	}
 
 	async function acceptInvitation() {
 		status = 'accepting';
@@ -303,11 +329,16 @@
 				<input
 					type="email"
 					placeholder="Email"
+					class:locked={invitedEmail !== null}
 					bind:value={email}
 					onkeydown={handleKeydown}
 					disabled={submitting}
+					readonly={invitedEmail !== null}
 					autocomplete="email"
 				/>
+				{#if invitedEmail !== null}
+					<p class="field-hint">This invitation was sent to this address.</p>
+				{/if}
 				<input
 					type="password"
 					placeholder="Password"
@@ -425,6 +456,17 @@
 	input::placeholder { color: var(--text-muted); }
 	input:focus { border-color: var(--accent-blue); }
 	input:disabled { opacity: 0.6; }
+	input.locked {
+		color: var(--text-secondary);
+		cursor: not-allowed;
+	}
+	input.locked:focus { border-color: var(--border); }
+
+	.field-hint {
+		color: var(--text-muted);
+		font-size: 0.75rem;
+		margin: calc(-1 * var(--space-2)) 0 0;
+	}
 
 	.error {
 		color: #ef4444;


### PR DESCRIPTION
## What

On Pad Cloud the `/join/[code]` page never showed the invited email, so a mistyped address hit a confusing `403 invitation_email_mismatch`. This adds a non-consuming preview endpoint and prefills the invited email read-only on the join page.

Fixes **BUG-1934** (audit §B5, Wave 0 of PLAN-1933 / IDEA-1927). Composes with the merged BUG-1930 (register default).

## Changes

- **New endpoint** `GET /api/v1/invitations/{code}/preview` (`handlePreviewInvitation`) — non-consuming, public/pre-auth, always HTTP 200, rate-limited. Returns `{found, email, workspace_name, has_account}`. Reuses `store.GetInvitationByCode` (never accepts/consumes the invite).
  - **Enumeration-safe:** invalid / expired / missing codes and dangling-workspace codes all return `200 {found:false}` — no 404 status signal to distinguish valid from invalid codes. A genuine DB fault still 500s, but that outcome is code-independent so it leaks nothing.
  - `has_account` = whether a user already exists for the invited email (`store.GetUserByEmail`).
- **Public exemption:** added to `isPublicAPIPath` in `middleware_auth.go`, matching only the trailing `/preview` segment so `/invitations/{code}/accept` stays auth-gated.
- **Rate limit:** dedicated per-IP limiter (`InvitationPreview`, 20/min burst 20) wired into the `RateLimit` switch in `middleware_ratelimit.go` (+ `Stop()` list) so invite codes can't be enumerated at speed. (Codes are 128-bit random, so this is defense in depth.)
- **TS client:** `api.members.previewInvitation` + `InvitationPreview` type.
- **Join page:** calls preview on mount, prefills + locks the invited email (read-only), and defaults register-vs-login by `has_account`. Keeps the mode-switch affordance and BUG-1930's register default when preview is unavailable.
- **Tests:** non-consumption, `has_account`, always-200 on unknown code, and rate-limiting.

## Gates

- `make check` green (golangci-lint + `go test ./...` + govulncheck + web-check / svelte-check 0 errors).
- Codex review of the diff: **CLEAN**.

https://claude.ai/code/session_01HxBkAMiFBtCRJ2tKSCt3ST