### PR TITLE
fix(security): scope MCP workspace-global reads by OAuth consent allow-list (BUG-2102)

### DIFF
--- a/internal/mcp/dispatch_http_envelope_test.go
+++ b/internal/mcp/dispatch_http_envelope_test.go
@@ -312,46 +312,11 @@ func TestUnknownWorkspace_StoreError_EmptyHints(t *testing.T) {
 	}
 }
 
-// ─────────────────────────────────────────────────────────────────────
-// buildAllowSet unit tests — the shared helper between lister + gate.
-// ─────────────────────────────────────────────────────────────────────
-
-func TestBuildAllowSet_NilReturnsNilNoFilter(t *testing.T) {
-	if got := buildAllowSet(nil); got != nil {
-		t.Errorf("nil input should yield nil (no filter); got %v", got)
-	}
-}
-
-func TestBuildAllowSet_WildcardReturnsNilNoFilter(t *testing.T) {
-	if got := buildAllowSet([]string{"*"}); got != nil {
-		t.Errorf("wildcard should yield nil (no filter); got %v", got)
-	}
-}
-
-func TestBuildAllowSet_WildcardWinsOverSpecific(t *testing.T) {
-	// Defense-in-depth: a tampered allow-list with both a slug AND
-	// the wildcard collapses to "no filter" — the safer
-	// interpretation, matching what RequireWorkspaceAccess does.
-	if got := buildAllowSet([]string{"alpha", "*"}); got != nil {
-		t.Errorf("wildcard + specific should yield nil (no filter); got %v", got)
-	}
-}
-
-func TestBuildAllowSet_SpecificListBuildsSet(t *testing.T) {
-	got := buildAllowSet([]string{"alpha", "beta"})
-	if got == nil {
-		t.Fatal("specific list should yield non-nil set")
-	}
-	if _, ok := got["alpha"]; !ok {
-		t.Error("expected alpha in set")
-	}
-	if _, ok := got["beta"]; !ok {
-		t.Error("expected beta in set")
-	}
-	if _, ok := got["gamma"]; ok {
-		t.Error("gamma must not be in set")
-	}
-}
+// The allow-set builder these listers rely on now lives in internal/server
+// as server.TokenAllowedWorkspaceSet (promoted from mcp's buildAllowSet in
+// BUG-2102 so the workspace-global handlers and these MCP filters share one
+// implementation). Its unit tests moved with it — see
+// internal/server/token_workspace_allowlist_test.go.
 
 // ─────────────────────────────────────────────────────────────────────
 // End-to-end through packageHTTPResponse (the dispatcher's actual

