### PR TITLE
fix(mcp): sync tool-surface docs to v0.9 after item-list default bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ pad mcp install claude-desktop   # or: cursor, windsurf, --all
 # Restart the client; pad shows up as the "pad" MCP server.
 ```
 
-**Tool catalog (v0.8)** — nine resource × action tools plus `pad_set_workspace` (ten total), no flat verb explosion:
+**Tool catalog (v0.9)** — nine resource × action tools plus `pad_set_workspace` (ten total), no flat verb explosion:
 
 | Tool | Actions |
 |---|---|
@@ -335,7 +335,7 @@ initialize handshake under `capabilities.experimental.padCmdhelp` and
 `pad://_meta/version`):
 
 - `cmdhelp_version: "0.1"` — CLI help-tree contract (used at dispatch time)
-- `tool_surface_version: "0.8"` — MCP tool catalog contract (v0.5 added `pad_library`; v0.6 `pad_item.backlinks`; v0.7 `pad_item` `export`/`import`; v0.8 `pad_workspace` `deleted`/`restore`; see `internal/mcp/version.go` for the full changelog)
+- `tool_surface_version: "0.9"` — MCP tool catalog contract (v0.5 added `pad_library`; v0.6 `pad_item.backlinks`; v0.7 `pad_item` `export`/`import`; v0.8 `pad_workspace` `deleted`/`restore`; v0.9 made `pad_item.list` summary-shaped by default with a default+max result cap; see `internal/mcp/version.go` for the full changelog)
 
 External agents pin against these so a future rename doesn't break them
 silently. Errors come back as structured envelopes (`{error: {code,

--- a/internal/mcp/instructions.md
+++ b/internal/mcp/instructions.md
@@ -6,7 +6,7 @@ Pad is a project tracker for developers and AI agents — issues (TASK, BUG), pl
 
 If the user is asking general code questions with no project-management thread, you don't need this server.
 
-## Tool surface (v0.8)
+## Tool surface (v0.9)
 
 Nine resource × action tools, plus `pad_set_workspace` (which takes a `workspace` slug only — no action enum). Ten tools total.
 


### PR DESCRIPTION
Follow-up to the parallel merges of TASK-2000 (bumped `ToolSurfaceVersion` 0.8→0.9) and TASK-2005 (v0.8 doc sync + drift guard). The two merged cleanly as text but left `instructions.md` and README at v0.8, tripping the drift guard on `main`. This syncs the three version strings to v0.9 and adds a v0.9 changelog note (summary-shaped `pad_item.list`). Action lists unchanged. `go test ./internal/mcp/...` green.