### PR TITLE
docs: document Docker first-run bootstrap-token flow (TASK-2038)

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,15 @@ docker run -p 127.0.0.1:7777:7777 -v pad-data:/data ghcr.io/perpetualsoftware/pa
 
 This publishes Pad to `localhost:7777` on the host machine, which is the recommended default for local use.
 
+**First run — create the first admin.** Open `http://localhost:7777` and you'll hit a setup page asking for a bootstrap token. On first start with no users, Pad logs a one-time setup URL to stderr (captured by `docker logs`) — grep it and open the printed link:
+
+```bash
+docker logs <container> 2>&1 | grep -A6 'Pad first-run setup'
+# → http://<your-host>:7777/setup#token=<one-time-token>
+```
+
+Open that URL, create your admin account, and the token is consumed (the banner stops appearing). If you'd rather stay on the CLI, `docker exec -it <container> pad auth setup` works too — running inside the container counts as loopback, which the bootstrap gate allows. On a network you already trust, set `PAD_BYPASS_SETUP_TOKEN=true` to skip the token and create the admin straight from `http://<your-host>:7777/setup` (only safe when the port isn't reachable from the open internet).
+
 **Single user, more than one device?** Publish to all interfaces so you can reach Pad from your phone, tablet, or another machine on the same LAN, Tailscale network, or home VPN:
 
 ```bash


### PR DESCRIPTION
## What

Documents the Docker first-run bootstrap-token flow in the README `### Docker` section. Previously the generic README pointed Docker users only at the harder `docker exec pad auth setup` path (or nothing); the logs-token flow was documented only on the Unraid page.

## Change

Adds a **First run** subsection after the basic `docker run` example:
- Open `http://localhost:7777` → setup page asks for a bootstrap token.
- On first start with zero users, Pad logs a one-time setup URL to stderr (captured by `docker logs`); grep the `Pad first-run setup` banner and open the printed `/setup#token=<token>` link.
- Token is consumed one-time after the first admin is created.
- Keeps `docker exec -it <container> pad auth setup` as the loopback fallback.
- Notes `PAD_BYPASS_SETUP_TOKEN=true` as the trusted-network escape hatch.

Docs-only. Codex-reviewed for factual accuracy against `cmd/pad/cmd_server.go::logBootstrapBanner` and `internal/server/handlers_auth.go`.

Part of TASK-2038 (pad-web self-hosting docs get the mirror change in a separate PR).

https://claude.ai/code/session_015yuBJQYfDj95cgX3DaD8SF