### PR TITLE
feat(web): pane accessibility & focus management (TASK-2122)

### DIFF
--- a/web/e2e/pane-a11y-focus.spec.ts
+++ b/web/e2e/pane-a11y-focus.spec.ts
@@ -1,0 +1,297 @@
+import { test, expect } from './fixtures';
+import { browserLogin, seedDoc } from './lib/collab-helpers';
+import type { Page } from '@playwright/test';
+
+/**
+ * Accessibility & focus management for the detail pane
+ * (PLAN-2105 Phase 4 / TASK-2122).
+ *
+ * The pane is the URL-derived (`?item=`) master-detail surface on the
+ * collection page. This spec drives the focus behaviours the task specifies,
+ * in a REAL browser (jsdom has no layout/focus model, so the unit tests in
+ * paneFocus.svelte.test.ts cover only the pure DOM math — the runtime wiring
+ * is verified here).
+ *
+ * The DESKTOP model (per the TASK-2122 review decision): focus STAYS on the
+ * list when the pane opens, so arrow/j-k navigation (with the pane following)
+ * is uninterrupted. The user bridges INTO the pane with Tab and back with a
+ * two-level ESC — ESC from inside the pane returns focus to the list (pane
+ * stays open); a second ESC from the list closes the pane. The pane is a
+ * labelled, non-trapping region on desktop.
+ *
+ * The MOBILE model: the pane is a full-screen modal overlay — focus moves in
+ * on open and is TRAPPED (Tab / Shift+Tab cycle within, never reaching the
+ * list mounted behind it).
+ *
+ * Viewport is driven explicitly, so one project is enough.
+ */
+
+const DESKTOP = { width: 1200, height: 900 };
+const MOBILE = { width: 768, height: 1024 }; // == breakpoint (inclusive) → overlay
+
+function docsUrl(fixture: { adminUsername: string; workspaceSlug: string }, query = ''): string {
+	return `/${fixture.adminUsername}/${fixture.workspaceSlug}/docs${query}`;
+}
+
+function openItemParam(page: Page): string | null {
+	return new URL(page.url()).searchParams.get('item');
+}
+
+/** Is the document's active element inside the detail pane? */
+function activeInPane(page: Page): Promise<boolean> {
+	return page.evaluate(() => !!document.activeElement?.closest('.item-pane'));
+}
+
+test.describe('pane accessibility & focus management (PLAN-2105 / TASK-2122)', () => {
+	test('desktop: focus stays on the list on open; Tab bridges into the pane; two-level ESC returns then closes', async ({
+		page,
+		fixture,
+		request,
+	}, testInfo) => {
+		test.skip(
+			testInfo.project.name !== 'desktop-chromium',
+			'viewport is driven explicitly; one project is enough',
+		);
+		await page.setViewportSize(DESKTOP);
+		await browserLogin(page);
+		await seedDoc(fixture, request, 'A11y focus alpha');
+		await seedDoc(fixture, request, 'A11y focus bravo');
+		await page.goto(docsUrl(fixture));
+
+		const row = page.locator('.item-card', { hasText: 'A11y focus alpha' }).first();
+		await expect(row).toBeVisible();
+		await row.click();
+
+		const pane = page.locator('.item-pane');
+		await expect(pane).toBeVisible();
+		// The region carries the landmark semantics the task requires.
+		await expect(pane).toHaveAttribute('aria-label', 'Item detail');
+		await expect(pane).toHaveAttribute('tabindex', '-1');
+
+		// Focus STAYS on the list — the pane did NOT steal it on the desktop split.
+		expect(await activeInPane(page)).toBe(false);
+
+		// (Tab bridge) Tab from the list moves focus INTO the pane region.
+		await page.keyboard.press('Tab');
+		await expect.poll(() => activeInPane(page)).toBe(true);
+
+		// (Two-level ESC, step 1) ESC from inside the pane returns focus to the
+		// list — the pane STAYS open.
+		await page.keyboard.press('Escape');
+		await expect.poll(() => activeInPane(page)).toBe(false);
+		expect(openItemParam(page)).not.toBeNull();
+		// Focus landed on the paned row (the `.focused` list card).
+		expect(
+			await page.evaluate(() => document.activeElement?.classList.contains('item-card')),
+		).toBe(true);
+
+		// (Two-level ESC, step 2) A second ESC from the list closes the pane.
+		await page.keyboard.press('Escape');
+		await expect.poll(() => openItemParam(page)).toBeNull();
+		await expect(pane).toBeHidden();
+	});
+
+	test('desktop: j/k keeps driving the list with the pane open (focus never leaves the list)', async ({
+		page,
+		fixture,
+		request,
+	}, testInfo) => {
+		test.skip(
+			testInfo.project.name !== 'desktop-chromium',
+			'viewport is driven explicitly; one project is enough',
+		);
+		await page.setViewportSize(DESKTOP);
+		await browserLogin(page);
+		await seedDoc(fixture, request, 'A11y split alpha');
+		await seedDoc(fixture, request, 'A11y split bravo');
+		await page.goto(docsUrl(fixture));
+
+		await page.locator('.item-card').first().click();
+		const pane = page.locator('.item-pane');
+		await expect(pane).toBeVisible();
+		const opened = openItemParam(page);
+		expect(opened).not.toBeNull();
+		// Focus is on the list, not the pane — so j/k list nav is unhijacked.
+		expect(await activeInPane(page)).toBe(false);
+
+		// j moves the list cursor and the open pane follows the selection
+		// (?item= re-targets after the follow debounce).
+		await page.keyboard.press('j');
+		await expect.poll(() => openItemParam(page)).not.toBe(opened);
+		// Still on the list, pane still open — the browse flow is intact.
+		expect(await activeInPane(page)).toBe(false);
+		await expect(pane).toBeVisible();
+
+		// Tab still bridges into the pane even though the click left DOM focus on
+		// the ORIGINAL row while j moved the `.focused` marker to another (the
+		// bridge keys off the row anchor, not the marker — Codex P1).
+		await page.keyboard.press('Tab');
+		await expect.poll(() => activeInPane(page)).toBe(true);
+	});
+
+	test('desktop: browser Back closes the pane and returns focus to the originating row', async ({
+		page,
+		fixture,
+		request,
+	}, testInfo) => {
+		test.skip(
+			testInfo.project.name !== 'desktop-chromium',
+			'viewport is driven explicitly; one project is enough',
+		);
+		await page.setViewportSize(DESKTOP);
+		await browserLogin(page);
+		await seedDoc(fixture, request, 'A11y back alpha');
+		await seedDoc(fixture, request, 'A11y back bravo');
+		await page.goto(docsUrl(fixture));
+
+		// First open PUSHES a history entry, so Back closes the pane.
+		const row = page.locator('.item-card', { hasText: 'A11y back alpha' }).first();
+		await expect(row).toBeVisible();
+		const rowHref = await row.getAttribute('href');
+		await row.click();
+		const pane = page.locator('.item-pane');
+		await expect(pane).toBeVisible();
+
+		// Move focus into the pane, then close via browser Back (which drops
+		// ?item= straight from the URL — closeItemPane never runs).
+		await page.keyboard.press('Tab');
+		await expect.poll(() => activeInPane(page)).toBe(true);
+		await page.goBack();
+
+		await expect.poll(() => openItemParam(page)).toBeNull();
+		await expect(pane).toBeHidden();
+		// Focus was returned to the originating row (not dropped to <body>).
+		await expect
+			.poll(() => page.evaluate(() => document.activeElement?.getAttribute('href')))
+			.toBe(rowHref);
+	});
+
+	test('desktop: closing a pane whose item is filtered out of the list lands focus on the list, not <body>', async ({
+		page,
+		fixture,
+		request,
+	}, testInfo) => {
+		test.skip(
+			testInfo.project.name !== 'desktop-chromium',
+			'viewport is driven explicitly; one project is enough',
+		);
+		await page.setViewportSize(DESKTOP);
+		await browserLogin(page);
+		const { slug } = await seedDoc(fixture, request, 'A11y orphan');
+		// Deep-link the item open while a search excludes it from the list, so
+		// there's NO `.focused` row and no captured trigger to return to.
+		await page.goto(docsUrl(fixture, `?item=${slug}&q=zzz-no-match-zzz`));
+
+		const pane = page.locator('.item-pane');
+		await expect(pane).toBeVisible();
+		await expect(page.locator('.item-card.focused, .table-row.focused')).toHaveCount(0);
+
+		// Close (focus is on <body>; ESC falls through to the escape stack).
+		await page.keyboard.press('Escape');
+		await expect.poll(() => openItemParam(page)).toBeNull();
+		// Focus landed on the stable list-column landmark, not dropped to <body>.
+		await expect
+			.poll(() => page.evaluate(() => document.activeElement?.classList.contains('list-column')))
+			.toBe(true);
+	});
+
+	test('desktop: navigating to another collection with the pane open does NOT steal focus (route reuse)', async ({
+		page,
+		fixture,
+		request,
+	}, testInfo) => {
+		test.skip(
+			testInfo.project.name !== 'desktop-chromium',
+			'viewport is driven explicitly; one project is enough',
+		);
+		await page.setViewportSize(DESKTOP);
+		await browserLogin(page);
+		const { slug } = await seedDoc(fixture, request, 'A11y route reuse');
+		await page.goto(docsUrl(fixture, `?item=${slug}`));
+		await expect(page.locator('.item-pane')).toBeVisible();
+
+		// Client-side nav to a DIFFERENT collection (SvelteKit reuses this
+		// [collection] page, so openItemRef flips truthy→null without a close).
+		// The focus-return effect must treat this as navigation, not a pane close
+		// — it must NOT yank focus into the newly-loaded list (Codex P2).
+		const tasksLink = page.locator(`a.nav-item[href$="/${fixture.workspaceSlug}/tasks"]`).first();
+		await expect(tasksLink).toBeVisible();
+		await tasksLink.click();
+
+		await expect(page).toHaveURL(new RegExp(`/${fixture.workspaceSlug}/tasks$`));
+		await expect(page.locator('.item-pane')).toBeHidden();
+		// Focus was NOT stolen into the new collection's list-column.
+		expect(await page.evaluate(() => !!document.activeElement?.closest('.list-column'))).toBe(false);
+	});
+
+	test('mobile overlay traps focus — Tab and Shift+Tab cycle within the pane', async ({
+		page,
+		fixture,
+		request,
+	}, testInfo) => {
+		test.skip(
+			testInfo.project.name !== 'desktop-chromium',
+			'viewport is driven explicitly; one project is enough',
+		);
+		await page.setViewportSize(MOBILE);
+		await browserLogin(page);
+		const { slug } = await seedDoc(fixture, request, 'A11y trap');
+		await page.goto(docsUrl(fixture, `?item=${slug}`));
+
+		const pane = page.locator('.item-pane');
+		await expect(pane).toBeVisible();
+		// Full-screen overlay on mobile (the trap only applies here).
+		await expect.poll(() => pane.evaluate((el) => getComputedStyle(el).position)).toBe('fixed');
+		// Modal: focus moved INTO the overlay on open.
+		await expect.poll(() => activeInPane(page)).toBe(true);
+		// The hidden list behind it is `inert` — isolated from both the focus
+		// order and the screen-reader tree (a JS trap can't constrain an SR
+		// virtual cursor).
+		expect(await page.locator('.list-column').evaluate((el) => (el as HTMLElement).inert)).toBe(
+			true,
+		);
+
+		// Forward Tab many times: focus must NEVER escape the pane into the list
+		// column mounted behind the overlay. Without the trap it would leak out
+		// after cycling past the pane's last focusable.
+		for (let i = 0; i < 15; i++) {
+			await page.keyboard.press('Tab');
+			expect(await activeInPane(page)).toBe(true);
+		}
+		// Backward Tab is trapped too.
+		for (let i = 0; i < 5; i++) {
+			await page.keyboard.press('Shift+Tab');
+			expect(await activeInPane(page)).toBe(true);
+		}
+
+		// Containment backstop: a PROGRAMMATIC focus escape (not via Tab — e.g.
+		// Cmd+F focusing the search box behind the overlay) is yanked back into
+		// the pane by the focusin handler (Codex P1). Synthesize it with an
+		// injected outside button.
+		await page.evaluate(() => {
+			const b = document.createElement('button');
+			b.id = '__t2122_outside';
+			document.body.insertBefore(b, document.body.firstChild);
+			b.focus();
+		});
+		expect(await activeInPane(page)).toBe(true);
+		await page.evaluate(() => document.getElementById('__t2122_outside')?.remove());
+
+		// A modal <dialog> stacked over the overlay owns its OWN focus cycle —
+		// the window-level pane trap must defer to it and NOT drag Tab back into
+		// the inert pane behind it (Codex P1). Inject one, focus inside, Tab.
+		await page.evaluate(() => {
+			const dlg = document.createElement('dialog');
+			dlg.id = '__t2122_dialog';
+			dlg.innerHTML = '<button id="__t2122_a">A</button><button id="__t2122_b">B</button>';
+			document.body.appendChild(dlg);
+			dlg.showModal();
+			(document.getElementById('__t2122_a') as HTMLElement).focus();
+		});
+		expect(await page.evaluate(() => document.activeElement?.id)).toBe('__t2122_a');
+		await page.keyboard.press('Tab');
+		// Focus advanced WITHIN the dialog (native cycle) — not hijacked to the pane.
+		expect(await activeInPane(page)).toBe(false);
+		expect(await page.evaluate(() => !!document.activeElement?.closest('dialog'))).toBe(true);
+	});
+});

