### PR TITLE
fix(web): harden split-pane collab teardown flush + regression e2e (TASK-2117)

### DIFF
--- a/web/e2e/collab-persistence.spec.ts
+++ b/web/e2e/collab-persistence.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect, type SuiteFixture } from './fixtures';
-import { ADMIN_EMAIL, ADMIN_PASSWORD } from './global-setup';
 import type { Browser, Page } from '@playwright/test';
+import { browserLogin, seedDoc } from './lib/collab-helpers';
 
 /**
  * Editor / collab persistence e2e (TASK-2058 under TASK-733).
@@ -37,43 +37,6 @@ import type { Browser, Page } from '@playwright/test';
  * UA-bound session survives the WS upgrade (unlike a node-minted
  * session; see fixtures.ts).
  */
-
-async function browserLogin(page: Page) {
-	// Land on a same-origin page first so the fetch + Set-Cookie land in
-	// the browser's cookie jar (and under the browser's UA).
-	await page.goto('/login');
-	const status = await page.evaluate(
-		async ({ email, password }) => {
-			const r = await fetch('/api/v1/auth/login', {
-				method: 'POST',
-				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({ email, password })
-			});
-			return r.status;
-		},
-		{ email: ADMIN_EMAIL, password: ADMIN_PASSWORD }
-	);
-	if (status !== 200) throw new Error(`in-page login failed with status ${status}`);
-}
-
-const enc = (obj: Record<string, unknown>) => JSON.stringify(obj);
-
-async function seedDoc(
-	fixture: SuiteFixture,
-	request: { post: (url: string, o: unknown) => Promise<{ ok(): boolean; status(): number; text(): Promise<string>; json(): Promise<unknown> }> }
-): Promise<{ slug: string }> {
-	const ws = fixture.workspaceSlug;
-	const headers = { Authorization: `Bearer ${fixture.apiToken}`, 'Content-Type': 'application/json' };
-	// Empty content: the editor starts on a single empty paragraph, so
-	// the text we type becomes the item's entire body — a clean anchor
-	// for the post-reload assertion.
-	const resp = await request.post(`/api/v1/workspaces/${ws}/collections/docs/items`, {
-		headers,
-		data: { title: `Collab persistence ${Date.now()}`, fields: enc({}), content: '' }
-	});
-	if (!resp.ok()) throw new Error(`doc create failed (${resp.status()}): ${await resp.text()}`);
-	return (await resp.json()) as { slug: string };
-}
 
 test('typed editor content survives a reload via the collab op-log', async ({
 	page,

--- a/web/e2e/lib/collab-helpers.ts
+++ b/web/e2e/lib/collab-helpers.ts
@@ -1,0 +1,64 @@
+import type { APIRequestContext, Page } from '@playwright/test';
+import type { SuiteFixture } from '../fixtures';
+import { ADMIN_EMAIL, ADMIN_PASSWORD } from '../global-setup';
+
+/**
+ * Shared scaffolding for the collab / editor e2e specs
+ * (collab-persistence.spec.ts, pane-collab-teardown.spec.ts).
+ *
+ * Why an in-page login instead of the fixture's Bearer token: the collab
+ * WebSocket handshake can't carry an `Authorization` header (browsers
+ * don't let JS set headers on a WS upgrade), so the server authenticates
+ * it from the session cookie. The suite's default token auth therefore
+ * can't reach the WS. We establish a same-browser session cookie via an
+ * in-page login — the cookie is minted under the browser's own
+ * User-Agent, so the UA-bound session survives the WS upgrade (unlike a
+ * node-minted session; see fixtures.ts).
+ */
+export async function browserLogin(page: Page): Promise<void> {
+	// Land on a same-origin page first so the fetch + Set-Cookie land in
+	// the browser's cookie jar (and under the browser's UA).
+	await page.goto('/login');
+	const status = await page.evaluate(
+		async ({ email, password }) => {
+			const r = await fetch('/api/v1/auth/login', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ email, password }),
+			});
+			return r.status;
+		},
+		{ email: ADMIN_EMAIL, password: ADMIN_PASSWORD },
+	);
+	if (status !== 200) throw new Error(`in-page login failed with status ${status}`);
+}
+
+const enc = (obj: Record<string, unknown>) => JSON.stringify(obj);
+
+/**
+ * Seed an empty doc item and return its slug. Empty content means the
+ * editor starts on a single empty paragraph, so text we later type
+ * becomes the item's entire body — a clean anchor for content assertions.
+ */
+export async function seedDoc(
+	fixture: SuiteFixture,
+	request: APIRequestContext,
+	titlePrefix = 'Collab persistence',
+): Promise<{ slug: string }> {
+	const ws = fixture.workspaceSlug;
+	const headers = {
+		Authorization: `Bearer ${fixture.apiToken}`,
+		'Content-Type': 'application/json',
+	};
+	const resp = await request.post(`/api/v1/workspaces/${ws}/collections/docs/items`, {
+		headers,
+		data: { title: `${titlePrefix} ${Date.now()}`, fields: enc({}), content: '' },
+	});
+	if (!resp.ok()) throw new Error(`doc create failed (${resp.status()}): ${await resp.text()}`);
+	return (await resp.json()) as { slug: string };
+}
+
+/** The live-editor ProseMirror surface — shared selector across specs. */
+export const EDITOR_SELECTOR = '.editor-content .ProseMirror';
+/** The "Synced" collab-state badge — present once the Y.Doc binding is live. */
+export const SYNCED_BADGE_SELECTOR = '.collab-state-synced';

