### PR TITLE
test(server): adopt t.Parallel() in heaviest handler tests (TASK-2059)

### DIFF
--- a/internal/server/handlers_dashboard_test.go
+++ b/internal/server/handlers_dashboard_test.go
@@ -55,6 +55,7 @@ func createBlocksLink(t *testing.T, srv *Server, wsSlug, sourceSlug, targetID st
 // workspace created via the web (cookie session, no Authorization header)
 // still reports false until an agent actually creates an item.
 func TestDashboardHasAgentActivityFromWorkspaceSource(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 	sessionToken := bootstrapFirstUser(t, srv, "admin@example.com", "Admin")
 
@@ -141,6 +142,7 @@ func TestDashboardHasAgentActivityFromWorkspaceSource(t *testing.T) {
 }
 
 func TestDashboardEmpty(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 	slug := createWSWithCollections(t, srv)
 
@@ -201,6 +203,7 @@ func TestDashboardEmpty(t *testing.T) {
 // item_number=1), this test can be deleted along with the handler
 // branch.
 func TestDashboardOnboardingSeed_NilForAllTemplates(t *testing.T) {
+	t.Parallel()
 	for _, name := range []string{"startup", "scrum", "product"} {
 		t.Run(name, func(t *testing.T) {
 			srv := testServer(t)
@@ -228,6 +231,7 @@ func TestDashboardOnboardingSeed_NilForAllTemplates(t *testing.T) {
 // agent-onboarding script (see PLAN-1140 paused). Banner should
 // stay hidden for these workspaces.
 func TestDashboardOnboardingSeed_HiringTemplate(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 	rr := doRequest(srv, "POST", "/api/v1/workspaces", map[string]string{
 		"name":     "Onboarding Seed Hiring",
@@ -248,6 +252,7 @@ func TestDashboardOnboardingSeed_HiringTemplate(t *testing.T) {
 // TestDashboardOnboardingSeed_EmptyWorkspace verifies that a workspace
 // without a template (no SeedItems) reports no onboarding seed.
 func TestDashboardOnboardingSeed_EmptyWorkspace(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 	slug := createWSWithCollections(t, srv) // empty template path
 
@@ -258,6 +263,7 @@ func TestDashboardOnboardingSeed_EmptyWorkspace(t *testing.T) {
 }
 
 func TestDashboardSummary(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 	slug := createWSWithCollections(t, srv)
 
@@ -335,6 +341,7 @@ func TestDashboardSummary(t *testing.T) {
 }
 
 func TestDashboardActiveItems(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 	slug := createWSWithCollections(t, srv)
 
@@ -398,6 +405,7 @@ func TestDashboardActiveItems(t *testing.T) {
 }
 
 func TestDashboardActiveItemsSorting(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 	slug := createWSWithCollections(t, srv)
 
@@ -442,6 +450,7 @@ func TestDashboardActiveItemsSorting(t *testing.T) {
 }
 
 func TestDashboardActiveItemsExcludesPlans(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 	slug := createWSWithCollections(t, srv)
 
@@ -469,6 +478,7 @@ func TestDashboardActiveItemsExcludesPlans(t *testing.T) {
 }
 
 func TestDashboardActivePlans(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 	slug := createWSWithCollections(t, srv)
 
@@ -525,6 +535,7 @@ func TestDashboardActivePlans(t *testing.T) {
 }
 
 func TestDashboardAttentionOverdue(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 	slug := createWSWithCollections(t, srv)
 
@@ -565,6 +576,7 @@ func TestDashboardAttentionOverdue(t *testing.T) {
 }
 
 func TestDashboardAttentionOverdueEndDate(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 	slug := createWSWithCollections(t, srv)
 
@@ -587,6 +599,7 @@ func TestDashboardAttentionOverdueEndDate(t *testing.T) {
 }
 
 func TestDashboardAttentionBlocked(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 	slug := createWSWithCollections(t, srv)
 
@@ -621,6 +634,7 @@ func TestDashboardAttentionBlocked(t *testing.T) {
 }
 
 func TestDashboardAttentionBlockedNotFlaggedWhenBlockerDone(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 	slug := createWSWithCollections(t, srv)
 
@@ -647,6 +661,7 @@ func TestDashboardAttentionBlockedNotFlaggedWhenBlockerDone(t *testing.T) {
 }
 
 func TestDashboardAttentionBlockedNotFlaggedWhenTargetDone(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 	slug := createWSWithCollections(t, srv)
 
@@ -673,6 +688,7 @@ func TestDashboardAttentionBlockedNotFlaggedWhenTargetDone(t *testing.T) {
 }
 
 func TestDashboardSuggestedNext(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 	slug := createWSWithCollections(t, srv)
 
@@ -755,6 +771,7 @@ func TestDashboardSuggestedNext(t *testing.T) {
 // can't actually start. Verifies that an explicit blocker results
 // in the otherwise-eligible task being skipped.
 func TestDashboardSuggestedNext_FiltersBlockedItems(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 	slug := createWSWithCollections(t, srv)
 
@@ -816,6 +833,7 @@ func TestDashboardSuggestedNext_FiltersBlockedItems(t *testing.T) {
 // task existed. Post-fix the orphan branch surfaces high-priority
 // open items even outside any plan.
 func TestDashboardSuggestedNextNoPlans(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 	slug := createWSWithCollections(t, srv)
 
@@ -844,6 +862,7 @@ func TestDashboardSuggestedNextNoPlans(t *testing.T) {
 // plan rank as orphans (since their plan parent doesn't trigger the
 // active-plan loop). Pre-BUG-1082 they were invisible.
 func TestDashboardSuggestedNextFromPlannedPlan(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 	slug := createWSWithCollections(t, srv)
 
@@ -877,6 +896,7 @@ func TestDashboardSuggestedNextFromPlannedPlan(t *testing.T) {
 // critical to surface (avoids flooding suggestions with low-priority
 // open work). The "continue what's in flight" signal beats priority.
 func TestDashboardSuggestedNextOrphan_InProgressBeatsPriority(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 	slug := createWSWithCollections(t, srv)
 
@@ -907,6 +927,7 @@ func TestDashboardSuggestedNextOrphan_InProgressBeatsPriority(t *testing.T) {
 // candidate exist at the same in-progress / priority bucket, the
 // active-plan one comes first (more contextful).
 func TestDashboardSuggestedNextOrphan_RanksBelowActivePlan(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 	slug := createWSWithCollections(t, srv)
 
@@ -936,6 +957,7 @@ func TestDashboardSuggestedNextOrphan_RanksBelowActivePlan(t *testing.T) {
 }
 
 func TestDashboardIsDoneStatus(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 	slug := createWSWithCollections(t, srv)
 
@@ -976,6 +998,7 @@ func TestDashboardIsDoneStatus(t *testing.T) {
 }
 
 func TestDashboardPlanCompletion(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 	slug := createWSWithCollections(t, srv)
 
@@ -1011,6 +1034,7 @@ func TestDashboardPlanCompletion(t *testing.T) {
 }
 
 func TestDashboardPlanCompletionNotTriggeredWithOpenTasks(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 	slug := createWSWithCollections(t, srv)
 
@@ -1038,6 +1062,7 @@ func TestDashboardPlanCompletionNotTriggeredWithOpenTasks(t *testing.T) {
 }
 
 func TestDashboardRecentActivity(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 	slug := createWSWithCollections(t, srv)
 
@@ -1064,6 +1089,7 @@ func TestDashboardRecentActivity(t *testing.T) {
 }
 
 func TestDashboardActiveItemsItemRef(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 	slug := createWSWithCollections(t, srv)
 
@@ -1088,6 +1114,7 @@ func TestDashboardActiveItemsItemRef(t *testing.T) {
 }
 
 func TestDashboardNonexistentWorkspace(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 
 	rr := doRequest(srv, "GET", "/api/v1/workspaces/nonexistent-ws/dashboard", nil)
@@ -1097,6 +1124,7 @@ func TestDashboardNonexistentWorkspace(t *testing.T) {
 }
 
 func TestDashboardMultipleActivePlans(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 	slug := createWSWithCollections(t, srv)
 
@@ -1161,6 +1189,7 @@ func TestDashboardMultipleActivePlans(t *testing.T) {
 }
 
 func TestDashboardActiveItemsCappedAt10(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 	slug := createWSWithCollections(t, srv)
 
@@ -1180,6 +1209,7 @@ func TestDashboardActiveItemsCappedAt10(t *testing.T) {
 }
 
 func TestDashboardOrphanedTasks(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 	slug := createWSWithCollections(t, srv)
 
@@ -1217,6 +1247,7 @@ func TestDashboardOrphanedTasks(t *testing.T) {
 }
 
 func TestDashboardOrphanedTasksNotFlaggedWithoutPlanLinks(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 	slug := createWSWithCollections(t, srv)
 
@@ -1262,6 +1293,7 @@ func filterAttention(items []DashboardAttention, typ string) []DashboardAttentio
 // called the ungated visibleCollectionIDs and leaked the hidden collection's
 // items to a bearer-authed admin.
 func TestDashboard_AdminBearer_RestrictedMemberIsScoped(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 
 	admin, err := srv.store.CreateUser(models.UserCreate{
@@ -1351,6 +1383,7 @@ func TestDashboard_AdminBearer_RestrictedMemberIsScoped(t *testing.T) {
 // section still loads (partial failure, not all-or-nothing) and the
 // endpoint still returns 200.
 func TestDashboardDegradedOnSubQueryFailure(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 	slug := createWSWithCollections(t, srv)
 

--- a/internal/server/handlers_items_test.go
+++ b/internal/server/handlers_items_test.go
@@ -44,6 +44,7 @@ func createWSWithCollections(t *testing.T, srv *Server) string {
 }
 
 func TestCollectionCRUD(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 	slug := createWSWithCollections(t, srv)
 
@@ -125,6 +126,7 @@ func TestCollectionCRUD(t *testing.T) {
 }
 
 func TestCollectionCreateValidation(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 	slug := createWSWithCollections(t, srv)
 
@@ -136,6 +138,7 @@ func TestCollectionCreateValidation(t *testing.T) {
 }
 
 func TestItemCRUD(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 	slug := createWSWithCollections(t, srv)
 
@@ -258,6 +261,7 @@ func TestItemCRUD(t *testing.T) {
 }
 
 func TestListCollectionItemsResolvesRelationFieldFilterRefs(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 	slug := createWSWithCollections(t, srv)
 
@@ -307,6 +311,7 @@ func TestListCollectionItemsResolvesRelationFieldFilterRefs(t *testing.T) {
 }
 
 func TestListItemsResolvesRelationFieldFilterRefsAcrossCollections(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 	slug := createWSWithCollections(t, srv)
 
@@ -353,6 +358,7 @@ func TestListItemsResolvesRelationFieldFilterRefsAcrossCollections(t *testing.T)
 }
 
 func TestItemCreateValidation(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 	slug := createWSWithCollections(t, srv)
 
@@ -396,6 +402,7 @@ func TestItemCreateValidation(t *testing.T) {
 }
 
 func TestItemFieldDefaults(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 	slug := createWSWithCollections(t, srv)
 
@@ -423,6 +430,7 @@ func TestItemFieldDefaults(t *testing.T) {
 }
 
 func TestItemListWithFilters(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 	slug := createWSWithCollections(t, srv)
 
@@ -476,6 +484,7 @@ func TestItemListWithFilters(t *testing.T) {
 }
 
 func TestItemSearch(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 	slug := createWSWithCollections(t, srv)
 
@@ -506,6 +515,7 @@ func TestItemSearch(t *testing.T) {
 }
 
 func TestItemLinks(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 	slug := createWSWithCollections(t, srv)
 
@@ -597,6 +607,7 @@ func TestItemLinks(t *testing.T) {
 }
 
 func TestGetItemIncludesDerivedClosureForSupersededItems(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 	slug := createWSWithCollections(t, srv)
 
@@ -647,6 +658,7 @@ func TestGetItemIncludesDerivedClosureForSupersededItems(t *testing.T) {
 }
 
 func TestGetItemIncludesDerivedClosureWhenSplitChildrenAreDone(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 	slug := createWSWithCollections(t, srv)
 
@@ -700,6 +712,7 @@ func TestGetItemIncludesDerivedClosureWhenSplitChildrenAreDone(t *testing.T) {
 }
 
 func TestGetItemIncludesDerivedClosureForImplementedItems(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 	slug := createWSWithCollections(t, srv)
 
@@ -747,6 +760,7 @@ func TestGetItemIncludesDerivedClosureForImplementedItems(t *testing.T) {
 }
 
 func TestGetItemIncludesCodeContext(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 	slug := createWSWithCollections(t, srv)
 
@@ -782,6 +796,7 @@ func TestGetItemIncludesCodeContext(t *testing.T) {
 }
 
 func TestGetItemIncludesStructuredNotes(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 	slug := createWSWithCollections(t, srv)
 
@@ -820,6 +835,7 @@ func TestGetItemIncludesStructuredNotes(t *testing.T) {
 }
 
 func TestGetItemIncludesConventionMetadata(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 	slug := createWSWithCollections(t, srv)
 
@@ -858,6 +874,7 @@ func TestGetItemIncludesConventionMetadata(t *testing.T) {
 }
 
 func TestItemVersions(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 	slug := createWSWithCollections(t, srv)
 
@@ -888,6 +905,7 @@ func TestItemVersions(t *testing.T) {
 }
 
 func TestDashboard(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 	slug := createWSWithCollections(t, srv)
 
@@ -953,6 +971,7 @@ func TestDashboard(t *testing.T) {
 }
 
 func TestDashboardEmptyWorkspace(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 	slug := createWSWithCollections(t, srv)
 
@@ -970,6 +989,7 @@ func TestDashboardEmptyWorkspace(t *testing.T) {
 }
 
 func TestItemUpdateFieldValidation(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 	slug := createWSWithCollections(t, srv)
 
@@ -991,6 +1011,7 @@ func TestItemUpdateFieldValidation(t *testing.T) {
 }
 
 func TestItemCrossCollectionListing(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 	slug := createWSWithCollections(t, srv)
 
@@ -1046,6 +1067,7 @@ func TestItemCrossCollectionListing(t *testing.T) {
 // the auth middleware validates token format (rejects "pad_anything"
 // shapes with 401 before the handler ever runs).
 func TestCreateItemSourcePersistedFromAuth(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 	sessionToken := bootstrapFirstUser(t, srv, "admin@example.com", "Admin")
 
@@ -1131,6 +1153,7 @@ func TestCreateItemSourcePersistedFromAuth(t *testing.T) {
 // the historical JSON-encoded-string shape. Wrong shapes return a
 // clean domain-level error instead of leaked Go unmarshal internals.
 func TestPatchItem_FlexibleFieldsShape(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 	slug := createWSWithCollections(t, srv)
 
@@ -1265,6 +1288,7 @@ type itemsIndexBody struct {
 // resolution, so two creates inside the same second tie on updated_at
 // and the ID tiebreaker (not creation order) decides the row order.
 func TestListItemsIndex_SkinnyProjectionAndShape(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 	slug := createWSWithCollections(t, srv)
 
@@ -1339,6 +1363,7 @@ func TestListItemsIndex_SkinnyProjectionAndShape(t *testing.T) {
 // testing a sort whose tiebreaker (id ASC) would otherwise win — see
 // the comment on TestListItemsIndex_SkinnyProjectionAndShape.
 func TestListItemsIndex_SortByUpdatedAt(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 	slug := createWSWithCollections(t, srv)
 
@@ -1376,6 +1401,7 @@ func TestListItemsIndex_SortByUpdatedAt(t *testing.T) {
 // TestListItemsIndex_EmptyWorkspace covers the edge case the cursor
 // is documented to handle: no items → cursor "0".
 func TestListItemsIndex_EmptyWorkspace(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 	slug := createWSWithCollections(t, srv)
 
@@ -1410,6 +1436,7 @@ func TestListItemsIndex_EmptyWorkspace(t *testing.T) {
 // /items-changes?since=cursor poll starts at the right floor rather
 // than replaying every prior mutation from 0.
 func TestListItemsIndex_EmptyResultFallsBackToWorkspaceMax(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 	slug := createWSWithCollections(t, srv)
 
@@ -1460,6 +1487,7 @@ func TestListItemsIndex_EmptyResultFallsBackToWorkspaceMax(t *testing.T) {
 // `since` parameter on a follow-up /items-changes call (cursor contract
 // for PLAN-1343 Phase 2).
 func TestListItemsIndex_CursorMonotonicAcrossMutations(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 	slug := createWSWithCollections(t, srv)
 
@@ -1492,6 +1520,7 @@ func TestListItemsIndex_CursorMonotonicAcrossMutations(t *testing.T) {
 
 // TestListItemsIndex_CollectionFilter covers ?collection=<slug>.
 func TestListItemsIndex_CollectionFilter(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 	slug := createWSWithCollections(t, srv)
 
@@ -1524,6 +1553,7 @@ func TestListItemsIndex_CollectionFilter(t *testing.T) {
 // are populated for child items (same enrichment path the existing items
 // list uses).
 func TestListItemsIndex_ParentEnrichment(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 	slug := createWSWithCollections(t, srv)
 
@@ -1560,6 +1590,7 @@ func TestListItemsIndex_ParentEnrichment(t *testing.T) {
 // TestListItemsIndex_ExcludesArchivedByDefault confirms the IncludeArchived
 // gate matches handleListItems' default behavior.
 func TestListItemsIndex_ExcludesArchivedByDefault(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 	slug := createWSWithCollections(t, srv)
 
@@ -1619,6 +1650,7 @@ type itemsChangesBody struct {
 // `?since=0`, all three returned in ascending seq order, every row
 // `deleted:false`, cursor = max seq.
 func TestListItemsChanges_FullDeltaFromZero(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 	slug := createWSWithCollections(t, srv)
 
@@ -1665,6 +1697,7 @@ func TestListItemsChanges_FullDeltaFromZero(t *testing.T) {
 // one. A poll at the snapshot cursor returns exactly those two rows
 // with `deleted` set correctly.
 func TestListItemsChanges_IncrementalUpdateAndDelete(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 	slug := createWSWithCollections(t, srv)
 
@@ -1731,6 +1764,7 @@ func TestListItemsChanges_IncrementalUpdateAndDelete(t *testing.T) {
 // gap": after running the delta once, re-polling with the returned
 // cursor as `since` returns zero rows.
 func TestListItemsChanges_CursorRoundtripsCleanly(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 	slug := createWSWithCollections(t, srv)
 
@@ -1760,6 +1794,7 @@ func TestListItemsChanges_CursorRoundtripsCleanly(t *testing.T) {
 // equals seq of the last returned row so the client can resume with
 // no overlap or gap.
 func TestListItemsChanges_LimitTruncatesAndCursorResumes(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 	slug := createWSWithCollections(t, srv)
 
@@ -1806,6 +1841,7 @@ func TestListItemsChanges_LimitTruncatesAndCursorResumes(t *testing.T) {
 // TestListItemsChanges_InvalidParams rejects bad `since` / `limit`
 // values with 400 instead of silently returning the entire workspace.
 func TestListItemsChanges_InvalidParams(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 	slug := createWSWithCollections(t, srv)
 
@@ -1830,6 +1866,7 @@ func TestListItemsChanges_InvalidParams(t *testing.T) {
 // TestListItemsChanges_EmptyWorkspace returns no rows and preserves
 // the caller's cursor.
 func TestListItemsChanges_EmptyWorkspace(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 	slug := createWSWithCollections(t, srv)
 
@@ -1861,6 +1898,7 @@ func TestListItemsChanges_EmptyWorkspace(t *testing.T) {
 // the endpoint outside the /items/{itemSlug} subtree means no item slug
 // can ever shadow it (or vice versa). See Codex round 1 [P2] on PR #486.
 func TestListItemsIndex_DoesNotShadowItemSlug(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 	slug := createWSWithCollections(t, srv)
 
@@ -1899,6 +1937,7 @@ func TestListItemsIndex_DoesNotShadowItemSlug(t *testing.T) {
 // client used to compute from item.content before /items-index made
 // content unavailable in list view.
 func TestCollectionCheckboxProgress(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 	slug := createWSWithCollections(t, srv)
 
@@ -2017,6 +2056,7 @@ func firstID(items []models.Item) string {
 //   - Visibility gate: a restricted member without access to the collection
 //     receives an empty response (not child counts for a hidden collection).
 func TestCollectionChildProgress(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 	slug := createWSWithCollections(t, srv)
 
@@ -2321,6 +2361,7 @@ func TestCollectionChildProgress(t *testing.T) {
 // token (PAT/CLI/OAuth). Mirrors handlers_admin_bearer_gate_test.go's
 // fixture idiom.
 func TestListItems_AdminBearer_RestrictedMemberIsScoped(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 
 	admin, err := srv.store.CreateUser(models.UserCreate{
@@ -2409,6 +2450,7 @@ func TestListItems_AdminBearer_RestrictedMemberIsScoped(t *testing.T) {
 // creating in their visible collection still succeeds. A cookie session
 // keeps the pre-existing unrestricted admin affordance on both collections.
 func TestCreateItem_AdminBearer_RestrictedMemberIsScoped(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 
 	admin, err := srv.store.CreateUser(models.UserCreate{
@@ -2590,6 +2632,7 @@ func (f *bearerGateItemFixture) bearerHeaders() map[string]string {
 // member_collection_access — bypassing BUG-1917's list-level scoping
 // entirely for anyone who can guess (or enumerate) a ref.
 func TestGetItem_AdminBearer_RestrictedMemberBlockedOnHiddenCollection(t *testing.T) {
+	t.Parallel()
 	f := newBearerGateItemFixture(t)
 
 	rr := doRequestWithHeaders(f.srv, "GET", "/api/v1/workspaces/"+f.ws.Slug+"/items/"+f.hiddenItem.Slug, nil, f.bearerHeaders())
@@ -2620,6 +2663,7 @@ func TestGetItem_AdminBearer_RestrictedMemberBlockedOnHiddenCollection(t *testin
 // ever runs — the hidden-collection item must be indistinguishable from
 // a genuinely nonexistent one.
 func TestUpdateItem_AdminBearer_RestrictedMemberBlockedOnHiddenCollection(t *testing.T) {
+	t.Parallel()
 	f := newBearerGateItemFixture(t)
 
 	rr := doRequestWithHeaders(f.srv, "PATCH", "/api/v1/workspaces/"+f.ws.Slug+"/items/"+f.hiddenItem.Slug,
@@ -2647,6 +2691,7 @@ func TestUpdateItem_AdminBearer_RestrictedMemberBlockedOnHiddenCollection(t *tes
 // TestDeleteItem_AdminBearer_RestrictedMemberBlockedOnHiddenCollection
 // completes the write-path sweep for BUG-1918 (DELETE).
 func TestDeleteItem_AdminBearer_RestrictedMemberBlockedOnHiddenCollection(t *testing.T) {
+	t.Parallel()
 	f := newBearerGateItemFixture(t)
 
 	rr := doRequestWithHeaders(f.srv, "DELETE", "/api/v1/workspaces/"+f.ws.Slug+"/items/"+f.hiddenItem.Slug, nil, f.bearerHeaders())

--- a/internal/server/handlers_mcp_test.go
+++ b/internal/server/handlers_mcp_test.go
@@ -16,6 +16,7 @@ import (
 // 404. This is the self-hosted contract — the binary stays free of
 // MCP-server overhead unless an operator explicitly opts in.
 func TestMCP_CloudModeOff_RoutesAbsent(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 	// Cloud mode deliberately not set; SetMCPTransport never called.
 
@@ -40,6 +41,7 @@ func TestMCP_CloudModeOff_RoutesAbsent(t *testing.T) {
 // SetMCPTransport. The route group is gated on BOTH conditions; this
 // pins the AND.
 func TestMCP_CloudModeOnButTransportNotWired_RoutesAbsent(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 	srv.SetCloudMode("test-secret")
 	// Note: SetMCPTransport NOT called.
@@ -56,6 +58,7 @@ func TestMCP_CloudModeOnButTransportNotWired_RoutesAbsent(t *testing.T) {
 // where a config change makes the doc emit fallback values that don't
 // match the cert in production.
 func TestMCP_DiscoveryDoc_PopulatedFromConfig(t *testing.T) {
+	t.Parallel()
 	srv := mcpEnabledTestServer(t)
 
 	rr := doRequest(srv, "GET", "/.well-known/oauth-protected-resource", nil)
@@ -100,6 +103,7 @@ func TestMCP_DiscoveryDoc_PopulatedFromConfig(t *testing.T) {
 // shape assertions live in TestOAuth_AuthorizationServerMetadata_PopulatedShape
 // (which uses oauthEnabledTestServer).
 func TestMCP_AuthServerMetadata_MountedAndGated(t *testing.T) {
+	t.Parallel()
 	srv := mcpEnabledTestServer(t)
 
 	rr := doRequest(srv, "GET", "/.well-known/oauth-authorization-server", nil)
@@ -114,6 +118,7 @@ func TestMCP_AuthServerMetadata_MountedAndGated(t *testing.T) {
 // them at the discovery doc. Without this, Claude Desktop refuses to
 // proceed past the first request.
 func TestMCP_NoToken_Returns401WithWWWAuthenticate(t *testing.T) {
+	t.Parallel()
 	srv := mcpEnabledTestServer(t)
 
 	rr := doRequest(srv, "POST", "/mcp", map[string]any{
@@ -138,6 +143,7 @@ func TestMCP_NoToken_Returns401WithWWWAuthenticate(t *testing.T) {
 // same envelope shape for a bearer that isn't even shaped like a pad
 // PAT. Format-rejection happens before the DB lookup.
 func TestMCP_BadTokenFormat_Returns401WithWWWAuthenticate(t *testing.T) {
+	t.Parallel()
 	srv := mcpEnabledTestServer(t)
 
 	req := httptest.NewRequest("POST", "/mcp", strings.NewReader(`{}`))
@@ -164,6 +170,7 @@ func TestMCP_BadTokenFormat_Returns401WithWWWAuthenticate(t *testing.T) {
 // transport with the right user," not "the streamable transport
 // works" (mcp-go's own tests cover that).
 func TestMCP_ValidPAT_ReachesTransport(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 
 	user, err := srv.store.CreateUser(models.UserCreate{
@@ -247,6 +254,7 @@ func TestMCP_ValidPAT_ReachesTransport(t *testing.T) {
 // deploys that hadn't configured the public URL yet. The fallback
 // derives "https://" + r.Host so the discovery handshake completes.
 func TestMCP_NoToken_FallsBackToHostWhenPublicURLUnset(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 	srv.SetCloudMode("test-secret")
 	stub := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -287,6 +295,7 @@ func TestMCP_NoToken_FallsBackToHostWhenPublicURLUnset(t *testing.T) {
 // MCPBearerAuth-side stash; the dispatcher enforcement is unit-
 // tested in internal/mcp/dispatch_http_test.go.
 func TestMCP_ReadScopedPAT_StashesScopesInContext(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 
 	user, err := srv.store.CreateUser(models.UserCreate{
@@ -338,6 +347,7 @@ func TestMCP_ReadScopedPAT_StashesScopesInContext(t *testing.T) {
 // Specifically pins the read-vs-write decision the security finding
 // cared about.
 func TestTokenScopeAllows_PublicWrapper(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name           string
 		scopes, method string
@@ -441,6 +451,7 @@ func (t *mcpStubTransport) serve(w http.ResponseWriter, r *http.Request) {
 // context, and stashes scopes via WithTokenScopes so the in-process
 // dispatcher can enforce per-tool checks.
 func TestMCP_OAuthAccessToken_Authenticates(t *testing.T) {
+	t.Parallel()
 	srv, transport := mcpAndOAuthEnabledTestServer(t)
 	user, sessionToken := loginTestUser(t, srv)
 	csrfTok := readCSRFFromCookie(t, srv, sessionToken)
@@ -498,6 +509,7 @@ func TestMCP_OAuthAccessToken_Authenticates(t *testing.T) {
 // here defends against scenarios where the auth server is
 // compromised, misconfigured, or shared across multiple resources.
 func TestMCP_OAuthAccessToken_AudienceMismatch_Rejected(t *testing.T) {
+	t.Parallel()
 	// Step 1: build a normal MCP+OAuth server matched to
 	// testCanonicalAudience and mint a token through the standard
 	// helper.
@@ -551,6 +563,7 @@ func TestMCP_OAuthAccessToken_AudienceMismatch_Rejected(t *testing.T) {
 // accidentally puts the refresh token in the Authorization header
 // must NOT authenticate.
 func TestMCP_OAuthRefreshToken_RejectedAtMCP(t *testing.T) {
+	t.Parallel()
 	srv, _ := mcpAndOAuthEnabledTestServer(t)
 	_, sessionToken := loginTestUser(t, srv)
 	csrfTok := readCSRFFromCookie(t, srv, sessionToken)
@@ -582,6 +595,7 @@ func TestMCP_OAuthRefreshToken_RejectedAtMCP(t *testing.T) {
 // flow that sub-PRs A + D wired: a revoke call must invalidate
 // every bearer in the chain.
 func TestMCP_RevokedOAuthToken_Rejected(t *testing.T) {
+	t.Parallel()
 	srv, _ := mcpAndOAuthEnabledTestServer(t)
 	_, sessionToken := loginTestUser(t, srv)
 	csrfTok := readCSRFFromCookie(t, srv, sessionToken)
@@ -621,6 +635,7 @@ func TestMCP_RevokedOAuthToken_Rejected(t *testing.T) {
 // keep working unchanged so existing CLI / Claude-Code-on-self-host
 // users don't see a regression.
 func TestMCP_PATPath_StillWorks(t *testing.T) {
+	t.Parallel()
 	srv, transport := mcpAndOAuthEnabledTestServer(t)
 
 	user, err := srv.store.CreateUser(models.UserCreate{
@@ -667,6 +682,7 @@ func TestMCP_PATPath_StillWorks(t *testing.T) {
 // dispatcher-side enforcement is covered by
 // TestTokenScopeAllows_PublicWrapper / token_scopes_test.go.
 func TestMCP_OAuthScopeReadOnly_StashesPadReadScope(t *testing.T) {
+	t.Parallel()
 	srv, transport := mcpAndOAuthEnabledTestServer(t)
 	_, sessionToken := loginTestUser(t, srv)
 	csrfTok := readCSRFFromCookie(t, srv, sessionToken)
@@ -705,6 +721,7 @@ func TestMCP_OAuthScopeReadOnly_StashesPadReadScope(t *testing.T) {
 // the contract: oauthScopesToJSON produces null, and tokenScopeAllows
 // then denies for every method.
 func TestOAuthScopesToJSON_FailClosedOnEmpty(t *testing.T) {
+	t.Parallel()
 	got := oauthScopesToJSON(nil)
 	if got != "null" {
 		t.Errorf("nil scopes: got %q, want %q", got, "null")
@@ -740,6 +757,7 @@ func TestOAuthScopesToJSON_FailClosedOnEmpty(t *testing.T) {
 // support endpoint returns the four whitelisted fields and matches
 // what was registered.
 func TestOAuthClientPublicInfo_HappyPath(t *testing.T) {
+	t.Parallel()
 	srv, _ := oauthEnabledTestServer(t)
 	_, sessionToken := loginTestUser(t, srv)
 
@@ -797,6 +815,7 @@ func TestOAuthClientPublicInfo_HappyPath(t *testing.T) {
 // client ID gets 404, not 401 (caller IS authenticated; the resource
 // just doesn't exist).
 func TestOAuthClientPublicInfo_UnknownClient_404(t *testing.T) {
+	t.Parallel()
 	srv, _ := oauthEnabledTestServer(t)
 	_, sessionToken := loginTestUser(t, srv)
 
@@ -816,6 +835,7 @@ func TestOAuthClientPublicInfo_UnknownClient_404(t *testing.T) {
 // have to seed a user so the system is past setup, even though we
 // don't use that user's session in the actual request.
 func TestOAuthClientPublicInfo_Unauthenticated_401(t *testing.T) {
+	t.Parallel()
 	srv, _ := oauthEnabledTestServer(t)
 	// Seed a user so the system isn't in setup_required mode (which
 	// auto-allows everything). Discard the session — we want this
@@ -834,6 +854,7 @@ func TestOAuthClientPublicInfo_Unauthenticated_401(t *testing.T) {
 // cloud-mode gate covers the endpoint — self-hosted deployments
 // without the OAuth surface don't expose it.
 func TestOAuthClientPublicInfo_NotMountedOutsideCloudMode(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 	_, sessionToken := loginTestUser(t, srv)
 
@@ -871,6 +892,7 @@ func TestOAuthClientPublicInfo_NotMountedOutsideCloudMode(t *testing.T) {
 // hop breaks, the whole connector experience breaks for every
 // MCP-aware client. Worth one slow integration test.
 func TestE2E_ClaudeDesktopFlow(t *testing.T) {
+	t.Parallel()
 	srv, transport := mcpAndOAuthEnabledTestServer(t)
 	user, sessionToken := loginTestUser(t, srv)
 
@@ -948,6 +970,7 @@ func TestE2E_ClaudeDesktopFlow(t *testing.T) {
 // AFTER ValidateToken — Codex review #378 round 1 — to bound the
 // limiter map to valid-token hashes only).
 func TestMCPRateLimit_PerToken_BucketEnforced(t *testing.T) {
+	t.Parallel()
 	srv := mcpEnabledTestServer(t)
 	pat := mustCreatePATForTest(t, srv, "rate-limit-bucket")
 
@@ -986,6 +1009,7 @@ func TestMCPRateLimit_PerToken_BucketEnforced(t *testing.T) {
 // Strategy: drain token1 to 429, then verify token2 still gets
 // through. Two real PATs so the rate-limit check fires for both.
 func TestMCPRateLimit_PerToken_TwoTokensIndependent(t *testing.T) {
+	t.Parallel()
 	srv := mcpEnabledTestServer(t)
 	pat1 := mustCreatePATForTest(t, srv, "rate-limit-pat-1")
 	pat2 := mustCreatePATForTest(t, srv, "rate-limit-pat-2")
@@ -1037,6 +1061,7 @@ func TestMCPRateLimit_PerToken_TwoTokensIndependent(t *testing.T) {
 // 50 invalid bearers in a row — each one should 401 cleanly, none
 // should 429 (because validation rejected before the limiter runs).
 func TestMCPRateLimit_InvalidBearerNotRateLimited(t *testing.T) {
+	t.Parallel()
 	srv := mcpEnabledTestServer(t)
 
 	// Shape-valid but unknown PAT — passes the prefix+length check,
@@ -1071,6 +1096,7 @@ func TestMCPRateLimit_InvalidBearerNotRateLimited(t *testing.T) {
 // hammer /mcp with it 50 times, assert every response is 401 (not
 // 429) AND the limiter map size is unchanged.
 func TestMCPRateLimit_OAuthRefreshTokenNotCounted(t *testing.T) {
+	t.Parallel()
 	srv, _ := mcpAndOAuthEnabledTestServer(t)
 	_, sessionToken := loginTestUser(t, srv)
 	csrfTok := readCSRFFromCookie(t, srv, sessionToken)
@@ -1120,6 +1146,7 @@ func TestMCPRateLimit_OAuthRefreshTokenNotCounted(t *testing.T) {
 // a new entry in the map, growing it unbounded under random-bearer
 // spam.
 func TestMCPRateLimit_LimiterMapBoundedByValidTokensOnly(t *testing.T) {
+	t.Parallel()
 	srv := mcpEnabledTestServer(t)
 
 	if srv.rateLimiters == nil || srv.rateLimiters.MCPPerToken == nil {
@@ -1158,6 +1185,7 @@ func TestMCPRateLimit_LimiterMapBoundedByValidTokensOnly(t *testing.T) {
 // which only runs on /mcp — so by construction the discovery
 // routes never hit it. This test pins that wiring.
 func TestMCPRateLimit_DiscoveryDocsExempt(t *testing.T) {
+	t.Parallel()
 	srv := mcpEnabledTestServer(t)
 
 	// Hammer the protected-resource discovery doc 50 times; expect
@@ -1185,6 +1213,7 @@ func TestMCPRateLimit_DiscoveryDocsExempt(t *testing.T) {
 //
 // Concretely: 50 no-bearer requests should all 401, never 429.
 func TestMCPRateLimit_NoBearer_NotCounted(t *testing.T) {
+	t.Parallel()
 	srv := mcpEnabledTestServer(t)
 
 	for i := 0; i < 50; i++ {
@@ -1208,6 +1237,7 @@ func TestMCPRateLimit_NoBearer_NotCounted(t *testing.T) {
 // the message; without the envelope they'd render a raw 429 with
 // no actionable text.
 func TestMCPRateLimit_429EnvelopeShape(t *testing.T) {
+	t.Parallel()
 	srv := mcpEnabledTestServer(t)
 	pat := mustCreatePATForTest(t, srv, "rate-limit-envelope")
 
@@ -1259,6 +1289,7 @@ func TestMCPRateLimit_429EnvelopeShape(t *testing.T) {
 // hash (caller is expected to skip empty bearers, but the helper
 // itself must not panic).
 func TestHashTokenForLimiter(t *testing.T) {
+	t.Parallel()
 	a := hashTokenForLimiter("token-a")
 	b := hashTokenForLimiter("token-b")
 	a2 := hashTokenForLimiter("token-a")
@@ -1293,6 +1324,7 @@ func TestHashTokenForLimiter(t *testing.T) {
 // inherits it; RequireWorkspaceAccess reads it; the workspace
 // resolves; the gate matches; the standard membership check runs.
 func TestWorkspaceAllowList_AllowsListedSlug(t *testing.T) {
+	t.Parallel()
 	srv, _ := mcpAndOAuthEnabledTestServer(t)
 	user, sessionToken := loginTestUser(t, srv)
 	csrfTok := readCSRFFromCookie(t, srv, sessionToken)
@@ -1336,6 +1368,7 @@ func TestWorkspaceAllowList_AllowsListedSlug(t *testing.T) {
 // rejected with 403 even when the user is a member of it. The
 // user's choice at consent time is binding.
 func TestWorkspaceAllowList_DeniesUnlistedSlug(t *testing.T) {
+	t.Parallel()
 	srv, _ := mcpAndOAuthEnabledTestServer(t)
 	user, sessionToken := loginTestUser(t, srv)
 	csrfTok := readCSRFFromCookie(t, srv, sessionToken)
@@ -1377,6 +1410,7 @@ func TestWorkspaceAllowList_DeniesUnlistedSlug(t *testing.T) {
 // user is a member of, no per-slug gate. Standard membership is
 // still the boundary.
 func TestWorkspaceAllowList_WildcardAllowsAnyMembership(t *testing.T) {
+	t.Parallel()
 	srv, _ := mcpAndOAuthEnabledTestServer(t)
 	user, sessionToken := loginTestUser(t, srv)
 	csrfTok := readCSRFFromCookie(t, srv, sessionToken)
@@ -1423,6 +1457,7 @@ func TestWorkspaceAllowList_WildcardAllowsAnyMembership(t *testing.T) {
 // permissions change immediately" property from the PLAN-943 design
 // (TASK-952's consent-screen footer references this).
 func TestWorkspaceAllowList_LiveMembershipRevocation(t *testing.T) {
+	t.Parallel()
 	srv, _ := mcpAndOAuthEnabledTestServer(t)
 	user, sessionToken := loginTestUser(t, srv)
 	csrfTok := readCSRFFromCookie(t, srv, sessionToken)
@@ -1484,6 +1519,7 @@ func TestWorkspaceAllowList_LiveMembershipRevocation(t *testing.T) {
 // hit the gate. PATs that hit /api/v1/workspaces/<slug>/* should
 // continue to work the same as they did pre-TASK-953.
 func TestWorkspaceAllowList_PATPathUnaffected(t *testing.T) {
+	t.Parallel()
 	srv, _ := mcpAndOAuthEnabledTestServer(t)
 	user := mustCreateUserForTest(t, srv, "pat-no-gate@example.com")
 	mustSeedWorkspaceWithRole(t, srv, user.ID, "Alpha", "alpha", "owner")
@@ -1526,6 +1562,7 @@ func TestWorkspaceAllowList_PATPathUnaffected(t *testing.T) {
 // "pad:write action + Viewer → 403 (capability allows but role
 // doesn't)."
 func TestWorkspaceAllowList_TierTimesRole_WriteByViewer(t *testing.T) {
+	t.Parallel()
 	srv, _ := mcpAndOAuthEnabledTestServer(t)
 	user, sessionToken := loginTestUser(t, srv)
 	csrfTok := readCSRFFromCookie(t, srv, sessionToken)

--- a/internal/server/handlers_oauth_test.go
+++ b/internal/server/handlers_oauth_test.go
@@ -87,6 +87,7 @@ func bytes32ForTest() []byte {
 // =====================================================================
 
 func TestOAuth_AuthorizationServerMetadata_PopulatedShape(t *testing.T) {
+	t.Parallel()
 	srv, _ := oauthEnabledTestServer(t)
 
 	rr := doRequest(srv, "GET", "/.well-known/oauth-authorization-server", nil)
@@ -149,6 +150,7 @@ func sliceContainsString(v any, want string) bool {
 // =====================================================================
 
 func TestOAuth_Register_HappyPath(t *testing.T) {
+	t.Parallel()
 	srv, _ := oauthEnabledTestServer(t)
 
 	rr := doRequest(srv, "POST", "/oauth/register", map[string]any{
@@ -181,6 +183,7 @@ func TestOAuth_Register_HappyPath(t *testing.T) {
 }
 
 func TestOAuth_Register_RejectsMissingRedirectURIs(t *testing.T) {
+	t.Parallel()
 	srv, _ := oauthEnabledTestServer(t)
 	rr := doRequest(srv, "POST", "/oauth/register", map[string]any{
 		"client_name": "No URIs",
@@ -196,6 +199,7 @@ func TestOAuth_Register_RejectsMissingRedirectURIs(t *testing.T) {
 }
 
 func TestOAuth_Register_RejectsBadRedirectURIShapes(t *testing.T) {
+	t.Parallel()
 	srv, _ := oauthEnabledTestServer(t)
 	cases := map[string]string{
 		"relative":          "/oauth/cb",
@@ -216,6 +220,7 @@ func TestOAuth_Register_RejectsBadRedirectURIShapes(t *testing.T) {
 }
 
 func TestOAuth_Register_RejectsNonPublicClientAuth(t *testing.T) {
+	t.Parallel()
 	srv, _ := oauthEnabledTestServer(t)
 	rr := doRequest(srv, "POST", "/oauth/register", map[string]any{
 		"redirect_uris":              []string{"https://app.test/cb"},
@@ -227,6 +232,7 @@ func TestOAuth_Register_RejectsNonPublicClientAuth(t *testing.T) {
 }
 
 func TestOAuth_Register_RejectsUnknownGrantType(t *testing.T) {
+	t.Parallel()
 	srv, _ := oauthEnabledTestServer(t)
 	rr := doRequest(srv, "POST", "/oauth/register", map[string]any{
 		"redirect_uris": []string{"https://app.test/cb"},
@@ -238,6 +244,7 @@ func TestOAuth_Register_RejectsUnknownGrantType(t *testing.T) {
 }
 
 func TestOAuth_Register_NotMountedOutsideCloudMode(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t) // no SetCloudMode, no SetOAuthServer
 	rr := doRequest(srv, "POST", "/oauth/register", map[string]any{
 		"redirect_uris": []string{"https://app.test/cb"},
@@ -255,6 +262,7 @@ func TestOAuth_Register_NotMountedOutsideCloudMode(t *testing.T) {
 // =====================================================================
 
 func TestOAuth_Authorize_RedirectsToLoginWhenNoSession(t *testing.T) {
+	t.Parallel()
 	srv, _ := oauthEnabledTestServer(t)
 	// Register a client to make the request well-formed.
 	clientID := registerTestClient(t, srv, "https://app.test/cb")
@@ -288,6 +296,7 @@ func TestOAuth_Authorize_RedirectsToLoginWhenNoSession(t *testing.T) {
 }
 
 func TestOAuth_Authorize_RendersConsentWhenLoggedIn(t *testing.T) {
+	t.Parallel()
 	srv, _ := oauthEnabledTestServer(t)
 	clientID := registerTestClient(t, srv, "https://app.test/cb")
 	user, sessionToken := loginTestUser(t, srv)
@@ -353,6 +362,7 @@ func TestOAuth_Authorize_RendersConsentWhenLoggedIn(t *testing.T) {
 }
 
 func TestOAuth_Authorize_RejectsAudienceMismatch(t *testing.T) {
+	t.Parallel()
 	srv, _ := oauthEnabledTestServer(t)
 	clientID := registerTestClient(t, srv, "https://app.test/cb")
 	_, sessionToken := loginTestUser(t, srv)
@@ -394,6 +404,7 @@ func TestOAuth_Authorize_RejectsAudienceMismatch(t *testing.T) {
 // =====================================================================
 
 func TestOAuth_AuthorizeDecide_RejectsMissingCSRFToken(t *testing.T) {
+	t.Parallel()
 	srv, _ := oauthEnabledTestServer(t)
 	_, sessionToken := loginTestUser(t, srv)
 	clientID := registerTestClient(t, srv, "https://app.test/cb")
@@ -425,6 +436,7 @@ func TestOAuth_AuthorizeDecide_RejectsMissingCSRFToken(t *testing.T) {
 }
 
 func TestOAuth_AuthorizeDecide_DenyRedirectsAccessDenied(t *testing.T) {
+	t.Parallel()
 	srv, _ := oauthEnabledTestServer(t)
 	_, sessionToken := loginTestUser(t, srv)
 	clientID := registerTestClient(t, srv, "https://app.test/cb")
@@ -458,6 +470,7 @@ func TestOAuth_AuthorizeDecide_DenyRedirectsAccessDenied(t *testing.T) {
 // =====================================================================
 
 func TestOAuth_FullAuthCodeFlow_PKCE(t *testing.T) {
+	t.Parallel()
 	srv, _ := oauthEnabledTestServer(t)
 	_, sessionToken := loginTestUser(t, srv)
 	clientID := registerTestClient(t, srv, "https://app.test/cb")
@@ -544,6 +557,7 @@ func TestOAuth_FullAuthCodeFlow_PKCE(t *testing.T) {
 // the request reaches the consent stub successfully — i.e.
 // translateResourceToAudience populated fosite's expected key.
 func TestOAuth_Authorize_AcceptsResourceOnly(t *testing.T) {
+	t.Parallel()
 	srv, _ := oauthEnabledTestServer(t)
 	clientID := registerTestClient(t, srv, "https://app.test/cb")
 	_, sessionToken := loginTestUser(t, srv)
@@ -593,6 +607,7 @@ func TestOAuth_Authorize_AcceptsResourceOnly(t *testing.T) {
 // audience-mismatch tests (the wrong-audience path) to lock in the
 // full matrix of what /authorize accepts for the audience parameter.
 func TestOAuth_Authorize_AcceptsNoResource_DefaultsToCanonical(t *testing.T) {
+	t.Parallel()
 	srv, _ := oauthEnabledTestServer(t)
 	clientID := registerTestClient(t, srv, "https://app.test/cb")
 	_, sessionToken := loginTestUser(t, srv)
@@ -641,6 +656,7 @@ func TestOAuth_Authorize_AcceptsNoResource_DefaultsToCanonical(t *testing.T) {
 // Without (1), the browser blocks. Without (2), the browser blocks
 // even WITH the CSP override. Both are necessary.
 func TestOAuth_ConsentScreen_NonceCSPLetsInlineScriptRun(t *testing.T) {
+	t.Parallel()
 	srv, _ := oauthEnabledTestServer(t)
 	clientID := registerTestClient(t, srv, "https://app.test/cb")
 	_, sessionToken := loginTestUser(t, srv)
@@ -722,6 +738,7 @@ func snippetAround(body, marker string, n int) string {
 // the previous OmitsUnimplementedEndpoints test asserted those were
 // also absent — those assertions moved to AdvertisesRevokeIntrospect.)
 func TestOAuth_AuthorizationServerMetadata_OmitsRFC9207IssFlag(t *testing.T) {
+	t.Parallel()
 	srv, _ := oauthEnabledTestServer(t)
 
 	rr := doRequest(srv, "GET", "/.well-known/oauth-authorization-server", nil)
@@ -754,6 +771,7 @@ func TestOAuth_AuthorizationServerMetadata_OmitsRFC9207IssFlag(t *testing.T) {
 // will dial a 404 and surface "auth server appears broken" to the
 // user with no clean recovery. Pin the wire shape.
 func TestOAuth_AuthorizationServerMetadata_AdvertisesRevokeIntrospect(t *testing.T) {
+	t.Parallel()
 	srv, _ := oauthEnabledTestServer(t)
 
 	rr := doRequest(srv, "GET", "/.well-known/oauth-authorization-server", nil)
@@ -799,6 +817,7 @@ func TestOAuth_AuthorizationServerMetadata_AdvertisesRevokeIntrospect(t *testing
 //
 // Fail-loud 503 lets ops detect the misconfiguration immediately.
 func TestOAuth_AuthorizationServerMetadata_503WhenOAuthDisabled(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t)
 	srv.SetCloudMode("test-secret")
 	// Mount MCP transport (so the discovery route is registered)
@@ -825,6 +844,7 @@ func TestOAuth_AuthorizationServerMetadata_503WhenOAuthDisabled(t *testing.T) {
 // fresh Server has fresh limiters, so other tests don't leak
 // budget across.
 func TestOAuth_Register_RateLimited(t *testing.T) {
+	t.Parallel()
 	srv, _ := oauthEnabledTestServer(t)
 
 	body := map[string]any{
@@ -847,6 +867,7 @@ func TestOAuth_Register_RateLimited(t *testing.T) {
 }
 
 func TestOAuth_Token_RejectsMissingPKCEVerifier(t *testing.T) {
+	t.Parallel()
 	srv, _ := oauthEnabledTestServer(t)
 	_, sessionToken := loginTestUser(t, srv)
 	clientID := registerTestClient(t, srv, "https://app.test/cb")
@@ -903,6 +924,7 @@ func TestOAuth_Token_RejectsMissingPKCEVerifier(t *testing.T) {
 // role shown next to each. Multi-workspace coverage — the single-
 // workspace case is covered implicitly by the basic render test.
 func TestConsent_RendersUserWorkspaces(t *testing.T) {
+	t.Parallel()
 	srv, _ := oauthEnabledTestServer(t)
 	user, sessionToken := loginTestUser(t, srv)
 	clientID := registerTestClient(t, srv, "https://app.test/cb")
@@ -966,6 +988,7 @@ func TestConsent_RendersUserWorkspaces(t *testing.T) {
 // (e.g. autoCreateWorkspace failing silently) doesn't leave users
 // with a broken consent screen.
 func TestConsent_NoWorkspaces_ShowsEmptyState(t *testing.T) {
+	t.Parallel()
 	srv, _ := oauthEnabledTestServer(t)
 	_, sessionToken := loginTestUser(t, srv)
 	clientID := registerTestClient(t, srv, "https://app.test/cb")
@@ -999,6 +1022,7 @@ func TestConsent_NoWorkspaces_ShowsEmptyState(t *testing.T) {
 // subset check (RFC 6749 §3.3) would reject granting a tier the
 // client didn't request, so the UI must never offer it.
 func TestConsent_TierRadios_OnlyRequestedScopes(t *testing.T) {
+	t.Parallel()
 	srv, _ := oauthEnabledTestServer(t)
 	_, sessionToken := loginTestUser(t, srv)
 	clientID := registerTestClient(t, srv, "https://app.test/cb")
@@ -1037,6 +1061,7 @@ func TestConsent_TierRadios_OnlyRequestedScopes(t *testing.T) {
 // workspace allow-list in session.Extra (where TASK-953 will read
 // it for live role enforcement).
 func TestConsent_ApproveWithSpecificWorkspaces(t *testing.T) {
+	t.Parallel()
 	srv, _ := oauthEnabledTestServer(t)
 	user, sessionToken := loginTestUser(t, srv)
 	clientID := registerTestClient(t, srv, "https://app.test/cb")
@@ -1163,6 +1188,7 @@ func TestConsent_ApproveWithSpecificWorkspaces(t *testing.T) {
 // ["*"] which TASK-953 will translate to "no workspace gating
 // beyond live membership" at enforcement time.
 func TestConsent_ApproveWithWildcard(t *testing.T) {
+	t.Parallel()
 	srv, _ := oauthEnabledTestServer(t)
 	_, sessionToken := loginTestUser(t, srv)
 	clientID := registerTestClient(t, srv, "https://app.test/cb")
@@ -1256,6 +1282,7 @@ func TestConsent_ApproveWithWildcard(t *testing.T) {
 // may_create_workspaces checkbox. Verifies the parsed values land on
 // the oauth_connections row exactly as the user picked them.
 func TestConsent_ApproveWithNewShape(t *testing.T) {
+	t.Parallel()
 	srv, _ := oauthEnabledTestServer(t)
 	user, sessionToken := loginTestUser(t, srv)
 	clientID := registerTestClient(t, srv, "https://app.test/cb")
@@ -1342,6 +1369,7 @@ func TestConsent_ApproveWithNewShape(t *testing.T) {
 // screen (IDEA-1517 §2a — clients can suggest a default name to help
 // users tell their connections apart later).
 func TestConsent_SuggestedNamePrefill(t *testing.T) {
+	t.Parallel()
 	srv, _ := oauthEnabledTestServer(t)
 	clientID := registerTestClient(t, srv, "https://app.test/cb")
 	user, sessionToken := loginTestUser(t, srv)
@@ -1400,6 +1428,7 @@ func extractAroundSubstring(body, substr string, radius int) string {
 // a tampered POST that sends decision=approve with no
 // allowed_workspaces must still be rejected.
 func TestConsent_ApproveWithoutWorkspaceSelection_Rejected(t *testing.T) {
+	t.Parallel()
 	srv, _ := oauthEnabledTestServer(t)
 	_, sessionToken := loginTestUser(t, srv)
 	clientID := registerTestClient(t, srv, "https://app.test/cb")
@@ -1433,6 +1462,7 @@ func TestConsent_ApproveWithoutWorkspaceSelection_Rejected(t *testing.T) {
 // stored on the token (where TASK-953 would also reject, but with
 // a misleading "you don't have access" error far downstream).
 func TestConsent_ApproveWithUntrustedSlug_Rejected(t *testing.T) {
+	t.Parallel()
 	srv, _ := oauthEnabledTestServer(t)
 	user, sessionToken := loginTestUser(t, srv)
 	clientID := registerTestClient(t, srv, "https://app.test/cb")
@@ -1470,6 +1500,7 @@ func TestConsent_ApproveWithUntrustedSlug_Rejected(t *testing.T) {
 // fosite's grant-time check would also catch this with a less-
 // readable error, so the parse-time check produces a cleaner UX.
 func TestConsent_ApproveWithUnrequestedTier_Rejected(t *testing.T) {
+	t.Parallel()
 	srv, _ := oauthEnabledTestServer(t)
 	_, sessionToken := loginTestUser(t, srv)
 	clientID := registerTestClient(t, srv, "https://app.test/cb")
@@ -1508,6 +1539,7 @@ func TestConsent_ApproveWithUnrequestedTier_Rejected(t *testing.T) {
 // here — the read-vs-write distinction is the same selective-consent
 // property either way.
 func TestConsent_TokenScopeMatchesTierChoice_Read(t *testing.T) {
+	t.Parallel()
 	srv, _ := oauthEnabledTestServer(t)
 	_, sessionToken := loginTestUser(t, srv)
 	clientID := registerTestClient(t, srv, "https://app.test/cb")
@@ -1575,6 +1607,7 @@ func TestConsent_TokenScopeMatchesTierChoice_Read(t *testing.T) {
 // user's actual selection produces a token matching the user's
 // choice (not the attacker's URL params).
 func TestConsent_URLPollution_DoesNotOverrideUserSelection(t *testing.T) {
+	t.Parallel()
 	srv, _ := oauthEnabledTestServer(t)
 	_, sessionToken := loginTestUser(t, srv)
 	clientID := registerTestClient(t, srv, "https://app.test/cb")
@@ -1716,6 +1749,7 @@ func mustSeedWorkspaceWithRole(t *testing.T, srv *Server, userID, name, slug, ro
 // Mints two grants on the same client + user, uses tokens2.access
 // to verify tokens1.access went inactive after revoke.
 func TestOAuth_Revoke_AccessToken_MarksInactive(t *testing.T) {
+	t.Parallel()
 	srv, _ := oauthEnabledTestServer(t)
 	_, sessionToken := loginTestUser(t, srv)
 	csrfTok := readCSRFFromCookie(t, srv, sessionToken)
@@ -1769,6 +1803,7 @@ func TestOAuth_Revoke_AccessToken_MarksInactive(t *testing.T) {
 // returning ErrInvalidRequest for unknown tokens) gets caught here
 // instead of in production with a confused-client report.
 func TestOAuth_Revoke_UnknownToken_Returns200(t *testing.T) {
+	t.Parallel()
 	srv, _ := oauthEnabledTestServer(t)
 	clientID := registerTestClient(t, srv, "https://app.test/cb")
 
@@ -1800,6 +1835,7 @@ func TestOAuth_Revoke_UnknownToken_Returns200(t *testing.T) {
 //
 // Sending client_id but no token must remain 400 invalid_request.
 func TestOAuth_Revoke_MissingToken_Returns400(t *testing.T) {
+	t.Parallel()
 	srv, _ := oauthEnabledTestServer(t)
 	clientID := registerTestClient(t, srv, "https://app.test/cb")
 
@@ -1820,6 +1856,7 @@ func TestOAuth_Revoke_MissingToken_Returns400(t *testing.T) {
 // (set on malformed cases via WithHint*, absent on the !found path);
 // isRevocationUnknownToken only matches the latter.
 func TestOAuth_Revoke_MalformedRequest_Returns400(t *testing.T) {
+	t.Parallel()
 	srv, _ := oauthEnabledTestServer(t)
 
 	// Empty form body — fosite rejects with ErrInvalidRequest
@@ -1849,6 +1886,7 @@ func TestOAuth_Revoke_MalformedRequest_Returns400(t *testing.T) {
 // store.Revoke*Family, which marks every chain member inactive in
 // one statement. This test validates the wiring end-to-end.
 func TestOAuth_Revoke_RefreshToken_RevokesFamily(t *testing.T) {
+	t.Parallel()
 	srv, _ := oauthEnabledTestServer(t)
 	_, sessionToken := loginTestUser(t, srv)
 	csrfTok := readCSRFFromCookie(t, srv, sessionToken)
@@ -1907,6 +1945,7 @@ func TestOAuth_Revoke_RefreshToken_RevokesFamily(t *testing.T) {
 // (single-use refresh tokens, OAuth 2.1 §6.1). This is the normal
 // happy path before any replay-detection logic kicks in.
 func TestOAuth_Refresh_RotatesAndOldBecomesInactive(t *testing.T) {
+	t.Parallel()
 	srv, _ := oauthEnabledTestServer(t)
 	_, sessionToken := loginTestUser(t, srv)
 	csrfTok := readCSRFFromCookie(t, srv, sessionToken)
@@ -1989,6 +2028,7 @@ func TestOAuth_Refresh_RotatesAndOldBecomesInactive(t *testing.T) {
 // client indefinitely. With it, the entire chain dies on the
 // first replay attempt.
 func TestOAuth_Refresh_ReplayDetection_RevokesFamily(t *testing.T) {
+	t.Parallel()
 	srv, _ := oauthEnabledTestServer(t)
 	_, sessionToken := loginTestUser(t, srv)
 	csrfTok := readCSRFFromCookie(t, srv, sessionToken)
@@ -2058,6 +2098,7 @@ func TestOAuth_Refresh_ReplayDetection_RevokesFamily(t *testing.T) {
 // presence here catches a future fosite version-bump that drops
 // or renames a field before the integration breaks.
 func TestOAuth_Introspect_ActiveToken_ReturnsClaims(t *testing.T) {
+	t.Parallel()
 	srv, _ := oauthEnabledTestServer(t)
 	user, sessionToken := loginTestUser(t, srv)
 	csrfTok := readCSRFFromCookie(t, srv, sessionToken)
@@ -2120,6 +2161,7 @@ func TestOAuth_Introspect_ActiveToken_ReturnsClaims(t *testing.T) {
 // for valid token shapes by introspecting random strings and
 // reading the response body for hints.
 func TestOAuth_Introspect_UnknownToken_ReturnsActiveFalse(t *testing.T) {
+	t.Parallel()
 	srv, _ := oauthEnabledTestServer(t)
 	_, sessionToken := loginTestUser(t, srv)
 	csrfTok := readCSRFFromCookie(t, srv, sessionToken)
@@ -2158,6 +2200,7 @@ func TestOAuth_Introspect_UnknownToken_ReturnsActiveFalse(t *testing.T) {
 // Bearer auth (public clients, no Basic auth path); a request with
 // no Authorization header MUST be rejected.
 func TestOAuth_Introspect_RejectsMissingBearer(t *testing.T) {
+	t.Parallel()
 	srv, _ := oauthEnabledTestServer(t)
 	rr := postOAuthForm(srv, "/oauth/introspect", url.Values{
 		"token": {"any-token-here"},
@@ -2172,6 +2215,7 @@ func TestOAuth_Introspect_RejectsMissingBearer(t *testing.T) {
 // confirm the cloud-mode gate covers the new endpoints (mirrors
 // TestOAuth_Register_NotMountedOutsideCloudMode for sub-PR C).
 func TestOAuth_RevokeAndIntrospect_NotMountedOutsideCloudMode(t *testing.T) {
+	t.Parallel()
 	srv := testServer(t) // no SetCloudMode
 	for _, path := range []string{"/oauth/revoke", "/oauth/introspect"} {
 		rr := postOAuthForm(srv, path, url.Values{"token": {"x"}, "client_id": {"y"}})


### PR DESCRIPTION
## What

Retrofits `t.Parallel()` onto every top-level `Test*` func in the four heaviest `internal/server` test files so the suite scales concurrently and keeps headroom under CI's `-race -timeout=45m` budget as it grows.

| File | Tests parallelized |
|------|-------------------|
| `handlers_items_test.go` | 45 |
| `handlers_oauth_test.go` | 44 |
| `handlers_mcp_test.go` | 37 |
| `handlers_dashboard_test.go` | 33 |
| **Total** | **159** |

## Why it's safe

Every one of these tests builds an isolated per-test fixture — `testServer(t)` / `oauthEnabledTestServer(t)`, both backed by `storetest.NewSQLite(t)`, which copies a fresh template DB into `t.TempDir()` per call. Each test owns its own DB, rate limiters, and event bus; nothing shares mutable global/package state, env vars, the working directory, or ordering.

## Deliberately left serial

- **`t.Run` subtests** in `TestCreateItemSourcePersistedFromAuth` and `TestPatchItem_FlexibleFieldsShape` — they share the parent's server+workspace and mutate the same seeded item, so parallelizing them would introduce write-write races. The parent-level `t.Parallel()` already delivers the concurrency win.
- **`server_test.go`** goroutine-leak / `Stop()`-drain / timing-sensitive tests (`runtime.NumGoroutine()` baselines) — untouched.

## Verification

- `go build ./cmd/pad` — OK
- `go test ./internal/server/` (serial correctness) — ok, 63s
- `go test -race ./internal/server/` — **ok, 282s / 7m16s wall, exit 0** (this is exactly what CI runs; the whole point of the task)
- Focused `-race` re-run of the timing-sensitive rate-limit + sleep tests x3 — clean each time
- `go test ./...` — all pass
- `golangci-lint run ./internal/server/` — 0 issues
- Independent Codex read-only review — no issues found

Relates to BUG-1913 (structurally resolved; this keeps headroom). Establishes convention CONVE-2086.

https://claude.ai/code/session_015yuBJQYfDj95cgX3DaD8SF