### PR TITLE
fix(security): rate-limit share-link password verification (TASK-2055)

### DIFF
--- a/internal/server/handlers_share_links.go
+++ b/internal/server/handlers_share_links.go
@@ -1,10 +1,13 @@
 package server
 
 import (
+	"crypto/sha256"
 	"database/sql"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"io"
+	"log/slog"
 	"net/http"
 	"strconv"
 	"strings"
@@ -421,6 +424,45 @@ func (s *Server) handleResolveShareLink(w http.ResponseWriter, r *http.Request) 
 				"message":          "Password required to view this content",
 			})
 			return
+		}
+		// Brute-force defense, two limiters charged BEFORE the bcrypt compare so
+		// no keying trades one failure mode for another:
+		//
+		//   1. Per-share+IP bucket. Rejects a single grinder's flood cheaply
+		//      (protecting bcrypt CPU) and turns the offline-fast attack into an
+		//      online crawl. Keyed on SHA-256(share ID)+client IP so the map
+		//      holds no secret; clientIP reads the trusted-proxy value, so it
+		//      can't be spoofed. Because it caps each address at a small burst,
+		//      one caller can't drain the link-wide bucket below.
+		//   2. Per-share AGGREGATE bucket (all IPs), keyed on SHA-256(share ID),
+		//      charged only after the per-IP gate passes. A botnet rotating
+		//      addresses gets a fresh per-IP burst from each, so the per-IP
+		//      layer alone can't cap link-wide guessing — this does, capping the
+		//      guess rate (and bcrypt CPU) at the bucket's rate across all IPs.
+		//      Charging it before the compare (like login's per-email AuthEmail
+		//      gate) means an exhausted link blocks even a would-be-correct
+		//      guess, so there's no password oracle. Its burst is sized so
+		//      ordinary multi-viewer traffic never trips it, and the per-IP gate
+		//      ahead of it means exhausting it takes a genuine botnet, not one
+		//      caller — the residual lockout is a self-healing botnet-only case,
+		//      the same bounded tradeoff AuthEmail accepts.
+		shareKeyHash := sha256.Sum256([]byte(link.ID))
+		shareKeyHex := hex.EncodeToString(shareKeyHash[:])
+		if s.rateLimiters != nil && s.rateLimiters.SharePasswordIP != nil {
+			key := "sp:" + shareKeyHex + ":" + clientIP(r)
+			if !s.rateLimiters.SharePasswordIP.getLimiter(key).Allow() {
+				slog.Warn("rate limited", "share_link_id", link.ID, "limiter", "share_password_ip")
+				writeRateLimitResponse(w, s.rateLimiters.SharePasswordIP.config)
+				return
+			}
+		}
+		if s.rateLimiters != nil && s.rateLimiters.SharePasswordShare != nil {
+			key := "sps:" + shareKeyHex
+			if !s.rateLimiters.SharePasswordShare.getLimiter(key).Allow() {
+				slog.Warn("rate limited", "share_link_id", link.ID, "limiter", "share_password_share")
+				writeRateLimitResponse(w, s.rateLimiters.SharePasswordShare.config)
+				return
+			}
 		}
 		if !s.store.ValidateShareLinkPassword(link, password) {
 			writeError(w, http.StatusForbidden, "forbidden", "Incorrect password")

--- a/internal/server/handlers_share_links_bruteforce_test.go
+++ b/internal/server/handlers_share_links_bruteforce_test.go
@@ -1,0 +1,201 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/store"
+)
+
+// resolveShareWithPassword issues an anonymous GET /api/v1/s/{token} from the
+// given source IP with the password supplied via the X-Share-Password header
+// (the only accepted channel — see handleResolveShareLink).
+func resolveShareWithPassword(srv *Server, token, password, remoteIP string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest("GET", "/api/v1/s/"+token, nil)
+	req.Header.Set("X-Share-Password", password)
+	req.RemoteAddr = remoteIP + ":1234"
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	return rr
+}
+
+// TestResolveShareLink_PasswordBruteForceLimiter pins TASK-2055: password
+// verification on a share link must be throttled per-share so a
+// password-protected link can't be ground offline-fast. The limiter is
+// charged before the bcrypt compare, so a correct password still works while
+// there's burst budget, and once the burst is exhausted further attempts
+// (right or wrong) get a 429.
+func TestResolveShareLink_PasswordBruteForceLimiter(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSForTest(t, srv)
+
+	// Create the collection BEFORE any user exists — the first user flips the
+	// instance into auth-required mode, and the public unauthenticated
+	// doRequest helper would then be CSRF-rejected. A real collection lets the
+	// correct-password path resolve to a clean 200.
+	cr := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections", map[string]interface{}{
+		"name":   "Shared",
+		"prefix": "SHAR",
+	})
+	if cr.Code != http.StatusCreated {
+		t.Fatalf("create collection: expected 201, got %d: %s", cr.Code, cr.Body.String())
+	}
+	var coll models.Collection
+	parseJSON(t, cr, &coll)
+
+	// Mint a password-protected share link directly via the store. The public
+	// resolve path is what we're exercising; a real created_by user satisfies
+	// the FK without standing up an auth session.
+	owner, err := srv.store.CreateUser(models.UserCreate{Email: "bf-owner@test.com", Name: "Owner", Password: "pw-owner"})
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	ws, err := srv.store.GetWorkspaceBySlug(slug)
+	if err != nil || ws == nil {
+		t.Fatalf("get workspace: %v", err)
+	}
+
+	const correct = "correct-horse-battery-staple"
+	link, err := srv.store.CreateShareLink(ws.ID, "collection", coll.ID, "view", owner.ID, &store.ShareLinkOptions{
+		Password: correct,
+	})
+	if err != nil {
+		t.Fatalf("create share link: %v", err)
+	}
+	if !link.HasPassword {
+		t.Fatal("expected share link to require a password")
+	}
+
+	const attackerIP = "192.0.2.10"
+	const viewerIP = "192.0.2.20"
+
+	// Per-IP burst is 5 (see RateLimiters.SharePasswordIP). The first attempt
+	// uses the correct password and must succeed — a correct password works
+	// while there's budget.
+	rr := resolveShareWithPassword(srv, link.Token, correct, attackerIP)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("correct password within budget: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	// Remaining budget for this IP is 4. Fire 4 wrong-password attempts — each
+	// clears the limiter (403 Incorrect password), not throttled yet.
+	for i := 0; i < 4; i++ {
+		rr := resolveShareWithPassword(srv, link.Token, "wrong-guess", attackerIP)
+		if rr.Code != http.StatusForbidden {
+			t.Fatalf("wrong attempt %d within budget: expected 403, got %d: %s", i+1, rr.Code, rr.Body.String())
+		}
+	}
+
+	// Budget is now exhausted for this IP (1 correct + 4 wrong = 5). The next
+	// attempt is rate-limited regardless of the password supplied.
+	rr = resolveShareWithPassword(srv, link.Token, "wrong-guess", attackerIP)
+	if rr.Code != http.StatusTooManyRequests {
+		t.Fatalf("attempt past burst: expected 429, got %d: %s", rr.Code, rr.Body.String())
+	}
+	// Even a correct password is throttled once the burst is spent — the
+	// limiter is charged before the compare, which is what forces an attacker
+	// offline-fast grind into an online-slow crawl.
+	rr = resolveShareWithPassword(srv, link.Token, correct, attackerIP)
+	if rr.Code != http.StatusTooManyRequests {
+		t.Fatalf("correct password past burst: expected 429, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if rr.Header().Get("Retry-After") == "" {
+		t.Error("expected Retry-After header on rate-limit response")
+	}
+
+	// No cross-viewer lockout: the key folds in the client IP, so a DIFFERENT
+	// viewer of the SAME link is unaffected by the attacker exhausting their
+	// own bucket. A per-share-only key would 429 this legitimate viewer.
+	rr = resolveShareWithPassword(srv, link.Token, correct, viewerIP)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("second viewer of same link must have its own budget, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	// A DIFFERENT share link also has its own bucket (per-share keying).
+	other, err := srv.store.CreateShareLink(ws.ID, "collection", coll.ID, "view", owner.ID, &store.ShareLinkOptions{
+		Password: correct,
+	})
+	if err != nil {
+		t.Fatalf("create second share link: %v", err)
+	}
+	rr = resolveShareWithPassword(srv, other.Token, correct, attackerIP)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("second share link must have its own budget, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+// TestResolveShareLink_AggregateCap pins the anti-botnet layer of TASK-2055: a
+// distributed attacker rotating source IPs gets a fresh per-IP burst from each
+// address, so the per-share aggregate bucket must cap link-wide guessing. It's
+// charged before the password compare, so once exhausted even a would-be-
+// correct guess is blocked — no password oracle survives the link-wide cap.
+func TestResolveShareLink_AggregateCap(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSForTest(t, srv)
+
+	cr := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections", map[string]interface{}{
+		"name":   "Shared",
+		"prefix": "SHAR",
+	})
+	if cr.Code != http.StatusCreated {
+		t.Fatalf("create collection: expected 201, got %d: %s", cr.Code, cr.Body.String())
+	}
+	var coll models.Collection
+	parseJSON(t, cr, &coll)
+
+	owner, err := srv.store.CreateUser(models.UserCreate{Email: "agg-owner@test.com", Name: "Owner", Password: "pw-owner"})
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	ws, err := srv.store.GetWorkspaceBySlug(slug)
+	if err != nil || ws == nil {
+		t.Fatalf("get workspace: %v", err)
+	}
+
+	const correct = "correct-horse-battery-staple"
+	link, err := srv.store.CreateShareLink(ws.ID, "collection", coll.ID, "view", owner.ID, &store.ShareLinkOptions{
+		Password: correct,
+	})
+	if err != nil {
+		t.Fatalf("create share link: %v", err)
+	}
+
+	// Aggregate burst is 60 (see RateLimiters.SharePasswordShare). Keep each IP
+	// to 5 wrong guesses so the per-IP bucket (burst 5) never trips — that way
+	// any 429 we see is unambiguously the link-wide layer. ~12 distinct IPs ×
+	// 5 = 60 exhausts it; keep going until a 429 appears.
+	sawThrottle := false
+	total := 0
+outer:
+	for ipN := 0; ipN < 20; ipN++ {
+		ip := "198.51.100." + strconv.Itoa(ipN+1)
+		for a := 0; a < 5; a++ {
+			rr := resolveShareWithPassword(srv, link.Token, "wrong-guess", ip)
+			if rr.Code == http.StatusTooManyRequests {
+				sawThrottle = true
+				break outer
+			}
+			if rr.Code != http.StatusForbidden {
+				t.Fatalf("wrong guess from %s: expected 403, got %d: %s", ip, rr.Code, rr.Body.String())
+			}
+			total++
+		}
+	}
+	if !sawThrottle {
+		t.Fatal("aggregate cap never engaged across distinct-IP wrong guesses")
+	}
+	if total < 60 {
+		t.Fatalf("aggregate cap tripped too early after %d guesses (burst is 60)", total)
+	}
+
+	// No password oracle: with the link-wide budget spent, even a CORRECT guess
+	// from a brand-new IP is blocked pre-validation (429), so an attacker can't
+	// keep probing candidates and read success/failure once the cap engages.
+	rr := resolveShareWithPassword(srv, link.Token, correct, "203.0.113.7")
+	if rr.Code != http.StatusTooManyRequests {
+		t.Fatalf("correct guess past aggregate cap must be blocked (no oracle), got %d: %s", rr.Code, rr.Body.String())
+	}
+}

--- a/internal/server/middleware_ratelimit.go
+++ b/internal/server/middleware_ratelimit.go
@@ -156,6 +156,29 @@ type RateLimiters struct {
 	// valid challenge_token can grind through the small recovery-code
 	// space before the 5-minute challenge expires.
 	RecoveryCode *ipRateLimiter
+	// SharePasswordIP throttles password guesses on a single share link from a
+	// single source IP. Keyed on SHA-256(share ID)+client IP and charged on
+	// every attempt BEFORE the bcrypt compare, so a single grinder is capped
+	// (defeating the offline-fast attack) and can't burn server bcrypt CPU.
+	// Per-IP (not link-wide) so one caller exhausting their own bucket can't
+	// lock every legitimate viewer out. See handleResolveShareLink.
+	SharePasswordIP *ipRateLimiter
+	// SharePasswordShare caps the AGGREGATE guess rate against a single share
+	// link across all source IPs — the defense the per-IP bucket alone can't
+	// provide, since a botnet rotating addresses gets a fresh per-IP burst
+	// from each. Keyed on SHA-256(share ID) only and charged BEFORE the bcrypt
+	// compare (like the per-email AuthEmail gate on login), so it caps both
+	// distributed guessing AND bcrypt CPU, and once exhausted it blocks even a
+	// would-be-correct guess (no password oracle). It's charged only AFTER the
+	// per-IP gate passes, so a single IP — capped at its own small burst —
+	// contributes just a few tokens and can't drain the link-wide bucket on
+	// its own; exhausting this requires a genuine botnet, and the burst is
+	// sized so ordinary multi-viewer traffic never trips it. This is the same
+	// bounded-lockout tradeoff AuthEmail accepts: for an unauthenticated
+	// shared-secret URL a hard link-wide cap and zero DoS exposure can't
+	// coexist, so we cap the guess rate and keep the residual lockout to a
+	// self-healing botnet-only case. See handleResolveShareLink.
+	SharePasswordShare *ipRateLimiter
 	// MCPPerToken caps requests per individual bearer token on /mcp.
 	// PLAN-943 / TASK-959: per-token (not per-IP) buckets so that
 	// office-NAT-shared users don't share a quota, and a runaway
@@ -249,6 +272,42 @@ func NewRateLimiters() *RateLimiters {
 			Rate:  rate.Limit(6.0 / 3600.0),
 			Burst: 6,
 		}),
+		// SharePasswordIP: up to 5 guesses per share+IP, refilling at 10/hour. A
+		// share password is entered by people who already know it, so a
+		// legitimate viewer needs only a try or two — burst 5 leaves slop for
+		// a mistype. The burst is tighter than the login limiter's (5/min,
+		// which refills to full in a minute) and the slow 10/hour refill makes
+		// the sustained budget far tighter still: it turns a would-be
+		// offline-fast grind into a handful of guesses an hour, which no
+		// non-trivial password survives being cracked at.
+		//
+		// Retention must be ≥ the refill window (burst / rate = 5 ÷ (10/hour)
+		// = 30 min); otherwise cleanup could evict the bucket between guesses,
+		// letting an attacker pace their probes to dodge the cap. 1 hour gives
+		// margin.
+		SharePasswordIP: newIPRateLimiter(rateLimitConfig{
+			Rate:      rate.Limit(10.0 / 3600.0),
+			Burst:     5,
+			Retention: time.Hour,
+		}),
+		// SharePasswordShare: up to 60 guesses per link aggregated over all IPs,
+		// refilling at 60/hour. This is the anti-botnet ceiling — a distributed
+		// attacker rotating source addresses gets a fresh per-IP burst from
+		// each, so without a link-wide cap they could still grind the password
+		// fast. Charged before the compare (after the per-IP gate), so it caps
+		// bcrypt CPU and the guess rate at 60/hour link-wide — no real password
+		// survives that. Burst 60 is generous enough that ordinary multi-viewer
+		// traffic (a team all opening a link after an announcement) never trips
+		// it, and because the per-IP gate caps each address at 5 first, ~12
+		// distinct IPs are needed to exhaust this — a single IP can't DoS the
+		// link, and a botnet lockout self-heals at 1/min.
+		//
+		// Retention ≥ refill window (60 ÷ (60/hour) = 1 h); 2 h gives margin.
+		SharePasswordShare: newIPRateLimiter(rateLimitConfig{
+			Rate:      rate.Limit(60.0 / 3600.0),
+			Burst:     60,
+			Retention: 2 * time.Hour,
+		}),
 		// MCP per-token: 60 req/min sustained, burst 60. PLAN-943
 		// TASK-959, bumped under BUG-1430. 60/60 = 1 req/sec —
 		// written with explicit math rather than `rate.Limit(1)`
@@ -305,6 +364,8 @@ func (rls *RateLimiters) Stop() {
 		rls.Search,
 		rls.InvitationPreview,
 		rls.RecoveryCode,
+		rls.SharePasswordIP,
+		rls.SharePasswordShare,
 		rls.MCPPerToken,
 	} {
 		rl.Stop() // nil-safe via the receiver guard in (*ipRateLimiter).Stop


### PR DESCRIPTION
## TASK-2055 — Brute-force limiter for share-link password verification

Share-link password verification (`GET /api/v1/s/{token}` with `X-Share-Password`) had no dedicated brute-force limiter, so a password-protected link could be ground fast — the resolve handler would bcrypt-compare an unbounded stream of guesses.

### Fix
Two limiters in `RateLimiters`, both charged **before** the bcrypt compare in `handleResolveShareLink`:

- **`SharePasswordIP`** — 5 guesses / 10-per-hour, keyed on `SHA-256(share ID)+client IP`. Caps a single grinder and protects bcrypt CPU. Per-IP, so one caller can't lock out other viewers; checked first so a single address can't drain the link-wide bucket.
- **`SharePasswordShare`** — 60 guesses / 60-per-hour, keyed on `SHA-256(share ID)`. Caps the aggregate guess rate across a botnet that rotates IPs. Charged pre-compare like login's per-email `AuthEmail` gate, so an exhausted link blocks even a would-be-correct guess (no password oracle). Burst sized so ordinary multi-viewer traffic never trips it; the per-IP gate ahead of it means exhausting it needs a genuine botnet (self-healing) — the same bounded tradeoff `AuthEmail` accepts for an unauthenticated shared secret.

Both keyed on SHA-256 so no secret hits the limiter map. In-memory limiter — no DB migration.

### Tests
`internal/server/handlers_share_links_bruteforce_test.go`:
- Per-IP burst throttles repeated wrong guesses (429 after burst) while a correct password works within budget and a second viewer / second link keep their own budget.
- Aggregate cap engages across rotating IPs and blocks even a correct guess once spent (no oracle).

### Gates
`go build`, `go test ./...`, `golangci-lint` on `internal/server` — all green. Self-Codex review: CLEAN.

https://claude.ai/code/session_015yuBJQYfDj95cgX3DaD8SF