### PR TITLE
perf(web): cache members/roles + server capabilities per item switch (TASK-2120)

### DIFF
--- a/web/src/lib/api/client.test.ts
+++ b/web/src/lib/api/client.test.ts
@@ -280,3 +280,59 @@ describe('rate-limit UI seam / setRateLimitHandler (TASK-2080)', () => {
 		expect(handler).not.toHaveBeenCalled();
 	});
 });
+
+// TASK-2120 — /server/capabilities is static for the binary's lifetime, so the
+// client memoizes it at module scope. This locks in the two properties the
+// Editor-remount hot path relies on: repeat callers share one fetch, and a
+// failed fetch is NOT cached (a later call retries). NOTE: the cache is a
+// module singleton, so these tests must be the file's only capabilities()
+// callers and must run in order — the failure test runs first (cold cache),
+// leaving it cold for the dedupe test that follows.
+describe('server.capabilities() caching (TASK-2120)', () => {
+	beforeEach(() => {
+		vi.unstubAllGlobals();
+	});
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('does NOT cache a failed capabilities fetch — a later call retries', async () => {
+		const failing = vi.fn(async () => ({
+			status: 500,
+			ok: false,
+			json: async () => ({ error: { code: 'internal', message: 'boom' } }),
+		}));
+		vi.stubGlobal('fetch', failing);
+		await expect(api.server.capabilities()).rejects.toBeTruthy();
+		expect(failing).toHaveBeenCalledTimes(1);
+
+		// The rejected promise was dropped from the cache, so a retry re-fetches.
+		const ok = vi.fn(async () => ({
+			status: 200,
+			ok: true,
+			json: async () => ({ image: { image_formats: ['png'], transcode: false, max_pixels: 1 } }),
+		}));
+		vi.stubGlobal('fetch', ok);
+		await expect(api.server.capabilities()).resolves.toMatchObject({
+			image: { image_formats: ['png'] },
+		});
+		expect(ok).toHaveBeenCalledTimes(1);
+	});
+
+	it('fetches /server/capabilities at most once across repeat callers', async () => {
+		// The success above warmed the cache, so no further fetch should fire —
+		// both callers resolve from the shared cached promise (same reference).
+		const fetchMock = vi.fn(async () => ({
+			status: 200,
+			ok: true,
+			json: async () => ({ image: { image_formats: ['jpeg'], transcode: true, max_pixels: 2 } }),
+		}));
+		vi.stubGlobal('fetch', fetchMock);
+		const a = await api.server.capabilities();
+		const b = await api.server.capabilities();
+		expect(a).toBe(b);
+		expect(fetchMock).not.toHaveBeenCalled();
+		// Still the warmed 'png' value, proving the cache served it (not 'jpeg').
+		expect(a.image.image_formats).toEqual(['png']);
+	});
+});

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -729,6 +729,17 @@ export interface InvitationPreview {
 	has_account?: boolean;
 }
 
