### PR TITLE
fix(web): dedupe collab flush in editor-markdown space (BUG-1941)

### DIFF
--- a/web/src/lib/collab/flushDedupe.test.ts
+++ b/web/src/lib/collab/flushDedupe.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { shouldDedupeEditorSpace } from './flushDedupe';
+
+describe('shouldDedupeEditorSpace', () => {
+	it('dedupes a pure no-edit view: no flush yet this session, markdown matches the seed', () => {
+		expect(shouldDedupeEditorSpace(null, 'seed text', 'seed text')).toBe(true);
+	});
+
+	it('does not dedupe when no flush yet but markdown differs from the seed (a real edit)', () => {
+		expect(shouldDedupeEditorSpace(null, 'seed text', 'edited text')).toBe(false);
+	});
+
+	it('does not dedupe when no seed was ever captured (e.g. the lazy-seed never fired this session)', () => {
+		expect(shouldDedupeEditorSpace(null, null, 'seed text')).toBe(false);
+	});
+
+	// Revert-safety (BUG-1899's original guarantee): once a real flush has
+	// landed this session, the server holds edited content — reverting the
+	// editor back to the original seed text must still PATCH, not dedupe,
+	// because the storage-space compare against `lastFlushedContent` (not
+	// this predicate) is what's authoritative from that point on.
+	it('does NOT dedupe once a flush has already happened this session, even if markdown reverts to the seed', () => {
+		expect(shouldDedupeEditorSpace('some flushed content', 'seed text', 'seed text')).toBe(false);
+	});
+});

--- a/web/src/lib/collab/flushDedupe.ts
+++ b/web/src/lib/collab/flushDedupe.ts
@@ -1,0 +1,32 @@
+// Editor-markdown-space dedupe predicate for the collab snapshot-flush
+// (BUG-1941, regression of BUG-1899). Extracted as a pure function so the
+// invariant that broke silently last time — a no-edit view must never
+// re-PATCH — is pinned by a unit-testable truth table instead of living
+// only inline inside the delicate +page.svelte flush path.
+//
+// Why this check exists at all: `runCollabFlush`'s storage-space dedupe
+// (`(lastFlushedContent ?? baseline) === toSave`) re-serializes the
+// editor's markdown through `markdownToWikiLinks` using the FLUSH-TIME
+// wiki-link index before comparing. If that index differs from the index
+// used to seed the Y.Doc (or the stored link was already non-canonical),
+// the re-serialization diverges from the stored baseline even though the
+// user made no edit, and a spurious PATCH fires. Comparing in
+// editor-markdown-space — BEFORE `markdownToWikiLinks` ever runs — sidesteps
+// the index dependency entirely for a pure view.
+//
+// Scope: only ever applies to the `baseline` arm of the existing dedupe,
+// i.e. before this session's first successful flush. `lastFlushedContent`
+// non-null means a real flush already happened this session; from then on
+// the server holds edited content, so reverting to the seed must still
+// PATCH (revert-safety) — hence the `lastFlushedContent === null` gate.
+export function shouldDedupeEditorSpace(
+	lastFlushedContent: string | null,
+	seedMarkdown: string | null,
+	normalizedMarkdown: string,
+): boolean {
+	return (
+		lastFlushedContent === null &&
+		seedMarkdown !== null &&
+		normalizedMarkdown === seedMarkdown
+	);
+}

