### PR TITLE
feat(bootstrap): add convention_index for triggered-convention discovery (TASK-2004)

### DIFF
--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -20,6 +20,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 	"syscall"
@@ -5293,6 +5294,8 @@ The blob carries everything the /pad skill needs to start a session:
   - The calling user (name, email, id)
   - Collections (with schemas)
   - Always-on, active conventions (full body — must-follow rules)
+  - Convention index (METADATA ONLY — every active convention by
+    trigger, so triggered rules are discoverable; bodies load on demand)
   - Agent roles
   - Playbooks (METADATA ONLY — full bodies load on invocation)
   - Dashboard (active items, attention, suggested next)
@@ -5349,6 +5352,12 @@ func printBootstrapMarkdown(raw []byte) error {
 			Slug string `json:"slug"`
 			Name string `json:"name"`
 		} `json:"roles"`
+		ConventionIndex []struct {
+			Ref     string `json:"ref"`
+			Title   string `json:"title"`
+			Trigger string `json:"trigger"`
+			Role    string `json:"role"`
+		} `json:"convention_index"`
 		Playbooks []struct {
 			Ref            string `json:"ref"`
 			Title          string `json:"title"`
@@ -5379,6 +5388,32 @@ func printBootstrapMarkdown(raw []byte) error {
 		fmt.Printf("- [%s] %s — %s\n", c.Ref, c.Title, c.Priority)
 	}
 	fmt.Println()
+
+	// convention_index: metadata-only catalog of EVERY active convention
+	// (all triggers). Grouped by trigger so the triggered set an agent
+	// would otherwise never see is legible at a glance. Bodies load on
+	// demand via `pad item list conventions --field trigger=<t>`.
+	if len(b.ConventionIndex) > 0 {
+		byTrigger := map[string]int{}
+		for _, c := range b.ConventionIndex {
+			trig := c.Trigger
+			if trig == "" {
+				trig = "(none)"
+			}
+			byTrigger[trig]++
+		}
+		triggers := make([]string, 0, len(byTrigger))
+		for trig := range byTrigger {
+			triggers = append(triggers, trig)
+		}
+		sort.Strings(triggers)
+		fmt.Printf("## Convention index (%d total)\n", len(b.ConventionIndex))
+		for _, trig := range triggers {
+			fmt.Printf("- %s: %d\n", trig, byTrigger[trig])
+		}
+		fmt.Println("Pull bodies on demand: pad item list conventions --field trigger=<trigger>")
+		fmt.Println()
+	}
 
 	fmt.Printf("## Agent roles (%d)\n", len(b.Roles))
 	for _, r := range b.Roles {

--- a/internal/mcp/instructions.md
+++ b/internal/mcp/instructions.md
@@ -18,7 +18,7 @@ Nine resource × action tools, plus `pad_set_workspace` (which takes a `workspac
 - `pad_search` — Full-text search across items: query.
 - `pad_playbook` — Invokable procedures: list / get / run. Use `run` to bind args against a playbook's declared spec and get the rendered body back; side-effect-free.
 - `pad_library` — Convention + playbook library (the global catalog of pre-built entries workspaces activate): list / get / activate.
-- `pad_meta` — Server introspection: server-info / version / tool-surface / bootstrap. The `bootstrap` action returns one-shot workspace context (user + collections + always-on conventions + roles + playbook metadata + dashboard + recent activity).
+- `pad_meta` — Server introspection: server-info / version / tool-surface / bootstrap. The `bootstrap` action returns one-shot workspace context (user + collections + always-on conventions + a metadata-only `convention_index` of every active convention + roles + playbook metadata + dashboard + recent activity).
 - `pad_set_workspace` — Load workspace context; response embeds the bootstrap blob so you load context in one call. On a single-user local server it also pins the workspace as the session default for subsequent calls; a multi-user/remote server does **not** persist it — pass `workspace` explicitly on each call. Takes `workspace: <slug>` only (no `action`).
 
 For the nine resource × action tools, always pass `action` as a top-level field. Per-action required parameters are documented in each tool's description.
@@ -56,13 +56,18 @@ For `pad_item.action: update`, the server merges your patch with the item's curr
 
 ## Project conventions
 
-Workspaces can declare conventions (e.g. "run `make test` before PR", "use conventional commit format"). Before performing meaningful work, you may want to read active conventions:
+Workspaces can declare conventions (e.g. "run `make test` before PR", "use conventional commit format"). The bootstrap blob gives you two views:
+
+- `conventions` — full bodies of the always-on (`trigger=always`) rules. Follow these unconditionally.
+- `convention_index` — METADATA ONLY (`ref`, `title`, `trigger`, `role`; no bodies) for **every** active convention, including the triggered ones whose bodies are NOT in `conventions`. This is your map of what triggered rules exist.
+
+Before performing meaningful work with a specific trigger (e.g. `on-implement` before writing code), consult `convention_index`: if it lists entries for that trigger, pull their bodies on demand; if it lists none, skip the query.
 
 ```
 pad_item.action: list, collection: "conventions", status: "active"
 ```
 
-Filter by trigger (`always`, `on-implement`, `on-task-complete`, etc.) when relevant.
+Filter by trigger (`always`, `on-implement`, `on-task-complete`, etc.) when relevant — the `convention_index` triggers tell you which filters are worth running.
 
 ## Adding a workspace to this connection
 

--- a/internal/server/handlers_bootstrap.go
+++ b/internal/server/handlers_bootstrap.go
@@ -21,13 +21,23 @@ import (
 // in `pad_set_workspace`'s response, and an on-demand `pad_meta.action=bootstrap`
 // refresh.
 type AgentBootstrap struct {
-	Workspace   AgentBootstrapWorkspace      `json:"workspace"`
-	User        AgentBootstrapUser           `json:"user"`
-	Collections []BootstrapCollection        `json:"collections"`
-	Conventions []AgentBootstrapConvention   `json:"conventions"`
-	Roles       []BootstrapRole              `json:"roles"`
-	Playbooks   []AgentBootstrapPlaybookMeta `json:"playbooks"`
-	Dashboard   *BootstrapDashboard          `json:"dashboard,omitempty"`
+	Workspace   AgentBootstrapWorkspace    `json:"workspace"`
+	User        AgentBootstrapUser         `json:"user"`
+	Collections []BootstrapCollection      `json:"collections"`
+	Conventions []AgentBootstrapConvention `json:"conventions"`
+	// ConventionIndex is the metadata-only catalog of EVERY active
+	// convention (all triggers, including the always-on ones whose full
+	// bodies also appear in Conventions). It carries no bodies — just
+	// ref/title/trigger/role — so an agent can see that e.g. 10
+	// `on-implement` conventions exist and fire the targeted
+	// `pad item list conventions --field trigger=on-implement` query only
+	// when that trigger is relevant, instead of loading every body up
+	// front or (as before) never learning the triggered set exists.
+	// Mirrors the Playbooks metadata pattern. TASK-2004.
+	ConventionIndex []AgentBootstrapConventionMeta `json:"convention_index"`
+	Roles           []BootstrapRole                `json:"roles"`
+	Playbooks       []AgentBootstrapPlaybookMeta   `json:"playbooks"`
+	Dashboard       *BootstrapDashboard            `json:"dashboard,omitempty"`
 	// NeedsOnboarding is true when the workspace has ZERO user-created
 	// items — i.e. nothing beyond what SeedCollectionsFromTemplate seeded
 	// at init time. The agent skill reads this on every /pad invocation
@@ -273,6 +283,31 @@ type AgentBootstrapConvention struct {
 	Trigger  string `json:"trigger,omitempty"`
 }
 
+// AgentBootstrapConventionMeta is the lightweight, body-less convention
+// projection returned in the bootstrap's convention_index. It mirrors the
+// AgentBootstrapPlaybookMeta pattern: metadata only, no content, so a
+// workspace with dozens of triggered conventions costs the agent only a
+// handful of bytes per entry (~40 bytes) at greeting time.
+//
+// The index exists so triggered (non-always) conventions are DISCOVERABLE.
+// The always-on set ships its full bodies in AgentBootstrap.Conventions,
+// but trigger-specific conventions (on-implement, on-task-complete,
+// on-pr-create, …) previously never appeared even as titles — so agents
+// never knew to fire the targeted `pad item list conventions --field
+// trigger=<t>` query. The index lists ALL active conventions (always-on
+// included, for a complete picture); the agent reads a trigger's count
+// here and pulls the bodies on demand only when that trigger fires.
+// TASK-2004.
+type AgentBootstrapConventionMeta struct {
+	Ref     string `json:"ref"`
+	Title   string `json:"title"`
+	Trigger string `json:"trigger,omitempty"`
+	// Role is the slug of the agent role this convention is scoped to,
+	// when set. Most conventions are workspace-wide (no role) so this is
+	// omitted for them.
+	Role string `json:"role,omitempty"`
+}
+
 // AgentBootstrapPlaybookMeta is the lightweight playbook projection
 // returned at bootstrap. Bodies (which can be 5-10KB each) are
 // deliberately excluded; the agent loads a body on demand via
@@ -458,8 +493,18 @@ func (s *Server) BuildAgentBootstrap(workspaceID string, user *models.User, r *h
 			return nil, cerr
 		}
 		out.Conventions = convs
+
+		// convention_index: metadata-only catalog of EVERY active
+		// convention (all triggers), so the triggered set is discoverable
+		// without shipping bodies. See AgentBootstrapConventionMeta.
+		idx, ierr := s.collectConventionIndex(workspaceID, subCollIDs, subItemIDs)
+		if ierr != nil {
+			return nil, ierr
+		}
+		out.ConventionIndex = idx
 	} else {
 		out.Conventions = []AgentBootstrapConvention{}
+		out.ConventionIndex = []AgentBootstrapConventionMeta{}
 	}
 
 	// Agent roles — workspace-scoped, not collection-bound. Item counts
@@ -621,6 +666,60 @@ func (s *Server) collectAlwaysOnConventions(workspaceID string, collIDs []string
 		pj := conventionPriorityRank(out[j].Priority)
 		if pi != pj {
 			return pi < pj
+		}
+		return out[i].Ref < out[j].Ref
+	})
+	return out, nil
+}
+
+// collectConventionIndex returns the metadata-only catalog of EVERY
+// active convention in the workspace (all triggers, always-on included),
+// projected into AgentBootstrapConventionMeta. Bodies are NOT loaded —
+// the query uses NoContent so the potentially-large markdown column never
+// leaves the DB. This backs AgentBootstrap.ConventionIndex; see that
+// field + AgentBootstrapConventionMeta for why a body-less index is the
+// point (triggered conventions must be discoverable without their bodies
+// flooding the bootstrap). TASK-2004.
+//
+// collIDs / itemIDs scope the underlying ListItems call the same way
+// collectAlwaysOnConventions does: nil collIDs means "no restriction"
+// (full member); non-nil collIDs + non-nil itemIDs is the
+// guest-with-item-grants shape. A guest granted one convention sees only
+// that one in the index.
+//
+// Sorted by trigger, then ref for a stable, grouped order so an agent can
+// eyeball "how many on-implement conventions exist" at a glance.
+func (s *Server) collectConventionIndex(workspaceID string, collIDs []string, itemIDs []string) ([]AgentBootstrapConventionMeta, error) {
+	items, err := s.store.ListItems(workspaceID, models.ItemListParams{
+		CollectionSlug: "conventions",
+		CollectionIDs:  collIDs,
+		ItemIDs:        itemIDs,
+		NoContent:      true,
+		Fields: map[string]string{
+			"status": "active",
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]AgentBootstrapConventionMeta, 0, len(items))
+	for _, it := range items {
+		fields := map[string]any{}
+		_ = json.Unmarshal([]byte(it.Fields), &fields)
+		trigger := ""
+		if v, ok := fields["trigger"].(string); ok {
+			trigger = v
+		}
+		out = append(out, AgentBootstrapConventionMeta{
+			Ref:     it.Ref,
+			Title:   it.Title,
+			Trigger: trigger,
+			Role:    it.AgentRoleSlug,
+		})
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Trigger != out[j].Trigger {
+			return out[i].Trigger < out[j].Trigger
 		}
 		return out[i].Ref < out[j].Ref
 	})

--- a/internal/server/handlers_bootstrap_test.go
+++ b/internal/server/handlers_bootstrap_test.go
@@ -220,7 +220,7 @@ func TestBootstrapEmptyArraysNotNull(t *testing.T) {
 	// PLAN-1410 / TASK-1413: the top-level `recent_activity` key was
 	// retired (duplicate of dashboard.recent_activity). The remaining
 	// top-level array fields must still serialize as [] not null.
-	for _, key := range []string{"collections", "conventions", "roles", "playbooks"} {
+	for _, key := range []string{"collections", "conventions", "convention_index", "roles", "playbooks"} {
 		val, ok := raw[key]
 		if !ok {
 			t.Errorf("missing key %q in bootstrap response", key)
@@ -481,6 +481,95 @@ func TestBootstrapIncludesPlaybookMetadata(t *testing.T) {
 	}
 }
 
+// TestBootstrapConventionIndex verifies the convention_index (TASK-2004):
+// EVERY active convention appears as body-less metadata (ref/title/trigger),
+// including the triggered set that never surfaced before, while the
+// always-on bodies still ship in `conventions`. The load-bearing negative
+// assertion is that no index entry carries a `content` body — the whole
+// point is that triggered conventions are DISCOVERABLE without their bodies
+// flooding the bootstrap.
+func TestBootstrapConventionIndex(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	// One always-on (body ships in `conventions`) + two triggered
+	// (previously invisible — only the index makes them discoverable).
+	createItem(t, srv, slug, "conventions", map[string]interface{}{
+		"title":   "Always follow this",
+		"content": "This body ships in full under bootstrap.conventions.",
+		"fields":  `{"status":"active","trigger":"always","priority":"must","scope":"all"}`,
+	})
+	createItem(t, srv, slug, "conventions", map[string]interface{}{
+		"title":   "On implement, run the suite",
+		"content": "Long triggered-convention body that must NOT leak into the index.",
+		"fields":  `{"status":"active","trigger":"on-implement","priority":"should","scope":"all"}`,
+	})
+	createItem(t, srv, slug, "conventions", map[string]interface{}{
+		"title":   "On PR create, request review",
+		"content": "Another triggered body that stays out of the index.",
+		"fields":  `{"status":"active","trigger":"on-pr-create","priority":"should","scope":"all"}`,
+	})
+	// A disabled convention must NOT appear — index is active-only.
+	createItem(t, srv, slug, "conventions", map[string]interface{}{
+		"title":   "Retired convention",
+		"content": "Disabled; should be absent from the index.",
+		"fields":  `{"status":"disabled","trigger":"on-implement","priority":"nice-to-have","scope":"all"}`,
+	})
+
+	rr := doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/agent/bootstrap", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("bootstrap: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var b AgentBootstrap
+	parseJSON(t, rr, &b)
+
+	byTitle := map[string]AgentBootstrapConventionMeta{}
+	for _, m := range b.ConventionIndex {
+		byTitle[m.Title] = m
+	}
+
+	// All three active conventions (always + both triggered) present.
+	for _, want := range []struct{ title, trigger string }{
+		{"Always follow this", "always"},
+		{"On implement, run the suite", "on-implement"},
+		{"On PR create, request review", "on-pr-create"},
+	} {
+		m, ok := byTitle[want.title]
+		if !ok {
+			t.Errorf("convention_index missing %q; got %+v", want.title, b.ConventionIndex)
+			continue
+		}
+		if m.Trigger != want.trigger {
+			t.Errorf("convention_index[%q].trigger = %q, want %q", want.title, m.Trigger, want.trigger)
+		}
+		if m.Ref == "" {
+			t.Errorf("convention_index[%q].ref is empty", want.title)
+		}
+	}
+
+	// Archived convention absent.
+	if _, ok := byTitle["Retired convention"]; ok {
+		t.Error("convention_index included an archived convention; want active-only")
+	}
+
+	// Load-bearing: the index carries NO bodies. Re-marshal and assert
+	// the raw JSON of each index entry has no `content` key at all.
+	raw := struct {
+		ConventionIndex []map[string]json.RawMessage `json:"convention_index"`
+	}{}
+	if err := json.Unmarshal(rr.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("decode raw convention_index: %v", err)
+	}
+	if len(raw.ConventionIndex) == 0 {
+		t.Fatal("convention_index serialized empty")
+	}
+	for _, entry := range raw.ConventionIndex {
+		if _, has := entry["content"]; has {
+			t.Errorf("convention_index entry carries a `content` body; index must be metadata-only: %v", entry)
+		}
+	}
+}
+
 // bootstrapSizeBudget is the maximum byte count tolerated for the bootstrap
 // JSON response against the seeded fixture in seedBootstrapSizeFixture.
 //
@@ -619,6 +708,7 @@ func bootstrapSectionBytes(b AgentBootstrap) []string {
 		fmt.Sprintf("user:        %d bytes", jsonLen(b.User)),
 		fmt.Sprintf("collections: %d bytes (%d items)", jsonLen(b.Collections), len(b.Collections)),
 		fmt.Sprintf("conventions: %d bytes (%d items)", jsonLen(b.Conventions), len(b.Conventions)),
+		fmt.Sprintf("conv_index:  %d bytes (%d items)", jsonLen(b.ConventionIndex), len(b.ConventionIndex)),
 		fmt.Sprintf("roles:       %d bytes (%d items)", jsonLen(b.Roles), len(b.Roles)),
 		fmt.Sprintf("playbooks:   %d bytes (%d items)", jsonLen(b.Playbooks), len(b.Playbooks)),
 		fmt.Sprintf("dashboard:   %d bytes", jsonLen(b.Dashboard)),

--- a/skills/pad/SKILL.md
+++ b/skills/pad/SKILL.md
@@ -33,6 +33,7 @@ The returned `AgentBootstrap` blob carries everything the skill needs to start a
 - `user { name, email, id }` — who's talking
 - `collections [...]` — schemas (drives `pad item create`/`update` field validation)
 - `conventions [...]` — full bodies of `trigger=always, status=active` items. **Must-follow project rules.**
+- `convention_index [...]` — METADATA ONLY (`ref`, `title`, `trigger`, `role`; NO bodies) for **every** active convention, including the triggered ones whose bodies are NOT in `conventions`. This is your map of what triggered rules exist — e.g. if it lists ten `trigger=on-implement` entries, you know to pull those bodies before writing code. Load bodies on demand with `pad item list conventions --field trigger=<trigger> --field status=active` only when the matching trigger fires.
 - `roles [...]` — agent roles configured in the workspace
 - `playbooks [...]` — METADATA ONLY: `ref`, `title`, `slug`, `invocation_slug`, `trigger`, `scope`, `status`, `has_arguments`, `summary`. Full bodies load on invocation via `pad playbook show <slug>`.
 - `dashboard {...}` — active items, attention, suggested next, recent activity. Five sub-arrays are capped to 5 entries each (`attention`, `recent_activity`, `active_items`, `active_plans`, `by_role`); each pairs with a `<name>_overflow_count` int field surfaced when truncation kicked in. Use `pad project dashboard` to pull the full set when any overflow > 0.
@@ -195,7 +196,7 @@ After creation, tell the user how to invoke it — by intent ("just say *run the
 
 When you are about to take action, load the relevant conventions and playbooks FIRST. The shape is always the same: match the trigger to the action you're about to take.
 
-**Bootstrap already gave you the always-on conventions and the full playbooks metadata array.** When the action you're about to take has a specific trigger (e.g. `on-implement` before writing code), pull the trigger-matched conventions on demand — those aren't in the bootstrap to keep its size tight.
+**Bootstrap already gave you the always-on conventions (full bodies), the `convention_index` (metadata for every active convention), and the full playbooks metadata array.** When the action you're about to take has a specific trigger (e.g. `on-implement` before writing code), first check `convention_index` — if it lists entries for that trigger, pull their bodies on demand with the query below; if it lists none, skip the query. The triggered bodies aren't in the bootstrap to keep its size tight, but the index tells you which ones exist so you neither miss them nor waste a query when there are none.
 
 **Trigger vocabulary is workspace-defined and differs between conventions and playbooks.** Each template ships its own set — software conventions include `on-implement`, `on-commit`, `on-pr-create`, `on-task-complete`, `on-plan`, `always`; software playbooks include those plus `on-triage`, `on-release`, `on-review`, `on-deploy`, `manual`. A hiring workspace would have triggers like `on-candidate-advance`, `on-interview-scheduled`. A research workspace would have `on-source-cited`, `on-experiment-run`. **The bootstrap's `collections` array carries each schema** — inspect the conventions/playbooks schemas there to see the available triggers for the current workspace.
 


### PR DESCRIPTION
## What

Adds `convention_index` to the agent bootstrap payload — a **metadata-only** catalog (`ref`, `title`, `trigger`, `role`; **no bodies**) of every active convention, mirroring the existing playbook-metadata pattern.

## Why

Bootstrap previously shipped only `trigger=always` conventions (with full bodies). Triggered conventions (on-implement, on-task-complete, on-pr-create, …) never appeared even as titles, so agents never knew to fire the targeted `pad item list conventions --field trigger=<t>` query SKILL.md asks for. The index makes the triggered set discoverable: an agent sees e.g. 10 on-implement conventions exist and pulls their bodies on demand only when that trigger fires.

## Shape

```json
"convention_index": [
  { "ref": "CONVE-1863", "title": "…", "trigger": "on-implement" },
  { "ref": "CONVE-42", "title": "…", "trigger": "always", "role": "planner" }
]
```

- All active conventions (always-on included, for a complete picture). Always-on bodies still ship in `conventions` unchanged.
- Loaded via `ListItems(NoContent: true)` (BUG-2002 no-content projection) — bodies never leave the DB.
- Sorted by trigger, then ref for stable, grouped order. ~155 bytes for 2 items in the fixture; ~1.2KB on the live 32-convention workspace.

## Additive — no version bump

Purely additive bootstrap field (older clients ignore the unknown key). No tool names / action enums / param shapes changed, so `ToolSurfaceVersion` stays 0.9 and the MCP drift guard passes. Same precedent as `needs_onboarding` (TASK-1504).

## Docs + tests

- `skills/pad/SKILL.md` + `internal/mcp/instructions.md`: tell the agent to consult `convention_index` and pull bodies on demand per trigger.
- `pad bootstrap --format markdown`: new grouped-by-trigger index section.
- New `TestBootstrapConventionIndex` (asserts triggered set present, active-only, **no bodies**); extended empty-array + size-budget guards.

## Gate

`go build ./... && go test ./... && golangci-lint run` all green; `go test ./internal/mcp/...` (drift guard) green; codex review clean.