### PR TITLE
refactor(mcp): make pad_plan/ideate/retro prompt bodies surface-neutral (TASK-2016)

### DIFF
--- a/internal/mcp/prompts_data.go
+++ b/internal/mcp/prompts_data.go
@@ -12,18 +12,12 @@ package mcp
 
 const promptPlanBody = `# Pad: Plan workflow
 
-You are helping the user create and decompose a Plan in their pad workspace.
+You are helping the user create and decompose a Plan in their pad workspace. Use your MCP tools — no shell required. (CLI-capable agents can run the parenthetical ` + "`pad`" + ` commands instead.)
 
-1. **Load context.** Run ` + "`pad project dashboard --format json`" + ` and ` + "`pad item list plans --all --format json`" + `. Understand current state — what plans exist, what's active, what's completed.
+1. **Load context.** Call ` + "`pad_project`" + ` with ` + "`action: dashboard`" + ` (CLI: ` + "`pad project dashboard`" + `) and ` + "`pad_item`" + ` with ` + "`action: list`" + `, ` + "`collection: plans`" + ` (CLI: ` + "`pad item list plans --all`" + `). Understand current state — what plans exist, what's active, what's completed.
 2. **Propose an outline.** Present a plan title plus a 1-line summary. Ask for feedback before writing anything.
-3. **Create the plan** when approved:
-   ` + "```bash" + `
-   pad item create plan "Plan N: Title" --status draft --content "<plan content>"
-   ` + "```" + `
-4. **Decompose into tasks.** For each actionable unit, propose a Task; create it linked to the plan:
-   ` + "```bash" + `
-   pad item create task "Task description" --parent PLAN-3 --priority medium
-   ` + "```" + `
+3. **Create the plan** when approved: call ` + "`pad_item`" + ` with ` + "`action: create`" + `, ` + "`collection: plans`" + `, ` + "`title: \"Plan N: Title\"`" + `, ` + "`status: draft`" + `, and the plan content (CLI: ` + "`pad item create plan \"Plan N: Title\" --status draft --content \"<plan content>\"`" + `).
+4. **Decompose into tasks.** For each actionable unit, propose a Task; create it linked to the plan — call ` + "`pad_item`" + ` with ` + "`action: create`" + `, ` + "`collection: tasks`" + `, ` + "`title: \"Task description\"`" + `, ` + "`parent: PLAN-3`" + `, ` + "`priority: medium`" + ` (CLI: ` + "`pad item create task \"Task description\" --parent PLAN-3 --priority medium`" + `).
 5. **Suggest role assignments** if the workspace has agent roles ("This looks like Implementer work — assign to Implementer?").
 6. **Size each task for a single meaningful unit of work.** Software workspaces typically size tasks to one branch / one PR; other domains size them to one deliverable, one interview loop, one draft section, etc. Check the workspace's conventions for domain-specific sizing rules.
 7. **Always ask before creating each item.** Don't bulk-create without approval.
@@ -31,29 +25,29 @@ You are helping the user create and decompose a Plan in their pad workspace.
 
 const promptIdeateBody = `# Pad: Ideate workflow
 
-You are helping the user brainstorm an idea in their pad workspace.
+You are helping the user brainstorm an idea in their pad workspace. Use your MCP tools — no shell required. (CLI-capable agents can run the parenthetical ` + "`pad`" + ` commands instead.)
 