--- a/web/src/lib/collections/paneFocus.svelte.test.ts
+++ b/web/src/lib/collections/paneFocus.svelte.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+	PANE_FOCUSABLE_SELECTOR,
+	paneFocusables,
+	nextTrapTarget,
+	resolvePaneReturnTarget,
+} from './paneFocus';
+
+// jsdom has no layout engine, so `offsetParent` / `getClientRects` can't gate
+// visibility here — the production default reads those, but every helper that
+// needs them takes an injectable predicate. These tests pass an "everything
+// visible" stub and assert the DOM-selection + cycle math directly.
+const allVisible = () => true;
+
+function mount(html: string): HTMLElement {
+	document.body.innerHTML = `<div id="root">${html}</div>`;
+	return document.getElementById('root') as HTMLElement;
+}
+
+beforeEach(() => {
+	document.body.innerHTML = '';
+});
+
+describe('paneFocusables', () => {
+	it('collects tabbable descendants in DOM order', () => {
+		const el = mount(`
+			<a href="/a">a</a>
+			<button>b</button>
+			<input />
+			<div contenteditable="true">editor</div>
+		`);
+		const found = paneFocusables(el, allVisible);
+		expect(found.map((n) => n.tagName.toLowerCase())).toEqual([
+			'a',
+			'button',
+			'input',
+			'div',
+		]);
+	});
+
+	it('excludes tabindex="-1", disabled controls, and href-less anchors', () => {
+		const el = mount(`
+			<a>no-href</a>
+			<button disabled>disabled</button>
+			<input disabled />
+			<div tabindex="-1">programmatic</div>
+			<button tabindex="-1">skip</button>
+			<a href="/keep">keep</a>
+		`);
+		const found = paneFocusables(el, allVisible);
+		expect(found).toHaveLength(1);
+		expect(found[0].getAttribute('href')).toBe('/keep');
+	});
+
+	it('honors the injected visibility predicate', () => {
+		const el = mount(`<a href="/x" class="show">x</a><a href="/y" class="hide">y</a>`);
+		const found = paneFocusables(el, (n) => n.classList.contains('show'));
+		expect(found).toHaveLength(1);
+		expect(found[0].getAttribute('href')).toBe('/x');
+	});
+
+	it('the selector includes positive/zero tabindex but not -1', () => {
+		expect(PANE_FOCUSABLE_SELECTOR).toContain('[tabindex]:not([tabindex="-1"])');
+	});
+});
+
+describe('nextTrapTarget', () => {
+	function setup() {
+		const container = mount(`<a href="/1">1</a><a href="/2">2</a><a href="/3">3</a>`);
+		container.setAttribute('tabindex', '-1');
+		const focusables = paneFocusables(container, allVisible);
+		return { container, focusables, first: focusables[0], last: focusables[2] };
+	}
+
+	it('forward Tab off the last element wraps to the first', () => {
+		const { container, focusables, first, last } = setup();
+		expect(nextTrapTarget(focusables, last, false, container)).toBe(first);
+	});
+
+	it('Shift+Tab off the first element wraps to the last', () => {
+		const { container, focusables, first, last } = setup();
+		expect(nextTrapTarget(focusables, first, true, container)).toBe(last);
+	});
+
+	it('forward Tab mid-list returns null (let the browser move naturally)', () => {
+		const { container, focusables } = setup();
+		expect(nextTrapTarget(focusables, focusables[1], false, container)).toBeNull();
+	});
+
+	it('Shift+Tab mid-list returns null', () => {
+		const { container, focusables } = setup();
+		expect(nextTrapTarget(focusables, focusables[1], true, container)).toBeNull();
+	});
+
+	it('Shift+Tab from the region container itself wraps to the last', () => {
+		const { container, focusables, last } = setup();
+		expect(nextTrapTarget(focusables, container, true, container)).toBe(last);
+	});
+
+	it('forward Tab from the region container falls through to native move', () => {
+		const { container, focusables } = setup();
+		// Container contains itself → treated as "inside", not off-the-end.
+		expect(nextTrapTarget(focusables, container, false, container)).toBeNull();
+	});
+
+	it('focus escaped outside the pane is pulled back to the edge', () => {
+		const { container, focusables, first, last } = setup();
+		const outside = document.createElement('button');
+		document.body.appendChild(outside);
+		expect(nextTrapTarget(focusables, outside, false, container)).toBe(first);
+		expect(nextTrapTarget(focusables, outside, true, container)).toBe(last);
+		expect(nextTrapTarget(focusables, null, false, container)).toBe(first);
+	});
+
+	it('an empty pane keeps focus on the container', () => {
+		const container = mount('');
+		expect(nextTrapTarget([], container, false, container)).toBe(container);
+		expect(nextTrapTarget([], container, true, container)).toBe(container);
+	});
+});
+
+describe('resolvePaneReturnTarget', () => {
+	it('returns the focused list/board card anchor itself', () => {
+		const root = mount(`
+			<a href="/a" class="item-card">a</a>
+			<a href="/b" class="item-card focused">b</a>
+		`);
+		const target = resolvePaneReturnTarget(root, null);
+		expect(target?.getAttribute('href')).toBe('/b');
+	});
+
+	it('returns the title-link inside a focused table row', () => {
+		const root = mount(`
+			<div class="table-row" role="row"><a href="/a" class="title-link">a</a></div>
+			<div class="table-row focused" role="row"><a href="/b" class="title-link">b</a></div>
+		`);
+		const target = resolvePaneReturnTarget(root, null);
+		expect(target?.getAttribute('href')).toBe('/b');
+	});
+
+	it('falls back to the captured trigger when no focused row exists', () => {
+		const root = mount(`<a href="/a" class="item-card">a</a>`);
+		const captured = root.querySelector<HTMLElement>('a')!;
+		expect(resolvePaneReturnTarget(root, captured)).toBe(captured);
+	});
+
+	it('prefers the focused row over the captured trigger (paged A→C returns to C)', () => {
+		const root = mount(`
+			<a href="/a" class="item-card">a</a>
+			<a href="/c" class="item-card focused">c</a>
+		`);
+		const captured = root.querySelector<HTMLElement>('a[href="/a"]')!;
+		const target = resolvePaneReturnTarget(root, captured);
+		expect(target?.getAttribute('href')).toBe('/c');
+	});
+
+	it('ignores a captured trigger detached from the document', () => {
+		const root = mount('');
+		const detached = document.createElement('a');
+		detached.href = '/gone';
+		expect(detached.isConnected).toBe(false);
+		expect(resolvePaneReturnTarget(root, detached)).toBeNull();
+	});
+
+	it('returns null when there is neither a focused row nor a live trigger', () => {
+		const root = mount(`<a href="/a" class="item-card">a</a>`);
+		expect(resolvePaneReturnTarget(root, null)).toBeNull();
+	});
+});

