### PR TITLE
fix(store): workspace-level guard for N-hop parent cycles (BUG-2074)

### DIFF
--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -101,6 +101,52 @@ func (s *Store) acquireWorkspaceSeqLock(tx *sql.Tx, workspaceID string) error {
 	return nil
 }
 
+// acquireWorkspaceParentLinkLock takes a Postgres advisory transaction lock
+// that serializes ALL parent-edge-ADDING transactions within a workspace
+// (BUG-2074). It is the outer guard that closes the N-hop parent-cycle gap the
+// per-endpoint cycle walk cannot: BUG-2073's per-item sorted lock batch only
+// covers the two endpoints of the edge being written, so a cycle closed via an
+// edge on an item that NEITHER endpoint locks (e.g. an existing A->B and C->D
+// cross-linked concurrently by SetParentLink(B,C) + SetParentLink(D,A), whose
+// lock sets {B,C} and {D,A} are disjoint) still slips through — both cycle
+// walks run on stale snapshots and both inserts commit, forming A->B->C->D->A.
+//
+// With this lock held by every edge-adder, no two parent-edge insertions can
+// run concurrently in a workspace, so checkParentCycleQ always walks a
+// consistent, non-racing ancestor snapshot and catches arbitrary N-hop cycles.
+// Parent-link writes are rare, so serializing them per-workspace is an
+// acceptable trade-off. Only edge-ADDING paths take this lock (the paths that
+// call setParentLinkTx with a non-empty parentID); edge REMOVALS (clear /
+// detach) and plain field updates can't create a cycle, so they don't request
+// it — keeping the common UpdateItem path un-serialized.
+//
+// DISTINCT namespace from acquireWorkspaceSeqLock (bare hashtext(workspaceID))
+// and from AcquireParentChildrenLocks (per-item 'pad:parent-children:<id>') so
+// the three lock classes never alias on the same key.
+//
+// LOCK ORDERING (deadlock-freedom): callers acquire this OUTERMOST — before the
+// workspace seq lock and before the per-item parent-children batch. The global
+// order across every transaction is therefore:
+//
+//	parent-link-cycle lock  ->  workspace seq lock  ->  parent-children batch
+//
+// No transaction takes any of these in the reverse relative order, and only
+// edge-adding transactions take the cycle lock at all (a plain UpdateItem /
+// CreateItem / clear-parent never requests it), so the classic AB/BA deadlock
+// shape can't form.
+//
+// On SQLite the global BEGIN IMMEDIATE write lock already serializes every
+// writer, so this is a no-op there (the N-hop race can't manifest on SQLite).
+func (s *Store) acquireWorkspaceParentLinkLock(tx *sql.Tx, workspaceID string) error {
+	if s.dialect.Driver() != DriverPostgres {
+		return nil
+	}
+	if _, err := tx.Exec("SELECT pg_advisory_xact_lock(hashtext('pad:parent-link-cycle:' || $1))", workspaceID); err != nil {
+		return fmt.Errorf("acquire workspace parent-link lock: %w", err)
+	}
+	return nil
+}
+
 func (s *Store) CreateItem(workspaceID, collectionID string, input models.ItemCreate) (*models.Item, error) {
 	// Validate assignment scope before writing
 	if err := s.validateAssignmentScope(workspaceID, input.AssignedUserID, input.AgentRoleID); err != nil {
@@ -1775,6 +1821,21 @@ func (s *Store) updateItemWithParentLinkOnce(
 	}
 	defer tx.Rollback()
 
+	// BUG-2074: when this update ADDS a parent edge (parentLink sets a
+	// non-empty ParentID), take the workspace-scoped parent-link cycle lock
+	// FIRST — before the seq lock and the parent-children batch — so the
+	// cycle walk in setParentLinkTx (applied later in this tx) runs against a
+	// consistent, non-racing ancestor snapshot and catches N-hop cycles that
+	// the per-endpoint lock set can't cover. Acquired only for edge-ADDING
+	// updates so plain field updates / status flips / clear-parent stay off
+	// this serialization point. Outermost acquisition keeps the global order
+	// cycle -> seq -> parent-children (see acquireWorkspaceParentLinkLock).
+	if parentLink != nil && parentLink.Provided && parentLink.ParentID != "" {
+		if err := s.acquireWorkspaceParentLinkLock(tx, existing.WorkspaceID); err != nil {
+			return nil, err
+		}
+	}
+
 	// Serialize concurrent seq assignments per workspace on Postgres
 	// (no-op on SQLite). Held until COMMIT / ROLLBACK.
 	if err := s.acquireWorkspaceSeqLock(tx, existing.WorkspaceID); err != nil {
@@ -2407,6 +2468,22 @@ func (s *Store) CreateItemLink(workspaceID string, input models.ItemLinkCreate, 
 		createdBy = "user"
 	}
 
+	// BUG-2074: a `parent` link is the same graph edge SetParentLink writes and
+	// the only link_type checkParentCycleQ's ancestor walk follows. Route it
+	// through SetParentLink so it gets the FULL guarded parent-edge protocol:
+	//   - single-parent DELETE-then-INSERT (so a child can't accumulate two
+	//     `parent` rows — the append-only insert below would, and the cycle
+	//     walk only follows ONE arbitrary parent per source, so a second row
+	//     would let an N-hop cycle hide on the un-walked branch);
+	//   - the workspace-scoped cycle lock + checkParentCycleQ under lock;
+	//   - the errParentSetChanged retry wrapper.
+	// The plain append-only INSERT below is only safe for NON-parent link types
+	// (blocks / supersedes / implements / related / …), none of which the cycle
+	// walk follows.
+	if linkType == models.ItemLinkTypeParent {
+		return s.SetParentLink(workspaceID, sourceID, input.TargetID, createdBy)
+	}
+
 	tx, err := s.db.Begin()
 	if err != nil {
 		return nil, fmt.Errorf("begin tx: %w", err)
@@ -2428,6 +2505,11 @@ func (s *Store) CreateItemLink(workspaceID string, input models.ItemLinkCreate, 
 	// hold — otherwise a concurrent UpdateItem(sourceID) could miss this new
 	// parent on its post-lock re-read. Both keys go through the sorted helper,
 	// so the two-key grab stays deadlock-free.
+	//
+	// (The `parent` link_type never reaches here — it is routed through
+	// SetParentLink above for the full guarded parent-edge protocol; BUG-2074.
+	// The remaining child-link type that lands here is 'implements', which the
+	// cycle walk does not follow, so no cycle guard is needed.)
 	if isChildLinkType(linkType) {
 		if err := s.AcquireParentChildrenLocks(tx, sourceID, input.TargetID); err != nil {
 			return nil, err
@@ -2666,6 +2748,15 @@ func (s *Store) setParentLinkOnce(workspaceID, itemID, parentID, createdBy strin
 	}
 	defer tx.Rollback()
 
+	// BUG-2074: serialize all parent-edge additions in this workspace so the
+	// cycle walk below runs against a consistent snapshot and can't miss an
+	// N-hop cycle closed by a concurrent add on items neither endpoint locks.
+	// Acquired OUTERMOST (before setParentLinkTx's parent-children batch) to
+	// keep the global lock order cycle -> seq -> parent-children.
+	if err := s.acquireWorkspaceParentLinkLock(tx, workspaceID); err != nil {
+		return nil, err
+	}
+
 	id, err := s.setParentLinkTx(tx, workspaceID, itemID, parentID, createdBy)
 	if err != nil {
 		return nil, err
@@ -2745,9 +2836,15 @@ func (s *Store) setParentLinkTx(tx *sql.Tx, workspaceID, itemID, parentID, creat
 	// each pass on a stale ancestry snapshot, block on the lock, then both insert
 	// — closing the loop (A→B→C→A). Under the lock the walk reads via the tx, so
 	// it sees the edge the just-unblocked peer committed and catches the cycle.
-	// (Residual: cycles closed via an edge on an item NEITHER endpoint locks can
-	// still slip through — a pre-existing limitation of the per-endpoint lock
-	// scheme, tracked separately.)
+	// BUG-2074: cycles closed via an edge on an item NEITHER endpoint locks
+	// (e.g. concurrent SetParentLink(B,C) + SetParentLink(D,A) completing
+	// A→B→C→D→A, whose per-endpoint lock sets {B,C} and {D,A} are disjoint)
+	// used to slip past this per-endpoint walk. The tx-owning callers now hold
+	// the workspace-scoped parent-link cycle lock (acquireWorkspaceParentLinkLock,
+	// taken outermost in setParentLinkOnce / updateItemWithParentLinkOnce), which
+	// serializes ALL parent-edge additions in the workspace — so this walk runs
+	// against a snapshot no concurrent add can mutate, catching arbitrary N-hop
+	// cycles.
 	if err := s.checkParentCycleQ(tx, itemID, parentID); err != nil {
 		return "", err
 	}

--- a/internal/store/parent_link_concurrency_test.go
+++ b/internal/store/parent_link_concurrency_test.go
@@ -175,3 +175,243 @@ func TestSetParentLink_ConcurrentReparentSingleParent(t *testing.T) {
 		t.Errorf("child parent link points at %q, which is not one of the reparent targets", link.TargetID)
 	}
 }
+
+// parentChainCycles walks the `parent` edges up from startID and reports
+// whether the chain revisits a node (a cycle) within a bounded number of hops.
+// The bound doubles as a safety net so a genuine cycle can't spin the walk
+// forever. Reads committed state directly (post-concurrency assertion).
+func parentChainCycles(t *testing.T, s *Store, startID string, maxHops int) bool {
+	t.Helper()
+	visited := map[string]bool{}
+	current := startID
+	for hops := 0; hops <= maxHops; hops++ {
+		if visited[current] {
+			return true
+		}
+		visited[current] = true
+		var target string
+		err := s.db.QueryRow(s.q(`
+			SELECT target_id FROM item_links
+			WHERE source_id = ? AND link_type = 'parent'
+			LIMIT 1
+		`), current).Scan(&target)
+		if err != nil || target == "" {
+			return false // no parent — chain terminates, no cycle
+		}
+		current = target
+	}
+	// Ran past maxHops without terminating: treat as a cycle.
+	return true
+}
+
+// TestSetParentLink_ConcurrentNHopNoCycle exercises BUG-2074: an N-hop parent
+// cycle closed via an edge on an item that NEITHER endpoint of a concurrent
+// write locks. The BUG-2073 fix folds the child key into a per-endpoint sorted
+// lock batch, but that only covers the two endpoints of the edge being written.
+//
+// Setup per quad: two committed 2-node chains A→B and C→D. Then two goroutines
+// race to cross-link them:
+//
+//	SetParentLink(B, C)  — B's parent becomes C  (lock set {B, C})
+//	SetParentLink(D, A)  — D's parent becomes A  (lock set {D, A})
+//
+// The two lock sets are DISJOINT, so under the per-endpoint scheme alone both
+// cycle walks pass on stale snapshots and both inserts commit — forming
+// A→B→C→D→A. The workspace-scoped parent-link cycle lock (BUG-2074) serializes
+// the two adds so the loser's walk sees the committed edge and is rejected.
+//
+// Invariant asserted: after both goroutines finish, NO node's parent chain
+// forms a cycle, and the two closing edges never BOTH exist.
+func TestSetParentLink_ConcurrentNHopNoCycle(t *testing.T) {
+	requirePostgresForConcurrency(t)
+
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+
+	const quads = 64
+	type quad struct{ a, b, c, d *models.Item }
+	qs := make([]quad, quads)
+	for i := range qs {
+		q := quad{
+			a: createTestItem(t, s, ws.ID, col.ID, fmt.Sprintf("A%d", i), ""),
+			b: createTestItem(t, s, ws.ID, col.ID, fmt.Sprintf("B%d", i), ""),
+			c: createTestItem(t, s, ws.ID, col.ID, fmt.Sprintf("C%d", i), ""),
+			d: createTestItem(t, s, ws.ID, col.ID, fmt.Sprintf("D%d", i), ""),
+		}
+		// Commit the two base chains BEFORE the race: A→B and C→D.
+		if _, err := s.SetParentLink(ws.ID, q.a.ID, q.b.ID, "user"); err != nil {
+			t.Fatalf("quad %d seed A→B: %v", i, err)
+		}
+		if _, err := s.SetParentLink(ws.ID, q.c.ID, q.d.ID, "user"); err != nil {
+			t.Fatalf("quad %d seed C→D: %v", i, err)
+		}
+		qs[i] = q
+	}
+
+	// One shared barrier so every closing-edge pair is released together,
+	// maximizing the odds the disjoint-lock adds actually interleave.
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := range qs {
+		q := qs[i]
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			<-start
+			// B's parent → C. A cycle rejection here is the EXPECTED loser outcome.
+			_, _ = s.SetParentLink(ws.ID, q.b.ID, q.c.ID, "user")
+		}()
+		go func() {
+			defer wg.Done()
+			<-start
+			// D's parent → A. Likewise, a rejection is acceptable.
+			_, _ = s.SetParentLink(ws.ID, q.d.ID, q.a.ID, "user")
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	var cycles int64
+	for i, q := range qs {
+		// Walk from every node in the quad — a cycle is reachable from any of them.
+		for _, item := range []*models.Item{q.a, q.b, q.c, q.d} {
+			if parentChainCycles(t, s, item.ID, 8) {
+				atomic.AddInt64(&cycles, 1)
+				t.Errorf("quad %d formed an N-hop parent cycle (reachable from %s)", i, item.ID)
+				break
+			}
+		}
+		// The two closing edges must never both exist (that IS the cycle).
+		bParent, err := s.GetParentForItem(q.b.ID)
+		if err != nil {
+			t.Fatalf("quad %d GetParentForItem(B): %v", i, err)
+		}
+		dParent, err := s.GetParentForItem(q.d.ID)
+		if err != nil {
+			t.Fatalf("quad %d GetParentForItem(D): %v", i, err)
+		}
+		bToC := bParent != nil && bParent.TargetID == q.c.ID
+		dToA := dParent != nil && dParent.TargetID == q.a.ID
+		if bToC && dToA {
+			t.Errorf("quad %d: both closing edges committed (B→C and D→A) — cycle", i)
+		}
+	}
+	if n := atomic.LoadInt64(&cycles); n > 0 {
+		t.Fatalf("%d/%d quads formed an N-hop parent cycle under concurrency (BUG-2074 not closed)", n, quads)
+	}
+}
+
+// TestCreateItemLink_ConcurrentNHopNoCycle covers the second parent-edge adder
+// (BUG-2074 / Codex round-1): CreateItemLink with link_type="parent" writes the
+// same graph edge SetParentLink does and is the only other path that can close
+// a cycle, yet it neither ran a cycle check nor joined the workspace cycle
+// serialization. Here the B→C closing edge is written via CreateItemLink(parent)
+// while D→A goes through SetParentLink — proving the two paths serialize on the
+// shared workspace cycle lock and CreateItemLink's own cycle check rejects the
+// loser, so A→B→C→D→A can't form across the two APIs.
+func TestCreateItemLink_ConcurrentNHopNoCycle(t *testing.T) {
+	requirePostgresForConcurrency(t)
+
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+
+	const quads = 64
+	type quad struct{ a, b, c, d *models.Item }
+	qs := make([]quad, quads)
+	for i := range qs {
+		q := quad{
+			a: createTestItem(t, s, ws.ID, col.ID, fmt.Sprintf("A%d", i), ""),
+			b: createTestItem(t, s, ws.ID, col.ID, fmt.Sprintf("B%d", i), ""),
+			c: createTestItem(t, s, ws.ID, col.ID, fmt.Sprintf("C%d", i), ""),
+			d: createTestItem(t, s, ws.ID, col.ID, fmt.Sprintf("D%d", i), ""),
+		}
+		if _, err := s.SetParentLink(ws.ID, q.a.ID, q.b.ID, "user"); err != nil {
+			t.Fatalf("quad %d seed A→B: %v", i, err)
+		}
+		if _, err := s.SetParentLink(ws.ID, q.c.ID, q.d.ID, "user"); err != nil {
+			t.Fatalf("quad %d seed C→D: %v", i, err)
+		}
+		qs[i] = q
+	}
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := range qs {
+		q := qs[i]
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			<-start
+			// B's parent → C, via the item-link API (link_type=parent).
+			_, _ = s.CreateItemLink(ws.ID, models.ItemLinkCreate{
+				TargetID: q.c.ID,
+				LinkType: models.ItemLinkTypeParent,
+			}, q.b.ID)
+		}()
+		go func() {
+			defer wg.Done()
+			<-start
+			// D's parent → A, via SetParentLink.
+			_, _ = s.SetParentLink(ws.ID, q.d.ID, q.a.ID, "user")
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	var cycles int64
+	for i, q := range qs {
+		for _, item := range []*models.Item{q.a, q.b, q.c, q.d} {
+			if parentChainCycles(t, s, item.ID, 8) {
+				atomic.AddInt64(&cycles, 1)
+				t.Errorf("quad %d formed an N-hop parent cycle (reachable from %s)", i, item.ID)
+				break
+			}
+		}
+	}
+	if n := atomic.LoadInt64(&cycles); n > 0 {
+		t.Fatalf("%d/%d quads formed an N-hop cycle across CreateItemLink+SetParentLink (BUG-2074 not closed)", n, quads)
+	}
+}
+
+// TestCreateItemLink_ParentSingleParentAndCycle asserts CreateItemLink with
+// link_type="parent" now behaves like SetParentLink (BUG-2074 / Codex round-2):
+// it enforces the single-parent invariant (DELETE-then-INSERT, not append) and
+// runs cycle detection. Both were absent before — CreateItemLink appended a raw
+// parent row with no cycle check, so a child could accumulate multiple parents
+// and the cycle walk (which follows one arbitrary parent per source) could miss
+// a cycle. Dialect-agnostic: the invariant holds on SQLite and Postgres alike.
+func TestCreateItemLink_ParentSingleParentAndCycle(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+
+	child := createTestItem(t, s, ws.ID, col.ID, "Child", "")
+	p1 := createTestItem(t, s, ws.ID, col.ID, "P1", "")
+	p2 := createTestItem(t, s, ws.ID, col.ID, "P2", "")
+
+	// First parent via CreateItemLink(parent).
+	if _, err := s.CreateItemLink(ws.ID, models.ItemLinkCreate{TargetID: p1.ID, LinkType: models.ItemLinkTypeParent}, child.ID); err != nil {
+		t.Fatalf("CreateItemLink child→p1: %v", err)
+	}
+	// Second parent via CreateItemLink(parent) must REPLACE, not append.
+	if _, err := s.CreateItemLink(ws.ID, models.ItemLinkCreate{TargetID: p2.ID, LinkType: models.ItemLinkTypeParent}, child.ID); err != nil {
+		t.Fatalf("CreateItemLink child→p2: %v", err)
+	}
+	if n := countParentLinks(t, s, child.ID); n != 1 {
+		t.Fatalf("child has %d parent links via CreateItemLink, want exactly 1 (single-parent invariant)", n)
+	}
+	link, err := s.GetParentForItem(child.ID)
+	if err != nil {
+		t.Fatalf("GetParentForItem(child): %v", err)
+	}
+	if link == nil || link.TargetID != p2.ID {
+		t.Fatalf("child's parent = %v, want p2 (latest wins)", link)
+	}
+
+	// Cycle rejection: child→p2 exists, so p2→child would close a 1-hop cycle.
+	if _, err := s.CreateItemLink(ws.ID, models.ItemLinkCreate{TargetID: child.ID, LinkType: models.ItemLinkTypeParent}, p2.ID); err == nil {
+		t.Fatal("CreateItemLink(p2→child) should have been rejected as a cycle, got nil error")
+	}
+}


### PR DESCRIPTION
## Summary

BUG-2073 (PR #870) closed the 1-hop A↔B parent-cycle race by folding the child key into a sorted per-endpoint lock batch. But that batch only covers the two endpoints of the edge being written, so an N-hop cycle closed via an edge on an item that **neither** endpoint locks still slipped past the per-endpoint `checkParentCycleQ` walk under concurrency (Postgres-only; SQLite serializes all writers via `BEGIN IMMEDIATE`).

**Concrete reproduction:** with `A→B` and `C→D` already committed, two concurrent adds `SetParentLink(B,C)` and `SetParentLink(D,A)` lock the **disjoint** sets `{B,C}` and `{D,A}`, so both cycle walks pass on stale snapshots and both inserts commit — forming `A→B→C→D→A`.

## Fix — workspace-level cycle guard

- **`acquireWorkspaceParentLinkLock`** — a Postgres advisory xact lock on a **distinct** namespace (`pad:parent-link-cycle:` || workspaceID) that serializes **all** parent-edge-adding transactions per workspace. With no two adds running concurrently, `checkParentCycleQ` always walks a consistent, non-racing ancestor snapshot and catches arbitrary N-hop cycles.
- Acquired **outermost** (before the seq lock and the per-item parent-children batch) in the edge-adding paths — `SetParentLink` and `UpdateItemWithParentLink` (only when it actually adds a parent). Global order is `cycle → seq → parent-children` in every transaction that takes them, so no AB/BA inversion can form. **Deadlock-free.**
- **`CreateItemLink` was a second, unguarded parent-edge adder:** `link_type="parent"` appended a raw row with no cycle check and no workspace lock — it could form cycles even single-threaded and give a child multiple parent rows (the schema only uniques `(source_id,target_id,link_type)`), which the single-chain cycle walk can't see. It now routes `parent` links through `SetParentLink`, inheriting the full guarded protocol (single-parent DELETE-then-INSERT, workspace cycle lock, cycle check, retry). Non-parent link types keep the append-only insert — none are followed by the cycle walk.
- **Scope is edge-adders only.** Removals and plain field/status updates can't create a cycle and don't take the lock, so the common `UpdateItem` path stays un-serialized. BUG-2073's per-endpoint locks remain (they still bound the open-children re-read invariant); the workspace lock is the outer guard.
- **Rejected alternative** (locking the full ancestor chain per write): complex, deadlock-prone under concurrent reparents, hard to keep in canonical sorted order.

## Tests (Postgres-gated where concurrent)

- `TestSetParentLink_ConcurrentNHopNoCycle` + `TestCreateItemLink_ConcurrentNHopNoCycle` — build the disjoint-lock `A→B→C→D→A` quad via parallel goroutines and assert no cycle forms. Both verified to **reproduce** the bug with the guard disabled (6/64 and 14/64 quads cycle) and **pass** with it.
- `TestCreateItemLink_ParentSingleParentAndCycle` (dialect-agnostic) — asserts `CreateItemLink(parent)` now enforces single-parent (latest wins) and rejects a direct cycle.

## Gates

`~/go/bin/golangci-lint run` (0 issues), `go test ./...`, and the full Postgres suite (`make test-pg` equivalent) all green. Two rounds of Codex review addressed (CreateItemLink hole → cycle check + delegation); final review CLEAN.

https://claude.ai/code/session_019knGmnHcx5rrgWXQ8V8DZS