### PR TITLE
refactor(web): reactive master/pane freeze — drop the peeking-driven editor remount (TASK-2180)

### DIFF
--- a/web/e2e/pane-full-page-host.spec.ts
+++ b/web/e2e/pane-full-page-host.spec.ts
@@ -35,6 +35,22 @@ interface SeededItem {
 	slug: string;
 }
 
+/** Seed a doc with real markdown body content — needed for hover tests where a
+ *  concrete block must exist for the block drag handle to attach to. */
+async function seedDocWithContent(
+	fixture: SuiteFixture,
+	request: APIRequestContext,
+	titlePrefix: string,
+	content: string,
+): Promise<SeededItem> {
+	const resp = await request.post(
+		`/api/v1/workspaces/${fixture.workspaceSlug}/collections/docs/items`,
+		{ headers: authHeaders(fixture), data: { title: `${titlePrefix} ${Date.now()}`, fields: '{}', content } },
+	);
+	if (!resp.ok()) throw new Error(`doc create failed (${resp.status()}): ${await resp.text()}`);
+	return (await resp.json()) as SeededItem;
+}
+
 /** Seed a doc whose `fields.parent` makes it a child of `parentId` (mirrors
  *  `ChildItems.submitCreate`'s `{ parent }` shape) so the parent's pane renders
  *  a `.child-row` to drill into. */