--- a/web/src/lib/collections/paneFocus.ts
+++ b/web/src/lib/collections/paneFocus.ts
@@ -1,0 +1,104 @@
+/**
+ * Focus helpers for the collection detail pane (PLAN-2105 / TASK-2122).
+ *
+ * Split out of `[collection]/+page.svelte` so the DOM-selection and
+ * focus-trap-cycle logic is unit testable without a full component mount
+ * (mirrors `paneUrlParams` / `boardNav`). The `.svelte` side owns the effects
+ * that install/tear these down; this module is pure, side-effect-free DOM math.
+ */
+
+/**
+ * Tabbable-element selector. Excludes `tabindex="-1"` (programmatic-only focus
+ * targets, e.g. the pane region container itself) and disabled form controls.
+ * The Tiptap editor body is a `contenteditable="true"` div, so it's included.
+ */
+export const PANE_FOCUSABLE_SELECTOR =
+	'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), ' +
+	'textarea:not([disabled]), [tabindex]:not([tabindex="-1"]), [contenteditable="true"]';
+
+/**
+ * Default visibility test for a focusable candidate. `offsetParent === null`
+ * catches `display:none` (and detached) subtrees; the `getClientRects` fallback
+ * catches the `position:fixed` case where `offsetParent` is null despite the
+ * element being on-screen. Injected in {@link paneFocusables} so tests (jsdom
+ * has no layout) can supply a deterministic stub.
+ */
+export function isFocusableVisible(el: HTMLElement): boolean {
+	return el.offsetParent !== null || el.getClientRects().length > 0;
+}
+
+/**
+ * Visible, enabled, tabbable descendants of `container`, in DOM order — the
+ * trap cycle set.
+ */
+export function paneFocusables(
+	container: HTMLElement,
+	isVisible: (el: HTMLElement) => boolean = isFocusableVisible,
+): HTMLElement[] {
+	return Array.from(
+		container.querySelectorAll<HTMLElement>(PANE_FOCUSABLE_SELECTOR),
+	).filter(
+		// A `tabindex="-1"` element is programmatic-focus-only — never a Tab stop,
+		// even when it's a natively-focusable tag (`<button tabindex="-1">`) that
+		// the tag clauses of the selector would otherwise pick up.
+		(el) => el.getAttribute('tabindex') !== '-1' && isVisible(el),
+	);
+}
+
+/**
+ * Where a Tab / Shift+Tab should send focus while the pane is TRAPPING (the
+ * mobile full-screen overlay). Returns the element to focus, or `null` to let
+ * the browser's native Tab move stand (focus is mid-list and staying inside the
+ * pane — no wrap needed).
+ *
+ * Wrapping rules (standard modal trap):
+ *  • Forward Tab off the LAST focusable → wrap to the first.
+ *  • Shift+Tab off the FIRST focusable (or off the region container itself) →
+ *    wrap to the last.
+ *  • Focus somehow OUTSIDE the pane → pull it back to the edge (first on a
+ *    forward Tab, last on a back Tab).
+ *  • Empty pane (no focusables yet — loading) → keep focus on the container.
+ */
+export function nextTrapTarget(
+	focusables: HTMLElement[],
+	active: Element | null,
+	shiftKey: boolean,
+	container: HTMLElement,
+): HTMLElement | null {
+	if (focusables.length === 0) return container;
+	const first = focusables[0];
+	const last = focusables[focusables.length - 1];
+	const inside = active != null && container.contains(active);
+	if (shiftKey) {
+		if (active === first || active === container || !inside) return last;
+		return null;
+	}
+	if (active === last || !inside) return first;
+	return null;
+}
+
+/**
+ * Resolve the element to return focus to when the pane CLOSES (TASK-2122): the
+ * row that opened / last drove the pane.
+ *
+ * The paned item's row always carries the `.focused` marker (kept in sync as
+ * the pane follows j/k), so it's the canonical "row that opened it" even after
+ * paging A→C. List/board rows ARE the anchor (`.item-card` is an `<a>`); table
+ * rows are a `<div>` wrapping a `.title-link` anchor — so fall through to the
+ * first focusable inside the row there. When no row is present (a deep-linked
+ * item that isn't in the current filtered list), fall back to the captured
+ * trigger element if it's still in the document.
+ */
+export function resolvePaneReturnTarget(
+	root: Document | HTMLElement,
+	captured: HTMLElement | null,
+): HTMLElement | null {
+	const row = root.querySelector<HTMLElement>('.item-card.focused, .table-row.focused');
+	if (row) {
+		if (row.matches('a[href]')) return row;
+		const inner = row.querySelector<HTMLElement>('a[href], button, [tabindex]');
+		if (inner) return inner;
+	}
+	if (captured && captured.isConnected) return captured;
+	return null;
+}

