### PR TITLE
feat(web): default agent-connect modal to MCP setup, steer zero-grant users

### DIFF
--- a/internal/server/handlers_claim_code.go
+++ b/internal/server/handlers_claim_code.go
@@ -130,6 +130,21 @@ func (s *Server) handleWorkspaceClaimCode(w http.ResponseWriter, r *http.Request
 		return
 	}
 
+	// Not covered by any grant. Two sub-cases the modal renders
+	// differently: the user has a connection that just doesn't reach
+	// this workspace (a scoped grant — the claim code is the right
+	// tool), versus the user has no connection at all (the code is
+	// inert — steer them to set up an agent first). Surface the flag
+	// so the client can branch without a second round-trip. Failure
+	// is a 500 for the same reason the suppression check is: a silent
+	// wrong answer here reintroduces the dead-end code path.
+	hasAnyConnection, err := s.store.HasActiveConnectionForUser(user.ID)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	resp["has_any_connection"] = hasAnyConnection
+
 	resp["code"] = DeriveClaimCode(s.claimSecret, user.ID, ws.ID, now)
 	writeJSON(w, http.StatusOK, resp)
 }

--- a/internal/store/oauth_connections.go
+++ b/internal/store/oauth_connections.go
@@ -505,6 +505,56 @@ func (s *Store) IsWorkspaceCoveredForUser(userID, workspaceID string) (string, b
 	return name, true, nil
 }
 
+// HasActiveConnectionForUser reports whether the user has ANY active
+// OAuth connection at all, regardless of which workspaces it covers.
+//
+// The claim-code endpoint uses this to disambiguate the two "not
+// covered" cases the modal must render differently (IDEA-1517 §4
+// follow-up):
+//
+//   - The user has a connection that just doesn't cover THIS workspace
+//     (e.g. a grant scoped to specific workspaces at consent time) →
+//     the claim code is exactly the right tool; render it.
+//   - The user has NO connection at all → the claim code is inert,
+//     because nothing exists to redeem it. Handing over a live-looking
+//     code here is the dead end this whole reshuffle set out to kill;
+//     the modal steers the user to set up an agent (MCP) first instead.
+//
+// "Active" matches IsWorkspaceCoveredForUser / ListUserOAuthConnections:
+// at least one access OR refresh token in the chain still has
+// active=TRUE. The query short-circuits at the first match (LIMIT 1) —
+// the caller only needs the boolean.
+func (s *Store) HasActiveConnectionForUser(userID string) (bool, error) {
+	if userID == "" {
+		return false, nil
+	}
+	trueVal := s.dialect.BoolToInt(true)
+	var one int
+	err := s.db.QueryRow(s.q(`
+        SELECT 1
+          FROM oauth_connections oc
+         WHERE oc.user_id = ?
+           AND (
+             EXISTS (
+               SELECT 1 FROM oauth_access_tokens t
+                WHERE t.request_id = oc.request_id AND t.active = ?
+             )
+             OR EXISTS (
+               SELECT 1 FROM oauth_refresh_tokens t
+                WHERE t.request_id = oc.request_id AND t.active = ?
+             )
+           )
+         LIMIT 1
+    `), userID, trueVal, trueVal).Scan(&one)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false, nil
+		}
+		return false, fmt.Errorf("oauth_connections: has-connection check: %w", err)
+	}
+	return true, nil
+}
+
 // DeleteOAuthConnection removes the row + cascades to
 // oauth_connection_workspaces. Phase D's "Revoke" handler calls this
 // after RevokeRefreshTokenFamily + RevokeAccessTokenFamily so the

--- a/web/src/lib/components/ConnectWorkspaceModal.svelte
+++ b/web/src/lib/components/ConnectWorkspaceModal.svelte
@@ -14,8 +14,10 @@
 		// Used by the CLI tab to produce a `pad init --url <serverUrl>` snippet.
 		serverUrl: string;
 		// Empty string when the deployment doesn't expose a public MCP URL
-		// (typical self-host without PAD_MCP_PUBLIC_URL). When empty, the
-		// MCP tab is hidden entirely and the default tab falls through to CLI.
+		// (typical self-host without PAD_MCP_PUBLIC_URL). When empty, both the
+		// MCP tab and the claim-code ("Connect code") tab are hidden — they
+		// depend on the remote OAuth server — leaving only CLI, which also
+		// becomes the default.
 		mcpPublicUrl?: string;
 	}
 
@@ -29,27 +31,32 @@
 
 	// --- Primary tabs --------------------------------------------------------
 	//