@@ -163,6 +179,123 @@ test.describe('full-page pane host (PLAN-2154 Phase 2 / TASK-2174)', () => {
 		await expect.poll(() => openItemParam(page)).toBeNull();
 		await expect(page.locator('button.title', { hasText: 'FP host master' })).toBeVisible();
 		await expect(page.locator('h1.title.title-readonly')).toHaveCount(0);
+	});
+
+	test('opening AND closing the pane freezes/thaws the master WITHOUT remounting its editor (PLAN-2179 DR-1 / TASK-2180 — reactive freeze)', async ({
+		page,
+		fixture,
+		request,
+	}) => {
+		await page.setViewportSize(DESKTOP);
+		await browserLogin(page);
+
+		// A (master) --related--> B.
+		const master = await seedDoc(fixture, request, 'FP host reactive-freeze master');
+		const related = await seedDoc(fixture, request, 'FP host reactive-freeze related');
+		await seedRelatedLink(fixture, request, master.slug, related.id);
+		const relatedRef = await itemRef(fixture, request, related.slug);
+
+		await page.goto(fullPageUrl(fixture, master.slug));
+		await expect(page.locator('button.title', { hasText: 'FP host reactive-freeze master' })).toBeVisible();
+
+		// The MASTER's main content editor (its ProseMirror), scoped to the
+		// master column (`.item-page-host > .item-page`, never the `.item-pane`).
+		// Wait until it has synced to editable — the collab skeleton renders no
+		// ProseMirror, so this also guarantees the real editor is mounted before
+		// we capture a handle to its DOM node.
+		const masterMainEditor = page.locator(
+			'.item-page-host > .item-page .editor-wrapper .ProseMirror',
+		);
+		await expect(masterMainEditor).toHaveAttribute('contenteditable', 'true');
+		const editorNode = await masterMainEditor.elementHandle();
+		expect(editorNode).not.toBeNull();
+		expect(await editorNode!.evaluate((el) => el.isConnected)).toBe(true);
+
+		// Open the pane → the master goes peeking (read-only).
+		await page
+			.locator('.relationship-group', { hasText: 'Related' })
+			.locator('a.link-target', { hasText: 'FP host reactive-freeze related' })
+			.click();
+		await expect(page.locator('.item-pane')).toBeVisible();
+		await expect.poll(() => openItemParam(page)).toBe(relatedRef);
+		await expect(
+			page.locator('h1.title.title-readonly', { hasText: 'FP host reactive-freeze master' }),
+		).toBeVisible();
+
+		// The freeze is REACTIVE: the SAME editor DOM node is still connected (a
+		// `{#key}`-driven remount — the OLD peeking-in-the-key behavior — would
+		// have detached this handle, isConnected → false), and it merely flipped
+		// contenteditable=false in place. This is the whole point of PLAN-2179
+		// DR-1: freeze without destroying/recreating the editor.
+		expect(await editorNode!.evaluate((el) => el.isConnected)).toBe(true);
+		await expect(masterMainEditor).toHaveAttribute('contenteditable', 'false');
+
+		// Close the pane → the master thaws back to editable. The editor node
+		// survives the un-freeze too (no remount on either edge), flipping
+		// contenteditable=true again in place.
+		await page.locator('button[title="Close pane"]').click();
+		await expect(page.locator('.item-pane')).toHaveCount(0);
+		await expect(page.locator('button.title', { hasText: 'FP host reactive-freeze master' })).toBeVisible();
+		await expect(page.locator('h1.title.title-readonly')).toHaveCount(0);
+		expect(await editorNode!.evaluate((el) => el.isConnected)).toBe(true);
+		await expect(masterMainEditor).toHaveAttribute('contenteditable', 'true');
+	});
+
+	test('the master block drag handle appears on hover while editable, is frozen (never appears) while peeking, and returns on close (PLAN-2179 DR-1 / TASK-2180)', async ({
+		page,
+		fixture,
+		request,
+	}) => {
+		await page.setViewportSize(DESKTOP);
+		await browserLogin(page);
+
+		const master = await seedDocWithContent(
+			fixture,
+			request,
+			'FP host drag-handle master',
+			'Alpha paragraph here\n\nBravo paragraph here',
+		);
+		const related = await seedDoc(fixture, request, 'FP host drag-handle related');
+		await seedRelatedLink(fixture, request, master.slug, related.id);
+		const relatedRef = await itemRef(fixture, request, related.slug);
+
+		await page.goto(fullPageUrl(fixture, master.slug));
+		const masterMain = page.locator('.item-page-host > .item-page .editor-wrapper .ProseMirror');
+		await expect(masterMain).toHaveAttribute('contenteditable', 'true');
+		await expect(masterMain.locator('p').first()).toContainText('Alpha paragraph');
+
+		// The block drag handle lives inside the master's editor wrapper; it is
+		// display:none until a hover reveals it over a block.
+		const handle = page.locator('.item-page-host > .item-page .editor-wrapper .block-drag-handle');
+		const handleDisplay = () =>
+			handle.evaluate((el) => getComputedStyle(el as HTMLElement).display).catch(() => 'missing');
+
+		// EDITABLE: hovering a paragraph reveals the handle.
+		await masterMain.locator('p').first().hover();
+		await expect.poll(handleDisplay, { timeout: 3000 }).not.toBe('none');
+
+		// PEEK: open the pane → the master freezes (contenteditable=false). Hovering
+		// the SAME paragraph must NOT reveal the handle — the reactive-editable
+		// choke (onMouseMove/update bail on !editorView.editable) keeps it hidden.
+		await page
+			.locator('.relationship-group', { hasText: 'Related' })
+			.locator('a.link-target', { hasText: 'FP host drag-handle related' })
+			.click();
+		await expect(page.locator('.item-pane')).toBeVisible();
+		await expect.poll(() => openItemParam(page)).toBe(relatedRef);
+		await expect(masterMain).toHaveAttribute('contenteditable', 'false');
+		await page.mouse.move(5, 5); // leave the editor first
+		await masterMain.locator('p').first().hover({ force: true });
+		await page.waitForTimeout(250);
+		expect(await handleDisplay()).toBe('none');
+
+		// CLOSE: the master thaws → hovering reveals the handle again.
+		await page.locator('button[title="Close pane"]').click();
+		await expect(page.locator('.item-pane')).toHaveCount(0);
+		await expect(masterMain).toHaveAttribute('contenteditable', 'true');
+		await page.mouse.move(5, 5);
+		await masterMain.locator('p').first().hover();
+		await expect.poll(handleDisplay, { timeout: 3000 }).not.toBe('none');
 	});
 
 	test('a cold-loaded `?item=<the master itself>` is stripped — never mounts a pane on the master', async ({

--- a/web/src/lib/components/editor/Editor.svelte
+++ b/web/src/lib/components/editor/Editor.svelte
@@ -20,6 +20,7 @@
 		selectionCell,
 		findTable,
 		TableMap,
+		columnResizingPluginKey,
 	} from '@tiptap/pm/tables';
 	import Link from '@tiptap/extension-link';
 	import CodeBlock from '@tiptap/extension-code-block';
@@ -715,7 +716,13 @@
 	}
 
 	function execSlash(id: string) {
-		if (!editor) return;
+		// Reactive-freeze guard (PLAN-2179 DR-1 / TASK-2180): a slash menu left
+		// OPEN when the master froze must not insert into the read-only doc. The
+		// `{#if slashOpen && editable}` render gate hides it reactively, and this
+		// is the belt for a queued Enter/click racing the flip. (The old peeking
+		// `{#key}` remount reset this component state; the reactive freeze needs
+		// the explicit bail.)
+		if (!editor || !editor.isEditable) return;
 		if (slashStartPos >= 0) {
 			const to = editor.state.selection.from;
 			editor.chain().focus().deleteRange({ from: slashStartPos, to }).run();
@@ -792,7 +799,9 @@
 	}
 
 	function execLink(doc: Item) {
-		if (!editor) return;
+		// Reactive-freeze guard (PLAN-2179 DR-1 / TASK-2180): see execSlash — a
+		// `[[` picker left open at freeze time must not mutate the read-only doc.
+		if (!editor || !editor.isEditable) return;
 		// Build the URL in the same shape wikiLinksToMarkdown produces so the
 		// save round-trip (markdownToWikiLinks) reliably converts it back to
 		// [[Title]]. We read from the live route params (not workspaceStore)
@@ -890,12 +899,17 @@
 				transformPastedText: true,
 				transformCopiedText: true,
 			}),
-			// BlockDragHandle registers a drag-to-reorder UI in the prose
-			// mirror view that is NOT gated on tiptap's `editable` flag —
-			// its handle can still drag/dispatch transactions even when
-			// `editable=false`. Exclude entirely in read-only mode so the
-			// handle is never injected (PLAN-1100 / TASK-1105 round 3).
-			...(editable ? [BlockDragHandle] : []),
+			// BlockDragHandle registers UNCONDITIONALLY (PLAN-2179 DR-1 /
+			// TASK-2180). It is now reactive-editable-aware: onMouseMove and
+			// the plugin update() choke on `editorView.editable` (hiding the
+			// handle synchronously the moment editable flips false), and every
+			// mutation dispatch site (drag-move, duplicate, delete, turn-into,
+			// attach) bails on `!editorView.editable`. That lets a read-only /
+			// peeking editor freeze the handle via `editable={!peeking}` WITHOUT
+			// remounting the editor — replacing the old construction-time gate
+			// (PLAN-1100 / TASK-1105) and, in ItemDetail, its peeking-driven
+			// `{#key}` remount. Pure superset: editable=true is byte-identical.
+			BlockDragHandle,
 			AttachmentImage.configure({
 				getDownloadUrl: getAttachmentUrl,
 				workspaceSlug: wsSlug,
@@ -1167,6 +1181,33 @@
 		});
 	});
 
