### PR TITLE
fix(web): retarget URL/breadcrumb on collection rename across tabs (BUG-2272)

### DIFF
--- a/web/src/lib/collections/renameNav.test.ts
+++ b/web/src/lib/collections/renameNav.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+import { resolveRenameNavTarget, type RenameNavInput } from './renameNav';
+
+// Convenience builder — every field is named so each scenario reads as the
+// concrete route/snapshot/tracker state at the moment the SSE event arrives.
+function input(over: Partial<RenameNavInput>): RenameNavInput {
+	return {
+		eventOldSlug: 'a',
+		eventNewSlug: 'b',
+		loadedCollectionSlug: 'a',
+		routeSlug: 'a',
+		renameNav: null,
+		...over,
+	};
+}
+
+describe('resolveRenameNavTarget', () => {
+	it('applies a normal single rename in steady state (snapshot matches route)', () => {
+		// Viewing collection X at slug A; a remote A→B rename arrives.
+		expect(
+			resolveRenameNavTarget(
+				input({ eventOldSlug: 'a', eventNewSlug: 'b', loadedCollectionSlug: 'a', routeSlug: 'a', renameNav: null }),
+			),
+		).toBe('b');
+	});
+
+	it('converges a synchronous chained burst A→B→C (pre-goto-commit) on the final slug', () => {
+		// Both events fire before any goto commits: routeSlug + snapshot stay at A.
+		const afterAB = resolveRenameNavTarget(
+			input({ eventOldSlug: 'a', eventNewSlug: 'b', loadedCollectionSlug: 'a', routeSlug: 'a', renameNav: null }),
+		);
+		expect(afterAB).toBe('b'); // handler sets renameNav = 'b'
+		const afterBC = resolveRenameNavTarget(
+			input({ eventOldSlug: 'b', eventNewSlug: 'c', loadedCollectionSlug: 'a', routeSlug: 'a', renameNav: 'b' }),
+		);
+		expect(afterBC).toBe('c');
+	});
+
+	it('REGRESSION: applies a chained B→C during the goto→reload window (stale snapshot, continuation)', () => {
+		// A→B has committed: routeSlug = B and renameNav = B, but loadCollection(B)
+		// is still in flight so the loaded snapshot is briefly the pre-rename slug A.
+		// A live B→C must still retarget to C rather than strand on dead slug B.
+		expect(
+			resolveRenameNavTarget(
+				input({ eventOldSlug: 'b', eventNewSlug: 'c', loadedCollectionSlug: 'a', routeSlug: 'b', renameNav: 'b' }),
+			),
+		).toBe('c');
+	});
+
+	it('rejects a stale FOREIGN snapshot in the reused-slug X/B → Y/A window (renameNav reset)', () => {
+		// X renamed A→B settled; user navigates X/B → Y/A (Y reused the freed slug
+		// A). renameNav is reset to null on the cross-collection nav. A replayed X
+		// A→B event arrives while `collection` is still stale X (its current slug
+		// is B). It must NOT hijack the Y navigation.
+		expect(
+			resolveRenameNavTarget(
+				input({ eventOldSlug: 'a', eventNewSlug: 'b', loadedCollectionSlug: 'b', routeSlug: 'a', renameNav: null }),
+			),
+		).toBeNull();
+	});
+
+	it('rejects the reused-slug hijack even before renameNav is reset (renameNav still B)', () => {
+		// Timing sub-window: collSlug already flipped to A (Y route) but the effect
+		// has not yet reset renameNav from B. pendingContinuation needs
+		// renameNav === routeSlug (B === A → false), so it stays rejected.
+		expect(
+			resolveRenameNavTarget(
+				input({ eventOldSlug: 'a', eventNewSlug: 'b', loadedCollectionSlug: 'b', routeSlug: 'a', renameNav: 'b' }),
+			),
+		).toBeNull();
+	});
+
+	it('drops a duplicate/superseded replay of an already-applied rename (fresh snapshot at B)', () => {
+		// Settled at B; a duplicate A→B replay arrives. believed = B, eventOldSlug
+		// = A ≠ believed → no redundant goto.
+		expect(
+			resolveRenameNavTarget(
+				input({ eventOldSlug: 'a', eventNewSlug: 'b', loadedCollectionSlug: 'b', routeSlug: 'b', renameNav: 'b' }),
+			),
+		).toBeNull();
+	});
+
+	it('skips a no-op where the new slug already equals the believed slug', () => {
+		expect(
+			resolveRenameNavTarget(
+				input({ eventOldSlug: 'a', eventNewSlug: 'a', loadedCollectionSlug: 'a', routeSlug: 'a', renameNav: null }),
+			),
+		).toBeNull();
+	});
+
+	it('does not treat a same-slug snapshot match as a continuation shortcut for a foreign old-slug', () => {
+		// Snapshot matches route (fresh, at A), renameNav null: only an event whose
+		// OLD slug is the current slug A applies. An event routed by some other old
+		// slug is dropped.
+		expect(
+			resolveRenameNavTarget(
+				input({ eventOldSlug: 'z', eventNewSlug: 'q', loadedCollectionSlug: 'a', routeSlug: 'a', renameNav: null }),
+			),
+		).toBeNull();
+	});
+});

