### PR TITLE
feat(security): enforce session UA binding under strict mode (TASK-2056)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -79,7 +79,7 @@ type Config struct {
 	SecureCookies   bool   `toml:"secure_cookies"`    // Set Secure flag on cookies (requires TLS)
 	TrustedProxies  string `toml:"trusted_proxies"`   // Comma-separated CIDRs whose X-Forwarded-For is trusted. Empty = ignore proxy headers.
 	MetricsToken    string `toml:"metrics_token"`     // Shared Bearer token required to scrape /metrics. Empty = loopback-only.
-	IPChangeEnforce string `toml:"ip_change_enforce"` // "" (log only) or "strict" (reject session when client IP differs from the one recorded at session creation).
+	IPChangeEnforce string `toml:"ip_change_enforce"` // "" (log only) or "strict" (revoke+reject session when client IP OR User-Agent hash differs from the one recorded at session creation).
 
 	// SSE limits
 	SSEMaxConnections  int `toml:"sse_max_connections"`   // Global max SSE connections (0 = unlimited)

--- a/internal/models/activity.go
+++ b/internal/models/activity.go
@@ -51,6 +51,18 @@ const (
 	// deployments configured with PAD_IP_CHANGE_ENFORCE=strict the middleware
 	// additionally rejects the request.
 	ActionSessionIPChanged = "session_ip_changed"
+	// ActionSessionUAChanged is logged when a session presents a different
+	// User-Agent hash than the one recorded at creation. Like the IP signal
+	// this is surfaced to the audit log for detection; in deployments
+	// configured with PAD_IP_CHANGE_ENFORCE=strict the middleware additionally
+	// revokes the session and rejects the request. The UA hash is stable for
+	// the life of a real session (a browser doesn't rewrite its own UA mid-
+	// session), so a mismatch is a stronger theft signal than an IP change —
+	// which is precisely why UA enforcement carries fewer false positives than
+	// IP enforcement. This audit row is only emitted in strict mode; log-only
+	// mode keeps the historical slog-only behavior to avoid changing the audit
+	// feed for existing self-host users.
+	ActionSessionUAChanged = "session_ua_changed"
 	// ActionStripeEventUnmarked is logged when /admin/stripe-event-unmark
 	// rolls back a row from stripe_processed_events (TASK-736). The
 	// endpoint intentionally reopens Stripe retry windows, so a persisted

--- a/internal/server/middleware_auth.go
+++ b/internal/server/middleware_auth.go
@@ -114,18 +114,26 @@ func (s *Server) TokenAuth(next http.Handler) http.Handler {
 				rejectInvalidBearer(w, r, next, "unauthorized", "Invalid or expired session")
 				return
 			}
-			// Session binding: log a User-Agent change for visibility but do
-			// NOT reject. The UA is client-supplied and trivially replayed by
-			// anyone who already stole the token, so hard-enforcing it adds
-			// little security while breaking legitimate clients (browser/WebView
-			// updates, DevTools device emulation, mobile-app rebuilds). This
-			// mirrors the default IP-change handling (logged, request allowed);
-			// strict rejection on IP change is still available via
-			// PAD_IP_CHANGE_ENFORCE=strict.
-			if session.UAHash != "" && sha256hex(r.UserAgent()) != session.UAHash {
-				slog.Warn("session binding mismatch: User-Agent changed (logged, request allowed)",
-					"session_ip", session.IPAddress,
-					"client_ip", clientIP(r))
+			// Session binding: detect a User-Agent change. Logged in all
+			// modes; the session is revoked + the request rejected only when
+			// PAD_IP_CHANGE_ENFORCE=strict. The UA is client-supplied and
+			// trivially replayed by anyone who already stole the token, so it
+			// stays log-only by default (breaking browser/WebView updates,
+			// DevTools device emulation, and mobile-app rebuilds would hurt
+			// more than it helps). Checked BEFORE the IP change so a stolen
+			// token replayed from a fresh client is killed on the more stable
+			// of the two signals first.
+			switch s.handleSessionUAChange(w, r, session, token) {
+			case sessionIPChangeTerminated:
+				return
+			case sessionIPChangeRevoked:
+				if isPublicAPIPath(r.URL.Path) {
+					next.ServeHTTP(w, r)
+					return
+				}
+				writeError(w, http.StatusUnauthorized, "session_ua_changed",
+					"Session client changed — please log in again.")
+				return
 			}
 			// Session binding: detect IP changes. Log to audit log in all modes;
 			// reject only when PAD_IP_CHANGE_ENFORCE=strict.
@@ -235,15 +243,20 @@ func (s *Server) SessionAuth(next http.Handler) http.Handler {
 			return
 		}
 
-		// Session binding: log a User-Agent change for visibility but do NOT
-		// de-authenticate. See the matching note in TokenAuth above — UA is
-		// client-supplied, weak as a binding, and false-positives on routine
-		// client churn (browser/WebView updates, DevTools device emulation,
-		// mobile-app rebuilds). Logged-but-allowed, like the default IP path.
-		if session.UAHash != "" && sha256hex(r.UserAgent()) != session.UAHash {
-			slog.Warn("session binding mismatch: User-Agent changed (logged, request allowed)",
-				"session_ip", session.IPAddress,
-				"client_ip", clientIP(r))
+		// Session binding: detect a User-Agent change. Logged in all modes;
+		// the session is revoked only when PAD_IP_CHANGE_ENFORCE=strict. See
+		// the matching note in TokenAuth above — UA is client-supplied, weak
+		// as a binding, and false-positives on routine client churn
+		// (browser/WebView updates, DevTools device emulation, mobile-app
+		// rebuilds), so it stays log-only by default.
+		switch s.handleSessionUAChange(w, r, session, cookie.Value) {
+		case sessionIPChangeTerminated:
+			return
+		case sessionIPChangeRevoked:
+			// Browser path: let the request through unauthenticated so
+			// the SPA renders its login flow instead of a JSON error.
+			next.ServeHTTP(w, r)
+			return
 		}
 
 		// Session binding: detect IP changes. Log to audit log in all modes;
@@ -938,6 +951,98 @@ func (s *Server) handleSessionIPChange(w http.ResponseWriter, r *http.Request, s
 			"user_id", userID)
 	}
 	return sessionIPChangeAllowedLogged
+}
+
+// handleSessionUAChange compares the User-Agent hash on this request to the
+// hash recorded when the session was created, and enforces the same opt-in
+// policy as handleSessionIPChange (governed by the single
+// PAD_IP_CHANGE_ENFORCE toggle, so operators arm both signals at once).
+//
+// Behavior:
+//   - Session has no recorded UA hash (legacy pre-binding row) or the hash
+//     matches: continue.
+//   - Log-only mode (default): emit exactly the historical slog line and let
+//     the request through. Deliberately NO audit row and NO rotation — this
+//     preserves today's behavior byte-for-byte for existing self-host users,
+//     who would otherwise see new audit noise on routine client churn.
+//   - Strict mode (PAD_IP_CHANGE_ENFORCE=strict): destroy the session via
+//     DeleteSessionIfExists (the same CAS primitive the IP path uses), log a
+//     single ActionSessionUAChanged audit row on the winning delete, and
+//     reject the request (401 for API, revoked-passthrough for public/browser
+//     paths). A failed delete fails closed with a 500 so a still-valid stolen
+//     session can't slip through.
+//
+// Unlike an IP, a real client does not rewrite its own User-Agent mid-session,
+// so a UA mismatch is a stronger theft signal and carries far fewer
+// false-positive lockouts than IP enforcement (which trips on mobile roaming,
+// VPN toggles, and carrier NAT). Both remain opt-in behind the same flag
+// because the UA is still client-supplied — an attacker who stole the token
+// can replay the victim's UA header — so this is a defense-in-depth speed bump,
+// not a hard identity binding.
+//
+// Returns the shared sessionIPChangeOutcome vocabulary so callers can reuse the
+// same switch they use for handleSessionIPChange.
+func (s *Server) handleSessionUAChange(w http.ResponseWriter, r *http.Request, session *store.SessionInfo, plainToken string) sessionIPChangeOutcome {
+	if session.UAHash == "" || sha256hex(r.UserAgent()) == session.UAHash {
+		return sessionIPChangeContinue
+	}
+
+	userID := ""
+	if session.User != nil {
+		userID = session.User.ID
+	}
+
+	if !s.ipChangeEnforceStrict {
+		// Log-only mode (default): unchanged from the pre-enforce behavior —
+		// warn and allow. No audit row so the audit feed is untouched.
+		slog.Warn("session binding mismatch: User-Agent changed (logged, request allowed)",
+			"session_ip", session.IPAddress,
+			"client_ip", clientIP(r))
+		return sessionIPChangeContinue
+	}
+
+	// Strict mode: destroy the session atomically. Only the caller whose
+	// DELETE affected a row logs + issues the response. A failed delete leaves
+	// the session valid, so a follow-up request from the same mismatching UA
+	// hits this path again — safe (mirrors handleSessionIPChange).
+	deleted, err := s.store.DeleteSessionIfExists(plainToken)
+	if err != nil {
+		slog.Error("failed to destroy session on UA-change in strict mode; failing closed",
+			"session_ip", session.IPAddress,
+			"client_ip", clientIP(r),
+			"user_id", userID,
+			"error", err)
+		writeError(w, http.StatusInternalServerError, "internal_error",
+			"Unable to validate session. Please try again.")
+		return sessionIPChangeTerminated
+	}
+	if deleted {
+		s.logAuditEventForUser(models.ActionSessionUAChanged, r, userID, auditMeta(map[string]string{
+			"session_ip": session.IPAddress,
+			"client_ip":  clientIP(r),
+		}))
+		slog.Warn("session destroyed: User-Agent changed (strict enforcement)",
+			"session_ip", session.IPAddress,
+			"client_ip", clientIP(r),
+			"user_id", userID)
+	}
+	// Clear client-side cookies regardless — even if another request already
+	// deleted the row, this client is still holding the now-invalid token.
+	clearSessionCookie(w, s.secureCookies)
+	clearCSRFCookie(w)
+	// Public API paths (login/register/password-reset, health, share links,
+	// plan-limits) must still work after revocation so the user can recover.
+	if isPublicAPIPath(r.URL.Path) {
+		return sessionIPChangeRevoked
+	}
+	if strings.HasPrefix(r.URL.Path, "/api/") {
+		writeError(w, http.StatusUnauthorized, "session_ua_changed",
+			"Session client changed — please log in again.")
+		return sessionIPChangeTerminated
+	}
+	// Non-API (browser) path: caller must not install the destroyed session's
+	// user; the SPA renders its unauth state.
+	return sessionIPChangeRevoked
 }
 
 // clearSessionCookie expires the session cookie on the client so a

--- a/internal/server/middleware_session_ua_test.go
+++ b/internal/server/middleware_session_ua_test.go
@@ -1,0 +1,169 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// uaBoundSession creates a user + a session bound to a fixed client IP and
+// User-Agent, returning the raw session token. Tests drive requests through
+// doGetWithCookieUA below, varying only the User-Agent so the IP-binding
+// check stays quiet and the UA-binding check is what's under test.
+func uaBoundSession(t *testing.T, srv *Server, email, ua string) string {
+	t.Helper()
+	user, err := srv.store.CreateUser(models.UserCreate{
+		Email:    email,
+		Name:     "UA Tester",
+		Password: "pw-test-12345",
+	})
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	tok, err := srv.store.CreateSession(user.ID, "test", "192.0.2.1", ua, webSessionTTL)
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	return tok
+}
+
+// doGetWithCookieUA issues a GET with the session cookie, a fixed client IP
+// matching the session binding, and a caller-chosen User-Agent. GET needs no
+// CSRF token, keeping the UA-binding assertion isolated.
+func doGetWithCookieUA(srv *Server, path, token, ua string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest("GET", path, nil)
+	req.RemoteAddr = "192.0.2.1:1234"
+	req.Header.Set("User-Agent", ua)
+	req.AddCookie(&http.Cookie{Name: sessionCookieName(srv.secureCookies), Value: token})
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	return rr
+}
+
+// countUAChangeEvents returns the number of session_ua_changed rows in the
+// audit log.
+func countUAChangeEvents(t *testing.T, srv *Server) int {
+	t.Helper()
+	acts, err := srv.store.ListAuditLog(models.AuditLogParams{
+		Action: models.ActionSessionUAChanged,
+		Limit:  100,
+	})
+	if err != nil {
+		t.Fatalf("list audit log: %v", err)
+	}
+	n := 0
+	for _, a := range acts {
+		if a.Action == models.ActionSessionUAChanged {
+			n++
+		}
+	}
+	return n
+}
+
+// TestSessionUAChange_LogOnlyDefault verifies that without
+// PAD_IP_CHANGE_ENFORCE=strict a session that presents a different
+// User-Agent is allowed through, the session survives, and — critically —
+// NO audit row is written (log-only mode must preserve the historical
+// slog-only behavior exactly, so existing self-host audit feeds are
+// untouched).
+func TestSessionUAChange_LogOnlyDefault(t *testing.T) {
+	srv := testServer(t)
+	const boundUA = "pad-cli/1.0 (session-bound)"
+	token := uaBoundSession(t, srv, "ua-logonly@example.com", boundUA)
+
+	// Matching UA — happy path.
+	rr := doGetWithCookieUA(srv, "/api/v1/auth/me", token, boundUA)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("matching-UA request: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	// Mismatched UA — still allowed in log-only mode.
+	rr = doGetWithCookieUA(srv, "/api/v1/auth/me", token, "totally-different-agent/9.9")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("UA-changed request in log-only mode: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	// No audit row (behavior preserved exactly).
+	if got := countUAChangeEvents(t, srv); got != 0 {
+		t.Fatalf("expected 0 session_ua_changed audit rows in log-only mode, got %d", got)
+	}
+
+	// Session survives — the original UA still authenticates afterward.
+	rr = doGetWithCookieUA(srv, "/api/v1/auth/me", token, boundUA)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("post-mismatch matching-UA request: expected 200 (session not revoked), got %d", rr.Code)
+	}
+}
+
+// TestSessionUAChange_StrictRevokes verifies that with strict enforcement a
+// session presenting a different User-Agent is rejected (401), the session
+// is destroyed, and an ActionSessionUAChanged audit row is written.
+func TestSessionUAChange_StrictRevokes(t *testing.T) {
+	srv := testServer(t)
+	srv.SetIPChangeEnforce("strict")
+	const boundUA = "pad-cli/1.0 (session-bound)"
+	token := uaBoundSession(t, srv, "ua-strict@example.com", boundUA)
+
+	// Sanity: matching UA still works in strict mode.
+	rr := doGetWithCookieUA(srv, "/api/v1/auth/me", token, boundUA)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("matching-UA request in strict mode: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	// Mismatched UA — rejected with 401 session_ua_changed.
+	rr = doGetWithCookieUA(srv, "/api/v1/auth/me", token, "stolen-token-replayer/1.0")
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("UA-changed request in strict mode: expected 401, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if got := countUAChangeEvents(t, srv); got != 1 {
+		t.Fatalf("expected 1 session_ua_changed audit row in strict mode, got %d", got)
+	}
+
+	// Session was destroyed — even the ORIGINAL (matching) UA no longer
+	// authenticates. This is the whole point: the stolen token is dead.
+	rr = doGetWithCookieUA(srv, "/api/v1/auth/me", token, boundUA)
+	if rr.Code == http.StatusOK {
+		t.Fatal("session should have been destroyed after strict UA rejection")
+	}
+}
+
+// TestSessionUAChange_StrictBearerRevokes verifies the same enforcement on
+// the CLI session-bearer path (Authorization: Bearer padsess_...), which
+// runs through TokenAuth rather than SessionAuth.
+func TestSessionUAChange_StrictBearerRevokes(t *testing.T) {
+	srv := testServer(t)
+	srv.SetIPChangeEnforce("strict")
+	const boundUA = "pad-cli/1.0 (session-bound)"
+	token := uaBoundSession(t, srv, "ua-bearer@example.com", boundUA)
+
+	doBearer := func(ua string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest("GET", "/api/v1/auth/me", nil)
+		req.RemoteAddr = "192.0.2.1:1234"
+		req.Header.Set("User-Agent", ua)
+		req.Header.Set("Authorization", "Bearer "+token)
+		rr := httptest.NewRecorder()
+		srv.ServeHTTP(rr, req)
+		return rr
+	}
+
+	// Matching UA works.
+	if rr := doBearer(boundUA); rr.Code != http.StatusOK {
+		t.Fatalf("matching-UA bearer request: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	// Mismatched UA — rejected + revoked.
+	rr := doBearer("stolen-bearer/1.0")
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("UA-changed bearer request in strict mode: expected 401, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if got := countUAChangeEvents(t, srv); got != 1 {
+		t.Fatalf("expected 1 session_ua_changed audit row, got %d", got)
+	}
+
+	// Token is dead now, even with the original UA.
+	if rr := doBearer(boundUA); rr.Code == http.StatusOK {
+		t.Fatal("bearer session should be destroyed after strict UA rejection")
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -55,7 +55,7 @@ type Server struct {
 	metrics               *metrics.Metrics     // Prometheus metrics (optional)
 	metricsToken          string               // shared bearer token for /metrics scrapes ("" = loopback-only)
 	trustedProxyCIDRs     []*net.IPNet         // CIDRs allowed to set X-Forwarded-For (nil = proxy headers untrusted)
-	ipChangeEnforceStrict bool                 // when true, reject sessions whose client IP differs from the one recorded at session creation
+	ipChangeEnforceStrict bool                 // when true, revoke+reject sessions whose client IP OR User-Agent hash differs from the one recorded at session creation
 	sseMaxConnections     int                  // global SSE connection limit (0 = unlimited)
 	sseMaxPerWorkspace    int                  // per-workspace SSE connection limit (0 = unlimited)
 	cloudMode             bool                 // true when running as Pad Cloud (PAD_CLOUD=true or PAD_MODE=cloud)
@@ -887,12 +887,16 @@ func (s *Server) SetTrustedProxies(spec string) {
 }
 
 // SetIPChangeEnforce controls how the auth middleware reacts when a
-// session's client IP changes mid-lifetime:
-//   - mode == "strict": reject the request (session treated as possibly stolen)
+// session's binding (client IP OR User-Agent hash) changes mid-lifetime:
+//   - mode == "strict": revoke the session and reject the request (the token
+//     is treated as possibly stolen). Covers BOTH the IP and the UA signal —
+//     one flag arms the whole session-binding enforcement.
 //   - anything else (default): log to the audit log, update the stored IP,
 //     and let the request through. Strict mode breaks legitimate mobility
-//     (mobile roaming, VPN toggles) so it is opt-in for high-sensitivity
-//     deployments via the PAD_IP_CHANGE_ENFORCE env var.
+//     (mobile roaming, VPN toggles for IP; browser/WebView updates for UA) so
+//     it is opt-in for high-sensitivity deployments via the
+//     PAD_IP_CHANGE_ENFORCE env var. See handleSessionIPChange /
+//     handleSessionUAChange for the per-signal semantics.
 func (s *Server) SetIPChangeEnforce(mode string) {
 	s.ipChangeEnforceStrict = strings.EqualFold(strings.TrimSpace(mode), "strict")
 }


### PR DESCRIPTION
## Summary

Session IP/User-Agent binding was **log-only by default**, so a stolen session token granted durable any-origin access. IP-change enforcement already existed behind `PAD_IP_CHANGE_ENFORCE=strict`; this extends the **same single toggle** to also enforce the User-Agent-hash binding.

## Behavior

- **Enforce ON** (`PAD_IP_CHANGE_ENFORCE=strict`): a request whose client IP **or** User-Agent hash no longer matches the session's stored binding now **revokes the session** (`DeleteSessionIfExists`) and **rejects the request** (401 for API, revoked-passthrough for public/browser paths) — killing the stolen token. A matching request proceeds.
- **Enforce OFF** (default, unchanged): UA mismatch is logged (slog only, **no new audit row**) and the request proceeds. Existing self-host users see no behavior change, and routine client churn (browser/WebView updates, DevTools emulation, mobile-app rebuilds) is tolerated.

## Design notes

- The UA hash is **stable within a real session**, so UA-mismatch enforce carries fewer false positives than IP enforce (mobile roaming, VPN toggles, carrier NAT) — documented in the handler comment. Both remain opt-in behind the one flag because UA is still client-supplied (defense-in-depth, not a hard binding).
- UA check runs **before** the IP check so a token replayed from a fresh client dies on the more stable signal first.
- Reconciled with the existing log-only IP rotation path (`UpdateSessionIPIfEquals`), which is untouched — that path only runs in log-only mode.
- New `ActionSessionUAChanged` audit action, emitted **only** in strict mode.
- **No DB migration** — reuses the existing `IPChangeEnforce` config flag and existing session store primitives.

## Tests

`internal/server/middleware_session_ua_test.go`:
- log-only: UA mismatch proceeds, session survives, zero audit rows
- strict: UA mismatch → 401 + session revoked + one audit row; matching UA proceeds
- strict (bearer/CLI path): same enforcement through `TokenAuth`

Gates: `go build`, `go test ./...`, golangci-lint (server/models/config) all green. Codex review CLEAN.

https://claude.ai/code/session_015yuBJQYfDj95cgX3DaD8SF