### PR TITLE
docs(mcp): sync tool-surface docs to v0.8 + drift guard (TASK-2005)

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,17 +278,18 @@ pad mcp install claude-desktop   # or: cursor, windsurf, --all
 # Restart the client; pad shows up as the "pad" MCP server.
 ```
 
-**Tool catalog (v0.4)** — eight resource × action tools plus `pad_set_workspace` (nine total), no flat verb explosion:
+**Tool catalog (v0.8)** — nine resource × action tools plus `pad_set_workspace` (ten total), no flat verb explosion:
 
 | Tool | Actions |
 |---|---|
-| `pad_item` | `create`, `update`, `delete`, `get`, `list`, `move`, `link`, `unlink`, `deps`, `star`, `unstar`, `starred`, `comment`, `list-comments`, `bulk-update`, `note`, `decide` |
-| `pad_workspace` | `list`, `members`, `invite`, `storage`, `audit-log` |
+| `pad_item` | `create`, `update`, `delete`, `get`, `list`, `move`, `restore`, `link`, `unlink`, `deps`, `star`, `unstar`, `starred`, `comment`, `list-comments`, `backlinks`, `bulk-update`, `note`, `decide`, `export`, `import` |
+| `pad_workspace` | `list`, `members`, `invite`, `storage`, `audit-log`, `create`, `claim`, `deleted`, `restore` |
 | `pad_collection` | `list`, `create`, `update`, `delete` |
-| `pad_project` | `dashboard`, `next`, `standup`, `changelog` |
+| `pad_project` | `dashboard`, `next`, `standup`, `changelog`, `report` |
 | `pad_role` | `list`, `create`, `update`, `delete` |
 | `pad_search` | `query` |
 | `pad_playbook` | `list`, `get`, `run` |
+| `pad_library` | `list`, `get`, `activate` |
 | `pad_meta` | `server-info`, `version`, `tool-surface`, `bootstrap` |
 | `pad_set_workspace` | session-default workspace pinning (response embeds the bootstrap blob) |
 
@@ -303,7 +304,7 @@ initialize handshake under `capabilities.experimental.padCmdhelp` and
 `pad://_meta/version`):
 
 - `cmdhelp_version: "0.1"` — CLI help-tree contract (used at dispatch time)
