### PR TITLE
fix: parent commands exit non-zero on unknown subcommand

### DIFF
--- a/cmd/pad/cmd_attachment.go
+++ b/cmd/pad/cmd_attachment.go
@@ -27,6 +27,7 @@ func attachmentCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "attachment",
 		Short: "Upload, download, view, and list item attachments",
+		RunE:  unknownSubcommandRun,
 		Long: `Upload, download, view, and list attachments (images, files) on items.
 
 Examples:

--- a/cmd/pad/cmd_github.go
+++ b/cmd/pad/cmd_github.go
@@ -36,6 +36,7 @@ func githubCmd() *cobra.Command {
 		Use:     "github",
 		Short:   "Link GitHub pull requests to Pad items",
 		Aliases: []string{"gh"},
+		RunE:    unknownSubcommandRun,
 		Long: `Link GitHub pull requests to Pad items and view their status.
 
 Requires the GitHub CLI (gh) to be installed: https://cli.github.com/

--- a/cmd/pad/cmd_playbook.go
+++ b/cmd/pad/cmd_playbook.go
@@ -24,6 +24,7 @@ func playbookCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "playbook",
 		Short: "Work with playbooks — first-class invokable procedures",
+		RunE:  unknownSubcommandRun,
 	}
 	cmd.AddCommand(playbookListCmd())
 	cmd.AddCommand(playbookShowCmd())

--- a/cmd/pad/cmd_role.go
+++ b/cmd/pad/cmd_role.go
@@ -17,6 +17,7 @@ func roleCmd() *cobra.Command {
 		Use:   "role",
 		Short: "Manage agent roles",
 		Long:  "Agent roles define capability specializations (e.g. Planner, Implementer, Reviewer) for human-agent work assignment.",
+		RunE:  unknownSubcommandRun,
 	}
 	cmd.AddCommand(roleListCmd(), roleCreateCmd(), roleUpdateCmd(), roleDeleteCmd())
 	return cmd

--- a/cmd/pad/cmd_tag.go
+++ b/cmd/pad/cmd_tag.go
@@ -15,6 +15,7 @@ func tagCmd() *cobra.Command {
 		Use:   "tag",
 		Short: "Inspect tags used across the workspace",
 		Long:  "Tags are free-form labels on items. They span collections, so a single tag groups items of any type (an Idea and a Bug can share one tag).",
+		RunE:  unknownSubcommandRun,
 	}
 	cmd.AddCommand(tagListCmd())
 	return cmd

--- a/cmd/pad/cmd_webhook.go
+++ b/cmd/pad/cmd_webhook.go
@@ -17,6 +17,7 @@ func webhooksCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "webhook",
 		Short: "Manage workspace webhooks",
+		RunE:  unknownSubcommandRun,
 		Long: `Manage webhooks that receive POST notifications when events occur.
 
 Examples:

--- a/cmd/pad/groups.go
+++ b/cmd/pad/groups.go
@@ -1,11 +1,27 @@
 package main
 
-import "github.com/spf13/cobra"
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// unknownSubcommandRun returns an error when the user passes an
+// unrecognized subcommand (e.g. a typo like `pad item
+// nonexistentsubcommand`). When called with no args the parent's help is
+// shown and nil is returned.
+func unknownSubcommandRun(cmd *cobra.Command, args []string) error {
+	if len(args) > 0 {
+		return fmt.Errorf("unknown command %q for %q", args[0], cmd.CommandPath())
+	}
+	return cmd.Help()
+}
 
 func authCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "auth",
 		Short: "Configure authentication and account access",