--- a/internal/mcp/dispatch_http_lister.go
+++ b/internal/mcp/dispatch_http_lister.go
@@ -106,8 +106,11 @@ func (l *oauthWorkspaceLister) ListWorkspaces(ctx context.Context) ([]WorkspaceH
 	if err != nil {
 		return nil, err
 	}
-	allowed := server.TokenAllowedWorkspacesFromContext(ctx)
-	if allowList := buildAllowSet(allowed); allowList != nil {
+	// server.TokenAllowedWorkspaceSet is the canonical allow-set builder
+	// (BUG-2102 moved it into internal/server so the workspace-global
+	// handlers and these MCP filters share one implementation): nil for the
+	// no-filter cases (nil allow-list / wildcard), a slug-set otherwise.
+	if allowList := server.TokenAllowedWorkspaceSet(ctx); allowList != nil {
 		filtered := make([]WorkspaceHint, 0, len(all))
 		for _, ws := range all {
 			if _, ok := allowList[ws.Slug]; ok {
@@ -117,23 +120,4 @@ func (l *oauthWorkspaceLister) ListWorkspaces(ctx context.Context) ([]WorkspaceH
 		return filtered, nil
 	}
 	return all, nil
-}
-
-// buildAllowSet returns nil for the "no token-level filter" cases
-// (nil allow-list, or wildcard) and a slug-set otherwise. Matches
-// the three return-shape contract of TokenAllowedWorkspacesFromContext.
-func buildAllowSet(allowed []string) map[string]struct{} {
-	if allowed == nil {
-		return nil
-	}
-	for _, entry := range allowed {
-		if entry == "*" {
-			return nil
-		}
-	}
-	out := make(map[string]struct{}, len(allowed))
-	for _, slug := range allowed {
-		out[slug] = struct{}{}
-	}
-	return out
 }

--- a/internal/mcp/resources_http.go
+++ b/internal/mcp/resources_http.go
@@ -196,11 +196,11 @@ func (f *HTTPResourceFetcher) fetchWorkspaceList(ctx context.Context, user *mode
 	// Honor the OAuth token's consent allow-list: the /api/v1/workspaces
 	// handler returns every membership, so — unlike per-workspace routes —
 	// nothing scopes it to the workspaces the token was granted. Filter here
-	// with the same rule the error-hint lister uses (nil/wildcard → no
-	// filter, so PAT auth and local stdio are unaffected; a specific
-	// allow-list → intersect) so this resource can't enumerate the slugs of
-	// workspaces the user never consented to expose.
-	allowSet := buildAllowSet(server.TokenAllowedWorkspacesFromContext(ctx))
+	// with the canonical set builder (nil/wildcard → no filter, so PAT auth
+	// and local stdio are unaffected; a specific allow-list → intersect) so
+	// this resource can't enumerate the slugs of workspaces the user never
+	// consented to expose.
+	allowSet := server.TokenAllowedWorkspaceSet(ctx)
 	entries := make([]workspaceListEntry, 0, len(wss))
 	for _, ws := range wss {
 		if allowSet != nil {

--- a/internal/server/context.go
+++ b/internal/server/context.go
@@ -207,3 +207,36 @@ func TokenAllowedWorkspacesFromContext(ctx context.Context) []string {
 	copy(out, v)
 	return out
 }
+
+// TokenAllowedWorkspaceSet returns the token's allow-list as a slug-set for
+// filtering a multi-workspace result, or nil when no per-slug gate applies.
+// It is the multi-slug companion to tokenAllowedWorkspaceMatches (single
+// slug, hot path): use the matcher to gate one resolved workspace, use this
+// to filter a list.
+//
+// Return contract mirrors TokenAllowedWorkspacesFromContext:
+//
+//   - nil allow-list (PAT / pre-consent / local stdio) → nil set → NO filter.
+//   - wildcard ["*"] → nil set → NO filter.
+//   - explicit ["a","b"] → set{a,b}; caller MUST drop any workspace whose
+//     slug is not a key, even one the user is a member of.
+//
+// An empty (non-nil) allow-list yields an empty (non-nil) set — fail closed,
+// every workspace dropped — matching tokenAllowedWorkspaceMatches. The consent
+// flow rejects empty lists, so this shouldn't occur in practice.
+func TokenAllowedWorkspaceSet(ctx context.Context) map[string]struct{} {
+	allowed := TokenAllowedWorkspacesFromContext(ctx)
+	if allowed == nil {
+		return nil
+	}
+	for _, entry := range allowed {
+		if entry == "*" {
+			return nil
+		}
+	}
+	set := make(map[string]struct{}, len(allowed))
+	for _, slug := range allowed {
+		set[slug] = struct{}{}
+	}
+	return set
+}

--- a/internal/server/handlers_audit.go
+++ b/internal/server/handlers_audit.go
@@ -16,6 +16,18 @@ func (s *Server) handleAuditLog(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// OAuth consent scoping (BUG-2102): the audit log is a platform-wide,
+	// cross-workspace admin surface with no per-workspace routing, so a
+	// consent-scoped OAuth token (specific allow-list) must not receive it —
+	// it would leak audit entries for every workspace and user, well outside
+	// the token's granted scope. nil/wildcard allow-list (PAT / web session /
+	// broad consent) is unaffected.
+	if TokenAllowedWorkspaceSet(r.Context()) != nil {
+		writeError(w, http.StatusForbidden, "forbidden",
+			"The platform audit log is not available to workspace-scoped tokens")
+		return
+	}
+
 	// Accept both "user" and "actor" query params for filtering by user ID.
 	actorFilter := r.URL.Query().Get("user")
 	if actorFilter == "" {

--- a/internal/server/handlers_search.go
+++ b/internal/server/handlers_search.go
@@ -76,6 +76,13 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 				writeError(w, http.StatusInternalServerError, "internal_error", "Failed to resolve user workspaces")
 				return
 			}
+			// OAuth consent scoping (BUG-2102): /search is workspace-global
+			// when no workspace is given — it fans out over EVERY membership.
+			// RequireWorkspaceAccess never runs here, so a consent-scoped
+			// token would otherwise get item titles + content across
+			// workspaces it wasn't granted. Restrict the fan-out to the
+			// allow-list. No-op for PAT / web session (nil allow-list).
+			workspaces = filterWorkspacesByTokenAllowlist(r.Context(), workspaces)
 			for _, ws := range workspaces {
 				params.WorkspaceIDs = append(params.WorkspaceIDs, ws.ID)
 			}
@@ -160,6 +167,18 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 	if params.Workspace != "" {
 		ws, _ := s.store.GetWorkspaceBySlug(params.Workspace)
 		if ws != nil {
+			// OAuth consent scoping (BUG-2102): a token consented to specific
+			// workspaces must not read another one's item content by naming it
+			// here, even a co-membership. Return empty (not 403) so the token
+			// can't confirm the workspace exists. No-op for PAT / web session.
+			if !tokenAllowedWorkspaceMatches(r.Context(), ws.Slug) {
+				writeJSON(w, http.StatusOK, &store.SearchResponse{
+					Results: []store.SearchResult{},
+					Limit:   params.Limit,
+					Offset:  params.Offset,
+				})
+				return
+			}
 			user := currentUser(r)
 			visibleIDs, visErr := s.visibleCollectionIDs(r, ws.ID)
 			if visErr != nil {

--- a/internal/server/handlers_workspaces.go
+++ b/internal/server/handlers_workspaces.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"log/slog"
@@ -15,6 +16,26 @@ import (
 	"github.com/PerpetualSoftware/pad/internal/store"
 	"github.com/go-chi/chi/v5"
 )
+
+// filterWorkspacesByTokenAllowlist returns the subset of wss the request's
+// OAuth consent allow-list permits, or wss unchanged when no per-slug gate
+// applies (nil/wildcard allow-list — PAT auth, web session, local stdio, or
+// wildcard consent). Shared by the workspace-global reads that sit outside
+// the /{slug} subrouter (list, deleted-list, search fan-out) and therefore
+// never pass through RequireWorkspaceAccess's allow-list gate. See BUG-2102.
+func filterWorkspacesByTokenAllowlist(ctx context.Context, wss []models.Workspace) []models.Workspace {
+	allow := TokenAllowedWorkspaceSet(ctx)
+	if allow == nil {
+		return wss
+	}
+	out := make([]models.Workspace, 0, len(wss))
+	for _, ws := range wss {
+		if _, ok := allow[ws.Slug]; ok {
+			out = append(out, ws)
+		}
+	}
+	return out
+}
 
 func normalizeWorkspaceInput(input *models.WorkspaceCreate) error {
 	if input == nil {
@@ -155,6 +176,12 @@ func (s *Server) handleListWorkspaces(w http.ResponseWriter, r *http.Request) {
 			writeInternalError(w, err)
 			return
 		}
+		// OAuth consent scoping (BUG-2102): this route is workspace-global
+		// (no {slug} path param), so RequireWorkspaceAccess — the sole
+		// enforcer of the token allow-list — never runs. Filter here so a
+		// consent-scoped token can't enumerate the slugs of workspaces it
+		// wasn't granted. No-op for web-session / PAT auth (nil allow-list).
+		workspaces = filterWorkspacesByTokenAllowlist(r.Context(), workspaces)
 		if workspaces == nil {
 			workspaces = []models.Workspace{}
 		}
@@ -442,6 +469,10 @@ func (s *Server) handleListDeletedWorkspaces(w http.ResponseWriter, r *http.Requ
 		writeInternalError(w, err)
 		return
 	}
+	// OAuth consent scoping (BUG-2102): workspace-global route, outside
+	// RequireWorkspaceAccess. A consent-scoped token must not enumerate
+	// soft-deleted workspaces it wasn't granted. No-op for PAT / web session.
+	workspaces = filterWorkspacesByTokenAllowlist(r.Context(), workspaces)
 
 	now := time.Now().UTC()
 	out := make([]deletedWorkspaceResponse, 0, len(workspaces))
@@ -484,6 +515,17 @@ func (s *Server) handleRestoreWorkspace(w http.ResponseWriter, r *http.Request) 
 	if ws == nil {
 		// Not soft-deleted (live), unknown, or already hard-purged —
 		// nothing to restore.
+		writeError(w, http.StatusNotFound, "not_found", "No restorable workspace found")
+		return
+	}
+
+	// OAuth consent scoping (BUG-2102): this route is a sibling of the
+	// /{slug} subrouter, so RequireWorkspaceAccess never gates it. A
+	// consent-scoped token must not restore a workspace outside its
+	// allow-list, even one the user owns. Return the same 404 as
+	// "not restorable" so the token can't probe which slugs exist.
+	// nil/wildcard allow-list (PAT / web session) → no gate.
+	if !tokenAllowedWorkspaceMatches(r.Context(), ws.Slug) {
 		writeError(w, http.StatusNotFound, "not_found", "No restorable workspace found")
 		return
 	}

--- a/internal/server/token_workspace_allowlist_test.go
+++ b/internal/server/token_workspace_allowlist_test.go
@@ -106,3 +106,53 @@ func TestTokenAllowedWorkspacesFromContext_ReturnsCopy(t *testing.T) {
 		t.Errorf("returned slice should be a copy; got2[0] = %q after caller mutation", got2[0])
 	}
 }
+
+// TestTokenAllowedWorkspaceSet covers the multi-slug companion to
+// tokenAllowedWorkspaceMatches, promoted from internal/mcp's buildAllowSet in
+// BUG-2102. Same three-shape contract, but returns a slug-set for filtering a
+// list rather than gating one slug: nil/wildcard → nil (no filter); explicit
+// list → a set; empty (non-nil) list → empty set (fail closed).
+func TestTokenAllowedWorkspaceSet(t *testing.T) {
+	set := func(slugs []string) map[string]struct{} {
+		ctx := context.Background()
+		if slugs != nil {
+			ctx = WithTokenAllowedWorkspaces(ctx, slugs)
+		}
+		return TokenAllowedWorkspaceSet(ctx)
+	}
+
+	if got := set(nil); got != nil {
+		t.Errorf("nil allow-list should yield nil (no filter); got %v", got)
+	}
+	if got := set([]string{"*"}); got != nil {
+		t.Errorf("wildcard should yield nil (no filter); got %v", got)
+	}
+	// Defense-in-depth: wildcard mixed with a specific slug still collapses to
+	// "no filter" — the safer read, matching tokenAllowedWorkspaceMatches.
+	if got := set([]string{"alpha", "*"}); got != nil {
+		t.Errorf("wildcard + specific should yield nil (no filter); got %v", got)
+	}
+
+	got := set([]string{"alpha", "beta"})
+	if got == nil {
+		t.Fatal("specific list should yield a non-nil set")
+	}
+	if _, ok := got["alpha"]; !ok {
+		t.Error("expected alpha in set")
+	}
+	if _, ok := got["beta"]; !ok {
+		t.Error("expected beta in set")
+	}
+	if _, ok := got["gamma"]; ok {
+		t.Error("gamma must not be in set")
+	}
+
+	// Empty (non-nil) allow-list fails closed: an empty set drops everything.
+	empty := TokenAllowedWorkspaceSet(WithTokenAllowedWorkspaces(context.Background(), []string{}))
+	if empty == nil {
+		t.Fatal("empty (non-nil) allow-list should yield an empty non-nil set (fail closed), not nil")
+	}
+	if len(empty) != 0 {
+		t.Errorf("empty allow-list set should have no entries; got %v", empty)
+	}
+}

--- a/internal/server/token_workspace_consent_scope_test.go
+++ b/internal/server/token_workspace_consent_scope_test.go
@@ -1,0 +1,299 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/store"
+	"github.com/go-chi/chi/v5"
+)
+
+// These tests cover BUG-2102: the OAuth consent allow-list was enforced only
+// by RequireWorkspaceAccess, which fires solely for /{slug} path-param routes.
+// Every MCP-reachable read that is workspace-global (list, deleted, search
+// fan-out, audit-log) or takes the workspace as a query/body param (search
+// by workspace, restore by slug) bypassed the gate. Each handler now honors
+// the allow-list; these tests drive the handlers directly with a context
+// carrying WithCurrentUser + WithTokenAllowedWorkspaces (the shape MCPBearerAuth
+// produces for a consent-scoped OAuth token — the cookie/PAT test path never
+// sets an allow-list).
+
+// consentScopedRequest builds an in-context request as an OAuth-scoped MCP
+// call would arrive at a handler: the user on context, an optional allow-list,
+// and optional chi URL params. Passing allow == nil models PAT / web-session
+// auth (no allow-list → no gate).
+func consentScopedRequest(method, path string, user *models.User, allow []string, urlParams map[string]string) *http.Request {
+	req := httptest.NewRequest(method, path, nil)
+	ctx := WithCurrentUser(req.Context(), user)
+	if allow != nil {
+		ctx = WithTokenAllowedWorkspaces(ctx, allow)
+	}
+	if len(urlParams) > 0 {
+		rctx := chi.NewRouteContext()
+		for k, v := range urlParams {
+			rctx.URLParams.Add(k, v)
+		}
+		ctx = context.WithValue(ctx, chi.RouteCtxKey, rctx)
+	}
+	return req.WithContext(ctx)
+}
+
+func mustCreateUser(t *testing.T, srv *Server, email, name, role string) *models.User {
+	t.Helper()
+	u, err := srv.store.CreateUser(models.UserCreate{
+		Email: email, Name: name, Password: "correct-horse-battery-staple", Role: role,
+	})
+	if err != nil {
+		t.Fatalf("create user %s: %v", email, err)
+	}
+	return u
+}
+
+func mustCreateOwnedWorkspace(t *testing.T, srv *Server, name string, owner *models.User) *models.Workspace {
+	t.Helper()
+	ws, err := srv.store.CreateWorkspace(models.WorkspaceCreate{Name: name, OwnerID: owner.ID})
+	if err != nil {
+		t.Fatalf("create workspace %s: %v", name, err)
+	}
+	if err := srv.store.AddWorkspaceMember(ws.ID, owner.ID, "owner"); err != nil {
+		t.Fatalf("add owner to %s: %v", name, err)
+	}
+	return ws
+}
+
+func TestHandleListWorkspaces_FiltersByConsentAllowList(t *testing.T) {
+	srv := testServer(t)
+	user := mustCreateUser(t, srv, "u@test.com", "U", "member")
+	alpha := mustCreateOwnedWorkspace(t, srv, "Alpha", user)
+	beta := mustCreateOwnedWorkspace(t, srv, "Beta", user)
+
+	list := func(allow []string) []models.Workspace {
+		t.Helper()
+		req := consentScopedRequest("GET", "/api/v1/workspaces", user, allow, nil)
+		rec := httptest.NewRecorder()
+		srv.handleListWorkspaces(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status %d: %s", rec.Code, rec.Body.String())
+		}
+		var out []models.Workspace
+		if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		return out
+	}
+
+	// Consent scoped to alpha: beta must be dropped (the leak BUG-2102 fixes).
+	scoped := list([]string{alpha.Slug})
+	if containsWorkspace(scoped, beta.ID) {
+		t.Error("beta leaked despite consent scoped to alpha")
+	}
+	if !containsWorkspace(scoped, alpha.ID) {
+		t.Error("alpha (consented) should be present")
+	}
+
+	// No allow-list (PAT / web session): unchanged — both present.
+	all := list(nil)
+	if !containsWorkspace(all, alpha.ID) || !containsWorkspace(all, beta.ID) {
+		t.Error("without an allow-list both workspaces should be present")
+	}
+
+	// Wildcard consent: no per-slug filter — both present.
+	wild := list([]string{"*"})
+	if !containsWorkspace(wild, alpha.ID) || !containsWorkspace(wild, beta.ID) {
+		t.Error("wildcard allow-list must not filter")
+	}
+}
+
+func TestHandleListDeletedWorkspaces_FiltersByConsentAllowList(t *testing.T) {
+	srv := testServer(t)
+	user := mustCreateUser(t, srv, "u@test.com", "U", "member")
+	ws := mustCreateOwnedWorkspace(t, srv, "Gone", user)
+	if err := srv.store.DeleteWorkspace(ws.Slug); err != nil {
+		t.Fatalf("soft-delete: %v", err)
+	}
+
+	deleted := func(allow []string) []deletedWorkspaceEntry {
+		t.Helper()
+		req := consentScopedRequest("GET", "/api/v1/workspaces/deleted", user, allow, nil)
+		rec := httptest.NewRecorder()
+		srv.handleListDeletedWorkspaces(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status %d: %s", rec.Code, rec.Body.String())
+		}
+		var out []deletedWorkspaceEntry
+		if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		return out
+	}
+
+	// No allow-list: the owner sees their soft-deleted workspace.
+	var sawIt bool
+	for _, e := range deleted(nil) {
+		if e.ID == ws.ID {
+			sawIt = true
+		}
+	}
+	if !sawIt {
+		t.Fatal("owner should see their soft-deleted workspace without a consent gate")
+	}
+
+	// Consent scoped to a different slug: the deleted workspace is hidden.
+	for _, e := range deleted([]string{"some-other-slug"}) {
+		if e.ID == ws.ID {
+			t.Error("deleted workspace leaked despite consent scope excluding it")
+		}
+	}
+
+	// Consent INCLUDING the slug still shows it — guards against a filter
+	// that drops everything on any non-nil allow-list (which would pass the
+	// nil-shows + other-slug-hides cases above vacuously).
+	var sawScoped bool
+	for _, e := range deleted([]string{ws.Slug}) {
+		if e.ID == ws.ID {
+			sawScoped = true
+		}
+	}
+	if !sawScoped {
+		t.Error("consent including the workspace slug should still show the soft-deleted workspace")
+	}
+}
+
+func TestHandleRestoreWorkspace_GatedByConsentAllowList(t *testing.T) {
+	srv := testServer(t)
+	user := mustCreateUser(t, srv, "owner@test.com", "Owner", "member")
+	ws := mustCreateOwnedWorkspace(t, srv, "Gone", user)
+	if err := srv.store.DeleteWorkspace(ws.Slug); err != nil {
+		t.Fatalf("soft-delete: %v", err)
+	}
+
+	// Consent scoped to a different workspace: restore is denied (404, so the
+	// token can't even confirm the slug exists) and the workspace stays deleted.
+	req := consentScopedRequest("POST", "/api/v1/workspaces/"+ws.Slug+"/restore",
+		user, []string{"some-other-slug"}, map[string]string{"slug": ws.Slug})
+	rec := httptest.NewRecorder()
+	srv.handleRestoreWorkspace(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("out-of-consent restore should 404, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if d, _ := srv.store.GetDeletedWorkspaceBySlug(ws.Slug); d == nil {
+		t.Fatal("workspace must remain soft-deleted after a denied restore")
+	}
+
+	// Consent including the slug (owner): restore succeeds.
+	req2 := consentScopedRequest("POST", "/api/v1/workspaces/"+ws.Slug+"/restore",
+		user, []string{ws.Slug}, map[string]string{"slug": ws.Slug})
+	rec2 := httptest.NewRecorder()
+	srv.handleRestoreWorkspace(rec2, req2)
+	if rec2.Code != http.StatusOK {
+		t.Fatalf("in-consent owner restore should 200, got %d: %s", rec2.Code, rec2.Body.String())
+	}
+}
+
+func TestHandleSearch_ConsentScopesResults(t *testing.T) {
+	srv := testServer(t)
+	user := mustCreateUser(t, srv, "u@test.com", "U", "member")
+	alpha := mustCreateOwnedWorkspace(t, srv, "Alpha", user)
+	beta := mustCreateOwnedWorkspace(t, srv, "Beta", user)
+
+	collA, err := srv.store.CreateCollection(alpha.ID, models.CollectionCreate{Name: "Tasks", Slug: "tasks", Prefix: "TASK"})
+	if err != nil {
+		t.Fatalf("collA: %v", err)
+	}
+	collB, err := srv.store.CreateCollection(beta.ID, models.CollectionCreate{Name: "Tasks", Slug: "tasks", Prefix: "TASK"})
+	if err != nil {
+		t.Fatalf("collB: %v", err)
+	}
+	if _, err := srv.store.CreateItem(alpha.ID, collA.ID, models.ItemCreate{Title: "zebrafish alpha", CreatedBy: "user", Source: "test"}); err != nil {
+		t.Fatalf("item alpha: %v", err)
+	}
+	if _, err := srv.store.CreateItem(beta.ID, collB.ID, models.ItemCreate{Title: "zebrafish beta", CreatedBy: "user", Source: "test"}); err != nil {
+		t.Fatalf("item beta: %v", err)
+	}
+
+	search := func(workspace string, allow []string) store.SearchResponse {
+		t.Helper()
+		path := "/api/v1/search?q=zebrafish"
+		if workspace != "" {
+			path += "&workspace=" + workspace
+		}
+		req := consentScopedRequest("GET", path, user, allow, nil)
+		rec := httptest.NewRecorder()
+		srv.handleSearch(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("search status %d: %s", rec.Code, rec.Body.String())
+		}
+		var resp store.SearchResponse
+		if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		return resp
+	}
+
+	hasWorkspace := func(resp store.SearchResponse, wsID string) bool {
+		for _, r := range resp.Results {
+			if r.Item.WorkspaceID == wsID {
+				return true
+			}
+		}
+		return false
+	}
+
+	// Baseline (no allow-list): fan-out finds items in BOTH workspaces. If this
+	// fails the FTS seed is broken, not the consent gate.
+	base := search("", nil)
+	if !hasWorkspace(base, alpha.ID) || !hasWorkspace(base, beta.ID) {
+		t.Fatalf("baseline fan-out search should find both workspaces' items; got %d results", len(base.Results))
+	}
+
+	// Fan-out consent-scoped to alpha: beta's item CONTENT must not appear.
+	scoped := search("", []string{alpha.Slug})
+	if hasWorkspace(scoped, beta.ID) {
+		t.Error("beta item leaked in a consent-scoped fan-out search (HIGH leak)")
+	}
+	if !hasWorkspace(scoped, alpha.ID) {
+		t.Error("alpha's own item should still be found under consent scoped to alpha")
+	}
+
+	// Explicit workspace=beta while consent-scoped to alpha: empty, no leak.
+	denied := search(beta.Slug, []string{alpha.Slug})
+	if len(denied.Results) != 0 {
+		t.Errorf("searching a non-consented workspace by name should return empty; got %d results", len(denied.Results))
+	}
+
+	// Explicit workspace=beta with matching consent: results returned.
+	allowed := search(beta.Slug, []string{beta.Slug})
+	if !hasWorkspace(allowed, beta.ID) {
+		t.Error("searching a consented workspace by name should return its items")
+	}
+}
+
+func TestHandleAuditLog_DeniedForConsentScopedToken(t *testing.T) {
+	srv := testServer(t)
+	admin := mustCreateUser(t, srv, "admin@test.com", "Admin", "admin")
+
+	code := func(allow []string) int {
+		t.Helper()
+		req := consentScopedRequest("GET", "/api/v1/audit-log", admin, allow, nil)
+		rec := httptest.NewRecorder()
+		srv.handleAuditLog(rec, req)
+		return rec.Code
+	}
+
+	// Consent-scoped (specific allow-list): the platform-wide log is denied.
+	if got := code([]string{"alpha"}); got != http.StatusForbidden {
+		t.Errorf("consent-scoped admin token should be denied the platform audit log; got %d", got)
+	}
+	// No allow-list (PAT / web session admin): unchanged — allowed.
+	if got := code(nil); got != http.StatusOK {
+		t.Errorf("non-scoped admin should get the audit log; got %d", got)
+	}
+	// Wildcard consent: allowed.
+	if got := code([]string{"*"}); got != http.StatusOK {
+		t.Errorf("wildcard-consent admin should get the audit log; got %d", got)
+	}
+}


### PR DESCRIPTION
## Summary

Started as BUG-2102 (the `pad_workspace list` tool ignored the OAuth consent allow-list). A blast-radius investigation revealed it's a **class** of consent-enforcement bypass: the allow-list (`TokenAllowedWorkspaces`) is enforced only by `RequireWorkspaceAccess`, which fires **only for `/{slug}` path-param routes** (it early-returns on an empty slug). Every MCP-reachable read that is workspace-global or takes the workspace as a query/body param silently bypassed consent scoping.

A token consented to workspace A could reach data in other workspaces the user is a member of. This PR closes all five bypasses.

## Bypasses fixed

| Surface | Leak | Fix |
|---|---|---|
| `pad_search.query` | **HIGH** — item titles + content across any co-membership (or all workspaces when none named) | fan-out restricted to allow-list; named non-consented workspace → empty (no existence leak) |
| `pad_workspace.list` | workspace names/slugs (original BUG-2102) | filtered by allow-list |
| `pad_workspace.deleted` | soft-deleted workspace enumeration | filtered by allow-list |
| `pad_workspace.audit-log` | admin token → entire platform audit log | denied for consent-scoped tokens |
| `pad_workspace.restore` | restore + metadata for out-of-consent owned workspace | gated by allow-list (404) |

All gates are **no-ops for nil/wildcard allow-lists**, so PAT auth, web sessions, and local stdio are unchanged. Verified `store.Search` scopes `workspace` by slug only (no UUID bypass of the slug-based gate).

## Root-cause hardening (DRY)

The allow-set semantics move into `internal/server` as the canonical `TokenAllowedWorkspaceSet(ctx)` (promoted from `internal/mcp`'s `buildAllowSet`). The two mcp call sites (error-hint lister, `pad://workspaces` resource) and the unit tests migrate to it, so server handlers and MCP filters share one implementation. This addresses the pattern that caused the bug — TASK-977 (error hints) and TASK-2101 (resource) each point-fixed a single surface while enforcement stayed decentralized.

## Not in scope (confirmed safe)

Everything under `/{slug}` (dashboard, bootstrap, collections, roles, members, item reads, storage) already hits `RequireWorkspaceAccess`. Admin `/admin/*` routes and workspace `reorder` aren't MCP-reachable. The `pad://workspaces` resource was fixed in #934.

## Testing

- Per-handler regression tests (`token_workspace_consent_scope_test.go`) drive each handler with the `WithTokenAllowedWorkspaces` context `MCPBearerAuth` produces; the user is an owner/member of every workspace under test, so **exclusion is proven to come from the consent layer, not membership**. nil/wildcard baselines guard against over-blocking; the search test baselines FTS.
- `TokenAllowedWorkspaceSet` unit tests (nil / wildcard / mixed / explicit / empty-fail-closed).
- `go test ./...` green · `go vet` clean · `golangci-lint` 0 issues · `make install` OK.
- Adversarial multi-agent review (4 finders → per-finding verify): the verifier independently reverted each of the 6 fixes and confirmed every test fails on revert (no tautological tests). No correctness bugs, bypasses, or DRY drift confirmed; one LOW test-completeness gap found and closed.

Fixes BUG-2102. Follow-up to #930 / #933 / #934.

https://claude.ai/code/session_01EZ6yr6pAUFb1uffan912ra