### PR TITLE
feat(cli): add claude-code + codex targets to pad mcp install (TASK-2040)

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,14 +300,22 @@ pad library list --type playbooks    # Pre-built multi-step workflows
 
 ### 4. Optional — connect a desktop AI app via MCP
 
-Pad ships an MCP (Model Context Protocol) server so Claude Desktop, Cursor, or
-Windsurf can manage items, plans, ideas, and dependencies as native tools, read
-workspace state by URL, and load multi-step workflows as prompts.
+Pad ships an MCP (Model Context Protocol) server so Claude Desktop, Cursor,
+Windsurf, Claude Code, or Codex can manage items, plans, ideas, and dependencies
+as native tools, read workspace state by URL, and load multi-step workflows as
+prompts.
 
 ```bash
-pad mcp install claude-desktop   # or: cursor, windsurf, --all
+pad mcp install claude-desktop   # or: cursor, windsurf, claude-code, codex, --all
 # Restart the client; pad shows up as the "pad" MCP server.
 ```
+
+`pad mcp install` writes each client's native config: JSON `mcpServers` for
+Claude Desktop / Cursor / Windsurf, a **project-local `.mcp.json`** in the current
+directory for `claude-code`, and an `[mcp_servers.pad]` table in
+`~/.codex/config.toml` (TOML) for `codex`. Because Claude Code's config is
+project-scoped, it's install-on-request only — `--all` and `pad mcp status` cover
+the per-user clients (including Codex) and skip it.
 
 **Tool catalog (v0.14)** — ten resource × action tools plus `pad_set_workspace` (eleven total), no flat verb explosion:
 

