### PR TITLE
fix(webhooks): enforce SSRF guard at dial time + widen deny-list

### DIFF
--- a/internal/webhooks/dispatcher.go
+++ b/internal/webhooks/dispatcher.go
@@ -6,12 +6,23 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
+	"syscall"
 	"time"
 
 	"github.com/PerpetualSoftware/pad/internal/models"
 )
+
+// maxWebhookRedirects caps how many HTTP redirects a delivery will follow.
+// Every hop is re-validated by checkRedirect, so this is a belt-and-braces
+// bound against redirect loops rather than the primary SSRF control.
+const maxWebhookRedirects = 5
+
+// deliveryTimeout is the total per-delivery HTTP timeout.
+const deliveryTimeout = 10 * time.Second
 
 // WebhookStore is the interface the dispatcher needs to fetch webhooks
 // and record delivery outcomes.
@@ -36,13 +47,75 @@ type Dispatcher struct {
 }
 
 // NewDispatcher creates a Dispatcher with the given store.
+//
+// The delivery client enforces the SSRF guard at connect time, not just at
+// parse time: its dialer's Control callback re-checks the ACTUAL resolved IP
+// before the socket connects (closing the DNS-rebind TOCTOU where a hostname
+// validates as public then resolves to an internal IP), and CheckRedirect
+// re-runs ValidateWebhookURL on every hop so a 302 can't bounce the request
+// to an internal target. Proxy is intentionally nil — honoring HTTP(S)_PROXY
+// would connect to the proxy host and skip our dialer's IP check entirely.
 func NewDispatcher(store WebhookStore) *Dispatcher {
-	return &Dispatcher{
-		store: store,
-		client: &http.Client{
-			Timeout: 10 * time.Second,
+	d := &Dispatcher{store: store}
+
+	dialer := &net.Dialer{
+		Timeout:   deliveryTimeout,
+		KeepAlive: 30 * time.Second,
+		Control: func(_, address string, _ syscall.RawConn) error {
+			if d.SkipSSRF {
+				return nil
+			}
+			return screenDialAddr(address)
 		},
 	}
+	d.client = &http.Client{
+		Timeout: deliveryTimeout,
+		Transport: &http.Transport{
+			Proxy:                 nil, // never route through an env proxy — see NewDispatcher docstring
+			DialContext:           dialer.DialContext,
+			MaxIdleConns:          100,
+			IdleConnTimeout:       90 * time.Second,
+			TLSHandshakeTimeout:   10 * time.Second,
+			ExpectContinueTimeout: 1 * time.Second,
+		},
+		CheckRedirect: d.checkRedirect,
+	}
+	return d
+}
+
+// checkRedirect re-validates every redirect hop against the SSRF guard and
+// caps the redirect chain length. Without it, an allowed public endpoint
+// could 302 the delivery to an internal address.
+func (d *Dispatcher) checkRedirect(req *http.Request, via []*http.Request) error {
+	if len(via) >= maxWebhookRedirects {
+		return fmt.Errorf("stopped after %d redirects", maxWebhookRedirects)
+	}
+	if d.SkipSSRF {
+		return nil
+	}
+	if err := ValidateWebhookURL(req.URL.String()); err != nil {
+		return fmt.Errorf("redirect to %s blocked: %w", req.URL.Redacted(), err)
+	}
+	return nil
+}
+
+// screenDialAddr rejects a dial to a private/reserved IP. The dialer calls
+// this with the resolved connection address (ip:port), so it validates the
+// exact target the socket is about to connect to — this is the dial-time
+// check that defeats DNS rebinding.
+func screenDialAddr(address string) error {
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		host = address
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return fmt.Errorf("webhook dial blocked: %q is not a resolved IP", address)
+	}
+	if isPrivateIP(ip) {
+		return fmt.Errorf("webhook dial blocked: private or reserved IP %s", ip)
+	}
+	return nil
 }
 
 // Dispatch sends the event payload to all matching active webhooks for the workspace.

--- a/internal/webhooks/dispatcher_test.go
+++ b/internal/webhooks/dispatcher_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 
@@ -226,6 +227,87 @@ func TestDispatcher_FailureOnNon2xx(t *testing.T) {
 	defer store.mu.Unlock()
 	if !store.failures["hook-1"] {
 		t.Error("expected failure to be recorded for non-2xx response")
+	}
+}
+
+// stubTransport lets a test drive the delivery client's redirect handling
+// without any real network I/O.
+type stubTransport struct {
+	respond func(*http.Request) *http.Response
+}
+
+func (s *stubTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return s.respond(req), nil
+}
+
+// TestScreenDialAddr is the dial-time guard that closes the DNS-rebind
+// TOCTOU: it validates the resolved ip:port the socket is about to connect
+// to, regardless of what the parse-time URL check saw.
+func TestScreenDialAddr(t *testing.T) {
+	tests := []struct {
+		name    string
+		address string
+		wantErr bool
+	}{
+		{"public", "93.184.216.34:443", false},
+		{"public dns", "8.8.8.8:80", false},
+		{"loopback", "127.0.0.1:80", true},
+		{"rfc1918", "10.1.2.3:8080", true},
+		{"cloud metadata", "169.254.169.254:80", true},
+		{"cgnat", "100.64.0.1:443", true},
+		{"benchmarking", "198.18.0.1:80", true},
+		{"reserved class E", "240.0.0.1:80", true},
+		{"broadcast", "255.255.255.255:80", true},
+		{"not an ip", "example.com:80", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := screenDialAddr(tt.address)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("screenDialAddr(%q) error = %v, wantErr = %v", tt.address, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestDispatcher_RedirectToInternalBlocked proves a 302 from an allowed
+// public endpoint cannot bounce a delivery to an internal IP: the initial
+// URL is a public literal (passes parse-time validation), but the stubbed
+// transport returns a redirect to the cloud-metadata IP, which CheckRedirect
+// must reject so d.client.Do fails and the delivery is recorded as failed.
+func TestDispatcher_RedirectToInternalBlocked(t *testing.T) {
+	store := newMockStore(nil)
+	d := NewDispatcher(store)
+	d.SkipSSRF = false
+	d.client.Transport = &stubTransport{
+		respond: func(req *http.Request) *http.Response {
+			return &http.Response{
+				StatusCode: http.StatusFound,
+				Header:     http.Header{"Location": []string{"http://169.254.169.254/latest/meta-data/"}},
+				Body:       io.NopCloser(strings.NewReader("")),
+				Request:    req,
+			}
+		},
+	}
+
+	hook := models.Webhook{ID: "hook-1", WorkspaceID: "ws-1", URL: "http://93.184.216.34/hook"}
+	d.deliver(hook, []byte("{}"))
+	store.waitForUpdate()
+
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if !store.failures["hook-1"] {
+		t.Error("expected redirect-to-internal delivery to be recorded as failed")
+	}
+}
+
+// TestDispatcher_CheckRedirectCap stops runaway redirect chains.
+func TestDispatcher_CheckRedirectCap(t *testing.T) {
+	d := NewDispatcher(newMockStore(nil))
+	req, _ := http.NewRequest(http.MethodGet, "http://93.184.216.34/", nil)
+	via := make([]*http.Request, maxWebhookRedirects)
+	if err := d.checkRedirect(req, via); err == nil {
+		t.Errorf("checkRedirect with %d prior hops: expected error, got nil", maxWebhookRedirects)
 	}
 }
 

--- a/internal/webhooks/validate.go
+++ b/internal/webhooks/validate.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net"
 	"net/url"
-	"strings"
 )
 
 // ValidateWebhookURL checks that a webhook URL is safe to call.
@@ -58,50 +57,53 @@ func ValidateWebhookURL(rawURL string) error {
 }
 
 // isPrivateIP returns true if the IP is in a private, reserved, or
-// otherwise non-routable range.
+// otherwise non-routable range. It covers loopback (127.0.0.0/8, ::1),
+// RFC1918 (10/8, 172.16/12, 192.168/16) and IPv6 unique-local (fc00::/7)
+// via the stdlib predicates, link-local (169.254.0.0/16 — which catches
+// the AWS/GCP/Azure metadata IP 169.254.169.254 — and fe80::/10), all
+// multicast (224.0.0.0/4, ff00::/8), the unspecified address, and the
+// extra reserved ranges in reservedRanges below.
 func isPrivateIP(ip net.IP) bool {
-	// Loopback (127.0.0.0/8, ::1)
-	if ip.IsLoopback() {
+	if ip.IsLoopback() ||
+		ip.IsLinkLocalUnicast() ||
+		ip.IsLinkLocalMulticast() ||
+		ip.IsMulticast() ||
+		ip.IsUnspecified() ||
+		ip.IsPrivate() {
 		return true
 	}
-
-	// Link-local (169.254.0.0/16, fe80::/10)
-	if ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() {
-		return true
-	}
-
-	// Unspecified (0.0.0.0, ::)
-	if ip.IsUnspecified() {
-		return true
-	}
-
-	// RFC1918 private ranges
-	privateRanges := []struct {
-		network string
-	}{
-		{"10.0.0.0/8"},
-		{"172.16.0.0/12"},
-		{"192.168.0.0/16"},
-		// IPv6 unique local (fc00::/7)
-		{"fc00::/7"},
-		// Cloud metadata (AWS, GCP, Azure)
-		{"169.254.169.254/32"},
-	}
-
-	for _, r := range privateRanges {
-		_, cidr, err := net.ParseCIDR(r.network)
-		if err != nil {
-			continue
-		}
+	for _, cidr := range reservedRanges {
 		if cidr.Contains(ip) {
 			return true
 		}
 	}
-
-	// Also catch common cloud metadata IPv6 variants
-	if strings.EqualFold(ip.String(), "fd00::") {
-		return true
-	}
-
 	return false
+}
+
+// reservedRanges are additional blocks that are not routable on the public
+// internet but are not caught by the stdlib predicates above. Precomputed
+// at init so isPrivateIP stays allocation-free and concurrency-safe.
+var reservedRanges = mustParseCIDRs(
+	"0.0.0.0/8",          // "this network" (RFC 1122) — some stacks route it locally
+	"100.64.0.0/10",      // CGNAT (RFC 6598)
+	"192.0.0.0/24",       // IETF protocol assignments (RFC 6890)
+	"198.18.0.0/15",      // benchmarking (RFC 2544)
+	"240.0.0.0/4",        // reserved / Class E (also contains 255.255.255.255)
+	"255.255.255.255/32", // limited broadcast
+	"192.0.2.0/24",       // TEST-NET-1 documentation (RFC 5737)
+	"198.51.100.0/24",    // TEST-NET-2 documentation (RFC 5737)
+	"203.0.113.0/24",     // TEST-NET-3 documentation (RFC 5737)
+	"2001:db8::/32",      // IPv6 documentation (RFC 3849)
+)
+
+func mustParseCIDRs(networks ...string) []*net.IPNet {
+	out := make([]*net.IPNet, 0, len(networks))
+	for _, n := range networks {
+		_, cidr, err := net.ParseCIDR(n)
+		if err != nil {
+			panic(fmt.Errorf("webhooks: parse reserved CIDR %q: %w", n, err))
+		}
+		out = append(out, cidr)
+	}
+	return out
 }

--- a/internal/webhooks/validate_test.go
+++ b/internal/webhooks/validate_test.go
@@ -36,6 +36,17 @@ func TestValidateWebhookURL(t *testing.T) {
 		{"link-local", "http://169.254.1.1/hook", true},
 		{"unspecified", "http://0.0.0.0/hook", true},
 
+		// Widened reserved ranges
+		{"cgnat 100.64.x", "http://100.64.1.2/hook", true},
+		{"ietf protocol 192.0.0.x", "http://192.0.0.8/hook", true},
+		{"benchmarking 198.18.x", "http://198.19.0.1/hook", true},
+		{"reserved class E 240.x", "http://240.0.0.1/hook", true},
+		{"broadcast", "http://255.255.255.255/hook", true},
+
+		// Public addresses just outside the widened ranges must still pass
+		{"public above cgnat", "http://100.128.0.1/hook", false},
+		{"public above 198.18/15", "http://198.20.0.1/hook", false},
+
 		// Hostnames resolving to private IPs
 		{"localhost", "http://localhost/hook", true},
 
@@ -69,6 +80,28 @@ func TestIsPrivateIP(t *testing.T) {
 		{"8.8.8.8", false},
 		{"1.1.1.1", false},
 		{"93.184.216.34", false},
+		// Widened reserved ranges
+		{"100.64.0.1", true},      // CGNAT lower bound
+		{"100.127.255.254", true}, // CGNAT upper bound
+		{"192.0.0.1", true},       // IETF protocol assignments
+		{"198.18.0.1", true},      // benchmarking lower bound
+		{"198.19.255.254", true},  // benchmarking upper bound
+		{"240.0.0.1", true},       // reserved / Class E
+		{"255.255.255.255", true}, // limited broadcast
+		{"0.0.0.1", true},         // "this network" (RFC 1122), not just 0.0.0.0
+		{"0.255.255.255", true},   // "this network" upper bound
+		{"224.0.0.1", true},       // IPv4 multicast
+		{"239.1.2.3", true},       // IPv4 multicast (admin-scoped)
+		{"ff02::1", true},         // IPv6 multicast
+		{"192.0.2.1", true},       // TEST-NET-1 documentation
+		{"198.51.100.1", true},    // TEST-NET-2 documentation
+		{"203.0.113.1", true},     // TEST-NET-3 documentation
+		{"2001:db8::1", true},     // IPv6 documentation
+		// Just outside the widened ranges — must stay public
+		{"100.128.0.1", false},     // above CGNAT
+		{"192.0.1.1", false},       // above 192.0.0.0/24
+		{"198.20.0.1", false},      // above 198.18.0.0/15
+		{"223.255.255.255", false}, // last public /8 below the 240/4 reserved block
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Closes the webhook SSRF: the guard only validated the literal URL at parse time, so HTTP redirects and DNS rebinding reached internal IPs. Now enforced at dial time via net.Dialer.Control (validates the actual resolved connection IP, closing the DNS-rebind TOCTOU) + CheckRedirect re-validation on every hop (with a redirect cap), and the deny-list is widened.

Deny-list additions: CGNAT (100.64/10), IETF protocol (192.0.0/24), benchmarking (198.18/15), Class E (240/4), broadcast, all multicast (224/4, ff00::/8), and TEST-NET / IPv6 documentation ranges.

Fixes BUG-1993.

Gates: go build/test (webhooks+server) green; golangci-lint clean; Codex review CLEAN.

https://claude.ai/code/session_01BoPkYhKqMiWPYmxQigeWsA