### PR TITLE
feat(server): cloud email self-registration + verify-email/resend endpoints (TASK-1938)

### DIFF
--- a/internal/server/handlers_auth.go
+++ b/internal/server/handlers_auth.go
@@ -572,10 +572,28 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 
 	// When users exist, allow registration if:
 	// 1. The requester is an admin, OR
-	// 2. A valid invitation code was provided
+	// 2. A valid invitation code was provided, OR
+	// 3. Cloud self-serve signup (PLAN-1933 DR-6): on Pad Cloud, when the
+	//    instance can actually deliver a verification email (sender wired +
+	//    usable public base URL), anyone may register. The created account
+	//    starts UNVERIFIED and must confirm via the emailed link before it
+	//    can mutate anything (RequireVerifiedEmail, Wave 3a). Self-hosted and
+	//    email-unconfigured cloud stay locked to admin/invitation only.
+	//
+	// selfServe is the ONLY path that creates an unverified user (DR-3): it
+	// flips UserCreate.Unverified below. Admin-created and invited signups
+	// leave it false, inheriting the verified default — so a missed branch
+	// fails SAFE (verified), never write-locked.
+	selfServe := false
 	if invitation == nil {
 		reqUser := currentUser(r)
-		if reqUser == nil || reqUser.Role != "admin" {
+		isAdmin := reqUser != nil && reqUser.Role == "admin"
+		switch {
+		case isAdmin:
+			// Admin-created account — stays verified.
+		case s.cloudMode && s.emailConfigured():
+			selfServe = true
+		default:
 			writeError(w, http.StatusForbidden, "forbidden", "Registration is restricted")
 			return
 		}
@@ -617,13 +635,15 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 		input.Username = unique
 	}
 
-	// Create user
+	// Create user. Only the cloud self-serve branch starts UNVERIFIED (DR-3);
+	// admin-created and invited signups inherit the verified default.
 	user, err := s.store.CreateUser(models.UserCreate{
-		Email:    input.Email,
-		Username: input.Username,
-		Name:     input.Name,
-		Password: input.Password,
-		Role:     "member",
+		Email:      input.Email,
+		Username:   input.Username,
+		Name:       input.Name,
+		Password:   input.Password,
+		Role:       "member",
+		Unverified: selfServe,
 	})
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to create user")
@@ -635,6 +655,35 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 	if invitation != nil {
 		_ = s.store.AddWorkspaceMember(invitation.WorkspaceID, user.ID, invitation.Role)
 		_ = s.store.AcceptInvitation(invitation.ID)
+	}
+
+	// Cloud self-serve signup: mint + send the email-verification link. The
+	// selfServe gate above already guaranteed emailConfigured() (sender wired
+	// + usable base URL), so the link is deliverable.
+	//
+	// Token creation is REQUIRED to complete signup (invariant: never leave a
+	// user who can't verify). If minting the token fails we roll the user back
+	// and 500 — otherwise the duplicate-email 409 would block a retry and the
+	// account would be write-locked with no link. Only the async SEND is
+	// best-effort: a send failure keeps the account (the token exists) and the
+	// user recovers via POST /auth/resend-verification.
+	if selfServe {
+		vtoken, verr := s.store.CreateEmailVerification(user.ID)
+		if verr != nil {
+			slog.Error("failed to create email verification token; rolling back signup", "error", verr, "user_id", user.ID)
+			if derr := s.store.DeleteUser(user.ID); derr != nil {
+				slog.Error("failed to roll back user after verification-token error", "error", derr, "user_id", user.ID)
+			}
+			writeError(w, http.StatusInternalServerError, "internal_error", "Failed to start email verification")
+			return
+		}
+		verifyURL := s.baseURL + "/verify-email/" + vtoken
+		toEmail, toName := user.Email, user.Name
+		s.goAsync(func() {
+			if err := s.email.SendEmailVerification(context.Background(), toEmail, toName, verifyURL); err != nil {
+				slog.Error("failed to send verification email", "error", err)
+			}
+		})
 	}
 
 	token, err := s.createAuthSession(w, r, user, webSessionTTL)
@@ -1288,4 +1337,117 @@ func (s *Server) handleResetPassword(w http.ResponseWriter, r *http.Request) {
 		},
 		"token": sessionToken,
 	})
