### PR TITLE
test(web): vitest for pane ?item= round-trip + click interception (TASK-2116)

### DIFF
--- a/web/src/lib/collections/paneUrlParams.test.ts
+++ b/web/src/lib/collections/paneUrlParams.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { KNOWN_COLLECTION_URL_PARAMS, PANE_ITEM_PARAM, preservePaneItemParam } from './paneUrlParams';
+
+describe('preservePaneItemParam', () => {
+	it('re-emits the currently-open pane ref onto a freshly rebuilt params object', () => {
+		const currentUrl = new URL('https://pad.test/alice/ws/tasks?view=board&item=TASK-5');
+		const params = new URLSearchParams();
+		params.set('view', 'board');
+		preservePaneItemParam(params, currentUrl);
+		expect(params.get('item')).toBe('TASK-5');
+	});
+
+	it('is a no-op when no pane is open — nothing to preserve', () => {
+		const currentUrl = new URL('https://pad.test/alice/ws/tasks?view=board');
+		const params = new URLSearchParams();
+		preservePaneItemParam(params, currentUrl);
+		expect(params.has('item')).toBe(false);
+	});
+
+	// This is the actual regression `updateUrlFilters` guards against: it
+	// calls `new URLSearchParams()` from scratch on every filter/sort/view/
+	// tag/search change, with zero knowledge of the open pane. Without this
+	// re-emit, the very next unrelated filter change would silently close
+	// the pane by dropping `?item=` from the rebuilt query.
+	it('survives a simulated filter-change rebuild that starts from a blank params object', () => {
+		const currentUrl = new URL('https://pad.test/alice/ws/tasks?item=BUG-12&status=open');
+		const rebuilt = new URLSearchParams();
+		rebuilt.set('status', 'closed'); // simulates the new filter/sort/view state
+		preservePaneItemParam(rebuilt, currentUrl);
+		expect(rebuilt.get('item')).toBe('BUG-12');
+		expect(rebuilt.get('status')).toBe('closed');
+	});
+
+	it('re-targets to whatever ref is currently open, not a stale one', () => {
+		const currentUrl = new URL('https://pad.test/alice/ws/tasks?item=TASK-9');
+		const params = new URLSearchParams();
+		params.set('item', 'TASK-1'); // some stale/pre-existing value on the rebuilt params
+		preservePaneItemParam(params, currentUrl);
+		expect(params.get('item')).toBe('TASK-9');
+	});
+});
+
+describe('KNOWN_COLLECTION_URL_PARAMS', () => {
+	it('whitelists the pane `item` param', () => {
+		expect(KNOWN_COLLECTION_URL_PARAMS).toContain(PANE_ITEM_PARAM);
+		expect(KNOWN_COLLECTION_URL_PARAMS).toContain('item');
+	});
+
+	// Mirrors `loadUrlFilters`'s else-branch exactly: any param NOT in this
+	// whitelist is absorbed into `activeFilters` as a schema-field filter.
+	// `item` must be known, or a `?item=TASK-5` URL would produce a
+	// phantom `activeFilters.item = 'TASK-5'` field filter instead of
+	// opening the split pane.
+	it('treats `item` as known (not a phantom field filter) while leaving ordinary schema fields unknown', () => {
+		const knownParams = new Set(KNOWN_COLLECTION_URL_PARAMS);
+		expect(knownParams.has('item')).toBe(true);
+		expect(knownParams.has('status')).toBe(false);
+		expect(knownParams.has('priority')).toBe(false);
+	});
+});

--- a/web/src/lib/collections/paneUrlParams.test.ts
+++ b/web/src/lib/collections/paneUrlParams.test.ts
@@ -1,5 +1,24 @@
 import { describe, it, expect } from 'vitest';
