### PR TITLE
fix(web): debounce item link-search inputs (rate-limit relief)

### DIFF
--- a/web/src/lib/components/ChildItems.svelte
+++ b/web/src/lib/components/ChildItems.svelte
@@ -237,6 +237,7 @@
 		// await so a create/search/link in flight during an item switch
 		// can't write into the wrong item or toast after teardown.
 		destroyed = true;
+		clearTimeout(searchDebounceTimer);
 		unsubscribeSSE?.();
 		unsubscribeSync?.();
 	});
@@ -331,6 +332,12 @@
 	// slow older search that resolves after a newer one.
 	let destroyed = false;
 	let searchSeq = 0;
+	// Debounce the link-search network call so typing doesn't fire one request
+	// per keystroke (rate-limit relief). Plain `let` timer per the CommandPalette
+	// idiom; cleared on reset + onDestroy so a pending fetch never fires after
+	// the form closes or the instance is torn down.
+	const SEARCH_DEBOUNCE_MS = 250;
+	let searchDebounceTimer: ReturnType<typeof setTimeout> | undefined;
 
 	// Candidates: drop the parent itself, items already children here, and
 	// any the caller can't edit (view-only → 403 on link) — DR-2.
@@ -375,6 +382,9 @@
 		linkResults = [];
 		confirmCandidate = null;
 		linkSearching = false;
+		// Cancel a pending debounced search so it doesn't fire a wasted request
+		// after the form was cleared/closed.
+		clearTimeout(searchDebounceTimer);
 		// Invalidate any in-flight search so its late result can't repopulate
 		// linkResults after the form was cleared/closed (Codex diff review P1).
 		searchSeq++;
@@ -413,6 +423,12 @@
 		if (next === 'link' && !canLinkExisting) return;
 		mode = next;
 		confirmCandidate = null;
+		// Leaving Link mode hides the search box — cancel a pending debounced
+		// search + invalidate any in-flight one so it can't fire/repopulate
+		// after the input is gone (Codex review P2).
+		clearTimeout(searchDebounceTimer);
+		searchSeq++;
+		linkSearching = false;
 	}
 
 	async function submitCreate() {
@@ -461,6 +477,29 @@
 			// request settles; a write to a destroyed instance is a no-op.
 			creating = false;
 		}