--- a/web/src/lib/collections/renameNav.ts
+++ b/web/src/lib/collections/renameNav.ts
@@ -1,0 +1,73 @@
+// Cross-tab collection-rename re-navigation decision (BUG-2272).
+//
+// The collection route (`[collection]/+page.svelte`) subscribes to
+// `collection_updated` SSE events. On a RENAME, the route's URL slug is now
+// dead and must be re-targeted to the new slug. This helper is the pure
+// decision at the heart of that handler — extracted here because the live
+// handler lives inside a component `$effect` with no mount seam, so this is the
+// only way to deterministically unit-test the two subtle behaviours it
+// balances:
+//
+//   1. Reject a rename computed against a STALE collection snapshot from a
+//      PREVIOUS route (the reused-slug X/B → Y/A window). `routeSlug`
+//      (page.params.collection) flips synchronously on navigation, but the
+//      loaded `collection` snapshot is refreshed asynchronously, so the
+//      handler's stable-id gate can still pass for the previous collection —
+//      firing a goto that hijacks the new navigation.
+//
+//   2. STILL apply a legitimate chained-rename CONTINUATION on the current
+//      route during the goto→reload window (a live A→B commits, then B→C
+//      arrives while `loadCollection(B)` is in flight so the snapshot is briefly
+//      stale). Dropping it would strand the route on the dead intermediate slug.
+//
+// The distinguishing signal is `renameNav` — the synchronous tracker of the
+// slug we most recently goto'd. It equals `routeSlug` ONLY in the continuation
+// window (we just navigated there and the route caught up); it is reset to
+// null / a different value on a real cross-collection navigation, so it never
+// equals the reused slug in case 1.
+
+export interface RenameNavInput {
+	/** The event's OLD (routed-by) slug — `event.collection` on a `collection_updated`. */
+	eventOldSlug: string;
+	/** The event's NEW slug — `event.new_slug` (present only on a rename). */
+	eventNewSlug: string;
+	/**
+	 * The loaded collection snapshot's slug. May be STALE — briefly the previous
+	 * collection's slug during a cross-collection load, or the pre-rename slug
+	 * during a same-collection goto→reload window.
+	 */
+	loadedCollectionSlug: string;
+	/** The live route slug (`page.params.collection`). */
+	routeSlug: string;
+	/** The synchronous pending-rename tracker (the slug we last goto'd), or null. */
+	renameNav: string | null;
+}
+
+/**
+ * Decide the slug a collection-rename event should navigate the route to, or
+ * `null` to skip (already there, superseded/duplicate replay, or a stale
+ * foreign snapshot). The caller (the `+page.svelte` handler) sets
+ * `renameNav = <result>` and `goto`s it when non-null.
+ */
+export function resolveRenameNavTarget(input: RenameNavInput): string | null {
+	const { eventOldSlug, eventNewSlug, loadedCollectionSlug, routeSlug, renameNav } = input;
+
+	// A pending-rename CONTINUATION on THIS route: we just goto'd `renameNav`,
+	// the route caught up (`renameNav === routeSlug`), and this event renames the
+	// slug we're now on. Admit it even though the loaded snapshot is briefly
+	// stale. Never holds in the reused-slug X/B → Y/A case (renameNav is
+	// reset / ≠ the new route slug on a real cross-collection navigation).
+	const pendingContinuation = renameNav === routeSlug && eventOldSlug === routeSlug;
+
+	// Reject a snapshot that belongs to the PREVIOUS collection (the reused-slug
+	// hijack window) unless it's the continuation above.
+	if (loadedCollectionSlug !== routeSlug && !pendingContinuation) return null;
+
+	// Chained/replayed serialization: retarget from wherever we're actually
+	// headed (`renameNav` if a rename is pending, else the live route slug), so a
+	// burst A→B→C converges on the final slug and a stale/duplicate replay of an
+	// already-applied rename is dropped.
+	const believed = renameNav ?? routeSlug;
+	if (eventOldSlug === believed && eventNewSlug !== believed) return eventNewSlug;
+	return null;
+}

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -327,6 +327,24 @@
 				? renameOverride.to
 				: collSlug,
 	);
