### PR TITLE
feat(admin): admin force-verify email override (TASK-1939)

### DIFF
--- a/internal/server/handlers_admin_users.go
+++ b/internal/server/handlers_admin_users.go
@@ -86,45 +86,47 @@ func (s *Server) handleAdminListUsers(w http.ResponseWriter, r *http.Request) {
 	}
 
 	type adminUser struct {
-		ID             string `json:"id"`
-		Email          string `json:"email"`
-		Username       string `json:"username"`
-		Name           string `json:"name"`
-		Role           string `json:"role"`
-		Plan           string `json:"plan"`
-		PlanExpiresAt  string `json:"plan_expires_at,omitempty"`
-		PlanOverrides  string `json:"plan_overrides,omitempty"`
-		TOTPEnabled    bool   `json:"totp_enabled"`
-		DisabledAt     string `json:"disabled_at,omitempty"`
-		LastActiveAt   string `json:"last_active_at,omitempty"`
-		LastWriteAt    string `json:"last_write_at,omitempty"`
-		CreatedAt      string `json:"created_at"`
-		UpdatedAt      string `json:"updated_at"`
-		WorkspaceCount int    `json:"workspace_count"`
-		StorageBytes   int64  `json:"storage_bytes"`
-		Status         string `json:"status"`
+		ID              string `json:"id"`
+		Email           string `json:"email"`
+		Username        string `json:"username"`
+		Name            string `json:"name"`
+		Role            string `json:"role"`
+		Plan            string `json:"plan"`
+		PlanExpiresAt   string `json:"plan_expires_at,omitempty"`
+		PlanOverrides   string `json:"plan_overrides,omitempty"`
+		TOTPEnabled     bool   `json:"totp_enabled"`
+		DisabledAt      string `json:"disabled_at,omitempty"`
+		EmailVerifiedAt string `json:"email_verified_at,omitempty"`
+		LastActiveAt    string `json:"last_active_at,omitempty"`
+		LastWriteAt     string `json:"last_write_at,omitempty"`
+		CreatedAt       string `json:"created_at"`
+		UpdatedAt       string `json:"updated_at"`
+		WorkspaceCount  int    `json:"workspace_count"`
+		StorageBytes    int64  `json:"storage_bytes"`
+		Status          string `json:"status"`
 	}
 
 	users := make([]adminUser, 0, len(result.Users))
 	for _, u := range result.Users {
 		users = append(users, adminUser{
-			ID:             u.ID,
-			Email:          u.Email,
-			Username:       u.Username,
-			Name:           u.Name,
-			Role:           u.Role,
-			Plan:           u.Plan,
-			PlanExpiresAt:  u.PlanExpiresAt,
-			PlanOverrides:  u.PlanOverrides,
-			TOTPEnabled:    u.TOTPEnabled,
-			DisabledAt:     u.DisabledAt,
-			LastActiveAt:   u.LastActiveAt,
-			LastWriteAt:    u.LastWriteAt,
-			CreatedAt:      u.CreatedAt.Format("2006-01-02T15:04:05Z"),
-			UpdatedAt:      u.UpdatedAt.Format("2006-01-02T15:04:05Z"),
-			WorkspaceCount: u.WorkspaceCount,
-			StorageBytes:   u.StorageBytes,
-			Status:         u.Status,
+			ID:              u.ID,
+			Email:           u.Email,
+			Username:        u.Username,
+			Name:            u.Name,
+			Role:            u.Role,
+			Plan:            u.Plan,
+			PlanExpiresAt:   u.PlanExpiresAt,
+			PlanOverrides:   u.PlanOverrides,
+			TOTPEnabled:     u.TOTPEnabled,
+			DisabledAt:      u.DisabledAt,
+			EmailVerifiedAt: u.EmailVerifiedAt,
+			LastActiveAt:    u.LastActiveAt,
+			LastWriteAt:     u.LastWriteAt,
+			CreatedAt:       u.CreatedAt.Format("2006-01-02T15:04:05Z"),
+			UpdatedAt:       u.UpdatedAt.Format("2006-01-02T15:04:05Z"),
+			WorkspaceCount:  u.WorkspaceCount,
+			StorageBytes:    u.StorageBytes,
+			Status:          u.Status,
 		})
 	}
 