+// Module-scope cache for GET /server/capabilities. The response is static
+// for the lifetime of the binary (image-processor formats / limits), so every
+// caller can share one fetch. The Editor remounts on each item switch (its
+// `{#key}` rebuilds ~20 Tiptap extensions for Y.Doc safety) and each remount
+// fired this request; caching makes every remount past the first a warm no-op
+// (TASK-2120). We memoize the PROMISE (not just the value) so concurrent
+// callers dedupe onto one in-flight request, and we clear the slot on failure
+// so a transient network blip / pre-login rejection can't poison capabilities
+// for the rest of the session — a later call retries.
+let serverCapabilitiesCache: Promise<ServerCapabilities> | null = null;
+
 export const api = {
 	// ── Health / Version ──────────────────────────────────────────────────────
 
@@ -2154,7 +2165,18 @@ export const api = {
 	// can cache freely.
 
 	server: {
-		capabilities: () => request<ServerCapabilities>('/server/capabilities')
+		capabilities: () => {
+			if (!serverCapabilitiesCache) {
+				serverCapabilitiesCache = request<ServerCapabilities>('/server/capabilities').catch(
+					(err) => {
+						// Don't cache failures — drop the slot so the next call retries.
+						serverCapabilitiesCache = null;
+						throw err;
+					}
+				);
+			}
+			return serverCapabilitiesCache;
+		}
 	},
 
 	// ── Connected apps (TASK-954) ────────────────────────────────────────────

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -129,6 +129,31 @@
 	// counter — not reactive; it only fences async writes.
 	let loadGeneration = 0;
 
+	// Per-switch fetch memoization (TASK-2120). The workspace's members and
+	// agent roles are workspace-invariant, yet loadData re-fetched them on
+	// every row-click and every j/k keystroke. Cache them on this persistent
+	// (no-{#key}) pane instance, keyed by wsSlug, and reuse on a cache-key hit
+	// so a switch only pays for the genuinely per-item reads (item / progress /
+	// links) plus the collection. Plain `let` — not reactive; they seed the
+	// reactive `workspaceMembers` / `agentRoles` state below.
+	//
+	// The collection schema is DELIBERATELY NOT cached here. Unlike members /
+	// roles, it has a live mutation surface — the in-pane edit modal + quick-
+	// actions menu, the host collection page's own edit controls, and cross-tab
+	// edits — and none of those reliably reach a pane-local cache (the in-pane
+	// callbacks are switch-fenced and can be dropped mid-PATCH; the host edits
+	// never touch the pane at all). A stale schema is not cosmetic: a later
+	// updateField() would write field JSON against the wrong shape and clobber
+	// migrated values. Refetching it per switch keeps it self-healing and cheap
+	// (one request), which is the correct trade for a schema that can change out
+	// from under the pane (Codex review).
+	let cachedMembers:
+		| { user_id: string; user_name: string; user_email: string; role: string }[]
+		| null = null;
+	let cachedMembersWs: string | null = null;
+	let cachedRoles: AgentRole[] | null = null;
+	let cachedRolesWs: string | null = null;
+
 	// True when a captured (item, generation) snapshot is no longer the one on
 	// screen — the uniform fence for DROPPING a post-await write/feedback after
 	// a no-{#key} pane switch (PLAN-2105 / TASK-2112; Codex). Checks BOTH the
@@ -905,17 +930,34 @@
 				itemLinks = links;
 			} catch { if (myGen !== loadGeneration) return; itemLinks = []; }
 
-			// Load workspace members and agent roles for assignment picker
-			try {
-				const membersData = await api.members.list(wsSlug);
-				if (myGen !== loadGeneration) return;
-				workspaceMembers = membersData.members ?? [];
-			} catch { if (myGen !== loadGeneration) return; workspaceMembers = []; }
-			try {
-				const roles = await api.agentRoles.list(wsSlug);
-				if (myGen !== loadGeneration) return;
-				agentRoles = roles;
-			} catch { if (myGen !== loadGeneration) return; agentRoles = []; }
+			// Load workspace members and agent roles for the assignment picker.
+			// Both are workspace-invariant, so reuse the cached copy on a
+			// same-workspace switch and only fetch on a cache miss (TASK-2120).
+			// A cache hit is a synchronous assignment (no await), so it needs no
+			// generation fence — the last per-item await above already bailed if
+			// a newer load started.
+			if (cachedMembersWs === wsSlug && cachedMembers) {
+				workspaceMembers = cachedMembers;
+			} else {
+				try {
+					const membersData = await api.members.list(wsSlug);
+					if (myGen !== loadGeneration) return;
+					workspaceMembers = membersData.members ?? [];
+					cachedMembers = workspaceMembers;
+					cachedMembersWs = wsSlug;
+				} catch { if (myGen !== loadGeneration) return; workspaceMembers = []; }
+			}
+			if (cachedRolesWs === wsSlug && cachedRoles) {
+				agentRoles = cachedRoles;
+			} else {
+				try {
+					const roles = await api.agentRoles.list(wsSlug);
+					if (myGen !== loadGeneration) return;
+					agentRoles = roles;
+					cachedRoles = roles;
+					cachedRolesWs = wsSlug;
+				} catch { if (myGen !== loadGeneration) return; agentRoles = []; }
+			}
 		} catch (e: any) {
 			// A newer load owns the state — don't overwrite it with this
 			// superseded load's error.


### PR DESCRIPTION
## What

Eliminates redundant per-item-switch fetches in the split-pane `ItemDetail` (PLAN-2105), the ones that fired on every row-click and `j`/`k` keystroke.

**ItemDetail.loadData** — the persistent no-`{#key}` pane now caches the workspace's **members** and **agent roles** (keyed by `wsSlug`) and reuses them on a same-workspace item switch. A switch now only pays for the genuinely per-item reads (item / progress / links) + the collection. Cache-hit reuse is a synchronous assignment past the last per-item `await`, so it needs no `loadGeneration` fence; all existing switch-safety guards are preserved.

**API client** — `api.server.capabilities()` is memoized at module scope. The Editor's `{#key}` remount (which rebuilds ~20 Tiptap extensions for Y.Doc safety) fired this on every switch; the response is static for the binary's lifetime, so every remount past the first is now a warm no-op. The **promise** is cached (concurrent callers dedupe) and a failed fetch is dropped from the cache so a later call retries — no poisoned-failure state.

## Deliberately NOT cached: the collection schema

Unlike members/roles, the collection has a live mutation surface (in-pane edit modal + quick-actions menu, the host collection page's own edit controls, cross-tab edits) that a pane-local cache can't reliably track, and a stale schema would let a later `updateField()` clobber migrated field values. It stays a per-switch refetch — self-healing and one request. (This was Codex round-1's P1; resolved by dropping the collection cache entirely.)

## Codex review

- Round 1: flagged the collection cache staleness (P1) + members/roles indefinite caching (P2). → Removed the collection cache; kept members/roles per the task's explicit intent (benign picker staleness).
- Round 2: flagged a collection-migration-vs-rapid-switch race — verified **pre-existing** (the collection fetch + modal switch-fence are byte-identical to `main`; this diff doesn't touch them). Filed as **BUG-2129** (out of scope: independent, risky cross-cutting concurrency fix).

## Testing

- `make check` green (golangci-lint + `go test ./...` + govulncheck + web-check).
- Web unit tests: 282 pass, incl. new `client.test.ts` coverage for the capabilities-cache dedupe + no-cache-on-failure retry.
- Production vite build + `make install` clean; `/api/v1/server/capabilities` verified at runtime.
- Mermaid / heavy editor imports confirmed still lazy (`await import('mermaid')`).

Note: the DevTools Network confirmation (a switch issues only item/progress/links; capabilities fires ≤once) is best eyeballed in a browser — the logic is statically sound and unit-locked.

Closes TASK-2120.

https://claude.ai/code/session_01EZ6yr6pAUFb1uffan912ra