### PR TITLE
feat(web): detach at depth>0 — clear list highlight + gate pane-snap (TASK-2161)

### DIFF
--- a/web/e2e/pane-controller.spec.ts
+++ b/web/e2e/pane-controller.spec.ts
@@ -414,4 +414,104 @@ test.describe('pane controller: depth/ownership state machine (PLAN-2154 / TASK-
 		// page liveness via the heading rather than a specific row.)
 		await expect(page.getByRole('heading', { level: 1, name: new RegExp(newName) })).toBeVisible();
 	});
+
+	// ── Detach at depth>0 (PLAN-2154 Architecture C / D-detach / TASK-2161) ──
+	// Once the pane DRILLS past its base (depth>0) it becomes an independent
+	// viewer: the list row-highlight is cleared, the pane-snap effect stops
+	// snapping, and j/k goes INERT (schedulePaneFollow bails at schedule time and
+	// re-checks depth in its fired callback, and any pending follow is cancelled
+	// on drill). A direct row-click, by contrast, RESETS the stack (covered by
+	// the 'detached row click RESETS' test above). Only row-clicks reset; j/k
+	// never does.
+
+	test('detach: at depth>0 the list highlight is CLEARED, j/k cannot re-introduce it or move the pane, and unwind restores it', async ({
+		page,
+		fixture,
+		request,
+	}) => {
+		await page.setViewportSize(DESKTOP);
+		await enableHook(page);
+		await browserLogin(page);
+		await seedDoc(fixture, request, 'Ctrl hl alpha');
+		const b = await seedDoc(fixture, request, 'Ctrl hl bravo');
+		await seedDoc(fixture, request, 'Ctrl hl charlie');
+		await page.goto(docsUrl(fixture));
+
+		// The list row-highlight marker (`focusedItemId === item.id`) renders as
+		// `.item-card.focused` in the list column. Scoped to `.list-column` so the
+		// pane's own ItemDetail can never match.
+		const focusedRows = page.locator('.list-column .item-card.focused');
+
+		// Open A at depth 0 → the pane-snap effect highlights A's row.
+		await page.locator('.item-card', { hasText: 'Ctrl hl alpha' }).first().click();
+		const pane = page.locator('.item-pane');
+		await expect(pane).toBeVisible();
+		await expect.poll(() => paneState(page)).toEqual({ paneDepth: 0, paneOwned: true });
+		await expect(focusedRows).toHaveCount(1);
+		await expect(focusedRows).toHaveText(/Ctrl hl alpha/);
+
+		// Drill A→B → depth 1 (detached). The highlight is CLEARED (focusedItemId
+		// gated to null at depth>0) and the pane-snap effect no longer snaps to B.
+		await drillTo(page, b.slug);
+		await expect.poll(() => paneState(page)).toEqual({ paneDepth: 1, paneOwned: true });
+		const refAtB = openItemParam(page);
+		await expect(focusedRows).toHaveCount(0);
+
+		// j/k is INERT at depth>0: pressing j moves no highlight and does NOT
+		// re-target (schedulePaneFollow bails; focusedItemId stays null).
+		await page.evaluate(() => document.querySelector<HTMLElement>('.list-column')?.focus());
+		await page.keyboard.press('j');
+		await page.waitForTimeout(250); // > PANE_FOLLOW_DEBOUNCE_MS (140ms)
+		await expect(focusedRows).toHaveCount(0);
+		expect(openItemParam(page)).toBe(refAtB);
+		await expect.poll(() => paneState(page)).toEqual({ paneDepth: 1, paneOwned: true });
+
+		// Browser Back unwinds to depth 0 → the base row's highlight is restored
+		// (both openItemRef and page.state change, so the gated effect re-runs).
+		await page.goBack();
+		await expect.poll(() => paneState(page)).toEqual({ paneDepth: 0, paneOwned: true });
+		await expect(focusedRows).toHaveCount(1);
+		await expect(focusedRows).toHaveText(/Ctrl hl alpha/);
+	});
+
+	test('R3 late-timer: a j/k pane-follow scheduled at depth 0 does NOT clobber a drill to depth>0', async ({
+		page,
+		fixture,
+		request,
+	}) => {
+		await page.setViewportSize(DESKTOP);
+		await enableHook(page);
+		await browserLogin(page);
+		await seedDoc(fixture, request, 'Ctrl late alpha');
+		const b = await seedDoc(fixture, request, 'Ctrl late bravo');
+		await seedDoc(fixture, request, 'Ctrl late charlie');
+		await page.goto(docsUrl(fixture));
+
+		// Open A at depth 0.
+		await page.locator('.item-card', { hasText: 'Ctrl late alpha' }).first().click();
+		const pane = page.locator('.item-pane');
+		await expect(pane).toBeVisible();
+		await expect.poll(() => paneState(page)).toEqual({ paneDepth: 0, paneOwned: true });
+
+		// SCHEDULE a pane-follow at depth 0 (press j while focused on the list) —
+		// the 140ms debounce timer is now pending, armed to re-target the pane to
+		// the newly focused row.
+		await page.evaluate(() => document.querySelector<HTMLElement>('.list-column')?.focus());
+		await page.keyboard.press('j');
+
+		// DRILL to B BEFORE the follow fires (well within the 140ms window). The
+		// drill cancels the pending follow AND pushes depth 1; even if a timer
+		// somehow survived, its fired callback re-checks the CURRENT depth and
+		// bails. Either way the drilled `?item=` must NOT be clobbered.
+		await drillTo(page, b.slug);
+		await expect.poll(() => openItemParam(page)).toBe(b.slug);
+		await expect.poll(() => paneState(page)).toEqual({ paneDepth: 1, paneOwned: true });
+
+		// Wait PAST the debounce window: the stale follow must never fire. Had it
+		// clobbered, it would have `openItemPane`-RESET the stack (depth→0) and
+		// re-targeted `?item=` to the j-focused row.
+		await page.waitForTimeout(250); // > PANE_FOLLOW_DEBOUNCE_MS (140ms)
+		expect(openItemParam(page)).toBe(b.slug);
+		await expect.poll(() => paneState(page)).toEqual({ paneDepth: 1, paneOwned: true });
+	});
 });

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -2347,8 +2347,20 @@
 
 	// --- Keyboard navigation ---
 	let focusedIndex = $state(-1);
