### PR TITLE
fix(web): item field edits use fields_patch + optimistic concurrency (BUG-2273)

### DIFF
--- a/web/e2e/pane-collection-migration-race.spec.ts
+++ b/web/e2e/pane-collection-migration-race.spec.ts
@@ -288,13 +288,17 @@ test('a collection migration completing after a rapid A->B pane switch refreshes
 		'B should have reloaded post-migration fields (the fix), not stayed on the stale pre-migration snapshot',
 	).toBe('draft-migrated');
 
-	// Now the clobber check: edit an UNRELATED field on B. `updateField()`
-	// serializes B's entire local `fields` object back to the server
-	// (ItemDetail.svelte). Pre-fix, B's local `fields.status` would still
-	// be the stale "draft" (the reload above never happened), so this PATCH
-	// would silently clobber the server's migrated "draft-migrated" back to
-	// "draft". Post-fix, B's local fields already reflect the migration, so
-	// the round-trip preserves it.
+	// Now the clobber check: edit an UNRELATED field on B. Post-BUG-2273,
+	// `updateField()` (ItemDetail.svelte) sends a single-key `fields_patch`
+	// carrying ONLY the edited field plus an `expected_updated_at` OCC token —
+	// not a full-blob replace of B's entire local `fields`. The migrated
+	// `status` is never in the request at all, so it is structurally
+	// un-clobberable: the server merges the one key under its write lock and
+	// leaves every other field (including the freshly-migrated `status`)
+	// untouched. Pre-BUG-2273 this PATCH serialized B's whole local `fields`
+	// object, so a stale local `status` could silently overwrite the migrated
+	// value — the clobber is now impossible by construction, not merely avoided
+	// by the reload above.
 	const categoryRow = pane.locator('.field-row:has(.field-label:text-is("Category"))');
 	const categoryInput = categoryRow.locator('input.field-input');
 	await expect(categoryInput).toHaveValue('pre-migration');
@@ -311,12 +315,19 @@ test('a collection migration completing after a rapid A->B pane switch refreshes
 	const patchRes = await fieldPatch;
 	expect(patchRes.ok()).toBe(true);
 	const patchBody = JSON.parse(patchRes.request().postData() ?? '{}');
-	const patchFields = JSON.parse(patchBody.fields ?? '{}');
+	// BUG-2273: the write is a single-key merge patch, not a full-blob replace —
+	// only the edited `category` travels, `status` is absent (so it can't be
+	// clobbered), and an OCC token rides along.
 	expect(
-		patchFields.status,
-		'editing an unrelated field on B must not clobber the migrated status back to the stale value',
-	).toBe('draft-migrated');
-	expect(patchFields.category).toBe('post-migration-edit');
+		patchBody.fields_patch?.category,
+		'the unrelated-field edit is sent as a single-key fields_patch',
+	).toBe('post-migration-edit');
+	expect(
+		patchBody.fields_patch?.status,
+		'the migrated status must NOT be in the patch (structurally un-clobberable)',
+	).toBeUndefined();
+	expect(patchBody.fields, 'no full fields blob is sent alongside fields_patch').toBeUndefined();
+	expect(patchBody.expected_updated_at, 'the field write is OCC-guarded').toBeTruthy();
 
 	// Belt-and-suspenders: read B back from the server and confirm neither
 	// value was clobbered by the round-trip.

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { page } from '$app/state';
 	import { tick, onMount, onDestroy, untrack } from 'svelte';
-	import { api, PadApiError, type ImportURLResponse } from '$lib/api/client';
+	import { api, PadApiError, isUpdateConflictError, type ImportURLResponse } from '$lib/api/client';
 	import { confirmOpenChildrenOrThrow, isOpenChildrenError } from '$lib/items/openChildrenError';
 	import { marked } from 'marked';
 	import { collectionStore } from '$lib/stores/collections.svelte';
@@ -2291,14 +2291,14 @@
 		// (This also lets a pre-flip pending onchange from FieldEditor's 500ms
 		// debounce complete rather than being suppressed.)
 		if (!item) return;