-	// IDEA-1517 §4 spec: three primary connection paths in one modal. Order is
-	// deliberate — claim code first because once a user has authorized any agent
-	// on any workspace via OAuth, claim-code is dramatically the lowest-friction
-	// path to add additional workspaces. MCP setup is the "fresh agent" path.
-	// CLI is the terminal-only escape hatch (and the only flow that works on
-	// self-host deployments without a public MCP URL).
+	// IDEA-1517 §4 established three connection paths; this ordering is the
+	// post-follow-up correction. MCP setup is FIRST and the default because
+	// most users landing here have never connected an agent — the "fresh
+	// agent" OAuth path is their actual first step (and a default "All my
+	// workspaces" grant then covers this workspace with no code needed at
+	// all). CLI is the terminal / self-host path — the only one that works
+	// without a public MCP URL. The claim ("Connect code") path is LAST: it
+	// does nothing until you already hold an OAuth grant and want to add THIS
+	// workspace to it — a narrow escalation, not a starting point.
 	type PrimaryTab = 'agent' | 'mcp' | 'cli';
 
 	const primaryTabs: { id: PrimaryTab; label: string; subtitle: string }[] = [
-		{ id: 'agent', label: 'Agent', subtitle: 'Claim a workspace (recommended)' },
-		{ id: 'mcp', label: 'MCP setup', subtitle: 'Authorize a new agent' },
-		{ id: 'cli', label: 'CLI', subtitle: 'Terminal access' }
+		{ id: 'mcp', label: 'Connect an agent', subtitle: 'Set up MCP (recommended)' },
+		{ id: 'cli', label: 'CLI', subtitle: 'Terminal access' },
+		{ id: 'agent', label: 'Connect code', subtitle: 'Add to an agent you already connected' }
 	];
 
 	// Default-tab logic. Two cases:
-	//   1. Deployment has a public MCP URL → claim-code is the high-value path
-	//      because users typically already have one OAuth-authorized agent and
-	//      just want this workspace added to that grant. Default to 'agent'.
-	//   2. No public MCP URL (self-host without remote MCP) → claim-code AND
-	//      the MCP tab are both meaningless (the claim flow only matters in
-	//      the context of an OAuth grant on the remote MCP). Default to 'cli'.
+	//   1. Deployment has a public MCP URL → default to 'mcp'. The visitor
+	//      most likely hasn't connected any agent yet, and authorizing one
+	//      via OAuth is the real first step. A default "All my workspaces"
+	//      grant then covers this workspace with no claim code needed at all.
+	//   2. No public MCP URL (self-host without remote MCP) → both the MCP
+	//      and the claim-code paths are meaningless (no OAuth server to
+	//      authorize against, no grant to claim into). Default to 'cli', the
+	//      only path that works there.
 	//
 	// We compute this as a $derived rather than $state because we want it to
 	// reset to the appropriate default each time `open` flips true — using
@@ -63,7 +70,7 @@
 	let lastOpen = false;
 	$effect(() => {
 		if (open && !lastOpen) {
-			activeTab = mcpPublicUrl ? 'agent' : 'cli';
+			activeTab = mcpPublicUrl ? 'mcp' : 'cli';
 		}
 		lastOpen = open;
 	});
@@ -147,6 +154,7 @@
 		| { kind: 'loading' }
 		| { kind: 'ready'; data: ClaimCodeResponse }
 		| { kind: 'suppressed'; grantName: string }
+		| { kind: 'no_connection' }
 		| { kind: 'disabled' }
 		| { kind: 'error'; message: string }
 	>({ kind: 'idle' });
@@ -208,6 +216,17 @@
 					kind: 'suppressed',
 					grantName: data.suppression_grant_name ?? ''
 				};
+				return;
+			}
+			// No grant covers this workspace. If the user has NO active
+			// connection at all, the code is inert — nothing can redeem it —
+			// so steer them to the MCP tab instead of handing over a dead
+			// code. `has_any_connection` is absent on older servers; treat
+			// absent as "has one" so we fall through to the code rather than
+			// hiding it spuriously.
+			if (data.has_any_connection === false) {
+				clearCountdown();
+				claimState = { kind: 'no_connection' };
 				return;
 			}
 			claimState = { kind: 'ready', data };
@@ -292,10 +311,15 @@
 			: 'Connect this workspace to your AI agent'
 	);
 
-	// Hide MCP tab on deployments without a public MCP URL — the tab would
-	// have nothing meaningful to show.
+	// Hide the MCP and claim-code tabs on deployments without a public MCP
+	// URL. Both depend on the remote OAuth server, which only mounts under
+	// PAD_MCP_PUBLIC_URL — without it the MCP tab has nothing to show and the
+	// claim endpoint returns claim_disabled (a dead tab). That leaves
+	// self-host with just the CLI tab, which is the only path that works
+	// there. (The 'disabled' claimState render stays as defense-in-depth in
+	// case the secret is somehow unset while a public URL is present.)
 	let visibleTabs = $derived(
-		primaryTabs.filter((t) => t.id !== 'mcp' || !!mcpPublicUrl)
+		primaryTabs.filter((t) => (t.id !== 'mcp' && t.id !== 'agent') || !!mcpPublicUrl)
 	);
 
 	const CONNECTED_APPS_HREF = '/console/connected-apps';
@@ -352,6 +376,32 @@
 								Open Connected apps &rarr;
 							</a>
 						</div>