@@ -172,23 +174,24 @@ func (s *Server) handleAdminGetUser(w http.ResponseWriter, r *http.Request) {
 	status := store.ComputeAdminUserStatusValue(user.DisabledAt, user.LastWriteAt, wsCount)
 
 	writeJSON(w, http.StatusOK, map[string]interface{}{
-		"id":              user.ID,
-		"email":           user.Email,
-		"username":        user.Username,
-		"name":            user.Name,
-		"role":            user.Role,
-		"plan":            user.Plan,
-		"plan_expires_at": user.PlanExpiresAt,
-		"plan_overrides":  user.PlanOverrides,
-		"totp_enabled":    user.TOTPEnabled,
-		"disabled_at":     user.DisabledAt,
-		"last_active_at":  user.LastActiveAt,
-		"last_write_at":   user.LastWriteAt,
-		"created_at":      user.CreatedAt,
-		"updated_at":      user.UpdatedAt,
-		"workspace_count": wsCount,
-		"storage_bytes":   storageBytes,
-		"status":          status,
+		"id":                user.ID,
+		"email":             user.Email,
+		"username":          user.Username,
+		"name":              user.Name,
+		"role":              user.Role,
+		"plan":              user.Plan,
+		"plan_expires_at":   user.PlanExpiresAt,
+		"plan_overrides":    user.PlanOverrides,
+		"totp_enabled":      user.TOTPEnabled,
+		"disabled_at":       user.DisabledAt,
+		"email_verified_at": user.EmailVerifiedAt,
+		"last_active_at":    user.LastActiveAt,
+		"last_write_at":     user.LastWriteAt,
+		"created_at":        user.CreatedAt,
+		"updated_at":        user.UpdatedAt,
+		"workspace_count":   wsCount,
+		"storage_bytes":     storageBytes,
+		"status":            status,
 	})
 }
 
@@ -667,6 +670,48 @@ func (s *Server) handleAdminEnableUser(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]interface{}{
 		"ok":      true,
 		"message": "User re-enabled",
+	})
+}
+
+// handleAdminVerifyEmail force-verifies a user's email address — the admin
+// override for a locked-out unverified account (PLAN-1933 DR-7). Web-console
+// only: no CLI, no MCP (matches the no-auth-mutation-on-MCP rule). Reuses the
+// tokenless SetUserEmailVerified store method. Distinct from the self-serve
+// verify-email flow — a force-verify is an operator security action, so it
+// audits with ActionEmailVerifiedByAdmin rather than ActionEmailVerified.
+// POST /api/v1/admin/users/{userID}/verify-email
+func (s *Server) handleAdminVerifyEmail(w http.ResponseWriter, r *http.Request) {
+	if !requireAdmin(w, r) {
+		return
+	}
+
+	userID := chi.URLParam(r, "userID")
+	user, err := s.store.GetUser(userID)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	if user == nil {
+		writeError(w, http.StatusNotFound, "not_found", "User not found")
+		return
+	}
+	if user.IsEmailVerified() {
+		writeJSON(w, http.StatusOK, map[string]interface{}{"ok": true, "message": "User email is already verified"})
+		return
+	}
+
+	if err := s.store.SetUserEmailVerified(userID); err != nil {
+		writeInternalError(w, err)
+		return
+	}
+
+	s.logAuditEvent(models.ActionEmailVerifiedByAdmin, r, auditMeta(map[string]string{
+		"target_user_id": userID,
+	}))
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"ok":      true,
+		"message": "User email verified",
 	})
 }
 

--- a/internal/server/handlers_admin_users_test.go
+++ b/internal/server/handlers_admin_users_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/PerpetualSoftware/pad/internal/models"
 )
@@ -210,4 +211,145 @@ func itoa(n int) string {
 		return "-" + string(buf)
 	}
 	return string(buf)
