### PR TITLE
perf(server): collapse dashboard/bootstrap N+1 into set-based queries (BUG-2002)

### DIFF
--- a/internal/models/item.go
+++ b/internal/models/item.go
@@ -806,8 +806,13 @@ type ItemListParams struct {
 	// scheduled) are handled correctly rather than against a hardcoded
 	// global status allowlist (BUG-2001).
 	NonTerminal bool
-	Limit       int
-	Offset      int
+	// NoContent omits the (potentially large) rich-text body column from
+	// the projection — callers that only count/summarize/scan structured
+	// fields (e.g. the dashboard builder) don't pay to load every item's
+	// full markdown. item.Content comes back empty when set. See BUG-2002.
+	NoContent bool
+	Limit     int
+	Offset    int
 }
 
 // TagCount is a distinct tag used within a workspace and the number of items

--- a/internal/server/handlers_dashboard.go
+++ b/internal/server/handlers_dashboard.go
@@ -152,60 +152,13 @@ type DashboardSuggestion struct {
 	Reason     string `json:"reason"`
 }
 
-// itemBlockedByActive returns true when the item identified by id
-// has at least one active "blocks" link with a non-done blocker.
-// Mirrors the attention-blocked logic above so the suggested_next
-// algorithm filters out the same items the dashboard's attention
-// section flags as blocked.
-//
-// Visibility filters (collection visibility + per-item guest grants)
-// apply to BLOCKERS too — a blocker the requesting user can't see
-// shouldn't influence whether the target is suggested. This matches
-// the attention block's behavior.
-//
-// Returns false on lookup errors (best-effort: better to surface a
-// suggestion than swallow the algorithm on a transient store hiccup).
-//
-// BUG-990 introduced this helper alongside the in-progress
-// surfacing change in handleDashboard's suggested_next section.
-func (s *Server) itemBlockedByActive(
-	workspaceID, itemID string,
-	ctxMap map[string]doneContext,
-	visibleIDs []string,
-	r *http.Request,
-	dashFullCollIDs, dashGrantedItemIDs []string,
-) bool {
-	links, err := s.store.GetItemLinks(itemID)
-	if err != nil {
-		return false
-	}
-	for _, link := range links {
-		if link.LinkType != "blocks" {
-			continue
-		}
-		// We care only about links where this item is the BLOCKED
-		// (target) side — `source blocks target`.
-		if link.TargetID != itemID {
-			continue
-		}
-		blocker, err := s.store.GetItem(link.SourceID)
-		if err != nil || blocker == nil {
-			continue
-		}
-		if !isCollectionVisible(blocker.CollectionID, visibleIDs) {
-			continue
-		}
-		if !s.isItemVisibleToGuest(r, workspaceID, blocker, dashFullCollIDs, dashGrantedItemIDs) {
-			continue
-		}
-		if isItemDone(blocker.Fields, blocker.CollectionID, ctxMap) {
-			continue
-		}
-		// At least one active blocker visible to this user — bail.
-		return true
-	}
-	return false
-}
+// Blocked-item resolution (both the attention-blocked section and the
+// suggested_next blocked-filter) is driven by the firstActiveBlocker map
+// computed once per dashboard build from Store.GetBlocksEdges — a single
+// query in place of the old per-item GetItemLinks + per-link GetItem N+1
+// (BUG-2002). The map's presence check is the successor to the former
+// itemBlockedByActive helper (BUG-990); its visibility + non-done blocker
+// filtering is identical.
 
 // priorityRank returns a sort rank for task priority (lower = higher priority).
 func priorityRank(priority string) int {
@@ -242,6 +195,15 @@ func isActiveStatus(status string) bool {
 type doneContext struct {
 	schema   models.CollectionSchema
 	settings models.CollectionSettings
+}
+
+// activeBlocker holds the display fields for the first visible, still-active
+// blocker of a blocked item — the blocker's title and status, used to build
+// the "Blocked by X (still Y)" attention reason. Precomputed per blocked
+// target from a single GetBlocksEdges query (BUG-2002).
+type activeBlocker struct {
+	title  string
+	status string
 }
 
 // buildDoneContextMap builds a map of collection ID → (schema, settings)
@@ -328,31 +290,24 @@ func (s *Server) buildDashboardResponse(workspaceID string, r *http.Request) (*D
 		dashItemIDs = dashGrantedItemIDs
 	}
 
-	// Build a schema map for terminal status lookups
-	collections, err := s.store.ListCollections(workspaceID)
+	// Build a schema map for terminal status lookups from ALL workspace
+	// collections (id + slug + schema + settings), before visibility
+	// filtering. The dashboard may surface item-level grants from
+	// collections that aren't in the user's full-visibility set (via
+	// dashItemIDs); those items still need their own collection's done
+	// rules for isItemDone, not the status-based default fallback.
+	//
+	// ListCollectionsMinimal is used deliberately over ListCollections: the
+	// dashboard never reads per-collection item counts, and ListCollections
+	// runs a COUNT query PER collection (~one N+1 per workspace). The
+	// Minimal projection is a single row-scan (BUG-2002). collections is
+	// reused below to build an ID→slug map for the recent-activity
+	// visibility filter, avoiding a GetCollection per visible ID.
+	collections, err := s.store.ListCollectionsMinimal(workspaceID)
 	if err != nil {
 		return nil, err
 	}
-	// Build the done-context map from ALL workspace collections before
-	// visibility filtering. The dashboard may surface item-level grants
-	// from collections that aren't in the user's full-visibility set
-	// (via dashItemIDs); those items still need their own collection's
-	// done rules for isItemDone, not the status-based default fallback.
-	// ListCollectionsMinimal skips the per-collection count queries —
-	// we only need schema + settings here.
-	allCollections, mcErr := s.store.ListCollectionsMinimal(workspaceID)
-	if mcErr != nil {
-		// Non-fatal: fall back to the visibility-filtered collections.
-		allCollections = collections
-	}
-	ctxMap := buildDoneContextMap(allCollections)
-	// Note: the `collections` slice is not part of response visibility
-	// filtering. Dashboard outputs are filtered by dashCollIDs /
-	// dashItemIDs on the ListItems calls below, plus per-item
-	// isCollectionVisible / isItemVisibleToGuest checks for outputs
-	// that walk graphs (plan progress, blocked attention, suggested
-	// next). `collections` is retained only as the fallback target for
-	// `allCollections` above when ListCollectionsMinimal fails.
+	ctxMap := buildDoneContextMap(collections)
 
 	resp := DashboardResponse{
 		Summary: DashboardSummary{
@@ -404,8 +359,11 @@ func (s *Server) buildDashboardResponse(workspaceID string, r *http.Request) (*D
 	}
 	resp.NeedsOnboarding = !hasUserItems
 
-	// Summary: items grouped by collection slug and status field
-	allItems, err := s.store.ListItems(workspaceID, models.ItemListParams{CollectionIDs: dashCollIDs, ItemIDs: dashItemIDs})
+	// Summary: items grouped by collection slug and status field.
+	// NoContent: the dashboard only counts/summarizes/scans structured
+	// fields — it never reads item.Content — so we skip loading every
+	// item's full markdown body (BUG-2002).
+	allItems, err := s.store.ListItems(workspaceID, models.ItemListParams{CollectionIDs: dashCollIDs, ItemIDs: dashItemIDs, NoContent: true})
 	if err != nil {
 		return nil, err
 	}
@@ -492,7 +450,32 @@ func (s *Server) buildDashboardResponse(workspaceID string, r *http.Request) (*D
 		CollectionIDs:  dashCollIDs,
 		ItemIDs:        dashItemIDs,
 		Fields:         map[string]string{"status": "active"},
+		NoContent:      true,
 	})
+	// Batch-fetch the children of every active plan in ONE query (BUG-2002),
+	// collapsing the per-plan GetChildItems N+1 that both the progress loop
+	// below and the suggested_next section used to pay. childrenByParent is
+	// keyed by plan item ID; planIDBySlug lets suggested_next reuse it
+	// without re-resolving each plan slug.
+	childrenByParent := map[string][]models.Item{}
+	planIDBySlug := make(map[string]string, len(plans))
+	if err == nil {
+		activePlanIDs := make([]string, 0, len(plans))
+		for _, plan := range plans {
+			activePlanIDs = append(activePlanIDs, plan.ID)
+			planIDBySlug[plan.Slug] = plan.ID
+		}
+		// A batch-children failure is fatal, not best-effort: silently
+		// degrading to an empty map would globally skew active_plans
+		// progress, plan_completion attention, orphan detection, and
+		// suggested_next. Mirror the sibling batch queries (allItems,
+		// GetBlocksEdges) which also return on error (BUG-2002, Codex review).
+		kids, cbErr := s.store.GetChildItemsForParents(activePlanIDs)
+		if cbErr != nil {
+			return nil, cbErr
+		}
+		childrenByParent = kids
+	}
 	if err == nil {
 		for _, plan := range plans {
 			dp := DashboardPlan{
@@ -503,18 +486,16 @@ func (s *Server) buildDashboardResponse(workspaceID string, r *http.Request) (*D
 
 			// Compute progress from visible child items only
 			total, done := 0, 0
-			if planChildren, cerr := s.store.GetChildItems(plan.ID); cerr == nil {
-				for _, child := range planChildren {
-					if !isCollectionVisible(child.CollectionID, visibleIDs) {
-						continue
-					}
-					if !s.isItemVisibleToGuest(r, workspaceID, &child, dashFullCollIDs, dashGrantedItemIDs) {
-						continue
-					}
-					total++
-					if isItemDone(child.Fields, child.CollectionID, ctxMap) {
-						done++
-					}
+			for _, child := range childrenByParent[plan.ID] {
+				if !isCollectionVisible(child.CollectionID, visibleIDs) {
+					continue
+				}
+				if !s.isItemVisibleToGuest(r, workspaceID, &child, dashFullCollIDs, dashGrantedItemIDs) {
+					continue
+				}
+				total++
+				if isItemDone(child.Fields, child.CollectionID, ctxMap) {
+					done++
 				}
 			}
 			if total > 0 {
@@ -547,6 +528,7 @@ func (s *Server) buildDashboardResponse(workspaceID string, r *http.Request) (*D
 			CollectionIDs: dashCollIDs,
 			ItemIDs:       dashItemIDs,
 			Fields:        map[string]string{"status": statusVal},
+			NoContent:     true,
 		})
 		if err != nil {
 			continue
@@ -625,6 +607,7 @@ func (s *Server) buildDashboardResponse(workspaceID string, r *http.Request) (*D
 			CollectionSlug: "tasks",
 			CollectionIDs:  dashCollIDs,
 			ItemIDs:        dashItemIDs,
+			NoContent:      true,
 		})
 		if err == nil {
 			for _, task := range allTasks {
@@ -645,51 +628,59 @@ func (s *Server) buildDashboardResponse(workspaceID string, r *http.Request) (*D
 		}
 	}
 
-	// (e) Blocked: non-done items that are blocked by other non-done items
+	// (e) Blocked: non-done items that are blocked by other non-done items.
+	//
+	// firstActiveBlocker resolves, for every blocked target in the
+	// workspace, the FIRST blocker (in the same created_at DESC order
+	// GetItemLinks used) that the caller can see AND that is still non-done.
+	// It's computed once from a single GetBlocksEdges query — replacing the
+	// per-non-done-item GetItemLinks + per-link GetItem N+1 that dominated
+	// dashboard latency (BUG-2002). Presence in the map == the target has an
+	// active blocker, which also drives the suggested_next blocked-filter
+	// below.
+	blocksEdges, err := s.store.GetBlocksEdges(workspaceID)
+	if err != nil {
+		return nil, err
+	}
+	firstActiveBlocker := make(map[string]activeBlocker)
+	for _, e := range blocksEdges {
+		if _, resolved := firstActiveBlocker[e.TargetID]; resolved {
+			continue // already picked this target's first active blocker
+		}
+		// Skip blockers from hidden collections or ungrantable items — a
+		// blocker the caller can't see must not influence the target.
+		if !isCollectionVisible(e.SourceCollectionID, visibleIDs) {
+			continue
+		}
+		if !s.isItemVisibleToGuest(r, workspaceID, &models.Item{ID: e.SourceID, CollectionID: e.SourceCollectionID}, dashFullCollIDs, dashGrantedItemIDs) {
+			continue
+		}
+		if isItemDone(e.SourceFields, e.SourceCollectionID, ctxMap) {
+			continue
+		}
+		firstActiveBlocker[e.TargetID] = activeBlocker{
+			title: e.SourceTitle,
+			// Used only in the human-readable "Reason" string — the terminal
+			// check above owns the actual done-detection.
+			status: extractFieldValue(e.SourceFields, "status"),
+		}
+	}
 	for _, item := range allItems {
 		if isItemDone(item.Fields, item.CollectionID, ctxMap) {
 			continue
 		}
-		links, err := s.store.GetItemLinks(item.ID)
-		if err != nil {
+		blk, blocked := firstActiveBlocker[item.ID]
+		if !blocked {
 			continue
 		}
-		for _, link := range links {
-			if link.LinkType != "blocks" {
-				continue
-			}
-			// We care about links where this item is the target (i.e., blocked by source)
-			if link.TargetID != item.ID {
-				continue
-			}
-			// Check if the blocking item is still not done
-			blocker, err := s.store.GetItem(link.SourceID)
-			if err != nil || blocker == nil {
-				continue
-			}
-			// Skip blockers from hidden collections or ungrantable items
-			if !isCollectionVisible(blocker.CollectionID, visibleIDs) {
-				continue
-			}
-			if !s.isItemVisibleToGuest(r, workspaceID, blocker, dashFullCollIDs, dashGrantedItemIDs) {
-				continue
-			}
-			if isItemDone(blocker.Fields, blocker.CollectionID, ctxMap) {
-				continue
-			}
-			// Used only in the human-readable "Reason" string below — the
-			// terminal check above owns the actual done-detection.
-			blockerStatus := extractFieldValue(blocker.Fields, "status")
-			resp.Attention = append(resp.Attention, DashboardAttention{
-				Type:       "blocked",
-				ItemSlug:   item.Slug,
-				ItemRef:    item.Ref,
-				ItemTitle:  item.Title,
-				Collection: item.CollectionSlug,
-				Reason:     "Blocked by " + link.SourceTitle + " (still " + blockerStatus + ")",
-			})
-			break // only report the first active blocker per item
-		}
+		resp.Attention = append(resp.Attention, DashboardAttention{
+			Type:       "blocked",
+			ItemSlug:   item.Slug,
+			ItemRef:    item.Ref,
+			ItemTitle:  item.Title,
+			Collection: item.CollectionSlug,
+			Reason:     "Blocked by " + blk.title + " (still " + blk.status + ")",
+		})
 	}
 
 	// Recent activity — enriched with item titles and user names
@@ -698,16 +689,41 @@ func (s *Server) buildDashboardResponse(workspaceID string, r *http.Request) (*D
 		Limit: 30,
 	})
 	if err == nil && activities != nil {
-		// Build visible slug set for filtering
+		// Build visible slug set for filtering. Resolve slugs from the
+		// already-loaded collection list (ListCollections above) rather than
+		// a GetCollection per visible ID — no extra queries (BUG-2002).
 		var visibleSlugSet map[string]bool
 		if visibleIDs != nil {
+			collSlugByID := make(map[string]string, len(collections))
+			for _, c := range collections {
+				collSlugByID[c.ID] = c.Slug
+			}
 			visibleSlugSet = make(map[string]bool)
 			for _, id := range visibleIDs {
-				coll, _ := s.store.GetCollection(id)
-				if coll != nil {
-					visibleSlugSet[coll.Slug] = true
+				if slug, ok := collSlugByID[id]; ok {
+					visibleSlugSet[slug] = true
 				}
 			}
+		}
+
+		// Batch-hydrate the items referenced by these activity rows in one
+		// include-deleted query instead of a GetItemIncludeDeleted per row
+		// (BUG-2002). Collect the distinct document IDs first.
+		activityItemIDs := make([]string, 0, len(activities))
+		seenActID := make(map[string]struct{}, len(activities))
+		for _, a := range activities {
+			if a.DocumentID == "" {
+				continue
+			}
+			if _, dup := seenActID[a.DocumentID]; dup {
+				continue
+			}
+			seenActID[a.DocumentID] = struct{}{}
+			activityItemIDs = append(activityItemIDs, a.DocumentID)
+		}
+		activityItems, aiErr := s.store.GetItemsByIDsIncludeDeleted(activityItemIDs)
+		if aiErr != nil {
+			return nil, aiErr
 		}
 
 		for _, a := range activities {
@@ -729,8 +745,8 @@ func (s *Server) buildDashboardResponse(workspaceID string, r *http.Request) (*D
 			// If the referenced item is gone entirely, drop the row rather
 			// than emit a blank entry.
 			if a.DocumentID != "" {
-				item, err := s.store.GetItemIncludeDeleted(a.DocumentID)
-				if err != nil || item == nil {
+				item := activityItems[a.DocumentID]
+				if item == nil {
 					continue
 				}
 				// Skip items in hidden collections
@@ -776,15 +792,13 @@ func (s *Server) buildDashboardResponse(workspaceID string, r *http.Request) (*D
 	var candidates []suggestion
 
 	for _, dp := range resp.ActivePlans {
-		parentItem, err := s.store.ResolveItem(workspaceID, dp.Slug)
-		if err != nil || parentItem == nil {
+		// Reuse the children batched once above (BUG-2002) instead of
+		// re-resolving the plan slug and re-querying its children per plan.
+		planID, ok := planIDBySlug[dp.Slug]
+		if !ok {
 			continue
 		}
-		tasks, err := s.store.GetChildItems(parentItem.ID)
-		if err != nil {
-			continue
-		}
-		for _, task := range tasks {
+		for _, task := range childrenByParent[planID] {
 			// Skip tasks from hidden collections
 			if !isCollectionVisible(task.CollectionID, visibleIDs) {
 				continue
@@ -799,10 +813,10 @@ func (s *Server) buildDashboardResponse(workspaceID string, r *http.Request) (*D
 				continue
 			}
 			// Filter blocked items: don't suggest work an agent can't
-			// actually start. Mirrors the attention-blocked logic
-			// above — `blocks` link with this item as the target,
-			// where the blocker is still non-done.
-			if s.itemBlockedByActive(workspaceID, task.ID, ctxMap, visibleIDs, r, dashFullCollIDs, dashGrantedItemIDs) {
+			// actually start. Mirrors the attention-blocked logic above —
+			// a `blocks` link with this item as the target where the
+			// blocker is still non-done (presence in firstActiveBlocker).
+			if _, blocked := firstActiveBlocker[task.ID]; blocked {
 				continue
 			}
 			pri := extractFieldValue(task.Fields, "priority")
@@ -866,7 +880,7 @@ func (s *Server) buildDashboardResponse(workspaceID string, r *http.Request) (*D
 		if !isInProgress && pri != "high" && pri != "critical" {
 			continue
 		}
-		if s.itemBlockedByActive(workspaceID, item.ID, ctxMap, visibleIDs, r, dashFullCollIDs, dashGrantedItemIDs) {
+		if _, blocked := firstActiveBlocker[item.ID]; blocked {
 			continue
 		}
 		candidates = append(candidates, suggestion{

--- a/internal/store/collections.go
+++ b/internal/store/collections.go
@@ -144,14 +144,15 @@ func (s *Store) GetCollectionBySlug(workspaceID, slug string) (*models.Collectio
 }
 
 // ListCollectionsMinimal returns collection rows populated with just the
-// fields needed for done-detection context: ID, Schema, Settings.
-// Skips the per-collection COUNT queries that ListCollections runs, which
-// matters on hot paths that only need the schema + settings pair (e.g.
-// handlers that build a ctxMap for isItemDone). Includes soft-deleted
-// collections so items still attached to them can be evaluated.
+// fields needed for done-detection context and slug lookups: ID, Slug,
+// Schema, Settings. Skips the per-collection COUNT queries that
+// ListCollections runs, which matters on hot paths that only need those
+// fields (e.g. handlers that build a ctxMap for isItemDone or an ID→slug
+// map). Includes soft-deleted collections so items still attached to them
+// can be evaluated.
 func (s *Store) ListCollectionsMinimal(workspaceID string) ([]models.Collection, error) {
 	rows, err := s.db.Query(
-		s.q(`SELECT id, schema, settings FROM collections WHERE workspace_id = ?`),
+		s.q(`SELECT id, slug, schema, settings FROM collections WHERE workspace_id = ?`),
 		workspaceID,
 	)
 	if err != nil {
@@ -161,7 +162,7 @@ func (s *Store) ListCollectionsMinimal(workspaceID string) ([]models.Collection,
 	var result []models.Collection
 	for rows.Next() {
 		var c models.Collection
-		if err := rows.Scan(&c.ID, &c.Schema, &c.Settings); err != nil {
+		if err := rows.Scan(&c.ID, &c.Slug, &c.Schema, &c.Settings); err != nil {
 			return nil, fmt.Errorf("scan collection minimal: %w", err)
 		}
 		result = append(result, c)

--- a/internal/store/dashboard_batch_test.go
+++ b/internal/store/dashboard_batch_test.go
@@ -1,0 +1,259 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// linkChild wires child -> parent via a `parent` link (the shape
+// GetChildItems / GetChildItemsForParents walk).
+func linkChild(t *testing.T, s *Store, workspaceID, childID, parentID string) {
+	t.Helper()
+	if _, err := s.CreateItemLink(workspaceID, models.ItemLinkCreate{
+		TargetID: parentID,
+		LinkType: "parent",
+	}, childID); err != nil {
+		t.Fatalf("link child %s -> parent %s: %v", childID, parentID, err)
+	}
+}
+
+// linkBlocks wires blocker -> blocked via a `blocks` link.
+func linkBlocks(t *testing.T, s *Store, workspaceID, blockerID, blockedID string) {
+	t.Helper()
+	if _, err := s.CreateItemLink(workspaceID, models.ItemLinkCreate{
+		TargetID: blockedID,
+		LinkType: "blocks",
+	}, blockerID); err != nil {
+		t.Fatalf("link blocker %s -> blocked %s: %v", blockerID, blockedID, err)
+	}
+}
+
+func TestGetChildItemsForParents(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+
+	planA := createTestItem(t, s, ws.ID, col.ID, "Plan A", "")
+	planB := createTestItem(t, s, ws.ID, col.ID, "Plan B", "")
+	planC := createTestItem(t, s, ws.ID, col.ID, "Plan C (no children)", "")
+
+	a1 := createTestItem(t, s, ws.ID, col.ID, "A child 1", "body-a1")
+	a2 := createTestItem(t, s, ws.ID, col.ID, "A child 2", "body-a2")
+	b1 := createTestItem(t, s, ws.ID, col.ID, "B child 1", "body-b1")
+
+	linkChild(t, s, ws.ID, a1.ID, planA.ID)
+	linkChild(t, s, ws.ID, a2.ID, planA.ID)
+	linkChild(t, s, ws.ID, b1.ID, planB.ID)
+
+	byParent, err := s.GetChildItemsForParents([]string{planA.ID, planB.ID, planC.ID})
+	if err != nil {
+		t.Fatalf("GetChildItemsForParents: %v", err)
+	}
+
+	if got := len(byParent[planA.ID]); got != 2 {
+		t.Errorf("plan A: expected 2 children, got %d", got)
+	}
+	if got := len(byParent[planB.ID]); got != 1 {
+		t.Errorf("plan B: expected 1 child, got %d", got)
+	}
+	if _, ok := byParent[planC.ID]; ok {
+		t.Errorf("plan C: expected no map entry for childless parent")
+	}
+
+	// Grouping must match the per-parent GetChildItems (same rows).
+	single, err := s.GetChildItems(planA.ID)
+	if err != nil {
+		t.Fatalf("GetChildItems: %v", err)
+	}
+	if len(single) != len(byParent[planA.ID]) {
+		t.Errorf("batch child count %d != single %d for plan A", len(byParent[planA.ID]), len(single))
+	}
+
+	// The projection omits content (heavy body column) but keeps identity +
+	// computed ref/fields.
+	for _, child := range byParent[planA.ID] {
+		if child.Content != "" {
+			t.Errorf("expected empty content in batch projection, got %q for %s", child.Content, child.Title)
+		}
+		if child.Ref == "" {
+			t.Errorf("expected computed ref on child %s", child.Title)
+		}
+	}
+}
+
+func TestGetChildItemsForParentsExcludesDeleted(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+
+	plan := createTestItem(t, s, ws.ID, col.ID, "Plan", "")
+	live := createTestItem(t, s, ws.ID, col.ID, "Live child", "")
+	gone := createTestItem(t, s, ws.ID, col.ID, "Deleted child", "")
+	linkChild(t, s, ws.ID, live.ID, plan.ID)
+	linkChild(t, s, ws.ID, gone.ID, plan.ID)
+
+	if err := s.DeleteItem(gone.ID); err != nil {
+		t.Fatalf("DeleteItem: %v", err)
+	}
+
+	byParent, err := s.GetChildItemsForParents([]string{plan.ID})
+	if err != nil {
+		t.Fatalf("GetChildItemsForParents: %v", err)
+	}
+	if got := len(byParent[plan.ID]); got != 1 {
+		t.Fatalf("expected 1 live child, got %d", got)
+	}
+	if byParent[plan.ID][0].ID != live.ID {
+		t.Errorf("expected live child, got %s", byParent[plan.ID][0].Title)
+	}
+}
+
+func TestGetChildItemsForParentsEmpty(t *testing.T) {
+	s := testStore(t)
+	byParent, err := s.GetChildItemsForParents(nil)
+	if err != nil {
+		t.Fatalf("GetChildItemsForParents(nil): %v", err)
+	}
+	if len(byParent) != 0 {
+		t.Errorf("expected empty map, got %d entries", len(byParent))
+	}
+}
+
+func TestGetBlocksEdges(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+
+	blocker := createTestItem(t, s, ws.ID, col.ID, "Blocker", "")
+	blocked := createTestItem(t, s, ws.ID, col.ID, "Blocked", "")
+	// A non-blocks link must NOT appear in the result.
+	parent := createTestItem(t, s, ws.ID, col.ID, "Parent", "")
+	child := createTestItem(t, s, ws.ID, col.ID, "Child", "")
+
+	linkBlocks(t, s, ws.ID, blocker.ID, blocked.ID)
+	linkChild(t, s, ws.ID, child.ID, parent.ID)
+
+	edges, err := s.GetBlocksEdges(ws.ID)
+	if err != nil {
+		t.Fatalf("GetBlocksEdges: %v", err)
+	}
+	if len(edges) != 1 {
+		t.Fatalf("expected 1 blocks edge, got %d: %+v", len(edges), edges)
+	}
+	e := edges[0]
+	if e.TargetID != blocked.ID {
+		t.Errorf("expected target %s (blocked), got %s", blocked.ID, e.TargetID)
+	}
+	if e.SourceID != blocker.ID {
+		t.Errorf("expected source %s (blocker), got %s", blocker.ID, e.SourceID)
+	}
+	if e.SourceTitle != "Blocker" {
+		t.Errorf("expected source title 'Blocker', got %q", e.SourceTitle)
+	}
+	if e.SourceCollectionID != col.ID {
+		t.Errorf("expected source collection %s, got %s", col.ID, e.SourceCollectionID)
+	}
+}
+
+func TestGetBlocksEdgesExcludesDeleted(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+
+	blocker := createTestItem(t, s, ws.ID, col.ID, "Blocker", "")
+	blocked := createTestItem(t, s, ws.ID, col.ID, "Blocked", "")
+	linkBlocks(t, s, ws.ID, blocker.ID, blocked.ID)
+
+	// Soft-deleting either endpoint drops the edge (join requires both live).
+	if err := s.DeleteItem(blocker.ID); err != nil {
+		t.Fatalf("DeleteItem: %v", err)
+	}
+	edges, err := s.GetBlocksEdges(ws.ID)
+	if err != nil {
+		t.Fatalf("GetBlocksEdges: %v", err)
+	}
+	if len(edges) != 0 {
+		t.Errorf("expected 0 edges after deleting blocker, got %d", len(edges))
+	}
+}
+
+func TestGetItemsByIDsIncludeDeleted(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+
+	live := createTestItem(t, s, ws.ID, col.ID, "Live", "body")
+	gone := createTestItem(t, s, ws.ID, col.ID, "Archived", "body")
+	if err := s.DeleteItem(gone.ID); err != nil {
+		t.Fatalf("DeleteItem: %v", err)
+	}
+
+	got, err := s.GetItemsByIDsIncludeDeleted([]string{live.ID, gone.ID, "missing-id"})
+	if err != nil {
+		t.Fatalf("GetItemsByIDsIncludeDeleted: %v", err)
+	}
+	// Both live and soft-deleted must be present; missing ID absent.
+	if got[live.ID] == nil {
+		t.Errorf("expected live item present")
+	}
+	if got[gone.ID] == nil {
+		t.Errorf("expected soft-deleted item present (include-deleted)")
+	}
+	if _, ok := got["missing-id"]; ok {
+		t.Errorf("expected missing id absent")
+	}
+	if got[live.ID] != nil {
+		if got[live.ID].Title != "Live" {
+			t.Errorf("expected title 'Live', got %q", got[live.ID].Title)
+		}
+		if got[live.ID].Ref == "" {
+			t.Errorf("expected computed ref on hydrated item")
+		}
+		if got[live.ID].Content != "" {
+			t.Errorf("expected empty content in projection, got %q", got[live.ID].Content)
+		}
+	}
+}
+
+func TestGetItemsByIDsIncludeDeletedEmpty(t *testing.T) {
+	s := testStore(t)
+	got, err := s.GetItemsByIDsIncludeDeleted(nil)
+	if err != nil {
+		t.Fatalf("GetItemsByIDsIncludeDeleted(nil): %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected empty map, got %d", len(got))
+	}
+}
+
+func TestListItemsNoContentProjection(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+	createTestItem(t, s, ws.ID, col.ID, "Has body", "the full markdown body")
+
+	// Default: content loaded.
+	full, err := s.ListItems(ws.ID, models.ItemListParams{})
+	if err != nil {
+		t.Fatalf("ListItems: %v", err)
+	}
+	if len(full) != 1 || full[0].Content != "the full markdown body" {
+		t.Fatalf("expected content loaded by default, got %+v", full)
+	}
+
+	// NoContent: body omitted, everything else intact.
+	skinny, err := s.ListItems(ws.ID, models.ItemListParams{NoContent: true})
+	if err != nil {
+		t.Fatalf("ListItems NoContent: %v", err)
+	}
+	if len(skinny) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(skinny))
+	}
+	if skinny[0].Content != "" {
+		t.Errorf("expected empty content with NoContent, got %q", skinny[0].Content)
+	}
+	if skinny[0].Title != "Has body" {
+		t.Errorf("expected title preserved, got %q", skinny[0].Title)
+	}
+}

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -649,6 +649,71 @@ func (s *Store) GetItemIncludeDeleted(id string) (*models.Item, error) {
 	return &item, nil
 }
 
+// GetItemsByIDsIncludeDeleted fetches items (soft-deleted included) for the
+// given IDs in ONE `WHERE id IN (...)` query, keyed by item ID. It replaces
+// the per-row GetItemIncludeDeleted N+1 the dashboard's recent-activity
+// enrichment used to run once per activity row (BUG-2002). The rich-text body
+// is omitted — the only consumers read title/slug/ref/collection + the
+// visibility inputs, never the markdown body. IDs with no matching row are
+// simply absent from the map.
+func (s *Store) GetItemsByIDsIncludeDeleted(ids []string) (map[string]*models.Item, error) {
+	result := make(map[string]*models.Item, len(ids))
+	if len(ids) == 0 {
+		return result, nil
+	}
+	placeholders := make([]string, len(ids))
+	args := make([]any, len(ids))
+	for i, id := range ids {
+		placeholders[i] = "?"
+		args[i] = id
+	}
+	rows, err := s.db.Query(s.q(fmt.Sprintf(`
+		SELECT i.id, i.workspace_id, i.collection_id, i.title, i.slug, '', i.fields, i.tags,
+		       i.pinned, i.sort_order, i.parent_id, i.assigned_user_id, i.agent_role_id, i.role_sort_order,
+		       i.created_by, i.last_modified_by, i.source,
+		       i.item_number, i.seq, i.created_at, i.updated_at, i.deleted_at,
+		       c.slug, c.name, c.icon, c.prefix,
+		       COALESCE(au.name, ''), COALESCE(au.email, ''),
+		       COALESCE(ar.name, ''), COALESCE(ar.slug, ''), COALESCE(ar.icon, '')
+		FROM items i
+		JOIN collections c ON c.id = i.collection_id
+		LEFT JOIN users au ON au.id = i.assigned_user_id
+		LEFT JOIN agent_roles ar ON ar.id = i.agent_role_id
+		WHERE i.id IN (%s)
+	`, strings.Join(placeholders, ","))), args...)
+	if err != nil {
+		return nil, fmt.Errorf("get items by ids (include deleted): %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var item models.Item
+		var createdAt, updatedAt string
+		var deletedAt *string
+		var pinned bool
+		if err := rows.Scan(
+			&item.ID, &item.WorkspaceID, &item.CollectionID, &item.Title, &item.Slug,
+			&item.Content, &item.Fields, &item.Tags,
+			&pinned, &item.SortOrder, &item.ParentID, &item.AssignedUserID, &item.AgentRoleID, &item.RoleSortOrder,
+			&item.CreatedBy, &item.LastModifiedBy, &item.Source,
+			&item.ItemNumber, &item.Seq, &createdAt, &updatedAt, &deletedAt,
+			&item.CollectionSlug, &item.CollectionName, &item.CollectionIcon, &item.CollectionPrefix,
+			&item.AssignedUserName, &item.AssignedUserEmail,
+			&item.AgentRoleName, &item.AgentRoleSlug, &item.AgentRoleIcon,
+		); err != nil {
+			return nil, err
+		}
+		item.Pinned = pinned
+		item.CreatedAt = parseTime(createdAt)
+		item.UpdatedAt = parseTime(updatedAt)
+		item.DeletedAt = parseTimePtr(deletedAt)
+		hydrateItemComputedMetadata(&item)
+		itemCopy := item
+		result[item.ID] = &itemCopy
+	}
+	return result, rows.Err()
+}
+
 // GetItemBySlugIncludeDeleted finds an item by slug including soft-deleted items.
 // Used for restore operations where the item is archived.
 func (s *Store) GetItemBySlugIncludeDeleted(workspaceID, slug string) (*models.Item, error) {
@@ -711,8 +776,16 @@ func (s *Store) ListItems(workspaceID string, params models.ItemListParams) ([]m
 		return s.listItemsFTS(workspaceID, params)
 	}
 
+	// NoContent swaps the rich-text body column for an empty literal so
+	// count/summary scans (e.g. the dashboard builder) don't load every
+	// item's full markdown. scanItems still scans the same column count;
+	// item.Content just comes back empty (BUG-2002).
+	contentCol := "i.content"
+	if params.NoContent {
+		contentCol = "''"
+	}
 	query := `
-		SELECT i.id, i.workspace_id, i.collection_id, i.title, i.slug, i.content, i.fields, i.tags,
+		SELECT i.id, i.workspace_id, i.collection_id, i.title, i.slug, ` + contentCol + `, i.fields, i.tags,
 		       i.pinned, i.sort_order, i.parent_id, i.assigned_user_id, i.agent_role_id, i.role_sort_order,
 		       i.created_by, i.last_modified_by, i.source,
 		       i.item_number, i.seq, i.created_at, i.updated_at,
@@ -3222,6 +3295,125 @@ func (s *Store) getChildItems(q childQueryer, parentItemID string) ([]models.Ite
 	defer rows.Close()
 
 	return scanItems(rows)
+}
+
+// GetChildItemsForParents returns the live child items for each of the given
+// parent item IDs, grouped by parent ID, in ONE query — collapsing the
+// per-parent GetChildItems N+1 the dashboard used to run once per active plan
+// (BUG-2002). The rich-text body (content) is omitted from the projection:
+// every dashboard consumer of plan children reads only structured fields
+// (status/priority) + identity, never the markdown body, so we skip the heavy
+// column.
+//
+// Ordering within each parent's slice matches GetChildItems (sort_order ASC,
+// created_at ASC). A child linked to more than one requested parent appears
+// under each. Parents with no live children are simply absent from the map.
+func (s *Store) GetChildItemsForParents(parentIDs []string) (map[string][]models.Item, error) {
+	result := make(map[string][]models.Item, len(parentIDs))
+	if len(parentIDs) == 0 {
+		return result, nil
+	}
+	placeholders := make([]string, len(parentIDs))
+	args := make([]any, len(parentIDs))
+	for i, id := range parentIDs {
+		placeholders[i] = "?"
+		args[i] = id
+	}
+	rows, err := s.db.Query(s.q(fmt.Sprintf(`
+		SELECT DISTINCT il.target_id,
+		       i.id, i.workspace_id, i.collection_id, i.title, i.slug, '', i.fields, i.tags,
+		       i.pinned, i.sort_order, i.parent_id, i.assigned_user_id, i.agent_role_id, i.role_sort_order,
+		       i.created_by, i.last_modified_by, i.source,
+		       i.item_number, i.seq, i.created_at, i.updated_at,
+		       c.slug, c.name, c.icon, c.prefix,
+		       COALESCE(au.name, ''), COALESCE(au.email, ''),
+		       COALESCE(ar.name, ''), COALESCE(ar.slug, ''), COALESCE(ar.icon, ''), i.deleted_at
+		FROM items i
+		JOIN collections c ON c.id = i.collection_id
+		JOIN item_links il ON il.source_id = i.id AND il.link_type IN (%s) AND il.target_id IN (%s)
+		LEFT JOIN users au ON au.id = i.assigned_user_id
+		LEFT JOIN agent_roles ar ON ar.id = i.agent_role_id
+		WHERE i.deleted_at IS NULL
+		ORDER BY i.sort_order ASC, i.created_at ASC
+	`, childLinkTypeSQL(), strings.Join(placeholders, ","))), args...)
+	if err != nil {
+		return nil, fmt.Errorf("get child items for parents: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var parentID string
+		var item models.Item
+		var createdAt, updatedAt string
+		var deletedAt *string
+		var pinned bool
+		if err := rows.Scan(
+			&parentID,
+			&item.ID, &item.WorkspaceID, &item.CollectionID, &item.Title, &item.Slug,
+			&item.Content, &item.Fields, &item.Tags,
+			&pinned, &item.SortOrder, &item.ParentID, &item.AssignedUserID, &item.AgentRoleID, &item.RoleSortOrder,
+			&item.CreatedBy, &item.LastModifiedBy, &item.Source,
+			&item.ItemNumber, &item.Seq, &createdAt, &updatedAt,
+			&item.CollectionSlug, &item.CollectionName, &item.CollectionIcon, &item.CollectionPrefix,
+			&item.AssignedUserName, &item.AssignedUserEmail,
+			&item.AgentRoleName, &item.AgentRoleSlug, &item.AgentRoleIcon,
+			&deletedAt,
+		); err != nil {
+			return nil, err
+		}
+		item.Pinned = pinned
+		item.CreatedAt = parseTime(createdAt)
+		item.UpdatedAt = parseTime(updatedAt)
+		item.DeletedAt = parseTimePtr(deletedAt)
+		hydrateItemComputedMetadata(&item)
+		result[parentID] = append(result[parentID], item)
+	}
+	return result, rows.Err()
+}
+
+// BlocksEdge is a skinny projection of a `blocks` link plus the blocker
+// (source) essentials the dashboard needs to decide whether a blocked item
+// should be flagged: the blocker's visibility input (collection ID), its
+// done-state input (fields), and its title/status for the reason string.
+// Fetched for a whole workspace in one query instead of the per-item
+// GetItemLinks + per-link GetItem N+1 the dashboard used to run (BUG-2002).
+type BlocksEdge struct {
+	TargetID           string // the blocked item (the `blocks` link's target)
+	SourceID           string // the blocker (the `blocks` link's source)
+	SourceTitle        string
+	SourceCollectionID string
+	SourceFields       string
+}
+
+// GetBlocksEdges returns every `blocks` link in the workspace whose source and
+// target items are both live (non-deleted), newest link first. The
+// created_at DESC ordering matches GetItemLinks so callers replicating the
+// dashboard's "first active blocker wins" selection pick the same blocker the
+// per-item path did. Replaces the dashboard's per-non-done-item
+// GetItemLinks + per-link GetItem N+1 (BUG-2002).
+func (s *Store) GetBlocksEdges(workspaceID string) ([]BlocksEdge, error) {
+	rows, err := s.db.Query(s.q(`
+		SELECT l.target_id, l.source_id, s.title, s.collection_id, s.fields
+		FROM item_links l
+		JOIN items s ON s.id = l.source_id AND s.deleted_at IS NULL
+		JOIN items t ON t.id = l.target_id AND t.deleted_at IS NULL
+		WHERE l.workspace_id = ? AND l.link_type = 'blocks'
+		ORDER BY l.created_at DESC
+	`), workspaceID)
+	if err != nil {
+		return nil, fmt.Errorf("get blocks edges: %w", err)
+	}
+	defer rows.Close()
+
+	var edges []BlocksEdge
+	for rows.Next() {
+		var e BlocksEdge
+		if err := rows.Scan(&e.TargetID, &e.SourceID, &e.SourceTitle, &e.SourceCollectionID, &e.SourceFields); err != nil {
+			return nil, err
+		}
+		edges = append(edges, e)
+	}
+	return edges, rows.Err()
 }
 
 // PopulateHasChildren sets HasChildren=true on items that have at least one


### PR DESCRIPTION
## BUG-2002 — kill the ~1000-query dashboard/bootstrap N+1

`buildDashboardResponse` (backing `GET /dashboard`, the bootstrap endpoint, and every `pad_set_workspace`) ran ~1000 queries on a large workspace. Every per-item / per-row loop is now a single set-based query. **Pure performance refactor — output shape preserved exactly.**

### N+1s collapsed
| Section | Before | After |
|---|---|---|
| Blocked attention + suggested_next filter | `GetItemLinks` + `GetItem` per non-done item (~700-1000) | 1 `GetBlocksEdges` JOIN |
| Active-plan progress + suggested_next children | `GetChildItems` per active plan (+`ResolveItem` per plan) | 1 `GetChildItemsForParents` IN query |
| Recent-activity enrichment | `GetItemIncludeDeleted` per activity row + `GetCollection` per visible collection | 1 `GetItemsByIDsIncludeDeleted` IN query + in-memory slug map |
| Collection schema/counts | `ListCollections` (per-collection COUNT the dashboard never uses) | `ListCollectionsMinimal` (now selects `slug`) |
| Summary/count scans | loaded full markdown bodies | `ItemListParams.NoContent` projection |

Per-item N+1s are gone; the query count is now **constant in workspace size**. `itemBlockedByActive` is retired (replaced by the precomputed `firstActiveBlocker` map).

### Verification
- **Byte-identical** dashboard **and** bootstrap JSON diffed against three live workspaces (docapp 1907 items, claude, apm) — no differences.
- Dashboard latency ~376ms → ~198ms; bootstrap ~391ms → ~244ms on the docapp workspace.
- New store methods unit-tested (`internal/store/dashboard_batch_test.go`); full `go test ./...` green; golangci-lint clean.
- Codex review: one finding (batch-children error was swallowed) — fixed to return the error, consistent with sibling batch queries.

Fixes BUG-2002.
