### PR TITLE
fix(web): scrub dead paned-item ?item= from last-route cache + other-surfaces audit (TASK-2123)

### DIFF
--- a/web/src/lib/collections/paneUrlParams.test.ts
+++ b/web/src/lib/collections/paneUrlParams.test.ts
@@ -4,7 +4,9 @@ import {
 	PANE_ITEM_PARAM,
 	buildCollectionUrlParams,
 	preservePaneItemParam,
+	repairDeadItemLastRoute,
 	type CollectionUrlFilterState,
+	type DeadItemRoute,
 } from './paneUrlParams';
 
 // Baseline "nothing changed" state — each `buildCollectionUrlParams` spec
@@ -95,6 +97,95 @@ describe('buildCollectionUrlParams', () => {
 		const currentUrl = new URL('https://pad.test/alice/ws/tasks');
 		const params = buildCollectionUrlParams(state({ activeFilters: { status: 'open' } }), currentUrl);
 		expect(params.has('item')).toBe(false);
+	});
+});
+
+// TASK-2123: after a paned item is hard-deleted, its dead `?item=` ref must
+// be scrubbed from `pad-last-route-{ws}` so the workspace switcher doesn't
+// re-restore a broken split on re-entry. The pre-fix code only ever built a
+// full-page `failedPath` (`/{user}/{ws}/{coll}/<ref>`), which never matches
+// the embedded pane shape (`/{user}/{ws}/{coll}?item=<ref>`), so the dead
+// pane persisted. These specs pin both shapes plus the navigate-away guard.
+describe('repairDeadItemLastRoute', () => {
+	function dead(overrides: Partial<DeadItemRoute> = {}): DeadItemRoute {
+		return {
+			username: 'alice',
+			wsSlug: 'ws',
+			collSlug: 'tasks',
+			itemSlug: 'TASK-5',
+			embedded: true,
+			...overrides,
+		};
+	}
+
+	describe('embedded pane', () => {
+		it('drops the whole entry when the dead pane ref was its only URL state', () => {
+			// The core TASK-2123 scenario: `/alice/ws/tasks?item=TASK-5` with a
+			// now-dead TASK-5. The old full-page compare missed this shape.
+			expect(repairDeadItemLastRoute('/alice/ws/tasks?item=TASK-5', dead())).toBeNull();
+		});
+
+		it('strips only ?item= and keeps the collection view/sort/filter state', () => {
+			const cached = '/alice/ws/tasks?view=board&status=open&item=TASK-5';
+			const repaired = repairDeadItemLastRoute(cached, dead());
+			// Cleaned route restores the board view minus the dead pane.
+			expect(repaired).toBe('/alice/ws/tasks?view=board&status=open');
+			expect(repaired).not.toContain('item=');
+		});
+
+		it('leaves the entry untouched when it now points at a DIFFERENT open ref (navigate-away)', () => {
+			// The user opened TASK-9 while TASK-5's load was still failing; the
+			// +layout effect already persisted the newer pane. Must not clobber.
+			expect(
+				repairDeadItemLastRoute('/alice/ws/tasks?item=TASK-9', dead({ itemSlug: 'TASK-5' })),
+			).toBeUndefined();
+		});
+
+		it('leaves the entry untouched when it now points at a different collection page', () => {
+			expect(
+				repairDeadItemLastRoute('/alice/ws/ideas?item=TASK-5', dead()),
+			).toBeUndefined();
+		});
+
+		it('handles a slug-form ?item= value the same as a ref', () => {
+			// itemUrlId falls back to the slug when an item has no ref, so the
+			// pane param — and thus `itemSlug` — can be a slug.
+			expect(
+				repairDeadItemLastRoute('/alice/ws/tasks?item=my-dead-task', dead({ itemSlug: 'my-dead-task' })),
+			).toBeNull();
+		});
+
+		it('is a no-op on a missing cache entry', () => {
+			expect(repairDeadItemLastRoute(null, dead())).toBeUndefined();
+		});
+	});
+
+	describe('full page', () => {
+		it('removes the entry when the whole URL is the dead item path', () => {
+			expect(
+				repairDeadItemLastRoute('/alice/ws/tasks/TASK-5', dead({ embedded: false })),
+			).toBeNull();
+		});
+
+		it('removes the entry even when the dead item path carries a query/hash', () => {
+			expect(
+				repairDeadItemLastRoute('/alice/ws/tasks/TASK-5?foo=1#frag', dead({ embedded: false })),
+			).toBeNull();
+		});
+
+		it('leaves the entry untouched when it points elsewhere (navigate-away)', () => {
+			expect(
+				repairDeadItemLastRoute('/alice/ws/tasks/TASK-99', dead({ embedded: false })),
+			).toBeUndefined();
+		});
+
+		// A full-page dead item never matches the pane shape and vice-versa —
+		// the branch is chosen by `embedded`, not by sniffing the stored URL.
+		it('does not treat a full-page dead path as an embedded pane match', () => {
+			expect(
+				repairDeadItemLastRoute('/alice/ws/tasks/TASK-5', dead({ embedded: true })),
+			).toBeUndefined();
+		});
 	});
 });
 

