### PR TITLE
ci(web): run vitest unit tests in CI + Makefile web-test target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,6 +184,9 @@ jobs:
       - name: Type check (svelte-check)
         run: npm run check
 
+      - name: Run web unit tests (vitest)
+        run: npm run test
+
   e2e:
     name: E2E (Playwright)
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -331,6 +331,7 @@ Server handlers existed pre-PLAN-1496; these tasks just wired CLI subcommands an
 go test ./...              # All Go tests
 go test ./internal/store/  # Store tests only
 cd web && npm run build    # Verify frontend compiles
+cd web && npm run test     # Web unit tests (vitest, run once)
 ```
 
 ## Common Tasks

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test test-pg test-pg-down dev clean web dev-web serve restart lint install check vuln web-check
+.PHONY: build test test-pg test-pg-down dev clean web dev-web serve restart lint install check vuln web-check web-test
 
 BINARY=pad
 BUILD_DIR=./cmd/pad
@@ -125,13 +125,20 @@ vuln:
 web-check: web
 	cd web && npm audit --audit-level=high --omit=dev && npm run check
 
+# Run the web unit-test suite (vitest, non-watch). Mirrors the "Run web unit
+# tests" step in CI's Web job. Kept separate from web-check so a contributor
+# can run just the vitest suite via `make web-test`; `check` invokes both.
+web-test:
+	cd web && npm run test
+
 # Pre-flight target that mirrors CI's Go and Web jobs. Run this before
 # pushing — if it passes, the corresponding CI checks should pass too.
 #
 # Covers: golangci-lint suite (lint), Go test suite, govulncheck, npm ci,
-# npm audit, web build, svelte-check. The race-detector + Postgres jobs
-# only run on push to main (per .github/workflows/ci.yml) and are not
-# included here; run `make test-pg` separately if you want them locally.
+# npm audit, web build, svelte-check, vitest unit tests. The race-detector +
+# Postgres jobs only run on push to main (per .github/workflows/ci.yml) and
+# are not included here; run `make test-pg` separately if you want them
+# locally.
 #
 # `make install` stays lightweight (build + restart only) so the inner
 # dev loop is fast; opt into `check` when you're ready to push.
@@ -139,3 +146,4 @@ check: lint
 	go test ./...
 	$(MAKE) vuln
 	$(MAKE) web-check
+	$(MAKE) web-test


### PR DESCRIPTION
The 128-test vitest suite (incl. the WebMCP dispatch/descriptor tests) ran nowhere in CI. Adds a web unit-test step to the Web job, a web-test Makefile target, and a CLAUDE.md note.

Fixes TASK-1999.

Gates: npm run test (128 pass) + npm run check clean; ci.yml/Makefile reviewed; Codex review CLEAN.

https://claude.ai/code/session_01BoPkYhKqMiWPYmxQigeWsA