### PR TITLE
feat(web): un-hide structural parent breadcrumb in the embedded pane (TASK-2165)

### DIFF
--- a/web/src/lib/collections/paneTarget.test.ts
+++ b/web/src/lib/collections/paneTarget.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import type { Item, PaneTarget } from '$lib/types';
-import { resolvePaneTarget, isSamePaneTarget, isSameWorkspaceItemHref } from './paneTarget';
+import {
+	resolvePaneTarget,
+	isSamePaneTarget,
+	isSameWorkspaceItemHref,
+	breadcrumbParentTarget,
+} from './paneTarget';
 
 // Minimal Item stand-in — resolution/guard only touch id/slug/item_number/
 // collection_prefix (the fields `formatItemRef`/`itemUrlId` read).
@@ -322,5 +327,65 @@ describe('isSameWorkspaceItemHref — editor content-link gate (TASK-2160)', () 
 	it('declines when context is missing (empty wsSlug or empty collection map)', () => {
 		expect(isSameWorkspaceItemHref('/alice/myws/tasks/TASK-5', '', colls)).toBe(false);
 		expect(isSameWorkspaceItemHref('/alice/myws/tasks/TASK-5', 'myws', new Map())).toBe(false);
+	});
+});
+
+describe('breadcrumbParentTarget — structural parent hop (PLAN-2154 Architecture C / D3, TASK-2165)', () => {
+	// Minimal item-shaped object carrying ONLY the parent_* fields a real API
+	// item response includes — proves the target reconstructs from the
+	// item's own data with ZERO additional fetches, exactly as it would on a
+	// cold-loaded shared `?item=` pane URL.
+	function withParent(opts: {
+		parent_ref?: string;
+		parent_slug?: string;
+		parent_collection_slug?: string;
+		parent_title?: string;
+	}) {
+		return opts;
+	}
+
+	it('builds a target from ref + slug + collectionSlug when the item has a structural parent', () => {
+		const target = breadcrumbParentTarget(
+			withParent({ parent_ref: 'PLAN-3', parent_slug: 'plan-3-slug', parent_collection_slug: 'plans' }),
+		);
+		expect(target).toEqual<PaneTarget>({
+			ref: 'PLAN-3',
+			slug: 'plan-3-slug',
+			collectionSlug: 'plans',
+		});
+	});
+
+	it('omits ref when the parent has no number (slug-only addressable)', () => {
+		const target = breadcrumbParentTarget(
+			withParent({ parent_slug: 'legacy-parent', parent_collection_slug: 'plans' }),
+		);
+		expect(target).toEqual<PaneTarget>({
+			ref: undefined,
+			slug: 'legacy-parent',
+			collectionSlug: 'plans',
+		});
+	});
+
+	it('returns undefined when the item has no structural parent at all', () => {
+		expect(breadcrumbParentTarget(withParent({}))).toBeUndefined();
+	});
+
+	it('returns undefined when only ONE of parent_slug/parent_collection_slug is present', () => {
+		expect(breadcrumbParentTarget(withParent({ parent_slug: 'plan-3-slug' }))).toBeUndefined();
+		expect(breadcrumbParentTarget(withParent({ parent_collection_slug: 'plans' }))).toBeUndefined();
+	});
+
+	it('returns undefined for a null/undefined item (no loaded item yet)', () => {
+		expect(breadcrumbParentTarget(null)).toBeUndefined();
+		expect(breadcrumbParentTarget(undefined)).toBeUndefined();
+	});
+
+	it('the resulting target round-trips through resolvePaneTarget to the parent ref (drills the pane)', () => {
+		const target = breadcrumbParentTarget(
+			withParent({ parent_ref: 'PLAN-3', parent_slug: 'plan-3-slug', parent_collection_slug: 'plans' }),
+		)!;
+		// No `current` item passed — mirrors the collection host's resolution
+		// once the click interceptor has already fired the target up.
+		expect(resolvePaneTarget(target)).toBe('PLAN-3');
 	});
 });

--- a/web/src/lib/collections/paneTarget.ts
+++ b/web/src/lib/collections/paneTarget.ts
@@ -304,3 +304,31 @@ export function resolvePaneTarget(target: PaneTarget, current?: Item | null): st
 	if (isSamePaneTarget(target, current)) return null;
 	return rawPaneTargetCandidate(target);
 }
