### PR TITLE
fix(security): require workspace membership on SSE subscriptions (TASK-264)

### DIFF
--- a/internal/server/handlers_events.go
+++ b/internal/server/handlers_events.go
@@ -100,6 +100,50 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Entry membership/grant gate for regular (non-admin) users (TASK-264).
+	// resolveWorkspace resolves a UUID ?workspace= param via the GLOBAL,
+	// unscoped GetWorkspaceByID lookup (server.go), so an authenticated
+	// non-member passing another workspace's UUID reaches this point with a
+	// fully-resolved ws — even though the slug form is membership-scoped
+	// (GetWorkspacesBySlugForUser → nil → the 404 above). Events are still
+	// fail-closed filtered by computeSSEVisibility and the stream is torn
+	// down within ~60s by the revalidation tick, so this is not a data leak,
+	// but the open connection is a connection-slot DoS and a
+	// workspace-existence oracle (200+connected vs 404). Gate the entry
+	// exactly like RequireWorkspaceAccess / authorizeCollabAccess: admit
+	// only direct members or guest-grant holders.
+	//
+	// Scope of this branch:
+	//   - admin-via-cookie (web UI) keeps its platform-wide bypass, matching
+	//     resolveWorkspace's global admin slug lookup and BUG-1616's carve-out;
+	//   - admin-via-bearer (CLI / PAT / MCP) was already gated by the branch
+	//     above (membership-only), so we skip it here to avoid a redundant query;
+	//   - the legacy workspace-scoped token (no user context) was gated by the
+	//     branch above that;
+	//   - the fresh-install / no-auth path has currentUser(r) == nil, so it
+	//     falls through untouched.
+	// On failure return 404 (not 403) so the stream reveals nothing about the
+	// workspace's existence — matching the slug path and the not-found branch above.
+	if u := currentUser(r); u != nil && u.Role != "admin" {
+		member, err := s.store.GetWorkspaceMember(ws.ID, u.ID)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "internal_error", "Failed to check workspace access")
+			return
+		}
+		if member == nil {
+			hasGrants, grantErr := s.store.UserHasGrantsInWorkspace(ws.ID, u.ID)
+			if grantErr != nil {
+				writeError(w, http.StatusInternalServerError, "internal_error", "Failed to check workspace access")
+				return
+			}
+			if !hasGrants {
+				s.recordMCPAuthzDenial(r, "not_a_member")
+				writeError(w, http.StatusNotFound, "not_found", "Workspace not found")
+				return
+			}
+		}
+	}
+
 	// Verify streaming support
 	flusher, ok := w.(http.Flusher)
 	if !ok {

--- a/internal/server/handlers_events_membership_test.go
+++ b/internal/server/handlers_events_membership_test.go
@@ -1,0 +1,120 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// TestSSEEntryRequiresMembership is the TASK-264 regression: the SSE
+// entry gate must reject an authenticated NON-member for BOTH the
+// ?workspace=<slug> and ?workspace=<uuid> forms with a 404 (not 403 —
+// a 403 would itself be a workspace-existence oracle), while a
+// legitimate member still connects (200 + the initial "connected"
+// event).
+//
+// The UUID form is the one the pre-fix handler leaked: resolveWorkspace
+// resolves a UUID ?workspace= param via the global, unscoped
+// GetWorkspaceByID, so a non-member reached SubscribeIfAllowed with a
+// fully-resolved workspace (a connection-slot DoS + existence oracle).
+// The slug form was already membership-scoped
+// (GetWorkspacesBySlugForUser → nil → 404); we assert it too so the two
+// forms can never silently drift apart.
+//
+// Every subtest drives handleSSE with a short-deadline context so the
+// live-stream select loop unblocks and the synchronous call returns
+// even when the handler admits the connection.
+func TestSSEEntryRequiresMembership(t *testing.T) {
+	srv := testServerWithEvents(t)
+
+	owner, err := srv.store.CreateUser(models.UserCreate{
+		Email: "owner@example.com", Name: "Owner", Password: "correct-horse-battery-staple", Role: "member",
+	})
+	if err != nil {
+		t.Fatalf("create owner: %v", err)
+	}
+	outsider, err := srv.store.CreateUser(models.UserCreate{
+		Email: "outsider@example.com", Name: "Outsider", Password: "correct-horse-battery-staple", Role: "member",
+	})
+	if err != nil {
+		t.Fatalf("create outsider: %v", err)
+	}
+
+	ws, err := srv.store.CreateWorkspace(models.WorkspaceCreate{Name: "PrivateWS"})
+	if err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	if err := srv.store.AddWorkspaceMember(ws.ID, owner.ID, "owner"); err != nil {
+		t.Fatalf("add owner member: %v", err)
+	}
+
+	// mkReq builds a GET /api/v1/events request carrying the given user
+	// in context (mirroring what the auth middleware would set) and a
+	// bounded deadline so an admitted stream returns instead of hanging.
+	mkReq := func(u *models.User, wsParam string) (*http.Request, context.CancelFunc) {
+		ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
+		if u != nil {
+			ctx = context.WithValue(ctx, ctxCurrentUser, u)
+		}
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/events?workspace="+wsParam, nil)
+		return req.WithContext(ctx), cancel
+	}
+
+	// Non-member via SLUG → 404. resolveWorkspace's membership-scoped
+	// slug lookup returns nil for an outsider, so the existing not-found
+	// branch already covers this form.
+	t.Run("non-member via slug rejected with 404", func(t *testing.T) {
+		req, cancel := mkReq(outsider, ws.Slug)
+		defer cancel()
+		rr := httptest.NewRecorder()
+		srv.handleSSE(rr, req)
+		if rr.Code != http.StatusNotFound {
+			t.Fatalf("non-member via slug: got %d, want 404; body=%q", rr.Code, rr.Body.String())
+		}
+		if strings.Contains(rr.Body.String(), "connected") {
+			t.Fatalf("non-member via slug must not receive a connected event; body=%q", rr.Body.String())
+		}
+	})
+
+	// Non-member via UUID → 404. This is the TASK-264 gap: resolveWorkspace
+	// resolves the UUID globally via GetWorkspaceByID, so without the
+	// explicit entry-gate the outsider would get 200 + connected.
+	t.Run("non-member via uuid rejected with 404", func(t *testing.T) {
+		req, cancel := mkReq(outsider, ws.ID)
+		defer cancel()
+		rr := httptest.NewRecorder()
+		srv.handleSSE(rr, req)
+		if rr.Code != http.StatusNotFound {
+			t.Fatalf("non-member via uuid: got %d, want 404; body=%q", rr.Code, rr.Body.String())
+		}
+		if strings.Contains(rr.Body.String(), "connected") {
+			t.Fatalf("non-member via uuid must not receive a connected event; body=%q", rr.Body.String())
+		}
+		// No connection slot may be consumed by a rejected non-member.
+		if got := srv.events.SubscriberCount(); got != 0 {
+			t.Fatalf("rejected non-member must not subscribe; SubscriberCount=%d, want 0", got)
+		}
+	})
+
+	// Legitimate member → 200 + connected. Drives the streaming handler
+	// under the bounded deadline; the initial connected event is written
+	// before the select loop, so it is present by the time the call
+	// returns.
+	t.Run("member connects with 200 + connected", func(t *testing.T) {
+		req, cancel := mkReq(owner, ws.Slug)
+		defer cancel()
+		rr := httptest.NewRecorder()
+		srv.handleSSE(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("member: got %d, want 200; body=%q", rr.Code, rr.Body.String())
+		}
+		if !strings.Contains(rr.Body.String(), "event: connected") {
+			t.Fatalf("member should receive the initial connected event; body=%q", rr.Body.String())
+		}
+	})
+}


### PR DESCRIPTION
## Root cause

`handleSSE` (`GET /api/v1/events?workspace=`) resolves the workspace via `resolveWorkspace(slug, currentUser(r))`. The **slug** form is membership-scoped — `GetWorkspacesBySlugForUser` returns nil for a non-member → 404. But the **UUID** form (`?workspace=<uuid>`) resolves through the GLOBAL, unscoped `GetWorkspaceByID`. So an authenticated **non-member** passing another workspace's UUID reached `SubscribeIfAllowed` with a fully-resolved workspace and **no explicit membership check** for a regular (non-admin) user.

Events are still fail-closed filtered by `computeSSEVisibility` and the stream is torn down within ~60s by the membership revalidation tick, so this is **not a data leak**. But the open connection is:
- a **connection-slot DoS** (a non-member can hold SSE slots against an arbitrary workspace), and
- a **workspace-existence oracle** (`200` + `connected` vs `404`).

It also diverged from the explicit membership gate that `RequireWorkspaceAccess` (`/api/v1/*`) and the collab sibling `authorizeCollabAccess` (WS upgrade) already enforce.

## Fix

Add an entry membership/grant gate in `handleSSE`, after the workspace is resolved and before `SubscribeIfAllowed`, for regular (non-admin) user-context callers — mirroring `RequireWorkspaceAccess` / `authorizeCollabAccess`:

- admit only direct workspace **members** (`GetWorkspaceMember`) **or** **guest-grant** holders (`UserHasGrantsInWorkspace`);
- otherwise return **404** (not 403 — a 403 would itself be an existence oracle, and 404 matches the slug path and the existing not-found branch);
- fail **closed** (500) on a store error.

Preserved untouched (each handled by a pre-existing branch above):
- **admin-via-cookie** (web UI) keeps its platform-wide bypass;
- **admin-via-bearer** (CLI / PAT / MCP) — already gated membership-only above (BUG-1616);
- **legacy workspace-scoped token** (no user context) — gated above;
- **fresh-install / no-auth** — `currentUser(r) == nil`, falls through.

The change is a minimal entry-gate addition; `computeSSEVisibility` fail-closed filtering and the ~60s revalidation teardown are unchanged.

## Tests

`TestSSEEntryRequiresMembership` (`internal/server/handlers_events_membership_test.go`) asserts:
- a regular non-admin **non-member** is rejected with **404** at the SSE entry for **both** the `?workspace=<slug>` and `?workspace=<uuid>` forms (and consumes **no** connection slot);
- a legitimate **member** still connects (**200** + initial `connected` event).

Confirmed the UUID subtest goes **red** against the unfixed handler (got `200` + `connected`) and **green** after the fix.

## Gates

- `go build ./...` OK
- `gofmt -l` (changed files) clean · `go vet ./internal/server/...` OK
- `golangci-lint run ./internal/server/...` — 0 issues
- `go test ./internal/server/ -count=1` — pass
- Codex review: **CLEAN**

## Note (out of scope, flagged)

The audit also flagged a latent sibling: SSE does not apply the OAuth **consent allow-list**. That was deliberately deferred by the audit and is not part of TASK-264's narrowed scope; not addressed here.

https://claude.ai/code/session_01EZ6yr6pAUFb1uffan912ra