### PR TITLE
feat(web): delete-account confirm flow in settings Danger Zone

### DIFF
--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -255,6 +255,21 @@ function getCSRFToken(): string | null {
  */
 const AUTH_FORM_401_PATHS = new Set(['/auth/login', '/auth/register', '/auth/2fa/login-verify']);
 
+/**
+ * AUTHENTICATED credential-reconfirmation endpoints (TASK-1962). Unlike the
+ * auth-form paths above, these sit BEHIND RequireAuth, so a 401 is
+ * ambiguous: it can mean either a wrong second factor (e.g.
+ * `totp_invalid` — must surface verbatim so the user can retry inline) OR
+ * a genuinely expired session (`unauthorized` — must redirect to /login
+ * like every other endpoint). We disambiguate on the error CODE below: a
+ * non-`unauthorized` 401 body is a credential failure and is thrown
+ * verbatim; an `unauthorized` (or bodyless) 401 falls through to the
+ * standard redirect. `/auth/delete-account`'s wrong-password case is a 403
+ * and its billing/partial-delete failures are 500s, so `totp_invalid` is
+ * the only 401 that needs this treatment.
+ */
+const CREDENTIAL_RECONFIRM_401_PATHS = new Set(['/auth/delete-account']);
+
 async function request<T>(path: string, options?: RequestInit): Promise<T> {
 	const headers: Record<string, string> = { 'Content-Type': 'application/json' };
 
@@ -276,6 +291,16 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
 			const body = await resp.json().catch(() => null);
 			if (body?.error) throw new PadApiError(body.error);
 			throw new PadApiError({ code: 'unauthorized', message: 'Authentication failed' });
+		}
+		// Credential-reconfirmation endpoints: surface a wrong-second-factor
+		// 401 verbatim, but let a genuine session-expiry `unauthorized` 401
+		// fall through to the redirect below (see CREDENTIAL_RECONFIRM_401_PATHS).
+		if (CREDENTIAL_RECONFIRM_401_PATHS.has(barePath)) {
+			const body = await resp.json().catch(() => null);
+			if (body?.error && body.error.code !== 'unauthorized') {
+				throw new PadApiError(body.error);
+			}
+			// else: expired session — continue to the standard redirect.
 		}
 		// Redirect to login page (avoid infinite loop), preserving the
 		// current location as a return-to target so a genuine session

--- a/web/src/routes/console/settings/+page.svelte
+++ b/web/src/routes/console/settings/+page.svelte
@@ -79,6 +79,29 @@
 	let exportMsg = $state('');
 	let exportError = $state('');
 
+	// Danger Zone — delete my account (TASK-1962). Own $state trio, distinct from
+	// the export trio above (per-action state, mirroring the file's convention).
+	let showDeleteConfirm = $state(false);
+	let deletePassword = $state('');
+	let deleteConfirmText = $state('');
+	let deleteTotpCode = $state('');
+	let deleteSaving = $state(false);
+	let deleteError = $state('');
+
+	// Which identity check the confirm block demands. Email/password accounts
+	// (and every self-host account) re-enter their password; cloud OAuth-only
+	// accounts have no password, so they type a confirmation string instead.
+	// `?? true` makes the password branch the SAFE FALLBACK while `password_set`
+	// is still loading — an unknown password state must never downgrade to the
+	// weaker typed-confirm path.
+	const usePasswordBranch = $derived(!authStore.cloudMode || (profile?.password_set ?? true));
+
+	// Focus the first confirm input the moment the block reveals (a11y). Same
+	// requestAnimationFrame action the quick-capture sheet uses.
+	function autofocus(node: HTMLElement) {
+		requestAnimationFrame(() => node.focus());
+	}
+
 	let loading = $state(true);
 
 	// Map pad-cloud's /console/settings?error= / ?linked= redirect codes to
@@ -367,6 +390,85 @@
 			exportError = err instanceof Error ? err.message : 'Failed to export your data. Please try again.';
 		} finally {
 			exportSaving = false;
+		}
+	}
+
+	// Reveal the delete confirm block. Clears the action's own stale error so a
+	// prior failed attempt doesn't linger over a fresh reveal.
+	function revealDeleteConfirm() {
+		showDeleteConfirm = true;
+		deleteError = '';
+	}
+
+	// Cancel out of the confirm block (also the Escape-key target). Wipes every
+	// secret the user may have typed so nothing lingers in memory / the DOM.
+	function cancelDelete() {
+		showDeleteConfirm = false;
+		deletePassword = '';
+		deleteConfirmText = '';
+		deleteTotpCode = '';
+		deleteError = '';
+	}
+
+	// Shared keydown for the confirm inputs: Escape cancels, Enter submits.
+	function deleteKeydown(e: KeyboardEvent) {
+		if (e.key === 'Escape') {
+			cancelDelete();
+		} else if (e.key === 'Enter') {
+			deleteAccount();
+		}
+	}
+
+	// Permanently delete the account (TASK-1962). Builds the request from the
+	// account's auth method: password for email/password + self-host users, a
+	// typed confirmation for cloud OAuth-only users, plus a TOTP code whenever
+	// 2FA is on (the server re-verifies it — TASK-1958). On success the server
+	// has already cleared the session + CSRF cookies, so we HARD-reset to /login
+	// (authStore.clear() then window.location) and make NO further API calls —
+	// a goto() to an authed route would 401 against a now-deleted account.
+	async function deleteAccount() {
+		deleteError = '';
+
+		const opts: { password?: string; confirm?: boolean; totp_code?: string } = {};
+		if (usePasswordBranch) {
+			if (!deletePassword) {
+				deleteError = 'Please enter your password to delete your account.';
+				return;
+			}
+			opts.password = deletePassword;
+		} else {
+			const typed = deleteConfirmText.trim();
+			const matchesEmail = profile?.email ? typed === profile.email : false;
+			const matchesWord = typed.toUpperCase() === 'DELETE';
+			if (!matchesEmail && !matchesWord) {
+				deleteError = `Type your email (${profile?.email ?? ''}) or the word DELETE to confirm.`;
+				return;
+			}
+			opts.confirm = true;
+		}
+
+		if (profile?.totp_enabled) {
+			const code = deleteTotpCode.trim();
+			if (!code) {
+				deleteError = 'Enter your 6-digit 2FA code to delete your account.';
+				return;
+			}
+			opts.totp_code = code;
+		}
+
+		deleteSaving = true;
+		try {
+			await api.auth.deleteAccount(opts);
+			// Success: hard reset, no further API calls.
+			authStore.clear();
+			window.location.href = '/login';
+		} catch (err) {
+			// Render the server message VERBATIM. billing_cancel_failed /
+			// partial_delete carry account-state truth ("your account was NOT
+			// deleted", "your billing was cancelled but…") that must NOT be
+			// swallowed behind a generic retry line.
+			deleteError = err instanceof Error ? err.message : 'Failed to delete your account. Please try again.';
+			deleteSaving = false;
 		}
 	}
 