--- a/web/src/lib/collections/itemSort.test.ts
+++ b/web/src/lib/collections/itemSort.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import type { Collection, Item } from '$lib/types';
+import { itemComparator } from './itemSort';
+
+// Minimal Item stand-in — the manual comparator only touches sort_order,
+// created_at, and id.
+function item(id: string, sort_order: number, created_at: string): Item {
+	return { id, sort_order, created_at } as unknown as Item;
+}
+
+// Manual mode doesn't read the collection's schema, so an empty stand-in
+// satisfies the comparator factory's signature.
+const collection = {} as Collection;
+
+describe('itemComparator manual mode', () => {
+	it('orders primarily by sort_order', () => {
+		const comparator = itemComparator('manual', collection);
+		const items = [
+			item('a', 2, '2026-01-01T00:00:00Z'),
+			item('b', 0, '2026-01-01T00:00:00Z'),
+			item('c', 1, '2026-01-01T00:00:00Z'),
+		];
+		expect([...items].sort(comparator).map((i) => i.id)).toEqual(['b', 'c', 'a']);
+	});
+
+	// BUG-1941: every un-dragged card in a lane shares sort_order = 0. A
+	// stray updated_at bump (e.g. a spurious collab-flush PATCH) must not
+	// reorder them — the tiebreak has to be independent of updated_at.
+	it('breaks a sort_order tie by created_at ascending, ignoring updated_at entirely', () => {
+		const comparator = itemComparator('manual', collection);
+		const older = { ...item('older', 0, '2026-01-01T00:00:00Z'), updated_at: '2026-07-04T00:00:00Z' } as Item;
+		const newer = { ...item('newer', 0, '2026-02-01T00:00:00Z'), updated_at: '2026-01-01T00:00:00Z' } as Item;
+		// `newer`'s updated_at is EARLIER than `older`'s, proving the
+		// comparator ignores updated_at and still orders by created_at.
+		expect([newer, older].sort(comparator).map((i) => i.id)).toEqual(['older', 'newer']);
+		expect([older, newer].sort(comparator).map((i) => i.id)).toEqual(['older', 'newer']);
+	});
+
+	it('falls back to id when sort_order and created_at both tie', () => {
+		const comparator = itemComparator('manual', collection);
+		const b = item('b-item', 0, '2026-01-01T00:00:00Z');
+		const a = item('a-item', 0, '2026-01-01T00:00:00Z');
+		expect([b, a].sort(comparator).map((i) => i.id)).toEqual(['a-item', 'b-item']);
+	});
+
+	it('treats a missing/unparseable created_at as epoch (sorts first among ties)', () => {
+		const comparator = itemComparator('manual', collection);
+		const withDate = item('with-date', 0, '2026-01-01T00:00:00Z');
+		const withoutDate = { ...item('without-date', 0, ''), created_at: undefined } as unknown as Item;
+		expect([withDate, withoutDate].sort(comparator).map((i) => i.id)).toEqual([
+			'without-date',
+			'with-date',
+		]);
+	});
+});

--- a/web/src/lib/collections/itemSort.ts
+++ b/web/src/lib/collections/itemSort.ts
@@ -70,6 +70,16 @@ export function itemComparator(
 				});
 		case 'manual':
 		default:
-			return (a, b) => a.sort_order - b.sort_order;
+			// Deterministic tiebreak on equal sort_order (created_at asc,
+			// then id) so a stray updated_at bump — e.g. a spurious
+			// collab-flush PATCH, BUG-1941 — can't reorder cards that were
+			// never actually dragged. Every un-dragged card in a lane
+			// shares sort_order = 0, so without this the comparator was a
+			// no-op there and silently inherited whatever order the input
+			// array arrived in (updated_at DESC from the API).
+			return (a, b) =>
+				a.sort_order - b.sort_order ||
+				timeValue(a.created_at) - timeValue(b.created_at) ||
+				a.id.localeCompare(b.id);
 	}
 }

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -849,15 +849,61 @@
 		// active editing. collabKey just changed to this itemId, so item is
 		// the freshly-loaded item for it. Per Codex review.
 		const baseline = untrack(() => (item && item.id === itemId ? item.content ?? '' : ''));
