### PR TITLE
feat(web): add deleteAccount + exportAccountData API client methods

### DIFF
--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -1618,6 +1618,46 @@ export const api = {
 				method: 'POST',
 				body: JSON.stringify({ provider })
 			}),
+		// Permanently delete the current user's account (TASK-1960). Routed
+		// through the shared request() helper so the X-CSRF-Token + credentials
+		// are attached automatically — a hand-rolled fetch would omit CSRF and
+		// 403. All fields are optional so the caller sends only what the
+		// account's auth method requires (password for email/password users,
+		// totp_code when 2FA is on, confirm as a UI guard).
+		deleteAccount: (opts: { password?: string; confirm?: boolean; totp_code?: string }) =>
+			request<{ ok: boolean }>('/auth/delete-account', {
+				method: 'POST',
+				body: JSON.stringify({ ...opts })
+			}),
+		// GET the account-export endpoint and return the JSON artifact text plus
+		// the server-suggested filename (Content-Disposition, falling back to
+		// `pad-account-export.json`). Modeled on exportItemArtifact, NOT request()
+		// — request() JSON-parses the body and force-redirects on 401, whereas
+		// here we want the raw text and a PadApiError that surfaces the
+		// restricted-owner 403 (BUG-1945). Auth is by session; 401 → /login.
+		exportAccountData: async (): Promise<{ filename: string; text: string }> => {
+			const resp = await fetch(`${BASE}/auth/export`, {
+				credentials: 'same-origin'
+			});
+			if (resp.status === 401) {
+				if (typeof window !== 'undefined' && !window.location.pathname.startsWith('/login')) {
+					window.location.href = '/login';
+				}
+				throw new PadApiError({ code: 'unauthorized', message: 'Authentication required' });
+			}
+			if (!resp.ok) {
+				const body = await resp.json().catch(() => null);
+				if (body?.error) throw new PadApiError(body.error);
+				// Non-OK with no JSON error envelope: still surface a PadApiError so
+				// every failure path (incl. the restricted-owner 403) is one type for
+				// callers to catch — satisfies TASK-1960's "!ok → PadApiError".
+				throw new PadApiError({ code: 'export_failed', message: `account export failed: ${resp.status}` });
+			}
+			const text = await resp.text();
+			const disposition = resp.headers.get('Content-Disposition') ?? '';
+			const filename = parseContentDispositionFilename(disposition) ?? 'pad-account-export.json';
+			return { filename, text };
+		},
 		totp: {
 			setup: () => request<TOTPSetupResponse>('/auth/2fa/setup', { method: 'POST' }),
 			verify: (code: string, secret: string) =>

--- a/web/src/lib/utils/artifacts.ts
+++ b/web/src/lib/utils/artifacts.ts
@@ -34,6 +34,16 @@ export async function exportAndDownloadArtifact(ws: string, ref: string): Promis
 }
 
 /**
+ * Export the current user's account data as a JSON artifact and immediately
+ * download it (TASK-1960). Throws the underlying PadApiError so callers can
+ * surface `err.message` in a toast — e.g. the restricted-owner 403 (BUG-1945).
+ */
+export async function exportAndDownloadAccountData(): Promise<void> {
+	const { filename, text } = await api.auth.exportAccountData();
+	downloadTextFile(filename, text, 'application/json');
+}
+
+/**
  * Read a picked artifact File as text and POST it to the import endpoint.
  * Returns the server result (ref + slug + warnings); throws on read failure
  * or a 4xx import error (PadApiError) for the caller to surface.


### PR DESCRIPTION
## What

Wires the existing account **delete** and **export** endpoints into the web API client (`web/src/lib/api/client.ts`). Neither was callable from the web UI before — `api.auth` had me/updateProfile/unlinkProvider/totp/tokens but no delete/export.

- **`api.auth.deleteAccount(opts)`** — POSTs `/auth/delete-account` through the shared `request()` helper so `X-CSRF-Token` + credentials are attached automatically (a hand-rolled fetch would omit CSRF and 403). Optional `{ password?, confirm?, totp_code? }`, spread into the body.
- **`api.auth.exportAccountData()`** — modeled on `exportItemArtifact` (bare credentialed `fetch`, NOT `request()`): `401 → /login`; `!resp.ok → PadApiError` (surfaces the restricted-owner 403, BUG-1945; incl. a `PadApiError` fallback when there's no JSON error body); `resp.text()` + `parseContentDispositionFilename` with `pad-account-export.json` fallback. Returns `{ filename, text }`.
- **`exportAndDownloadAccountData()`** (`web/src/lib/utils/artifacts.ts`) — pipes the bytes into `downloadTextFile(filename, text, 'application/json')`.

## Why

Phase 2 of the account delete/export feature — the client plumbing that the UI (T5/T6) builds on.

## Acceptance criteria

- [x] `api.auth.deleteAccount(...)` POSTs with CSRF attached (via `request()`)
- [x] `api.auth.exportAccountData()` returns the file bytes and surfaces the 403 as a `PadApiError`
- [x] Export download triggers a browser save of `application/json`

Closes TASK-1960

Gates: `npm run check` → 0 errors. Codex review → CLEAN.

https://claude.ai/code/session_01HxBkAMiFBtCRJ2tKSCt3ST