### PR TITLE
fix(web): distinguish transient failures from not-found (BUG-2025)

### DIFF
--- a/web/src/routes/[username]/[workspace]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/+page.svelte
@@ -21,6 +21,16 @@
 
 	let loading = $state(true);
 	let dashboard = $state<DashboardResponse | null>(null);
+	// `dashError` captures a dashboard LOAD failure (network / 5xx /
+	// 429) so the template can render an error + Retry state instead of
+	// the flat "No dashboard data available." message, which used to
+	// show on ANY transient failure and read as "this workspace is
+	// empty" (BUG-2025). A dashboard is a computed aggregate that never
+	// legitimately 404s, so any thrown error is treated as transient.
+	// Only shown when there's no `dashboard` to fall back to — a failed
+	// silent poll never clobbers an already-rendered board. Cleared on
+	// every successful load.
+	let dashError = $state<Error | null>(null);
 	// The workspace slug the current `dashboard` data was fetched for. A silent
 	// reload leaves stale `dashboard` in place while `wsSlug` already changed on
 	// a workspace switch, so route-param-keyed logic can read mismatched state.
@@ -195,8 +205,17 @@
 			dashboard = dash;
 			dashboardSlug = slug;
 			collections = colls;
-		} catch {
-			// allow partial render
+			// A clean load clears any prior transient error so a recovered
+			// dashboard renders normally rather than pinning the retry state.
+			dashError = null;
+		} catch (err) {
+			// Transient failure (network / 5xx / 429) — surface an error +
+			// Retry state instead of the flat "No dashboard data available."
+			// empty state (BUG-2025). A silent poll that fails while
+			// `dashboard` already holds data leaves that data in place; the
+			// error branch is gated on `!dashboard` in the template, so the
+			// live board is never clobbered by a background poll blip.
+			dashError = err instanceof Error ? err : new Error('Failed to load dashboard');
 		} finally {
 			loading = false;
 		}
@@ -622,6 +641,17 @@
 			</section>
 		{/if}
 		{/if}
+	{:else if dashError}
+		<!-- Transient dashboard load failure (network / 5xx / 429) —
+		     NOT an empty workspace (BUG-2025). Offer a Retry instead of
+		     the flat "No dashboard data available." message that reads
+		     as "nothing here". -->
+		<div class="dash-error">
+			<div class="dash-error-icon">⚠️</div>
+			<h2>Couldn't load the dashboard</h2>
+			<p>Something went wrong while loading. It may be a temporary network or server issue.</p>
+			<button class="btn btn-primary" onclick={() => { if (wsSlug) load(wsSlug); }}>Retry</button>
+		</div>
 	{:else}
 		<div class="loading">No dashboard data available.</div>
 	{/if}
@@ -676,6 +706,32 @@
 		text-align: center;
 		padding-top: 20vh;
 		color: var(--text-muted);
+	}
+	/* Transient dashboard load failure state (BUG-2025). */
+	.dash-error {
+		text-align: center;
+		padding-top: 15vh;
+		color: var(--text-secondary);
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: var(--space-3);
+	}
+	.dash-error-icon {
+		font-size: 2em;
+	}
+	.dash-error h2 {
+		font-size: 1.2em;
+		font-weight: 700;
+		color: var(--text-primary);
+	}
+	.dash-error p {
+		color: var(--text-muted);
+		max-width: 32em;
+	}
+	.dash-error .btn {
+		cursor: pointer;
+		border: none;
 	}
 
 	/* ── Header ─────────────────────────────────────────────────────────── */

--- a/web/src/routes/[username]/[workspace]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/+page.svelte
@@ -194,7 +194,16 @@
 		unsubscribeSync?.();
 	});
 
+	// Monotonic load token (plain, non-reactive) guarding against a
+	// superseded dashboard fetch committing out of order. Concurrent
+	// navigation / 30s poll / sync / retry loads can resolve in any
+	// order; only the latest may write `dashboard` / `dashboardSlug` /
+	// `dashError` / `loading` (Codex race finding). Mirrors the
+	// collection page's `loadSeq`.
+	let dashLoadSeq = 0;
+
 	async function load(slug: string, silent = false) {
+		const seq = ++dashLoadSeq;
 		if (!silent) loading = true;
 		try {
 			await workspaceStore.setCurrent(slug);
@@ -202,6 +211,8 @@
 				api.dashboard.get(slug),
 				api.collections.list(slug)
 			]);
+			// Superseded by a newer load — drop this result.
+			if (seq !== dashLoadSeq) return;
 			dashboard = dash;
 			dashboardSlug = slug;
 			collections = colls;
