### PR TITLE
feat(web): j/k pane-follow + ESC precedence chain (TASK-2119, TASK-2118)

### DIFF
--- a/web/src/lib/collections/boardNav.test.ts
+++ b/web/src/lib/collections/boardNav.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { boardKeyNav, type BoardNavColumn } from './boardNav';
+
+// Minimal shape — boardKeyNav only reads `.id`.
+const item = (id: string) => ({ id });
+
+// backlog: a,b,c | in_progress: d,e | done: (empty) | review: f
+const columns: BoardNavColumn<{ id: string }>[] = [
+	{ value: 'backlog', items: [item('a'), item('b'), item('c')] },
+	{ value: 'in_progress', items: [item('d'), item('e')] },
+	{ value: 'done', items: [] },
+	{ value: 'review', items: [item('f')] },
+];
+
+describe('boardKeyNav', () => {
+	it('down moves within the column and clamps at the bottom', () => {
+		expect(boardKeyNav(columns, 'a', 'down')).toBe('b');
+		expect(boardKeyNav(columns, 'b', 'down')).toBe('c');
+		expect(boardKeyNav(columns, 'c', 'down')).toBe('c'); // clamped
+	});
+
+	it('up moves within the column and clamps at the top', () => {
+		expect(boardKeyNav(columns, 'c', 'up')).toBe('b');
+		expect(boardKeyNav(columns, 'a', 'up')).toBe('a'); // clamped
+	});
+
+	it('never jumps to another column on up/down', () => {
+		// bottom of backlog stays in backlog, does NOT roll into in_progress
+		expect(boardKeyNav(columns, 'c', 'down')).toBe('c');
+		// top of in_progress stays in in_progress
+		expect(boardKeyNav(columns, 'd', 'up')).toBe('d');
+	});
+
+	it('right moves to the adjacent column, clamping the row position', () => {
+		expect(boardKeyNav(columns, 'a', 'right')).toBe('d'); // row 0 → in_progress row 0
+		expect(boardKeyNav(columns, 'c', 'right')).toBe('e'); // row 2 → in_progress clamps to row 1
+	});
+
+	it('right skips an empty column to the next non-empty one', () => {
+		// in_progress row 0 → done is empty → review (clamped to its single item)
+		expect(boardKeyNav(columns, 'd', 'right')).toBe('f');
+		expect(boardKeyNav(columns, 'e', 'right')).toBe('f');
+	});
+
+	it('right returns null at the rightmost non-empty column', () => {
+		expect(boardKeyNav(columns, 'f', 'right')).toBeNull();
+	});
+
+	it('left moves to the previous non-empty column, clamping the row', () => {
+		expect(boardKeyNav(columns, 'f', 'left')).toBe('d'); // review row 0 → in_progress row 0
+		expect(boardKeyNav(columns, 'e', 'left')).toBe('b'); // in_progress row 1 → backlog row 1
+	});
+
+	it('left skips empty columns and returns null at the leftmost', () => {
+		expect(boardKeyNav(columns, 'a', 'left')).toBeNull();
+	});
+
+	it('with nothing focused, any direction lands on the first item of the first non-empty column', () => {
+		expect(boardKeyNav(columns, null, 'down')).toBe('a');
+		expect(boardKeyNav(columns, null, 'up')).toBe('a');
+		expect(boardKeyNav(columns, null, 'right')).toBe('a');
+		expect(boardKeyNav(columns, null, 'left')).toBe('a');
+	});
+
+	it('treats an unknown focused id as nothing focused (first item)', () => {
+		expect(boardKeyNav(columns, 'ghost', 'down')).toBe('a');
+	});
+
+	it('skips a leading empty column when picking the first item', () => {
+		const cols: BoardNavColumn<{ id: string }>[] = [
+			{ value: 'a', items: [] },
+			{ value: 'b', items: [item('x'), item('y')] },
+		];
+		expect(boardKeyNav(cols, null, 'down')).toBe('x');
+	});
+
+	it('returns null when the board has no items at all', () => {
+		const empty: BoardNavColumn<{ id: string }>[] = [
+			{ value: 'a', items: [] },
+			{ value: 'b', items: [] },
+		];
+		expect(boardKeyNav(empty, null, 'down')).toBeNull();
+	});
+});

