### PR TITLE
fix(server): add panic recovery to goAsync background tasks

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"net/netip"
 	"net/url"
+	"runtime/debug"
 	"strconv"
 	"strings"
 	"sync"
@@ -255,6 +256,20 @@ func (s *Server) goAsync(fn func()) {
 	s.bg.Add(1)
 	go func() {
 		defer s.bg.Done()
+		// Recover from panics in fn so a single bad background task
+		// (e.g. deriveThumbnails hitting a Go image-decoder panic on a
+		// crafted upload, or an email send) can't crash the whole
+		// single-binary server for every tenant. chi's Recoverer only
+		// covers request goroutines, not these detached ones. The
+		// deferred Done() above still fires because recover() keeps the
+		// goroutine from unwinding past this point.
+		defer func() {
+			if r := recover(); r != nil {
+				slog.Error("background task panicked",
+					"panic", r,
+					"stack", string(debug.Stack()))
+			}
+		}()
 		fn()
 	}()
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -501,3 +501,43 @@ func TestServer_Stop_DrainsBackgroundGoroutines(t *testing.T) {
 		t.Fatal("background goroutine did not run to completion before Stop returned")
 	}
 }
+
+// TestServer_goAsync_RecoversPanic pins BUG-2011: a panicking fn passed to
+// goAsync (e.g. deriveThumbnails hitting a Go image-decoder panic on a
+// crafted upload) must NOT crash the whole single-binary server, and the
+// tracked WaitGroup must still be released so Stop() can return. Without the
+// deferred recover() the goroutine unwinds all the way up and takes the
+// process down, killing every tenant.
+func TestServer_goAsync_RecoversPanic(t *testing.T) {
+	srv := testServer(t)
+
+	// Panic BEFORE any signal so the only way we learn the goroutine ran is
+	// via Stop() returning (WaitGroup released) — the process surviving this
+	// call at all is the primary assertion.
+	var ran atomic.Bool
+	srv.goAsync(func() {
+		ran.Store(true)
+		panic("boom: simulated background-task panic")
+	})
+
+	// If recover() didn't fire, Stop() would still return here because
+	// s.bg.Done() runs on unwind — but the process would already have
+	// crashed on the re-panic. Reaching this line proves survival.
+	stopReturned := make(chan struct{})
+	go func() {
+		srv.Stop()
+		close(stopReturned)
+	}()
+
+	select {
+	case <-stopReturned:
+		// Expected: the panicking goroutine was recovered, Done() fired,
+		// and Stop() drained the WaitGroup.
+	case <-time.After(2 * time.Second):
+		t.Fatal("Server.Stop() did not return within 2s after a panicking goAsync fn")
+	}
+
+	if !ran.Load() {
+		t.Fatal("panicking background goroutine never executed")
+	}
+}


### PR DESCRIPTION
Fixes BUG-2011.

## Problem
`internal/server/server.go` `goAsync` wrapped `fn` in a bare goroutine with **no** `recover()`. chi's Recoverer only covers request goroutines, not these detached ones. `goAsync` runs `deriveThumbnails` (image decode of user-uploaded bytes — a historical Go decoder panic source) and email sends. One crafted upload that panics would unwind past the goroutine and crash the whole single-binary server for **every tenant**.

## Fix
Add a single deferred `recover()` inside the `goAsync` goroutine that logs the panic + stack via `slog` (using `runtime/debug.Stack()`). This covers all 15+ call sites at once.

The recover defer is registered *after* `defer s.bg.Done()`, so on unwind it runs first and `Done()` still fires — `Stop()` continues to drain the `WaitGroup` even when `fn` panics.

## Test
`TestServer_goAsync_RecoversPanic` passes a panicking `fn` to `goAsync` and asserts the process survives and `Stop()` returns (WaitGroup drained).

## Gates
- `golangci-lint run` — 0 issues
- `go test ./...` — green

https://claude.ai/code/session_019knGmnHcx5rrgWXQ8V8DZS