### PR TITLE
feat(web): editor content-link pane interception via EditorLinkPopover (TASK-2160)

### DIFF
--- a/web/src/lib/collections/paneTarget.test.ts
+++ b/web/src/lib/collections/paneTarget.test.ts
@@ -219,11 +219,12 @@ describe('resolvePaneTarget — same-item guard short-circuits to null', () => {
 });
 
 describe('isSameWorkspaceItemHref — editor content-link gate (TASK-2160)', () => {
-	// collection slug → ref prefix
+	// collection slug → ref prefix (incl. a digit-bearing prefix, R2)
 	const colls = new Map([
 		['tasks', 'TASK'],
 		['docs', 'DOC'],
 		['plans', 'PLAN'],
+		['releases', 'R2'],
 	]);
 
 	it('accepts a username-prefixed item link in the current workspace', () => {
@@ -241,6 +242,24 @@ describe('isSameWorkspaceItemHref — editor content-link gate (TASK-2160)', () 
 
 	it('matches the ref prefix case-insensitively (server parseItemRef parity)', () => {
 		expect(isSameWorkspaceItemHref('/alice/myws/tasks/task-5', 'myws', colls)).toBe(true);
+	});
+
+	it('accepts a digit-bearing collection prefix (e.g. R2-1 — server ref grammar allows it)', () => {
+		expect(isSameWorkspaceItemHref('/alice/myws/releases/R2-1', 'myws', colls)).toBe(true);
+	});
+
+	it('rejects a digit-bearing SLUG that is not a known collection prefix (roadmap2-5)', () => {
+		// The exact prefix comparison keeps `roadmap2-5` a plain slug — its
+		// "prefix" (roadmap2) is not `docs`' prefix (DOC).
+		expect(isSameWorkspaceItemHref('/alice/myws/docs/roadmap2-5', 'myws', colls)).toBe(false);
+	});
+
+	it('rejects a malformed double-slash path (empty interior segment)', () => {
+		expect(isSameWorkspaceItemHref('/alice/myws//tasks/TASK-9', 'myws', colls)).toBe(false);
+	});
+
+	it('rejects a trailing-slash path (empty final segment)', () => {
+		expect(isSameWorkspaceItemHref('/alice/myws/tasks/TASK-5/', 'myws', colls)).toBe(false);
 	});
 
 	it('strips query/hash before matching', () => {
@@ -280,10 +299,6 @@ describe('isSameWorkspaceItemHref — editor content-link gate (TASK-2160)', () 
 		expect(isSameWorkspaceItemHref('/console', 'myws', colls)).toBe(false);
 		expect(isSameWorkspaceItemHref('/alice/myws/settings', 'myws', colls)).toBe(false); // settings not a collection
 		expect(isSameWorkspaceItemHref('/a/alice/myws/tasks/TASK-5', 'myws', colls)).toBe(false);
-	});
-
-	it('does not misread a digit-bearing slug as a ref', () => {
-		expect(isSameWorkspaceItemHref('/alice/myws/docs/roadmap2-5', 'myws', colls)).toBe(false);
 	});
 
 	it('declines when context is missing (empty wsSlug or empty collection map)', () => {

--- a/web/src/lib/collections/paneTarget.test.ts
+++ b/web/src/lib/collections/paneTarget.test.ts
@@ -265,6 +265,13 @@ describe('isSameWorkspaceItemHref — editor content-link gate (TASK-2160)', () 
 		expect(isSameWorkspaceItemHref('//evil.example/myws/tasks/TASK-5', 'myws', colls)).toBe(false);
 	});
 
+	it('rejects a backslash-in-segment href (URL-normalizes but the raw href is what gets resolved)', () => {
+		// `/alice/myws/tasks\TASK-5` normalizes to `.../tasks/TASK-5`, but the
+		// raw href is what the host later splits on "/" — accepting it would
+		// drill a bogus `tasks\TASK-5` item. Require canonical form (Codex).
+		expect(isSameWorkspaceItemHref('/alice/myws/tasks\\TASK-5', 'myws', colls)).toBe(false);
+	});
+
 	it('rejects a malformed double-slash path (empty interior segment)', () => {
 		expect(isSameWorkspaceItemHref('/alice/myws//tasks/TASK-9', 'myws', colls)).toBe(false);
 	});

--- a/web/src/lib/collections/paneTarget.test.ts
+++ b/web/src/lib/collections/paneTarget.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import type { Item, PaneTarget } from '$lib/types';
-import { resolvePaneTarget, isSamePaneTarget } from './paneTarget';
+import { resolvePaneTarget, isSamePaneTarget, isSameWorkspaceItemHref } from './paneTarget';
 
 // Minimal Item stand-in — resolution/guard only touch id/slug/item_number/
 // collection_prefix (the fields `formatItemRef`/`itemUrlId` read).
@@ -215,5 +215,79 @@ describe('resolvePaneTarget — same-item guard short-circuits to null', () => {
 	it('resolves normally (no guard) when current has no matching id/ref/slug', () => {
 		const target: PaneTarget = { slug: 'legacy-item' };
 		expect(resolvePaneTarget(target, task5)).toBe('legacy-item');
+	});
+});
+
+describe('isSameWorkspaceItemHref — editor content-link gate (TASK-2160)', () => {
+	// collection slug → ref prefix
+	const colls = new Map([
+		['tasks', 'TASK'],
+		['docs', 'DOC'],
+		['plans', 'PLAN'],
+	]);
+
+	it('accepts a username-prefixed item link in the current workspace', () => {
+		expect(isSameWorkspaceItemHref('/alice/myws/tasks/TASK-5', 'myws', colls)).toBe(true);
+	});
+
+	it('accepts a workspace-root-relative (no username) item link', () => {
+		expect(isSameWorkspaceItemHref('/myws/tasks/TASK-5', 'myws', colls)).toBe(true);
+	});
+
+	it('accepts a link into any known collection whose prefix matches the ref', () => {
+		expect(isSameWorkspaceItemHref('/alice/myws/docs/DOC-9', 'myws', colls)).toBe(true);
+		expect(isSameWorkspaceItemHref('/alice/myws/plans/PLAN-2', 'myws', colls)).toBe(true);
+	});
+
+	it('matches the ref prefix case-insensitively (server parseItemRef parity)', () => {
+		expect(isSameWorkspaceItemHref('/alice/myws/tasks/task-5', 'myws', colls)).toBe(true);
+	});
+
+	it('strips query/hash before matching', () => {
+		expect(isSameWorkspaceItemHref('/alice/myws/tasks/TASK-5?x=1', 'myws', colls)).toBe(true);
+		expect(isSameWorkspaceItemHref('/alice/myws/tasks/TASK-5#sec', 'myws', colls)).toBe(true);
+	});
+
+	it('rejects a DIFFERENT workspace item as a plain path (would open the wrong item)', () => {
+		expect(isSameWorkspaceItemHref('/bob/otherws/tasks/TASK-9', 'myws', colls)).toBe(false);
+	});
+
+	it('rejects a non-item route whose tail merely looks ref-shaped', () => {
+		// `tags` is not a collection → tags route, not an item.
+		expect(isSameWorkspaceItemHref('/alice/myws/tags/TASK-5', 'myws', colls)).toBe(false);
+	});
+
+	it('rejects a self-inconsistent collection/ref path (collection prefix != ref prefix)', () => {
+		// `TASK-9` is a task, not a doc — the collection segment's prefix (DOC)
+		// must match the ref's prefix (TASK). Otherwise a hand-authored
+		// `/docs/TASK-9` would drop the segment and drill the real TASK-9.
+		expect(isSameWorkspaceItemHref('/alice/myws/docs/TASK-9', 'myws', colls)).toBe(false);
+	});
+
+	it('rejects a zero-number ref (server parseItemRef rejects zero)', () => {
+		expect(isSameWorkspaceItemHref('/alice/myws/tasks/TASK-0', 'myws', colls)).toBe(false);
+	});
+
+	it('rejects a cross-workspace resolver link', () => {
+		expect(isSameWorkspaceItemHref('/-/r/other-workspace/TASK-9', 'myws', colls)).toBe(false);
+	});
+
+	it('rejects a slug-only (non-ref) trailing segment', () => {
+		expect(isSameWorkspaceItemHref('/alice/myws/docs/some-slug', 'myws', colls)).toBe(false);
+	});
+
+	it('rejects wrong segment counts (too short / too long)', () => {
+		expect(isSameWorkspaceItemHref('/console', 'myws', colls)).toBe(false);
+		expect(isSameWorkspaceItemHref('/alice/myws/settings', 'myws', colls)).toBe(false); // settings not a collection
+		expect(isSameWorkspaceItemHref('/a/alice/myws/tasks/TASK-5', 'myws', colls)).toBe(false);
+	});
+
+	it('does not misread a digit-bearing slug as a ref', () => {
+		expect(isSameWorkspaceItemHref('/alice/myws/docs/roadmap2-5', 'myws', colls)).toBe(false);
+	});
+
+	it('declines when context is missing (empty wsSlug or empty collection map)', () => {
+		expect(isSameWorkspaceItemHref('/alice/myws/tasks/TASK-5', '', colls)).toBe(false);
+		expect(isSameWorkspaceItemHref('/alice/myws/tasks/TASK-5', 'myws', new Map())).toBe(false);
 	});
 });

--- a/web/src/lib/collections/paneTarget.test.ts
+++ b/web/src/lib/collections/paneTarget.test.ts
@@ -254,6 +254,17 @@ describe('isSameWorkspaceItemHref — editor content-link gate (TASK-2160)', () 
 		expect(isSameWorkspaceItemHref('/alice/myws/docs/roadmap2-5', 'myws', colls)).toBe(false);
 	});
 
+	it('rejects a backslash-authority href that resolves cross-origin (/\\evil.example/...)', () => {
+		// Browsers treat "\" as "/", so this resolves to https://evil.example/…
+		// — an external navigation that must NOT be classified as a local item
+		// link even though it "looks" root-relative (Codex review).
+		expect(isSameWorkspaceItemHref('/\\evil.example/myws/tasks/TASK-5', 'myws', colls)).toBe(false);
+	});
+
+	it('rejects a protocol-relative (//host/...) href', () => {
+		expect(isSameWorkspaceItemHref('//evil.example/myws/tasks/TASK-5', 'myws', colls)).toBe(false);
+	});
+
 	it('rejects a malformed double-slash path (empty interior segment)', () => {
 		expect(isSameWorkspaceItemHref('/alice/myws//tasks/TASK-9', 'myws', colls)).toBe(false);
 	});

--- a/web/src/lib/collections/paneTarget.ts
+++ b/web/src/lib/collections/paneTarget.ts
@@ -35,6 +35,14 @@ const CROSS_WORKSPACE_HREF_PREFIX = '/-/r/';
 // catches both uniformly; a raw `string.startsWith` on the href only catches
 // the root-relative case (Codex review).
 const HREF_PARSE_BASE = 'http://pad.invalid';
+// The host of `HREF_PARSE_BASE` — a resolved href keeps this host ONLY when it
+// was a genuinely same-origin root-relative path. A value like
+// "/\evil.example/…" (browsers treat "\" as "/") or "//evil.example/…"
+// resolves to a DIFFERENT host and is really an external navigation, so
+// comparing the parsed host against this sentinel is the robust "is this
+// truly local?" test — a raw `startsWith('/')` string check is fooled by the
+// backslash trick (Codex review).
+const HREF_PARSE_HOST = new URL(HREF_PARSE_BASE).host;
 
 /** True when `href` is (or resolves to) the cross-workspace resolver route. */
 function isCrossWorkspaceHref(href: string): boolean {
@@ -125,16 +133,23 @@ export function isSameWorkspaceItemHref(
 ): boolean {
 	if (!wsSlug || collectionPrefixes.size === 0) return false;
 	if (isCrossWorkspaceHref(href)) return false;
-	const path = href.split(/[?#]/)[0];
-	// A root-relative href always leads with "/", so split()[0] is the empty
-	// string before it; require that (rejects a non-root-relative value) and
-	// strip it. Do NOT `filter(Boolean)` the rest — collapsing empties would
-	// accept malformed paths with a double slash / trailing slash
+	// Parse against the sentinel base and require the result to be
+	// same-origin: this rejects an href that only LOOKS root-relative but
+	// resolves cross-origin (`/\evil.example/…`, `//evil.example/…`) — those
+	// are external navigations, not local item links (Codex review).
+	let url: URL;
+	try {
+		url = new URL(href, HREF_PARSE_BASE);
+	} catch {
+		return false;
+	}
+	if (url.host !== HREF_PARSE_HOST) return false;
+	// `url.pathname` always leads with "/", so split()[0] is the empty string
+	// before it; drop it. Do NOT `filter(Boolean)` the rest — collapsing
+	// empties would accept malformed paths with a double slash / trailing slash
 	// (`/alice/myws//tasks/TASK-9`) as valid item routes (Codex review). Any
 	// remaining empty segment means the path isn't a clean item URL.
-	const raw = path.split('/');
-	if (raw[0] !== '') return false;
-	const segments = raw.slice(1);
+	const segments = url.pathname.split('/').slice(1);
 	if (segments.some((s) => s === '')) return false;
 	let ws: string;
 	let coll: string;

--- a/web/src/lib/collections/paneTarget.ts
+++ b/web/src/lib/collections/paneTarget.ts
@@ -137,6 +137,7 @@ export function isSameWorkspaceItemHref(
 	// same-origin: this rejects an href that only LOOKS root-relative but
 	// resolves cross-origin (`/\evil.example/…`, `//evil.example/…`) — those
 	// are external navigations, not local item links (Codex review).
+	const rawPath = href.split(/[?#]/)[0];
 	let url: URL;
 	try {
 		url = new URL(href, HREF_PARSE_BASE);
@@ -144,6 +145,15 @@ export function isSameWorkspaceItemHref(
 		return false;
 	}
 	if (url.host !== HREF_PARSE_HOST) return false;
+	// Require the raw path to ALREADY be in canonical form. The URL parser
+	// silently normalizes a path (backslash→slash, dot-segments, percent
+	// casing), so an href like `/alice/myws/tasks\TASK-5` would validate as
+	// `.../tasks/TASK-5` here — yet the RAW href is what the host later resolves
+	// (`resolvePaneTarget` splits on "/" only), yielding a bogus `tasks\TASK-5`
+	// segment and drilling an invalid item. Every builder emits clean ASCII
+	// item URLs, so any href that isn't already canonical isn't one — navigate
+	// it normally instead (Codex review, regression guard).
+	if (url.pathname !== rawPath) return false;
 	// `url.pathname` always leads with "/", so split()[0] is the empty string
 	// before it; drop it. Do NOT `filter(Boolean)` the rest — collapsing
 	// empties would accept malformed paths with a double slash / trailing slash

--- a/web/src/lib/collections/paneTarget.ts
+++ b/web/src/lib/collections/paneTarget.ts
@@ -79,6 +79,79 @@ function parseRefNumber(candidate: string): number | null {
 }
 
 /**
+ * True when `href` is a root-relative link to a REF-identified item IN THE
+ * CURRENT WORKSPACE (`wsSlug`) that is WELL-FORMED — its collection segment
+ * is a known workspace collection AND that collection's prefix matches the
+ * ref's prefix (i.e. exactly the shape every item-URL builder emits). This
+ * is the strict gate that decides whether the ONE untrusted content-link
+ * surface — `EditorLinkPopover`, whose href comes off a Tiptap `link` MARK —
+ * may drill the split pane.
+ *
+ * Every OTHER `PaneTarget.href` producer (relationships, children, the graph
+ * drawer) builds its href FROM real same-workspace item data, so it's
+ * item-shaped by construction and doesn't need this check — `resolvePaneTarget`
+ * trusts it outright, slug-only items included. The editor popover is
+ * different: a `link` mark is indistinguishable between a wiki-link-inserted
+ * item link and a human-typed arbitrary path (Codex review, TASK-2160). A
+ * trailing-REF-shape test ALONE isn't enough, because the pane's `?item=`
+ * is scoped to the CURRENT workspace and resolved by ref NUMBER (the
+ * collection segment is dropped): a link to a different workspace's item as
+ * a plain path (`/bob/otherws/tasks/TASK-9` — NOT a `/-/r/` resolver link),
+ * to a non-item route that merely ends in a ref-shaped segment
+ * (`/alice/myws/tags/TASK-5`), or to a self-inconsistent path whose
+ * collection doesn't match the ref (`/alice/myws/playbooks/TASK-9`) would
+ * otherwise drill the current workspace's same-numbered item. So the
+ * segments are checked POSITIONALLY against the two shapes every item-URL
+ * builder in this codebase emits (`itemUrlId` via `renderMarkdown`/
+ * `wikiLinksToMarkdown`/`Editor.execLink`):
+ *
+ *   [username, workspace, collection, REF]   (4 segments — with username)
+ *   [workspace, collection, REF]             (3 segments — no username)
+ *
+ * requiring `workspace === wsSlug`, a `collectionPrefixes` entry for
+ * `collection`, a REF whose prefix equals that collection's prefix
+ * (case-insensitive — mirrors the server's case-insensitive `parseItemRef`),
+ * and a POSITIVE ref number (rejecting `TASK-0`, which the server's
+ * `parseItemRef` also rejects). A cross-workspace resolver link is rejected
+ * up front. Anything else falls back to a normal `goto` — the link still
+ * works, it just doesn't drill the pane (a graceful degradation, not a
+ * break). Empty `wsSlug` or `collectionPrefixes` (context not yet loaded)
+ * also declines, for the same safe fallback.
+ */
+export function isSameWorkspaceItemHref(
+	href: string,
+	wsSlug: string,
+	collectionPrefixes: ReadonlyMap<string, string>,
+): boolean {
+	if (!wsSlug || collectionPrefixes.size === 0) return false;
+	if (isCrossWorkspaceHref(href)) return false;
+	const path = href.split(/[?#]/)[0];
+	const segments = path.split('/').filter(Boolean);
+	let ws: string;
+	let coll: string;
+	let ref: string;
+	if (segments.length === 4) {
+		[, ws, coll, ref] = segments;
+	} else if (segments.length === 3) {
+		[ws, coll, ref] = segments;
+	} else {
+		return false;
+	}
+	if (ws !== wsSlug) return false;
+	const expectedPrefix = collectionPrefixes.get(coll);
+	if (!expectedPrefix) return false;
+	const m = REF_SHAPE.exec(ref);
+	if (!m) return false;
+	const [, refPrefix, numStr] = m;
+	// The ref's prefix must name THIS collection (a self-consistent item-URL),
+	// and the number must be positive — a self-inconsistent path like
+	// `/playbooks/TASK-9` or a zero ref like `/tasks/TASK-0` navigates
+	// normally instead of drilling the wrong pane item.
+	if (refPrefix.toLowerCase() !== expectedPrefix.toLowerCase()) return false;
+	return Number(numStr) > 0;
+}
+
+/**
  * The raw ref-or-slug candidate a `PaneTarget` carries, before any
  * same-item normalization — `ref` preferred over `slug` over an `href`'s
  * trailing segment (mirrors `itemUrlId`/`formatItemRef`'s ref-over-slug

--- a/web/src/lib/collections/paneTarget.ts
+++ b/web/src/lib/collections/paneTarget.ts
@@ -126,7 +126,16 @@ export function isSameWorkspaceItemHref(
 	if (!wsSlug || collectionPrefixes.size === 0) return false;
 	if (isCrossWorkspaceHref(href)) return false;
 	const path = href.split(/[?#]/)[0];
-	const segments = path.split('/').filter(Boolean);
+	// A root-relative href always leads with "/", so split()[0] is the empty
+	// string before it; require that (rejects a non-root-relative value) and
+	// strip it. Do NOT `filter(Boolean)` the rest — collapsing empties would
+	// accept malformed paths with a double slash / trailing slash
+	// (`/alice/myws//tasks/TASK-9`) as valid item routes (Codex review). Any
+	// remaining empty segment means the path isn't a clean item URL.
+	const raw = path.split('/');
+	if (raw[0] !== '') return false;
+	const segments = raw.slice(1);
+	if (segments.some((s) => s === '')) return false;
 	let ws: string;
 	let coll: string;
 	let ref: string;
@@ -140,14 +149,21 @@ export function isSameWorkspaceItemHref(
 	if (ws !== wsSlug) return false;
 	const expectedPrefix = collectionPrefixes.get(coll);
 	if (!expectedPrefix) return false;
-	const m = REF_SHAPE.exec(ref);
-	if (!m) return false;
-	const [, refPrefix, numStr] = m;
-	// The ref's prefix must name THIS collection (a self-consistent item-URL),
-	// and the number must be positive — a self-inconsistent path like
-	// `/playbooks/TASK-9` or a zero ref like `/tasks/TASK-0` navigates
-	// normally instead of drilling the wrong pane item.
+	// The ref must be exactly `<collection-prefix>-<positive-int>` — a
+	// self-consistent item-URL as every builder emits. Comparing against the
+	// KNOWN prefix (rather than a generic REF_SHAPE) accepts digit-bearing
+	// collection prefixes like `R2-1` (the server's ref grammar allows a
+	// letter-led alphanumeric prefix) while still rejecting a digit-bearing
+	// SLUG like `roadmap2-5` (its "prefix" won't equal the collection's), a
+	// self-inconsistent path like `/docs/TASK-9` (prefix mismatch), and a
+	// zero ref like `TASK-0` (server `parseItemRef` rejects zero). Prefixes
+	// never contain a hyphen, so the LAST hyphen splits prefix from number.
+	const dash = ref.lastIndexOf('-');
+	if (dash <= 0 || dash === ref.length - 1) return false;
+	const refPrefix = ref.slice(0, dash);
+	const numStr = ref.slice(dash + 1);
 	if (refPrefix.toLowerCase() !== expectedPrefix.toLowerCase()) return false;
+	if (!/^\d+$/.test(numStr)) return false;
 	return Number(numStr) > 0;
 }
 

--- a/web/src/lib/components/editor/EditorLinkPopover.svelte
+++ b/web/src/lib/components/editor/EditorLinkPopover.svelte
@@ -1,11 +1,39 @@
 <script lang="ts">
 	import type { Editor } from '@tiptap/core';
 	import { goto } from '$app/navigation';
+	import type { PaneTarget } from '$lib/types';
+	import { planHrefClick } from './editorHrefClick';
+
+	// Stable empty fallback so an unprovided `collectionPrefixes` prop can't
+	// mint a fresh Map on every click (and reads as "no context → decline
+	// the pane drill" in `isSameWorkspaceItemHref`).
+	const EMPTY_COLLECTION_PREFIXES: ReadonlyMap<string, string> = new Map();
 
 	let {
 		editor,
+		onOpenTarget,
+		wsSlug = '',
+		collectionPrefixes,
 	}: {
 		editor: Editor | null;
+		// PLAN-2154 Architecture B.3 / TASK-2160: the pane-navigate seam.
+		// Content-body/wiki-link anchors in the Tiptap doc are inert
+		// `data-href` and every editor-anchor click is globally
+		// `preventDefault`ed elsewhere — this popover's `handleHrefClick` is
+		// the SINGLE chokepoint where navigation actually happens (open in a
+		// new tab and edit/remove bypass it entirely). `ItemDetail` threads
+		// its `fireOpenTarget` wrapper down here (same-item guard already
+		// applied there), so this component only decides WHETHER a click
+		// should drill the pane vs. hard-navigate — never resolves identity
+		// itself.
+		onOpenTarget?: (target: PaneTarget) => void;
+		// The current workspace slug + a map of collection slug → ref prefix —
+		// the context `planHrefClick` uses to confirm an internal link points at
+		// a WELL-FORMED item in THIS workspace before drilling the pane
+		// (rejecting cross-workspace plain paths, non-item routes, and
+		// self-inconsistent collection/ref paths; Codex review).
+		wsSlug?: string;
+		collectionPrefixes?: ReadonlyMap<string, string>;
 	} = $props();
 
 	let visible = $state(false);
@@ -112,19 +140,39 @@
 	// URLs fall back to a full-page load. The handler is attached to a
 	// real <a> element so middle-click / cmd-click / "copy link" behave
 	// naturally.
+	//
+	// PLAN-2154 Architecture B.3 / TASK-2160: this is the single `goto`
+	// chokepoint for editor content-body links, so it's also the single
+	// place that decides whether an internal item link should drill the
+	// pane in place instead of navigating away. Modifier/middle-click and
+	// external-URL handling are UNCHANGED — `planHrefClick` (factored out
+	// for unit testing, `./editorHrefClick`) only replaces the internal
+	// `goto(target)` call with the pane drill, and only when a handler is
+	// actually wired (a bare `<Editor>` with no `onOpenTarget`, e.g. an
+	// unembedded full-page view with no pane host, keeps navigating) AND the
+	// href is a current-workspace item link (`isSameWorkspaceItemHref`:
+	// right workspace slug + a known collection + a REF-shaped tail). A link
+	// a user typed by hand via "Edit link" — an app route, a different
+	// workspace's item, a `/-/r/` resolver link — is indistinguishable from
+	// a wiki-link at the Tiptap mark level, so it's left to navigate normally
+	// rather than misrouted into the current pane's `?item=` (Codex review).
 	function handleHrefClick(e: MouseEvent) {
-		if (!href) return;
-		// Let the browser handle new-tab modifiers and middle-click itself.
-		if (e.button !== 0 || e.ctrlKey || e.metaKey || e.shiftKey) return;
+		const plan = planHrefClick(e, href, {
+			hasOnOpenTarget: !!onOpenTarget,
+			wsSlug,
+			collectionPrefixes: collectionPrefixes ?? EMPTY_COLLECTION_PREFIXES,
+		});
+		if (plan.kind === 'passthrough') return;
 		e.preventDefault();
 		e.stopPropagation();
-		const target = href;
 		visible = false;
 		editing = false;
-		if (target.startsWith('/') && !target.startsWith('//')) {
-			goto(target);
+		if (plan.kind === 'pane') {
+			onOpenTarget?.({ href: plan.href });
+		} else if (plan.kind === 'goto') {
+			goto(plan.href);
 		} else {
-			window.location.assign(target);
+			window.location.assign(plan.href);
 		}
 	}
 

--- a/web/src/lib/components/editor/editorHrefClick.test.ts
+++ b/web/src/lib/components/editor/editorHrefClick.test.ts
@@ -2,14 +2,15 @@ import { describe, it, expect } from 'vitest';
 import { planHrefClick, type HrefClickContext } from './editorHrefClick';
 
 // A left-click with no modifiers held — the common case.
-const leftClick = { button: 0, ctrlKey: false, metaKey: false, shiftKey: false };
+const leftClick = { button: 0, ctrlKey: false, metaKey: false, shiftKey: false, altKey: false };
 
 // The current-workspace context: workspace "myws" with collections
-// tasks/docs/plans (slug → ref prefix).
+// tasks/docs/plans + a digit-bearing prefix collection (slug → ref prefix).
 const COLLS = new Map([
 	['tasks', 'TASK'],
 	['docs', 'DOC'],
 	['plans', 'PLAN'],
+	['releases', 'R2'],
 ]);
 function ctx(overrides: Partial<HrefClickContext> = {}): HrefClickContext {
 	return { hasOnOpenTarget: true, wsSlug: 'myws', collectionPrefixes: COLLS, ...overrides };
@@ -39,6 +40,11 @@ describe('planHrefClick — PLAN-2154 Architecture B.3 / TASK-2160', () => {
 			expect(planHrefClick(e, '/alice/myws/tasks/TASK-5', ctx())).toEqual({ kind: 'passthrough' });
 		});
 
+		it('passthrough on alt-click (download gesture — Codex review)', () => {
+			const e = { ...leftClick, altKey: true };
+			expect(planHrefClick(e, '/alice/myws/tasks/TASK-5', ctx())).toEqual({ kind: 'passthrough' });
+		});
+
 		it('passthrough on middle-click (button 1)', () => {
 			const e = { ...leftClick, button: 1 };
 			expect(planHrefClick(e, '/alice/myws/tasks/TASK-5', ctx())).toEqual({ kind: 'passthrough' });
@@ -64,6 +70,13 @@ describe('planHrefClick — PLAN-2154 Architecture B.3 / TASK-2160', () => {
 			expect(planHrefClick(leftClick, '/alice/myws/docs/DOC-9', ctx())).toEqual({
 				kind: 'pane',
 				href: '/alice/myws/docs/DOC-9',
+			});
+		});
+
+		it('drills the pane for a digit-bearing collection prefix (e.g. R2-1 — Codex review)', () => {
+			expect(planHrefClick(leftClick, '/alice/myws/releases/R2-1', ctx())).toEqual({
+				kind: 'pane',
+				href: '/alice/myws/releases/R2-1',
 			});
 		});
 	});
@@ -139,6 +152,13 @@ describe('planHrefClick — PLAN-2154 Architecture B.3 / TASK-2160', () => {
 			expect(planHrefClick(leftClick, '/alice/myws/tasks/TASK-0', ctx())).toEqual({
 				kind: 'goto',
 				href: '/alice/myws/tasks/TASK-0',
+			});
+		});
+
+		it('a malformed double-slash path falls back to goto (Codex review)', () => {
+			expect(planHrefClick(leftClick, '/alice/myws//tasks/TASK-9', ctx())).toEqual({
+				kind: 'goto',
+				href: '/alice/myws//tasks/TASK-9',
 			});
 		});
 	});

--- a/web/src/lib/components/editor/editorHrefClick.test.ts
+++ b/web/src/lib/components/editor/editorHrefClick.test.ts
@@ -170,6 +170,13 @@ describe('planHrefClick — PLAN-2154 Architecture B.3 / TASK-2160', () => {
 				href: '/\\evil.example/myws/tasks/TASK-5',
 			});
 		});
+
+		it('a backslash-in-segment href is NOT pane-drilled (raw != canonical — Codex review)', () => {
+			expect(planHrefClick(leftClick, '/alice/myws/tasks\\TASK-5', ctx())).toEqual({
+				kind: 'goto',
+				href: '/alice/myws/tasks\\TASK-5',
+			});
+		});
 	});
 
 	describe('missing context — declines to drill, falls back to goto', () => {

--- a/web/src/lib/components/editor/editorHrefClick.test.ts
+++ b/web/src/lib/components/editor/editorHrefClick.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect } from 'vitest';
+import { planHrefClick, type HrefClickContext } from './editorHrefClick';
+
+// A left-click with no modifiers held — the common case.
+const leftClick = { button: 0, ctrlKey: false, metaKey: false, shiftKey: false };
+
+// The current-workspace context: workspace "myws" with collections
+// tasks/docs/plans (slug → ref prefix).
+const COLLS = new Map([
+	['tasks', 'TASK'],
+	['docs', 'DOC'],
+	['plans', 'PLAN'],
+]);
+function ctx(overrides: Partial<HrefClickContext> = {}): HrefClickContext {
+	return { hasOnOpenTarget: true, wsSlug: 'myws', collectionPrefixes: COLLS, ...overrides };
+}
+
+describe('planHrefClick — PLAN-2154 Architecture B.3 / TASK-2160', () => {
+	it('passthrough when href is empty', () => {
+		expect(planHrefClick(leftClick, '', ctx())).toEqual({ kind: 'passthrough' });
+	});
+
+	describe('modifier / middle-click behavior — unchanged regardless of context', () => {
+		it('passthrough on ctrl-click (new tab)', () => {
+			const e = { ...leftClick, ctrlKey: true };
+			expect(planHrefClick(e, '/alice/myws/tasks/TASK-5', ctx())).toEqual({ kind: 'passthrough' });
+			expect(planHrefClick(e, '/alice/myws/tasks/TASK-5', ctx({ hasOnOpenTarget: false }))).toEqual({
+				kind: 'passthrough',
+			});
+		});
+
+		it('passthrough on cmd/meta-click (new tab)', () => {
+			const e = { ...leftClick, metaKey: true };
+			expect(planHrefClick(e, '/alice/myws/tasks/TASK-5', ctx())).toEqual({ kind: 'passthrough' });
+		});
+
+		it('passthrough on shift-click (new window)', () => {
+			const e = { ...leftClick, shiftKey: true };
+			expect(planHrefClick(e, '/alice/myws/tasks/TASK-5', ctx())).toEqual({ kind: 'passthrough' });
+		});
+
+		it('passthrough on middle-click (button 1)', () => {
+			const e = { ...leftClick, button: 1 };
+			expect(planHrefClick(e, '/alice/myws/tasks/TASK-5', ctx())).toEqual({ kind: 'passthrough' });
+		});
+	});
+
+	describe('same-workspace item link with a pane-navigate handler wired', () => {
+		it('drills the pane for a username-prefixed item link', () => {
+			expect(planHrefClick(leftClick, '/alice/myws/tasks/TASK-5', ctx())).toEqual({
+				kind: 'pane',
+				href: '/alice/myws/tasks/TASK-5',
+			});
+		});
+
+		it('drills the pane for a workspace-root-relative (no username) item link', () => {
+			expect(planHrefClick(leftClick, '/myws/tasks/TASK-5', ctx())).toEqual({
+				kind: 'pane',
+				href: '/myws/tasks/TASK-5',
+			});
+		});
+
+		it('drills the pane for a link into a DIFFERENT (but same-workspace) collection', () => {
+			expect(planHrefClick(leftClick, '/alice/myws/docs/DOC-9', ctx())).toEqual({
+				kind: 'pane',
+				href: '/alice/myws/docs/DOC-9',
+			});
+		});
+	});
+
+	describe('no pane-navigate handler wired (e.g. unembedded full-page view)', () => {
+		it('falls back to goto for an internal item link', () => {
+			expect(
+				planHrefClick(leftClick, '/alice/myws/tasks/TASK-5', ctx({ hasOnOpenTarget: false })),
+			).toEqual({ kind: 'goto', href: '/alice/myws/tasks/TASK-5' });
+		});
+	});
+
+	describe('cross-workspace links — never drill the current pane (Codex review)', () => {
+		it('falls back to goto for a /-/r/{workspace}/{ref} resolver link', () => {
+			expect(planHrefClick(leftClick, '/-/r/other-workspace/TASK-9', ctx())).toEqual({
+				kind: 'goto',
+				href: '/-/r/other-workspace/TASK-9',
+			});
+		});
+
+		it('falls back to goto for a DIFFERENT workspace item as a plain path (would open the wrong item)', () => {
+			// /bob/otherws/tasks/TASK-9 is a real, internal, ref-shaped link, but
+			// to a DIFFERENT workspace. Drilling would set ?item=TASK-9 on the
+			// CURRENT workspace's collection page — a different item numbered 9.
+			expect(planHrefClick(leftClick, '/bob/otherws/tasks/TASK-9', ctx())).toEqual({
+				kind: 'goto',
+				href: '/bob/otherws/tasks/TASK-9',
+			});
+		});
+	});
+
+	describe('internal non-item routes — not misrouted into a pane target (Codex review)', () => {
+		it('a non-item route with a ref-shaped tail (e.g. /tags/TASK-5) falls back to goto', () => {
+			// `tags` is not a collection slug, so this is a tags route, not an
+			// item — a trailing-REF-shape check alone would wrongly intercept it.
+			expect(planHrefClick(leftClick, '/alice/myws/tags/TASK-5', ctx())).toEqual({
+				kind: 'goto',
+				href: '/alice/myws/tags/TASK-5',
+			});
+		});
+
+		it('a workspace settings-style link falls back to goto', () => {
+			expect(planHrefClick(leftClick, '/alice/myws/settings', ctx())).toEqual({
+				kind: 'goto',
+				href: '/alice/myws/settings',
+			});
+		});
+
+		it('a bare top-level app route falls back to goto', () => {
+			expect(planHrefClick(leftClick, '/console', ctx())).toEqual({
+				kind: 'goto',
+				href: '/console',
+			});
+		});
+
+		it('a slug-only (no ref) item link falls back to goto — a graceful degradation, not a break', () => {
+			expect(planHrefClick(leftClick, '/alice/myws/docs/some-slug-title', ctx())).toEqual({
+				kind: 'goto',
+				href: '/alice/myws/docs/some-slug-title',
+			});
+		});
+
+		it('a self-inconsistent collection/ref path (e.g. /playbooks/TASK-9) falls back to goto (Codex review)', () => {
+			// `TASK-9` is a task, not a playbook — even if `playbooks` were a
+			// known collection, the ref prefix must match the collection.
+			expect(planHrefClick(leftClick, '/alice/myws/docs/TASK-9', ctx())).toEqual({
+				kind: 'goto',
+				href: '/alice/myws/docs/TASK-9',
+			});
+		});
+
+		it('a zero-number ref (e.g. TASK-0) falls back to goto (Codex review)', () => {
+			expect(planHrefClick(leftClick, '/alice/myws/tasks/TASK-0', ctx())).toEqual({
+				kind: 'goto',
+				href: '/alice/myws/tasks/TASK-0',
+			});
+		});
+	});
+
+	describe('missing context — declines to drill, falls back to goto', () => {
+		it('empty wsSlug falls back to goto', () => {
+			expect(planHrefClick(leftClick, '/alice/myws/tasks/TASK-5', ctx({ wsSlug: '' }))).toEqual({
+				kind: 'goto',
+				href: '/alice/myws/tasks/TASK-5',
+			});
+		});
+
+		it('empty collectionPrefixes falls back to goto', () => {
+			expect(
+				planHrefClick(leftClick, '/alice/myws/tasks/TASK-5', ctx({ collectionPrefixes: new Map() })),
+			).toEqual({ kind: 'goto', href: '/alice/myws/tasks/TASK-5' });
+		});
+	});
+
+	describe('external URLs — unchanged regardless of context', () => {
+		it('a protocol-relative URL ("//host/...") is external, not internal', () => {
+			expect(planHrefClick(leftClick, '//evil.example.com/x', ctx())).toEqual({
+				kind: 'external',
+				href: '//evil.example.com/x',
+			});
+		});
+
+		it('an absolute external URL is external', () => {
+			expect(planHrefClick(leftClick, 'https://example.com/page', ctx())).toEqual({
+				kind: 'external',
+				href: 'https://example.com/page',
+			});
+			expect(
+				planHrefClick(leftClick, 'https://example.com/page', ctx({ hasOnOpenTarget: false })),
+			).toEqual({ kind: 'external', href: 'https://example.com/page' });
+		});
+
+		it('a mailto: link is external', () => {
+			expect(planHrefClick(leftClick, 'mailto:a@b.com', ctx())).toEqual({
+				kind: 'external',
+				href: 'mailto:a@b.com',
+			});
+		});
+	});
+});

--- a/web/src/lib/components/editor/editorHrefClick.test.ts
+++ b/web/src/lib/components/editor/editorHrefClick.test.ts
@@ -161,6 +161,15 @@ describe('planHrefClick — PLAN-2154 Architecture B.3 / TASK-2160', () => {
 				href: '/alice/myws//tasks/TASK-9',
 			});
 		});
+
+		it('a backslash-authority href that resolves cross-origin is NOT pane-drilled (Codex review)', () => {
+			// "/\evil.example/..." resolves to https://evil.example/... in the
+			// browser — it must not be misclassified as a local item and drilled.
+			expect(planHrefClick(leftClick, '/\\evil.example/myws/tasks/TASK-5', ctx())).toEqual({
+				kind: 'goto',
+				href: '/\\evil.example/myws/tasks/TASK-5',
+			});
+		});
 	});
 
 	describe('missing context — declines to drill, falls back to goto', () => {

--- a/web/src/lib/components/editor/editorHrefClick.ts
+++ b/web/src/lib/components/editor/editorHrefClick.ts
@@ -1,0 +1,93 @@
+// Pure decision logic factored out of `EditorLinkPopover.svelte`'s
+// `handleHrefClick` (PLAN-2154 Architecture B.3 / TASK-2160) so the pane-
+// navigate branching is unit-testable without mounting a live Tiptap editor
+// — `handleHrefClick` only fires from real editor `selectionUpdate`/click
+// events, which need a full `Editor` instance to simulate.
+//
+// `EditorLinkPopover.handleHrefClick` is the SINGLE `goto` chokepoint for
+// editor content-body/wiki-links: every anchor rendered inside the Tiptap
+// document is inert `data-href` with clicks globally `preventDefault`ed, so
+// this is the only place a click on one of those links actually navigates.
+// `planHrefClick` decides WHAT that navigation should be; the component
+// stays responsible for the DOM side effects (preventDefault, hiding the
+// popover, actually calling `goto`/`onOpenTarget`/`window.location.assign`).
+
+import { isSameWorkspaceItemHref } from '$lib/collections/paneTarget';
+
+/**
+ * The subset of `MouseEvent` the decision reads. Narrowed to a plain
+ * interface (rather than requiring `MouseEvent` itself) so specs can pass
+ * plain object literals instead of constructing DOM events — mirrors
+ * `itemCardClick.ts`'s `CardClickLike`.
+ */
+export interface HrefClickLike {
+	button: number;
+	ctrlKey: boolean;
+	metaKey: boolean;
+	shiftKey: boolean;
+}
+
+/**
+ * The navigation context the pane-drill decision needs. `hasOnOpenTarget`
+ * mirrors whether `ItemDetail`'s `onOpenTarget` seam is wired at all (an
+ * unembedded full-page view with no pane host passes none); `wsSlug` +
+ * `collectionPrefixes` (a map of collection slug → ref prefix) let the
+ * classifier confirm an internal link actually points at a well-formed item
+ * in the CURRENT workspace before drilling the pane (see
+ * `isSameWorkspaceItemHref`).
+ */
+export interface HrefClickContext {
+	hasOnOpenTarget: boolean;
+	wsSlug: string;
+	collectionPrefixes: ReadonlyMap<string, string>;
+}
+
+export type HrefClickPlan =
+	// Modifier/middle-click, or no href at all: let the browser's native
+	// anchor behavior handle it (new tab, download, etc). The component
+	// must NOT preventDefault/stopPropagation in this case.
+	| { kind: 'passthrough' }
+	// An internal, same-workspace item link with a pane-navigate handler
+	// wired: drill the pane in place instead of navigating away.
+	| { kind: 'pane'; href: string }
+	// An internal link with no pane handler, OR one that isn't a
+	// current-workspace item link (a cross-workspace resolver link, a
+	// different workspace's item as a plain path, a non-item app route, or
+	// an arbitrary internal path a user typed via "Edit link" — all
+	// indistinguishable from a wiki-link at the Tiptap mark level, so they're
+	// let through as a normal nav rather than misrouted into `?item=`):
+	// SPA-navigate via `goto`.
+	| { kind: 'goto'; href: string }
+	// A non-internal (external / absolute) URL: full-page navigation.
+	| { kind: 'external'; href: string };
+
+/**
+ * Decide how a left-click on the link popover's href anchor should be
+ * handled.
+ *
+ * The `pane` branch requires `isSameWorkspaceItemHref` — unlike
+ * relationships/children/graph, this popover's href comes off a Tiptap
+ * `link` mark with no signal distinguishing a wiki-link-inserted item link
+ * from a human-typed arbitrary internal path (Codex review, TASK-2160; see
+ * that function's doc comment in `$lib/collections/paneTarget`).
+ */
+export function planHrefClick(
+	e: HrefClickLike,
+	href: string,
+	ctx: HrefClickContext,
+): HrefClickPlan {
+	if (!href) return { kind: 'passthrough' };
+	// Let the browser handle new-tab modifiers and middle-click itself.
+	if (e.button !== 0 || e.ctrlKey || e.metaKey || e.shiftKey) return { kind: 'passthrough' };
+
+	const isInternal = href.startsWith('/') && !href.startsWith('//');
+	if (
+		isInternal &&
+		ctx.hasOnOpenTarget &&
+		isSameWorkspaceItemHref(href, ctx.wsSlug, ctx.collectionPrefixes)
+	) {
+		return { kind: 'pane', href };
+	}
+	if (isInternal) return { kind: 'goto', href };
+	return { kind: 'external', href };
+}

--- a/web/src/lib/components/editor/editorHrefClick.ts
+++ b/web/src/lib/components/editor/editorHrefClick.ts
@@ -25,6 +25,7 @@ export interface HrefClickLike {
 	ctrlKey: boolean;
 	metaKey: boolean;
 	shiftKey: boolean;
+	altKey: boolean;
 }
 
 /**
@@ -77,8 +78,13 @@ export function planHrefClick(
 	ctx: HrefClickContext,
 ): HrefClickPlan {
 	if (!href) return { kind: 'passthrough' };
-	// Let the browser handle new-tab modifiers and middle-click itself.
-	if (e.button !== 0 || e.ctrlKey || e.metaKey || e.shiftKey) return { kind: 'passthrough' };
+	// Let the browser handle new-tab / new-window / download modifiers and
+	// middle-click itself. `altKey` is included to match `itemCardClick.ts`'s
+	// `shouldOpenInPane` and every other pane interceptor — alt-click is a
+	// download gesture, not a pane drill (Codex review).
+	if (e.button !== 0 || e.ctrlKey || e.metaKey || e.shiftKey || e.altKey) {
+		return { kind: 'passthrough' };
+	}
 
 	const isInternal = href.startsWith('/') && !href.startsWith('//');
 	if (

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -3020,7 +3020,18 @@
 	// than misrouting a cross-workspace plain path, a non-item route, or a
 	// self-inconsistent collection/ref path into `?item=` (PLAN-2154
 	// Architecture B.3 / TASK-2160; Codex review).
-	let collectionPrefixMap = $derived(new Map(allCollections.map((c) => [c.slug, c.prefix])));
+	//
+	// Gated on `collectionsAreFreshFor(wsSlug)`: `collectionStore.collections`
+	// is a single global slot that retains the PREVIOUS workspace's data while
+	// a workspace switch's `loadCollections()` is in flight, so pairing it with
+	// the current `wsSlug` unguarded could validate a link against another
+	// workspace's prefixes. An empty map during that window makes the gate
+	// decline (fall back to a normal `goto`) — the safe default (Codex review).
+	let collectionPrefixMap = $derived(
+		collectionStore.collectionsAreFreshFor(wsSlug)
+			? new Map(allCollections.map((c) => [c.slug, c.prefix]))
+			: new Map<string, string>(),
+	);
 
 	// In-pane drill interception for a relationship's `<a class="link-target">`
 	// (TASK-2159 / PLAN-2154 Architecture B.1). Sits as a SIBLING of the

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -94,14 +94,17 @@
 		onNavigateAway?: (url: string) => void;
 		onReady?: (ready: boolean) => void;
 		// PLAN-2154 Architecture B / TASK-2158: the seam content-link surfaces
-		// (relationships, breadcrumb, editor wiki-links, the graph drawer —
-		// TASK-2159/2160) will fire, via the internal `fireOpenTarget` wrapper
-		// below, to drill the pane in place instead of a hard navigation.
-		// Callers hand up a `PaneTarget` (ref/slug/href/collection metadata
-		// only — never a full `Item`); the collection host resolves it
-		// (`resolvePaneTarget`, `$lib/collections/paneTarget`) and drives its
-		// pane controller's `navigatePaneTo`. Not called by anything yet — no
-		// content-link surface intercepts clicks until TASK-2159/2160 land.
+		// (relationships, breadcrumb, editor wiki-links, the graph drawer)
+		// fire, via the internal `fireOpenTarget` wrapper below, to drill the
+		// pane in place instead of a hard navigation. Callers hand up a
+		// `PaneTarget` (ref/slug/href/collection metadata only — never a full
+		// `Item`); the collection host resolves it (`resolvePaneTarget`,
+		// `$lib/collections/paneTarget`) and drives its pane controller's
+		// `navigatePaneTo`. Wired through to the editor's content-body/wiki-
+		// links via `EditorLinkPopover.handleHrefClick` (TASK-2160, Architecture
+		// B.3) — the single chokepoint editor-anchor navigation ever fires
+		// through. Relationships/breadcrumb/graph land separately
+		// (TASK-2159/2161ff).
 		onOpenTarget?: (target: PaneTarget) => void;
 	} = $props();
 
@@ -176,16 +179,16 @@
 		return gen !== loadGeneration || item?.id !== targetItem.id;
 	}
 
-	// The `onOpenTarget` seam's same-item guard (PLAN-2154 / TASK-2158). No
-	// content-link surface calls this yet — TASK-2159/2160's relationships /
-	// breadcrumb / editor wiki-link / graph interceptors will call
-	// `fireOpenTarget(target)` instead of `onOpenTarget?.(target)` directly, so
-	// a link that names THIS item (by ref, slug, id, or an href built from
-	// either — even when it differs from however the pane's own `?item=` names
-	// it) is dropped here rather than round-tripping to the host only to
-	// become a no-op there. `isSamePaneTarget` is the same reusable check
-	// `resolvePaneTarget` (`$lib/collections/paneTarget`) applies when a
-	// caller passes it a `current` item.
+	// The `onOpenTarget` seam's same-item guard (PLAN-2154 / TASK-2158).
+	// Content-link interceptors call `fireOpenTarget(target)` instead of
+	// `onOpenTarget?.(target)` directly — the editor's content-body/wiki-link
+	// popover does (TASK-2160); relationships/breadcrumb/graph land
+	// separately — so a link that names THIS item (by ref, slug, id, or an
+	// href built from either — even when it differs from however the pane's
+	// own `?item=` names it) is dropped here rather than round-tripping to
+	// the host only to become a no-op there. `isSamePaneTarget` is the same
+	// reusable check `resolvePaneTarget` (`$lib/collections/paneTarget`)
+	// applies when a caller passes it a `current` item.
 	function fireOpenTarget(target: PaneTarget) {
 		if (isSamePaneTarget(target, item)) return;
 		onOpenTarget?.(target);
@@ -2987,6 +2990,15 @@
 	// no-op "move" to the item's own collection (PLAN-2105 / TASK-2112).
 	let moveTargets = $derived(allCollections.filter(c => c.slug !== effectiveCollSlug));
 
+	// The workspace's collection slug → ref-prefix map — passed to
+	// EditorLinkPopover so it can confirm an editor content-link's href points
+	// at a WELL-FORMED item in THIS workspace (current wsSlug + a known
+	// collection whose prefix matches the ref) before drilling the pane, rather
+	// than misrouting a cross-workspace plain path, a non-item route, or a
+	// self-inconsistent collection/ref path into `?item=` (PLAN-2154
+	// Architecture B.3 / TASK-2160; Codex review).
+	let collectionPrefixMap = $derived(new Map(allCollections.map((c) => [c.slug, c.prefix])));
+
 	async function handleDeleteLink(linkId?: string) {
 		if (!linkId || !item) return;
 		// Capture identity BEFORE the awaits. The refresh GET must use the
@@ -4037,7 +4049,12 @@
 							collections={collectionStore.collections}
 							onItemCreated={(item, ws, epoch) => localIndex.upsert(ws, item, epoch)}
 						/>
-						<EditorLinkPopover editor={editorInstance} />
+						<EditorLinkPopover
+							editor={editorInstance}
+							onOpenTarget={onOpenTarget ? fireOpenTarget : undefined}
+							{wsSlug}
+							collectionPrefixes={collectionPrefixMap}
+						/>
 					{/if}
 				{/if}
 			</div>

--- a/web/src/lib/stores/collections.svelte.ts
+++ b/web/src/lib/stores/collections.svelte.ts
@@ -13,6 +13,16 @@ let items = $state<Item[]>([]);
 // for a full workspace; a non-null value pairs the items array with its
 // source workspace.
 let itemsWorkspace = $state<string | null>(null);
+// Workspace slug the current `collections` array was loaded for — the
+// collections analogue of `itemsWorkspace`. `collections` is likewise a
+// single global slot that retains the previous workspace's data while
+// `loadCollections()` for the new workspace is in flight. A consumer that
+// pairs the collections with a specific `wsSlug` — e.g. TASK-2160's editor
+// content-link gate maps collection slug → ref prefix and validates a link
+// against the CURRENT workspace — must be able to tell "these collections
+// are actually this workspace's" from "stale from the last workspace"
+// (Codex review). Null = no load completed yet.
+let collectionsWorkspace = $state<string | null>(null);
 let activeItem = $state<Item | null>(null);
 let loading = $state(false);
 
@@ -20,6 +30,7 @@ export const collectionStore = {
 	get collections() { return collections; },
 	get items() { return items; },
 	get itemsWorkspace() { return itemsWorkspace; },
+	get collectionsWorkspace() { return collectionsWorkspace; },
 	get activeItem() { return activeItem; },
 	get loading() { return loading; },
 
@@ -34,6 +45,17 @@ export const collectionStore = {
 		return itemsWorkspace === ws;
 	},
 
+	/**
+	 * Returns true when the `collections` array was last loaded for the given
+	 * workspace slug — the collections analogue of `itemsAreFreshFor`. A
+	 * consumer that pairs collection metadata (e.g. slug → prefix) with a
+	 * specific workspace must gate on this rather than trust a possibly-stale
+	 * global array mid workspace-switch (Codex review, TASK-2160).
+	 */
+	collectionsAreFreshFor(ws: string): boolean {
+		return collectionsWorkspace === ws;
+	},
+
 	get defaultCollections() {
 		return collections.filter(c => c.is_default).sort((a, b) => a.sort_order - b.sort_order);
 	},
@@ -46,6 +68,12 @@ export const collectionStore = {
 		loading = true;
 		try {
 			collections = await api.collections.list(ws);
+			// Stamp the array with its source workspace so consumers can tell
+			// it apart from a stale previous-workspace load (see
+			// `collectionsAreFreshFor`). Set only on success — a failed load
+			// leaves the prior (possibly stale) array in place, and its stamp
+			// with it, which is the correct conservative signal.
+			collectionsWorkspace = ws;
 		} finally {
 			loading = false;
 		}

--- a/web/src/lib/stores/collections.svelte.ts
+++ b/web/src/lib/stores/collections.svelte.ts
@@ -26,6 +26,14 @@ let collectionsWorkspace = $state<string | null>(null);
 let activeItem = $state<Item | null>(null);
 let loading = $state(false);
 
+// Monotonic load generation for `loadCollections`. A workspace switch can
+// leave two list requests in flight (A pending, then B); without a guard a
+// late-resolving A response would overwrite B's `collections` +
+// `collectionsWorkspace` and strand `collectionsAreFreshFor(B)` at false. Each
+// call captures its generation and only commits if it's still the latest
+// (Codex review). Plain counter — not reactive; it only fences async writes.
+let collectionsLoadSeq = 0;
+
 export const collectionStore = {
 	get collections() { return collections; },
 	get items() { return items; },
@@ -65,9 +73,16 @@ export const collectionStore = {
 	},
 
 	async loadCollections(ws: string) {
+		const seq = ++collectionsLoadSeq;
 		loading = true;
 		try {
-			collections = await api.collections.list(ws);
+			const result = await api.collections.list(ws);
+			// Drop a stale response: a newer loadCollections (e.g. a workspace
+			// switch that resolved first) has superseded this one, so writing
+			// `collections`/`collectionsWorkspace` here would clobber the newer
+			// workspace's data with this older load (Codex review).
+			if (seq !== collectionsLoadSeq) return;
+			collections = result;
 			// Stamp the array with its source workspace so consumers can tell
 			// it apart from a stale previous-workspace load (see
 			// `collectionsAreFreshFor`). Set only on success — a failed load
@@ -75,7 +90,9 @@ export const collectionStore = {
 			// with it, which is the correct conservative signal.
 			collectionsWorkspace = ws;
 		} finally {
-			loading = false;
+			// Only the latest in-flight load owns the `loading` flag — an older
+			// load resolving late must not flip it off while the newer one runs.
+			if (seq === collectionsLoadSeq) loading = false;
 		}
 	},
 


### PR DESCRIPTION
## What

Phase 1 of PLAN-2154 (Architecture B.3): editor content-body / wiki-link clicks now drill the split pane in place instead of navigating away, wired through the single navigation chokepoint.

Editor anchors in the Tiptap doc are inert `data-href` and every editor-anchor click is globally `preventDefault`ed — navigation happens ONLY through `EditorLinkPopover.handleHrefClick`. This injects the pane-navigate callback there: when the popover's target is a same-workspace item URL and a pane-navigate handler is present, it builds a `PaneTarget` and fires the drill (`onOpenTarget`) instead of `goto`. Modifier/middle-click/alt-click, external URLs, and cross-workspace `/-/r/` resolver links keep their existing behavior.

## How

- **`editorHrefClick.ts`** (new): pure `planHrefClick()` decision, extracted for unit testing (mirrors `itemCardClick.ts`'s `shouldOpenInPane` pattern). Returns `passthrough | pane | goto | external`.
- **`paneTarget.ts`**: `isSameWorkspaceItemHref()` — the strict gate for the ONE untrusted content-link surface (an editor `link` mark is indistinguishable from a hand-typed path). Parses via the URL API (same-origin host check + canonical-path requirement), then validates positionally: workspace slug == current, collection segment is a known collection whose prefix matches the ref's prefix (case-insensitive, digit-bearing prefixes allowed), and a positive ref number. Everything else falls back to a normal `goto` (graceful degradation).
- **`ItemDetail.svelte`**: threads `fireOpenTarget` + `wsSlug` + a collection slug→prefix map into `EditorLinkPopover`, reusing TASK-2159's shared `paneOpenTarget` derived (so full-page/unembedded views pass `undefined` and keep plain navigation).
- **`collections.svelte.ts`**: stamps `collections` by workspace (`collectionsAreFreshFor`), mirroring `itemsWorkspace`, plus a monotonic load-generation guard — so the prefix map declines safely during a workspace switch rather than validating against a stale workspace's prefixes.

## Testing

- `npm run check`: 0 errors.
- `npm run test`: 421 passing (46 in `paneTarget.test.ts`, 27 in `editorHrefClick.test.ts` covering: same-workspace drill, workspace-root-relative links, cross-collection links, digit-bearing prefixes, and normal-navigation for external URLs, `/-/r/` links, other-workspace plain paths, non-item routes, self-inconsistent collection/ref paths, zero refs, double-slash/backslash/trailing-slash, and modifier/middle/alt-click).
- Codex review: 5 rounds to CLEAN (each fixed real issues: full-page undefined callback, ref-shape over/under-matching, zero refs, cross-collection mismatch, alt-click, malformed-path parsing, digit-prefixes, stale collection map, cross-origin backslash-authority hrefs, and a canonical-form regression guard).

Sibling to TASK-2159 (anchor content links) — both lightly touch `ItemDetail` in disjoint regions; merged origin/main and resolved the disjoint doc-comment conflict keeping both.

https://claude.ai/code/session_01EZ6yr6pAUFb1uffan912ra