--- a/cmd/pad/mcp.go
+++ b/cmd/pad/mcp.go
@@ -14,7 +14,7 @@ import (
 //
 //   - `pad mcp serve` — run the stdio MCP server.
 //   - `pad mcp install [agent]` — write a "pad" entry into a client's
-//     MCP config (Claude Desktop / Cursor / Windsurf).
+//     MCP config (Claude Desktop / Cursor / Windsurf / Claude Code / Codex).
 //   - `pad mcp uninstall <agent>` — remove the entry.
 //   - `pad mcp status` — show install state across all supported clients.
 func mcpCmd() *cobra.Command {
@@ -22,8 +22,9 @@ func mcpCmd() *cobra.Command {
 		Use:   "mcp",
 		Short: "Run pad as a Model Context Protocol server",
 		RunE:  unknownSubcommandRun,
-		Long: `Run pad as an MCP server so AI agents (Claude Desktop, Cursor, Windsurf, etc.)
-can call pad commands as tools and read pad data as resources.
+		Long: `Run pad as an MCP server so AI agents (Claude Desktop, Cursor, Windsurf,
+Claude Code, Codex, etc.) can call pad commands as tools and read pad data
+as resources.
 
 Use ` + "`pad mcp serve`" + ` to start the server over stdio.
 Use ` + "`pad mcp install`" + ` to register pad with a client app.
@@ -52,13 +53,19 @@ func mcpInstallCmd() *cobra.Command {
 		Long: `Write a "pad" entry into the named agent's MCP server config.
 
 Supported agents:
-  claude-desktop   Claude Desktop
-  cursor           Cursor
-  windsurf         Windsurf
+  claude-desktop   Claude Desktop        (~/.../Claude/claude_desktop_config.json)
+  cursor           Cursor                (~/.cursor/mcp.json)
+  windsurf         Windsurf              (~/.codeium/windsurf/mcp_config.json)
+  claude-code      Claude Code           (project-local ./.mcp.json)
+  codex            Codex                 (~/.codex/config.toml)
+
+claude-code writes a project-local .mcp.json in the current directory,
+so it's install-on-request only — ` + "`--all`" + ` and ` + "`pad mcp status`" + ` skip it
+(they cover the per-user configs). codex writes TOML; the rest write JSON.
 
 With no arguments, lists current install status across supported
 agents (run ` + "`pad mcp status`" + ` for the same view). With
---all, installs for every supported agent, creating config files
+--all, installs for every per-user agent, creating config files
 on demand.
 
 Existing MCP server entries (other servers configured by the user)
@@ -168,7 +175,7 @@ func runMCPStatus(cmd *cobra.Command, inst *mcpserver.Installer) error {
 		}
 	}
 	fmt.Fprintln(w)
-	fmt.Fprintln(w, "Install: pad mcp install <agent>   (or --all for every supported)")
+	fmt.Fprintln(w, "Install: pad mcp install <agent>   (or --all for every per-user client above)")
 	return nil
 }
 
@@ -190,6 +197,12 @@ func runMCPInstallOne(cmd *cobra.Command, inst *mcpserver.Installer, agent strin
 func runMCPInstallAll(cmd *cobra.Command, inst *mcpserver.Installer) error {
 	w := cmd.OutOrStdout()
 	for _, a := range mcpserver.SupportedAgents {
+		// CWDBased agents (Claude Code) write a project-local config in
+		// the current directory — not a stable global target, so --all
+		// skips them. Install them explicitly: `pad mcp install claude-code`.
+		if a.CWDBased {
+			continue
+		}
 		path, modified, err := inst.Install(a.Name)
 		if err != nil {
 			fmt.Fprintf(w, "  ✗ %s — skipped: %v\n", a.Label, err)

--- a/internal/mcp/install.go
+++ b/internal/mcp/install.go
@@ -7,12 +7,31 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
+
+	"github.com/BurntSushi/toml"
 )
 
 // MCPServerKey is the canonical name pad registers itself under in
 // each agent's `mcpServers` map. Stable across versions; renaming
 // would orphan every existing install.
 const MCPServerKey = "pad"
+
+// codexServersKey is the table key Codex nests its MCP servers under
+// in ~/.codex/config.toml — `[mcp_servers.pad]`, snake_case, distinct
+// from the JSON clients' camelCase `mcpServers`.
+const codexServersKey = "mcp_servers"
+
+// configFormat selects how an agent's config file is encoded. The JSON
+// clients (Claude Desktop, Cursor, Windsurf, Claude Code) share one
+// reader/writer; Codex uses TOML, which needs its own load/merge/write
+// path (a JSON writer would corrupt a TOML file).
+type configFormat int
+
+const (
+	formatJSON configFormat = iota
+	formatTOML
+)
 
 // Agent describes a known MCP-compatible client and how to find its
 // per-user config file.
@@ -24,11 +43,24 @@ type Agent struct {
 	Label string
 	// Aliases match alternate user inputs.
 	Aliases []string
-	// PathFor resolves the config path given a user's home directory
-	// and runtime.GOOS. Pure function — no I/O — so tests override
-	// `home` and `goos` to verify path logic without touching the
-	// real filesystem.
-	PathFor func(home, goos string) (string, error)
+	// Format selects the config file encoding (JSON vs TOML). Defaults
+	// to formatJSON (the zero value) for the JSON clients.
+	Format configFormat
+	// CWDBased marks agents whose config lives in the current working
+	// directory rather than under $HOME — Claude Code's project-local
+	// `.mcp.json`. These are install-on-request only: they're excluded
+	// from `--all` and from Status(), because "the current directory"
+	// isn't a stable global target the way a per-user config file is
+	// (sweeping a project-local file into whatever directory `--all`
+	// happens to run from would scatter stray configs). See globalAgents.
+	CWDBased bool
+	// PathFor resolves the config path given a base directory and
+	// runtime.GOOS. The base is the user's home directory for normal
+	// agents, or the current working directory for CWDBased agents
+	// (Installer.ResolvePath picks which). Pure function — no I/O — so
+	// tests override `base` and `goos` to verify path logic without
+	// touching the real filesystem.
+	PathFor func(base, goos string) (string, error)
 }
 
 // SupportedAgents is the canonical list of MCP-aware clients pad
@@ -51,6 +83,34 @@ var SupportedAgents = []Agent{
 		Label:   "Windsurf",
 		PathFor: windsurfPathFor,
 	},
+	{
+		Name:     "claude-code",
+		Label:    "Claude Code",
+		Aliases:  []string{"claudecode"},
+		CWDBased: true, // project-local .mcp.json in the current directory
+		PathFor:  claudeCodePathFor,
+	},
+	{
+		Name:    "codex",
+		Label:   "Codex",
+		Format:  formatTOML,
+		PathFor: codexPathFor,
+	},
+}
+
+// globalAgents returns the agents that target a stable per-user config
+// file — i.e. everything except CWDBased (project-local) agents. It's
+// the iteration set for `--all` and Status(); CWDBased agents like
+// Claude Code are install-on-request only (see Agent.CWDBased).
+func globalAgents() []*Agent {
+	out := make([]*Agent, 0, len(SupportedAgents))
+	for i := range SupportedAgents {
+		if SupportedAgents[i].CWDBased {
+			continue
+		}
+		out = append(out, &SupportedAgents[i])
+	}
+	return out
 }
 
 // FindAgent returns the matching Agent for a name or alias. Names are
@@ -67,7 +127,11 @@ func FindAgent(name string) (*Agent, error) {
 			}
 		}
 	}
-	return nil, fmt.Errorf("unknown agent %q (supported: claude-desktop, cursor, windsurf)", name)
+	names := make([]string, 0, len(SupportedAgents))
+	for i := range SupportedAgents {
+		names = append(names, SupportedAgents[i].Name)
+	}
+	return nil, fmt.Errorf("unknown agent %q (supported: %s)", name, strings.Join(names, ", "))
 }
 
 // equalFold is a tiny case-insensitive string compare without
@@ -121,6 +185,21 @@ func windsurfPathFor(home, goos string) (string, error) {
 		return filepath.Join(appData, "Codeium", "windsurf", "mcp_config.json"), nil
 	}
 	return filepath.Join(home, ".codeium", "windsurf", "mcp_config.json"), nil
+}
+
+// claudeCodePathFor resolves Claude Code's project-local `.mcp.json`.
+// `base` is the current working directory (Installer.ResolvePath passes
+// cwd for CWDBased agents, not home) — Claude Code reads `.mcp.json`
+// from the project root it's launched in, same file shape as the other
+// JSON clients but scoped to a directory rather than a user.
+func claudeCodePathFor(base, _ string) (string, error) {
+	return filepath.Join(base, ".mcp.json"), nil
+}
+
+// codexPathFor resolves Codex's `~/.codex/config.toml` (same location on
+// every platform — Codex is a CLI tool with a Unix-style dotdir).
+func codexPathFor(home, _ string) (string, error) {
+	return filepath.Join(home, ".codex", "config.toml"), nil
 }
 
 // AddPadEntry reads (or creates) the JSON config at path, ensures
@@ -312,6 +391,179 @@ func jsonEqual(a, b map[string]any) bool {
 	return string(ab) == string(bb)
 }
 
+// --- TOML config path (Codex) --------------------------------------------
+//
+// Codex nests its MCP servers in a TOML `[mcp_servers.pad]` table, so the
+// JSON reader/writer above won't do. These mirror the JSON functions'
+// behaviour (merge, don't clobber; idempotent; 0600 perms) against a
+// map[string]any decoded from / encoded to TOML.
+
+// addPadEntryTOML reads (or creates) the TOML config at path, ensures
+// mcp_servers.pad points to `binary`, and writes the file back. Existing
+// unrelated keys and other mcp_servers entries are preserved. Returns
+// (modified=true, nil) only when the on-disk content actually changed.
+func addPadEntryTOML(path, binary string) (bool, error) {
+	if binary == "" {
+		return false, errors.New("addPadEntryTOML: binary path is required")
+	}
+	cfg, err := loadTOMLConfig(path)
+	if err != nil {
+		return false, err
+	}
+	wantedEntry := map[string]any{
+		"command": binary,
+		"args":    []any{"mcp", "serve"},
+	}
+	// If mcp_servers exists but isn't a table (e.g. a scalar left by a
+	// hand-edit or an incompatible tool), refuse rather than silently
+	// clobbering it — same "never overwrite a config we can't reconcile"
+	// posture as loadTOMLConfig's parse-error path.
+	rawServers, hasServers := cfg[codexServersKey]
+	servers, ok := rawServers.(map[string]any)
+	if hasServers && !ok {
+		return false, fmt.Errorf("%s: %q exists but is not a table; refusing to overwrite", path, codexServersKey)
+	}
+	if servers == nil {
+		servers = map[string]any{}
+	}
+	current, hadPad := servers[MCPServerKey].(map[string]any)
+	if hadPad && jsonEqual(current, wantedEntry) {
+		// Idempotent path: content already correct. Still tighten perms
+		// (mirrors AddPadEntry) — a hand-edited config may be 0644.
+		tightenPerms(path)
+		return false, nil
+	}
+	servers[MCPServerKey] = wantedEntry
+	cfg[codexServersKey] = servers
+	if err := writeTOMLConfig(path, cfg); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// removePadEntryTOML deletes mcp_servers.pad while leaving other servers
+// and top-level keys intact. Returns (true, nil) when an entry was
+// removed, (false, nil) when there was nothing to do.
+func removePadEntryTOML(path string) (bool, error) {
+	if _, err := os.Stat(path); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		return false, fmt.Errorf("stat %s: %w", path, err)
+	}
+	cfg, err := loadTOMLConfig(path)
+	if err != nil {
+		return false, err
+	}
+	servers, ok := cfg[codexServersKey].(map[string]any)
+	if !ok {
+		return false, nil
+	}
+	if _, exists := servers[MCPServerKey]; !exists {
+		return false, nil
+	}
+	delete(servers, MCPServerKey)
+	cfg[codexServersKey] = servers
+	if err := writeTOMLConfig(path, cfg); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// hasPadEntryTOML reports whether mcp_servers.pad is present plus its
+// current `command` value. Missing files are "not installed", no error.
+func hasPadEntryTOML(path string) (installed bool, command string, err error) {
+	if _, statErr := os.Stat(path); statErr != nil {
+		if errors.Is(statErr, os.ErrNotExist) {
+			return false, "", nil
+		}
+		return false, "", fmt.Errorf("stat %s: %w", path, statErr)
+	}
+	cfg, err := loadTOMLConfig(path)
+	if err != nil {
+		return false, "", err
+	}
+	servers, _ := cfg[codexServersKey].(map[string]any)
+	if servers == nil {
+		return false, "", nil
+	}
+	entry, ok := servers[MCPServerKey].(map[string]any)
+	if !ok {
+		return false, "", nil
+	}
+	cmd, _ := entry["command"].(string)
+	return true, cmd, nil
+}
+
+// loadTOMLConfig reads path as a TOML document into a map. A missing or
+// whitespace-only file is an empty config. Parse errors on a non-empty
+// file propagate — we never silently overwrite a config we can't read.
+func loadTOMLConfig(path string) (map[string]any, error) {
+	b, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return map[string]any{}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	if isAllWhitespace(b) {
+		return map[string]any{}, nil
+	}
+	var raw map[string]any
+	if err := toml.Unmarshal(b, &raw); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	if raw == nil {
+		raw = map[string]any{}
+	}
+	return raw, nil
+}
+
+func writeTOMLConfig(path string, cfg map[string]any) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("mkdir %s: %w", filepath.Dir(path), err)
+	}
+	b, err := toml.Marshal(cfg)
+	if err != nil {
+		return fmt.Errorf("marshal toml config: %w", err)
+	}
+	// 0o600 — like the JSON path, Codex configs can hold credentials for
+	// other MCP servers. os.WriteFile only honors mode on create, so we
+	// Chmod after (tightenPerms) to catch a pre-existing 0644 file.
+	if err := os.WriteFile(path, b, 0o600); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	tightenPerms(path)
+	return nil
+}
+
+// --- format dispatch ------------------------------------------------------
+//
+// Install/Uninstall/Status route through these so each agent's config is
+// read and written in its native format. JSON is the default; TOML is
+// Codex-only for now.
+
+func addEntry(agent *Agent, path, binary string) (bool, error) {
+	if agent.Format == formatTOML {
+		return addPadEntryTOML(path, binary)
+	}
+	return AddPadEntry(path, binary)
+}
+
+func removeEntry(agent *Agent, path string) (bool, error) {
+	if agent.Format == formatTOML {
+		return removePadEntryTOML(path)
+	}
+	return RemovePadEntry(path)
+}
+
+func hasEntry(agent *Agent, path string) (bool, string, error) {
+	if agent.Format == formatTOML {
+		return hasPadEntryTOML(path)
+	}
+	return HasPadEntry(path)
+}
+
 // Installer is the high-level façade over AddPadEntry / RemovePadEntry,
 // resolving config paths from per-agent rules and the user's home dir.
 //
@@ -322,6 +574,9 @@ type Installer struct {
 	Binary string
 	// Home overrides os.UserHomeDir when non-empty (test-only).
 	Home string
+	// CWD overrides os.Getwd when non-empty (test-only). Used to resolve
+	// CWDBased agents' project-local config (Claude Code's .mcp.json).
+	CWD string
 	// GOOS overrides runtime.GOOS when non-empty (test-only).
 	GOOS string
 }
@@ -353,17 +608,29 @@ func (i *Installer) goos() string {
 	return runtime.GOOS
 }
 
-// ResolvePath returns the absolute config path for the given agent
-// using the installer's home + goos overrides.
-func (i *Installer) ResolvePath(agent *Agent) (string, error) {
-	home, err := i.home()
-	if err != nil {
-		return "", err
+func (i *Installer) cwd() (string, error) {
+	if i.CWD != "" {
+		return i.CWD, nil
 	}
+	return os.Getwd()
+}
+
+// ResolvePath returns the config path for the given agent using the
+// installer's home/cwd + goos overrides. CWDBased agents (Claude Code)
+// resolve against the current working directory; all others resolve
+// against the user's home directory.
+func (i *Installer) ResolvePath(agent *Agent) (string, error) {
 	if agent.PathFor == nil {
 		return "", fmt.Errorf("agent %q has no PathFor resolver", agent.Name)
 	}
-	return agent.PathFor(home, i.goos())
+	base, err := i.home()
+	if agent.CWDBased {
+		base, err = i.cwd()
+	}
+	if err != nil {
+		return "", err
+	}
+	return agent.PathFor(base, i.goos())
 }
 
 // Install adds (or refreshes) the pad entry in the named agent's
@@ -381,7 +648,7 @@ func (i *Installer) Install(agentName string) (string, bool, error) {
 	if err != nil {
 		return "", false, err
 	}
-	modified, err := AddPadEntry(path, i.Binary)
+	modified, err := addEntry(agent, path, i.Binary)
 	return path, modified, err
 }
 
@@ -397,17 +664,20 @@ func (i *Installer) Uninstall(agentName string) (string, bool, error) {
 	if err != nil {
 		return "", false, err
 	}
-	removed, err := RemovePadEntry(path)
+	removed, err := removeEntry(agent, path)
 	return path, removed, err
 }
 
-// Status walks every supported agent and reports installation state.
-// Per-agent failures are captured in AgentStatus.Error rather than
+// Status walks every global (per-user) agent and reports installation
+// state. CWDBased agents (Claude Code) are omitted — their config is
+// project-local, so a global status table can't meaningfully represent
+// them; they're install-on-request only (see Agent.CWDBased). Per-agent
+// failures are captured in AgentStatus.Error rather than
 // short-circuiting the whole report.
 func (i *Installer) Status() []AgentStatus {
-	out := make([]AgentStatus, 0, len(SupportedAgents))
-	for idx := range SupportedAgents {
-		agent := &SupportedAgents[idx]
+	agents := globalAgents()
+	out := make([]AgentStatus, 0, len(agents))
+	for _, agent := range agents {
 		row := AgentStatus{Name: agent.Name, Label: agent.Label}
 		path, err := i.ResolvePath(agent)
 		if err != nil {
@@ -416,7 +686,7 @@ func (i *Installer) Status() []AgentStatus {
 			continue
 		}
 		row.ConfigPath = path
-		installed, cmd, err := HasPadEntry(path)
+		installed, cmd, err := hasEntry(agent, path)
 		if err != nil {
 			row.Error = err.Error()
 		}

--- a/internal/mcp/install_test.go
+++ b/internal/mcp/install_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/BurntSushi/toml"
 )
 
 func TestFindAgent_NameAndAliases(t *testing.T) {
@@ -20,8 +22,13 @@ func TestFindAgent_NameAndAliases(t *testing.T) {
 		{"anthropic", "claude-desktop", false},
 		{"cursor", "cursor", false},
 		{"windsurf", "windsurf", false},
-		{"vscode", "", true}, // unsupported
-		{"", "", true},       // empty
+		{"claude-code", "claude-code", false},
+		{"claudecode", "claude-code", false},  // alias
+		{"Claude-Code", "claude-code", false}, // case-insensitive
+		{"codex", "codex", false},
+		{"CODEX", "codex", false}, // case-insensitive
+		{"vscode", "", true},      // unsupported
+		{"", "", true},            // empty
 	}
 	for _, c := range cases {
 		got, err := FindAgent(c.input)
@@ -55,6 +62,13 @@ func TestPathResolvers_LinuxAndDarwin(t *testing.T) {
 		{"cursor", "linux", "/h/.cursor/mcp.json"},
 		{"cursor", "darwin", "/h/.cursor/mcp.json"},
 		{"windsurf", "linux", "/h/.codeium/windsurf/mcp_config.json"},
+		{"codex", "linux", "/h/.codex/config.toml"},
+		{"codex", "darwin", "/h/.codex/config.toml"},
+		// claude-code's base is the working directory, not home — but the
+		// PathFor contract is the same (join base + relative path), so we
+		// pass "/h" as the base here and get the project-local file back.
+		{"claude-code", "linux", "/h/.mcp.json"},
+		{"claude-code", "darwin", "/h/.mcp.json"},
 	}
 	for _, c := range cases {
 		agent, _ := FindAgent(c.agentName)
@@ -325,10 +339,15 @@ func TestInstaller_Status_ReportsAllAgents(t *testing.T) {
 		t.Fatalf("install cursor: %v", err)
 	}
 	status := inst.Status()
-	if len(status) != len(SupportedAgents) {
-		t.Fatalf("status returned %d rows, want %d", len(status), len(SupportedAgents))
+	// Status reports only global (per-user) agents; CWDBased agents like
+	// claude-code are install-on-request and omitted from the sweep.
+	if len(status) != len(globalAgents()) {
+		t.Fatalf("status returned %d rows, want %d", len(status), len(globalAgents()))
 	}
 	for _, row := range status {
+		if row.Name == "claude-code" {
+			t.Errorf("claude-code (CWDBased) must not appear in Status()")
+		}
 		switch row.Name {
 		case "cursor":
 			if !row.Installed {
@@ -429,7 +448,359 @@ func TestAddPadEntry_RejectsCorruptJSON(t *testing.T) {
 	}
 }
 
+// --- Codex (TOML) ---------------------------------------------------------
+
+func TestAddPadEntryTOML_NewConfig(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+
+	modified, err := addPadEntryTOML(path, "/usr/local/bin/pad")
+	if err != nil {
+		t.Fatalf("addPadEntryTOML: %v", err)
+	}
+	if !modified {
+		t.Errorf("expected modified=true on fresh install")
+	}
+
+	cfg := readTOML(t, path)
+	servers := cfg[codexServersKey].(map[string]any)
+	pad := servers[MCPServerKey].(map[string]any)
+	if pad["command"] != "/usr/local/bin/pad" {
+		t.Errorf("command = %v, want /usr/local/bin/pad", pad["command"])
+	}
+	args := pad["args"].([]any)
+	if len(args) != 2 || args[0] != "mcp" || args[1] != "serve" {
+		t.Errorf("args = %v, want [mcp serve]", args)
+	}
+
+	// Sanity: the file is valid TOML with the expected table header.
+	raw, _ := os.ReadFile(path)
+	if !strings.Contains(string(raw), "[mcp_servers.pad]") {
+		t.Errorf("expected [mcp_servers.pad] table, got:\n%s", raw)
+	}
+}
+
+func TestAddPadEntryTOML_PreservesUnrelatedKeys(t *testing.T) {
+	// A real Codex config has top-level keys (model, approval policy) and
+	// possibly other mcp_servers. Install must merge, not clobber.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	existing := `model = "gpt-5"
+approval_policy = "on-request"
+
+[mcp_servers.other]
+command = "/usr/local/bin/other-mcp"
+args = ["run"]
+`
+	if err := os.WriteFile(path, []byte(existing), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := addPadEntryTOML(path, "/usr/bin/pad"); err != nil {
+		t.Fatalf("addPadEntryTOML: %v", err)
+	}
+
+	cfg := readTOML(t, path)
+	if cfg["model"] != "gpt-5" {
+		t.Errorf("unrelated top-level key 'model' lost: %v", cfg["model"])
+	}
+	if cfg["approval_policy"] != "on-request" {
+		t.Errorf("unrelated top-level key 'approval_policy' lost: %v", cfg["approval_policy"])
+	}
+	servers := cfg[codexServersKey].(map[string]any)
+	if _, ok := servers["other"]; !ok {
+		t.Errorf("preserved 'other' mcp server was removed; servers=%v", servers)
+	}
+	if _, ok := servers["pad"]; !ok {
+		t.Errorf("pad entry not added; servers=%v", servers)
+	}
+}
+
+func TestAddPadEntryTOML_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+
+	if _, err := addPadEntryTOML(path, "/usr/bin/pad"); err != nil {
+		t.Fatalf("first install: %v", err)
+	}
+	modified, err := addPadEntryTOML(path, "/usr/bin/pad")
+	if err != nil {
+		t.Fatalf("second install: %v", err)
+	}
+	if modified {
+		t.Errorf("re-install with identical config should report modified=false")
+	}
+}
+
+func TestAddPadEntryTOML_BinaryChangeMarksModified(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+
+	if _, err := addPadEntryTOML(path, "/old/pad"); err != nil {
+		t.Fatalf("initial: %v", err)
+	}
+	modified, err := addPadEntryTOML(path, "/new/pad")
+	if err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	if !modified {
+		t.Errorf("binary path change should mark modified=true")
+	}
+	cfg := readTOML(t, path)
+	pad := cfg[codexServersKey].(map[string]any)[MCPServerKey].(map[string]any)
+	if pad["command"] != "/new/pad" {
+		t.Errorf("expected updated command, got %v", pad["command"])
+	}
+}
+
+func TestAddPadEntryTOML_RequiresBinary(t *testing.T) {
+	if _, err := addPadEntryTOML("/tmp/x.toml", ""); err == nil {
+		t.Errorf("expected error when binary path empty")
+	}
+}
+
+func TestAddPadEntryTOML_RejectsCorruptTOML(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "broken.toml")
+	if err := os.WriteFile(path, []byte("this is = not [valid toml"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := addPadEntryTOML(path, "/p"); err == nil {
+		t.Errorf("expected error on malformed TOML; we should NOT silently overwrite")
+	}
+}
+
+func TestAddPadEntryTOML_RejectsNonTableServers(t *testing.T) {
+	// mcp_servers present but a scalar — refuse rather than clobber a
+	// config we can't reconcile.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	if err := os.WriteFile(path, []byte("mcp_servers = \"legacy\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := addPadEntryTOML(path, "/p"); err == nil {
+		t.Errorf("expected error when mcp_servers is not a table; must not clobber")
+	}
+	// Original content untouched.
+	b, _ := os.ReadFile(path)
+	if !strings.Contains(string(b), `mcp_servers = "legacy"`) {
+		t.Errorf("config was modified despite rejection:\n%s", b)
+	}
+}
+
+func TestAddPadEntryTOML_TightensPerms(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	// Pre-create loose (Codex configs can hold other servers' secrets).
+	if err := os.WriteFile(path, []byte("model = \"x\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := addPadEntryTOML(path, "/p"); err != nil {
+		t.Fatalf("addPadEntryTOML: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mode := info.Mode().Perm(); mode != 0o600 {
+		t.Errorf("expected 0600 after install, got %#o", mode)
+	}
+}
+
+func TestRemovePadEntryTOML_RemovesOnlyPad(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	existing := `[mcp_servers.pad]
+command = "/usr/bin/pad"
+
+[mcp_servers.other]
+command = "/usr/bin/other"
+`
+	if err := os.WriteFile(path, []byte(existing), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	removed, err := removePadEntryTOML(path)
+	if err != nil {
+		t.Fatalf("removePadEntryTOML: %v", err)
+	}
+	if !removed {
+		t.Errorf("expected removed=true")
+	}
+	cfg := readTOML(t, path)
+	servers := cfg[codexServersKey].(map[string]any)
+	if _, ok := servers["pad"]; ok {
+		t.Errorf("pad entry not removed")
+	}
+	if _, ok := servers["other"]; !ok {
+		t.Errorf("other entry should be preserved")
+	}
+}
+
+func TestRemovePadEntryTOML_MissingIsNoOp(t *testing.T) {
+	dir := t.TempDir()
+	// missing file
+	removed, err := removePadEntryTOML(filepath.Join(dir, "nope.toml"))
+	if err != nil || removed {
+		t.Errorf("missing file: removed=%v err=%v, want (false, nil)", removed, err)
+	}
+	// present file, no pad entry
+	path := filepath.Join(dir, "config.toml")
+	if err := os.WriteFile(path, []byte("[mcp_servers.other]\ncommand = \"/x\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	removed, err = removePadEntryTOML(path)
+	if err != nil || removed {
+		t.Errorf("no pad entry: removed=%v err=%v, want (false, nil)", removed, err)
+	}
+}
+
+func TestHasPadEntryTOML_AllPaths(t *testing.T) {
+	dir := t.TempDir()
+
+	installed, _, err := hasPadEntryTOML(filepath.Join(dir, "missing.toml"))
+	if err != nil || installed {
+		t.Errorf("missing file: installed=%v err=%v, want (false, nil)", installed, err)
+	}
+
+	bare := filepath.Join(dir, "bare.toml")
+	if err := os.WriteFile(bare, []byte("model = \"x\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	installed, _, err = hasPadEntryTOML(bare)
+	if err != nil || installed {
+		t.Errorf("bare config: installed=%v err=%v, want (false, nil)", installed, err)
+	}
+
+	full := filepath.Join(dir, "full.toml")
+	if err := os.WriteFile(full, []byte("[mcp_servers.pad]\ncommand = \"/p\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	installed, cmd, err := hasPadEntryTOML(full)
+	if err != nil {
+		t.Fatalf("full config: %v", err)
+	}
+	if !installed || cmd != "/p" {
+		t.Errorf("full config: installed=%v cmd=%q, want (true, /p)", installed, cmd)
+	}
+}
+
+func TestInstaller_Codex_InstallUninstallStatus(t *testing.T) {
+	tmpHome := t.TempDir()
+	inst := &Installer{Binary: "/usr/local/bin/pad", Home: tmpHome, GOOS: "linux"}
+
+	path, modified, err := inst.Install("codex")
+	if err != nil {
+		t.Fatalf("Install codex: %v", err)
+	}
+	if !modified {
+		t.Errorf("first install should modify=true")
+	}
+	wantPath := filepath.Join(tmpHome, ".codex", "config.toml")
+	if path != wantPath {
+		t.Errorf("path = %q, want %q", path, wantPath)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("expected config written at %s, got: %v", path, err)
+	}
+
+	// codex is a global agent, so Status reports it.
+	var seen bool
+	for _, row := range inst.Status() {
+		if row.Name == "codex" {
+			seen = true
+			if !row.Installed || row.Command != "/usr/local/bin/pad" {
+				t.Errorf("codex status = {installed:%v cmd:%q}, want {true /usr/local/bin/pad}", row.Installed, row.Command)
+			}
+		}
+	}
+	if !seen {
+		t.Errorf("codex missing from Status()")
+	}
+
+	_, removed, err := inst.Uninstall("codex")
+	if err != nil {
+		t.Fatalf("uninstall codex: %v", err)
+	}
+	if !removed {
+		t.Errorf("expected removed=true after install")
+	}
+}
+
+// --- Claude Code (cwd-based .mcp.json) ------------------------------------
+
+func TestInstaller_ClaudeCode_UsesCWDNotHome(t *testing.T) {
+	tmpHome := t.TempDir()
+	tmpCWD := t.TempDir()
+	inst := &Installer{Binary: "/usr/local/bin/pad", Home: tmpHome, CWD: tmpCWD, GOOS: "linux"}
+
+	path, modified, err := inst.Install("claude-code")
+	if err != nil {
+		t.Fatalf("Install claude-code: %v", err)
+	}
+	if !modified {
+		t.Errorf("first install should modify=true")
+	}
+	wantPath := filepath.Join(tmpCWD, ".mcp.json")
+	if path != wantPath {
+		t.Errorf("path = %q, want %q (must resolve against CWD, not home)", path, wantPath)
+	}
+	// Nothing should have been written under home.
+	if _, err := os.Stat(filepath.Join(tmpHome, ".mcp.json")); err == nil {
+		t.Errorf("claude-code wrote under home; should be cwd-only")
+	}
+
+	// Same JSON shape as the other JSON clients.
+	cfg := readConfig(t, path)
+	pad := cfg["mcpServers"].(map[string]any)[MCPServerKey].(map[string]any)
+	if pad["command"] != "/usr/local/bin/pad" {
+		t.Errorf("command = %v, want /usr/local/bin/pad", pad["command"])
+	}
+
+	_, removed, err := inst.Uninstall("claude-code")
+	if err != nil {
+		t.Fatalf("uninstall claude-code: %v", err)
+	}
+	if !removed {
+		t.Errorf("expected removed=true after install")
+	}
+}
+
+func TestGlobalAgents_ExcludesCWDBased(t *testing.T) {
+	for _, a := range globalAgents() {
+		if a.CWDBased {
+			t.Errorf("globalAgents() included CWDBased agent %q", a.Name)
+		}
+		if a.Name == "claude-code" {
+			t.Errorf("claude-code must not be a global agent")
+		}
+	}
+	// codex is global; make sure it's present.
+	var hasCodex bool
+	for _, a := range globalAgents() {
+		if a.Name == "codex" {
+			hasCodex = true
+		}
+	}
+	if !hasCodex {
+		t.Errorf("codex should be a global agent")
+	}
+}
+
 // Helpers ------------------------------------------------------------------
+
+func readTOML(t *testing.T, path string) map[string]any {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var raw map[string]any
+	if err := toml.Unmarshal(b, &raw); err != nil {
+		t.Fatalf("parse %s: %v\n%s", path, err, b)
+	}
+	return raw
+}
 
 func writeConfig(t *testing.T, path string, data map[string]any) {
 	t.Helper()


### PR DESCRIPTION
## What

Adds **claude-code** and **codex** as first-class `pad mcp install` targets, alongside the existing claude-desktop / cursor / windsurf.

| Target | File | Format | Scope |
|---|---|---|---|
| `claude-code` | `./.mcp.json` (current dir) | JSON | project-local |
| `codex` | `~/.codex/config.toml` | TOML `[mcp_servers.pad]` | per-user |

## Design

- `Agent` gains a `Format` discriminator (`formatJSON`/`formatTOML`) and a `CWDBased` flag. `Install`/`Uninstall`/`Status` dispatch through `addEntry`/`removeEntry`/`hasEntry` to the right reader/writer, and `ResolvePath` resolves against cwd (Claude Code) vs home (everyone else). Installer gains a test-only `CWD` override mirroring `Home`.
- New TOML load/merge/write path (BurntSushi/toml, already a direct dep): merges into existing config, preserves unrelated top-level keys + other `mcp_servers`, idempotent, 0600 perms, and **refuses to clobber a non-table `mcp_servers`**.
- **Claude Code is install-on-request only.** Its `.mcp.json` is project-scoped, so a global sweep (`--all`) or a global `status` table can't represent it meaningfully — both skip `CWDBased` agents. `pad mcp install claude-code` installs it explicitly. (Documented in code comments.)
- Existing claude-desktop/cursor/windsurf behavior is byte-for-byte unchanged. `FindAgent`'s error string is now built from the agent list.

## Tests / verification

- New unit tests for both targets: path resolution, JSON/TOML round-trips, merge/preserve, idempotency, uninstall, perms, corrupt-input rejection, non-table rejection, `--all`/status exclusion of claude-code.
- `go build`, `go test ./...`, `golangci-lint` all green.
- Real-binary smoke test: `pad mcp install codex` → valid TOML with `[mcp_servers.pad]`, merges into existing config, idempotent, uninstall removes only pad; `pad mcp install claude-code` → project-local `.mcp.json` 0600, preserves other servers; `--all` writes the 4 per-user configs and no stray `.mcp.json`.
- Independent Codex review: High finding (non-table clobber) fixed + test added; Low finding (status footer wording) fixed; Medium (best-effort chmod) declined as the JSON path's deliberate, documented existing behavior that the TOML path intentionally mirrors.

Docs: README MCP section updated. pad-web `/mcp/local` per-client sections in a companion PR.

https://claude.ai/code/session_015yuBJQYfDj95cgX3DaD8SF