### PR TITLE
feat(web): drill the pane from relationship, child, and graph-Open anchors

### DIFF
--- a/web/e2e/pane-content-link-anchors.spec.ts
+++ b/web/e2e/pane-content-link-anchors.spec.ts
@@ -1,0 +1,303 @@
+import { test, expect } from './fixtures';
+import { browserLogin, seedDoc } from './lib/collab-helpers';
+import type { APIRequestContext, Page } from '@playwright/test';
+import type { SuiteFixture } from './fixtures';
+
+/**
+ * Anchor-based content-link interception (PLAN-2154 Architecture B.1/B.2/B.4
+ * / TASK-2159).
+ *
+ * TASK-2158 wired the `onOpenTarget`/`fireOpenTarget` seam and the
+ * collection host's resolve→drill path (`handleOpenTarget` →
+ * `resolvePaneTarget` → `navigatePaneTo`), but shipped with no UI caller.
+ * This task adds the callers: the relationships `<a class="link-target">`
+ * in ItemDetail, `ChildItems`' `.child-row` + recursive `NestedChildren`'s
+ * `.nested-link`, and `ItemGraph`'s node "Open" anchors (NOT the node click,
+ * which stays select-only). A plain click on any of them must re-target the
+ * pane IN PLACE (URL `?item=` changes, pathname unchanged, no full
+ * navigation); a modifier-click must fall through to the anchor's plain
+ * `href` and open the full page normally (the interceptor must never call
+ * `preventDefault()` on a click it isn't going to handle).
+ *
+ * `?item=` values in this app are REF-preferred (`resolvePaneTarget`'s
+ * ref > slug > href-segment order, mirroring `itemUrlId`/`formatItemRef`)
+ * — every PaneTarget built by the interceptors under test carries a `ref`,
+ * so assertions below compare against the item's PREFIX-NUMBER ref, not its
+ * slug.
+ *
+ * The modifier bail-out itself (button / meta / ctrl / shift / alt /
+ * defaultPrevented) is exhaustively unit-tested against the SHARED
+ * predicate every surface here reuses — `shouldOpenInPane`
+ * (itemCardClick.test.ts). This spec verifies the WIRING: that each new
+ * onclick handler actually calls that predicate before intercepting, in a
+ * real browser (ctrl-click's "open a new background tab" behavior has no
+ * jsdom equivalent).
+ *
+ * Viewport is driven explicitly (desktop split), so one project is enough.
+ */
+
+const DESKTOP = { width: 1200, height: 900 };
+
+function docsUrl(fixture: SuiteFixture, query = ''): string {
+	return `/${fixture.adminUsername}/${fixture.workspaceSlug}/docs${query}`;
+}
+
+function openItemParam(page: Page): string | null {
+	return new URL(page.url()).searchParams.get('item');
+}
+
+function pathname(page: Page): string {
+	return new URL(page.url()).pathname;
+}
+
+function authHeaders(fixture: SuiteFixture) {
+	return { Authorization: `Bearer ${fixture.apiToken}`, 'Content-Type': 'application/json' };
+}
+
+interface SeededItem {
+	id: string;
+	slug: string;
+}
+
+/** Seed a doc with `fields.parent` set — a child of `parentId` (mirrors
+ *  `ChildItems.submitCreate`'s `fields: { parent }` shape). */
+async function seedChildDoc(
+	fixture: SuiteFixture,
+	request: APIRequestContext,
+	titlePrefix: string,
+	parentId: string,
+): Promise<SeededItem> {
+	const resp = await request.post(
+		`/api/v1/workspaces/${fixture.workspaceSlug}/collections/docs/items`,
+		{
+			headers: authHeaders(fixture),
+			data: {
+				title: `${titlePrefix} ${Date.now()}`,
+				fields: JSON.stringify({ parent: parentId }),
+				content: '',
+			},
+		},
+	);
+	if (!resp.ok()) throw new Error(`child doc create failed (${resp.status()}): ${await resp.text()}`);
+	return (await resp.json()) as SeededItem;
+}
+
+/** Create a `related` link FROM `sourceSlug` TO `targetId` — surfaces under
+ *  the "Related" relationship group on both ends. */
+async function seedRelatedLink(
+	fixture: SuiteFixture,
+	request: APIRequestContext,
+	sourceSlug: string,
+	targetId: string,
+): Promise<void> {
+	const resp = await request.post(
+		`/api/v1/workspaces/${fixture.workspaceSlug}/items/${sourceSlug}/links`,
+		{ headers: authHeaders(fixture), data: { target_id: targetId, link_type: 'related' } },
+	);
+	if (!resp.ok()) throw new Error(`link create failed (${resp.status()}): ${await resp.text()}`);
+}
+
+/** The PREFIX-NUMBER ref (e.g. "DOC-5") the app renders for an item —
+ *  computed the same way `formatItemRef` does, client-side. */
+async function itemRef(
+	fixture: SuiteFixture,
+	request: APIRequestContext,
+	slug: string,
+): Promise<string> {
+	const resp = await request.get(`/api/v1/workspaces/${fixture.workspaceSlug}/items/${slug}`, {
+		headers: authHeaders(fixture),
+	});
+	if (!resp.ok()) throw new Error(`item get failed (${resp.status()}): ${await resp.text()}`);
+	const item = (await resp.json()) as { collection_prefix?: string; item_number?: number };
+	if (!item.collection_prefix || !item.item_number) throw new Error('item has no ref');
+	return `${item.collection_prefix}-${item.item_number}`;
+}
+
+/** Wait for a ctrl/cmd-clicked popup to actually navigate to the full-page
+ *  item route ending in `idSegment` (a ref OR a slug — hrefs are built with
+ *  whichever the surface prefers; `ChildItems` uses slugs, relationships and
+ *  the graph use refs). Chromium briefly reports the new tab's url() as
+ *  "about:blank" before the real navigation commits, so `waitForLoadState`
+ *  alone can race it — wait on the URL itself instead. */
+async function waitForItemPopup(popup: Page, idSegment: string): Promise<void> {
+	await popup.waitForURL((url) => url.pathname.endsWith(`/docs/${idSegment}`));
+}
+
+/** Locate an `.item-card` by its OWN title, scoped to `.card-title` — NOT a
+ *  bare `hasText` on the whole card, which also matches substring hits in
+ *  `.card-meta`'s parent breadcrumb (a child's card renders "· PARENT-REF:
+ *  Parent Title" there, so a parent's exact title can spuriously match its
+ *  OWN child's card first in DOM order). */
+function itemCard(page: Page, title: string) {
+	return page.locator('.item-card').filter({ has: page.locator('.card-title', { hasText: title }) });
+}
+
+test.describe('content-link anchor interception (PLAN-2154 / TASK-2159)', () => {
+	test.beforeEach(({}, testInfo) => {
+		test.skip(
+			testInfo.project.name !== 'desktop-chromium',
+			'the pane is a desktop-split concern; one project is enough',
+		);
+	});
+
+	test('Children: clicking a child row drills the pane in place; ctrl-click still opens the full page', async ({
+		page,
+		fixture,
+		request,
+	}) => {
+		await page.setViewportSize(DESKTOP);
+		await browserLogin(page);
+		const parent = await seedDoc(fixture, request, 'Anchors children parent');
+		const child = await seedChildDoc(fixture, request, 'Anchors children kid', parent.id);
+		const childRef = await itemRef(fixture, request, child.slug);
+		await page.goto(docsUrl(fixture));
+
+		await itemCard(page, 'Anchors children parent').first().click();
+		const pane = page.locator('.item-pane');
+		await expect(pane).toBeVisible();
+		await expect.poll(() => openItemParam(page)).not.toBeNull();
+		const paneUrlAtParent = page.url();
+
+		const childRow = pane.locator('.child-row', { hasText: 'Anchors children kid' });
+		await expect(childRow).toBeVisible();
+
+		// Plain click: re-targets the pane IN PLACE — same pathname, `?item=`
+		// swaps to the child's ref, and the pane header now shows the child's
+		// title. No full navigation (the collection list stays mounted
+		// underneath).
+		await childRow.click();
+		await expect.poll(() => openItemParam(page)).toBe(childRef);
+		expect(pathname(page)).toBe(new URL(paneUrlAtParent).pathname);
+		await expect(pane.locator('.title', { hasText: /Anchors children kid/ })).toBeVisible();
+		await expect(itemCard(page, 'Anchors children parent').first()).toBeVisible();
+
+		// Back to the parent, then ctrl-click the SAME child row: the interceptor
+		// must NOT call preventDefault for a modifier click, so the browser's
+		// native "open link in a new background tab" behavior fires instead —
+		// the pane's own `?item=` must stay put (proving our handler bailed).
+		await page.goto(paneUrlAtParent);
+		await expect(pane).toBeVisible();
+		await expect(childRow).toBeVisible();
+		const [popup] = await Promise.all([
+			page.context().waitForEvent('page'),
+			childRow.click({ modifiers: ['ControlOrMeta'] }),
+		]);
+		await waitForItemPopup(popup, child.slug);
+		await popup.close();
+		expect(openItemParam(page)).toBe(new URL(paneUrlAtParent).searchParams.get('item'));
+	});
+
+	test('Relationships: clicking a linked item drills the pane in place; ctrl-click still opens the full page', async ({
+		page,
+		fixture,
+		request,
+	}) => {
+		await page.setViewportSize(DESKTOP);
+		await browserLogin(page);
+		const a = await seedDoc(fixture, request, 'Anchors rel alpha');
+		const b = await seedDoc(fixture, request, 'Anchors rel bravo');
+		const bRef = await itemRef(fixture, request, b.slug);
+		await seedRelatedLink(fixture, request, a.slug, b.id);
+		await page.goto(docsUrl(fixture));
+
+		await itemCard(page, 'Anchors rel alpha').first().click();
+		const pane = page.locator('.item-pane');
+		await expect(pane).toBeVisible();
+		const paneUrlAtA = page.url();
+
+		const relLink = pane.locator('.link-target', { hasText: 'Anchors rel bravo' });
+		await expect(relLink).toBeVisible();
+
+		await relLink.click();
+		await expect.poll(() => openItemParam(page)).toBe(bRef);
+		await expect(pane.locator('.title', { hasText: /Anchors rel bravo/ })).toBeVisible();
+		expect(pathname(page)).toBe(new URL(paneUrlAtA).pathname);
+
+		// Ctrl-click falls through to the plain `href` (full-page popout); the
+		// pane's own `?item=` is untouched.
+		await page.goto(paneUrlAtA);
+		await expect(pane).toBeVisible();
+		await expect(relLink).toBeVisible();
+		const [popup] = await Promise.all([
+			page.context().waitForEvent('page'),
+			relLink.click({ modifiers: ['ControlOrMeta'] }),
+		]);
+		await waitForItemPopup(popup, bRef);
+		await popup.close();
+		expect(openItemParam(page)).toBe(new URL(paneUrlAtA).searchParams.get('item'));
+	});
+
+	test('Graph: clicking a node then its "Open item" anchor drills the pane in place (node click itself stays select-only)', async ({
+		page,
+		fixture,
+		request,
+	}) => {
+		await page.setViewportSize(DESKTOP);
+		await browserLogin(page);
+		const parent = await seedDoc(fixture, request, 'Anchors graph parent');
+		const child = await seedChildDoc(fixture, request, 'Anchors graph kid', parent.id);
+		const childRef = await itemRef(fixture, request, child.slug);
+		await page.goto(docsUrl(fixture));
+
+		await itemCard(page, 'Anchors graph parent').first().click();
+		const pane = page.locator('.item-pane');
+		await expect(pane).toBeVisible();
+		const paneUrlAtParent = page.url();
+
+		await pane.locator('button[title="View this item\'s dependency graph"]').click();
+		const drawer = pane.locator('.graph-drawer');
+		await expect(drawer).toBeVisible();
+		const childNode = drawer.locator('.node', { hasText: childRef });
+		await expect(childNode).toBeVisible();
+
+		// A plain click on the NODE selects it (opens the detail card) but does
+		// NOT navigate — the pane must still be showing the parent.
+		await childNode.click();
+		const detailCard = drawer.locator('.detail-card');
+		await expect(detailCard).toBeVisible();
+		expect(openItemParam(page)).toBe(new URL(paneUrlAtParent).searchParams.get('item'));
+
+		// The detail card's "Open item ↗" anchor is the actual interception
+		// point (Architecture B.4) — clicking IT drills the pane to the child.
+		await detailCard.locator('.open-btn', { hasText: 'Open item' }).click();
+		await expect.poll(() => openItemParam(page)).toBe(childRef);
+		await expect(pane.locator('.title', { hasText: /Anchors graph kid/ })).toBeVisible();
+	});
+
+	test('Graph: ctrl-click on an "Open" anchor still opens the full page instead of drilling', async ({
+		page,
+		fixture,
+		request,
+	}) => {
+		await page.setViewportSize(DESKTOP);
+		await browserLogin(page);
+		const parent = await seedDoc(fixture, request, 'Anchors graph ctrl parent');
+		const parentRef = await itemRef(fixture, request, parent.slug);
+		await page.goto(docsUrl(fixture));
+
+		await itemCard(page, 'Anchors graph ctrl parent').first().click();
+		const pane = page.locator('.item-pane');
+		await expect(pane).toBeVisible();
+		const paneUrlAtParent = page.url();
+
+		await pane.locator('button[title="View this item\'s dependency graph"]').click();
+		const drawer = pane.locator('.graph-drawer');
+		await expect(drawer).toBeVisible();
+
+		// The controls-bar "Open ↗" anchor targets the currently-focused node
+		// (the origin item itself here) — a modifier click must still fall
+		// through to its plain `href` rather than being swallowed by the
+		// interceptor (which would otherwise preventDefault + no-op on the
+		// same-item guard, dropping the click entirely).
+		const openBtn = drawer.locator('.controls .open-btn', { hasText: 'Open' });
+		await expect(openBtn).toBeVisible();
+		const [popup] = await Promise.all([
+			page.context().waitForEvent('page'),
+			openBtn.click({ modifiers: ['ControlOrMeta'] }),
+		]);
+		await waitForItemPopup(popup, parentRef);
+		await popup.close();
+		// The pane itself never navigated away.
+		expect(openItemParam(page)).toBe(new URL(paneUrlAtParent).searchParams.get('item'));
+	});
+});

