### PR TITLE
fix(store): make item field + parent-link update atomic (BUG-2013)

### DIFF
--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -813,11 +813,13 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 	// the three UpdateItem call sites that follow. nil = no guard.
 	var openChildrenPrecheck func(tx *sql.Tx, existing *models.Item) error
 
-	// IDEA-1494 R4 P3: parent-link change is captured here and
-	// applied AFTER the main UpdateItemWithPreCheck succeeds, so a
-	// guard rejection on the status field doesn't leave a committed
-	// link change behind. Hoisted out of the `if input.Fields != nil`
-	// block so the post-write step can read them.
+	// IDEA-1494 R4 P3 / BUG-2013: the parent-link change is captured
+	// here and applied INSIDE the same store transaction as the field
+	// write (see store.UpdateItemWithParentLink). A guard rejection on
+	// the status field rolls the whole tx back, and a failing link write
+	// rolls the field write back too — the caller only ever observes both
+	// writes or neither. Hoisted out of the `if input.Fields != nil`
+	// block so the parentLink directive below can read them.
 	var parentValue string
 	var parentProvided bool
 
@@ -971,25 +973,38 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 		validated := string(validatedFields)
 		input.Fields = &validated
 
-		// IDEA-1494 R4 P3: parent-link mutations are DEFERRED until
-		// after the field write succeeds. Pre-fix this block ran the
-		// link update INLINE here — before the precheck even fired —
-		// so a PATCH that combined a parent change with a status flip
-		// could end up with the link committed AND the field write
-		// rejected by the guard. Caller saw 409 but the parent had
-		// already moved.
+		// IDEA-1494 R4 P3 / BUG-2013: parent-link mutations are neither
+		// run inline here nor deferred to a post-commit write. They are
+		// staged (parentValue / parentProvided, above) and handed to
+		// UpdateItemWithParentLink, which applies them INSIDE the same
+		// store transaction as the field write.
 		//
-		// Now we record the desired link change and execute it ONLY
-		// when the main UpdateItemWithPreCheck call below succeeds.
-		// A guard rejection short-circuits with the link untouched.
-		// Documented choice: "reorder, don't tx-wrap" — wrapping the
-		// link mutation in the same store tx as UpdateItem would
-		// require threading a tx through SetParentLink (which has
-		// its own tx already, and is also called from the
-		// handler_item_links path). Reordering is the smaller surgery
-		// and preserves atomicity in the failure direction — caller
-		// only sees both writes on success, or neither (with a clear
-		// 409) on rejection.
+		// History: the pre-IDEA-1494 code ran the link update inline
+		// (before the precheck), so a combined parent-change + status-flip
+		// PATCH could commit the link and then have the field write
+		// rejected by the guard. IDEA-1494 R4 P3 moved it to a post-commit
+		// write, which fixed that direction but left the OTHER partial-
+		// commit window: field write committed, then link write failed →
+		// 500 with half the patch applied. BUG-2013 closes it for good by
+		// folding the link write into the update tx (see the parentLink
+		// directive built below).
+	}
+
+	// BUG-2013: build the atomic parent-link directive. When the PATCH
+	// changed the parent (parentProvided), this is threaded through every
+	// UpdateItemWithParentLink call site below so the link write shares
+	// the field write's transaction. parentValue=="" means "clear"; a
+	// non-empty value means "set to that item ID". Nil when the PATCH
+	// didn't touch the parent, giving the plain update path.
+	var parentLink *store.ParentLinkUpdate
+	if parentProvided {
+		linkActor, _ := actorFromRequest(r)
+		parentLink = &store.ParentLinkUpdate{
+			Provided:    true,
+			ParentID:    parentValue,
+			WorkspaceID: workspaceID,
+			CreatedBy:   linkActor,
+		}
 	}
 
 	// Designated-applier routing (PLAN-1248 TASK-1257). When the
@@ -1106,7 +1121,7 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 					return errStaleCollabSnapshot
 				}
 			}
-			updated, uerr := s.store.UpdateItemWithPreCheck(item.ID, input, openChildrenPrecheck)
+			updated, uerr := s.store.UpdateItemWithParentLink(item.ID, input, openChildrenPrecheck, parentLink)
 			if uerr != nil {
 				return uerr
 			}
