### PR TITLE
feat(web): mount split-pane detail view + row-click open (TASK-2112, TASK-2111)

### DIFF
--- a/web/src/lib/components/BacklinksPanel.svelte
+++ b/web/src/lib/components/BacklinksPanel.svelte
@@ -38,39 +38,51 @@
 	});
 
 	async function loadFirstPage() {
+		// Capture the request identity BEFORE the await. ItemDetail reuses this
+		// panel across a no-{#key} item switch (props just change), so a slower
+		// A load must NOT overwrite B's backlinks or push A's count into the
+		// parent's `backlinksCount` badge (PLAN-2105 / TASK-2112).
+		const reqSlug = itemSlug;
+		const reqWs = wsSlug;
 		loading = true;
 		error = '';
 		try {
-			const rows = await api.items.backlinks(wsSlug, itemSlug, { limit: PAGE_LIMIT });
+			const rows = await api.items.backlinks(reqWs, reqSlug, { limit: PAGE_LIMIT });
+			if (reqSlug !== itemSlug || reqWs !== wsSlug) return;
 			backlinks = rows;
 			hasMore = rows.length === PAGE_LIMIT;
 			onCountChange?.(rows.length);
 		} catch (err) {
+			if (reqSlug !== itemSlug || reqWs !== wsSlug) return;
 			error = err instanceof Error ? err.message : 'Failed to load backlinks';
 			backlinks = [];
 			hasMore = false;
 			// Empty contract: signal zero so the badge stays hidden on error.
 			onCountChange?.(0);
 		} finally {
-			loading = false;
+			if (reqSlug === itemSlug && reqWs === wsSlug) loading = false;
 		}
 	}
 
 	async function loadMore() {
 		if (loadingMore || !hasMore) return;
+		const reqSlug = itemSlug;
+		const reqWs = wsSlug;
 		loadingMore = true;
 		try {
-			const rows = await api.items.backlinks(wsSlug, itemSlug, {
+			const rows = await api.items.backlinks(reqWs, reqSlug, {
 				limit: PAGE_LIMIT,
 				offset: backlinks.length
 			});
+			if (reqSlug !== itemSlug || reqWs !== wsSlug) return;
 			backlinks = [...backlinks, ...rows];
 			hasMore = rows.length === PAGE_LIMIT;
 			onCountChange?.(backlinks.length);
 		} catch (err) {
+			if (reqSlug !== itemSlug || reqWs !== wsSlug) return;
 			error = err instanceof Error ? err.message : 'Failed to load more backlinks';
 		} finally {
-			loadingMore = false;
+			if (reqSlug === itemSlug && reqWs === wsSlug) loadingMore = false;
 		}
 	}
 

--- a/web/src/lib/components/ChildItems.svelte
+++ b/web/src/lib/components/ChildItems.svelte
@@ -160,16 +160,26 @@
 	// ── Data loading ─────────────────────────────────────────────────────────
 
 	async function loadChildren() {
+		// Capture the request identity (item + workspace) BEFORE the await.
+		// ItemDetail reuses this panel across a no-{#key} item switch (its
+		// `itemSlug` prop just changes), so a slower A load must NOT overwrite
+		// B's children — nor fire onChildrenChange with A's data into the
+		// parent's childItemIds / progress overrides (PLAN-2105 / TASK-2112).
+		const reqSlug = itemSlug;
+		const reqWs = wsSlug;
 		loading = true;
 		error = '';
 		try {
-			children = await api.items.children(wsSlug, itemSlug);
+			const loaded = await api.items.children(reqWs, reqSlug);
+			if (reqSlug !== itemSlug || reqWs !== wsSlug) return;
+			children = loaded;
 			onChildrenChange?.(children);
 		} catch (err) {
+			if (reqSlug !== itemSlug || reqWs !== wsSlug) return;
 			error = err instanceof Error ? err.message : 'Failed to load children';
 			onChildrenChange?.([]);
 		} finally {
-			loading = false;
+			if (reqSlug === itemSlug && reqWs === wsSlug) loading = false;
 		}
 	}
 

--- a/web/src/lib/components/CommentEditor.svelte
+++ b/web/src/lib/components/CommentEditor.svelte
@@ -85,12 +85,22 @@
 		if (busy || !editor) return;
 		const md = currentMarkdown();
 		if (md === '') return;
+		// Capture the composer's item identity BEFORE the await. This composer
+		// is REUSED across a no-{#key} item switch in the timeline (its `itemId`
+		// prop just changes), so if the user switches A→B while A's submit is in
+		// flight, clearing on completion would ERASE B's freshly-typed draft
+		// (PLAN-2105 / TASK-2112; Codex). Only clear when the composer is still
+		// on the same item and its editor is still alive.
+		const reqWs = wsSlug;
+		const reqItem = itemId;
 		saving = true;
 		try {
 			await onSubmit(md);
 			// Composer behaviour: clear on success. In edit/reply mode the host
 			// unmounts this component, so the clear is harmless there.
-			editor.commands.clearContent();
+			if (editor && !editor.isDestroyed && reqWs === wsSlug && reqItem === itemId) {
+				editor.commands.clearContent();
+			}
 		} catch {
 			// Keep the draft so the user can retry.
 		} finally {

--- a/web/src/lib/components/collections/BoardView.svelte
+++ b/web/src/lib/components/collections/BoardView.svelte
@@ -78,9 +78,15 @@
 		 * lane would be meaningless (the comparator would re-sort it).
 		 */
 		sortMode?: SortMode;
+		/**
+		 * Opt-in split-pane open (PLAN-2105 / TASK-2111). Threaded straight
+		 * through to each ItemCard; omitted everywhere except the collection
+		 * page, so other surfaces keep full-page anchor navigation.
+		 */
+		onItemOpen?: (item: Item) => void;
 	}
 
-	let { items, collection, wsSlug = '', groupField = 'status', focusedItemId = null, onStatusChange, onReorder, onArchiveColumn, onGroupReorder, oncreate, onCreateInColumn, onMoveColumn, onTagColumn, onUntagColumn, onSetPriorityColumn, onAssignColumn, members = [], tagSuggestions = [], filtered = false, itemProgress, progressLabel = 'tasks', canEdit = true, preserveOrder = false, sortMode = 'manual', draftText = $bindable({}), draftOpen = $bindable({}) }: Props = $props();
+	let { items, collection, wsSlug = '', groupField = 'status', focusedItemId = null, onStatusChange, onReorder, onArchiveColumn, onGroupReorder, oncreate, onCreateInColumn, onMoveColumn, onTagColumn, onUntagColumn, onSetPriorityColumn, onAssignColumn, members = [], tagSuggestions = [], filtered = false, itemProgress, progressLabel = 'tasks', canEdit = true, preserveOrder = false, sortMode = 'manual', draftText = $bindable({}), draftOpen = $bindable({}), onItemOpen }: Props = $props();
 
 	// Local — disables the draft card while its Enter-create is in flight.
 	let savingDraft = $state(false);
@@ -572,6 +578,7 @@
 							onMoveItem={canReorderLane(colValue) ? (it, dir) => moveItem(colValue, it, dir) : undefined}
 							horizontal={canReorderLane(colValue)}
 							reorderDisabledDirs={canReorderLane(colValue) ? moveDisabledDirs(colValue, i, colItems.length) : undefined}
+							{onItemOpen}
 						/>
 					</div>
 				{/each}

--- a/web/src/lib/components/collections/ItemCard.svelte
+++ b/web/src/lib/components/collections/ItemCard.svelte
@@ -37,9 +37,20 @@
 		onMoveItem?: (item: Item, dir: 'left' | 'right') => void;
 		/** Render the Move left / Move right menu entries (BoardView only). */
 		horizontal?: boolean;
+		/**
+		 * Opt-in split-pane open (PLAN-2105 / TASK-2111). When set, a plain
+		 * left-click on the card opens the item in the collection page's
+		 * detail pane instead of navigating; modifier/middle clicks still
+		 * fall through to the `href` so cmd/middle-click opens the full page
+		 * in a new tab (the "popout" state) and right-click-copy / SSR still
+		 * target the full page. Omitted everywhere except the collection page,
+		 * so all other surfaces (starred / tags / roles) keep full-page
+		 * anchor navigation.
+		 */
+		onItemOpen?: (item: Item) => void;
 	}
 
-	let { item, collection, compact = false, focused = false, showCollection = false, statusOptions, onStatusClick, progress = null, progressLabel = 'tasks', onReorderItem, reorderDisabledDirs, onMoveItem, horizontal = false }: Props = $props();
+	let { item, collection, compact = false, focused = false, showCollection = false, statusOptions, onStatusClick, progress = null, progressLabel = 'tasks', onReorderItem, reorderDisabledDirs, onMoveItem, horizontal = false, onItemOpen }: Props = $props();
 
 	let wsSlug = $derived(page.params.workspace ?? '');
 	let username = $derived(page.params.username ?? '');
@@ -148,9 +159,23 @@
 			setTimeout(() => { copied = false; }, 1500);
 		}
 	}
+
+	// Split-pane row-click interception (PLAN-2105 / TASK-2111). Only a plain
+	// left-click opens the pane; modifier/middle clicks fall through to the
+	// native <a href> (cmd/middle-click = full-page popout in a new tab,
+	// right-click-copy / SSR target the full page). Sub-controls (star / PR /
+	// status / tags / reorder) already stopPropagation, so their clicks never
+	// reach this handler; `defaultPrevented` is a defensive backstop.
+	function handleCardClick(e: MouseEvent) {
+		if (!onItemOpen) return;
+		if (e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+		if (e.defaultPrevented) return;
+		e.preventDefault();
+		onItemOpen(item);
+	}
 </script>
 
-<a href={itemUrl} class="item-card" class:compact class:focused class:has-pr={!!pullRequest}>
+<a href={itemUrl} class="item-card" class:compact class:focused class:has-pr={!!pullRequest} onclick={handleCardClick}>
 	{#if pullRequest}
 		<button
 			type="button"

--- a/web/src/lib/components/collections/ListView.svelte
+++ b/web/src/lib/components/collections/ListView.svelte
@@ -55,6 +55,12 @@
 		 * group would be meaningless.
 		 */
 		sortMode?: SortMode;
+		/**
+		 * Opt-in split-pane open (PLAN-2105 / TASK-2111). Threaded straight
+		 * through to each ItemCard; omitted everywhere except the collection
+		 * page, so other surfaces keep full-page anchor navigation.
+		 */
+		onItemOpen?: (item: Item) => void;
 	}
 
 	let {
@@ -73,7 +79,8 @@
 		progressLabel = 'tasks',
 		canEdit = true,
 		preserveOrder = false,
-		sortMode = 'manual'
+		sortMode = 'manual',
+		onItemOpen
 	}: Props = $props();
 
 	let confirmArchiveGroup = $state<string | null>(null);
@@ -360,6 +367,7 @@
 									{progressLabel}
 									onReorderItem={canReorderItems ? (it, dir) => reorderItem(groupName, it, dir) : undefined}
 									reorderDisabledDirs={canReorderItems ? disabledDirections(i, grpItems.length) : undefined}
+									{onItemOpen}
 								/>
 							</div>
 						{/each}

--- a/web/src/lib/components/collections/TableView.svelte
+++ b/web/src/lib/components/collections/TableView.svelte
@@ -26,6 +26,19 @@
 		canEdit?: boolean;
 		preserveOrder?: boolean;
 		sortMode?: SortMode;
+		/**
+		 * Opt-in split-pane open (PLAN-2105 / TASK-2111). When set, a plain
+		 * left-click on the title link opens the item in the collection page's
+		 * detail pane; modifier/middle clicks fall through to the `href`
+		 * (full-page popout). Omitted everywhere except the collection page.
+		 */
+		onItemOpen?: (item: Item) => void;
+		/**
+		 * Highlights the row whose detail pane is open (PLAN-2105 / TASK-2112),
+		 * mirroring the focused-row marker List/Board already show. Null =
+		 * nothing highlighted.
+		 */
+		focusedItemId?: string | null;
 	}
 
 	let {
@@ -39,8 +52,22 @@
 		onReorder,
 		canEdit = true,
 		preserveOrder = false,
-		sortMode = 'manual'
+		sortMode = 'manual',
+		onItemOpen,
+		focusedItemId = null
 	}: Props = $props();