--- a/web/e2e/pane-collab-teardown.spec.ts
+++ b/web/e2e/pane-collab-teardown.spec.ts
@@ -1,0 +1,302 @@
+import { test, expect } from './fixtures';
+import { browserLogin, seedDoc, EDITOR_SELECTOR, SYNCED_BADGE_SELECTOR } from './lib/collab-helpers';
+
+/**
+ * Split-pane collab teardown e2e (PLAN-2105 Phase 3 / TASK-2117).
+ *
+ * The Asana-style split pane mounts the shared <ItemDetail> collab editor
+ * in a right-docked pane on the collection page and switches items by
+ * changing the `?item=` query param — reusing the mounted component
+ * instead of a full-page navigation. That reuse creates teardown paths
+ * the full-page route never exercised. This spec drives them through the
+ * real embedded UI and proves the edit reaches items.content:
+ *
+ *   1. FULL pane-close (unmount): typing then closing the pane must
+ *      mirror the edit into items.content via the teardown flush in the
+ *      collab $effect cleanup as <ItemDetail> unmounts.
+ *   2. Item-switch (A->B re-key): switching must flush the outgoing item's
+ *      edit AND tear down the old provider's WebSocket (no leak).
+ *   3. Raw-markdown switch: switching mid raw-save-debounce must flush the
+ *      outgoing raw edit (loadData keepalive flush before clearPending).
+ *
+ * NOT FALSE-PASSING — the key design constraint. These edits are ALSO
+ * persisted by timer-based backups (the 5s collab idle flush; the 1.2s
+ * raw-save debounce), so a naive test passes even if the teardown flush
+ * is removed — a backup timer fires later and masks the regression (Codex
+ * review, TASK-2117; verified by mutation testing). Two mechanisms keep
+ * these honest:
+ *
+ *   - Item-switch + raw-switch: loadData() CANCELS the outgoing item's
+ *     idle timer / raw debounce on switch, so the teardown/keepalive flush
+ *     is the ONLY path that can persist the outgoing edit. Revert the
+ *     flush and the item never persists → the test's content poll fails.
+ *   - Pane-close: loadData does NOT run (no new item), so the 5s idle
+ *     timer stays armed and would fire ~5s later. We therefore assert the
+ *     collab-snapshot PATCH is DISPATCHED within 3s of the EDIT (anchored
+ *     before the close click, so a stall can't shift the reference) — the
+ *     teardown flush fires synchronously on close, whereas the idle timer
+ *     can't dispatch until ~5s after the edit. Revert the teardown flush
+ *     and the only PATCH is the late idle one → the 3s bound fails.
+ *
+ * The item-switch and raw-switch tests additionally assert the switch
+ * happened within the timer window (edit-anchored), so a pathological
+ * stall that let the backup timer fire first yields an HONEST failure
+ * rather than a silent false-pass.
+ *
+ * We register the marker-scoped PATCH wait BEFORE typing so the content
+ * assertion pins to the flush that wrote OUR text. Explicit 20s waits on
+ * "Synced" cover a slow handshake + reconnect backoff (default expect
+ * timeout is 5s).
+ */
+
+const COLLAB_WS_RE = /\/api\/v1\/collab\//;
+const COLLAB_SNAPSHOT_RE = /source=collab-snapshot/;
+const SYNC_TIMEOUT = 20_000;
+// The teardown flush dispatches its PATCH synchronously on close; the 5s
+// idle backup can't dispatch until ~5s after the edit. 3s cleanly
+// separates them (a local keepalive PATCH dispatches in well under 1s).
+const TEARDOWN_DISPATCH_BUDGET = 3_000;
+
+test('closing the split pane flushes the edit to items.content on unmount (not the 5s idle backup)', async ({
+	page,
+	fixture,
+	request,
+}, testInfo) => {
+	// The collab chain is viewport-agnostic; one project is enough and
+	// running both doubles WS load on the single test instance.
+	test.skip(
+		testInfo.project.name !== 'desktop-chromium',
+		'collab teardown is viewport-agnostic; one project is enough',
+	);
+	test.setTimeout(60_000);
+
+	const { slug } = await seedDoc(fixture, request, 'Pane close teardown');
+	const marker = `pane-close-${Date.now()}`;
+
+	await browserLogin(page);
+	await page.goto(`/${fixture.adminUsername}/${fixture.workspaceSlug}/docs?item=${slug}`);
+
+	const editor = page.locator(EDITOR_SELECTOR);
+	await expect(editor).toBeVisible({ timeout: SYNC_TIMEOUT });
+	await expect(page.locator(SYNCED_BADGE_SELECTOR)).toBeVisible({ timeout: SYNC_TIMEOUT });
+
+	// Content check: a collab-snapshot PATCH whose response body carries
+	// OUR marker (proves items.content actually got the typed text).
+	const flushed = page.waitForResponse(
+		async (r) =>
+			COLLAB_SNAPSHOT_RE.test(r.url()) &&
+			r.request().method() === 'PATCH' &&
+			r.ok() &&
+			(await r.text()).includes(marker),
+		{ timeout: 30_000 },
+	);
+
+	await editor.click();
+	await page.keyboard.type(marker);
+	// Anchor timing to the EDIT, not the close click. The idle backup arms
+	// on the last keystroke, so `editAt` is captured HERE — immediately
+	// after typing and BEFORE the awaited toContainText — so a stall in that
+	// assertion can't push the reference forward and let the ~5s idle look
+	// prompt. From this anchor a reverted teardown flush can only dispatch
+	// at ~editAt+5s, which exceeds the 3s budget below.
+	const editAt = Date.now();
+	await expect(editor).toContainText(marker);
+
+	// The collab-snapshot PATCH carrying OUR marker must DISPATCH promptly
+	// after the edit (the teardown flush fires synchronously on close), not
+	// ~5s later (the idle backup). Marker-scoped so a stray/other flush
+	// can't satisfy it.
+	const flushDispatched = page.waitForRequest(
+		(r) =>
+			COLLAB_SNAPSHOT_RE.test(r.url()) &&
+			r.method() === 'PATCH' &&
+			(r.postData()?.includes(marker) ?? false),
+		{ timeout: 30_000 },
+	);
+
+	await page.locator('[aria-label="Close pane"]').first().click();
+	await flushDispatched;
+	const dispatchMs = Date.now() - editAt;
+	expect(
+		dispatchMs,
+		`teardown flush should dispatch on close (${dispatchMs}ms after edit), not via the ~5s idle backup`,
+	).toBeLessThan(TEARDOWN_DISPATCH_BUDGET);
+
+	await expect(editor).toHaveCount(0);
+	await flushed;
+
+	// Belt-and-suspenders: read items.content back and confirm the marker.
+	const item = await request.get(
+		`/api/v1/workspaces/${fixture.workspaceSlug}/items/${slug}`,
+		{ headers: { Authorization: `Bearer ${fixture.apiToken}` } },
+	);
+	expect(item.ok()).toBe(true);
+	expect(await item.text()).toContain(marker);
+});
+
+test('switching items in the pane tears down the old collab socket and flushes the outgoing edit', async ({
+	page,
+	fixture,
+	request,
+}, testInfo) => {
+	test.skip(
+		testInfo.project.name !== 'desktop-chromium',
+		'collab teardown is viewport-agnostic; one project is enough',
+	);
+	test.setTimeout(60_000);
+
+	// Two docs: A opened in the pane, B switched-to by a list row-click.
+	const a = await seedDoc(fixture, request, 'Pane switch A');
+	const b = await seedDoc(fixture, request, 'Pane switch B');
+	const markerA = `pane-switch-a-${Date.now()}`;
+
+	// Track live collab WebSockets. Provider.destroy() on switch must close
+	// the outgoing socket so they never accumulate.
+	const liveSockets = new Set<unknown>();
+	page.on('websocket', (ws) => {
+		if (!COLLAB_WS_RE.test(ws.url())) return;
+		liveSockets.add(ws);
+		ws.on('close', () => liveSockets.delete(ws));
+	});
+
+	await browserLogin(page);
+	await page.goto(`/${fixture.adminUsername}/${fixture.workspaceSlug}/docs?item=${a.slug}`);
+
+	const editor = page.locator(EDITOR_SELECTOR);
+	await expect(editor).toBeVisible({ timeout: SYNC_TIMEOUT });
+	await expect(page.locator(SYNCED_BADGE_SELECTOR)).toBeVisible({ timeout: SYNC_TIMEOUT });
+	await expect.poll(() => liveSockets.size).toBe(1);
+
+	// A's edit flush wait (marker-scoped). loadData() cancels A's idle timer
+	// on the switch, so the switch's cleanup flush is the ONLY path that can
+	// persist this — no idle backup to mask a reverted flush.
+	const flushedA = page.waitForResponse(
+		async (r) =>
+			COLLAB_SNAPSHOT_RE.test(r.url()) &&
+			r.request().method() === 'PATCH' &&
+			r.ok() &&
+			(await r.text()).includes(markerA),
+		{ timeout: 30_000 },
+	);
+
+	await editor.click();
+	await page.keyboard.type(markerA);
+	// Anchor to the EDIT (the keystroke that armed A's 5s idle timer),
+	// captured BEFORE the awaited toContainText so a stall there can't
+	// consume the idle window while the measured switch interval still
+	// looks prompt (same reasoning as the pane-close test).
+	const editAt = Date.now();
+	await expect(editor).toContainText(markerA);
+
+	// Switch A->B IN-PANE via a list row-click (client-side re-target of
+	// ?item=, no full navigation). `?item=` re-targets to B's issue id
+	// (itemUrlId), not its slug, so we assert the param changed AWAY from A.
+	const itemParam = () => new URL(page.url()).searchParams.get('item');
+	await page.locator('a.item-card', { hasText: 'Pane switch B' }).first().click();
+
+	// Isolation premise: the switch must beat A's 5s idle timer, so that
+	// loadData()'s cancel leaves the cleanup flush as the SOLE path that can
+	// persist A. If a pathological runner stall let the idle fire first, the
+	// test can't isolate the fix — fail honestly rather than false-pass.
+	expect(
+		Date.now() - editAt,
+		'switch must happen before the 5s idle timer to isolate the cleanup flush',
+	).toBeLessThan(4_500);
+
+	// The switch must have flushed A's edit before swapping to B.
+	await flushedA;
+
+	// B's editor re-synced, the pane re-targeted off A, and the socket
+	// count settled back to exactly one — A's provider socket was
+	// destroyed, not leaked.
+	await expect(page.locator(SYNCED_BADGE_SELECTOR)).toBeVisible({ timeout: SYNC_TIMEOUT });
+	await expect.poll(itemParam).not.toBe(a.slug);
+	expect(itemParam()).toBeTruthy();
+	await expect.poll(() => liveSockets.size, { timeout: 10_000 }).toBe(1);
+
+	// Closing the pane returns the socket count to baseline (no leak).
+	await page.locator('[aria-label="Close pane"]').first().click();
+	await expect(editor).toHaveCount(0);
+	await expect.poll(() => liveSockets.size, { timeout: 10_000 }).toBe(0);
+
+	const readContent = async (slug: string) => {
+		const r = await request.get(
+			`/api/v1/workspaces/${fixture.workspaceSlug}/items/${slug}`,
+			{ headers: { Authorization: `Bearer ${fixture.apiToken}` } },
+		);
+		expect(r.ok()).toBe(true);
+		return r.text();
+	};
+
+	// A's edit is durable in items.content...
+	expect(await readContent(a.slug)).toContain(markerA);
+	// ...and it did NOT leak into B (the no-{#key} cross-write class this
+	// pane design is prone to — A's flush must target A, never the swapped-in B).
+	expect(await readContent(b.slug)).not.toContain(markerA);
+});
+
+test('switching items mid raw-markdown debounce flushes the outgoing raw edit (no data loss)', async ({
+	page,
+	fixture,
+	request,
+}, testInfo) => {
+	test.skip(
+		testInfo.project.name !== 'desktop-chromium',
+		'collab teardown is viewport-agnostic; one project is enough',
+	);
+	test.setTimeout(60_000);
+
+	// In RAW markdown mode there is NO collab cleanup flush (collabKey is
+	// null), so switching A->B relies on loadData flushing the raw saver
+	// (keepalive) before clearPending(). loadData also CANCELS the 1.2s raw
+	// debounce on the switch, so that keepalive flush is the ONLY path that
+	// can persist A — no debounce backup to mask a reverted flush.
+	const a = await seedDoc(fixture, request, 'Raw switch A');
+	const b = await seedDoc(fixture, request, 'Raw switch B');
+	const markerA = `raw-switch-a-${Date.now()}`;
+
+	await browserLogin(page);
+	await page.goto(`/${fixture.adminUsername}/${fixture.workspaceSlug}/docs?item=${a.slug}`);
+
+	await expect(page.locator(EDITOR_SELECTOR)).toBeVisible({ timeout: SYNC_TIMEOUT });
+	await expect(page.locator(SYNCED_BADGE_SELECTOR)).toBeVisible({ timeout: SYNC_TIMEOUT });
+
+	// Toggle A into raw markdown mode and type — arms the 1.2s raw-save
+	// debounce (which the switch will cancel).
+	await page.locator('button[title="Raw markdown editor"]').first().click();
+	const raw = page.locator('textarea.raw-textarea');
+	await expect(raw).toBeVisible();
+	await raw.fill(markerA);
+	const fillAt = Date.now();
+
+	// Switch A->B immediately. loadData cancels the debounce and the
+	// keepalive flush must persist A's edit.
+	await page.locator('a.item-card', { hasText: 'Raw switch B' }).first().click();
+
+	// Isolation premise: the switch must beat the 1.2s raw debounce, so the
+	// keepalive flush is the SOLE path that can persist A. If a pathological
+	// runner stall let the debounce fire first, the test can't isolate the
+	// fix — fail honestly rather than false-pass.
+	expect(
+		Date.now() - fillAt,
+		'switch must happen before the 1.2s raw debounce to isolate the keepalive flush',
+	).toBeLessThan(1_000);
+	await expect.poll(() => new URL(page.url()).searchParams.get('item')).not.toBe(a.slug);
+
+	const readContent = async (slug: string) => {
+		const r = await request.get(
+			`/api/v1/workspaces/${fixture.workspaceSlug}/items/${slug}`,
+			{ headers: { Authorization: `Bearer ${fixture.apiToken}` } },
+		);
+		expect(r.ok()).toBe(true);
+		return r.text();
+	};
+
+	// A's raw edit survived the switch (keepalive PATCH is fire-and-forget,
+	// so poll until it lands)...
+	await expect
+		.poll(async () => (await readContent(a.slug)).includes(markerA), { timeout: 15_000 })
+		.toBe(true);
+	// ...and did not cross-write into B.
+	expect(await readContent(b.slug)).not.toContain(markerA);
+});