--- a/web/src/lib/collections/paneUrlParams.ts
+++ b/web/src/lib/collections/paneUrlParams.ts
@@ -84,3 +84,76 @@ export function buildCollectionUrlParams(state: CollectionUrlFilterState, curren
 	preservePaneItemParam(params, currentUrl);
 	return params;
 }
+
+/** The dead item whose failed load should be scrubbed from the persisted
+ *  `pad-last-route-{ws}` entry. `itemSlug` is the ref/slug that failed to
+ *  load — for an embedded pane it equals the `?item=` value verbatim, since
+ *  the collection page threads `openItemRef` → ItemDetail's `ref` prop →
+ *  `itemSlug` unchanged. */
+export interface DeadItemRoute {
+	username: string;
+	wsSlug: string;
+	collSlug: string;
+	itemSlug: string;
+	/** True when the failed load was an embedded split pane (persisted route
+	 *  shape `/{user}/{ws}/{coll}?item=<ref>`); false for a full-page item
+	 *  route (`/{user}/{ws}/{coll}/<ref>`). */
+	embedded: boolean;
+}
+
+// `pad-last-route-{ws}` stores `pathname + search` (a root-relative URL). A
+// throwaway base lets us parse it with the `URL` API in any environment (no
+// `window`); only the pathname + query are ever read back out.
+const RELATIVE_URL_BASE = 'http://pad.invalid';
+
+/**
+ * Repair a persisted `pad-last-route-{ws}` value after the item it points at
+ * fails to load (hard-deleted / dead ref). The workspace switcher restores
+ * this route on re-entry (TASK-754), so a dead entry would keep re-opening a
+ * broken view. Returns one of:
+ *
+ *  - a CLEANED route string to persist — an embedded pane whose only dead
+ *    part was `?item=` but which still carries view/sort/filter/search state
+ *    (strip just the param, keep the collection route);
+ *  - `null` to REMOVE the entry entirely — a full-page dead item, or an
+ *    embedded pane whose `?item=` was its only URL state;
+ *  - `undefined` to LEAVE the entry untouched — it no longer points at THIS
+ *    failed URL, so a navigate-away already wrote a newer entry we must not
+ *    clobber (PLAN-2105 / TASK-754 in-flight race guard).
+ *
+ * The embedded branch is the TASK-2123 fix: the old code only ever built a
+ * full-page `failedPath`, which never matches the `?item=` pane shape, so the
+ * dead pane re-restored on every workspace re-entry.
+ */
+export function repairDeadItemLastRoute(
+	cached: string | null,
+	failed: DeadItemRoute,
+): string | null | undefined {
+	if (!cached) return undefined;
+	const root = `/${failed.username}/${failed.wsSlug}/${failed.collSlug}`;
+
+	if (failed.embedded) {
+		let url: URL;
+		try {
+			url = new URL(cached, RELATIVE_URL_BASE);
+		} catch {
+			return undefined;
+		}
+		// Only scrub if the stored route is still THIS collection page with
+		// THIS dead pane ref — otherwise a newer navigate-away entry owns it.
+		if (
+			url.pathname !== root ||
+			url.searchParams.get(PANE_ITEM_PARAM) !== failed.itemSlug
+		) {
+			return undefined;
+		}
+		url.searchParams.delete(PANE_ITEM_PARAM);
+		return url.search ? url.pathname + url.search : null;
+	}
+
+	// Full page: the whole URL is the dead item path. Remove the entry, but
+	// only if it still points at this failed item (ignore any query/hash).
+	const failedPath = `${root}/${failed.itemSlug}`;
+	const cachedPath = cached.split('?')[0].split('#')[0];
+	return cachedPath === failedPath ? null : undefined;
+}

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -130,17 +130,6 @@
 	// counter — not reactive; it only fences async writes.
 	let loadGeneration = 0;
 
