### PR TITLE
fix(server): surface dashboard sub-query failures instead of silent empty sections (BUG-2014)

### DIFF
--- a/internal/server/handlers_dashboard.go
+++ b/internal/server/handlers_dashboard.go
@@ -647,22 +647,21 @@ func (s *Server) buildDashboardResponse(workspaceID string, r *http.Request) (*D
 		}
 	}
 	if hasParentWithChildren {
-		// Batch-fetch all child→parent mappings for efficiency
+		// Batch-fetch all child→parent mappings for efficiency.
+		// A GetParentMap failure must SKIP orphan detection entirely:
+		// falling back to an empty map would flag every visible non-done
+		// task as orphaned (false positives). Degrade the section and
+		// bail instead.
 		parentMap, err := s.store.GetParentMap(workspaceID)
 		if err != nil {
-			// Empty parentMap would make every task look orphaned;
-			// degrade the section instead of emitting false positives.
 			markDegraded("attention.orphaned_tasks", err)
-			parentMap = map[string]string{}
-		}
-		allTasks, err := s.store.ListItems(workspaceID, models.ItemListParams{
+		} else if allTasks, tErr := s.store.ListItems(workspaceID, models.ItemListParams{
 			CollectionSlug: "tasks",
 			CollectionIDs:  dashCollIDs,
 			ItemIDs:        dashItemIDs,
 			NoContent:      true,
-		})
-		if err != nil {
-			markDegraded("attention.orphaned_tasks", err)
+		}); tErr != nil {
+			markDegraded("attention.orphaned_tasks", tErr)
 		} else {
 			for _, task := range allTasks {
 				if isItemDone(task.Fields, task.CollectionID, ctxMap) {

--- a/internal/server/handlers_dashboard.go
+++ b/internal/server/handlers_dashboard.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"sort"
 	"strconv"
@@ -49,6 +50,19 @@ type DashboardResponse struct {
 	// Nil for workspaces that didn't seed an onboarding primary
 	// (empty template, hiring/interviewing example items, etc.).
 	OnboardingSeed *DashboardOnboardingSeed `json:"onboarding_seed,omitempty"`
+	// Degraded is true when one or more best-effort sub-queries failed
+	// while assembling the dashboard (BUG-2014). The remaining sections
+	// are still returned, but the client should surface a "some data
+	// couldn't load" state rather than presenting the partial result as
+	// authoritative — a failed sub-query previously rendered
+	// indistinguishably from a genuinely-empty section. DegradedSections
+	// names which sections were affected. Every failure is also logged
+	// server-side (slog.Error) with the workspace + section for triage.
+	Degraded bool `json:"degraded"`
+	// DegradedSections lists the section names whose sub-query failed
+	// (e.g. "active_plans", "recent_activity", "by_role"). Empty/omitted
+	// when Degraded is false.
+	DegradedSections []string `json:"degraded_sections,omitempty"`
 }
 
 // DashboardOnboardingSeed is the dashboard-side projection of a
@@ -320,6 +334,28 @@ func (s *Server) buildDashboardResponse(workspaceID string, r *http.Request) (*D
 		SuggestedNext:  []DashboardSuggestion{},
 	}
 
+	// markDegraded records a best-effort sub-query failure (BUG-2014):
+	// it logs the failure with enough context to diagnose (workspace +
+	// section) and flags the response so the client can distinguish a
+	// section that failed to load from one that is genuinely empty. Used
+	// only for the non-fatal sections below — the queries whose failure
+	// invalidates the whole dashboard still `return nil, err` above.
+	markDegraded := func(section string, err error) {
+		resp.Degraded = true
+		// Some sections query in a loop (e.g. stalled attention over
+		// several status spellings); record each section name once.
+		for _, s := range resp.DegradedSections {
+			if s == section {
+				slog.Error("dashboard sub-query failed; section returned degraded",
+					"workspace_id", workspaceID, "section", section, "error", err)
+				return
+			}
+		}
+		resp.DegradedSections = append(resp.DegradedSections, section)
+		slog.Error("dashboard sub-query failed; section returned degraded",
+			"workspace_id", workspaceID, "section", section, "error", err)
+	}
+
 	// Cheap EXISTS query — drives the connect-agent banner's auto-hide on
 	// the web side. Filtered by the same visibility set used elsewhere in
 	// this handler (dashCollIDs / dashItemIDs) so a guest can't infer the
@@ -343,6 +379,13 @@ func (s *Server) buildDashboardResponse(workspaceID string, r *http.Request) (*D
 	if !hasAgent {
 		if ws, wErr := s.store.GetWorkspaceByID(workspaceID); wErr == nil && ws != nil {
 			hasAgent = ws.Source == "cli" || ws.Source == "mcp"
+		} else if wErr != nil {
+			// Non-fatal: hasAgent already has a valid value from the
+			// EXISTS check above; this is only a source-signal fallback.
+			// Log it but don't degrade the response — the banner just
+			// stays visible one render longer, no section renders empty.
+			slog.Warn("dashboard: workspace source lookup failed (agent banner fallback)",
+				"workspace_id", workspaceID, "error", wErr)
 		}
 	}
 	resp.HasAgentActivity = hasAgent
@@ -475,6 +518,11 @@ func (s *Server) buildDashboardResponse(workspaceID string, r *http.Request) (*D
 			return nil, cbErr
 		}
 		childrenByParent = kids
+	} else {
+		// The active-plans query failed. It also feeds plan_completion
+		// attention and suggested_next, so mark the whole response
+		// degraded rather than let those render as silently empty.
+		markDegraded("active_plans", err)
 	}
 	if err == nil {
 		for _, plan := range plans {
@@ -531,6 +579,7 @@ func (s *Server) buildDashboardResponse(workspaceID string, r *http.Request) (*D
 			NoContent:     true,
 		})
 		if err != nil {
+			markDegraded("attention.stalled", err)
 			continue
 		}
 		for _, item := range items {
@@ -601,6 +650,9 @@ func (s *Server) buildDashboardResponse(workspaceID string, r *http.Request) (*D
 		// Batch-fetch all child→parent mappings for efficiency
 		parentMap, err := s.store.GetParentMap(workspaceID)
 		if err != nil {
+			// Empty parentMap would make every task look orphaned;
+			// degrade the section instead of emitting false positives.
+			markDegraded("attention.orphaned_tasks", err)
 			parentMap = map[string]string{}
 		}
 		allTasks, err := s.store.ListItems(workspaceID, models.ItemListParams{
@@ -609,7 +661,9 @@ func (s *Server) buildDashboardResponse(workspaceID string, r *http.Request) (*D
 			ItemIDs:        dashItemIDs,
 			NoContent:      true,
 		})
-		if err == nil {
+		if err != nil {
+			markDegraded("attention.orphaned_tasks", err)
+		} else {
 			for _, task := range allTasks {
 				if isItemDone(task.Fields, task.CollectionID, ctxMap) {
 					continue
@@ -688,7 +742,9 @@ func (s *Server) buildDashboardResponse(workspaceID string, r *http.Request) (*D
 	activities, err := s.store.ListWorkspaceActivity(workspaceID, models.ActivityListParams{
 		Limit: 30,
 	})
-	if err == nil && activities != nil {
+	if err != nil {
+		markDegraded("recent_activity", err)
+	} else if activities != nil {
 		// Build visible slug set for filtering. Resolve slugs from the
 		// already-loaded collection list (ListCollections above) rather than
 		// a GetCollection per visible ID — no extra queries (BUG-2002).
@@ -945,7 +1001,9 @@ func (s *Server) buildDashboardResponse(workspaceID string, r *http.Request) (*D
 	// When visibility is restricted, recompute from visible items only.
 	if visibleIDs != nil {
 		roleBreakdown, err := s.store.GetRoleBreakdown(workspaceID)
-		if err == nil {
+		if err != nil {
+			markDegraded("by_role", err)
+		} else {
 			// Recount from visible items
 			roleCounts := make(map[string]int)
 			roleUsers := make(map[string]map[string]bool)
@@ -983,7 +1041,9 @@ func (s *Server) buildDashboardResponse(workspaceID string, r *http.Request) (*D
 		}
 	} else {
 		roleBreakdown, err := s.store.GetRoleBreakdown(workspaceID)
-		if err == nil && len(roleBreakdown) > 0 {
+		if err != nil {
+			markDegraded("by_role", err)
+		} else if len(roleBreakdown) > 0 {
 			resp.ByRole = roleBreakdown
 		}
 	}
@@ -991,7 +1051,9 @@ func (s *Server) buildDashboardResponse(workspaceID string, r *http.Request) (*D
 	// Starred items: non-terminal items starred by the current user
 	if userID := currentUserID(r); userID != "" {
 		starred, err := s.store.ListStarredItems(userID, workspaceID, false)
-		if err == nil && len(starred) > 0 {
+		if err != nil {
+			markDegraded("starred_items", err)
+		} else if len(starred) > 0 {
 			starredItems := []DashboardActiveItem{}
 			for _, item := range starred {
 				// Apply same visibility filter as the rest of the dashboard

--- a/internal/server/handlers_dashboard_test.go
+++ b/internal/server/handlers_dashboard_test.go
@@ -1341,3 +1341,65 @@ func TestDashboard_AdminBearer_RestrictedMemberIsScoped(t *testing.T) {
 		t.Errorf("cookie admin dashboard should be unrestricted (see hidden collection); got %+v", cookieResp.Summary.ByCollection)
 	}
 }
+
+// TestDashboardDegradedOnSubQueryFailure covers BUG-2014: a failing
+// best-effort sub-query must not render indistinguishably from a
+// genuinely-empty section. Before this fix, buildDashboardResponse
+// swallowed the error (if err == nil / continue) and returned an empty
+// by_role with no signal. Now the failure flips resp.Degraded and names
+// the affected section in resp.DegradedSections, while every other
+// section still loads (partial failure, not all-or-nothing) and the
+// endpoint still returns 200.
+func TestDashboardDegradedOnSubQueryFailure(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	// Seed real data so the healthy sections are demonstrably non-empty.
+	createItem(t, srv, slug, "tasks", map[string]interface{}{
+		"title":  "Live Task",
+		"fields": `{"status":"open","priority":"high"}`,
+	})
+
+	// Sanity: a healthy dashboard is NOT degraded.
+	healthy := getDashboard(t, srv, slug)
+	if healthy.Degraded {
+		t.Fatalf("healthy dashboard should not be degraded; got sections %v", healthy.DegradedSections)
+	}
+	if healthy.Summary.TotalItems == 0 {
+		t.Fatalf("expected the seeded task in summary; got 0 items")
+	}
+
+	// Force the recent_activity sub-query (ListWorkspaceActivity) to fail
+	// by removing the table it reads. The activities table is read only by
+	// that best-effort section — every fatal dashboard query reads other
+	// tables — so this isolates a single section's failure without 500ing
+	// the whole request.
+	if _, err := srv.store.DB().Exec("DROP TABLE activities"); err != nil {
+		t.Fatalf("drop activities: %v", err)
+	}
+
+	rr := doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/dashboard", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("degraded dashboard should still return 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var resp DashboardResponse
+	parseJSON(t, rr, &resp)
+
+	if !resp.Degraded {
+		t.Fatalf("expected Degraded=true after recent_activity sub-query failure; response was not flagged")
+	}
+	found := false
+	for _, s := range resp.DegradedSections {
+		if s == "recent_activity" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected 'recent_activity' in DegradedSections, got %v", resp.DegradedSections)
+	}
+	// Partial-failure, not all-or-nothing: the unaffected sections still load.
+	if resp.Summary.TotalItems == 0 {
+		t.Errorf("degraded dashboard dropped healthy sections too; summary is empty")
+	}
+}

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -1017,6 +1017,17 @@ export interface DashboardResponse {
 		// (untouched) status — banner shows only when this is true.
 		active: boolean;
 	};
+	// degraded is true when one or more best-effort dashboard sub-queries
+	// failed server-side (BUG-2014). The remaining sections are still
+	// returned, but a failed section is indistinguishable from a
+	// genuinely-empty one, so the UI should surface a "some data couldn't
+	// load" state rather than presenting the partial result as complete.
+	// degraded_sections names which sections failed (e.g. "recent_activity",
+	// "by_role", "active_plans"). Every failure is also logged server-side.
+	degraded: boolean;
+	// degraded_sections lists the section names whose sub-query failed.
+	// Omitted when degraded is false.
+	degraded_sections?: string[];
 }
 
 // ─── Project Intelligence: standup / changelog (PLAN-1888 / TASK-1894) ──────

--- a/web/src/routes/[username]/[workspace]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/+page.svelte
@@ -332,6 +332,23 @@
 			</div>
 		</header>
 
+		<!-- Degraded-load banner (BUG-2014). When one or more best-effort
+			dashboard sub-queries failed server-side, the response still returns
+			200 with the sections that loaded, but `degraded` is set so the
+			affected sections aren't misread as genuinely empty. -->
+		{#if dashboard.degraded}
+			<div class="degraded-banner" role="status">
+				<span class="degraded-icon">⚠</span>
+				<span>
+					Some dashboard data couldn't be loaded and may be incomplete.
+					{#if dashboard.degraded_sections && dashboard.degraded_sections.length > 0}
+						<span class="degraded-sections">Affected: {dashboard.degraded_sections.join(', ')}.</span>
+					{/if}
+					Try refreshing.
+				</span>
+			</div>
+		{/if}
+
 		<!-- 2. Onboarding nudge (IDEA-1516 §3 / TASK-1530) -->
 		<!--
 			Single banner triggered by `dashboard.needs_onboarding`. The
@@ -790,6 +807,26 @@
 	/* ── Section headers ────────────────────────────────────────────────── */
 	.section {
 		margin-bottom: var(--space-8);
+	}
+	.degraded-banner {
+		display: flex;
+		align-items: flex-start;
+		gap: var(--space-2);
+		padding: var(--space-3) var(--space-4);
+		margin-bottom: var(--space-4);
+		border: 1px solid var(--accent-amber);
+		border-radius: var(--radius);
+		background: color-mix(in srgb, var(--accent-amber) 12%, transparent);
+		color: var(--text-secondary);
+		font-size: 0.85em;
+		line-height: 1.4;
+	}
+	.degraded-icon {
+		color: var(--accent-amber);
+		flex-shrink: 0;
+	}
+	.degraded-sections {
+		color: var(--text-muted);
 	}
 	.section-header {
 		display: flex;


### PR DESCRIPTION
## Problem

`buildDashboardResponse` (internal/server/handlers_dashboard.go) assembled several best-effort sections with `if err == nil` / `if err != nil { continue }` and **no logging**. A failing sub-query rendered indistinguishably from a genuinely-empty section — the failure was completely silent, both server-side (no log) and client-side (looks empty). (BUG-2014)

## Fix

- **Log every best-effort sub-query failure** via a `markDegraded` helper — `slog.Error` with `workspace_id` + `section` for triage.
- **Surface partial failure in the response**: new `Degraded bool` + `DegradedSections []string` on `DashboardResponse`. Sections whose sub-query fails are named so the client can render a "some data couldn't load" state instead of a false-empty. Wired into: `active_plans`, `attention.stalled`, `attention.orphaned_tasks`, `recent_activity`, `by_role`, `starred_items`.
- The queries whose failure genuinely invalidates the whole dashboard still `return nil, err` (all-or-nothing preserved for those) — this only changes the previously-swallowed best-effort paths.
- `attention.orphaned_tasks`: a `GetParentMap` failure now **skips** orphan detection entirely rather than falling back to an empty map (which would falsely flag every task as orphaned).
- The `has_agent_activity` source fallback (which has a valid default) logs a `Warn` but does not degrade.
- **TypeScript type** (`web/src/lib/types/index.ts`) mirrors the new fields.
- **Web UI**: the workspace dashboard renders an amber degraded-load banner (listing affected sections) when `degraded` is set.

## Tests

- New `TestDashboardDegradedOnSubQueryFailure`: drops the `activities` table (read only by `recent_activity`), asserts the endpoint still returns 200, `Degraded` flips true, `recent_activity` is named in `DegradedSections`, and the healthy sections still load (partial failure, not all-or-nothing).

## Gates

- `~/go/bin/golangci-lint run --timeout=5m ./...` — 0 issues
- `go test ./...` — green
- `web` `npm run check` — 0 errors
- Codex review — CLEAN

https://claude.ai/code/session_019knGmnHcx5rrgWXQ8V8DZS