### PR TITLE
feat(store): hard-purge soft-deleted workspaces after 30 days (TASK-1966)

### DIFF
--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -859,6 +859,24 @@ func serveCmd() *cobra.Command {
 			}
 			srv.StartTokenReaper()
 
+			// Workspace hard-purge sweeper (TASK-1966). Periodic sweep
+			// that hard-deletes workspaces soft-deleted more than 30 days
+			// ago — cascading every child row and reclaiming attachment
+			// blobs — to honor the /privacy 30-day GDPR erasure SLA.
+			// DeleteAccountAtomic / DeleteWorkspace only soft-delete
+			// (workspaces.deleted_at); nothing else ever expunges them.
+			// Defaults: 24h interval, 30-day retention — both override-
+			// able via env (PAD_WORKSPACE_PURGE_INTERVAL=1m /
+			// PAD_WORKSPACE_PURGE_RETENTION=1s for tests/CI). Must run
+			// AFTER the attachment registry is wired (above) so blob
+			// reclamation has a backend.
+			wsPurgeInterval := parseDurationEnv("PAD_WORKSPACE_PURGE_INTERVAL", 0)
+			wsPurgeRetention := parseDurationEnv("PAD_WORKSPACE_PURGE_RETENTION", 0)
+			if wsPurgeInterval != 0 || wsPurgeRetention != 0 {
+				srv.SetWorkspacePurgeConfig(wsPurgeInterval, wsPurgeRetention)
+			}
+			srv.StartWorkspacePurgeSweeper()
+
 			// Attach webhook dispatcher for outgoing notifications
 			srv.SetWebhookDispatcher(webhooks.NewDispatcher(s))
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -182,6 +182,13 @@ type Server struct {
 	// stopTokenReaper.
 	tokenReaper tokenReaperConfig
 
+	// workspacePurge holds the periodic-sweep config + lifecycle for the
+	// soft-deleted-workspace hard-purge sweeper (TASK-1966 — the 30-day
+	// GDPR erasure SLA). Mirrors orphanGC. Configured via
+	// SetWorkspacePurgeConfig + started via StartWorkspacePurgeSweeper;
+	// Stop() signals the loop via stopWorkspacePurgeSweeper.
+	workspacePurge workspacePurgeConfig
+
 	// inFlightUploadHashes tracks content_hash values for uploads
 	// that have called AttachmentStore.Put but not yet inserted the
 	// attachments row. Without this, the orphan GC could delete a
@@ -268,6 +275,9 @@ func (s *Server) Stop() {
 	// Short-lived-credential reaper (PLAN-1933 DR-5 / TASK-1936). Same
 	// lifecycle pattern; signal BEFORE Wait() so the goroutine exits.
 	s.stopTokenReaper()
+	// Soft-deleted-workspace hard-purge sweeper (TASK-1966). Same
+	// lifecycle pattern; signal BEFORE Wait() so the goroutine exits.
+	s.stopWorkspacePurgeSweeper()
 	// MCP audit writer / sweeper run on s.bg too. Signal first so
 	// the workers see the close BEFORE Wait() blocks; without the
 	// signal Wait would hang forever on the writer's blocking

--- a/internal/server/workspace_purge.go
+++ b/internal/server/workspace_purge.go
@@ -1,0 +1,340 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/store"
+)
+
+// Scheduled hard-purge of soft-deleted workspaces (TASK-1966).
+//
+// The published /privacy policy promises "personal account data and
+// workspaces you solely own are removed from our live systems within 30
+// days." Account deletion (DeleteAccountAtomic) and manual workspace
+// deletion (DeleteWorkspace) only SOFT-delete a workspace — they stamp
+// workspaces.deleted_at and leave every item/comment/attachment row in
+// place indefinitely. This sweeper honors the promise: it hard-deletes
+// soft-deleted workspaces past the retention window, cascading every
+// child row (via store.PurgeWorkspaceData) and reclaiming attachment
+// blobs through the storage abstraction (FS + S3 safe).
+//
+// Modeled on the orphan-GC sweeper (orphan_gc.go): its own periodic
+// loop tracked by s.bg, an env-overridable interval + retention for
+// tests, failure isolation per workspace, and blob reclamation that
+// reuses the orphan GC's content-addressed dedupe + in-flight-upload
+// guards. Runs on every deployment (self-host and cloud), mirroring the
+// orphan GC, which already hard-reclaims soft-deleted attachment blobs
+// on the same 30-day horizon everywhere.
+
+const (
+	// workspacePurgeRetention is the age a workspace's deleted_at must
+	// exceed before it is hard-purged. 30 days matches the /privacy
+	// erasure SLA — keep the two in lockstep.
+	workspacePurgeRetention = 30 * 24 * time.Hour
+
+	// defaultWorkspacePurgeInterval is how often the sweep runs. Daily,
+	// matching the orphan GC and MCP-audit retention sweepers.
+	defaultWorkspacePurgeInterval = 24 * time.Hour
+)
+
+// workspacePurgeResult records what one sweep accomplished — returned
+// from runWorkspacePurgeSweep so tests can assert on the counters and
+// the periodic logger can summarize a run in one line.
+type workspacePurgeResult struct {
+	Eligible       int   // workspaces matched by the eligibility query
+	Purged         int   // workspaces fully purged (DB rows removed)
+	BlobsReclaimed int   // on-disk/S3 blobs Delete'd through the backend
+	BytesReclaimed int64 // sum of size_bytes for reclaimed blobs
+	Skipped        int   // workspaces skipped due to a mid-sweep error
+}
+
+// workspacePurgeConfig captures the runtime knobs + lifecycle for the
+// periodic loop. Mirrors orphanGCConfig / tokenReaperConfig.
+type workspacePurgeConfig struct {
+	mu        sync.Mutex
+	interval  time.Duration
+	retention time.Duration
+	stop      chan struct{}
+	running   bool
+}
+
+// SetWorkspacePurgeConfig overrides the default sweep interval (24h) and
+// retention window (30d). Pass 0 for either to keep the package default.
+// Must be called before StartWorkspacePurgeSweeper.
+func (s *Server) SetWorkspacePurgeConfig(interval, retention time.Duration) {
+	s.workspacePurge.mu.Lock()
+	defer s.workspacePurge.mu.Unlock()
+	if interval > 0 {
+		s.workspacePurge.interval = interval
+	}
+	if retention > 0 {
+		s.workspacePurge.retention = retention
+	}
+}
+
+// StartWorkspacePurgeSweeper kicks off the periodic sweep loop.
+// Idempotent — calling twice is a no-op. Must be called AFTER
+// SetAttachments; the sweep no-ops (and logs) when the registry isn't
+// wired so a server without attachment storage doesn't purge workspaces
+// whose blobs it couldn't reclaim.
+//
+// Started from the real server bootstrap path (cmd/pad/main.go), NOT
+// from Server.New, so unit tests that construct a Server don't spawn a
+// background goroutine unless they opt in (mirrors StartOrphanGC). The
+// loop is tracked by Server.bg so Stop() drains it before the process
+// exits / the DB is closed (BUG-842 invariant).
+func (s *Server) StartWorkspacePurgeSweeper() {
+	s.workspacePurge.mu.Lock()
+	if s.workspacePurge.running {
+		s.workspacePurge.mu.Unlock()
+		return
+	}
+	if s.workspacePurge.interval == 0 {
+		s.workspacePurge.interval = defaultWorkspacePurgeInterval
+	}
+	if s.workspacePurge.retention == 0 {
+		s.workspacePurge.retention = workspacePurgeRetention
+	}
+	s.workspacePurge.stop = make(chan struct{})
+	s.workspacePurge.running = true
+	interval := s.workspacePurge.interval
+	retention := s.workspacePurge.retention
+	stop := s.workspacePurge.stop
+	s.workspacePurge.mu.Unlock()
+
+	slog.Info("workspace purge sweeper started",
+		"interval", interval.String(), "retention", retention.String())
+
+	s.bg.Add(1)
+	go func() {
+		defer s.bg.Done()
+		// One sweep on startup so a long-stopped server catches up
+		// immediately rather than waiting a full interval.
+		s.runWorkspacePurgeTick(retention)
+		t := time.NewTicker(interval)
+		defer t.Stop()
+		for {
+			select {
+			case <-stop:
+				return
+			case <-t.C:
+				s.runWorkspacePurgeTick(retention)
+			}
+		}
+	}()
+}
+
+// stopWorkspacePurgeSweeper signals the loop to exit. Called from
+// Server.Stop(). Safe to call when the loop never started.
+func (s *Server) stopWorkspacePurgeSweeper() {
+	s.workspacePurge.mu.Lock()
+	defer s.workspacePurge.mu.Unlock()
+	if !s.workspacePurge.running {
+		return
+	}
+	close(s.workspacePurge.stop)
+	s.workspacePurge.running = false
+}
+
+// runWorkspacePurgeTick runs one tick of the periodic loop, wrapped with
+// a 30-minute cap so a large sweep can't pin the goroutine across
+// intervals. Logged at info on any purge, warn on failure, quiet when
+// there is nothing to do.
+func (s *Server) runWorkspacePurgeTick(retention time.Duration) {
+	if s.attachments == nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	defer cancel()
+	cutoff := time.Now().UTC().Add(-retention)
+	res, err := s.runWorkspacePurgeSweep(ctx, cutoff)
+	if err != nil {
+		slog.Warn("workspace purge sweep failed", "error", err)
+		return
+	}
+	if res.Purged > 0 || res.Skipped > 0 {
+		slog.Info("workspace purge sweep",
+			"eligible", res.Eligible,
+			"purged", res.Purged,
+			"blobs_reclaimed", res.BlobsReclaimed,
+			"bytes_reclaimed", res.BytesReclaimed,
+			"skipped", res.Skipped,
+			"cutoff", cutoff.Format(time.RFC3339))
+	}
+}
+
+// runWorkspacePurgeSweep purges every workspace whose deleted_at is
+// older than cutoff. Blobs are reclaimed BEFORE the DB rows are removed
+// so a failed reclamation never strands an orphaned blob: the DB purge
+// (which deletes the attachment rows) only runs once every physical blob
+// is confirmed gone-or-still-shared. For each eligible workspace it:
+//
+//  1. Loads the attachment rows (physical storage keys + sizes).
+//  2. Reclaims each unique physical blob through the storage backend
+//     (FS + S3 safe via Registry.Resolve). A blob is deleted only when
+//     no OTHER workspace references that exact storage_key
+//     (content-addressed dedupe) and no upload of its content hash is in
+//     flight. Anything that can't be reclaimed this tick — a transient
+//     backend error OR an in-flight upload — DEFERS the whole workspace:
+//     its DB rows are left in place and it stays eligible, so the next
+//     tick retries. AttachmentStore.Delete is idempotent (missing key =
+//     success), so retries self-heal after a crash between reclaim and
+//     purge.
+//  3. Only when all blobs are reclaimed-or-shared, runs
+//     store.PurgeWorkspaceData in a single transaction (cascades every
+//     child row + the workspace row). PurgeWorkspaceData refuses to
+//     touch anything that isn't soft-deleted, so a live workspace is
+//     never at risk even if the eligibility list were stale.
+//
+// Failures are isolated per workspace — a bad/deferred workspace
+// increments Skipped and the sweep continues, so a single failure never
+// wedges the loop. A context error (shutdown / timeout) stops the sweep
+// and returns what was done so far.
+func (s *Server) runWorkspacePurgeSweep(ctx context.Context, cutoff time.Time) (*workspacePurgeResult, error) {
+	if s.attachments == nil {
+		return nil, errors.New("attachments registry not configured")
+	}
+	res := &workspacePurgeResult{}
+
+	candidates, err := s.store.ListPurgeableWorkspaces(cutoff)
+	if err != nil {
+		return nil, err
+	}
+	res.Eligible = len(candidates)
+
+	for _, c := range candidates {
+		if err := ctx.Err(); err != nil {
+			return res, err
+		}
+
+		blobs, err := s.store.WorkspaceAttachmentBlobs(c.ID)
+		if err != nil {
+			slog.Warn("workspace purge: load attachment blobs failed",
+				"workspace_id", c.ID, "slug", c.Slug, "error", err)
+			res.Skipped++
+			continue
+		}
+
+		// Reclaim blobs FIRST. If anything can't be reclaimed this tick,
+		// defer the whole workspace (leave its rows so it's retried) —
+		// this is what keeps a transient backend failure from orphaning a
+		// blob the DB no longer references.
+		if !s.reclaimWorkspaceBlobs(ctx, c, blobs, res) {
+			res.Skipped++
+			continue
+		}
+
+		// Every blob is gone (or still shared by another workspace) — now
+		// it's safe to remove the DB rows.
+		if err := s.store.PurgeWorkspaceData(c.ID); err != nil {
+			slog.Warn("workspace purge: cascade delete failed",
+				"workspace_id", c.ID, "slug", c.Slug, "error", err)
+			res.Skipped++
+			continue
+		}
+		res.Purged++
+	}
+
+	return res, nil
+}
+
+// reclaimWorkspaceBlobs deletes every physical blob owned solely by
+// workspace c, returning true only when the workspace is safe to purge —
+// i.e. every blob was either deleted or is legitimately retained because
+// another workspace still references the same storage_key. It returns
+// false (defer this workspace to a later tick) on ANY transient
+// condition: a backend/count error, or a content hash with an upload in
+// flight. Counters land on res.
+//
+// Dedupe is tracked by physical storage_key, not content_hash, so a blob
+// stored under two keys (mixed FS/S3 backends) is reclaimed once per
+// physical object rather than once per hash.
+//
+// Single-instance assumption. The sweep runs as ONE goroutine per
+// process and processes candidates sequentially, so two workspaces
+// sharing a storage_key are handled in order: the first sees the second
+// still referencing the blob (others > 0, retained) and the second — its
+// only remaining sharer now purged — deletes it. The shared blob is thus
+// reclaimed by the last sharer. This is correct for Pad's single-instance
+// deployment (CLAUDE.md: "single-instance everywhere" for v1). Two
+// separate server PROCESSES sweeping concurrently could both observe the
+// other's row and both skip the delete, orphaning the physical blob — the
+// same cross-process limitation the orphan GC has (its inFlightHashes
+// guard is a per-process mutex, not distributed). A distributed purge
+// lock / backend-enumeration reclaimer is deferred with multi-instance
+// support (out of scope for v1).
+func (s *Server) reclaimWorkspaceBlobs(ctx context.Context, c store.WorkspacePurgeCandidate, blobs []models.Attachment, res *workspacePurgeResult) bool {
+	reclaimed := make(map[string]bool) // storage_key -> deleted this call
+	for _, a := range blobs {
+		if reclaimed[a.StorageKey] {
+			continue
+		}
+
+		// Dedupe guard: another workspace may still point at this exact
+		// physical object. This workspace's own rows still exist (we
+		// haven't purged yet), and the query excludes workspace_id = c.ID,
+		// so only OTHER workspaces count.
+		others, err := s.store.CountAttachmentsForStorageKeyOutsideWorkspace(a.StorageKey, c.ID)
+		if err != nil {
+			slog.Warn("workspace purge: count protecting refs failed",
+				"workspace_id", c.ID, "storage_key", a.StorageKey, "error", err)
+			return false
+		}
+		if others > 0 {
+			// Physical blob is still shared — leave it; purging this
+			// workspace's rows is safe, the other workspace keeps the
+			// blob alive.
+			reclaimed[a.StorageKey] = true
+			continue
+		}
+
+		// Critical section: hold the in-flight mutex across the
+		// uploadInFlight check AND the backend Delete so a concurrent
+		// markUploadInFlight (an upload of the same content to another
+		// workspace, Put done but row not yet inserted) blocks until we
+		// finish — closing the TOCTOU window the orphan GC documents.
+		s.inFlightHashesMu.Lock()
+		inFlight := s.inFlightHashes[a.ContentHash] > 0
+		var delErr error
+		deleted := false
+		if !inFlight {
+			backend, resolveErr := s.attachments.Resolve(a.StorageKey)
+			if resolveErr != nil {
+				delErr = resolveErr
+			} else if e := backend.Delete(ctx, a.StorageKey); e != nil {
+				// Delete of a missing key is NOT an error per the
+				// AttachmentStore contract, so this is a real IO/
+				// permission failure.
+				delErr = e
+			} else {
+				deleted = true
+			}
+		}
+		s.inFlightHashesMu.Unlock()
+
+		if inFlight {
+			// An upload of this content is racing us — defer so we don't
+			// delete a blob it's about to depend on, and don't purge rows
+			// while its physical object is in doubt. Retried next tick.
+			slog.Info("workspace purge: deferring — upload in flight",
+				"workspace_id", c.ID, "storage_key", a.StorageKey)
+			return false
+		}
+		if delErr != nil {
+			slog.Warn("workspace purge: blob delete failed, deferring workspace",
+				"workspace_id", c.ID, "storage_key", a.StorageKey, "error", delErr)
+			return false
+		}
+		if deleted {
+			reclaimed[a.StorageKey] = true
+			res.BlobsReclaimed++
+			res.BytesReclaimed += a.SizeBytes
+		}
+	}
+	return true
+}

--- a/internal/server/workspace_purge_test.go
+++ b/internal/server/workspace_purge_test.go
@@ -1,0 +1,275 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/attachments"
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// deleteControlledStore is a minimal AttachmentStore whose Delete result
+// is scriptable, so a test can force a backend failure (transient FS/S3
+// error) and then flip it to success to prove retry self-heals. Only
+// Delete is exercised by the purge sweeper; the rest return errors so a
+// stray call is loud.
+type deleteControlledStore struct{ deleteErr error }
+
+func (d *deleteControlledStore) Put(context.Context, string, string, io.Reader) (string, error) {
+	return "", errors.New("deleteControlledStore: Put not supported")
+}
+func (d *deleteControlledStore) Get(context.Context, string) (io.ReadCloser, error) {
+	return nil, errors.New("deleteControlledStore: Get not supported")
+}
+func (d *deleteControlledStore) Stat(context.Context, string) (int64, error) {
+	return 0, errors.New("deleteControlledStore: Stat not supported")
+}
+func (d *deleteControlledStore) Delete(context.Context, string) error { return d.deleteErr }
+
+// softDeleteWorkspaceAt stamps a workspace's deleted_at to a specific
+// time so the sweep's age cutoff can be exercised deterministically —
+// there's no API to backdate. Server tests run on SQLite, so raw "?"
+// placeholders are fine (mirrors orphan_gc_test.go).
+func softDeleteWorkspaceAt(t *testing.T, srv *Server, wsID string, at time.Time) {
+	t.Helper()
+	ts := at.UTC().Format(time.RFC3339)
+	if _, err := srv.store.DB().Exec(
+		`UPDATE workspaces SET deleted_at = ? WHERE id = ?`, ts, wsID,
+	); err != nil {
+		t.Fatalf("soft-delete backdate: %v", err)
+	}
+}
+
+func blobPresent(t *testing.T, srv *Server, storageKey string) bool {
+	t.Helper()
+	store, err := srv.attachments.Resolve(storageKey)
+	if err != nil {
+		t.Fatalf("resolve backend: %v", err)
+	}
+	_, err = store.Stat(context.Background(), storageKey)
+	if err == nil {
+		return true
+	}
+	if errors.Is(err, attachments.ErrNotFound) {
+		return false
+	}
+	t.Fatalf("stat blob: %v", err)
+	return false
+}
+
+// TestWorkspacePurgeSweep_PurgesEligibleReclaimsBlob is the main case:
+// a workspace soft-deleted past the retention window is hard-deleted and
+// its attachment blob reclaimed through the storage backend.
+func TestWorkspacePurgeSweep_PurgesEligibleReclaimsBlob(t *testing.T) {
+	srv, slug := testServerWithAttachments(t)
+
+	if rr := doMultipartUpload(srv, slug, "doomed.png", realPNG()); rr.Code != 201 {
+		t.Fatalf("upload: %d %s", rr.Code, rr.Body.String())
+	}
+	wsID := workspaceIDForSlug(t, srv, slug)
+	attID := getOnlyAttachmentID(t, srv, wsID)
+	att, err := srv.store.GetAttachment(attID)
+	if err != nil || att == nil {
+		t.Fatalf("GetAttachment: %v", err)
+	}
+	storageKey := att.StorageKey
+	if !blobPresent(t, srv, storageKey) {
+		t.Fatalf("blob missing before sweep")
+	}
+
+	// Soft-deleted 31 days ago → eligible for a 30-day cutoff.
+	softDeleteWorkspaceAt(t, srv, wsID, time.Now().Add(-31*24*time.Hour))
+
+	res, err := srv.runWorkspacePurgeSweep(context.Background(), time.Now().Add(-30*24*time.Hour))
+	if err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	if res.Purged != 1 {
+		t.Errorf("Purged=%d, want 1", res.Purged)
+	}
+	if res.BlobsReclaimed < 1 {
+		t.Errorf("BlobsReclaimed=%d, want >= 1", res.BlobsReclaimed)
+	}
+
+	// Workspace row gone (query bypasses the deleted_at filter).
+	var n int
+	if err := srv.store.DB().QueryRow(`SELECT COUNT(*) FROM workspaces WHERE id = ?`, wsID).Scan(&n); err != nil {
+		t.Fatalf("count workspace: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("workspace row still present after purge")
+	}
+	// Attachment row gone + blob reclaimed.
+	if got, _ := srv.store.GetAttachment(attID); got != nil {
+		t.Errorf("attachment row still present after purge")
+	}
+	if blobPresent(t, srv, storageKey) {
+		t.Errorf("blob still on disk after purge")
+	}
+}
+
+// TestWorkspacePurgeSweep_LeavesRecentAndLiveUntouched pins the
+// no-over-purge guarantee: a workspace soft-deleted inside the window
+// and a live workspace are both invisible to the sweep.
+func TestWorkspacePurgeSweep_LeavesRecentAndLiveUntouched(t *testing.T) {
+	srv, liveSlug := testServerWithAttachments(t)
+	liveWS := workspaceIDForSlug(t, srv, liveSlug)
+
+	recentSlug := createWSForTest(t, srv)
+	recentWS := workspaceIDForSlug(t, srv, recentSlug)
+	// Soft-deleted only 29 days ago — inside the 30-day window.
+	softDeleteWorkspaceAt(t, srv, recentWS, time.Now().Add(-29*24*time.Hour))
+
+	res, err := srv.runWorkspacePurgeSweep(context.Background(), time.Now().Add(-30*24*time.Hour))
+	if err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	if res.Eligible != 0 || res.Purged != 0 {
+		t.Errorf("expected nothing eligible/purged, got eligible=%d purged=%d", res.Eligible, res.Purged)
+	}
+
+	for _, id := range []string{liveWS, recentWS} {
+		var n int
+		if err := srv.store.DB().QueryRow(`SELECT COUNT(*) FROM workspaces WHERE id = ?`, id).Scan(&n); err != nil {
+			t.Fatalf("count workspace: %v", err)
+		}
+		if n != 1 {
+			t.Errorf("workspace %s should be untouched, got %d rows", id, n)
+		}
+	}
+}
+
+// TestWorkspacePurgeSweep_CrossWorkspaceDedupKeepsSharedBlob pins the
+// content-addressed safety: purging one workspace must NOT delete a blob
+// that a different workspace still references (identical bytes dedupe to
+// one physical blob).
+func TestWorkspacePurgeSweep_CrossWorkspaceDedupKeepsSharedBlob(t *testing.T) {
+	srv, doomedSlug := testServerWithAttachments(t)
+	keeperSlug := createWSForTest(t, srv)
+
+	// Same bytes uploaded to both workspaces → shared content_hash → one
+	// physical blob.
+	if rr := doMultipartUpload(srv, doomedSlug, "shared.png", realPNG()); rr.Code != 201 {
+		t.Fatalf("upload doomed: %d %s", rr.Code, rr.Body.String())
+	}
+	if rr := doMultipartUpload(srv, keeperSlug, "shared.png", realPNG()); rr.Code != 201 {
+		t.Fatalf("upload keeper: %d %s", rr.Code, rr.Body.String())
+	}
+
+	doomedWS := workspaceIDForSlug(t, srv, doomedSlug)
+	keeperWS := workspaceIDForSlug(t, srv, keeperSlug)
+	keeperAtt, err := srv.store.GetAttachment(getOnlyAttachmentID(t, srv, keeperWS))
+	if err != nil || keeperAtt == nil {
+		t.Fatalf("GetAttachment keeper: %v", err)
+	}
+	sharedKey := keeperAtt.StorageKey
+
+	softDeleteWorkspaceAt(t, srv, doomedWS, time.Now().Add(-31*24*time.Hour))
+
+	res, err := srv.runWorkspacePurgeSweep(context.Background(), time.Now().Add(-30*24*time.Hour))
+	if err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	if res.Purged != 1 {
+		t.Errorf("Purged=%d, want 1", res.Purged)
+	}
+	if res.BlobsReclaimed != 0 {
+		t.Errorf("BlobsReclaimed=%d, want 0 — shared blob must survive", res.BlobsReclaimed)
+	}
+
+	// Keeper workspace + its attachment + the shared blob all intact.
+	if got, _ := srv.store.GetAttachment(keeperAtt.ID); got == nil {
+		t.Errorf("keeper attachment row wrongly removed")
+	}
+	if !blobPresent(t, srv, sharedKey) {
+		t.Errorf("shared blob wrongly deleted while keeper still references it")
+	}
+}
+
+// TestWorkspacePurgeSweep_BlobFailureDefersNoOrphan is the P1 guard: if
+// a blob can't be reclaimed (transient backend error), the workspace is
+// DEFERRED — its DB rows are left intact so it stays eligible — rather
+// than purged into an orphaned blob. A subsequent sweep with a healthy
+// backend then completes the purge (idempotent self-heal).
+func TestWorkspacePurgeSweep_BlobFailureDefersNoOrphan(t *testing.T) {
+	srv, slug := testServerWithAttachments(t)
+	wsID := workspaceIDForSlug(t, srv, slug)
+
+	// A blob whose backend Delete fails. Routed via a "ctl" prefix so
+	// Resolve dispatches to our scriptable store.
+	ctl := &deleteControlledStore{deleteErr: errors.New("s3 unavailable")}
+	srv.attachments.Register("ctl", ctl)
+	attID := "att-blobfail-1"
+	if err := srv.store.CreateAttachment(&models.Attachment{
+		ID: attID, WorkspaceID: wsID, UploadedBy: "tester",
+		StorageKey: "ctl:blob-1", ContentHash: "hash-1",
+		MimeType: "image/png", SizeBytes: 10, Filename: "x.png",
+	}); err != nil {
+		t.Fatalf("CreateAttachment: %v", err)
+	}
+	softDeleteWorkspaceAt(t, srv, wsID, time.Now().Add(-31*24*time.Hour))
+
+	cutoff := time.Now().Add(-30 * 24 * time.Hour)
+	res, err := srv.runWorkspacePurgeSweep(context.Background(), cutoff)
+	if err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	if res.Purged != 0 || res.Skipped != 1 {
+		t.Errorf("blob failure should defer: got purged=%d skipped=%d", res.Purged, res.Skipped)
+	}
+	// Workspace + attachment row must still exist — nothing orphaned.
+	var n int
+	if err := srv.store.DB().QueryRow(`SELECT COUNT(*) FROM workspaces WHERE id = ?`, wsID).Scan(&n); err != nil {
+		t.Fatalf("count workspace: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("deferred workspace row wrongly removed")
+	}
+	if got, _ := srv.store.GetAttachment(attID); got == nil {
+		t.Errorf("attachment row wrongly removed while its blob delete failed")
+	}
+
+	// Heal the backend; the retry now completes the purge.
+	ctl.deleteErr = nil
+	res, err = srv.runWorkspacePurgeSweep(context.Background(), cutoff)
+	if err != nil {
+		t.Fatalf("retry sweep: %v", err)
+	}
+	if res.Purged != 1 {
+		t.Errorf("retry should purge: got purged=%d skipped=%d", res.Purged, res.Skipped)
+	}
+	if err := srv.store.DB().QueryRow(`SELECT COUNT(*) FROM workspaces WHERE id = ?`, wsID).Scan(&n); err != nil {
+		t.Fatalf("count workspace: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("workspace not purged on healthy retry")
+	}
+}
+
+// TestWorkspacePurgeSweep_Idempotent pins that re-running the sweep after
+// everything eligible is purged is a clean no-op — a single run doesn't
+// wedge the loop and repeats are safe.
+func TestWorkspacePurgeSweep_Idempotent(t *testing.T) {
+	srv, slug := testServerWithAttachments(t)
+	wsID := workspaceIDForSlug(t, srv, slug)
+	softDeleteWorkspaceAt(t, srv, wsID, time.Now().Add(-31*24*time.Hour))
+
+	cutoff := time.Now().Add(-30 * 24 * time.Hour)
+	first, err := srv.runWorkspacePurgeSweep(context.Background(), cutoff)
+	if err != nil {
+		t.Fatalf("first sweep: %v", err)
+	}
+	if first.Purged != 1 {
+		t.Fatalf("first Purged=%d, want 1", first.Purged)
+	}
+	second, err := srv.runWorkspacePurgeSweep(context.Background(), cutoff)
+	if err != nil {
+		t.Fatalf("second sweep: %v", err)
+	}
+	if second.Eligible != 0 || second.Purged != 0 {
+		t.Errorf("second sweep not a no-op: eligible=%d purged=%d", second.Eligible, second.Purged)
+	}
+}

--- a/internal/store/migrations/073_workspace_deleted_at_idx.sql
+++ b/internal/store/migrations/073_workspace_deleted_at_idx.sql
@@ -1,0 +1,18 @@
+-- Migration 073: partial index on workspaces(deleted_at) for the
+-- soft-deleted-workspace hard-purge sweeper (TASK-1966).
+--
+-- The sweeper's eligibility query runs on every tick (daily):
+--   SELECT id, slug FROM workspaces
+--   WHERE deleted_at IS NOT NULL AND deleted_at < ?
+--   ORDER BY deleted_at
+--
+-- Without an index that is a full scan of the workspaces table. A
+-- PARTIAL index (WHERE deleted_at IS NOT NULL) keeps the index tiny —
+-- it only holds soft-deleted rows, which are a vanishing fraction of
+-- all workspaces — while still covering the cutoff range scan and the
+-- ORDER BY. Partial indexes are supported on both SQLite (>= 3.8.0) and
+-- PostgreSQL; mirrored in pgmigrations/051.
+
+CREATE INDEX IF NOT EXISTS idx_workspaces_deleted_at
+    ON workspaces(deleted_at)
+    WHERE deleted_at IS NOT NULL;

--- a/internal/store/pgmigrations/051_workspace_deleted_at_idx.sql
+++ b/internal/store/pgmigrations/051_workspace_deleted_at_idx.sql
@@ -1,0 +1,16 @@
+-- Migration 051 (Postgres): partial index on workspaces(deleted_at) for
+-- the soft-deleted-workspace hard-purge sweeper (TASK-1966). Mirrors
+-- SQLite migrations/073.
+--
+-- The sweeper's eligibility query runs daily:
+--   SELECT id, slug FROM workspaces
+--   WHERE deleted_at IS NOT NULL AND deleted_at < ?
+--   ORDER BY deleted_at
+--
+-- The partial predicate (WHERE deleted_at IS NOT NULL) keeps the index
+-- restricted to the handful of soft-deleted rows rather than every
+-- workspace, while still covering the cutoff range scan + ORDER BY.
+
+CREATE INDEX IF NOT EXISTS idx_workspaces_deleted_at
+    ON workspaces(deleted_at)
+    WHERE deleted_at IS NOT NULL;

--- a/internal/store/workspace_purge.go
+++ b/internal/store/workspace_purge.go
@@ -1,0 +1,276 @@
+package store
+
+import (
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// Hard-purge of soft-deleted workspaces (TASK-1966).
+//
+// Account deletion (DeleteAccountAtomic) and manual workspace deletion
+// (DeleteWorkspace) both only SOFT-delete a workspace — they stamp
+// workspaces.deleted_at and leave every item/comment/attachment/etc.
+// row in place. The published /privacy policy promises owned workspaces
+// are removed from live systems within 30 days, so a scheduled sweeper
+// (internal/server/workspace_purge.go) hard-deletes soft-deleted
+// workspaces past that window. These are the store-layer primitives it
+// drives:
+//
+//   - ListPurgeableWorkspaces — the eligibility query (soft-deleted +
+//     older than the cutoff). Purely additive; touches no live rows.
+//   - WorkspaceAttachmentBlobs — captures every attachment row's
+//     storage_key/content_hash/size BEFORE the DB purge so the server
+//     can reclaim on-disk/S3 blobs afterward (the DB rows are gone by
+//     then).
+//   - CountAttachmentsForHashOutsideWorkspace — the content-addressed
+//     dedupe guard: a blob shared by another workspace must NOT be
+//     deleted when this one is purged.
+//   - PurgeWorkspaceData — the transactional cascade that removes every
+//     child row (in FK-dependency order) and the workspace row itself.
+//
+// Both dialects: SQLite runs with `_pragma=foreign_keys(on)` and
+// Postgres always enforces FKs, so the delete order matters on both.
+// PurgeWorkspaceData explicitly deletes every child table rather than
+// leaning on ON DELETE CASCADE (most workspace FKs are RESTRICT/NO
+// ACTION, which would otherwise block the parent delete) — the same
+// posture DeleteAccountAtomic takes for the users FK graph.
+
+// WorkspacePurgeCandidate identifies a workspace eligible for hard
+// purge. Slug is carried for logging/observability only; ID is the key
+// PurgeWorkspaceData operates on.
+type WorkspacePurgeCandidate struct {
+	ID   string
+	Slug string
+}
+
+// ListPurgeableWorkspaces returns workspaces whose deleted_at is set and
+// older than cutoff — i.e. soft-deleted long enough ago to hard-purge.
+// Live workspaces (deleted_at IS NULL) are never returned, so a caller
+// can never purge a workspace that is still in use.
+//
+// deleted_at is stored as fixed-width RFC3339 UTC (see store.now()), so
+// the `< cutoff` comparison is a valid lexicographic ordering — the same
+// technique SweepMCPAuditOlderThan uses for its timestamp cutoff.
+func (s *Store) ListPurgeableWorkspaces(cutoff time.Time) ([]WorkspacePurgeCandidate, error) {
+	cutoffStr := cutoff.UTC().Format(time.RFC3339)
+	rows, err := s.db.Query(s.q(`
+		SELECT id, slug
+		FROM workspaces
+		WHERE deleted_at IS NOT NULL AND deleted_at < ?
+		ORDER BY deleted_at
+	`), cutoffStr)
+	if err != nil {
+		return nil, fmt.Errorf("list purgeable workspaces: %w", err)
+	}
+	defer rows.Close()
+
+	var out []WorkspacePurgeCandidate
+	for rows.Next() {
+		var c WorkspacePurgeCandidate
+		if err := rows.Scan(&c.ID, &c.Slug); err != nil {
+			return nil, fmt.Errorf("scan purgeable workspace: %w", err)
+		}
+		out = append(out, c)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate purgeable workspaces: %w", err)
+	}
+	return out, nil
+}
+
+// WorkspaceAttachmentBlobs returns every attachment row for a workspace —
+// originals AND thumbnail variants, live AND soft-deleted — so the purge
+// sweeper can reclaim their blobs. This deliberately does NOT filter on
+// deleted_at or parent_id (unlike WorkspaceAttachments): once the
+// workspace is purged, ALL its blobs must be considered for reclamation.
+//
+// Captured BEFORE PurgeWorkspaceData runs; afterward the rows are gone
+// and the storage_key/content_hash are unrecoverable.
+func (s *Store) WorkspaceAttachmentBlobs(workspaceID string) ([]models.Attachment, error) {
+	rows, err := s.db.Query(s.q(`
+		SELECT `+attachmentColumns+`
+		FROM attachments
+		WHERE workspace_id = ?
+	`), workspaceID)
+	if err != nil {
+		return nil, fmt.Errorf("workspace attachment blobs: %w", err)
+	}
+	defer rows.Close()
+
+	var out []models.Attachment
+	for rows.Next() {
+		a, err := scanAttachment(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan workspace attachment blob: %w", err)
+		}
+		out = append(out, *a)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate workspace attachment blobs: %w", err)
+	}
+	return out, nil
+}
+
+// CountAttachmentsForStorageKeyOutsideWorkspace counts attachment rows
+// in a DIFFERENT workspace that point at the same PHYSICAL blob
+// (storage_key). Attachments are content-addressed and deduped: two
+// workspaces uploading identical bytes to the same backend share one
+// physical object under one storage_key. Before the purge sweeper
+// deletes a blob it MUST confirm no other workspace still references
+// that exact storage_key — otherwise purging workspace A strands
+// workspace B's live attachment on a missing blob.
+//
+// Keyed on storage_key rather than content_hash so it stays correct
+// under mixed backends (FS + S3): identical bytes stored in two backends
+// have the same content_hash but DIFFERENT storage_keys and are distinct
+// physical objects — deleting one must not be gated on rows referencing
+// the other. storage_key is the physical identity; content_hash is not.
+//
+// Returns the count of protecting rows in OTHER workspaces; 0 means the
+// physical blob is safe to delete.
+func (s *Store) CountAttachmentsForStorageKeyOutsideWorkspace(storageKey, workspaceID string) (int, error) {
+	var n int
+	err := s.db.QueryRow(s.q(`
+		SELECT COUNT(*) FROM attachments
+		WHERE storage_key = ? AND workspace_id <> ?
+	`), storageKey, workspaceID).Scan(&n)
+	if err != nil {
+		return 0, fmt.Errorf("count attachments for storage key outside workspace: %w", err)
+	}
+	return n, nil
+}
+
+// purgeWorkspaceChildDeletes is the FK-dependency-ordered list of
+// statements that remove every workspace-scoped child row. Each query
+// takes a single workspace_id placeholder. Ordering rules (both SQLite
+// with foreign_keys=ON and Postgres enforce these):
+//
+//   - Item child rows (comments, item_versions, item_links, ...) before
+//     items — several carry RESTRICT FKs to items.
+//   - Collection child rows (views, collection_grants,
+//     member_collection_access) before collections; items before
+//     collections (items.collection_id is RESTRICT).
+//   - versions before documents (versions.document_id is RESTRICT).
+//   - comments before activities (comments.activity_id is RESTRICT).
+//   - Everything before the workspace row (handled by PurgeWorkspaceData).
+//
+// Self-referential RESTRICT columns (items.parent_id, comments.parent_id)
+// are NULLed first (see PurgeWorkspaceData) so a bulk DELETE can't trip
+// the constraint on SQLite, which checks NO ACTION FKs immediately
+// rather than at end-of-statement.
+//
+// mcp_audit_log.workspace_id is NULLed rather than deleted: it is a
+// user-scoped security audit log (rows may belong to other users who
+// accessed the workspace via MCP) under its own 90-day retention. NULLing
+// clears the RESTRICT FK to workspaces while preserving the audit trail —
+// the de-identify posture DeleteAccountAtomic uses for audit rows.
+var purgeWorkspaceChildDeletes = []struct{ what, query string }{
+	// --- item child rows (before items) ---
+	{"comment reactions", `DELETE FROM comment_reactions WHERE comment_id IN (SELECT id FROM comments WHERE workspace_id = ?)`},
+	{"comments", `DELETE FROM comments WHERE workspace_id = ?`},
+	{"item versions", `DELETE FROM item_versions WHERE item_id IN (SELECT id FROM items WHERE workspace_id = ?)`},
+	{"item links", `DELETE FROM item_links WHERE workspace_id = ?`},
+	{"item stars", `DELETE FROM item_stars WHERE item_id IN (SELECT id FROM items WHERE workspace_id = ?)`},
+	{"item yjs op-log", `DELETE FROM item_yjs_updates WHERE item_id IN (SELECT id FROM items WHERE workspace_id = ?)`},
+	{"item wiki links", `DELETE FROM item_wiki_links WHERE source_item_id IN (SELECT id FROM items WHERE workspace_id = ?)`},
+	{"item collection moves", `DELETE FROM item_collection_moves WHERE workspace_id = ?`},
+	{"item grants", `DELETE FROM item_grants WHERE workspace_id = ?`},
+	{"status transitions", `DELETE FROM status_transitions WHERE workspace_id = ?`},
+	// --- items (self-ref parent_id NULLed by PurgeWorkspaceData first) ---
+	{"items", `DELETE FROM items WHERE workspace_id = ?`},
+	// --- collection child rows (before collections) ---
+	{"views", `DELETE FROM views WHERE workspace_id = ?`},
+	{"collection grants", `DELETE FROM collection_grants WHERE workspace_id = ?`},
+	{"member collection access", `DELETE FROM member_collection_access WHERE workspace_id = ?`},
+	{"collections", `DELETE FROM collections WHERE workspace_id = ?`},
+	// --- documents child rows (before documents) ---
+	{"document versions", `DELETE FROM versions WHERE document_id IN (SELECT id FROM documents WHERE workspace_id = ?)`},
+	{"documents", `DELETE FROM documents WHERE workspace_id = ?`},
+	// --- remaining workspace-direct rows ---
+	{"agent roles", `DELETE FROM agent_roles WHERE workspace_id = ?`},
+	{"progress snapshots", `DELETE FROM progress_snapshots WHERE workspace_id = ?`},
+	{"webhooks", `DELETE FROM webhooks WHERE workspace_id = ?`},
+	{"workspace invitations", `DELETE FROM workspace_invitations WHERE workspace_id = ?`},
+	{"custom templates", `DELETE FROM custom_templates WHERE workspace_id = ?`},
+	{"workspace-scoped api tokens", `DELETE FROM api_tokens WHERE workspace_id = ?`},
+	{"share link views", `DELETE FROM share_link_views WHERE share_link_id IN (SELECT id FROM share_links WHERE workspace_id = ?)`},
+	{"share links", `DELETE FROM share_links WHERE workspace_id = ?`},
+	{"oauth connection workspaces", `DELETE FROM oauth_connection_workspaces WHERE workspace_id = ?`},
+	{"user report layouts", `DELETE FROM user_report_layouts WHERE workspace_id = ?`},
+	{"workspace members", `DELETE FROM workspace_members WHERE workspace_id = ?`},
+	{"attachments", `DELETE FROM attachments WHERE workspace_id = ?`},
+	{"detach mcp audit log", `UPDATE mcp_audit_log SET workspace_id = NULL WHERE workspace_id = ?`},
+	{"activities", `DELETE FROM activities WHERE workspace_id = ?`},
+}
+
+// PurgeWorkspaceData hard-deletes every child row of a soft-deleted
+// workspace and the workspace row itself, in a single transaction. Blob
+// bytes are NOT touched here — the caller reclaims them through the
+// attachment store abstraction after this commits (capture the rows via
+// WorkspaceAttachmentBlobs first).
+//
+// SAFETY: refuses to touch a workspace that is not soft-deleted. The
+// eligibility age check lives in ListPurgeableWorkspaces; this method
+// re-verifies deleted_at IS NOT NULL inside the transaction as
+// defense-in-depth so a misused/stale workspace ID can never destroy a
+// live workspace's data. If the workspace is missing or live, it returns
+// an error and rolls back without deleting anything.
+func (s *Store) PurgeWorkspaceData(workspaceID string) error {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("purge workspace: begin tx: %w", err)
+	}
+	defer tx.Rollback()
+
+	// Defense-in-depth: never purge a live workspace, even if handed a
+	// bad ID. deleted_at must be set.
+	var deletedAt sql.NullString
+	err = tx.QueryRow(s.q(`SELECT deleted_at FROM workspaces WHERE id = ?`), workspaceID).Scan(&deletedAt)
+	if err == sql.ErrNoRows {
+		return fmt.Errorf("purge workspace %s: not found", workspaceID)
+	}
+	if err != nil {
+		return fmt.Errorf("purge workspace %s: read deleted_at: %w", workspaceID, err)
+	}
+	if !deletedAt.Valid || deletedAt.String == "" {
+		return fmt.Errorf("purge workspace %s: refusing to purge live (non-soft-deleted) workspace", workspaceID)
+	}
+
+	// NULL self-referential RESTRICT columns before the bulk deletes so a
+	// single-statement DELETE can't hit a parent-before-child ordering
+	// violation on SQLite.
+	selfRefNulls := []struct{ what, query string }{
+		{"detach item parents", `UPDATE items SET parent_id = NULL WHERE workspace_id = ?`},
+		{"detach comment parents", `UPDATE comments SET parent_id = NULL WHERE workspace_id = ?`},
+	}
+	for _, stmt := range selfRefNulls {
+		if _, err := tx.Exec(s.q(stmt.query), workspaceID); err != nil {
+			return fmt.Errorf("purge workspace %s: %s: %w", workspaceID, stmt.what, err)
+		}
+	}
+
+	for _, stmt := range purgeWorkspaceChildDeletes {
+		if _, err := tx.Exec(s.q(stmt.query), workspaceID); err != nil {
+			return fmt.Errorf("purge workspace %s: %s: %w", workspaceID, stmt.what, err)
+		}
+	}
+
+	// Finally the workspace row. Guard on deleted_at again so a concurrent
+	// (hypothetical) un-delete between the read above and here can't let a
+	// live workspace slip through.
+	res, err := tx.Exec(s.q(`DELETE FROM workspaces WHERE id = ? AND deleted_at IS NOT NULL`), workspaceID)
+	if err != nil {
+		return fmt.Errorf("purge workspace %s: delete workspace row: %w", workspaceID, err)
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		return fmt.Errorf("purge workspace %s: workspace row not deleted (no longer soft-deleted?)", workspaceID)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("purge workspace %s: commit: %w", workspaceID, err)
+	}
+	return nil
+}

--- a/internal/store/workspace_purge_test.go
+++ b/internal/store/workspace_purge_test.go
@@ -1,0 +1,336 @@
+package store
+
+import (
+	"testing"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// seededWorkspace captures the IDs needed to assert — after a purge —
+// that no child row was orphaned. Item-scoped child tables (versions,
+// reactions, stars, ...) have no workspace_id, so they're checked
+// against the original parent IDs rather than a workspace filter: a
+// leaked row is only detectable that way once the parents are gone.
+type seededWorkspace struct {
+	wsID        string
+	slug        string
+	item1       string
+	item2       string
+	commentID   string
+	docID       string
+	shareLinkID string
+	mcpAuditID  string
+}
+
+// wsChildTables is every table carrying a workspace_id column that the
+// purge must clear (mcp_audit_log excluded — it's de-identified, not
+// deleted, and asserted separately). Used to prove "no orphans" (all
+// zero after purging a workspace) and "no over-purge" (all intact after
+// purging a DIFFERENT workspace).
+var wsChildTables = []string{
+	"items", "comments", "item_links", "item_collection_moves", "item_grants",
+	"collection_grants", "status_transitions", "views", "collections",
+	"documents", "agent_roles", "progress_snapshots", "webhooks",
+	"workspace_invitations", "custom_templates", "api_tokens", "share_links",
+	"oauth_connection_workspaces", "user_report_layouts",
+	"member_collection_access", "workspace_members", "attachments", "activities",
+}
+
+func (s *Store) mustExec(t *testing.T, query string, args ...interface{}) {
+	t.Helper()
+	if _, err := s.db.Exec(s.q(query), args...); err != nil {
+		t.Fatalf("seed exec %q: %v", query, err)
+	}
+}
+
+func (s *Store) countRows(t *testing.T, query string, args ...interface{}) int {
+	t.Helper()
+	var n int
+	if err := s.db.QueryRow(s.q(query), args...).Scan(&n); err != nil {
+		t.Fatalf("count %q: %v", query, err)
+	}
+	return n
+}
+
+// seedFullWorkspace inserts one row into every workspace-scoped child
+// table so a purge can be proven exhaustive. Raw inserts deliberately
+// omit columns that have defaults (including every JSONB column) so the
+// same statements run unchanged on SQLite and PostgreSQL.
+func seedFullWorkspace(t *testing.T, s *Store, u *models.User, name string) seededWorkspace {
+	t.Helper()
+
+	ws, err := s.CreateWorkspace(models.WorkspaceCreate{Name: name, OwnerID: u.ID})
+	if err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	coll := createTestCollection(t, s, ws.ID, "Tasks")
+	item1 := createTestItem(t, s, ws.ID, coll.ID, "Item One", "")
+	item2 := createTestItem(t, s, ws.ID, coll.ID, "Item Two", "")
+
+	if err := s.AddWorkspaceMember(ws.ID, u.ID, "owner"); err != nil {
+		t.Fatalf("add member: %v", err)
+	}
+
+	ts := now()
+	commentID := newID()
+	docID := newID()
+	shareLinkID := newID()
+	mcpAuditID := newID()
+	oauthReq := "conn-" + newID()
+
+	// comments + comment_reactions
+	s.mustExec(t, `INSERT INTO comments (id, item_id, workspace_id, body, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`,
+		commentID, item1.ID, ws.ID, "hi", ts, ts)
+	s.mustExec(t, `INSERT INTO comment_reactions (id, comment_id, emoji, created_at) VALUES (?, ?, ?, ?)`,
+		newID(), commentID, "👍", ts)
+
+	// item_versions / item_links / item_stars / item_yjs_updates /
+	// item_wiki_links / item_collection_moves / item_grants / status_transitions
+	s.mustExec(t, `INSERT INTO item_versions (id, item_id, content, created_at) VALUES (?, ?, ?, ?)`,
+		newID(), item1.ID, "v1", ts)
+	s.mustExec(t, `INSERT INTO item_links (id, workspace_id, source_id, target_id, created_at) VALUES (?, ?, ?, ?, ?)`,
+		newID(), ws.ID, item1.ID, item2.ID, ts)
+	s.mustExec(t, `INSERT INTO item_stars (user_id, item_id, created_at) VALUES (?, ?, ?)`,
+		u.ID, item1.ID, ts)
+	s.mustExec(t, `INSERT INTO item_yjs_updates (item_id, update_data, schema_version, created_at) VALUES (?, ?, ?, ?)`,
+		item1.ID, []byte{1, 2, 3}, "v1", ts)
+	s.mustExec(t, `INSERT INTO item_wiki_links (source_item_id, target_kind, position) VALUES (?, ?, ?)`,
+		item1.ID, "ref", 0)
+	s.mustExec(t, `INSERT INTO item_collection_moves (id, workspace_id, item_id, from_collection_id, to_collection_id, seq, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		newID(), ws.ID, item1.ID, coll.ID, coll.ID, 1, ts)
+	s.mustExec(t, `INSERT INTO item_grants (id, item_id, workspace_id, user_id, granted_by, created_at) VALUES (?, ?, ?, ?, ?, ?)`,
+		newID(), item1.ID, ws.ID, u.ID, u.ID, ts)
+	s.mustExec(t, `INSERT INTO status_transitions (id, item_id, workspace_id, collection_id, to_status, created_at) VALUES (?, ?, ?, ?, ?, ?)`,
+		newID(), item1.ID, ws.ID, coll.ID, "done", ts)
+
+	// collection_grants / views
+	s.mustExec(t, `INSERT INTO collection_grants (id, collection_id, workspace_id, user_id, granted_by, created_at) VALUES (?, ?, ?, ?, ?, ?)`,
+		newID(), coll.ID, ws.ID, u.ID, u.ID, ts)
+	s.mustExec(t, `INSERT INTO views (id, workspace_id, name, slug, view_type, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		newID(), ws.ID, "Board", "board", "kanban", ts, ts)
+
+	// member_collection_access (FK to workspace_members(ws,user))
+	s.mustExec(t, `INSERT INTO member_collection_access (workspace_id, user_id, collection_id, created_at) VALUES (?, ?, ?, ?)`,
+		ws.ID, u.ID, coll.ID, ts)
+
+	// documents + versions
+	s.mustExec(t, `INSERT INTO documents (id, workspace_id, title, slug, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`,
+		docID, ws.ID, "Doc", "doc", ts, ts)
+	s.mustExec(t, `INSERT INTO versions (id, document_id, content, created_at) VALUES (?, ?, ?, ?)`,
+		newID(), docID, "d1", ts)
+
+	// agent_roles / progress_snapshots / webhooks / invitations / custom_templates
+	s.mustExec(t, `INSERT INTO agent_roles (id, workspace_id, slug, name, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`,
+		newID(), ws.ID, "eng", "Engineer", ts, ts)
+	s.mustExec(t, `INSERT INTO progress_snapshots (id, workspace_id, created_at) VALUES (?, ?, ?)`,
+		newID(), ws.ID, ts)
+	s.mustExec(t, `INSERT INTO webhooks (id, workspace_id, url) VALUES (?, ?, ?)`,
+		newID(), ws.ID, "https://example.test/hook")
+	s.mustExec(t, `INSERT INTO workspace_invitations (id, workspace_id, email, invited_by, code) VALUES (?, ?, ?, ?, ?)`,
+		newID(), ws.ID, "invitee@test.com", u.ID, "code-"+newID())
+	s.mustExec(t, `INSERT INTO custom_templates (id, workspace_id, name, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`,
+		newID(), ws.ID, "Tmpl", ts, ts)
+
+	// workspace-scoped api token
+	s.mustExec(t, `INSERT INTO api_tokens (id, workspace_id, name, token_hash, prefix) VALUES (?, ?, ?, ?, ?)`,
+		newID(), ws.ID, "ci", "hash-"+newID(), "pad_")
+
+	// share_links + share_link_views
+	s.mustExec(t, `INSERT INTO share_links (id, token_hash, target_type, target_id, workspace_id, created_by, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		shareLinkID, "sh-"+newID(), "item", item1.ID, ws.ID, u.ID, ts)
+	s.mustExec(t, `INSERT INTO share_link_views (id, share_link_id, viewed_at) VALUES (?, ?, ?)`,
+		newID(), shareLinkID, ts)
+
+	// oauth connection + join row
+	if err := s.CreateOAuthConnection(OAuthConnection{RequestID: oauthReq, UserID: u.ID, Name: "Claude"}); err != nil {
+		t.Fatalf("create oauth connection: %v", err)
+	}
+	s.mustExec(t, `INSERT INTO oauth_connection_workspaces (request_id, workspace_id) VALUES (?, ?)`,
+		oauthReq, ws.ID)
+
+	// user_report_layouts (ON DELETE CASCADE from workspaces — proves the
+	// explicit delete is harmless and covered)
+	s.mustExec(t, `INSERT INTO user_report_layouts (user_id, workspace_id, created_at, updated_at) VALUES (?, ?, ?, ?)`,
+		u.ID, ws.ID, ts, ts)
+
+	// activity
+	if _, err := s.CreateActivity(models.Activity{WorkspaceID: ws.ID, Action: "updated", Actor: "user", Source: "web", UserID: u.ID}); err != nil {
+		t.Fatalf("create activity: %v", err)
+	}
+
+	// attachment (row only — blob reclamation is exercised at the server layer)
+	if err := s.CreateAttachment(&models.Attachment{
+		WorkspaceID: ws.ID, ItemID: &item1.ID, UploadedBy: u.ID,
+		StorageKey: "fs:" + newID(), ContentHash: newID(),
+		MimeType: "image/png", SizeBytes: 3, Filename: "a.png",
+	}); err != nil {
+		t.Fatalf("create attachment: %v", err)
+	}
+
+	// mcp_audit_log row scoped to this workspace (must be de-identified,
+	// not deleted, by the purge).
+	s.mustExec(t, `INSERT INTO mcp_audit_log (id, timestamp, user_id, workspace_id, token_kind, token_ref, tool_name, args_hash, result_status, latency_ms, request_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		mcpAuditID, ts, u.ID, ws.ID, "pat", "tok-1", "pad_item", "", "ok", 0, "req-"+newID())
+
+	return seededWorkspace{
+		wsID: ws.ID, slug: ws.Slug, item1: item1.ID, item2: item2.ID,
+		commentID: commentID, docID: docID, shareLinkID: shareLinkID, mcpAuditID: mcpAuditID,
+	}
+}
+
+// totalChildRows sums every seeded child row for a workspace, checking
+// item-scoped tables against the original parent IDs so a leaked row is
+// detectable even after its parents are gone.
+func (s *Store) totalChildRows(t *testing.T, sw seededWorkspace) int {
+	t.Helper()
+	total := 0
+	for _, tbl := range wsChildTables {
+		total += s.countRows(t, `SELECT COUNT(*) FROM `+tbl+` WHERE workspace_id = ?`, sw.wsID)
+	}
+	// Item/parent-scoped tables without a workspace_id column.
+	total += s.countRows(t, `SELECT COUNT(*) FROM comment_reactions WHERE comment_id = ?`, sw.commentID)
+	total += s.countRows(t, `SELECT COUNT(*) FROM item_versions WHERE item_id IN (?, ?)`, sw.item1, sw.item2)
+	total += s.countRows(t, `SELECT COUNT(*) FROM item_stars WHERE item_id IN (?, ?)`, sw.item1, sw.item2)
+	total += s.countRows(t, `SELECT COUNT(*) FROM item_yjs_updates WHERE item_id IN (?, ?)`, sw.item1, sw.item2)
+	total += s.countRows(t, `SELECT COUNT(*) FROM item_wiki_links WHERE source_item_id IN (?, ?)`, sw.item1, sw.item2)
+	total += s.countRows(t, `SELECT COUNT(*) FROM versions WHERE document_id = ?`, sw.docID)
+	total += s.countRows(t, `SELECT COUNT(*) FROM share_link_views WHERE share_link_id = ?`, sw.shareLinkID)
+	return total
+}
+
+// TestPurgeWorkspaceData_RemovesAllChildDataNoOrphans is the acceptance
+// test: a fully-populated soft-deleted workspace is purged with NO child
+// row left behind on either dialect, while a second live workspace is
+// completely untouched (no over-purge). mcp_audit_log is de-identified
+// (workspace_id nulled) rather than deleted.
+func TestPurgeWorkspaceData_RemovesAllChildDataNoOrphans(t *testing.T) {
+	s := testStore(t)
+	u, err := s.CreateUser(models.UserCreate{Email: "owner@test.com", Name: "Owner", Password: "correct-horse-battery-staple"})
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+
+	doomed := seedFullWorkspace(t, s, u, "Doomed")
+	bystander := seedFullWorkspace(t, s, u, "Bystander")
+
+	// Sanity: both workspaces seeded a substantial number of child rows.
+	if got := s.totalChildRows(t, doomed); got < 25 {
+		t.Fatalf("doomed seed too small: %d child rows", got)
+	}
+	bystanderBefore := s.totalChildRows(t, bystander)
+
+	// Soft-delete via the manual workspace-delete path, then purge.
+	if err := s.DeleteWorkspace(doomed.slug); err != nil {
+		t.Fatalf("soft-delete doomed: %v", err)
+	}
+	if err := s.PurgeWorkspaceData(doomed.wsID); err != nil {
+		t.Fatalf("PurgeWorkspaceData: %v", err)
+	}
+
+	// --- No orphans: every child row of the doomed workspace is gone ---
+	if got := s.totalChildRows(t, doomed); got != 0 {
+		t.Errorf("doomed workspace left %d orphaned child rows after purge", got)
+	}
+	// Per-table detail to make a failure actionable.
+	for _, tbl := range wsChildTables {
+		if got := s.countRows(t, `SELECT COUNT(*) FROM `+tbl+` WHERE workspace_id = ?`, doomed.wsID); got != 0 {
+			t.Errorf("table %s left %d rows for purged workspace", tbl, got)
+		}
+	}
+	// Workspace row itself gone.
+	if got := s.countRows(t, `SELECT COUNT(*) FROM workspaces WHERE id = ?`, doomed.wsID); got != 0 {
+		t.Errorf("workspace row still present after purge")
+	}
+
+	// --- mcp_audit_log de-identified, not deleted ---
+	if got := s.countRows(t, `SELECT COUNT(*) FROM mcp_audit_log WHERE workspace_id = ?`, doomed.wsID); got != 0 {
+		t.Errorf("mcp_audit_log still references purged workspace: %d rows", got)
+	}
+	if got := s.countRows(t, `SELECT COUNT(*) FROM mcp_audit_log WHERE id = ?`, doomed.mcpAuditID); got != 1 {
+		t.Errorf("mcp_audit_log row not preserved (de-identify posture): got %d, want 1", got)
+	}
+
+	// --- No over-purge: the live bystander workspace is fully intact ---
+	if got := s.countRows(t, `SELECT COUNT(*) FROM workspaces WHERE id = ? AND deleted_at IS NULL`, bystander.wsID); got != 1 {
+		t.Errorf("bystander workspace disturbed by purge")
+	}
+	if got := s.totalChildRows(t, bystander); got != bystanderBefore {
+		t.Errorf("bystander child rows changed by purge: before=%d after=%d", bystanderBefore, got)
+	}
+}
+
+// TestPurgeWorkspaceData_RefusesLiveWorkspace pins the critical safety
+// guard: PurgeWorkspaceData must refuse to touch a workspace that is not
+// soft-deleted, even if handed its ID directly — no child row is removed.
+func TestPurgeWorkspaceData_RefusesLiveWorkspace(t *testing.T) {
+	s := testStore(t)
+	u, err := s.CreateUser(models.UserCreate{Email: "live@test.com", Name: "Live", Password: "correct-horse-battery-staple"})
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	live := seedFullWorkspace(t, s, u, "Alive")
+	before := s.totalChildRows(t, live)
+
+	if err := s.PurgeWorkspaceData(live.wsID); err == nil {
+		t.Fatalf("expected PurgeWorkspaceData to refuse a live workspace")
+	}
+
+	if got := s.countRows(t, `SELECT COUNT(*) FROM workspaces WHERE id = ? AND deleted_at IS NULL`, live.wsID); got != 1 {
+		t.Errorf("live workspace row disturbed by refused purge")
+	}
+	if got := s.totalChildRows(t, live); got != before {
+		t.Errorf("live workspace child rows changed by refused purge: before=%d after=%d", before, got)
+	}
+}
+
+// TestListPurgeableWorkspaces_Boundary pins the 30-day boundary: a
+// workspace soft-deleted just past the cutoff is eligible; one deleted
+// just inside the window and a live workspace are NOT.
+func TestListPurgeableWorkspaces_Boundary(t *testing.T) {
+	s := testStore(t)
+	u, err := s.CreateUser(models.UserCreate{Email: "b@test.com", Name: "B", Password: "correct-horse-battery-staple"})
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+
+	old := createWSWithDeletedAt(t, s, u, "Old", time.Now().Add(-31*24*time.Hour))
+	recent := createWSWithDeletedAt(t, s, u, "Recent", time.Now().Add(-29*24*time.Hour))
+	liveWS, err := s.CreateWorkspace(models.WorkspaceCreate{Name: "Live", OwnerID: u.ID})
+	if err != nil {
+		t.Fatalf("create live workspace: %v", err)
+	}
+
+	cutoff := time.Now().Add(-30 * 24 * time.Hour)
+	got, err := s.ListPurgeableWorkspaces(cutoff)
+	if err != nil {
+		t.Fatalf("ListPurgeableWorkspaces: %v", err)
+	}
+
+	ids := map[string]bool{}
+	for _, c := range got {
+		ids[c.ID] = true
+	}
+	if !ids[old] {
+		t.Errorf("workspace soft-deleted 31d ago should be purgeable")
+	}
+	if ids[recent] {
+		t.Errorf("workspace soft-deleted 29d ago must NOT be purgeable (boundary)")
+	}
+	if ids[liveWS.ID] {
+		t.Errorf("live workspace must NEVER be purgeable")
+	}
+}
+
+// createWSWithDeletedAt creates a workspace and stamps its deleted_at to
+// a specific time so the boundary test can inject a deterministic age.
+func createWSWithDeletedAt(t *testing.T, s *Store, u *models.User, name string, deletedAt time.Time) string {
+	t.Helper()
+	ws, err := s.CreateWorkspace(models.WorkspaceCreate{Name: name, OwnerID: u.ID})
+	if err != nil {
+		t.Fatalf("create workspace %s: %v", name, err)
+	}
+	s.mustExec(t, `UPDATE workspaces SET deleted_at = ? WHERE id = ?`,
+		deletedAt.UTC().Format(time.RFC3339), ws.ID)
+	return ws.ID
+}


### PR DESCRIPTION
## What & why

The published /privacy policy promises "personal account data and workspaces you solely own are removed from our live systems within 30 days," but `DeleteAccountAtomic` (account deletion) and `DeleteWorkspace` (manual workspace delete) only **soft-delete** a workspace (stamp `workspaces.deleted_at`) — nothing ever expunged the rows or the items/content inside, a right-to-erasure gap surfaced by the /privacy audit ([[BUG-1965]]). This adds a scheduled sweeper that hard-purges workspaces soft-deleted longer than a named 30-day retention constant.

## How

- **Store (`internal/store/workspace_purge.go`):**
  - `ListPurgeableWorkspaces(cutoff)` — eligibility query (`deleted_at IS NOT NULL AND deleted_at < cutoff`); never returns live workspaces.
  - `PurgeWorkspaceData(id)` — one transaction that deletes every workspace-scoped child row in FK-dependency order (comments/reactions, item_versions, item_links, item_stars, yjs op-log, wiki-links, collection moves/grants, status transitions, items, views, collections, documents+versions, agent_roles, webhooks, invitations, custom_templates, share_links+views, oauth join rows, report layouts, members, member access, api tokens, attachments, activities), de-identifies `mcp_audit_log` (nulls `workspace_id`, preserving the security audit trail), NULLs self-referential `parent_id`s first for SQLite FK-order safety, and **refuses to touch a non-soft-deleted workspace** (defense-in-depth guard).
  - `WorkspaceAttachmentBlobs` + `CountAttachmentsForStorageKeyOutsideWorkspace` — blob capture + physical-`storage_key` cross-workspace dedupe guard.
- **Server (`internal/server/workspace_purge.go`):** periodic sweeper modeled on the orphan GC. **Reclaims blobs BEFORE the DB purge** through the attachment store abstraction (FS + S3 safe); a workspace is **deferred** (rows left, retried next tick) on any blob-delete failure or in-flight upload, so a transient backend error never orphans a blob and retries self-heal. Failure-isolated per workspace; idempotent. Wired unconditionally after `StartOrphanGC` in `cmd/pad/main.go` (env-overridable interval/retention).
- **Dual-dialect** (SQLite + Postgres) throughout `s.dialect`/`s.q`. Partial index on `workspaces(deleted_at)` — **migrations/073 + pgmigrations/051** (mirrored, forward-only).

## Safety acceptance criteria

- [x] Purges ONLY workspaces with `deleted_at` older than 30 days; a workspace soft-deleted 29 days ago is UNTOUCHED (boundary test).
- [x] Purges ALL child data + attachment blobs — fully-populated-workspace test asserts zero orphaned rows across every child table (both dialects).
- [x] NEVER touches live (non-soft-deleted) workspaces or their data (`PurgeWorkspaceData` refuses; sweep excludes them).
- [x] Idempotent; one failure doesn't wedge the loop (blob-failure defer + retry self-heal test).
- [x] Cross-workspace content-addressed dedupe: purging one workspace doesn't delete a blob another still references.
- [x] `make test` (SQLite) + `make test-pg` (Postgres) both green; golangci-lint 0 issues.

## Semantics resolved (please confirm)

- **Both delete paths purge on the same 30-day clock.** Account deletion and manual workspace deletion use the identical `deleted_at` mechanism with no distinguishing column; both are owner-initiated, and the orphan GC already reclaims their attachment blobs at 30 days. Purged uniformly.
- **Runs on self-host and cloud** (like the orphan GC), not cloud-gated.
- **Cross-*process* shared-blob race** (two server processes) is a documented deferred limitation matching the orphan GC and CLAUDE.md's single-instance v1 posture; single-instance sequential operation reclaims shared blobs correctly.

Closes TASK-1966.

https://claude.ai/code/session_01HxBkAMiFBtCRJ2tKSCt3ST