### PR TITLE
fix(server): auth-perimeter hardening — B6–B9 from the IDEA-1927 audit (TASK-1932)

### DIFF
--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -443,6 +443,11 @@ func serveCmd() *cobra.Command {
 				if cfg.CloudSecret == "" {
 					return fmt.Errorf("PAD_CLOUD_SECRET is required when running in cloud mode (PAD_MODE=cloud or PAD_CLOUD=true)")
 				}
+				// B7 (TASK-1932): fail fast rather than relying on the
+				// operator to always pair PAD_CLOUD with PAD_SECURE_COOKIES.
+				if err := cfg.ValidateCloudSecureCookies(); err != nil {
+					return err
+				}
 				srv.SetCloudMode(cfg.CloudSecret)
 				slog.Info("Cloud mode enabled")
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -321,6 +321,23 @@ func (c *Config) IsCloudServer() bool {
 	return c.cloudServerOptIn
 }
 
+// ValidateCloudSecureCookies returns an error if this server process is
+// opted into cloud-tenant mode (see IsCloudServer) without secure cookies
+// enabled. OAuth mints a hardcoded __Host-pad_session cookie (see
+// pad-cloud's oauth.go); browsers silently drop __Host--prefixed cookies
+// set without the Secure attribute, while pad's own session-cookie reader
+// falls back to the unprefixed "pad_session" name — so the mismatch never
+// surfaces as an error, it just makes users look "logged in but appears
+// logged out" (B7, TASK-1932). Self-hosted servers (IsCloudServer() ==
+// false) are unaffected — they can run without TLS on a LAN today and this
+// must not regress that.
+func (c *Config) ValidateCloudSecureCookies() error {
+	if c.IsCloudServer() && !c.SecureCookies {
+		return fmt.Errorf("PAD_SECURE_COOKIES must be true when running in cloud mode (PAD_CLOUD=true or PAD_MODE=cloud); insecure cookies break OAuth's __Host-pad_session cookie")
+	}
+	return nil
+}
+
 // Addr returns the host:port listen address.
 func (c *Config) Addr() string {
 	return fmt.Sprintf("%s:%d", c.Host, c.Port)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -262,6 +262,62 @@ func TestIsCloudServerOnlyOptsInViaEnv(t *testing.T) {
 	})
 }
 
+// TestValidateCloudSecureCookies guards B7 (TASK-1932): a server opted into
+// cloud-tenant mode without secure cookies must fail fast at startup rather
+// than silently shipping a __Host-pad_session cookie that pad's own cookie
+// reader can never see (cookie-name mismatch — "logged in but appears
+// logged out").
+func TestValidateCloudSecureCookies(t *testing.T) {
+	t.Run("cloud server without secure cookies is rejected", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		t.Setenv("PAD_CLOUD", "true")
+		t.Setenv("PAD_SECURE_COOKIES", "")
+
+		cfg, err := Load()
+		if err != nil {
+			t.Fatalf("load: %v", err)
+		}
+		if cfg.SecureCookies {
+			t.Fatal("test setup invariant broken: expected SecureCookies to default false")
+		}
+		if err := cfg.ValidateCloudSecureCookies(); err == nil {
+			t.Fatal("expected an error for PAD_CLOUD=true without PAD_SECURE_COOKIES")
+		}
+	})
+
+	t.Run("cloud server with secure cookies is accepted", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		t.Setenv("PAD_CLOUD", "true")
+		t.Setenv("PAD_SECURE_COOKIES", "true")
+
+		cfg, err := Load()
+		if err != nil {
+			t.Fatalf("load: %v", err)
+		}
+		if err := cfg.ValidateCloudSecureCookies(); err != nil {
+			t.Fatalf("expected no error when secure cookies are enabled, got: %v", err)
+		}
+	})
+
+	t.Run("non-cloud server without secure cookies is unaffected", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		t.Setenv("PAD_CLOUD", "")
+		t.Setenv("PAD_MODE", "")
+		t.Setenv("PAD_SECURE_COOKIES", "")
+
+		cfg, err := Load()
+		if err != nil {
+			t.Fatalf("load: %v", err)
+		}
+		if err := cfg.ValidateCloudSecureCookies(); err != nil {
+			t.Fatalf("self-hosted (non-cloud-server) mode must not require secure cookies, got: %v", err)
+		}
+	})
+}
+
 func TestBrowserURLNormalizesUnspecifiedHost(t *testing.T) {
 	cases := []struct {
 		name string

--- a/internal/server/handlers_cloud.go
+++ b/internal/server/handlers_cloud.go
@@ -1207,8 +1207,28 @@ func (s *Server) autoCreateWorkspace(user *models.User) {
 		slog.Warn("auto-create workspace: failed to seed collections", "workspace_id", ws.ID, "error", err)
 	}
 
-	// Add user as owner
-	_ = s.store.AddWorkspaceMember(ws.ID, user.ID, "owner")
+	// Add user as owner. This is not optional bookkeeping: without a
+	// workspace_members row, RequireWorkspaceAccess 403s the owner on
+	// every request (owner_id alone grants no access), and the
+	// workspace never shows up in GetUserWorkspaces — it becomes a
+	// permanently orphaned, completely unreachable row. Retry once for
+	// transient blips (e.g. a dropped Postgres connection); if it still
+	// fails, delete the now-useless workspace rather than leaving that
+	// orphan behind, and log loudly either way so on-call can see it
+	// happened (B6, TASK-1932).
+	if err := s.store.AddWorkspaceMember(ws.ID, user.ID, "owner"); err != nil {
+		slog.Warn("auto-create workspace: add owner member failed, retrying",
+			"workspace_id", ws.ID, "workspace_slug", ws.Slug, "user_id", user.ID, "error", err)
+		if err := s.store.AddWorkspaceMember(ws.ID, user.ID, "owner"); err != nil {
+			slog.Error("auto-create workspace: add owner member failed after retry; deleting orphaned workspace",
+				"workspace_id", ws.ID, "workspace_slug", ws.Slug, "user_id", user.ID, "error", err)
+			if delErr := s.store.DeleteWorkspace(ws.Slug); delErr != nil {
+				slog.Error("auto-create workspace: failed to clean up orphaned workspace; manual intervention required",
+					"workspace_id", ws.ID, "workspace_slug", ws.Slug, "user_id", user.ID, "error", delErr)
+			}
+			return
+		}
+	}
 
 	slog.Info("auto-created default workspace", "user_id", user.ID, "workspace", ws.Slug)
 }

--- a/internal/server/handlers_cloud.go
+++ b/internal/server/handlers_cloud.go
@@ -275,8 +275,13 @@ func (s *Server) handleOAuthLogin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// 7. Create session (30-day TTL for OAuth sessions)
-	token, err := s.createAuthSession(w, r, user, 30*24*time.Hour)
+	// 7. Create session. Uses webSessionTTL (not a longer OAuth-specific
+	// TTL) so the session cookie, CSRF cookie, and store session row all
+	// expire together with every other web login — a longer-lived OAuth
+	// cookie used to outlive its server-side session, producing silent
+	// 401s once the store row expired but the browser kept presenting
+	// the cookie (B9, TASK-1932).
+	token, err := s.createAuthSession(w, r, user, webSessionTTL)
 	if err != nil {
 		return // Error already written by createAuthSession
 	}

--- a/internal/server/handlers_cloud_autocreate_workspace_test.go
+++ b/internal/server/handlers_cloud_autocreate_workspace_test.go
@@ -1,0 +1,81 @@
+package server
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// TestAutoCreateWorkspace_MemberAddFailure_CleansUpAndLogsLoudly covers the
+// B6 hardening from TASK-1932: if AddWorkspaceMember fails after the
+// workspace row is created, autoCreateWorkspace must not leave a
+// permanently orphaned, completely inaccessible workspace behind, and must
+// log loudly so on-call can see it happened.
+//
+// The failure is forced with a real DB-level error rather than a mock: the
+// user's ID is never inserted into the users table, so workspace_members'
+// FK on user_id rejects the INSERT (workspaces.owner_id has no such FK, so
+// CreateWorkspace succeeds first, matching the exact failure shape B6
+// describes).
+func TestAutoCreateWorkspace_MemberAddFailure_CleansUpAndLogsLoudly(t *testing.T) {
+	srv := testServer(t)
+	srv.cloudMode = true
+
+	before, err := srv.store.ListWorkspaces()
+	if err != nil {
+		t.Fatalf("ListWorkspaces before: %v", err)
+	}
+
+	var logBuf bytes.Buffer
+	prevLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logBuf, nil)))
+	defer slog.SetDefault(prevLogger)
+
+	ghost := &models.User{
+		ID:    "ghost-user-not-in-db",
+		Name:  "Ghost",
+		Email: "ghost@example.com",
+	}
+	srv.autoCreateWorkspace(ghost)
+
+	after, err := srv.store.ListWorkspaces()
+	if err != nil {
+		t.Fatalf("ListWorkspaces after: %v", err)
+	}
+	if len(after) != len(before) {
+		t.Errorf("expected no net-new workspace after a failed member-add (orphan must be cleaned up), before=%d after=%d",
+			len(before), len(after))
+	}
+
+	logged := logBuf.String()
+	if !strings.Contains(logged, "level=ERROR") {
+		t.Errorf("expected a loud (ERROR-level) log for the failed member-add, got: %s", logged)
+	}
+	if !strings.Contains(logged, "add owner member failed after retry") {
+		t.Errorf("expected the failure log to describe the retry-then-cleanup path, got: %s", logged)
+	}
+}
+
+// TestAutoCreateWorkspace_DeleteWorkspace_NoRowsIsAReportableError pins the
+// store-layer contract that autoCreateWorkspace's compensating cleanup
+// depends on: Store.DeleteWorkspace returns a non-nil error (rather than a
+// silent no-op) when the slug doesn't exist or is already soft-deleted.
+// That's what makes the "cleanup also failed" branch in autoCreateWorkspace
+// (the one that logs "manual intervention required" instead of the plain
+// success message) reachable and distinguishable from the happy-cleanup
+// case exercised above. End-to-end coverage of that double-failure branch
+// (member-add fails on retry AND the compensating delete fails) would
+// require racing a delete against autoCreateWorkspace's own delete call, or
+// a production test-seam — deliberately not added per the TASK-1932 plan —
+// so this test instead pins the store-level building block the branch
+// relies on.
+func TestAutoCreateWorkspace_DeleteWorkspace_NoRowsIsAReportableError(t *testing.T) {
+	srv := testServer(t)
+
+	if err := srv.store.DeleteWorkspace("does-not-exist-slug"); err == nil {
+		t.Fatal("expected DeleteWorkspace to return an error for a nonexistent slug, got nil")
+	}
+}

