### PR TITLE
feat(web): parameterize scroll-target in createScrollRestoration (TASK-2171)

### DIFF
--- a/web/src/lib/scroll/restore.svelte.ts
+++ b/web/src/lib/scroll/restore.svelte.ts
@@ -60,6 +60,13 @@ import { onDestroy } from 'svelte';
 // the workspace layout; for pages outside the layout it falls back
 // to `window`. The lookup is cheap and re-runs on every capture /
 // restore so DOM swaps between mounts are handled.
+//
+// This is the DEFAULT resolver. A caller whose scroll container is NOT
+// `.main-content` (e.g. the full-page item host, whose master content
+// scrolls inside its own `.item-page` overflow column once a detail pane
+// docks beside it — PLAN-2154 Phase 2 / Architecture E) passes an explicit
+// `scrollTarget` getter in {@link ScrollRestorationOptions}; see
+// `resolveScrollTarget` in {@link createScrollRestoration}.
 function getScrollTarget(): HTMLElement | Window | null {
 	if (typeof document === 'undefined') return null;
 	const el = document.querySelector<HTMLElement>('.main-content');
@@ -117,6 +124,23 @@ export interface ScrollRestorationOptions {
 	 * routes that always remount on entry).
 	 */
 	persistKey?: () => string | null;
+	/**
+	 * Optional override for the scroll container to capture/restore. When
+	 * omitted, the module default is used: `.main-content` (the workspace
+	 * layout's overflow column), falling back to `window` for pages outside
+	 * the layout. Supply this ONLY when the page's scroll container differs —
+	 * e.g. the full-page item host, whose master content scrolls inside its
+	 * own `.item-page` overflow column once a detail pane docks beside it
+	 * (PLAN-2154 Phase 2 / Architecture E).
+	 *
+	 * Called lazily on every capture/restore (same semantics as the default
+	 * lookup), so it's safe to return `null` before the element mounts — the
+	 * restore loop re-fires each frame and picks the element up once present.
+	 * Because this fully REPLACES the default resolver, the caller owns its
+	 * own fallback: return `window` (or the default target) explicitly if a
+	 * fallback is wanted when the scoped element is absent.
+	 */
+	scrollTarget?: () => HTMLElement | Window | null;
 }
 
 export interface ScrollRestoration {
@@ -147,6 +171,14 @@ export interface ScrollRestoration {
 export function createScrollRestoration(
 	opts: ScrollRestorationOptions,
 ): ScrollRestoration {
+	// Which element to capture/restore against. Callers that scroll a
+	// non-default container (the full-page item host's `.item-page` column —
+	// PLAN-2154 Phase 2) pass `opts.scrollTarget`, which fully replaces the
+	// module default. Resolved lazily on every capture/restore, so a getter
+	// that returns null before mount is fine — the restore loop retries.
+	const resolveScrollTarget: () => HTMLElement | Window | null =
+		opts.scrollTarget ?? getScrollTarget;
+
 	// Parked restore value waiting for ready(). Stored together with the
 	// `persistKey` captured at restore-time so a value saved for entry A
 	// can't apply later to entry B.
@@ -370,7 +402,7 @@ export function createScrollRestoration(
 				return;
 			}
 
-			const target = getScrollTarget();
+			const target = resolveScrollTarget();
 			if (!target) {
 				cleanupListeners();
 				return;
@@ -409,7 +441,7 @@ export function createScrollRestoration(
 	return {
 		snapshot: {
 			capture: () => {
-				const y = readScrollY(getScrollTarget());
+				const y = readScrollY(resolveScrollTarget());
 				// Mirror to localStorage for cross-tab restoration. Only
 				// writes meaningful (>0) positions; clears the entry on
 				// y===0 so a stale value can't replay against a user

--- a/web/src/lib/scroll/restore.svelte.ts
+++ b/web/src/lib/scroll/restore.svelte.ts
@@ -404,7 +404,20 @@ export function createScrollRestoration(
 
 			const target = resolveScrollTarget();
 			if (!target) {
-				cleanupListeners();
+				// A custom `scrollTarget` getter can legitimately return null before
+				// its element mounts (e.g. the full-page host's `.item-page` during a
+				// remount). Honor the documented per-frame-retry contract: keep
+				// polling WITHIN THE SAME BUDGET until it appears, instead of aborting
+				// the restore permanently — `restoredKey` is already set for this key,
+				// so the gated effect will NOT re-fire, and a bare return would strand
+				// the parked offset forever. The default `.main-content`/window
+				// resolver never returns null in-browser, so existing callers are
+				// unaffected (Codex review, TASK-2171).
+				if (performance.now() - startTime > budgetMs) {
+					cleanupListeners();
+					return;
+				}
+				requestAnimationFrame(tryScroll);
 				return;
 			}
 


### PR DESCRIPTION
## Phase 2 (PLAN-2154, Architecture E · bullet 3) — TASK-2171

Parameterizes the scroll container in `createScrollRestoration` so the upcoming full-page pane host can restore against its own overflow column instead of the layout's `.main-content`.

### Change
- New optional `scrollTarget?: () => HTMLElement | Window | null` on `ScrollRestorationOptions`.
- `resolveScrollTarget = opts.scrollTarget ?? getScrollTarget` — resolved lazily on every capture/restore (safe to return `null` before mount; the restore loop retries per-frame).
- Both real call sites (the retry-until-stable restore loop and `snapshot.capture`) now route through `resolveScrollTarget()`.

### Compatibility
Purely additive. All **12** existing callers omit the option → default `.main-content`/`window` resolution is unchanged (byte-identical behavior). Because the getter *replaces* the default, a caller owns its own fallback.

### Follow-up
TASK-2174 (mount the pane on `[collection]/[slug]`) wires the full-page host to pass its `.item-page` column via this getter.

### Verification
- `npm run check` — 0 errors (pre-existing warnings only, none in this file)
- `make install` — web + Go build green, server restarted

https://claude.ai/code/session_01EZ6yr6pAUFb1uffan912ra