+
+	// Split-pane row-click interception (PLAN-2105 / TASK-2111). Mirrors
+	// ItemCard: only a plain left-click opens the pane; modifier/middle
+	// clicks fall through to the native <a href> (full-page popout / SSR /
+	// right-click-copy).
+	function handleTitleClick(e: MouseEvent, item: Item) {
+		if (!onItemOpen) return;
+		if (e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+		if (e.defaultPrevented) return;
+		e.preventDefault();
+		onItemOpen(item);
+	}
 
 	let resolvedWsSlug = $derived(wsSlug || page.params.workspace || '');
 	let resolvedUsername = $derived(page.params.username || '');
@@ -200,10 +227,10 @@
 		</div>
 		{#each sortedItems as item, i (item.id)}
 			{@const fields = parseFields(item)}
-			<div class="table-row" role="row">
+			<div class="table-row" class:focused={focusedItemId === item.id} role="row">
 				<div class="table-cell col-ref" role="cell"><span class="ref">{formatItemRef(item) ?? ''}</span></div>
 				<div class="table-cell col-title" role="cell">
-					<a href="/{resolvedUsername}/{resolvedWsSlug}/{collection.slug}/{itemUrlId(item)}" class="title-link">{item.title}</a>
+					<a href="/{resolvedUsername}/{resolvedWsSlug}/{collection.slug}/{itemUrlId(item)}" class="title-link" onclick={(e) => handleTitleClick(e, item)}>{item.title}</a>
 					{#if itemProgress?.[item.id]}
 						{@const p = itemProgress[item.id]}
 						<div class="cell-progress">
@@ -305,6 +332,12 @@
 
 	.table-row:not(.table-header):hover {
 		background: var(--bg-hover);
+	}
+
+	/* Highlight the row whose detail pane is open (PLAN-2105 / TASK-2112). */
+	.table-row:not(.table-header).focused {
+		background: var(--bg-hover);
+		box-shadow: inset 2px 0 0 var(--accent-blue);
 	}
 
 	.table-cell {

--- a/web/src/lib/components/editor/EditorBubbleMenu.svelte
+++ b/web/src/lib/components/editor/EditorBubbleMenu.svelte
@@ -146,6 +146,15 @@
 		// navigated to another workspace mid-create. Per Codex review (round 2).
 		const ws = wsSlug;
 
+		// Capture the ORIGINATING editor instance too. This bubble menu is
+		// bound to the PERSISTENT editor (outside the split pane's {#key}),
+		// which the host remounts per-item. If the item switches A→B during the
+		// create await, the live `editor` prop now points at B's document —
+		// inserting A's wiki-link at A's stale selection coords would corrupt B.
+		// Require the SAME, undestroyed editor before the post-await insert /
+		// callback / toast (PLAN-2105 / TASK-2112; coordinator).
+		const originEditor = editor;
+
 		// Scope epoch before the create so the parent's optimistic upsert can be
 		// refused if a projection resync lands mid-create (BUG-2098).
 		const sinceEpoch = localIndex.scopeEpochFor(ws);
@@ -170,9 +179,25 @@
 				source: 'web',
 			});
 
+			// The editor was swapped out (item switch) during the create — the
+			// item WAS created (SSE/reconcile will index it), but do NOT insert
+			// its wiki-link into the now-different document, nor fire the
+			// callback/toast for it. Reset the persistent menu's form directly:
+			// hide() early-returns while `creating` is still true (the normal
+			// path hides via the post-insert selectionUpdate, which never fires
+			// here), so A's create form/selection would otherwise linger over B
+			// (Codex).
+			if (originEditor.isDestroyed || editor !== originEditor) {
+				visible = false;
+				showForm = false;
+				title = '';
+				errorMsg = '';
+				return;
+			}
+
 			// Replace the selection with a wiki-link
 			const wikiLink = `[[${item.title}]]`;
-			editor
+			originEditor
 				.chain()
 				.focus()
 				.deleteRange({ from: selFrom, to: selTo })

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -3000,21 +3000,28 @@
 				{starredStore.isStarred(item.id) ? '★' : '☆'}
 			</button>
 			{#if collection && (quickActions.length > 0 || isOwner)}
-				<QuickActionsMenu
-					actions={quickActions}
-					{item}
-					{collection}
-					scope="item"
-					{wsSlug}
-					canEdit={isOwner}
-					onmanage={() => {
-						editCollectionSection = 'actions';
-						editCollectionOpen = true;
-					}}
-					oncollectionupdated={(updated) => {
-						collection = updated;
-					}}
-				/>
+				<!-- {#key itemSlug}: structural containment (PLAN-2105 / TASK-2112).
+				     Remount this item-scoped menu on every item switch so any
+				     in-flight quick-action continuation is discarded. Keyed on
+				     itemSlug (the URL/ref identity), NOT item.id, so it resets the
+				     instant the ref changes rather than waiting for B to load. -->
+				{#key itemSlug}
+					<QuickActionsMenu
+						actions={quickActions}
+						{item}
+						{collection}
+						scope="item"
+						{wsSlug}
+						canEdit={isOwner}
+						onmanage={() => {
+							editCollectionSection = 'actions';
+							editCollectionOpen = true;
+						}}
+						oncollectionupdated={(updated) => {
+							collection = updated;
+						}}
+					/>
+				{/key}
 			{/if}
 			<button
 				class="action-btn"
@@ -3141,7 +3148,14 @@
 
 		<!-- Layout wrapper -->
 		<div class="item-body layout-{layout}">
-			<!-- Fields -->
+			<!-- Fields — {#key itemSlug}: structural containment (PLAN-2105 /
+			     TASK-2112). The fields sidebar (FieldEditor debounces, assignment
+			     selects) remounts on every item switch so a stale field
+			     continuation is discarded. The SIBLING .content-panel (the collab
+			     Editor) is deliberately OUTSIDE this key so it never remounts.
+			     Keyed on itemSlug (URL/ref identity), not item.id, so it resets
+			     the instant the ref changes. -->
+			{#key itemSlug}
 			<div class="fields-panel">
 				<div class="fields-header">Properties</div>
 				{#each schema.fields as field (field.key)}
@@ -3269,8 +3283,11 @@
 					</div>
 				{/if}
 			</div>
+			{/key}
 
-			<!-- Content editor -->
+			<!-- Content editor — OUTSIDE the {#key itemSlug} above: the collab
+			     Editor, EditorBubbleMenu, provider, collabKey and SSE stay
+			     persistent across an A→B item switch (the no-{#key} perf premise). -->
 			<div class="content-panel">
 				<div class="editor-mode-toggle">
 					<button
@@ -3284,7 +3301,17 @@
 							// Stay in raw mode if the flush failed — the
 							// user retains their unsaved edits to retry
 							// or copy out. Per Codex review round 6.
+							//
+							// Editor-write residue (this button writes rawMode
+							// on the PERSISTENT editor subtree — NOT inside the
+							// {#key}). Capture item+generation before the await:
+							// flushRawIfPending's re-entrancy waiter can resolve
+							// `true` AFTER a switch, and flipping rawMode then
+							// would apply to the WRONG item (PLAN-2105 / TASK-2112).
+							const startItemId = item?.id;
+							const startGen = loadGeneration;
 							const ok = await flushRawIfPending();
+							if (startGen !== loadGeneration || item?.id !== startItemId) return;
 							if (ok) {
 								rawSeedMarkdown = null;
 								rawMode = false;
@@ -3342,6 +3369,13 @@
 											md,
 											false,
 										);
+										// Fence IMMEDIATELY after the awaited flush,
+										// before inspecting `result`: if the pane
+										// switched items during this iteration, don't
+										// show B a recovery toast, keep looping, or
+										// fall through to rawMode=true for the wrong
+										// item (PLAN-2105 / TASK-2112; coordinator).
+										if (!item || item.id !== itemId || genAtToggle !== loadGeneration) return;
 										if (result === 'failed' || result === 'skipped') {
 											// 'failed' — PATCH errored;
 											//   runCollabFlush already
@@ -3509,6 +3543,14 @@
 			</div>
 		</div>
 
+		<!-- {#key itemSlug}: structural containment (PLAN-2105 / TASK-2112).
+		     Remounts the item-scoped data panels below (relationships, add-link
+		     form, ChildItems, BacklinksPanel, ItemTimeline incl. its comment
+		     composer + version cards) on every item switch, structurally
+		     cancelling their in-flight async loads/continuations. Keyed on
+		     itemSlug (URL/ref identity) so they reset — showing loading/empty —
+		     the instant the ref changes, before B's data resolves. -->
+		{#key itemSlug}
 		{#if relationshipGroups.length > 0}
 			<div class="relationships-section">
 				<h3 class="section-title">Relationships</h3>
@@ -3635,17 +3677,21 @@
 				collectionId={item.collection_id}
 			/>
 		</div>
+		{/key}
 
 	</div>
 
 	{#if isOwner && item}
-		<ShareDialog
-			{wsSlug}
-			type="item"
-			targetSlug={item.slug}
-			targetName={formatItemRef(item) || item.title}
-			bind:open={shareDialogOpen}
-		/>
+		<!-- {#key itemSlug}: remount the item-scoped share dialog on switch. -->
+		{#key itemSlug}
+			<ShareDialog
+				{wsSlug}
+				type="item"
+				targetSlug={item.slug}
+				targetName={formatItemRef(item) || item.title}
+				bind:open={shareDialogOpen}
+			/>
+		{/key}
 	{/if}
 
 	{#if showGraph && item && graphFocusRef}
@@ -3682,6 +3728,9 @@
 	{/if}
 
 	{#if isOwner && collection}
+		<!-- {#key itemSlug}: remount the owner collection-editor modal on item
+		     switch (it's closed on switch anyway; keeps its async loads scoped). -->
+		{#key itemSlug}
 		<EditCollectionModal
 			bind:open={editCollectionOpen}
 			{collection}
@@ -3736,6 +3785,7 @@
 				editCollectionSection = undefined;
 			}}
 		/>
+		{/key}
 	{/if}
 {/if}
 

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -128,6 +128,15 @@
 	// counter — not reactive; it only fences async writes.
 	let loadGeneration = 0;
 
+	// True when a captured (item, generation) snapshot is no longer the one on
+	// screen — the uniform fence for DROPPING a post-await write/feedback after
+	// a no-{#key} pane switch (PLAN-2105 / TASK-2112; Codex). Checks BOTH the
+	// item id (cheap) AND the load generation, which closes the A→B→A gap where
+	// the returning id matches but a newer load replaced the item in between.
+	function switchedAway(targetItem: Item, gen: number): boolean {
+		return gen !== loadGeneration || item?.id !== targetItem.id;
+	}
+
 	// Cross-collection `?item=` safety (PLAN-2105 / TASK-2112). A stale /
 	// shared / hand-crafted `?item=REF` in the split pane could reference an
 	// item that lives in a DIFFERENT collection than the route's `collSlug`
@@ -156,12 +165,21 @@
 	//
 	// Embedded panes don't pass `onReady` — they manage their own scroll
 	// container (TASK-2112), not the route-level snapshot.
-	let scrollReady = $derived(
-		!loading &&
-			item !== null &&
+	//
+	// itemMatchesRef is true once the LOADED item's identity matches the
+	// requested ref/slug — i.e. loadData for the current `itemSlug` has
+	// resolved and we're not still rendering the PREVIOUS item mid-switch.
+	// It's the switch boundary for the no-{#key} prop update: reused by
+	// scrollReady AND by the collab lifecycle gate (collabKey below), so a
+	// stale provider for the previous item tears down the instant `ref`
+	// changes — before the new fetch resolves — instead of lingering with a
+	// destroyed editor (PLAN-2105 / TASK-2112 switch-safety; Codex).
+	let itemMatchesRef = $derived(
+		item !== null &&
 			(item.slug === itemSlug ||
 				`${item.collection_prefix}-${item.item_number}` === itemSlug),
 	);
+	let scrollReady = $derived(!loading && itemMatchesRef);
 	$effect(() => {
 		onReady?.(scrollReady);
 	});
@@ -320,12 +338,19 @@
 	// (TASK-2028).
 
 	async function handleCopyRef() {
-		const ref = formatItemRef(item!);
+		if (!item) return;
+		const targetItem = item;
+		const gen = loadGeneration;
+		const ref = formatItemRef(targetItem);
 		if (!ref) return;
 		const success = await copyToClipboard(ref);
-		if (success) {
+		// Don't flip the "Copied!" checkmark on a different item if the pane
+		// switched during the async clipboard write (Codex).
+		if (success && !switchedAway(targetItem, gen)) {
 			copied = true;
-			setTimeout(() => { copied = false; }, 1500);
+			setTimeout(() => {
+				if (!switchedAway(targetItem, gen)) copied = false;
+			}, 1500);
 		}
 	}
 	let relationshipGroups = $derived(item ? buildRelationshipGroups(item, itemLinks, childItemIds) : []);
@@ -418,6 +443,17 @@
 		// state integration; tracked separately.
 		unsubscribeSSE = sseService.onItemEvent(async (event) => {
 			if (!item || event.item_id !== item.id) return;
+			// Ignore events while mid-switch: during A→B the loaded `item` is
+			// still A but the requested ref is already B, so a stale archive/
+			// delete event for A would otherwise call handleGone() and close
+			// B's just-opening pane. The new item's loadData refetches fresh
+			// state anyway (PLAN-2105 / TASK-2112; Codex).
+			if (!itemMatchesRef) return;
+			// Capture the generation at accept-time; every post-await guard
+			// below also checks it so a switch DURING an in-flight refetch (or
+			// an A→B→A that re-matches the id) can't apply a stale write or fire
+			// handleGone() against the wrong item.
+			const sseGen = loadGeneration;
 
 			// Archive is destructive and must NOT be gated by the
 			// edit-conflict guard below — a user editing a since-archived
@@ -447,10 +483,10 @@
 				const archItemSlug = itemSlug;
 				try {
 					const archived = await api.items.get(archWsSlug, archItemSlug);
-					if (!item || item.id !== archItemId) return;
+					if (!item || item.id !== archItemId || sseGen !== loadGeneration) return;
 					item = withInflightTags(archived);
 				} catch {
-					if (!item || item.id !== archItemId) return;
+					if (!item || item.id !== archItemId || sseGen !== loadGeneration) return;
 					handleGone();
 				}
 				return;
@@ -475,7 +511,7 @@
 					try {
 						const updated = await api.items.get(reqWsSlug, reqItemSlug);
 						// Bail if the user navigated away before this resolved.
-						if (!item || item.id !== reqItemId) return;
+						if (!item || item.id !== reqItemId || sseGen !== loadGeneration) return;
 						// Drop TASK-1243's conservative content-skip
 						// when collab is active (TASK-1262). Under
 						// collab the editor reads from Y.Doc, NOT
@@ -494,7 +530,7 @@
 						// still lose chars without this branch.
 						item = adoptServerItem(updated);
 						const links = await api.links.list(reqWsSlug, updated.slug).catch(() => []);
-						if (!item || item.id !== reqItemId) return;
+						if (!item || item.id !== reqItemId || sseGen !== loadGeneration) return;
 						itemLinks = links;
 					} catch {
 						// Ignore — will catch up on next event
@@ -504,7 +540,7 @@
 				case 'item_restored': {
 					try {
 						const updated = await api.items.get(reqWsSlug, reqItemSlug);
-						if (!item || item.id !== reqItemId) return;
+						if (!item || item.id !== reqItemId || sseGen !== loadGeneration) return;
 						item = adoptServerItem(updated);
 					} catch {
 						// Ignore — will catch up on next event
@@ -516,6 +552,15 @@
 
 		unsubscribeSync = syncService.onSync(async (result) => {
 			if (!wsSlug || !itemSlug || !item) return;
+			// Ignore sync results while mid-switch (loaded item still A, ref
+			// already B) so a stale delete/refresh can't close B's pane or
+			// clobber it — the new item's loadData refetches fresh state
+			// (PLAN-2105 / TASK-2112; Codex).
+			if (!itemMatchesRef) return;
+			// Generation captured at accept-time; every post-await guard below
+			// also checks it so a switch during an in-flight refetch (or an
+			// A→B→A id re-match) can't clobber the wrong item or fire handleGone.
+			const syncGen = loadGeneration;
 
 			if (result.type === 'caught_up') return;
 
@@ -543,10 +588,10 @@
 				const delItemSlug = itemSlug;
 				try {
 					const refreshed = await api.items.get(delWsSlug, delItemSlug);
-					if (!item || item.id !== delItemId) return;
+					if (!item || item.id !== delItemId || syncGen !== loadGeneration) return;
 					item = withInflightTags(refreshed);
 				} catch {
-					if (!item || item.id !== delItemId) return;
+					if (!item || item.id !== delItemId || syncGen !== loadGeneration) return;
 					handleGone();
 				}
 				return;
@@ -570,10 +615,10 @@
 					// Merge server state without disrupting the editor.
 					// Same collab-aware adoption rule as the SSE
 					// handler above (TASK-1262).
-					if (!item || item.id !== reqItemId) return;
+					if (!item || item.id !== reqItemId || syncGen !== loadGeneration) return;
 					item = adoptServerItem(updated);
 					const links = await api.links.list(reqWsSlug, updated.slug).catch(() => []);
-					if (!item || item.id !== reqItemId) return;
+					if (!item || item.id !== reqItemId || syncGen !== loadGeneration) return;
 					itemLinks = links;
 				}
 				return;
@@ -582,10 +627,10 @@
 			// Full refresh fallback
 			try {
 				const updated = await api.items.get(reqWsSlug, reqItemSlug);
-				if (!item || item.id !== reqItemId) return;
+				if (!item || item.id !== reqItemId || syncGen !== loadGeneration) return;
 				item = adoptServerItem(updated);
 				const links = await api.links.list(reqWsSlug, updated.slug).catch(() => []);
-				if (!item || item.id !== reqItemId) return;
+				if (!item || item.id !== reqItemId || syncGen !== loadGeneration) return;
 				itemLinks = links;
 				syncService.markSynced(); // Advance cursor now that reload succeeded
 			} catch {
@@ -624,10 +669,57 @@
 		contentDebounceTimer = undefined;
 		collabFlusher.cancel();
 		rawSeedMarkdown = null;
+		// Raw-mode data-loss guard (PLAN-2105 / TASK-2112; coordinator P1).
+		// In raw mode there is NO collab cleanup flush, so switching A→B within
+		// the 1.2s debounce would silently DROP A's pending markdown at
+		// clearPending() below. `item` still holds the OLD item here (B's fetch
+		// hasn't resolved — this runs at the top of loadData, before Promise.all),
+		// so flush the pending edit with keepalive (fire-and-forget, survives the
+		// swap) FIRST. The saver's `save` callback captures the live item.id (the
+		// old item) internally, so the PATCH targets the right item.
+		//
+		// UNTRACK is load-bearing (Codex): loadData runs inside the route
+		// $effect's tracking scope, and flushNow synchronously invokes the save
+		// callback which reads `item`. A tracked read here would make `item` a
+		// dependency of the route effect → loadData would re-fire on every item
+		// mutation (SSE / field edit), a duplicate-load loop. untrack keeps
+		// loadData's dependency set unchanged.
+		untrack(() => {
+			if (rawContentSaver.dirty && item) {
+				rawContentSaver.flushNow({ keepalive: true });
+			}
+		});
 		// Cancel the raw saver's debounce and drop its pending edit so a
 		// stale queued markdown from item A can't PATCH into item B.
 		rawContentSaver.cancel();
 		rawContentSaver.clearPending();
+		// Reset item-scoped ephemeral UI so an armed / open control from the
+		// PREVIOUS item can't act on the newly-loaded one across the no-{#key}
+		// prop-update switch (PLAN-2105 / TASK-2112; coordinator P2).
+		// confirmDelete is the dangerous one — armed on A, switch to B, and a
+		// confirming click would delete B — but every open menu / dialog / drawer,
+		// the in-place title edit, and the add-relationship search box are
+		// item-scoped and must not survive the swap. The in-flight operation
+		// flags (deleting / moving / restoring) are cleared too: they gate the
+		// CURRENTLY-shown item's buttons, so B must start clean — the previous
+		// item's op continues under its own switch-fenced handler, whose finally
+		// settles the flag again harmlessly.
+		confirmDelete = false;
+		deleting = false;
+		moving = false;
+		restoring = false;
+		refreshing = false;
+		copied = false;
+		editingTitle = false;
+		showMoveMenu = false;
+		showAddLink = false;
+		addLinkSearch = '';
+		addLinkResults = [];
+		addLinkLoading = false;
+		shareDialogOpen = false;
+		editCollectionOpen = false;
+		showGraph = false;
+		backlinksCount = 0;
 		// lastFlushedContent is per-item; resetting prevents the
 		// dedupe from incorrectly suppressing the first flush on
 		// the next item (which happens to share the same markdown
@@ -851,7 +943,15 @@
 	// the new collab $effect run (after rebuild completes). Per
 	// Codex round 7 [P1] of TASK-1319.
 	let forceRefreshInFlight = false;
-	const collabKey = $derived(item && canEdit && !rawMode ? item.id : null);
+	// Gated on `itemMatchesRef` (PLAN-2105 / TASK-2112 switch-safety): the
+	// instant `ref` changes, `item` still holds the PREVIOUS item until the
+	// new fetch resolves, so without this gate collabKey would stay the old
+	// item id — leaving the old provider connected while its editor is
+	// unmounted (a stale applier would then ACK success against a destroyed
+	// editor). Going null tears the old provider down (its $effect cleanup
+	// still flushes the Y.Doc) until the new item loads. Same-item reloads
+	// keep the provider (item.slug still matches itemSlug). Codex.
+	const collabKey = $derived(item && itemMatchesRef && canEdit && !rawMode ? item.id : null);
 
 	// Local user identity broadcast over awareness for the
 	// CollaborationCaret extension (TASK-1263). Colour is a
@@ -1066,7 +1166,17 @@
 			// items.content directly. The full ExpiresAtMillis-driven
 			// late-apply guard is TASK-1262's concern.
 			onApplierRequest: async (markdown, _requestID, expiresAtMillis) => {
-				if (!editorInstance) return false;
+				// Reject unless we can apply into the LIVE editor for THIS
+				// provider's item. The no-{#key} pane switch can leave
+				// editorInstance pointing at a destroyed editor, or this
+				// provider stale (superseded / item moved on), in which case
+				// setContent would silently ACK success while applying no
+				// Yjs transaction. Falling through to `false` lets the
+				// server's direct-write fallback own the PATCH instead
+				// (PLAN-2105 / TASK-2112; Codex).
+				if (!editorInstance || editorInstance.isDestroyed) return false;
+				if (collabProvider !== provider) return false;
+				if (!item || item.id !== itemId) return false;
 				// Pre-mutation late-apply guard. The provider already
 				// gates the ack on expiry but the actual setContent
 				// is owned here; gating the mutation itself is the
@@ -1145,12 +1255,16 @@
 				// the user is already showing the toast about a
 				// refresh. Per Codex round 4 [P1].
 				const refreshCtx = ctx;
+				const refreshGen = loadGeneration;
 				void api.items
 					.get(refreshCtx.wsSlug, refreshCtx.itemId)
 					.then((fresh) => {
-						// Apply only if the user is still on this
-						// item; a navigation away should not stamp
-						// fresh content into the OTHER item's slot.
+						// Only act if THIS provider is still the active one and
+						// we haven't switched items. A pane switch already tore
+						// this provider down; bumping the nonce would rebuild the
+						// NEW item's provider needlessly and stamp A's content
+						// into the wrong slot (PLAN-2105 / TASK-2112; Codex).
+						if (collabProvider !== provider || refreshGen !== loadGeneration) return;
 						if (item && item.id === refreshCtx.itemId) {
 							item = withInflightTags(fresh);
 						}
@@ -1158,6 +1272,9 @@
 						forceRefreshNonce += 1;
 					})
 					.catch((err) => {
+						// Suppress the error toast for a superseded provider —
+						// the switch already replaced this editor session.
+						if (collabProvider !== provider || refreshGen !== loadGeneration) return;
 						// Refetch failed — we cannot guarantee the
 						// cached `item.content` reflects canonical
 						// server state. Rebuilding here would
@@ -1417,11 +1534,21 @@
 	async function saveTitle() {
 		editingTitle = false;
 		if (!item || titleDraft.trim() === item.title) return;
+		// Capture the target item + generation BEFORE the await. A blur-fired
+		// saveTitle can resolve AFTER the pane switched to another item (click
+		// row B while editing A's title); dropping the write then keeps the
+		// pane from showing A under ?item=B (PLAN-2105 / TASK-2112; coordinator
+		// P1). The PATCH itself targets `targetItem.id` (captured, = A).
+		const targetItem = item;
+		const gen = loadGeneration;
 		saveStatus = 'saving';
 		try {
-			item = withInflightTags(await api.items.update(wsSlug, item.id, { title: titleDraft.trim() }));
+			const updated = await api.items.update(wsSlug, targetItem.id, { title: titleDraft.trim() });
+			if (gen !== loadGeneration || item?.id !== targetItem.id) return;
+			item = withInflightTags(updated);
 			showSaved();
 		} catch {
+			if (gen !== loadGeneration || item?.id !== targetItem.id) return;
 			saveStatus = 'idle';
 			toastStore.show('Failed to update title', 'error');
 		}
@@ -1444,6 +1571,14 @@
 		const payload = JSON.stringify(updated);
 		const targetItem = item;
 		const targetWs = wsSlug;
+		// Generation + id fence (Codex). A plain id check has an A→B→A gap (the
+		// returning id matches but the response is stale) and would also leak
+		// A's save/error feedback (showSaved / saveStatus / toasts) onto B.
+		// `stillCurrent()` gates EVERY post-await branch — success, the
+		// open-children force-retry, the decline, and the error paths — so a
+		// switch mid-request completes silently.
+		const gen = loadGeneration;
+		const stillCurrent = () => gen === loadGeneration && item?.id === targetItem.id;
 		saveStatus = 'saving';
 
 		const doUpdate = (force: boolean) =>
@@ -1454,7 +1589,8 @@
 
 		try {
 			const fresh = await doUpdate(false);
-			if (item && item.id === targetItem.id) item = withInflightTags(fresh);
+			if (!stillCurrent()) return;
+			item = withInflightTags(fresh);
 			showSaved();
 		} catch (e) {
 			// BUG-1538 / TASK-1539: same open-children-guard recovery
@@ -1464,21 +1600,33 @@
 			// force-override instead of toasting a vague "Failed to
 			// save".
 			if (isOpenChildrenError(e)) {
+				// Don't even OPEN the confirm dialog if the pane already switched
+				// items while the 409 was in flight — A's dialog must not appear
+				// over B. The retry callback is likewise fenced so a force-PATCH
+				// can't fire for a no-longer-shown item (Codex).
+				if (!stillCurrent()) return;
 				const parentRef = formatItemRef(targetItem) ?? targetItem.slug;
 				let forced;
 				try {
-					forced = await confirmOpenChildrenOrThrow(e, parentRef, () => doUpdate(true));
+					forced = await confirmOpenChildrenOrThrow(e, parentRef, () => {
+						if (!stillCurrent()) throw new Error('switched away');
+						return doUpdate(true);
+					});
 				} catch (retryErr) {
 					// The force retry itself failed (network / 500 /
 					// fresh validation error after the override).
+					if (!stillCurrent()) return;
 					saveStatus = 'idle';
 					const msg = retryErr instanceof Error ? retryErr.message : 'Failed to save';
 					console.error('Forced field update failed:', retryErr);
 					toastStore.show(msg, 'error');
 					return;
 				}
+				// Switched items while the confirm modal was up — complete
+				// silently rather than stamping A's result onto B.
+				if (!stillCurrent() || !item) return;
 				if (forced) {
-					if (item && item.id === targetItem.id) item = withInflightTags(forced);
+					item = withInflightTags(forced);
 					showSaved();
 					return;
 				}
@@ -1489,11 +1637,12 @@
 				// reference so child components re-prop unambiguously
 				// even if they cache by identity.
 				saveStatus = 'idle';
-				if (item && item.id === targetItem.id) item = { ...item };
+				item = { ...item };
 				toastStore.show('Status change cancelled', 'info');
 				return;
 			}
 			// Any other failure mode — network, validation, 500, etc.
+			if (!stillCurrent()) return;
 			saveStatus = 'idle';
 			console.error('Failed to save field:', e);
 			toastStore.show('Failed to save', 'error');
@@ -1670,12 +1819,16 @@
 		if (!item) return;
 		const targetItem = item;
 		const targetWs = wsSlug;
+		// Generation fence closes the A→B→A gap the id-only check missed — a
+		// stale GET could otherwise issue a full-fields PATCH against a
+		// re-shown item (Codex).
+		const gen = loadGeneration;
 		try {
 			// Re-fetch to get the latest fields snapshot from the server,
 			// then merge our two keys. This narrows but does not fully
 			// close the race against concurrent field edits.
 			const latest = await api.items.get(targetWs, targetItem.id);
-			if (!item || item.id !== targetItem.id) return;
+			if (switchedAway(targetItem, gen)) return;
 			const latestFields = parseFields(latest);
 			const merged = {
 				...latestFields,
@@ -1685,20 +1838,18 @@
 			const fresh = await api.items.update(targetWs, targetItem.id, {
 				fields: JSON.stringify(merged)
 			});
-			if (item && item.id === targetItem.id) {
-				item = withInflightTags(fresh);
-			}
+			if (switchedAway(targetItem, gen)) return;
+			item = withInflightTags(fresh);
 		} catch (err) {
 			// Non-fatal: the content was inserted regardless of whether
 			// the stamping succeeded. Toast so the user knows the
 			// "Refresh from source" affordance won't be available.
 			console.warn('failed to stamp source_url', err);
-			if (item && item.id === targetItem.id) {
-				toastStore.show(
-					'Imported, but source_url not saved — refresh affordance disabled',
-					'error'
-				);
-			}
+			if (switchedAway(targetItem, gen)) return;
+			toastStore.show(
+				'Imported, but source_url not saved — refresh affordance disabled',
+				'error'
+			);
 		}
 	}
 
@@ -1739,6 +1890,9 @@
 		// and bail if not. (Per Codex review round 2.)
 		const targetItem = item;
 		const targetEditor = editorInstance;
+		// Generation fence (Codex) alongside the item/editor identity checks —
+		// closes the A→B→A gap and keeps A's spinner/toast off B.
+		const gen = loadGeneration;
 		const ok = typeof window !== 'undefined' &&
 			window.confirm(
 				`Replace the current content with a fresh fetch from:\n${url}\n\n` +
@@ -1751,7 +1905,7 @@
 			// Bail if the user navigated to a different item — applying
 			// the refresh now would target the wrong document AND stamp
 			// the wrong source URL.
-			if (!item || item.id !== targetItem.id || editorInstance !== targetEditor) {
+			if (switchedAway(targetItem, gen) || editorInstance !== targetEditor) {
 				return;
 			}
 			const html = marked.parse(resp.markdown, { async: false }) as string;
@@ -1769,28 +1923,29 @@
 			// resolved through a different final URL on this fetch.
 			// stampSourceUrl's own guard re-checks identity.
 			await stampSourceUrl(resp);
-			if (item && item.id === targetItem.id) {
+			if (!switchedAway(targetItem, gen)) {
 				toastStore.show('Refreshed from source', 'success');
 			}
 		} catch (err) {
-			if (item && item.id === targetItem.id) {
+			if (!switchedAway(targetItem, gen)) {
 				toastStore.show(err instanceof Error ? err.message : 'Refresh failed', 'error');
 			}
 		} finally {
-			// Always clear the spinner. The page component is reused
-			// across item navigation, so leaving `refreshing = true`
-			// when the user navigates away would re-emerge as a stuck
-			// "Refreshing…" label the next time they open ANY item
-			// with a source_url. The visual feedback is per-item only
-			// while the user stays on the originating item; that's
-			// acceptable — a successful navigation already signals
-			// "user moved on". (Per Codex review round 3.)
-			refreshing = false;
+			// Clear the spinner for the originating item only. loadData resets
+			// `refreshing` on a switch so B always starts clean; guarding here
+			// stops a superseded refresh from clearing a NEWER item's spinner
+			// (Codex). Navigating away already signals "user moved on".
+			if (!switchedAway(targetItem, gen)) refreshing = false;
 		}
 	}
 
 	async function updateAssignedUser(userId: string | null) {
 		if (!item) return;
+		// Capture target + generation before the await; drop the post-await
+		// write if the pane switched items mid-request (PLAN-2105 / TASK-2112;
+		// coordinator P1).
+		const targetItem = item;
+		const gen = loadGeneration;
 		saveStatus = 'saving';
 		try {
 			const update: Record<string, any> = {};
@@ -1799,9 +1954,12 @@
 			} else {
 				update.clear_assigned_user = true;
 			}
-			item = withInflightTags(await api.items.update(wsSlug, item.id, update));
+			const updated = await api.items.update(wsSlug, targetItem.id, update);
+			if (gen !== loadGeneration || item?.id !== targetItem.id) return;
+			item = withInflightTags(updated);
 			showSaved();
 		} catch {
+			if (gen !== loadGeneration || item?.id !== targetItem.id) return;
 			saveStatus = 'idle';
 			toastStore.show('Failed to update assignment', 'error');
 		}
@@ -1809,6 +1967,11 @@
 
 	async function updateAgentRole(roleId: string | null) {
 		if (!item) return;
+		// Capture target + generation before the await; drop the post-await
+		// write if the pane switched items mid-request (PLAN-2105 / TASK-2112;
+		// coordinator P1).
+		const targetItem = item;
+		const gen = loadGeneration;
 		saveStatus = 'saving';
 		try {
 			const update: Record<string, any> = {};
@@ -1817,9 +1980,12 @@
 			} else {
 				update.clear_agent_role = true;
 			}
-			item = withInflightTags(await api.items.update(wsSlug, item.id, update));
+			const updated = await api.items.update(wsSlug, targetItem.id, update);
+			if (gen !== loadGeneration || item?.id !== targetItem.id) return;
+			item = withInflightTags(updated);
 			showSaved();
 		} catch {
+			if (gen !== loadGeneration || item?.id !== targetItem.id) return;
 			saveStatus = 'idle';
 			toastStore.show('Failed to update role', 'error');
 		}
@@ -1853,6 +2019,12 @@
 		editorStore.setDirty(true);
 		contentDebounceTimer = setTimeout(() => {
 			if (!item) return;
+			// Capture identity at fire time. loadData cancels this timer on a
+			// switch, so it normally can't fire for a stale item — but an
+			// already-dispatched PATCH resolving late must not leak its
+			// saved/error feedback onto a switched-in item (Codex).
+			const reqItem = item;
+			const gen = loadGeneration;
 			saveStatus = 'saving';
 			// Set lastSaveTime BEFORE the API call so the SSE guard works
 			// even if the SSE event arrives before the response.
@@ -1863,13 +2035,15 @@
 				toSave = markdownToWikiLinks(toSave, allItems);
 			}
 			toSave = cleanBrokenLinks(toSave);
-			api.items.update(wsSlug, item.id, { content: toSave }).then(() => {
+			api.items.update(wsSlug, reqItem.id, { content: toSave }).then(() => {
+				if (switchedAway(reqItem, gen)) return;
 				// Don't overwrite item -- resetting editorContent would
 				// clobber anything typed since the debounce started.
 				editorStore.setLastSaveTime(Date.now());
 				editorStore.setDirty(false);
 				showSaved();
 			}).catch(() => {
+				if (switchedAway(reqItem, gen)) return;
 				saveStatus = 'idle';
 				toastStore.show('Failed to save content', 'error');
 			});
@@ -2030,7 +2204,11 @@
 			// late-arriving response after navigation to a new item
 			// can't apply the old item's snapshot to the new page
 			// state (cross-item bleed). Per Codex review round 11.
+			// The load generation is captured alongside it to close the
+			// A→B→A gap the id-only check missed — a returning id can match a
+			// re-shown item that a newer load already replaced (Codex).
 			const reqItemId = item.id;
+			const genAtSave = loadGeneration;
 			if (keepalive) {
 				// BUG-2024 keepalive-on-unload path. Fire an immediate
 				// keepalive PATCH so the edit survives page teardown
@@ -2041,7 +2219,7 @@
 				return api.items
 					.update(wsSlug, reqItemId, { content: markdown }, { keepalive: true })
 					.then(() => {
-						if (item && item.id === reqItemId && rawContentSaver.pending === markdown) {
+						if (item && item.id === reqItemId && genAtSave === loadGeneration && rawContentSaver.pending === markdown) {
 							rawContentSaver.clearPending();
 							editorStore.setDirty(false);
 						}
@@ -2054,7 +2232,7 @@
 			// Raw mode: content is already in storage format (with [[wiki links]])
 			const toSave = markdown;
 			return api.items.update(wsSlug, reqItemId, { content: toSave }).then((updated) => {
-				if (!item || item.id !== reqItemId) return;
+				if (!item || item.id !== reqItemId || genAtSave !== loadGeneration) return;
 				editorStore.setLastSaveTime(Date.now());
 				// Raw saves change items.content via a path the
 				// collab dedupe doesn't see. Without resetting the
@@ -2082,7 +2260,7 @@
 					item = withInflightTags({ ...updated, content: item.content });
 				}
 			}).catch(() => {
-				if (!item || item.id !== reqItemId) return;
+				if (!item || item.id !== reqItemId || genAtSave !== loadGeneration) return;
 				saveStatus = 'idle';
 				toastStore.show('Failed to save content', 'error');
 			});
@@ -2142,11 +2320,14 @@
 		if (rawContentSaver.pending === null) return true;
 
 		rawFlushInFlight = true;
-		// Capture the item id once for the entire drain. If the user
-		// navigates away mid-flush, every iteration's stale response
-		// (including the in-flight one) is discarded so it can't
-		// clobber the newly-loaded item. Per Codex review round 11.
+		// Capture the item id + load generation once for the entire drain. If
+		// the user navigates away mid-flush, every iteration's stale response
+		// (including the in-flight one) is discarded so it can't clobber the
+		// newly-loaded item. The generation closes the A→B→A id-reuse gap the
+		// id-only check missed. Per Codex review round 11 + PLAN-2105 switch-
+		// safety.
 		const reqItemId = item.id;
+		const genAtFlush = loadGeneration;
 		let lastError = false;
 		try {
 			for (let i = 0; i < RAW_FLUSH_DRAIN_CAP; i++) {
@@ -2157,7 +2338,7 @@
 					saveStatus = 'saving';
 					editorStore.setLastSaveTime(Date.now());
 					const updated = await api.items.update(wsSlug, reqItemId, { content: markdown });
-					if (!item || item.id !== reqItemId) {
+					if (!item || item.id !== reqItemId || genAtFlush !== loadGeneration) {
 						// Navigation completed during the await;
 						// abort and let the new item's state take
 						// over.
@@ -2187,6 +2368,10 @@
 						item = withInflightTags({ ...updated, content: item.content });
 					}
 				} catch {
+					// Don't surface A's save failure over B (a superseded
+					// drain must not reset the current item's saveStatus /
+					// toast) — Codex.
+					if (!item || item.id !== reqItemId || genAtFlush !== loadGeneration) return false;
 					saveStatus = 'idle';
 					toastStore.show('Failed to save content', 'error');
 					lastError = true;
@@ -2355,12 +2540,22 @@
 
 	async function handleDelete() {
 		if (!item) return;
+		// Capture identity before the await. The DELETE targets `targetItem.id`
+		// (= A), but the post-await feedback must be fenced: if the pane
+		// switched to B while A's delete was in flight, calling handleGone()
+		// would close B's pane (embedded onGone = closeItemPane) and the toast
+		// would show over B. A was deleted regardless — the list reflects it via
+		// SSE (PLAN-2105 / TASK-2112; Codex).
+		const targetItem = item;
+		const gen = loadGeneration;
 		deleting = true;
 		try {
-			await api.items.delete(wsSlug, item.id);
+			await api.items.delete(wsSlug, targetItem.id);
+			if (switchedAway(targetItem, gen)) return;
 			toastStore.show('Item deleted', 'success');
 			handleGone();
 		} catch {
+			if (switchedAway(targetItem, gen)) return;
 			toastStore.show('Failed to delete item', 'error');
 			deleting = false;
 			confirmDelete = false;
@@ -2375,16 +2570,27 @@
 	// archived — surface that message the same way other handlers do. TASK-1829.
 	async function handleRestore() {
 		if (!item || restoring) return;
+		// Capture target + generation before the awaits; drop the post-await
+		// write if the pane switched items mid-request (PLAN-2105 / TASK-2112;
+		// coordinator "gate all post-await writes").
+		const targetItem = item;
+		const targetSlug = itemSlug;
+		const gen = loadGeneration;
 		restoring = true;
 		try {
-			await api.items.restore(wsSlug, itemSlug);
-			const refreshed = await api.items.get(wsSlug, itemSlug);
+			await api.items.restore(wsSlug, targetSlug);
+			const refreshed = await api.items.get(wsSlug, targetSlug);
+			if (switchedAway(targetItem, gen)) return;
 			item = withInflightTags(refreshed);
 			toastStore.show('Item restored', 'success');
 		} catch (e: any) {
+			if (switchedAway(targetItem, gen)) return;
 			toastStore.show(e.message ?? 'Failed to restore item', 'error');
 		} finally {
-			restoring = false;
+			// Don't clobber a NEWER item's restore flag: loadData already reset
+			// `restoring` for the new item on switch, so a superseded restore's
+			// finally must leave it alone.
+			if (!switchedAway(targetItem, gen)) restoring = false;
 		}
 	}
 
@@ -2396,14 +2602,26 @@
 
 	async function handleDeleteLink(linkId?: string) {
 		if (!linkId || !item) return;
+		// Capture identity BEFORE the awaits. The refresh GET must use the
+		// captured slug (not the live `itemSlug`, which an A→B→C switch would
+		// have advanced) and the result must be dropped if we switched away —
+		// otherwise B's refresh could land under C's ref, carrying the current
+		// item's content (Codex).
+		const targetItem = item;
+		const targetSlug = itemSlug;
+		const targetWs = wsSlug;
+		const gen = loadGeneration;
 		try {
-			await api.links.delete(wsSlug, linkId);
+			await api.links.delete(targetWs, linkId);
+			if (switchedAway(targetItem, gen)) return;
 			itemLinks = itemLinks.filter(l => l.id !== linkId);
 			// Refresh item to update parent info
-			const refreshed = await api.items.get(wsSlug, itemSlug);
+			const refreshed = await api.items.get(targetWs, targetSlug);
+			if (switchedAway(targetItem, gen) || !item) return;
 			item = withInflightTags({ ...refreshed, content: item.content });
 			toastStore.show('Relationship removed', 'success');
 		} catch (e: any) {
+			if (switchedAway(targetItem, gen)) return;
 			toastStore.show(e.message ?? 'Failed to remove relationship', 'error');
 		}
 	}
@@ -2420,9 +2638,13 @@
 			addLinkResults = [];
 			return;
 		}
+		// Fence the async search so results from item A's add-link box can't
+		// repopulate the panel after switching to item B (Codex).
+		const gen = loadGeneration;
 		addLinkLoading = true;
 		try {
 			const results = await api.search(addLinkSearch, { workspace: wsSlug });
+			if (gen !== loadGeneration) return;
 			// Filter out self and items already linked
 			const linkedIds = new Set(itemLinks.flatMap(l => [l.source_id, l.target_id]));
 			addLinkResults = (results.results || [])
@@ -2430,28 +2652,41 @@
 				.filter((i: Item) => i.id !== item?.id && !linkedIds.has(i.id))
 				.slice(0, 10);
 		} catch {
+			if (gen !== loadGeneration) return;
 			addLinkResults = [];
 		} finally {
-			addLinkLoading = false;
+			if (gen === loadGeneration) addLinkLoading = false;
 		}
 	}
 
-	async function handleCreateLink(targetItem: Item) {
+	async function handleCreateLink(target: Item) {
 		if (!item) return;
+		// Capture the SOURCE item (the one being edited) + generation before the
+		// awaits. `target` is the link target chosen from search; `sourceItem`
+		// is the current item. Use the captured slug for the refresh GET and
+		// drop the result if we switched away (Codex).
+		const sourceItem = item;
+		const sourceSlug = item.slug;
+		const targetSlug = itemSlug;
+		const targetWs = wsSlug;
+		const gen = loadGeneration;
 		try {
-			const newLink = await api.links.create(wsSlug, item.slug, {
-				target_id: targetItem.id,
+			const newLink = await api.links.create(targetWs, sourceSlug, {
+				target_id: target.id,
 				link_type: addLinkType
 			});
+			if (switchedAway(sourceItem, gen)) return;
 			itemLinks = [...itemLinks, newLink];
 			showAddLink = false;
 			addLinkSearch = '';
 			addLinkResults = [];
 			// Refresh item to update parent info
-			const refreshed = await api.items.get(wsSlug, itemSlug);
+			const refreshed = await api.items.get(targetWs, targetSlug);
+			if (switchedAway(sourceItem, gen) || !item) return;
 			item = withInflightTags({ ...refreshed, content: item.content });
 			toastStore.show('Relationship added', 'success');
 		} catch (e: any) {
+			if (switchedAway(sourceItem, gen)) return;
 			toastStore.show(e.message ?? 'Failed to add relationship', 'error');
 		}
 	}
@@ -2473,6 +2708,12 @@
 		const sourceCollSlug = collSlug;
 		const sourceItemSlug = itemSlug;
 		const parentRef = formatItemRef(sourceItem) ?? sourceItem.slug;
+		// Generation fence for the toasts (the nav is separately guarded by
+		// navIfStillCurrent below). If the pane switched to another item while
+		// the move was in flight, A's move feedback must not surface over B
+		// (Codex). `stillOnSource()` also implicitly guarantees item !== null.
+		const gen = loadGeneration;
+		const stillOnSource = () => !switchedAway(sourceItem, gen);
 		const doMove = (force: boolean) =>
 			api.items.move(sourceWs, sourceSlug, targetSlug, undefined, force ? { force: true } : undefined);
 		// After the modal resolves, only honor the success path's
@@ -2497,7 +2738,7 @@
 		};
 		try {
 			const moved = await doMove(false);
-			toastStore.show(`Moved to ${targetSlug}`, 'success');
+			if (stillOnSource()) toastStore.show(`Moved to ${targetSlug}`, 'success');
 			navIfStillCurrent(moved.slug);
 		} catch (e: any) {
 			// BUG-1538 / Codex review round 1: the server's
@@ -2506,25 +2747,33 @@
 			// collection. Wire the same modal + ?force=true override
 			// path used for PATCH status changes.
 			if (isOpenChildrenError(e)) {
+				// Don't open the confirm dialog (or fire its forced retry) if the
+				// pane already switched away from the source item.
+				if (!stillOnSource()) return;
 				let forced;
 				try {
-					forced = await confirmOpenChildrenOrThrow(e, parentRef, () => doMove(true));
+					forced = await confirmOpenChildrenOrThrow(e, parentRef, () => {
+						if (!stillOnSource()) throw new Error('switched away');
+						return doMove(true);
+					});
 				} catch (retryErr: any) {
 					console.error('Forced move failed:', retryErr);
-					toastStore.show(retryErr?.message ?? 'Failed to move item', 'error');
+					if (stillOnSource()) toastStore.show(retryErr?.message ?? 'Failed to move item', 'error');
 					return; // outer finally still resets `moving`
 				}
 				if (forced) {
-					toastStore.show(`Moved to ${targetSlug}`, 'success');
+					if (stillOnSource()) toastStore.show(`Moved to ${targetSlug}`, 'success');
 					navIfStillCurrent(forced.slug);
-				} else {
+				} else if (stillOnSource()) {
 					toastStore.show('Move cancelled', 'info');
 				}
 				return;
 			}
-			toastStore.show(e.message ?? 'Failed to move item', 'error');
+			if (stillOnSource()) toastStore.show(e.message ?? 'Failed to move item', 'error');
 		} finally {
-			moving = false;
+			// Guard against clobbering a NEWER item's move: a superseded move's
+			// finally must not clear the flag the current item's handler set.
+			if (!switchedAway(sourceItem, gen)) moving = false;
 		}
 	}
 
@@ -3051,6 +3300,7 @@
 							if (collabProvider && editorInstance && item) {
 								const ws = wsSlug;
 								const itemId = item.id;
+								const genAtToggle = loadGeneration;
 								const baseline = item.content ?? '';
 								const ed = editorInstance;
 								try {
@@ -3117,11 +3367,25 @@
 									// rawMode + rawSeedMarkdown to
 									// the new page would be wrong.
 									// Per Codex review round 7.
-									if (!item || item.id !== itemId) return;
+									// The load-generation check closes BOTH the
+									// mid-switch A→B gap (loaded item still A but
+									// ref already B) AND the A→B→A gap the id-only
+									// check missed (id matches again but a newer
+									// load replaced the item) — without it B would
+									// mount in rawMode seeded with A's content and
+									// the new flusher would be cancelled
+									// (PLAN-2105 / TASK-2112; Codex).
+									if (!item || item.id !== itemId || genAtToggle !== loadGeneration) return;
 									if (lastFlushed !== null) rawSeedMarkdown = lastFlushed;
 								} catch {
-									// Fall through; RawMarkdownEditor
-									// will seed from item.content.
+									// Fall through so RawMarkdownEditor
+									// seeds from item.content — BUT still
+									// bail on a switch: an exception here
+									// must not let the trailing
+									// collabFlusher.cancel() + rawMode=true
+									// apply to a DIFFERENT item (incl.
+									// A→B→A). Per Codex.
+									if (!item || item.id !== itemId || genAtToggle !== loadGeneration) return;
 								}
 							}
 							// Cancel any pending timer-driven flush

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -2127,16 +2127,22 @@
 		// post-await force_refresh check (returns 'skipped' when it fires so
 		// the module doesn't record a known-stale base as lastFlushedContent).
 		save: async ({ ws, itemId, toSave, keepalive }) => {
+			// Snapshot the load generation at flush-start so the UI-feedback
+			// gate below also closes the A→B→A gap (id re-matches but a newer
+			// load replaced the item) — Codex. The PATCH itself still targets
+			// the captured `itemId`/`ws` (never-cross-write, unchanged).
+			const genAtFlush = loadGeneration;
 			// UI mutations only fire when:
 			//   - This is a foreground (user-driven) flush (!keepalive), AND
-			//   - The user is still looking at the item we're flushing.
+			//   - The user is still looking at the item we're flushing, AND
+			//   - No newer load has superseded this generation.
 			// Background (keepalive=true) cleanup flushes after navigation MUST
 			// NOT touch saveStatus / lastSaveTime — those slots belong to
 			// whatever item the user is now on, and stamping them from a stale
 			// flush leaves the new page pinned in 'Saving...' indefinitely.
 			// Per Codex review round 2.
 			const isForegroundCurrent = (): boolean =>
-				!keepalive && !!item && item.id === itemId;
+				!keepalive && !!item && item.id === itemId && genAtFlush === loadGeneration;
 
 			if (isForegroundCurrent()) {
 				saveStatus = 'saving';
@@ -2535,6 +2541,14 @@
 	}
 
 	function handleVersionRestore(updatedItem: Item) {
+		// The restore's await lives in the descendant TimelineVersionCard, which
+		// can resolve + invoke this callback AFTER a no-{#key} switch to another
+		// item (the destroyed card still fires its parent callback). Fence in
+		// the parent: only adopt the restored version if it's for the item
+		// currently shown — otherwise A's restore would render permanently under
+		// ?item=B (PLAN-2105 / TASK-2112; coordinator). The descendant also
+		// fences its own onRestore by itemSlug (belt-and-suspenders).
+		if (!item || item.id !== updatedItem.id) return;
 		item = withInflightTags(updatedItem);
 	}
 
@@ -2726,7 +2740,9 @@
 		// (Codex review round 3 P1). Stale resolutions complete
 		// silently rather than yanking the user back.
 		const navIfStillCurrent = (toSlug: string) => {
-			const itemStillCurrent = item && item.id === sourceItem.id;
+			// stillOnSource() folds in the load-generation check, so an A→B→A
+			// that re-matches the id can't let a superseded move navigate.
+			const itemStillCurrent = stillOnSource();
 			const routeStillCurrent =
 				wsSlug === sourceWs &&
 				username === sourceUsername &&

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -3006,6 +3006,13 @@
 				     itemSlug (the URL/ref identity), NOT item.id, so it resets the
 				     instant the ref changes rather than waiting for B to load. -->
 				{#key itemSlug}
+					<!-- Capture the item identity at THIS render (frozen for this
+					     {#key} instance). A destroyed instance's in-flight async
+					     still fires its callback into the PERSISTENT parent, and
+					     its OWN prop check passes (frozen at its item) — so the
+					     PARENT-side guard below drops the write when the pane has
+					     since moved on (PLAN-2105 / TASK-2112; coordinator). -->
+					{@const keyedSlug = itemSlug}
 					<QuickActionsMenu
 						actions={quickActions}
 						{item}
@@ -3018,6 +3025,7 @@
 							editCollectionOpen = true;
 						}}
 						oncollectionupdated={(updated) => {
+							if (keyedSlug !== itemSlug) return;
 							collection = updated;
 						}}
 					/>
@@ -3551,6 +3559,13 @@
 		     itemSlug (URL/ref identity) so they reset — showing loading/empty —
 		     the instant the ref changes, before B's data resolves. -->
 		{#key itemSlug}
+		<!-- Capture the item identity at THIS render (frozen for this {#key}
+		     instance) so the PARENT-side guards on ChildItems.onChildrenChange
+		     and BacklinksPanel.onCountChange below drop a callback that a
+		     destroyed A-instance's in-flight load fires after the pane switched
+		     to B — the child's OWN prop check can't catch it (its prop is frozen
+		     at A). PLAN-2105 / TASK-2112; coordinator. -->
+		{@const keyedSlug = itemSlug}
 		{#if relationshipGroups.length > 0}
 			<div class="relationships-section">
 				<h3 class="section-title">Relationships</h3>
@@ -3639,7 +3654,7 @@
 
 		<!-- Child Items: always mounted so SSE subscriptions stay active even when starting with 0 children -->
 		{#if item}
-			<ChildItems {wsSlug} {username} {itemSlug} itemId={item.id} parentFields={fields} terminalStatuses={childTerminalStatuses} onChildrenChange={handleChildrenChange} {canEdit} />
+			<ChildItems {wsSlug} {username} {itemSlug} itemId={item.id} parentFields={fields} terminalStatuses={childTerminalStatuses} onChildrenChange={(children) => { if (keyedSlug !== itemSlug) return; handleChildrenChange(children); }} {canEdit} />
 		{/if}
 
 		<!--
@@ -3659,7 +3674,7 @@
 					{username}
 					{itemSlug}
 					itemId={item.id}
-					onCountChange={(n) => { backlinksCount = n; }}
+					onCountChange={(n) => { if (keyedSlug !== itemSlug) return; backlinksCount = n; }}
 				/>
 			</div>
 		{/if}
@@ -3731,12 +3746,19 @@
 		<!-- {#key itemSlug}: remount the owner collection-editor modal on item
 		     switch (it's closed on switch anyway; keeps its async loads scoped). -->
 		{#key itemSlug}
+		<!-- Capture item identity at THIS render so a destroyed A-instance's
+		     completed save/archive can't reload / navigate / close B's pane
+		     after the switch (PLAN-2105 / TASK-2112; coordinator). -->
+		{@const keyedSlug = itemSlug}
 		<EditCollectionModal
 			bind:open={editCollectionOpen}
 			{collection}
 			{wsSlug}
 			initialSection={editCollectionSection}
 			onupdated={(updated) => {
+				// Parent-side switch fence: drop a callback from a superseded
+				// item's modal instance (don't reload/navigate/close B's pane).
+				if (keyedSlug !== itemSlug) return;
 				if (!updated) {
 					// Archive case — the collection is gone. Navigate away from
 					// this now-invalid item route rather than leaving the user

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -118,6 +118,27 @@
 	let loading = $state(true);
 	let error = $state('');
 
+	// Monotonic load generation. The split pane re-drives loadData on every
+	// `ref` change (rapid j/k A→B→C paging), so overlapping loads can resolve
+	// out of order — a slower A response must NOT clobber B's item/collection/
+	// links/error/loading after `ref` moved on. Each load captures its
+	// generation and bails at every await-resume once a newer load has
+	// started; onDestroy also bumps it so an in-flight load can't write global
+	// stores after unmount (PLAN-2105 / TASK-2112; Codex rounds 1-2 P1). Plain
+	// counter — not reactive; it only fences async writes.
+	let loadGeneration = 0;
+
+	// Cross-collection `?item=` safety (PLAN-2105 / TASK-2112). A stale /
+	// shared / hand-crafted `?item=REF` in the split pane could reference an
+	// item that lives in a DIFFERENT collection than the route's `collSlug`
+	// prop. When embedded, trust the LOADED item's `collection_slug` for
+	// schema selection (loadData refetches the right collection below) and
+	// for building any collection-scoped URL — never the possibly-wrong
+	// route prop. Full-page keeps `collSlug` (the route is authoritative).
+	let effectiveCollSlug = $derived(
+		embedded && item?.collection_slug ? item.collection_slug : collSlug,
+	);
+
 	// ── Scroll position restoration readiness (BUG-1425) ───────────────
 	// The route wrapper (`[slug]/+page.svelte`) owns `createScrollRestoration`
 	// + `export const snapshot` — a SvelteKit route-module concern that can't
@@ -270,7 +291,7 @@
 	// SvelteKit navigation, and the new route (no ?graph) closes the drawer via
 	// the URL-watching effect.
 	function graphItemHref(ref: string, collection?: string): string {
-		return `/${username}/${wsSlug}/${collection ?? collSlug}/${ref}`;
+		return `/${username}/${wsSlug}/${collection ?? effectiveCollSlug}/${ref}`;
 	}
 	// ESC closes the graph drawer (only while open — no global listener otherwise).
 	$effect(() => {
@@ -336,12 +357,14 @@
 	// Surface the item's ref (e.g. IDEA-592) in the browser tab title.
 	// Clear the section so the format reads "{REF} · {Workspace} · Pad".
 	//
-	// The tab title is a route-owner concern. Full-page owns it. When
-	// embedded in the collection page's pane, defer to the collection page
-	// (Phase 2 / TASK-2112 finalizes title precedence — paned item vs list)
-	// so the two ItemDetail/collection title writers don't race.
+	// Title precedence (PLAN-2105 / TASK-2112): the paned item's title WINS
+	// the tab title while a pane is open. This effect owns the title whenever
+	// ItemDetail is mounted — full-page (the only writer) and embedded alike.
+	// The collection page gates its OWN title writer on `!openItemRef`, so it
+	// yields while the pane is mounted and reclaims the tab title the instant
+	// the pane closes and this component unmounts. (Embedded ItemDetail is
+	// only ever mounted when `?item=` is set, so the two never write at once.)
 	$effect(() => {
-		if (embedded) return;
 		titleStore.setPageTitle({
 			section: null,
 			item: item ? (formatItemRef(item) || null) : null,
@@ -575,11 +598,20 @@
 		unsubscribeSync?.();
 		unsubscribeSSE?.();
 		unsubscribeBeforePrint?.();
+		// Invalidate any in-flight loadData so a request that resolves AFTER
+		// this instance is torn down (pane closed mid-load) can't reach its
+		// global-store writes — collectionStore.setActiveItem / editorStore —
+		// and clobber the next view's state. Bumping the generation makes the
+		// pending load bail at its next await-resume guard, before those calls
+		// (PLAN-2105 / TASK-2112; Codex round 2 P1). onDestroy runs
+		// synchronously on unmount, before the awaited fetch continuations.
+		loadGeneration++;
 		editorStore.resetForDoc();
 		collectionStore.setActiveItem(null);
 	});
 
 	async function loadData() {
+		const myGen = ++loadGeneration;
 		loading = true;
 		error = '';
 		// Clear per-item state that must NOT leak across navigation.
@@ -645,17 +677,47 @@
 				api.collections.get(wsSlug, collSlug),
 				itemsPromise
 			]);
+			// A newer load superseded this one while awaiting (fast A→B pane
+			// switch) — bail before clobbering the current item/collection.
+			if (myGen !== loadGeneration) return;
 			// Overlay any in-flight optimistic tag edit so navigating away and
 			// back mid-save can't show (and then let a follow-up edit overwrite
 			// with) stale server tags. See withInflightTags. Per Codex PR #659.
 			item = withInflightTags(itemData);
-			collection = collData;
+			// Cross-collection `?item=` safety (PLAN-2105 / TASK-2112). The
+			// Promise.all above optimistically fetched the collection by the
+			// route's `collSlug` — correct for the common (row-click) case,
+			// which is always same-collection. But an embedded pane can be
+			// driven by a stale / hand-crafted `?item=REF` whose item actually
+			// lives in a DIFFERENT collection; rendering its fields against the
+			// route collection's schema would be wrong. Refetch the item's
+			// real collection so `schema`/`settings` match the loaded item.
+			// Only pays the extra request on an actual mismatch.
+			if (embedded && itemData.collection_slug && itemData.collection_slug !== collSlug) {
+				try {
+					const realColl = await api.collections.get(wsSlug, itemData.collection_slug);
+					if (myGen !== loadGeneration) return;
+					collection = realColl;
+				} catch {
+					if (myGen !== loadGeneration) return;
+					// Can't resolve the item's REAL collection. Surface the
+					// failure instead of falling back to the route collection's
+					// schema — rendering another collection's fields is exactly
+					// the mismatch the cross-collection guard exists to prevent
+					// (Codex round 1 P2).
+					error = 'Failed to load this item’s collection';
+					return;
+				}
+			} else {
+				collection = collData;
+			}
 			collectionStore.setActiveItem(itemData);
 			editorStore.resetForDoc();
 
 			// Fetch child item progress for any item (generalized parent/child)
 			try {
 				const progress = await api.items.progress(wsSlug, itemData.slug);
+				if (myGen !== loadGeneration) return;
 				if (progress.total > 0) {
 					hasChildren = true;
 					computedOverrides = { progress: progress.percentage, _progressDone: progress.done, _progressTotal: progress.total };
@@ -664,6 +726,7 @@
 					computedOverrides = {};
 				}
 			} catch {
+				if (myGen !== loadGeneration) return;
 				hasChildren = false;
 				computedOverrides = {};
 			}
@@ -675,18 +738,26 @@
 
 			// Load links for this item
 			try {
-				itemLinks = await api.links.list(wsSlug, itemData.slug);
-			} catch { itemLinks = []; }
+				const links = await api.links.list(wsSlug, itemData.slug);
+				if (myGen !== loadGeneration) return;
+				itemLinks = links;
+			} catch { if (myGen !== loadGeneration) return; itemLinks = []; }
 
 			// Load workspace members and agent roles for assignment picker
 			try {
 				const membersData = await api.members.list(wsSlug);
+				if (myGen !== loadGeneration) return;
 				workspaceMembers = membersData.members ?? [];
-			} catch { workspaceMembers = []; }
+			} catch { if (myGen !== loadGeneration) return; workspaceMembers = []; }
 			try {
-				agentRoles = await api.agentRoles.list(wsSlug);
-			} catch { agentRoles = []; }
+				const roles = await api.agentRoles.list(wsSlug);
+				if (myGen !== loadGeneration) return;
+				agentRoles = roles;
+			} catch { if (myGen !== loadGeneration) return; agentRoles = []; }
 		} catch (e: any) {
+			// A newer load owns the state — don't overwrite it with this
+			// superseded load's error.
+			if (myGen !== loadGeneration) return;
 			error = e.message ?? 'Failed to load item';
 			// Clear the workspace's last-route cache so the workspace
 			// switcher (TASK-754) doesn't keep restoring this dead item
@@ -705,17 +776,23 @@
 				}
 			} catch {}
 		} finally {
-			loading = false;
+			// Only the CURRENT (newest) load owns the shared loading / pending
+			// flags — a superseded load's finally (it early-returned above)
+			// must not clear the newer load's skeleton or fire its ?new intent
+			// (PLAN-2105 / TASK-2112).
+			if (myGen === loadGeneration) {
+				loading = false;
 
-			// Capture the auto-edit intent — actual trigger lives in the
-			// $effect below so it can fire even if /me (which feeds canEdit)
-			// resolves AFTER loadData() finishes. One-shot. Always reassign
-			// (true OR false) so a stale flag from a previous ?new=1 load
-			// can't fire on a subsequent non-new item load — Codex round 6.
-			// `?new=1` create-intent is a full-page-only flow (create stays
-			// full-page for v1 — PLAN-2105). When embedded, `page.url` is the
-			// COLLECTION route, so never read it there.
-			pendingNewItemEdit = !embedded && page.url.searchParams.get('new') === '1';
+				// Capture the auto-edit intent — actual trigger lives in the
+				// $effect below so it can fire even if /me (which feeds canEdit)
+				// resolves AFTER loadData() finishes. One-shot. Always reassign
+				// (true OR false) so a stale flag from a previous ?new=1 load
+				// can't fire on a subsequent non-new item load — Codex round 6.
+				// `?new=1` create-intent is a full-page-only flow (create stays
+				// full-page for v1 — PLAN-2105). When embedded, `page.url` is the
+				// COLLECTION route, so never read it there.
+				pendingNewItemEdit = !embedded && page.url.searchParams.get('new') === '1';
+			}
 		}
 	}
 
@@ -2312,7 +2389,10 @@
 	}
 
 	let allCollections = $derived(collectionStore.collections ?? []);
-	let moveTargets = $derived(allCollections.filter(c => c.slug !== collSlug));
+	// Exclude the item's ACTUAL collection (effectiveCollSlug), not the route
+	// prop — a cross-collection `?item=` in the pane could otherwise offer a
+	// no-op "move" to the item's own collection (PLAN-2105 / TASK-2112).
+	let moveTargets = $derived(allCollections.filter(c => c.slug !== effectiveCollSlug));
 
 	async function handleDeleteLink(linkId?: string) {
 		if (!linkId || !item) return;
@@ -3332,8 +3412,16 @@
 					// Archive case — the collection is gone. Navigate away from
 					// this now-invalid item route rather than leaving the user
 					// with stale state that would hit deleted resources.
+					// Route-away is parameterized (PLAN-2105 / TASK-2112): an
+					// embedded pane closes in place (the collection page
+					// reconciles the archive itself) instead of hard-navigating
+					// the whole page; full-page returns to the workspace root.
 					collectionStore.loadCollections(wsSlug);
-					void goto(`/${username}/${wsSlug}`);
+					if (embedded) {
+						handleGone();
+					} else {
+						void goto(`/${username}/${wsSlug}`);
+					}
 					return;
 				}
 				collection = updated;
@@ -3342,11 +3430,18 @@
 				// changed. The current `/[collection]/[slug]` URL still
 				// points at the old slug and subsequent loadData() calls
 				// (which fetch by collSlug) would 404. Navigate to the
-				// new slug while preserving the item slug. The new route
-				// will trigger its own loadData() via the $effect on
-				// wsSlug/collSlug/itemSlug, so no explicit refresh here.
+				// new slug while preserving the item slug — routed through
+				// handleNavigateAway (PLAN-2105 / TASK-2112) so an embedded
+				// pane re-targets its host collection page (keeping the pane
+				// open via `?item=`) instead of hard-navigating to the
+				// full-page item route. The destination triggers a fresh
+				// loadData() on arrival, so no explicit refresh here.
 				if (updated.slug !== collSlug && itemSlug) {
-					void goto(`/${username}/${wsSlug}/${updated.slug}/${itemSlug}`);
+					handleNavigateAway(
+						embedded
+							? `/${username}/${wsSlug}/${updated.slug}?item=${encodeURIComponent(itemSlug)}`
+							: `/${username}/${wsSlug}/${updated.slug}/${itemSlug}`,
+					);
 					return;
 				}
 				// Non-navigating update: schema or field mappings may have

--- a/web/src/lib/components/timeline/ItemTimeline.svelte
+++ b/web/src/lib/components/timeline/ItemTimeline.svelte
@@ -68,10 +68,17 @@
 	function probeAttachment(uuid: string) {
 		if (probed.has(uuid)) return;
 		probed.add(uuid);
+		// Capture the workspace identity before the HEAD probe. `attMeta` is a
+		// workspace-scoped attachment cache; ItemDetail reuses this panel across
+		// a no-{#key} item switch (its wsSlug/itemSlug props just change), so a
+		// probe resolving after a workspace switch must NOT write the old
+		// workspace's attachment metadata into the new item's cache (TASK-2112).
+		const reqWs = wsSlug;
 		fetchAttachmentMetadata(wsSlug, uuid, (id, variant) =>
 			attachmentDownloadUrl(wsSlug, id, variant)
 		).then((m) => {
 			if (!m) return;
+			if (reqWs !== wsSlug) return;
 			const next = new Map(attMeta);
 			// filename is left empty — the markdown alt text is the chip/img
 			// label, and renderAttachmentImage only falls back to filename
@@ -175,38 +182,52 @@
 	let firstPageIds = $state<Set<string>>(new Set());
 
 	async function loadTimeline() {
+		// Capture the request identity (item + workspace) BEFORE the await.
+		// ItemDetail reuses this panel across a no-{#key} item switch (its
+		// itemSlug/wsSlug props just change), so a slower A load must NOT
+		// overwrite B's entries / error / spinner (TASK-2112).
+		const reqSlug = itemSlug;
+		const reqWs = wsSlug;
 		loading = true;
 		error = '';
 		try {
-			const resp: TimelineResponse = await api.timeline.list(wsSlug, itemSlug);
+			const resp: TimelineResponse = await api.timeline.list(reqWs, reqSlug);
+			if (reqSlug !== itemSlug || reqWs !== wsSlug) return;
 			entries = resp.entries;
 			hasMore = resp.has_more;
 			firstPageIds = new Set(resp.entries.map((e) => e.id));
 		} catch (err: any) {
+			if (reqSlug !== itemSlug || reqWs !== wsSlug) return;
 			error = err?.message ?? 'Failed to load timeline';
 		} finally {
-			loading = false;
+			if (reqSlug === itemSlug && reqWs === wsSlug) loading = false;
 		}
 	}
 
 	async function loadMore() {
 		if (loadingMore || entries.length === 0) return;
+		// Capture identity before the await so a switch mid-flight can't append
+		// A's older page onto B's entries (TASK-2112).
+		const reqSlug = itemSlug;
+		const reqWs = wsSlug;
 		const oldest = entries[entries.length - 1];
 		loadingMore = true;
 		try {
-			const resp: TimelineResponse = await api.timeline.list(wsSlug, itemSlug, {
+			const resp: TimelineResponse = await api.timeline.list(reqWs, reqSlug, {
 				before: oldest.created_at,
 				before_id: oldest.id
 			});
+			if (reqSlug !== itemSlug || reqWs !== wsSlug) return;
 			// Deduplicate by ID to handle boundary overlap from <= queries.
 			const existingIds = new Set(entries.map((e) => e.id));
 			const newEntries = resp.entries.filter((e) => !existingIds.has(e.id));
 			entries = [...entries, ...newEntries];
 			hasMore = resp.has_more;
 		} catch (err: any) {
+			if (reqSlug !== itemSlug || reqWs !== wsSlug) return;
 			error = err?.message ?? 'Failed to load more';
 		} finally {
-			loadingMore = false;
+			if (reqSlug === itemSlug && reqWs === wsSlug) loadingMore = false;
 		}
 	}
 
@@ -236,8 +257,14 @@
 		if (relevantEvents.has(event.type)) {
 			clearTimeout(sseRefreshTimer);
 			sseRefreshTimer = setTimeout(async () => {
+				// Capture identity before the await — this same panel instance
+				// serves the next item after a no-{#key} switch, so a debounced
+				// refresh resolving late must not merge A's entries into B (TASK-2112).
+				const reqSlug = itemSlug;
+				const reqWs = wsSlug;
 				try {
-					const resp: TimelineResponse = await api.timeline.list(wsSlug, itemSlug);
+					const resp: TimelineResponse = await api.timeline.list(reqWs, reqSlug);
+					if (reqSlug !== itemSlug || reqWs !== wsSlug) return;
 					const freshIds = new Set(resp.entries.map((e) => e.id));
 					const existingIds = new Set(entries.map((e) => e.id));
 
@@ -273,16 +300,25 @@
 	// Posts a new comment. Throws on failure so CommentEditor preserves the
 	// draft; clears itself on success.
 	async function submitComment(body: string) {
+		// Capture identity before the await so a mid-flight item switch can't
+		// leak A's error into B's view or refresh B off A's mutation (TASK-2112).
+		// `submitting` is a composer busy flag (not item-scoped load state), so
+		// it's always cleared in finally — the switched-to composer must not
+		// stay stuck spinning.
+		const reqSlug = itemSlug;
+		const reqWs = wsSlug;
 		submitting = true;
 		error = '';
 		try {
-			await api.comments.create(wsSlug, itemSlug, {
+			await api.comments.create(reqWs, reqSlug, {
 				body,
 				created_by: 'user',
 				source: 'web'
 			});
+			if (reqSlug !== itemSlug || reqWs !== wsSlug) return;
 			await loadTimeline();
 		} catch (err: any) {
+			if (reqSlug !== itemSlug || reqWs !== wsSlug) return;
 			error = err?.message ?? 'Failed to post comment';
 			throw err;
 		} finally {
@@ -291,14 +327,18 @@
 	}
 
 	async function handleReply(commentId: string, body: string) {
+		const reqSlug = itemSlug;
+		const reqWs = wsSlug;
 		try {
-			await api.comments.reply(wsSlug, commentId, {
+			await api.comments.reply(reqWs, commentId, {
 				body,
 				created_by: 'user',
 				source: 'web'
 			});
+			if (reqSlug !== itemSlug || reqWs !== wsSlug) return;
 			await loadTimeline();
 		} catch (err: any) {
+			if (reqSlug !== itemSlug || reqWs !== wsSlug) return;
 			error = err?.message ?? 'Failed to post reply';
 			throw err; // let CommentEditor keep the draft
 		}
@@ -307,10 +347,14 @@
 	// Edits a comment or reply (author/admin enforced server-side). Throws on
 	// failure so the inline CommentEditor preserves the draft.
 	async function handleEdit(commentId: string, body: string) {
+		const reqSlug = itemSlug;
+		const reqWs = wsSlug;
 		try {
-			await api.comments.update(wsSlug, commentId, { body });
+			await api.comments.update(reqWs, commentId, { body });
+			if (reqSlug !== itemSlug || reqWs !== wsSlug) return;
 			await loadTimeline();
 		} catch (err: any) {
+			if (reqSlug !== itemSlug || reqWs !== wsSlug) return;
 			error = err?.message ?? 'Failed to edit comment';
 			throw err;
 		}
@@ -318,28 +362,40 @@
 
 	async function handleDelete(commentId: string) {
 		if (!confirm('Delete this comment?')) return;
+		const reqSlug = itemSlug;
+		const reqWs = wsSlug;
 		try {
-			await api.comments.delete(wsSlug, commentId);
+			await api.comments.delete(reqWs, commentId);
+			if (reqSlug !== itemSlug || reqWs !== wsSlug) return;
 			await loadTimeline();
 		} catch (err: any) {
+			if (reqSlug !== itemSlug || reqWs !== wsSlug) return;
 			error = err?.message ?? 'Failed to delete comment';
 		}
 	}
 
 	async function handleReaction(commentId: string, emoji: string) {
+		const reqSlug = itemSlug;
+		const reqWs = wsSlug;
 		try {
-			await api.comments.addReaction(wsSlug, commentId, emoji);
+			await api.comments.addReaction(reqWs, commentId, emoji);
+			if (reqSlug !== itemSlug || reqWs !== wsSlug) return;
 			await loadTimeline();
 		} catch (err: any) {
+			if (reqSlug !== itemSlug || reqWs !== wsSlug) return;
 			error = err?.message ?? 'Failed to add reaction';
 		}
 	}
 
 	async function handleRemoveReaction(commentId: string, emoji: string) {
+		const reqSlug = itemSlug;
+		const reqWs = wsSlug;
 		try {
-			await api.comments.removeReaction(wsSlug, commentId, emoji);
+			await api.comments.removeReaction(reqWs, commentId, emoji);
+			if (reqSlug !== itemSlug || reqWs !== wsSlug) return;
 			await loadTimeline();
 		} catch (err: any) {
+			if (reqSlug !== itemSlug || reqWs !== wsSlug) return;
 			error = err?.message ?? 'Failed to remove reaction';
 		}
 	}

--- a/web/src/lib/components/timeline/TimelineVersionCard.svelte
+++ b/web/src/lib/components/timeline/TimelineVersionCard.svelte
@@ -29,12 +29,21 @@
 
 	async function ensureResolved() {
 		if (!version.is_diff || fetchedContent !== null || resolving) return;
+		// Capture the item identity before the await. This card lives in the
+		// timeline panel that ItemDetail reuses across a no-{#key} item switch
+		// (its itemSlug/wsSlug props change under it), so a lazy version-content
+		// resolve landing after a switch must not write into a stale card
+		// (TASK-2112). `resolving` is a local spinner flag, always cleared.
+		const reqSlug = itemSlug;
+		const reqWs = wsSlug;
 		resolving = true;
 		resolveError = false;
 		try {
-			const full = await api.versions.get(wsSlug, itemSlug, version.id);
+			const full = await api.versions.get(reqWs, reqSlug, version.id);
+			if (reqSlug !== itemSlug || reqWs !== wsSlug) return;
 			fetchedContent = full.content;
 		} catch {
+			if (reqSlug !== itemSlug || reqWs !== wsSlug) return;
 			resolveError = true;
 		} finally {
 			resolving = false;
@@ -59,9 +68,17 @@
 	}
 
 	async function confirmRestore() {
+		// Capture the item identity before the await so a mid-flight item switch
+		// (rapid j/k / row-click in the split pane) can't fire onRestore with
+		// A's restored item into a parent now showing B — nor flip this card's
+		// confirm state after it's been repurposed (TASK-2112). `restoring` is a
+		// local button flag, always cleared.
+		const reqSlug = itemSlug;
+		const reqWs = wsSlug;
 		restoring = true;
 		try {
-			const updatedItem = await api.versions.restore(wsSlug, itemSlug, version.id);
+			const updatedItem = await api.versions.restore(reqWs, reqSlug, version.id);
+			if (reqSlug !== itemSlug || reqWs !== wsSlug) return;
 			confirming = false;
 			onRestore?.(updatedItem);
 		} finally {

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -8,6 +8,7 @@
 	import BoardView from '$lib/components/collections/BoardView.svelte';
 	import ListView from '$lib/components/collections/ListView.svelte';
 	import TableView from '$lib/components/collections/TableView.svelte';
+	import ItemDetail from '$lib/components/items/ItemDetail.svelte';
 	import FilterBar from '$lib/components/collections/FilterBar.svelte';
 	import QuickActionsMenu from '$lib/components/common/QuickActionsMenu.svelte';
 	import BottomSheet from '$lib/components/common/BottomSheet.svelte';
@@ -471,20 +472,23 @@
 	// `{ noScroll, keepFocus }` goto options as `updateUrlFilters`.
 	//
 	// History policy (deliberate split):
-	//  • openItemPane PUSHES a history entry (replaceState:false) so a
+	//  • The INITIAL open PUSHES a history entry (replaceState:false) so a
 	//    single Back closes the pane — matching "back/forward work
 	//    naturally".
-	//  • closeItemPane REPLACES (replaceState:true) and clears ONLY the
-	//    `item` param, so closing (and future j/k re-targets, TASK-2111)
-	//    don't push a trail of entries that Back must unwind.
-	//
-	// Not wired to row-click yet (TASK-2111) and no pane is rendered yet
-	// (TASK-2112) — this is the URL-state plumbing those tasks build on.
+	//  • RE-TARGETING an already-open pane (row-click / Enter / j-k moving
+	//    A→B→C) REPLACES, so paging through N rows doesn't stack N history
+	//    entries that Back must unwind before it can close the pane
+	//    (PLAN-2105 history policy; Codex round 2 P2). `closeItemPane`
+	//    likewise REPLACES.
 	function openItemPane(item: Item) {
 		const url = new URL(page.url);
+		// Whether a pane is ALREADY open decides push (first open) vs replace
+		// (re-target). Read off the live URL — the same source openItemRef
+		// derives from.
+		const alreadyOpen = url.searchParams.has('item');
 		url.searchParams.set('item', itemUrlId(item));
 		goto(`${url.pathname}${url.search}`, {
-			replaceState: false,
+			replaceState: alreadyOpen,
 			noScroll: true,
 			keepFocus: true,
 		});
@@ -594,7 +598,14 @@
 	export const snapshot = scrollRestoration.snapshot;
 
 	// Reflect the collection name in the browser tab; clear any stale item ref.
+	//
+	// Title precedence (PLAN-2105 / TASK-2112): when a detail pane is open the
+	// paned item's title WINS the tab title, so yield here while `?item=` is
+	// set. The embedded ItemDetail owns the title whenever it's mounted; this
+	// effect depends on `openItemRef`, so it re-runs and reclaims the tab
+	// title the instant the pane closes.
 	$effect(() => {
+		if (openItemRef) return;
 		titleStore.setPageTitle({
 			section: collection?.name ?? null,
 			item: null,
@@ -1591,6 +1602,23 @@
 		focusedIndex = -1;
 	});
 
+	// Keep the row highlight on the OPEN pane's item (PLAN-2105 / TASK-2112).
+	// `focusedItemId` (the marker List/Board/Table read) is otherwise driven
+	// only by the keyboard cursor, so a click- / back-forward- / refresh-
+	// opened pane wouldn't highlight its row. Snap the cursor to the paned
+	// item whenever `?item=` (or the hydrated list) changes. Defined AFTER the
+	// reset effect above so, when both fire on a filteredItems change, this one
+	// wins and restores the paned row. j/k between openItemRef changes still
+	// moves the cursor freely (this effect only re-runs on openItemRef /
+	// filteredItems changes, not on focusedIndex).
+	$effect(() => {
+		if (!openItemRef) return;
+		const idx = filteredItems.findIndex(
+			(i) => itemUrlId(i) === openItemRef || i.slug === openItemRef,
+		);
+		if (idx >= 0) focusedIndex = idx;
+	});
+
 	// Register a Cmd+F handler with the layout while this page is mounted.
 	// The layout only intercepts Cmd+F when a handler is registered, so on
 	// pages without one (e.g. item view) it falls through to browser-native
@@ -1609,6 +1637,11 @@
 		// Don't capture when typing in inputs/textareas or when quick-create is open
 		const tag = (e.target as HTMLElement)?.tagName;
 		if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
+		// Also bail when typing inside a contenteditable (the Tiptap editor is
+		// a contenteditable DIV) or anywhere inside the detail pane — otherwise
+		// j/k/arrows/Enter/Escape typed in the open pane's editor would drive
+		// list navigation instead of editing (PLAN-2105 / TASK-2111).
+		if ((e.target as HTMLElement)?.closest?.('[contenteditable="true"], .item-pane')) return;
 		if (quickCreateOpen || saveViewOpen) return;
 
 		switch (e.key) {
@@ -1632,7 +1665,9 @@
 				if (focusedIndex >= 0 && focusedIndex < filteredItems.length) {
 					e.preventDefault();
 					const item = filteredItems[focusedIndex];
-					goto(`/${username}/${wsSlug}/${collSlug}/${itemUrlId(item)}`);
+					// Enter opens the focused row in the split pane (PLAN-2105 /
+					// TASK-2111) rather than navigating full-page.
+					openItemPane(item);
 				}
 				break;
 			case 'Escape':
@@ -2113,7 +2148,16 @@
 
 <svelte:window onkeydown={handlePageKeydown} />
 
-<div class="collection-page" class:board-active={viewMode === 'board'}>
+<!--
+	Split-pane layout (PLAN-2105 / TASK-2112). When `?item=` is set the page
+	becomes a flex row: the list column (flex:1, always mounted) + a right-
+	docked <ItemDetail embedded> pane. The list content is always wrapped in
+	.list-column so opening/closing the pane never remounts the list. The pane
+	is the ONLY thing that mounts/unmounts on open/close — see the NO-{#key}
+	note on the ItemDetail mount below.
+-->
+<div class="collection-page" class:board-active={viewMode === 'board'} class:pane-open={!!openItemRef}>
+	<div class="list-column">
 	{#if loading}
 		<div class="loading">Loading...</div>
 	{:else if metaError}
@@ -2516,12 +2560,14 @@
 				canEdit={canEditThisCollection}
 				preserveOrder={searchQuery.trim() !== ''}
 				{sortMode}
+				onItemOpen={openItemPane}
 			/>
 		{:else if viewMode === 'table'}
 			<TableView
 				items={filteredItems}
 				{collection}
 				{wsSlug}
+				{focusedItemId}
 				onStatusChange={handleStatusChange}
 				onReorder={handleReorder}
 				oncreate={canEditThisCollection ? openQuickCreate : undefined}
@@ -2530,6 +2576,7 @@
 				canEdit={canEditThisCollection}
 				preserveOrder={searchQuery.trim() !== ''}
 				{sortMode}
+				onItemOpen={openItemPane}
 			/>
 		{:else}
 			<ListView
@@ -2549,8 +2596,34 @@
 				canEdit={canEditThisCollection}
 				preserveOrder={searchQuery.trim() !== ''}
 				{sortMode}
+				onItemOpen={openItemPane}
 			/>
 		{/if}
+	{/if}
+	</div>
+	{#if openItemRef}
+		<!--
+			The detail pane. CRITICAL (PLAN-2105 / TASK-2112): NO {#key} wrapper.
+			A→B item switch must be a PROP UPDATE (`ref` change re-drives
+			ItemDetail's loadData + collabKey via its own reactive effects,
+			reusing the mounted instance + its single SSE subscription). A
+			{#key} would silently full-remount on every switch and defeat the
+			whole design. Open/close (this {#if}) is the ONLY mount/unmount.
+			`onNavigateAway` handles the collection-rename case; onClose/onGone
+			clear only `?item=`, preserving view/sort/filter/tags/search.
+		-->
+		<aside class="item-pane">
+			<ItemDetail
+				ref={openItemRef}
+				embedded
+				{username}
+				{wsSlug}
+				{collSlug}
+				onClose={closeItemPane}
+				onGone={closeItemPane}
+				onNavigateAway={(url) => goto(url)}
+			/>
+		</aside>
 	{/if}
 </div>
 
@@ -2682,6 +2755,75 @@
 	}
 	.board-active .page-header {
 		flex-shrink: 0;
+	}
+
+	/* ── Split-pane layout (PLAN-2105 / TASK-2112) ──────────────────────
+	   The list content is always wrapped in .list-column so the detail
+	   pane can mount/unmount without remounting the list. In the default
+	   (no-pane, non-board) layout .list-column is a transparent block, so
+	   no styles are needed there. Board view is a fixed-height flex column
+	   though, so the wrapper must fill it: the board's own `flex:1;
+	   min-height:0` expects its parent to be a constrained flex column,
+	   which .list-column now sits in place of. */
+	.collection-page.board-active .list-column {
+		flex: 1;
+		min-height: 0;
+		display: flex;
+		flex-direction: column;
+		overflow: hidden;
+	}
+
+	/* When a detail pane is open the page becomes a flex row: list column
+	   (flex:1) + a right-docked pane. Break out of the max-width constraint
+	   (mirroring board-active) and fill .main-content so the pane docks
+	   full-height and scrolls independently of the list. These rules follow
+	   .board-active in source order so, for a board+pane combination (equal
+	   specificity), the row layout wins the shared props. */
+	.collection-page.pane-open {
+		max-width: none;
+		margin: 0;
+		padding: 0;
+		display: flex;
+		flex-direction: row;
+		align-items: stretch;
+		height: 100%;
+		overflow: hidden;
+	}
+	.collection-page.pane-open .list-column {
+		flex: 1 1 0;
+		min-width: 0;
+		overflow-y: auto;
+		padding: var(--space-8) var(--space-6);
+	}
+	/* Board manages its own internal height + horizontal scroll, so keep
+	   the column clipped and let the board fill it. */
+	.collection-page.pane-open.board-active .list-column {
+		overflow: hidden;
+		padding: var(--space-6);
+	}
+	.item-pane {
+		flex: 0 0 clamp(360px, 38%, 640px);
+		min-width: 0;
+		overflow-y: auto;
+		border-left: 1px solid var(--border);
+		background: var(--bg-primary);
+	}
+
+	@media (max-width: 768px) {
+		/* Mobile full-screen overlay is Phase 4 (PLAN-2105); until then the
+		   pane stacks below the list so neither column gets crushed. */
+		.collection-page.pane-open {
+			flex-direction: column;
+			overflow-y: auto;
+		}
+		.collection-page.pane-open .list-column {
+			overflow-y: visible;
+		}
+		.item-pane {
+			flex: 1 1 auto;
+			border-left: none;
+			border-top: 1px solid var(--border);
+		}
 	}
 
 	.loading {


### PR DESCRIPTION
PLAN-2105 wave 2 — the increment where the Asana-style right-docked detail pane first becomes **visible**. Builds directly on the already-merged **TASK-2106** (`<ItemDetail>` `embedded` extraction) and **TASK-2110** (`?item=` URL plumbing). Combines **TASK-2112** (mount the split pane) + **TASK-2111** (row-click to open it) as one coherent PR.

## What lands

### TASK-2112 — split layout + mount the pane
- `.collection-page` becomes a **flex row** when `?item=` is set: the list content (always wrapped in `.list-column`, `flex:1`) + a right-docked `.item-pane`. It breaks out of `max-width: var(--content-max-width)` while the pane is open (mirroring how `board-active` already drops max-width) and fills `.main-content` so the pane scrolls independently. Board view keeps its fixed-height fill through the wrapper.
- `<ItemDetail ref={openItemRef} embedded .../>` is mounted inside `{#if openItemRef}` with **NO `{#key}` wrapper** — A→B is a **prop update** that reuses the mounted instance (re-drives `loadData`/`collabKey` via the `ref` change + keeps the single SSE subscription). Open/close is the only mount/unmount.
- **Cross-collection `?item=` safety** (in `ItemDetail`): when embedded, the effective collection (schema + expand/popout URLs) derives from the **loaded `item.collection_slug`**, refetching the correct collection on mismatch; on refetch failure it surfaces an error rather than rendering the route collection's schema.
- **Paned row highlighted** in list, board **and** table — `focusedItemId` is now threaded into `TableView`, and an effect snaps the cursor to the open pane's item (covers click / Enter / back-forward / refresh).
- **Title precedence:** the embedded `ItemDetail` owns the tab title while mounted; the collection page gates its own title writer on `!openItemRef`.
- The **two `EditCollectionModal` route-away gotos** (owner-only rename/archive) are parameterized through `onNavigateAway`/`onGone` so an embedded pane doesn't hard-navigate the whole page.
- `loadData` is fenced by a monotonic `loadGeneration` (also bumped on unmount) so overlapping A→B loads can't clobber newer state or write global stores after teardown.

### TASK-2111 — opt-in row-click interception
- Added an `onclick` to the plain `ItemCard` (`:153`) + `TableView` title (`:206`) anchors, **`href` intact**: plain left-click → `preventDefault()` + `onItemOpen`; modifier/middle-click **falls through** to the full-page URL (popout); sub-control clicks (star/PR/status/tags/reorder) are untouched (they already `stopPropagation`).
- `onItemOpen` threads from `+page.svelte` through `ListView`/`BoardView` to `ItemCard` and directly to `TableView` (`openItemPane`). Absent elsewhere (starred/tags/roles) it defaults to full-page anchor nav.
- Keyboard **Enter** opens the pane; `handlePageKeydown` now also bails on `contenteditable` / `.item-pane` so keys typed in the pane editor aren't captured by list nav.
- `openItemPane` **pushes** history on the first open, **replaces** on re-target so paging A→B→C doesn't stack entries Back must unwind.

## Out of scope (deferred)
- Pane **header controls** (expand/popout/close button) — **TASK-2113**. The pane closes via browser Back for now.
- Resize divider / persisted width, mobile full-screen overlay, j/k pane-follow — later PLAN-2105 waves.

## Verification
- `cd web && npm run check` — **0 errors** (8 pre-existing warnings in unrelated files).
- Codex review (3 rounds) → **CLEAN**: no `{#key}`; left-click-only preventDefault with modifier/middle fall-through; sub-controls not swallowed; keydown guard excludes contenteditable/pane; cross-collection schema derives from `item.collection_slug`; title gates on `openItemRef`.

## Browser checks to do
- Left-click a row → list stays + right pane opens, `?item=REF` in URL, pane body identical to the full page.
- Refresh a `?item=` URL → split restored; the paned row is highlighted in list, board, and table.
- Switch A→B (click another row / Enter) → pane content updates **without** a remount (DevTools: no new SSE subscription; one persistent connection).
- cmd-click / middle-click a row → full page opens in a new tab (popout); right-click-copy targets the full page.
- Sub-controls (star / PR badge / status cycle / tag chip / reorder) still work without opening the pane.
- Type j/k/Enter inside the pane editor → not captured by list navigation.

https://claude.ai/code/session_01EZ6yr6pAUFb1uffan912ra