### PR TITLE
feat(web): mount the detail pane on the full-page item host (TASK-2174)

### DIFF
--- a/web/e2e/pane-collection-migration-race.spec.ts
+++ b/web/e2e/pane-collection-migration-race.spec.ts
@@ -408,15 +408,35 @@ test('a collection migration completing after a cross-collection navigation does
 	await page.locator('button.btn-cancel', { hasText: 'Cancel' }).click();
 	await expect(page.locator('#edit-collection-title')).toHaveCount(0);
 
-	// Navigate A -> B via the relationship link — a real client-side
-	// SvelteKit transition (same route component, different params), while
-	// A's collection-edit save is still pending.
+	// Navigate A -> B while A's collection-edit save is still pending, as a real
+	// client-side SvelteKit transition (same `[collection]/[slug]` route
+	// component, different collection+item params) that REUSES the master
+	// <ItemDetail> instance — the same-instance reuse this fence guards.
+	//
+	// Post-TASK-2174 the full-page host mounts a detail pane, so a PLAIN click on
+	// a content link no longer hard-navigates the master: it FIRST-OPENS the
+	// target in the docked pane (`onOpenTarget` → `openItemPaneByRef`). To
+	// reproduce a same-instance cross-collection FULL-PAGE navigation we open B
+	// in the pane, then EXPAND it — `expandToFullPage` does a real client-side
+	// `goto(B's full-page URL)`, dropping `?item=` and re-driving the SAME master
+	// instance from collA/A to collB/B exactly as the pre-pane relationship-link
+	// nav did.
 	await page
 		.locator('.relationship-group', { hasText: 'Related' })
 		.locator('a.link-target', { hasText: bTitle })
 		.click();
+	// B opens in the docked pane beside the (now peeking) A master.
+	const pane = page.locator('.item-pane');
+	await expect(pane).toBeVisible();
+	await expect(pane.locator('.title', { hasText: bTitle })).toBeVisible();
+	await expect(page).toHaveURL(/\?item=/);
+	// Expand the pane -> the master navigates full-page to B (same instance,
+	// cross-collection), and `?item=` drops out so the pane unmounts.
+	await pane.locator('button.pane-header-btn[aria-label="Expand to full page"]').click();
+	await expect(page.locator('.item-pane')).toHaveCount(0);
 	await expect(page.locator('.title', { hasText: bTitle })).toBeVisible();
 	await expect(page).toHaveURL(new RegExp(`/${collB.slug}/`));
+	await expect(page).not.toHaveURL(/\?item=/);
 
 	const urlAtRelease = page.url();
 	// waitForResponse (not a fixed sleep) — we need the PATCH to actually

--- a/web/e2e/pane-full-page-host.spec.ts
+++ b/web/e2e/pane-full-page-host.spec.ts
@@ -1,0 +1,191 @@
+import { test, expect } from './fixtures';
+import { browserLogin, seedDoc } from './lib/collab-helpers';
+import type { APIRequestContext, Page } from '@playwright/test';
+import type { SuiteFixture } from './fixtures';
+
+/**
+ * Full-page pane HOST (PLAN-2154 Phase 2 / Architecture E, bullet 5 /
+ * TASK-2174 — the Q1 payoff).
+ *
+ * The full-page item route (`[collection]/[slug]/+page.svelte`) now mounts the
+ * SAME right-docked detail pane the collection page carries. From a full-page
+ * item, clicking a child / related / wiki-linked item opens a navigable
+ * mini-browser pane BESIDE the master (the `[slug]` PATH param) via the `?item=`
+ * QUERY param — no collision. The master goes retain-alive READ-ONLY (peeking)
+ * while the pane is open; drill / in-pane Back / browser Back / close all work;
+ * and a `?item=` that resolves to the MASTER itself is refused (no second collab
+ * provider on the master's own room) — on cold load it's stripped.
+ *
+ * This spec drives that host end-to-end in a real browser against the built
+ * binary. The pane is a desktop-split concern, so one project is enough.
+ */
+
+const DESKTOP = { width: 1200, height: 900 };
+
+function authHeaders(fixture: SuiteFixture) {
+	return { Authorization: `Bearer ${fixture.apiToken}`, 'Content-Type': 'application/json' };
+}
+
+function openItemParam(page: Page): string | null {
+	return new URL(page.url()).searchParams.get('item');
+}
+
+interface SeededItem {
+	id: string;
+	slug: string;
+}
+
+/** Seed a doc whose `fields.parent` makes it a child of `parentId` (mirrors
+ *  `ChildItems.submitCreate`'s `{ parent }` shape) so the parent's pane renders
+ *  a `.child-row` to drill into. */
+async function seedChildDoc(
+	fixture: SuiteFixture,
+	request: APIRequestContext,
+	titlePrefix: string,
+	parentId: string,
+): Promise<SeededItem> {
+	const resp = await request.post(
+		`/api/v1/workspaces/${fixture.workspaceSlug}/collections/docs/items`,
+		{
+			headers: authHeaders(fixture),
+			data: { title: `${titlePrefix} ${Date.now()}`, fields: JSON.stringify({ parent: parentId }), content: '' },
+		},
+	);
+	if (!resp.ok()) throw new Error(`child doc create failed (${resp.status()}): ${await resp.text()}`);
+	return (await resp.json()) as SeededItem;
+}
+
+/** A `related` link FROM `sourceSlug` TO `targetId` — surfaces under the
+ *  "Related" relationship group on the source's page. */
+async function seedRelatedLink(
+	fixture: SuiteFixture,
+	request: APIRequestContext,
+	sourceSlug: string,
+	targetId: string,
+): Promise<void> {
+	const resp = await request.post(
+		`/api/v1/workspaces/${fixture.workspaceSlug}/items/${sourceSlug}/links`,
+		{ headers: authHeaders(fixture), data: { target_id: targetId, link_type: 'related' } },
+	);
+	if (!resp.ok()) throw new Error(`link create failed (${resp.status()}): ${await resp.text()}`);
+}
+
+/** The PREFIX-NUMBER ref (e.g. "DOC-5") the app renders + puts in `?item=`. */
+async function itemRef(fixture: SuiteFixture, request: APIRequestContext, slug: string): Promise<string> {
+	const resp = await request.get(`/api/v1/workspaces/${fixture.workspaceSlug}/items/${slug}`, {
+		headers: authHeaders(fixture),
+	});
+	if (!resp.ok()) throw new Error(`item get failed (${resp.status()}): ${await resp.text()}`);
+	const item = (await resp.json()) as { collection_prefix?: string; item_number?: number };
+	if (!item.collection_prefix || !item.item_number) throw new Error('item has no ref');
+	return `${item.collection_prefix}-${item.item_number}`;
+}
+
+function fullPageUrl(fixture: SuiteFixture, slug: string, query = ''): string {
+	return `/${fixture.adminUsername}/${fixture.workspaceSlug}/docs/${slug}${query}`;
+}
+
+test.describe('full-page pane host (PLAN-2154 Phase 2 / TASK-2174)', () => {
+	test.beforeEach(({}, testInfo) => {
+		test.skip(
+			testInfo.project.name !== 'desktop-chromium',
+			'the pane is a desktop-split concern; one project is enough',
+		);
+	});
+
+	test('a master content-link opens a pane beside the (read-only, still-live) master; the pane drills, in-pane Back and ✕ close cleanly', async ({
+		page,
+		fixture,
+		request,
+	}) => {
+		await page.setViewportSize(DESKTOP);
+		await browserLogin(page);
+
+		// A (master) --related--> B (pane target); C is a CHILD of B (the drill
+		// target once B is in the pane).
+		const master = await seedDoc(fixture, request, 'FP host master');
+		const related = await seedDoc(fixture, request, 'FP host related');
+		const grandchild = await seedChildDoc(fixture, request, 'FP host grandchild', related.id);
+		await seedRelatedLink(fixture, request, master.slug, related.id);
+		const relatedRef = await itemRef(fixture, request, related.slug);
+		const grandchildRef = await itemRef(fixture, request, grandchild.slug);
+
+		// Land on the MASTER full page. No pane yet: the flex-row host is present,
+		// the master title is EDITABLE (a click-to-edit button — not peeking), and
+		// there's no `?item=`.
+		await page.goto(fullPageUrl(fixture, master.slug));
+		await expect(page.locator('.item-page-host')).toBeVisible();
+		await expect(page.locator('button.title', { hasText: 'FP host master' })).toBeVisible();
+		await expect(page.locator('.item-pane')).toHaveCount(0);
+		expect(openItemParam(page)).toBeNull();
+
+		// Click the RELATED link on the master → FIRST-OPEN the pane beside it.
+		await page
+			.locator('.relationship-group', { hasText: 'Related' })
+			.locator('a.link-target', { hasText: 'FP host related' })
+			.click();
+
+		const pane = page.locator('.item-pane');
+		await expect(pane).toBeVisible();
+		await expect(pane.locator('.title', { hasText: 'FP host related' })).toBeVisible();
+		await expect.poll(() => openItemParam(page)).toBe(relatedRef);
+
+		// The master is RETAIN-ALIVE READ-ONLY (peeking): its content is still
+		// rendered (not torn down), but the title is now a non-editable <h1>
+		// (`title-readonly`) instead of the click-to-edit button — the freeze.
+		await expect(page.locator('h1.title.title-readonly', { hasText: 'FP host master' })).toBeVisible();
+		await expect(page.locator('button.title', { hasText: 'FP host master' })).toHaveCount(0);
+
+		// Depth 0: the pane's Back chevron is hidden.
+		await expect(pane.locator('button.pane-back-btn')).toHaveCount(0);
+
+		// Click the CHILD row INSIDE the pane → DRILL in place (same pathname,
+		// `?item=` swaps to the child, the Back chevron appears at depth>0). The
+		// master stays put + read-only underneath.
+		const masterPathname = new URL(page.url()).pathname;
+		await pane.locator('.child-row', { hasText: 'FP host grandchild' }).click();
+		await expect.poll(() => openItemParam(page)).toBe(grandchildRef);
+		expect(new URL(page.url()).pathname).toBe(masterPathname);
+		await expect(pane.locator('button.pane-back-btn')).toBeVisible();
+		await expect(pane.locator('.title', { hasText: 'FP host grandchild' })).toBeVisible();
+		await expect(page.locator('h1.title.title-readonly', { hasText: 'FP host master' })).toBeVisible();
+
+		// Browser BACK → pops one drill level back to B in the pane.
+		await page.goBack();
+		await expect.poll(() => openItemParam(page)).toBe(relatedRef);
+		await expect(pane.locator('.title', { hasText: 'FP host related' })).toBeVisible();
+		await expect(pane.locator('button.pane-back-btn')).toHaveCount(0);
+
+		// Close (✕) → the pane unmounts cleanly, `?item=` drops, and the master is
+		// EDITABLE again (no longer peeking → click-to-edit button returns).
+		await pane.locator('button[title="Close pane"]').click();
+		await expect(page.locator('.item-pane')).toHaveCount(0);
+		await expect.poll(() => openItemParam(page)).toBeNull();
+		await expect(page.locator('button.title', { hasText: 'FP host master' })).toBeVisible();
+		await expect(page.locator('h1.title.title-readonly')).toHaveCount(0);
+	});
+
+	test('a cold-loaded `?item=<the master itself>` is stripped — never mounts a pane on the master', async ({
+		page,
+		fixture,
+		request,
+	}) => {
+		await page.setViewportSize(DESKTOP);
+		await browserLogin(page);
+
+		const master = await seedDoc(fixture, request, 'FP host self-ref');
+		const masterRef = await itemRef(fixture, request, master.slug);
+
+		// Hand-craft a `?item=` that aliases the MASTER's own ref. Two providers on
+		// one collab room (sharing the itemID-only sessionStorage cursor) is
+		// forbidden, so once the master's identity resolves the host strips `?item=`
+		// in place — no pane mounts.
+		await page.goto(fullPageUrl(fixture, master.slug, `?item=${masterRef}`));
+		await expect(page.locator('button.title', { hasText: 'FP host self-ref' })).toBeVisible();
+		// The pane must never appear, and `?item=` must be stripped from the URL.
+		await expect(page.locator('.item-pane')).toHaveCount(0);
+		await expect.poll(() => openItemParam(page)).toBeNull();
+		// The master stays fully EDITABLE (never went peeking).
+		await expect(page.locator('h1.title.title-readonly')).toHaveCount(0);
+	});
+});

--- a/web/e2e/pane-full-page-host.spec.ts
+++ b/web/e2e/pane-full-page-host.spec.ts
@@ -188,4 +188,29 @@ test.describe('full-page pane host (PLAN-2154 Phase 2 / TASK-2174)', () => {
 		// The master stays fully EDITABLE (never went peeking).
 		await expect(page.locator('h1.title.title-readonly')).toHaveCount(0);
 	});
+
+	test('a cold-loaded shared `?item=<a different item>` still mounts the pane (the self-collision mount-gate does not suppress legitimate cross-item cold loads)', async ({
+		page,
+		fixture,
+		request,
+	}) => {
+		await page.setViewportSize(DESKTOP);
+		await browserLogin(page);
+
+		const master = await seedDoc(fixture, request, 'FP host cold master');
+		const other = await seedDoc(fixture, request, 'FP host cold other');
+		const otherRef = await itemRef(fixture, request, other.slug);
+
+		// Deep-link straight to the master with a shared `?item=` pointing at a
+		// DIFFERENT item. The mount-gate holds the pane one master-load beat (so a
+		// `?item=<master-alias>` can't transiently mint a 2nd provider), then mounts
+		// it once identity confirms the target isn't the master.
+		await page.goto(fullPageUrl(fixture, master.slug, `?item=${otherRef}`));
+		const pane = page.locator('.item-pane');
+		await expect(pane).toBeVisible();
+		await expect(pane.locator('.title', { hasText: 'FP host cold other' })).toBeVisible();
+		await expect.poll(() => openItemParam(page)).toBe(otherRef);
+		// The master is present + peeking (read-only) beside the pane.
+		await expect(page.locator('h1.title.title-readonly', { hasText: 'FP host cold master' })).toBeVisible();
+	});
 });

--- a/web/e2e/pane-full-page-host.spec.ts
+++ b/web/e2e/pane-full-page-host.spec.ts
@@ -214,6 +214,34 @@ test.describe('full-page pane host (PLAN-2154 Phase 2 / TASK-2174)', () => {
 		await expect(page.locator('h1.title.title-readonly', { hasText: 'FP host cold master' })).toBeVisible();
 	});
 
