### PR TITLE
test: account delete + export contract tests and Danger Zone e2e (TASK-1963)

### DIFF
--- a/internal/server/handlers_account_export_contract_test.go
+++ b/internal/server/handlers_account_export_contract_test.go
@@ -1,0 +1,127 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// TestExportAccount_HappyPath_ArtifactContract pins the account-export
+// artifact shape a consumer relies on — the web Danger Zone "Export my data"
+// download (web/src/lib/utils/artifacts.ts::exportAndDownloadAccountData) and
+// any offline GDPR-portability parse. This fills the TASK-508 gap: the export
+// endpoint had a restricted-owner gate test but no positive assertion on the
+// bytes it produces.
+//
+// Distinct from TestExportAccount_UnrestrictedOwner_OK in
+// handlers_account_export_gate_test.go, which is a substring smoke proving
+// BUG-1945's gate does not 403 the unrestricted case. This test decodes the
+// body and asserts the STRUCTURE: the exact attachment header (the filename a
+// browser saves under), the JSON content type, the top-level {user,
+// workspaces} envelope, the user projection's fields, and that an owned
+// workspace carries its collections + items inline.
+func TestExportAccount_HappyPath_ArtifactContract(t *testing.T) {
+	srv := testServer(t)
+
+	owner, err := srv.store.CreateUser(models.UserCreate{
+		Email: "export-contract@example.com", Name: "Export Contract", Username: "export-contract",
+		Password: "pw-test-12345",
+	})
+	if err != nil {
+		t.Fatalf("create owner: %v", err)
+	}
+	ws, err := srv.store.CreateWorkspace(models.WorkspaceCreate{Name: "Exported", OwnerID: owner.ID})
+	if err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	if err := srv.store.AddWorkspaceMember(ws.ID, owner.ID, "owner"); err != nil {
+		t.Fatalf("add member: %v", err)
+	}
+	coll, err := srv.store.CreateCollection(ws.ID, models.CollectionCreate{
+		Name: "Tasks", Slug: "tasks", Prefix: "TASK", Schema: `{"fields":[]}`,
+	})
+	if err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	if _, err := srv.store.CreateItem(ws.ID, coll.ID, models.ItemCreate{Title: "Exported Item", Fields: `{}`}); err != nil {
+		t.Fatalf("create item: %v", err)
+	}
+
+	sessTok, err := srv.store.CreateSession(owner.ID, "go-test", "192.0.2.1", "", 24*time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	rr := doRequestWithCookie(srv, "GET", "/api/v1/auth/export", nil, sessTok)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	// The download headers a browser keys the "Save as pad-export.json"
+	// prompt off. Exact match, not substring: the filename is the contract.
+	if cd := rr.Header().Get("Content-Disposition"); cd != `attachment; filename="pad-export.json"` {
+		t.Errorf("Content-Disposition = %q, want `attachment; filename=\"pad-export.json\"`", cd)
+	}
+	if ct := rr.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+
+	// Decode the streamed body and assert the portability envelope.
+	var payload struct {
+		User struct {
+			ID       string `json:"id"`
+			Email    string `json:"email"`
+			Username string `json:"username"`
+			Name     string `json:"name"`
+		} `json:"user"`
+		Workspaces []struct {
+			ID          string              `json:"id"`
+			Slug        string              `json:"slug"`
+			Role        string              `json:"role"`
+			Collections []models.Collection `json:"collections"`
+			Items       []models.Item       `json:"items"`
+		} `json:"workspaces"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("export body is not valid JSON matching the documented shape: %v\nbody: %s", err, rr.Body.String())
+	}
+
+	if payload.User.ID != owner.ID {
+		t.Errorf("user.id = %q, want %q", payload.User.ID, owner.ID)
+	}
+	if payload.User.Email != "export-contract@example.com" {
+		t.Errorf("user.email = %q, want export-contract@example.com", payload.User.Email)
+	}
+	if payload.User.Username == "" || payload.User.Name == "" {
+		t.Errorf("user projection missing username/name: %+v", payload.User)
+	}
+
+	if len(payload.Workspaces) != 1 {
+		t.Fatalf("expected exactly 1 exported workspace, got %d", len(payload.Workspaces))
+	}
+	wsOut := payload.Workspaces[0]
+	if wsOut.ID != ws.ID || wsOut.Slug != ws.Slug {
+		t.Errorf("workspace id/slug mismatch: got %s/%s, want %s/%s", wsOut.ID, wsOut.Slug, ws.ID, ws.Slug)
+	}
+	if wsOut.Role != "owner" {
+		t.Errorf("owned workspace role = %q, want owner", wsOut.Role)
+	}
+	// Owned workspaces carry their collections + items inline (the whole point
+	// of the export). The seeded collection + item must round-trip.
+	if len(wsOut.Collections) == 0 {
+		t.Error("owned workspace export missing collections")
+	}
+	foundItem := false
+	for _, it := range wsOut.Items {
+		if it.Title == "Exported Item" {
+			foundItem = true
+			break
+		}
+	}
+	if !foundItem {
+		t.Errorf("owned workspace export missing the seeded item; items=%+v", wsOut.Items)
+	}
+}

--- a/internal/server/handlers_account_test.go
+++ b/internal/server/handlers_account_test.go
@@ -420,6 +420,44 @@ func validTOTPCode(t *testing.T, secret string) string {
 	return code
 }
 
+// TestHandleDeleteAccount_SuccessBody pins the exact JSON envelope a UI
+// consumes on a successful delete: {"ok": true} and nothing else. The
+// cascade/skip tests above assert only the 200 status; the web Danger Zone
+// keys its "account deleted → hard-redirect to /login" transition off this
+// body (web/src/routes/console/settings/+page.svelte::deleteAccount awaits
+// api.auth.deleteAccount which types the response as {ok: boolean}). A
+// regression that renamed "ok", returned an empty 200, or leaked an extra
+// field would break that transition while still returning 200, so it needs
+// its own assertion. This is the non-2FA, non-Stripe baseline; the TOTP
+// happy-path test below covers the same envelope on the 2FA branch.
+func TestHandleDeleteAccount_SuccessBody(t *testing.T) {
+	srv := testServer(t)
+	fake := &fakeSidecar{}
+	srv.SetCloudSidecar(fake)
+
+	_, token := bootstrapAccountDeleteUser(t, srv, "") // no Stripe customer, no 2FA
+
+	rr := deleteAccountReq(srv, map[string]interface{}{"password": "correct-horse-battery-staple"}, token)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("delete-account: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if ct := rr.Header().Get("Content-Type"); !strings.Contains(ct, "application/json") {
+		t.Errorf("expected application/json Content-Type on success, got %q", ct)
+	}
+
+	var resp map[string]interface{}
+	parseJSON(t, rr, &resp)
+	if resp["ok"] != true {
+		t.Errorf("expected {\"ok\": true}, got %v", resp)
+	}
+	// Pin the envelope: the success body carries exactly one key. A stray
+	// extra field (error echo, message, user payload) would be a silent
+	// contract widening the UI never opted into.
+	if len(resp) != 1 {
+		t.Errorf("success body must be exactly {\"ok\": true}, got %d keys: %v", len(resp), resp)
+	}
+}
+
 // TestHandleDeleteAccount_TOTPEnabled_ValidCode — a 2FA-enabled account with
 // the correct password AND a valid TOTP code deletes successfully (200
 // {ok:true}) and the user row is gone.

--- a/web/e2e/account-delete.spec.ts
+++ b/web/e2e/account-delete.spec.ts
@@ -1,0 +1,228 @@
+import { test, expect, request as playwrightRequest } from '@playwright/test';
+import { suiteFixture } from './fixtures';
+
+/**
+ * Danger Zone — "Delete my account" (TASK-1962 / TASK-1963).
+ *
+ * These specs must NOT run under the shared admin Bearer context: the header
+ * from e2e/fixtures.ts would make every request auth as the suite admin, so a
+ * real delete would wipe the admin the rest of the suite depends on. Instead
+ * each test spins up a CLEAN context (no Bearer) and a throwaway user.
+ *
+ * Two branches of web/src/routes/console/settings/+page.svelte::deleteAccount
+ * are covered:
+ *   (b) password branch — the only branch a self-hosted server ever renders
+ *       (usePasswordBranch is true whenever cloud_mode is false). Driven
+ *       end-to-end against the real server: register → login → delete → the
+ *       account is really gone (admin user search no longer lists it).
+ *   (c) cloud OAuth-only typed-confirm branch — renders only when
+ *       cloud_mode === true AND password_set === false. The self-hosted e2e
+ *       binary reports neither, so we patch the two flag-bearing responses
+ *       (/auth/session, /auth/me) to flip just those flags, and stub the
+ *       delete transport (a self-host server 400s a confirm-only delete —
+ *       "password required"). The real server contract for both branches is
+ *       pinned in internal/server/handlers_account_test.go; this spec asserts
+ *       the UI branch selection + the post-delete /login redirect (d).
+ *
+ * These run on desktop-chromium only. The delete flow is viewport-agnostic,
+ * and running it on both projects doubles the hits to /auth/login and
+ * /auth/register — both IP-rate-limited (burst 5; see middleware_ratelimit.go)
+ * — which flaked the suite under Playwright's parallel load.
+ */
+
+// A password that satisfies validatePasswordStrength (see
+// internal/server/handlers_auth.go) and isn't derivable from the email/name.
+const THROWAWAY_PASSWORD = 'Playwright-Delete-2026!';
+
+// A collision-safe email + username. The username is passed explicitly to the
+// register call: letting the server auto-generate one from the display name
+// risked a UNIQUE-constraint 500 across concurrent runs.
+function throwawayIdentity(tag: string): { email: string; username: string } {
+	const suffix = `${tag}${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`;
+	return { email: `e2e-del-${suffix}@example.com`, username: `e2edel${suffix}` };
+}
+
+// Create a verified, password-holding user via the admin-authenticated
+// register endpoint. Admin-created accounts stay verified (handleRegister),
+// so the user can log in and reach settings immediately. Bearer auth exempts
+// the call from CSRF.
+async function createThrowawayUser(
+	baseURL: string,
+	adminToken: string,
+	identity: { email: string; username: string },
+	name: string
+): Promise<void> {
+	const api = await playwrightRequest.newContext({
+		baseURL,
+		extraHTTPHeaders: { Authorization: `Bearer ${adminToken}` }
+	});
+	try {
+		const resp = await api.post('/api/v1/auth/register', {
+			data: {
+				email: identity.email,
+				username: identity.username,
+				name,
+				password: THROWAWAY_PASSWORD
+			}
+		});
+		if (!resp.ok()) {
+			throw new Error(`register throwaway user failed (${resp.status()}): ${await resp.text()}`);
+		}
+	} finally {
+		await api.dispose();
+	}
+}
+
+// Log in through the real form. Sessions are User-Agent-bound (see
+// fixtures.ts); minting the session from the browser itself keeps the UA
+// consistent so it isn't silently rejected on the next request.
+async function loginViaForm(page: import('@playwright/test').Page, email: string): Promise<void> {
+	await page.goto('/login');
+	await page.getByPlaceholder('Email').fill(email);
+	await page.getByPlaceholder('Password').fill(THROWAWAY_PASSWORD);
+	await Promise.all([
+		page.waitForResponse(
+			(r) => r.url().includes('/api/v1/auth/login') && r.request().method() === 'POST'
+		),
+		page.getByRole('button', { name: /^sign in$/i }).click()
+	]);
+}
+
+test.describe('Danger Zone: delete my account', () => {
+	test.beforeEach(({}, testInfo) => {
+		test.skip(
+			testInfo.project.name !== 'desktop-chromium',
+			'Account-deletion flow is viewport-agnostic; run once (desktop) to avoid multiplying auth-endpoint rate-limit pressure across projects.'
+		);
+	});
+
+	test('password branch removes the account and redirects to /login', async ({ browser }) => {
+		const { baseURL, apiToken } = suiteFixture();
+		const identity = throwawayIdentity('pw');
+		await createThrowawayUser(baseURL, apiToken, identity, 'Delete PW');
+
+		const context = await browser.newContext({ baseURL });
+		try {
+			const page = await context.newPage();
+			await loginViaForm(page, identity.email);
+
+			await page.goto('/console/settings');
+
+			// Reveal the confirm block. Only the reveal button exists at this
+			// point (the "Permanently delete…" button appears after reveal), so
+			// an exact name match is unambiguous.
+			await page.getByRole('button', { name: 'Delete my account', exact: true }).click();
+
+			// Self-host always uses the password branch.
+			await page.locator('#delete-password').fill(THROWAWAY_PASSWORD);
+			await page.getByRole('button', { name: 'Permanently delete my account' }).click();
+
+			// (d) On success the server clears the cookies and the client
+			// hard-navigates to /login.
+			await page.waitForURL('**/login', { timeout: 15_000 });
+			expect(new URL(page.url()).pathname).toBe('/login');
+		} finally {
+			await context.close();
+		}
+
+		// The account is really gone: an admin user search no longer lists it.
+		// (A GET on the generous API limiter, so it adds no /auth rate pressure.)
+		const admin = await playwrightRequest.newContext({
+			baseURL,
+			extraHTTPHeaders: { Authorization: `Bearer ${apiToken}` }
+		});
+		try {
+			const resp = await admin.get(
+				`/api/v1/admin/users?q=${encodeURIComponent(identity.email)}`
+			);
+			expect(resp.ok()).toBeTruthy();
+			const body = (await resp.json()) as { users?: Array<{ email: string }> };
+			const emails = (body.users ?? []).map((u) => u.email);
+			expect(emails).not.toContain(identity.email);
+		} finally {
+			await admin.dispose();
+		}
+	});
+
+	test('cloud OAuth-only typed-confirm branch redirects to /login', async ({ browser }) => {
+		const { baseURL, apiToken } = suiteFixture();
+		const identity = throwawayIdentity('cloud');
+		await createThrowawayUser(baseURL, apiToken, identity, 'Delete Cloud');
+
+		const context = await browser.newContext({ baseURL });
+		try {
+			const page = await context.newPage();
+
+			// Real login first, so every un-mocked layout/settings request is
+			// genuinely authenticated (no 401 → /login bounce).
+			await loginViaForm(page, identity.email);
+
+			// The delete is stubbed (below), so the real session stays valid —
+			// which would make the post-delete /login page see authenticated:true
+			// and bounce back to /console, racing the assertion. Flip the mocked
+			// session to authenticated:false once the delete fires so /login stays.
+			let deleted = false;
+			let deletePayload: Record<string, unknown> | null = null;
+
+			// Force the cloud OAuth-only shape by patching only the flags that
+			// select the typed-confirm branch; every other real field is kept.
+			await page.route('**/api/v1/auth/session', async (route) => {
+				const resp = await route.fetch();
+				const body = await resp.json();
+				body.cloud_mode = true;
+				if (deleted) {
+					body.authenticated = false;
+					body.user = null;
+				}
+				await route.fulfill({
+					status: 200,
+					contentType: 'application/json',
+					body: JSON.stringify(body)
+				});
+			});
+			await page.route('**/api/v1/auth/me', async (route) => {
+				const resp = await route.fetch();
+				const body = await resp.json();
+				body.password_set = false;
+				await route.fulfill({
+					status: 200,
+					contentType: 'application/json',
+					body: JSON.stringify(body)
+				});
+			});
+
+			// A self-host server 400s a confirm-only delete ("password required"),
+			// so stub the transport at 200 {ok:true}. The real server contract is
+			// covered by the Go handler tests; here we assert the UI branch + the
+			// confirm-only payload + the success→/login redirect.
+			await page.route('**/api/v1/auth/delete-account', async (route) => {
+				deletePayload = route.request().postDataJSON();
+				deleted = true;
+				await route.fulfill({
+					status: 200,
+					contentType: 'application/json',
+					body: JSON.stringify({ ok: true })
+				});
+			});
+
+			await page.goto('/console/settings');
+
+			await page.getByRole('button', { name: 'Delete my account', exact: true }).click();
+
+			// Typed-confirm branch: the password input is absent; a text confirm
+			// input is shown instead.
+			await expect(page.locator('#delete-password')).toHaveCount(0);
+			await page.locator('#delete-confirm').fill('DELETE');
+			await page.getByRole('button', { name: 'Permanently delete my account' }).click();
+
+			await page.waitForURL('**/login', { timeout: 15_000 });
+			expect(new URL(page.url()).pathname).toBe('/login');
+
+			// The OAuth-only account sends confirm:true and NO password.
+			expect(deletePayload).toMatchObject({ confirm: true });
+			expect(deletePayload?.password).toBeUndefined();
+		} finally {
+			await context.close();
+		}
+	});
+});

--- a/web/e2e/account-export.spec.ts
+++ b/web/e2e/account-export.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from './fixtures';
+
+/**
+ * Danger Zone — "Export my data" (TASK-1961 / TASK-1963).
+ *
+ * Uses the shared authenticated fixture (admin Bearer header applied to the
+ * context). The export endpoint is read-only, so exercising it as the suite
+ * admin is safe and touches no other spec's state.
+ *
+ * The client (web/src/lib/utils/artifacts.ts::exportAndDownloadAccountData)
+ * GETs /api/v1/auth/export, then triggers a Blob download named from the
+ * server's Content-Disposition. We assert the download fires with the
+ * contract filename and that the success line renders — proving the client
+ * saw a 200 and parsed the artifact. The exact header + JSON shape are pinned
+ * server-side in internal/server/handlers_account_export_contract_test.go.
+ */
+test('Danger Zone: Export my data downloads pad-export.json', async ({ page }) => {
+	await page.goto('/console/settings');
+
+	const exportBtn = page.getByRole('button', { name: 'Export my data', exact: true });
+	await expect(exportBtn).toBeVisible();
+
+	const [download] = await Promise.all([page.waitForEvent('download'), exportBtn.click()]);
+
+	// The filename the browser saves under comes straight from the server's
+	// `Content-Disposition: attachment; filename="pad-export.json"`.
+	expect(download.suggestedFilename()).toBe('pad-export.json');
+
+	await expect(page.getByText('Your data export has downloaded.')).toBeVisible();
+});


### PR DESCRIPTION
## What

Phase-4 test coverage for the account delete + export feature. **Tests only — no product code changed.**

### Backend contract tests (`internal/server`)
- **delete-account success body** — pin the exact `{ok:true}` envelope the UI consumes (`TestHandleDeleteAccount_SuccessBody`). The existing cascade/skip tests asserted only status 200; the web Danger Zone keys its "deleted → redirect to /login" transition off this body.
- **export happy-path artifact contract** — `TestExportAccount_HappyPath_ArtifactContract` decodes the body and asserts the exact `Content-Disposition: attachment; filename="pad-export.json"`, `application/json`, and the top-level `{user, workspaces}` shape with inline collections/items. Fills the TASK-508 gap and complements (does not duplicate) the BUG-1945 restricted-owner gate smoke test.
- **TOTP paths** (enabled+valid → 200, missing → `totp_required`, invalid → `totp_invalid`, non-TOTP unaffected) were already added in TASK-1958 — confirmed present, not duplicated.

### Web e2e (`web/e2e`, Playwright)
Settings Danger Zone:
- **(a) export download** — asserts the download fires with filename `pad-export.json` + the success line.
- **(b) delete — password branch** — real `register → login → delete`; deletion verified via the admin user search (row is gone).
- **(c) delete — cloud OAuth-only typed-confirm branch** — `/auth/session` + `/auth/me` flags patched to force `cloud_mode && !password_set`; the delete transport is stubbed (a self-host server 400s a confirm-only delete), and the confirm-only payload (`confirm:true`, no password) is asserted.
- **(d) post-delete redirect to `/login`** — asserted in both delete branches.

The delete specs run **desktop-chromium only** (the flow is viewport-agnostic; running on both projects doubled hits to the IP-rate-limited `/auth/login` + `/auth/register`, which flaked the suite under Playwright's parallel load).

## Why
Closes TASK-1963. Zero UI/e2e coverage existed for delete/export, and the delete-success + export-artifact response contracts were untested.

## Verification
- `go build ./...`, `golangci-lint run ./...` (0 issues), `go test ./internal/server/... -run 'Delete|Export|Account|TOTP' -v`, and full `go test ./...` — all green.
- **Playwright: ran locally and passed.** New specs green across 3 repeat runs plus a full-suite run; delete tests correctly skip on mobile-chromium. CI also runs Playwright.

## Coverage checklist
- [x] delete-account `200 {ok:true}` success body
- [x] TOTP enabled+valid / missing / invalid / non-TOTP (confirmed from TASK-1958)
- [x] export `Content-Disposition` + top-level JSON shape
- [x] e2e export download
- [x] e2e delete password branch
- [x] e2e delete cloud OAuth-only typed-confirm branch
- [x] e2e post-delete `/login` redirect

Out of scope (per task): large-export streaming/OOM robustness.

https://claude.ai/code/session_01HxBkAMiFBtCRJ2tKSCt3ST