### PR TITLE
docs(cli): document export/import artifact constraint (TASK-2033)

### DIFF
--- a/cmd/pad/cmd_item.go
+++ b/cmd/pad/cmd_item.go
@@ -1205,8 +1205,11 @@ func itemExportCmd() *cobra.Command {
 		Long: `Export a single playbook or convention item to a portable artifact
 (Markdown body + YAML frontmatter) that can be imported into another workspace.
 
-Only playbooks and conventions are exportable as artifacts; any other item
-type is rejected by the server.
+Only playbooks and conventions can be exported. They are Pad's two "library"
+item types — the ones designed to move between workspaces. Every other item
+type is workspace-local and has no portable-artifact form, so the server
+rejects it. To pull data out of a task, idea, doc, or any other item, use
+"pad item show <ref> --format json" instead.
 
 Items can be referenced by issue ID (e.g. PLAYB-3) or slug.
 
@@ -1299,6 +1302,10 @@ func itemImportCmd() *cobra.Command {
 		Short: "Import a playbook or convention artifact into the workspace",
 		Long: `Import a portable artifact (Markdown body + YAML frontmatter) as a new
 playbook or convention in the current workspace.
+
+Only playbooks and conventions have a portable-artifact form, so an import
+only ever creates one of those two "library" item types. No other item type
+can be created this way.
 
 The item is always imported as a draft — review and activate it afterward.
 The server may emit warnings (e.g. a foreign select value cleared, or an


### PR DESCRIPTION
## Summary
Clarifies in `pad item export` / `pad item import` help that **only playbooks and conventions** have a portable-artifact form (Markdown body + YAML frontmatter) — they are Pad's two "library" item types designed to move between workspaces. Every other item type is workspace-local; the help now points users at `pad item show <ref> --format json` to extract that data instead.

Help-text-only change to `cmd/pad/cmd_item.go`. No behavior change.

Refs: TASK-2033 (PLAN-1985).

## Rationale
The audit found `pad item export`/`import` live under `pad item` but only accept playbooks and conventions, with no in-help signal of the constraint. Fix options were "a dedicated `pad artifact` verb OR document the constraint in help." We document the constraint — a new command group is a larger surface change (new MCP considerations) and out of scope for this S task. The server-side rejection message stays as-is.

## Changes (`cmd/pad/cmd_item.go`)
- `itemExportCmd` Long: explains only playbooks/conventions export, why (they're the library types), and the `pad item show --format json` alternative for other item types.
- `itemImportCmd` Long: mirrors the constraint — imports only ever create a playbook or convention.
- Phrasing avoids presenting an exhaustive item-type list (Pad supports arbitrary custom collections).

## Gates
- `go build ./...` — PASS
- `go vet ./...` — PASS
- `make lint` (golangci-lint v2.11.4) — PASS (0 issues)
- `go test ./cmd/pad/...` — PASS
- Rendered `item export --help` / `item import --help` — constraint reads clearly

## Codex review
CLEAN (2 rounds). Round 1 flagged (a) an exhaustive item-type list that ignored custom collections and (b) a runtime error-wrap that was a behavioral change in a docs PR; both addressed by dropping the exhaustive list and removing the error-wrap so the change is purely help text.