### PR TITLE
fix(store): optimistic concurrency + sibling broadcast for collection settings (BUG-2265)

### DIFF
--- a/internal/events/bus.go
+++ b/internal/events/bus.go
@@ -67,13 +67,18 @@ type Event struct {
 	DocumentID  string `json:"document_id,omitempty"`
 	ItemID      string `json:"item_id,omitempty"`
 	Collection  string `json:"collection,omitempty"`
-	Title       string `json:"title,omitempty"`
-	DocType     string `json:"doc_type,omitempty"`
-	Actor       string `json:"actor,omitempty"`
-	ActorName   string `json:"actor_name,omitempty"`
-	Source      string `json:"source,omitempty"`
-	UserID      string `json:"user_id,omitempty"` // For user-scoped events (e.g. star/unstar)
-	Timestamp   int64  `json:"timestamp"`
+	// NewSlug carries a collection's NEW slug on a collection_updated event
+	// that is a rename (BUG-2265). The event is routed by Collection (the OLD
+	// slug, which the sibling tabs still address) so old-slug watchers receive
+	// it and can re-target to NewSlug. Empty for non-rename updates.
+	NewSlug   string `json:"new_slug,omitempty"`
+	Title     string `json:"title,omitempty"`
+	DocType   string `json:"doc_type,omitempty"`
+	Actor     string `json:"actor,omitempty"`
+	ActorName string `json:"actor_name,omitempty"`
+	Source    string `json:"source,omitempty"`
+	UserID    string `json:"user_id,omitempty"` // For user-scoped events (e.g. star/unstar)
+	Timestamp int64  `json:"timestamp"`
 	// Seq is the workspace-scoped monotonic mutation cursor of the
 	// item the event references (PLAN-1343 / TASK-1352). Populated
 	// for item lifecycle events (created / updated / archived /

--- a/internal/events/bus.go
+++ b/internal/events/bus.go
@@ -66,17 +66,24 @@ type Event struct {
 	WorkspaceID string `json:"workspace_id"`
 	DocumentID  string `json:"document_id,omitempty"`
 	ItemID      string `json:"item_id,omitempty"`
-	Collection  string `json:"collection,omitempty"`
+	// CollectionID is the STABLE collection identity on a collection_updated
+	// event (BUG-2265). Slugs are mutable and reusable and events replay, so a
+	// stale rename event's OLD slug could be re-owned by a different collection;
+	// clients therefore match these events by CollectionID, not the slug (which
+	// stays only for rename-navigation URLs). Empty on non-collection events.
+	CollectionID string `json:"collection_id,omitempty"`
+	Collection   string `json:"collection,omitempty"`
 	// NewSlug carries a collection's NEW slug on a collection_updated event
 	// that is a rename (BUG-2265). The event is routed by Collection (the OLD
 	// slug, which the sibling tabs still address) so old-slug watchers receive
 	// it and can re-target to NewSlug. Empty for non-rename updates.
 	NewSlug string `json:"new_slug,omitempty"`
-	// ItemsChanged is set on a collection_updated event whose schema migration
-	// actually mutated item field values (BUG-2265). It's a SANITIZED reconcile
-	// signal — a bare bool carrying NO per-item data — so it can be delivered to
-	// item-grant subscribers (who receive collection_updated) without leaking
-	// items they can't see; their client triggers a /items-changes deltaSync
+	// ItemsChanged is set on a collection_updated event when a field MIGRATION
+	// WAS REQUESTED (a schema change carrying migrations), independent of how
+	// many rows actually changed (BUG-2265 Codex round 7). It's a SANITIZED
+	// reconcile signal — a bare bool carrying NO per-item data and revealing
+	// nothing about hidden item values — so it can be delivered to item-grant
+	// subscribers; their client triggers a /items-changes deltaSync
 	// (server-filtered to their grants) to pick up the migrated field JSON.
 	ItemsChanged bool   `json:"items_changed,omitempty"`
 	Title        string `json:"title,omitempty"`

--- a/internal/events/bus.go
+++ b/internal/events/bus.go
@@ -21,6 +21,14 @@ const (
 	ItemArchived = "item_archived"
 	ItemRestored = "item_restored"
 
+	// Collection events. Emitted when a collection's own row changes
+	// (settings/schema/name/icon, e.g. a quick-action added). Routed by
+	// Collection (slug) through the SSE visibility filter so sibling
+	// ItemDetails / collection pages refresh their independent Collection
+	// snapshot proactively — shrinking the optimistic-concurrency (409)
+	// window (BUG-2265).
+	CollectionUpdated = "collection_updated"
+
 	// Comment events
 	CommentCreated = "comment_created"
 	CommentUpdated = "comment_updated"

--- a/internal/events/bus.go
+++ b/internal/events/bus.go
@@ -71,14 +71,21 @@ type Event struct {
 	// that is a rename (BUG-2265). The event is routed by Collection (the OLD
 	// slug, which the sibling tabs still address) so old-slug watchers receive
 	// it and can re-target to NewSlug. Empty for non-rename updates.
-	NewSlug   string `json:"new_slug,omitempty"`
-	Title     string `json:"title,omitempty"`
-	DocType   string `json:"doc_type,omitempty"`
-	Actor     string `json:"actor,omitempty"`
-	ActorName string `json:"actor_name,omitempty"`
-	Source    string `json:"source,omitempty"`
-	UserID    string `json:"user_id,omitempty"` // For user-scoped events (e.g. star/unstar)
-	Timestamp int64  `json:"timestamp"`
+	NewSlug string `json:"new_slug,omitempty"`
+	// ItemsChanged is set on a collection_updated event whose schema migration
+	// actually mutated item field values (BUG-2265). It's a SANITIZED reconcile
+	// signal — a bare bool carrying NO per-item data — so it can be delivered to
+	// item-grant subscribers (who receive collection_updated) without leaking
+	// items they can't see; their client triggers a /items-changes deltaSync
+	// (server-filtered to their grants) to pick up the migrated field JSON.
+	ItemsChanged bool   `json:"items_changed,omitempty"`
+	Title        string `json:"title,omitempty"`
+	DocType      string `json:"doc_type,omitempty"`
+	Actor        string `json:"actor,omitempty"`
+	ActorName    string `json:"actor_name,omitempty"`
+	Source       string `json:"source,omitempty"`
+	UserID       string `json:"user_id,omitempty"` // For user-scoped events (e.g. star/unstar)
+	Timestamp    int64  `json:"timestamp"`
 	// Seq is the workspace-scoped monotonic mutation cursor of the
 	// item the event references (PLAN-1343 / TASK-1352). Populated
 	// for item lifecycle events (created / updated / archived /

--- a/internal/models/collection.go
+++ b/internal/models/collection.go
@@ -93,6 +93,14 @@ type CollectionUpdate struct {
 	Settings    *string          `json:"settings,omitempty"`
 	SortOrder   *int             `json:"sort_order,omitempty"`
 	Migrations  []FieldMigration `json:"migrations,omitempty"`
+	// ExpectedUpdatedAt, when non-empty, opts into optimistic-concurrency
+	// control (BUG-2265, mirroring the item pattern from IDEA-1480): the
+	// store re-reads the row's updated_at under the workspace write lock and
+	// rejects the write with a conflict error when it no longer matches the
+	// RFC3339 timestamp the caller last read. Empty = last-write-wins (the
+	// legacy behaviour, unchanged for CLI / MCP / API callers that don't send
+	// it). Never persisted; consumed by UpdateCollection only.
+	ExpectedUpdatedAt string `json:"expected_updated_at,omitempty"`
 }
 
 // ErrInvalidSettingsType is returned by CollectionUpdate.UnmarshalJSON

--- a/internal/server/handlers_collections.go
+++ b/internal/server/handlers_collections.go
@@ -260,18 +260,16 @@ func (s *Server) handleUpdateCollection(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	// Apply field value migrations to existing items
-	if len(migrations) > 0 {
-		if _, err := s.store.MigrateItemFieldValues(coll.ID, migrations); err != nil {
-			writeError(w, http.StatusInternalServerError, "internal_error", "Schema updated but migration failed: "+err.Error())
-			return
-		}
-	}
-
 	// BUG-2265 (part 3): broadcast a collection.updated event so sibling
 	// ItemDetails / collection pages in this workspace refresh their own
 	// independent Collection snapshot proactively — shrinking the window in
 	// which another client would send a stale expected_updated_at and 409.
+	//
+	// Published BEFORE the field migration runs (Codex P2): UpdateCollection has
+	// already COMMITTED (updated_at advanced), so even if the migration below
+	// fails and we return a 500, the row genuinely changed — siblings must still
+	// be told to resync their concurrency token, or they'd 409 blindly against a
+	// value they can never guess. Publishing on the commit is the accurate seam.
 	//
 	// ALWAYS routed by the OLD slug (coll.Slug) — the slug sibling tabs still
 	// address. On a rename the event carries the NEW slug so those tabs can
@@ -283,6 +281,14 @@ func (s *Server) handleUpdateCollection(w http.ResponseWriter, r *http.Request) 
 		newSlug = updated.Slug
 	}
 	s.publishCollectionEvent(events.CollectionUpdated, workspaceID, coll.Slug, newSlug)
+
+	// Apply field value migrations to existing items
+	if len(migrations) > 0 {
+		if _, err := s.store.MigrateItemFieldValues(coll.ID, migrations); err != nil {
+			writeError(w, http.StatusInternalServerError, "internal_error", "Schema updated but migration failed: "+err.Error())
+			return
+		}
+	}
 
 	writeJSON(w, http.StatusOK, updated)
 }

--- a/internal/server/handlers_collections.go
+++ b/internal/server/handlers_collections.go
@@ -374,7 +374,25 @@ func (s *Server) handleDeleteCollection(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	if err := s.store.DeleteCollection(coll.ID); err != nil {
+	// Optimistic-concurrency token (BUG-2265 Codex round 8): a caller that
+	// resolved the collection by stable id passes the updated_at it read so the
+	// delete 409s if a concurrent RENAME re-owned this slug with a DIFFERENT
+	// collection (or the collection changed) — never archiving the wrong one.
+	// Validated at the boundary (clean 400 on a malformed value).
+	expectedUpdatedAt := r.URL.Query().Get("expected_updated_at")
+	if expectedUpdatedAt != "" {
+		if _, perr := time.Parse(time.RFC3339, expectedUpdatedAt); perr != nil {
+			writeError(w, http.StatusBadRequest, "bad_request",
+				"expected_updated_at must be an RFC3339 timestamp")
+			return
+		}
+	}
+
+	if err := s.store.DeleteCollection(coll.ID, expectedUpdatedAt); err != nil {
+		if conflict, ok := asCollectionUpdateConflictError(err); ok {
+			writeCollectionUpdateConflictError(w, coll.Slug, conflict)
+			return
+		}
 		if err == sql.ErrNoRows {
 			writeError(w, http.StatusNotFound, "not_found", "Collection not found")
 			return

--- a/internal/server/handlers_collections.go
+++ b/internal/server/handlers_collections.go
@@ -240,10 +240,12 @@ func (s *Server) handleUpdateCollection(w http.ResponseWriter, r *http.Request) 
 		}
 	}
 
-	// Extract migrations before updating (they're not stored on the collection)
-	migrations := input.Migrations
-	input.Migrations = nil
-
+	// Field-value migrations (select-option renames) are applied ATOMICALLY
+	// inside UpdateCollection's transaction (BUG-2265 Codex P1) — a migration
+	// failure rolls back the schema change AND the concurrency-token advance,
+	// so nothing is committed and the caller's retry works cleanly. Leave them
+	// on the input rather than extracting + running them as a separate,
+	// non-atomic write.
 	updated, err := s.store.UpdateCollection(coll.ID, input)
 	if err != nil {
 		// BUG-2265: an optimistic-concurrency loss → structured 409, same
@@ -264,12 +266,8 @@ func (s *Server) handleUpdateCollection(w http.ResponseWriter, r *http.Request) 
 	// ItemDetails / collection pages in this workspace refresh their own
 	// independent Collection snapshot proactively — shrinking the window in
 	// which another client would send a stale expected_updated_at and 409.
-	//
-	// Published BEFORE the field migration runs (Codex P2): UpdateCollection has
-	// already COMMITTED (updated_at advanced), so even if the migration below
-	// fails and we return a 500, the row genuinely changed — siblings must still
-	// be told to resync their concurrency token, or they'd 409 blindly against a
-	// value they can never guess. Publishing on the commit is the accurate seam.
+	// Published AFTER the fully-atomic update+migration committed, so a failed
+	// migration (which rolled everything back) does NOT emit a spurious refresh.
 	//
 	// ALWAYS routed by the OLD slug (coll.Slug) — the slug sibling tabs still
 	// address. On a rename the event carries the NEW slug so those tabs can
@@ -281,14 +279,6 @@ func (s *Server) handleUpdateCollection(w http.ResponseWriter, r *http.Request) 
 		newSlug = updated.Slug
 	}
 	s.publishCollectionEvent(events.CollectionUpdated, workspaceID, coll.Slug, newSlug)
-
-	// Apply field value migrations to existing items
-	if len(migrations) > 0 {
-		if _, err := s.store.MigrateItemFieldValues(coll.ID, migrations); err != nil {
-			writeError(w, http.StatusInternalServerError, "internal_error", "Schema updated but migration failed: "+err.Error())
-			return
-		}
-	}
 
 	writeJSON(w, http.StatusOK, updated)
 }

--- a/internal/server/handlers_collections.go
+++ b/internal/server/handlers_collections.go
@@ -7,10 +7,13 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 
+	"github.com/PerpetualSoftware/pad/internal/events"
 	"github.com/PerpetualSoftware/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/store"
 )
 
 // reservedSchemaFieldKeys are collection schema field keys that collide
@@ -205,6 +208,19 @@ func (s *Server) handleUpdateCollection(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	// BUG-2265: validate the optimistic-concurrency token's format at the
+	// boundary so a malformed value is a clean 400 rather than surfacing from
+	// the store as a generic 500. The store re-parses (guaranteed to succeed)
+	// and does the actual under-lock comparison. Mirrors handlers_items.go's
+	// handleUpdateItem boundary check.
+	if input.ExpectedUpdatedAt != "" {
+		if _, perr := time.Parse(time.RFC3339, input.ExpectedUpdatedAt); perr != nil {
+			writeError(w, http.StatusBadRequest, "bad_request",
+				"expected_updated_at must be an RFC3339 timestamp")
+			return
+		}
+	}
+
 	if input.Schema != nil {
 		var schema models.CollectionSchema
 		if err := json.Unmarshal([]byte(*input.Schema), &schema); err != nil {
@@ -230,6 +246,12 @@ func (s *Server) handleUpdateCollection(w http.ResponseWriter, r *http.Request) 
 
 	updated, err := s.store.UpdateCollection(coll.ID, input)
 	if err != nil {
+		// BUG-2265: an optimistic-concurrency loss → structured 409, same
+		// wire shape as the item path, BEFORE the generic internal-error path.
+		if conflict, ok := asCollectionUpdateConflictError(err); ok {
+			writeCollectionUpdateConflictError(w, coll.Slug, conflict)
+			return
+		}
 		writeInternalError(w, err)
 		return
 	}
@@ -246,7 +268,52 @@ func (s *Server) handleUpdateCollection(w http.ResponseWriter, r *http.Request) 
 		}
 	}
 
+	// BUG-2265 (part 3): broadcast a collection.updated event so sibling
+	// ItemDetails / collection pages in this workspace refresh their own
+	// independent Collection snapshot proactively — shrinking the window in
+	// which another client would send a stale expected_updated_at and 409.
+	// Published with the NEW slug (renames change it); settings-only edits
+	// keep the slug, which is the common BUG-2265 case (quick actions).
+	actor, source := actorFromRequest(r)
+	s.publishCollectionEvent(events.CollectionUpdated, workspaceID, updated.Slug, actor, actorNameFromRequest(r), source)
+
 	writeJSON(w, http.StatusOK, updated)
+}
+
+// asCollectionUpdateConflictError reports whether err is (or wraps) a
+// store.CollectionUpdateConflictError and returns it. Mirrors
+// asUpdateConflictError for the item path (BUG-2265).
+func asCollectionUpdateConflictError(err error) (*store.CollectionUpdateConflictError, bool) {
+	var conflict *store.CollectionUpdateConflictError
+	if errors.As(err, &conflict) {
+		return conflict, true
+	}
+	return nil, false
+}
+
+// writeCollectionUpdateConflictError emits the shared update_conflict envelope
+// (HTTP 409) for a collection optimistic-concurrency loss. `ref` is the
+// collection slug. Reuses writeUpdateConflictEnvelope so the wire shape is
+// byte-for-byte identical to the item path's 409 (BUG-2265).
+func writeCollectionUpdateConflictError(w http.ResponseWriter, ref string, conflict *store.CollectionUpdateConflictError) {
+	writeUpdateConflictEnvelope(w, ref, conflict.ExpectedUpdatedAt, conflict.ActualUpdatedAt)
+}
+
+// publishCollectionEvent publishes a real-time event for a collection-level
+// change (BUG-2265). Collection carries the slug so the SSE visibility filter
+// routes it to workspace clients who can see the collection.
+func (s *Server) publishCollectionEvent(eventType, workspaceID, collectionSlug, actor, actorName, source string) {
+	if s.events == nil {
+		return
+	}
+	s.events.Publish(events.Event{
+		Type:        eventType,
+		WorkspaceID: workspaceID,
+		Collection:  collectionSlug,
+		Actor:       actor,
+		ActorName:   actorName,
+		Source:      source,
+	})
 }
 
 func (s *Server) handleDeleteCollection(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/handlers_collections.go
+++ b/internal/server/handlers_collections.go
@@ -246,7 +246,7 @@ func (s *Server) handleUpdateCollection(w http.ResponseWriter, r *http.Request) 
 	// so nothing is committed and the caller's retry works cleanly. Leave them
 	// on the input rather than extracting + running them as a separate,
 	// non-atomic write.
-	updated, err := s.store.UpdateCollection(coll.ID, input)
+	updated, migratedItems, err := s.store.UpdateCollection(coll.ID, input)
 	if err != nil {
 		// BUG-2265: an optimistic-concurrency loss → structured 409, same
 		// wire shape as the item path, BEFORE the generic internal-error path.
@@ -279,6 +279,18 @@ func (s *Server) handleUpdateCollection(w http.ResponseWriter, r *http.Request) 
 		newSlug = updated.Slug
 	}
 	s.publishCollectionEvent(events.CollectionUpdated, workspaceID, coll.Slug, newSlug)
+
+	// BUG-2265 (Codex P1): a field-value migration mutated item `fields` JSON
+	// and advanced item `seq`. collection_updated only refreshes collection
+	// METADATA — open item views would keep stale field JSON under the new
+	// schema and a later full-fields item update could UNDO the migration. When
+	// the migration actually touched ≥1 item, ALSO emit the existing bulk
+	// item-mutation signal (items_bulk_updated) so open views reconcile the
+	// migrated rows via /items-changes. Routed by the collection so the SSE
+	// visibility filter handles it like any collection-scoped item event.
+	if migratedItems > 0 {
+		s.publishBulkItemsEvent(workspaceID, "migrate", updated.Slug, int(migratedItems), "", "", "", 0)
+	}
 
 	writeJSON(w, http.StatusOK, updated)
 }

--- a/internal/server/handlers_collections.go
+++ b/internal/server/handlers_collections.go
@@ -272,10 +272,18 @@ func (s *Server) handleUpdateCollection(w http.ResponseWriter, r *http.Request) 
 	// ItemDetails / collection pages in this workspace refresh their own
 	// independent Collection snapshot proactively — shrinking the window in
 	// which another client would send a stale expected_updated_at and 409.
-	// Published with the NEW slug (renames change it); settings-only edits
-	// keep the slug, which is the common BUG-2265 case (quick actions).
-	actor, source := actorFromRequest(r)
-	s.publishCollectionEvent(events.CollectionUpdated, workspaceID, updated.Slug, actor, actorNameFromRequest(r), source)
+	//
+	// Only when the slug is UNCHANGED (settings/schema/icon/description edits —
+	// the common BUG-2265 case). A rename changes the slug, and the event is
+	// routed + visibility-filtered by slug: an old-slug event would make
+	// siblings refetch the now-dead old slug (404), while a new-slug event
+	// can't reach clients whose visibility snapshot still knows the old slug
+	// (Codex P2). Renames are handled by the existing navigation path
+	// (ItemDetail.onupdated / the collection route), not this refresh event.
+	if updated.Slug == coll.Slug {
+		actor, source := actorFromRequest(r)
+		s.publishCollectionEvent(events.CollectionUpdated, workspaceID, coll.Slug, actor, actorNameFromRequest(r), source)
+	}
 
 	writeJSON(w, http.StatusOK, updated)
 }

--- a/internal/server/handlers_collections.go
+++ b/internal/server/handlers_collections.go
@@ -272,25 +272,24 @@ func (s *Server) handleUpdateCollection(w http.ResponseWriter, r *http.Request) 
 	// ALWAYS routed by the OLD slug (coll.Slug) — the slug sibling tabs still
 	// address. On a rename the event carries the NEW slug so those tabs can
 	// re-target instead of silently hitting the dead old slug on their next
-	// action (Codex P2). No actor/source: an item-grant guest receives this
-	// event, so it must not leak the owner's identity/source (Codex P1).
+	// action (Codex P2). No actor/source: an item-grant subscriber receives
+	// this event, so it must not leak the owner's identity/source (Codex P1).
+	//
+	// itemsChanged (Codex round 6 P1): a field-value migration mutated item
+	// `fields` JSON and advanced item `seq`. Rather than a SEPARATE
+	// items_bulk_updated event (which carries op/count for items an item-grant
+	// subscriber can't see, and isn't rename-routed), fold a SANITIZED bool
+	// onto this already item-grant-delivered, old-slug-routed event. The client
+	// triggers a /items-changes deltaSync (server-filtered to the caller's
+	// grants) + refetches an open item, so open views reconcile the migrated
+	// field JSON — closing the clobber where a stale full-fields item update
+	// would UNDO the migration. Empty/false leak surface: "a collection you can
+	// see items in changed [+ renamed + had item changes]".
 	newSlug := ""
 	if updated.Slug != coll.Slug {
 		newSlug = updated.Slug
 	}
-	s.publishCollectionEvent(events.CollectionUpdated, workspaceID, coll.Slug, newSlug)
-
-	// BUG-2265 (Codex P1): a field-value migration mutated item `fields` JSON
-	// and advanced item `seq`. collection_updated only refreshes collection
-	// METADATA — open item views would keep stale field JSON under the new
-	// schema and a later full-fields item update could UNDO the migration. When
-	// the migration actually touched ≥1 item, ALSO emit the existing bulk
-	// item-mutation signal (items_bulk_updated) so open views reconcile the
-	// migrated rows via /items-changes. Routed by the collection so the SSE
-	// visibility filter handles it like any collection-scoped item event.
-	if migratedItems > 0 {
-		s.publishBulkItemsEvent(workspaceID, "migrate", updated.Slug, int(migratedItems), "", "", "", 0)
-	}
+	s.publishCollectionEvent(events.CollectionUpdated, workspaceID, coll.Slug, newSlug, migratedItems > 0)
 
 	writeJSON(w, http.StatusOK, updated)
 }
@@ -317,19 +316,22 @@ func writeCollectionUpdateConflictError(w http.ResponseWriter, ref string, confl
 // publishCollectionEvent publishes a real-time collection-level change
 // (BUG-2265). Collection carries the (old) slug so the SSE visibility filter
 // routes it to workspace clients who can see the collection; newSlug is set
-// only on a rename. Deliberately SANITIZED — no Actor / ActorName / Source —
-// because this event is delivered to item-grant-only subscribers, who must
-// not learn the owner's identity or edit source (Codex P1). Clients only need
-// the slug(s) to refresh their snapshot / re-target.
-func (s *Server) publishCollectionEvent(eventType, workspaceID, collectionSlug, newSlug string) {
+// only on a rename; itemsChanged is set when a schema migration mutated item
+// field values (a SANITIZED reconcile bool). Deliberately SANITIZED — no Actor
+// / ActorName / Source, no per-item data — because this event is delivered to
+// item-grant subscribers, who must not learn the owner's identity/source or
+// anything about items they can't see (Codex P1). Clients only need the
+// slug(s) + itemsChanged to refresh their snapshot / re-target / reconcile.
+func (s *Server) publishCollectionEvent(eventType, workspaceID, collectionSlug, newSlug string, itemsChanged bool) {
 	if s.events == nil {
 		return
 	}
 	s.events.Publish(events.Event{
-		Type:        eventType,
-		WorkspaceID: workspaceID,
-		Collection:  collectionSlug,
-		NewSlug:     newSlug,
+		Type:         eventType,
+		WorkspaceID:  workspaceID,
+		Collection:   collectionSlug,
+		NewSlug:      newSlug,
+		ItemsChanged: itemsChanged,
 	})
 }
 

--- a/internal/server/handlers_collections.go
+++ b/internal/server/handlers_collections.go
@@ -246,7 +246,16 @@ func (s *Server) handleUpdateCollection(w http.ResponseWriter, r *http.Request) 
 	// so nothing is committed and the caller's retry works cleanly. Leave them
 	// on the input rather than extracting + running them as a separate,
 	// non-atomic write.
-	updated, migratedItems, err := s.store.UpdateCollection(coll.ID, input)
+	// items_changed is set from whether a field MIGRATION WAS REQUESTED, NOT
+	// how many rows actually changed (Codex round 7 P1): an item-grant
+	// subscriber receives this flag, so keying it off the affected-row count
+	// would let a subscriber whose OWN items were unaffected infer that HIDDEN
+	// items matched the migrated value — an info leak. "Migration requested"
+	// leaks nothing about hidden item values. Captured before the store call
+	// (input is passed by value, but read it here for clarity).
+	migrationRequested := len(input.Migrations) > 0
+
+	updated, err := s.store.UpdateCollection(coll.ID, input)
 	if err != nil {
 		// BUG-2265: an optimistic-concurrency loss → structured 409, same
 		// wire shape as the item path, BEFORE the generic internal-error path.
@@ -275,21 +284,26 @@ func (s *Server) handleUpdateCollection(w http.ResponseWriter, r *http.Request) 
 	// action (Codex P2). No actor/source: an item-grant subscriber receives
 	// this event, so it must not leak the owner's identity/source (Codex P1).
 	//
-	// itemsChanged (Codex round 6 P1): a field-value migration mutated item
-	// `fields` JSON and advanced item `seq`. Rather than a SEPARATE
+	// items_changed (Codex round 6/7 P1): a requested field migration mutates
+	// item `fields` JSON and advances item `seq`. Rather than a SEPARATE
 	// items_bulk_updated event (which carries op/count for items an item-grant
-	// subscriber can't see, and isn't rename-routed), fold a SANITIZED bool
-	// onto this already item-grant-delivered, old-slug-routed event. The client
+	// subscriber can't see, and isn't rename-routed), fold a SANITIZED bool onto
+	// this already item-grant-delivered, old-slug-routed event. The client
 	// triggers a /items-changes deltaSync (server-filtered to the caller's
 	// grants) + refetches an open item, so open views reconcile the migrated
 	// field JSON — closing the clobber where a stale full-fields item update
-	// would UNDO the migration. Empty/false leak surface: "a collection you can
-	// see items in changed [+ renamed + had item changes]".
+	// would UNDO the migration.
+	//
+	// The event carries the STABLE collection ID (Codex round 7 P1): slugs are
+	// mutable and reusable, and events replay, so a stale rename event could
+	// otherwise pass a subscriber's slug-based match for a DIFFERENT collection
+	// now owning the old slug. Clients match by collection_id, not slug (the
+	// slug(s) stay only for the rename-navigation URL).
 	newSlug := ""
 	if updated.Slug != coll.Slug {
 		newSlug = updated.Slug
 	}
-	s.publishCollectionEvent(events.CollectionUpdated, workspaceID, coll.Slug, newSlug, migratedItems > 0)
+	s.publishCollectionEvent(events.CollectionUpdated, workspaceID, updated.ID, coll.Slug, newSlug, migrationRequested)
 
 	writeJSON(w, http.StatusOK, updated)
 }
@@ -314,21 +328,23 @@ func writeCollectionUpdateConflictError(w http.ResponseWriter, ref string, confl
 }
 
 // publishCollectionEvent publishes a real-time collection-level change
-// (BUG-2265). Collection carries the (old) slug so the SSE visibility filter
-// routes it to workspace clients who can see the collection; newSlug is set
-// only on a rename; itemsChanged is set when a schema migration mutated item
-// field values (a SANITIZED reconcile bool). Deliberately SANITIZED — no Actor
-// / ActorName / Source, no per-item data — because this event is delivered to
-// item-grant subscribers, who must not learn the owner's identity/source or
+// (BUG-2265). collectionID is the STABLE identity clients match on; Collection
+// carries the (old) slug so the SSE visibility filter routes it to workspace
+// clients who can see the collection; newSlug is set only on a rename;
+// itemsChanged is set when a field migration was requested (a SANITIZED
+// reconcile bool). Deliberately SANITIZED — no Actor / ActorName / Source, no
+// per-item data — because this event is delivered to item-grant subscribers,
+// who must not learn the owner's identity/source or
 // anything about items they can't see (Codex P1). Clients only need the
 // slug(s) + itemsChanged to refresh their snapshot / re-target / reconcile.
-func (s *Server) publishCollectionEvent(eventType, workspaceID, collectionSlug, newSlug string, itemsChanged bool) {
+func (s *Server) publishCollectionEvent(eventType, workspaceID, collectionID, collectionSlug, newSlug string, itemsChanged bool) {
 	if s.events == nil {
 		return
 	}
 	s.events.Publish(events.Event{
 		Type:         eventType,
 		WorkspaceID:  workspaceID,
+		CollectionID: collectionID,
 		Collection:   collectionSlug,
 		NewSlug:      newSlug,
 		ItemsChanged: itemsChanged,

--- a/internal/server/handlers_collections.go
+++ b/internal/server/handlers_collections.go
@@ -273,17 +273,16 @@ func (s *Server) handleUpdateCollection(w http.ResponseWriter, r *http.Request) 
 	// independent Collection snapshot proactively — shrinking the window in
 	// which another client would send a stale expected_updated_at and 409.
 	//
-	// Only when the slug is UNCHANGED (settings/schema/icon/description edits —
-	// the common BUG-2265 case). A rename changes the slug, and the event is
-	// routed + visibility-filtered by slug: an old-slug event would make
-	// siblings refetch the now-dead old slug (404), while a new-slug event
-	// can't reach clients whose visibility snapshot still knows the old slug
-	// (Codex P2). Renames are handled by the existing navigation path
-	// (ItemDetail.onupdated / the collection route), not this refresh event.
-	if updated.Slug == coll.Slug {
-		actor, source := actorFromRequest(r)
-		s.publishCollectionEvent(events.CollectionUpdated, workspaceID, coll.Slug, actor, actorNameFromRequest(r), source)
+	// ALWAYS routed by the OLD slug (coll.Slug) — the slug sibling tabs still
+	// address. On a rename the event carries the NEW slug so those tabs can
+	// re-target instead of silently hitting the dead old slug on their next
+	// action (Codex P2). No actor/source: an item-grant guest receives this
+	// event, so it must not leak the owner's identity/source (Codex P1).
+	newSlug := ""
+	if updated.Slug != coll.Slug {
+		newSlug = updated.Slug
 	}
+	s.publishCollectionEvent(events.CollectionUpdated, workspaceID, coll.Slug, newSlug)
 
 	writeJSON(w, http.StatusOK, updated)
 }
@@ -307,10 +306,14 @@ func writeCollectionUpdateConflictError(w http.ResponseWriter, ref string, confl
 	writeUpdateConflictEnvelope(w, ref, conflict.ExpectedUpdatedAt, conflict.ActualUpdatedAt)
 }
 
-// publishCollectionEvent publishes a real-time event for a collection-level
-// change (BUG-2265). Collection carries the slug so the SSE visibility filter
-// routes it to workspace clients who can see the collection.
-func (s *Server) publishCollectionEvent(eventType, workspaceID, collectionSlug, actor, actorName, source string) {
+// publishCollectionEvent publishes a real-time collection-level change
+// (BUG-2265). Collection carries the (old) slug so the SSE visibility filter
+// routes it to workspace clients who can see the collection; newSlug is set
+// only on a rename. Deliberately SANITIZED — no Actor / ActorName / Source —
+// because this event is delivered to item-grant-only subscribers, who must
+// not learn the owner's identity or edit source (Codex P1). Clients only need
+// the slug(s) to refresh their snapshot / re-target.
+func (s *Server) publishCollectionEvent(eventType, workspaceID, collectionSlug, newSlug string) {
 	if s.events == nil {
 		return
 	}
@@ -318,9 +321,7 @@ func (s *Server) publishCollectionEvent(eventType, workspaceID, collectionSlug, 
 		Type:        eventType,
 		WorkspaceID: workspaceID,
 		Collection:  collectionSlug,
-		Actor:       actor,
-		ActorName:   actorName,
-		Source:      source,
+		NewSlug:     newSlug,
 	})
 }
 

--- a/internal/server/handlers_collections_concurrency_test.go
+++ b/internal/server/handlers_collections_concurrency_test.go
@@ -150,10 +150,74 @@ func TestUpdateCollection_PublishesCollectionUpdatedEvent(t *testing.T) {
 				if event.Collection != coll.Slug {
 					t.Fatalf("collection_updated collection=%q want %q", event.Collection, coll.Slug)
 				}
+				if event.NewSlug != "" {
+					t.Fatalf("settings-only update should not carry new_slug, got %q", event.NewSlug)
+				}
+				// Sanitized: no owner identity/source leaked to (item-grant) guests.
+				if event.Actor != "" || event.ActorName != "" || event.Source != "" {
+					t.Fatalf("collection_updated leaked actor metadata: actor=%q name=%q source=%q",
+						event.Actor, event.ActorName, event.Source)
+				}
 				return
 			}
 		case <-deadline:
 			t.Fatal("timed out waiting for collection_updated event")
+		}
+	}
+}
+
+// TestUpdateCollection_RenameEventCarriesNewSlug covers BUG-2265 Codex-round
+// P2: a rename broadcasts collection_updated routed by the OLD slug and
+// carrying the NEW slug so remote tabs can re-target instead of hitting the
+// dead old slug.
+func TestUpdateCollection_RenameEventCarriesNewSlug(t *testing.T) {
+	srv := testServerWithEvents(t)
+	slug := createWSWithCollections(t, srv)
+	ws, err := srv.store.GetWorkspaceBySlug(slug)
+	if err != nil || ws == nil {
+		t.Fatalf("workspace: %v", err)
+	}
+
+	createRR := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections", map[string]interface{}{
+		"name": "Old Name",
+	})
+	if createRR.Code != http.StatusCreated {
+		t.Fatalf("seed create: expected 201, got %d: %s", createRR.Code, createRR.Body.String())
+	}
+	var coll models.Collection
+	parseJSON(t, createRR, &coll)
+	oldSlug := coll.Slug
+
+	ch := srv.events.Subscribe(ws.ID)
+	defer srv.events.Unsubscribe(ch)
+
+	rr := doRequest(srv, "PATCH", "/api/v1/workspaces/"+slug+"/collections/"+oldSlug, map[string]interface{}{
+		"name": "Brand New Name",
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("rename: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var updated models.Collection
+	parseJSON(t, rr, &updated)
+	if updated.Slug == oldSlug {
+		t.Fatalf("expected the rename to change the slug, still %q", oldSlug)
+	}
+
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case event := <-ch:
+			if event.Type == events.CollectionUpdated {
+				if event.Collection != oldSlug {
+					t.Fatalf("rename event should route by OLD slug, got %q want %q", event.Collection, oldSlug)
+				}
+				if event.NewSlug != updated.Slug {
+					t.Fatalf("rename event new_slug=%q want %q", event.NewSlug, updated.Slug)
+				}
+				return
+			}
+		case <-deadline:
+			t.Fatal("timed out waiting for rename collection_updated event")
 		}
 	}
 }

--- a/internal/server/handlers_collections_concurrency_test.go
+++ b/internal/server/handlers_collections_concurrency_test.go
@@ -97,6 +97,61 @@ func TestUpdateCollection_OptimisticConcurrency(t *testing.T) {
 		}
 	})
 
+	// Codex round-2 P2: the 409's actual_updated_at must be FULL sub-second
+	// precision so the client can round-trip it as the token on retry. A
+	// truncated (second-precision) token would never match the row's real
+	// sub-second updated_at, 409-looping forever.
+	t.Run("409 actual_updated_at round-trips as a usable retry token", func(t *testing.T) {
+		coll := seed(t, "OCC RoundTrip")
+		// First update establishes a sub-second updated_at on the row.
+		first := doRequest(srv, "PATCH", "/api/v1/workspaces/"+slug+"/collections/"+coll.Slug, map[string]interface{}{
+			"settings": `{"layout":"content-primary"}`,
+		})
+		if first.Code != http.StatusOK {
+			t.Fatalf("first update: expected 200, got %d: %s", first.Code, first.Body.String())
+		}
+		var afterFirst models.Collection
+		parseJSON(t, first, &afterFirst)
+
+		// A stale token loses the race → 409 carrying the row's real token.
+		conflictRR := doRequest(srv, "PATCH", "/api/v1/workspaces/"+slug+"/collections/"+coll.Slug, map[string]interface{}{
+			"settings":            `{"layout":"fields-primary"}`,
+			"expected_updated_at": coll.UpdatedAt.UTC().Format(time.RFC3339),
+		})
+		if conflictRR.Code != http.StatusConflict {
+			t.Fatalf("expected 409, got %d: %s", conflictRR.Code, conflictRR.Body.String())
+		}
+		var envelope struct {
+			Error struct {
+				Details struct {
+					ActualUpdatedAt string `json:"actual_updated_at"`
+				} `json:"details"`
+			} `json:"error"`
+		}
+		if err := json.Unmarshal(conflictRR.Body.Bytes(), &envelope); err != nil {
+			t.Fatalf("parse 409 envelope: %v", err)
+		}
+		actual := envelope.Error.Details.ActualUpdatedAt
+		if actual == "" {
+			t.Fatalf("409 missing actual_updated_at: %s", conflictRR.Body.String())
+		}
+		// It must equal the row's current updated_at at full precision, not a
+		// second-truncated version of it.
+		if actual != afterFirst.UpdatedAt.UTC().Format(time.RFC3339Nano) {
+			t.Fatalf("actual_updated_at %q not full-precision (want %q)", actual, afterFirst.UpdatedAt.UTC().Format(time.RFC3339Nano))
+		}
+
+		// Retrying with the returned token must now SUCCEED — proving it's a
+		// usable token, not a truncated one that loops forever.
+		retryRR := doRequest(srv, "PATCH", "/api/v1/workspaces/"+slug+"/collections/"+coll.Slug, map[string]interface{}{
+			"settings":            `{"layout":"fields-primary"}`,
+			"expected_updated_at": actual,
+		})
+		if retryRR.Code != http.StatusOK {
+			t.Fatalf("retry with returned token should succeed, got %d: %s", retryRR.Code, retryRR.Body.String())
+		}
+	})
+
 	t.Run("omitting the token keeps last-write-wins (200)", func(t *testing.T) {
 		coll := seed(t, "OCC NoToken")
 		rr := doRequest(srv, "PATCH", "/api/v1/workspaces/"+slug+"/collections/"+coll.Slug, map[string]interface{}{

--- a/internal/server/handlers_collections_concurrency_test.go
+++ b/internal/server/handlers_collections_concurrency_test.go
@@ -163,6 +163,75 @@ func TestUpdateCollection_OptimisticConcurrency(t *testing.T) {
 	})
 }
 
+// TestDeleteCollection_OptimisticConcurrency covers BUG-2265 Codex round 8: the
+// archive/delete accepts an expected_updated_at token so a concurrent rename
+// that re-owned the slug (or any change) 409s instead of archiving the wrong
+// collection. Mirrors the update OCC.
+func TestDeleteCollection_OptimisticConcurrency(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	seed := func(t *testing.T, name string) models.Collection {
+		t.Helper()
+		createRR := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections", map[string]interface{}{
+			"name": name,
+		})
+		if createRR.Code != http.StatusCreated {
+			t.Fatalf("seed create: expected 201, got %d: %s", createRR.Code, createRR.Body.String())
+		}
+		var coll models.Collection
+		parseJSON(t, createRR, &coll)
+		return coll
+	}
+	exists := func(t *testing.T, collSlug string) bool {
+		t.Helper()
+		getRR := doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/collections/"+collSlug, nil)
+		return getRR.Code == http.StatusOK
+	}
+
+	t.Run("malformed token is a 400", func(t *testing.T) {
+		coll := seed(t, "Del Malformed")
+		rr := doRequest(srv, "DELETE", "/api/v1/workspaces/"+slug+"/collections/"+coll.Slug+"?expected_updated_at=nope", nil)
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400 for malformed token, got %d: %s", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("stale token 409s and does NOT delete", func(t *testing.T) {
+		coll := seed(t, "Del Stale")
+		rr := doRequest(srv, "DELETE", "/api/v1/workspaces/"+slug+"/collections/"+coll.Slug+"?expected_updated_at=2000-01-01T00:00:00Z", nil)
+		if rr.Code != http.StatusConflict {
+			t.Fatalf("expected 409 for stale token, got %d: %s", rr.Code, rr.Body.String())
+		}
+		if !strings.Contains(rr.Body.String(), "update_conflict") {
+			t.Fatalf("expected update_conflict envelope, got: %s", rr.Body.String())
+		}
+		if !exists(t, coll.Slug) {
+			t.Fatalf("collection must still exist after a rejected (409) archive")
+		}
+	})
+
+	t.Run("current token archives (204)", func(t *testing.T) {
+		coll := seed(t, "Del Current")
+		token := coll.UpdatedAt.UTC().Format(time.RFC3339Nano)
+		rr := doRequest(srv, "DELETE", "/api/v1/workspaces/"+slug+"/collections/"+coll.Slug+"?expected_updated_at="+token, nil)
+		if rr.Code != http.StatusNoContent {
+			t.Fatalf("expected 204 for current token, got %d: %s", rr.Code, rr.Body.String())
+		}
+		if exists(t, coll.Slug) {
+			t.Fatalf("collection must be gone after a successful archive")
+		}
+	})
+
+	t.Run("no token archives (legacy path, 204)", func(t *testing.T) {
+		coll := seed(t, "Del NoToken")
+		rr := doRequest(srv, "DELETE", "/api/v1/workspaces/"+slug+"/collections/"+coll.Slug, nil)
+		if rr.Code != http.StatusNoContent {
+			t.Fatalf("expected 204 without a token, got %d: %s", rr.Code, rr.Body.String())
+		}
+	})
+}
+
 // TestUpdateCollection_PublishesCollectionUpdatedEvent covers BUG-2265 part 3:
 // a successful collection update broadcasts a collection_updated event carrying
 // the workspace + collection slug so sibling ItemDetails / pages can refresh

--- a/internal/server/handlers_collections_concurrency_test.go
+++ b/internal/server/handlers_collections_concurrency_test.go
@@ -277,13 +277,13 @@ func TestUpdateCollection_RenameEventCarriesNewSlug(t *testing.T) {
 	}
 }
 
