### PR TITLE
fix(collab): version restore via prune+reseed (BUG-2264)

### DIFF
--- a/internal/collab/applier.go
+++ b/internal/collab/applier.go
@@ -310,7 +310,14 @@ func (r *Room) pickApplier(tried map[*websocket.Conn]struct{}) *roomConn {
 		// and the edit would be silently lost. Skip them so election
 		// only ever lands on a writer (or returns nil → the caller's
 		// direct-write fallback fires).
-		if !rc.canWrite.Load() {
+		//
+		// A frozen conn (mid version-restore, BUG-2264) is excluded for the
+		// identical reason: readLoop drops its inbound sync frames while frozen,
+		// so an elected frozen conn would ack a no-op. Combined with the frozen
+		// check in handleControlMessage (which rejects a late ack from a conn
+		// frozen AFTER it was picked), a concurrent ApplyExternalContent can never
+		// falsely succeed against a restore's frozen peer.
+		if !rc.canWrite.Load() || rc.frozen.Load() {
 			continue
 		}
 		candidates = append(candidates, rc)

--- a/internal/collab/applier_test.go
+++ b/internal/collab/applier_test.go
@@ -503,6 +503,42 @@ func TestHandleControlMessageIgnoresAckFromReadOnlyConn(t *testing.T) {
 	}
 }
 
+// TestHandleControlMessageIgnoresAckFromFrozenConn is the pick-then-freeze half
+// of the BUG-2264 applier fix: a WRITABLE conn that ForceRefreshRoom froze mid
+// version-restore has its inbound sync frames dropped by readLoop, so an
+// applier_ack from it would be a phantom success (ApplyExternalContent returns
+// nil, the PATCH handler skips its direct-write fallback, and the external edit
+// is silently lost while the restore prunes the op-log). canWrite=true isolates
+// the frozen gate from the read-only gate.
+func TestHandleControlMessageIgnoresAckFromFrozenConn(t *testing.T) {
+	bus := NewMemoryOpBus()
+	defer bus.Close()
+	mgr := NewRoomManager(&fakeOpLog{}, bus)
+	defer mgr.Close()
+
+	room := mgr.getOrCreate("item-a")
+
+	rc := &roomConn{id: 1, conn: &websocket.Conn{}}
+	rc.canWrite.Store(true)
+	rc.frozen.Store(true)
+
+	reqID := "req-frozen"
+	ch, err := room.registerPendingAck(reqID, rc.conn)
+	if err != nil {
+		t.Fatalf("registerPendingAck: %v", err)
+	}
+
+	payload, _ := json.Marshal(ControlMessage{Type: ControlMessageApplierAck, RequestID: reqID})
+	room.handleControlMessage(rc, payload)
+
+	select {
+	case <-ch:
+		t.Fatal("applier_ack from a frozen conn must be ignored, but it signaled the pending ack")
+	case <-time.After(50 * time.Millisecond):
+		// Correct: the ack was dropped before routeApplierAck.
+	}
+}
+
 // TestPruneAndApplyAllowsReadOnlyRoom verifies the load-bearing
 // writer-aware guard (TASK-265): a room whose only peers are read-only
 // must NOT block the no-applier direct write. PruneAndApply runs applyFn

--- a/internal/collab/manager.go
+++ b/internal/collab/manager.go
@@ -95,6 +95,109 @@ type RoomManager struct {
 	// round 5.
 	itemLocksMu sync.Mutex
 	itemLocks   map[string]*sync.Mutex
+
+	// restoreBoundaries records, per item, the pre-prune MAX(op-log.id)+1 at the
+	// most recent version RESTORE (BUG-2264, prune+reseed). A collab-snapshot
+	// flush whose op_log_cursor is BELOW this boundary captured a Y.Doc that
+	// predates the restore's op-log wipe — its markdown is the stale PRE-restore
+	// content — so the PATCH handler rejects it (RestoreBoundary), preventing an
+	// in-flight pre-restore flush from re-clobbering items.content after the
+	// restore write.
+	//
+	// In-memory (process-lifetime, monotonic non-decreasing). Op-log ids never
+	// reset, so a stale boundary can never falsely reject a genuine post-restore
+	// flush (whose cursor is always >= the boundary). One int64 per restored
+	// item — same acceptable footprint as itemLocks. For the process-restart
+	// residual this shares with lastRestoreSeqs, see that field's doc.
+	restoreBoundaryMu sync.Mutex
+	restoreBoundaries map[string]int64
+
+	// lastRestoreSeqs records, per item, the item.seq assigned by the most
+	// recent version RESTORE — i.e. the content generation of the restored (and
+	// now canonical) items.content that the pruned op-log's peers must rebuild
+	// from (BUG-2264, closing the additional-P1 + Codex-xhigh stale-seed race).
+	// On Join a client announces the items.content `seq` its Y.Doc was seeded
+	// from (?content_seq=); if that seed predates the last restore (contentSeq <
+	// lastRestoreSeq), the client's seed is the stale PRE-restore content and the
+	// empty/post-restore op-log can't reconcile it (a since==0 client slips the
+	// resume-cursor MIN check entirely), so Join force_refreshes it BEFORE its
+	// on-open Y.encodeStateAsUpdate can re-push the stale document. This closes
+	// the two seed-based clobbers the resume-cursor boundary alone can't: a lost
+	// force_refresh frame on a cursor-0 peer, and a browser that GETs
+	// items.content, blocks in Join behind the restore, and joins after the prune.
+	//
+	// In-memory / monotonic, mirroring restoreBoundaries. Seq is
+	// workspace-monotonic and only bumped when THIS item is written, so a stale
+	// value can never falsely reject a client that seeded at-or-after the restore.
+	//
+	// This is a FAST-PATH cache, not the source of truth. The restart hole it
+	// used to have — a server restart resets the map, and a restart is NOT a safe
+	// refresh barrier because the BROWSER's in-memory Y.Doc survives the WS drop,
+	// so a cursor-0 pre-restore provider reconnecting post-restart would slip the
+	// since==0 resume-cursor check and re-push its stale document — is now closed
+	// DURABLY by items.last_restore_seq (BUG-2264, migration 075/pg 053). The
+	// restore stamps that column in its own tx; Join reads it (via
+	// store.ItemLastRestoreSeq) whenever this in-memory fast-path misses, so a
+	// stale-seeded tab is fenced even after a restart. This map only saves the
+	// column read in the common (same-process) case.
+	lastRestoreSeqMu sync.Mutex
+	lastRestoreSeqs  map[string]int64
+}
+
+// SetRestoreBoundary records a restore boundary for itemID, keeping the
+// stored value monotonically non-decreasing (a later restore always has a
+// higher op-log MAX, and a stale/duplicate call can never lower it). See the
+// restoreBoundaries field doc for the invariant this enforces (BUG-2264).
+func (m *RoomManager) SetRestoreBoundary(itemID string, boundary int64) {
+	if itemID == "" || boundary <= 0 {
+		return
+	}
+	m.restoreBoundaryMu.Lock()
+	defer m.restoreBoundaryMu.Unlock()
+	if m.restoreBoundaries == nil {
+		m.restoreBoundaries = make(map[string]int64)
+	}
+	if boundary > m.restoreBoundaries[itemID] {
+		m.restoreBoundaries[itemID] = boundary
+	}
+}
+
+// RestoreBoundary returns the restore boundary recorded for itemID, or
+// (0, false) when none has been set. The collab-snapshot PATCH handler
+// consults it to reject stale pre-restore flushes (BUG-2264).
+func (m *RoomManager) RestoreBoundary(itemID string) (int64, bool) {
+	m.restoreBoundaryMu.Lock()
+	defer m.restoreBoundaryMu.Unlock()
+	v, ok := m.restoreBoundaries[itemID]
+	return v, ok
+}
+
+// SetLastRestoreSeq records the item.seq of the most recent restore for itemID,
+// kept monotonically non-decreasing (a later restore always has a higher seq;
+// a stale/duplicate call can never lower it). See the lastRestoreSeqs field doc
+// for the seed-based clobber this closes (BUG-2264).
+func (m *RoomManager) SetLastRestoreSeq(itemID string, seq int64) {
+	if itemID == "" || seq <= 0 {
+		return
+	}
+	m.lastRestoreSeqMu.Lock()
+	defer m.lastRestoreSeqMu.Unlock()
+	if m.lastRestoreSeqs == nil {
+		m.lastRestoreSeqs = make(map[string]int64)
+	}
+	if seq > m.lastRestoreSeqs[itemID] {
+		m.lastRestoreSeqs[itemID] = seq
+	}
+}
+
+// LastRestoreSeq returns the item.seq of the most recent restore for itemID, or
+// (0, false) when none has been recorded. Join consults it to force_refresh a
+// client whose announced ?content_seq predates the last restore (BUG-2264).
+func (m *RoomManager) LastRestoreSeq(itemID string) (int64, bool) {
+	m.lastRestoreSeqMu.Lock()
+	defer m.lastRestoreSeqMu.Unlock()
+	v, ok := m.lastRestoreSeqs[itemID]
+	return v, ok
 }
 
 // itemLock returns the lazily-allocated mutex guarding setup-phase
@@ -147,6 +250,18 @@ func NewRoomManagerWithConfig(store opLogStore, bus OpBus, cfg RoomManagerConfig
 // close the conn cleanly. Per TASK-1319.
 var ErrForceRefreshSent = errors.New("collab: client cursor below op-log MIN; force_refresh sent")
 
+// ErrStaleSeedFenceUnavailable is returned by Join when the DURABLE stale-seed
+// boundary read (items.last_restore_seq) fails on an in-memory miss, so we can't
+// confirm the client's ?content_seq seed is current (BUG-2264). We fail CLOSED —
+// the conn is closed WITHOUT admitting it (so a stale seed can't be pushed) — but
+// via a plain close, NOT a force_refresh: force_refresh would make the client
+// DISCARD its Y.Doc and rebuild, and a persistent read error (DB down) would then
+// spin an unbounded refresh/GET loop that also drops local-only edits (Codex
+// xhigh). A plain close is retryable: the client's provider reconnects with
+// backoff, Y.Doc intact, and once the DB recovers it's admitted (or legitimately
+// force_refreshed if genuinely stale). The handler closes the conn on this.
+var ErrStaleSeedFenceUnavailable = errors.New("collab: durable restore-boundary read failed; retryable close")
+
 // Join attaches a freshly-upgraded WebSocket connection to the room
 // for itemID. Replays the op-log to the new peer, spins up an inbound
 // reader and an outbound writer, and blocks until the WebSocket
@@ -179,7 +294,7 @@ var ErrForceRefreshSent = errors.New("collab: client cursor below op-log MIN; fo
 // Returns whatever error caused the WebSocket to close, or nil on a
 // normal close. The handler typically logs but doesn't act on the
 // return value: the connection is gone either way.
-func (m *RoomManager) Join(itemID string, conn *websocket.Conn, since int64, canWrite bool, onRegistered func()) error {
+func (m *RoomManager) Join(itemID string, conn *websocket.Conn, since int64, contentSeq int64, canWrite bool, onRegistered func()) error {
 	// Gate Add on the closed flag under m.mu so a late Join (e.g. a
 	// hijacked WS handler that didn't enter Join until AFTER Close
 	// returned) can't sneak past the drain barrier.
@@ -245,6 +360,59 @@ func (m *RoomManager) Join(itemID string, conn *websocket.Conn, since int64, can
 					"since", since,
 					"min_id", minID,
 					"has_min", hasMin,
+				)
+				_ = sendForceRefreshFrame(conn)
+				itemLock.Unlock()
+				return ErrForceRefreshSent
+			}
+		}
+
+		// Stale-seed force_refresh (BUG-2264). Independent of the resume-cursor
+		// check above: `?content_seq=<seq>` is the items.content generation the
+		// client's Y.Doc was SEEDED from. If it predates the most recent restore
+		// (contentSeq < lastRestoreSeq), the seed is the stale PRE-restore content
+		// and the pruned op-log can't reconcile it — a since==0 client (fresh
+		// session OR a cursor-0 peer whose force_refresh frame was lost) slips the
+		// MIN check entirely and would re-push that stale document on open.
+		//
+		// The boundary has two tiers: the in-memory lastRestoreSeqs fast-path
+		// (set under itemLock by ForceRefreshRoom, so a Join serialised behind a
+		// restore sees it) and the DURABLE items.last_restore_seq column (written
+		// in the restore's own tx). The durable value is the source of truth
+		// across a server RESTART: after a restart the in-memory map is empty, so
+		// a stale-seeded cursor-0 tab reconnecting would otherwise slip through —
+		// on an in-memory miss we read the column so it is still fenced. contentSeq
+		// ==0 (old bundle that doesn't announce it) falls through to the legacy
+		// behaviour — no regression.
+		if contentSeq > 0 {
+			lastRestoreSeq, ok := m.LastRestoreSeq(itemID)
+			if !ok {
+				durable, hasDurable, derr := m.store.ItemLastRestoreSeq(itemID)
+				if derr != nil {
+					// FAIL CLOSED, but RETRYABLE (Codex xhigh): a read error means
+					// we can't confirm the seed is current, so admitting the client
+					// would let a stale cursor-0 tab push its pre-restore Y.Doc and
+					// clobber the restored content once the DB recovers. Close the
+					// conn WITHOUT admitting it — but via a plain close, not a
+					// force_refresh: force_refresh discards the Y.Doc + rebuilds, so
+					// a persistent read error would spin an unbounded refresh/GET
+					// loop and drop local-only edits. A plain close lets the client
+					// reconnect with backoff, Y.Doc intact, until the DB recovers.
+					// Only reachable on an in-memory miss (post-restart), contentSeq>0.
+					slog.Warn("collab: durable restore-boundary read failed; retryable close (fence unavailable)",
+						"item_id", itemID, "error", derr)
+					itemLock.Unlock()
+					return ErrStaleSeedFenceUnavailable
+				}
+				if hasDurable {
+					lastRestoreSeq, ok = durable, true
+				}
+			}
+			if ok && contentSeq < lastRestoreSeq {
+				slog.Info("collab: client seed predates last restore; sending force_refresh",
+					"item_id", itemID,
+					"content_seq", contentSeq,
+					"last_restore_seq", lastRestoreSeq,
 				)
 				_ = sendForceRefreshFrame(conn)
 				itemLock.Unlock()
@@ -785,6 +953,140 @@ func (m *RoomManager) PruneAndApply(itemID string, applyFn func() error) error {
 	room.mu.Unlock()
 
 	return applyFn()
+}
+
+// ForceRefreshRoom makes items.content the canonical source for an item's collab
+// state: it runs `commit` under the per-item lock (so the caller can atomically
+// set items.content to the value clients should rebuild from), prunes the ENTIRE
+// per-item op-log (the commit does the prune in its own transaction), then
+// force-refreshes every connected client (force_refresh frame + close) so each
+// peer discards its in-memory Y.Doc and lazy-seeds from items.content on
+// reconnect. Used by version-restore (BUG-2264): the restored content becomes
+// canonical and every peer converges on it — unflushed edits are discarded,
+// which is exactly restore semantics.
+//
+// `commit` MUST perform the canonical items.content write, the version row, AND
+// the op-log wipe in ONE store transaction (the restore handler passes
+// UpdateItemWithPreCheck + PruneItemOpLogTx). ForceRefreshRoom no longer prunes
+// separately: a split prune/commit leaves a divergent state on any failure
+// (Codex xhigh [P1]). The op-log wipe is what makes reconnecting/cold clients
+// lazy-seed from items.content (an empty op-log ⇒ nothing to replay).
+//
+// Holding the per-item lock across the commit + boundary + broadcast serialises
+// against Join's addConn+replayTo (and the collab-snapshot gate, which also runs
+// under this lock), so a client reconnecting after its force_refresh blocks here
+// until the op-log is empty AND the boundary is published, then rebuilds cleanly.
+//
+// Failure handling (Codex xhigh [P1]): the conns are frozen (rc.frozen=true) and
+// appendMu is held BEFORE the fallible commit. If the commit fails the restore
+// did not happen (the ONE tx rolled back — items.content, version, op-log wipe,
+// and the boundary MAX read all together), so we UN-freeze the conns (peers keep
+// editing their live Y.Doc, viewers keep their read-only status), do NOT publish
+// the boundary, skip the reseed, and return the error — the room is left exactly
+// as it was. The freeze uses a dedicated rc.frozen flag, NOT canWrite, so the
+// mid-session auth revalidation loop (which writes canWrite) can neither thaw the
+// freeze mid-restore nor get its viewer/editor decision clobbered by it.
+//
+// RESIDUAL (BUG-2276, deferred — commit-outcome ambiguity): a commit ERROR is
+// treated as "rolled back". On SQLite (the self-host shape) that holds — a commit
+// either fsyncs or it doesn't. On Postgres a commit that DURABLY lands but whose
+// acknowledgement is lost (connection drop at the commit boundary) surfaces as an
+// error here, so we unfreeze+resume peers on a stale Y.Doc even though the DB now
+// holds restored content + a pruned op-log — a stale flush could then clobber.
+// Un-freezing is the RIGHT call for the common genuine-rollback error (a real
+// rollback must not discard peers' unflushed edits), so the fix is not "reseed on
+// every error" (that regresses the common case) but commit-outcome reconciliation
+// (re-read after a commit error to learn what actually happened). Narrow +
+// Postgres-only; tracked in BUG-2276.
+//
+// `commit` returns (pre-prune MAX(op-log), restored item.seq): both captured
+// INSIDE its transaction, so the boundary can't fail-open on a MAX read error
+// (the whole restore rolls back instead) and the seq is this restore's, not a
+// concurrent writer's.
+//
+// The stale-SEED clobber that survives the boundary (BUG-2264 additional-P1 +
+// Codex-xhigh) is closed by the restore boundary generation: the restore stamps
+// the item's seq both in-memory (lastRestoreSeqs fast-path) and DURABLY
+// (items.last_restore_seq, in the commit tx), and Join force_refreshes any client
+// whose announced ?content_seq predates it. That catches a client whose Y.Doc
+// seeded from PRE-restore items.content and would otherwise re-push it as a fresh
+// (post-MAX) op — (1) a lost force_refresh frame on a cursor-0 peer, (2) a browser
+// that GETs items.content, blocks in Join behind this restore, and joins AFTER
+// the prune (so it isn't in forceRefreshAll), and (3) a cursor-0 pre-restore tab
+// that reconnects AFTER a server restart (fenced off the durable column since the
+// in-memory fast-path is empty then). See the lastRestoreSeqs field doc.
+func (m *RoomManager) ForceRefreshRoom(itemID string, commit func() (int64, int64, error)) error {
+	lock := m.itemLock(itemID)
+	lock.Lock()
+	defer lock.Unlock()
+
+	m.mu.Lock()
+	room := m.rooms[itemID]
+	m.mu.Unlock()
+
+	// P1c — freeze inbound persistence for the duration: hold appendMu (which
+	// readLoop takes across its frozen/canWrite check + AppendYjsUpdate) AND mark
+	// every conn frozen, so no live readLoop can append a frame after the prune
+	// (which would survive as a stale op replayed on reconnect). A readLoop that
+	// already read a frame and is queued on appendMu will, on acquiring it, see
+	// frozen=true and drop the frame. Lock order: itemLock → appendMu → room.mu.
+	// No socket I/O happens under appendMu.
+	if room != nil {
+		room.appendMu.Lock()
+		room.mu.Lock()
+		for _, rc := range room.conns {
+			rc.frozen.Store(true)
+		}
+		room.mu.Unlock()
+	}
+
+	// The commit reads the pre-prune MAX(op-log), writes items.content=restored +
+	// the version, and wipes the op-log in ONE transaction, returning (MAX, seq).
+	// On failure nothing changed on disk; un-freeze the room and bail without
+	// publishing the boundary or reseeding.
+	var maxID, restoredSeq int64
+	if commit != nil {
+		m, seq, err := commit()
+		if err != nil {
+			if room != nil {
+				room.mu.Lock()
+				for _, rc := range room.conns {
+					rc.frozen.Store(false)
+				}
+				room.mu.Unlock()
+				room.appendMu.Unlock()
+			}
+			return err
+		}
+		maxID, restoredSeq = m, seq
+	}
+
+	// Commit succeeded: items.content=restored, op-log empty. Publish the
+	// stale-flush boundary = pre-prune MAX+1 (or 1 when empty). IDs are
+	// AUTOINCREMENT/BIGSERIAL-monotonic across prunes, so every in-flight
+	// snapshot's cursor (≤ pre-prune MAX) is below the boundary and rejected by
+	// the collab-snapshot gate, while every genuine post-refresh op gets an id ≥
+	// MAX+1 and is accepted. The gate runs under this same itemLock, so no
+	// in-flight snapshot can slip a write between the prune (committed above) and
+	// the boundary becoming visible.
+	m.SetRestoreBoundary(itemID, maxID+1)
+
+	// Record the restored content generation so Join can force_refresh any peer
+	// whose ?content_seq seed predates it (the stale-SEED clobber the op-log-id
+	// boundary alone can't fence — see the lastRestoreSeqs field doc). Set under
+	// this same itemLock, so a Join serialised behind this restore sees the
+	// updated generation.
+	m.SetLastRestoreSeq(itemID, restoredSeq)
+
+	// Reseed: every peer discards its in-memory Y.Doc and rebuilds from the (now
+	// canonical) items.content on reconnect. The conns stay frozen (never cleared
+	// on the success path) until forceRefreshAll closes them, so no late frame can
+	// append even after appendMu is released for the socket fan-out.
+	if room != nil {
+		room.appendMu.Unlock()
+		room.forceRefreshAll()
+	}
+	return nil
 }
 
 // closeFrameDeadline is the absolute time budget for sending a

--- a/internal/collab/manager_test.go
+++ b/internal/collab/manager_test.go
@@ -33,6 +33,16 @@ type fakeOpLog struct {
 	// it. Missing key = NULL watermark = "never flushed".
 	contentFlushedIDs map[string]int64
 
+	// lastRestoreSeqs simulates the DURABLE items.last_restore_seq column
+	// (BUG-2264). Tests populate it to exercise the Join stale-seed fence's
+	// durable read (e.g. a fresh RoomManager on the same store = a "restart"
+	// with an empty in-memory fast-path). Missing key = NULL = never restored.
+	lastRestoreSeqs map[string]int64
+
+	// failLastRestoreSeq makes ItemLastRestoreSeq return an error, to exercise
+	// the Join fence's fail-closed path (a flaky DB after restart).
+	failLastRestoreSeq bool
+
 	// onListDormantHook fires once per call to
 	// ListDormantOpLogItemsBefore, AFTER the listing scan but BEFORE
 	// the result is returned to the caller. Used by tests that
@@ -222,6 +232,16 @@ func (f *fakeOpLog) MaxOpLogID(itemID string) (int64, bool, error) {
 	return maxID, found, nil
 }
 
+func (f *fakeOpLog) ItemLastRestoreSeq(itemID string) (int64, bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.failLastRestoreSeq {
+		return 0, false, errors.New("simulated durable last_restore_seq read failure")
+	}
+	v, ok := f.lastRestoreSeqs[itemID]
+	return v, ok, nil
+}
+
 func (f *fakeOpLog) appendCount() int {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -257,10 +277,16 @@ func newCollabTestServer(t *testing.T, mgr *RoomManager) *httptest.Server {
 				since = v
 			}
 		}
+		var contentSeq int64
+		if raw := r.URL.Query().Get("content_seq"); raw != "" {
+			if v, perr := strconv.ParseInt(raw, 10, 64); perr == nil && v > 0 {
+				contentSeq = v
+			}
+		}
 		// `?readonly=1` joins as a read-only participant (canWrite=false)
 		// so tests can exercise the TASK-265 gate. Default is writable.
 		canWrite := r.URL.Query().Get("readonly") != "1"
-		_ = mgr.Join(itemID, conn, since, canWrite, nil)
+		_ = mgr.Join(itemID, conn, since, contentSeq, canWrite, nil)
 	})
 	return httptest.NewServer(mux)
 }
@@ -279,6 +305,19 @@ func dialWSSince(t *testing.T, server *httptest.Server, itemID string, since int
 	if since > 0 {
 		wsURL += "?since=" + strconv.FormatInt(since, 10)
 	}
+	c, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	return c
+}
+
+// dialWSContentSeq appends `?content_seq=<seq>` so the test exercises the
+// BUG-2264 stale-seed force_refresh fence.
+func dialWSContentSeq(t *testing.T, server *httptest.Server, itemID string, contentSeq int64) *websocket.Conn {
+	t.Helper()
+	u, _ := url.Parse(server.URL)
+	wsURL := "ws://" + u.Host + "/ws/" + itemID + "?content_seq=" + strconv.FormatInt(contentSeq, 10)
 	c, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
 	if err != nil {
 		t.Fatalf("dial: %v", err)
@@ -391,6 +430,228 @@ func TestRoomManagerLazyCreate(t *testing.T) {
 	}
 	if got := mgr.RoomCount(); got != 1 {
 		t.Fatalf("after first Join: want 1 room, got %d", got)
+	}
+}
+
+// TestRestoreBoundaryMonotonic covers the per-item restore boundary the
+// collab-snapshot PATCH handler consults to reject stale pre-restore flushes
+// (BUG-2264 Invariant B): unset reads as (0,false); SetRestoreBoundary records
+// a value and keeps it monotonically non-decreasing (a later/higher restore
+// wins; a stale/lower or non-positive call can never lower it); boundaries are
+// isolated per item.
+func TestRestoreBoundaryMonotonic(t *testing.T) {
+	bus := NewMemoryOpBus()
+	defer bus.Close()
+	mgr := NewRoomManager(&fakeOpLog{}, bus)
+
+	if v, ok := mgr.RestoreBoundary("item-a"); ok || v != 0 {
+		t.Fatalf("unset boundary: want (0,false), got (%d,%v)", v, ok)
+	}
+
+	mgr.SetRestoreBoundary("item-a", 10)
+	if v, ok := mgr.RestoreBoundary("item-a"); !ok || v != 10 {
+		t.Fatalf("after set 10: want (10,true), got (%d,%v)", v, ok)
+	}
+
+	// A later restore with a higher op-log MAX advances the boundary.
+	mgr.SetRestoreBoundary("item-a", 25)
+	if v, _ := mgr.RestoreBoundary("item-a"); v != 25 {
+		t.Fatalf("after set 25: want 25, got %d", v)
+	}
+
+	// A stale / duplicate call with a lower value can never lower the boundary.
+	mgr.SetRestoreBoundary("item-a", 12)
+	if v, _ := mgr.RestoreBoundary("item-a"); v != 25 {
+		t.Fatalf("after stale set 12: boundary must stay 25, got %d", v)
+	}
+
+	// Non-positive values are ignored (no boundary to enforce).
+	mgr.SetRestoreBoundary("item-a", 0)
+	mgr.SetRestoreBoundary("item-a", -5)
+	if v, _ := mgr.RestoreBoundary("item-a"); v != 25 {
+		t.Fatalf("after non-positive sets: boundary must stay 25, got %d", v)
+	}
+
+	// Boundaries are per item.
+	if v, ok := mgr.RestoreBoundary("item-b"); ok || v != 0 {
+		t.Fatalf("unrelated item-b: want (0,false), got (%d,%v)", v, ok)
+	}
+}
+
+// TestForceRefreshRoom verifies the server-initiated force-refresh (BUG-2264):
+// it runs the caller's commit, prunes the ENTIRE per-item op-log, and sends a
+// force_refresh control frame to every connected client before closing the
+// connection — so peers discard their in-memory Y.Doc and rebuild from
+// items.content.
+func TestForceRefreshRoom(t *testing.T) {
+	bus := NewMemoryOpBus()
+	defer bus.Close()
+	store := &fakeOpLog{}
+	mgr := NewRoomManager(store, bus)
+	defer mgr.Close()
+
+	srv := newCollabTestServer(t, mgr)
+	defer srv.Close()
+
+	conn := dialWS(t, srv, "item-a")
+	defer conn.Close()
+
+	for i := 0; i < 200; i++ {
+		if mgr.RoomCount() == 1 && bus.SubscriberCount("item-a") == 1 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	// Seed op-log rows to prove the prune wipes them.
+	if _, err := store.AppendYjsUpdate("item-a", []byte{0x00, 0x01}, "1"); err != nil {
+		t.Fatalf("seed 1: %v", err)
+	}
+	if _, err := store.AppendYjsUpdate("item-a", []byte{0x00, 0x02}, "1"); err != nil {
+		t.Fatalf("seed 2: %v", err)
+	}
+
+	// The commit captures the pre-prune MAX and performs the op-log wipe
+	// atomically (the real path runs both inside UpdateItem's tx via
+	// MaxOpLogIDTx + PruneItemOpLogTx); the fake mirrors that by reading MAX,
+	// pruning here, and returning (MAX, restored seq).
+	committed := false
+	if err := mgr.ForceRefreshRoom("item-a", func() (int64, int64, error) {
+		committed = true
+		maxID, _, merr := store.MaxOpLogID("item-a")
+		if merr != nil {
+			return 0, 0, merr
+		}
+		if _, err := store.PruneYjsUpdatesBefore("item-a", distantFuture); err != nil {
+			return 0, 0, err
+		}
+		return maxID, 42, nil
+	}); err != nil {
+		t.Fatalf("ForceRefreshRoom: %v", err)
+	}
+	if !committed {
+		t.Fatal("commit callback did not run")
+	}
+
+	// Op-log fully pruned (by the commit).
+	store.mu.Lock()
+	remaining := 0
+	for _, r := range store.rows {
+		if r.ItemID == "item-a" {
+			remaining++
+		}
+	}
+	store.mu.Unlock()
+	if remaining != 0 {
+		t.Fatalf("op-log not pruned: %d rows remain", remaining)
+	}
+
+	// The restore published both fences: the op-log-id boundary (MAX+1) and the
+	// content generation (the restored seq).
+	if b, ok := mgr.RestoreBoundary("item-a"); !ok || b <= 0 {
+		t.Fatalf("restore boundary not published: got (%d, %v)", b, ok)
+	}
+	if s, ok := mgr.LastRestoreSeq("item-a"); !ok || s != 42 {
+		t.Fatalf("last restore seq = (%d, %v), want (42, true)", s, ok)
+	}
+
+	// The client received a force_refresh frame and then the conn was closed.
+	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	sawForceRefresh := false
+	for {
+		mt, data, err := conn.ReadMessage()
+		if err != nil {
+			break // conn closed by forceRefreshAll
+		}
+		if mt == websocket.TextMessage {
+			var ctl ControlMessage
+			if json.Unmarshal(data, &ctl) == nil && ctl.Type == ControlMessageForceRefresh {
+				sawForceRefresh = true
+			}
+		}
+	}
+	if !sawForceRefresh {
+		t.Fatal("client did not receive a force_refresh frame before the conn closed")
+	}
+}
+
+// TestJoinDurableRestoreBoundaryFencesStaleSeedAfterRestart is the BUG-2264
+// restart-durability guard (residual #1 closed): the stale-seed Join fence must
+// survive a server restart. A restore in a PRIOR process stamped the DURABLE
+// items.last_restore_seq column; after a restart the RoomManager is brand new,
+// so its in-memory lastRestoreSeqs fast-path is empty. A cursor-0 tab that
+// seeded PRE-restore reconnects — it must STILL be force_refreshed, off the
+// durable column read, not the (absent) in-memory value.
+func TestJoinDurableRestoreBoundaryFencesStaleSeedAfterRestart(t *testing.T) {
+	bus := NewMemoryOpBus()
+	defer bus.Close()
+	// Durable boundary present in the store (a restore stamped seq=10), but the
+	// manager is fresh — exactly the post-restart state.
+	store := &fakeOpLog{lastRestoreSeqs: map[string]int64{"item-a": 10}}
+	mgr := NewRoomManager(store, bus)
+	defer mgr.Close()
+	if _, ok := mgr.LastRestoreSeq("item-a"); ok {
+		t.Fatal("a fresh manager must have an empty in-memory restore-boundary fast-path")
+	}
+
+	srv := newCollabTestServer(t, mgr)
+	defer srv.Close()
+
+	// Stale seed (content_seq=5 < durable 10): force_refreshed via the durable
+	// column even though the in-memory fast-path is empty.
+	stale := dialWSContentSeq(t, srv, "item-a", 5)
+	defer stale.Close()
+	if ctl := readControlWithin(t, stale, time.Second); ctl.Type != ControlMessageForceRefresh {
+		t.Fatalf("stale seed after restart: want %q, got %q", ControlMessageForceRefresh, ctl.Type)
+	}
+
+	// Current seed (content_seq=10 == durable): joins normally (first control
+	// frame is the op_log_cursor, never force_refresh).
+	fresh := dialWSContentSeq(t, srv, "item-a", 10)
+	defer fresh.Close()
+	if ctl := readControlWithin(t, fresh, time.Second); ctl.Type == ControlMessageForceRefresh {
+		t.Fatal("current-generation seed must NOT be force_refreshed after restart")
+	}
+}
+
+// TestJoinFailsClosedWhenDurableBoundaryReadErrors is the BUG-2264 fail-closed
+// guard (Codex xhigh): if the durable restore-boundary read errors on an
+// in-memory miss (a flaky DB after a restart), the fence must NOT degrade open
+// and admit a possibly-stale seed — that client could push its pre-restore Y.Doc
+// and clobber the restored content once the DB recovers. It fails CLOSED via a
+// RETRYABLE plain close (NOT a force_refresh, which would discard the Y.Doc and
+// spin an unbounded refresh loop on a persistent error): the conn is closed
+// without admission and WITHOUT a force_refresh frame, so the client reconnects
+// with backoff, Y.Doc intact.
+func TestJoinFailsClosedWhenDurableBoundaryReadErrors(t *testing.T) {
+	bus := NewMemoryOpBus()
+	defer bus.Close()
+	// Empty in-memory fast-path (fresh manager) AND the durable read errors.
+	store := &fakeOpLog{failLastRestoreSeq: true}
+	mgr := NewRoomManager(store, bus)
+	defer mgr.Close()
+
+	srv := newCollabTestServer(t, mgr)
+	defer srv.Close()
+
+	c := dialWSContentSeq(t, srv, "item-a", 5)
+	defer c.Close()
+
+	// The conn is closed by the server WITHOUT a force_refresh frame (that would
+	// discard the Y.Doc). We should see a close/read error and never a
+	// force_refresh control message.
+	_ = c.SetReadDeadline(time.Now().Add(2 * time.Second))
+	for {
+		mt, data, err := c.ReadMessage()
+		if err != nil {
+			break // conn closed — the expected retryable close
+		}
+		if mt == websocket.TextMessage {
+			var ctl ControlMessage
+			if json.Unmarshal(data, &ctl) == nil && ctl.Type == ControlMessageForceRefresh {
+				t.Fatal("durable-read error must NOT force_refresh (discards Y.Doc); expected a retryable close")
+			}
+		}
 	}
 }
 
@@ -718,7 +979,7 @@ func TestRoomManagerJoinAfterCloseFailsFast(t *testing.T) {
 
 	// Direct Join — bypass the WS plumbing since we want to exercise
 	// the closed-flag short-circuit in isolation.
-	err := mgr.Join("item-a", nil, 0, true, nil) // conn is irrelevant; we never reach the WS path
+	err := mgr.Join("item-a", nil, 0, 0, true, nil) // conn is irrelevant; we never reach the WS path
 	if !errors.Is(err, errManagerClosed) {
 		t.Fatalf("want errManagerClosed, got %v", err)
 	}

--- a/internal/collab/room.go
+++ b/internal/collab/room.go
@@ -90,6 +90,19 @@ type roomConn struct {
 	// Server-side mirror of the REST requireEditPermission gate
 	// (TASK-265).
 	canWrite atomic.Bool
+
+	// frozen reports whether ForceRefreshRoom (version restore, BUG-2264) has
+	// paused this connection's inbound sync persistence for the duration of a
+	// prune+reseed. Kept SEPARATE from canWrite deliberately: the mid-session
+	// auth revalidation loop writes canWrite freely, so overloading it as the
+	// restore freeze let a revalidation tick thaw the freeze mid-restore
+	// (Codex xhigh [P1]) and a failed restore silently promote a viewer to
+	// writable. readLoop drops a sync frame when EITHER frozen or !canWrite.
+	// Set under appendMu (so a readLoop already queued on appendMu observes it
+	// on the very next check) and cleared only by ForceRefreshRoom's failure
+	// path; on success the conn is force-closed instead. atomic.Bool so the
+	// restore goroutine's write can't race readLoop's read.
+	frozen atomic.Bool
 }
 
 // writeMessage is a tiny helper that holds writeMu while writing one
@@ -100,6 +113,20 @@ func (rc *roomConn) writeMessage(messageType int, data []byte) error {
 	rc.writeMu.Lock()
 	defer rc.writeMu.Unlock()
 	return rc.conn.WriteMessage(messageType, data)
+}
+
+// writeMessageWithDeadline writes one frame with a bounded write deadline, both
+// the deadline set AND the write under writeMu — gorilla treats SetWriteDeadline
+// as a write-side method, so doing it outside the mutex would race the writeLoop
+// (BUG-2264 P2). Used by force_refresh so a slow/dead peer can't block the caller
+// indefinitely while it holds the per-item lock.
+func (rc *roomConn) writeMessageWithDeadline(messageType int, data []byte, deadline time.Time) error {
+	rc.writeMu.Lock()
+	defer rc.writeMu.Unlock()
+	_ = rc.conn.SetWriteDeadline(deadline)
+	err := rc.conn.WriteMessage(messageType, data)
+	_ = rc.conn.SetWriteDeadline(time.Time{})
+	return err
 }
 
 // Room is the per-item collab fan-out point. One Room per `itemID`
@@ -171,14 +198,21 @@ type opLogStore interface {
 	// (TASK-1319): when a reconnecting client announces `?since=<id>`
 	// and that id is below MIN, rows it expected to replay have
 	// been pruned and the server sends ControlMessageForceRefresh.
-	// MaxOpLogID is intentionally NOT on this interface — earlier
-	// versions used it to populate the initial cursor when replay
-	// produced no rows, but Codex round 6 [P1] caught the race
-	// between MaxOpLogID and an in-flight broadcast: the cursor
-	// could advertise an id whose binary frame hadn't been
-	// delivered through this conn's writeLoop yet. The initial
-	// cursor now strictly uses `max(highestReplayed, since)`.
 	MinOpLogID(itemID string) (int64, bool, error)
+	// MaxOpLogID is consulted ONLY by ForceRefreshRoom (BUG-2264), which reads
+	// it under the per-item lock WITH appendMu held (inbound persistence frozen)
+	// to set the pre-prune restore boundary = MAX+1. That fencing is why the
+	// broadcast-vs-MAX race (Codex round 6 [P1] of TASK-1319) — which kept this
+	// off the initial-cursor path — does not apply here: no frame can be persisted
+	// but not yet delivered, because appends are frozen while we read.
+	MaxOpLogID(itemID string) (int64, bool, error)
+	// ItemLastRestoreSeq returns the DURABLE per-item restore boundary
+	// (items.last_restore_seq) — the item.seq of the most recent version restore
+	// (BUG-2264). Join consults it to force_refresh a client whose ?content_seq
+	// seed predates the last restore; being persisted, it fences a stale-seeded
+	// cursor-0 tab that reconnects AFTER a server restart (when the in-memory
+	// lastRestoreSeqs fast-path is empty). (0, false) = never restored.
+	ItemLastRestoreSeq(itemID string) (int64, bool, error)
 }
 
 // addConn registers a freshly-built roomConn with the room. Cancels
@@ -349,7 +383,15 @@ func (r *Room) readLoop(rc *roomConn) error {
 			// dropped. Without this fencing a reader could read
 			// canWrite=true, block on appendMu, and persist AFTER
 			// SetConnWritable(false) returned (TOCTOU).
-			if !rc.canWrite.Load() {
+			//
+			// The `frozen` check shares the same appendMu fence and closes
+			// the restore-prune window (BUG-2264): a readLoop that already
+			// read a frame and is queued on appendMu when ForceRefreshRoom
+			// sets frozen=true will, on acquiring appendMu, drop the frame
+			// instead of appending it AFTER the prune (which would survive as
+			// a stale post-boundary op). It is a separate flag from canWrite
+			// so the auth revalidation loop can't thaw it mid-restore.
+			if rc.frozen.Load() || !rc.canWrite.Load() {
 				r.appendMu.Unlock()
 				continue
 			}
@@ -506,10 +548,37 @@ func (r *Room) handleControlMessage(rc *roomConn, data []byte) {
 		// dropped by the read-only gate, making ApplyExternalContent
 		// return nil, skip the PATCH handler's direct-write fallback,
 		// and silently lose the external edit.
-		if !rc.canWrite.Load() {
-			slog.Warn("collab: applier_ack from read-only conn; ignoring",
+		//
+		// A frozen conn (mid version-restore, BUG-2264) is rejected for the
+		// same reason AND to close the pick-then-freeze race: pickApplier may
+		// have elected this conn while it was writable, then ForceRefreshRoom
+		// froze it before its editor produced the sync frames. readLoop drops
+		// those frames while frozen, so accepting the ack would falsely report
+		// success. Rejecting it leaves the request pending until the applier
+		// flow times out and retries (pickApplier now skips frozen), so the
+		// caller's direct-write fallback owns the external edit.
+		//
+		// This is a plain atomic read, NOT taken under appendMu. Synchronising
+		// it with appendMu (to observe the freeze's FINAL state) would couple
+		// the ack path to the restore commit's duration — ForceRefreshRoom holds
+		// appendMu across the whole prune+write tx, so a slow commit (or any slow
+		// AppendYjsUpdate) could stall the ack past ApplyExternalContent's
+		// timeout and spuriously fail even a NORMAL ack (Codex xhigh round 5).
+		// The un-synchronised read leaves one narrow residual (BUG-2276): if a
+		// restore ROLLS BACK while an in-flight applier ack races the transient
+		// frozen=true window, the ack is dropped even though the rolled-back
+		// conn's frames persisted, so the applier flow retries/falls back
+		// (re-applying its own markdown — a possible clobber of peer edits made
+		// in the retry window). That is a quadruple-narrow edge (concurrent
+		// external PATCH + exact ack timing + restore ROLLBACK, i.e. a DB commit
+		// error + peer edits in the retry window); fully closing it needs the
+		// applier flow serialised with the restore under itemLock (a larger
+		// rework with its own 30s-restore-stall cost). Tracked in BUG-2276.
+		if !rc.canWrite.Load() || rc.frozen.Load() {
+			slog.Warn("collab: applier_ack from read-only or frozen conn; ignoring",
 				"item_id", r.itemID,
 				"client_id", rc.id,
+				"frozen", rc.frozen.Load(),
 			)
 			return
 		}
@@ -540,6 +609,63 @@ func (r *Room) closeAll() {
 	for _, c := range conns {
 		_ = c.Close()
 	}
+}
+
+// forceRefreshAll sends a force_refresh control frame to every connected client
+// and then closes each connection, so every peer discards its in-memory Y.Doc
+// and rebuilds from the canonical items.content on reconnect (BUG-2264). Used by
+// RoomManager.ForceRefreshRoom after the op-log has been pruned. The frame goes
+// through rc.writeMessage (holds writeMu) so it can't race the live writeLoop's
+// concurrent write — sendForceRefreshFrame's bare conn.WriteMessage is only safe
+// pre-addConn. Snapshots the conn set under r.mu, then does socket I/O OUTSIDE
+// the lock (matching closeAll) so a slow write/close can't block the room's
+// addConn/removeConn.
+func (r *Room) forceRefreshAll() {
+	payload, err := json.Marshal(ControlMessage{Type: ControlMessageForceRefresh})
+	if err != nil {
+		slog.Warn("collab: marshal force_refresh frame failed", "item_id", r.itemID, "error", err)
+		payload = nil
+	}
+
+	r.mu.Lock()
+	conns := make([]*roomConn, 0, len(r.conns))
+	for _, rc := range r.conns {
+		conns = append(conns, rc)
+	}
+	r.mu.Unlock()
+
+	// Fan the frame+close out per conn concurrently (additional-P2): a slow peer
+	// already inside a deadline-free WriteMessage would otherwise block the whole
+	// loop — and the caller still holds the per-item lock, stalling that item's
+	// restore/joins/snapshots.
+	//
+	// Each conn's frame is written with a bounded write deadline, but the deadline
+	// is set INSIDE writeMu (gorilla treats SetWriteDeadline as a write op), so it
+	// can't bound the wait to ACQUIRE writeMu. If the writeLoop is wedged in a
+	// deadline-free WriteMessage to a dead peer it holds writeMu indefinitely and
+	// writeMessageWithDeadline would block on writeMu.Lock() forever, hanging
+	// wg.Wait while the caller holds the per-item lock (BUG-2264 P1, Codex xhigh).
+	// So arm an independent timer per conn that Closes it after the deadline:
+	// conn.Close is concurrency-safe with an in-flight WriteMessage (gorilla), so
+	// it forces the wedged write to error, releasing writeMu and unblocking us.
+	var wg sync.WaitGroup
+	deadline := time.Now().Add(closeFrameDeadline)
+	for _, rc := range conns {
+		wg.Add(1)
+		go func(rc *roomConn) {
+			defer wg.Done()
+			// The timer bounds writeMu acquisition even if the frame write itself
+			// never gets to run its own deadline; Close is idempotent so the
+			// explicit Close below is harmless if the timer already fired.
+			t := time.AfterFunc(closeFrameDeadline, func() { _ = rc.conn.Close() })
+			if payload != nil {
+				_ = rc.writeMessageWithDeadline(websocket.TextMessage, payload, deadline)
+			}
+			t.Stop()
+			_ = rc.conn.Close()
+		}(rc)
+	}
+	wg.Wait()
 }
 
 // connIDCounter is package-scoped so multiple RoomManagers in the

--- a/internal/models/item.go
+++ b/internal/models/item.go
@@ -574,9 +574,26 @@ type ItemUpdate struct {
 	// re-attribute a CLI/MCP-created item to "collab-snapshot" and
 	// silently flip it out of `WorkspaceHasAgentActivity`'s count.
 	// Per Codex review round 3 of TASK-1267 [P2].
-	VersionSource string  `json:"version_source,omitempty"`
-	ChangeSummary string  `json:"change_summary,omitempty"`
-	Comment       *string `json:"comment,omitempty"`
+	VersionSource string `json:"version_source,omitempty"`
+	ChangeSummary string `json:"change_summary,omitempty"`
+	// ForceVersion bypasses the per-(actor, source) version throttle
+	// (VersionThrottleInterval) so a version snapshot is ALWAYS created when
+	// content changes. Set by deliberate, infrequent operations that must
+	// leave an undo point regardless of recent edit cadence — chiefly a
+	// version RESTORE, which changes items.content out from under the existing
+	// reverse-patch chain and would corrupt that chain (and lose the restore's
+	// own undo point) if a throttled write moved content forward without a
+	// bracketing version. Internal-only (`json:"-"`): the store honours it, but
+	// no HTTP client can set it. Only consulted when content actually changes.
+	ForceVersion bool `json:"-"`
+	// MarkRestoreBoundary stamps items.last_restore_seq with this update's newly
+	// assigned seq, INSIDE the same transaction as the content write + op-log
+	// prune (BUG-2264). Set only by version RESTORE. That durable per-item
+	// boundary is what Join reads to force_refresh a client whose ?content_seq
+	// seed predates the restore — surviving a server restart, unlike the
+	// in-memory fast-path. Internal-only (`json:"-"`); no HTTP client can set it.
+	MarkRestoreBoundary bool    `json:"-"`
+	Comment             *string `json:"comment,omitempty"`
 	// OpLogCursor is the highest item_yjs_updates.id the calling client
 	// has applied into its local Y.Doc (TASK-1319). Used by the
 	// collab-snapshot flush PATCH to advance the op-log GC watermark

--- a/internal/server/handlers_collab.go
+++ b/internal/server/handlers_collab.go
@@ -159,6 +159,19 @@ func (s *Server) handleCollab(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// `?content_seq=<seq>` is the items.content generation the client's Y.Doc
+	// was SEEDED from (BUG-2264). If it predates the item's most recent restore,
+	// Join force_refreshes the client before its on-open Y.encodeStateAsUpdate
+	// can re-push the stale pre-restore document. Empty / blank / unparseable
+	// values are tolerated as 0 (older bundles that don't announce it fall
+	// through to the legacy resume-cursor behaviour with no regression).
+	var contentSeq int64
+	if raw := r.URL.Query().Get("content_seq"); raw != "" {
+		if v, perr := strconv.ParseInt(raw, 10, 64); perr == nil && v > 0 {
+			contentSeq = v
+		}
+	}
+
 	conn, err := collabUpgrader.Upgrade(w, r, nil)
 	if err != nil {
 		// Upgrade itself emits the right HTTP status (e.g. 400 on
@@ -233,11 +246,19 @@ func (s *Server) handleCollab(w http.ResponseWriter, r *http.Request) {
 	// (closes `registered`) fires once the conn is in the room, so
 	// revalidation only starts after SetConnWritable can find it.
 	onRegistered := func() { close(registered) }
-	if err := s.collab.Join(itemID, conn, sinceID, access.canWrite, onRegistered); err != nil {
+	if err := s.collab.Join(itemID, conn, sinceID, contentSeq, access.canWrite, onRegistered); err != nil {
 		// ErrForceRefreshSent is the protocol's normal close-after-
 		// notify path — the JSON frame is already on the wire and
 		// the client knows what to do. Don't warn.
 		if errors.Is(err, collab.ErrForceRefreshSent) {
+			return
+		}
+		// ErrStaleSeedFenceUnavailable is an expected, retryable close (the
+		// durable stale-seed boundary read failed, so we fail closed without
+		// admitting the peer; Join already logged it at warn). The deferred
+		// conn.Close closes the WS so the client reconnects with backoff,
+		// Y.Doc intact. Don't double-warn. Per BUG-2264 (Codex xhigh).
+		if errors.Is(err, collab.ErrStaleSeedFenceUnavailable) {
 			return
 		}
 		// Normal closure paths surface here as websocket.CloseError

--- a/internal/server/handlers_item_versions.go
+++ b/internal/server/handlers_item_versions.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"database/sql"
+	"errors"
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
@@ -8,6 +10,11 @@ import (
 	"github.com/PerpetualSoftware/pad/internal/events"
 	"github.com/PerpetualSoftware/pad/internal/models"
 )
+
+// errRestoreItemGone signals that the item was concurrently deleted during a
+// restore's transaction (the tx committed nothing). Used to distinguish a
+// benign 404 from a genuine 500 out of ForceRefreshRoom's commit callback.
+var errRestoreItemGone = errors.New("restore: item not found")
 
 // handleListItemVersions returns all versions for an item with diffs resolved.
 func (s *Server) handleListItemVersions(w http.ResponseWriter, r *http.Request) {
@@ -126,7 +133,22 @@ func (s *Server) handleRestoreItemVersion(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	// Update item content to the version's content
+	// Restore = prune + reseed (BUG-2264). A restore makes the old version's
+	// content canonical and DISCARDS whatever peers are currently co-editing —
+	// that is exactly restore semantics, so every peer must converge on the
+	// restored content. When collab is configured, ForceRefreshRoom drives this
+	// under the per-item lock: it freezes inbound persistence, runs the commit
+	// (which writes items.content=restored + the "Restored from…" undo-point
+	// version + prunes the ENTIRE op-log in ONE store transaction), publishes the
+	// stale-flush boundary, then — if a live room exists — forces every connected
+	// peer to discard its in-memory Y.Doc and rebuild from items.content. The
+	// content write, the version, and the op-log wipe are atomic (Codex xhigh
+	// [P1]): a failed commit rolls back all three, so there is no divergent
+	// "restored content + stale op-log" or "wiped op-log + unchanged content"
+	// state on any failure path. The pruned op-log means a reconnecting or cold
+	// client lazy-seeds from the restored content; the boundary rejects any
+	// in-flight pre-restore snapshot. This replaces the earlier
+	// applier/epoch/watermark routing: prune+reseed needs none of it.
 	content := targetVersion.Content
 	summary := "Restored from version " + targetVersion.CreatedAt.Format("Jan 2, 2006 3:04 PM")
 	input := models.ItemUpdate{
@@ -134,11 +156,76 @@ func (s *Server) handleRestoreItemVersion(w http.ResponseWriter, r *http.Request
 		ChangeSummary:  summary,
 		LastModifiedBy: "user",
 		Source:         "web",
+		// A restore must always leave an undo point + a version bracketing the
+		// content it moves items.content back to, even on a repeat restore within
+		// the version-throttle window (VersionThrottleInterval = 1h).
+		// NOTE(BUG-2270): ForceVersion can mint same-second versions; the
+		// item_versions ordering tie-breaker is tracked there.
+		ForceVersion: true,
+		// Stamp the DURABLE restore boundary (items.last_restore_seq) in the same
+		// tx, so the Join stale-seed fence survives a server restart (BUG-2264).
+		MarkRestoreBoundary: true,
 	}
 
-	updated, err := s.store.UpdateItem(item.ID, input)
-	if err != nil {
-		writeInternalError(w, err)
+	var updated *models.Item
+	if s.collab != nil {
+		// Atomic capture + write + version + op-log prune in one tx: the precheck
+		// hook reads the pre-prune MAX(op-log) AND wipes the op-log inside
+		// UpdateItem's own transaction, so the restore boundary is captured
+		// atomically (no out-of-tx fail-open) and a failed commit rolls back all of
+		// it. ForceRefreshRoom then publishes the boundary (maxID+1) + content
+		// generation (seq) and reseeds under the per-item lock.
+		werr := s.collab.ForceRefreshRoom(item.ID, func() (int64, int64, error) {
+			var maxID int64
+			u, uerr := s.store.UpdateItemWithPreCheck(item.ID, input,
+				func(tx *sql.Tx, _ *models.Item) error {
+					m, _, merr := s.store.MaxOpLogIDTx(tx, item.ID)
+					if merr != nil {
+						return merr
+					}
+					maxID = m
+					// Stamp the DURABLE op-log-id boundary (= pre-prune MAX+1) in
+					// this same tx, so the collab-snapshot flush gate survives a
+					// restart (residual #1's restore-boundary facet).
+					if serr := s.store.StampRestoreBoundaryOpIDTx(tx, item.ID, m+1); serr != nil {
+						return serr
+					}
+					return s.store.PruneItemOpLogTx(tx, item.ID)
+				})
+			if uerr != nil {
+				return 0, 0, uerr
+			}
+			if u == nil {
+				// Item vanished (concurrently deleted) — the tx committed nothing.
+				// Fail so ForceRefreshRoom un-freezes without publishing a boundary
+				// or reseeding; the handler surfaces it below.
+				return 0, 0, errRestoreItemGone
+			}
+			updated = u
+			// (pre-prune MAX for the stale-flush boundary, restored seq for the
+			// content generation Join uses to force_refresh stale-seeded peers).
+			return maxID, u.Seq, nil
+		})
+		if werr != nil {
+			if errors.Is(werr, errRestoreItemGone) {
+				writeError(w, http.StatusNotFound, "not_found", "Item not found")
+				return
+			}
+			writeInternalError(w, werr)
+			return
+		}
+	} else {
+		// No collab configured (self-host build without the room manager): plain
+		// direct write — no op-log, no live peers.
+		u, uerr := s.store.UpdateItem(item.ID, input)
+		if uerr != nil {
+			writeInternalError(w, uerr)
+			return
+		}
+		updated = u
+	}
+	if updated == nil {
+		writeError(w, http.StatusNotFound, "not_found", "Item not found")
 		return
 	}
 

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -1303,6 +1303,55 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 					return errStaleCollabSnapshot
 				}
 			}
+			// Restore-boundary gate (BUG-2264 Invariant B): reject a stale
+			// PRE-restore snapshot. A version restore that reconciled the live
+			// Y.Doc through the applier records a boundary = MAX(op-log.id) at
+			// restore time; a flush whose op_log_cursor is below it captured a
+			// Y.Doc predating the restore's applier op, so its markdown is the
+			// pre-restore content that would clobber the restore. The
+			// op_log_cursor frame is delivered AFTER the restore's binary update
+			// on the same conn, and every Y.Doc update re-arms the client flush,
+			// so a cursor >= boundary always reflects post-restore content — this
+			// rejects only genuinely stale flushes (a post-restore flush
+			// momentarily below the boundary is harmlessly deferred to the next
+			// flush). Runs OUTSIDE the cursor-present gate above and FAILS CLOSED
+			// on a missing cursor: a snapshot without a cursor can't prove it
+			// captured post-restore state, so once a boundary exists it must be
+			// rejected too (a nil cursor would otherwise sail straight past the
+			// fence into the write below).
+			// Read the restore boundary from the in-memory fast-path, falling back
+			// to the DURABLE items.restore_boundary_op_id column on a miss — so a
+			// pre-restore flush is fenced even after a server restart cleared the
+			// in-memory map (BUG-2264 residual #1). A durable read ERROR fails
+			// CLOSED (reject the flush): we can't prove the flush is post-restore,
+			// and rejecting is safe (the client reloads; no data is discarded).
+			boundary, ok := s.collab.RestoreBoundary(item.ID)
+			if !ok {
+				durable, hasDurable, derr := s.store.ItemRestoreBoundaryOpID(item.ID)
+				if derr != nil {
+					slog.Warn("collab-snapshot: durable restore-boundary read failed; failing closed",
+						"item_id", item.ID, "error", derr)
+					return errStaleCollabSnapshot
+				}
+				if hasDurable {
+					boundary, ok = durable, true
+				}
+			}
+			if ok {
+				if input.OpLogCursor == nil || *input.OpLogCursor < boundary {
+					cur := int64(-1)
+					if input.OpLogCursor != nil {
+						cur = *input.OpLogCursor
+					}
+					slog.Info("collab-snapshot: rejecting PATCH; cursor below/absent vs restore boundary",
+						"item_id", item.ID,
+						"cursor", cur,
+						"has_cursor", input.OpLogCursor != nil,
+						"restore_boundary", boundary,
+					)
+					return errStaleCollabSnapshot
+				}
+			}
 			updated, uerr := s.store.UpdateItemWithParentLink(item.ID, input, openChildrenPrecheck, parentLink)
 			if uerr != nil {
 				return uerr

--- a/internal/server/handlers_items_collab_versions_test.go
+++ b/internal/server/handlers_items_collab_versions_test.go
@@ -3,11 +3,14 @@ package server
 import (
 	"encoding/json"
 	"net/http"
+	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/PerpetualSoftware/pad/internal/models"
+	"github.com/gorilla/websocket"
 )
 
 // TestCollabSnapshotHTTPSourceStamping is a regression guard for
@@ -397,4 +400,445 @@ func TestCollabSnapshotRejectsCursorZeroOnNonEmptyOpLog(t *testing.T) {
 	if rr.Code != http.StatusConflict {
 		t.Fatalf("expected 409 Conflict for cursor=0 on non-empty op-log; got %d %s", rr.Code, rr.Body.String())
 	}
+}
+
+// TestCollabSnapshotRejectedBelowRestoreBoundary is the BUG-2264 Invariant B
+// guard at the HTTP boundary. Once a version restore reconciles the live Y.Doc
+// and records a restore boundary (MAX(op-log.id) at restore time), a
+// collab-snapshot flush whose op_log_cursor is BELOW the boundary captured a
+// PRE-restore Y.Doc — its markdown is stale and would re-clobber the restored
+// content — so the handler rejects it (409). A flush at or above the boundary
+// is a post-restore snapshot and is accepted. Requires the RoomManager (the
+// boundary lives there and the check runs only on the s.collab != nil path).
+func TestCollabSnapshotRejectedBelowRestoreBoundary(t *testing.T) {
+	srv := testServerWithCollab(t)
+	slug := createWSWithCollections(t, srv)
+
+	rr := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections/tasks/items", map[string]interface{}{
+		"title":   "Restore boundary gate",
+		"content": "v1",
+		"source":  "cli",
+		"fields":  `{"status":"open"}`,
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create: %d %s", rr.Code, rr.Body.String())
+	}
+	var created models.Item
+	parseJSON(t, rr, &created)
+
+	// Seed op-log rows so the MIN-based staleness check passes (non-empty log,
+	// low MIN) — isolating the restore-boundary gate from the MIN gate.
+	var ids []int64
+	for i := 0; i < 5; i++ {
+		id, err := srv.store.AppendYjsUpdate(created.ID, []byte{0x00, byte(i + 1)}, "1")
+		if err != nil {
+			t.Fatalf("AppendYjsUpdate %d: %v", i, err)
+		}
+		ids = append(ids, id)
+	}
+	// Simulate the collab-live restore having recorded the boundary at a mid-log
+	// id (the restore path sets it to MAX(op-log) after the applier ack).
+	srv.collab.SetRestoreBoundary(created.ID, ids[2])
+
+	// A flush below the boundary (but >= MIN) is a stale pre-restore snapshot.
+	rr = doRequest(srv, "PATCH",
+		"/api/v1/workspaces/"+slug+"/items/"+created.Slug+"?source=collab-snapshot",
+		map[string]interface{}{"content": "stale pre-restore", "op_log_cursor": ids[1]},
+	)
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("pre-restore flush (cursor %d < boundary %d): expected 409, got %d %s", ids[1], ids[2], rr.Code, rr.Body.String())
+	}
+	// items.content must NOT have been clobbered by the stale snapshot.
+	rr = doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/items/"+created.Slug, nil)
+	var afterReject models.Item
+	parseJSON(t, rr, &afterReject)
+	if afterReject.Content == "stale pre-restore" {
+		t.Fatalf("stale pre-restore snapshot clobbered items.content (BUG-2264 Invariant B)")
+	}
+
+	// A flush at the boundary is a post-restore snapshot → accepted.
+	rr = doRequest(srv, "PATCH",
+		"/api/v1/workspaces/"+slug+"/items/"+created.Slug+"?source=collab-snapshot",
+		map[string]interface{}{"content": "post-restore", "op_log_cursor": ids[2]},
+	)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("post-restore flush (cursor %d >= boundary %d): expected 200, got %d %s", ids[2], ids[2], rr.Code, rr.Body.String())
+	}
+	rr = doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/items/"+created.Slug, nil)
+	var afterAccept models.Item
+	parseJSON(t, rr, &afterAccept)
+	if afterAccept.Content != "post-restore" {
+		t.Fatalf("post-restore flush should have written items.content, got %q", afterAccept.Content)
+	}
+
+	// Fail-closed on a MISSING cursor once a boundary exists: a snapshot with no
+	// op_log_cursor can't prove it captured post-restore state, so it must be
+	// rejected too — otherwise a legacy/in-flight no-cursor flush would sail past
+	// the fence and clobber the restore.
+	rr = doRequest(srv, "PATCH",
+		"/api/v1/workspaces/"+slug+"/items/"+created.Slug+"?source=collab-snapshot",
+		map[string]interface{}{"content": "no-cursor stale"},
+	)
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("no-cursor flush with a boundary set: expected 409 (fail closed), got %d %s", rr.Code, rr.Body.String())
+	}
+	rr = doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/items/"+created.Slug, nil)
+	var afterNoCursor models.Item
+	parseJSON(t, rr, &afterNoCursor)
+	if afterNoCursor.Content == "no-cursor stale" {
+		t.Fatalf("no-cursor flush clobbered items.content past the restore boundary (BUG-2264 Invariant B)")
+	}
+}
+
+// TestCollabSnapshotRejectedBelowDurableRestoreBoundaryAfterRestart is the
+// BUG-2264 residual-#1 guard for the COLLAB-SNAPSHOT flush vector: after a server
+// restart the in-memory RoomManager.RestoreBoundary is gone, so a surviving
+// pre-restore tab's stale flush must be fenced off the DURABLE
+// items.restore_boundary_op_id column instead. On an empty (post-restore, pruned)
+// op-log the MIN gate accepts cursor 0 (the fresh-client path), so the durable
+// boundary is the only thing standing between a stale cursor-0 flush and the
+// restored content.
+func TestCollabSnapshotRejectedBelowDurableRestoreBoundaryAfterRestart(t *testing.T) {
+	srv := testServerWithCollab(t)
+	slug := createWSWithCollections(t, srv)
+
+	rr := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections/tasks/items", map[string]interface{}{
+		"title":   "Durable restore boundary gate",
+		"content": "v1",
+		"source":  "cli",
+		"fields":  `{"status":"open"}`,
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create: %d %s", rr.Code, rr.Body.String())
+	}
+	var created models.Item
+	parseJSON(t, rr, &created)
+
+	// Baseline: with NO restore boundary (durable or in-memory) and an empty
+	// op-log, a cursor-0 flush is the accepted fresh-client path.
+	rr = doRequest(srv, "PATCH",
+		"/api/v1/workspaces/"+slug+"/items/"+created.Slug+"?source=collab-snapshot",
+		map[string]interface{}{"content": "fresh cursor-0", "op_log_cursor": int64(0)},
+	)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("baseline cursor-0 flush (no boundary): expected 200, got %d %s", rr.Code, rr.Body.String())
+	}
+
+	// Simulate a restore that happened in a PRIOR process: stamp the DURABLE
+	// boundary but leave the in-memory RoomManager.RestoreBoundary ABSENT (a fresh
+	// process after a restart).
+	if err := srv.store.SetItemRestoreBoundaryOpID(created.ID, 6); err != nil {
+		t.Fatalf("SetItemRestoreBoundaryOpID: %v", err)
+	}
+	if _, ok := srv.collab.RestoreBoundary(created.ID); ok {
+		t.Fatal("in-memory restore boundary must be absent for the restart scenario")
+	}
+
+	// The same cursor-0 flush is now FENCED by the durable boundary (cursor 0 < 6)
+	// even though the in-memory boundary is gone — the restart-durability fix.
+	rr = doRequest(srv, "PATCH",
+		"/api/v1/workspaces/"+slug+"/items/"+created.Slug+"?source=collab-snapshot",
+		map[string]interface{}{"content": "stale pre-restore", "op_log_cursor": int64(0)},
+	)
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("stale cursor-0 flush vs durable boundary: expected 409, got %d %s", rr.Code, rr.Body.String())
+	}
+	rr = doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/items/"+created.Slug, nil)
+	var after models.Item
+	parseJSON(t, rr, &after)
+	if after.Content == "stale pre-restore" {
+		t.Fatalf("stale flush clobbered items.content past the DURABLE restore boundary")
+	}
+}
+
+// restoreCollabFixture bundles the ws + collection + item(v1, edited to v2 so a
+// version resolving to v1 exists) + live test server the prune+reseed restore
+// tests share.
+type restoreCollabFixture struct {
+	srv         *Server
+	ts          *httptest.Server
+	wsSlug      string
+	itemID      string
+	itemSlug    string
+	v1VersionID string
+}
+
+func newRestoreCollabFixture(t *testing.T, name string) *restoreCollabFixture {
+	t.Helper()
+	srv := testServerWithCollab(t)
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+	ws, err := srv.store.CreateWorkspace(models.WorkspaceCreate{Name: name})
+	if err != nil {
+		t.Fatalf("CreateWorkspace: %v", err)
+	}
+	col, err := srv.store.CreateCollection(ws.ID, models.CollectionCreate{Name: "Tasks", Schema: `{"fields":[]}`})
+	if err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	item, err := srv.store.CreateItem(ws.ID, col.ID, models.ItemCreate{Title: "Doc", Content: "v1", Fields: `{}`})
+	if err != nil {
+		t.Fatalf("CreateItem: %v", err)
+	}
+	v2 := "v2"
+	if _, err := srv.store.UpdateItem(item.ID, models.ItemUpdate{Content: &v2, LastModifiedBy: "user", Source: "web"}); err != nil {
+		t.Fatalf("seed v2: %v", err)
+	}
+	versions, err := srv.store.ListItemVersionsResolved(item.ID, "v2")
+	if err != nil {
+		t.Fatalf("ListItemVersionsResolved: %v", err)
+	}
+	var v1VersionID string
+	for _, v := range versions {
+		if v.Content == "v1" {
+			v1VersionID = v.ID
+			break
+		}
+	}
+	if v1VersionID == "" {
+		t.Fatalf("no version resolving to v1")
+	}
+	return &restoreCollabFixture{srv: srv, ts: ts, wsSlug: ws.Slug, itemID: item.ID, itemSlug: item.Slug, v1VersionID: v1VersionID}
+}
+
+// dialReady dials the collab WS and blocks until the initial control frame (the
+// post-replay op_log_cursor, sent AFTER addConn) proves the conn is registered.
+func (f *restoreCollabFixture) dialReady(t *testing.T) *websocket.Conn {
+	t.Helper()
+	conn, resp, err := dialCollab(t, f.ts.URL, f.itemID, nil, "")
+	if err != nil {
+		status := ""
+		if resp != nil {
+			status = resp.Status
+		}
+		t.Fatalf("dialCollab: %v (%s)", err, status)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	_ = conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+	if _, _, rerr := conn.ReadMessage(); rerr != nil {
+		t.Fatalf("waiting for initial collab frame: %v", rerr)
+	}
+	_ = conn.SetReadDeadline(time.Time{})
+	return conn
+}
+
+func (f *restoreCollabFixture) restore(t *testing.T) *httptest.ResponseRecorder {
+	t.Helper()
+	return doRequest(f.srv, "POST",
+		"/api/v1/workspaces/"+f.wsSlug+"/items/"+f.itemSlug+"/versions/"+f.v1VersionID+"/restore", nil)
+}
+
+func assertItemContent(t *testing.T, srv *Server, itemID, want string) {
+	t.Helper()
+	got, err := srv.store.GetItem(itemID)
+	if err != nil {
+		t.Fatalf("GetItem: %v", err)
+	}
+	if got.Content != want {
+		t.Fatalf("items.content: want %q, got %q", want, got.Content)
+	}
+}
+
+func assertOpLogEmpty(t *testing.T, srv *Server, itemID string) {
+	t.Helper()
+	if _, ok, err := srv.store.MaxOpLogID(itemID); err != nil || ok {
+		t.Fatalf("op-log must be pruned/empty (ok=%v, err=%v)", ok, err)
+	}
+}
+
+// assertGotForceRefresh drains conn until it either receives a force_refresh
+// control frame (pass) or the conn closes without one (fail).
+func assertGotForceRefresh(t *testing.T, conn *websocket.Conn) {
+	t.Helper()
+	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	saw := false
+	for {
+		mt, data, err := conn.ReadMessage()
+		if err != nil {
+			break // conn closed
+		}
+		if mt == websocket.TextMessage {
+			var ctl struct {
+				Type string `json:"type"`
+			}
+			if json.Unmarshal(data, &ctl) == nil && ctl.Type == "force_refresh" {
+				saw = true
+			}
+		}
+	}
+	if !saw {
+		t.Fatal("peer did not receive a force_refresh frame before the conn closed")
+	}
+}
+
+// TestRestoreLiveRoomPrunesAndReseeds is the BUG-2264 prune+reseed happy path: a
+// restore under a live collab room writes items.content=restored, prunes the
+// per-item op-log, sets the stale-flush boundary, and force-refreshes every peer
+// so they rebuild from the restored content (all peers converge; unflushed edits
+// are discarded — restore semantics).
+func TestRestoreLiveRoomPrunesAndReseeds(t *testing.T) {
+	f := newRestoreCollabFixture(t, "LiveRestore")
+	conn := f.dialReady(t)
+	// A peer op grows the op-log so we can prove the prune wipes it + boundary.
+	if _, err := f.srv.store.AppendYjsUpdate(f.itemID, []byte{0x00, 0x01}, "1"); err != nil {
+		t.Fatalf("seed op: %v", err)
+	}
+	maxBefore, _, _ := f.srv.store.MaxOpLogID(f.itemID)
+
+	rr := f.restore(t)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("restore: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	assertItemContent(t, f.srv, f.itemID, "v1")
+	assertOpLogEmpty(t, f.srv, f.itemID)
+	if b, ok := f.srv.collab.RestoreBoundary(f.itemID); !ok || b <= maxBefore {
+		t.Fatalf("restore boundary must be > pre-prune MAX %d; got %d ok=%v", maxBefore, b, ok)
+	}
+	// The op-log-id boundary was also stamped DURABLY (survives restart) with the
+	// same pre-prune MAX+1, atomically in the restore tx.
+	if db, ok, derr := f.srv.store.ItemRestoreBoundaryOpID(f.itemID); derr != nil || !ok || db <= maxBefore {
+		t.Fatalf("durable restore_boundary_op_id must be > pre-prune MAX %d; got %d ok=%v err=%v", maxBefore, db, ok, derr)
+	}
+	assertGotForceRefresh(t, conn)
+}
+
+// TestRestorePrunesStalePeerOpAndFencesStaleCursor is the BUG-2264 P1b guard:
+// after the prune the op-log is empty, and an in-flight stale collab-snapshot —
+// whether it carries the pruned peer op's cursor OR cursor 0 — is fenced by the
+// pre-prune-MAX+1 boundary and cannot clobber the restored items.content.
+func TestRestorePrunesStalePeerOpAndFencesStaleCursor(t *testing.T) {
+	f := newRestoreCollabFixture(t, "R1PeerOp")
+	conn := f.dialReady(t)
+	// A concurrent peer op grows MAX(op-log) to nID (the false-positive the old
+	// "MAX grew" heuristic tripped on; prune+reseed doesn't care — it prunes it).
+	nID, err := f.srv.store.AppendYjsUpdate(f.itemID, []byte{0x00, 0x01}, "1")
+	if err != nil {
+		t.Fatalf("seed peer op: %v", err)
+	}
+
+	rr := f.restore(t)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("restore: %d %s", rr.Code, rr.Body.String())
+	}
+	assertItemContent(t, f.srv, f.itemID, "v1")
+	assertOpLogEmpty(t, f.srv, f.itemID)
+	assertGotForceRefresh(t, conn)
+
+	// Stale snapshot at the pruned peer op's cursor → rejected, no clobber.
+	rr = doRequest(f.srv, "PATCH",
+		"/api/v1/workspaces/"+f.wsSlug+"/items/"+f.itemSlug+"?source=collab-snapshot",
+		map[string]interface{}{"content": "stale pre-restore", "op_log_cursor": nID})
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("stale-cursor flush (cursor=%d) must be 409, got %d: %s", nID, rr.Code, rr.Body.String())
+	}
+	assertItemContent(t, f.srv, f.itemID, "v1")
+
+	// cursor=0 must ALSO be fenced (the empty-op-log MIN gate alone accepts 0).
+	rr = doRequest(f.srv, "PATCH",
+		"/api/v1/workspaces/"+f.wsSlug+"/items/"+f.itemSlug+"?source=collab-snapshot",
+		map[string]interface{}{"content": "stale cursor zero", "op_log_cursor": int64(0)})
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("stale cursor=0 flush must be 409, got %d: %s", rr.Code, rr.Body.String())
+	}
+	assertItemContent(t, f.srv, f.itemID, "v1")
+}
+
+// TestRestoreNoRoomStillPrunesAndWrites: with collab configured but no live room,
+// the restore still writes items.content=restored and prunes any stale op-log, so
+// a later cold connect lazy-seeds the restored content.
+func TestRestoreNoRoomStillPrunesAndWrites(t *testing.T) {
+	f := newRestoreCollabFixture(t, "NoRoom") // no dialReady → no live room
+	if _, err := f.srv.store.AppendYjsUpdate(f.itemID, []byte{0x00, 0x01}, "1"); err != nil {
+		t.Fatalf("seed stale op: %v", err)
+	}
+	rr := f.restore(t)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("restore: %d %s", rr.Code, rr.Body.String())
+	}
+	assertItemContent(t, f.srv, f.itemID, "v1")
+	assertOpLogEmpty(t, f.srv, f.itemID)
+}
+
+// dialContentSeq dials the collab WS announcing ?content_seq=<seq> (the
+// items.content generation the client's Y.Doc was seeded from).
+func (f *restoreCollabFixture) dialContentSeq(t *testing.T, seq int64) *websocket.Conn {
+	t.Helper()
+	target := f.itemID + "?content_seq=" + strconv.FormatInt(seq, 10)
+	conn, resp, err := dialCollab(t, f.ts.URL, target, nil, "")
+	if err != nil {
+		status := ""
+		if resp != nil {
+			status = resp.Status
+		}
+		t.Fatalf("dialCollab(content_seq=%d): %v (%s)", seq, err, status)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	return conn
+}
+
+// assertNoForceRefresh reads the first frame and fails if it is a force_refresh
+// (a normal Join's first frame is the op_log_cursor control, not force_refresh).
+func assertNoForceRefresh(t *testing.T, conn *websocket.Conn) {
+	t.Helper()
+	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	mt, data, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatalf("expected a normal initial frame, got read error: %v", err)
+	}
+	if mt == websocket.TextMessage {
+		var ctl struct {
+			Type string `json:"type"`
+		}
+		if json.Unmarshal(data, &ctl) == nil && ctl.Type == "force_refresh" {
+			t.Fatal("current-generation client was wrongly force_refreshed")
+		}
+	}
+}
+
+// TestRestoreForceRefreshesStaleSeedOnJoin is the BUG-2264 stale-SEED guard
+// (additional-P1 + Codex-xhigh): after a restore, a client that connects with a
+// Y.Doc seeded from PRE-restore items.content — a cursor-0 peer whose
+// force_refresh frame was lost, or a browser that GET items.content before the
+// restore and joins after the prune — announces a ?content_seq below the
+// restored generation and must be force_refreshed BEFORE its on-open state push
+// can resurrect the stale document. A client that seeded at (or after) the
+// restored generation must join normally.
+func TestRestoreForceRefreshesStaleSeedOnJoin(t *testing.T) {
+	f := newRestoreCollabFixture(t, "StaleSeed")
+
+	// The seq a pre-restore client would have seeded from (item is at v2).
+	pre, err := f.srv.store.GetItem(f.itemID)
+	if err != nil {
+		t.Fatalf("GetItem (pre): %v", err)
+	}
+	preSeq := pre.Seq
+
+	rr := f.restore(t)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("restore: %d %s", rr.Code, rr.Body.String())
+	}
+	assertItemContent(t, f.srv, f.itemID, "v1")
+
+	lrs, ok := f.srv.collab.LastRestoreSeq(f.itemID)
+	if !ok || lrs <= preSeq {
+		t.Fatalf("lastRestoreSeq must be > pre-restore seq %d; got %d ok=%v", preSeq, lrs, ok)
+	}
+
+	// The DURABLE boundary (items.last_restore_seq) was stamped atomically in the
+	// restore tx with the SAME seq — this is what survives a server restart.
+	durable, hasDurable, derr := f.srv.store.ItemLastRestoreSeq(f.itemID)
+	if derr != nil || !hasDurable {
+		t.Fatalf("durable last_restore_seq must be set after restore (ok=%v, err=%v)", hasDurable, derr)
+	}
+	if durable != lrs {
+		t.Fatalf("durable last_restore_seq %d must equal the in-memory boundary %d", durable, lrs)
+	}
+
+	// A stale-seed client (content_seq predates the restore) is force_refreshed.
+	staleConn := f.dialContentSeq(t, preSeq)
+	assertGotForceRefresh(t, staleConn)
+
+	// A current-seed client (content_seq == restored generation) joins normally.
+	freshConn := f.dialContentSeq(t, lrs)
+	assertNoForceRefresh(t, freshConn)
 }

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -2063,7 +2063,15 @@ func (s *Store) updateItemWithParentLinkOnce(
 			source = "web"
 		}
 
-		forceVersion := input.Title != nil && *input.Title != existing.Title
+		// ForceVersion (e.g. a version restore) and a title change both bypass
+		// the per-(actor, source) throttle so a bracketing snapshot is always
+		// written when content changes — otherwise a throttled write would move
+		// items.content forward with no version anchoring the reverse-patch chain.
+		// NOTE(BUG-2270): ForceVersion can mint same-second versions; item_versions
+		// ordering has no monotonic tie-breaker (second-precision created_at), so
+		// rapid forced versions can resolve out of order. The tie-breaker (a
+		// version sequence, needs a schema migration) is tracked there.
+		forceVersion := input.ForceVersion || (input.Title != nil && *input.Title != existing.Title)
 		shouldVersion := forceVersion
 		if !shouldVersion {
 			shouldVersion, err = s.shouldCreateItemVersion(id, createdBy, source)
@@ -2260,6 +2268,19 @@ func (s *Store) updateItemWithParentLinkOnce(
 		return nil, fmt.Errorf("update item: %w", err)
 	}
 
+	// Durable restore boundary (BUG-2264): stamp last_restore_seq with the seq
+	// this UPDATE just assigned. A second statement (not a SET on the UPDATE
+	// above) because seq is computed there via nextWorkspaceSeqSubquery, so
+	// `last_restore_seq = seq` in the same statement would read the OLD seq; a
+	// follow-up UPDATE in the SAME tx reads the freshly-committed-to-row value.
+	// Atomic with the content write + op-log prune (all in this one tx), so the
+	// boundary can never be torn from the restore it fences.
+	if input.MarkRestoreBoundary {
+		if _, err = tx.Exec(s.q("UPDATE items SET last_restore_seq = seq WHERE id = ?"), id); err != nil {
+			return nil, fmt.Errorf("stamp restore boundary: %w", err)
+		}
+	}
+
 	// Record a structured status transition when the fields blob was part
 	// of this update AND the `status` value actually changed. Written in
 	// the same tx as the item UPDATE so the transition log can never
@@ -2354,11 +2375,26 @@ func (s *Store) updateItemWithParentLinkOnce(
 		}
 	}
 
+	// Read the updated row WITHIN the tx, BEFORE commit (BUG-2264). A
+	// post-commit re-read (s.GetItem) can fail AFTER a successful commit —
+	// making a committed update look failed to the caller (version-restore
+	// treats that as "roll back the room" and diverges) — and can observe a
+	// concurrent writer's later seq. getItemTx sees exactly this tx's own write
+	// (identical SQL to GetItem); a read failure here rolls the tx back cleanly,
+	// so a nil error is an unambiguous "this update committed, with this seq".
+	updated, err := s.getItemTx(tx, id)
+	if err != nil {
+		return nil, err
+	}
+	if updated == nil {
+		return nil, nil
+	}
+
 	if err := tx.Commit(); err != nil {
 		return nil, err
 	}
 
-	return s.GetItem(id)
+	return updated, nil
 }
 
 // DeleteItem soft-deletes the item by stamping deleted_at and bumping

--- a/internal/store/items_collab_versions_test.go
+++ b/internal/store/items_collab_versions_test.go
@@ -365,8 +365,6 @@ func TestCollabSnapshotNoCursorLeavesWatermark(t *testing.T) {
 	}
 }
 
-// TestMinAndMaxOpLogIDEmptyAndPopulated covers the two store helpers
-// the resume-cursor protocol depends on.
 func TestMinAndMaxOpLogIDEmptyAndPopulated(t *testing.T) {
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Min Max Test")

--- a/internal/store/items_test.go
+++ b/internal/store/items_test.go
@@ -2509,6 +2509,87 @@ func TestItemVersionCreation(t *testing.T) {
 	}
 }
 
+// TestItemVersionForceBypassesThrottle guards the ForceVersion flag (BUG-2264):
+// a version restore sets it so a snapshot is ALWAYS taken when content changes,
+// even on a repeat same-(actor, source) write inside the 1h throttle window.
+// Without it the throttle skips the snapshot, moving items.content forward with
+// no version anchoring the reverse-patch chain (and losing the restore's undo
+// point).
+func TestItemVersionForceBypassesThrottle(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+
+	item := createTestItem(t, s, ws.ID, col.ID, "My Task", "v0")
+
+	// Seed a most-recent version under a DIFFERENT (actor, source) so the next
+	// user/web write is guaranteed to snapshot (actor/source change bypasses
+	// the throttle) — this pins the most-recent version's attribution.
+	a := "a"
+	if _, err := s.UpdateItem(item.ID, models.ItemUpdate{Content: &a, LastModifiedBy: "agent", Source: "cli"}); err != nil {
+		t.Fatalf("UpdateItem a: %v", err)
+	}
+	// user/web write: actor/source changed from (agent, cli) → creates a version.
+	// The most-recent version is now (user, web).
+	b := "b"
+	if _, err := s.UpdateItem(item.ID, models.ItemUpdate{Content: &b, LastModifiedBy: "user", Source: "web"}); err != nil {
+		t.Fatalf("UpdateItem b: %v", err)
+	}
+	before, err := s.ListItemVersions(item.ID)
+	if err != nil {
+		t.Fatalf("ListItemVersions before: %v", err)
+	}
+
+	// A second user/web content write inside the throttle window is suppressed —
+	// the exact throttle a plain (non-forced) restore would hit.
+	c := "c"
+	if _, err := s.UpdateItem(item.ID, models.ItemUpdate{Content: &c, LastModifiedBy: "user", Source: "web"}); err != nil {
+		t.Fatalf("UpdateItem c: %v", err)
+	}
+	throttled, err := s.ListItemVersions(item.ID)
+	if err != nil {
+		t.Fatalf("ListItemVersions throttled: %v", err)
+	}
+	if len(throttled) != len(before) {
+		t.Fatalf("expected throttled same-(actor,source) write to add no version: had %d, now %d", len(before), len(throttled))
+	}
+
+	// The same write WITH ForceVersion must bypass the throttle and snapshot.
+	d := "d"
+	if _, err := s.UpdateItem(item.ID, models.ItemUpdate{
+		Content:        &d,
+		LastModifiedBy: "user",
+		Source:         "web",
+		ForceVersion:   true,
+		ChangeSummary:  "Restored from version …",
+	}); err != nil {
+		t.Fatalf("UpdateItem forced: %v", err)
+	}
+	forced, err := s.ListItemVersions(item.ID)
+	if err != nil {
+		t.Fatalf("ListItemVersions forced: %v", err)
+	}
+	if len(forced) != len(throttled)+1 {
+		t.Fatalf("expected ForceVersion to add exactly one version despite throttle: had %d, now %d", len(throttled), len(forced))
+	}
+
+	// ForceVersion must NOT create a version when content is unchanged (it is
+	// only consulted inside the content-changed branch).
+	if _, err := s.UpdateItem(item.ID, models.ItemUpdate{
+		Content:      &d, // identical to current content
+		ForceVersion: true,
+	}); err != nil {
+		t.Fatalf("UpdateItem forced no-op: %v", err)
+	}
+	noop, err := s.ListItemVersions(item.ID)
+	if err != nil {
+		t.Fatalf("ListItemVersions noop: %v", err)
+	}
+	if len(noop) != len(forced) {
+		t.Fatalf("expected ForceVersion with unchanged content to add no version: had %d, now %d", len(forced), len(noop))
+	}
+}
+
 func TestWorkspaceHasAgentActivity(t *testing.T) {
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Connect Banner")

--- a/internal/store/migrations/075_item_last_restore_seq.sql
+++ b/internal/store/migrations/075_item_last_restore_seq.sql
@@ -1,0 +1,26 @@
+-- Add last_restore_seq: the durable per-item restore boundary (BUG-2264).
+-- Records the item.seq assigned by the most recent version RESTORE. Version
+-- restore prunes the per-item Yjs op-log and reseeds peers from the restored
+-- items.content; a client whose Y.Doc seeded from PRE-restore content
+-- (announced as ?content_seq= on WS connect) must be force_refreshed on Join so
+-- it can't re-push the stale document. That fence was in-memory only, so a
+-- server RESTART with a surviving cursor-0 pre-restore browser tab wasn't fenced
+-- on reconnect. Persisting the boundary here makes the Join fence survive a
+-- restart: the restore writes this column in the SAME transaction as the
+-- content write + op-log prune (atomic), and Join reads it from the row.
+--
+-- NOTE: no `IF NOT EXISTS` — SQLite's ALTER TABLE ADD COLUMN rejects it.
+-- Nullable with no default; NULL = never restored (no fence), so no backfill is
+-- needed and existing items keep working unchanged.
+ALTER TABLE items ADD COLUMN last_restore_seq INTEGER;
+
+-- restore_boundary_op_id: the DURABLE op-log-id restore boundary — pre-prune
+-- MAX(item_yjs_updates.id)+1 at the most recent restore. The collab-snapshot
+-- flush gate rejects a PATCH whose op_log_cursor is below this boundary (a
+-- pre-restore Y.Doc). That gate used the IN-MEMORY RoomManager.RestoreBoundary,
+-- so after a server restart a surviving pre-restore tab's stale flush wasn't
+-- fenced. Persisting it (stamped in the restore's own tx, atomic with the
+-- content write + op-log prune) lets the gate read it from the row after a
+-- restart. op-log ids are monotonic across prunes, so this value stays valid.
+-- Nullable; NULL = never restored (no fence).
+ALTER TABLE items ADD COLUMN restore_boundary_op_id INTEGER;

--- a/internal/store/pgmigrations/053_item_last_restore_seq.sql
+++ b/internal/store/pgmigrations/053_item_last_restore_seq.sql
@@ -1,0 +1,11 @@
+-- Add last_restore_seq: the durable per-item restore boundary (BUG-2264).
+-- Postgres mirror of migrations/075_item_last_restore_seq.sql. BIGINT because
+-- seq is a workspace-monotonic counter that grows unbounded; NULL = never
+-- restored, so no backfill is required. See the SQLite migration for the full
+-- rationale (durable Join fence that survives a server restart).
+ALTER TABLE items ADD COLUMN IF NOT EXISTS last_restore_seq BIGINT;
+
+-- restore_boundary_op_id: DURABLE op-log-id restore boundary (pre-prune
+-- MAX(op-log.id)+1). Postgres mirror; makes the collab-snapshot flush gate's
+-- restore boundary survive a restart. See the SQLite migration for rationale.
+ALTER TABLE items ADD COLUMN IF NOT EXISTS restore_boundary_op_id BIGINT;

--- a/internal/store/yjs_updates.go
+++ b/internal/store/yjs_updates.go
@@ -228,6 +228,91 @@ func (s *Store) MaxOpLogID(itemID string) (int64, bool, error) {
 	return v.Int64, true, nil
 }
 
+// ItemLastRestoreSeq returns items.last_restore_seq — the item.seq stamped by
+// the most recent version RESTORE (BUG-2264), or (0, false) when the item has
+// never been restored (NULL column) or is missing. This is the DURABLE restore
+// boundary the collab Join fence reads to force_refresh a client whose
+// ?content_seq seed predates the last restore; unlike the in-memory
+// lastRestoreSeqs fast-path, it survives a server restart.
+func (s *Store) ItemLastRestoreSeq(itemID string) (int64, bool, error) {
+	if itemID == "" {
+		return 0, false, errors.New("ItemLastRestoreSeq: itemID is required")
+	}
+	query := s.dialect.Rebind(`SELECT last_restore_seq FROM items WHERE id = ?`)
+	var v sql.NullInt64
+	if err := s.db.QueryRow(query, itemID).Scan(&v); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return 0, false, nil
+		}
+		return 0, false, fmt.Errorf("item last restore seq: %w", err)
+	}
+	if !v.Valid {
+		return 0, false, nil
+	}
+	return v.Int64, true, nil
+}
+
+// StampRestoreBoundaryOpIDTx sets items.restore_boundary_op_id INSIDE the
+// caller's transaction (BUG-2264) — the DURABLE counterpart of the in-memory
+// RoomManager.RestoreBoundary. Version-restore stamps it with pre-prune
+// MAX(op-log.id)+1 in the SAME tx as the op-log wipe + content write, so the
+// collab-snapshot flush gate can reject a stale pre-restore flush even after a
+// server restart (when the in-memory boundary is gone). op-log ids are monotonic
+// across prunes, so the stored value never falsely rejects a genuine
+// post-restore flush.
+func (s *Store) StampRestoreBoundaryOpIDTx(tx *sql.Tx, itemID string, boundary int64) error {
+	if tx == nil {
+		return errors.New("StampRestoreBoundaryOpIDTx: tx is required")
+	}
+	if itemID == "" {
+		return errors.New("StampRestoreBoundaryOpIDTx: itemID is required")
+	}
+	query := s.dialect.Rebind(`UPDATE items SET restore_boundary_op_id = ? WHERE id = ?`)
+	if _, err := tx.Exec(query, boundary, itemID); err != nil {
+		return fmt.Errorf("stamp restore boundary op id: %w", err)
+	}
+	return nil
+}
+
+// SetItemRestoreBoundaryOpID is the non-transactional setter for
+// items.restore_boundary_op_id. Production stamps the boundary atomically inside
+// the restore tx via StampRestoreBoundaryOpIDTx; this standalone form exists for
+// callers/tests that set it outside a restore tx (e.g. simulating the
+// post-restart state — durable column present, in-memory boundary absent).
+func (s *Store) SetItemRestoreBoundaryOpID(itemID string, boundary int64) error {
+	if itemID == "" {
+		return errors.New("SetItemRestoreBoundaryOpID: itemID is required")
+	}
+	query := s.dialect.Rebind(`UPDATE items SET restore_boundary_op_id = ? WHERE id = ?`)
+	if _, err := s.db.Exec(query, boundary, itemID); err != nil {
+		return fmt.Errorf("set restore boundary op id: %w", err)
+	}
+	return nil
+}
+
+// ItemRestoreBoundaryOpID returns items.restore_boundary_op_id — the DURABLE
+// op-log-id restore boundary (BUG-2264), or (0, false) when the item has never
+// been restored (NULL) or is missing. The collab-snapshot flush gate reads it
+// when the in-memory RoomManager.RestoreBoundary misses (after a restart), so a
+// surviving pre-restore tab's stale flush is still fenced.
+func (s *Store) ItemRestoreBoundaryOpID(itemID string) (int64, bool, error) {
+	if itemID == "" {
+		return 0, false, errors.New("ItemRestoreBoundaryOpID: itemID is required")
+	}
+	query := s.dialect.Rebind(`SELECT restore_boundary_op_id FROM items WHERE id = ?`)
+	var v sql.NullInt64
+	if err := s.db.QueryRow(query, itemID).Scan(&v); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return 0, false, nil
+		}
+		return 0, false, fmt.Errorf("item restore boundary op id: %w", err)
+	}
+	if !v.Valid {
+		return 0, false, nil
+	}
+	return v.Int64, true, nil
+}
+
 // GetItemContentFlushedOpLogID returns the value of
 // items.content_flushed_op_log_id for an item — the highest op-log
 // id known to be reflected in items.content, or (0, false) if the
@@ -405,4 +490,61 @@ func (s *Store) PruneYjsUpdatesBefore(itemID string, before time.Time) (int64, e
 		return 0, fmt.Errorf("prune yjs updates (rows affected): %w", err)
 	}
 	return n, nil
+}
+
+// MaxOpLogIDTx is the in-transaction variant of MaxOpLogID. Version-restore
+// (BUG-2264) reads the pre-prune MAX inside the SAME tx as the op-log wipe +
+// content write, so the restore boundary (MAX+1) is captured atomically: a read
+// error rolls the whole restore back (clean failure) instead of the previous
+// out-of-tx fail-open, where a MAX read error silently published boundary 1 and
+// let a stale snapshot carrying any real pre-prune cursor slip through.
+func (s *Store) MaxOpLogIDTx(tx *sql.Tx, itemID string) (int64, bool, error) {
+	if tx == nil {
+		return 0, false, errors.New("MaxOpLogIDTx: tx is required")
+	}
+	if itemID == "" {
+		return 0, false, errors.New("MaxOpLogIDTx: itemID is required")
+	}
+	query := s.dialect.Rebind(`SELECT MAX(id) FROM item_yjs_updates WHERE item_id = ?`)
+	var v sql.NullInt64
+	if err := tx.QueryRow(query, itemID).Scan(&v); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return 0, false, nil
+		}
+		return 0, false, fmt.Errorf("max op-log id (tx): %w", err)
+	}
+	if !v.Valid {
+		return 0, false, nil
+	}
+	return v.Int64, true, nil
+}
+
+// PruneItemOpLogTx deletes an item's ENTIRE op-log inside the caller's
+// transaction. Used by version-restore (BUG-2264): the restore's canonical
+// items.content write, its "Restored from…" version row, AND the op-log wipe
+// must be one atomic unit — a commit-then-prune (or prune-then-commit) split
+// leaves a divergent state on any failure (restored content + a stale op-log,
+// or a wiped op-log + unchanged content that a cold connect then lazy-seeds
+// wrong). Running the DELETE in UpdateItem's own tx (via its precheck hook)
+// means a failed update rolls the prune back too, so the three move together
+// or not at all (Codex xhigh [P1]).
+//
+// Wipes every row (no cutoff): a restore makes the old version canonical and
+// discards all in-flight collaborative state, so nothing in the op-log should
+// survive to be replayed. Safe as a full wipe for the same reason the
+// schema-rebuild path is (yjs_updates.go's prefix-prune caveat is about
+// deleting a PREFIX while keeping a dependent suffix — deleting everything has
+// no dangling causal references).
+func (s *Store) PruneItemOpLogTx(tx *sql.Tx, itemID string) error {
+	if tx == nil {
+		return errors.New("PruneItemOpLogTx: tx is required")
+	}
+	if itemID == "" {
+		return errors.New("PruneItemOpLogTx: itemID is required")
+	}
+	query := s.dialect.Rebind(`DELETE FROM item_yjs_updates WHERE item_id = ?`)
+	if _, err := tx.Exec(query, itemID); err != nil {
+		return fmt.Errorf("prune item op-log in tx: %w", err)
+	}
+	return nil
 }

--- a/web/e2e/version-restore-collab.spec.ts
+++ b/web/e2e/version-restore-collab.spec.ts
@@ -1,0 +1,165 @@
+import { test, expect } from './fixtures';
+import { browserLogin, EDITOR_SELECTOR, SYNCED_BADGE_SELECTOR } from './lib/collab-helpers';
+
+/**
+ * Version-restore under live collab (BUG-2264).
+ *
+ * The version-restore handler used to write items.content directly,
+ * bypassing the Yjs collab applier. Under a live co-editing session the
+ * editor's Y.Doc still held the PRE-restore document, so the next
+ * collab-snapshot flush PATCHed that stale markdown back over the
+ * restored content — silently undoing the restore.
+ *
+ * The fix routes the restore's content through the same applier path as
+ * a normal content PATCH (server/handlers_item_versions.go): a connected
+ * client applies the restored markdown into the shared Y.Doc (propagating
+ * to all peers + the op-log), with a plain items.content write only when
+ * no collab room is live.
+ *
+ * This spec drives the real chain through the embedded UI:
+ *
+ *   seed v1 → open live editor → type v2 (creates a version) → restore v1
+ *   while the room is live → type a further edit → assert items.content
+ *   reflects the restored v1 (+ the new edit) and was NOT reverted to v2.
+ *
+ * Under the bug, the restore leaves the live Y.Doc holding v2, so both
+ * the immediate editor assertion (v2 still present) and the final
+ * persisted-content assertion (v2 leaked back) go red.
+ *
+ * Determinism notes (mirrors collab-persistence.spec.ts):
+ *   - We wait for the "Synced" collab badge before typing so the Y.Doc
+ *     binding is live.
+ *   - We register the collab-snapshot flush wait (the 5s idle PATCH that
+ *     writes items.content) BEFORE each edit and scope it to a response
+ *     body carrying the marker, so assertions can't race the write.
+ *   - The restore POST blocks server-side until the connected client acks
+ *     the applier request, so by the time it resolves the live Y.Doc has
+ *     already been reconciled.
+ *
+ * Why an in-page login (browserLogin): the collab WebSocket handshake
+ * can't carry an Authorization header, so the server authenticates it
+ * from a same-UA session cookie. See collab-helpers.ts.
+ */
+
+test('restoring a version under live collab is not clobbered by the next flush (BUG-2264)', async ({
+	page,
+	fixture,
+	request
+}, testInfo) => {
+	// The collab chain is viewport-agnostic; one project is enough and
+	// running both doubles WS load on the single test instance for no
+	// added coverage.
+	test.skip(
+		testInfo.project.name !== 'desktop-chromium',
+		'version-restore collab is viewport-agnostic; one project is enough'
+	);
+	// Two 5s idle flushes + the WS handshake + the applier round-trip need
+	// well over the 30s default on a busy CI runner.
+	test.setTimeout(90_000);
+
+	const ws = fixture.workspaceSlug;
+	const headers = {
+		Authorization: `Bearer ${fixture.apiToken}`,
+		'Content-Type': 'application/json'
+	};
+	const ts = Date.now();
+	const alpha = `alpha-restore-${ts}`;
+	const beta = `beta-super-${ts}`;
+	const gamma = `gamma-after-${ts}`;
+
+	// Seed a doc whose initial (v1) body is `alpha` — the state we later
+	// restore back to after typing over it.
+	const createResp = await request.post(`/api/v1/workspaces/${ws}/collections/docs/items`, {
+		headers,
+		data: { title: `Version restore collab ${ts}`, content: alpha }
+	});
+	if (!createResp.ok())
+		throw new Error(`doc create failed (${createResp.status()}): ${await createResp.text()}`);
+	const { slug } = (await createResp.json()) as { id: string; slug: string };
+
+	await browserLogin(page);
+	await page.goto(`/${fixture.adminUsername}/${ws}/docs/${slug}`);
+
+	const editor = page.locator(EDITOR_SELECTOR);
+	await expect(editor).toBeVisible();
+	// Y.Doc hydrated from items.content (the seeded v1).
+	await expect(editor).toContainText(alpha);
+	// Schema-version handshake complete — typing before this races the binding.
+	await expect(page.locator(SYNCED_BADGE_SELECTOR)).toBeVisible();
+
+	// Type `beta` — the v2 edit that supersedes v1. Its collab-snapshot
+	// flush persists "alpha beta" and (first content change → no throttle)
+	// creates a version whose resolved content is the pre-edit v1.
+	const betaFlushed = page.waitForResponse(
+		async (r) =>
+			r.url().includes('source=collab-snapshot') &&
+			r.request().method() === 'PATCH' &&
+			r.ok() &&
+			(await r.text()).includes(beta),
+		{ timeout: 30_000 }
+	);
+	await editor.click();
+	await page.keyboard.press('Control+End');
+	await page.keyboard.type(' ' + beta);
+	await expect(editor).toContainText(beta);
+	await betaFlushed;
+
+	// Find the version snapshot holding the pre-beta (v1) state: resolved
+	// content contains alpha but not beta.
+	const versionsResp = await request.get(
+		`/api/v1/workspaces/${ws}/items/${slug}/versions`,
+		{ headers }
+	);
+	expect(versionsResp.ok()).toBeTruthy();
+	const versions = (await versionsResp.json()) as Array<{ id: string; content: string }>;
+	const v1 = versions.find((v) => v.content.includes(alpha) && !v.content.includes(beta));
+	expect(v1, 'expected a version snapshot holding the pre-edit (v1) content').toBeTruthy();
+
+	// Restore v1 while the collab room is LIVE. The POST blocks until the
+	// connected client applies the restored markdown into its Y.Doc via the
+	// applier protocol (the BUG-2264 fix). Under the bug this wrote
+	// items.content directly and the still-live Y.Doc (holding beta) would
+	// overwrite it on the next flush.
+	const restoreResp = await request.post(
+		`/api/v1/workspaces/${ws}/items/${slug}/versions/${v1!.id}/restore`,
+		{ headers }
+	);
+	expect(restoreResp.ok()).toBeTruthy();
+
+	// The restore endpoint must return the RESTORED body synchronously — the
+	// UI adopts this response immediately. A metadata-only write on the
+	// applier-ack path would echo the still-pre-restore content here.
+	const restored = (await restoreResp.json()) as { content: string };
+	expect(restored.content).toContain(alpha);
+	expect(restored.content).not.toContain(beta);
+
+	// The applier reconciled the live editor: v1 is back, v2 is gone. Under
+	// the bug the editor's Y.Doc would still hold beta here.
+	await expect(editor).toContainText(alpha);
+	await expect(editor).not.toContainText(beta, { timeout: 15_000 });
+
+	// Subsequent edit + flush. If the restore had NOT reconciled the Y.Doc,
+	// this flush would persist the stale beta back into items.content.
+	const gammaFlushed = page.waitForResponse(
+		async (r) =>
+			r.url().includes('source=collab-snapshot') &&
+			r.request().method() === 'PATCH' &&
+			r.ok() &&
+			(await r.text()).includes(gamma),
+		{ timeout: 30_000 }
+	);
+	await editor.click();
+	await page.keyboard.press('Control+End');
+	await page.keyboard.type(' ' + gamma);
+	await expect(editor).toContainText(gamma);
+	await gammaFlushed;
+
+	// The persisted body reflects the restored v1 (+ the new edit) and was
+	// NOT reverted to v2.
+	const finalResp = await request.get(`/api/v1/workspaces/${ws}/items/${slug}`, { headers });
+	expect(finalResp.ok()).toBeTruthy();
+	const finalItem = (await finalResp.json()) as { content: string };
+	expect(finalItem.content).toContain(alpha);
+	expect(finalItem.content).toContain(gamma);
+	expect(finalItem.content).not.toContain(beta);
+});

--- a/web/src/lib/collab/wsProvider.svelte.ts
+++ b/web/src/lib/collab/wsProvider.svelte.ts
@@ -198,6 +198,18 @@ export interface CollabProviderOptions {
 	 * leaving the editor on stale state.
 	 */
 	onForceRefresh?: ForceRefreshHandler;
+	/**
+	 * The items.content generation (`item.seq`) this provider's Y.Doc was
+	 * SEEDED from (BUG-2264). Announced to the server as `?content_seq=<seq>`
+	 * on every (re)connect. If it predates the item's most recent version
+	 * RESTORE, the server force_refreshes this connection before its on-open
+	 * state push can resurrect the stale pre-restore document. Constant for the
+	 * provider's lifetime (the seed doesn't change under it); the force_refresh
+	 * recovery refetches a fresh item + rebuilds the provider with the new seq.
+	 * Omitted / 0 falls through to legacy behaviour (server can't fence a stale
+	 * seed) — no regression.
+	 */
+	contentSeq?: number;
 }
 
 export class CollabProvider {
@@ -298,6 +310,11 @@ export class CollabProvider {
 	private readonly WebSocketImpl: typeof WebSocket;
 	private readonly onApplierRequest?: ApplierRequestHandler;
 	private readonly onForceRefresh?: ForceRefreshHandler;
+	/**
+	 * items.content generation the Y.Doc was seeded from, announced as
+	 * `?content_seq=` on every (re)connect (BUG-2264). Constant per provider.
+	 */
+	private readonly contentSeq: number;
 	private destroyed = false;
 	private reconnectAttempts = 0;
 	private reconnectTimer: ReturnType<typeof setTimeout> | undefined;
@@ -318,6 +335,7 @@ export class CollabProvider {
 		this.WebSocketImpl = options.WebSocketImpl ?? globalThis.WebSocket;
 		this.onApplierRequest = options.onApplierRequest;
 		this.onForceRefresh = options.onForceRefresh;
+		this.contentSeq = options.contentSeq ?? 0;
 		// Restore the per-tab cursor BEFORE the first connect. The
 		// `since=<id>` query string is appended in connect() each
 		// time so a reconnect after some live edits announces a
@@ -1139,9 +1157,17 @@ export class CollabProvider {
 	 * that hard-code the base URL working as-is.
 	 */
 	private connectUrl(): string {
-		if (this.lastOpLogID <= 0) return this.url;
+		// `content_seq` (the items.content generation the Y.Doc was seeded from)
+		// rides alongside `since` on every (re)connect so the server can
+		// force_refresh a connection whose seed predates the last version restore
+		// (BUG-2264). Both are omitted when 0, so test fixtures that hard-code the
+		// base URL and fresh clients with no cursor/seq keep the bare base URL.
+		const params: string[] = [];
+		if (this.lastOpLogID > 0) params.push(`since=${this.lastOpLogID}`);
+		if (this.contentSeq > 0) params.push(`content_seq=${this.contentSeq}`);
+		if (params.length === 0) return this.url;
 		const sep = this.url.includes('?') ? '&' : '?';
-		return `${this.url}${sep}since=${this.lastOpLogID}`;
+		return `${this.url}${sep}${params.join('&')}`;
 	}
 
 	private closeSocket(code: number, reason: string): void {

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -1747,6 +1747,12 @@
 		// active editing. collabKey just changed to this itemId, so item is
 		// the freshly-loaded item for it. Per Codex review.
 		const baseline = untrack(() => (item && item.id === itemId ? item.content ?? '' : ''));
+		// The items.content generation this Y.Doc is being seeded from (same
+		// untracked item snapshot as `baseline`). Announced to the server as
+		// ?content_seq= so a restore can force_refresh a connection whose seed
+		// predates it (BUG-2264). Untracked for the same reason as `baseline`:
+		// tracking `item.seq` would rebuild the provider on every seq bump.
+		const seedSeq = untrack(() => (item && item.id === itemId ? item.seq ?? 0 : 0));
 		// Eager, all-tabs seedMd (BUG-1941 follow-up — codex round 2 found
 		// that only the multi-tab-election WINNER got a captured seed via
 		// the lazy-seed effect below; a second tab on the same item, or
@@ -1807,6 +1813,12 @@
 
 		const doc = new Y.Doc();
 		const provider = new CollabProvider(itemId, doc, {
+			// The items.content generation this Y.Doc is seeded from, announced
+			// as ?content_seq= so a version restore can force_refresh this
+			// connection if its seed predates the restore (BUG-2264). The
+			// force_refresh recovery below refetches a fresh item and rebuilds
+			// this provider, so the rebuilt provider announces the new seq.
+			contentSeq: seedSeq,
 			// Designated-applier handler: when a CLI / MCP / API caller
 			// PATCHes content while this tab is connected, the server
 			// asks one tab to apply the markdown via the editor's


### PR DESCRIPTION
## BUG-2264 — version restore didn't reconcile the live Y.Doc

Restoring a version wrote `items.content` but left every connected peer editing a Y.Doc built on the pre-restore op-log. The next collab-snapshot flush then clobbered the restored content back to the pre-restore state.

**Approach: prune + reseed.** A restore makes the old version canonical and discards whatever peers are co-editing — that IS restore semantics — so every peer must converge on the restored content. `handleRestoreItemVersion` now drives `RoomManager.ForceRefreshRoom` under the per-item lock: it freezes inbound persistence, runs the restore commit, publishes the fences, and force-refreshes every peer so each discards its in-memory Y.Doc and rebuilds from `items.content`. This replaces the earlier applier/epoch/watermark routing entirely.

### Hardening (three Codex xhigh review rounds)

- **Atomicity** — the pre-prune `MAX(op-log)`, the `items.content` write, the "Restored from…" version, and the op-log wipe all run in **one** store transaction (`UpdateItemWithPreCheck` + `MaxOpLogIDTx` + `PruneItemOpLogTx`), returning `(MAX, restored seq)`. A failed commit rolls back all of it — no divergent "restored content + stale op-log" and no fail-open boundary on a MAX read error.
- **Unambiguous commit signal** — `UpdateItem` now reads the updated row *inside* the tx (`getItemTx`) before commit instead of a post-commit `GetItem`, so a read failure can't make a committed update look failed and the returned seq is this restore's, not a concurrent writer's.
- **Restore freeze** — conns are paused via a dedicated `rc.frozen` flag (separate from `canWrite`) held before the fallible commit; on failure they're un-frozen and the room is left exactly as it was. Keeping it separate from `canWrite` stops the auth-revalidation loop from thawing the freeze mid-restore or a failed restore promoting a viewer to writable. `pickApplier` and the applier-ack handler also reject frozen conns, so a concurrent external-content PATCH can't falsely succeed against a peer whose restore-dropped sync frames were never persisted.
- **Stale-flush boundary** — pre-prune `MAX+1` (captured in-tx) fences every in-flight snapshot cursor; the collab-snapshot gate runs under the same item lock so no write slips between prune and boundary.
- **force_refresh fan-out deadlock** — each conn is closed by an independent timer so a `writeLoop` wedged in a deadline-free write to a dead peer can't hang the fan-out (and the per-item lock) forever.
- **Stale-SEED clobber** — a client whose Y.Doc seeded from pre-restore `items.content` (a cursor-0 peer whose force_refresh frame was lost, or a browser that GET content before the restore and joins after the prune) would re-push the stale document as a fresh post-boundary op. Closed with a per-item content generation: the client announces the `item.seq` it seeded from (`?content_seq=`) on every (re)connect; Join force_refreshes any connection whose seed predates the last restore. **No `SCHEMA_VERSION` bump.**

### Restart-durability — now closed (both stale vectors)

The two restore fences were in-memory, so a server **restart** with a surviving cursor-0 pre-restore browser tab wasn't fenced on reconnect. Closed durably with two nullable per-item columns (migration `075` SQLite / `053` Postgres), each **stamped inside the restore's own transaction** (atomic with the content write + op-log prune):

- `items.last_restore_seq` (content generation) — the `Join` stale-seed fence reads it via `store.ItemLastRestoreSeq` when the in-memory fast-path misses (after a restart). If that read errors, `Join` fails closed via a **retryable plain close** (not a force_refresh, which would discard the Y.Doc and spin an unbounded refresh loop) — the client reconnects with backoff, Y.Doc intact.
- `items.restore_boundary_op_id` (op-log-id boundary) — the **collab-snapshot flush gate** reads it via `store.ItemRestoreBoundaryOpID` when the in-memory `RestoreBoundary` misses, failing closed (409) on a read error, so a surviving tab's stale HTTP flush is fenced too.

Still **no `SCHEMA_VERSION` bump** — durable columns are not a Y.Doc node-spec change.

### Deferred residuals → BUG-2276

Both narrow; both strictly better than `main` (which clobbered every live-room restore):

1. A **Postgres** commit whose acknowledgement is lost is treated as rolled-back — needs commit-outcome reconciliation. SQLite (the self-host shape) is unaffected.
2. A restore **rollback** racing an in-flight external-content applier ack can drop the ack and retry/fall back — needs the applier flow serialised with the restore under `itemLock` (at a 30s-restore-stall cost). Quadruple-narrow (concurrent external PATCH + exact ack timing + a DB commit error + peer edits in the retry window).

`NOTE(BUG-2270)`: `ForceVersion` can mint same-second version rows; the `item_versions` ordering tie-breaker is tracked there.

### Tests / gates

`go build ./...`, full `go test ./...` (SQLite), `make test-pg` (Postgres — new migration + store change), `go test -race ./internal/collab/`, and `cd web && npm run check` (0 errors) all pass. New coverage: `TestRestoreLiveRoomPrunesAndReseeds`, `TestRestorePrunesStalePeerOpAndFencesStaleCursor`, `TestRestoreNoRoomStillPrunesAndWrites`, `TestRestoreForceRefreshesStaleSeedOnJoin` (now also asserts the durable column), `TestJoinDurableRestoreBoundaryFencesStaleSeedAfterRestart` (fresh manager = post-restart, empty in-memory → durable-column fence), `TestCollabSnapshotRejectedBelowDurableRestoreBoundaryAfterRestart` (durable op-id boundary fences a cursor-0 flush with the in-memory boundary absent), `TestJoinFailsClosedWhenDurableBoundaryReadErrors` (retryable close), `TestForceRefreshRoom`, `TestHandleControlMessageIgnoresAckFromFrozenConn`, plus a Playwright regression spec.

https://claude.ai/code/session_01EZ6yr6pAUFb1uffan912ra