--- a/web/src/lib/components/ChildItems.svelte
+++ b/web/src/lib/components/ChildItems.svelte
@@ -7,7 +7,7 @@
 	import { collectionStore } from '$lib/stores/collections.svelte';
 	import { workspaceStore } from '$lib/stores/workspace.svelte';
 	import { toastStore } from '$lib/stores/toast.svelte';
-	import type { Item, Collection } from '$lib/types';
+	import type { Item, Collection, PaneTarget } from '$lib/types';
 	import { parseFields, parseSchema, formatItemRef } from '$lib/types';
 	import { dndzone, TRIGGERS, SHADOW_ITEM_MARKER_PROPERTY_NAME } from 'svelte-dnd-action';
 	import type { DndEvent } from 'svelte-dnd-action';
@@ -17,6 +17,7 @@
 		disabledDirections,
 		type ReorderDirection
 	} from '$lib/collections/reorder';
+	import { shouldOpenInPane } from './collections/itemCardClick';
 	import ItemActionsMenu from './collections/ItemActionsMenu.svelte';
 	import ChildChart from './ChildChart.svelte';
 	import NestedChildren from './NestedChildren.svelte';
@@ -49,9 +50,17 @@
 		 */
 		selfDirty?: boolean;
 		selfLastSaveTime?: number;