--- a/web/src/lib/stores/escapeStack.test.ts
+++ b/web/src/lib/stores/escapeStack.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import {
 	pushEscapeHandler,
 	runTopEscape,
+	topEscapePriority,
 	ESCAPE_PRIORITY,
 	_resetEscapeStackForTests,
 } from './escapeStack';
@@ -93,6 +94,27 @@ describe('escapeStack', () => {
 		off();
 		expect(runTopEscape()).toBe(false);
 		expect(calls).toEqual([]);
+	});
+
+	it('topEscapePriority reports the frontmost registered layer (or null when empty)', () => {
+		expect(topEscapePriority()).toBeNull();
+
+		const offPane = pushEscapeHandler(() => true, ESCAPE_PRIORITY.pane);
+		pushEscapeHandler(() => true, ESCAPE_PRIORITY.listFocus);
+		// Pane (20) outranks list-focus (10) → pane is frontmost.
+		expect(topEscapePriority()).toBe(ESCAPE_PRIORITY.pane);
+
+		// Opening the graph drawer (30) makes IT frontmost — the pane's two-level
+		// ESC must defer while this is true (TASK-2122 Codex P2).
+		const offGraph = pushEscapeHandler(() => true, ESCAPE_PRIORITY.graphDrawer);
+		expect(topEscapePriority()).toBe(ESCAPE_PRIORITY.graphDrawer);
+
+		// Closing the graph returns the pane to the front.
+		offGraph();
+		expect(topEscapePriority()).toBe(ESCAPE_PRIORITY.pane);
+
+		offPane();
+		expect(topEscapePriority()).toBe(ESCAPE_PRIORITY.listFocus);
 	});
 
 	it('breaks priority ties toward the most-recently registered handler', () => {

--- a/web/src/lib/stores/escapeStack.ts
+++ b/web/src/lib/stores/escapeStack.ts
@@ -49,6 +49,16 @@ export function pushEscapeHandler(handler: EscapeHandler, priority: number): () 
 	};
 }
 