-// TestUpdateCollection_MigrationEmitsBulkItemsEvent covers BUG-2265 Codex round
-// 5 P1: a schema change that MIGRATES item field values must ALSO emit the bulk
-// item-mutation signal (items_bulk_updated) so open item views reconcile the
-// migrated rows via /items-changes — collection_updated only refreshes
-// collection metadata. A settings-only update (no migrated items) must NOT emit
-// it.
-func TestUpdateCollection_MigrationEmitsBulkItemsEvent(t *testing.T) {
+// TestUpdateCollection_MigrationSetsItemsChanged covers BUG-2265 Codex round 6:
+// a schema change that MIGRATES item field values must set the SANITIZED
+// items_changed flag on the (already item-grant-delivered, old-slug-routed)
+// collection_updated event, so open views reconcile the migrated rows via a
+// client /items-changes deltaSync. A settings-only update (no migrated items)
+// leaves items_changed false. No separate items_bulk_updated is emitted.
+func TestUpdateCollection_MigrationSetsItemsChanged(t *testing.T) {
 	srv := testServerWithEvents(t)
 	slug := createWSWithCollections(t, srv)
 	ws, err := srv.store.GetWorkspaceBySlug(slug)
@@ -302,7 +302,26 @@ func TestUpdateCollection_MigrationEmitsBulkItemsEvent(t *testing.T) {
 		t.Fatalf("CreateItem: %v", err)
 	}
 
-	t.Run("migration touching an item emits items_bulk_updated", func(t *testing.T) {
+	// awaitCollectionUpdated returns the next collection_updated event (or fails).
+	awaitCollectionUpdated := func(t *testing.T, ch <-chan events.Event) events.Event {
+		t.Helper()
+		deadline := time.After(2 * time.Second)
+		for {
+			select {
+			case event := <-ch:
+				if event.Type == events.CollectionUpdated {
+					return event
+				}
+				if event.Type == events.ItemsBulkUpdated {
+					t.Fatalf("collection update must not emit items_bulk_updated (folded into collection_updated)")
+				}
+			case <-deadline:
+				t.Fatal("timed out waiting for collection_updated")
+			}
+		}
+	}
+
+	t.Run("migration touching an item sets items_changed", func(t *testing.T) {
 		ch := srv.events.Subscribe(ws.ID)
 		defer srv.events.Unsubscribe(ch)
 
@@ -315,27 +334,21 @@ func TestUpdateCollection_MigrationEmitsBulkItemsEvent(t *testing.T) {
 		if rr.Code != http.StatusOK {
 			t.Fatalf("migration update: expected 200, got %d: %s", rr.Code, rr.Body.String())
 		}
-
-		deadline := time.After(2 * time.Second)
-		for {
-			select {
-			case event := <-ch:
-				if event.Type == events.ItemsBulkUpdated {
-					if event.Collection != coll.Slug {
-						t.Fatalf("bulk event collection=%q want %q", event.Collection, coll.Slug)
-					}
-					if event.Op != "migrate" || event.Count != 1 {
-						t.Fatalf("bulk event op=%q count=%d, want migrate/1", event.Op, event.Count)
-					}
-					return
-				}
-			case <-deadline:
-				t.Fatal("timed out waiting for items_bulk_updated after a migration")
-			}
+		event := awaitCollectionUpdated(t, ch)
+		if event.Collection != coll.Slug {
+			t.Fatalf("collection_updated collection=%q want %q", event.Collection, coll.Slug)
+		}
+		if !event.ItemsChanged {
+			t.Fatalf("migration collection_updated must set items_changed")
+		}
+		// Still sanitized — no actor/source leaked to item-grant subscribers.
+		if event.Actor != "" || event.Source != "" || event.Count != 0 {
+			t.Fatalf("migration event leaked non-sanitized fields: actor=%q source=%q count=%d",
+				event.Actor, event.Source, event.Count)
 		}
 	})
 
-	t.Run("settings-only update emits NO items_bulk_updated", func(t *testing.T) {
+	t.Run("settings-only update leaves items_changed false", func(t *testing.T) {
 		ch := srv.events.Subscribe(ws.ID)
 		defer srv.events.Unsubscribe(ch)
 
@@ -345,18 +358,9 @@ func TestUpdateCollection_MigrationEmitsBulkItemsEvent(t *testing.T) {
 		if rr.Code != http.StatusOK {
 			t.Fatalf("settings update: expected 200, got %d: %s", rr.Code, rr.Body.String())
 		}
-
-		// Drain briefly; a bulk event must NOT arrive (a collection_updated may).
-		deadline := time.After(300 * time.Millisecond)
-		for {
-			select {
-			case event := <-ch:
-				if event.Type == events.ItemsBulkUpdated {
-					t.Fatalf("settings-only update must not emit items_bulk_updated")
-				}
-			case <-deadline:
-				return
-			}
+		event := awaitCollectionUpdated(t, ch)
+		if event.ItemsChanged {
+			t.Fatalf("settings-only update must not set items_changed")
 		}
 	})
 }

--- a/internal/server/handlers_collections_concurrency_test.go
+++ b/internal/server/handlers_collections_concurrency_test.go
@@ -276,3 +276,87 @@ func TestUpdateCollection_RenameEventCarriesNewSlug(t *testing.T) {
 		}
 	}
 }
+
+// TestUpdateCollection_MigrationEmitsBulkItemsEvent covers BUG-2265 Codex round
+// 5 P1: a schema change that MIGRATES item field values must ALSO emit the bulk
+// item-mutation signal (items_bulk_updated) so open item views reconcile the
+// migrated rows via /items-changes — collection_updated only refreshes
+// collection metadata. A settings-only update (no migrated items) must NOT emit
+// it.
+func TestUpdateCollection_MigrationEmitsBulkItemsEvent(t *testing.T) {
+	srv := testServerWithEvents(t)
+	slug := createWSWithCollections(t, srv)
+	ws, err := srv.store.GetWorkspaceBySlug(slug)
+	if err != nil || ws == nil {
+		t.Fatalf("workspace: %v", err)
+	}
+	coll, err := srv.store.CreateCollection(ws.ID, models.CollectionCreate{
+		Name:   "Tasks",
+		Slug:   "tasks-migrate-evt",
+		Schema: `{"fields":[{"key":"status","label":"Status","type":"select","options":["a","b"]}]}`,
+	})
+	if err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	if _, err := srv.store.CreateItem(ws.ID, coll.ID, models.ItemCreate{Title: "T", Fields: `{"status":"a"}`}); err != nil {
+		t.Fatalf("CreateItem: %v", err)
+	}
+
+	t.Run("migration touching an item emits items_bulk_updated", func(t *testing.T) {
+		ch := srv.events.Subscribe(ws.ID)
+		defer srv.events.Unsubscribe(ch)
+
+		rr := doRequest(srv, "PATCH", "/api/v1/workspaces/"+slug+"/collections/"+coll.Slug, map[string]interface{}{
+			"schema": `{"fields":[{"key":"status","label":"Status","type":"select","options":["c","b"]}]}`,
+			"migrations": []map[string]interface{}{
+				{"field": "status", "rename_options": map[string]string{"a": "c"}},
+			},
+		})
+		if rr.Code != http.StatusOK {
+			t.Fatalf("migration update: expected 200, got %d: %s", rr.Code, rr.Body.String())
+		}
+
+		deadline := time.After(2 * time.Second)
+		for {
+			select {
+			case event := <-ch:
+				if event.Type == events.ItemsBulkUpdated {
+					if event.Collection != coll.Slug {
+						t.Fatalf("bulk event collection=%q want %q", event.Collection, coll.Slug)
+					}
+					if event.Op != "migrate" || event.Count != 1 {
+						t.Fatalf("bulk event op=%q count=%d, want migrate/1", event.Op, event.Count)
+					}
+					return
+				}
+			case <-deadline:
+				t.Fatal("timed out waiting for items_bulk_updated after a migration")
+			}
+		}
+	})
+
+	t.Run("settings-only update emits NO items_bulk_updated", func(t *testing.T) {
+		ch := srv.events.Subscribe(ws.ID)
+		defer srv.events.Unsubscribe(ch)
+
+		rr := doRequest(srv, "PATCH", "/api/v1/workspaces/"+slug+"/collections/"+coll.Slug, map[string]interface{}{
+			"settings": `{"layout":"content-primary"}`,
+		})
+		if rr.Code != http.StatusOK {
+			t.Fatalf("settings update: expected 200, got %d: %s", rr.Code, rr.Body.String())
+		}
+
+		// Drain briefly; a bulk event must NOT arrive (a collection_updated may).
+		deadline := time.After(300 * time.Millisecond)
+		for {
+			select {
+			case event := <-ch:
+				if event.Type == events.ItemsBulkUpdated {
+					t.Fatalf("settings-only update must not emit items_bulk_updated")
+				}
+			case <-deadline:
+				return
+			}
+		}
+	})
+}

--- a/internal/server/handlers_collections_concurrency_test.go
+++ b/internal/server/handlers_collections_concurrency_test.go
@@ -205,6 +205,9 @@ func TestUpdateCollection_PublishesCollectionUpdatedEvent(t *testing.T) {
 				if event.Collection != coll.Slug {
 					t.Fatalf("collection_updated collection=%q want %q", event.Collection, coll.Slug)
 				}
+				if event.CollectionID != coll.ID {
+					t.Fatalf("collection_updated collection_id=%q want %q", event.CollectionID, coll.ID)
+				}
 				if event.NewSlug != "" {
 					t.Fatalf("settings-only update should not carry new_slug, got %q", event.NewSlug)
 				}
@@ -266,6 +269,9 @@ func TestUpdateCollection_RenameEventCarriesNewSlug(t *testing.T) {
 				if event.Collection != oldSlug {
 					t.Fatalf("rename event should route by OLD slug, got %q want %q", event.Collection, oldSlug)
 				}
+				if event.CollectionID != updated.ID {
+					t.Fatalf("rename event collection_id=%q want %q (stable identity)", event.CollectionID, updated.ID)
+				}
 				if event.NewSlug != updated.Slug {
 					t.Fatalf("rename event new_slug=%q want %q", event.NewSlug, updated.Slug)
 				}
@@ -277,12 +283,13 @@ func TestUpdateCollection_RenameEventCarriesNewSlug(t *testing.T) {
 	}
 }
 
-// TestUpdateCollection_MigrationSetsItemsChanged covers BUG-2265 Codex round 6:
-// a schema change that MIGRATES item field values must set the SANITIZED
-// items_changed flag on the (already item-grant-delivered, old-slug-routed)
-// collection_updated event, so open views reconcile the migrated rows via a
-// client /items-changes deltaSync. A settings-only update (no migrated items)
-// leaves items_changed false. No separate items_bulk_updated is emitted.
+// TestUpdateCollection_MigrationSetsItemsChanged covers BUG-2265 Codex round
+// 6/7: a schema change carrying migrations sets the SANITIZED items_changed
+// flag on collection_updated — keyed on whether a migration was REQUESTED, not
+// how many rows changed (round 7 P1: an affected-row count would let an
+// item-grant subscriber infer that hidden items matched). The event carries the
+// STABLE CollectionID for id-based matching. A settings-only update leaves
+// items_changed false. No separate items_bulk_updated is emitted.
 func TestUpdateCollection_MigrationSetsItemsChanged(t *testing.T) {
 	srv := testServerWithEvents(t)
 	slug := createWSWithCollections(t, srv)
@@ -338,13 +345,38 @@ func TestUpdateCollection_MigrationSetsItemsChanged(t *testing.T) {
 		if event.Collection != coll.Slug {
 			t.Fatalf("collection_updated collection=%q want %q", event.Collection, coll.Slug)
 		}
+		if event.CollectionID != coll.ID {
+			t.Fatalf("collection_updated collection_id=%q want %q", event.CollectionID, coll.ID)
+		}
 		if !event.ItemsChanged {
 			t.Fatalf("migration collection_updated must set items_changed")
 		}
-		// Still sanitized — no actor/source leaked to item-grant subscribers.
+		// Still sanitized — no actor/source/count leaked to item-grant subscribers.
 		if event.Actor != "" || event.Source != "" || event.Count != 0 {
 			t.Fatalf("migration event leaked non-sanitized fields: actor=%q source=%q count=%d",
 				event.Actor, event.Source, event.Count)
+		}
+	})
+
+	t.Run("migration matching ZERO items still sets items_changed (no row-count leak)", func(t *testing.T) {
+		ch := srv.events.Subscribe(ws.ID)
+		defer srv.events.Unsubscribe(ch)
+
+		// Rename an option value that NO item currently has → 0 rows migrated.
+		// items_changed must STILL be true (keyed on request, not row count), so
+		// an item-grant subscriber can't infer whether hidden items matched.
+		rr := doRequest(srv, "PATCH", "/api/v1/workspaces/"+slug+"/collections/"+coll.Slug, map[string]interface{}{
+			"schema": `{"fields":[{"key":"status","label":"Status","type":"select","options":["b","z"]}]}`,
+			"migrations": []map[string]interface{}{
+				{"field": "status", "rename_options": map[string]string{"nonexistent": "z"}},
+			},
+		})
+		if rr.Code != http.StatusOK {
+			t.Fatalf("zero-match migration: expected 200, got %d: %s", rr.Code, rr.Body.String())
+		}
+		event := awaitCollectionUpdated(t, ch)
+		if !event.ItemsChanged {
+			t.Fatalf("a REQUESTED migration must set items_changed even when 0 rows matched")
 		}
 	})
 

--- a/internal/server/handlers_collections_concurrency_test.go
+++ b/internal/server/handlers_collections_concurrency_test.go
@@ -1,0 +1,159 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/events"
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// settingsLayout parses a collection's settings JSON and returns its layout.
+// Postgres re-serializes the JSONB settings column (spaces / key order differ
+// from the literal sent), so tests compare parsed values, not raw strings.
+func settingsLayout(t *testing.T, raw string) string {
+	t.Helper()
+	var s models.CollectionSettings
+	if err := json.Unmarshal([]byte(raw), &s); err != nil {
+		t.Fatalf("parse settings %q: %v", raw, err)
+	}
+	return s.Layout
+}
+
+// BUG-2265: collection settings writes are optimistic-concurrency guarded when
+// the caller round-trips expected_updated_at. These tests cover the handler
+// boundary (400 on a malformed token, 409 on a stale token with the shared
+// update_conflict envelope, 200 when the token matches) and confirm a rejected
+// write does NOT land.
+
+func TestUpdateCollection_OptimisticConcurrency(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	seed := func(t *testing.T, name string) models.Collection {
+		t.Helper()
+		createRR := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections", map[string]interface{}{
+			"name":     name,
+			"settings": `{"layout":"balanced"}`,
+		})
+		if createRR.Code != http.StatusCreated {
+			t.Fatalf("seed create: expected 201, got %d: %s", createRR.Code, createRR.Body.String())
+		}
+		var coll models.Collection
+		parseJSON(t, createRR, &coll)
+		return coll
+	}
+
+	t.Run("malformed expected_updated_at is a 400", func(t *testing.T) {
+		coll := seed(t, "OCC Malformed")
+		rr := doRequest(srv, "PATCH", "/api/v1/workspaces/"+slug+"/collections/"+coll.Slug, map[string]interface{}{
+			"settings":            `{"layout":"content-primary"}`,
+			"expected_updated_at": "not-a-timestamp",
+		})
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400 for malformed token, got %d: %s", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("stale expected_updated_at is a 409 update_conflict and does not land", func(t *testing.T) {
+		coll := seed(t, "OCC Stale")
+		rr := doRequest(srv, "PATCH", "/api/v1/workspaces/"+slug+"/collections/"+coll.Slug, map[string]interface{}{
+			"settings":            `{"layout":"content-primary"}`,
+			"expected_updated_at": "2000-01-01T00:00:00Z",
+		})
+		if rr.Code != http.StatusConflict {
+			t.Fatalf("expected 409 for stale token, got %d: %s", rr.Code, rr.Body.String())
+		}
+		if !strings.Contains(rr.Body.String(), "update_conflict") {
+			t.Fatalf("expected update_conflict envelope, got: %s", rr.Body.String())
+		}
+
+		// The rejected write must NOT have landed.
+		getRR := doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/collections/"+coll.Slug, nil)
+		var refetched models.Collection
+		parseJSON(t, getRR, &refetched)
+		if got := settingsLayout(t, refetched.Settings); got != "balanced" {
+			t.Fatalf("expected layout unchanged (balanced) after a rejected conflict, got %q (%q)", got, refetched.Settings)
+		}
+	})
+
+	t.Run("matching expected_updated_at is accepted", func(t *testing.T) {
+		coll := seed(t, "OCC Match")
+		token := coll.UpdatedAt.UTC().Format(time.RFC3339)
+		rr := doRequest(srv, "PATCH", "/api/v1/workspaces/"+slug+"/collections/"+coll.Slug, map[string]interface{}{
+			"settings":            `{"layout":"content-primary"}`,
+			"expected_updated_at": token,
+		})
+		if rr.Code != http.StatusOK {
+			t.Fatalf("expected 200 for matching token, got %d: %s", rr.Code, rr.Body.String())
+		}
+		var updated models.Collection
+		parseJSON(t, rr, &updated)
+		if got := settingsLayout(t, updated.Settings); got != "content-primary" {
+			t.Fatalf("expected layout content-primary written, got %q (%q)", got, updated.Settings)
+		}
+	})
+
+	t.Run("omitting the token keeps last-write-wins (200)", func(t *testing.T) {
+		coll := seed(t, "OCC NoToken")
+		rr := doRequest(srv, "PATCH", "/api/v1/workspaces/"+slug+"/collections/"+coll.Slug, map[string]interface{}{
+			"settings": `{"layout":"fields-primary"}`,
+		})
+		if rr.Code != http.StatusOK {
+			t.Fatalf("expected 200 without a token, got %d: %s", rr.Code, rr.Body.String())
+		}
+	})
+}
+
+// TestUpdateCollection_PublishesCollectionUpdatedEvent covers BUG-2265 part 3:
+// a successful collection update broadcasts a collection_updated event carrying
+// the workspace + collection slug so sibling ItemDetails / pages can refresh
+// their independent snapshot.
+func TestUpdateCollection_PublishesCollectionUpdatedEvent(t *testing.T) {
+	srv := testServerWithEvents(t)
+	slug := createWSWithCollections(t, srv)
+	ws, err := srv.store.GetWorkspaceBySlug(slug)
+	if err != nil || ws == nil {
+		t.Fatalf("workspace: %v", err)
+	}
+
+	createRR := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections", map[string]interface{}{
+		"name": "Broadcast Me",
+	})
+	if createRR.Code != http.StatusCreated {
+		t.Fatalf("seed create: expected 201, got %d: %s", createRR.Code, createRR.Body.String())
+	}
+	var coll models.Collection
+	parseJSON(t, createRR, &coll)
+
+	ch := srv.events.Subscribe(ws.ID)
+	defer srv.events.Unsubscribe(ch)
+
+	rr := doRequest(srv, "PATCH", "/api/v1/workspaces/"+slug+"/collections/"+coll.Slug, map[string]interface{}{
+		"settings": `{"quick_actions":[{"label":"Go","prompt":"/pad go","scope":"item"}]}`,
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("update: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case event := <-ch:
+			if event.Type == events.CollectionUpdated {
+				if event.WorkspaceID != ws.ID {
+					t.Fatalf("collection_updated workspace=%q want %q", event.WorkspaceID, ws.ID)
+				}
+				if event.Collection != coll.Slug {
+					t.Fatalf("collection_updated collection=%q want %q", event.Collection, coll.Slug)
+				}
+				return
+			}
+		case <-deadline:
+			t.Fatal("timed out waiting for collection_updated event")
+		}
+	}
+}

--- a/internal/server/handlers_events.go
+++ b/internal/server/handlers_events.go
@@ -386,18 +386,30 @@ func sseEventVisibleFor(vis sseVisibility, sseUserID string, event events.Event)
 		}
 		return true
 	}
-	if !vis.visibleSlugSet[collection] {
+	// Determine which slug this subscriber can actually see. For a rename
+	// (NewSlug set, BUG-2265) the event is ROUTED by the OLD slug, but a
+	// subscriber that reconnected / revalidated AFTER the rename only has the
+	// NEW slug in its visibleSlugSet — accept EITHER so the client still learns
+	// the rename mapping (Codex). Non-rename events have NewSlug == "", so this
+	// reduces to the old single-slug check.
+	visibleColl := ""
+	if vis.visibleSlugSet[collection] {
+		visibleColl = collection
+	} else if event.NewSlug != "" && vis.visibleSlugSet[event.NewSlug] {
+		visibleColl = event.NewSlug
+	}
+	if visibleColl == "" {
 		return false
 	}
 	// For subscribers filtered to item-level grants in this collection
 	// (no full-collection access):
-	if vis.grantedItemSet != nil && !vis.fullCollSet[collection] {
+	if vis.grantedItemSet != nil && !vis.fullCollSet[visibleColl] {
 		// Item-scoped events: gate on the specific granted item.
 		if itemID != "" {
 			return vis.grantedItemSet[itemID]
 		}
 		// collection.updated (BUG-2265) is itemless but carries ONLY the
-		// collection slug — no per-item op/count/timing — and the collection
+		// collection slug(s) — no per-item op/count/timing — and the collection
 		// is already confirmed visible above, so it's safe to deliver to
 		// item-grant subscribers. They need it to converge their ItemDetail's
 		// schema/settings snapshot for the items they CAN see.

--- a/internal/server/handlers_events.go
+++ b/internal/server/handlers_events.go
@@ -396,7 +396,15 @@ func sseEventVisibleFor(vis sseVisibility, sseUserID string, event events.Event)
 		if itemID != "" {
 			return vis.grantedItemSet[itemID]
 		}
-		// Itemless collection-scoped events (e.g. the items_bulk_updated
+		// collection.updated (BUG-2265) is itemless but carries ONLY the
+		// collection slug — no per-item op/count/timing — and the collection
+		// is already confirmed visible above, so it's safe to deliver to
+		// item-grant subscribers. They need it to converge their ItemDetail's
+		// schema/settings snapshot for the items they CAN see.
+		if event.Type == events.CollectionUpdated {
+			return true
+		}
+		// Other itemless collection-scoped events (e.g. the items_bulk_updated
 		// batch event, TASK-1668) can't be item-grant-filtered — they'd
 		// otherwise leak op/count/timing for items the subscriber can't
 		// see. Suppress; these subscribers reconcile their granted items

--- a/internal/server/handlers_events.go
+++ b/internal/server/handlers_events.go
@@ -377,6 +377,17 @@ func sseEventVisibleFor(vis sseVisibility, sseUserID string, event events.Event)
 	if vis.visibleSlugSet == nil {
 		return true // all access
 	}
+	// collection_updated (BUG-2265) matches on the STABLE collection ID, not the
+	// mutable slug. Slugs are reusable and events replay, so a stale rename
+	// event's OLD slug could be re-owned by a DIFFERENT collection and pass a
+	// slug-based check for a collection this subscriber can't actually see
+	// (misroute + leak of the new slug). Matching by ID closes that. The event
+	// is sanitized (no per-item data), so any subscriber who can see the
+	// collection — full OR item-grant access — receives it and reconciles.
+	// (Legacy events without a CollectionID fall through to slug matching.)
+	if event.Type == events.CollectionUpdated && event.CollectionID != "" {
+		return vis.visibleCollIDSet[event.CollectionID]
+	}
 	if collection == "" {
 		// Events without a collection (workspace-level, legacy docs) are
 		// only sent to actual members, not guests — they may contain
@@ -431,6 +442,12 @@ type sseVisibility struct {
 	// editor with no collection scope). A non-nil empty map means deny all
 	// collection-scoped events (fail-closed on grant-resolution errors).
 	visibleSlugSet map[string]bool
+	// visibleCollIDSet mirrors visibleSlugSet keyed by STABLE collection ID.
+	// collection_updated events (BUG-2265) match on this, not the mutable slug,
+	// so a replayed rename event whose OLD slug was re-owned by a DIFFERENT
+	// collection can't pass visibility for a collection the subscriber can't
+	// actually see. nil when visibleSlugSet is nil (no filtering).
+	visibleCollIDSet map[string]bool
 	// grantedItemSet is populated for users whose effective access is
 	// item-level (guests, restricted members). nil = no item filtering
 	// needed beyond visibleSlugSet.
@@ -500,7 +517,9 @@ func (s *Server) computeSSEVisibility(r *http.Request, workspaceID string) sseVi
 		v.visibleSlugSet = make(map[string]bool) // empty = deny
 	} else if visibleIDs != nil {
 		v.visibleSlugSet = make(map[string]bool, len(visibleIDs))
+		v.visibleCollIDSet = make(map[string]bool, len(visibleIDs))
 		for _, id := range visibleIDs {
+			v.visibleCollIDSet[id] = true
 			coll, _ := s.store.GetCollection(id)
 			if coll != nil {
 				v.visibleSlugSet[coll.Slug] = true

--- a/internal/server/handlers_events_filter_test.go
+++ b/internal/server/handlers_events_filter_test.go
@@ -21,6 +21,14 @@ func TestSSEEventVisibleFor(t *testing.T) {
 	collUpdated := func(coll string) events.Event {
 		return events.Event{Type: events.CollectionUpdated, Collection: coll}
 	}
+	collRenamed := func(oldSlug, newSlug string) events.Event {
+		return events.Event{Type: events.CollectionUpdated, Collection: oldSlug, NewSlug: newSlug}
+	}
+
+	// A subscriber that revalidated AFTER a rename knows only the NEW slug.
+	newSlugOnly := sseVisibility{
+		visibleSlugSet: map[string]bool{"renamed-tasks": true},
+	}
 
 	allAccess := sseVisibility{visibleSlugSet: nil}
 
@@ -57,6 +65,12 @@ func TestSSEEventVisibleFor(t *testing.T) {
 		{"item-grant-only denied collection.updated for invisible collection", itemGrantOnly, collUpdated("secrets"), false},
 		{"full-collection access gets collection.updated", fullColl, collUpdated("tasks"), true},
 		{"all-access gets collection.updated", allAccess, collUpdated("tasks"), true},
+		// Rename: a subscriber that only knows the NEW slug (revalidated after
+		// the rename) still receives the event routed by the OLD slug, so it
+		// learns the mapping (Codex round 2).
+		{"rename delivered when only new slug is visible", newSlugOnly, collRenamed("tasks", "renamed-tasks"), true},
+		{"rename still dropped when neither slug is visible", newSlugOnly, collRenamed("tasks", "other-new"), false},
+		{"rename delivered when only old slug is visible", fullColl, collRenamed("tasks", "renamed-tasks"), true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/server/handlers_events_filter_test.go
+++ b/internal/server/handlers_events_filter_test.go
@@ -18,6 +18,9 @@ func TestSSEEventVisibleFor(t *testing.T) {
 	perItem := func(coll, itemID string) events.Event {
 		return events.Event{Type: events.ItemUpdated, Collection: coll, ItemID: itemID}
 	}
+	collUpdated := func(coll string) events.Event {
+		return events.Event{Type: events.CollectionUpdated, Collection: coll}
+	}
 
 	allAccess := sseVisibility{visibleSlugSet: nil}
 
@@ -47,6 +50,13 @@ func TestSSEEventVisibleFor(t *testing.T) {
 		{"item-grant-only still gets granted per-item event", itemGrantOnly, perItem("tasks", "item-1"), true},
 		{"item-grant-only denied non-granted per-item event", itemGrantOnly, perItem("tasks", "item-2"), false},
 		{"any subscriber denied bulk in unseen collection", fullColl, bulk("other"), false},
+		// BUG-2265: collection.updated is itemless but leak-free (only the
+		// collection slug), so item-grant subscribers DO receive it for a
+		// visible collection — but still not for an invisible one.
+		{"item-grant-only gets collection.updated for visible collection", itemGrantOnly, collUpdated("tasks"), true},
+		{"item-grant-only denied collection.updated for invisible collection", itemGrantOnly, collUpdated("secrets"), false},
+		{"full-collection access gets collection.updated", fullColl, collUpdated("tasks"), true},
+		{"all-access gets collection.updated", allAccess, collUpdated("tasks"), true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/server/handlers_events_filter_test.go
+++ b/internal/server/handlers_events_filter_test.go
@@ -24,6 +24,9 @@ func TestSSEEventVisibleFor(t *testing.T) {
 	collRenamed := func(oldSlug, newSlug string) events.Event {
 		return events.Event{Type: events.CollectionUpdated, Collection: oldSlug, NewSlug: newSlug}
 	}
+	collMigrated := func(coll string) events.Event {
+		return events.Event{Type: events.CollectionUpdated, Collection: coll, ItemsChanged: true}
+	}
 
 	// A subscriber that revalidated AFTER a rename knows only the NEW slug.
 	newSlugOnly := sseVisibility{
@@ -65,6 +68,11 @@ func TestSSEEventVisibleFor(t *testing.T) {
 		{"item-grant-only denied collection.updated for invisible collection", itemGrantOnly, collUpdated("secrets"), false},
 		{"full-collection access gets collection.updated", fullColl, collUpdated("tasks"), true},
 		{"all-access gets collection.updated", allAccess, collUpdated("tasks"), true},
+		// BUG-2265 Pattern A: the migration-reconcile signal rides on
+		// collection.updated (items_changed) so item-grant editors receive it
+		// for a visible collection and reconcile their item's migrated fields.
+		{"item-grant-only gets migration collection.updated for visible collection", itemGrantOnly, collMigrated("tasks"), true},
+		{"item-grant-only denied migration collection.updated for invisible collection", itemGrantOnly, collMigrated("secrets"), false},
 		// Rename: a subscriber that only knows the NEW slug (revalidated after
 		// the rename) still receives the event routed by the OLD slug, so it
 		// learns the mapping (Codex round 2).

--- a/internal/server/handlers_events_filter_test.go
+++ b/internal/server/handlers_events_filter_test.go
@@ -6,46 +6,58 @@ import (
 	"github.com/PerpetualSoftware/pad/internal/events"
 )
 
-// TestSSEEventVisibleFor covers the visibility matrix, with focus on the
-// itemless batch event (items_bulk_updated, TASK-1668): an item-grant-
-// only subscriber must NOT receive a collection-scoped event that carries
-// no item ID, since it can't be item-filtered and would leak op/count/
-// timing for items they can't see.
+// TestSSEEventVisibleFor covers the visibility matrix:
+//   - itemless batch events (items_bulk_updated, TASK-1668) are suppressed for
+//     item-grant-only subscribers (would leak op/count/timing for hidden items);
+//   - collection_updated (BUG-2265) matches on the STABLE collection ID, not the
+//     mutable slug, so a replayed rename event whose OLD slug was re-owned by a
+//     DIFFERENT collection can't pass visibility for a collection the subscriber
+//     can't actually see.
 func TestSSEEventVisibleFor(t *testing.T) {
+	const tasksID = "coll-tasks"
+	const secretsID = "coll-secrets"
+	const otherID = "coll-other"
+
 	bulk := func(coll string) events.Event {
 		return events.Event{Type: events.ItemsBulkUpdated, Collection: coll, Op: "archive", Count: 3}
 	}
 	perItem := func(coll, itemID string) events.Event {
 		return events.Event{Type: events.ItemUpdated, Collection: coll, ItemID: itemID}
 	}
-	collUpdated := func(coll string) events.Event {
-		return events.Event{Type: events.CollectionUpdated, Collection: coll}
+	collUpd := func(id, slug string) events.Event {
+		return events.Event{Type: events.CollectionUpdated, CollectionID: id, Collection: slug}
 	}
-	collRenamed := func(oldSlug, newSlug string) events.Event {
-		return events.Event{Type: events.CollectionUpdated, Collection: oldSlug, NewSlug: newSlug}
+	collMigrated := func(id, slug string) events.Event {
+		return events.Event{Type: events.CollectionUpdated, CollectionID: id, Collection: slug, ItemsChanged: true}
 	}
-	collMigrated := func(coll string) events.Event {
-		return events.Event{Type: events.CollectionUpdated, Collection: coll, ItemsChanged: true}
-	}
-
-	// A subscriber that revalidated AFTER a rename knows only the NEW slug.
-	newSlugOnly := sseVisibility{
-		visibleSlugSet: map[string]bool{"renamed-tasks": true},
+	collRenamed := func(id, oldSlug, newSlug string) events.Event {
+		return events.Event{Type: events.CollectionUpdated, CollectionID: id, Collection: oldSlug, NewSlug: newSlug}
 	}
 
 	allAccess := sseVisibility{visibleSlugSet: nil}
 
 	fullColl := sseVisibility{
-		visibleSlugSet: map[string]bool{"tasks": true},
-		grantedItemSet: map[string]bool{"item-1": true},
-		fullCollSet:    map[string]bool{"tasks": true},
+		visibleSlugSet:   map[string]bool{"tasks": true},
+		visibleCollIDSet: map[string]bool{tasksID: true},
+		grantedItemSet:   map[string]bool{"item-1": true},
+		fullCollSet:      map[string]bool{"tasks": true},
 	}
 
 	itemGrantOnly := sseVisibility{
-		visibleSlugSet: map[string]bool{"tasks": true},
-		grantedItemSet: map[string]bool{"item-1": true},
-		fullCollSet:    map[string]bool{}, // no full access to tasks
-		isGuest:        true,
+		visibleSlugSet:   map[string]bool{"tasks": true},
+		visibleCollIDSet: map[string]bool{tasksID: true},
+		grantedItemSet:   map[string]bool{"item-1": true},
+		fullCollSet:      map[string]bool{}, // no full access to tasks
+		isGuest:          true,
+	}
+
+	// A subscriber that can see the collection whose CURRENT slug is "tasks",
+	// but that collection's id is `otherID` — a DIFFERENT collection re-owns the
+	// slug "tasks" after the original was renamed away. Slug matching would
+	// wrongly deliver an event for the original (tasksID); ID matching drops it.
+	slugReuse := sseVisibility{
+		visibleSlugSet:   map[string]bool{"tasks": true},
+		visibleCollIDSet: map[string]bool{otherID: true},
 	}
 
 	cases := []struct {
@@ -54,6 +66,7 @@ func TestSSEEventVisibleFor(t *testing.T) {
 		ev   events.Event
 		want bool
 	}{
+		// items_bulk_updated (slug-based, unchanged).
 		{"all-access sees bulk", allAccess, bulk("tasks"), true},
 		{"full-collection access sees bulk", fullColl, bulk("tasks"), true},
 		{"item-grant-only suppressed for itemless bulk", itemGrantOnly, bulk("tasks"), false},
@@ -61,24 +74,28 @@ func TestSSEEventVisibleFor(t *testing.T) {
 		{"item-grant-only still gets granted per-item event", itemGrantOnly, perItem("tasks", "item-1"), true},
 		{"item-grant-only denied non-granted per-item event", itemGrantOnly, perItem("tasks", "item-2"), false},
 		{"any subscriber denied bulk in unseen collection", fullColl, bulk("other"), false},
-		// BUG-2265: collection.updated is itemless but leak-free (only the
-		// collection slug), so item-grant subscribers DO receive it for a
-		// visible collection — but still not for an invisible one.
-		{"item-grant-only gets collection.updated for visible collection", itemGrantOnly, collUpdated("tasks"), true},
-		{"item-grant-only denied collection.updated for invisible collection", itemGrantOnly, collUpdated("secrets"), false},
-		{"full-collection access gets collection.updated", fullColl, collUpdated("tasks"), true},
-		{"all-access gets collection.updated", allAccess, collUpdated("tasks"), true},
-		// BUG-2265 Pattern A: the migration-reconcile signal rides on
-		// collection.updated (items_changed) so item-grant editors receive it
-		// for a visible collection and reconcile their item's migrated fields.
-		{"item-grant-only gets migration collection.updated for visible collection", itemGrantOnly, collMigrated("tasks"), true},
-		{"item-grant-only denied migration collection.updated for invisible collection", itemGrantOnly, collMigrated("secrets"), false},
-		// Rename: a subscriber that only knows the NEW slug (revalidated after
-		// the rename) still receives the event routed by the OLD slug, so it
-		// learns the mapping (Codex round 2).
-		{"rename delivered when only new slug is visible", newSlugOnly, collRenamed("tasks", "renamed-tasks"), true},
-		{"rename still dropped when neither slug is visible", newSlugOnly, collRenamed("tasks", "other-new"), false},
-		{"rename delivered when only old slug is visible", fullColl, collRenamed("tasks", "renamed-tasks"), true},
+
+		// collection_updated matches by STABLE id (BUG-2265). Delivered to
+		// anyone who can see the collection (full OR item-grant), since it's
+		// sanitized; denied for a collection the subscriber can't see by id.
+		{"all-access gets collection.updated", allAccess, collUpd(tasksID, "tasks"), true},
+		{"full access gets collection.updated by id", fullColl, collUpd(tasksID, "tasks"), true},
+		{"item-grant-only gets collection.updated by id", itemGrantOnly, collUpd(tasksID, "tasks"), true},
+		{"item-grant-only denied collection.updated for unseen id", itemGrantOnly, collUpd(secretsID, "secrets"), false},
+		// Pattern A: the migration-reconcile variant reaches item-grant editors.
+		{"item-grant-only gets migration collection.updated by id", itemGrantOnly, collMigrated(tasksID, "tasks"), true},
+		{"item-grant-only denied migration collection.updated for unseen id", itemGrantOnly, collMigrated(secretsID, "secrets"), false},
+		// Rename: identity is the id (unchanged by a rename), so a subscriber who
+		// can see the collection receives it regardless of which slug they know.
+		{"rename delivered by id", fullColl, collRenamed(tasksID, "tasks", "renamed-tasks"), true},
+
+		// SLUG-REUSE LEAK FIX (Codex round 7): the subscriber sees a DIFFERENT
+		// collection (otherID) that now owns slug "tasks"; a replayed event for
+		// the ORIGINAL collection (tasksID) must be DROPPED even though its slug
+		// is in visibleSlugSet — otherwise it misroutes / leaks the new slug.
+		{"slug-reuse: event for original id dropped despite visible slug", slugReuse, collUpd(tasksID, "tasks"), false},
+		{"slug-reuse: rename for original id dropped (no new-slug leak)", slugReuse, collRenamed(tasksID, "tasks", "secret-new"), false},
+		{"slug-reuse: event for the re-owning id is delivered", slugReuse, collUpd(otherID, "tasks"), true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/server/handlers_grant_visibility_test.go
+++ b/internal/server/handlers_grant_visibility_test.go
@@ -649,7 +649,7 @@ func TestDeleteCollectionGrant_SoftDeletedCollection_StillRevocable(t *testing.T
 	f := newRestrictedOwnerVisibilityFixture(t)
 	grantee := f.seedGrantee(t)
 
-	if err := f.srv.store.DeleteCollection(f.visibleColl.ID); err != nil {
+	if err := f.srv.store.DeleteCollection(f.visibleColl.ID, ""); err != nil {
 		t.Fatalf("soft-delete visible collection: %v", err)
 	}
 
@@ -734,7 +734,7 @@ func TestDeleteCollectionGrant_SoftDeletedCollection_UnrestrictedOwnerStillRevok
 	// Soft-delete AFTER seeding the grant/link, mirroring the real
 	// sequence: mint on a live collection, then the collection gets
 	// archived out from under them.
-	if err := srv.store.DeleteCollection(coll.ID); err != nil {
+	if err := srv.store.DeleteCollection(coll.ID, ""); err != nil {
 		t.Fatalf("soft-delete collection: %v", err)
 	}
 

--- a/internal/server/handlers_items_open_children_guard.go
+++ b/internal/server/handlers_items_open_children_guard.go
@@ -313,6 +313,16 @@ func writeOpenChildrenError(w http.ResponseWriter, parentRef string, details *op
 // (e.g. "TASK-5"). The details carry both timestamps so a client can decide
 // whether to re-read + retry or surface the collision to the user.
 func writeUpdateConflictError(w http.ResponseWriter, ref string, conflict *store.UpdateConflictError) {
+	writeUpdateConflictEnvelope(w, ref, conflict.ExpectedUpdatedAt, conflict.ActualUpdatedAt)
+}
+
+// writeUpdateConflictEnvelope is the shared writer for the
+// pad-structured-error/v1 update_conflict envelope. Both the item path
+// (writeUpdateConflictError) and the collection path
+// (writeCollectionUpdateConflictError, BUG-2265) emit the IDENTICAL wire shape
+// through this helper so clients branch on one `code` + `details` contract
+// regardless of which resource conflicted.
+func writeUpdateConflictEnvelope(w http.ResponseWriter, ref, expectedUpdatedAt string, actualUpdatedAt time.Time) {
 	writeJSON(w, http.StatusConflict, map[string]any{
 		"error": map[string]any{
 			"code": "update_conflict",
@@ -321,8 +331,8 @@ func writeUpdateConflictError(w http.ResponseWriter, ref string, conflict *store
 				ref),
 			"details": map[string]any{
 				"ref":                 ref,
-				"expected_updated_at": conflict.ExpectedUpdatedAt,
-				"actual_updated_at":   conflict.ActualUpdatedAt.UTC().Format(time.RFC3339),
+				"expected_updated_at": expectedUpdatedAt,
+				"actual_updated_at":   actualUpdatedAt.UTC().Format(time.RFC3339),
 			},
 		},
 	})

--- a/internal/server/handlers_items_open_children_guard.go
+++ b/internal/server/handlers_items_open_children_guard.go
@@ -330,9 +330,18 @@ func writeUpdateConflictEnvelope(w http.ResponseWriter, ref, expectedUpdatedAt s
 				"%s was modified by another writer since you last read it; re-read and retry.",
 				ref),
 			"details": map[string]any{
-				"ref":                 ref,
+				"ref": ref,
+				// expected_updated_at is echoed verbatim (the exact string the
+				// caller sent). actual_updated_at MUST use full RFC3339Nano
+				// precision so a client can round-trip it back as the token on
+				// retry: collection tokens are now sub-second (BUG-2265), and
+				// truncating to whole seconds (time.RFC3339) would hand back a
+				// token that never matches, 409-looping forever. Item tokens are
+				// second-precision (zero nanoseconds), so RFC3339Nano emits no
+				// fractional part for them — byte-identical to the old output,
+				// and the item path parses/compares via time.Equal regardless.
 				"expected_updated_at": expectedUpdatedAt,
-				"actual_updated_at":   actualUpdatedAt.UTC().Format(time.RFC3339),
+				"actual_updated_at":   actualUpdatedAt.UTC().Format(time.RFC3339Nano),
 			},
 		},
 	})

--- a/internal/store/collections.go
+++ b/internal/store/collections.go
@@ -331,16 +331,22 @@ func (s *Store) UpdateCollection(id string, input models.CollectionUpdate) (*mod
 	query := fmt.Sprintf("UPDATE collections SET %s WHERE id = ?", strings.Join(sets, ", "))
 
 	// Optimistic-concurrency guard (BUG-2265). When the caller round-trips the
-	// updated_at it last read, do the compare-and-set ATOMICALLY under the
-	// workspace write lock so two clients editing the same collection's
-	// settings can't clobber each other (the full-page pane host's master +
-	// pane each hold an independent Collection snapshot). Mirrors the item
-	// path (items.go updateItemWithParentLinkOnce): re-read the row inside the
-	// tx after taking the lock, compare with time.Equal, then UPDATE. On
-	// SQLite the db-wide BEGIN IMMEDIATE write lock (set via _txlock=immediate)
-	// already serializes writers; on Postgres acquireWorkspaceSeqLock takes the
-	// per-workspace advisory xact lock. Callers that don't send the token keep
-	// the legacy single-statement last-write-wins path below unchanged.
+	// updated_at it last read, do the compare-and-set ATOMICALLY so two clients
+	// editing the same collection's settings can't clobber each other (the
+	// full-page pane host's master + pane each hold an independent Collection
+	// snapshot). Re-read the row inside the tx, compare with time.Equal
+	// (format-agnostic — Postgres re-serializes the JSONB/timestamptz round
+	// trip), then UPDATE. Callers that don't send the token keep the legacy
+	// single-statement last-write-wins path below unchanged.
+	//
+	// Serialization is watertight on BOTH drivers WITHOUT relying on the
+	// advisory lock (which only serializes writers that also take it — a
+	// tokenless UpdateCollection would slip between the re-read and the UPDATE
+	// on Postgres, Codex P1):
+	//   - SQLite: the db-wide BEGIN IMMEDIATE write lock (_txlock=immediate)
+	//     already serializes EVERY writer for the whole tx.
+	//   - Postgres: the re-read takes a `FOR UPDATE` row lock, so a concurrent
+	//     tokenless UPDATE blocks on that row until this tx commits.
 	if input.ExpectedUpdatedAt != "" {
 		expected, perr := time.Parse(time.RFC3339, input.ExpectedUpdatedAt)
 		if perr != nil {
@@ -353,14 +359,15 @@ func (s *Store) UpdateCollection(id string, input models.CollectionUpdate) (*mod
 		}
 		defer tx.Rollback()
 
-		if err := s.acquireWorkspaceSeqLock(tx, existing.WorkspaceID); err != nil {
-			return nil, err
+		// Re-read updated_at UNDER a row lock (Postgres) / the BEGIN IMMEDIATE
+		// write lock (SQLite). SQLite rejects `FOR UPDATE` syntactically, so it
+		// is Postgres-only; the whole-DB write lock makes it unnecessary there.
+		reread := "SELECT updated_at FROM collections WHERE id = ? AND deleted_at IS NULL"
+		if s.dialect.Driver() == DriverPostgres {
+			reread += " FOR UPDATE"
 		}
-
-		// Re-read updated_at UNDER the lock — the pre-tx GetCollection above
-		// ran before the lock, so a concurrent writer could have superseded it.
 		var currentUpdatedAt string
-		rerr := tx.QueryRow(s.q("SELECT updated_at FROM collections WHERE id = ? AND deleted_at IS NULL"), id).Scan(&currentUpdatedAt)
+		rerr := tx.QueryRow(s.q(reread), id).Scan(&currentUpdatedAt)
 		if rerr == sql.ErrNoRows {
 			// Deleted between the pre-tx read and here — treat as not-found.
 			return nil, nil
@@ -374,6 +381,17 @@ func (s *Store) UpdateCollection(id string, input models.CollectionUpdate) (*mod
 				ExpectedUpdatedAt: input.ExpectedUpdatedAt,
 				ActualUpdatedAt:   actual,
 			}
+		}
+
+		// Guarantee the stored updated_at STRICTLY ADVANCES past the accepted
+		// token so a second guarded write within the SAME wall-clock second
+		// still changes the token (now() is one-second precision — two
+		// same-second writes would otherwise keep an identical token and defeat
+		// the guard, Codex P1). now() is used verbatim whenever it already
+		// exceeds the token (the common case; timestamps stay accurate). args[0]
+		// is the `updated_at = ?` bind (built first, above).
+		if !parseTime(ts).After(expected) {
+			args[0] = expected.Add(time.Second).UTC().Format(time.RFC3339)
 		}
 
 		if _, err := tx.Exec(s.q(query), args...); err != nil {

--- a/internal/store/collections.go
+++ b/internal/store/collections.go
@@ -407,6 +407,22 @@ func (s *Store) UpdateCollection(id string, input models.CollectionUpdate) (*mod
 	if _, err := tx.Exec(s.q(query), args...); err != nil {
 		return nil, fmt.Errorf("update collection: %w", err)
 	}
+
+	// Apply field-value migrations (select-option renames) in the SAME tx as
+	// the schema change (BUG-2265 Codex): a migration failure rolls back the
+	// schema AND the concurrency-token advance, so the row is untouched and the
+	// caller's retry works cleanly — no committed-schema/stale-items split and
+	// no guaranteed-409. Take the workspace seq lock first (the per-row seq
+	// bumps need it on Postgres; no-op on SQLite under BEGIN IMMEDIATE).
+	if len(input.Migrations) > 0 {
+		if err := s.acquireWorkspaceSeqLock(tx, existing.WorkspaceID); err != nil {
+			return nil, err
+		}
+		if _, err := s.applyFieldMigrationsTx(tx, id, existing.WorkspaceID, input.Migrations); err != nil {
+			return nil, fmt.Errorf("apply field migrations: %w", err)
+		}
+	}
+
 	if err := tx.Commit(); err != nil {
 		return nil, fmt.Errorf("commit collection update: %w", err)
 	}
@@ -489,6 +505,25 @@ func (s *Store) MigrateItemFieldValues(collectionID string, migrations []models.
 		return 0, err
 	}
 
+	totalAffected, err := s.applyFieldMigrationsTx(tx, collectionID, workspaceID, migrations)
+	if err != nil {
+		return totalAffected, err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return totalAffected, err
+	}
+	return totalAffected, nil
+}
+
+// applyFieldMigrationsTx runs the per-row field-value migration loop on an
+// EXISTING transaction. Extracted so UpdateCollection can run the schema
+// change and its item migrations ATOMICALLY in one tx (BUG-2265 Codex: a
+// migration failure must roll back the schema AND the concurrency token, or a
+// 500 leaves the row changed and every client retry blind-409s). Callers must
+// already hold the workspace seq lock (acquireWorkspaceSeqLock) so the per-row
+// seq bumps serialize on Postgres.
+func (s *Store) applyFieldMigrationsTx(tx *sql.Tx, collectionID, workspaceID string, migrations []models.FieldMigration) (int64, error) {
 	ts := now()
 	var totalAffected int64
 
@@ -547,10 +582,6 @@ func (s *Store) MigrateItemFieldValues(collectionID string, migrations []models.
 				totalAffected += n
 			}
 		}
-	}
-
-	if err := tx.Commit(); err != nil {
-		return totalAffected, err
 	}
 	return totalAffected, nil
 }

--- a/internal/store/collections.go
+++ b/internal/store/collections.go
@@ -270,7 +270,12 @@ func (s *Store) UpdateCollection(id string, input models.CollectionUpdate) (*mod
 		return nil, nil
 	}
 
-	ts := now()
+	// Sub-second timestamp (BUG-2265): collections.updated_at doubles as the
+	// concurrency token, so it must differ between two writes in the same
+	// wall-clock second. nowNano() makes that near-certain without a schema
+	// change (the column is TEXT on both dialects and never lexically compared
+	// — only via time.Equal and for display).
+	ts := nowNano()
 	sets := []string{"updated_at = ?"}
 	args := []interface{}{ts}
 
@@ -345,13 +350,15 @@ func (s *Store) UpdateCollection(id string, input models.CollectionUpdate) (*mod
 	//      closes the tokenless-writer race the advisory lock could NOT (an
 	//      advisory lock only serializes writers that also take it — Codex P1).
 	//
-	//   2. Strictly monotonic token. now() is one-second precision, so two
-	//      writes in the same wall-clock second — or a tokenless write racing a
-	//      guarded one — would otherwise keep OR regress the timestamp, letting
-	//      a stale reader's token still match and clobber newer data (Codex P1).
-	//      Every write therefore advances updated_at strictly past the row's
-	//      current value; now() is used verbatim whenever it already exceeds it
-	//      (the common case, so timestamps stay accurate).
+	//   2. Strictly monotonic token. Sub-second nowNano() makes same-second
+	//      collisions near-impossible, but a coarse platform clock (or an NTP
+	//      step-back) could still return a value <= the row's current one, which
+	//      would let a tokenless or racing write keep/regress the token and a
+	//      stale reader clobber newer data. Guard it: when the fresh timestamp
+	//      doesn't already exceed the row's current value, advance by a single
+	//      NANOSECOND past it. That keeps the token strictly increasing on every
+	//      writer while bounding any drift to nanoseconds — no meaningful
+	//      advance-into-the-future even under sustained writes.
 	tx, err := s.db.Begin()
 	if err != nil {
 		return nil, err
@@ -390,9 +397,11 @@ func (s *Store) UpdateCollection(id string, input models.CollectionUpdate) (*mod
 	}
 
 	// Monotonic advance (invariant 2 above). args[0] is the `updated_at = ?`
-	// bind built first, so overwrite it in place.
+	// bind built first, so overwrite it in place. A one-nanosecond step keeps
+	// the token strictly increasing without drifting meaningfully ahead of
+	// wall-clock.
 	if !parseTime(ts).After(current) {
-		args[0] = current.Add(time.Second).UTC().Format(time.RFC3339)
+		args[0] = current.Add(time.Nanosecond).UTC().Format(time.RFC3339Nano)
 	}
 
 	if _, err := tx.Exec(s.q(query), args...); err != nil {

--- a/internal/store/collections.go
+++ b/internal/store/collections.go
@@ -365,6 +365,22 @@ func (s *Store) UpdateCollection(id string, input models.CollectionUpdate) (*mod
 	}
 	defer tx.Rollback()
 
+	// LOCK ORDER (Codex P1 deadlock fix). When this update also migrates item
+	// field values it locks TWO things: the workspace advisory/seq lock (for
+	// the per-row seq bumps) and the collection ROW (FOR UPDATE, below). Item
+	// creation locks the same pair in the order [workspace advisory lock
+	// (tryCreateItem) → collection-row FK key-share lock (on INSERT)], so we
+	// MUST take the workspace lock FIRST here too — grabbing the row lock first
+	// would ABBA-deadlock against a concurrent item-create. Acquired only on the
+	// migration path (the only path that touches the workspace seq lock); a
+	// plain update just takes the row lock and can't deadlock. On SQLite both
+	// are no-ops under the single BEGIN IMMEDIATE write lock.
+	if len(input.Migrations) > 0 {
+		if err := s.acquireWorkspaceSeqLock(tx, existing.WorkspaceID); err != nil {
+			return nil, err
+		}
+	}
+
 	reread := "SELECT updated_at FROM collections WHERE id = ? AND deleted_at IS NULL"
 	if s.dialect.Driver() == DriverPostgres {
 		reread += " FOR UPDATE"
@@ -412,12 +428,9 @@ func (s *Store) UpdateCollection(id string, input models.CollectionUpdate) (*mod
 	// the schema change (BUG-2265 Codex): a migration failure rolls back the
 	// schema AND the concurrency-token advance, so the row is untouched and the
 	// caller's retry works cleanly — no committed-schema/stale-items split and
-	// no guaranteed-409. Take the workspace seq lock first (the per-row seq
-	// bumps need it on Postgres; no-op on SQLite under BEGIN IMMEDIATE).
+	// no guaranteed-409. The workspace seq lock was already taken above (before
+	// the row lock) to preserve the item-create lock order.
 	if len(input.Migrations) > 0 {
-		if err := s.acquireWorkspaceSeqLock(tx, existing.WorkspaceID); err != nil {
-			return nil, err
-		}
 		if _, err := s.applyFieldMigrationsTx(tx, id, existing.WorkspaceID, input.Migrations); err != nil {
 			return nil, fmt.Errorf("apply field migrations: %w", err)
 		}

--- a/internal/store/collections.go
+++ b/internal/store/collections.go
@@ -261,13 +261,13 @@ func (s *Store) ListCollections(workspaceID string) ([]models.Collection, error)
 	return result, nil
 }
 
-func (s *Store) UpdateCollection(id string, input models.CollectionUpdate) (*models.Collection, int64, error) {
+func (s *Store) UpdateCollection(id string, input models.CollectionUpdate) (*models.Collection, error) {
 	existing, err := s.GetCollection(id)
 	if err != nil {
-		return nil, 0, err
+		return nil, err
 	}
 	if existing == nil {
-		return nil, 0, nil
+		return nil, nil
 	}
 
 	// Sub-second timestamp (BUG-2265): collections.updated_at doubles as the
@@ -292,7 +292,7 @@ func (s *Store) UpdateCollection(id string, input models.CollectionUpdate) (*mod
 		}
 		newSlug, err := s.uniqueSlugExcluding("collections", "workspace_id", existing.WorkspaceID, baseSlug, id)
 		if err != nil {
-			return nil, 0, fmt.Errorf("unique slug: %w", err)
+			return nil, fmt.Errorf("unique slug: %w", err)
 		}
 		sets = append(sets, "slug = ?")
 		args = append(args, newSlug)
@@ -361,7 +361,7 @@ func (s *Store) UpdateCollection(id string, input models.CollectionUpdate) (*mod
 	//      advance-into-the-future even under sustained writes.
 	tx, err := s.db.Begin()
 	if err != nil {
-		return nil, 0, err
+		return nil, err
 	}
 	defer tx.Rollback()
 
@@ -377,7 +377,7 @@ func (s *Store) UpdateCollection(id string, input models.CollectionUpdate) (*mod
 	// are no-ops under the single BEGIN IMMEDIATE write lock.
 	if len(input.Migrations) > 0 {
 		if err := s.acquireWorkspaceSeqLock(tx, existing.WorkspaceID); err != nil {
-			return nil, 0, err
+			return nil, err
 		}
 	}
 
@@ -389,10 +389,10 @@ func (s *Store) UpdateCollection(id string, input models.CollectionUpdate) (*mod
 	rerr := tx.QueryRow(s.q(reread), id).Scan(&currentUpdatedAt)
 	if rerr == sql.ErrNoRows {
 		// Deleted between the pre-tx GetCollection and here — treat as not-found.
-		return nil, 0, nil
+		return nil, nil
 	}
 	if rerr != nil {
-		return nil, 0, fmt.Errorf("re-read collection under lock: %w", rerr)
+		return nil, fmt.Errorf("re-read collection under lock: %w", rerr)
 	}
 	current := parseTime(currentUpdatedAt)
 
@@ -401,10 +401,10 @@ func (s *Store) UpdateCollection(id string, input models.CollectionUpdate) (*mod
 	if input.ExpectedUpdatedAt != "" {
 		expected, perr := time.Parse(time.RFC3339, input.ExpectedUpdatedAt)
 		if perr != nil {
-			return nil, 0, fmt.Errorf("invalid expected_updated_at %q: %w", input.ExpectedUpdatedAt, perr)
+			return nil, fmt.Errorf("invalid expected_updated_at %q: %w", input.ExpectedUpdatedAt, perr)
 		}
 		if !current.Equal(expected) {
-			return nil, 0, &CollectionUpdateConflictError{
+			return nil, &CollectionUpdateConflictError{
 				CollectionID:      id,
 				ExpectedUpdatedAt: input.ExpectedUpdatedAt,
 				ActualUpdatedAt:   current,
@@ -421,7 +421,7 @@ func (s *Store) UpdateCollection(id string, input models.CollectionUpdate) (*mod
 	}
 
 	if _, err := tx.Exec(s.q(query), args...); err != nil {
-		return nil, 0, fmt.Errorf("update collection: %w", err)
+		return nil, fmt.Errorf("update collection: %w", err)
 	}
 
 	// Apply field-value migrations (select-option renames) in the SAME tx as
@@ -430,19 +430,17 @@ func (s *Store) UpdateCollection(id string, input models.CollectionUpdate) (*mod
 	// caller's retry works cleanly — no committed-schema/stale-items split and
 	// no guaranteed-409. The workspace seq lock was already taken above (before
 	// the row lock) to preserve the item-create lock order.
-	var migratedItems int64
 	if len(input.Migrations) > 0 {
-		if migratedItems, err = s.applyFieldMigrationsTx(tx, id, existing.WorkspaceID, input.Migrations); err != nil {
-			return nil, 0, fmt.Errorf("apply field migrations: %w", err)
+		if _, err := s.applyFieldMigrationsTx(tx, id, existing.WorkspaceID, input.Migrations); err != nil {
+			return nil, fmt.Errorf("apply field migrations: %w", err)
 		}
 	}
 
 	if err := tx.Commit(); err != nil {
-		return nil, 0, fmt.Errorf("commit collection update: %w", err)
+		return nil, fmt.Errorf("commit collection update: %w", err)
 	}
 
-	updated, err := s.GetCollection(id)
-	return updated, migratedItems, err
+	return s.GetCollection(id)
 }
 
 func (s *Store) DeleteCollection(id string) error {

--- a/internal/store/collections.go
+++ b/internal/store/collections.go
@@ -261,13 +261,13 @@ func (s *Store) ListCollections(workspaceID string) ([]models.Collection, error)
 	return result, nil
 }
 
-func (s *Store) UpdateCollection(id string, input models.CollectionUpdate) (*models.Collection, error) {
+func (s *Store) UpdateCollection(id string, input models.CollectionUpdate) (*models.Collection, int64, error) {
 	existing, err := s.GetCollection(id)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	if existing == nil {
-		return nil, nil
+		return nil, 0, nil
 	}
 
 	// Sub-second timestamp (BUG-2265): collections.updated_at doubles as the
@@ -292,7 +292,7 @@ func (s *Store) UpdateCollection(id string, input models.CollectionUpdate) (*mod
 		}
 		newSlug, err := s.uniqueSlugExcluding("collections", "workspace_id", existing.WorkspaceID, baseSlug, id)
 		if err != nil {
-			return nil, fmt.Errorf("unique slug: %w", err)
+			return nil, 0, fmt.Errorf("unique slug: %w", err)
 		}
 		sets = append(sets, "slug = ?")
 		args = append(args, newSlug)
@@ -361,7 +361,7 @@ func (s *Store) UpdateCollection(id string, input models.CollectionUpdate) (*mod
 	//      advance-into-the-future even under sustained writes.
 	tx, err := s.db.Begin()
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	defer tx.Rollback()
 
@@ -377,7 +377,7 @@ func (s *Store) UpdateCollection(id string, input models.CollectionUpdate) (*mod
 	// are no-ops under the single BEGIN IMMEDIATE write lock.
 	if len(input.Migrations) > 0 {
 		if err := s.acquireWorkspaceSeqLock(tx, existing.WorkspaceID); err != nil {
-			return nil, err
+			return nil, 0, err
 		}
 	}
 
@@ -389,10 +389,10 @@ func (s *Store) UpdateCollection(id string, input models.CollectionUpdate) (*mod
 	rerr := tx.QueryRow(s.q(reread), id).Scan(&currentUpdatedAt)
 	if rerr == sql.ErrNoRows {
 		// Deleted between the pre-tx GetCollection and here — treat as not-found.
-		return nil, nil
+		return nil, 0, nil
 	}
 	if rerr != nil {
-		return nil, fmt.Errorf("re-read collection under lock: %w", rerr)
+		return nil, 0, fmt.Errorf("re-read collection under lock: %w", rerr)
 	}
 	current := parseTime(currentUpdatedAt)
 
@@ -401,10 +401,10 @@ func (s *Store) UpdateCollection(id string, input models.CollectionUpdate) (*mod
 	if input.ExpectedUpdatedAt != "" {
 		expected, perr := time.Parse(time.RFC3339, input.ExpectedUpdatedAt)
 		if perr != nil {
-			return nil, fmt.Errorf("invalid expected_updated_at %q: %w", input.ExpectedUpdatedAt, perr)
+			return nil, 0, fmt.Errorf("invalid expected_updated_at %q: %w", input.ExpectedUpdatedAt, perr)
 		}
 		if !current.Equal(expected) {
-			return nil, &CollectionUpdateConflictError{
+			return nil, 0, &CollectionUpdateConflictError{
 				CollectionID:      id,
 				ExpectedUpdatedAt: input.ExpectedUpdatedAt,
 				ActualUpdatedAt:   current,
@@ -421,7 +421,7 @@ func (s *Store) UpdateCollection(id string, input models.CollectionUpdate) (*mod
 	}
 
 	if _, err := tx.Exec(s.q(query), args...); err != nil {
-		return nil, fmt.Errorf("update collection: %w", err)
+		return nil, 0, fmt.Errorf("update collection: %w", err)
 	}
 
 	// Apply field-value migrations (select-option renames) in the SAME tx as
@@ -430,17 +430,19 @@ func (s *Store) UpdateCollection(id string, input models.CollectionUpdate) (*mod
 	// caller's retry works cleanly — no committed-schema/stale-items split and
 	// no guaranteed-409. The workspace seq lock was already taken above (before
 	// the row lock) to preserve the item-create lock order.
+	var migratedItems int64
 	if len(input.Migrations) > 0 {
-		if _, err := s.applyFieldMigrationsTx(tx, id, existing.WorkspaceID, input.Migrations); err != nil {
-			return nil, fmt.Errorf("apply field migrations: %w", err)
+		if migratedItems, err = s.applyFieldMigrationsTx(tx, id, existing.WorkspaceID, input.Migrations); err != nil {
+			return nil, 0, fmt.Errorf("apply field migrations: %w", err)
 		}
 	}
 
 	if err := tx.Commit(); err != nil {
-		return nil, fmt.Errorf("commit collection update: %w", err)
+		return nil, 0, fmt.Errorf("commit collection update: %w", err)
 	}
 
-	return s.GetCollection(id)
+	updated, err := s.GetCollection(id)
+	return updated, migratedItems, err
 }
 
 func (s *Store) DeleteCollection(id string) error {

--- a/internal/store/collections.go
+++ b/internal/store/collections.go
@@ -330,83 +330,76 @@ func (s *Store) UpdateCollection(id string, input models.CollectionUpdate) (*mod
 	args = append(args, id)
 	query := fmt.Sprintf("UPDATE collections SET %s WHERE id = ?", strings.Join(sets, ", "))
 
-	// Optimistic-concurrency guard (BUG-2265). When the caller round-trips the
-	// updated_at it last read, do the compare-and-set ATOMICALLY so two clients
-	// editing the same collection's settings can't clobber each other (the
-	// full-page pane host's master + pane each hold an independent Collection
-	// snapshot). Re-read the row inside the tx, compare with time.Equal
-	// (format-agnostic — Postgres re-serializes the JSONB/timestamptz round
-	// trip), then UPDATE. Callers that don't send the token keep the legacy
-	// single-statement last-write-wins path below unchanged.
+	// BUG-2265: collections.updated_at doubles as the optimistic-concurrency
+	// token (no schema migration — it's the existing column). For that to be
+	// reliable it must satisfy two invariants that a plain
+	// `UPDATE ... SET updated_at = now()` doesn't, so EVERY update (guarded or
+	// not) runs through one small transaction that re-reads the row and derives
+	// the new timestamp atomically:
 	//
-	// Serialization is watertight on BOTH drivers WITHOUT relying on the
-	// advisory lock (which only serializes writers that also take it — a
-	// tokenless UpdateCollection would slip between the re-read and the UPDATE
-	// on Postgres, Codex P1):
-	//   - SQLite: the db-wide BEGIN IMMEDIATE write lock (_txlock=immediate)
-	//     already serializes EVERY writer for the whole tx.
-	//   - Postgres: the re-read takes a `FOR UPDATE` row lock, so a concurrent
-	//     tokenless UPDATE blocks on that row until this tx commits.
+	//   1. Serialized check-and-set. The re-read happens under a lock, so a
+	//      concurrent writer can't slip between it and the UPDATE. SQLite gets
+	//      this from the db-wide BEGIN IMMEDIATE write lock (_txlock=immediate);
+	//      Postgres needs an explicit `FOR UPDATE` row lock (it rejects `FOR
+	//      UPDATE` on SQLite syntactically, hence the driver gate). This also
+	//      closes the tokenless-writer race the advisory lock could NOT (an
+	//      advisory lock only serializes writers that also take it — Codex P1).
+	//
+	//   2. Strictly monotonic token. now() is one-second precision, so two
+	//      writes in the same wall-clock second — or a tokenless write racing a
+	//      guarded one — would otherwise keep OR regress the timestamp, letting
+	//      a stale reader's token still match and clobber newer data (Codex P1).
+	//      Every write therefore advances updated_at strictly past the row's
+	//      current value; now() is used verbatim whenever it already exceeds it
+	//      (the common case, so timestamps stay accurate).
+	tx, err := s.db.Begin()
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+
+	reread := "SELECT updated_at FROM collections WHERE id = ? AND deleted_at IS NULL"
+	if s.dialect.Driver() == DriverPostgres {
+		reread += " FOR UPDATE"
+	}
+	var currentUpdatedAt string
+	rerr := tx.QueryRow(s.q(reread), id).Scan(&currentUpdatedAt)
+	if rerr == sql.ErrNoRows {
+		// Deleted between the pre-tx GetCollection and here — treat as not-found.
+		return nil, nil
+	}
+	if rerr != nil {
+		return nil, fmt.Errorf("re-read collection under lock: %w", rerr)
+	}
+	current := parseTime(currentUpdatedAt)
+
+	// Optimistic-concurrency guard — only when the caller opted in by sending
+	// the token it last read. Compared with time.Equal (format-agnostic).
 	if input.ExpectedUpdatedAt != "" {
 		expected, perr := time.Parse(time.RFC3339, input.ExpectedUpdatedAt)
 		if perr != nil {
 			return nil, fmt.Errorf("invalid expected_updated_at %q: %w", input.ExpectedUpdatedAt, perr)
 		}
-
-		tx, err := s.db.Begin()
-		if err != nil {
-			return nil, err
-		}
-		defer tx.Rollback()
-
-		// Re-read updated_at UNDER a row lock (Postgres) / the BEGIN IMMEDIATE
-		// write lock (SQLite). SQLite rejects `FOR UPDATE` syntactically, so it
-		// is Postgres-only; the whole-DB write lock makes it unnecessary there.
-		reread := "SELECT updated_at FROM collections WHERE id = ? AND deleted_at IS NULL"
-		if s.dialect.Driver() == DriverPostgres {
-			reread += " FOR UPDATE"
-		}
-		var currentUpdatedAt string
-		rerr := tx.QueryRow(s.q(reread), id).Scan(&currentUpdatedAt)
-		if rerr == sql.ErrNoRows {
-			// Deleted between the pre-tx read and here — treat as not-found.
-			return nil, nil
-		}
-		if rerr != nil {
-			return nil, fmt.Errorf("re-read collection under lock: %w", rerr)
-		}
-		if actual := parseTime(currentUpdatedAt); !actual.Equal(expected) {
+		if !current.Equal(expected) {
 			return nil, &CollectionUpdateConflictError{
 				CollectionID:      id,
 				ExpectedUpdatedAt: input.ExpectedUpdatedAt,
-				ActualUpdatedAt:   actual,
+				ActualUpdatedAt:   current,
 			}
 		}
-
-		// Guarantee the stored updated_at STRICTLY ADVANCES past the accepted
-		// token so a second guarded write within the SAME wall-clock second
-		// still changes the token (now() is one-second precision — two
-		// same-second writes would otherwise keep an identical token and defeat
-		// the guard, Codex P1). now() is used verbatim whenever it already
-		// exceeds the token (the common case; timestamps stay accurate). args[0]
-		// is the `updated_at = ?` bind (built first, above).
-		if !parseTime(ts).After(expected) {
-			args[0] = expected.Add(time.Second).UTC().Format(time.RFC3339)
-		}
-
-		if _, err := tx.Exec(s.q(query), args...); err != nil {
-			return nil, fmt.Errorf("update collection: %w", err)
-		}
-		if err := tx.Commit(); err != nil {
-			return nil, fmt.Errorf("commit collection update: %w", err)
-		}
-
-		return s.GetCollection(id)
 	}
 
-	_, err = s.db.Exec(s.q(query), args...)
-	if err != nil {
+	// Monotonic advance (invariant 2 above). args[0] is the `updated_at = ?`
+	// bind built first, so overwrite it in place.
+	if !parseTime(ts).After(current) {
+		args[0] = current.Add(time.Second).UTC().Format(time.RFC3339)
+	}
+
+	if _, err := tx.Exec(s.q(query), args...); err != nil {
 		return nil, fmt.Errorf("update collection: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit collection update: %w", err)
 	}
 
 	return s.GetCollection(id)

--- a/internal/store/collections.go
+++ b/internal/store/collections.go
@@ -5,10 +5,33 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/PerpetualSoftware/pad/internal/collections"
 	"github.com/PerpetualSoftware/pad/internal/models"
 )
+
+// CollectionUpdateConflictError is returned by UpdateCollection when the
+// caller supplied CollectionUpdate.ExpectedUpdatedAt and it no longer matches
+// the collection's current updated_at — another writer changed the row first
+// (BUG-2265, optimistic concurrency; mirrors items.go's UpdateConflictError
+// for the item path from IDEA-1480/TASK-2022). The check runs under the same
+// workspace write lock as the mutation, so a matching timestamp is a genuine
+// guarantee that nothing slipped in between. The handler maps this to the same
+// pad-structured-error/v1 conflict envelope (HTTP 409, code "update_conflict")
+// the item path emits.
+type CollectionUpdateConflictError struct {
+	CollectionID      string
+	ExpectedUpdatedAt string
+	ActualUpdatedAt   time.Time
+}
+
+func (e *CollectionUpdateConflictError) Error() string {
+	return fmt.Sprintf(
+		"collection %s was modified by another writer (expected updated_at %s, actual %s)",
+		e.CollectionID, e.ExpectedUpdatedAt, e.ActualUpdatedAt.UTC().Format(time.RFC3339),
+	)
+}
 
 func (s *Store) CreateCollection(workspaceID string, input models.CollectionCreate) (*models.Collection, error) {
 	id := newID()
@@ -306,6 +329,63 @@ func (s *Store) UpdateCollection(id string, input models.CollectionUpdate) (*mod
 
 	args = append(args, id)
 	query := fmt.Sprintf("UPDATE collections SET %s WHERE id = ?", strings.Join(sets, ", "))
+
+	// Optimistic-concurrency guard (BUG-2265). When the caller round-trips the
+	// updated_at it last read, do the compare-and-set ATOMICALLY under the
+	// workspace write lock so two clients editing the same collection's
+	// settings can't clobber each other (the full-page pane host's master +
+	// pane each hold an independent Collection snapshot). Mirrors the item
+	// path (items.go updateItemWithParentLinkOnce): re-read the row inside the
+	// tx after taking the lock, compare with time.Equal, then UPDATE. On
+	// SQLite the db-wide BEGIN IMMEDIATE write lock (set via _txlock=immediate)
+	// already serializes writers; on Postgres acquireWorkspaceSeqLock takes the
+	// per-workspace advisory xact lock. Callers that don't send the token keep
+	// the legacy single-statement last-write-wins path below unchanged.
+	if input.ExpectedUpdatedAt != "" {
+		expected, perr := time.Parse(time.RFC3339, input.ExpectedUpdatedAt)
+		if perr != nil {
+			return nil, fmt.Errorf("invalid expected_updated_at %q: %w", input.ExpectedUpdatedAt, perr)
+		}
+
+		tx, err := s.db.Begin()
+		if err != nil {
+			return nil, err
+		}
+		defer tx.Rollback()
+
+		if err := s.acquireWorkspaceSeqLock(tx, existing.WorkspaceID); err != nil {
+			return nil, err
+		}
+
+		// Re-read updated_at UNDER the lock — the pre-tx GetCollection above
+		// ran before the lock, so a concurrent writer could have superseded it.
+		var currentUpdatedAt string
+		rerr := tx.QueryRow(s.q("SELECT updated_at FROM collections WHERE id = ? AND deleted_at IS NULL"), id).Scan(&currentUpdatedAt)
+		if rerr == sql.ErrNoRows {
+			// Deleted between the pre-tx read and here — treat as not-found.
+			return nil, nil
+		}
+		if rerr != nil {
+			return nil, fmt.Errorf("re-read collection under lock: %w", rerr)
+		}
+		if actual := parseTime(currentUpdatedAt); !actual.Equal(expected) {
+			return nil, &CollectionUpdateConflictError{
+				CollectionID:      id,
+				ExpectedUpdatedAt: input.ExpectedUpdatedAt,
+				ActualUpdatedAt:   actual,
+			}
+		}
+
+		if _, err := tx.Exec(s.q(query), args...); err != nil {
+			return nil, fmt.Errorf("update collection: %w", err)
+		}
+		if err := tx.Commit(); err != nil {
+			return nil, fmt.Errorf("commit collection update: %w", err)
+		}
+
+		return s.GetCollection(id)
+	}
+
 	_, err = s.db.Exec(s.q(query), args...)
 	if err != nil {
 		return nil, fmt.Errorf("update collection: %w", err)

--- a/internal/store/collections.go
+++ b/internal/store/collections.go
@@ -443,7 +443,16 @@ func (s *Store) UpdateCollection(id string, input models.CollectionUpdate) (*mod
 	return s.GetCollection(id)
 }
 
-func (s *Store) DeleteCollection(id string) error {
+// DeleteCollection soft-deletes a collection by id. When expectedUpdatedAt is
+// non-empty it opts into optimistic-concurrency control (BUG-2265): the row's
+// updated_at is re-read UNDER A LOCK and the delete is rejected with a
+// CollectionUpdateConflictError when it no longer matches. This closes the
+// archive TOCTOU where the handler resolved a collection by its (mutable) slug
+// but a concurrent RENAME re-owned that slug with a DIFFERENT collection before
+// the delete landed — the token mismatch 409s instead of archiving the wrong
+// collection. Empty token keeps the legacy unconditional soft-delete (CLI/API
+// callers that don't opt in).
+func (s *Store) DeleteCollection(id string, expectedUpdatedAt string) error {
 	// Check if it's a default collection
 	var isDefault bool
 	err := s.db.QueryRow(s.q("SELECT is_default FROM collections WHERE id = ? AND deleted_at IS NULL"), id).Scan(&isDefault)
@@ -458,6 +467,43 @@ func (s *Store) DeleteCollection(id string) error {
 	}
 
 	ts := now()
+
+	if expectedUpdatedAt != "" {
+		expected, perr := time.Parse(time.RFC3339, expectedUpdatedAt)
+		if perr != nil {
+			return fmt.Errorf("invalid expected_updated_at %q: %w", expectedUpdatedAt, perr)
+		}
+		tx, terr := s.db.Begin()
+		if terr != nil {
+			return terr
+		}
+		defer tx.Rollback()
+
+		reread := "SELECT updated_at FROM collections WHERE id = ? AND deleted_at IS NULL"
+		if s.dialect.Driver() == DriverPostgres {
+			reread += " FOR UPDATE"
+		}
+		var currentUpdatedAt string
+		rerr := tx.QueryRow(s.q(reread), id).Scan(&currentUpdatedAt)
+		if rerr == sql.ErrNoRows {
+			return sql.ErrNoRows
+		}
+		if rerr != nil {
+			return fmt.Errorf("re-read collection under lock: %w", rerr)
+		}
+		if actual := parseTime(currentUpdatedAt); !actual.Equal(expected) {
+			return &CollectionUpdateConflictError{
+				CollectionID:      id,
+				ExpectedUpdatedAt: expectedUpdatedAt,
+				ActualUpdatedAt:   actual,
+			}
+		}
+		if _, err := tx.Exec(s.q(`UPDATE collections SET deleted_at = ?, updated_at = ? WHERE id = ? AND deleted_at IS NULL`), ts, ts, id); err != nil {
+			return fmt.Errorf("delete collection: %w", err)
+		}
+		return tx.Commit()
+	}
+
 	result, err := s.db.Exec(s.q(`
 		UPDATE collections SET deleted_at = ?, updated_at = ?
 		WHERE id = ? AND deleted_at IS NULL

--- a/internal/store/collections_test.go
+++ b/internal/store/collections_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"encoding/json"
+	"errors"
 	"reflect"
 	"testing"
 
@@ -113,6 +114,128 @@ func TestUpdateCollectionCoercesEmptyStringSettings(t *testing.T) {
 	}
 	if updated.Settings != "{}" {
 		t.Errorf("expected UpdateCollection to coerce empty-string settings to %q, got %q", "{}", updated.Settings)
+	}
+}
+
+// TestUpdateCollectionExpectedUpdatedAtMatch: a matching optimistic-concurrency
+// token (BUG-2265) lets the settings write through unchanged. Mirrors the item
+// path's TestUpdateItemExpectedUpdatedAtMatch.
+func TestUpdateCollectionExpectedUpdatedAtMatch(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "OCCCollMatch")
+
+	created, err := s.CreateCollection(ws.ID, models.CollectionCreate{
+		Name: "Things",
+		Slug: "things-occ-match",
+	})
+	if err != nil {
+		t.Fatalf("CreateCollection error: %v", err)
+	}
+
+	expected := created.UpdatedAt.UTC().Format("2006-01-02T15:04:05Z07:00")
+	settings := `{"quick_actions":[{"label":"Ship","prompt":"/pad ship","scope":"item"}]}`
+	updated, err := s.UpdateCollection(created.ID, models.CollectionUpdate{
+		Settings:          &settings,
+		ExpectedUpdatedAt: expected,
+	})
+	if err != nil {
+		t.Fatalf("UpdateCollection with matching expected_updated_at should succeed: %v", err)
+	}
+	if updated == nil {
+		t.Fatalf("UpdateCollection returned nil")
+	}
+	// Compare semantically — Postgres re-serializes the JSONB column (spaces /
+	// key order differ from the literal we sent), so an exact-string check
+	// would be a false failure on PG while passing on SQLite.
+	var got models.CollectionSettings
+	if err := json.Unmarshal([]byte(updated.Settings), &got); err != nil {
+		t.Fatalf("parse updated settings %q: %v", updated.Settings, err)
+	}
+	if len(got.QuickActions) != 1 || got.QuickActions[0].Label != "Ship" {
+		t.Errorf("expected the Ship quick action to be written, got %q", updated.Settings)
+	}
+}
+
+// TestUpdateCollectionExpectedUpdatedAtConflict: a stale token is rejected with
+// *CollectionUpdateConflictError and the write does NOT land — the BUG-2265
+// last-write-wins fix. Mirrors TestUpdateItemExpectedUpdatedAtConflict.
+func TestUpdateCollectionExpectedUpdatedAtConflict(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "OCCCollConflict")
+
+	created, err := s.CreateCollection(ws.ID, models.CollectionCreate{
+		Name:     "Things",
+		Slug:     "things-occ-conflict",
+		Settings: `{"layout":"balanced"}`,
+	})
+	if err != nil {
+		t.Fatalf("CreateCollection error: %v", err)
+	}
+
+	// A timestamp that definitely doesn't match the row's updated_at.
+	stale := "2000-01-01T00:00:00Z"
+	newSettings := `{"quick_actions":[{"label":"X","prompt":"y","scope":"item"}]}`
+	_, err = s.UpdateCollection(created.ID, models.CollectionUpdate{
+		Settings:          &newSettings,
+		ExpectedUpdatedAt: stale,
+	})
+	if err == nil {
+		t.Fatal("expected CollectionUpdateConflictError, got nil")
+	}
+	var conflict *CollectionUpdateConflictError
+	if !errors.As(err, &conflict) {
+		t.Fatalf("expected *CollectionUpdateConflictError, got %T: %v", err, err)
+	}
+	if conflict.ExpectedUpdatedAt != stale {
+		t.Errorf("conflict.ExpectedUpdatedAt: got %q want %q", conflict.ExpectedUpdatedAt, stale)
+	}
+	if conflict.ActualUpdatedAt.IsZero() {
+		t.Error("conflict.ActualUpdatedAt should carry the row's real timestamp")
+	}
+
+	// The write must NOT have landed — settings unchanged (semantic compare;
+	// see the match test for why exact-string fails on Postgres JSONB).
+	reread, err := s.GetCollection(created.ID)
+	if err != nil {
+		t.Fatalf("GetCollection: %v", err)
+	}
+	var got models.CollectionSettings
+	if err := json.Unmarshal([]byte(reread.Settings), &got); err != nil {
+		t.Fatalf("parse reread settings %q: %v", reread.Settings, err)
+	}
+	if got.Layout != "balanced" || len(got.QuickActions) != 0 {
+		t.Errorf("settings should be unchanged after a rejected conflict, got %q", reread.Settings)
+	}
+}
+
+// TestUpdateCollectionNoTokenSkipsConcurrencyCheck: omitting the token keeps
+// the legacy last-write-wins path — an unconditional write that always lands
+// (CLI / MCP / API callers that don't opt in). BUG-2265 is additive.
+func TestUpdateCollectionNoTokenSkipsConcurrencyCheck(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "OCCCollNoToken")
+
+	created, err := s.CreateCollection(ws.ID, models.CollectionCreate{
+		Name: "Things",
+		Slug: "things-occ-notoken",
+	})
+	if err != nil {
+		t.Fatalf("CreateCollection error: %v", err)
+	}
+
+	settings := `{"layout":"content-primary"}`
+	updated, err := s.UpdateCollection(created.ID, models.CollectionUpdate{
+		Settings: &settings, // no ExpectedUpdatedAt
+	})
+	if err != nil {
+		t.Fatalf("UpdateCollection without token should succeed: %v", err)
+	}
+	var got models.CollectionSettings
+	if err := json.Unmarshal([]byte(updated.Settings), &got); err != nil {
+		t.Fatalf("parse updated settings %q: %v", updated.Settings, err)
+	}
+	if got.Layout != "content-primary" {
+		t.Errorf("settings not written: got %q", updated.Settings)
 	}
 }
 

--- a/internal/store/collections_test.go
+++ b/internal/store/collections_test.go
@@ -268,6 +268,47 @@ func TestUpdateCollectionTokenAdvancesPreventsSameSecondClobber(t *testing.T) {
 	}
 }
 
+// TestUpdateCollectionTokenlessWriteStillAdvancesToken is the BUG-2265 Codex
+// round-2 guard: a TOKENLESS update must also advance updated_at strictly past
+// the row's current value, so it can't regress the concurrency token in the
+// same wall-clock second and let a stale guarded token clobber newer data.
+func TestUpdateCollectionTokenlessWriteStillAdvancesToken(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "OCCCollTokenlessMono")
+
+	created, err := s.CreateCollection(ws.ID, models.CollectionCreate{
+		Name: "Things",
+		Slug: "things-occ-tokenless-mono",
+	})
+	if err != nil {
+		t.Fatalf("CreateCollection error: %v", err)
+	}
+	token := created.UpdatedAt.UTC().Format("2006-01-02T15:04:05Z07:00")
+
+	// Tokenless write (the CLI/MCP/API path) — must advance updated_at even if
+	// it lands in the same second the token was read.
+	first := `{"layout":"content-primary"}`
+	updated, err := s.UpdateCollection(created.ID, models.CollectionUpdate{Settings: &first})
+	if err != nil {
+		t.Fatalf("tokenless update should succeed: %v", err)
+	}
+	if !updated.UpdatedAt.After(created.UpdatedAt) {
+		t.Fatalf("tokenless update must advance updated_at: created=%s updated=%s",
+			created.UpdatedAt.UTC(), updated.UpdatedAt.UTC())
+	}
+
+	// A guarded write replaying the pre-tokenless token must now conflict.
+	second := `{"layout":"fields-primary"}`
+	_, err = s.UpdateCollection(created.ID, models.CollectionUpdate{
+		Settings:          &second,
+		ExpectedUpdatedAt: token,
+	})
+	var conflict *CollectionUpdateConflictError
+	if !errors.As(err, &conflict) {
+		t.Fatalf("stale guarded token must conflict after a tokenless write, got %T: %v", err, err)
+	}
+}
+
 // TestUpdateCollectionNoTokenSkipsConcurrencyCheck: omitting the token keeps
 // the legacy last-write-wins path — an unconditional write that always lands
 // (CLI / MCP / API callers that don't opt in). BUG-2265 is additive.

--- a/internal/store/collections_test.go
+++ b/internal/store/collections_test.go
@@ -3,7 +3,9 @@ package store
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"reflect"
+	"sync"
 	"testing"
 
 	"github.com/PerpetualSoftware/pad/internal/models"
@@ -265,6 +267,69 @@ func TestUpdateCollectionAppliesMigrationsAtomically(t *testing.T) {
 	}
 	if fields["status"] != "active" {
 		t.Errorf("item field value not migrated, got %v (fields %q)", fields["status"], got.Fields)
+	}
+}
+
+// TestUpdateCollectionMigrationNoDeadlockWithItemCreate is the BUG-2265 Codex
+// round-4 lock-ordering regression guard. UpdateCollection's migration path and
+// item creation both lock the workspace advisory/seq lock AND a collection row;
+// they MUST take them in the same order (workspace lock first, then the
+// collection row) or a concurrent item-create + schema-migration ABBA-deadlocks.
+// On Postgres a wrong order surfaces as a "deadlock detected" error (the
+// detector aborts a tx rather than hanging); on SQLite the single-writer lock
+// serializes everything. Either way, with the correct order every worker
+// succeeds.
+func TestUpdateCollectionMigrationNoDeadlockWithItemCreate(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "OCCCollDeadlock")
+	coll, err := s.CreateCollection(ws.ID, models.CollectionCreate{
+		Name:   "Tasks",
+		Slug:   "tasks-occ-deadlock",
+		Schema: `{"fields":[{"key":"status","label":"Status","type":"select","options":["a","b"]}]}`,
+	})
+	if err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+
+	const workers = 8
+	var ready sync.WaitGroup
+	ready.Add(workers)
+	release := make(chan struct{})
+	errCh := make(chan error, workers)
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			ready.Done()
+			<-release // all workers contend simultaneously
+			if n%2 == 0 {
+				// Migration path: takes the workspace seq lock + the collection
+				// row FOR UPDATE. A non-matching rename still exercises both
+				// locks (len(Migrations) > 0 is the only gate).
+				_, e := s.UpdateCollection(coll.ID, models.CollectionUpdate{
+					Migrations: []models.FieldMigration{{Field: "status", RenameOptions: map[string]string{"z": "y"}}},
+				})
+				errCh <- e
+			} else {
+				// Item creation: takes the workspace advisory lock, then the
+				// collection-row FK lock on INSERT.
+				_, e := s.CreateItem(ws.ID, coll.ID, models.ItemCreate{
+					Title:  fmt.Sprintf("i%d", n),
+					Fields: `{"status":"a"}`,
+				})
+				errCh <- e
+			}
+		}(i)
+	}
+	ready.Wait()
+	close(release)
+	wg.Wait()
+	close(errCh)
+	for e := range errCh {
+		if e != nil {
+			t.Fatalf("concurrent item-create + schema-migration errored (ABBA-deadlock regression?): %v", e)
+		}
 	}
 }
 

--- a/internal/store/collections_test.go
+++ b/internal/store/collections_test.go
@@ -208,6 +208,66 @@ func TestUpdateCollectionExpectedUpdatedAtConflict(t *testing.T) {
 	}
 }
 
+// TestUpdateCollectionTokenAdvancesPreventsSameSecondClobber is the BUG-2265
+// same-second regression guard (Codex P1): two guarded writes reusing the SAME
+// token must not both succeed even when they land in the same wall-clock second
+// (now() is one-second precision). The first accepted write advances updated_at
+// strictly past the token, so replaying the stale token conflicts — DETERMINISTIC
+// regardless of timing.
+func TestUpdateCollectionTokenAdvancesPreventsSameSecondClobber(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "OCCCollSameSecond")
+
+	created, err := s.CreateCollection(ws.ID, models.CollectionCreate{
+		Name: "Things",
+		Slug: "things-occ-samesecond",
+	})
+	if err != nil {
+		t.Fatalf("CreateCollection error: %v", err)
+	}
+
+	token := created.UpdatedAt.UTC().Format("2006-01-02T15:04:05Z07:00")
+
+	first := `{"layout":"content-primary"}`
+	updated, err := s.UpdateCollection(created.ID, models.CollectionUpdate{
+		Settings:          &first,
+		ExpectedUpdatedAt: token,
+	})
+	if err != nil {
+		t.Fatalf("first guarded update should succeed: %v", err)
+	}
+	// The accepted write must have advanced updated_at strictly past the token
+	// even if it committed in the same second the token was read.
+	if !updated.UpdatedAt.After(created.UpdatedAt) {
+		t.Fatalf("updated_at must advance past the token: created=%s updated=%s",
+			created.UpdatedAt.UTC(), updated.UpdatedAt.UTC())
+	}
+
+	// Replaying the SAME (now stale) token must conflict, not clobber.
+	second := `{"layout":"fields-primary"}`
+	_, err = s.UpdateCollection(created.ID, models.CollectionUpdate{
+		Settings:          &second,
+		ExpectedUpdatedAt: token,
+	})
+	var conflict *CollectionUpdateConflictError
+	if !errors.As(err, &conflict) {
+		t.Fatalf("replaying the stale token must conflict, got %T: %v", err, err)
+	}
+
+	// The first write must still be the current state (second write rejected).
+	reread, err := s.GetCollection(created.ID)
+	if err != nil {
+		t.Fatalf("GetCollection: %v", err)
+	}
+	var got models.CollectionSettings
+	if err := json.Unmarshal([]byte(reread.Settings), &got); err != nil {
+		t.Fatalf("parse reread settings %q: %v", reread.Settings, err)
+	}
+	if got.Layout != "content-primary" {
+		t.Errorf("expected the first write to survive, got %q", reread.Settings)
+	}
+}
+
 // TestUpdateCollectionNoTokenSkipsConcurrencyCheck: omitting the token keeps
 // the legacy last-write-wins path — an unconditional write that always lands
 // (CLI / MCP / API callers that don't opt in). BUG-2265 is additive.

--- a/internal/store/collections_test.go
+++ b/internal/store/collections_test.go
@@ -105,7 +105,7 @@ func TestUpdateCollectionCoercesEmptyStringSettings(t *testing.T) {
 	}
 
 	empty := ""
-	updated, err := s.UpdateCollection(created.ID, models.CollectionUpdate{
+	updated, _, err := s.UpdateCollection(created.ID, models.CollectionUpdate{
 		Settings: &empty,
 	})
 	if err != nil {
@@ -136,7 +136,7 @@ func TestUpdateCollectionExpectedUpdatedAtMatch(t *testing.T) {
 
 	expected := created.UpdatedAt.UTC().Format("2006-01-02T15:04:05Z07:00")
 	settings := `{"quick_actions":[{"label":"Ship","prompt":"/pad ship","scope":"item"}]}`
-	updated, err := s.UpdateCollection(created.ID, models.CollectionUpdate{
+	updated, _, err := s.UpdateCollection(created.ID, models.CollectionUpdate{
 		Settings:          &settings,
 		ExpectedUpdatedAt: expected,
 	})
@@ -177,7 +177,7 @@ func TestUpdateCollectionExpectedUpdatedAtConflict(t *testing.T) {
 	// A timestamp that definitely doesn't match the row's updated_at.
 	stale := "2000-01-01T00:00:00Z"
 	newSettings := `{"quick_actions":[{"label":"X","prompt":"y","scope":"item"}]}`
-	_, err = s.UpdateCollection(created.ID, models.CollectionUpdate{
+	_, _, err = s.UpdateCollection(created.ID, models.CollectionUpdate{
 		Settings:          &newSettings,
 		ExpectedUpdatedAt: stale,
 	})
@@ -234,7 +234,7 @@ func TestUpdateCollectionAppliesMigrationsAtomically(t *testing.T) {
 
 	token := coll.UpdatedAt.UTC().Format("2006-01-02T15:04:05Z07:00")
 	newSchema := `{"fields":[{"key":"status","label":"Status","type":"select","options":["active","closed"]}]}`
-	updated, err := s.UpdateCollection(coll.ID, models.CollectionUpdate{
+	updated, _, err := s.UpdateCollection(coll.ID, models.CollectionUpdate{
 		Schema:            &newSchema,
 		ExpectedUpdatedAt: token,
 		Migrations:        []models.FieldMigration{{Field: "status", RenameOptions: map[string]string{"open": "active"}}},
@@ -307,7 +307,7 @@ func TestUpdateCollectionMigrationNoDeadlockWithItemCreate(t *testing.T) {
 				// Migration path: takes the workspace seq lock + the collection
 				// row FOR UPDATE. A non-matching rename still exercises both
 				// locks (len(Migrations) > 0 is the only gate).
-				_, e := s.UpdateCollection(coll.ID, models.CollectionUpdate{
+				_, _, e := s.UpdateCollection(coll.ID, models.CollectionUpdate{
 					Migrations: []models.FieldMigration{{Field: "status", RenameOptions: map[string]string{"z": "y"}}},
 				})
 				errCh <- e
@@ -354,7 +354,7 @@ func TestUpdateCollectionTokenAdvancesPreventsSameSecondClobber(t *testing.T) {
 	token := created.UpdatedAt.UTC().Format("2006-01-02T15:04:05Z07:00")
 
 	first := `{"layout":"content-primary"}`
-	updated, err := s.UpdateCollection(created.ID, models.CollectionUpdate{
+	updated, _, err := s.UpdateCollection(created.ID, models.CollectionUpdate{
 		Settings:          &first,
 		ExpectedUpdatedAt: token,
 	})
@@ -370,7 +370,7 @@ func TestUpdateCollectionTokenAdvancesPreventsSameSecondClobber(t *testing.T) {
 
 	// Replaying the SAME (now stale) token must conflict, not clobber.
 	second := `{"layout":"fields-primary"}`
-	_, err = s.UpdateCollection(created.ID, models.CollectionUpdate{
+	_, _, err = s.UpdateCollection(created.ID, models.CollectionUpdate{
 		Settings:          &second,
 		ExpectedUpdatedAt: token,
 	})
@@ -413,7 +413,7 @@ func TestUpdateCollectionTokenlessWriteStillAdvancesToken(t *testing.T) {
 	// Tokenless write (the CLI/MCP/API path) — must advance updated_at even if
 	// it lands in the same second the token was read.
 	first := `{"layout":"content-primary"}`
-	updated, err := s.UpdateCollection(created.ID, models.CollectionUpdate{Settings: &first})
+	updated, _, err := s.UpdateCollection(created.ID, models.CollectionUpdate{Settings: &first})
 	if err != nil {
 		t.Fatalf("tokenless update should succeed: %v", err)
 	}
@@ -424,7 +424,7 @@ func TestUpdateCollectionTokenlessWriteStillAdvancesToken(t *testing.T) {
 
 	// A guarded write replaying the pre-tokenless token must now conflict.
 	second := `{"layout":"fields-primary"}`
-	_, err = s.UpdateCollection(created.ID, models.CollectionUpdate{
+	_, _, err = s.UpdateCollection(created.ID, models.CollectionUpdate{
 		Settings:          &second,
 		ExpectedUpdatedAt: token,
 	})
@@ -450,7 +450,7 @@ func TestUpdateCollectionNoTokenSkipsConcurrencyCheck(t *testing.T) {
 	}
 
 	settings := `{"layout":"content-primary"}`
-	updated, err := s.UpdateCollection(created.ID, models.CollectionUpdate{
+	updated, _, err := s.UpdateCollection(created.ID, models.CollectionUpdate{
 		Settings: &settings, // no ExpectedUpdatedAt
 	})
 	if err != nil {

--- a/internal/store/collections_test.go
+++ b/internal/store/collections_test.go
@@ -105,7 +105,7 @@ func TestUpdateCollectionCoercesEmptyStringSettings(t *testing.T) {
 	}
 
 	empty := ""
-	updated, _, err := s.UpdateCollection(created.ID, models.CollectionUpdate{
+	updated, err := s.UpdateCollection(created.ID, models.CollectionUpdate{
 		Settings: &empty,
 	})
 	if err != nil {
@@ -136,7 +136,7 @@ func TestUpdateCollectionExpectedUpdatedAtMatch(t *testing.T) {
 
 	expected := created.UpdatedAt.UTC().Format("2006-01-02T15:04:05Z07:00")
 	settings := `{"quick_actions":[{"label":"Ship","prompt":"/pad ship","scope":"item"}]}`
-	updated, _, err := s.UpdateCollection(created.ID, models.CollectionUpdate{
+	updated, err := s.UpdateCollection(created.ID, models.CollectionUpdate{
 		Settings:          &settings,
 		ExpectedUpdatedAt: expected,
 	})
@@ -177,7 +177,7 @@ func TestUpdateCollectionExpectedUpdatedAtConflict(t *testing.T) {
 	// A timestamp that definitely doesn't match the row's updated_at.
 	stale := "2000-01-01T00:00:00Z"
 	newSettings := `{"quick_actions":[{"label":"X","prompt":"y","scope":"item"}]}`
-	_, _, err = s.UpdateCollection(created.ID, models.CollectionUpdate{
+	_, err = s.UpdateCollection(created.ID, models.CollectionUpdate{
 		Settings:          &newSettings,
 		ExpectedUpdatedAt: stale,
 	})
@@ -234,7 +234,7 @@ func TestUpdateCollectionAppliesMigrationsAtomically(t *testing.T) {
 
 	token := coll.UpdatedAt.UTC().Format("2006-01-02T15:04:05Z07:00")
 	newSchema := `{"fields":[{"key":"status","label":"Status","type":"select","options":["active","closed"]}]}`
-	updated, _, err := s.UpdateCollection(coll.ID, models.CollectionUpdate{
+	updated, err := s.UpdateCollection(coll.ID, models.CollectionUpdate{
 		Schema:            &newSchema,
 		ExpectedUpdatedAt: token,
 		Migrations:        []models.FieldMigration{{Field: "status", RenameOptions: map[string]string{"open": "active"}}},
@@ -307,7 +307,7 @@ func TestUpdateCollectionMigrationNoDeadlockWithItemCreate(t *testing.T) {
 				// Migration path: takes the workspace seq lock + the collection
 				// row FOR UPDATE. A non-matching rename still exercises both
 				// locks (len(Migrations) > 0 is the only gate).
-				_, _, e := s.UpdateCollection(coll.ID, models.CollectionUpdate{
+				_, e := s.UpdateCollection(coll.ID, models.CollectionUpdate{
 					Migrations: []models.FieldMigration{{Field: "status", RenameOptions: map[string]string{"z": "y"}}},
 				})
 				errCh <- e
@@ -354,7 +354,7 @@ func TestUpdateCollectionTokenAdvancesPreventsSameSecondClobber(t *testing.T) {
 	token := created.UpdatedAt.UTC().Format("2006-01-02T15:04:05Z07:00")
 
 	first := `{"layout":"content-primary"}`
-	updated, _, err := s.UpdateCollection(created.ID, models.CollectionUpdate{
+	updated, err := s.UpdateCollection(created.ID, models.CollectionUpdate{
 		Settings:          &first,
 		ExpectedUpdatedAt: token,
 	})
@@ -370,7 +370,7 @@ func TestUpdateCollectionTokenAdvancesPreventsSameSecondClobber(t *testing.T) {
 
 	// Replaying the SAME (now stale) token must conflict, not clobber.
 	second := `{"layout":"fields-primary"}`
-	_, _, err = s.UpdateCollection(created.ID, models.CollectionUpdate{
+	_, err = s.UpdateCollection(created.ID, models.CollectionUpdate{
 		Settings:          &second,
 		ExpectedUpdatedAt: token,
 	})
@@ -413,7 +413,7 @@ func TestUpdateCollectionTokenlessWriteStillAdvancesToken(t *testing.T) {
 	// Tokenless write (the CLI/MCP/API path) — must advance updated_at even if
 	// it lands in the same second the token was read.
 	first := `{"layout":"content-primary"}`
-	updated, _, err := s.UpdateCollection(created.ID, models.CollectionUpdate{Settings: &first})
+	updated, err := s.UpdateCollection(created.ID, models.CollectionUpdate{Settings: &first})
 	if err != nil {
 		t.Fatalf("tokenless update should succeed: %v", err)
 	}
@@ -424,7 +424,7 @@ func TestUpdateCollectionTokenlessWriteStillAdvancesToken(t *testing.T) {
 
 	// A guarded write replaying the pre-tokenless token must now conflict.
 	second := `{"layout":"fields-primary"}`
-	_, _, err = s.UpdateCollection(created.ID, models.CollectionUpdate{
+	_, err = s.UpdateCollection(created.ID, models.CollectionUpdate{
 		Settings:          &second,
 		ExpectedUpdatedAt: token,
 	})
@@ -450,7 +450,7 @@ func TestUpdateCollectionNoTokenSkipsConcurrencyCheck(t *testing.T) {
 	}
 
 	settings := `{"layout":"content-primary"}`
-	updated, _, err := s.UpdateCollection(created.ID, models.CollectionUpdate{
+	updated, err := s.UpdateCollection(created.ID, models.CollectionUpdate{
 		Settings: &settings, // no ExpectedUpdatedAt
 	})
 	if err != nil {

--- a/internal/store/collections_test.go
+++ b/internal/store/collections_test.go
@@ -208,6 +208,66 @@ func TestUpdateCollectionExpectedUpdatedAtConflict(t *testing.T) {
 	}
 }
 
+// TestUpdateCollectionAppliesMigrationsAtomically (BUG-2265 Codex P1): the
+// schema change and its field-value migration commit together in ONE tx — the
+// item's renamed option value lands with the schema, and the concurrency token
+// advances once. (Failure-rollback is covered structurally: the migration runs
+// inside the same tx, so an error returns before commit.)
+func TestUpdateCollectionAppliesMigrationsAtomically(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "OCCCollMigrate")
+
+	coll, err := s.CreateCollection(ws.ID, models.CollectionCreate{
+		Name:   "Tasks",
+		Slug:   "tasks-occ-migrate",
+		Schema: `{"fields":[{"key":"status","label":"Status","type":"select","options":["open","closed"]}]}`,
+	})
+	if err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	item, err := s.CreateItem(ws.ID, coll.ID, models.ItemCreate{Title: "T", Fields: `{"status":"open"}`})
+	if err != nil {
+		t.Fatalf("CreateItem: %v", err)
+	}
+
+	token := coll.UpdatedAt.UTC().Format("2006-01-02T15:04:05Z07:00")
+	newSchema := `{"fields":[{"key":"status","label":"Status","type":"select","options":["active","closed"]}]}`
+	updated, err := s.UpdateCollection(coll.ID, models.CollectionUpdate{
+		Schema:            &newSchema,
+		ExpectedUpdatedAt: token,
+		Migrations:        []models.FieldMigration{{Field: "status", RenameOptions: map[string]string{"open": "active"}}},
+	})
+	if err != nil {
+		t.Fatalf("UpdateCollection with migration: %v", err)
+	}
+	// Schema change landed (compare semantically — Postgres re-serializes the
+	// JSONB schema column, so an exact-string check would false-fail on PG).
+	var gotSchema models.CollectionSchema
+	if err := json.Unmarshal([]byte(updated.Schema), &gotSchema); err != nil {
+		t.Fatalf("parse updated schema %q: %v", updated.Schema, err)
+	}
+	if len(gotSchema.Fields) != 1 || len(gotSchema.Fields[0].Options) != 2 ||
+		gotSchema.Fields[0].Options[0] != "active" || gotSchema.Fields[0].Options[1] != "closed" {
+		t.Errorf("schema options not updated to [active closed]: %q", updated.Schema)
+	}
+	// Token advanced exactly (strictly past the accepted token).
+	if !updated.UpdatedAt.After(coll.UpdatedAt) {
+		t.Errorf("token did not advance: %s !> %s", updated.UpdatedAt.UTC(), coll.UpdatedAt.UTC())
+	}
+	// Item value migrated in the SAME commit.
+	got, err := s.GetItem(item.ID)
+	if err != nil || got == nil {
+		t.Fatalf("GetItem: %v", err)
+	}
+	var fields map[string]any
+	if err := json.Unmarshal([]byte(got.Fields), &fields); err != nil {
+		t.Fatalf("parse item fields %q: %v", got.Fields, err)
+	}
+	if fields["status"] != "active" {
+		t.Errorf("item field value not migrated, got %v (fields %q)", fields["status"], got.Fields)
+	}
+}
+
 // TestUpdateCollectionTokenAdvancesPreventsSameSecondClobber is the BUG-2265
 // same-second regression guard (Codex P1): two guarded writes reusing the SAME
 // token must not both succeed even when they land in the same wall-clock second

--- a/internal/store/done_field_test.go
+++ b/internal/store/done_field_test.go
@@ -200,7 +200,7 @@ func TestGetItemProgress_HonorsSoftDeletedChildCollections(t *testing.T) {
 
 	// Soft-delete the tasks collection. Its items remain in the DB and
 	// are still linked to the plan.
-	if err := s.DeleteCollection(tasks.ID); err != nil {
+	if err := s.DeleteCollection(tasks.ID, ""); err != nil {
 		t.Fatalf("soft delete tasks: %v", err)
 	}
 

--- a/internal/store/items_test.go
+++ b/internal/store/items_test.go
@@ -217,7 +217,7 @@ func TestCollectionCRUD(t *testing.T) {
 	// Update
 	newName := "My Tasks"
 	newIcon := "list"
-	updated, _, err := s.UpdateCollection(col.ID, models.CollectionUpdate{
+	updated, err := s.UpdateCollection(col.ID, models.CollectionUpdate{
 		Name: &newName,
 		Icon: &newIcon,
 	})

--- a/internal/store/items_test.go
+++ b/internal/store/items_test.go
@@ -244,7 +244,7 @@ func TestCollectionCRUD(t *testing.T) {
 	}
 
 	// Delete
-	err = s.DeleteCollection(col.ID)
+	err = s.DeleteCollection(col.ID, "")
 	if err != nil {
 		t.Fatalf("DeleteCollection error: %v", err)
 	}
@@ -276,7 +276,7 @@ func TestCollectionDeleteDefaultRefused(t *testing.T) {
 	}
 
 	// Attempt to delete — should fail
-	err = s.DeleteCollection(col.ID)
+	err = s.DeleteCollection(col.ID, "")
 	if err == nil {
 		t.Fatal("expected error when deleting default collection")
 	}

--- a/internal/store/items_test.go
+++ b/internal/store/items_test.go
@@ -217,7 +217,7 @@ func TestCollectionCRUD(t *testing.T) {
 	// Update
 	newName := "My Tasks"
 	newIcon := "list"
-	updated, err := s.UpdateCollection(col.ID, models.CollectionUpdate{
+	updated, _, err := s.UpdateCollection(col.ID, models.CollectionUpdate{
 		Name: &newName,
 		Icon: &newIcon,
 	})

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -847,6 +847,19 @@ func now() string {
 	return time.Now().UTC().Format(time.RFC3339)
 }
 
+// nowNano is a sub-second (nanosecond) UTC timestamp. Used where a stored
+// timestamp doubles as an optimistic-concurrency token and must distinguish
+// writes that land within the same wall-clock second (BUG-2265 collections):
+// second-precision now() would collide, forcing a whole-second "advance into
+// the future" to keep the token monotonic. Sub-second resolution makes
+// collisions near-impossible, so the token advances naturally and never drifts
+// meaningfully ahead of wall-clock. The value is a valid RFC3339 string
+// (time.Parse(time.RFC3339, …) accepts the fractional seconds), so it
+// round-trips through parseTime and the JSON API unchanged.
+func nowNano() string {
+	return time.Now().UTC().Format(time.RFC3339Nano)
+}
+
 func parseTime(s string) time.Time {
 	t, _ := time.Parse(time.RFC3339, s)
 	return t

--- a/web/src/lib/api/client.test.ts
+++ b/web/src/lib/api/client.test.ts
@@ -1,5 +1,14 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { api, parseRetryAfterMs, isRateLimitError, PadApiError, setRateLimitHandler } from './client';
+import {
+	api,
+	parseRetryAfterMs,
+	isRateLimitError,
+	PadApiError,
+	setRateLimitHandler,
+	isNotFoundError,
+	isUpdateConflictError,
+	isConflictOrNotFound
+} from './client';
 
 // The 401 interceptor branches on `typeof window !== 'undefined'`. The
 // vitest environment here is 'node' (see vitest.config.ts), so `window` is
@@ -29,6 +38,52 @@ function mockFetchOnce(status: number, body: unknown) {
 		}))
 	);
 }
+
+// BUG-2265 Pattern C: retry paths must recover from BOTH a 409 update_conflict
+// (settings/schema changed) AND a 404 not_found (a competing RENAME killed the
+// slug). These verify the classification helpers those retries branch on, and
+// that a real 404/409 response surfaces as the right PadApiError code.
+describe('conflict/not-found classification (BUG-2265 Pattern C)', () => {
+	beforeEach(() => vi.unstubAllGlobals());
+	afterEach(() => vi.unstubAllGlobals());
+
+	it('a 404 surfaces as not_found and is classified for retry', async () => {
+		mockFetchOnce(404, { error: { code: 'not_found', message: 'gone' } });
+		const err = await api.collections
+			.update('ws', 'renamed-away', { settings: '{}' })
+			.then(() => null)
+			.catch((e) => e);
+		expect(err).toBeInstanceOf(PadApiError);
+		expect((err as PadApiError).code).toBe('not_found');
+		expect(isNotFoundError(err)).toBe(true);
+		expect(isConflictOrNotFound(err)).toBe(true);
+		expect(isUpdateConflictError(err)).toBe(false);
+	});
+
+	it('a 409 surfaces as update_conflict and is classified for retry', async () => {
+		mockFetchOnce(409, {
+			error: { code: 'update_conflict', message: 'stale', details: { ref: 'tasks' } },
+		});
+		const err = await api.collections
+			.update('ws', 'tasks', { settings: '{}', expected_updated_at: 'x' })
+			.then(() => null)
+			.catch((e) => e);
+		expect(err).toBeInstanceOf(PadApiError);
+		expect((err as PadApiError).code).toBe('update_conflict');
+		expect(isUpdateConflictError(err)).toBe(true);
+		expect(isConflictOrNotFound(err)).toBe(true);
+		expect(isNotFoundError(err)).toBe(false);
+	});
+
+	it('an unrelated error is NOT classified for conflict/not-found retry', async () => {
+		mockFetchOnce(500, { error: { code: 'internal_error', message: 'boom' } });
+		const err = await api.collections
+			.update('ws', 'tasks', { settings: '{}' })
+			.then(() => null)
+			.catch((e) => e);
+		expect(isConflictOrNotFound(err)).toBe(false);
+	});
+});
 
 describe('api client 401 handling (BUG-1929)', () => {
 	beforeEach(() => {

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -207,6 +207,26 @@ function isUpdateConflictError(err: unknown): err is PadApiError {
 }
 
 /**
+ * Returns true when `err` is a 404 not_found. BUG-2265 (Codex round 6): a
+ * competing RENAME can kill the slug a write targeted, so the request returns
+ * 404 instead of 409 — retry paths must treat BOTH as "resolve the fresh
+ * collection by stable id and retry", surfacing an error only if it's truly
+ * gone.
+ */
+function isNotFoundError(err: unknown): err is PadApiError {
+	return err instanceof PadApiError && err.code === 'not_found';
+}
+
+/**
+ * True when `err` is either an optimistic-concurrency 409 OR a rename-induced
+ * 404 — the two ways a concurrent collection change can defeat a slug-targeted
+ * write (BUG-2265). Retry paths branch on this to resolve-by-id and retry.
+ */
+function isConflictOrNotFound(err: unknown): err is PadApiError {
+	return isUpdateConflictError(err) || isNotFoundError(err);
+}
+
+/**
  * Returns a human-readable upgrade-signal message for a plan limit error.
  * Falls back to the server-supplied `err.message` if details are unavailable,
  * so the function is always safe to call. TASK-788.
@@ -2394,4 +2414,12 @@ export const api = {
 	}
 };
 
-export { PadApiError, isPlanLimitError, planLimitMessage, isRateLimitError, isUpdateConflictError };
+export {
+	PadApiError,
+	isPlanLimitError,
+	planLimitMessage,
+	isRateLimitError,
+	isUpdateConflictError,
+	isNotFoundError,
+	isConflictOrNotFound
+};

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -940,10 +940,18 @@ export const api = {
 				body: JSON.stringify(data)
 			}),
 
-		delete: (ws: string, slug: string) =>
-			request<void>(`/workspaces/${ws}/collections/${slug}`, {
+		// expectedUpdatedAt (BUG-2265): the updated_at of the collection the
+		// caller resolved. Sent as a query param so the server 409s if a
+		// concurrent rename re-owned this slug with a DIFFERENT collection —
+		// never archiving the wrong one. Omit for the legacy unconditional path.
+		delete: (ws: string, slug: string, expectedUpdatedAt?: string) => {
+			const q = expectedUpdatedAt
+				? `?expected_updated_at=${encodeURIComponent(expectedUpdatedAt)}`
+				: '';
+			return request<void>(`/workspaces/${ws}/collections/${slug}${q}`, {
 				method: 'DELETE'
-			})
+			});
+		}
 	},
 
 	// ── Agent Roles ──────────────────────────────────────────────────────────

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -194,6 +194,19 @@ function isPlanLimitError(err: unknown): err is PadApiError {
 }
 
 /**
+ * Returns true when `err` is the optimistic-concurrency 409 (BUG-2265):
+ * the resource was modified by another writer since the caller last read it.
+ * `err.details` carries `{ ref, expected_updated_at, actual_updated_at }`.
+ * Callers can catch this to transparently refetch-and-retry (quick actions)
+ * or surface a "reload to see the latest" message (full-form edits). Mirrors
+ * isRateLimitError / isPlanLimitError; shared by the item and collection
+ * update paths, whose 409 wire shape is identical.
+ */
+function isUpdateConflictError(err: unknown): err is PadApiError {
+	return err instanceof PadApiError && err.code === 'update_conflict';
+}
+
+/**
  * Returns a human-readable upgrade-signal message for a plan limit error.
  * Falls back to the server-supplied `err.message` if details are unavailable,
  * so the function is always safe to call. TASK-788.
@@ -2381,4 +2394,4 @@ export const api = {
 	}
 };
 
-export { PadApiError, isPlanLimitError, planLimitMessage, isRateLimitError };
+export { PadApiError, isPlanLimitError, planLimitMessage, isRateLimitError, isUpdateConflictError };

--- a/web/src/lib/components/collections/EditCollectionModal.svelte
+++ b/web/src/lib/components/collections/EditCollectionModal.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { api, isUpdateConflictError } from '$lib/api/client';
+	import { api, isConflictOrNotFound } from '$lib/api/client';
 	import type { Collection, CollectionUpdate, CollectionSettings, FieldDef, FieldMigration, QuickAction } from '$lib/types';
 	import { parseSchema, parseSettings } from '$lib/types';
 	import EmojiPickerButton from '$lib/components/common/EmojiPickerButton.svelte';
@@ -86,12 +86,34 @@
 		const editedCollectionSlug = seededCollectionSlug;
 		const editedCollectionName = seededCollectionName;
 		const editedWsSlug = seededWsSlug;
-		try {
-			await api.collections.delete(editedWsSlug, editedCollectionSlug);
+		const finishArchived = () => {
 			toastStore.show(`Archived "${editedCollectionName}"`, 'success');
 			onupdated(undefined, editedCollectionId, editedCollectionSlug, editedWsSlug);
 			onclose();
+		};
+		try {
+			await api.collections.delete(editedWsSlug, editedCollectionSlug);
+			finishArchived();
 		} catch (err) {
+			// A concurrent RENAME can kill the seeded slug (404), or a change
+			// could 409 (BUG-2265 Pattern C). Resolve the SAME collection by its
+			// STABLE id and retry the delete against its current slug; if it's
+			// already gone from the list, it's effectively archived already.
+			if (isConflictOrNotFound(err)) {
+				try {
+					const list = await api.collections.list(editedWsSlug);
+					const fresh = list.find((c) => c.id === editedCollectionId);
+					if (!fresh) {
+						finishArchived();
+						return;
+					}
+					await api.collections.delete(editedWsSlug, fresh.slug);
+					finishArchived();
+					return;
+				} catch {
+					// fall through to the generic error
+				}
+			}
 			toastStore.show('Failed to archive collection', 'error');
 		} finally {
 			archiving = false;
@@ -625,10 +647,14 @@
 			toastStore.show(`Updated ${name.trim()}`, 'success');
 			onupdated(updated, editedCollectionId, editedCollectionSlug, editedWsSlug);
 		} catch (err) {
-			if (isUpdateConflictError(err)) {
-				// Non-destructive: keep the user's in-progress edits visible and
-				// tell them to reload to pick up the concurrent change, then
-				// re-apply. We deliberately do NOT auto-merge a full-form edit.
+			if (isConflictOrNotFound(err)) {
+				// The collection changed elsewhere — a 409 (settings/schema
+				// changed) OR a 404 (a RENAME killed the slug we targeted). Both
+				// are non-destructive here (BUG-2265 Pattern C): keep the user's
+				// in-progress edits visible and tell them to reload, then re-apply.
+				// We deliberately do NOT auto-merge a full-form edit — a rebuilt
+				// schema+settings blob from a stale snapshot can't be safely
+				// reconciled, and silently overwriting would clobber the change.
 				error =
 					'This collection was changed elsewhere while you were editing. Reload to see the latest, then re-apply your changes.';
 			} else {

--- a/web/src/lib/components/collections/EditCollectionModal.svelte
+++ b/web/src/lib/components/collections/EditCollectionModal.svelte
@@ -301,6 +301,22 @@
 
 			void loadCollectionOptions();
 			void loadPreviewContext();
+		} else if (
+			open &&
+			collection &&
+			collection.id === seededCollectionId &&
+			collection.slug !== seededCollectionSlug
+		) {
+			// SAME collection (same id) but a concurrent RENAME changed its slug
+			// (and name) while the modal is open (Codex P2). Retarget the PATCH
+			// endpoint slug + re-capture the token so handleSave/handleArchive
+			// hit the LIVE slug instead of the now-dead one (which would 404
+			// before the token could even 409). Do NOT reseed the form — the
+			// user's in-progress edits are preserved.
+			seededCollectionSlug = collection.slug;
+			seededCollectionName = collection.name;
+			seededWsSlug = wsSlug;
+			expectedUpdatedAt = collection.updated_at;
 		}
 		// Latch AFTER the seed so the next `collection` change (e.g. the
 		// BUG-2265 broadcast) re-runs this effect but skips re-seeding until

--- a/web/src/lib/components/collections/EditCollectionModal.svelte
+++ b/web/src/lib/components/collections/EditCollectionModal.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { api } from '$lib/api/client';
+	import { api, isUpdateConflictError } from '$lib/api/client';
 	import type { Collection, CollectionUpdate, CollectionSettings, FieldDef, FieldMigration, QuickAction } from '$lib/types';
 	import { parseSchema, parseSettings } from '$lib/types';
 	import EmojiPickerButton from '$lib/components/common/EmojiPickerButton.svelte';
@@ -109,6 +109,14 @@
 	let saving = $state(false);
 	let error = $state('');
 
+	// Optimistic-concurrency token (BUG-2265): the collection's updated_at
+	// captured at the moment the form was seeded from `collection` (see the
+	// open-edge seed effect below). handleSave round-trips it so a full-form
+	// save that lost a race to another writer is rejected with a 409 instead
+	// of silently overwriting their change; on 409 we surface a
+	// non-destructive "reload" message and keep the user's edits intact.
+	let expectedUpdatedAt = $state('');
+
 	// ── Field editing state ──────────────────────────────────────────────────
 	// EditableField shape lives in `./field-editor-types.ts` so FieldEditor
 	// and this modal share one type.
@@ -207,8 +215,18 @@
 
 	// ── Sync from collection when modal opens ────────────────────────────────
 
+	// Seed the form ONCE per open transition (open false→true), not on every
+	// `collection` reassignment. BUG-2265's sibling broadcast can refresh the
+	// parent's `collection` prop while this modal is open mid-edit; without
+	// this edge-gate the effect would re-run and wipe the user's in-progress
+	// edits (and reset the captured optimistic-concurrency token). `wasOpen`
+	// is a plain (non-reactive) latch — the effect still depends on `open` and
+	// `collection`, but only re-seeds on the rising edge of `open`.
+	let wasOpen = false;
+
 	$effect(() => {
-		if (open && collection) {
+		if (open && !wasOpen && collection) {
+			expectedUpdatedAt = collection.updated_at;
 			name = collection.name;
 			selectedIcon = collection.icon || '';
 			description = collection.description || '';
@@ -265,6 +283,10 @@
 			void loadCollectionOptions();
 			void loadPreviewContext();
 		}
+		// Latch AFTER the seed so the next `collection` change (e.g. the
+		// BUG-2265 broadcast) re-runs this effect but skips re-seeding until
+		// the modal is actually closed and reopened.
+		wasOpen = open;
 	});
 
 	// ── Existing field actions ───────────────────────────────────────────────
@@ -542,7 +564,13 @@
 				icon: selectedIcon || undefined,
 				description: description.trim() || undefined,
 				schema: JSON.stringify({ fields: allFields }),
-				settings: JSON.stringify(settingsObj)
+				settings: JSON.stringify(settingsObj),
+				// BUG-2265: round-trip the open-time token so a full-form save
+				// that lost a race is rejected rather than clobbering the other
+				// writer. Unlike QuickActionsMenu we do NOT auto-merge a whole
+				// form — a rebuilt schema+settings blob from a stale snapshot
+				// can't be safely reconciled — so we surface a reload prompt.
+				expected_updated_at: expectedUpdatedAt || undefined
 			};
 
 			if (migrations.length > 0) {
@@ -550,10 +578,22 @@
 			}
 
 			const updated = await api.collections.update(editedWsSlug, editedCollectionSlug, data);
+			// Keep the token fresh in case the modal stays open (the parent may
+			// leave it mounted after a save) so a subsequent edit doesn't
+			// spuriously 409 against our own just-committed change.
+			expectedUpdatedAt = updated.updated_at;
 			toastStore.show(`Updated ${name.trim()}`, 'success');
 			onupdated(updated, editedCollectionId, editedCollectionSlug, editedWsSlug);
 		} catch (err) {
-			error = err instanceof Error ? err.message : 'Failed to update collection';
+			if (isUpdateConflictError(err)) {
+				// Non-destructive: keep the user's in-progress edits visible and
+				// tell them to reload to pick up the concurrent change, then
+				// re-apply. We deliberately do NOT auto-merge a full-form edit.
+				error =
+					'This collection was changed elsewhere while you were editing. Reload to see the latest, then re-apply your changes.';
+			} else {
+				error = err instanceof Error ? err.message : 'Failed to update collection';
+			}
 		} finally {
 			saving = false;
 		}

--- a/web/src/lib/components/collections/EditCollectionModal.svelte
+++ b/web/src/lib/components/collections/EditCollectionModal.svelte
@@ -79,12 +79,13 @@
 			return;
 		}
 		archiving = true;
-		// Synchronous capture (see the Props.onupdated doc comment) — read
-		// BEFORE the await, not after.
-		const editedCollectionId = collection.id;
-		const editedCollectionSlug = collection.slug;
-		const editedCollectionName = collection.name;
-		const editedWsSlug = wsSlug;
+		// Target the SEEDED collection identity, NOT the live props — the props
+		// may now identify a different collection while this form still shows
+		// the seeded one, and archive is destructive (Codex switch-safety).
+		const editedCollectionId = seededCollectionId;
+		const editedCollectionSlug = seededCollectionSlug;
+		const editedCollectionName = seededCollectionName;
+		const editedWsSlug = seededWsSlug;
 		try {
 			await api.collections.delete(editedWsSlug, editedCollectionSlug);
 			toastStore.show(`Archived "${editedCollectionName}"`, 'success');
@@ -116,6 +117,18 @@
 	// of silently overwriting their change; on 409 we surface a
 	// non-destructive "reload" message and keep the user's edits intact.
 	let expectedUpdatedAt = $state('');
+
+	// Target-collection IDENTITY captured when the form was SEEDED (Codex
+	// switch-safety). SvelteKit reuses this modal's host route, so the
+	// `collection`/`wsSlug` PROPS can come to identify a DIFFERENT collection
+	// while collection A's form is still on screen. handleSave/handleArchive
+	// MUST target the collection the form was seeded from — never the live
+	// props — or a save overwrites, and an archive DELETES, the wrong
+	// collection. The seed effect re-seeds when the identity changes.
+	let seededCollectionId = $state('');
+	let seededCollectionSlug = $state('');
+	let seededCollectionName = $state('');
+	let seededWsSlug = $state('');
 
 	// ── Field editing state ──────────────────────────────────────────────────
 	// EditableField shape lives in `./field-editor-types.ts` so FieldEditor
@@ -215,17 +228,23 @@
 
 	// ── Sync from collection when modal opens ────────────────────────────────
 
-	// Seed the form ONCE per open transition (open false→true), not on every
-	// `collection` reassignment. BUG-2265's sibling broadcast can refresh the
-	// parent's `collection` prop while this modal is open mid-edit; without
-	// this edge-gate the effect would re-run and wipe the user's in-progress
-	// edits (and reset the captured optimistic-concurrency token). `wasOpen`
-	// is a plain (non-reactive) latch — the effect still depends on `open` and
-	// `collection`, but only re-seeds on the rising edge of `open`.
+	// Seed the form once per open transition (open false→true) OR when the
+	// target collection IDENTITY changes while open (Codex switch-safety —
+	// navigation can swap the `collection` prop to a different collection). A
+	// same-identity `collection` reassignment (BUG-2265's sibling broadcast
+	// refreshing settings/updated_at) must NOT re-seed, or it would wipe the
+	// user's in-progress edits — so gate on the id, not any change. `wasOpen`
+	// is a plain (non-reactive) latch.
 	let wasOpen = false;
 
 	$effect(() => {
-		if (open && !wasOpen && collection) {
+		if (open && collection && (!wasOpen || collection.id !== seededCollectionId)) {
+			// Capture the target identity the form is being seeded FROM, so
+			// handleSave/handleArchive act on it rather than the live props.
+			seededCollectionId = collection.id;
+			seededCollectionSlug = collection.slug;
+			seededCollectionName = collection.name;
+			seededWsSlug = wsSlug;
 			expectedUpdatedAt = collection.updated_at;
 			name = collection.name;
 			selectedIcon = collection.icon || '';
@@ -403,11 +422,13 @@
 		if (!name.trim() || saving || hasNewFieldBlockingErrors) return;
 		saving = true;
 		error = '';
-		// Synchronous capture (see the Props.onupdated doc comment) — read
-		// BEFORE the await, not after.
-		const editedCollectionId = collection.id;
-		const editedCollectionSlug = collection.slug;
-		const editedWsSlug = wsSlug;
+		// Target the SEEDED collection identity, NOT the live props — the form
+		// data and expectedUpdatedAt below were seeded from that collection, so
+		// the write must land on it even if the props now identify a different
+		// collection (Codex switch-safety). Matches the captured token.
+		const editedCollectionId = seededCollectionId;
+		const editedCollectionSlug = seededCollectionSlug;
+		const editedWsSlug = seededWsSlug;
 		try {
 			// Build existing fields back into FieldDef[]
 			const updatedExisting: FieldDef[] = existingFields.map((f) => {

--- a/web/src/lib/components/collections/EditCollectionModal.svelte
+++ b/web/src/lib/components/collections/EditCollectionModal.svelte
@@ -86,19 +86,25 @@
 		const editedCollectionSlug = seededCollectionSlug;
 		const editedCollectionName = seededCollectionName;
 		const editedWsSlug = seededWsSlug;
+		// OCC token (BUG-2265 Codex round 8): the seeded collection's updated_at.
+		// Passed to the server delete so a concurrent RENAME that re-owned this
+		// slug with a DIFFERENT collection 409s instead of archiving the wrong
+		// one — closing the resolve-by-id → delete-by-slug TOCTOU.
+		const editedExpectedUpdatedAt = expectedUpdatedAt;
 		const finishArchived = () => {
 			toastStore.show(`Archived "${editedCollectionName}"`, 'success');
 			onupdated(undefined, editedCollectionId, editedCollectionSlug, editedWsSlug);
 			onclose();
 		};
 		try {
-			await api.collections.delete(editedWsSlug, editedCollectionSlug);
+			await api.collections.delete(editedWsSlug, editedCollectionSlug, editedExpectedUpdatedAt);
 			finishArchived();
 		} catch (err) {
-			// A concurrent RENAME can kill the seeded slug (404), or a change
-			// could 409 (BUG-2265 Pattern C). Resolve the SAME collection by its
-			// STABLE id and retry the delete against its current slug; if it's
-			// already gone from the list, it's effectively archived already.
+			// A concurrent RENAME can kill the seeded slug (404) or 409 the OCC
+			// token (BUG-2265 Pattern C). Resolve the SAME collection by its
+			// STABLE id and retry the delete against its current slug + FRESH
+			// token; if it's already gone from the list, it's effectively
+			// archived already.
 			if (isConflictOrNotFound(err)) {
 				try {
 					const list = await api.collections.list(editedWsSlug);
@@ -107,7 +113,7 @@
 						finishArchived();
 						return;
 					}
-					await api.collections.delete(editedWsSlug, fresh.slug);
+					await api.collections.delete(editedWsSlug, fresh.slug, fresh.updated_at);
 					finishArchived();
 					return;
 				} catch {

--- a/web/src/lib/components/collections/EditCollectionModal.svelte
+++ b/web/src/lib/components/collections/EditCollectionModal.svelte
@@ -309,14 +309,17 @@
 		) {
 			// SAME collection (same id) but a concurrent RENAME changed its slug
 			// (and name) while the modal is open (Codex P2). Retarget the PATCH
-			// endpoint slug + re-capture the token so handleSave/handleArchive
-			// hit the LIVE slug instead of the now-dead one (which would 404
-			// before the token could even 409). Do NOT reseed the form — the
-			// user's in-progress edits are preserved.
+			// endpoint (slug/name/ws) so handleSave/handleArchive hit the LIVE
+			// slug instead of the now-dead one (which would 404 before the token
+			// could even 409). Do NOT reseed the form, and DELIBERATELY do NOT
+			// re-capture the token: the seeded token stays stale so the save
+			// correctly 409s → the non-destructive "collection changed, reload"
+			// message, rather than succeeding and reverting the concurrent rename
+			// with this modal's pre-rename full form (the exact stale-snapshot
+			// clobber BUG-2265 prevents).
 			seededCollectionSlug = collection.slug;
 			seededCollectionName = collection.name;
 			seededWsSlug = wsSlug;
-			expectedUpdatedAt = collection.updated_at;
 		}
 		// Latch AFTER the seed so the next `collection` change (e.g. the
 		// BUG-2265 broadcast) re-runs this effect but skips re-seeding until

--- a/web/src/lib/components/common/QuickActionsMenu.svelte
+++ b/web/src/lib/components/common/QuickActionsMenu.svelte
@@ -177,23 +177,28 @@
 				});
 			} catch (err) {
 				if (!isUpdateConflictError(err)) throw err;
-				// Someone changed the collection between our read and write.
-				// Refetch the SAME collection (captured slug — not live props),
-				// re-append onto its fresh settings, and retry ONCE. Only a
-				// second conflict surfaces.
-				const fresh = await api.collections.get(ws, slug);
+				// Someone changed the collection between our read and write —
+				// possibly a RENAME, which makes the captured slug dead (a
+				// slug-based refetch would 404). Resolve by the STABLE id
+				// instead (mirrors EditCollectionModal's identity approach),
+				// then re-append onto its fresh settings and retry ONCE.
+				const list = await api.collections.list(ws);
+				const fresh = list.find((c) => c.id === baseCollection.id);
+				if (!fresh) throw err; // collection gone (deleted) — surface the conflict
 				updated = await api.collections.update(ws, fresh.slug, {
 					settings: appendOnto(fresh),
 					expected_updated_at: fresh.updated_at
 				});
 			}
 			// Only propagate the result if this component still represents the
-			// SAME collection it started with. On a reused route (no guaranteed
-			// remount) the live `collection`/`wsSlug` props may now identify a
-			// DIFFERENT collection, and `oncollectionupdated` is the live
-			// (navigated) page's callback — feeding it our old response would
-			// assign stale data to the wrong page (Codex switch-safety).
-			if (wsSlug !== ws || collection?.slug !== slug) return;
+			// SAME collection it started with — compared by STABLE id so a
+			// concurrent rename (slug changed, same collection) still
+			// propagates, while a genuine switch to a DIFFERENT collection
+			// (different id) is dropped. On a reused route (no guaranteed
+			// remount) `oncollectionupdated` is the live (navigated) page's
+			// callback — feeding it our old response would assign stale data to
+			// the wrong page (Codex switch-safety).
+			if (wsSlug !== ws || collection?.id !== baseCollection.id) return;
 			toastStore.show('Saved', 'success');
 			oncollectionupdated?.(updated);
 			resetCreateForm();

--- a/web/src/lib/components/common/QuickActionsMenu.svelte
+++ b/web/src/lib/components/common/QuickActionsMenu.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import type { QuickAction, Item, Collection } from '$lib/types';
 	import { parseFields, formatItemRef, parseSettings } from '$lib/types';
-	import { api } from '$lib/api/client';
+	import { api, isUpdateConflictError } from '$lib/api/client';
 	import { toastStore } from '$lib/stores/toast.svelte';
 	import BottomSheet from '$lib/components/common/BottomSheet.svelte';
 	import { viewport } from '$lib/stores/breakpoint.svelte';
@@ -146,14 +146,39 @@
 				scope,
 				...(icon ? { icon } : {})
 			};
-			const settings = parseSettings(collection);
-			const nextSettings = {
-				...settings,
-				quick_actions: [...(settings.quick_actions ?? []), newAction]
+
+			// BUG-2265: append onto a base snapshot AND round-trip its
+			// updated_at so the server rejects a stale write instead of
+			// clobbering a sibling ItemDetail's concurrent settings change.
+			// `appendOnto` re-derives the full settings from a FRESH base
+			// each time, so a 409-triggered refetch+retry re-applies our new
+			// action onto whatever the other writer just saved (no silent
+			// loss) rather than replaying our stale local snapshot.
+			const appendOnto = (base: Collection): string => {
+				const s = parseSettings(base);
+				return JSON.stringify({
+					...s,
+					quick_actions: [...(s.quick_actions ?? []), newAction]
+				});
 			};
-			const updated = await api.collections.update(wsSlug, collection.slug, {
-				settings: JSON.stringify(nextSettings)
-			});
+
+			let updated: Collection;
+			try {
+				updated = await api.collections.update(wsSlug, collection.slug, {
+					settings: appendOnto(collection),
+					expected_updated_at: collection.updated_at
+				});
+			} catch (err) {
+				if (!isUpdateConflictError(err)) throw err;
+				// Someone changed the collection between our read and write.
+				// Refetch the current collection, re-append onto its fresh
+				// settings, and retry ONCE. Only a second conflict surfaces.
+				const fresh = await api.collections.get(wsSlug, collection.slug);
+				updated = await api.collections.update(wsSlug, fresh.slug, {
+					settings: appendOnto(fresh),
+					expected_updated_at: fresh.updated_at
+				});
+			}
 			toastStore.show('Saved', 'success');
 			oncollectionupdated?.(updated);
 			resetCreateForm();

--- a/web/src/lib/components/common/QuickActionsMenu.svelte
+++ b/web/src/lib/components/common/QuickActionsMenu.svelte
@@ -138,6 +138,13 @@
 		const prompt = newPrompt.trim();
 		if (!label || !prompt || saving) return;
 		saving = true;
+		// Capture workspace + collection identity BEFORE any await. This
+		// component is reused across items/collections without a guaranteed
+		// remount, so reading live props after the await could fetch/update the
+		// WRONG collection on a mid-save navigation (BUG-2265 switch-safety).
+		const ws = wsSlug;
+		const baseCollection = collection;
+		const slug = baseCollection.slug;
 		try {
 			const icon = newIcon.trim();
 			const newAction: QuickAction = {
@@ -164,17 +171,18 @@
 
 			let updated: Collection;
 			try {
-				updated = await api.collections.update(wsSlug, collection.slug, {
-					settings: appendOnto(collection),
-					expected_updated_at: collection.updated_at
+				updated = await api.collections.update(ws, slug, {
+					settings: appendOnto(baseCollection),
+					expected_updated_at: baseCollection.updated_at
 				});
 			} catch (err) {
 				if (!isUpdateConflictError(err)) throw err;
 				// Someone changed the collection between our read and write.
-				// Refetch the current collection, re-append onto its fresh
-				// settings, and retry ONCE. Only a second conflict surfaces.
-				const fresh = await api.collections.get(wsSlug, collection.slug);
-				updated = await api.collections.update(wsSlug, fresh.slug, {
+				// Refetch the SAME collection (captured slug — not live props),
+				// re-append onto its fresh settings, and retry ONCE. Only a
+				// second conflict surfaces.
+				const fresh = await api.collections.get(ws, slug);
+				updated = await api.collections.update(ws, fresh.slug, {
 					settings: appendOnto(fresh),
 					expected_updated_at: fresh.updated_at
 				});

--- a/web/src/lib/components/common/QuickActionsMenu.svelte
+++ b/web/src/lib/components/common/QuickActionsMenu.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import type { QuickAction, Item, Collection } from '$lib/types';
 	import { parseFields, formatItemRef, parseSettings } from '$lib/types';
-	import { api, isUpdateConflictError } from '$lib/api/client';
+	import { api, isConflictOrNotFound } from '$lib/api/client';
 	import { toastStore } from '$lib/stores/toast.svelte';
 	import BottomSheet from '$lib/components/common/BottomSheet.svelte';
 	import { viewport } from '$lib/stores/breakpoint.svelte';
@@ -176,15 +176,15 @@
 					expected_updated_at: baseCollection.updated_at
 				});
 			} catch (err) {
-				if (!isUpdateConflictError(err)) throw err;
-				// Someone changed the collection between our read and write —
-				// possibly a RENAME, which makes the captured slug dead (a
-				// slug-based refetch would 404). Resolve by the STABLE id
-				// instead (mirrors EditCollectionModal's identity approach),
-				// then re-append onto its fresh settings and retry ONCE.
+				// A concurrent change can defeat our slug-targeted write two ways:
+				// a 409 update_conflict (settings changed) OR a 404 not_found (a
+				// RENAME killed the slug). Recover from BOTH (BUG-2265 Pattern C):
+				// resolve the collection by its STABLE id, re-append onto its
+				// fresh settings, and retry ONCE. Surface only if it's truly gone.
+				if (!isConflictOrNotFound(err)) throw err;
 				const list = await api.collections.list(ws);
 				const fresh = list.find((c) => c.id === baseCollection.id);
-				if (!fresh) throw err; // collection gone (deleted) — surface the conflict
+				if (!fresh) throw err; // collection gone (deleted) — surface it
 				updated = await api.collections.update(ws, fresh.slug, {
 					settings: appendOnto(fresh),
 					expected_updated_at: fresh.updated_at

--- a/web/src/lib/components/common/QuickActionsMenu.svelte
+++ b/web/src/lib/components/common/QuickActionsMenu.svelte
@@ -187,6 +187,13 @@
 					expected_updated_at: fresh.updated_at
 				});
 			}
+			// Only propagate the result if this component still represents the
+			// SAME collection it started with. On a reused route (no guaranteed
+			// remount) the live `collection`/`wsSlug` props may now identify a
+			// DIFFERENT collection, and `oncollectionupdated` is the live
+			// (navigated) page's callback — feeding it our old response would
+			// assign stale data to the wrong page (Codex switch-safety).
+			if (wsSlug !== ws || collection?.slug !== slug) return;
 			toastStore.show('Saved', 'success');
 			oncollectionupdated?.(updated);
 			resetCreateForm();

--- a/web/src/lib/components/common/QuickActionsMenu.svelte.test.ts
+++ b/web/src/lib/components/common/QuickActionsMenu.svelte.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+import { tick } from 'svelte';
+import type { Collection } from '$lib/types';
+
+// BUG-2265 Pattern C: QuickActionsMenu's save must recover from a competing
+// RENAME (404 not_found) — not just a 409 — by resolving the collection by its
+// STABLE id and retrying against the fresh slug. This mounts the REAL component
+// with a mocked api and drives the create-action save through a not_found on
+// the FIRST update, asserting the retry targets the renamed slug.
+
+const updateMock = vi.fn();
+const listMock = vi.fn();
+
+vi.mock('$lib/api/client', () => ({
+	api: {
+		collections: {
+			update: (...args: unknown[]) => updateMock(...args),
+			list: (...args: unknown[]) => listMock(...args),
+		},
+	},
+	// Real-ish classifier so the component's branch fires for 404/409.
+	isConflictOrNotFound: (err: unknown) =>
+		err instanceof Error &&
+		((err as { code?: string }).code === 'not_found' ||
+			(err as { code?: string }).code === 'update_conflict'),
+}));
+
+const toastShow = vi.fn();
+vi.mock('$lib/stores/toast.svelte', () => ({
+	toastStore: { show: (...a: unknown[]) => toastShow(...a) },
+}));
+
+vi.mock('$lib/stores/breakpoint.svelte', () => ({
+	viewport: { isMobile: false },
+}));
+
+// Stub the sub-components rendered inside the create form so the test doesn't
+// depend on their internals.
+vi.mock('$lib/components/common/BottomSheet.svelte', () => ({ default: noopComponent() }));
+vi.mock('$lib/components/common/EmojiPickerButton.svelte', () => ({ default: noopComponent() }));
+
+function noopComponent() {
+	// A minimal Svelte-5-compatible mountable component.
+	return function () {};
+}
+
+const { default: QuickActionsMenu } = await import('./QuickActionsMenu.svelte');
+
+function makeCollection(id: string, slug: string): Collection {
+	return {
+		id,
+		workspace_id: 'ws-1',
+		name: 'Tasks',
+		slug,
+		icon: '',
+		description: '',
+		schema: '{"fields":[]}',
+		settings: '{"quick_actions":[]}',
+		sort_order: 0,
+		is_default: false,
+		is_system: false,
+		created_at: '2026-01-01T00:00:00Z',
+		updated_at: '2026-01-01T00:00:00Z',
+		prefix: 'TASK',
+	} as Collection;
+}
+
+function notFound() {
+	const e = new Error('gone') as Error & { code: string };
+	e.code = 'not_found';
+	return e;
+}
+
+describe('QuickActionsMenu save retry (BUG-2265 Pattern C)', () => {
+	beforeEach(() => {
+		updateMock.mockReset();
+		listMock.mockReset();
+		toastShow.mockReset();
+	});
+
+	it('recovers from a 404 (renamed slug) by resolving the collection by id', async () => {
+		// First update (against the captured "old" slug) hits a rename → 404.
+		// The retry lists collections, finds the SAME id under the new slug, and
+		// updates against that new slug.
+		updateMock
+			.mockRejectedValueOnce(notFound())
+			.mockResolvedValueOnce(makeCollection('c1', 'renamed-tasks'));
+		listMock.mockResolvedValueOnce([makeCollection('c1', 'renamed-tasks')]);
+
+		const host = document.createElement('div');
+		document.body.appendChild(host);
+		const onupdated = vi.fn();
+		const component = mount(QuickActionsMenu, {
+			target: host,
+			props: {
+				actions: [],
+				collection: makeCollection('c1', 'tasks'),
+				scope: 'item',
+				wsSlug: 'ws-1',
+				canEdit: true,
+				oncollectionupdated: onupdated,
+			},
+		});
+		flushSync();
+
+		// Open the menu, then the inline create form.
+		(host.querySelector('.trigger-btn') as HTMLButtonElement).click();
+		flushSync();
+		const openFormBtn = [...host.querySelectorAll('button')].find((b) =>
+			b.textContent?.includes('New quick action')
+		) as HTMLButtonElement;
+		openFormBtn.click();
+		flushSync();
+
+		// Fill label + prompt.
+		const label = host.querySelector('.qa-label-input') as HTMLInputElement;
+		const prompt = host.querySelector('.qa-prompt-input') as HTMLTextAreaElement;
+		label.value = 'Ship';
+		label.dispatchEvent(new Event('input', { bubbles: true }));
+		prompt.value = '/pad ship';
+		prompt.dispatchEvent(new Event('input', { bubbles: true }));
+		flushSync();
+
+		// Click Save.
+		const saveBtn = [...host.querySelectorAll('button')].find(
+			(b) => b.textContent?.trim() === 'Save'
+		) as HTMLButtonElement;
+		saveBtn.click();
+
+		// Let the async save + retry settle.
+		await vi.waitFor(() => expect(updateMock).toHaveBeenCalledTimes(2));
+		await tick();
+
+		// First update used the OLD slug; the retry used the NEW (renamed) slug.
+		expect(updateMock.mock.calls[0][1]).toBe('tasks');
+		expect(updateMock.mock.calls[1][1]).toBe('renamed-tasks');
+		expect(listMock).toHaveBeenCalledTimes(1);
+		// The retry succeeded → success toast + callback.
+		expect(onupdated).toHaveBeenCalledTimes(1);
+
+		unmount(component);
+		host.remove();
+	});
+});

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -786,10 +786,14 @@
 				const snap = collection;
 				if (!snap || event.collection !== snap.slug) return;
 				const slug = snap.slug;
+				// On a rename, refetch by the NEW slug (the old one is dead) so
+				// this pane's collection reference — used to build quick-action /
+				// edit writes — stays valid (Codex P2).
+				const targetSlug = event.new_slug || slug;
 				const gen = loadGeneration;
 				const refreshGen = ++collectionRefreshGen;
 				try {
-					const fresh = await api.collections.get(wsSlug, slug);
+					const fresh = await api.collections.get(wsSlug, targetSlug);
 					// Persistent pane host has no {#key} remount — fence the
 					// write against a switch during the fetch (PLAN-2105
 					// discipline): drop if a newer refresh superseded us, a

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -189,12 +189,14 @@
 	// counter — not reactive; it only fences async writes.
 	let loadGeneration = 0;
 
-	// Dedicated monotonic counter for BUG-2265 collection-snapshot refreshes.
-	// `loadGeneration` only bumps on item loadData() — it can't order two rapid
-	// collection_updated refetches against EACH OTHER, so an older refetch could
-	// resolve after (and clobber) a newer one. Plain counter — not reactive; it
-	// only fences the async collection refresh.
-	let collectionRefreshGen = 0;
+	// UNIFIED collection-snapshot generation (BUG-2265 Codex): bumped by EVERY
+	// operation that assigns `collection` — loadData's collection fetch, the SSE
+	// collection_updated refresh, and the quick-action / edit-modal callbacks —
+	// so the last-STARTED write wins and a stale in-flight continuation can't
+	// revert a newer snapshot (its token included). `loadGeneration` still
+	// fences the ITEM load; this token is dedicated to the `collection` object.
+	// Plain counter — not reactive; it only fences writes.
+	let collectionGen = 0;
 
 	// R9 teardown ownership (TASK-2172). The onDestroy clear-if-owner compares
 	// the global `collectionStore.activeItem` against the id THIS instance last
@@ -795,17 +797,18 @@
 				// Deferred (already broken on main; snapshot refresh below is the
 				// in-scope BUG-2265 fix).
 				const targetSlug = event.new_slug || slug;
-				const gen = loadGeneration;
-				const refreshGen = ++collectionRefreshGen;
+				// Unified generation: bumped here AND by loadData / the
+				// quick-action + edit-modal callbacks, so the last-started write
+				// wins and neither a stale refresh nor a stale load can revert a
+				// newer snapshot.
+				const collGen = ++collectionGen;
 				try {
 					const fresh = await api.collections.get(wsSlug, targetSlug);
-					// Persistent pane host has no {#key} remount — fence the
-					// write against a switch during the fetch (PLAN-2105
-					// discipline): drop if a newer refresh superseded us, a
-					// newer item load ran, or the loaded collection changed
-					// identity.
-					if (refreshGen !== collectionRefreshGen) return;
-					if (gen !== loadGeneration) return;
+					// Persistent pane host has no {#key} remount — fence the write
+					// against a switch during the fetch (PLAN-2105 discipline):
+					// drop if a newer collection write superseded us or the loaded
+					// collection changed identity.
+					if (collGen !== collectionGen) return;
 					if (!collection || collection.slug !== slug) return;
 					collection = fresh;
 				} catch {
@@ -1073,6 +1076,11 @@
 
 	async function loadData() {
 		const myGen = ++loadGeneration;
+		// Join the unified collection-snapshot fence so this load's `collection`
+		// write is dropped if a newer SSE refresh / callback landed a fresher
+		// snapshot while this load was in flight (Codex — separate lifecycle
+		// from loadGeneration).
+		const collGen = ++collectionGen;
 		loading = true;
 		error = '';
 		// Clear per-item state that must NOT leak across navigation.
@@ -1258,7 +1266,14 @@
 				try {
 					const realColl = await api.collections.get(wsSlug, itemData.collection_slug);
 					if (myGen !== loadGeneration) return;
-					collection = realColl;
+					// Gate the collection SNAPSHOT on the unified generation so a
+					// newer SSE refresh (bumps collectionGen, not loadGeneration)
+					// isn't reverted by this in-flight load.
+					// Apply when this is the freshest same-collection write OR when it's
+					// a switch to a DIFFERENT collection (a stale refresh for the old
+					// collection must not block loading the new one).
+					if (collGen === collectionGen || collection?.slug !== realColl.slug)
+						collection = realColl;
 				} catch {
 					if (myGen !== loadGeneration) return;
 					// Can't resolve the item's REAL collection. Surface the
@@ -1269,7 +1284,7 @@
 					error = 'Failed to load this item’s collection';
 					return;
 				}
-			} else {
+			} else if (collGen === collectionGen || collection?.slug !== collData.slug) {
 				collection = collData;
 			}
 			// A FROZEN (peeking) instance must NOT write the SINGLETON global stores
@@ -3987,6 +4002,9 @@
 						}}
 						oncollectionupdated={(updated) => {
 							if (keyedSlug !== itemSlug) return;
+							// Bump the unified fence so an in-flight stale load/refresh
+							// can't revert this fresh write (Codex).
+							collectionGen++;
 							collection = updated;
 						}}
 					/>
@@ -4923,6 +4941,9 @@
 					}
 					return;
 				}
+				// Bump the unified fence so an in-flight stale load/refresh can't
+				// revert this fresh edit-modal write (Codex).
+				collectionGen++;
 				collection = updated;
 				// If the owner renamed the collection, its slug may have
 				// changed. The current `/[collection]/[slug]` URL still

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -189,6 +189,13 @@
 	// counter — not reactive; it only fences async writes.
 	let loadGeneration = 0;
 
+	// Dedicated monotonic counter for BUG-2265 collection-snapshot refreshes.
+	// `loadGeneration` only bumps on item loadData() — it can't order two rapid
+	// collection_updated refetches against EACH OTHER, so an older refetch could
+	// resolve after (and clobber) a newer one. Plain counter — not reactive; it
+	// only fences the async collection refresh.
+	let collectionRefreshGen = 0;
+
 	// R9 teardown ownership (TASK-2172). The onDestroy clear-if-owner compares
 	// the global `collectionStore.activeItem` against the id THIS instance last
 	// set active — NOT against the reactive `item`, which a cross-collection load
@@ -780,12 +787,15 @@
 				if (!snap || event.collection !== snap.slug) return;
 				const slug = snap.slug;
 				const gen = loadGeneration;
+				const refreshGen = ++collectionRefreshGen;
 				try {
 					const fresh = await api.collections.get(wsSlug, slug);
 					// Persistent pane host has no {#key} remount — fence the
 					// write against a switch during the fetch (PLAN-2105
-					// discipline): drop if a newer load superseded us or the
-					// loaded collection changed identity.
+					// discipline): drop if a newer refresh superseded us, a
+					// newer item load ran, or the loaded collection changed
+					// identity.
+					if (refreshGen !== collectionRefreshGen) return;
 					if (gen !== loadGeneration) return;
 					if (!collection || collection.slug !== slug) return;
 					collection = fresh;

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -767,6 +767,34 @@
 		// the user's in-flight document. A proper fix needs editor-dirty-
 		// state integration; tracked separately.
 		unsubscribeSSE = sseService.onItemEvent(async (event) => {
+			// BUG-2265 sibling broadcast: another ItemDetail / collection page
+			// changed THIS collection's settings/schema. This instance holds
+			// its OWN independent `collection` snapshot (the full-page pane
+			// host renders a master + a pane, each with its own copy), so
+			// refresh it here — a subsequent quick-action / edit save then
+			// sends a fresh expected_updated_at instead of clobbering the
+			// sibling's write. `collection_updated` carries no item_id, so this
+			// branch must run BEFORE the item-id guard below.
+			if (event.type === 'collection_updated') {
+				const snap = collection;
+				if (!snap || event.collection !== snap.slug) return;
+				const slug = snap.slug;
+				const gen = loadGeneration;
+				try {
+					const fresh = await api.collections.get(wsSlug, slug);
+					// Persistent pane host has no {#key} remount — fence the
+					// write against a switch during the fetch (PLAN-2105
+					// discipline): drop if a newer load superseded us or the
+					// loaded collection changed identity.
+					if (gen !== loadGeneration) return;
+					if (!collection || collection.slug !== slug) return;
+					collection = fresh;
+				} catch {
+					// Best-effort — a stale snapshot just means the next save
+					// may 409 and self-heal via QuickActionsMenu's retry.
+				}
+				return;
+			}
 			if (!item || event.item_id !== item.id) return;
 			// Ignore events while mid-switch: during A→B the loaded `item` is
 			// still A but the requested ref is already B, so a stale archive/

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -786,7 +786,10 @@
 			// branch must run BEFORE the item-id guard below.
 			if (event.type === 'collection_updated') {
 				const snap = collection;
-				if (!snap || event.collection !== snap.slug) return;
+				// Match by STABLE id, not slug (Codex round 7): a replayed rename
+				// event's old slug can be re-owned by a DIFFERENT collection, so a
+				// slug match could load the wrong schema into this pane.
+				if (!snap || event.collection_id !== snap.id) return;
 				const slug = snap.slug;
 				// On a rename, refetch by the NEW slug (the old one is dead) so
 				// this pane's collection reference — used to build quick-action /
@@ -822,6 +825,10 @@
 				// migration. Refetch it. Skip while mid-edit (saving/title-editing):
 				// item-level optimistic concurrency then catches a clobbering save
 				// via a 409, and refetching would clobber the editor.
+				// NOTE(BUG-2273): updateField's full-blob write lacks item-level OCC
+				// (no expected_updated_at / fields_patch — the web editor never
+				// adopted IDEA-1480/v0.14), so a mid-edit field save can still race
+				// this reconcile. The migration reconcile is best-effort until then.
 				if (
 					event.items_changed &&
 					item &&
@@ -2232,6 +2239,12 @@
 		// (This also lets a pre-flip pending onchange from FieldEditor's 500ms
 		// debounce complete rather than being suppressed.)
 		if (!item) return;
+		// NOTE(BUG-2273): this sends a FULL `fields` blob (stale ...fields + one
+		// key) with NO expected_updated_at / fields_patch — the web editor never
+		// adopted the IDEA-1480/v0.14 item merge+OCC. So a concurrent schema
+		// MIGRATION (or any other field write) can be silently UNDONE by this
+		// write. The BUG-2265 migration reconcile above refetches to shrink the
+		// window, but the real fix is item-level OCC here (tracked in BUG-2273).
 		const updated = { ...fields, [key]: value };
 		const payload = JSON.stringify(updated);
 		const targetItem = item;

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -808,12 +808,39 @@
 					// against a switch during the fetch (PLAN-2105 discipline):
 					// drop if a newer collection write superseded us or the loaded
 					// collection changed identity.
-					if (collGen !== collectionGen) return;
-					if (!collection || collection.slug !== slug) return;
-					collection = fresh;
+					if (collGen === collectionGen && collection && collection.slug === slug) {
+						collection = fresh;
+					}
 				} catch {
 					// Best-effort — a stale snapshot just means the next save
 					// may 409 and self-heal via QuickActionsMenu's retry.
+				}
+				// BUG-2265 (Codex P1): if the schema migration mutated item field
+				// values, THIS pane's `item` (loaded via api.items.get, NOT from
+				// the localIndex that the workspace deltaSync reconciles) may hold
+				// stale field JSON — a later full-fields save would UNDO the
+				// migration. Refetch it. Skip while mid-edit (saving/title-editing):
+				// item-level optimistic concurrency then catches a clobbering save
+				// via a 409, and refetching would clobber the editor.
+				if (
+					event.items_changed &&
+					item &&
+					itemMatchesRef &&
+					saveStatus !== 'saving' &&
+					!editingTitle
+				) {
+					const gen = loadGeneration;
+					const reqItemId = item.id;
+					const reqWsSlug = wsSlug;
+					const reqItemSlug = itemSlug;
+					try {
+						const updated = await api.items.get(reqWsSlug, reqItemSlug);
+						if (item && item.id === reqItemId && gen === loadGeneration) {
+							item = adoptServerItem(updated);
+						}
+					} catch {
+						// Best-effort — the next event / tab-resume sync catches up.
+					}
 				}
 				return;
 			}

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -789,6 +789,11 @@
 				// On a rename, refetch by the NEW slug (the old one is dead) so
 				// this pane's collection reference — used to build quick-action /
 				// edit writes — stays valid (Codex P2).
+				// TODO(BUG-2272): full cross-tab rename renavigation — the
+				// full-page item route's URL/collSlug is NOT retargeted here, so
+				// breadcrumbs / a hard reload still resolve the dead old slug.
+				// Deferred (already broken on main; snapshot refresh below is the
+				// in-scope BUG-2265 fix).
 				const targetSlug = event.new_slug || slug;
 				const gen = loadGeneration;
 				const refreshGen = ++collectionRefreshGen;

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -198,6 +198,19 @@
 	// Plain counter — not reactive; it only fences writes.
 	let collectionGen = 0;
 
+	// UNIFIED item-snapshot generation (BUG-2265 Codex round 9): bumped by EVERY
+	// async operation that assigns `item` from a fetch — loadData's item load,
+	// the SSE item_updated/archived/restored refetches, the onSync refetches,
+	// the collab refresh, the migration item-refetch, and the user-write adopts
+	// (title/field/tag saves) — so the last-STARTED write wins and a stale
+	// in-flight continuation can't revert a newer item snapshot. Distinct from
+	// loadGeneration (which also fences the whole load's collection/links/
+	// members writes) so a same-item refetch doesn't need a full reload to be
+	// ordered against another. Every `item = <fetched>` gates on this + the item
+	// id; synchronous optimistic writes bump it so a stale refetch can't revert
+	// them. Plain counter — not reactive.
+	let itemGen = 0;
+
 	// R9 teardown ownership (TASK-2172). The onDestroy clear-if-owner compares
 	// the global `collectionStore.activeItem` against the id THIS instance last
 	// set active — NOT against the reactive `item`, which a cross-collection load
@@ -799,7 +812,13 @@
 				// breadcrumbs / a hard reload still resolve the dead old slug.
 				// Deferred (already broken on main; snapshot refresh below is the
 				// in-scope BUG-2265 fix).
-				const targetSlug = event.new_slug || slug;
+				// Fetch the collection's CURRENT slug. A rename carries new_slug;
+				// a settings update that follows a rename routes by (and carries in
+				// `collection`) the NEW slug — so prefer new_slug, THEN event's own
+				// slug, THEN the pane's snapshot slug. Using `slug` alone would make
+				// a post-rename settings update request the DEAD old slug and bump
+				// collectionGen, cancelling the valid rename fetch (Codex round 9).
+				const targetSlug = event.new_slug || event.collection || slug;
 				// Unified generation: bumped here AND by loadData / the
 				// quick-action + edit-modal callbacks, so the last-started write
 				// wins and neither a stale refresh nor a stale load can revert a
@@ -810,8 +829,9 @@
 					// Persistent pane host has no {#key} remount — fence the write
 					// against a switch during the fetch (PLAN-2105 discipline):
 					// drop if a newer collection write superseded us or the loaded
-					// collection changed identity.
-					if (collGen === collectionGen && collection && collection.slug === slug) {
+					// collection changed IDENTITY. Compare by stable id, not slug,
+					// so a rename (same id, new slug) still applies (Codex round 9).
+					if (collGen === collectionGen && collection && collection.id === snap.id) {
 						collection = fresh;
 					}
 				} catch {
@@ -836,13 +856,17 @@
 					saveStatus !== 'saving' &&
 					!editingTitle
 				) {
-					const gen = loadGeneration;
 					const reqItemId = item.id;
 					const reqWsSlug = wsSlug;
 					const reqItemSlug = itemSlug;
+					// Dedicated item-snapshot gen (round 9): the migration refetch
+					// and loadData no longer share loadGeneration, so a stale
+					// loadData response can't overwrite the migrated item (and
+					// vice-versa).
+					const myItemGen = ++itemGen;
 					try {
 						const updated = await api.items.get(reqWsSlug, reqItemSlug);
-						if (item && item.id === reqItemId && gen === loadGeneration) {
+						if (item && item.id === reqItemId && myItemGen === itemGen) {
 							item = adoptServerItem(updated);
 						}
 					} catch {
@@ -858,11 +882,10 @@
 			// B's just-opening pane. The new item's loadData refetches fresh
 			// state anyway (PLAN-2105 / TASK-2112; Codex).
 			if (!itemMatchesRef) return;
-			// Capture the generation at accept-time; every post-await guard
-			// below also checks it so a switch DURING an in-flight refetch (or
-			// an A→B→A that re-matches the id) can't apply a stale write or fire
-			// handleGone() against the wrong item.
-			const sseGen = loadGeneration;
+			// Item writes below are ordered via the dedicated itemGen (round 9),
+			// captured per-refetch just before the fetch so a switch / a newer
+			// item write (load, migration, another SSE/onSync refetch) drops the
+			// stale continuation. Identity is always checked by item id.
 
 			// Archive is destructive and must NOT be gated by the
 			// edit-conflict guard below — a user editing a since-archived
@@ -893,12 +916,13 @@
 				const archItemId = item.id;
 				const archWsSlug = wsSlug;
 				const archItemSlug = itemSlug;
+				const myItemGen = ++itemGen;
 				try {
 					const archived = await api.items.get(archWsSlug, archItemSlug);
-					if (!item || item.id !== archItemId || sseGen !== loadGeneration) return;
+					if (!item || item.id !== archItemId || myItemGen !== itemGen) return;
 					item = withInflightTags(archived);
 				} catch {
-					if (!item || item.id !== archItemId || sseGen !== loadGeneration) return;
+					if (!item || item.id !== archItemId || myItemGen !== itemGen) return;
 					handleGone();
 				}
 				return;
@@ -917,13 +941,15 @@
 			const reqItemId = item.id;
 			const reqWsSlug = wsSlug;
 			const reqItemSlug = itemSlug;
+			// One switch case runs per event, so bump the item-snapshot gen once.
+			const myItemGen = ++itemGen;
 
 			switch (event.type) {
 				case 'item_updated': {
 					try {
 						const updated = await api.items.get(reqWsSlug, reqItemSlug);
 						// Bail if the user navigated away before this resolved.
-						if (!item || item.id !== reqItemId || sseGen !== loadGeneration) return;
+						if (!item || item.id !== reqItemId || myItemGen !== itemGen) return;
 						// Drop TASK-1243's conservative content-skip
 						// when collab is active (TASK-1262). Under
 						// collab the editor reads from Y.Doc, NOT
@@ -942,7 +968,7 @@
 						// still lose chars without this branch.
 						item = adoptServerItem(updated);
 						const links = await api.links.list(reqWsSlug, updated.slug).catch(() => []);
-						if (!item || item.id !== reqItemId || sseGen !== loadGeneration) return;
+						if (!item || item.id !== reqItemId || myItemGen !== itemGen) return;
 						itemLinks = links;
 					} catch {
 						// Ignore — will catch up on next event
@@ -952,7 +978,7 @@
 				case 'item_restored': {
 					try {
 						const updated = await api.items.get(reqWsSlug, reqItemSlug);
-						if (!item || item.id !== reqItemId || sseGen !== loadGeneration) return;
+						if (!item || item.id !== reqItemId || myItemGen !== itemGen) return;
 						item = adoptServerItem(updated);
 					} catch {
 						// Ignore — will catch up on next event
@@ -969,10 +995,8 @@
 			// clobber it — the new item's loadData refetches fresh state
 			// (PLAN-2105 / TASK-2112; Codex).
 			if (!itemMatchesRef) return;
-			// Generation captured at accept-time; every post-await guard below
-			// also checks it so a switch during an in-flight refetch (or an
-			// A→B→A id re-match) can't clobber the wrong item or fire handleGone.
-			const syncGen = loadGeneration;
+			// Item writes below are ordered via the dedicated itemGen (round 9),
+			// bumped per-refetch; a switch is caught by the item-id check.
 
 			if (result.type === 'caught_up') return;
 
@@ -1001,12 +1025,13 @@
 				const delItemId = item.id;
 				const delWsSlug = wsSlug;
 				const delItemSlug = itemSlug;
+				const myItemGen = ++itemGen;
 				try {
 					const refreshed = await api.items.get(delWsSlug, delItemSlug);
-					if (!item || item.id !== delItemId || syncGen !== loadGeneration) return;
+					if (!item || item.id !== delItemId || myItemGen !== itemGen) return;
 					item = withInflightTags(refreshed);
 				} catch {
-					if (!item || item.id !== delItemId || syncGen !== loadGeneration) return;
+					if (!item || item.id !== delItemId || myItemGen !== itemGen) return;
 					handleGone();
 				}
 				return;
@@ -1030,22 +1055,25 @@
 					// Merge server state without disrupting the editor.
 					// Same collab-aware adoption rule as the SSE
 					// handler above (TASK-1262).
-					if (!item || item.id !== reqItemId || syncGen !== loadGeneration) return;
+					if (!item || item.id !== reqItemId) return;
+					// Bump the item-snapshot gen so an in-flight refetch drops (round 9).
+					const myItemGen = ++itemGen;
 					item = adoptServerItem(updated);
 					const links = await api.links.list(reqWsSlug, updated.slug).catch(() => []);
-					if (!item || item.id !== reqItemId || syncGen !== loadGeneration) return;
+					if (!item || item.id !== reqItemId || myItemGen !== itemGen) return;
 					itemLinks = links;
 				}
 				return;
 			}
 
 			// Full refresh fallback
+			const myItemGen = ++itemGen;
 			try {
 				const updated = await api.items.get(reqWsSlug, reqItemSlug);
-				if (!item || item.id !== reqItemId || syncGen !== loadGeneration) return;
+				if (!item || item.id !== reqItemId || myItemGen !== itemGen) return;
 				item = adoptServerItem(updated);
 				const links = await api.links.list(reqWsSlug, updated.slug).catch(() => []);
-				if (!item || item.id !== reqItemId || syncGen !== loadGeneration) return;
+				if (!item || item.id !== reqItemId || myItemGen !== itemGen) return;
 				itemLinks = links;
 				syncService.markSynced(); // Advance cursor now that reload succeeded
 			} catch {
@@ -1115,6 +1143,11 @@
 		// snapshot while this load was in flight (Codex — separate lifecycle
 		// from loadGeneration).
 		const collGen = ++collectionGen;
+		// Join the item-snapshot fence (round 9) so this load's `item` write is
+		// dropped if a newer item write (e.g. the migration refetch, or another
+		// load/refetch) landed a fresher item while this load was in flight —
+		// they no longer share loadGeneration.
+		const myItemGen = ++itemGen;
 		loading = true;
 		error = '';
 		// Clear per-item state that must NOT leak across navigation.
@@ -1286,7 +1319,10 @@
 			// Overlay any in-flight optimistic tag edit so navigating away and
 			// back mid-save can't show (and then let a follow-up edit overwrite
 			// with) stale server tags. See withInflightTags. Per Codex PR #659.
-			item = withInflightTags(itemData);
+			// Gate the ITEM snapshot on itemGen too: a newer item write (e.g. the
+			// migration refetch) that bumped itemGen but not loadGeneration must
+			// not be reverted by this in-flight load (round 9).
+			if (myItemGen === itemGen) item = withInflightTags(itemData);
 			// Cross-collection `?item=` safety (PLAN-2105 / TASK-2112). The
 			// Promise.all above optimistically fetched the collection by the
 			// route's `collSlug` — correct for the common (row-click) case,
@@ -1306,7 +1342,7 @@
 					// Apply when this is the freshest same-collection write OR when it's
 					// a switch to a DIFFERENT collection (a stale refresh for the old
 					// collection must not block loading the new one).
-					if (collGen === collectionGen || collection?.slug !== realColl.slug)
+					if (collGen === collectionGen || collection?.id !== realColl.id)
 						collection = realColl;
 				} catch {
 					if (myGen !== loadGeneration) return;
@@ -1318,7 +1354,7 @@
 					error = 'Failed to load this item’s collection';
 					return;
 				}
-			} else if (collGen === collectionGen || collection?.slug !== collData.slug) {
+			} else if (collGen === collectionGen || collection?.id !== collData.id) {
 				collection = collData;
 			}
 			// A FROZEN (peeking) instance must NOT write the SINGLETON global stores
@@ -1873,6 +1909,10 @@
 				// refresh. Per Codex round 4 [P1].
 				const refreshCtx = ctx;
 				const refreshGen = loadGeneration;
+				// Order the `item` write against every other item-snapshot write
+				// via the dedicated itemGen (round 9); refreshGen still guards the
+				// collab provider + nonce rebuild.
+				const myItemGen = ++itemGen;
 				void api.items
 					.get(refreshCtx.wsSlug, refreshCtx.itemId)
 					.then((fresh) => {
@@ -1882,7 +1922,7 @@
 						// NEW item's provider needlessly and stamp A's content
 						// into the wrong slot (PLAN-2105 / TASK-2112; Codex).
 						if (collabProvider !== provider || refreshGen !== loadGeneration) return;
-						if (item && item.id === refreshCtx.itemId) {
+						if (item && item.id === refreshCtx.itemId && myItemGen === itemGen) {
 							item = withInflightTags(fresh);
 						}
 						// Refetch succeeded → safe to rebuild.

--- a/web/src/lib/services/sse.svelte.ts
+++ b/web/src/lib/services/sse.svelte.ts
@@ -33,6 +33,10 @@ const ITEM_EVENTS = [
 	'item_archived',
 	'item_restored',
 	'workspace_updated',
+	// Collection-row change (settings/schema/name/icon). Carries `collection`
+	// (slug) but no `item_id`; ItemDetail / collection pages refresh their
+	// independent Collection snapshot on it (BUG-2265 sibling broadcast).
+	'collection_updated',
 	'comment_created',
 	'comment_updated',
 	'comment_deleted',

--- a/web/src/lib/services/sse.svelte.ts
+++ b/web/src/lib/services/sse.svelte.ts
@@ -9,6 +9,9 @@ export interface ItemEvent {
 	item_id: string;
 	title: string;
 	collection: string;
+	// On a collection_updated RENAME, the collection's new slug (the event is
+	// routed by the old slug). Absent for non-rename updates. BUG-2265.
+	new_slug?: string;
 	actor: string;
 	actor_name?: string;
 	source: string;

--- a/web/src/lib/services/sse.svelte.ts
+++ b/web/src/lib/services/sse.svelte.ts
@@ -12,6 +12,10 @@ export interface ItemEvent {
 	// On a collection_updated RENAME, the collection's new slug (the event is
 	// routed by the old slug). Absent for non-rename updates. BUG-2265.
 	new_slug?: string;
+	// On a collection_updated whose schema migration mutated item field values,
+	// a SANITIZED reconcile flag (no per-item data) — the client triggers a
+	// /items-changes deltaSync + refetches an open item. BUG-2265.
+	items_changed?: boolean;
 	actor: string;
 	actor_name?: string;
 	source: string;
@@ -242,6 +246,15 @@ function createSSEService() {
 				const data: ItemEvent = JSON.parse(e.data);
 				dispatchItemEvent(data);
 				broadcast({ type: 'item_event', event: data });
+				// BUG-2265: a collection_updated whose schema migration mutated
+				// item field values also needs an item reconcile — its
+				// items_changed flag is delivered even to item-grant subscribers,
+				// so route it through the same /items-changes sync as bulk item
+				// mutations. Peers get the sync_required broadcast too.
+				if (data.type === 'collection_updated' && data.items_changed) {
+					dispatchSyncRequired();
+					broadcast({ type: 'sync_required' });
+				}
 			});
 		}
 	}

--- a/web/src/lib/services/sse.svelte.ts
+++ b/web/src/lib/services/sse.svelte.ts
@@ -9,6 +9,11 @@ export interface ItemEvent {
 	item_id: string;
 	title: string;
 	collection: string;
+	// STABLE collection identity on collection_updated events (BUG-2265). Slugs
+	// are mutable/reusable and events replay, so clients MUST match these events
+	// by `collection_id`, not `collection` (slug) — the slug is only for the
+	// rename-navigation URL.
+	collection_id?: string;
 	// On a collection_updated RENAME, the collection's new slug (the event is
 	// routed by the old slug). Absent for non-rename updates. BUG-2265.
 	new_slug?: string;

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -432,6 +432,10 @@ export interface CollectionUpdate {
 	settings?: string;
 	sort_order?: number;
 	migrations?: FieldMigration[];
+	// Optimistic-concurrency token (BUG-2265). Round-trip the `updated_at`
+	// you last read; the server re-reads under a write lock and rejects a
+	// stale write with a 409 `update_conflict`. Omit for last-write-wins.
+	expected_updated_at?: string;
 }
 
 // ─── Agent Roles ─────────────────────────────────────────────────────────────

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -2,7 +2,7 @@
 	import { page } from '$app/state';
 	import { browser } from '$app/environment';
 	import { goto, beforeNavigate, afterNavigate } from '$app/navigation';
-	import { api, PadApiError, isPlanLimitError, planLimitMessage } from '$lib/api/client';
+	import { api, PadApiError, isPlanLimitError, planLimitMessage, isUpdateConflictError } from '$lib/api/client';
 	import type { BulkItemsRequest, Collection, Item, PaneTarget, QuickAction, View, ViewConfig } from '$lib/types';
 	import { parseSettings, parseFields, parseSchema, parseTags, getStatusOptions, itemUrlId, formatItemRef } from '$lib/types';
 	import { plansProgressToMap, fetchCollectionProgress } from '$lib/collections/progressMerge';
@@ -1601,16 +1601,42 @@
 
 	async function handleGroupReorder(newOrder: string[]) {
 		if (!wsSlug || !collSlug || !collection) return;
-		const currentSchema = parseSchema(collection);
-		const fieldIdx = currentSchema.fields.findIndex((f) => f.key === groupField);
-		if (fieldIdx === -1) return;
 
-		// Update the field's options to the new order
-		currentSchema.fields[fieldIdx].options = newOrder;
-		const newSchemaStr = JSON.stringify(currentSchema);
+		// Apply `newOrder` to the grouped field's options ON TOP OF a base
+		// schema. Re-derived from a FRESH base on a 409 retry so the reorder
+		// lands on the latest schema instead of clobbering a concurrent
+		// collection edit with our stale snapshot (BUG-2265 — this is a
+		// full-schema write, the same last-write-wins class the modal /
+		// quick-actions paths were hardened against). Returns null when the
+		// grouped field no longer exists in the base.
+		const applyOrder = (base: Collection): string | null => {
+			const s = parseSchema(base);
+			const idx = s.fields.findIndex((f) => f.key === groupField);
+			if (idx === -1) return null;
+			s.fields[idx].options = newOrder;
+			return JSON.stringify(s);
+		};
 
 		try {
-			const updated = await api.collections.update(wsSlug, collSlug, { schema: newSchemaStr });
+			const schemaStr = applyOrder(collection);
+			if (schemaStr === null) return;
+			let updated: Collection;
+			try {
+				updated = await api.collections.update(wsSlug, collSlug, {
+					schema: schemaStr,
+					expected_updated_at: collection.updated_at
+				});
+			} catch (err) {
+				if (!isUpdateConflictError(err)) throw err;
+				// Refetch, re-apply the reorder onto the fresh schema, retry once.
+				const fresh = await api.collections.get(wsSlug, collSlug);
+				const retryStr = applyOrder(fresh);
+				if (retryStr === null) return;
+				updated = await api.collections.update(wsSlug, fresh.slug, {
+					schema: retryStr,
+					expected_updated_at: fresh.updated_at
+				});
+			}
 			collection = updated;
 		} catch {
 			toastStore.show('Failed to save column order', 'error');

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -840,6 +840,11 @@
 				// can land on a dead intermediate. Deferred (already broken on main).
 				if (event.new_slug && event.new_slug !== coll) {
 					const search = typeof window !== 'undefined' ? window.location.search : '';
+					// TODO(BUG-2272): refresh global collectionStore / handle collection_updated
+					// in the workspace layout on rename. This route navigates, but the GLOBAL
+					// collectionStore (sidebar links/icons/names, pickers) isn't refreshed and
+					// the layout ignores collection_updated, so the sidebar keeps the dead old
+					// slug and clicking it 404s. Deferred (layout-level renavigation).
 					void goto(`/${username}/${wsSlug}/${event.new_slug}${search}`);
 					return;
 				}

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -825,7 +825,10 @@
 			// controls send a fresh expected_updated_at. Carries no item_id,
 			// so short-circuit before the item-delta path below.
 			if (event.type === 'collection_updated') {
-				if (event.collection !== coll) return;
+				// Match by STABLE id, not slug (Codex round 7): a replayed rename
+				// event's old slug can be re-owned by a DIFFERENT collection, so a
+				// slug match could navigate away / refresh from the wrong one.
+				if (!collection || event.collection_id !== collection.id) return;
 				// Rename (Codex P2): this route's URL slug is now dead. Re-target
 				// to the new slug — preserving the query string (open pane) — so
 				// the next fetch/action doesn't 404. Mirrors the originating
@@ -1668,6 +1671,11 @@
 					const fresh = list.find((c) => c.id === base.id);
 					if (fresh && collGen === collectionGen && ws === wsSlug && slug === collSlug) {
 						collection = fresh;
+						// TODO(BUG-2272): on a remote RENAME this reseeds `collection`
+						// (fresh slug) but NOT the route's `collSlug`, so the NEXT
+						// reorder still PATCHes the dead old slug and re-fails. A real
+						// fix retargets the route slug (renavigation, deferred to
+						// BUG-2272); we don't build that here.
 					}
 				} catch {
 					// Best-effort reseed.

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -1601,44 +1601,37 @@
 
 	async function handleGroupReorder(newOrder: string[]) {
 		if (!wsSlug || !collSlug || !collection) return;
+		// Capture identity + base snapshot BEFORE the await (no {#key} on this
+		// route — a switch mid-await must not write the wrong collection).
+		const ws = wsSlug;
+		const slug = collSlug;
+		const base = collection;
 
-		// Apply `newOrder` to the grouped field's options ON TOP OF a base
-		// schema. Re-derived from a FRESH base on a 409 retry so the reorder
-		// lands on the latest schema instead of clobbering a concurrent
-		// collection edit with our stale snapshot (BUG-2265 — this is a
-		// full-schema write, the same last-write-wins class the modal /
-		// quick-actions paths were hardened against). Returns null when the
-		// grouped field no longer exists in the base.
-		const applyOrder = (base: Collection): string | null => {
-			const s = parseSchema(base);
-			const idx = s.fields.findIndex((f) => f.key === groupField);
-			if (idx === -1) return null;
-			s.fields[idx].options = newOrder;
-			return JSON.stringify(s);
-		};
+		const s = parseSchema(base);
+		const idx = s.fields.findIndex((f) => f.key === groupField);
+		if (idx === -1) return;
+		s.fields[idx].options = newOrder;
+		const schemaStr = JSON.stringify(s);
 
 		try {
-			const schemaStr = applyOrder(collection);
-			if (schemaStr === null) return;
-			let updated: Collection;
-			try {
-				updated = await api.collections.update(wsSlug, collSlug, {
-					schema: schemaStr,
-					expected_updated_at: collection.updated_at
-				});
-			} catch (err) {
-				if (!isUpdateConflictError(err)) throw err;
-				// Refetch, re-apply the reorder onto the fresh schema, retry once.
-				const fresh = await api.collections.get(wsSlug, collSlug);
-				const retryStr = applyOrder(fresh);
-				if (retryStr === null) return;
-				updated = await api.collections.update(wsSlug, fresh.slug, {
-					schema: retryStr,
-					expected_updated_at: fresh.updated_at
-				});
-			}
+			const updated = await api.collections.update(ws, slug, {
+				schema: schemaStr,
+				// BUG-2265: reject a stale full-schema write rather than clobber
+				// a concurrent collection edit.
+				expected_updated_at: base.updated_at
+			});
+			if (ws !== wsSlug || slug !== collSlug) return;
 			collection = updated;
-		} catch {
+		} catch (err) {
+			if (isUpdateConflictError(err)) {
+				// The schema changed under us. Replaying this stale option order
+				// onto the fresh field would silently drop concurrent option
+				// add/remove/rename, so ABORT — reordering is cosmetic and never
+				// worth clobbering a real schema edit. `collection` refreshes via
+				// the collection_updated broadcast; the user can re-drag.
+				toastStore.show('Columns changed elsewhere — please reorder again', 'error');
+				return;
+			}
 			toastStore.show('Failed to save column order', 'error');
 		}
 	}

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -831,6 +831,15 @@
 			// so short-circuit before the item-delta path below.
 			if (event.type === 'collection_updated') {
 				if (event.collection !== coll) return;
+				// Rename (Codex P2): this route's URL slug is now dead. Re-target
+				// to the new slug — preserving the query string (open pane) — so
+				// the next fetch/action doesn't 404. Mirrors the originating
+				// client's rename navigation.
+				if (event.new_slug && event.new_slug !== coll) {
+					const search = typeof window !== 'undefined' ? window.location.search : '';
+					void goto(`/${username}/${wsSlug}/${event.new_slug}${search}`);
+					return;
+				}
 				const refreshSeq = ++collectionRefreshSeq;
 				const seq = loadSeq;
 				try {
@@ -1627,8 +1636,15 @@
 				// The schema changed under us. Replaying this stale option order
 				// onto the fresh field would silently drop concurrent option
 				// add/remove/rename, so ABORT — reordering is cosmetic and never
-				// worth clobbering a real schema edit. `collection` refreshes via
-				// the collection_updated broadcast; the user can re-drag.
+				// worth clobbering a real schema edit. REFETCH here (don't rely on
+				// the SSE broadcast, which may be missed / mid-reconnect) so the
+				// token reseeds and the next re-drag doesn't 409 forever.
+				try {
+					const fresh = await api.collections.get(ws, slug);
+					if (ws === wsSlug && slug === collSlug) collection = fresh;
+				} catch {
+					// Best-effort reseed.
+				}
 				toastStore.show('Columns changed elsewhere — please reorder again', 'error');
 				return;
 			}

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -807,6 +807,11 @@
 
 	// Subscribe to SSE events for live updates to this collection's items
 	let unsubscribeSSE: (() => void) | null = null;
+	// Dedicated monotonic counter for BUG-2265 collection-snapshot refreshes.
+	// `loadSeq` only bumps on route loadCollection() calls, so it can't order
+	// two rapid collection_updated fetches against EACH OTHER — this does,
+	// dropping an older refetch that resolves after a newer one (Codex P2).
+	let collectionRefreshSeq = 0;
 
 	$effect(() => {
 		// Clean up previous subscription
@@ -826,11 +831,13 @@
 			// so short-circuit before the item-delta path below.
 			if (event.type === 'collection_updated') {
 				if (event.collection !== coll) return;
+				const refreshSeq = ++collectionRefreshSeq;
 				const seq = loadSeq;
 				try {
 					const fresh = await api.collections.get(ws, coll);
-					// Drop if a newer loadCollection superseded us or the route
-					// moved on while fetching.
+					// Drop if a newer refresh superseded us, a newer
+					// loadCollection ran, or the route moved on while fetching.
+					if (refreshSeq !== collectionRefreshSeq) return;
 					if (seq !== loadSeq || collSlug !== coll) return;
 					collection = fresh;
 				} catch {

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -819,6 +819,25 @@
 		const coll = collSlug;
 
 		unsubscribeSSE = sseService.onItemEvent(async (event) => {
+			// BUG-2265 sibling broadcast: another client changed THIS
+			// collection's settings/schema. Refresh the page's own
+			// `collection` snapshot so its list-header quick actions / edit
+			// controls send a fresh expected_updated_at. Carries no item_id,
+			// so short-circuit before the item-delta path below.
+			if (event.type === 'collection_updated') {
+				if (event.collection !== coll) return;
+				const seq = loadSeq;
+				try {
+					const fresh = await api.collections.get(ws, coll);
+					// Drop if a newer loadCollection superseded us or the route
+					// moved on while fetching.
+					if (seq !== loadSeq || collSlug !== coll) return;
+					collection = fresh;
+				} catch {
+					// Best-effort; the next save will 409 and self-heal.
+				}
+				return;
+			}
 			// React to item lifecycle events by pulling deltas through
 			// the local store. With seq-stamped events (TASK-1358) we
 			// can short-circuit duplicates the server's replay buffer

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -835,6 +835,11 @@
 				// to the new slug — preserving the query string (open pane) — so
 				// the next fetch/action doesn't 404. Mirrors the originating
 				// client's rename navigation.
+				// TODO(BUG-2272): full cross-tab rename renavigation — chained
+				// renames replayed on reconnect (A→B then B→C) can arrive with
+				// `coll` already past the intermediate slug, so a B→C event whose
+				// old slug (B) no longer matches `coll` is skipped and the route
+				// can land on a dead intermediate. Deferred (already broken on main).
 				if (event.new_slug && event.new_slug !== coll) {
 					const search = typeof window !== 'undefined' ? window.location.search : '';
 					void goto(`/${username}/${wsSlug}/${event.new_slug}${search}`);

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -2,7 +2,7 @@
 	import { page } from '$app/state';
 	import { browser } from '$app/environment';
 	import { goto, beforeNavigate, afterNavigate } from '$app/navigation';
-	import { api, PadApiError, isPlanLimitError, planLimitMessage, isUpdateConflictError } from '$lib/api/client';
+	import { api, PadApiError, isPlanLimitError, planLimitMessage, isConflictOrNotFound } from '$lib/api/client';
 	import type { BulkItemsRequest, Collection, Item, PaneTarget, QuickAction, View, ViewConfig } from '$lib/types';
 	import { parseSettings, parseFields, parseSchema, parseTags, getStatusOptions, itemUrlId, formatItemRef } from '$lib/types';
 	import { plansProgressToMap, fetchCollectionProgress } from '$lib/collections/progressMerge';
@@ -1654,16 +1654,21 @@
 			if (collGen !== collectionGen || ws !== wsSlug || slug !== collSlug) return;
 			collection = updated;
 		} catch (err) {
-			if (isUpdateConflictError(err)) {
-				// The schema changed under us. Replaying this stale option order
-				// onto the fresh field would silently drop concurrent option
-				// add/remove/rename, so ABORT — reordering is cosmetic and never
-				// worth clobbering a real schema edit. REFETCH here (don't rely on
-				// the SSE broadcast, which may be missed / mid-reconnect) so the
-				// token reseeds and the next re-drag doesn't 409 forever.
+			// A concurrent change defeats our slug-targeted write via a 409
+			// (schema changed) OR a 404 (a RENAME killed the slug). Handle BOTH
+			// (BUG-2265 Pattern C). Replaying this stale option order onto the
+			// fresh field would silently drop concurrent option add/remove/rename,
+			// so ABORT — reordering is cosmetic and never worth clobbering a real
+			// schema edit. Reseed by STABLE id (a slug refetch would 404 on a
+			// rename) — not the SSE broadcast, which may be missed / reconnecting —
+			// so the token reseeds and the next re-drag doesn't fail forever.
+			if (isConflictOrNotFound(err)) {
 				try {
-					const fresh = await api.collections.get(ws, slug);
-					if (collGen === collectionGen && ws === wsSlug && slug === collSlug) collection = fresh;
+					const list = await api.collections.list(ws);
+					const fresh = list.find((c) => c.id === base.id);
+					if (fresh && collGen === collectionGen && ws === wsSlug && slug === collSlug) {
+						collection = fresh;
+					}
 				} catch {
 					// Best-effort reseed.
 				}

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -807,11 +807,6 @@
 
 	// Subscribe to SSE events for live updates to this collection's items
 	let unsubscribeSSE: (() => void) | null = null;
-	// Dedicated monotonic counter for BUG-2265 collection-snapshot refreshes.
-	// `loadSeq` only bumps on route loadCollection() calls, so it can't order
-	// two rapid collection_updated fetches against EACH OTHER — this does,
-	// dropping an older refetch that resolves after a newer one (Codex P2).
-	let collectionRefreshSeq = 0;
 
 	$effect(() => {
 		// Clean up previous subscription
@@ -845,14 +840,15 @@
 					void goto(`/${username}/${wsSlug}/${event.new_slug}${search}`);
 					return;
 				}
-				const refreshSeq = ++collectionRefreshSeq;
-				const seq = loadSeq;
+				// Unified generation: bumped here AND by loadCollection /
+				// handleGroupReorder, so the last-started write wins and neither
+				// a stale refresh nor a stale load can revert a newer snapshot.
+				const collGen = ++collectionGen;
 				try {
 					const fresh = await api.collections.get(ws, coll);
-					// Drop if a newer refresh superseded us, a newer
-					// loadCollection ran, or the route moved on while fetching.
-					if (refreshSeq !== collectionRefreshSeq) return;
-					if (seq !== loadSeq || collSlug !== coll) return;
+					// Drop if a newer collection write superseded us or the route
+					// moved on while fetching.
+					if (collGen !== collectionGen || collSlug !== coll) return;
 					collection = fresh;
 				} catch {
 					// Best-effort; the next save will 409 and self-heal.
@@ -1060,8 +1056,19 @@
 	// result checks it's still the latest before writing.
 	let loadSeq = 0;
 
+	// UNIFIED collection-snapshot generation (BUG-2265 Codex): bumped by EVERY
+	// operation that assigns `collection` — loadCollection, the SSE
+	// collection_updated refresh, and handleGroupReorder — so the last-STARTED
+	// write wins and a stale in-flight continuation (e.g. a slow load resolving
+	// after a fresh SSE refresh, which uses a different lifecycle than loadSeq)
+	// can't revert the collection and its concurrency token. `loadSeq` still
+	// guards the route-load's OTHER state (views/members/progress); this token
+	// is dedicated to the `collection` object itself.
+	let collectionGen = 0;
+
 	async function loadCollection(ws: string, coll: string, includeArchived = false) {
 		const seq = ++loadSeq;
+		const collGen = ++collectionGen;
 		metaLoading = true;
 		metaError = null;
 		// Reset for the new route; only flips back to `true` once
@@ -1090,7 +1097,11 @@
 			// A newer load started while this one was in flight — drop
 			// this result so it can't overwrite the current route's state.
 			if (seq !== loadSeq) return;
-			collection = collData;
+			// Gate the collection SNAPSHOT on the unified generation: a newer
+			// SSE refresh (which bumps collectionGen but not loadSeq) may have
+			// landed fresher data since this load began — don't revert it. The
+			// route-load's other state below stays on loadSeq.
+			if (collGen === collectionGen) collection = collData;
 			savedViews = viewsData;
 			workspaceMembers = membersData.members ?? [];
 			activeViewId = null;
@@ -1159,7 +1170,9 @@
 			// error + Retry affordance instead of masking a live
 			// collection as deleted.
 			if (err instanceof PadApiError && err.code === 'not_found') {
-				collection = null;
+				// Same generation gate as the success path — don't null a
+				// collection a newer SSE refresh just repopulated.
+				if (collGen === collectionGen) collection = null;
 				metaError = null;
 				// `items` is derived from localIndex; nothing to clear here.
 				// A missing collection shows the empty / not-found state via
@@ -1620,6 +1633,10 @@
 		const ws = wsSlug;
 		const slug = collSlug;
 		const base = collection;
+		// Join the unified collection-snapshot fence: bump on start, gate every
+		// write, so a concurrent load/SSE-refresh that started later wins and a
+		// stale one can't revert our result (and vice-versa).
+		const collGen = ++collectionGen;
 
 		const s = parseSchema(base);
 		const idx = s.fields.findIndex((f) => f.key === groupField);
@@ -1634,7 +1651,7 @@
 				// a concurrent collection edit.
 				expected_updated_at: base.updated_at
 			});
-			if (ws !== wsSlug || slug !== collSlug) return;
+			if (collGen !== collectionGen || ws !== wsSlug || slug !== collSlug) return;
 			collection = updated;
 		} catch (err) {
 			if (isUpdateConflictError(err)) {
@@ -1646,7 +1663,7 @@
 				// token reseeds and the next re-drag doesn't 409 forever.
 				try {
 					const fresh = await api.collections.get(ws, slug);
-					if (ws === wsSlug && slug === collSlug) collection = fresh;
+					if (collGen === collectionGen && ws === wsSlug && slug === collSlug) collection = fresh;
 				} catch {
 					// Best-effort reseed.
 				}
@@ -2968,7 +2985,9 @@
 								// follow-up save reads fresh settings.quick_actions
 								// instead of stale ones — without this, a second
 								// save can overwrite the first before loadCollection
-								// resolves.
+								// resolves. Bump the unified fence so an in-flight
+								// stale load/refresh can't revert this fresh write.
+								collectionGen++;
 								collection = updated;
 								loadCollection(wsSlug, collSlug, showArchived);
 							}}

--- a/web/src/routes/[username]/[workspace]/settings/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/settings/+page.svelte
@@ -88,23 +88,27 @@
 
 	// BUG-2265: keep the collections list fresh when another client changes a
 	// collection, so opening the edit modal seeds a CURRENT
-	// expected_updated_at instead of a stale one (which would produce a false
-	// 409 "reload" on a change that predates editing). `editingCollection` is
-	// captured at edit-click time from this list; a mid-edit refresh doesn't
-	// touch the already-open modal (its seed is edge-gated). Guarded so two
-	// rapid events can't resolve out of order.
-	let collectionsRefreshSeq = 0;
-	async function refreshCollectionsOnEvent() {
-		const ws = wsSlug;
+	// expected_updated_at instead of a stale one. UNIFIED generation (Codex):
+	// EVERY collections-list write — load(), create/update handlers, and the
+	// SSE refresh — bumps this and gates its assignment, so a stale in-flight
+	// fetch (e.g. a slow load for workspace A) can't revert a newer one.
+	let collectionsGen = 0;
+	async function refreshCollections(ws: string) {
 		if (!ws) return;
-		const seq = ++collectionsRefreshSeq;
+		const gen = ++collectionsGen;
 		try {
 			const fresh = await api.collections.list(ws);
-			// Drop if a newer refresh superseded us OR the workspace changed
-			// while fetching — a slow refresh for workspace A must not overwrite
-			// workspace B's freshly loaded list (Codex round 4).
-			if (seq !== collectionsRefreshSeq || ws !== wsSlug) return;
+			// Drop if a newer write superseded us OR the workspace changed.
+			if (gen !== collectionsGen || ws !== wsSlug) return;
 			collections = fresh;
+			// If the edit modal is open, feed it the refreshed object for the
+			// SAME id so a concurrent rename updates its `collection` prop and
+			// its same-id-rename retarget branch fires — otherwise the modal
+			// keeps PATCHing the dead old slug → 404 (Codex #4).
+			if (editingCollection) {
+				const refreshed = fresh.find((c) => c.id === editingCollection!.id);
+				if (refreshed) editingCollection = refreshed;
+			}
 		} catch {
 			// Best-effort; a stale token just yields a recoverable 409.
 		}
@@ -125,7 +129,7 @@
 			pendingHash = hash;
 		}
 		unsubscribeSSE = sseService.onItemEvent((event) => {
-			if (event.type === 'collection_updated') void refreshCollectionsOnEvent();
+			if (event.type === 'collection_updated') void refreshCollections(wsSlug);
 		});
 	});
 
@@ -138,7 +142,11 @@
 			await workspaceStore.setCurrent(slug);
 			wsName = workspaceStore.current?.name ?? '';
 			contextEditor = JSON.stringify(workspaceStore.current?.context ?? {}, null, 2);
-			collections = await api.collections.list(slug);
+			// Gate under the unified generation so a slow load can't revert a
+			// newer SSE refresh (or another load) that landed while in flight.
+			const gen = ++collectionsGen;
+			const fresh = await api.collections.list(slug);
+			if (gen === collectionsGen && slug === wsSlug) collections = fresh;
 			try {
 				const memberData = await api.members.list(slug);
 				members = memberData.members ?? [];
@@ -241,14 +249,14 @@
 		localStorage.setItem('pad-theme', theme);
 	}
 	async function handleCollectionCreated() {
-		collections = await api.collections.list(wsSlug);
+		await refreshCollections(wsSlug);
 		collectionStore.loadCollections(wsSlug);
 		showCreateModal = false;
 	}
 	async function handleCollectionUpdated() {
-		collections = await api.collections.list(wsSlug);
-		collectionStore.loadCollections(wsSlug);
 		editingCollection = null;
+		await refreshCollections(wsSlug);
+		collectionStore.loadCollections(wsSlug);
 	}
 	async function handleInvite() {
 		if (!inviteEmail.trim() || inviting) return;

--- a/web/src/routes/[username]/[workspace]/settings/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/settings/+page.svelte
@@ -93,6 +93,12 @@
 	// SSE refresh — bumps this and gates its assignment, so a stale in-flight
 	// fetch (e.g. a slow load for workspace A) can't revert a newer one.
 	let collectionsGen = 0;
+	// Dedicated fence for the whole load() path (name/context/collections/
+	// members). Bumped only by load() (each workspace switch re-runs it), so a
+	// slow load for workspace A can't resume after B's load and clobber B — and,
+	// unlike collectionsGen (which an SSE refresh also bumps), an SSE
+	// collections-refresh mid-load doesn't drop load()'s name/members writes.
+	let loadGen = 0;
 	async function refreshCollections(ws: string) {
 		if (!ws) return;
 		const gen = ++collectionsGen;
@@ -138,17 +144,25 @@
 	});
 	async function load(slug: string) {
 		loading = true;
+		// Capture generations at ENTRY — BEFORE any await (including setCurrent)
+		// — and fence EVERY continuation (Codex round 8). A slow load for
+		// workspace A that resumes after B's load is superseded (myLoad !==
+		// loadGen) and drops all its writes, so it can't clobber B's
+		// name/context/collections/members. The collections write ALSO respects
+		// collectionsGen so it doesn't revert a fresher SSE refresh.
+		const myLoad = ++loadGen;
+		const myColl = ++collectionsGen;
 		try {
 			await workspaceStore.setCurrent(slug);
+			if (myLoad !== loadGen) return;
 			wsName = workspaceStore.current?.name ?? '';
 			contextEditor = JSON.stringify(workspaceStore.current?.context ?? {}, null, 2);
-			// Gate under the unified generation so a slow load can't revert a
-			// newer SSE refresh (or another load) that landed while in flight.
-			const gen = ++collectionsGen;
 			const fresh = await api.collections.list(slug);
-			if (gen === collectionsGen && slug === wsSlug) collections = fresh;
+			if (myLoad !== loadGen) return;
+			if (myColl === collectionsGen) collections = fresh;
 			try {
 				const memberData = await api.members.list(slug);
+				if (myLoad !== loadGen) return;
 				members = memberData.members ?? [];
 				invitations = memberData.invitations ?? [];
 				// Note: current-user role no longer derived here. workspaceStore.setCurrent
@@ -156,7 +170,7 @@
 			} catch {}
 		} catch { /* allow partial render */
 		} finally {
-			loading = false;
+			if (myLoad === loadGen) loading = false;
 		}
 	}
 	async function saveName() {

--- a/web/src/routes/[username]/[workspace]/settings/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/settings/+page.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
 	import { page } from '$app/state';
 	import { goto } from '$app/navigation';
-	import { onMount } from 'svelte';
+	import { onMount, onDestroy } from 'svelte';
 	import { api, isPlanLimitError, planLimitMessage } from '$lib/api/client';
+	import { sseService } from '$lib/services/sse.svelte';
 	import { workspaceStore } from '$lib/stores/workspace.svelte';
 	import type { Collection, WorkspaceContext } from '$lib/types';
 	import { parseSchema } from '$lib/types';
@@ -85,6 +86,27 @@
 		if (wsSlug) load(wsSlug);
 	});
 
+	// BUG-2265: keep the collections list fresh when another client changes a
+	// collection, so opening the edit modal seeds a CURRENT
+	// expected_updated_at instead of a stale one (which would produce a false
+	// 409 "reload" on a change that predates editing). `editingCollection` is
+	// captured at edit-click time from this list; a mid-edit refresh doesn't
+	// touch the already-open modal (its seed is edge-gated). Guarded so two
+	// rapid events can't resolve out of order.
+	let collectionsRefreshSeq = 0;
+	async function refreshCollectionsOnEvent() {
+		if (!wsSlug) return;
+		const seq = ++collectionsRefreshSeq;
+		try {
+			const fresh = await api.collections.list(wsSlug);
+			if (seq !== collectionsRefreshSeq) return;
+			collections = fresh;
+		} catch {
+			// Best-effort; a stale token just yields a recoverable 409.
+		}
+	}
+	let unsubscribeSSE: (() => void) | null = null;
+
 	onMount(() => {
 		const stored = localStorage.getItem('pad-theme');
 		if (stored === 'light' || stored === 'dark') {
@@ -98,6 +120,13 @@
 			// so an owner-only tab in the hash won't be in validTabIds yet.
 			pendingHash = hash;
 		}
+		unsubscribeSSE = sseService.onItemEvent((event) => {
+			if (event.type === 'collection_updated') void refreshCollectionsOnEvent();
+		});
+	});
+
+	onDestroy(() => {
+		unsubscribeSSE?.();
 	});
 	async function load(slug: string) {
 		loading = true;

--- a/web/src/routes/[username]/[workspace]/settings/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/settings/+page.svelte
@@ -95,11 +95,15 @@
 	// rapid events can't resolve out of order.
 	let collectionsRefreshSeq = 0;
 	async function refreshCollectionsOnEvent() {
-		if (!wsSlug) return;
+		const ws = wsSlug;
+		if (!ws) return;
 		const seq = ++collectionsRefreshSeq;
 		try {
-			const fresh = await api.collections.list(wsSlug);
-			if (seq !== collectionsRefreshSeq) return;
+			const fresh = await api.collections.list(ws);
+			// Drop if a newer refresh superseded us OR the workspace changed
+			// while fetching — a slow refresh for workspace A must not overwrite
+			// workspace B's freshly loaded list (Codex round 4).
+			if (seq !== collectionsRefreshSeq || ws !== wsSlug) return;
 			collections = fresh;
 		} catch {
 			// Best-effort; a stale token just yields a recoverable 409.


### PR DESCRIPTION
## BUG-2265 — collection-settings writes are last-write-wins from per-item snapshots

**Symptom.** Collection-level settings (e.g. `quick_actions`) were written by reconstructing the COMPLETE settings JSON from an ItemDetail's LOCAL collection snapshot, and `store.UpdateCollection` replaced the whole column with no concurrency check. Two ItemDetails in the same collection (full-page pane host master + pane) hold independent snapshots and clobber each other; `oncollectionupdated` only refreshed the originating instance.

**Root cause.** `UpdateCollection` did a blind `UPDATE collections SET ... WHERE id = ?` from a caller-reconstructed full-settings blob, and there was no cross-instance signal to refresh sibling snapshots.

## The 3-part fix

### 1. Optimistic concurrency (store)
`CollectionUpdate` gains `ExpectedUpdatedAt` (mirrors the item pattern, IDEA-1480). Every `UpdateCollection` now runs through one small transaction that re-reads `updated_at` atomically (`FOR UPDATE` row lock on Postgres; SQLite `BEGIN IMMEDIATE` covers it) and, when the caller opted in, rejects a stale write with a `CollectionUpdateConflictError`. The stored `updated_at` (a `TEXT` RFC3339 column on both drivers) is made **strictly monotonic for every write** — guarded and tokenless — so the one-second-precision timestamp is a reliable token: no same-second or tokenless write can keep/regress a token a stale reader still holds. No DB migration (reuses `collections.updated_at`).

### 2. Client 409 handling (web)
- `QuickActionsMenu` sends the token and, on a 409, refetches the collection, re-appends the new action onto the FRESH settings, and retries once — no silent loss, no user-visible error. Captures ws/collection identity before the first await (switch-safety).
- `EditCollectionModal` captures the token at open-time (edge-gated seed so a concurrent broadcast can't wipe in-progress edits) and shows a non-destructive "changed elsewhere — reload" message on 409 (no auto-merge of a full-form edit).
- Board column reorder sends the token and ABORTS on 409 (cosmetic reorder must never clobber a concurrent option add/remove/rename).

### 3. Sibling broadcast (server + web)
New EventBus type `collection_updated`, published by `handleUpdateCollection` (only when the slug is unchanged — renames are handled by the existing navigation path) and routed through SSE. On the event, sibling `ItemDetail`s, the collection page, and the settings page refresh their independent `collection` snapshot (each fenced with a dedicated refresh generation), shrinking the 409 window. Delivered to item-grant-only subscribers too (it's itemless but leak-free).

## Conflict envelope
Reused the existing `writeUpdateConflictError` wire shape via an extracted `writeUpdateConflictEnvelope` helper; added a parallel `store.CollectionUpdateConflictError` type + `asCollectionUpdateConflictError` mapper so the collection 409 is byte-identical to the item 409 (`code: "update_conflict"`, `details: {ref, expected_updated_at, actual_updated_at}`).

## Gates
- `go build ./...` — pass
- `make test` (full Go SQLite suite) — pass
- **`make test-pg` (full Go suite on Postgres :5445) — pass** (GO_EXIT=0, all packages `ok`, incl. `internal/store` + `internal/server`)
- `cd web && npm run check` (svelte-check) — pass (0 errors)

## Codex review
4 rounds. R1: optimistic-concurrency atomicity + same-second + rename broadcast + out-of-order fetch (fixed). R2: tokenless-write monotonicity (fixed). R3: board-reorder token + settings-page staleness + item-grant delivery (fixed). R4: switch-safety on the round-3 web fixes (fixed). A final confirming Codex pass runs on this PR.

https://claude.ai/code/session_01EZ6yr6pAUFb1uffan912ra