-		// seedMd starts null and is populated (if at all) by the lazy-seed
-		// effect below, only when it actually calls setContent — see that
-		// effect's comment for why. Lives on this per-item ctx object so it
-		// resets automatically on every item load, same as `baseline`.
+		// Eager, all-tabs seedMd (BUG-1941 follow-up — codex round 2 found
+		// that only the multi-tab-election WINNER got a captured seed via
+		// the lazy-seed effect below; a second tab on the same item, or
+		// simply reopening an item that already has collab history, never
+		// lazy-seeds and was left with seedMd stuck at null). This
+		// eagerly projects `baseline` (the SAME item.content @ load that
+		// the pre-existing storage-space dedupe already trusts) into
+		// editor-markdown space via the identical transform the lazy-seed
+		// effect uses, so every tab gets a best-effort seed regardless of
+		// whether it wins any election.
+		//
+		// False-dedupe safety: if this projection doesn't match what
+		// actually ends up in the Y.Doc (index drift since load, or a
+		// concurrently-live unflushed peer edit this tab's REST fetch
+		// didn't see), the comparison in runCollabFlush just MISSES —
+		// falling through to the existing baseline compare, never masking
+		// a real edit. See flushDedupe.ts's doc comment for the full
+		// revert-safety argument, which is unchanged by this addition.
+		//
+		// MUST stay untracked, and the untrack must wrap the ENTIRE index
+		// read + transform below, not just localIndex.getAll: this effect
+		// OWNS the collab provider's construction and teardown (see the
+		// cleanup below), and localIndex.getAll reads a live reactive
+		// SvelteMap. A tracked read here would rebuild (tear down and
+		// reconnect) the provider on every index mutation elsewhere in
+		// the workspace — a title rename, an inline [[-picker create,
+		// bootstrap's reconcile loop — which would be a far worse
+		// regression than the bug this fixes. Mirrors the untracked
+		// `baseline` read directly above for the same reason.
+		const seedMd = untrack(() => {
+			const allItemsAtLoad = localIndex.getAll(wsSlug);
+			const raw =
+				allItemsAtLoad.length > 0 && baseline.includes('[[')
+					? wikiLinksToMarkdown(baseline, allItemsAtLoad, wsSlug, username)
+					: baseline;
+			return unescapeDocLinks(raw);
+		});
+		// The lazy-seed effect below OVERWRITES this with its own value
+		// when (and only when) it actually calls setContent — its capture
+		// reflects the EXACT text written into the Y.Doc at that later
+		// moment and takes precedence for the winning tab. This eager
+		// value is the fallback for every other case: a losing tab in a
+		// multi-tab race, or (more commonly) any reopen of an item whose
+		// Y.Doc already has established content, where the lazy-seed
+		// effect never fires at all. It does not cover the case where the
+		// established Y.Doc holds link text rendered under a PAST index
+		// that differs from this load's current-index projection of
+		// item.content — that falls through safely to the baseline
+		// compare, and its visible symptom (a re-float) is covered by the
+		// Manual-comparator tiebreak below.
 		const ctx: { wsSlug: string; itemId: string; baseline: string; seedMd: string | null } = {
 			wsSlug,
 			itemId,
 			baseline,
-			seedMd: null,
+			seedMd,
 		};
 		activeCollabContext = ctx;
 
@@ -1154,14 +1200,18 @@
 			const lowest2 = peerIds2.reduce((min, id) => (id < min ? id : min), peerIds2[0]);
 			if (lowest2 !== localId) return;
 			editorInstance!.commands.setContent(seedMd);
-			// Record the exact markdown that just landed in the Y.Doc, in
-			// the same normalized space runCollabFlush compares against
-			// (unescapeDocLinks — see flushDedupe.ts and the +page.svelte
-			// PR notes for the escaping-space equivalence). Guarded on
+			// Overwrite the ctx-creation effect's eager (best-effort)
+			// seedMd with the EXACT markdown that just landed in the
+			// Y.Doc, in the same normalized space runCollabFlush compares
+			// against (unescapeDocLinks — see flushDedupe.ts and the
+			// +page.svelte PR notes for the escaping-space equivalence).
+			// This is strictly more precise than the eager value (it's
+			// what was actually written, not a projection), so the
+			// winning tab always ends up with this one. Guarded on
 			// `activeCollabContext === ctx` so a losing multi-tab election
-			// peer (which never reaches this point) or a superseded
-			// item-load can't stamp a seed nobody actually wrote. Per
-			// BUG-1941.
+			// peer (which never reaches this point, and so keeps its
+			// eager value) or a superseded item-load can't stamp a seed
+			// nobody actually wrote. Per BUG-1941.
 			if (ctx && activeCollabContext === ctx) ctx.seedMd = unescapeDocLinks(seedMd);
 		});
 	});
@@ -1748,12 +1798,22 @@
 		// shouldDedupeEditorSpace scopes this to the baseline arm only
 		// (lastFlushedContent === null); see its own doc comment for the
 		// revert-safety rationale the storage-space compare below still