+// The priority of the currently-frontmost registered layer (the highest
+// priority among all registered handlers), or `null` when the stack is empty.
+// Lets a caller decide whether ITS layer is the one ESC would act on before
+// running the stack — e.g. the pane's two-level ESC must defer to a
+// higher-priority graph drawer stacked above it (TASK-2122).
+export function topEscapePriority(): number | null {
+	if (entries.length === 0) return null;
+	return entries.reduce((max, e) => (e.priority > max ? e.priority : max), -Infinity);
+}
+
 // Invoke the highest-priority handler that consumes the ESC. Returns true if
 // some handler consumed it (the caller should then `preventDefault`), false if
 // every handler declined or the stack is empty (leave native ESC untouched).

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -44,7 +44,8 @@
 		viewHasUnparentedFilter,
 	} from '$lib/collections/unparentedFilter';
 	import { KNOWN_COLLECTION_URL_PARAMS, buildCollectionUrlParams } from '$lib/collections/paneUrlParams';
-	import { pushEscapeHandler, runTopEscape, ESCAPE_PRIORITY } from '$lib/stores/escapeStack';
+	import { paneFocusables, nextTrapTarget, resolvePaneReturnTarget } from '$lib/collections/paneFocus';
+	import { pushEscapeHandler, runTopEscape, topEscapePriority, ESCAPE_PRIORITY } from '$lib/stores/escapeStack';
 	import { boardKeyNav, type BoardNavColumn, type BoardNavDirection } from '$lib/collections/boardNav';
 
 	type ViewMode = 'list' | 'board' | 'table';
@@ -471,12 +472,25 @@
 	//    entries that Back must unwind before it can close the pane
 	//    (PLAN-2105 history policy; Codex round 2 P2). `closeItemPane`
 	//    likewise REPLACES.