--- a/web/src/lib/collections/boardNav.ts
+++ b/web/src/lib/collections/boardNav.ts
@@ -1,0 +1,91 @@
+// Board (kanban) keyboard-navigation model (PLAN-2105 / TASK-2119).
+//
+// The collection page's j/k/arrow navigation moves a `focusedIndex` over the
+// FLAT `filteredItems` array — correct for the list/table views, but the board
+// renders those same items grouped into columns (swimlanes) and sorted WITHIN
+// each column, so a flat step jumps across columns and feels "all over the
+// place". This helper maps a directional keypress onto the board's ACTUAL
+// rendered order.
+//
+// Critical: the caller must pass the columns in the board's real render order
+// (column order + within-column sort as BoardView renders them) — BoardView is
+// the single source of truth and surfaces that structure upward, so this never
+// re-derives a grouping that could drift from the render.
+
+export interface BoardNavColumn<T extends { id: string } = { id: string }> {
+	value: string;
+	items: T[];
+}
+
+export type BoardNavDirection = 'up' | 'down' | 'left' | 'right';
+
+// Given the board columns in visual render order (each with its items in
+// rendered order) plus the currently focused item id, return the id of the item
+// to focus after a directional keypress — or null when the move isn't possible
+// (already at a column edge with no adjacent non-empty column, or no items at
+// all).
+//
+// - up/down move WITHIN the focused item's column, clamped at the column ends
+//   (never jump to another column).
+// - left/right switch to the nearest NON-EMPTY column in that direction,
+//   landing on the same row position clamped to that column's length.
+// - With nothing focused yet (or a focused id that's no longer on the board),
+//   ANY direction lands on the first item of the first non-empty column.
+export function boardKeyNav<T extends { id: string }>(
+	columns: BoardNavColumn<T>[],
+	focusedId: string | null,
+	direction: BoardNavDirection,
+): string | null {
+	// Locate the focused item within the rendered structure.
+	let colIdx = -1;
+	let rowIdx = -1;
+	if (focusedId != null) {
+		for (let c = 0; c < columns.length; c++) {
+			const r = columns[c].items.findIndex((it) => it.id === focusedId);
+			if (r !== -1) {
+				colIdx = c;
+				rowIdx = r;
+				break;
+			}
+		}
+	}
+
+	// Nothing focused (or the focused item left the board): first nav lands on
+	// the first item of the first non-empty column.
+	if (colIdx === -1) {
+		return firstItemId(columns);
+	}
+
+	switch (direction) {
+		case 'down': {
+			const col = columns[colIdx].items;
+			return col[Math.min(rowIdx + 1, col.length - 1)]?.id ?? null;
+		}
+		case 'up': {
+			const col = columns[colIdx].items;
+			return col[Math.max(rowIdx - 1, 0)]?.id ?? null;
+		}
+		case 'right': {
+			for (let c = colIdx + 1; c < columns.length; c++) {
+				const col = columns[c].items;
+				if (col.length > 0) return col[Math.min(rowIdx, col.length - 1)].id;
+			}
+			return null; // no non-empty column to the right
+		}
+		case 'left': {
+			for (let c = colIdx - 1; c >= 0; c--) {
+				const col = columns[c].items;
+				if (col.length > 0) return col[Math.min(rowIdx, col.length - 1)].id;
+			}
+			return null; // no non-empty column to the left
+		}
+	}
+	return null;
+}
+
+function firstItemId<T extends { id: string }>(columns: BoardNavColumn<T>[]): string | null {
+	for (const col of columns) {
+		if (col.items.length > 0) return col.items[0].id;
+	}
+	return null;
+}

--- a/web/src/lib/components/collections/BoardView.svelte
+++ b/web/src/lib/components/collections/BoardView.svelte
@@ -84,9 +84,17 @@
 		 * page, so other surfaces keep full-page anchor navigation.
 		 */
 		onItemOpen?: (item: Item) => void;
+		/**
+		 * Report the board's rendered column structure (visual column order +
+		 * within-column sort, as actually rendered) up to the parent so its
+		 * keyboard navigation follows the real render order rather than a
+		 * re-derived grouping that could drift from it (PLAN-2105 / TASK-2119).
+		 * The parent (collection page) is the only caller.
+		 */
+		onColumnsRendered?: (columns: { value: string; items: Item[] }[]) => void;
 	}
 
-	let { items, collection, wsSlug = '', groupField = 'status', focusedItemId = null, onStatusChange, onReorder, onArchiveColumn, onGroupReorder, oncreate, onCreateInColumn, onMoveColumn, onTagColumn, onUntagColumn, onSetPriorityColumn, onAssignColumn, members = [], tagSuggestions = [], filtered = false, itemProgress, progressLabel = 'tasks', canEdit = true, preserveOrder = false, sortMode = 'manual', draftText = $bindable({}), draftOpen = $bindable({}), onItemOpen }: Props = $props();
+	let { items, collection, wsSlug = '', groupField = 'status', focusedItemId = null, onStatusChange, onReorder, onArchiveColumn, onGroupReorder, oncreate, onCreateInColumn, onMoveColumn, onTagColumn, onUntagColumn, onSetPriorityColumn, onAssignColumn, members = [], tagSuggestions = [], filtered = false, itemProgress, progressLabel = 'tasks', canEdit = true, preserveOrder = false, sortMode = 'manual', draftText = $bindable({}), draftOpen = $bindable({}), onItemOpen, onColumnsRendered }: Props = $props();
 
 	// Local — disables the draft card while its Enter-create is in flight.
 	let savingDraft = $state(false);
@@ -265,6 +273,23 @@
 		if (!isDragging && !dropCooldown) {
 			columnData = data;
 		}
+	});
+
+	// Surface the board's rendered column structure to the parent for keyboard
+	// navigation (PLAN-2105 / TASK-2119). Visual column order (`columnOrder`,
+	// which reflects any local column-drag) × each lane's rendered item order
+	// (`columnData`, which reflects per-lane sort overrides), with DnD shadow
+	// placeholders filtered so mid-drag nav never targets a phantom card. This
+	// is the single source of truth — the parent navigates THIS, never a
+	// re-derived grouping that could disagree with what's on screen.
+	let navColumns = $derived(
+		columnOrder.map((col) => ({
+			value: col,
+			items: (columnData[col] ?? []).filter((i: any) => !i[SHADOW_ITEM_MARKER_PROPERTY_NAME]),
+		}))
+	);
+	$effect(() => {
+		onColumnsRendered?.(navColumns);
 	});
 
 	function handleConsider(columnValue: string, e: CustomEvent<DndEvent<Item>>) {

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -5,6 +5,7 @@
 	import { confirmOpenChildrenOrThrow, isOpenChildrenError } from '$lib/items/openChildrenError';
 	import { marked } from 'marked';
 	import { collectionStore } from '$lib/stores/collections.svelte';
+	import { pushEscapeHandler, ESCAPE_PRIORITY } from '$lib/stores/escapeStack';
 	import { localIndex } from '$lib/stores/localIndex.svelte';
 	import { syncService } from '$lib/services/sync.svelte';
 	import { sseService } from '$lib/services/sse.svelte';
@@ -312,13 +313,30 @@
 		return `/${username}/${wsSlug}/${collection ?? effectiveCollSlug}/${ref}`;
 	}
 	// ESC closes the graph drawer (only while open — no global listener otherwise).