@@ -209,6 +220,8 @@
 			// dashboard renders normally rather than pinning the retry state.
 			dashError = null;
 		} catch (err) {
+			// Superseded by a newer load — don't commit this stale outcome.
+			if (seq !== dashLoadSeq) return;
 			// A genuine not-found (nonexistent workspace → 404 `not_found`
 			// from the workspace-access middleware) is terminal, not
 			// transient — fall through to the "No dashboard data available."
@@ -222,12 +235,19 @@
 			// live board (and stale data from a previous workspace never
 			// masks a failed load of the new one).
 			if (err instanceof PadApiError && err.code === 'not_found') {
+				// Terminal: drop any stale dashboard for this route so the
+				// "No dashboard data available." empty state shows instead
+				// of a workspace that's since been deleted/revoked lingering
+				// on screen (Codex P2).
+				dashboard = null;
+				dashboardSlug = null;
 				dashError = null;
 			} else {
 				dashError = err instanceof Error ? err : new Error('Failed to load dashboard');
 			}
 		} finally {
-			loading = false;
+			// Only the latest load owns the loading flag.
+			if (seq === dashLoadSeq) loading = false;
 		}
 	}
 

--- a/web/src/routes/[username]/[workspace]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/+page.svelte
@@ -2,7 +2,7 @@
 	import { page } from '$app/state';
 	import { onMount, onDestroy, untrack } from 'svelte';
 	import { browser } from '$app/environment';
-	import { api } from '$lib/api/client';
+	import { api, PadApiError } from '$lib/api/client';
 	import { workspaceStore } from '$lib/stores/workspace.svelte';
 	import { authStore } from '$lib/stores/auth.svelte';
 	import { uiStore } from '$lib/stores/ui.svelte';
@@ -209,13 +209,23 @@
 			// dashboard renders normally rather than pinning the retry state.
 			dashError = null;
 		} catch (err) {
-			// Transient failure (network / 5xx / 429) — surface an error +
-			// Retry state instead of the flat "No dashboard data available."
-			// empty state (BUG-2025). A silent poll that fails while
-			// `dashboard` already holds data leaves that data in place; the
-			// error branch is gated on `!dashboard` in the template, so the
-			// live board is never clobbered by a background poll blip.
-			dashError = err instanceof Error ? err : new Error('Failed to load dashboard');
+			// A genuine not-found (nonexistent workspace → 404 `not_found`
+			// from the workspace-access middleware) is terminal, not
+			// transient — fall through to the "No dashboard data available."
+			// empty state rather than a Retry loop that can never succeed
+			// (BUG-2025). Any OTHER thrown error (network / 5xx / 429) is
+			// transient: surface an error + Retry state instead of the flat
+			// empty state. A silent poll that fails while `dashboard`
+			// already holds data for the CURRENT workspace leaves it in
+			// place — the error branch is gated on `dashboardSlug === wsSlug`
+			// in the template, so a background poll blip never clobbers the
+			// live board (and stale data from a previous workspace never
+			// masks a failed load of the new one).
+			if (err instanceof PadApiError && err.code === 'not_found') {
+				dashError = null;
+			} else {
+				dashError = err instanceof Error ? err : new Error('Failed to load dashboard');
+			}
 		} finally {
 			loading = false;
 		}
@@ -318,7 +328,7 @@
 				{/each}
 			</div>
 		</div>
