### PR TITLE
feat(cli,mcp): summary-shaped item list with --full opt-in + limit clamp (TASK-2000)

### DIFF
--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -3537,6 +3537,17 @@ Run with --help-collections to see available collections and their status values
 
 // --- list ---
 
+// Default + hard-max caps on `pad item list` result size (TASK-2000).
+// The default is a safety net so a bare `pad item list` / `--all` can't dump
+// the whole workspace into an agent's context; the max clamps an explicit
+// oversized `--limit`. Both bound the JSON/table payload, never the item body
+// (that's handled by the summary projection). Generous enough that normal
+// workspaces aren't truncated; small enough that pathological ones are.
+const (
+	defaultItemListLimit = 200
+	maxItemListLimit     = 1000
+)
+
 func listCmd() *cobra.Command {
 	var (
 		statusFilter   string
@@ -3549,6 +3560,7 @@ func listCmd() *cobra.Command {
 		groupBy        string
 		limitNum       int
 		showAll        bool
+		fullOutput     bool
 		fieldFlags     []string
 	)
 
@@ -3619,9 +3631,18 @@ Examples:
 			if groupBy != "" {
 				params.Set("group_by", groupBy)
 			}
-			if limitNum > 0 {
-				params.Set("limit", fmt.Sprintf("%d", limitNum))
+			// Apply a default limit + hard-max clamp (TASK-2000). Unbounded
+			// lists (esp. --all, which spans every collection) can dump
+			// megabytes into an agent's context; cap them. An explicit
+			// oversized --limit is clamped down rather than rejected.
+			effectiveLimit := limitNum
+			if effectiveLimit <= 0 {
+				effectiveLimit = defaultItemListLimit
 			}
+			if effectiveLimit > maxItemListLimit {
+				effectiveLimit = maxItemListLimit
+			}
+			params.Set("limit", fmt.Sprintf("%d", effectiveLimit))
 
 			// Apply arbitrary --field key=value filters as query params
 			for _, kv := range fieldFlags {
@@ -3643,7 +3664,13 @@ Examples:
 			}
 
 			if formatFlag == "json" {
-				return cli.PrintJSON(items)
+				// Default to the token-light summary shape (drops the rich
+				// `content` body + UUID plumbing). --full restores the raw
+				// models.Item shape for callers that need everything.
+				if fullOutput {
+					return cli.PrintJSON(items)
+				}
+				return cli.PrintJSON(cli.ToItemSummaries(items))
 			}
 
 			if len(items) == 0 {
@@ -3657,6 +3684,14 @@ Examples:
 			} else {
 				cli.PrintItemTable(items)
 			}
+
+			// Nudge when the result was (possibly) capped by the limit so a
+			// human doesn't silently miss items. len==limit is a heuristic:
+			// it can't distinguish "exactly N" from "N and more", so the
+			// message hedges.
+			if len(items) == effectiveLimit {
+				cli.Dim.Fprintf(os.Stderr, "\n(showing %d items — capped by limit; pass --limit N to see more)\n", effectiveLimit)
+			}
 			return nil
 		},
 	}
@@ -3669,8 +3704,9 @@ Examples:
 	cmd.Flags().StringVar(&parentFilter, "parent", "", "filter by parent item (ref, slug, or ID)")
 	cmd.Flags().StringVar(&sortBy, "sort", "", "sort order (e.g. priority:desc,created_at:asc)")
 	cmd.Flags().StringVar(&groupBy, "group-by", "", "group results by field")
-	cmd.Flags().IntVar(&limitNum, "limit", 0, "max number of items to return")
+	cmd.Flags().IntVar(&limitNum, "limit", 0, fmt.Sprintf("max number of items to return (default %d, max %d)", defaultItemListLimit, maxItemListLimit))
 	cmd.Flags().BoolVar(&showAll, "all", false, "include done/completed/archived items")
+	cmd.Flags().BoolVar(&fullOutput, "full", false, "JSON output only: include full content + all fields (default: token-light summary shape)")
 	cmd.Flags().StringArrayVarP(&fieldFlags, "field", "f", nil, "filter by field value (repeatable): --field key=value")
 
 	return cmd

--- a/internal/cli/item_summary.go
+++ b/internal/cli/item_summary.go
@@ -1,0 +1,126 @@
+package cli
+
+import (
+	"encoding/json"
+	"strings"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// ItemSummary is the agent-friendly, token-light projection of
+// models.Item used by `pad item list` JSON output by default (TASK-2000).
+//
+// It drops the single biggest cost in a list response — the full rich-text
+// `content` body, which is ~half the bytes of a typical `item list --format
+// json` — replacing it with a short `content_preview`. It also drops the
+// redundant UUID plumbing (id / workspace_id / collection_id / *_user_id /
+// parent_id / agent_role_id) and the duplicate collection/parent join fields
+// that only repeat data already addressable via slugs/refs. `fields` and
+// `tags` are emitted as nested JSON (not escaped strings) so agents can read
+// them without a second parse.
+//
+// The full shape (raw models.Item) is still available via `item list --full`.
+type ItemSummary struct {
+	Ref            string          `json:"ref,omitempty"`
+	Title          string          `json:"title"`
+	Slug           string          `json:"slug"`
+	CollectionSlug string          `json:"collection_slug,omitempty"`
+	ItemNumber     *int            `json:"item_number,omitempty"`
+	Fields         json.RawMessage `json:"fields,omitempty"`
+	Tags           json.RawMessage `json:"tags,omitempty"`
+	Pinned         bool            `json:"pinned,omitempty"`
+	ContentPreview string          `json:"content_preview,omitempty"`
+	ParentRef      string          `json:"parent_ref,omitempty"`
+	AssignedUser   string          `json:"assigned_user,omitempty"`
+	AgentRole      string          `json:"agent_role,omitempty"`
+	HasChildren    bool            `json:"has_children,omitempty"`
+	CreatedAt      time.Time       `json:"created_at"`
+	UpdatedAt      time.Time       `json:"updated_at"`
+}
+
+// contentPreviewLimit caps the content_preview at a small, agent-friendly
+// length. A preview exists so an agent can recognize an item without pulling
+// the whole body; the full body is one `pad item show <ref>` away.
+const contentPreviewLimit = 200
+
+// contentPreview returns the first non-empty line of the body (markdown
+// stripped of a leading heading marker), truncated to contentPreviewLimit
+// runes with an ellipsis when longer. Empty content yields "".
+func contentPreview(content string) string {
+	trimmed := strings.TrimSpace(content)
+	if trimmed == "" {
+		return ""
+	}
+	// Take the first non-blank line so the preview is a coherent snippet
+	// rather than a mid-sentence cut across a blank line.
+	line := trimmed
+	for _, l := range strings.Split(trimmed, "\n") {
+		if s := strings.TrimSpace(l); s != "" {
+			line = s
+			break
+		}
+	}
+	// Drop a leading markdown heading marker for readability.
+	line = strings.TrimLeft(line, "#")
+	line = strings.TrimSpace(line)
+
+	runes := []rune(line)
+	if len(runes) > contentPreviewLimit {
+		return strings.TrimSpace(string(runes[:contentPreviewLimit])) + "…"
+	}
+	return line
+}
+
+// rawJSONOrNil returns s as json.RawMessage when it is a non-empty, non-empty-
+// container JSON value, else nil (so the field is omitted). Guards against
+// json.RawMessage("") — which is invalid JSON — and drops the noise of empty
+// "{}" / "[]" so the summary stays lean.
+func rawJSONOrNil(s string) json.RawMessage {
+	t := strings.TrimSpace(s)
+	if t == "" || t == "{}" || t == "[]" || t == "null" {
+		return nil
+	}
+	// Defensive: item.Fields/Tags are validated JSON on write, but a
+	// malformed stored value must never break the whole list marshal
+	// (json.Marshal of an invalid RawMessage errors). Fall back to
+	// emitting the raw value as a JSON string so output stays valid.
+	if !json.Valid([]byte(t)) {
+		if b, err := json.Marshal(t); err == nil {
+			return json.RawMessage(b)
+		}
+		return nil
+	}
+	return json.RawMessage(t)
+}
+
+// ToItemSummary projects a single models.Item into the summary shape.
+func ToItemSummary(item models.Item) ItemSummary {
+	return ItemSummary{
+		Ref:            item.Ref,
+		Title:          item.Title,
+		Slug:           item.Slug,
+		CollectionSlug: item.CollectionSlug,
+		ItemNumber:     item.ItemNumber,
+		Fields:         rawJSONOrNil(item.Fields),
+		Tags:           rawJSONOrNil(item.Tags),
+		Pinned:         item.Pinned,
+		ContentPreview: contentPreview(item.Content),
+		ParentRef:      item.ParentRef,
+		AssignedUser:   item.AssignedUserName,
+		AgentRole:      item.AgentRoleSlug,
+		HasChildren:    item.HasChildren,
+		CreatedAt:      item.CreatedAt,
+		UpdatedAt:      item.UpdatedAt,
+	}
+}
+
+// ToItemSummaries projects a slice of items into summary shape, preserving
+// order. A nil input yields a non-nil empty slice so the JSON encodes as `[]`.
+func ToItemSummaries(items []models.Item) []ItemSummary {
+	out := make([]ItemSummary, 0, len(items))
+	for _, it := range items {
+		out = append(out, ToItemSummary(it))
+	}
+	return out
+}

--- a/internal/cli/item_summary_test.go
+++ b/internal/cli/item_summary_test.go
@@ -1,0 +1,123 @@
+package cli
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+func intPtr(n int) *int       { return &n }
+func strPtr(s string) *string { return &s }
+
+// TestToItemSummary_DropsContentAndUUIDs verifies the default summary
+// projection replaces the rich body with a preview and drops the UUID
+// plumbing / duplicate join fields. TASK-2000.
+func TestToItemSummary_DropsContentAndUUIDs(t *testing.T) {
+	item := models.Item{
+		ID:               "uuid-1",
+		WorkspaceID:      "ws-uuid",
+		CollectionID:     "coll-uuid",
+		Title:            "Fix the widget",
+		Slug:             "fix-the-widget",
+		Ref:              "TASK-5",
+		Content:          "# Heading\n\nThe body has real detail that costs tokens.",
+		Fields:           `{"status":"open","priority":"high"}`,
+		Tags:             `["bug","ui"]`,
+		CollectionSlug:   "tasks",
+		CollectionName:   "Tasks",
+		ItemNumber:       intPtr(5),
+		AssignedUserID:   strPtr("user-uuid"),
+		AssignedUserName: "Dave",
+		AgentRoleSlug:    "implementer",
+		ParentRef:        "PLAN-2",
+		ParentTitle:      "Big plan",
+	}
+
+	sum := ToItemSummary(item)
+
+	// Marshal to JSON and confirm the heavy/duplicate fields are gone.
+	b, err := json.Marshal(sum)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	js := string(b)
+
+	for _, banned := range []string{"uuid-1", "ws-uuid", "coll-uuid", "user-uuid", `"content"`, "real detail", "Big plan", "\"id\""} {
+		if strings.Contains(js, banned) {
+			t.Errorf("summary JSON should not contain %q; got %s", banned, js)
+		}
+	}
+	if sum.Ref != "TASK-5" || sum.Title != "Fix the widget" || sum.CollectionSlug != "tasks" {
+		t.Errorf("summary dropped a field it should keep: %+v", sum)
+	}
+	if sum.ContentPreview == "" || strings.Contains(sum.ContentPreview, "#") {
+		t.Errorf("content_preview should be a heading-stripped snippet, got %q", sum.ContentPreview)
+	}
+	if sum.AssignedUser != "Dave" || sum.AgentRole != "implementer" || sum.ParentRef != "PLAN-2" {
+		t.Errorf("summary dropped a human-readable field: %+v", sum)
+	}
+	// fields/tags should be nested JSON, not escaped strings.
+	if !strings.Contains(js, `"fields":{"status":"open"`) {
+		t.Errorf("fields should be a nested object, got %s", js)
+	}
+	if !strings.Contains(js, `"tags":["bug","ui"]`) {
+		t.Errorf("tags should be a nested array, got %s", js)
+	}
+}
+
+// TestContentPreview_TruncatesAndStrips checks the preview helper.
+func TestContentPreview_TruncatesAndStrips(t *testing.T) {
+	if got := contentPreview(""); got != "" {
+		t.Errorf("empty content should yield empty preview, got %q", got)
+	}
+	if got := contentPreview("\n\n## Title line\nmore"); got != "Title line" {
+		t.Errorf("preview should take first non-blank line, heading-stripped, got %q", got)
+	}
+	long := strings.Repeat("a", contentPreviewLimit+50)
+	got := contentPreview(long)
+	if !strings.HasSuffix(got, "…") {
+		t.Errorf("over-long preview should be ellipsized, got %q", got)
+	}
+	if len([]rune(got)) > contentPreviewLimit+1 {
+		t.Errorf("preview should be capped near %d runes, got %d", contentPreviewLimit, len([]rune(got)))
+	}
+}
+
+// TestRawJSONOrNil_OmitsEmpty confirms empty containers are dropped so
+// the summary stays lean and never emits invalid RawMessage("").
+func TestRawJSONOrNil_OmitsEmpty(t *testing.T) {
+	for _, empty := range []string{"", "{}", "[]", "null", "  "} {
+		if got := rawJSONOrNil(empty); got != nil {
+			t.Errorf("rawJSONOrNil(%q) = %s, want nil", empty, got)
+		}
+	}
+	if got := rawJSONOrNil(`{"a":1}`); string(got) != `{"a":1}` {
+		t.Errorf("rawJSONOrNil should pass through real JSON, got %s", got)
+	}
+	// Malformed stored value must not break marshal — falls back to a
+	// valid JSON string rather than an invalid RawMessage.
+	got := rawJSONOrNil(`{not valid`)
+	if got == nil {
+		t.Fatal("malformed value should fall back, not drop")
+	}
+	if !json.Valid(got) {
+		t.Errorf("fallback must be valid JSON, got %s", got)
+	}
+	if string(got) != `"{not valid"` {
+		t.Errorf("malformed value should be emitted as a JSON string, got %s", got)
+	}
+}
+
+// TestToItemSummaries_EmptyIsNonNil ensures a nil input encodes as `[]`.
+func TestToItemSummaries_EmptyIsNonNil(t *testing.T) {
+	out := ToItemSummaries(nil)
+	if out == nil {
+		t.Fatal("ToItemSummaries(nil) should be non-nil")
+	}
+	b, _ := json.Marshal(out)
+	if string(b) != "[]" {
+		t.Errorf("empty summaries should encode as [], got %s", b)
+	}
+}

--- a/internal/mcp/catalog_item.go
+++ b/internal/mcp/catalog_item.go
@@ -41,11 +41,15 @@ var padItemTool = ToolDef{
 	},
 	Actions: map[string]ActionFn{
 		// Lifecycle
-		"create":  passThrough([]string{"item", "create"}),
-		"update":  passThrough([]string{"item", "update"}),
-		"delete":  passThrough([]string{"item", "delete"}),
-		"get":     passThrough([]string{"item", "show"}),
-		"list":    passThrough([]string{"item", "list"}),
+		"create": passThrough([]string{"item", "create"}),
+		"update": passThrough([]string{"item", "update"}),
+		"delete": passThrough([]string{"item", "delete"}),
+		"get":    passThrough([]string{"item", "show"}),
+		// list is CUSTOM (not passThrough) so a bare agent list stays
+		// bounded: it injects a default limit and clamps an oversized one
+		// before dispatch, mirroring the backlinks default/max. See
+		// actionItemList. TASK-2000.
+		"list":    actionItemList,
 		"move":    passThrough([]string{"item", "move"}),
 		"restore": passThrough([]string{"item", "restore"}),
 
@@ -162,7 +166,7 @@ var padItemSchemaParams = []ParamDef{
 
 	// ── List / starred ──
 	{Name: "all", Type: "bool", Description: "Include archived/done items in list responses. Optional for: list, starred."},
-	{Name: "limit", Type: "number", Description: "Maximum results. Optional for: list, backlinks. Backlinks defaults to 50, max 300."},
+	{Name: "limit", Type: "number", Description: "Maximum results. Optional for: list, backlinks. List defaults to 50, max 300. Backlinks defaults to 50, max 300."},
 	{Name: "offset", Type: "number", Description: "Skip the first N results (paging). Optional for: backlinks."},
 	{Name: "sort", Type: "string", Description: "Sort field. Optional for: list."},
 	{Name: "group_by", Type: "string", Description: "Group-by field. Optional for: list."},
@@ -574,6 +578,41 @@ func normalizeBulkUpdateRefs(raw any) ([]string, error) {
 // (every bulk-update entry).
 func trimSpace(s string) string {
 	return strings.TrimSpace(s)
+}
+
+// MCP list limits (TASK-2000). A bare `pad_item.list` from an agent
+// otherwise dumps the whole workspace into context (the CLI's own default
+// only kicks in via the exec path; the HTTP dispatch path bypasses it). We
+// inject a tight default and clamp an oversized one here so both dispatchers
+// stay bounded. Mirrors the backlinks default/max (50 / 300).
+const (
+	mcpItemListDefaultLimit = 50
+	mcpItemListMaxLimit     = 300
+)
+
+// actionItemList handles pad_item.action=list. It forwards to `item list`
+// but first applies a default limit (when the agent didn't ask for one) and
+// clamps an oversized one, so a bare agent list can't dump the whole
+// workspace into context. Everything else about the input passes through
+// unchanged — collection/status/priority/parent filters, all, etc. (The
+// summary vs full result shape is a CLI-side concern; MCP callers that
+// need a full body fetch it per-item via action=get.)
+func actionItemList(ctx context.Context, input map[string]any, env ActionEnv) (*mcp.CallToolResult, error) {
+	out := make(map[string]any, len(input)+1)
+	for k, v := range input {
+		out[k] = v
+	}
+
+	limit := mcpItemListDefaultLimit
+	if n, ok := numericInput(input["limit"]); ok && n > 0 {
+		limit = int(n)
+	}
+	if limit > mcpItemListMaxLimit {
+		limit = mcpItemListMaxLimit
+	}
+	out["limit"] = limit
+
+	return env.Dispatch(ctx, []string{"item", "list"}, out)
 }
 
 // actionItemExport handles pad_item.action=export. The CLI's

--- a/internal/mcp/catalog_item_list_test.go
+++ b/internal/mcp/catalog_item_list_test.go
@@ -1,0 +1,86 @@
+package mcp
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// TestPadItemList_InjectsDefaultLimit verifies action=list adds a
+// default `--limit` (mcpItemListDefaultLimit) when the agent didn't
+// ask for one, so a bare agent list can't dump the whole workspace
+// into context. TASK-2000.
+func TestPadItemList_InjectsDefaultLimit(t *testing.T) {
+	disp := &fakeDispatcher{}
+	env := ActionEnv{
+		Doc:        liveCmdhelpDoc(t),
+		Workspace:  NewWorkspaceState("docapp"),
+		Dispatcher: disp,
+	}
+	res, err := actionItemList(context.Background(), map[string]any{
+		"collection": "tasks",
+	}, env)
+	if err != nil {
+		t.Fatalf("actionItemList error: %v", err)
+	}
+	if res != nil && res.IsError {
+		t.Fatalf("error result: %s", textOf(res))
+	}
+	if !equalStrings(disp.gotPath, []string{"item", "list"}) {
+		t.Errorf("cmdPath = %v, want [item list]", disp.gotPath)
+	}
+	joined := strings.Join(disp.gotArgs, " ")
+	wantLimit := "--limit 50"
+	if !strings.Contains(joined, wantLimit) {
+		t.Errorf("cliArgs %q should inject the default %q", joined, wantLimit)
+	}
+}
+
+// TestPadItemList_ClampsOversizedLimit verifies an agent-supplied limit
+// above the hard max is clamped down to mcpItemListMaxLimit rather than
+// forwarded verbatim. TASK-2000.
+func TestPadItemList_ClampsOversizedLimit(t *testing.T) {
+	disp := &fakeDispatcher{}
+	env := ActionEnv{
+		Doc:        liveCmdhelpDoc(t),
+		Workspace:  NewWorkspaceState("docapp"),
+		Dispatcher: disp,
+	}
+	// JSON decoders deliver numbers as float64 — mirror that here.
+	_, err := actionItemList(context.Background(), map[string]any{
+		"collection": "tasks",
+		"limit":      float64(999999),
+	}, env)
+	if err != nil {
+		t.Fatalf("actionItemList error: %v", err)
+	}
+	joined := strings.Join(disp.gotArgs, " ")
+	if !strings.Contains(joined, "--limit 300") {
+		t.Errorf("cliArgs %q should clamp oversized limit to 300", joined)
+	}
+	if strings.Contains(joined, "999999") {
+		t.Errorf("cliArgs %q must not forward the oversized limit verbatim", joined)
+	}
+}
+
+// TestPadItemList_RespectsInRangeLimit verifies a reasonable
+// agent-supplied limit passes through untouched. TASK-2000.
+func TestPadItemList_RespectsInRangeLimit(t *testing.T) {
+	disp := &fakeDispatcher{}
+	env := ActionEnv{
+		Doc:        liveCmdhelpDoc(t),
+		Workspace:  NewWorkspaceState("docapp"),
+		Dispatcher: disp,
+	}
+	_, err := actionItemList(context.Background(), map[string]any{
+		"collection": "tasks",
+		"limit":      float64(25),
+	}, env)
+	if err != nil {
+		t.Fatalf("actionItemList error: %v", err)
+	}
+	joined := strings.Join(disp.gotArgs, " ")
+	if !strings.Contains(joined, "--limit 25") {
+		t.Errorf("cliArgs %q should honor an in-range limit of 25", joined)
+	}
+}

--- a/internal/mcp/version.go
+++ b/internal/mcp/version.go
@@ -94,7 +94,26 @@ const CmdhelpVersion = "0.1"
 //     the `artifact` param to the vocabulary. Pure addition; existing
 //     pad_item actions unchanged. Backwards-compatible for v0.6
 //     consumers that don't enumerate the new actions.
-//   - "0.8" — current. TASK-1973: workspace soft-delete recovery.
+//   - "0.9" — current. TASK-2000: `pad_item.list` is now summary-shaped
+//     and bounded. Two changes for agent-token thrift:
+//   - The `list` action injects a default `limit` (50) and clamps an
+//     oversized one (max 300), mirroring the backlinks default/max, so
+//     a bare agent list can't dump the whole workspace into context.
+//   - The list RESULT shape changed: `pad item list` (which the
+//     ExecDispatcher shells out to) now defaults to a token-light
+//     SUMMARY projection — the rich `content` body is replaced by a
+//     short `content_preview`, UUID plumbing (id, workspace_id,
+//     collection_id, *_user_id, parent_id, agent_role_id) and the
+//     duplicate collection/parent join fields are dropped, and
+//     `fields`/`tags` are emitted as nested JSON rather than escaped
+//     strings. This is a BREAKING result-shape change for consumers
+//     that read `content` or the dropped fields off a list row; the
+//     full former shape is available via the CLI `--full` flag (not
+//     yet surfaced as an MCP param — agents that need a full body
+//     fetch it per-item via action=get). No action-enum or param
+//     removals; `limit` semantics unchanged for callers that pass one
+//     under the max.
+//   - "0.8" — historical. TASK-1973: workspace soft-delete recovery.
 //     Adds two actions to `pad_workspace` mirroring the CLI
 //     `pad workspace deleted` / `pad workspace restore` (TASK-1972):
 //     `deleted` (read-only) lists the caller's soft-deleted workspaces
@@ -147,7 +166,7 @@ const CmdhelpVersion = "0.1"
 //   - result.capabilities.experimental.padToolSurface.version (handshake).
 //   - pad://_meta/version resource (queryable JSON document).
 //   - pad_meta.action: tool-surface (full catalog introspection).
-const ToolSurfaceVersion = "0.8"
+const ToolSurfaceVersion = "0.9"
 
 // MetaVersionURI is the canonical URI of the queryable version document.
 // Lives outside the pad://workspace/{ws}/... namespace because it's a

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -2308,6 +2308,12 @@ func autoPopulateDates(newFields map[string]any, existingFieldsJSON string, sche
 	}
 }
 
+// maxItemListQueryLimit is the hard-max clamp applied to a caller-supplied
+// `?limit=` on the item-list endpoints (TASK-2000). It matches the CLI's
+// maxItemListLimit so both layers agree on the ceiling. A zero/absent limit is
+// left unbounded — this only clamps an explicit oversized request.
+const maxItemListQueryLimit = 1000
+
 // parseItemListParams extracts item list parameters from the request query string.
 func parseItemListParams(r *http.Request) models.ItemListParams {
 	params := models.ItemListParams{
@@ -2328,6 +2334,15 @@ func parseItemListParams(r *http.Request) models.ItemListParams {
 		if l, err := strconv.Atoi(limitStr); err == nil {
 			params.Limit = l
 		}
+	}
+	// Hard-max backstop (TASK-2000): clamp an explicit oversized limit so a
+	// raw `?limit=999999` against this endpoint can't materialize the whole
+	// workspace. No default is applied here — a zero/absent limit stays
+	// unbounded so the many internal callers of store.ListItems (dashboard,
+	// bootstrap, playbooks, …) that intentionally fetch every row are
+	// untouched. The CLI applies its own default before it ever reaches here.
+	if params.Limit > maxItemListQueryLimit {
+		params.Limit = maxItemListQueryLimit
 	}
 	if offsetStr := r.URL.Query().Get("offset"); offsetStr != "" {
 		if o, err := strconv.Atoi(offsetStr); err == nil {


### PR DESCRIPTION
## TASK-2000 — Make `item list` summary-shaped for agents

`pad item list --format json` returned the full `models.Item` shape — each item's rich markdown `content` body (~52% of bytes) plus UUID plumbing and duplicate join fields — with no default limit. A bare agent list dumped ~1.4MB (all collections) / 5.3MB (`--all`) into context. Called out as the single biggest agent-token lever.

### CLI (`pad item list`)
- **Default JSON output is now a token-light `ItemSummary` projection**: `content` → short `content_preview` (first heading-stripped line, ≤200 runes); UUIDs (`id`/`workspace_id`/`collection_id`/`*_user_id`/`parent_id`/`agent_role_id`) and duplicate collection/parent join fields dropped; `fields`/`tags` emitted as nested JSON instead of escaped strings. **~71% smaller** on a real workspace (301KB → 87KB for `tasks`).
- **`--full`** opt-in flag restores the complete `models.Item` shape.
- **Default limit 200 + hard-max clamp 1000** so `--all`/huge lists can't dump unboundedly. Table mode prints a stderr note when the result is capped.

### MCP (`pad_item.list`)
- Now a custom action that **injects a default `limit` (50)** and **clamps an oversized one (max 300)**, mirroring the `backlinks` default/max, so a bare agent list stays bounded on both dispatchers.
- `ToolSurfaceVersion` 0.8 → 0.9 (list result shape + limit behavior change; documented in `version.go`).

### Server
- Hard-max backstop clamp (1000) on an explicit `?limit=` at the item-list request boundary. **No default** applied — the many internal `store.ListItems` callers (dashboard, bootstrap, playbooks) that fetch every row are untouched.

### Backward-compat
- The default JSON shape change is the point; `--full` restores the old shape. Web uses its own `/items-index` endpoint (skinny projection), not this path.
- `rawJSONOrNil` guards against a malformed stored `Fields`/`Tags` value breaking the whole list marshal.

### Tests
- `internal/cli/item_summary_test.go` — projection drops content/UUIDs, preview truncation, empty-container omission, malformed-JSON fallback.
- `internal/mcp/catalog_item_list_test.go` — default-limit injection, oversized clamp, in-range passthrough.

Gate green: `go build ./... && go test ./... && golangci-lint run` all pass. Codex-reviewed (2 findings addressed). Behavior verified end-to-end against a live workspace.