-		// NOTE(BUG-2273): this sends a FULL `fields` blob (stale ...fields + one
-		// key) with NO expected_updated_at / fields_patch — the web editor never
-		// adopted the IDEA-1480/v0.14 item merge+OCC. So a concurrent schema
-		// MIGRATION (or any other field write) can be silently UNDONE by this
-		// write. The BUG-2265 migration reconcile above refetches to shrink the
-		// window, but the real fix is item-level OCC here (tracked in BUG-2273).
-		const updated = { ...fields, [key]: value };
-		const payload = JSON.stringify(updated);
+		// BUG-2273: field edits use fields_patch + optimistic concurrency instead
+		// of a full-blob replace. Only the single changed key travels; the server
+		// MERGES it into the row read under its write lock (mergeFieldsPatch), so a
+		// concurrent write to OTHER fields — or a schema MIGRATION committing while
+		// this save is in flight — is no longer silently undone. `expected_updated_at`
+		// makes a stale write fail with a 409 `update_conflict` we refetch-and-retry
+		// below (IDEA-1480 / MCP v0.14, finally adopted by the web editor).
+		const patch = { [key]: value };
 		const targetItem = item;
 		const targetWs = wsSlug;
 		// Generation + id fence (Codex). A plain id check has an A→B→A gap (the
@@ -2311,14 +2311,45 @@
 		const stillCurrent = () => gen === loadGeneration && item?.id === targetItem.id;
 		saveStatus = 'saving';
 
-		const doUpdate = (force: boolean) =>
+		// One PATCH attempt: single-key merge, OCC-guarded by the caller-supplied
+		// updated_at. `force` overrides the open-children guard (BUG-1538).
+		const doUpdate = (force: boolean, expectedUpdatedAt: string) =>
 			api.items.update(targetWs, targetItem.id, {
-				fields: payload,
+				fields_patch: patch,
+				expected_updated_at: expectedUpdatedAt,
 				...(force ? { force: true } : {})
 			});
 