@@ -695,6 +797,104 @@
 				{/if}
 				{#if exportError}
 					<p class="error" role="alert" aria-live="assertive">{exportError}</p>
+				{/if}
+
+				<hr class="danger-divider" />
+
+				<!-- Delete my account (TASK-1962) -->
+				<div class="danger-row">
+					<div class="danger-info">
+						<span class="danger-heading">Delete my account</span>
+						<p class="danger-desc">
+							Permanently delete your account and everything you own. This cannot be undone.
+						</p>
+					</div>
+					{#if !showDeleteConfirm}
+						<button class="danger-btn" onclick={revealDeleteConfirm}>Delete my account</button>
+					{/if}
+				</div>
+
+				{#if showDeleteConfirm}
+					<div class="disable-confirm">
+						<ul id="delete-warnings" class="delete-warnings">
+							<li>This is <strong>permanent and irreversible</strong>.</li>
+							<li>It cancels any active paid subscription immediately, with no refund.</li>
+							<li>
+								Any workspaces you own that are shared with others are
+								<strong>deleted</strong>, and every member loses access. There is no
+								ownership transfer.
+							</li>
+						</ul>
+						<p class="section-desc">
+							Want a copy first? Use the
+							<button type="button" class="inline-export-link" onclick={exportData} disabled={exportSaving || deleteSaving}>
+								{exportSaving ? 'exporting your data…' : 'Export my data'}
+							</button>
+							button above before you delete.
+						</p>
+
+						{#if usePasswordBranch}
+							<div class="field">
+								<label for="delete-password">Enter your password to confirm</label>
+								<input
+									id="delete-password"
+									type="password"
+									bind:value={deletePassword}
+									disabled={deleteSaving}
+									autocomplete="current-password"
+									aria-describedby="delete-warnings"
+									onkeydown={deleteKeydown}
+									use:autofocus
+								/>
+							</div>
+						{:else}
+							<div class="field">
+								<label for="delete-confirm">
+									Type your email ({profile?.email ?? ''}) or the word <strong>DELETE</strong> to confirm
+								</label>
+								<input
+									id="delete-confirm"
+									type="text"
+									placeholder="DELETE"
+									bind:value={deleteConfirmText}
+									disabled={deleteSaving}
+									autocomplete="off"
+									aria-describedby="delete-warnings"
+									onkeydown={deleteKeydown}
+									use:autofocus
+								/>
+							</div>
+						{/if}
+
+						{#if profile?.totp_enabled}
+							<div class="field">
+								<label for="delete-totp">2FA code</label>
+								<input
+									id="delete-totp"
+									type="text"
+									placeholder="6-digit code"
+									bind:value={deleteTotpCode}
+									disabled={deleteSaving}
+									autocomplete="one-time-code"
+									inputmode="numeric"
+									maxlength="6"
+									aria-describedby="delete-warnings"
+									onkeydown={deleteKeydown}
+								/>
+							</div>
+						{/if}
+
+						{#if deleteError}
+							<p class="error" role="alert" aria-live="assertive">{deleteError}</p>
+						{/if}
+
+						<div class="btn-row">
+							<button class="danger-btn" onclick={deleteAccount} disabled={deleteSaving}>
+								{deleteSaving ? 'Deleting...' : 'Permanently delete my account'}
+							</button>
+							<button class="secondary-btn" onclick={cancelDelete} disabled={deleteSaving}>Cancel</button>
+						</div>
+					</div>
 				{/if}
 			</div>
 		</section>
@@ -1153,5 +1353,43 @@
 	.danger-desc {
 		font-size: 0.85rem;
 		color: var(--text-muted);
+	}
+
+	/* Divider between the export row and the delete-account block (TASK-1962) */
+	.danger-divider {
+		border: none;
+		border-top: 1px solid var(--border);
+		margin: 0;
+	}
+
+	.delete-warnings {
+		margin: 0;
+		padding-left: var(--space-5);
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-1);
+		font-size: 0.85rem;
+		color: var(--text-secondary);
+		line-height: 1.4;
+	}
+
+	.delete-warnings strong {
+		color: #ef4444;
+	}
+
+	/* Inline "Export my data" link inside the delete confirm nudge (TASK-1962) */
+	.inline-export-link {
+		background: none;
+		border: none;
+		padding: 0;
+		font: inherit;
+		color: var(--accent-blue);
+		cursor: pointer;
+		text-decoration: underline;
+	}
+
+	.inline-export-link:disabled {
+		opacity: 0.6;
+		cursor: not-allowed;
 	}
 </style>


### PR DESCRIPTION
## What

Adds a two-step delete-account flow to the console settings Danger Zone (`web/src/routes/console/settings/+page.svelte`), completing Phase 3 of the account-deletion work. Clones the inline TOTP-disable two-step reveal pattern already in this file.

## Why

TASK-1961 shipped the Danger Zone section + Export button; TASK-1957/1958/1960 landed the `password_set` field, server-side TOTP re-verify, and the `api.auth.deleteAccount` client method. This wires the actual delete UI on top of them.

## How

- **Two-step reveal:** a `.danger-btn` flips `showDeleteConfirm` and clears stale error, revealing a `.disable-confirm` block.
- **Auth-method branch** (`usePasswordBranch = !cloudMode || (password_set ?? true)`):
  - password re-entry → `{ password }` for email/password + self-host accounts (safe fallback while `password_set` loads)
  - typed confirmation (account email or the word `DELETE`) → `{ confirm: true }` for cloud OAuth-only accounts
- **TOTP:** when `profile.totp_enabled`, renders a code input and includes `totp_code` (server enforces via TASK-1958).
- **Warnings:** irreversible; cancels any active paid subscription with no refund; owned shared workspaces are deleted and members lose access (no ownership transfer). Nudges users to Export first via an inline link to the existing Export button.
- **Errors:** renders the server `billing_cancel_failed` / `partial_delete` message strings verbatim (never swallowed behind a generic retry line).
- **Success:** `authStore.clear()` then `window.location.href = '/login'` — hard reset, no further API calls.
- **a11y:** focus-on-reveal (`use:autofocus`), Escape-to-cancel, `aria-describedby` linking the warnings.
- Own `$state` trio for the delete action; reuses `.danger-btn` / `.secondary-btn` / `.disable-confirm` / `.error`.

### Client 401 handling (`web/src/lib/api/client.ts`)

The delete endpoint returns `401 totp_invalid` for a wrong 2FA code, which the shared `request()` helper would otherwise mask with a `/login` redirect — swallowing the verbatim message. Added `CREDENTIAL_RECONFIRM_401_PATHS` so `/auth/delete-account` surfaces a credential-failure 401 body verbatim (`error.code !== 'unauthorized'`) while still falling through to the standard redirect for a genuine session-expiry (`unauthorized`) or bodyless 401. (Wrong-password is a 403 and billing/partial-delete failures are 500s, so `totp_invalid` is the only 401 needing this.)

Closes TASK-1962

## Acceptance criteria

- [x] Self-host / has-password users delete via password; cloud OAuth-only via typed confirm; 2FA users must supply a valid TOTP code
- [x] Irreversibility, subscription, and shared-workspace warnings shown
- [x] `billing_cancel_failed` / `partial_delete` render verbatim; `totp_invalid` reaches the confirm block inline
- [x] On success the user lands logged-out on `/login` with no stale authed state
- [x] `npm run check` clean (0 errors); Codex review CLEAN

https://claude.ai/code/session_01HxBkAMiFBtCRJ2tKSCt3ST