### PR TITLE
fix(security): scope webhook + token mutations by workspace to close cross-workspace IDOR (TASK-266)

### DIFF
--- a/internal/server/handlers_tokens.go
+++ b/internal/server/handlers_tokens.go
@@ -96,13 +96,17 @@ func (s *Server) handleDeleteToken(w http.ResponseWriter, r *http.Request) {
 	if !requireMinRole(w, r, "owner") {
 		return
 	}
-	_, ok := s.getWorkspaceID(w, r)
+	workspaceID, ok := s.getWorkspaceID(w, r)
 	if !ok {
 		return
 	}
 
+	// Scope the revoke to the URL's workspace. requireMinRole("owner") only
+	// proves the caller owns THIS workspace, not that {tokenID} belongs to it,
+	// so an unscoped delete-by-id is a cross-workspace IDOR (TASK-266). Mirrors
+	// DeleteUserAPIToken's user-scoped guard.
 	tokenID := chi.URLParam(r, "tokenID")
-	if err := s.store.DeleteAPIToken(tokenID); err != nil {
+	if err := s.store.DeleteAPITokenScoped(tokenID, workspaceID); err != nil {
 		if err == sql.ErrNoRows {
 			writeError(w, http.StatusNotFound, "not_found", "Token not found")
 			return

--- a/internal/server/handlers_webhook_token_idor_test.go
+++ b/internal/server/handlers_webhook_token_idor_test.go
@@ -56,9 +56,11 @@ func TestWebhookTokenCrossWorkspaceIDOR(t *testing.T) {
 	attackerToken := loginUser(t, srv, "attacker@test.com", "correct-horse-battery-staple")
 
 	// Victim webhook in workspace A. 8.8.8.8 is a public, non-reserved literal
-	// IP so ValidateWebhookURL passes without a DNS lookup.
+	// IP so ValidateWebhookURL passes without a DNS lookup. A non-empty secret
+	// ensures the cross-workspace test-delivery probe would have to decrypt if
+	// it fetched by ID — the scoped lookup must filter it out before then.
 	rr = doRequestWithCookie(srv, "POST", "/api/v1/workspaces/"+wsA.Slug+"/webhooks",
-		map[string]interface{}{"url": "https://8.8.8.8/hook"}, adminToken)
+		map[string]interface{}{"url": "https://8.8.8.8/hook", "secret": "victim-hmac-secret"}, adminToken)
 	if rr.Code != http.StatusCreated {
 		t.Fatalf("create victim webhook: %d %s", rr.Code, rr.Body.String())
 	}

--- a/internal/server/handlers_webhook_token_idor_test.go
+++ b/internal/server/handlers_webhook_token_idor_test.go
@@ -1,0 +1,144 @@
+package server
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// TestWebhookTokenCrossWorkspaceIDOR is the TASK-266 regression guard: an owner
+// of one workspace must not be able to delete or test another workspace's
+// webhook, nor revoke its API token, by object ID reached through their OWN
+// workspace's URL. Before the fix, handleDeleteWebhook / handleTestWebhook /
+// handleDeleteToken looked the object up by ID with no workspace-ownership
+// predicate, so any owner of any workspace could destroy another workspace's
+// integrations given the object ID (cross-workspace IDOR).
+func TestWebhookTokenCrossWorkspaceIDOR(t *testing.T) {
+	srv := testServer(t)
+
+	// Admin owns the VICTIM workspace (A) and its webhook + API token.
+	adminToken := bootstrapFirstUser(t, srv, "victim-owner@test.com", "Victim")
+
+	rr := doRequestWithCookie(srv, "POST", "/api/v1/workspaces",
+		map[string]string{"name": "Victim WS"}, adminToken)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create victim ws: %d %s", rr.Code, rr.Body.String())
+	}
+	var wsA models.Workspace
+	parseJSON(t, rr, &wsA)
+
+	// Attacker is a separate user who legitimately OWNS a different workspace (B),
+	// but is NOT a member of A.
+	rr = doRequestWithCookie(srv, "POST", "/api/v1/auth/register", map[string]string{
+		"email":    "attacker@test.com",
+		"name":     "Attacker",
+		"password": "correct-horse-battery-staple",
+	}, adminToken)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("register attacker: %d %s", rr.Code, rr.Body.String())
+	}
+	attacker, err := srv.store.GetUserByEmail("attacker@test.com")
+	if err != nil || attacker == nil {
+		t.Fatalf("find attacker user: %v", err)
+	}
+
+	rr = doRequestWithCookie(srv, "POST", "/api/v1/workspaces",
+		map[string]string{"name": "Attacker WS"}, adminToken)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create attacker ws: %d %s", rr.Code, rr.Body.String())
+	}
+	var wsB models.Workspace
+	parseJSON(t, rr, &wsB)
+	if err := srv.store.AddWorkspaceMember(wsB.ID, attacker.ID, "owner"); err != nil {
+		t.Fatalf("add attacker as owner of B: %v", err)
+	}
+	attackerToken := loginUser(t, srv, "attacker@test.com", "correct-horse-battery-staple")
+
+	// Victim webhook in workspace A. 8.8.8.8 is a public, non-reserved literal
+	// IP so ValidateWebhookURL passes without a DNS lookup.
+	rr = doRequestWithCookie(srv, "POST", "/api/v1/workspaces/"+wsA.Slug+"/webhooks",
+		map[string]interface{}{"url": "https://8.8.8.8/hook"}, adminToken)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create victim webhook: %d %s", rr.Code, rr.Body.String())
+	}
+	var hook models.Webhook
+	parseJSON(t, rr, &hook)
+
+	// Victim API token in workspace A.
+	rr = doRequestWithCookie(srv, "POST", "/api/v1/workspaces/"+wsA.Slug+"/tokens",
+		map[string]interface{}{"name": "victim-token"}, adminToken)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create victim token: %d %s", rr.Code, rr.Body.String())
+	}
+	var tok models.APIToken
+	parseJSON(t, rr, &tok)
+
+	// --- Attack: reach A's objects through the attacker's OWN workspace B URL. ---
+	// Each must 404 (object not found in workspace B), not act on A's object.
+	t.Run("delete webhook cross-workspace", func(t *testing.T) {
+		rr := doRequestWithCookie(srv, "DELETE",
+			"/api/v1/workspaces/"+wsB.Slug+"/webhooks/"+hook.ID, nil, attackerToken)
+		if rr.Code != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d: %s", rr.Code, rr.Body.String())
+		}
+	})
+	t.Run("test webhook cross-workspace", func(t *testing.T) {
+		rr := doRequestWithCookie(srv, "POST",
+			"/api/v1/workspaces/"+wsB.Slug+"/webhooks/"+hook.ID+"/test", nil, attackerToken)
+		if rr.Code != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d: %s", rr.Code, rr.Body.String())
+		}
+	})
+	t.Run("delete token cross-workspace", func(t *testing.T) {
+		rr := doRequestWithCookie(srv, "DELETE",
+			"/api/v1/workspaces/"+wsB.Slug+"/tokens/"+tok.ID, nil, attackerToken)
+		if rr.Code != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d: %s", rr.Code, rr.Body.String())
+		}
+	})
+
+	// --- The victim's objects must still exist (the attack mutated nothing). ---
+	rr = doRequestWithCookie(srv, "GET", "/api/v1/workspaces/"+wsA.Slug+"/webhooks", nil, adminToken)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("list victim webhooks: %d %s", rr.Code, rr.Body.String())
+	}
+	var hooks []models.Webhook
+	parseJSON(t, rr, &hooks)
+	if len(hooks) != 1 || hooks[0].ID != hook.ID {
+		t.Fatalf("victim webhook should survive the attack; got %+v", hooks)
+	}
+
+	rr = doRequestWithCookie(srv, "GET", "/api/v1/workspaces/"+wsA.Slug+"/tokens", nil, adminToken)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("list victim tokens: %d %s", rr.Code, rr.Body.String())
+	}
+	var toks []models.APIToken
+	parseJSON(t, rr, &toks)
+	found := false
+	for _, x := range toks {
+		if x.ID == tok.ID {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("victim token should survive the attack; got %+v", toks)
+	}
+
+	// --- Control: the legitimate owner CAN act within their own workspace, so
+	// the fix rejects only the cross-workspace case, not all deletes. ---
+	t.Run("owner deletes own webhook", func(t *testing.T) {
+		rr := doRequestWithCookie(srv, "DELETE",
+			"/api/v1/workspaces/"+wsA.Slug+"/webhooks/"+hook.ID, nil, adminToken)
+		if rr.Code != http.StatusNoContent {
+			t.Fatalf("expected 204, got %d: %s", rr.Code, rr.Body.String())
+		}
+	})
+	t.Run("owner deletes own token", func(t *testing.T) {
+		rr := doRequestWithCookie(srv, "DELETE",
+			"/api/v1/workspaces/"+wsA.Slug+"/tokens/"+tok.ID, nil, adminToken)
+		if rr.Code != http.StatusNoContent {
+			t.Fatalf("expected 204, got %d: %s", rr.Code, rr.Body.String())
+		}
+	})
+}