@@ -1174,7 +1189,7 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 		// Store.UpdateItem's content-versioning peek at Title.
 		// Per Codex review round 9.
 		err := s.applyContentViaCollab(r, item.ID, *input.Content, func() error {
-			updated, uerr := s.store.UpdateItemWithPreCheck(item.ID, input, openChildrenPrecheck)
+			updated, uerr := s.store.UpdateItemWithParentLink(item.ID, input, openChildrenPrecheck, parentLink)
 			if uerr != nil {
 				return uerr
 			}
@@ -1206,7 +1221,7 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 	if fullWriteHandled {
 		updated = fullWriteUpdated
 	} else {
-		updated, err = s.store.UpdateItemWithPreCheck(item.ID, input, openChildrenPrecheck)
+		updated, err = s.store.UpdateItemWithParentLink(item.ID, input, openChildrenPrecheck, parentLink)
 	}
 	if err != nil {
 		// IDEA-1494 R2: surface the open-children guard rejection as
@@ -1234,33 +1249,12 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// IDEA-1494 R4 P3: deferred parent-link mutation. Runs ONLY now
-	// that the main UpdateItemWithPreCheck succeeded (the precheck
-	// passed AND the field write committed). A guard rejection above
-	// `return`s before reaching here, so the link is untouched on
-	// the failure path.
-	//
-	// Failure of the link write itself after a successful field
-	// write is still possible (e.g. SetParentLink discovers a cycle
-	// the cycle-check missed, or a DB error). We surface that as a
-	// 500 with the field write already committed — same partial-
-	// success window the pre-IDEA-1494 code had in the OTHER
-	// direction, and not made worse by the reorder. A future tx-
-	// wrap fix could close this entirely; out of scope for round 4.
-	if parentProvided {
-		if parentValue != "" {
-			actor, _ := actorFromRequest(r)
-			if _, err := s.store.SetParentLink(workspaceID, item.ID, parentValue, actor); err != nil {
-				writeError(w, http.StatusInternalServerError, "internal_error", fmt.Sprintf("failed to update parent link: %v", err))
-				return
-			}
-		} else {
-			if err := s.store.ClearParentLink(item.ID); err != nil {
-				writeError(w, http.StatusInternalServerError, "internal_error", fmt.Sprintf("failed to clear parent link: %v", err))
-				return
-			}
-		}
-	}
+	// BUG-2013: the parent-link mutation is no longer a separate
+	// post-commit write here — it ran INSIDE UpdateItemWithParentLink's
+	// transaction above (via the parentLink directive). A cycle or DB
+	// error on the link write now rolls the field write back and surfaces
+	// through the shared error handling above, so there is no remaining
+	// partial-commit window and nothing to do in this post-commit stage.
 
 	// Build rich metadata describing what changed
 	var meta string

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -1682,6 +1682,23 @@ func (s *Store) UpdateItem(id string, input models.ItemUpdate) (*models.Item, er
 	return s.UpdateItemWithPreCheck(id, input, nil)
 }
 
+// ParentLinkUpdate describes an optional parent-link mutation to apply
+// ATOMICALLY inside UpdateItem's transaction (BUG-2013). The handler used
+// to run SetParentLink/ClearParentLink as a separate write AFTER the field
+// update committed, so a failing link write left the item half-updated and
+// returned a 500. Folding the mutation into the same tx makes the pair
+// all-or-nothing.
+//
+//   - Provided=false  → no parent-link change (the common case).
+//   - Provided=true, ParentID!="" → set the parent to ParentID.
+//   - Provided=true, ParentID=="" → clear the parent link.
+type ParentLinkUpdate struct {
+	Provided    bool
+	ParentID    string
+	WorkspaceID string
+	CreatedBy   string
+}
+
 // UpdateItemWithPreCheck is UpdateItem with an optional pre-mutation
 // hook that runs inside the same transaction (and, on Postgres, holds
 // the same workspace advisory lock) as the update itself. Callers can
@@ -1701,6 +1718,24 @@ func (s *Store) UpdateItemWithPreCheck(
 	id string,
 	input models.ItemUpdate,
 	precheck func(tx *sql.Tx, existing *models.Item) error,
+) (*models.Item, error) {
+	return s.UpdateItemWithParentLink(id, input, precheck, nil)
+}
+
+// UpdateItemWithParentLink is UpdateItemWithPreCheck plus an OPTIONAL
+// parent-link mutation applied inside the same transaction (BUG-2013).
+// When parentLink is non-nil and Provided, the SetParentLink/ClearParentLink
+// write runs after the field update but BEFORE commit — so if the link write
+// fails (cycle, DB error), the field update rolls back too. No more
+// 500-with-half-the-patch-applied.
+//
+// Pass a nil parentLink for the standard update path (equivalent to
+// UpdateItemWithPreCheck).
+func (s *Store) UpdateItemWithParentLink(
+	id string,
+	input models.ItemUpdate,
+	precheck func(tx *sql.Tx, existing *models.Item) error,
+	parentLink *ParentLinkUpdate,
 ) (*models.Item, error) {
 	existing, err := s.GetItem(id)
 	if err != nil {
@@ -1746,7 +1781,15 @@ func (s *Store) UpdateItemWithPreCheck(
 	// item's own children lock. Both lock keys are namespaced under
 	// `pad:parent-children:` so they only contend on the parent ID;
 	// acquiring two distinct keys in a fixed order can't deadlock.
-	if err := s.acquireParentChildrenLocksForUpdate(tx, id); err != nil {
+	//
+	// BUG-2013: when this update also re-parents the item, fold the NEW
+	// parent's key into this same sorted acquisition so setParentLinkTx's
+	// later (idempotent) re-lock never introduces an out-of-order grab.
+	var extraLockKeys []string
+	if parentLink != nil && parentLink.Provided && parentLink.ParentID != "" {
+		extraLockKeys = append(extraLockKeys, parentLink.ParentID)
+	}
+	if err := s.acquireParentChildrenLocksForUpdate(tx, id, extraLockKeys...); err != nil {
 		return nil, err
 	}
 
@@ -2076,6 +2119,24 @@ func (s *Store) UpdateItemWithPreCheck(
 		}
 		if err := s.replaceWikiLinks(tx, id, existing.WorkspaceID, currentContent); err != nil {
 			return nil, fmt.Errorf("index wiki links: %w", err)
+		}
+	}
+
+	// BUG-2013: apply the parent-link mutation INSIDE this tx, after the
+	// field write. A failure here (cycle detected, DB error) rolls the
+	// whole transaction back, so the caller can never observe the field
+	// update committed while the parent link write failed. The new
+	// parent's advisory lock was already folded into the acquisition
+	// above, so setParentLinkTx's re-lock is a no-op.
+	if parentLink != nil && parentLink.Provided {
+		if parentLink.ParentID != "" {
+			if _, err := s.setParentLinkTx(tx, parentLink.WorkspaceID, id, parentLink.ParentID, parentLink.CreatedBy); err != nil {
+				return nil, err
+			}
+		} else {
+			if err := s.clearParentLinkTx(tx, id); err != nil {
+				return nil, err
+			}
 		}
 	}
 
@@ -2550,16 +2611,45 @@ func (s *Store) DeleteItemLink(id string) error {
 // guard could read 0 open children while this method was about to
 // attach a non-terminal child.
 func (s *Store) SetParentLink(workspaceID, itemID, parentID, createdBy string) (*models.ItemLink, error) {
-	// Cycle detection: walk the ancestor chain from parentID to ensure itemID is not an ancestor.
-	if err := s.checkParentCycle(itemID, parentID); err != nil {
-		return nil, err
-	}
-
 	tx, err := s.db.Begin()
 	if err != nil {
 		return nil, fmt.Errorf("begin tx: %w", err)
 	}
 	defer tx.Rollback()
+
+	id, err := s.setParentLinkTx(tx, workspaceID, itemID, parentID, createdBy)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit parent link: %w", err)
+	}
+
+	// Return the full link with enriched fields. Use the unfiltered readback
+	// helper so that a delete race against either endpoint between commit and
+	// readback doesn't cause the successful insert to surface as nil.
+	return s.getItemLink(id)
+}
+
+// setParentLinkTx performs the cycle check, lock acquisition, and the
+// DELETE-then-INSERT of the parent link entirely within the caller's
+// transaction, returning the new link's id. It is the shared core of the
+// public SetParentLink (which opens its own tx) AND UpdateItemWithParentLink
+// (which reuses the item-update tx so the field write and the link write
+// commit or roll back together — closing the partial-commit window from
+// BUG-2013).
+//
+// Lock acquisition routes through AcquireParentChildrenLocks, so re-acquiring
+// keys the enclosing tx already holds (as UpdateItemWithParentLink does after
+// pre-locking the new parent) is an idempotent no-op rather than a deadlock.
+func (s *Store) setParentLinkTx(tx *sql.Tx, workspaceID, itemID, parentID, createdBy string) (string, error) {
+	// Cycle detection: walk the ancestor chain from parentID to ensure itemID
+	// is not an ancestor. Read via the tx so the walk sees the same item_links
+	// state the DELETE/INSERT below writes against.
+	if err := s.checkParentCycleQ(tx, itemID, parentID); err != nil {
+		return "", err
+	}
 
 	// Find the existing parent (if any) so we can lock against it too.
 	// The DELETE below targets link_type='parent' specifically, which
@@ -2573,16 +2663,16 @@ func (s *Store) SetParentLink(workspaceID, itemID, parentID, createdBy string) (
 		WHERE source_id = ? AND link_type = 'parent'
 		LIMIT 1
 	`), itemID).Scan(&oldParentID); err != nil && err != sql.ErrNoRows {
-		return nil, fmt.Errorf("lookup existing parent: %w", err)
+		return "", fmt.Errorf("lookup existing parent: %w", err)
 	}
 
 	if err := s.AcquireParentChildrenLocks(tx, oldParentID.String, parentID); err != nil {
-		return nil, err
+		return "", err
 	}
 
 	// Delete existing parent link for this item (if any)
 	if _, err := tx.Exec(s.q(`DELETE FROM item_links WHERE source_id = ? AND link_type = 'parent'`), itemID); err != nil {
-		return nil, fmt.Errorf("delete existing parent link: %w", err)
+		return "", fmt.Errorf("delete existing parent link: %w", err)
 	}
 
 	// Insert new parent link
@@ -2592,22 +2682,27 @@ func (s *Store) SetParentLink(workspaceID, itemID, parentID, createdBy string) (
 		INSERT INTO item_links (id, workspace_id, source_id, target_id, link_type, created_by, created_at)
 		VALUES (?, ?, ?, ?, 'parent', ?, ?)
 	`), id, workspaceID, itemID, parentID, createdBy, now); err != nil {
-		return nil, fmt.Errorf("insert parent link: %w", err)
+		return "", fmt.Errorf("insert parent link: %w", err)
 	}
 
-	if err := tx.Commit(); err != nil {
-		return nil, fmt.Errorf("commit parent link: %w", err)
-	}
-
-	// Return the full link with enriched fields. Use the unfiltered readback
-	// helper so that a delete race against either endpoint between commit and
-	// readback doesn't cause the successful insert to surface as nil.
-	return s.getItemLink(id)
+	return id, nil
 }
 
-// checkParentCycle walks the ancestor chain from parentID and returns an error
-// if itemID is found (which would create a cycle).
-func (s *Store) checkParentCycle(itemID, parentID string) error {
+// rowQueryer is the minimal surface checkParentCycleQ needs from either
+// *sql.DB or *sql.Tx, so the cycle walk can run either unlocked (public
+// SetParentLink) or inside an in-flight transaction (UpdateItem's atomic
+// parent-link path, which must read item_links under the same tx/locks
+// it writes with).
+type rowQueryer interface {
+	QueryRow(query string, args ...any) *sql.Row
+}
+
+// checkParentCycleQ walks the ancestor chain from parentID and returns an
+// error if itemID is found (which would create a cycle). Parameterized over
+// the queryer so the walk can execute inside a transaction: reading via the
+// same tx that holds the parent-children locks keeps the cycle decision
+// consistent with the DELETE/INSERT that follows it.
+func (s *Store) checkParentCycleQ(q rowQueryer, itemID, parentID string) error {
 	visited := map[string]bool{itemID: true}
 	current := parentID
 	for {
@@ -2618,7 +2713,7 @@ func (s *Store) checkParentCycle(itemID, parentID string) error {
 
 		// Look up the parent of current
 		var targetID sql.NullString
-		err := s.db.QueryRow(s.q(`
+		err := q.QueryRow(s.q(`
 			SELECT target_id FROM item_links
 			WHERE source_id = ? AND link_type = 'parent'
 		`), current).Scan(&targetID)
@@ -2644,6 +2739,17 @@ func (s *Store) ClearParentLink(itemID string) error {
 	}
 	defer tx.Rollback()
 
+	if err := s.clearParentLinkTx(tx, itemID); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+// clearParentLinkTx removes the item's parent link within the caller's
+// transaction. Shared by the public ClearParentLink (own tx) and
+// UpdateItemWithParentLink (item-update tx), so a cleared parent commits
+// atomically with the field write it accompanied (BUG-2013).
+func (s *Store) clearParentLinkTx(tx *sql.Tx, itemID string) error {
 	var oldParentID sql.NullString
 	if err := tx.QueryRow(s.q(`
 		SELECT target_id FROM item_links
@@ -2660,7 +2766,7 @@ func (s *Store) ClearParentLink(itemID string) error {
 	if _, err := tx.Exec(s.q(`DELETE FROM item_links WHERE source_id = ? AND link_type = 'parent'`), itemID); err != nil {
 		return fmt.Errorf("clear parent link: %w", err)
 	}
-	return tx.Commit()
+	return nil
 }
 
 // GetParentForItem returns the parent link for an item, or nil if it has no parent.
@@ -3155,7 +3261,14 @@ func (s *Store) GetChildItemsTx(tx *sql.Tx, parentItemID string) ([]models.Item,
 // canonical sorted order — round-4 P2's deadlock-avoidance contract.
 // No call site outside this helper takes pad:parent-children:* locks
 // in any other order.
-func (s *Store) acquireParentChildrenLocksForUpdate(tx *sql.Tx, itemID string) error {
+//
+// extraKeys lets a caller fold additional parent IDs into the SAME sorted
+// batch — UpdateItemWithParentLink passes the NEW parent when an atomic
+// parent-link change accompanies the field write. Acquiring the new parent
+// in this initial sorted acquisition (rather than later, inside
+// setParentLinkTx) preserves the canonical lock ordering and keeps the
+// combined update deadlock-free.
+func (s *Store) acquireParentChildrenLocksForUpdate(tx *sql.Tx, itemID string, extraKeys ...string) error {
 	if s.dialect.Driver() != DriverPostgres {
 		return nil
 	}
@@ -3164,6 +3277,7 @@ func (s *Store) acquireParentChildrenLocksForUpdate(tx *sql.Tx, itemID string) e
 		return err
 	}
 	keys := append(parentIDs, itemID)
+	keys = append(keys, extraKeys...)
 	return s.AcquireParentChildrenLocks(tx, keys...)
 }
 

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -2632,7 +2632,7 @@ func (s *Store) SetParentLink(workspaceID, itemID, parentID, createdBy string) (
 	return s.getItemLink(id)
 }
 
-// setParentLinkTx performs the cycle check, lock acquisition, and the
+// setParentLinkTx performs the lock acquisition, cycle check, and the
 // DELETE-then-INSERT of the parent link entirely within the caller's
 // transaction, returning the new link's id. It is the shared core of the
 // public SetParentLink (which opens its own tx) AND UpdateItemWithParentLink
@@ -2644,13 +2644,6 @@ func (s *Store) SetParentLink(workspaceID, itemID, parentID, createdBy string) (
 // keys the enclosing tx already holds (as UpdateItemWithParentLink does after
 // pre-locking the new parent) is an idempotent no-op rather than a deadlock.
 func (s *Store) setParentLinkTx(tx *sql.Tx, workspaceID, itemID, parentID, createdBy string) (string, error) {
-	// Cycle detection: walk the ancestor chain from parentID to ensure itemID
-	// is not an ancestor. Read via the tx so the walk sees the same item_links
-	// state the DELETE/INSERT below writes against.
-	if err := s.checkParentCycleQ(tx, itemID, parentID); err != nil {
-		return "", err
-	}
-
 	// Find the existing parent (if any) so we can lock against it too.
 	// The DELETE below targets link_type='parent' specifically, which
 	// matches what the guard's children query treats as the parent
@@ -2667,6 +2660,19 @@ func (s *Store) setParentLinkTx(tx *sql.Tx, workspaceID, itemID, parentID, creat
 	}
 
 	if err := s.AcquireParentChildrenLocks(tx, oldParentID.String, parentID); err != nil {
+		return "", err
+	}
+
+	// Cycle detection: walk the ancestor chain from parentID to ensure itemID
+	// is not an ancestor. Run this AFTER the parent-children locks are held (Codex
+	// review, PR #868): checking before the lock lets two concurrent reparents
+	// each pass on a stale ancestry snapshot, block on the lock, then both insert
+	// — closing the loop (A→B→C→A). Under the lock the walk reads via the tx, so
+	// it sees the edge the just-unblocked peer committed and catches the cycle.
+	// (Residual: cycles closed via an edge on an item NEITHER endpoint locks can
+	// still slip through — a pre-existing limitation of the per-endpoint lock
+	// scheme, tracked separately.)
+	if err := s.checkParentCycleQ(tx, itemID, parentID); err != nil {
 		return "", err
 	}
 

--- a/internal/store/items_test.go
+++ b/internal/store/items_test.go
@@ -1072,6 +1072,106 @@ func TestGetParentForItem_HidesSoftDeletedParent(t *testing.T) {
 	}
 }
 
+// TestUpdateItemWithParentLink_AtomicRollback proves BUG-2013: a field
+// update combined with a parent-link change is atomic. When the parent-link
+// write fails (here, because it would create a cycle), the field update must
+// roll back too — no partial commit, no half-applied patch.
+func TestUpdateItemWithParentLink_AtomicRollback(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+
+	parent := createTestItem(t, s, ws.ID, col.ID, "Parent", "")
+	child := createTestItem(t, s, ws.ID, col.ID, "Child", "")
+
+	// child's parent is parent → parent → child would be a cycle.
+	if _, err := s.SetParentLink(ws.ID, child.ID, parent.ID, "user"); err != nil {
+		t.Fatalf("SetParentLink: %v", err)
+	}
+
+	// Attempt to (a) flip parent's status to "done" AND (b) set parent's
+	// parent to child in one update. The cycle check inside the tx must
+	// reject (b), rolling back (a).
+	doneFields := `{"status":"done"}`
+	_, err := s.UpdateItemWithParentLink(
+		parent.ID,
+		models.ItemUpdate{Fields: &doneFields},
+		nil,
+		&ParentLinkUpdate{Provided: true, ParentID: child.ID, WorkspaceID: ws.ID, CreatedBy: "user"},
+	)
+	if err == nil {
+		t.Fatal("expected cycle error from combined update, got nil")
+	}
+
+	// The field write must have rolled back: parent's status is still "open".
+	got, gerr := s.GetItem(parent.ID)
+	if gerr != nil {
+		t.Fatalf("GetItem parent: %v", gerr)
+	}
+	if status := extractFieldValue(got.Fields, "status"); status != "open" {
+		t.Errorf("field update leaked despite failed parent-link write: status=%q, want %q (partial commit!)", status, "open")
+	}
+
+	// The parent-link write must also NOT have committed: parent has no parent.
+	if link, lerr := s.GetParentForItem(parent.ID); lerr != nil {
+		t.Fatalf("GetParentForItem parent: %v", lerr)
+	} else if link != nil {
+		t.Errorf("parent-link write committed despite rollback: %+v", link)
+	}
+}
+
+// TestUpdateItemWithParentLink_AtomicCommit is the happy-path counterpart:
+// when the parent-link write succeeds, BOTH the field change and the link
+// change commit together.
+func TestUpdateItemWithParentLink_AtomicCommit(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+
+	parent := createTestItem(t, s, ws.ID, col.ID, "Parent", "")
+	child := createTestItem(t, s, ws.ID, col.ID, "Child", "")
+
+	doneFields := `{"status":"done"}`
+	updated, err := s.UpdateItemWithParentLink(
+		child.ID,
+		models.ItemUpdate{Fields: &doneFields},
+		nil,
+		&ParentLinkUpdate{Provided: true, ParentID: parent.ID, WorkspaceID: ws.ID, CreatedBy: "user"},
+	)
+	if err != nil {
+		t.Fatalf("UpdateItemWithParentLink: %v", err)
+	}
+	if status := extractFieldValue(updated.Fields, "status"); status != "done" {
+		t.Errorf("field update not committed: status=%q, want %q", status, "done")
+	}
+	if link, lerr := s.GetParentForItem(child.ID); lerr != nil {
+		t.Fatalf("GetParentForItem: %v", lerr)
+	} else if link == nil || link.TargetID != parent.ID {
+		t.Errorf("parent-link not committed: %+v", link)
+	}
+
+	// Clearing the parent alongside a field change also commits atomically.
+	openFields := `{"status":"open"}`
+	if _, err := s.UpdateItemWithParentLink(
+		child.ID,
+		models.ItemUpdate{Fields: &openFields},
+		nil,
+		&ParentLinkUpdate{Provided: true, ParentID: "", WorkspaceID: ws.ID, CreatedBy: "user"},
+	); err != nil {
+		t.Fatalf("UpdateItemWithParentLink (clear): %v", err)
+	}
+	if link, lerr := s.GetParentForItem(child.ID); lerr != nil {
+		t.Fatalf("GetParentForItem after clear: %v", lerr)
+	} else if link != nil {
+		t.Errorf("expected parent cleared, got %+v", link)
+	}
+	if got, gerr := s.GetItem(child.ID); gerr != nil {
+		t.Fatalf("GetItem: %v", gerr)
+	} else if status := extractFieldValue(got.Fields, "status"); status != "open" {
+		t.Errorf("field update on clear not committed: status=%q, want %q", status, "open")
+	}
+}
+
 // TestGetParentMap_ExcludesSoftDeletedEndpoints covers the dashboard
 // orphan-detection path: a task whose parent has been soft-deleted should
 // NOT appear in GetParentMap, so handlers_dashboard.go correctly flags the


### PR DESCRIPTION
## Summary

`handleUpdateItem` committed the field write, then ran `SetParentLink`/`ClearParentLink` as a **separate** store transaction. A failure there (a cycle discovered late, a DB error) returned 500 with **half the patch already applied** — a code-acknowledged partial-commit window (BUG-2013).

This folds the parent-link mutation into the **same transaction** as the field write, so a single item update is all-or-nothing.

## Changes

- **store:** extracted `setParentLinkTx` / `clearParentLinkTx` from the public `SetParentLink` / `ClearParentLink` (which keep their own tx). Added `UpdateItemWithParentLink(id, input, precheck, *ParentLinkUpdate)`; `UpdateItemWithPreCheck` now delegates to it with a nil link. The link write runs after the field `UPDATE` but **before `COMMIT`**, so a failing link write rolls the field write back too.
- **lock ordering:** the NEW parent's advisory key is folded into the update's initial sorted `AcquireParentChildrenLocks` batch (`extraKeys` on `acquireParentChildrenLocksForUpdate`), so `setParentLinkTx`'s later re-lock is an idempotent no-op and the combined update stays deadlock-free. `checkParentCycle` is parameterized over the queryer (`checkParentCycleQ`) so the cycle walk reads inside the tx, and now runs after lock acquisition.
- **handler:** restructured into validate / atomic-write / post-commit stages. The parent-link directive is built once and threaded through all three `UpdateItemWithParentLink` call sites; the old post-commit `SetParentLink`/`ClearParentLink` block is removed.

Works on both SQLite (atomicity from `BEGIN IMMEDIATE`) and Postgres (advisory locks).

## Tests

- `TestUpdateItemWithParentLink_AtomicRollback` — a failing (cycle) parent-link write rolls back the field change; asserts no partial state and no committed link.
- `TestUpdateItemWithParentLink_AtomicCommit` — happy path commits field + link together; also covers atomic clear.

## Gates

- `golangci-lint run` — 0 issues
- `go test ./...` — green
- `make test-pg` (Postgres suite) — green
- Codex review — atomicity confirmed correct

## Out of scope / follow-up (BUG-2073)

Codex review surfaced two **pre-existing** concurrency TOCTOU races in the parent-link locking scheme (present on `main` verbatim, orthogonal to this partial-commit fix): (1) public `SetParentLink` doesn't lock the child's own key, so a symmetric A↔B reparent can form a cycle; (2) `oldParent` is read before the lock and not re-read after (the same read-then-lock pattern the whole parent-children protocol uses). This PR already makes the **new** atomic path cycle-safe (it holds the child + parents + new-parent locks up front). The residual public-path races are tracked in BUG-2073 rather than expanding this PR.

https://claude.ai/code/session_019knGmnHcx5rrgWXQ8V8DZS