+	// FULL-PAGE only: there's no pane/list contention on the full-page route, so
+	// it keeps its own window listener. The EMBEDDED graph drawer routes ESC
+	// through the shared escape stack instead (see below) so it composes with
+	// the pane + list-focus layers — one ESC closes exactly one layer
+	// (PLAN-2105 / TASK-2118).
 	$effect(() => {
+		if (embedded) return;
 		if (!showGraph) return;
 		const onKey = (e: KeyboardEvent) => {
 			if (e.key === 'Escape') closeGraph();
 		};
 		window.addEventListener('keydown', onKey);
 		return () => window.removeEventListener('keydown', onKey);
+	});
+	// EMBEDDED graph drawer — highest-priority ESC layer (innermost). Registered
+	// into the shared escape stack while open; the single top-level listener on
+	// the collection page invokes only the top handler, so one ESC closes the
+	// drawer and leaves the pane open (PLAN-2105 / TASK-2118).
+	$effect(() => {
+		if (!embedded || !showGraph) return;
+		return pushEscapeHandler(() => {
+			closeGraph();
+			return true;
+		}, ESCAPE_PRIORITY.graphDrawer);
 	});
 
 	// ── Embedded pane chrome (PLAN-2105 / TASK-2113) ───────────────────
@@ -339,24 +357,21 @@
 		if (!item) return;
 		goto(fullPageUrl);
 	}
-	// Scoped ESC-to-close — active ONLY while embedded (the pane is mounted
-	// only when ?item= is set). Bails when the graph drawer is open (its own
-	// ESC listener above closes it first) or focus is in a text-editing
-	// control (ESC there dismisses that control — e.g. cancels a title edit —
-	// not the whole pane). Final multi-layer ESC precedence with the graph
-	// drawer + list focus is TASK-2118; this scoped listener is the pane's
-	// own layer.
+	// Pane-close — the middle ESC layer, between the graph drawer (higher) and
+	// the collection list-focus marker (lower). Registered into the shared
+	// escape stack while embedded (the pane is mounted only when ?item= is set).
+	// Priority — not a per-handler `showGraph` guard — decides graph-vs-pane
+	// precedence now: while the drawer is open its higher-priority handler wins,
+	// so one ESC closes the drawer and a second closes the pane. The
+	// text-editing-control bail (ESC cancels a title edit / editor selection,
+	// not the pane) lives in the single top-level listener on the collection
+	// page, so it isn't repeated here (PLAN-2105 / TASK-2118).
 	$effect(() => {
 		if (!embedded) return;
-		const onKey = (e: KeyboardEvent) => {
-			if (e.key !== 'Escape') return;
-			if (showGraph) return;
-			const t = e.target as HTMLElement | null;
-			if (t?.closest('input, textarea, select, [contenteditable="true"]')) return;
+		return pushEscapeHandler(() => {
 			onClose?.();
-		};
-		window.addEventListener('keydown', onKey);
-		return () => window.removeEventListener('keydown', onKey);
+			return true;
+		}, ESCAPE_PRIORITY.pane);
 	});
 	let editCollectionSection = $state<'general' | 'fields' | 'display' | 'actions' | undefined>(undefined);
 	let agentRoles = $state<AgentRole[]>([]);

