### PR TITLE
feat(web): server-busy toast for rate_limited errors (TASK-2080)

### DIFF
--- a/web/src/lib/api/client.test.ts
+++ b/web/src/lib/api/client.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { api, parseRetryAfterMs, isRateLimitError, PadApiError } from './client';
+import { api, parseRetryAfterMs, isRateLimitError, PadApiError, setRateLimitHandler } from './client';
 
 // The 401 interceptor branches on `typeof window !== 'undefined'`. The
 // vitest environment here is 'node' (see vitest.config.ts), so `window` is
@@ -243,5 +243,40 @@ describe('api client 429 handling (TASK-2026)', () => {
 		const err = (await api.workspaces.list().catch((e) => e)) as PadApiError;
 		expect(err.code).toBe('rate_limited');
 		expect(err.retryAfterMs).toBe(2000);
+	});
+});
+
+describe('rate-limit UI seam / setRateLimitHandler (TASK-2080)', () => {
+	beforeEach(() => {
+		vi.unstubAllGlobals();
+	});
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		setRateLimitHandler(null);
+	});
+
+	it('fires the registered handler once (with the Retry-After delay) when a 429 surfaces', async () => {
+		const handler = vi.fn();
+		setRateLimitHandler(handler);
+		mockFetchSequence([
+			{ status: 429, body: { error: { code: 'rate_limited' } }, retryAfter: '0' },
+			{ status: 429, body: { error: { code: 'rate_limited' } }, retryAfter: '2' },
+		]);
+
+		const err = await api.workspaces.list().catch((e) => e);
+		expect(isRateLimitError(err)).toBe(true);
+		// The surfaced 429 is the single chokepoint — handler fires exactly once,
+		// receiving the parsed Retry-After so the toast can name the wait.
+		expect(handler).toHaveBeenCalledTimes(1);
+		expect(handler).toHaveBeenCalledWith(2000);
+	});
+
+	it('does NOT fire the handler for a non-429 error', async () => {
+		const handler = vi.fn();
+		setRateLimitHandler(handler);
+		mockFetchOnce(500, { error: { code: 'internal', message: 'boom' } });
+
+		await expect(api.workspaces.list()).rejects.toBeTruthy();
+		expect(handler).not.toHaveBeenCalled();
 	});
 });

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -247,6 +247,48 @@ export function setAccessRevokedHandler(handler: AccessRevokedHandler | null): v
 }
 
 /**
+ * Fired once per surfaced 429 so the UI can show a distinct "server busy"
+ * notification instead of a generic failure (TASK-2080). The optional
+ * `retryAfterMs` is the parsed `Retry-After` delay (present only when the
+ * server sent a usable header) so the handler can say "try again in ~Ns".
+ *
+ * This is the client → UI seam that keeps client.ts free of a toast-store
+ * (Svelte) import, mirroring `setAccessRevokedHandler`. The chokepoint is
+ * the single `throw err` in the 429 branch of `request()`, so EVERY 429 that
+ * actually surfaces (auto-retry exhausted, or a non-idempotent write) calls
+ * this exactly once. Burst DEDUPE is the handler's job, not the client's —
+ * the client stays a dumb signal source.
+ */
+type RateLimitHandler = (retryAfterMs?: number) => void;
+
+let rateLimitHandler: RateLimitHandler | null = null;
+
+/**
+ * Register a single callback fired when the API client surfaces a 429
+ * `rate_limited` error. The app wires this once at startup (from
+ * +layout.svelte) to a deduped "server busy" toast. Calling this again
+ * replaces the previous handler; pass null to clear. Handler failures are
+ * swallowed so the 429 still propagates cleanly. TASK-2080.
+ */
+export function setRateLimitHandler(handler: RateLimitHandler | null): void {
+	rateLimitHandler = handler;
+}
+
+/**
+ * Best-effort fire of the registered rate-limit handler. Swallows handler
+ * failures so a broken UI hook can't corrupt the API error path. TASK-2080.
+ */
+function notifyRateLimited(retryAfterMs?: number): void {
+	if (!rateLimitHandler) return;
+	try {
+		rateLimitHandler(retryAfterMs);
+	} catch (err) {
+		// eslint-disable-next-line no-console
+		console.warn('rate-limit handler threw', err);
+	}
+}
+
+/**
  * Parse a URL path and decide whether a 403 on it indicates that the
  * caller's READ access to the workspace's item set has been revoked.
  * Returns null for any path that doesn't qualify — auth, admin,
@@ -479,6 +521,11 @@ async function request<T>(
 			details: body?.error?.details,
 		});
 		if (retryAfterMs != null) err.retryAfterMs = retryAfterMs;
+		// Single UI seam for the "server busy" notification (TASK-2080).
+		// Every 429 that actually surfaces funnels through this throw, so
+		// the registered handler fires exactly once per surfaced 429; the
+		// handler owns burst dedupe so a storm doesn't stack toasts.
+		notifyRateLimited(err.retryAfterMs);
 		throw err;
 	}
 	if (!resp.ok) {

--- a/web/src/lib/api/serverBusyToast.test.ts
+++ b/web/src/lib/api/serverBusyToast.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the rune-based toast store so this stays a pure node test (no Svelte
+// compile). We only assert on how `notifyServerBusy` calls `show`.
+vi.mock('$lib/stores/toast.svelte', () => ({
+	toastStore: { show: vi.fn() },
+}));
+
+import { toastStore } from '$lib/stores/toast.svelte';
+import {
+	notifyServerBusy,
+	serverBusyMessage,
+	__resetServerBusyToastForTest,
+} from './serverBusyToast';
+
+const showMock = toastStore.show as ReturnType<typeof vi.fn>;
+
+describe('serverBusyMessage (TASK-2080)', () => {
+	it('names the wait when a usable Retry-After is present', () => {
+		expect(serverBusyMessage(3000)).toBe('Server busy — please try again in 3s.');
+		expect(serverBusyMessage(1200)).toBe('Server busy — please try again in 1s.');
+	});
+
+	it('stays vague when no (or sub-second) Retry-After is given', () => {
+		expect(serverBusyMessage()).toBe('Server busy — please try again in a moment.');
+		expect(serverBusyMessage(0)).toBe('Server busy — please try again in a moment.');
+		expect(serverBusyMessage(400)).toBe('Server busy — please try again in a moment.');
+	});
+});
+
+describe('notifyServerBusy dedupe (TASK-2080)', () => {
+	beforeEach(() => {
+		showMock.mockClear();
+		__resetServerBusyToastForTest();
+	});
+
+	it('fires exactly one info toast for a single rate_limited notification', () => {
+		const shown = notifyServerBusy(undefined, 0);
+		expect(shown).toBe(true);
+		expect(showMock).toHaveBeenCalledTimes(1);
+		// Non-alarming severity: 'info'.
+		expect(showMock.mock.calls[0][1]).toBe('info');
+	});
+
+	it('does NOT stack toasts for a burst of 429s within the dedupe window', () => {
+		// First 429 shows; the next nine (all within the ~6s window) suppress.
+		expect(notifyServerBusy(undefined, 0)).toBe(true);
+		for (let i = 1; i <= 9; i++) {
+			expect(notifyServerBusy(undefined, i * 100)).toBe(false);
+		}
+		expect(showMock).toHaveBeenCalledTimes(1);
+	});
+
+	it('shows again once the dedupe window has elapsed', () => {
+		expect(notifyServerBusy(undefined, 0)).toBe(true);
+		// Still inside the window — suppressed.
+		expect(notifyServerBusy(undefined, 5_000)).toBe(false);
+		// Past the window — a fresh toast is allowed.
+		expect(notifyServerBusy(undefined, 6_500)).toBe(true);
+		expect(showMock).toHaveBeenCalledTimes(2);
+	});
+});

--- a/web/src/lib/api/serverBusyToast.ts
+++ b/web/src/lib/api/serverBusyToast.ts
@@ -1,0 +1,67 @@
+import { toastStore } from '$lib/stores/toast.svelte';
+
+/**
+ * "Server busy" toast handler for surfaced 429 `rate_limited` errors
+ * (TASK-2080 / PLAN-1984). The API client (`client.ts`) fires
+ * `setRateLimitHandler` once per surfaced 429; +layout.svelte wires that
+ * seam to `notifyServerBusy` here. Keeping this OUT of client.ts is
+ * deliberate — client.ts stays free of any Svelte/toast-store import
+ * (mirrors the `setAccessRevokedHandler` split).
+ *
+ * DEDUPE is this handler's whole reason for existing: a busy server 429s a
+ * BURST of independent in-flight requests at once, and the client faithfully
+ * fires the seam for each one. Without a throttle the user would get a stack
+ * of ~10 identical "server busy" toasts. We show at most one within
+ * `DEDUPE_WINDOW_MS`.
+ */
+
+// Suppress repeat busy-toasts inside this window. Slightly longer than the
+// toast's own on-screen lifetime so a sustained 429 storm can't refresh a
+// second toast the instant the first auto-dismisses.
+const DEDUPE_WINDOW_MS = 6_000;
+
+// The busy toast lingers a touch longer than the 3s default so the user
+// actually reads it before it clears.
+const BUSY_TOAST_DURATION_MS = 5_000;
+
+// Epoch ms of the last shown busy toast. Module-level so dedupe spans every
+// call site funneling through the one registered handler. Seeded to
+// -Infinity (not 0) so the very first notification always fires — otherwise a
+// caller passing now=0 (tests) would collide with a 0 initial value.
+let lastShownAt = Number.NEGATIVE_INFINITY;
+
+/**
+ * Human-readable, non-alarming busy message. When the server handed us a
+ * usable `Retry-After` (>= ~1s) we name the wait; otherwise we stay vague
+ * ("in a moment") rather than invent a number.
+ */
+export function serverBusyMessage(retryAfterMs?: number): string {
+	const secs = retryAfterMs != null && retryAfterMs > 0 ? Math.round(retryAfterMs / 1000) : 0;
+	if (secs >= 1) {
+		return `Server busy — please try again in ${secs}s.`;
+	}
+	return 'Server busy — please try again in a moment.';
+}
+
+/**
+ * Show the deduped "server busy" toast. Returns true when a toast was
+ * actually shown, false when it was suppressed as a duplicate inside the
+ * dedupe window. `now` is injectable for deterministic tests; production
+ * callers omit it. TASK-2080.
+ */
+export function notifyServerBusy(retryAfterMs?: number, now: number = Date.now()): boolean {
+	if (now - lastShownAt < DEDUPE_WINDOW_MS) return false;
+	lastShownAt = now;
+	// 'info' is the least-alarming severity the toast store offers — a busy
+	// server is transient, not an error the user did anything wrong to cause.
+	toastStore.show(serverBusyMessage(retryAfterMs), 'info', BUSY_TOAST_DURATION_MS);
+	return true;
+}
+
+/**
+ * Test-only reset of the dedupe clock so each test starts from a clean
+ * "no toast shown yet" state. Not used in production.
+ */
+export function __resetServerBusyToastForTest(): void {
+	lastShownAt = Number.NEGATIVE_INFINITY;
+}

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -7,7 +7,8 @@
 	import { authStore } from '$lib/stores/auth.svelte';
 	import { uiStore } from '$lib/stores/ui.svelte';
 	import { titleStore } from '$lib/stores/title.svelte';
