### PR TITLE
fix(web): guard optimistic upsert with scope epoch (BUG-2098)

### DIFF
--- a/web/src/lib/components/editor/EditorBubbleMenu.svelte
+++ b/web/src/lib/components/editor/EditorBubbleMenu.svelte
@@ -4,6 +4,7 @@
 	import { parseSchema } from '$lib/types';
 	import { api, isPlanLimitError, planLimitMessage } from '$lib/api/client';
 	import { toastStore } from '$lib/stores/toast.svelte';
+	import { localIndex } from '$lib/stores/localIndex.svelte';
 
 	const AGENT_SLUGS = ['conventions', 'playbooks'];
 
@@ -16,7 +17,7 @@
 		editor: Editor | null;
 		wsSlug: string;
 		collections: Collection[];
-		onItemCreated?: (item: Item, ws: string) => void;
+		onItemCreated?: (item: Item, ws: string, sinceEpoch?: number) => void;
 	} = $props();
 
 	let visible = $state(false);
@@ -145,6 +146,10 @@
 		// navigated to another workspace mid-create. Per Codex review (round 2).
 		const ws = wsSlug;
 
+		// Scope epoch before the create so the parent's optimistic upsert can be
+		// refused if a projection resync lands mid-create (BUG-2098).
+		const sinceEpoch = localIndex.scopeEpochFor(ws);
+
 		const coll = collections.find((c) => c.slug === selectedCollectionSlug);
 		if (!coll) {
 			errorMsg = 'Collection not found';
@@ -174,7 +179,7 @@
 				.insertContentAt(selFrom, wikiLink)
 				.run();
 
-			onItemCreated?.(item, ws);
+			onItemCreated?.(item, ws, sinceEpoch);
 			toastStore.show(`Created "${item.title}"`, 'success');
 			hide();
 		} catch (err: any) {

--- a/web/src/lib/stores/localIndex.svelte.ts
+++ b/web/src/lib/stores/localIndex.svelte.ts
@@ -981,10 +981,25 @@ export const localIndex = {
 	 * landed. Rows or peers missing `seq` (legacy snapshots before
 	 * TASK-1352) overwrite unconditionally — there's no basis to
 	 * compare.
+	 *
+	 * `sinceEpoch` (BUG-2098): pass the `scopeEpochFor(ws)` captured
+	 * *before* issuing the create/update whose response you're upserting.
+	 * If a projection resync bumped the epoch while that request was in
+	 * flight, the response was authorized under the now-superseded scope
+	 * and is refused. This closes the gap the fence alone can't cover: a
+	 * brand-new create id was never in the map to be dropped, so it's
+	 * never in `fencedIds` — without the epoch check a stale old-scope
+	 * create would resurrect a row no new-scope delta will ever evict.
+	 * Omit it (SSE / authoritative paths) to skip the check entirely.
 	 */
-	upsert(ws: string, row: ItemIndexRow | Item): void {
+	upsert(ws: string, row: ItemIndexRow | Item, sinceEpoch?: number): void {
 		const state = ensureState(ws);
 		let next = toSkinny(row);
+		// Epoch guard (BUG-2098): a resync between request-issue and this
+		// response means the row may belong to the old scope. Reject it —
+		// the fence below only catches ids the resync explicitly dropped,
+		// not a fresh create whose id was never in the map.
+		if (sinceEpoch !== undefined && sinceEpoch < state.scopeEpoch) return;
 		// Fence guard (Codex P1 round 8): a projection resync records the ids it
 		// dropped as hidden under the new scope. This is the untrusted optimistic
 		// path — a create/update response authorized under the OLD scope can

--- a/web/src/lib/stores/localIndexUnparented.svelte.test.ts
+++ b/web/src/lib/stores/localIndexUnparented.svelte.test.ts
@@ -118,4 +118,38 @@ describe('localIndex unparented projection compatibility', () => {
 		localIndex.upsert(ws, { ...row('hidden', 4), content: 'fresh' } as Item);
 		expect(localIndex.findByIdOrSlug(ws, 'hidden')?.seq).toBe(4);
 	});
+
+	it('rejects a stale-epoch brand-new create the fence cannot catch (BUG-2098)', async () => {
+		localIndex.upsert(ws, row('visible', 1, true));
+		localIndex.applyDelta(ws, [], '1', true); // cursor=1, scope=unrestricted
+
+		// A create is issued under the current (unrestricted) scope. The call
+		// site captures the epoch BEFORE awaiting the create response.
+		const staleEpoch = localIndex.scopeEpochFor(ws);
+
+		// Before the create resolves, a downgrade resync installs the
+		// authoritative snapshot and bumps the scope epoch. The brand-new id is
+		// NOT in the snapshot — but it was never in the map either, so it can't
+		// be fenced the way a dropped row is; only the epoch guard covers it.
+		vi.spyOn(api.items, 'listIndex').mockResolvedValueOnce({
+			items: [row('visible', 1)],
+			total: 1,
+			cursor: '1',
+			includes_unparented_metadata: false,
+		});
+		expect(await localIndex.ensureProjectionScope(ws, false)).toBe(true);
+		expect(localIndex.scopeEpochFor(ws)).toBeGreaterThan(staleEpoch);
+
+		// The stale old-scope create response now resolves. Its id was never
+		// dropped, so the fence set is empty for it — the epoch guard is the
+		// only thing that refuses it.
+		localIndex.upsert(ws, { ...row('created', 5), content: 'stale' } as Item, staleEpoch);
+		expect(localIndex.findByIdOrSlug(ws, 'created')).toBeNull();
+
+		// A create issued under the CURRENT scope (epoch not behind) is accepted —
+		// the guard rejects only responses that predate the resync, not all writes.
+		const freshEpoch = localIndex.scopeEpochFor(ws);
+		localIndex.upsert(ws, { ...row('created', 6), content: 'fresh' } as Item, freshEpoch);
+		expect(localIndex.findByIdOrSlug(ws, 'created')?.seq).toBe(6);
+	});
 });

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -907,14 +907,23 @@
 		const ws = wsSlug;
 		const parentRef = formatItemRef(item) ?? item.slug;
 
-		const doUpdate = (force: boolean) =>
-			api.items.update(ws, item.id, { fields: fieldsPayload, ...(force ? { force: true } : {}) });
+		// Record the scope epoch at each request's issue time (BUG-2098). The
+		// force-retry below can fire seconds later, after a user confirmation —
+		// long enough for a projection resync to bump the epoch — so it must
+		// capture its OWN epoch, not reuse the first request's. Setting it inside
+		// doUpdate, right before the network call, gives each attempt the epoch
+		// that was live when it was issued; a stale one makes upsert() refuse it.
+		let epoch = localIndex.scopeEpochFor(ws);
+		const doUpdate = (force: boolean) => {
+			epoch = localIndex.scopeEpochFor(ws);
+			return api.items.update(ws, item.id, { fields: fieldsPayload, ...(force ? { force: true } : {}) });
+		};
 
 		try {
 			const updated = await doUpdate(false);
 			// Push the canonical post-update row into the local index;
 			// the `items` derived view re-renders automatically.
-			localIndex.upsert(ws, updated);
+			localIndex.upsert(ws, updated, epoch);
 			toastStore.show(`Moved to ${formatLabel(newValue)}`, 'success');
 		} catch (e) {
 			// BUG-1538 / TASK-1539: the server's open-children guard
@@ -937,7 +946,7 @@
 					throw retryErr;
 				}
 				if (forced) {
-					localIndex.upsert(ws, forced);
+					localIndex.upsert(ws, forced, epoch);
 					toastStore.show(`Moved to ${formatLabel(newValue)}`, 'success');
 					return;
 				}
@@ -986,8 +995,15 @@
 		// settles back to the canonical server seq.
 		try {
 			for (const { id, sort_order } of dirty) {
+				// Per-iteration epoch: a resync mid-loop must only reject the
+				// settle-upserts for PATCHes issued before it, not later ones
+				// issued under the new scope (BUG-2098). Capturing outside the
+				// loop would wrongly reject every post-resync iteration. The
+				// optimistic pre-writes above are synchronous (no await gap) so
+				// they need no guard.
+				const epoch = localIndex.scopeEpochFor(wsSlug);
 				const updated = await api.items.update(wsSlug, id, { sort_order });
-				localIndex.upsert(wsSlug, updated);
+				localIndex.upsert(wsSlug, updated, epoch);
 			}
 		} catch (e) {
 			console.error('Failed to persist sort order:', e);
@@ -1069,6 +1085,9 @@
 			// Pre-fill the lane's group field (status, or a custom
 			// board_group_by select) so the item opens in this lane.
 			defaultFields[groupField] = groupValue;
+			// Epoch before create: a brand-new id is never in the fence set,
+			// so this is the case the epoch guard exists for (BUG-2098).
+			const epoch = localIndex.scopeEpochFor(wsSlug);
 			const item = await api.items.create(wsSlug, collSlug, {
 				title: trimmed,
 				content: '',
@@ -1078,7 +1097,7 @@
 			if (navigate) {
 				goto(`/${username}/${wsSlug}/${collSlug}/${itemUrlId(item)}?new=1`);
 			} else {
-				localIndex.upsert(wsSlug, item);
+				localIndex.upsert(wsSlug, item, epoch);
 			}
 			return item;
 		} catch (err: any) {
@@ -1194,13 +1213,15 @@
 			if (statusField?.options?.length) {
 				defaultFields.status = statusField.options[0];
 			}
+			// Epoch before create: brand-new id, never fenced (BUG-2098).
+			const epoch = localIndex.scopeEpochFor(wsSlug);
 			const item = await api.items.create(wsSlug, collSlug, {
 				title,
 				content: '',
 				fields: JSON.stringify(defaultFields),
 				source: 'web'
 			});
-			localIndex.upsert(wsSlug, item);
+			localIndex.upsert(wsSlug, item, epoch);
 			quickCreateTitle = '';
 			toastStore.show(`Created "${title}"`, 'success');
 		} catch (err: any) {
@@ -1441,9 +1462,10 @@
 
 	async function handleRestore(item: Item) {
 		if (!wsSlug) return;
+		const epoch = localIndex.scopeEpochFor(wsSlug);
 		try {
 			const restored = await api.items.restore(wsSlug, item.id);
-			localIndex.upsert(wsSlug, restored);
+			localIndex.upsert(wsSlug, restored, epoch);
 			toastStore.show(`Restored "${item.title}"`, 'success');
 		} catch {
 			toastStore.show('Failed to restore item', 'error');

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -3060,7 +3060,7 @@
 							editor={editorInstance}
 							{wsSlug}
 							collections={collectionStore.collections}
-							onItemCreated={(item, ws) => localIndex.upsert(ws, item)}
+							onItemCreated={(item, ws, epoch) => localIndex.upsert(ws, item, epoch)}
 						/>
 						<EditorLinkPopover editor={editorInstance} />
 					{/if}


### PR DESCRIPTION
## What & why

Closes **BUG-2098**. The PR-926 projection-resync fence (`fencedIds`) closes the case where an item *already in the local index* is dropped by a downgrade resync and a stale optimistic `upsert()` tries to resurrect it. It does **not** cover a brand-new **create** issued under the old scope whose response resolves *after* the resync: that id was never in the map to be "dropped", so it isn't fenced, and `upsert()` accepted and persisted it. The row then lingered until a full reload since no new-scope delta ever emits it.

Client-cache-consistency only — the server still enforces visibility (403) on any real read; this is a local UI artifact.

## Fix — request-generation epoch threading

- `localIndex.upsert(ws, row, sinceEpoch?)` gains an optional `sinceEpoch`. Callers capture `scopeEpochFor(ws)` **before** issuing a create/update; if a resync bumped `scopeEpoch` in flight (`resyncProjectionScope` bumps it before its network await), the stale-scope response is refused.
- Threaded through the optimistic post-response call sites: quick-create, column-create, status change (+ force-retry), reorder settle, restore, and the editor bubble-menu create (via a new `onItemCreated(item, ws, sinceEpoch?)` callback arg).
- Each request captures its **own** epoch immediately before issue — the force-retry and the reorder loop recapture per-attempt so a mid-handler resync only rejects the requests that predate it.
- SSE / authoritative paths omit the param and are unaffected.

## Tests & gates

- New unit test mirrors the fence test for a brand-new create id + stale epoch — the case the fence alone can't catch.
- `npm run check` (svelte-check) 0 errors · full web suite 196/196 · production build compiles.
- Two Codex review rounds: round 1 flagged epoch-reuse across later requests (fixed); round 2 **CLEAN**.

https://claude.ai/code/session_01EZ6yr6pAUFb1uffan912ra