--- a/web/src/lib/stores/escapeStack.test.ts
+++ b/web/src/lib/stores/escapeStack.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+	pushEscapeHandler,
+	runTopEscape,
+	ESCAPE_PRIORITY,
+	_resetEscapeStackForTests,
+} from './escapeStack';
+
+describe('escapeStack', () => {
+	beforeEach(() => {
+		_resetEscapeStackForTests();
+	});
+
+	it('returns false when the stack is empty', () => {
+		expect(runTopEscape()).toBe(false);
+	});
+
+	it('invokes only the highest-priority handler per ESC (one layer)', () => {
+		const calls: string[] = [];
+		pushEscapeHandler(() => {
+			calls.push('listFocus');
+			return true;
+		}, ESCAPE_PRIORITY.listFocus);
+		pushEscapeHandler(() => {
+			calls.push('pane');
+			return true;
+		}, ESCAPE_PRIORITY.pane);
+		pushEscapeHandler(() => {
+			calls.push('graph');
+			return true;
+		}, ESCAPE_PRIORITY.graphDrawer);
+
+		expect(runTopEscape()).toBe(true);
+		// Exactly one handler fired — the innermost (graph drawer).
+		expect(calls).toEqual(['graph']);
+	});
+
+	it('closes one layer at a time, innermost-first, as layers unregister', () => {
+		const calls: string[] = [];
+		pushEscapeHandler(() => {
+			calls.push('listFocus');
+			return true;
+		}, ESCAPE_PRIORITY.listFocus);
+		const offPane = pushEscapeHandler(() => {
+			calls.push('pane');
+			return true;
+		}, ESCAPE_PRIORITY.pane);
+		const offGraph = pushEscapeHandler(() => {
+			calls.push('graph');
+			offGraph();
+			return true;
+		}, ESCAPE_PRIORITY.graphDrawer);
+
+		// ESC #1: graph drawer (and it unregisters itself, mimicking close).
+		runTopEscape();
+		// ESC #2: pane (unregister it as the pane would on close).
+		runTopEscape();
+		offPane();
+		// ESC #3: list focus clear.
+		runTopEscape();
+
+		expect(calls).toEqual(['graph', 'pane', 'listFocus']);
+	});
+
+	it('falls through to a lower-priority handler when the top declines', () => {
+		const calls: string[] = [];
+		// The list-focus layer is always registered but DECLINES when it has
+		// nothing to clear (returns false), so ESC falls through.
+		pushEscapeHandler(() => {
+			calls.push('pane');
+			return true;
+		}, ESCAPE_PRIORITY.pane);
+		pushEscapeHandler(() => {
+			calls.push('graph-declines');
+			return false;
+		}, ESCAPE_PRIORITY.graphDrawer);
+
+		expect(runTopEscape()).toBe(true);
+		expect(calls).toEqual(['graph-declines', 'pane']);
+	});
+
+	it('returns false when every handler declines', () => {
+		pushEscapeHandler(() => false, ESCAPE_PRIORITY.listFocus);
+		expect(runTopEscape()).toBe(false);
+	});
+
+	it('unregister removes the handler', () => {
+		const calls: string[] = [];
+		const off = pushEscapeHandler(() => {
+			calls.push('pane');
+			return true;
+		}, ESCAPE_PRIORITY.pane);
+		off();
+		expect(runTopEscape()).toBe(false);
+		expect(calls).toEqual([]);
+	});
+
+	it('breaks priority ties toward the most-recently registered handler', () => {
+		const calls: string[] = [];
+		pushEscapeHandler(() => {
+			calls.push('first');
+			return true;
+		}, ESCAPE_PRIORITY.pane);
+		pushEscapeHandler(() => {
+			calls.push('second');
+			return true;
+		}, ESCAPE_PRIORITY.pane);
+
+		runTopEscape();
+		expect(calls).toEqual(['second']);
+	});
+});

--- a/web/src/lib/stores/escapeStack.ts
+++ b/web/src/lib/stores/escapeStack.ts
@@ -1,0 +1,70 @@
+// Shared ESC precedence chain (PLAN-2105 / TASK-2118).
+//
+// Several overlapping UI layers can each want to handle the ESC key at the
+// same time — a right-docked detail pane, a dependency-graph drawer floating
+// over it, and the collection list's keyboard-focus marker. Each historically
+// registered its OWN `window` keydown listener, so a single ESC fired ALL of
+// them and collapsed multiple layers in one press.
+//
+// This module centralises that contention. Every layer REGISTERS a handler
+// (with a priority) when it opens and UNREGISTERS on close/destroy. A single
+// top-level keydown listener calls `runTopEscape()`, which invokes only the
+// highest-priority registered handler that CONSUMES the key — so one ESC
+// closes exactly one layer, innermost-first. A handler returns `true` to
+// consume the ESC (stop here) or `false` to decline (fall through to the next
+// lower-priority handler), which lets an always-registered layer (e.g. the
+// list-focus marker) opt out when it currently has nothing to close.
+//
+// It is deliberately a plain module (no runes): nothing renders reactively off
+// the stack — components push/pop imperatively and one listener reads the top
+// — so keeping it non-reactive makes it trivially unit-testable.
+
+export type EscapeHandler = () => boolean;
+
+// Higher priority = more "inner" = handled first. Gaps are intentional so a
+// future layer can slot between two without renumbering the others.
+export const ESCAPE_PRIORITY = {
+	listFocus: 10,
+	pane: 20,
+	graphDrawer: 30,
+} as const;
+
+interface Entry {
+	id: number;
+	priority: number;
+	handler: EscapeHandler;
+}
+
+let entries: Entry[] = [];
+let nextId = 1;
+
+// Register an ESC handler at the given priority. Returns an unregister fn to
+// call on close/destroy (idempotent — safe to call more than once). Ties
+// (equal priority) break toward the most-recently registered handler.
+export function pushEscapeHandler(handler: EscapeHandler, priority: number): () => void {
+	const id = nextId++;
+	entries.push({ id, priority, handler });
+	return () => {
+		entries = entries.filter((e) => e.id !== id);
+	};
+}
+
+// Invoke the highest-priority handler that consumes the ESC. Returns true if
+// some handler consumed it (the caller should then `preventDefault`), false if
+// every handler declined or the stack is empty (leave native ESC untouched).
+export function runTopEscape(): boolean {
+	// Iterate over a COPY, highest priority first (newest wins ties), so a
+	// handler that unregisters itself (or another) during its own invocation
+	// can't corrupt the iteration.
+	const ordered = [...entries].sort((a, b) => b.priority - a.priority || b.id - a.id);
+	for (const entry of ordered) {
+		if (entry.handler()) return true;
+	}
+	return false;
+}
+
+// Test-only: reset module state between cases.
+export function _resetEscapeStackForTests(): void {
+	entries = [];
+	nextId = 1;
+}

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -44,6 +44,7 @@
 		viewHasUnparentedFilter,
 	} from '$lib/collections/unparentedFilter';
 	import { KNOWN_COLLECTION_URL_PARAMS, buildCollectionUrlParams } from '$lib/collections/paneUrlParams';