+		/**
+		 * In-pane drill interceptor (PLAN-2154 Architecture B.2 / TASK-2159).
+		 * Threaded down from `ItemDetail`'s `fireOpenTarget` — `undefined` when
+		 * no host wired a pane (e.g. the full-page route), in which case the
+		 * child row's `<a href>` falls through to plain navigation. Forwarded
+		 * recursively into `NestedChildren`.
+		 */
+		onOpenTarget?: (target: PaneTarget) => void;
 	}
 
-	let { wsSlug, username = '', itemSlug, itemId, parentFields, terminalStatuses, onChildrenChange, canEdit = true, selfDirty = false, selfLastSaveTime = 0 }: Props = $props();
+	let { wsSlug, username = '', itemSlug, itemId, parentFields, terminalStatuses, onChildrenChange, canEdit = true, selfDirty = false, selfLastSaveTime = 0, onOpenTarget }: Props = $props();
 
 	const defaultTerminal = ['done', 'completed', 'resolved', 'cancelled', 'rejected', 'wontfix', 'fixed', 'implemented', 'archived', 'disabled', 'deprecated'];
 	const terminal = $derived(terminalStatuses ?? defaultTerminal);
@@ -261,6 +270,16 @@
 
 	function formatLabel(value: string): string {
 		return value.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+	}
