### PR TITLE
feat(server): RequireVerifiedEmail enforcement across all mutation perimeters (TASK-1937)

### DIFF
--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -502,6 +502,16 @@ func serveCmd() *cobra.Command {
 					// because Server.RecordMCPTierMismatch nil-checks
 					// internally.
 					OnScopeDenied: srv.RecordMCPTierMismatch,
+					// PLAN-1933 DR-4: gate the remote MCP write path for
+					// unverified cloud users. /mcp mounts outside the
+					// /api/v1 stack, so the RequireVerifiedEmail HTTP
+					// middleware can't cover it — this hook is the
+					// perimeter's own gate (fires on mutating methods
+					// only, inside buildAuthedRequest). Cloud-only via
+					// srv.IsCloud(); a no-op on self-host.
+					RequireVerifiedEmail: func(user *models.User) bool {
+						return srv.IsCloud() && user != nil && !user.IsEmailVerified()
+					},
 				}
 				if _, regErr := mcpserver.Register(mcpSrv.MCP(), mcpserver.RegistryOptions{
 					Doc: mcpDoc,

--- a/internal/mcp/dispatch_http.go
+++ b/internal/mcp/dispatch_http.go
@@ -127,6 +127,30 @@ type HTTPHandlerDispatcher struct {
 	// The local stdio transport (ExecDispatcher) doesn't go through
 	// this dispatcher, so its lister wiring is independent.
 	Lister WorkspaceLister
+
+	// RequireVerifiedEmail, when non-nil, gates the remote MCP write
+	// path for PLAN-1933 DR-4. It's invoked in buildAuthedRequest —
+	// the single chokepoint every synthesized request passes through,
+	// same place the token-scope check lives — for MUTATING methods
+	// only (reads stay open). Returning true BLOCKS the request: the
+	// dispatcher fails the build with an email_not_verified error
+	// instead of hitting the handler, so no content mutation reaches
+	// the store.
+	//
+	// The /mcp mount lives outside the /api/v1 middleware stack, so the
+	// RequireVerifiedEmail HTTP middleware can't cover it directly; this
+	// hook is the perimeter's own gate. cmd/pad/main.go wires it to
+	// `srv.IsCloud() && user != nil && !user.IsEmailVerified()`. A
+	// callback (rather than importing a cloudMode flag) keeps the
+	// dispatcher decoupled from server config, matching the OnScopeDenied
+	// pattern above.
+	//
+	// nil → no gate (self-host, stdio, and tests that don't exercise the
+	// verified-email perimeter). Belt-and-suspenders with the /api/v1
+	// middleware: even without this hook a synthesized write re-enters
+	// the /api/v1 chain and the middleware blocks it, but wiring the hook
+	// stops the request before it's ever built.
+	RequireVerifiedEmail func(user *models.User) bool
 }
 
 // RouteMapper translates a tool's JSON input into a concrete HTTP
@@ -439,6 +463,17 @@ func (d *HTTPHandlerDispatcher) executeRequest(
 				Hint:    "Token scope does not permit this operation. Re-issue with the required scopes (read for GET; write for POST/PATCH; admin for workspace settings).",
 			}), nil
 		}
+		// PLAN-1933 DR-4: the RequireVerifiedEmail gate rejected this
+		// write because the cloud user hasn't verified their email.
+		// Surface as permission_denied (the closest closed-set code) so
+		// agents branch consistently with a backend 403.
+		if strings.HasPrefix(err.Error(), errEmailNotVerifiedPrefix+":") {
+			return NewErrorResult(ErrorPayload{
+				Code:    ErrPermissionDenied,
+				Message: fmt.Sprintf("%s: %s", cmdKey, err.Error()),
+				Hint:    "Verify your email address (check your inbox for the verification link) before creating or editing content.",
+			}), nil
+		}
 		return dispatcherErrorResult(cmdKey, "build request", err), nil
 	}
 