+		RunE:  unknownSubcommandRun,
 	}
 	cmd.AddCommand(
 		configureCmd(),
@@ -22,6 +38,7 @@ func serverCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "server",
 		Short: "Manage the Pad server process and web UI",
+		RunE:  unknownSubcommandRun,
 	}
 	cmd.AddCommand(
 		serveCmd(),
@@ -36,6 +53,7 @@ func workspaceCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "workspace",
 		Short: "Manage workspaces and workspace membership",
+		RunE:  unknownSubcommandRun,
 	}
 	cmd.AddCommand(
 		initCmd(),
@@ -65,6 +83,7 @@ func projectCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "project",
 		Short: "Inspect project state, reports, and activity",
+		RunE:  unknownSubcommandRun,
 	}
 	cmd.AddCommand(
 		statusCmd(),
@@ -85,6 +104,7 @@ func itemCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "item",
 		Short: "Create, update, relate, and discuss Pad items",
+		RunE:  unknownSubcommandRun,
 	}
 	cmd.AddCommand(
 		createCmd(),
@@ -128,6 +148,7 @@ func collectionCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "collection",
 		Short: "List, create, update, and delete collections",
+		RunE:  unknownSubcommandRun,
 	}
 	cmd.AddCommand(
 		collectionsCmd(),
@@ -142,6 +163,7 @@ func libraryGroupCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "library",
 		Short: "Browse and activate pre-built conventions and playbooks",
+		RunE:  unknownSubcommandRun,
 	}
 	cmd.AddCommand(
 		libraryCmd(),
@@ -155,6 +177,7 @@ func agentCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "agent",
 		Short: "Install and manage Pad agent skills",
+		RunE:  unknownSubcommandRun,
 	}
 	cmd.AddCommand(
 		installCmd(),
@@ -168,6 +191,7 @@ func dbCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "db",
 		Short: "Database backup, restore, and migration tools",
+		RunE:  unknownSubcommandRun,
 	}
 	cmd.AddCommand(
 		dbBackupCmd(),

--- a/cmd/pad/mcp.go
+++ b/cmd/pad/mcp.go
@@ -21,6 +21,7 @@ func mcpCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "mcp",
 		Short: "Run pad as a Model Context Protocol server",
+		RunE:  unknownSubcommandRun,
 		Long: `Run pad as an MCP server so AI agents (Claude Desktop, Cursor, Windsurf, etc.)
 can call pad commands as tools and read pad data as resources.
 

--- a/cmd/pad/unknown_subcommand_test.go
+++ b/cmd/pad/unknown_subcommand_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"bytes"
+	"io"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -54,4 +56,61 @@ func TestUnknownSubcommandReturnsError(t *testing.T) {
 			t.Fatalf("unexpected error for valid subcommand: %v", err)
 		}
 	})
+}
+
+// TestRealCommandTreeRejectsUnknownSubcommands walks the actual pad command
+// tree and asserts every *pure container* command (a command that groups
+// subcommands but does no work of its own) returns a non-nil error (exit
+// non-zero, per main.go's os.Exit(1) on error) when handed an unknown
+// subcommand. This guards against a newly added command group forgetting the
+// unknownSubcommandRun guard — the whole point of issue #850.
+//
+// Commands that have subcommands but are *also independently runnable* (e.g.
+// `pad workspace context`, which prints the context when run and carries a
+// `set` subcommand) are out of scope: they legitimately execute with args, so
+// they're skipped. Unknown-subcommand resolution on a pure container fails
+// before any leaf command runs, so no network calls or side effects fire.
+func TestRealCommandTreeRejectsUnknownSubcommands(t *testing.T) {
+	guardPtr := reflect.ValueOf(unknownSubcommandRun).Pointer()
+
+	var groups []string
+	var walk func(c *cobra.Command)
+	walk = func(c *cobra.Command) {
+		if !c.HasAvailableSubCommands() {
+			return
+		}
+		// A pure container has no runner of its own, or uses the
+		// unknownSubcommandRun guard. A command with a *different* real
+		// Run/RunE is an independently runnable command — out of scope.
+		guarded := c.RunE != nil && reflect.ValueOf(c.RunE).Pointer() == guardPtr
+		pureContainer := c.Run == nil && c.RunE == nil
+		if guarded || pureContainer {
+			groups = append(groups, c.CommandPath())
+		}
+		for _, sub := range c.Commands() {
+			walk(sub)
+		}
+	}
+	walk(newRootCmd())
+
+	if len(groups) == 0 {
+		t.Fatal("expected to find parent command groups, found none")
+	}
+
+	for _, path := range groups {
+		t.Run(path, func(t *testing.T) {
+			// Drop the leading "pad" program name, append a token that
+			// cannot match any real subcommand.
+			args := append(strings.Fields(path)[1:], "zzz-not-a-real-subcommand")
+
+			root := newRootCmd()
+			root.SetArgs(args)
+			root.SetOut(io.Discard)
+			root.SetErr(io.Discard)
+
+			if err := root.Execute(); err == nil {
+				t.Errorf("%q: unknown subcommand returned nil error (exits 0); missing unknownSubcommandRun guard?", path)
+			}
+		})
+	}
 }

--- a/cmd/pad/unknown_subcommand_test.go
+++ b/cmd/pad/unknown_subcommand_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestUnknownSubcommandReturnsError(t *testing.T) {
+	// Build a minimal tree that mirrors pad's command-group pattern.
+	parent := &cobra.Command{
+		Use:   "item",
+		Short: "item group",
+		RunE:  unknownSubcommandRun,
+	}
+	parent.AddCommand(
+		&cobra.Command{Use: "list", Short: "list items"},
+		&cobra.Command{Use: "show", Short: "show item"},
+	)
+	root := &cobra.Command{Use: "pad"}
+	root.AddCommand(parent)
+
+	t.Run("unknown subcommand returns error", func(t *testing.T) {
+		root.SetArgs([]string{"item", "bogus"})
+		err := root.Execute()
+		if err == nil {
+			t.Fatal("expected error for unknown subcommand, got nil")
+		}
+		if !strings.Contains(err.Error(), "bogus") {
+			t.Errorf("expected error to mention 'bogus', got %q", err.Error())
+		}
+	})
+
+	t.Run("bare parent shows help without error", func(t *testing.T) {
+		var buf bytes.Buffer
+		root.SetOut(&buf)
+		root.SetArgs([]string{"item"})
+		err := root.Execute()
+		if err != nil {
+			t.Fatalf("unexpected error for bare parent: %v", err)
+		}
+		got := buf.String()
+		if !strings.Contains(got, "Usage:") {
+			t.Errorf("expected help output for bare parent, got %q", got)
+		}
+	})
+
+	t.Run("valid subcommand runs without error", func(t *testing.T) {
+		root.SetArgs([]string{"item", "list"})
+		err := root.Execute()
+		if err != nil {
+			t.Fatalf("unexpected error for valid subcommand: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
Fixes PICK: PerpetualSoftware/pad | #850 | Go | CLI: unknown subcommands should exit non-zero.

Note: PR body was not generated by the contributor agent. See outbox/pr-PerpetualSoftware-pad-20260708-022626.md for the full plan.
