### PR TITLE
fix(ci): let Go fetch the 1.26.5 toolchain go.mod pins (unbreak CI)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,16 @@ jobs:
         with:
           go-version: "1.26"
 
+      - name: Allow Go to fetch the toolchain go.mod pins
+        # actions/setup-go unconditionally exports GOTOOLCHAIN=local, which
+        # forbids Go from fetching the toolchain go.mod requires. go.mod pins
+        # `go 1.26.5`, but setup-go's "1.26" resolves to the newest patch in
+        # its manifest (1.26.4 here), so every `go` command fails with
+        # "go.mod requires go >= 1.26.5 (running go 1.26.4)". Written AFTER
+        # setup-go so it wins the $GITHUB_ENV last-write; `auto` lets Go pull
+        # 1.26.5 on demand. Added after #896 raised the go.mod floor.
+        run: echo "GOTOOLCHAIN=auto" >> "$GITHUB_ENV"
+
       - name: Create web build placeholder for embed
         run: mkdir -p web/build && echo "placeholder" > web/build/.gitkeep
 
@@ -141,6 +151,11 @@ jobs:
         with:
           go-version: "1.26"
 
+      - name: Allow Go to fetch the toolchain go.mod pins
+        # See the identical step in the `go` job — setup-go pins
+        # GOTOOLCHAIN=local, blocking the 1.26.5 fetch go.mod requires.
+        run: echo "GOTOOLCHAIN=auto" >> "$GITHUB_ENV"
+
       - name: Create web build placeholder for embed
         run: mkdir -p web/build && echo "placeholder" > web/build/.gitkeep
 
@@ -222,6 +237,12 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.26"
+
+      - name: Allow Go to fetch the toolchain go.mod pins
+        # See the identical step in the `go` job — setup-go pins
+        # GOTOOLCHAIN=local, blocking the 1.26.5 fetch go.mod requires
+        # (the "Build pad binary" step below fails without this).
+        run: echo "GOTOOLCHAIN=auto" >> "$GITHUB_ENV"
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,13 @@ jobs:
         with:
           go-version: "1.26"
 
+      - name: Allow Go to fetch the toolchain go.mod pins
+        # actions/setup-go pins GOTOOLCHAIN=local, which blocks the toolchain
+        # go.mod requires (`go 1.26.5`) from being fetched. `auto`, written
+        # after setup-go so it wins the $GITHUB_ENV last-write, lets Go pull
+        # it on demand. Mirrors the CI workflow; see #896.
+        run: echo "GOTOOLCHAIN=auto" >> "$GITHUB_ENV"
+
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "24"


### PR DESCRIPTION
## Problem

CI has been red on `main` and every PR since #896. #896 raised the `go.mod` floor to `go 1.26.5`, but:

- `actions/setup-go` with `go-version: "1.26"` resolves to the newest patch in its version manifest (currently **1.26.4**), and
- setup-go **unconditionally** exports `GOTOOLCHAIN=local`, which forbids Go from downloading a newer toolchain.

So every Go command dies immediately with:

```
go: go.mod requires go >= 1.26.5 (running go 1.26.4; GOTOOLCHAIN=local)
```

This takes down the `Go` job (`go vet`), `Go (PostgreSQL)` (tests), and `E2E (Playwright)` (`Build pad binary`) — all within seconds, on main and every PR.

## Fix

Add a step immediately after each `setup-go` that writes `GOTOOLCHAIN=auto` to `$GITHUB_ENV`. Because setup-go's `GOTOOLCHAIN=local` export is unconditional, a workflow/job-level `env:` would be overridden by it; writing to `$GITHUB_ENV` *after* setup-go wins on last-write and lets Go fetch the exact toolchain `go.mod` pins on demand. Applied to all three Go jobs in `ci.yml` plus `release.yml`.

## Verification

- YAML structurally consistent with the surrounding steps; local Go is 1.26.5 (matches the go.mod floor, so the requirement is satisfiable).
- This PR's own CI run is the real proof — the Go jobs should go green again.

https://claude.ai/code/session_015yuBJQYfDj95cgX3DaD8SF