### PR TITLE
feat(store): guard against schema-ahead downgrade + pre-migration snapshot + upgrade docs (TASK-2006)

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,37 @@ pad init --url https://app.getpad.dev --workspace my-workspace
 
 Self-hosting stays first-class: the binary is unchanged and no features are Cloud-only.
 
+### Upgrading Pad
+
+Pad ships a new binary on a roughly weekly cadence. Upgrades are designed to be boring: install the new binary and restart. Database migrations run automatically at startup, only the ones your database is missing are applied, and each migration commits atomically (a failed migration rolls back cleanly and is retried next boot).
+
+**The one rule: only ever move forward.** Newer binaries know how to migrate an older database; older binaries do **not** understand a newer schema. Since Pad added its schema-ahead guard, a downgraded binary that finds a database newer than itself refuses to start rather than silently running old code against a newer schema (which can corrupt data):
+
+```
+database schema is newer than this pad binary: ... This almost always means the
+binary was DOWNGRADED (e.g. brew/docker rollback) ... Upgrade pad back to a build
+that includes those migrations, or re-run with `pad start --force`.
+```
+
+To recover, reinstall the newer binary (`brew upgrade pad`, pull the newer Docker tag, etc.). If you have *intentionally* downgraded and accept the risk, start with `pad start --force` (or set `PAD_ALLOW_SCHEMA_AHEAD=1`) to override the guard.
+
+**Automatic pre-migration snapshot (SQLite).** Whenever a SQLite-backed instance has pending migrations to apply, Pad first copies the database file to `pad.db.pre-<version>` next to it. If an upgrade ever goes wrong, stop the server and copy that snapshot back over `pad.db`. This is a convenience net, not a backup strategy — keep your own backups (see [docs/backup.md](docs/backup.md)). PostgreSQL instances are skipped here; use `pg_dump` or a provider snapshot before upgrading.
+
+Recommended upgrade flow:
+
+```bash
+# 1. Back up first (SQLite shown; see docs/backup.md for Postgres)
+pad db backup -o pad-backup-$(date +%Y%m%d).db
+
+# 2. Stop the server, install the new binary, restart
+#    (migrations + the pre-migration snapshot run automatically on start)
+brew upgrade pad        # or: docker pull, binary download, make install
+
+# 3. Confirm it's healthy
+pad --version
+curl -s localhost:7777/api/v1/health
+```
+
 ## Getting Started
 
 ### 1. Set up Pad

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -66,6 +66,16 @@ var (
 	urlFlag       string
 )
 