-	// The load generation that was live when this instance was torn down (pane
-	// closed / workspace switched away); -1 while mounted. onDestroy records it
-	// just before bumping `loadGeneration`. The dead-item last-route cleanup
-	// (loadData's catch) uses it to tell the ONE abandoned load that owned the
-	// cached route at teardown from earlier superseded loads: only that load —
-	// or the current live load — may scrub the cache. A blanket "destroyed"
-	// boolean would wrongly let a very-late superseded A₁ rejection scrub a
-	// route a newer A₂ re-loaded successfully (A→B→A) (TASK-2123; Codex rounds
-	// 2-3 P2).
-	let abandonedGen = -1;
-
 	// Per-switch fetch memoization (TASK-2120). The workspace's members and
 	// agent roles are workspace-invariant, yet loadData re-fetched them on
 	// every row-click and every j/k keystroke. Cache them on this persistent
@@ -757,10 +746,6 @@
 		// pending load bail at its next await-resume guard, before those calls
 		// (PLAN-2105 / TASK-2112; Codex round 2 P1). onDestroy runs
 		// synchronously on unmount, before the awaited fetch continuations.
-		// Record the generation live at teardown (before the bump) so a load
-		// that rejects post-teardown can tell it was the abandoned owner of the
-		// cached route vs. a stale superseded load (TASK-2123 last-route repair).
-		abandonedGen = loadGeneration;
 		loadGeneration++;
 		editorStore.resetForDoc();
 		collectionStore.setActiveItem(null);
