### PR TITLE
docs(web): point workspace-delete copy at real recovery surfaces

### DIFF
--- a/web/src/routes/[username]/[workspace]/settings/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/settings/+page.svelte
@@ -786,7 +786,7 @@
 						<div class="danger-row">
 							<div class="danger-info">
 								<strong>Delete this workspace</strong>
-								<p>This immediately hides the workspace and everything in it — collections, items, documents, and attachments — and permanently deletes it 30 days later. You can restore it any time within those 30 days — you'll get an Undo prompt right after deleting.</p>
+								<p>This immediately hides the workspace and everything in it — collections, items, documents, and attachments — and permanently deletes it 30 days later. You can restore it any time within those 30 days — from the Undo prompt right after deleting, the workspace switcher's Recently deleted section, or the Deleted workspaces page.</p>
 							</div>
 							<button class="btn btn-danger" onclick={() => confirmDelete = true}>
 								Delete workspace


### PR DESCRIPTION
## What

Refine the Danger Zone "Delete this workspace" copy in `web/src/routes/[username]/[workspace]/settings/+page.svelte` to name all three 30-day recovery paths:

- The **Undo** prompt right after deleting
- The workspace switcher's **Recently deleted** section
- The **Deleted workspaces** page (`/console/deleted-workspaces`)

## Why

TASK-1976 only mentioned the post-delete Undo prompt because the persistent recovery surfaces (TASK-1974 / TASK-1975) hadn't merged yet. Both are now live, so the delete copy should point users at where they can actually restore a workspace within the 30-day window — not just the transient Undo toast.

Copy-only: no logic/behavior change. Keeps the "Delete" naming, typed-slug confirm, and owner-only gating. Verified `npm run check` (0 errors) and both named surfaces exist.

Closes TASK-1977

https://claude.ai/code/session_01HxBkAMiFBtCRJ2tKSCt3ST