+	import { pushEscapeHandler, runTopEscape, ESCAPE_PRIORITY } from '$lib/stores/escapeStack';
 
 	type ViewMode = 'list' | 'board' | 'table';
 
@@ -484,6 +485,9 @@
 	}
 
 	function closeItemPane() {
+		// A pending j/k pane-follow must not re-open the pane after an explicit
+		// close (e.g. ESC while a follow debounce is in flight).
+		cancelPaneFollow();
 		const url = new URL(page.url);
 		url.searchParams.delete('item');
 		goto(`${url.pathname}${url.search}`, {
@@ -903,6 +907,9 @@
 	onDestroy(() => {
 		unsubscribeSSE?.();
 		unsubscribeSync?.();
+		// Drop any pending j/k pane-follow so a late timer can't call goto on
+		// the unmounted page (PLAN-2105 / TASK-2119).
+		cancelPaneFollow();
 		// Scroll save/restore cleanup is owned by createScrollRestoration
 		// (snapshot.capture fires on navigate-away; the helper's $effect
 		// teardown cancels any in-flight RAF).
@@ -1853,6 +1860,20 @@
 		if (idx >= 0) focusedIndex = idx;
 	});
 
+	// Lowest-priority ESC layer: clear the list keyboard-focus marker
+	// (PLAN-2105 / TASK-2118). Registered for the page's lifetime, but the
+	// handler DECLINES (returns false) when no row is focused, so ESC falls
+	// through to nothing rather than being spuriously swallowed. The pane +
+	// graph-drawer layers register at higher priority when open, so a single
+	// ESC closes those first; only once they're gone does ESC clear the row.
+	$effect(() => {
+		return pushEscapeHandler(() => {
+			if (focusedIndex < 0) return false;
+			focusedIndex = -1;
+			return true;
+		}, ESCAPE_PRIORITY.listFocus);
+	});
+
 	// Register a Cmd+F handler with the layout while this page is mounted.
 	// The layout only intercepts Cmd+F when a handler is registered, so on
 	// pages without one (e.g. item view) it falls through to browser-native
@@ -1867,13 +1888,68 @@
 		return () => uiStore.unregisterCollectionSearch();
 	});
 
+	// j/k pane-follow (PLAN-2105 / TASK-2119). While the pane is OPEN, moving
+	// the list cursor with j/k/arrows re-targets `?item=` to the newly focused
+	// row so the pane follows the selection. Debounced (~PANE_FOLLOW_DEBOUNCE_MS)
+	// so HOLDING a key settles on the FINAL row instead of firing a
+	// loadData / collab-provider churn per intermediate row. `openItemPane`
+	// re-targets via `replaceState` when a pane is already open, so paging
+	// through N rows never pushes N history entries — a single Back still just
+	// closes the pane. No-op when the pane is CLOSED: j/k moves the cursor only,
+	// exactly as before.
+	const PANE_FOLLOW_DEBOUNCE_MS = 140;
+	let paneFollowTimer: ReturnType<typeof setTimeout> | null = null;
+	function cancelPaneFollow() {
+		if (paneFollowTimer) {
+			clearTimeout(paneFollowTimer);
+			paneFollowTimer = null;
+		}
+	}
+	function schedulePaneFollow() {
+		if (!browser) return;
+		if (!openItemRef) return; // pane closed → keyboard nav moves focus only
+		cancelPaneFollow();
+		paneFollowTimer = setTimeout(() => {
+			paneFollowTimer = null;
+			// Re-check: the pane may have closed during the debounce window.
+			if (!openItemRef) return;
+			if (focusedIndex < 0 || focusedIndex >= filteredItems.length) return;
+			const item = filteredItems[focusedIndex];
+			// Skip if the focused row is already the paned item — avoids a
+			// redundant replaceState navigation on a same-item settle.
+			if (itemUrlId(item) === openItemRef || item.slug === openItemRef) return;
+			// Pane is open → openItemPane re-targets via replaceState (no push).
+			openItemPane(item);
+		}, PANE_FOLLOW_DEBOUNCE_MS);
+	}
+
 	function handlePageKeydown(e: KeyboardEvent) {
 		// Don't capture when typing in inputs/textareas or when quick-create is open
 		const tag = (e.target as HTMLElement)?.tagName;
 		if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
+
+		// ESC precedence chain (PLAN-2105 / TASK-2118). Handled here for the
+		// WHOLE collection route — including an open pane — so it must run
+		// BEFORE the `.item-pane` guard below (that guard correctly stops
+		// j/k/Enter typed in the pane from driving the list, but must NOT
+		// swallow the pane's own ESC). The shared escape stack closes exactly
+		// ONE layer, innermost-first (graph drawer → pane → clear list focus);
+		// each layer registers its own handler. Still bail when focus is inside
+		// the Tiptap editor (contenteditable) — ESC there is the editor's to
+		// handle, not a layer-close.
+		if (e.key === 'Escape') {
+			if ((e.target as HTMLElement)?.closest?.('[contenteditable="true"]')) return;
+			// A modal (native <dialog>, focus-trapped) owns its own ESC — don't
+			// also pop a pane/graph/list layer underneath it. The pane and graph
+			// drawer aren't dialogs, so this never blocks the chain.
+			if ((e.target as HTMLElement)?.closest?.('dialog')) return;
+			if (runTopEscape()) e.preventDefault();
+			return;
+		}
+
 		// Also bail when typing inside a contenteditable (the Tiptap editor is
 		// a contenteditable DIV) or anywhere inside the detail pane — otherwise
-		// j/k/arrows/Enter/Escape typed in the open pane's editor would drive
+		// j/k/arrows/Enter typed in the open pane's editor would drive
 		// list navigation instead of editing (PLAN-2105 / TASK-2111).
 		if ((e.target as HTMLElement)?.closest?.('[contenteditable="true"], .item-pane')) return;
 		if (quickCreateOpen || saveViewOpen) return;
@@ -1885,6 +1961,7 @@
 				if (filteredItems.length > 0) {
 					focusedIndex = Math.min(focusedIndex + 1, filteredItems.length - 1);
 					scrollFocusedIntoView();
+					schedulePaneFollow();
 				}
 				break;
 			case 'k':
@@ -1893,6 +1970,7 @@
 				if (filteredItems.length > 0) {
 					focusedIndex = Math.max(focusedIndex - 1, 0);
 					scrollFocusedIntoView();
+					schedulePaneFollow();
 				}
 				break;
 			case 'Enter':
@@ -1904,9 +1982,7 @@
 					openItemPane(item);
 				}
 				break;
-			case 'Escape':
-				focusedIndex = -1;
-				break;
+			// Escape is handled above (before the `.item-pane` guard).
 		}
 	}
 

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -45,6 +45,7 @@
 	} from '$lib/collections/unparentedFilter';
 	import { KNOWN_COLLECTION_URL_PARAMS, buildCollectionUrlParams } from '$lib/collections/paneUrlParams';
 	import { pushEscapeHandler, runTopEscape, ESCAPE_PRIORITY } from '$lib/stores/escapeStack';