+}
+
+// handleVerifyEmail consumes an email-verification token and flips the owning
+// user's email_verified_at to now (PLAN-1933 DR-5). It backs the link mailed
+// by the cloud self-serve signup flow.
+//
+// Session freshness (the load-bearing invariant): currentUser is NOT cached in
+// the session row — SessionAuth/TokenAuth call Store.ValidateSession on every
+// request, which re-reads the user fresh from the DB via GetUser. So flipping
+// email_verified_at here immediately unblocks the SAME session's subsequent
+// mutating requests under RequireVerifiedEmail (Wave 3a) — no session rewrite
+// needed. We also return the freshly-verified user payload so the SPA's auth
+// store updates without a second round-trip.
+func (s *Server) handleVerifyEmail(w http.ResponseWriter, r *http.Request) {
+	var input struct {
+		Token string `json:"token"`
+	}
+	if err := decodeJSON(r, &input); err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", "Invalid request body")
+		return
+	}
+	input.Token = strings.TrimSpace(input.Token)
+	if input.Token == "" {
+		writeError(w, http.StatusBadRequest, "validation_error", "Verification token is required")
+		return
+	}
+
+	user, err := s.store.ConsumeEmailVerification(input.Token)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to verify email")
+		return
+	}
+	if user == nil {
+		// Invalid, expired, or already-used token. This is the token secret
+		// itself (256-bit), not an account identifier, so a distinct error is
+		// not an enumeration signal.
+		writeError(w, http.StatusBadRequest, "invalid_token",
+			"This verification link is invalid or has expired. Request a new one.")
+		return
+	}
+
+	s.logAuditEventForUser(models.ActionEmailVerified, r, user.ID, auditMeta(map[string]string{"email": user.Email}))
+
+	// No session rewrite is required to unblock the user: sessions do NOT
+	// cache the user row — TokenAuth/SessionAuth call Store.ValidateSession on
+	// every request, which re-reads the user fresh via GetUser (and the
+	// pad_/padsess_ bearer paths do the same). ConsumeEmailVerification above
+	// already flipped email_verified_at in the DB, so this session's very next
+	// mutating request reads verified=true and passes RequireVerifiedEmail. We
+	// return the freshly-verified user so the SPA can update its auth store
+	// without a second round-trip.
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"ok":   true,
+		"user": sessionUserPayload(user),
+	})
+}
+
+// handleResendVerification re-sends an email-verification link for an
+// UNVERIFIED account (PLAN-1933 DR-5).
+//
+// Enumeration-safe: it ALWAYS returns 200 with the same body whether or not a
+// matching unverified account exists, so it can't be used to probe which
+// emails are registered (or which are still unverified). Minting a fresh token
+// invalidates any prior unused one (CreateEmailVerification burns previous
+// links), so only the most recent link stays live.
+func (s *Server) handleResendVerification(w http.ResponseWriter, r *http.Request) {
+	var input struct {
+		Email string `json:"email"`
+	}
+	if err := decodeJSON(r, &input); err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", "Invalid request body")
+		return
+	}
+	input.Email = strings.TrimSpace(input.Email)
+
+	// Uniform response for every outcome (unknown email, already verified,
+	// send failure) — no account-existence signal leaks.
+	okResponse := map[string]interface{}{
+		"ok":      true,
+		"message": "If your account still needs verification, a new link has been sent.",
+	}
+
+	if input.Email == "" || !emailRegexp.MatchString(input.Email) {
+		writeJSON(w, http.StatusOK, okResponse)
+		return
+	}
+
+	user, err := s.store.GetUserByEmail(input.Email)
+	if err != nil || user == nil || user.IsEmailVerified() {
+		// Unknown email or an already-verified account: no-op, same response.
+		writeJSON(w, http.StatusOK, okResponse)
+		return
+	}
+
+	// Only mint + send when the instance can actually deliver the link. A
+	// self-hosted instance never creates unverified users, so in practice this
+	// is cloud-only; the emailConfigured() guard ensures we never mint a token
+	// whose link we can't send.
+	if s.emailConfigured() {
+		if vtoken, verr := s.store.CreateEmailVerification(user.ID); verr != nil {
+			slog.Error("failed to create verification token on resend", "error", verr, "user_id", user.ID)
+		} else {
+			verifyURL := s.baseURL + "/verify-email/" + vtoken
+			toEmail, toName := user.Email, user.Name
+			s.goAsync(func() {
+				if err := s.email.SendEmailVerification(context.Background(), toEmail, toName, verifyURL); err != nil {
+					slog.Error("failed to send verification email on resend", "error", err)
+				}
+			})
+		}
+	}
+
+	writeJSON(w, http.StatusOK, okResponse)
 }