+	// Master-freeze (PLAN-2179 DR-1 / TASK-2180): when the editor goes read-only
+	// (a peek), dismiss any open insertion UI — the slash / `[[` pickers and the
+	// Insert-from-URL modal — so none can linger over (or reappear on un-freeze
+	// above), or mutate, a frozen doc. Reactive counterpart to the old peeking
+	// `{#key}` remount, which reset this component state by destroying it. Split
+	// from the setEditable flip above per CONVE-606 (state reset vs sync).
+	$effect(() => {
+		if (editable) return;
+		untrack(() => {
+			slashOpen = false;
+			linkOpen = false;
+			importUrlModalOpen = false;
+			// Cancel an in-flight table column-resize: prosemirror-tables gates
+			// resize START on view.editable but its window mouseup completion does
+			// NOT recheck it, so a resize begun before the freeze would otherwise
+			// dispatch changed colwidths into the now-read-only doc (Codex round 3;
+			// direct Yjs repro confirmed). Clearing `dragging` (a meta-only tr — no
+			// doc step, no Yjs op, safe on a frozen view) makes that mouseup a
+			// no-op. The old peeking `{#key}` remount closed this by destroying the
+			// view mid-drag.
+			const view = editor?.view;
+			if (view && columnResizingPluginKey.getState(view.state)?.dragging) {
+				view.dispatch(view.state.tr.setMeta(columnResizingPluginKey, { setDragging: null }));
+			}
+		});
+	});
+
 	// Sync content when prop changes (e.g. doc switch, external update).
 	//
 	// CRITICAL: when ydoc is set, this path MUST NOT run. Y.Doc is the
@@ -1374,7 +1415,10 @@
 	{/if}
 </div>
 