-	{:else if dashboard}
+	{:else if dashboard && dashboardSlug === wsSlug}
 		{#if needsOnboarding && !onboardingDismissed}
 			<!--
 				Launchpad render-mode (PLAN-1847 Phase 2 / TASK-1852). While

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -39,6 +39,16 @@
 	// case where filteredItems is briefly empty.
 	let metaLoading = $state(true);
 	let collection = $state<Collection | null>(null);
+	// `metaError` distinguishes a TRANSIENT collection-metadata load
+	// failure (network blip / 5xx / 429) from a genuine not-found
+	// (BUG-2025). A genuine 404 (`PadApiError.code === 'not_found'`)
+	// leaves `collection` null and `metaError` null so the template
+	// renders the terminal "Collection not found" empty state. Any
+	// other thrown error sets `metaError`, which the template renders
+	// as an error + Retry state — mirroring the items branch's
+	// `indexError`/`deltaSyncFailed` retry box — instead of masking a
+	// live collection as deleted. Cleared at the top of every load.
+	let metaError = $state<Error | null>(null);
 	let viewMode = $state<ViewMode>('list');
 	// Page-wide within-group sort (TASK-1670 / IDEA-1648). 'manual' is the
 	// stored sort_order (drag order). Persisted per collection.
@@ -140,7 +150,7 @@
 	// deltaSync.
 	let deltaSyncFailed = $state(false);
 	let loading = $derived(
-		metaLoading || (!indexReady && !indexError && !deltaSyncFailed),
+		!metaError && (metaLoading || (!indexReady && !indexError && !deltaSyncFailed)),
 	);
 
 	// Bootstrap the workspace on entry. Idempotent: if already 'ready'
@@ -502,6 +512,7 @@
 
 	async function loadCollection(ws: string, coll: string, includeArchived = false) {
 		metaLoading = true;
+		metaError = null;
 		try {
 			// Items now flow through localIndex (the `items` $derived
 			// above reads `getByCollection`). We still fetch the
@@ -590,11 +601,22 @@
 
 			// Override with URL params if present
 			loadUrlFilters();
-		} catch {
-			collection = null;
-			// `items` is derived from localIndex; nothing to clear here.
-			// A missing collection shows the empty / not-found state via
-			// the `collection` null branch in the template.
+		} catch (err) {
+			// Distinguish a genuine not-found from a transient failure
+			// (BUG-2025). Only a real 404 (`not_found`) collapses to the
+			// terminal "Collection not found" empty state; a network
+			// blip / 5xx / 429 sets `metaError` so the template shows an
+			// error + Retry affordance instead of masking a live
+			// collection as deleted.
+			if (err instanceof PadApiError && err.code === 'not_found') {
+				collection = null;
+				metaError = null;
+				// `items` is derived from localIndex; nothing to clear here.
+				// A missing collection shows the empty / not-found state via
+				// the `collection` null branch in the template.
+			} else {
+				metaError = err instanceof Error ? err : new Error('Failed to load collection');
+			}
 		} finally {
 			metaLoading = false;
 		}
@@ -1739,6 +1761,24 @@
 <div class="collection-page" class:board-active={viewMode === 'board'}>
 	{#if loading}
 		<div class="loading">Loading...</div>
+	{:else if metaError}
+		<!-- Transient collection-metadata load failure (network / 5xx /
+		     429) — NOT a genuine 404 (BUG-2025). Show an error + Retry
+		     path instead of the misleading "Collection not found" empty
+		     state, mirroring the items branch's retry box. -->
+		<div class="empty-state-box">
+			<div class="empty-icon">⚠️</div>
+			<h2>Couldn't load this collection</h2>
+			<p>Something went wrong while loading. It may be a temporary network or server issue.</p>
+			<button
+				class="empty-cta"
+				onclick={() => {
+					if (wsSlug && collSlug) loadCollection(wsSlug, collSlug, showArchived);
+				}}
+			>
+				Retry
+			</button>
+		</div>
 	{:else if !collection}
 		<div class="empty-state">Collection not found</div>
 	{:else}

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -554,6 +554,9 @@
 					itemProgress = map;
 					progressLabel = 'tasks';
 				} catch {
+					// Don't clear a newer load's progress badges if this
+					// stale load's progress fetch rejected (Codex round 5).
+					if (seq !== loadSeq) return;
 					itemProgress = {};
 				}
 			} else {
@@ -597,6 +600,9 @@
 					itemProgress = map;
 					progressLabel = 'done';
 				} catch {
+					// Don't clear a newer load's progress badges if this
+					// stale load's progress fetch rejected (Codex round 5).
+					if (seq !== loadSeq) return;
 					itemProgress = {};
 				}
 			}

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -510,7 +510,16 @@
 		}
 	}
 
+	// Monotonic load token (plain, non-reactive) guarding against a
+	// superseded fetch committing stale state. A slow load for
+	// collection A that resolves AFTER the route already switched to B
+	// must not overwrite B's `collection` / `metaError` / `metaLoading`
+	// (Codex race finding). Every entry bumps the token; each awaited
+	// result checks it's still the latest before writing.
+	let loadSeq = 0;
+
 	async function loadCollection(ws: string, coll: string, includeArchived = false) {
+		const seq = ++loadSeq;
 		metaLoading = true;
 		metaError = null;
 		try {
@@ -525,6 +534,9 @@
 				api.views.list(ws, coll).catch(() => [] as View[]),
 				api.members.list(ws).catch(() => ({ members: [], invitations: [] })),
 			]);