+	// The element that opened the pane, captured so closing can return focus to
+	// it (TASK-2122). A plain ref (not $state) — it never drives the UI. The
+	// live `.focused` row is the primary return target; this is the fallback for
+	// a deep-linked item that isn't in the current filtered list.
+	let paneReturnFocusEl: HTMLElement | null = null;
+
 	function openItemPane(item: Item) {
 		const url = new URL(page.url);
 		// Whether a pane is ALREADY open decides push (first open) vs replace
 		// (re-target). Read off the live URL — the same source openItemRef
 		// derives from.
 		const alreadyOpen = url.searchParams.has('item');
+		// Capture the trigger on the FIRST open only — re-targeting (j/k follow /
+		// row re-click on an open pane) keeps the ORIGINAL trigger as the
+		// fallback return target (TASK-2122).
+		if (!alreadyOpen && browser) {
+			const active = document.activeElement as HTMLElement | null;
+			paneReturnFocusEl = active && active !== document.body ? active : null;
+		}
 		url.searchParams.set('item', itemUrlId(item));
 		goto(`${url.pathname}${url.search}`, {
 			replaceState: alreadyOpen,
@@ -491,11 +505,27 @@
 		cancelPaneFollow();
 		const url = new URL(page.url);
 		url.searchParams.delete('item');
+		// Focus return to the originating row is handled by the close-detection
+		// effect below (keyed off `openItemRef` going truthy→null), so it covers
+		// browser Back / delete alike — not just this imperative close path.
 		goto(`${url.pathname}${url.search}`, {
 			replaceState: true,
 			noScroll: true,
 			keepFocus: true,
 		});
+	}
+
+	// Move keyboard focus back to the paned row in the list (TASK-2122). Backs
+	// the desktop ESC "back to the list" step — the pane stays OPEN, this only
+	// relocates focus. Returns false when there's no focused row to land on (e.g.
+	// a deep-linked item filtered out of the list) so the ESC handler can fall
+	// through to the escape stack (which closes the pane).
+	function returnFocusToList(): boolean {
+		if (!browser) return false;
+		const target = resolvePaneReturnTarget(document, null);
+		if (!target) return false;
+		target.focus();
+		return true;
 	}
 
 	// ── Resizable detail pane + persisted width (PLAN-2105 / TASK-2114) ─
@@ -665,6 +695,134 @@
 		});
 		ro.observe(container);
 		return () => ro.disconnect();
+	});
+
+	// Move focus INTO the pane on open — MOBILE ONLY (PLAN-2105 / TASK-2122).
+	// The mobile overlay is a modal, so focus enters it (and the trap below keeps
+	// it there). On the DESKTOP split we deliberately do NOT move focus: it stays
+	// on the list so arrow/j-k navigation (with the pane following) is
+	// uninterrupted; the user bridges INTO the pane with Tab and back with ESC
+	// (handled in the keydown handler). Focus lands on the `<aside>` region
+	// itself (tabindex=-1) — a screen reader announces the aria-labeled region
+	// and Tab proceeds into its controls. Re-runs on mount/unmount and on a
+	// breakpoint crossing (desktop→mobile enters the modal); `preventScroll`
+	// avoids a jump on a direct `?item=` deep-link; skips if focus is already
+	// inside.
+	$effect(() => {
+		if (!browser) return;
+		const el = paneEl;
+		if (!el || !viewport.isMobile) return;
+		if (!el.contains(document.activeElement)) {
+			el.focus({ preventScroll: true });
+		}
+	});
+
+	// Mobile focus trap (PLAN-2105 / TASK-2122). At ≤768px the pane is a
+	// full-screen overlay (modal semantics), so focus must stay WITHIN it. On the
+	// desktop split we deliberately do NOT trap — the list must stay reachable
+	// (Tab-out + j/k depend on it). Re-runs when the pane mounts/unmounts OR the
+	// viewport crosses the breakpoint, engaging/releasing the trap accordingly.
+	//
+	// Two backstops, both WINDOW/DOCUMENT-level (not pane-scoped) so they still
+	// fire after focus has already escaped the pane:
+	//  • Tab keydown — cycles focus within the pane's tabbables (smooth, no
+	//    flicker) via `nextTrapTarget`.
+	//  • focusin — the catch-all: ANY programmatic focus escape (Cmd+F focusing
+	//    the search box behind the overlay, a removed control dropping focus to
+	//    <body>) is pulled straight back into the pane (Codex P1 — Tab alone
+	//    can't see these).
+	// Both DEFER to a native modal <dialog> (Share / Edit Collection / the
+	// Open-Children confirm — `Modal.svelte` uses `showModal()`), which renders
+	// in the top layer above the overlay and owns its own focus cycle. `<aside>`
+	// isn't a dialog, so this never exempts the pane itself; role="dialog" sheets
+	// (BottomSheet) sit BELOW the pane and stay behind it, so focus belongs on
+	// the pane, not them.
+	$effect(() => {
+		if (!browser) return;
+		if (!paneEl || !viewport.isMobile) return;
+		// Bind the narrowed, non-null element so the nested handlers capture
+		// `HTMLElement` (TS re-widens a `$state` read back to `| null` across a
+		// closure boundary otherwise).
+		const region = paneEl;
+		// Surfaces that OWN their own focus/keyboard and legitimately overlay the
+		// pane — exempt from the trap so it neither hijacks their Tab nor yanks
+		// focus off them the instant they open. Recognised by role/tag rather than
+		// per-component class, so PANE-OWNED popups that portal out to <body>
+		// (outside `.item-pane` in the DOM) are all covered without whack-a-mole:
+		//  • native modal <dialog> (Share / Edit Collection / Open-Children
+		//    confirm) — top layer, self-trapping.
+		//  • [role="dialog"] — BottomSheets opened FROM WITHIN the pane (field
+		//    selects, Quick Actions, Move To); they render in the pane's own
+		//    stacking context, ABOVE its content, and own their Escape (Codex P1).
+		//  • [role="menu"] / [role="listbox"] — the item-actions reorder menu, the
+		//    editor slash/turn-into menus, select dropdowns, etc. (Codex P2).
+		//  • the editor block context menu — imperative, no ARIA role, so matched
+		//    by class (block-drag-handle.ts).
+		// (Focus already inside `.item-pane` is handled by the `region.contains`
+		// check at each call site.)
+		const inExemptSurface = (el: Element | null | undefined): boolean =>
+			!!el?.closest?.('dialog, [role="dialog"], [role="menu"], [role="listbox"], .block-context-menu');
+		function onTrapKeydown(e: KeyboardEvent) {
+			if (e.key !== 'Tab' || e.defaultPrevented) return;
+			if (inExemptSurface(e.target as Element | null)) return;
+			const target = nextTrapTarget(
+				paneFocusables(region),
+				document.activeElement,
+				e.shiftKey,
+				region,
+			);
+			if (target) {
+				e.preventDefault();
+				target.focus({ preventScroll: true });
+			}
+		}
+		function onFocusIn(e: FocusEvent) {
+			const t = e.target as Element | null;
+			if (!t || region.contains(t) || inExemptSurface(t)) return;
+			region.focus({ preventScroll: true });
+		}
+		window.addEventListener('keydown', onTrapKeydown);
+		document.addEventListener('focusin', onFocusIn);
+		return () => {
+			window.removeEventListener('keydown', onTrapKeydown);
+			document.removeEventListener('focusin', onFocusIn);
+		};
+	});
+
+	// Return focus to the originating row whenever the pane CLOSES while this
+	// page stays mounted (PLAN-2105 / TASK-2122). Keyed off `openItemRef` going
+	// truthy→null, so it covers EVERY close path uniformly — ESC, the ✕ button,
+	// item-deleted, AND browser Back (which drops `?item=` straight from the URL
+	// without calling `closeItemPane`, Codex P2). Navigating AWAY (expand to full
+	// page / collection rename) unmounts this whole page, so the effect never
+	// runs a truthy→null transition for those — and `resolvePaneReturnTarget`
+	// returns null once the list is gone, a second guard against stealing focus
+	// mid-navigation.
+	let prevOpenItemRef: string | null = null;
+	let prevRouteKey: string | null = null;
+	$effect(() => {
+		const current = openItemRef;
+		// SvelteKit REUSES this component across collections/workspaces (same
+		// `[username]/[workspace]/[collection]` route), so navigating from
+		// `/ws/tasks?item=X` to `/ws/ideas` also flips openItemRef truthy→null.
+		// That's a NAVIGATION, not a pane close — don't steal focus for it (Codex
+		// P2). Only treat truthy→null as a close when the route identity is
+		// unchanged (same collection page, only `?item=` dropped).
+		const routeKey = `${username}/${wsSlug}/${collSlug}`;
+		const sameRoute = prevRouteKey === null || prevRouteKey === routeKey;
+		const justClosed = !!prevOpenItemRef && !current && sameRoute;
+		prevOpenItemRef = current;
+		prevRouteKey = routeKey;
+		if (!justClosed || !browser) return;
+		// Prefer the originating row; fall back to the list container (a stable
+		// tabindex=-1 landmark) so a deep-linked / filtered-out / cross-collection
+		// item — which has no `.focused` row and no captured trigger — still lands
+		// focus somewhere in the list instead of dropping it to <body> (Codex P2).
+		const target =
+			resolvePaneReturnTarget(document, paneReturnFocusEl) ??
+			document.querySelector<HTMLElement>('.list-column');
+		paneReturnFocusEl = null;
+		target?.focus();
 	});
 
 	// Safety net for an interrupted drag: if the pane closes (ESC / Back /