+	// BUG-2272 P2: the override is a SPENT-ONCE bridge, not a dormant persistent
+	// pair — null it the instant the route prop leaves the pre-rename slug (the
+	// goto it triggered committed, so `collSlug === to`, OR a real navigation
+	// moved on). Clearing it — rather than leaving it dormant behind the guards —
+	// closes a TRANSIENT: after X/B settled, an X/B → Y/A navigation (Y reusing
+	// X's freed slug A) sets `collSlug === A` synchronously while Y's collection
+	// fetch is still async, so `collection` is briefly the stale X snapshot and
+	// BOTH guards (`from === collSlug` AND `collectionId === collection.id`) would
+	// pass again, misdirecting to B until Y loads. A cleared override can't
+	// reactivate. The legit window still holds: the rename handler sets the
+	// override while `collSlug` is still `from`, so this keeps it until the goto
+	// commits; chained A→B→C stays intact (the burst is synchronous, `collSlug`
+	// unchanged until the final goto commits).
+	$effect(() => {
+		if (renameOverride && collSlug !== renameOverride.from) {
+			renameOverride = null;
+		}
+	});
 
 	// ── Scroll position restoration readiness (BUG-1425) ───────────────
 	// The route wrapper (`[slug]/+page.svelte`) owns `createScrollRestoration`

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -298,21 +298,32 @@
 	// BUG-2272: a remote rename of THIS collection in another tab leaves the
 	// full-page route's `collSlug` prop (page.params.collection) frozen at the
 	// DEAD old slug until a real navigation — so breadcrumbs + a hard reload
-	// resolve a 404. On such a rename the SSE handler below records the
-	// {from,to} slugs here and `goto`s the live URL; this override retargets
-	// the effective slug (breadcrumbs + navigateToCollectionRoot + item URLs)
-	// to the new slug while the goto is in flight. Self-expiring: honored ONLY
-	// while the prop is still the pre-rename slug (`from === collSlug`) — once
-	// the goto commits (prop advances to the new slug) OR a real navigation
-	// moves the prop elsewhere, the guard fails and the derived falls through
-	// to the live prop, so no stale override survives (no reset effect needed).
-	// Embedded panes never touch this branch — they trust `item.collection_slug`
-	// (PLAN-2154, no goto).
-	let renameOverride = $state<{ from: string; to: string } | null>(null);
+	// resolve a 404. On such a rename the SSE handler below records the renamed
+	// collection's stable id + {from,to} slugs here and `goto`s the live URL;
+	// this override retargets the effective slug (breadcrumbs +
+	// navigateToCollectionRoot + item URLs) to the new slug while the goto is in
+	// flight. Applied ONLY when ALL of:
+	//   - `collectionId === collection?.id` — we still DISPLAY the very collection
+	//     that was renamed. Slugs are reusable: after X renames A→B, a DIFFERENT
+	//     collection Y can later adopt the freed slug A; without this identity
+	//     scope a persistent full-page route sitting on Y at `/…/A/…` would match
+	//     `from === collSlug` and wrongly resolve to B. Also guards X being renamed
+	//     AGAIN out of band (we navigate to X's newest slug before the event lands).
+	//   - `from === collSlug` — the route prop is still the pre-rename slug; the
+	//     moment the goto commits (prop advances to the new slug) or a real
+	//     navigation moves it, the guard fails and the derived falls through to
+	//     the live prop. So the override is self-expiring — no stale value survives
+	//     and no reset effect is needed.
+	// A subsequent B→C for the SAME collection id re-records the override to C
+	// (chained renames intact). Embedded panes never touch this branch — they
+	// trust `item.collection_slug` (PLAN-2154, no goto).
+	let renameOverride = $state<{ collectionId: string; from: string; to: string } | null>(null);
 	let effectiveCollSlug = $derived(
 		embedded && item?.collection_slug
 			? item.collection_slug
-			: renameOverride && renameOverride.from === collSlug
+			: renameOverride &&
+				  renameOverride.from === collSlug &&
+				  renameOverride.collectionId === collection?.id
 				? renameOverride.to
 				: collSlug,
 	);
