### PR TITLE
fix(agent): support OpenCode install target

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ pad server info                         # How this client is connected to Pad
 pad agent install        # Auto-detects your tools and installs the skill
 ```
 
-Works with **Claude Code**, **Cursor**, **Windsurf**, **Codex**, **GitHub Copilot**, **Amazon Q**, and **JetBrains Junie**.
+Works with **Claude Code**, **Cursor**, **Windsurf**, **Codex**, **OpenCode**, **GitHub Copilot**, **Amazon Q**, and **JetBrains Junie**.
 
 Then just talk to your project:
 

--- a/cmd/pad/cmd_agent.go
+++ b/cmd/pad/cmd_agent.go
@@ -22,9 +22,10 @@ Specify a tool name to install for that tool directly.
 
 Supported tools:
   claude       Claude Code (.claude/skills/)
-  cursor       Cursor (.agents/skills/) — also covers Codex & Windsurf
+  cursor       Cursor (.agents/skills/) — also covers Codex, Windsurf & OpenCode
   codex        OpenAI Codex (.agents/skills/)
   windsurf     Windsurf (.agents/skills/)
+  opencode     OpenCode (.agents/skills/)
   copilot      GitHub Copilot (.github/instructions/)
   amazon-q     Amazon Q Developer (.amazonq/rules/)
   junie        JetBrains Junie (.junie/guidelines/)
@@ -32,7 +33,8 @@ Supported tools:
 Examples:
   pad agent install              # Auto-detect and install
   pad agent install claude       # Install for Claude Code
-  pad agent install cursor       # Install for Cursor/Codex/Windsurf
+  pad agent install cursor       # Install for Cursor/Codex/Windsurf/OpenCode
+  pad agent install opencode     # Install for OpenCode
   pad agent install --all        # Install for all detected tools
   pad agent status               # Show supported tools and status`,
 		ValidArgs: cli.AllToolNames(),

--- a/internal/cli/agents.go
+++ b/internal/cli/agents.go
@@ -34,7 +34,7 @@ type AgentTool struct {
 }
 
 // SupportedTools lists all supported agent tools.
