### PR TITLE
refactor(web): migrate KeyboardShortcuts modal to the shared Modal primitive

### DIFF
--- a/web/src/lib/components/common/KeyboardShortcuts.svelte
+++ b/web/src/lib/components/common/KeyboardShortcuts.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import Modal from './Modal.svelte';
+
 	interface Props {
 		visible: boolean;
 		onclose: () => void;
@@ -20,17 +22,17 @@
 		{
 			title: 'Global',
 			shortcuts: [
-				{ key: '\u2318K', description: 'Search / Command palette' },
-				{ key: '\u2318N', description: 'New item' },
-				{ key: '\u2318\\', description: 'Toggle sidebar' },
+				{ key: '⌘K', description: 'Search / Command palette' },
+				{ key: '⌘N', description: 'New item' },
+				{ key: '⌘\\', description: 'Toggle sidebar' },
 				{ key: '?', description: 'Show keyboard shortcuts' }
 			]
 		},
 		{
 			title: 'Navigation',
 			shortcuts: [
-				{ key: 'j / \u2193', description: 'Move down' },
-				{ key: 'k / \u2191', description: 'Move up' },
+				{ key: 'j / ↓', description: 'Move down' },
+				{ key: 'k / ↑', description: 'Move up' },
 				{ key: 'Enter', description: 'Open selected item' },
 				{ key: 'Esc', description: 'Go back / Close' }
 			]
@@ -38,82 +40,51 @@
 		{
 			title: 'Item Detail',
 			shortcuts: [
-				{ key: '\u2318Enter', description: 'Save' },
+				{ key: '⌘Enter', description: 'Save' },
 				{ key: 'Esc', description: 'Cancel editing' }
 			]
 		}
 	];
-
-	function handleKeydown(e: KeyboardEvent) {
-		if (!visible) return;
-		if (e.key === 'Escape') {
-			e.preventDefault();
-			onclose();
-		}
-	}
-
-	function handleBackdropClick(e: MouseEvent) {
-		if (e.target === e.currentTarget) {
-			onclose();
-		}
-	}
 </script>
 
-<svelte:window onkeydown={handleKeydown} />
-
-{#if visible}
-	<!-- svelte-ignore a11y_click_events_have_key_events -->
-	<div class="backdrop" onclick={handleBackdropClick} role="dialog" aria-modal="true" aria-label="Keyboard shortcuts" tabindex="-1">
-		<div class="modal">
-			<div class="header">
-				<h2 class="title">Keyboard Shortcuts</h2>
-				<button class="close-btn" onclick={onclose} aria-label="Close">
-					<svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-						<path d="M4 4L12 12M12 4L4 12" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" />
-					</svg>
-				</button>
-			</div>
-			<div class="body">
-				{#each groups as group (group.title)}
-					<div class="group">
-						<h3 class="group-title">{group.title}</h3>
-						<div class="shortcut-list">
-							{#each group.shortcuts as shortcut (shortcut.key)}
-								<div class="shortcut-row">
-									<kbd class="key">{shortcut.key}</kbd>
-									<span class="description">{shortcut.description}</span>
-								</div>
-							{/each}
-						</div>
-					</div>
-				{/each}
-			</div>
-		</div>
+<!-- The native <dialog> (via <Modal>) owns Escape, backdrop dismiss, the focus
+     trap, and focus save/restore — the hand-rolled listeners this component
+     used to carry are gone. placement/shadow overrides keep the original
+     centered look (the pre-migration backdrop was flex-centered). -->
+<Modal
+	open={visible}
+	{onclose}
+	labelledby="keyboard-shortcuts-title"
+	maxWidth="500px"
+	placement="center"
+	--modal-shadow="0 8px 32px rgba(0, 0, 0, 0.3)"
+>
+	<div class="header">
+		<h2 class="title" id="keyboard-shortcuts-title">Keyboard Shortcuts</h2>
+		<button class="close-btn" onclick={onclose} aria-label="Close">
+			<svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+				<path d="M4 4L12 12M12 4L4 12" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" />
+			</svg>
+		</button>
 	</div>
-{/if}
+	<div class="body">
+		{#each groups as group (group.title)}
+			<div class="group">
+				<h3 class="group-title">{group.title}</h3>
+				<div class="shortcut-list">
+					{#each group.shortcuts as shortcut (shortcut.key)}
+						<div class="shortcut-row">
+							<kbd class="key">{shortcut.key}</kbd>
+							<span class="description">{shortcut.description}</span>
+						</div>
+					{/each}
+				</div>
+			</div>
+		{/each}
+	</div>
+</Modal>
 
 <style>
-	.backdrop {
-		position: fixed;
-		inset: 0;
-		background: rgba(0, 0, 0, 0.5);
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		z-index: 100;
-	}
-
-	.modal {
-		background: var(--bg-secondary);
-		border: 1px solid var(--border);
-		border-radius: var(--radius-lg);
-		max-width: 500px;
-		width: 90%;
-		max-height: 80vh;
-		overflow-y: auto;
-		box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
-	}
-
 	.header {
 		display: flex;
 		align-items: center;
@@ -145,11 +116,13 @@
 		color: var(--text-primary);
 	}
 
+	/* The Modal box is overflow:hidden flex-column; the body is the scroll area. */
 	.body {
 		padding: var(--space-4) var(--space-5);
 		display: flex;
 		flex-direction: column;
 		gap: var(--space-5);
+		overflow-y: auto;
 	}
 
 	.group-title {

--- a/web/src/lib/components/common/KeyboardShortcuts.svelte.test.ts
+++ b/web/src/lib/components/common/KeyboardShortcuts.svelte.test.ts
@@ -1,0 +1,66 @@
+// Runs in the jsdom vitest project (filename ends `.svelte.test.ts`) — the
+// same setup Modal.svelte.test.ts relies on polyfills showModal/close.
+// Covers the migration off the hand-rolled backdrop div onto the shared
+// <Modal> primitive: the native dialog drives visibility, aria-labelledby
+// points at the visible heading, and the close button asks the parent to
+// flip `visible` (single source of truth) rather than closing itself.
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/svelte';
+import { tick, flushSync } from 'svelte';
+import KeyboardShortcuts from './KeyboardShortcuts.svelte';
+
+function getDialog(): HTMLDialogElement {
+	const el = document.querySelector('dialog.modal');
+	if (!el) throw new Error('dialog.modal not found');
+	return el as HTMLDialogElement;
+}
+
+afterEach(() => {
+	cleanup();
+	document.body.innerHTML = '';
+});
+
+describe('KeyboardShortcuts.svelte', () => {
+	it('renders through the shared Modal primitive when visible', async () => {
+		render(KeyboardShortcuts, { props: { visible: true, onclose: vi.fn() } });
+		await tick();
+		flushSync();
+
+		const dialog = getDialog();
+		expect(dialog.open).toBe(true);
+		// The heading provides the accessible name via aria-labelledby.
+		expect(dialog.getAttribute('aria-labelledby')).toBe('keyboard-shortcuts-title');
+		expect(document.getElementById('keyboard-shortcuts-title')?.textContent).toBe(
+			'Keyboard Shortcuts'
+		);
+		// The shortcut groups render inside the dialog.
+		const text = dialog.textContent ?? '';
+		for (const group of ['Global', 'Navigation', 'Item Detail']) {
+			expect(text).toContain(group);
+		}
+	});
+
+	it('stays closed (content torn down) while visible=false', async () => {
+		render(KeyboardShortcuts, { props: { visible: false, onclose: vi.fn() } });
+		await tick();
+		flushSync();
+
+		expect(getDialog().open).toBe(false);
+		expect(document.getElementById('keyboard-shortcuts-title')).toBeNull();
+	});
+
+	it('close button asks the parent to close instead of closing itself', async () => {
+		const onclose = vi.fn();
+		render(KeyboardShortcuts, { props: { visible: true, onclose } });
+		await tick();
+		flushSync();
+
+		const btn = document.querySelector<HTMLButtonElement>('dialog.modal button[aria-label="Close"]');
+		expect(btn).not.toBeNull();
+		btn?.click();
+		expect(onclose).toHaveBeenCalledOnce();
+		// `visible` is the single source of truth — until the parent flips it,
+		// the dialog itself has not closed.
+		expect(getDialog().open).toBe(true);
+	});
+});


### PR DESCRIPTION
Closes #899

## What

`KeyboardShortcuts.svelte` was the last hand-rolled modal after #890/#891: a `<div class="backdrop" role="dialog" aria-modal="true">` with its own `svelte:window` Escape listener and backdrop-click handler — no focus trap/restore, no top-layer.

Migrated to the shared native-`<dialog>` `Modal` primitive, matching the already-migrated modals:

- `Modal` now owns Escape, backdrop dismiss, the focus trap, and focus save/restore; the component's own keydown/backdrop handlers are deleted. `visible` stays the single source of truth in `+layout.svelte` (its redundant Escape branch is harmless — both paths just flip the same state).
- The original look is preserved the same way `UserModal` did it: `placement="center"` (the old backdrop was flex-centered, unlike the primitive's `top` default) and `--modal-shadow="0 8px 32px rgba(0,0,0,0.3)"`; `bg/border/radius` already match the primitive's defaults. `maxWidth="500px"` carries over.
- The `.body` becomes the scroll area (`overflow-y: auto`) since the Modal box is `overflow: hidden` flex-column — previously the whole box scrolled.
- `aria-labelledby` is wired to the now-`id`'d `Keyboard Shortcuts` heading (the old version only had `aria-label` on the backdrop).

## Tests

New `KeyboardShortcuts.svelte.test.ts` in the jsdom project, following `Modal.svelte.test.ts`: renders through `dialog.modal` with the aria link and all three shortcut groups when `visible`; stays closed with content torn down when not; and the Close button calls `onclose` while leaving the dialog open until the parent flips `visible` (single-source-of-truth semantics).

## Verification

- `npm run check` — 0 errors (the 8 CSS warnings are pre-existing, all in unrelated route files)
- `npm test` — 190 passed (187 existing + 3 new)
- `grep` confirms no e2e spec targets the old `.backdrop` markup