-1. **Load context.** Run ` + "`pad project dashboard --format json`" + ` and ` + "`pad item list --format json --limit 20`" + `.
-2. **Search for related items:** ` + "`pad item search \"X\" --format json`" + `.
+1. **Load context.** Call ` + "`pad_project`" + ` with ` + "`action: dashboard`" + ` (CLI: ` + "`pad project dashboard`" + `) and ` + "`pad_item`" + ` with ` + "`action: list`" + `, ` + "`limit: 20`" + ` (CLI: ` + "`pad item list --limit 20`" + `).
+2. **Search for related items.** Call ` + "`pad_search`" + ` with ` + "`action: query`" + `, ` + "`query: \"X\"`" + ` (CLI: ` + "`pad item search \"X\"`" + `).
 3. **Discuss systematically.** Ask clarifying questions, explore trade-offs, reference existing items with [[Title]] links to keep cross-links intact.
 4. **Offer to save** at natural checkpoints. Examples:
-   - "Want me to save this as an Idea?" → ` + "`pad item create idea \"X\" --content \"...\"`" + `
-   - "Should I create a Doc for this architecture decision?" → ` + "`pad item create doc \"X\" --category decision --content \"...\"`" + `
+   - "Want me to save this as an Idea?" → call ` + "`pad_item`" + ` with ` + "`action: create`" + `, ` + "`collection: ideas`" + `, ` + "`title: \"X\"`" + `, ` + "`content: \"...\"`" + ` (CLI: ` + "`pad item create idea \"X\" --content \"...\"`" + `).
+   - "Should I create a Doc for this architecture decision?" → call ` + "`pad_item`" + ` with ` + "`action: create`" + `, ` + "`collection: docs`" + `, ` + "`title: \"X\"`" + `, ` + "`category: decision`" + `, ` + "`content: \"...\"`" + ` (CLI: ` + "`pad item create doc \"X\" --category decision --content \"...\"`" + `).
 5. **Never save without asking.** Always show what you'll create and get confirmation first.
 `
 
 const promptRetroBody = `# Pad: Retrospective workflow
 
-You are helping the user run a retrospective on a completed Plan.
+You are helping the user run a retrospective on a completed Plan. Use your MCP tools — no shell required. (CLI-capable agents can run the parenthetical ` + "`pad`" + ` commands instead.)
 
-1. **Load the plan:** ` + "`pad item show PLAN-N --format markdown`" + `.
-2. **Load the tasks:** ` + "`pad item list tasks --all --format json`" + ` (filter to the plan).
+1. **Load the plan.** Call ` + "`pad_item`" + ` with ` + "`action: get`" + `, ` + "`ref: PLAN-N`" + ` (CLI: ` + "`pad item show PLAN-N --format markdown`" + `).
+2. **Load the tasks.** Call ` + "`pad_item`" + ` with ` + "`action: list`" + `, ` + "`collection: tasks`" + ` (CLI: ` + "`pad item list tasks --all`" + `), then filter to the plan.
 3. **Generate the retro:**
    - What shipped: completed tasks + impact.
    - What was deferred: tasks not done + why.
    - Lessons learned: themes from the run.
-4. **Offer to save:** ` + "`pad item create doc \"Plan N Retrospective\" --category retro --content \"...\"`" + `.
-5. **Offer to close the plan:** ` + "`pad item update PLAN-N --status completed`" + `.
+4. **Offer to save.** Call ` + "`pad_item`" + ` with ` + "`action: create`" + `, ` + "`collection: docs`" + `, ` + "`title: \"Plan N Retrospective\"`" + `, ` + "`category: retro`" + `, ` + "`content: \"...\"`" + ` (CLI: ` + "`pad item create doc \"Plan N Retrospective\" --category retro --content \"...\"`" + `).
+5. **Offer to close the plan.** Call ` + "`pad_item`" + ` with ` + "`action: update`" + `, ` + "`ref: PLAN-N`" + `, ` + "`status: completed`" + ` (CLI: ` + "`pad item update PLAN-N --status completed`" + `).
 
 Always confirm before creating or mutating items.
 `

--- a/internal/mcp/prompts_test.go
+++ b/internal/mcp/prompts_test.go
@@ -92,6 +92,23 @@ func TestPromptsLockstep_CoreCommands(t *testing.T) {
 	}
 }
 
+// TestPromptsLockstep_NoBashBlocks asserts every prompt body is
+// surface-neutral (TASK-2016): no ```bash fenced code blocks, which
+// instruct shell-less MCP clients to run commands they can't. The
+// bodies name the pad_* tool + action and carry the CLI form only as
+// a parenthetical.
+func TestPromptsLockstep_NoBashBlocks(t *testing.T) {
+	for _, name := range []string{PromptPlan, PromptIdeate, PromptRetro, PromptOnboard} {
+		body, err := PromptBody(name)
+		if err != nil {
+			t.Fatalf("PromptBody(%q): %v", name, err)
+		}
+		if strings.Contains(body, "```bash") {
+			t.Errorf("%s body contains a ```bash code block; prompt bodies must be surface-neutral (name the pad_* tool + action, CLI as a parenthetical)", name)
+		}
+	}
+}
+
 // TestPromptsLockstep_SkillSourceExists is the inverse check — fail
 // if SKILL.md has been removed/renamed under our feet, so the next
 // person updating prompts notices the source moved.


### PR DESCRIPTION
## What

Rewrites the three multi-step MCP prompt bodies (`pad_plan`, `pad_ideate`, `pad_retro`) in the surface-neutral style `promptOnboardBody` already uses: each step names the `pad_*` tool + action and carries the CLI form as a parenthetical, instead of embedding ```bash code blocks that instruct shell-less MCP clients to run CLI commands they can't execute.

## Why

The old bodies told MCP-only agents to `Run` bash CLI commands — dead instructions for any client without a shell. `pad_onboard` was already surface-neutral; this brings the other three into line.

## Changes

- `internal/mcp/prompts_data.go` — rewrite `promptPlanBody`, `promptIdeateBody`, `promptRetroBody`. Tool+action forms include required `title`/`content` fields so MCP-only clients don't emit invalid/empty-item calls (per Codex review parity). CLI fragments preserved in parentheticals.
- `internal/mcp/prompts_test.go` — add `TestPromptsLockstep_NoBashBlocks` asserting no ```bash blocks in any prompt body.

Content-only: no prompt name/count/param changes, so `ToolSurfaceVersion` is unchanged.

## Testing

- `go test ./...` green
- `golangci-lint run` — 0 issues
- `go build ./cmd/pad` OK
- Codex review: CLEAN

https://claude.ai/code/session_019knGmnHcx5rrgWXQ8V8DZS