@@ -2000,10 +2158,33 @@
 			// Text-editing targets (title edit, tag input, the Tiptap editor)
 			// own ESC locally (cancel/blur) — don't hijack it into a layer-close.
 			if (isTextEntryTarget(target)) return;
-			// A modal (native <dialog>, focus-trapped) owns its own ESC — don't
-			// also pop a pane/graph/list layer underneath it. The pane and graph
-			// drawer aren't dialogs, so this never blocks the chain.
-			if (target?.closest?.('dialog')) return;
+			// A modal (native <dialog>, or a role="dialog" BottomSheet opened from
+			// within the pane — field selects / Quick Actions / Move To) owns its
+			// own ESC — don't also pop the pane/graph/list layer underneath it
+			// (Codex P1). The pane (<aside>) and graph drawer aren't dialogs, so
+			// this never blocks the chain.
+			if (target?.closest?.('dialog, [role="dialog"]')) return;
+			// Desktop two-level ESC (TASK-2122): from INSIDE the open pane (a
+			// non-text target), ESC returns focus to the list — the master/detail
+			// "back to the list" step — and the pane STAYS open so the user can
+			// keep navigating with j/k (which the pane follows). A SECOND ESC, now
+			// on the list, falls through to the escape stack below and closes the
+			// pane ("ESC-to-close"). Skipped on the mobile overlay: it's a
+			// focus-trapped modal, so ESC there closes it via the stack. Gated on
+			// the pane being the FRONTMOST escape layer: a higher-priority layer
+			// stacked over it (e.g. the dependency-graph drawer) must own ESC
+			// first, so we defer to the stack when one is open (Codex P2). Only
+			// fires when there's a focused list row to land on.
+			if (
+				openItemRef &&
+				!viewport.isMobile &&
+				topEscapePriority() === ESCAPE_PRIORITY.pane &&
+				target?.closest?.('.item-pane') &&
+				returnFocusToList()
+			) {
+				e.preventDefault();
+				return;
+			}
 			if (runTopEscape()) e.preventDefault();
 			return;
 		}
@@ -2019,6 +2200,12 @@
 		// drive list/board navigation instead (PLAN-2105 / TASK-2111 / -2119).
 		if (target?.closest?.('[contenteditable="true"], .item-pane, .pane-divider')) return;
 		if (quickCreateOpen || saveViewOpen) return;
