### PR TITLE
fix(web): make workspace Danger Zone honest — it deletes, not archives

### DIFF
--- a/web/src/routes/[username]/[workspace]/settings/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/settings/+page.svelte
@@ -355,10 +355,10 @@
 		deleting = true;
 		try {
 			await api.workspaces.delete(wsSlug);
-			toastStore.show(`Workspace "${wsName}" archived`, 'success');
+			toastStore.show(`Workspace "${wsName}" deleted`, 'success');
 			goto('/console');
 		} catch {
-			toastStore.show('Failed to archive workspace', 'error');
+			toastStore.show('Failed to delete workspace', 'error');
 			deleting = false;
 		}
 	}
@@ -760,16 +760,16 @@
 					{#if !confirmDelete}
 						<div class="danger-row">
 							<div class="danger-info">
-								<strong>Archive this workspace</strong>
-								<p>This will hide the workspace and all its collections, items, and documents. The data is preserved but no longer accessible.</p>
+								<strong>Delete this workspace</strong>
+								<p>This immediately hides the workspace and everything in it — collections, items, documents, and attachments — and permanently deletes it 30 days later.</p>
 							</div>
 							<button class="btn btn-danger" onclick={() => confirmDelete = true}>
-								Archive workspace
+								Delete workspace
 							</button>
 						</div>
 					{:else}
 						<div class="danger-confirm">
-							<p class="danger-warning">This will archive <strong>{wsName}</strong> and all its contents. To confirm, type the workspace slug below:</p>
+							<p class="danger-warning">This will delete <strong>{wsName}</strong> and all its contents. It becomes inaccessible immediately and is permanently erased after 30 days. To confirm, type the workspace slug below:</p>
 							<div class="danger-input-row">
 								<code class="slug-hint">{wsSlug}</code>
 								<input
@@ -782,7 +782,7 @@
 							</div>
 							<div class="danger-actions">
 								<button class="btn btn-danger" onclick={handleDeleteWorkspace} disabled={deleteInput !== wsSlug || deleting}>
-									{deleting ? 'Archiving...' : 'Archive this workspace'}
+									{deleting ? 'Deleting...' : 'Delete this workspace'}
 								</button>
 								<button class="btn" onclick={() => { confirmDelete = false; deleteInput = ''; }}>Cancel</button>
 							</div>


### PR DESCRIPTION
## What

Rewrites the workspace Danger Zone copy in `web/src/routes/[username]/[workspace]/settings/+page.svelte` from "Archive / data preserved" to an honest "Delete":

- Heading: "Archive this workspace" → "Delete this workspace"
- Buttons / in-flight label: "Archive workspace" / "Archive this workspace" / "Archiving..." → "Delete workspace" / "Delete this workspace" / "Deleting..."
- Body copy: "…The data is preserved but no longer accessible." → "This immediately hides the workspace and everything in it — collections, items, documents, and attachments — and permanently deletes it 30 days later."
- Confirm warning: now states it becomes inaccessible immediately and is permanently erased after 30 days.
- Toasts: "…archived" → "…deleted"; "Failed to archive workspace" → "Failed to delete workspace".

## Why

The Danger Zone said "Archive" and claimed "The data is preserved but no longer accessible." That is false: the action soft-deletes (`workspaces.deleted_at`), and TASK-1966's sweeper (already merged) permanently hard-purges any `deleted_at` workspace after 30 days. There is no archive-vs-delete distinction. The UI now matches reality.

A workspace restore path (within the 30-day window) is planned as a follow-up, so the copy states the 30-day finality without asserting the workspace is unrecoverable.

## Scope / non-goals

Copy + toasts only. Typed-slug confirm and owner-only gating are unchanged; no behavior/logic change. The internal `archived` activity action is untouched, no restore feature added here, and the account-delete Danger Zone (console) is not touched. The root CLAUDE.md has no "Danger Zone / data is preserved" note to update (grep found zero matches).

Follows TASK-1966 (the purge sweeper).

Closes TASK-1967.

## Checks

- `npm run check` (svelte-check): 0 errors
- Codex review: CLEAN

https://claude.ai/code/session_01HxBkAMiFBtCRJ2tKSCt3ST