### PR TITLE
refactor(web): unify mobile breakpoint into one shared isMobile store (TASK-2028)

### DIFF
--- a/web/src/lib/components/collections/BoardView.svelte
+++ b/web/src/lib/components/collections/BoardView.svelte
@@ -8,6 +8,7 @@
 	import ItemCard from './ItemCard.svelte';
 	import EmptyState from '../common/EmptyState.svelte';
 	import LaneActionsMenu from './LaneActionsMenu.svelte';
+	import { viewport } from '$lib/stores/breakpoint.svelte';
 
 
 	interface Props {
@@ -87,7 +88,6 @@
 	// Which lane's ⋯ menu is open (null = none). One menu open at a time;
 	// the LaneActionsMenu component owns the drill-down + confirm state.
 	let openMenuColumn = $state<string | null>(null);
-	let isMobile = $state(false);
 
 	function toggleMenu(colValue: string) {
 		openMenuColumn = openMenuColumn === colValue ? null : colValue;
@@ -172,18 +172,6 @@
 
 	$effect(() => {
 		columnOrder = [...columns];
-	});
-
-	$effect(() => {
-		const mql = window.matchMedia('(max-width: 768px)');
-		isMobile = mql.matches;
-		function onChange(e: MediaQueryListEvent) {
-			isMobile = e.matches;
-		}
-		mql.addEventListener('change', onChange);
-		return () => {
-			mql.removeEventListener('change', onChange);
-		};
 	});
 
 	// Native HTML5 drag-and-drop for column reordering
@@ -563,14 +551,14 @@
 					// under any non-manual page sort (TASK-1670): the
 					// lane is comparator-ordered, so a drag couldn't
 					// stick anyway.
-					dragDisabled: isMobile || !canEdit || preserveOrder || laneSortFor(colValue) !== 'manual'
+					dragDisabled: viewport.isMobile || !canEdit || preserveOrder || laneSortFor(colValue) !== 'manual'
 				}}
 				onconsider={(e) => handleConsider(colValue, e)}
 				onfinalize={(e) => handleFinalize(colValue, e)}
 				oncontextmenu={(e) => e.preventDefault()}
 			>
 				{#each colItems as item, i (item.id)}
-					<div class="card-wrapper" class:no-drag={isMobile}>
+					<div class="card-wrapper" class:no-drag={viewport.isMobile}>
 						<ItemCard
 							{item}
 							{collection}

--- a/web/src/lib/components/collections/FilterBar.svelte
+++ b/web/src/lib/components/collections/FilterBar.svelte
@@ -2,6 +2,7 @@
 	import type { Collection } from '$lib/types';
 	import { parseSchema } from '$lib/types';
 	import BottomSheet from '$lib/components/common/BottomSheet.svelte';
+	import { viewport } from '$lib/stores/breakpoint.svelte';
 	import TagFilter from '$lib/components/collections/TagFilter.svelte';
 
 	interface Props {
@@ -81,25 +82,15 @@
 	// On mobile the parent filter is rendered as a chip that opens a
 	// BottomSheet of options; on desktop the native <select> is kept
 	// because it's compact inside the toolbar and familiar.
-	let isMobile = $state(false);
-	$effect(() => {
-		if (typeof window === 'undefined') return;
-		const mq = window.matchMedia('(max-width: 639.98px)');
-		isMobile = mq.matches;
-		const onChange = (e: MediaQueryListEvent) => {
-			isMobile = e.matches;
-			// If the viewport crosses above the mobile breakpoint while the
-			// sheet is open (e.g. device rotation), close it so it doesn't
-			// spring back open as soon as the viewport returns to mobile.
-			if (!e.matches) {
-				parentSheetOpen = false;
-			}
-		};
-		mq.addEventListener('change', onChange);
-		return () => mq.removeEventListener('change', onChange);
-	});
-
 	let parentSheetOpen = $state(false);
+
+	// If the viewport crosses above the mobile breakpoint while the sheet is
+	// open (e.g. device rotation), close it so it doesn't spring back open as
+	// soon as the viewport returns to mobile. Reads the shared breakpoint flag
+	// (TASK-2028); writes only `parentSheetOpen`, so no self-invalidation.
+	$effect(() => {
+		if (!viewport.isMobile) parentSheetOpen = false;
+	});
 
 	function openParentSheet() {
 		parentSheetOpen = true;
@@ -130,7 +121,7 @@
 	{/if}
 
 	{#if hasParentFilter}
-		{#if isMobile}
+		{#if viewport.isMobile}
 			<!--
 				Mobile: render the parent filter as a chip + BottomSheet to keep
 				option labels readable full-width and avoid the native <select>'s

--- a/web/src/lib/components/common/EmojiPickerButton.svelte
+++ b/web/src/lib/components/common/EmojiPickerButton.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import EmojiPicker from '$lib/components/common/EmojiPicker.svelte';
 	import BottomSheet from '$lib/components/common/BottomSheet.svelte';
+	import { viewport } from '$lib/stores/breakpoint.svelte';
 
 	interface Props {
 		value: string;
@@ -15,21 +16,9 @@
 	let dropdownX = $state(0);
 	let dropdownY = $state(0);
 
-	// ── Viewport detection ───────────────────────────────────────────────
-	// Track mobile viewport so we can swap the absolute-positioned portal
-	// dropdown for a BottomSheet that never clips off-screen. Mirrors the
-	// reference pattern from QuickActionsMenu.
-	let isMobile = $state(false);
-	$effect(() => {
-		if (typeof window === 'undefined') return;
-		const mq = window.matchMedia('(max-width: 639.98px)');
-		isMobile = mq.matches;
-		const onChange = (e: MediaQueryListEvent) => {
-			isMobile = e.matches;
-		};
-		mq.addEventListener('change', onChange);
-		return () => mq.removeEventListener('change', onChange);
-	});
+	// Mobile viewport swaps the absolute-positioned portal dropdown for a
+	// BottomSheet that never clips off-screen. Uses the shared breakpoint store
+	// (TASK-2028).
 
 	/**
 	 * Portal into the nearest <dialog> (stays in top-layer, escapes overflow
@@ -59,7 +48,7 @@
 	function handleWindowClick(e: MouseEvent) {
 		// On mobile the BottomSheet owns dismissal (backdrop tap + Escape +
 		// close button) — skip the outside-click handler so it doesn't race.
-		if (isMobile) return;
+		if (viewport.isMobile) return;
 		if (open) {
 			const target = e.target as HTMLElement;
 			if (!target?.closest('.emoji-picker-button') && !target?.closest('.epb-dropdown')) {
@@ -71,7 +60,7 @@
 	function toggleOpen() {
 		// Mobile branch skips the positioning math — BottomSheet docks to
 		// the viewport edge and doesn't need trigger-relative coordinates.
-		if (!open && !isMobile && triggerEl) {
+		if (!open && !viewport.isMobile && triggerEl) {
 			const triggerRect = triggerEl.getBoundingClientRect();
 			const dialog = triggerEl.closest('dialog');
 			if (dialog) {
@@ -108,7 +97,7 @@
 		{value || placeholder}
 	</button>
 
-	{#if isMobile}
+	{#if viewport.isMobile}
 		<BottomSheet {open} onclose={() => (open = false)} title="Pick an emoji">
 			<div class="epb-sheet-body">
 				<EmojiPicker selected={value} onselect={handleSelect} />

--- a/web/src/lib/components/common/QuickActionsMenu.svelte
+++ b/web/src/lib/components/common/QuickActionsMenu.svelte
@@ -4,6 +4,7 @@
 	import { api } from '$lib/api/client';
 	import { toastStore } from '$lib/stores/toast.svelte';
 	import BottomSheet from '$lib/components/common/BottomSheet.svelte';
+	import { viewport } from '$lib/stores/breakpoint.svelte';
 	import EmojiPickerButton from '$lib/components/common/EmojiPickerButton.svelte';
 
 	interface Props {
@@ -43,20 +44,8 @@
 
 	let filtered = $derived(actions.filter((a) => a.scope === scope));
 
-	// ── Viewport detection ────────────────────────────────────────────────
-	// Track mobile viewport so we can swap the absolute-positioned popover
-	// for a BottomSheet that never clips off-screen.
-	let isMobile = $state(false);
-	$effect(() => {
-		if (typeof window === 'undefined') return;
-		const mq = window.matchMedia('(max-width: 639.98px)');
-		isMobile = mq.matches;
-		const onChange = (e: MediaQueryListEvent) => {
-			isMobile = e.matches;
-		};
-		mq.addEventListener('change', onChange);
-		return () => mq.removeEventListener('change', onChange);
-	});
+	// Mobile viewport swaps the absolute-positioned popover for a BottomSheet
+	// that never clips off-screen. Uses the shared breakpoint store (TASK-2028).
 
 	function resolvePrompt(action: QuickAction): string {
 		let prompt = action.prompt;
@@ -173,7 +162,7 @@
 		const nextOpen = !open;
 		// Only compute alignment when opening on desktop; the mobile branch
 		// renders a BottomSheet which doesn't need trigger-relative positioning.
-		if (nextOpen && !isMobile && triggerEl) {
+		if (nextOpen && !viewport.isMobile && triggerEl) {
 			const rect = triggerEl.getBoundingClientRect();
 			// If the trigger is too close to the left edge, the default
 			// right-anchored 200px dropdown would clip — switch to left-anchored.
@@ -190,7 +179,7 @@
 	function handleWindowClick(e: MouseEvent) {
 		// On mobile the BottomSheet owns dismissal (backdrop tap, Escape,
 		// swipe-down) — skip the outside-click handler so it doesn't race.
-		if (isMobile) return;
+		if (viewport.isMobile) return;
 		const target = e.target as HTMLElement;
 		if (!target) return;
 		// The EmojiPickerButton portals its dropdown to document.body (or the
@@ -287,7 +276,7 @@
 			&#9889;
 		</button>
 
-		{#if isMobile}
+		{#if viewport.isMobile}
 			<BottomSheet {open} onclose={handleBottomSheetClose} title="Quick actions">
 				{@render actionList()}
 			</BottomSheet>

--- a/web/src/lib/components/editor/Editor.svelte
+++ b/web/src/lib/components/editor/Editor.svelte
@@ -570,6 +570,7 @@
 	import { collectionStore } from '$lib/stores/collections.svelte';
 	import { workspaceStore } from '$lib/stores/workspace.svelte';
 	import { localIndex } from '$lib/stores/localIndex.svelte';
+	import { viewport } from '$lib/stores/breakpoint.svelte';
 	import { api } from '$lib/api/client';
 	import { BlockDragHandle } from './block-drag-handle';
 	import { HtmlBlock, captureHtmlBlockSnapshot, flipHtmlBlockToSource } from './extensions/htmlBlock';
@@ -658,7 +659,6 @@
 	let editor = $state<Editor | null>(null);
 	let editorFocused = $state(false);
 	let editorTick = $state(0);
-	let isMobile = $state(typeof window !== 'undefined' && window.innerWidth <= 768);
 	let toolbarBottom = $state(0);
 	let keyboardVisible = $state(false);
 	let suppressUpdate = false;
@@ -867,7 +867,7 @@
 				HTMLAttributes: { class: 'editor-link', target: null, rel: null },
 			}),
 			Placeholder.configure({
-				placeholder: isMobile ? 'Start writing...' : 'Type / for commands...',
+				placeholder: viewport.isMobile ? 'Start writing...' : 'Type / for commands...',
 			}),
 			Markdown.configure({
 				html: true,
@@ -1106,7 +1106,7 @@
 		});
 
 		// Prevent mobile keyboard from opening when tapping task list checkboxes
-		if (isMobile) {
+		if (viewport.isMobile) {
 			editor.view.dom.addEventListener('touchend', (e) => {
 				const target = e.target as HTMLElement;
 				if (target.tagName === 'INPUT' && target.getAttribute('type') === 'checkbox' && target.closest('[data-type="taskItem"]')) {
@@ -1288,7 +1288,7 @@
 	lines 658-659) — this just makes the toolbar visibility actually
 	consult it.
 -->
-{#if editable && isMobile && keyboardVisible && editor && editorFocused}
+{#if editable && viewport.isMobile && keyboardVisible && editor && editorFocused}
 	{@const _tick = editorTick}
 	{@const listItemType = getActiveListItemType()}
 	{@const canIndent = canIndentListItem(listItemType)}

--- a/web/src/lib/components/fields/FieldEditor.svelte
+++ b/web/src/lib/components/fields/FieldEditor.svelte
@@ -17,6 +17,7 @@ handlers — onchange is never called.
 <script lang="ts">
 	import type { FieldDef } from '$lib/types';
 	import BottomSheet from '$lib/components/common/BottomSheet.svelte';
+	import { viewport } from '$lib/stores/breakpoint.svelte';
 
 	interface Props {
 		field: FieldDef;
@@ -29,23 +30,15 @@ handlers — onchange is never called.
 
 	// ── Viewport detection ───────────────────────────────────────────────
 	// On mobile the absolute-positioned select dropdown can clip at the
-	// edge of the properties panel; swap it for a BottomSheet of options.
-	// Desktop keeps the inline dropdown with keyboard nav unchanged.
-	let isMobile = $state(false);
+	// edge of the properties panel; swap it for a BottomSheet of options
+	// (gated on `viewport.isMobile`, TASK-2028). Desktop keeps the inline
+	// dropdown with keyboard nav unchanged.
+	//
+	// If the viewport crosses above mobile while the sheet is open (e.g.
+	// rotation), close it so it doesn't spring back on return. Reads the shared
+	// breakpoint flag; writes only `dropdownOpen`, so no self-invalidation.
 	$effect(() => {
-		if (typeof window === 'undefined') return;
-		const mq = window.matchMedia('(max-width: 639.98px)');
-		isMobile = mq.matches;
-		const onChange = (e: MediaQueryListEvent) => {
-			isMobile = e.matches;
-			// If the viewport crosses above mobile while the sheet is open
-			// (e.g. rotation), close it so it doesn't spring back on return.
-			if (!e.matches) {
-				dropdownOpen = false;
-			}
-		};
-		mq.addEventListener('change', onChange);
-		return () => mq.removeEventListener('change', onChange);
+		if (!viewport.isMobile) dropdownOpen = false;
 	});
 
 	// ── Date input state ──────────────────────────────────────────────────
@@ -135,7 +128,7 @@ handlers — onchange is never called.
 	function handleWindowClick(e: MouseEvent) {
 		// On mobile the BottomSheet owns dismissal (backdrop tap + Escape +
 		// close button) — skip this handler so it doesn't race the sheet.
-		if (isMobile) return;
+		if (viewport.isMobile) return;
 		if (
 			dropdownOpen &&
 			triggerEl &&
@@ -402,7 +395,7 @@ handlers — onchange is never called.
 			</svg>
 		</button>
 
-		{#if isMobile && dropdownOpen}
+		{#if viewport.isMobile && dropdownOpen}
 			<!--
 				Mobile: full-width BottomSheet of options, titled with the
 				field label (e.g. "Set status"). Gated on `dropdownOpen`

--- a/web/src/lib/components/layout/TopBar.svelte
+++ b/web/src/lib/components/layout/TopBar.svelte
@@ -943,10 +943,9 @@
 		</div>
 		<div class="mobile-switcher-slot">
 			<!--
-				Force the mobile branch. TopBar's mobile/desktop decision uses
-				`uiStore.isMobile` (≤768px) but WorkspaceSwitcher's own query
-				is ≤639.98px — without this prop, 640–768px viewports would
-				render the desktop dropdown inside a mobile layout.
+				This slot only renders inside the mobile TopBar, so force the
+				mobile (BottomSheet) branch unconditionally rather than
+				re-deriving it from the viewport.
 			-->
 			<WorkspaceSwitcher mobile={true} />
 		</div>

--- a/web/src/lib/components/layout/WorkspaceSwitcher.svelte
+++ b/web/src/lib/components/layout/WorkspaceSwitcher.svelte
@@ -5,17 +5,18 @@
 	import { uiStore } from '$lib/stores/ui.svelte';
 	import { toastStore } from '$lib/stores/toast.svelte';
 	import BottomSheet from '$lib/components/common/BottomSheet.svelte';
+	import { viewport } from '$lib/stores/breakpoint.svelte';
 	import { workspaceRestoreTarget } from '$lib/utils/workspace-route';
 	import type { DeletedWorkspace } from '$lib/types';
 
 	interface Props {
 		/**
-		 * Force the mobile (BottomSheet) branch regardless of the internal
-		 * viewport detection. Use this when an ancestor component already
-		 * owns the mobile/desktop decision (e.g. TopBar branches on
-		 * `uiStore.isMobile` at ≤768px but this component's own breakpoint
-		 * is ≤639.98px — without the override, 640–768px would show the
-		 * desktop dropdown inside a mobile layout).
+		 * Force the mobile (BottomSheet) branch regardless of the shared
+		 * viewport flag. Callers that live only inside mobile chrome (TopBar's
+		 * mobile slot, MobileContextBar) pass `mobile={true}` so the switcher
+		 * always renders as a sheet there. Left unset elsewhere, the switcher
+		 * follows the shared breakpoint (now unified with the app chrome at
+		 * ≤768px — TASK-2028).
 		 */
 		mobile?: boolean;
 	}
@@ -24,39 +25,18 @@
 
 	let open = $state(false);
 
-	// ── Viewport detection ───────────────────────────────────────────────
-	// Track mobile viewport so we can swap the absolute-positioned dropdown
-	// for a full-width BottomSheet that reads better when workspace names
-	// are long or the list is deep. Skipped when the caller passes an
-	// explicit `mobile` prop.
-	let detectedMobile = $state(false);
-	$effect(() => {
-		if (mobile !== undefined) return;
-		if (typeof window === 'undefined') return;
-		const mq = window.matchMedia('(max-width: 639.98px)');
-		detectedMobile = mq.matches;
-		const onChange = (e: MediaQueryListEvent) => {
-			detectedMobile = e.matches;
-			// Close the sheet if the viewport crosses above mobile while it's
-			// open (e.g. rotation) so returning to mobile doesn't reopen it.
-			if (!e.matches) {
-				open = false;
-			}
-		};
-		mq.addEventListener('change', onChange);
-		return () => mq.removeEventListener('change', onChange);
-	});
+	// On mobile the absolute-positioned dropdown is swapped for a full-width
+	// BottomSheet that reads better when workspace names are long or the list is
+	// deep. Follows the shared breakpoint store unless the caller forces the
+	// branch via the `mobile` prop.
+	let isMobile = $derived(mobile ?? viewport.isMobile);
 
-	// Also close the sheet if an ancestor-driven `mobile` prop flips off
-	// while the sheet is open — same rotation-reopen guard as the internal
-	// detection path.
+	// Close the sheet if the viewport (or an ancestor-driven `mobile` prop)
+	// crosses above mobile while it's open (e.g. rotation) so returning to
+	// mobile doesn't reopen it. Reads `isMobile`; writes only `open`.
 	$effect(() => {
-		if (mobile === false) {
-			open = false;
-		}
+		if (!isMobile) open = false;
 	});
-
-	let isMobile = $derived(mobile ?? detectedMobile);
 
 	function select(ws: { slug: string; owner_username?: string }) {
 		open = false;

--- a/web/src/lib/components/timeline/ReactionPicker.svelte
+++ b/web/src/lib/components/timeline/ReactionPicker.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import BottomSheet from '$lib/components/common/BottomSheet.svelte';
+	import { viewport } from '$lib/stores/breakpoint.svelte';
 
 	interface Props {
 		onSelect: (emoji: string) => void;
@@ -12,21 +13,9 @@
 	let open = $state(false);
 	let pickerEl: HTMLDivElement | undefined = $state();
 
-	// ── Viewport detection ───────────────────────────────────────────────
-	// Track mobile viewport so we can swap the absolute-positioned popover
-	// for a BottomSheet that never clips off-screen at the edge of narrow
-	// comment cards. Mirrors the QuickActionsMenu reference pattern.
-	let isMobile = $state(false);
-	$effect(() => {
-		if (typeof window === 'undefined') return;
-		const mq = window.matchMedia('(max-width: 639.98px)');
-		isMobile = mq.matches;
-		const onChange = (e: MediaQueryListEvent) => {
-			isMobile = e.matches;
-		};
-		mq.addEventListener('change', onChange);
-		return () => mq.removeEventListener('change', onChange);
-	});
+	// Mobile viewport swaps the absolute-positioned popover for a BottomSheet
+	// that never clips off-screen at the edge of narrow comment cards. Uses the
+	// shared breakpoint store (TASK-2028).
 
 	function toggle() {
 		open = !open;
@@ -46,7 +35,7 @@
 	$effect(() => {
 		// On mobile the BottomSheet owns dismissal (backdrop tap + Escape +
 		// close button) — skip the outside-click listener so it doesn't race.
-		if (open && !isMobile) {
+		if (open && !viewport.isMobile) {
 			document.addEventListener('click', handleClickOutside, true);
 			return () => {
 				document.removeEventListener('click', handleClickOutside, true);
@@ -80,7 +69,7 @@
 		<span class="plus">+</span>
 	</button>
 
-	{#if isMobile && open}
+	{#if viewport.isMobile && open}
 		<!--
 			Gate the mobile sheet on `open` so the component (and its global
 			`<svelte:window onkeydown>` listener inside BottomSheet) isn't

--- a/web/src/lib/stores/breakpoint.svelte.ts
+++ b/web/src/lib/stores/breakpoint.svelte.ts
@@ -1,0 +1,46 @@
+import { browser } from '$app/environment';
+
+/**
+ * The single mobile breakpoint for the whole app (px). Viewports whose width
+ * is at or below this are "mobile".
+ *
+ * 768 was chosen as the canonical value (TASK-2028 / PLAN-1984) because it is
+ * the width the app chrome already switches at — `uiStore.isMobile` drives the
+ * Sidebar / TopBar / BottomNav / MobileContextBar at ≤768, and the dominant CSS
+ * `@media (max-width: 768px)` queries key off the same width. The component-local
+ * bottom-sheet swaps that previously used 639.98px were pure-JS gates (no CSS
+ * media query at 639.98), so aligning them up to 768 makes JS `isMobile` agree
+ * with the CSS layout switch without any CSS rewrite. Before this unification the
+ * two breakpoints disagreed in the 640–768px band, producing e.g. a desktop
+ * dropdown rendered inside otherwise-mobile chrome.
+ */
+export const MOBILE_BREAKPOINT = 768;
+
+/** Canonical media-query string. Kept in lockstep with the CSS `@media (max-width: 768px)`. */
+export const MOBILE_MEDIA_QUERY = `(max-width: ${MOBILE_BREAKPOINT}px)`;
+
+// Single app-wide source of truth for the mobile viewport flag. Written only by
+// the one matchMedia listener below; components READ it (directly or via
+// `uiStore.isMobile`). Deliberately no `$effect` here — per CONVE-1688 the store
+// must never read state it also writes, which would wedge the effect scheduler.
+// SSR-safe: `false` on the server, resolved to the real value at module init on
+// the client (the same browser-guarded pattern uiStore uses).
+let mobile = $state(browser ? window.matchMedia(MOBILE_MEDIA_QUERY).matches : false);
+
+if (browser) {
+	// One listener for the entire app instead of one per component. `change`
+	// fires only when the viewport crosses the breakpoint, not on every resize.
+	window.matchMedia(MOBILE_MEDIA_QUERY).addEventListener('change', (e) => {
+		mobile = e.matches;
+	});
+}
+
+/**
+ * Reactive mobile-viewport flag. Read it in components (`viewport.isMobile`) or
+ * templates and it tracks the viewport automatically. `false` during SSR.
+ */
+export const viewport = {
+	get isMobile() {
+		return mobile;
+	}
+};

--- a/web/src/lib/stores/ui.svelte.ts
+++ b/web/src/lib/stores/ui.svelte.ts
@@ -1,9 +1,9 @@
 import { browser } from '$app/environment';
+import { viewport, MOBILE_MEDIA_QUERY } from '$lib/stores/breakpoint.svelte';
 
-let sidebarOpen = $state(browser ? window.innerWidth > 768 : true);
+let sidebarOpen = $state(browser ? !viewport.isMobile : true);
 let topbarOpen = $state(browser ? localStorage.getItem('pad-topbar') !== 'closed' : true);
 let searchOpen = $state(false);
-let isMobile = $state(browser ? window.innerWidth <= 768 : false);
 let isTouch = $state(browser ? 'ontouchstart' in window : false);
 // True while the on-screen keyboard is up. Detected from the geometry of the
 // keyboard itself — visualViewport.height shrinking below the tallest height
@@ -13,7 +13,7 @@ let isTouch = $state(browser ? 'ontouchstart' in window : false);
 // viewport, leaving the delta ~0. Consumers (e.g. BottomNav) hide fixed bottom
 // chrome so it doesn't sit stranded above the keyboard. PLAN-1694.
 let keyboardVisible = $state(false);
-let detailPanelOpen = $state(browser ? localStorage.getItem('pad-detail-panel') !== 'closed' && window.innerWidth > 768 : false);
+let detailPanelOpen = $state(browser ? localStorage.getItem('pad-detail-panel') !== 'closed' && !viewport.isMobile : false);
 let createWorkspaceOpen = $state(false);
 let quickAddRequested = $state(false);
 let quickAddTargetSlug = $state<string | null>(null);
@@ -26,16 +26,17 @@ let collectionSearchHandler = $state<(() => void) | null>(null);
 let connectAfterNavigateSlug = $state<string | null>(null);
 
 if (browser) {
-	window.addEventListener('resize', () => {
-		const mobile = window.innerWidth <= 768;
-		if (mobile !== isMobile) {
-			isMobile = mobile;
-			if (mobile) {
-				sidebarOpen = false;
-				detailPanelOpen = false;
-			} else {
-				sidebarOpen = true;
-			}
+	// `isMobile` itself is owned by the shared breakpoint store (one app-wide
+	// listener). Here we only run the layout side effects that must fire when
+	// the viewport crosses the mobile breakpoint: collapse the sidebar/detail
+	// panel entering mobile, restore the sidebar leaving it. `change` fires only
+	// on a crossing, so no manual before/after comparison is needed.
+	window.matchMedia(MOBILE_MEDIA_QUERY).addEventListener('change', (e) => {
+		if (e.matches) {
+			sidebarOpen = false;
+			detailPanelOpen = false;
+		} else {
+			sidebarOpen = true;
 		}
 	});
 
@@ -68,7 +69,7 @@ export const uiStore = {
 	get sidebarOpen() { return sidebarOpen; },
 	get topbarOpen() { return topbarOpen; },
 	get searchOpen() { return searchOpen; },
-	get isMobile() { return isMobile; },
+	get isMobile() { return viewport.isMobile; },
 	get isTouch() { return isTouch; },
 	get keyboardVisible() { return keyboardVisible; },
 	get detailPanelOpen() { return detailPanelOpen; },
@@ -142,6 +143,6 @@ export const uiStore = {
 
 	/** Close sidebar on mobile after navigation */
 	onNavigate() {
-		if (isMobile) sidebarOpen = false;
+		if (viewport.isMobile) sidebarOpen = false;
 	},
 };

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -11,6 +11,7 @@
 	import FilterBar from '$lib/components/collections/FilterBar.svelte';
 	import QuickActionsMenu from '$lib/components/common/QuickActionsMenu.svelte';
 	import BottomSheet from '$lib/components/common/BottomSheet.svelte';
+	import { viewport } from '$lib/stores/breakpoint.svelte';
 	import SSEStatusIndicator from '$lib/components/SSEStatusIndicator.svelte';
 	import { onDestroy, onMount } from 'svelte';
 	import { sseService } from '$lib/services/sse.svelte';
@@ -716,26 +717,17 @@
 	// On mobile the 3-icon view toggle (list/board/table) is swapped for a
 	// chip trigger that opens a BottomSheet with labeled options — the raw
 	// icon glyphs are ambiguous on touch and a labeled sheet is clearer.
-	// Desktop keeps the segmented toggle unchanged.
-	let isMobile = $state(false);
-	$effect(() => {
-		if (typeof window === 'undefined') return;
-		const mq = window.matchMedia('(max-width: 639.98px)');
-		isMobile = mq.matches;
-		const onChange = (e: MediaQueryListEvent) => {
-			isMobile = e.matches;
-			// If the viewport crosses above the mobile breakpoint while the
-			// sheet is open (e.g. rotation), close it so a return to mobile
-			// doesn't immediately re-mount the open sheet.
-			if (!e.matches) {
-				viewSheetOpen = false;
-			}
-		};
-		mq.addEventListener('change', onChange);
-		return () => mq.removeEventListener('change', onChange);
-	});
-
+	// Desktop keeps the segmented toggle unchanged. Uses the shared breakpoint
+	// store (TASK-2028).
 	let viewSheetOpen = $state(false);
+
+	// If the viewport crosses above the mobile breakpoint while the sheet is
+	// open (e.g. rotation), close it so a return to mobile doesn't immediately
+	// re-mount the open sheet. Reads the shared breakpoint flag; writes only
+	// `viewSheetOpen`, so no self-invalidation.
+	$effect(() => {
+		if (!viewport.isMobile) viewSheetOpen = false;
+	});
 	let viewModeLabel = $derived(
 		viewMode === 'list' ? 'List' : viewMode === 'board' ? 'Board' : 'Table'
 	);
@@ -1762,7 +1754,7 @@
 				</div>
 
 				<div class="header-actions">
-					{#if isMobile}
+					{#if viewport.isMobile}
 						<!--
 							Mobile: labeled chip + BottomSheet picker. Icon-only
 							segmented buttons are hard to decode on touch, and the

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -32,6 +32,7 @@
 	import { parseFields, parseSchema, parseSettings, parseTags, formatItemRef, getTerminalOptions } from '$lib/types';
 	import QuickActionsMenu from '$lib/components/common/QuickActionsMenu.svelte';
 	import BottomSheet from '$lib/components/common/BottomSheet.svelte';
+	import { viewport } from '$lib/stores/breakpoint.svelte';
 	import ContentSkeleton from '$lib/components/common/ContentSkeleton.svelte';
 	import ContentError from '$lib/components/common/ContentError.svelte';
 	import EditCollectionModal from '$lib/components/collections/EditCollectionModal.svelte';
@@ -226,21 +227,9 @@
 	// notifies us and the badge hides.
 	let backlinksCount = $state(0);
 
-	// ── Viewport detection ───────────────────────────────────────────────
-	// Drives BottomSheet vs popover branching for mobile-only surfaces on
-	// this page (currently the "Move to…" menu). Matches the reference
-	// pattern from QuickActionsMenu / EmojiPickerButton / ReactionPicker.
-	let isMobile = $state(false);
-	$effect(() => {
-		if (typeof window === 'undefined') return;
-		const mq = window.matchMedia('(max-width: 639.98px)');
-		isMobile = mq.matches;
-		const onChange = (e: MediaQueryListEvent) => {
-			isMobile = e.matches;
-		};
-		mq.addEventListener('change', onChange);
-		return () => mq.removeEventListener('change', onChange);
-	});
+	// Drives BottomSheet vs popover branching for mobile-only surfaces on this
+	// page (currently the "Move to…" menu) via the shared breakpoint store
+	// (TASK-2028).
 
 	async function handleCopyRef() {
 		const ref = formatItemRef(item!);
@@ -2742,7 +2731,7 @@
 							</button>
 						{/each}
 					{/snippet}
-					{#if isMobile && showMoveMenu}
+					{#if viewport.isMobile && showMoveMenu}
 						<!--
 							Gate the mobile sheet on `showMoveMenu` so BottomSheet (and
 							its global keydown listener) isn't mounted when the menu is


### PR DESCRIPTION
## TASK-2028 — Unify the mobile breakpoint (PLAN-1984 Web-UX audit)

Two competing JS `isMobile` breakpoints (**768** and **639.98**) disagreed in the 640–768px band across ~15 self-rolled implementations. This replaces all of them with **one shared, reactive, matchMedia-backed store**.

### Chosen breakpoint: **768px** (`<=768` is mobile)
Verified against the codebase rather than defaulting to the `sm` (639.98) boundary:
- **768 is the app-chrome / mobile-nav switch** — `uiStore.isMobile` (≤768) already drives Sidebar, TopBar, BottomNav, and MobileContextBar.
- **768 is the dominant CSS breakpoint** — 16 files carry `@media (max-width: 768px)` layout queries; the chrome CSS keys off it.
- **The 639.98 sites were pure-JS bottom-sheet gates** (`{#if isMobile}` → `<BottomSheet>`), with *no* matching `@media (max-width: 639.98px)` layout query. Aligning them up to 768 therefore introduces **no CSS mismatch** and avoids a sprawling CSS rewrite (which choosing 639.98 would have forced on the 20 chrome queries).
- The codebase already contained a workaround (`WorkspaceSwitcher mobile` prop) documenting the 768-vs-639.98 conflict; unifying removes the underlying disagreement.

### New store — `web/src/lib/stores/breakpoint.svelte.ts`
```
export const MOBILE_BREAKPOINT = 768;
export const MOBILE_MEDIA_QUERY = '(max-width: 768px)';
export const viewport = { get isMobile() { … } };  // reactive
```
One app-wide `matchMedia('change')` listener writes a single `$state`; components only READ it (directly or via `uiStore.isMobile`). No `$effect` in the store (CONVE-1688). **SSR-safe:** `browser`-guarded, returns `false` on the server and resolves to the real value at client module init — the same pattern `uiStore` already used.

### Call sites unified (11 files)
- `uiStore.isMobile` now delegates to the store; its resize listener became a single `matchMedia change` listener that only runs the sidebar/detail-panel side effects.
- Swapped the local detection out of: BoardView, Editor, FilterBar, ReactionPicker, FieldEditor, EmojiPickerButton, QuickActionsMenu, WorkspaceSwitcher, the `[collection]` list page, and the `[collection]/[slug]` item page.
- The three "close the sheet when the viewport crosses back above mobile" side effects (FilterBar, FieldEditor, collection page, WorkspaceSwitcher) were reimplemented as small guard `$effect`s that read `viewport.isMobile` and write only the local sheet-open flag (CONVE-1688 safe).
- All existing `isMobile && open` BottomSheet gates preserved (CONVE-639); `WorkspaceSwitcher`'s `mobile` prop retained (mobile-chrome slots still force the sheet). Updated the now-stale TopBar comment.

### Deliberately NOT changed
`BottomSheet.svelte`'s internal `@media (min-width: 640px)` (centered-modal presentation on tablet widths) is left as-is. It is established behavior already relied on by the 768-gated mobile chrome (MobileContextBar → YouSheet/QuickCaptureSheet, WorkspaceSwitcher's TopBar slot), which have always mounted the sheet in the 640–768 band. Moving it to 768 would regress those consumers; leaving it makes the newly-unified consumers adopt the same coherent tablet presentation.

### Gates
- `npm run check` — 0 errors (pre-existing warnings only)
- `npm run build` — success
- `npm run test` — 153/153 pass
- Codex review — CLEAN

A focused unit test for the store was not feasible: the web vitest config runs in `node` with no Svelte plugin (the suite is "plain TS, no Svelte components"), so a `.svelte.ts` rune module importing `$app/environment` can't be compiled there without adding Svelte+jsdom test infra (out of scope). Noted as a follow-up.
