### PR TITLE
ci: add Windows and macOS smoke tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,81 @@ jobs:
       - name: Verify binary runs
         run: ./pad --help
 
+  native-smoke:
+    name: Smoke (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    defaults:
+      run:
+        shell: pwsh
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-latest
+            binary: pad
+            path: ./pad
+          - os: windows-latest
+            binary: pad.exe
+            path: .\pad.exe
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+
+      - name: Create web build placeholder
+        run: |
+          New-Item -ItemType Directory -Force web/build | Out-Null
+          Set-Content web/build/index.html '<!doctype html>'
+
+      - name: Build binary
+        run: go build -o "${{ matrix.binary }}" ./cmd/pad
+
+      - name: Verify help output
+        run: '& "${{ matrix.path }}" --help'
+
+      - name: Run CLI smoke test
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $PSNativeCommandUseErrorActionPreference = $true
+          $binary = '${{ matrix.path }}'
+          $env:PAD_DATA_DIR = Join-Path $env:RUNNER_TEMP 'pad-smoke'
+          $env:PAD_BYPASS_SETUP_TOKEN = 'true'
+          $stdout = Join-Path $env:RUNNER_TEMP 'pad-server.out.log'
+          $stderr = Join-Path $env:RUNNER_TEMP 'pad-server.err.log'
+          $server = Start-Process -FilePath $binary -ArgumentList 'server','start','--port','17777' -PassThru -RedirectStandardOutput $stdout -RedirectStandardError $stderr
+
+          try {
+            $ready = $false
+            for ($attempt = 0; $attempt -lt 60; $attempt++) {
+              try {
+                Invoke-WebRequest -UseBasicParsing http://127.0.0.1:17777/api/v1/health | Out-Null
+                $ready = $true
+                break
+              } catch {
+                Start-Sleep -Seconds 1
+              }
+            }
+            if (-not $ready) {
+              Get-Content $stdout, $stderr -ErrorAction SilentlyContinue
+              throw 'Pad server did not become ready'
+            }
+
+            & $binary auth configure --mode local --port 17777
+            & $binary auth setup --email smoke@example.com --name Smoke --password 'SmokePass123!'
+            & $binary workspace create Smoke --slug smoke --template startup
+
+            $item = (& $binary --workspace smoke --format json item create task 'Native smoke item') | ConvertFrom-Json
+            $shown = (& $binary --workspace smoke --format json item show $item.ref) | ConvertFrom-Json
+            if ($shown.title -ne 'Native smoke item') {
+              throw "Unexpected item title: $($shown.title)"
+            }
+          } finally {
+            Stop-Process -Id $server.Id -ErrorAction SilentlyContinue
+          }
+
   go-postgres:
     name: Go (PostgreSQL)
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes #857

Adds a native CI matrix for macOS and Windows. Each runner builds Pad, checks the help command, starts an isolated local server, and verifies an item create/read round-trip through the CLI.

Checks run:
- actionlint .github/workflows/ci.yml
- local macOS build and CLI smoke test