+
+	// In-pane drill interception for a `.child-row` anchor (TASK-2159 /
+	// PLAN-2154 Architecture B.2). Mirrors `ItemCard.handleCardClick`'s
+	// bail-out order via the shared `shouldOpenInPane` predicate — modifier/
+	// middle-click still falls through to the plain `<a href>` popout.
+	function handleChildClick(e: MouseEvent, child: Item) {
+		if (!shouldOpenInPane(e, !!onOpenTarget)) return;
+		e.preventDefault();
+		onOpenTarget?.({ ref: formatItemRef(child) ?? undefined, slug: child.slug, collectionSlug: child.collection_slug });
 	}
 
 	// ── Add child (PLAN-2140) ─────────────────────────────────────────────────
@@ -774,7 +793,7 @@
 										<span class="expand-icon" class:expanded={isExpanded}>▸</span>
 									</button>
 								{/if}
-								<a href="/{username}/{wsSlug}/{child.collection_slug}/{child.slug}" class="child-row" class:has-toggle={canExpand}>
+								<a href="/{username}/{wsSlug}/{child.collection_slug}/{child.slug}" class="child-row" class:has-toggle={canExpand} onclick={(e) => handleChildClick(e, child)}>
 									<span class="child-ref">{formatItemRef(child) ?? ''}</span>
 									<span class="child-title" class:done={isDone}>{child.title}</span>
 									{#if fields.priority}
@@ -797,7 +816,7 @@
 								{/if}
 							</div>
 							{#if canExpand && isExpanded}
-								<NestedChildren {wsSlug} {username} parentSlug={child.slug} depth={1} maxDepth={3} {terminalStatuses} />
+								<NestedChildren {wsSlug} {username} parentSlug={child.slug} depth={1} maxDepth={3} {terminalStatuses} {onOpenTarget} />
 							{/if}
 						</div>
 					{/each}

--- a/web/src/lib/components/NestedChildren.svelte
+++ b/web/src/lib/components/NestedChildren.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
 	import { api } from '$lib/api/client';
-	import type { Item } from '$lib/types';
+	import type { Item, PaneTarget } from '$lib/types';
 	import { parseFields, formatItemRef } from '$lib/types';
+	import { shouldOpenInPane } from './collections/itemCardClick';
 
 	interface Props {
 		wsSlug: string;
@@ -10,9 +11,16 @@
 		depth?: number;
 		maxDepth?: number;
 		terminalStatuses?: string[];
+		/**
+		 * In-pane drill interceptor (PLAN-2154 Architecture B.2 / TASK-2159).
+		 * Threaded from `ChildItems`/`ItemDetail`'s `fireOpenTarget`; forwarded
+		 * unchanged into the recursive `svelte:self` so every depth intercepts
+		 * the same way. `undefined` when no host wired a pane.
+		 */
+		onOpenTarget?: (target: PaneTarget) => void;
 	}
 
-	let { wsSlug, username = '', parentSlug, depth = 1, maxDepth = 3, terminalStatuses }: Props = $props();
+	let { wsSlug, username = '', parentSlug, depth = 1, maxDepth = 3, terminalStatuses, onOpenTarget }: Props = $props();
 
 	const defaultTerminal = ['done', 'completed', 'resolved', 'cancelled', 'rejected', 'wontfix', 'fixed', 'implemented', 'archived', 'disabled', 'deprecated'];
 	const terminal = $derived(terminalStatuses ?? defaultTerminal);
@@ -48,6 +56,16 @@
 	}
 
 	let doneCount = $derived(children.filter(c => terminal.includes(parseFields(c).status)).length);
+
+	// In-pane drill interception for a `.nested-link` anchor (TASK-2159 /
+	// PLAN-2154 Architecture B.2) — same predicate/contract as
+	// `ChildItems.handleChildClick`, duplicated rather than shared because the
+	// two components have independent `child`-shaped data on hand.
+	function handleChildClick(e: MouseEvent, child: Item) {
+		if (!shouldOpenInPane(e, !!onOpenTarget)) return;
+		e.preventDefault();
+		onOpenTarget?.({ ref: formatItemRef(child) ?? undefined, slug: child.slug, collectionSlug: child.collection_slug });
+	}
 </script>
 
 {#if loading}
@@ -74,7 +92,7 @@
 					{:else}
 						<span class="expand-spacer"></span>
 					{/if}
-					<a href="/{username}/{wsSlug}/{child.collection_slug}/{child.slug}" class="nested-link">
+					<a href="/{username}/{wsSlug}/{child.collection_slug}/{child.slug}" class="nested-link" onclick={(e) => handleChildClick(e, child)}>
 						<span class="nested-ref">{formatItemRef(child) ?? ''}</span>
 						<span class="nested-title" class:done={isDone}>{child.title}</span>
 					</a>
@@ -89,7 +107,7 @@
 					{/if}
 				</div>
 				{#if canExpand && isExpanded}
-					<svelte:self wsSlug={wsSlug} {username} parentSlug={child.slug} depth={depth + 1} {maxDepth} {terminalStatuses} />
+					<svelte:self wsSlug={wsSlug} {username} parentSlug={child.slug} depth={depth + 1} {maxDepth} {terminalStatuses} {onOpenTarget} />
 				{/if}
 			</div>
 		{/each}

--- a/web/src/lib/components/graph/ItemGraph.svelte
+++ b/web/src/lib/components/graph/ItemGraph.svelte
@@ -14,15 +14,17 @@
 
 	import { onMount, untrack } from 'svelte';
 	import { api } from '$lib/api/client';
-	import type { GraphEdge, GraphNode, GraphResponse } from '$lib/types';
+	import type { GraphEdge, GraphNode, GraphResponse, PaneTarget } from '$lib/types';
 	import { createCollectionColorMap } from '$lib/graph/palette';
 	import { sseService, type ItemEvent } from '$lib/services/sse.svelte';
+	import { shouldOpenInPane } from '$lib/components/collections/itemCardClick';
 
 	let {
 		workspace,
 		focusRef,
 		depth: initialDepth = 2,
-		itemHref
+		itemHref,
+		onOpenTarget
 	}: {
 		workspace: string;
 		focusRef: string;
@@ -31,6 +33,14 @@
 		 *  cmd/ctrl-click opens the item in a new tab. Collection is passed so the
 		 *  caller can build /{user}/{ws}/{collection}/{ref} without a lookup. */
 		itemHref: (ref: string, collection?: string) => string;
+		/**
+		 * In-pane drill interceptor (PLAN-2154 Architecture B.4 / TASK-2159).
+		 * Intercepts the "Open" anchors ONLY — node clicks stay select-only, per
+		 * the plan (a stray click on a node must not navigate away). `undefined`
+		 * when no host wired a pane (e.g. the full-page route), in which case
+		 * the anchors fall through to plain `href` navigation.
+		 */
+		onOpenTarget?: (target: PaneTarget) => void;
 	} = $props();
 
 	// ── Fixed layout geometry ────────────────────────────────────────────────────
@@ -572,6 +582,16 @@
 		currentFocus = ref; // re-root the neighborhood on this node
 	}
 
+	// In-pane drill interception for the node "Open" anchors (TASK-2159 /
+	// PLAN-2154 Architecture B.4) — the controls-bar "Open ↗" and the
+	// detail-card "Open item ↗". NOT wired to node click/dblclick, which stay
+	// select/zoom-only (a stray click on a node must not navigate away).
+	function handleOpenClick(e: MouseEvent, ref: string, collection?: string) {
+		if (!shouldOpenInPane(e, !!onOpenTarget)) return;
+		e.preventDefault();
+		onOpenTarget?.({ ref, collectionSlug: collection });
+	}
+
 	function backToOrigin() {
 		currentFocus = focusRef;
 	}
@@ -682,7 +702,7 @@
 		<div class="spacer"></div>
 
 		<button type="button" class="ghost-btn" onclick={fitView} title="Fit graph to view">Fit</button>
-		<a class="open-btn" href={itemHref(currentFocus, collectionFor(currentFocus))}>Open ↗</a>
+		<a class="open-btn" href={itemHref(currentFocus, collectionFor(currentFocus))} onclick={(e) => handleOpenClick(e, currentFocus, collectionFor(currentFocus))}>Open ↗</a>
 	</div>
 
 	<!-- Canvas -->
@@ -832,7 +852,7 @@
 					{/if}
 				</div>
 				<div class="detail-actions">
-					<a class="open-btn" href={itemHref(sel.ref, sel.collection)}>Open item ↗</a>
+					<a class="open-btn" href={itemHref(sel.ref, sel.collection)} onclick={(e) => handleOpenClick(e, sel.ref, sel.collection)}>Open item ↗</a>
 					{#if sel.ref !== currentFocus}
 						<button type="button" class="ghost-btn" onclick={() => focusHere(sel.ref)}>Focus here</button>
 					{/if}

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -41,6 +41,7 @@
 	import { copyToClipboard } from '$lib/utils/clipboard';
 	import { repairDeadItemLastRoute } from '$lib/collections/paneUrlParams';
 	import { isSamePaneTarget } from '$lib/collections/paneTarget';
+	import { shouldOpenInPane } from '$lib/components/collections/itemCardClick';
 	import { starredStore } from '$lib/stores/starred.svelte';
 	import { titleStore } from '$lib/stores/title.svelte';
 	import { workspaceStore } from '$lib/stores/workspace.svelte';
@@ -51,6 +52,12 @@
 		href: string | null;
 		status?: string;
 		linkId?: string;
+		// PaneTarget metadata (TASK-2159) — carried alongside `href` so the
+		// in-pane click interceptor can build a precise `PaneTarget` (ref/slug
+		// preferred over parsing href's trailing segment) without a re-lookup.
+		ref?: string;
+		slug?: string;
+		collectionSlug?: string;
 	};
 
 	type RelationshipGroup = {
@@ -176,20 +183,31 @@
 		return gen !== loadGeneration || item?.id !== targetItem.id;
 	}
 
-	// The `onOpenTarget` seam's same-item guard (PLAN-2154 / TASK-2158). No
-	// content-link surface calls this yet — TASK-2159/2160's relationships /
-	// breadcrumb / editor wiki-link / graph interceptors will call
-	// `fireOpenTarget(target)` instead of `onOpenTarget?.(target)` directly, so
-	// a link that names THIS item (by ref, slug, id, or an href built from
-	// either — even when it differs from however the pane's own `?item=` names
-	// it) is dropped here rather than round-tripping to the host only to
-	// become a no-op there. `isSamePaneTarget` is the same reusable check
-	// `resolvePaneTarget` (`$lib/collections/paneTarget`) applies when a
-	// caller passes it a `current` item.
+	// The `onOpenTarget` seam's same-item guard (PLAN-2154 / TASK-2158). The
+	// TASK-2159 anchor interceptors (relationships / Children / graph "Open")
+	// call `fireOpenTarget(target)` instead of `onOpenTarget?.(target)`
+	// directly, so a link that names THIS item (by ref, slug, id, or an href
+	// built from either — even when it differs from however the pane's own
+	// `?item=` names it) is dropped here rather than round-tripping to the
+	// host only to become a no-op there. `isSamePaneTarget` is the same
+	// reusable check `resolvePaneTarget` (`$lib/collections/paneTarget`)
+	// applies when a caller passes it a `current` item.
 	function fireOpenTarget(target: PaneTarget) {
 		if (isSamePaneTarget(target, item)) return;
 		onOpenTarget?.(target);
 	}
+
+	// The callback threaded down to the anchor-based content-link surfaces
+	// (relationships, `ChildItems`/`NestedChildren`, `ItemGraph`'s "Open"
+	// anchor — TASK-2159). `undefined` — not `fireOpenTarget` — when no host
+	// wired `onOpenTarget` (e.g. the full-page route with no pane): those
+	// surfaces gate their click interception on `!!onOpenTarget` (mirroring
+	// `ItemCard`'s `shouldOpenInPane` contract, itemCardClick.ts), so passing
+	// a function that would just silently no-op after already having called
+	// `preventDefault()` would swallow the click with nothing happening.
+	// Passing `undefined` instead lets it fall through to the anchor's plain
+	// `href` navigation, same as before this task.
+	let paneOpenTarget = $derived(onOpenTarget ? fireOpenTarget : undefined);
 
 	// Cross-collection `?item=` safety (PLAN-2105 / TASK-2112). A stale /
 	// shared / hand-crafted `?item=REF` in the split pane could reference an
@@ -2829,7 +2847,10 @@
 			label: relationLabel(ref, title, id),
 			href,
 			status,
-			linkId: link.id
+			linkId: link.id,
+			ref,
+			slug,
+			collectionSlug
 		};
 	}
 
