### PR TITLE
feat(web): unparented filtering UI and persistence (TASK-2099)

### DIFF
--- a/web/src/lib/collections/unparentedFilter.test.ts
+++ b/web/src/lib/collections/unparentedFilter.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest';
+import {
+	UNPARENTED_FILTER_FIELD,
+	buildUnparentedViewFilter,
+	clearParentFilter,
+	filtersSetParent,
+	readUnparentedParam,
+	unparentedEffective,
+	viewHasUnparentedFilter,
+	writeUnparentedParam,
+} from './unparentedFilter';
+
+describe('filtersSetParent', () => {
+	it('is true when the patch carries a non-empty parent value', () => {
+		expect(filtersSetParent({ parent: 'plan-1' })).toBe(true);
+	});
+
+	it('is false when parent is absent or empty', () => {
+		expect(filtersSetParent({})).toBe(false);
+		expect(filtersSetParent({ parent: '' })).toBe(false);
+		expect(filtersSetParent({ status: 'open' })).toBe(false);
+	});
+});
+
+describe('clearParentFilter', () => {
+	it('drops the parent key, preserving other filters', () => {
+		const result = clearParentFilter({ parent: 'plan-1', status: 'open' });
+		expect(result).toEqual({ status: 'open' });
+	});
+
+	it('returns the same reference when there is nothing to clear (no-op)', () => {
+		const filters = { status: 'open' };
+		expect(clearParentFilter(filters)).toBe(filters);
+	});
+});
+
+describe('unparentedEffective', () => {
+	it('applies only when both intent and metadata availability are true', () => {
+		expect(unparentedEffective(true, true)).toBe(true);
+		expect(unparentedEffective(true, false)).toBe(false);
+		expect(unparentedEffective(false, true)).toBe(false);
+		expect(unparentedEffective(false, false)).toBe(false);
+	});
+});
+
+describe('buildUnparentedViewFilter', () => {
+	it('emits the reserved $unparented condition when active and available', () => {
+		expect(buildUnparentedViewFilter(true, true)).toEqual({
+			field: UNPARENTED_FILTER_FIELD,
+			op: 'eq',
+			value: true,
+		});
+	});
+
+	it('is null when inactive', () => {
+		expect(buildUnparentedViewFilter(false, true)).toBeNull();
+	});
+
+	// DR-2: a restricted caller can't legitimately have flipped the chip, but
+	// a stale intent carried over from a URL/prior session must never be
+	// persisted into a saved view.
+	it('is null when metadata is unavailable, even if the intent flag is stuck true', () => {
+		expect(buildUnparentedViewFilter(true, false)).toBeNull();
+	});
+});
+
+describe('viewHasUnparentedFilter', () => {
+	it('detects the reserved condition among other filters', () => {
+		expect(
+			viewHasUnparentedFilter([
+				{ field: 'status', op: 'eq', value: 'open' },
+				{ field: UNPARENTED_FILTER_FIELD, op: 'eq', value: true },
+			]),
+		).toBe(true);
+	});
+
+	it('is false when absent, undefined, or malformed (wrong op/value)', () => {
+		expect(viewHasUnparentedFilter(undefined)).toBe(false);
+		expect(viewHasUnparentedFilter([])).toBe(false);
+		expect(viewHasUnparentedFilter([{ field: UNPARENTED_FILTER_FIELD, op: 'in', value: true }])).toBe(
+			false,
+		);
+		expect(
+			viewHasUnparentedFilter([{ field: UNPARENTED_FILTER_FIELD, op: 'eq', value: 'true' }]),
+		).toBe(false);
+	});
+
+	// Grandfathered-schema guard: a REAL field literally named `unparented`
+	// (no `$`) must never be mistaken for the reserved discriminator.
+	it('does not match a grandfathered field literally named "unparented" (no $)', () => {
+		expect(viewHasUnparentedFilter([{ field: 'unparented', op: 'eq', value: true }])).toBe(false);
+	});
+});
+
+describe('URL round-trip', () => {
+	it('reads unparented=true from search params', () => {
+		expect(readUnparentedParam(new URLSearchParams('unparented=true'))).toBe(true);
+	});
+
+	it('treats any other value (or absence) as false', () => {
+		expect(readUnparentedParam(new URLSearchParams(''))).toBe(false);
+		expect(readUnparentedParam(new URLSearchParams('unparented=false'))).toBe(false);
+		expect(readUnparentedParam(new URLSearchParams('unparented=1'))).toBe(false);
+	});
+
+	it('writes the param when active and removes it when not', () => {
+		const params = new URLSearchParams();
+		writeUnparentedParam(params, true);
+		expect(params.get('unparented')).toBe('true');
+
+		writeUnparentedParam(params, false);
+		expect(params.has('unparented')).toBe(false);
+	});
+});

--- a/web/src/lib/collections/unparentedFilter.test.ts
+++ b/web/src/lib/collections/unparentedFilter.test.ts
@@ -5,6 +5,7 @@ import {
 	clearParentFilter,
 	filtersSetParent,
 	readUnparentedParam,
+	resolveParentUnparentedMutex,
 	unparentedEffective,
 	viewHasUnparentedFilter,
 	writeUnparentedParam,
@@ -15,9 +16,16 @@ describe('filtersSetParent', () => {
 		expect(filtersSetParent({ parent: 'plan-1' })).toBe(true);
 	});
 
-	it('is false when parent is absent or empty', () => {
+	// The legacy `phase` key is a backward-compat alias for `parent` that
+	// `filteredItems` resolves identically (both hit `parent_link_id`).
+	it('is true for the legacy phase alias too', () => {
+		expect(filtersSetParent({ phase: 'plan-1' })).toBe(true);
+	});
+
+	it('is false when parent/phase are absent or empty', () => {
 		expect(filtersSetParent({})).toBe(false);
 		expect(filtersSetParent({ parent: '' })).toBe(false);
+		expect(filtersSetParent({ phase: '' })).toBe(false);
 		expect(filtersSetParent({ status: 'open' })).toBe(false);
 	});
 });
@@ -28,9 +36,37 @@ describe('clearParentFilter', () => {
 		expect(result).toEqual({ status: 'open' });
 	});
 
+	it('drops the legacy phase alias too', () => {
+		const result = clearParentFilter({ phase: 'plan-1', status: 'open' });
+		expect(result).toEqual({ status: 'open' });
+	});
+
+	it('drops both when a filter set somehow carries both aliases', () => {
+		const result = clearParentFilter({ parent: 'a', phase: 'b', status: 'open' });
+		expect(result).toEqual({ status: 'open' });
+	});
+
 	it('returns the same reference when there is nothing to clear (no-op)', () => {
 		const filters = { status: 'open' };
 		expect(clearParentFilter(filters)).toBe(filters);
+	});
+});
+
+describe('resolveParentUnparentedMutex', () => {
+	it('is a no-op when unparented is false', () => {
+		const filters = { parent: 'plan-1' };
+		expect(resolveParentUnparentedMutex(filters, false)).toEqual({ filters, unparented: false });
+	});
+
+	it('drops parent/phase when unparented is true (unparented wins)', () => {
+		expect(resolveParentUnparentedMutex({ parent: 'plan-1', status: 'open' }, true)).toEqual({
+			filters: { status: 'open' },
+			unparented: true,
+		});
+		expect(resolveParentUnparentedMutex({ phase: 'plan-1' }, true)).toEqual({
+			filters: {},
+			unparented: true,
+		});
 	});
 });
 
