### PR TITLE
fix(collab): flush live editor into items.content before version restore so the undo-point captures in-flight edits (BUG-2271)

### DIFF
--- a/web/e2e/version-restore-collab.spec.ts
+++ b/web/e2e/version-restore-collab.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from './fixtures';
+import type { Request as PWRequest } from '@playwright/test';
 import { browserLogin, EDITOR_SELECTOR, SYNCED_BADGE_SELECTOR } from './lib/collab-helpers';
 
 /**
@@ -192,12 +193,16 @@ test('restoring a version under live collab is not clobbered by the next flush (
  * captured without gamma and gamma is lost when the op-log is pruned — no
  * version ever contains gamma and the poll goes red.
  *
- * Determinism note: we reach the Restore click well under the 5s idle-flush
- * window, so the collab-snapshot PATCH that lands gamma is the restore-triggered
- * one, not the idle timer. (Even if the idle timer raced ahead it would persist
- * gamma to items.content but create a version holding the PRE-gamma content — so
- * only the restore's pre-flush undo-point can hold gamma. See BUG-2264 spec for
- * the version-on-content-change behaviour.)
+ * Determinism / no false-pass (Codex P3 on #994): the poll alone could pass for
+ * the WRONG reason if the ordinary 5s idle flush happened to land gamma before
+ * the restore. So we ALSO capture request ordering and assert the fix's causal
+ * signature directly: a `source=collab-snapshot` PATCH carrying gamma is
+ * INITIATED after the "Confirm Restore" click (i.e. it's the pre-restore flush,
+ * not the idle timer) AND its response arrives BEFORE the restore POST is issued
+ * (i.e. the client awaited it). Under the bug the restore POST fires immediately
+ * on click with no preceding gamma flush, so no gamma PATCH can complete before
+ * the restore POST — the ordering assertion goes red. Reaching the click well
+ * under 5s keeps the idle timer from firing before the click.
  */
 test('an unflushed live edit is captured in the restore undo-point via the UI (BUG-2271)', async ({
 	page,
@@ -264,6 +269,26 @@ test('an unflushed live edit is captured in the restore undo-point via the UI (B
 	await expect(editor).toContainText(beta);
 	await expect(page.locator(SYNCED_BADGE_SELECTOR)).toBeVisible();
 
+	// Capture request ordering so we can prove the PRE-RESTORE flush (not the idle
+	// timer) is what landed gamma (Codex P3). Record, with timestamps: when a
+	// gamma-carrying collab-snapshot PATCH is INITIATED and when its RESPONSE
+	// arrives, and when the restore POST is INITIATED. Registered before typing so
+	// nothing is missed; the gamma filter ignores the earlier beta flush.
+	const order: { kind: 'gamma-flush-start' | 'gamma-flush-done' | 'restore-start'; t: number }[] = [];
+	const isGammaFlush = (r: PWRequest) =>
+		r.url().includes('source=collab-snapshot') &&
+		r.method() === 'PATCH' &&
+		(r.postData() ?? '').includes(gamma);
+	const isRestorePost = (r: PWRequest) =>
+		/\/versions\/[^/]+\/restore$/.test(r.url()) && r.method() === 'POST';
+	page.on('request', (r) => {
+		if (isGammaFlush(r)) order.push({ kind: 'gamma-flush-start', t: Date.now() });
+		else if (isRestorePost(r)) order.push({ kind: 'restore-start', t: Date.now() });
+	});
+	page.on('response', (resp) => {
+		if (isGammaFlush(resp.request())) order.push({ kind: 'gamma-flush-done', t: Date.now() });
+	});
+
 	// Type `gamma` but do NOT wait for its idle flush — it stays in the live
 	// Y.Doc, unpersisted to items.content (the BUG-2271 window). We reach the
 	// Restore click well under 5s so the idle timer can't pre-persist it.
@@ -290,12 +315,31 @@ test('an unflushed live edit is captured in the restore undo-point via the UI (B
 	const card = page.locator('#item-timeline .version-card').first();
 	await card.locator('.card-header').click(); // expand
 	await card.getByRole('button', { name: 'Restore this version' }).click();
+	// Timestamp the click so we can prove the gamma flush was initiated AFTER it
+	// (the pre-restore flush) and not by the idle timer beforehand.
+	const clickTime = Date.now();
 	await card.getByRole('button', { name: 'Confirm Restore' }).click();
 	await restoreDone;
 
-	// The undo-point version created by the restore holds the pre-restore
-	// items.content — which, thanks to the pre-restore flush, includes gamma.
-	// Under the bug no version ever holds gamma (it was lost with the op-log).
+	// Ordering proof (Codex P3): the fix's causal signature must hold.
+	const gammaStart = order.find((e) => e.kind === 'gamma-flush-start');
+	const gammaDone = order.find((e) => e.kind === 'gamma-flush-done');
+	const restoreStart = order.find((e) => e.kind === 'restore-start');
+	expect(gammaStart, 'a gamma collab-snapshot PATCH must be issued').toBeTruthy();
+	expect(gammaDone, 'the gamma flush must complete').toBeTruthy();
+	expect(restoreStart, 'the restore POST must be issued').toBeTruthy();
+	// (a) The gamma flush was initiated AFTER the Confirm-Restore click → it's the
+	//     pre-restore flush, not a stray idle-timer flush that raced ahead.
+	expect(gammaStart!.t).toBeGreaterThanOrEqual(clickTime);
+	// (b) The gamma flush RESPONSE arrived BEFORE the restore POST was issued →
+	//     the client awaited the flush, so items.content held gamma when the
+	//     restore captured its undo-point. Under the bug the restore POST fires
+	//     first and this is false.
+	expect(gammaDone!.t).toBeLessThanOrEqual(restoreStart!.t);
+
+	// And the outcome: the undo-point version created by the restore holds the
+	// pre-restore items.content — which, thanks to the pre-restore flush, includes
+	// gamma. Under the bug no version ever holds gamma (it was lost with the op-log).
 	await expect
 		.poll(
 			async () => {

--- a/web/e2e/version-restore-collab.spec.ts
+++ b/web/e2e/version-restore-collab.spec.ts
@@ -195,14 +195,16 @@ test('restoring a version under live collab is not clobbered by the next flush (
  *
  * Determinism / no false-pass (Codex P3 on #994): the poll alone could pass for
  * the WRONG reason if the ordinary 5s idle flush happened to land gamma before
- * the restore. So we ALSO capture request ordering and assert the fix's causal
- * signature directly: a `source=collab-snapshot` PATCH carrying gamma is
- * INITIATED after the "Confirm Restore" click (i.e. it's the pre-restore flush,
- * not the idle timer) AND its response arrives BEFORE the restore POST is issued
- * (i.e. the client awaited it). Under the bug the restore POST fires immediately
- * on click with no preceding gamma flush, so no gamma PATCH can complete before
- * the restore POST — the ordering assertion goes red. Reaching the click well
- * under 5s keeps the idle timer from firing before the click.
+ * the restore. So we deterministically SUPPRESS the idle flush — a route gate
+ * ABORTS every `source=collab-snapshot` PATCH until we explicitly allow it,
+ * immediately before the Confirm-Restore click — so the ONLY gamma collab-snapshot
+ * PATCH that can land is the pre-restore one. That makes both assertions airtight:
+ * (1) items.content can only acquire gamma via the pre-restore flush, so the
+ * undo-point holding gamma proves the fix; and (2) a monotonic event sequence
+ * (array index, not ms timestamps) shows the successful gamma flush response is
+ * dispatched STRICTLY before the restore POST is issued (the client awaited it).
+ * Under the bug the restore POST fires with no preceding gamma flush, so both go
+ * red.
  */
 test('an unflushed live edit is captured in the restore undo-point via the UI (BUG-2271)', async ({
 	page,
@@ -269,35 +271,53 @@ test('an unflushed live edit is captured in the restore undo-point via the UI (B
 	await expect(editor).toContainText(beta);
 	await expect(page.locator(SYNCED_BADGE_SELECTOR)).toBeVisible();
 
-	// Capture request ordering so we can prove the PRE-RESTORE flush (not the idle
-	// timer) is what landed gamma (Codex P3). Record, with timestamps: when a
-	// gamma-carrying collab-snapshot PATCH is INITIATED and when its RESPONSE
-	// arrives, and when the restore POST is INITIATED. Registered before typing so
-	// nothing is missed; the gamma filter ignores the earlier beta flush.
-	const order: { kind: 'gamma-flush-start' | 'gamma-flush-done' | 'restore-start'; t: number }[] = [];
+	// P3 (Codex): deterministically SUPPRESS the ordinary 5s idle collab-snapshot
+	// flush so the ONLY gamma-carrying collab-snapshot PATCH that can land is the
+	// pre-restore one — making both the outcome and the ordering assertions
+	// airtight (no reliance on "reach the click under 5s"). A route gate ABORTS
+	// collab-snapshot PATCHes until we explicitly allow them, immediately before
+	// the Confirm-Restore click. The earlier beta flush already completed before
+	// this gate is installed, so it's unaffected; hydration after the reload does
+	// no edit, so it issues no flush to abort.
+	let allowSnapshotFlush = false;
+	await page.route(/source=collab-snapshot/, async (route) => {
+		if (route.request().method() === 'PATCH' && !allowSnapshotFlush) {
+			await route.abort();
+			return;
+		}
+		await route.continue();
+	});
+
+	// Record a MONOTONIC event sequence (array index, NOT ms Date.now()) so the
+	// ordering compare is exact and tie-free. Only a SUCCESSFUL (2xx) gamma
+	// collab-snapshot response and the restore POST request enter the sequence;
+	// aborted idle attempts fire 'requestfailed', never 'response', so they can't
+	// pollute it. The gamma filter also ignores the earlier beta flush.
+	const seq: string[] = [];
 	const isGammaFlush = (r: PWRequest) =>
 		r.url().includes('source=collab-snapshot') &&
 		r.method() === 'PATCH' &&
 		(r.postData() ?? '').includes(gamma);
 	const isRestorePost = (r: PWRequest) =>
 		/\/versions\/[^/]+\/restore$/.test(r.url()) && r.method() === 'POST';
-	page.on('request', (r) => {
-		if (isGammaFlush(r)) order.push({ kind: 'gamma-flush-start', t: Date.now() });
-		else if (isRestorePost(r)) order.push({ kind: 'restore-start', t: Date.now() });
-	});
 	page.on('response', (resp) => {
-		if (isGammaFlush(resp.request())) order.push({ kind: 'gamma-flush-done', t: Date.now() });
+		if (isGammaFlush(resp.request()) && resp.ok()) seq.push('gamma-flush-ok');
+	});
+	page.on('request', (r) => {
+		if (isRestorePost(r)) seq.push('restore-start');
 	});
 
-	// Type `gamma` but do NOT wait for its idle flush — it stays in the live
-	// Y.Doc, unpersisted to items.content (the BUG-2271 window). We reach the
-	// Restore click well under 5s so the idle timer can't pre-persist it.
+	// Type `gamma` — its idle flush is now blocked by the gate, so it stays in the
+	// live Y.Doc, unpersisted to items.content (the BUG-2271 window).
 	await editor.click();
 	await page.keyboard.press('Control+End');
 	await page.keyboard.type(' ' + gamma);
 	await expect(editor).toContainText(gamma);
 
-	// Sanity: items.content does NOT yet hold gamma (still the unflushed window).
+	// Sanity: items.content does NOT hold gamma. With the gate aborting every
+	// collab-snapshot PATCH, gamma can reach items.content ONLY via the pre-restore
+	// flush we allow below — so the undo-point holding gamma is airtight proof that
+	// the pre-restore flush (not an idle flush) captured it.
 	const preRestore = await request.get(`/api/v1/workspaces/${ws}/items/${slug}`, { headers });
 	expect(preRestore.ok()).toBeTruthy();
 	expect((await preRestore.json()).content as string).not.toContain(gamma);
@@ -315,27 +335,22 @@ test('an unflushed live edit is captured in the restore undo-point via the UI (B
 	const card = page.locator('#item-timeline .version-card').first();
 	await card.locator('.card-header').click(); // expand
 	await card.getByRole('button', { name: 'Restore this version' }).click();
-	// Timestamp the click so we can prove the gamma flush was initiated AFTER it
-	// (the pre-restore flush) and not by the idle timer beforehand.
-	const clickTime = Date.now();
+	// Allow collab-snapshot PATCHes ONLY from here, so the first (and only) gamma
+	// PATCH that lands is the pre-restore flush the confirm click triggers.
+	allowSnapshotFlush = true;
 	await card.getByRole('button', { name: 'Confirm Restore' }).click();
 	await restoreDone;
 
-	// Ordering proof (Codex P3): the fix's causal signature must hold.
-	const gammaStart = order.find((e) => e.kind === 'gamma-flush-start');
-	const gammaDone = order.find((e) => e.kind === 'gamma-flush-done');
-	const restoreStart = order.find((e) => e.kind === 'restore-start');
-	expect(gammaStart, 'a gamma collab-snapshot PATCH must be issued').toBeTruthy();
-	expect(gammaDone, 'the gamma flush must complete').toBeTruthy();
-	expect(restoreStart, 'the restore POST must be issued').toBeTruthy();
-	// (a) The gamma flush was initiated AFTER the Confirm-Restore click → it's the
-	//     pre-restore flush, not a stray idle-timer flush that raced ahead.
-	expect(gammaStart!.t).toBeGreaterThanOrEqual(clickTime);
-	// (b) The gamma flush RESPONSE arrived BEFORE the restore POST was issued →
-	//     the client awaited the flush, so items.content held gamma when the
-	//     restore captured its undo-point. Under the bug the restore POST fires
-	//     first and this is false.
-	expect(gammaDone!.t).toBeLessThanOrEqual(restoreStart!.t);
+	// Ordering proof (Codex P3): a SUCCESSFUL gamma collab-snapshot flush occurred
+	// AND its response was dispatched STRICTLY BEFORE the restore POST was issued
+	// (monotonic index — the client awaited the flush before POSTing the restore).
+	// Under the bug the restore POST fires with no preceding gamma flush, so
+	// 'gamma-flush-ok' is absent (or after) → red.
+	const gammaIdx = seq.indexOf('gamma-flush-ok');
+	const restoreIdx = seq.indexOf('restore-start');
+	expect(gammaIdx, 'a successful pre-restore gamma flush must occur').toBeGreaterThanOrEqual(0);
+	expect(restoreIdx, 'the restore POST must be issued').toBeGreaterThanOrEqual(0);
+	expect(gammaIdx).toBeLessThan(restoreIdx);
 
 	// And the outcome: the undo-point version created by the restore holds the
 	// pre-restore items.content — which, thanks to the pre-restore flush, includes

--- a/web/e2e/version-restore-collab.spec.ts
+++ b/web/e2e/version-restore-collab.spec.ts
@@ -163,3 +163,151 @@ test('restoring a version under live collab is not clobbered by the next flush (
 	expect(finalItem.content).toContain(gamma);
 	expect(finalItem.content).not.toContain(beta);
 });
+
+/**
+ * Undo-point captures an UNFLUSHED live edit (BUG-2271).
+ *
+ * A version restore creates a "Restored from…" undo-point version from the
+ * CURRENT persisted items.content, server-side, inside the restore tx. If a
+ * live collab editor holds edits still sitting in the Y.Doc/op-log within the
+ * ~5s flush-debounce window (not yet PATCHed to items.content), those edits are
+ * NOT in the undo-point — and, because the restore also prunes the op-log +
+ * reseeds every peer (BUG-2264), they are permanently lost.
+ *
+ * The collab server is a dumb relay with no Yjs decoder, so it can't render the
+ * live Y.Doc to markdown. The fix is client-side: the initiating client flushes
+ * its live editor markdown into items.content BEFORE issuing the restore, so the
+ * undo-point reflects the true pre-restore live state. ItemDetail threads a
+ * `flushBeforeRestore` callback down through ItemTimeline → TimelineVersionCard,
+ * which awaits it immediately before the restore POST.
+ *
+ * This spec drives the restore through the REAL UI button (not the API) so the
+ * flush-before-restore callback is exercised:
+ *
+ *   seed alpha → type+flush beta (creates a version) → reload (so the timeline
+ *   shows the version card) → type gamma but do NOT wait for its flush → click
+ *   Restore in the UI → assert a version now holds gamma (the undo-point).
+ *
+ * Under the bug, clicking Restore issues no pre-flush, so the undo-point is
+ * captured without gamma and gamma is lost when the op-log is pruned — no
+ * version ever contains gamma and the poll goes red.
+ *
+ * Determinism note: we reach the Restore click well under the 5s idle-flush
+ * window, so the collab-snapshot PATCH that lands gamma is the restore-triggered
+ * one, not the idle timer. (Even if the idle timer raced ahead it would persist
+ * gamma to items.content but create a version holding the PRE-gamma content — so
+ * only the restore's pre-flush undo-point can hold gamma. See BUG-2264 spec for
+ * the version-on-content-change behaviour.)
+ */
+test('an unflushed live edit is captured in the restore undo-point via the UI (BUG-2271)', async ({
+	page,
+	fixture,
+	request
+}, testInfo) => {
+	test.skip(
+		testInfo.project.name !== 'desktop-chromium',
+		'version-restore collab is viewport-agnostic; one project is enough'
+	);
+	// A flush + reload + WS re-handshake + a second flush + restore need well
+	// over the 30s default on a busy CI runner.
+	test.setTimeout(90_000);
+
+	const ws = fixture.workspaceSlug;
+	const headers = {
+		Authorization: `Bearer ${fixture.apiToken}`,
+		'Content-Type': 'application/json'
+	};
+	const ts = Date.now();
+	const alpha = `alpha-base-${ts}`;
+	const beta = `beta-mid-${ts}`;
+	const gamma = `gamma-unflushed-${ts}`;
+
+	// Seed a doc whose v1 body is `alpha` — the state we restore back to.
+	const createResp = await request.post(`/api/v1/workspaces/${ws}/collections/docs/items`, {
+		headers,
+		data: { title: `Restore undo-point ${ts}`, content: alpha }
+	});
+	if (!createResp.ok())
+		throw new Error(`doc create failed (${createResp.status()}): ${await createResp.text()}`);
+	const { slug } = (await createResp.json()) as { id: string; slug: string };
+
+	await browserLogin(page);
+	await page.goto(`/${fixture.adminUsername}/${ws}/docs/${slug}`);
+
+	let editor = page.locator(EDITOR_SELECTOR);
+	await expect(editor).toBeVisible();
+	await expect(editor).toContainText(alpha);
+	await expect(page.locator(SYNCED_BADGE_SELECTOR)).toBeVisible();
+
+	// Type `beta` and let it flush — persists "alpha beta" and (first content
+	// change → no throttle) creates the version snapshot we later restore to.
+	const betaFlushed = page.waitForResponse(
+		async (r) =>
+			r.url().includes('source=collab-snapshot') &&
+			r.request().method() === 'PATCH' &&
+			r.ok() &&
+			(await r.text()).includes(beta),
+		{ timeout: 30_000 }
+	);
+	await editor.click();
+	await page.keyboard.press('Control+End');
+	await page.keyboard.type(' ' + beta);
+	await expect(editor).toContainText(beta);
+	await betaFlushed;
+
+	// Reload so the timeline renders the version card. Content saves deliberately
+	// do NOT auto-refresh the timeline (ItemTimeline only refreshes on
+	// comment/reaction events); a natural reload surfaces the new version entry.
+	await page.reload();
+	editor = page.locator(EDITOR_SELECTOR);
+	await expect(editor).toBeVisible();
+	await expect(editor).toContainText(beta);
+	await expect(page.locator(SYNCED_BADGE_SELECTOR)).toBeVisible();
+
+	// Type `gamma` but do NOT wait for its idle flush — it stays in the live
+	// Y.Doc, unpersisted to items.content (the BUG-2271 window). We reach the
+	// Restore click well under 5s so the idle timer can't pre-persist it.
+	await editor.click();
+	await page.keyboard.press('Control+End');
+	await page.keyboard.type(' ' + gamma);
+	await expect(editor).toContainText(gamma);
+
+	// Sanity: items.content does NOT yet hold gamma (still the unflushed window).
+	const preRestore = await request.get(`/api/v1/workspaces/${ws}/items/${slug}`, { headers });
+	expect(preRestore.ok()).toBeTruthy();
+	expect((await preRestore.json()).content as string).not.toContain(gamma);
+
+	// Drive the restore through the UI. confirmRestore must FIRST flush the live
+	// editor (gamma) into items.content, THEN POST the restore — so the server's
+	// undo-point (captured from items.content in the restore tx) includes gamma.
+	const restoreDone = page.waitForResponse(
+		(r) =>
+			/\/versions\/[^/]+\/restore$/.test(r.url()) &&
+			r.request().method() === 'POST' &&
+			r.ok(),
+		{ timeout: 30_000 }
+	);
+	const card = page.locator('#item-timeline .version-card').first();
+	await card.locator('.card-header').click(); // expand
+	await card.getByRole('button', { name: 'Restore this version' }).click();
+	await card.getByRole('button', { name: 'Confirm Restore' }).click();
+	await restoreDone;
+
+	// The undo-point version created by the restore holds the pre-restore
+	// items.content — which, thanks to the pre-restore flush, includes gamma.
+	// Under the bug no version ever holds gamma (it was lost with the op-log).
+	await expect
+		.poll(
+			async () => {
+				const vr = await request.get(
+					`/api/v1/workspaces/${ws}/items/${slug}/versions`,
+					{ headers }
+				);
+				if (!vr.ok()) return false;
+				const versions = (await vr.json()) as Array<{ content: string }>;
+				return versions.some((v) => v.content.includes(gamma));
+			},
+			{ timeout: 15_000 }
+		)
+		.toBe(true);
+});

--- a/web/src/lib/collab/wsProvider.svelte.ts
+++ b/web/src/lib/collab/wsProvider.svelte.ts
@@ -258,21 +258,6 @@ export class CollabProvider {
 	lastOpLogID = $state(0);
 
 	/**
-	 * Public read of `cursorAnchored` (below): true once the server has
-	 * delivered any op_log_cursor control frame this provider's lifetime, i.e.
-	 * the op-log cursor is anchored so a collab-snapshot flush will carry a
-	 * cursor the server can evaluate against the restore boundary. Read by the
-	 * pre-restore flush (BUG-2271 / Codex P1) to avoid flushing in the
-	 * post-reconnect, pre-anchor window where the cursor is still 0 and a durable
-	 * restore boundary would reject the PATCH. Non-reactive (the backing field
-	 * flips inside an async control-frame handler) — poll it, don't read it in a
-	 * `$effect`.
-	 */
-	get anchored(): boolean {
-		return this.cursorAnchored;
-	}
-
-	/**
 	 * True after the server has sent ANY op_log_cursor control frame
 	 * in this provider's lifetime — including the initial post-
 	 * replay cursor of 0 against an empty op-log. The boolean

--- a/web/src/lib/collab/wsProvider.svelte.ts
+++ b/web/src/lib/collab/wsProvider.svelte.ts
@@ -258,6 +258,21 @@ export class CollabProvider {
 	lastOpLogID = $state(0);
 
 	/**
+	 * Public read of `cursorAnchored` (below): true once the server has
+	 * delivered any op_log_cursor control frame this provider's lifetime, i.e.
+	 * the op-log cursor is anchored so a collab-snapshot flush will carry a
+	 * cursor the server can evaluate against the restore boundary. Read by the
+	 * pre-restore flush (BUG-2271 / Codex P1) to avoid flushing in the
+	 * post-reconnect, pre-anchor window where the cursor is still 0 and a durable
+	 * restore boundary would reject the PATCH. Non-reactive (the backing field
+	 * flips inside an async control-frame handler) — poll it, don't read it in a
+	 * `$effect`.
+	 */
+	get anchored(): boolean {
+		return this.cursorAnchored;
+	}
+
+	/**
 	 * True after the server has sent ANY op_log_cursor control frame
 	 * in this provider's lifetime — including the initial post-
 	 * replay cursor of 0 against an empty op-log. The boolean

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -3556,6 +3556,30 @@
 		// TASK-2112 / TASK-2172). A stale ctx is skipped rather than mis-flushed.
 		const ctx = activeCollabContext;
 		if (!ctx || ctx.itemId !== item.id) return;
+		// P1 (Codex on #994): a provider that just reconnected can expose the
+		// editor after its ~1s synced grace but BEFORE the server's op_log_cursor
+		// anchor arrives (lastOpLogID still 0 / not anchored). A flush issued in
+		// that window carries cursor 0, which the server rejects against a prior
+		// DURABLE restore boundary (handlers_items.go: cursor < boundary → 409) —
+		// the typed edit would be lost. Wait, bounded, for the anchor so the flush
+		// carries a boundary-satisfying cursor. Resolves immediately in the common
+		// (already-anchored) case, so it adds no latency to a normal restore; the
+		// cap keeps a never-arriving anchor from hanging the restore. If it times
+		// out unanchored, we fall through and step 2 (below) makes any resulting
+		// failure non-silent.
+		await waitForCollabAnchor(collabProvider, 1500);
+		// Re-check after the await: the pane may have switched or the editor torn
+		// down while we waited. (The flush ctx is self-routing, but don't read a
+		// destroyed editor or flush for a now-different item.)
+		if (
+			!collabProvider ||
+			!editorInstance ||
+			editorInstance.isDestroyed ||
+			!item ||
+			item.id !== ctx.itemId
+		) {
+			return;
+		}
 		// Read the live editor's markdown; fall back to the per-edit shadow if the
 		// live read throws (mirrors the flusher's readEditorMarkdown injection).
 		let md: string | null = null;
@@ -3571,8 +3595,40 @@
 		// restore blocks on it). The flusher's own dedupe short-circuits to a no-op
 		// when there are no unflushed edits, so a clean view costs at most one
 		// deduped call. We await so items.content is updated before the restore
-		// captures the undo-point; the outcome is irrelevant (best-effort).
-		await collabFlusher.flush(ctx, md, false);
+		// captures the undo-point.
+		const result = await collabFlusher.flush(ctx, md, false);
+		// Step 2 (Codex P1): 'flushed' landed the edit and 'deduped' means the
+		// server already has this exact markdown — both success. 'failed' (e.g. the
+		// boundary 409 above) and 'skipped' (force-refresh recovery: the Y.Doc
+		// markdown is known stale) mean the live edit did NOT land in items.content,
+		// so the restore's undo-point won't capture it. We must NOT block the
+		// restore — but the loss must not be silent, so surface it. (The restore
+		// still proceeds in the caller.)
+		if (result === 'failed' || result === 'skipped') {
+			toastStore.show(
+				'Your most recent edits may not be included in the restore point.',
+				'error',
+			);
+		}
+	}
+
+	// Bounded best-effort wait for the collab provider's op-log cursor anchor
+	// (BUG-2271 / Codex P1). Resolves immediately when already anchored; otherwise
+	// polls the (non-reactive) `anchored` getter until it flips or the deadline
+	// passes, then resolves regardless (best-effort — never rejects, never hangs).
+	function waitForCollabAnchor(provider: CollabProvider, timeoutMs: number): Promise<void> {
+		if (provider.anchored) return Promise.resolve();
+		return new Promise((resolve) => {
+			const deadline = Date.now() + timeoutMs;
+			const tick = () => {
+				if (provider.anchored || Date.now() >= deadline) {
+					resolve();
+					return;
+				}
+				setTimeout(tick, 50);
+			};
+			setTimeout(tick, 50);
+		});
 	}
 
 	async function handleDelete() {

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -3523,6 +3523,58 @@
 		item = withInflightTags(updatedItem);
 	}
 
+	// BUG-2271: flush the LIVE collab editor's markdown into items.content BEFORE
+	// a version restore issues its POST. The restore's server-side undo-point
+	// ("Restored from…") is captured from the CURRENT persisted items.content
+	// inside the restore tx; a live collab editor may hold edits still sitting in
+	// the Y.Doc/op-log within the ~5s flush-debounce window (not yet PATCHed).
+	// Those edits would be lost after the restore prunes the op-log + reseeds all
+	// peers (BUG-2264). The collab server is a dumb relay with no Yjs decoder, so
+	// it CANNOT render the live Y.Doc to markdown — the only place that can is
+	// this initiating client. So we drain the live editor into items.content here
+	// (via the same `?source=collab-snapshot` flush the idle timer uses); with no
+	// restore boundary set yet, the flush passes and the undo-point then reflects
+	// the true pre-restore live state. Threaded down to TimelineVersionCard, which
+	// awaits it immediately before `api.versions.restore`.
+	//
+	// RESIDUAL (accepted, do NOT try to close): only THIS client's editor is
+	// flushed. An edit a peer typed but that hasn't yet synced over the WS to this
+	// initiator (sub-second window) still isn't captured — this narrows BUG-2271
+	// from the ~5s debounce window to the sub-second sync window, the accepted
+	// trade of the client-side approach (the relay can't decode the Y.Doc).
+	async function flushCollabBeforeRestore(): Promise<void> {
+		// No LIVE collab editor to drain: non-collab item, raw mode (provider
+		// destroyed), a viewer (no provider/editor), or the editor isn't mounted.
+		// In every such case items.content is already canonical, so no-op.
+		if (!collabProvider || !editorInstance || editorInstance.isDestroyed || !item) return;
+		// Flush against the context the connected provider was minted with (captured
+		// at $effect-body time, NOT live route state), so the PATCH is self-routing
+		// and can never cross-write another item. Switch-safety: activeCollabContext
+		// and the live editor are minted together for the shown item and reset
+		// together on a no-{#key} pane switch, so require they still agree with the
+		// shown item before flushing (mirrors the rich→raw toggle fences —
+		// TASK-2112 / TASK-2172). A stale ctx is skipped rather than mis-flushed.
+		const ctx = activeCollabContext;
+		if (!ctx || ctx.itemId !== item.id) return;
+		// Read the live editor's markdown; fall back to the per-edit shadow if the
+		// live read throws (mirrors the flusher's readEditorMarkdown injection).
+		let md: string | null = null;
+		try {
+			const raw = (editorInstance.storage as any).markdown?.getMarkdown?.();
+			if (typeof raw === 'string') md = raw;
+		} catch {
+			// Live read failed — fall through to the shadow.
+		}
+		if (md == null) md = lastEditorMarkdown;
+		if (md == null) return;
+		// keepalive=false — this is a foreground flush the user is waiting on (the
+		// restore blocks on it). The flusher's own dedupe short-circuits to a no-op
+		// when there are no unflushed edits, so a clean view costs at most one
+		// deduped call. We await so items.content is updated before the restore
+		// captures the undo-point; the outcome is irrelevant (best-effort).
+		await collabFlusher.flush(ctx, md, false);
+	}
+
 	async function handleDelete() {
 		if (!item || !canEdit) return;
 		// Capture identity before the await. The DELETE targets `targetItem.id`
@@ -5011,6 +5063,7 @@
 				currentContent={item.content ?? ''}
 				items={localIndex.getAll(wsSlug)}
 				onRestore={handleVersionRestore}
+				flushBeforeRestore={flushCollabBeforeRestore}
 				itemId={item.id}
 				collectionId={item.collection_id}
 				frozen={false}

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -3556,30 +3556,6 @@
 		// TASK-2112 / TASK-2172). A stale ctx is skipped rather than mis-flushed.
 		const ctx = activeCollabContext;
 		if (!ctx || ctx.itemId !== item.id) return;
-		// P1 (Codex on #994): a provider that just reconnected can expose the
-		// editor after its ~1s synced grace but BEFORE the server's op_log_cursor
-		// anchor arrives (lastOpLogID still 0 / not anchored). A flush issued in
-		// that window carries cursor 0, which the server rejects against a prior
-		// DURABLE restore boundary (handlers_items.go: cursor < boundary → 409) —
-		// the typed edit would be lost. Wait, bounded, for the anchor so the flush
-		// carries a boundary-satisfying cursor. Resolves immediately in the common
-		// (already-anchored) case, so it adds no latency to a normal restore; the
-		// cap keeps a never-arriving anchor from hanging the restore. If it times
-		// out unanchored, we fall through and step 2 (below) makes any resulting
-		// failure non-silent.
-		await waitForCollabAnchor(collabProvider, 1500);
-		// Re-check after the await: the pane may have switched or the editor torn
-		// down while we waited. (The flush ctx is self-routing, but don't read a
-		// destroyed editor or flush for a now-different item.)
-		if (
-			!collabProvider ||
-			!editorInstance ||
-			editorInstance.isDestroyed ||
-			!item ||
-			item.id !== ctx.itemId
-		) {
-			return;
-		}
 		// Read the live editor's markdown; fall back to the per-edit shadow if the
 		// live read throws (mirrors the flusher's readEditorMarkdown injection).
 		let md: string | null = null;
@@ -3595,40 +3571,39 @@
 		// restore blocks on it). The flusher's own dedupe short-circuits to a no-op
 		// when there are no unflushed edits, so a clean view costs at most one
 		// deduped call. We await so items.content is updated before the restore
-		// captures the undo-point.
+		// captures the undo-point. The flush ctx is self-routing (PATCHes ctx's
+		// item), so a same-item provider replacement during the await can't
+		// cross-write, and the only post-await action is an informational toast —
+		// switch-safe regardless of where the pane is now.
 		const result = await collabFlusher.flush(ctx, md, false);
-		// Step 2 (Codex P1): 'flushed' landed the edit and 'deduped' means the
-		// server already has this exact markdown — both success. 'failed' (e.g. the
-		// boundary 409 above) and 'skipped' (force-refresh recovery: the Y.Doc
-		// markdown is known stale) mean the live edit did NOT land in items.content,
-		// so the restore's undo-point won't capture it. We must NOT block the
-		// restore — but the loss must not be silent, so surface it. (The restore
-		// still proceeds in the caller.)
-		if (result === 'failed' || result === 'skipped') {
+		// Non-silent failure (Codex P1 on #994). Warn ONLY on 'failed' — an
+		// attempted, non-deduped snapshot PATCH the server rejected (e.g. the
+		// restore-boundary 409 in the narrow post-reconnect cursor-0 window; see
+		// the residual note below), so the live edit did NOT land in items.content
+		// and the undo-point won't capture it. The other outcomes are NOT losses:
+		// 'flushed' landed it; 'deduped' means the server already has this exact
+		// markdown; 'skipped' is force-refresh recovery which either attempted no
+		// PATCH (nothing to lose) OR the PATCH already succeeded before
+		// forceRefreshInFlight flipped (content IS in items.content + the
+		// undo-point) — so warning on 'skipped' would mis-fire on ordinary
+		// restores. The restore itself is never blocked (the caller proceeds).
+		if (result === 'failed') {
 			toastStore.show(
 				'Your most recent edits may not be included in the restore point.',
 				'error',
 			);
 		}
-	}
-
-	// Bounded best-effort wait for the collab provider's op-log cursor anchor
-	// (BUG-2271 / Codex P1). Resolves immediately when already anchored; otherwise
-	// polls the (non-reactive) `anchored` getter until it flips or the deadline
-	// passes, then resolves regardless (best-effort — never rejects, never hangs).
-	function waitForCollabAnchor(provider: CollabProvider, timeoutMs: number): Promise<void> {
-		if (provider.anchored) return Promise.resolve();
-		return new Promise((resolve) => {
-			const deadline = Date.now() + timeoutMs;
-			const tick = () => {
-				if (provider.anchored || Date.now() >= deadline) {
-					resolve();
-					return;
-				}
-				setTimeout(tick, 50);
-			};
-			setTimeout(tick, 50);
-		});
+		// RESIDUAL (accepted): in the narrow window where the provider has just
+		// reconnected and the editor is exposed BEFORE the new connection's
+		// op_log_cursor anchor arrives (cursor still 0), a flush against an item
+		// with a prior DURABLE restore boundary is rejected (cursor < boundary →
+		// 409) and lands as 'failed' above — the user is warned rather than
+		// silently losing the edit. We deliberately do NOT pre-wait for the anchor:
+		// the anchor flag is lifetime-scoped (stays true across reconnects), so a
+		// wait wouldn't actually gate the NEW connection, and per-connection
+		// scoping would entangle the delicate TASK-1319 pre-anchor buffering /
+		// force-refresh machinery. The warn-only path is the proportionate outcome
+		// for this narrow case.
 	}
 
 	async function handleDelete() {

--- a/web/src/lib/components/timeline/ItemTimeline.svelte
+++ b/web/src/lib/components/timeline/ItemTimeline.svelte
@@ -54,9 +54,18 @@
 		 * active editor. Defaults false → byte-identical for every existing caller.
 		 */
 		restoreFrozen?: boolean;
+		/**
+		 * BUG-2271: forwarded verbatim to TimelineVersionCard so the initiating
+		 * client can flush its LIVE collab editor markdown into items.content
+		 * BEFORE a restore captures the server-side undo-point (otherwise in-flight
+		 * edits still in the ~5s flush-debounce window are lost). Threaded from
+		 * ItemDetail, which owns the collab flusher. Unset → no-op for non-collab
+		 * callers, so existing usage is unaffected.
+		 */
+		flushBeforeRestore?: () => Promise<void>;
 	}
 
-	let { wsSlug, username = '', itemSlug, currentContent, items = [], onRestore, itemId, collectionId, frozen = false, restoreFrozen = false }: Props = $props();
+	let { wsSlug, username = '', itemSlug, currentContent, items = [], onRestore, itemId, collectionId, frozen = false, restoreFrozen = false, flushBeforeRestore }: Props = $props();
 
 	// Resolve canEditItem reactively; falls to false if itemId/collectionId
 	// aren't supplied (e.g. an older caller). Folds in the master-freeze gate
@@ -503,6 +512,7 @@
 								{itemSlug}
 								{currentContent}
 								{onRestore}
+								{flushBeforeRestore}
 								frozen={frozen || restoreFrozen}
 							/>
 						{/if}

--- a/web/src/lib/components/timeline/TimelineVersionCard.svelte
+++ b/web/src/lib/components/timeline/TimelineVersionCard.svelte
@@ -17,9 +17,24 @@
 		 * byte-identical for existing callers.
 		 */
 		frozen?: boolean;
+		/**
+		 * BUG-2271: flush the initiating client's LIVE collab editor markdown into
+		 * items.content BEFORE the restore POST runs. The restore's server-side
+		 * undo-point ("Restored from…") is captured from the CURRENT persisted
+		 * items.content inside the restore tx; a live collab editor may hold edits
+		 * still sitting in the Y.Doc/op-log within the ~5s flush-debounce window
+		 * (not yet PATCHed). Without this flush those edits aren't captured in the
+		 * undo-point and are lost after the restore wipes the op-log + reseeds peers
+		 * (BUG-2264). The collab server is a dumb relay with no Yjs decoder, so the
+		 * ONLY place that can render the live doc to markdown is the initiating
+		 * client — hence a client-side flush here. ItemDetail owns the flusher and
+		 * threads this down through ItemTimeline; leave it unset (no-op) for
+		 * non-collab / other callers, who are then byte-identical to before.
+		 */
+		flushBeforeRestore?: () => Promise<void>;
 	}
 
-	let { version, wsSlug, itemSlug, currentContent, onRestore, frozen = false }: Props = $props();
+	let { version, wsSlug, itemSlug, currentContent, onRestore, frozen = false, flushBeforeRestore }: Props = $props();
 
 	let expanded = $state(false);
 	let confirming = $state(false);
@@ -87,6 +102,19 @@
 		const reqWs = wsSlug;
 		restoring = true;
 		try {
+			// BUG-2271: flush the initiating client's live collab editor into
+			// items.content FIRST, so the restore's undo-point (captured from
+			// items.content server-side, inside the restore tx) reflects in-flight
+			// edits not yet PATCHed. Best-effort: a flush failure must NOT block a
+			// user-confirmed restore, so swallow and proceed. The flush is
+			// self-routing (it PATCHes the item it was minted against), so no
+			// cross-write is possible even if the pane switched mid-await; the
+			// restore below re-fences on reqSlug/reqWs as before.
+			try {
+				await flushBeforeRestore?.();
+			} catch {
+				// Swallow — proceed with the restore regardless.
+			}
 			const updatedItem = await api.versions.restore(reqWs, reqSlug, version.id);
 			if (reqSlug !== itemSlug || reqWs !== wsSlug) return;
 			confirming = false;

--- a/web/src/lib/components/timeline/TimelineVersionCard.svelte.test.ts
+++ b/web/src/lib/components/timeline/TimelineVersionCard.svelte.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import { flushSync, mount, unmount } from 'svelte';
 import TimelineVersionCard from './TimelineVersionCard.svelte';
 import type { Version } from '$lib/types';
@@ -10,6 +10,31 @@ import type { Version } from '$lib/types';
 // `restoreFrozen={peeking}` → ItemTimeline passes `frozen={frozen || restoreFrozen}`
 // → TimelineVersionCard's `frozen`. This mounts the ACTUAL card (not a probe) to
 // lock the terminal gate: the restore control is present iff NOT frozen.
+//
+// BUG-2271 — the same real card also owns the flush-before-restore contract:
+// confirmRestore must AWAIT `flushBeforeRestore` (which drains the initiating
+// client's live collab editor into items.content) BEFORE issuing the restore
+// POST, so the server-side undo-point captures in-flight edits — and must NOT let
+// a flush failure block the restore. We mock the API client so the restore is a
+// recorded no-op and assert call ORDER against a passed flush spy.
+
+// `vi.mock`'s factory is hoisted above imports, so the shared order array must be
+// created via `vi.hoisted` to be referenceable from inside the factory.
+const { apiCalls } = vi.hoisted(() => ({ apiCalls: [] as string[] }));
+
+vi.mock('$lib/api/client', () => ({
+	api: {
+		versions: {
+			restore: vi.fn(async () => {
+				apiCalls.push('restore');
+				return { id: 'i1' };
+			}),
+			// Never reached (the fixture version is non-diff so ensureResolved
+			// short-circuits), but present so the module shape is complete.
+			get: vi.fn(async () => ({ content: '' })),
+		},
+	},
+}));
 
 function target(): HTMLElement {
 	return document.body.appendChild(document.createElement('div'));
@@ -60,5 +85,68 @@ describe('TimelineVersionCard restore gate (BUG-2263)', () => {
 	it('HIDES the restore control when frozen (peeking side — same-item content collision)', () => {
 		const r = render(true);
 		expect(r.querySelector('.restore-area')).toBeNull();
+	});
+});
+
+describe('TimelineVersionCard flush-before-restore (BUG-2271)', () => {
+	let root: HTMLElement | null = null;
+	let instance: ReturnType<typeof mount> | null = null;
+
+	// Mount the card, expand it, and drive Restore → Confirm Restore.
+	function confirmRestoreFlow(flushBeforeRestore: () => Promise<void>) {
+		root = target();
+		instance = mount(TimelineVersionCard, {
+			target: root,
+			props: {
+				version,
+				wsSlug: 'ws',
+				itemSlug: 'ITEM-1',
+				currentContent: 'now',
+				onRestore: () => {},
+				flushBeforeRestore,
+			},
+		});
+		flushSync();
+		(root.querySelector('.card-header') as HTMLButtonElement).click(); // expand
+		flushSync();
+		(root.querySelector('.btn-restore') as HTMLButtonElement).click(); // startRestore
+		flushSync();
+		(root.querySelector('.btn-restore-confirm') as HTMLButtonElement).click(); // confirmRestore
+		flushSync();
+	}
+
+	afterEach(() => {
+		if (instance) unmount(instance);
+		root?.remove();
+		instance = null;
+		root = null;
+		apiCalls.length = 0;
+	});
+
+	it('awaits flushBeforeRestore BEFORE issuing the restore POST', async () => {
+		const flushBeforeRestore = vi.fn(async () => {
+			// Resolve on a real microtask: if confirmRestore did NOT await the
+			// flush, the restore POST would win this race and record 'restore'
+			// first — so the ['flush','restore'] ordering only holds when the
+			// flush is genuinely awaited before the restore.
+			await Promise.resolve();
+			apiCalls.push('flush');
+		});
+		confirmRestoreFlow(flushBeforeRestore);
+		await vi.waitFor(() => {
+			expect(apiCalls).toEqual(['flush', 'restore']);
+		});
+		expect(flushBeforeRestore).toHaveBeenCalledTimes(1);
+	});
+
+	it('still restores when flushBeforeRestore rejects (best-effort flush)', async () => {
+		const flushBeforeRestore = vi.fn(async () => {
+			throw new Error('flush failed');
+		});
+		confirmRestoreFlow(flushBeforeRestore);
+		// A flush failure must not block a user-confirmed restore.
+		await vi.waitFor(() => {
+			expect(apiCalls).toContain('restore');
+		});
 	});
 });


### PR DESCRIPTION
## BUG-2271

A version restore builds its **"Restored from…" undo-point** version from the CURRENT persisted `items.content`, server-side, inside the restore tx. If a live collab editor holds edits still sitting in the Y.Doc/op-log within the ~5s flush-debounce window (not yet PATCHed to `items.content`), those edits are absent from the undo-point — and, since the restore also prunes the op-log + reseeds every peer (BUG-2264), they are **permanently lost**.

## Why the fix is client-side

The collab server is a **dumb relay with no Yjs decoder**, so it cannot render the live Y.Doc to markdown. The only place that can is the **initiating client**. So the fix flushes the live editor markdown into `items.content` BEFORE the restore is issued; the server's undo-point (captured from `items.content`) then reflects the true pre-restore live state. No server change is needed or possible. (Dave explicitly chose this approach.)

## Change

- Thread an async `flushBeforeRestore` callback prop from `ItemDetail.svelte` (which owns the collab flusher) → `ItemTimeline.svelte` → `TimelineVersionCard.svelte`. Unset → no-op, so non-collab / other callers are byte-identical.
- `TimelineVersionCard.confirmRestore` `await`s `flushBeforeRestore?.()` immediately before `api.versions.restore(...)`, wrapped in try/catch — **best-effort**: a flush failure must not block a user-confirmed restore.
- `ItemDetail.flushCollabBeforeRestore` reuses the existing `collabFlusher` + live-editor read: when a collab provider is active and the editor is mounted, it drains the live markdown into `items.content` via the existing `?source=collab-snapshot` flush and awaits it. No-op for non-collab items / raw mode / viewers (`items.content` already canonical). The flush is **self-routing** against the captured collab context, so it can never cross-write another item, and it respects the existing switch-safety fences (`activeCollabContext.itemId === item.id`).

## Residual (accepted, not closed)

Only the **initiating client's** editor is flushed — an edit a peer typed but that hasn't yet synced over the WS to the initiator (sub-second window) still isn't captured. This narrows BUG-2271 from the ~5s debounce window to the sub-second sync window, the accepted trade of the client-side approach.

## Tests

- **vitest** (`TimelineVersionCard.svelte.test.ts`): 2 new cases — the flush is awaited BEFORE the restore POST (ordering), and a rejected flush still proceeds to restore (best-effort).
- **e2e** (`version-restore-collab.spec.ts`): a new sibling test drives the restore through the **real UI button** and asserts an unflushed live edit is captured in the undo-point after restore. (E2E can't run locally; CI verifies on push.)

## Gates (web, all pass)

- `npm run check` — 0 errors
- `npm run build` — success
- `npm run test` — 464 passed (36 files)

https://claude.ai/code/session_01EZ6yr6pAUFb1uffan912ra