### PR TITLE
fix(web): flush pending raw-markdown on unload (BUG-2024)

### DIFF
--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -1039,10 +1039,18 @@ export const api = {
 		get: (ws: string, slug: string) =>
 			request<Item>(`/workspaces/${ws}/items/${slug}`),
 
-		update: (ws: string, slug: string, data: ItemUpdate) =>
+		/**
+		 * `opts.keepalive` is passed straight to fetch so the
+		 * beforeunload / unmount flush path can outlive the page
+		 * lifecycle (browser holds the request open until it completes
+		 * or hits the ~64KB body cap). Used to land pending raw-markdown
+		 * edits on tab close/reload (BUG-2024).
+		 */
+		update: (ws: string, slug: string, data: ItemUpdate, opts?: { keepalive?: boolean }) =>
 			request<Item>(`/workspaces/${ws}/items/${slug}`, {
 				method: 'PATCH',
-				body: JSON.stringify(data)
+				body: JSON.stringify(data),
+				keepalive: opts?.keepalive
 			}),
 
 		/**

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -1105,9 +1105,29 @@
 	// ~64KB body which dwarfs typical markdown items.
 	$effect(() => {
 		if (typeof window === 'undefined') return;
-		const onBeforeUnload = () => {
+		const onBeforeUnload = (event: BeforeUnloadEvent) => {
+			// Collab path: flush the live Y.Doc snapshot (unchanged).
 			const ctx = activeCollabContext;
 			if (ctx) flushCollabNow(ctx, true);
+
+			// Raw-markdown path (BUG-2024). rawPendingMarkdown holds the
+			// exact debounced-but-unsaved markdown; when non-null there
+			// is up to ~1.2s of typing the collab flush above never
+			// sees. Fire an immediate keepalive PATCH so it survives the
+			// page teardown, and set returnValue so the browser shows
+			// its native "unsaved changes" prompt. Only when actually
+			// dirty — never warn on a clean page.
+			const pendingRaw = rawPendingMarkdown;
+			if (pendingRaw !== null && item) {
+				void api.items.update(
+					wsSlug,
+					item.id,
+					{ content: pendingRaw },
+					{ keepalive: true }
+				);
+				event.preventDefault();
+				event.returnValue = '';
+			}
 		};
 		window.addEventListener('beforeunload', onBeforeUnload);
 		return () => window.removeEventListener('beforeunload', onBeforeUnload);

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -1113,18 +1113,37 @@
 			// Raw-markdown path (BUG-2024). rawPendingMarkdown holds the
 			// exact debounced-but-unsaved markdown; when non-null there
 			// is up to ~1.2s of typing the collab flush above never
-			// sees. Fire an immediate keepalive PATCH so it survives the
-			// page teardown, and set returnValue so the browser shows
-			// its native "unsaved changes" prompt. Only when actually
-			// dirty — never warn on a clean page.
+			// sees. Only when actually dirty — never warn on a clean page.
 			const pendingRaw = rawPendingMarkdown;
 			if (pendingRaw !== null && item) {
-				void api.items.update(
-					wsSlug,
-					item.id,
-					{ content: pendingRaw },
-					{ keepalive: true }
-				);
+				const reqItemId = item.id;
+				// Cancel any queued debounce so it can't fire a second,
+				// older-content PATCH racing the keepalive one below —
+				// the keepalive request already carries the latest
+				// markdown. (An already-in-flight debounced PATCH would
+				// carry older content, but the debounce spacing makes
+				// one being airborne at unload vanishingly narrow, and
+				// the server's un-versioned content PATCH has never
+				// guarded that ordering; this is strictly better than
+				// the pre-fix total loss of the debounced edit.)
+				clearTimeout(contentDebounceTimer);
+				contentDebounceTimer = undefined;
+				// Fire an immediate keepalive PATCH so the edit survives
+				// page teardown (keepalive holds the request open past
+				// unload — that's the point). If the user cancels the
+				// navigation ("Stay"), clear the dirty state once it
+				// lands so a later unload doesn't re-prompt / re-PATCH
+				// already-saved content.
+				void api.items
+					.update(wsSlug, reqItemId, { content: pendingRaw }, { keepalive: true })
+					.then(() => {
+						if (item && item.id === reqItemId && rawPendingMarkdown === pendingRaw) {
+							rawPendingMarkdown = null;
+							editorStore.setDirty(false);
+						}
+					})
+					.catch(() => {});
+				// Native "unsaved changes" prompt.
 				event.preventDefault();
 				event.returnValue = '';
 			}


### PR DESCRIPTION
## BUG-2024 — Raw-markdown editor loses typed content on tab close/reload

From the PLAN-1984 Web-UX audit: up to ~1.2s of typed raw-markdown content is lost on tab close/reload. The item-detail `beforeunload` handler only flushed the collaborative (Yjs) path and ignored pending **raw markdown** debounced edits, and never warned on dirty state.

### Before
- Raw-markdown typing is debounced (1200ms) before it PATCHes `items.content`.
- On tab close/reload within that window, `onBeforeUnload` flushed only the collab Y.Doc snapshot — the pending raw edit (`rawPendingMarkdown`) was silently dropped.
- No native "unsaved changes" prompt.

### After
- `onBeforeUnload` still flushes the collab path unchanged, and now **additionally**, when raw markdown is dirty (`rawPendingMarkdown !== null`):
  - Fires an **immediate keepalive** `PATCH /items/{id}` of the pending content so the request survives page teardown (`keepalive: true`, the modern `sendBeacon` equivalent; markdown bodies are well under the ~64KB cap).
  - Cancels the queued debounce timer so it can't fire a second, older-content PATCH racing the keepalive one.
  - Sets `event.preventDefault()` + `event.returnValue` so the browser shows its native "unsaved changes" prompt — **only when actually dirty**, never on a clean page.
  - Clears `rawPendingMarkdown` + the dirty flag once the keepalive save lands, so if the user picks "Stay" a later unload doesn't re-prompt / re-PATCH already-saved content.

`rawPendingMarkdown` is the authoritative dirty signal — set on every raw keystroke, cleared to `null` after each normal debounced save. So the prompt only fires when there's genuinely unsaved content.

### client.ts
`api.items.update` gains an optional `{ keepalive?: boolean }` — passed straight to `fetch` (mirrors the existing `flushCollabContent` keepalive option). No behavior change for existing callers.

### Test plan
- `npm run check` — 0 errors (only pre-existing unrelated warnings)
- `npm run build` — succeeds
- `npm run test` — 138/138 pass
- Handler reasoned through: keepalive PATCH + returnValue fire only when `rawPendingMarkdown !== null`; dirty cleared after normal save (existing path) and after keepalive save; collab flush preserved untouched.

Refs BUG-2024, PLAN-1984.