+
+/**
+ * Build the `PaneTarget` for an item's structural PARENT — the single-hop
+ * breadcrumb `ItemDetail` un-hides for the embedded pane (PLAN-2154
+ * Architecture C / D3, TASK-2165). Reads only fields already present on the
+ * item response (`parent_ref`/`parent_slug`/`parent_collection_slug` —
+ * `$lib/types` Item), so it reconstructs correctly even on a cold-loaded
+ * shared `?item=` pane URL with zero additional fetches — the same property
+ * that makes `resolvePaneTarget` above framework-agnostic and exhaustively
+ * unit-testable.
+ *
+ * `parent_slug` + `parent_collection_slug` are the presence gate (mirroring
+ * the pre-existing full-page breadcrumb's own `{#if item.parent_collection_slug
+ * && item.parent_slug}` condition): `parent_ref` is carried when available
+ * but not required, since a legacy/no-number item can have a parent
+ * addressable only by slug. Returns `undefined` when the item has no
+ * structural parent to show.
+ */
+export function breadcrumbParentTarget(
+	item: Pick<Item, 'parent_ref' | 'parent_slug' | 'parent_collection_slug'> | null | undefined,
+): PaneTarget | undefined {
+	if (!item?.parent_collection_slug || !item?.parent_slug) return undefined;
+	return {
+		ref: item.parent_ref ?? undefined,
+		slug: item.parent_slug,
+		collectionSlug: item.parent_collection_slug,
+	};
+}

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -40,7 +40,7 @@
 	import ShareDialog from '$lib/components/ShareDialog.svelte';
 	import { copyToClipboard } from '$lib/utils/clipboard';
 	import { repairDeadItemLastRoute } from '$lib/collections/paneUrlParams';
-	import { isSamePaneTarget } from '$lib/collections/paneTarget';
+	import { isSamePaneTarget, breadcrumbParentTarget } from '$lib/collections/paneTarget';
 	import { shouldOpenInPane } from '$lib/components/collections/itemCardClick';
 	import { starredStore } from '$lib/stores/starred.svelte';
 	import { titleStore } from '$lib/stores/title.svelte';
@@ -3045,6 +3045,24 @@
 		paneOpenTarget?.({ ref: entry.ref, slug: entry.slug, href: entry.href ?? undefined, collectionSlug: entry.collectionSlug });
 	}
 