@@ -487,6 +522,24 @@ func (d *HTTPHandlerDispatcher) executeRequest(
 // dispatch_http_project.go's bulk-update path (PATCH issued
 // directly via buildAuthedRequest + ServeHTTP, bypassing
 // executeRequest's previous scope check).
+// errEmailNotVerifiedPrefix tags the build-request error the
+// RequireVerifiedEmail gate returns so executeRequest can map it to a
+// clean permission_denied envelope (mirrors the "permission_denied:"
+// prefix convention used for token-scope denials).
+const errEmailNotVerifiedPrefix = "email_not_verified"
+
+// isMutatingMethod reports whether an HTTP method can mutate server
+// state. The verified-email gate only fires on these; reads pass
+// through so an unverified user can still fetch context over MCP.
+func isMutatingMethod(method string) bool {
+	switch method {
+	case http.MethodPost, http.MethodPatch, http.MethodPut, http.MethodDelete:
+		return true
+	default:
+		return false
+	}
+}
+
 func (d *HTTPHandlerDispatcher) buildAuthedRequest(
 	ctx context.Context,
 	method, urlPath string,
@@ -503,6 +556,15 @@ func (d *HTTPHandlerDispatcher) buildAuthedRequest(
 			d.OnScopeDenied(method, urlPath)
 		}
 		return nil, fmt.Errorf("permission_denied: token scope does not permit %s on this resource", method)
+	}
+	// PLAN-1933 DR-4: block the remote MCP write path for an unverified
+	// cloud user. Only mutating methods are gated — the read prefetches
+	// (dispatchItemUpdate's GET, lookupAssigneeID's members fetch) pass
+	// through so an unverified user can still read. The errEmailNotVerified
+	// prefix is recognised by executeRequest to surface a clean
+	// permission_denied envelope.
+	if isMutatingMethod(method) && d.RequireVerifiedEmail != nil && d.RequireVerifiedEmail(user) {
+		return nil, fmt.Errorf("%s: verify your email address before mutating content over MCP", errEmailNotVerifiedPrefix)
 	}
 	req, err := buildHTTPRequest(ctx, method, urlPath, body, user)
 	if err != nil {

--- a/internal/mcp/dispatch_http_verified_email_test.go
+++ b/internal/mcp/dispatch_http_verified_email_test.go
@@ -1,0 +1,150 @@
+package mcp
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// PLAN-1933 DR-4 — the remote MCP write perimeter. /mcp mounts outside
+// the /api/v1 middleware stack, so RequireVerifiedEmail can't cover it as
+// a chi middleware; the dispatcher carries its own gate (the
+// RequireVerifiedEmail hook, wired in cmd/pad/main.go to
+// `srv.IsCloud() && user != nil && !user.IsEmailVerified()`). These tests
+// exercise the gate directly through the dispatcher, mirroring the
+// scope-enforcement tests next door.
+
+// veUnverifiedGate simulates the production hook for a cloud instance:
+// block iff the user's email is unverified.
+func veUnverifiedGate(user *models.User) bool {
+	return user != nil && !user.IsEmailVerified()
+}
+
+func TestHTTPHandlerDispatcher_VerifiedEmail_BlocksUnverifiedWrite(t *testing.T) {
+	user := &models.User{ID: "u1", Name: "Unv", Email: "unv@example.com"} // EmailVerifiedAt == "" → unverified
+	rec := &recordingHandler{t: t}
+
+	d := &HTTPHandlerDispatcher{
+		Handler:              rec,
+		UserResolver:         fixedUserResolver(user),
+		RequireVerifiedEmail: veUnverifiedGate,
+	}
+
+	ctx := WithDispatchInput(context.Background(), map[string]any{
+		"workspace":  "docapp",
+		"collection": "tasks",
+		"title":      "Should Be Blocked",
+	})
+
+	res, err := d.Dispatch(ctx, []string{"item", "create"}, nil)
+	if err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+	if !res.IsError {
+		t.Fatalf("expected IsError for unverified write; got success: %#v", res)
+	}
+	if rec.requestCount != 0 {
+		t.Errorf("handler must NOT be invoked when the verified-email gate fires; got %d calls", rec.requestCount)
+	}
+	var msg string
+	if len(res.Content) > 0 {
+		if tc, ok := res.Content[0].(mcp.TextContent); ok {
+			msg = tc.Text
+		}
+	}
+	// Surfaced as permission_denied (closed-set code) with the
+	// email_not_verified marker in the message.
+	if !strings.Contains(msg, "permission_denied") {
+		t.Errorf("error envelope missing permission_denied marker: %q", msg)
+	}
+	if !strings.Contains(msg, "email_not_verified") {
+		t.Errorf("error envelope missing email_not_verified marker: %q", msg)
+	}
+}
+
+func TestHTTPHandlerDispatcher_VerifiedEmail_AllowsVerifiedWrite(t *testing.T) {
+	user := &models.User{ID: "u2", Name: "Ver", Email: "ver@example.com", EmailVerifiedAt: "2026-01-01T00:00:00Z"}
+	rec := &recordingHandler{t: t}
+
+	d := &HTTPHandlerDispatcher{
+		Handler:              rec,
+		UserResolver:         fixedUserResolver(user),
+		RequireVerifiedEmail: veUnverifiedGate,
+	}
+
+	ctx := WithDispatchInput(context.Background(), map[string]any{
+		"workspace":  "docapp",
+		"collection": "tasks",
+		"title":      "Allowed",
+	})
+
+	res, err := d.Dispatch(ctx, []string{"item", "create"}, nil)
+	if err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("verified write should succeed; got error: %#v", res)
+	}
+	if rec.requestCount != 1 || rec.gotMethod != http.MethodPost {
+		t.Errorf("expected one POST to reach the handler; got count=%d method=%q", rec.requestCount, rec.gotMethod)
+	}
+}
+
+func TestHTTPHandlerDispatcher_VerifiedEmail_AllowsUnverifiedRead(t *testing.T) {
+	user := &models.User{ID: "u3", Name: "Unv", Email: "unv@example.com"} // unverified
+	rec := &recordingHandler{t: t, wantStatus: http.StatusOK, respBody: `{"items":[]}`}
+
+	d := &HTTPHandlerDispatcher{
+		Handler:              rec,
+		UserResolver:         fixedUserResolver(user),
+		RequireVerifiedEmail: veUnverifiedGate,
+	}
+
+	ctx := WithDispatchInput(context.Background(), map[string]any{"workspace": "docapp"})
+
+	// item list → GET. Reads stay open even for unverified users.
+	res, err := d.Dispatch(ctx, []string{"item", "list"}, nil)
+	if err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("unverified read should succeed; got error: %#v", res)
+	}
+	if rec.gotMethod != http.MethodGet {
+		t.Errorf("expected GET, got %q", rec.gotMethod)
+	}
+}
+
+func TestHTTPHandlerDispatcher_VerifiedEmail_NilHookIsNoOp(t *testing.T) {
+	user := &models.User{ID: "u4", Name: "Unv", Email: "unv@example.com"} // unverified
+	rec := &recordingHandler{t: t}
+
+	// No RequireVerifiedEmail hook wired — the self-host / stdio / test
+	// default. An unverified user's write passes straight through.
+	d := &HTTPHandlerDispatcher{
+		Handler:      rec,
+		UserResolver: fixedUserResolver(user),
+	}
+
+	ctx := WithDispatchInput(context.Background(), map[string]any{
+		"workspace":  "docapp",
+		"collection": "tasks",
+		"title":      "No Gate",
+	})
+
+	res, err := d.Dispatch(ctx, []string{"item", "create"}, nil)
+	if err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("nil-hook write should succeed; got error: %#v", res)
+	}
+	if rec.requestCount != 1 {
+		t.Errorf("expected the write to reach the handler with no gate; got %d calls", rec.requestCount)
+	}
+}

--- a/internal/server/handlers_collab.go
+++ b/internal/server/handlers_collab.go
@@ -579,6 +579,18 @@ func (s *Server) authorizeCollabAccess(r *http.Request, item *models.Item) error
 	if fresh.IsDisabled() {
 		return newStatusError(http.StatusForbidden, "forbidden", "User is disabled")
 	}