@@ -976,6 +961,17 @@
 				} catch { if (myGen !== loadGeneration) return; agentRoles = []; }
 			}
 		} catch (e: any) {
+			// A newer load (or an onDestroy teardown bump) owns the state — don't
+			// let this superseded/abandoned load overwrite it. This guard also
+			// fences the last-route scrub below: ONLY the current live load may
+			// touch the cache. A superseded or torn-down load can't tell a dead
+			// route from one another load — even a later component instance
+			// (workspace re-entry) — just revived, so scrubbing on its stale
+			// rejection risks clobbering a valid cached pane. The current live
+			// load has no such ambiguity: it is failing right now, so its route
+			// is dead right now (TASK-2123; Codex rounds 1-4 converged here).
+			if (myGen !== loadGeneration) return;
+			error = e.message ?? 'Failed to load item';
 			// Scrub the dead item from the workspace's last-route cache so the
 			// workspace switcher (TASK-754) doesn't keep restoring it on re-entry.
 			// An embedded pane persists the collection route with `?item=<ref>`;
@@ -983,43 +979,28 @@
 			// handles both shapes: strip only the dead `?item=` param (keeping the
 			// collection's view/sort/filter state) for a pane, or drop the whole
 			// entry for a full page — and returns `undefined` (no write) when the
-			// entry no longer points at this failed URL (TASK-2123 / TASK-754).
+			// entry no longer points at this failed URL, so we never clobber a
+			// route a concurrent navigation just wrote (TASK-2123 / TASK-754).
 			//
-			// Scrub only when THIS is the live load (`myGen === loadGeneration`)
-			// or THIS was the exact load that owned the cached route at teardown
-			// (`myGen === abandonedGen`). We must NOT scrub for a superseded load:
-			// an A→B→A re-load may have fetched the SAME ref successfully after
-			// this stale request was fired, and route identity can't tell that
-			// live entry from a dead one — the current/abandoned-owner load owns
-			// the outcome, and its own catch scrubs if it too failed (Codex rounds
-			// 2-3 P2). Both allowed cases additionally self-protect via
-			// repairDeadItemLastRoute's `undefined` (cache-no-longer-matches)
-			// return. Residual (benign, self-healing): a direct switch between two
-			// collection routes reuses this component (no teardown, so no
-			// abandonedGen), leaving the departed workspace's dead `?item=`
-			// uncleaned until its next visit re-loads it and the then-current load
-			// scrubs it.
-			if (myGen === loadGeneration || myGen === abandonedGen) {
-				try {
-					const cacheKey = `pad-last-route-${reqWsSlug}`;
-					const repaired = repairDeadItemLastRoute(localStorage.getItem(cacheKey), {
-						username: reqUsername,
-						wsSlug: reqWsSlug,
-						collSlug: reqCollSlug,
-						itemSlug: reqItemSlug,
-						embedded: reqEmbedded,
-					});
-					if (repaired === null) {
-						localStorage.removeItem(cacheKey);
-					} else if (repaired !== undefined) {
-						localStorage.setItem(cacheKey, repaired);
-					}
-				} catch {}
-			}
-			// A newer load owns the on-screen state — don't overwrite it with
-			// this superseded load's error.
-			if (myGen !== loadGeneration) return;
-			error = e.message ?? 'Failed to load item';
+			// A dead route abandoned by a switch-away (deleted while the pane was
+			// closed / in another tab) is cleaned on the NEXT visit instead: the
+			// switcher restores it, this pane reloads it, that load fails as the
+			// current load, and lands right here. Self-healing and instance-safe.
+			try {
+				const cacheKey = `pad-last-route-${reqWsSlug}`;
+				const repaired = repairDeadItemLastRoute(localStorage.getItem(cacheKey), {
+					username: reqUsername,
+					wsSlug: reqWsSlug,
+					collSlug: reqCollSlug,
+					itemSlug: reqItemSlug,
+					embedded: reqEmbedded,
+				});
+				if (repaired === null) {
+					localStorage.removeItem(cacheKey);
+				} else if (repaired !== undefined) {
+					localStorage.setItem(cacheKey, repaired);
+				}
+			} catch {}
 		} finally {
 			// Only the CURRENT (newest) load owns the shared loading / pending
 			// flags — a superseded load's finally (it early-returned above)

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -1011,6 +1011,13 @@
 			// shared localStorage). Those errors still surface via `error` above;
 			// they just don't touch the cache (Codex).
 			if (itemFetchNotFound) {
+				// The read + write below is one synchronous block, so no same-tab
+				// interleaving is possible. Across tabs, `pad-last-route-{ws}` is
+				// best-effort (last-writer-wins, no CAS — as the +layout writer
+				// that owns this key already is): a concurrent write in another
+				// tab could momentarily win or lose one update, self-healed by the
+				// next navigation. Accepted, pre-existing property — not worth
+				// cross-tab coordination for a convenience restore cache.
 				try {
 					const cacheKey = `pad-last-route-${reqWsSlug}`;
 					const repaired = repairDeadItemLastRoute(localStorage.getItem(cacheKey), {

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -840,6 +840,7 @@
 		const reqWsSlug = wsSlug;
 		const reqCollSlug = collSlug;
 		const reqItemSlug = itemSlug;
+		const reqEmbedded = embedded;
 		try {
 			// The workspace item index is needed for wiki-link resolution
 			// at Y.Doc seed time (the $effect ~line 904 below) and for the
@@ -960,19 +961,22 @@
 				} catch { if (myGen !== loadGeneration) return; agentRoles = []; }
 			}
 		} catch (e: any) {
-			// A newer load owns the state — don't overwrite it with this
-			// superseded load's error.
-			if (myGen !== loadGeneration) return;
-			error = e.message ?? 'Failed to load item';
 			// Scrub the dead item from the workspace's last-route cache so the
 			// workspace switcher (TASK-754) doesn't keep restoring it on re-entry.
 			// An embedded pane persists the collection route with `?item=<ref>`;
 			// a full page persists the item's own path. `repairDeadItemLastRoute`
 			// handles both shapes: strip only the dead `?item=` param (keeping the
 			// collection's view/sort/filter state) for a pane, or drop the whole
-			// entry for a full page — and returns `undefined` (no write) when a
-			// navigate-away already replaced the entry, so we never clobber it
-			// (TASK-2123 / TASK-754).
+			// entry for a full page — and returns `undefined` (no write) when the
+			// entry no longer points at this failed URL, so we never clobber a
+			// newer one (TASK-2123 / TASK-754).
+			//
+			// This runs BEFORE the generation guard on purpose: it's keyed to the
+			// captured request snapshot and self-protects via that `undefined`
+			// state, so it's safe even for a superseded load. Running it here
+			// cleans the entry when the user switched workspace / closed the pane
+			// (bumping loadGeneration) before this failed request settled —
+			// otherwise that workspace keeps its dead `?item=` (Codex P2).
 			try {
 				const cacheKey = `pad-last-route-${reqWsSlug}`;
 				const repaired = repairDeadItemLastRoute(localStorage.getItem(cacheKey), {
@@ -980,7 +984,7 @@
 					wsSlug: reqWsSlug,
 					collSlug: reqCollSlug,
 					itemSlug: reqItemSlug,
-					embedded,
+					embedded: reqEmbedded,
 				});
 				if (repaired === null) {
 					localStorage.removeItem(cacheKey);
@@ -988,6 +992,10 @@
 					localStorage.setItem(cacheKey, repaired);
 				}
 			} catch {}
+			// A newer load owns the on-screen state — don't overwrite it with
+			// this superseded load's error.
+			if (myGen !== loadGeneration) return;
+			error = e.message ?? 'Failed to load item';
 		} finally {
 			// Only the CURRENT (newest) load owns the shared loading / pending
 			// flags — a superseded load's finally (it early-returned above)

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -130,14 +130,16 @@
 	// counter — not reactive; it only fences async writes.
 	let loadGeneration = 0;
 
-	// Set once in onDestroy so a load that rejects AFTER this instance is torn
-	// down (pane closed / workspace switched away) can still tell "I'm abandoned"
-	// from "a newer mounted load superseded me". The dead-item last-route cleanup
-	// (loadData's catch) needs this: a superseded-but-mounted failure must NOT
-	// scrub the cache (a newer load may have re-loaded the same ref successfully —
-	// A→B→A), but an abandoned failure MUST, or a workspace switched-away-from
-	// keeps its dead `?item=` (TASK-2123; Codex round 2 P2).
-	let destroyed = false;
+	// The load generation that was live when this instance was torn down (pane
+	// closed / workspace switched away); -1 while mounted. onDestroy records it
+	// just before bumping `loadGeneration`. The dead-item last-route cleanup
+	// (loadData's catch) uses it to tell the ONE abandoned load that owned the
+	// cached route at teardown from earlier superseded loads: only that load —
+	// or the current live load — may scrub the cache. A blanket "destroyed"
+	// boolean would wrongly let a very-late superseded A₁ rejection scrub a
+	// route a newer A₂ re-loaded successfully (A→B→A) (TASK-2123; Codex rounds
+	// 2-3 P2).
+	let abandonedGen = -1;
 
 	// Per-switch fetch memoization (TASK-2120). The workspace's members and
 	// agent roles are workspace-invariant, yet loadData re-fetched them on
@@ -745,7 +747,6 @@
 	});
 
 	onDestroy(() => {
-		destroyed = true;
 		unsubscribeSync?.();
 		unsubscribeSSE?.();
 		unsubscribeBeforePrint?.();
@@ -756,6 +757,10 @@
 		// pending load bail at its next await-resume guard, before those calls
 		// (PLAN-2105 / TASK-2112; Codex round 2 P1). onDestroy runs
 		// synchronously on unmount, before the awaited fetch continuations.
+		// Record the generation live at teardown (before the bump) so a load
+		// that rejects post-teardown can tell it was the abandoned owner of the
+		// cached route vs. a stale superseded load (TASK-2123 last-route repair).
+		abandonedGen = loadGeneration;
 		loadGeneration++;
 		editorStore.resetForDoc();
 		collectionStore.setActiveItem(null);
@@ -980,15 +985,21 @@
 			// entry for a full page — and returns `undefined` (no write) when the
 			// entry no longer points at this failed URL (TASK-2123 / TASK-754).
 			//
-			// Run it only when THIS is the live load (`myGen === loadGeneration`)
-			// or the instance was torn down (`destroyed`). We must NOT scrub for a
-			// superseded-but-still-mounted failure: an A→B→A re-load may have
-			// fetched the SAME ref successfully after this stale request was fired,
-			// and route identity can't tell that live entry from a dead one — the
-			// current load owns the outcome and its own catch will scrub if it too
-			// failed (Codex round 2 P2). The `destroyed` case still self-protects
-			// via the `undefined` (cache-no-longer-matches) return.
-			if (myGen === loadGeneration || destroyed) {
+			// Scrub only when THIS is the live load (`myGen === loadGeneration`)
+			// or THIS was the exact load that owned the cached route at teardown
+			// (`myGen === abandonedGen`). We must NOT scrub for a superseded load:
+			// an A→B→A re-load may have fetched the SAME ref successfully after
+			// this stale request was fired, and route identity can't tell that
+			// live entry from a dead one — the current/abandoned-owner load owns
+			// the outcome, and its own catch scrubs if it too failed (Codex rounds
+			// 2-3 P2). Both allowed cases additionally self-protect via
+			// repairDeadItemLastRoute's `undefined` (cache-no-longer-matches)
+			// return. Residual (benign, self-healing): a direct switch between two
+			// collection routes reuses this component (no teardown, so no
+			// abandonedGen), leaving the departed workspace's dead `?item=`
+			// uncleaned until its next visit re-loads it and the then-current load
+			// scrubs it.
+			if (myGen === loadGeneration || myGen === abandonedGen) {
 				try {
 					const cacheKey = `pad-last-route-${reqWsSlug}`;
 					const repaired = repairDeadItemLastRoute(localStorage.getItem(cacheKey), {

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -841,6 +841,15 @@
 		const reqCollSlug = collSlug;
 		const reqItemSlug = itemSlug;
 		const reqEmbedded = embedded;
+		// Set by the item GET's OWN rejection handler (below) so the catch can
+		// tell an item-not-found — the item is genuinely gone, so its dead route
+		// should be scrubbed — from a collection/index failure or any transient
+		// error that merely rejected the shared Promise.all first. `Promise.all`
+		// surfaces only the first rejection, so keying the scrub off the outer
+		// error's code would (a) scrub a VALID item's route on a collection
+		// `not_found` and (b) miss a dead item when the collection/index errors
+		// first. Classifying the item request separately fixes both (Codex).
+		let itemFetchNotFound = false;
 		try {
 			// The workspace item index is needed for wiki-link resolution
 			// at Y.Doc seed time (the $effect ~line 904 below) and for the
@@ -862,7 +871,14 @@
 				userId: authStore.userId || null,
 			});
 			const [itemData, collData] = await Promise.all([
-				api.items.get(wsSlug, itemSlug),
+				api.items.get(wsSlug, itemSlug).catch((err) => {
+					// Tag an item-specific not-found for the catch's cache scrub,
+					// then re-throw so the load still fails as before.
+					if (err instanceof PadApiError && err.code === 'not_found') {
+						itemFetchNotFound = true;
+					}
+					throw err;
+				}),
 				api.collections.get(wsSlug, collSlug),
 				itemsPromise
 			]);
@@ -987,13 +1003,14 @@
 			// switcher restores it, this pane reloads it, that load fails as the
 			// current load, and lands right here. Self-healing and instance-safe.
 			//
-			// Gate on a genuine not-found (the item — or its collection — is
-			// really gone) so a TRANSIENT failure (offline, 429 rate-limit, 5xx,
-			// auth) never strips a still-valid cached pane, including one another
-			// live tab wrote to the shared localStorage (Codex round 5 P2). Non-
-			// not_found errors still surface via `error` above; they just don't
-			// touch the cache.
-			if (e instanceof PadApiError && e.code === 'not_found') {
+			// Gate on the ITEM GET's own not-found (`itemFetchNotFound`, set in
+			// the Promise.all above) — the item is genuinely gone. A TRANSIENT
+			// failure (offline, 429 rate-limit, 5xx, auth), a collection/index
+			// error, or a first-to-reject sibling in the Promise.all never strips
+			// a still-valid cached pane (incl. one another live tab wrote to the
+			// shared localStorage). Those errors still surface via `error` above;
+			// they just don't touch the cache (Codex).
+			if (itemFetchNotFound) {
 				try {
 					const cacheKey = `pad-last-route-${reqWsSlug}`;
 					const repaired = repairDeadItemLastRoute(localStorage.getItem(cacheKey), {

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -986,21 +986,30 @@
 			// closed / in another tab) is cleaned on the NEXT visit instead: the
 			// switcher restores it, this pane reloads it, that load fails as the
 			// current load, and lands right here. Self-healing and instance-safe.
-			try {
-				const cacheKey = `pad-last-route-${reqWsSlug}`;
-				const repaired = repairDeadItemLastRoute(localStorage.getItem(cacheKey), {
-					username: reqUsername,
-					wsSlug: reqWsSlug,
-					collSlug: reqCollSlug,
-					itemSlug: reqItemSlug,
-					embedded: reqEmbedded,
-				});
-				if (repaired === null) {
-					localStorage.removeItem(cacheKey);
-				} else if (repaired !== undefined) {
-					localStorage.setItem(cacheKey, repaired);
-				}
-			} catch {}
+			//
+			// Gate on a genuine not-found (the item — or its collection — is
+			// really gone) so a TRANSIENT failure (offline, 429 rate-limit, 5xx,
+			// auth) never strips a still-valid cached pane, including one another
+			// live tab wrote to the shared localStorage (Codex round 5 P2). Non-
+			// not_found errors still surface via `error` above; they just don't
+			// touch the cache.
+			if (e instanceof PadApiError && e.code === 'not_found') {
+				try {
+					const cacheKey = `pad-last-route-${reqWsSlug}`;
+					const repaired = repairDeadItemLastRoute(localStorage.getItem(cacheKey), {
+						username: reqUsername,
+						wsSlug: reqWsSlug,
+						collSlug: reqCollSlug,
+						itemSlug: reqItemSlug,
+						embedded: reqEmbedded,
+					});
+					if (repaired === null) {
+						localStorage.removeItem(cacheKey);
+					} else if (repaired !== undefined) {
+						localStorage.setItem(cacheKey, repaired);
+					}
+				} catch {}
+			}
 		} finally {
 			// Only the CURRENT (newest) load owns the shared loading / pending
 			// flags — a superseded load's finally (it early-returned above)

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -130,6 +130,15 @@
 	// counter — not reactive; it only fences async writes.
 	let loadGeneration = 0;
 
+	// Set once in onDestroy so a load that rejects AFTER this instance is torn
+	// down (pane closed / workspace switched away) can still tell "I'm abandoned"
+	// from "a newer mounted load superseded me". The dead-item last-route cleanup
+	// (loadData's catch) needs this: a superseded-but-mounted failure must NOT
+	// scrub the cache (a newer load may have re-loaded the same ref successfully —
+	// A→B→A), but an abandoned failure MUST, or a workspace switched-away-from
+	// keeps its dead `?item=` (TASK-2123; Codex round 2 P2).
+	let destroyed = false;
+
 	// Per-switch fetch memoization (TASK-2120). The workspace's members and
 	// agent roles are workspace-invariant, yet loadData re-fetched them on
 	// every row-click and every j/k keystroke. Cache them on this persistent
@@ -736,6 +745,7 @@
 	});
 
 	onDestroy(() => {
+		destroyed = true;
 		unsubscribeSync?.();
 		unsubscribeSSE?.();
 		unsubscribeBeforePrint?.();
@@ -968,30 +978,33 @@
 			// handles both shapes: strip only the dead `?item=` param (keeping the
 			// collection's view/sort/filter state) for a pane, or drop the whole
 			// entry for a full page — and returns `undefined` (no write) when the
-			// entry no longer points at this failed URL, so we never clobber a
-			// newer one (TASK-2123 / TASK-754).
+			// entry no longer points at this failed URL (TASK-2123 / TASK-754).
 			//
-			// This runs BEFORE the generation guard on purpose: it's keyed to the
-			// captured request snapshot and self-protects via that `undefined`
-			// state, so it's safe even for a superseded load. Running it here
-			// cleans the entry when the user switched workspace / closed the pane
-			// (bumping loadGeneration) before this failed request settled —
-			// otherwise that workspace keeps its dead `?item=` (Codex P2).
-			try {
-				const cacheKey = `pad-last-route-${reqWsSlug}`;
-				const repaired = repairDeadItemLastRoute(localStorage.getItem(cacheKey), {
-					username: reqUsername,
-					wsSlug: reqWsSlug,
-					collSlug: reqCollSlug,
-					itemSlug: reqItemSlug,
-					embedded: reqEmbedded,
-				});
-				if (repaired === null) {
-					localStorage.removeItem(cacheKey);
-				} else if (repaired !== undefined) {
-					localStorage.setItem(cacheKey, repaired);
-				}
-			} catch {}
+			// Run it only when THIS is the live load (`myGen === loadGeneration`)
+			// or the instance was torn down (`destroyed`). We must NOT scrub for a
+			// superseded-but-still-mounted failure: an A→B→A re-load may have
+			// fetched the SAME ref successfully after this stale request was fired,
+			// and route identity can't tell that live entry from a dead one — the
+			// current load owns the outcome and its own catch will scrub if it too
+			// failed (Codex round 2 P2). The `destroyed` case still self-protects
+			// via the `undefined` (cache-no-longer-matches) return.
+			if (myGen === loadGeneration || destroyed) {
+				try {
+					const cacheKey = `pad-last-route-${reqWsSlug}`;
+					const repaired = repairDeadItemLastRoute(localStorage.getItem(cacheKey), {
+						username: reqUsername,
+						wsSlug: reqWsSlug,
+						collSlug: reqCollSlug,
+						itemSlug: reqItemSlug,
+						embedded: reqEmbedded,
+					});
+					if (repaired === null) {
+						localStorage.removeItem(cacheKey);
+					} else if (repaired !== undefined) {
+						localStorage.setItem(cacheKey, repaired);
+					}
+				} catch {}
+			}
 			// A newer load owns the on-screen state — don't overwrite it with
 			// this superseded load's error.
 			if (myGen !== loadGeneration) return;

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -39,6 +39,7 @@
 	import EditCollectionModal from '$lib/components/collections/EditCollectionModal.svelte';
 	import ShareDialog from '$lib/components/ShareDialog.svelte';
 	import { copyToClipboard } from '$lib/utils/clipboard';
+	import { repairDeadItemLastRoute } from '$lib/collections/paneUrlParams';
 	import { starredStore } from '$lib/stores/starred.svelte';
 	import { titleStore } from '$lib/stores/title.svelte';
 	import { workspaceStore } from '$lib/stores/workspace.svelte';
@@ -963,20 +964,28 @@
 			// superseded load's error.
 			if (myGen !== loadGeneration) return;
 			error = e.message ?? 'Failed to load item';
-			// Clear the workspace's last-route cache so the workspace
-			// switcher (TASK-754) doesn't keep restoring this dead item
-			// URL on subsequent re-entries — but only if the stored value
-			// still points at THIS failed URL. If the user navigated away
-			// while the request was in flight, the +layout effect has
-			// already written a newer entry and we must not clobber it.
+			// Scrub the dead item from the workspace's last-route cache so the
+			// workspace switcher (TASK-754) doesn't keep restoring it on re-entry.
+			// An embedded pane persists the collection route with `?item=<ref>`;
+			// a full page persists the item's own path. `repairDeadItemLastRoute`
+			// handles both shapes: strip only the dead `?item=` param (keeping the
+			// collection's view/sort/filter state) for a pane, or drop the whole
+			// entry for a full page — and returns `undefined` (no write) when a
+			// navigate-away already replaced the entry, so we never clobber it
+			// (TASK-2123 / TASK-754).
 			try {
-				const failedPath = `/${reqUsername}/${reqWsSlug}/${reqCollSlug}/${reqItemSlug}`;
-				const cached = localStorage.getItem(`pad-last-route-${reqWsSlug}`);
-				if (cached) {
-					const cachedPath = cached.split('?')[0].split('#')[0];
-					if (cachedPath === failedPath) {
-						localStorage.removeItem(`pad-last-route-${reqWsSlug}`);
-					}
+				const cacheKey = `pad-last-route-${reqWsSlug}`;
+				const repaired = repairDeadItemLastRoute(localStorage.getItem(cacheKey), {
+					username: reqUsername,
+					wsSlug: reqWsSlug,
+					collSlug: reqCollSlug,
+					itemSlug: reqItemSlug,
+					embedded,
+				});
+				if (repaired === null) {
+					localStorage.removeItem(cacheKey);
+				} else if (repaired !== undefined) {
+					localStorage.setItem(cacheKey, repaired);
 				}
 			} catch {}
 		} finally {


### PR DESCRIPTION
Closes **TASK-2123** (PLAN-2105, Phase 4 — split-pane polish).

## Part 1 — Other-surfaces audit (verification only)

Confirmed every non-collection item-open surface still navigates **full-page** — none thread the opt-in `onItemOpen` pane callback:

| Surface | Navigation | Result |
|---|---|---|
| Workspace home, activity, search, starred, tags, roles, graph | plain `<a href>` / `goto` | PASS |
| Share pages (`/s/[token]`, PublicItemCard/BoardView) | separate `onactivate` toggle, no `?item=` | PASS |
| Reserved (insights, conventions, library, playbooks) | no item lists | PASS |

Structural rule holds: only the 4 collection list components (`ItemCard`, `TableView`, `ListView`, `BoardView`) *define* `onItemOpen`, and only the collection page (`[collection]/+page.svelte`, 3 sites) ever *passes* it (`openItemPane`). `?item=` / `openItemPane` are confined there. **No code changes needed.**

## Part 2 — Dead paned-item last-route cleanup (the fix)

A paned item that's hard-deleted left a dead `?item=<ref>` in `pad-last-route-{ws}`, so the workspace switcher re-restored a broken split on re-entry. ItemDetail's dead-item cleanup only ever built a full-page `failedPath` (`/{user}/{ws}/{coll}/<ref>`), which **never matches** the embedded pane shape (`/{user}/{ws}/{coll}?item=<ref>`) — so the pane's dead route was never cleaned.

- Extracted the cleanup into a pure, framework-agnostic **`repairDeadItemLastRoute`** helper in `paneUrlParams.ts` (the TASK-2116 testable-pane-logic pattern): for a pane it strips only the dead `?item=` param and **keeps the collection's view/sort/filter state**; for a full page it drops the whole entry; and it returns "leave untouched" when the entry no longer points at the failed URL.
- The scrub runs **only in the current-live-load path** and **only on a genuine `not_found`** — never on a superseded/abandoned load (no cross-instance clobber) and never on a transient network/429/5xx/auth blip (no stripping a valid pane, incl. one another tab wrote). A route abandoned by a switch-away self-heals on next visit.
- Unit tests cover both URL shapes + the navigate-away race guard (10 new specs; full web suite 311/311 green).

## Verification
- `cd web && npm run check` — 0 errors
- `make web-check` — svelte-check clean (npm audit: 2 pre-existing moderate, below the high gate)
- `npm run test` — 24 files / 311 tests pass
- `npm run build` — embedded web build compiles
- Web-only diff (no Go / store / migration / collab-schema changes)
- **Codex CLI review: CLEAN** (converged over 6 rounds; the loop hardened the load-generation / cross-instance / transient-error races that a naive cleanup would miss)

https://claude.ai/code/session_01EZ6yr6pAUFb1uffan912ra