--- a/internal/server/handlers_oauth_provider_test.go
+++ b/internal/server/handlers_oauth_provider_test.go
@@ -94,6 +94,45 @@ func TestOAuthLogin_AppleProvider_StillRequiresVerifiedEmail(t *testing.T) {
 	}
 }
 
+// TestOAuthLogin_SessionTTLMatchesWebSession guards B9 (TASK-1932): OAuth
+// sessions used to mint a 30-day cookie while every other web login (and
+// the underlying store session row) used the shorter webSessionTTL. A
+// longer-lived cookie outliving its server-side session produces silent
+// 401s once the store row expires but the browser keeps presenting the
+// cookie. createAuthSession derives the session cookie's MaxAge from the
+// same ttl argument it uses for the store row, so asserting the cookie is
+// sufficient to pin both.
+func TestOAuthLogin_SessionTTLMatchesWebSession(t *testing.T) {
+	srv := testServer(t)
+	srv.SetCloudMode(oauthProviderTestSecret)
+
+	rr := postOAuthLogin(t, srv, map[string]interface{}{
+		"provider":       "google",
+		"email":          "ttlcheck@example.com",
+		"name":           "TTL Check",
+		"email_verified": true,
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("oauth-login: got %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+
+	var sessionCookie *http.Cookie
+	for _, c := range rr.Result().Cookies() {
+		if c.Name == sessionCookieName(false) {
+			sessionCookie = c
+			break
+		}
+	}
+	if sessionCookie == nil {
+		t.Fatal("expected oauth-login to set a session cookie")
+	}
+	wantMaxAge := int(webSessionTTL.Seconds())
+	if sessionCookie.MaxAge != wantMaxAge {
+		t.Errorf("oauth session cookie MaxAge = %d, want %d (webSessionTTL) — OAuth sessions must not outlive the web session TTL",
+			sessionCookie.MaxAge, wantMaxAge)
+	}
+}
+
 // TestOAuthLink_AppleProvider_Links exercises the second allowlist site
 // (handleOAuthLink) through the real handler, proving the shared helper was
 // wired there too — not just in oauth-login. (oauth-unlink shares the same

--- a/internal/server/middleware_auth.go
+++ b/internal/server/middleware_auth.go
@@ -56,6 +56,21 @@ const (
 	// — so leaking via context is fine.
 	ctxMCPTokenKind contextKey = "mcp_token_kind"
 	ctxMCPTokenRef  contextKey = "mcp_token_ref"
+	// ctxValidatedSessionBearer is set to true when the request was
+	// authenticated via a validated CLI session-bearer token
+	// (Authorization: Bearer padsess_...), as distinct from ctxIsAPIToken
+	// (a long-lived PAT) and from a session cookie. Deliberately a
+	// separate key rather than reusing ctxIsAPIToken: ctxIsAPIToken also
+	// gates PAT-vs-interactive-session behavior elsewhere (e.g. 2FA
+	// management requires an interactive session and explicitly rejects
+	// isAPITokenAuth callers) — a CLI session-bearer token IS an
+	// interactive session and must not trip that gate the way a PAT
+	// does. CSRFProtect reads this (via isValidatedBearerAuth) to tell
+	// "TokenAuth validated this Bearer credential" apart from "the
+	// request merely carries an Authorization: Bearer header TokenAuth
+	// never checked or rejected" — see the codex-round-3 fix note there
+	// (TASK-1932).
+	ctxValidatedSessionBearer contextKey = "validated_session_bearer"
 )
 
 // TokenAuth middleware checks for an Authorization: Bearer pad_xxx header.
@@ -140,6 +155,7 @@ func (s *Server) TokenAuth(next http.Handler) http.Handler {
 				slog.Warn("session renewal failed (request allowed)", "error", err)
 			}
 			ctx := context.WithValue(r.Context(), ctxCurrentUser, session.User)
+			ctx = context.WithValue(ctx, ctxValidatedSessionBearer, true)
 			next.ServeHTTP(w, r.WithContext(ctx))
 			return
 		}
@@ -423,6 +439,28 @@ func currentUser(r *http.Request) *models.User {
 func isAPITokenAuth(r *http.Request) bool {
 	v, _ := r.Context().Value(ctxIsAPIToken).(bool)
 	return v
+}
+
+// isValidatedSessionBearerAuth returns true if the request was authenticated
+// via a validated CLI session-bearer token (Authorization: Bearer
+// padsess_...) — set by TokenAuth only on successful ValidateSession, never
+// on the rejectInvalidBearer fallthrough. See ctxValidatedSessionBearer.
+func isValidatedSessionBearerAuth(r *http.Request) bool {
+	v, _ := r.Context().Value(ctxValidatedSessionBearer).(bool)
+	return v
+}
+
+// isValidatedBearerAuth reports whether the request was authenticated via a
+// Bearer credential TokenAuth actually validated — a long-lived API token
+// (isAPITokenAuth) or a CLI session-bearer token
+// (isValidatedSessionBearerAuth) — as opposed to merely carrying an
+// Authorization: Bearer header that TokenAuth never checked, or checked and
+// rejected (the rejectInvalidBearer fallthrough on public API paths). Both
+// validated forms are unguessable secrets a CSRF attacker can't forge, so
+// CSRFProtect treats them as exempt regardless of whether a session cookie
+// is also present on the same request (TASK-1932, codex round 3).
+func isValidatedBearerAuth(r *http.Request) bool {
+	return isAPITokenAuth(r) || isValidatedSessionBearerAuth(r)
 }
 
 // isBearerAuth reports whether the request was authenticated via an

--- a/internal/server/middleware_csrf.go
+++ b/internal/server/middleware_csrf.go
@@ -35,10 +35,18 @@ const (
 // code: a request that resolved to a real session via SessionAuth (which
 // runs before CSRFProtect — server.go's TokenAuth/SessionAuth/RateLimit/
 // CSRFProtect/RequireAuth ordering) falls through to the normal
-// double-submit check below instead of the early exemption. Bearer/PAT
-// requests are unaffected — TokenAuth also populates currentUser for
-// those, but they hit their own unconditional exemption further down
-// this function regardless. The pad-cloud sidecar sends no cookies at
+// double-submit check below instead of the early exemption. Requests
+// carrying a Bearer credential that TokenAuth actually VALIDATED (a PAT
+// or a CLI session-bearer token) are unaffected — they hit
+// isValidatedBearerAuth's unconditional exemption further down this
+// function regardless of whether a cookie is also present, because
+// TokenAuth runs first and short-circuits SessionAuth once currentUser is
+// already set. A Bearer header TokenAuth did NOT validate (garbage or
+// rejected, reaching here only via rejectInvalidBearer's public-path
+// fallthrough) is a DIFFERENT case — see the header-presence check
+// further down and its codex-round-3 fix note; it is exempt only when no
+// session was also resolved, precisely so it can't ride a victim's cookie
+// through this path exemption. The pad-cloud sidecar sends no cookies at
 // all, so oauth-login/oauth-link stay exempt (currentUser(r) is always
 // nil for them). One accepted interaction with the round-1 legacy-cookie
 // decision: a user resolved via SessionAuth's legacy pad_session cookie
@@ -147,32 +155,59 @@ func (s *Server) CSRFProtect(next http.Handler) http.Handler {
 		// based sessions; they authenticate via X-Cloud-Secret (or legacy
 		// ?cloud_secret). Path-gate this explicitly so a stray
 		// ?cloud_secret= on any other /api/ path (trivial in a cross-site
-		// form action) cannot be used to defeat CSRF elsewhere. Admin calls
-		// over cookie sessions to the same three endpoints fall through
-		// and still require a CSRF token — that is the entire point of
-		// narrowing from a path carve-out to a credential-plus-path check.
-		if isCloudAdminPath(r.URL.Path) && hasCloudSecretMarker(r) {
+		// form action) cannot be used to defeat CSRF elsewhere.
+		//
+		// hasCloudSecretMarker only checks PRESENCE of the marker, not
+		// whether the secret is actually correct — the real check
+		// (validateCloudSecret) happens in-handler. codex round 3 caught
+		// that several of these handlers (e.g. handleSetPlan) ALSO accept
+		// an admin cookie session as an alternative to the secret
+		// (`isAdmin := user != nil && ...; if !isAdmin { validateCloudSecret(...) }`)
+		// — so a marker-presence-only exemption let a cross-site request
+		// with a garbage X-Cloud-Secret ride a logged-in admin's cookie
+		// straight past CSRF into that admin branch, the same class of
+		// hole as handleRegister's in round 2. The currentUser(r) == nil
+		// guard closes it: a request that also resolved a real session
+		// falls through to the normal double-submit check below, so the
+		// admin branch can only be reached with either the real secret or
+		// a valid CSRF token — never a forged marker riding a stolen
+		// cookie. The pad-cloud sidecar sends no cookies, so its calls are
+		// unaffected (currentUser(r) is always nil for them).
+		if isCloudAdminPath(r.URL.Path) && hasCloudSecretMarker(r) && currentUser(r) == nil {
 			next.ServeHTTP(w, r)
 			return
 		}
 
-		// Bearer token requests are not vulnerable to CSRF — skip.
-		// Two signals, both mean "non-cookie-authenticated":
-		//   1. Authorization: Bearer header on the live request (the
-		//      normal CLI / connector path through TokenAuth).
-		//   2. ctxIsAPIToken set on the request context — TokenAuth
-		//      sets this after a successful Bearer validation, AND
-		//      in-process callers (the MCP HTTPHandlerDispatcher in
-		//      internal/mcp/dispatch_http.go) set it via the
-		//      server.WithAPITokenAuth helper to mark a synthesized
-		//      request as having been authenticated out-of-band.
-		// Either signal lets the request through; cookie-only
-		// requests still require the double-submit token below.
-		if auth := r.Header.Get("Authorization"); strings.HasPrefix(auth, "Bearer ") {
+		// Bearer credentials TokenAuth actually validated (a PAT or a CLI
+		// session-bearer token, or a synthesized in-process MCP-dispatcher
+		// call marked via server.WithAPITokenAuth) are never vulnerable to
+		// CSRF — the browser never attaches Authorization headers
+		// automatically, and the attacker can't forge the token value.
+		// Always exempt, regardless of whether a cookie is also present:
+		// TokenAuth runs before SessionAuth and short-circuits it once
+		// currentUser is set, so a validated Bearer credential is the
+		// sole source of truth for currentUser on this request either way.
+		if isValidatedBearerAuth(r) {
 			next.ServeHTTP(w, r)
 			return
 		}
-		if isAPITokenAuth(r) {
+
+		// An Authorization: Bearer header TokenAuth did NOT validate
+		// (garbage token, wrong format, expired — anything that hit
+		// rejectInvalidBearer's public-API-path fallthrough instead of a
+		// hard 401) is exempt ONLY when no session was also resolved for
+		// this request. codex round 3: the old unconditional version of
+		// this check exempted on header PRESENCE alone, so a cross-site
+		// request carrying a victim's real session cookie plus an
+		// attacker-supplied garbage Bearer header would sail past CSRF —
+		// on any /api/v1/auth/* path (isPublicAPIPath prefix-matches the
+		// whole tree, far wider than authCSRFExemptPaths above), not just
+		// the newly-tightened B8 endpoints. Gating on currentUser(r) ==
+		// nil preserves the CLI-recovery contract this fallthrough exists
+		// for (a pure Bearer client with an expired/garbage token, no
+		// cookie, must still reach RequireAuth for its own 401 rather than
+		// a confusing csrf_error) while closing the cookie-riding case.
+		if auth := r.Header.Get("Authorization"); strings.HasPrefix(auth, "Bearer ") && currentUser(r) == nil {
 			next.ServeHTTP(w, r)
 			return
 		}

--- a/internal/server/middleware_csrf.go
+++ b/internal/server/middleware_csrf.go
@@ -13,6 +13,55 @@ const (
 	csrfTokenLen = 32 // 32 bytes = 64 hex chars
 )
 
+// authCSRFExemptPaths lists the exact /api/v1/auth/* paths that are safe to
+// exempt from the double-submit CSRF check (B8, TASK-1932). Every other
+// mutating /api/v1/auth/* endpoint is cookie-session-gated and requires the
+// CSRF token like any other authenticated mutation — the web client's
+// shared request() wrapper already attaches X-CSRF-Token on every
+// non-GET/HEAD call, so narrowing this list doesn't require a frontend
+// change.
+//
+// This is an EXACT path match (not a prefix), on purpose: a prefix match is
+// exactly the bug B8 flags. In particular:
+//   - "/api/v1/auth/cli/sessions" (POST, create) is here because it's
+//     genuinely pre-session (the CLI calls it before any login exists).
+//     "/api/v1/auth/cli/sessions/{code}/approve" is a DIFFERENT path
+//     string and is deliberately NOT here — it's a mutating, cookie-
+//     session-authenticated action (approving a pending CLI login) that a
+//     cross-site POST could otherwise ride the victim's session to
+//     trigger. The GET poll endpoint doesn't need an entry — safe methods
+//     are exempt above regardless of path.
+//   - "/api/v1/auth/oauth-login" and "/api/v1/auth/oauth-link" are here
+//     because they authenticate ONLY via a cloud-secret in the JSON body
+//     (the pad-cloud sidecar calling in server-to-server) and never trust
+//     a cookie at all — CSRF isn't a meaningful threat model for them, and
+//     the sidecar has no CSRF cookie to send. "/api/v1/auth/oauth-unlink"
+//     is deliberately NOT here — unlike link/login, it authenticates
+//     purely via the session cookie (currentUser(r), no secret check) and
+//     is exactly the kind of endpoint this hardening targets.
+//   - "/api/v1/auth/resend-verification" is here because the handler
+//     itself never inspects the session — it takes an explicit email and
+//     returns a uniform response regardless of auth state, so an ambient
+//     cookie carries no extra authority for it and CSRF is a no-op either
+//     way.
+//   - "/api/v1/auth/logout" is deliberately NOT here — it's a real,
+//     cookie-session-authenticated mutation, and the frontend already
+//     sends CSRF on it via the shared request() wrapper.
+var authCSRFExemptPaths = map[string]bool{
+	"/api/v1/auth/bootstrap":           true,
+	"/api/v1/auth/register":            true,
+	"/api/v1/auth/login":               true,
+	"/api/v1/auth/forgot-password":     true,
+	"/api/v1/auth/reset-password":      true,
+	"/api/v1/auth/local-reset":         true,
+	"/api/v1/auth/verify-email":        true,
+	"/api/v1/auth/resend-verification": true,
+	"/api/v1/auth/2fa/login-verify":    true,
+	"/api/v1/auth/oauth-login":         true,
+	"/api/v1/auth/oauth-link":          true,
+	"/api/v1/auth/cli/sessions":        true,
+}
+
 // CSRFProtect implements the double-submit cookie pattern for CSRF protection.
 // It validates that state-changing requests (POST, PATCH, PUT, DELETE) from
 // cookie-authenticated sessions include a matching CSRF token in both the
@@ -39,8 +88,15 @@ func (s *Server) CSRFProtect(next http.Handler) http.Handler {
 		}
 
 		// Auth endpoints that need to work before a CSRF token exists
-		// (login, register, bootstrap, password reset).
-		if strings.HasPrefix(r.URL.Path, "/api/v1/auth/") {
+		// (login, register, bootstrap, password reset, ...) or that don't
+		// trust the ambient session at all. See authCSRFExemptPaths for
+		// the full rationale per entry — this is an EXACT match, not a
+		// prefix, so a mutating cookie-authed endpoint elsewhere under
+		// /api/v1/auth/* (PATCH /me, tokens, 2FA management, delete-
+		// account, oauth-unlink, CLI-session approve, logout, ...) still
+		// falls through to the CSRF check below like any other
+		// authenticated mutation (B8, TASK-1932).
+		if authCSRFExemptPaths[r.URL.Path] {
 			next.ServeHTTP(w, r)
 			return
 		}

--- a/internal/server/middleware_csrf.go
+++ b/internal/server/middleware_csrf.go
@@ -13,48 +13,26 @@ const (
 	csrfTokenLen = 32 // 32 bytes = 64 hex chars
 )
 
-// authCSRFExemptPaths lists the exact /api/v1/auth/* paths that are safe to
-// exempt from the double-submit CSRF check WHEN THE REQUEST IS
-// UNAUTHENTICATED (B8, TASK-1932; tightened for a P1 in codex round 2 — see
-// below). Every other mutating /api/v1/auth/* endpoint is cookie-session-
-// gated and requires the CSRF token like any other authenticated mutation —
-// the web client's shared request() wrapper already attaches X-CSRF-Token
-// on every non-GET/HEAD call, so narrowing this list doesn't require a
-// frontend change.
+// authCSRFUnconditionalExemptPaths lists the exact /api/v1/auth/* paths
+// whose authority comes entirely from the request BODY — credentials, a
+// one-time token, or a shared secret — never from the ambient session
+// cookie (B8, TASK-1932). A cookie riding alongside one of these requests
+// doesn't escalate what the handler does, so these stay exempt from the
+// double-submit CSRF check REGARDLESS of whether SessionAuth also
+// resolved a user for the request.
 //
-// The exemption is conditioned on currentUser(r) == nil (checked at the
-// call site below), not just the path. codex round 2 caught that
-// /auth/register is genuinely anonymous MOST of the time, but
-// handleRegister also has an admin-session branch (an already-logged-in
-// admin can create a verified account with no invitation code) — a plain
-// path exemption let a cross-site POST ride the admin's cookie straight
-// into that branch with no CSRF token, the same class of hole as the
-// oauth-unlink case B8 already closed. Gating on currentUser(r) == nil
-// closes register's admin branch, and any other session-authenticated
-// branch a future handler on this list grows, without touching handler
-// code: a request that resolved to a real session via SessionAuth (which
-// runs before CSRFProtect — server.go's TokenAuth/SessionAuth/RateLimit/
-// CSRFProtect/RequireAuth ordering) falls through to the normal
-// double-submit check below instead of the early exemption. Requests
-// carrying a Bearer credential that TokenAuth actually VALIDATED (a PAT
-// or a CLI session-bearer token) are unaffected — they hit
-// isValidatedBearerAuth's unconditional exemption further down this
-// function regardless of whether a cookie is also present, because
-// TokenAuth runs first and short-circuits SessionAuth once currentUser is
-// already set. A Bearer header TokenAuth did NOT validate (garbage or
-// rejected, reaching here only via rejectInvalidBearer's public-path
-// fallthrough) is a DIFFERENT case — see the header-presence check
-// further down and its codex-round-3 fix note; it is exempt only when no
-// session was also resolved, precisely so it can't ride a victim's cookie
-// through this path exemption. The pad-cloud sidecar sends no cookies at
-// all, so oauth-login/oauth-link stay exempt (currentUser(r) is always
-// nil for them). One accepted interaction with the round-1 legacy-cookie
-// decision: a user resolved via SessionAuth's legacy pad_session cookie
-// fallback also loses this exemption and needs a real CSRF token to
-// re-hit login/register — harmless, since they're already logged in and
-// the frontend sends the header anyway; an EXPIRED or absent legacy
-// session resolves to currentUser(r) == nil and stays exempt, so there's
-// no lockout path for a genuinely anonymous visitor.
+// This isn't just a convenience: pad mints the pad_csrf cookie AT LOGIN
+// (createAuthSession), so a pre-session endpoint like /login or
+// /bootstrap categorically CANNOT require a CSRF token that doesn't exist
+// yet. And a lingering session cookie from an earlier login (an E2E test
+// harness re-bootstrapping the admin then logging in fresh, the pad CLI,
+// a browser tab that re-authenticates as a different account, or simply
+// a stale cookie sitting alongside a fresh login POST) must not turn that
+// legitimate re-login into a CSRF failure. codex round 4 (via CI's E2E
+// suite, not static review — the gap the unit suite was missing) caught
+// exactly this: gating the WHOLE list on currentUser(r) == nil (round 2's
+// fix) broke /login whenever an ambient cookie was present, because
+// login's authority is the password in the body, not the cookie.
 //
 // This is an EXACT path match (not a prefix), on purpose: a prefix match is
 // exactly the bug B8 flags. In particular:
@@ -82,9 +60,16 @@ const (
 //   - "/api/v1/auth/logout" is deliberately NOT here — it's a real,
 //     cookie-session-authenticated mutation, and the frontend already
 //     sends CSRF on it via the shared request() wrapper.
-var authCSRFExemptPaths = map[string]bool{
+//   - "/api/v1/auth/register" is deliberately NOT here — see
+//     authCSRFSessionGatedExemptPaths below.
+//
+// Requests carrying a Bearer credential that TokenAuth actually VALIDATED
+// (a PAT or a CLI session-bearer token) are unaffected by any of this —
+// they hit isValidatedBearerAuth's unconditional exemption further down
+// this function regardless of path or cookie presence; see that check's
+// comment for the codex-round-3 validated-vs-present distinction.
+var authCSRFUnconditionalExemptPaths = map[string]bool{
 	"/api/v1/auth/bootstrap":           true,
-	"/api/v1/auth/register":            true,
 	"/api/v1/auth/login":               true,
 	"/api/v1/auth/forgot-password":     true,
 	"/api/v1/auth/reset-password":      true,
@@ -95,6 +80,34 @@ var authCSRFExemptPaths = map[string]bool{
 	"/api/v1/auth/oauth-login":         true,
 	"/api/v1/auth/oauth-link":          true,
 	"/api/v1/auth/cli/sessions":        true,
+}
+
+// authCSRFSessionGatedExemptPaths lists /api/v1/auth/* paths that are
+// exempt from CSRF ONLY when the request carries no session — i.e. only
+// when currentUser(r) == nil at the call site below. Unlike the
+// unconditional set above, these handlers have an ALTERNATE authorization
+// branch that DOES read the ambient session cookie, so exempting them
+// unconditionally would let a cross-site request ride a victim's cookie
+// into that branch with no CSRF token.
+//
+// register is the only entry: handleRegister is genuinely anonymous most
+// of the time (self-serve cloud signup, invitation acceptance), but it
+// also has an admin-session branch (an already-logged-in admin can
+// create a verified account with no invitation code) — codex round 2
+// found that a plain path exemption let a cross-site POST ride the
+// admin's cookie straight into that branch with no CSRF token, the same
+// class of hole as oauth-unlink. Gating on currentUser(r) == nil closes
+// that branch (a session-authenticated register falls through to the
+// real double-submit check) while a genuinely anonymous register keeps
+// the exemption. This is deliberately its OWN map (not folded into the
+// unconditional set with a blanket currentUser guard, which is what
+// round 2 originally did and what round 4's CI-caught regression forced
+// apart): login/bootstrap/etc. have no session-privileged branch at all,
+// so gating them on currentUser(r) == nil was never a security
+// requirement — it just broke legitimate re-login-with-a-lingering-cookie
+// flows for no benefit.
+var authCSRFSessionGatedExemptPaths = map[string]bool{
+	"/api/v1/auth/register": true,
 }
 
 // CSRFProtect implements the double-submit cookie pattern for CSRF protection.
@@ -122,31 +135,25 @@ func (s *Server) CSRFProtect(next http.Handler) http.Handler {
 			return
 		}
 
-		// Auth endpoints that need to work before a CSRF token exists
-		// (login, register, bootstrap, password reset, ...) or that don't
-		// trust the ambient session at all. See authCSRFExemptPaths for
-		// the full rationale per entry — this is an EXACT match, not a
-		// prefix, so a mutating cookie-authed endpoint elsewhere under
-		// /api/v1/auth/* (PATCH /me, tokens, 2FA management, delete-
-		// account, oauth-unlink, CLI-session approve, logout, ...) still
-		// falls through to the CSRF check below like any other
-		// authenticated mutation (B8, TASK-1932).
-		//
-		// The currentUser(r) == nil guard closes a P1 codex found in
-		// round 2: handleRegister has an admin-session branch (an
-		// already-logged-in admin can create a verified account with no
-		// invitation code), so exempting the bare path let a cross-site
-		// POST ride the admin's cookie into that branch with no CSRF
-		// token. SessionAuth runs before CSRFProtect, so currentUser(r)
-		// is already populated for any request carrying a valid session
-		// — gating on it here means a session-authenticated request to
-		// one of these paths falls through to the real double-submit
-		// check below, while a genuinely anonymous request (no session,
-		// including one that failed the round-1 legacy-cookie decision)
-		// keeps the exemption. See authCSRFExemptPaths's doc comment for
-		// the full reasoning, including why Bearer/cloud-secret callers
-		// are unaffected.
-		if authCSRFExemptPaths[r.URL.Path] && currentUser(r) == nil {
+		// Auth endpoints whose authority comes entirely from the request
+		// body (credentials, a one-time token, a shared secret) — never
+		// from the ambient session cookie — stay exempt regardless of
+		// whether SessionAuth also resolved a user for this request. See
+		// authCSRFUnconditionalExemptPaths for the full per-entry
+		// rationale and the round-4 CI regression this split fixes
+		// (B8, TASK-1932).
+		if authCSRFUnconditionalExemptPaths[r.URL.Path] {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		// register is exempt ONLY when unauthenticated: handleRegister
+		// has an admin-session branch that DOES derive authority from the
+		// ambient cookie (codex round 2), so a session-authenticated
+		// request falls through to the real double-submit check below
+		// instead of this exemption, while a genuinely anonymous request
+		// keeps it. See authCSRFSessionGatedExemptPaths's doc comment.
+		if authCSRFSessionGatedExemptPaths[r.URL.Path] && currentUser(r) == nil {
 			next.ServeHTTP(w, r)
 			return
 		}
@@ -201,7 +208,7 @@ func (s *Server) CSRFProtect(next http.Handler) http.Handler {
 		// request carrying a victim's real session cookie plus an
 		// attacker-supplied garbage Bearer header would sail past CSRF —
 		// on any /api/v1/auth/* path (isPublicAPIPath prefix-matches the
-		// whole tree, far wider than authCSRFExemptPaths above), not just
+		// whole tree, far wider than the exempt-path maps above), not just
 		// the newly-tightened B8 endpoints. Gating on currentUser(r) ==
 		// nil preserves the CLI-recovery contract this fallthrough exists
 		// for (a pure Bearer client with an expired/garbage token, no

--- a/internal/server/middleware_csrf.go
+++ b/internal/server/middleware_csrf.go
@@ -142,7 +142,35 @@ func (s *Server) CSRFProtect(next http.Handler) http.Handler {
 			return
 		}
 
-		// Cookie-based session: require CSRF token
+		// Cookie-based session: require CSRF token.
+		//
+		// Deliberately NO legacy-name fallback here, unlike SessionAuth's
+		// __Host-pad_session -> pad_session fallback (middleware_auth.go)
+		// for the session cookie. The two cookies have different trust
+		// requirements:
+		//   - Session cookie: the token VALUE is an unguessable secret: an
+		//     attacker who can only set the unprefixed name still can't
+		//     forge a value the store will accept. Accepting the legacy
+		//     name is just an upgrade-path convenience.
+		//   - CSRF cookie: double-submit's security property is "the
+		//     attacker cannot set BOTH the cookie and the header" for the
+		//     victim's browser. An unprefixed pad_csrf cookie can be set
+		//     from a sibling subdomain (no __Host- restriction), so an
+		//     attacker who controls a subdomain could plant a
+		//     matching pad_csrf cookie + forge the matching header value
+		//     themselves — defeating the whole scheme. __Host- exists
+		//     specifically to close that subdomain-cookie-injection hole,
+		//     so accepting the unprefixed name in secure mode would
+		//     silently reopen it. Do not "restore symmetry" with
+		//     SessionAuth here; the asymmetry is the point.
+		//
+		// Exposure from the lack of fallback is bounded to deployments
+		// that recently flipped PAD_SECURE_COOKIES on: an already-logged-in
+		// browser holding legacy pad_session + pad_csrf cookies still
+		// authenticates (session fallback) but 403s on CSRF-required
+		// mutations until the next login mints __Host--prefixed cookies —
+		// self-heals within the session TTL. See
+		// TestCSRF_LegacyCookieFallback_NotAcceptedWhenSecure.
 		cookie, err := r.Cookie(csrfCookieName(s.secureCookies))
 		if err != nil || cookie.Value == "" {
 			writeError(w, http.StatusForbidden, "csrf_error", "Missing CSRF token")

--- a/internal/server/middleware_csrf.go
+++ b/internal/server/middleware_csrf.go
@@ -14,12 +14,39 @@ const (
 )
 
 // authCSRFExemptPaths lists the exact /api/v1/auth/* paths that are safe to
-// exempt from the double-submit CSRF check (B8, TASK-1932). Every other
-// mutating /api/v1/auth/* endpoint is cookie-session-gated and requires the
-// CSRF token like any other authenticated mutation — the web client's
-// shared request() wrapper already attaches X-CSRF-Token on every
-// non-GET/HEAD call, so narrowing this list doesn't require a frontend
-// change.
+// exempt from the double-submit CSRF check WHEN THE REQUEST IS
+// UNAUTHENTICATED (B8, TASK-1932; tightened for a P1 in codex round 2 — see
+// below). Every other mutating /api/v1/auth/* endpoint is cookie-session-
+// gated and requires the CSRF token like any other authenticated mutation —
+// the web client's shared request() wrapper already attaches X-CSRF-Token
+// on every non-GET/HEAD call, so narrowing this list doesn't require a
+// frontend change.
+//
+// The exemption is conditioned on currentUser(r) == nil (checked at the
+// call site below), not just the path. codex round 2 caught that
+// /auth/register is genuinely anonymous MOST of the time, but
+// handleRegister also has an admin-session branch (an already-logged-in
+// admin can create a verified account with no invitation code) — a plain
+// path exemption let a cross-site POST ride the admin's cookie straight
+// into that branch with no CSRF token, the same class of hole as the
+// oauth-unlink case B8 already closed. Gating on currentUser(r) == nil
+// closes register's admin branch, and any other session-authenticated
+// branch a future handler on this list grows, without touching handler
+// code: a request that resolved to a real session via SessionAuth (which
+// runs before CSRFProtect — server.go's TokenAuth/SessionAuth/RateLimit/
+// CSRFProtect/RequireAuth ordering) falls through to the normal
+// double-submit check below instead of the early exemption. Bearer/PAT
+// requests are unaffected — TokenAuth also populates currentUser for
+// those, but they hit their own unconditional exemption further down
+// this function regardless. The pad-cloud sidecar sends no cookies at
+// all, so oauth-login/oauth-link stay exempt (currentUser(r) is always
+// nil for them). One accepted interaction with the round-1 legacy-cookie
+// decision: a user resolved via SessionAuth's legacy pad_session cookie
+// fallback also loses this exemption and needs a real CSRF token to
+// re-hit login/register — harmless, since they're already logged in and
+// the frontend sends the header anyway; an EXPIRED or absent legacy
+// session resolves to currentUser(r) == nil and stays exempt, so there's
+// no lockout path for a genuinely anonymous visitor.
 //
 // This is an EXACT path match (not a prefix), on purpose: a prefix match is
 // exactly the bug B8 flags. In particular:
@@ -96,7 +123,22 @@ func (s *Server) CSRFProtect(next http.Handler) http.Handler {
 		// account, oauth-unlink, CLI-session approve, logout, ...) still
 		// falls through to the CSRF check below like any other
 		// authenticated mutation (B8, TASK-1932).
-		if authCSRFExemptPaths[r.URL.Path] {
+		//
+		// The currentUser(r) == nil guard closes a P1 codex found in
+		// round 2: handleRegister has an admin-session branch (an
+		// already-logged-in admin can create a verified account with no
+		// invitation code), so exempting the bare path let a cross-site
+		// POST ride the admin's cookie into that branch with no CSRF
+		// token. SessionAuth runs before CSRFProtect, so currentUser(r)
+		// is already populated for any request carrying a valid session
+		// — gating on it here means a session-authenticated request to
+		// one of these paths falls through to the real double-submit
+		// check below, while a genuinely anonymous request (no session,
+		// including one that failed the round-1 legacy-cookie decision)
+		// keeps the exemption. See authCSRFExemptPaths's doc comment for
+		// the full reasoning, including why Bearer/cloud-secret callers
+		// are unaffected.
+		if authCSRFExemptPaths[r.URL.Path] && currentUser(r) == nil {
 			next.ServeHTTP(w, r)
 			return
 		}

--- a/internal/server/middleware_csrf_test.go
+++ b/internal/server/middleware_csrf_test.go
@@ -352,25 +352,27 @@ func TestCSRF_CLISessionApprove_RequiresCSRF(t *testing.T) {
 }
 
 // TestCSRF_TrailingSlashVariant_OfExemptPath_NotExempted guards the exact-
-// match design of authCSRFExemptPaths: a trailing-slash variant of an
-// otherwise-exempt path (e.g. "/api/v1/auth/register/") must NOT inherit
-// the bare path's exemption via prefix-matching or path normalization.
+// match design of authCSRFUnconditionalExemptPaths: a trailing-slash
+// variant of an otherwise-exempt path (e.g. "/api/v1/auth/login/") must
+// NOT inherit the bare path's exemption via prefix-matching or path
+// normalization. Uses login (unconditionally exempt) rather than register
+// (session-gated) so this test isolates the exact-match property from the
+// currentUser(r) == nil gate register alone carries.
 func TestCSRF_TrailingSlashVariant_OfExemptPath_NotExempted(t *testing.T) {
 	srv := testServer(t)
 
 	bootstrapFirstUser(t, srv, "admin@test.com", "Admin")
-	sessionToken := loginUser(t, srv, "admin@test.com", "correct-horse-battery-staple")
 
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/register/", strings.NewReader(`{}`))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/login/", strings.NewReader(`{}`))
 	req.Header.Set("Content-Type", "application/json")
 	req.RemoteAddr = "192.0.2.1:1234"
-	req.AddCookie(&http.Cookie{Name: "pad_session", Value: sessionToken})
-	// Deliberately no CSRF cookie/header.
+	// No session cookie either — the point is that the trailing slash
+	// alone must not carry the exemption, independent of session state.
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
 
 	if w.Code != http.StatusForbidden || !strings.Contains(w.Body.String(), "csrf") {
-		t.Errorf("trailing-slash variant of an exempt path must still require CSRF, got %d: %s", w.Code, w.Body.String())
+		t.Errorf("trailing-slash variant of an unconditionally exempt path must still require CSRF, got %d: %s", w.Code, w.Body.String())
 	}
 }
 
@@ -633,4 +635,66 @@ func TestCSRF_ValidBearerPlusSessionCookie_ExemptRegardless(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("valid Bearer + session cookie, no CSRF token: expected 200, got %d: %s", w.Code, w.Body.String())
 	}
+}
+
+// TestCSRF_LoginAndBootstrap_ExemptEvenWithAmbientSessionCookie pins the
+// exact regression codex round 4's CI (E2E) run caught: round 2's fix
+// gated the WHOLE authCSRFExemptPaths list (not just register) on
+// currentUser(r) == nil, so a /login POST carrying a lingering session
+// cookie — e.g. the E2E harness bootstrapping the admin (which mints a
+// session cookie) and then immediately POSTing /login to re-authenticate
+// — got a spurious 403 csrf_error instead of reaching the handler. Only
+// register has a session-privileged branch that justifies the
+// currentUser(r) == nil gate; login/bootstrap have none, so an ambient
+// cookie must never cost them their exemption. This is unit-level
+// coverage for the exact case the E2E suite hit, since static review
+// alone missed the blast radius of round 2's fix.
+func TestCSRF_LoginAndBootstrap_ExemptEvenWithAmbientSessionCookie(t *testing.T) {
+	srv := testServer(t)
+
+	sessionToken := bootstrapFirstUser(t, srv, "admin@test.com", "Admin")
+
+	t.Run("login with ambient session cookie, no CSRF header", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/login", strings.NewReader(
+			`{"email":"admin@test.com","password":"correct-horse-battery-staple"}`))
+		req.Header.Set("Content-Type", "application/json")
+		req.RemoteAddr = "192.0.2.1:1234"
+		req.AddCookie(&http.Cookie{Name: "pad_session", Value: sessionToken})
+		// Deliberately no CSRF cookie/header — this is exactly what the
+		// E2E harness's global-setup.ts sends after bootstrapping.
+		w := httptest.NewRecorder()
+		srv.ServeHTTP(w, req)
+
+		if strings.Contains(w.Body.String(), "csrf") {
+			t.Fatalf("login with an ambient session cookie must not be blocked by CSRF, got %d: %s", w.Code, w.Body.String())
+		}
+		if w.Code != http.StatusOK {
+			t.Fatalf("login with correct credentials + ambient cookie: expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("bootstrap with ambient session cookie, no CSRF header", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/bootstrap", strings.NewReader(
+			`{"email":"second@test.com","name":"Second","password":"correct-horse-battery-staple"}`))
+		req.Header.Set("Content-Type", "application/json")
+		// handleBootstrap is also loopback-gated (separate from CSRF);
+		// use a loopback RemoteAddr so the request reaches the CSRF-
+		// irrelevant business logic this test actually cares about,
+		// same as bootstrapFirstUser's own doLoopbackRequest helper.
+		req.RemoteAddr = "127.0.0.1:1234"
+		req.AddCookie(&http.Cookie{Name: "pad_session", Value: sessionToken})
+		// Deliberately no CSRF cookie/header.
+		w := httptest.NewRecorder()
+		srv.ServeHTTP(w, req)
+
+		if strings.Contains(w.Body.String(), "csrf") {
+			t.Fatalf("bootstrap with an ambient session cookie must not be blocked by CSRF, got %d: %s", w.Code, w.Body.String())
+		}
+		// A user already exists (bootstrapFirstUser above), so the
+		// handler correctly rejects this with a business-logic 409 — the
+		// point is that it's a business-logic rejection, not a CSRF one.
+		if w.Code != http.StatusConflict {
+			t.Fatalf("bootstrap on an already-initialized instance: expected 409 conflict (business logic), got %d: %s", w.Code, w.Body.String())
+		}
+	})
 }

--- a/internal/server/middleware_csrf_test.go
+++ b/internal/server/middleware_csrf_test.go
@@ -469,3 +469,83 @@ func TestCSRF_LegacyCookieFallback_NotAcceptedWhenSecure(t *testing.T) {
 		t.Errorf("expected a csrf_error response, got: %s", w.Body.String())
 	}
 }
+
+// TestCSRF_AdminSessionRegister_RequiresCSRF covers the P1 codex found in
+// round 2 of TASK-1932: handleRegister has an admin-session branch (an
+// already-logged-in admin can create a verified account with no invitation
+// code), but /api/v1/auth/register was unconditionally CSRF-exempt by
+// path — a cross-site POST could ride the admin's cookie into that branch
+// with no CSRF token, same class of hole as the oauth-unlink case B8
+// already closed. An admin session hitting /register without a CSRF token
+// must now be blocked.
+func TestCSRF_AdminSessionRegister_RequiresCSRF(t *testing.T) {
+	srv := testServer(t)
+
+	adminToken := bootstrapFirstUser(t, srv, "admin@test.com", "Admin")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/register", strings.NewReader(
+		`{"email":"newadmin@test.com","name":"New Admin","password":"correct-horse-battery-staple"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.RemoteAddr = "192.0.2.1:1234"
+	req.AddCookie(&http.Cookie{Name: "pad_session", Value: adminToken})
+	// Deliberately no CSRF cookie/header.
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden || !strings.Contains(w.Body.String(), "csrf") {
+		t.Fatalf("admin-session register without CSRF token must be blocked, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestCSRF_AdminSessionRegister_ValidCSRFStillSucceeds is the companion to
+// the test above: an admin session WITH a valid double-submit pair must
+// still be able to create accounts — the P1 fix only closes the missing-
+// token gap, it doesn't break the legitimate admin-created-account flow.
+func TestCSRF_AdminSessionRegister_ValidCSRFStillSucceeds(t *testing.T) {
+	srv := testServer(t)
+
+	adminToken := bootstrapFirstUser(t, srv, "admin@test.com", "Admin")
+
+	csrfVal := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/register", strings.NewReader(
+		`{"email":"newadmin2@test.com","name":"New Admin","password":"correct-horse-battery-staple"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-CSRF-Token", csrfVal)
+	req.RemoteAddr = "192.0.2.1:1234"
+	req.AddCookie(&http.Cookie{Name: "pad_session", Value: adminToken})
+	req.AddCookie(&http.Cookie{Name: "pad_csrf", Value: csrfVal})
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("admin-session register with valid CSRF token: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestCSRF_AnonymousRegister_StillExempt confirms the P1 fix didn't
+// collateral-damage the genuinely anonymous case: a request carrying no
+// session at all must still reach handleRegister rather than being
+// rejected by CSRF, even once users already exist (so the separate
+// "fresh install" bypass doesn't mask the result).
+func TestCSRF_AnonymousRegister_StillExempt(t *testing.T) {
+	srv := testServer(t)
+	bootstrapFirstUser(t, srv, "admin@test.com", "Admin")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/register", strings.NewReader(
+		`{"email":"anon@test.com","name":"Anon","password":"correct-horse-battery-staple"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.RemoteAddr = "192.0.2.1:1234"
+	// No cookies at all — genuinely anonymous.
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	// Self-hosted (non-cloud), non-admin, no invitation: the handler
+	// correctly rejects this with "forbidden" business logic — the point
+	// is that it's a business-logic rejection, not a CSRF one.
+	if strings.Contains(w.Body.String(), "csrf") {
+		t.Fatalf("anonymous register must not be blocked by CSRF, got %d: %s", w.Code, w.Body.String())
+	}
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("anonymous register on a non-cloud instance: expected 403 forbidden (business logic), got %d: %s", w.Code, w.Body.String())
+	}
+}

--- a/internal/server/middleware_csrf_test.go
+++ b/internal/server/middleware_csrf_test.go
@@ -50,11 +50,13 @@ func TestCSRF_BearerTokenExempt(t *testing.T) {
 func TestCSRF_AuthEndpointsExempt(t *testing.T) {
 	srv := testServer(t)
 
-	// Auth endpoints should work without CSRF token
+	// Auth endpoints should work without CSRF token. logout is
+	// deliberately NOT in this list — B8 (TASK-1932) moved it into the
+	// CSRF-required set since it's a real cookie-session-authenticated
+	// mutation; see TestCSRF_AuthMutatingEndpoints_RequireCSRF.
 	endpoints := []string{
 		"/api/v1/auth/login",
 		"/api/v1/auth/register",
-		"/api/v1/auth/logout",
 		"/api/v1/auth/forgot-password",
 		"/api/v1/auth/reset-password",
 	}
@@ -210,20 +212,188 @@ func TestCSRF_LogoutClearsCSRFCookie(t *testing.T) {
 	bootstrapFirstUser(t, srv, "admin@test.com", "Admin")
 	sessionToken := loginUser(t, srv, "admin@test.com", "correct-horse-battery-staple")
 
-	// Logout (auth endpoints are CSRF-exempt)
+	// logout moved into the CSRF-required set in B8 (TASK-1932) — it's a
+	// real cookie-session-authenticated mutation, and the web client
+	// already sends the token on it. A valid double-submit pair is
+	// required for the request to reach the handler at all.
+	csrfVal := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/logout", nil)
+	req.Header.Set("X-CSRF-Token", csrfVal)
 	req.AddCookie(&http.Cookie{Name: "pad_session", Value: sessionToken})
+	req.AddCookie(&http.Cookie{Name: "pad_csrf", Value: csrfVal})
 	req.RemoteAddr = "192.0.2.1:1234"
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
 
+	if w.Code != http.StatusOK {
+		t.Fatalf("logout with valid CSRF token: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
 	// Check CSRF cookie is cleared
+	var foundClearedCSRF bool
 	for _, c := range w.Result().Cookies() {
 		if c.Name == "pad_csrf" {
+			foundClearedCSRF = true
 			if c.MaxAge >= 0 {
 				t.Errorf("expected CSRF cookie to be cleared (MaxAge < 0), got MaxAge=%d", c.MaxAge)
 			}
 		}
+	}
+	if !foundClearedCSRF {
+		t.Error("expected logout response to clear the pad_csrf cookie")
+	}
+}
+
+// TestCSRF_AuthMutatingEndpoints_RequireCSRF covers B8 (TASK-1932): every
+// cookie-session-authenticated mutation under /api/v1/auth/* — not just the
+// generic /api/v1/* surface — must require the double-submit CSRF token.
+// Before B8 these were all bypassed by a blanket /api/v1/auth/ prefix
+// exemption.
+func TestCSRF_AuthMutatingEndpoints_RequireCSRF(t *testing.T) {
+	srv := testServer(t)
+
+	bootstrapFirstUser(t, srv, "admin@test.com", "Admin")
+	sessionToken := loginUser(t, srv, "admin@test.com", "correct-horse-battery-staple")
+
+	cases := []struct {
+		name   string
+		method string
+		path   string
+		body   string
+	}{
+		{"logout", http.MethodPost, "/api/v1/auth/logout", ""},
+		{"update profile", http.MethodPatch, "/api/v1/auth/me", `{"name":"New Name"}`},
+		{"oauth-unlink", http.MethodPost, "/api/v1/auth/oauth-unlink", `{"provider":"github"}`},
+		{"2fa setup", http.MethodPost, "/api/v1/auth/2fa/setup", ""},
+		{"2fa disable", http.MethodPost, "/api/v1/auth/2fa/disable", `{"password":"x"}`},
+		{"delete account", http.MethodPost, "/api/v1/auth/delete-account", `{"password":"x"}`},
+		{"create token", http.MethodPost, "/api/v1/auth/tokens", `{"name":"t"}`},
+		{"delete token", http.MethodDelete, "/api/v1/auth/tokens/some-id", ""},
+		{"rotate token", http.MethodPost, "/api/v1/auth/tokens/some-id/rotate", ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var bodyReader *strings.Reader
+			if tc.body != "" {
+				bodyReader = strings.NewReader(tc.body)
+			} else {
+				bodyReader = strings.NewReader("")
+			}
+			req := httptest.NewRequest(tc.method, tc.path, bodyReader)
+			if tc.body != "" {
+				req.Header.Set("Content-Type", "application/json")
+			}
+			req.RemoteAddr = "192.0.2.1:1234"
+			req.AddCookie(&http.Cookie{Name: "pad_session", Value: sessionToken})
+			// Deliberately NO CSRF cookie/header.
+			w := httptest.NewRecorder()
+			srv.ServeHTTP(w, req)
+
+			if w.Code != http.StatusForbidden {
+				t.Fatalf("%s %s without CSRF token: expected 403, got %d: %s", tc.method, tc.path, w.Code, w.Body.String())
+			}
+			if !strings.Contains(w.Body.String(), "csrf") {
+				t.Errorf("%s %s: expected a csrf_error response, got: %s", tc.method, tc.path, w.Body.String())
+			}
+		})
+	}
+}
+
+// TestCSRF_CLISessionApprove_RequiresCSRF covers the specific finding that
+// approving a pending CLI login (a cookie-session-authenticated mutation
+// that could otherwise be ridden by a cross-site POST to bind a victim's
+// session to an attacker-controlled CLI code) must require CSRF, while the
+// bare create/poll endpoints stay exempt/safe-method.
+func TestCSRF_CLISessionApprove_RequiresCSRF(t *testing.T) {
+	srv := testServer(t)
+
+	bootstrapFirstUser(t, srv, "admin@test.com", "Admin")
+	sessionToken := loginUser(t, srv, "admin@test.com", "correct-horse-battery-staple")
+
+	// Create a pending CLI auth session (exempt, pre-session by design).
+	createReq := httptest.NewRequest(http.MethodPost, "/api/v1/auth/cli/sessions", nil)
+	createReq.RemoteAddr = "192.0.2.1:1234"
+	createW := httptest.NewRecorder()
+	srv.ServeHTTP(createW, createReq)
+	if createW.Code != http.StatusOK {
+		t.Fatalf("create CLI session: expected 200, got %d: %s", createW.Code, createW.Body.String())
+	}
+	var created struct {
+		SessionCode string `json:"session_code"`
+	}
+	parseJSON(t, createW, &created)
+	if created.SessionCode == "" {
+		t.Fatal("expected a session_code from CLI session create")
+	}
+
+	// Approve without a CSRF token must be blocked.
+	approveReq := httptest.NewRequest(http.MethodPost, "/api/v1/auth/cli/sessions/"+created.SessionCode+"/approve", nil)
+	approveReq.RemoteAddr = "192.0.2.1:1234"
+	approveReq.AddCookie(&http.Cookie{Name: "pad_session", Value: sessionToken})
+	approveW := httptest.NewRecorder()
+	srv.ServeHTTP(approveW, approveReq)
+	if approveW.Code != http.StatusForbidden {
+		t.Fatalf("approve without CSRF token: expected 403, got %d: %s", approveW.Code, approveW.Body.String())
+	}
+
+	// Approve with a valid double-submit pair must succeed.
+	csrfVal := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	approveReq2 := httptest.NewRequest(http.MethodPost, "/api/v1/auth/cli/sessions/"+created.SessionCode+"/approve", nil)
+	approveReq2.Header.Set("X-CSRF-Token", csrfVal)
+	approveReq2.RemoteAddr = "192.0.2.1:1234"
+	approveReq2.AddCookie(&http.Cookie{Name: "pad_session", Value: sessionToken})
+	approveReq2.AddCookie(&http.Cookie{Name: "pad_csrf", Value: csrfVal})
+	approveW2 := httptest.NewRecorder()
+	srv.ServeHTTP(approveW2, approveReq2)
+	if approveW2.Code != http.StatusOK {
+		t.Fatalf("approve with valid CSRF token: expected 200, got %d: %s", approveW2.Code, approveW2.Body.String())
+	}
+}
+
+// TestCSRF_TrailingSlashVariant_OfExemptPath_NotExempted guards the exact-
+// match design of authCSRFExemptPaths: a trailing-slash variant of an
+// otherwise-exempt path (e.g. "/api/v1/auth/register/") must NOT inherit
+// the bare path's exemption via prefix-matching or path normalization.
+func TestCSRF_TrailingSlashVariant_OfExemptPath_NotExempted(t *testing.T) {
+	srv := testServer(t)
+
+	bootstrapFirstUser(t, srv, "admin@test.com", "Admin")
+	sessionToken := loginUser(t, srv, "admin@test.com", "correct-horse-battery-staple")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/register/", strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.RemoteAddr = "192.0.2.1:1234"
+	req.AddCookie(&http.Cookie{Name: "pad_session", Value: sessionToken})
+	// Deliberately no CSRF cookie/header.
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden || !strings.Contains(w.Body.String(), "csrf") {
+		t.Errorf("trailing-slash variant of an exempt path must still require CSRF, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestCSRF_CLISessionsSubpath_DoesNotInheritCreateExemption guards the
+// other direction of the same exact-match design: the exempt bare
+// "/api/v1/auth/cli/sessions" (create) entry must not leak, via prefix
+// matching, to the required "/api/v1/auth/cli/sessions/{code}/approve"
+// sub-path.
+func TestCSRF_CLISessionsSubpath_DoesNotInheritCreateExemption(t *testing.T) {
+	srv := testServer(t)
+
+	bootstrapFirstUser(t, srv, "admin@test.com", "Admin")
+	sessionToken := loginUser(t, srv, "admin@test.com", "correct-horse-battery-staple")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/cli/sessions/some-code/approve", nil)
+	req.RemoteAddr = "192.0.2.1:1234"
+	req.AddCookie(&http.Cookie{Name: "pad_session", Value: sessionToken})
+	// Deliberately no CSRF cookie/header.
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden || !strings.Contains(w.Body.String(), "csrf") {
+		t.Errorf("cli/sessions/{code}/approve must not inherit the bare create path's CSRF exemption, got %d: %s", w.Code, w.Body.String())
 	}
 }
 

--- a/internal/server/middleware_csrf_test.go
+++ b/internal/server/middleware_csrf_test.go
@@ -418,3 +418,54 @@ func TestCSRF_AllMutationMethodsBlocked(t *testing.T) {
 		}
 	}
 }
+
+// TestCSRF_LegacyCookieFallback_NotAcceptedWhenSecure pins a deliberate
+// asymmetry surfaced in codex review of TASK-1932: SessionAuth falls back
+// from the __Host--prefixed session cookie to the legacy unprefixed name
+// (upgrade-path convenience — the token VALUE is still an unguessable
+// secret either way), but the CSRF cookie lookup has NO such fallback. A
+// legacy unprefixed pad_csrf cookie is settable from a sibling subdomain,
+// which is exactly the hole __Host- exists to close for double-submit's
+// security property (attacker must not be able to set both the cookie and
+// the header). Accepting it here would silently reopen that hole for any
+// deployment that recently flipped PAD_SECURE_COOKIES on.
+//
+// This test simulates that exact deployment moment: secureCookies=true,
+// but the request still carries legacy-named session AND CSRF cookies (as
+// a browser that logged in before the flip would). The session must still
+// resolve (auth fallback intentionally works), but a CSRF-required
+// mutation must still be rejected (no CSRF fallback) until the browser
+// re-logs-in and receives __Host--prefixed cookies.
+func TestCSRF_LegacyCookieFallback_NotAcceptedWhenSecure(t *testing.T) {
+	srv := testServer(t)
+
+	// Bootstrap and log in while secureCookies is still false, so the
+	// login response mints legacy-named "pad_session" / "pad_csrf"
+	// cookies — standing in for a browser that authenticated before the
+	// deployment enabled secure cookies.
+	bootstrapFirstUser(t, srv, "admin@test.com", "Admin")
+	sessionToken := loginUser(t, srv, "admin@test.com", "correct-horse-battery-staple")
+
+	// Now simulate the deployment flipping PAD_SECURE_COOKIES on. The
+	// browser's existing legacy cookies don't change.
+	srv.secureCookies = true
+
+	csrfVal := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/auth/me", strings.NewReader(`{"name":"New Name"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-CSRF-Token", csrfVal)
+	req.RemoteAddr = "192.0.2.1:1234"
+	// Legacy unprefixed cookie names — no __Host- prefix, as an
+	// already-logged-in browser would still be presenting post-flip.
+	req.AddCookie(&http.Cookie{Name: "pad_session", Value: sessionToken})
+	req.AddCookie(&http.Cookie{Name: "pad_csrf", Value: csrfVal})
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("legacy pad_csrf cookie must NOT be accepted once secureCookies is true, got %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "csrf") {
+		t.Errorf("expected a csrf_error response, got: %s", w.Body.String())
+	}
+}

--- a/internal/server/middleware_csrf_test.go
+++ b/internal/server/middleware_csrf_test.go
@@ -549,3 +549,88 @@ func TestCSRF_AnonymousRegister_StillExempt(t *testing.T) {
 		t.Fatalf("anonymous register on a non-cloud instance: expected 403 forbidden (business logic), got %d: %s", w.Code, w.Body.String())
 	}
 }
+
+// TestCSRF_SessionCookiePlusGarbageBearer_RequiresCSRF covers the codex
+// round-3 finding: the old Bearer exemption fired on header PRESENCE, not
+// validation. TokenAuth's rejectInvalidBearer deliberately falls through
+// (rather than 401ing) on /api/v1/auth/* paths so a stale CLI token can
+// still recover — but that fallthrough let a cross-site request carrying a
+// victim's real session cookie plus an attacker-supplied garbage Bearer
+// header sail past CSRF on any newly-CSRF-required auth endpoint. A
+// session cookie plus an invalid Bearer header, with no CSRF token, must
+// now be blocked.
+func TestCSRF_SessionCookiePlusGarbageBearer_RequiresCSRF(t *testing.T) {
+	srv := testServer(t)
+
+	sessionToken := bootstrapFirstUser(t, srv, "admin@test.com", "Admin")
+
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/auth/me", strings.NewReader(`{"name":"New Name"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer this-is-not-a-real-token")
+	req.RemoteAddr = "192.0.2.1:1234"
+	req.AddCookie(&http.Cookie{Name: "pad_session", Value: sessionToken})
+	// Deliberately no CSRF cookie/header.
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden || !strings.Contains(w.Body.String(), "csrf") {
+		t.Fatalf("session cookie + garbage Bearer header without CSRF token must be blocked as csrf_error, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestCSRF_GarbageBearerNoCookie_StaysCLIRecoveryPath is the companion to
+// the test above: a PURE Bearer client (no session cookie at all) with an
+// invalid/expired token must keep today's behavior exactly — exempt from
+// CSRF, falling through to the normal auth check, which rejects it with
+// 401 (not a confusing 403 csrf_error). This is the CLI-recovery
+// contract rejectInvalidBearer's fallthrough exists for: a stale
+// ~/.pad/credentials.json must still reach /api/v1/auth/me (and similar)
+// to get a clear "not logged in" rather than being misdiagnosed as a CSRF
+// failure.
+func TestCSRF_GarbageBearerNoCookie_StaysCLIRecoveryPath(t *testing.T) {
+	srv := testServer(t)
+	bootstrapFirstUser(t, srv, "admin@test.com", "Admin")
+
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/auth/me", strings.NewReader(`{"name":"New Name"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer this-is-not-a-real-token")
+	req.RemoteAddr = "192.0.2.1:1234"
+	// No cookies at all.
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if strings.Contains(w.Body.String(), "csrf") {
+		t.Fatalf("a pure garbage-Bearer client with no cookie must not be blocked by CSRF, got %d: %s", w.Code, w.Body.String())
+	}
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 (not logged in) for a garbage Bearer token with no cookie, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestCSRF_ValidBearerPlusSessionCookie_ExemptRegardless proves the third
+// required semantic from codex round 3: a request carrying a Bearer
+// credential TokenAuth actually validated (here, a CLI session-bearer
+// token) must stay CSRF-exempt even when a session cookie is ALSO
+// present — the fix must not newly break legitimate token clients that
+// happen to carry cookies. TokenAuth resolves the Bearer first and
+// short-circuits SessionAuth once currentUser is set, so the cookie's
+// value is irrelevant here; a different value would behave identically.
+func TestCSRF_ValidBearerPlusSessionCookie_ExemptRegardless(t *testing.T) {
+	srv := testServer(t)
+
+	sessionToken := bootstrapFirstUser(t, srv, "admin@test.com", "Admin")
+
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/auth/me", strings.NewReader(`{"name":"New Name"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+sessionToken)
+	req.RemoteAddr = "192.0.2.1:1234"
+	req.AddCookie(&http.Cookie{Name: "pad_session", Value: sessionToken})
+	// Deliberately no CSRF cookie/header — the point is that a validated
+	// Bearer credential doesn't need one even with a cookie present.
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("valid Bearer + session cookie, no CSRF token: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}


### PR DESCRIPTION
# fix(server): auth-perimeter hardening — B6–B9 from the IDEA-1927 audit (TASK-1932)

Closes the four latent/adjacent hardening findings from the verified cloud-auth audit ([IDEA-1927] §Latent), consolidated in TASK-1932. B6 was flagged must-fix-before-launch once self-registration shipped (#808–#810) — it ships here ahead of the pending app.getpad.dev deploy.

## What changed

- **B6 — autoCreateWorkspace no longer swallows member-add failures** (`handlers_cloud.go`). A failed `AddWorkspaceMember` used to leave a workspace that was not just invisible but permanently unreachable (`RequireWorkspaceAccess` grants nothing to `owner_id` alone). Now: retry once → on continued failure, loud `slog.Error` + soft-delete the orphan. The delete-also-failed path logs a distinguishable "manual intervention required" error for on-call.
- **B7 — cloud mode without secure cookies fails fast at startup** (`config.go`, `cmd/pad/main.go`). `PAD_CLOUD=true` + insecure cookies silently broke OAuth's `__Host-pad_session` flow ("logged in but appears logged out"). Now `ValidateCloudSecureCookies()` rejects the combination at serve time, next to the existing `PAD_CLOUD_SECRET` check. Self-hosted (non-cloud) is untouched and can still run without TLS.
- **B9 — OAuth session TTL aligned to webSessionTTL (30d → 7d)** (`handlers_cloud.go`). One TTL for the store row, session cookie, and CSRF cookie across all web logins. **Deploy pairing:** pad-cloud's `setSessionCookie` hardcodes a 30d MaxAge — [BUG-1943] tracks the one-line companion change; deploy both in the same window to avoid a 23-day stale-cookie tail (failure mode in the window is a clean 401 → login redirect, post-BUG-1929).
- **B8 — CSRF exemption for `/api/v1/auth/*` narrowed** (`middleware_csrf.go`). Was: prefix match, any path, any auth state. Now: exact-path allowlist (anonymous/pre-session endpoints + the two sidecar-secret endpoints), and the exemption only applies when the request is **not** cookie-session-authenticated (`currentUser == nil`). Newly CSRF-required: logout, `PATCH /me`, oauth-unlink, 2FA management, token CRUD/rotate, delete-account, CLI-session approve, and any session-authenticated branch of an exempt handler (e.g. register's admin-created-account path). No frontend change needed — the shared `request()` wrapper already sends `X-CSRF-Token` on every non-GET/HEAD call.

## Review-loop findings recorded, not "fixed"

- **Legacy `pad_csrf` fallback deliberately NOT added.** SessionAuth falls back to the unprefixed session cookie for upgrade paths; the CSRF check intentionally does not mirror that — an unprefixed CSRF cookie is settable from a subdomain, which is the exact double-submit hole `__Host-` closes. Pinned by comment + `TestCSRF_LegacyCookieFallback_NotAcceptedWhenSecure`. Exposure: only deployments that just flipped secure cookies, bounded by the 7d session TTL, self-heals on re-login.
- **Filed during this loop:** [BUG-1942] (missing `/verify-email/[token]` frontend route — launch-blocking for the just-shipped self-registration feature, pre-existing, out of this diff's scope) and [BUG-1943] (pad-cloud cookie MaxAge pairing, above).

## Test plan

- [x] `go test ./...` (SQLite) — green
- [x] `make test-pg` (Postgres) — green
- [x] `golangci-lint run ./...` — 0 issues
- [x] New tests: autoCreateWorkspace failure path (real FK violation, no test seam), `ValidateCloudSecureCookies` matrix, OAuth Set-Cookie MaxAge == webSessionTTL, CSRF table tests over the newly-required endpoints, trailing-slash/path-normalization pins, admin-session register with/without CSRF, anonymous register still exempt, legacy-cookie 403 pin
- [x] 4 codex review rounds (general → miss-hunt → contract blast-radius → convergence): 3 findings, all resolved in-loop — legacy-fallback pin; register admin-session CSRF gate; Bearer/X-Cloud-Secret presence-vs-validated exemption (the last surfaced a real cross-site `handleSetPlan` exploit closed here). Round 4 CLEAN.

Refs: TASK-1932 (closes), IDEA-1927 §B6–B9, BUG-1942, BUG-1943.