+	// PLAN-1933 DR-4: the collab upgrade authorizes then persists
+	// incoming Yjs frames to item_yjs_updates (room.go) — a content
+	// mutation reached over a GET, so the /api/v1 method gate can't
+	// catch it. Reject the upgrade for an unverified cloud user before
+	// any admin/membership bypass below (the write-lock applies to
+	// everyone, including an unverified admin). No-op on self-host and
+	// for verified users via emailUnverifiedBlocked. Uses the freshly
+	// re-fetched user so an admin force-verify mid-session is honoured.
+	if s.emailUnverifiedBlocked(fresh) {
+		return newStatusError(http.StatusForbidden, "email_not_verified",
+			"Verify your email address to edit content.")
+	}
 	// Admin platform-role bypass — cookie session auth only (BUG-1616).
 	// Bearer-borne admin (CLI / PAT / MCP) falls through to the
 	// membership-only check below. Mirrors RequireWorkspaceAccess.

--- a/internal/server/handlers_oauth.go
+++ b/internal/server/handlers_oauth.go
@@ -602,6 +602,17 @@ func (s *Server) handleOAuthAuthorize(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// PLAN-1933 DR-4: /oauth/* is mounted outside the /api/v1 chain, so
+	// the RequireVerifiedEmail middleware never runs here. Block the
+	// consent render for an unverified cloud user — the decide POST that
+	// mints the auth code is blocked too (below), but stopping the flow
+	// at the render is friendlier than letting them fill out consent and
+	// fail. No-op on self-host / for verified users.
+	if s.emailUnverifiedBlocked(user) {
+		writeEmailNotVerified(w)
+		return
+	}
+
 	// TASK-961: consent render is the canonical "flow started" signal —
 	// the user has identified themselves AND fosite has accepted the
 	// authorize request. From here the only outcomes are
@@ -672,6 +683,18 @@ func (s *Server) handleOAuthAuthorizeDecide(w http.ResponseWriter, r *http.Reque
 		// (whose underlying request will be carried via the form
 		// fields they're about to submit).
 		http.Redirect(w, r, "/login", http.StatusFound)
+		return
+	}
+
+	// PLAN-1933 DR-4: this is the load-bearing block for the OAuth-
+	// provider perimeter — /oauth/authorize/decide persists the OAuth
+	// connection and mints an auth code (which the client then exchanges
+	// at /oauth/token). Reject it for an unverified cloud user so no
+	// bearer credential is ever minted for an unverified account. Checked
+	// before CSRF/authorize-request parsing so the gate can't be probed
+	// around; no-op on self-host / for verified users.
+	if s.emailUnverifiedBlocked(user) {
+		writeEmailNotVerified(w)
 		return
 	}
 

--- a/internal/server/middleware_verified_email.go
+++ b/internal/server/middleware_verified_email.go
@@ -1,0 +1,146 @@
+package server
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// emailUnverifiedBlocked is the central predicate for PLAN-1933 DR-4's
+// email-verification gate. It reports whether a request carrying `user`
+// must be rejected because this is a Pad Cloud instance and the
+// authenticated user has NOT verified their email address.
+//
+// Two short-circuits keep the gate a no-op everywhere it shouldn't fire:
+//
+//   - Self-hosted (`!s.cloudMode`) always returns false. Mandatory
+//     email verification is a cloud-only feature (DR-9), so the gate is
+//     entirely inert on self-hosted binaries — the middleware, the
+//     collab upgrade check, the OAuth-provider checks, and the MCP
+//     write gate all collapse to pass-through.
+//   - An unauthenticated request (user == nil) returns false. The gate
+//     only constrains what a logged-in-but-unverified user may do; it
+//     never turns an anonymous request into a 403 (RequireAuth already
+//     owns the "must be logged in" decision). Keying on user != nil is
+//     also what auto-skips the unauthenticated auth routes — login,
+//     register, forgot/reset-password, bootstrap, CLI-session creation —
+//     so no fragile URL allowlist is needed for those (DR-4 core rule).
+//     It is also why legacy workspace-scoped API tokens with no
+//     currentUser (middleware_auth.go) are intentionally NOT gated:
+//     currentUser==nil → false. That's acceptable per DR-4 (pre-existing
+//     token owners are backfilled verified; unverified users cannot mint
+//     tokens because token-create is blocked below; MCP PAT auth already
+//     rejects legacy no-user workspace tokens in middleware_mcp_auth.go).
+//
+// Shared by the RequireVerifiedEmail middleware (the /api/v1 method
+// gate), the collab WebSocket upgrade check (a GET the method gate
+// misses), and the OAuth-provider authorize/decide handlers (mounted
+// outside /api/v1). The remote MCP write path uses an equivalent inline
+// predicate wired onto the dispatcher in cmd/pad/main.go.
+func (s *Server) emailUnverifiedBlocked(user *models.User) bool {
+	return s.cloudMode && user != nil && !user.IsEmailVerified()
+}
+
+// isMutatingMethod reports whether an HTTP method can mutate server
+// state. The verified-email gate only fires on these — reads (GET /
+// HEAD / OPTIONS) stay open for unverified users so they can still
+// browse, poll their session, and see the "verify your email" banner.
+func isMutatingMethod(method string) bool {
+	switch method {
+	case http.MethodPost, http.MethodPatch, http.MethodPut, http.MethodDelete:
+		return true
+	default:
+		return false
+	}
+}
+
+// verifiedEmailExemptPath reports whether a mutating /api/v1 request
+// stays allowed for an authenticated-but-unverified cloud user. These
+// are the narrow, deliberate carve-outs from DR-4:
+//
+//   - POST /api/v1/invitations/{code}/accept — the hard carve-out. It
+//     lives OUTSIDE /auth/, and blocking it would strand an unverified
+//     invitee (they could never join a workspace). Per DR-1, accepting
+//     an email-bound invitation VERIFIES the account, so this is also
+//     an escape hatch OUT of the unverified state.
+//   - The account-lifecycle /auth/ mutations an unverified user must be
+//     able to run: logout (end the session), verify-email +
+//     resend-verification (the routes that clear the unverified state —
+//     they land in Wave 3b; allowlisting them now is harmless because
+//     they aren't routed yet), and delete-account (removing your own
+//     unverified account is harmless).
+//
+// Everything else — token create/rotate/delete, PATCH /me, 2FA
+// setup/disable, OAuth link/unlink, CLI-session approve, and every
+// workspace/content mutation — is intentionally NOT here, so it gets
+// the 403. The mutating auth routes that are unauthenticated (login,
+// register, forgot/reset-password, bootstrap, 2fa/login-verify,
+// oauth-login, CLI-session create) never reach this check: their
+// callers have no currentUser, so emailUnverifiedBlocked already
+// returned false.
+func verifiedEmailExemptPath(path string) bool {
+	// Invitation accept — matched structurally so any {code} passes,
+	// while /invitations/{code}/preview (GET, already public) and any
+	// other /invitations subpath are unaffected.
+	if strings.HasPrefix(path, "/api/v1/invitations/") && strings.HasSuffix(path, "/accept") {
+		return true
+	}
+	switch path {
+	case "/api/v1/auth/logout",
+		"/api/v1/auth/verify-email",
+		"/api/v1/auth/resend-verification",
+		"/api/v1/auth/delete-account":
+		return true
+	}
+	return false
+}
+
+// RequireVerifiedEmail is the /api/v1 method-gated enforcement point for
+// DR-4. Mounted immediately after RequireAuth in setupRouter, it rejects
+// mutating requests (POST/PATCH/PUT/DELETE) from an authenticated cloud
+// user whose email is unverified, returning 403 email_not_verified.
+//
+// It deliberately does NOT inherit CSRFProtect's / RequireAuth's blanket
+// `/api/v1/auth/*` exemption — those exemptions exist so unauthenticated
+// callers can reach login/register, but an authenticated-but-unverified
+// user hitting POST /api/v1/auth/tokens must still be blocked. This
+// middleware makes its own decision: emailUnverifiedBlocked auto-skips
+// the unauthenticated routes (currentUser==nil), and
+// verifiedEmailExemptPath allows the handful of authenticated auth
+// mutations an unverified user legitimately needs.
+//
+// The method gate is necessary but NOT sufficient — several mutation
+// surfaces are reached without a mutating /api/v1 method:
+//
+//   - the collab WebSocket upgrade is a GET (handled in
+//     authorizeCollabAccess),
+//   - the OAuth-provider authorize/decide endpoints are mounted outside
+//     /api/v1 (handled in handlers_oauth.go),
+//   - the remote MCP write path dispatches in-process (handled by the
+//     dispatcher's RequireVerifiedEmail hook, wired in cmd/pad/main.go).
+//
+// Each of those is gated separately; see DR-4's systematic perimeter
+// audit and the tests in middleware_verified_email_test.go.
+func (s *Server) RequireVerifiedEmail(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !s.emailUnverifiedBlocked(currentUser(r)) {
+			next.ServeHTTP(w, r)
+			return
+		}
+		if !isMutatingMethod(r.Method) || verifiedEmailExemptPath(r.URL.Path) {
+			next.ServeHTTP(w, r)
+			return
+		}
+		writeEmailNotVerified(w)
+	})
+}
+
+// writeEmailNotVerified is the single 403 writer shared by every
+// verified-email enforcement point so the code/message stay identical
+// across perimeters (the middleware, the collab upgrade, the OAuth
+// handlers). Clients branch on the stable `email_not_verified` code.
+func writeEmailNotVerified(w http.ResponseWriter) {
+	writeError(w, http.StatusForbidden, "email_not_verified",
+		"Verify your email address to perform this action. Check your inbox for the verification link or request a new one.")
+}

