### PR TITLE
fix(e2e): disable rate limiting on the E2E server to stop 429 flakes (BUG-2089)

### DIFF
--- a/internal/server/middleware_ratelimit_test.go
+++ b/internal/server/middleware_ratelimit_test.go
@@ -45,6 +45,33 @@ func TestRateLimit_AuthEndpointLimited(t *testing.T) {
 	}
 }
 
+// TestRateLimit_DisabledByEnv pins BUG-2089: PAD_DISABLE_RATE_LIMITS=1
+// makes the server skip all rate limiting (nil rateLimiters → RateLimit
+// is a pass-through), so the E2E harness — where every test shares one
+// loopback IP — doesn't trip the auth limiter. Without the env the same
+// burst returns 429 (see TestRateLimit_AuthEndpointLimited).
+func TestRateLimit_DisabledByEnv(t *testing.T) {
+	t.Setenv("PAD_DISABLE_RATE_LIMITS", "1")
+	srv := testServer(t)
+	if srv.rateLimiters != nil {
+		t.Fatal("PAD_DISABLE_RATE_LIMITS=1 must leave rateLimiters nil")
+	}
+	bootstrapFirstUser(t, srv, "admin@test.com", "Admin")
+
+	// Well past the burst of 5 — none may be rate-limited.
+	for i := 0; i < 20; i++ {
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/login",
+			strings.NewReader(`{"email":"wrong@test.com","password":"wrong"}`))
+		req.Header.Set("Content-Type", "application/json")
+		req.RemoteAddr = "10.0.0.1:1234"
+		w := httptest.NewRecorder()
+		srv.ServeHTTP(w, req)
+		if w.Code == http.StatusTooManyRequests {
+			t.Fatalf("request %d hit 429 with rate limiting disabled", i+1)
+		}
+	}
+}
+
 func TestRateLimit_DifferentIPsNotAffected(t *testing.T) {
 	srv := testServer(t)
 	bootstrapFirstUser(t, srv, "admin@test.com", "Admin")

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"net/netip"
 	"net/url"
+	"os"
 	"runtime/debug"
 	"strconv"
 	"strings"
@@ -342,9 +343,22 @@ func (s *Server) Stop() {
 }
 
 func New(s *store.Store) *Server {
+	rl := NewRateLimiters()
+	// PAD_DISABLE_RATE_LIMITS turns off ALL HTTP rate limiting when set to a
+	// truthy value. It exists ONLY for the E2E harness (BUG-2089): every
+	// Playwright test shares one loopback IP (127.0.0.1), so the auth limiter
+	// (5 logins/min/IP) trips the moment a spec logs in a couple of browser
+	// clients — collab-persistence.spec.ts logs in two per test. A nil
+	// rateLimiters makes RateLimit() a pass-through (see middleware_ratelimit.go
+	// line 379), and Stop() + the MCP path are already nil-safe. Never set this
+	// in production or self-host; it's an explicit opt-in so it can't flip on
+	// by accident.
+	if disabled, _ := strconv.ParseBool(os.Getenv("PAD_DISABLE_RATE_LIMITS")); disabled {
+		rl = nil
+	}
 	return &Server{
 		store:            s,
-		rateLimiters:     NewRateLimiters(),
+		rateLimiters:     rl,
 		storageInfoCache: newStorageInfoCache(storageInfoTTL),
 	}
 }

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -98,7 +98,13 @@ export default defineConfig({
 			PAD_HOST: E2E_HOST,
 			PAD_PORT: String(E2E_PORT),
 			PAD_DATA_DIR: DATA_DIR,
-			PAD_LOG_LEVEL: 'warn'
+			PAD_LOG_LEVEL: 'warn',
+			// Every E2E test shares one loopback IP, so the auth limiter
+			// (5 logins/min/IP) trips as soon as a spec logs in a couple of
+			// browser clients (BUG-2089). Disable rate limiting for the E2E
+			// server only — never in prod/self-host. run-pad.mjs spawns the
+			// binary with inherited env, so this reaches the pad process.
+			PAD_DISABLE_RATE_LIMITS: '1'
 		}
 	}
 });


### PR DESCRIPTION
## Problem

The `E2E (Playwright)` CI job fails deterministically in `web/e2e/collab-persistence.spec.ts`:

```
Error: in-page login failed with status 429
  at browserLogin (web/e2e/collab-persistence.spec.ts:56:28)
```

Server logs:
```
level=WARN msg="rate limited" ip=127.0.0.1 path=/api/v1/auth/login limiter=auth
POST /api/v1/auth/login status=429
```

**Not a flake** — introduced by TASK-2058 (`348c8a3d`); CI for that PR *and* its push to `main` both failed the same way, and every downstream PR since (e.g. #921). `main` is currently red on E2E.

## Root cause

The E2E harness runs the real `pad` binary with the real rate limiter, and every test shares one loopback IP (`127.0.0.1`). The `auth` limiter allows **5 logins/min/IP, burst 5** (`internal/server/middleware_ratelimit.go:206`). `collab-persistence.spec.ts` calls `browserLogin` for **two browser clients per test across several tests**, blowing past the cap.

## Fix

Add a test-only env knob `PAD_DISABLE_RATE_LIMITS`. When truthy, `New()` leaves `Server.rateLimiters` nil — and `RateLimit()` already treats nil as a pass-through (`middleware_ratelimit.go:379`), with `Stop()` and the MCP path already nil-safe. Wired into the Playwright `webServer.env`; `run-pad.mjs` spawns the binary with inherited env so it reaches the pad process.

Limiters stay **fully active in prod / self-host** — the knob is an explicit opt-in only the E2E server sets.

## Testing

- `collab-persistence.spec.ts` passes locally with the fix (2/2, was failing on 429).
- New `TestRateLimit_DisabledByEnv` pins the bypass; existing limiter tests still pass (limiters on when the env is unset).
- `go build ./...` green.

Fixes BUG-2089.

https://claude.ai/code/session_015yuBJQYfDj95cgX3DaD8SF