+// truthyEnv reports whether an environment-variable value means "on".
+func truthyEnv(v string) bool {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
+}
+
 func fullVersion() string {
 	if commit == "" {
 		return version
@@ -286,6 +296,15 @@ func serveCmd() *cobra.Command {
 			}
 			if cmd.Flags().Changed("port") {
 				cfg.Port = port
+			}
+
+			// Label pre-migration snapshots with this build's version, and
+			// honor the schema-ahead-guard escape hatch (--force or
+			// PAD_ALLOW_SCHEMA_AHEAD=1). See internal/store/migration_guard.go.
+			store.BinaryVersion = version
+			forceMigrate, _ := cmd.Flags().GetBool("force")
+			if forceMigrate || truthyEnv(os.Getenv("PAD_ALLOW_SCHEMA_AHEAD")) {
+				store.AllowSchemaAhead = true
 			}
 
 			// Open database (SQLite default, PostgreSQL via PAD_DB_DRIVER)
@@ -1026,6 +1045,7 @@ func serveCmd() *cobra.Command {
 
 	cmd.Flags().StringVar(&host, "host", "127.0.0.1", "host address to listen on")
 	cmd.Flags().IntVar(&port, "port", 7777, "port to listen on")
+	cmd.Flags().Bool("force", false, "start even if the database schema is newer than this binary (a downgrade — risks data corruption; see the README \"Upgrading Pad\" section)")
 
 	return cmd
 }

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -261,6 +261,60 @@ curl http://localhost:7777/api/v1/health
 # {"status":"ok"}
 ```
 
+## Upgrading
+
+Pad releases a new binary roughly weekly. Migrations run automatically at
+startup — only the ones your database is missing are applied, and each one
+commits atomically, so a failed migration rolls back cleanly and is retried
+on the next boot.
+
+**Only ever move forward.** A newer binary can migrate an older database; an
+older binary cannot understand a newer schema. Pad enforces this with a
+schema-ahead guard: if the binary finds a database that carries migrations it
+doesn't ship (the signature of a downgrade — a rolled-back brew formula, an
+older Docker tag, a redeployed prior binary), it **refuses to start** instead
+of silently running old code against a newer schema and corrupting data.
+
+```
+database schema is newer than this pad binary: the database has N migration(s)
+this binary doesn't ship (...) ... This almost always means the binary was
+DOWNGRADED (e.g. brew/docker rollback) ... Upgrade pad back to a build that
+includes those migrations, or ... re-run with `pad start --force`.
+```
+
+- **Recover** by reinstalling the newer binary (`brew upgrade pad`, pull the
+  newer Docker tag, redeploy the newer image).
+- **Override** — only if you have *intentionally* downgraded and accept the
+  data-corruption risk — with `pad start --force` or `PAD_ALLOW_SCHEMA_AHEAD=1`.
+
+### Pre-migration snapshot (SQLite)
+
+When a SQLite-backed instance has pending migrations, Pad copies the database
+file to `pad.db.pre-<version>` (next to the DB) *before* applying them. If an
+upgrade goes wrong, stop the server and copy that file back over `pad.db`. It
+is a convenience net, not a substitute for backups — take a real backup first
+(see [backup.md](backup.md)). The copy is best-effort: if it can't be written
+(read-only volume, full disk) the server logs a warning and proceeds, so keep
+your own backups regardless.
+
+PostgreSQL is not snapshotted this way — take a `pg_dump` or provider snapshot
+before upgrading (see [backup.md](backup.md)).
+
+### Recommended flow
+
+```bash
+# 1. Back up (SQLite shown; pg_dump for Postgres — see backup.md)
+pad db backup -o pad-backup-$(date +%Y%m%d).db
+
+# 2. Stop, install the new binary, restart. Migrations + the pre-migration
+#    snapshot run automatically on start.
+brew upgrade pad     # or: docker pull, binary download, systemctl restart pad
+
+# 3. Verify
+pad --version
+curl -s http://localhost:7777/api/v1/health   # {"status":"ok"}
+```
+
 ## Production Checklist
 
 - [ ] **Database:** PostgreSQL configured with `PAD_DB_DRIVER=postgres`

--- a/internal/store/migration_guard.go
+++ b/internal/store/migration_guard.go
@@ -1,0 +1,206 @@
+package store
+
+import (
+	"database/sql"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"sort"
+	"strings"
+)
+
+// appliedMigrations returns the set of migration version strings recorded
+// in schema_migrations (the full filename, e.g. "073_workspace_deleted_at_idx.sql").
+// The caller must have already ensured the table exists.
+func appliedMigrations(db *sql.DB) (map[string]bool, error) {
+	rows, err := db.Query("SELECT version FROM schema_migrations")
+	if err != nil {
+		return nil, fmt.Errorf("read applied migrations: %w", err)
+	}
+	defer rows.Close()
+
+	applied := make(map[string]bool)
+	for rows.Next() {
+		var v string
+		if err := rows.Scan(&v); err != nil {
+			return nil, fmt.Errorf("scan applied migration: %w", err)
+		}
+		applied[v] = true
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate applied migrations: %w", err)
+	}
+	return applied, nil
+}
+
+// hasPending reports whether any embedded migration has not yet been applied.
+func hasPending(applied map[string]bool, embedded []string) bool {
+	for _, name := range embedded {
+		if !applied[name] {
+			return true
+		}
+	}
+	return false
+}
+
+// guardSchemaAhead refuses to start when the database contains migrations
+// this binary doesn't ship — i.e. the DB is AHEAD of the binary, the
+// tell-tale of a downgrade (brew/docker rollback to an older pad against a
+// newer schema). Running old code on a newer schema silently corrupts data:
+// missing columns, dropped-then-recreated tables, changed constraints.
+//
+// Detection: migration filenames are zero-padded (NNN_name.sql), so they
+// sort lexically in the same order they were authored. Any applied version
+// that sorts AFTER the highest embedded migration is one the binary has
+// never heard of, so the DB is ahead. This is cheap and needs no separate
+// version column.
+//
+// Escape hatch: set AllowSchemaAhead (start --force / PAD_ALLOW_SCHEMA_AHEAD=1)
+// to downgrade the refusal to a warning for the operator who has knowingly
+// downgraded and accepts the risk.
+func guardSchemaAhead(applied map[string]bool, embedded []string) error {
+	if len(embedded) == 0 || len(applied) == 0 {
+		return nil
+	}
+	// embedded is sorted ascending by readMigrationNames.
+	highestEmbedded := embedded[len(embedded)-1]
+
+	var ahead []string
+	for v := range applied {
+		if v > highestEmbedded {
+			ahead = append(ahead, v)
+		}
+	}
+	if len(ahead) == 0 {
+		return nil
+	}
+	sort.Strings(ahead)
+
+	if AllowSchemaAhead {
+		slog.Warn(
+			"database schema is AHEAD of this binary — proceeding anyway because the schema-ahead guard was overridden; old code running against a newer schema can corrupt data",
+			"unknown_migrations", strings.Join(ahead, ","),
+			"highest_known", highestEmbedded,
+		)
+		return nil
+	}
+
+	return fmt.Errorf(
+		"database schema is newer than this pad binary: the database has %d migration(s) this binary doesn't ship (%s), the newest known to this binary is %s. "+
+			"This almost always means the binary was DOWNGRADED (e.g. brew/docker rollback) — running old code against a newer schema can corrupt data. "+
+			"Upgrade pad back to a build that includes those migrations, or, if you have intentionally downgraded and accept the risk, re-run with `pad start --force` (or PAD_ALLOW_SCHEMA_AHEAD=1). "+
+			"See the \"Upgrading Pad\" section of the README",
+		len(ahead), strings.Join(ahead, ", "), highestEmbedded,
+	)
+}
+
+// snapshotBeforeMigrate copies the live SQLite database file to
+// <db>.pre-<VERSION> before any pending migrations run, so a botched
+// upgrade can be rolled back by copying the snapshot back over the DB.
+//
+// SQLite-only and best-effort: any failure (checkpoint, copy, missing
+// file) is logged as a warning and migration proceeds. Refusing to boot
+// because a backup file couldn't be written (read-only volume, full disk)
+// would be worse than proceeding — the operator following the upgrade docs
+// keeps their own backup regardless.
+func (s *Store) snapshotBeforeMigrate() {
+	if s.dialect.Driver() != DriverSQLite {
+		return // Postgres: snapshots are the operator's pg_dump/PITR job.
+	}
+	if s.dbPath == "" || strings.HasPrefix(s.dbPath, ":memory:") || strings.Contains(s.dbPath, "mode=memory") {
+		return // in-memory DB: nothing on disk to copy.
+	}
+	if _, err := os.Stat(s.dbPath); err != nil {
+		return // no file yet (fresh DB) — nothing to snapshot.
+	}
+
+	dst := s.dbPath + ".pre-" + sanitizeVersion(BinaryVersion)
+
+	// Preserve the FIRST snapshot taken for this binary version. Migrations
+	// apply one file at a time, so a failed migration can leave some already
+	// committed; the next boot still sees pending migrations and would call
+	// us again. Overwriting here would replace the true pre-upgrade snapshot
+	// with a half-migrated DB — destroying the rollback point. If a snapshot
+	// for this version already exists, keep it.
+	if _, err := os.Stat(dst); err == nil {
+		slog.Info("pre-migration snapshot already exists; preserving it", "path", dst)
+		return
+	}
+
+	// Flush the WAL into the main DB file so the copy is a complete,
+	// self-contained snapshot (no dependence on -wal/-shm sidecars).
+	// wal_checkpoint returns a (busy, log, checkpointed) row rather than an
+	// error when it can't fully checkpoint; surface that so an incomplete
+	// snapshot isn't taken silently. At startup the DB has a single
+	// connection and no live readers, so busy should always be 0.
+	var busy, logFrames, ckpt sql.NullInt64
+	if err := s.db.QueryRow("PRAGMA wal_checkpoint(TRUNCATE)").Scan(&busy, &logFrames, &ckpt); err != nil {
+		slog.Warn("pre-migration snapshot: WAL checkpoint failed; snapshot may be incomplete", "error", err)
+	} else if busy.Int64 != 0 {
+		slog.Warn("pre-migration snapshot: WAL checkpoint reported busy; snapshot may miss un-checkpointed WAL frames", "log_frames", logFrames.Int64)
+	}
+
+	if err := copyFileContents(s.dbPath, dst); err != nil {
+		slog.Warn("pre-migration snapshot failed; continuing with migration (make sure you have your own backup)", "dest", dst, "error", err)
+		return
+	}
+	slog.Info("wrote pre-migration database snapshot", "path", dst)
+}
+
+// sanitizeVersion makes a build-version string safe as a filename suffix.
+// Build versions can carry spaces/parens (e.g. "1.2.3 (abc1234)"); collapse
+// anything outside [A-Za-z0-9._-] to a hyphen so the snapshot path is clean.
+func sanitizeVersion(v string) string {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return "unknown"
+	}
+	var b strings.Builder
+	for _, r := range v {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '.', r == '_', r == '-':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('-')
+		}
+	}
+	return b.String()
+}
+
+// copyFileContents copies src to dst atomically: it writes to a sibling
+// temp file, fsyncs it, then renames it into place. A failure therefore
+// never leaves a partial file at dst that a later existence check would
+// mistake for a complete snapshot.
+func copyFileContents(src, dst string) (err error) {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	tmp := dst + ".tmp"
+	out, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	if err != nil {
+		return err
+	}
+	// Clean up the temp file on any error path.
+	defer func() {
+		if err != nil {
+			_ = os.Remove(tmp)
+		}
+	}()
+
+	if _, err = io.Copy(out, in); err != nil {
+		out.Close()
+		return err
+	}
+	if err = out.Sync(); err != nil {
+		out.Close()
+		return err
+	}
+	if err = out.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmp, dst)
+}

--- a/internal/store/migration_guard_test.go
+++ b/internal/store/migration_guard_test.go
@@ -1,0 +1,219 @@
+package store
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestGuardSchemaAhead_Detection covers the pure detection logic: a DB is
+// "ahead" iff it has an applied migration that sorts after the highest
+// embedded one.
+func TestGuardSchemaAhead_Detection(t *testing.T) {
+	embedded := []string{"001_initial.sql", "002_foo.sql", "003_bar.sql"}
+
+	cases := []struct {
+		name      string
+		applied   []string
+		wantError bool
+	}{
+		{"fresh db (nothing applied)", nil, false},
+		{"in sync", []string{"001_initial.sql", "002_foo.sql", "003_bar.sql"}, false},
+		{"behind (missing latest)", []string{"001_initial.sql", "002_foo.sql"}, false},
+		{"ahead by one", []string{"001_initial.sql", "002_foo.sql", "003_bar.sql", "004_future.sql"}, true},
+		{"ahead by several", []string{"003_bar.sql", "010_way_ahead.sql", "011_more.sql"}, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			applied := make(map[string]bool, len(tc.applied))
+			for _, v := range tc.applied {
+				applied[v] = true
+			}
+			err := guardSchemaAhead(applied, embedded)
+			if tc.wantError && err == nil {
+				t.Fatalf("expected schema-ahead error, got nil")
+			}
+			if !tc.wantError && err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+			if tc.wantError && !strings.Contains(err.Error(), "newer than this pad binary") {
+				t.Fatalf("error should explain the downgrade, got: %v", err)
+			}
+		})
+	}
+}
+
+// TestGuardSchemaAhead_ForceOverride verifies the escape hatch: with
+// AllowSchemaAhead set, an ahead DB is allowed through (warning only).
+func TestGuardSchemaAhead_ForceOverride(t *testing.T) {
+	prev := AllowSchemaAhead
+	t.Cleanup(func() { AllowSchemaAhead = prev })
+
+	embedded := []string{"001_initial.sql", "002_foo.sql"}
+	applied := map[string]bool{"001_initial.sql": true, "002_foo.sql": true, "003_future.sql": true}
+
+	if err := guardSchemaAhead(applied, embedded); err == nil {
+		t.Fatalf("without override, expected error")
+	}
+
+	AllowSchemaAhead = true
+	if err := guardSchemaAhead(applied, embedded); err != nil {
+		t.Fatalf("with override, expected nil, got %v", err)
+	}
+}
+
+// TestMigrate_RefusesSchemaAheadDB is the end-to-end guard: a DB carrying a
+// migration this binary doesn't ship must fail New(), and must succeed once
+// the override is set.
+func TestMigrate_RefusesSchemaAheadDB(t *testing.T) {
+	if os.Getenv("PAD_TEST_POSTGRES_URL") != "" {
+		t.Skip("SQLite-specific path")
+	}
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "ahead.db")
+
+	// Fully migrate a fresh DB, then stamp a from-the-future migration row.
+	s, err := New(dbPath)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if _, err := s.db.Exec(
+		"INSERT INTO schema_migrations (version, applied_at) VALUES ('999_from_the_future.sql', '2099-01-01T00:00:00Z')",
+	); err != nil {
+		t.Fatalf("stamp future migration: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// Reopening must now be refused.
+	prev := AllowSchemaAhead
+	t.Cleanup(func() { AllowSchemaAhead = prev })
+	AllowSchemaAhead = false
+
+	if _, err := New(dbPath); err == nil {
+		t.Fatalf("expected New() to refuse a schema-ahead DB")
+	} else if !strings.Contains(err.Error(), "newer than this pad binary") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// With the override, it must open.
+	AllowSchemaAhead = true
+	s2, err := New(dbPath)
+	if err != nil {
+		t.Fatalf("New() with override should succeed, got %v", err)
+	}
+	s2.Close()
+}
+
+// TestSnapshotBeforeMigrate_WritesCopy verifies the SQLite snapshot writes a
+// byte-faithful copy next to the DB, named for the binary version.
+func TestSnapshotBeforeMigrate_WritesCopy(t *testing.T) {
+	if os.Getenv("PAD_TEST_POSTGRES_URL") != "" {
+		t.Skip("SQLite-specific path")
+	}
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "snap.db")
+	s, err := New(dbPath)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer s.Close()
+
+	prev := BinaryVersion
+	t.Cleanup(func() { BinaryVersion = prev })
+	BinaryVersion = "9.9.9 (deadbee)" // exercises sanitizeVersion
+
+	s.snapshotBeforeMigrate()
+
+	dst := dbPath + ".pre-9.9.9--deadbee-"
+	info, err := os.Stat(dst)
+	if err != nil {
+		t.Fatalf("snapshot not written at %s: %v", dst, err)
+	}
+	if info.Size() == 0 {
+		t.Fatalf("snapshot is empty")
+	}
+
+	// The snapshot must be a real SQLite DB — open it and read a known table.
+	snap, err := New(dst) // migrates cleanly (already fully migrated copy)
+	if err != nil {
+		t.Fatalf("snapshot is not a usable DB: %v", err)
+	}
+	defer snap.Close()
+	var n int
+	if err := snap.db.QueryRow("SELECT COUNT(*) FROM schema_migrations").Scan(&n); err != nil {
+		t.Fatalf("query snapshot: %v", err)
+	}
+	if n == 0 {
+		t.Fatalf("snapshot has no applied migrations recorded")
+	}
+}
+
+// TestSnapshotBeforeMigrate_PreservesExisting verifies a retry doesn't
+// clobber the original pre-upgrade snapshot with a later (partially-migrated)
+// DB state.
+func TestSnapshotBeforeMigrate_PreservesExisting(t *testing.T) {
+	if os.Getenv("PAD_TEST_POSTGRES_URL") != "" {
+		t.Skip("SQLite-specific path")
+	}
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "snap.db")
+	s, err := New(dbPath)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer s.Close()
+
+	prev := BinaryVersion
+	t.Cleanup(func() { BinaryVersion = prev })
+	BinaryVersion = "1.0.0"
+	dst := dbPath + ".pre-1.0.0"
+
+	// Pre-seed a sentinel snapshot as if a prior boot already wrote it.
+	if err := os.WriteFile(dst, []byte("ORIGINAL-PRE-UPGRADE-STATE"), 0o600); err != nil {
+		t.Fatalf("seed snapshot: %v", err)
+	}
+
+	s.snapshotBeforeMigrate() // must NOT overwrite the existing snapshot
+
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("read snapshot: %v", err)
+	}
+	if string(got) != "ORIGINAL-PRE-UPGRADE-STATE" {
+		t.Fatalf("existing snapshot was overwritten; want sentinel, got %d bytes", len(got))
+	}
+}
+
+// TestSnapshotBeforeMigrate_SkipsInMemory ensures the snapshot path is a
+// no-op for a store with no on-disk file (defensive: guards the dbPath gate).
+func TestSnapshotBeforeMigrate_SkipsNoFile(t *testing.T) {
+	s := &Store{dialect: &sqliteDialect{}, dbPath: ""}
+	s.snapshotBeforeMigrate() // must not panic; nothing to do
+
+	// A path that doesn't exist on disk is also a silent no-op.
+	s2 := &Store{dialect: &sqliteDialect{}, dbPath: filepath.Join(t.TempDir(), "does-not-exist.db")}
+	s2.snapshotBeforeMigrate()
+	if _, err := os.Stat(s2.dbPath + ".pre-" + sanitizeVersion(BinaryVersion)); !os.IsNotExist(err) {
+		t.Fatalf("expected no snapshot for a missing DB file")
+	}
+}
+
+func TestSanitizeVersion(t *testing.T) {
+	cases := map[string]string{
+		"dev":             "dev",
+		"1.2.3":           "1.2.3",
+		"v1.2.3":          "v1.2.3",
+		"1.2.3 (abc1234)": "1.2.3--abc1234-",
+		"  ":              "unknown",
+		"weird/../path":   "weird-..-path",
+	}
+	for in, want := range cases {
+		if got := sanitizeVersion(in); got != want {
+			t.Errorf("sanitizeVersion(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -23,9 +23,27 @@ var migrationsFS embed.FS
 //go:embed pgmigrations/*.sql
 var pgMigrationsFS embed.FS
 
+// BinaryVersion labels the pre-migration snapshot file
+// (<db>.pre-<VERSION>). The `pad` binary sets it to its build version at
+// startup; it defaults to "dev" so tests and direct library callers still
+// produce a sensibly-named snapshot. See snapshotBeforeMigrate.
+var BinaryVersion = "dev"
+
+// AllowSchemaAhead downgrades the schema-ahead migration guard (see
+// guardSchemaAhead) from a fatal error to a logged warning. It is the
+// escape hatch for the rare operator who has knowingly downgraded the
+// binary and accepts running old code against a newer schema. The `pad`
+// binary wires it to `start --force` / PAD_ALLOW_SCHEMA_AHEAD=1; tests
+// toggle it directly.
+var AllowSchemaAhead bool
+
 type Store struct {
-	db            *sql.DB
-	dialect       Dialect
+	db      *sql.DB
+	dialect Dialect
+	// dbPath is the on-disk SQLite file path (empty for Postgres and for
+	// in-memory SQLite). Retained so the migration path can write a
+	// pre-migration snapshot next to it. See snapshotBeforeMigrate.
+	dbPath        string
 	encryptionKey []byte // 32-byte AES-256 key for encrypting sensitive fields (e.g., TOTP secrets)
 
 	// stopMaint signals the background WAL checkpointer to exit; maintDone
@@ -139,7 +157,7 @@ func New(dbPath string) (*Store, error) {
 	db.SetMaxIdleConns(sqliteMaxOpenConns)
 	db.SetConnMaxLifetime(time.Hour)
 
-	s := &Store{db: db, dialect: &sqliteDialect{}}
+	s := &Store{db: db, dialect: &sqliteDialect{}, dbPath: dbPath}
 	if err := s.migrate(); err != nil {
 		return nil, fmt.Errorf("migrate: %w", err)
 	}
@@ -284,13 +302,28 @@ func (s *Store) migrate() error {
 		return err
 	}
 
+	applied, err := appliedMigrations(s.db)
+	if err != nil {
+		return err
+	}
+
+	// Refuse to run against a DB that is AHEAD of this binary — i.e. a
+	// downgrade, where old code would silently operate on a newer schema.
+	if err := guardSchemaAhead(applied, migrations); err != nil {
+		return err
+	}
+
+	// Snapshot the DB file before applying any pending migrations, so a
+	// bad upgrade can be rolled back by copying the snapshot over the DB.
+	// Only when this is an UPGRADE of an existing DB (pending migrations
+	// AND at least one already applied) — a fresh install has nothing
+	// worth snapshotting. Best-effort; a failed snapshot warns, not fatal.
+	if len(applied) > 0 && hasPending(applied, migrations) {
+		s.snapshotBeforeMigrate()
+	}
+
 	for _, name := range migrations {
-		// Check if already applied
-		var count int
-		if err := s.db.QueryRow("SELECT COUNT(*) FROM schema_migrations WHERE version = ?", name).Scan(&count); err != nil {
-			return fmt.Errorf("check migration %s: %w", name, err)
-		}
-		if count > 0 {
+		if applied[name] {
 			continue
 		}
 
@@ -398,12 +431,21 @@ func (s *Store) migratePostgres() error {
 		return err
 	}
 
+	applied, err := appliedMigrations(s.db)
+	if err != nil {
+		return err
+	}
+
+	// Same schema-ahead guard as SQLite (a Postgres binary downgrade is
+	// equally unsafe). No pre-migration snapshot on Postgres — backups
+	// there are the operator's DBA responsibility (pg_dump / PITR), not
+	// something we can safely fake with a file copy.
+	if err := guardSchemaAhead(applied, migrations); err != nil {
+		return err
+	}
+
 	for _, name := range migrations {
-		var count int
-		if err := s.db.QueryRow("SELECT COUNT(*) FROM schema_migrations WHERE version = $1", name).Scan(&count); err != nil {
-			return fmt.Errorf("check migration %s: %w", name, err)
-		}
-		if count > 0 {
+		if applied[name] {
 			continue
 		}
 


### PR DESCRIPTION
## What & why

Pad ships weekly, auto-applies 73 migrations at startup, and had **zero** upgrade docs. Worse, `migrate()` only applied *missing* embedded migrations — it never detected a DB that was **ahead** of the binary, so a brew/docker **downgrade** silently ran old code against a newer schema (data-corruption risk). No snapshot was taken before migrating.

Fixes all three parts of TASK-2006:

### 1. Schema-ahead guard (`guardSchemaAhead`)
Refuses to start when `schema_migrations` contains a version that sorts after the highest embedded migration — the signature of a downgrade. Clear error pointing at the fix. Applied to **both** SQLite and Postgres migration paths. Escape hatch for intentional downgrades: `pad start --force` or `PAD_ALLOW_SCHEMA_AHEAD=1`.

### 2. Pre-migration snapshot (SQLite only)
Before applying pending migrations, copies the DB file to `<db>.pre-<VERSION>`, but only when **upgrading an existing DB** (pending migrations AND at least one already applied — a fresh install has nothing worth snapshotting). WAL-checkpointed for a self-contained copy; atomic temp+rename so a failed copy never leaves a partial file; **preserves an existing snapshot on retry** so a failed multi-step upgrade can't clobber the original rollback point. Postgres is skipped gracefully (pg_dump/PITR is the operator's job).

### 3. Docs
"Upgrading Pad" section in `README.md` and an "Upgrading" section in `docs/deployment.md`: the forward-only rule, guard behavior + recovery, the snapshot, and a recommended upgrade flow.

## Tests
`internal/store/migration_guard_test.go`: guard detection matrix, force override, end-to-end `New()` refusal + override, snapshot write/skip/preserve-on-retry, and `sanitizeVersion`.

## Review
Codex-reviewed. Addressed: (a) snapshot no longer overwrites the original rollback point on retry; (b) `wal_checkpoint` result row is now inspected and a busy checkpoint is surfaced rather than silently producing an incomplete snapshot. Findings on unknown-lower migrations and URI DSNs are non-issues here (migrations are append-only/never-renamed; `store.New` always receives a plain filesystem path).

Gates green: `go build ./...`, `go test ./...`, `golangci-lint run ./internal/store/... ./cmd/pad/...`.