+					{:else if claimState.kind === 'no_connection'}
+						<!--
+							The user has no active OAuth connection, so a claim
+							code has nothing to redeem it. Rather than hand over a
+							live-looking but dead code, point them at the MCP tab
+							to connect an agent first — after a default "All my
+							workspaces" authorization this workspace is covered
+							with no code needed at all.
+						-->
+						<div class="info-panel">
+							<p class="info-panel-title">Connect an agent first</p>
+							<p class="info-panel-body">
+								A connect code only works once you’ve authorized an agent. Set
+								one up on the <strong>Connect an agent</strong> tab — the default
+								“All my workspaces” option covers this workspace automatically,
+								so you won’t need a code at all. Codes are for adding a single
+								workspace to an agent you limited to specific ones.
+							</p>
+							<button
+								class="retry-btn"
+								type="button"
+								onclick={() => (activeTab = 'mcp')}
+							>
+								Go to Connect an agent &rarr;
+							</button>
+						</div>
 					{:else if claimState.kind === 'disabled'}
 						<!--
 							"claim_disabled" only fires on self-host deployments
@@ -385,6 +435,16 @@
 						</div>
 					{:else}
 						<!-- ready -->
+						<p class="intro-copy">
+							Already connected an agent through MCP? Read it this code to give it
+							access to <strong>this</strong> workspace — no re-authorization needed.
+							Haven’t connected one yet?
+							<button
+								class="inline-link-btn"
+								type="button"
+								onclick={() => (activeTab = 'mcp')}>Set one up first</button
+							>.
+						</p>
 						<section class="step">
 							<span class="section-label">Step 1 — Read your agent the code</span>
 							<div class="claim-code-row">
@@ -525,6 +585,17 @@
 								{/each}
 							</div>
 						</section>
+
+						<p class="hint">
+							Authorizing with “All my workspaces” (the default) includes this one
+							automatically. If you limit your agent to specific workspaces, use the
+							<button
+								class="inline-link-btn"
+								type="button"
+								onclick={() => (activeTab = 'agent')}>Connect code</button
+							>
+							tab to add this workspace to it.
+						</p>
 					{/if}
 				{:else}
 					<!-- CLI panel -->

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -214,6 +214,14 @@ export interface WorkspaceMembership {
 //     hint instead. `suppression_grant_name` is the name of the
 //     covering connection if available (may be empty).
 //
+// `has_any_connection` (present only when suppressed=false) tells the
+// modal whether the user has ANY active OAuth connection at all. A
+// claim code is inert without one — nothing can redeem it — so when
+// this is false the modal steers the user to set up an agent (MCP tab)
+// first instead of rendering a dead code. When true, the user has a
+// connection that merely doesn't reach this workspace (a scoped grant),
+// which is exactly what the code is for.
+//
 // `expires_at` is the END of the CURRENT 5-minute bucket in RFC3339;
 // verification still accepts the previous bucket for ~5 additional
 // minutes (sliding 5–10 min lifetime). UI drives a countdown from
@@ -224,6 +232,7 @@ export interface ClaimCodeResponse {
 	expires_at: string;
 	suppressed: boolean;
 	suppression_grant_name?: string;
+	has_any_connection?: boolean;
 }
 
 // ImportArtifactResult is the wire shape returned by


### PR DESCRIPTION
## What & why

The "Connect this workspace to your AI agent" modal defaulted to the **claim code** tab, labeled "(recommended)". But a claim code only does something once you *already* hold an OAuth grant and want to add another workspace to it — it's inert for the majority of visitors, who have never connected an agent. This reorders the modal around the actual first-time journey and closes a dead-end state.

## Changes

- **MCP setup is now the default + first tab** ("Connect an agent" / "Set up MCP (recommended)"). CLI is second. The claim code moves to a third **"Connect code"** tab, reframed as a scoped-grant add-on. The "(recommended)" badge moved off the claim code onto MCP.
- **Zero-grants steer** — new `Store.HasActiveConnectionForUser` + `has_any_connection` on the claim-code endpoint. A user who opens the Connect-code tab with *no* connected agent now gets a "Connect an agent first" steer to the MCP tab instead of a live-looking but unredeemable code. (Complements the existing "already covered" smart-suppression — this fills the opposite gap.)
- **MCP panel** gains an accurate footnote: the default "All my workspaces" grant already covers this workspace, so most users never need a code; the code is only for agents scoped to specific workspaces.
- **Self-host cleanup** — the MCP *and* Connect-code tabs are now hidden when there's no public MCP URL (both depend on the remote OAuth server), leaving CLI as the sole default path instead of a dead "claim_disabled" tab.

## Verification

- `go build ./...` clean
- `go test ./internal/server/ ./internal/store/` pass
- `web` `npm run check` — 0 errors (pre-existing warnings only, none in this file)
- Codex review: CLEAN

Design context: IDEA-1517 §4 (claim-code + OAuth-grant primitives), IDEA-1516 (modal redesign).

https://claude.ai/code/session_01HxBkAMiFBtCRJ2tKSCt3ST
