### PR TITLE
fix(web): remove visualViewport listeners on Editor destroy (TASK-2109)

### DIFF
--- a/web/src/lib/components/editor/Editor.svelte
+++ b/web/src/lib/components/editor/Editor.svelte
@@ -1138,7 +1138,9 @@
 
 	onDestroy(() => {
 		editor?.destroy();
-		if (window.visualViewport && visualViewportHandler) {
+		// onDestroy (unlike onMount) also runs during SSR, where `window` is
+		// undefined — guard with typeof before touching it (TASK-2109).
+		if (typeof window !== 'undefined' && window.visualViewport && visualViewportHandler) {
 			window.visualViewport.removeEventListener('resize', visualViewportHandler);
 			window.visualViewport.removeEventListener('scroll', visualViewportHandler);
 		}

--- a/web/src/lib/components/editor/Editor.svelte
+++ b/web/src/lib/components/editor/Editor.svelte
@@ -663,6 +663,9 @@
 	let keyboardVisible = $state(false);
 	let suppressUpdate = false;
 	let lastMarkdown = '';
+	// visualViewport 'resize'/'scroll' handler ref, so onDestroy can remove
+	// the exact listeners registered in onMount (TASK-2109).
+	let visualViewportHandler: (() => void) | null = null;
 
 	// Slash command state
 	let slashOpen = $state(false);
@@ -1127,6 +1130,7 @@
 				// Hide toolbar when keyboard is dismissed (viewport matches window)
 				keyboardVisible = kbHeight > 50;
 			};
+			visualViewportHandler = updateToolbarPos;
 			window.visualViewport.addEventListener('resize', updateToolbarPos);
 			window.visualViewport.addEventListener('scroll', updateToolbarPos);
 		}
@@ -1134,6 +1138,10 @@
 
 	onDestroy(() => {
 		editor?.destroy();
+		if (window.visualViewport && visualViewportHandler) {
+			window.visualViewport.removeEventListener('resize', visualViewportHandler);
+			window.visualViewport.removeEventListener('scroll', visualViewportHandler);
+		}
 	});
 
 	$effect(() => {


### PR DESCRIPTION
## Summary
- `Editor.svelte` registers `window.visualViewport` `resize`/`scroll` listeners in `onMount` (for mobile toolbar keyboard-tracking positioning) but never removed them in `onDestroy` — a leak that grows fast once the pane `{#key}`-remounts the Editor per item-switch (later phases), and would skew Phase 3's WebSocket/Y.Doc leak instrumentation.
- Store the handler reference in a component-scoped variable and `removeEventListener` both listeners in `onDestroy`.
- Round 1 Codex review caught a real SSR bug in the first pass: `onDestroy` (unlike `onMount`) also runs during server-side rendering, where `window` is undefined. Fixed with a `typeof window !== 'undefined'` guard, matching the existing convention used elsewhere in this same file.
- No change to mobile-toolbar keyboard-tracking behavior — same handler function, same events, same logic.

## Test plan
- [x] `cd web && npm run check` — clean (0 errors; only pre-existing unrelated warnings)
- [x] Reviewed with the Svelte MCP `svelte-autofixer` tool — no issues on the changed code
- [x] Codex review round 1 — found SSR `window` access bug; fixed
- [x] Codex review round 2 — CLEAN

https://claude.ai/code/session_01EZ6yr6pAUFb1uffan912ra