+		// Bound on OCC refetch-and-retry cycles per save (a hot item shouldn't spin).
+		const MAX_FIELD_OCC_RETRIES = 2;
+		// The freshest server item seen during OCC refetches — adopted to show
+		// server truth if we ultimately give up (so the field snaps to reality,
+		// not to our un-landed optimistic value).
+		let lastServerItem: Item | null = null;
+
+		// Submit the single-key patch, transparently refetch-and-retrying on a
+		// 409 `update_conflict`. Because only `key` is ever in `fields_patch`, a
+		// retry re-applies THIS delta against the freshly-read row without
+		// clobbering whatever another writer changed — the whole point of BUG-2273.
+		const submitWithOCC = async (force: boolean): Promise<Item> => {
+			let expected = targetItem.updated_at;
+			for (let attempt = 0; ; attempt++) {
+				try {
+					return await doUpdate(force, expected);
+				} catch (e) {
+					if (isUpdateConflictError(e) && attempt < MAX_FIELD_OCC_RETRIES && stillCurrent()) {
+						const latest = await api.items.get(targetWs, targetItem.id);
+						lastServerItem = latest;
+						expected = latest.updated_at;
+						continue;
+					}
+					throw e;
+				}
+			}
+		};
+
 		try {
-			const fresh = await doUpdate(false);
+			const fresh = await submitWithOCC(false);
 			if (!stillCurrent()) return;
 			item = withInflightTags(fresh);
 			showSaved();
@@ -2340,7 +2371,7 @@
 				try {
 					forced = await confirmOpenChildrenOrThrow(e, parentRef, () => {
 						if (!stillCurrent()) throw new Error('switched away');
-						return doUpdate(true);
+						return submitWithOCC(true);
 					});
 				} catch (retryErr) {
 					// The force retry itself failed (network / 500 /
@@ -2369,6 +2400,25 @@
 				saveStatus = 'idle';
 				item = { ...item };
 				toastStore.show('Status change cancelled', 'info');
+				return;
+			}
+			// BUG-2273: OCC retries were exhausted (or a conflict raced a pane
+			// switch). Don't clobber — adopt the freshest server truth we saw so
+			// the field snaps to reality rather than to our un-landed value, and
+			// tell the user to reconcile.
+			if (isUpdateConflictError(e)) {
+				if (!stillCurrent() || !item) return;
+				saveStatus = 'idle';
+				// `lastServerItem` is only ever assigned inside the submitWithOCC
+				// closure, so TS's control-flow narrows it to `null` here — the
+				// assertion restores the real union type it actually holds.
+				const server = lastServerItem as Item | null;
+				if (server && server.id === item.id) {
+					item = withInflightTags(server);
+				} else {
+					item = { ...item };
+				}
+				toastStore.show('This item was changed elsewhere — reload to see the latest.', 'error');
 				return;
 			}
 			// Any other failure mode — network, validation, 500, etc.

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -677,6 +677,25 @@ export interface ItemUpdate {
 	title?: string;
 	content?: string;
 	fields?: string;
+	/**
+	 * Field-level SHALLOW merge (IDEA-1480 / TASK-2022): only the keys present
+	 * here are written; every other stored field is left untouched. Mutually
+	 * exclusive with `fields` — the server rejects a request carrying both.
+	 * Sent as a JSON object (not a stringified blob, unlike `fields`), mirroring
+	 * the server model's `map[string]interface{}`. Use this (paired with
+	 * `expected_updated_at`) instead of a full-blob replace so two concurrent
+	 * single-field edits — or a field save racing a schema migration — can't
+	 * clobber each other (BUG-2273).
+	 */
+	fields_patch?: Record<string, unknown>;
+	/**
+	 * Optimistic-concurrency token (IDEA-1480 / TASK-2022, BUG-2273). Round-trip
+	 * the `updated_at` you last read; the server re-reads under a write lock and
+	 * rejects a stale write with a 409 `update_conflict` (details carry
+	 * `{ ref, expected_updated_at, actual_updated_at }`). Omit for
+	 * last-write-wins. Mirrors `CollectionUpdate.expected_updated_at`.
+	 */
+	expected_updated_at?: string;
 	tags?: string;
 	pinned?: boolean;
 	sort_order?: number;


### PR DESCRIPTION
## BUG-2273

The web item detail editor (`ItemDetail.svelte::updateField`) persisted a field edit by sending the **complete** `fields` blob (`{ ...fields, [key]: value }` → `JSON.stringify`) with no `expected_updated_at` and no `fields_patch` — the last-write-wins full-blob replace that IDEA-1480 / MCP v0.14 (TASK-2022) already retired on the API/MCP path but the web UI never adopted.

Consequences:
- Two concurrent field edits clobbered each other's **unrelated** fields.
- A field save in flight when a collection schema migration committed silently restored the pre-migration value.

## Fix

- **`ItemUpdate` type** (`web/src/lib/types/index.ts`) gains `fields_patch?: Record<string, unknown>` and `expected_updated_at?: string`, mirroring the existing `CollectionUpdate.expected_updated_at`. The `api.items.update` client forwards them verbatim — no client-method change needed.
- **`updateField`** now sends only the single changed key via `fields_patch` plus `expected_updated_at: targetItem.updated_at` (dropping the full `fields` blob — the server rejects sending both). The server merges the delta under its write lock (`mergeFieldsPatch`), so a concurrent write to other fields survives.
- **409 handling:** on `update_conflict` it refetches the item, re-reads the fresh `updated_at`, and retries the **same single-key delta** (bounded to 2 retries). Other fields are never re-applied — the whole point. If retries are exhausted it adopts the freshest server truth and shows a "changed elsewhere — reload" toast instead of clobbering.
- The existing **open-children force-override** branch (BUG-1538) and the **generation+id switch-safety** fences are preserved; the force retry runs through the same OCC loop.

No Go/API changes — the server, request model (`FieldsPatch` + `ExpectedUpdatedAt`), and the `isUpdateConflictError` client helper already existed.

### Testing note
No new unit test added: `updateField` is a private function deeply coupled to the component's `$state`/fences with no export seam, and the file is being edited concurrently by sibling fixes — extraction was deferred to avoid churn. Covered by svelte-check + build + the existing 454 web tests.

## Gates
- `npm run check` — 0 errors (8 pre-existing unrelated CSS/deprecation warnings)
- `npm run build` — ok
- `npm run test` — 454 passed (35 files)

https://claude.ai/code/session_01EZ6yr6pAUFb1uffan912ra