--- a/web/src/lib/collab/teardownOrder/Child.svelte
+++ b/web/src/lib/collab/teardownOrder/Child.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { onDestroy } from 'svelte';
+	let { log }: { log: (s: string) => void } = $props();
+	onDestroy(() => log('child-onDestroy'));
+</script>
+
+<div>child</div>

--- a/web/src/lib/collab/teardownOrder/Parent.svelte
+++ b/web/src/lib/collab/teardownOrder/Parent.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+	import Child from './Child.svelte';
+	let { log }: { log: (s: string) => void } = $props();
+	// Mirrors ItemDetail's collab $effect: a top-level $effect with a
+	// cleanup return, alongside a child component (the <Editor>) that
+	// registers onDestroy. The question TASK-2117 hinges on: on unmount,
+	// does this $effect cleanup run BEFORE or AFTER the child's onDestroy?
+	$effect(() => {
+		return () => log('parent-effect-cleanup');
+	});
+</script>
+
+<Child {log} />

--- a/web/src/lib/collab/teardownOrder/order.svelte.test.ts
+++ b/web/src/lib/collab/teardownOrder/order.svelte.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+import Parent from './Parent.svelte';
+
+// Empirical probe for TASK-2117 / Codex Finding 5: on component unmount,
+// does a top-level $effect's cleanup run BEFORE or AFTER a child
+// component's onDestroy? ItemDetail's pane-close teardown flush lives in
+// a top-level collab $effect cleanup and reads the child <Editor>'s
+// markdown — so the answer determines whether the editor is still
+// mounted when the flush fires.
+describe('svelte 5 teardown order (top-level $effect cleanup vs child onDestroy)', () => {
+	it('destroys the child (onDestroy) BEFORE the parent top-level $effect cleanup', () => {
+		const order: string[] = [];
+		const target = document.createElement('div');
+		const app = mount(Parent, { target, props: { log: (s: string) => order.push(s) } });
+		flushSync(); // let the deferred top-level $effect body run
+		unmount(app);
+		flushSync();
+		// If this ever flips (a Svelte upgrade running top-level $effect
+		// cleanups first), ItemDetail could read a live editor at teardown —
+		// but the shadow-markdown fallback keeps the flush correct either way.
+		expect(order).toEqual(['child-onDestroy', 'parent-effect-cleanup']);
+	});
+});

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -187,6 +187,23 @@
 
 	let editorInstance = $state<EditorType | null>(null);
 
