### PR TITLE
perf(store): batch parent-lineage enrichment into one scoped query (BUG-2003)

### DIFF
--- a/internal/server/item_lineage.go
+++ b/internal/server/item_lineage.go
@@ -26,48 +26,51 @@ func (s *Server) enrichItemsWithParent(workspaceID string, items []models.Item, 
 	if err != nil || len(parentMap) == 0 {
 		return
 	}
-	// Collect unique parent IDs
-	parentIDs := make(map[string]bool)
-	for _, pid := range parentMap {
-		parentIDs[pid] = true
-	}
-	// Fetch parent item details (title, ref) in bulk
-	type parentInfo struct {
-		title          string
-		ref            string
-		slug           string
-		collectionSlug string
-	}
-	parents := make(map[string]parentInfo)
-	for pid := range parentIDs {
-		item, err := s.store.GetItem(pid)
-		if err != nil || item == nil {
-			continue
+	// Collect only the parent IDs of the items we're actually returning —
+	// not every parent link in the workspace. Scoping here keeps the batch
+	// fetch below proportional to the page size, not the whole workspace
+	// (BUG-2003).
+	parentIDSet := make(map[string]bool, len(items))
+	for i := range items {
+		if pid, ok := parentMap[items[i].ID]; ok {
+			parentIDSet[pid] = true
 		}
-		// Skip parents from hidden collections
-		if hasVis && !isCollectionVisible(item.CollectionID, vis) {
-			continue
-		}
-		ref := ""
-		if item.CollectionPrefix != "" && item.ItemNumber != nil {
-			ref = fmt.Sprintf("%s-%d", item.CollectionPrefix, *item.ItemNumber)
-		}
-		parents[pid] = parentInfo{title: item.Title, ref: ref, slug: item.Slug, collectionSlug: item.CollectionSlug}
 	}
-	// Populate items — only set parent fields when the parent passed
-	// the visibility filter (i.e. is in the parents map)
+	if len(parentIDSet) == 0 {
+		return
+	}
+	parentIDs := make([]string, 0, len(parentIDSet))
+	for pid := range parentIDSet {
+		parentIDs = append(parentIDs, pid)
+	}
+	// Fetch parent details (title, ref, slug, collection) for just those
+	// parents in one skinny WHERE id IN (...) query — replaces the former
+	// full-row GetItem per parent. Best-effort: on error, leave items
+	// undecorated rather than failing the list.
+	parents, err := s.store.GetItemLineageByIDs(parentIDs)
+	if err != nil {
+		return
+	}
+	// Populate items — only set parent fields when the parent resolved and
+	// passed the visibility filter.
 	for i := range items {
 		pid, ok := parentMap[items[i].ID]
 		if !ok {
 			continue
 		}
-		if info, ok := parents[pid]; ok {
-			items[i].ParentLinkID = pid
-			items[i].ParentTitle = info.title
-			items[i].ParentRef = info.ref
-			items[i].ParentSlug = info.slug
-			items[i].ParentCollectionSlug = info.collectionSlug
+		info, ok := parents[pid]
+		if !ok {
+			continue
 		}
+		// Skip parents from hidden collections
+		if hasVis && !isCollectionVisible(info.CollectionID, vis) {
+			continue
+		}
+		items[i].ParentLinkID = pid
+		items[i].ParentTitle = info.Title
+		items[i].ParentRef = info.Ref
+		items[i].ParentSlug = info.Slug
+		items[i].ParentCollectionSlug = info.CollectionSlug
 	}
 }
 

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -2680,6 +2680,65 @@ func (s *Store) GetParentMap(workspaceID string) (map[string]string, error) {
 	return m, rows.Err()
 }
 
+// LineageRef is a skinny projection of a parent item — only the fields
+// parent-link enrichment decorates onto children (title, ref, slug, and the
+// collection info needed for the visibility filter). Fetched in one batch
+// query instead of a full-row GetItem per parent. See BUG-2003.
+type LineageRef struct {
+	ID             string
+	Title          string
+	Ref            string
+	Slug           string
+	CollectionID   string
+	CollectionSlug string
+}
+
+// GetItemLineageByIDs fetches skinny parent-lineage projections for the given
+// item IDs in a single `WHERE id IN (...)` query. Soft-deleted items are
+// excluded. IDs with no matching (or soft-deleted) row are simply absent from
+// the returned map — parent enrichment is best-effort decoration, so a missing
+// parent must not fail the caller.
+//
+// This replaces the per-parent GetItem N+1 in enrichItemsWithParent (BUG-2003):
+// callers scope the ID slice to only the parents of the returned items, then
+// hydrate all of them in one round-trip.
+func (s *Store) GetItemLineageByIDs(ids []string) (map[string]LineageRef, error) {
+	result := make(map[string]LineageRef, len(ids))
+	if len(ids) == 0 {
+		return result, nil
+	}
+	placeholders := make([]string, len(ids))
+	args := make([]any, len(ids))
+	for i, id := range ids {
+		placeholders[i] = "?"
+		args[i] = id
+	}
+	rows, err := s.db.Query(s.q(fmt.Sprintf(`
+		SELECT i.id, i.title, i.slug, i.item_number, i.collection_id, c.slug, c.prefix
+		FROM items i
+		JOIN collections c ON c.id = i.collection_id
+		WHERE i.id IN (%s) AND i.deleted_at IS NULL
+	`, strings.Join(placeholders, ","))), args...)
+	if err != nil {
+		return nil, fmt.Errorf("get item lineage by ids: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var ref LineageRef
+		var itemNumber *int
+		var prefix string
+		if err := rows.Scan(&ref.ID, &ref.Title, &ref.Slug, &itemNumber, &ref.CollectionID, &ref.CollectionSlug, &prefix); err != nil {
+			return nil, err
+		}
+		if prefix != "" && itemNumber != nil {
+			ref.Ref = fmt.Sprintf("%s-%d", prefix, *itemNumber)
+		}
+		result[ref.ID] = ref
+	}
+	return result, rows.Err()
+}
+
 // --- Child Item Progress ---
 
 // GetItemProgress counts total and done child items linked to a parent via item_links.

--- a/internal/store/items_test.go
+++ b/internal/store/items_test.go
@@ -1134,6 +1134,63 @@ func TestGetParentMap_ExcludesSoftDeletedEndpoints(t *testing.T) {
 	}
 }
 
+// TestGetItemLineageByIDs covers the skinny batch parent-lineage fetch that
+// replaced the per-parent GetItem N+1 in enrichItemsWithParent (BUG-2003):
+// a single WHERE id IN (...) query hydrates many parents at once, scopes to
+// only the requested IDs, computes refs, and drops soft-deleted parents.
+func TestGetItemLineageByIDs(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+
+	// Create several parents. Only a subset gets requested below to prove the
+	// query is scoped to the passed IDs, not the whole workspace.
+	p1 := createTestItem(t, s, ws.ID, col.ID, "Parent One", "")
+	p2 := createTestItem(t, s, ws.ID, col.ID, "Parent Two", "")
+	p3 := createTestItem(t, s, ws.ID, col.ID, "Parent Three", "")
+	other := createTestItem(t, s, ws.ID, col.ID, "Unrequested Parent", "")
+
+	// Empty input returns an empty (non-nil) map with no query.
+	if m, err := s.GetItemLineageByIDs(nil); err != nil || m == nil || len(m) != 0 {
+		t.Fatalf("GetItemLineageByIDs(nil) = %v, %v; want empty map, nil err", m, err)
+	}
+
+	m, err := s.GetItemLineageByIDs([]string{p1.ID, p2.ID, p3.ID})
+	if err != nil {
+		t.Fatalf("GetItemLineageByIDs: %v", err)
+	}
+	if len(m) != 3 {
+		t.Fatalf("expected 3 lineage refs, got %d", len(m))
+	}
+	// Scoping: the unrequested parent must not appear even though it exists.
+	if _, ok := m[other.ID]; ok {
+		t.Errorf("unrequested parent %s leaked into result (scoping regression)", other.ID)
+	}
+	// Field projection matches the source item.
+	got := m[p1.ID]
+	if got.Title != "Parent One" || got.Slug != p1.Slug || got.CollectionSlug != col.Slug {
+		t.Errorf("lineage projection mismatch: got %+v", got)
+	}
+	if got.Ref == "" {
+		t.Errorf("expected a computed ref for %s, got empty", p1.ID)
+	}
+
+	// Soft-deleted parents drop out of the batch fetch.
+	if err := s.DeleteItem(p2.ID); err != nil {
+		t.Fatalf("DeleteItem: %v", err)
+	}
+	m, err = s.GetItemLineageByIDs([]string{p1.ID, p2.ID, p3.ID})
+	if err != nil {
+		t.Fatalf("GetItemLineageByIDs after delete: %v", err)
+	}
+	if _, ok := m[p2.ID]; ok {
+		t.Errorf("soft-deleted parent %s should be excluded", p2.ID)
+	}
+	if len(m) != 2 {
+		t.Errorf("expected 2 lineage refs after soft-deleting one parent, got %d", len(m))
+	}
+}
+
 // TestListItems_ParentFilter_FTS_RespectsSoftDeletedParent covers the
 // `parent=<UUID>&search=<q>` combination. The search path routes through
 // listItemsFTS, which the non-FTS parent filter doesn't touch; the FTS


### PR DESCRIPTION
## BUG-2003 — Fix enrichItemsWithParent workspace-wide N+1 on every list request

### Problem
`enrichItemsWithParent` (`internal/server/item_lineage.go`) loaded **every** parent link in the workspace via `GetParentMap`, then called full-row `GetItem` once per unique parent (151 in the live workspace) — despite a comment claiming a bulk fetch. Measured: `?limit=1` took 34-39ms vs ~2ms for a single GET, a ~20x tax to return one row. Hit on every list request, including the `/items-changes` sync endpoint the local-first client polls. Errors were swallowed silently.

### Fix
- New skinny store method `Store.GetItemLineageByIDs(ids []string) (map[string]LineageRef, error)` — one `WHERE id IN (?, ?, ...)` query returning only title/ref/slug/collection (the fields enrichment actually consumes), soft-deleted rows excluded.
- `enrichItemsWithParent` now scopes the parent IDs to **only the parents of the returned item slice** (not the whole workspace), then hydrates them in one round-trip.
- Output shape and best-effort behavior preserved: a missing/hidden parent leaves the item undecorated rather than failing the list. The visibility filter runs against the batched projection's `collection_id`.

Net effect: per-parent full-row `GetItem` N+1 (scaled with total workspace parents) → one query scaled to page size.

### Call sites
All 7 `enrichItemsWithParent` callers (handlers_items, handlers_stars, handlers_project_intel) are unchanged — same signature, same populated fields. The dashboard's separate `GetParentMap` presence-check is untouched.

### Tests
- New `TestGetItemLineageByIDs`: proves one batch query hydrates many parents, scopes to only the requested IDs, computes refs, and drops soft-deleted parents.
- Full `go test ./...` green; `golangci-lint` clean on touched dirs; Codex review returned no findings.