+			// A newer load started while this one was in flight — drop
+			// this result so it can't overwrite the current route's state.
+			if (seq !== loadSeq) return;
 			collection = collData;
 			savedViews = viewsData;
 			workspaceMembers = membersData.members ?? [];
@@ -602,6 +614,9 @@
 			// Override with URL params if present
 			loadUrlFilters();
 		} catch (err) {
+			// Superseded by a newer load — don't clobber the current
+			// route's state with this stale failure.
+			if (seq !== loadSeq) return;
 			// Distinguish a genuine not-found from a transient failure
 			// (BUG-2025). Only a real 404 (`not_found`) collapses to the
 			// terminal "Collection not found" empty state; a network
@@ -618,7 +633,9 @@
 				metaError = err instanceof Error ? err : new Error('Failed to load collection');
 			}
 		} finally {
-			metaLoading = false;
+			// Only the latest load owns the loading flag — a superseded
+			// load must not flip it false out from under the current one.
+			if (seq === loadSeq) metaLoading = false;
 		}
 	}
 

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -546,6 +546,7 @@
 			if (coll === 'plans') {
 				try {
 					const progress = await api.items.plansProgress(ws);
+					if (seq !== loadSeq) return;
 					const map: Record<string, { total: number; done: number; label?: string }> = {};
 					for (const p of progress) {
 						map[p.item_id] = { total: p.total, done: p.done };
@@ -572,6 +573,7 @@
 						api.items.collectionChildProgress(ws, coll, { includeArchived }).catch(() => [] as {item_id: string; total: number; done: number}[]),
 						api.items.collectionCheckboxProgress(ws, coll, { includeArchived }).catch(() => [] as {item_id: string; total: number; done: number}[]),
 					]);
+					if (seq !== loadSeq) return;
 
 					const checkboxMap: Record<string, { total: number; done: number }> = {};
 					for (const p of checkboxRows) {
@@ -604,6 +606,10 @@
 			// fetch; now plans flow into the local store and the
 			// derived map below picks them up as they hydrate.)
 
+			// A newer load may have started during the progress awaits —
+			// don't apply this (stale) collection's view/sort/filter state
+			// over the current route's (Codex round 4).
+			if (seq !== loadSeq) return;
 			// Set view mode: URL param > localStorage > collection default
 			const settings = parseSettings(collData);
 			const defaultMode = (['board', 'list', 'table'].includes(settings.default_view))


### PR DESCRIPTION
## BUG-2025 (PLAN-1984 Web-UX audit)

A network blip / 500 / 429 rendered the same terminal empty-state as a real 404: users saw "Collection not found" / "No dashboard data available" for resources that actually exist, with no retry affordance. This distinguishes a genuine not-found from transient failures and adds error+retry states.

### Collection page (`[collection]/+page.svelte`)
Three states off the metadata load:
- **Genuine not-found** (`PadApiError.code === 'not_found'`) -> the existing terminal **"Collection not found"** empty state.
- **Transient failure** (network / 5xx / 429) -> new **error + Retry** box (reuses the `.empty-state-box`/`.empty-cta` idiom from the items branch); Retry re-fires `loadCollection`.
- **Success + empty** -> unchanged "No <collection> yet" empty state.

### Dashboard (`+page.svelte`)
Three states off the dashboard load:
- **Transient failure** -> new **error + Retry** state; Retry re-fires `load(wsSlug)`.
- **Genuine not-found** (deleted/unavailable workspace -> 404 `not_found`) -> terminal "No dashboard data available."; stale dashboard state is cleared so a since-deleted workspace can't linger on screen.
- **Success + empty** -> unchanged flat empty state (now only reachable on a real empty/terminal result).

### Robustness (Codex review)
- Load-sequence supersession guards on **both** loads, rechecked after every await (incl. progress fetches and inner catch blocks) so a slow load for resource A can't overwrite the current route's state after B rendered.
- Dashboard render gated on `dashboardSlug === wsSlug` so stale data from a previous workspace never masks a failed load of the new one.
- No Svelte-5 reactivity footguns: `metaError`/`dashError` are `$state` read only in the template/`$derived`; the `loadSeq`/`dashLoadSeq` tokens are plain non-reactive `let`s (CONVE-1688); error/load reset lives inside the load functions, not a separate route-change effect (CONVE-606).

## Test plan
- `npm run check` (0 errors), `npm run build` (ok), `npm run test` (138 passed).
- Reasoned states: genuine 404 -> not-found empty state; transient/5xx/network -> error+retry with a working retry; success+empty -> empty state.
- Codex review CLEAN after 5 rounds.