+	// Shadow of the live rich editor's markdown, captured on every edit
+	// (handleContentUpdate). The teardown flush (readEditorMarkdown, below)
+	// falls back to this when it can't read the live editor — which is the
+	// COMMON case on unmount: Svelte destroys the child <Editor> BEFORE this
+	// component's top-level collab $effect cleanup runs (top-level $effects
+	// are deferred to component pop(), so they sit AFTER the template render
+	// effect in teardown order — confirmed by
+	// src/lib/collab/teardownOrder/order.svelte.test.ts, and by TASK-2117's
+	// e2e). Reading `editorInstance.storage` after `editor.destroy()` happens
+	// to still return cached markdown in the current Tiptap, but that's an
+	// implementation detail we must not depend on. Capturing at edit time
+	// makes the flush correct-by-construction regardless of destroy order or
+	// Tiptap's post-destroy behavior. Plain var, NOT $state (CONVE-1688): it's
+	// a handler-only tracker; a $state written in a handler that an $effect
+	// also read would wedge the effect scheduler in prod.
+	let lastEditorMarkdown: string | null = null;
+
 	let editingTitle = $state(false);
 	let titleDraft = $state('');
 	let titleInputEl = $state<HTMLTextAreaElement>();
@@ -1062,6 +1079,15 @@
 		void collabProvider;
 		hasEverSynced = false;
 		editorInstance = null;