--- a/internal/server/handlers_members.go
+++ b/internal/server/handlers_members.go
@@ -346,6 +346,25 @@ func (s *Server) handleAcceptInvitation(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	// DR-1: accepting an email-bound invitation proves control of that email
+	// address, so verify the account if it's still unverified. This makes
+	// "invited = verified" hold for later accepts too — an existing unverified
+	// self-signup who accepts an invite becomes verified. Because currentUser
+	// is re-read fresh from the DB per request (ValidateSession → GetUser),
+	// this flip unblocks the user's subsequent mutations under
+	// RequireVerifiedEmail immediately, in the same session. Best-effort: a
+	// failure here doesn't undo the accepted membership.
+	if !user.IsEmailVerified() {
+		if err := s.store.SetUserEmailVerified(user.ID); err != nil {
+			slog.Error("failed to mark email verified on invite accept", "error", err, "user_id", user.ID)
+		} else {
+			s.logAuditEventForUser(models.ActionEmailVerified, r, user.ID, auditMeta(map[string]string{
+				"email":  user.Email,
+				"method": "invitation_accept",
+			}))
+		}
+	}
+
 	writeJSON(w, http.StatusOK, map[string]interface{}{
 		"accepted":     true,
 		"workspace_id": inv.WorkspaceID,

--- a/internal/server/handlers_verify_email_test.go
+++ b/internal/server/handlers_verify_email_test.go
@@ -1,0 +1,473 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/email"
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// PLAN-1933 Wave 3b (TASK-1938) — cloud email self-registration + the
+// verify-email / resend-verification endpoints + invite-accept verification.
+//
+// These tests exercise the full behavioral contract from DR-6 (register
+// relaxation), DR-5 (verify/resend endpoints, enumeration-safe), DR-11
+// (duplicate-email 409), and DR-1 (invite-accept verifies), plus the
+// load-bearing session-freshness invariant: a user who verifies in a live
+// session is immediately unblocked under RequireVerifiedEmail (Wave 3a).
+
+// capturedMail is one email the fake Maileroo endpoint received.
+type capturedMail struct {
+	to      string
+	subject string
+	body    string // html + plain concatenated, for token/URL extraction
+}
+
+// newMailSink stands up a fake Maileroo v2 endpoint that records every
+// outgoing email onto a channel, and returns a Sender wired to it. Mirrors
+// the httptest pattern in internal/email/sender_test.go.
+func newMailSink(t *testing.T) (*email.Sender, chan capturedMail) {
+	t.Helper()
+	ch := make(chan capturedMail, 8)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var p struct {
+			To []struct {
+				Address string `json:"address"`
+			} `json:"to"`
+			Subject string `json:"subject"`
+			HTML    string `json:"html"`
+			Plain   string `json:"plain"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&p)
+		to := ""
+		if len(p.To) > 0 {
+			to = p.To[0].Address
+		}
+		ch <- capturedMail{to: to, subject: p.Subject, body: p.HTML + "\n" + p.Plain}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"success":true,"message":"sent"}`))
+	}))
+	t.Cleanup(ts.Close)
+
+	sender := email.NewSender("test-api-key", "noreply@pad.test", "Pad", "http://pad.test")
+	sender.SetEndpoint(ts.URL)
+	return sender, ch
+}
+
+// waitMail blocks for the next captured email or fails on timeout. Emails are
+// sent from a goAsync goroutine, so the caller can't assume synchronous
+// delivery.
+func waitMail(t *testing.T, ch chan capturedMail) capturedMail {
+	t.Helper()
+	select {
+	case m := <-ch:
+		return m
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for outgoing email")
+		return capturedMail{}
+	}
+}
+
+var verifyTokenRe = regexp.MustCompile(`padver_[0-9a-f]{64}`)
+
+// extractVerifyToken pulls the padver_ token out of a verification email body.
+func extractVerifyToken(t *testing.T, m capturedMail) string {
+	t.Helper()
+	tok := verifyTokenRe.FindString(m.body)
+	if tok == "" {
+		t.Fatalf("no padver_ token found in email body: %q", m.body)
+	}
+	return tok
+}
+
+// newCloudEmailServer returns a cloud-mode server with a usable base URL and a
+// capturing email sink, bootstrapped with one admin. This is the configuration
+// where self-serve signup is permitted (DR-6).
+func newCloudEmailServer(t *testing.T) (*Server, chan capturedMail) {
+	t.Helper()
+	srv := testServer(t)
+	// Bootstrap the admin BEFORE cloud mode (bootstrap is disabled in cloud).
+	bootstrapFirstUser(t, srv, "admin@pad.test", "Admin")
+	sender, mails := newMailSink(t)
+	srv.baseURL = "https://app.getpad.dev"
+	srv.SetEmailSender(sender)
+	srv.cloudMode = true
+	return srv, mails
+}
+
+// ---------------------------------------------------------------------
+// DR-6 + DR-5 + Wave 3a: cloud signup → unverified → verify → unblocked.
+// ---------------------------------------------------------------------
+
+func TestCloudSignup_UnverifiedThenVerifyUnblocksSameSession(t *testing.T) {
+	srv, mails := newCloudEmailServer(t)
+
+	admin, err := srv.store.GetUserByEmail("admin@pad.test")
+	if err != nil || admin == nil {
+		t.Fatalf("GetUserByEmail admin: %v", err)
+	}
+	// A workspace + collection owned by the admin so the cloud-mode
+	// item-create plan check can resolve the owner's plan (mirrors
+	// middleware_verified_email_test.go).
+	ws, err := srv.store.CreateWorkspace(models.WorkspaceCreate{Name: "Signup WS", OwnerID: admin.ID})
+	if err != nil {
+		t.Fatalf("CreateWorkspace: %v", err)
+	}
+	coll, err := srv.store.CreateCollection(ws.ID, models.CollectionCreate{Name: "Tasks", Schema: `{"fields":[]}`})
+	if err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+
+	// Self-serve register (no invitation, no admin session, from a public IP).
+	rr := doRequest(srv, "POST", "/api/v1/auth/register", map[string]string{
+		"email":    "newbie@pad.test",
+		"name":     "Newbie",
+		"password": "correct-horse-battery-staple",
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("self-serve register: expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var reg struct {
+		Token string `json:"token"`
+		User  struct {
+			EmailVerified bool `json:"email_verified"`
+		} `json:"user"`
+	}
+	parseJSON(t, rr, &reg)
+	if reg.Token == "" {
+		t.Fatal("expected a session token from register")
+	}
+	if reg.User.EmailVerified {
+		t.Fatal("a self-serve signup must be UNVERIFIED in the response payload")
+	}
+
+	// The persisted row is unverified.
+	u, err := srv.store.GetUserByEmail("newbie@pad.test")
+	if err != nil || u == nil {
+		t.Fatalf("GetUserByEmail newbie: %v", err)
+	}
+	if u.IsEmailVerified() {
+		t.Fatal("self-serve signup persisted as verified — DR-3 says only this path writes NULL")
+	}
+
+	// Make the user an editor so item-create passes workspace access.
+	if err := srv.store.AddWorkspaceMember(ws.ID, u.ID, "editor"); err != nil {
+		t.Fatalf("AddWorkspaceMember: %v", err)
+	}
+
+	// A verification email was sent to the right address; grab its token.
+	mail := waitMail(t, mails)
+	if mail.to != "newbie@pad.test" {
+		t.Fatalf("verification email to=%q, want newbie@pad.test", mail.to)
+	}
+	token := extractVerifyToken(t, mail)
+
+	itemsPath := "/api/v1/workspaces/" + ws.Slug + "/collections/" + coll.Slug + "/items"
+
+	// Before verification: a content mutation is blocked (Wave 3a live).
+	rr = doRequestWithCookie(srv, "POST", itemsPath, map[string]any{"title": "blocked"}, reg.Token)
+	if rr.Code != http.StatusForbidden || veErrorCode(rr) != "email_not_verified" {
+		t.Fatalf("pre-verify item-create: expected 403 email_not_verified, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	// Verify the email.
+	rr = doRequest(srv, "POST", "/api/v1/auth/verify-email", map[string]string{"token": token})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("verify-email: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var vr struct {
+		User struct {
+			EmailVerified bool `json:"email_verified"`
+		} `json:"user"`
+	}
+	parseJSON(t, rr, &vr)
+	if !vr.User.EmailVerified {
+		t.Fatal("verify-email response should report email_verified=true")
+	}
+
+	// SAME session token now performs the mutation — the DB flip is
+	// immediately visible because ValidateSession re-reads the user per
+	// request (no session rewrite needed).
+	rr = doRequestWithCookie(srv, "POST", itemsPath, map[string]any{"title": "unblocked"}, reg.Token)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("post-verify item-create (same session): expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+// ---------------------------------------------------------------------
+// DR-11: duplicate email at open signup keeps the clear 409.
+// ---------------------------------------------------------------------
+
+func TestCloudSignup_DuplicateEmail_Returns409(t *testing.T) {
+	srv, mails := newCloudEmailServer(t)
+
+	rr := doRequest(srv, "POST", "/api/v1/auth/register", map[string]string{
+		"email": "dup@pad.test", "name": "Dup", "password": "correct-horse-battery-staple",
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("first register: expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+	_ = waitMail(t, mails) // drain the verification email
+
+	rr = doRequest(srv, "POST", "/api/v1/auth/register", map[string]string{
+		"email": "dup@pad.test", "name": "Dup Again", "password": "correct-horse-battery-staple",
+	})
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("duplicate register: expected 409, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+// ---------------------------------------------------------------------
+// DR-5: resend is enumeration-safe (always 200) and invalidates the prior
+// token.
+// ---------------------------------------------------------------------
+
+func TestResendVerification_InvalidatesPriorTokenAndIsEnumerationSafe(t *testing.T) {
+	srv, mails := newCloudEmailServer(t)
+
+	// The PasswordReset limiter (burst 3, shared by verify/resend) is keyed by
+	// IP; give each of these calls its own source IP so the test's several
+	// verify/resend hits don't trip the limiter.
+	ipN := 0
+	post := func(path string, body any) *httptest.ResponseRecorder {
+		ipN++
+		return doRequestFromRemoteAddr(srv, "POST", path, body, "203.0.113."+strconv.Itoa(ipN)+":1234")
+	}
+
+	rr := doRequest(srv, "POST", "/api/v1/auth/register", map[string]string{
+		"email": "resend@pad.test", "name": "Resend", "password": "correct-horse-battery-staple",
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("register: expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+	firstToken := extractVerifyToken(t, waitMail(t, mails))
+
+	// Resend → always 200, and a NEW token lands in the inbox.
+	rr = post("/api/v1/auth/resend-verification", map[string]string{"email": "resend@pad.test"})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("resend: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	secondToken := extractVerifyToken(t, waitMail(t, mails))
+	if secondToken == firstToken {
+		t.Fatal("resend should mint a fresh token")
+	}
+
+	// The prior token is now invalidated.
+	rr = post("/api/v1/auth/verify-email", map[string]string{"token": firstToken})
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("stale first token: expected 400 (invalidated by resend), got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	// The new token still verifies.
+	rr = post("/api/v1/auth/verify-email", map[string]string{"token": secondToken})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("new token verify: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	// Enumeration safety: unknown email, now-verified account, and the admin
+	// (verified) all still return 200 with no distinguishing signal.
+	for _, addr := range []string{"nobody@pad.test", "resend@pad.test", "admin@pad.test"} {
+		rr = post("/api/v1/auth/resend-verification", map[string]string{"email": addr})
+		if rr.Code != http.StatusOK {
+			t.Fatalf("resend %s: expected 200 (enumeration-safe), got %d: %s", addr, rr.Code, rr.Body.String())
+		}
+	}
+}
+
+// ---------------------------------------------------------------------
+// DR-6 negative: self-host register stays admin/invitation-only.
+// ---------------------------------------------------------------------
+
+func TestSelfHostRegister_StaysRestricted(t *testing.T) {
+	srv := testServer(t)
+	bootstrapFirstUser(t, srv, "admin@pad.test", "Admin")
+	// Email fully configured, but NOT cloud mode.
+	sender, _ := newMailSink(t)
+	srv.baseURL = "https://app.getpad.dev"
+	srv.SetEmailSender(sender)
+
+	rr := doRequest(srv, "POST", "/api/v1/auth/register", map[string]string{
+		"email": "selfhost@pad.test", "name": "SelfHost", "password": "correct-horse-battery-staple",
+	})
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("self-host self-serve register: expected 403, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if u, _ := srv.store.GetUserByEmail("selfhost@pad.test"); u != nil {
+		t.Fatal("self-host register must not create a user")
+	}
+}
+
+// ---------------------------------------------------------------------
+// DR-6 guard: cloud WITHOUT a usable emailed-link path stays CLOSED, so no
+// user is ever created who could never verify.
+// ---------------------------------------------------------------------
+
+func TestCloudRegister_UnverifiableConfig_StaysClosed(t *testing.T) {
+	// (a) Cloud, usable base URL, but NO email sender wired.
+	t.Run("no email sender", func(t *testing.T) {
+		srv := testServer(t)
+		bootstrapFirstUser(t, srv, "admin@pad.test", "Admin")
+		srv.cloudMode = true
+		srv.baseURL = "https://app.getpad.dev" // usable, but s.email == nil
+		rr := doRequest(srv, "POST", "/api/v1/auth/register", map[string]string{
+			"email": "noemail@pad.test", "name": "NoEmail", "password": "correct-horse-battery-staple",
+		})
+		if rr.Code != http.StatusForbidden {
+			t.Fatalf("cloud no-email register: expected 403, got %d: %s", rr.Code, rr.Body.String())
+		}
+		if u, _ := srv.store.GetUserByEmail("noemail@pad.test"); u != nil {
+			t.Fatal("no unverifiable user should be created when email is unconfigured")
+		}
+	})
+
+	// (b) Cloud, email sender wired, but the base URL is not reachable by an
+	// external recipient — an emailed verification link would be undeliverable.
+	// emailConfigured() must be false across the whole unusable-host set so no
+	// write-locked user is ever minted.
+	t.Run("unusable base URLs disable emailConfigured", func(t *testing.T) {
+		srv := testServer(t)
+		sender, _ := newMailSink(t)
+		srv.SetEmailSender(sender)
+		srv.cloudMode = true
+		for _, base := range []string{
+			// Literal IPs are rejected WHOLESALE (a public verification
+			// endpoint is a hostname) — loopback, private, reserved, AND even
+			// an ordinary public IP like 8.8.8.8 all disqualify self-serve.
+			"http://0.0.0.0:7777",    // unspecified bind-all
+			"http://[::]:7777",       // unspecified IPv6
+			"http://127.0.0.1:777",   // loopback IP
+			"https://[::1]",          // loopback IPv6
+			"http://10.1.2.3",        // RFC1918 private
+			"http://192.168.0.5",     // RFC1918 private
+			"http://169.254.1.1",     // link-local
+			"http://100.64.0.1",      // CGNAT (RFC 6598)
+			"http://192.0.2.1",       // TEST-NET-1
+			"http://192.88.99.1",     // 6to4 relay anycast
+			"http://0.1.2.3",         // 0.0.0.0/8 "this network"
+			"http://255.255.255.255", // broadcast
+			"http://[2001:2::1]",     // IPv6 benchmarking
+			"http://8.8.8.8",         // ordinary public IP — still a literal, rejected
+			// Non-public / malformed hostnames.
+			"http://localhost:777",            // loopback name
+			"http://pad.internal",             // special-use TLD (.internal)
+			"http://svc.local",                // special-use TLD (.local)
+			"https://example.invalid",         // special-use TLD (.invalid)
+			"http://app.test",                 // special-use TLD (.test)
+			"http://pad.home.arpa",            // reserved infrastructure TLD (.arpa)
+			"https://pad.onion",               // Tor hidden service (RFC 7686)
+			"https://service.alt",             // alternative namespace (RFC 9476)
+			"http://intranet",                 // single-label, not a public FQDN
+			"https://app.getpad.dev?x=1",      // query string breaks link concatenation
+			"https://app.getpad.dev/#/verify", // fragment breaks link concatenation
+			"https://.com",                    // empty leading label
+			"https://foo..com",                // empty interior label
+			"https://-bad.com",                // label starts with hyphen
+			"https://a.123",                   // all-numeric TLD
+			"https://app.getpad.dev:99999",    // port out of range
+			"https://app.getpad.dev:0",        // port zero
+			"ftp://example.com",               // non-http scheme
+			"",                                // unset
+		} {
+			srv.baseURL = base
+			if srv.emailConfigured() {
+				t.Fatalf("emailConfigured() must be false for unusable base URL %q", base)
+			}
+		}
+	})
+
+	// (b2) Full register path stays closed for a loopback base URL.
+	t.Run("register closed for loopback base URL", func(t *testing.T) {
+		srv := testServer(t)
+		bootstrapFirstUser(t, srv, "admin@pad.test", "Admin")
+		sender, _ := newMailSink(t)
+		srv.SetEmailSender(sender)
+		srv.cloudMode = true
+		srv.baseURL = "http://localhost:7777"
+		rr := doRequest(srv, "POST", "/api/v1/auth/register", map[string]string{
+			"email": "unreachable@pad.test", "name": "Unreachable", "password": "correct-horse-battery-staple",
+		})
+		if rr.Code != http.StatusForbidden {
+			t.Fatalf("cloud loopback-base-URL register: expected 403, got %d: %s", rr.Code, rr.Body.String())
+		}
+		if u, _ := srv.store.GetUserByEmail("unreachable@pad.test"); u != nil {
+			t.Fatal("no unverifiable user should be created when the base URL is unreachable")
+		}
+	})
+
+	// (b3) A real public base URL enables it (sanity: the guard isn't
+	// rejecting everything).
+	t.Run("public base URL enables emailConfigured", func(t *testing.T) {
+		srv := testServer(t)
+		sender, _ := newMailSink(t)
+		srv.SetEmailSender(sender)
+		srv.cloudMode = true
+		srv.baseURL = "https://app.getpad.dev"
+		if !srv.emailConfigured() {
+			t.Fatal("emailConfigured() must be true for a usable public base URL")
+		}
+	})
+}
+
+// ---------------------------------------------------------------------
+// DR-1: accepting an email-bound invitation verifies an unverified account,
+// and the invite-accept carve-out lets an unverified cloud user reach it.
+// ---------------------------------------------------------------------
+
+func TestInviteAccept_VerifiesUnverifiedUser(t *testing.T) {
+	srv := testServer(t)
+	bootstrapFirstUser(t, srv, "admin@pad.test", "Admin")
+	srv.cloudMode = true // so RequireVerifiedEmail is live and the carve-out matters
+
+	admin, err := srv.store.GetUserByEmail("admin@pad.test")
+	if err != nil || admin == nil {
+		t.Fatalf("GetUserByEmail admin: %v", err)
+	}
+	ws, err := srv.store.CreateWorkspace(models.WorkspaceCreate{Name: "Invite WS", OwnerID: admin.ID})
+	if err != nil {
+		t.Fatalf("CreateWorkspace: %v", err)
+	}
+
+	// An existing UNVERIFIED self-signup (created directly via the store's
+	// explicit control).
+	u, err := srv.store.CreateUser(models.UserCreate{
+		Email: "invitee@pad.test", Name: "Invitee", Password: "correct-horse-battery-staple",
+		Role: "member", Unverified: true,
+	})
+	if err != nil {
+		t.Fatalf("CreateUser invitee: %v", err)
+	}
+	if u.IsEmailVerified() {
+		t.Fatal("precondition: invitee should start unverified")
+	}
+	sess, err := srv.store.CreateSession(u.ID, "web", "192.0.2.1", "", 24*time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	// An invitation bound to the invitee's email.
+	inv, err := srv.store.CreateInvitation(ws.ID, "invitee@pad.test", "editor", admin.ID)
+	if err != nil {
+		t.Fatalf("CreateInvitation: %v", err)
+	}
+
+	rr := doRequestWithCookie(srv, "POST", "/api/v1/invitations/"+inv.Code+"/accept", nil, sess)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("accept invitation (unverified user, cloud carve-out): expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	// The account is now verified — proving "invited = verified" for later
+	// accepts, not just register-with-code.
+	u2, err := srv.store.GetUser(u.ID)
+	if err != nil || u2 == nil {
+		t.Fatalf("GetUser after accept: %v", err)
+	}
+	if !u2.IsEmailVerified() {
+		t.Fatal("accepting an email-bound invitation should verify the account (DR-1)")
+	}
+}

--- a/internal/server/middleware_ratelimit.go
+++ b/internal/server/middleware_ratelimit.go
@@ -362,7 +362,12 @@ func (s *Server) RateLimit(next http.Handler) http.Handler {
 			switch {
 			case path == "/api/v1/auth/login" || path == "/api/v1/auth/bootstrap" || path == "/api/v1/auth/2fa/login-verify":
 				limiter = s.rateLimiters.Auth
-			case path == "/api/v1/auth/forgot-password" || path == "/api/v1/auth/reset-password" || path == "/api/v1/auth/local-reset":
+			case path == "/api/v1/auth/forgot-password" || path == "/api/v1/auth/reset-password" || path == "/api/v1/auth/local-reset" ||
+				path == "/api/v1/auth/verify-email" || path == "/api/v1/auth/resend-verification":
+				// Email-verification endpoints (PLAN-1933 DR-5) reuse the
+				// PasswordReset bucket — same low-frequency, enumeration-safe
+				// shape as forgot/reset-password. Without an entry here they'd
+				// fall through to the looser default API limiter.
 				limiter = s.rateLimiters.PasswordReset
 			case path == "/api/v1/auth/register":
 				limiter = s.rateLimiters.Register

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -11,7 +11,9 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"net/netip"
 	"net/url"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -449,6 +451,155 @@ func (s *Server) SetBaseURL(rawURL string) {
 			slog.Warn("server base URL has an unspecified host; emailed links (password reset, invites, share links) will not be reachable. Set PAD_URL or PUBLIC_URL to the deployment's public URL (e.g. https://app.getpad.dev).", "base_url", s.baseURL)
 		}
 	}
+}
+
+// specialUseTLDs is the (finite) set of reserved top-level names from the IANA
+// Special-Use Domain Names registry + related RFCs that never resolve to a
+// public web host, so an emailed link using one is undeliverable. Matched on
+// the final label so example.com (public) is allowed while foo.example /
+// foo.test / bar.internal / pad.home.arpa / x.onion / y.alt (non-public) are
+// rejected. Sources: RFC 6761 (localhost/invalid/test/example), RFC 6762
+// (local), RFC 8375 (home.arpa) + the "arpa" infrastructure TLD, RFC 7686
+// (onion), RFC 9476 (alt), and ICANN-reserved "internal".
+var specialUseTLDs = map[string]bool{
+	"localhost": true, "local": true, "internal": true,
+	"invalid": true, "test": true, "example": true, "arpa": true,
+	"onion": true, "alt": true,
+}
+
+// hasUsableBaseURL reports whether s.baseURL is a URL a verification-email
+// recipient on the public internet can actually reach. It supersets the
+// unreachable-host warning in SetBaseURL (BUG-899): the bind-all hosts
+// 0.0.0.0 / :: are the right thing to bind() to but the wrong thing to email,
+// and so is every other host an external recipient can't resolve or route to.
+//
+// This gates the cloud self-serve signup path (PLAN-1933 DR-6): creating an
+// UNVERIFIED user whose only way out of the write-lock is an emailed link we
+// can't deliver would strand them permanently. So "usable" is conservative —
+// anything not clearly a public web endpoint disqualifies self-serve signup:
+//
+//   - scheme must be http/https (a browser can't follow ftp://, file://, …);
+//   - no query/fragment (the link is built by concatenation, so either would
+//     push the /verify-email/<token> route into the query/fragment);
+//   - a present port must be a valid TCP port (1–65535);
+//   - the host must be a valid public DNS FQDN, NOT a literal IP. A real cloud
+//     verification endpoint is a hostname (Pad Cloud is app.getpad.dev);
+//     bare-IP base URLs aren't used for emailed links, and exhaustively
+//     enumerating every non-public IP range (loopback / private / CGNAT /
+//     TEST-NET / 6to4 / benchmarking / reserved / … across IPv4 and IPv6) is a
+//     losing game — so we require a hostname and fail closed on any IP literal.
+//
+// No usable base URL → no self-serve signup (registration stays closed rather
+// than minting a write-locked user). Self-host and admin/invitation signup are
+// unaffected either way.
+func (s *Server) hasUsableBaseURL() bool {
+	if s.baseURL == "" {
+		return false
+	}
+	u, err := url.Parse(s.baseURL)
+	if err != nil {
+		return false
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return false
+	}
+	// The verification link is built by concatenation (baseURL +
+	// "/verify-email/" + token), so a base URL carrying a query or fragment
+	// would push the route into the query/fragment and break the link.
+	if u.RawQuery != "" || u.Fragment != "" {
+		return false
+	}
+	host := u.Hostname()
+	if host == "" {
+		return false
+	}
+	// A present port must be a valid TCP port (1–65535); url.Parse accepts
+	// out-of-range numeric ports that no client can actually connect to.
+	if p := u.Port(); p != "" {
+		n, perr := strconv.Atoi(p)
+		if perr != nil || n < 1 || n > 65535 {
+			return false
+		}
+	}
+
+	// Reject literal IPs outright — a usable public verification endpoint is a
+	// DNS hostname, and "is this IP publicly reachable" is not decidable from a
+	// finite denylist. Fail closed on any IP.
+	if _, aerr := netip.ParseAddr(host); aerr == nil {
+		return false
+	}
+
+	// The host must be a syntactically-valid, multi-label public FQDN (rejects
+	// malformed hosts like ".com", "foo..com", "-a.com" and special-use TLDs).
+	return isPublicDNSName(host)
+}
+
+// isPublicDNSName reports whether host is a syntactically-valid public FQDN
+// (RFC 1123 labels) whose TLD is neither a special-use reserved name nor
+// all-numeric. Empty labels, over-length labels, and invalid characters are
+// rejected. Assumes host is not an IP literal (that's handled before this is
+// called). Punycode/IDN TLDs (xn--…) are accepted since they aren't all-digit.
+func isPublicDNSName(host string) bool {
+	host = strings.ToLower(strings.TrimSuffix(host, "."))
+	if host == "" || len(host) > 253 {
+		return false
+	}
+	labels := strings.Split(host, ".")
+	if len(labels) < 2 {
+		return false
+	}
+	for _, l := range labels {
+		if !isValidDNSLabel(l) {
+			return false
+		}
+	}
+	tld := labels[len(labels)-1]
+	if specialUseTLDs[tld] || isAllDigits(tld) {
+		return false
+	}
+	return true
+}
+
+// isValidDNSLabel reports whether l is a valid RFC 1123 hostname label:
+// 1–63 chars of [a-z0-9-], not starting or ending with a hyphen.
+func isValidDNSLabel(l string) bool {
+	if len(l) == 0 || len(l) > 63 {
+		return false
+	}
+	if l[0] == '-' || l[len(l)-1] == '-' {
+		return false
+	}
+	for i := 0; i < len(l); i++ {
+		c := l[i]
+		if !((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '-') {
+			return false
+		}
+	}
+	return true
+}
+
+// isAllDigits reports whether s is non-empty and entirely ASCII digits. A
+// public TLD is never all-numeric (RFC 3696), so an all-digit final label
+// signals a malformed host rather than a reachable name.
+func isAllDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// emailConfigured reports whether this instance can actually SEND an emailed
+// link — a sender is wired AND the public base URL is usable. This is the
+// DR-6 gate for cloud email self-registration: the sender-only check (s.email
+// != nil) is insufficient because link generation also needs a reachable
+// public base URL (see handleRegister's verification email + BUG-899).
+func (s *Server) emailConfigured() bool {
+	return s.email != nil && s.hasUsableBaseURL()
 }
 
 // SetEventBus attaches an event bus for real-time SSE streaming.
@@ -900,6 +1051,14 @@ func (s *Server) setupRouter() {
 				r.Post("/reset-password", s.handleResetPassword)
 				// Localhost-only recovery escape hatch (self-host, non-cloud).
 				r.Post("/local-reset", s.handleLocalReset)
+
+				// Email verification (PLAN-1933 Wave 3b). Both are
+				// enumeration-safe and rate-limited (middleware_ratelimit.go
+				// reuses the PasswordReset bucket) and are already in
+				// RequireVerifiedEmail's exempt list so an unverified user
+				// can reach them to clear their own unverified state.
+				r.Post("/verify-email", s.handleVerifyEmail)
+				r.Post("/resend-verification", s.handleResendVerification)
 
 				// Two-factor authentication
 				r.Post("/2fa/setup", s.handleTOTPSetup)

--- a/internal/store/email_verification.go
+++ b/internal/store/email_verification.go
@@ -143,3 +143,21 @@ func (s *Store) CleanExpiredEmailVerifications() error {
 	`), now())
 	return err
 }
+
+// SetUserEmailVerified marks a user's email as verified (email_verified_at =
+// now) WITHOUT a token — for paths that prove email control by other means,
+// e.g. accepting an email-bound workspace invitation (PLAN-1933 DR-1). This is
+// the tokenless sibling of ConsumeEmailVerification's user-update side-effect.
+//
+// Idempotent: re-verifying an already-verified user just refreshes the
+// timestamp. Callers that want to skip a redundant write can gate on
+// user.IsEmailVerified() first.
+func (s *Store) SetUserEmailVerified(userID string) error {
+	_, err := s.db.Exec(s.q(`
+		UPDATE users SET email_verified_at = ?, updated_at = ? WHERE id = ?
+	`), now(), now(), userID)
+	if err != nil {
+		return fmt.Errorf("set email verified: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
## What

Wave 3b of PLAN-1933 — turns ON Pad Cloud email/password self-registration with mandatory email verification. When this lands the feature is functionally complete (Wave 4 admin override + Wave 5 web UX remain).

## Changes

- **DR-6 — register relaxation.** `handleRegister` allows self-serve signup when `cloudMode && emailConfigured()`. `emailConfigured = s.email != nil && hasUsableBaseURL()`, where a USABLE base URL is a real public web endpoint: http/https scheme, no query/fragment, valid port range, a DNS hostname (all literal IPs rejected — a public verification endpoint is a hostname), and a valid RFC1123 FQDN whose TLD is not special-use/all-numeric. If the instance can't deliver a link, self-serve stays CLOSED (admin/invitation only) so no write-locked user is ever created. Self-host is untouched.
- **DR-3 — unverified only via self-serve.** The cloud self-serve branch is the ONLY path that sets `UserCreate.Unverified` (writes `email_verified_at = NULL`). Admin-created and invited signups inherit the verified default. If minting the verification token fails, the just-created user is rolled back (`DeleteUser`) and the request 500s — the duplicate-email 409 would otherwise block a retry.
- **DR-5 — verify endpoints.** `POST /auth/verify-email` (consumes the token, flips `email_verified_at`, returns the fresh user) and `POST /auth/resend-verification` (always-200, enumeration-safe; minting a new token invalidates the prior one). Both wired into the rate-limiter path switch (reusing the PasswordReset bucket).
- **DR-1 — invite-accept verifies.** `handleAcceptInvitation` verifies an unverified account on accept (email-bound invite proves email control) via new store method `SetUserEmailVerified`.
- **DR-11 — kept the clear 409** on duplicate email at signup.

## Session freshness (load-bearing)

Sessions are NOT cached: `TokenAuth`/`SessionAuth` call `Store.ValidateSession` on every request, which re-reads the user fresh via `GetUser` (cookie + `padsess_`/`pad_` bearer paths all do). So flipping `email_verified_at` (on verify-email OR invite-accept) unblocks the same session's next mutating request immediately under `RequireVerifiedEmail` (Wave 3a) — no session-row rewrite needed. A test proves verify → same-session item-create succeeds.

## Tests

`internal/server/handlers_verify_email_test.go`: cloud signup → unverified + verification email sent (asserted via a fake Maileroo sink) → verify flips + unblocks a mutation in the same session; resend is enumeration-safe (always 200) + invalidates the prior token; self-host register stays restricted; cloud-with-no-email / unusable base URL stays CLOSED (broad unusable-host table); duplicate-email 409; invite-accept verifies an unverified user.

## Gates

`make check` green, `make test-pg` green, Codex review CLEAN.

https://claude.ai/code/session_01HxBkAMiFBtCRJ2tKSCt3ST