### PR TITLE
feat(web): sticky pane header keeps item ID + controls visible while scrolling (IDEA-2134)

### DIFF
--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -4177,20 +4177,35 @@
 	*/
 
 	/* Pane chrome (PLAN-2105 / TASK-2113) — embedded-only header docked at
-	   the top of the split pane, replacing the full-page breadcrumb. */
+	   the top of the split pane, replacing the full-page breadcrumb.
+
+	   Sticky (IDEA-2134): the header stays pinned to the top of the pane's
+	   scroll container (`.item-pane` — `overflow-y: auto` on desktop, the
+	   fixed full-screen overlay on mobile) so the item ref + expand / popout /
+	   close controls remain visible while the body scrolls. The negative side
+	   margins bleed the opaque background out over `.item-page`'s horizontal
+	   padding so scrolling content is covered edge-to-edge, mirroring the
+	   full-page `.sticky-header` pattern above. */
 	.pane-header {
+		position: sticky;
+		top: 0;
+		z-index: 10;
+		background: var(--bg-primary);
 		display: flex;
 		align-items: center;
 		justify-content: space-between;
 		gap: var(--space-3);
-		margin-bottom: var(--space-3);
+		margin: 0 calc(-1 * var(--space-6)) var(--space-3);
+		padding: var(--space-2) var(--space-6);
 	}
-	/* Loading / error variant: only the close button, right-aligned, with its
-	   own padding since it renders outside the padded `.item-page` wrapper. */
+	/* Loading / error variant: only the close button, right-aligned. Renders
+	   OUTSIDE the padded `.item-page` wrapper, so it drops the negative bleed
+	   and keeps its own edge padding — but stays sticky so the close control
+	   survives a tall loading skeleton. */
 	.pane-header--minimal {
 		justify-content: flex-end;
+		margin: 0;
 		padding: var(--space-4) var(--space-4) 0;
-		margin-bottom: 0;
 	}
 	.pane-header-ref {
 		display: flex;
@@ -5170,6 +5185,7 @@
 
 		/* Hide interactive / screen-only chrome inside the item page. */
 		.sticky-header,
+		.pane-header,
 		.meta-actions,
 		.editor-mode-toggle,
 		.add-relationship-section,


### PR DESCRIPTION
## What

The embedded split-pane's header — item ref + copy button + expand/popout/close controls — scrolled away with the body content. This makes `.pane-header` **`position: sticky; top: 0`** within the pane's scroll container (`.item-pane`) so the item ID and controls stay pinned and reachable while the content scrolls.

Mirrors the existing full-page `.sticky-header` breadcrumb pattern. Negative side margins bleed the opaque `--bg-primary` background over `.item-page`'s horizontal padding so scrolling content is covered edge-to-edge.

- Works on both the desktop docked pane and the mobile full-screen overlay (both are `overflow-y: auto` scroll containers).
- The loading/error `--minimal` variant drops the bleed (it renders outside the padded wrapper) but stays sticky so the close control survives a tall skeleton.
- Added `.pane-header` to the print-hide list alongside `.sticky-header` (route-owner chrome).

CSS-only; no markup or schema change.

## Verification

- `make install` + web build clean.
- Playwright against the running instance (PLAN-2105, 28k-char body): computed `position: sticky`, `z-index: 10`, opaque bg; after scrolling 1200px the header's top pins to the pane top (`headerTop == paneTop`) instead of scrolling away; ref stays on screen. Screenshots confirm resting state is visually unchanged and scrolled state pins the header.
- Codex review (`main..HEAD`): CLEAN.

Closes IDEA-2134.

https://claude.ai/code/session_01EZ6yr6pAUFb1uffan912ra