### PR TITLE
feat(editor): add explicit attach-file button to tiptap menu (TASK-2067)

### DIFF
--- a/web/src/lib/components/editor/Editor.svelte
+++ b/web/src/lib/components/editor/Editor.svelte
@@ -735,6 +735,13 @@
 				// against the editor reference we hold in this scope.
 				importUrlModalOpen = true;
 				break;
+			case 'attachFile':
+				// The slash text was already deleted above; open the
+				// native file picker. onAttachInputChange runs
+				// uploadAttachments, which inserts at the (preserved)
+				// selection where the slash was typed.
+				triggerAttachPicker();
+				break;
 		}
 		closeSlash();
 	}
@@ -1213,6 +1220,26 @@
 		slashOpen = true;
 	}
 
+	// Hidden file <input> that backs the attach-file button (mobile
+	// toolbar) and the /attach slash command. A real input is the only
+	// way to open a file picker on touch devices, where paste/drop —
+	// the editor's only other upload path — is unavailable (TASK-2067).
+	let attachInput = $state<HTMLInputElement>();
+
+	function triggerAttachPicker() {
+		attachInput?.click();
+	}
+
+	function onAttachInputChange(event: Event) {
+		const input = event.currentTarget as HTMLInputElement;
+		const files = input.files ? Array.from(input.files) : [];
+		if (files.length && editor) {
+			editor.commands.uploadAttachments(files);
+		}
+		// Reset so re-picking the same file fires 'change' again.
+		input.value = '';
+	}
+
 	type ListItemTypeName = 'listItem' | 'taskItem';
 
 	function getActiveListItemType(): ListItemTypeName | null {
@@ -1284,10 +1311,28 @@
 		<span class="mt-sep"></span>
 		<button class="mt-btn" class:active={_tick >= 0 && editor.isActive('codeBlock')} onclick={() => editor?.chain().focus().toggleCodeBlock().run()}>&lt;&gt;</button>
 		<button class="mt-btn" class:active={_tick >= 0 && editor.isActive('blockquote')} onclick={() => editor?.chain().focus().toggleBlockquote().run()}>❝</button>
+		<span class="mt-sep"></span>
+		<button class="mt-btn" onclick={triggerAttachPicker} title="Attach file">📎</button>
 	</div>
 {/if}
 
 <div class="editor-wrapper">
+	<!--
+		Hidden file picker shared by the mobile toolbar attach button and
+		the /attach slash command. `multiple` mirrors paste/drop, which
+		can carry several files; no `accept` filter — images become inline
+		images and everything else becomes an attachment chip, same as
+		paste/drop (TASK-2067).
+	-->
+	<input
+		bind:this={attachInput}
+		type="file"
+		multiple
+		class="attach-file-input"
+		aria-hidden="true"
+		tabindex="-1"
+		onchange={onAttachInputChange}
+	/>
 	<div bind:this={element} class="editor-content prose"></div>
 	{#if editable && editor && editorTick >= 0 && editor.isActive('table')}
 		{@const tpos = getTableToolbarPos()}
@@ -1358,6 +1403,19 @@
 		outline: none;
 		/* Pad left to make room for the drag handle */
 		padding-left: 24px;
+	}
+
+	/* Visually hidden but still focusable/clickable programmatically —
+	   display:none inputs can't be .click()'d reliably on some browsers. */
+	.attach-file-input {
+		position: absolute;
+		width: 1px;
+		height: 1px;
+		padding: 0;
+		margin: -1px;
+		overflow: hidden;
+		clip: rect(0, 0, 0, 0);
+		border: 0;
 	}
 
 	/* Block drag handle */

--- a/web/src/lib/components/editor/attachment-upload.ts
+++ b/web/src/lib/components/editor/attachment-upload.ts
@@ -32,6 +32,20 @@ import { Plugin, PluginKey } from '@tiptap/pm/state';
 import { Decoration, DecorationSet, type EditorView } from '@tiptap/pm/view';
 import type { AttachmentUploadResult } from '$lib/types';
 
+declare module '@tiptap/core' {
+	interface Commands<ReturnType> {
+		attachmentUpload: {
+			/**
+			 * Upload one or more files through the same pipeline as
+			 * paste/drop, inserting each at the current selection. Backs
+			 * the toolbar / slash "Attach file" buttons — the surface a
+			 * touch device (which can't paste/drop a file) relies on.
+			 */
+			uploadAttachments: (files: File[]) => ReturnType;
+		};
+	}
+}
+
 /** Per-upload metadata stored in plugin state and rendered as a decoration. */
 interface UploadEntry {
 	pos: number;
@@ -289,5 +303,28 @@ export const AttachmentUpload = Extension.create<AttachmentUploadOptions>({
 
 	addProseMirrorPlugins() {
 		return [attachmentUploadPlugin(this.options)];
+	},
+
+	addCommands() {
+		return {
+			// Programmatic entry point for the toolbar / slash "Attach
+			// file" buttons. Routes each picked file through the exact
+			// same startUpload flow as paste/drop (placeholder → upload →
+			// replace with attachmentImage/attachmentChip), so behavior,
+			// error handling, and image-vs-chip routing stay identical
+			// across every insertion surface. Inserts at the current
+			// selection; startUpload's position mapping carries the
+			// placeholder forward across intervening edits.
+			uploadAttachments:
+				(files: File[]) =>
+				({ view }) => {
+					if (!files.length) return false;
+					const pos = view.state.selection.from;
+					for (const file of files) {
+						startUpload(view, file, pos, this.options);
+					}
+					return true;
+				},
+		};
 	},
 });

--- a/web/src/lib/components/editor/block-types.ts
+++ b/web/src/lib/components/editor/block-types.ts
@@ -35,6 +35,7 @@ export const BLOCK_TYPES: BlockType[] = [
 	{ id: 'horizontalRule', icon: '——', label: 'Divider', description: 'Horizontal rule', insertOnly: true, keywords: ['hr', 'rule', 'separator'] },
 	{ id: 'table', icon: '⊞', label: 'Table', description: '3×3 table', insertOnly: true, keywords: ['tbl', 'grid'] },
 	{ id: 'importUrl', icon: '🌐', label: 'Insert from URL', description: 'Fetch a page and convert to markdown', insertOnly: true, keywords: ['url', 'fetch', 'import', 'web', 'page', 'openapi'] },
+	{ id: 'attachFile', icon: '📎', label: 'Attach File', description: 'Upload an image or file', insertOnly: true, keywords: ['attach', 'upload', 'file', 'image', 'photo', 'attachment'] },
 ];
 
 /** Block types available in the slash command menu (excludes convert-only types like "Text") */


### PR DESCRIPTION
## What & why

The editor's attachment upload (`attachment-upload.ts`) was **paste/drop-only** — unreachable on touch devices. So the mobile shells' new file-chooser plumbing (TASK-2049, Android `onShowFileChooser` / iOS picker) had nothing to trigger. This adds an explicit attach affordance backed by a real `<input type="file">`.

Closes the web half of the mobile-attach gap (TASK-2067, "part 1"). Refs TASK-2049, PLAN-1693.

## Approach

- **`attachment-upload.ts`** — expose the existing `startUpload` pipeline as a Tiptap command `uploadAttachments(files: File[])` (+ `@tiptap/core` Commands module augmentation). No new upload logic; it reuses the paste/drop flow verbatim — images → `attachmentImage`, other files → `attachmentChip`, same `upload`/`onError` options (workspace context, `itemId` grant chain, error alerts).
- **`Editor.svelte`** — a hidden `<input type="file" multiple>` (no `accept` filter, mirroring paste/drop) plus:
  - a 📎 button on the **mobile toolbar** (the core fix — where paste/drop is impossible),
  - a **`/attach` slash command** (the desktop insertion affordance, same pattern as tables / HTML / import-from-URL).
- **`block-types.ts`** — the `attachFile` slash entry.

## Surfaces note

The desktop `EditorToolbar.svelte` is unmounted dead code (an earlier revision added a button there; Codex review caught it and it was reverted). Desktop's real insertion surface is the slash menu, so `/attach` covers desktop.

## Foot-guns checked

- **Pure UI change** — no ProseMirror / Y.Doc node-spec change, so **no collab schema-version bump** (`SCHEMA_VERSION` / `DefaultSchemaVersion` untouched).
- No Go / `internal/store` / dialect / migration / MCP-catalog surfaces touched.

## Gates

- `cd web && npm run check` — 0 errors
- `cd web && npm run build` — green (UI is embedded)
- `cd web && npm run test` — 128/128 pass
- Codex CLI read-only review — **CLEAN**

https://claude.ai/code/session_019knGmnHcx5rrgWXQ8V8DZS