+		// Reset the markdown shadow alongside editorInstance: a new provider
+		// means a new editor session, so any prior shadow belongs to a
+		// now-gone editor (item swap, raw↔rich, force_refresh). This runs
+		// AFTER the outgoing provider's collab $effect cleanup (which sets
+		// collabProvider, triggering this), so the outgoing teardown flush
+		// still reads the outgoing item's shadow before it's cleared — and a
+		// fresh item can never fall back to the previous item's markdown
+		// (which would be a cross-write in the readEditorMarkdown fallback).
+		lastEditorMarkdown = null;
 	});
 
 	// Flip the latch on the live provider's first sync.
@@ -2052,6 +2078,11 @@
 	// each other on rapid mode toggles.
 
 	function handleContentUpdate(markdown: string) {
+		// Capture the latest editor markdown for the teardown-flush fallback
+		// (readEditorMarkdown). onUpdate fires on every transaction, so this
+		// shadow always holds the newest edit — captured while the editor is
+		// live, before any unmount tears it down (TASK-2117).
+		lastEditorMarkdown = markdown;
 		// Collab-active path: 5s idle flush of items.content via the
 		// `?source=collab-snapshot` bypass (server skips the applier
 		// loop, writes items.content directly). Y.Doc op-log is
@@ -2157,19 +2188,42 @@
 			}
 			return cleanBrokenLinks(toSave);
 		},
