### PR TITLE
fix(security): make TOTP login codes single-use (BUG-2054)

### DIFF
--- a/internal/server/handlers_2fa.go
+++ b/internal/server/handlers_2fa.go
@@ -3,6 +3,7 @@ package server
 import (
 	"crypto/rand"
 	"crypto/sha256"
+	"crypto/subtle"
 	"encoding/base32"
 	"encoding/hex"
 	"fmt"
@@ -11,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pquerna/otp"
 	"github.com/pquerna/otp/totp"
 
 	"github.com/PerpetualSoftware/pad/internal/models"
@@ -22,7 +24,36 @@ const (
 
 	// recoveryCodeCount is the number of recovery codes generated.
 	recoveryCodeCount = 8
+
+	// totpPeriod is the TOTP time-step length in seconds. Matches the period
+	// baked into totp.Validate (Google-Authenticator compatible) and is used
+	// to derive the step a code matched for single-use enforcement (BUG-2054).
+	totpPeriod = 30
 )
+
+// deriveTOTPStep returns the TOTP time-step whose generated code equals
+// passcode, searching the same ±1 skew window totp.Validate accepts (in the
+// library's search order: current, +1, -1). The bool is false if no step in
+// the window matches — which shouldn't happen once totp.Validate has already
+// returned true, but if it does the caller MUST refuse rather than risk
+// accepting a replay it can't pin to a step. See BUG-2054.
+func deriveTOTPStep(passcode, secret string, t time.Time) (int64, bool) {
+	current := t.Unix() / totpPeriod
+	for _, step := range []int64{current, current + 1, current - 1} {
+		code, err := totp.GenerateCodeCustom(secret, time.Unix(step*totpPeriod, 0).UTC(), totp.ValidateOpts{
+			Period:    totpPeriod,
+			Digits:    otp.DigitsSix,
+			Algorithm: otp.AlgorithmSHA1,
+		})
+		if err != nil {
+			continue
+		}
+		if subtle.ConstantTimeCompare([]byte(code), []byte(passcode)) == 1 {
+			return step, true
+		}
+	}
+	return 0, false
+}
 
 // handleTOTPSetup generates a TOTP secret and returns the provisioning URI
 // for the user to scan with their authenticator app. The secret is stored
@@ -253,8 +284,48 @@ func (s *Server) handleTOTPLoginVerify(w http.ResponseWriter, r *http.Request) {
 
 	// Try TOTP code first
 	if input.Code != "" {
-		if totp.Validate(input.Code, user.TOTPSecret) {
-			verified = true
+		// Per-challenge attempt cap on the TOTP branch, mirroring the
+		// recovery-code branch below: a captured challenge token shouldn't be
+		// a license to grind the 6-digit space before it expires. Reuses the
+		// existing RecoveryCode limiter (keyed on a SHA-256 of the challenge
+		// token, distinct "totp:" prefix) rather than adding a new limiter.
+		if s.rateLimiters != nil && s.rateLimiters.RecoveryCode != nil {
+			h := sha256.Sum256([]byte(input.ChallengeToken))
+			key := "totp:" + hex.EncodeToString(h[:])
+			if !s.rateLimiters.RecoveryCode.getLimiter(key).Allow() {
+				slog.Warn("rate limited", "user_id", user.ID, "limiter", "totp")
+				writeRateLimitResponse(w, s.rateLimiters.RecoveryCode.config)
+				return
+			}
+		}
+		// Capture the clock ONCE so validation and step derivation agree on the
+		// window. totp.Validate reads its own time.Now(); if a boundary crosses
+		// between it and deriveTOTPStep, a code valid under one clock could
+		// derive to a step outside the other's ±1 window and be spuriously
+		// rejected. ValidateCustom with the same `now` + the opts Validate bakes
+		// in (period 30, skew 1, SHA1, 6 digits) closes that race.
+		now := time.Now().UTC()
+		valid, _ := totp.ValidateCustom(input.Code, user.TOTPSecret, now, totp.ValidateOpts{
+			Period:    totpPeriod,
+			Skew:      1,
+			Digits:    otp.DigitsSix,
+			Algorithm: otp.AlgorithmSHA1,
+		})
+		if valid {
+			// Single-use enforcement (BUG-2054): a valid TOTP code is otherwise
+			// replayable within its ~30s window (plus skew). Derive the step
+			// the code actually matched and atomically claim it; a step already
+			// consumed means this is a replay, so leave verified=false and let
+			// it fall through to the same invalid-code response (no replay
+			// signal is leaked to the caller).
+			if step, ok := deriveTOTPStep(input.Code, user.TOTPSecret, now); ok {
+				consumed, err := s.store.ConsumeTOTPStep(user.ID, user.TOTPSecret, step)
+				if err != nil {
+					writeInternalError(w, err)
+					return
+				}
+				verified = consumed
+			}
 		}
 	}
 

--- a/internal/server/handlers_2fa_totp_step_test.go
+++ b/internal/server/handlers_2fa_totp_step_test.go
@@ -1,0 +1,64 @@
+package server
+
+import (
+	"testing"
+	"time"
+
+	"github.com/pquerna/otp"
+	"github.com/pquerna/otp/totp"
+)
+
+// TestDeriveTOTPStep verifies the single-use step derivation the verify
+// handler relies on (BUG-2054): a code resolves to the exact step it was
+// generated for, and — crucially — even when the library would still accept
+// it one step later/earlier via skew, deriveTOTPStep pins it to the ORIGINAL
+// step so the replay watermark advances correctly.
+func TestDeriveTOTPStep(t *testing.T) {
+	const secret = "JBSWY3DPEHPK3PXP" // canonical base32 test secret
+	now := time.Unix(1_700_000_000, 0).UTC()
+	wantStep := now.Unix() / totpPeriod
+
+	code, err := totp.GenerateCodeCustom(secret, now, totp.ValidateOpts{
+		Period:    totpPeriod,
+		Digits:    otp.DigitsSix,
+		Algorithm: otp.AlgorithmSHA1,
+	})
+	if err != nil {
+		t.Fatalf("GenerateCodeCustom: %v", err)
+	}
+
+	// Derived at the generating instant → exact step.
+	step, ok := deriveTOTPStep(code, secret, now)
+	if !ok {
+		t.Fatal("expected the freshly-generated code to derive a step")
+	}
+	if step != wantStep {
+		t.Fatalf("got step %d, want %d", step, wantStep)
+	}
+
+	// The code is still accepted ±1 step (the skew totp.Validate allows), but
+	// deriveTOTPStep must report the step it was ISSUED for, not the current
+	// one — otherwise a replay a step later would record a too-low watermark.
+	for _, delta := range []int64{-1, 1} {
+		later := now.Add(time.Duration(delta*totpPeriod) * time.Second)
+		got, ok := deriveTOTPStep(code, secret, later)
+		if !ok {
+			t.Fatalf("delta %d: expected code derivable within skew window", delta)
+		}
+		if got != wantStep {
+			t.Errorf("delta %d: got step %d, want original %d", delta, got, wantStep)
+		}
+	}
+
+	// Two steps away is outside the ±1 skew window → no match (mirrors
+	// totp.Validate refusing it).
+	tooFar := now.Add(2 * totpPeriod * time.Second)
+	if _, ok := deriveTOTPStep(code, secret, tooFar); ok {
+		t.Error("expected no step outside the ±1 skew window")
+	}
+
+	// A non-matching passcode derives nothing.
+	if _, ok := deriveTOTPStep("not-a-code", secret, now); ok {
+		t.Error("expected no step for a non-matching passcode")
+	}
+}

--- a/internal/store/migrations/074_totp_last_step.sql
+++ b/internal/store/migrations/074_totp_last_step.sql
@@ -1,0 +1,12 @@
+-- Add totp_last_step for single-use TOTP enforcement (BUG-2054).
+-- Records the highest TOTP time-step (unix_time / 30) a user has already
+-- consumed on the 2FA login-verify path. Without it a valid TOTP code is
+-- replayable within its ~30s window (plus skew): the verify handler now
+-- derives the step a code matched and rejects any step <= this value,
+-- advancing the column via a compare-and-set UPDATE on each success.
+--
+-- NOTE: no `IF NOT EXISTS` — SQLite's ALTER TABLE ADD COLUMN rejects it.
+-- Nullable with no default; the SAFE default (never-consumed) is NULL, so no
+-- backfill is needed — every existing user can still log in with their next
+-- code, and the first successful verification seeds the column.
+ALTER TABLE users ADD COLUMN totp_last_step INTEGER;

--- a/internal/store/pgmigrations/052_totp_last_step.sql
+++ b/internal/store/pgmigrations/052_totp_last_step.sql
@@ -1,0 +1,6 @@
+-- Add totp_last_step for single-use TOTP enforcement (BUG-2054).
+-- Postgres mirror of migrations/074_totp_last_step.sql. BIGINT because the
+-- step counter (unix_time / 30) grows unbounded over time; NULL = no code
+-- consumed yet, so no backfill is required. See the SQLite migration for the
+-- full rationale.
+ALTER TABLE users ADD COLUMN IF NOT EXISTS totp_last_step BIGINT;

--- a/internal/store/users.go
+++ b/internal/store/users.go
@@ -1174,12 +1174,18 @@ func (s *Store) backfillUsernames() error {
 
 // SetTOTPSecret stores the TOTP secret for a user (before 2FA is verified).
 // The secret is encrypted at rest if an encryption key is configured.
+//
+// It also clears totp_last_step: that single-use watermark (BUG-2054) is a
+// time-step counter that belongs to the OLD secret, so a fresh secret must
+// start with a clean slate — otherwise a re-enrolled authenticator's
+// current-window code could be spuriously rejected until time advances past
+// the stale watermark.
 func (s *Store) SetTOTPSecret(userID, secret string) error {
 	encrypted, err := s.encrypt(secret)
 	if err != nil {
 		return fmt.Errorf("encrypt totp secret: %w", err)
 	}
-	_, err = s.db.Exec(s.q(`UPDATE users SET totp_secret = ?, updated_at = ? WHERE id = ?`), encrypted, now(), userID)
+	_, err = s.db.Exec(s.q(`UPDATE users SET totp_secret = ?, totp_last_step = NULL, updated_at = ? WHERE id = ?`), encrypted, now(), userID)
 	if err != nil {
 		return fmt.Errorf("set totp secret: %w", err)
 	}
@@ -1222,14 +1228,86 @@ func (s *Store) EnableTOTP(userID, expectedSecret, hashedRecoveryCodes string) e
 	return nil
 }
 
-// DisableTOTP disables 2FA and clears the secret and recovery codes.
+// DisableTOTP disables 2FA and clears the secret and recovery codes. It also
+// clears the totp_last_step single-use watermark (BUG-2054) so it doesn't
+// outlive the secret it belonged to and reject a future re-enrollment's codes.
 func (s *Store) DisableTOTP(userID string) error {
-	_, err := s.db.Exec(s.q(`UPDATE users SET totp_enabled = ?, totp_secret = '', recovery_codes = '', updated_at = ? WHERE id = ?`),
+	_, err := s.db.Exec(s.q(`UPDATE users SET totp_enabled = ?, totp_secret = '', recovery_codes = '', totp_last_step = NULL, updated_at = ? WHERE id = ?`),
 		s.dialect.BoolToInt(false), now(), userID)
 	if err != nil {
 		return fmt.Errorf("disable totp: %w", err)
 	}
 	return nil
+}
+
+// ConsumeTOTPStep atomically records a TOTP time-step as consumed, enforcing
+// single-use semantics for login codes (BUG-2054). It succeeds only if step is
+// strictly greater than the user's stored totp_last_step (or none is stored
+// yet), persisting the new value in the SAME guarded UPDATE. Two concurrent
+// verifications for the same step therefore can't both win: the first advances
+// totp_last_step and the second's WHERE clause no longer matches. Mirrors the
+// compare-and-set pattern in UpdateSessionIPIfEquals.
+//
+// expectedSecret is the (decrypted) secret the caller validated the code
+// against; the update is additionally gated on the stored secret STILL being
+// that one. This closes a TOCTOU where a login validates, then the user
+// disables / re-enrolls 2FA (clearing the watermark, migration 074), and this
+// write would otherwise stamp the OLD secret's step back over the fresh secret
+// — spuriously rejecting the new authenticator's next code. If the secret
+// changed underfoot the login is refused (it validated against a secret that
+// no longer exists), which is the correct outcome.
+//
+// Returns true if this call claimed the step (caller may proceed), false if the
+// step was already consumed (a replay) or the secret changed — either way the
+// caller must reject as an invalid code.
+func (s *Store) ConsumeTOTPStep(userID, expectedSecret string, step int64) (bool, error) {
+	// BEGIN IMMEDIATE (the store's _txlock) serializes this read-then-write
+	// against a concurrent DisableTOTP/SetTOTPSecret on SQLite; on Postgres the
+	// secret-equality guard in the UPDATE's WHERE provides the same protection.
+	tx, err := s.db.Begin()
+	if err != nil {
+		return false, fmt.Errorf("consume totp step: begin: %w", err)
+	}
+	defer tx.Rollback()
+
+	var storedSecret string
+	err = tx.QueryRow(s.q(`SELECT totp_secret FROM users WHERE id = ?`), userID).Scan(&storedSecret)
+	if err == sql.ErrNoRows {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("consume totp step: read secret: %w", err)
+	}
+	decrypted, err := s.decrypt(storedSecret)
+	if err != nil {
+		return false, fmt.Errorf("consume totp step: decrypt secret: %w", err)
+	}
+	if decrypted != expectedSecret {
+		// Secret rotated out from under this login between validation and now.
+		return false, nil
+	}
+
+	// Guard on the exact stored (possibly encrypted) ciphertext for atomicity,
+	// the same technique EnableTOTP uses, so a secret change racing between the
+	// SELECT and the UPDATE also fails the CAS instead of stamping a stale step.
+	res, err := tx.Exec(s.q(`
+		UPDATE users
+		SET totp_last_step = ?
+		WHERE id = ? AND totp_secret = ? AND (totp_last_step IS NULL OR totp_last_step < ?)
+	`), step, userID, storedSecret, step)
+	if err != nil {
+		return false, fmt.Errorf("consume totp step: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		// Some drivers don't report RowsAffected reliably. Err on the safe
+		// side: treat as "not the winner" so a replay is never accepted.
+		return false, nil
+	}
+	if err := tx.Commit(); err != nil {
+		return false, fmt.Errorf("consume totp step: commit: %w", err)
+	}
+	return n > 0, nil
 }
 
 // ConsumeRecoveryCode validates and removes a single recovery code.

--- a/internal/store/users_totp_step_test.go
+++ b/internal/store/users_totp_step_test.go
@@ -1,0 +1,187 @@
+package store
+
+import (
+	"sync"
+	"testing"
+)
+
+const totpStepTestSecret = "JBSWY3DPEHPK3PXP" // canonical base32 test secret
+
+// TestConsumeTOTPStep_SingleUse exercises the compare-and-set that enforces
+// single-use TOTP login codes (BUG-2054): a step is claimed once, replaying
+// the same (or an older) step is rejected, and a fresh higher step succeeds
+// and advances the stored value.
+func TestConsumeTOTPStep_SingleUse(t *testing.T) {
+	s := testStore(t)
+	u := createTestUser(t, s, "totp@example.com", "TOTP User", "password123")
+	if err := s.SetTOTPSecret(u.ID, totpStepTestSecret); err != nil {
+		t.Fatalf("SetTOTPSecret: %v", err)
+	}
+
+	// First claim of a step wins (stored value starts NULL).
+	ok, err := s.ConsumeTOTPStep(u.ID, totpStepTestSecret, 1000)
+	if err != nil {
+		t.Fatalf("ConsumeTOTPStep(1000): %v", err)
+	}
+	if !ok {
+		t.Fatal("expected first claim of step 1000 to succeed")
+	}
+
+	// Replaying the same step is rejected (this is the replay guard).
+	ok, err = s.ConsumeTOTPStep(u.ID, totpStepTestSecret, 1000)
+	if err != nil {
+		t.Fatalf("ConsumeTOTPStep(1000) replay: %v", err)
+	}
+	if ok {
+		t.Fatal("expected replay of step 1000 to be rejected")
+	}
+
+	// An older step (e.g. a captured earlier code) is also rejected.
+	ok, err = s.ConsumeTOTPStep(u.ID, totpStepTestSecret, 999)
+	if err != nil {
+		t.Fatalf("ConsumeTOTPStep(999): %v", err)
+	}
+	if ok {
+		t.Fatal("expected older step 999 to be rejected")
+	}
+
+	// A fresh, strictly-greater step succeeds and advances the watermark.
+	ok, err = s.ConsumeTOTPStep(u.ID, totpStepTestSecret, 1001)
+	if err != nil {
+		t.Fatalf("ConsumeTOTPStep(1001): %v", err)
+	}
+	if !ok {
+		t.Fatal("expected fresh step 1001 to succeed")
+	}
+
+	var stored int64
+	if err := s.db.QueryRow(s.q(`SELECT totp_last_step FROM users WHERE id = ?`), u.ID).Scan(&stored); err != nil {
+		t.Fatalf("read totp_last_step: %v", err)
+	}
+	if stored != 1001 {
+		t.Fatalf("expected stored totp_last_step=1001, got %d", stored)
+	}
+}
+
+// TestConsumeTOTPStep_SecretMismatch asserts the secret-identity guard: a code
+// validated against a secret that is no longer the stored one (a 2FA
+// disable/re-enroll racing an in-flight login) does NOT advance the watermark,
+// so it can't spuriously lock out the freshly-enrolled authenticator.
+func TestConsumeTOTPStep_SecretMismatch(t *testing.T) {
+	s := testStore(t)
+	u := createTestUser(t, s, "mismatch@example.com", "Mismatch User", "password123")
+	if err := s.SetTOTPSecret(u.ID, "SECRETAAAAAAAAAA"); err != nil {
+		t.Fatalf("SetTOTPSecret: %v", err)
+	}
+
+	// Consuming with a stale/wrong secret is refused...
+	ok, err := s.ConsumeTOTPStep(u.ID, "SECRETBBBBBBBBBB", 3000)
+	if err != nil {
+		t.Fatalf("ConsumeTOTPStep(wrong secret): %v", err)
+	}
+	if ok {
+		t.Fatal("expected consumption with a mismatched secret to be rejected")
+	}
+
+	// ...and it left the watermark untouched, so the current secret can still
+	// consume a LOWER step (proving no stale 3000 was written).
+	ok, err = s.ConsumeTOTPStep(u.ID, "SECRETAAAAAAAAAA", 100)
+	if err != nil {
+		t.Fatalf("ConsumeTOTPStep(current secret): %v", err)
+	}
+	if !ok {
+		t.Fatal("expected step 100 to succeed — the mismatched call must not have advanced the watermark")
+	}
+}
+
+// TestTOTPStep_ResetOnSecretChange asserts the single-use watermark is cleared
+// when the secret changes (BUG-2054 Codex follow-up): a time-step counter from
+// an old secret must not reject a freshly-enrolled authenticator's codes.
+func TestTOTPStep_ResetOnSecretChange(t *testing.T) {
+	s := testStore(t)
+
+	stepIsSet := func(userID string) bool {
+		t.Helper()
+		var step *int64
+		if err := s.db.QueryRow(s.q(`SELECT totp_last_step FROM users WHERE id = ?`), userID).Scan(&step); err != nil {
+			t.Fatalf("read totp_last_step: %v", err)
+		}
+		return step != nil
+	}
+
+	// DisableTOTP clears the watermark.
+	u := createTestUser(t, s, "reset-disable@example.com", "Reset User", "password123")
+	if err := s.SetTOTPSecret(u.ID, totpStepTestSecret); err != nil {
+		t.Fatalf("SetTOTPSecret: %v", err)
+	}
+	if ok, err := s.ConsumeTOTPStep(u.ID, totpStepTestSecret, 5000); err != nil || !ok {
+		t.Fatalf("seed step: ok=%v err=%v", ok, err)
+	}
+	if err := s.DisableTOTP(u.ID); err != nil {
+		t.Fatalf("DisableTOTP: %v", err)
+	}
+	if stepIsSet(u.ID) {
+		t.Fatal("expected totp_last_step cleared after DisableTOTP")
+	}
+
+	// SetTOTPSecret (re-enrollment) also clears the watermark, and a now-lower
+	// step is accepted again with the fresh secret.
+	u2 := createTestUser(t, s, "reset-setup@example.com", "Reset User 2", "password123")
+	if err := s.SetTOTPSecret(u2.ID, "OLDSECRETAAAAAAA"); err != nil {
+		t.Fatalf("SetTOTPSecret(old): %v", err)
+	}
+	if ok, err := s.ConsumeTOTPStep(u2.ID, "OLDSECRETAAAAAAA", 5000); err != nil || !ok {
+		t.Fatalf("seed step: ok=%v err=%v", ok, err)
+	}
+	if err := s.SetTOTPSecret(u2.ID, "NEWSECRETBBBBBBB"); err != nil {
+		t.Fatalf("SetTOTPSecret(new): %v", err)
+	}
+	if stepIsSet(u2.ID) {
+		t.Fatal("expected totp_last_step cleared after SetTOTPSecret")
+	}
+	if ok, err := s.ConsumeTOTPStep(u2.ID, "NEWSECRETBBBBBBB", 4000); err != nil || !ok {
+		t.Fatalf("expected step 4000 to succeed after secret reset: ok=%v err=%v", ok, err)
+	}
+}
+
+// TestConsumeTOTPStep_ConcurrentCAS asserts that when many goroutines race to
+// claim the SAME step, exactly one wins — the compare-and-set closes the
+// concurrent-replay window.
+func TestConsumeTOTPStep_ConcurrentCAS(t *testing.T) {
+	s := testStore(t)
+	u := createTestUser(t, s, "race@example.com", "Race User", "password123")
+	if err := s.SetTOTPSecret(u.ID, totpStepTestSecret); err != nil {
+		t.Fatalf("SetTOTPSecret: %v", err)
+	}
+
+	const goroutines = 8
+	var (
+		wg    sync.WaitGroup
+		mu    sync.Mutex
+		wins  int
+		start = make(chan struct{})
+	)
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			ok, err := s.ConsumeTOTPStep(u.ID, totpStepTestSecret, 2000)
+			if err != nil {
+				t.Errorf("ConsumeTOTPStep: %v", err)
+				return
+			}
+			if ok {
+				mu.Lock()
+				wins++
+				mu.Unlock()
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	if wins != 1 {
+		t.Fatalf("expected exactly one goroutine to claim step 2000, got %d", wins)
+	}
+}


### PR DESCRIPTION
## BUG-2054 — TOTP login codes are replayable

The 2FA verify path accepted a valid TOTP code with no consumed-step tracking, so within a code's ~30s window (plus skew) the same code was replayable. Unlike the recovery-code branch, the TOTP branch also had no per-challenge attempt cap.

### Fix
- **Migration** `074_totp_last_step.sql` (+ pg `052`): nullable `users.totp_last_step` watermark.
- **Store** `ConsumeTOTPStep(userID, expectedSecret, step)`: transactional compare-and-set — accepts a step only if strictly greater than the stored watermark and advances it in the same guarded UPDATE, so two concurrent requests can't both consume one step. Gated on the stored secret still matching the one the code validated against (closes a disable/re-enroll TOCTOU). `SetTOTPSecret`/`DisableTOTP` now clear the watermark so it never outlives its secret.
- **Handler**: captures one clock, uses `totp.ValidateCustom` + derives the exact step the code matched (pinned within the ±1 skew window), atomically claims it, and rejects a replay with the same invalid-code response — no replay signal leaked. Also caps TOTP attempts per challenge token by reusing the existing `RecoveryCode` limiter (no new limiter field, avoiding the TASK-2055 struct collision).

### Tests
Store: single-use/replay rejection, fresh-step advance, secret-mismatch guard, watermark reset on secret change, concurrent CAS (one winner). Handler: `deriveTOTPStep` derivation + skew-window pinning. Green on SQLite and Postgres.

https://claude.ai/code/session_015yuBJQYfDj95cgX3DaD8SF