### PR TITLE
fix(release): migrate cosign signing to v3 bundle format (BUG-2091)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -51,19 +51,20 @@ sboms:
 
 # Keyless cosign signing for checksums.txt. Uses Sigstore's public Fulcio
 # CA + Rekor transparency log via GitHub Actions OIDC — no long-lived keys
-# to store. Verify with:
+# to store. cosign v3 emits a single Sigstore bundle (cert + signature +
+# Rekor entry) as checksums.txt.sigstore.json — the separate .pem/.sig
+# outputs are gone as of the v2→v3 bump. Verify with:
 #   cosign verify-blob --certificate-identity-regexp \
 #     "^https://github.com/PerpetualSoftware/pad/.github/workflows/release.yml@.*" \
 #     --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
-#     --bundle checksums.txt.cosign.bundle checksums.txt
+#     --bundle checksums.txt.sigstore.json checksums.txt
 signs:
   - cmd: cosign
-    certificate: "${artifact}.pem"
+    signature: "${artifact}.sigstore.json"
     args:
       - "sign-blob"
       - "--yes"
-      - "--output-certificate=${certificate}"
-      - "--output-signature=${signature}"
+      - "--bundle=${signature}"
       - "${artifact}"
     artifacts: checksum
     output: true


### PR DESCRIPTION
## What

The v0.10.0-rc.1 release failed at **Run GoReleaser** because the cosign-installer bump (v3.10.1 → v4.1.2) pulled the cosign **binary** from v2.x to **v3.0.6**. cosign v3 defaults `--new-bundle-format=true` for `sign-blob` and removes the separate `--output-certificate`/`--output-signature` outputs:

```
Error: signing dist/checksums.txt: create bundle file: open : no such file or directory
```

## Fix

Migrate `.goreleaser.yaml` signs block to the [official cosign-v3 path](https://goreleaser.com/blog/cosign-v3/): emit a single Sigstore bundle `checksums.txt.sigstore.json` via `--bundle`, replacing the `.pem` + `.sig` pair. Also refreshes the stale verify comment.

## Artifact-shape change (intentional)

- `checksums.txt.pem` + `checksums.txt.sig` → **`checksums.txt.sigstore.json`**
- Release asset count: **15 → 14**
- Verify: `cosign verify-blob --bundle checksums.txt.sigstore.json --certificate-identity-regexp ... checksums.txt`

## Validation

Regular CI can't exercise the signing path (tag-triggered only) — this is validated by re-cutting **v0.10.0-rc.2**. Confirmed locally that the cosign v3 `--bundle` command is flag-valid (cosign v3.0.6, same binary the runner installs).

## Follow-ups (tracked on BUG-2091)

- PLAYB-1160 Step 5 smoke test (asset count 15→14 + 5a verify command)
- DOC-2090 (v0.10.0 release notes) Verifying section
- BLOG-1022 public verify instructions

Closes BUG-2091. Supersedes stale-comment drift in TASK-1032.

https://claude.ai/code/session_015yuBJQYfDj95cgX3DaD8SF