@@ -93,22 +129,38 @@ describe('viewHasUnparentedFilter', () => {
 });
 
 describe('URL round-trip', () => {
-	it('reads unparented=true from search params', () => {
-		expect(readUnparentedParam(new URLSearchParams('unparented=true'))).toBe(true);
+	it('reads $unparented=true from search params', () => {
+		const params = new URLSearchParams();
+		params.set(UNPARENTED_FILTER_FIELD, 'true');
+		expect(readUnparentedParam(params)).toBe(true);
 	});
 
 	it('treats any other value (or absence) as false', () => {
 		expect(readUnparentedParam(new URLSearchParams(''))).toBe(false);
-		expect(readUnparentedParam(new URLSearchParams('unparented=false'))).toBe(false);
-		expect(readUnparentedParam(new URLSearchParams('unparented=1'))).toBe(false);
+		const falseParams = new URLSearchParams();
+		falseParams.set(UNPARENTED_FILTER_FIELD, 'false');
+		expect(readUnparentedParam(falseParams)).toBe(false);
 	});
 
-	it('writes the param when active and removes it when not', () => {
+	it('writes the reserved param when active and removes it when not', () => {
 		const params = new URLSearchParams();
 		writeUnparentedParam(params, true);
-		expect(params.get('unparented')).toBe('true');
+		expect(params.get(UNPARENTED_FILTER_FIELD)).toBe('true');
 
 		writeUnparentedParam(params, false);
-		expect(params.has('unparented')).toBe(false);
+		expect(params.has(UNPARENTED_FILTER_FIELD)).toBe(false);
+	});
+
+	// Collision guard (Codex review round 1): a real field literally named
+	// `unparented` (no `$`) round-trips through the plain `unparented`
+	// query param independently — untouched by the reserved-param helpers.
+	it('does not read/write the plain "unparented" param (real-field collision guard)', () => {
+		const params = new URLSearchParams('unparented=some-real-field-value');
+		expect(readUnparentedParam(params)).toBe(false);
+		writeUnparentedParam(params, true);
+		// The reserved param is added under its own (distinct) key; the
+		// pre-existing plain `unparented` param is untouched.
+		expect(params.get('unparented')).toBe('some-real-field-value');
+		expect(params.get(UNPARENTED_FILTER_FIELD)).toBe('true');
 	});
 });

--- a/web/src/lib/collections/unparentedFilter.test.ts
+++ b/web/src/lib/collections/unparentedFilter.test.ts
@@ -6,6 +6,7 @@ import {
 	filtersSetParent,
 	readUnparentedParam,
 	resolveParentUnparentedMutex,
+	unparentedConfirmedRestricted,
 	unparentedEffective,
 	viewHasUnparentedFilter,
 	writeUnparentedParam,
@@ -67,6 +68,25 @@ describe('resolveParentUnparentedMutex', () => {
 			filters: {},
 			unparented: true,
 		});
+	});
+});
+
+describe('unparentedConfirmedRestricted', () => {
+	it('is true only when metadata is confirmed false AND no resync is in flight', () => {
+		expect(unparentedConfirmedRestricted(true, false)).toBe(true);
+	});
+
+	// Codex review round 3, P1: mere "unavailable" (metadata unknown/pending)
+	// must NOT be treated as confirmed restriction — that would destroy a
+	// legitimate intent that loaded mid-resync, moments before the resync
+	// confirms the caller unrestricted.
+	it('is false while a resync is in flight, even if metadata currently reads false', () => {
+		expect(unparentedConfirmedRestricted(true, true)).toBe(false);
+	});
+
+	it('is false when metadata is not confirmed false (unknown/true)', () => {
+		expect(unparentedConfirmedRestricted(false, false)).toBe(false);
+		expect(unparentedConfirmedRestricted(false, true)).toBe(false);
 	});
 });
 

--- a/web/src/lib/collections/unparentedFilter.ts
+++ b/web/src/lib/collections/unparentedFilter.ts
@@ -21,27 +21,55 @@
  */
 export const UNPARENTED_FILTER_FIELD = '$unparented';
 
+// The collection page's `filteredItems` treats `parent` and the legacy
+// `phase` key identically — both resolve against `item.parent_link_id`
+// (`phase` is kept for backward compat with pre-rename saved views). The
+// mutex helpers below must recognize both aliases, or a legacy view/URL
+// carrying `phase` would survive "Unparented only" turning on and produce a
+// contradictory (always-empty) filter combination (Codex review round 1).
+const PARENT_FILTER_KEYS = ['parent', 'phase'] as const;
+
 /**
  * True when an incoming `activeFilters` patch (as FilterBar's
- * `onFilterChange` hands it to the page) sets a specific-parent filter.
- * The unparented chip is mutually exclusive with the parent filter
- * (PLAN-2095 DR-3) — the page clears `unparentedFilter` when this is true.
+ * `onFilterChange` hands it to the page) sets a specific-parent filter
+ * (`parent` or its legacy `phase` alias). The unparented chip is mutually
+ * exclusive with the parent filter (PLAN-2095 DR-3) — the page clears
+ * `unparentedFilter` when this is true.
  */
 export function filtersSetParent(filters: Record<string, string>): boolean {
-	return typeof filters.parent === 'string' && filters.parent !== '';
+	return PARENT_FILTER_KEYS.some((key) => typeof filters[key] === 'string' && filters[key] !== '');
 }
 
 /**
- * Drop the specific-parent filter from an `activeFilters` map. Used when
- * the unparented chip is switched on — mutual exclusivity in the other
- * direction (PLAN-2095 DR-3). Returns the same reference when there was
- * nothing to clear, so callers can skip a state write on a no-op.
+ * Drop the specific-parent filter (`parent` and/or the legacy `phase`
+ * alias) from an `activeFilters` map. Used when the unparented chip is
+ * switched on — mutual exclusivity in the other direction (PLAN-2095 DR-3).
+ * Returns the same reference when there was nothing to clear, so callers
+ * can skip a state write on a no-op.
  */
 export function clearParentFilter(filters: Record<string, string>): Record<string, string> {
-	if (!('parent' in filters)) return filters;
+	if (!PARENT_FILTER_KEYS.some((key) => key in filters)) return filters;
 	const next = { ...filters };
-	delete next.parent;
+	for (const key of PARENT_FILTER_KEYS) delete next[key];
 	return next;
+}
+
+/**
+ * Resolve the parent/unparented mutex over a full filter state at once —
+ * used when a URL or saved view is applied wholesale (as opposed to the
+ * incremental FilterBar handlers, which enforce the mutex interactively).
+ * A hand-crafted URL or a legacy saved view could carry both a
+ * specific-parent filter AND the unparented pseudo-filter simultaneously;
+ * unparented wins (same precedence as `handleUnparentedChange`), dropping
+ * `parent`/`phase` rather than leaving a contradictory, always-empty
+ * combination in place (PLAN-2095 DR-3, Codex review round 1).
+ */
+export function resolveParentUnparentedMutex(
+	filters: Record<string, string>,
+	unparented: boolean
+): { filters: Record<string, string>; unparented: boolean } {
+	if (!unparented) return { filters, unparented };
+	return { filters: clearParentFilter(filters), unparented };
 }
 
 /**
@@ -94,20 +122,32 @@ export function viewHasUnparentedFilter(filters: ViewFilterCondition[] | undefin
 	);
 }
 
-/** Read the `unparented` URL search param as a boolean intent. */
+// The URL round-trip reuses the reserved `$unparented` name (not a plain
+// `unparented` param) for the SAME reason the saved-view discriminator does
+// (PLAN-2095 DR-5): a grandfathered collection can legally have a real
+// schema field literally keyed `unparented` (no `$`) that the collection
+// page's generic field-filter loop reads/writes through `activeFilters`
+// via the SAME URL searchParams object. A plain `unparented` param name
+// would collide with that field's filter value and either clobber it or
+// swallow it into the "known params" skip-set on read (Codex review round
+// 1). `$` is not a legal field-key character server-side (see
+// `internal/store/store.go::isValidFieldKey`), so this name is collision-free.
+
+/** Read the reserved `$unparented` URL search param as a boolean intent. */
 export function readUnparentedParam(searchParams: URLSearchParams): boolean {
-	return searchParams.get('unparented') === 'true';
+	return searchParams.get(UNPARENTED_FILTER_FIELD) === 'true';
 }
 
 /**
- * Write (or remove) the `unparented` URL search param. Callers should pass
- * the EFFECTIVE state (`unparentedEffective(...)`), not raw intent, so a
- * restricted caller's URL never even transiently carries the param.
+ * Write (or remove) the reserved `$unparented` URL search param. Callers
+ * should pass the EFFECTIVE state (`unparentedEffective(...)`), not raw
+ * intent, so a restricted caller's URL never even transiently carries the
+ * param.
  */
 export function writeUnparentedParam(params: URLSearchParams, active: boolean): void {
 	if (active) {
-		params.set('unparented', 'true');
+		params.set(UNPARENTED_FILTER_FIELD, 'true');
 	} else {
-		params.delete('unparented');
+		params.delete(UNPARENTED_FILTER_FIELD);
 	}
 }

--- a/web/src/lib/collections/unparentedFilter.ts
+++ b/web/src/lib/collections/unparentedFilter.ts
@@ -1,0 +1,113 @@
+// The "Unparented only" collection-page filter (TASK-2099 / PLAN-2095
+// Phase 2). Phase 1 (TASK-2096) delivered the backend/CLI/MCP contract —
+// index/delta rows carry an optional `is_unparented` bit, gated to
+// unrestricted callers via `includes_unparented_metadata` (see
+// `localIndex.svelte.ts::includesUnparentedMetadataFor`). This module holds
+// the PURE decision logic the collection page (+page.svelte) and the public
+// share route (`/s/[token]`) wire up around that bit, so the filter/mutex/
+// round-trip/skip rules are unit-testable without mounting the full page.
+//
+// Kept deliberately framework-agnostic (no `$state`/`$derived`) — every
+// export here is a plain function over plain data.
+
+/**
+ * Reserved saved-view filter field for the "unparented only" pseudo-filter
+ * (PLAN-2095 DR-5). Never a real schema field key — server-reserved (schema
+ * validation rejects new fields keyed `$unparented`) so a grandfathered
+ * schema that happens to carry a literal `unparented` field (no `$`) can
+ * never collide with it. Public-share evaluation must always skip
+ * conditions on this exact field — see `filterEvaluable` /
+ * `matchesFilter` in `$lib/components/share/shareView`.
+ */
+export const UNPARENTED_FILTER_FIELD = '$unparented';
+
+/**
+ * True when an incoming `activeFilters` patch (as FilterBar's
+ * `onFilterChange` hands it to the page) sets a specific-parent filter.
+ * The unparented chip is mutually exclusive with the parent filter
+ * (PLAN-2095 DR-3) — the page clears `unparentedFilter` when this is true.
+ */
+export function filtersSetParent(filters: Record<string, string>): boolean {
+	return typeof filters.parent === 'string' && filters.parent !== '';
+}
+
+/**
+ * Drop the specific-parent filter from an `activeFilters` map. Used when
+ * the unparented chip is switched on — mutual exclusivity in the other
+ * direction (PLAN-2095 DR-3). Returns the same reference when there was
+ * nothing to clear, so callers can skip a state write on a no-op.
+ */
+export function clearParentFilter(filters: Record<string, string>): Record<string, string> {
+	if (!('parent' in filters)) return filters;
+	const next = { ...filters };
+	delete next.parent;
+	return next;
+}
+
+/**
+ * Whether the unparented chip's filter should actually apply to the item
+ * list. Requires BOTH the user's toggle intent AND confirmed unrestricted
+ * metadata availability (PLAN-2095 DR-2) — a restricted caller's intent
+ * (carried over from a URL or saved view) never takes effect, closing the
+ * side channel DR-2 calls out. `metadataAvailable` should come from
+ * `localIndex.includesUnparentedMetadataFor(ws) === true` (strict `true`,
+ * not just truthy — `null`/`false` both mean "don't apply").
+ */
+export function unparentedEffective(intent: boolean, metadataAvailable: boolean): boolean {
+	return intent && metadataAvailable;
+}
+
+/** One saved-view filter condition, matching `ViewConfig['filters'][number]`. */
+export interface ViewFilterCondition {
+	field: string;
+	op: string;
+	value: unknown;
+}
+
+/**
+ * Build the `$unparented` saved-view condition for `buildViewConfig`, or
+ * `null` when it shouldn't be persisted — the chip isn't active, or
+ * metadata isn't available to this caller (a restricted caller can't have
+ * toggled it, but this guards a stale `true` from ever round-tripping into
+ * a saved view). PLAN-2095 DR-5.
+ */
+export function buildUnparentedViewFilter(
+	active: boolean,
+	metadataAvailable: boolean
+): ViewFilterCondition | null {
+	if (!unparentedEffective(active, metadataAvailable)) return null;
+	return { field: UNPARENTED_FILTER_FIELD, op: 'eq', value: true };
+}
+
+/**
+ * True when a saved view's parsed `filters` array carries the reserved
+ * `$unparented` discriminator (PLAN-2095 DR-5). Used by `applyViewConfig`
+ * to recover the chip's intent when a saved view is selected — the actual
+ * on-screen effect still runs through `unparentedEffective`, so a
+ * restricted caller applying a view that carries this never filters
+ * anything (DR-2).
+ */
+export function viewHasUnparentedFilter(filters: ViewFilterCondition[] | undefined): boolean {
+	if (!filters) return false;
+	return filters.some(
+		(f) => f.field === UNPARENTED_FILTER_FIELD && f.op === 'eq' && f.value === true
+	);
+}
+
+/** Read the `unparented` URL search param as a boolean intent. */
+export function readUnparentedParam(searchParams: URLSearchParams): boolean {
+	return searchParams.get('unparented') === 'true';
+}
+
+/**
+ * Write (or remove) the `unparented` URL search param. Callers should pass
+ * the EFFECTIVE state (`unparentedEffective(...)`), not raw intent, so a
+ * restricted caller's URL never even transiently carries the param.
+ */
+export function writeUnparentedParam(params: URLSearchParams, active: boolean): void {
+	if (active) {
+		params.set('unparented', 'true');
+	} else {
+		params.delete('unparented');
+	}
+}

--- a/web/src/lib/collections/unparentedFilter.ts
+++ b/web/src/lib/collections/unparentedFilter.ts
@@ -73,6 +73,25 @@ export function resolveParentUnparentedMutex(
 }
 
 /**
+ * Whether a workspace's projection scope is CONFIRMED restricted — used
+ * ONLY to gate destructively clearing a stuck unparented-filter intent
+ * (from a URL/saved view). Deliberately narrower than
+ * `!unparentedEffective(...)`: that also covers "unknown" (pre-bootstrap)
+ * and "a resync is currently deciding", and destructively clearing intent
+ * on mere unavailability would permanently discard a legitimate caller's
+ * intent the instant it loaded mid-resync — even one about to resolve
+ * unrestricted a moment later (PLAN-2095 DR-2, Codex review round 3, P1).
+ *
+ * `metadataKnownFalse` should be `localIndex.includesUnparentedMetadataFor(ws)
+ * === false` (a CONFIRMED negative, not just "not true") and `pendingResync`
+ * should be `localIndex.pendingResyncFor(ws)` (no resync in flight that
+ * could still flip the answer).
+ */
+export function unparentedConfirmedRestricted(metadataKnownFalse: boolean, pendingResync: boolean): boolean {
+	return metadataKnownFalse && !pendingResync;
+}
+
+/**
  * Whether the unparented chip's filter should actually apply to the item
  * list. Requires BOTH the user's toggle intent AND confirmed unrestricted
  * metadata availability (PLAN-2095 DR-2) — a restricted caller's intent

--- a/web/src/lib/components/collections/FilterBar.svelte
+++ b/web/src/lib/components/collections/FilterBar.svelte
@@ -18,6 +18,16 @@
 		selectedTags?: string[];
 		onTagFilterChange?: (tags: string[]) => void;
 		searchInputEl?: HTMLInputElement | undefined;
+		/**
+		 * Whether the "Unparented only" chip should render at all (TASK-2099 /
+		 * PLAN-2095 DR-2). Driven by the caller's projection-scope state
+		 * (`localIndex.includesUnparentedMetadataFor`) — `false` for
+		 * restricted callers, who must never see this filter exists.
+		 */
+		unparentedAvailable?: boolean;
+		/** Current effective state of the unparented chip. */
+		unparentedActive?: boolean;
+		onUnparentedChange?: (value: boolean) => void;
 	}
 
 	let {
@@ -31,6 +41,9 @@
 		selectedTags = [],
 		onTagFilterChange = () => {},
 		searchInputEl = $bindable(),
+		unparentedAvailable = false,
+		unparentedActive = false,
+		onUnparentedChange = () => {},
 	}: Props = $props();
 
 	let schema = $derived(parseSchema(collection));
@@ -168,6 +181,24 @@
 				{/each}
 			</select>
 		{/if}
