### PR TITLE
feat(web): focus per hop for the detail-pane mini-browser (TASK-2162)

### DIFF
--- a/web/e2e/pane-content-link-anchors.spec.ts
+++ b/web/e2e/pane-content-link-anchors.spec.ts
@@ -301,3 +301,182 @@ test.describe('content-link anchor interception (PLAN-2154 / TASK-2159)', () => 
 		expect(openItemParam(page)).toBe(new URL(paneUrlAtParent).searchParams.get('item'));
 	});
 });
+
+/**
+ * Focus per hop (PLAN-2154 Architecture C / R1, TASK-2162).
+ *
+ * Each in-pane hop (a content-link DRILL or an in-pane BACK) changes `?item=`,
+ * which remounts ItemDetail's `{#key itemSlug}` subtrees and destroys the very
+ * link/row the user just activated. `keepFocus` then has nothing to restore, so
+ * focus falls to `<body>` — where the next `j`/`k` runs list-nav
+ * (`handlePageKeydown`'s `.item-pane` bail doesn't match `<body>`) and could
+ * laterally re-target the drilled `?item=`. The host moves focus onto the
+ * STABLE aria-labeled `<aside>` region synchronously at each hop
+ * (`focusPaneRegion`), backed by a desktop `focusin` net, so focus stays inside
+ * `.item-pane` across the remount and `j`/`k` stay inert.
+ *
+ * These drive REAL content-link clicks (and a keyboard activation) so the
+ * anchor-removed-by-remount path is exercised end to end — `pane-controller`'s
+ * `drillTo` test hook calls `navigatePaneTo` directly and can't reproduce it.
+ * The editor content-body link path (EditorLinkPopover, which additionally
+ * hides its popover — removing the focused anchor — synchronously) funnels
+ * through the SAME `navigatePaneTo` → `focusPaneRegion` chokepoint these cover,
+ * with the synchronous-removal case caught by the same desktop `focusin` net.
+ */
+function paneHasFocus(page: Page): Promise<boolean> {
+	return page.evaluate(() => {
+		const active = document.activeElement;
+		const pane = document.querySelector('.item-pane');
+		return !!active && !!pane && pane.contains(active);
+	});
+}
+
+test.describe('focus per hop (PLAN-2154 / TASK-2162)', () => {
+	test.beforeEach(({}, testInfo) => {
+		test.skip(
+			testInfo.project.name !== 'desktop-chromium',
+			'focus-per-hop is a desktop-split concern; the mobile overlay runs its own focus trap',
+		);
+	});
+
+	// Gate GET fetches for one item ref so a hop's DESTINATION stays on the
+	// minimal (loading) pane header — no content, no editor. That isolates
+	// `focusPaneRegion` as the ONLY thing that could have put focus in the pane
+	// during the load window (ItemDetail's editor autofocuses once the item
+	// loads, which would otherwise mask whether the synchronous hop focus fired
+	// at all). Returns a `release` to drain the fetch afterward.
+	async function gateItemFetch(page: Page, ref: string): Promise<() => void> {
+		let release: () => void = () => {};
+		const gate = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+		await page.route(`**/api/v1/workspaces/*/items/${ref}`, async (route) => {
+			if (route.request().method() !== 'GET') {
+				await route.continue();
+				return;
+			}
+			await gate;
+			await route.continue();
+		});
+		return release;
+	}
+
+	test('a mouse content-link drill lands focus inside the pane (while loading), and the next j does not steal to list-nav', async ({
+		page,
+		fixture,
+		request,
+	}) => {
+		await page.setViewportSize(DESKTOP);
+		await browserLogin(page);
+		const a = await seedDoc(fixture, request, 'Focus hop rel alpha');
+		const b = await seedDoc(fixture, request, 'Focus hop rel bravo');
+		const bRef = await itemRef(fixture, request, b.slug);
+		await seedRelatedLink(fixture, request, a.slug, b.id);
+		await page.goto(docsUrl(fixture));
+
+		await itemCard(page, 'Focus hop rel alpha').first().click();
+		const pane = page.locator('.item-pane');
+		await expect(pane).toBeVisible();
+
+		// Gate B so the drill's destination stalls on the loading header — the
+		// editor never mounts, so focus in the pane can only be `focusPaneRegion`.
+		const releaseB = await gateItemFetch(page, bRef);
+
+		// DRILL A→B by clicking the related-item link. Its anchor lives inside a
+		// `{#key itemSlug}` subtree that this very drill remounts — the exact R1
+		// "clicked link destroyed, focus falls to <body>" case.
+		const relLink = pane.locator('.link-target', { hasText: 'Focus hop rel bravo' });
+		await expect(relLink).toBeVisible();
+		await relLink.click();
+		await expect.poll(() => openItemParam(page)).toBe(bRef);
+		await expect(pane.locator('.pane-header--minimal')).toBeVisible();
+
+		// R1: focus is INSIDE the pane even mid-load, purely from the hop's
+		// synchronous region focus — not dropped to <body>.
+		await expect.poll(() => paneHasFocus(page)).toBe(true);
+
+		// The next `j` is inert (focus in the pane → the keydown handler bails),
+		// so the drilled `?item=` is untouched — no lateral list re-target.
+		await page.keyboard.press('j');
+		await page.waitForTimeout(250); // outlast the pane-follow debounce
+		expect(openItemParam(page)).toBe(bRef);
+		await expect.poll(() => paneHasFocus(page)).toBe(true);
+
+		releaseB();
+		await expect(pane.locator('.title', { hasText: /Focus hop rel bravo/ })).toBeVisible();
+	});
+
+	test('a keyboard content-link drill (focus the link, press Enter) also lands focus inside the pane while loading', async ({
+		page,
+		fixture,
+		request,
+	}) => {
+		await page.setViewportSize(DESKTOP);
+		await browserLogin(page);
+		const a = await seedDoc(fixture, request, 'Focus hop kbd alpha');
+		const b = await seedDoc(fixture, request, 'Focus hop kbd bravo');
+		const bRef = await itemRef(fixture, request, b.slug);
+		await seedRelatedLink(fixture, request, a.slug, b.id);
+		await page.goto(docsUrl(fixture));
+
+		await itemCard(page, 'Focus hop kbd alpha').first().click();
+		const pane = page.locator('.item-pane');
+		await expect(pane).toBeVisible();
+
+		const releaseB = await gateItemFetch(page, bRef);
+
+		const relLink = pane.locator('.link-target', { hasText: 'Focus hop kbd bravo' });
+		await expect(relLink).toBeVisible();
+		// KEYBOARD drill: focus the anchor and activate it with Enter (an <a>
+		// fires its click handler on Enter). This is the keyboard analogue of
+		// the editor-link path, where the focused anchor is removed as the drill
+		// fires and focus must be recovered into the pane.
+		await relLink.focus();
+		await page.keyboard.press('Enter');
+		await expect.poll(() => openItemParam(page)).toBe(bRef);
+		await expect(pane.locator('.pane-header--minimal')).toBeVisible();
+		await expect.poll(() => paneHasFocus(page)).toBe(true);
+
+		releaseB();
+		await expect(pane.locator('.title', { hasText: /Focus hop kbd bravo/ })).toBeVisible();
+	});
+
+	test('an in-pane Back keeps focus inside the pane (while the popped-to item loads)', async ({
+		page,
+		fixture,
+		request,
+	}) => {
+		await page.setViewportSize(DESKTOP);
+		await browserLogin(page);
+		const a = await seedDoc(fixture, request, 'Focus hop back alpha');
+		const b = await seedDoc(fixture, request, 'Focus hop back bravo');
+		await seedRelatedLink(fixture, request, a.slug, b.id);
+		await page.goto(docsUrl(fixture));
+
+		await itemCard(page, 'Focus hop back alpha').first().click();
+		const pane = page.locator('.item-pane');
+		await expect(pane).toBeVisible();
+		const aRef = openItemParam(page)!;
+
+		const relLink = pane.locator('.link-target', { hasText: 'Focus hop back bravo' });
+		await expect(relLink).toBeVisible();
+		await relLink.click();
+		await expect(pane.locator('.title', { hasText: /Focus hop back bravo/ })).toBeVisible();
+
+		// Gate A (the Back destination) so the pop stalls on the loading header —
+		// focus in the pane during that window is purely `focusPaneRegion`.
+		const releaseA = await gateItemFetch(page, aRef);
+
+		// In-pane Back (‹) pops B→A. The pop remounts the pane content and
+		// unmounts the just-clicked Back button; focus must stay inside the pane.
+		const backBtn = pane.locator('button[aria-label="Back"]');
+		await expect(backBtn).toBeVisible();
+		await backBtn.click();
+		await expect.poll(() => openItemParam(page)).toBe(aRef);
+		await expect(pane.locator('.pane-header--minimal')).toBeVisible();
+		await expect.poll(() => paneHasFocus(page)).toBe(true);
+
+		releaseA();
+		await expect(pane.locator('.title', { hasText: /Focus hop back alpha/ })).toBeVisible();
+	});
+});