-// The "agents" target covers Codex, Cursor, and Windsurf via the shared .agents/skills/ directory.
+// The "agents" target covers Codex, Cursor, Windsurf, and OpenCode via the shared .agents/skills/ directory.
 var SupportedTools = []AgentTool{
 	{
 		Name:           "claude",
@@ -48,11 +48,11 @@ var SupportedTools = []AgentTool{
 	},
 	{
 		Name:           "agents",
-		Label:          "Codex / Cursor / Windsurf",
-		Aliases:        []string{"codex", "cursor", "windsurf"},
-		DetectDirs:     []string{".cursor", ".windsurf", ".codex", ".agents"},
-		DetectHomeDirs: []string{".cursor", ".windsurf", ".codex", ".agents"},
-		DetectBinaries: []string{"codex", "cursor", "windsurf"},
+		Label:          "Codex / Cursor / Windsurf / OpenCode",
+		Aliases:        []string{"codex", "cursor", "windsurf", "opencode"},
+		DetectDirs:     []string{".cursor", ".windsurf", ".codex", ".opencode", ".agents"},
+		DetectHomeDirs: []string{".cursor", ".windsurf", ".codex", ".opencode", ".agents"},
+		DetectBinaries: []string{"codex", "cursor", "windsurf", "opencode"},
 		SkillDir:       filepath.Join(".agents", "skills", "pad"),
 		SkillFile:      "SKILL.md",
 	},
@@ -206,7 +206,7 @@ func FormatForTool(tool AgentTool, embeddedContent []byte) []byte {
 		return embeddedContent
 
 	case "agents":
-		// Codex/Cursor/Windsurf use name + description frontmatter
+		// Codex/Cursor/Windsurf/OpenCode use name + description frontmatter
 		body := StripFrontmatter(embeddedContent)
 		fm := `---
 name: pad

--- a/internal/cli/agents_test.go
+++ b/internal/cli/agents_test.go
@@ -17,6 +17,7 @@ func TestResolveTool(t *testing.T) {
 		{"cursor", "agents", false},
 		{"codex", "agents", false},
 		{"windsurf", "agents", false},
+		{"opencode", "agents", false},
 		{"agents", "agents", false},
 		{"copilot", "copilot", false},
 		{"amazon-q", "amazon-q", false},
@@ -216,6 +217,20 @@ func TestDetectTools(t *testing.T) {
 		}
 	})
 
+	t.Run("home dir hit for agents via ~/.opencode", func(t *testing.T) {
+		home, _ := isolateEnv(t)
+		if err := os.Mkdir(filepath.Join(home, ".opencode"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		names := detectedNames(DetectTools())
+		if !names["agents"] {
+			t.Errorf("expected agents detected via ~/.opencode, got %v", names)
+		}
+		if names["claude"] {
+			t.Errorf("claude should not be detected, got %v", names)
+		}
+	})
+
 	t.Run("home dir hit for claude via ~/.claude", func(t *testing.T) {
 		home, _ := isolateEnv(t)
 		if err := os.Mkdir(filepath.Join(home, ".claude"), 0o755); err != nil {
@@ -236,6 +251,15 @@ func TestDetectTools(t *testing.T) {
 		names := detectedNames(DetectTools())
 		if !names["agents"] {
 			t.Errorf("expected agents detected via codex binary, got %v", names)
+		}
+	})
+
+	t.Run("binary hit for agents via opencode on PATH", func(t *testing.T) {
+		_, bin := isolateEnv(t)
+		writeStubBinary(t, bin, "opencode")
+		names := detectedNames(DetectTools())
+		if !names["agents"] {
+			t.Errorf("expected agents detected via opencode binary, got %v", names)
 		}
 	})
 
@@ -295,12 +319,13 @@ func TestAllToolNames(t *testing.T) {
 	names := AllToolNames()
 	// Should include both canonical names and aliases
 	expected := map[string]bool{
-		"claude":  true,
-		"agents":  true,
-		"cursor":  true,
-		"codex":   true,
-		"copilot": true,
-		"junie":   true,
+		"claude":   true,
+		"agents":   true,
+		"cursor":   true,
+		"codex":    true,
+		"opencode": true,
+		"copilot":  true,
+		"junie":    true,
 	}
 	nameMap := map[string]bool{}
 	for _, n := range names {


### PR DESCRIPTION
## What does this PR do?
### Summary
- Added OpenCode support to pad agent install through the existing
    shared .agents/skills/pad target.

### Changes
- Added opencode as an alias for the agents install target.
- Added .opencode and opencode binary detection for auto-detect
  installs.

- Updated CLI help to list OpenCode as supported.
- Updated README supported-agent list to include OpenCode.
- Added focused tests for OpenCode alias resolution, detection, and
  supported tool names.

- Verified with go test ./internal/cli ./cmd/pad.

---
Closes #856 

---
## How to test

### Step 1
```bash
mkdir -p web/build
go test ./internal/cli ./cmd/pad
```

### Step 2
```bash
 go build -o /tmp/pad-opencode-test ./cmd/pad

  tmp="$(mktemp -d)"
  mkdir -p "$tmp/home" "$tmp/project/.opencode"
  cd "$tmp/project"

  HOME="$tmp/home" /tmp/pad-opencode-test agent install opencode
  test -f .agents/skills/pad/SKILL.md
  HOME="$tmp/home" /tmp/pad-opencode-test agent status
```

### Result
<img width="662" height="111" alt="Screenshot 2026-07-11 at 3 11 05 PM" src="https://github.com/user-attachments/assets/ad8a94fe-bd26-41ae-a21a-dd627bb1a893" />
<img width="641" height="455" alt="Screenshot 2026-07-11 at 3 14 21 PM" src="https://github.com/user-attachments/assets/2c321754-0b42-4876-90b6-5df452b12a40" />

## Checklist

- [x] `make build` passes
- [x] `make test` passes
- [ ] New features have tests (if applicable)
- [ ] TypeScript types updated (if API changed)
- [x] CLI help text updated (if new command)