+		// On the MOBILE overlay the list is hidden behind the full-screen pane, so
+		// list nav is meaningless — bail even if focus has escaped to <body> (e.g.
+		// a focused pane control was removed with no focusin to re-trap it). Without
+		// this, j/k would silently navigate the hidden list and re-target the pane
+		// (Codex P1). Desktop split is unaffected; ESC (handled above) still closes.
+		if (viewport.isMobile && openItemRef) return;
 
 		switch (e.key) {
 			case 'j':
@@ -2068,6 +2255,35 @@
 					// Enter opens the focused row in the split pane (PLAN-2105 /
 					// TASK-2111) rather than navigating full-page.
 					openItemPane(item);
+				}
+				break;
+			case 'Tab':
+				// Bridge focus from the LIST into the open pane (desktop keyboard
+				// nav, TASK-2122). Forward Tab only — Shift+Tab keeps native order
+				// so the user can step back out of the pane. Gated to the list
+				// KEYBOARD-NAV context only: the pane is open, we're on the desktop
+				// split (mobile focus is already trapped in the overlay), the list
+				// cursor is active, and focus is on <body> (the state right after a
+				// j/k step, which doesn't move DOM focus) OR ON A ROW ANCHOR. We
+				// match the row ANCHOR (`a.item-card` / `a.title-link`), NOT the
+				// `.focused` marker — a click focuses row A, then j/k moves the
+				// marker to B without moving DOM focus, so the focused-marker check
+				// would wrongly reject the still-focused A (Codex P1). Matching the
+				// anchor also EXCLUDES toolbar buttons, saved-view tabs, and in-row
+				// sub-controls, whose native Tab order must be untouched. ESC brings
+				// focus back to the list (handled above); focus lands on the
+				// aria-labeled `<aside>` region, and Tab again steps into its
+				// controls.
+				if (
+					openItemRef &&
+					!e.shiftKey &&
+					!viewport.isMobile &&
+					focusedIndex >= 0 &&
+					paneEl &&
+					(target === document.body || !!target?.matches?.('a.item-card, a.title-link'))
+				) {
+					e.preventDefault();
+					paneEl.focus();
 				}
 				break;
 			// Escape is handled above (before the `.item-pane` guard).
@@ -2555,7 +2771,15 @@
 	note on the ItemDetail mount below.
 -->
 <div class="collection-page" class:board-active={viewMode === 'board'} class:pane-open={!!openItemRef}>
-	<div class="list-column">
+	<!-- tabindex=-1: a programmatic focus landmark (not a Tab stop) so closing
+	     the pane can return focus here when there's no originating row to land on
+	     (deep-linked / filtered-out item — TASK-2122).
+	     inert on the MOBILE overlay: the list is fully hidden behind the
+	     full-screen pane, so isolate it from BOTH the focus order AND the
+	     screen-reader accessibility tree — a JS focus trap alone can't constrain
+	     an SR virtual cursor, and inert also blocks Cmd+F from focusing the
+	     hidden search box. Desktop split leaves the list fully interactive. -->
+	<div class="list-column" tabindex="-1" inert={viewport.isMobile && !!openItemRef}>
 	{#if loading}
 		<div class="loading">Loading...</div>
 	{:else if metaError}
@@ -3040,9 +3264,22 @@
 			until localStorage is read so the CSS clamp() default applies on
 			first paint when there's no stored value.
 		-->
+		<!--
+			`aside` gives the pane complementary-landmark semantics; `aria-label`
+			names it so a screen reader announces the region on entry (TASK-2122).
+			`tabindex="-1"` makes it a programmatic focus target (not a Tab stop):
+			Tab from the list moves focus here, and the mobile overlay moves focus
+			here on open (then traps it). Desktop keeps focus on the list so j/k
+			navigation is uninterrupted. Focus-in (mobile), the Tab bridge, ESC
+			return-to-list, and the mobile focus trap are wired in the effects +
+			keydown handler above.
+		-->
+		<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
 		<aside
 			class="item-pane"
 			bind:this={paneEl}
+			tabindex="-1"
+			aria-label="Item detail"
 			style={paneWidth != null ? `--pane-width: ${paneWidth}px` : undefined}
 		>
 			<ItemDetail


### PR DESCRIPTION
Closes **TASK-2122** (PLAN-2105 Phase 4) — accessibility & keyboard focus management for the collection detail pane.

## What
- **Landmark semantics.** The pane `<aside>` is now an aria-labeled (`"Item detail"`), `tabindex=-1` complementary region — a screen reader announces it and it's a programmatic focus target.
- **Desktop split (non-modal).** Focus STAYS on the list on open, so arrow/j-k navigation (pane follows) is uninterrupted. **Tab** from the list bridges focus into the pane; a **two-level ESC** returns focus to the list (pane stays open — the "back to master" step), and a second ESC closes the pane. Not focus-trapped — the list stays reachable.
- **Mobile overlay (modal).** Focus moves in on open and is **trapped** (Tab + focusin, both deferring to native `<dialog>` / `role=dialog|menu|listbox` popups and the editor's portaled context menu). The hidden background list is marked **`inert`** — out of the focus order AND the screen-reader tree.
- **Focus return on close.** Every close path (ESC, ✕, browser Back, delete) returns focus to the originating row; falls back to the list container for deep-linked/filtered-out items. Gated on route identity so cross-collection navigation (which reuses this page) isn't mistaken for a close.
- Header controls (⤢/↗/✕) were already keyboard-operable + labeled.

## How it's structured
Pure DOM/trap math extracted to `lib/collections/paneFocus.ts` + a `topEscapePriority()` helper on the escape stack (both unit-tested); runtime wiring verified by a real-browser e2e spec (`pane-a11y-focus.spec.ts`, 6 tests).

## Verification
- `make check` green (golangci-lint, go test, govulncheck, npm audit, svelte-check, 301 vitest).
- 11 pane e2e tests pass (6 new a11y + 5 sibling regression).
- 8 rounds of independent Codex review; all in-scope correctness findings fixed.

## Deferred (filed, out of scope)
- **BUG-2130** — shared `BottomSheet` doesn't move/trap focus (app-wide, pre-existing; surfaced here).
- **TASK-2131** — full mobile ARIA-modal isolation (inert the app shell in `+layout.svelte`, `role=dialog`/`aria-modal`) — beyond the task's `<aside>` spec.

https://claude.ai/code/session_01EZ6yr6pAUFb1uffan912ra