-	import { setAccessRevokedHandler } from '$lib/api/client';
+	import { setAccessRevokedHandler, setRateLimitHandler } from '$lib/api/client';
+	import { notifyServerBusy } from '$lib/api/serverBusyToast';
 	import { localIndex } from '$lib/stores/localIndex.svelte';
 	import Sidebar from '$lib/components/layout/Sidebar.svelte';
 	import TopBar from '$lib/components/layout/TopBar.svelte';
@@ -61,6 +62,15 @@
 	// import that would create a circular dep.
 	setAccessRevokedHandler((scope) => {
 		localIndex.reset(scope.workspace);
+	});
+
+	// Register the "server busy" toast for surfaced 429s (TASK-2080 /
+	// PLAN-1984). The API client fires this seam once per surfaced 429;
+	// `notifyServerBusy` dedupes a burst down to a single non-alarming toast.
+	// Wired here (not inside client.ts) so client.ts stays free of a
+	// toast-store import, matching the access-revoked split above.
+	setRateLimitHandler((retryAfterMs) => {
+		notifyServerBusy(retryAfterMs);
 	});
 
 	onMount(async () => {


### PR DESCRIPTION
## What

Wires the 429 `rate_limited` handling from TASK-2026 into a dedicated, user-facing "Server busy" toast. Previously a surfaced 429 fell through to generic error handling; now it shows a distinct, non-alarming notification.

## Chokepoint

`client.ts` already funnels every surfaced 429 through a single `throw err` in the 429 branch of `request()`. I added a `setRateLimitHandler(handler)` seam (mirroring the existing `setAccessRevokedHandler` pattern) and call `notifyRateLimited(err.retryAfterMs)` right before that throw. This keeps **`client.ts` free of any UI/Svelte import** — the toast wiring lives in the layout + a small helper, exactly like the access-revoked split.

- `+layout.svelte` registers the handler once at bootstrap: `setRateLimitHandler((ms) => notifyServerBusy(ms))`.
- `serverBusyToast.ts` owns the message + dedupe, calling the existing `toastStore.show(..., 'info', ...)`.

## Dedupe

A busy server 429s a burst of independent in-flight requests at once; the client faithfully fires the seam per request. `notifyServerBusy` throttles to **one toast per 6s window** (module-level `lastShownAt`, seeded to `-Infinity` so the first call always fires). `retryAfterMs` names the wait ("try again in 3s") when the server sent a usable `Retry-After`, else stays vague ("in a moment"). Severity is `'info'` (least alarming; transient condition).

## Tests

- `serverBusyToast.test.ts` (node, mocks toast store): single 429 -> one toast; burst of 10 within window -> one toast; window elapsed -> toast fires again; message formatting.
- `client.test.ts` (new describe): a surfaced 429 fires the handler exactly once with the parsed `retryAfterMs`; a non-429 (500) does **not** fire it.

All 160 node tests pass; `npm run check` clean for touched files; `npm run build` succeeds. (The 2 jsdom suites from TASK-2081 fail to load in this worktree due to a pre-existing shared-node_modules resolution artifact — verified identical with my changes stashed.)

Codex review: CLEAN.

Refs TASK-2080, PLAN-1984.