-- `tool_surface_version: "0.4"` — MCP tool catalog contract (PLAN-1410 trimmed the bootstrap-response shape by ~40%; see `internal/mcp/version.go` for the full v0.4 changelog)
+- `tool_surface_version: "0.8"` — MCP tool catalog contract (v0.5 added `pad_library`; v0.6 `pad_item.backlinks`; v0.7 `pad_item` `export`/`import`; v0.8 `pad_workspace` `deleted`/`restore`; see `internal/mcp/version.go` for the full changelog)
 
 External agents pin against these so a future rename doesn't break them
 silently. Errors come back as structured envelopes (`{error: {code,

--- a/internal/mcp/catalog_meta.go
+++ b/internal/mcp/catalog_meta.go
@@ -57,14 +57,14 @@ var padMetaTool = ToolDef{
 	},
 }
 
-const padMetaToolDescription = `Server introspection — version, capabilities, the v0.4 tool catalog, and the agent bootstrap blob.
+const padMetaToolDescription = `Server introspection — version, capabilities, the hand-curated tool catalog, and the agent bootstrap blob.
 
 Actions:
   server-info   — Server name + runtime version. Lightweight; no params.
   version       — Full version metadata (pad version, cmdhelp version, tool surface
                   version, MCP protocol version). Same JSON as pad://_meta/version.
-  tool-surface  — v0.4 catalog dump: every tool managed by the hand-curated
-                  catalog (the eight resource × action tools — pad_set_workspace
+  tool-surface  — catalog dump: every tool managed by the hand-curated
+                  catalog (the nine resource × action tools — pad_set_workspace
                   is registered separately and not included), its actions, and
                   its input schema. tools/list also contains pad_set_workspace
                   and matches the catalog otherwise — the historical cmdhelp

--- a/internal/mcp/instructions.md
+++ b/internal/mcp/instructions.md
@@ -6,21 +6,22 @@ Pad is a project tracker for developers and AI agents — issues (TASK, BUG), pl
 
 If the user is asking general code questions with no project-management thread, you don't need this server.
 
-## Tool surface (v0.4)
+## Tool surface (v0.8)
 
-Eight resource × action tools, plus `pad_set_workspace` (which takes a `workspace` slug only — no action enum). Nine tools total.
+Nine resource × action tools, plus `pad_set_workspace` (which takes a `workspace` slug only — no action enum). Ten tools total.
 
-- `pad_item` — Items: create / update / delete / get / list / move / link / unlink / deps / star / unstar / starred / comment / list-comments / bulk-update / note / decide.
-- `pad_workspace` — Workspaces: list / members / invite / storage / audit-log.
+- `pad_item` — Items: create / update / delete / get / list / move / restore / link / unlink / deps / star / unstar / starred / comment / list-comments / backlinks / bulk-update / note / decide / export / import.
+- `pad_workspace` — Workspaces: list / members / invite / storage / audit-log / create / claim / deleted / restore.
 - `pad_collection` — Collections: list / create / update / delete.
-- `pad_project` — Project intelligence: dashboard / next / standup / changelog.
+- `pad_project` — Project intelligence: dashboard / next / standup / changelog / report.
 - `pad_role` — Agent roles: list / create / update / delete.
 - `pad_search` — Full-text search across items: query.
 - `pad_playbook` — Invokable procedures: list / get / run. Use `run` to bind args against a playbook's declared spec and get the rendered body back; side-effect-free.
+- `pad_library` — Convention + playbook library (the global catalog of pre-built entries workspaces activate): list / get / activate.
 - `pad_meta` — Server introspection: server-info / version / tool-surface / bootstrap. The `bootstrap` action returns one-shot workspace context (user + collections + always-on conventions + roles + playbook metadata + dashboard + recent activity).
 - `pad_set_workspace` — Load workspace context; response embeds the bootstrap blob so you load context in one call. On a single-user local server it also pins the workspace as the session default for subsequent calls; a multi-user/remote server does **not** persist it — pass `workspace` explicitly on each call. Takes `workspace: <slug>` only (no `action`).
 
-For the eight resource × action tools, always pass `action` as a top-level field. Per-action required parameters are documented in each tool's description.
+For the nine resource × action tools, always pass `action` as a top-level field. Per-action required parameters are documented in each tool's description.
 
 ## Resources are cheaper than tool calls
 

--- a/internal/mcp/tool_surface_drift_test.go
+++ b/internal/mcp/tool_surface_drift_test.go
@@ -1,0 +1,140 @@
+package mcp
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TASK-2005 drift guard.
+//
+// The MCP tool catalog (internal/mcp/catalog_*.go, authoritative) is the
+// source of truth for what tools + actions exist. Three documentation
+// surfaces must stay in lockstep with it or agents under-discover tools:
+//
+//   - internal/mcp/instructions.md — the in-binary server instructions
+//     handed to EVERY MCP session. Stale here is the worst kind of drift:
+//     silent, per-session, invisible.
+//   - README.md — the developer-facing tool catalog table + the
+//     tool_surface_version string.
+//   - internal/mcp/version.go::ToolSurfaceVersion — the version constant.
+//
+// These tests FAIL when a catalog action is missing from the tool's own
+// documented action list, or when a documented version string drifts from
+// ToolSurfaceVersion.
+//
+// The action checks are PER-TOOL scoped (not a whole-document substring
+// search): each action must appear on the line that documents ITS tool.
+// That way adding, say, `restore` to pad_role without documenting it fails
+// even though `restore` is already documented under pad_item/pad_workspace.
+// Both docs render one line per tool — instructions.md as a "- `tool` — …"
+// bullet, README as a "| `tool` | … |" table row — so the tool's own line
+// is an unambiguous scope. If either layout ever goes multi-line per tool,
+// these helpers need updating (and will fail loudly rather than silently
+// passing).
+
+// TestInstructionsMDCoversEveryCatalogAction asserts every tool in the live
+// Catalog has a documentation bullet in instructions.md, and every one of
+// its actions appears on that bullet.
+func TestInstructionsMDCoversEveryCatalogAction(t *testing.T) {
+	if len(Catalog) == 0 {
+		t.Fatal("Catalog is empty — init() registration broke; drift guard cannot run")
+	}
+
+	for _, def := range Catalog {
+		line := findToolLine(Instructions, "- `"+def.Name+"`")
+		if line == "" {
+			t.Errorf("tool %q is in the catalog but has no '- `%s` — …' bullet in instructions.md — document it under the '## Tool surface' section", def.Name, def.Name)
+			continue
+		}
+		for action := range def.Actions {
+			if !containsAction(line, action) {
+				t.Errorf("action %q of tool %q is in the catalog but not documented on %q's instructions.md bullet — add it to the tool's action list", action, def.Name, def.Name)
+			}
+		}
+	}
+}
+
+// TestReadmeTableCoversEveryCatalogAction asserts the README catalog table
+// has a row for every tool in the live Catalog, and every one of its actions
+// appears in that row.
+func TestReadmeTableCoversEveryCatalogAction(t *testing.T) {
+	readme := readRepoFile(t, "README.md")
+
+	for _, def := range Catalog {
+		row := findToolLine(readme, "| `"+def.Name+"` |")
+		if row == "" {
+			t.Errorf("tool %q is in the catalog but has no '| `%s` | … |' row in the README catalog table", def.Name, def.Name)
+			continue
+		}
+		for action := range def.Actions {
+			if !containsAction(row, action) {
+				t.Errorf("action %q of tool %q is in the catalog but not in %q's README table row", action, def.Name, def.Name)
+			}
+		}
+	}
+}
+
+// TestInstructionsMDVersionMatchesToolSurface pins the "## Tool surface (vX)"
+// heading in instructions.md to the current ToolSurfaceVersion. Bump
+// ToolSurfaceVersion without re-titling the heading and this fails.
+func TestInstructionsMDVersionMatchesToolSurface(t *testing.T) {
+	want := "## Tool surface (v" + ToolSurfaceVersion + ")"
+	if !strings.Contains(Instructions, want) {
+		t.Errorf("instructions.md is missing the current tool-surface heading %q — its '## Tool surface (v…)' title drifted from ToolSurfaceVersion (%q). Re-title the heading.", want, ToolSurfaceVersion)
+	}
+}
+
+// TestReadmeVersionMatchesToolSurface pins README.md's version references
+// (the catalog table heading and the tool_surface_version line) to the
+// current ToolSurfaceVersion. Bump the constant without touching the README
+// and this fails.
+func TestReadmeVersionMatchesToolSurface(t *testing.T) {
+	readme := readRepoFile(t, "README.md")
+
+	catalogHeading := "**Tool catalog (v" + ToolSurfaceVersion + ")**"
+	if !strings.Contains(readme, catalogHeading) {
+		t.Errorf("README.md is missing the current catalog heading %q — it drifted from ToolSurfaceVersion (%q).", catalogHeading, ToolSurfaceVersion)
+	}
+
+	versionLine := `tool_surface_version: "` + ToolSurfaceVersion + `"`
+	if !strings.Contains(readme, versionLine) {
+		t.Errorf("README.md is missing %q — the documented tool_surface_version drifted from ToolSurfaceVersion (%q).", versionLine, ToolSurfaceVersion)
+	}
+}
+
+// findToolLine returns the first line of doc whose trimmed form starts with
+// prefix (the tool's documentation-line marker), or "" if none matches.
+// Scoping the action search to a single line keeps one tool's actions from
+// satisfying another tool's coverage check.
+func findToolLine(doc, prefix string) string {
+	for _, line := range strings.Split(doc, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), prefix) {
+			return line
+		}
+	}
+	return ""
+}
+
+// containsAction reports whether a tool's documentation line references the
+// given action. Actions are rendered backtick-quoted in the README table
+// (`create`) and slash- or space-separated in instructions.md (create /
+// update); a plain substring check within the already-tool-scoped line
+// covers both layouts without coupling to either.
+func containsAction(line, action string) bool {
+	return strings.Contains(line, action)
+}
+
+// readRepoFile reads a file relative to the repo root. Go runs tests with the
+// package directory as the working directory, so the repo root is two levels
+// up from internal/mcp.
+func readRepoFile(t *testing.T, rel string) string {
+	t.Helper()
+	path := filepath.Join("..", "..", rel)
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("cannot read %s (%s): %v", rel, path, err)
+	}
+	return string(b)
+}


### PR DESCRIPTION
## What

`internal/mcp/version.go` ships `ToolSurfaceVersion = "0.8"`, but the in-binary MCP instructions and README were stale at v0.4 / eight tools — omitting `pad_library` and the `pad_item` restore/backlinks/export/import, `pad_workspace` deleted/restore, `pad_project` report, and `pad_collection`/`pad_role` update actions. Every MCP session got the stale map, so agents under-discovered v0.5-v0.8 tools.

## Changes

- **`internal/mcp/instructions.md`** (in-binary server instructions, handed to every MCP session): retitled to v0.8; now lists nine resource x action tools (ten total) including `pad_library` and all new actions.
- **`internal/mcp/catalog_meta.go`**: dropped stale `v0.4` / `eight resource` from the agent-facing `pad_meta` tool + `tool-surface` action descriptions.
- **`README.md`**: catalog table + `tool_surface_version` bumped to 0.8.
- **Drift guard** (`internal/mcp/tool_surface_drift_test.go`): per-tool test that fails when a live `Catalog` action is missing from its own documented action list in instructions.md / README, or when the documented version strings drift from `ToolSurfaceVersion`. Per-tool scoping means an undocumented action can't be masked by the same verb appearing under another tool. Verified it catches both classes of drift.

## Test

`go build ./... && go test ./... && golangci-lint run ./internal/mcp/...` all green.

Companion pad-web docs PR syncs the public `docs/mcp/tools`, `mcp/remote`, `mcp/local` pages to v0.8.

TASK-2005