### PR TITLE
feat(web): in-pane Back chevron for the pane chrome (TASK-2164)

### DIFF
--- a/web/e2e/pane-controller.spec.ts
+++ b/web/e2e/pane-controller.spec.ts
@@ -1051,6 +1051,68 @@ test.describe('pane controller: depth/ownership state machine (PLAN-2154 / TASK-
 		await expect.poll(closeIsFocused).toBe(false);
 	});
 
+	test('Back chevron: a genuinely slow (but legitimate) destination load still restores focus, past the no-op check window (Codex review round 8)', async ({
+		page,
+		fixture,
+		request,
+	}) => {
+		await page.setViewportSize(DESKTOP);
+		await enableHook(page);
+		await browserLogin(page);
+		await seedDoc(fixture, request, 'Ctrl back-slow alpha');
+		const b = await seedDoc(fixture, request, 'Ctrl back-slow bravo');
+		await page.goto(docsUrl(fixture));
+
+		await page.locator('.item-card', { hasText: 'Ctrl back-slow alpha' }).first().click();
+		const pane = page.locator('.item-pane');
+		await expect(pane).toBeVisible();
+		// A real row click puts the item's REF (e.g. `DOC-16`), not its slug,
+		// in `?item=` (`itemUrlId` prefers `formatItemRef` — +page.svelte),
+		// and that's what the fetch path segment uses too.
+		const aRef = openItemParam(page);
+
+		await drillTo(page, b.slug);
+		await expect.poll(() => paneState(page)).toEqual({ paneDepth: 1, paneOwned: true });
+
+		// Gate A's item fetch — the Back press (B→A) LANDS on it, no
+		// unrelated navigation involved, so the eventual restore is fully
+		// legitimate. Held for 400ms: comfortably past the 200ms no-op check
+		// (which only disarms a genuine coalesced-to-nothing case — itemSlug
+		// has already changed here by then, so it must NOT fire) and past
+		// what the old, since-replaced flat 600ms wall-clock timeout design
+		// would have tolerated on a slower run.
+		let releaseGate: () => void = () => {};
+		const gate = new Promise<void>((resolve) => {
+			releaseGate = resolve;
+		});
+		await page.route(`**/api/v1/workspaces/*/items/${aRef}`, async (route) => {
+			if (route.request().method() !== 'GET') {
+				await route.continue();
+				return;
+			}
+			await gate;
+			await route.continue();
+		});
+
+		const backBtn = pane.locator('button[aria-label="Back"]');
+		await expect(backBtn).toBeVisible();
+		await backBtn.focus();
+		await backBtn.click();
+		await expect.poll(() => paneState(page)).toEqual({ paneDepth: 0, paneOwned: true });
+		await expect(pane.locator('.pane-header--minimal')).toBeVisible();
+
+		// Wait well past the 200ms no-op check before releasing — the pop
+		// must still be pending, not silently abandoned.
+		await page.waitForTimeout(400);
+		releaseGate();
+		await expect.poll(() => openItemParam(page)).toBe(aRef);
+		await expect(pane.locator('.pane-header--minimal')).toBeHidden();
+
+		const closeIsFocusedAfterSlowLoad = () =>
+			page.evaluate(() => document.activeElement?.getAttribute('aria-label') === 'Close pane');
+		await expect.poll(closeIsFocusedAfterSlowLoad).toBe(true);
+	});
+
 	test('Back chevron: a cold-loaded shared ?item= starts at depth 0 and stays hidden; browser Back still exits the pane', async ({
 		page,
 		fixture,

--- a/web/e2e/pane-controller.spec.ts
+++ b/web/e2e/pane-controller.spec.ts
@@ -1051,7 +1051,7 @@ test.describe('pane controller: depth/ownership state machine (PLAN-2154 / TASK-
 		await expect.poll(closeIsFocused).toBe(false);
 	});
 
-	test('Back chevron: a genuinely slow (but legitimate) destination load still restores focus, past the no-op check window (Codex review round 8)', async ({
+	test('Back chevron: a genuinely slow (but legitimate) destination load still restores focus, however long it takes', async ({
 		page,
 		fixture,
 		request,
@@ -1076,11 +1076,10 @@ test.describe('pane controller: depth/ownership state machine (PLAN-2154 / TASK-
 
 		// Gate A's item fetch — the Back press (B→A) LANDS on it, no
 		// unrelated navigation involved, so the eventual restore is fully
-		// legitimate. Held for 400ms: comfortably past the 200ms no-op check
-		// (which only disarms a genuine coalesced-to-nothing case — itemSlug
-		// has already changed here by then, so it must NOT fire) and past
-		// what the old, since-replaced flat 600ms wall-clock timeout design
-		// would have tolerated on a slower run.
+		// legitimate — no matter how long the fetch takes, the restore has no
+		// wall-clock deadline to race (the design deliberately dropped the
+		// timer-based "give up waiting" heuristic explored in earlier review
+		// rounds; see the focus-restore block's comment for why).
 		let releaseGate: () => void = () => {};
 		const gate = new Promise<void>((resolve) => {
 			releaseGate = resolve;
@@ -1101,7 +1100,7 @@ test.describe('pane controller: depth/ownership state machine (PLAN-2154 / TASK-
 		await expect.poll(() => paneState(page)).toEqual({ paneDepth: 0, paneOwned: true });
 		await expect(pane.locator('.pane-header--minimal')).toBeVisible();
 
-		// Wait well past the 200ms no-op check before releasing — the pop
+		// Hold well past the mint-settle window before releasing — the pop
 		// must still be pending, not silently abandoned.
 		await page.waitForTimeout(400);
 		releaseGate();

--- a/web/e2e/pane-controller.spec.ts
+++ b/web/e2e/pane-controller.spec.ts
@@ -76,6 +76,20 @@ function historyLength(page: Page): Promise<number> {
 	return page.evaluate(() => history.length);
 }
 
+/**
+ * Whether the currently-focused element is a pane-header Back button
+ * (`aria-label="Back"`). A `page.evaluate` read of `document.activeElement`,
+ * NOT `expect(locator).toBeFocused()` — this file's other focus checks
+ * (pane-a11y-focus.spec.ts) use the same `evaluate`-based pattern, which is
+ * the reliable one under heavy parallel load: a bare locator-based
+ * `toBeFocused()` polls independently of the app's own microtask queue and
+ * can observe a still-mid-flush DOM after a header swap, where an
+ * `evaluate` round-trip naturally lets pending Svelte effects settle first.
+ */
+function backButtonIsFocused(page: Page): Promise<boolean> {
+	return page.evaluate(() => document.activeElement?.getAttribute('aria-label') === 'Back');
+}
+
 /** Enable the controller test hook for all navigations in this context. */
 async function enableHook(page: Page): Promise<void> {
 	await page.addInitScript(() => {
@@ -855,19 +869,99 @@ test.describe('pane controller: depth/ownership state machine (PLAN-2154 / TASK-
 		await backBtn.click();
 		await expect.poll(() => paneState(page)).toEqual({ paneDepth: 2, paneOwned: true });
 		await expect.poll(() => openItemParam(page)).toBe(c.slug);
-		await expect(backBtn).toBeFocused();
+		await expect.poll(() => backButtonIsFocused(page)).toBe(true);
 
 		// Press 2: C(2) → B(1). Focus restored again.
 		await backBtn.click();
 		await expect.poll(() => paneState(page)).toEqual({ paneDepth: 1, paneOwned: true });
 		await expect.poll(() => openItemParam(page)).toBe(b.slug);
-		await expect(backBtn).toBeFocused();
+		await expect.poll(() => backButtonIsFocused(page)).toBe(true);
 
 		// Press 3: B(1) → A(0), the base — chevron disappears, pane stays open.
 		await backBtn.click();
 		await expect.poll(() => paneState(page)).toEqual({ paneDepth: 0, paneOwned: true });
 		await expect(pane).toBeVisible();
 		await expect(pane.locator('button[aria-label="Back"]')).toHaveCount(0);
+	});
+
+	test('Back chevron: a second press while the first pop is still loading still ends with focus restored (Codex review round 3)', async ({
+		page,
+		fixture,
+		request,
+	}) => {
+		await page.setViewportSize(DESKTOP);
+		await enableHook(page);
+		await browserLogin(page);
+		await seedDoc(fixture, request, 'Ctrl back-race alpha');
+		const b = await seedDoc(fixture, request, 'Ctrl back-race bravo');
+		const c = await seedDoc(fixture, request, 'Ctrl back-race charlie');
+		const d = await seedDoc(fixture, request, 'Ctrl back-race delta');
+		await page.goto(docsUrl(fixture));
+
+		await page.locator('.item-card', { hasText: 'Ctrl back-race alpha' }).first().click();
+		const pane = page.locator('.item-pane');
+		await expect(pane).toBeVisible();
+
+		await drillTo(page, b.slug);
+		await expect.poll(() => paneState(page)).toEqual({ paneDepth: 1, paneOwned: true });
+		await drillTo(page, c.slug);
+		await expect.poll(() => paneState(page)).toEqual({ paneDepth: 2, paneOwned: true });
+		await drillTo(page, d.slug);
+		await expect.poll(() => paneState(page)).toEqual({ paneDepth: 3, paneOwned: true });
+
+		// Gate C's item fetch — the FIRST Back press (D→C) lands on it and
+		// stalls mid-load, so the SECOND Back press (fired while that fetch is
+		// still outstanding) exercises the exact race Codex round 3 flagged:
+		// a click while `loading` is already true from an EARLIER, unrelated
+		// load must not let the focus-restore effect latch onto that stale
+		// cycle instead of its own.
+		let releaseGate: () => void = () => {};
+		const gate = new Promise<void>((resolve) => {
+			releaseGate = resolve;
+		});
+		await page.route(`**/api/v1/workspaces/*/items/${c.slug}`, async (route) => {
+			if (route.request().method() !== 'GET') {
+				await route.continue();
+				return;
+			}
+			await gate;
+			await route.continue();
+		});
+
+		const backBtn = pane.locator('button[aria-label="Back"]');
+		await expect(backBtn).toBeVisible();
+		await backBtn.focus();
+
+		// Press 1: D(3) → C(2). C's fetch is gated — this pop never actually
+		// finishes loading until the gate is released below.
+		await backBtn.click();
+		await expect.poll(() => paneState(page)).toEqual({ paneDepth: 2, paneOwned: true });
+		// Wait for the DOM to actually reach the minimal (loading) header —
+		// not just for `page.state` to have updated — so press 2 below
+		// deterministically lands mid-fetch regardless of system load
+		// (rather than merely racing the depth-poll's own timing).
+		await expect(pane.locator('.pane-header--minimal')).toBeVisible();
+
+		// Press 2, fired while `loading` is STILL true from the stalled C
+		// fetch (the history-level `paneNavInFlight()` fence has already
+		// cleared by now, since that only guards the `history.go` traversal
+		// itself, not the data fetch it triggers). Targets B, whose fetch is
+		// NOT gated.
+		await backBtn.click();
+		await expect.poll(() => paneState(page)).toEqual({ paneDepth: 1, paneOwned: true });
+		await expect.poll(() => openItemParam(page)).toBe(b.slug);
+
+		// The pane settled on B — focus must have landed on ITS Back button,
+		// not been consumed early by C's stale, still-outstanding load.
+		await expect.poll(() => backButtonIsFocused(page)).toBe(true);
+
+		// Release the gate so C's now-superseded fetch can drain (generation-
+		// fenced server-side by `loadData`'s own `myGen === loadGeneration`
+		// checks — it must not clobber the now-current B state).
+		releaseGate();
+		await page.waitForTimeout(100);
+		await expect.poll(() => openItemParam(page)).toBe(b.slug);
+		await expect.poll(() => backButtonIsFocused(page)).toBe(true);
 	});
 
 	test('Back chevron: a cold-loaded shared ?item= starts at depth 0 and stays hidden; browser Back still exits the pane', async ({

--- a/web/e2e/pane-controller.spec.ts
+++ b/web/e2e/pane-controller.spec.ts
@@ -970,6 +970,87 @@ test.describe('pane controller: depth/ownership state machine (PLAN-2154 / TASK-
 		await expect.poll(() => backButtonIsFocused(page)).toBe(true);
 	});
 
+	test('Back chevron: a superseding row-click while the pop is still loading does NOT steal focus back into the pane (Codex review round 6)', async ({
+		page,
+		fixture,
+		request,
+	}) => {
+		await page.setViewportSize(DESKTOP);
+		await enableHook(page);
+		await browserLogin(page);
+		const a = await seedDoc(fixture, request, 'Ctrl back-supersede alpha');
+		const b = await seedDoc(fixture, request, 'Ctrl back-supersede bravo');
+		const c = await seedDoc(fixture, request, 'Ctrl back-supersede charlie');
+		await page.goto(docsUrl(fixture));
+
+		await page.locator('.item-card', { hasText: 'Ctrl back-supersede alpha' }).first().click();
+		const pane = page.locator('.item-pane');
+		await expect(pane).toBeVisible();
+		// A real row click puts the item's REF (e.g. `DOC-16`), not its slug,
+		// in `?item=` (`itemUrlId` prefers `formatItemRef` — +page.svelte),
+		// and that's what the fetch path segment uses too. Capture it here
+		// rather than assuming `a.slug` so the route gate below actually
+		// matches.
+		const aRef = openItemParam(page);
+
+		await drillTo(page, b.slug);
+		await expect.poll(() => paneState(page)).toEqual({ paneDepth: 1, paneOwned: true });
+
+		// Gate A's item fetch — the Back press (B→A) lands on it and stalls
+		// mid-load, giving room to fire an UNRELATED navigation (a direct
+		// row click on C) before the Back pop ever settles.
+		let releaseGate: () => void = () => {};
+		const gate = new Promise<void>((resolve) => {
+			releaseGate = resolve;
+		});
+		await page.route(`**/api/v1/workspaces/*/items/${aRef}`, async (route) => {
+			if (route.request().method() !== 'GET') {
+				await route.continue();
+				return;
+			}
+			await gate;
+			await route.continue();
+		});
+
+		const backBtn = pane.locator('button[aria-label="Back"]');
+		await expect(backBtn).toBeVisible();
+		await backBtn.focus();
+		await backBtn.click();
+		await expect.poll(() => paneState(page)).toEqual({ paneDepth: 0, paneOwned: true });
+		// Confirm the pop is genuinely stalled mid-fetch before superseding it.
+		await expect(pane.locator('.pane-header--minimal')).toBeVisible();
+
+		// SUPERSEDE: a direct row click on a THIRD item while A is still
+		// loading. `paneDepth` is already 0 (the Back pop's own destination
+		// settled at the history level), so this is a normal depth-0
+		// re-target (`openItemPane` replace) — a completely different, later
+		// navigation than the stalled Back pop, landing on C.
+		await page.locator('.item-card', { hasText: 'Ctrl back-supersede charlie' }).first().click();
+		await expect(pane.locator('.title', { hasText: /Ctrl back-supersede charlie/ })).toBeVisible();
+		await expect.poll(() => paneState(page)).toEqual({ paneDepth: 0, paneOwned: true });
+		// A row click lands the item's ref (not necessarily its slug — same
+		// `itemUrlId` caveat as `aRef` above) in `?item=`; just confirm it
+		// changed to something other than A's ref.
+		const cRef = openItemParam(page);
+		expect(cRef).not.toBe(aRef);
+
+		// The stalled Back pop's pending focus-restore must NOT fire once A
+		// eventually settles — it was superseded, so it must not steal focus
+		// into C's pane chrome. `backButtonIsFocused` covers the paneDepth>0
+		// case; C is at depth 0, so also check the Close button directly.
+		const closeIsFocused = () =>
+			page.evaluate(() => document.activeElement?.getAttribute('aria-label') === 'Close pane');
+		await expect.poll(closeIsFocused).toBe(false);
+
+		// Release the gate — A's now-superseded fetch drains (generation-
+		// fenced by `loadData`'s own checks), and the abandoned restore must
+		// still not fire afterward.
+		releaseGate();
+		await page.waitForTimeout(150);
+		await expect.poll(() => openItemParam(page)).toBe(cRef);
+		await expect.poll(closeIsFocused).toBe(false);
+	});
+
 	test('Back chevron: a cold-loaded shared ?item= starts at depth 0 and stays hidden; browser Back still exits the pane', async ({
 		page,
 		fixture,

--- a/web/e2e/pane-controller.spec.ts
+++ b/web/e2e/pane-controller.spec.ts
@@ -764,4 +764,153 @@ test.describe('pane controller: depth/ownership state machine (PLAN-2154 / TASK-
 		await expect.poll(() => openItemParam(page)).toBe(b.slug);
 		await expect(pane).toBeVisible();
 	});
+
+	// ── In-pane Back chevron (PLAN-2154 Architecture C, TASK-2164) ──────────
+	// The pane chrome (⤢/↗/✕ today) grows a fourth control — a Back chevron —
+	// shown ONLY once the pane has drilled past its base (depth>0), wired to
+	// the same fenced `paneHistoryGo(-1)`/`paneNavInFlight()` traversal the
+	// depth-aware ESC handler above uses (R14). Depth is read reactively off
+	// SvelteKit `page.state` inside `ItemDetail` itself (never raw
+	// `history.state`), so the chevron's visibility always matches the
+	// controller's own `paneState()` read back through the test hook.
+
+	test('Back chevron: hidden at depth 0, visible once drilled, one press pops exactly one level', async ({
+		page,
+		fixture,
+		request,
+	}) => {
+		await page.setViewportSize(DESKTOP);
+		await enableHook(page);
+		await browserLogin(page);
+		await seedDoc(fixture, request, 'Ctrl back alpha');
+		const b = await seedDoc(fixture, request, 'Ctrl back bravo');
+		await page.goto(docsUrl(fixture));
+
+		await page.locator('.item-card', { hasText: 'Ctrl back alpha' }).first().click();
+		const pane = page.locator('.item-pane');
+		await expect(pane).toBeVisible();
+		await expect.poll(() => paneState(page)).toEqual({ paneDepth: 0, paneOwned: true });
+		const refA = openItemParam(page);
+
+		const backBtn = pane.locator('button[aria-label="Back"]');
+		// Depth 0 (first-open) — the chevron is not rendered at all.
+		await expect(backBtn).toHaveCount(0);
+
+		// Drill A→B → depth 1 — the chevron appears.
+		await drillTo(page, b.slug);
+		await expect.poll(() => paneState(page)).toEqual({ paneDepth: 1, paneOwned: true });
+		await expect(backBtn).toBeVisible();
+
+		// One press pops exactly one level: back to A at depth 0, and the pane
+		// stays open (this is a drill-stack pop, not a close).
+		await backBtn.click();
+		await expect.poll(() => paneState(page)).toEqual({ paneDepth: 0, paneOwned: true });
+		await expect.poll(() => openItemParam(page)).toBe(refA);
+		await expect(pane).toBeVisible();
+		// Back at the base — the chevron is gone again.
+		await expect(pane.locator('button[aria-label="Back"]')).toHaveCount(0);
+	});
+
+	test('Back chevron: pops one level per press across a multi-hop drill', async ({
+		page,
+		fixture,
+		request,
+	}) => {
+		await page.setViewportSize(DESKTOP);
+		await enableHook(page);
+		await browserLogin(page);
+		await seedDoc(fixture, request, 'Ctrl back-multi alpha');
+		const b = await seedDoc(fixture, request, 'Ctrl back-multi bravo');
+		const c = await seedDoc(fixture, request, 'Ctrl back-multi charlie');
+		const d = await seedDoc(fixture, request, 'Ctrl back-multi delta');
+		await page.goto(docsUrl(fixture));
+
+		await page.locator('.item-card', { hasText: 'Ctrl back-multi alpha' }).first().click();
+		const pane = page.locator('.item-pane');
+		await expect(pane).toBeVisible();
+
+		// Drill to depth 3: A(0) → B(1) → C(2) → D(3).
+		await drillTo(page, b.slug);
+		await drillTo(page, c.slug);
+		await drillTo(page, d.slug);
+		await expect.poll(() => paneState(page)).toEqual({ paneDepth: 3, paneOwned: true });
+		expect(openItemParam(page)).toBe(d.slug);
+
+		const backBtn = pane.locator('button[aria-label="Back"]');
+
+		// Press 1: D(3) → C(2).
+		await expect(backBtn).toBeVisible();
+		await backBtn.click();
+		await expect.poll(() => paneState(page)).toEqual({ paneDepth: 2, paneOwned: true });
+		await expect.poll(() => openItemParam(page)).toBe(c.slug);
+
+		// Press 2: C(2) → B(1).
+		await backBtn.click();
+		await expect.poll(() => paneState(page)).toEqual({ paneDepth: 1, paneOwned: true });
+		await expect.poll(() => openItemParam(page)).toBe(b.slug);
+
+		// Press 3: B(1) → A(0), the base — chevron disappears, pane stays open.
+		await backBtn.click();
+		await expect.poll(() => paneState(page)).toEqual({ paneDepth: 0, paneOwned: true });
+		await expect(pane).toBeVisible();
+		await expect(pane.locator('button[aria-label="Back"]')).toHaveCount(0);
+	});
+
+	test('Back chevron: a cold-loaded shared ?item= starts at depth 0 and stays hidden; browser Back still exits the pane', async ({
+		page,
+		fixture,
+		request,
+	}) => {
+		await page.setViewportSize(DESKTOP);
+		await enableHook(page);
+		await browserLogin(page);
+		const a = await seedDoc(fixture, request, 'Ctrl back-cold alpha');
+
+		// COLD LOAD straight into an open pane — no history stamp, so the
+		// controller normalizes to depth 0 / unowned (readPaneState's base
+		// default). The chevron must NOT render here.
+		await page.goto(docsUrl(fixture, `?item=${a.slug}`));
+		const pane = page.locator('.item-pane');
+		await expect(pane).toBeVisible();
+		await expect.poll(() => paneState(page)).toEqual({ paneDepth: 0, paneOwned: false });
+		await expect(pane.locator('button[aria-label="Back"]')).toHaveCount(0);
+
+		// Browser Back at the cold base behaves exactly as before this task —
+		// it leaves the page entirely (there was no pre-pane entry to unwind
+		// to within this tab's history), unaffected by the chevron addition.
+		await page.goBack();
+		await expect.poll(() => page.url()).not.toContain(`item=${a.slug}`);
+	});
+
+	test('Back chevron: works from the mobile full-screen overlay too', async ({
+		page,
+		fixture,
+		request,
+	}, testInfo) => {
+		test.skip(
+			testInfo.project.name !== 'desktop-chromium',
+			'mobile viewport is driven explicitly; one project is enough',
+		);
+		await page.setViewportSize(MOBILE);
+		await enableHook(page);
+		await browserLogin(page);
+		await seedDoc(fixture, request, 'Ctrl back-mobile alpha');
+		const b = await seedDoc(fixture, request, 'Ctrl back-mobile bravo');
+		await page.goto(docsUrl(fixture));
+
+		await page.locator('.item-card', { hasText: 'Ctrl back-mobile alpha' }).first().click();
+		const pane = page.locator('.item-pane');
+		await expect(pane).toBeVisible();
+		const backBtn = pane.locator('button[aria-label="Back"]');
+		await expect(backBtn).toHaveCount(0);
+
+		await drillTo(page, b.slug);
+		await expect.poll(() => paneState(page)).toEqual({ paneDepth: 1, paneOwned: true });
+		await expect(backBtn).toBeVisible();
+
+		await backBtn.click();
+		await expect.poll(() => paneState(page)).toEqual({ paneDepth: 0, paneOwned: true });
+		await expect(pane).toBeVisible();
+		await expect(pane.locator('button[aria-label="Back"]')).toHaveCount(0);
+	});
 });

--- a/web/e2e/pane-controller.spec.ts
+++ b/web/e2e/pane-controller.spec.ts
@@ -829,25 +829,39 @@ test.describe('pane controller: depth/ownership state machine (PLAN-2154 / TASK-
 		const pane = page.locator('.item-pane');
 		await expect(pane).toBeVisible();
 
-		// Drill to depth 3: A(0) → B(1) → C(2) → D(3).
+		// Drill to depth 3: A(0) → B(1) → C(2) → D(3). Each `drillTo` only
+		// awaits `navigatePaneTo`'s SYNCHRONOUS portion — the `goto()` it
+		// fires is fire-and-forget — so poll `page.state` to settle after
+		// each hop before firing the next; otherwise a later drill can read
+		// a still-stale depth off an in-flight earlier one (Codex review
+		// round 2, P1).
 		await drillTo(page, b.slug);
+		await expect.poll(() => paneState(page)).toEqual({ paneDepth: 1, paneOwned: true });
 		await drillTo(page, c.slug);
+		await expect.poll(() => paneState(page)).toEqual({ paneDepth: 2, paneOwned: true });
 		await drillTo(page, d.slug);
 		await expect.poll(() => paneState(page)).toEqual({ paneDepth: 3, paneOwned: true });
 		expect(openItemParam(page)).toBe(d.slug);
 
 		const backBtn = pane.locator('button[aria-label="Back"]');
 
-		// Press 1: D(3) → C(2).
+		// Press 1: D(3) → C(2). The click triggers a reload (`loading` briefly
+		// true), which swaps the loaded header for the minimal one and
+		// unmounts the just-clicked, focused Back button — Codex review round
+		// 2, P2. Focus must land back on the (re-mounted) Back button once the
+		// reload settles, so a keyboard user can keep popping levels.
 		await expect(backBtn).toBeVisible();
+		await backBtn.focus();
 		await backBtn.click();
 		await expect.poll(() => paneState(page)).toEqual({ paneDepth: 2, paneOwned: true });
 		await expect.poll(() => openItemParam(page)).toBe(c.slug);
+		await expect(backBtn).toBeFocused();
 
-		// Press 2: C(2) → B(1).
+		// Press 2: C(2) → B(1). Focus restored again.
 		await backBtn.click();
 		await expect.poll(() => paneState(page)).toEqual({ paneDepth: 1, paneOwned: true });
 		await expect.poll(() => openItemParam(page)).toBe(b.slug);
+		await expect(backBtn).toBeFocused();
 
 		// Press 3: B(1) → A(0), the base — chevron disappears, pane stays open.
 		await backBtn.click();

--- a/web/e2e/pane-controller.spec.ts
+++ b/web/e2e/pane-controller.spec.ts
@@ -878,10 +878,16 @@ test.describe('pane controller: depth/ownership state machine (PLAN-2154 / TASK-
 		await expect.poll(() => backButtonIsFocused(page)).toBe(true);
 
 		// Press 3: B(1) → A(0), the base — chevron disappears, pane stays open.
+		// The terminal pop has no Back button left to land focus on, so it
+		// falls back to the always-present Close button rather than stranding
+		// focus on <body> (Codex review round 4).
 		await backBtn.click();
 		await expect.poll(() => paneState(page)).toEqual({ paneDepth: 0, paneOwned: true });
 		await expect(pane).toBeVisible();
 		await expect(pane.locator('button[aria-label="Back"]')).toHaveCount(0);
+		await expect
+			.poll(() => page.evaluate(() => document.activeElement?.getAttribute('aria-label')))
+			.toBe('Close pane');
 	});
 
 	test('Back chevron: a second press while the first pop is still loading still ends with focus restored (Codex review round 3)', async ({

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -1940,19 +1940,30 @@
 	// nothing else raced in between. A mismatch means something else
 	// superseded it; abandon the restore instead of stealing focus.
 	//
-	// BOUNDED, not indefinitely armed (Codex review round 7): the generation
-	// fence alone does NOT self-resolve every case — a Back immediately
-	// reversed by Forward within TASK-2166's ~140ms pane-mint settle window
-	// can coalesce to a NET NO-OP (neither `itemSlug` nor `loadGeneration`
-	// ever change), leaving `pendingBackFocus` armed with nothing left to
-	// ever falsify the generation check against. The NEXT, wholly unrelated
-	// single-load navigation would then satisfy `backFocusStartGen + 1` by
-	// coincidence and steal focus. A bounded timer (mirroring the host's own
-	// `PANE_GO_SETTLE_MS` "give up waiting" pattern, +page.svelte) closes
-	// this class of case generally instead of chasing each interleaving
-	// individually: if the click's own restore hasn't resolved within
-	// `BACK_FOCUS_TIMEOUT_MS`, disarm unconditionally.
-	const BACK_FOCUS_TIMEOUT_MS = 600;
+	// NOT INDEFINITELY ARMED on a coalesced NO-OP (Codex review round 7): the
+	// generation fence alone doesn't self-resolve every case — a Back
+	// immediately reversed by Forward within TASK-2166's ~140ms pane-mint
+	// settle window can coalesce to a NET NO-OP (neither `itemSlug` nor
+	// `loadGeneration` ever change), leaving `pendingBackFocus` armed with
+	// nothing left to ever falsify the generation check against. The NEXT,
+	// wholly unrelated single-load navigation would then satisfy
+	// `backFocusStartGen + 1` by coincidence and steal focus.
+	//
+	// A single check shortly after the settle window, NOT a blanket
+	// wall-clock cutoff on the whole intent (Codex review round 8: a fixed
+	// timeout that disarms unconditionally would ALSO cancel a legitimately
+	// slow, still-in-flight restore — `loadData()` makes several requests,
+	// and a modestly slow connection can easily outrun a few hundred ms,
+	// stranding a keyboard user's Back press on <body> for the common case,
+	// not just the rare no-op one). Since `itemSlug` updates SYNCHRONOUSLY
+	// with the popstate (independent of network speed) and `loadGeneration`
+	// bumps synchronously at the top of `loadData()`, a load that's
+	// genuinely in flight has ALREADY moved one of the two by the time this
+	// check fires — only the coalesced-to-nothing case still shows BOTH
+	// unchanged, so the check disarms exactly that case and leaves every
+	// other (however slow) pending restore to resolve normally through the
+	// effect below, however long it actually takes.
+	const BACK_FOCUS_NOOP_CHECK_MS = 200;
 	let pendingBackFocus = $state(false);
 	let backFocusStartSlug = '';
 	let backFocusStartGen = 0;
@@ -1963,8 +1974,10 @@
 		backFocusStartGen = loadGeneration;
 		clearTimeout(backFocusTimer);
 		backFocusTimer = setTimeout(() => {
-			pendingBackFocus = false;
-		}, BACK_FOCUS_TIMEOUT_MS);
+			if (itemSlug === backFocusStartSlug && loadGeneration === backFocusStartGen) {
+				pendingBackFocus = false; // genuinely nothing moved — a coalesced no-op
+			}
+		}, BACK_FOCUS_NOOP_CHECK_MS);
 		onBack?.();
 	}
 	$effect(() => {

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -1902,31 +1902,31 @@
 	// re-anchors focus on the Back button's OWN click, not the general
 	// "focus per hop" for arbitrary content-link drills (TASK-2162).
 	//
-	// TWO flags, not one (Codex review round 2 follow-up): `paneDepth` (a
-	// `page.state`-derived value) updates SYNCHRONOUSLY with the popstate
-	// that `history.go(-1)` fires, which lands BEFORE `itemSlug` changes and
-	// `loadData()` sets `loading = true` — so a naive single-flag effect can
-	// observe `loading` still `false` (stale, from the PREVIOUS item) on that
-	// intermediate run, fire early, and consume the flag before the real
-	// reload cycle (the one that actually unmounts/remounts the header) even
-	// starts. `backFocusSeenLoading` requires observing `loading` go true
-	// FIRST, so the restore only fires on the matching false that follows it.
+	// Keyed off `itemSlug` actually CHANGING, not an observed `loading`
+	// true→false transition (Codex review rounds 2 and 3 both found races in
+	// an earlier `loading`-transition-based design: `paneDepth` can update a
+	// tick before `itemSlug` does, and a second press fired while a PRIOR
+	// item is still loading — `paneNavInFlight()` only fences the `history.go`
+	// traversal, not the data fetch — could let the effect latch onto that
+	// STALE, already-in-flight cycle instead of its own). `itemSlug` is
+	// purely URL-derived (`ref` prop → `page.url`'s `?item=`), so it updates
+	// SYNCHRONOUSLY with the same popstate that stamps `paneDepth`, regardless
+	// of whether the fetch for it has even started — comparing against it
+	// directly needs no "did I see the right transition" bookkeeping: once
+	// it differs from the ref captured at click time AND the (new item's)
+	// load has finished, the pop is done.
 	let pendingBackFocus = $state(false);
-	let backFocusSeenLoading = $state(false);
+	let backFocusStartSlug = '';
 	function handleBackClick() {
 		pendingBackFocus = true;
-		backFocusSeenLoading = false;
+		backFocusStartSlug = itemSlug;
 		onBack?.();
 	}
 	$effect(() => {
 		if (!pendingBackFocus) return;
-		if (loading) {
-			backFocusSeenLoading = true;
-			return;
-		}
-		if (!backFocusSeenLoading) return; // the reload hasn't actually started yet
+		if (itemSlug === backFocusStartSlug) return; // the pop hasn't landed yet
+		if (loading) return; // the new item is still loading
 		pendingBackFocus = false;
-		backFocusSeenLoading = false;
 		// Only if the stack still has a level to pop — at depth 0 there's no
 		// Back button left to focus (that terminal case is the general
 		// focus-management scope of TASK-2162, not this one).

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -309,6 +309,10 @@
 	// `handleBackClick` near `startEditTitle`) can reach whichever one
 	// re-mounts after the reload settles.
 	let backBtnEl = $state<HTMLButtonElement>();
+	// The loaded header's Close button — the focus-restore fallback for the
+	// TERMINAL Back pop (landing at depth 0, where there's no Back button
+	// left to land on; Codex review round 4).
+	let closeBtnEl = $state<HTMLButtonElement>();
 
 	let fields = $derived<Record<string, any>>(item ? parseFields(item) : {});
 	// Tags live on item.tags (a JSON-array string), NOT in the schema.
@@ -1927,14 +1931,17 @@
 		if (itemSlug === backFocusStartSlug) return; // the pop hasn't landed yet
 		if (loading) return; // the new item is still loading
 		pendingBackFocus = false;
-		// Only if the stack still has a level to pop — at depth 0 there's no
-		// Back button left to focus (that terminal case is the general
-		// focus-management scope of TASK-2162, not this one).
-		if (paneDepth > 0) restoreBackFocus();
+		// At depth>0 there's a fresh Back button to land on. At depth 0 (the
+		// terminal pop, back to the base) the Back button is gone — Codex
+		// review round 4 flagged that this left focus stranded on <body> with
+		// the pane still open. Fall back to the always-present Close button
+		// rather than nothing: a stable, keyboard-reachable control, not a
+		// full "focus per hop" implementation (still TASK-2162's scope).
+		restoreBackFocus();
 	});
 	async function restoreBackFocus() {
 		await tick();
-		backBtnEl?.focus({ preventScroll: true });
+		(paneDepth > 0 ? backBtnEl : closeBtnEl)?.focus({ preventScroll: true });
 	}
 
 	function showSaved() {
@@ -3513,6 +3520,7 @@
 					>↗</a>
 					<button
 						type="button"
+						bind:this={closeBtnEl}
 						class="pane-header-btn"
 						onclick={() => onClose?.()}
 						title="Close pane"

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -41,6 +41,7 @@
 	import { copyToClipboard } from '$lib/utils/clipboard';
 	import { repairDeadItemLastRoute } from '$lib/collections/paneUrlParams';
 	import { isSamePaneTarget } from '$lib/collections/paneTarget';
+	import { readPaneState } from '$lib/collections/paneController';
 	import { shouldOpenInPane } from '$lib/components/collections/itemCardClick';
 	import { starredStore } from '$lib/stores/starred.svelte';
 	import { titleStore } from '$lib/stores/title.svelte';
@@ -90,6 +91,7 @@
 		onNavigateAway,
 		onReady,
 		onOpenTarget,
+		onBack,
 	}: {
 		username: string;
 		wsSlug: string;
@@ -113,7 +115,23 @@
 		// through. Relationships/breadcrumb/graph land separately
 		// (TASK-2159/2161ff).
 		onOpenTarget?: (target: PaneTarget) => void;
+		// PLAN-2154 Architecture C / TASK-2164: fired by the pane chrome's Back
+		// chevron (rendered only at depth>0 — see `paneDepth` below). The host
+		// owns the actual traversal (its fenced `paneHistoryGo`/`paneNavInFlight`
+		// — R14), so this stays a plain notify, mirroring `onClose`/`onOpenTarget`.
+		onBack?: () => void;
 	} = $props();
+
+	// PLAN-2154 Architecture C / TASK-2164: in-pane drill depth, read
+	// reactively from SvelteKit's `page.state` accessor (never raw
+	// `history.state` — Kit nests app state under `sveltekit:states`). Depth
+	// is the single source of truth for the pane chrome's Back chevron —
+	// hidden at depth 0 (first-open, or a cold-loaded shared `?item=` that
+	// starts at depth 0 by construction, `readPaneState`'s base default),
+	// shown once a drill (`navigatePaneTo`) has pushed depth>0. Shared with
+	// the collection host's own `currentPaneState()` via the same
+	// `$lib/collections/paneController` module.
+	let paneDepth = $derived(readPaneState(page.state).paneDepth);
 
 	// itemSlug is the identity that drives loadData + the whole collabKey
 	// chain. It derives from the `ref` prop (NOT page.params) so a `?item=`
@@ -3355,11 +3373,28 @@
 		{:else}
 			<!-- Pane chrome (PLAN-2105 / TASK-2113). Replaces the full-page
 			     breadcrumb (hidden above) inside the narrow docked pane: expand
-			     to the full page, pop out to a new tab, or collapse the pane.
-			     The ref label + copy button mirror the full-page identity; the
-			     three controls are the pane's route-owner chrome. -->
+			     to the full page, pop out to a new tab, or collapse the pane —
+			     plus, once drilled (PLAN-2154 / TASK-2164), a Back chevron to pop
+			     one level. The ref label + copy button mirror the full-page
+			     identity; these controls are the pane's route-owner chrome. -->
 			<header class="pane-header" aria-label="Item pane">
 				<div class="pane-header-ref">
+					<!-- Back chevron (PLAN-2154 Architecture C / TASK-2164) — shown
+					     only once the pane has drilled past its base (depth>0).
+					     Pops exactly one level per press; the host owns the actual
+					     traversal (fenced `paneHistoryGo`/`paneNavInFlight`, mirroring
+					     the depth-aware ESC handler) so this is a plain notify. Desktop
+					     and mobile share this markup — the pane header is identical in
+					     both (mobile's is the fixed full-screen overlay's header). -->
+					{#if paneDepth > 0}
+						<button
+							type="button"
+							class="pane-header-btn pane-back-btn"
+							onclick={() => onBack?.()}
+							title="Back"
+							aria-label="Back"
+						>‹</button>
+					{/if}
 					<span class="pane-header-ref-text">{formatItemRef(item) || item.title}</span>
 					{#if formatItemRef(item)}
 						<button class="copy-ref-btn" onclick={handleCopyRef} title="Copy item ID" aria-label="Copy item ID">
@@ -4560,6 +4595,14 @@
 	.pane-header-btn:hover {
 		background: var(--bg-hover);
 		color: var(--text-primary);
+	}
+	/* Back chevron (PLAN-2154 / TASK-2164) — sits inside `.pane-header-ref`
+	   alongside the ref label, so it needs a touch more breathing room than
+	   the trailing action icons, and the glyph itself renders small at the
+	   shared 0.95rem size. */
+	.pane-back-btn {
+		flex-shrink: 0;
+		font-size: 1.25rem;
 	}
 
 	/* Breadcrumb */

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -42,6 +42,7 @@
 	import { repairDeadItemLastRoute } from '$lib/collections/paneUrlParams';
 	import { isSamePaneTarget, breadcrumbParentTarget } from '$lib/collections/paneTarget';
 	import { readPaneState } from '$lib/collections/paneController';
+	import { PANE_MINT_SETTLE_MS } from '$lib/collections/paneMintSettle';
 	import { shouldOpenInPane } from '$lib/components/collections/itemCardClick';
 	import { starredStore } from '$lib/stores/starred.svelte';
 	import { titleStore } from '$lib/stores/title.svelte';
@@ -1913,57 +1914,63 @@
 	// re-anchors focus on the Back button's OWN click, not the general
 	// "focus per hop" for arbitrary content-link drills (TASK-2162).
 	//
-	// Keyed off `itemSlug` actually CHANGING, not an observed `loading`
-	// true→false transition (Codex review rounds 2 and 3 both found races in
-	// an earlier `loading`-transition-based design: `paneDepth` can update a
-	// tick before `itemSlug` does, and a second press fired while a PRIOR
-	// item is still loading — `paneNavInFlight()` only fences the `history.go`
-	// traversal, not the data fetch — could let the effect latch onto that
-	// STALE, already-in-flight cycle instead of its own). `itemSlug` is
-	// purely URL-derived (`ref` prop → `page.url`'s `?item=`), so it updates
-	// SYNCHRONOUSLY with the same popstate that stamps `paneDepth`, regardless
-	// of whether the fetch for it has even started — comparing against it
-	// directly needs no "did I see the right transition" bookkeeping: once
-	// it differs from the ref captured at click time AND the (new item's)
-	// load has finished, the pop is done.
+	// The design below survived several review rounds against real races;
+	// summarized here rather than as a round-by-round diary (Codex review
+	// round 9 asked for this after an earlier comment's timing claim was
+	// invalidated by a concurrent sibling change — see the note at the
+	// bottom).
 	//
-	// GENERATION-FENCED against a SUPERSEDING, unrelated navigation (Codex
-	// review round 6): comparing only `itemSlug` treats ANY later change as
-	// "the Back pop landed" — so if the user clicks a different row/link (or
-	// hits Forward) while the Back destination is still loading, that
-	// unrelated navigation's `itemSlug` change satisfies the check just as
-	// well, and focus gets stolen into a pane the user never asked to
-	// restore-focus on. `loadGeneration` (bumped synchronously at the top of
-	// EVERY `loadData()` call, regardless of what triggered it) gives an
-	// exact fence: capture it at click time and require the settled
-	// generation to be EXACTLY one more — i.e. the Back click's own load and
-	// nothing else raced in between. A mismatch means something else
-	// superseded it; abandon the restore instead of stealing focus.
+	// 1. Keyed off `itemSlug` actually CHANGING, not an observed `loading`
+	//    true→false transition. An earlier `loading`-transition design let a
+	//    second press fired while a PRIOR item was still loading — see (2) —
+	//    latch onto that STALE, already-in-flight cycle instead of its own
+	//    (`paneNavInFlight()` only fences the `history.go` traversal, not the
+	//    data fetch). Comparing `itemSlug` against the ref captured at click
+	//    time needs no "did I see the right transition" bookkeeping: once it
+	//    differs AND the new item's load has finished, the pop is done.
 	//
-	// NOT INDEFINITELY ARMED on a coalesced NO-OP (Codex review round 7): the
-	// generation fence alone doesn't self-resolve every case — a Back
-	// immediately reversed by Forward within TASK-2166's ~140ms pane-mint
-	// settle window can coalesce to a NET NO-OP (neither `itemSlug` nor
-	// `loadGeneration` ever change), leaving `pendingBackFocus` armed with
-	// nothing left to ever falsify the generation check against. The NEXT,
-	// wholly unrelated single-load navigation would then satisfy
-	// `backFocusStartGen + 1` by coincidence and steal focus.
+	// 2. GENERATION-FENCED against a SUPERSEDING, unrelated navigation.
+	//    Comparing only `itemSlug` treats ANY later change as "the Back pop
+	//    landed" — so if the user clicks a different row/link (or hits
+	//    Forward) while the Back destination is still loading, that unrelated
+	//    navigation's `itemSlug` change satisfies the check just as well, and
+	//    focus gets stolen into a pane the user never asked to restore-focus
+	//    on. `loadGeneration` (bumped synchronously at the top of EVERY
+	//    `loadData()` call, regardless of what triggered it) gives an exact
+	//    fence: capture it at click time and require the settled generation
+	//    to be EXACTLY one more — the Back click's own load and nothing else
+	//    raced in between. A mismatch means something else superseded it;
+	//    abandon the restore instead of stealing focus.
 	//
-	// A single check shortly after the settle window, NOT a blanket
-	// wall-clock cutoff on the whole intent (Codex review round 8: a fixed
-	// timeout that disarms unconditionally would ALSO cancel a legitimately
-	// slow, still-in-flight restore — `loadData()` makes several requests,
-	// and a modestly slow connection can easily outrun a few hundred ms,
-	// stranding a keyboard user's Back press on <body> for the common case,
-	// not just the rare no-op one). Since `itemSlug` updates SYNCHRONOUSLY
-	// with the popstate (independent of network speed) and `loadGeneration`
-	// bumps synchronously at the top of `loadData()`, a load that's
-	// genuinely in flight has ALREADY moved one of the two by the time this
-	// check fires — only the coalesced-to-nothing case still shows BOTH
-	// unchanged, so the check disarms exactly that case and leaves every
-	// other (however slow) pending restore to resolve normally through the
-	// effect below, however long it actually takes.
-	const BACK_FOCUS_NOOP_CHECK_MS = 200;
+	// 3. NOT INDEFINITELY ARMED on a coalesced NO-OP. The generation fence
+	//    alone doesn't self-resolve every case — a Back immediately reversed
+	//    by Forward within TASK-2166's pane-mint settle window (see the note
+	//    below) can coalesce to a NET NO-OP where neither `itemSlug` nor
+	//    `loadGeneration` ever change, leaving `pendingBackFocus` armed with
+	//    nothing left to ever falsify the generation check against — the
+	//    NEXT, wholly unrelated single-load navigation would then satisfy
+	//    `backFocusStartGen + 1` by coincidence and steal focus. Disarm it
+	//    with a single check, NOT a blanket wall-clock cutoff on the whole
+	//    intent (a fixed timeout that disarms unconditionally would ALSO
+	//    cancel a legitimately slow, still-in-flight restore — `loadData()`
+	//    makes several requests, and a modestly slow connection can easily
+	//    outrun a short timer). The check only disarms when BOTH `itemSlug`
+	//    and `loadGeneration` are STILL unchanged by the time it fires —
+	//    every other (however slow) pending restore resolves normally
+	//    through the effect below instead.
+	//
+	// NOTE — the check's timing, and why it can't be short: `itemSlug` does
+	// NOT update synchronously with the popstate `onBack` triggers. TASK-2166
+	// (a concurrent sibling change) added a provider-mint settle that
+	// deliberately COALESCES every popstate-driven `?item=` change onto the
+	// `<ItemDetail>` `ref` prop — even a single Back press — behind a
+	// `PANE_MINT_SETTLE_MS` (140ms) window (`paneMintSettle.ts`), so
+	// `itemSlug` only starts moving ~140ms (plus the `history.go`→popstate
+	// round-trip) after the click, regardless of network speed. The no-op
+	// check in (3) has to clear that mandatory delay before concluding
+	// "nothing moved" — sized at `PANE_MINT_SETTLE_MS * 2` for headroom over
+	// the popstate round-trip on top of the settle itself.
+	const BACK_FOCUS_NOOP_CHECK_MS = PANE_MINT_SETTLE_MS * 2;
 	let pendingBackFocus = $state(false);
 	let backFocusStartSlug = '';
 	let backFocusStartGen = 0;

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -1923,18 +1923,38 @@
 	// directly needs no "did I see the right transition" bookkeeping: once
 	// it differs from the ref captured at click time AND the (new item's)
 	// load has finished, the pop is done.
+	//
+	// GENERATION-FENCED against a SUPERSEDING, unrelated navigation (Codex
+	// review round 6): comparing only `itemSlug` treats ANY later change as
+	// "the Back pop landed" — so if the user clicks a different row/link (or
+	// hits Forward) while the Back destination is still loading, that
+	// unrelated navigation's `itemSlug` change satisfies the check just as
+	// well, and focus gets stolen into a pane the user never asked to
+	// restore-focus on. `loadGeneration` (bumped synchronously at the top of
+	// EVERY `loadData()` call, regardless of what triggered it) gives an
+	// exact fence: capture it at click time and require the settled
+	// generation to be EXACTLY one more — i.e. the Back click's own load and
+	// nothing else raced in between. A mismatch means something else
+	// superseded it; abandon the restore instead of stealing focus. This
+	// also self-resolves the "armed indefinitely" case Codex flagged (a
+	// quick Back→Forward before the pop settles) — `loadGeneration` only
+	// increases, so once it passes the target it can never match again and
+	// the abandon branch takes over on the very next settle.
 	let pendingBackFocus = $state(false);
 	let backFocusStartSlug = '';
+	let backFocusStartGen = 0;
 	function handleBackClick() {
 		pendingBackFocus = true;
 		backFocusStartSlug = itemSlug;
+		backFocusStartGen = loadGeneration;
 		onBack?.();
 	}
 	$effect(() => {
 		if (!pendingBackFocus) return;
 		if (itemSlug === backFocusStartSlug) return; // the pop hasn't landed yet
 		if (loading) return; // the new item is still loading
-		pendingBackFocus = false;
+		pendingBackFocus = false; // one-shot regardless of outcome below
+		if (loadGeneration !== backFocusStartGen + 1) return; // superseded — abandon, don't steal focus
 		// At depth>0 there's a fresh Back button to land on. At depth 0 (the
 		// terminal pop, back to the base) the Back button is gone — Codex
 		// review round 4 flagged that this left focus stranded on <body> with

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -3307,6 +3307,20 @@
 {#if embedded && (loading || error || !item || !collection)}
 	<header class="pane-header pane-header--minimal" aria-label="Item pane">
 		<div class="pane-header-actions">
+			<!-- Back chevron (PLAN-2154 Architecture C / TASK-2164, Codex review):
+			     every drill sets `loading = true`, landing here — WITHOUT this, a
+			     slow or failed drilled item would strand the user with no way back
+			     (only Close), especially on mobile where ESC isn't reachable. Same
+			     depth gate + `onBack` notify as the loaded header's chevron. -->
+			{#if paneDepth > 0}
+				<button
+					type="button"
+					class="pane-header-btn pane-back-btn"
+					onclick={() => onBack?.()}
+					title="Back"
+					aria-label="Back"
+				>‹</button>
+			{/if}
 			<button
 				type="button"
 				class="pane-header-btn"

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -309,9 +309,13 @@
 	// `handleBackClick` near `startEditTitle`) can reach whichever one
 	// re-mounts after the reload settles.
 	let backBtnEl = $state<HTMLButtonElement>();
-	// The loaded header's Close button — the focus-restore fallback for the
-	// TERMINAL Back pop (landing at depth 0, where there's no Back button
-	// left to land on; Codex review round 4).
+	// The Close button — the focus-restore fallback for the TERMINAL Back pop
+	// (landing at depth 0, where there's no Back button left to land on;
+	// Codex review round 4). Bound by BOTH headers, same reasoning as
+	// `backBtnEl` above: if the pop's destination is slow/failed, the
+	// MINIMAL header can still be mounted when the restore fires, and it
+	// needs its own Close button bound or the restore silently no-ops
+	// (Codex review round 5).
 	let closeBtnEl = $state<HTMLButtonElement>();
 
 	let fields = $derived<Record<string, any>>(item ? parseFields(item) : {});
@@ -3403,6 +3407,7 @@
 			{/if}
 			<button
 				type="button"
+				bind:this={closeBtnEl}
 				class="pane-header-btn"
 				onclick={() => onClose?.()}
 				title="Close pane"

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -42,7 +42,6 @@
 	import { repairDeadItemLastRoute } from '$lib/collections/paneUrlParams';
 	import { isSamePaneTarget, breadcrumbParentTarget } from '$lib/collections/paneTarget';
 	import { readPaneState } from '$lib/collections/paneController';
-	import { PANE_MINT_SETTLE_MS } from '$lib/collections/paneMintSettle';
 	import { shouldOpenInPane } from '$lib/components/collections/itemCardClick';
 	import { starredStore } from '$lib/stores/starred.svelte';
 	import { titleStore } from '$lib/stores/title.svelte';
@@ -878,9 +877,6 @@
 		// Cancel a pending add-relationship search so it can't fire a wasted
 		// /search request after this instance is torn down.
 		clearTimeout(addLinkDebounceTimer);
-		// Cancel a pending Back-chevron focus-restore timer (TASK-2164) so it
-		// can't write to `pendingBackFocus` after the pane closes.
-		clearTimeout(backFocusTimer);
 		// Invalidate any in-flight loadData so a request that resolves AFTER
 		// this instance is torn down (pane closed mid-load) can't reach its
 		// global-store writes — collectionStore.setActiveItem / editorStore —
@@ -1915,10 +1911,7 @@
 	// "focus per hop" for arbitrary content-link drills (TASK-2162).
 	//
 	// The design below survived several review rounds against real races;
-	// summarized here rather than as a round-by-round diary (Codex review
-	// round 9 asked for this after an earlier comment's timing claim was
-	// invalidated by a concurrent sibling change — see the note at the
-	// bottom).
+	// summarized here rather than as a round-by-round diary.
 	//
 	// 1. Keyed off `itemSlug` actually CHANGING, not an observed `loading`
 	//    true→false transition. An earlier `loading`-transition design let a
@@ -1931,60 +1924,50 @@
 	//
 	// 2. GENERATION-FENCED against a SUPERSEDING, unrelated navigation.
 	//    Comparing only `itemSlug` treats ANY later change as "the Back pop
-	//    landed" — so if the user clicks a different row/link (or hits
-	//    Forward) while the Back destination is still loading, that unrelated
-	//    navigation's `itemSlug` change satisfies the check just as well, and
-	//    focus gets stolen into a pane the user never asked to restore-focus
-	//    on. `loadGeneration` (bumped synchronously at the top of EVERY
-	//    `loadData()` call, regardless of what triggered it) gives an exact
+	//    landed" — so if the user clicks a different row/link while the Back
+	//    destination is still loading, that unrelated navigation's `itemSlug`
+	//    change satisfies the check just as well, and focus gets stolen into
+	//    a pane the user never asked to restore-focus on. `loadGeneration`
+	//    (bumped synchronously at the top of EVERY `loadData()` call,
+	//    regardless of what triggered it) gives an exact, timing-independent
 	//    fence: capture it at click time and require the settled generation
 	//    to be EXACTLY one more — the Back click's own load and nothing else
 	//    raced in between. A mismatch means something else superseded it;
 	//    abandon the restore instead of stealing focus.
 	//
-	// 3. NOT INDEFINITELY ARMED on a coalesced NO-OP. The generation fence
-	//    alone doesn't self-resolve every case — a Back immediately reversed
-	//    by Forward within TASK-2166's pane-mint settle window (see the note
-	//    below) can coalesce to a NET NO-OP where neither `itemSlug` nor
-	//    `loadGeneration` ever change, leaving `pendingBackFocus` armed with
-	//    nothing left to ever falsify the generation check against — the
-	//    NEXT, wholly unrelated single-load navigation would then satisfy
-	//    `backFocusStartGen + 1` by coincidence and steal focus. Disarm it
-	//    with a single check, NOT a blanket wall-clock cutoff on the whole
-	//    intent (a fixed timeout that disarms unconditionally would ALSO
-	//    cancel a legitimately slow, still-in-flight restore — `loadData()`
-	//    makes several requests, and a modestly slow connection can easily
-	//    outrun a short timer). The check only disarms when BOTH `itemSlug`
-	//    and `loadGeneration` are STILL unchanged by the time it fires —
-	//    every other (however slow) pending restore resolves normally
-	//    through the effect below instead.
-	//
-	// NOTE — the check's timing, and why it can't be short: `itemSlug` does
-	// NOT update synchronously with the popstate `onBack` triggers. TASK-2166
-	// (a concurrent sibling change) added a provider-mint settle that
-	// deliberately COALESCES every popstate-driven `?item=` change onto the
-	// `<ItemDetail>` `ref` prop — even a single Back press — behind a
-	// `PANE_MINT_SETTLE_MS` (140ms) window (`paneMintSettle.ts`), so
-	// `itemSlug` only starts moving ~140ms (plus the `history.go`→popstate
-	// round-trip) after the click, regardless of network speed. The no-op
-	// check in (3) has to clear that mandatory delay before concluding
-	// "nothing moved" — sized at `PANE_MINT_SETTLE_MS * 2` for headroom over
-	// the popstate round-trip on top of the settle itself.
-	const BACK_FOCUS_NOOP_CHECK_MS = PANE_MINT_SETTLE_MS * 2;
+	// KNOWN LIMITATION (deliberately not chased further — see below): a Back
+	// immediately reversed by Forward can, in principle, coalesce to a NET
+	// NO-OP (TASK-2166's provider-mint settle can settle back onto the exact
+	// ref this component started on, which Svelte's fine-grained reactivity
+	// then treats as no change at all) — leaving `pendingBackFocus` armed
+	// with nothing left to ever falsify the generation check against, so the
+	// NEXT, wholly unrelated single-load navigation could satisfy
+	// `backFocusStartGen + 1` by coincidence and land focus on ITS Close/Back
+	// button instead of wherever that unrelated navigation would have
+	// naturally put it. Three review rounds (7-9) tried progressively more
+	// careful wall-clock "give up waiting" timeouts to close this — each one
+	// got shown to be racing an ever-longer worst-case bound elsewhere in the
+	// pipeline (the mint settle, then the settle PLUS the popstate
+	// round-trip, then `paneHistoryGo`'s own 500ms fallback on top of both) —
+	// confirming a fixed-duration heuristic is structurally the wrong tool: closing
+	// it for real needs an explicit "did this specific click's traversal
+	// resolve" signal from the host (`+page.svelte`), not inference from
+	// elapsed time. That's new cross-component plumbing, not a hardening
+	// pass on the existing effect, so it's left as a documented, narrow,
+	// low-severity gap for TASK-2162 (the already-planned general "focus per
+	// hop" follow-up) rather than an ever-growing pile of timing patches
+	// here: the WORST outcome is focus landing on a nearby, still-sensible,
+	// keyboard-reachable pane control (Close or Back) instead of the ideal
+	// target — not lost, not on a hidden node, not a correctness or data
+	// issue — and it requires the fairly deliberate Back-then-Forward
+	// sequence to trigger at all.
 	let pendingBackFocus = $state(false);
 	let backFocusStartSlug = '';
 	let backFocusStartGen = 0;
-	let backFocusTimer: ReturnType<typeof setTimeout> | undefined;
 	function handleBackClick() {
 		pendingBackFocus = true;
 		backFocusStartSlug = itemSlug;
 		backFocusStartGen = loadGeneration;
-		clearTimeout(backFocusTimer);
-		backFocusTimer = setTimeout(() => {
-			if (itemSlug === backFocusStartSlug && loadGeneration === backFocusStartGen) {
-				pendingBackFocus = false; // genuinely nothing moved — a coalesced no-op
-			}
-		}, BACK_FOCUS_NOOP_CHECK_MS);
 		onBack?.();
 	}
 	$effect(() => {
@@ -1992,7 +1975,6 @@
 		if (itemSlug === backFocusStartSlug) return; // the pop hasn't landed yet
 		if (loading) return; // the new item is still loading
 		pendingBackFocus = false; // one-shot regardless of outcome below
-		clearTimeout(backFocusTimer);
 		if (loadGeneration !== backFocusStartGen + 1) return; // superseded — abandon, don't steal focus
 		// At depth>0 there's a fresh Back button to land on. At depth 0 (the
 		// terminal pop, back to the base) the Back button is gone — Codex

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -877,6 +877,9 @@
 		// Cancel a pending add-relationship search so it can't fire a wasted
 		// /search request after this instance is torn down.
 		clearTimeout(addLinkDebounceTimer);
+		// Cancel a pending Back-chevron focus-restore timer (TASK-2164) so it
+		// can't write to `pendingBackFocus` after the pane closes.
+		clearTimeout(backFocusTimer);
 		// Invalidate any in-flight loadData so a request that resolves AFTER
 		// this instance is torn down (pane closed mid-load) can't reach its
 		// global-store writes — collectionStore.setActiveItem / editorStore —
@@ -1935,18 +1938,33 @@
 	// exact fence: capture it at click time and require the settled
 	// generation to be EXACTLY one more — i.e. the Back click's own load and
 	// nothing else raced in between. A mismatch means something else
-	// superseded it; abandon the restore instead of stealing focus. This
-	// also self-resolves the "armed indefinitely" case Codex flagged (a
-	// quick Back→Forward before the pop settles) — `loadGeneration` only
-	// increases, so once it passes the target it can never match again and
-	// the abandon branch takes over on the very next settle.
+	// superseded it; abandon the restore instead of stealing focus.
+	//
+	// BOUNDED, not indefinitely armed (Codex review round 7): the generation
+	// fence alone does NOT self-resolve every case — a Back immediately
+	// reversed by Forward within TASK-2166's ~140ms pane-mint settle window
+	// can coalesce to a NET NO-OP (neither `itemSlug` nor `loadGeneration`
+	// ever change), leaving `pendingBackFocus` armed with nothing left to
+	// ever falsify the generation check against. The NEXT, wholly unrelated
+	// single-load navigation would then satisfy `backFocusStartGen + 1` by
+	// coincidence and steal focus. A bounded timer (mirroring the host's own
+	// `PANE_GO_SETTLE_MS` "give up waiting" pattern, +page.svelte) closes
+	// this class of case generally instead of chasing each interleaving
+	// individually: if the click's own restore hasn't resolved within
+	// `BACK_FOCUS_TIMEOUT_MS`, disarm unconditionally.
+	const BACK_FOCUS_TIMEOUT_MS = 600;
 	let pendingBackFocus = $state(false);
 	let backFocusStartSlug = '';
 	let backFocusStartGen = 0;
+	let backFocusTimer: ReturnType<typeof setTimeout> | undefined;
 	function handleBackClick() {
 		pendingBackFocus = true;
 		backFocusStartSlug = itemSlug;
 		backFocusStartGen = loadGeneration;
+		clearTimeout(backFocusTimer);
+		backFocusTimer = setTimeout(() => {
+			pendingBackFocus = false;
+		}, BACK_FOCUS_TIMEOUT_MS);
 		onBack?.();
 	}
 	$effect(() => {
@@ -1954,6 +1972,7 @@
 		if (itemSlug === backFocusStartSlug) return; // the pop hasn't landed yet
 		if (loading) return; // the new item is still loading
 		pendingBackFocus = false; // one-shot regardless of outcome below
+		clearTimeout(backFocusTimer);
 		if (loadGeneration !== backFocusStartGen + 1) return; // superseded — abandon, don't steal focus
 		// At depth>0 there's a fresh Back button to land on. At depth 0 (the
 		// terminal pop, back to the base) the Back button is gone — Codex

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -302,6 +302,14 @@
 	let titleDraft = $state('');
 	let titleInputEl = $state<HTMLTextAreaElement>();
 
+	// PLAN-2154 Architecture C / TASK-2164 (Codex review round 2, P2): the
+	// pane chrome's Back chevron. Bound by BOTH the loaded and minimal
+	// headers below (mutually exclusive `{#if}`s, so only one is ever
+	// mounted) so a pending focus-restore (see `pendingBackFocus` /
+	// `handleBackClick` near `startEditTitle`) can reach whichever one
+	// re-mounts after the reload settles.
+	let backBtnEl = $state<HTMLButtonElement>();
+
 	let fields = $derived<Record<string, any>>(item ? parseFields(item) : {});
 	// Tags live on item.tags (a JSON-array string), NOT in the schema.
 	// parseTags is defensive (tolerates empty/garbage) and dedupes
@@ -1883,6 +1891,52 @@
 		el.style.height = el.scrollHeight + 'px';
 	}
 
+	// PLAN-2154 Architecture C / TASK-2164 (Codex review round 2, P2): the
+	// Back chevron's own click triggers a reload of the drilled-to item —
+	// `loadData()` sets `loading = true`, which swaps the loaded pane header
+	// for the minimal one and UNMOUNTS the just-clicked (and browser-focused)
+	// Back button, dropping focus to <body>. Without restoring it, a
+	// keyboard user popping a multi-level stack loses their place after every
+	// press. Mirrors the `pendingNewItemEdit` pattern above: flag the intent,
+	// then act once the reload settles. Deliberately narrow — this only
+	// re-anchors focus on the Back button's OWN click, not the general
+	// "focus per hop" for arbitrary content-link drills (TASK-2162).
+	//
+	// TWO flags, not one (Codex review round 2 follow-up): `paneDepth` (a
+	// `page.state`-derived value) updates SYNCHRONOUSLY with the popstate
+	// that `history.go(-1)` fires, which lands BEFORE `itemSlug` changes and
+	// `loadData()` sets `loading = true` — so a naive single-flag effect can
+	// observe `loading` still `false` (stale, from the PREVIOUS item) on that
+	// intermediate run, fire early, and consume the flag before the real
+	// reload cycle (the one that actually unmounts/remounts the header) even
+	// starts. `backFocusSeenLoading` requires observing `loading` go true
+	// FIRST, so the restore only fires on the matching false that follows it.
+	let pendingBackFocus = $state(false);
+	let backFocusSeenLoading = $state(false);
+	function handleBackClick() {
+		pendingBackFocus = true;
+		backFocusSeenLoading = false;
+		onBack?.();
+	}
+	$effect(() => {
+		if (!pendingBackFocus) return;
+		if (loading) {
+			backFocusSeenLoading = true;
+			return;
+		}
+		if (!backFocusSeenLoading) return; // the reload hasn't actually started yet
+		pendingBackFocus = false;
+		backFocusSeenLoading = false;
+		// Only if the stack still has a level to pop — at depth 0 there's no
+		// Back button left to focus (that terminal case is the general
+		// focus-management scope of TASK-2162, not this one).
+		if (paneDepth > 0) restoreBackFocus();
+	});
+	async function restoreBackFocus() {
+		await tick();
+		backBtnEl?.focus({ preventScroll: true });
+	}
+
 	function showSaved() {
 		saveStatus = 'saved';
 		clearTimeout(saveStatusTimer);
@@ -3333,8 +3387,9 @@
 			{#if paneDepth > 0}
 				<button
 					type="button"
+					bind:this={backBtnEl}
 					class="pane-header-btn pane-back-btn"
-					onclick={() => onBack?.()}
+					onclick={handleBackClick}
 					title="Back"
 					aria-label="Back"
 				>‹</button>
@@ -3421,8 +3476,9 @@
 					{#if paneDepth > 0}
 						<button
 							type="button"
+							bind:this={backBtnEl}
 							class="pane-header-btn pane-back-btn"
-							onclick={() => onBack?.()}
+							onclick={handleBackClick}
 							title="Back"
 							aria-label="Back"
 						>‹</button>

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -684,6 +684,19 @@
 		navigatePaneTo(resolved);
 	}
 
+	// The pane chrome's Back chevron (PLAN-2154 Architecture C / TASK-2164) —
+	// `ItemDetail`'s `onBack`, rendered only once `page.state.paneDepth > 0`.
+	// Pops exactly one drill level through the same FENCED `paneHistoryGo` /
+	// `paneNavInFlight()` guard the depth-aware ESC handler below uses (R14),
+	// not a bare `history.back()` — a rapid double-click, or a click racing
+	// ESC/close, can't queue a second traversal and overshoot. The depth
+	// check is defense-in-depth: the chevron only renders at depth>0, but a
+	// stale click could in principle race a continuation that already
+	// unwound the stack back to the base.
+	function handlePaneBack() {
+		if (currentPaneState().paneDepth > 0 && !paneNavInFlight()) paneHistoryGo(-1);
+	}
+
 	// The pane's ItemDetail fires `onNavigateAway` for TWO distinct cases, which
 	// we tell apart by whether the target URL still carries `?item=` (i.e. keeps
 	// the pane open):
@@ -3743,6 +3756,7 @@
 				onGone={closeItemPane}
 				onNavigateAway={handlePaneNavigateAway}
 				onOpenTarget={handleOpenTarget}
+				onBack={handlePaneBack}
 			/>
 		</aside>
 	{/if}


### PR DESCRIPTION
## Summary
- Render a Back chevron in the pane header (both the loaded and minimal-header branches of `ItemDetail`'s embedded chrome), shown only when `page.state.paneDepth > 0` (PLAN-2154 Architecture C).
- Wired to the collection host's existing fenced `paneHistoryGo(-1)` / `paneNavInFlight()` traversal — the same mechanism the depth-aware ESC handler (TASK-2163) uses.
- Depth is read reactively via SvelteKit's `page.state` accessor inside `ItemDetail` itself, so a cold-loaded shared `?item=` correctly starts at depth 0 with the chevron hidden.
- Focus-restoration hardening (proactive, beyond the original acceptance criteria, added in response to review): after each Back press pops the pane header out from under the just-clicked button, focus is restored to the fresh Back button (or the Close button at the terminal depth-0 pop / in the minimal loading header), keyed off `itemSlug` actually changing and generation-fenced against a superseding, unrelated navigation.
- **Known, documented, deliberately-deferred limitation**: a Back press immediately reversed by Forward can, in a narrow window, coalesce to a net no-op that leaves the focus-restore intent armed until the next unrelated navigation, which could then land focus on that pane's Close/Back button instead of its natural target. Closing this fully needs an explicit host→component traversal-resolution signal (new cross-component plumbing), which is out of scope here — documented in the code and deferred to TASK-2162 (the already-planned general "focus per hop" follow-up). Worst case is focus landing on a nearby, still-sensible, keyboard-reachable control, not a correctness or data issue, and it requires a fairly deliberate Back-then-Forward sequence to trigger.

## Test plan
- [x] `npm run check` — 0 errors
- [x] Playwright e2e coverage in `e2e/pane-controller.spec.ts`: chevron hidden at depth 0 / visible at depth>0 / one press pops one level, multi-hop pop with focus restoration, cold-load starts hidden at depth 0, a mobile-viewport variant, a superseding-navigation regression test, and a slow-load regression test — all passing
- [x] Full `pane-controller.spec.ts` + `pane-a11y-focus.spec.ts` + `pane-content-link-anchors.spec.ts` + `pane-mobile-overlay.spec.ts` regression suite (33/33) passing on desktop-chromium after merging both TASK-2165 (breadcrumb) and TASK-2166 (pane-mint settle)
- [x] `vitest` unit suite for `paneController`/`paneTarget`/`paneFocus`/`paneMintSettle` — all passing
- [x] 11 Codex `read-only` review rounds — rounds 1-10 found real issues (all fixed); round 11 re-flagged the same limitation documented and consciously deferred in round 10's fix

https://claude.ai/code/session_01EZ6yr6pAUFb1uffan912ra