### PR TITLE
fix(webhooks): track delivery goroutines + bounded retry (BUG-2012)

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -642,8 +642,15 @@ func (s *Server) SetCollabRoomManager(rm *collab.RoomManager) {
 	s.collab = rm
 }
 
-// SetWebhookDispatcher attaches a webhook dispatcher for outgoing notifications.
+// SetWebhookDispatcher attaches a webhook dispatcher for outgoing
+// notifications. Delivery goroutines are routed through s.goAsync so they're
+// tracked on s.bg — Server.Stop() waits for in-flight deliveries (closing the
+// BUG-842 shutdown race where a detached delivery writes to a closed store)
+// and inherits goAsync's panic recovery (BUG-2011).
 func (s *Server) SetWebhookDispatcher(d *webhooks.Dispatcher) {
+	if d != nil {
+		d.SetSpawn(s.goAsync)
+	}
 	s.webhooks = d
 }
 

--- a/internal/webhooks/dispatcher.go
+++ b/internal/webhooks/dispatcher.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -20,6 +21,15 @@ import (
 // Every hop is re-validated by checkRedirect, so this is a belt-and-braces
 // bound against redirect loops rather than the primary SSRF control.
 const maxWebhookRedirects = 5
+
+// errRedirectRejected marks a delivery error that originated in checkRedirect
+// (an SSRF-blocked redirect hop or an exceeded redirect chain). http.Client.Do
+// surfaces CheckRedirect errors wrapped in a *url.Error, so attemptDeliver uses
+// errors.Is to distinguish these PERMANENT rejections from genuinely transient
+// network errors — retrying a redirect to an internal target is pointless (and
+// undesirable). The wrapping *url.Error implements Unwrap, so errors.Is reaches
+// this sentinel.
+var errRedirectRejected = errors.New("webhook redirect rejected")
 
 // deliveryTimeout is the total per-delivery HTTP timeout.
 const deliveryTimeout = 10 * time.Second
@@ -135,13 +145,13 @@ func NewDispatcher(store WebhookStore) *Dispatcher {
 // could 302 the delivery to an internal address.
 func (d *Dispatcher) checkRedirect(req *http.Request, via []*http.Request) error {
 	if len(via) >= maxWebhookRedirects {
-		return fmt.Errorf("stopped after %d redirects", maxWebhookRedirects)
+		return fmt.Errorf("%w: stopped after %d redirects", errRedirectRejected, maxWebhookRedirects)
 	}
 	if d.SkipSSRF {
 		return nil
 	}
 	if err := ValidateWebhookURL(req.URL.String()); err != nil {
-		return fmt.Errorf("redirect to %s blocked: %w", req.URL.Redacted(), err)
+		return fmt.Errorf("%w: redirect to %s blocked: %v", errRedirectRejected, req.URL.Redacted(), err)
 	}
 	return nil
 }
@@ -248,6 +258,12 @@ func (d *Dispatcher) attemptDeliver(hook models.Webhook, body []byte) deliveryRe
 
 	resp, err := d.client.Do(req)
 	if err != nil {
+		// A blocked/looping redirect is permanent — the SSRF guard won't
+		// relent on retry, so don't waste attempts on it.
+		if errors.Is(err, errRedirectRejected) {
+			slog.Warn("blocked webhook redirect", "url", hook.URL, "error", err)
+			return deliveryPermanent
+		}
 		// Network error / timeout — transient, worth retrying.
 		slog.Error("webhook delivery failed", "url", hook.URL, "error", err)
 		return deliveryTransient
@@ -257,14 +273,15 @@ func (d *Dispatcher) attemptDeliver(hook models.Webhook, body []byte) deliveryRe
 	switch {
 	case resp.StatusCode >= 200 && resp.StatusCode < 300:
 		return deliverySuccess
-	case resp.StatusCode >= 400 && resp.StatusCode < 500:
-		// Client error — permanent; the request itself is unacceptable.
-		slog.Warn("webhook 4xx response", "status", resp.StatusCode, "url", hook.URL)
-		return deliveryPermanent
-	default:
-		// 5xx (and any other non-2xx) — transient, worth retrying.
-		slog.Warn("webhook non-2xx response", "status", resp.StatusCode, "url", hook.URL)
+	case resp.StatusCode >= 500 && resp.StatusCode < 600:
+		// Server error — transient, worth retrying.
+		slog.Warn("webhook 5xx response", "status", resp.StatusCode, "url", hook.URL)
 		return deliveryTransient
+	default:
+		// 4xx and any other non-2xx (3xx with no followable Location, 1xx)
+		// — permanent; retrying won't change an unacceptable request.
+		slog.Warn("webhook non-2xx response", "status", resp.StatusCode, "url", hook.URL)
+		return deliveryPermanent
 	}
 }
 

--- a/internal/webhooks/dispatcher.go
+++ b/internal/webhooks/dispatcher.go
@@ -24,6 +24,27 @@ const maxWebhookRedirects = 5
 // deliveryTimeout is the total per-delivery HTTP timeout.
 const deliveryTimeout = 10 * time.Second
 
+// maxDeliveryAttempts caps how many times a single delivery is attempted
+// before giving up. Only transient failures (network errors, timeouts, 5xx)
+// consume retries; permanent failures (4xx, SSRF block) stop immediately.
+const maxDeliveryAttempts = 3
+
+// defaultRetryBackoff is the base backoff between transient-failure retries;
+// the Nth wait is defaultRetryBackoff * N (linear). Overridable via the
+// Dispatcher.retryBackoff field (set to 0 in tests to avoid sleeping).
+const defaultRetryBackoff = 500 * time.Millisecond
+
+// deliveryResult classifies the outcome of a single delivery attempt so the
+// retry loop knows whether to retry (transient), give up (permanent), or
+// stop happily (success).
+type deliveryResult int
+
+const (
+	deliverySuccess deliveryResult = iota
+	deliveryTransient
+	deliveryPermanent
+)
+
 // WebhookStore is the interface the dispatcher needs to fetch webhooks
 // and record delivery outcomes.
 type WebhookStore interface {
@@ -41,9 +62,35 @@ type WebhookPayload struct {
 
 // Dispatcher sends webhook HTTP POST notifications for workspace events.
 type Dispatcher struct {
-	store    WebhookStore
-	client   *http.Client
-	SkipSSRF bool // Skip SSRF validation (for tests only)
+	store  WebhookStore
+	client *http.Client
+	// spawn runs a delivery goroutine. When nil, deliveries run on a plain
+	// `go f()`. The server injects Server.goAsync here (via SetSpawn) so
+	// in-flight deliveries are tracked on s.bg and awaited by Server.Stop()
+	// — closing the BUG-842 shutdown race where a detached delivery writes
+	// to an already-closed store — and inherit goAsync's panic recovery.
+	spawn func(func())
+	// retryBackoff is the base wait between transient-failure retries.
+	// Defaults to defaultRetryBackoff; tests set it to 0.
+	retryBackoff time.Duration
+	SkipSSRF     bool // Skip SSRF validation (for tests only)
+}
+
+// SetSpawn injects the goroutine spawner used for deliveries. Passing the
+// server's tracked-goroutine helper (Server.goAsync) makes Server.Stop()
+// wait for in-flight deliveries. A nil spawn (the default) falls back to a
+// plain goroutine, keeping standalone Dispatcher usage working.
+func (d *Dispatcher) SetSpawn(spawn func(func())) {
+	d.spawn = spawn
+}
+
+// run executes fn on the injected spawner, or a plain goroutine if none is set.
+func (d *Dispatcher) run(fn func()) {
+	if d.spawn != nil {
+		d.spawn(fn)
+		return
+	}
+	go fn()
 }
 
 // NewDispatcher creates a Dispatcher with the given store.
@@ -56,7 +103,7 @@ type Dispatcher struct {
 // to an internal target. Proxy is intentionally nil — honoring HTTP(S)_PROXY
 // would connect to the proxy host and skip our dialer's IP check entirely.
 func NewDispatcher(store WebhookStore) *Dispatcher {
-	d := &Dispatcher{store: store}
+	d := &Dispatcher{store: store, retryBackoff: defaultRetryBackoff}
 
 	dialer := &net.Dialer{
 		Timeout:   deliveryTimeout,
@@ -147,26 +194,48 @@ func (d *Dispatcher) Dispatch(workspaceID, event string, data interface{}) {
 		if !matchesEvent(hook.Events, event) {
 			continue
 		}
-		go d.deliver(hook, body)
+		d.run(func() { d.deliver(hook, body) })
 	}
 }
 
-// deliver sends a single HTTP POST to the webhook URL.
+// deliver sends a webhook, retrying transient failures up to
+// maxDeliveryAttempts with linear backoff, and records the final outcome
+// once via the store. Permanent failures (4xx, SSRF block, malformed URL)
+// stop immediately without consuming retries.
 func (d *Dispatcher) deliver(hook models.Webhook, body []byte) {
-	// Defense in depth: re-validate URL before making the request
+	result := deliveryPermanent
+	for attempt := 1; attempt <= maxDeliveryAttempts; attempt++ {
+		result = d.attemptDeliver(hook, body)
+		if result != deliveryTransient {
+			break // success or permanent failure — no point retrying
+		}
+		if attempt < maxDeliveryAttempts {
+			if backoff := d.retryBackoff * time.Duration(attempt); backoff > 0 {
+				time.Sleep(backoff)
+			}
+		}
+	}
+	d.store.UpdateWebhookFailure(hook.ID, result != deliverySuccess)
+}
+
+// attemptDeliver performs a single HTTP POST to the webhook URL and
+// classifies the outcome. It does NOT record the result — deliver owns the
+// single terminal store write so the retry loop doesn't churn the store.
+func (d *Dispatcher) attemptDeliver(hook models.Webhook, body []byte) deliveryResult {
+	// Defense in depth: re-validate URL before making the request. An
+	// SSRF block is permanent — retrying won't make the target public.
 	if !d.SkipSSRF {
 		if err := ValidateWebhookURL(hook.URL); err != nil {
 			slog.Warn("blocked webhook delivery", "url", hook.URL, "error", err)
-			d.store.UpdateWebhookFailure(hook.ID, true)
-			return
+			return deliveryPermanent
 		}
 	}
 
 	req, err := http.NewRequest(http.MethodPost, hook.URL, bytes.NewReader(body))
 	if err != nil {
+		// A malformed URL/method won't fix itself on retry.
 		slog.Error("failed to create webhook request", "url", hook.URL, "error", err)
-		d.store.UpdateWebhookFailure(hook.ID, true)
-		return
+		return deliveryPermanent
 	}
 
 	req.Header.Set("Content-Type", "application/json")
@@ -179,17 +248,23 @@ func (d *Dispatcher) deliver(hook models.Webhook, body []byte) {
 
 	resp, err := d.client.Do(req)
 	if err != nil {
+		// Network error / timeout — transient, worth retrying.
 		slog.Error("webhook delivery failed", "url", hook.URL, "error", err)
-		d.store.UpdateWebhookFailure(hook.ID, true)
-		return
+		return deliveryTransient
 	}
 	resp.Body.Close()
 
-	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
-		d.store.UpdateWebhookFailure(hook.ID, false)
-	} else {
+	switch {
+	case resp.StatusCode >= 200 && resp.StatusCode < 300:
+		return deliverySuccess
+	case resp.StatusCode >= 400 && resp.StatusCode < 500:
+		// Client error — permanent; the request itself is unacceptable.
+		slog.Warn("webhook 4xx response", "status", resp.StatusCode, "url", hook.URL)
+		return deliveryPermanent
+	default:
+		// 5xx (and any other non-2xx) — transient, worth retrying.
 		slog.Warn("webhook non-2xx response", "status", resp.StatusCode, "url", hook.URL)
-		d.store.UpdateWebhookFailure(hook.ID, true)
+		return deliveryTransient
 	}
 }
 

--- a/internal/webhooks/dispatcher_test.go
+++ b/internal/webhooks/dispatcher_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/PerpetualSoftware/pad/internal/models"
@@ -332,5 +333,136 @@ func TestMatchesEvent(t *testing.T) {
 		if got != tt.want {
 			t.Errorf("matchesEvent(%q, %q) = %v, want %v", tt.eventsJSON, tt.event, got, tt.want)
 		}
+	}
+}
+
+// TestDispatcher_UsesInjectedSpawn verifies deliveries run on the injected
+// spawn func (the server wires Server.goAsync here so Stop() can drain them).
+func TestDispatcher_UsesInjectedSpawn(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	store := newMockStore([]models.Webhook{
+		{ID: "hook-1", WorkspaceID: "ws-1", URL: ts.URL, Events: `["*"]`, Active: true},
+	})
+
+	d := NewDispatcher(store)
+	d.SkipSSRF = true
+
+	var spawnCount int32
+	// Synchronous spawn: run inline so the test is deterministic without
+	// channels, while still proving the injected spawner is used.
+	d.SetSpawn(func(fn func()) {
+		atomic.AddInt32(&spawnCount, 1)
+		fn()
+	})
+
+	d.Dispatch("ws-1", "item.created", map[string]string{"title": "Test"})
+
+	if got := atomic.LoadInt32(&spawnCount); got != 1 {
+		t.Errorf("expected delivery to run on injected spawn once, got %d calls", got)
+	}
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if store.failures["hook-1"] {
+		t.Error("expected success recorded, got failure")
+	}
+}
+
+// TestDispatcher_RetriesTransientFailure asserts a 5xx (transient) response
+// is retried up to maxDeliveryAttempts and the final failure is recorded.
+func TestDispatcher_RetriesTransientFailure(t *testing.T) {
+	var attempts int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&attempts, 1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	store := newMockStore([]models.Webhook{
+		{ID: "hook-1", WorkspaceID: "ws-1", URL: ts.URL, Events: `["*"]`, Active: true},
+	})
+
+	d := NewDispatcher(store)
+	d.SkipSSRF = true
+	d.retryBackoff = 0 // no sleeping in tests
+	d.SetSpawn(func(fn func()) { fn() })
+
+	d.Dispatch("ws-1", "item.created", map[string]string{"title": "Test"})
+
+	if got := atomic.LoadInt32(&attempts); got != maxDeliveryAttempts {
+		t.Errorf("expected %d attempts for transient 5xx, got %d", maxDeliveryAttempts, got)
+	}
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if !store.failures["hook-1"] {
+		t.Error("expected failure recorded after exhausting retries")
+	}
+}
+
+// TestDispatcher_DoesNotRetryPermanentFailure asserts a 4xx (permanent)
+// response is attempted exactly once — no retries — and recorded as a failure.
+func TestDispatcher_DoesNotRetryPermanentFailure(t *testing.T) {
+	var attempts int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&attempts, 1)
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer ts.Close()
+
+	store := newMockStore([]models.Webhook{
+		{ID: "hook-1", WorkspaceID: "ws-1", URL: ts.URL, Events: `["*"]`, Active: true},
+	})
+
+	d := NewDispatcher(store)
+	d.SkipSSRF = true
+	d.retryBackoff = 0
+	d.SetSpawn(func(fn func()) { fn() })
+
+	d.Dispatch("ws-1", "item.created", map[string]string{"title": "Test"})
+
+	if got := atomic.LoadInt32(&attempts); got != 1 {
+		t.Errorf("expected exactly 1 attempt for permanent 4xx, got %d", got)
+	}
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if !store.failures["hook-1"] {
+		t.Error("expected failure recorded for permanent 4xx")
+	}
+}
+
+// TestDispatcher_RetriesThenSucceeds asserts a transient failure that later
+// recovers is recorded as success (failed=false).
+func TestDispatcher_RetriesThenSucceeds(t *testing.T) {
+	var attempts int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&attempts, 1) < 2 {
+			w.WriteHeader(http.StatusServiceUnavailable) // transient
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	store := newMockStore([]models.Webhook{
+		{ID: "hook-1", WorkspaceID: "ws-1", URL: ts.URL, Events: `["*"]`, Active: true},
+	})
+
+	d := NewDispatcher(store)
+	d.SkipSSRF = true
+	d.retryBackoff = 0
+	d.SetSpawn(func(fn func()) { fn() })
+
+	d.Dispatch("ws-1", "item.created", map[string]string{"title": "Test"})
+
+	if got := atomic.LoadInt32(&attempts); got != 2 {
+		t.Errorf("expected 2 attempts (fail then succeed), got %d", got)
+	}
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if store.failures["hook-1"] {
+		t.Error("expected success recorded after retry recovered")
 	}
 }

--- a/internal/webhooks/dispatcher_test.go
+++ b/internal/webhooks/dispatcher_test.go
@@ -2,6 +2,7 @@ package webhooks
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -464,5 +465,47 @@ func TestDispatcher_RetriesThenSucceeds(t *testing.T) {
 	defer store.mu.Unlock()
 	if store.failures["hook-1"] {
 		t.Error("expected success recorded after retry recovered")
+	}
+}
+
+// errRoundTripper returns a fixed error from every RoundTrip and counts calls,
+// letting a test drive attemptDeliver's error classification deterministically.
+type errRoundTripper struct {
+	err   error
+	calls int32
+}
+
+func (e *errRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	atomic.AddInt32(&e.calls, 1)
+	return nil, e.err
+}
+
+// TestDispatcher_RedirectBlockIsPermanent asserts a redirect rejected by the
+// SSRF guard (surfaced via CheckRedirect through client.Do) is classified as
+// permanent and attempted exactly once — no retries against an internal target.
+func TestDispatcher_RedirectBlockIsPermanent(t *testing.T) {
+	store := newMockStore([]models.Webhook{
+		{ID: "hook-1", WorkspaceID: "ws-1", URL: "https://example.com/hook", Events: `["*"]`, Active: true},
+	})
+
+	d := NewDispatcher(store)
+	d.SkipSSRF = true // skip the pre-flight URL check so we exercise the client.Do path
+	d.retryBackoff = 0
+	d.SetSpawn(func(fn func()) { fn() })
+
+	// Mimic what http.Client.Do surfaces when CheckRedirect blocks a hop:
+	// the checkRedirect error wrapped so errors.Is reaches errRedirectRejected.
+	rt := &errRoundTripper{err: fmt.Errorf("%w: redirect to 169.254.169.254 blocked", errRedirectRejected)}
+	d.client.Transport = rt
+
+	d.Dispatch("ws-1", "item.created", map[string]string{"title": "Test"})
+
+	if got := atomic.LoadInt32(&rt.calls); got != 1 {
+		t.Errorf("expected exactly 1 attempt for blocked redirect (permanent), got %d", got)
+	}
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if !store.failures["hook-1"] {
+		t.Error("expected failure recorded for blocked redirect")
 	}
 }


### PR DESCRIPTION
## What

Webhook deliveries ran in untracked `go d.deliver(...)` goroutines that write to the store — the exact BUG-842 shutdown-race class that `goAsync` was built to prevent (`internal/webhooks/dispatcher.go`). Delivery also had no retry.

## Changes

**1. Tracked delivery goroutines**
- Added a `spawn func(func())` field to `Dispatcher` with `SetSpawn`. `Server.SetWebhookDispatcher` wires `s.goAsync` in, so deliveries are tracked on `s.bg` — `Server.Stop()` now waits for in-flight deliveries (no write-to-closed-store race) and they inherit `goAsync`'s panic recovery (BUG-2011).
- Backward-compatible: a `Dispatcher` with no spawn set falls back to a plain `go f()`, so standalone/test usage is unchanged.

**2. Bounded retry**
- Up to 3 attempts with linear backoff on transient failures (network error / timeout / 5xx).
- Permanent failures (4xx, SSRF block, malformed URL) stop immediately — no wasted retries.
- Final outcome recorded once via `UpdateWebhookFailure` (the retry loop no longer churns the store per attempt).

## Tests

`internal/webhooks/dispatcher_test.go`:
- delivery runs on the injected spawn func
- transient 5xx retries to the cap and records failure
- permanent 4xx is attempted exactly once
- a transient failure that later recovers records success

## Gates
- `~/go/bin/golangci-lint run --timeout=5m ./...` — 0 issues
- `go test ./...` — green
- Codex review — CLEAN

No store schema/query changes, so `make test-pg` not required.

https://claude.ai/code/session_019knGmnHcx5rrgWXQ8V8DZS