### PR TITLE
feat(store): email_verification_tokens + SendEmailVerification + token reaper (TASK-1936)

### DIFF
--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -833,6 +833,17 @@ func serveCmd() *cobra.Command {
 			}
 			srv.StartOpLogGC()
 
+			// Token reaper (PLAN-1933 DR-5 / TASK-1936). Periodic sweep
+			// that deletes expired/used email-verification tokens,
+			// password-reset tokens, sessions, and CLI-auth sessions —
+			// the CleanExpired* methods existed but were never called.
+			// Default: 1h interval, override-able via env
+			// (PAD_TOKEN_REAPER_INTERVAL=1m for tests/CI).
+			if reaperInterval := parseDurationEnv("PAD_TOKEN_REAPER_INTERVAL", 0); reaperInterval != 0 {
+				srv.SetTokenReaperConfig(reaperInterval)
+			}
+			srv.StartTokenReaper()
+
 			// Attach webhook dispatcher for outgoing notifications
 			srv.SetWebhookDispatcher(webhooks.NewDispatcher(s))
 

--- a/internal/email/sender_test.go
+++ b/internal/email/sender_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -183,6 +184,42 @@ func TestSendWelcome(t *testing.T) {
 	}
 	if received.To[0].DisplayName != "Alice" {
 		t.Errorf("expected to name 'Alice', got %q", received.To[0].DisplayName)
+	}
+}
+
+func TestSendEmailVerification(t *testing.T) {
+	var received mailerooPayload
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewDecoder(r.Body).Decode(&received)
+		json.NewEncoder(w).Encode(mailerooResponse{Success: true, Message: "sent"})
+	}))
+	defer ts.Close()
+
+	s := newTestSender(ts)
+
+	verifyURL := "https://example.com/verify-email/padver_abc123"
+	err := s.SendEmailVerification(context.Background(), "newuser@example.com", "New User", verifyURL)
+	if err != nil {
+		t.Fatalf("SendEmailVerification failed: %v", err)
+	}
+
+	if received.Subject != "Verify your Pad email address" {
+		t.Errorf("unexpected subject: %q", received.Subject)
+	}
+	if received.To[0].DisplayName != "New User" {
+		t.Errorf("expected to name 'New User', got %q", received.To[0].DisplayName)
+	}
+	// The 24h TTL copy must be parameterized (not the 1h reset copy).
+	if !strings.Contains(received.HTML, "24 hours") || !strings.Contains(received.Plain, "24 hours") {
+		t.Errorf("expected '24 hours' expiry copy in both bodies\nHTML=%q\nPlain=%q", received.HTML, received.Plain)
+	}
+	if strings.Contains(received.HTML, "1 hour") || strings.Contains(received.Plain, "1 hour") {
+		t.Errorf("verification email must not carry the reset flow's '1 hour' copy")
+	}
+	// The verification link must be present in both bodies.
+	if !strings.Contains(received.HTML, verifyURL) || !strings.Contains(received.Plain, verifyURL) {
+		t.Errorf("verify URL missing from bodies\nHTML=%q\nPlain=%q", received.HTML, received.Plain)
 	}
 }
 

--- a/internal/email/templates.go
+++ b/internal/email/templates.go
@@ -143,6 +143,48 @@ This link expires in 1 hour. If you didn't request a password reset, you can saf
 	return s.Send(ctx, to, name, subject, htmlBody, plainBody)
 }
 
+// SendEmailVerification sends an email-verification link to a newly
+// registered user. Mirrors SendPasswordReset (buildHTMLShell/buildPlainShell,
+// CloudMode footer) with the copy adapted to verification and the link
+// lifetime parameterized to 24 hours (matching verificationTokenTTL).
+// PLAN-1933 Wave 2 / TASK-1936.
+func (s *Sender) SendEmailVerification(ctx context.Context, to, name, verifyURL string) error {
+	subject := "Verify your Pad email address"
+	cloudMode := s.CloudMode()
+
+	body := fmt.Sprintf(`  <p style="font-size: 16px; line-height: 1.5;">
+    Hi %s, please confirm your email address to finish setting up your Pad account.
+  </p>
+  <p style="margin: 32px 0;">
+    <a href="%s" style="display: inline-block; padding: 12px 28px; background: #2563eb; color: #fff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: 500;">
+      Verify Email
+    </a>
+  </p>
+  <p style="font-size: 13px; color: #666; line-height: 1.5;">
+    This link expires in 24 hours. If you didn't create a Pad account, you can safely ignore this email.
+  </p>
+`,
+		html.EscapeString(name),
+		verifyURL,
+	)
+
+	footerNoteHTML := "You received this because an email address was used to register a Pad account."
+
+	htmlBody := buildHTMLShell(body, footerNoteHTML, cloudMode)
+
+	plainBody := buildPlainShell(
+		fmt.Sprintf(`Hi %s, please confirm your email address to finish setting up your Pad account.
+
+Verify your email: %s
+
+This link expires in 24 hours. If you didn't create a Pad account, you can safely ignore this email.`, name, verifyURL),
+		"You received this because an email address was used to register a Pad account.",
+		cloudMode,
+	)
+
+	return s.Send(ctx, to, name, subject, htmlBody, plainBody)
+}
+
 // SendPaymentFailed notifies a user that a Stripe invoice attempt failed.
 // Called by the sidecar (via POST /api/v1/admin/payment-failed) after it
 // handles an invoice.payment_failed webhook. The email links to the