-import { KNOWN_COLLECTION_URL_PARAMS, PANE_ITEM_PARAM, preservePaneItemParam } from './paneUrlParams';
+import {
+	KNOWN_COLLECTION_URL_PARAMS,
+	PANE_ITEM_PARAM,
+	buildCollectionUrlParams,
+	preservePaneItemParam,
+	type CollectionUrlFilterState,
+} from './paneUrlParams';
+
+// Baseline "nothing changed" state — each `buildCollectionUrlParams` spec
+// below overrides only the field(s) it's exercising.
+function state(overrides: Partial<CollectionUrlFilterState> = {}): CollectionUrlFilterState {
+	return {
+		viewMode: 'list',
+		activeFilters: {},
+		selectedTags: [],
+		unparentedApplied: false,
+		searchQuery: '',
+		...overrides,
+	};
+}
 
 describe('preservePaneItemParam', () => {
 	it('re-emits the currently-open pane ref onto a freshly rebuilt params object', () => {
@@ -37,6 +56,45 @@ describe('preservePaneItemParam', () => {
 		params.set('item', 'TASK-1'); // some stale/pre-existing value on the rebuilt params
 		preservePaneItemParam(params, currentUrl);
 		expect(params.get('item')).toBe('TASK-9');
+	});
+});
+
+// `buildCollectionUrlParams` is the exact function `+page.svelte`'s
+// `updateUrlFilters` calls in production (no inline duplicate logic left in
+// the route) — so these specs exercise the real `?item=` round-trip, not a
+// parallel reimplementation. Removing the `preservePaneItemParam` call
+// inside `buildCollectionUrlParams`, or reverting `updateUrlFilters` to
+// build params without delegating to it, breaks these specs.
+describe('buildCollectionUrlParams', () => {
+	it('preserves an existing ?item= across a filter change — the updateUrlFilters call path', () => {
+		const currentUrl = new URL('https://pad.test/alice/ws/tasks?item=BUG-12&status=open');
+		const params = buildCollectionUrlParams(state({ activeFilters: { status: 'closed' } }), currentUrl);
+		expect(params.get('item')).toBe('BUG-12');
+		expect(params.get('status')).toBe('closed');
+	});
+
+	it('preserves an existing ?item= across a view-mode change', () => {
+		const currentUrl = new URL('https://pad.test/alice/ws/tasks?item=TASK-5');
+		const params = buildCollectionUrlParams(state({ viewMode: 'board' }), currentUrl);
+		expect(params.get('view')).toBe('board');
+		expect(params.get('item')).toBe('TASK-5');
+	});
+
+	it('preserves an existing ?item= across a tag/search change', () => {
+		const currentUrl = new URL('https://pad.test/alice/ws/tasks?item=DOC-2');
+		const params = buildCollectionUrlParams(
+			state({ selectedTags: ['a', 'b'], searchQuery: 'hello' }),
+			currentUrl
+		);
+		expect(params.get('tags')).toBe('a,b');
+		expect(params.get('q')).toBe('hello');
+		expect(params.get('item')).toBe('DOC-2');
+	});
+
+	it('omits ?item= entirely when no pane is open', () => {
+		const currentUrl = new URL('https://pad.test/alice/ws/tasks');
+		const params = buildCollectionUrlParams(state({ activeFilters: { status: 'open' } }), currentUrl);
+		expect(params.has('item')).toBe(false);
 	});
 });
 

--- a/web/src/lib/collections/paneUrlParams.ts
+++ b/web/src/lib/collections/paneUrlParams.ts
@@ -1,13 +1,22 @@
 // The `?item=` query param drives the collection page's split-pane detail
-// view (PLAN-2105 Phase 2 / TASK-2111). This module holds the two PURE
-// decision points the pane's URL machinery depends on, factored out of
+// view (PLAN-2105 Phase 2 / TASK-2111). This module holds the PURE decision
+// points the pane's URL machinery depends on, factored out of
 // `[collection]/+page.svelte`'s `updateUrlFilters` / `loadUrlFilters` so
 // they're unit-testable without mounting the full route (TASK-2116) — the
 // same pattern `unparentedFilter.ts` already uses for the `$unparented`
 // pseudo-filter.
 //
+// `buildCollectionUrlParams` is the COMPLETE `updateUrlFilters` param
+// builder, not just the pane-preservation sliver — `+page.svelte` calls it
+// directly rather than duplicating any of this logic inline, so a spec
+// exercising this function is exercising the real production code path: a
+// future edit that drops the `?item=` re-emit (or any other param) here
+// breaks both the app and these specs together, not just a parallel copy.
+//
 // Kept framework-agnostic (no `$state`/`page`) — callers pass plain
-// `URL`/`URLSearchParams` values.
+// `URL`/`URLSearchParams` values and plain data.
+
+import { writeUnparentedParam } from './unparentedFilter';
 
 /** The query-string key the split pane's `openItemRef` derives from. */
 export const PANE_ITEM_PARAM = 'item';
@@ -34,4 +43,44 @@ export const KNOWN_COLLECTION_URL_PARAMS: readonly string[] = ['view', 'q', 'tag
 export function preservePaneItemParam(params: URLSearchParams, currentUrl: URL): void {
 	const openItem = currentUrl.searchParams.get(PANE_ITEM_PARAM);
 	if (openItem) params.set(PANE_ITEM_PARAM, openItem);
+}
+
+/** The filter/sort/view/search state `updateUrlFilters` serializes. */
+export interface CollectionUrlFilterState {
+	/** The page's `ViewMode` ('list' | 'board' | 'table'); 'list' is the
+	 *  default and omitted from the query string. */
+	viewMode: string;
+	activeFilters: Record<string, string>;
+	selectedTags: string[];
+	/** The EFFECTIVE unparented-filter state (`unparentedEffective(...)`),
+	 *  not raw intent — see `writeUnparentedParam`. */
+	unparentedApplied: boolean;
+	searchQuery: string;
+}
+
+/**
+ * Build the full query-string params for `updateUrlFilters` — view mode,
+ * active field filters, tags, the unparented pseudo-filter, search, and the
+ * preserved pane ref, in the same order the route wires them. `currentUrl`
+ * is only consulted for the pane ref (via `preservePaneItemParam`); every
+ * other value comes from `state`.
+ */
+export function buildCollectionUrlParams(state: CollectionUrlFilterState, currentUrl: URL): URLSearchParams {
+	const params = new URLSearchParams();
+	if (state.viewMode !== 'list') params.set('view', state.viewMode);
+	for (const [k, v] of Object.entries(state.activeFilters)) {
+		params.set(k, v);
+	}
+	// Tags are comma-joined under a single `tags` param. The tag editor
+	// uses comma as its add-delimiter, so tag values never contain
+	// commas — round-tripping through a comma-joined string is safe.
+	if (state.selectedTags.length > 0) params.set('tags', state.selectedTags.join(','));
+	// Write the EFFECTIVE state, not raw intent — a restricted caller's URL
+	// never even transiently carries `unparented=true` (PLAN-2095 DR-2).
+	writeUnparentedParam(params, state.unparentedApplied);
+	if (state.searchQuery) params.set('q', state.searchQuery);
+	// Preserve an open split pane across this rebuild (PLAN-2105) — see
+	// `preservePaneItemParam` above for why this is necessary.
+	preservePaneItemParam(params, currentUrl);
+	return params;
 }

--- a/web/src/lib/collections/paneUrlParams.ts
+++ b/web/src/lib/collections/paneUrlParams.ts
@@ -1,0 +1,37 @@
+// The `?item=` query param drives the collection page's split-pane detail
+// view (PLAN-2105 Phase 2 / TASK-2111). This module holds the two PURE
+// decision points the pane's URL machinery depends on, factored out of
+// `[collection]/+page.svelte`'s `updateUrlFilters` / `loadUrlFilters` so
+// they're unit-testable without mounting the full route (TASK-2116) — the
+// same pattern `unparentedFilter.ts` already uses for the `$unparented`
+// pseudo-filter.
+//
+// Kept framework-agnostic (no `$state`/`page`) — callers pass plain
+// `URL`/`URLSearchParams` values.
+
+/** The query-string key the split pane's `openItemRef` derives from. */
+export const PANE_ITEM_PARAM = 'item';
+
+/**
+ * Params `loadUrlFilters` already understands by name (view mode, search
+ * query, tags, and the pane ref) rather than absorbing into
+ * `activeFilters` as a schema-field filter. `+page.svelte` folds in the
+ * collection-specific `UNPARENTED_FILTER_FIELD` on top of this base list —
+ * kept here as the base so this module doesn't need to import that
+ * vocabulary.
+ */
+export const KNOWN_COLLECTION_URL_PARAMS: readonly string[] = ['view', 'q', 'tags', PANE_ITEM_PARAM];
+
+/**
+ * Re-emit the currently-open pane ref (if any) onto `params` — the
+ * `updateUrlFilters` half of the round-trip. `updateUrlFilters` rebuilds
+ * its query from scratch (`new URLSearchParams()`) on every
+ * filter/sort/view/tag/search change, so without this the pane would
+ * silently close on the next unrelated URL sync. `currentUrl` is the live
+ * `page.url` that `openItemRef` itself derives from, so this always
+ * reflects the pane that's actually open.
+ */
+export function preservePaneItemParam(params: URLSearchParams, currentUrl: URL): void {
+	const openItem = currentUrl.searchParams.get(PANE_ITEM_PARAM);
+	if (openItem) params.set(PANE_ITEM_PARAM, openItem);
+}

--- a/web/src/lib/components/collections/ItemCard.svelte
+++ b/web/src/lib/components/collections/ItemCard.svelte
@@ -7,6 +7,7 @@
 	import { copyToClipboard } from '$lib/utils/clipboard';
 	import ItemActionsMenu from './ItemActionsMenu.svelte';
 	import type { ReorderDirection } from '$lib/collections/reorder';
+	import { shouldOpenInPane } from './itemCardClick';
 
 	interface Props {
 		item: Item;
@@ -165,13 +166,13 @@
 	// native <a href> (cmd/middle-click = full-page popout in a new tab,
 	// right-click-copy / SSR target the full page). Sub-controls (star / PR /
 	// status / tags / reorder) already stopPropagation, so their clicks never
-	// reach this handler; `defaultPrevented` is a defensive backstop.
+	// reach this handler; `defaultPrevented` is a defensive backstop. The
+	// bail-out predicate is factored into `shouldOpenInPane` (TASK-2116) so
+	// it's unit-testable without mounting this component.
 	function handleCardClick(e: MouseEvent) {
-		if (!onItemOpen) return;
-		if (e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
-		if (e.defaultPrevented) return;
+		if (!shouldOpenInPane(e, !!onItemOpen)) return;
 		e.preventDefault();
-		onItemOpen(item);
+		onItemOpen?.(item);
 	}
 </script>
 

--- a/web/src/lib/components/collections/itemCardClick.test.ts
+++ b/web/src/lib/components/collections/itemCardClick.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { shouldOpenInPane, type CardClickLike } from './itemCardClick';
+
+// A plain, unmodified left-click — the baseline every test below tweaks a
+// single field of.
+function click(overrides: Partial<CardClickLike> = {}): CardClickLike {
+	return {
+		button: 0,
+		metaKey: false,
+		ctrlKey: false,
+		shiftKey: false,
+		altKey: false,
+		defaultPrevented: false,
+		...overrides,
+	};
+}
+
+describe('shouldOpenInPane', () => {
+	it('opens the pane on a plain left-click when onItemOpen is wired', () => {
+		expect(shouldOpenInPane(click(), true)).toBe(true);
+	});
+
+	// Every other surface (starred / tags / roles / share) renders ItemCard
+	// with no `onItemOpen` — those clicks must keep navigating full-page.
+	it('falls through to href when no onItemOpen handler is wired', () => {
+		expect(shouldOpenInPane(click(), false)).toBe(false);
+	});
+
+	it('falls through on cmd/meta-click (full-page popout in a new tab)', () => {
+		expect(shouldOpenInPane(click({ metaKey: true }), true)).toBe(false);
+	});
+
+	it('falls through on ctrl-click', () => {
+		expect(shouldOpenInPane(click({ ctrlKey: true }), true)).toBe(false);
+	});
+
+	it('falls through on shift-click', () => {
+		expect(shouldOpenInPane(click({ shiftKey: true }), true)).toBe(false);
+	});
+
+	it('falls through on alt-click', () => {
+		expect(shouldOpenInPane(click({ altKey: true }), true)).toBe(false);
+	});
+
+	it('falls through on middle-click (button 1, native new-tab open)', () => {
+		expect(shouldOpenInPane(click({ button: 1 }), true)).toBe(false);
+	});
+
+	it('falls through on right-click (button 2, context menu / copy-link)', () => {
+		expect(shouldOpenInPane(click({ button: 2 }), true)).toBe(false);
+	});
+
+	// Defensive backstop: sub-controls (star / PR badge / status cycle / tag
+	// chips / reorder menu) already stopPropagation so they never reach this
+	// predicate, but if some other handler upstream already prevented the
+	// default action, the pane must not double-handle the click.
+	it('falls through when the click was already defaultPrevented', () => {
+		expect(shouldOpenInPane(click({ defaultPrevented: true }), true)).toBe(false);
+	});
+
+	it('a held modifier still wins even without onItemOpen wired (both reasons to fall through)', () => {
+		expect(shouldOpenInPane(click({ metaKey: true }), false)).toBe(false);
+	});
+});

--- a/web/src/lib/components/collections/itemCardClick.ts
+++ b/web/src/lib/components/collections/itemCardClick.ts
@@ -1,0 +1,42 @@
+// Pure predicate factored out of `ItemCard.svelte`'s `handleCardClick`
+// (PLAN-2105 / TASK-2111 row-click interception) so it's unit-testable
+// without mounting the component (TASK-2116).
+//
+// The interception is opt-in (`onItemOpen` prop, wired only by the
+// collection page) and must NEVER swallow:
+//  - a click with no `onItemOpen` handler wired — every other surface
+//    (starred / tags / roles / share) keeps plain full-page anchor nav.
+//  - modifier-clicks (cmd/ctrl/shift/alt) — so cmd/ctrl-click still opens
+//    the full page in a new tab (the "popout" state, PLAN-2105).
+//  - non-left-button clicks (middle-click new-tab, right-click context
+//    menu / copy-link).
+//  - a click some other handler (a sub-control — star/PR badge/status
+//    cycle/tag chip/reorder menu) already called `preventDefault()` on.
+// Anything else is a plain left-click, which opens the item in the split
+// pane instead of navigating.
+
+/**
+ * The subset of `MouseEvent` the predicate reads. Narrowed to a plain
+ * interface (rather than requiring `MouseEvent` itself) so specs can pass
+ * plain object literals instead of constructing DOM events.
+ */
+export interface CardClickLike {
+	button: number;
+	metaKey: boolean;
+	ctrlKey: boolean;
+	shiftKey: boolean;
+	altKey: boolean;
+	defaultPrevented: boolean;
+}
+
+/**
+ * True when a card click should open the item in the split pane instead of
+ * following its `href`. Mirrors `ItemCard.handleCardClick`'s bail-out order
+ * exactly — see that function for the call site.
+ */
+export function shouldOpenInPane(e: CardClickLike, hasOnItemOpen: boolean): boolean {
+	if (!hasOnItemOpen) return false;
+	if (e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return false;
+	if (e.defaultPrevented) return false;
+	return true;
+}

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -43,6 +43,7 @@
 		viewHasUnparentedFilter,
 		writeUnparentedParam,
 	} from '$lib/collections/unparentedFilter';
+	import { KNOWN_COLLECTION_URL_PARAMS, preservePaneItemParam } from '$lib/collections/paneUrlParams';
 
 	type ViewMode = 'list' | 'board' | 'table';
 
@@ -455,10 +456,11 @@
 		// changes. This function rebuilds the query from scratch (the fresh
 		// `new URLSearchParams()` above), so without re-emitting the current
 		// `?item=` the next filter change would silently drop the open pane
-		// (PLAN-2105). Read the live value off `page.url` — it's the same
-		// source `openItemRef` derives from, so this stays in sync.
-		const openItem = page.url.searchParams.get('item');
-		if (openItem) params.set('item', openItem);
+		// (PLAN-2105). Reads the live value off `page.url` — it's the same
+		// source `openItemRef` derives from, so this stays in sync. Factored
+		// into `preservePaneItemParam` (TASK-2116) so the round-trip is
+		// unit-testable without mounting this route.
+		preservePaneItemParam(params, page.url);
 		const qs = params.toString();
 		const newUrl = `/${username}/${wsSlug}/${collSlug}${qs ? '?' + qs : ''}`;
 		goto(newUrl, { replaceState: true, noScroll: true, keepFocus: true });
@@ -518,11 +520,12 @@
 		// know that yet.
 		selectedTags = [];
 		const unparentedIntent = readUnparentedParam(url.searchParams);
-		// `item` is the split-pane param (PLAN-2105) — whitelist it so it's
-		// not misread as a schema-field filter and absorbed into
-		// activeFilters. It's consumed by the `openItemRef` derived, not by
-		// the filter load cycle.
-		const knownParams = new Set(['view', 'q', 'tags', 'item', UNPARENTED_FILTER_FIELD]);
+		// `item` is the split-pane param (PLAN-2105) — whitelist it (via the
+		// shared `KNOWN_COLLECTION_URL_PARAMS`, TASK-2116) so it's not
+		// misread as a schema-field filter and absorbed into activeFilters.
+		// It's consumed by the `openItemRef` derived, not by the filter load
+		// cycle.
+		const knownParams = new Set([...KNOWN_COLLECTION_URL_PARAMS, UNPARENTED_FILTER_FIELD]);
 		for (const [k, v] of url.searchParams.entries()) {
 			if (k === 'view' && (v === 'list' || v === 'board')) {
 				viewMode = v;

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -41,9 +41,8 @@
 		unparentedConfirmedRestricted,
 		unparentedEffective,
 		viewHasUnparentedFilter,
-		writeUnparentedParam,
 	} from '$lib/collections/unparentedFilter';
-	import { KNOWN_COLLECTION_URL_PARAMS, preservePaneItemParam } from '$lib/collections/paneUrlParams';
+	import { KNOWN_COLLECTION_URL_PARAMS, buildCollectionUrlParams } from '$lib/collections/paneUrlParams';
 
 	type ViewMode = 'list' | 'board' | 'table';
 
@@ -436,31 +435,18 @@
 		}
 	});
 
-	// Sync filters to URL query params (shareable)
+	// Sync filters to URL query params (shareable). The full param-build
+	// (view/filters/tags/unparented/search, plus preserving an open split
+	// pane's `?item=` across the rebuild — PLAN-2105) is factored into
+	// `buildCollectionUrlParams` (TASK-2116) so it's unit-testable without
+	// mounting this route; this function just supplies the live state and
+	// URL and performs the actual navigation.
 	function updateUrlFilters() {
 		if (!collSlug || !wsSlug) return;
-		const params = new URLSearchParams();
-		if (viewMode !== 'list') params.set('view', viewMode);
-		for (const [k, v] of Object.entries(activeFilters)) {
-			params.set(k, v);
-		}
-		// Tags are comma-joined under a single `tags` param. The tag editor
-		// uses comma as its add-delimiter, so tag values never contain
-		// commas — round-tripping through a comma-joined string is safe.
-		if (selectedTags.length > 0) params.set('tags', selectedTags.join(','));
-		// Write the EFFECTIVE state, not raw intent — a restricted caller's
-		// URL never even transiently carries `unparented=true` (DR-2).
-		writeUnparentedParam(params, unparentedApplied);
-		if (searchQuery) params.set('q', searchQuery);
-		// Preserve an open split pane across filter/sort/view/tag/search
-		// changes. This function rebuilds the query from scratch (the fresh
-		// `new URLSearchParams()` above), so without re-emitting the current
-		// `?item=` the next filter change would silently drop the open pane
-		// (PLAN-2105). Reads the live value off `page.url` — it's the same
-		// source `openItemRef` derives from, so this stays in sync. Factored
-		// into `preservePaneItemParam` (TASK-2116) so the round-trip is
-		// unit-testable without mounting this route.
-		preservePaneItemParam(params, page.url);
+		const params = buildCollectionUrlParams(
+			{ viewMode, activeFilters, selectedTags, unparentedApplied, searchQuery },
+			page.url
+		);
 		const qs = params.toString();
 		const newUrl = `/${username}/${wsSlug}/${collSlug}${qs ? '?' + qs : ''}`;
 		goto(newUrl, { replaceState: true, noScroll: true, keepFocus: true });


### PR DESCRIPTION
## Summary

- PLAN-2105 Phase 2 wave 3: automated vitest specs for the split-pane's two highest-regression-risk deterministic behaviors. The pane + row-click interception (TASK-2111/TASK-2112) are already merged to main — this task only adds test coverage, extracting pure helpers where needed to make the logic unit-testable without a DOM/component harness (the jsdom `*.svelte.test.ts` harness is flaky under worktree-symlinked node_modules in this environment).
- **Click-interception predicate** (`ItemCard.svelte`'s `handleCardClick`): factored the bail-out predicate into `web/src/lib/components/collections/itemCardClick.ts::shouldOpenInPane`, imported back into `ItemCard.svelte` unchanged in behavior. 10 specs in `itemCardClick.test.ts` cover plain left-click (opens pane), cmd/ctrl/shift/alt-click, middle/right-click, no-`onItemOpen`-wired, and `defaultPrevented` (all fall through to href).
- **`?item=` URL round-trip** (`[collection]/+page.svelte`'s `updateUrlFilters` / `loadUrlFilters`): factored the *entire* param builder into `web/src/lib/collections/paneUrlParams.ts::buildCollectionUrlParams` (not just the pane-preservation sliver — round 1 of Codex review flagged that a partial extraction would let the production re-emit call be silently removed without failing any spec), plus the `KNOWN_COLLECTION_URL_PARAMS` whitelist. `+page.svelte` now delegates its whole query-string construction to this tested function rather than duplicating any logic inline, so the specs exercise the real production code path. 10 specs in `paneUrlParams.test.ts` cover: preserving `?item=` across filter/view/tag/search changes, omitting it when no pane is open, and `item` being a known param (not absorbed into `activeFilters` as a phantom field filter).
- No pane-chrome regions were touched (a sibling task is concurrently editing `+page.svelte`'s pane header and `ItemDetail.svelte`) — the diff here is confined to the two URL-builder functions and the `handleCardClick` one-liner.

## Test plan

- [x] `cd web && npm run test` — 229 passed (20 new specs: 10 in `itemCardClick.test.ts`, 10 in `paneUrlParams.test.ts`). 5 pre-existing `jsdom` `*.svelte.test.ts` suites fail to load under this worktree's symlinked `node_modules` (`@testing-library/svelte/src/vitest.js` module resolution) — a known environment artifact, unrelated to this change.
- [x] `cd web && npm run check` — 0 errors, 8 pre-existing warnings (none in touched files).
- [x] Codex review (2 rounds): round 1 flagged that testing `preservePaneItemParam` directly left the production wiring in `updateUrlFilters` unverified; fixed by extracting the complete `buildCollectionUrlParams` builder so `+page.svelte` delegates entirely to it. Round 2 mutation-tested by actually removing the `?item=` re-emit (3 spec failures) and removing `item` from `KNOWN_COLLECTION_URL_PARAMS` (2 spec failures) — verdict **CLEAN**.

https://claude.ai/code/session_01EZ6yr6pAUFb1uffan912ra