### PR TITLE
feat(web): add ?item= URL-state plumbing to collection page (TASK-2110)

### DIFF
--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -128,6 +128,17 @@
 	let username = $derived(page.params.username ?? '');
 	let collSlug = $derived(page.params.collection ?? '');
 
+	// PLAN-2105 Phase 2 — split-pane URL state. `?item=<ref>` is the
+	// single URL-derived source of truth for which item (if any) has its
+	// detail pane open. Derived over `page` (from $app/state) so it reacts
+	// to back/forward, `goto`, and any other query-state change WITHOUT
+	// being routed through the load cycle — `loadUrlFilters` only runs on a
+	// ws/collection/showArchived change, never on same-pathname query
+	// edits, so pane state must be a standalone derived over `page.url`.
+	// No pane component is mounted yet (TASK-2112); this is the URL-state
+	// groundwork the pane will read.
+	let openItemRef = $derived(page.url.searchParams.get('item'));
+
 	// Reactive parse of the current search query — shared with the
 	// search-dispatch effect below so it doesn't reparse per run.
 	// TASK-1367.
@@ -439,9 +450,54 @@
 		// URL never even transiently carries `unparented=true` (DR-2).
 		writeUnparentedParam(params, unparentedApplied);
 		if (searchQuery) params.set('q', searchQuery);
+		// Preserve an open split pane across filter/sort/view/tag/search
+		// changes. This function rebuilds the query from scratch (the fresh
+		// `new URLSearchParams()` above), so without re-emitting the current
+		// `?item=` the next filter change would silently drop the open pane
+		// (PLAN-2105). Read the live value off `page.url` — it's the same
+		// source `openItemRef` derives from, so this stays in sync.
+		const openItem = page.url.searchParams.get('item');
+		if (openItem) params.set('item', openItem);
 		const qs = params.toString();
 		const newUrl = `/${username}/${wsSlug}/${collSlug}${qs ? '?' + qs : ''}`;
 		goto(newUrl, { replaceState: true, noScroll: true, keepFocus: true });
+	}
+
+	// ── Split-pane open/close (PLAN-2105 Phase 2) ──────────────────────
+	// Toggle the `?item=` query param that `openItemRef` derives from.
+	// Both helpers preserve every OTHER query param (view/sort/filter/
+	// tags/search) by mutating a clone of the live URL rather than
+	// rebuilding from filter state, and reuse the same
+	// `{ noScroll, keepFocus }` goto options as `updateUrlFilters`.
+	//
+	// History policy (deliberate split):
+	//  • openItemPane PUSHES a history entry (replaceState:false) so a
+	//    single Back closes the pane — matching "back/forward work
+	//    naturally".
+	//  • closeItemPane REPLACES (replaceState:true) and clears ONLY the
+	//    `item` param, so closing (and future j/k re-targets, TASK-2111)
+	//    don't push a trail of entries that Back must unwind.
+	//
+	// Not wired to row-click yet (TASK-2111) and no pane is rendered yet
+	// (TASK-2112) — this is the URL-state plumbing those tasks build on.
+	function openItemPane(item: Item) {
+		const url = new URL(page.url);
+		url.searchParams.set('item', itemUrlId(item));
+		goto(`${url.pathname}${url.search}`, {
+			replaceState: false,
+			noScroll: true,
+			keepFocus: true,
+		});
+	}
+
+	function closeItemPane() {
+		const url = new URL(page.url);
+		url.searchParams.delete('item');
+		goto(`${url.pathname}${url.search}`, {
+			replaceState: true,
+			noScroll: true,
+			keepFocus: true,
+		});
 	}
 
 	// Read filters from URL on load
@@ -458,7 +514,11 @@
 		// know that yet.
 		selectedTags = [];
 		const unparentedIntent = readUnparentedParam(url.searchParams);
-		const knownParams = new Set(['view', 'q', 'tags', UNPARENTED_FILTER_FIELD]);
+		// `item` is the split-pane param (PLAN-2105) — whitelist it so it's
+		// not misread as a schema-field filter and absorbed into
+		// activeFilters. It's consumed by the `openItemRef` derived, not by
+		// the filter load cycle.
+		const knownParams = new Set(['view', 'q', 'tags', 'item', UNPARENTED_FILTER_FIELD]);
 		for (const [k, v] of url.searchParams.entries()) {
 			if (k === 'view' && (v === 'list' || v === 'board')) {
 				viewMode = v;


### PR DESCRIPTION
## What

Adds the `?item=` URL-state plumbing to the collection page (`[username]/[workspace]/[collection]/+page.svelte`) that the PLAN-2105 split pane will later read. **Pure URL-state groundwork** — no pane component is rendered by this task (that is TASK-2112), and row-click is not wired to these helpers yet (that is TASK-2111).

Part of PLAN-2105 (implements IDEA-1968), Phase 2 — Split pane (desktop).

## Changes (single file)

- **`openItemRef`** — `let openItemRef = $derived(page.url.searchParams.get('item'))`, the single URL-derived source of truth for which item (if any) has its detail pane open. Because `page` is from `$app/state`, it reacts to back/forward + `goto` without being routed through the load cycle (`loadUrlFilters` only runs on a ws/collection/showArchived change, never on same-pathname query edits).
- **`loadUrlFilters`** — `'item'` added to the `knownParams` whitelist Set so it is NOT misread as a schema-field filter and absorbed into `activeFilters` (no phantom filter, results unaffected).
- **`updateUrlFilters`** — re-emits the current `?item=` (read off `page.url`) into the freshly-rebuilt `URLSearchParams` so a filter/sort/view/tag/search change does NOT drop an open pane.
- **`openItemPane(item)` / `closeItemPane()`** — helpers using `goto(url, { noScroll: true, keepFocus: true })` (same options the page already uses). Documented history policy: `openItemPane` PUSHES a history entry (`replaceState:false`) so Back closes the pane; `closeItemPane` uses `replaceState:true` and clears ONLY the `item` param, preserving all other query state (view/sort/filter/tags/search).

## Verification

- `cd web && npm run check` — clean: 0 errors, 8 warnings (all pre-existing, in unrelated files).
- Svelte autofixer MCP — no issues on the new runes code.
- Codex review — CLEAN.

The `?item=` round-trip is hard to unit-verify without the pane mounted; TASK-2116 adds the vitest specs once the pane lands.

https://claude.ai/code/session_01EZ6yr6pAUFb1uffan912ra