--- a/internal/server/middleware_verified_email_test.go
+++ b/internal/server/middleware_verified_email_test.go
@@ -1,0 +1,494 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// PLAN-1933 DR-4 — RequireVerifiedEmail enforcement across every
+// authenticated mutation perimeter. These tests are the DR-4 "systematic
+// perimeter audit": one blocked-unverified assertion per perimeter, plus
+// the three cross-cutting invariants (verified passes, self-host is a
+// no-op, invitation-accept carve-out works unverified).
+//
+// Unverified users are created directly via the store's explicit
+// UserCreate.Unverified control (Wave 1) — nothing in production mints an
+// unverified user until Wave 3b, so the store is the only way to reach
+// the state this middleware guards.
+
+// veUser bundles the two credential shapes a member can present.
+type veUser struct {
+	id      string
+	email   string
+	session string // raw session token (cookie value)
+	bearer  string // raw PAT (Authorization: Bearer)
+}
+
+// verifiedEmailFixture is a workspace with one unverified + one verified
+// editor member, each holding a session cookie AND a workspace-scoped
+// PAT. cloud toggles SetCloudMode so the same fixture drives both the
+// enforcement tests and the self-host no-op test.
+type verifiedEmailFixture struct {
+	srv      *Server
+	wsSlug   string
+	collSlug string
+	unv      veUser
+	ver      veUser
+}
+
+func newVerifiedEmailFixture(t *testing.T, cloud bool) *verifiedEmailFixture {
+	t.Helper()
+	srv := testServer(t)
+	if cloud {
+		srv.SetCloudMode("ve-secret")
+	}
+	// Bootstrap the first admin so UserCount>0 → RequireAuth is active
+	// (the middleware chain we're exercising only kicks in once users
+	// exist). The admin is verified via the DR-3 safe default.
+	bootstrapFirstUser(t, srv, "admin@ve.test", "Admin")
+	admin, err := srv.store.GetUserByEmail("admin@ve.test")
+	if err != nil || admin == nil {
+		t.Fatalf("GetUserByEmail admin: %v", err)
+	}
+	// The workspace needs an owner so the cloud-mode plan-limit check on
+	// item-create can resolve the owner's plan (else it 500s on "owner
+	// not found"). A verified item-create must reach 201.
+	ws, err := srv.store.CreateWorkspace(models.WorkspaceCreate{Name: "Verified Email WS", OwnerID: admin.ID})
+	if err != nil {
+		t.Fatalf("CreateWorkspace: %v", err)
+	}
+	coll, err := srv.store.CreateCollection(ws.ID, models.CollectionCreate{
+		Name: "Tasks", Schema: `{"fields":[]}`,
+	})
+	if err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+
+	mkMember := func(email string, unverified bool) veUser {
+		u, err := srv.store.CreateUser(models.UserCreate{
+			Email:      email,
+			Name:       email,
+			Password:   "correct-horse-battery-staple",
+			Role:       "member",
+			Unverified: unverified,
+		})
+		if err != nil {
+			t.Fatalf("CreateUser %s: %v", email, err)
+		}
+		if u.IsEmailVerified() == unverified {
+			t.Fatalf("CreateUser %s: IsEmailVerified()=%v, want %v", email, u.IsEmailVerified(), !unverified)
+		}
+		if err := srv.store.AddWorkspaceMember(ws.ID, u.ID, "editor"); err != nil {
+			t.Fatalf("AddWorkspaceMember %s: %v", email, err)
+		}
+		// UA="" → no session UA binding; ip matches doRequestWithCookie's
+		// 192.0.2.1 so the IP-change path stays quiet.
+		sess, err := srv.store.CreateSession(u.ID, "ve", "192.0.2.1", "", 24*time.Hour)
+		if err != nil {
+			t.Fatalf("CreateSession %s: %v", email, err)
+		}
+		pat, err := srv.store.CreateAPIToken(u.ID, models.APITokenCreate{
+			Name: "ve-pat", WorkspaceID: ws.ID,
+		}, 0, 0)
+		if err != nil {
+			t.Fatalf("CreateAPIToken %s: %v", email, err)
+		}
+		return veUser{id: u.ID, email: email, session: sess, bearer: pat.Token}
+	}
+
+	return &verifiedEmailFixture{
+		srv:      srv,
+		wsSlug:   ws.Slug,
+		collSlug: coll.Slug,
+		unv:      mkMember("unverified@ve.test", true),
+		ver:      mkMember("verified@ve.test", false),
+	}
+}
+
+func (f *verifiedEmailFixture) itemsPath() string {
+	return "/api/v1/workspaces/" + f.wsSlug + "/collections/" + f.collSlug + "/items"
+}
+
+// veDoBearer issues a request authenticated with a Bearer PAT (which
+// skips CSRF). Mirrors the CLI / connector path through TokenAuth.
+func veDoBearer(srv *Server, method, path string, body any, bearer string) *httptest.ResponseRecorder {
+	var r *strings.Reader
+	if body != nil {
+		b, _ := json.Marshal(body)
+		r = strings.NewReader(string(b))
+	}
+	var req *http.Request
+	if r != nil {
+		req = httptest.NewRequest(method, path, r)
+		req.Header.Set("Content-Type", "application/json")
+	} else {
+		req = httptest.NewRequest(method, path, nil)
+	}
+	req.Header.Set("Authorization", "Bearer "+bearer)
+	req.RemoteAddr = "192.0.2.1:1234"
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	return rr
+}
+
+// veErrorCode extracts the JSON error.code from a response, or "" if the
+// body isn't an error envelope.
+func veErrorCode(rr *httptest.ResponseRecorder) string {
+	var env struct {
+		Error struct {
+			Code string `json:"code"`
+		} `json:"error"`
+	}
+	_ = json.Unmarshal(rr.Body.Bytes(), &env)
+	return env.Error.Code
+}
+
+// assertBlocked asserts the response is a 403 email_not_verified.
+func assertBlocked(t *testing.T, rr *httptest.ResponseRecorder, what string) {
+	t.Helper()
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("%s: expected 403, got %d (body: %s)", what, rr.Code, rr.Body.String())
+	}
+	if code := veErrorCode(rr); code != "email_not_verified" {
+		t.Fatalf("%s: expected error code email_not_verified, got %q (body: %s)", what, code, rr.Body.String())
+	}
+}
+
+// assertNotEmailBlocked asserts the response is NOT a verified-email 403
+// (it may legitimately be a 2xx, or a 4xx for an unrelated reason).
+func assertNotEmailBlocked(t *testing.T, rr *httptest.ResponseRecorder, what string) {
+	t.Helper()
+	if rr.Code == http.StatusForbidden && veErrorCode(rr) == "email_not_verified" {
+		t.Fatalf("%s: unexpectedly blocked with email_not_verified (body: %s)", what, rr.Body.String())
+	}
+}
+
+// ---------------------------------------------------------------------
+// Perimeter 1: /api/v1 core writes — session AND PAT.
+// ---------------------------------------------------------------------
+
+func TestVerifiedEmail_CoreWrite_Session_BlocksUnverified(t *testing.T) {
+	f := newVerifiedEmailFixture(t, true)
+	rr := doRequestWithCookie(f.srv, "POST", f.itemsPath(), map[string]any{"title": "blocked"}, f.unv.session)
+	assertBlocked(t, rr, "unverified session item-create")
+}
+
+func TestVerifiedEmail_CoreWrite_PAT_BlocksUnverified(t *testing.T) {
+	f := newVerifiedEmailFixture(t, true)
+	rr := veDoBearer(f.srv, "POST", f.itemsPath(), map[string]any{"title": "blocked"}, f.unv.bearer)
+	assertBlocked(t, rr, "unverified PAT item-create")
+}
+
+// ---------------------------------------------------------------------
+// Cross-cutting invariant: a VERIFIED cloud user passes every perimeter.
+// ---------------------------------------------------------------------
+
+func TestVerifiedEmail_VerifiedUser_PassesAllPerimeters(t *testing.T) {
+	f := newVerifiedEmailFixture(t, true)
+
+	// Core write via session → 201.
+	if rr := doRequestWithCookie(f.srv, "POST", f.itemsPath(), map[string]any{"title": "ok-session"}, f.ver.session); rr.Code != http.StatusCreated {
+		t.Fatalf("verified session item-create: expected 201, got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+	// Core write via PAT → 201.
+	if rr := veDoBearer(f.srv, "POST", f.itemsPath(), map[string]any{"title": "ok-pat"}, f.ver.bearer); rr.Code != http.StatusCreated {
+		t.Fatalf("verified PAT item-create: expected 201, got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+	// Token create → not email-blocked (should succeed).
+	if rr := doRequestWithCookie(f.srv, "POST", "/api/v1/auth/tokens", map[string]any{"name": "t"}, f.ver.session); rr.Code == http.StatusForbidden && veErrorCode(rr) == "email_not_verified" {
+		t.Fatalf("verified token-create unexpectedly email-blocked (body: %s)", rr.Body.String())
+	}
+	// PATCH /me → not email-blocked.
+	rr := doRequestWithCookie(f.srv, "PATCH", "/api/v1/auth/me", map[string]any{"name": "Verified Renamed"}, f.ver.session)
+	assertNotEmailBlocked(t, rr, "verified PATCH /me")
+	// import/url → not email-blocked (may 400/upstream, but never our gate).
+	rr = doRequestWithCookie(f.srv, "POST", "/api/v1/import/url", map[string]any{"url": "https://example.com"}, f.ver.session)
+	assertNotEmailBlocked(t, rr, "verified import/url")
+}
+
+// ---------------------------------------------------------------------
+// Cross-cutting invariant: self-host (!cloudMode) is entirely unaffected.
+// ---------------------------------------------------------------------
+
+func TestVerifiedEmail_SelfHost_NoOp(t *testing.T) {
+	f := newVerifiedEmailFixture(t, false) // NOT cloud mode
+
+	// An unverified user on a self-hosted instance writes freely — the
+	// middleware collapses to pass-through.
+	if rr := doRequestWithCookie(f.srv, "POST", f.itemsPath(), map[string]any{"title": "selfhost-ok"}, f.unv.session); rr.Code != http.StatusCreated {
+		t.Fatalf("self-host unverified item-create: expected 201, got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+	if rr := veDoBearer(f.srv, "POST", f.itemsPath(), map[string]any{"title": "selfhost-ok-pat"}, f.unv.bearer); rr.Code != http.StatusCreated {
+		t.Fatalf("self-host unverified PAT item-create: expected 201, got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+	// Token-minting paths also stay open on self-host.
+	if rr := doRequestWithCookie(f.srv, "POST", "/api/v1/auth/tokens", map[string]any{"name": "t"}, f.unv.session); rr.Code == http.StatusForbidden && veErrorCode(rr) == "email_not_verified" {
+		t.Fatalf("self-host unverified token-create unexpectedly blocked (body: %s)", rr.Body.String())
+	}
+}
+
+// ---------------------------------------------------------------------
+// Perimeter 2: authenticated /auth/* token-minting + profile mutations.
+// ---------------------------------------------------------------------
+
+func TestVerifiedEmail_TokenCreate_BlocksUnverified(t *testing.T) {
+	f := newVerifiedEmailFixture(t, true)
+	rr := doRequestWithCookie(f.srv, "POST", "/api/v1/auth/tokens", map[string]any{"name": "sneaky"}, f.unv.session)
+	assertBlocked(t, rr, "unverified token-create")
+}
+
+func TestVerifiedEmail_PatchMe_BlocksUnverified(t *testing.T) {
+	f := newVerifiedEmailFixture(t, true)
+	rr := doRequestWithCookie(f.srv, "PATCH", "/api/v1/auth/me", map[string]any{"name": "Renamed"}, f.unv.session)
+	assertBlocked(t, rr, "unverified PATCH /me")
+}
+
+func TestVerifiedEmail_CLISessionApprove_BlocksUnverified(t *testing.T) {
+	f := newVerifiedEmailFixture(t, true)
+	// A pending CLI session so the block can't be attributed to a 404.
+	sess, err := f.srv.store.CreateCLIAuthSession()
+	if err != nil {
+		t.Fatalf("CreateCLIAuthSession: %v", err)
+	}
+	rr := doRequestWithCookie(f.srv, "POST", "/api/v1/auth/cli/sessions/"+sess.Code+"/approve", nil, f.unv.session)
+	assertBlocked(t, rr, "unverified cli-session approve")
+
+	// Verified user reaches the handler (session gets minted).
+	rr = doRequestWithCookie(f.srv, "POST", "/api/v1/auth/cli/sessions/"+sess.Code+"/approve", nil, f.ver.session)
+	assertNotEmailBlocked(t, rr, "verified cli-session approve")
+}
+
+// ---------------------------------------------------------------------
+// Perimeter 3: POST /api/v1/import/url (SSRF/abuse surface).
+// ---------------------------------------------------------------------
+
+func TestVerifiedEmail_ImportURL_BlocksUnverified(t *testing.T) {
+	f := newVerifiedEmailFixture(t, true)
+	rr := doRequestWithCookie(f.srv, "POST", "/api/v1/import/url", map[string]any{"url": "https://example.com"}, f.unv.session)
+	assertBlocked(t, rr, "unverified import/url")
+}
+
+// ---------------------------------------------------------------------
+// Reads + the account-lifecycle carve-outs stay open for unverified.
+// ---------------------------------------------------------------------
+
+func TestVerifiedEmail_Reads_AllowedForUnverified(t *testing.T) {
+	f := newVerifiedEmailFixture(t, true)
+	// GET /me (session identity) works.
+	if rr := doRequestWithCookie(f.srv, "GET", "/api/v1/auth/me", nil, f.unv.session); rr.Code != http.StatusOK {
+		t.Fatalf("unverified GET /me: expected 200, got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+	// GET item list works.
+	if rr := doRequestWithCookie(f.srv, "GET", f.itemsPath(), nil, f.unv.session); rr.Code != http.StatusOK {
+		t.Fatalf("unverified GET items: expected 200, got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+}
+
+func TestVerifiedEmail_Logout_AllowedForUnverified(t *testing.T) {
+	f := newVerifiedEmailFixture(t, true)
+	rr := doRequestWithCookie(f.srv, "POST", "/api/v1/auth/logout", nil, f.unv.session)
+	assertNotEmailBlocked(t, rr, "unverified logout")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("unverified logout: expected 200, got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+}
+
+func TestVerifiedEmail_DeleteAccount_AllowedForUnverified(t *testing.T) {
+	f := newVerifiedEmailFixture(t, true)
+	// delete-account requires the account password in the body.
+	rr := doRequestWithCookie(f.srv, "POST", "/api/v1/auth/delete-account",
+		map[string]any{"password": "correct-horse-battery-staple"}, f.unv.session)
+	assertNotEmailBlocked(t, rr, "unverified delete-account")
+}
+
+// ---------------------------------------------------------------------
+// Carve-out: POST /api/v1/invitations/{code}/accept works unverified.
+// ---------------------------------------------------------------------
+
+func TestVerifiedEmail_InvitationAccept_CarveOut(t *testing.T) {
+	f := newVerifiedEmailFixture(t, true)
+
+	// A second workspace the unverified user is NOT yet a member of,
+	// with an invitation bound to their email.
+	otherWS, err := f.srv.store.CreateWorkspace(models.WorkspaceCreate{Name: "Invite Target"})
+	if err != nil {
+		t.Fatalf("CreateWorkspace: %v", err)
+	}
+	inv, err := f.srv.store.CreateInvitation(otherWS.ID, f.unv.email, "editor", f.unv.id)
+	if err != nil {
+		t.Fatalf("CreateInvitation: %v", err)
+	}
+
+	rr := doRequestWithCookie(f.srv, "POST", "/api/v1/invitations/"+inv.Code+"/accept", nil, f.unv.session)
+	assertNotEmailBlocked(t, rr, "unverified invitation-accept")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("unverified invitation-accept: expected 200, got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+}
+
+// ---------------------------------------------------------------------
+// Perimeter 4: collab WebSocket GET-upgrade (persists Yjs edits).
+// ---------------------------------------------------------------------
+
+// veCollabMember seeds ws+coll+item and returns the itemID plus a
+// session token for a member with the given verification state.
+func veCollabMember(t *testing.T, srv *Server, wsName, email string, unverified bool) (itemID, sessionToken string) {
+	t.Helper()
+	ws, err := srv.store.CreateWorkspace(models.WorkspaceCreate{Name: wsName})
+	if err != nil {
+		t.Fatalf("CreateWorkspace: %v", err)
+	}
+	coll, err := srv.store.CreateCollection(ws.ID, models.CollectionCreate{Name: "Tasks", Schema: `{"fields":[]}`})
+	if err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	item, err := srv.store.CreateItem(ws.ID, coll.ID, models.ItemCreate{Title: "Doc", Fields: `{}`})
+	if err != nil {
+		t.Fatalf("CreateItem: %v", err)
+	}
+	u, err := srv.store.CreateUser(models.UserCreate{
+		Email: email, Name: email, Password: "correct-horse-battery-staple", Role: "member", Unverified: unverified,
+	})
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	if err := srv.store.AddWorkspaceMember(ws.ID, u.ID, "editor"); err != nil {
+		t.Fatalf("AddWorkspaceMember: %v", err)
+	}
+	tok, err := srv.store.CreateSession(u.ID, "ve", "127.0.0.1", "ve-ua", 24*time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	return item.ID, tok
+}
+
+func TestVerifiedEmail_CollabUpgrade_BlocksUnverified(t *testing.T) {
+	srv := testServerWithCollab(t)
+	srv.SetCloudMode("ve-secret")
+	bootstrapFirstUser(t, srv, "admin@ve.test", "Admin")
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	itemID, sessionToken := veCollabMember(t, srv, "Collab Unverified", "collab-unv@ve.test", true)
+
+	cookies := []*http.Cookie{{Name: "pad_session", Value: sessionToken}}
+	_, resp, err := dialCollab(t, ts.URL, itemID, cookies, "ve-ua")
+	if err == nil {
+		t.Fatal("expected collab dial to fail for unverified member")
+	}
+	if resp == nil {
+		t.Fatalf("dial returned no response: %v", err)
+	}
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", resp.StatusCode)
+	}
+	var env struct {
+		Error struct {
+			Code string `json:"code"`
+		} `json:"error"`
+	}
+	_ = json.NewDecoder(resp.Body).Decode(&env)
+	if env.Error.Code != "email_not_verified" {
+		t.Fatalf("expected email_not_verified, got %q", env.Error.Code)
+	}
+}
+
+func TestVerifiedEmail_CollabUpgrade_AllowsVerified(t *testing.T) {
+	srv := testServerWithCollab(t)
+	srv.SetCloudMode("ve-secret")
+	bootstrapFirstUser(t, srv, "admin@ve.test", "Admin")
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	itemID, sessionToken := veCollabMember(t, srv, "Collab Verified", "collab-ver@ve.test", false)
+
+	cookies := []*http.Cookie{{Name: "pad_session", Value: sessionToken}}
+	conn, resp, err := dialCollab(t, ts.URL, itemID, cookies, "ve-ua")
+	if err != nil {
+		body := ""
+		if resp != nil {
+			body = "status=" + resp.Status
+		}
+		t.Fatalf("verified collab dial: %v (%s)", err, body)
+	}
+	defer conn.Close()
+	if resp.StatusCode != http.StatusSwitchingProtocols {
+		t.Fatalf("expected 101, got %d", resp.StatusCode)
+	}
+}
+
+// ---------------------------------------------------------------------
+// Perimeter 5: OAuth-provider authorize + decide (mints auth codes).
+// ---------------------------------------------------------------------
+
+// veOAuthUnverifiedSession creates an unverified user + session on an
+// OAuth-enabled server.
+func veOAuthUnverifiedSession(t *testing.T, srv *Server, email string) string {
+	t.Helper()
+	u, err := srv.store.CreateUser(models.UserCreate{
+		Email: email, Name: email, Password: "correct-horse-battery-staple", Unverified: true,
+	})
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	tok, err := srv.store.CreateSession(u.ID, "ve", "192.0.2.1", testSessionUA, webSessionTTL)
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	return tok
+}
+
+func TestVerifiedEmail_OAuthAuthorizeDecide_BlocksUnverified(t *testing.T) {
+	srv, _ := oauthEnabledTestServer(t)
+	sessionToken := veOAuthUnverifiedSession(t, srv, "oauth-unv@ve.test")
+	clientID := registerTestClient(t, srv, "https://app.test/cb")
+
+	form := url.Values{
+		"client_id":             {clientID},
+		"response_type":         {"code"},
+		"redirect_uri":          {"https://app.test/cb"},
+		"scope":                 {"pad:read"},
+		"code_challenge":        {s256Challenge("verifier-the-quick-brown-fox-1234567890-abcdef-1234")},
+		"code_challenge_method": {"S256"},
+		"audience":              {testCanonicalAudience},
+		"state":                 {"test-state-12345"},
+		"decision":              {"approve"},
+	}
+	// Verified check runs before CSRF/authorize-request parsing, so no
+	// csrf_token is needed to reach it.
+	req := httptest.NewRequest("POST", "/oauth/authorize/decide", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("User-Agent", testSessionUA)
+	req.AddCookie(&http.Cookie{Name: sessionCookieName(srv.secureCookies), Value: sessionToken})
+	req.RemoteAddr = "192.0.2.1:1234"
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	assertBlocked(t, rr, "unverified oauth authorize/decide")
+}
+
+func TestVerifiedEmail_OAuthAuthorize_BlocksUnverified(t *testing.T) {
+	srv, _ := oauthEnabledTestServer(t)
+	sessionToken := veOAuthUnverifiedSession(t, srv, "oauth-unv2@ve.test")
+	clientID := registerTestClient(t, srv, "https://app.test/cb")
+
+	q := url.Values{
+		"client_id":             {clientID},
+		"response_type":         {"code"},
+		"redirect_uri":          {"https://app.test/cb"},
+		"scope":                 {"pad:read"},
+		"code_challenge":        {s256Challenge("verifier-the-quick-brown-fox-1234567890-abcdef-1234")},
+		"code_challenge_method": {"S256"},
+		"audience":              {testCanonicalAudience},
+		"state":                 {"authorize-state-12345"},
+	}
+	rr := doAuthedRequest(srv, "GET", "/oauth/authorize?"+q.Encode(), nil, sessionToken)
+	assertBlocked(t, rr, "unverified oauth authorize render")
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -849,6 +849,14 @@ func (s *Server) setupRouter() {
 		r.Use(s.RateLimit)
 		r.Use(s.CSRFProtect)
 		r.Use(s.RequireAuth)
+		// PLAN-1933 DR-4: block content-mutating requests from an
+		// authenticated cloud user whose email is unverified. Mounted
+		// AFTER RequireAuth so currentUser is already resolved; a no-op
+		// on self-host and for verified / unauthenticated callers. The
+		// method gate here covers the /api/v1 surface (session + PAT);
+		// the collab GET-upgrade, the OAuth-provider flow, and the MCP
+		// write path are gated at their own out-of-band mounts.
+		r.Use(s.RequireVerifiedEmail)
 		r.Use(jsonContentType)
 
 		// SSE endpoint (outside jsonContentType middleware — but inherits auth)


### PR DESCRIPTION
## What

Wave 3a of PLAN-1933 (**DR-4**). Enforces, on **Pad Cloud only**, that an authenticated-but-unverified user cannot mutate content or mint credentials. Returns `403 email_not_verified`.

**A no-op in production until Wave 3b** starts creating unverified users (all rows backfilled verified in Wave 1; signup relaxation is 3b). Tests drive the unverified state directly via the store's explicit `UserCreate.Unverified` control.

**Core rule:** block only when `cloudMode && currentUser != nil && !IsEmailVerified()`, on mutating methods (POST/PATCH/PUT/DELETE). The middleware does **not** inherit CSRFProtect's / RequireAuth's blanket `/api/v1/auth/*` exemption — it decides for itself (`emailUnverifiedBlocked` auto-skips unauthenticated routes via `currentUser==nil`; a small allowlist covers the authenticated auth mutations an unverified user legitimately needs).

## Perimeters gated (systematic DR-4 audit — one test each)

| Perimeter | Enforcement point | Test |
|---|---|---|
| `/api/v1` core write — session | `RequireVerifiedEmail` method gate (server.go, after RequireAuth) | `TestVerifiedEmail_CoreWrite_Session_BlocksUnverified` |
| `/api/v1` core write — PAT | same middleware (identity-level) | `TestVerifiedEmail_CoreWrite_PAT_BlocksUnverified` |
| token create | method gate (no `/auth/*` exemption) | `TestVerifiedEmail_TokenCreate_BlocksUnverified` |
| `PATCH /me` | method gate | `TestVerifiedEmail_PatchMe_BlocksUnverified` |
| CLI-session approve (mints `padsess_` bearer) | method gate | `TestVerifiedEmail_CLISessionApprove_BlocksUnverified` |
| `POST /import/url` (SSRF/abuse) | method gate | `TestVerifiedEmail_ImportURL_BlocksUnverified` |
| collab WS **GET**-upgrade (persists Yjs edits) | `authorizeCollabAccess` | `TestVerifiedEmail_CollabUpgrade_BlocksUnverified` / `_AllowsVerified` |
| OAuth authorize + authorize/decide (mints auth code) | `emailUnverifiedBlocked` in handlers (mounted outside `/api/v1`) | `TestVerifiedEmail_OAuthAuthorize_BlocksUnverified` / `_OAuthAuthorizeDecide_BlocksUnverified` |
| remote MCP write path | dispatcher `RequireVerifiedEmail` hook in `buildAuthedRequest` (single write chokepoint), wired in `cmd/pad/main.go` | `TestHTTPHandlerDispatcher_VerifiedEmail_*` |

Also covered: 2FA setup/disable + OAuth link/unlink fall through the same method gate (no auth exemption).

## Carve-outs / intentionally NOT gated
- `POST /api/v1/invitations/{code}/accept` stays open for unverified invitees (DR-1) — `TestVerifiedEmail_InvitationAccept_CarveOut`.
- Authenticated auth lifecycle: logout, verify-email, resend-verification (arrive 3b), delete-account — allowlisted.
- Reads (GET/HEAD/OPTIONS) — `TestVerifiedEmail_Reads_AllowedForUnverified`.
- Legacy no-user workspace PATs (`currentUser==nil`) — ungated per DR-4 (owners backfilled verified; unverified can't mint tokens; MCP already rejects them).

## Cross-cutting invariants
- Verified cloud user passes every perimeter — `TestVerifiedEmail_VerifiedUser_PassesAllPerimeters`.
- Self-host (`!cloudMode`) is a full no-op — `TestVerifiedEmail_SelfHost_NoOp` + `TestHTTPHandlerDispatcher_VerifiedEmail_NilHookIsNoOp`.

## Gates
- `make check` — green (lint + `go test ./...` + govulncheck + web-check).
- `make test-pg` — green (24 packages ok, 0 failures on Postgres).
- Codex adversarial review — **CLEAN** (round 1).

**Do not merge** — orchestrator reviews perimeter coverage before landing.

https://claude.ai/code/session_01HxBkAMiFBtCRJ2tKSCt3ST