--- a/web/e2e/pane-controller.spec.ts
+++ b/web/e2e/pane-controller.spec.ts
@@ -77,17 +77,27 @@ function historyLength(page: Page): Promise<number> {
 }
 
 /**
- * Whether the currently-focused element is a pane-header Back button
- * (`aria-label="Back"`). A `page.evaluate` read of `document.activeElement`,
- * NOT `expect(locator).toBeFocused()` — this file's other focus checks
+ * Whether keyboard focus currently sits INSIDE the detail pane (`.item-pane`).
+ * This is the actual "focus per hop" acceptance criterion (PLAN-2154 R1 /
+ * TASK-2162): each in-pane hop moves focus into the STABLE aria-labeled
+ * `<aside>` region so the next `j`/`k` can't steal to list-nav — the exact
+ * element (the region itself vs. a control within it) is not load-bearing, so
+ * this asserts containment rather than a specific button.
+ *
+ * A `page.evaluate` read of `document.activeElement`, NOT
+ * `expect(locator).toBeFocused()` — this file's other focus checks
  * (pane-a11y-focus.spec.ts) use the same `evaluate`-based pattern, which is
  * the reliable one under heavy parallel load: a bare locator-based
  * `toBeFocused()` polls independently of the app's own microtask queue and
  * can observe a still-mid-flush DOM after a header swap, where an
  * `evaluate` round-trip naturally lets pending Svelte effects settle first.
  */
