### PR TITLE
feat(web): settle popstate-driven pane mints to one teardown/mint (TASK-2166)

### DIFF
--- a/web/src/lib/collections/paneMintSettle.test.ts
+++ b/web/src/lib/collections/paneMintSettle.test.ts
@@ -53,17 +53,48 @@ describe('createPaneMintSettle', () => {
 		expect(onSettle).toHaveBeenCalledTimes(1);
 	});
 
-	it('settles to null when a held-Back burst ends on the pane closing', () => {
+	it('a popstate that closes the pane (ref -> null) applies IMMEDIATELY, never settled', () => {
+		// The pane's mount boundary (`{#if openItemRef}` in +page.svelte)
+		// reacts to the raw URL instantly and tears `<ItemDetail>` down the
+		// moment `?item=` disappears — a delayed null would leave a stale
+		// non-null `paneMintRef` around to remount against on a quick
+		// close-then-reopen (the P2 this guards against; see the next spec).
 		const onSettle = vi.fn();
 		const settle = createPaneMintSettle({ onSettle });
 
-		settle.onNavigate('popstate', 'TASK-2');
+		settle.onNavigate('popstate', 'TASK-2'); // held Back, still mid-drill
 		vi.advanceTimersByTime(50);
-		settle.onNavigate('popstate', null);
-		vi.advanceTimersByTime(PANE_MINT_SETTLE_MS);
+		settle.onNavigate('popstate', null); // Back crosses the pane-closed boundary
 
+		// Fires right away — no need to advance the fake clock at all.
 		expect(onSettle).toHaveBeenCalledTimes(1);
 		expect(onSettle).toHaveBeenCalledWith(null);
+
+		// The superseded TASK-2 timer must not fire a stale second call.
+		vi.advanceTimersByTime(PANE_MINT_SETTLE_MS);
+		expect(onSettle).toHaveBeenCalledTimes(1);
+	});
+
+	it('a quick close-then-reopen (ref -> null -> different ref) settles cleanly with no stale intermediate mint', () => {
+		const onSettle = vi.fn();
+		const settle = createPaneMintSettle({ onSettle });
+
+		settle.onNavigate('popstate', 'TASK-2'); // pane open, drilling
+		settle.onNavigate('popstate', null); // Back closes — applies immediately
+		expect(onSettle).toHaveBeenNthCalledWith(1, null);
+
+		// Forward reopens on a DIFFERENT item, itself a held burst.
+		settle.onNavigate('popstate', 'TASK-9');
+		vi.advanceTimersByTime(50);
+		settle.onNavigate('popstate', 'TASK-10');
+		// Still just the close call — the reopen burst hasn't settled yet, and
+		// critically never applied the stale 'TASK-2' or the intermediate
+		// 'TASK-9'.
+		expect(onSettle).toHaveBeenCalledTimes(1);
+
+		vi.advanceTimersByTime(PANE_MINT_SETTLE_MS);
+		expect(onSettle).toHaveBeenCalledTimes(2);
+		expect(onSettle).toHaveBeenNthCalledWith(2, 'TASK-10');
 	});
 
 	it('cancel() drops a pending settle without applying it', () => {

--- a/web/src/lib/collections/paneMintSettle.test.ts
+++ b/web/src/lib/collections/paneMintSettle.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createPaneMintSettle, PANE_MINT_SETTLE_MS } from './paneMintSettle';
+
+describe('createPaneMintSettle', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('coalesces a held-Back popstate burst into a single settle on the final ref', () => {
+		const onSettle = vi.fn();
+		const settle = createPaneMintSettle({ onSettle });
+
+		settle.onNavigate('popstate', 'TASK-3');
+		vi.advanceTimersByTime(50);
+		settle.onNavigate('popstate', 'TASK-2'); // supersedes TASK-3 before it fires
+		vi.advanceTimersByTime(50);
+		settle.onNavigate('popstate', 'TASK-1');
+
+		// Nothing fires until a full settle window elapses after the LAST popstate.
+		expect(onSettle).not.toHaveBeenCalled();
+		vi.advanceTimersByTime(PANE_MINT_SETTLE_MS);
+
+		expect(onSettle).toHaveBeenCalledTimes(1);
+		expect(onSettle).toHaveBeenCalledWith('TASK-1');
+	});
+
+	it('applies a non-popstate nav (explicit open/drill/close) immediately, no settle delay', () => {
+		const onSettle = vi.fn();
+		const settle = createPaneMintSettle({ onSettle });
+
+		settle.onNavigate('goto', 'TASK-9');
+
+		expect(onSettle).toHaveBeenCalledTimes(1);
+		expect(onSettle).toHaveBeenCalledWith('TASK-9');
+	});
+
+	it('a deliberate nav mid-burst cancels the pending popstate settle and applies right away', () => {
+		const onSettle = vi.fn();
+		const settle = createPaneMintSettle({ onSettle });
+
+		settle.onNavigate('popstate', 'TASK-2'); // held Back in flight
+		vi.advanceTimersByTime(50);
+		settle.onNavigate('goto', 'TASK-7'); // e.g. the reset-latch write mid-traversal
+
+		expect(onSettle).toHaveBeenCalledTimes(1);
+		expect(onSettle).toHaveBeenCalledWith('TASK-7');
+
+		// The superseded popstate timer must not fire a second, stale settle.
+		vi.advanceTimersByTime(PANE_MINT_SETTLE_MS);
+		expect(onSettle).toHaveBeenCalledTimes(1);
+	});
+
+	it('settles to null when a held-Back burst ends on the pane closing', () => {
+		const onSettle = vi.fn();
+		const settle = createPaneMintSettle({ onSettle });
+
+		settle.onNavigate('popstate', 'TASK-2');
+		vi.advanceTimersByTime(50);
+		settle.onNavigate('popstate', null);
+		vi.advanceTimersByTime(PANE_MINT_SETTLE_MS);
+
+		expect(onSettle).toHaveBeenCalledTimes(1);
+		expect(onSettle).toHaveBeenCalledWith(null);
+	});
+
+	it('cancel() drops a pending settle without applying it', () => {
+		const onSettle = vi.fn();
+		const settle = createPaneMintSettle({ onSettle });
+
+		settle.onNavigate('popstate', 'TASK-2');
+		settle.cancel();
+		vi.advanceTimersByTime(5000);
+
+		expect(onSettle).not.toHaveBeenCalled();
+	});
+
+	it('uses a custom settleMs when supplied', () => {
+		const onSettle = vi.fn();
+		const settle = createPaneMintSettle({ onSettle, settleMs: 500 });
+
+		settle.onNavigate('popstate', 'TASK-1');
+		vi.advanceTimersByTime(499);
+		expect(onSettle).not.toHaveBeenCalled();
+		vi.advanceTimersByTime(1);
+		expect(onSettle).toHaveBeenCalledTimes(1);
+	});
+
+	it('a single isolated popstate (not a burst) still settles after the window', () => {
+		const onSettle = vi.fn();
+		const settle = createPaneMintSettle({ onSettle });
+
+		settle.onNavigate('popstate', 'TASK-5');
+		vi.advanceTimersByTime(PANE_MINT_SETTLE_MS);
+
+		expect(onSettle).toHaveBeenCalledTimes(1);
+		expect(onSettle).toHaveBeenCalledWith('TASK-5');
+	});
+});

--- a/web/src/lib/collections/paneMintSettle.ts
+++ b/web/src/lib/collections/paneMintSettle.ts
@@ -1,0 +1,79 @@
+// paneMintSettle — coalesces rapid popstate-driven `?item=` changes (a HELD
+// browser Back/Forward) into a single collab teardown/mint for the split
+// pane's `<ItemDetail>` instance (PLAN-2154 Architecture D).
+//
+// Every `?item=` change re-drives ItemDetail's `loadData`/`collabKey`
+// effects (destroy the old Y.Doc/WS provider, mint a fresh one, replay the
+// op-log) — cheap for a single deliberate open/drill/close, expensive when a
+// user holds Back/Forward and the browser fires a `popstate` per history
+// entry traversed. `j`/`k` pane-follow already protects the same mint path
+// with a ~140ms debounce (`PANE_FOLLOW_DEBOUNCE_MS`, `[collection]/+page.svelte`),
+// but popstate bypasses that entirely — it flows straight through
+// `beforeNavigate`'s same-pathname early return to the `openItemRef`
+// derived. This module is the popstate-side mirror of that same coalescing.
+//
+// Direct actions (`openItemPane`/`navigatePaneTo`/`closeItemPane` — a `goto`
+// push/replace, `nav.type !== 'popstate'`) apply IMMEDIATELY: they're
+// already a single deliberate action, not a burst, and delaying one would
+// only add latency users would notice. Only `nav.type === 'popstate'`
+// changes settle.
+//
+// Framework-agnostic (no `$state`/`page`/`goto`) so it's unit-testable with
+// vitest fake timers without mounting the route — same pattern as
+// `contentSaver.svelte.ts` and `paneController.ts`.
+
+/** Default settle window in ms — mirrors `PANE_FOLLOW_DEBOUNCE_MS`. */
+export const PANE_MINT_SETTLE_MS = 140;
+
+export interface PaneMintSettleConfig {
+	/** Settle window in ms (default `PANE_MINT_SETTLE_MS`). */
+	settleMs?: number;
+	/**
+	 * Fired with the settled `?item=` ref: immediately for a non-popstate
+	 * nav, or once a popstate burst quiesces for `settleMs` with no further
+	 * popstate. Only the LAST ref of a burst is ever applied — intermediate
+	 * refs traversed mid-burst are dropped, which is the coalescing itself.
+	 */
+	onSettle: (ref: string | null) => void;
+}
+
+export interface PaneMintSettle {
+	/**
+	 * Report a completed navigation. `navType` is SvelteKit's `nav.type`
+	 * (e.g. `'popstate' | 'link' | 'goto'`); `ref` is the `?item=` value at
+	 * the navigation's destination. Every call — of EITHER kind — cancels
+	 * any previously pending settle first, so a burst always collapses to
+	 * the most recent call: a non-popstate nav mid-burst applies right away
+	 * (and can't be clobbered by a stale popstate timer landing later); a
+	 * fresh popstate mid-burst re-arms the window against the new ref.
+	 */
+	onNavigate(navType: string, ref: string | null): void;
+	/** Cancel any pending settle without applying it (component teardown). */
+	cancel(): void;
+}
+
+export function createPaneMintSettle(config: PaneMintSettleConfig): PaneMintSettle {
+	const settleMs = config.settleMs ?? PANE_MINT_SETTLE_MS;
+	let timer: ReturnType<typeof setTimeout> | undefined;
+
+	function cancel(): void {
+		if (timer !== undefined) {
+			clearTimeout(timer);
+			timer = undefined;
+		}
+	}
+
+	function onNavigate(navType: string, ref: string | null): void {
+		cancel();
+		if (navType !== 'popstate') {
+			config.onSettle(ref);
+			return;
+		}
+		timer = setTimeout(() => {
+			timer = undefined;
+			config.onSettle(ref);
+		}, settleMs);
+	}
+
+	return { onNavigate, cancel };
+}

--- a/web/src/lib/collections/paneMintSettle.ts
+++ b/web/src/lib/collections/paneMintSettle.ts
@@ -15,8 +15,15 @@
 // Direct actions (`openItemPane`/`navigatePaneTo`/`closeItemPane` — a `goto`
 // push/replace, `nav.type !== 'popstate'`) apply IMMEDIATELY: they're
 // already a single deliberate action, not a burst, and delaying one would
-// only add latency users would notice. Only `nav.type === 'popstate'`
-// changes settle.
+// only add latency users would notice. A popstate landing on a CLOSED pane
+// (`ref === null`) also applies immediately, never settled: the pane's
+// mount boundary (`{#if openItemRef}` in `+page.svelte`) already reacts to
+// the raw URL instantly, tearing the `<ItemDetail>` down the moment the URL
+// loses `?item=`. If the null were delayed instead, a quick close-then-
+// reopen within the settle window (Back to close, Forward to reopen) would
+// remount `<ItemDetail>` against the STALE pre-close `paneMintRef` — wrong
+// content, and a wasted mint on top of the correct one that follows. Only a
+// popstate settling on a NON-null ref during an already-open pane settles.
 //
 // Framework-agnostic (no `$state`/`page`/`goto`) so it's unit-testable with
 // vitest fake timers without mounting the route — same pattern as
@@ -30,7 +37,8 @@ export interface PaneMintSettleConfig {
 	settleMs?: number;
 	/**
 	 * Fired with the settled `?item=` ref: immediately for a non-popstate
-	 * nav, or once a popstate burst quiesces for `settleMs` with no further
+	 * nav or a popstate landing on `null` (pane closed), or once a popstate
+	 * burst on a non-null ref quiesces for `settleMs` with no further
 	 * popstate. Only the LAST ref of a burst is ever applied — intermediate
 	 * refs traversed mid-burst are dropped, which is the coalescing itself.
 	 */
@@ -65,7 +73,8 @@ export function createPaneMintSettle(config: PaneMintSettleConfig): PaneMintSett
 
 	function onNavigate(navType: string, ref: string | null): void {
 		cancel();
-		if (navType !== 'popstate') {
+		// A close (ref === null) is never settled — see the module comment.
+		if (navType !== 'popstate' || ref === null) {
 			config.onSettle(ref);
 			return;
 		}

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -53,6 +53,7 @@
 	} from '$lib/collections/paneController';
 	import { paneFocusables, nextTrapTarget, resolvePaneReturnTarget } from '$lib/collections/paneFocus';
 	import { resolvePaneTarget } from '$lib/collections/paneTarget';
+	import { createPaneMintSettle, PANE_MINT_SETTLE_MS } from '$lib/collections/paneMintSettle';
 	import { pushEscapeHandler, runTopEscape, topEscapePriority, ESCAPE_PRIORITY } from '$lib/stores/escapeStack';
 	import { boardKeyNav, type BoardNavColumn, type BoardNavDirection } from '$lib/collections/boardNav';
 
@@ -151,6 +152,30 @@
 	// No pane component is mounted yet (TASK-2112); this is the URL-state
 	// groundwork the pane will read.
 	let openItemRef = $derived(page.url.searchParams.get('item'));
+
+	// ── Provider-mint settle (PLAN-2154 Architecture D / TASK-2166) ────────
+	// `openItemRef` above is the immediate URL truth — used for the pane's
+	// mount boundary (`{#if openItemRef}`), title precedence, focus, and
+	// every other cheap read. The `<ItemDetail>` `ref` PROP is different: it
+	// re-drives `loadData`/`collabKey` (destroy + fresh-mint the Y.Doc/WS
+	// provider), which is expensive to fire once per intermediate popstate
+	// during a held Back/Forward. `paneMintRef` is the coalesced value fed
+	// to that prop — updated immediately for a deliberate open/drill/close
+	// (`nav.type !== 'popstate'`), but settled (~PANE_MINT_SETTLE_MS,
+	// mirroring the j/k `PANE_FOLLOW_DEBOUNCE_MS` coalescing) for a popstate
+	// burst so only the FINAL ref of the burst ever mints. See
+	// `$lib/collections/paneMintSettle` for the pure, unit-tested decision
+	// logic this just wires up.
+	let paneMintRef = $state<string | null>(page.url.searchParams.get('item'));
+	const paneMintSettle = createPaneMintSettle({
+		settleMs: PANE_MINT_SETTLE_MS,
+		onSettle: (ref) => {
+			paneMintRef = ref;
+		},
+	});
+	afterNavigate((nav) => {
+		paneMintSettle.onNavigate(nav.type, nav.to?.url.searchParams.get('item') ?? null);
+	});
 
 	// Reactive parse of the current search query — shared with the
 	// search-dispatch effect below so it doesn't reparse per run.
@@ -1426,6 +1451,9 @@
 		// Drop any in-flight `history.go` continuation (and its fallback timer) so
 		// a late afterNavigate latch can't write to the unmounted page.
 		clearPaneGo();
+		// Drop any pending provider-mint settle so a late timer can't write
+		// `paneMintRef` on the unmounted page (PLAN-2154 / TASK-2166).
+		paneMintSettle.cancel();
 		// Scroll save/restore cleanup is owned by createScrollRestoration
 		// (snapshot.capture fires on navigate-away; the helper's $effect
 		// teardown cancels any in-flight RAF).
@@ -3734,7 +3762,7 @@
 			style={paneWidth != null ? `--pane-width: ${paneWidth}px` : undefined}
 		>
 			<ItemDetail
-				ref={openItemRef}
+				ref={paneMintRef ?? openItemRef}
 				embedded
 				{username}
 				{wsSlug}

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -159,10 +159,8 @@
 	// every other cheap read. The `<ItemDetail>` `ref` PROP is different: it
 	// re-drives `loadData`/`collabKey` (destroy + fresh-mint the Y.Doc/WS
 	// provider), which is expensive to fire once per intermediate popstate
-	// during a held Back/Forward. `paneMintRef` is the coalesced value fed
-	// to that prop (nested `{#if paneMintRef}`, below, so a still-settling
-	// null never reaches ItemDetail's required `ref: string` prop) — updated
-	// immediately for a deliberate open/drill/close, but settled
+	// during a held Back/Forward. `paneMintRef` is the coalesced value —
+	// updated immediately for a deliberate open/drill/close, but settled
 	// (~PANE_MINT_SETTLE_MS, mirroring the j/k `PANE_FOLLOW_DEBOUNCE_MS`
 	// coalescing) for a same-pathname popstate burst so only the FINAL ref
 	// of the burst ever mints. See `$lib/collections/paneMintSettle` for the
@@ -170,16 +168,29 @@
 	//
 	// This component is REUSED across a workspace/collection switch (same
 	// route id, different `page.params`) — `wsSlug`/`collSlug` update
-	// IMMEDIATELY on any such popstate, so a coalesced `paneMintRef` could
-	// otherwise linger mid-settle carrying a ref from the SOURCE
-	// workspace/collection into the DESTINATION's `ItemDetail` for up to
-	// `PANE_MINT_SETTLE_MS` (Codex review). Only a same-pathname popstate —
-	// the pane-only `?item=` traversal this feature targets — is eligible to
-	// settle; any pathname change (route reuse across params, or the rare
-	// case where `nav.from` is unavailable, e.g. the initial load) is forced
-	// through the settle module's immediate branch by passing a non-
-	// `'popstate'` type.
+	// IMMEDIATELY on any such popstate. Correcting `paneMintRef` from
+	// `afterNavigate` alone isn't enough (Codex review, PR #971 round 2):
+	// SvelteKit commits the new `page.params`/`page.url` — and Svelte
+	// re-renders every `$derived` over them, including `wsSlug`/`collSlug`
+	// AND the `<ItemDetail>` props built from them — BEFORE `afterNavigate`
+	// fires. So a plain `afterNavigate`-only fix still lets ONE render pass
+	// through with the DESTINATION `wsSlug`/`collSlug` paired against the
+	// still-stale SOURCE `paneMintRef`. `paneMintForRoute` below closes that
+	// gap: it's a `$derived` — recomputed SYNCHRONOUSLY in the very same
+	// reactive pass as `wsSlug`/`collSlug`, not a render-cycle later like an
+	// `afterNavigate`-driven correction — that falls back to the live,
+	// always-route-consistent `openItemRef` the instant `page.url.pathname`
+	// (reactive) diverges from `paneMintPathname` (the plain, non-reactive
+	// pathname `paneMintRef` was captured for, corrected by `afterNavigate`
+	// below). A same-pathname settle-in-progress (the actual pane-burst
+	// case) is unaffected: the pathnames match throughout, so this clamp is
+	// a no-op and `paneMintRef` — including a settling `null` — passes
+	// through untouched.
 	let paneMintRef = $state<string | null>(page.url.searchParams.get('item'));
+	// `string`, not SvelteKit's route-typed `Pathname` — `nav.to.url` (a plain
+	// `URL`) isn't route-typed, so the annotation avoids a type mismatch on
+	// the `afterNavigate` assignment below.
+	let paneMintPathname: string = page.url.pathname;
 	const paneMintSettle = createPaneMintSettle({
 		settleMs: PANE_MINT_SETTLE_MS,
 		onSettle: (ref) => {
@@ -190,8 +201,12 @@
 		const samePathname =
 			!!nav.from && nav.to?.url.pathname === nav.from.url.pathname;
 		const effectiveType = samePathname ? nav.type : 'goto';
+		paneMintPathname = nav.to?.url.pathname ?? paneMintPathname;
 		paneMintSettle.onNavigate(effectiveType, nav.to?.url.searchParams.get('item') ?? null);
 	});
+	let paneMintForRoute = $derived(
+		page.url.pathname === paneMintPathname ? paneMintRef : openItemRef,
+	);
 
 	// Reactive parse of the current search query — shared with the
 	// search-dispatch effect below so it doesn't reparse per run.
@@ -3777,21 +3792,26 @@
 			aria-label="Item detail"
 			style={paneWidth != null ? `--pane-width: ${paneWidth}px` : undefined}
 		>
-			{#if paneMintRef}
+			{#if paneMintForRoute}
 				<!--
-					Nested (not `{#key}`) on `paneMintRef`, not raw `openItemRef`
+					Nested (not `{#key}`) on `paneMintForRoute`, not raw `openItemRef`
 					(PLAN-2154 / TASK-2166; Codex review): while the pane is ALREADY
-					open, `paneMintRef` stays pinned at the last-settled ref through an
-					entire popstate burst, so this branch stays mounted and `ref` never
-					flips mid-burst — the coalescing itself. It only actually
-					mounts/unmounts at a genuine open (closed → first settle) or close
-					(`openItemRef` going null tears down the whole `{#if}` above). A
-					fallback to `openItemRef` here would defeat the settle for exactly
-					the closed→open-burst case, since `paneMintRef` legitimately stays
-					null until the first settle fires.
+					open on the SAME route, `paneMintForRoute` (== `paneMintRef`) stays
+					pinned at the last-settled ref through an entire popstate burst, so
+					this branch stays mounted and `ref` never flips mid-burst — the
+					coalescing itself. It only actually mounts/unmounts at a genuine
+					open (closed → first settle) or close (`openItemRef` going null
+					tears down the whole `{#if}` above) — OR a route change, where
+					`paneMintForRoute` falls through to the live `openItemRef` instead
+					(see the declaration above). A bare `paneMintRef` fallback to
+					`openItemRef` here would defeat the settle for the closed→open-
+					burst case, since `paneMintRef` legitimately stays null until the
+					first settle fires; `paneMintForRoute`'s fallback is scoped to an
+					actual pathname change, not a null-during-settle, so it doesn't
+					reintroduce that bug.
 				-->
 				<ItemDetail
-					ref={paneMintRef}
+					ref={paneMintForRoute}
 					embedded
 					{username}
 					{wsSlug}

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -160,12 +160,25 @@
 	// re-drives `loadData`/`collabKey` (destroy + fresh-mint the Y.Doc/WS
 	// provider), which is expensive to fire once per intermediate popstate
 	// during a held Back/Forward. `paneMintRef` is the coalesced value fed
-	// to that prop — updated immediately for a deliberate open/drill/close
-	// (`nav.type !== 'popstate'`), but settled (~PANE_MINT_SETTLE_MS,
-	// mirroring the j/k `PANE_FOLLOW_DEBOUNCE_MS` coalescing) for a popstate
-	// burst so only the FINAL ref of the burst ever mints. See
-	// `$lib/collections/paneMintSettle` for the pure, unit-tested decision
-	// logic this just wires up.
+	// to that prop (nested `{#if paneMintRef}`, below, so a still-settling
+	// null never reaches ItemDetail's required `ref: string` prop) — updated
+	// immediately for a deliberate open/drill/close, but settled
+	// (~PANE_MINT_SETTLE_MS, mirroring the j/k `PANE_FOLLOW_DEBOUNCE_MS`
+	// coalescing) for a same-pathname popstate burst so only the FINAL ref
+	// of the burst ever mints. See `$lib/collections/paneMintSettle` for the
+	// pure, unit-tested decision logic this just wires up.
+	//
+	// This component is REUSED across a workspace/collection switch (same
+	// route id, different `page.params`) — `wsSlug`/`collSlug` update
+	// IMMEDIATELY on any such popstate, so a coalesced `paneMintRef` could
+	// otherwise linger mid-settle carrying a ref from the SOURCE
+	// workspace/collection into the DESTINATION's `ItemDetail` for up to
+	// `PANE_MINT_SETTLE_MS` (Codex review). Only a same-pathname popstate —
+	// the pane-only `?item=` traversal this feature targets — is eligible to
+	// settle; any pathname change (route reuse across params, or the rare
+	// case where `nav.from` is unavailable, e.g. the initial load) is forced
+	// through the settle module's immediate branch by passing a non-
+	// `'popstate'` type.
 	let paneMintRef = $state<string | null>(page.url.searchParams.get('item'));
 	const paneMintSettle = createPaneMintSettle({
 		settleMs: PANE_MINT_SETTLE_MS,
@@ -174,7 +187,10 @@
 		},
 	});
 	afterNavigate((nav) => {
-		paneMintSettle.onNavigate(nav.type, nav.to?.url.searchParams.get('item') ?? null);
+		const samePathname =
+			!!nav.from && nav.to?.url.pathname === nav.from.url.pathname;
+		const effectiveType = samePathname ? nav.type : 'goto';
+		paneMintSettle.onNavigate(effectiveType, nav.to?.url.searchParams.get('item') ?? null);
 	});
 
 	// Reactive parse of the current search query — shared with the
@@ -3761,17 +3777,31 @@
 			aria-label="Item detail"
 			style={paneWidth != null ? `--pane-width: ${paneWidth}px` : undefined}
 		>
-			<ItemDetail
-				ref={paneMintRef ?? openItemRef}
-				embedded
-				{username}
-				{wsSlug}
-				{collSlug}
-				onClose={closeItemPane}
-				onGone={closeItemPane}
-				onNavigateAway={handlePaneNavigateAway}
-				onOpenTarget={handleOpenTarget}
-			/>
+			{#if paneMintRef}
+				<!--
+					Nested (not `{#key}`) on `paneMintRef`, not raw `openItemRef`
+					(PLAN-2154 / TASK-2166; Codex review): while the pane is ALREADY
+					open, `paneMintRef` stays pinned at the last-settled ref through an
+					entire popstate burst, so this branch stays mounted and `ref` never
+					flips mid-burst — the coalescing itself. It only actually
+					mounts/unmounts at a genuine open (closed → first settle) or close
+					(`openItemRef` going null tears down the whole `{#if}` above). A
+					fallback to `openItemRef` here would defeat the settle for exactly
+					the closed→open-burst case, since `paneMintRef` legitimately stays
+					null until the first settle fires.
+				-->
+				<ItemDetail
+					ref={paneMintRef}
+					embedded
+					{username}
+					{wsSlug}
+					{collSlug}
+					onClose={closeItemPane}
+					onGone={closeItemPane}
+					onNavigateAway={handlePaneNavigateAway}
+					onOpenTarget={handleOpenTarget}
+				/>
+			{/if}
 		</aside>
 	{/if}
 </div>


### PR DESCRIPTION
## Summary
- Adds `paneMintSettle` (`web/src/lib/collections/paneMintSettle.ts`), a pure, unit-tested module that coalesces a HELD browser Back/Forward — one `popstate` per history entry traversed — into a single collab teardown/mint of the split pane's `<ItemDetail>`, mirroring the existing j/k `PANE_FOLLOW_DEBOUNCE_MS` coalescing (~140ms) that popstate previously bypassed entirely.
- Wires it into `[collection]/+page.svelte`: a new `paneMintRef` state feeds `<ItemDetail ref>` (nested `{#if paneMintRef}` inside the existing `{#if openItemRef}` pane mount, so a still-settling `null` never reaches the required `ref: string` prop). Coalescing is scoped to same-pathname popstates only (the route component is reused across a workspace/collection switch, so a cross-route popstate always applies immediately) and a popstate that closes the pane (`ref === null`) always applies immediately too — closing is already instant via the raw URL-derived mount boundary, so delaying the null would let a quick close-then-reopen remount against a stale ref.
- Audited the rest of PLAN-2154 Architecture D and found the remaining three items already correct (TASK-2157/2158): `loadUrlFilters`' known-params whitelist includes `item`, `updateUrlFilters` already re-emits both `?item=` and `page.state` (depth+ownership) via `buildCollectionUrlParams` + `currentPaneState()`, and the collection page's title write is already gated on `!openItemRef`. No changes needed there.
- Audited the scroll `persistKey` item: the embedded pane deliberately does NOT wire into the route-level `createScrollRestoration`/persistKey system at all (PLAN-2105's chosen resolution — "let the pane manage its own scroll container"), so there's no persistKey collision to fix. Left untouched per the task's explicit "don't change working scroll behavior speculatively" guidance.

## Test plan
- [x] `cd web && npm run check` — 0 errors (8 pre-existing warnings, unrelated).
- [x] `cd web && npm run test` — 435/435 passing, including 8 new specs in `paneMintSettle.test.ts` covering: burst coalescing to the final ref, immediate application of deliberate (non-popstate) navigation, a deliberate nav mid-burst superseding a pending settle, immediate (never-delayed) application of a pane-close, a quick close→reopen burst with no stale intermediate mint, `cancel()`, custom `settleMs`, and a single isolated popstate.
- [x] Pre-existing `paneUrlParams.test.ts` (`KNOWN_COLLECTION_URL_PARAMS` / `buildCollectionUrlParams`) and `paneController.test.ts` (`readPaneState`) continue to cover the already-correct known-params and state-preservation behavior.
- [x] Two Codex review rounds found real issues (cross-route ref bleed on workspace/collection switch; a fallback that silently bypassed settling when the pane opened from closed) — both fixed and re-reviewed; a third round found a close-timing edge case (delayed `null` letting a stale ref remount on a fast close→reopen) — fixed and re-reviewed CLEAN.
- [ ] Browser/e2e verification of the actual popstate-burst timing was not runnable in this environment (no Playwright browsers installed); behavior is verified via the pure module's fake-timer unit tests plus manual code-path tracing through `+page.svelte`'s navigation wiring.

https://claude.ai/code/session_01EZ6yr6pAUFb1uffan912ra