### PR TITLE
fix(security): gate collab WebSocket writes on editor role (TASK-265)

### DIFF
--- a/internal/collab/applier.go
+++ b/internal/collab/applier.go
@@ -301,6 +301,18 @@ func (r *Room) pickApplier(tried map[*websocket.Conn]struct{}) *roomConn {
 		if _, skip := tried[rc.conn]; skip {
 			continue
 		}
+		// Read-only participants (workspace viewers / view-only guests,
+		// TASK-265) are never eligible appliers: the applier applies the
+		// external markdown by producing Y.Doc sync frames, which the
+		// read-only gate drops, so an elected viewer would ack a
+		// no-op and make ApplyExternalContent falsely report success —
+		// the PATCH handler would then skip its direct-write fallback
+		// and the edit would be silently lost. Skip them so election
+		// only ever lands on a writer (or returns nil → the caller's
+		// direct-write fallback fires).
+		if !rc.canWrite.Load() {
+			continue
+		}
 		candidates = append(candidates, rc)
 	}
 	r.mu.Unlock()

--- a/internal/collab/applier_test.go
+++ b/internal/collab/applier_test.go
@@ -431,6 +431,78 @@ func TestApplyExternalContentRejectsAckFromUnexpectedConn(t *testing.T) {
 	}
 }
 
+// TestApplyExternalContentSkipsReadOnlyApplier is a TASK-265
+// regression: a read-only participant must NEVER be elected applier.
+// If it were, it would ack a no-op — its resulting Y.Doc sync frames
+// are dropped by the read-only gate — and ApplyExternalContent would
+// falsely return nil, making the PATCH handler skip its direct-write
+// fallback and silently lose the external edit. With the only conn
+// read-only, pickApplier finds no candidate → ErrNoApplierAvailable,
+// so the caller falls back to a direct write (no loss). The conn even
+// runs an honest ack-echo to prove that a *willing* but unauthorized
+// applier is still never asked.
+func TestApplyExternalContentSkipsReadOnlyApplier(t *testing.T) {
+	bus := NewMemoryOpBus()
+	defer bus.Close()
+	mgr := NewRoomManager(&fakeOpLog{}, bus)
+	defer mgr.Close()
+
+	srv := newCollabTestServer(t, mgr)
+	defer srv.Close()
+
+	conn := dialWSReadOnly(t, srv, "item-a")
+	stop := runApplierEcho(t, conn)
+	defer stop()
+
+	// Wait for the room to register the read-only conn.
+	for i := 0; i < 200; i++ {
+		if mgr.RoomCount() == 1 && bus.SubscriberCount("item-a") == 1 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	err := mgr.ApplyExternalContent("item-a", "# new content")
+	if !errors.Is(err, ErrNoApplierAvailable) {
+		t.Fatalf("read-only-only room: want ErrNoApplierAvailable (so the caller direct-writes), got %v", err)
+	}
+}
+
+// TestHandleControlMessageIgnoresAckFromReadOnlyConn is the
+// defence-in-depth half of the TASK-265 applier fix: even if a
+// read-only conn somehow holds a pending-ack slot (e.g. an editor
+// demoted after being elected), an applier_ack from it must be
+// ignored so ApplyExternalContent doesn't report a phantom success.
+func TestHandleControlMessageIgnoresAckFromReadOnlyConn(t *testing.T) {
+	bus := NewMemoryOpBus()
+	defer bus.Close()
+	mgr := NewRoomManager(&fakeOpLog{}, bus)
+	defer mgr.Close()
+
+	room := mgr.getOrCreate("item-a")
+
+	// Read-only conn: canWrite defaults to false. The conn pointer is
+	// only used for identity (pending-ack expectedConn match); no I/O
+	// happens on it because the ack is rejected before routeApplierAck.
+	rc := &roomConn{id: 1, conn: &websocket.Conn{}}
+
+	reqID := "req-readonly"
+	ch, err := room.registerPendingAck(reqID, rc.conn)
+	if err != nil {
+		t.Fatalf("registerPendingAck: %v", err)
+	}
+
+	payload, _ := json.Marshal(ControlMessage{Type: ControlMessageApplierAck, RequestID: reqID})
+	room.handleControlMessage(rc, payload)
+
+	select {
+	case <-ch:
+		t.Fatal("applier_ack from a read-only conn must be ignored, but it signaled the pending ack")
+	case <-time.After(50 * time.Millisecond):
+		// Correct: the ack was dropped before routeApplierAck.
+	}
+}
+
 // swapApplierTimeouts is a small test-only mutator. The package
 // constants are *not* exported as vars so the swap goes through a
 // dedicated helper that lives only in test builds. We accept a

--- a/internal/collab/applier_test.go
+++ b/internal/collab/applier_test.go
@@ -503,6 +503,89 @@ func TestHandleControlMessageIgnoresAckFromReadOnlyConn(t *testing.T) {
 	}
 }
 