-		// owns. Known boundary: seedMarkdown is only ever non-null when
-		// the lazy-seed effect actually fired THIS session (first-ever
-		// collab connect for the item, or after an op-log prune) — index
-		// drift across two sessions of an already-established item, with
-		// no lazy-seed in either, still falls through to the storage-space
-		// compare unchanged. Accepted scope per BUG-1941.
+		// owns. seedMarkdown comes from one of two sources (see the
+		// ctx-creation $effect): the lazy-seed effect's exact
+		// just-written value when this tab actually seeded the Y.Doc, or
+		// — for every other tab, including a losing multi-tab peer or a
+		// plain reopen of an already-established item — an eager
+		// projection of item.content through the current-load-time index.
+		// Known boundary: that eager projection only matches what's
+		// actually in the Y.Doc when the Y.Doc's established content
+		// agrees with THIS load's index projection of item.content. If
+		// the Y.Doc holds link display text rendered under a PAST index
+		// that has since drifted (e.g. a linked item was renamed since
+		// the content was last established), the projection won't match
+		// and this check safely falls through to the storage-space
+		// compare below — never a false dedupe, just a missed one. That
+		// residual case's visible symptom (a re-float) is covered by the
+		// Manual-comparator tiebreak. Accepted scope per BUG-1941.
 		if (shouldDedupeEditorSpace(lastFlushedContent, seedMarkdown, normalizedMarkdown)) {
 			return 'deduped';
 		}

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -16,6 +16,7 @@
 	import * as Y from 'yjs';
 	import { CollabProvider, type CollabConnectionState } from '$lib/collab/wsProvider.svelte';
 	import { userColor } from '$lib/collab/cursorColor';
+	import { shouldDedupeEditorSpace } from '$lib/collab/flushDedupe';
 	import { authStore } from '$lib/stores/auth.svelte';
 	import FieldEditor from '$lib/components/fields/FieldEditor.svelte';
 	import TagInput from '$lib/components/fields/TagInput.svelte';
@@ -848,7 +849,16 @@
 		// active editing. collabKey just changed to this itemId, so item is
 		// the freshly-loaded item for it. Per Codex review.
 		const baseline = untrack(() => (item && item.id === itemId ? item.content ?? '' : ''));
-		const ctx = { wsSlug, itemId, baseline };
+		// seedMd starts null and is populated (if at all) by the lazy-seed
+		// effect below, only when it actually calls setContent — see that
+		// effect's comment for why. Lives on this per-item ctx object so it
+		// resets automatically on every item load, same as `baseline`.
+		const ctx: { wsSlug: string; itemId: string; baseline: string; seedMd: string | null } = {
+			wsSlug,
+			itemId,
+			baseline,
+			seedMd: null,
+		};
 		activeCollabContext = ctx;
 
 		const doc = new Y.Doc();
@@ -1124,6 +1134,13 @@
 				? wikiLinksToMarkdown(seedRaw, allItems, wsSlug, username)
 				: seedRaw;
 
+		// Snapshot activeCollabContext now so the microtask below can
+		// record the seed onto the SAME ctx object the flush path reads
+		// (BUG-1941). By the time this effect runs, the ctx-creating
+		// $effect above has already set activeCollabContext for this
+		// item — see the ordering note there.
+		const ctx = activeCollabContext;
+
 		// Microtask-yield + recheck: a concurrent peer's seed may
 		// have already propagated and just hasn't been applied to
 		// our fragment yet. Yielding once gives the y-protocol
@@ -1137,6 +1154,15 @@
 			const lowest2 = peerIds2.reduce((min, id) => (id < min ? id : min), peerIds2[0]);
 			if (lowest2 !== localId) return;
 			editorInstance!.commands.setContent(seedMd);
+			// Record the exact markdown that just landed in the Y.Doc, in
+			// the same normalized space runCollabFlush compares against
+			// (unescapeDocLinks — see flushDedupe.ts and the +page.svelte
+			// PR notes for the escaping-space equivalence). Guarded on
+			// `activeCollabContext === ctx` so a losing multi-tab election
+			// peer (which never reaches this point) or a superseded
+			// item-load can't stamp a seed nobody actually wrote. Per
+			// BUG-1941.
+			if (ctx && activeCollabContext === ctx) ctx.seedMd = unescapeDocLinks(seedMd);
 		});
 	});
 
