### PR TITLE
fix(web): restore fixed-width board lanes + horizontal scroll (revert BUG-2127 lane sizing)

### DIFF
--- a/web/src/lib/components/collections/BoardView.svelte
+++ b/web/src/lib/components/collections/BoardView.svelte
@@ -637,15 +637,18 @@
 	.kanban-column {
 		display: flex;
 		flex-direction: column;
-		/* 220px is the PREFERRED lane width, not a hard floor: flex-shrink 1 +
-		   min-width 0 lets the lanes shrink to fill a narrow board (pane open)
-		   instead of overflowing at a fixed 220px. That keeps scrollWidth ==
-		   clientWidth and a constant right gutter in every sidebar/pane state,
-		   rather than the scrollport cutting the fixed 928px track at a
-		   different point as the sidebar resizes the board (BUG-2127). The
-		   mobile @media below restores fixed 75vw lanes + horizontal scroll. */
-		flex: 1 1 220px;
-		min-width: 0;
+		/* Lanes have a fixed 220px FLOOR and do NOT shrink (flex-shrink 0).
+		   flex-grow 1 + basis 0 lets a few lanes GROW to fill a wide board, but
+		   when the lanes don't all fit — many statuses, a narrow window, or the
+		   detail pane open — they hold 220px each and the board SCROLLS
+		   HORIZONTALLY (.board-view overflow-x: auto). That horizontal scroll is
+		   the INTENDED behavior of a kanban board, NOT a bug.
+		   DO NOT change this to flex-shrink 1 / min-width 0 to make the lanes
+		   "fill" a narrow board — that removes the scroll and crams the lanes
+		   (PR #946 / BUG-2127 did exactly that and it was reverted at the
+		   owner's request). The mobile @media below uses fixed 75vw lanes. */
+		flex: 1 0 0;
+		min-width: 220px;
 		background: var(--bg-secondary);
 		border: 1px solid var(--border);
 		border-radius: var(--radius-lg);


### PR DESCRIPTION
PR #946 (BUG-2127) mis-diagnosed the board's intended horizontal-scroll behavior as a bug and changed `.kanban-column` from `flex: 1 0 0; min-width: 220px` → `flex: 1 1 220px; min-width: 0`, so lanes **shrink to fill** a narrow board instead of holding their width and scrolling. With the detail pane open (or a narrow window) the lanes crammed to ~163px with ellipsized headers and never scrolled.

This restores `flex: 1 0 0; min-width: 220px` — lanes keep a 220px floor and the board **scrolls horizontally** when they don't all fit, while still growing to fill a wide board. The comment now documents the overflow/scroll is **intentional** so it isn't re-diagnosed. Kept the orthogonal `.board-view { overflow-y: hidden }` + header ellipsis from #946 (neither conflicts with scroll).

**Verified with Playwright geometry on the live board:**
| state | before (flexible) | after (this PR) |
|---|---|---|
| wide 1440 | 4 @ 277px, no scroll | 4 @ 277px, no scroll |
| narrow 1024 | 4 @ 173px, **no scroll** | 4 @ **220px**, **scrolls** (928>740) |
| pane open | 4 @ 163px, **no scroll** | 4 @ **220px**, **scrolls** (928>702) |

`npm run check` 0 errors. Already deployed to the local server via `make install`.

https://claude.ai/code/session_01EZ6yr6pAUFb1uffan912ra