+	test('a cold-loaded `?item=<the master by its ref-shaped slug>` is stripped (server slug-fallback self-collision)', async ({
+		page,
+		fixture,
+		request,
+	}) => {
+		await page.setViewportSize(DESKTOP);
+		await browserLogin(page);
+
+		// `seedDoc` titles are `<prefix> <Date.now()>`, and the server slugifies that
+		// to `<prefix>-<digits>` — so a doc titled "plan" gets the REF-SHAPED slug
+		// `plan-<timestamp>` while its own item number is small. `?item=plan-<ts>`
+		// therefore parses as a ref at a NON-existent number; the server falls back
+		// to the SLUG and resolves to THIS master. The ref-NUMBER channel alone
+		// (timestamp != item number) would MISS this — the guard must also match the
+		// raw slug string.
+		const master = await seedDoc(fixture, request, 'plan');
+		expect(master.slug).toMatch(/^[A-Za-z]+-\d+$/); // fixture assumption: ref-shaped slug
+		const masterRef = await itemRef(fixture, request, master.slug);
+		expect(master.slug).not.toBe(masterRef); // slug number != item ref number
+
+		await page.goto(fullPageUrl(fixture, master.slug, `?item=${encodeURIComponent(master.slug)}`));
+		await expect(page.locator('button.title')).toBeVisible();
+		// Must be stripped — never mount a second provider on the master's own room.
+		await expect(page.locator('.item-pane')).toHaveCount(0);
+		await expect.poll(() => openItemParam(page)).toBeNull();
+		await expect(page.locator('h1.title.title-readonly')).toHaveCount(0);
+	});
+
 	test('Expand a pane item to full page, then browser Back, restores the pane (no stale-master strip)', async ({
 		page,
 		fixture,

--- a/web/e2e/pane-full-page-host.spec.ts
+++ b/web/e2e/pane-full-page-host.spec.ts
@@ -242,6 +242,37 @@ test.describe('full-page pane host (PLAN-2154 Phase 2 / TASK-2174)', () => {
 		await expect(page.locator('h1.title.title-readonly')).toHaveCount(0);
 	});
 
+	test("a master whose SLUG equals another item's UUID does not over-block that item (server UUID-first precedence)", async ({
+		page,
+		fixture,
+		request,
+	}) => {
+		await page.setViewportSize(DESKTOP);
+		await browserLogin(page);
+
+		// A is the real `?item=` target. B is a master whose SLUG is created to be
+		// EXACTLY A's UUID (slugify keeps a UUID's hex+hyphens verbatim). The server
+		// resolves `?item=<A's UUID>` UUID-FIRST to A — a DIFFERENT item — so the
+		// pane must OPEN A, NOT be stripped as a master self-collision just because
+		// B's slug string-equals it (orchestrator Codex round-8 verify).
+		const a = await seedDoc(fixture, request, 'FP host uuid-slug target');
+		const bResp = await request.post(
+			`/api/v1/workspaces/${fixture.workspaceSlug}/collections/docs/items`,
+			{ headers: authHeaders(fixture), data: { title: a.id, fields: '{}', content: '' } },
+		);
+		if (!bResp.ok()) throw new Error(`B create failed (${bResp.status()}): ${await bResp.text()}`);
+		const b = (await bResp.json()) as SeededItem;
+		expect(b.slug).toBe(a.id); // fixture assumption: B's slug IS A's UUID
+		// Resolve B by its OWN id — GET /items/<B.slug> would resolve UUID-first to A.
+		const bRef = await itemRef(fixture, request, b.id);
+
+		await page.goto(fullPageUrl(fixture, bRef, `?item=${encodeURIComponent(a.id)}`));
+		const pane = page.locator('.item-pane');
+		await expect(pane).toBeVisible();
+		await expect(pane.locator('.title', { hasText: 'FP host uuid-slug target' })).toBeVisible();
+		await expect.poll(() => openItemParam(page)).toBe(a.id);
+	});
+
 	test('Expand a pane item to full page, then browser Back, restores the pane (no stale-master strip)', async ({
 		page,
 		fixture,

--- a/web/e2e/pane-full-page-host.spec.ts
+++ b/web/e2e/pane-full-page-host.spec.ts
@@ -213,4 +213,45 @@ test.describe('full-page pane host (PLAN-2154 Phase 2 / TASK-2174)', () => {
 		// The master is present + peeking (read-only) beside the pane.
 		await expect(page.locator('h1.title.title-readonly', { hasText: 'FP host cold master' })).toBeVisible();
 	});
+
+	test('Expand a pane item to full page, then browser Back, restores the pane (no stale-master strip)', async ({
+		page,
+		fixture,
+		request,
+	}) => {
+		await page.setViewportSize(DESKTOP);
+		await browserLogin(page);
+
+		// A (master) --related--> B.
+		const master = await seedDoc(fixture, request, 'FP host expand master');
+		const related = await seedDoc(fixture, request, 'FP host expand related');
+		await seedRelatedLink(fixture, request, master.slug, related.id);
+		const relatedRef = await itemRef(fixture, request, related.slug);
+
+		await page.goto(fullPageUrl(fixture, master.slug));
+		await page
+			.locator('.relationship-group', { hasText: 'Related' })
+			.locator('a.link-target', { hasText: 'FP host expand related' })
+			.click();
+		const pane = page.locator('.item-pane');
+		await expect(pane).toBeVisible();
+		await expect.poll(() => openItemParam(page)).toBe(relatedRef);
+		const paneUrl = page.url();
+
+		// Expand B to the full page (same route reused, master A -> B), dropping ?item=.
+		await pane.locator('button.pane-header-btn[aria-label="Expand to full page"]').click();
+		await expect(page.locator('.item-pane')).toHaveCount(0);
+		await expect(page.locator('button.title', { hasText: 'FP host expand related' })).toBeVisible();
+		await expect.poll(() => openItemParam(page)).toBeNull();
+
+		// Browser Back -> `master?item=B`. The route is reused and `masterIdentity`
+		// briefly still holds B; the fresh-for-`ref` gate must NOT let the strip
+		// delete `?item=B`, so the pane RESTORES to B beside the (reloaded) A master.
+		await page.goBack();
+		await expect(page).toHaveURL(paneUrl);
+		await expect(pane).toBeVisible();
+		await expect(pane.locator('.title', { hasText: 'FP host expand related' })).toBeVisible();
+		await expect.poll(() => openItemParam(page)).toBe(relatedRef);
+		await expect(page.locator('h1.title.title-readonly', { hasText: 'FP host expand master' })).toBeVisible();
+	});
 });

--- a/web/e2e/pane-full-page-host.spec.ts
+++ b/web/e2e/pane-full-page-host.spec.ts
@@ -242,37 +242,6 @@ test.describe('full-page pane host (PLAN-2154 Phase 2 / TASK-2174)', () => {
 		await expect(page.locator('h1.title.title-readonly')).toHaveCount(0);
 	});
 
-	test("a master whose SLUG equals another item's UUID does not over-block that item (server UUID-first precedence)", async ({
-		page,
-		fixture,
-		request,
-	}) => {
-		await page.setViewportSize(DESKTOP);
-		await browserLogin(page);
-
-		// A is the real `?item=` target. B is a master whose SLUG is created to be
-		// EXACTLY A's UUID (slugify keeps a UUID's hex+hyphens verbatim). The server
-		// resolves `?item=<A's UUID>` UUID-FIRST to A — a DIFFERENT item — so the
-		// pane must OPEN A, NOT be stripped as a master self-collision just because
-		// B's slug string-equals it (orchestrator Codex round-8 verify).
-		const a = await seedDoc(fixture, request, 'FP host uuid-slug target');
-		const bResp = await request.post(
-			`/api/v1/workspaces/${fixture.workspaceSlug}/collections/docs/items`,
-			{ headers: authHeaders(fixture), data: { title: a.id, fields: '{}', content: '' } },
-		);
-		if (!bResp.ok()) throw new Error(`B create failed (${bResp.status()}): ${await bResp.text()}`);
-		const b = (await bResp.json()) as SeededItem;
-		expect(b.slug).toBe(a.id); // fixture assumption: B's slug IS A's UUID
-		// Resolve B by its OWN id — GET /items/<B.slug> would resolve UUID-first to A.
-		const bRef = await itemRef(fixture, request, b.id);
-
-		await page.goto(fullPageUrl(fixture, bRef, `?item=${encodeURIComponent(a.id)}`));
-		const pane = page.locator('.item-pane');
-		await expect(pane).toBeVisible();
-		await expect(pane.locator('.title', { hasText: 'FP host uuid-slug target' })).toBeVisible();
-		await expect.poll(() => openItemParam(page)).toBe(a.id);
-	});
-
 	test('Expand a pane item to full page, then browser Back, restores the pane (no stale-master strip)', async ({
 		page,
 		fixture,

--- a/web/src/lib/collections/paneHostController.ts
+++ b/web/src/lib/collections/paneHostController.ts
@@ -81,6 +81,17 @@ export interface PaneController {
 	clearPaneGo: () => void;
 	/** Lateral / list open: first-open (push), depth-0 re-target (replace), or depth>0 stack RESET. */
 	openItemPane: (item: Item) => void;
+	/**
+	 * The ref-first counterpart to `openItemPane(item)` — first-open / re-target /
+	 * stack-reset the pane to an ALREADY-RESOLVED canonical `?item=` ref, applying
+	 * the exact same lateral-open semantics (`planLateralOpen`). `openItemPane` is a
+	 * thin wrapper over this that first derives the ref from an `Item` via
+	 * `itemUrlId`. Hosts whose content-links hand up a resolved ref rather than a
+	 * full `Item` — the full-page item host's MASTER content-links (PLAN-2154
+	 * Architecture E / TASK-2174), which FIRST-OPEN the pane (a depth-0
+	 * `paneOwned:true` push) instead of drilling — wire straight into this.
+	 */
+	openItemPaneByRef: (ref: string) => void;
 	/** In-pane DRILL to an already-resolved canonical `?item=` ref. */
 	navigatePaneTo: (target: string) => void;
 	/** `ItemDetail`'s `onOpenTarget` seam: resolve a raw `PaneTarget`, then drill. */
@@ -182,10 +193,16 @@ export function createPaneController(deps: PaneControllerDeps): PaneController {
 		clearPaneGo();
 	});
 
-	function openItemPane(item: Item) {
+	// Lateral / list open from an ALREADY-RESOLVED canonical `?item=` ref
+	// (PLAN-2154 Architecture E / TASK-2174). This is the whole body of the
+	// pre-refactor `openItemPane`; `openItemPane(item)` below is now a thin
+	// wrapper that derives `targetRef` from an `Item` and calls in, so its
+	// behavior — and the collection host's every `openItemPane(item)` call site —
+	// is byte-identical. The full-page item host's MASTER content-links (which
+	// hand up a resolved ref, not an `Item`) first-open the pane through here.
+	function openItemPaneByRef(targetRef: string) {
 		if (paneNavInFlight()) return;
 		controllerActionSeq++;
-		const targetRef = itemUrlId(item);
 		const url = new URL(page.url);
 		const alreadyOpen = url.searchParams.has('item');
 		// Capture the trigger on the FIRST open only — re-targeting (j/k follow /
@@ -232,6 +249,15 @@ export function createPaneController(deps: PaneControllerDeps): PaneController {
 			keepFocus: true,
 			state: plan.state,
 		});
+	}
+
+	// Lateral / list open from an `Item` (the collection host's row / j-k
+	// selection). A thin wrapper over `openItemPaneByRef` — the ONLY thing it
+	// adds is deriving the canonical `?item=` ref from the item — so every
+	// existing `openItemPane(item)` call site is byte-identical to the
+	// pre-refactor function (PLAN-2154 Architecture E / TASK-2174).
+	function openItemPane(item: Item) {
+		openItemPaneByRef(itemUrlId(item));
 	}
 
 	// In-pane DRILL (Architecture A). `target` is an already-resolved canonical
@@ -406,6 +432,7 @@ export function createPaneController(deps: PaneControllerDeps): PaneController {
 		paneNavInFlight,
 		clearPaneGo,
 		openItemPane,
+		openItemPaneByRef,
 		navigatePaneTo,
 		handleOpenTarget,
 		handlePaneBack,

--- a/web/src/lib/collections/paneTarget.ts
+++ b/web/src/lib/collections/paneTarget.ts
@@ -16,6 +16,19 @@
 
 import type { Item, PaneTarget } from '$lib/types';
 
+/**
+ * The minimal item shape the same-item guard (`isSamePaneTarget` /
+ * `resolvePaneTarget`) actually reads: `id` + `slug` for exact matches and
+ * `item_number` for the case-insensitive ref-number equivalence. Narrowing the
+ * `current` param to this (rather than a full `Item`) lets callers that only
+ * hold a resolved identity — the full-page pane host, which has the master's
+ * `{ id, ref, slug }` from `ItemDetail.onIdentity` and derives `item_number`
+ * from `ref` (PLAN-2154 Architecture E / TASK-2174) — reuse the guard without
+ * fabricating a whole `Item`. A full `Item` is still assignable, so every
+ * existing caller is unaffected.
+ */
+export type PaneGuardItem = Pick<Item, 'id' | 'slug' | 'item_number'>;
+
 // The cross-workspace wiki-link resolver route, `/-/r/{workspace}/{ref}`
 // (`wikiLinksToMarkdown`/`renderMarkdown` in `$lib/utils/markdown`). Its
 // trailing segment IS a ref, but for a possibly-DIFFERENT workspace — taking
@@ -218,7 +231,7 @@ function rawPaneTargetCandidate(target: PaneTarget): string | null {
 /** True when `candidate` is `current`'s own item number, expressed as a
  *  ref-shaped string (case-insensitive, prefix ignored — see `REF_SHAPE`'s
  *  doc comment). False when `current` has no item number. */
-function matchesRefNumber(candidate: string, current: Item): boolean {
+function matchesRefNumber(candidate: string, current: PaneGuardItem): boolean {
 	if (!current.item_number) return false;
 	const number = parseRefNumber(candidate);
 	return number !== null && number === current.item_number;
@@ -251,7 +264,7 @@ function matchesRefNumber(candidate: string, current: Item): boolean {
  * this — and `resolvePaneTarget` — without one; the guard simply never
  * fires.
  */
-export function isSamePaneTarget(target: PaneTarget, current: Item | null | undefined): boolean {
+export function isSamePaneTarget(target: PaneTarget, current: PaneGuardItem | null | undefined): boolean {
 	if (!current) return false;
 	// A cross-workspace href is unambiguous evidence of non-locality — see
 	// `rawPaneTargetCandidate`'s doc comment for why this precedes ref/slug.
@@ -300,7 +313,7 @@ export function isSamePaneTarget(target: PaneTarget, current: Item | null | unde
  *
  * Returns null when the target carries nothing resolvable.
  */
-export function resolvePaneTarget(target: PaneTarget, current?: Item | null): string | null {
+export function resolvePaneTarget(target: PaneTarget, current?: PaneGuardItem | null): string | null {
 	if (isSamePaneTarget(target, current)) return null;
 	return rawPaneTargetCandidate(target);
 }

--- a/web/src/lib/components/editor/block-drag-handle.ts
+++ b/web/src/lib/components/editor/block-drag-handle.ts
@@ -362,7 +362,25 @@ export const BlockDragHandle = Extension.create({
 					let menuOpen = false;
 
 					function getScrollContainer(): HTMLElement {
-						return wrapper.closest('.main-content') as HTMLElement || document.documentElement;
+						// Auto-scroll targets the INNERMOST actually-scrollable ancestor,
+						// resolved by computed `overflow-y` rather than a hard-coded
+						// `.main-content` class. The editor now lives inside different
+						// scroll owners depending on surface — the docked detail pane's
+						// `.item-pane`, the full-page item host's `.item-page` overflow
+						// column (PLAN-2154 Architecture E / TASK-2174), or the layout's
+						// `.main-content` — and a class walk is unreliable here because the
+						// full-page host's scroll column shares the `.item-page` class with
+						// <ItemDetail>'s NON-scrolling inner content wrapper. Walking to the
+						// first `auto`/`scroll`/`overlay` ancestor finds the right column on
+						// every surface (and fixes the pane editor, which previously scrolled
+						// the `.main-content` it doesn't live in).
+						let el: HTMLElement | null = wrapper.parentElement;
+						while (el && el !== document.documentElement) {
+							const oy = getComputedStyle(el).overflowY;
+							if (oy === 'auto' || oy === 'scroll' || oy === 'overlay') return el;
+							el = el.parentElement;
+						}
+						return document.documentElement;
 					}
 
 					// --- Handle positioning ---

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -504,27 +504,23 @@
 	function graphItemHref(ref: string, collection?: string): string {
 		return `/${username}/${wsSlug}/${collection ?? effectiveCollSlug}/${ref}`;
 	}
-	// ESC closes the graph drawer (only while open — no global listener otherwise).
-	// FULL-PAGE only: there's no pane/list contention on the full-page route, so
-	// it keeps its own window listener. The EMBEDDED graph drawer routes ESC
-	// through the shared escape stack instead (see below) so it composes with
-	// the pane + list-focus layers — one ESC closes exactly one layer
-	// (PLAN-2105 / TASK-2118).
+	// The dependency-graph drawer routes ESC through the shared escape stack as
+	// the highest-priority (innermost) layer — for BOTH the embedded pane AND the
+	// full-page (non-embedded) master. One ESC closes exactly one layer, composing
+	// with the pane + list-focus layers (PLAN-2105 / TASK-2118). The full-page
+	// master USED to keep its own `window` keydown listener on the assumption that
+	// "there's no pane/list contention on the full-page route" — but the full-page
+	// pane host (PLAN-2154 / TASK-2174) now mounts a pane beside a non-embedded
+	// master, and an uncoordinated window listener double-closed the master graph
+	// alongside the pane's own depth-aware ESC (it ignored preventDefault, text-
+	// edit / open-dialog / held-key guards, and the pane's precedence). Registering
+	// in the stack instead fixes that: the host's single top-level keydown
+	// (`handleHostKeydown` → `runTopEscape`) invokes it, exactly as the collection
+	// host does for the embedded pane. Only the `[collection]/[slug]` route mounts
+	// a non-embedded ItemDetail, and it owns that top-level listener, so there is
+	// no full-page surface left without one.
 	$effect(() => {
-		if (embedded) return;
 		if (!showGraph) return;
-		const onKey = (e: KeyboardEvent) => {
-			if (e.key === 'Escape') closeGraph();
-		};
-		window.addEventListener('keydown', onKey);
-		return () => window.removeEventListener('keydown', onKey);
-	});
-	// EMBEDDED graph drawer — highest-priority ESC layer (innermost). Registered
-	// into the shared escape stack while open; the single top-level listener on
-	// the collection page invokes only the top handler, so one ESC closes the
-	// drawer and leaves the pane open (PLAN-2105 / TASK-2118).
-	$effect(() => {
-		if (!embedded || !showGraph) return;
 		return pushEscapeHandler(() => {
 			closeGraph();
 			return true;

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -283,10 +283,14 @@
 	// `ready` requires the loaded item's identity to match the URL ref —
 	// otherwise a same-instance route change (item A → wiki-link to B → back
 	// to A) would fire the restore against B's still-rendered content. The
-	// match accepts EITHER the slug form OR the issue ref (e.g. `TASK-123`)
-	// because `itemUrlId()` (in `$lib/types/index.ts`) prefers refs over
-	// slugs when building links, so most app URLs are `/tasks/TASK-123`
-	// rather than `/tasks/some-slug`. Codex BUG-1425 round 5 P1.
+	// match accepts the slug form, the issue ref (e.g. `TASK-123`), OR the raw
+	// item UUID: `itemUrlId()` (in `$lib/types/index.ts`) prefers refs over
+	// slugs when building links (so most app URLs are `/tasks/TASK-123`), but the
+	// server ALSO resolves a bare item id (internal/store/items.go) and app toast
+	// links use UUIDs — without the `item.id` arm a UUID route would never satisfy
+	// `itemMatchesRef`, so scroll-readiness, `onIdentity`, and the collab gate
+	// would silently never fire on it (Codex BUG-1425 round 5 P1; UUID arm added
+	// for the full-page pane host's `onIdentity` guard — orchestrator review).
 	//
 	// Embedded panes don't pass `onReady` — they manage their own scroll
 	// container (TASK-2112), not the route-level snapshot.
@@ -301,7 +305,8 @@
 	// destroyed editor (PLAN-2105 / TASK-2112 switch-safety; Codex).
 	let itemMatchesRef = $derived(
 		item !== null &&
-			(item.slug === itemSlug ||
+			(item.id === itemSlug ||
+				item.slug === itemSlug ||
 				`${item.collection_prefix}-${item.item_number}` === itemSlug),
 	);
 	let scrollReady = $derived(!loading && itemMatchesRef);

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -179,23 +179,34 @@
 		};
 	});
 
+	// A canonical item-UUID shape (`GetItemByRef`'s FIRST resolution branch —
+	// internal/store/items.go). Used to mirror the server's UUID-first precedence
+	// in `isMasterRef` below.
+	const UUID_SHAPE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 	// The forbidden `?item == master` collision (PLAN-2154 D2 / Architecture E)
 	// for a BARE `?item=` string (the cold-load strip + the mount gate + a resolved
-	// content-link ref). The server resolves a bare/href `?item=` REF-FIRST, then
-	// falls back to SLUG (internal/store/items.go). So a candidate aliases the
-	// master if it matches under EITHER interpretation: the ref-number channel
-	// (`isSamePaneTarget`'s href resolution) OR the RAW string equal to the
-	// master's id / slug — INCLUDING a ref-shaped slug (e.g. master #5 slugged
-	// `plan-6` with no live #6, which the server resolves to the master by the slug
-	// fallback; the ref-number channel alone would miss it, 6≠5). Erring toward a
-	// match is the safe direction for the forbidden D2 collision — never mount a
-	// 2nd provider on the master's own collab room (orchestrator Codex review). The
-	// rare cost is over-blocking a hand-crafted `?item=<ref-shaped-slug>` when a
-	// live item at that number DOES exist; that merely declines to open a pane (no
+	// content-link ref). Mirrors the server's resolution PRECEDENCE — UUID-first,
+	// then ref (by NUMBER), then slug (internal/store/items.go) — as closely as a
+	// client can WITHOUT knowing which items exist:
+	//   1. an exact id match is always the master (UUID-first);
+	//   2. a UUID-SHAPED candidate that ISN'T the master's id resolves UUID-first
+	//      to a DIFFERENT item (UUIDs are assigned, not title-derived), so we do
+	//      NOT fall through to a slug compare — otherwise `?item=<another item's
+	//      UUID>` would be over-blocked whenever the master's slug coincidentally
+	//      equals it (orchestrator Codex round-8 verify);
+	//   3. otherwise match the ref NUMBER (`isSamePaneTarget`'s href channel) OR
+	//      the RAW slug string — so a ref-shaped SLUG the server reaches by its
+	//      slug-fallback (e.g. master #5 slugged `plan-6` with no live #6, 6≠5) is
+	//      caught, the forbidden D2 collision's safe direction.
+	// The only residual over-block is a hand-crafted `?item=<ref-shaped-slug>` when
+	// a live item at that number DOES exist — benign (declines to open a pane; no
 	// collision, no data loss). `false` while the master identity is unresolved.
 	function isMasterRef(candidate: string): boolean {
 		if (!masterItem) return false;
-		if (candidate === masterItem.id || candidate === masterItem.slug) return true;
+		if (candidate === masterItem.id) return true;
+		if (UUID_SHAPE.test(candidate)) return false;
+		if (candidate === masterItem.slug) return true;
 		return isSamePaneTarget({ href: candidate }, masterItem);
 	}
 

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -54,8 +54,12 @@
 	// The MASTER's resolved {id, ref, slug} identity (TASK-2173), captured via
 	// `onIdentity`. Drives the `?item == master` guard so a slug-path master and
 	// a ref-query `?item=` (or vice versa) that alias the SAME item are caught.
-	// `null` until the master's loaded item matches its URL ref.
+	// `null` until the master's loaded item matches its URL ref. Paired with the
+	// pathname it resolved for, so a STALE identity from a since-navigated master
+	// (Expand→Back, cross-collection, cross-workspace — all encoded in the
+	// pathname) is dropped (see `masterItem`).
 	let masterIdentity = $state<ResolvedItemIdentity | null>(null);
+	let masterIdentityPathname = $state<string | null>(null);
 
 	// Scroll restoration parks on the master's OWN `.item-page` overflow column
 	// (not the layout's `.main-content`), which is where the master content
@@ -148,24 +152,26 @@
 	// item #6 (Codex review).
 	let masterItem = $derived.by<PaneGuardItem | null>(() => {
 		if (!masterIdentity) return null;
-		const projected: PaneGuardItem = {
-			id: masterIdentity.id,
-			slug: masterIdentity.slug,
-			item_number: refNumber(masterIdentity.ref) ?? 0,
-		};
 		// `masterIdentity` (from `onIdentity`) LAGS a same-route master navigation:
 		// expanding a pane item to the full page, then browser-Back to
 		// `<prev-master>?item=<that item>`, REUSES this route — `masterIdentity`
 		// still holds the expanded item until the master reloads the previous one
-		// and re-emits identity. Comparing it against the live master `ref` path
-		// param (via the shared `isSamePaneTarget`) drops that STALE identity, so
-		// the self-guard / cold-load strip never match a bare `?item=` against the
-		// WRONG (previous) master and wrongly strip a still-valid pane — the R14
-		// late-continuation class (Codex review). Because `masterItem` is a
-		// `$derived` over `ref`, it re-nulls SYNCHRONOUSLY the instant `ref`
-		// changes — before the strip `$effect` runs — so the effect never sees a
-		// stale master. Null until identity resolves AND matches the current `ref`.
-		return isSamePaneTarget({ href: ref }, projected) ? projected : null;
+		// and re-emits identity. Compare the pathname it resolved FOR against the
+		// LIVE pathname: EVERY master navigation (ref, collection, OR workspace —
+		// all encoded in `/username/workspace/collection/ref`) makes them diverge,
+		// so a stale identity is dropped until the master reloads and re-emits.
+		// `?item=` lives in the query, not the pathname, so opening / drilling /
+		// closing the pane never trips this. Because it's a `$derived` over
+		// `page.url.pathname`, it re-nulls SYNCHRONOUSLY the instant the URL changes
+		// — before the strip `$effect` runs — so the guard never matches a bare
+		// `?item=` against the WRONG (previous) master (the R14 late-continuation
+		// class; Codex review). Null until identity resolves AND still matches.
+		if (masterIdentityPathname !== page.url.pathname) return null;
+		return {
+			id: masterIdentity.id,
+			slug: masterIdentity.slug,
+			item_number: refNumber(masterIdentity.ref) ?? 0,
+		};
 	});
 
 	// The forbidden `?item == master` collision (PLAN-2154 D2 / Architecture E)
@@ -264,9 +270,13 @@
 	// list, so there is NO two-level return-focus-to-list step: at depth>0 ESC
 	// pops exactly ONE drill level via the controller's fenced `handlePaneBack`;
 	// at depth 0 it closes the pane through the shared escape stack (the embedded
-	// pane registers `onClose` = `closeItemPane` at `ESCAPE_PRIORITY.pane`). Text
-	// edits, open modals/sheets, and a higher-priority stacked graph drawer all
-	// win ESC first (the same guards the collection host applies).
+	// pane registers `onClose` = `closeItemPane` at `ESCAPE_PRIORITY.pane`). The
+	// master's dependency-graph drawer now ALSO composes in the escape stack
+	// (ItemDetail routes both embedded + non-embedded graphs through it — TASK-2174),
+	// so a graph drawer (master or pane) is the innermost layer `runTopEscape`
+	// closes first, with no uncoordinated window listener to double-close. Text
+	// edits and open modals/sheets win ESC first (the same guards the collection
+	// host applies).
 	function handleHostKeydown(e: KeyboardEvent) {
 		// A control that already handled this key (preventDefault) owns it.
 		if (e.defaultPrevented) return;
@@ -276,33 +286,11 @@
 		if (isTextEntryTarget(target)) return;
 		// A native <dialog> / role="dialog" sheet owns its own ESC.
 		if (document.querySelector('dialog[open], [role="dialog"]')) return;
-		// The MASTER's full-page (non-embedded) dependency-graph drawer keeps its
-		// OWN window ESC listener (ItemDetail, `!embedded`) that ignores
-		// preventDefault. Whenever one coexists with the pane, any ESC WE consume
-		// must ALSO `stopImmediatePropagation` so that listener can't double-close
-		// on the same keystroke — including auto-repeats of a held key, which its
-		// listener doesn't bail on either. The host's `<svelte:window>` listener is
-		// registered before it (that listener arms only when the graph opens), so
-		// this runs first and can suppress it. A master graph is a `.graph-drawer`
-		// OUTSIDE `.item-pane` (`closest`).
-		const hasMasterGraph = [...document.querySelectorAll('.graph-drawer')].some(
-			(g) => !g.closest('.item-pane'),
-		);
-		// A HELD key auto-repeats; only the initial physical press acts. Consume the
-		// repeats — and suppress the master graph's listener on them (checked BEFORE
-		// the deferral below) so a hold can't cascade the master graph closed after
-		// the first press already closed the innermost layer (Codex review).
+		// A HELD key auto-repeats; only the initial physical press acts.
 		if (e.repeat) {
 			e.preventDefault();
-			if (hasMasterGraph) e.stopImmediatePropagation();
 			return;
 		}
-		// Defer to the master graph's own listener ONLY when it's the FRONTMOST ESC
-		// concern (no pane graph drawer at ESCAPE_PRIORITY.graphDrawer is the top
-		// stack layer): one press closes just the master graph via that listener (no
-		// stopImmediatePropagation here, so it fires). When a pane graph IS the top
-		// layer it's innermost and must close first via `runTopEscape` below.
-		if (hasMasterGraph && topEscapePriority() !== ESCAPE_PRIORITY.graphDrawer) return;
 		// Detached pane (depth>0): pop exactly one drill level, consume the key.
 		// Routed through the controller's fenced `handlePaneBack` (not a bare
 		// `history.back()`), gated on `paneNavInFlight()` — a rapid double ESC
@@ -319,21 +307,10 @@
 			}
 			return;
 		}
-		// Depth 0 (or a higher-priority layer): let the escape stack close exactly
-		// one layer, innermost-first (a pane graph drawer → the pane). No-op with
-		// no pane open (stack empty → returns false → native ESC untouched).
-		if (runTopEscape()) {
-			e.preventDefault();
-			// Case C (master graph + pane graph both open): `runTopEscape` just
-			// closed the innermost PANE graph. The MASTER graph's uncoordinated
-			// window listener ignores `preventDefault`, so stop it from ALSO closing
-			// on this same ESC — one layer per press. The host's `<svelte:window>`
-			// listener is registered before the master graph's (which arms only when
-			// that graph opens), so this runs first and can suppress it. Scoped to
-			// when a master graph actually exists so it never blocks unrelated window
-			// ESC listeners on the ordinary close path.
-			if (hasMasterGraph) e.stopImmediatePropagation();
-		}
+		// Otherwise let the escape stack close exactly one layer, innermost-first
+		// (a graph drawer → the pane). No-op with nothing registered (stack empty →
+		// returns false → native ESC untouched).
+		if (runTopEscape()) e.preventDefault();
 	}
 
 	onDestroy(() => {
@@ -370,7 +347,13 @@
 			{ref}
 			peeking={!!openItemRef}
 			onReady={(r) => (scrollReady = r)}
-			onIdentity={(id) => (masterIdentity = id)}
+			onIdentity={(id) => {
+				masterIdentity = id;
+				// Stamp the pathname this identity resolved FOR (see `masterItem`);
+				// `onIdentity` fires only once the loaded item matches the current
+				// URL, so `page.url.pathname` is that item's route here.
+				masterIdentityPathname = id ? page.url.pathname : null;
+			}}
 			onOpenTarget={handleMasterOpenTarget}
 		/>
 	</div>

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -209,23 +209,37 @@
 		return isSamePaneTarget({ href: candidate }, masterItem);
 	}
 
-	// Server confirmation for the UNCERTAIN case above. `null` = pending; the only
-	// way to know whether a ref/UUID-shaped master slug is preempted (target
-	// resolves to a different live item) or reached by the server's slug-fallback
-	// (target resolves to the master) is to resolve `?item=` to its actual item id
-	// and compare. Fires ONLY when `masterMatchSync` is null, so a normal
-	// plain-slug master never touches the network.
-	let confirmedTargetIsMaster = $state<boolean | null>(null);
-	let lastConfirmKey: string | null = null; // plain let: an effect edge tracker (CONVE-1688)
+	// The exact identity of an uncertain resolve — `wsSlug`, the master, and the
+	// candidate — so a stored result is only ever consumed for the target it was
+	// computed for.
+	function uncertainKey(candidate: string, master: PaneGuardItem): string {
+		return `${wsSlug}::${master.id}::${candidate}`;
+	}
+
+	// Server confirmation for the UNCERTAIN case above. The only way to know whether
+	// a ref/UUID-shaped master slug is preempted (target resolves to a different
+	// live item) or reached by the server's slug-fallback (target resolves to the
+	// master) is to resolve `?item=` to its actual item id and compare. Fires ONLY
+	// when `masterMatchSync` is null, so a normal plain-slug master never touches
+	// the network. The result is STAMPED with its `key`: a consumer treats a
+	// key-mismatch (stale result for a different target, or none yet) as pending —
+	// so a prior target's answer can't transiently leak to a new one (Codex review).
+	let confirmedTarget = $state<{ key: string; isMaster: boolean } | null>(null);
+	// Dedup: the key currently being fetched, a plain `let` NOT `$state` — the
+	// effect must not READ the reactive `confirmedTarget` it also writes (CONVE-1688
+	// self-invalidation). Cleared on cancel/complete so revisiting a cancelled key
+	// re-fetches instead of wedging. (A re-run for the same still-open uncertain
+	// target won't fire — the effect's reactive deps `openItemRef`/`masterItem` are
+	// stable then — so this dedup only guards a genuine in-flight duplicate.)
+	let inFlightKey: string | null = null;
 	$effect(() => {
 		const candidate = openItemRef;
 		const master = masterItem;
 		if (!browser || !candidate || !master) return;
 		if (masterMatchSync(candidate) !== null) return; // sync decided → no fetch
-		const key = `${wsSlug}::${master.id}::${candidate}`;
-		if (key === lastConfirmKey) return; // already resolved / in flight for this key
-		lastConfirmKey = key;
-		confirmedTargetIsMaster = null; // pending (not read in this effect → no self-invalidation)
+		const key = uncertainKey(candidate, master);
+		if (key === inFlightKey) return; // a fetch is already in flight for this exact key
+		inFlightKey = key;
 		let cancelled = false;
 		void (async () => {
 			let isMaster: boolean;
@@ -237,13 +251,22 @@
 				// direction for the forbidden D2 collision.
 				isMaster = true;
 			}
-			if (cancelled || key !== lastConfirmKey) return;
-			confirmedTargetIsMaster = isMaster;
+			if (inFlightKey === key) inFlightKey = null;
+			if (cancelled) return;
+			confirmedTarget = { key, isMaster };
 		})();
 		return () => {
 			cancelled = true;
+			if (inFlightKey === key) inFlightKey = null; // re-armable, never wedged
 		};
 	});
+
+	// The server-confirmed answer for the CURRENT uncertain `?item=`, or null when
+	// pending (no stamped result for this exact key yet).
+	function confirmedFor(candidate: string, master: PaneGuardItem): boolean | null {
+		const key = uncertainKey(candidate, master);
+		return confirmedTarget?.key === key ? confirmedTarget.isMaster : null;
+	}
 
 	// Does the CURRENT `?item=` alias the master, for the MOUNT gate? Blocks (true)
 	// while an uncertain resolve is pending — never mount a 2nd provider on the
@@ -252,7 +275,7 @@
 		const candidate = openItemRef;
 		if (!candidate || !masterItem) return false;
 		const sync = masterMatchSync(candidate);
-		return sync !== null ? sync : (confirmedTargetIsMaster ?? true);
+		return sync !== null ? sync : (confirmedFor(candidate, masterItem) ?? true);
 	});
 
 	// Does the CURRENT `?item=` alias the master, for the cold-load STRIP? Only
@@ -262,7 +285,7 @@
 		const candidate = openItemRef;
 		if (!candidate || !masterItem) return false;
 		const sync = masterMatchSync(candidate);
-		return sync !== null ? sync : (confirmedTargetIsMaster ?? false);
+		return sync !== null ? sync : (confirmedFor(candidate, masterItem) ?? false);
 	});
 
 	// Whether to MOUNT the pane. Gating the MOUNT (not merely stripping `?item=`
@@ -288,26 +311,28 @@
 	// master's room). The master's own <ItemDetail> `fireOpenTarget` already
 	// drops self-links against its loaded item; this is the host-side belt.
 	function handleMasterOpenTarget(target: PaneTarget) {
-		// `resolvePaneTarget(target, masterItem)` returns null BOTH when the target
-		// is unresolvable AND when it resolves to the master (the provenance-correct
-		// `isSamePaneTarget` self-guard). `masterMatchSync(resolved) === true`
-		// additionally drops a resolved segment that DEFINITELY aliases the master
-		// (e.g. its plain slug) up front. An UNCERTAIN ref/UUID-shaped-slug alias
-		// (`=== null`) is left for the mount gate's server-confirm to catch — never
-		// a collision, just a possible brief `?item=` flicker in that pathological
-		// case.
-		const resolved = resolvePaneTarget(target, masterItem);
+		// Resolve WITHOUT `resolvePaneTarget`'s `current` same-item guard — that guard
+		// is `isSamePaneTarget`, which over-blocks the same undecidable UUID-shaped-
+		// slug case (a UUID-shaped href equal to the master's slug is treated as self
+		// even when it's a different LIVE item — Codex review). Instead drop only a
+		// DEFINITE master alias here (`masterMatchSync(resolved) === true`); an
+		// UNCERTAIN alias (`=== null`) is left for the mount gate's server-confirm to
+		// catch — never a collision, just a possible brief `?item=` flicker in that
+		// pathological case. A master self-link resolves to the master's ref →
+		// `masterMatchSync` true → still dropped here.
+		const resolved = resolvePaneTarget(target);
 		if (!resolved || masterMatchSync(resolved) === true) return;
 		openItemPaneByRef(resolved);
 	}
 
 	// PANE content-links DRILL in place (PLAN-2154 Architecture A/B). A link
 	// clicked INSIDE the pane re-targets the pane with a back stack via
-	// `navigatePaneTo` — the same `resolvePaneTarget(target, masterItem)` drops a
-	// drill back onto the master (the pane's own `fireOpenTarget` already dropped
-	// drills to the pane's currently-shown item).
+	// `navigatePaneTo` — the same `masterMatchSync(resolved) === true` drop guards
+	// a drill back onto the master (resolved without the `isSamePaneTarget`
+	// same-item guard, for the same UUID-shaped-slug reason as above; the pane's
+	// own `fireOpenTarget` already dropped drills to the pane's shown item).
 	function guardedDrill(target: PaneTarget) {
-		const resolved = resolvePaneTarget(target, masterItem);
+		const resolved = resolvePaneTarget(target);
 		if (!resolved || masterMatchSync(resolved) === true) return;
 		navigatePaneTo(resolved);
 	}

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -61,19 +61,24 @@
 	let masterIdentity = $state<ResolvedItemIdentity | null>(null);
 	let masterIdentityPathname = $state<string | null>(null);
 
-	// Scroll restoration parks on the master's OWN `.item-page` overflow column
-	// (not the layout's `.main-content`), which is where the master content
-	// scrolls once the flex-row host is in place — pane open or not (PLAN-2154
-	// Architecture E / TASK-2171's `scrollTarget` getter). `.item-page` is the
-	// FIRST (ancestor) `.item-page` in document order, so `querySelector` resolves
-	// to this host's scroll column, not <ItemDetail>'s inner content wrapper of
-	// the same (Svelte-scoped, separately-styled) class name.
+	// The master's OWN `.item-page` overflow column element, bound directly so
+	// scroll restoration targets THIS host's scroll column — not the layout's
+	// `.main-content`, and not <ItemDetail>'s inner content wrapper which reuses
+	// the same `.item-page` class. Binding the element removes the global
+	// `querySelector('.item-page')` that would rely on ancestor DOM order to
+	// disambiguate the collision (orchestrator Codex review).
+	let itemPageEl = $state<HTMLElement | null>(null);
+
+	// Scroll restoration parks on the master's own `.item-page` overflow column,
+	// which is where the master content scrolls once the flex-row host is in place
+	// — pane open or not (PLAN-2154 Architecture E / TASK-2171's `scrollTarget`
+	// getter). Returns the BOUND element (null before mount → restore.svelte.ts
+	// retries per frame).
 	const scrollRestoration = createScrollRestoration({
 		ready: () => scrollReady,
 		persistKey: () =>
 			wsSlug ? `pad-last-scroll-${wsSlug}-${page.url.pathname}` : null,
-		scrollTarget: () =>
-			browser ? document.querySelector<HTMLElement>('.item-page') : null,
+		scrollTarget: () => itemPageEl,
 	});
 	export const snapshot = scrollRestoration.snapshot;
 
@@ -175,12 +180,22 @@
 	});
 
 	// The forbidden `?item == master` collision (PLAN-2154 D2 / Architecture E)
-	// for a BARE `?item=` string (the cold-load strip + the mount gate). Wrap the
-	// value as an href-channel target so `isSamePaneTarget` applies the server's
-	// ref-before-slug resolution order (ref-shaped → item-NUMBER match, else slug,
-	// plus id) — the documented "bare `?item=` value" contract. `false` while the
-	// master identity is unresolved (`masterItem` null).
+	// for a BARE `?item=` string (the cold-load strip + the mount gate + a resolved
+	// content-link ref). The server resolves a bare/href `?item=` REF-FIRST, then
+	// falls back to SLUG (internal/store/items.go). So a candidate aliases the
+	// master if it matches under EITHER interpretation: the ref-number channel
+	// (`isSamePaneTarget`'s href resolution) OR the RAW string equal to the
+	// master's id / slug — INCLUDING a ref-shaped slug (e.g. master #5 slugged
+	// `plan-6` with no live #6, which the server resolves to the master by the slug
+	// fallback; the ref-number channel alone would miss it, 6≠5). Erring toward a
+	// match is the safe direction for the forbidden D2 collision — never mount a
+	// 2nd provider on the master's own collab room (orchestrator Codex review). The
+	// rare cost is over-blocking a hand-crafted `?item=<ref-shaped-slug>` when a
+	// live item at that number DOES exist; that merely declines to open a pane (no
+	// collision, no data loss). `false` while the master identity is unresolved.
 	function isMasterRef(candidate: string): boolean {
+		if (!masterItem) return false;
+		if (candidate === masterItem.id || candidate === masterItem.slug) return true;
 		return isSamePaneTarget({ href: candidate }, masterItem);
 	}
 
@@ -209,9 +224,12 @@
 	function handleMasterOpenTarget(target: PaneTarget) {
 		// `resolvePaneTarget(target, masterItem)` returns null BOTH when the target
 		// is unresolvable AND when it resolves to the master (the provenance-correct
-		// `isSamePaneTarget` self-guard), so a master self-link is a clean no-op.
+		// `isSamePaneTarget` self-guard). The extra `isMasterRef(resolved)` closes
+		// the ref-shaped-slug hole for an href-only editor link whose resolved
+		// segment string-equals the master slug (server slug-fallback) — dropping it
+		// at the source instead of relying on the mount gate + strip to catch it.
 		const resolved = resolvePaneTarget(target, masterItem);
-		if (!resolved) return;
+		if (!resolved || isMasterRef(resolved)) return;
 		openItemPaneByRef(resolved);
 	}
 
@@ -222,7 +240,7 @@
 	// drills to the pane's currently-shown item).
 	function guardedDrill(target: PaneTarget) {
 		const resolved = resolvePaneTarget(target, masterItem);
-		if (!resolved) return;
+		if (!resolved || isMasterRef(resolved)) return;
 		navigatePaneTo(resolved);
 	}
 
@@ -339,7 +357,7 @@
 	<!-- inert on the MOBILE overlay: the pane covers the viewport, so isolate the
 	     master from BOTH focus order and the SR tree behind it. Desktop keeps the
 	     master fully reachable (it's beside the pane, not behind it). -->
-	<div class="item-page" inert={viewport.isMobile && !!openItemRef}>
+	<div class="item-page" bind:this={itemPageEl} inert={viewport.isMobile && !!openItemRef}>
 		<ItemDetail
 			{username}
 			{wsSlug}

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -127,18 +127,49 @@
 		clearPaneGo,
 	} = paneController;
 
-	// The forbidden `?item == master` collision (PLAN-2154 D2 / Architecture E).
-	// True when a resolved pane ref names the MASTER item itself — by its
-	// canonical ref, its slug, or its id (so a slug-path/ref-query alias is
-	// caught). Never fires until the master's identity resolves.
-	function isMaster(candidate: string): boolean {
-		return (
-			!!masterIdentity &&
-			(candidate === masterIdentity.ref ||
-				candidate === masterIdentity.slug ||
-				candidate === masterIdentity.id)
-		);
+	// Parse a ref-shaped candidate's item NUMBER — mirrors
+	// `$lib/collections/paneTarget`'s private `parseRefNumber` (case-insensitive
+	// LETTERS-only prefix, hyphen, positive integer). Null for a non-ref-shaped
+	// string or a zero/non-finite number.
+	function refNumber(candidate: string): number | null {
+		const m = /^([A-Za-z]+)-(\d+)$/.exec(candidate);
+		if (!m) return null;
+		const n = Number(m[2]);
+		return Number.isFinite(n) && n > 0 ? n : null;
 	}
+
+	// The forbidden `?item == master` collision (PLAN-2154 D2 / Architecture E).
+	// True when a candidate names the MASTER item itself — by its id, its slug,
+	// its canonical ref, OR (mirroring the server's case-insensitive, item-number
+	// resolution the way `isSamePaneTarget`'s `matchesRefNumber` does) any
+	// ref-shaped alias that resolves to the same item NUMBER. So a hand-crafted
+	// `?item=doc-5` / `DOC-005` / a stale pre-move prefix that all resolve to the
+	// master are caught too, not just the byte-exact canonical ref. Never fires
+	// until the master's identity resolves.
+	function isMaster(candidate: string): boolean {
+		if (!masterIdentity) return false;
+		if (
+			candidate === masterIdentity.id ||
+			candidate === masterIdentity.slug ||
+			candidate === masterIdentity.ref
+		) {
+			return true;
+		}
+		const n = refNumber(candidate);
+		return n !== null && n === refNumber(masterIdentity.ref);
+	}
+
+	// Whether to MOUNT the pane. Gating the MOUNT (not merely stripping `?item=`
+	// after the fact) closes the cold-load self-collision RACE (Codex review): on
+	// a cold `?item=` load the master identity is unresolved for a beat, and a
+	// `?item=` that turns out to alias the master would otherwise mount
+	// `PaneHost`/`ItemDetail` and mint a SECOND collab provider on the master's
+	// own room BEFORE the strip effect's `goto` removes the query. So the pane
+	// mounts only once identity has resolved AND confirmed the target isn't the
+	// master. For a CLICK-driven open the master identity is already resolved, so
+	// there is no delay; only a cold `?item=` load waits one master-load beat
+	// (master-first, which is the correct order anyway).
+	let showPane = $derived(!!openItemRef && !!masterIdentity && !isMaster(openItemRef));
 
 	// MASTER content-links FIRST-OPEN the pane (PLAN-2154 D3 / Architecture E).
 	// The master's relationship / child / wiki-link / graph surfaces hand up a
@@ -222,6 +253,18 @@
 		if (isTextEntryTarget(target)) return;
 		// A native <dialog> / role="dialog" sheet owns its own ESC.
 		if (document.querySelector('dialog[open], [role="dialog"]')) return;
+		// The MASTER's full-page (non-embedded) dependency-graph drawer keeps its
+		// OWN window ESC listener (ItemDetail, `!embedded`) — NOT the shared escape
+		// stack. If it's open (e.g. a pane was opened from a master graph node's
+		// "Open" anchor, leaving the graph up), defer this ESC to that listener so
+		// one press closes ONLY the graph, not the graph AND the pane (Codex
+		// review). The PANE's OWN (embedded) graph drawer registers in the escape
+		// stack at the higher `graphDrawer` priority and is closed correctly by
+		// `runTopEscape` below, so this bail is scoped to a `.graph-drawer` OUTSIDE
+		// `.item-pane` (a master graph) via `closest`.
+		for (const g of document.querySelectorAll('.graph-drawer')) {
+			if (!g.closest('.item-pane')) return;
+		}
 		// A HELD key auto-repeats; only the initial physical press acts.
 		if (e.repeat) {
 			e.preventDefault();
@@ -287,7 +330,7 @@
 			onOpenTarget={handleMasterOpenTarget}
 		/>
 	</div>
-	{#if openItemRef}
+	{#if showPane}
 		<PaneHost
 			bind:this={paneHostEl}
 			{openItemRef}

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -9,6 +9,7 @@
 	import { createPaneController } from '$lib/collections/paneHostController';
 	import { createPaneMintSettle, PANE_MINT_SETTLE_MS } from '$lib/collections/paneMintSettle';
 	import { resolvePaneTarget, isSamePaneTarget, type PaneGuardItem } from '$lib/collections/paneTarget';
+	import { api } from '$lib/api/client';
 	import { viewport } from '$lib/stores/breakpoint.svelte';
 	import { runTopEscape, topEscapePriority, ESCAPE_PRIORITY } from '$lib/stores/escapeStack';
 	import type { PaneTarget, ResolvedItemIdentity } from '$lib/types';
@@ -179,36 +180,90 @@
 		};
 	});
 
-	// A canonical item-UUID shape (`GetItemByRef`'s FIRST resolution branch —
-	// internal/store/items.go). Used to mirror the server's UUID-first precedence
-	// in `isMasterRef` below.
+	// Item-identifier SHAPES the server resolves a bare `?item=` by, in precedence
+	// order (`GetItemByRef` — internal/store/items.go): a canonical UUID, then a
+	// PREFIX-NUMBER ref, then a slug.
 	const UUID_SHAPE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+	const REF_SHAPE = /^[A-Za-z]+-\d+$/;
 
-	// The forbidden `?item == master` collision (PLAN-2154 D2 / Architecture E)
-	// for a BARE `?item=` string (the cold-load strip + the mount gate + a resolved
-	// content-link ref). Mirrors the server's resolution PRECEDENCE — UUID-first,
-	// then ref (by NUMBER), then slug (internal/store/items.go) — as closely as a
-	// client can WITHOUT knowing which items exist:
-	//   1. an exact id match is always the master (UUID-first);
-	//   2. a UUID-SHAPED candidate that ISN'T the master's id resolves UUID-first
-	//      to a DIFFERENT item (UUIDs are assigned, not title-derived), so we do
-	//      NOT fall through to a slug compare — otherwise `?item=<another item's
-	//      UUID>` would be over-blocked whenever the master's slug coincidentally
-	//      equals it (orchestrator Codex round-8 verify);
-	//   3. otherwise match the ref NUMBER (`isSamePaneTarget`'s href channel) OR
-	//      the RAW slug string — so a ref-shaped SLUG the server reaches by its
-	//      slug-fallback (e.g. master #5 slugged `plan-6` with no live #6, 6≠5) is
-	//      caught, the forbidden D2 collision's safe direction.
-	// The only residual over-block is a hand-crafted `?item=<ref-shaped-slug>` when
-	// a live item at that number DOES exist — benign (declines to open a pane; no
-	// collision, no data loss). `false` while the master identity is unresolved.
-	function isMasterRef(candidate: string): boolean {
+	// SYNCHRONOUS `?item == master` decision (PLAN-2154 D2 / Architecture E) —
+	// `true` (definite master), `false` (definite non-master), or `null` when the
+	// answer can't be settled from the master identity ALONE and needs a server
+	// resolve. Mirrors the server's UUID-first → ref-by-NUMBER → slug precedence:
+	//   • exact id → master (UUID-first);
+	//   • candidate === master.slug: a PLAIN slug can't be preempted by a UUID/ref
+	//     lookup → definite master; but a ref/UUID-SHAPED slug MIGHT resolve
+	//     UUID/ref-first to a DIFFERENT LIVE item — OR fall back to the master when
+	//     that item is absent/archived/cross-workspace — which shape alone cannot
+	//     decide → `null` (server-confirm below). This is the ONLY network path,
+	//     and it's reached only for a pathological ref/UUID-shaped master slug;
+	//     a normal plain-slug master is always decided synchronously here.
+	//   • otherwise the ref-NUMBER channel (`isSamePaneTarget`'s href resolution)
+	//     is definite (ref numbers are workspace-unique).
+	function masterMatchSync(candidate: string): boolean | null {
 		if (!masterItem) return false;
 		if (candidate === masterItem.id) return true;
-		if (UUID_SHAPE.test(candidate)) return false;
-		if (candidate === masterItem.slug) return true;
+		if (candidate === masterItem.slug) {
+			return UUID_SHAPE.test(candidate) || REF_SHAPE.test(candidate) ? null : true;
+		}
 		return isSamePaneTarget({ href: candidate }, masterItem);
 	}
+
+	// Server confirmation for the UNCERTAIN case above. `null` = pending; the only
+	// way to know whether a ref/UUID-shaped master slug is preempted (target
+	// resolves to a different live item) or reached by the server's slug-fallback
+	// (target resolves to the master) is to resolve `?item=` to its actual item id
+	// and compare. Fires ONLY when `masterMatchSync` is null, so a normal
+	// plain-slug master never touches the network.
+	let confirmedTargetIsMaster = $state<boolean | null>(null);
+	let lastConfirmKey: string | null = null; // plain let: an effect edge tracker (CONVE-1688)
+	$effect(() => {
+		const candidate = openItemRef;
+		const master = masterItem;
+		if (!browser || !candidate || !master) return;
+		if (masterMatchSync(candidate) !== null) return; // sync decided → no fetch
+		const key = `${wsSlug}::${master.id}::${candidate}`;
+		if (key === lastConfirmKey) return; // already resolved / in flight for this key
+		lastConfirmKey = key;
+		confirmedTargetIsMaster = null; // pending (not read in this effect → no self-invalidation)
+		let cancelled = false;
+		void (async () => {
+			let isMaster: boolean;
+			try {
+				const resolved = await api.items.get(wsSlug, candidate);
+				isMaster = resolved?.id === master.id;
+			} catch {
+				// Resolve failed (network / not-found) — err toward BLOCKING, the safe
+				// direction for the forbidden D2 collision.
+				isMaster = true;
+			}
+			if (cancelled || key !== lastConfirmKey) return;
+			confirmedTargetIsMaster = isMaster;
+		})();
+		return () => {
+			cancelled = true;
+		};
+	});
+
+	// Does the CURRENT `?item=` alias the master, for the MOUNT gate? Blocks (true)
+	// while an uncertain resolve is pending — never mount a 2nd provider on the
+	// master's own room before we're sure it ISN'T the master.
+	let openTargetBlocksMount = $derived.by(() => {
+		const candidate = openItemRef;
+		if (!candidate || !masterItem) return false;
+		const sync = masterMatchSync(candidate);
+		return sync !== null ? sync : (confirmedTargetIsMaster ?? true);
+	});
+
+	// Does the CURRENT `?item=` alias the master, for the cold-load STRIP? Only
+	// strips once DEFINITELY the master — a pending resolve does NOT strip (never
+	// delete a `?item=` that might still resolve to a DIFFERENT item).
+	let openTargetIsMaster = $derived.by(() => {
+		const candidate = openItemRef;
+		if (!candidate || !masterItem) return false;
+		const sync = masterMatchSync(candidate);
+		return sync !== null ? sync : (confirmedTargetIsMaster ?? false);
+	});
 
 	// Whether to MOUNT the pane. Gating the MOUNT (not merely stripping `?item=`
 	// after the fact) closes the cold-load self-collision RACE (Codex review): on
@@ -222,7 +277,7 @@
 	// CLICK-driven open the master identity is already resolved (and `ref` is
 	// unchanged), so there is no delay; only a cold `?item=` load or a master
 	// navigation waits one master-load beat (master-first, the correct order).
-	let showPane = $derived(!!openItemRef && !!masterItem && !isMasterRef(openItemRef));
+	let showPane = $derived(!!openItemRef && !!masterItem && !openTargetBlocksMount);
 
 	// MASTER content-links FIRST-OPEN the pane (PLAN-2154 D3 / Architecture E).
 	// The master's relationship / child / wiki-link / graph surfaces hand up a
@@ -235,12 +290,14 @@
 	function handleMasterOpenTarget(target: PaneTarget) {
 		// `resolvePaneTarget(target, masterItem)` returns null BOTH when the target
 		// is unresolvable AND when it resolves to the master (the provenance-correct
-		// `isSamePaneTarget` self-guard). The extra `isMasterRef(resolved)` closes
-		// the ref-shaped-slug hole for an href-only editor link whose resolved
-		// segment string-equals the master slug (server slug-fallback) — dropping it
-		// at the source instead of relying on the mount gate + strip to catch it.
+		// `isSamePaneTarget` self-guard). `masterMatchSync(resolved) === true`
+		// additionally drops a resolved segment that DEFINITELY aliases the master
+		// (e.g. its plain slug) up front. An UNCERTAIN ref/UUID-shaped-slug alias
+		// (`=== null`) is left for the mount gate's server-confirm to catch — never
+		// a collision, just a possible brief `?item=` flicker in that pathological
+		// case.
 		const resolved = resolvePaneTarget(target, masterItem);
-		if (!resolved || isMasterRef(resolved)) return;
+		if (!resolved || masterMatchSync(resolved) === true) return;
 		openItemPaneByRef(resolved);
 	}
 
@@ -251,24 +308,23 @@
 	// drills to the pane's currently-shown item).
 	function guardedDrill(target: PaneTarget) {
 		const resolved = resolvePaneTarget(target, masterItem);
-		if (!resolved || isMasterRef(resolved)) return;
+		if (!resolved || masterMatchSync(resolved) === true) return;
 		navigatePaneTo(resolved);
 	}
 
 	// Cold-load strip (PLAN-2154 Architecture E). A hand-crafted / shared
 	// `?item=<the master's own ref>` URL must NOT mount a pane on the master
-	// itself (two providers, one room, one shared itemID-only cursor). Once the
-	// master's identity resolves, strip `?item=` in place if it aliases the
-	// master. Reads `masterIdentity`/`openItemRef` and WRITES neither (only a
-	// `goto` — CONVE-1688 safe); the strip drops `?item=`, `openItemRef`
-	// recomputes to null, and the effect re-runs to a no-op (settles, no loop).
-	// It can't fight the controller: `isMaster` only ever matches the master, so
-	// a legitimately-opened pane (always a non-master ref) is never touched.
+	// itself (two providers, one room, one shared itemID-only cursor). Strip
+	// `?item=` in place once it's DEFINITELY the master (`openTargetIsMaster` —
+	// which waits for the server-confirm on a pathological ref/UUID-shaped-slug
+	// master rather than stripping a `?item=` that might still resolve elsewhere).
+	// Reads reactive state and WRITES none of it (only a `goto` — CONVE-1688
+	// safe); the strip drops `?item=`, `openItemRef` recomputes to null, and the
+	// effect re-runs to a no-op (settles, no loop). It can't fight the controller:
+	// a legitimately-opened pane (a confirmed non-master ref) is never touched.
 	$effect(() => {
 		if (!browser) return;
-		if (!masterItem) return;
-		const current = openItemRef;
-		if (!current || !isMasterRef(current)) return;
+		if (!openTargetIsMaster) return;
 		const url = new URL(page.url);
 		url.searchParams.delete('item');
 		void goto(`${url.pathname}${url.search}`, {

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -8,7 +8,7 @@
 	import { createScrollRestoration } from '$lib/scroll/restore.svelte';
 	import { createPaneController } from '$lib/collections/paneHostController';
 	import { createPaneMintSettle, PANE_MINT_SETTLE_MS } from '$lib/collections/paneMintSettle';
-	import { resolvePaneTarget } from '$lib/collections/paneTarget';
+	import { resolvePaneTarget, isSamePaneTarget, type PaneGuardItem } from '$lib/collections/paneTarget';
 	import { viewport } from '$lib/stores/breakpoint.svelte';
 	import { runTopEscape, topEscapePriority, ESCAPE_PRIORITY } from '$lib/stores/escapeStack';
 	import type { PaneTarget, ResolvedItemIdentity } from '$lib/types';
@@ -127,10 +127,9 @@
 		clearPaneGo,
 	} = paneController;
 
-	// Parse a ref-shaped candidate's item NUMBER — mirrors
-	// `$lib/collections/paneTarget`'s private `parseRefNumber` (case-insensitive
-	// LETTERS-only prefix, hyphen, positive integer). Null for a non-ref-shaped
-	// string or a zero/non-finite number.
+	// Parse a ref-shaped candidate's item NUMBER (mirrors paneTarget's private
+	// `parseRefNumber`) — used only to derive `masterItem.item_number` from the
+	// master's canonical ref below.
 	function refNumber(candidate: string): number | null {
 		const m = /^([A-Za-z]+)-(\d+)$/.exec(candidate);
 		if (!m) return null;
@@ -138,25 +137,33 @@
 		return Number.isFinite(n) && n > 0 ? n : null;
 	}
 
-	// The forbidden `?item == master` collision (PLAN-2154 D2 / Architecture E).
-	// True when a candidate names the MASTER item itself — by its id, its slug,
-	// its canonical ref, OR (mirroring the server's case-insensitive, item-number
-	// resolution the way `isSamePaneTarget`'s `matchesRefNumber` does) any
-	// ref-shaped alias that resolves to the same item NUMBER. So a hand-crafted
-	// `?item=doc-5` / `DOC-005` / a stale pre-move prefix that all resolve to the
-	// master are caught too, not just the byte-exact canonical ref. Never fires
-	// until the master's identity resolves.
-	function isMaster(candidate: string): boolean {
-		if (!masterIdentity) return false;
-		if (
-			candidate === masterIdentity.id ||
-			candidate === masterIdentity.slug ||
-			candidate === masterIdentity.ref
-		) {
-			return true;
-		}
-		const n = refNumber(candidate);
-		return n !== null && n === refNumber(masterIdentity.ref);
+	// The master projected into the minimal identity the same-item guard reads
+	// (`id` / `slug` / `item_number`), built from `onIdentity`'s {id, ref, slug}
+	// with `item_number` parsed from the canonical `ref`. Reusing the SHARED,
+	// unit-tested `isSamePaneTarget` / `resolvePaneTarget` (rather than a
+	// hand-rolled compare) is what keeps the `?item == master` guard
+	// PROVENANCE-CORRECT: a bare `?item=` value resolves REF-BEFORE-SLUG the same
+	// way the server does, so a ref-shaped SLUG (e.g. master #5 slugged `plan-6`)
+	// is NOT mistaken for the master when `?item=plan-6` actually resolves to
+	// item #6 (Codex review).
+	let masterItem = $derived<PaneGuardItem | null>(
+		masterIdentity
+			? {
+					id: masterIdentity.id,
+					slug: masterIdentity.slug,
+					item_number: refNumber(masterIdentity.ref) ?? 0,
+				}
+			: null,
+	);
+
+	// The forbidden `?item == master` collision (PLAN-2154 D2 / Architecture E)
+	// for a BARE `?item=` string (the cold-load strip + the mount gate). Wrap the
+	// value as an href-channel target so `isSamePaneTarget` applies the server's
+	// ref-before-slug resolution order (ref-shaped → item-NUMBER match, else slug,
+	// plus id) — the documented "bare `?item=` value" contract. `false` while the
+	// master identity is unresolved (`masterItem` null).
+	function isMasterRef(candidate: string): boolean {
+		return isSamePaneTarget({ href: candidate }, masterItem);
 	}
 
 	// Whether to MOUNT the pane. Gating the MOUNT (not merely stripping `?item=`
@@ -169,7 +176,7 @@
 	// master. For a CLICK-driven open the master identity is already resolved, so
 	// there is no delay; only a cold `?item=` load waits one master-load beat
 	// (master-first, which is the correct order anyway).
-	let showPane = $derived(!!openItemRef && !!masterIdentity && !isMaster(openItemRef));
+	let showPane = $derived(!!openItemRef && !!masterIdentity && !isMasterRef(openItemRef));
 
 	// MASTER content-links FIRST-OPEN the pane (PLAN-2154 D3 / Architecture E).
 	// The master's relationship / child / wiki-link / graph surfaces hand up a
@@ -180,20 +187,22 @@
 	// master's room). The master's own <ItemDetail> `fireOpenTarget` already
 	// drops self-links against its loaded item; this is the host-side belt.
 	function handleMasterOpenTarget(target: PaneTarget) {
-		const resolved = resolvePaneTarget(target);
+		// `resolvePaneTarget(target, masterItem)` returns null BOTH when the target
+		// is unresolvable AND when it resolves to the master (the provenance-correct
+		// `isSamePaneTarget` self-guard), so a master self-link is a clean no-op.
+		const resolved = resolvePaneTarget(target, masterItem);
 		if (!resolved) return;
-		if (isMaster(resolved)) return;
 		openItemPaneByRef(resolved);
 	}
 
 	// PANE content-links DRILL in place (PLAN-2154 Architecture A/B). A link
 	// clicked INSIDE the pane re-targets the pane with a back stack via
-	// `navigatePaneTo` — the same-item guard drops a self-referential drill, and
-	// the `?item == master` guard drops one back onto the master.
+	// `navigatePaneTo` — the same `resolvePaneTarget(target, masterItem)` drops a
+	// drill back onto the master (the pane's own `fireOpenTarget` already dropped
+	// drills to the pane's currently-shown item).
 	function guardedDrill(target: PaneTarget) {
-		const resolved = resolvePaneTarget(target);
+		const resolved = resolvePaneTarget(target, masterItem);
 		if (!resolved) return;
-		if (isMaster(resolved)) return;
 		navigatePaneTo(resolved);
 	}
 
@@ -210,7 +219,7 @@
 		if (!browser) return;
 		if (!masterIdentity) return;
 		const current = openItemRef;
-		if (!current || !isMaster(current)) return;
+		if (!current || !isMasterRef(current)) return;
 		const url = new URL(page.url);
 		url.searchParams.delete('item');
 		void goto(`${url.pathname}${url.search}`, {
@@ -258,13 +267,17 @@
 		// stack. If it's open (e.g. a pane was opened from a master graph node's
 		// "Open" anchor, leaving the graph up), defer this ESC to that listener so
 		// one press closes ONLY the graph, not the graph AND the pane (Codex
-		// review). The PANE's OWN (embedded) graph drawer registers in the escape
-		// stack at the higher `graphDrawer` priority and is closed correctly by
-		// `runTopEscape` below, so this bail is scoped to a `.graph-drawer` OUTSIDE
-		// `.item-pane` (a master graph) via `closest`.
-		for (const g of document.querySelectorAll('.graph-drawer')) {
-			if (!g.closest('.item-pane')) return;
-		}
+		// review) — BUT only when the master graph is the FRONTMOST ESC concern.
+		// The PANE's OWN (embedded) graph drawer registers in the escape stack at
+		// the higher `graphDrawer` priority; when it's the top layer it is innermost
+		// and must close first via `runTopEscape` below, so we do NOT bail then (its
+		// own listener will still fire on the master graph — an inherent limit of
+		// that standalone listener — but at least the innermost layer closes). The
+		// master graph is a `.graph-drawer` OUTSIDE `.item-pane` (`closest`).
+		const hasMasterGraph = [...document.querySelectorAll('.graph-drawer')].some(
+			(g) => !g.closest('.item-pane'),
+		);
+		if (hasMasterGraph && topEscapePriority() !== ESCAPE_PRIORITY.graphDrawer) return;
 		// A HELD key auto-repeats; only the initial physical press acts.
 		if (e.repeat) {
 			e.preventDefault();

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -1,47 +1,330 @@
 <script lang="ts">
 	import { page } from '$app/state';
+	import { goto, afterNavigate } from '$app/navigation';
+	import { browser } from '$app/environment';
+	import { onDestroy } from 'svelte';
 	import ItemDetail from '$lib/components/items/ItemDetail.svelte';
+	import PaneHost from '$lib/components/collections/PaneHost.svelte';
 	import { createScrollRestoration } from '$lib/scroll/restore.svelte';
+	import { createPaneController } from '$lib/collections/paneHostController';
+	import { createPaneMintSettle, PANE_MINT_SETTLE_MS } from '$lib/collections/paneMintSettle';
+	import { resolvePaneTarget } from '$lib/collections/paneTarget';
+	import { viewport } from '$lib/stores/breakpoint.svelte';
+	import { runTopEscape, topEscapePriority, ESCAPE_PRIORITY } from '$lib/stores/escapeStack';
+	import type { PaneTarget, ResolvedItemIdentity } from '$lib/types';
 
-	// Thin route wrapper (PLAN-2105 / TASK-2106). The item body now lives in
-	// the shared, embeddable <ItemDetail> component. This wrapper renders it
-	// full-page (embedded defaults false), so behavior is byte-identical to
-	// before the extraction, and owns the SvelteKit route-module concern that
-	// cannot live in a child component:
+	// Full-page pane HOST (PLAN-2154 Phase 2 / Architecture E, bullet 5 /
+	// TASK-2174 — the Q1 payoff). This route was a 47-line wrapper that rendered
+	// the item body full-page via the shared, embeddable <ItemDetail>; it now
+	// mounts the SAME right-docked detail pane the collection page carries beside
+	// the master, so clicking a child / related / wiki-linked item inside the
+	// full-page item opens a navigable mini-browser pane WITHOUT leaving the
+	// master.
 	//
-	//   `export const snapshot` — scroll-position restoration wired through
-	//   the route's snapshot API (BUG-1425). ItemDetail reports readiness (its
-	//   loaded item matching the URL ref) via onReady, so the parked scroll
-	//   offset un-parks only once the right item has rendered. The persistKey
-	//   still keys on the item route's pathname, exactly as before.
+	// The MASTER ref is the `[slug]` PATH param; the pane ref is the `?item=`
+	// QUERY param — no collision (the two live in different parts of the URL).
+	// The forbidden case (`?item=` resolving to the MASTER itself — two collab
+	// providers on one room sharing the itemID-only sessionStorage cursor) is
+	// guarded on BOTH the open/drill paths AND stripped on cold load once the
+	// master's identity resolves (`isMaster` + the strip effect below).
 	//
-	// Route-away callbacks (onClose/onGone/onNavigateAway) are intentionally
-	// NOT passed here — ItemDetail's embedded=false defaults reproduce the
-	// original in-component `goto`s. The pane surface wires them (TASK-2107).
+	// This host MIRRORS the collection page's pane wiring (same `PaneHost`, same
+	// `createPaneController`, same `paneMint` settle, same depth-aware ESC via the
+	// shared escape stack) but DROPS everything collection-specific: there is no
+	// list, so no j/k pane-follow, no `focusedItemId` highlight, and no list-row
+	// focus-return — the controller's `cancelFollow` / `captureReturnFocus` /
+	// `setBypassNavGuard` deps are correctly no-ops here.
 
 	let wsSlug = $derived(page.params.workspace ?? '');
 	let username = $derived(page.params.username ?? '');
 	let collSlug = $derived(page.params.collection ?? '');
 	let ref = $derived(page.params.slug ?? '');
 
-	// Threaded up from ItemDetail: true once its loaded item matches the URL
-	// ref (see ItemDetail's scrollReady). Parks the snapshot restore until the
-	// child's content is the URL's content — matching the pre-extraction
-	// `ready()` predicate that read item/loading/itemSlug directly.
+	// The pane's single URL truth — the `?item=` query param (the master is the
+	// `[slug]` path param, so the two never collide). Mounts the pane below via
+	// `{#if openItemRef}`; the actual <ItemDetail> `ref` keys off the coalesced
+	// `paneMintForRoute` (TASK-2166), never this raw value.
+	let openItemRef = $derived(page.url.searchParams.get('item'));
+
+	// Threaded up from the MASTER ItemDetail: true once its loaded item matches
+	// the URL ref. Parks the snapshot scroll restore until the master's content
+	// is the URL's content (matching the pre-extraction `ready()` predicate).
 	let scrollReady = $state(false);
 
+	// The MASTER's resolved {id, ref, slug} identity (TASK-2173), captured via
+	// `onIdentity`. Drives the `?item == master` guard so a slug-path master and
+	// a ref-query `?item=` (or vice versa) that alias the SAME item are caught.
+	// `null` until the master's loaded item matches its URL ref.
+	let masterIdentity = $state<ResolvedItemIdentity | null>(null);
+
+	// Scroll restoration parks on the master's OWN `.item-page` overflow column
+	// (not the layout's `.main-content`), which is where the master content
+	// scrolls once the flex-row host is in place — pane open or not (PLAN-2154
+	// Architecture E / TASK-2171's `scrollTarget` getter). `.item-page` is the
+	// FIRST (ancestor) `.item-page` in document order, so `querySelector` resolves
+	// to this host's scroll column, not <ItemDetail>'s inner content wrapper of
+	// the same (Svelte-scoped, separately-styled) class name.
 	const scrollRestoration = createScrollRestoration({
 		ready: () => scrollReady,
 		persistKey: () =>
 			wsSlug ? `pad-last-scroll-${wsSlug}-${page.url.pathname}` : null,
+		scrollTarget: () =>
+			browser ? document.querySelector<HTMLElement>('.item-page') : null,
 	});
 	export const snapshot = scrollRestoration.snapshot;
+
+	// ── Provider-mint settle (PLAN-2154 Architecture D / TASK-2166) ────────
+	// Replicated verbatim from the collection host. `openItemRef` is the immediate
+	// URL truth (mount boundary, focus, guards); the pane's <ItemDetail> `ref`
+	// PROP re-drives loadData/collabKey (destroy + fresh-mint the Y.Doc/WS
+	// provider), so it settles a same-pathname popstate burst (held Back/Forward)
+	// down to ONE mint via `paneMintForRoute`. `paneMintForRoute` falls back to
+	// the live `openItemRef` the instant the pathname diverges (a genuine route
+	// change), so a stale settling ref can't pair against a new route.
+	let paneMintRef = $state<string | null>(page.url.searchParams.get('item'));
+	let paneMintPathname: string = page.url.pathname;
+	const paneMintSettle = createPaneMintSettle({
+		settleMs: PANE_MINT_SETTLE_MS,
+		onSettle: (r) => {
+			paneMintRef = r;
+		},
+	});
+	afterNavigate((nav) => {
+		const samePathname =
+			!!nav.from && nav.to?.url.pathname === nav.from.url.pathname;
+		const effectiveType = samePathname ? nav.type : 'goto';
+		paneMintPathname = nav.to?.url.pathname ?? paneMintPathname;
+		paneMintSettle.onNavigate(effectiveType, nav.to?.url.searchParams.get('item') ?? null);
+	});
+	let paneMintForRoute = $derived(
+		page.url.pathname === paneMintPathname ? paneMintRef : openItemRef,
+	);
+
+	// The PaneHost shell instance — bound once it mounts (i.e. the pane is open).
+	// The controller's `focusPaneRegion` dep resolves it lazily at hop time.
+	let paneHostEl = $state<PaneHost | undefined>();
+
+	// ── Pane-navigation controller (PLAN-2154 Architecture A/E) ────────────
+	// The SAME controller the collection page mounts — one depth/ownership state
+	// machine, one three-way close. The full-page host has NO list, so the
+	// collection-specific deps are no-ops: no j/k follow to cancel, no list-row
+	// focus to capture/return, no unsaved-draft leave guard.
+	const paneController = createPaneController({
+		getOpenItemRef: () => openItemRef,
+		cancelFollow: () => {},
+		focusPaneRegion: () => paneHostEl?.focusPaneRegion(),
+		captureReturnFocus: () => {},
+		setBypassNavGuard: () => {},
+	});
+	const {
+		openItemPaneByRef,
+		navigatePaneTo,
+		handlePaneBack,
+		handlePaneNavigateAway,
+		closeItemPane,
+		currentPaneState,
+		paneNavInFlight,
+		clearPaneGo,
+	} = paneController;
+
+	// The forbidden `?item == master` collision (PLAN-2154 D2 / Architecture E).
+	// True when a resolved pane ref names the MASTER item itself — by its
+	// canonical ref, its slug, or its id (so a slug-path/ref-query alias is
+	// caught). Never fires until the master's identity resolves.
+	function isMaster(candidate: string): boolean {
+		return (
+			!!masterIdentity &&
+			(candidate === masterIdentity.ref ||
+				candidate === masterIdentity.slug ||
+				candidate === masterIdentity.id)
+		);
+	}
+
+	// MASTER content-links FIRST-OPEN the pane (PLAN-2154 D3 / Architecture E).
+	// The master's relationship / child / wiki-link / graph surfaces hand up a
+	// `PaneTarget`; a first-open is `openItemPane`-semantics (a depth-0
+	// `paneOwned:true` push), NOT a drill — so it routes through
+	// `openItemPaneByRef`, not `navigatePaneTo`. Guarded so a link naming the
+	// master itself is a clean no-op (never mount a second provider on the
+	// master's room). The master's own <ItemDetail> `fireOpenTarget` already
+	// drops self-links against its loaded item; this is the host-side belt.
+	function handleMasterOpenTarget(target: PaneTarget) {
+		const resolved = resolvePaneTarget(target);
+		if (!resolved) return;
+		if (isMaster(resolved)) return;
+		openItemPaneByRef(resolved);
+	}
+
+	// PANE content-links DRILL in place (PLAN-2154 Architecture A/B). A link
+	// clicked INSIDE the pane re-targets the pane with a back stack via
+	// `navigatePaneTo` — the same-item guard drops a self-referential drill, and
+	// the `?item == master` guard drops one back onto the master.
+	function guardedDrill(target: PaneTarget) {
+		const resolved = resolvePaneTarget(target);
+		if (!resolved) return;
+		if (isMaster(resolved)) return;
+		navigatePaneTo(resolved);
+	}
+
+	// Cold-load strip (PLAN-2154 Architecture E). A hand-crafted / shared
+	// `?item=<the master's own ref>` URL must NOT mount a pane on the master
+	// itself (two providers, one room, one shared itemID-only cursor). Once the
+	// master's identity resolves, strip `?item=` in place if it aliases the
+	// master. Reads `masterIdentity`/`openItemRef` and WRITES neither (only a
+	// `goto` — CONVE-1688 safe); the strip drops `?item=`, `openItemRef`
+	// recomputes to null, and the effect re-runs to a no-op (settles, no loop).
+	// It can't fight the controller: `isMaster` only ever matches the master, so
+	// a legitimately-opened pane (always a non-master ref) is never touched.
+	$effect(() => {
+		if (!browser) return;
+		if (!masterIdentity) return;
+		const current = openItemRef;
+		if (!current || !isMaster(current)) return;
+		const url = new URL(page.url);
+		url.searchParams.delete('item');
+		void goto(`${url.pathname}${url.search}`, {
+			replaceState: true,
+			noScroll: true,
+			keepFocus: true,
+		});
+	});
+
+	// Text-editing target detection — copied from the collection host's ESC
+	// precedence. ESC in a title edit / the Tiptap editor / a text input has
+	// LOCAL meaning (cancel/blur); the pane's depth-aware ESC must not hijack it.
+	// NON-text form controls (checkbox, button, …) have no local ESC semantics.
+	const NON_TEXT_INPUT_TYPES = new Set([
+		'checkbox', 'radio', 'button', 'submit', 'reset', 'range', 'color', 'file', 'image',
+	]);
+	function isTextEntryTarget(el: HTMLElement | null | undefined): boolean {
+		if (!el) return false;
+		if (el.isContentEditable) return true;
+		const tag = el.tagName;
+		if (tag === 'TEXTAREA') return true;
+		if (tag === 'INPUT') return !NON_TEXT_INPUT_TYPES.has((el as HTMLInputElement).type);
+		return false;
+	}
+
+	// Depth-aware ESC (PLAN-2154 Architecture C / R2, mirroring the collection
+	// host's escape-stack `pane` slot — TASK-2163). The full-page host has NO
+	// list, so there is NO two-level return-focus-to-list step: at depth>0 ESC
+	// pops exactly ONE drill level via the controller's fenced `handlePaneBack`;
+	// at depth 0 it closes the pane through the shared escape stack (the embedded
+	// pane registers `onClose` = `closeItemPane` at `ESCAPE_PRIORITY.pane`). Text
+	// edits, open modals/sheets, and a higher-priority stacked graph drawer all
+	// win ESC first (the same guards the collection host applies).
+	function handleHostKeydown(e: KeyboardEvent) {
+		// A control that already handled this key (preventDefault) owns it.
+		if (e.defaultPrevented) return;
+		if (e.key !== 'Escape') return;
+		const target = e.target as HTMLElement | null;
+		// Text-editing targets own ESC locally — don't hijack into a layer-close.
+		if (isTextEntryTarget(target)) return;
+		// A native <dialog> / role="dialog" sheet owns its own ESC.
+		if (document.querySelector('dialog[open], [role="dialog"]')) return;
+		// A HELD key auto-repeats; only the initial physical press acts.
+		if (e.repeat) {
+			e.preventDefault();
+			return;
+		}
+		// Detached pane (depth>0): pop exactly one drill level, consume the key.
+		// Routed through the controller's fenced `handlePaneBack` (not a bare
+		// `history.back()`), gated on `paneNavInFlight()` — a rapid double ESC
+		// can't stack a second traversal and overshoot (R14). A no-op while a
+		// traversal is armed STILL consumes the key (never falls through to close).
+		if (
+			openItemRef &&
+			topEscapePriority() === ESCAPE_PRIORITY.pane &&
+			currentPaneState().paneDepth > 0
+		) {
+			e.preventDefault();
+			if (!paneNavInFlight()) {
+				handlePaneBack();
+			}
+			return;
+		}
+		// Depth 0 (or a higher-priority layer): let the escape stack close exactly
+		// one layer, innermost-first (a pane graph drawer → the pane). No-op with
+		// no pane open (stack empty → returns false → native ESC untouched).
+		if (runTopEscape()) e.preventDefault();
+	}
+
+	onDestroy(() => {
+		// Drop any in-flight controller `history.go` continuation, and cancel a
+		// settling paneMint so a late latch/settle can't write to the unmounted
+		// page (PLAN-2154 / TASK-2166/2170).
+		clearPaneGo();
+		paneMintSettle.cancel();
+	});
 </script>
 
-<ItemDetail
-	{username}
-	{wsSlug}
-	{collSlug}
-	{ref}
-	onReady={(ready) => (scrollReady = ready)}
-/>
+<svelte:window onkeydown={handleHostKeydown} />
+
+<!--
+	Full-page pane layout (PLAN-2154 Architecture E). A flex row: the master's
+	own `.item-page` overflow column (always the scroll container — pane open or
+	not, so scroll restoration is consistent) + the right-docked <PaneHost>. The
+	host fills `.main-content` (height:100%) and clips, so `.main-content` never
+	double-scrolls while `.item-page` scrolls independently — mirroring the
+	collection host's `.pane-open` overflow handling. The pane is the ONLY thing
+	that mounts/unmounts on open/close (its own `.item-pane` CSS docks it and,
+	at ≤768px, makes it a full-screen overlay with the master left mounted +
+	inert behind it).
+-->
+<div class="item-page-host">
+	<!-- inert on the MOBILE overlay: the pane covers the viewport, so isolate the
+	     master from BOTH focus order and the SR tree behind it. Desktop keeps the
+	     master fully reachable (it's beside the pane, not behind it). -->
+	<div class="item-page" inert={viewport.isMobile && !!openItemRef}>
+		<ItemDetail
+			{username}
+			{wsSlug}
+			{collSlug}
+			{ref}
+			peeking={!!openItemRef}
+			onReady={(r) => (scrollReady = r)}
+			onIdentity={(id) => (masterIdentity = id)}
+			onOpenTarget={handleMasterOpenTarget}
+		/>
+	</div>
+	{#if openItemRef}
+		<PaneHost
+			bind:this={paneHostEl}
+			{openItemRef}
+			{username}
+			{wsSlug}
+			{collSlug}
+			{paneMintForRoute}
+			onClose={closeItemPane}
+			onGone={closeItemPane}
+			onNavigateAway={handlePaneNavigateAway}
+			onOpenTarget={guardedDrill}
+			onBack={handlePaneBack}
+		/>
+	{/if}
+</div>
+
+<style>
+	/* Fill the scrollable `.main-content` region and clip, delegating scroll to
+	   the `.item-page` column so the layout's `.main-content` never
+	   double-scrolls (mirrors the collection host's `.collection-page.pane-open`).
+	   Always a flex row so `.item-page` is a consistent, bounded scroll container
+	   whether or not the pane is docked. */
+	.item-page-host {
+		height: 100%;
+		display: flex;
+		flex-direction: row;
+		align-items: stretch;
+		overflow: hidden;
+	}
+
+	/* The master's OWN overflow-y:auto scroll column (the analogue of the
+	   collection host's `.list-column`). No padding here — <ItemDetail>'s inner
+	   `.item-page` content wrapper owns the max-width + padding, so this stays a
+	   transparent, full-width, scrollable flex child. */
+	.item-page {
+		flex: 1 1 0;
+		min-width: 0;
+		overflow-y: auto;
+	}
+</style>

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -302,7 +302,18 @@
 		// Depth 0 (or a higher-priority layer): let the escape stack close exactly
 		// one layer, innermost-first (a pane graph drawer → the pane). No-op with
 		// no pane open (stack empty → returns false → native ESC untouched).
-		if (runTopEscape()) e.preventDefault();
+		if (runTopEscape()) {
+			e.preventDefault();
+			// Case C (master graph + pane graph both open): `runTopEscape` just
+			// closed the innermost PANE graph. The MASTER graph's uncoordinated
+			// window listener ignores `preventDefault`, so stop it from ALSO closing
+			// on this same ESC — one layer per press. The host's `<svelte:window>`
+			// listener is registered before the master graph's (which arms only when
+			// that graph opens), so this runs first and can suppress it. Scoped to
+			// when a master graph actually exists so it never blocks unrelated window
+			// ESC listeners on the ordinary close path.
+			if (hasMasterGraph) e.stopImmediatePropagation();
+		}
 	}
 
 	onDestroy(() => {
@@ -382,5 +393,27 @@
 		flex: 1 1 0;
 		min-width: 0;
 		overflow-y: auto;
+	}
+
+	/* Print: the docked pane is a screen-only navigational surface, and the
+	   flex-row host clips to the viewport for the on-screen split — neither is
+	   right for print. Hide the pane + divider so Ctrl/Cmd+P captures ONLY the
+	   master document (not two items side-by-side with duplicate footers), and
+	   un-clip the host/column so the master flows naturally across print pages —
+	   mirroring app.css's `.app-shell`/`.main-content` print unlock, which does
+	   not reach these route-owned containers (Codex review). */
+	@media print {
+		.item-page-host {
+			display: block;
+			height: auto;
+			overflow: visible;
+		}
+		.item-page {
+			overflow: visible;
+		}
+		.item-page-host :global(.item-pane),
+		.item-page-host :global(.pane-divider) {
+			display: none;
+		}
 	}
 </style>

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -263,26 +263,32 @@
 		// A native <dialog> / role="dialog" sheet owns its own ESC.
 		if (document.querySelector('dialog[open], [role="dialog"]')) return;
 		// The MASTER's full-page (non-embedded) dependency-graph drawer keeps its
-		// OWN window ESC listener (ItemDetail, `!embedded`) — NOT the shared escape
-		// stack. If it's open (e.g. a pane was opened from a master graph node's
-		// "Open" anchor, leaving the graph up), defer this ESC to that listener so
-		// one press closes ONLY the graph, not the graph AND the pane (Codex
-		// review) — BUT only when the master graph is the FRONTMOST ESC concern.
-		// The PANE's OWN (embedded) graph drawer registers in the escape stack at
-		// the higher `graphDrawer` priority; when it's the top layer it is innermost
-		// and must close first via `runTopEscape` below, so we do NOT bail then (its
-		// own listener will still fire on the master graph — an inherent limit of
-		// that standalone listener — but at least the innermost layer closes). The
-		// master graph is a `.graph-drawer` OUTSIDE `.item-pane` (`closest`).
+		// OWN window ESC listener (ItemDetail, `!embedded`) that ignores
+		// preventDefault. Whenever one coexists with the pane, any ESC WE consume
+		// must ALSO `stopImmediatePropagation` so that listener can't double-close
+		// on the same keystroke — including auto-repeats of a held key, which its
+		// listener doesn't bail on either. The host's `<svelte:window>` listener is
+		// registered before it (that listener arms only when the graph opens), so
+		// this runs first and can suppress it. A master graph is a `.graph-drawer`
+		// OUTSIDE `.item-pane` (`closest`).
 		const hasMasterGraph = [...document.querySelectorAll('.graph-drawer')].some(
 			(g) => !g.closest('.item-pane'),
 		);
-		if (hasMasterGraph && topEscapePriority() !== ESCAPE_PRIORITY.graphDrawer) return;
-		// A HELD key auto-repeats; only the initial physical press acts.
+		// A HELD key auto-repeats; only the initial physical press acts. Consume the
+		// repeats — and suppress the master graph's listener on them (checked BEFORE
+		// the deferral below) so a hold can't cascade the master graph closed after
+		// the first press already closed the innermost layer (Codex review).
 		if (e.repeat) {
 			e.preventDefault();
+			if (hasMasterGraph) e.stopImmediatePropagation();
 			return;
 		}
+		// Defer to the master graph's own listener ONLY when it's the FRONTMOST ESC
+		// concern (no pane graph drawer at ESCAPE_PRIORITY.graphDrawer is the top
+		// stack layer): one press closes just the master graph via that listener (no
+		// stopImmediatePropagation here, so it fires). When a pane graph IS the top
+		// layer it's innermost and must close first via `runTopEscape` below.
+		if (hasMasterGraph && topEscapePriority() !== ESCAPE_PRIORITY.graphDrawer) return;
 		// Detached pane (depth>0): pop exactly one drill level, consume the key.
 		// Routed through the controller's fenced `handlePaneBack` (not a bare
 		// `history.back()`), gated on `paneNavInFlight()` — a rapid double ESC

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -9,7 +9,6 @@
 	import { createPaneController } from '$lib/collections/paneHostController';
 	import { createPaneMintSettle, PANE_MINT_SETTLE_MS } from '$lib/collections/paneMintSettle';
 	import { resolvePaneTarget, isSamePaneTarget, type PaneGuardItem } from '$lib/collections/paneTarget';
-	import { api } from '$lib/api/client';
 	import { viewport } from '$lib/stores/breakpoint.svelte';
 	import { runTopEscape, topEscapePriority, ESCAPE_PRIORITY } from '$lib/stores/escapeStack';
 	import type { PaneTarget, ResolvedItemIdentity } from '$lib/types';
@@ -180,113 +179,33 @@
 		};
 	});
 
-	// Item-identifier SHAPES the server resolves a bare `?item=` by, in precedence
-	// order (`GetItemByRef` — internal/store/items.go): a canonical UUID, then a
-	// PREFIX-NUMBER ref, then a slug.
-	const UUID_SHAPE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-	const REF_SHAPE = /^[A-Za-z]+-\d+$/;
-
-	// SYNCHRONOUS `?item == master` decision (PLAN-2154 D2 / Architecture E) —
-	// `true` (definite master), `false` (definite non-master), or `null` when the
-	// answer can't be settled from the master identity ALONE and needs a server
-	// resolve. Mirrors the server's UUID-first → ref-by-NUMBER → slug precedence:
-	//   • exact id → master (UUID-first);
-	//   • candidate === master.slug: a PLAIN slug can't be preempted by a UUID/ref
-	//     lookup → definite master; but a ref/UUID-SHAPED slug MIGHT resolve
-	//     UUID/ref-first to a DIFFERENT LIVE item — OR fall back to the master when
-	//     that item is absent/archived/cross-workspace — which shape alone cannot
-	//     decide → `null` (server-confirm below). This is the ONLY network path,
-	//     and it's reached only for a pathological ref/UUID-shaped master slug;
-	//     a normal plain-slug master is always decided synchronously here.
-	//   • otherwise the ref-NUMBER channel (`isSamePaneTarget`'s href resolution)
-	//     is definite (ref numbers are workspace-unique).
-	function masterMatchSync(candidate: string): boolean | null {
+	// The forbidden `?item == master` collision (PLAN-2154 D2 / Architecture E) for
+	// a BARE `?item=` string (the cold-load strip + mount gate + a resolved
+	// content-link ref). CONSERVATIVE by design: return true whenever the candidate
+	// aliases the master under ANY of the server's resolution channels
+	// (`GetItemByRef` — internal/store/items.go: UUID-first, then ref by NUMBER,
+	// then slug) — an exact id, the raw slug string, OR the ref number. This is the
+	// D2 "err toward a match" mandate: the forbidden outcome is a SECOND collab
+	// provider on the master's own room, so when the master COULD be the target we
+	// decline to open a pane. `false` while the master identity is unresolved.
+	//
+	// A server round-trip could distinguish the two genuinely-undecidable-by-client
+	// cases (a ref/UUID-SHAPED master SLUG that either preempts to a different live
+	// item or falls back to the master) — but it was evaluated and rejected: the
+	// async resolve added real race surface (stale-cache-across-archive, a
+	// popstate/mint-settle remount race, SSE-driven refetch) for a scenario that
+	// requires a PATHOLOGICAL master slug (one shaped like a ref or a UUID — never
+	// produced by an organic title). The only residual cost of the sync guard is a
+	// BENIGN over-block in exactly that pathological case: a `?item=<X>` where X is
+	// a live different item AND coincidentally equals the master's ref/UUID-shaped
+	// slug declines to open a pane (no collision, no data loss). This matches the
+	// existing shared behavior of `isSamePaneTarget` / `ItemDetail.fireOpenTarget`,
+	// which already conservatively drop a slug-matching target.
+	function isMasterRef(candidate: string): boolean {
 		if (!masterItem) return false;
-		if (candidate === masterItem.id) return true;
-		if (candidate === masterItem.slug) {
-			return UUID_SHAPE.test(candidate) || REF_SHAPE.test(candidate) ? null : true;
-		}
+		if (candidate === masterItem.id || candidate === masterItem.slug) return true;
 		return isSamePaneTarget({ href: candidate }, masterItem);
 	}
-
-	// The exact identity of an uncertain resolve — `wsSlug`, the master, and the
-	// candidate — so a stored result is only ever consumed for the target it was
-	// computed for.
-	function uncertainKey(candidate: string, master: PaneGuardItem): string {
-		return `${wsSlug}::${master.id}::${candidate}`;
-	}
-
-	// Server confirmation for the UNCERTAIN case above. The only way to know whether
-	// a ref/UUID-shaped master slug is preempted (target resolves to a different
-	// live item) or reached by the server's slug-fallback (target resolves to the
-	// master) is to resolve `?item=` to its actual item id and compare. Fires ONLY
-	// when `masterMatchSync` is null, so a normal plain-slug master never touches
-	// the network. The result is STAMPED with its `key`: a consumer treats a
-	// key-mismatch (stale result for a different target, or none yet) as pending —
-	// so a prior target's answer can't transiently leak to a new one (Codex review).
-	let confirmedTarget = $state<{ key: string; isMaster: boolean } | null>(null);
-	// Dedup: the key currently being fetched, a plain `let` NOT `$state` — the
-	// effect must not READ the reactive `confirmedTarget` it also writes (CONVE-1688
-	// self-invalidation). Cleared on cancel/complete so revisiting a cancelled key
-	// re-fetches instead of wedging. (A re-run for the same still-open uncertain
-	// target won't fire — the effect's reactive deps `openItemRef`/`masterItem` are
-	// stable then — so this dedup only guards a genuine in-flight duplicate.)
-	let inFlightKey: string | null = null;
-	$effect(() => {
-		const candidate = openItemRef;
-		const master = masterItem;
-		if (!browser || !candidate || !master) return;
-		if (masterMatchSync(candidate) !== null) return; // sync decided → no fetch
-		const key = uncertainKey(candidate, master);
-		if (key === inFlightKey) return; // a fetch is already in flight for this exact key
-		inFlightKey = key;
-		let cancelled = false;
-		void (async () => {
-			let isMaster: boolean;
-			try {
-				const resolved = await api.items.get(wsSlug, candidate);
-				isMaster = resolved?.id === master.id;
-			} catch {
-				// Resolve failed (network / not-found) — err toward BLOCKING, the safe
-				// direction for the forbidden D2 collision.
-				isMaster = true;
-			}
-			if (inFlightKey === key) inFlightKey = null;
-			if (cancelled) return;
-			confirmedTarget = { key, isMaster };
-		})();
-		return () => {
-			cancelled = true;
-			if (inFlightKey === key) inFlightKey = null; // re-armable, never wedged
-		};
-	});
-
-	// The server-confirmed answer for the CURRENT uncertain `?item=`, or null when
-	// pending (no stamped result for this exact key yet).
-	function confirmedFor(candidate: string, master: PaneGuardItem): boolean | null {
-		const key = uncertainKey(candidate, master);
-		return confirmedTarget?.key === key ? confirmedTarget.isMaster : null;
-	}
-
-	// Does the CURRENT `?item=` alias the master, for the MOUNT gate? Blocks (true)
-	// while an uncertain resolve is pending — never mount a 2nd provider on the
-	// master's own room before we're sure it ISN'T the master.
-	let openTargetBlocksMount = $derived.by(() => {
-		const candidate = openItemRef;
-		if (!candidate || !masterItem) return false;
-		const sync = masterMatchSync(candidate);
-		return sync !== null ? sync : (confirmedFor(candidate, masterItem) ?? true);
-	});
-
-	// Does the CURRENT `?item=` alias the master, for the cold-load STRIP? Only
-	// strips once DEFINITELY the master — a pending resolve does NOT strip (never
-	// delete a `?item=` that might still resolve to a DIFFERENT item).
-	let openTargetIsMaster = $derived.by(() => {
-		const candidate = openItemRef;
-		if (!candidate || !masterItem) return false;
-		const sync = masterMatchSync(candidate);
-		return sync !== null ? sync : (confirmedFor(candidate, masterItem) ?? false);
-	});
 
 	// Whether to MOUNT the pane. Gating the MOUNT (not merely stripping `?item=`
 	// after the fact) closes the cold-load self-collision RACE (Codex review): on
@@ -300,7 +219,7 @@
 	// CLICK-driven open the master identity is already resolved (and `ref` is
 	// unchanged), so there is no delay; only a cold `?item=` load or a master
 	// navigation waits one master-load beat (master-first, the correct order).
-	let showPane = $derived(!!openItemRef && !!masterItem && !openTargetBlocksMount);
+	let showPane = $derived(!!openItemRef && !!masterItem && !isMasterRef(openItemRef));
 
 	// MASTER content-links FIRST-OPEN the pane (PLAN-2154 D3 / Architecture E).
 	// The master's relationship / child / wiki-link / graph surfaces hand up a
@@ -311,45 +230,41 @@
 	// master's room). The master's own <ItemDetail> `fireOpenTarget` already
 	// drops self-links against its loaded item; this is the host-side belt.
 	function handleMasterOpenTarget(target: PaneTarget) {
-		// Resolve WITHOUT `resolvePaneTarget`'s `current` same-item guard — that guard
-		// is `isSamePaneTarget`, which over-blocks the same undecidable UUID-shaped-
-		// slug case (a UUID-shaped href equal to the master's slug is treated as self
-		// even when it's a different LIVE item — Codex review). Instead drop only a
-		// DEFINITE master alias here (`masterMatchSync(resolved) === true`); an
-		// UNCERTAIN alias (`=== null`) is left for the mount gate's server-confirm to
-		// catch — never a collision, just a possible brief `?item=` flicker in that
-		// pathological case. A master self-link resolves to the master's ref →
-		// `masterMatchSync` true → still dropped here.
-		const resolved = resolvePaneTarget(target);
-		if (!resolved || masterMatchSync(resolved) === true) return;
+		// `resolvePaneTarget(target, masterItem)` returns null BOTH when the target is
+		// unresolvable AND when it resolves to the master (the `isSamePaneTarget`
+		// self-guard, same as `ItemDetail.fireOpenTarget`); `isMasterRef(resolved)`
+		// additionally drops a resolved segment that aliases the master by id / raw
+		// slug / ref-number (the conservative D2 guard — err toward a match).
+		const resolved = resolvePaneTarget(target, masterItem);
+		if (!resolved || isMasterRef(resolved)) return;
 		openItemPaneByRef(resolved);
 	}
 
 	// PANE content-links DRILL in place (PLAN-2154 Architecture A/B). A link
 	// clicked INSIDE the pane re-targets the pane with a back stack via
-	// `navigatePaneTo` — the same `masterMatchSync(resolved) === true` drop guards
-	// a drill back onto the master (resolved without the `isSamePaneTarget`
-	// same-item guard, for the same UUID-shaped-slug reason as above; the pane's
+	// `navigatePaneTo` — the same `resolvePaneTarget(target, masterItem)` +
+	// `isMasterRef(resolved)` drop guards a drill back onto the master (the pane's
 	// own `fireOpenTarget` already dropped drills to the pane's shown item).
 	function guardedDrill(target: PaneTarget) {
-		const resolved = resolvePaneTarget(target);
-		if (!resolved || masterMatchSync(resolved) === true) return;
+		const resolved = resolvePaneTarget(target, masterItem);
+		if (!resolved || isMasterRef(resolved)) return;
 		navigatePaneTo(resolved);
 	}
 
 	// Cold-load strip (PLAN-2154 Architecture E). A hand-crafted / shared
-	// `?item=<the master's own ref>` URL must NOT mount a pane on the master
-	// itself (two providers, one room, one shared itemID-only cursor). Strip
-	// `?item=` in place once it's DEFINITELY the master (`openTargetIsMaster` —
-	// which waits for the server-confirm on a pathological ref/UUID-shaped-slug
-	// master rather than stripping a `?item=` that might still resolve elsewhere).
-	// Reads reactive state and WRITES none of it (only a `goto` — CONVE-1688
-	// safe); the strip drops `?item=`, `openItemRef` recomputes to null, and the
-	// effect re-runs to a no-op (settles, no loop). It can't fight the controller:
-	// a legitimately-opened pane (a confirmed non-master ref) is never touched.
+	// `?item=<the master's own ref>` URL must NOT mount a pane on the master itself
+	// (two providers, one room, one shared itemID-only cursor). Once the master's
+	// identity resolves, strip `?item=` in place if it aliases the master. Reads
+	// reactive state and WRITES none of it (only a `goto` — CONVE-1688 safe); the
+	// strip drops `?item=`, `openItemRef` recomputes to null, and the effect re-runs
+	// to a no-op (settles, no loop). It can't fight the controller: `isMasterRef`
+	// only ever matches the master, so a legitimately-opened pane (a non-master ref)
+	// is never touched.
 	$effect(() => {
 		if (!browser) return;
-		if (!openTargetIsMaster) return;
+		if (!masterItem) return;
+		const current = openItemRef;
+		if (!current || !isMasterRef(current)) return;
 		const url = new URL(page.url);
 		url.searchParams.delete('item');
 		void goto(`${url.pathname}${url.search}`, {

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -146,15 +146,27 @@
 	// way the server does, so a ref-shaped SLUG (e.g. master #5 slugged `plan-6`)
 	// is NOT mistaken for the master when `?item=plan-6` actually resolves to
 	// item #6 (Codex review).
-	let masterItem = $derived<PaneGuardItem | null>(
-		masterIdentity
-			? {
-					id: masterIdentity.id,
-					slug: masterIdentity.slug,
-					item_number: refNumber(masterIdentity.ref) ?? 0,
-				}
-			: null,
-	);
+	let masterItem = $derived.by<PaneGuardItem | null>(() => {
+		if (!masterIdentity) return null;
+		const projected: PaneGuardItem = {
+			id: masterIdentity.id,
+			slug: masterIdentity.slug,
+			item_number: refNumber(masterIdentity.ref) ?? 0,
+		};
+		// `masterIdentity` (from `onIdentity`) LAGS a same-route master navigation:
+		// expanding a pane item to the full page, then browser-Back to
+		// `<prev-master>?item=<that item>`, REUSES this route — `masterIdentity`
+		// still holds the expanded item until the master reloads the previous one
+		// and re-emits identity. Comparing it against the live master `ref` path
+		// param (via the shared `isSamePaneTarget`) drops that STALE identity, so
+		// the self-guard / cold-load strip never match a bare `?item=` against the
+		// WRONG (previous) master and wrongly strip a still-valid pane — the R14
+		// late-continuation class (Codex review). Because `masterItem` is a
+		// `$derived` over `ref`, it re-nulls SYNCHRONOUSLY the instant `ref`
+		// changes — before the strip `$effect` runs — so the effect never sees a
+		// stale master. Null until identity resolves AND matches the current `ref`.
+		return isSamePaneTarget({ href: ref }, projected) ? projected : null;
+	});
 
 	// The forbidden `?item == master` collision (PLAN-2154 D2 / Architecture E)
 	// for a BARE `?item=` string (the cold-load strip + the mount gate). Wrap the
@@ -168,15 +180,17 @@
 
 	// Whether to MOUNT the pane. Gating the MOUNT (not merely stripping `?item=`
 	// after the fact) closes the cold-load self-collision RACE (Codex review): on
-	// a cold `?item=` load the master identity is unresolved for a beat, and a
-	// `?item=` that turns out to alias the master would otherwise mount
+	// a cold `?item=` load the (fresh) master identity is unresolved for a beat,
+	// and a `?item=` that turns out to alias the master would otherwise mount
 	// `PaneHost`/`ItemDetail` and mint a SECOND collab provider on the master's
-	// own room BEFORE the strip effect's `goto` removes the query. So the pane
-	// mounts only once identity has resolved AND confirmed the target isn't the
-	// master. For a CLICK-driven open the master identity is already resolved, so
-	// there is no delay; only a cold `?item=` load waits one master-load beat
-	// (master-first, which is the correct order anyway).
-	let showPane = $derived(!!openItemRef && !!masterIdentity && !isMasterRef(openItemRef));
+	// own room BEFORE the strip effect's `goto` removes the query. Gating on
+	// `masterItem` (fresh-for-`ref`) means the pane mounts only once the CURRENT
+	// master's identity has resolved AND confirmed the target isn't the master —
+	// and never against a stale prior master (the Expand→Back case). For a
+	// CLICK-driven open the master identity is already resolved (and `ref` is
+	// unchanged), so there is no delay; only a cold `?item=` load or a master
+	// navigation waits one master-load beat (master-first, the correct order).
+	let showPane = $derived(!!openItemRef && !!masterItem && !isMasterRef(openItemRef));
 
 	// MASTER content-links FIRST-OPEN the pane (PLAN-2154 D3 / Architecture E).
 	// The master's relationship / child / wiki-link / graph surfaces hand up a
@@ -217,7 +231,7 @@
 	// a legitimately-opened pane (always a non-master ref) is never touched.
 	$effect(() => {
 		if (!browser) return;
-		if (!masterIdentity) return;
+		if (!masterItem) return;
 		const current = openItemRef;
 		if (!current || !isMasterRef(current)) return;
 		const url = new URL(page.url);


### PR DESCRIPTION
## What

PLAN-2154 Phase 2 / Architecture E, bullet 5 — the Q1 payoff (TASK-2174). Turns the full-page item route (`[collection]/[slug]/+page.svelte`), previously a 47-line wrapper rendering `<ItemDetail>` full-page, into a **full-page pane host**: from a full-page item, clicking a child / related / wiki-linked item opens the SAME right-docked detail pane the collection page carries, beside the master. The master is the `[slug]` PATH param; the pane is the `?item=` QUERY param — no collision.

Reuses the shared `PaneHost`, `createPaneController`, and `paneMint` machinery (TASK-2170–2173). Collection-specific deps (j/k pane-follow, list-row focus-return, quick-create draft guard) are correct no-ops here.

## How

- **Layout + scroll (B):** a flex-row `.item-page-host` fills `.main-content` and clips; an `.item-page` overflow column is the master's own (always-on) scroll container, mirroring the collection host's `.pane-open` overflow handling. `createScrollRestoration` gets the `.item-page` `scrollTarget` getter (TASK-2171); `export const snapshot` kept.
- **Freeze master (C):** `peeking={!!openItemRef}` makes the master retain-alive read-only (TASK-2172) — never a provider teardown. `onIdentity` captures the master's resolved `{id,ref,slug}` (TASK-2173).
- **First-open vs drill (D3/E):** master content-links FIRST-OPEN the pane (`openItemPaneByRef` — a depth-0 `paneOwned:true` push); pane content-links DRILL (`navigatePaneTo`). Both go through the provenance-correct `?item == master` self-guard (reusing `resolvePaneTarget`/`isSamePaneTarget`), plus a cold-load strip + a mount-gate that never mounts a second collab provider on the master's own room.
- **`paneHostController`:** extract `openItemPane(item)`'s body into `openItemPaneByRef(ref)` and make `openItemPane` a thin `openItemPaneByRef(itemUrlId(item))` wrapper — byte-identical, so the collection page's pane e2e stays green.
- **Depth-aware ESC:** mirrors the collection host's escape-stack `pane` slot minus the list-focus step. Master graph drawer now composes in the escape stack (ItemDetail routes both embedded + non-embedded graphs through it).

## Review-driven hardening (7 Codex rounds → CLEAN)

- Mount-gate closes the cold-load self-collision race; ref-NUMBER + pathname-stamped master identity (handles Expand→Back and ref/collection/workspace route reuse without a stale-master strip); block-drag auto-scroll targets the innermost scroll container; print rule hides the pane; master-graph ESC unified through the escape stack.

## Tests

- New `e2e/pane-full-page-host.spec.ts` (4 tests): master link opens pane beside a read-only-but-live master → drill (Back chevron) → browser Back → ✕ close; cold `?item=<master>` stripped; cold `?item=<other>` still mounts; Expand→Back restores the pane.
- Adapted `pane-collection-migration-race.spec.ts` BUG-2129 fence to the new full-page behavior (relationship-link now opens a pane; the same-instance cross-collection nav is reached via the pane's Expand).
- `svelte-check` 0 errors · `vitest` 444 passed · full `pane-` e2e suite **53/53** (the pre-existing 49 stayed green).

## Deferred

- BUG-2178 (child of PLAN-2154): the pane's collection-rename/move navigate-away emits collection-host-shaped URLs on the full-page host — a separable, obscure refinement (Codex agreed: not a merge blocker).

https://claude.ai/code/session_01EZ6yr6pAUFb1uffan912ra