+}
+
+// TestAdminVerifyEmail_ForceVerifiesUnverifiedUser pins TASK-1939's core
+// acceptance criterion (PLAN-1933 DR-7): in cloud mode an unverified user is
+// blocked from mutating content (403 email_not_verified); an admin calls the
+// force-verify override; the row flips to verified; the audit feed records
+// the DISTINCT ActionEmailVerifiedByAdmin action; and the same now-verified
+// session is unblocked.
+func TestAdminVerifyEmail_ForceVerifiesUnverifiedUser(t *testing.T) {
+	srv := testServer(t)
+	adminToken := bootstrapFirstUser(t, srv, "admin@test.com", "Admin")
+	// Cloud mode makes RequireVerifiedEmail live so the before/after gate is
+	// observable. Bootstrap MUST precede SetCloudMode (bootstrap is disabled
+	// in cloud mode).
+	srv.cloudMode = true
+
+	admin, err := srv.store.GetUserByEmail("admin@test.com")
+	if err != nil || admin == nil {
+		t.Fatalf("GetUserByEmail admin: %v", err)
+	}
+
+	// A workspace + collection owned by the admin so the cloud-mode
+	// item-create plan check can resolve the owner's plan.
+	ws, err := srv.store.CreateWorkspace(models.WorkspaceCreate{Name: "Verify WS", OwnerID: admin.ID})
+	if err != nil {
+		t.Fatalf("CreateWorkspace: %v", err)
+	}
+	coll, err := srv.store.CreateCollection(ws.ID, models.CollectionCreate{Name: "Tasks", Schema: `{"fields":[]}`})
+	if err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+
+	// An UNVERIFIED user (the only path that writes NULL is cloud self-serve;
+	// the store's Unverified flag is the test's explicit control).
+	target, err := srv.store.CreateUser(models.UserCreate{
+		Email: "unverified@test.com", Name: "Unverified",
+		Password: "correct-horse-battery-staple", Role: "member", Unverified: true,
+	})
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	if target.IsEmailVerified() {
+		t.Fatal("precondition: target should start unverified")
+	}
+	if err := srv.store.AddWorkspaceMember(ws.ID, target.ID, "editor"); err != nil {
+		t.Fatalf("AddWorkspaceMember: %v", err)
+	}
+	sess, err := srv.store.CreateSession(target.ID, "web", "192.0.2.1", "", 24*time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	itemsPath := "/api/v1/workspaces/" + ws.Slug + "/collections/" + coll.Slug + "/items"
+
+	// Before verification: the unverified user's content mutation is blocked.
+	rr := doRequestWithCookie(srv, "POST", itemsPath, map[string]any{"title": "blocked"}, sess)
+	if rr.Code != http.StatusForbidden || veErrorCode(rr) != "email_not_verified" {
+		t.Fatalf("pre-verify item-create: expected 403 email_not_verified, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	// Admin force-verifies.
+	rr = doRequestWithCookie(srv, "POST", "/api/v1/admin/users/"+target.ID+"/verify-email", nil, adminToken)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("admin verify-email: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	// The row flipped to verified.
+	got, err := srv.store.GetUser(target.ID)
+	if err != nil || got == nil {
+		t.Fatalf("GetUser after verify: %v", err)
+	}
+	if !got.IsEmailVerified() {
+		t.Fatal("admin force-verify should set email_verified_at")
+	}
+
+	// The audit feed records the DISTINCT admin action (not the self-serve one).
+	rr = doRequestWithCookie(srv, "GET", "/api/v1/audit-log?limit=20", nil, adminToken)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("audit-log: status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	var entries []struct {
+		Action string `json:"action"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &entries); err != nil {
+		t.Fatalf("decode audit-log: %v body=%s", err, rr.Body.String())
+	}
+	foundAdmin, foundSelfServe := false, false
+	for _, e := range entries {
+		if e.Action == models.ActionEmailVerifiedByAdmin {
+			foundAdmin = true
+		}
+		if e.Action == models.ActionEmailVerified {
+			foundSelfServe = true
+		}
+	}
+	if !foundAdmin {
+		t.Errorf("audit feed missing %q; entries=%+v", models.ActionEmailVerifiedByAdmin, entries)
+	}
+	if foundSelfServe {
+		t.Errorf("audit feed should NOT contain the self-serve %q for an admin override", models.ActionEmailVerified)
+	}
+
+	// After verification: the SAME session performs the mutation (the DB flip
+	// is immediately visible because the user is re-read per request).
+	rr = doRequestWithCookie(srv, "POST", itemsPath, map[string]any{"title": "unblocked"}, sess)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("post-verify item-create: expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+// TestAdminVerifyEmail_NonAdminForbidden pins the admin-only gate: a
+// non-admin caller hitting the force-verify endpoint gets 403 (mirrors
+// TestAdminUpdateUser_NonAdminForbidden). Non-cloud server so the
+// RequireVerifiedEmail middleware is a no-op and requireAdmin is the sole
+// gate under test.
+func TestAdminVerifyEmail_NonAdminForbidden(t *testing.T) {
+	srv := testServer(t)
+	bootstrapFirstUser(t, srv, "admin@test.com", "Admin")
+	memberToken := registerNonAdmin(t, srv, "member@test.com", "Member")
+
+	target, err := srv.store.CreateUser(models.UserCreate{
+		Email: "victim@test.com", Name: "Victim",
+		Password: "correct-horse-battery-staple", Role: "member", Unverified: true,
+	})
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	rr := doRequestWithCookie(srv, "POST", "/api/v1/admin/users/"+target.ID+"/verify-email", nil, memberToken)
+	if rr.Code != http.StatusForbidden {
+		t.Errorf("non-admin verify-email: status=%d, want 403", rr.Code)
+	}
+
+	// The target remains unverified — the forbidden call had no side-effect.
+	got, err := srv.store.GetUser(target.ID)
+	if err != nil || got == nil {
+		t.Fatalf("GetUser: %v", err)
+	}
+	if got.IsEmailVerified() {
+		t.Error("target should remain unverified after a forbidden verify-email call")
+	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1125,6 +1125,7 @@ func (s *Server) setupRouter() {
 				r.Get("/users/{userID}/metrics", s.handleAdminGetUserMetrics)
 				r.Post("/users/{userID}/disable", s.handleAdminDisableUser)
 				r.Post("/users/{userID}/enable", s.handleAdminEnableUser)
+				r.Post("/users/{userID}/verify-email", s.handleAdminVerifyEmail)
 
 				// Invitations
 				r.Get("/invitations", s.handleAdminListInvitations)

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -1979,7 +1979,18 @@ export const api = {
 		// stripe_configured + cloud_unreachable booleans on the body.
 		// Cloud-mode only (returns 404 in self-host).
 		getBillingStats: () =>
-			request<AdminBillingStats>('/admin/billing-stats')
+			request<AdminBillingStats>('/admin/billing-stats'),
+		/**
+		 * Force-verify a user's email address — the admin override for a
+		 * locked-out unverified account (PLAN-1933 DR-7 / TASK-1939).
+		 * Web-console only (no CLI, no MCP). Backs the "Mark email verified"
+		 * button in the admin user panel; the button is shown only when the
+		 * target user is unverified. Admin-only server-side (non-admin → 403).
+		 */
+		verifyEmail: (userId: string) =>
+			request<{ ok: boolean; message: string }>(`/admin/users/${userId}/verify-email`, {
+				method: 'POST'
+			})
 	},
 
 	// ── Billing (user-facing Stripe Checkout / Portal) ────────────────────

--- a/web/src/lib/components/admin/UserSettingsForm.svelte
+++ b/web/src/lib/components/admin/UserSettingsForm.svelte
@@ -20,6 +20,7 @@
 <script lang="ts">
 	import { untrack } from 'svelte';
 	import { adminFetch, adminPatch, adminPost, type AdminUser } from '$lib/stores/admin.svelte';
+	import { api } from '$lib/api/client';
 
 	interface Props {
 		user: AdminUser;
@@ -66,6 +67,11 @@
 	// NEW for T1551: typed-email confirmation for disable. The user must
 	// type the target email exactly before the Disable button enables.
 	let disableTyped = $state('');
+
+	// Email force-verify override (PLAN-1933 DR-7 / TASK-1939). Admin-only,
+	// web-console only. Surfaced only when the target is unverified.
+	let verifySaving = $state(false);
+	let verifyMsg = $state('');
 
 	// Hydrate form state when the modal switches to a different user.
 	//
@@ -255,6 +261,24 @@
 		}
 	}
 
+	// Force-verify the user's email (admin override). Refetches the user so
+	// the panel reflects the now-verified state (which hides this control).
+	async function verifyEmail() {
+		const userId = user.id;
+		verifySaving = true;
+		verifyMsg = '';
+		try {
+			await api.admin.verifyEmail(userId);
+			const updated = await adminFetch(`/admin/users/${userId}`);
+			onUserUpdated?.(updated as AdminUser);
+			verifyMsg = 'Email marked verified';
+		} catch (e) {
+			verifyMsg = e instanceof Error ? e.message : 'Action failed';
+		} finally {
+			verifySaving = false;
+		}
+	}
+
 	async function saveUser() {
 		const userId = user.id;
 		saving = true;
@@ -438,6 +462,22 @@
 			>
 		{/if}
 	</div>
+
+	<!-- Email verification — admin force-verify override (PLAN-1933 DR-7).
+	     Shown only when the target is unverified; verifying hides the field. -->
+	{#if !user.email_verified_at}
+		<div class="field">
+			<div class="field-label">Email verification</div>
+			{#if verifyMsg}<div class="msg" class:error={verifyMsg === 'Action failed'}>{verifyMsg}</div>{/if}
+			<p class="hint">
+				This user hasn't confirmed their email. Marking it verified unblocks content
+				mutations and invites for their account.
+			</p>
+			<button class="btn" type="button" disabled={verifySaving} onclick={verifyEmail}
+				>{verifySaving ? 'Verifying…' : 'Mark email verified'}</button
+			>
+		</div>
+	{/if}
 
 	<!-- Plan + overrides -->
 	<div class="field">

--- a/web/src/lib/stores/admin.svelte.ts
+++ b/web/src/lib/stores/admin.svelte.ts
@@ -21,6 +21,14 @@ export interface AdminUser {
 	plan_overrides: string | null;
 	totp_enabled: boolean;
 	disabled_at: string | null;
+	/**
+	 * Email-verification timestamp (RFC3339) or null/undefined when the
+	 * user hasn't confirmed their email. Mirrors disabled_at. Surfaced by
+	 * the admin list + get-user handlers (PLAN-1933 Wave 1's SearchUsers
+	 * scan). Drives the "Mark email verified" force-verify override in the
+	 * admin user panel — shown only while this is falsy. TASK-1939 / DR-7.
+	 */
+	email_verified_at: string | null;
 	last_active_at: string | null;
 	/**
 	 * Last mutating action (item/comment/attachment) — distinct from


### PR DESCRIPTION
Wave 4 of PLAN-1933 (DR-7) — a web-console-only admin override to force-verify a locked-out unverified account. No CLI, no MCP (matches the no-auth-mutation-on-MCP rule). Reuses the `SetUserEmailVerified` store method from Wave 3b.

## Server
- `POST /api/v1/admin/users/{userID}/verify-email` — admin-only (`requireAdmin`), mirrors `handleAdminEnableUser`. Loads the user, calls `s.store.SetUserEmailVerified`, and audits with the **distinct** `ActionEmailVerifiedByAdmin` action (separate from the self-serve `ActionEmailVerified` — a force-verify is an operator security action). Idempotent: an already-verified user returns a 200 no-op. Route registered in the admin group in `server.go`.
- Surface `email_verified_at` in the admin list (`handleAdminListUsers`) + get-user (`handleAdminGetUser`) JSON so the console knows verified state (Wave 1 only added the store-level scan).

## Web
- `api.admin.verifyEmail(userId)` client method, confined to the admin section of `client.ts` (avoids the Wave 5 session-type edit).
- "Mark email verified" action in the admin user panel (`UserSettingsForm.svelte`), shown only when the target user is unverified; verifying refetches the user and hides the control.
- `email_verified_at` added to the `AdminUser` type.

## Tests
- `TestAdminVerifyEmail_ForceVerifiesUnverifiedUser` (cloud mode): unverified user blocked from mutating (403 `email_not_verified`) → admin force-verifies (200, `email_verified_at` set) → audit feed contains `ActionEmailVerifiedByAdmin` and NOT the self-serve action → same session is unblocked (201).
- `TestAdminVerifyEmail_NonAdminForbidden`: non-admin caller → 403, target stays unverified (no side-effect).

## Gates
- `make check` green (golangci-lint 0 issues, `go test ./...`, govulncheck, svelte-check 0 errors). No store SQL touched, so `test-pg` not required.
- Codex review: CLEAN.

https://claude.ai/code/session_01HxBkAMiFBtCRJ2tKSCt3ST