--- a/internal/server/handlers_webhooks.go
+++ b/internal/server/handlers_webhooks.go
@@ -117,12 +117,27 @@ func (s *Server) handleDeleteWebhook(w http.ResponseWriter, r *http.Request) {
 	if !requireMinRole(w, r, "owner") {
 		return
 	}
-	_, ok := s.getWorkspaceID(w, r)
+	workspaceID, ok := s.getWorkspaceID(w, r)
 	if !ok {
 		return
 	}
 
+	// Verify the webhook belongs to the URL's workspace before deleting.
+	// requireMinRole("owner") only proves the caller owns THIS workspace —
+	// not that {webhookID} lives in it — so without this check an owner of
+	// any workspace could delete another workspace's webhook by ID
+	// (cross-workspace IDOR, TASK-266). Mirrors handleDeleteWorkspaceAttachment.
 	webhookID := chi.URLParam(r, "webhookID")
+	hook, err := s.store.GetWebhook(webhookID)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	if hook == nil || hook.WorkspaceID != workspaceID {
+		writeError(w, http.StatusNotFound, "not_found", "Webhook not found")
+		return
+	}
+
 	if err := s.store.DeleteWebhook(webhookID); err != nil {
 		if err == sql.ErrNoRows {
 			writeError(w, http.StatusNotFound, "not_found", "Webhook not found")
@@ -140,7 +155,7 @@ func (s *Server) handleTestWebhook(w http.ResponseWriter, r *http.Request) {
 	if !requireMinRole(w, r, "owner") {
 		return
 	}
-	_, ok := s.getWorkspaceID(w, r)
+	workspaceID, ok := s.getWorkspaceID(w, r)
 	if !ok {
 		return
 	}
@@ -151,7 +166,11 @@ func (s *Server) handleTestWebhook(w http.ResponseWriter, r *http.Request) {
 		writeInternalError(w, err)
 		return
 	}
-	if hook == nil {
+	// Scope to the URL's workspace: without the WorkspaceID match, an owner of
+	// any workspace could fire a test delivery to another workspace's endpoint
+	// and use the 200-vs-404 result as a cross-workspace existence oracle
+	// (TASK-266).
+	if hook == nil || hook.WorkspaceID != workspaceID {
 		writeError(w, http.StatusNotFound, "not_found", "Webhook not found")
 		return
 	}

--- a/internal/server/handlers_webhooks.go
+++ b/internal/server/handlers_webhooks.go
@@ -150,17 +150,18 @@ func (s *Server) handleTestWebhook(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Scope the lookup to the URL's workspace in SQL, before the secret is
+	// decrypted. A foreign (or missing) webhook ID returns no row → 404, so an
+	// owner of any workspace can neither fire a test delivery to another
+	// workspace's endpoint nor use 200-vs-404 (or a decrypt-failure 500) as a
+	// cross-workspace existence oracle (TASK-266).
 	webhookID := chi.URLParam(r, "webhookID")
-	hook, err := s.store.GetWebhook(webhookID)
+	hook, err := s.store.GetWebhookScoped(webhookID, workspaceID)
 	if err != nil {
 		writeInternalError(w, err)
 		return
 	}
-	// Scope to the URL's workspace: without the WorkspaceID match, an owner of
-	// any workspace could fire a test delivery to another workspace's endpoint
-	// and use the 200-vs-404 result as a cross-workspace existence oracle
-	// (TASK-266).
-	if hook == nil || hook.WorkspaceID != workspaceID {
+	if hook == nil {
 		writeError(w, http.StatusNotFound, "not_found", "Webhook not found")
 		return
 	}

--- a/internal/server/handlers_webhooks.go
+++ b/internal/server/handlers_webhooks.go
@@ -122,23 +122,13 @@ func (s *Server) handleDeleteWebhook(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Verify the webhook belongs to the URL's workspace before deleting.
-	// requireMinRole("owner") only proves the caller owns THIS workspace —
-	// not that {webhookID} lives in it — so without this check an owner of
-	// any workspace could delete another workspace's webhook by ID
-	// (cross-workspace IDOR, TASK-266). Mirrors handleDeleteWorkspaceAttachment.
+	// Scope the delete to the URL's workspace. requireMinRole("owner") only
+	// proves the caller owns THIS workspace, not that {webhookID} belongs to
+	// it, so an unscoped delete-by-id is a cross-workspace IDOR (TASK-266). An
+	// atomic scoped DELETE also avoids decrypting the secret just to delete —
+	// a rotated/missing key would otherwise make a broken webhook undeletable.
 	webhookID := chi.URLParam(r, "webhookID")
-	hook, err := s.store.GetWebhook(webhookID)
-	if err != nil {
-		writeInternalError(w, err)
-		return
-	}
-	if hook == nil || hook.WorkspaceID != workspaceID {
-		writeError(w, http.StatusNotFound, "not_found", "Webhook not found")
-		return
-	}
-
-	if err := s.store.DeleteWebhook(webhookID); err != nil {
+	if err := s.store.DeleteWebhookScoped(webhookID, workspaceID); err != nil {
 		if err == sql.ErrNoRows {
 			writeError(w, http.StatusNotFound, "not_found", "Webhook not found")
 			return

--- a/internal/store/api_tokens.go
+++ b/internal/store/api_tokens.go
@@ -187,9 +187,12 @@ func (s *Store) ListUserAPITokens(userID string) ([]models.APIToken, error) {
 	return result, rows.Err()
 }
 
-// DeleteAPIToken removes an API token by ID.
-func (s *Store) DeleteAPIToken(id string) error {
-	result, err := s.db.Exec(s.q("DELETE FROM api_tokens WHERE id = ?"), id)
+// DeleteAPITokenScoped removes a workspace-scoped API token by ID, verifying it
+// belongs to the given workspace. Prevents cross-workspace revocation (TASK-266):
+// an owner of one workspace must not be able to revoke another workspace's token
+// by ID. Returns sql.ErrNoRows when no token matches both id and workspace.
+func (s *Store) DeleteAPITokenScoped(id, workspaceID string) error {
+	result, err := s.db.Exec(s.q("DELETE FROM api_tokens WHERE id = ? AND workspace_id = ?"), id, workspaceID)
 	if err != nil {
 		return fmt.Errorf("delete api token: %w", err)
 	}

--- a/internal/store/webhooks.go
+++ b/internal/store/webhooks.go
@@ -72,6 +72,44 @@ func (s *Store) GetWebhook(id string) (*models.Webhook, error) {
 	return &wh, nil
 }
 
+// GetWebhookScoped retrieves a single webhook by ID, but only if it belongs to
+// the given workspace. The workspace_id predicate is applied in SQL BEFORE the
+// secret is decrypted, so a foreign (or nonexistent) ID returns (nil, nil)
+// without touching the ciphertext — this both closes the cross-workspace
+// existence oracle (TASK-266) and avoids a decrypt-failure 500 leaking that a
+// foreign webhook exists. Returns (nil, nil) when no webhook matches both.
+func (s *Store) GetWebhookScoped(id, workspaceID string) (*models.Webhook, error) {
+	var wh models.Webhook
+	var active bool
+	var createdAt, updatedAt string
+	var lastTriggeredAt *string
+
+	err := s.db.QueryRow(s.q(`
+		SELECT id, workspace_id, url, secret, events, active, created_at, updated_at, last_triggered_at, failure_count
+		FROM webhooks
+		WHERE id = ? AND workspace_id = ?
+	`), id, workspaceID).Scan(
+		&wh.ID, &wh.WorkspaceID, &wh.URL, &wh.Secret, &wh.Events,
+		&active, &createdAt, &updatedAt, &lastTriggeredAt, &wh.FailureCount,
+	)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get webhook: %w", err)
+	}
+
+	if wh.Secret, err = s.decrypt(wh.Secret); err != nil {
+		return nil, fmt.Errorf("decrypt webhook secret: %w", err)
+	}
+	wh.HasSecret = wh.Secret != ""
+	wh.Active = active
+	wh.CreatedAt = parseTime(createdAt)
+	wh.UpdatedAt = parseTime(updatedAt)
+	wh.LastTriggeredAt = parseTimePtr(lastTriggeredAt)
+	return &wh, nil
+}
+
 // ListWebhooks returns all webhooks for a workspace.
 func (s *Store) ListWebhooks(workspaceID string) ([]models.Webhook, error) {
 	rows, err := s.db.Query(s.q(`

--- a/internal/store/webhooks.go
+++ b/internal/store/webhooks.go
@@ -111,9 +111,14 @@ func (s *Store) ListWebhooks(workspaceID string) ([]models.Webhook, error) {
 	return result, rows.Err()
 }
 
-// DeleteWebhook removes a webhook by ID.
-func (s *Store) DeleteWebhook(id string) error {
-	result, err := s.db.Exec(s.q("DELETE FROM webhooks WHERE id = ?"), id)
+// DeleteWebhookScoped removes a webhook by ID, verifying it belongs to the given
+// workspace. Prevents cross-workspace deletion (TASK-266): an owner of one
+// workspace must not be able to delete another workspace's webhook by ID. The
+// scoped DELETE is also atomic and avoids decrypting the secret just to delete —
+// a rotated/missing encryption key would otherwise leave a broken webhook
+// undeletable. Returns sql.ErrNoRows when no webhook matches both id and workspace.
+func (s *Store) DeleteWebhookScoped(id, workspaceID string) error {
+	result, err := s.db.Exec(s.q("DELETE FROM webhooks WHERE id = ? AND workspace_id = ?"), id, workspaceID)
 	if err != nil {
 		return fmt.Errorf("delete webhook: %w", err)
 	}


### PR DESCRIPTION
## Summary

Closes the webhook + token half of **TASK-266** (part of the **PLAN-259** pre-open-source security audit). Surfaced by an adversarially-verified re-audit of the security cluster on 2026-07-15.

`handleDeleteWebhook`, `handleTestWebhook`, and `handleDeleteToken` resolved the URL workspace but then looked their object up **purely by ID** with no workspace-ownership predicate:

- `DeleteWebhook` → `DELETE FROM webhooks WHERE id = ?`
- `DeleteAPIToken` → `DELETE FROM api_tokens WHERE id = ?`
- `handleTestWebhook` → `GetWebhook(id)` then dispatch to `hook.WorkspaceID`

`requireMinRole("owner")` only proves the caller owns **the URL's** workspace — not that `{webhookID}`/`{tokenID}` lives in it. So **any owner of any workspace A could destroy workspace B's webhook / revoke B's token** by object ID via `/workspaces/A/...`, and `handleTestWebhook` doubled as a cross-workspace existence oracle + endpoint-spam primitive. Object IDs are visible to any owner/co-owner at creation and persist after a user is removed.

## Fix

Follows the existing pre-fetch-and-compare idiom already used by `handleDeleteWorkspaceAttachment` / views / comments / links (the other half of TASK-266, already scoped):

- **Webhooks** — pre-fetch via `GetWebhook`, `404` unless `hook.WorkspaceID == workspaceID`, on both the delete and test paths.
- **Tokens** — new `store.DeleteAPITokenScoped(id, workspaceID)` = `DELETE ... WHERE id = ? AND workspace_id = ?`, mirroring the existing `DeleteUserAPIToken`. The unscoped `DeleteAPIToken` (whose only caller was the vulnerable handler) is removed so the footgun can't be reused.

## Test

`TestWebhookTokenCrossWorkspaceIDOR`: an owner of workspace B cannot delete/test A's webhook or revoke A's token via B's URL (expects `404`, asserts the victim objects **survive**), while the legitimate owner still can within their own workspace.

- Verified **red before / green after** — without the fix the cross-workspace delete returns `204` and actually destroys the victim webhook.
- Full `internal/server` and `internal/store` suites pass; `gofmt` + `go vet` clean.

## Scope / follow-ups

Only the webhook + token IDOR. The other two remaining PLAN-259 items are tracked separately: **TASK-265** (collab WebSocket lacks an editor-role gate) and **TASK-264** (SSE UUID-form entry membership check). The rest of the cluster (search scoping, invitation hardening, secure cookies, comment-XSS, bootstrap lockdown) was verified already-shipped and closed.

https://claude.ai/code/session_01EZ6yr6pAUFb1uffan912ra