### PR TITLE
fix(web): render SSE connection-status indicator (TASK-2027)

### DIFF
--- a/web/src/lib/components/SSEStatusIndicator.svelte
+++ b/web/src/lib/components/SSEStatusIndicator.svelte
@@ -1,0 +1,99 @@
+<script lang="ts">
+	import { sseService, type SSEStatus } from '$lib/services/sse.svelte';
+
+	// Small live/reconnecting/offline indicator for the realtime board.
+	// Reads the existing SSE connection state (sseService.status) — it was
+	// already computed for the event stream but never surfaced, so a stale
+	// board gave no hint the stream was down (PLAN-1984 / TASK-2027).
+	// Colour + dot idiom mirrors the collab-state badge on the item page.
+
+	const status = $derived(sseService.status as SSEStatus);
+
+	const label = $derived(
+		{
+			connected: 'Live',
+			reconnecting: 'Reconnecting…',
+			disconnected: 'Offline',
+			unauthorized: 'Disconnected'
+		}[status]
+	);
+
+	const title = $derived(
+		{
+			connected: 'Real-time updates are live. The board reflects changes as they happen.',
+			reconnecting: 'Connection dropped. Trying to reconnect… The board may be out of date.',
+			disconnected: 'Not connected to the live update stream. The board may be out of date.',
+			unauthorized:
+				'Live updates stopped — this session lost access to the workspace. Reload to reconnect.'
+		}[status]
+	);
+</script>
+
+<span
+	class="sse-state sse-state-{status}"
+	title={title}
+	role="status"
+	aria-label={`Live updates: ${label}`}
+>
+	<span class="sse-state-dot" aria-hidden="true"></span>
+	<span class="sse-state-label">{label}</span>
+</span>
+
+<style>
+	.sse-state {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.35em;
+		font-size: 0.8em;
+		color: var(--text-muted);
+		white-space: nowrap;
+	}
+	.sse-state-dot {
+		width: 0.5em;
+		height: 0.5em;
+		border-radius: 50%;
+		background: var(--text-muted);
+		flex-shrink: 0;
+	}
+
+	/* Connected stays deliberately subtle — muted label, quiet green dot. */
+	.sse-state-connected {
+		color: var(--text-muted);
+	}
+	.sse-state-connected .sse-state-dot {
+		background: var(--accent-green, #2e9e5b);
+	}
+
+	.sse-state-reconnecting {
+		color: var(--accent-yellow, #d4a017);
+	}
+	.sse-state-reconnecting .sse-state-dot {
+		background: var(--accent-yellow, #d4a017);
+		animation: sse-pulse 1.2s ease-in-out infinite;
+	}
+
+	.sse-state-disconnected,
+	.sse-state-unauthorized {
+		color: var(--accent-red, #c0392b);
+	}
+	.sse-state-disconnected .sse-state-dot,
+	.sse-state-unauthorized .sse-state-dot {
+		background: var(--accent-red, #c0392b);
+	}
+
+	@keyframes sse-pulse {
+		0%,
+		100% {
+			opacity: 1;
+		}
+		50% {
+			opacity: 0.3;
+		}
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.sse-state-reconnecting .sse-state-dot {
+			animation: none;
+		}
+	}
+</style>

--- a/web/src/lib/services/sse.svelte.ts
+++ b/web/src/lib/services/sse.svelte.ts
@@ -46,7 +46,14 @@ const ITEM_EVENTS = [
 type BCEnvelope =
 	| { type: 'item_event'; event: ItemEvent }
 	| { type: 'sync_required' }
-	| { type: 'status'; status: SSEStatus };
+	| { type: 'status'; status: SSEStatus }
+	// A newly-joined tab asks the current leader for its live status.
+	// BroadcastChannel doesn't replay the leader's earlier `status`
+	// message, so without this handshake a follower that opens after
+	// the leader already connected would sit on its initial
+	// `disconnected` value forever — surfacing as a bogus "Offline"
+	// indicator while it's actually receiving live updates (TASK-2027).
+	| { type: 'status_request' };
 
 function createSSEService() {
 	let status = $state<SSEStatus>('disconnected');
@@ -129,8 +136,22 @@ function createSSEService() {
 				// indicators don't show "disconnected" while the
 				// leader is happily streaming.
 				status = env.status;
+			} else if (env.type === 'status_request') {
+				// A tab just joined and asked for the current status.
+				// Only the leader holds the authoritative EventSource
+				// status, so only the leader answers — reply with our
+				// live value so the follower initializes correctly
+				// instead of sitting on its stale `disconnected`
+				// default (TASK-2027).
+				if (isLeader) {
+					broadcast({ type: 'status', status });
+				}
 			}
 		};
+		// Ask any existing leader for its current status. If we're the
+		// first/only tab (no leader yet) nobody answers and our own
+		// EventSource's `onopen` will set the status shortly — no harm.
+		broadcast({ type: 'status_request' });
 	}
 
 	// `pendingSyncOnConnect` defers a `sync_required` dispatch until

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -10,6 +10,7 @@
 	import FilterBar from '$lib/components/collections/FilterBar.svelte';
 	import QuickActionsMenu from '$lib/components/common/QuickActionsMenu.svelte';
 	import BottomSheet from '$lib/components/common/BottomSheet.svelte';
+	import SSEStatusIndicator from '$lib/components/SSEStatusIndicator.svelte';
 	import { onDestroy, onMount } from 'svelte';
 	import { sseService } from '$lib/services/sse.svelte';
 	import { syncService } from '$lib/services/sync.svelte';
@@ -1744,11 +1745,18 @@
 		<!-- Header -->
 		<div class="page-header">
 			<div class="title-row">
-				<h1>
-					{#if collection.icon}<span class="collection-icon">{collection.icon}</span>{/if}
-					{collection.name}
-					<span class="item-count">{items.length}</span>
-				</h1>
+				<div class="title-group">
+					<h1>
+						{#if collection.icon}<span class="collection-icon">{collection.icon}</span>{/if}
+						{collection.name}
+						<span class="item-count">{items.length}</span>
+					</h1>
+
+					<!-- Realtime stream status (PLAN-1984 / TASK-2027): surfaces the
+					     already-computed SSE connection state so a stale board hints
+					     when live updates are down or unauthorized. -->
+					<SSEStatusIndicator />
+				</div>
 
 				<div class="header-actions">
 					{#if isMobile}
@@ -2360,6 +2368,14 @@
 		gap: var(--space-4);
 		margin-bottom: var(--space-3);
 		flex-wrap: wrap;
+	}
+
+	.title-group {
+		display: flex;
+		align-items: center;
+		gap: var(--space-3);
+		flex-wrap: wrap;
+		min-width: 0;
 	}
 
 	h1 {


### PR DESCRIPTION
## What

From the PLAN-1984 Web-UX audit: the SSE connection status was already computed in `sseService` but never rendered, so a stale board gave no hint the realtime stream was down or unauthorized.

This renders a small, unobtrusive live/reconnecting/offline indicator on the collection board view, wired off the **existing** `sseService.status` state (no new polling / no new connection layer).

## Changes

- **New** `web/src/lib/components/SSEStatusIndicator.svelte` — dot + label badge reading `sseService.status`. Reuses the visual idiom of the item page's collab-state badge:
  - `connected` → subtle "Live" (muted label, quiet green dot)
  - `reconnecting` → yellow "Reconnecting…" (pulsing dot; respects `prefers-reduced-motion`)
  - `disconnected` → red "Offline"
  - `unauthorized` → red "Disconnected" (session lost workspace access)
- **`[collection]/+page.svelte`** — renders the indicator in the header title-row (wrapped h1 + indicator in a `.title-group` so `space-between` layout stays clean).
- **`sse.svelte.ts`** — added a one-shot `status_request` BroadcastChannel handshake so a follower tab that opens *after* the leader already connected initializes its status correctly (BroadcastChannel doesn't replay the leader's earlier `status` message; without this a peer tab receiving live updates would wrongly show "Offline"). Found in Codex review.

## Test plan

- `cd web && npm run check` — 0 errors on touched files.
- `cd web && npm run build` — succeeds.
- Codex review: CLEAN.
- Manual: open a collection board; indicator shows "Live". Kill the server → "Reconnecting…" then "Offline". Open a second tab while connected → follower initializes to "Live" via the handshake.

Refs TASK-2027, PLAN-1984.