--- a/internal/models/activity.go
+++ b/internal/models/activity.go
@@ -38,6 +38,12 @@ const (
 	ActionUserDisabled         = "user_disabled"
 	ActionUserEnabled          = "user_enabled"
 	ActionAccountDeleted       = "account_deleted"
+	// ActionEmailVerified is logged when a user confirms their email address
+	// via a verification link (POST /auth/verify-email). PLAN-1933 / TASK-1936.
+	ActionEmailVerified = "email_verified"
+	// ActionEmailVerifiedByAdmin is logged when an admin force-verifies a
+	// user's email from the admin console (DR-7). PLAN-1933 / TASK-1936.
+	ActionEmailVerifiedByAdmin = "email_verified_by_admin"
 	// ActionSessionIPChanged is logged when a session presents a different
 	// client IP than the one recorded at creation. We don't strict-check IP
 	// by default (that breaks legitimate geo shifts — VPN toggle, mobile

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -173,6 +173,13 @@ type Server struct {
 	// StartOpLogGC; Stop() signals the loop via stopOpLogGC.
 	opLogGC opLogGCConfig
 
+	// tokenReaper holds the periodic-sweep config + lifecycle for the
+	// short-lived-credential reaper (PLAN-1933 DR-5 / TASK-1936).
+	// Mirrors orphanGC/opLogGC. Configured via SetTokenReaperConfig +
+	// started via StartTokenReaper; Stop() signals the loop via
+	// stopTokenReaper.
+	tokenReaper tokenReaperConfig
+
 	// inFlightUploadHashes tracks content_hash values for uploads
 	// that have called AttachmentStore.Put but not yet inserted the
 	// attachments row. Without this, the orphan GC could delete a
@@ -256,6 +263,9 @@ func (s *Server) Stop() {
 	// Yjs op-log prune sweeper (TASK-1309). Same lifecycle pattern;
 	// signals BEFORE Wait() so the goroutine sees the close and exits.
 	s.stopOpLogGC()
+	// Short-lived-credential reaper (PLAN-1933 DR-5 / TASK-1936). Same
+	// lifecycle pattern; signal BEFORE Wait() so the goroutine exits.
+	s.stopTokenReaper()
 	// MCP audit writer / sweeper run on s.bg too. Signal first so
 	// the workers see the close BEFORE Wait() blocks; without the
 	// signal Wait would hang forever on the writer's blocking

--- a/internal/server/token_reaper.go
+++ b/internal/server/token_reaper.go
@@ -1,0 +1,109 @@
+package server
+
+import (
+	"log/slog"
+	"sync"
+	"time"
+)
+
+// defaultTokenReaperInterval is how often the background reaper sweeps expired
+// short-lived credentials. Hourly balances "bounded row growth" against
+// "negligible overhead" — every table it touches is small and every DELETE is
+// range-indexed on expires_at. PLAN-1933 DR-5 / TASK-1936.
+const defaultTokenReaperInterval = 1 * time.Hour
+
+// tokenReaperConfig captures the runtime knobs + lifecycle for the periodic
+// token-reaper loop. Mirrors orphanGCConfig / opLogGCConfig (same lifecycle
+// pattern, separate goroutine, separate stop channel). The CleanExpired*
+// store methods existed but were never called before this — they leak rows
+// without a caller (DR-5).
+type tokenReaperConfig struct {
+	mu       sync.Mutex
+	interval time.Duration
+	stop     chan struct{}
+	running  bool
+}
+
+// SetTokenReaperConfig overrides the default sweep interval (1h). Pass 0 to
+// keep the package default. Must be called before StartTokenReaper; calling
+// after the loop has started silently no-ops since the goroutine captured the
+// value at start.
+func (s *Server) SetTokenReaperConfig(interval time.Duration) {
+	s.tokenReaper.mu.Lock()
+	defer s.tokenReaper.mu.Unlock()
+	if interval > 0 {
+		s.tokenReaper.interval = interval
+	}
+}
+
+// StartTokenReaper kicks off the periodic sweep that deletes expired/used
+// email-verification tokens, password-reset tokens, sessions, and CLI-auth
+// sessions. Idempotent — calling twice silently no-ops.
+//
+// Started from the real server bootstrap path (cmd/pad/main.go), NOT from
+// Server.New, so unit tests that construct a Server don't spawn a background
+// goroutine unless they opt in (mirrors StartOrphanGC / StartOpLogGC). The
+// loop is tracked by Server.bg so Stop() drains it before the process exits /
+// the DB is closed (BUG-842 invariant).
+func (s *Server) StartTokenReaper() {
+	s.tokenReaper.mu.Lock()
+	if s.tokenReaper.running {
+		s.tokenReaper.mu.Unlock()
+		return
+	}
+	if s.tokenReaper.interval == 0 {
+		s.tokenReaper.interval = defaultTokenReaperInterval
+	}
+	s.tokenReaper.stop = make(chan struct{})
+	s.tokenReaper.running = true
+	interval := s.tokenReaper.interval
+	stop := s.tokenReaper.stop
+	s.tokenReaper.mu.Unlock()
+
+	slog.Info("token reaper started", "interval", interval.String())
+
+	s.bg.Add(1)
+	go func() {
+		defer s.bg.Done()
+		t := time.NewTicker(interval)
+		defer t.Stop()
+		for {
+			select {
+			case <-stop:
+				return
+			case <-t.C:
+				s.runTokenReaperTick()
+			}
+		}
+	}()
+}
+
+// stopTokenReaper signals the loop to exit. Called from Server.Stop().
+// Safe to call when the loop never started.
+func (s *Server) stopTokenReaper() {
+	s.tokenReaper.mu.Lock()
+	defer s.tokenReaper.mu.Unlock()
+	if !s.tokenReaper.running {
+		return
+	}
+	close(s.tokenReaper.stop)
+	s.tokenReaper.running = false
+}
+
+// runTokenReaperTick runs one sweep. Each cleaner is independent — a failure
+// in one is logged and does not skip the others. Quiet on success (operators
+// don't want hourly no-op log lines).
+func (s *Server) runTokenReaperTick() {
+	if err := s.store.CleanExpiredEmailVerifications(); err != nil {
+		slog.Warn("token reaper: clean expired email verifications failed", "error", err)
+	}
+	if err := s.store.CleanExpiredPasswordResets(); err != nil {
+		slog.Warn("token reaper: clean expired password resets failed", "error", err)
+	}
+	if err := s.store.CleanExpiredSessions(); err != nil {
+		slog.Warn("token reaper: clean expired sessions failed", "error", err)
+	}
+	if err := s.store.CleanExpiredCLIAuthSessions(); err != nil {
+		slog.Warn("token reaper: clean expired CLI auth sessions failed", "error", err)
+	}
+}

--- a/internal/server/token_reaper_test.go
+++ b/internal/server/token_reaper_test.go
@@ -1,0 +1,109 @@
+package server
+
+import (
+	"testing"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+func countEmailVerificationTokens(t *testing.T, srv *Server) int {
+	t.Helper()
+	var n int
+	if err := srv.store.DB().QueryRow(`SELECT COUNT(*) FROM email_verification_tokens`).Scan(&n); err != nil {
+		t.Fatalf("count email_verification_tokens: %v", err)
+	}
+	return n
+}
+
+// mintUsedVerificationToken creates an unverified user, mints a verification
+// token, and consumes it — leaving a single used (reaper-eligible) row.
+func mintUsedVerificationToken(t *testing.T, srv *Server, email string) {
+	t.Helper()
+	u, err := srv.store.CreateUser(models.UserCreate{
+		Email: email, Name: "Unv", Password: "password123", Unverified: true,
+	})
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	token, err := srv.store.CreateEmailVerification(u.ID)
+	if err != nil {
+		t.Fatalf("CreateEmailVerification: %v", err)
+	}
+	if _, err := srv.store.ConsumeEmailVerification(token); err != nil {
+		t.Fatalf("ConsumeEmailVerification: %v", err)
+	}
+}
+
+// TestTokenReaper_SweepsViaLoop drives the real ticker: a used verification
+// token row is deleted by a live reaper loop, then Stop() drains it cleanly.
+// Interval is tight (10ms) purely to land the sweep inside the test window —
+// the production default is 1h.
+func TestTokenReaper_SweepsViaLoop(t *testing.T) {
+	srv := testServer(t)
+
+	mintUsedVerificationToken(t, srv, "reaper-loop@example.com")
+	if got := countEmailVerificationTokens(t, srv); got != 1 {
+		t.Fatalf("precondition: want 1 used row, got %d", got)
+	}
+
+	srv.SetTokenReaperConfig(10 * time.Millisecond)
+	srv.StartTokenReaper()
+	t.Cleanup(srv.Stop)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if countEmailVerificationTokens(t, srv) == 0 {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("after 2s: reaper did not delete the used token row (still %d)", countEmailVerificationTokens(t, srv))
+}
+
+// TestTokenReaper_TickIsSafeWithNoRows: a tick on an empty database is a clean
+// no-op (all four cleaners run without error).
+func TestTokenReaper_TickIsSafeWithNoRows(t *testing.T) {
+	srv := testServer(t)
+	// Should not panic or error; nothing to assert beyond "doesn't blow up".
+	srv.runTokenReaperTick()
+}
+
+// TestTokenReaper_StartIsIdempotent confirms StartTokenReaper twice only spawns
+// one goroutine — without the running-flag guard, Stop() would hang forever on
+// the second goroutine that never received its stop signal.
+func TestTokenReaper_StartIsIdempotent(t *testing.T) {
+	srv := testServer(t)
+
+	// 1h interval = the loop never actually fires during the test; we only
+	// exercise the running-flag check + clean shutdown.
+	srv.SetTokenReaperConfig(1 * time.Hour)
+	srv.StartTokenReaper()
+	srv.StartTokenReaper() // second call must be a no-op
+	srv.StartTokenReaper() // third too
+
+	done := make(chan struct{})
+	go func() {
+		srv.Stop()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Stop() hung — a duplicate reaper goroutine was likely spawned")
+	}
+
+	// Stop is safe to call again (loop already stopped).
+	srv.stopTokenReaper()
+}
+
+// TestTokenReaper_NotStartedIsCleanShutdown: a server that never started the
+// reaper still stops cleanly (stopTokenReaper is a no-op when not running).
+// Guards the "does not leak goroutines in unit tests" invariant — the reaper
+// only runs when explicitly started (from cmd/pad/main.go), never from New.
+func TestTokenReaper_NotStartedIsCleanShutdown(t *testing.T) {
+	srv := testServer(t)
+	// testServer registers srv.Stop via t.Cleanup; calling stop on the
+	// never-started reaper here must be harmless.
+	srv.stopTokenReaper()
+}

--- a/internal/store/email_verification.go
+++ b/internal/store/email_verification.go
@@ -1,0 +1,145 @@
+package store
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"fmt"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// verificationTokenTTL is the lifetime of an email verification link.
+// 24h (vs password reset's 1h) — verification is a lower-urgency,
+// higher-friction flow (a new signup may not check email immediately),
+// so the link stays valid longer. PLAN-1933 DR-2 / DR-5.
+const verificationTokenTTL = 24 * time.Hour
+
+// CreateEmailVerification generates an email-verification token for the given
+// user. Returns the plaintext token (to embed in the verification URL). The
+// token is stored as a SHA-256 hash — the plaintext cannot be recovered.
+//
+// Mirrors CreatePasswordReset (PLAN-1933 DR-2) with three deltas: a 24h TTL,
+// the `padver_` prefix, and no password/session side-effects. The
+// invalidate-prior-unused-tokens-on-mint behavior is KEPT so a
+// resend-verification silently burns the previous link.
+func (s *Store) CreateEmailVerification(userID string) (string, error) {
+	// Invalidate any existing unused tokens for this user so a resend
+	// invalidates the previous verification link.
+	_, _ = s.db.Exec(s.q(`
+		UPDATE email_verification_tokens SET used_at = ? WHERE user_id = ? AND used_at IS NULL
+	`), now(), userID)
+
+	// Generate token (256-bit crypto/rand).
+	raw := make([]byte, 32)
+	if _, err := rand.Read(raw); err != nil {
+		return "", fmt.Errorf("generate token: %w", err)
+	}
+	plaintext := "padver_" + hex.EncodeToString(raw)
+	hash := sha256.Sum256([]byte(plaintext))
+	tokenHash := hex.EncodeToString(hash[:])
+
+	expiresAt := time.Now().UTC().Add(verificationTokenTTL).Format(time.RFC3339)
+
+	_, err := s.db.Exec(s.q(`
+		INSERT INTO email_verification_tokens (id, user_id, token_hash, expires_at, created_at)
+		VALUES (?, ?, ?, ?, ?)
+	`), newID(), userID, tokenHash, expiresAt, now())
+	if err != nil {
+		return "", fmt.Errorf("insert verification token: %w", err)
+	}
+
+	return plaintext, nil
+}
+
+// LookupEmailVerification performs a read-only validation of a verification
+// token and returns the associated user WITHOUT consuming the token. Mirrors
+// LookupPasswordReset — useful for a pre-consume validity check.
+//
+// Returns nil user if the token is invalid, already used, or expired.
+func (s *Store) LookupEmailVerification(token string) (*models.User, error) {
+	hash := sha256.Sum256([]byte(token))
+	tokenHash := hex.EncodeToString(hash[:])
+
+	var userID string
+	err := s.db.QueryRow(s.q(`
+		SELECT user_id FROM email_verification_tokens
+		WHERE token_hash = ? AND used_at IS NULL AND expires_at > ?
+	`), tokenHash, now()).Scan(&userID)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("lookup verification token: %w", err)
+	}
+	return s.GetUser(userID)
+}
+
+// ConsumeEmailVerification atomically validates and marks a verification token
+// as used, then sets users.email_verified_at to now. Returns the (now-verified)
+// user if the token is valid, unused, and not expired; nil user otherwise.
+//
+// The token is marked used in the same UPDATE that gates on used_at IS NULL,
+// so only one concurrent caller can succeed (race-safe single-use). Both the
+// token consume and the user update run in one transaction so a crash between
+// them can't leave a consumed-but-unverified state.
+//
+// The email_verified_at value uses the same RFC3339-with-`Z` format Wave 1's
+// migration used (now() → time.RFC3339 UTC), so time.Parse(time.RFC3339, …) /
+// store.parseTime reads it back. Unlike ConsumePasswordReset this does NOT
+// reset a password or mint a session — verification is the sole side-effect.
+func (s *Store) ConsumeEmailVerification(token string) (*models.User, error) {
+	hash := sha256.Sum256([]byte(token))
+	tokenHash := hex.EncodeToString(hash[:])
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return nil, fmt.Errorf("begin consume verification: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	// Atomically mark the token used and return its user, only if it's
+	// currently unused and not expired. The WHERE clause ensures only one
+	// concurrent caller can succeed.
+	var userID string
+	err = tx.QueryRow(s.q(`
+		UPDATE email_verification_tokens
+		SET used_at = ?
+		WHERE token_hash = ? AND used_at IS NULL AND expires_at > ?
+		RETURNING user_id
+	`), now(), tokenHash, now()).Scan(&userID)
+	if err == sql.ErrNoRows {
+		return nil, nil // Invalid, expired, or already used
+	}
+	if err != nil {
+		return nil, fmt.Errorf("consume verification token: %w", err)
+	}
+
+	// Side-effect: mark the user's email verified.
+	if _, err := tx.Exec(s.q(`
+		UPDATE users SET email_verified_at = ?, updated_at = ? WHERE id = ?
+	`), now(), now(), userID); err != nil {
+		return nil, fmt.Errorf("set email verified: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit consume verification: %w", err)
+	}
+
+	user, err := s.GetUser(userID)
+	if err != nil {
+		return nil, fmt.Errorf("get user: %w", err)
+	}
+	return user, nil
+}
+
+// CleanExpiredEmailVerifications removes expired or already-used verification
+// tokens. Mirrors CleanExpiredPasswordResets; run by the periodic token reaper.
+func (s *Store) CleanExpiredEmailVerifications() error {
+	_, err := s.db.Exec(s.q(`
+		DELETE FROM email_verification_tokens WHERE expires_at < ? OR used_at IS NOT NULL
+	`), now())
+	return err
+}

--- a/internal/store/email_verification_test.go
+++ b/internal/store/email_verification_test.go
@@ -1,0 +1,222 @@
+package store
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// createUnverifiedUser makes a user whose email starts UNVERIFIED, so a
+// consume can be observed flipping it verified. CreateUser's safe default is
+// verified, so we pass Unverified explicitly.
+func createUnverifiedUser(t *testing.T, s *Store, email string) *models.User {
+	t.Helper()
+	u, err := s.CreateUser(models.UserCreate{
+		Email: email, Name: "Unv " + email, Password: "password123", Unverified: true,
+	})
+	if err != nil {
+		t.Fatalf("CreateUser(unverified): %v", err)
+	}
+	if u.IsEmailVerified() {
+		t.Fatalf("precondition: %s should start unverified, got %q", email, u.EmailVerifiedAt)
+	}
+	return u
+}
+
+// insertVerificationToken writes a token row directly with a caller-chosen
+// expires_at / used_at so tests can craft expired and already-used rows.
+func insertVerificationToken(t *testing.T, s *Store, userID, plaintext, expiresAt string, usedAt *string) {
+	t.Helper()
+	hash := sha256.Sum256([]byte(plaintext))
+	tokenHash := hex.EncodeToString(hash[:])
+	var used any
+	if usedAt != nil {
+		used = *usedAt
+	}
+	if _, err := s.db.Exec(s.q(`
+		INSERT INTO email_verification_tokens (id, user_id, token_hash, expires_at, used_at, created_at)
+		VALUES (?, ?, ?, ?, ?, ?)
+	`), newID(), userID, tokenHash, expiresAt, used, now()); err != nil {
+		t.Fatalf("insert verification token: %v", err)
+	}
+}
+
+func countVerificationTokens(t *testing.T, s *Store) int {
+	t.Helper()
+	var n int
+	if err := s.db.QueryRow(s.q(`SELECT COUNT(*) FROM email_verification_tokens`)).Scan(&n); err != nil {
+		t.Fatalf("count tokens: %v", err)
+	}
+	return n
+}
+
+// TestEmailVerification_CreateLookupConsume covers the happy path: mint →
+// non-destructive lookup → consume flips users.email_verified_at → single-use.
+func TestEmailVerification_CreateLookupConsume(t *testing.T) {
+	s := testStore(t)
+	u := createUnverifiedUser(t, s, "verify@example.com")
+
+	token, err := s.CreateEmailVerification(u.ID)
+	if err != nil {
+		t.Fatalf("CreateEmailVerification: %v", err)
+	}
+	if !strings.HasPrefix(token, "padver_") {
+		t.Errorf("token missing padver_ prefix: %q", token)
+	}
+
+	// Lookup is non-destructive: it returns the user but must NOT consume.
+	got, err := s.LookupEmailVerification(token)
+	if err != nil {
+		t.Fatalf("LookupEmailVerification: %v", err)
+	}
+	if got == nil || got.ID != u.ID {
+		t.Fatalf("Lookup returned wrong/nil user: %+v", got)
+	}
+	if got.IsEmailVerified() {
+		t.Errorf("Lookup must not verify the user")
+	}
+	// A second lookup still works — proof the first didn't consume.
+	if again, _ := s.LookupEmailVerification(token); again == nil {
+		t.Errorf("second Lookup should still succeed (non-destructive)")
+	}
+
+	// Consume flips email_verified_at and returns the now-verified user.
+	consumed, err := s.ConsumeEmailVerification(token)
+	if err != nil {
+		t.Fatalf("ConsumeEmailVerification: %v", err)
+	}
+	if consumed == nil || consumed.ID != u.ID {
+		t.Fatalf("Consume returned wrong/nil user: %+v", consumed)
+	}
+	if !consumed.IsEmailVerified() {
+		t.Errorf("Consume should mark the returned user verified, got %q", consumed.EmailVerifiedAt)
+	}
+	if _, err := time.Parse(time.RFC3339, consumed.EmailVerifiedAt); err != nil {
+		t.Errorf("email_verified_at not RFC3339: %q (%v)", consumed.EmailVerifiedAt, err)
+	}
+	// Persisted (not just on the returned struct).
+	if refetched, _ := s.GetUser(u.ID); refetched == nil || !refetched.IsEmailVerified() {
+		t.Errorf("verification did not persist: %+v", refetched)
+	}
+
+	// Single-use: consuming again returns nil (no user), and lookup fails too.
+	if reused, err := s.ConsumeEmailVerification(token); err != nil || reused != nil {
+		t.Errorf("second Consume should return (nil, nil), got (%+v, %v)", reused, err)
+	}
+	if look, _ := s.LookupEmailVerification(token); look != nil {
+		t.Errorf("Lookup of a used token should return nil, got %+v", look)
+	}
+}
+
+// TestEmailVerification_ExpiredRejected: an expired token validates as nil and
+// cannot be consumed, and its consume leaves the user unverified.
+func TestEmailVerification_ExpiredRejected(t *testing.T) {
+	s := testStore(t)
+	u := createUnverifiedUser(t, s, "expired@example.com")
+
+	past := time.Now().UTC().Add(-time.Hour).Format(time.RFC3339)
+	insertVerificationToken(t, s, u.ID, "padver_expiredtoken", past, nil)
+
+	if got, err := s.LookupEmailVerification("padver_expiredtoken"); err != nil || got != nil {
+		t.Errorf("expired token Lookup should be (nil, nil), got (%+v, %v)", got, err)
+	}
+	if got, err := s.ConsumeEmailVerification("padver_expiredtoken"); err != nil || got != nil {
+		t.Errorf("expired token Consume should be (nil, nil), got (%+v, %v)", got, err)
+	}
+	if refetched, _ := s.GetUser(u.ID); refetched == nil || refetched.IsEmailVerified() {
+		t.Errorf("expired-token consume must not verify the user, got %+v", refetched)
+	}
+}
+
+// TestEmailVerification_ResendInvalidatesPrior: minting a new token invalidates
+// the previous unused one (so resend-verification burns the old link).
+func TestEmailVerification_ResendInvalidatesPrior(t *testing.T) {
+	s := testStore(t)
+	u := createUnverifiedUser(t, s, "resend@example.com")
+
+	first, err := s.CreateEmailVerification(u.ID)
+	if err != nil {
+		t.Fatalf("CreateEmailVerification (first): %v", err)
+	}
+	second, err := s.CreateEmailVerification(u.ID)
+	if err != nil {
+		t.Fatalf("CreateEmailVerification (second): %v", err)
+	}
+	if first == second {
+		t.Fatalf("resend produced an identical token")
+	}
+
+	// The first token is now invalidated.
+	if got, _ := s.LookupEmailVerification(first); got != nil {
+		t.Errorf("first token should be invalidated after resend, got %+v", got)
+	}
+	if got, _ := s.ConsumeEmailVerification(first); got != nil {
+		t.Errorf("first token should not be consumable after resend, got %+v", got)
+	}
+	// The second (current) token still works.
+	if got, _ := s.ConsumeEmailVerification(second); got == nil || !got.IsEmailVerified() {
+		t.Errorf("current token should consume + verify, got %+v", got)
+	}
+}
+
+// TestEmailVerification_HashAtRest: the plaintext is never stored — the column
+// holds the SHA-256 hex of the plaintext.
+func TestEmailVerification_HashAtRest(t *testing.T) {
+	s := testStore(t)
+	u := createUnverifiedUser(t, s, "hash@example.com")
+
+	token, err := s.CreateEmailVerification(u.ID)
+	if err != nil {
+		t.Fatalf("CreateEmailVerification: %v", err)
+	}
+
+	var stored string
+	if err := s.db.QueryRow(s.q(`SELECT token_hash FROM email_verification_tokens WHERE user_id = ? AND used_at IS NULL`), u.ID).Scan(&stored); err != nil {
+		t.Fatalf("read token_hash: %v", err)
+	}
+	if stored == token {
+		t.Fatalf("plaintext token stored at rest")
+	}
+	if strings.Contains(stored, "padver_") {
+		t.Errorf("stored hash contains the plaintext prefix: %q", stored)
+	}
+	want := sha256.Sum256([]byte(token))
+	if stored != hex.EncodeToString(want[:]) {
+		t.Errorf("stored hash mismatch: got %q want %q", stored, hex.EncodeToString(want[:]))
+	}
+}
+
+// TestCleanExpiredEmailVerifications: the reaper's store method deletes expired
+// AND used rows but keeps live ones. Exercised on both dialects via test-pg.
+func TestCleanExpiredEmailVerifications(t *testing.T) {
+	s := testStore(t)
+	u := createUnverifiedUser(t, s, "clean@example.com")
+
+	past := time.Now().UTC().Add(-time.Hour).Format(time.RFC3339)
+	future := time.Now().UTC().Add(time.Hour).Format(time.RFC3339)
+	usedTs := now()
+
+	insertVerificationToken(t, s, u.ID, "padver_expired", past, nil)    // expired
+	insertVerificationToken(t, s, u.ID, "padver_used", future, &usedTs) // used but not expired
+	insertVerificationToken(t, s, u.ID, "padver_live", future, nil)     // live
+
+	if got := countVerificationTokens(t, s); got != 3 {
+		t.Fatalf("precondition: want 3 rows, got %d", got)
+	}
+
+	if err := s.CleanExpiredEmailVerifications(); err != nil {
+		t.Fatalf("CleanExpiredEmailVerifications: %v", err)
+	}
+
+	if got := countVerificationTokens(t, s); got != 1 {
+		t.Errorf("after clean: want 1 live row, got %d", got)
+	}
+	// The surviving row is the live one.
+	if got, _ := s.LookupEmailVerification("padver_live"); got == nil {
+		t.Errorf("live token should survive the reaper sweep")
+	}
+}

--- a/internal/store/migrations/071_email_verification_tokens.sql
+++ b/internal/store/migrations/071_email_verification_tokens.sql
@@ -1,0 +1,15 @@
+-- Email verification tokens (time-limited, single-use, stored as SHA-256 hashes).
+-- Clones the password_reset_tokens shape (migration 015). PLAN-1933 Wave 2 / TASK-1936.
+-- Deltas vs password_resets: 24h TTL and `padver_` prefix live in the store layer
+-- (email_verification.go), not the DDL — the table shape is identical.
+CREATE TABLE IF NOT EXISTS email_verification_tokens (
+    id          TEXT PRIMARY KEY,
+    user_id     TEXT NOT NULL REFERENCES users(id),
+    token_hash  TEXT NOT NULL,
+    expires_at  TEXT NOT NULL,
+    used_at     TEXT,
+    created_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_email_verification_tokens_token_hash ON email_verification_tokens(token_hash);
+CREATE INDEX IF NOT EXISTS idx_email_verification_tokens_user_id ON email_verification_tokens(user_id);

--- a/internal/store/pgmigrations/049_email_verification_tokens.sql
+++ b/internal/store/pgmigrations/049_email_verification_tokens.sql
@@ -1,0 +1,16 @@
+-- Email verification tokens (time-limited, single-use, stored as SHA-256 hashes).
+-- Clones the password_reset_tokens shape from pgmigrations/001_initial.sql
+-- (there is NO PG 015). PLAN-1933 Wave 2 / TASK-1936. Deltas vs password_resets
+-- (24h TTL, `padver_` prefix) live in the store layer, not the DDL — the table
+-- shape is identical.
+CREATE TABLE IF NOT EXISTS email_verification_tokens (
+    id          TEXT PRIMARY KEY,
+    user_id     TEXT NOT NULL REFERENCES users(id),
+    token_hash  TEXT NOT NULL,
+    expires_at  TEXT NOT NULL,
+    used_at     TEXT,
+    created_at  TEXT NOT NULL DEFAULT (NOW() AT TIME ZONE 'UTC')::TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_email_verification_tokens_token_hash ON email_verification_tokens(token_hash);
+CREATE INDEX IF NOT EXISTS idx_email_verification_tokens_user_id ON email_verification_tokens(user_id);


### PR DESCRIPTION
## TASK-1936 — Wave 2 of PLAN-1933

Verification-token infrastructure. **Pure infra** — no endpoint consumes it until Wave 3. Clones the `password_resets` machinery with the DR-2/DR-5 deltas.

### Migration (dual-dialect)
- `migrations/071_email_verification_tokens.sql` (SQLite) + `pgmigrations/049_email_verification_tokens.sql` (Postgres): `email_verification_tokens` table cloning the `password_resets` shape — `id` PK, `user_id` FK→users(id), `token_hash`, `expires_at`, `used_at` (nullable), `created_at`, plus `token_hash` + `user_id` indexes. Each dialect keeps its own `created_at` default convention.

### Store (`internal/store/email_verification.go`)
- 256-bit crypto/rand token, prefix **`padver_`**, SHA-256-at-rest, non-destructive `LookupEmailVerification`, atomic `UPDATE...RETURNING` `ConsumeEmailVerification`.
- **Deltas from `password_resets` (DR-2):** TTL **24h** (not 1h); **keeps** invalidate-prior-unused-on-mint (so resend burns the previous link); consume side-effect sets `users.email_verified_at` (RFC3339-with-`Z`, the same format Wave 1's migration used) in one transaction — no password reset, no session mint.
- `CreateEmailVerification(userID)` returns the plaintext token. `CleanExpiredEmailVerifications` added.

### Email (`internal/email/templates.go`)
- `SendEmailVerification(ctx, to, name, verifyURL)` clones `SendPasswordReset` (buildHTMLShell/buildPlainShell, CloudMode footer); the hardcoded "1 hour" copy is parameterized to **"24 hours"**.

### Reaper (DR-5)
- Lifecycle-safe background sweep (`internal/server/token_reaper.go`) mirroring `orphanGC`/`opLogGC`: self-registers on `Server.bg`, context-cancellable via a stop channel, signalled from `Server.Stop()`, and **started only from `cmd/pad/main.go`** — never from `Server.New`, so unit tests don't leak goroutines. Calls the four previously-unwired `CleanExpired*` methods (email verifications, password resets, sessions, CLI auth sessions) hourly (override via `PAD_TOKEN_REAPER_INTERVAL`).

### Audit consts
- `ActionEmailVerified` + `ActionEmailVerifiedByAdmin` added to the models audit-action set.

### Gates
- `make check` green (lint + `go test ./...` + govulncheck + web-check).
- `make test-pg` green — store + migration on **both** dialects. New tests: create→lookup→consume flips `email_verified_at`; expired/used token rejected; resend invalidates prior; hash-at-rest (plaintext never persisted); reaper deletes expired/used rows; reaper lifecycle (idempotent start, clean shutdown, no-op when never started).
- Codex review: CLEAN.

https://claude.ai/code/session_01HxBkAMiFBtCRJ2tKSCt3ST