### PR TITLE
fix(server): add panic recovery to background sweeper goroutines (BUG-2071)

### DIFF
--- a/internal/server/oplog_gc.go
+++ b/internal/server/oplog_gc.go
@@ -88,6 +88,7 @@ func (s *Server) StartOpLogGC() {
 	s.bg.Add(1)
 	go func() {
 		defer s.bg.Done()
+		defer s.recoverSweeper("oplog-gc") // BUG-2071
 		t := time.NewTicker(interval)
 		defer t.Stop()
 		for {

--- a/internal/server/orphan_gc.go
+++ b/internal/server/orphan_gc.go
@@ -229,6 +229,7 @@ func (s *Server) StartOrphanGC() {
 	s.bg.Add(1)
 	go func() {
 		defer s.bg.Done()
+		defer s.recoverSweeper("orphan-gc") // BUG-2071
 		t := time.NewTicker(interval)
 		defer t.Stop()
 		for {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -274,6 +274,28 @@ func (s *Server) goAsync(fn func()) {
 	}()
 }
 
+// recoverSweeper is the panic firewall for the long-running background
+// sweeper loops (orphan GC, op-log GC, token reaper, workspace purge).
+// Each of those manages its own s.bg.Add/Done + stop-channel lifecycle,
+// so — unlike fire-and-forget work — they can't just route through
+// goAsync without breaking their shutdown handling or double-counting
+// s.bg. Instead each spawns `defer s.recoverSweeper("<name>")` as a
+// deferred call INSIDE its goroutine (BUG-2071): a panic in the loop
+// body is logged with a stack (matching goAsync's style) and unwinds
+// cleanly, the goroutine's own deferred s.bg.Done() still fires because
+// recover() stops the unwind here, and Stop() still returns. Without it a
+// panic in any sweeper takes down the whole single-binary server for
+// every tenant. Must be `defer`-called directly in the goroutine for
+// recover() to catch the panic.
+func (s *Server) recoverSweeper(name string) {
+	if r := recover(); r != nil {
+		slog.Error("background sweeper panicked",
+			"sweeper", name,
+			"panic", r,
+			"stack", string(debug.Stack()))
+	}
+}
+
 // Stop waits for all background goroutines started via goAsync to finish
 // AND drains the rate-limiter cleanup goroutines spawned at construction
 // time (BUG-851). Safe to call multiple times. Should be called before

--- a/internal/server/token_reaper.go
+++ b/internal/server/token_reaper.go
@@ -65,6 +65,7 @@ func (s *Server) StartTokenReaper() {
 	s.bg.Add(1)
 	go func() {
 		defer s.bg.Done()
+		defer s.recoverSweeper("token-reaper") // BUG-2071
 		t := time.NewTicker(interval)
 		defer t.Stop()
 		for {

--- a/internal/server/token_reaper_test.go
+++ b/internal/server/token_reaper_test.go
@@ -1,11 +1,34 @@
 package server
 
 import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/PerpetualSoftware/pad/internal/models"
 )
+
+// syncBuffer is a minimal concurrency-safe io.Writer so a test can read a
+// slog buffer written from a background sweeper goroutine without racing.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
 
 func countEmailVerificationTokens(t *testing.T, srv *Server) int {
 	t.Helper()
@@ -95,6 +118,64 @@ func TestTokenReaper_StartIsIdempotent(t *testing.T) {
 
 	// Stop is safe to call again (loop already stopped).
 	srv.stopTokenReaper()
+}
+
+// TestTokenReaper_RecoversPanic pins BUG-2071: the long-running sweeper loops
+// spawn their own s.bg-tracked goroutine (they can't route through goAsync
+// without breaking their stop-channel lifecycle), so each needs its own
+// deferred recover(). A panic inside a sweeper tick must NOT crash the whole
+// single-binary server — it must be logged with a stack, the goroutine must
+// unwind cleanly with s.bg.Done() still firing, and Stop() must still drain.
+//
+// A Server built with a nil store makes the reaper tick panic for real: the
+// first cleaner (CleanExpiredEmailVerifications) dereferences the nil
+// *store.Store. That exercises the actual token-reaper goroutine + tick + the
+// deferred recoverSweeper end-to-end, mirroring TestServer_goAsync_RecoversPanic
+// for the loop-shaped sweepers.
+func TestTokenReaper_RecoversPanic(t *testing.T) {
+	var logBuf syncBuffer
+	prevLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logBuf, nil)))
+	defer slog.SetDefault(prevLogger)
+
+	// New(nil) wires rateLimiters (so Stop() is safe) but leaves store nil,
+	// so the very first reaper tick panics on the nil-pointer deref.
+	srv := New(nil)
+
+	// Tight interval so the panicking tick lands inside the test window; the
+	// production default is 1h.
+	srv.SetTokenReaperConfig(5 * time.Millisecond)
+	srv.StartTokenReaper()
+
+	// Deterministic proof the recover path executed: wait for the panic log.
+	// If recover() were missing, the re-panic would have already killed the
+	// process (and this test binary) before we could observe anything.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		logged := logBuf.String()
+		if strings.Contains(logged, "background sweeper panicked") &&
+			strings.Contains(logged, "token-reaper") {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if logged := logBuf.String(); !strings.Contains(logged, "background sweeper panicked") ||
+		!strings.Contains(logged, "token-reaper") {
+		t.Fatalf("expected a recovered-panic log from the token-reaper sweeper, got: %s", logged)
+	}
+
+	// The goroutine's deferred s.bg.Done() must still fire after the recover,
+	// so Stop() drains rather than hanging.
+	stopReturned := make(chan struct{})
+	go func() {
+		srv.Stop()
+		close(stopReturned)
+	}()
+	select {
+	case <-stopReturned:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Server.Stop() did not return within 2s after a panicking reaper tick")
+	}
 }
 
 // TestTokenReaper_NotStartedIsCleanShutdown: a server that never started the

--- a/internal/server/workspace_purge.go
+++ b/internal/server/workspace_purge.go
@@ -129,6 +129,7 @@ func (s *Server) StartWorkspacePurgeSweeper() {
 	s.bg.Add(1)
 	go func() {
 		defer s.bg.Done()
+		defer s.recoverSweeper("workspace-purge") // BUG-2071
 		// One sweep on startup so a long-stopped server catches up
 		// immediately rather than waiting a full interval.
 		s.runWorkspacePurgeTick(retention)


### PR DESCRIPTION
## Summary

The four long-running background sweeper loops spawn their own `s.bg`-tracked goroutine directly (`s.bg.Add(1); go func(){...}()`) rather than through `goAsync`, so — unlike fire-and-forget tasks after BUG-2011 (#863) — they had **no `recover()`**. A panic in any sweeper body would crash the whole single-binary server for every tenant:

- `internal/server/orphan_gc.go`
- `internal/server/oplog_gc.go`
- `internal/server/token_reaper.go`
- `internal/server/workspace_purge.go`

These loops manage their own `s.bg.Add/Done` + stop-channel lifecycle, so they can't just route through `goAsync` (a fire-and-forget helper that owns the whole goroutine) without breaking shutdown or double-counting `s.bg`.

## Fix

Add a shared `Server.recoverSweeper(name)` firewall — mirroring `goAsync`'s `recover()` + `debug.Stack()` slog style — and `defer` it inside each sweeper goroutine. A panic is now logged with a stack and the goroutine unwinds cleanly; its own deferred `s.bg.Done()` still fires (recover stops the unwind), so `Stop()` still drains.

**No change** to any sweeper's loop cadence or stop-signal shutdown — only a deferred recover is added inside each goroutine.

## Test

Adds `TestTokenReaper_RecoversPanic`, which drives a real reaper tick to panic (nil store → nil-pointer deref in the first cleaner) and asserts the panic is logged + recovered and `Stop()` returns. Mirrors `TestServer_goAsync_RecoversPanic` for the loop-shaped sweepers.

## Gates

- `~/go/bin/golangci-lint run --timeout=5m ./...` — 0 issues
- `go test ./...` — green
- Codex review — CLEAN

https://claude.ai/code/session_019knGmnHcx5rrgWXQ8V8DZS