+	// The list row-highlight marker (List/Board/Table read it as
+	// `focusedItemId === item.id`). Gated on stamped `depth===0` (PLAN-2154
+	// Architecture C / D-detach / TASK-2161): once the pane has DRILLED past its
+	// base (depth>0) it's an independent viewer, so the list highlight is
+	// CLEARED — the breadcrumb becomes the sole location indicator. `page.state`
+	// (read via `currentPaneState`) is reactive, so this recomputes to null on
+	// drill and re-highlights the base row on unwind. j/k may still nudge
+	// `focusedIndex` underneath a detached pane, but with no visible highlight
+	// here and no pane-follow (`schedulePaneFollow` is likewise inert at
+	// depth>0), so j/k is INERT while detached.
 	let focusedItemId = $derived(
-		focusedIndex >= 0 && focusedIndex < filteredItems.length
+		currentPaneState().paneDepth === 0 &&
+			focusedIndex >= 0 &&
+			focusedIndex < filteredItems.length
 			? filteredItems[focusedIndex].id
 			: null
 	);
@@ -2381,8 +2393,16 @@
 	// wins and restores the paned row. j/k between openItemRef changes still
 	// moves the cursor freely (this effect only re-runs on openItemRef /
 	// filteredItems changes, not on focusedIndex).
+	//
+	// DETACH gate (PLAN-2154 Architecture C / D-detach / TASK-2161): only snap
+	// while the pane is at its BASE (depth 0). Once drilled (depth>0) the pane
+	// shows an item that may not be in this list at all, and the row highlight
+	// is cleared (see `focusedItemId`), so snapping would be meaningless — bail.
+	// On unwind back to depth 0 both `openItemRef` and `page.state` change, so
+	// this re-runs and restores the base row's highlight.
 	$effect(() => {
 		if (!openItemRef) return;
+		if (currentPaneState().paneDepth > 0) return;
 		const idx = filteredItems.findIndex(
 			(i) => itemUrlId(i) === openItemRef || i.slug === openItemRef,
 		);


### PR DESCRIPTION
## TASK-2161 — Phase 1: Detach at depth>0

At a stamped pane `depth>0` the split-pane detail is a detached mini-browser (PLAN-2154 Architecture C / D-detach), so the collection list underneath must go inert. This closes the two remaining detach gaps left by TASK-2157.

### Pre-existing (TASK-2157, verified in the audit — not re-implemented)
- `schedulePaneFollow` bails at schedule time AND re-checks current depth in its fired debounce callback (R3), and the pending follow is cancelled on `navigatePaneTo` — so `j`/`k` never reaches the pane at depth>0.
- A detached list-ROW CLICK at depth>0 RESETS the stack (`history.go(-depth)` to base + an `afterNavigate`-latched fresh depth-0 open via `planLateralOpen`'s `reset` plan), never a replace of the drilled entry.

### Added here (the gaps)
- **`focusedItemId`** (the List/Board/Table row-highlight marker) now gates on `currentPaneState().paneDepth === 0`, so the list highlight is CLEARED once the pane drills past its base and re-appears on unwind. `page.state` is reactive, confirmed at runtime by the new e2e.
- **The pane-snap `$effect`** bails when `depth>0`, so it no longer snaps the list cursor onto a drilled item that may not even be in the list.

Together with the pre-existing `schedulePaneFollow` guards, `j`/`k` is fully INERT at depth>0: no pane-follow, no visible highlight movement.

### Tests (`e2e/pane-controller.spec.ts`)
- **highlight-cleared**: drilling clears the row highlight, `j`/`k` at depth>0 cannot re-introduce it or move the pane, and browser Back restores it at depth 0.
- **R3 late-timer**: a `j`/`k` pane-follow scheduled at depth 0 does NOT clobber a drill to depth>0.

### Gates (all green, run locally)
- `npm run check` — 0 errors.
- `pane-controller.spec.ts` (9, incl. 2 new) + `pane-a11y-focus.spec.ts` (6) on desktop-chromium.
- `src/lib/collections` vitest (157).
- Codex review of `origin/main...HEAD` diff: CLEAN.

https://claude.ai/code/session_01EZ6yr6pAUFb1uffan912ra