### PR TITLE
feat(web): add workspaces.restore + listDeleted API client methods

### DIFF
--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -1,5 +1,6 @@
 import type {
 	Workspace,
+	DeletedWorkspace,
 	WorkspaceCreate,
 	WorkspaceUpdate,
 	Collection,
@@ -614,6 +615,17 @@ export const api = {
 
 		delete: (slug: string) =>
 			request<void>(`/workspaces/${slug}`, { method: 'DELETE' }),
+
+		// restore un-deletes a soft-deleted workspace that's still inside the
+		// purge window, returning the restored Workspace. Mirrors
+		// POST /workspaces/{slug}/restore (TASK-1970).
+		restore: (slug: string) =>
+			request<Workspace>(`/workspaces/${slug}/restore`, { method: 'POST' }),
+
+		// listDeleted returns the caller's soft-deleted workspaces still inside
+		// the restore window, each with purge_at + days_left. Backs the
+		// restore UI (GET /workspaces/deleted, TASK-1970).
+		listDeleted: () => request<DeletedWorkspace[]>('/workspaces/deleted'),
 
 		reorder: (updates: { slug: string; sort_order: number }[]) =>
 			request<void>('/workspaces/reorder', {


### PR DESCRIPTION
## What

Adds two methods to `api.workspaces` in `web/src/lib/api/client.ts`:

- `restore(slug)` -> `POST /workspaces/{slug}/restore`, returns the restored `Workspace`.
- `listDeleted()` -> `GET /workspaces/deleted`, returns `DeletedWorkspace[]` (Workspace + `purge_at` + `days_left`).

Both use the shared `request()` helper and the existing `DeletedWorkspace` type (imported from `$lib/types`, not redefined).

## Why

Wires the web TypeScript API client to the TASK-1970 restore endpoints (PR #827). The restore UI that consumes these methods lands in TASK-1974/1975/1976.

Scope is intentionally minimal: one file, +12 lines. Gate `cd web && npm run check` passes with 0 errors. Codex review: CLEAN.

Closes TASK-1971

https://claude.ai/code/session_01HxBkAMiFBtCRJ2tKSCt3ST