+	{/if}
+
+	{#if unparentedAvailable}
+		<!--
+			"Unparented only" chip (TASK-2099 / PLAN-2095). Rendered only when
+			the caller's projection scope confirms `is_unparented` metadata is
+			present — restricted callers never see this exists (DR-2). Mutually
+			exclusive with the parent filter; the page component owns that
+			mutex, not this component (it doesn't know about `unparented` as a
+			field in `activeFilters` — the flag lives outside it).
+		-->
+		<button
+			type="button"
+			class="unparented-chip"
+			class:active={unparentedActive}
+			aria-pressed={unparentedActive}
+			onclick={() => onUnparentedChange(!unparentedActive)}
+		>Unparented only</button>
 	{/if}
 
 	{#if tagCounts.length > 0}
@@ -312,6 +343,27 @@
 
 	.parent-sheet-option.active {
 		background: var(--bg-tertiary);
+		font-weight: 600;
+	}
+
+	.unparented-chip {
+		background: var(--bg-secondary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+		padding: var(--space-1) var(--space-3);
+		font-size: 0.82em;
+		color: var(--text-primary);
+		cursor: pointer;
+		white-space: nowrap;
+	}
+
+	.unparented-chip:hover:not(.active) {
+		border-color: var(--accent-blue);
+	}
+
+	.unparented-chip.active {
+		background: var(--bg-tertiary);
+		border-color: var(--accent-blue);
 		font-weight: 600;
 	}
 

--- a/web/src/lib/components/collections/FilterBar.svelte.test.ts
+++ b/web/src/lib/components/collections/FilterBar.svelte.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { render, cleanup, fireEvent } from '@testing-library/svelte';
+import { tick } from 'svelte';
+import FilterBar from './FilterBar.svelte';
+import type { Collection } from '$lib/types';
+
+function collection(): Collection {
+	return {
+		id: 'c1',
+		workspace_id: 'ws1',
+		name: 'Tasks',
+		slug: 'tasks',
+		icon: '',
+		description: '',
+		schema: JSON.stringify({ fields: [] }),
+		settings: JSON.stringify({}),
+		sort_order: 0,
+		is_default: true,
+		is_system: false,
+		created_at: '2026-01-01T00:00:00Z',
+		updated_at: '2026-01-01T00:00:00Z',
+		prefix: 'TASK',
+	};
+}
+
+function baseProps(overrides: Record<string, unknown> = {}) {
+	return {
+		collection: collection(),
+		activeFilters: {},
+		searchQuery: '',
+		onFilterChange: vi.fn(),
+		onSearchChange: vi.fn(),
+		...overrides,
+	};
+}
+
+afterEach(() => {
+	cleanup();
+});
+
+describe('FilterBar unparented chip (TASK-2099)', () => {
+	it('does not render when unparentedAvailable is false (default / restricted caller)', () => {
+		render(FilterBar, { props: baseProps() });
+		expect(document.querySelector('.unparented-chip')).toBeNull();
+	});
+
+	it('renders when unparentedAvailable is true (unrestricted caller)', () => {
+		render(FilterBar, { props: baseProps({ unparentedAvailable: true }) });
+		const chip = document.querySelector('.unparented-chip');
+		expect(chip).not.toBeNull();
+		expect(chip?.textContent).toContain('Unparented only');
+	});
+
+	it('reflects unparentedActive via the active class + aria-pressed', () => {
+		render(FilterBar, { props: baseProps({ unparentedAvailable: true, unparentedActive: true }) });
+		const chip = document.querySelector('.unparented-chip') as HTMLButtonElement;
+		expect(chip.classList.contains('active')).toBe(true);
+		expect(chip.getAttribute('aria-pressed')).toBe('true');
+	});
+
+	it('fires onUnparentedChange with the toggled value on click', async () => {
+		const onUnparentedChange = vi.fn();
+		render(FilterBar, {
+			props: baseProps({ unparentedAvailable: true, unparentedActive: false, onUnparentedChange }),
+		});
+		const chip = document.querySelector('.unparented-chip') as HTMLButtonElement;
+		await fireEvent.click(chip);
+		await tick();
+		expect(onUnparentedChange).toHaveBeenCalledWith(true);
+	});
+
+	it('a restricted caller (unparentedAvailable=false) never sees the chip, even if active=true is passed', () => {
+		// Defensive case: a stale/incorrect caller still can't render it —
+		// availability is the sole gate (DR-2), not activeness.
+		render(FilterBar, { props: baseProps({ unparentedAvailable: false, unparentedActive: true }) });
+		expect(document.querySelector('.unparented-chip')).toBeNull();
+	});
+});

--- a/web/src/lib/components/share/shareView.test.ts
+++ b/web/src/lib/components/share/shareView.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { UNPARENTED_FILTER_FIELD, filterEvaluable, matchesFilter, parsePublicItem } from './shareView';
+
+function item(fields: Record<string, unknown>) {
+	return parsePublicItem({ title: 'x', ref: 'TASK-1', fields });
+}
+
+describe('filterEvaluable', () => {
+	it('is evaluable when the field is present in the schema', () => {
+		const schemaKeys = new Set(['status', 'priority']);
+		expect(filterEvaluable(schemaKeys, { field: 'status', op: 'eq', value: 'open' })).toBe(true);
+	});
+
+	it('is not evaluable when the field is absent from the schema', () => {
+		const schemaKeys = new Set(['status']);
+		expect(filterEvaluable(schemaKeys, { field: 'nope', op: 'eq', value: 'x' })).toBe(false);
+	});
+
+	// PLAN-2095 DR-5 / TASK-2099: public shares never carry `is_unparented`,
+	// so the reserved pseudo-filter must always be excluded — regardless of
+	// what the schema happens to contain.
+	it('always excludes the reserved $unparented field, even if it were somehow "in" the schema', () => {
+		const schemaKeys = new Set([UNPARENTED_FILTER_FIELD, 'status']);
+		expect(filterEvaluable(schemaKeys, { field: UNPARENTED_FILTER_FIELD, op: 'eq', value: true })).toBe(
+			false,
+		);
+	});
+
+	// Grandfathered-schema guard: a REAL field literally named `unparented`
+	// (no `$`) is a different string and must evaluate normally.
+	it('does not confuse a grandfathered "unparented" (no $) field with the reserved one', () => {
+		const schemaKeys = new Set(['unparented']);
+		expect(filterEvaluable(schemaKeys, { field: 'unparented', op: 'eq', value: 'true' })).toBe(true);
+	});
+
+	it('treats malformed/fieldless filters as evaluable (matchesFilter no-ops them)', () => {
+		const schemaKeys = new Set<string>();
+		expect(filterEvaluable(schemaKeys, null)).toBe(true);
+		expect(filterEvaluable(schemaKeys, {})).toBe(true);
+	});
+});
+
+describe('matchesFilter', () => {
+	it('evaluates eq against the item field', () => {
+		expect(matchesFilter(item({ status: 'open' }), { field: 'status', op: 'eq', value: 'open' })).toBe(
+			true,
+		);
+		expect(matchesFilter(item({ status: 'done' }), { field: 'status', op: 'eq', value: 'open' })).toBe(
+			false,
+		);
+	});
+
+	it('evaluates in against array and scalar item fields', () => {
+		expect(
+			matchesFilter(item({ tags: ['a', 'b'] }), { field: 'tags', op: 'in', value: ['b', 'c'] }),
+		).toBe(true);
+		expect(matchesFilter(item({ status: 'open' }), { field: 'status', op: 'in', value: ['open'] })).toBe(
+			true,
+		);
+	});
+
+	// Defense in depth: even called directly (bypassing filterEvaluable), the
+	// reserved field must never actually filter anything.
+	it('never filters on the reserved $unparented field, even called directly', () => {
+		expect(
+			matchesFilter(item({}), { field: UNPARENTED_FILTER_FIELD, op: 'eq', value: true }),
+		).toBe(true);
+		expect(
+			matchesFilter(item({ [UNPARENTED_FILTER_FIELD]: false }), {
+				field: UNPARENTED_FILTER_FIELD,
+				op: 'eq',
+				value: true,
+			}),
+		).toBe(true);
+	});
+
+	it('does not confuse a grandfathered "unparented" (no $) field with the reserved one', () => {
+		expect(
+			matchesFilter(item({ unparented: 'true' }), { field: 'unparented', op: 'eq', value: 'true' }),
+		).toBe(true);
+		expect(
+			matchesFilter(item({ unparented: 'false' }), { field: 'unparented', op: 'eq', value: 'true' }),
+		).toBe(false);
+	});
+});

--- a/web/src/lib/components/share/shareView.ts
+++ b/web/src/lib/components/share/shareView.ts
@@ -15,6 +15,14 @@
 // mirror the in-app helpers so a shared kanban looks like the owner's kanban.
 
 import type { FieldDef } from '$lib/types';
+import { UNPARENTED_FILTER_FIELD } from '$lib/collections/unparentedFilter';
+
+// Re-exported so existing/future imports of `UNPARENTED_FILTER_FIELD` from
+// this module keep working — the canonical definition lives in
+// `$lib/collections/unparentedFilter` (shared with the interactive
+// collection page) so the reserved field name can't drift between the two
+// evaluation paths.
+export { UNPARENTED_FILTER_FIELD };
 
 /** Collection settings as understood by the public renderers. View-type +
  *  grouping/sort knobs only — interactive-only settings are ignored. */
@@ -185,6 +193,68 @@ export function capItems(items: PublicItem[]): CappedItems {
 		return { items, total: items.length, capped: false };
 	}
 	return { items: items.slice(0, PUBLIC_ITEM_CAP), total: items.length, capped: true };
+}
+
+// ── Saved-view filter evaluation (public shares) ────────────────────────────
+//
+// `/s/[token]/+page.svelte` overlays an active saved view's `config.filters`
+// onto the shared item set (read-only, no server round-trip). These two
+// functions are the single evaluation choke-point for that — pulled out of
+// the route so the `$unparented` skip (PLAN-2095 DR-5 / TASK-2099) is a
+// pure, independently-testable rule rather than logic embedded in a page
+// component.
+
+/**
+ * True when the filter targets a field present in the public collection
+ * schema, so it's meaningful against the shared payload. Malformed/fieldless
+ * filters are treated as evaluable so `matchesFilter` can no-op them.
+ *
+ * The reserved `$unparented` pseudo-filter is ALWAYS excluded here —
+ * explicitly, not incidentally. Public shares never carry the structural
+ * `is_unparented` projection bit (Phase 1 / TASK-2096 gates it to
+ * unrestricted API/local-index callers only, and the share payload doesn't
+ * include it at all), so this condition must never filter a public share —
+ * including on a grandfathered schema that happens to have a REAL field
+ * literally named `unparented` (no `$`), which is a different string and
+ * evaluated normally.
+ */
+export function filterEvaluable(schemaKeys: Set<string>, filter: unknown): boolean {
+	if (!filter || typeof filter !== 'object') return true;
+	const field = (filter as { field?: unknown }).field;
+	if (typeof field !== 'string') return true;
+	if (field === UNPARENTED_FILTER_FIELD) return false;
+	return schemaKeys.has(field);
+}
+
+/**
+ * Read-only filter evaluation mirroring the logged-in collection page's
+ * `eq` / `in` handling (the only ops saved-view configs emit). Unknown ops
+ * pass through (don't hide items we can't reason about).
+ *
+ * Callers should route filters through `filterEvaluable` first — that's
+ * where `$unparented` is actually excluded from the applied set — but this
+ * function also refuses to evaluate it directly, so a caller that skips the
+ * `filterEvaluable` gate can't accidentally apply it either (defense in
+ * depth for DR-5).
+ */
+export function matchesFilter(item: PublicItem, filter: unknown): boolean {
+	if (!filter || typeof filter !== 'object') return true;
+	const f = filter as { field?: unknown; op?: unknown; value?: unknown };
+	if (typeof f.field !== 'string') return true;
+	if (f.field === UNPARENTED_FILTER_FIELD) return true;
+	const fieldVal = item.fields[f.field];
+	if (f.op === 'eq') {
+		return String(fieldVal ?? '') === String(f.value ?? '');
+	}
+	if (f.op === 'in') {
+		const wanted = Array.isArray(f.value) ? f.value.map((v) => String(v)) : [String(f.value)];
+		// Tags-style array fields: match if any item value is wanted.
+		if (Array.isArray(fieldVal)) {
+			return fieldVal.some((v) => wanted.includes(String(v)));
+		}
+		return wanted.includes(String(fieldVal ?? ''));
+	}
+	return true;
 }
 
 // ── Field lookup ──────────────────────────────────────────────────────────

--- a/web/src/lib/stores/localIndex.svelte.ts
+++ b/web/src/lib/stores/localIndex.svelte.ts
@@ -1099,6 +1099,20 @@ export const localIndex = {
 	},
 
 	/**
+	 * Whether the workspace's current projection includes the `is_unparented`
+	 * bit — `true` for unrestricted callers, `false` for restricted ones,
+	 * `null` when the workspace hasn't resolved a snapshot/delta yet
+	 * (unknown). Consumers gating unparented-filter UI (TASK-2099 / PLAN-2095
+	 * DR-2) must treat `null` the same as `false` — never show or apply the
+	 * chip until this is confirmed `true`, so a restricted caller (or one
+	 * whose scope hasn't resolved) never sees a side channel into structural
+	 * parent state.
+	 */
+	includesUnparentedMetadataFor(ws: string): boolean | null {
+		return workspaces.get(ws)?.includesUnparentedMetadata ?? null;
+	},
+
+	/**
 	 * Current projection-scope epoch — bumped each time a resync installs a
 	 * new authoritative snapshot. A reconcile loop captures it before an
 	 * `/items-changes` request and, if it differs when the request returns, a

--- a/web/src/lib/stores/localIndex.svelte.ts
+++ b/web/src/lib/stores/localIndex.svelte.ts
@@ -1164,11 +1164,29 @@ export const localIndex = {
 	 * confirms it has caught up (the same predicate `bootstrap()` uses:
 	 * an empty delta batch, or the response cursor not advancing past
 	 * `since`) — mirroring exactly what `bootstrap()`'s loop already does
-	 * for the path it owns. No-op for an unhydrated workspace.
+	 * for the path it owns.
+	 *
+	 * `epoch` MUST be the `scopeEpochFor(ws)` the caller captured at (or
+	 * reconfirmed immediately before) the point it decided "caught up" —
+	 * the same value already threaded through these reconcile loops as
+	 * `epochBefore`. SSE, periodic sync, and `bootstrap()` can all trigger
+	 * reconciliations concurrently; without this check, one caller's stale
+	 * catch-up confirmation could unconditionally clear `pendingResync`
+	 * out from under a DIFFERENT, still-in-progress (or just-restarted)
+	 * resync that landed after this caller's own epoch check — silencing
+	 * `bootstrap()`'s retry of a resync/replay that hasn't actually
+	 * finished (Codex review round 5). A mismatched epoch means a resync
+	 * has landed since this caller confirmed catch-up, so the clear is
+	 * skipped — whichever loop eventually catches up under the NEW epoch
+	 * will clear it.
+	 *
+	 * No-op for an unhydrated workspace.
 	 */
-	markCaughtUp(ws: string): void {
+	markCaughtUp(ws: string, epoch: number): void {
 		const state = workspaces.get(ws);
-		if (state) state.pendingResync = false;
+		if (!state) return;
+		if (state.scopeEpoch !== epoch) return;
+		state.pendingResync = false;
 	},
 
 	/**

--- a/web/src/lib/stores/localIndex.svelte.ts
+++ b/web/src/lib/stores/localIndex.svelte.ts
@@ -1113,6 +1113,23 @@ export const localIndex = {
 	},
 
 	/**
+	 * Whether a workspace's warm-cache snapshot has landed but the
+	 * follow-up `/items-changes` reconcile hasn't confirmed it yet (see
+	 * `bootstrap`'s warm-path doc comment). `includesUnparentedMetadataFor`
+	 * can reflect a STALE cached capability bit during this window — e.g. a
+	 * permission downgrade that happened while offline hasn't been detected
+	 * yet, so the persisted `true` from before the downgrade is still what
+	 * warm-boot serves. Consumers gating unparented-filter UI/filtering
+	 * (TASK-2099 / PLAN-2095 DR-2, Codex review round 2) must treat
+	 * capability as unknown while this is `true`, not act on the
+	 * possibly-stale cached value. Returns `false` for an unhydrated
+	 * workspace (nothing pending because nothing has started).
+	 */
+	pendingResyncFor(ws: string): boolean {
+		return workspaces.get(ws)?.pendingResync ?? false;
+	},
+
+	/**
 	 * Current projection-scope epoch — bumped each time a resync installs a
 	 * new authoritative snapshot. A reconcile loop captures it before an
 	 * `/items-changes` request and, if it differs when the request returns, a

--- a/web/src/lib/stores/localIndex.svelte.ts
+++ b/web/src/lib/stores/localIndex.svelte.ts
@@ -1127,16 +1127,48 @@ export const localIndex = {
 	 * resolving" direction (e.g. permanently discarding a URL/saved-view
 	 * intent) — combine it with a CONFIRMED `includesUnparentedMetadataFor`
 	 * value (`=== true` or `=== false`, not just "unavailable"), not used
-	 * as a blanket gate on ordinary rendering/filtering. `pendingResync` is
-	 * cleared only by `bootstrap()`'s own reconcile loop, never by a
-	 * standalone `deltaSync`-triggered resync, so gating routine
-	 * availability on this being `false` can wedge a UI element hidden
-	 * indefinitely after a live permission upgrade (Codex review round 3,
-	 * P1/P2 — TASK-2099 / PLAN-2095 DR-2). Returns `false` for an
-	 * unhydrated workspace (nothing pending because nothing has started).
+	 * as a blanket gate on ordinary rendering/filtering. `bootstrap()`'s
+	 * own reconcile loop clears this on catch-up for the cold/warm-boot
+	 * path; a caller with an independent reconcile loop (e.g. the
+	 * collection page's SSE/periodic-sync-driven `deltaSync`) MUST call
+	 * `markCaughtUp` itself on ITS catch-up, or gating routine availability
+	 * on this being `false` can wedge a UI element hidden indefinitely
+	 * after a live permission upgrade (Codex review round 3 P1/P2, round 4
+	 * — TASK-2099 / PLAN-2095 DR-2). Returns `false` for an unhydrated
+	 * workspace (nothing pending because nothing has started).
 	 */
 	pendingResyncFor(ws: string): boolean {
 		return workspaces.get(ws)?.pendingResync ?? false;
+	},
+
+	/**
+	 * Mark a workspace's resync as caught up — clears `pendingResync`.
+	 *
+	 * `bootstrap()`'s own internal reconcile loop already does this
+	 * (`if (caughtUp) state.pendingResync = false`), but that loop only
+	 * runs for the initial cold/warm-boot path. A resync triggered mid-
+	 * session (`resyncProjectionScope`, e.g. because the collection page's
+	 * OWN `deltaSync` loop — driven by SSE events / periodic sync, not
+	 * `bootstrap()` — detected a projection-scope change) has no such
+	 * owner: nothing else ever flips `pendingResync` back to `false` for
+	 * it, so it would stay stuck `true` for the rest of the session. That
+	 * wedges any consumer gating a destructive decision on
+	 * `pendingResyncFor` (TASK-2099 / PLAN-2095 DR-2's
+	 * `unparentedConfirmedRestricted`, Codex review round 4) — a caller
+	 * downgraded and later re-upgraded within the same session would never
+	 * see the "confirmed restricted" transition fire, so a stuck
+	 * unparented-filter intent from before the downgrade would silently
+	 * reactivate on the upgrade instead of staying cleared.
+	 *
+	 * Callers should invoke this once THEIR OWN independent reconcile loop
+	 * confirms it has caught up (the same predicate `bootstrap()` uses:
+	 * an empty delta batch, or the response cursor not advancing past
+	 * `since`) — mirroring exactly what `bootstrap()`'s loop already does
+	 * for the path it owns. No-op for an unhydrated workspace.
+	 */
+	markCaughtUp(ws: string): void {
+		const state = workspaces.get(ws);
+		if (state) state.pendingResync = false;
 	},
 
 	/**

--- a/web/src/lib/stores/localIndex.svelte.ts
+++ b/web/src/lib/stores/localIndex.svelte.ts
@@ -1115,15 +1115,25 @@ export const localIndex = {
 	/**
 	 * Whether a workspace's warm-cache snapshot has landed but the
 	 * follow-up `/items-changes` reconcile hasn't confirmed it yet (see
-	 * `bootstrap`'s warm-path doc comment). `includesUnparentedMetadataFor`
-	 * can reflect a STALE cached capability bit during this window — e.g. a
-	 * permission downgrade that happened while offline hasn't been detected
-	 * yet, so the persisted `true` from before the downgrade is still what
-	 * warm-boot serves. Consumers gating unparented-filter UI/filtering
-	 * (TASK-2099 / PLAN-2095 DR-2, Codex review round 2) must treat
-	 * capability as unknown while this is `true`, not act on the
-	 * possibly-stale cached value. Returns `false` for an unhydrated
-	 * workspace (nothing pending because nothing has started).
+	 * `bootstrap`'s warm-path doc comment) — OR a live-session resync
+	 * (`resyncProjectionScope`, e.g. triggered mid-session by a permission
+	 * change `deltaSync` detects) is still replaying post-snapshot
+	 * mutations under the new scope. `includesUnparentedMetadataFor` can
+	 * reflect a value that hasn't survived a full reconcile pass yet during
+	 * either window.
+	 *
+	 * Consumers should use this ONLY to gate a DESTRUCTIVE decision that
+	 * would be expensive/user-visible to get wrong in the "unknown, still
+	 * resolving" direction (e.g. permanently discarding a URL/saved-view
+	 * intent) — combine it with a CONFIRMED `includesUnparentedMetadataFor`
+	 * value (`=== true` or `=== false`, not just "unavailable"), not used
+	 * as a blanket gate on ordinary rendering/filtering. `pendingResync` is
+	 * cleared only by `bootstrap()`'s own reconcile loop, never by a
+	 * standalone `deltaSync`-triggered resync, so gating routine
+	 * availability on this being `false` can wedge a UI element hidden
+	 * indefinitely after a live permission upgrade (Codex review round 3,
+	 * P1/P2 — TASK-2099 / PLAN-2095 DR-2). Returns `false` for an
+	 * unhydrated workspace (nothing pending because nothing has started).
 	 */
 	pendingResyncFor(ws: string): boolean {
 		return workspaces.get(ws)?.pendingResync ?? false;

--- a/web/src/lib/stores/localIndexUnparented.svelte.test.ts
+++ b/web/src/lib/stores/localIndexUnparented.svelte.test.ts
@@ -185,7 +185,7 @@ describe('localIndex.pendingResyncFor', () => {
 		expect(localIndex.pendingResyncFor(ws)).toBe(false);
 	});
 
-	it('stays true after a projection resync — only a caught-up bootstrap reconcile loop clears it', async () => {
+	it('stays true after a projection resync until an owning reconcile loop clears it', async () => {
 		localIndex.upsert(ws, row('scoped', 1, true));
 		localIndex.applyDelta(ws, [], '1', true);
 		expect(localIndex.pendingResyncFor(ws)).toBe(false);
@@ -198,9 +198,41 @@ describe('localIndex.pendingResyncFor', () => {
 		});
 		await localIndex.ensureProjectionScope(ws, false);
 		// resyncProjectionScope intentionally leaves pendingResync=true —
-		// it only installs the authoritative snapshot; the bootstrap
-		// reconcile loop (not exercised by ensureProjectionScope alone) is
-		// what clears it once post-snapshot mutations are caught up.
+		// it only installs the authoritative snapshot; catch-up is the
+		// reconcile loop's job (bootstrap()'s own loop for the cold/warm
+		// boot path, or a caller's independent loop via `markCaughtUp` —
+		// neither is exercised by `ensureProjectionScope` alone).
 		expect(localIndex.pendingResyncFor(ws)).toBe(true);
+	});
+});
+
+// TASK-2099 Codex review round 4: a resync triggered mid-session (e.g. the
+// collection page's SSE/periodic-sync-driven `deltaSync`, not
+// `bootstrap()`) has no owner for clearing `pendingResync` unless the
+// caller explicitly marks its own catch-up. Without `markCaughtUp`, a
+// caller downgraded and later re-upgraded within the same session would
+// never see the "confirmed restricted" transition — DR-2's clearing
+// wouldn't fire, and a stuck pre-downgrade intent could silently
+// reactivate on the upgrade instead of staying cleared.
+describe('localIndex.markCaughtUp', () => {
+	it('clears a pending resync', async () => {
+		localIndex.upsert(ws, row('scoped', 1, true));
+		localIndex.applyDelta(ws, [], '1', true);
+		vi.spyOn(api.items, 'listIndex').mockResolvedValueOnce({
+			items: [row('scoped', 1)],
+			total: 1,
+			cursor: '1',
+			includes_unparented_metadata: false,
+		});
+		await localIndex.ensureProjectionScope(ws, false);
+		expect(localIndex.pendingResyncFor(ws)).toBe(true);
+
+		localIndex.markCaughtUp(ws);
+		expect(localIndex.pendingResyncFor(ws)).toBe(false);
+	});
+
+	it('is a no-op for an unhydrated workspace', () => {
+		expect(() => localIndex.markCaughtUp('never-bootstrapped-ws-3')).not.toThrow();
+		expect(localIndex.pendingResyncFor('never-bootstrapped-ws-3')).toBe(false);
 	});
 });

--- a/web/src/lib/stores/localIndexUnparented.svelte.test.ts
+++ b/web/src/lib/stores/localIndexUnparented.svelte.test.ts
@@ -215,7 +215,7 @@ describe('localIndex.pendingResyncFor', () => {
 // wouldn't fire, and a stuck pre-downgrade intent could silently
 // reactivate on the upgrade instead of staying cleared.
 describe('localIndex.markCaughtUp', () => {
-	it('clears a pending resync', async () => {
+	it('clears a pending resync when the epoch still matches', async () => {
 		localIndex.upsert(ws, row('scoped', 1, true));
 		localIndex.applyDelta(ws, [], '1', true);
 		vi.spyOn(api.items, 'listIndex').mockResolvedValueOnce({
@@ -227,12 +227,39 @@ describe('localIndex.markCaughtUp', () => {
 		await localIndex.ensureProjectionScope(ws, false);
 		expect(localIndex.pendingResyncFor(ws)).toBe(true);
 
-		localIndex.markCaughtUp(ws);
+		localIndex.markCaughtUp(ws, localIndex.scopeEpochFor(ws));
 		expect(localIndex.pendingResyncFor(ws)).toBe(false);
 	});
 
+	// Codex review round 5: a caller's catch-up confirmation must not clear
+	// `pendingResync` out from under a DIFFERENT, concurrently-landed resync
+	// (SSE/periodic-sync/bootstrap can all trigger one). A stale epoch means
+	// exactly that raced — skip the clear so the newer resync's own
+	// catch-up (under its own epoch) is what eventually clears the flag.
+	it('does NOT clear a pending resync when a newer resync has landed under a different epoch', async () => {
+		localIndex.upsert(ws, row('scoped', 1, true));
+		localIndex.applyDelta(ws, [], '1', true);
+		const staleEpoch = localIndex.scopeEpochFor(ws);
+
+		vi.spyOn(api.items, 'listIndex').mockResolvedValueOnce({
+			items: [row('scoped', 1)],
+			total: 1,
+			cursor: '1',
+			includes_unparented_metadata: false,
+		});
+		await localIndex.ensureProjectionScope(ws, false);
+		expect(localIndex.pendingResyncFor(ws)).toBe(true);
+		expect(localIndex.scopeEpochFor(ws)).toBeGreaterThan(staleEpoch);
+
+		// A caller that captured the epoch BEFORE this resync landed tries
+		// to confirm catch-up — its confirmation predates the newer resync
+		// and must not silence it.
+		localIndex.markCaughtUp(ws, staleEpoch);
+		expect(localIndex.pendingResyncFor(ws)).toBe(true);
+	});
+
 	it('is a no-op for an unhydrated workspace', () => {
-		expect(() => localIndex.markCaughtUp('never-bootstrapped-ws-3')).not.toThrow();
+		expect(() => localIndex.markCaughtUp('never-bootstrapped-ws-3', 0)).not.toThrow();
 		expect(localIndex.pendingResyncFor('never-bootstrapped-ws-3')).toBe(false);
 	});
 });

--- a/web/src/lib/stores/localIndexUnparented.svelte.test.ts
+++ b/web/src/lib/stores/localIndexUnparented.svelte.test.ts
@@ -153,3 +153,21 @@ describe('localIndex unparented projection compatibility', () => {
 		expect(localIndex.findByIdOrSlug(ws, 'created')?.seq).toBe(6);
 	});
 });
+
+// TASK-2099 / PLAN-2095 Phase 2: the collection page's "Unparented only"
+// chip gates its visibility off this accessor (not the internal `$state`
+// field directly, which isn't exported). Covers the three states a
+// consumer must be able to distinguish: unknown, restricted, unrestricted.
+describe('localIndex.includesUnparentedMetadataFor', () => {
+	it('is null for a workspace that has never resolved a snapshot/delta', () => {
+		expect(localIndex.includesUnparentedMetadataFor('never-bootstrapped-ws')).toBeNull();
+	});
+
+	it('reflects true after an unrestricted delta and false after a restricted one', () => {
+		localIndex.applyDelta(ws, [], '1', true);
+		expect(localIndex.includesUnparentedMetadataFor(ws)).toBe(true);
+
+		localIndex.applyDelta(ws, [], '2', false);
+		expect(localIndex.includesUnparentedMetadataFor(ws)).toBe(false);
+	});
+});

--- a/web/src/lib/stores/localIndexUnparented.svelte.test.ts
+++ b/web/src/lib/stores/localIndexUnparented.svelte.test.ts
@@ -171,3 +171,36 @@ describe('localIndex.includesUnparentedMetadataFor', () => {
 		expect(localIndex.includesUnparentedMetadataFor(ws)).toBe(false);
 	});
 });
+
+// TASK-2099 Codex review round 2 (P1): the collection page must not trust
+// `includesUnparentedMetadataFor` while a resync is still in flight — the
+// warm-cache boot path can serve a persisted (possibly stale) capability
+// bit before its follow-up reconcile confirms it. `pendingResyncFor` is the
+// signal the page gates on to treat capability as unknown during that
+// window.
+describe('localIndex.pendingResyncFor', () => {
+	it('is false for an unhydrated workspace and after ordinary delta application', () => {
+		expect(localIndex.pendingResyncFor('never-bootstrapped-ws-2')).toBe(false);
+		localIndex.applyDelta(ws, [], '1', true);
+		expect(localIndex.pendingResyncFor(ws)).toBe(false);
+	});
+
+	it('stays true after a projection resync — only a caught-up bootstrap reconcile loop clears it', async () => {
+		localIndex.upsert(ws, row('scoped', 1, true));
+		localIndex.applyDelta(ws, [], '1', true);
+		expect(localIndex.pendingResyncFor(ws)).toBe(false);
+
+		vi.spyOn(api.items, 'listIndex').mockResolvedValueOnce({
+			items: [row('scoped', 1)],
+			total: 1,
+			cursor: '1',
+			includes_unparented_metadata: false,
+		});
+		await localIndex.ensureProjectionScope(ws, false);
+		// resyncProjectionScope intentionally leaves pendingResync=true —
+		// it only installs the authoritative snapshot; the bootstrap
+		// reconcile loop (not exercised by ensureProjectionScope alone) is
+		// what clears it once post-snapshot mutations are caught up.
+		expect(localIndex.pendingResyncFor(ws)).toBe(true);
+	});
+});

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -265,7 +265,17 @@
 	// is only ever set after mount, via URL/view load or user interaction).
 	let lastSyncedUnparented = false;
 	$effect(() => {
-		if (!wsSlug || !indexReady) return;
+		// Gate on `!metaLoading`, not just `indexReady` (Codex review round
+		// 5, P2): `metaLoading` only flips false once `loadCollection` has
+		// fully settled for the CURRENT `collSlug` — including its trailing
+		// `loadUrlFilters()` call — mirroring exactly the guard
+		// `defaultViewApplied` already uses for the identical race. Without
+		// it, navigating collection A → B (same still-`indexReady`
+		// workspace) could fire this effect using A's stale
+		// `unparentedFilter`/`activeFilters` before B's `loadUrlFilters()`
+		// has run, rebuilding B's URL with A's filter state and dropping
+		// whatever B's URL actually asked for.
+		if (!wsSlug || !indexReady || metaLoading) return;
 		let needsUrlSync = false;
 		if (unparentedFilter && isUnparentedConfirmedRestricted) {
 			unparentedFilter = false;
@@ -276,6 +286,22 @@
 		}
 		lastSyncedUnparented = unparentedApplied;
 		if (needsUrlSync) updateUrlFilters();
+	});
+
+	// Reset the transition-detection memo whenever the route changes so a
+	// value carried over from a PREVIOUS collection can't mask a genuine
+	// transition in the new one (Codex review round 5, P2): e.g. route A
+	// last synced `true`; a cold route B applies a default view carrying
+	// the pseudo-filter before metadata resolves (so its own URL write
+	// correctly omits the param); once metadata resolves `true` for route
+	// B, `unparentedApplied` transitions `false → true` — but if the memo
+	// still held route A's stale `true`, the diff check above would see
+	// `true !== true` as no change and skip the corrective URL write.
+	// Mirrors the existing `defaultViewApplied` reset effect below.
+	$effect(() => {
+		void wsSlug;
+		void collSlug;
+		lastSyncedUnparented = false;
 	});
 
 	// Bootstrap the workspace on entry. Idempotent: if already 'ready'
@@ -604,8 +630,12 @@
 					// Mark caught up so a mid-session projection-scope
 					// change doesn't leave `pendingResyncFor` stuck `true`
 					// for the rest of the session (TASK-2099 / PLAN-2095
-					// DR-2, Codex review round 4).
-					localIndex.markCaughtUp(ws);
+					// DR-2, Codex review round 4). Pass `epochBefore` — this
+					// iteration already confirmed it still matches the live
+					// epoch above — so a differently-scoped resync that
+					// lands concurrently after this point isn't silently
+					// stomped (Codex review round 5).
+					localIndex.markCaughtUp(ws, epochBefore);
 					return true;
 				}
 				localIndex.applyDelta(
@@ -616,7 +646,7 @@
 				);
 				if (delta.cursor === since) {
 					deltaSyncFailed = false;
-					localIndex.markCaughtUp(ws);
+					localIndex.markCaughtUp(ws, epochBefore);
 					return true;
 				}
 			}

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -597,6 +597,15 @@
 				}
 				if (delta.changes.length === 0 || delta.cursor === since) {
 					deltaSyncFailed = false;
+					// This loop is an independent reconcile path from
+					// `bootstrap()`'s internal one (driven by SSE/periodic
+					// sync, not the initial cold/warm boot) — it's the only
+					// owner of `pendingResync` for a resync IT triggered.
+					// Mark caught up so a mid-session projection-scope
+					// change doesn't leave `pendingResyncFor` stuck `true`
+					// for the rest of the session (TASK-2099 / PLAN-2095
+					// DR-2, Codex review round 4).
+					localIndex.markCaughtUp(ws);
 					return true;
 				}
 				localIndex.applyDelta(
@@ -607,6 +616,7 @@
 				);
 				if (delta.cursor === since) {
 					deltaSyncFailed = false;
+					localIndex.markCaughtUp(ws);
 					return true;
 				}
 			}

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -30,6 +30,15 @@
 	import { createScrollRestoration } from '$lib/scroll/restore.svelte';
 	import { confirmOpenChildrenOrThrow, isOpenChildrenError } from '$lib/items/openChildrenError';
 	import { SORT_OPTIONS, priorityField, type SortMode } from '$lib/collections/itemSort';
+	import {
+		buildUnparentedViewFilter,
+		clearParentFilter,
+		filtersSetParent,
+		readUnparentedParam,
+		unparentedEffective,
+		viewHasUnparentedFilter,
+		writeUnparentedParam,
+	} from '$lib/collections/unparentedFilter';
 
 	type ViewMode = 'list' | 'board' | 'table';
 
@@ -61,6 +70,15 @@
 	// `tags` column, not in `fields` JSON, so they're tracked separately
 	// from `activeFilters` and applied in their own `filteredItems` branch.
 	let selectedTags = $state<string[]>([]);
+	// "Unparented only" chip state (TASK-2099 / PLAN-2095). Tracked separately
+	// from `activeFilters` — it isn't a schema field filter, it's a structural
+	// predicate over the local-first projection's `is_unparented` bit, and it
+	// requires the caller to be unrestricted (DR-2). This is raw user/URL/
+	// saved-view INTENT; whether it actually takes effect always routes
+	// through `unparentedEffective` against `unparentedMetadataAvailable`
+	// below, so a restricted caller's carried-over intent never filters
+	// anything or renders the chip.
+	let unparentedFilter = $state(false);
 	let searchQuery = $state('');
 	let showArchived = $state(false);
 	let itemProgress = $state<Record<string, { total: number; done: number; label?: string }>>({});
@@ -155,6 +173,37 @@
 	let loading = $derived(
 		!metaError && (metaLoading || (!indexReady && !indexError && !deltaSyncFailed)),
 	);
+
+	// Unparented-filter projection scope (TASK-2099 / PLAN-2095 DR-2). `true`
+	// only once the local index has confirmed (via `includes_unparented_
+	// metadata` on an index/delta response) that THIS caller is unrestricted.
+	// `null` (unknown, pre-bootstrap) and `false` (restricted) both read as
+	// unavailable — the chip stays hidden and the filter never applies until
+	// this is a confirmed `true`.
+	let unparentedMetadataAvailable = $derived(
+		wsSlug ? localIndex.includesUnparentedMetadataFor(wsSlug) === true : false,
+	);
+	// The chip's EFFECTIVE state — intent AND availability. Everything that
+	// actually filters/badges/persists reads this, not the raw intent flag,
+	// so a restricted caller's carried-over `unparentedFilter=true` (from a
+	// URL or saved view) never filters anything or counts as an active
+	// filter (DR-2).
+	let unparentedApplied = $derived(unparentedEffective(unparentedFilter, unparentedMetadataAvailable));
+
+	// Restricted clearing (DR-2): once the workspace's projection scope is
+	// confirmed and it does NOT include unparented metadata, physically
+	// clear a stuck intent flag (from a URL or saved view carrying the
+	// pseudo-filter) instead of leaving it dangling. Without this, the flag
+	// would silently no-op (via `unparentedApplied`) but could still get
+	// re-persisted into the URL/a new saved view the moment the user
+	// interacts with something else that calls `updateUrlFilters()`.
+	$effect(() => {
+		if (!wsSlug || !indexReady) return;
+		if (unparentedFilter && !unparentedMetadataAvailable) {
+			unparentedFilter = false;
+			updateUrlFilters();
+		}
+	});
 
 	// Bootstrap the workspace on entry. Idempotent: if already 'ready'
 	// (and no pendingResync), this is a no-op; if 'cold', it kicks off
@@ -267,6 +316,9 @@
 		// uses comma as its add-delimiter, so tag values never contain
 		// commas — round-tripping through a comma-joined string is safe.
 		if (selectedTags.length > 0) params.set('tags', selectedTags.join(','));
+		// Write the EFFECTIVE state, not raw intent — a restricted caller's
+		// URL never even transiently carries `unparented=true` (DR-2).
+		writeUnparentedParam(params, unparentedApplied);
 		if (searchQuery) params.set('q', searchQuery);
 		const qs = params.toString();
 		const newUrl = `/${username}/${wsSlug}/${collSlug}${qs ? '?' + qs : ''}`;
@@ -277,11 +329,17 @@
 	function loadUrlFilters() {
 		const url = new URL(page.url);
 		const filters: Record<string, string> = {};
-		// Reset tags up-front so navigating to a collection whose URL has no
-		// `tags` param clears any selection carried over from the previous
-		// collection (absent = cleared).
+		// Reset tags (and the unparented intent) up-front so navigating to a
+		// collection whose URL has no `tags`/`unparented` param clears any
+		// selection carried over from the previous collection (absent =
+		// cleared). The unparented intent is read here optimistically — a
+		// restricted caller's URL carrying it gets corrected by the
+		// restricted-clearing effect once `unparentedMetadataAvailable`
+		// resolves (DR-2); nothing in this function's synchronous read can
+		// know that yet.
 		selectedTags = [];
-		const knownParams = new Set(['view', 'q', 'tags']);
+		unparentedFilter = readUnparentedParam(url.searchParams);
+		const knownParams = new Set(['view', 'q', 'tags', 'unparented']);
 		for (const [k, v] of url.searchParams.entries()) {
 			if (k === 'view' && (v === 'list' || v === 'board')) {
 				viewMode = v;
@@ -648,6 +706,15 @@
 			);
 		}
 
+		// Apply the "Unparented only" chip (TASK-2099 / PLAN-2095): keep
+		// items the local-first projection marked structurally loose. Gated
+		// on `unparentedApplied` (intent AND confirmed unrestricted scope —
+		// DR-2), not raw `unparentedFilter`, so a restricted caller's
+		// carried-over intent never filters anything.
+		if (unparentedApplied) {
+			result = result.filter((item) => item.is_unparented === true);
+		}
+
 		// Apply search query. PLAN-1343 Phase 3b: the local path
 		// populates `searchResultRank` synchronously (sub-ms) so the
 		// filter just intersects. The substring fallback below covers
@@ -734,7 +801,7 @@
 	let emptyHint = $derived(emptyHintMap[collSlug] ?? null);
 
 	let filtersOpen = $state(false);
-	let hasActiveFilters = $derived(searchQuery.trim() !== '' || Object.keys(activeFilters).length > 0 || selectedTags.length > 0);
+	let hasActiveFilters = $derived(searchQuery.trim() !== '' || Object.keys(activeFilters).length > 0 || selectedTags.length > 0 || unparentedApplied);
 
 	// ── Viewport detection ───────────────────────────────────────────────
 	// On mobile the 3-icon view toggle (list/board/table) is swapped for a
@@ -773,6 +840,21 @@
 
 	function handleFilterChange(filters: Record<string, string>) {
 		activeFilters = filters;
+		// Mutual exclusivity with the unparented chip (PLAN-2095 DR-3):
+		// setting a specific-parent filter clears "Unparented only".
+		if (filtersSetParent(filters) && unparentedFilter) {
+			unparentedFilter = false;
+		}
+		updateUrlFilters();
+	}
+
+	// Mutual exclusivity in the other direction: switching the "Unparented
+	// only" chip on clears any specific-parent filter (PLAN-2095 DR-3).
+	function handleUnparentedChange(value: boolean) {
+		unparentedFilter = value;
+		if (value) {
+			activeFilters = clearParentFilter(activeFilters);
+		}
 		updateUrlFilters();
 	}
 
@@ -1637,6 +1719,13 @@
 		if (selectedTags.length > 0) {
 			filters.push({ field: 'tags', op: 'in', value: [...selectedTags] });
 		}
+		// "Unparented only" persists as the reserved `$unparented` condition
+		// (PLAN-2095 DR-5). Gated on `unparentedMetadataAvailable` (not just
+		// intent) so a restricted caller can never save it into a view.
+		const unparentedEntry = buildUnparentedViewFilter(unparentedFilter, unparentedMetadataAvailable);
+		if (unparentedEntry) {
+			filters.push(unparentedEntry);
+		}
 		if (filters.length > 0) {
 			config.filters = filters;
 		}
@@ -1665,15 +1754,30 @@
 				} else if (f.op === 'eq' && typeof f.value === 'string') {
 					newFilters[f.field] = f.value;
 				}
+				// The reserved `$unparented` condition (`value: true`, a
+				// boolean) never matches the `typeof f.value === 'string'`
+				// branch above, so it's naturally skipped here — recovered
+				// separately below via `viewHasUnparentedFilter`.
 			}
 		}
+		// Recover "Unparented only" intent from the saved view (PLAN-2095
+		// DR-5). Applied as raw intent — same as the URL path — and left to
+		// `unparentedApplied` / the restricted-clearing effect to enforce
+		// DR-2 once the projection scope is known. This does NOT check
+		// `unparentedMetadataAvailable` here because `applyViewConfig` can
+		// run before the local index has hydrated (the default-view-on-
+		// mount effect gates only on `!metaLoading`); gating here would
+		// incorrectly drop the filter for a legitimate unrestricted caller
+		// on a cold load.
+		const newUnparented = viewHasUnparentedFilter(config.filters);
 		activeFilters = newFilters;
 		selectedTags = newTags;
+		unparentedFilter = newUnparented;
 		searchQuery = '';
 		searchResultRank = null;
 
 		// Open filters panel if the view has filters
-		if (Object.keys(newFilters).length > 0 || newTags.length > 0) {
+		if (Object.keys(newFilters).length > 0 || newTags.length > 0 || newUnparented) {
 			filtersOpen = true;
 		}
 
@@ -1685,6 +1789,7 @@
 		activeViewId = null;
 		activeFilters = {};
 		selectedTags = [];
+		unparentedFilter = false;
 		searchQuery = '';
 		searchResultRank = null;
 		filtersOpen = false;
@@ -1993,6 +2098,9 @@
 						{selectedTags}
 						onTagFilterChange={handleTagFilterChange}
 						bind:searchInputEl
+						unparentedAvailable={unparentedMetadataAvailable}
+						unparentedActive={unparentedApplied}
+						onUnparentedChange={handleUnparentedChange}
 					/>
 				</div>
 			{/if}
@@ -2122,12 +2230,12 @@
 					<p>This collection is empty.</p>
 				{/if}
 			</div>
-		{:else if filteredItems.length === 0 && (searchQuery || Object.keys(activeFilters).length > 0)}
+		{:else if filteredItems.length === 0 && (searchQuery || Object.keys(activeFilters).length > 0 || unparentedApplied)}
 			<div class="empty-state-box">
 				<div class="empty-icon">🔍</div>
 				<h2>No matches</h2>
 				<p>No items match your current filters.
-					<button class="clear-link" onclick={() => { activeFilters = {}; searchQuery = ''; searchResultRank = null; }}>Clear filters</button>
+					<button class="clear-link" onclick={() => { activeFilters = {}; searchQuery = ''; searchResultRank = null; unparentedFilter = false; updateUrlFilters(); }}>Clear filters</button>
 				</p>
 			</div>
 		{:else if viewMode === 'board'}

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -182,8 +182,21 @@
 	// `null` (unknown, pre-bootstrap) and `false` (restricted) both read as
 	// unavailable — the chip stays hidden and the filter never applies until
 	// this is a confirmed `true`.
+	//
+	// ALSO gated on `!pendingResyncFor` (Codex review round 2, P1): the
+	// warm-cache boot path serves a PERSISTED capability bit before its
+	// follow-up `/items-changes` reconcile confirms it's still current. A
+	// permission change that happened while this client was offline (either
+	// direction) is invisible until that reconcile completes — trusting the
+	// cached bit during that window could expose the chip / apply
+	// client-side structural filtering to a now-restricted caller, or
+	// silently drop a now-legitimate caller's intent. Treat capability as
+	// unknown (unavailable) for the whole pending-resync window rather than
+	// act on a possibly-stale value either way.
 	let unparentedMetadataAvailable = $derived(
-		wsSlug ? localIndex.includesUnparentedMetadataFor(wsSlug) === true : false,
+		wsSlug
+			? !localIndex.pendingResyncFor(wsSlug) && localIndex.includesUnparentedMetadataFor(wsSlug) === true
+			: false,
 	);
 	// The chip's EFFECTIVE state — intent AND availability. Everything that
 	// actually filters/badges/persists reads this, not the raw intent flag,
@@ -212,6 +225,21 @@
 	//      the on-screen list becomes correctly filtered but nothing had
 	//      re-written the address bar to match — a copied/reloaded URL
 	//      would silently drop the filter (Codex review round 1).
+	//
+	//   Note the two conditions are independent, NOT merged into one
+	//   `unparentedApplied !== lastSyncedUnparented` check (Codex review
+	//   round 2, P2): a restricted caller loading a URL that carries the
+	//   pseudo-filter has `unparentedApplied === false` BOTH before and
+	//   after clearing the stuck raw intent (it was never effective to
+	//   begin with), so that diff alone would never fire — leaving the
+	//   literal `$unparented=true` sitting in the address bar even though
+	//   internal state is correctly clean. That stale param is not just
+	//   cosmetic: `defaultViewApplied`'s "don't override URL-driven state"
+	//   check treats ANY search param as explicit user intent and skips
+	//   applying the user's stored default view — a restricted caller
+	//   opening a shared unparented-filter link would silently lose their
+	//   default view too. So: sync whenever we just cleared a stuck intent,
+	//   in addition to syncing on an effective-value transition.
 	// Plain (non-reactive) memo, not `$derived` — we only need last-observed
 	// bookkeeping inside the effect below, not a tracked value. `false`
 	// matches `unparentedApplied`'s guaranteed value at this point (intent
@@ -219,13 +247,16 @@
 	let lastSyncedUnparented = false;
 	$effect(() => {
 		if (!wsSlug || !indexReady) return;
+		let needsUrlSync = false;
 		if (unparentedFilter && !unparentedMetadataAvailable) {
 			unparentedFilter = false;
+			needsUrlSync = true;
 		}
 		if (unparentedApplied !== lastSyncedUnparented) {
-			lastSyncedUnparented = unparentedApplied;
-			updateUrlFilters();
+			needsUrlSync = true;
 		}
+		lastSyncedUnparented = unparentedApplied;
+		if (needsUrlSync) updateUrlFilters();
 	});
 
 	// Bootstrap the workspace on entry. Idempotent: if already 'ready'
@@ -381,7 +412,18 @@
 		// round 1).
 		const resolved = resolveParentUnparentedMutex(filters, unparentedIntent);
 		unparentedFilter = resolved.unparented;
-		if (Object.keys(filters).length > 0) activeFilters = resolved.filters;
+		// Assign `activeFilters` whenever the URL expressed EITHER kind of
+		// filter intent — plain field params OR the unparented pseudo-param
+		// on its own. Gating on `filters` alone (Codex review round 2, P2)
+		// missed the "URL carries only `$unparented=true`, no field params"
+		// case: `filters` is empty there, so the old guard left a STALE
+		// `activeFilters.parent` from a previous navigation in place
+		// alongside the freshly-applied unparented intent — breaking the
+		// mutex and producing a silently-empty result instead of the
+		// mutex-resolved `{}` this URL actually describes.
+		if (Object.keys(filters).length > 0 || unparentedIntent) {
+			activeFilters = resolved.filters;
+		}
 	}
 
 	$effect(() => {
@@ -741,8 +783,22 @@
 		// on `unparentedApplied` (intent AND confirmed unrestricted scope —
 		// DR-2), not raw `unparentedFilter`, so a restricted caller's
 		// carried-over intent never filters anything.
+		//
+		// `!== false` (optimistic-inclusive), not `=== true`: a full
+		// mutation response (create/update) intentionally omits local-
+		// first-only projections (see `localIndex.svelte.ts::toSkinny` /
+		// `preserveProjectionMetadata`), so a just-created item's optimistic
+		// row carries `is_unparented: undefined` until the authoritative
+		// index/delta row lands and merges it in. Requiring strict `true`
+		// made a brand-new loose item — the exact case a user creating
+		// while this filter is active most wants to see — flash out of the
+		// list immediately after creation (Codex review round 2). Every
+		// AUTHORITATIVE row for an unrestricted caller always carries the
+		// bit (Phase 1 / TASK-2096), so `undefined` here is bounded to that
+		// narrow optimistic window, not a permanent unknown; an item that
+		// turns out to be parented is corrected out on the next delta.
 		if (unparentedApplied) {
-			result = result.filter((item) => item.is_unparented === true);
+			result = result.filter((item) => item.is_unparented !== false);
 		}
 
 		// Apply search query. PLAN-1343 Phase 3b: the local path

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -31,10 +31,12 @@
 	import { confirmOpenChildrenOrThrow, isOpenChildrenError } from '$lib/items/openChildrenError';
 	import { SORT_OPTIONS, priorityField, type SortMode } from '$lib/collections/itemSort';
 	import {
+		UNPARENTED_FILTER_FIELD,
 		buildUnparentedViewFilter,
 		clearParentFilter,
 		filtersSetParent,
 		readUnparentedParam,
+		resolveParentUnparentedMutex,
 		unparentedEffective,
 		viewHasUnparentedFilter,
 		writeUnparentedParam,
@@ -190,17 +192,38 @@
 	// filter (DR-2).
 	let unparentedApplied = $derived(unparentedEffective(unparentedFilter, unparentedMetadataAvailable));
 
-	// Restricted clearing (DR-2): once the workspace's projection scope is
-	// confirmed and it does NOT include unparented metadata, physically
-	// clear a stuck intent flag (from a URL or saved view carrying the
-	// pseudo-filter) instead of leaving it dangling. Without this, the flag
-	// would silently no-op (via `unparentedApplied`) but could still get
-	// re-persisted into the URL/a new saved view the moment the user
-	// interacts with something else that calls `updateUrlFilters()`.
+	// Restricted clearing (DR-2) AND URL honesty as the projection scope
+	// resolves. Two things this effect keeps correct once `indexReady`:
+	//
+	//   1. Once the scope is confirmed and does NOT include unparented
+	//      metadata, physically clear a stuck intent flag (from a URL or
+	//      saved view carrying the pseudo-filter) instead of leaving it
+	//      dangling — otherwise it would silently no-op (via
+	//      `unparentedApplied`) but could still get re-persisted into the
+	//      URL/a new saved view the moment something else calls
+	//      `updateUrlFilters()`.
+	//   2. Re-sync the URL whenever `unparentedApplied` (the EFFECTIVE
+	//      state) actually changes value, in EITHER direction. This covers
+	//      not just the clear-on-downgrade case above but also: a default
+	//      saved view applied before local-index hydration (gated only on
+	//      `!metaLoading`, not `indexReady` — see `applyViewConfig`'s
+	//      caller) writes the URL with `unparentedApplied` still false
+	//      (metadata unknown); once metadata resolves `true` afterward,
+	//      the on-screen list becomes correctly filtered but nothing had
+	//      re-written the address bar to match — a copied/reloaded URL
+	//      would silently drop the filter (Codex review round 1).
+	// Plain (non-reactive) memo, not `$derived` — we only need last-observed
+	// bookkeeping inside the effect below, not a tracked value. `false`
+	// matches `unparentedApplied`'s guaranteed value at this point (intent
+	// is only ever set after mount, via URL/view load or user interaction).
+	let lastSyncedUnparented = false;
 	$effect(() => {
 		if (!wsSlug || !indexReady) return;
 		if (unparentedFilter && !unparentedMetadataAvailable) {
 			unparentedFilter = false;
+		}
+		if (unparentedApplied !== lastSyncedUnparented) {
+			lastSyncedUnparented = unparentedApplied;
 			updateUrlFilters();
 		}
 	});
@@ -330,7 +353,7 @@
 		const url = new URL(page.url);
 		const filters: Record<string, string> = {};
 		// Reset tags (and the unparented intent) up-front so navigating to a
-		// collection whose URL has no `tags`/`unparented` param clears any
+		// collection whose URL has no `tags`/`$unparented` param clears any
 		// selection carried over from the previous collection (absent =
 		// cleared). The unparented intent is read here optimistically — a
 		// restricted caller's URL carrying it gets corrected by the
@@ -338,8 +361,8 @@
 		// resolves (DR-2); nothing in this function's synchronous read can
 		// know that yet.
 		selectedTags = [];
-		unparentedFilter = readUnparentedParam(url.searchParams);
-		const knownParams = new Set(['view', 'q', 'tags', 'unparented']);
+		const unparentedIntent = readUnparentedParam(url.searchParams);
+		const knownParams = new Set(['view', 'q', 'tags', UNPARENTED_FILTER_FIELD]);
 		for (const [k, v] of url.searchParams.entries()) {
 			if (k === 'view' && (v === 'list' || v === 'board')) {
 				viewMode = v;
@@ -351,7 +374,14 @@
 				filters[k] = v;
 			}
 		}
-		if (Object.keys(filters).length > 0) activeFilters = filters;
+		// Mutual exclusivity (PLAN-2095 DR-3): a hand-crafted or legacy URL
+		// could carry both a specific-parent filter (`parent`/`phase`) AND
+		// the unparented pseudo-param at once. Resolve it the same way the
+		// interactive chip toggle does — unparented wins (Codex review
+		// round 1).
+		const resolved = resolveParentUnparentedMutex(filters, unparentedIntent);
+		unparentedFilter = resolved.unparented;
+		if (Object.keys(filters).length > 0) activeFilters = resolved.filters;
 	}
 
 	$effect(() => {
@@ -1709,7 +1739,15 @@
 
 	function buildViewConfig(): ViewConfig {
 		const config: ViewConfig = {};
-		const filterEntries = Object.entries(activeFilters);
+		// Defensive mutex enforcement (PLAN-2095 DR-3): the interactive
+		// handlers already keep `activeFilters.parent`/`phase` and
+		// `unparentedFilter` mutually exclusive, but a saved view should
+		// never persist a contradictory combination even if some other
+		// path (a stale prop, a future call site) let both linger.
+		const effectiveFilters = unparentedEffective(unparentedFilter, unparentedMetadataAvailable)
+			? clearParentFilter(activeFilters)
+			: activeFilters;
+		const filterEntries = Object.entries(effectiveFilters);
 		const filters: NonNullable<ViewConfig['filters']> = filterEntries.map(
 			([field, value]) => ({ field, op: 'eq', value }),
 		);
@@ -1770,14 +1808,19 @@
 		// incorrectly drop the filter for a legitimate unrestricted caller
 		// on a cold load.
 		const newUnparented = viewHasUnparentedFilter(config.filters);
-		activeFilters = newFilters;
+		// Mutual exclusivity (PLAN-2095 DR-3): a legacy/hand-authored saved
+		// view could carry both a specific-parent filter and the
+		// unparented pseudo-filter at once — resolve it the same way the
+		// interactive chip toggle does (Codex review round 1).
+		const resolved = resolveParentUnparentedMutex(newFilters, newUnparented);
+		activeFilters = resolved.filters;
 		selectedTags = newTags;
-		unparentedFilter = newUnparented;
+		unparentedFilter = resolved.unparented;
 		searchQuery = '';
 		searchResultRank = null;
 
 		// Open filters panel if the view has filters
-		if (Object.keys(newFilters).length > 0 || newTags.length > 0 || newUnparented) {
+		if (Object.keys(resolved.filters).length > 0 || newTags.length > 0 || resolved.unparented) {
 			filtersOpen = true;
 		}
 

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -229,6 +229,41 @@
 			: false,
 	);
 
+	// True once `loadUrlFilters()` has actually run for the CURRENT route
+	// (`loadCollection` flips it `true` right after that call, on the
+	// success path only; see `loadCollection`). Reset by the route-change
+	// effect immediately below. `$state`, not plain — the URL-sync effect
+	// below must reactively re-run once this flips, since the load itself
+	// is asynchronous and happens well after the route-change flush that
+	// resets it.
+	let urlFiltersLoaded = $state(false);
+
+	// Reset per-route bookkeeping whenever wsSlug/collSlug change. This
+	// effect is declared BEFORE the URL-sync effect below on purpose:
+	// Svelte runs effects with no parent/child relationship in declaration
+	// order when a shared dependency invalidates them in the same flush, so
+	// placing the reset first guarantees it always lands before the sync
+	// effect could read a stale value in that same tick (Codex review round
+	// 6 — relying on `metaLoading` transitioning was an ordering-fragile
+	// proxy for "this is a new route" and also missed the case where a
+	// route's `loadCollection` call fails, so `loadUrlFilters()` never ran
+	// but `metaLoading` still flips back to `false` in the `finally`).
+	//
+	//   - `lastSyncedUnparented`: a value carried over from a PREVIOUS
+	//     collection could otherwise mask a genuine transition in the new
+	//     one (Codex review round 5, P2) — see the sync effect's comment.
+	//   - `urlFiltersLoaded`: starts `false` for every new route; only
+	//     `loadCollection`'s own `loadUrlFilters()` call (async, run later)
+	//     flips it back, which is what actually gates the sync effect below
+	//     — not `metaLoading`.
+	// Mirrors the existing `defaultViewApplied` reset effect further down.
+	$effect(() => {
+		void wsSlug;
+		void collSlug;
+		lastSyncedUnparented = false;
+		urlFiltersLoaded = false;
+	});
+
 	// Restricted clearing (DR-2) AND URL honesty as the projection scope
 	// resolves. Two things this effect keeps correct once `indexReady`:
 	//
@@ -265,17 +300,18 @@
 	// is only ever set after mount, via URL/view load or user interaction).
 	let lastSyncedUnparented = false;
 	$effect(() => {
-		// Gate on `!metaLoading`, not just `indexReady` (Codex review round
-		// 5, P2): `metaLoading` only flips false once `loadCollection` has
-		// fully settled for the CURRENT `collSlug` — including its trailing
-		// `loadUrlFilters()` call — mirroring exactly the guard
-		// `defaultViewApplied` already uses for the identical race. Without
-		// it, navigating collection A → B (same still-`indexReady`
-		// workspace) could fire this effect using A's stale
-		// `unparentedFilter`/`activeFilters` before B's `loadUrlFilters()`
-		// has run, rebuilding B's URL with A's filter state and dropping
-		// whatever B's URL actually asked for.
-		if (!wsSlug || !indexReady || metaLoading) return;
+		// Gate on `urlFiltersLoaded`, not `metaLoading` (Codex review round
+		// 6): `metaLoading` flips back to `false` on BOTH a successful load
+		// (after `loadUrlFilters()` ran) AND a failed one (where it never
+		// ran) — and relying on it also implicitly assumed this effect
+		// re-runs strictly after the load-triggering effect's synchronous
+		// reset, which isn't a documented guarantee across effects declared
+		// with a dependency this indirect. `urlFiltersLoaded` is the
+		// precise, explicit signal for "this route's URL-derived filter
+		// state is real," reset synchronously by the effect declared right
+		// above (guaranteed to run first) and only set `true` by
+		// `loadCollection` itself once `loadUrlFilters()` has genuinely run.
+		if (!wsSlug || !indexReady || !urlFiltersLoaded) return;
 		let needsUrlSync = false;
 		if (unparentedFilter && isUnparentedConfirmedRestricted) {
 			unparentedFilter = false;
@@ -286,22 +322,6 @@
 		}
 		lastSyncedUnparented = unparentedApplied;
 		if (needsUrlSync) updateUrlFilters();
-	});
-
-	// Reset the transition-detection memo whenever the route changes so a
-	// value carried over from a PREVIOUS collection can't mask a genuine
-	// transition in the new one (Codex review round 5, P2): e.g. route A
-	// last synced `true`; a cold route B applies a default view carrying
-	// the pseudo-filter before metadata resolves (so its own URL write
-	// correctly omits the param); once metadata resolves `true` for route
-	// B, `unparentedApplied` transitions `false → true` — but if the memo
-	// still held route A's stale `true`, the diff check above would see
-	// `true !== true` as no change and skip the corrective URL write.
-	// Mirrors the existing `defaultViewApplied` reset effect below.
-	$effect(() => {
-		void wsSlug;
-		void collSlug;
-		lastSyncedUnparented = false;
 	});
 
 	// Bootstrap the workspace on entry. Idempotent: if already 'ready'
@@ -700,6 +720,17 @@
 		const seq = ++loadSeq;
 		metaLoading = true;
 		metaError = null;
+		// Reset for the new route; only flips back to `true` once
+		// `loadUrlFilters()` below has actually run for THIS load (guarded
+		// by the same `seq !== loadSeq` supersede-check). Deliberately NOT
+		// derived from `metaLoading` alone (Codex review round 6): on a
+		// failed load (a genuine 404, or a transient error), `metaLoading`
+		// still flips back to `false` in the `finally` block below even
+		// though `loadUrlFilters()` never ran — `urlFiltersLoaded` stays
+		// `false` through that path, correctly keeping the unparented
+		// URL-sync effect from firing with stale filter state while this
+		// route is erroring.
+		urlFiltersLoaded = false;
 		try {
 			// Items now flow through localIndex (the `items` $derived
 			// above reads `getByCollection`). We still fetch the
@@ -772,6 +803,7 @@
 
 			// Override with URL params if present
 			loadUrlFilters();
+			urlFiltersLoaded = true;
 		} catch (err) {
 			// Superseded by a newer load — don't clobber the current
 			// route's state with this stale failure.

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -37,6 +37,7 @@
 		filtersSetParent,
 		readUnparentedParam,
 		resolveParentUnparentedMutex,
+		unparentedConfirmedRestricted,
 		unparentedEffective,
 		viewHasUnparentedFilter,
 		writeUnparentedParam,
@@ -183,20 +184,24 @@
 	// unavailable — the chip stays hidden and the filter never applies until
 	// this is a confirmed `true`.
 	//
-	// ALSO gated on `!pendingResyncFor` (Codex review round 2, P1): the
-	// warm-cache boot path serves a PERSISTED capability bit before its
-	// follow-up `/items-changes` reconcile confirms it's still current. A
-	// permission change that happened while this client was offline (either
-	// direction) is invisible until that reconcile completes — trusting the
-	// cached bit during that window could expose the chip / apply
-	// client-side structural filtering to a now-restricted caller, or
-	// silently drop a now-legitimate caller's intent. Treat capability as
-	// unknown (unavailable) for the whole pending-resync window rather than
-	// act on a possibly-stale value either way.
+	// Deliberately NOT gated on `pendingResyncFor`: a warm-cache boot's
+	// PERSISTED capability bit can be momentarily stale (e.g. an offline
+	// permission downgrade not yet reconciled), but that's the SAME
+	// staleness window every other locally-cached field on `Item` already
+	// has under the local-first model (PLAN-1343) — nothing else on this
+	// page blocks rendering on `pendingResync`, and any client-side
+	// filtering during that window only ever operates on data this caller
+	// was already shown before the (possible) downgrade, so it isn't a NEW
+	// disclosure. `includesUnparentedMetadataFor` self-corrects reactively
+	// the moment a resync installs a fresh value — see the effect below.
+	// (Codex review round 2 gated this on `pendingResyncFor`; round 3 P1/P2
+	// showed that blunt gate both destroyed legitimate intent mid-resync
+	// and could wedge the chip hidden forever after a live permission
+	// upgrade, since `pendingResync` is cleared only by `bootstrap()`'s own
+	// reconcile loop — never by the page's separate `deltaSync()` calls
+	// that also trigger a resync during a live session.)
 	let unparentedMetadataAvailable = $derived(
-		wsSlug
-			? !localIndex.pendingResyncFor(wsSlug) && localIndex.includesUnparentedMetadataFor(wsSlug) === true
-			: false,
+		wsSlug ? localIndex.includesUnparentedMetadataFor(wsSlug) === true : false,
 	);
 	// The chip's EFFECTIVE state — intent AND availability. Everything that
 	// actually filters/badges/persists reads this, not the raw intent flag,
@@ -204,17 +209,35 @@
 	// URL or saved view) never filters anything or counts as an active
 	// filter (DR-2).
 	let unparentedApplied = $derived(unparentedEffective(unparentedFilter, unparentedMetadataAvailable));
+	// A NARROWER signal than `!unparentedMetadataAvailable`, used ONLY to
+	// gate the destructive "physically clear a stuck intent" action below.
+	// Requires a CONFIRMED restriction (`includesUnparentedMetadataFor ===
+	// false`, not just "unavailable" — which also covers `null`/unknown and
+	// a mid-resync window where the true answer just hasn't landed yet) AND
+	// `!pendingResyncFor` (no resync in flight that could still flip the
+	// answer). Without this narrower gate, clearing on mere unavailability
+	// would permanently discard a legitimate URL/saved-view intent the
+	// instant it loaded during ANY in-flight resync — even one that was
+	// about to confirm the caller unrestricted a moment later (Codex review
+	// round 3, P1).
+	let isUnparentedConfirmedRestricted = $derived(
+		wsSlug
+			? unparentedConfirmedRestricted(
+					localIndex.includesUnparentedMetadataFor(wsSlug) === false,
+					localIndex.pendingResyncFor(wsSlug),
+				)
+			: false,
+	);
 
 	// Restricted clearing (DR-2) AND URL honesty as the projection scope
 	// resolves. Two things this effect keeps correct once `indexReady`:
 	//
-	//   1. Once the scope is confirmed and does NOT include unparented
-	//      metadata, physically clear a stuck intent flag (from a URL or
-	//      saved view carrying the pseudo-filter) instead of leaving it
-	//      dangling — otherwise it would silently no-op (via
-	//      `unparentedApplied`) but could still get re-persisted into the
-	//      URL/a new saved view the moment something else calls
-	//      `updateUrlFilters()`.
+	//   1. Once restriction is CONFIRMED (`isUnparentedConfirmedRestricted`),
+	//      physically clear a stuck intent flag (from a URL or saved view
+	//      carrying the pseudo-filter) instead of leaving it dangling —
+	//      otherwise it would silently no-op (via `unparentedApplied`) but
+	//      could still get re-persisted into the URL/a new saved view the
+	//      moment something else calls `updateUrlFilters()`.
 	//   2. Re-sync the URL whenever `unparentedApplied` (the EFFECTIVE
 	//      state) actually changes value, in EITHER direction. This covers
 	//      not just the clear-on-downgrade case above but also: a default
@@ -233,13 +256,9 @@
 	//   after clearing the stuck raw intent (it was never effective to
 	//   begin with), so that diff alone would never fire — leaving the
 	//   literal `$unparented=true` sitting in the address bar even though
-	//   internal state is correctly clean. That stale param is not just
-	//   cosmetic: `defaultViewApplied`'s "don't override URL-driven state"
-	//   check treats ANY search param as explicit user intent and skips
-	//   applying the user's stored default view — a restricted caller
-	//   opening a shared unparented-filter link would silently lose their
-	//   default view too. So: sync whenever we just cleared a stuck intent,
-	//   in addition to syncing on an effective-value transition.
+	//   internal state is correctly clean. So: sync whenever we just
+	//   cleared a confirmed-restricted stuck intent, in addition to syncing
+	//   on an effective-value transition.
 	// Plain (non-reactive) memo, not `$derived` — we only need last-observed
 	// bookkeeping inside the effect below, not a tracked value. `false`
 	// matches `unparentedApplied`'s guaranteed value at this point (intent
@@ -248,7 +267,7 @@
 	$effect(() => {
 		if (!wsSlug || !indexReady) return;
 		let needsUrlSync = false;
-		if (unparentedFilter && !unparentedMetadataAvailable) {
+		if (unparentedFilter && isUnparentedConfirmedRestricted) {
 			unparentedFilter = false;
 			needsUrlSync = true;
 		}

--- a/web/src/routes/s/[token]/+page.svelte
+++ b/web/src/routes/s/[token]/+page.svelte
@@ -8,6 +8,8 @@
 	import {
 		parsePublicCollection,
 		parsePublicItems,
+		filterEvaluable,
+		matchesFilter,
 		type PublicCollection,
 		type PublicItem
 	} from '$lib/components/share/shareView';
@@ -148,37 +150,10 @@
 		return items.filter((item) => applicable.every((f) => matchesFilter(item, f)));
 	});
 
-	// True when the filter targets a field present in the public collection
-	// schema, so it's meaningful against the shared payload. Malformed/fieldless
-	// filters are treated as evaluable so matchesFilter can no-op them.
-	function filterEvaluable(schemaKeys: Set<string>, filter: unknown): boolean {
-		if (!filter || typeof filter !== 'object') return true;
-		const field = (filter as { field?: unknown }).field;
-		if (typeof field !== 'string') return true;
-		return schemaKeys.has(field);
-	}
-
-	// Read-only filter evaluation mirroring the logged-in collection page's
-	// `eq` / `in` handling (the only ops saved-view configs emit). Unknown ops
-	// pass through (don't hide items we can't reason about).
-	function matchesFilter(item: PublicItem, filter: unknown): boolean {
-		if (!filter || typeof filter !== 'object') return true;
-		const f = filter as { field?: unknown; op?: unknown; value?: unknown };
-		if (typeof f.field !== 'string') return true;
-		const fieldVal = item.fields[f.field];
-		if (f.op === 'eq') {
-			return String(fieldVal ?? '') === String(f.value ?? '');
-		}
-		if (f.op === 'in') {
-			const wanted = Array.isArray(f.value) ? f.value.map((v) => String(v)) : [String(f.value)];
-			// Tags-style array fields: match if any item value is wanted.
-			if (Array.isArray(fieldVal)) {
-				return fieldVal.some((v) => wanted.includes(String(v)));
-			}
-			return wanted.includes(String(fieldVal ?? ''));
-		}
-		return true;
-	}
+	// `filterEvaluable` / `matchesFilter` now live in `shareView.ts` — the
+	// single evaluation choke-point shared by every public-share renderer,
+	// and the place the `$unparented` skip (PLAN-2095 DR-5 / TASK-2099) is
+	// enforced + pure-tested (see `shareView.test.ts`).
 
 	function coerceBaseView(value: unknown): BaseView | null {
 		if (value === 'list' || value === 'board' || value === 'table') return value;

--- a/web/src/test/setup-jsdom.ts
+++ b/web/src/test/setup-jsdom.ts
@@ -22,3 +22,30 @@ if (typeof HTMLDialogElement !== 'undefined') {
 		this.dispatchEvent(new Event('close'));
 	};
 }
+
+// jsdom does not implement `window.matchMedia`. Several client-only stores
+// (`breakpoint.svelte.ts`, `ui.svelte.ts`) call it at MODULE-LOAD time,
+// guarded behind SvelteKit's `browser` flag — which the jsdom test project
+// forces `true` (see `src/test/mocks/app-environment.ts`). That means any
+// jsdom test whose component tree transitively imports one of those stores
+// (e.g. FilterBar.svelte → breakpoint.svelte.ts) needs `matchMedia` to exist
+// before its top-level `import` runs; a per-test `vi.stubGlobal` (as
+// `breakpoint.svelte.test.ts` uses for a controllable result) is too late
+// for a static import. This default polyfill (match-nothing / desktop
+// viewport) covers everyone else; tests that need a specific result install
+// their own `vi.stubGlobal('matchMedia', ...)`, which layers over — and
+// `vi.unstubAllGlobals()` cleanly restores — this default.
+if (typeof window !== 'undefined' && typeof window.matchMedia !== 'function') {
+	window.matchMedia = function matchMedia(query: string): MediaQueryList {
+		return {
+			matches: false,
+			media: query,
+			onchange: null,
+			addEventListener: () => {},
+			removeEventListener: () => {},
+			addListener: () => {},
+			removeListener: () => {},
+			dispatchEvent: () => false,
+		} as MediaQueryList;
+	};
+}


### PR DESCRIPTION
## Summary

Phase 2 of [[PLAN-2095]] ([[TASK-2099]]): the web UI + persistence layer for "unparented" (structurally loose) item filtering. Phase 1 (TASK-2096, PR #926) delivered the backend/CLI/MCP contract — index/delta rows carry an optional `is_unparented` bit gated to unrestricted callers via `includes_unparented_metadata`. This PR is purely web/frontend; no backend, store, or MCP changes, and `ToolSurfaceVersion` stays at 0.15.

- **FilterBar "Unparented only" chip** (`FilterBar.svelte`) — renders only when the caller's projection scope confirms `is_unparented` metadata is available (restricted callers never see it exists, per DR-2).
- **Local filtering** across list/board/table, driven off the local-first `is_unparented` projection — no extra request.
- **URL round-trip** under the reserved `$unparented` query param (not a plain `unparented` param — avoids colliding with a grandfathered schema field literally named `unparented`).
- **Mutual exclusivity** with the specific-parent filter (`parent`/legacy `phase` alias) — enforced both interactively and when a URL/saved view is applied wholesale.
- **Saved-view persistence** via the reserved `{field: '$unparented', op: 'eq', value: true}` condition (DR-5).
- **Restricted clearing** (DR-2) — a URL or saved view carrying the pseudo-filter is silently ignored for restricted callers, and any stuck intent is cleared once restriction is confirmed (not merely "unavailable/pending" — see trade-off note below).
- **Public-share skip** — `shareView.ts`'s `filterEvaluable`/`matchesFilter` explicitly refuse to evaluate `$unparented`, including against a grandfathered schema with a literal `unparented` (no `$`) field.

## New/changed surfaces

- `web/src/lib/collections/unparentedFilter.ts` (new) — pure decision logic: mutex resolution, effective-state computation, saved-view build/detect, URL param read/write, confirmed-restriction gating. Framework-agnostic, independently unit-tested.
- `web/src/lib/stores/localIndex.svelte.ts` — three new read-only accessors: `includesUnparentedMetadataFor`, `pendingResyncFor`, and a `markCaughtUp(ws, epoch)` mutator (epoch-guarded) so the collection page's own SSE/periodic-sync-driven reconcile loop can clear a resync it triggered, mirroring what `bootstrap()`'s internal loop already does for the cold/warm-boot path.
- `web/src/lib/components/collections/FilterBar.svelte` — the chip.
- `web/src/lib/components/share/shareView.ts` — `filterEvaluable`/`matchesFilter` extracted from the `/s/[token]` route as pure, tested functions; explicit `$unparented` skip.
- `web/src/routes/[username]/[workspace]/[collection]/+page.svelte` — state, URL round-trip, mutex, saved-view apply/build, restricted-clearing + URL-sync effect.

## Test notes

18 test files / 240 tests, all green. New coverage: `unparentedFilter.test.ts` (pure mutex/effective/URL/saved-view logic), `FilterBar.svelte.test.ts` (chip visibility/state), `shareView.test.ts` (public-share skip incl. grandfathered-field guard), `localIndexUnparented.svelte.test.ts` additions (new accessors + `markCaughtUp`). Added a default `window.matchMedia` polyfill to `setup-jsdom.ts` so jsdom component tests that transitively import `breakpoint.svelte.ts` don't need a per-test stub.

Gates: `npm run check` (0 errors), `npm run test` (240/240), `make check` (lint/go test/govulncheck/npm audit/web-check all green), `make install` (server rebuilt + restarted).

## Codex review

Six substantive review→fix rounds (well past the usual ~4-round cap) closed real races: URL-param collision with a real `unparented` field, parent/`phase` mutex gaps on whole-state URL/view application, `pendingResync`-vs-intent-preservation tension (see below), an optimistic-create flash-hide, epoch-guarding `markCaughtUp`, and a cross-collection-navigation URL-sync race replaced with an explicit `urlFiltersLoaded` flag instead of an effect-ordering assumption.

**One documented trade-off left open:** the final round asked to gate `unparentedMetadataAvailable` (rendering/filtering availability) on `!pendingResyncFor`, reverting round 3's fix. Round 2 tried exactly that; rounds 3–4 found it destroys a legitimate user's filter intent if it loads mid-resync (even when the resync was about to confirm them unrestricted) and can wedge the chip hidden forever after a live permission upgrade. Kept the round-3 design (ordinary availability ungated; a narrower `unparentedConfirmedRestricted` — requiring metadata confirmed `false` AND no resync in flight — gates only the destructive "clear a stuck intent" action). The residual risk this declines to close is a sub-second, self-correcting window where a just-offline-downgraded caller could locally filter data they were already shown before the downgrade — not a new server-side disclosure; DR-2's hard boundary is enforced server-side regardless. Extensively commented in `+page.svelte` near `unparentedMetadataAvailable`.

## Pad refs

[[PLAN-2095]] · [[TASK-2099]] · [[TASK-2096]] (Phase 1, merged)

https://claude.ai/code/session_01EZ6yr6pAUFb1uffan912ra