-function backButtonIsFocused(page: Page): Promise<boolean> {
-	return page.evaluate(() => document.activeElement?.getAttribute('aria-label') === 'Back');
+function paneHasFocus(page: Page): Promise<boolean> {
+	return page.evaluate(() => {
+		const active = document.activeElement;
+		const pane = document.querySelector('.item-pane');
+		return !!active && !!pane && pane.contains(active);
+	});
 }
 
 /** Enable the controller test hook for all navigations in this context. */
@@ -590,10 +600,24 @@ test.describe('pane controller: depth/ownership state machine (PLAN-2154 / TASK-
 		await expect.poll(() => openItemParam(page)).not.toBeNull();
 		await expect(pane).toBeVisible();
 
-		// At depth 0, ESC falls through to today's behavior: no row is focused,
-		// so the two-level "return focus to list" step is skipped and the
-		// escape stack's pane handler closes it directly — unchanged from
-		// before TASK-2163.
+		// At depth 0, ESC falls through to today's two-level desktop behavior
+		// (TASK-2118). Focus-per-hop (TASK-2162) keeps focus INSIDE the pane
+		// across the drills+pops, and the paned row A carries `.focused` again
+		// once the stack unwinds to depth 0, so the FIRST depth-0 ESC returns
+		// focus to the list (level one) — the pane stays open, `?item=` truthy —
+		// rather than closing outright. (Before focus-per-hop, drilling had
+		// dropped focus to <body>, so this branch was skipped and the pane
+		// closed on the first press; keeping focus in the pane is the correct
+		// fix, and it simply restores the standard two-level ESC here.)
+		await page.keyboard.press('Escape');
+		await expect(pane).toBeVisible();
+		await expect.poll(() => openItemParam(page)).not.toBeNull();
+		await expect
+			.poll(() => page.evaluate(() => !!document.activeElement?.closest('.item-card')))
+			.toBe(true);
+
+		// The SECOND depth-0 ESC — now with focus on the list row, outside the
+		// pane — closes it, returning to the pre-pane URL.
 		await page.keyboard.press('Escape');
 		await expect.poll(() => openItemParam(page)).toBeNull();
 		await expect(pane).toBeHidden();
@@ -861,33 +885,33 @@ test.describe('pane controller: depth/ownership state machine (PLAN-2154 / TASK-
 
 		// Press 1: D(3) → C(2). The click triggers a reload (`loading` briefly
 		// true), which swaps the loaded header for the minimal one and
-		// unmounts the just-clicked, focused Back button — Codex review round
-		// 2, P2. Focus must land back on the (re-mounted) Back button once the
-		// reload settles, so a keyboard user can keep popping levels.
+		// unmounts the just-clicked, focused Back button. Focus-per-hop
+		// (TASK-2162) moves focus onto the STABLE pane region synchronously at
+		// the pop, so it stays inside `.item-pane` across that remount — a
+		// following `j`/`k` can't steal to list-nav, and further ESC/Back pops
+		// still land on the detached pane.
 		await expect(backBtn).toBeVisible();
 		await backBtn.focus();
 		await backBtn.click();
 		await expect.poll(() => paneState(page)).toEqual({ paneDepth: 2, paneOwned: true });
 		await expect.poll(() => openItemParam(page)).toBe(c.slug);
-		await expect.poll(() => backButtonIsFocused(page)).toBe(true);
+		await expect.poll(() => paneHasFocus(page)).toBe(true);
 
-		// Press 2: C(2) → B(1). Focus restored again.
+		// Press 2: C(2) → B(1). Focus stays in the pane again.
 		await backBtn.click();
 		await expect.poll(() => paneState(page)).toEqual({ paneDepth: 1, paneOwned: true });
 		await expect.poll(() => openItemParam(page)).toBe(b.slug);
-		await expect.poll(() => backButtonIsFocused(page)).toBe(true);
+		await expect.poll(() => paneHasFocus(page)).toBe(true);
 
 		// Press 3: B(1) → A(0), the base — chevron disappears, pane stays open.
-		// The terminal pop has no Back button left to land focus on, so it
-		// falls back to the always-present Close button rather than stranding
-		// focus on <body> (Codex review round 4).
+		// The terminal pop has no Back button left to land focus on, but the
+		// pane region itself is always present, so focus stays inside the pane
+		// rather than stranding on <body>.
 		await backBtn.click();
 		await expect.poll(() => paneState(page)).toEqual({ paneDepth: 0, paneOwned: true });
 		await expect(pane).toBeVisible();
 		await expect(pane.locator('button[aria-label="Back"]')).toHaveCount(0);
-		await expect
-			.poll(() => page.evaluate(() => document.activeElement?.getAttribute('aria-label')))
-			.toBe('Close pane');
+		await expect.poll(() => paneHasFocus(page)).toBe(true);
 	});
 
 	test('Back chevron: a second press while the first pop is still loading still ends with focus restored (Codex review round 3)', async ({
@@ -957,9 +981,10 @@ test.describe('pane controller: depth/ownership state machine (PLAN-2154 / TASK-
 		await expect.poll(() => paneState(page)).toEqual({ paneDepth: 1, paneOwned: true });
 		await expect.poll(() => openItemParam(page)).toBe(b.slug);
 
-		// The pane settled on B — focus must have landed on ITS Back button,
-		// not been consumed early by C's stale, still-outstanding load.
-		await expect.poll(() => backButtonIsFocused(page)).toBe(true);
+		// The pane settled on B — focus stayed inside the pane throughout (each
+		// pop moves it onto the stable region synchronously), not consumed early
+		// or lost to <body> by C's stale, still-outstanding load.
+		await expect.poll(() => paneHasFocus(page)).toBe(true);
 
 		// Release the gate so C's now-superseded fetch can drain (generation-
 		// fenced server-side by `loadData`'s own `myGen === loadGeneration`
@@ -967,7 +992,7 @@ test.describe('pane controller: depth/ownership state machine (PLAN-2154 / TASK-
 		releaseGate();
 		await page.waitForTimeout(100);
 		await expect.poll(() => openItemParam(page)).toBe(b.slug);
-		await expect.poll(() => backButtonIsFocused(page)).toBe(true);
+		await expect.poll(() => paneHasFocus(page)).toBe(true);
 	});
 
 	test('Back chevron: a superseding row-click while the pop is still loading does NOT steal focus back into the pane (Codex review round 6)', async ({
@@ -1034,24 +1059,27 @@ test.describe('pane controller: depth/ownership state machine (PLAN-2154 / TASK-
 		const cRef = openItemParam(page);
 		expect(cRef).not.toBe(aRef);
 
-		// The stalled Back pop's pending focus-restore must NOT fire once A
-		// eventually settles — it was superseded, so it must not steal focus
-		// into C's pane chrome. `backButtonIsFocused` covers the paneDepth>0
-		// case; C is at depth 0, so also check the Close button directly.
+		// The stalled Back pop must NOT reach back and steal focus onto C's pane
+		// CHROME once A eventually settles. Under host-owned focus-per-hop there
+		// is no armed restore intent to mis-fire (TASK-2162 dissolved the exact
+		// TASK-2164 deferred edge this test guarded). We assert the Close button
+		// is never focused — not that focus stays wholly outside the pane, since
+		// C's editor legitimately autofocuses on load (ItemDetail), which is
+		// benign in-pane focus, not the mis-fire onto the Close/Back control.
 		const closeIsFocused = () =>
 			page.evaluate(() => document.activeElement?.getAttribute('aria-label') === 'Close pane');
 		await expect.poll(closeIsFocused).toBe(false);
 
 		// Release the gate — A's now-superseded fetch drains (generation-
-		// fenced by `loadData`'s own checks), and the abandoned restore must
-		// still not fire afterward.
+		// fenced by `loadData`'s own checks), and no stale focus pull may fire
+		// afterward.
 		releaseGate();
 		await page.waitForTimeout(150);
 		await expect.poll(() => openItemParam(page)).toBe(cRef);
 		await expect.poll(closeIsFocused).toBe(false);
 	});
 
-	test('Back chevron: a genuinely slow (but legitimate) destination load still restores focus, however long it takes', async ({
+	test('Back chevron: a genuinely slow (but legitimate) destination load keeps focus in the pane, however long it takes', async ({
 		page,
 		fixture,
 		request,
@@ -1074,12 +1102,12 @@ test.describe('pane controller: depth/ownership state machine (PLAN-2154 / TASK-
 		await drillTo(page, b.slug);
 		await expect.poll(() => paneState(page)).toEqual({ paneDepth: 1, paneOwned: true });
 
-		// Gate A's item fetch — the Back press (B→A) LANDS on it, no
-		// unrelated navigation involved, so the eventual restore is fully
-		// legitimate — no matter how long the fetch takes, the restore has no
-		// wall-clock deadline to race (the design deliberately dropped the
-		// timer-based "give up waiting" heuristic explored in earlier review
-		// rounds; see the focus-restore block's comment for why).
+		// Gate A's item fetch — the Back press (B→A) LANDS on it. Focus-per-hop
+		// moves focus onto the stable pane region SYNCHRONOUSLY at the pop, so
+		// it never depends on the destination load at all: no matter how long
+		// the fetch takes, focus can't drift out of the pane while it loads
+		// (TASK-2162 replaced TASK-2164's load-settle-timed restore, which is
+		// why there is no wall-clock deadline to race here).
 		let releaseGate: () => void = () => {};
 		const gate = new Promise<void>((resolve) => {
 			releaseGate = resolve;
@@ -1100,16 +1128,18 @@ test.describe('pane controller: depth/ownership state machine (PLAN-2154 / TASK-
 		await expect.poll(() => paneState(page)).toEqual({ paneDepth: 0, paneOwned: true });
 		await expect(pane.locator('.pane-header--minimal')).toBeVisible();
 
-		// Hold well past the mint-settle window before releasing — the pop
-		// must still be pending, not silently abandoned.
+		// Focus is already inside the pane (moved there synchronously at the
+		// pop) even while the destination is still loading behind the minimal
+		// header.
+		await expect.poll(() => paneHasFocus(page)).toBe(true);
+
+		// Hold well past the mint-settle window before releasing — the pop's
+		// slow load must not knock focus back out of the pane.
 		await page.waitForTimeout(400);
 		releaseGate();
 		await expect.poll(() => openItemParam(page)).toBe(aRef);
 		await expect(pane.locator('.pane-header--minimal')).toBeHidden();
-
-		const closeIsFocusedAfterSlowLoad = () =>
-			page.evaluate(() => document.activeElement?.getAttribute('aria-label') === 'Close pane');
-		await expect.poll(closeIsFocusedAfterSlowLoad).toBe(true);
+		await expect.poll(() => paneHasFocus(page)).toBe(true);
 	});
 
 	test('Back chevron: a cold-loaded shared ?item= starts at depth 0 and stays hidden; browser Back still exits the pane', async ({

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -302,22 +302,6 @@
 	let titleDraft = $state('');
 	let titleInputEl = $state<HTMLTextAreaElement>();
 
-	// PLAN-2154 Architecture C / TASK-2164 (Codex review round 2, P2): the
-	// pane chrome's Back chevron. Bound by BOTH the loaded and minimal
-	// headers below (mutually exclusive `{#if}`s, so only one is ever
-	// mounted) so a pending focus-restore (see `pendingBackFocus` /
-	// `handleBackClick` near `startEditTitle`) can reach whichever one
-	// re-mounts after the reload settles.
-	let backBtnEl = $state<HTMLButtonElement>();
-	// The Close button — the focus-restore fallback for the TERMINAL Back pop
-	// (landing at depth 0, where there's no Back button left to land on;
-	// Codex review round 4). Bound by BOTH headers, same reasoning as
-	// `backBtnEl` above: if the pop's destination is slow/failed, the
-	// MINIMAL header can still be mounted when the restore fires, and it
-	// needs its own Close button bound or the restore silently no-ops
-	// (Codex review round 5).
-	let closeBtnEl = $state<HTMLButtonElement>();
-
 	let fields = $derived<Record<string, any>>(item ? parseFields(item) : {});
 	// Tags live on item.tags (a JSON-array string), NOT in the schema.
 	// parseTags is defensive (tolerates empty/garbage) and dedupes
@@ -1899,94 +1883,26 @@
 		el.style.height = el.scrollHeight + 'px';
 	}
 
-	// PLAN-2154 Architecture C / TASK-2164 (Codex review round 2, P2): the
-	// Back chevron's own click triggers a reload of the drilled-to item —
-	// `loadData()` sets `loading = true`, which swaps the loaded pane header
-	// for the minimal one and UNMOUNTS the just-clicked (and browser-focused)
-	// Back button, dropping focus to <body>. Without restoring it, a
-	// keyboard user popping a multi-level stack loses their place after every
-	// press. Mirrors the `pendingNewItemEdit` pattern above: flag the intent,
-	// then act once the reload settles. Deliberately narrow — this only
-	// re-anchors focus on the Back button's OWN click, not the general
-	// "focus per hop" for arbitrary content-link drills (TASK-2162).
+	// PLAN-2154 Architecture C / R1 — the Back chevron's onclick. A plain
+	// notify: the host (`[collection]/+page.svelte::handlePaneBack`) owns the
+	// fenced `paneHistoryGo(-1)` traversal AND the focus-per-hop restore.
 	//
-	// The design below survived several review rounds against real races;
-	// summarized here rather than as a round-by-round diary.
-	//
-	// 1. Keyed off `itemSlug` actually CHANGING, not an observed `loading`
-	//    true→false transition. An earlier `loading`-transition design let a
-	//    second press fired while a PRIOR item was still loading — see (2) —
-	//    latch onto that STALE, already-in-flight cycle instead of its own
-	//    (`paneNavInFlight()` only fences the `history.go` traversal, not the
-	//    data fetch). Comparing `itemSlug` against the ref captured at click
-	//    time needs no "did I see the right transition" bookkeeping: once it
-	//    differs AND the new item's load has finished, the pop is done.
-	//
-	// 2. GENERATION-FENCED against a SUPERSEDING, unrelated navigation.
-	//    Comparing only `itemSlug` treats ANY later change as "the Back pop
-	//    landed" — so if the user clicks a different row/link while the Back
-	//    destination is still loading, that unrelated navigation's `itemSlug`
-	//    change satisfies the check just as well, and focus gets stolen into
-	//    a pane the user never asked to restore-focus on. `loadGeneration`
-	//    (bumped synchronously at the top of EVERY `loadData()` call,
-	//    regardless of what triggered it) gives an exact, timing-independent
-	//    fence: capture it at click time and require the settled generation
-	//    to be EXACTLY one more — the Back click's own load and nothing else
-	//    raced in between. A mismatch means something else superseded it;
-	//    abandon the restore instead of stealing focus.
-	//
-	// KNOWN LIMITATION (deliberately not chased further — see below): a Back
-	// immediately reversed by Forward can, in principle, coalesce to a NET
-	// NO-OP (TASK-2166's provider-mint settle can settle back onto the exact
-	// ref this component started on, which Svelte's fine-grained reactivity
-	// then treats as no change at all) — leaving `pendingBackFocus` armed
-	// with nothing left to ever falsify the generation check against, so the
-	// NEXT, wholly unrelated single-load navigation could satisfy
-	// `backFocusStartGen + 1` by coincidence and land focus on ITS Close/Back
-	// button instead of wherever that unrelated navigation would have
-	// naturally put it. Three review rounds (7-9) tried progressively more
-	// careful wall-clock "give up waiting" timeouts to close this — each one
-	// got shown to be racing an ever-longer worst-case bound elsewhere in the
-	// pipeline (the mint settle, then the settle PLUS the popstate
-	// round-trip, then `paneHistoryGo`'s own 500ms fallback on top of both) —
-	// confirming a fixed-duration heuristic is structurally the wrong tool: closing
-	// it for real needs an explicit "did this specific click's traversal
-	// resolve" signal from the host (`+page.svelte`), not inference from
-	// elapsed time. That's new cross-component plumbing, not a hardening
-	// pass on the existing effect, so it's left as a documented, narrow,
-	// low-severity gap for TASK-2162 (the already-planned general "focus per
-	// hop" follow-up) rather than an ever-growing pile of timing patches
-	// here: the WORST outcome is focus landing on a nearby, still-sensible,
-	// keyboard-reachable pane control (Close or Back) instead of the ideal
-	// target — not lost, not on a hidden node, not a correctness or data
-	// issue — and it requires the fairly deliberate Back-then-Forward
-	// sequence to trigger at all.
-	let pendingBackFocus = $state(false);
-	let backFocusStartSlug = '';
-	let backFocusStartGen = 0;
+	// TASK-2164 originally kept focus restoration HERE — an armed
+	// `pendingBackFocus` intent that, once the pop's reload settled, focused
+	// this component's Back/Close button. That inference-from-load-settling
+	// design carried a documented, deliberately-deferred edge (a Back
+	// immediately reversed by Forward could coalesce to a net no-op that left
+	// the intent armed, so the next unrelated navigation stole focus onto a
+	// pane control by coincidence) whose real fix TASK-2164 identified as "an
+	// explicit 'did this traversal resolve' signal from the host, not
+	// inference from elapsed time." TASK-2162 supplies exactly that: the host
+	// moves focus into the STABLE pane region SYNCHRONOUSLY at each hop (drill
+	// AND back), so there is no armed intent left to mis-fire — the edge is
+	// dissolved, not patched. See `focusPaneRegion` in the host for the full
+	// "focus per hop" rationale. This component therefore no longer restores
+	// focus itself; `onBack` is a pure notify like `onClose`/`onOpenTarget`.
 	function handleBackClick() {
-		pendingBackFocus = true;
-		backFocusStartSlug = itemSlug;
-		backFocusStartGen = loadGeneration;
 		onBack?.();
-	}
-	$effect(() => {
-		if (!pendingBackFocus) return;
-		if (itemSlug === backFocusStartSlug) return; // the pop hasn't landed yet
-		if (loading) return; // the new item is still loading
-		pendingBackFocus = false; // one-shot regardless of outcome below
-		if (loadGeneration !== backFocusStartGen + 1) return; // superseded — abandon, don't steal focus
-		// At depth>0 there's a fresh Back button to land on. At depth 0 (the
-		// terminal pop, back to the base) the Back button is gone — Codex
-		// review round 4 flagged that this left focus stranded on <body> with
-		// the pane still open. Fall back to the always-present Close button
-		// rather than nothing: a stable, keyboard-reachable control, not a
-		// full "focus per hop" implementation (still TASK-2162's scope).
-		restoreBackFocus();
-	});
-	async function restoreBackFocus() {
-		await tick();
-		(paneDepth > 0 ? backBtnEl : closeBtnEl)?.focus({ preventScroll: true });
 	}
 
 	function showSaved() {
@@ -3439,7 +3355,6 @@
 			{#if paneDepth > 0}
 				<button
 					type="button"
-					bind:this={backBtnEl}
 					class="pane-header-btn pane-back-btn"
 					onclick={handleBackClick}
 					title="Back"
@@ -3448,7 +3363,6 @@
 			{/if}
 			<button
 				type="button"
-				bind:this={closeBtnEl}
 				class="pane-header-btn"
 				onclick={() => onClose?.()}
 				title="Close pane"
@@ -3529,7 +3443,6 @@
 					{#if paneDepth > 0}
 						<button
 							type="button"
-							bind:this={backBtnEl}
 							class="pane-header-btn pane-back-btn"
 							onclick={handleBackClick}
 							title="Back"
@@ -3566,7 +3479,6 @@
 					>↗</a>
 					<button
 						type="button"
-						bind:this={closeBtnEl}
 						class="pane-header-btn"
 						onclick={() => onClose?.()}
 						title="Close pane"

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -934,23 +934,22 @@
 	}
 
 	// Focus per hop (PLAN-2154 Architecture C / R1, TASK-2162). Move keyboard
-	// focus INTO the stable pane region on each in-pane hop that removes a
-	// focused in-pane control — a drill (`navigatePaneTo`, the clicked link) or
-	// an in-pane Back (`handlePaneBack`, the clicked Back chevron). (The
-	// depth-aware ESC pop deliberately does NOT call this — see its note.) Each
-	// hop changes `?item=`, which remounts ItemDetail's
-	// `{#key itemSlug}` subtrees and DESTROYS whatever link/row the user just
-	// activated to trigger the hop; `keepFocus` then has nothing to restore, so
-	// focus falls to `<body>`, where the NEXT `j`/`k` runs list-nav
-	// (`handlePageKeydown`'s `.item-pane` bail doesn't match `<body>`) and
-	// laterally re-targets the drilled `?item=`, corrupting the stack (R1).
+	// focus INTO the stable pane region on each in-pane hop — a drill
+	// (`navigatePaneTo`, the clicked link), an in-pane Back (`handlePaneBack`,
+	// the clicked Back chevron), or a depth-aware ESC pop. Each hop changes
+	// `?item=`, which remounts ItemDetail's `{#key itemSlug}` subtrees (and
+	// swaps its loaded↔minimal header) and DESTROYS whatever link/row/button
+	// was focused; `keepFocus` then has nothing to restore, so focus falls to
+	// `<body>`, where the NEXT `j`/`k` runs list-nav (`handlePageKeydown`'s
+	// `.item-pane` bail doesn't match `<body>`) and laterally re-targets the
+	// drilled `?item=`, corrupting the stack (R1).
 	//
 	// We focus the aria-labeled `<aside>` (`paneEl`) itself — it lives OUTSIDE
-	// every `{#key}`, so it's STABLE across the remount. Called SYNCHRONOUSLY
-	// right after the hop's `goto`/`history.go` (while the just-activated link
-	// is still in the DOM and focused), so focus moves off it BEFORE the
-	// imminent remount removes it — the removed link never had focus to drop.
-	// Focus now sits inside `.item-pane`, so `handlePageKeydown` bails and
+	// every `{#key}` and the header swap, so it's STABLE across the remount.
+	// Called SYNCHRONOUSLY at the hop (while the just-activated control is still
+	// in the DOM), so focus moves onto the stable region BEFORE the imminent
+	// remount removes that control — the removed control never had focus to
+	// drop. Focus now sits inside `.item-pane`, so `handlePageKeydown` bails and
 	// `j`/`k` stay inert. This is the plan's serializable "focus per hop"
 	// target: no stored element ref (keyed remounts destroy those) — `paneEl`
 	// is re-found via its binding, never captured across a hop.
@@ -961,11 +960,18 @@
 	// item change the hop triggers, so it is NEVER still in the DOM once the pop
 	// lands — the "else the pane heading" fallback is the operative branch, and
 	// re-finding the link across TASK-2166's mint settle is the unbounded timing
-	// tail we deliberately don't chase. Desktop only: the mobile overlay runs
-	// its own focus trap (below). `{preventScroll:true}` so the programmatic
-	// focus never jumps the pane's scroll position.
+	// tail we deliberately don't chase.
+	//
+	// Runs on BOTH desktop and the mobile overlay: on mobile `j`/`k` is already
+	// inert (the list is hidden), but focus must still not strand on `<body>`
+	// behind the overlay after a Back/drill — the synchronous belt this
+	// provides is what TASK-2164's now-retired `pendingBackFocus` used to give
+	// the mobile Back path, and the mobile focus trap's `focusin` is the async
+	// net on top. `{preventScroll:true}` so the programmatic focus never jumps
+	// the pane's scroll position (nor summons the mobile keyboard — `paneEl` is
+	// a non-editable region, not an input).
 	function focusPaneRegion() {
-		if (!browser || viewport.isMobile) return;
+		if (!browser) return;
 		if (!openItemRef || !paneEl) return;
 		paneEl.focus({ preventScroll: true });
 	}
@@ -2764,16 +2770,19 @@
 				currentPaneState().paneDepth > 0
 			) {
 				e.preventDefault();
-				// NB: no `focusPaneRegion()` here, unlike `navigatePaneTo` /
-				// `handlePaneBack`. Those hops REMOVE a focused in-pane control (the
-				// clicked link / the Back button) and must catch the resulting drop
-				// to `<body>`; an ESC press removes no such control, so there's
-				// nothing to recover — and forcing focus into the pane here would
-				// fight the depth-0 fallthrough below, whose whole job is to return
-				// focus to the LIST (`returnFocusToList`) on the way out. `j`/`k`
-				// stays inert at depth>0 via the detach guard regardless of where
-				// focus sits, so this pop needs no focus move.
-				if (!paneNavInFlight()) paneHistoryGo(-1);
+				if (!paneNavInFlight()) {
+					paneHistoryGo(-1);
+					// Focus per hop (R1): land focus on the stable pane region so a
+					// control that WAS focused (e.g. the user Tabbed to the Back
+					// chevron) and is then removed by the pop's header swap / content
+					// remount can't strand focus on `<body>`. This targets `paneEl`
+					// itself, never a control the pop removes, so it doesn't rely on a
+					// `focusin` firing for the removal. It doesn't fight the depth-0
+					// two-level ESC below: that's a SEPARATE, later press, and from
+					// `paneEl` (inside `.item-pane`) it correctly runs
+					// `returnFocusToList` on the way out.
+					focusPaneRegion();
+				}
 				return;
 			}
 			// Desktop two-level ESC (TASK-2122): from INSIDE the open pane (a

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -723,6 +723,12 @@
 			keepFocus: true,
 			state: plan.state,
 		});
+		// Focus per hop (R1): pull focus into the stable pane region NOW, before
+		// this drill's `{#key itemSlug}` remount destroys the just-clicked link
+		// and dumps focus to `<body>`. Covers the editor-link keyboard path too —
+		// EditorLinkPopover.handleHrefClick hides the popover (removing the
+		// focused anchor) synchronously before calling in here.
+		focusPaneRegion();
 	}
 
 	// `ItemDetail`'s `onOpenTarget` seam (PLAN-2154 Architecture B / TASK-2158).
@@ -750,7 +756,14 @@
 	// stale click could in principle race a continuation that already
 	// unwound the stack back to the base.
 	function handlePaneBack() {
-		if (currentPaneState().paneDepth > 0 && !paneNavInFlight()) paneHistoryGo(-1);
+		if (currentPaneState().paneDepth > 0 && !paneNavInFlight()) {
+			paneHistoryGo(-1);
+			// Focus per hop (R1) — same rationale as `navigatePaneTo`: the pop
+			// remounts the pane content and unmounts the just-clicked Back button,
+			// so move focus onto the stable region before that drop can reach
+			// `<body>` (where the next `j`/`k` would steal to list-nav).
+			focusPaneRegion();
+		}
 	}
 
 	// The pane's ItemDetail fires `onNavigateAway` for TWO distinct cases, which
@@ -918,6 +931,43 @@
 		if (!target) return false;
 		target.focus();
 		return true;
+	}
+
+	// Focus per hop (PLAN-2154 Architecture C / R1, TASK-2162). Move keyboard
+	// focus INTO the stable pane region on each in-pane hop that removes a
+	// focused in-pane control — a drill (`navigatePaneTo`, the clicked link) or
+	// an in-pane Back (`handlePaneBack`, the clicked Back chevron). (The
+	// depth-aware ESC pop deliberately does NOT call this — see its note.) Each
+	// hop changes `?item=`, which remounts ItemDetail's
+	// `{#key itemSlug}` subtrees and DESTROYS whatever link/row the user just
+	// activated to trigger the hop; `keepFocus` then has nothing to restore, so
+	// focus falls to `<body>`, where the NEXT `j`/`k` runs list-nav
+	// (`handlePageKeydown`'s `.item-pane` bail doesn't match `<body>`) and
+	// laterally re-targets the drilled `?item=`, corrupting the stack (R1).
+	//
+	// We focus the aria-labeled `<aside>` (`paneEl`) itself — it lives OUTSIDE
+	// every `{#key}`, so it's STABLE across the remount. Called SYNCHRONOUSLY
+	// right after the hop's `goto`/`history.go` (while the just-activated link
+	// is still in the DOM and focused), so focus moves off it BEFORE the
+	// imminent remount removes it — the removed link never had focus to drop.
+	// Focus now sits inside `.item-pane`, so `handlePageKeydown` bails and
+	// `j`/`k` stay inert. This is the plan's serializable "focus per hop"
+	// target: no stored element ref (keyed remounts destroy those) — `paneEl`
+	// is re-found via its binding, never captured across a hop.
+	//
+	// The plan's "focus the originating link if still in the DOM, else the pane
+	// heading" reduces to this region focus in practice: the originating link
+	// always sits inside a `{#key itemSlug}` subtree that remounts on the very
+	// item change the hop triggers, so it is NEVER still in the DOM once the pop
+	// lands — the "else the pane heading" fallback is the operative branch, and
+	// re-finding the link across TASK-2166's mint settle is the unbounded timing
+	// tail we deliberately don't chase. Desktop only: the mobile overlay runs
+	// its own focus trap (below). `{preventScroll:true}` so the programmatic
+	// focus never jumps the pane's scroll position.
+	function focusPaneRegion() {
+		if (!browser || viewport.isMobile) return;
+		if (!openItemRef || !paneEl) return;
+		paneEl.focus({ preventScroll: true });
 	}
 
 	// ── Resizable detail pane + persisted width (PLAN-2105 / TASK-2114) ─
@@ -1179,6 +1229,48 @@
 			window.removeEventListener('keydown', onTrapKeydown);
 			document.removeEventListener('focusin', onFocusIn);
 		};
+	});
+
+	// Desktop focusin backstop (PLAN-2154 Architecture C / R1, TASK-2162) — the
+	// NARROWED desktop mirror of the mobile trap's focusin catch-all above.
+	// `focusPaneRegion` (fired synchronously at each hop) is the primary R1
+	// mechanism; this is the async safety net for a focus drop that lands
+	// LATER than that synchronous focus — e.g. an inner `{#key itemSlug}`
+	// subtree, or EditorLinkPopover's anchor, being removed a tick after the
+	// hop. It re-pulls focus into the pane ONLY when focus DROPS to `<body>`
+	// (the R1 removed-control case) AND the focus it dropped FROM was inside
+	// `.item-pane`. It must NOT fire for a deliberate Tab / click OUT to the
+	// list — the desktop split keeps the list reachable — so any outside
+	// target that ISN'T bare `<body>` (a real row/control) is left untouched.
+	//
+	// `focusin`'s own `relatedTarget` (the blurring element) is unreliable in
+	// exactly the R1 case — the element was REMOVED, so it's already gone — so
+	// we remember whether the last settled focus was inside the pane ourselves
+	// rather than reading it off the event.
+	$effect(() => {
+		if (!browser) return;
+		if (!paneEl || viewport.isMobile || !openItemRef) return;
+		const region = paneEl;
+		let lastFocusWasInPane = region.contains(document.activeElement);
+		function onFocusIn(e: FocusEvent) {
+			const t = e.target as Element | null;
+			if (t && region.contains(t)) {
+				lastFocusWasInPane = true;
+				return;
+			}
+			// Dropped to <body> out of the pane → pull it back into the stable
+			// region. `region.focus()` re-fires focusin with the region as target,
+			// which the branch above treats as "inside" (no loop).
+			if (t === document.body && lastFocusWasInPane) {
+				region.focus({ preventScroll: true });
+				return;
+			}
+			// A real element outside the pane (a list row/control the user Tabbed
+			// or clicked to) — legitimate on the desktop split; stand down.
+			lastFocusWasInPane = false;
+		}
+		document.addEventListener('focusin', onFocusIn);
+		return () => document.removeEventListener('focusin', onFocusIn);
 	});
 
 	// Return focus to the originating row whenever the pane CLOSES while this
@@ -2672,6 +2764,15 @@
 				currentPaneState().paneDepth > 0
 			) {
 				e.preventDefault();
+				// NB: no `focusPaneRegion()` here, unlike `navigatePaneTo` /
+				// `handlePaneBack`. Those hops REMOVE a focused in-pane control (the
+				// clicked link / the Back button) and must catch the resulting drop
+				// to `<body>`; an ESC press removes no such control, so there's
+				// nothing to recover — and forcing focus into the pane here would
+				// fight the depth-0 fallthrough below, whose whole job is to return
+				// focus to the LIST (`returnFocusToList`) on the way out. `j`/`k`
+				// stays inert at depth>0 via the detach guard regardless of where
+				// focus sits, so this pop needs no focus move.
 				if (!paneNavInFlight()) paneHistoryGo(-1);
 				return;
 			}


### PR DESCRIPTION
## Summary
Implements PLAN-2154 Architecture C / R1 "focus per hop" for the collection detail-pane mini-browser. On each in-pane hop — a content-link drill (`navigatePaneTo`), an in-pane Back (`handlePaneBack`), or a depth-aware ESC pop — the host now moves keyboard focus onto the **stable** aria-labeled `<aside>` region (`paneEl`) synchronously, before the hop's `{#key itemSlug}` remount (and header swap) can destroy the just-activated control and dump focus to `<body>` — where the next `j`/`k` would run list-nav and laterally re-target the drilled `?item=`, corrupting the stack (R1).

- **`focusPaneRegion()`** focuses the stable `paneEl` (outside every `{#key}`), so it's robust to the remount and needs no stored element ref. Fired from `navigatePaneTo`, `handlePaneBack`, and the depth-aware ESC pop, on **desktop and mobile** (on mobile `j`/`k` is already inert, but focus must still not strand behind the overlay).
- **Editor-link keyboard path** (`EditorLinkPopover.handleHrefClick`, which hides its popover — removing the focused anchor — synchronously) is covered because it funnels through the same `navigatePaneTo` chokepoint.
- **Desktop `focusin` backstop** mirrors the mobile trap, re-pulling focus into the pane only when it drops to `<body>` from within `.item-pane` — the desktop list stays reachable (a real Tab/click to a list row/control is left alone).

### What TASK-2164 pre-provided vs. what this adds
TASK-2164 (#970) shipped a component-local, armed-`pendingBackFocus` restore that focused the Back/Close **button** after a Back pop, and **deferred to this task** a documented edge: a Back immediately reversed by Forward could coalesce to a net no-op that left the intent armed, so a later unrelated navigation stole focus onto a pane control. This PR **retires** that armed intent in favor of deterministic host-owned focus — the explicit host resolution signal TASK-2164 round 10 identified as the real fix — so the edge is **dissolved, not patched**. `onBack` is now a pure notify like `onClose`/`onOpenTarget`. TASK-2164 only handled the Back pop; this adds the missing drill-hop focus + the desktop backstop.

## Test plan
- [x] `npm run check` — 0 errors
- [x] New focus-per-hop e2e (`pane-content-link-anchors.spec.ts`): a **mouse** drill and a **keyboard** (focus-link + Enter) drill each land focus inside the pane **while the destination is gated on the loading header** (so only `focusPaneRegion`, not the editor autofocus, could have done it); the next `j` stays inert; an in-pane Back keeps focus in the pane.
- [x] TASK-2164's Back-chevron focus assertions reconciled to assert focus-in-pane (the actual R1 acceptance criterion) rather than a specific button; the depth-0 ESC test now asserts the standard two-level return-to-list-then-close, which focus-per-hop correctly restores (drilling no longer strands focus on `<body>`).
- [x] Full pane regression suite (`pane-controller` + `pane-a11y-focus` + `pane-content-link-anchors` + `pane-mobile-overlay`) — 36/36 passing on desktop-chromium; `vitest` pane units 191/191.
- [x] Codex `read-only` review: round 1 found 2 P1s (mobile focus-per-hop, ESC removal race — both fixed by running `focusPaneRegion` on mobile + the ESC pop, targeting the stable `paneEl`); round 2 CLEAN.

https://claude.ai/code/session_01EZ6yr6pAUFb1uffan912ra