### PR TITLE
fix(server,cli,mcp): default item list to per-collection non-terminal filter (BUG-2001)

### DIFF
--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -3609,11 +3609,12 @@ Examples:
 			if statusFilter != "" {
 				params.Set("status", statusFilter)
 			} else if !showAll {
-				// Default: exclude terminal statuses (done, completed, archived, etc.)
-				// Rather than listing all active statuses, we fetch all items and
-				// let the server filter. We use a broad inclusion list that covers
-				// all built-in templates plus common custom statuses.
-				params.Set("status", "open,in_progress,in-progress,active,draft,raw,exploring,decided,new,triaged,fixing,planned,published,paused,proposed,researching,building,ready,in_sprint,reviewed,planning")
+				// Default: exclude terminal statuses (done, fixed, rejected, etc.).
+				// The server resolves "terminal" per-collection from each schema's
+				// terminal_options, so collections with custom status vocabularies
+				// (e.g. todo/drafting/scheduled) show their open items instead of
+				// being hidden behind a hardcoded global allowlist (BUG-2001).
+				params.Set("non_terminal", "true")
 			}
 			if priorityFilter != "" {
 				params.Set("priority", priorityFilter)

--- a/internal/mcp/dispatch_http_routes.go
+++ b/internal/mcp/dispatch_http_routes.go
@@ -1098,17 +1098,12 @@ func mapWorkspaceInvite(input map[string]any) (string, string, []byte, error) {
 	return http.MethodPost, urlPath, body, nil
 }
 
-// defaultActiveStatusFilter mirrors the broad inclusion list the
-// CLI sets when neither --status nor --all is provided. Hides
-// terminal statuses (done / completed / archived / etc.) by default
-// without making the dispatcher have to fetch+filter, which would be
-// a behaviour divergence from `pad item list` if we simply omitted
-// the filter (Codex review on PR #344, finding 1).
-//
-// Kept as a constant — pad's status vocabulary is template-driven
-// and changes rarely; the CLI's literal list at cmd/pad/main.go
-// itemListCmd is the source of truth, mirrored here.
-const defaultActiveStatusFilter = "open,in_progress,in-progress,active,draft,raw,exploring,decided,new,triaged,fixing,planned,published,paused,proposed,researching,building,ready,in_sprint,reviewed,planning"
+// (BUG-2001) The dispatcher used to mirror the CLI's hardcoded
+// active-status allowlist here. That wrongly hid open items in
+// collections with custom status vocabularies. It now sends
+// `non_terminal=true`, which the server resolves per-collection from
+// each schema's terminal_options — identical to the CLI default. See
+// mapItemList below.
 
 // mapItemList dispatches `pad item list [collection] [filters...]`.
 //
@@ -1120,10 +1115,10 @@ const defaultActiveStatusFilter = "open,in_progress,in-progress,active,draft,raw
 // Filter parity with the CLI:
 //
 //   - `--status X` → `?status=X` directly.
-//   - Neither `--status` nor `--all` → broad active-status filter
-//     (matches the CLI's hardcoded list so done items don't leak by
-//     default — see defaultActiveStatusFilter).
-//   - `--all` → `?include_archived=true`, and the default-status
+//   - Neither `--status` nor `--all` → `?non_terminal=true`, which the
+//     server resolves per-collection from each schema's terminal_options
+//     so custom status vocabularies show their open items (BUG-2001).
+//   - `--all` → `?include_archived=true`, and the non-terminal
 //     filter is dropped so all statuses pass.
 //   - `--parent <ref>` → `?parent=<ref>`. The handler's
 //     resolveParentFilter resolves the ref via the field-filter path.
@@ -1167,8 +1162,10 @@ func mapItemList(input map[string]any) (string, string, []byte, error) {
 	if s, _ := input["status"].(string); s != "" {
 		add("status", s)
 	} else if b, _ := input["all"].(bool); !b {
-		// CLI parity: hide terminal statuses by default. --all overrides.
-		add("status", defaultActiveStatusFilter)
+		// CLI parity: hide terminal items by default. The server resolves
+		// "terminal" per-collection from each schema's terminal_options, so
+		// custom status vocabularies work (BUG-2001). --all overrides.
+		add("non_terminal", "true")
 	}
 	if s, _ := input["priority"].(string); s != "" {
 		add("priority", s)

--- a/internal/mcp/dispatch_http_routes_test.go
+++ b/internal/mcp/dispatch_http_routes_test.go
@@ -238,11 +238,12 @@ func TestRoute_ItemDelete(t *testing.T) {
 	}
 }
 
-func TestRoute_ItemList_AllItemsPath_AppliesDefaultActiveStatusFilter(t *testing.T) {
-	// CLI parity: bare `pad item list` hides terminal statuses by
-	// default. The HTTP mapper must apply the same broad inclusion
-	// list — Codex caught a regression where it returned no status
-	// filter and would have leaked done items to agents.
+func TestRoute_ItemList_AllItemsPath_AppliesNonTerminalFilter(t *testing.T) {
+	// CLI parity: bare `pad item list` hides terminal items by default.
+	// The HTTP mapper must send `non_terminal=true` so the server resolves
+	// "terminal" per-collection from each schema's terminal_options rather
+	// than a hardcoded status allowlist that hides custom vocabularies
+	// (BUG-2001). It must NOT send an explicit status filter.
 	m, p, _, err := routeTable["item list"](map[string]any{"workspace": "docapp"})
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -254,29 +255,18 @@ func TestRoute_ItemList_AllItemsPath_AppliesDefaultActiveStatusFilter(t *testing
 		t.Errorf("expected cross-collection path with query, got %q", p)
 	}
 	values := mustParseQueryFromPath(t, p)
-	got := values.Get("status")
-	if got == "" {
-		t.Errorf("default status filter missing; got query %v", values)
+	if values.Get("non_terminal") != "true" {
+		t.Errorf("expected non_terminal=true; got query %v", values)
 	}
-	// Spot-check a few well-known active statuses.
-	for _, want := range []string{"open", "in_progress", "draft", "exploring"} {
-		if !strings.Contains(got, want) {
-			t.Errorf("default status filter missing %q; got %q", want, got)
-		}
-	}
-	// And confirm terminal statuses are NOT included.
-	for _, blocked := range []string{"done", "completed", "archived"} {
-		if strings.Contains(got, blocked) {
-			t.Errorf("default status filter incorrectly includes %q; got %q", blocked, got)
-		}
+	if values.Has("status") {
+		t.Errorf("must not send a hardcoded status filter; got %v", values)
 	}
 }
 
-func TestRoute_ItemList_AllFlagDropsDefaultStatus(t *testing.T) {
-	// `--all` overrides the active-status default. Both
-	// include_archived=true must be set AND the default status
-	// inclusion list must NOT be present (otherwise --all wouldn't
-	// actually let through done items).
+func TestRoute_ItemList_AllFlagDropsNonTerminal(t *testing.T) {
+	// `--all` overrides the non-terminal default. include_archived=true
+	// must be set AND the non_terminal filter must NOT be present
+	// (otherwise --all wouldn't actually let through terminal items).
 	_, p, _, err := routeTable["item list"](map[string]any{
 		"workspace": "docapp", "all": true,
 	})
@@ -287,8 +277,11 @@ func TestRoute_ItemList_AllFlagDropsDefaultStatus(t *testing.T) {
 	if values.Get("include_archived") != "true" {
 		t.Errorf("include_archived not set under --all; got %v", values)
 	}
+	if values.Has("non_terminal") {
+		t.Errorf("non_terminal filter must be dropped under --all; got %v", values)
+	}
 	if values.Has("status") {
-		t.Errorf("status filter must be dropped under --all; got %v", values)
+		t.Errorf("status filter must not be set under --all; got %v", values)
 	}
 }
 
@@ -314,7 +307,7 @@ func TestRoute_ItemList_CollectionScopedPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	// Path may carry the default-active-status query string from the
+	// Path may carry the non_terminal=true query string from the
 	// no-explicit-status branch — we only assert the path prefix here.
 	if !strings.HasPrefix(p, "/api/v1/workspaces/docapp/collections/tasks/items") {
 		t.Errorf("expected collection-scoped + normalized path, got %q", p)

--- a/internal/models/item.go
+++ b/internal/models/item.go
@@ -798,8 +798,16 @@ type ItemListParams struct {
 	AgentRoleID     string // filter by agent role (ID or slug)
 	ParentLinkID    string // filter by parent link (item ID of the parent)
 	IncludeArchived bool
-	Limit           int
-	Offset          int
+	// NonTerminal, when true, restricts results to items whose resolved
+	// done-field value is NOT one of their collection's terminal options.
+	// Each collection is evaluated against its OWN terminal_options (falling
+	// back to DefaultTerminalStatuses when the schema declares none), so
+	// collections with custom status vocabularies (e.g. todo/drafting/
+	// scheduled) are handled correctly rather than against a hardcoded
+	// global status allowlist (BUG-2001).
+	NonTerminal bool
+	Limit       int
+	Offset      int
 }
 
 // TagCount is a distinct tag used within a workspace and the number of items

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -2350,11 +2350,19 @@ func parseItemListParams(r *http.Request) models.ItemListParams {
 		}
 	}
 
+	// non_terminal=true restricts results to items that are NOT in their
+	// collection's terminal state, resolved per-collection from each
+	// schema's terminal_options (BUG-2001). This is the CLI/MCP default
+	// list behavior; an explicit status/field filter is applied on top.
+	if r.URL.Query().Get("non_terminal") == "true" {
+		params.NonTerminal = true
+	}
+
 	// Extract field filters: any query param that isn't a known param is a field filter.
 	knownParams := map[string]bool{
 		"sort": true, "group_by": true, "search": true, "parent_id": true,
 		"tag": true, "include_archived": true, "limit": true, "offset": true,
-		"assigned_user_id": true, "agent_role_id": true,
+		"assigned_user_id": true, "agent_role_id": true, "non_terminal": true,
 	}
 
 	fields := make(map[string]string)

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -819,6 +819,15 @@ func (s *Store) ListItems(workspaceID string, params models.ItemListParams) ([]m
 		}
 	}
 
+	// Non-terminal filter (BUG-2001): keep only items whose resolved done
+	// field is NOT one of their collection's terminal options. Evaluated
+	// per-collection so custom status vocabularies work.
+	if params.NonTerminal {
+		clause, ntArgs := s.nonTerminalFilter(workspaceID, "i")
+		query += " AND " + clause
+		args = append(args, ntArgs...)
+	}
+
 	// Sorting
 	query += buildItemSort(params.Sort, s.dialect)
 
@@ -1560,6 +1569,15 @@ func (s *Store) listItemsFTS(workspaceID string, params models.ItemListParams) (
 			query += " AND " + jsonExpr + " = ?"
 			args = append(args, value)
 		}
+	}
+
+	// Non-terminal filter (BUG-2001) — parity with the non-FTS path so a
+	// `search + non_terminal` combination hides terminal items per each
+	// collection's own terminal_options.
+	if params.NonTerminal {
+		clause, ntArgs := s.nonTerminalFilter(workspaceID, "i")
+		query += " AND " + clause
+		args = append(args, ntArgs...)
 	}
 
 	// SQLite bm25(): more negative = more relevant → ASC (default).
@@ -2866,6 +2884,28 @@ func (s *Store) buildChildrenDoneExpr(filters []collectionDoneFilter, itemAlias 
 		))
 	}
 	return "(" + strings.Join(clauses, " OR ") + ")", args
+}
+
+// nonTerminalFilter builds a WHERE fragment (plus ordered args) that keeps
+// only items whose resolved done-field value is NOT one of their
+// collection's terminal options. It reuses the same per-collection done
+// machinery as parent-progress (doneFiltersForWorkspace +
+// buildChildrenDoneExpr): buildChildrenDoneExpr yields an expression that
+// is TRUE when an item is terminal, so negating it selects the
+// non-terminal set.
+//
+// Each collection is evaluated against its OWN terminal_options (with the
+// global DefaultTerminalStatuses fallback for schemas that declare none),
+// so collections with custom status vocabularies are handled correctly
+// rather than against a hardcoded global allowlist (BUG-2001). This is the
+// server-side default that both the CLI (`pad item list` with no --status/
+// --all) and the MCP `pad_item.action=list` inherit.
+//
+// itemAlias is the item-table alias in the outer query (e.g. "i").
+func (s *Store) nonTerminalFilter(workspaceID, itemAlias string) (string, []any) {
+	filters := s.doneFiltersForWorkspace(workspaceID)
+	doneExpr, args := s.buildChildrenDoneExpr(filters, itemAlias)
+	return "NOT " + doneExpr, args
 }
 
 // ItemProgress holds child item completion counts for a single parent item.

--- a/internal/store/non_terminal_filter_test.go
+++ b/internal/store/non_terminal_filter_test.go
@@ -1,0 +1,112 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// TestListItems_NonTerminalFilter is the BUG-2001 acceptance test: the
+// default (no --status / no --all) `pad item list` must resolve "open"
+// per-collection from each schema's terminal_options, so collections with
+// CUSTOM status vocabularies (todo / drafting / scheduled) show their open
+// items instead of being hidden behind a hardcoded global allowlist.
+func TestListItems_NonTerminalFilter(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "NonTerminalFilter")
+
+	// A collection with a CUSTOM status vocabulary that the old hardcoded
+	// allowlist did NOT cover: `todo`, `drafting`, `scheduled` are open;
+	// only `published` is terminal.
+	blog, err := s.CreateCollection(ws.ID, models.CollectionCreate{
+		Name:   "Blog",
+		Schema: `{"fields":[{"key":"status","label":"Status","type":"select","options":["todo","drafting","scheduled","published"],"terminal_options":["published"],"default":"todo"}]}`,
+	})
+	if err != nil {
+		t.Fatalf("create blog collection: %v", err)
+	}
+
+	// A second collection with the built-in `done` terminal so we confirm
+	// the per-collection resolution composes across collections.
+	tasks, err := s.CreateCollection(ws.ID, models.CollectionCreate{
+		Name:   "Tasks",
+		Schema: `{"fields":[{"key":"status","label":"Status","type":"select","options":["todo","in-progress","done"],"terminal_options":["done"],"default":"todo"}]}`,
+	})
+	if err != nil {
+		t.Fatalf("create tasks collection: %v", err)
+	}
+
+	seed := []struct {
+		coll   string
+		id     string
+		fields string
+	}{
+		{"blog", "blog-todo", `{"status":"todo"}`},
+		{"blog", "blog-drafting", `{"status":"drafting"}`},
+		{"blog", "blog-scheduled", `{"status":"scheduled"}`},
+		{"blog", "blog-published", `{"status":"published"}`}, // terminal
+		{"tasks", "task-todo", `{"status":"todo"}`},
+		{"tasks", "task-done", `{"status":"done"}`}, // terminal
+	}
+	collID := map[string]string{"blog": blog.ID, "tasks": tasks.ID}
+	for _, sd := range seed {
+		if _, err := s.CreateItem(ws.ID, collID[sd.coll], models.ItemCreate{
+			Title:  sd.id,
+			Fields: sd.fields,
+		}); err != nil {
+			t.Fatalf("create item %s: %v", sd.id, err)
+		}
+	}
+
+	titles := func(items []models.Item) map[string]bool {
+		m := make(map[string]bool, len(items))
+		for _, it := range items {
+			m[it.Title] = true
+		}
+		return m
+	}
+
+	// Default (NonTerminal): every non-terminal item across BOTH collections
+	// appears; the two terminal items (blog-published, task-done) are hidden.
+	got, err := s.ListItems(ws.ID, models.ItemListParams{NonTerminal: true})
+	if err != nil {
+		t.Fatalf("ListItems non-terminal: %v", err)
+	}
+	tset := titles(got)
+	wantPresent := []string{"blog-todo", "blog-drafting", "blog-scheduled", "task-todo"}
+	for _, w := range wantPresent {
+		if !tset[w] {
+			t.Errorf("non-terminal list missing open item %q (got %v)", w, tset)
+		}
+	}
+	wantHidden := []string{"blog-published", "task-done"}
+	for _, w := range wantHidden {
+		if tset[w] {
+			t.Errorf("non-terminal list wrongly includes terminal item %q", w)
+		}
+	}
+	if len(got) != 4 {
+		t.Errorf("expected 4 non-terminal items, got %d (%v)", len(got), tset)
+	}
+
+	// --all (NonTerminal false): every item, including terminals.
+	all, err := s.ListItems(ws.ID, models.ItemListParams{})
+	if err != nil {
+		t.Fatalf("ListItems all: %v", err)
+	}
+	if len(all) != 6 {
+		t.Errorf("expected 6 items with no filter (--all), got %d", len(all))
+	}
+
+	// Explicit status filter still works: only the terminal blog item.
+	explicit, err := s.ListItems(ws.ID, models.ItemListParams{
+		CollectionSlug: "blog",
+		Fields:         map[string]string{"status": "published"},
+	})
+	if err != nil {
+		t.Fatalf("ListItems explicit status: %v", err)
+	}
+	if len(explicit) != 1 || explicit[0].Title != "blog-published" {
+		t.Errorf("explicit status=published expected [blog-published], got %v", titles(explicit))
+	}
+}


### PR DESCRIPTION
## BUG-2001 — stop hiding open items behind the hardcoded status allowlist

### Problem
`pad item list` (default, no `--status`/`--all`) sent a hardcoded ~20-status
allowlist as the `status` filter. Collections with **custom status
vocabularies** fell outside that list and had their open items hidden:
- live `human-tasks`: 2 of 24 shown (22 `todo` hidden)
- live `blog`: only `published` shown (5 `drafting` + 13 `scheduled` hidden)

MCP inherited the bug two ways — the ExecDispatcher runs the CLI (same
default), and the HTTP route table mirrored the same allowlist in
`mapItemList`. An agent asking "what's open" got a wrong answer.

### Fix
A **server-side, per-collection non-terminal filter**:
- New `ItemListParams.NonTerminal`. When set, `ListItems` (and the FTS path)
  append `AND NOT (<per-collection terminal expr>)`, reusing the existing
  `doneFiltersForWorkspace` + `buildChildrenDoneExpr` machinery. Each
  collection is evaluated against its **own** `terminal_options` (falling back
  to `DefaultTerminalStatuses` when none declared).
- `parseItemListParams` reads `?non_terminal=true`.
- The CLI default and **both** MCP dispatch paths now send `non_terminal=true`
  instead of the hardcoded allowlist. The old `defaultActiveStatusFilter`
  constant is removed.

`--status X` (explicit) and `--all` semantics are unchanged.

### Tests
- `internal/store/non_terminal_filter_test.go` — custom-vocabulary blog
  collection: `todo`/`drafting`/`scheduled` appear, `published` hidden; a
  second collection's `done` also hidden; `--all` shows everything; explicit
  `status=published` still filters.
- `dispatch_http_routes_test.go` updated: bare list sends `non_terminal=true`
  (no status allowlist); `--all` drops it; explicit `--status` still wins.

Gates green: `go build ./...`, `go test ./...`, `golangci-lint run` (0 issues).
Codex-reviewed (caught the HTTP-route allowlist, now fixed).
