### PR TITLE
fix(server): deny workspace export to restricted owners (BUG-1922)

### DIFF
--- a/internal/server/handlers_export_bundle.go
+++ b/internal/server/handlers_export_bundle.go
@@ -22,6 +22,32 @@ import (
 // evolve the JSON schema and the bundle format on different cadences.
 const exportBundleVersion = 1
 
+// requireUnrestrictedExportAccess denies workspace export (both the JSON
+// and tar.gz bundle forms) to a caller whose workspace access is scoped to
+// specific collections (BUG-1922). Dave's ruling: workspace export is an
+// owner affordance for backup/portability, not a visibility-scoped view —
+// so rather than filtering the export contents to what the caller can see
+// (which would silently produce incomplete backups), a restricted caller
+// is denied the export outright. member_collection_access has no role
+// exclusion (see BUG-1920), so a workspace-role "owner" can still be
+// restricted; requireMinRole("owner") alone doesn't catch that.
+//
+// Must be called after requireMinRole(w, r, "owner") has already passed,
+// and before any export content is read from the store or written to the
+// response — a 403 here must never follow partial output.
+func (s *Server) requireUnrestrictedExportAccess(w http.ResponseWriter, r *http.Request, workspaceID string) bool {
+	visibleIDs, err := s.visibleCollectionIDs(r, workspaceID)
+	if err != nil {
+		writeInternalError(w, err)
+		return false
+	}
+	if visibleIDs != nil {
+		writeError(w, http.StatusForbidden, "forbidden", "Workspace export requires unrestricted workspace access")
+		return false
+	}
+	return true
+}
+
 // handleExportWorkspaceBundle streams a tar.gz containing the
 // workspace JSON export plus every original (non-thumbnail)
 // attachment blob and a manifest. Bundle layout:
@@ -48,8 +74,9 @@ const exportBundleVersion = 1
 // wire. The error is logged with attachment_id context so operators
 // can diagnose without re-running the export.
 //
-// Auth: owner. The plain JSON path is owner-only too; the bundle
-// has the same access scope plus the user-uploaded attachment
+// Auth: owner, and requireUnrestrictedExportAccess further denies a
+// restricted owner (BUG-1922). The plain JSON path is owner-only too; the
+// bundle has the same access scope plus the user-uploaded attachment
 // blobs, so don't loosen.
 func (s *Server) handleExportWorkspaceBundle(w http.ResponseWriter, r *http.Request) {
 	if !requireMinRole(w, r, "owner") {
@@ -57,6 +84,9 @@ func (s *Server) handleExportWorkspaceBundle(w http.ResponseWriter, r *http.Requ
 	}
 	ws, ok := s.getWorkspace(w, r)
 	if !ok {
+		return
+	}
+	if !s.requireUnrestrictedExportAccess(w, r, ws.ID) {
 		return
 	}
 

--- a/internal/server/handlers_export_gate_test.go
+++ b/internal/server/handlers_export_gate_test.go
@@ -1,0 +1,74 @@
+package server
+
+import (
+	"net/http"
+	"testing"
+)
+
+// TestExportWorkspace_RestrictedOwner_Forbidden pins BUG-1922: workspace
+// export (JSON form) is an owner-only backup/portability affordance, not a
+// visibility-scoped view. A workspace-role "owner" who is independently
+// restricted via collection_access="specific" (member_collection_access has
+// no role exclusion — BUG-1920) must be denied the export outright rather
+// than receiving a filtered subset, over either auth class.
+func TestExportWorkspace_RestrictedOwner_Forbidden(t *testing.T) {
+	f := newRestrictedOwnerVisibilityFixture(t)
+
+	path := "/api/v1/workspaces/" + f.ws.Slug + "/export"
+	rr := doRequestWithHeaders(f.srv, "GET", path, nil, f.bearerHeaders())
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("bearer restricted owner export (json): expected 403, got %d: %s", rr.Code, rr.Body.String())
+	}
+	rr = doRequestWithCookie(f.srv, "GET", path, nil, f.sessionToken)
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("session restricted owner export (json): expected 403, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+// TestExportWorkspaceBundle_RestrictedOwner_Forbidden is the tar.gz-bundle
+// twin of TestExportWorkspace_RestrictedOwner_Forbidden. It also pins that
+// the 403 is written before any bundle bytes are streamed — a restricted
+// owner must never see even a truncated tar, which would still contain
+// pad-export.json with the full unfiltered workspace inside it.
+func TestExportWorkspaceBundle_RestrictedOwner_Forbidden(t *testing.T) {
+	f := newRestrictedOwnerVisibilityFixture(t)
+
+	path := "/api/v1/workspaces/" + f.ws.Slug + "/export?format=tar"
+	rr := doRequestWithHeaders(f.srv, "GET", path, nil, f.bearerHeaders())
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("bearer restricted owner export (tar): expected 403, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if ct := rr.Header().Get("Content-Type"); ct == "application/gzip" {
+		t.Fatalf("bearer restricted owner export (tar): got gzip Content-Type on a 403 — bundle stream started before the gate")
+	}
+	body := rr.Body.Bytes()
+	if len(body) >= 2 && body[0] == 0x1f && body[1] == 0x8b {
+		t.Fatalf("bearer restricted owner export (tar): response body starts with gzip magic bytes — bundle content leaked on a 403")
+	}
+
+	rr = doRequestWithCookie(f.srv, "GET", path, nil, f.sessionToken)
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("session restricted owner export (tar): expected 403, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if ct := rr.Header().Get("Content-Type"); ct == "application/gzip" {
+		t.Fatalf("session restricted owner export (tar): got gzip Content-Type on a 403 — bundle stream started before the gate")
+	}
+	body = rr.Body.Bytes()
+	if len(body) >= 2 && body[0] == 0x1f && body[1] == 0x8b {
+		t.Fatalf("session restricted owner export (tar): response body starts with gzip magic bytes — bundle content leaked on a 403")
+	}
+}
+
+// TestExportWorkspace_UnrestrictedOwner_OK confirms BUG-1922's gate doesn't
+// regress the common case: an owner with unrestricted (mode "all")
+// workspace access still gets the JSON export exactly as before. The
+// tar-bundle equivalent is already pinned by TestExportBundle_RoundTrip.
+func TestExportWorkspace_UnrestrictedOwner_OK(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSForTest(t, srv)
+
+	rr := doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/export", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("unrestricted owner export (json): expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+}

--- a/internal/server/handlers_workspaces.go
+++ b/internal/server/handlers_workspaces.go
@@ -414,6 +414,9 @@ func (s *Server) handleExportWorkspace(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
+	if !s.requireUnrestrictedExportAccess(w, r, ws.ID) {
+		return
+	}
 	export, err := s.store.ExportWorkspace(ws.Slug)
 	if err != nil {
 		writeError(w, http.StatusNotFound, "not_found", err.Error())


### PR DESCRIPTION
## fix(server): deny workspace export to restricted owners (BUG-1922)

Per Dave's ruling on BUG-1922: workspace export is an owner affordance for backup/portability, available **only to callers with unrestricted workspace access**. Previously both export forms dumped the full workspace — every collection's content — regardless of the caller's `collection_access="specific"` restriction, so a restricted owner could exfiltrate collections they otherwise can't see. (`member_collection_access` has no role exclusion — BUG-1920 — so a workspace-role "owner" can still be restricted; `requireMinRole("owner")` alone doesn't catch that.)

## Change

- New helper `requireUnrestrictedExportAccess(w, r, workspaceID)` (handlers_export_bundle.go): denies with `403 forbidden` when `visibleCollectionIDs(r, workspaceID)` is non-nil (restricted), passes when nil (unrestricted: admin / member mode "all"). Same idiom the rest of the visibility family uses.
- Wired into **both** export paths — `handleExportWorkspaceBundle` (tar) and `handleExportWorkspace` (JSON) — right after `requireMinRole("owner")` + workspace resolution and **before any store read or response write**, so a 403 never follows partial output. Gating only one branch would be a no-op (both hit the same `store.ExportWorkspace`).

## Scope

- **Not** the content-filtering "export fork" — a restricted caller is denied outright rather than handed a silently-incomplete backup.
- Sibling leak on the **account-export** endpoint (`handleExportAccount`, `/auth/export`) found during recon and filed as **BUG-1945** (high) — a different endpoint with its own semantics, deliberately not folded in here to keep this bisectable.

## Test plan

- [x] `go test ./...` (SQLite) — pass, incl. 3 new tests; all pre-existing export tests still green
- [x] `make test-pg` (Postgres) — pass; export suite re-run individually against a fresh PG container
- [x] `golangci-lint run ./...` — 0 issues
- [x] 2 codex review rounds (soundness trace + miss-hunt/endpoint-enumeration) — both CLEAN, converged
- New tests: restricted owner → 403 on both JSON and tar (bearer + session); tar 403 asserts **no partial gzip body leaked** (pins gate-before-stream); unrestricted owner → 200 unchanged

Refs: BUG-1922 (closes), BUG-1920 (role-exclusion nuance), BUG-1945 (account-export sibling), BUG-1925 (restricted-owner self-escalation).

https://claude.ai/code/session_01CL1pBjNpPUX6SWkuAuYXHS
