### PR TITLE
feat(web): onOpenTarget(PaneTarget) callback contract + central resolution + same-item guard

### DIFF
--- a/web/src/lib/collections/paneTarget.test.ts
+++ b/web/src/lib/collections/paneTarget.test.ts
@@ -163,6 +163,20 @@ describe('isSamePaneTarget — same-item guard', () => {
 		// though the trailing ref segment is identical.
 		expect(isSamePaneTarget({ href: '/-/r/other-workspace/TASK-5' }, task5)).toBe(false);
 	});
+
+	it('a ref-sourced candidate is judged ONLY as a ref, never falling through to a raw slug compare', () => {
+		// The exact collision Codex's PR-diff pass flagged: current is
+		// slugged "plan-6" but numbered 5; a target explicitly carrying
+		// `{ ref: "plan-6" }` names a DIFFERENT item (number 6) and must NOT
+		// be swallowed as a same-item alias just because the ref string
+		// happens to equal current's slug — that would silently drop a
+		// legitimate navigation.
+		const current = item({ id: 'id-9', slug: 'plan-6', item_number: 5, collection_prefix: 'TASK' });
+		expect(isSamePaneTarget({ ref: 'plan-6' }, current)).toBe(false);
+		// A slug-sourced candidate is likewise judged only as a slug: it
+		// still matches when it's genuinely current's own slug.
+		expect(isSamePaneTarget({ slug: 'plan-6' }, current)).toBe(true);
+	});
 });
 
 describe('resolvePaneTarget — same-item guard short-circuits to null', () => {

--- a/web/src/lib/collections/paneTarget.test.ts
+++ b/web/src/lib/collections/paneTarget.test.ts
@@ -48,6 +48,15 @@ describe('resolvePaneTarget — candidate extraction (no current item)', () => {
 		expect(resolvePaneTarget({ href: '' })).toBeNull();
 		expect(resolvePaneTarget({ href: '/' })).toBeNull();
 	});
+
+	it('refuses a cross-workspace resolver href (/-/r/{workspace}/{ref}) rather than misreading its trailing ref as local', () => {
+		// wikiLinksToMarkdown/renderMarkdown emit this shape for [[otherWs::REF]]
+		// links. Taking the trailing segment at face value would drill the
+		// CURRENT workspace's pane to a same-numbered local item — the wrong
+		// item. This link shape must fall through to a normal navigation
+		// instead (Codex review).
+		expect(resolvePaneTarget({ href: '/-/r/other-workspace/TASK-9' })).toBeNull();
+	});
 });
 
 describe('isSamePaneTarget — same-item guard', () => {
@@ -108,6 +117,12 @@ describe('isSamePaneTarget — same-item guard', () => {
 
 	it('a ref-shaped candidate with the right prefix but wrong number is a different item', () => {
 		expect(isSamePaneTarget({ ref: 'TASK-6' }, task5)).toBe(false);
+	});
+
+	it('a cross-workspace resolver href never false-positives, even when the numbers coincide', () => {
+		// A different workspace's TASK-5 is NOT this workspace's task5, even
+		// though the trailing ref segment is identical.
+		expect(isSamePaneTarget({ href: '/-/r/other-workspace/TASK-5' }, task5)).toBe(false);
 	});
 });
 

--- a/web/src/lib/collections/paneTarget.test.ts
+++ b/web/src/lib/collections/paneTarget.test.ts
@@ -148,6 +148,16 @@ describe('isSamePaneTarget — same-item guard', () => {
 		expect(isSamePaneTarget({ ref: 'TASK-6' }, task5)).toBe(false);
 	});
 
+	it('does NOT treat a digit-bearing slug as a ref, even when its trailing number coincides', () => {
+		// The server's parseItemRef requires a LETTERS-ONLY prefix (no digits);
+		// a slug like "roadmap2-5" is not ref-shaped by that grammar and must
+		// stay a plain slug candidate — not misread as ref number 5, which
+		// would false-positive against an unrelated item TASK-5 (Codex review
+		// — PR diff pass).
+		expect(isSamePaneTarget({ slug: 'roadmap2-5' }, task5)).toBe(false);
+		expect(isSamePaneTarget({ href: '/alice/myws/docs/roadmap2-5' }, task5)).toBe(false);
+	});
+
 	it('a cross-workspace resolver href never false-positives, even when the numbers coincide', () => {
 		// A different workspace's TASK-5 is NOT this workspace's task5, even
 		// though the trailing ref segment is identical.

--- a/web/src/lib/collections/paneTarget.test.ts
+++ b/web/src/lib/collections/paneTarget.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from 'vitest';
+import type { Item, PaneTarget } from '$lib/types';
+import { resolvePaneTarget, isSamePaneTarget } from './paneTarget';
+
+// Minimal Item stand-in — resolution/guard only touch id/slug/item_number/
+// collection_prefix (the fields `formatItemRef`/`itemUrlId` read).
+function item(opts: {
+	id: string;
+	slug: string;
+	item_number?: number;
+	collection_prefix?: string;
+}): Item {
+	return {
+		id: opts.id,
+		slug: opts.slug,
+		item_number: opts.item_number,
+		collection_prefix: opts.collection_prefix,
+	} as unknown as Item;
+}
+
+const task5 = item({ id: 'id-1', slug: 'task-5-slug', item_number: 5, collection_prefix: 'TASK' });
+const noRefItem = item({ id: 'id-2', slug: 'legacy-item' }); // no item_number → formatItemRef is null
+
+describe('resolvePaneTarget — candidate extraction (no current item)', () => {
+	it('prefers ref over slug over href', () => {
+		expect(resolvePaneTarget({ ref: 'TASK-9', slug: 'other-slug', href: '/a/b/c/other' })).toBe(
+			'TASK-9',
+		);
+	});
+
+	it('falls back to slug when no ref', () => {
+		expect(resolvePaneTarget({ slug: 'my-slug', href: '/a/b/c/other' })).toBe('my-slug');
+	});
+
+	it('falls back to an href trailing segment when no ref/slug', () => {
+		expect(resolvePaneTarget({ href: '/alice/myws/tasks/TASK-9' })).toBe('TASK-9');
+	});
+
+	it('strips query/hash and trailing slash from an href', () => {
+		expect(resolvePaneTarget({ href: '/alice/myws/tasks/TASK-9?foo=1' })).toBe('TASK-9');
+		expect(resolvePaneTarget({ href: '/alice/myws/tasks/TASK-9#section' })).toBe('TASK-9');
+		expect(resolvePaneTarget({ href: '/alice/myws/tasks/TASK-9/' })).toBe('TASK-9');
+	});
+
+	it('returns null when the target carries nothing resolvable', () => {
+		expect(resolvePaneTarget({})).toBeNull();
+		expect(resolvePaneTarget({ collectionSlug: 'tasks' })).toBeNull();
+		expect(resolvePaneTarget({ href: '' })).toBeNull();
+		expect(resolvePaneTarget({ href: '/' })).toBeNull();
+	});
+});
+
+describe('isSamePaneTarget — same-item guard', () => {
+	it('is false with no current item', () => {
+		expect(isSamePaneTarget({ ref: 'TASK-5' }, null)).toBe(false);
+		expect(isSamePaneTarget({ ref: 'TASK-5' }, undefined)).toBe(false);
+	});
+
+	it('matches by ref', () => {
+		expect(isSamePaneTarget({ ref: 'TASK-5' }, task5)).toBe(true);
+	});
+
+	it('SLUG-vs-REF alias: a target naming the item by slug matches even though the item is shown by its ref', () => {
+		// The classic alias case TASK-2158 guards against: the pane is showing
+		// task5 (which itemUrlId would open under its REF, "TASK-5"), but a
+		// link surface names the same item by its SLUG instead.
+		expect(isSamePaneTarget({ slug: task5.slug }, task5)).toBe(true);
+	});
+
+	it('an item with no ref (item_number unset) only matches by id/slug', () => {
+		expect(isSamePaneTarget({ ref: 'TASK-5' }, noRefItem)).toBe(false);
+		expect(isSamePaneTarget({ slug: 'legacy-item' }, noRefItem)).toBe(true);
+	});
+
+	it('matches by id when the target resolves an id-shaped candidate', () => {
+		expect(isSamePaneTarget({ ref: task5.id }, task5)).toBe(true);
+	});
+
+	it('matches via an href whose trailing segment is the ref or slug', () => {
+		expect(isSamePaneTarget({ href: '/alice/myws/tasks/TASK-5' }, task5)).toBe(true);
+		expect(isSamePaneTarget({ href: '/alice/myws/tasks/task-5-slug' }, task5)).toBe(true);
+	});
+
+	it('is false for a genuinely different item', () => {
+		const other = item({ id: 'id-3', slug: 'other-slug', item_number: 9, collection_prefix: 'TASK' });
+		expect(isSamePaneTarget({ ref: 'TASK-5' }, other)).toBe(false);
+		expect(isSamePaneTarget({ slug: 'task-5-slug' }, other)).toBe(false);
+	});
+
+	it('is false when the target resolves to nothing', () => {
+		expect(isSamePaneTarget({}, task5)).toBe(false);
+	});
+});
+
+describe('resolvePaneTarget — same-item normalization', () => {
+	it('normalizes a slug-alias of the current item to its own canonical ref', () => {
+		// target names task5 by slug; task5 is showing under its ref form.
+		const target: PaneTarget = { slug: 'task-5-slug' };
+		expect(resolvePaneTarget(target, task5)).toBe('TASK-5');
+	});
+
+	it('normalizes a ref-alias of the current item to its own canonical ref', () => {
+		const target: PaneTarget = { ref: 'TASK-5' };
+		expect(resolvePaneTarget(target, task5)).toBe('TASK-5');
+	});
+
+	it('falls back to the raw candidate for a different item even with a current item present', () => {
+		const target: PaneTarget = { ref: 'TASK-9' };
+		expect(resolvePaneTarget(target, task5)).toBe('TASK-9');
+	});
+
+	it('normalizes to the slug when the current item has no ref', () => {
+		const target: PaneTarget = { slug: 'legacy-item' };
+		expect(resolvePaneTarget(target, noRefItem)).toBe('legacy-item');
+	});
+});

--- a/web/src/lib/collections/paneTarget.test.ts
+++ b/web/src/lib/collections/paneTarget.test.ts
@@ -92,16 +92,24 @@ describe('isSamePaneTarget — same-item guard', () => {
 	});
 });
 
-describe('resolvePaneTarget — same-item normalization', () => {
-	it('normalizes a slug-alias of the current item to its own canonical ref', () => {
+describe('resolvePaneTarget — same-item guard short-circuits to null', () => {
+	it('a slug-alias of the current item resolves to null (no-op), not a ref/slug string', () => {
 		// target names task5 by slug; task5 is showing under its ref form.
+		// Returning task5's own ref here (rather than null) could itself
+		// mismatch the pane's actual open `?item=` value if that happens to be
+		// slug-shaped (e.g. a shared/deep-linked URL) — see paneTarget.ts.
 		const target: PaneTarget = { slug: 'task-5-slug' };
-		expect(resolvePaneTarget(target, task5)).toBe('TASK-5');
+		expect(resolvePaneTarget(target, task5)).toBeNull();
 	});
 
-	it('normalizes a ref-alias of the current item to its own canonical ref', () => {
+	it('a ref-alias of the current item resolves to null (no-op)', () => {
 		const target: PaneTarget = { ref: 'TASK-5' };
-		expect(resolvePaneTarget(target, task5)).toBe('TASK-5');
+		expect(resolvePaneTarget(target, task5)).toBeNull();
+	});
+
+	it('an id-alias of the current item resolves to null (no-op)', () => {
+		const target: PaneTarget = { ref: task5.id };
+		expect(resolvePaneTarget(target, task5)).toBeNull();
 	});
 
 	it('falls back to the raw candidate for a different item even with a current item present', () => {
@@ -109,8 +117,8 @@ describe('resolvePaneTarget — same-item normalization', () => {
 		expect(resolvePaneTarget(target, task5)).toBe('TASK-9');
 	});
 
-	it('normalizes to the slug when the current item has no ref', () => {
+	it('resolves normally (no guard) when current has no matching id/ref/slug', () => {
 		const target: PaneTarget = { slug: 'legacy-item' };
-		expect(resolvePaneTarget(target, noRefItem)).toBe('legacy-item');
+		expect(resolvePaneTarget(target, task5)).toBe('legacy-item');
 	});
 });

--- a/web/src/lib/collections/paneTarget.test.ts
+++ b/web/src/lib/collections/paneTarget.test.ts
@@ -177,6 +177,14 @@ describe('isSamePaneTarget — same-item guard', () => {
 		// still matches when it's genuinely current's own slug.
 		expect(isSamePaneTarget({ slug: 'plan-6' }, current)).toBe(true);
 	});
+
+	it('an href-sourced ref-shaped candidate is likewise judged ONLY as a ref, not a slug fallback', () => {
+		// Same collision as above, via the href channel this time — a second
+		// Codex PR-diff round caught the href branch still checking slug
+		// before ref-shape.
+		const current = item({ id: 'id-9', slug: 'plan-6', item_number: 5, collection_prefix: 'TASK' });
+		expect(isSamePaneTarget({ href: '/alice/myws/plans/plan-6' }, current)).toBe(false);
+	});
 });
 
 describe('resolvePaneTarget — same-item guard short-circuits to null', () => {

--- a/web/src/lib/collections/paneTarget.test.ts
+++ b/web/src/lib/collections/paneTarget.test.ts
@@ -90,6 +90,25 @@ describe('isSamePaneTarget — same-item guard', () => {
 	it('is false when the target resolves to nothing', () => {
 		expect(isSamePaneTarget({}, task5)).toBe(false);
 	});
+
+	it('matches a ref case-insensitively', () => {
+		expect(isSamePaneTarget({ ref: 'task-5' }, task5)).toBe(true);
+		expect(isSamePaneTarget({ ref: 'Task-5' }, task5)).toBe(true);
+	});
+
+	it('STALE-PREFIX alias: a ref-shaped candidate matches by item NUMBER alone, ignoring a stale prefix from before a collection move', () => {
+		// Mirrors the server's GetItemByRef fallback (item numbers are
+		// workspace-unique): a wiki-link written as "[[PLAN-5]]" before the
+		// item moved to the Tasks collection (now TASK-5, item_number 5) still
+		// names the same item — the guard must catch it, not push a redundant
+		// re-target (Codex review).
+		expect(isSamePaneTarget({ ref: 'PLAN-5' }, task5)).toBe(true);
+		expect(isSamePaneTarget({ ref: 'plan-5' }, task5)).toBe(true);
+	});
+
+	it('a ref-shaped candidate with the right prefix but wrong number is a different item', () => {
+		expect(isSamePaneTarget({ ref: 'TASK-6' }, task5)).toBe(false);
+	});
 });
 
 describe('resolvePaneTarget — same-item guard short-circuits to null', () => {

--- a/web/src/lib/collections/paneTarget.test.ts
+++ b/web/src/lib/collections/paneTarget.test.ts
@@ -57,6 +57,35 @@ describe('resolvePaneTarget — candidate extraction (no current item)', () => {
 		// instead (Codex review).
 		expect(resolvePaneTarget({ href: '/-/r/other-workspace/TASK-9' })).toBeNull();
 	});
+
+	it('refuses an ABSOLUTE cross-workspace resolver href too', () => {
+		// HTMLAnchorElement.href always returns the fully-resolved absolute
+		// URL, not the raw attribute — a future click-interceptor reading it
+		// off a live DOM anchor must still be caught (Codex review).
+		expect(
+			resolvePaneTarget({ href: 'http://localhost:5173/-/r/other-workspace/TASK-9' }),
+		).toBeNull();
+		expect(resolvePaneTarget({ href: 'https://mypad.example.com/-/r/other/TASK-9' })).toBeNull();
+	});
+
+	it('distrusts the WHOLE target (including ref/slug) when href signals cross-workspace', () => {
+		// A target that carries both a `ref` and a cross-workspace `href`
+		// contradicts this type's own contract — the href is unambiguous
+		// evidence of non-locality, so it wins rather than risk opening
+		// whatever local item `ref` happens to name (Codex review).
+		expect(
+			resolvePaneTarget({ ref: 'TASK-9', href: '/-/r/other-workspace/TASK-9' }),
+		).toBeNull();
+		expect(
+			resolvePaneTarget({ slug: 'some-slug', href: '/-/r/other-workspace/TASK-9' }),
+		).toBeNull();
+	});
+
+	it('still resolves a same-workspace ABSOLUTE href normally', () => {
+		expect(resolvePaneTarget({ href: 'http://localhost:5173/alice/myws/tasks/TASK-9' })).toBe(
+			'TASK-9',
+		);
+	});
 });
 
 describe('isSamePaneTarget — same-item guard', () => {

--- a/web/src/lib/collections/paneTarget.ts
+++ b/web/src/lib/collections/paneTarget.ts
@@ -126,10 +126,11 @@ function matchesRefNumber(candidate: string, current: Item): boolean {
  * target `{ ref: "plan-6" }` names some OTHER item numbered 6) and wrongly
  * suppress a valid navigation. A `slug`-sourced candidate is likewise
  * judged only as a slug (or id). An `href`-sourced candidate carries no
- * declared identity — its trailing segment could be either shape — so both
- * are tried, matching the server's own ambiguous-string resolution order
- * for a bare `?item=` value (PLAN-2154 / TASK-2158; Codex review — PR diff
- * pass).
+ * declared identity — its trailing segment could be EITHER shape — so it's
+ * tried as a ref FIRST when it's ref-shaped (never falling through to the
+ * slug compare in that case either), and as a slug only when it isn't;
+ * this mirrors the server's own ref-before-slug resolution order for a bare
+ * `?item=` value (PLAN-2154 / TASK-2158; Codex review — PR diff pass, x2).
  *
  * `current` is optional/nullable so callers that don't have a loaded item
  * in hand (e.g. the collection host, which only sees the target) can call
@@ -150,9 +151,15 @@ export function isSamePaneTarget(target: PaneTarget, current: Item | null | unde
 	if (target.href) {
 		const candidate = lastHrefSegment(target.href);
 		if (!candidate) return false;
-		return (
-			candidate === current.id || candidate === current.slug || matchesRefNumber(candidate, current)
-		);
+		if (candidate === current.id) return true;
+		// Ref-shaped candidates are evaluated ONLY as refs — mirroring the
+		// server's ref-before-slug resolution order — never falling through
+		// to a slug compare that could coincidentally match current.slug's
+		// literal string while the ref actually names a DIFFERENT item (the
+		// same collision fixed above for `target.ref`, now made consistent
+		// for the href channel too; Codex review — PR diff pass).
+		if (REF_SHAPE.test(candidate)) return matchesRefNumber(candidate, current);
+		return candidate === current.slug;
 	}
 	return false;
 }

--- a/web/src/lib/collections/paneTarget.ts
+++ b/web/src/lib/collections/paneTarget.ts
@@ -60,9 +60,13 @@ function lastHrefSegment(href: string): string | null {
 }
 
 // Ref-shaped candidate: PREFIX-NUMBER. Mirrors `internal/store/items.go`'s
-// `parseItemRef` closely enough for guard purposes — case-insensitive
-// letter/digit prefix, a hyphen, then a positive integer suffix.
-const REF_SHAPE = /^([A-Za-z][A-Za-z0-9]*)-(\d+)$/;
+// `parseItemRef` — case-insensitive LETTERS-ONLY prefix (no digits; the
+// server's own loop rejects any non-A-Z byte in the prefix), a hyphen, then
+// a positive integer suffix. A looser digit-permitting prefix would
+// misclassify a digit-bearing slug like "roadmap2-5" as ref number 5 and
+// false-positive the same-item guard against an unrelated item TASK-5
+// (Codex review — PR diff pass).
+const REF_SHAPE = /^([A-Za-z]+)-(\d+)$/;
 
 /** Parse a ref-shaped candidate's item NUMBER (case-insensitive; prefix is
  *  discarded — see `isSamePaneTarget`). Null for a non-ref-shaped string or

--- a/web/src/lib/collections/paneTarget.ts
+++ b/web/src/lib/collections/paneTarget.ts
@@ -16,14 +16,30 @@
 
 import type { Item, PaneTarget } from '$lib/types';
 
+// The cross-workspace wiki-link resolver route, `/-/r/{workspace}/{ref}`
+// (`wikiLinksToMarkdown`/`renderMarkdown` in `$lib/utils/markdown`). Its
+// trailing segment IS a ref, but for a possibly-DIFFERENT workspace — taking
+// it at face value would drill the CURRENT workspace's pane to a same-
+// numbered local item (wrong item), or false-positive the same-item guard
+// when the numbers happen to coincide. The `/-/r/` sentinel can't appear in
+// a same-workspace item URL (those are always `/{username}/{workspace}/...`,
+// and usernames are letter-led — see `markdownToWikiLinks`), so it's an
+// unambiguous signal to treat the href as NOT pane-resolvable.
+const CROSS_WORKSPACE_HREF_PREFIX = '/-/r/';
+
 /**
- * Extract the trailing path segment of an internal item href, e.g.
- * "/alice/myws/tasks/TASK-5" -> "TASK-5", "/alice/myws/tasks/TASK-5/" ->
- * "TASK-5". Query string / hash are stripped first. Null for an href with
- * no non-empty segment (e.g. "", "/").
+ * Extract the trailing path segment of a SAME-WORKSPACE internal item href,
+ * e.g. "/alice/myws/tasks/TASK-5" -> "TASK-5", "/alice/myws/tasks/TASK-5/"
+ * -> "TASK-5". Query string / hash are stripped first. Null for an href
+ * with no non-empty segment (e.g. "", "/") or for a cross-workspace
+ * resolver href (`/-/r/{workspace}/{ref}` — see
+ * `CROSS_WORKSPACE_HREF_PREFIX`), which this deliberately refuses to
+ * resolve rather than risk opening the wrong item (PLAN-2154 / TASK-2158;
+ * Codex review).
  */
 function lastHrefSegment(href: string): string | null {
 	const path = href.split(/[?#]/)[0];
+	if (path.startsWith(CROSS_WORKSPACE_HREF_PREFIX)) return null;
 	const segments = path.split('/').filter(Boolean);
 	return segments.length > 0 ? segments[segments.length - 1] : null;
 }

--- a/web/src/lib/collections/paneTarget.ts
+++ b/web/src/lib/collections/paneTarget.ts
@@ -24,22 +24,37 @@ import type { Item, PaneTarget } from '$lib/types';
 // when the numbers happen to coincide. The `/-/r/` sentinel can't appear in
 // a same-workspace item URL (those are always `/{username}/{workspace}/...`,
 // and usernames are letter-led — see `markdownToWikiLinks`), so it's an
-// unambiguous signal to treat the href as NOT pane-resolvable.
+// unambiguous signal to treat the WHOLE target as not pane-resolvable.
 const CROSS_WORKSPACE_HREF_PREFIX = '/-/r/';
+
+// A throwaway base so `href` can be parsed with the `URL` API regardless of
+// shape — root-relative ("/-/r/…", what every href BUILDER in this codebase
+// emits) or absolute ("http://host/-/r/…", what `HTMLAnchorElement.href`
+// ALWAYS returns when a future click-interceptor reads it off a live DOM
+// anchor rather than its raw attribute). Comparing `.pathname` after parsing
+// catches both uniformly; a raw `string.startsWith` on the href only catches
+// the root-relative case (Codex review).
+const HREF_PARSE_BASE = 'http://pad.invalid';
+
+/** True when `href` is (or resolves to) the cross-workspace resolver route. */
+function isCrossWorkspaceHref(href: string): boolean {
+	try {
+		return new URL(href, HREF_PARSE_BASE).pathname.startsWith(CROSS_WORKSPACE_HREF_PREFIX);
+	} catch {
+		return false;
+	}
+}
 
 /**
  * Extract the trailing path segment of a SAME-WORKSPACE internal item href,
  * e.g. "/alice/myws/tasks/TASK-5" -> "TASK-5", "/alice/myws/tasks/TASK-5/"
  * -> "TASK-5". Query string / hash are stripped first. Null for an href
- * with no non-empty segment (e.g. "", "/") or for a cross-workspace
- * resolver href (`/-/r/{workspace}/{ref}` — see
- * `CROSS_WORKSPACE_HREF_PREFIX`), which this deliberately refuses to
- * resolve rather than risk opening the wrong item (PLAN-2154 / TASK-2158;
- * Codex review).
+ * with no non-empty segment (e.g. "", "/"). Callers must check
+ * `isCrossWorkspaceHref` first — this function only strips the path, it
+ * doesn't re-validate workspace locality.
  */
 function lastHrefSegment(href: string): string | null {
 	const path = href.split(/[?#]/)[0];
-	if (path.startsWith(CROSS_WORKSPACE_HREF_PREFIX)) return null;
 	const segments = path.split('/').filter(Boolean);
 	return segments.length > 0 ? segments[segments.length - 1] : null;
 }
@@ -64,8 +79,18 @@ function parseRefNumber(candidate: string): number | null {
  * same-item normalization — `ref` preferred over `slug` over an `href`'s
  * trailing segment (mirrors `itemUrlId`/`formatItemRef`'s ref-over-slug
  * preference). Null when the target carries nothing resolvable.
+ *
+ * A cross-workspace `href` (`isCrossWorkspaceHref`) makes the WHOLE target
+ * untrustworthy, not just the href field: it's unambiguous evidence the
+ * link doesn't point at a same-workspace item, so a `ref`/`slug` set
+ * alongside it is more likely mis-derived than an intentional override —
+ * trusting it anyway risks silently opening the wrong local item (Codex
+ * review). By this type's own contract (`$lib/types`), a genuinely
+ * same-workspace target never carries a cross-workspace href in the first
+ * place.
  */
 function rawPaneTargetCandidate(target: PaneTarget): string | null {
+	if (target.href && isCrossWorkspaceHref(target.href)) return null;
 	if (target.ref) return target.ref;
 	if (target.slug) return target.slug;
 	if (target.href) return lastHrefSegment(target.href);

--- a/web/src/lib/collections/paneTarget.ts
+++ b/web/src/lib/collections/paneTarget.ts
@@ -15,7 +15,6 @@
 // hands, so it's exhaustively unit-testable without mounting a route.
 
 import type { Item, PaneTarget } from '$lib/types';
-import { formatItemRef } from '$lib/types';
 
 /**
  * Extract the trailing path segment of an internal item href, e.g.
@@ -27,6 +26,21 @@ function lastHrefSegment(href: string): string | null {
 	const path = href.split(/[?#]/)[0];
 	const segments = path.split('/').filter(Boolean);
 	return segments.length > 0 ? segments[segments.length - 1] : null;
+}
+
+// Ref-shaped candidate: PREFIX-NUMBER. Mirrors `internal/store/items.go`'s
+// `parseItemRef` closely enough for guard purposes — case-insensitive
+// letter/digit prefix, a hyphen, then a positive integer suffix.
+const REF_SHAPE = /^([A-Za-z][A-Za-z0-9]*)-(\d+)$/;
+
+/** Parse a ref-shaped candidate's item NUMBER (case-insensitive; prefix is
+ *  discarded — see `isSamePaneTarget`). Null for a non-ref-shaped string or
+ *  a zero/non-finite number. */
+function parseRefNumber(candidate: string): number | null {
+	const m = REF_SHAPE.exec(candidate);
+	if (!m) return null;
+	const number = Number(m[2]);
+	return Number.isFinite(number) && number > 0 ? number : null;
 }
 
 /**
@@ -45,12 +59,22 @@ function rawPaneTargetCandidate(target: PaneTarget): string | null {
 /**
  * True when `target` refers to the SAME item as `current` — the item
  * presently loaded (e.g. `ItemDetail`'s own `item` state for the pane
- * showing it). Compares `current`'s stable `id` and BOTH its ref and slug
- * forms against the target's candidate, so a target that names the current
- * item by slug while it's open under its ref (or vice versa, or via an
- * href built from either) is still caught — a bare
- * `itemUrlId(current) === candidate` string compare misses that alias
- * (PLAN-2154 / TASK-2158).
+ * showing it). Compares `current`'s stable `id` and slug, plus a
+ * ref-shaped candidate's item NUMBER (not the literal ref string), against
+ * the target's candidate:
+ *
+ *  - a target that names the current item by slug while it's open under its
+ *    ref (or vice versa, or via an href built from either) is caught — a
+ *    bare `itemUrlId(current) === candidate` string compare misses that
+ *    alias;
+ *  - a ref-shaped candidate is compared case-insensitively BY NUMBER ONLY,
+ *    ignoring its prefix, mirroring the server's `GetItemByRef` (item
+ *    numbers are workspace-unique, so it falls back to a number-only match
+ *    when the prefix is stale — the same case a wiki-link written before an
+ *    item moved collections, e.g. "[[PLAN-42]]" for an item now filed as
+ *    TASK-42, would still present). Matching by number alone reproduces
+ *    that same-item outcome instead of pushing a redundant re-target
+ *    (PLAN-2154 / TASK-2158; Codex review).
  *
  * `current` is optional/nullable so callers that don't have a loaded item
  * in hand (e.g. the collection host, which only sees the target) can call
@@ -62,9 +86,12 @@ export function isSamePaneTarget(target: PaneTarget, current: Item | null | unde
 	const candidate = rawPaneTargetCandidate(target);
 	if (!candidate) return false;
 	if (candidate === current.id) return true;
-	const currentRef = formatItemRef(current);
-	if (currentRef && candidate === currentRef) return true;
-	return candidate === current.slug;
+	if (candidate === current.slug) return true;
+	if (current.item_number) {
+		const number = parseRefNumber(candidate);
+		if (number !== null && number === current.item_number) return true;
+	}
+	return false;
 }
 
 /**

--- a/web/src/lib/collections/paneTarget.ts
+++ b/web/src/lib/collections/paneTarget.ts
@@ -101,25 +101,35 @@ function rawPaneTargetCandidate(target: PaneTarget): string | null {
 	return null;
 }
 
+/** True when `candidate` is `current`'s own item number, expressed as a
+ *  ref-shaped string (case-insensitive, prefix ignored — see `REF_SHAPE`'s
+ *  doc comment). False when `current` has no item number. */
+function matchesRefNumber(candidate: string, current: Item): boolean {
+	if (!current.item_number) return false;
+	const number = parseRefNumber(candidate);
+	return number !== null && number === current.item_number;
+}
+
 /**
  * True when `target` refers to the SAME item as `current` — the item
  * presently loaded (e.g. `ItemDetail`'s own `item` state for the pane
- * showing it). Compares `current`'s stable `id` and slug, plus a
- * ref-shaped candidate's item NUMBER (not the literal ref string), against
- * the target's candidate:
+ * showing it).
  *
- *  - a target that names the current item by slug while it's open under its
- *    ref (or vice versa, or via an href built from either) is caught — a
- *    bare `itemUrlId(current) === candidate` string compare misses that
- *    alias;
- *  - a ref-shaped candidate is compared case-insensitively BY NUMBER ONLY,
- *    ignoring its prefix, mirroring the server's `GetItemByRef` (item
- *    numbers are workspace-unique, so it falls back to a number-only match
- *    when the prefix is stale — the same case a wiki-link written before an
- *    item moved collections, e.g. "[[PLAN-42]]" for an item now filed as
- *    TASK-42, would still present). Matching by number alone reproduces
- *    that same-item outcome instead of pushing a redundant re-target
- *    (PLAN-2154 / TASK-2158; Codex review).
+ * Field-provenance-aware: a target names an item through exactly one
+ * "channel" at a time, and only checked with that channel's own semantics,
+ * so a `ref`-sourced candidate is judged ONLY as a ref (id, or its item
+ * NUMBER — case-insensitive, prefix ignored, matching a stale/renamed
+ * prefix from before a collection move, mirroring the server's
+ * `GetItemByRef` number-only fallback) and never falls through to a raw
+ * string compare against `current.slug` — which could coincidentally equal
+ * a DIFFERENT item's ref string (e.g. current is slugged "plan-6" while a
+ * target `{ ref: "plan-6" }` names some OTHER item numbered 6) and wrongly
+ * suppress a valid navigation. A `slug`-sourced candidate is likewise
+ * judged only as a slug (or id). An `href`-sourced candidate carries no
+ * declared identity — its trailing segment could be either shape — so both
+ * are tried, matching the server's own ambiguous-string resolution order
+ * for a bare `?item=` value (PLAN-2154 / TASK-2158; Codex review — PR diff
+ * pass).
  *
  * `current` is optional/nullable so callers that don't have a loaded item
  * in hand (e.g. the collection host, which only sees the target) can call
@@ -128,13 +138,21 @@ function rawPaneTargetCandidate(target: PaneTarget): string | null {
  */
 export function isSamePaneTarget(target: PaneTarget, current: Item | null | undefined): boolean {
 	if (!current) return false;
-	const candidate = rawPaneTargetCandidate(target);
-	if (!candidate) return false;
-	if (candidate === current.id) return true;
-	if (candidate === current.slug) return true;
-	if (current.item_number) {
-		const number = parseRefNumber(candidate);
-		if (number !== null && number === current.item_number) return true;
+	// A cross-workspace href is unambiguous evidence of non-locality — see
+	// `rawPaneTargetCandidate`'s doc comment for why this precedes ref/slug.
+	if (target.href && isCrossWorkspaceHref(target.href)) return false;
+	if (target.ref) {
+		return target.ref === current.id || matchesRefNumber(target.ref, current);
+	}
+	if (target.slug) {
+		return target.slug === current.id || target.slug === current.slug;
+	}
+	if (target.href) {
+		const candidate = lastHrefSegment(target.href);
+		if (!candidate) return false;
+		return (
+			candidate === current.id || candidate === current.slug || matchesRefNumber(candidate, current)
+		);
 	}
 	return false;
 }

--- a/web/src/lib/collections/paneTarget.ts
+++ b/web/src/lib/collections/paneTarget.ts
@@ -2,16 +2,20 @@
 // Architecture B / TASK-2158). This is the seam future content-link
 // surfaces (relationships, breadcrumb, editor wiki-links, the graph drawer —
 // TASK-2159/2160) thread `onOpenTarget` calls through: they hand up a
-// `PaneTarget` (ref/slug/href/collectionSlug — never a full `Item`), and
-// this module turns it into whatever `navigatePaneTo` (the pane's DRILL
-// entry point in `paneController.ts`) expects.
+// `PaneTarget` (ref/slug/href/collectionSlug — never a full `Item`).
+// `isSamePaneTarget` is called INSIDE `ItemDetail` (via its `fireOpenTarget`
+// wrapper), where the loaded `item` is on hand, to drop a self-referential
+// target before it ever reaches the host. `resolvePaneTarget` is called at
+// the collection host to turn whatever survives into the canonical string
+// `navigatePaneTo` (the pane's DRILL entry point in `paneController.ts`)
+// expects.
 //
 // Kept framework-agnostic (no `$state`/`page`) and free of any `Item`
 // FETCH — resolution only reads fields already present on the caller's
 // hands, so it's exhaustively unit-testable without mounting a route.
 
 import type { Item, PaneTarget } from '$lib/types';
-import { formatItemRef, itemUrlId } from '$lib/types';
+import { formatItemRef } from '$lib/types';
 
 /**
  * Extract the trailing path segment of an internal item href, e.g.
@@ -70,22 +74,22 @@ export function isSamePaneTarget(target: PaneTarget, current: Item | null | unde
  * ref > slug > an href's trailing path segment, mirroring
  * `itemUrlId`/`formatItemRef`.
  *
- * When `current` (the item already loaded where this target was clicked)
- * is supplied and the target resolves to THAT item — by id, or by either
- * its ref or slug even when the target names it differently than however
- * it's currently open — this returns `current`'s OWN canonical ref instead
- * of the target's raw candidate. That normalization is the same-item guard:
- * handing the exact currently-open ref back to `navigatePaneTo` lets its
- * existing same-ref no-op check (`planPaneDrill`) catch the alias and skip
- * a redundant re-target onto the identical item, rather than requiring
- * every caller to duplicate the id/ref/slug comparison.
+ * When `current` (the item already loaded where this target was clicked) is
+ * supplied and the target resolves to THAT item — by id, or by either its
+ * ref or slug even when the target names it differently than however it's
+ * currently open (`isSamePaneTarget`) — this returns `null` rather than any
+ * ref/slug string. That's the same-item guard: null is `navigatePaneTo`'s
+ * caller's uniform "nothing to do" signal (mirrors "target carries nothing
+ * resolvable" below), so a self-referential alias — e.g. the pane is open
+ * via `?item=my-slug` and a link names the same item by its `TASK-5` ref —
+ * is a clean no-op. Deliberately NOT the item's own canonical ref: that
+ * could itself mismatch the pane's actual (possibly slug-shaped) open `?item=`
+ * value and cause `planPaneDrill`'s same-ref check to wrongly treat it as a
+ * new target (Codex review).
  *
  * Returns null when the target carries nothing resolvable.
  */
 export function resolvePaneTarget(target: PaneTarget, current?: Item | null): string | null {
-	if (isSamePaneTarget(target, current)) {
-		// isSamePaneTarget only returns true when `current` is present.
-		return itemUrlId(current as Item);
-	}
+	if (isSamePaneTarget(target, current)) return null;
 	return rawPaneTargetCandidate(target);
 }

--- a/web/src/lib/collections/paneTarget.ts
+++ b/web/src/lib/collections/paneTarget.ts
@@ -1,0 +1,91 @@
+// PaneTarget → canonical `?item=` resolution + same-item guard (PLAN-2154
+// Architecture B / TASK-2158). This is the seam future content-link
+// surfaces (relationships, breadcrumb, editor wiki-links, the graph drawer —
+// TASK-2159/2160) thread `onOpenTarget` calls through: they hand up a
+// `PaneTarget` (ref/slug/href/collectionSlug — never a full `Item`), and
+// this module turns it into whatever `navigatePaneTo` (the pane's DRILL
+// entry point in `paneController.ts`) expects.
+//
+// Kept framework-agnostic (no `$state`/`page`) and free of any `Item`
+// FETCH — resolution only reads fields already present on the caller's
+// hands, so it's exhaustively unit-testable without mounting a route.
+
+import type { Item, PaneTarget } from '$lib/types';
+import { formatItemRef, itemUrlId } from '$lib/types';
+
+/**
+ * Extract the trailing path segment of an internal item href, e.g.
+ * "/alice/myws/tasks/TASK-5" -> "TASK-5", "/alice/myws/tasks/TASK-5/" ->
+ * "TASK-5". Query string / hash are stripped first. Null for an href with
+ * no non-empty segment (e.g. "", "/").
+ */
+function lastHrefSegment(href: string): string | null {
+	const path = href.split(/[?#]/)[0];
+	const segments = path.split('/').filter(Boolean);
+	return segments.length > 0 ? segments[segments.length - 1] : null;
+}
+
+/**
+ * The raw ref-or-slug candidate a `PaneTarget` carries, before any
+ * same-item normalization — `ref` preferred over `slug` over an `href`'s
+ * trailing segment (mirrors `itemUrlId`/`formatItemRef`'s ref-over-slug
+ * preference). Null when the target carries nothing resolvable.
+ */
+function rawPaneTargetCandidate(target: PaneTarget): string | null {
+	if (target.ref) return target.ref;
+	if (target.slug) return target.slug;
+	if (target.href) return lastHrefSegment(target.href);
+	return null;
+}
+
+/**
+ * True when `target` refers to the SAME item as `current` — the item
+ * presently loaded (e.g. `ItemDetail`'s own `item` state for the pane
+ * showing it). Compares `current`'s stable `id` and BOTH its ref and slug
+ * forms against the target's candidate, so a target that names the current
+ * item by slug while it's open under its ref (or vice versa, or via an
+ * href built from either) is still caught — a bare
+ * `itemUrlId(current) === candidate` string compare misses that alias
+ * (PLAN-2154 / TASK-2158).
+ *
+ * `current` is optional/nullable so callers that don't have a loaded item
+ * in hand (e.g. the collection host, which only sees the target) can call
+ * this — and `resolvePaneTarget` — without one; the guard simply never
+ * fires.
+ */
+export function isSamePaneTarget(target: PaneTarget, current: Item | null | undefined): boolean {
+	if (!current) return false;
+	const candidate = rawPaneTargetCandidate(target);
+	if (!candidate) return false;
+	if (candidate === current.id) return true;
+	const currentRef = formatItemRef(current);
+	if (currentRef && candidate === currentRef) return true;
+	return candidate === current.slug;
+}
+
+/**
+ * Resolve a `PaneTarget` — whatever a content-link surface carries — to the
+ * canonical `?item=` value the pane controller expects (`navigatePaneTo` in
+ * the collection host, backed by `planPaneDrill`). Preference order is
+ * ref > slug > an href's trailing path segment, mirroring
+ * `itemUrlId`/`formatItemRef`.
+ *
+ * When `current` (the item already loaded where this target was clicked)
+ * is supplied and the target resolves to THAT item — by id, or by either
+ * its ref or slug even when the target names it differently than however
+ * it's currently open — this returns `current`'s OWN canonical ref instead
+ * of the target's raw candidate. That normalization is the same-item guard:
+ * handing the exact currently-open ref back to `navigatePaneTo` lets its
+ * existing same-ref no-op check (`planPaneDrill`) catch the alias and skip
+ * a redundant re-target onto the identical item, rather than requiring
+ * every caller to duplicate the id/ref/slug comparison.
+ *
+ * Returns null when the target carries nothing resolvable.
+ */
+export function resolvePaneTarget(target: PaneTarget, current?: Item | null): string | null {
+	if (isSamePaneTarget(target, current)) {
+		// isSamePaneTarget only returns true when `current` is present.
+		return itemUrlId(current as Item);
+	}
+	return rawPaneTargetCandidate(target);
+}

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -29,7 +29,7 @@
 	import { relativeTime, wikiLinksToMarkdown, markdownToWikiLinks, cleanBrokenLinks, unescapeDocLinks } from '$lib/utils/markdown';
 	import { toastStore } from '$lib/stores/toast.svelte';
 	import { editorStore } from '$lib/stores/editor.svelte';
-	import type { Item, Collection, CollectionSettings, QuickAction, ItemLink, AgentRole } from '$lib/types';
+	import type { Item, Collection, CollectionSettings, QuickAction, ItemLink, AgentRole, PaneTarget } from '$lib/types';
 	import { parseFields, parseSchema, parseSettings, parseTags, formatItemRef, itemUrlId, getTerminalOptions } from '$lib/types';
 	import QuickActionsMenu from '$lib/components/common/QuickActionsMenu.svelte';
 	import BottomSheet from '$lib/components/common/BottomSheet.svelte';
@@ -81,6 +81,7 @@
 		onGone,
 		onNavigateAway,
 		onReady,
+		onOpenTarget,
 	}: {
 		username: string;
 		wsSlug: string;
@@ -91,6 +92,15 @@
 		onGone?: () => void;
 		onNavigateAway?: (url: string) => void;
 		onReady?: (ready: boolean) => void;
+		// PLAN-2154 Architecture B / TASK-2158: the seam content-link surfaces
+		// (relationships, breadcrumb, editor wiki-links, the graph drawer —
+		// TASK-2159/2160) will fire to drill the pane in place instead of a
+		// hard navigation. Callers hand up a `PaneTarget` (ref/slug/href/
+		// collection metadata only — never a full `Item`); the collection
+		// host resolves it (`resolvePaneTarget`, `$lib/collections/
+		// paneTarget`) and drives its pane controller's `navigatePaneTo`.
+		// Unused by ItemDetail itself until those link surfaces are wired.
+		onOpenTarget?: (target: PaneTarget) => void;
 	} = $props();
 
 	// itemSlug is the identity that drives loadData + the whole collabKey

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -40,6 +40,7 @@
 	import ShareDialog from '$lib/components/ShareDialog.svelte';
 	import { copyToClipboard } from '$lib/utils/clipboard';
 	import { repairDeadItemLastRoute } from '$lib/collections/paneUrlParams';
+	import { isSamePaneTarget } from '$lib/collections/paneTarget';
 	import { starredStore } from '$lib/stores/starred.svelte';
 	import { titleStore } from '$lib/stores/title.svelte';
 	import { workspaceStore } from '$lib/stores/workspace.svelte';
@@ -94,12 +95,13 @@
 		onReady?: (ready: boolean) => void;
 		// PLAN-2154 Architecture B / TASK-2158: the seam content-link surfaces
 		// (relationships, breadcrumb, editor wiki-links, the graph drawer —
-		// TASK-2159/2160) will fire to drill the pane in place instead of a
-		// hard navigation. Callers hand up a `PaneTarget` (ref/slug/href/
-		// collection metadata only — never a full `Item`); the collection
-		// host resolves it (`resolvePaneTarget`, `$lib/collections/
-		// paneTarget`) and drives its pane controller's `navigatePaneTo`.
-		// Unused by ItemDetail itself until those link surfaces are wired.
+		// TASK-2159/2160) will fire, via the internal `fireOpenTarget` wrapper
+		// below, to drill the pane in place instead of a hard navigation.
+		// Callers hand up a `PaneTarget` (ref/slug/href/collection metadata
+		// only — never a full `Item`); the collection host resolves it
+		// (`resolvePaneTarget`, `$lib/collections/paneTarget`) and drives its
+		// pane controller's `navigatePaneTo`. Not called by anything yet — no
+		// content-link surface intercepts clicks until TASK-2159/2160 land.
 		onOpenTarget?: (target: PaneTarget) => void;
 	} = $props();
 
@@ -172,6 +174,21 @@
 	// the returning id matches but a newer load replaced the item in between.
 	function switchedAway(targetItem: Item, gen: number): boolean {
 		return gen !== loadGeneration || item?.id !== targetItem.id;
+	}
+
+	// The `onOpenTarget` seam's same-item guard (PLAN-2154 / TASK-2158). No
+	// content-link surface calls this yet — TASK-2159/2160's relationships /
+	// breadcrumb / editor wiki-link / graph interceptors will call
+	// `fireOpenTarget(target)` instead of `onOpenTarget?.(target)` directly, so
+	// a link that names THIS item (by ref, slug, id, or an href built from
+	// either — even when it differs from however the pane's own `?item=` names
+	// it) is dropped here rather than round-tripping to the host only to
+	// become a no-op there. `isSamePaneTarget` is the same reusable check
+	// `resolvePaneTarget` (`$lib/collections/paneTarget`) applies when a
+	// caller passes it a `current` item.
+	function fireOpenTarget(target: PaneTarget) {
+		if (isSamePaneTarget(target, item)) return;
+		onOpenTarget?.(target);
 	}
 
 	// Cross-collection `?item=` safety (PLAN-2105 / TASK-2112). A stale /

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -1697,8 +1697,12 @@ export interface PaneTarget {
 	ref?: string;
 	/** Item slug, used when no `ref` is available. */
 	slug?: string;
-	/** An internal item URL, e.g. "/alice/myws/tasks/TASK-5". Only its
-	 *  trailing path segment (the ref-or-slug) is used. */
+	/** A SAME-WORKSPACE internal item URL, e.g. "/alice/myws/tasks/TASK-5"
+	 *  (only its trailing path segment — the ref-or-slug — is used). A
+	 *  cross-workspace resolver URL (`/-/r/{workspace}/{ref}`) is NOT
+	 *  resolvable through this field — `resolvePaneTarget` refuses it rather
+	 *  than risk opening the wrong item; that link shape should bypass pane
+	 *  interception and navigate normally. */
 	href?: string;
 	/** The target item's collection slug, if known. */
 	collectionSlug?: string;

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -1674,3 +1674,32 @@ export function formatItemRef(item: Item): string | null {
 export function itemUrlId(item: Item): string {
 	return formatItemRef(item) ?? item.slug;
 }
+
+/**
+ * The minimal, non-`Item` description of a navigation target a content-link
+ * surface hands to `ItemDetail`'s `onOpenTarget` callback (PLAN-2154
+ * Architecture B). Link surfaces — relationships, breadcrumb, editor wiki-
+ * links, the graph drawer — carry only href/ref/collection metadata about
+ * the item they point at, NEVER a full `Item` (fetching one just to link to
+ * it would defeat the point). `resolvePaneTarget`
+ * (`$lib/collections/paneTarget`) turns a `PaneTarget` into the canonical
+ * `?item=` value the pane controller (`navigatePaneTo`) expects.
+ *
+ * At least one of `ref` / `slug` / `href` should be set for the target to be
+ * resolvable; `ref` is preferred over `slug` over an `href`'s trailing path
+ * segment, mirroring `itemUrlId`/`formatItemRef`'s own ref-over-slug
+ * preference. `collectionSlug` is carried for future collection-aware
+ * routing / cross-collection guards — resolution itself doesn't need it,
+ * since the canonical `?item=` value is workspace-unique.
+ */
+export interface PaneTarget {
+	/** Canonical PREFIX-NUMBER ref, e.g. "TASK-5". */
+	ref?: string;
+	/** Item slug, used when no `ref` is available. */
+	slug?: string;
+	/** An internal item URL, e.g. "/alice/myws/tasks/TASK-5". Only its
+	 *  trailing path segment (the ref-or-slug) is used. */
+	href?: string;
+	/** The target item's collection slug, if known. */
+	collectionSlug?: string;
+}

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -3,7 +3,7 @@
 	import { browser } from '$app/environment';
 	import { goto, beforeNavigate, afterNavigate } from '$app/navigation';
 	import { api, PadApiError, isPlanLimitError, planLimitMessage } from '$lib/api/client';
-	import type { BulkItemsRequest, Collection, Item, QuickAction, View, ViewConfig } from '$lib/types';
+	import type { BulkItemsRequest, Collection, Item, PaneTarget, QuickAction, View, ViewConfig } from '$lib/types';
 	import { parseSettings, parseFields, parseSchema, parseTags, getStatusOptions, itemUrlId, formatItemRef } from '$lib/types';
 	import { plansProgressToMap, fetchCollectionProgress } from '$lib/collections/progressMerge';
 	import BoardView from '$lib/components/collections/BoardView.svelte';
@@ -52,6 +52,7 @@
 		type ResolvedPaneState,
 	} from '$lib/collections/paneController';
 	import { paneFocusables, nextTrapTarget, resolvePaneReturnTarget } from '$lib/collections/paneFocus';
+	import { resolvePaneTarget } from '$lib/collections/paneTarget';
 	import { pushEscapeHandler, runTopEscape, topEscapePriority, ESCAPE_PRIORITY } from '$lib/stores/escapeStack';
 	import { boardKeyNav, type BoardNavColumn, type BoardNavDirection } from '$lib/collections/boardNav';
 
@@ -505,13 +506,14 @@
 	// cold-load. The pure decision logic is in `$lib/collections/paneController`
 	// (unit-tested); this wiring EXECUTES the returned plans.
 	//
-	// NOTE (TASK-2157 scope): `navigatePaneTo` has no in-pane content-link
-	// caller yet — those land in TASK-2158/2159/2160, which resolve a
-	// `PaneTarget` (ref/slug/href/collection) to a canonical `?item=` value and
-	// then call `navigatePaneTo(resolvedRef)`. It's exported onto the pane's
-	// ItemDetail seam below and reachable now only via the depth>0 test hook
+	// NOTE (TASK-2157/2158 scope): `navigatePaneTo` still has no in-pane
+	// content-link CALLER — `ItemDetail`'s `onOpenTarget` prop and the
+	// `resolvePaneTarget`/`handleOpenTarget` resolve→drill path are wired
+	// (TASK-2158), but no content-link surface fires it yet; relationships,
+	// breadcrumb, editor wiki-links, and the graph drawer land in
+	// TASK-2159/2160. Until then it's reachable only via the depth>0 test hook
 	// (`__padPaneController`) so the controller's drill/reset/close arithmetic
-	// is exercisable end-to-end before the UI callers exist.
+	// is exercisable end-to-end before the real UI callers exist.
 
 	/** Current pane depth+ownership, read from SvelteKit `page.state`. */
 	function currentPaneState(): ResolvedPaneState {
@@ -645,9 +647,10 @@
 	}
 
 	// In-pane DRILL (Architecture A). `target` is an already-resolved canonical
-	// `?item=` ref (TASK-2158 supplies the PaneTarget→ref resolution in front of
-	// this). Same-ref guard + soft depth cap + ownership INHERITED from the
-	// current entry, all decided by `planPaneDrill`.
+	// `?item=` ref — `handleOpenTarget` below resolves a raw `PaneTarget`
+	// (TASK-2158) into this shape before calling in. Same-ref guard + soft
+	// depth cap + ownership INHERITED from the current entry, all decided by
+	// `planPaneDrill`.
 	function navigatePaneTo(target: string) {
 		if (paneNavInFlight()) return;
 		controllerActionSeq++;
@@ -664,6 +667,21 @@
 			keepFocus: true,
 			state: plan.state,
 		});
+	}
+
+	// `ItemDetail`'s `onOpenTarget` seam (PLAN-2154 Architecture B / TASK-2158).
+	// No content-link surface calls this yet (relationships/breadcrumb/editor
+	// wiki-links/graph land in TASK-2159/2160) — wiring it now establishes the
+	// resolve→drill path so those tasks only need to build the `PaneTarget` and
+	// fire it, with no host-side plumbing left to add. `resolvePaneTarget`
+	// (`$lib/collections/paneTarget`) turns whatever ref/slug/href shape the
+	// link surface hands up into the canonical `?item=` value `navigatePaneTo`
+	// expects; a target that resolves to nothing is silently dropped (nothing
+	// to open).
+	function handleOpenTarget(target: PaneTarget) {
+		const resolved = resolvePaneTarget(target);
+		if (!resolved) return;
+		navigatePaneTo(resolved);
 	}
 
 	// The pane's ItemDetail fires `onNavigateAway` for TWO distinct cases, which
@@ -1348,9 +1366,10 @@
 	let unsubscribeSync: (() => void) | null = null;
 
 	// Test-only hook (PLAN-2154 / TASK-2157): exposes the pane controller so e2e
-	// can drive `navigatePaneTo` — which has NO in-pane UI caller until
-	// TASK-2158/2159/2160 wire content links — and read back the depth/ownership
-	// stamp. Gated on an opt-in localStorage flag so it adds ZERO surface to
+	// can drive `navigatePaneTo` — which has NO real content-link UI caller
+	// until TASK-2159/2160 wire relationships/breadcrumb/editor/graph onto
+	// `ItemDetail`'s `onOpenTarget` — and read back the depth/ownership stamp.
+	// Gated on an opt-in localStorage flag so it adds ZERO surface to
 	// production; the e2e harness sets `pad:pane-test-hook=1` before navigating.
 	interface PaneTestHook {
 		navigatePaneTo: (ref: string) => void;
@@ -3649,6 +3668,7 @@
 				onClose={closeItemPane}
 				onGone={closeItemPane}
 				onNavigateAway={handlePaneNavigateAway}
+				onOpenTarget={handleOpenTarget}
 			/>
 		</aside>
 	{/if}


### PR DESCRIPTION
## Summary

Phase 1 of PLAN-2154 Architecture B (the pane mini-browser's content-link seam). Builds on TASK-2157's pane controller (`navigatePaneTo`, currently reachable only via a test hook) without wiring any actual link surface yet — TASK-2159/2160 do that.

- Adds `PaneTarget` (`ref? / slug? / href? / collectionSlug?`) to `web/src/lib/types/index.ts` — the minimal, non-`Item` description link surfaces (relationships, breadcrumb, editor wiki-links, graph) will hand up.
- Adds `ItemDetail`'s `onOpenTarget?: (target: PaneTarget) => void` prop, plus an internal `fireOpenTarget(target)` wrapper that applies the same-item guard (`isSamePaneTarget`, using the pane's own loaded `item`) before ever calling the prop — no interceptor calls it yet.
- New `web/src/lib/collections/paneTarget.ts`: `resolvePaneTarget`/`isSamePaneTarget`, framework-agnostic and unit-tested (26 tests). Handles ref/slug/href extraction (ref > slug > href's trailing segment), a same-item guard that matches by id/slug/ref-number (case-insensitive, prefix-agnostic — mirrors the server's `GetItemByRef` fallback after a collection move) and short-circuits to `null` rather than a possibly-mismatched canonical ref, and refuses to resolve a cross-workspace resolver href (`/-/r/{workspace}/{ref}`, parsed via the `URL` API so both root-relative and absolute forms are caught) rather than risk opening the wrong local item.
- Wires the collection host: `onOpenTarget={(target) => navigatePaneTo(resolvePaneTarget(target))}` on the pane's `ItemDetail`.

No content-link surface intercepts clicks yet, so this is behavior-neutral — no user-visible change.

## Test plan

- [x] `cd web && npm run check` — 0 errors (1018 files)
- [x] `cd web && npm run test -- --run` — 371 passed (28 files), including 26 new `paneTarget.test.ts` cases covering candidate extraction, the same-item guard (id/slug/ref/case/stale-prefix/href aliases), and cross-workspace href rejection (root-relative + absolute)
- [x] 5 rounds of `codex exec -s read-only` review against the diff — rounds 1-4 found real issues (guard never wired, unsafe same-item normalization, case/prefix-insensitive ref aliasing, cross-workspace href mishandling), all fixed; round 5 returned **CLEAN**
- [x] Merged `origin/main` (TASK-2156 / PR #963) — auto-merged cleanly, disjoint region; re-ran both gates green after merge

https://claude.ai/code/session_01EZ6yr6pAUFb1uffan912ra