-{#if slashOpen}
+<!-- `&& editable` (PLAN-2179 DR-1 / TASK-2180): reactively hide an open slash
+     menu the instant the master freezes, so a peeking editor can't insert via a
+     lingering picker. The old peeking `{#key}` remount dropped this state. -->
+{#if slashOpen && editable}
 	<!-- svelte-ignore a11y_click_events_have_key_events -->
 	<div role="none" style="position:fixed; inset:0; z-index:49;" onclick={closeSlash}></div>
 	<div class="slash-menu" style:left="{slashX}px" style:top="{slashY}px">
@@ -1392,7 +1436,7 @@
 	</div>
 {/if}
 
-{#if linkOpen}
+{#if linkOpen && editable}
 	<!-- svelte-ignore a11y_click_events_have_key_events -->
 	<div role="none" style="position:fixed; inset:0; z-index:49;" onclick={closeLink}></div>
 	<div class="slash-menu" style:left="{linkX}px" style:top="{linkY}px">

--- a/web/src/lib/components/editor/EditorBubbleMenu.svelte
+++ b/web/src/lib/components/editor/EditorBubbleMenu.svelte
@@ -187,7 +187,14 @@
 			// path hides via the post-insert selectionUpdate, which never fires
 			// here), so A's create form/selection would otherwise linger over B
 			// (Codex).
-			if (originEditor.isDestroyed || editor !== originEditor) {
+			//
+			// `!originEditor.isEditable` is the master-freeze arm (PLAN-2179 DR-1
+			// / TASK-2180): the peeking `{#key}` remount used to destroy this
+			// editor mid-create (caught by `isDestroyed`); now the editor stays
+			// alive and merely goes read-only, so we must drop the wiki-link insert
+			// explicitly — a frozen master must not be mutated by an in-flight
+			// create the user started before the pane opened.
+			if (originEditor.isDestroyed || editor !== originEditor || !originEditor.isEditable) {
 				visible = false;
 				showForm = false;
 				title = '';

--- a/web/src/lib/components/editor/ImportFromUrlModal.svelte
+++ b/web/src/lib/components/editor/ImportFromUrlModal.svelte
@@ -89,7 +89,11 @@
 	}
 
 	function handleInsert() {
-		if (!result || !editor) return;
+		// Reactive-freeze guard (PLAN-2179 DR-1 / TASK-2180): the host closes this
+		// modal when the editor goes read-only (a peek), but belt the insert too —
+		// never mutate a frozen doc if an Insert click races that flip. The old
+		// peeking `{#key}` remount destroyed this modal outright.
+		if (!result || !editor || !editor.isEditable) return;
 		// Snapshot the editor's live emptiness BEFORE the insert. Under
 		// collab the ProseMirror doc reflects the authoritative Y.Doc
 		// state, which can include user-typed content that hasn't yet

--- a/web/src/lib/components/editor/attachment-image.ts
+++ b/web/src/lib/components/editor/attachment-image.ts
@@ -315,15 +315,16 @@ export const AttachmentImage = Node.create<AttachmentImageOptions>({
 			};
 
 			const swapNodeUuid = (newId: string): void => {
-				// Master-freeze / R12 (TASK-2172); ACCEPTED tracked edge BUG-2177:
-				// runRotate/runCrop gate editability at CLICK time, but the transform
-				// awaits a network round-trip during which the master can begin peeking
-				// — remounting the editor (editable=false) via the `{#key peeking}`,
-				// which destroys THIS NodeView's editor. Re-check right before the
-				// dispatch: a destroyed view would throw, and a read-only one must not
-				// receive the Yjs transaction the freeze forbids. The server-side
-				// transform still ran; only its doc reference is dropped (the tracked
-				// BUG-2177 tradeoff — no crash, no committed-content loss).
+				// Master-freeze / R12 (TASK-2172): runRotate/runCrop gate editability
+				// at CLICK time, but the transform awaits a network round-trip during
+				// which the master can begin peeking — flipping the editor read-only
+				// (PLAN-2179 DR-1 / TASK-2180: `peeking` no longer remounts via the
+				// `{#key}`; it flips `editable=false` on the SAME view) — or a genuine
+				// remount (item switch / forceRefreshNonce) can destroy THIS NodeView's
+				// editor. Re-check right before the dispatch: a destroyed view would
+				// throw, and a read-only one must not receive the Yjs transaction the
+				// freeze forbids. The server-side transform still ran; only its doc
+				// reference is dropped (no crash, no committed-content loss).
 				if (editor.isDestroyed || !editor.isEditable) return;
 				const pos = typeof getPos === 'function' ? getPos() : null;
 				if (pos == null) return;

--- a/web/src/lib/components/editor/attachment-upload.ts
+++ b/web/src/lib/components/editor/attachment-upload.ts
@@ -171,16 +171,17 @@ function startUpload(
 	opts
 		.upload(file)
 		.then((result) => {
-			// Master-freeze / R12 (TASK-2172); ACCEPTED tracked edge BUG-2177 — the
-			// bytes land server-side but the reference isn't inserted (no crash, no
-			// committed-content loss): the view can be torn down or turned
-			// read-only WHILE this upload is in flight — e.g. a peeking master
-			// remounts its editor (editable=false) via the `{#key peeking}`,
-			// destroying THIS view. Never dispatch into a destroyed/read-only view:
-			// dispatch on a destroyed view throws, and inserting into a frozen one
-			// is exactly the mutation the freeze forbids. Drop the result (the
-			// bytes are already stored server-side; the reference is simply not
-			// inserted) and clean up the placeholder if the same view still lives.
+			// Master-freeze / R12 (TASK-2172): the view can be torn down or turned
+			// read-only WHILE this upload is in flight — a genuine remount (item
+			// switch / forceRefreshNonce) destroys THIS view, or a peeking master
+			// flips it read-only in place (PLAN-2179 DR-1 / TASK-2180: `peeking` is
+			// no longer in the `{#key}`, so a freeze flips `editable=false` on the
+			// SAME view rather than remounting it). Never dispatch into a
+			// destroyed/read-only view: dispatch on a destroyed view throws, and
+			// inserting into a frozen one is exactly the mutation the freeze forbids.
+			// Drop the result (the bytes are already stored server-side; the
+			// reference is simply not inserted) and clean up the placeholder if the
+			// same view still lives.
 			if (view.isDestroyed || !view.editable) {
 				if (!view.isDestroyed) {
 					view.dispatch(view.state.tr.setMeta(pluginKey, { remove: id } satisfies UploadAction));

--- a/web/src/lib/components/editor/block-drag-handle.ts
+++ b/web/src/lib/components/editor/block-drag-handle.ts
@@ -195,6 +195,12 @@ function dropPosAtY(view: EditorView, y: number, dragPos: number): number | null
 }
 
 function executeMove(view: EditorView, fromPos: number, fromNode: any, targetPos: number) {
+	// Reactive-freeze backstop (PLAN-2179 DR-1): a peeking / read-only editor
+	// must never dispatch a block move. `view.editable` is flipped synchronously
+	// by Editor.svelte's editable $effect — ProseMirror recomputes it in
+	// updateStateInner BEFORE plugin views update — so a freeze landing mid-drag
+	// can't persist through this authoritative dispatch guard.
+	if (!view.editable) return;
 	const { state } = view;
 	const { tr, schema } = state;
 
@@ -423,7 +429,10 @@ export const BlockDragHandle = Extension.create({
 
 					// --- Context menu ---
 					function showMenu() {
-						if (!activeBlock) return;
+						// Reactive-freeze bail (PLAN-2179 DR-1): no context menu on a
+						// frozen editor. The handle should already be hidden, but a
+						// freeze can race a queued handle-click/tap.
+						if (!activeBlock || !editorView.editable) return;
 						menuOpen = true;
 						editorView.dom.blur();
 
@@ -485,7 +494,8 @@ export const BlockDragHandle = Extension.create({
 					// Menu item clicks
 					menu.addEventListener('click', (e) => {
 						const btn = (e.target as HTMLElement).closest('.block-menu-item') as HTMLElement;
-						if (!btn || !activeBlock) return;
+						// Reactive-freeze bail (PLAN-2179 DR-1): turn-into is a mutation.
+						if (!btn || !activeBlock || !editorView.editable) return;
 						e.stopPropagation();
 
 						const type = btn.dataset.type;
@@ -500,7 +510,8 @@ export const BlockDragHandle = Extension.create({
 
 					duplicateBtn.addEventListener('click', (e) => {
 						e.stopPropagation();
-						if (!activeBlock) return;
+						// Reactive-freeze bail (PLAN-2179 DR-1): duplicate is a mutation.
+						if (!activeBlock || !editorView.editable) return;
 						const { tr } = editorView.state;
 						const insertPos = activeBlock.pos + activeBlock.node.nodeSize;
 						tr.insert(insertPos, activeBlock.node.copy(activeBlock.node.content));
@@ -512,7 +523,8 @@ export const BlockDragHandle = Extension.create({
 
 					deleteBtn.addEventListener('click', (e) => {
 						e.stopPropagation();
-						if (!activeBlock) return;
+						// Reactive-freeze bail (PLAN-2179 DR-1): delete is a mutation.
+						if (!activeBlock || !editorView.editable) return;
 						const { tr } = editorView.state;
 						tr.delete(activeBlock.pos, activeBlock.pos + activeBlock.node.nodeSize);
 
@@ -541,7 +553,10 @@ export const BlockDragHandle = Extension.create({
 					if (attachBtn) {
 						attachBtn.addEventListener('click', (e) => {
 							e.stopPropagation();
-							if (!activeBlock) return;
+							// Reactive-freeze bail (PLAN-2179 DR-1): don't even open the
+							// picker on a frozen editor (the deferred change handler is
+							// guarded too, for a freeze that lands while it's open).
+							if (!activeBlock || !editorView.editable) return;
 							const block = activeBlock;
 
 							// Find the last non-code textblock within the active block.
@@ -586,6 +601,10 @@ export const BlockDragHandle = Extension.create({
 						attachInput.value = '';
 						const pendingAfter = attachPendingParagraphAfter;
 						attachPendingParagraphAfter = null;
+						// Reactive-freeze bail (PLAN-2179 DR-1): if a freeze landed while
+						// the OS picker was open, drop the upload — pending state is
+						// already cleared above, so the doc stays untouched.
+						if (!editorView.editable) return;
 						if (!files.length) return;
 						if (pendingAfter !== null) {
 							// Atom / code-block path: create the host paragraph now,
@@ -705,7 +724,10 @@ export const BlockDragHandle = Extension.create({
 
 					// --- Drag lifecycle ---
 					function startDrag() {
-						if (!activeBlock) return;
+						// Reactive-freeze bail (PLAN-2179 DR-1): never begin a reorder
+						// on a frozen editor (e.g. a freeze between handle-mousedown and
+						// the drag-threshold move).
+						if (!activeBlock || !editorView.editable) return;
 						hideMenu();
 						dragging = true;
 						activeBlock.dom.style.opacity = '0.2';
@@ -732,7 +754,11 @@ export const BlockDragHandle = Extension.create({
 						stopAutoScroll();
 						editorView.dom.style.pointerEvents = '';
 
-						if (currentDropPos !== null && currentDropPos !== activeBlock.pos) {
+						// Reactive-freeze bail (PLAN-2179 DR-1): if a freeze landed
+						// mid-drag, skip the move dispatch but still run the cleanup
+						// below so the ghost/opacity/drop-line don't dangle. executeMove
+						// also self-guards on `view.editable` as a final backstop.
+						if (editorView.editable && currentDropPos !== null && currentDropPos !== activeBlock.pos) {
 							try {
 								executeMove(editorView, activeBlock.pos, activeBlock.node, currentDropPos);
 							} catch (e) {
@@ -764,6 +790,11 @@ export const BlockDragHandle = Extension.create({
 
 					// --- Mouse events ---
 					function onMouseMove(e: MouseEvent) {
+						// Reactive-freeze choke (PLAN-2179 DR-1): a frozen editor shows
+						// no handle, so no hover/click/drag interaction can start. This
+						// (plus update() below) is what lets `editable={!peeking}` shed
+						// the handle WITHOUT remounting the editor.
+						if (!editorView.editable) { hideHandle(); return; }
 						if (dragging || menuOpen) return;
 						hoverMode = true;
 						userHasInteracted = true;
@@ -883,6 +914,11 @@ export const BlockDragHandle = Extension.create({
 
 					return {
 						update(view) {
+							// Reactive-freeze choke (PLAN-2179 DR-1): setEditable(false)
+							// runs an updateState, and ProseMirror recomputes view.editable
+							// BEFORE this plugin update fires — so a freeze hides the handle
+							// synchronously here, no editor remount required.
+							if (!editorView.editable) { hideHandle(); return; }
 							if (dragging || menuOpen) return;
 							if (hoverMode) return;
 							if (!userHasInteracted) return;

--- a/web/src/lib/components/editor/blockDragHandleFreeze.svelte.test.ts
+++ b/web/src/lib/components/editor/blockDragHandleFreeze.svelte.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { Editor } from '@tiptap/core';
+import StarterKit from '@tiptap/starter-kit';
+import { BlockDragHandle } from './block-drag-handle';
+
+// PLAN-2179 DR-1 / TASK-2180 — BlockDragHandle is now reactive-editable-aware,
+// so the master-freeze flips `editable` WITHOUT remounting the editor (the
+// `peeking` `{#key}` remount is gone). BlockDragHandle was the SOLE
+// construction-gated freeze surface; these tests lock the two load-bearing
+// properties of making it reactive instead:
+//
+//   1. Flipping `editable=false` (a "peek") hides the handle AND makes EVERY
+//      mutation dispatch path bail — drag-reorder, duplicate, delete, turn-into
+//      — so the freeze stays a TOTAL freeze even though the editor lives on.
+//   2. Flipping `editable` does NOT recreate the ProseMirror view — same view,
+//      same DOM node — which is the whole point of dropping the remount.
+//   3. Pure superset: with `editable=true` the exact same paths DO mutate, so
+//      the guards only ever add a runtime gate (byte-identical for editors).
+//
+// The handle + menu are imperative DOM the plugin appends to the wrapper /
+// <body>, so the tests drive it through a real Tiptap editor rather than mocks.
+// We use the SELECTION path (plugin `update()` → `blockAtPos`) to populate the
+// active block + show the handle, which — unlike the hover path — needs no
+// `posAtCoords` (absent in jsdom).
+
+function makeEditor(element: HTMLElement): Editor {
+	return new Editor({
+		element,
+		extensions: [StarterKit, BlockDragHandle],
+		content: '<p>alpha</p><p>bravo</p>',
+		editable: true,
+	});
+}
+
+/** Populate the plugin's active block + reveal the handle via the selection
+ *  path: arm `userHasInteracted` (a wrapper click), then drop an empty cursor
+ *  inside the first paragraph so the plugin `update()` runs `blockAtPos`. */
+function armHandleOnFirstBlock(editor: Editor, wrapper: HTMLElement): HTMLElement {
+	wrapper.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+	editor.commands.setTextSelection(3); // inside "alpha"
+	const handle = wrapper.querySelector('.block-drag-handle') as HTMLElement;
+	return handle;
+}
+
+function menuButtonByText(label: string): HTMLElement {
+	const btn = [...document.querySelectorAll('.block-menu-item')].find((b) =>
+		(b.textContent ?? '').includes(label),
+	);
+	if (!btn) throw new Error(`menu button "${label}" not found`);
+	return btn as HTMLElement;
+}
+
+describe('BlockDragHandle reactive-editable freeze (PLAN-2179 DR-1 / TASK-2180)', () => {
+	let editor: Editor | null = null;
+	let element: HTMLElement | null = null;
+
+	afterEach(() => {
+		editor?.destroy();
+		element?.remove();
+		editor = null;
+		element = null;
+	});
+
+	function setup(): { editor: Editor; wrapper: HTMLElement; handle: HTMLElement } {
+		element = document.body.appendChild(document.createElement('div'));
+		editor = makeEditor(element);
+		const handle = armHandleOnFirstBlock(editor, element);
+		return { editor, wrapper: element, handle };
+	}
+
+	it('shows the handle while editable, then hides it synchronously when editable flips false', () => {
+		const { editor, handle } = setup();
+
+		// Editable: the selection path revealed the handle.
+		expect(editor.view.editable).toBe(true);
+		expect(handle.style.display).toBe('flex');
+
+		// Freeze. setEditable runs an updateState → ProseMirror recomputes
+		// view.editable BEFORE the plugin update fires, so the handle hides in
+		// the SAME synchronous tick — no mouse move, no remount needed.
+		editor.setEditable(false);
+		expect(editor.view.editable).toBe(false);
+		expect(handle.style.display).toBe('none');
+	});
+
+	it('does NOT recreate the editor view or its DOM node across an editable flip (no remount)', () => {
+		const { editor } = setup();
+		const view = editor.view;
+		const dom = editor.view.dom;
+
+		editor.setEditable(false);
+		editor.setEditable(true);
+
+		// A remount would destroy + recreate these; the reactive freeze keeps the
+		// SAME view + DOM node alive across the peek/un-peek.
+		expect(editor.view).toBe(view);
+		expect(editor.view.dom).toBe(dom);
+		expect(dom.isConnected).toBe(true);
+	});
+
+	it('while frozen, NO mutation path fires — drag-reorder, delete, duplicate, or turn-into', () => {
+		const { editor, wrapper, handle } = setup();
+		expect(editor.state.doc.childCount).toBe(2);
+
+		editor.setEditable(false);
+
+		// Delete: the menu handler bails on !editable (the active block is still
+		// captured from the pre-freeze selection path, so absent the guard this
+		// WOULD delete).
+		document.querySelector<HTMLElement>('.block-menu-item-danger')!.dispatchEvent(
+			new MouseEvent('click', { bubbles: true }),
+		);
+		expect(editor.state.doc.childCount).toBe(2);
+
+		// Duplicate: same bail.
+		menuButtonByText('Duplicate').dispatchEvent(new MouseEvent('click', { bubbles: true }));
+		expect(editor.state.doc.childCount).toBe(2);
+
+		// Turn-into: the delegated menu-click listener bails on !editable, so the
+		// first paragraph stays a paragraph (never converted).
+		document.querySelector<HTMLElement>('.block-menu-item[data-type]')!.dispatchEvent(
+			new MouseEvent('click', { bubbles: true }),
+		);
+		expect(editor.state.doc.firstChild?.type.name).toBe('paragraph');
+
+		// Drag-reorder: a handle mousedown + past-threshold move must NOT start a
+		// drag (startDrag bails on !editable — it never adds the `active` class nor
+		// disables the editor's pointer-events), and nothing reorders.
+		handle.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, clientY: 100 }));
+		window.dispatchEvent(new MouseEvent('mousemove', { clientY: 130 }));
+		window.dispatchEvent(new MouseEvent('mouseup', { clientY: 130 }));
+		expect(handle.classList.contains('active')).toBe(false);
+		expect((editor.view.dom as HTMLElement).style.pointerEvents).not.toBe('none');
+		expect(editor.state.doc.childCount).toBe(2);
+		expect(editor.state.doc.firstChild?.textContent).toBe('alpha');
+		// no stray drag ghost left in the document body
+		expect(wrapper).toBeTruthy();
+	});
+
+	it('is a pure superset: with editable=true the delete path still dispatches (the guard is the ONLY blocker)', () => {
+		const { editor } = setup();
+		expect(editor.state.doc.childCount).toBe(2);
+
+		// Freeze then un-freeze; un-freezing re-runs update() and re-captures the
+		// active block from the (unchanged) selection.
+		editor.setEditable(false);
+		editor.setEditable(true);
+		expect(editor.view.editable).toBe(true);
+
+		document.querySelector<HTMLElement>('.block-menu-item-danger')!.dispatchEvent(
+			new MouseEvent('click', { bubbles: true }),
+		);
+
+		// The first paragraph is gone — proving the ONLY thing blocking it while
+		// frozen was the `!editorView.editable` guard, not a broken path.
+		expect(editor.state.doc.childCount).toBe(1);
+		expect(editor.state.doc.firstChild?.textContent).toBe('bravo');
+	});
+});

--- a/web/src/lib/components/editor/extensions/htmlBlock.ts
+++ b/web/src/lib/components/editor/extensions/htmlBlock.ts
@@ -349,6 +349,15 @@ export const HtmlBlock = Node.create({
 			}
 
 			function commit() {
+				// Reactive-freeze guard (PLAN-2179 DR-1 / TASK-2180): entering
+				// source mode is gated on `isEditable` (see the preview click
+				// handler), but a block ALREADY in source mode when the master
+				// froze keeps its native textarea editable — and commit() fires on
+				// blur / Escape / ⌘-Enter / Done. Never dispatch that edit into a
+				// read-only / peeking doc. The old peeking `{#key}` remount closed
+				// this by destroying the NodeView; the reactive freeze needs the
+				// explicit bail.
+				if (!editor.isEditable) return;
 				const next = textarea.value;
 				const pos = typeof getPos === 'function' ? getPos() : null;
 				if (typeof pos !== 'number') return;

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -2436,11 +2436,16 @@
 			// Bail if the user navigated to a different item — applying
 			// the refresh now would target the wrong document AND stamp
 			// the wrong source URL. The `editorInstance !== targetEditor` arm
-			// ALSO covers the ACCEPTED tracked edge BUG-2177 (TASK-2172): a
-			// source-refresh confirmed pre-pane whose editor is REMOUNTED by the
-			// peeking `{#key peeking}` — the captured `targetEditor` is stale, so
-			// we drop the content replacement (no crash, no committed-content loss).
-			if (switchedAway(targetItem, gen) || editorInstance !== targetEditor) {
+			// still guards genuine editor remounts (item switch /
+			// forceRefreshNonce). The `!targetEditor.isEditable` arm is the
+			// master-freeze backstop (PLAN-2179 DR-1 / TASK-2180): `peeking` no
+			// longer remounts the editor, so a source-refresh confirmed pre-pane
+			// keeps the SAME live `targetEditor` — but that editor is now frozen,
+			// and this full content REPLACE is exactly the mutation the freeze
+			// forbids. Drop it (the old peeking `{#key}` remount dropped it via the
+			// identity arm); no crash, no committed-content loss (the doc is in the
+			// retained Y.Doc).
+			if (switchedAway(targetItem, gen) || editorInstance !== targetEditor || !targetEditor?.isEditable) {
 				return;
 			}
 			const html = marked.parse(resp.markdown, { async: false }) as string;
@@ -4428,31 +4433,28 @@
 							<ContentSkeleton variant="inline" />
 						{:else}
 							<!--
-								Master-freeze (TASK-2154 D2 / TASK-2172): `peeking` is
-								in the {#key} so a freeze/un-freeze REMOUNTS the editor
-								re-bound to the SAME live Y.Doc (ydoc prop unchanged —
-								no teardown of the PROVIDER/Y.Doc, no data loss, the
-								forceRefreshNonce remount pattern). The remount is
-								load-bearing: BlockDragHandle is construction-gated on
-								`editable` (Editor.svelte ~885) — a complex plugin with no
-								single runtime gate — so a reactive editable flip alone
-								would leave the drag-reorder mutation hole open.
-								`editable={!peeking}` also auto-disables the slash menu,
-								mobile toolbar, and table toolbar. Defaults false →
-								editable=true, byte-identical for non-host callers.
-
-								Tradeoff (HT-2176 Option A): the remount destroys the
-								editor VIEW, so an editor-bound action in flight at the
-								instant the pane opens (a paste/drop upload, a rotate/crop
-								transform, a bubble-menu create, a source refresh) is
-								interrupted rather than completed. All degrade GRACEFULLY
-								— the completion paths check `view.isDestroyed`/identity
-								and drop silently; existing content is never lost (it's in
-								the retained Y.Doc). This is the accepted cost of closing
-								the drag-reorder NEW-mutation hole, which the freeze must
-								do; the alternative (no remount) reopens that hole.
+								Master-freeze (TASK-2154 D2 / TASK-2172 / PLAN-2179
+								DR-1 / TASK-2180): the `editable={!peeking}` freeze is
+								now PURELY REACTIVE — `peeking` is NO LONGER in the
+								{#key} (only item.id + forceRefreshNonce remount), so a
+								freeze/un-freeze keeps the SAME editor VIEW alive: no
+								teardown, no reconstruction, no orphaned in-flight action
+								(strictly improves BUG-2177). BlockDragHandle — the ONLY
+								construction-gated freeze surface — is now runtime
+								editable-aware (Editor.svelte registers it
+								unconditionally; block-drag-handle.ts chokes the handle
+								+ bails every mutation dispatch on `editorView.editable`,
+								flipped synchronously by Editor's editable $effect).
+								Everything else the old remount cited is ALREADY reactive
+								and needs no remount: attachment paste/drop/toolbar
+								(editable-gated, TASK-2172), clipboard cut/paste, image
+								rotate/crop, htmlBlock, slash/`[[` pickers (inert on a
+								contentEditable=false view), mobile/table toolbars ({#if
+								editable}), bubble/link popover (host-gated by {#if
+								mutationsEnabled} below). Defaults false → editable=true,
+								byte-identical for non-host callers.
 							-->
-							{#key `${item.id}:true:${forceRefreshNonce}:${peeking}`}
+							{#key `${item.id}:true:${forceRefreshNonce}`}
 								<Editor
 									content={editorContent}
 									onUpdate={handleContentUpdate}


### PR DESCRIPTION
## What

Make the `peeking` master-freeze work **without remounting the Tiptap editor** (PLAN-2179 DR-1), so a future focus-follows-editing model can flip the freeze on every focus switch smoothly (no cursor/scroll/IME loss, no flicker, no collab re-init). Foundational safe intermediate: behavior stays byte-identical for the vast `editable=true` majority — this only **adds runtime `editable` gates** and **removes a remount**.

Today `peeking` sits in the Editor's `{#key}` (ItemDetail) *solely* to shed the construction-gated `BlockDragHandle` (the only `editable ? [...] : []` in the extensions array). A spike confirmed the remount is unnecessary once BlockDragHandle is made reactive-editable-aware.

## Changes

**BlockDragHandle → reactive-editable-aware** (`block-drag-handle.ts`, `Editor.svelte`)
- Register `BlockDragHandle` **unconditionally** (drop the `editable ?` ternary).
- Choke handle visibility on `editorView.editable` in `onMouseMove` + the plugin `update()` — ProseMirror recomputes `view.editable` in `updateStateInner` **before** plugin views update, so a freeze hides the handle synchronously, no remount.
- Bail every mutation dispatch on `!editorView.editable`: `startDrag`, `executeMove`, the `endDrag` move dispatch (keeping cleanup), `showMenu`, and the four menu actions (turn-into / duplicate / delete / attach) + the deferred attach-picker `change` handler.

**Drop the remount** (`ItemDetail.svelte`)
- Remove `peeking` from the editor `{#key}` (keep `item.id` + `forceRefreshNonce`). The freeze now works via `editable={!peeking}` reactively — the **same editor view stays alive** across a peek (strictly improves BUG-2177: no freeze-driven remount to orphan in-flight editor actions).

**Close the late-async / lingering-UI holes the remount used to close** (all gated reactively, no remount reintroduced)
- `EditorBubbleMenu` create continuation — drop the wiki-link insert when `!originEditor.isEditable`.
- `htmlBlock` `commit()` — bail on `!editor.isEditable` (a block already in source mode keeps its native textarea editable across the freeze).
- Slash / `[[` pickers — bail `execSlash`/`execLink` on `!editor.isEditable`, render-gate the menus with `&& editable`, and dismiss them on freeze.
- Insert-from-URL modal — guard `handleInsert` on `!editor.isEditable` and close the modal on freeze.
- Source-refresh (URL re-import) — add `!targetEditor.isEditable` to the post-await guard so a pre-pane-confirmed content REPLACE drops on a frozen doc.
- Table column-resize — clear `columnResizingPluginKey` `dragging` on freeze (a meta-only tr) so its window `mouseup` completion is a no-op (prosemirror-tables gates resize *start* on `view.editable` but not the completion).

Verified everything else the old remount cited was already reactive-gated (attachment paste/drop, clipboard, image rotate/crop via `!view.editable`; mobile/table toolbars via `{#if editable}`; bubble/link popover host-gated by `{#if mutationsEnabled}`). Freshened the now-stale `{#key peeking}` comments in `attachment-upload.ts` / `attachment-image.ts`.

## Tests

- `blockDragHandleFreeze.svelte.test.ts` (new) — real Tiptap editor: the handle hides on freeze; no view/DOM remount across an `editable` flip; every mutation path bails while frozen; and the delete path still fires when editable (pure superset).
- `pane-full-page-host.spec.ts` (2 new, real-browser) — opening/closing the pane freezes/thaws the master editor **without remounting its DOM node** (contenteditable flips in place); the master block drag handle appears on hover when editable, **never** while peeking, and returns on close.

## Gates

- `svelte-check`: 0 errors.
- `vitest`: 448 passed.
- pane e2e (`playwright test pane-`, port 17850): 63 passed / 0 failed.
- Runtime-verified in real Chromium: editable-hover handle `flex` → frozen-hover `none` → thawed-hover `flex`.
- Codex review: **CLEAN** after 4 rounds (rounds 1-3 surfaced the reopened mutation holes above; all gated).

https://claude.ai/code/session_01EZ6yr6pAUFb1uffan912ra