### PR TITLE
feat(web): 429/Retry-After handling in API client (TASK-2026)

### DIFF
--- a/web/src/lib/api/client.test.ts
+++ b/web/src/lib/api/client.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { api } from './client';
+import { api, parseRetryAfterMs, isRateLimitError, PadApiError } from './client';
 
 // The 401 interceptor branches on `typeof window !== 'undefined'`. The
 // vitest environment here is 'node' (see vitest.config.ts), so `window` is
@@ -93,5 +93,125 @@ describe('api client 401 handling (BUG-1929)', () => {
 			message: 'Authentication required',
 		});
 		expect(win.location.href).toBe('');
+	});
+});
+
+// ── 429 / Retry-After handling (TASK-2026) ──────────────────────────────────
+
+/**
+ * Fetch mock that returns a scripted sequence of responses. Each entry is
+ * `{ status, body, retryAfter? }`; the last entry repeats for any calls
+ * beyond the script length. Responses carry a minimal `headers.get` so the
+ * client's `Retry-After` lookup works.
+ */
+function mockFetchSequence(responses: { status: number; body: unknown; retryAfter?: string }[]) {
+	let i = 0;
+	const fetchMock = vi.fn(async () => {
+		const r = responses[Math.min(i, responses.length - 1)];
+		i += 1;
+		return {
+			status: r.status,
+			ok: r.status >= 200 && r.status < 300,
+			headers: {
+				get: (name: string) =>
+					name.toLowerCase() === 'retry-after' ? (r.retryAfter ?? null) : null,
+			},
+			json: async () => r.body,
+		};
+	});
+	vi.stubGlobal('fetch', fetchMock);
+	return fetchMock;
+}
+
+describe('parseRetryAfterMs (TASK-2026)', () => {
+	it('parses the delta-seconds form to milliseconds', () => {
+		expect(parseRetryAfterMs('3')).toBe(3000);
+		expect(parseRetryAfterMs('0')).toBe(0);
+	});
+
+	it('clamps a huge Retry-After to the 5s ceiling so the UI cannot hang', () => {
+		expect(parseRetryAfterMs('86400')).toBe(5000);
+	});
+
+	it('parses the HTTP-date form as a clamped future delta', () => {
+		const future = new Date(Date.now() + 2000).toUTCString();
+		const ms = parseRetryAfterMs(future);
+		expect(ms).not.toBeNull();
+		// ~2s out, clamped to <= 5s; allow scheduling slack.
+		expect(ms!).toBeGreaterThan(500);
+		expect(ms!).toBeLessThanOrEqual(5000);
+	});
+
+	it('returns 0 for a past HTTP-date', () => {
+		const past = new Date(Date.now() - 60_000).toUTCString();
+		expect(parseRetryAfterMs(past)).toBe(0);
+	});
+
+	it('returns null for a missing / empty / garbage header', () => {
+		expect(parseRetryAfterMs(null)).toBeNull();
+		expect(parseRetryAfterMs(undefined)).toBeNull();
+		expect(parseRetryAfterMs('')).toBeNull();
+		expect(parseRetryAfterMs('   ')).toBeNull();
+		expect(parseRetryAfterMs('soon')).toBeNull();
+	});
+});
+
+describe('api client 429 handling (TASK-2026)', () => {
+	beforeEach(() => {
+		vi.unstubAllGlobals();
+	});
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('retries an idempotent GET exactly once after a 429, then returns the retry payload', async () => {
+		const fetchMock = mockFetchSequence([
+			{ status: 429, body: { error: { code: 'rate_limited' } }, retryAfter: '0' },
+			{ status: 200, body: [{ id: 'w1' }] },
+		]);
+
+		const result = await api.workspaces.list();
+		expect(result).toEqual([{ id: 'w1' }]);
+		// One original call + one retry.
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+	});
+
+	it('surfaces a distinct rate_limited error when the GET retry also 429s', async () => {
+		const fetchMock = mockFetchSequence([
+			{ status: 429, body: { error: { code: 'rate_limited' } }, retryAfter: '0' },
+			{ status: 429, body: { error: { code: 'rate_limited' } }, retryAfter: '0' },
+		]);
+
+		const err = await api.workspaces.list().catch((e) => e);
+		expect(isRateLimitError(err)).toBe(true);
+		expect(err).toBeInstanceOf(PadApiError);
+		expect((err as PadApiError).code).toBe('rate_limited');
+		// Original + a single retry — never more.
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+	});
+
+	it('does NOT retry a non-idempotent POST on 429 (avoids duplicate writes)', async () => {
+		const fetchMock = mockFetchSequence([
+			{ status: 429, body: { error: { code: 'rate_limited' } }, retryAfter: '0' },
+			{ status: 200, body: { id: 'w2' } },
+		]);
+
+		const err = await api.workspaces
+			.create({ name: 'X' } as unknown as Parameters<typeof api.workspaces.create>[0])
+			.catch((e) => e);
+		expect(isRateLimitError(err)).toBe(true);
+		// Exactly one call: the POST was never retried.
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
+	it('carries the parsed Retry-After delay on the rate_limited error', async () => {
+		mockFetchSequence([
+			{ status: 429, body: { error: { code: 'rate_limited' } }, retryAfter: '0' },
+			{ status: 429, body: { error: { code: 'rate_limited' } }, retryAfter: '2' },
+		]);
+
+		const err = (await api.workspaces.list().catch((e) => e)) as PadApiError;
+		expect(err.code).toBe('rate_limited');
+		expect(err.retryAfterMs).toBe(2000);
 	});
 });

--- a/web/src/lib/api/client.test.ts
+++ b/web/src/lib/api/client.test.ts
@@ -164,6 +164,32 @@ describe('api client 429 handling (TASK-2026)', () => {
 		vi.unstubAllGlobals();
 	});
 
+	it('arms a global cooldown so a follow-up GET waits out the last Retry-After instead of bursting (Codex P1)', async () => {
+		vi.useFakeTimers();
+		try {
+			// First chain: a GET that 429s on both the original and its one
+			// retry (Retry-After: 1s), exhausting the retry and arming the
+			// cooldown ~1s out.
+			mockFetchSequence([
+				{ status: 429, body: { error: { code: 'rate_limited' } }, retryAfter: '1' },
+			]);
+			const p1 = api.workspaces.list().catch((e) => e);
+			await vi.advanceTimersByTimeAsync(1000); // resolve the internal retry sleep
+			expect(isRateLimitError(await p1)).toBe(true);
+
+			// Second chain: an INDEPENDENT follow-up GET. It must sit in the
+			// cooldown sleep — no network call — until the window elapses.
+			const fetchMock2 = mockFetchSequence([{ status: 200, body: [] }]);
+			const p2 = api.workspaces.list();
+			expect(fetchMock2).toHaveBeenCalledTimes(0);
+			await vi.advanceTimersByTimeAsync(1000);
+			await p2;
+			expect(fetchMock2).toHaveBeenCalledTimes(1);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
 	it('retries an idempotent GET exactly once after a 429, then returns the retry payload', async () => {
 		const fetchMock = mockFetchSequence([
 			{ status: 429, body: { error: { code: 'rate_limited' } }, retryAfter: '0' },

--- a/web/src/lib/api/client.test.ts
+++ b/web/src/lib/api/client.test.ts
@@ -166,6 +166,10 @@ describe('api client 429 handling (TASK-2026)', () => {
 
 	it('arms a global cooldown so a follow-up GET waits out the last Retry-After instead of bursting (Codex P1)', async () => {
 		vi.useFakeTimers();
+		// Anchor the clock at epoch 0 so the cooldown this test arms is a
+		// small number that is safely in the past once real timers resume —
+		// no module-level cooldown leaks into later tests.
+		vi.setSystemTime(0);
 		try {
 			// First chain: a GET that 429s on both the original and its one
 			// retry (Retry-After: 1s), exhausting the retry and arming the

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -118,15 +118,29 @@ const MAX_RETRY_AFTER_MS = 5_000;
 // header, so the one automatic GET retry still spaces itself out.
 const DEFAULT_RETRY_BACKOFF_MS = 750;
 
-// Global soft cooldown (epoch ms). When a request exhausts its retry and
-// still gets a 429, we record `now + Retry-After` here. Subsequent
-// idempotent GET/HEAD requests wait out the remaining window (bounded by
-// MAX_RETRY_AFTER_MS) before firing, so INDEPENDENT call sites don't burst
-// a busy server — e.g. localIndex.bootstrap's reconcile 429s, then the
+// Global soft cooldown (epoch ms). Every observed 429 pushes this forward
+// to `now + Retry-After` (never backward — see `armRateLimitCooldown`).
+// Before firing an idempotent GET/HEAD we wait out the remaining window
+// (bounded by MAX_RETRY_AFTER_MS) so INDEPENDENT call sites don't burst a
+// busy server — e.g. localIndex.bootstrap's reconcile 429s, then the
 // collection page immediately fires a follow-up deltaSync (Codex P1 on the
-// first cut of TASK-2026). Cleared on the next successful response so a
-// recovered server stops the cooldown early. Zero = no cooldown active.
+// first cut of TASK-2026). We deliberately do NOT clear this on a
+// successful response: a success from an unrelated request that was already
+// in flight when the 429 landed is not evidence the rate limit lifted
+// (Codex round 2). The cooldown simply expires by wall-clock. Zero = no
+// cooldown active.
 let rateLimitedUntil = 0;
+
+/**
+ * Push the global rate-limit cooldown out to `now + backoffMs`, never
+ * pulling it in. Called on EVERY 429 (including the one that then triggers
+ * the single automatic retry) so a concurrent request started during the
+ * retry's own backoff sleep still sees the cooldown. TASK-2026.
+ */
+function armRateLimitCooldown(backoffMs: number): void {
+	const until = Date.now() + backoffMs;
+	if (until > rateLimitedUntil) rateLimitedUntil = until;
+}
 
 function clampRetryMs(ms: number): number {
 	if (!Number.isFinite(ms) || ms < 0) return 0;
@@ -368,12 +382,19 @@ async function request<T>(
 	// off, wait out the remaining window before firing another idempotent
 	// request so independent call sites don't hammer a busy server. The
 	// internal single-retry (`rateLimitRetried`) already slept, so it
-	// skips this. Bounded by MAX_RETRY_AFTER_MS. Non-idempotent writes are
-	// never delayed here — they don't auto-retry and shouldn't be silently
-	// stalled by an unrelated GET's cooldown.
+	// skips this. Non-idempotent writes are never delayed here — they
+	// don't auto-retry and shouldn't be silently stalled by an unrelated
+	// GET's cooldown. The loop re-reads the deadline after each nap so a
+	// cooldown EXTENDED by another 429 mid-sleep is honored (Codex round
+	// 2 P2), but the total wait is capped at MAX_RETRY_AFTER_MS so a
+	// sustained 429 storm can't stall a single request indefinitely.
 	if (isIdempotent && !rateLimitRetried) {
-		const wait = rateLimitedUntil - Date.now();
-		if (wait > 0) await sleep(Math.min(wait, MAX_RETRY_AFTER_MS));
+		const waitStart = Date.now();
+		let remaining = rateLimitedUntil - Date.now();
+		while (remaining > 0 && Date.now() - waitStart < MAX_RETRY_AFTER_MS) {
+			await sleep(Math.min(remaining, MAX_RETRY_AFTER_MS - (Date.now() - waitStart)));
+			remaining = rateLimitedUntil - Date.now();
+		}
 	}
 
 	const resp = await fetch(BASE + path, {
@@ -437,16 +458,17 @@ async function request<T>(
 		// than a generic failure.
 		const retryAfterMs = parseRetryAfterMs(resp.headers?.get('Retry-After'));
 		const backoffMs = retryAfterMs ?? DEFAULT_RETRY_BACKOFF_MS;
+		// Arm the global cooldown on EVERY 429 — including this one that we
+		// may be about to retry — so a concurrent idempotent request that
+		// started during the retry's own backoff sleep also backs off
+		// instead of immediately re-hitting the busy server (Codex round 2 P1).
+		armRateLimitCooldown(backoffMs);
 		// Only GET/HEAD auto-retry — retrying a POST/PATCH/DELETE could
 		// duplicate a write the server may have already partially applied.
 		if (isIdempotent && !rateLimitRetried) {
 			await sleep(backoffMs);
 			return request<T>(path, options, true);
 		}
-		// Retry exhausted (or non-idempotent): arm the global cooldown so
-		// other/subsequent idempotent calls back off for the same window
-		// instead of immediately re-hitting the busy server.
-		rateLimitedUntil = Date.now() + backoffMs;
 		// Prefer the server's structured error envelope if present, but
 		// force the distinct `rate_limited` code + a clear message so UI
 		// can branch on it regardless of what the proxy/server sent.
@@ -464,9 +486,6 @@ async function request<T>(
 		if (body?.error) throw new PadApiError(body.error);
 		throw new Error(`API error: ${resp.status}`);
 	}
-	// A successful response means the server is serving again — drop any
-	// active rate-limit cooldown so we don't keep delaying GETs (TASK-2026).
-	rateLimitedUntil = 0;
 	if (resp.status === 204) return undefined as T;
 	return resp.json();
 }

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -118,6 +118,16 @@ const MAX_RETRY_AFTER_MS = 5_000;
 // header, so the one automatic GET retry still spaces itself out.
 const DEFAULT_RETRY_BACKOFF_MS = 750;
 
+// Global soft cooldown (epoch ms). When a request exhausts its retry and
+// still gets a 429, we record `now + Retry-After` here. Subsequent
+// idempotent GET/HEAD requests wait out the remaining window (bounded by
+// MAX_RETRY_AFTER_MS) before firing, so INDEPENDENT call sites don't burst
+// a busy server — e.g. localIndex.bootstrap's reconcile 429s, then the
+// collection page immediately fires a follow-up deltaSync (Codex P1 on the
+// first cut of TASK-2026). Cleared on the next successful response so a
+// recovered server stops the cooldown early. Zero = no cooldown active.
+let rateLimitedUntil = 0;
+
 function clampRetryMs(ms: number): number {
 	if (!Number.isFinite(ms) || ms < 0) return 0;
 	return Math.min(ms, MAX_RETRY_AFTER_MS);
@@ -348,9 +358,22 @@ async function request<T>(
 
 	// Attach CSRF token for state-changing requests
 	const method = options?.method?.toUpperCase();
+	const isIdempotent = method === undefined || method === 'GET' || method === 'HEAD';
 	if (method && method !== 'GET' && method !== 'HEAD') {
 		const csrf = getCSRFToken();
 		if (csrf) headers['X-CSRF-Token'] = csrf;
+	}
+
+	// Rate-limit cooldown (TASK-2026). If a recent 429 asked us to back
+	// off, wait out the remaining window before firing another idempotent
+	// request so independent call sites don't hammer a busy server. The
+	// internal single-retry (`rateLimitRetried`) already slept, so it
+	// skips this. Bounded by MAX_RETRY_AFTER_MS. Non-idempotent writes are
+	// never delayed here — they don't auto-retry and shouldn't be silently
+	// stalled by an unrelated GET's cooldown.
+	if (isIdempotent && !rateLimitRetried) {
+		const wait = rateLimitedUntil - Date.now();
+		if (wait > 0) await sleep(Math.min(wait, MAX_RETRY_AFTER_MS));
 	}
 
 	const resp = await fetch(BASE + path, {
@@ -413,13 +436,17 @@ async function request<T>(
 		// `rate_limited` error so callers can show "server busy" rather
 		// than a generic failure.
 		const retryAfterMs = parseRetryAfterMs(resp.headers?.get('Retry-After'));
-		const isIdempotent = method === undefined || method === 'GET' || method === 'HEAD';
+		const backoffMs = retryAfterMs ?? DEFAULT_RETRY_BACKOFF_MS;
 		// Only GET/HEAD auto-retry — retrying a POST/PATCH/DELETE could
 		// duplicate a write the server may have already partially applied.
 		if (isIdempotent && !rateLimitRetried) {
-			await sleep(retryAfterMs ?? DEFAULT_RETRY_BACKOFF_MS);
+			await sleep(backoffMs);
 			return request<T>(path, options, true);
 		}
+		// Retry exhausted (or non-idempotent): arm the global cooldown so
+		// other/subsequent idempotent calls back off for the same window
+		// instead of immediately re-hitting the busy server.
+		rateLimitedUntil = Date.now() + backoffMs;
 		// Prefer the server's structured error envelope if present, but
 		// force the distinct `rate_limited` code + a clear message so UI
 		// can branch on it regardless of what the proxy/server sent.
@@ -437,6 +464,9 @@ async function request<T>(
 		if (body?.error) throw new PadApiError(body.error);
 		throw new Error(`API error: ${resp.status}`);
 	}
+	// A successful response means the server is serving again — drop any
+	// active rate-limit cooldown so we don't keep delaying GETs (TASK-2026).
+	rateLimitedUntil = 0;
 	if (resp.status === 204) return undefined as T;
 	return resp.json();
 }

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -88,11 +88,76 @@ class PadApiError extends Error {
 	 *   { feature: string, limit: number, current: number, plan: string, upgrade_url: string }
 	 */
 	details?: Record<string, unknown>;
+	/**
+	 * Milliseconds the client waited (or would have waited) before a
+	 * retry, derived from the 429 `Retry-After` header. Only set on
+	 * `code === 'rate_limited'` errors (TASK-2026); undefined otherwise.
+	 * Lets a caller/UI say "try again in ~Ns" instead of a bare toast.
+	 */
+	retryAfterMs?: number;
 	constructor(err: ApiError) {
 		super(err.message);
 		this.code = err.code;
 		this.details = err.details;
 	}
+}
+
+/**
+ * Server-busy / rate-limit handling (TASK-2026). When the server returns
+ * 429 we honor `Retry-After` for a SINGLE delayed retry of idempotent
+ * GET/HEAD requests, then (if it still 429s) surface a distinct
+ * `rate_limited` PadApiError so the UI can show a "server busy" message
+ * rather than a generic failure. This is the client half of the rate-limit
+ * story; the server-side raise lives separately (IDEA-1842).
+ */
+// Absolute ceiling on how long a single Retry-After delay may block the
+// UI. A hostile or misconfigured `Retry-After: 86400` must not hang the
+// app for a day — clamp to a few seconds and let the user retry by hand.
+const MAX_RETRY_AFTER_MS = 5_000;
+// Backoff used when a 429 arrives with no (or an unparseable) Retry-After
+// header, so the one automatic GET retry still spaces itself out.
+const DEFAULT_RETRY_BACKOFF_MS = 750;
+
+function clampRetryMs(ms: number): number {
+	if (!Number.isFinite(ms) || ms < 0) return 0;
+	return Math.min(ms, MAX_RETRY_AFTER_MS);
+}
+
+/**
+ * Parse an HTTP `Retry-After` header into a clamped millisecond delay.
+ * Supports both wire forms: delta-seconds (`Retry-After: 3`) and an
+ * HTTP-date (`Retry-After: Wed, 21 Oct 2026 07:28:00 GMT`). Returns null
+ * when the header is absent or unparseable so the caller can fall back to
+ * `DEFAULT_RETRY_BACKOFF_MS`. All results are clamped to
+ * `MAX_RETRY_AFTER_MS`. TASK-2026.
+ */
+export function parseRetryAfterMs(header: string | null | undefined): number | null {
+	if (!header) return null;
+	const trimmed = header.trim();
+	if (trimmed === '') return null;
+	// Delta-seconds form: a bare non-negative integer.
+	if (/^\d+$/.test(trimmed)) {
+		return clampRetryMs(Number(trimmed) * 1000);
+	}
+	// HTTP-date form. Date.parse returns NaN for garbage.
+	const when = Date.parse(trimmed);
+	if (Number.isNaN(when)) return null;
+	const delta = when - Date.now();
+	return clampRetryMs(delta <= 0 ? 0 : delta);
+}
+
+function sleep(ms: number): Promise<void> {
+	if (ms <= 0) return Promise.resolve();
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Returns true when `err` is the distinct 429 server-busy error. Mirrors
+ * the `isPlanLimitError` idiom so call sites can branch on rate limiting
+ * and show a "Server busy, try again shortly" message. TASK-2026.
+ */
+function isRateLimitError(err: unknown): err is PadApiError {
+	return err instanceof PadApiError && err.code === 'rate_limited';
 }
 
 /**
@@ -271,7 +336,14 @@ const AUTH_FORM_401_PATHS = new Set(['/auth/login', '/auth/register', '/auth/2fa
  */
 const CREDENTIAL_RECONFIRM_401_PATHS = new Set(['/auth/delete-account']);
 
-async function request<T>(path: string, options?: RequestInit): Promise<T> {
+async function request<T>(
+	path: string,
+	options?: RequestInit,
+	// Internal flag: true on the single automatic re-invocation after a
+	// 429. Prevents an infinite retry loop if the retried request also
+	// 429s. Never passed by external callers. TASK-2026.
+	rateLimitRetried = false,
+): Promise<T> {
 	const headers: Record<string, string> = { 'Content-Type': 'application/json' };
 
 	// Attach CSRF token for state-changing requests
@@ -334,6 +406,31 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
 		if (method === undefined || method === 'GET' || method === 'HEAD') {
 			notifyAccessRevoked(path);
 		}
+	}
+	if (resp.status === 429) {
+		// Rate limited (TASK-2026). Honor Retry-After for ONE delayed
+		// retry of idempotent requests; then surface a distinct
+		// `rate_limited` error so callers can show "server busy" rather
+		// than a generic failure.
+		const retryAfterMs = parseRetryAfterMs(resp.headers?.get('Retry-After'));
+		const isIdempotent = method === undefined || method === 'GET' || method === 'HEAD';
+		// Only GET/HEAD auto-retry — retrying a POST/PATCH/DELETE could
+		// duplicate a write the server may have already partially applied.
+		if (isIdempotent && !rateLimitRetried) {
+			await sleep(retryAfterMs ?? DEFAULT_RETRY_BACKOFF_MS);
+			return request<T>(path, options, true);
+		}
+		// Prefer the server's structured error envelope if present, but
+		// force the distinct `rate_limited` code + a clear message so UI
+		// can branch on it regardless of what the proxy/server sent.
+		const body = await resp.json().catch(() => null);
+		const err = new PadApiError({
+			code: 'rate_limited',
+			message: body?.error?.message || 'Server busy — please try again in a moment.',
+			details: body?.error?.details,
+		});
+		if (retryAfterMs != null) err.retryAfterMs = retryAfterMs;
+		throw err;
 	}
 	if (!resp.ok) {
 		const body = await resp.json().catch(() => null);
@@ -2147,4 +2244,4 @@ export const api = {
 	}
 };
 
-export { PadApiError, isPlanLimitError, planLimitMessage };
+export { PadApiError, isPlanLimitError, planLimitMessage, isRateLimitError };

--- a/web/src/lib/stores/localIndex.svelte.ts
+++ b/web/src/lib/stores/localIndex.svelte.ts
@@ -394,6 +394,14 @@ export const localIndex = {
 						// row data is NOT covered here — TASK-1360 and
 						// DOC-1342 decision #3 explicitly punt that in
 						// favor of the 403-on-click purge path.
+						//
+						// A `rate_limited` (429) error lands here too and is
+						// intentionally treated as transient: the per-request
+						// Retry-After backoff already ran centrally in
+						// api/client.ts's request wrapper (TASK-2026), and a
+						// thrown `rate_limited` breaks out of the reconcile loop
+						// so we never hammer a busy server page-after-page. The
+						// next bootstrap() retries the resync later.
 					}
 				} else {
 					// Stage 2: cold path. /items-index full snapshot.


### PR DESCRIPTION
## What

Adds client-side 429 / rate-limit handling to the web API request wrapper (`web/src/lib/api/client.ts`), from the PLAN-1984 Web-UX audit. Previously the client had zero 429 handling despite rate limits being hit fairly consistently.

## Retry policy

- **Retry-After parsing** — supports both wire forms: delta-seconds (`Retry-After: 3`) and HTTP-date (`Retry-After: Wed, 21 Oct 2026 07:28:00 GMT`). Clamped to a 5s ceiling so a hostile/misconfigured huge value can't hang the UI; missing/garbage headers fall back to a 750ms default backoff.
- **One delayed retry, GET/HEAD only** — idempotent requests get a single Retry-After-delayed retry. POST/PATCH/DELETE never auto-retry (avoids duplicate writes).
- **Distinct error** — an exhausted retry (or any non-idempotent 429) surfaces `PadApiError` with `code: 'rate_limited'`, a "Server busy — please try again in a moment." message, and a `retryAfterMs` field. New `isRateLimitError()` helper (exported) mirrors the `isPlanLimitError` idiom for UI branching.
- **Backoff-aware bootstrap / global cooldown** — every observed 429 arms a monotonic global cooldown (`now + Retry-After`, pushed forward only). Subsequent idempotent GETs wait out the remaining window (bounded to 5s total) before firing, so independent call sites don't burst a busy server — e.g. `localIndex.bootstrap`'s reconcile 429s, then the collection page immediately fires a follow-up `deltaSync`. The cooldown expires by wall-clock (not cleared on an unrelated in-flight success, which isn't evidence the limit lifted).

Non-429 code paths are unchanged; the cooldown is inert unless a 429 was recently observed.

## Test plan

Focused vitest coverage in `client.test.ts`: Retry-After parse (seconds / HTTP-date / past-date / missing / garbage / clamp), GET retries exactly once, second 429 surfaces `rate_limited`, POST does NOT retry, `retryAfterMs` carried on the error, and the global cooldown makes a follow-up GET wait out the last Retry-After. `npm run check` (0 errors), `npm run build`, and `npm run test` (138 passing) all green. Two rounds of Codex review — CLEAN.

## Refs

TASK-2026, PLAN-1984. Complements IDEA-1842 (the separate server-side rate-limit raise) — this is the client-side handling only and does not duplicate it.