+	import { boardKeyNav, type BoardNavColumn, type BoardNavDirection } from '$lib/collections/boardNav';
 
 	type ViewMode = 'list' | 'board' | 'table';
 
@@ -1837,6 +1838,19 @@
 			: null
 	);
 
+	// Board (kanban) render structure, reported up by BoardView (PLAN-2105 /
+	// TASK-2119). `focusedIndex` over `filteredItems` stays the canonical focus
+	// pointer for every view (so focusedItemId / pane-follow / the openItemRef
+	// sync all keep working); on the board, keyboard nav walks THIS structure
+	// (columns × in-column order) to pick the next item, then maps it back to a
+	// `filteredItems` index. Empty (`[]`) when not in board view.
+	let boardColumns = $state<BoardNavColumn<Item>[]>([]);
+	// Stable identity (not an inline arrow) so BoardView's reporting effect
+	// depends only on its rendered structure, not on a churning callback ref.
+	function handleBoardColumnsRendered(cols: BoardNavColumn<Item>[]) {
+		boardColumns = cols;
+	}
+
 	// Reset focus when items or filters change
 	$effect(() => {
 		filteredItems;
@@ -1943,6 +1957,26 @@
 		return false;
 	}
 
+	// Board keyboard nav (PLAN-2105 / TASK-2119): step the focus over the
+	// board's ACTUAL rendered structure (from BoardView) so j/k stay within a
+	// column and h/l switch columns, instead of stepping the flat sorted list
+	// (which jumps across columns). Maps the chosen board item back to its
+	// `filteredItems` index so the shared focus pointer / pane-follow / row
+	// highlight keep working. No-op when the board reports no items.
+	function moveBoardFocus(direction: BoardNavDirection) {
+		const focusedId =
+			focusedIndex >= 0 && focusedIndex < filteredItems.length
+				? filteredItems[focusedIndex].id
+				: null;
+		const nextId = boardKeyNav(boardColumns, focusedId, direction);
+		if (nextId == null) return;
+		const idx = filteredItems.findIndex((i) => i.id === nextId);
+		if (idx < 0) return;
+		focusedIndex = idx;
+		scrollFocusedIntoView();
+		schedulePaneFollow();
+	}
+
 	function handlePageKeydown(e: KeyboardEvent) {
 		const target = e.target as HTMLElement | null;
 
@@ -1981,7 +2015,11 @@
 			case 'j':
 			case 'ArrowDown':
 				e.preventDefault();
-				if (filteredItems.length > 0) {
+				// Board: move down WITHIN the focused column (rendered order).
+				// List/table: step the flat list, exactly as before.
+				if (viewMode === 'board') {
+					moveBoardFocus('down');
+				} else if (filteredItems.length > 0) {
 					focusedIndex = Math.min(focusedIndex + 1, filteredItems.length - 1);
 					scrollFocusedIntoView();
 					schedulePaneFollow();
@@ -1990,10 +2028,28 @@
 			case 'k':
 			case 'ArrowUp':
 				e.preventDefault();
-				if (filteredItems.length > 0) {
+				if (viewMode === 'board') {
+					moveBoardFocus('up');
+				} else if (filteredItems.length > 0) {
 					focusedIndex = Math.max(focusedIndex - 1, 0);
 					scrollFocusedIntoView();
 					schedulePaneFollow();
+				}
+				break;
+			case 'h':
+			case 'ArrowLeft':
+				// Column switching is board-only (h/l are vim aliases); in
+				// list/table these keys keep their default behavior.
+				if (viewMode === 'board') {
+					e.preventDefault();
+					moveBoardFocus('left');
+				}
+				break;
+			case 'l':
+			case 'ArrowRight':
+				if (viewMode === 'board') {
+					e.preventDefault();
+					moveBoardFocus('right');
 				}
 				break;
 			case 'Enter':
@@ -2894,6 +2950,7 @@
 				preserveOrder={searchQuery.trim() !== ''}
 				{sortMode}
 				onItemOpen={openItemPane}
+				onColumnsRendered={handleBoardColumnsRendered}
 			/>
 		{:else if viewMode === 'table'}
 			<TableView

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -1923,35 +1923,58 @@
 		}, PANE_FOLLOW_DEBOUNCE_MS);
 	}
 
-	function handlePageKeydown(e: KeyboardEvent) {
-		// Don't capture when typing in inputs/textareas or when quick-create is open
-		const tag = (e.target as HTMLElement)?.tagName;
-		if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
+	// Is the focused target a text-editing context where ESC has LOCAL meaning
+	// (cancel a title edit, dismiss a tag-input dropdown, the Tiptap editor)?
+	// The escape stack must NOT hijack ESC away from these. NON-text form
+	// controls (SELECT, checkbox, radio, button, range, …) have no local ESC
+	// semantics, so ESC from them is free to dismiss an overlay via the stack —
+	// e.g. the graph drawer's depth <select> / "include terminal" checkbox
+	// (PLAN-2105 / TASK-2118). Unknown input types default to "text" (treated
+	// as text-editing) so we err toward preserving local handling.
+	const NON_TEXT_INPUT_TYPES = new Set([
+		'checkbox', 'radio', 'button', 'submit', 'reset', 'range', 'color', 'file', 'image',
+	]);
+	function isTextEntryTarget(el: HTMLElement | null | undefined): boolean {
+		if (!el) return false;
+		if (el.isContentEditable) return true;
+		const tag = el.tagName;
+		if (tag === 'TEXTAREA') return true;
+		if (tag === 'INPUT') return !NON_TEXT_INPUT_TYPES.has((el as HTMLInputElement).type);
+		return false;
+	}
 
-		// ESC precedence chain (PLAN-2105 / TASK-2118). Handled here for the
-		// WHOLE collection route — including an open pane — so it must run
-		// BEFORE the `.item-pane` guard below (that guard correctly stops
-		// j/k/Enter typed in the pane from driving the list, but must NOT
-		// swallow the pane's own ESC). The shared escape stack closes exactly
-		// ONE layer, innermost-first (graph drawer → pane → clear list focus);
-		// each layer registers its own handler. Still bail when focus is inside
-		// the Tiptap editor (contenteditable) — ESC there is the editor's to
-		// handle, not a layer-close.
+	function handlePageKeydown(e: KeyboardEvent) {
+		const target = e.target as HTMLElement | null;
+
+		// ESC precedence chain (PLAN-2105 / TASK-2118). Handled FIRST — before
+		// the generic form-control guard below — because ESC is a dismiss key
+		// that must reach the escape stack even from a NON-text control inside
+		// an overlay (the graph drawer's depth <select> / checkbox), which the
+		// generic INPUT/SELECT guard would otherwise swallow. It also runs
+		// BEFORE the `.item-pane` guard so an open pane's own ESC isn't
+		// swallowed. The stack closes exactly ONE layer, innermost-first
+		// (graph drawer → pane → clear list focus).
 		if (e.key === 'Escape') {
-			if ((e.target as HTMLElement)?.closest?.('[contenteditable="true"]')) return;
+			// Text-editing targets (title edit, tag input, the Tiptap editor)
+			// own ESC locally (cancel/blur) — don't hijack it into a layer-close.
+			if (isTextEntryTarget(target)) return;
 			// A modal (native <dialog>, focus-trapped) owns its own ESC — don't
 			// also pop a pane/graph/list layer underneath it. The pane and graph
 			// drawer aren't dialogs, so this never blocks the chain.
-			if ((e.target as HTMLElement)?.closest?.('dialog')) return;
+			if (target?.closest?.('dialog')) return;
 			if (runTopEscape()) e.preventDefault();
 			return;
 		}
 
+		// Navigation keys (j/k/arrows/Enter): don't capture when focus is in an
+		// input/textarea/select or when quick-create is open.
+		const tag = target?.tagName;
+		if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
 		// Also bail when typing inside a contenteditable (the Tiptap editor is
 		// a contenteditable DIV) or anywhere inside the detail pane — otherwise
 		// j/k/arrows/Enter typed in the open pane's editor would drive
 		// list navigation instead of editing (PLAN-2105 / TASK-2111).
-		if ((e.target as HTMLElement)?.closest?.('[contenteditable="true"], .item-pane')) return;
+		if (target?.closest?.('[contenteditable="true"], .item-pane')) return;
 		if (quickCreateOpen || saveViewOpen) return;
 
 		switch (e.key) {

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -1980,6 +1980,14 @@
 	function handlePageKeydown(e: KeyboardEvent) {
 		const target = e.target as HTMLElement | null;
 
+		// General backstop: a focused control that ALREADY handled this key
+		// (called preventDefault) owns it — don't double-process. Chiefly the
+		// resizable pane divider (role="separator", TASK-2114), which nudges its
+		// width on ArrowLeft/ArrowRight and preventDefaults; without this those
+		// arrows would ALSO drive board column-switching + pane-follow mid-resize
+		// (PLAN-2105 / TASK-2119). Runs before ESC + nav handling alike.
+		if (e.defaultPrevented) return;
+
 		// ESC precedence chain (PLAN-2105 / TASK-2118). Handled FIRST — before
 		// the generic form-control guard below — because ESC is a dismiss key
 		// that must reach the escape stack even from a NON-text control inside
@@ -2005,10 +2013,11 @@
 		const tag = target?.tagName;
 		if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
 		// Also bail when typing inside a contenteditable (the Tiptap editor is
-		// a contenteditable DIV) or anywhere inside the detail pane — otherwise
-		// j/k/arrows/Enter typed in the open pane's editor would drive
-		// list navigation instead of editing (PLAN-2105 / TASK-2111).
-		if (target?.closest?.('[contenteditable="true"], .item-pane')) return;
+		// a contenteditable DIV), anywhere inside the detail pane, or on the
+		// resizable pane divider — otherwise j/k/arrows/Enter typed there (the
+		// divider owns ArrowLeft/ArrowRight for width nudging, TASK-2114) would
+		// drive list/board navigation instead (PLAN-2105 / TASK-2111 / -2119).
+		if (target?.closest?.('[contenteditable="true"], .item-pane, .pane-divider')) return;
 		if (quickCreateOpen || saveViewOpen) return;
 
 		switch (e.key) {


### PR DESCRIPTION
## What

PLAN-2105 Phase 3 keyboard/ESC polish on top of the already-merged split pane. Two coupled tasks in one PR.

### TASK-2119 — j/k pane-follow (history-hygienic)
When the detail pane is **open**, moving the list cursor with `j`/`k`/arrows now re-targets `?item=` to the newly focused row so the pane follows the selection. When the pane is **closed**, `j`/`k` moves the cursor only, exactly as before.

- **History hygiene:** follow re-targets go through the existing `openItemPane`, which uses `replaceState` once a pane is already open — paging through N rows never pushes N history entries, so a single Back still just closes the pane. Only the first explicit open (row-click / Enter) pushes.
- **Debounced (~140ms):** holding a key settles on the *final* row instead of firing a `loadData` / collab-provider churn per intermediate row. The timer is cancelled on explicit close and on page destroy (no late `goto` on an unmounted page).
- **No remount:** re-target reuses the existing `item.id`-keyed prop-update path (just a `?item=` change) — no `{#key}`, no provider teardown per step.
- The existing `contenteditable` / `.item-pane` keydown guard is preserved, so `j`/`k` typed inside the pane editor still inserts text and does not move the list.

### TASK-2118 — ESC precedence chain
Three window ESC consumers could previously fire on one press (list-focus-clear, pane-close, embedded graph-drawer). Introduces a small shared **escape stack** (`$lib/stores/escapeStack.ts`): each layer registers a priority-ranked handler on open and unregisters on close/destroy; a **single** top-level listener (the collection page's keydown handler) invokes only the highest-priority handler that consumes the key. One ESC now closes exactly one layer, innermost-first: **graph drawer → pane → clear list focus**.

- ESC is handled *before* the `.item-pane` guard so it still works when focus is inside the pane, but bails on `contenteditable` (editor owns it) and on native `<dialog>` (modals own their own ESC — no longer pops a pane layer underneath, which the old per-listener design did).
- The embedded pane-close + embedded graph-drawer ESC listeners were replaced by escape-stack registrations; the **full-page** graph-drawer keeps its own window listener (gated `!embedded`) — no behavior change on the full-page route.
- The list-focus layer is always registered but *declines* (falls through) when no row is focused.

## Verifications (TASK-2118, mostly landed in #942 — confirmed by inspection)
- `collectionStore.setActiveItem(item)` on load / `setActiveItem(null)` in `onDestroy` — present and unchanged (SSE active-item routing).
- Back/forward collapsed↔split↔full is purely URL-derived via `openItemRef = $derived(page.url.searchParams.get('item'))` — unchanged.
- Collab teardown on switch/close runs `provider.destroy()` + `doc.destroy()` — present; expand (⤢) is a real route change and the pane's `onDestroy` invalidates the in-flight load before the full-page provider connects. No change needed.

## Tests
- New `escapeStack.test.ts` (7 cases): one-layer-per-ESC, innermost-first ordering, decline/fall-through, unregister, tie-breaking.
- `cd web && npm run check` clean (0 errors; only pre-existing unrelated warnings).

## Browser-verify
- `j`/`k` pages the pane with the row highlight following; after paging several rows, a single Back closes the pane.
- With the pane graph drawer open: ESC #1 closes the drawer, #2 closes the pane, #3 clears the row — never two layers on one press.
- Typing `j`/`k`/ESC inside the pane editor is not captured by the list.

https://claude.ai/code/session_01EZ6yr6pAUFb1uffan912ra
---

## Follow-up fixes (post-review)

**ESC from non-text form controls (TASK-2118).** ESC now routes to the escape stack *before* the generic INPUT/TEXTAREA/SELECT guard, so a dismiss from a non-text control inside an overlay (the graph drawer's depth `<select>` / "include terminal" checkbox) still closes the drawer. A new `isTextEntryTarget()` bails only for genuine text-editing targets (TEXTAREA, contenteditable, text-like INPUT) so ESC while editing the pane title/tags still cancels locally.

**Board-aware j/k/h/l nav (TASK-2119).** On the board (kanban) view, j/k previously stepped the flat sorted `filteredItems`, jumping across columns. BoardView now reports its ACTUAL rendered column structure (visual column order x per-lane sorted items, DnD shadows filtered) up via `onColumnsRendered`; the keydown handler navigates it through the pure `boardKeyNav` helper — j/k stay within a column (clamped), h/l switch to the nearest non-empty adjacent column (row clamped), nothing-focused lands on the first item of the first non-empty column. List/table j/k are unchanged; `focusedIndex` over `filteredItems` stays the canonical focus pointer so the row highlight + pane-follow keep working in every view. New `boardNav.test.ts` (12 cases).