@@ -1650,7 +1676,7 @@
 	// flushes still PATCH the OLD item's URL with its OLD markdown,
 	// so we never cross-write one item's content into another. Per
 	// Codex review round 1.
-	let activeCollabContext: { wsSlug: string; itemId: string; baseline: string } | null = null;
+	let activeCollabContext: { wsSlug: string; itemId: string; baseline: string; seedMd: string | null } | null = null;
 
 	// Provider we've already attempted the lazy seed against. Reset
 	// implicitly when collabProvider is replaced (the new provider
@@ -1670,7 +1696,7 @@
 		if (!ctx) return;
 		collabFlushTimer = setTimeout(() => {
 			collabFlushTimer = undefined;
-			void runCollabFlush(ctx.wsSlug, ctx.itemId, markdown, false, ctx.baseline);
+			void runCollabFlush(ctx.wsSlug, ctx.itemId, markdown, false, ctx.baseline, ctx.seedMd);
 		}, COLLAB_FLUSH_IDLE_MS);
 	}
 
@@ -1703,6 +1729,7 @@
 		markdown: string,
 		keepalive: boolean,
 		baseline: string,
+		seedMarkdown: string | null = null,
 	): Promise<CollabFlushResult> {
 		// Force-refresh recovery is in flight: any markdown derived
 		// from the soon-to-be-discarded Y.Doc is, by definition,
@@ -1711,6 +1738,25 @@
 		// flushCollabNow) without needing per-call-site guards. Per
 		// Codex round 8 [P1] of TASK-1319.
 		if (forceRefreshInFlight) return 'skipped';
+		const normalizedMarkdown = unescapeDocLinks(markdown);
+		// Editor-markdown-space short-circuit (BUG-1941, regression of
+		// BUG-1899). BEFORE re-serializing through markdownToWikiLinks —
+		// which depends on the FLUSH-TIME wiki-link index and can diverge
+		// from a stable seed on index drift or a merely non-canonical
+		// stored link — check whether this is a pure no-edit view of the
+		// exact markdown that was seeded into the Y.Doc this session.
+		// shouldDedupeEditorSpace scopes this to the baseline arm only
+		// (lastFlushedContent === null); see its own doc comment for the
+		// revert-safety rationale the storage-space compare below still
+		// owns. Known boundary: seedMarkdown is only ever non-null when
+		// the lazy-seed effect actually fired THIS session (first-ever
+		// collab connect for the item, or after an op-log prune) — index
+		// drift across two sessions of an already-established item, with
+		// no lazy-seed in either, still falls through to the storage-space
+		// compare unchanged. Accepted scope per BUG-1941.
+		if (shouldDedupeEditorSpace(lastFlushedContent, seedMarkdown, normalizedMarkdown)) {
+			return 'deduped';
+		}
 		// Resolve links against the CAPTURED `ws` (the item being
 		// flushed), not the live route `wsSlug`. A background/unmount
 		// flush can fire after navigating to another workspace; the PATCH
@@ -1718,7 +1764,7 @@
 		// `wsSlug` would convert links against the wrong workspace's
 		// index. Per Codex review (round 1).
 		const allItems = localIndex.getAll(ws);
-		let toSave = unescapeDocLinks(markdown);
+		let toSave = normalizedMarkdown;
 		if (allItems.length > 0) {
 			toSave = markdownToWikiLinks(toSave, allItems);
 		}
@@ -1815,7 +1861,7 @@
 	// {#key}-driven unmounts, so the OLD editor (whose markdown we
 	// want) is still mounted. Used by $effect cleanup + beforeunload
 	// to land any in-flight markdown before the provider tears down.
-	function flushCollabNow(ctx: { wsSlug: string; itemId: string; baseline: string }, keepalive: boolean): boolean {
+	function flushCollabNow(ctx: { wsSlug: string; itemId: string; baseline: string; seedMd: string | null }, keepalive: boolean): boolean {
 		clearTimeout(collabFlushTimer);
 		collabFlushTimer = undefined;
 		if (!editorInstance) return false;
@@ -1828,7 +1874,7 @@
 		// runCollabFlush is async but its return value is irrelevant
 		// for synchronous callers — fire-and-forget under
 		// keepalive=true is the contract on the unmount path.
-		void runCollabFlush(ctx.wsSlug, ctx.itemId, md, keepalive, ctx.baseline);
+		void runCollabFlush(ctx.wsSlug, ctx.itemId, md, keepalive, ctx.baseline, ctx.seedMd);
 		return true;
 	}
 


### PR DESCRIPTION
## fix(web): dedupe collab flush in editor-markdown space (BUG-1941)

Regression of BUG-1899. Merely **opening** an item (no edits) intermittently re-sorted its card to the top of a Manual-sorted board. Root cause: the collab snapshot-flush dedupes a no-edit flush by re-serializing the editor markdown back to storage form with the **live flush-time** wiki-link index (`localIndex.getAll(ws)`) and comparing to `baseline = item.content` captured at load. Because `markdownToWikiLinks` canonicalizes index- and title-dependently (prefers `[[REF]]`, strips redundant `|Display`), when the flush-time index differs from the seed-time index — or the stored link was already non-canonical — the round-trip isn't an identity, the dedupe misses, and a spurious no-edit PATCH fires, bumping `updated_at` and floating the card. (b7bedc8 / PR #770 introduced this by swapping the seed+flush index reads from the page-lifetime-frozen `collectionStore.items` to the live `localIndex.getAll`, silently breaking the freshness contract BUG-1899's dedupe relied on.)

## Fix

**Part 1 — dedupe in editor-markdown space (root cause).** New pure `shouldDedupeEditorSpace(lastFlushedContent, seedMarkdown, normalizedMarkdown)` (`flushDedupe.ts`) short-circuits the flush **before** `markdownToWikiLinks` when the editor markdown still equals the captured seed — so a pure no-edit view no longer depends on the flush-time index at all. Gated on `lastFlushedContent === null` so it **only replaces the `baseline` arm**: after a real edit+flush the existing storage-space dedupe against `lastFlushedContent` stays authoritative (revert-safety preserved). The seed is captured in the same normalized space the flush compares (`unescapeDocLinks`), an equivalence already load-bearing at `Editor.svelte:1167-1168`.

**Seed coverage for every tab.** The precise seed is captured by the election-winning tab at the Y.Doc lazy-seed. A second commit additionally computes a best-effort `seedMd` at context-creation for **every** tab, by projecting the already-trusted `baseline` (`item.content` @ load) through the identical transform — so a losing multi-tab peer or a reopen of an already-established item also gets editor-space coverage (the gap codex round 2 caught). Any projection mismatch can only cause a *missed* dedupe (safe fall-through to the baseline compare), never a false one. The eager read is wrapped in `untrack(...)` — this effect owns the collab provider's teardown, so a tracked `localIndex` read would rebuild the provider on every index mutation.

**Part 2 — deterministic Manual-comparator tiebreak** (`itemSort.ts`): `created_at`/`id` on equal `sort_order`, so a stray `updated_at` bump can't reorder un-dragged cards. Kills the visible re-float symptom for **all** cases, including the documented residual below.

## Documented residual (accepted)

An already-established item whose Y.Doc holds link *display text* rendered under a **past** index that has since drifted from this load's current-index projection: the eager seed won't match, it falls through to the baseline storage-space compare (today's behavior — a spurious PATCH), and Part 2's tiebreak covers its visible symptom. Not a re-float regression.

## Test plan
- [x] `npm test` — 128 tests pass, incl. new `flushDedupe` truth table (4 rows: no-flush+match→dedupe, no-flush+differ→no, null-seed→no, **flushed+revert-to-seed→no** [revert-safety]) and `itemSort` tiebreak tests (incl. explicit "ignores `updated_at`" anti-regression case)
- [x] `npm run check` — 0 errors
- [x] `npm run build` — ok
- [x] 3 codex rounds: R1 CLEAN (revert-safety / escaping-space traced); R2 caught the multi-tab-loser gap (fixed in commit 2); R3 CONVERGED with the `untrack` scope hard-confirmed clean
- [x] E2E (Playwright) — CI gate

Refs: BUG-1941 (closes), BUG-1899 (original fix regressed), b7bedc8/PR #770 (regressor).

https://claude.ai/code/session_01CL1pBjNpPUX6SWkuAuYXHS