+	}
+
+	// Debounced input handler. Clearing/emptying the box takes effect
+	// immediately (no wasted request); a non-empty query fires searchLink()
+	// only after the user pauses for SEARCH_DEBOUNCE_MS.
+	function onSearchInput() {
+		clearTimeout(searchDebounceTimer);
+		if (!linkSearch.trim()) {
+			// Invalidate any in-flight query so its late result can't repopulate
+			// results after the box was cleared (searchSeq fence).
+			searchSeq++;
+			linkResults = [];
+			linkSearching = false;
+			return;
+		}
+		// Query changed: invalidate any in-flight search (its result is now
+		// stale) and drop the previous results so they aren't shown or clickable
+		// during the debounce window; show loading until the new search lands
+		// (Codex review P2).
+		searchSeq++;
+		linkResults = [];
+		linkSearching = true;
+		searchDebounceTimer = setTimeout(() => searchLink(), SEARCH_DEBOUNCE_MS);
 	}
 
 	async function searchLink() {
@@ -644,7 +683,7 @@
 							placeholder="Search items to link…"
 							bind:value={linkSearch}
 							disabled={linking}
-							oninput={() => searchLink()}
+							oninput={onSearchInput}
 						/>
 						{#if linkSearching}
 							<div class="add-child-hint">Searching…</div>

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -259,6 +259,16 @@
 	let contentDebounceTimer: ReturnType<typeof setTimeout> | undefined;
 	let saveStatus = $state<'idle' | 'saving' | 'saved'>('idle');
 	let saveStatusTimer: ReturnType<typeof setTimeout> | undefined;
+	// Debounce the add-relationship search so typing doesn't fire one /search
+	// request per keystroke (rate-limit relief). Cleared on the item-scoped
+	// reset + onDestroy so a pending fetch never fires after teardown/switch.
+	const ADD_LINK_SEARCH_DEBOUNCE_MS = 250;
+	let addLinkDebounceTimer: ReturnType<typeof setTimeout> | undefined;
+	// Per-query fence for the add-relationship search. loadGeneration only bumps
+	// on an item switch, so it can't invalidate an in-flight search when the box
+	// is merely emptied or closed on the SAME item — this seq does (Codex review
+	// P2). Plain `let` (CONVE-1688): read/written in handlers only.
+	let addLinkSearchSeq = 0;
 	let confirmDelete = $state(false);
 	let deleting = $state(false);
 	let restoring = $state(false);
@@ -739,6 +749,9 @@
 		unsubscribeSync?.();
 		unsubscribeSSE?.();
 		unsubscribeBeforePrint?.();
+		// Cancel a pending add-relationship search so it can't fire a wasted
+		// /search request after this instance is torn down.
+		clearTimeout(addLinkDebounceTimer);
 		// Invalidate any in-flight loadData so a request that resolves AFTER
 		// this instance is torn down (pane closed mid-load) can't reach its
 		// global-store writes — collectionStore.setActiveItem / editorStore —
@@ -844,6 +857,7 @@
 		editingTitle = false;
 		showMoveMenu = false;
 		showAddLink = false;
+		clearTimeout(addLinkDebounceTimer);
 		addLinkSearch = '';
 		addLinkResults = [];
 		addLinkLoading = false;
@@ -2920,18 +2934,49 @@
 	let addLinkResults = $state<Item[]>([]);
 	let addLinkLoading = $state(false);
 
+	// Cancel any pending debounce AND invalidate an in-flight add-relationship
+	// search so its late result can't repopulate the (now emptied/closed) box,
+	// and drop the loading flag. Used on empty, close, and after a link lands.
+	function cancelAddLinkSearch() {
+		clearTimeout(addLinkDebounceTimer);
+		addLinkSearchSeq++;
+		addLinkLoading = false;
+	}
+
+	// Debounced input handler. Emptying the box clears results + cancels any
+	// pending/in-flight request immediately; a non-empty query fires
+	// searchItemsForLink() only after the user pauses for the debounce window.
+	function onAddLinkInput() {
+		if (!addLinkSearch.trim()) {
+			cancelAddLinkSearch();
+			addLinkResults = [];
+			return;
+		}
+		clearTimeout(addLinkDebounceTimer);
+		// Query changed: invalidate any in-flight search and drop stale results
+		// so an old-query result can't appear or be selected during the debounce
+		// window; show loading until the new search lands (Codex review P2).
+		addLinkSearchSeq++;
+		addLinkResults = [];
+		addLinkLoading = true;
+		addLinkDebounceTimer = setTimeout(() => searchItemsForLink(), ADD_LINK_SEARCH_DEBOUNCE_MS);
+	}
+
 	async function searchItemsForLink() {
 		if (!addLinkSearch.trim()) {
 			addLinkResults = [];
 			return;
 		}
-		// Fence the async search so results from item A's add-link box can't
-		// repopulate the panel after switching to item B (Codex).
+		// Fence the async search so a result can't repopulate the panel after
+		// an item switch (loadGeneration) OR after the box was emptied/closed on
+		// the same item (addLinkSearchSeq) — Codex.
 		const gen = loadGeneration;
+		const seq = ++addLinkSearchSeq;
+		const stale = () => gen !== loadGeneration || seq !== addLinkSearchSeq;
 		addLinkLoading = true;
 		try {
 			const results = await api.search(addLinkSearch, { workspace: wsSlug });
-			if (gen !== loadGeneration) return;
+			if (stale()) return;
 			// Filter out self and items already linked
 			const linkedIds = new Set(itemLinks.flatMap(l => [l.source_id, l.target_id]));
 			addLinkResults = (results.results || [])
@@ -2939,10 +2984,10 @@
 				.filter((i: Item) => i.id !== item?.id && !linkedIds.has(i.id))
 				.slice(0, 10);
 		} catch {
-			if (gen !== loadGeneration) return;
+			if (stale()) return;
 			addLinkResults = [];
 		} finally {
-			if (gen === loadGeneration) addLinkLoading = false;
+			if (!stale()) addLinkLoading = false;
 		}
 	}
 
@@ -2964,6 +3009,9 @@
 			});
 			if (switchedAway(sourceItem, gen)) return;
 			itemLinks = [...itemLinks, newLink];