@@ -847,7 +858,14 @@
 				if (!embedded && event.new_slug) {
 					const believed = effectiveCollSlug;
 					if (event.collection === believed && event.new_slug !== believed) {
-						renameOverride = { from: collSlug, to: event.new_slug };
+						// Scope to the renamed collection's stable id (=== snap.id,
+						// guarded above) so a later reuse of the old slug by a
+						// DIFFERENT collection can't re-trigger this override (P2).
+						renameOverride = {
+							collectionId: event.collection_id ?? snap.id,
+							from: collSlug,
+							to: event.new_slug,
+						};
 						const search = typeof window !== 'undefined' ? window.location.search : '';
 						void goto(`/${username}/${wsSlug}/${event.new_slug}/${itemSlug}${search}`, {
 							replaceState: true,

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -162,7 +162,10 @@
 	// behavior exactly. When embedded, the pane injects handlers so an exit
 	// clears `?item=` in place instead of hard-navigating (TASK-2107).
 	function navigateToCollectionRoot() {
-		goto(`/${username}/${wsSlug}/${collSlug}`);
+		// effectiveCollSlug (not the raw prop) so a cross-tab rename that
+		// retargeted `renameOverride` lands on the LIVE collection root, not the
+		// dead old slug (BUG-2272). Full-page only — embedded uses onGone/onClose.
+		goto(`/${username}/${wsSlug}/${effectiveCollSlug}`);
 	}
 	// Fired when the open item disappears (archived mid-edit, hard delete,
 	// deleted). Full-page → collection root. Embedded → the pane's onGone,
@@ -291,8 +294,27 @@
 	// schema selection (loadData refetches the right collection below) and
 	// for building any collection-scoped URL — never the possibly-wrong
 	// route prop. Full-page keeps `collSlug` (the route is authoritative).
+	//
+	// BUG-2272: a remote rename of THIS collection in another tab leaves the
+	// full-page route's `collSlug` prop (page.params.collection) frozen at the
+	// DEAD old slug until a real navigation — so breadcrumbs + a hard reload
+	// resolve a 404. On such a rename the SSE handler below records the
+	// {from,to} slugs here and `goto`s the live URL; this override retargets
+	// the effective slug (breadcrumbs + navigateToCollectionRoot + item URLs)
+	// to the new slug while the goto is in flight. Self-expiring: honored ONLY
+	// while the prop is still the pre-rename slug (`from === collSlug`) — once
+	// the goto commits (prop advances to the new slug) OR a real navigation
+	// moves the prop elsewhere, the guard fails and the derived falls through
+	// to the live prop, so no stale override survives (no reset effect needed).
+	// Embedded panes never touch this branch — they trust `item.collection_slug`
+	// (PLAN-2154, no goto).
+	let renameOverride = $state<{ from: string; to: string } | null>(null);
 	let effectiveCollSlug = $derived(
-		embedded && item?.collection_slug ? item.collection_slug : collSlug,
+		embedded && item?.collection_slug
+			? item.collection_slug
+			: renameOverride && renameOverride.from === collSlug
+				? renameOverride.to
+				: collSlug,
 	);
 
 	// ── Scroll position restoration readiness (BUG-1425) ───────────────
@@ -804,14 +826,38 @@
 				// slug match could load the wrong schema into this pane.
 				if (!snap || event.collection_id !== snap.id) return;
 				const slug = snap.slug;
+				// BUG-2272: on the FULL-PAGE item route, retarget the URL +
+				// breadcrumb to the collection's NEW slug on a remote rename.
+				// `collSlug` (page.params.collection) is frozen at the dead old
+				// slug until a navigation, so a hard reload / breadcrumb click
+				// would 404. Record the {from,to} override — which drives
+				// effectiveCollSlug → breadcrumb + navigateToCollectionRoot
+				// immediately — and `goto` the live URL, PRESERVING the query
+				// string so an open pane (?item=) survives. `effectiveCollSlug` is
+				// the slug we currently believe this route is on (the pending
+				// rename target while a goto is in flight, else the live prop; its
+				// self-expiring guard drops a stale override once the user
+				// navigates elsewhere). Match the event's OLD slug
+				// (event.collection) against it so chained renames (A→B→C) advance
+				// in order and a late/duplicate replay of an already-applied rename
+				// can't yank us back to a dead intermediate slug. ONLY when
+				// !embedded — the embedded pane's URL segment is a PLAN-2154
+				// concern; it retargets via item.collection_slug / injected
+				// callbacks, never a goto.
+				if (!embedded && event.new_slug) {
+					const believed = effectiveCollSlug;
+					if (event.collection === believed && event.new_slug !== believed) {
+						renameOverride = { from: collSlug, to: event.new_slug };
+						const search = typeof window !== 'undefined' ? window.location.search : '';
+						void goto(`/${username}/${wsSlug}/${event.new_slug}/${itemSlug}${search}`, {
+							replaceState: true,
+							noScroll: true,
+						});
+					}
+				}
 				// On a rename, refetch by the NEW slug (the old one is dead) so
 				// this pane's collection reference — used to build quick-action /
 				// edit writes — stays valid (Codex P2).
-				// TODO(BUG-2272): full cross-tab rename renavigation — the
-				// full-page item route's URL/collSlug is NOT retargeted here, so
-				// breadcrumbs / a hard reload still resolve the dead old slug.
-				// Deferred (already broken on main; snapshot refresh below is the
-				// in-scope BUG-2265 fix).
 				// Fetch the collection's CURRENT slug. A rename carries new_slug;
 				// a settings update that follows a rename routes by (and carries in
 				// `collection`) the NEW slug — so prefer new_slug, THEN event's own
@@ -3811,7 +3857,7 @@
 						<a href="/{username}/{wsSlug}/{item.parent_collection_slug}/{item.parent_slug}">{item.parent_ref || item.parent_title}</a>
 						<span class="sep">/</span>
 					{:else}
-						<a href="/{username}/{wsSlug}/{collSlug}">{collection.icon} {collection.name}</a>
+						<a href="/{username}/{wsSlug}/{effectiveCollSlug}">{collection.icon} {collection.name}</a>
 						<span class="sep">/</span>
 					{/if}
 					<span class="current">{formatItemRef(item) || item.title}</span>

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -6,6 +6,7 @@
 	import type { BulkItemsRequest, Collection, Item, PaneTarget, QuickAction, View, ViewConfig } from '$lib/types';
 	import { parseSettings, parseFields, parseSchema, parseTags, getStatusOptions, itemUrlId, formatItemRef } from '$lib/types';
 	import { plansProgressToMap, fetchCollectionProgress } from '$lib/collections/progressMerge';
+	import { resolveRenameNavTarget } from '$lib/collections/renameNav';
 	import BoardView from '$lib/components/collections/BoardView.svelte';
 	import ListView from '$lib/components/collections/ListView.svelte';
 	import TableView from '$lib/components/collections/TableView.svelte';
@@ -863,26 +864,30 @@
 				// collectionStore so the sidebar/pickers point at the live slug too
 				// (they'd otherwise keep the dead slug and 404 on click).
 				if (event.new_slug) {
-					// BUG-2272 P2: reject a rename while `collection` is a STALE
-					// snapshot from a PREVIOUS route (a cross-collection load window).
-					// `collSlug` flips synchronously on navigation but `loadCollection`
-					// is async, so the id gate above can still pass for the previous
-					// collection — e.g. X/B → Y/A where Y reused X's freed slug A:
-					// `collection` is briefly still X, `event.collection_id` matches X,
-					// and `collSlug === A` matches, firing goto(.../B) and hijacking the
-					// Y navigation. Require the loaded snapshot to identify the CURRENT
-					// route (`collection.slug === collSlug`) before acting. A legit
-					// rename still passes: at event time we're still on the old slug, so
-					// the snapshot matches. Chained replay bursts are synchronous
-					// (pre-goto-commit, `collSlug` unchanged), so both events still see
-					// the matching pre-burst snapshot.
-					if (collection.slug !== collSlug) return;
-					const believed = renameNav ?? collSlug;
-					if (event.collection === believed && event.new_slug !== believed) {
-						renameNav = event.new_slug;
+					// BUG-2272 P2: resolveRenameNavTarget balances two concerns —
+					// (1) reject a rename computed against a STALE snapshot from the
+					// PREVIOUS collection (the reused-slug X/B → Y/A window, where the
+					// stale id gate would otherwise fire a goto that hijacks the Y
+					// navigation), and (2) STILL apply a chained continuation on THIS
+					// route during the goto→reload window (a live A→B commits, then B→C
+					// arrives while loadCollection(B) is in flight and the snapshot is
+					// briefly stale — dropping it would strand us on dead slug B).
+					// `renameNav === collSlug` distinguishes them: it holds only in the
+					// continuation window, never in the reused-slug case (renameNav is
+					// reset on cross-collection nav, ~line 834). See renameNav.ts +
+					// renameNav.test.ts for the deterministic scenarios.
+					const target = resolveRenameNavTarget({
+						eventOldSlug: event.collection,
+						eventNewSlug: event.new_slug,
+						loadedCollectionSlug: collection.slug,
+						routeSlug: collSlug,
+						renameNav,
+					});
+					if (target) {
+						renameNav = target;
 						void collectionStore.loadCollections(ws);
 						const search = typeof window !== 'undefined' ? window.location.search : '';
-						void goto(`/${username}/${wsSlug}/${event.new_slug}${search}`);
+						void goto(`/${username}/${wsSlug}/${target}${search}`);
 					}
 					return;
 				}

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -863,6 +863,20 @@
 				// collectionStore so the sidebar/pickers point at the live slug too
 				// (they'd otherwise keep the dead slug and 404 on click).
 				if (event.new_slug) {
+					// BUG-2272 P2: reject a rename while `collection` is a STALE
+					// snapshot from a PREVIOUS route (a cross-collection load window).
+					// `collSlug` flips synchronously on navigation but `loadCollection`
+					// is async, so the id gate above can still pass for the previous
+					// collection — e.g. X/B → Y/A where Y reused X's freed slug A:
+					// `collection` is briefly still X, `event.collection_id` matches X,
+					// and `collSlug === A` matches, firing goto(.../B) and hijacking the
+					// Y navigation. Require the loaded snapshot to identify the CURRENT
+					// route (`collection.slug === collSlug`) before acting. A legit
+					// rename still passes: at event time we're still on the old slug, so
+					// the snapshot matches. Chained replay bursts are synchronous
+					// (pre-goto-commit, `collSlug` unchanged), so both events still see
+					// the matching pre-burst snapshot.
+					if (collection.slug !== collSlug) return;
 					const believed = renameNav ?? collSlug;
 					if (event.collection === believed && event.new_slug !== believed) {
 						renameNav = event.new_slug;

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -808,12 +808,30 @@
 	// Subscribe to SSE events for live updates to this collection's items
 	let unsubscribeSSE: (() => void) | null = null;
 
+	// BUG-2272: the slug we currently believe this route is on, advanced
+	// SYNCHRONOUSLY on each rename `goto` (see the collection_updated handler).
+	// Deliberately a PLAIN let, NOT $state: a reactive value here would re-run
+	// the SSE $effect on every rename — tearing down the listener mid-burst.
+	// It serializes chained/replayed renames (A→B then B→C) that arrive before
+	// SvelteKit commits each goto (collSlug/page.params lag the goto), so each
+	// event retargets from where we're actually headed. Reset at re-subscribe
+	// when a real navigation lands on a slug that isn't the pending target.
+	let renameNav: string | null = null;
+
 	$effect(() => {
 		// Clean up previous subscription
 		unsubscribeSSE?.();
 		unsubscribeSSE = null;
 
 		if (!wsSlug || !collSlug) return;
+
+		// BUG-2272: this $effect re-runs whenever collSlug changes (a real
+		// navigation OR a committed rename goto). If the new route slug isn't the
+		// rename target we were headed to, any pending rename intent is stale —
+		// clear it so a later rename event's old-slug match is anchored to the
+		// live route rather than a dead target. (renameNav is a plain let, so
+		// reading/writing it here creates no reactive dependency.)
+		if (renameNav !== null && renameNav !== collSlug) renameNav = null;
 
 		const ws = wsSlug;
 		const coll = collSlug;
@@ -829,23 +847,29 @@
 				// event's old slug can be re-owned by a DIFFERENT collection, so a
 				// slug match could navigate away / refresh from the wrong one.
 				if (!collection || event.collection_id !== collection.id) return;
-				// Rename (Codex P2): this route's URL slug is now dead. Re-target
-				// to the new slug — preserving the query string (open pane) — so
-				// the next fetch/action doesn't 404. Mirrors the originating
-				// client's rename navigation.
-				// TODO(BUG-2272): full cross-tab rename renavigation — chained
-				// renames replayed on reconnect (A→B then B→C) can arrive with
-				// `coll` already past the intermediate slug, so a B→C event whose
-				// old slug (B) no longer matches `coll` is skipped and the route
-				// can land on a dead intermediate. Deferred (already broken on main).
-				if (event.new_slug && event.new_slug !== coll) {
-					const search = typeof window !== 'undefined' ? window.location.search : '';
-					// TODO(BUG-2272): refresh global collectionStore / handle collection_updated
-					// in the workspace layout on rename. This route navigates, but the GLOBAL
-					// collectionStore (sidebar links/icons/names, pickers) isn't refreshed and
-					// the layout ignores collection_updated, so the sidebar keeps the dead old
-					// slug and clicking it 404s. Deferred (layout-level renavigation).
-					void goto(`/${username}/${wsSlug}/${event.new_slug}${search}`);
+				// Rename (Codex P2 / BUG-2272): this route's URL slug is now dead —
+				// retarget to the new slug, robust to chained/replayed renames.
+				// `renameNav` (a plain, non-reactive tracker advanced synchronously
+				// on each rename goto below) is the slug we currently believe we're
+				// on; a burst of replayed renames (A→B then B→C) arrives before
+				// SvelteKit commits each goto (collSlug/page.params lag), so DON'T
+				// compare against the frozen `coll`. Match the event's OLD slug
+				// (event.collection) against `renameNav` — or the LIVE route param
+				// (collSlug) when no rename is pending — so each event retargets from
+				// wherever we're actually headed, chaining to the FINAL slug and
+				// dropping a late/duplicate replay of an already-applied rename that
+				// would otherwise land us on a dead intermediate. Preserve the query
+				// string so an open pane survives, and refresh the global
+				// collectionStore so the sidebar/pickers point at the live slug too
+				// (they'd otherwise keep the dead slug and 404 on click).
+				if (event.new_slug) {
+					const believed = renameNav ?? collSlug;
+					if (event.collection === believed && event.new_slug !== believed) {
+						renameNav = event.new_slug;
+						void collectionStore.loadCollections(ws);
+						const search = typeof window !== 'undefined' ? window.location.search : '';
+						void goto(`/${username}/${wsSlug}/${event.new_slug}${search}`);
+					}
 					return;
 				}
 				// Unified generation: bumped here AND by loadCollection /
@@ -1676,11 +1700,21 @@
 					const fresh = list.find((c) => c.id === base.id);
 					if (fresh && collGen === collectionGen && ws === wsSlug && slug === collSlug) {
 						collection = fresh;
-						// TODO(BUG-2272): on a remote RENAME this reseeds `collection`
-						// (fresh slug) but NOT the route's `collSlug`, so the NEXT
-						// reorder still PATCHes the dead old slug and re-fails. A real
-						// fix retargets the route slug (renavigation, deferred to
-						// BUG-2272); we don't build that here.
+						// BUG-2272: a 404 here means a RENAME (not just a concurrent
+						// schema edit) killed the old slug. Reseeding `collection` alone
+						// leaves the route on the dead slug, so the NEXT reorder would
+						// PATCH it and re-fail forever. Retarget the route (and refresh
+						// the sidebar) to the live slug — mirroring the SSE rename
+						// navigation and sharing the same `renameNav` intent tracker —
+						// so subsequent actions hit a valid slug. A plain 409 (schema
+						// edit, no rename) leaves fresh.slug === collSlug, so this is a
+						// no-op there.
+						if (fresh.slug !== collSlug) {
+							renameNav = fresh.slug;
+							void collectionStore.loadCollections(ws);
+							const search = typeof window !== 'undefined' ? window.location.search : '';
+							void goto(`/${username}/${wsSlug}/${fresh.slug}${search}`);
+						}
 					}
 				} catch {
 					// Best-effort reseed.


### PR DESCRIPTION
## BUG-2272 — cross-tab collection-rename re-navigation

PR #989 (BUG-2265) added the `collection_updated` SSE broadcast (stable `collection_id` + `new_slug`) and kept sibling collection snapshots valid by id, but deferred cross-tab rename RE-NAVIGATION with `TODO(BUG-2272)` markers. This finishes it.

### (A) `ItemDetail.svelte` — full-page item view
On a remote rename the handler refetched the renamed collection by stable id but never retargeted `collSlug`/the URL, so the breadcrumb (and a hard reload) resolved the DEAD old slug (404).

- New self-expiring `renameOverride` (`$state`) feeds `effectiveCollSlug` (mirrors the existing `~294` pattern): seeded from the `collSlug` prop, retargets to the new slug on rename, and auto-expires once the prop catches up or a real navigation moves it (`from === collSlug` guard — no reset effect needed).
- Breadcrumb (`~3857`), `navigateToCollectionRoot`, and the item-URL builders now read `effectiveCollSlug`.
- On `!embedded`: `goto` the new URL **preserving the query string** so an open pane (`?item=`) survives. Embedded panes keep trusting `item.collection_slug` (PLAN-2154) — no goto.
- Old-slug match (`event.collection`) against the believed slug so chained renames advance in order and a late/duplicate replay can't yank back to a dead intermediate.

### (B) `[collection]/+page.svelte` — collection route
- The rename handler compared `event.new_slug` against a frozen `coll` captured at effect-subscribe time; a chained/replayed rename burst (A→B then B→C) could land on a dead intermediate. Replaced with a plain, **non-reactive** `renameNav` tracker advanced synchronously on each rename goto (a `$state` would re-run the SSE `$effect` mid-burst), matched by the event's OLD slug against the **live** route param so each event retargets from where we're actually headed and chains to the final slug.
- Refresh the global `collectionStore` on rename so the sidebar/pickers stop pointing at the dead slug.
- Reorder-conflict recovery (`~1700`) fixed the same way: a 404 (rename) reseeded `collection` by id but left the route on the dead slug, so the next reorder PATCHed it and re-failed forever — now it retargets to the live slug.

All `TODO(BUG-2272)` markers resolved.

### Gates (all pass)
- `cd web && npm run check` — 0 errors (8 pre-existing warnings, none from this change)
- `cd web && npm run build` — built OK
- `cd web && npm run test` — 454 passed (35 files)
- Svelte MCP autofixer on the changed rune logic — no issues

https://claude.ai/code/session_01EZ6yr6pAUFb1uffan912ra