+// TestPruneAndApplyEvictsReadOnlyRoom is the TASK-265 / Codex-round-2
+// regression: a room whose only peers are read-only must NOT block the
+// no-applier direct write. PruneAndApply runs applyFn (prune + write)
+// and then evicts the read-only peers so their stale in-memory Y.Doc
+// can't survive into a later promotion-to-editor and clobber the
+// external update. Before the fix, live viewers made PruneAndApply
+// return ErrRoomActiveDuringPrune, forcing the caller onto an
+// unlocked, un-pruned direct write that a fresh editor would overwrite.
+func TestPruneAndApplyEvictsReadOnlyRoom(t *testing.T) {
+	bus := NewMemoryOpBus()
+	defer bus.Close()
+	mgr := NewRoomManager(&fakeOpLog{}, bus)
+	defer mgr.Close()
+
+	srv := newCollabTestServer(t, mgr)
+	defer srv.Close()
+
+	conn := dialWSReadOnly(t, srv, "item-a")
+	defer conn.Close()
+
+	for i := 0; i < 200; i++ {
+		if mgr.RoomCount() == 1 && bus.SubscriberCount("item-a") == 1 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	ran := false
+	if err := mgr.PruneAndApply("item-a", func() error { ran = true; return nil }); err != nil {
+		t.Fatalf("read-only-only room: want nil (prune allowed), got %v", err)
+	}
+	if !ran {
+		t.Fatal("applyFn did not run — a read-only peer wrongly blocked the prune")
+	}
+
+	// The read-only conn must be evicted: its bus subscription drops
+	// once its server-side readLoop unwinds after the close.
+	evicted := false
+	for i := 0; i < 200; i++ {
+		if bus.SubscriberCount("item-a") == 0 {
+			evicted = true
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if !evicted {
+		t.Fatal("read-only conn was not evicted after the no-applier prune")
+	}
+}
+
+// TestPruneAndApplyBlockedByLiveWriter confirms the complementary
+// invariant: a live WRITER still blocks the prune (ErrRoomActiveDuringPrune)
+// so the caller routes the external update through the applier protocol
+// rather than clobbering the writer's in-memory Y.Doc.
+func TestPruneAndApplyBlockedByLiveWriter(t *testing.T) {
+	bus := NewMemoryOpBus()
+	defer bus.Close()
+	mgr := NewRoomManager(&fakeOpLog{}, bus)
+	defer mgr.Close()
+
+	srv := newCollabTestServer(t, mgr)
+	defer srv.Close()
+
+	conn := dialWS(t, srv, "item-a") // writer (canWrite=true)
+	defer conn.Close()
+
+	for i := 0; i < 200; i++ {
+		if bus.SubscriberCount("item-a") == 1 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	ran := false
+	err := mgr.PruneAndApply("item-a", func() error { ran = true; return nil })
+	if !errors.Is(err, ErrRoomActiveDuringPrune) {
+		t.Fatalf("want ErrRoomActiveDuringPrune with a live writer, got %v", err)
+	}
+	if ran {
+		t.Fatal("applyFn must not run while a live writer is present")
+	}
+}
+
 // swapApplierTimeouts is a small test-only mutator. The package
 // constants are *not* exported as vars so the swap goes through a
 // dedicated helper that lives only in test builds. We accept a

--- a/internal/collab/applier_test.go
+++ b/internal/collab/applier_test.go
@@ -503,15 +503,15 @@ func TestHandleControlMessageIgnoresAckFromReadOnlyConn(t *testing.T) {
 	}
 }
 
-// TestPruneAndApplyEvictsReadOnlyRoom is the TASK-265 / Codex-round-2
-// regression: a room whose only peers are read-only must NOT block the
-// no-applier direct write. PruneAndApply runs applyFn (prune + write)
-// and then evicts the read-only peers so their stale in-memory Y.Doc
-// can't survive into a later promotion-to-editor and clobber the
-// external update. Before the fix, live viewers made PruneAndApply
-// return ErrRoomActiveDuringPrune, forcing the caller onto an
-// unlocked, un-pruned direct write that a fresh editor would overwrite.
-func TestPruneAndApplyEvictsReadOnlyRoom(t *testing.T) {
+// TestPruneAndApplyAllowsReadOnlyRoom verifies the load-bearing
+// writer-aware guard (TASK-265): a room whose only peers are read-only
+// must NOT block the no-applier direct write. PruneAndApply runs applyFn
+// (prune + write) rather than returning ErrRoomActiveDuringPrune, so the
+// op-log is safely pruned even with viewers attached and a later editor
+// lazy-seeds from the fresh items.content. (Read-only peers keep a
+// possibly-stale Y.Doc until they reconnect/refresh — an accepted
+// best-effort residual tracked in BUG-2103.)
+func TestPruneAndApplyAllowsReadOnlyRoom(t *testing.T) {
 	bus := NewMemoryOpBus()
 	defer bus.Close()
 	mgr := NewRoomManager(&fakeOpLog{}, bus)
@@ -536,20 +536,6 @@ func TestPruneAndApplyEvictsReadOnlyRoom(t *testing.T) {
 	}
 	if !ran {
 		t.Fatal("applyFn did not run — a read-only peer wrongly blocked the prune")
-	}
-
-	// The read-only conn must be evicted: its bus subscription drops
-	// once its server-side readLoop unwinds after the close.
-	evicted := false
-	for i := 0; i < 200; i++ {
-		if bus.SubscriberCount("item-a") == 0 {
-			evicted = true
-			break
-		}
-		time.Sleep(5 * time.Millisecond)
-	}
-	if !evicted {
-		t.Fatal("read-only conn was not evicted after the no-applier prune")
 	}
 }
 

--- a/internal/collab/manager.go
+++ b/internal/collab/manager.go
@@ -725,67 +725,48 @@ func (m *RoomManager) UnderItemLock(itemID string, fn func() error) error {
 // Y.Doc state that later overwrites the freshly-written
 // items.content on the next idle flush. Per Codex review round 5.
 //
-// Only a live WRITER peer blocks the prune (TASK-265, Codex round 2).
-// A read-only peer (workspace viewer / view-only guest) can never
-// persist — its sync frames are dropped and it can't be an applier —
-// so its presence does NOT force the caller onto the unsafe
-// direct-write-without-prune fallback. Instead, after the prune +
-// write, read-only peers are EVICTED (closeReadOnlyConns) so their
-// now-stale in-memory Y.Doc can't linger: without eviction a viewer
-// later promoted to editor would flush that stale state over the
-// external update, and a fresh editor would replay the un-pruned stale
-// op-log. Evicted viewers reconnect and lazy-seed from the fresh
-// items.content.
+// Only a live WRITER peer blocks the prune (TASK-265). A read-only
+// peer (workspace viewer / view-only guest) can never persist — its
+// sync frames are dropped and it can't be an applier — so its presence
+// does NOT force the caller onto the unsafe direct-write-without-prune
+// fallback: the op-log is safely pruned even while viewers are
+// attached, so a later editor lazy-seeds from the fresh items.content
+// instead of replaying stale ops.
+//
+// ACCEPTED RESIDUAL (TASK-265 / BUG-2103): connected read-only peers
+// keep a possibly-stale in-memory Y.Doc after this direct write until
+// their next reconnect/refresh (their resume cursor now sits below the
+// pruned op-log's MIN, so a reconnect force_refreshes and re-seeds). A
+// viewer promoted to editor BEFORE re-syncing could push that stale
+// content — a lost-update edge, not a security hole (a promoted viewer
+// is a legitimate editor). This is best-effort degradation consistent
+// with the pre-existing direct-write contract (see applier.go); a
+// proactive re-seed/refresh to remaining read-only peers is tracked in
+// BUG-2103.
 func (m *RoomManager) PruneAndApply(itemID string, applyFn func() error) error {
 	lock := m.itemLock(itemID)
 	lock.Lock()
 	defer lock.Unlock()
 
+	// Re-verify under the lock: only a live WRITER conn blocks the
+	// prune (its Y.Doc would diverge from the emptied op-log) — route
+	// through the applier protocol instead. A read-only conn can't
+	// persist, so it does NOT block (see the accepted residual above).
 	m.mu.Lock()
 	room := m.rooms[itemID]
 	m.mu.Unlock()
-
-	if room == nil {
-		// No room / no peers — nothing can race the prune + write.
-		return applyFn()
-	}
-
-	// Hold appendMu across the ENTIRE sequence — writer classification,
-	// applyFn (prune + write), and read-only eviction. appendMu is the
-	// same lock readLoop takes across its canWrite-check + persist and
-	// SetConnWritable takes when flipping canWrite, so holding it makes
-	// this whole operation atomic w.r.t. both. Without it, a concurrent
-	// viewer→editor revalidation could set canWrite=true AFTER the
-	// writer check, append a stale frame during the prune/write, and —
-	// being a writer now — evade closeReadOnlyConns, racing the prune
-	// and leaving a live stale Y.Doc. Per TASK-265 (Codex round 3).
-	room.appendMu.Lock()
-	defer room.appendMu.Unlock()
-
-	// Re-verify: if a live WRITER conn is present, refuse to prune
-	// (that peer's Y.Doc would diverge from the emptied op-log) — route
-	// through the applier protocol instead. Read-only conns don't block
-	// (they can't persist) but are evicted after the write, below.
-	room.mu.Lock()
-	for _, rc := range room.conns {
-		if rc.canWrite.Load() {
-			room.mu.Unlock()
-			return ErrRoomActiveDuringPrune
+	if room != nil {
+		room.mu.Lock()
+		for _, rc := range room.conns {
+			if rc.canWrite.Load() {
+				room.mu.Unlock()
+				return ErrRoomActiveDuringPrune
+			}
 		}
-	}
-	room.mu.Unlock()
-
-	if err := applyFn(); err != nil {
-		return err
+		room.mu.Unlock()
 	}
 
-	// Prune + write succeeded. Evict the read-only peers so they
-	// re-seed from the fresh items.content (their stale Y.Doc is now
-	// inert but would otherwise survive a later promotion-to-editor).
-	// Still under appendMu, so the eviction (which marks each conn
-	// terminally read-only) can't race a post-check promotion.
-	room.closeReadOnlyConns()
-	return nil
+	return applyFn()
 }
 
 // closeFrameDeadline is the absolute time budget for sending a

--- a/internal/collab/manager.go
+++ b/internal/collab/manager.go
@@ -748,23 +748,41 @@ func (m *RoomManager) PruneAndApply(itemID string, applyFn func() error) error {
 	lock.Lock()
 	defer lock.Unlock()
 
+	m.mu.Lock()
+	room := m.rooms[itemID]
+	m.mu.Unlock()
+
+	if room == nil {
+		// No room / no peers — nothing can race the prune + write.
+		return applyFn()
+	}
+
+	// Hold appendMu across the writer-scan AND applyFn so the
+	// classification and the prune+write are atomic w.r.t. a concurrent
+	// viewer→editor promotion. appendMu is the same lock readLoop takes
+	// across its canWrite-check+persist and SetConnWritable takes when
+	// flipping canWrite; without holding it here a viewer promoted right
+	// after the scan could append a stale frame while the op-log is
+	// pruned and content is written (a persist/prune ordering data
+	// race). No socket I/O happens under this lock, and applyFn is a
+	// pure store op (prune + UpdateItem) that never re-enters itemLock /
+	// appendMu / room.mu, so there's no inversion or re-entrant
+	// deadlock. Lock order: itemLock → appendMu → room.mu. Per TASK-265.
+	room.appendMu.Lock()
+	defer room.appendMu.Unlock()
+
 	// Re-verify under the lock: only a live WRITER conn blocks the
 	// prune (its Y.Doc would diverge from the emptied op-log) — route
 	// through the applier protocol instead. A read-only conn can't
 	// persist, so it does NOT block (see the accepted residual above).
-	m.mu.Lock()
-	room := m.rooms[itemID]
-	m.mu.Unlock()
-	if room != nil {
-		room.mu.Lock()
-		for _, rc := range room.conns {
-			if rc.canWrite.Load() {
-				room.mu.Unlock()
-				return ErrRoomActiveDuringPrune
-			}
+	room.mu.Lock()
+	for _, rc := range room.conns {
+		if rc.canWrite.Load() {
+			room.mu.Unlock()
+			return ErrRoomActiveDuringPrune
 		}
-		room.mu.Unlock()
 	}
+	room.mu.Unlock()
 
 	return applyFn()
 }

--- a/internal/collab/manager.go
+++ b/internal/collab/manager.go
@@ -168,10 +168,18 @@ var ErrForceRefreshSent = errors.New("collab: client cursor below op-log MIN; fo
 // The handler's periodic revalidation can update this mid-session via
 // SetConnWritable (editor⇄viewer role change).
 //
+// `onRegistered`, when non-nil, is invoked exactly once immediately
+// after the conn has been added to the room's conn map (so a
+// concurrent SetConnWritable can find it). The handler uses it to gate
+// the start of its revalidation loop, closing the startup-window race
+// where a demotion observed before registration would no-op. It is NOT
+// called on the bail-out paths (schema rebuild, force_refresh, manager
+// closed, retries) that return before addConn succeeds. Per TASK-265.
+//
 // Returns whatever error caused the WebSocket to close, or nil on a
 // normal close. The handler typically logs but doesn't act on the
 // return value: the connection is gone either way.
-func (m *RoomManager) Join(itemID string, conn *websocket.Conn, since int64, canWrite bool) error {
+func (m *RoomManager) Join(itemID string, conn *websocket.Conn, since int64, canWrite bool, onRegistered func()) error {
 	// Gate Add on the closed flag under m.mu so a late Join (e.g. a
 	// hijacked WS handler that didn't enter Join until AFTER Close
 	// returned) can't sneak past the drain barrier.
@@ -274,6 +282,13 @@ func (m *RoomManager) Join(itemID string, conn *websocket.Conn, since int64, can
 				continue
 			}
 			return err
+		}
+
+		// Conn is now registered in the room's conn map (SetConnWritable
+		// can find it). Signal the handler so it can start revalidation
+		// without racing this setup. Per TASK-265.
+		if onRegistered != nil {
+			onRegistered()
 		}
 
 		return m.runConn(room, rc, itemLock, since)
@@ -790,9 +805,16 @@ func (m *RoomManager) CloseConn(itemID string, conn *websocket.Conn, code int, r
 // access downgrades the conn to read-only rather than evicting it.
 //
 // No-op when the conn is nil or the room / conn has already been torn
-// down (a disconnect that raced the reval tick). The flag is an
-// atomic.Bool so this write is safe against readLoop's concurrent
-// read. Per TASK-265.
+// down (a disconnect that raced the reval tick).
+//
+// The flag is an atomic.Bool AND the store happens under the room's
+// appendMu — the same lock readLoop holds across its (now
+// under-appendMu) canWrite check + persist. That fencing means a
+// demotion can't interleave with an in-flight frame: readLoop either
+// runs the whole check+persist before this store, or observes the new
+// value and drops the frame. Room lookup (m.mu) and conn lookup
+// (room.mu) are released before appendMu is taken, so no lock nesting
+// is introduced. Per TASK-265.
 func (m *RoomManager) SetConnWritable(itemID string, conn *websocket.Conn, canWrite bool) {
 	if conn == nil {
 		return
@@ -806,9 +828,12 @@ func (m *RoomManager) SetConnWritable(itemID string, conn *websocket.Conn, canWr
 	room.mu.Lock()
 	rc := room.conns[conn]
 	room.mu.Unlock()
-	if rc != nil {
-		rc.canWrite.Store(canWrite)
+	if rc == nil {
+		return
 	}
+	room.appendMu.Lock()
+	rc.canWrite.Store(canWrite)
+	room.appendMu.Unlock()
 }
 
 // Close stops every active room AND blocks until every in-flight

--- a/internal/collab/manager.go
+++ b/internal/collab/manager.go
@@ -741,33 +741,50 @@ func (m *RoomManager) PruneAndApply(itemID string, applyFn func() error) error {
 	lock.Lock()
 	defer lock.Unlock()
 
-	// Re-verify under the lock: if a room with a live WRITER conn has
-	// appeared, refuse to prune (that peer's Y.Doc would diverge from
-	// an empty op-log). Read-only conns don't block — see below.
 	m.mu.Lock()
 	room := m.rooms[itemID]
 	m.mu.Unlock()
-	if room != nil {
-		room.mu.Lock()
-		for _, rc := range room.conns {
-			if rc.canWrite.Load() {
-				room.mu.Unlock()
-				return ErrRoomActiveDuringPrune
-			}
-		}
-		room.mu.Unlock()
+
+	if room == nil {
+		// No room / no peers — nothing can race the prune + write.
+		return applyFn()
 	}
+
+	// Hold appendMu across the ENTIRE sequence — writer classification,
+	// applyFn (prune + write), and read-only eviction. appendMu is the
+	// same lock readLoop takes across its canWrite-check + persist and
+	// SetConnWritable takes when flipping canWrite, so holding it makes
+	// this whole operation atomic w.r.t. both. Without it, a concurrent
+	// viewer→editor revalidation could set canWrite=true AFTER the
+	// writer check, append a stale frame during the prune/write, and —
+	// being a writer now — evade closeReadOnlyConns, racing the prune
+	// and leaving a live stale Y.Doc. Per TASK-265 (Codex round 3).
+	room.appendMu.Lock()
+	defer room.appendMu.Unlock()
+
+	// Re-verify: if a live WRITER conn is present, refuse to prune
+	// (that peer's Y.Doc would diverge from the emptied op-log) — route
+	// through the applier protocol instead. Read-only conns don't block
+	// (they can't persist) but are evicted after the write, below.
+	room.mu.Lock()
+	for _, rc := range room.conns {
+		if rc.canWrite.Load() {
+			room.mu.Unlock()
+			return ErrRoomActiveDuringPrune
+		}
+	}
+	room.mu.Unlock()
 
 	if err := applyFn(); err != nil {
 		return err
 	}
 
-	// Prune + write succeeded. Evict any read-only peers so they
+	// Prune + write succeeded. Evict the read-only peers so they
 	// re-seed from the fresh items.content (their stale Y.Doc is now
 	// inert but would otherwise survive a later promotion-to-editor).
-	if room != nil {
-		room.closeReadOnlyConns()
-	}
+	// Still under appendMu, so the eviction (which marks each conn
+	// terminally read-only) can't race a post-check promotion.
+	room.closeReadOnlyConns()
 	return nil
 }
 

--- a/internal/collab/manager.go
+++ b/internal/collab/manager.go
@@ -161,10 +161,17 @@ var ErrForceRefreshSent = errors.New("collab: client cursor below op-log MIN; fo
 // discard local Y.Doc state and reconnect with `?since=0`. Per
 // TASK-1319.
 //
+// `canWrite` reports whether this connection may PERSIST inbound sync
+// frames. A read-only participant (workspace viewer / view-only guest,
+// TASK-265) is admitted for live view + presence but its inbound sync
+// frames are dropped in readLoop rather than persisted/rebroadcast.
+// The handler's periodic revalidation can update this mid-session via
+// SetConnWritable (editor⇄viewer role change).
+//
 // Returns whatever error caused the WebSocket to close, or nil on a
 // normal close. The handler typically logs but doesn't act on the
 // return value: the connection is gone either way.
-func (m *RoomManager) Join(itemID string, conn *websocket.Conn, since int64) error {
+func (m *RoomManager) Join(itemID string, conn *websocket.Conn, since int64, canWrite bool) error {
 	// Gate Add on the closed flag under m.mu so a late Join (e.g. a
 	// hijacked WS handler that didn't enter Join until AFTER Close
 	// returned) can't sneak past the drain barrier.
@@ -252,6 +259,7 @@ func (m *RoomManager) Join(itemID string, conn *websocket.Conn, since int64) err
 			bus:         m.bus.Subscribe(itemID),
 			connectedAt: time.Now(),
 		}
+		rc.canWrite.Store(canWrite)
 
 		if err := room.addConn(rc); err != nil {
 			itemLock.Unlock()
@@ -770,6 +778,37 @@ func (m *RoomManager) CloseConn(itemID string, conn *websocket.Conn, code int, r
 	)
 	_ = conn.Close()
 	_ = itemID // reserved for future per-room metrics; see doc above
+}
+
+// SetConnWritable updates the write permission of a single live
+// connection mid-session. Called by the collab handler's periodic
+// authorization revalidation when a still-authorized peer's edit
+// permission changed — e.g. a workspace editor demoted to viewer (or
+// a viewer promoted to editor) — so readLoop's per-frame gate
+// reflects the current role without waiting for a reconnect. This is
+// the write-side complement of CloseConn: a demotion that keeps SOME
+// access downgrades the conn to read-only rather than evicting it.
+//
+// No-op when the conn is nil or the room / conn has already been torn
+// down (a disconnect that raced the reval tick). The flag is an
+// atomic.Bool so this write is safe against readLoop's concurrent
+// read. Per TASK-265.
+func (m *RoomManager) SetConnWritable(itemID string, conn *websocket.Conn, canWrite bool) {
+	if conn == nil {
+		return
+	}
+	m.mu.Lock()
+	room := m.rooms[itemID]
+	m.mu.Unlock()
+	if room == nil {
+		return
+	}
+	room.mu.Lock()
+	rc := room.conns[conn]
+	room.mu.Unlock()
+	if rc != nil {
+		rc.canWrite.Store(canWrite)
+	}
 }
 
 // Close stops every active room AND blocks until every in-flight

--- a/internal/collab/manager.go
+++ b/internal/collab/manager.go
@@ -712,8 +712,8 @@ func (m *RoomManager) UnderItemLock(itemID string, fn func() error) error {
 // classifies the request as "no live editors" (ErrNoActiveRoom or
 // ErrNoApplierAvailable).
 //
-// Returns ErrRoomActiveDuringPrune if a room with live conns has
-// appeared since the caller's classification check; otherwise the
+// Returns ErrRoomActiveDuringPrune if a room with a live WRITER conn
+// has appeared since the caller's classification check; otherwise the
 // error from applyFn (if any). The caller is expected to fall
 // through to a plain direct write in the active-room case so the
 // PATCH still completes.
@@ -724,27 +724,51 @@ func (m *RoomManager) UnderItemLock(itemID string, fn func() error) error {
 // soon-to-be-pruned op-log into a new client, and end up with stale
 // Y.Doc state that later overwrites the freshly-written
 // items.content on the next idle flush. Per Codex review round 5.
+//
+// Only a live WRITER peer blocks the prune (TASK-265, Codex round 2).
+// A read-only peer (workspace viewer / view-only guest) can never
+// persist — its sync frames are dropped and it can't be an applier —
+// so its presence does NOT force the caller onto the unsafe
+// direct-write-without-prune fallback. Instead, after the prune +
+// write, read-only peers are EVICTED (closeReadOnlyConns) so their
+// now-stale in-memory Y.Doc can't linger: without eviction a viewer
+// later promoted to editor would flush that stale state over the
+// external update, and a fresh editor would replay the un-pruned stale
+// op-log. Evicted viewers reconnect and lazy-seed from the fresh
+// items.content.
 func (m *RoomManager) PruneAndApply(itemID string, applyFn func() error) error {
 	lock := m.itemLock(itemID)
 	lock.Lock()
 	defer lock.Unlock()
 
-	// Re-verify under the lock: if a room with live conns has
-	// appeared, refuse to prune (peers' Y.Doc would diverge from
-	// an empty op-log).
+	// Re-verify under the lock: if a room with a live WRITER conn has
+	// appeared, refuse to prune (that peer's Y.Doc would diverge from
+	// an empty op-log). Read-only conns don't block — see below.
 	m.mu.Lock()
-	hasLivePeers := false
-	if r, ok := m.rooms[itemID]; ok {
-		r.mu.Lock()
-		hasLivePeers = len(r.conns) > 0
-		r.mu.Unlock()
-	}
+	room := m.rooms[itemID]
 	m.mu.Unlock()
-	if hasLivePeers {
-		return ErrRoomActiveDuringPrune
+	if room != nil {
+		room.mu.Lock()
+		for _, rc := range room.conns {
+			if rc.canWrite.Load() {
+				room.mu.Unlock()
+				return ErrRoomActiveDuringPrune
+			}
+		}
+		room.mu.Unlock()
 	}
 
-	return applyFn()
+	if err := applyFn(); err != nil {
+		return err
+	}
+
+	// Prune + write succeeded. Evict any read-only peers so they
+	// re-seed from the fresh items.content (their stale Y.Doc is now
+	// inert but would otherwise survive a later promotion-to-editor).
+	if room != nil {
+		room.closeReadOnlyConns()
+	}
+	return nil
 }
 
 // closeFrameDeadline is the absolute time budget for sending a

--- a/internal/collab/manager_test.go
+++ b/internal/collab/manager_test.go
@@ -257,7 +257,7 @@ func newCollabTestServer(t *testing.T, mgr *RoomManager) *httptest.Server {
 				since = v
 			}
 		}
-		_ = mgr.Join(itemID, conn, since)
+		_ = mgr.Join(itemID, conn, since, true)
 	})
 	return httptest.NewServer(mux)
 }
@@ -702,7 +702,7 @@ func TestRoomManagerJoinAfterCloseFailsFast(t *testing.T) {
 
 	// Direct Join — bypass the WS plumbing since we want to exercise
 	// the closed-flag short-circuit in isolation.
-	err := mgr.Join("item-a", nil, 0) // conn is irrelevant; we never reach the WS path
+	err := mgr.Join("item-a", nil, 0, true) // conn is irrelevant; we never reach the WS path
 	if !errors.Is(err, errManagerClosed) {
 		t.Fatalf("want errManagerClosed, got %v", err)
 	}

--- a/internal/collab/manager_test.go
+++ b/internal/collab/manager_test.go
@@ -257,7 +257,10 @@ func newCollabTestServer(t *testing.T, mgr *RoomManager) *httptest.Server {
 				since = v
 			}
 		}
-		_ = mgr.Join(itemID, conn, since, true)
+		// `?readonly=1` joins as a read-only participant (canWrite=false)
+		// so tests can exercise the TASK-265 gate. Default is writable.
+		canWrite := r.URL.Query().Get("readonly") != "1"
+		_ = mgr.Join(itemID, conn, since, canWrite, nil)
 	})
 	return httptest.NewServer(mux)
 }
@@ -279,6 +282,19 @@ func dialWSSince(t *testing.T, server *httptest.Server, itemID string, since int
 	c, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
 	if err != nil {
 		t.Fatalf("dial: %v", err)
+	}
+	return c
+}
+
+// dialWSReadOnly joins as a read-only participant (canWrite=false) via
+// the harness's `?readonly=1` switch — for TASK-265 tests.
+func dialWSReadOnly(t *testing.T, server *httptest.Server, itemID string) *websocket.Conn {
+	t.Helper()
+	u, _ := url.Parse(server.URL)
+	wsURL := "ws://" + u.Host + "/ws/" + itemID + "?readonly=1"
+	c, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial readonly: %v", err)
 	}
 	return c
 }
@@ -702,7 +718,7 @@ func TestRoomManagerJoinAfterCloseFailsFast(t *testing.T) {
 
 	// Direct Join — bypass the WS plumbing since we want to exercise
 	// the closed-flag short-circuit in isolation.
-	err := mgr.Join("item-a", nil, 0, true) // conn is irrelevant; we never reach the WS path
+	err := mgr.Join("item-a", nil, 0, true, nil) // conn is irrelevant; we never reach the WS path
 	if !errors.Is(err, errManagerClosed) {
 		t.Fatalf("want errManagerClosed, got %v", err)
 	}

--- a/internal/collab/room.go
+++ b/internal/collab/room.go
@@ -90,15 +90,6 @@ type roomConn struct {
 	// Server-side mirror of the REST requireEditPermission gate
 	// (TASK-265).
 	canWrite atomic.Bool
-	// evicted is set (once, terminally) by closeReadOnlyConns when a
-	// no-applier direct write prunes the op-log out from under this
-	// read-only conn. readLoop's persist gate checks it IN ADDITION to
-	// canWrite so that a frame already read into the reader — and
-	// blocked on appendMu when the eviction ran — can't be persisted
-	// after the prune even if a racing revalidation promotes the conn
-	// to writer in the same instant. Set under appendMu (via
-	// PruneAndApply) so the gate observes it. Per TASK-265 (Codex round 3).
-	evicted atomic.Bool
 }
 
 // writeMessage is a tiny helper that holds writeMu while writing one
@@ -358,13 +349,7 @@ func (r *Room) readLoop(rc *roomConn) error {
 			// dropped. Without this fencing a reader could read
 			// canWrite=true, block on appendMu, and persist AFTER
 			// SetConnWritable(false) returned (TOCTOU).
-			//
-			// `evicted` is the same fence for the no-applier prune path
-			// (PruneAndApply → closeReadOnlyConns, also under appendMu):
-			// once this read-only conn's op-log has been pruned out from
-			// under it, its frames MUST NOT persist even if a racing
-			// revalidation promotes it to writer in the same instant.
-			if rc.evicted.Load() || !rc.canWrite.Load() {
+			if !rc.canWrite.Load() {
 				r.appendMu.Unlock()
 				continue
 			}
@@ -553,52 +538,6 @@ func (r *Room) closeAll() {
 	r.mu.Unlock()
 
 	for _, c := range conns {
-		_ = c.Close()
-	}
-}
-
-// closeReadOnlyConns force-closes every read-only connection currently
-// in the room. Called by RoomManager.PruneAndApply after a no-applier
-// direct write has pruned the op-log and written items.content: a
-// read-only peer's in-memory Y.Doc is now stale, and leaving it
-// connected would let a later promotion-to-editor flush that stale
-// state over the external update (TASK-265, Codex round 2). Read-only
-// peers never persisted anything, so eviction loses no edits — they
-// reconnect and lazy-seed from the fresh items.content (their old
-// resume cursor is now below the pruned op-log's MIN, so the reconnect
-// force_refreshes).
-//
-// The close frame goes out via WriteControl, which gorilla documents
-// as concurrency-safe with the room's writeLoop (a normal WriteMessage
-// would race it). Best-effort: a WriteControl / Close error just means
-// the conn was already going away. removeConn fires from each closed
-// conn's readLoop asynchronously; we deliberately don't wait for the
-// drain (this runs under the per-item setup lock).
-//
-// MUST be called with the room's appendMu held (PruneAndApply does).
-// Setting rc.evicted under appendMu — the same lock readLoop's persist
-// gate holds — guarantees any frame already read but blocked on
-// appendMu observes the eviction and is dropped, so a stale frame
-// can't slip into the freshly-pruned op-log even under a racing
-// promotion. Per TASK-265 (Codex round 3).
-func (r *Room) closeReadOnlyConns() {
-	r.mu.Lock()
-	targets := make([]*websocket.Conn, 0, len(r.conns))
-	for c, rc := range r.conns {
-		if !rc.canWrite.Load() {
-			rc.evicted.Store(true)
-			targets = append(targets, c)
-		}
-	}
-	r.mu.Unlock()
-
-	for _, c := range targets {
-		_ = c.WriteControl(
-			websocket.CloseMessage,
-			websocket.FormatCloseMessage(websocket.CloseServiceRestart,
-				"Content updated externally; reconnect to refresh."),
-			time.Now().Add(closeFrameDeadline),
-		)
 		_ = c.Close()
 	}
 }

--- a/internal/collab/room.go
+++ b/internal/collab/room.go
@@ -78,6 +78,18 @@ type roomConn struct {
 	// force_refresh path on empty-replay sessions and discard
 	// buffered pre-anchor edits. Per Codex round 21 [P1] of TASK-1319.
 	maxLiveOpLogIDDuringReplay atomic.Int64
+	// canWrite reports whether this connection may PERSIST inbound
+	// sync frames. Non-editor participants (workspace viewers,
+	// view-only guests) are admitted read-only — they still receive
+	// live broadcasts + presence, but readLoop drops their inbound
+	// sync frames (not persisted, not rebroadcast). Set at Join time
+	// from the collab authorization decision and flipped live by the
+	// manager's mid-session revalidation when the peer's edit
+	// permission changes (editor⇄viewer). atomic.Bool so the
+	// revalidation goroutine's write can't race readLoop's read.
+	// Server-side mirror of the REST requireEditPermission gate
+	// (TASK-265).
+	canWrite atomic.Bool
 }
 
 // writeMessage is a tiny helper that holds writeMu while writing one
@@ -310,6 +322,21 @@ func (r *Room) readLoop(rc *roomConn) error {
 
 		switch data[0] {
 		case yMessageSync:
+			// Read-only participants (workspace viewers / view-only
+			// guests, TASK-265) are admitted for live view + presence
+			// but MUST NOT mutate content. Drop their inbound sync
+			// frames here — these are the frames that would otherwise
+			// persist to item_yjs_updates and get canonicalized into
+			// items.content by a co-present editor's authorized flush.
+			// Awareness (presence) frames below are still relayed so
+			// the viewer's cursor stays visible to editors. This is
+			// the collab-side mirror of the REST requireEditPermission
+			// gate; the flag is re-evaluated by the handler's periodic
+			// revalidation so a mid-session demotion takes effect
+			// without a reconnect.
+			if !rc.canWrite.Load() {
+				continue
+			}
 			// Hold appendMu across the persist+publish sequence so we
 			// uphold TASK-1252's single-writer-per-item contract. The
 			// dumb-relay design intends one writer per Room, but each

--- a/internal/collab/room.go
+++ b/internal/collab/room.go
@@ -322,21 +322,6 @@ func (r *Room) readLoop(rc *roomConn) error {
 
 		switch data[0] {
 		case yMessageSync:
-			// Read-only participants (workspace viewers / view-only
-			// guests, TASK-265) are admitted for live view + presence
-			// but MUST NOT mutate content. Drop their inbound sync
-			// frames here — these are the frames that would otherwise
-			// persist to item_yjs_updates and get canonicalized into
-			// items.content by a co-present editor's authorized flush.
-			// Awareness (presence) frames below are still relayed so
-			// the viewer's cursor stays visible to editors. This is
-			// the collab-side mirror of the REST requireEditPermission
-			// gate; the flag is re-evaluated by the handler's periodic
-			// revalidation so a mid-session demotion takes effect
-			// without a reconnect.
-			if !rc.canWrite.Load() {
-				continue
-			}
 			// Hold appendMu across the persist+publish sequence so we
 			// uphold TASK-1252's single-writer-per-item contract. The
 			// dumb-relay design intends one writer per Room, but each
@@ -346,6 +331,28 @@ func (r *Room) readLoop(rc *roomConn) error {
 			// commit order). awareness frames and OTHER rooms are
 			// unaffected by this lock.
 			r.appendMu.Lock()
+			// Read-only participants (workspace viewers / view-only
+			// guests, TASK-265) are admitted for live view + presence
+			// but MUST NOT mutate content. Drop their inbound sync
+			// frames — these are the frames that would otherwise persist
+			// to item_yjs_updates and get canonicalized into
+			// items.content by a co-present editor's authorized flush.
+			// Awareness (presence) frames below are still relayed so the
+			// viewer's cursor stays visible to editors. This is the
+			// collab-side mirror of the REST requireEditPermission gate.
+			//
+			// The canWrite check is INSIDE appendMu and SetConnWritable
+			// takes appendMu when flipping the flag, so a demotion that
+			// races an in-flight frame can't slip between the check and
+			// the persist: either the frame's whole persist runs before
+			// the demotion, or the demotion is observed and the frame is
+			// dropped. Without this fencing a reader could read
+			// canWrite=true, block on appendMu, and persist AFTER
+			// SetConnWritable(false) returned (TOCTOU).
+			if !rc.canWrite.Load() {
+				r.appendMu.Unlock()
+				continue
+			}
 			// Persist before broadcast so a server crash between
 			// persist and broadcast loses at most a live keystroke
 			// that the originating peer will replay on reconnect
@@ -489,6 +496,21 @@ func (r *Room) handleControlMessage(rc *roomConn, data []byte) {
 	switch ctl.Type {
 	case ControlMessageApplierAck:
 		if ctl.RequestID == "" {
+			return
+		}
+		// A read-only participant can never be a legitimate applier —
+		// pickApplier excludes non-writers — so an applier_ack from a
+		// conn whose canWrite is false MUST be ignored (TASK-265).
+		// Otherwise a viewer (or an editor demoted mid-apply) could
+		// report a phantom success while its resulting sync frames were
+		// dropped by the read-only gate, making ApplyExternalContent
+		// return nil, skip the PATCH handler's direct-write fallback,
+		// and silently lose the external edit.
+		if !rc.canWrite.Load() {
+			slog.Warn("collab: applier_ack from read-only conn; ignoring",
+				"item_id", r.itemID,
+				"client_id", rc.id,
+			)
 			return
 		}
 		r.routeApplierAck(ctl.RequestID, rc.conn)

--- a/internal/collab/room.go
+++ b/internal/collab/room.go
@@ -90,6 +90,15 @@ type roomConn struct {
 	// Server-side mirror of the REST requireEditPermission gate
 	// (TASK-265).
 	canWrite atomic.Bool
+	// evicted is set (once, terminally) by closeReadOnlyConns when a
+	// no-applier direct write prunes the op-log out from under this
+	// read-only conn. readLoop's persist gate checks it IN ADDITION to
+	// canWrite so that a frame already read into the reader — and
+	// blocked on appendMu when the eviction ran — can't be persisted
+	// after the prune even if a racing revalidation promotes the conn
+	// to writer in the same instant. Set under appendMu (via
+	// PruneAndApply) so the gate observes it. Per TASK-265 (Codex round 3).
+	evicted atomic.Bool
 }
 
 // writeMessage is a tiny helper that holds writeMu while writing one
@@ -349,7 +358,13 @@ func (r *Room) readLoop(rc *roomConn) error {
 			// dropped. Without this fencing a reader could read
 			// canWrite=true, block on appendMu, and persist AFTER
 			// SetConnWritable(false) returned (TOCTOU).
-			if !rc.canWrite.Load() {
+			//
+			// `evicted` is the same fence for the no-applier prune path
+			// (PruneAndApply → closeReadOnlyConns, also under appendMu):
+			// once this read-only conn's op-log has been pruned out from
+			// under it, its frames MUST NOT persist even if a racing
+			// revalidation promotes it to writer in the same instant.
+			if rc.evicted.Load() || !rc.canWrite.Load() {
 				r.appendMu.Unlock()
 				continue
 			}
@@ -559,11 +574,19 @@ func (r *Room) closeAll() {
 // the conn was already going away. removeConn fires from each closed
 // conn's readLoop asynchronously; we deliberately don't wait for the
 // drain (this runs under the per-item setup lock).
+//
+// MUST be called with the room's appendMu held (PruneAndApply does).
+// Setting rc.evicted under appendMu — the same lock readLoop's persist
+// gate holds — guarantees any frame already read but blocked on
+// appendMu observes the eviction and is dropped, so a stale frame
+// can't slip into the freshly-pruned op-log even under a racing
+// promotion. Per TASK-265 (Codex round 3).
 func (r *Room) closeReadOnlyConns() {
 	r.mu.Lock()
 	targets := make([]*websocket.Conn, 0, len(r.conns))
 	for c, rc := range r.conns {
 		if !rc.canWrite.Load() {
+			rc.evicted.Store(true)
 			targets = append(targets, c)
 		}
 	}

--- a/internal/collab/room.go
+++ b/internal/collab/room.go
@@ -542,6 +542,44 @@ func (r *Room) closeAll() {
 	}
 }
 
+// closeReadOnlyConns force-closes every read-only connection currently
+// in the room. Called by RoomManager.PruneAndApply after a no-applier
+// direct write has pruned the op-log and written items.content: a
+// read-only peer's in-memory Y.Doc is now stale, and leaving it
+// connected would let a later promotion-to-editor flush that stale
+// state over the external update (TASK-265, Codex round 2). Read-only
+// peers never persisted anything, so eviction loses no edits — they
+// reconnect and lazy-seed from the fresh items.content (their old
+// resume cursor is now below the pruned op-log's MIN, so the reconnect
+// force_refreshes).
+//
+// The close frame goes out via WriteControl, which gorilla documents
+// as concurrency-safe with the room's writeLoop (a normal WriteMessage
+// would race it). Best-effort: a WriteControl / Close error just means
+// the conn was already going away. removeConn fires from each closed
+// conn's readLoop asynchronously; we deliberately don't wait for the
+// drain (this runs under the per-item setup lock).
+func (r *Room) closeReadOnlyConns() {
+	r.mu.Lock()
+	targets := make([]*websocket.Conn, 0, len(r.conns))
+	for c, rc := range r.conns {
+		if !rc.canWrite.Load() {
+			targets = append(targets, c)
+		}
+	}
+	r.mu.Unlock()
+
+	for _, c := range targets {
+		_ = c.WriteControl(
+			websocket.CloseMessage,
+			websocket.FormatCloseMessage(websocket.CloseServiceRestart,
+				"Content updated externally; reconnect to refresh."),
+			time.Now().Add(closeFrameDeadline),
+		)
+		_ = c.Close()
+	}
+}
+
 // connIDCounter is package-scoped so multiple RoomManagers in the
 // same process never hand out colliding ids. Atomic Add returns a
 // fresh value per call; we never reset.

--- a/internal/server/handlers_admin_bearer_gate_test.go
+++ b/internal/server/handlers_admin_bearer_gate_test.go
@@ -226,15 +226,19 @@ func TestAuthorizeCollabAccess_AdminBearer_DeniedOnNonMember(t *testing.T) {
 		t.Fatalf("create item: %v", err)
 	}
 
-	// Cookie-session admin — bypass fires, access allowed.
-	if err := srv.authorizeCollabAccess(
+	// Cookie-session admin — bypass fires, access allowed with write.
+	access, err := srv.authorizeCollabAccess(
 		mkAdminCookieReq(t, "/api/v1/collab/"+item.ID, admin), item,
-	); err != nil {
+	)
+	if err != nil {
 		t.Fatalf("cookie admin should be allowed on collab WS; got error %v", err)
+	}
+	if !access.canWrite {
+		t.Error("cookie-session admin should be admitted with write access (canWrite=true)")
 	}
 
 	// Bearer admin — bypass suppressed, no membership → 403.
-	err = srv.authorizeCollabAccess(
+	_, err = srv.authorizeCollabAccess(
 		mkAdminBearerReq(t, "/api/v1/collab/"+item.ID, admin), item,
 	)
 	if err == nil {

--- a/internal/server/handlers_collab.go
+++ b/internal/server/handlers_collab.go
@@ -204,9 +204,24 @@ func (s *Server) handleCollab(w http.ResponseWriter, r *http.Request) {
 	// pattern but routed through the room manager so the close
 	// frame goes out under writeMu (no concurrent-write panics
 	// against the room's writeLoop / replay path).
+	//
+	// The loop is gated on `registered` — closed by Join once the conn
+	// is in the room's conn map — so the first tick's SetConnWritable
+	// can't race Join's setup and no-op against an unregistered conn,
+	// which would strand a startup-window demotion (a viewer able to
+	// write) until a later tick. If Join bails before registering
+	// (schema/force-refresh/closed), revalDone unblocks the wait so the
+	// goroutine exits without leaking. Per TASK-265.
 	revalDone := make(chan struct{})
 	defer close(revalDone)
-	go s.collabRevalidationLoop(r, item, conn, itemID, userID, revalDone)
+	registered := make(chan struct{})
+	go func() {
+		select {
+		case <-registered:
+			s.collabRevalidationLoop(r, item, conn, itemID, userID, revalDone)
+		case <-revalDone:
+		}
+	}()
 
 	// Hand the connection to the RoomManager. It owns the
 	// op-log replay, fan-out, and lifecycle bookkeeping (lazy create
@@ -214,8 +229,11 @@ func (s *Server) handleCollab(w http.ResponseWriter, r *http.Request) {
 	// access.canWrite gates whether the room persists+rebroadcasts
 	// this peer's inbound sync frames — a read-only participant
 	// (viewer / view-only guest) still receives broadcasts but its
-	// own frames are dropped (TASK-265).
-	if err := s.collab.Join(itemID, conn, sinceID, access.canWrite); err != nil {
+	// own frames are dropped (TASK-265). The onRegistered callback
+	// (closes `registered`) fires once the conn is in the room, so
+	// revalidation only starts after SetConnWritable can find it.
+	onRegistered := func() { close(registered) }
+	if err := s.collab.Join(itemID, conn, sinceID, access.canWrite, onRegistered); err != nil {
 		// ErrForceRefreshSent is the protocol's normal close-after-
 		// notify path — the JSON frame is already on the wire and
 		// the client knows what to do. Don't warn.
@@ -664,20 +682,31 @@ func (s *Server) authorizeCollabAccess(r *http.Request, item *models.Item) (coll
 			"You are not a member of this workspace")
 	}
 
-	// Compute the write decision ONCE, up front, using the same
-	// predicate the REST edit path falls back to
-	// (requireEditPermission → ResolveUserPermission): owner/editor
-	// membership grants edit; a viewer or guest gets edit only via a
-	// collection/item edit grant. The visibility checks below decide
-	// READ admission to the room; canWrite decides whether the
-	// admitted conn may persist inbound frames. Resolving it here
-	// (rather than at each grant-return) keeps the write predicate in
-	// one place; the read-only paths below discard it. Per TASK-265.
-	perm, err := s.store.ResolveUserPermission(wsID, fresh.ID, item.ID, item.CollectionID)
-	if err != nil {
-		return collabAccess{}, err
+	// Compute the write decision ONCE, up front, mirroring the REST
+	// edit path (requireEditPermission) EXACTLY. requireEditPermission
+	// grants an editor/owner MEMBER by role FIRST — short-circuiting
+	// before any grant lookup — and only falls back to
+	// ResolveUserPermission for viewers/guests, so that grants can
+	// OVERRIDE an insufficient base role. We must preserve that order:
+	// ResolveUserPermission resolves item/collection grants BEFORE
+	// membership role, so computing canWrite purely from it would let
+	// an incidental `view` grant on this item/collection wrongly demote
+	// a legitimate editor/owner to read-only. Members are never role
+	// "guest" (guests are non-members with grants), so the role check
+	// here is the analogue of requireEditPermission's
+	// `role != "guest" && requireRole(r, "editor")`. The visibility
+	// checks below decide READ admission to the room; canWrite decides
+	// whether the admitted conn may persist inbound frames. Per TASK-265.
+	var canWrite bool
+	if member != nil && roleLevel(member.Role) >= roleLevel("editor") {
+		canWrite = true
+	} else {
+		perm, err := s.store.ResolveUserPermission(wsID, fresh.ID, item.ID, item.CollectionID)
+		if err != nil {
+			return collabAccess{}, err
+		}
+		canWrite = permissionLevel(perm) >= permissionLevel("edit")
 	}
-	canWrite := permissionLevel(perm) >= permissionLevel("edit")
 
 	// Item-level visibility check. Mirrors requireItemVisible +
 	// guestResourceFilter without depending on middleware-set request

--- a/internal/server/handlers_collab.go
+++ b/internal/server/handlers_collab.go
@@ -95,7 +95,8 @@ func (s *Server) handleCollab(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := s.authorizeCollabAccess(r, item); err != nil {
+	access, err := s.authorizeCollabAccess(r, item)
+	if err != nil {
 		var sErr *statusError
 		if errors.As(err, &sErr) {
 			writeError(w, sErr.code, sErr.kind, sErr.message)
@@ -210,7 +211,11 @@ func (s *Server) handleCollab(w http.ResponseWriter, r *http.Request) {
 	// Hand the connection to the RoomManager. It owns the
 	// op-log replay, fan-out, and lifecycle bookkeeping (lazy create
 	// + grace-TTL reclaim). Returns when the WS closes for any reason.
-	if err := s.collab.Join(itemID, conn, sinceID); err != nil {
+	// access.canWrite gates whether the room persists+rebroadcasts
+	// this peer's inbound sync frames — a read-only participant
+	// (viewer / view-only guest) still receives broadcasts but its
+	// own frames are dropped (TASK-265).
+	if err := s.collab.Join(itemID, conn, sinceID, access.canWrite); err != nil {
 		// ErrForceRefreshSent is the protocol's normal close-after-
 		// notify path — the JSON frame is already on the wire and
 		// the client knows what to do. Don't warn.
@@ -295,12 +300,20 @@ func (s *Server) collabRevalidationLoop(
 				return
 			}
 
-			err := s.authorizeCollabAccess(r, fresh)
+			access, err := s.authorizeCollabAccess(r, fresh)
 			switch {
 			case err == nil:
-				// Still authorised. Re-arm at the regular cadence;
-				// the connect-time jitter has already spread the
-				// fleet so subsequent fires can be evenly spaced.
+				// Still authorised. Push any write-permission change
+				// to the live connection so the room's per-frame gate
+				// reflects the current role without a reconnect — e.g.
+				// an editor demoted to viewer becomes read-only
+				// (TASK-265), or a viewer promoted to editor gains
+				// write. This complements the CloseConn path below,
+				// which only fires when access is lost entirely.
+				s.collab.SetConnWritable(itemID, conn, access.canWrite)
+				// Re-arm at the regular cadence; the connect-time
+				// jitter has already spread the fleet so subsequent
+				// fires can be evenly spaced.
 				timer.Reset(interval)
 
 			case isAccessDenial(err):
@@ -512,6 +525,18 @@ func newStatusError(code int, kind, message string) *statusError {
 	return &statusError{code: code, kind: kind, message: message}
 }
 
+// collabAccess is the positive outcome of authorizeCollabAccess: the
+// caller is admitted to the collab room (read / live-view). canWrite
+// reports whether the caller may additionally PERSIST inbound Yjs
+// frames — false for a workspace viewer or view-only guest, who is
+// admitted as a read-only participant (keeps presence + live view,
+// but the room drops its inbound sync frames). Threaded into
+// RoomManager.Join and refreshed by the periodic revalidation. Per
+// TASK-265.
+type collabAccess struct {
+	canWrite bool
+}
+
 // authorizeCollabAccess mirrors RequireWorkspaceAccess but keyed on
 // the item's workspace ID (the WS URL path doesn't carry a workspace
 // slug). It checks:
@@ -524,9 +549,15 @@ func newStatusError(code int, kind, message string) *statusError {
 //   - Authenticated user → admin OR member OR has guest grants.
 //   - Anything else → 403 / 401 as appropriate.
 //
-// Returns nil on success, a *statusError on a known denial, or a
-// non-statusError for store errors.
-func (s *Server) authorizeCollabAccess(r *http.Request, item *models.Item) error {
+// On success it returns a collabAccess describing the admission —
+// including canWrite, which reports whether the caller may PERSIST
+// inbound Yjs frames (mirrors the REST requireEditPermission
+// predicate). A non-editor (workspace viewer / view-only guest) is
+// admitted read-only (canWrite=false): it keeps live view + presence
+// but its sync frames are dropped by the room. On a known denial it
+// returns a zero collabAccess + *statusError; store errors surface as
+// a non-statusError. TASK-265.
+func (s *Server) authorizeCollabAccess(r *http.Request, item *models.Item) (collabAccess, error) {
 	wsID := item.WorkspaceID
 
 	// Workspace lookup is needed for the OAuth-allow-list slug compare
@@ -534,36 +565,39 @@ func (s *Server) authorizeCollabAccess(r *http.Request, item *models.Item) error
 	// than a confusing 403.
 	ws, err := s.store.GetWorkspaceByID(wsID)
 	if err != nil {
-		return err
+		return collabAccess{}, err
 	}
 	if ws == nil {
-		return newStatusError(http.StatusNotFound, "not_found", "Workspace not found")
+		return collabAccess{}, newStatusError(http.StatusNotFound, "not_found", "Workspace not found")
 	}
 
 	// OAuth token allow-list gate.
 	if !tokenAllowedWorkspaceMatches(r.Context(), ws.Slug) {
 		s.recordMCPAuthzDenial(r, "workspace_not_in_allowlist")
-		return newStatusError(http.StatusForbidden, "permission_denied",
+		return collabAccess{}, newStatusError(http.StatusForbidden, "permission_denied",
 			"Token is not authorized for this workspace")
 	}
 
-	// Fresh-install escape hatch.
+	// Fresh-install escape hatch. No users yet → no auth at all, so
+	// the REST surface treats the caller as owner; grant write too.
 	if count, _ := s.store.UserCount(); count == 0 {
-		return nil
+		return collabAccess{canWrite: true}, nil
 	}
 
-	// Legacy API token (workspace-scoped, no user context).
+	// Legacy API token (workspace-scoped, no user context). The REST
+	// middleware maps a matching workspace-scoped token to the editor
+	// role, so it may write.
 	if tokenWsID := tokenWorkspaceID(r); tokenWsID != "" && currentUser(r) == nil {
 		if tokenWsID == wsID {
-			return nil
+			return collabAccess{canWrite: true}, nil
 		}
-		return newStatusError(http.StatusForbidden, "forbidden",
+		return collabAccess{}, newStatusError(http.StatusForbidden, "forbidden",
 			"Token not authorized for this workspace")
 	}
 
 	user := currentUser(r)
 	if user == nil {
-		return newStatusError(http.StatusUnauthorized, "unauthorized",
+		return collabAccess{}, newStatusError(http.StatusUnauthorized, "unauthorized",
 			"Authentication required")
 	}
 
@@ -571,13 +605,13 @@ func (s *Server) authorizeCollabAccess(r *http.Request, item *models.Item) error
 	// reflected immediately. Mirrors sseSubscriberStillHasAccess.
 	fresh, err := s.store.GetUser(user.ID)
 	if err != nil {
-		return err
+		return collabAccess{}, err
 	}
 	if fresh == nil {
-		return newStatusError(http.StatusForbidden, "forbidden", "User not found")
+		return collabAccess{}, newStatusError(http.StatusForbidden, "forbidden", "User not found")
 	}
 	if fresh.IsDisabled() {
-		return newStatusError(http.StatusForbidden, "forbidden", "User is disabled")
+		return collabAccess{}, newStatusError(http.StatusForbidden, "forbidden", "User is disabled")
 	}
 	// PLAN-1933 DR-4: the collab upgrade authorizes then persists
 	// incoming Yjs frames to item_yjs_updates (room.go) — a content
@@ -588,15 +622,16 @@ func (s *Server) authorizeCollabAccess(r *http.Request, item *models.Item) error
 	// for verified users via emailUnverifiedBlocked. Uses the freshly
 	// re-fetched user so an admin force-verify mid-session is honoured.
 	if s.emailUnverifiedBlocked(fresh) {
-		return newStatusError(http.StatusForbidden, "email_not_verified",
+		return collabAccess{}, newStatusError(http.StatusForbidden, "email_not_verified",
 			"Verify your email address to edit content.")
 	}
 	// Admin platform-role bypass — cookie session auth only (BUG-1616).
 	// Bearer-borne admin (CLI / PAT / MCP) falls through to the
-	// membership-only check below. Mirrors RequireWorkspaceAccess.
+	// membership-only check below. Mirrors RequireWorkspaceAccess,
+	// which maps a cookie-session admin to the owner role → write.
 	isBearer := isBearerAuth(r)
 	if fresh.Role == "admin" && !isBearer {
-		return nil
+		return collabAccess{canWrite: true}, nil
 	}
 
 	// Workspace-level gate: any access at all? Membership OR guest grants.
@@ -606,7 +641,7 @@ func (s *Server) authorizeCollabAccess(r *http.Request, item *models.Item) error
 	// 403 first so non-members see the same shape they always have.
 	member, err := s.store.GetWorkspaceMember(wsID, fresh.ID)
 	if err != nil {
-		return err
+		return collabAccess{}, err
 	}
 	hasWorkspaceLevelAccess := member != nil
 	if !hasWorkspaceLevelAccess {
@@ -614,20 +649,35 @@ func (s *Server) authorizeCollabAccess(r *http.Request, item *models.Item) error
 		// guest-grants fallback exactly like RequireWorkspaceAccess.
 		if fresh.Role == "admin" && isBearer {
 			s.recordMCPAuthzDenial(r, "not_a_member")
-			return newStatusError(http.StatusForbidden, "forbidden",
+			return collabAccess{}, newStatusError(http.StatusForbidden, "forbidden",
 				"You are not a member of this workspace")
 		}
 		hasGrants, err := s.store.UserHasGrantsInWorkspace(wsID, fresh.ID)
 		if err != nil {
-			return err
+			return collabAccess{}, err
 		}
 		hasWorkspaceLevelAccess = hasGrants
 	}
 	if !hasWorkspaceLevelAccess {
 		s.recordMCPAuthzDenial(r, "not_a_member")
-		return newStatusError(http.StatusForbidden, "forbidden",
+		return collabAccess{}, newStatusError(http.StatusForbidden, "forbidden",
 			"You are not a member of this workspace")
 	}
+
+	// Compute the write decision ONCE, up front, using the same
+	// predicate the REST edit path falls back to
+	// (requireEditPermission → ResolveUserPermission): owner/editor
+	// membership grants edit; a viewer or guest gets edit only via a
+	// collection/item edit grant. The visibility checks below decide
+	// READ admission to the room; canWrite decides whether the
+	// admitted conn may persist inbound frames. Resolving it here
+	// (rather than at each grant-return) keeps the write predicate in
+	// one place; the read-only paths below discard it. Per TASK-265.
+	perm, err := s.store.ResolveUserPermission(wsID, fresh.ID, item.ID, item.CollectionID)
+	if err != nil {
+		return collabAccess{}, err
+	}
+	canWrite := permissionLevel(perm) >= permissionLevel("edit")
 
 	// Item-level visibility check. Mirrors requireItemVisible +
 	// guestResourceFilter without depending on middleware-set request
@@ -652,10 +702,10 @@ func (s *Server) authorizeCollabAccess(r *http.Request, item *models.Item) error
 	// collection — the bug Codex found in round 3.
 	visibleIDs, err := s.store.VisibleCollectionIDs(wsID, fresh.ID)
 	if err != nil {
-		return err
+		return collabAccess{}, err
 	}
 	if visibleIDs == nil {
-		return nil // "all" access
+		return collabAccess{canWrite: canWrite}, nil // "all" access
 	}
 	collectionIsVisible := false
 	for _, id := range visibleIDs {
@@ -665,7 +715,7 @@ func (s *Server) authorizeCollabAccess(r *http.Request, item *models.Item) error
 		}
 	}
 	if !collectionIsVisible {
-		return newStatusError(http.StatusNotFound, "not_found", "Item not found")
+		return collabAccess{}, newStatusError(http.StatusNotFound, "not_found", "Item not found")
 	}
 
 	// Visible-set hit. If the user has NO item-level grants, the
@@ -674,10 +724,10 @@ func (s *Server) authorizeCollabAccess(r *http.Request, item *models.Item) error
 	// item in the collection.
 	collGrants, itemGrants, err := s.store.ListUserGrants(wsID, fresh.ID)
 	if err != nil {
-		return err
+		return collabAccess{}, err
 	}
 	if len(itemGrants) == 0 {
-		return nil
+		return collabAccess{canWrite: canWrite}, nil
 	}
 
 	// User has item grants. The visible-set hit may have been anchored
@@ -686,7 +736,7 @@ func (s *Server) authorizeCollabAccess(r *http.Request, item *models.Item) error
 	// (a) Full collection grant on this collection.
 	for _, g := range collGrants {
 		if g.CollectionID == item.CollectionID {
-			return nil
+			return collabAccess{canWrite: canWrite}, nil
 		}
 	}
 
@@ -695,11 +745,11 @@ func (s *Server) authorizeCollabAccess(r *http.Request, item *models.Item) error
 	if member != nil {
 		memberColls, err := s.store.GetMemberCollectionAccess(wsID, fresh.ID)
 		if err != nil {
-			return err
+			return collabAccess{}, err
 		}
 		for _, id := range memberColls {
 			if id == item.CollectionID {
-				return nil
+				return collabAccess{canWrite: canWrite}, nil
 			}
 		}
 	}
@@ -707,11 +757,11 @@ func (s *Server) authorizeCollabAccess(r *http.Request, item *models.Item) error
 	// (c) Item-level grant on this exact item.
 	for _, g := range itemGrants {
 		if g.ItemID == item.ID {
-			return nil
+			return collabAccess{canWrite: canWrite}, nil
 		}
 	}
 
 	// Visibility was anchored by a sibling grant — 404, mirroring
 	// requireItemVisible's "don't leak existence" pattern.
-	return newStatusError(http.StatusNotFound, "not_found", "Item not found")
+	return collabAccess{}, newStatusError(http.StatusNotFound, "not_found", "Item not found")
 }

--- a/internal/server/handlers_collab.go
+++ b/internal/server/handlers_collab.go
@@ -555,6 +555,20 @@ type collabAccess struct {
 	canWrite bool
 }
 
+// collabTokenWriteScopeAllowed reports whether the request's auth
+// principal is permitted to WRITE, mirroring REST's per-method token
+// scope gate (TokenAuth → tokenScopeAllows). The collab upgrade is a
+// GET, so a read-scoped bearer token passes that method check; this
+// re-applies the write-capability half so such a token can't persist
+// Yjs mutations over the socket. Cookie / CLI-session and fresh-install
+// principals carry no token scopes; tokenScopeAllows treats an empty
+// scope string as unrestricted, so they are always allowed. Uses
+// http.MethodPost as the representative mutating verb (tokenScopeAllows
+// only distinguishes read verbs from write verbs). Per TASK-265.
+func (s *Server) collabTokenWriteScopeAllowed(r *http.Request) bool {
+	return tokenScopeAllows(TokenScopesFromContext(r.Context()), http.MethodPost, r.URL.Path)
+}
+
 // authorizeCollabAccess mirrors RequireWorkspaceAccess but keyed on
 // the item's workspace ID (the WS URL path doesn't carry a workspace
 // slug). It checks:
@@ -604,10 +618,11 @@ func (s *Server) authorizeCollabAccess(r *http.Request, item *models.Item) (coll
 
 	// Legacy API token (workspace-scoped, no user context). The REST
 	// middleware maps a matching workspace-scoped token to the editor
-	// role, so it may write.
+	// role, so it may write — but only if the token's SCOPE permits
+	// writes (a read-scoped token is admitted read-only, mirroring REST).
 	if tokenWsID := tokenWorkspaceID(r); tokenWsID != "" && currentUser(r) == nil {
 		if tokenWsID == wsID {
-			return collabAccess{canWrite: true}, nil
+			return collabAccess{canWrite: s.collabTokenWriteScopeAllowed(r)}, nil
 		}
 		return collabAccess{}, newStatusError(http.StatusForbidden, "forbidden",
 			"Token not authorized for this workspace")
@@ -706,6 +721,16 @@ func (s *Server) authorizeCollabAccess(r *http.Request, item *models.Item) (coll
 			return collabAccess{}, err
 		}
 		canWrite = permissionLevel(perm) >= permissionLevel("edit")
+	}
+	// Token write-scope gate (mirror REST): the collab upgrade is a GET,
+	// so a read-scoped bearer token (PAT / OAuth) sails past the
+	// method-keyed tokenScopeAllows check in TokenAuth — but it must not
+	// be able to PERSIST Yjs mutations over the socket. Downgrade to
+	// read-only when the caller's token scope doesn't permit writes.
+	// Non-token principals (cookie / CLI session) have empty scopes,
+	// which map to "unrestricted" → no downgrade. Per TASK-265.
+	if canWrite {
+		canWrite = s.collabTokenWriteScopeAllowed(r)
 	}
 
 	// Item-level visibility check. Mirrors requireItemVisible +

--- a/internal/server/handlers_collab.go
+++ b/internal/server/handlers_collab.go
@@ -611,9 +611,13 @@ func (s *Server) authorizeCollabAccess(r *http.Request, item *models.Item) (coll
 	}
 
 	// Fresh-install escape hatch. No users yet → no auth at all, so
-	// the REST surface treats the caller as owner; grant write too.
+	// the REST surface treats the caller as owner; grant write too —
+	// EXCEPT a legacy workspace token still carries a scope even on a
+	// zero-user instance, so a read-scoped token stays read-only here
+	// too (collabTokenWriteScopeAllowed returns true for the no-token
+	// anonymous setup caller, whose scopes are empty = unrestricted).
 	if count, _ := s.store.UserCount(); count == 0 {
-		return collabAccess{canWrite: true}, nil
+		return collabAccess{canWrite: s.collabTokenWriteScopeAllowed(r)}, nil
 	}
 
 	// Legacy API token (workspace-scoped, no user context). The REST

--- a/internal/server/handlers_collab_test.go
+++ b/internal/server/handlers_collab_test.go
@@ -864,6 +864,23 @@ func TestAuthorizeCollabAccessCanWrite(t *testing.T) {
 	editor := mkUser("editor2@test.com", "editor")
 	viewer := mkUser("viewer2@test.com", "viewer")
 
+	// Editor member who ALSO holds an incidental item-level `view`
+	// grant. ResolveUserPermission resolves the item grant ("view")
+	// BEFORE membership role, so computing canWrite purely from it
+	// would wrongly demote this legitimate editor to read-only. The
+	// role short-circuit (mirroring requireEditPermission) must win.
+	editorWithViewGrant := mkUser("editorgrant@test.com", "editor")
+	if _, err := srv.store.CreateItemGrant(ws.ID, item.ID, editorWithViewGrant.ID, "view", editorWithViewGrant.ID); err != nil {
+		t.Fatalf("CreateItemGrant (editor view): %v", err)
+	}
+
+	// Viewer member who holds an item-level `edit` grant — the grant
+	// must OVERRIDE the insufficient base role (also mirrors REST).
+	viewerWithEditGrant := mkUser("viewergrant@test.com", "viewer")
+	if _, err := srv.store.CreateItemGrant(ws.ID, item.ID, viewerWithEditGrant.ID, "edit", viewerWithEditGrant.ID); err != nil {
+		t.Fatalf("CreateItemGrant (viewer edit): %v", err)
+	}
+
 	check := func(name string, u *models.User, wantWrite bool) {
 		// Cookie-session-shaped request (no bearer header) so the
 		// caller is treated as an interactive session, not a token.
@@ -879,4 +896,107 @@ func TestAuthorizeCollabAccessCanWrite(t *testing.T) {
 	}
 	check("editor", editor, true)
 	check("viewer", viewer, false)
+	check("editor+incidental view grant", editorWithViewGrant, true)
+	check("viewer+edit grant override", viewerWithEditGrant, true)
+}
+
+// TestCollabDemotionMakesConnReadOnly exercises the mid-session
+// demotion path (TASK-265): an editor connected to a collab room who
+// is demoted to viewer must become read-only WITHOUT a reconnect —
+// the periodic revalidation recomputes canWrite and pushes it via
+// SetConnWritable, and the room's readLoop then drops the (now
+// read-only) conn's inbound sync frames. Also implicitly covers the
+// startup-ordering fix: revalidation only starts after registration,
+// so the SetConnWritable can find the conn.
+func TestCollabDemotionMakesConnReadOnly(t *testing.T) {
+	origInterval := collabMembershipRevalInterval
+	collabMembershipRevalInterval = 25 * time.Millisecond
+	defer func() { collabMembershipRevalInterval = origInterval }()
+
+	srv := testServerWithCollab(t)
+	bootstrapFirstUser(t, srv, "admin@test.com", "Admin")
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	ws, err := srv.store.CreateWorkspace(models.WorkspaceCreate{Name: "Demotion"})
+	if err != nil {
+		t.Fatalf("CreateWorkspace: %v", err)
+	}
+	col, err := srv.store.CreateCollection(ws.ID, models.CollectionCreate{Name: "Tasks", Schema: `{"fields":[]}`})
+	if err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	item, err := srv.store.CreateItem(ws.ID, col.ID, models.ItemCreate{Title: "Doc", Fields: `{}`})
+	if err != nil {
+		t.Fatalf("CreateItem: %v", err)
+	}
+
+	u, err := srv.store.CreateUser(models.UserCreate{
+		Email: "demote@test.com", Name: "Demote", Password: "correct-horse-battery-staple", Role: "member",
+	})
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	if err := srv.store.AddWorkspaceMember(ws.ID, u.ID, "editor"); err != nil {
+		t.Fatalf("AddWorkspaceMember: %v", err)
+	}
+	token, err := srv.store.CreateSession(u.ID, "go-test", "127.0.0.1", "go-test", 24*time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	cookies := []*http.Cookie{{Name: "pad_session", Value: token}}
+
+	conn, resp, err := dialCollab(t, ts.URL, item.ID, cookies, "go-test")
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+	if resp.StatusCode != http.StatusSwitchingProtocols {
+		t.Fatalf("expected 101, got %d", resp.StatusCode)
+	}
+
+	// While an editor: a sync frame persists.
+	if err := conn.WriteMessage(websocket.BinaryMessage, []byte{0x00, 0xE1}); err != nil {
+		t.Fatalf("editor write: %v", err)
+	}
+	waitForOpLogRows(t, srv, item.ID, 1, 3*time.Second)
+
+	// Demote to viewer. The revalidation loop (25ms cadence) recomputes
+	// canWrite=false and pushes it via SetConnWritable.
+	if err := srv.store.UpdateWorkspaceMemberRole(ws.ID, u.ID, "viewer"); err != nil {
+		t.Fatalf("UpdateWorkspaceMemberRole: %v", err)
+	}
+
+	// Let the demotion propagate: several reval cadences (25ms) is
+	// ample for the loop to observe the viewer role and apply
+	// canWrite=false to the live conn. 500ms = ~20 ticks.
+	time.Sleep(500 * time.Millisecond)
+
+	// A post-demotion sync frame must now be dropped, not persisted.
+	// Send it, then watch the op-log for a further window: if the gate
+	// leaked, the frame would persist (in-process, sub-ms) and push the
+	// count to 2 well within the window.
+	if err := conn.WriteMessage(websocket.BinaryMessage, []byte{0x00, 0x22}); err != nil {
+		t.Fatalf("post-demotion write: %v", err)
+	}
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		rows, err := srv.store.LoadYjsUpdatesSince(item.ID, 0)
+		if err != nil {
+			t.Fatalf("LoadYjsUpdatesSince: %v", err)
+		}
+		if len(rows) > 1 {
+			t.Fatalf("post-demotion frame persisted (%d rows) — demoted editor still writable", len(rows))
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+
+	// Final confirmation: still exactly the single editor-era row.
+	rows, err := srv.store.LoadYjsUpdatesSince(item.ID, 0)
+	if err != nil {
+		t.Fatalf("LoadYjsUpdatesSince: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("op-log has %d rows, want 1 (only the pre-demotion editor frame)", len(rows))
+	}
 }

--- a/internal/server/handlers_collab_test.go
+++ b/internal/server/handlers_collab_test.go
@@ -923,6 +923,48 @@ func TestAuthorizeCollabAccessCanWrite(t *testing.T) {
 	checkScoped("editor + wildcard PAT", editor, `["*"]`, true)
 }
 
+// TestAuthorizeCollabAccessFreshInstallTokenScope covers the zero-user
+// (pre-bootstrap) branch: the anonymous setup caller keeps write, but a
+// legacy workspace token still carries a scope even on a fresh instance,
+// so a read-scoped token stays read-only here too — matching REST, where
+// the method gate would block a read token's mutation.
+func TestAuthorizeCollabAccessFreshInstallTokenScope(t *testing.T) {
+	srv := testServer(t)
+	// NO bootstrapFirstUser → UserCount == 0 (fresh install).
+	ws, err := srv.store.CreateWorkspace(models.WorkspaceCreate{Name: "Fresh"})
+	if err != nil {
+		t.Fatalf("CreateWorkspace: %v", err)
+	}
+	col, err := srv.store.CreateCollection(ws.ID, models.CollectionCreate{Name: "Tasks", Schema: `{"fields":[]}`})
+	if err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	item, err := srv.store.CreateItem(ws.ID, col.ID, models.ItemCreate{Title: "Item", Fields: `{}`})
+	if err != nil {
+		t.Fatalf("CreateItem: %v", err)
+	}
+	if n, _ := srv.store.UserCount(); n != 0 {
+		t.Fatalf("fresh-install precondition: expected 0 users, got %d", n)
+	}
+
+	check := func(name, scopesJSON string, wantWrite bool) {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/collab/"+item.ID, nil)
+		if scopesJSON != "" {
+			req = req.WithContext(WithTokenScopes(req.Context(), scopesJSON))
+		}
+		access, err := srv.authorizeCollabAccess(req, item)
+		if err != nil {
+			t.Fatalf("%s: authorizeCollabAccess error (should be admitted): %v", name, err)
+		}
+		if access.canWrite != wantWrite {
+			t.Fatalf("%s: canWrite = %v, want %v", name, access.canWrite, wantWrite)
+		}
+	}
+	check("fresh install, no token (anonymous setup)", "", true)
+	check("fresh install + read-scoped token", `["read"]`, false)
+	check("fresh install + write-scoped token", `["write"]`, true)
+}
+
 // TestCollabDemotionMakesConnReadOnly exercises the mid-session
 // demotion path (TASK-265): an editor connected to a collab room who
 // is demoted to viewer must become read-only WITHOUT a reconnect —

--- a/internal/server/handlers_collab_test.go
+++ b/internal/server/handlers_collab_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bytes"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -626,4 +627,256 @@ func TestCollabUpgradeMissingItemIDBadRequest(t *testing.T) {
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		t.Fatalf("expected non-success on missing item segment, got %d", resp.StatusCode)
 	}
+}
+
+// readNextBinaryFrame reads WebSocket frames from conn, skipping any
+// TextMessage control frames (op_log_cursor, force_refresh), until it
+// gets a BinaryMessage or the deadline passes. Returns (data, true)
+// on a binary frame and (nil, false) on timeout / connection error.
+func readNextBinaryFrame(t *testing.T, conn *websocket.Conn, within time.Duration) ([]byte, bool) {
+	t.Helper()
+	_ = conn.SetReadDeadline(time.Now().Add(within))
+	for {
+		mt, data, err := conn.ReadMessage()
+		if err != nil {
+			return nil, false
+		}
+		if mt == websocket.BinaryMessage {
+			return data, true
+		}
+		// Text control frame — skip and keep reading until the deadline.
+	}
+}
+
+// waitForOpLogRows polls the item's op-log until it holds exactly want
+// rows or the deadline passes. Fails immediately if the count exceeds
+// want (an unexpected extra persist — e.g. a read-only frame leaking
+// through). Returns the final snapshot.
+func waitForOpLogRows(t *testing.T, srv *Server, itemID string, want int, within time.Duration) []models.YjsUpdate {
+	t.Helper()
+	deadline := time.Now().Add(within)
+	for {
+		rows, err := srv.store.LoadYjsUpdatesSince(itemID, 0)
+		if err != nil {
+			t.Fatalf("LoadYjsUpdatesSince: %v", err)
+		}
+		if len(rows) > want {
+			t.Fatalf("op-log has %d rows, want %d (unexpected extra persist)", len(rows), want)
+		}
+		if len(rows) == want {
+			return rows
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for %d op-log row(s); have %d", want, len(rows))
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// TestCollabViewerIsReadOnly is the TASK-265 regression: a workspace
+// VIEWER admitted to a collab room is a READ-ONLY participant. It
+// keeps live view + presence (still receives broadcasts) but its
+// inbound Yjs sync frames are dropped — never persisted to
+// item_yjs_updates, never rebroadcast — while a co-present EDITOR's
+// frames ARE persisted and broadcast. This closes the viewer-write
+// bypass: the collab WS GET is mounted outside RequireWorkspaceAccess,
+// so before this fix a viewer's frames persisted and got canonicalized
+// into items.content on a co-present editor's authorized flush.
+func TestCollabViewerIsReadOnly(t *testing.T) {
+	srv := testServerWithCollab(t)
+	bootstrapFirstUser(t, srv, "admin@test.com", "Admin")
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	ws, err := srv.store.CreateWorkspace(models.WorkspaceCreate{Name: "ViewerReadOnly"})
+	if err != nil {
+		t.Fatalf("CreateWorkspace: %v", err)
+	}
+	col, err := srv.store.CreateCollection(ws.ID, models.CollectionCreate{
+		Name: "Tasks", Schema: `{"fields":[]}`,
+	})
+	if err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	item, err := srv.store.CreateItem(ws.ID, col.ID, models.ItemCreate{
+		Title: "Shared doc", Fields: `{}`,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem: %v", err)
+	}
+
+	// Two members: one editor (may write), one viewer (read-only).
+	mkMember := func(email, role string) []*http.Cookie {
+		u, err := srv.store.CreateUser(models.UserCreate{
+			Email: email, Name: role, Password: "correct-horse-battery-staple", Role: "member",
+		})
+		if err != nil {
+			t.Fatalf("CreateUser %s: %v", email, err)
+		}
+		if err := srv.store.AddWorkspaceMember(ws.ID, u.ID, role); err != nil {
+			t.Fatalf("AddWorkspaceMember %s: %v", role, err)
+		}
+		token, err := srv.store.CreateSession(u.ID, "go-test", "127.0.0.1", "go-test", 24*time.Hour)
+		if err != nil {
+			t.Fatalf("CreateSession %s: %v", email, err)
+		}
+		return []*http.Cookie{{Name: "pad_session", Value: token}}
+	}
+	editorCookies := mkMember("editor@test.com", "editor")
+	viewerCookies := mkMember("viewer@test.com", "viewer")
+
+	// Both members upgrade successfully — the viewer is admitted as a
+	// read-only participant, NOT rejected (live-view must stay intact).
+	editorConn, resp, err := dialCollab(t, ts.URL, item.ID, editorCookies, "go-test")
+	if err != nil {
+		body := ""
+		if resp != nil {
+			body = "status=" + resp.Status
+		}
+		t.Fatalf("editor dial: %v (%s)", err, body)
+	}
+	defer editorConn.Close()
+	if resp.StatusCode != http.StatusSwitchingProtocols {
+		t.Fatalf("editor: expected 101, got %d", resp.StatusCode)
+	}
+	// Drain the editor's initial post-replay op_log_cursor so we know
+	// its Join has completed (subscribed + readLoop running) before we
+	// send. At connect time nothing else writes, so the first frame is
+	// the text cursor.
+	if _, _, derr := editorConn.ReadMessage(); derr != nil {
+		t.Fatalf("editor initial frame: %v", derr)
+	}
+
+	viewerConn, resp, err := dialCollab(t, ts.URL, item.ID, viewerCookies, "go-test")
+	if err != nil {
+		body := ""
+		if resp != nil {
+			body = "status=" + resp.Status
+		}
+		t.Fatalf("viewer dial (should be admitted read-only, not rejected): %v (%s)", err, body)
+	}
+	defer viewerConn.Close()
+	if resp.StatusCode != http.StatusSwitchingProtocols {
+		t.Fatalf("viewer: expected 101 (read-only admission), got %d", resp.StatusCode)
+	}
+
+	// (c) EDITOR frame IS persisted + broadcast. Yjs sync frame: first
+	// byte 0 = sync (the dumb relay keys on data[0]; the remaining
+	// bytes needn't be a real Y update for the relay path).
+	editorFrame := []byte{0x00, 0xE1, 0xE2}
+	if err := editorConn.WriteMessage(websocket.BinaryMessage, editorFrame); err != nil {
+		t.Fatalf("editor write: %v", err)
+	}
+	rows := waitForOpLogRows(t, srv, item.ID, 1, 3*time.Second)
+	if !bytes.Equal(rows[0].UpdateData, editorFrame) {
+		t.Fatalf("persisted row = %x, want editor frame %x", rows[0].UpdateData, editorFrame)
+	}
+
+	// (b) The VIEWER receives the editor's broadcast — read-only
+	// participant, live view intact.
+	got, ok := readNextBinaryFrame(t, viewerConn, 3*time.Second)
+	if !ok {
+		t.Fatal("viewer did not receive the editor's broadcast frame (live view broken)")
+	}
+	if !bytes.Equal(got, editorFrame) {
+		t.Fatalf("viewer received %x, want editor frame %x", got, editorFrame)
+	}
+
+	// (a) VIEWER sync frame is dropped: not broadcast, not persisted.
+	// The viewer sends a sync frame V (must be dropped) then an
+	// awareness frame A (presence — still relayed). The viewer's
+	// readLoop is single-threaded and the bus is FIFO, so if the
+	// editor receives A we KNOW V was already processed (and dropped).
+	viewerSync := []byte{0x00, 0x11, 0x12}      // sync — must be dropped
+	viewerAwareness := []byte{0x01, 0xAA, 0xBB} // awareness — must relay
+	if err := viewerConn.WriteMessage(websocket.BinaryMessage, viewerSync); err != nil {
+		t.Fatalf("viewer sync write: %v", err)
+	}
+	if err := viewerConn.WriteMessage(websocket.BinaryMessage, viewerAwareness); err != nil {
+		t.Fatalf("viewer awareness write: %v", err)
+	}
+
+	// The next binary the editor receives must be the awareness frame,
+	// NOT the viewer's dropped sync frame.
+	edGot, ok := readNextBinaryFrame(t, editorConn, 3*time.Second)
+	if !ok {
+		t.Fatal("editor did not receive the viewer's awareness (presence) frame")
+	}
+	if bytes.Equal(edGot, viewerSync) || edGot[0] == 0x00 {
+		t.Fatalf("editor received the viewer's dropped SYNC frame %x — read-only gate leaked", edGot)
+	}
+	if !bytes.Equal(edGot, viewerAwareness) {
+		t.Fatalf("editor received unexpected frame %x, want awareness %x", edGot, viewerAwareness)
+	}
+
+	// Op-log still holds exactly the editor's single row: the viewer's
+	// sync frame was NOT persisted (barrier reached above).
+	final, err := srv.store.LoadYjsUpdatesSince(item.ID, 0)
+	if err != nil {
+		t.Fatalf("LoadYjsUpdatesSince: %v", err)
+	}
+	if len(final) != 1 {
+		t.Fatalf("op-log has %d rows after viewer write, want 1 (viewer frame must not persist)", len(final))
+	}
+	if !bytes.Equal(final[0].UpdateData, editorFrame) {
+		t.Fatalf("op-log row = %x, want only the editor frame %x", final[0].UpdateData, editorFrame)
+	}
+}
+
+// TestAuthorizeCollabAccessCanWrite unit-tests the write-permission
+// half of the collab authorization decision (TASK-265): a workspace
+// editor resolves canWrite=true, a viewer canWrite=false — both are
+// admitted (no error), mirroring requireEditPermission on the REST
+// path.
+func TestAuthorizeCollabAccessCanWrite(t *testing.T) {
+	srv := testServer(t)
+	bootstrapFirstUser(t, srv, "admin@test.com", "Admin")
+
+	ws, err := srv.store.CreateWorkspace(models.WorkspaceCreate{Name: "CanWrite"})
+	if err != nil {
+		t.Fatalf("CreateWorkspace: %v", err)
+	}
+	col, err := srv.store.CreateCollection(ws.ID, models.CollectionCreate{
+		Name: "Tasks", Schema: `{"fields":[]}`,
+	})
+	if err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	item, err := srv.store.CreateItem(ws.ID, col.ID, models.ItemCreate{
+		Title: "Item", Fields: `{}`,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem: %v", err)
+	}
+
+	mkUser := func(email, role string) *models.User {
+		u, err := srv.store.CreateUser(models.UserCreate{
+			Email: email, Name: role, Password: "correct-horse-battery-staple", Role: "member",
+		})
+		if err != nil {
+			t.Fatalf("CreateUser %s: %v", email, err)
+		}
+		if err := srv.store.AddWorkspaceMember(ws.ID, u.ID, role); err != nil {
+			t.Fatalf("AddWorkspaceMember %s: %v", role, err)
+		}
+		return u
+	}
+	editor := mkUser("editor2@test.com", "editor")
+	viewer := mkUser("viewer2@test.com", "viewer")
+
+	check := func(name string, u *models.User, wantWrite bool) {
+		// Cookie-session-shaped request (no bearer header) so the
+		// caller is treated as an interactive session, not a token.
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/collab/"+item.ID, nil)
+		req = req.WithContext(WithCurrentUser(req.Context(), u))
+		access, err := srv.authorizeCollabAccess(req, item)
+		if err != nil {
+			t.Fatalf("%s: authorizeCollabAccess returned error (should be admitted): %v", name, err)
+		}
+		if access.canWrite != wantWrite {
+			t.Fatalf("%s: canWrite = %v, want %v", name, access.canWrite, wantWrite)
+		}
+	}
+	check("editor", editor, true)
+	check("viewer", viewer, false)
 }

--- a/internal/server/handlers_collab_test.go
+++ b/internal/server/handlers_collab_test.go
@@ -898,6 +898,29 @@ func TestAuthorizeCollabAccessCanWrite(t *testing.T) {
 	check("viewer", viewer, false)
 	check("editor+incidental view grant", editorWithViewGrant, true)
 	check("viewer+edit grant override", viewerWithEditGrant, true)
+
+	// Token write-scope gate (mirror REST): the collab upgrade is a GET,
+	// so a read-scoped bearer token would otherwise ride the user's
+	// editor role to canWrite=true and persist Yjs mutations. A
+	// read-scoped PAT owned by an editor must be admitted read-only; a
+	// write-scoped PAT owned by an editor keeps write.
+	checkScoped := func(name string, u *models.User, scopesJSON string, wantWrite bool) {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/collab/"+item.ID, nil)
+		ctx := WithCurrentUser(req.Context(), u)
+		ctx = WithTokenScopes(ctx, scopesJSON)
+		req = req.WithContext(ctx)
+		access, err := srv.authorizeCollabAccess(req, item)
+		if err != nil {
+			t.Fatalf("%s: authorizeCollabAccess returned error (should be admitted): %v", name, err)
+		}
+		if access.canWrite != wantWrite {
+			t.Fatalf("%s: canWrite = %v, want %v", name, access.canWrite, wantWrite)
+		}
+	}
+	checkScoped("editor + read-scoped PAT", editor, `["read"]`, false)
+	checkScoped("editor + pad:read OAuth token", editor, `["pad:read"]`, false)
+	checkScoped("editor + write-scoped PAT", editor, `["write"]`, true)
+	checkScoped("editor + wildcard PAT", editor, `["*"]`, true)
 }
 
 // TestCollabDemotionMakesConnReadOnly exercises the mid-session

--- a/internal/server/middleware_auth.go
+++ b/internal/server/middleware_auth.go
@@ -194,6 +194,14 @@ func (s *Server) TokenAuth(next http.Handler) http.Handler {
 		setTokenExpiryWarning(w, apiToken)
 
 		ctx := context.WithValue(r.Context(), ctxIsAPIToken, true)
+		// Stash the token's scopes so downstream handlers can enforce
+		// write-scope on paths where the method gate above isn't
+		// sufficient. The chain-level tokenScopeAllows check keys on the
+		// HTTP method, which is right for ordinary REST verbs; but the
+		// collab WebSocket upgrade is a GET that goes on to PERSIST Yjs
+		// mutations, so its handler re-checks write capability from these
+		// scopes (mirrors what MCPBearerAuth already stashes). Per TASK-265.
+		ctx = WithTokenScopes(ctx, apiToken.Scopes)
 
 		// Resolve user from token's user_id (new user-owned tokens)
 		if apiToken.UserID != "" {


### PR DESCRIPTION
## Root cause

The collab WebSocket `GET /api/v1/collab/{itemID}` is mounted **outside** the `/{slug}` subrouter, so `RequireWorkspaceAccess` never runs on it — authorization lives entirely in `handleCollab` → `authorizeCollabAccess`. That function gated admission on the OAuth allow-list, workspace membership / guest grants, and item **visibility** — but it never checked **edit role**. A plain workspace **viewer** (member, all-access) was admitted and could **write**: every inbound Yjs sync frame was persisted to `item_yjs_updates` (`room.go`) and later canonicalized into `items.content` when a co-present editor's authorized flush ran (`?source=collab-snapshot`). The REST write path already blocks viewers via `requireEditPermission`; this closes the equivalent gap on the collab relay (parent PLAN-259; sibling to the BUG-984 client-side audit).

## Fix — read-only participants (not hard-rejected)

Non-editors become **read-only** collab participants so live view + presence stay intact:

- **`authorizeCollabAccess`** (`internal/server/handlers_collab.go`) now returns a `collabAccess{canWrite}` alongside the admission decision. `canWrite` is computed **once** via `store.ResolveUserPermission` — the same predicate `requireEditPermission` falls back to: owner/editor membership grants write; a viewer/guest gets write only through a collection/item **edit** grant. Fresh-install, matching legacy workspace token, and cookie-session admin keep write (matching the REST role mapping).
- **`RoomManager.Join`** (`internal/collab/manager.go`) takes a `canWrite` flag, stored per-connection as an `atomic.Bool` on `roomConn` (`internal/collab/room.go`). `readLoop` drops a read-only conn's inbound **sync** frames — not persisted via `AppendYjsUpdate`, not rebroadcast. **Awareness (presence) frames still relay** so the viewer's cursor stays visible, and outbound editor broadcasts still reach the viewer.
- **`RoomManager.SetConnWritable`** (new) lets the handler's periodic revalidation push mid-session write-permission changes, so an editor demoted to viewer becomes read-only **without a reconnect** — the write-side complement of the existing `CloseConn`-on-revocation path.

Client (`web/src/lib/collab/*`) is untouched — server-side enforcement only.

## No schema bump

**Deliberately did NOT bump** `SCHEMA_VERSION` / `DefaultSchemaVersion`. This is an authorization/behavioral change, not a ProseMirror/Y.Doc node-spec change; bumping would needlessly prune every item's op-log.

## Tests

- `TestCollabViewerIsReadOnly` — end-to-end: a viewer is admitted (101, not rejected), **receives** an editor's broadcast frame (live view intact), but its own sync frame is **neither persisted** to `item_yjs_updates` **nor broadcast** to the editor, while the editor's frame **is** persisted + broadcast. Verified the test **fails** with the gate removed.
- `TestAuthorizeCollabAccessCanWrite` — unit: viewer → `canWrite=false`, editor → `canWrite=true` (both admitted).

## Gates

`go build ./...`, `gofmt -l` (clean), `go vet`, `golangci-lint` (0 issues), and `go test ./internal/server/ ./internal/collab/` all pass. Codex review: CLEAN.

https://claude.ai/code/session_01EZ6yr6pAUFb1uffan912ra