### PR TITLE
fix(web): thin horizontal scrollbars — set ::-webkit-scrollbar height (BUG-2127 follow-up)

### DIFF
--- a/web/src/app.css
+++ b/web/src/app.css
@@ -98,9 +98,14 @@ input:focus, textarea:focus {
 	border-color: var(--accent-blue);
 }
 
-/* Scrollbar */
+/* Scrollbar. `width` styles the VERTICAL scrollbar; `height` styles the
+   HORIZONTAL one. Both are needed — without `height` a horizontal scrollbar
+   (e.g. the board-view lane track) falls back to the chunky ~15px browser
+   default while every vertical scrollbar is a thin 6px, which reads as a
+   "weirdly large" scrollbar (BUG-2127 follow-up). Keep them equal. */
 ::-webkit-scrollbar {
 	width: 6px;
+	height: 6px;
 }
 ::-webkit-scrollbar-track {
 	background: transparent;


### PR DESCRIPTION
The global `::-webkit-scrollbar` rule set `width: 6px` but no `height`. `width` only sizes vertical scrollbars; a horizontal scrollbar's thickness is `height`, which was unset — so horizontal scrollbars (notably the board-view lane track restored in #949) fell back to the chunky ~15px browser default while every vertical scrollbar was a thin 6px. That "weirdly large horizontal scrollbar" is the real defect PR #946 papered over by shrinking lanes so horizontal overflow never occurred.

Fix: add `height: 6px` so horizontal and vertical scrollbars match. Owner-verified on the live board.

https://claude.ai/code/session_01EZ6yr6pAUFb1uffan912ra