@@ -2986,6 +3007,18 @@
 	// prop — a cross-collection `?item=` in the pane could otherwise offer a
 	// no-op "move" to the item's own collection (PLAN-2105 / TASK-2112).
 	let moveTargets = $derived(allCollections.filter(c => c.slug !== effectiveCollSlug));
+
+	// In-pane drill interception for a relationship's `<a class="link-target">`
+	// (TASK-2159 / PLAN-2154 Architecture B.1). Sits as a SIBLING of the
+	// delete button (`.link-row-actions .link-delete-btn`), not a descendant,
+	// so a delete click never bubbles through this anchor in the first place;
+	// `shouldOpenInPane`'s `defaultPrevented` check is still applied as the
+	// same backstop every other interceptor uses.
+	function handleRelationshipClick(e: MouseEvent, entry: RelationshipEntry) {
+		if (!shouldOpenInPane(e, !!paneOpenTarget)) return;
+		e.preventDefault();
+		paneOpenTarget?.({ ref: entry.ref, slug: entry.slug, href: entry.href ?? undefined, collectionSlug: entry.collectionSlug });
+	}
 
 	async function handleDeleteLink(linkId?: string) {
 		if (!linkId || !item) return;
@@ -4072,7 +4105,7 @@
 								{#each group.entries as entry (entry.key)}
 									<div class="link-row" class:tone-blocks={group.tone === 'blocks'} class:tone-wiki={group.tone === 'wiki'} class:tone-lineage={group.tone === 'lineage'}>
 										{#if entry.href}
-											<a href={entry.href} class="link-target">{entry.label}</a>
+											<a href={entry.href} class="link-target" onclick={(e) => handleRelationshipClick(e, entry)}>{entry.label}</a>
 										{:else}
 											<span class="link-target">{entry.label}</span>
 										{/if}
@@ -4151,7 +4184,7 @@
 		     always-mounted SSE guarantee below. -->
 		{#if item}
 			<div id="item-children" class="children-anchor">
-				<ChildItems {wsSlug} {username} {itemSlug} itemId={item.id} parentFields={fields} terminalStatuses={childTerminalStatuses} onChildrenChange={(children) => { if (keyedSlug !== itemSlug) return; handleChildrenChange(children); }} {canEdit} selfDirty={localDirty} selfLastSaveTime={localLastSaveTime} />
+				<ChildItems {wsSlug} {username} {itemSlug} itemId={item.id} parentFields={fields} terminalStatuses={childTerminalStatuses} onChildrenChange={(children) => { if (keyedSlug !== itemSlug) return; handleChildrenChange(children); }} {canEdit} selfDirty={localDirty} selfLastSaveTime={localLastSaveTime} onOpenTarget={paneOpenTarget} />
 			</div>
 		{/if}
 
@@ -4232,7 +4265,7 @@
 					</div>
 				{:else if ItemGraphComp}
 					{@const Graph = ItemGraphComp}
-					<Graph workspace={wsSlug} focusRef={graphFocusRef} itemHref={graphItemHref} />
+					<Graph workspace={wsSlug} focusRef={graphFocusRef} itemHref={graphItemHref} onOpenTarget={paneOpenTarget} />
 				{:else}
 					<div class="graph-drawer-state">Loading graph…</div>
 				{/if}


### PR DESCRIPTION
## Summary
- Intercepts the three anchor-based content-link surfaces PLAN-2154 Architecture B targets so a plain click drills the pane in place instead of hard-navigating: the relationships `<a class="link-target">` in `ItemDetail`, `ChildItems`' `.child-row` + recursive `NestedChildren`'s `.nested-link`, and `ItemGraph`'s node "Open" anchors (the node click itself stays select-only, per the plan).
- Every interceptor reuses the existing `shouldOpenInPane` predicate (`itemCardClick.ts`) and builds a `PaneTarget` fired through `ItemDetail`'s `fireOpenTarget` seam (from TASK-2158/#964) — modifier/middle-click still falls through to the anchor's plain `href` for a full-page popout, and the pane host's `onOpenTarget` resolves/drills via the already-wired `handleOpenTarget` → `resolvePaneTarget` → `navigatePaneTo` path.
- `ItemDetail` only threads a live callback down to `ChildItems`/`ItemGraph`/the relationships handler when the host actually wired a pane (`paneOpenTarget = onOpenTarget ? fireOpenTarget : undefined`), so a click on the full-page route (no pane) falls through to normal navigation instead of being silently swallowed.

## Test plan
- [x] `npm run check` — 0 errors (pre-existing warnings only)
- [x] `npx vitest run` — 374/374 passing
- [x] New Playwright e2e (`web/e2e/pane-content-link-anchors.spec.ts`, 4 tests) covering all three surfaces: plain click drills the pane in place (URL `?item=` swaps, pathname unchanged), and ctrl-click still opens the full page via a real new-tab popup — run repeatedly (`--repeat-each=3`) with no flakes
- [x] Full existing pane e2e suite (`pane-controller`, `pane-a11y-focus`, `pane-mobile-overlay`, `pane-collection-migration-race`) still green after merging `origin/main` (TASK-2161, #965)
- [x] Codex review: CLEAN

https://claude.ai/code/session_01EZ6yr6pAUFb1uffan912ra