+			// Cancel any pending/in-flight search before closing the form so a
+			// stale debounced query can't fire after it's gone (Codex review P2).
+			cancelAddLinkSearch();
 			showAddLink = false;
 			addLinkSearch = '';
 			addLinkResults = [];
@@ -3970,7 +4018,7 @@
 					<div class="add-link-form">
 						<div class="add-link-header">
 							<h4>Add Relationship</h4>
-							<button class="add-link-close" onclick={() => { showAddLink = false; addLinkSearch = ''; addLinkResults = []; }}>×</button>
+							<button class="add-link-close" onclick={() => { cancelAddLinkSearch(); showAddLink = false; addLinkSearch = ''; addLinkResults = []; }}>×</button>
 						</div>
 						<div class="add-link-controls">
 							<select bind:value={addLinkType} class="add-link-type-select">
@@ -3986,7 +4034,7 @@
 								class="add-link-search"
 								placeholder="Search items..."
 								bind:value={addLinkSearch}
-								oninput={() => searchItemsForLink()}
+								oninput={onAddLinkInput}
 							/>
 						</div>
 						{#if addLinkLoading}


### PR DESCRIPTION
## What

Typing into the **add-child "Link existing"** search (`ChildItems.svelte`) — and the identical **add-relationship** search (`ItemDetail.svelte`) — fired an `api.search` request on **every keystroke**, tripping the server rate limiter mid-typing. This adds a **250ms debounce** to both inputs so a search fires once after the user pauses, not per character.

## How

- `onSearchInput` / `onAddLinkInput` schedule the search via a `setTimeout` after the debounce window. The timer is a plain non-`$state` `let` (CONVE-1688), and is **cleared on every path that hides the input**: `onDestroy`, form reset/close, the close (×) button, the mode/tab switch, the item-switch reset, and after a link lands — so no pending fetch fires after the box is gone.
- **In-flight + stale-result safety:** emptying or editing the query bumps a per-query sequence (`searchSeq` / new `addLinkSearchSeq`, which fences on the same item where `loadGeneration` alone can't) and clears the previous results immediately. An old-query request can't repopulate, and stale results can't be clicked, during the debounce window. The loading spinner can't get stuck on any close/clear/switch path.

The `ItemDetail` add-relationship search had the same un-debounced bug, so it's fixed here too (folded in — one coherent change).

## Verification

- `npm run check` → 0 errors; `npm run test` → 311/311.
- **Codex CLI review to CLEAN** (3 rounds — caught in-flight/stale-result races on the various close/switch paths, all fixed).
- **Playwright runtime proof:** 15 fast keystrokes → **0 `/search` requests during typing, 1 after the pause** (was ~15 per burst), on both inputs. Edge cases verified: tab-switch mid-type cancels the pending search, clearing the box fires nothing and leaves no stale results, editing the query clears stale matches, no stuck spinner.

## Notes

- Follows the existing debounce idiom (CommandPalette / PlaybookFormFields): plain-`let` timer + `clearTimeout`/`setTimeout`.
- Follow-up to PR #958 (the add-child feature).

https://claude.ai/code/session_01EZ6yr6pAUFb1uffan912ra