### PR TITLE
docs: list OpenCode in CLAUDE.md supported-agent set

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## What This Is
 
-Pad is a project management tool for developers and AI agents. Single Go binary with embedded SvelteKit web UI, SQLite storage, and multi-agent skill support (Claude Code, Cursor, Windsurf, Codex, Copilot, Amazon Q, Junie).
+Pad is a project management tool for developers and AI agents. Single Go binary with embedded SvelteKit web UI, SQLite storage, and multi-agent skill support (Claude Code, Cursor, Windsurf, Codex, OpenCode, Copilot, Amazon Q, Junie).
 
 **Related repo:** The marketing website (getpad.dev) lives at `../pad-web` — a separate SvelteKit site deployed to Vercel.
 


### PR DESCRIPTION
Follow-up to #923. That PR reconciled the user-facing README and CLI help to include OpenCode; `CLAUDE.md` still listed the old agent set. One-line doc fix to keep the dev-guide consistent.

https://claude.ai/code/session_015yuBJQYfDj95cgX3DaD8SF