### PR TITLE
fix(web): manual-sort tiebreak — new items float to top of lane (BUG-1941)

### DIFF
--- a/web/src/lib/collections/itemSort.test.ts
+++ b/web/src/lib/collections/itemSort.test.ts
@@ -26,14 +26,17 @@ describe('itemComparator manual mode', () => {
 	// BUG-1941: every un-dragged card in a lane shares sort_order = 0. A
 	// stray updated_at bump (e.g. a spurious collab-flush PATCH) must not
 	// reorder them — the tiebreak has to be independent of updated_at.
-	it('breaks a sort_order tie by created_at ascending, ignoring updated_at entirely', () => {
+	// The tie direction is created_at DESC (newest first) so a freshly
+	// created item floats to the top of its lane rather than the bottom.
+	it('breaks a sort_order tie by created_at descending, ignoring updated_at entirely', () => {
 		const comparator = itemComparator('manual', collection);
-		const older = { ...item('older', 0, '2026-01-01T00:00:00Z'), updated_at: '2026-07-04T00:00:00Z' } as Item;
-		const newer = { ...item('newer', 0, '2026-02-01T00:00:00Z'), updated_at: '2026-01-01T00:00:00Z' } as Item;
-		// `newer`'s updated_at is EARLIER than `older`'s, proving the
-		// comparator ignores updated_at and still orders by created_at.
-		expect([newer, older].sort(comparator).map((i) => i.id)).toEqual(['older', 'newer']);
-		expect([older, newer].sort(comparator).map((i) => i.id)).toEqual(['older', 'newer']);
+		const older = { ...item('older', 0, '2026-01-01T00:00:00Z'), updated_at: '2026-01-01T00:00:00Z' } as Item;
+		const newer = { ...item('newer', 0, '2026-02-01T00:00:00Z'), updated_at: '2026-07-04T00:00:00Z' } as Item;
+		// `newer`'s updated_at is LATER than `older`'s here, but the ordering
+		// is driven purely by created_at (newest first) — the newer item
+		// sorts ahead regardless of the updated_at values.
+		expect([older, newer].sort(comparator).map((i) => i.id)).toEqual(['newer', 'older']);
+		expect([newer, older].sort(comparator).map((i) => i.id)).toEqual(['newer', 'older']);
 	});
 
 	it('falls back to id when sort_order and created_at both tie', () => {
@@ -43,13 +46,13 @@ describe('itemComparator manual mode', () => {
 		expect([b, a].sort(comparator).map((i) => i.id)).toEqual(['a-item', 'b-item']);
 	});
 
-	it('treats a missing/unparseable created_at as epoch (sorts first among ties)', () => {
+	it('treats a missing/unparseable created_at as epoch (sorts last among ties under newest-first)', () => {
 		const comparator = itemComparator('manual', collection);
 		const withDate = item('with-date', 0, '2026-01-01T00:00:00Z');
 		const withoutDate = { ...item('without-date', 0, ''), created_at: undefined } as unknown as Item;
-		expect([withDate, withoutDate].sort(comparator).map((i) => i.id)).toEqual([
-			'without-date',
+		expect([withoutDate, withDate].sort(comparator).map((i) => i.id)).toEqual([
 			'with-date',
+			'without-date',
 		]);
 	});
 });

--- a/web/src/lib/collections/itemSort.ts
+++ b/web/src/lib/collections/itemSort.ts
@@ -70,16 +70,23 @@ export function itemComparator(
 				});
 		case 'manual':
 		default:
-			// Deterministic tiebreak on equal sort_order (created_at asc,
-			// then id) so a stray updated_at bump — e.g. a spurious
-			// collab-flush PATCH, BUG-1941 — can't reorder cards that were
-			// never actually dragged. Every un-dragged card in a lane
-			// shares sort_order = 0, so without this the comparator was a
-			// no-op there and silently inherited whatever order the input
+			// Deterministic tiebreak on equal sort_order (created_at DESC —
+			// newest first — then id) so a stray updated_at bump (e.g. a
+			// spurious collab-flush PATCH, BUG-1941) can't reorder cards that
+			// were never actually dragged. Every un-dragged card in a lane
+			// shares sort_order = 0, so without a tiebreak the comparator was
+			// a no-op there and silently inherited whatever order the input
 			// array arrived in (updated_at DESC from the API).
+			//
+			// The direction is DESC (newest first) so a freshly-created item —
+			// which lands with sort_order = 0, tying the top of a manually
+			// sorted lane and tying the whole of an un-dragged lane — floats to
+			// the TOP of its lane/group instead of the bottom. That is the
+			// "new items sort to the top under manual order" behaviour; the
+			// value is still independent of updated_at, so BUG-1941 holds.
 			return (a, b) =>
 				a.sort_order - b.sort_order ||
-				timeValue(a.created_at) - timeValue(b.created_at) ||
+				timeValue(b.created_at) - timeValue(a.created_at) ||
 				a.id.localeCompare(b.id);
 	}
 }


### PR DESCRIPTION
Flip the Manual comparator's deterministic tiebreak from `created_at` ASC to DESC (newest first) so a freshly-created item (which lands with `sort_order = 0`, tying the top of a manually-sorted lane and the whole of an un-dragged lane) floats to the **top** of its lane/group instead of the bottom — the "new items sort to the top under manual order" behavior.

The tiebreak stays independent of `updated_at`, so the [[BUG-1941]] invariant (a stray collab-flush PATCH can't reorder un-dragged cards) still holds. Comparator + tests + comments updated together.

**Verification:** `itemSort.test.ts` 4 passed · `npm run test` 280 passed · `npm run check` 0 errors · `npm run build` clean.

https://claude.ai/code/session_01EZ6yr6pAUFb1uffan912ra