### PR TITLE
fix(store): harden account-deletion FK cascade (TASK-1959)

### DIFF
--- a/internal/server/handlers_account.go
+++ b/internal/server/handlers_account.go
@@ -140,8 +140,15 @@ func (s *Server) handleDeleteAccount(w http.ResponseWriter, r *http.Request) {
 	})
 	clearCSRFCookie(w)
 
-	s.logAuditEventForUser(models.ActionAccountDeleted, r, user.ID, auditMeta(map[string]string{
-		"email": user.Email,
+	// Log the deletion with an EMPTY user_id: the user row is already gone,
+	// and activities.user_id is now an ON DELETE SET NULL FK (migrations
+	// 072/050), so an insert referencing the deleted id would fail the FK and
+	// CreateActivity's error is swallowed — the audit row would vanish. Pass
+	// "" (stored as NULL) and keep the deleted identity in metadata so the
+	// account_deleted event is actually recorded on both dialects.
+	s.logAuditEventForUser(models.ActionAccountDeleted, r, "", auditMeta(map[string]string{
+		"deleted_user_id": user.ID,
+		"email":           user.Email,
 	}))
 
 	slog.Info("account deleted", "user_id", user.ID, "email", user.Email)

--- a/internal/server/handlers_account_test.go
+++ b/internal/server/handlers_account_test.go
@@ -60,15 +60,11 @@ func (f *fakeSidecar) lastID() string {
 // Stripe customer ID on them, and returns (userID, sessionToken). Used by
 // the handleDeleteAccount cascade tests.
 //
-// Clears activities.user_id for the user after bootstrap because
-// DeleteAccountAtomic doesn't cascade through activities (a pre-existing
-// limitation unrelated to TASK-690). Without this, the FK from
-// activities.user_id → users.id blocks the final DELETE FROM users and
-// every happy-path test ends in a 500. Narrow test-only scrub — it
-// preserves the audit rows themselves (for callers that inspect them) and
-// only detaches the user reference, which mirrors the ON DELETE SET NULL
-// behaviour the production schema will get when the FK gap is fixed in a
-// follow-up migration.
+// The activities.user_id scrub this helper used to perform is gone:
+// DeleteAccountAtomic now de-identifies activities via the
+// activities.user_id ON DELETE SET NULL FK (migrations 072/050, TASK-1959),
+// so the bootstrap activity row no longer blocks the final DELETE FROM
+// users. Deleting the account exercises the real cascade end to end.
 func bootstrapAccountDeleteUser(t *testing.T, srv *Server, customerID string) (string, string) {
 	t.Helper()
 	token := bootstrapFirstUser(t, srv, "delete-me@test.com", "Delete Me")
@@ -81,22 +77,19 @@ func bootstrapAccountDeleteUser(t *testing.T, srv *Server, customerID string) (s
 			t.Fatalf("set customer id: %v", err)
 		}
 	}
-	if _, err := srv.store.DB().Exec("UPDATE activities SET user_id = NULL WHERE user_id = ?", u.ID); err != nil {
-		t.Fatalf("scrub activities.user_id for test user: %v", err)
-	}
 	return u.ID, token
 }
 
-// deleteAccountReq is a doRequestWithCookieFrom wrapper that pins the
-// RemoteAddr to 127.0.0.1 — the same loopback address bootstrap was
-// invoked from. Without this, the session-IP-change middleware writes an
-// ActionSessionIPChanged audit row at request time (user_id column,
-// FK → users.id), which then blocks the final DELETE FROM users at the
-// end of DeleteAccountAtomic. Until the account-delete cascade fix for
-// audit rows lands (pre-existing bug, tracked separately), these tests
-// keep the IP stable to sidestep the FK gap.
+// deleteAccountReq issues the delete-account request from a client IP that
+// differs from the loopback address bootstrap ran on. The session-IP-change
+// middleware (log-only mode, the default) therefore writes an
+// ActionSessionIPChanged audit row into activities (user_id → users.id) at
+// request time and lets the request through. The delete must still succeed:
+// this is the regression guard for the audit-row FK gap TASK-1959 closed —
+// previously the fresh audit row blocked the final DELETE FROM users and the
+// handler 500'd.
 func deleteAccountReq(srv *Server, body interface{}, token string) *httptest.ResponseRecorder {
-	return doRequestWithCookieFrom(srv, "POST", "/api/v1/auth/delete-account", body, token, "127.0.0.1:4321")
+	return doRequestWithCookieFrom(srv, "POST", "/api/v1/auth/delete-account", body, token, "198.51.100.7:5555")
 }
 
 // TestHandleDeleteAccount_CancelsStripeBeforeDelete is the happy-path
@@ -324,27 +317,27 @@ func TestHandleDeleteAccount_AbortsOnSidecar4xx(t *testing.T) {
 // gone; now it returns a truthful partial_delete error and logs the
 // customer ID for operator follow-up.
 //
-// The "local delete fails" condition is simulated by leaving a second
-// audit row referencing the user (activities.user_id) that we DON'T scrub
-// — that row blocks the final DELETE FROM users with a FK violation. The
-// test deliberately re-introduces the same FK that bootstrapAccountDeleteUser
-// normally scrubs.
+// The "local delete fails" condition is injected via the sidecar hook —
+// the existing seam that runs AFTER the cancel succeeds but BEFORE
+// DeleteAccountAtomic. It drops mcp_audit_log (a leaf table with no
+// inbound FKs, deleted from partway through DeleteAccountAtomic), so the
+// local delete's `DELETE FROM mcp_audit_log` errors and rolls the whole
+// transaction back. This replaces the pre-TASK-1959 mechanism, which
+// relied on an activities.user_id FK violation — no longer reproducible
+// now that FK is ON DELETE SET NULL. (Each test gets an isolated DB file
+// copy, so the drop can't leak into sibling tests.)
 func TestHandleDeleteAccount_PartialDelete_WhenLocalDeleteFailsAfterCancel(t *testing.T) {
 	srv := testServer(t)
 	fake := &fakeSidecar{}
+	fake.hook = func(string) {
+		// Sabotage the local delete AFTER the cancel has already fired.
+		if _, err := srv.store.DB().Exec("DROP TABLE mcp_audit_log"); err != nil {
+			t.Errorf("drop mcp_audit_log to force local-delete failure: %v", err)
+		}
+	}
 	srv.SetCloudSidecar(fake)
 
 	userID, token := bootstrapAccountDeleteUser(t, srv, "cus_paying_user")
-
-	// Re-attach an activity row to the user so the FK blocks the delete.
-	// This is the same FK gap the fixture normally scrubs around; we
-	// intentionally re-create it to force DeleteAccountAtomic to fail
-	// AFTER the successful Stripe cancel.
-	if _, err := srv.store.DB().Exec(
-		"UPDATE activities SET user_id = ? WHERE user_id IS NULL",
-		userID); err != nil {
-		t.Fatalf("reintroduce FK: %v", err)
-	}
 
 	rr := deleteAccountReq(srv, map[string]interface{}{"password": "correct-horse-battery-staple"}, token)
 	if rr.Code != http.StatusInternalServerError {

--- a/internal/store/account_deletion_test.go
+++ b/internal/store/account_deletion_test.go
@@ -1,0 +1,232 @@
+package store
+
+import (
+	"testing"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// TestDeleteAccountAtomic_FullyPopulatedUser is the TASK-1959 acceptance
+// test: deleting a user who has rows in every table that references
+// users(id) — activities (audit rows from multiple IPs), sessions, API
+// tokens, memberships, invitations, comments/reactions, grants, share
+// links + views, MCP audit, OAuth connections, item versions/links, stars,
+// and an owned workspace — succeeds atomically with NO work-arounds. FK
+// enforcement is on (testStore enables PRAGMA foreign_keys), so any
+// unhandled reference would surface here as a FK violation on the final
+// DELETE FROM users.
+//
+// Postures asserted:
+//   - audit/history rows survive, de-identified (user reference nulled);
+//   - owned/transient rows are removed;
+//   - the workspace is soft-deleted (recoverable), the second user and
+//     their data are untouched.
+func TestDeleteAccountAtomic_FullyPopulatedUser(t *testing.T) {
+	s := testStore(t)
+
+	// The account under deletion, plus a bystander whose data must survive.
+	u, err := s.CreateUser(models.UserCreate{Email: "delete-me@test.com", Name: "Delete Me", Password: "correct-horse-battery-staple"})
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	other, err := s.CreateUser(models.UserCreate{Email: "keep-me@test.com", Name: "Keep Me", Password: "correct-horse-battery-staple"})
+	if err != nil {
+		t.Fatalf("create other user: %v", err)
+	}
+
+	ws := createTestWorkspace(t, s, "Owned")
+	coll := createTestCollection(t, s, ws.ID, "Tasks")
+	item1 := createTestItem(t, s, ws.ID, coll.ID, "Item One", "")
+	item2 := createTestItem(t, s, ws.ID, coll.ID, "Item Two", "")
+
+	// Attribute item1 to u so the created/modified FKs are exercised.
+	if _, err := s.db.Exec(s.q(`UPDATE items SET created_by_user_id = ?, last_modified_by_user_id = ? WHERE id = ?`), u.ID, u.ID, item1.ID); err != nil {
+		t.Fatalf("attribute item: %v", err)
+	}
+
+	// Memberships: u owns, other edits.
+	if err := s.AddWorkspaceMember(ws.ID, u.ID, "owner"); err != nil {
+		t.Fatalf("add owner member: %v", err)
+	}
+	if err := s.AddWorkspaceMember(ws.ID, other.ID, "editor"); err != nil {
+		t.Fatalf("add editor member: %v", err)
+	}
+
+	// Sessions + API tokens.
+	if _, err := s.CreateSession(u.ID, "cli", "127.0.0.1", "test-agent", time.Hour); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	if _, err := s.CreateAPIToken(u.ID, models.APITokenCreate{Name: "cli"}, 30, 365); err != nil {
+		t.Fatalf("create api token: %v", err)
+	}
+
+	// Activities: audit rows from two different IPs, including a
+	// session_ip_changed row like the auth middleware writes. Capture their
+	// IDs so we can assert the rows survive (de-identified) post-delete.
+	act1, err := s.CreateActivity(models.Activity{WorkspaceID: ws.ID, Action: "updated", Actor: "user", Source: "web", UserID: u.ID, IPAddress: "198.51.100.7"})
+	if err != nil {
+		t.Fatalf("create activity 1: %v", err)
+	}
+	act2, err := s.CreateActivity(models.Activity{Action: models.ActionSessionIPChanged, Actor: "user", Source: "web", UserID: u.ID, IPAddress: "203.0.113.9"})
+	if err != nil {
+		t.Fatalf("create activity 2: %v", err)
+	}
+
+	// Comment + reaction authored by u.
+	comment, err := s.CreateComment(ws.ID, item1.ID, u.ID, models.CommentCreate{Body: "authored", Author: "Delete Me", CreatedBy: "user", Source: "web"})
+	if err != nil {
+		t.Fatalf("create comment: %v", err)
+	}
+	if _, err := s.AddReaction(comment.ID, u.ID, "user", "👍"); err != nil {
+		t.Fatalf("add reaction: %v", err)
+	}
+
+	// Invitation sent by u.
+	if _, err := s.CreateInvitation(ws.ID, "invitee@test.com", "editor", u.ID); err != nil {
+		t.Fatalf("create invitation: %v", err)
+	}
+
+	// Transient auth tokens.
+	if _, err := s.CreatePasswordReset(u.ID); err != nil {
+		t.Fatalf("create password reset: %v", err)
+	}
+	if _, err := s.CreateEmailVerification(u.ID); err != nil {
+		t.Fatalf("create email verification: %v", err)
+	}
+
+	// Grants: one issued BY u (granted_by → deleted directly), one issued TO
+	// u (user_id → cascades on user delete).
+	if _, err := s.CreateCollectionGrant(ws.ID, coll.ID, other.ID, "view", u.ID); err != nil {
+		t.Fatalf("create collection grant (granted_by u): %v", err)
+	}
+	if _, err := s.CreateItemGrant(ws.ID, item1.ID, u.ID, "view", other.ID); err != nil {
+		t.Fatalf("create item grant (user_id u): %v", err)
+	}
+
+	// Share links: one created by u (deleted, cascading its views); one
+	// created by other but VIEWED by u (survives, view de-identified).
+	if _, err := s.CreateShareLink(ws.ID, "item", item1.ID, "view", u.ID, nil); err != nil {
+		t.Fatalf("create share link (u): %v", err)
+	}
+	otherLink, err := s.CreateShareLink(ws.ID, "item", item2.ID, "view", other.ID, nil)
+	if err != nil {
+		t.Fatalf("create share link (other): %v", err)
+	}
+	if _, err := s.RecordShareLinkView(otherLink.ID, "fp-1", u.ID, nil); err != nil {
+		t.Fatalf("record share link view: %v", err)
+	}
+
+	// Item star (cascade), MCP audit row, OAuth connection.
+	if err := s.StarItem(u.ID, item1.ID); err != nil {
+		t.Fatalf("star item: %v", err)
+	}
+	if err := s.InsertMCPAuditEntry(models.MCPAuditEntryInput{UserID: u.ID, TokenKind: models.TokenKindPAT, TokenRef: "tok-1", ToolName: "pad_item", ResultStatus: models.MCPAuditResultOK, RequestID: "req-1"}); err != nil {
+		t.Fatalf("insert mcp audit: %v", err)
+	}
+	if err := s.CreateOAuthConnection(OAuthConnection{RequestID: "conn-1", UserID: u.ID, Name: "Claude"}); err != nil {
+		t.Fatalf("create oauth connection: %v", err)
+	}
+
+	// item_links / item_versions authored by u (no dedicated store creators).
+	if _, err := s.db.Exec(s.q(`INSERT INTO item_links (id, workspace_id, source_id, target_id, link_type, created_by, user_id, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`),
+		newID(), ws.ID, item1.ID, item2.ID, "related", "user", u.ID, now()); err != nil {
+		t.Fatalf("insert item link: %v", err)
+	}
+	if _, err := s.db.Exec(s.q(`INSERT INTO item_versions (id, item_id, content, change_summary, created_by, source, is_diff, user_id, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`),
+		newID(), item1.ID, "v1", "", "user", "web", s.dialect.BoolToInt(false), u.ID, now()); err != nil {
+		t.Fatalf("insert item version: %v", err)
+	}
+
+	count := func(query string, args ...interface{}) int {
+		t.Helper()
+		var n int
+		if err := s.db.QueryRow(s.q(query), args...).Scan(&n); err != nil {
+			t.Fatalf("count %q: %v", query, err)
+		}
+		return n
+	}
+
+	activitiesBefore := count(`SELECT COUNT(*) FROM activities`)
+
+	// The whole point: this must NOT fail on any FK.
+	if err := s.DeleteAccountAtomic(u.ID, []string{ws.Slug}); err != nil {
+		t.Fatalf("DeleteAccountAtomic on fully-populated user: %v", err)
+	}
+
+	// --- User gone, bystander intact ---
+	if got, err := s.GetUser(u.ID); err != nil || got != nil {
+		t.Fatalf("expected deleted user to be gone (got %v, err %v)", got, err)
+	}
+	if got, err := s.GetUser(other.ID); err != nil || got == nil {
+		t.Fatalf("bystander user must survive (got %v, err %v)", got, err)
+	}
+
+	// --- Owned workspace soft-deleted (row + contents recoverable) ---
+	if count(`SELECT COUNT(*) FROM workspaces WHERE id = ? AND deleted_at IS NOT NULL`, ws.ID) != 1 {
+		t.Error("owned workspace should be soft-deleted, not hard-deleted")
+	}
+
+	// --- Audit/history rows survive, de-identified ---
+	if got := count(`SELECT COUNT(*) FROM activities WHERE user_id = ?`, u.ID); got != 0 {
+		t.Errorf("activities.user_id must be nulled, got %d rows still referencing user", got)
+	}
+	if got := count(`SELECT COUNT(*) FROM activities WHERE id IN (?, ?)`, act1, act2); got != 2 {
+		t.Errorf("audit rows must survive de-identification, found %d/2", got)
+	}
+	if got := count(`SELECT COUNT(*) FROM activities`); got != activitiesBefore {
+		t.Errorf("no activity rows should be deleted (before=%d after=%d)", activitiesBefore, got)
+	}
+	if count(`SELECT COUNT(*) FROM items WHERE id = ? AND created_by_user_id IS NULL AND last_modified_by_user_id IS NULL`, item1.ID) != 1 {
+		t.Error("item author/modifier references must be nulled, item preserved")
+	}
+	if count(`SELECT COUNT(*) FROM comments WHERE id = ? AND user_id IS NULL`, comment.ID) != 1 {
+		t.Error("comment must survive with user_id nulled")
+	}
+	if got := count(`SELECT COUNT(*) FROM comment_reactions WHERE user_id = ?`, u.ID); got != 0 {
+		t.Errorf("comment_reactions.user_id must be nulled, got %d", got)
+	}
+	if got := count(`SELECT COUNT(*) FROM item_links WHERE user_id = ?`, u.ID); got != 0 {
+		t.Errorf("item_links.user_id must be nulled, got %d", got)
+	}
+	if got := count(`SELECT COUNT(*) FROM item_versions WHERE user_id = ?`, u.ID); got != 0 {
+		t.Errorf("item_versions.user_id must be nulled, got %d", got)
+	}
+	// other's share link survives; the view by u is de-identified, not deleted.
+	if count(`SELECT COUNT(*) FROM share_links WHERE id = ?`, otherLink.ID) != 1 {
+		t.Error("bystander's share link must survive")
+	}
+	if got := count(`SELECT COUNT(*) FROM share_link_views WHERE viewer_user_id = ?`, u.ID); got != 0 {
+		t.Errorf("share_link_views.viewer_user_id must be nulled, got %d", got)
+	}
+	if count(`SELECT COUNT(*) FROM share_link_views WHERE share_link_id = ? AND viewer_user_id IS NULL`, otherLink.ID) != 1 {
+		t.Error("the de-identified view row must survive on the bystander's link")
+	}
+
+	// --- Owned / transient / audit rows removed ---
+	for _, c := range []struct {
+		what, query string
+	}{
+		{"sessions", `SELECT COUNT(*) FROM sessions WHERE user_id = ?`},
+		{"api_tokens", `SELECT COUNT(*) FROM api_tokens WHERE user_id = ?`},
+		{"workspace_members", `SELECT COUNT(*) FROM workspace_members WHERE user_id = ?`},
+		{"workspace_invitations", `SELECT COUNT(*) FROM workspace_invitations WHERE invited_by = ?`},
+		{"password_reset_tokens", `SELECT COUNT(*) FROM password_reset_tokens WHERE user_id = ?`},
+		{"email_verification_tokens", `SELECT COUNT(*) FROM email_verification_tokens WHERE user_id = ?`},
+		{"collection_grants (granted_by)", `SELECT COUNT(*) FROM collection_grants WHERE granted_by = ?`},
+		{"item_grants (user_id, cascade)", `SELECT COUNT(*) FROM item_grants WHERE user_id = ?`},
+		{"share_links (created_by)", `SELECT COUNT(*) FROM share_links WHERE created_by = ?`},
+		{"mcp_audit_log", `SELECT COUNT(*) FROM mcp_audit_log WHERE user_id = ?`},
+		{"oauth_connections", `SELECT COUNT(*) FROM oauth_connections WHERE user_id = ?`},
+		{"item_stars (cascade)", `SELECT COUNT(*) FROM item_stars WHERE user_id = ?`},
+	} {
+		if got := count(c.query, u.ID); got != 0 {
+			t.Errorf("%s: expected 0 rows for deleted user, got %d", c.what, got)
+		}
+	}
+
+	// Bystander's membership must be untouched.
+	if count(`SELECT COUNT(*) FROM workspace_members WHERE user_id = ?`, other.ID) != 1 {
+		t.Error("bystander membership must survive")
+	}
+}

--- a/internal/store/migrations/072_activities_user_fk_set_null.sql
+++ b/internal/store/migrations/072_activities_user_fk_set_null.sql
@@ -1,0 +1,56 @@
+-- Migration 072: activities.user_id -> ON DELETE SET NULL (TASK-1959).
+--
+-- activities is pad's append-only audit/history log. It records every
+-- action, INCLUDING the session_ip_changed audit rows the auth
+-- middleware writes on the very request that deletes an account (a
+-- delete from a changed IP). Its user_id FK previously carried no
+-- ON DELETE action, so DELETE FROM users could 500 with nothing deleted
+-- whenever an activity row still referenced the user — the exact FK gap
+-- the delete-account tests worked around by pinning RemoteAddr and
+-- scrubbing activities.user_id.
+--
+-- ON DELETE SET NULL preserves the audit row and drops the identity —
+-- the same posture comments.user_id uses (TASK-509). Because
+-- activities is written on nearly every request, the schema-level SET
+-- NULL also closes the race where a concurrent request logs an activity
+-- for the user between DeleteAccountAtomic's cleanup and its final
+-- DELETE FROM users.
+--
+-- SQLite can't ALTER a column-level FK in place, so we rebuild the table
+-- following the 022_audit_trail pattern: PKs are preserved, so
+-- comments.activity_id references stay valid; FK enforcement is disabled
+-- during the swap. The Postgres side (pgmigrations/050) adds the same
+-- constraint via ALTER TABLE — Postgres never had a FK on this column.
+
+PRAGMA foreign_keys = OFF;
+
+DROP TABLE IF EXISTS activities_new;
+
+CREATE TABLE activities_new (
+    id            TEXT PRIMARY KEY,
+    workspace_id  TEXT REFERENCES workspaces(id),
+    document_id   TEXT,
+    action        TEXT NOT NULL,
+    actor         TEXT NOT NULL,
+    source        TEXT NOT NULL DEFAULT 'web',
+    metadata      TEXT NOT NULL DEFAULT '{}',
+    created_at    TEXT NOT NULL,
+    user_id       TEXT REFERENCES users(id) ON DELETE SET NULL,
+    ip_address    TEXT,
+    user_agent    TEXT
+);
+
+INSERT INTO activities_new (id, workspace_id, document_id, action, actor, source, metadata, created_at, user_id, ip_address, user_agent)
+SELECT id, workspace_id, document_id, action, actor, source, metadata, created_at, user_id, ip_address, user_agent
+FROM activities;
+
+DROP TABLE activities;
+ALTER TABLE activities_new RENAME TO activities;
+
+-- Recreate indexes (mirror of 022_audit_trail.sql).
+CREATE INDEX IF NOT EXISTS idx_activities_workspace ON activities(workspace_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_activities_document ON activities(document_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_activities_action ON activities(action, created_at);
+CREATE INDEX IF NOT EXISTS idx_activities_user ON activities(user_id, created_at);
+
+PRAGMA foreign_keys = ON;

--- a/internal/store/pgmigrations/050_activities_user_fk_set_null.sql
+++ b/internal/store/pgmigrations/050_activities_user_fk_set_null.sql
@@ -1,0 +1,21 @@
+-- Migration 050: add activities.user_id -> users(id) ON DELETE SET NULL (TASK-1959).
+--
+-- Postgres never enforced a FK on activities.user_id (SQLite did). Adding
+-- it with ON DELETE SET NULL brings the two dialects to parity and makes
+-- DELETE FROM users de-identify audit/history rows instead of leaving a
+-- dangling user_id behind. This mirrors the SQLite side (migrations/072)
+-- and is the durable form of the "ON DELETE SET NULL behaviour" the
+-- delete-account tests previously simulated with a manual scrub.
+-- See TASK-1959 for the full FK audit.
+--
+-- Defensive orphan scrub first: any activities.user_id that no longer
+-- references a live user (possible precisely because Postgres had no FK
+-- to enforce it) is nulled so ADD CONSTRAINT validation passes.
+
+UPDATE activities SET user_id = NULL
+WHERE user_id IS NOT NULL
+  AND user_id NOT IN (SELECT id FROM users);
+
+ALTER TABLE activities DROP CONSTRAINT IF EXISTS activities_user_id_fkey;
+ALTER TABLE activities ADD CONSTRAINT activities_user_id_fkey
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL;

--- a/internal/store/users.go
+++ b/internal/store/users.go
@@ -945,6 +945,23 @@ func (s *Store) DeleteUser(id string) error {
 // DeleteAccountAtomic deletes a user and all their owned workspaces in a single
 // transaction. If any step fails, the entire operation is rolled back and no data
 // is modified. This prevents orphaned workspaces from partial deletions.
+//
+// Every table with a foreign key to users(id) is handled here so the final
+// DELETE FROM users can't 500 on an FK constraint (TASK-1959). Three postures,
+// mirroring the FK audit:
+//
+//   - De-identify (UPDATE ... SET NULL): audit/history rows that should survive
+//     with their identity dropped — the comments.user_id posture from TASK-509.
+//     They live on in soft-deleted owned workspaces and in other workspaces the
+//     user contributed to.
+//   - Delete: rows the user solely owns or that are transient/audit and not
+//     worth de-identifying (sessions, tokens, memberships, sent invitations,
+//     issued grants, created share links, MCP audit, OAuth connections).
+//   - Cascade: rows the schema already removes/nulls at DELETE FROM users
+//     time — item_stars, user_report_layouts, {collection,item}_grants.user_id
+//     (ON DELETE CASCADE); items.assigned_user_id and activities.user_id
+//     (ON DELETE SET NULL; activities gained its FK action in migrations
+//     072/050).
 func (s *Store) DeleteAccountAtomic(userID string, ownedWorkspaceSlugs []string) error {
 	tx, err := s.db.Begin()
 	if err != nil {
@@ -954,46 +971,73 @@ func (s *Store) DeleteAccountAtomic(userID string, ownedWorkspaceSlugs []string)
 
 	ts := now()
 
-	// 1. Soft-delete all owned workspaces
+	// 1. Soft-delete all owned workspaces. They keep their rows (and every
+	// item/activity/comment within) so the data stays recoverable; only the
+	// user identity is hard-removed below.
 	for _, slug := range ownedWorkspaceSlugs {
-		result, err := tx.Exec(s.q(`
+		if _, err := tx.Exec(s.q(`
 			UPDATE workspaces SET deleted_at = ?, updated_at = ?
 			WHERE slug = ? AND deleted_at IS NULL
-		`), ts, ts, slug)
-		if err != nil {
+		`), ts, ts, slug); err != nil {
 			return fmt.Errorf("delete account: delete workspace %s: %w", slug, err)
 		}
-		rows, _ := result.RowsAffected()
-		if rows == 0 {
-			// Workspace already deleted or not found — not an error
-			continue
+	}
+
+	// exec runs one cleanup statement keyed on userID, wrapping the error with
+	// context. Each statement clears a reference to the user so the final
+	// DELETE FROM users can't trip a foreign-key constraint.
+	exec := func(what, query string) error {
+		if _, err := tx.Exec(s.q(query), userID); err != nil {
+			return fmt.Errorf("delete account: %s: %w", what, err)
+		}
+		return nil
+	}
+
+	// 2. De-identify audit/history rows (preserve row, drop identity). These
+	// FKs are RESTRICT on SQLite and either RESTRICT (items) or absent
+	// (comments/item_links/item_versions/comment_reactions) on Postgres —
+	// nulling here keeps the delete safe and the data clean on both dialects.
+	deidentify := []struct{ what, query string }{
+		{"detach authored items", "UPDATE items SET created_by_user_id = NULL WHERE created_by_user_id = ?"},
+		{"detach modified items", "UPDATE items SET last_modified_by_user_id = NULL WHERE last_modified_by_user_id = ?"},
+		{"detach comments", "UPDATE comments SET user_id = NULL WHERE user_id = ?"},
+		{"detach comment reactions", "UPDATE comment_reactions SET user_id = NULL WHERE user_id = ?"},
+		{"detach item links", "UPDATE item_links SET user_id = NULL WHERE user_id = ?"},
+		{"detach item versions", "UPDATE item_versions SET user_id = NULL WHERE user_id = ?"},
+		{"detach share-link views", "UPDATE share_link_views SET viewer_user_id = NULL WHERE viewer_user_id = ?"},
+	}
+	for _, stmt := range deidentify {
+		if err := exec(stmt.what, stmt.query); err != nil {
+			return err
 		}
 	}
 
-	// 2. Revoke all sessions
-	if _, err := tx.Exec(s.q("DELETE FROM sessions WHERE user_id = ?"), userID); err != nil {
-		return fmt.Errorf("delete account: delete sessions: %w", err)
+	// 3. Delete rows the user owns or that are transient/audit. CASCADE cleans
+	// the dependents: member_collection_access (off workspace_members),
+	// share_link_views (off deleted share_links), oauth_connection_workspaces
+	// (off oauth_connections).
+	deletes := []struct{ what, query string }{
+		{"delete sessions", "DELETE FROM sessions WHERE user_id = ?"},
+		{"delete api tokens", "DELETE FROM api_tokens WHERE user_id = ?"},
+		{"delete workspace memberships", "DELETE FROM workspace_members WHERE user_id = ?"},
+		{"delete sent invitations", "DELETE FROM workspace_invitations WHERE invited_by = ?"},
+		{"delete password reset tokens", "DELETE FROM password_reset_tokens WHERE user_id = ?"},
+		{"delete email verification tokens", "DELETE FROM email_verification_tokens WHERE user_id = ?"},
+		{"delete issued collection grants", "DELETE FROM collection_grants WHERE granted_by = ?"},
+		{"delete issued item grants", "DELETE FROM item_grants WHERE granted_by = ?"},
+		{"delete created share links", "DELETE FROM share_links WHERE created_by = ?"},
+		{"delete mcp audit log", "DELETE FROM mcp_audit_log WHERE user_id = ?"},
+		{"delete oauth connections", "DELETE FROM oauth_connections WHERE user_id = ?"},
+	}
+	for _, stmt := range deletes {
+		if err := exec(stmt.what, stmt.query); err != nil {
+			return err
+		}
 	}
 
-	// 3. Revoke all API tokens
-	if _, err := tx.Exec(s.q("DELETE FROM api_tokens WHERE user_id = ?"), userID); err != nil {
-		return fmt.Errorf("delete account: delete api tokens: %w", err)
-	}
-
-	// 3b. Detach authored comments. comments.user_id is a FK to users(id)
-	// (TASK-1663 started populating it); the user's comments live on in
-	// soft-deleted owned workspaces and in other workspaces they're a member
-	// of, so null the reference rather than let the FK block deletion. The
-	// comments.author display name is preserved; nulling user_id just makes
-	// those comments admin-only to edit going forward, which is correct once
-	// the author's account is gone.
-	if _, err := tx.Exec(s.q("UPDATE comments SET user_id = NULL WHERE user_id = ?"), userID); err != nil {
-		return fmt.Errorf("delete account: detach comments: %w", err)
-	}
-
-	// 4. Delete the user record
-	if _, err := tx.Exec(s.q("DELETE FROM users WHERE id = ?"), userID); err != nil {
-		return fmt.Errorf("delete account: delete user: %w", err)
+	// 4. Delete the user record. Remaining references cascade (see doc comment).
+	if err := exec("delete user", "DELETE FROM users WHERE id = ?"); err != nil {
+		return err
 	}
 
 	if err := tx.Commit(); err != nil {


### PR DESCRIPTION
## What

`DeleteAccountAtomic` could return **500 with nothing deleted** when a user had rows referencing them via foreign keys with no `ON DELETE` action — notably `activities.user_id`, the audit/history log (which includes the `session_ip_changed` rows the auth middleware writes on the very request that deletes the account). The delete-account tests only passed by working around this (pinning `RemoteAddr` to loopback, scrubbing `activities.user_id`).

## Why

Phase-1 backend reliability — deletes must be safe before the delete surface is exposed to all users. A real delete from a changed IP, or with any audit/history rows present, could fail and leave the account half-deleted.

## Changes

- **`DeleteAccountAtomic`** now handles every table with a FK to `users(id)`:
  - **de-identify** (`UPDATE … SET NULL`, preserve row / drop identity — the `comments.user_id` posture from TASK-509): items created/modified, comments, comment_reactions, item_links, item_versions, share_link_views
  - **delete** owned/transient/audit rows: sessions, api_tokens, workspace_members, sent invitations, password/email tokens, issued grants, created share links, mcp_audit_log, oauth_connections
  - **cascade** (already in schema): item_stars, user_report_layouts, {collection,item}_grants.user_id, items.assigned_user_id
- **Migration 072 (SQLite)** rebuilds `activities` giving `user_id` an `ON DELETE SET NULL` FK (follows the 022_audit_trail rebuild pattern; PKs preserved so `comments.activity_id` stays valid).
- **Migration 050 (Postgres)** adds the same FK — Postgres never had one on `activities.user_id` — after a defensive orphan scrub so `ADD CONSTRAINT` validation passes.
- Removed the test work-arounds: `deleteAccountReq` now deletes from a **changed IP** so the session-IP-change audit row exercises the fix, and the partial-delete test injects its post-cancel failure via the sidecar hook instead of the (now-fixed) FK gap.
- Added a store-level test that deletes a **fully-populated** user atomically.

## Acceptance criteria

- [x] Deleting a user with `activities` rows and audit rows from multiple IPs succeeds (no FK 500), history rows retained but de-identified
- [x] Store-level test deletes a fully-populated user (activities, sessions, tokens, audit, comments, owned workspaces, grants, share links, MCP audit, OAuth, item versions/links, stars) atomically without work-arounds
- [x] Both dialects green: Go gates (lint / `go test ./...` / govulncheck) + `make test-pg` (Postgres)

Migrations: SQLite `072_activities_user_fk_set_null.sql`, Postgres `050_activities_user_fk_set_null.sql`.

Closes TASK-1959

https://claude.ai/code/session_01HxBkAMiFBtCRJ2tKSCt3ST
