### PR TITLE
fix(cli): wrap comment not-found errors with item context

### DIFF
--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -383,7 +383,8 @@ func (c *Client) ListComments(wsSlug, itemSlug string) ([]models.Comment, error)
 
 func (c *Client) CreateComment(wsSlug, itemSlug string, input models.CommentCreate) (*models.Comment, error) {
 	var result models.Comment
-	return &result, c.post("/workspaces/"+wsSlug+"/items/"+itemSlug+"/comments", input, &result)
+	err := c.post("/workspaces/"+wsSlug+"/items/"+itemSlug+"/comments", input, &result)
+	return &result, wrapItemNotFound(err, itemSlug, wsSlug)
 }
 
 func (c *Client) DeleteComment(wsSlug, commentID string) error {

--- a/internal/cli/item_notfound_test.go
+++ b/internal/cli/item_notfound_test.go
@@ -65,6 +65,9 @@ func TestGetItemWrapsNotFound(t *testing.T) {
 	if err := client.DeleteItem("docapp", "TASK-999999"); err == nil || err.Error() != want {
 		t.Errorf("DeleteItem: got %v, want %q", err, want)
 	}
+	if _, err := client.CreateComment("docapp", "TASK-999999", models.CommentCreate{Body: "test"}); err == nil || err.Error() != want {
+		t.Errorf("CreateComment: got %v, want %q", err, want)
+	}
 }
 
 // TestNotFoundPreservesDetails confirms the enriched *APIError carries the


### PR DESCRIPTION
## What does this PR do?

Applies the existing `wrapItemNotFound` behavior to `Client.CreateComment`, so `pad item comment TASK-999999 ...` reports the failing item ref and workspace instead of the bare API message.

The wrapper preserves the original `APIError` code, details, and concrete type, matching the existing Get/Update/Delete item paths.

Closes #902

## How to test

1. `go test ./internal/cli -run 'Test(GetItemWrapsNotFound|NotFoundPreservesDetails|GetItemPassesThroughOtherErrors)$' -count=1`
2. `go vet ./internal/cli`
3. `gofmt -d internal/cli/client.go internal/cli/item_notfound_test.go`
4. `git diff --check`

The focused tests pass on Windows. Broader local package runs have existing workspace prerequisites/platform failures (missing generated `web/build` embed output and Windows HOME/credentials assumptions), unrelated to this two-file CLI change.

## Checklist

- [ ] `make build` passes - not run locally; requires the generated web embed assets
- [ ] `make test` passes - broader Windows baseline has unrelated HOME/credentials failures
- [x] New features have tests (if applicable)
- [x] TypeScript types updated (if API changed) - N/A
- [x] CLI help text updated (if new command) - N/A