### PR TITLE
fix(web): close BUG-2129 stale-fields gap in the collection-edit switch fence

### DIFF
--- a/web/e2e/lib/collab-helpers.ts
+++ b/web/e2e/lib/collab-helpers.ts
@@ -36,15 +36,20 @@ export async function browserLogin(page: Page): Promise<void> {
 const enc = (obj: Record<string, unknown>) => JSON.stringify(obj);
 
 /**
- * Seed an empty doc item and return its slug. Empty content means the
+ * Seed an empty doc item and return its identity. Empty content means the
  * editor starts on a single empty paragraph, so text we later type
  * becomes the item's entire body — a clean anchor for content assertions.
+ *
+ * `fields` seeds the item's structured `fields` JSON (e.g. `{ status:
+ * 'draft', category: 'general' }`) — defaults to `{}` (schema defaults
+ * apply server-side) for every pre-existing caller.
  */
 export async function seedDoc(
 	fixture: SuiteFixture,
 	request: APIRequestContext,
 	titlePrefix = 'Collab persistence',
-): Promise<{ slug: string }> {
+	fields: Record<string, unknown> = {},
+): Promise<{ id: string; slug: string }> {
 	const ws = fixture.workspaceSlug;
 	const headers = {
 		Authorization: `Bearer ${fixture.apiToken}`,
@@ -52,10 +57,10 @@ export async function seedDoc(
 	};
 	const resp = await request.post(`/api/v1/workspaces/${ws}/collections/docs/items`, {
 		headers,
-		data: { title: `${titlePrefix} ${Date.now()}`, fields: enc({}), content: '' },
+		data: { title: `${titlePrefix} ${Date.now()}`, fields: enc(fields), content: '' },
 	});
 	if (!resp.ok()) throw new Error(`doc create failed (${resp.status()}): ${await resp.text()}`);
-	return (await resp.json()) as { slug: string };
+	return (await resp.json()) as { id: string; slug: string };
 }
 
 /** The live-editor ProseMirror surface — shared selector across specs. */

--- a/web/e2e/pane-collection-migration-race.spec.ts
+++ b/web/e2e/pane-collection-migration-race.spec.ts
@@ -419,18 +419,28 @@ test('a collection migration completing after a cross-collection navigation does
 	await expect(page).toHaveURL(new RegExp(`/${collB.slug}/`));
 
 	const urlAtRelease = page.url();
+	// waitForResponse (not a fixed sleep) — we need the PATCH to actually
+	// COMPLETE (onupdated only fires once the fetch promise resolves)
+	// before checking the URL, or this assertion could false-pass simply
+	// because the buggy navigation hadn't had a chance to fire yet (Codex
+	// round 3).
+	const patchResponse = page.waitForResponse(
+		(r) => r.url().endsWith(`/collections/${collA.slug}`) && r.request().method() === 'PATCH',
+	);
 	releaseMigration();
+	await patchResponse;
 
-	// Give the (possibly buggy) navigation a moment to fire — long enough
-	// that a wrongful `goto()` would have landed, short enough to keep the
-	// suite fast. If BUG-2129's fence regresses to the non-functional
-	// `{@const keyedSlug}` comparison, this callback ALWAYS falls through to
-	// the "not superseded" branch and, since the edited collection's slug
-	// (collA) differs from the CURRENTLY-shown collSlug (collB), unconditionally
+	// A short settle window for onupdated's SYNCHRONOUS decision (and any
+	// navigation it triggers) to actually land — bounded by the confirmed
+	// PATCH completion above, not a guess at total round-trip time. If
+	// BUG-2129's fence regresses to the non-functional `{@const keyedSlug}`
+	// comparison, this callback ALWAYS falls through to the "not
+	// superseded" branch and, since the edited collection's slug (collA)
+	// differs from the CURRENTLY-shown collSlug (collB), unconditionally
 	// calls handleNavigateAway(`/{username}/{ws}/{collA.slug}/{itemSlug}`) —
 	// hard-redirecting off B's page to a broken URL (B's ref doesn't exist
 	// in collA).
-	await page.waitForTimeout(1500);
+	await page.waitForTimeout(500);
 
 	expect(
 		page.url(),

--- a/web/e2e/pane-collection-migration-race.spec.ts
+++ b/web/e2e/pane-collection-migration-race.spec.ts
@@ -1,0 +1,442 @@
+import { test, expect } from './fixtures';
+import { browserLogin } from './lib/collab-helpers';
+import type { APIRequestContext, Locator, Page } from '@playwright/test';
+import type { SuiteFixture } from './fixtures';
+
+// Run this file's tests one at a time. Each seeds its own collection(s), so
+// they don't race a shared resource the way an earlier version of this
+// spec did — but the suite's collection-prefix derivation
+// (collections.DerivePrefix, workspace-scoped) isn't guaranteed collision-
+// free across concurrently-created collections with similar names, and a
+// prefix collision would cross-contaminate item numbering between the two
+// tests' otherwise-isolated fixtures. Serial execution removes the
+// ambiguity entirely.
+test.describe.configure({ mode: 'serial' });
+
+/**
+ * Playwright has no built-in "locate an input by its current value"
+ * finder (getByDisplayValue is a Testing Library concept, not a Playwright
+ * one) — and a CSS `[value=...]` attribute selector only sees the
+ * server-rendered/initial attribute, not the live DOM property Svelte's
+ * `bind:value` actually writes to. `.inputValue()` reads the live
+ * property, so we scan with it instead of guessing at field/option order.
+ */
+async function locatorByInputValue(candidates: Locator, value: string): Promise<Locator> {
+	const count = await candidates.count();
+	for (let i = 0; i < count; i++) {
+		const candidate = candidates.nth(i);
+		if ((await candidate.inputValue()) === value) return candidate;
+	}
+	throw new Error(`no element among ${count} candidates has value "${value}"`);
+}
+
+async function fieldCardByLabel(page: Page, label: string): Promise<Locator> {
+	const cards = page.locator('.field-card');
+	const count = await cards.count();
+	for (let i = 0; i < count; i++) {
+		const card = cards.nth(i);
+		if ((await card.locator('.field-label-input').inputValue()) === label) return card;
+	}
+	throw new Error(`no field card among ${count} has label "${label}"`);
+}
+
+function authHeaders(fixture: SuiteFixture) {
+	return { Authorization: `Bearer ${fixture.apiToken}`, 'Content-Type': 'application/json' };
+}
+
+/**
+ * Create a fresh, test-scoped collection with a migratable `status` select
+ * field (options draft/published/archived, matching the docs template's
+ * shape) plus a plain `category` text field. Each test gets its OWN
+ * collection (unique slug) rather than reusing a shared template
+ * collection like `docs` — these tests rename a select option, a
+ * workspace-global schema mutation, so sharing a collection across tests
+ * (or across parallel runs) would race two concurrent renames against the
+ * same option.
+ */
+async function seedMigratableCollection(
+	fixture: SuiteFixture,
+	request: APIRequestContext,
+	namePrefix: string,
+	itemPrefix: string,
+) {
+	// IMPORTANT #1: don't pass an explicit `slug` that diverges from
+	// slugify(name). handleUpdateCollection unconditionally re-derives the
+	// slug from `name` on EVERY save (EditCollectionModal always submits
+	// `name`, even unchanged) via uniqueSlugExcluding(slugify(name)) —
+	// internal/store/collections.go's UpdateCollection. If name and slug
+	// were seeded out of sync, the very first Fields-tab-only save (no
+	// name edit at all) would silently reassign the collection a NEW slug
+	// out from under the still-loaded route, 404-ing every subsequent
+	// fetch by the OLD slug. Keeping name unique (timestamped) and letting
+	// the server derive slug from it keeps them in sync exactly like a
+	// real single collection does, so a same-collection resave is a no-op
+	// slug-wise.
+	//
+	// IMPORTANT #2: pass an explicit, LETTERS-ONLY `itemPrefix` rather than
+	// letting the server derive one from `name` (collections.DerivePrefix).
+	// The derived prefix can pick up a leading digit from a numeric "word"
+	// in the name (e.g. a trailing Date.now() uniqueness suffix) — item
+	// refs are `{PREFIX}-{N}`, and the server's ref parser expects the
+	// prefix to be pure letters, so a digit-containing prefix makes every
+	// by-ref lookup (GET /items/{ref}) 404 with "Item not found" even
+	// though the item exists (confirmed empirically: creating a collection
+	// named "bug2129-switch <timestamp>" derived prefix "BS1" — the
+	// leading digit of the timestamp "word" — and every subsequent
+	// GET /items/BS1-10 404'd while GET /items/{slug} succeeded).
+	const name = `${namePrefix} ${Date.now()}`;
+	const schema = JSON.stringify({
+		fields: [
+			{
+				key: 'status',
+				label: 'Status',
+				type: 'select',
+				options: ['draft', 'published', 'archived'],
+				default: 'draft',
+				required: true,
+			},
+			{ key: 'category', label: 'Category', type: 'text' },
+		],
+	});
+	const resp = await request.post(`/api/v1/workspaces/${fixture.workspaceSlug}/collections`, {
+		headers: authHeaders(fixture),
+		data: { name, prefix: itemPrefix, schema },
+	});
+	if (!resp.ok()) throw new Error(`collection create failed (${resp.status()}): ${await resp.text()}`);
+	return (await resp.json()) as { id: string; slug: string; name: string };
+}
+
+async function seedItem(
+	fixture: SuiteFixture,
+	request: APIRequestContext,
+	collSlug: string,
+	title: string,
+	fields: Record<string, unknown>,
+) {
+	const resp = await request.post(`/api/v1/workspaces/${fixture.workspaceSlug}/collections/${collSlug}/items`, {
+		headers: authHeaders(fixture),
+		data: { title, fields: JSON.stringify(fields), content: '' },
+	});
+	if (!resp.ok()) throw new Error(`item create failed (${resp.status()}): ${await resp.text()}`);
+	return (await resp.json()) as { id: string; slug: string };
+}
+
+/**
+ * BUG-2129 regression e2e (PLAN-2154 Phase 0 / TASK-2155).
+ *
+ * BACKGROUND — this spec's investigation found the switch-fence guarding
+ * <EditCollectionModal>'s `onupdated` callback (ItemDetail.svelte) was a
+ * `{@const keyedSlug = itemSlug}` comparison that LOOKS like it freezes the
+ * item identity at the moment the modal's `{#key itemSlug}` block renders,
+ * but does not: Svelte 5 compiles `{@const}` bindings (and prop-expression
+ * closures passed across a component boundary, e.g. an IIFE inside a prop
+ * value) as lazily-pulled derived signals. Since `keyedSlug` was read ONLY
+ * inside the `onupdated` closure — never in the template body — the signal
+ * was never "pulled" until the closure actually ran, at which point it
+ * computed the CURRENT `itemSlug`, not the value at render time. Verified
+ * by runtime instrumentation (console logging + stack traces) during this
+ * investigation: `keyedSlug` and `itemSlug` were byte-identical at every
+ * `onupdated` firing, in BOTH the pre-fix and a naively "fixed" build,
+ * because the comparison could never actually diverge.
+ *
+ * Net effect pre-fix: `keyedSlug !== itemSlug` was always false, so the
+ * "superseded" branch was DEAD CODE — the callback always ran as if it were
+ * still on the original item, which happens to reload the CURRENTLY shown
+ * item's fields correctly (a lucky non-symptom for the same-collection
+ * pane case: see the first test below) but ALSO means the archive/rename
+ * navigation always targeted whatever is currently displayed, with no
+ * actual identity check — a real hazard once panes/routes span different
+ * collections (the second test below, and the target of PLAN-2154's
+ * upcoming cross-collection pane work).
+ *
+ * THE FIX replaces the non-functional `{@const}` freeze with a genuine
+ * gen+id snapshot (`pendingCollectionEditGen` / `pendingCollectionEditItemId`
+ * in ItemDetail.svelte) captured SYNCHRONOUSLY inside the `onmanage` click
+ * handler that opens the modal — a real event-handler execution, not a
+ * template binding or a prop-expression closure, so it's genuine JS
+ * variable semantics with no signal/getter indirection. `onupdated` then
+ * compares that snapshot against the LIVE `loadGeneration`/`item.id` to
+ * decide whether it's superseded — mirroring the gen+id pattern used
+ * throughout this file (loadData, updateField, the SSE handlers). When
+ * superseded, it does the minimal safe thing: if the currently-shown item
+ * is STILL in the collection that changed, refresh it (closing BUG-2129's
+ * stale-fields gap); otherwise it does nothing (no wrongful navigation).
+ *
+ * Two tests:
+ *   1. Same-collection pane switch (BUG-2129's literal repro): asserts the
+ *      post-migration reload happens and a subsequent field edit doesn't
+ *      clobber the migrated value. This demonstrates correct end-state
+ *      behavior but — per the finding above — does NOT by itself
+ *      discriminate the fix from the pre-fix code (both happen to reload
+ *      correctly here, for different reasons).
+ *   2. Cross-collection full-page navigation: the case that DOES
+ *      discriminate. Pre-fix, the non-functional fence lets a completed
+ *      rename/migration hijack navigation to whatever item is CURRENTLY
+ *      displayed, even if that item is in a totally unrelated collection —
+ *      an observable, user-facing bug (broken redirect / wrong page).
+ *      Post-fix, the genuine gen+id fence correctly no-ops for a
+ *      different-collection supersession.
+ */
+
+const MIGRATION_TIMEOUT = 20_000;
+
+test('a collection migration completing after a rapid A->B pane switch refreshes B instead of leaving it stale (BUG-2129)', async ({
+	page,
+	fixture,
+	request,
+}, testInfo) => {
+	test.skip(
+		testInfo.project.name !== 'desktop-chromium',
+		'switch-safety is viewport-agnostic; one project is enough',
+	);
+	test.setTimeout(60_000);
+
+	const coll = await seedMigratableCollection(fixture, request, 'bug2129-switch', 'BGSW');
+	// Both items start with status=draft. B also carries a distinguishable
+	// `category` so we can later prove the clobber-check edit lands on B,
+	// not A.
+	const a = await seedItem(fixture, request, coll.slug, 'BUG-2129 switch A', { status: 'draft' });
+	const b = await seedItem(fixture, request, coll.slug, 'BUG-2129 switch B', {
+		status: 'draft',
+		category: 'pre-migration',
+	});
+
+	await browserLogin(page);
+	await page.goto(`/${fixture.adminUsername}/${fixture.workspaceSlug}/${coll.slug}?item=${a.slug}`);
+
+	const pane = page.locator('.item-pane');
+	await expect(pane.locator('.title', { hasText: /BUG-2129 switch A/ })).toBeVisible();
+
+	// Hold the collection-update PATCH open until the test explicitly lets
+	// it through — this is what lets us deterministically land the switch
+	// to B WHILE the migration is still in flight. GETs to the same
+	// endpoint (the page's own collection load) pass straight through.
+	let releaseMigration = () => {};
+	const migrationGate = new Promise<void>((resolve) => {
+		releaseMigration = resolve;
+	});
+	await page.route(`**/api/v1/workspaces/*/collections/${coll.slug}`, async (route) => {
+		if (route.request().method() !== 'PATCH') {
+			await route.continue();
+			return;
+		}
+		await migrationGate;
+		await route.continue();
+	});
+
+	// Open Quick Actions -> Manage actions -> Edit Collection modal, Fields tab.
+	await pane.locator('button.trigger-btn[title="Quick actions"]').click();
+	await pane.locator('button.action-item.footer-row', { hasText: 'Manage actions' }).click();
+	await expect(page.locator('#edit-collection-title')).toBeVisible();
+	await page.locator('button.tab', { hasText: 'Fields' }).click();
+
+	// Rename the Status field's "draft" option — this is what makes the
+	// server treat the save as a migration (buildMigrations() in
+	// EditCollectionModal.svelte diffs original vs. edited select options).
+	const statusCard = await fieldCardByLabel(page, 'Status');
+	const draftOptionInput = await locatorByInputValue(
+		statusCard.locator('.option-row .option-name-input'),
+		'draft',
+	);
+	await draftOptionInput.fill('draft-migrated');
+
+	const patchSeen = page.waitForRequest(
+		(r) => r.url().endsWith(`/collections/${coll.slug}`) && r.method() === 'PATCH',
+	);
+	await page.locator('button.btn-save', { hasText: 'Save Changes' }).click();
+	await patchSeen;
+
+	// Close the modal WITHOUT waiting for the (held) save to resolve — a
+	// user glancing away mid-save. The modal component itself keeps
+	// running its pending `handleSave()`; only its DOM/visibility close.
+	await page.locator('button.btn-cancel', { hasText: 'Cancel' }).click();
+	await expect(page.locator('#edit-collection-title')).toHaveCount(0);
+
+	// Switch the pane to B — a client-side `?item=` re-target, not a full
+	// navigation. This is the moment the modal's still-pending save's
+	// `onupdated` closure becomes "superseded".
+	await page.locator('a.item-card', { hasText: 'BUG-2129 switch B' }).first().click();
+	await expect(pane.locator('.title', { hasText: /BUG-2129 switch B/ })).toBeVisible();
+
+	// Register the post-migration reload wait BEFORE releasing the gate, so
+	// there's no window where the response could land un-observed. Matched
+	// on the response BODY's item id (not slug/ref, which differ) so it can
+	// only be satisfied by a GET that actually re-fetched B.
+	const reloadResponse = page.waitForResponse(
+		async (r) => {
+			if (r.request().method() !== 'GET' || !r.url().includes('/items/')) return false;
+			try {
+				const body = await r.json();
+				return body.id === b.id;
+			} catch {
+				return false;
+			}
+		},
+		{ timeout: MIGRATION_TIMEOUT },
+	);
+
+	releaseMigration();
+
+	// If BUG-2129's gap regresses, the switch fence drops the superseded
+	// callback unconditionally and this reload never fires -> honest
+	// timeout failure here, not a silent false pass.
+	const reloaded = await reloadResponse;
+	const reloadedItem = await reloaded.json();
+	const reloadedFields = JSON.parse(reloadedItem.fields);
+	expect(
+		reloadedFields.status,
+		'B should have reloaded post-migration fields (the fix), not stayed on the stale pre-migration snapshot',
+	).toBe('draft-migrated');
+
+	// Now the clobber check: edit an UNRELATED field on B. `updateField()`
+	// serializes B's entire local `fields` object back to the server
+	// (ItemDetail.svelte). Pre-fix, B's local `fields.status` would still
+	// be the stale "draft" (the reload above never happened), so this PATCH
+	// would silently clobber the server's migrated "draft-migrated" back to
+	// "draft". Post-fix, B's local fields already reflect the migration, so
+	// the round-trip preserves it.
+	const categoryRow = pane.locator('.field-row:has(.field-label:text-is("Category"))');
+	const categoryInput = categoryRow.locator('input.field-input');
+	await expect(categoryInput).toHaveValue('pre-migration');
+
+	const fieldPatch = page.waitForRequest(
+		(r) => r.url().endsWith(`/items/${b.id}`) && r.method() === 'PATCH',
+	);
+	await categoryInput.fill('post-migration-edit');
+	await categoryInput.blur();
+	const patchReq = await fieldPatch;
+	const patchBody = JSON.parse(patchReq.postData() ?? '{}');
+	const patchFields = JSON.parse(patchBody.fields ?? '{}');
+	expect(
+		patchFields.status,
+		'editing an unrelated field on B must not clobber the migrated status back to the stale value',
+	).toBe('draft-migrated');
+	expect(patchFields.category).toBe('post-migration-edit');
+
+	// Belt-and-suspenders: read B back from the server and confirm neither
+	// value was clobbered by the round-trip.
+	const finalItem = await request.get(
+		`/api/v1/workspaces/${fixture.workspaceSlug}/items/${b.slug}`,
+		{ headers: { Authorization: `Bearer ${fixture.apiToken}` } },
+	);
+	expect(finalItem.ok()).toBe(true);
+	const finalFields = JSON.parse((await finalItem.json()).fields);
+	expect(finalFields.status).toBe('draft-migrated');
+	expect(finalFields.category).toBe('post-migration-edit');
+
+	// A (never re-opened) also carries the migration server-side, proving
+	// the migration itself was collection-wide, not a fluke of B's reload.
+	const finalA = await request.get(`/api/v1/workspaces/${fixture.workspaceSlug}/items/${a.slug}`, {
+		headers: { Authorization: `Bearer ${fixture.apiToken}` },
+	});
+	expect(JSON.parse((await finalA.json()).fields).status).toBe('draft-migrated');
+});
+
+test('a collection migration completing after a cross-collection navigation does not hijack the new page (BUG-2129 fence)', async ({
+	page,
+	fixture,
+	request,
+}, testInfo) => {
+	test.skip(
+		testInfo.project.name !== 'desktop-chromium',
+		'switch-safety is viewport-agnostic; one project is enough',
+	);
+	test.setTimeout(60_000);
+
+	const collA = await seedMigratableCollection(fixture, request, 'bug2129-xcoll-a', 'BGXA');
+	const collB = await seedMigratableCollection(fixture, request, 'bug2129-xcoll-b', 'BGXB');
+	const a = await seedItem(fixture, request, collA.slug, 'BUG-2129 xcoll A', { status: 'draft' });
+	const bTitle = `BUG-2129 xcoll B ${Date.now()}`;
+	const b = await seedItem(fixture, request, collB.slug, bTitle, { status: 'draft' });
+
+	// Link A -> B so A's full-page view renders a clickable relationship
+	// link into B — the vehicle for a REAL client-side SvelteKit navigation
+	// (not page.goto, which would hard-reload and reset all component
+	// state, defeating the same-instance-reuse race this test targets).
+	const linkResp = await request.post(
+		`/api/v1/workspaces/${fixture.workspaceSlug}/items/${a.slug}/links`,
+		{ headers: authHeaders(fixture), data: { target_id: b.id, link_type: 'related' } },
+	);
+	if (!linkResp.ok()) throw new Error(`link create failed (${linkResp.status()}): ${await linkResp.text()}`);
+
+	await browserLogin(page);
+	// The FULL-PAGE (non-embedded) item route. `[collection]/[slug]/+page.svelte`
+	// passes collSlug/ref straight through as reactive props with no {#key} —
+	// SvelteKit reuses the SAME <ItemDetail> instance across a same-route
+	// client-side navigation to a DIFFERENT collection/item, exactly like the
+	// pane's no-remount reuse (PLAN-2105/TASK-2112's invariant, just on the
+	// full-page host instead of the split pane).
+	await page.goto(`/${fixture.adminUsername}/${fixture.workspaceSlug}/${collA.slug}/${a.slug}`);
+	await expect(page.locator('.title', { hasText: /BUG-2129 xcoll A/ })).toBeVisible();
+
+	let releaseMigration = () => {};
+	const migrationGate = new Promise<void>((resolve) => {
+		releaseMigration = resolve;
+	});
+	await page.route(`**/api/v1/workspaces/*/collections/${collA.slug}`, async (route) => {
+		if (route.request().method() !== 'PATCH') {
+			await route.continue();
+			return;
+		}
+		await migrationGate;
+		await route.continue();
+	});
+
+	await page.locator('button.trigger-btn[title="Quick actions"]').click();
+	await page.locator('button.action-item.footer-row', { hasText: 'Manage actions' }).click();
+	await expect(page.locator('#edit-collection-title')).toBeVisible();
+	await page.locator('button.tab', { hasText: 'Fields' }).click();
+
+	const statusCard = await fieldCardByLabel(page, 'Status');
+	const draftOptionInput = await locatorByInputValue(
+		statusCard.locator('.option-row .option-name-input'),
+		'draft',
+	);
+	await draftOptionInput.fill('draft-migrated');
+
+	const patchSeen = page.waitForRequest(
+		(r) => r.url().endsWith(`/collections/${collA.slug}`) && r.method() === 'PATCH',
+	);
+	await page.locator('button.btn-save', { hasText: 'Save Changes' }).click();
+	await patchSeen;
+
+	await page.locator('button.btn-cancel', { hasText: 'Cancel' }).click();
+	await expect(page.locator('#edit-collection-title')).toHaveCount(0);
+
+	// Navigate A -> B via the relationship link — a real client-side
+	// SvelteKit transition (same route component, different params), while
+	// A's collection-edit save is still pending.
+	await page
+		.locator('.relationship-group', { hasText: 'Related' })
+		.locator('a.link-target', { hasText: bTitle })
+		.click();
+	await expect(page.locator('.title', { hasText: bTitle })).toBeVisible();
+	await expect(page).toHaveURL(new RegExp(`/${collB.slug}/`));
+
+	const urlAtRelease = page.url();
+	releaseMigration();
+
+	// Give the (possibly buggy) navigation a moment to fire — long enough
+	// that a wrongful `goto()` would have landed, short enough to keep the
+	// suite fast. If BUG-2129's fence regresses to the non-functional
+	// `{@const keyedSlug}` comparison, this callback ALWAYS falls through to
+	// the "not superseded" branch and, since the edited collection's slug
+	// (collA) differs from the CURRENTLY-shown collSlug (collB), unconditionally
+	// calls handleNavigateAway(`/{username}/{ws}/{collA.slug}/{itemSlug}`) —
+	// hard-redirecting off B's page to a broken URL (B's ref doesn't exist
+	// in collA).
+	await page.waitForTimeout(1500);
+
+	expect(
+		page.url(),
+		'a superseded, different-collection collection-edit must not navigate the page away from what the user is currently viewing',
+	).toBe(urlAtRelease);
+	await expect(page.locator('.title', { hasText: bTitle })).toBeVisible();
+
+	// Belt-and-suspenders: the migration itself DID apply server-side
+	// (proves the held PATCH actually completed, not just got dropped).
+	const finalA = await request.get(`/api/v1/workspaces/${fixture.workspaceSlug}/items/${a.slug}`, {
+		headers: { Authorization: `Bearer ${fixture.apiToken}` },
+	});
+	expect(JSON.parse((await finalA.json()).fields).status).toBe('draft-migrated');
+});

--- a/web/e2e/pane-collection-migration-race.spec.ts
+++ b/web/e2e/pane-collection-migration-race.spec.ts
@@ -299,13 +299,18 @@ test('a collection migration completing after a rapid A->B pane switch refreshes
 	const categoryInput = categoryRow.locator('input.field-input');
 	await expect(categoryInput).toHaveValue('pre-migration');
 
-	const fieldPatch = page.waitForRequest(
-		(r) => r.url().endsWith(`/items/${b.id}`) && r.method() === 'PATCH',
+	// waitForResponse (not waitForRequest) — we need the PATCH to actually
+	// COMMIT server-side before the belt-and-suspenders readback below,
+	// not just be dispatched, or that GET can race an in-flight write and
+	// intermittently observe pre-PATCH data (Codex round 2).
+	const fieldPatch = page.waitForResponse(
+		(r) => r.url().endsWith(`/items/${b.id}`) && r.request().method() === 'PATCH',
 	);
 	await categoryInput.fill('post-migration-edit');
 	await categoryInput.blur();
-	const patchReq = await fieldPatch;
-	const patchBody = JSON.parse(patchReq.postData() ?? '{}');
+	const patchRes = await fieldPatch;
+	expect(patchRes.ok()).toBe(true);
+	const patchBody = JSON.parse(patchRes.request().postData() ?? '{}');
 	const patchFields = JSON.parse(patchBody.fields ?? '{}');
 	expect(
 		patchFields.status,

--- a/web/src/lib/components/collections/EditCollectionModal.svelte
+++ b/web/src/lib/components/collections/EditCollectionModal.svelte
@@ -28,23 +28,27 @@
 		collection: Collection;
 		wsSlug: string;
 		initialSection?: 'general' | 'fields' | 'display' | 'actions';
-		// `editedCollectionId` echoes back which collection THIS save/archive
-		// targeted, captured synchronously (before the request) from the
-		// `collection` prop. Callers that render this modal inside a
-		// no-remount persistent host (e.g. ItemDetail's split pane — PLAN-2105
-		// / TASK-2112) can't rely on freezing that identity themselves via a
-		// template `{@const}` or a closure baked into the `onupdated` prop
-		// expression: Svelte 5 passes props (including callback props) as
-		// live getters that re-evaluate the parent's binding expression on
-		// every read, so such a "snapshot" is actually re-read fresh at CALL
-		// time — i.e. whenever this promise resolves, which can be long
-		// after the host has moved on to a different item/collection
-		// (confirmed by runtime instrumentation during the BUG-2129
-		// investigation). Passing the id back as a plain function argument
-		// sidesteps that entirely — it's a real JS value captured at the
-		// point this component synchronously read its OWN `collection` prop,
-		// not a re-evaluated expression.
-		onupdated: (updated?: Collection, editedCollectionId?: string) => void;
+		// `editedCollectionId`/`editedCollectionSlug` echo back which
+		// collection THIS save/archive targeted, captured synchronously
+		// (before the request) from the `collection` prop. Callers that
+		// render this modal inside a no-remount persistent host (e.g.
+		// ItemDetail's split pane — PLAN-2105 / TASK-2112) can't rely on
+		// freezing that identity themselves via a template `{@const}` or a
+		// closure baked into the `onupdated` prop expression: Svelte 5
+		// passes props (including callback props) as live getters that
+		// re-evaluate the parent's binding expression on every read, so
+		// such a "snapshot" is actually re-read fresh at CALL time — i.e.
+		// whenever this promise resolves, which can be long after the host
+		// has moved on to a different item/collection (confirmed by
+		// runtime instrumentation during the BUG-2129 investigation).
+		// Passing these back as plain function arguments sidesteps that
+		// entirely — real JS values captured at the point this component
+		// synchronously read its OWN `collection` prop, not a re-evaluated
+		// expression. The slug (not just the id) matters to callers whose
+		// own "is this still relevant" check needs to compare against a
+		// route param (e.g. `collSlug`) rather than a loaded object that
+		// can itself be stale mid-navigation (Codex).
+		onupdated: (updated?: Collection, editedCollectionId?: string, editedCollectionSlug?: string) => void;
 		onclose: () => void;
 	}
 
@@ -74,7 +78,7 @@
 		try {
 			await api.collections.delete(wsSlug, editedCollectionSlug);
 			toastStore.show(`Archived "${editedCollectionName}"`, 'success');
-			onupdated(undefined, editedCollectionId);
+			onupdated(undefined, editedCollectionId, editedCollectionSlug);
 			onclose();
 		} catch (err) {
 			toastStore.show('Failed to archive collection', 'error');
@@ -536,7 +540,7 @@
 
 			const updated = await api.collections.update(wsSlug, editedCollectionSlug, data);
 			toastStore.show(`Updated ${name.trim()}`, 'success');
-			onupdated(updated, editedCollectionId);
+			onupdated(updated, editedCollectionId, editedCollectionSlug);
 		} catch (err) {
 			error = err instanceof Error ? err.message : 'Failed to update collection';
 		} finally {

--- a/web/src/lib/components/collections/EditCollectionModal.svelte
+++ b/web/src/lib/components/collections/EditCollectionModal.svelte
@@ -47,8 +47,17 @@
 		// expression. The slug (not just the id) matters to callers whose
 		// own "is this still relevant" check needs to compare against a
 		// route param (e.g. `collSlug`) rather than a loaded object that
-		// can itself be stale mid-navigation (Codex).
-		onupdated: (updated?: Collection, editedCollectionId?: string, editedCollectionSlug?: string) => void;
+		// can itself be stale mid-navigation (Codex). `editedWsSlug` is the
+		// `wsSlug` PROP at the same synchronous capture point — collection
+		// slugs are workspace-scoped (two workspaces can both have a
+		// "docs" collection), so a caller reused across a workspace switch
+		// needs this to disambiguate (Codex PR review).
+		onupdated: (
+			updated?: Collection,
+			editedCollectionId?: string,
+			editedCollectionSlug?: string,
+			editedWsSlug?: string
+		) => void;
 		onclose: () => void;
 	}
 
@@ -75,10 +84,11 @@
 		const editedCollectionId = collection.id;
 		const editedCollectionSlug = collection.slug;
 		const editedCollectionName = collection.name;
+		const editedWsSlug = wsSlug;
 		try {
-			await api.collections.delete(wsSlug, editedCollectionSlug);
+			await api.collections.delete(editedWsSlug, editedCollectionSlug);
 			toastStore.show(`Archived "${editedCollectionName}"`, 'success');
-			onupdated(undefined, editedCollectionId, editedCollectionSlug);
+			onupdated(undefined, editedCollectionId, editedCollectionSlug, editedWsSlug);
 			onclose();
 		} catch (err) {
 			toastStore.show('Failed to archive collection', 'error');
@@ -375,6 +385,7 @@
 		// BEFORE the await, not after.
 		const editedCollectionId = collection.id;
 		const editedCollectionSlug = collection.slug;
+		const editedWsSlug = wsSlug;
 		try {
 			// Build existing fields back into FieldDef[]
 			const updatedExisting: FieldDef[] = existingFields.map((f) => {
@@ -538,9 +549,9 @@
 				data.migrations = migrations;
 			}
 
-			const updated = await api.collections.update(wsSlug, editedCollectionSlug, data);
+			const updated = await api.collections.update(editedWsSlug, editedCollectionSlug, data);
 			toastStore.show(`Updated ${name.trim()}`, 'success');
-			onupdated(updated, editedCollectionId, editedCollectionSlug);
+			onupdated(updated, editedCollectionId, editedCollectionSlug, editedWsSlug);
 		} catch (err) {
 			error = err instanceof Error ? err.message : 'Failed to update collection';
 		} finally {

--- a/web/src/lib/components/collections/EditCollectionModal.svelte
+++ b/web/src/lib/components/collections/EditCollectionModal.svelte
@@ -28,7 +28,23 @@
 		collection: Collection;
 		wsSlug: string;
 		initialSection?: 'general' | 'fields' | 'display' | 'actions';
-		onupdated: (updated?: Collection) => void;
+		// `editedCollectionId` echoes back which collection THIS save/archive
+		// targeted, captured synchronously (before the request) from the
+		// `collection` prop. Callers that render this modal inside a
+		// no-remount persistent host (e.g. ItemDetail's split pane — PLAN-2105
+		// / TASK-2112) can't rely on freezing that identity themselves via a
+		// template `{@const}` or a closure baked into the `onupdated` prop
+		// expression: Svelte 5 passes props (including callback props) as
+		// live getters that re-evaluate the parent's binding expression on
+		// every read, so such a "snapshot" is actually re-read fresh at CALL
+		// time — i.e. whenever this promise resolves, which can be long
+		// after the host has moved on to a different item/collection
+		// (confirmed by runtime instrumentation during the BUG-2129
+		// investigation). Passing the id back as a plain function argument
+		// sidesteps that entirely — it's a real JS value captured at the
+		// point this component synchronously read its OWN `collection` prop,
+		// not a re-evaluated expression.
+		onupdated: (updated?: Collection, editedCollectionId?: string) => void;
 		onclose: () => void;
 	}
 
@@ -50,10 +66,15 @@
 			return;
 		}
 		archiving = true;
+		// Synchronous capture (see the Props.onupdated doc comment) — read
+		// BEFORE the await, not after.
+		const editedCollectionId = collection.id;
+		const editedCollectionSlug = collection.slug;
+		const editedCollectionName = collection.name;
 		try {
-			await api.collections.delete(wsSlug, collection.slug);
-			toastStore.show(`Archived "${collection.name}"`, 'success');
-			onupdated();
+			await api.collections.delete(wsSlug, editedCollectionSlug);
+			toastStore.show(`Archived "${editedCollectionName}"`, 'success');
+			onupdated(undefined, editedCollectionId);
 			onclose();
 		} catch (err) {
 			toastStore.show('Failed to archive collection', 'error');
@@ -346,6 +367,10 @@
 		if (!name.trim() || saving || hasNewFieldBlockingErrors) return;
 		saving = true;
 		error = '';
+		// Synchronous capture (see the Props.onupdated doc comment) — read
+		// BEFORE the await, not after.
+		const editedCollectionId = collection.id;
+		const editedCollectionSlug = collection.slug;
 		try {
 			// Build existing fields back into FieldDef[]
 			const updatedExisting: FieldDef[] = existingFields.map((f) => {
@@ -509,9 +534,9 @@
 				data.migrations = migrations;
 			}
 
-			const updated = await api.collections.update(wsSlug, collection.slug, data);
+			const updated = await api.collections.update(wsSlug, editedCollectionSlug, data);
 			toastStore.show(`Updated ${name.trim()}`, 'success');
-			onupdated(updated);
+			onupdated(updated, editedCollectionId);
 		} catch (err) {
 			error = err instanceof Error ? err.message : 'Failed to update collection';
 		} finally {

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -279,27 +279,6 @@
 	let workspaceMembers = $state<{ user_id: string; user_name: string; user_email: string; role: string }[]>([]);
 	let shareDialogOpen = $state(false);
 	let editCollectionOpen = $state(false);
-	// Plain (non-reactive) snapshot of "which item was open when the owner
-	// launched the collection editor" — consumed by the <EditCollectionModal>
-	// onupdated fence below. NOT a {@const}/prop-derived capture: Svelte 5
-	// passes props (including callback props like `onupdated`) as live
-	// getters that re-evaluate the parent's binding expression on every
-	// read, so a {@const keyedSlug = itemSlug} (or an inline-IIFE "snapshot"
-	// inside the prop expression) is NOT actually frozen at render time —
-	// the child re-reads it fresh at CALL time, i.e. whenever the pending
-	// save resolves, which can be long after an intervening item switch.
-	// That silently defeats a fence that LOOKS like it freezes (confirmed
-	// by instrumentation during the BUG-2129 investigation: `{@const}` and
-	// prop-expression IIFEs both observed reading the CURRENT itemSlug/
-	// loadGeneration/item.id, not the value at the modal-open render).
-	// A plain top-level `let`, WRITTEN synchronously inside a real click
-	// handler (onmanage, below — fires synchronously on click, never after
-	// an async gap) and READ synchronously inside another real callback
-	// (onupdated), is genuine JS variable semantics with no signal/getter
-	// indirection, matching the gen+id capture pattern used everywhere
-	// else in this file (loadData, updateField, the SSE handlers).
-	let pendingCollectionEditGen = 0;
-	let pendingCollectionEditItemId: string | undefined;
 
 	// Per-item dependency graph drawer (PLAN-1780 / TASK-1784). The renderer
 	// (and its dagre layout lib) are dynamically imported on first open so they
@@ -3428,13 +3407,6 @@
 						{wsSlug}
 						canEdit={isOwner}
 						onmanage={() => {
-							// Synchronous capture (fires on click, never after an
-							// async gap) — the freeze the EditCollectionModal
-							// onupdated fence below relies on. See the
-							// pendingCollectionEditGen/-ItemId declaration for why
-							// this can't be a {@const} in the modal's own markup.
-							pendingCollectionEditGen = loadGeneration;
-							pendingCollectionEditItemId = item?.id;
 							editCollectionSection = 'actions';
 							editCollectionOpen = true;
 						}}
@@ -4187,42 +4159,37 @@
 		     switch (it's closed on switch anyway; keeps its async loads scoped
 		     and its OWN in-progress edits from leaking across items). The
 		     onupdated fence below does NOT depend on this remount for
-		     correctness (see pendingCollectionEditGen/-ItemId) — a stale
-		     instance's in-flight save keeps running after this block is torn
-		     down regardless, same as any other JS promise. -->
+		     correctness — a stale instance's in-flight save keeps running
+		     after this block is torn down regardless, same as any other JS
+		     promise; the fence works off `editedCollectionId`, which
+		     EditCollectionModal echoes back rather than us trying to freeze
+		     anything on this side (see its Props.onupdated doc comment: a
+		     template-side {@const}/closure "snapshot" doesn't actually
+		     freeze in Svelte 5 — BUG-2129). -->
 		{#key itemSlug}
 		<EditCollectionModal
 			bind:open={editCollectionOpen}
 			{collection}
 			{wsSlug}
 			initialSection={editCollectionSection}
-			onupdated={(updated) => {
-				// Switch fence (BUG-2129): was the pane still showing the item
-				// this collection edit was launched from? Compared against the
-				// pendingCollectionEditGen/-ItemId snapshot taken synchronously
-				// in onmanage (see its declaration for why {@const}/prop-
-				// expression captures can't do this freeze reliably in Svelte 5).
-				const superseded =
-					pendingCollectionEditGen !== loadGeneration || item?.id !== pendingCollectionEditItemId;
-				if (superseded) {
-					// A genuinely superseded save must not navigate/close/
-					// archive-redirect the pane now showing a DIFFERENT item —
-					// that decision belongs to the abandoned route, not the
-					// current one. But dropping the callback outright (the
-					// pre-fix behavior) also skipped the field-shape refresh
-					// below, so a completed schema/field migration left the
-					// current pane holding PRE-migration `fields`; the next
-					// updateField() then serialized that stale blob straight
-					// back over the migrated values (BUG-2129). Minimal safe
-					// fix: if the currently-shown item is still in the
-					// collection that just changed, refresh it too.
-					if (updated && item?.collection_id === updated.id) {
-						collection = updated;
-						collectionStore.loadCollections(wsSlug);
-						void loadData();
-					}
-					return;
-				}
+			onupdated={(updated, editedCollectionId) => {
+				// Fence (BUG-2129): only act if the item CURRENTLY shown is
+				// still in the collection this save/archive targeted. Covers
+				// both directions —
+				//   - still on the original item: trivially the same
+				//     collection, so this is a no-op behavior change from
+				//     before.
+				//   - superseded (pane moved to a different item, same
+				//     collection): apply the FULL handling (was previously
+				//     dropped outright, leaving stale fields — the literal
+				//     BUG-2129 gap — and would also have skipped a pending
+				//     rename/archive's navigation for the new item, per
+				//     Codex review).
+				//   - superseded, DIFFERENT collection: no-op — a completed
+				//     edit for an abandoned item/collection must not
+				//     navigate/close/replace-fields on whatever the user is
+				//     now looking at.
+				if (!editedCollectionId || item?.collection_id !== editedCollectionId) return;
 				if (!updated) {
 					// Archive case — the collection is gone. Navigate away from
 					// this now-invalid item route rather than leaving the user
@@ -4250,7 +4217,11 @@
 				// pane re-targets its host collection page (keeping the pane
 				// open via `?item=`) instead of hard-navigating to the
 				// full-page item route. The destination triggers a fresh
-				// loadData() on arrival, so no explicit refresh here.
+				// loadData() on arrival, so no explicit refresh here. Reads
+				// `itemSlug`/`collSlug` live (not frozen) — correct for both
+				// the still-current and superseded-same-collection cases,
+				// since either way this must target whatever is CURRENTLY
+				// displayed.
 				if (updated.slug !== collSlug && itemSlug) {
 					handleNavigateAway(
 						embedded

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -4161,7 +4161,7 @@
 		     onupdated fence below does NOT depend on this remount for
 		     correctness — a stale instance's in-flight save keeps running
 		     after this block is torn down regardless, same as any other JS
-		     promise; the fence works off `editedCollectionId`, which
+		     promise; the fence works off `editedCollectionSlug`, which
 		     EditCollectionModal echoes back rather than us trying to freeze
 		     anything on this side (see its Props.onupdated doc comment: a
 		     template-side {@const}/closure "snapshot" doesn't actually
@@ -4172,93 +4172,89 @@
 			{collection}
 			{wsSlug}
 			initialSection={editCollectionSection}
-			onupdated={(updated, editedCollectionId) => {
-				if (!editedCollectionId) return;
+			onupdated={(updated, editedCollectionId, editedCollectionSlug) => {
+				if (!editedCollectionId || !editedCollectionSlug) return;
 				// Keep the GLOBAL collections list (sidebar, pickers, etc.)
 				// fresh regardless of whether this pane/item is even
 				// affected — harmless and always correct.
 				collectionStore.loadCollections(wsSlug);
 
-				// Fence (BUG-2129): only act further if the item CURRENTLY
-				// known is in the collection this save/archive targeted.
-				// Covers both directions —
-				//   - still on the original item: trivially the same
-				//     collection, so this is a no-op behavior change from
-				//     before.
-				//   - superseded (pane moved to a different item, same
-				//     collection): apply the handling below (was previously
+				// Fence (BUG-2129): only act further if the CURRENT ROUTE is
+				// still showing the collection this save/archive targeted.
+				// Compared against `collSlug` — a plain reactive prop
+				// derived straight from the route params — rather than
+				// `item`/`collection` (this component's OWN loaded state).
+				// item/collection lag behind an in-flight loadData() call
+				// (item can still hold the PREVIOUS item's data for a beat
+				// after a route change), so comparing against them risks a
+				// mixed stale/fresh read: pass the check on stale data,
+				// then build a navigation URL from the ALREADY-updated
+				// collSlug/itemSlug and hijack to a mismatched URL (Codex).
+				// collSlug has no such lag — it updates synchronously with
+				// the route — so this fence is correct regardless of
+				// whether loadData() has caught up yet, with no separate
+				// itemMatchesRef gate needed:
+				//   - still on the original item: collSlug trivially
+				//     matches (unchanged since the modal opened).
+				//   - superseded, SAME collection (embedded pane switch —
+				//     collSlug is fixed per pane/page, so it's unchanged):
+				//     matches — apply the full handling below (previously
 				//     dropped outright, leaving stale fields — the literal
-				//     BUG-2129 gap).
-				//   - superseded, DIFFERENT collection: no-op below — a
-				//     completed edit for an abandoned item/collection must
-				//     not touch whatever the user is now looking at.
-				// `item` can be MID-TRANSITION (still holding the PREVIOUS
-				// item's data) if a route change is in flight — see the
-				// itemMatchesRef gates below for why that's handled
-				// separately rather than bailing out entirely here (Codex).
-				if (item?.collection_id !== editedCollectionId) return;
-				if (updated) collection = updated;
-
-				// Route-changing side effects (rename-redirect / archive-
-				// redirect) are gated on `itemMatchesRef` — the SAME "has
-				// loadData() caught up with the current route" invariant
-				// that gates collabKey and the SSE handlers elsewhere in
-				// this file. Between a route change (collSlug/itemSlug
-				// updating) and loadData()'s async resolution, `item` above
-				// can still be stale (the PREVIOUS item) while collSlug/
-				// itemSlug already reflect the new one — building a
-				// navigation URL from that mix would hijack to a broken,
-				// mismatched URL (Codex). Skip navigation in that window;
-				// `void loadData()` below is unconditionally safe to call
-				// instead — it's idempotent and gen-fenced against any
-				// in-flight load (see loadData's `myGen` checks), so calling
-				// it again while a same-route load is still pending can only
-				// help (superseding it with fresher data) and never regress
-				// correctness. That's exactly what closes BUG-2129's
-				// stale-fields gap when an in-flight load raced the
-				// migration and lost.
-				if (itemMatchesRef) {
-					if (!updated) {
-						// Archive case — the collection is gone. Navigate
-						// away from this now-invalid item route rather than
-						// leaving the user with stale state that would hit
-						// deleted resources. Route-away is parameterized
-						// (PLAN-2105 / TASK-2112): an embedded pane closes in
-						// place (the collection page reconciles the archive
-						// itself) instead of hard-navigating the whole page;
-						// full-page returns to the workspace root.
-						if (embedded) {
-							handleGone();
-						} else {
-							void goto(`/${username}/${wsSlug}`);
-						}
-						return;
+				//     BUG-2129 gap — and any pending rename/archive
+				//     unhandled).
+				//   - superseded, DIFFERENT collection (full-page
+				//     cross-collection navigation — collSlug updates the
+				//     instant the route changes): no match — a completed
+				//     edit for an abandoned collection must not touch
+				//     whatever the user has already navigated to.
+				if (collSlug !== editedCollectionSlug) return;
+				if (!updated) {
+					// Archive case — the collection is gone. Navigate away
+					// from this now-invalid item route rather than leaving
+					// the user with stale state that would hit deleted
+					// resources. Route-away is parameterized (PLAN-2105 /
+					// TASK-2112): an embedded pane closes in place (the
+					// collection page reconciles the archive itself)
+					// instead of hard-navigating the whole page; full-page
+					// returns to the workspace root.
+					if (embedded) {
+						handleGone();
+					} else {
+						void goto(`/${username}/${wsSlug}`);
 					}
-					// If the owner renamed the collection, its slug may have
-					// changed. The current `/[collection]/[slug]` URL still
-					// points at the old slug and subsequent loadData() calls
-					// (which fetch by collSlug) would 404. Navigate to the
-					// new slug while preserving the item slug — routed
-					// through handleNavigateAway (PLAN-2105 / TASK-2112) so
-					// an embedded pane re-targets its host collection page
-					// (keeping the pane open via `?item=`) instead of
-					// hard-navigating to the full-page item route. The
-					// destination triggers a fresh loadData() on arrival, so
-					// no explicit refresh here.
-					if (updated.slug !== collSlug && itemSlug) {
-						handleNavigateAway(
-							embedded
-								? `/${username}/${wsSlug}/${updated.slug}?item=${encodeURIComponent(itemSlug)}`
-								: `/${username}/${wsSlug}/${updated.slug}/${itemSlug}`,
-						);
-						return;
-					}
+					return;
 				}
-				// Non-navigating update (or the itemMatchesRef window):
-				// schema or field mappings may have changed (rename /
-				// migration), so reload the item so fields reflect the new
-				// shape. Without this, a subsequent updateField() would
-				// write stale fields JSON back and clobber migrated values.
+				collection = updated;
+				// If the owner renamed the collection, its slug may have
+				// changed. The current `/[collection]/[slug]` URL still
+				// points at the old slug and subsequent loadData() calls
+				// (which fetch by collSlug) would 404. Navigate to the new
+				// slug while preserving the item slug — routed through
+				// handleNavigateAway (PLAN-2105 / TASK-2112) so an embedded
+				// pane re-targets its host collection page (keeping the
+				// pane open via `?item=`) instead of hard-navigating to the
+				// full-page item route. The destination triggers a fresh
+				// loadData() on arrival, so no explicit refresh here. Reads
+				// `itemSlug` live (always current, whether or not
+				// loadData() has caught up) — correct for both the
+				// still-current and superseded-same-collection cases.
+				if (updated.slug !== collSlug && itemSlug) {
+					handleNavigateAway(
+						embedded
+							? `/${username}/${wsSlug}/${updated.slug}?item=${encodeURIComponent(itemSlug)}`
+							: `/${username}/${wsSlug}/${updated.slug}/${itemSlug}`,
+					);
+					return;
+				}
+				// Non-navigating update: schema or field mappings may have
+				// changed (rename / migration), so reload the item so
+				// fields reflect the new shape. Without this, a subsequent
+				// updateField() would write stale fields JSON back and
+				// clobber migrated values. Always safe to call even if
+				// another load is already in flight — loadData() is
+				// idempotent and gen-fenced against any in-flight load, so
+				// this can only supersede it with fresher data, never
+				// regress correctness.
 				void loadData();
 			}}
 			onclose={() => {

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -4173,6 +4173,21 @@
 			{wsSlug}
 			initialSection={editCollectionSection}
 			onupdated={(updated, editedCollectionId) => {
+				// Route/load-identity guard (Codex round 2). `itemMatchesRef`
+				// is the SAME "has loadData() caught up with the current
+				// route" invariant that gates collabKey and the SSE handlers
+				// elsewhere in this file. Between a route change (collSlug/
+				// itemSlug updating) and loadData()'s async resolution,
+				// `item`/`collection` can transiently still hold the
+				// PREVIOUS item's data while collSlug/itemSlug already
+				// reflect the new one — a mixed read across that window
+				// could pass the collection-id check below using the stale
+				// `item` but then build a navigation URL from the ALREADY-
+				// updated `collSlug`/`itemSlug`, hijacking to a broken
+				// mismatched URL. Bailing here is always safe: the route's
+				// own in-flight loadData() will fetch fresh state for
+				// wherever the user has actually landed.
+				if (!itemMatchesRef) return;
 				// Fence (BUG-2129): only act if the item CURRENTLY shown is
 				// still in the collection this save/archive targeted. Covers
 				// both directions —

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -745,7 +745,20 @@
 		});
 	});
 
+	// Set synchronously by onDestroy, checked by callbacks that can still be
+	// invoked AFTER this instance is torn down (a lingering closure from a
+	// still-pending promise — e.g. <EditCollectionModal>'s onupdated after
+	// the pane closed or the whole page navigated away mid-save). Unlike
+	// loadGeneration (which is about "has a NEWER load superseded this
+	// one" and gets reused/rechecked across the instance's live), this is
+	// a one-way "am I even still alive" flag — never reset, checked first
+	// by any handler whose global side effects (goto, collectionStore
+	// writes) would be wrong to run against a dead instance's stale
+	// closure-captured props (Codex PR review).
+	let destroyed = false;
+
 	onDestroy(() => {
+		destroyed = true;
 		unsubscribeSync?.();
 		unsubscribeSSE?.();
 		unsubscribeBeforePrint?.();
@@ -4172,8 +4185,23 @@
 			{collection}
 			{wsSlug}
 			initialSection={editCollectionSection}
-			onupdated={(updated, editedCollectionId, editedCollectionSlug) => {
-				if (!editedCollectionId || !editedCollectionSlug) return;
+			onupdated={(updated, editedCollectionId, editedCollectionSlug, editedWsSlug) => {
+				// This callback can fire long after this ItemDetail instance
+				// (and everything it's part of — the pane, the whole page)
+				// was torn down — e.g. the user closed the pane, or
+				// navigated away entirely, before a pending save resolved.
+				// The closure still runs (JS doesn't cancel promises on
+				// unmount), so without this guard a dead instance's stale
+				// props could still call goto()/collectionStore writes,
+				// visibly affecting whatever the user has since navigated
+				// to (Codex PR review).
+				if (destroyed) return;
+				if (!editedCollectionId || !editedCollectionSlug || !editedWsSlug) return;
+				// Collection slugs are workspace-scoped (two workspaces can
+				// both have a "docs" collection) — guard against a reused
+				// instance (workspace switched without a remount) matching
+				// on slug alone (Codex PR review).
+				if (wsSlug !== editedWsSlug) return;
 				// Keep the GLOBAL collections list (sidebar, pickers, etc.)
 				// fresh regardless of whether this pane/item is even
 				// affected — harmless and always correct.
@@ -4207,6 +4235,19 @@
 				//     instant the route changes): no match — a completed
 				//     edit for an abandoned collection must not touch
 				//     whatever the user has already navigated to.
+				//
+				// KNOWN LIMITATION (documented, not fixed here — deferred to
+				// PLAN-2154 Phase 1's TASK-2167 fence sweep): an embedded
+				// pane can be driven by a hand-crafted `?item=REF` whose
+				// item lives in a DIFFERENT collection than the host page's
+				// `collSlug` (loadData()'s cross-collection `?item=` safety
+				// refetch above handles this for rendering). Editing THAT
+				// item's real collection through this modal won't match
+				// `collSlug` and so won't trigger a reload here — a
+				// pre-existing edge case this fix doesn't regress against
+				// (the prior fence was dead code and refreshed
+				// unconditionally for ANY collection edit, relevant or
+				// not) but also doesn't newly solve.
 				if (collSlug !== editedCollectionSlug) return;
 				if (!updated) {
 					// Archive case — the collection is gone. Navigate away

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -279,6 +279,27 @@
 	let workspaceMembers = $state<{ user_id: string; user_name: string; user_email: string; role: string }[]>([]);
 	let shareDialogOpen = $state(false);
 	let editCollectionOpen = $state(false);
+	// Plain (non-reactive) snapshot of "which item was open when the owner
+	// launched the collection editor" — consumed by the <EditCollectionModal>
+	// onupdated fence below. NOT a {@const}/prop-derived capture: Svelte 5
+	// passes props (including callback props like `onupdated`) as live
+	// getters that re-evaluate the parent's binding expression on every
+	// read, so a {@const keyedSlug = itemSlug} (or an inline-IIFE "snapshot"
+	// inside the prop expression) is NOT actually frozen at render time —
+	// the child re-reads it fresh at CALL time, i.e. whenever the pending
+	// save resolves, which can be long after an intervening item switch.
+	// That silently defeats a fence that LOOKS like it freezes (confirmed
+	// by instrumentation during the BUG-2129 investigation: `{@const}` and
+	// prop-expression IIFEs both observed reading the CURRENT itemSlug/
+	// loadGeneration/item.id, not the value at the modal-open render).
+	// A plain top-level `let`, WRITTEN synchronously inside a real click
+	// handler (onmanage, below — fires synchronously on click, never after
+	// an async gap) and READ synchronously inside another real callback
+	// (onupdated), is genuine JS variable semantics with no signal/getter
+	// indirection, matching the gen+id capture pattern used everywhere
+	// else in this file (loadData, updateField, the SSE handlers).
+	let pendingCollectionEditGen = 0;
+	let pendingCollectionEditItemId: string | undefined;
 
 	// Per-item dependency graph drawer (PLAN-1780 / TASK-1784). The renderer
 	// (and its dagre layout lib) are dynamically imported on first open so they
@@ -3407,6 +3428,13 @@
 						{wsSlug}
 						canEdit={isOwner}
 						onmanage={() => {
+							// Synchronous capture (fires on click, never after an
+							// async gap) — the freeze the EditCollectionModal
+							// onupdated fence below relies on. See the
+							// pendingCollectionEditGen/-ItemId declaration for why
+							// this can't be a {@const} in the modal's own markup.
+							pendingCollectionEditGen = loadGeneration;
+							pendingCollectionEditItemId = item?.id;
 							editCollectionSection = 'actions';
 							editCollectionOpen = true;
 						}}
@@ -4156,21 +4184,45 @@
 
 	{#if isOwner && collection}
 		<!-- {#key itemSlug}: remount the owner collection-editor modal on item
-		     switch (it's closed on switch anyway; keeps its async loads scoped). -->
+		     switch (it's closed on switch anyway; keeps its async loads scoped
+		     and its OWN in-progress edits from leaking across items). The
+		     onupdated fence below does NOT depend on this remount for
+		     correctness (see pendingCollectionEditGen/-ItemId) — a stale
+		     instance's in-flight save keeps running after this block is torn
+		     down regardless, same as any other JS promise. -->
 		{#key itemSlug}
-		<!-- Capture item identity at THIS render so a destroyed A-instance's
-		     completed save/archive can't reload / navigate / close B's pane
-		     after the switch (PLAN-2105 / TASK-2112; coordinator). -->
-		{@const keyedSlug = itemSlug}
 		<EditCollectionModal
 			bind:open={editCollectionOpen}
 			{collection}
 			{wsSlug}
 			initialSection={editCollectionSection}
 			onupdated={(updated) => {
-				// Parent-side switch fence: drop a callback from a superseded
-				// item's modal instance (don't reload/navigate/close B's pane).
-				if (keyedSlug !== itemSlug) return;
+				// Switch fence (BUG-2129): was the pane still showing the item
+				// this collection edit was launched from? Compared against the
+				// pendingCollectionEditGen/-ItemId snapshot taken synchronously
+				// in onmanage (see its declaration for why {@const}/prop-
+				// expression captures can't do this freeze reliably in Svelte 5).
+				const superseded =
+					pendingCollectionEditGen !== loadGeneration || item?.id !== pendingCollectionEditItemId;
+				if (superseded) {
+					// A genuinely superseded save must not navigate/close/
+					// archive-redirect the pane now showing a DIFFERENT item —
+					// that decision belongs to the abandoned route, not the
+					// current one. But dropping the callback outright (the
+					// pre-fix behavior) also skipped the field-shape refresh
+					// below, so a completed schema/field migration left the
+					// current pane holding PRE-migration `fields`; the next
+					// updateField() then serialized that stale blob straight
+					// back over the migrated values (BUG-2129). Minimal safe
+					// fix: if the currently-shown item is still in the
+					// collection that just changed, refresh it too.
+					if (updated && item?.collection_id === updated.id) {
+						collection = updated;
+						collectionStore.loadCollections(wsSlug);
+						void loadData();
+					}
+					return;
+				}
 				if (!updated) {
 					// Archive case — the collection is gone. Navigate away from
 					// this now-invalid item route rather than leaving the user

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -4173,83 +4173,92 @@
 			{wsSlug}
 			initialSection={editCollectionSection}
 			onupdated={(updated, editedCollectionId) => {
-				// Route/load-identity guard (Codex round 2). `itemMatchesRef`
-				// is the SAME "has loadData() caught up with the current
-				// route" invariant that gates collabKey and the SSE handlers
-				// elsewhere in this file. Between a route change (collSlug/
-				// itemSlug updating) and loadData()'s async resolution,
-				// `item`/`collection` can transiently still hold the
-				// PREVIOUS item's data while collSlug/itemSlug already
-				// reflect the new one — a mixed read across that window
-				// could pass the collection-id check below using the stale
-				// `item` but then build a navigation URL from the ALREADY-
-				// updated `collSlug`/`itemSlug`, hijacking to a broken
-				// mismatched URL. Bailing here is always safe: the route's
-				// own in-flight loadData() will fetch fresh state for
-				// wherever the user has actually landed.
-				if (!itemMatchesRef) return;
-				// Fence (BUG-2129): only act if the item CURRENTLY shown is
-				// still in the collection this save/archive targeted. Covers
-				// both directions —
+				if (!editedCollectionId) return;
+				// Keep the GLOBAL collections list (sidebar, pickers, etc.)
+				// fresh regardless of whether this pane/item is even
+				// affected — harmless and always correct.
+				collectionStore.loadCollections(wsSlug);
+
+				// Fence (BUG-2129): only act further if the item CURRENTLY
+				// known is in the collection this save/archive targeted.
+				// Covers both directions —
 				//   - still on the original item: trivially the same
 				//     collection, so this is a no-op behavior change from
 				//     before.
 				//   - superseded (pane moved to a different item, same
-				//     collection): apply the FULL handling (was previously
+				//     collection): apply the handling below (was previously
 				//     dropped outright, leaving stale fields — the literal
-				//     BUG-2129 gap — and would also have skipped a pending
-				//     rename/archive's navigation for the new item, per
-				//     Codex review).
-				//   - superseded, DIFFERENT collection: no-op — a completed
-				//     edit for an abandoned item/collection must not
-				//     navigate/close/replace-fields on whatever the user is
-				//     now looking at.
-				if (!editedCollectionId || item?.collection_id !== editedCollectionId) return;
-				if (!updated) {
-					// Archive case — the collection is gone. Navigate away from
-					// this now-invalid item route rather than leaving the user
-					// with stale state that would hit deleted resources.
-					// Route-away is parameterized (PLAN-2105 / TASK-2112): an
-					// embedded pane closes in place (the collection page
-					// reconciles the archive itself) instead of hard-navigating
-					// the whole page; full-page returns to the workspace root.
-					collectionStore.loadCollections(wsSlug);
-					if (embedded) {
-						handleGone();
-					} else {
-						void goto(`/${username}/${wsSlug}`);
+				//     BUG-2129 gap).
+				//   - superseded, DIFFERENT collection: no-op below — a
+				//     completed edit for an abandoned item/collection must
+				//     not touch whatever the user is now looking at.
+				// `item` can be MID-TRANSITION (still holding the PREVIOUS
+				// item's data) if a route change is in flight — see the
+				// itemMatchesRef gates below for why that's handled
+				// separately rather than bailing out entirely here (Codex).
+				if (item?.collection_id !== editedCollectionId) return;
+				if (updated) collection = updated;
+
+				// Route-changing side effects (rename-redirect / archive-
+				// redirect) are gated on `itemMatchesRef` — the SAME "has
+				// loadData() caught up with the current route" invariant
+				// that gates collabKey and the SSE handlers elsewhere in
+				// this file. Between a route change (collSlug/itemSlug
+				// updating) and loadData()'s async resolution, `item` above
+				// can still be stale (the PREVIOUS item) while collSlug/
+				// itemSlug already reflect the new one — building a
+				// navigation URL from that mix would hijack to a broken,
+				// mismatched URL (Codex). Skip navigation in that window;
+				// `void loadData()` below is unconditionally safe to call
+				// instead — it's idempotent and gen-fenced against any
+				// in-flight load (see loadData's `myGen` checks), so calling
+				// it again while a same-route load is still pending can only
+				// help (superseding it with fresher data) and never regress
+				// correctness. That's exactly what closes BUG-2129's
+				// stale-fields gap when an in-flight load raced the
+				// migration and lost.
+				if (itemMatchesRef) {
+					if (!updated) {
+						// Archive case — the collection is gone. Navigate
+						// away from this now-invalid item route rather than
+						// leaving the user with stale state that would hit
+						// deleted resources. Route-away is parameterized
+						// (PLAN-2105 / TASK-2112): an embedded pane closes in
+						// place (the collection page reconciles the archive
+						// itself) instead of hard-navigating the whole page;
+						// full-page returns to the workspace root.
+						if (embedded) {
+							handleGone();
+						} else {
+							void goto(`/${username}/${wsSlug}`);
+						}
+						return;
 					}
-					return;
+					// If the owner renamed the collection, its slug may have
+					// changed. The current `/[collection]/[slug]` URL still
+					// points at the old slug and subsequent loadData() calls
+					// (which fetch by collSlug) would 404. Navigate to the
+					// new slug while preserving the item slug — routed
+					// through handleNavigateAway (PLAN-2105 / TASK-2112) so
+					// an embedded pane re-targets its host collection page
+					// (keeping the pane open via `?item=`) instead of
+					// hard-navigating to the full-page item route. The
+					// destination triggers a fresh loadData() on arrival, so
+					// no explicit refresh here.
+					if (updated.slug !== collSlug && itemSlug) {
+						handleNavigateAway(
+							embedded
+								? `/${username}/${wsSlug}/${updated.slug}?item=${encodeURIComponent(itemSlug)}`
+								: `/${username}/${wsSlug}/${updated.slug}/${itemSlug}`,
+						);
+						return;
+					}
 				}
-				collection = updated;
-				collectionStore.loadCollections(wsSlug);
-				// If the owner renamed the collection, its slug may have
-				// changed. The current `/[collection]/[slug]` URL still
-				// points at the old slug and subsequent loadData() calls
-				// (which fetch by collSlug) would 404. Navigate to the
-				// new slug while preserving the item slug — routed through
-				// handleNavigateAway (PLAN-2105 / TASK-2112) so an embedded
-				// pane re-targets its host collection page (keeping the pane
-				// open via `?item=`) instead of hard-navigating to the
-				// full-page item route. The destination triggers a fresh
-				// loadData() on arrival, so no explicit refresh here. Reads
-				// `itemSlug`/`collSlug` live (not frozen) — correct for both
-				// the still-current and superseded-same-collection cases,
-				// since either way this must target whatever is CURRENTLY
-				// displayed.
-				if (updated.slug !== collSlug && itemSlug) {
-					handleNavigateAway(
-						embedded
-							? `/${username}/${wsSlug}/${updated.slug}?item=${encodeURIComponent(itemSlug)}`
-							: `/${username}/${wsSlug}/${updated.slug}/${itemSlug}`,
-					);
-					return;
-				}
-				// Non-navigating update: schema or field mappings may have
-				// changed (rename / migration), so reload the item so fields
-				// reflect the new shape. Without this, a subsequent
-				// updateField() would write stale fields JSON back and
-				// clobber migrated values.
+				// Non-navigating update (or the itemMatchesRef window):
+				// schema or field mappings may have changed (rename /
+				// migration), so reload the item so fields reflect the new
+				// shape. Without this, a subsequent updateField() would
+				// write stale fields JSON back and clobber migrated values.
 				void loadData();
 			}}
 			onclose={() => {


### PR DESCRIPTION
## Summary

Closes TASK-2155 (PLAN-2154 Phase 0). Adds regression coverage for the split-pane switch-safety fence and closes the specific BUG-2129 gap: a stale-field `updateField` clobber when a collection schema migration races a rapid item switch.

**Root cause (deeper than BUG-2129's original write-up):** the `<EditCollectionModal>` `onupdated` callback in `ItemDetail.svelte` used `{@const keyedSlug = itemSlug}` to detect whether a completed save was "superseded" by an item switch. That pattern doesn't actually freeze anything — Svelte 5 compiles `{@const}` bindings (and closures baked into a prop expression, e.g. an inline IIFE) as lazily-pulled derived signals. Since `keyedSlug` was only ever read inside the async `onupdated` closure, the signal was never "pulled" until the closure actually ran — at which point it read the *current* `itemSlug`, not the value at modal-open time. Confirmed empirically via runtime instrumentation (console logging + stack traces): `keyedSlug` and `itemSlug` were byte-identical at every firing, in both the pre-fix code and a naive "fixed" version that used the same pattern — meaning the "switch fence" for this callback was silently dead code.

**Fix:** `EditCollectionModal` now captures its own `collection`/`wsSlug` props synchronously (before its API call, inside a real event handler — genuine JS variable semantics, no signal/getter indirection) and echoes back `editedCollectionId`/`editedCollectionSlug`/`editedWsSlug` as plain function arguments to `onupdated`. `ItemDetail`'s fence compares `collSlug` (a plain reactive prop that updates synchronously with route changes, unlike `item`/`collection` which lag behind an async `loadData()`) against `editedCollectionSlug`, plus a `destroyed`-instance guard and workspace-scoping. This is correct in every case:
- still on the original item → trivially matches (collSlug unchanged)
- superseded, same collection (pane switch within one collection page) → still matches (collSlug is fixed per pane) → the migration reload, rename-redirect, and archive-redirect all now fire correctly for the new item
- superseded, different collection (cross-collection full-page navigation) → no longer matches (collSlug already updated) → correctly no-ops instead of hijacking navigation
- instance torn down entirely while a save was pending → `destroyed` flag short-circuits before any global side effect (goto/collectionStore write)

## What/Why

- `web/src/lib/components/collections/EditCollectionModal.svelte`: `onupdated` now takes `(updated?, editedCollectionId?, editedCollectionSlug?, editedWsSlug?)`; all captured synchronously before the API call in `handleSave`/`handleArchive`.
- `web/src/lib/components/items/ItemDetail.svelte`: replaced the non-functional `{@const keyedSlug}` fence with the `collSlug === editedCollectionSlug` (+ workspace + destroyed-instance) check described above.
- `web/e2e/pane-collection-migration-race.spec.ts` (new): two regression tests —
  1. Same-collection pane switch (BUG-2129's literal repro) — asserts the post-migration reload happens and a subsequent field edit doesn't clobber the migrated value.
  2. Cross-collection full-page navigation — the test that actually **discriminates** the fix (verified via mutation testing, repeated after every design iteration: fails on the pre-fix code with an observable wrong-page hijack; passes on the fix).
- `web/e2e/lib/collab-helpers.ts`: `seedDoc` now accepts an optional `fields` param and returns `id` (needed by the new spec).

## Gates

- `npm run check` (svelte-check): **0 errors** (8 pre-existing warnings, unrelated).
- New e2e spec (`pane-collection-migration-race.spec.ts`, 2 tests): **passing**, run repeatedly for stability.
- Existing pane e2e suite (`pane-collab-teardown`, `pane-a11y-focus`, `pane-mobile-overlay`): **all passing**, no regressions.
- Mutation-tested against `main`'s pre-fix code (reverting just the two `.svelte` files and rebuilding) after every design iteration — the cross-collection test fails with the exact predicted symptom (URL hijacked to a broken `{old-collection-slug}/{new-item-ref}` combination) every time, confirming the test is a real regression guard, not a false-pass.

## Codex review

6 rounds total (4 pre-PR + 2 PR-level), each finding a real (if progressively narrower) correctness gap that got fixed and re-verified:
1. Initial fix — shared-mutable-slot could be overwritten by a second concurrent save; rename/archive not handled in the superseded-but-relevant case.
2. Threaded `editedCollectionId` through the modal's own callback args — a route/item mixed-read window could still cause a hijack.
3. Added an `itemMatchesRef` gate — too broad, suppressed the legitimate corrective reload during a route transition.
4. Split reload (always safe) from navigation (gated) — same-collection rename/archive could still be missed during the transition window.
5. Replaced the item-state fence with the `collSlug`-based one (resolves rounds 2-4 with one simpler check) — PR opened here.
6. PR-level review found two more gaps: a destroyed-instance guard, and workspace-scoping (collection slugs collide across workspaces) — both fixed.

**Final round: one P2 finding remains, deliberately deferred** (documented in the code and here): an embedded pane can be driven by a hand-crafted `?item=` whose item lives in a different collection than the host page's `collSlug`. Editing THAT item's real collection won't match this fence and so won't trigger a reload. This does **not** regress anything — the prior fence was dead code and refreshed unconditionally regardless of relevance — it's a pre-existing-adjacent edge case, squarely in PLAN-2154 Phase 1's dedicated scope (TASK-2167, "R14 fence-on-continuation sweep") rather than this Phase 0 fix.

Closes TASK-2155. References BUG-2129.

https://claude.ai/code/session_01EZ6yr6pAUFb1uffan912ra