+	// The structural-parent breadcrumb target (PLAN-2154 Architecture C / D3,
+	// TASK-2165) — `undefined` when the item has no structural parent, in
+	// which case the embedded pane's breadcrumb doesn't render at all (the
+	// pane chrome header above already surfaces the current item's own ref).
+	// `breadcrumbParentTarget` reads only the loaded item's own `parent_*`
+	// fields (zero new fetches), so this is correct even on a cold-loaded
+	// shared `?item=` pane URL.
+	let breadcrumbTarget = $derived(breadcrumbParentTarget(item));
+
+	// In-pane drill interception for the structural parent-breadcrumb hop.
+	// Mirrors `handleRelationshipClick`'s interception order: modifier/
+	// middle-click still falls through to the plain `<a href>` popout.
+	function handleBreadcrumbParentClick(e: MouseEvent) {
+		if (!breadcrumbTarget || !shouldOpenInPane(e, !!paneOpenTarget)) return;
+		e.preventDefault();
+		paneOpenTarget?.(breadcrumbTarget);
+	}
+
 	async function handleDeleteLink(linkId?: string) {
 		if (!linkId || !item) return;
 		// Capture identity BEFORE the awaits. The refresh GET must use the
@@ -3397,6 +3415,33 @@
 					>✕</button>
 				</div>
 			</header>
+			<!-- Structural parent breadcrumb (PLAN-2154 Architecture C / D3,
+			     TASK-2165) — un-hidden for the embedded pane. Single parent hop
+			     for v1: rendered only when the item HAS a structural parent
+			     (`parent_collection_slug` + `parent_slug`), reconstructed
+			     entirely from the item's own fields with zero new fetches, so
+			     it's correct even on a cold-loaded shared `?item=` pane URL.
+			     The pane chrome above already surfaces the current item's own
+			     ref/title, so there's nothing useful to add here when there's
+			     no parent to show. The parent hop routes through
+			     `paneOpenTarget` (drills the pane); `href` is preserved so a
+			     modifier/middle-click still pops it out to a new tab. -->
+			{#if breadcrumbTarget}
+				{@const parentCollSlug = breadcrumbTarget.collectionSlug}
+				{@const parentColl = allCollections.find(c => c.slug === parentCollSlug)}
+				<nav class="breadcrumb pane-breadcrumb" aria-label="Breadcrumb">
+					<a href="/{username}/{wsSlug}">Home</a>
+					<span class="sep">/</span>
+					<a href="/{username}/{wsSlug}/{parentCollSlug}">{parentColl?.icon ?? ''} {parentColl?.name ?? parentCollSlug}</a>
+					<span class="sep">/</span>
+					<a
+						href="/{username}/{wsSlug}/{parentCollSlug}/{breadcrumbTarget.slug}"
+						onclick={(e) => handleBreadcrumbParentClick(e)}
+					>{item.parent_ref || item.parent_title}</a>
+					<span class="sep">/</span>
+					<span class="current">{formatItemRef(item) || item.title}</span>
+				</nav>
+			{/if}
 		{/if}
 
 		<!-- Archived banner (TASK-1829) — read-only notice shown above the
@@ -4581,6 +4626,17 @@
 	}
 	.sep { color: var(--text-muted); }
 	.current { color: var(--text-primary); }
+
+	/* Pane breadcrumb (PLAN-2154 / TASK-2165) — reuses `.breadcrumb`'s look
+	   but sits below the (already sticky) `.pane-header` as a plain block,
+	   not sticky itself: it's a single parent hop, short enough that it
+	   doesn't need to stay pinned while the body scrolls, and staying
+	   non-sticky avoids stacking two opaque sticky bars at the top of a
+	   narrow pane. */
+	.pane-breadcrumb {
+		flex-wrap: wrap;
+		margin: 0 0 var(--space-3);
+	}
 	.copy-ref-btn {
 		position: relative;
 		display: inline-flex;


### PR DESCRIPTION
## Summary
- Un-hides the structural parent breadcrumb (Home / parent-collection / parent / current) for the embedded pane — previously gated off with `{#if !embedded}`. Single parent hop for v1 (PLAN-2154 Architecture C / D3).
- Reconstructs entirely from the loaded item's own `parent_ref`/`parent_slug`/`parent_collection_slug` fields — zero new fetches, so it's correct even on a cold-loaded shared `?item=` pane URL.
- The parent breadcrumb hop routes through the pane-navigate callback (`onOpenTarget`/`paneOpenTarget`), drilling the pane on a plain click; `href` is preserved so a modifier/middle-click still pops it out to a new tab (mirrors `handleRelationshipClick`'s existing interception pattern).
- Extracted `breadcrumbParentTarget()` into `$lib/collections/paneTarget.ts` alongside the existing `resolvePaneTarget`/`isSamePaneTarget` helpers, so the reconstruction logic is exhaustively unit-tested without mounting the (very heavy — live collab/Tiptap) `ItemDetail` component.
- The full-page (`!embedded`) breadcrumb is unchanged.

## Test plan
- [x] `cd web && npm run check` — 0 errors, no new warnings
- [x] `cd web && npm run test` — 427 tests passed, including 6 new `breadcrumbParentTarget` cases in `paneTarget.test.ts` (builds target with ref+slug+collectionSlug; omits ref when parent has no number; undefined with no parent; undefined with only one of slug/collectionSlug; undefined for a null/undefined item; round-trips through `resolvePaneTarget` to drill the pane)
- [x] Codex review (`codex exec -s read-only`): CLEAN
- [ ] Full DOM-mounted interaction test (rendering the breadcrumb + clicking to drill vs. modifier-click popout) was not added — `ItemDetail.svelte` eagerly constructs a live `CollabProvider`/`WebSocket` + mounts the Tiptap editor on load, which isn't mockable in this repo's jsdom test project without disproportionate scaffolding for a single-hop breadcrumb. Coverage instead targets the click composition's two building blocks directly: `breadcrumbParentTarget` (new, unit-tested above) and `shouldOpenInPane` (pre-existing, already unit-tested in `itemCardClick.test.ts`) — the same reliance pattern the codebase already uses for `handleRelationshipClick`, which has no dedicated component-mount test either.

https://claude.ai/code/session_01EZ6yr6pAUFb1uffan912ra