-		// Read the live editor markdown for a flush-now. Reading
-		// editorInstance.storage at cleanup/beforeunload time is correct
-		// because Svelte runs parent $effect cleanups BEFORE child
-		// {#key}-driven unmounts, so the OLD editor is still mounted. Returns
-		// null when the editor is unavailable or its storage read throws, so
-		// flushNow no-ops.
+		// Markdown for a flush-now (editor teardown + beforeunload). Prefer
+		// the LIVE editor's storage, but fall back to `lastEditorMarkdown`
+		// (the shadow captured on every edit) when the editor can't be read.
+		//
+		// The fallback is load-bearing, NOT belt-and-suspenders. On BOTH
+		// teardown paths — item switch (the {#key `${item.id}...`} re-key)
+		// and full pane-close (<ItemDetail> unmount) — Svelte destroys the
+		// child <Editor> BEFORE this component's top-level collab $effect
+		// cleanup runs: top-level $effects are deferred to component pop(),
+		// so in teardown order they sit AFTER the template render effect that
+		// owns the <Editor> branch (confirmed by
+		// src/lib/collab/teardownOrder/order.svelte.test.ts). So at flush time
+		// `editorInstance` points at an already-destroyed Tiptap. It happens
+		// to still return cached markdown today, but that's a Tiptap
+		// implementation detail; the shadow makes the flush correct even if a
+		// Tiptap upgrade clears storage on destroy. Both paths are locked by
+		// e2e/pane-collab-teardown.spec.ts (type + close/switch within the
+		// idle window → the edit reaches items.content). Returns null only
+		// when the editor is unreadable AND no edit was ever captured, so
+		// flushNow no-ops (nothing to lose).
 		readEditorMarkdown: () => {
-			if (!editorInstance) return null;
-			try {
-				return (editorInstance.storage as any).markdown?.getMarkdown?.() ?? '';
-			} catch {
-				return null;
+			// Only read live storage while the editor is genuinely alive. On
+			// the teardown paths the <Editor> is already destroyed by the time
+			// this runs (see the shadow comment above), so we take the shadow —
+			// which is why the shadow, not Tiptap's post-destroy cache, is the
+			// tested teardown path. `beforeunload` fires while the editor is
+			// still alive, so it reads live storage.
+			if (editorInstance && !editorInstance.isDestroyed) {
+				try {
+					const md = (editorInstance.storage as any).markdown?.getMarkdown?.();
+					if (md != null) return md;
+				} catch {
+					// Live read failed — fall through to the shadow.
+				}
 			}
+			return lastEditorMarkdown;
 		},
 		// Gate per-item lastFlushedContent seeding: only record the flush if
 		// the item we flushed is still active, else a stale flush pollutes the


### PR DESCRIPTION
## What

**TASK-2117** (PLAN-2105 Phase 3) — verify + **harden** provider/doc/flusher teardown across the two split-pane teardown paths the no-`{#key}` persistent pane introduced, plus the raw-mode data-loss fix.

Started as a verify-and-add-tests task; an independent Codex pass + an empirical Svelte probe surfaced a **real fragility** the task had anticipated ("if the child Editor tears down before the parent collab `$effect` cleanup, capture the markdown synchronously"), so it also carries a small product fix.

## The fragility (confirmed, not hypothetical)

On unmount, Svelte 5.55.8 destroys the child `<Editor>` **before** this component's top-level collab `$effect` cleanup runs — top-level `$effect`s are deferred to component `pop()`, so they tear down *after* the template render effect that owns `<Editor>`. Proven by `src/lib/collab/teardownOrder/order.svelte.test.ts` (`['child-onDestroy', 'parent-effect-cleanup']`).

So at teardown-flush time the editor is already destroyed. Persistence survived **only** because Tiptap happens to still serve `storage.markdown` after `editor.destroy()` — a fragile implementation detail a future Tiptap bump could silently break. My original hardening comment claimed the *reverse* ordering; it's now corrected.

## Product hardening (`ItemDetail.svelte`, comment-heavy, ~1 behavior change)

- Add `lastEditorMarkdown` — a shadow captured on every edit (`handleContentUpdate`), reset per provider instance so it can't cross items.
- `readEditorMarkdown` now reads live storage **only while `!editorInstance.isDestroyed`**, else falls back to the shadow. This makes the teardown flush correct-by-construction regardless of destroy order or Tiptap's post-destroy behavior — and makes the shadow the *tested* teardown path (mutation-verified below), not dormant insurance.

Verified-correct, unchanged: item-switch cleanup (flush → destroy provider+doc → null slots), raw-mode keepalive flush before `clearPending()`, and CollabProvider's per-`itemID` cursor isolation (no change needed).

## Regression e2e (`pane-collab-teardown.spec.ts`) — mutation-tested, not false-passing

Each test was proven to go **red** when its target fix is reverted (three mutation runs), so none can false-pass on a timer-based backup — the risk the Codex review flagged:

| Test | Isolation | Mutation result |
|---|---|---|
| close pane → edit persists | collab-snapshot PATCH must **dispatch within 3s of the edit** (teardown flush), not ~5s (idle backup) | revert flush → dispatches at ~5s → RED |
| switch A→B in-pane | `loadData` cancels A's idle → cleanup flush is the sole path; + one WS at a time, 0 on close, no A→B cross-write | revert flush → A never persists → RED |
| switch mid raw-debounce | `loadData` cancels the debounce → keepalive flush is the sole path | revert flush → A never persists → RED |

All timing/premise assertions are **anchored to the edit timestamp** (captured before the click), so a runner stall yields an honest failure, not a silent false-pass. Reviewed to convergence across **5 independent Codex passes** (final verdict: CONVERGED). Explicit 20s waits on "Synced" cover slow-handshake CI.

Shared login/seed scaffolding extracted to `e2e/lib/collab-helpers.ts` (reused by `collab-persistence.spec.ts`).

## Verification

- `npm run check` — 0 errors · `npm run test` — 280 passed · `npm run build` — clean
- `playwright test collab-persistence pane-collab-teardown` — 5 passed (stable across repeats)
- 3× mutation testing (revert each flush → matching test fails) · 5× Codex adversarial review → CONVERGED

https://claude.ai/code/session_01EZ6yr6pAUFb1uffan912ra
