### PR TITLE
refactor(web): extract collab-flush path from item-detail monolith (TASK-2082)

### DIFF
--- a/web/src/lib/collab/collabFlush.svelte.ts
+++ b/web/src/lib/collab/collabFlush.svelte.ts
@@ -137,6 +137,15 @@ export function createCollabFlusher(config: CollabFlusherConfig): CollabFlusher 
 	// session for the active item. Coalesces redundant multi-tab PATCHes and,
 	// combined with `ctx.baseline`, suppresses the no-edit VIEW flush (BUG-1899).
 	let lastFlushedContent: string | null = null;
+	// Monotonic reset counter. Every resetDedup() (item swap, out-of-band raw
+	// save) bumps it. A flush captures it before awaiting the PATCH and refuses
+	// to record `lastFlushedContent` if it changed while the PATCH was in flight
+	// — a reset during the flush means the snapshot we were about to commit is
+	// now stale relative to whatever triggered the reset, so committing it would
+	// re-pollute the dedupe baseline the reset just cleared. Guards the extra
+	// promise turn `await config.save()` introduces over the page's original
+	// inline await. Per Codex review (TASK-2082).
+	let resetGeneration = 0;
 
 	function cancel(): void {
 		if (timer !== undefined) {
@@ -196,18 +205,26 @@ export function createCollabFlusher(config: CollabFlusherConfig): CollabFlusher 
 		const serverContent = lastFlushedContent ?? ctx.baseline;
 		if (serverContent === toSave) return 'deduped';
 
+		// Snapshot the reset generation across the PATCH so a resetDedup() that
+		// lands while it's in flight invalidates the record below.
+		const gen = resetGeneration;
 		const result = await config.save({
 			ws: ctx.wsSlug,
 			itemId: ctx.itemId,
 			toSave,
 			keepalive,
 		});
-		// lastFlushedContent is per-item; only seed it if the item we just
-		// flushed is still the active one. Otherwise a stale flush could pollute
-		// the new page's dedupe state. (The injected save() already returns
-		// 'skipped' when a force_refresh landed while the PATCH was in flight, so
-		// we never record a known-stale base.)
-		if (result === 'flushed' && config.isActiveItem(ctx.itemId)) {
+		// lastFlushedContent is per-item; only seed it if:
+		//   - the PATCH actually flushed (save() returns 'skipped' when a
+		//     force_refresh landed mid-flight, so we never record a stale base),
+		//   - no resetDedup() ran during the PATCH (item swap / raw save would
+		//     otherwise be re-polluted by this now-stale snapshot), AND
+		//   - the item we just flushed is still the active one.
+		if (
+			result === 'flushed' &&
+			resetGeneration === gen &&
+			config.isActiveItem(ctx.itemId)
+		) {
 			lastFlushedContent = toSave;
 		}
 		return result;
@@ -226,6 +243,8 @@ export function createCollabFlusher(config: CollabFlusherConfig): CollabFlusher 
 
 	function resetDedup(): void {
 		lastFlushedContent = null;
+		// Invalidate any in-flight flush's pending record (see `gen` in flush()).
+		resetGeneration++;
 	}
 
 	return {

--- a/web/src/lib/collab/collabFlush.svelte.ts
+++ b/web/src/lib/collab/collabFlush.svelte.ts
@@ -1,0 +1,241 @@
+// collabFlusher — the collaborative (Yjs) snapshot-flush path extracted from
+// the item detail page ([collection]/[slug]/+page.svelte) as part of TASK-2082,
+// the follow-on to TASK-2029's raw-markdown `contentSaver` extraction.
+//
+// Background: under live collab the Y.Doc + op-log are canonical for editor
+// state, but downstream consumers (search, share-page, exports, API readers)
+// read `items.content`. So the page flushes a markdown snapshot of the live
+// Y.Doc into `items.content` via the `?source=collab-snapshot` bypass on a 5s
+// idle timer, on editor teardown, and on `beforeunload` (TASK-1260 / TASK-1319
+// / BUG-1899 / BUG-1941). That machinery — the 5s debounce timer, the per-item
+// `lastFlushedContent` dedupe state, and the two-stage dedupe decision — is
+// what this module owns.
+//
+// It mirrors `contentSaver.svelte.ts`'s pattern: the module owns its own timer
+// and pending/dedupe state, and every piece of Svelte-reactive, API, or
+// editor/provider access the page can't hand off is INJECTED as a callback.
+// The module makes no Svelte / API / DOM calls itself, so it's unit-testable in
+// plain node.
+//
+// What stays in the page (injected via `CollabFlusherConfig`):
+//   - `isRecovering()`   — reads the page's plain `forceRefreshInFlight` guard.
+//   - `normalize()`      — `unescapeDocLinks` (markdown util).
+//   - `serialize()`      — `markdownToWikiLinks` + `cleanBrokenLinks` against a
+//                          workspace's live link index (page-owned `localIndex`).
+//   - `readEditorMarkdown()` — reads the live Tiptap editor's markdown storage.
+//   - `isActiveItem()`   — reads the page's reactive `item` to gate per-item
+//                          dedupe seeding.
+//   - `save()`           — the actual `api.items.flushCollabContent` PATCH plus
+//                          ALL reactive bookkeeping (saveStatus, editorStore,
+//                          toast, showSaved) and the post-await force-refresh
+//                          check + op-log-cursor read. Returns the outcome so
+//                          the module can record `lastFlushedContent`.
+//
+// NOTE (CONVE-1688): `lastFlushedContent` and `timer` are plain closure
+// variables, NOT `$state`. They're handler-only trackers; a `$state` written
+// inside the page's flush handlers that an $effect also read would silently
+// wedge the effect scheduler in PROD. This file is `.svelte.ts` for colocation
+// with the item-page module conventions but uses no runes.
+
+import { shouldDedupeEditorSpace } from './flushDedupe';
+
+/** The (workspace, item) a flush targets, captured at provider-mint time (NOT
+ *  read from live reactive state at flush time) so a navigation in flight can't
+ *  mis-route a PATCH to a different item. Mirrors the page's
+ *  `activeCollabContext` shape exactly. */
+export interface CollabFlushContext {
+	wsSlug: string;
+	itemId: string;
+	/** `item.content` at load — what the server already has. The baseline arm
+	 *  of the dedupe that makes a no-edit VIEW a no-op (BUG-1899). */
+	baseline: string;
+	/** Editor-markdown-space projection of the Y.Doc seed for the editor-space
+	 *  short-circuit (BUG-1941). Null when no seed was captured this session. */
+	seedMd: string | null;
+}
+
+// CollabFlushResult discriminates the four outcomes a flush can produce:
+//   - 'flushed' — PATCH succeeded; items.content now matches.
+//   - 'deduped' — skipped because the server already has this markdown (either
+//     lastFlushedContent already matched, the per-item baseline matched, or the
+//     editor-space short-circuit fired). Callers like the rich→raw toggle treat
+//     it as equivalent to 'flushed' for seeding purposes.
+//   - 'failed'  — PATCH errored. The toggle path bails so we don't enter raw
+//     mode with stale state.
+//   - 'skipped' — TASK-1319 force_refresh-recovery path: the local Y.Doc state
+//     is known stale relative to the canonical server content, so the flush was
+//     refused. Distinct from 'deduped' so callers can refuse to seed from it.
+export type CollabFlushResult = 'flushed' | 'deduped' | 'failed' | 'skipped';
+
+export interface CollabSaveInput {
+	ws: string;
+	itemId: string;
+	/** The fully-serialized storage-form markdown to PATCH. */
+	toSave: string;
+	keepalive: boolean;
+}
+
+export interface CollabFlusherConfig {
+	/** Idle debounce window in ms for the 5s snapshot flush (default 5000). */
+	idleMs?: number;
+	/** True while force-refresh recovery is in flight — any Y.Doc-derived
+	 *  markdown is known stale, so scheduling and running both bail. Reads the
+	 *  page's plain `forceRefreshInFlight`. */
+	isRecovering: () => boolean;
+	/** Normalize editor markdown into the space the dedupe compares in
+	 *  (`unescapeDocLinks`). */
+	normalize: (markdown: string) => string;
+	/** Serialize normalized markdown into storage form for the given workspace:
+	 *  `markdownToWikiLinks` (against `ws`'s live link index) + `cleanBrokenLinks`. */
+	serialize: (normalizedMarkdown: string, ws: string) => string;
+	/** Read the live editor's markdown for a flush-now. Returns null when the
+	 *  editor is unavailable or reading its storage throws (so the caller no-ops). */
+	readEditorMarkdown: () => string | null;
+	/** True when `itemId` is still the page's active item — gates per-item
+	 *  `lastFlushedContent` seeding so a stale flush can't pollute the new
+	 *  page's dedupe state. Reads the page's reactive `item`. */
+	isActiveItem: (itemId: string) => boolean;
+	/** Perform the actual PATCH + reactive bookkeeping. Owns saveStatus /
+	 *  editorStore / toast / showSaved, the op-log-cursor read, and the
+	 *  post-await force-refresh check (returning 'skipped' when it fires).
+	 *  Resolves 'flushed' on success, 'failed' on PATCH error. */
+	save: (input: CollabSaveInput) => Promise<'flushed' | 'failed' | 'skipped'>;
+}
+
+export interface CollabFlusher {
+	/** Arm (or re-arm) the idle debounce to flush `markdown` for `ctx`. No-op
+	 *  when recovering or `ctx` is null. Cancels any prior pending flush first,
+	 *  so rapid edits coalesce into one flush of the last markdown. */
+	schedule(ctx: CollabFlushContext | null, markdown: string): void;
+	/** Run a flush immediately for the given `markdown` + `ctx`, applying the
+	 *  full recovery/dedupe gauntlet before the injected PATCH. Used by the
+	 *  rich→raw toggle, which acts on the returned outcome. Does NOT touch the
+	 *  debounce timer (the caller cancels it explicitly). */
+	flush(ctx: CollabFlushContext, markdown: string, keepalive: boolean): Promise<CollabFlushResult>;
+	/** Cancel the debounce, read the live editor markdown, and flush it now.
+	 *  Returns false (no-op) when the editor is unavailable. Used by editor
+	 *  teardown + beforeunload with keepalive=true to land the snapshot before
+	 *  the provider tears down. */
+	flushNow(ctx: CollabFlushContext, keepalive: boolean): boolean;
+	/** Cancel the pending debounce without flushing. Leaves dedupe state intact. */
+	cancel(): void;
+	/** Reset the per-item dedupe baseline (`lastFlushedContent`). Call on item
+	 *  swap and after any out-of-band raw save that changed items.content via a
+	 *  path this dedupe doesn't see. */
+	resetDedup(): void;
+	/** The last content this session successfully flushed, or null before the
+	 *  first flush / after a reset. Exposed for assertions/diagnostics. */
+	readonly lastFlushed: string | null;
+}
+
+const DEFAULT_IDLE_MS = 5_000;
+
+export function createCollabFlusher(config: CollabFlusherConfig): CollabFlusher {
+	const idleMs = config.idleMs ?? DEFAULT_IDLE_MS;
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	// Per-item dedupe state: the last content we successfully flushed this
+	// session for the active item. Coalesces redundant multi-tab PATCHes and,
+	// combined with `ctx.baseline`, suppresses the no-edit VIEW flush (BUG-1899).
+	let lastFlushedContent: string | null = null;
+
+	function cancel(): void {
+		if (timer !== undefined) {
+			clearTimeout(timer);
+			timer = undefined;
+		}
+	}
+
+	function schedule(ctx: CollabFlushContext | null, markdown: string): void {
+		cancel();
+		// Force-refresh recovery in flight: block any new flush scheduling. The
+		// provider is destroyed but the editor component is still mounted; a
+		// local edit during this window must NOT arm a flush against the stale
+		// Y.Doc state. Per Codex round 7 [P1] of TASK-1319.
+		if (config.isRecovering()) return;
+		if (!ctx) return;
+		timer = setTimeout(() => {
+			timer = undefined;
+			void flush(ctx, markdown, false);
+		}, idleMs);
+	}
+
+	async function flush(
+		ctx: CollabFlushContext,
+		markdown: string,
+		keepalive: boolean,
+	): Promise<CollabFlushResult> {
+		// Force-refresh recovery is in flight: any markdown derived from the
+		// soon-to-be-discarded Y.Doc is stale relative to canonical server
+		// content. Skipping here covers every direct caller (beforeunload,
+		// raw-toggle, flushNow) without per-call-site guards. Per Codex round 8
+		// [P1] of TASK-1319.
+		if (config.isRecovering()) return 'skipped';
+		const normalizedMarkdown = config.normalize(markdown);
+		// Editor-markdown-space short-circuit (BUG-1941, regression of BUG-1899).
+		// BEFORE re-serializing through markdownToWikiLinks — which depends on
+		// the FLUSH-TIME wiki-link index and can diverge from a stable seed on
+		// index drift — check whether this is a pure no-edit view of the exact
+		// markdown seeded into the Y.Doc this session. shouldDedupeEditorSpace
+		// scopes this to the baseline arm only (lastFlushedContent === null); see
+		// its own doc comment for the revert-safety rationale the storage-space
+		// compare below still owns.
+		if (shouldDedupeEditorSpace(lastFlushedContent, ctx.seedMd, normalizedMarkdown)) {
+			return 'deduped';
+		}
+		// Serialize against the CAPTURED workspace (the item being flushed), not
+		// live route state — a background/unmount flush can fire after navigating
+		// to another workspace; the PATCH already targets `ctx.wsSlug`, so the
+		// link index must match it. Per Codex review (round 1).
+		const toSave = config.serialize(normalizedMarkdown, ctx.wsSlug);
+		// Dedupe against what the server already has for this item. Once we've
+		// flushed this session that's `lastFlushedContent`; before any flush it's
+		// the per-item `baseline` captured at load. The baseline arm makes merely
+		// VIEWING an item a no-op — a real edit changes `toSave`, so only genuine
+		// no-ops are suppressed. (Revert-safe: after a real flush
+		// `lastFlushedContent` is non-null and takes precedence.)
+		const serverContent = lastFlushedContent ?? ctx.baseline;
+		if (serverContent === toSave) return 'deduped';
+
+		const result = await config.save({
+			ws: ctx.wsSlug,
+			itemId: ctx.itemId,
+			toSave,
+			keepalive,
+		});
+		// lastFlushedContent is per-item; only seed it if the item we just
+		// flushed is still the active one. Otherwise a stale flush could pollute
+		// the new page's dedupe state. (The injected save() already returns
+		// 'skipped' when a force_refresh landed while the PATCH was in flight, so
+		// we never record a known-stale base.)
+		if (result === 'flushed' && config.isActiveItem(ctx.itemId)) {
+			lastFlushedContent = toSave;
+		}
+		return result;
+	}
+
+	function flushNow(ctx: CollabFlushContext, keepalive: boolean): boolean {
+		cancel();
+		const md = config.readEditorMarkdown();
+		if (md === null) return false;
+		// flush is async but its return value is irrelevant for synchronous
+		// callers — fire-and-forget under keepalive=true is the contract on the
+		// unmount / beforeunload path.
+		void flush(ctx, md, keepalive);
+		return true;
+	}
+
+	function resetDedup(): void {
+		lastFlushedContent = null;
+	}
+
+	return {
+		schedule,
+		flush,
+		flushNow,
+		cancel,
+		resetDedup,
+		get lastFlushed() {
+			return lastFlushedContent;
+		},
+	};
+}

--- a/web/src/lib/collab/collabFlush.test.ts
+++ b/web/src/lib/collab/collabFlush.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+	createCollabFlusher,
+	type CollabFlushContext,
+	type CollabFlusherConfig,
+} from './collabFlush.svelte';
+
+// A ctx helper mirroring the page's activeCollabContext shape.
+function ctx(overrides: Partial<CollabFlushContext> = {}): CollabFlushContext {
+	return {
+		wsSlug: 'ws',
+		itemId: 'item-1',
+		baseline: 'baseline text',
+		seedMd: null,
+		...overrides,
+	};
+}
+
+// Build a flusher with sensible identity defaults; every injected callback is
+// overridable per-test. `save` defaults to a spy that resolves 'flushed'.
+function makeFlusher(overrides: Partial<CollabFlusherConfig> = {}) {
+	const save = vi.fn(
+		async (_input: { ws: string; itemId: string; toSave: string; keepalive: boolean }) =>
+			'flushed' as const,
+	);
+	const config: CollabFlusherConfig = {
+		idleMs: 5000,
+		isRecovering: () => false,
+		normalize: (m) => m,
+		serialize: (m) => m, // identity: toSave === normalized markdown
+		readEditorMarkdown: () => 'editor md',
+		isActiveItem: () => true,
+		save,
+		...overrides,
+	};
+	return { flusher: createCollabFlusher(config), save, config };
+}
+
+describe('createCollabFlusher — scheduling / debounce', () => {
+	beforeEach(() => vi.useFakeTimers());
+	afterEach(() => vi.useRealTimers());
+
+	it('arms a 5s idle flush that fires the injected save with keepalive=false', () => {
+		const { flusher, save } = makeFlusher();
+		flusher.schedule(ctx(), 'hello');
+		expect(save).not.toHaveBeenCalled();
+		vi.advanceTimersByTime(5000);
+		expect(save).toHaveBeenCalledTimes(1);
+		expect(save).toHaveBeenCalledWith(
+			expect.objectContaining({ toSave: 'hello', keepalive: false, itemId: 'item-1' }),
+		);
+	});
+
+	it('coalesces rapid edits into one flush of the last markdown', () => {
+		const { flusher, save } = makeFlusher();
+		flusher.schedule(ctx(), 'a');
+		vi.advanceTimersByTime(2000);
+		flusher.schedule(ctx(), 'ab'); // re-arms, cancelling the first
+		vi.advanceTimersByTime(2000);
+		flusher.schedule(ctx(), 'abc');
+		expect(save).not.toHaveBeenCalled();
+		vi.advanceTimersByTime(5000);
+		expect(save).toHaveBeenCalledTimes(1);
+		expect(save).toHaveBeenCalledWith(expect.objectContaining({ toSave: 'abc' }));
+	});
+
+	it('does not schedule while force-refresh recovery is in flight', () => {
+		const { flusher, save } = makeFlusher({ isRecovering: () => true });
+		flusher.schedule(ctx(), 'hello');
+		vi.advanceTimersByTime(10000);
+		expect(save).not.toHaveBeenCalled();
+	});
+
+	it('does not schedule when there is no active context', () => {
+		const { flusher, save } = makeFlusher();
+		flusher.schedule(null, 'hello');
+		vi.advanceTimersByTime(10000);
+		expect(save).not.toHaveBeenCalled();
+	});
+
+	it('cancel() disarms a pending scheduled flush (no cross-item bleed on swap)', () => {
+		const { flusher, save } = makeFlusher();
+		flusher.schedule(ctx(), 'hello');
+		flusher.cancel();
+		vi.advanceTimersByTime(10000);
+		expect(save).not.toHaveBeenCalled();
+	});
+});
+
+describe('createCollabFlusher — dedupe', () => {
+	it("editor-space short-circuit: no-edit view of the session's seed dedupes without serializing or saving", async () => {
+		const serialize = vi.fn((m: string) => m);
+		const { flusher, save } = makeFlusher({ serialize });
+		const result = await flusher.flush(ctx({ seedMd: 'seed text' }), 'seed text', false);
+		expect(result).toBe('deduped');
+		expect(save).not.toHaveBeenCalled();
+		// Short-circuit happens BEFORE serialize (the whole point of BUG-1941).
+		expect(serialize).not.toHaveBeenCalled();
+	});
+
+	it('storage-space dedupe against the per-item baseline: merely viewing an item is a no-op', async () => {
+		const { flusher, save } = makeFlusher();
+		const result = await flusher.flush(ctx({ baseline: 'baseline text' }), 'baseline text', false);
+		expect(result).toBe('deduped');
+		expect(save).not.toHaveBeenCalled();
+	});
+
+	it('a real edit (markdown differs from baseline) flushes', async () => {
+		const { flusher, save } = makeFlusher();
+		const result = await flusher.flush(ctx({ baseline: 'old' }), 'new content', false);
+		expect(result).toBe('flushed');
+		expect(save).toHaveBeenCalledWith(expect.objectContaining({ toSave: 'new content' }));
+	});
+
+	it('records lastFlushed after a successful flush, then dedupes an identical re-flush', async () => {
+		const { flusher, save } = makeFlusher();
+		await flusher.flush(ctx({ baseline: 'old' }), 'edited', false);
+		expect(flusher.lastFlushed).toBe('edited');
+		save.mockClear();
+		// Same content again -> serverContent (lastFlushed) === toSave -> deduped.
+		const second = await flusher.flush(ctx({ baseline: 'old' }), 'edited', false);
+		expect(second).toBe('deduped');
+		expect(save).not.toHaveBeenCalled();
+	});
+
+	it('does NOT record lastFlushed when the flushed item is no longer active (no stale-page pollution)', async () => {
+		const { flusher } = makeFlusher({ isActiveItem: () => false });
+		const result = await flusher.flush(ctx({ baseline: 'old' }), 'edited', false);
+		expect(result).toBe('flushed');
+		expect(flusher.lastFlushed).toBeNull();
+	});
+
+	it('does NOT record lastFlushed when save reports failed / skipped', async () => {
+		const failed = makeFlusher({ save: vi.fn(async () => 'failed' as const) });
+		expect(await failed.flusher.flush(ctx({ baseline: 'old' }), 'edited', false)).toBe('failed');
+		expect(failed.flusher.lastFlushed).toBeNull();
+
+		const skipped = makeFlusher({ save: vi.fn(async () => 'skipped' as const) });
+		expect(await skipped.flusher.flush(ctx({ baseline: 'old' }), 'edited', false)).toBe('skipped');
+		expect(skipped.flusher.lastFlushed).toBeNull();
+	});
+});
+
+describe('createCollabFlusher — recovery gate', () => {
+	it('flush() bails to skipped while recovering, without saving', async () => {
+		const { flusher, save } = makeFlusher({ isRecovering: () => true });
+		const result = await flusher.flush(ctx({ baseline: 'old' }), 'edited', false);
+		expect(result).toBe('skipped');
+		expect(save).not.toHaveBeenCalled();
+	});
+});
+
+describe('createCollabFlusher — flushNow (teardown / beforeunload)', () => {
+	beforeEach(() => vi.useFakeTimers());
+	afterEach(() => vi.useRealTimers());
+
+	it('reads live editor markdown, flushes it, and returns true', () => {
+		const { flusher, save } = makeFlusher({ readEditorMarkdown: () => 'live editor md' });
+		const ok = flusher.flushNow(ctx({ baseline: 'old' }), true);
+		expect(ok).toBe(true);
+		expect(save).toHaveBeenCalledWith(
+			expect.objectContaining({ toSave: 'live editor md', keepalive: true }),
+		);
+	});
+
+	it('no-ops (returns false) when the editor is unavailable', () => {
+		const { flusher, save } = makeFlusher({ readEditorMarkdown: () => null });
+		const ok = flusher.flushNow(ctx(), true);
+		expect(ok).toBe(false);
+		expect(save).not.toHaveBeenCalled();
+	});
+
+	it('cancels the pending debounce so it cannot fire a second, older-content flush', () => {
+		const { flusher, save } = makeFlusher({ readEditorMarkdown: () => 'live md' });
+		flusher.schedule(ctx({ baseline: 'old' }), 'stale debounced md');
+		flusher.flushNow(ctx({ baseline: 'old' }), true);
+		vi.advanceTimersByTime(10000);
+		// Only the flushNow save fired; the debounce was cancelled.
+		expect(save).toHaveBeenCalledTimes(1);
+		expect(save).toHaveBeenCalledWith(expect.objectContaining({ toSave: 'live md' }));
+	});
+});
+
+describe('createCollabFlusher — resetDedup', () => {
+	it('clears the recorded baseline so an identical content flushes again (post raw-save)', async () => {
+		const { flusher, save } = makeFlusher();
+		await flusher.flush(ctx({ baseline: 'old' }), 'edited', false);
+		expect(flusher.lastFlushed).toBe('edited');
+		// Raw save happened out-of-band; reset so the collab dedupe can't skip.
+		flusher.resetDedup();
+		expect(flusher.lastFlushed).toBeNull();
+		save.mockClear();
+		// With lastFlushed cleared, serverContent falls back to baseline ('old'),
+		// so re-flushing 'edited' is a real PATCH again.
+		const result = await flusher.flush(ctx({ baseline: 'old' }), 'edited', false);
+		expect(result).toBe('flushed');
+		expect(save).toHaveBeenCalled();
+	});
+});

--- a/web/src/lib/collab/collabFlush.test.ts
+++ b/web/src/lib/collab/collabFlush.test.ts
@@ -181,6 +181,32 @@ describe('createCollabFlusher — flushNow (teardown / beforeunload)', () => {
 	});
 });
 
+describe('createCollabFlusher — reset during an in-flight flush', () => {
+	it('does NOT record lastFlushed if resetDedup() lands while the PATCH is in flight (no stale re-pollution)', async () => {
+		// A deferred save so we can interleave a reset before it resolves.
+		let resolveSave!: (v: 'flushed') => void;
+		const save = vi.fn(
+			() =>
+				new Promise<'flushed'>((res) => {
+					resolveSave = res;
+				}),
+		);
+		const { flusher } = makeFlusher({ save });
+
+		const flushPromise = flusher.flush(ctx({ baseline: 'old' }), 'edited', false);
+		expect(save).toHaveBeenCalledTimes(1);
+		// An out-of-band raw save / item swap resets the dedupe baseline WHILE the
+		// collab PATCH is still awaiting.
+		flusher.resetDedup();
+		expect(flusher.lastFlushed).toBeNull();
+		// Now the collab PATCH resolves — its stale snapshot must NOT re-seed.
+		resolveSave('flushed');
+		const result = await flushPromise;
+		expect(result).toBe('flushed');
+		expect(flusher.lastFlushed).toBeNull();
+	});
+});
+
 describe('createCollabFlusher — resetDedup', () => {
 	it('clears the recorded baseline so an identical content flushes again (post raw-save)', async () => {
 		const { flusher, save } = makeFlusher();

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -16,7 +16,7 @@
 	import * as Y from 'yjs';
 	import { CollabProvider, type CollabConnectionState } from '$lib/collab/wsProvider.svelte';
 	import { userColor } from '$lib/collab/cursorColor';
-	import { shouldDedupeEditorSpace } from '$lib/collab/flushDedupe';
+	import { createCollabFlusher, type CollabFlushContext } from '$lib/collab/collabFlush.svelte';
 	import { createContentSaver } from '$lib/items/contentSaver.svelte';
 	import { authStore } from '$lib/stores/auth.svelte';
 	import FieldEditor from '$lib/components/fields/FieldEditor.svelte';
@@ -517,8 +517,7 @@
 		// debounce too. Per Codex review round 10.
 		clearTimeout(contentDebounceTimer);
 		contentDebounceTimer = undefined;
-		clearTimeout(collabFlushTimer);
-		collabFlushTimer = undefined;
+		collabFlusher.cancel();
 		rawSeedMarkdown = null;
 		// Cancel the raw saver's debounce and drop its pending edit so a
 		// stale queued markdown from item A can't PATCH into item B.
@@ -529,7 +528,7 @@
 		// the next item (which happens to share the same markdown
 		// as the last flush of the previous item — vanishingly
 		// unlikely but trivial to defend).
-		lastFlushedContent = null;
+		collabFlusher.resetDedup();
 		// Reset transient save UI state too. Without this, a stale
 		// raw PATCH that gets discarded by the new race guard
 		// (item.id mismatch) leaves saveStatus pinned at 'saving' on
@@ -976,8 +975,7 @@
 				// fired would otherwise PATCH the (stale) Y.Doc-
 				// derived markdown after the cleanup ran. Per
 				// Codex round 2 [P1].
-				clearTimeout(collabFlushTimer);
-				collabFlushTimer = undefined;
+				collabFlusher.cancel();
 				// Refresh items.content from the server BEFORE
 				// rebuilding the Y.Doc. Without this, the lazy
 				// seed (TASK-1261) on the new doc reads the
@@ -1073,7 +1071,7 @@
 			const skipFlush = skipFlushOnNextCleanup;
 			skipFlushOnNextCleanup = false;
 			if (!rawMode && !skipFlush) {
-				flushCollabNow(ctx, true);
+				collabFlusher.flushNow(ctx, true);
 			}
 			provider.destroy();
 			doc.destroy();
@@ -1101,7 +1099,7 @@
 		const onBeforeUnload = (event: BeforeUnloadEvent) => {
 			// Collab path: flush the live Y.Doc snapshot (unchanged).
 			const ctx = activeCollabContext;
-			if (ctx) flushCollabNow(ctx, true);
+			if (ctx) collabFlusher.flushNow(ctx, true);
 
 			// Raw-markdown path (BUG-2024). The saver's pending markdown is
 			// the exact debounced-but-unsaved edit; when dirty there is up
@@ -1674,20 +1672,12 @@
 		}
 	}
 
-	// Tracks the last markdown we successfully PATCHed to items.content
-	// in collab-flush mode. Lets the idle-fire dedupe redundant flushes
-	// across multiple connected tabs that all converge on the same
-	// Y.Doc state — without this, every tab fires its own 5s flush
-	// after every shared edit, multiplying server PATCH load by the
-	// peer count.
-	let lastFlushedContent: string | null = null;
-
-	// 5s-idle timer for the collab flush path. Distinct from
-	// contentDebounceTimer (which the legacy non-collab and raw-mode
-	// paths still use) so the two firings don't trample each other on
-	// rapid mode toggles.
-	let collabFlushTimer: ReturnType<typeof setTimeout> | undefined;
-	const COLLAB_FLUSH_IDLE_MS = 5_000;
+	// The 5s-idle debounce timer, the per-item `lastFlushedContent` dedupe
+	// state, and the two-stage dedupe decision for the collab-snapshot flush
+	// path all live in `collabFlusher` (createCollabFlusher, defined below,
+	// TASK-2082). It's distinct from contentDebounceTimer (which the legacy
+	// non-collab and raw-mode paths still use) so the two firings don't trample
+	// each other on rapid mode toggles.
 
 	function handleContentUpdate(markdown: string) {
 		// Collab-active path: 5s idle flush of items.content via the
@@ -1698,7 +1688,7 @@
 		// TASK-1260 / PLAN-1248.
 		if (collabProvider) {
 			editorStore.setDirty(true);
-			scheduleCollabFlush(markdown);
+			collabFlusher.schedule(activeCollabContext, markdown);
 			return;
 		}
 		clearTimeout(contentDebounceTimer);
@@ -1741,7 +1731,7 @@
 	// flushes still PATCH the OLD item's URL with its OLD markdown,
 	// so we never cross-write one item's content into another. Per
 	// Codex review round 1.
-	let activeCollabContext: { wsSlug: string; itemId: string; baseline: string; seedMd: string | null } | null = null;
+	let activeCollabContext: CollabFlushContext | null = null;
 
 	// Provider we've already attempted the lazy seed against. Reset
 	// implicitly when collabProvider is replaced (the new provider
@@ -1749,209 +1739,125 @@
 	// TASK-1261 / PLAN-1248.
 	let seededProvider: CollabProvider | null = null;
 
-	function scheduleCollabFlush(markdown: string) {
-		clearTimeout(collabFlushTimer);
-		// Force-refresh recovery in flight: block any new flush
-		// scheduling. The provider is destroyed but the editor
-		// component is still mounted (cleanup hasn't run yet); a
-		// local edit during this window must NOT arm a flush timer
-		// against the stale Y.Doc state. Per Codex round 7 [P1].
-		if (forceRefreshInFlight) return;
-		const ctx = activeCollabContext;
-		if (!ctx) return;
-		collabFlushTimer = setTimeout(() => {
-			collabFlushTimer = undefined;
-			void runCollabFlush(ctx.wsSlug, ctx.itemId, markdown, false, ctx.baseline, ctx.seedMd);
-		}, COLLAB_FLUSH_IDLE_MS);
-	}
-
-	// CollabFlushResult discriminates the three outcomes runCollabFlush
-	// can produce so callers can act on them differently:
-	//   - 'flushed' — PATCH succeeded; items.content now matches.
-	//   - 'deduped' — skipped because lastFlushedContent already
-	//     matched; items.content is ALREADY at this content (the
-	//     previous successful flush put it there). Treated by the
-	//     rich→raw toggle as equivalent to 'flushed' for seeding
-	//     purposes — both mean "server has this markdown."
-	//   - 'failed' — PATCH errored. The toggle path bails so we
-	//     don't enter raw mode with stale state.
-	// Per Codex review round 8.
-	// 'skipped' is the TASK-1319 force_refresh-recovery path: the
-	// flush was blocked because the local Y.Doc state is known
-	// stale relative to the canonical server content. Distinct
-	// from 'deduped' (server already has this markdown) so callers
-	// like the rich→raw toggle can refuse to seed from the stale
-	// markdown rather than silently propagate it.
-	type CollabFlushResult = 'flushed' | 'deduped' | 'failed' | 'skipped';
-
-	// runCollabFlush PATCHes items.content via the
-	// `?source=collab-snapshot` bypass. Takes ws/item from the
-	// captured context (NOT live reactive state) so a navigation in
-	// flight doesn't mis-route the PATCH to a different item.
-	async function runCollabFlush(
-		ws: string,
-		itemId: string,
-		markdown: string,
-		keepalive: boolean,
-		baseline: string,
-		seedMarkdown: string | null = null,
-	): Promise<CollabFlushResult> {
-		// Force-refresh recovery is in flight: any markdown derived
-		// from the soon-to-be-discarded Y.Doc is, by definition,
-		// stale relative to the canonical server content. Skipping
-		// here covers every direct caller (beforeunload, raw-toggle,
-		// flushCollabNow) without needing per-call-site guards. Per
-		// Codex round 8 [P1] of TASK-1319.
-		if (forceRefreshInFlight) return 'skipped';
-		const normalizedMarkdown = unescapeDocLinks(markdown);
-		// Editor-markdown-space short-circuit (BUG-1941, regression of
-		// BUG-1899). BEFORE re-serializing through markdownToWikiLinks —
-		// which depends on the FLUSH-TIME wiki-link index and can diverge
-		// from a stable seed on index drift or a merely non-canonical
-		// stored link — check whether this is a pure no-edit view of the
-		// exact markdown that was seeded into the Y.Doc this session.
-		// shouldDedupeEditorSpace scopes this to the baseline arm only
-		// (lastFlushedContent === null); see its own doc comment for the
-		// revert-safety rationale the storage-space compare below still
-		// owns. seedMarkdown comes from one of two sources (see the
-		// ctx-creation $effect): the lazy-seed effect's exact
-		// just-written value when this tab actually seeded the Y.Doc, or
-		// — for every other tab, including a losing multi-tab peer or a
-		// plain reopen of an already-established item — an eager
-		// projection of item.content through the current-load-time index.
-		// Known boundary: that eager projection only matches what's
-		// actually in the Y.Doc when the Y.Doc's established content
-		// agrees with THIS load's index projection of item.content. If
-		// the Y.Doc holds link display text rendered under a PAST index
-		// that has since drifted (e.g. a linked item was renamed since
-		// the content was last established), the projection won't match
-		// and this check safely falls through to the storage-space
-		// compare below — never a false dedupe, just a missed one. That
-		// residual case's visible symptom (a re-float) is covered by the
-		// Manual-comparator tiebreak. Accepted scope per BUG-1941.
-		if (shouldDedupeEditorSpace(lastFlushedContent, seedMarkdown, normalizedMarkdown)) {
-			return 'deduped';
-		}
-		// Resolve links against the CAPTURED `ws` (the item being
-		// flushed), not the live route `wsSlug`. A background/unmount
-		// flush can fire after navigating to another workspace; the PATCH
-		// already targets `ws`, so the link index must match it — using
-		// `wsSlug` would convert links against the wrong workspace's
-		// index. Per Codex review (round 1).
-		const allItems = localIndex.getAll(ws);
-		let toSave = normalizedMarkdown;
-		if (allItems.length > 0) {
-			toSave = markdownToWikiLinks(toSave, allItems);
-		}
-		toSave = cleanBrokenLinks(toSave);
-		// Dedupe: skip the PATCH if our last successful flush
-		// already landed this exact content. Multiple connected
-		// tabs would otherwise each fire a redundant PATCH after
-		// every shared edit converges. Returns 'deduped' (NOT
-		// 'failed') so callers can distinguish "no work needed"
-		// from a real error. Per Codex review round 8.
-		// Dedupe against what the server already has for this item. Once
-		// we've flushed this session that's `lastFlushedContent`; before any
-		// flush it's the per-item `baseline` captured at load. The baseline
-		// arm is what makes merely VIEWING an item a no-op — a real edit
-		// changes `toSave`, so only genuine no-ops are suppressed. (Revert-
-		// safe: after a real flush `lastFlushedContent` is non-null and
-		// takes precedence, so editing away then back still flushes.)
-		const serverContent = lastFlushedContent ?? baseline;
-		if (serverContent === toSave) return 'deduped';
-
-		// UI mutations only fire when:
-		//   - This is a foreground (user-driven) flush (!keepalive),
-		//     AND
-		//   - The user is still looking at the item we're flushing
-		//     (item.id === itemId).
-		// Background (keepalive=true) cleanup flushes after
-		// navigation MUST NOT touch saveStatus / lastSaveTime —
-		// those slots belong to whatever item the user is now on,
-		// and stamping them from a stale flush leaves the new page
-		// pinned in 'Saving...' indefinitely. Per Codex review
-		// round 2.
-		const isForegroundCurrent = (): boolean =>
-			!keepalive && !!item && item.id === itemId;
-
-		if (isForegroundCurrent()) {
-			saveStatus = 'saving';
-			editorStore.setLastSaveTime(Date.now());
-		}
-		try {
-			// Pass the provider's per-tab op-log cursor (TASK-1319) so
-			// the server can advance the GC watermark when this tab is
-			// caught up to MAX(op-log.id). When the cursor is below
-			// MAX (peer ops not yet applied here) the server leaves
-			// the watermark untouched — the GC sweeper must not delete
-			// rows this markdown doesn't reflect. The cursor reflects
-			// the provider tracking THIS item; if a navigation has
-			// already swapped to another item the foreground flush
-			// path bails earlier on dedupe and this code doesn't run.
-			const opLogCursor =
-				collabProvider && collabProvider.itemID === itemId
-					? collabProvider.lastOpLogID
-					: undefined;
-			await api.items.flushCollabContent(ws, itemId, toSave, {
-				keepalive,
-				opLogCursor,
-			});
-			// Post-await force_refresh check: a force_refresh
-			// frame can arrive WHILE the PATCH is in flight
-			// (server already accepted, items.content already
-			// overwritten — the server-side gate covers the
-			// happens-before case where MIN had advanced past
-			// our cursor by the time the request landed). At
-			// minimum, refuse to record this flush as
-			// authoritative locally — don't seed lastFlushedContent
-			// or update saveStatus from a known-stale base. Per
-			// Codex round 10 [P1].
-			if (forceRefreshInFlight) return 'skipped';
-			// lastFlushedContent is per-item; only seed it if the
-			// item we just flushed is still the active one.
-			// Otherwise a stale flush could pollute the new page's
-			// dedupe state.
-			if (item && item.id === itemId) {
-				lastFlushedContent = toSave;
+	// collabFlusher (TASK-2082) owns the collab-snapshot flush's scheduling,
+	// 5s debounce, per-item `lastFlushedContent` dedupe state, and the
+	// two-stage dedupe decision (editor-space short-circuit + storage-space
+	// compare). Everything Svelte-reactive / API / editor-coupled the module
+	// can't own is injected below:
+	//
+	//   - schedule() replaces the old `scheduleCollabFlush` (5s idle arm).
+	//   - flush()    replaces the old `runCollabFlush` (called directly by the
+	//                rich→raw toggle, acting on the returned outcome).
+	//   - flushNow() replaces the old `flushCollabNow` (editor teardown +
+	//                beforeunload; reads the live editor markdown then flushes).
+	//   - cancel()/resetDedup() replace the inline `clearTimeout(collabFlushTimer)`
+	//     / `lastFlushedContent = null` sites.
+	//
+	// The PATCH + all reactive bookkeeping (saveStatus / editorStore / toast /
+	// showSaved), the op-log-cursor read, and the post-await force_refresh check
+	// stay HERE in the injected `save` — the module owns none of it. This
+	// mirrors contentSaver's split: the module owns timing/dedup; the page owns
+	// the effectful bits it's coupled to.
+	const collabFlusher = createCollabFlusher({
+		idleMs: 5_000,
+		// Force-refresh recovery gate: while in flight, any Y.Doc-derived
+		// markdown is stale relative to canonical server content, so both
+		// scheduling and running bail. Per Codex round 7/8 [P1] of TASK-1319.
+		isRecovering: () => forceRefreshInFlight,
+		normalize: (markdown) => unescapeDocLinks(markdown),
+		// Serialize against the CAPTURED workspace (the item being flushed),
+		// not the live route `wsSlug`. A background/unmount flush can fire
+		// after navigating to another workspace; the PATCH already targets
+		// `ws`, so the link index must match it. Per Codex review (round 1).
+		serialize: (normalizedMarkdown, ws) => {
+			const allItems = localIndex.getAll(ws);
+			let toSave = normalizedMarkdown;
+			if (allItems.length > 0) {
+				toSave = markdownToWikiLinks(toSave, allItems);
 			}
+			return cleanBrokenLinks(toSave);
+		},
+		// Read the live editor markdown for a flush-now. Reading
+		// editorInstance.storage at cleanup/beforeunload time is correct
+		// because Svelte runs parent $effect cleanups BEFORE child
+		// {#key}-driven unmounts, so the OLD editor is still mounted. Returns
+		// null when the editor is unavailable or its storage read throws, so
+		// flushNow no-ops.
+		readEditorMarkdown: () => {
+			if (!editorInstance) return null;
+			try {
+				return (editorInstance.storage as any).markdown?.getMarkdown?.() ?? '';
+			} catch {
+				return null;
+			}
+		},
+		// Gate per-item lastFlushedContent seeding: only record the flush if
+		// the item we flushed is still active, else a stale flush pollutes the
+		// new page's dedupe state.
+		isActiveItem: (itemId) => !!item && item.id === itemId,
+		// The actual PATCH + reactive bookkeeping. Owns saveStatus /
+		// editorStore / toast / showSaved, the op-log-cursor read, and the
+		// post-await force_refresh check (returns 'skipped' when it fires so
+		// the module doesn't record a known-stale base as lastFlushedContent).
+		save: async ({ ws, itemId, toSave, keepalive }) => {
+			// UI mutations only fire when:
+			//   - This is a foreground (user-driven) flush (!keepalive), AND
+			//   - The user is still looking at the item we're flushing.
+			// Background (keepalive=true) cleanup flushes after navigation MUST
+			// NOT touch saveStatus / lastSaveTime — those slots belong to
+			// whatever item the user is now on, and stamping them from a stale
+			// flush leaves the new page pinned in 'Saving...' indefinitely.
+			// Per Codex review round 2.
+			const isForegroundCurrent = (): boolean =>
+				!keepalive && !!item && item.id === itemId;
+
 			if (isForegroundCurrent()) {
+				saveStatus = 'saving';
 				editorStore.setLastSaveTime(Date.now());
-				editorStore.setDirty(false);
-				showSaved();
 			}
-			return 'flushed';
-		} catch {
-			if (isForegroundCurrent()) {
-				saveStatus = 'idle';
-				toastStore.show('Failed to save content', 'error');
+			try {
+				// Pass the provider's per-tab op-log cursor (TASK-1319) so the
+				// server can advance the GC watermark when this tab is caught
+				// up to MAX(op-log.id). When the cursor is below MAX (peer ops
+				// not yet applied here) the server leaves the watermark
+				// untouched — the GC sweeper must not delete rows this markdown
+				// doesn't reflect. The cursor reflects the provider tracking
+				// THIS item; if a navigation has already swapped to another
+				// item the foreground flush path bails earlier on dedupe and
+				// this code doesn't run.
+				const opLogCursor =
+					collabProvider && collabProvider.itemID === itemId
+						? collabProvider.lastOpLogID
+						: undefined;
+				await api.items.flushCollabContent(ws, itemId, toSave, {
+					keepalive,
+					opLogCursor,
+				});
+				// Post-await force_refresh check: a force_refresh frame can
+				// arrive WHILE the PATCH is in flight (server already accepted,
+				// items.content already overwritten — the server-side gate
+				// covers the happens-before case where MIN had advanced past
+				// our cursor by the time the request landed). Refuse to record
+				// this flush as authoritative locally — returning 'skipped'
+				// stops the flusher seeding lastFlushedContent from a
+				// known-stale base and skips the saveStatus update. Per Codex
+				// round 10 [P1].
+				if (forceRefreshInFlight) return 'skipped';
+				if (isForegroundCurrent()) {
+					editorStore.setLastSaveTime(Date.now());
+					editorStore.setDirty(false);
+					showSaved();
+				}
+				return 'flushed';
+			} catch {
+				if (isForegroundCurrent()) {
+					saveStatus = 'idle';
+					toastStore.show('Failed to save content', 'error');
+				}
+				return 'failed';
 			}
-			return 'failed';
-		}
-	}
-
-	// flushCollabNow fires the pending flush IMMEDIATELY (cancelling
-	// the 5s timer). Takes the explicit ctx the cleanup captured —
-	// reading editorInstance.storage at this instant is correct
-	// because Svelte runs parent $effect cleanups BEFORE child
-	// {#key}-driven unmounts, so the OLD editor (whose markdown we
-	// want) is still mounted. Used by $effect cleanup + beforeunload
-	// to land any in-flight markdown before the provider tears down.
-	function flushCollabNow(ctx: { wsSlug: string; itemId: string; baseline: string; seedMd: string | null }, keepalive: boolean): boolean {
-		clearTimeout(collabFlushTimer);
-		collabFlushTimer = undefined;
-		if (!editorInstance) return false;
-		let md: string;
-		try {
-			md = (editorInstance.storage as any).markdown?.getMarkdown?.() ?? '';
-		} catch {
-			return false;
-		}
-		// runCollabFlush is async but its return value is irrelevant
-		// for synchronous callers — fire-and-forget under
-		// keepalive=true is the contract on the unmount path.
-		void runCollabFlush(ctx.wsSlug, ctx.itemId, md, keepalive, ctx.baseline, ctx.seedMd);
-		return true;
-	}
+		},
+	});
 
 	// The raw-markdown content saver (TASK-2029, extracted from this page).
 	// Owns the 1.2s debounce, the "pending markdown" dirty tracker (was
@@ -1998,13 +1904,13 @@
 				if (!item || item.id !== reqItemId) return;
 				editorStore.setLastSaveTime(Date.now());
 				// Raw saves change items.content via a path the
-				// collab dedupe doesn't see. Without resetting
-				// lastFlushedContent, a later collab flush could
+				// collab dedupe doesn't see. Without resetting the
+				// flusher's dedupe baseline, a later collab flush could
 				// dedupe a content == lastFlushedContent that no
 				// longer reflects server state and skip the PATCH,
 				// leaving items.content stuck on the raw save.
 				// Per Codex review round 7.
-				lastFlushedContent = null;
+				collabFlusher.resetDedup();
 				// Stale-response guard: only swap in the server's
 				// snapshot when no newer raw edit landed during the
 				// PATCH. Otherwise RawMarkdownEditor's content-prop
@@ -2106,11 +2012,11 @@
 					}
 					editorStore.setLastSaveTime(Date.now());
 					// Raw saves change items.content via a path the
-					// collab dedupe doesn't see; reset
-					// lastFlushedContent so a future collab flush
+					// collab dedupe doesn't see; reset the flusher's
+					// dedupe baseline so a future collab flush
 					// can't skip a real PATCH. Per Codex review
 					// round 7.
-					lastFlushedContent = null;
+					collabFlusher.resetDedup();
 					// Only swap in the server's snapshot when no
 					// newer raw edit arrived during the await.
 					// RawMarkdownEditor mirrors `item.content` into
@@ -3004,7 +2910,11 @@
 									let aborted = false;
 									for (let i = 0; i < 3; i++) {
 										if (typeof md !== 'string') break;
-										const result = await runCollabFlush(ws, itemId, md, false, baseline);
+										const result = await collabFlusher.flush(
+											{ wsSlug: ws, itemId, baseline, seedMd: null },
+											md,
+											false,
+										);
 										if (result === 'failed' || result === 'skipped') {
 											// 'failed' — PATCH errored;
 											//   runCollabFlush already
@@ -3059,8 +2969,7 @@
 							// post-rawMode and PATCH a stale rich
 							// markdown over a subsequent raw save.
 							// Per Codex review round 5.
-							clearTimeout(collabFlushTimer);
-							collabFlushTimer = undefined;
+							collabFlusher.cancel();
 							rawMode = true;
 						}}
 						title="Raw markdown editor"


### PR DESCRIPTION
## What

Behavior-preserving extraction of the Yjs collaborative-snapshot **flush path** out of the ~4.6k-line item detail page (`web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte`) into a new focused module. Follow-on to TASK-2029 (which extracted the raw-markdown `contentSaver`), part of PLAN-1984.

## Extracted — `web/src/lib/collab/collabFlush.svelte.ts`

A `createCollabFlusher()` factory (mirrors `contentSaver.svelte.ts`'s pattern). The **module owns**: the 5s idle debounce timer, the per-item `lastFlushedContent` dedupe state, and the two-stage dedupe decision (editor-space short-circuit via `shouldDedupeEditorSpace` + storage-space `baseline`/`lastFlushed` compare). Public API:

- `schedule(ctx, markdown)` — arm the 5s idle flush (was `scheduleCollabFlush`)
- `flush(ctx, markdown, keepalive)` — run a flush now, returns `'flushed'|'deduped'|'failed'|'skipped'` (was `runCollabFlush`; called directly by the rich→raw toggle)
- `flushNow(ctx, keepalive)` — read live editor markdown + flush (was `flushCollabNow`; editor teardown + beforeunload)
- `cancel()` / `resetDedup()` — replace the inline `clearTimeout(collabFlushTimer)` / `lastFlushedContent = null` sites

## Deliberately LEFT in the page (injected as callbacks)

Everything Svelte-reactive / API / editor-coupled the module can't own: the `api.items.flushCollabContent` PATCH + all reactive bookkeeping (`saveStatus`, `editorStore`, toast, `showSaved`), the op-log-cursor read + post-await `force_refresh` check (in `save`), plus `isRecovering` (`forceRefreshInFlight`), `serialize` (`markdownToWikiLinks`/`cleanBrokenLinks` against `localIndex`), `normalize` (`unescapeDocLinks`), `readEditorMarkdown`, `isActiveItem`. `activeCollabContext` / `seededProvider` / the collab `$effect` lifecycle stay in the page — they're deeply coupled to provider construction/teardown.

## Behavior-preserving

Line-for-line faithful to the original control flow. Verified invariants:
- **beforeunload**: collab `flushNow(ctx, true)` still fires ALONGSIDE the BUG-2024 raw-markdown keepalive PATCH (both intact, unchanged ordering).
- `forceRefreshInFlight` gating (schedule + pre/post-await), `seededProvider` seeding, `activeCollabContext` switch-on-item-change all unchanged.
- Flush debounce timing (5s) + dedup (editor-space + storage-space) unchanged; `flushDedupe.ts` reused as-is.
- Item-swap resets cancel the pending flush (`cancel()` + `resetDedup()` in `loadData`) — no cross-item bleed.

One robustness addition from Codex review: a `resetGeneration` guard so an in-flight `resetDedup()` (item-swap / out-of-band raw save) can't be re-polluted by a stale flush's deferred `lastFlushedContent` commit — closes a window the `await config.save()` split would otherwise widen, and strengthens the same-item raw-save case that was latently racy in the original.

## Line-count delta

Item page: **4649 → 4558 lines** (−91). Net across files: +625 / −231 (new module + its unit tests).

## Tests

New `web/src/lib/collab/collabFlush.test.ts` (17 tests, node project): debounce/coalesce, recovery gate, editor-space + storage-space + baseline dedupe, `lastFlushed` recording + active-item gate, failed/skipped non-recording, `flushNow` read/no-op/cancel, `resetDedup`, and the in-flight-reset invalidation. `npm run check` clean (0 errors), `npm run build` succeeds, all 177 node tests pass. Codex review: CLEAN.

Refs TASK-2082, PLAN-1984.