### PR TITLE
fix(collab): release-on-resolve applier fence for restore-rollback vs applier-ack race (BUG-2276 residual 2)

### DIFF
--- a/internal/collab/applier.go
+++ b/internal/collab/applier.go
@@ -149,9 +149,28 @@ type ControlMessage struct {
 // double-send. expectedConn lets the server reject acks/brackets from other peers
 // (defence in depth). The bracket baselines are captured at request-send and
 // refined at apply_start (BUG-2276 residual 2).
+// applierOutcome is the DURABLE resolution of an applier round-trip (BUG-2276
+// residual 2). It is derived from op-log state, never a timer.
+type applierOutcome int
+
+const (
+	// applierPersisted — the applier's setContent durably landed (or was a no-op-diff
+	// on already-current content). Success; never re-applied.
+	applierPersisted applierOutcome = iota
+	// applierNotPersisted — the setContent DID NOT land (dropped by a freeze, or its
+	// frame is still in flight and will now be dropped). Safe to re-apply after the
+	// restore resolves — nothing landed to clobber.
+	applierNotPersisted
+	// applierAmbiguous — a legacy (non-bracket-capable) round-trip caught by a freeze:
+	// its setContent MIGHT have persisted, but without the apply_start bracket the
+	// server can't confirm. FAIL-SAFE: the external write is NOT re-applied (that
+	// could clobber peer edits) — it is returned as retryable via ErrApplierAmbiguous.
+	applierAmbiguous
+)
+
 type pendingApplierAck struct {
 	expectedConn *websocket.Conn
-	resultCh     chan bool
+	resultCh     chan applierOutcome
 
 	// startPersistedOpID / startFrozenDropSeq are the applier conn's durable
 	// high-water + frozen-drop count at the START of the apply bracket. Seeded at
@@ -159,8 +178,7 @@ type pendingApplierAck struct {
 	// scopes to exactly the setContent frame.
 	startPersistedOpID int64
 	startFrozenDropSeq int64
-	// applyStarted is set when apply_start was received. Finalization treats an
-	// un-bracketed round-trip as not-persisted (safe: retry, never a false success).
+	// applyStarted is set when apply_start was received.
 	applyStarted bool
 	// delivered guards resultCh against a double send (ack vs finalization race).
 	delivered bool
@@ -168,13 +186,13 @@ type pendingApplierAck struct {
 
 // deliver sends the round-trip's durable outcome exactly once. MUST be called with
 // r.pendingMu held.
-func (p *pendingApplierAck) deliver(success bool) {
+func (p *pendingApplierAck) deliver(o applierOutcome) {
 	if p.delivered {
 		return
 	}
 	p.delivered = true
 	select {
-	case p.resultCh <- success:
+	case p.resultCh <- o:
 	default:
 	}
 }
@@ -195,6 +213,13 @@ var (
 	// ack. Caller falls back to direct write and (depending on
 	// preference) logs a warn so operators can see degraded sessions.
 	ErrAllAppliersTimedOut = errors.New("collab: all designated appliers timed out")
+
+	// ErrApplierAmbiguous — a legacy (non-bracket-capable) applier round-trip was
+	// caught by a concurrent version restore and cannot be confirmed persisted
+	// (BUG-2276 residual 2, P1 mixed-deploy window). The caller MUST NOT fall back to
+	// a direct write / re-apply (either could clobber); instead it returns a RETRYABLE
+	// error to the external-write caller so the write is retried once clients converge.
+	ErrApplierAmbiguous = errors.New("collab: applier outcome ambiguous (legacy conn during restore); retry")
 )
 
 // ApplyExternalContent routes an external content update through a
@@ -265,7 +290,9 @@ func (m *RoomManager) electAndApply(room *Room, itemID, markdown string) (error,
 	for attempt := 0; attempt < applierMaxAttempts; attempt++ {
 		// Enter the restore gate FIRST so we wait out any in-progress restore
 		// before electing. `waited` means a restore held the room and just
-		// resolved — restart the whole election (the room's conn set changed).
+		// resolved — restart the whole election (the room's conn set changed). A
+		// !waited return ADMITS us; finishAdmission MUST run before we wait on the
+		// outcome so a concurrent beginRestore drains us (P1).
 		if room.enterApplierGate() {
 			return nil, true
 		}
@@ -273,6 +300,7 @@ func (m *RoomManager) electAndApply(room *Room, itemID, markdown string) (error,
 		applier := room.pickApplier(tried)
 		if applier == nil {
 			// No more candidates left.
+			room.finishAdmission()
 			if !anyWriteSucceeded {
 				return ErrNoApplierAvailable, false
 			}
@@ -281,6 +309,9 @@ func (m *RoomManager) electAndApply(room *Room, itemID, markdown string) (error,
 		tried[applier.conn] = struct{}{}
 
 		resultCh, registerErr := room.registerPendingAck(requestID, applier)
+		// End the admission span the instant registration is done (entry now visible
+		// to freezeAndFinalizePending), whether it succeeded or not.
+		room.finishAdmission()
 		if registerErr != nil {
 			// Race: room closed between pickApplier and registration.
 			return registerErr, false
@@ -334,24 +365,39 @@ func (m *RoomManager) electAndApply(room *Room, itemID, markdown string) (error,
 
 		// Wait for the DURABLE outcome OR timeout.
 		select {
-		case success := <-resultCh:
+		case outcome := <-resultCh:
 			room.cancelPendingAck(requestID)
-			if success {
+			switch outcome {
+			case applierPersisted:
 				// The applier's setContent durably landed (no frame in its apply
 				// bracket was frozen-dropped). All peers are on the new state.
 				return nil, false
+			case applierAmbiguous:
+				// Legacy conn caught by a restore: setContent MIGHT have landed but we
+				// can't confirm. FAIL-SAFE — do NOT re-apply (that could clobber peer
+				// edits); return retryable so the external write is retried once
+				// clients converge (BUG-2276 residual 2, P1 mixed-deploy window). Wait
+				// for the restore to resolve first so the caller's retry isn't a busy
+				// spin against a still-frozen room.
+				room.waitRestoreResolved()
+				slog.Warn("collab: applier round-trip ambiguous (legacy conn during restore); returning retryable",
+					"item_id", itemID,
+					"client_id", applier.id,
+				)
+				return ErrApplierAmbiguous, false
+			default: // applierNotPersisted
+				// A version restore froze this apply, so setContent did NOT land. This
+				// is a DURABLE determination (see restore_coord.go), not a timing guess
+				// — so we never re-apply over a landed edit. Wait for the restore to
+				// resolve, then restart the election: re-apply on rollback (unfrozen
+				// room), fall back on commit (force-closed room).
+				room.waitRestoreResolved() // bounded to the restore-tx duration
+				slog.Info("collab: applier round-trip superseded by version restore; will re-elect",
+					"item_id", itemID,
+					"client_id", applier.id,
+				)
+				return nil, true
 			}
-			// Not persisted: a version restore froze this apply, so setContent did
-			// NOT land. This is a DURABLE determination (see restore_coord.go), not a
-			// timing guess — so we never re-apply over a landed edit. Wait for the
-			// restore to resolve, then restart the election: re-apply on rollback
-			// (unfrozen room), fall back on commit (force-closed room).
-			room.waitRestoreResolved() // bounded to the restore-tx duration
-			slog.Info("collab: applier round-trip superseded by version restore; will re-elect",
-				"item_id", itemID,
-				"client_id", applier.id,
-			)
-			return nil, true
 		case <-time.After(timeouts[attempt]):
 			room.cancelPendingAck(requestID)
 			slog.Warn("collab: applier_request timed out; will retry next applier",
@@ -435,7 +481,17 @@ func (r *Room) pickApplier(tried map[*websocket.Conn]struct{}) *roomConn {
 		// success/commit path leaves conns frozen until they are force-closed, so a
 		// commit-case re-election must skip them → returns nil → the caller's
 		// direct-write fallback. (BUG-2276 residual 2.)
-		if !rc.canWrite.Load() || rc.frozen.Load() {
+		//
+		// An UNANCHORED conn (replayDone not yet flipped) is excluded (BUG-2276
+		// residual 2, P1): a conn is in the room map BEFORE runConn writes its initial
+		// op_log_cursor, and its client buffers Y.Doc updates until it receives that
+		// cursor (cursorAnchored). Electing it in that window means setContent produces
+		// a BUFFERED frame that is never sent, yet the client still acks — a false
+		// success for a never-persisted write. replayDone flips right after the cursor
+		// is written under writeMu, and any later applier_request is ordered behind
+		// that cursor on the same conn, so an elected (replayDone) conn is guaranteed
+		// anchored before it applies.
+		if !rc.canWrite.Load() || rc.frozen.Load() || !rc.replayDone.Load() {
 			continue
 		}
 		candidates = append(candidates, rc)
@@ -445,9 +501,15 @@ func (r *Room) pickApplier(tried map[*websocket.Conn]struct{}) *roomConn {
 	if len(candidates) == 0 {
 		return nil
 	}
-	// Stable: longest-connected first; tiebreak on conn id (which
-	// is monotonic within the process).
+	// Stable ordering. PRIMARY: bracket-capable conns first (BUG-2276 residual 2, P1)
+	// — prefer a conn whose applier outcome the freeze can confirm durably, so we
+	// avoid the legacy-ambiguous fail-safe whenever any capable conn exists. SECONDARY:
+	// longest-connected (most authoritative cumulative Y.Doc); tiebreak on conn id.
 	sort.SliceStable(candidates, func(i, j int) bool {
+		ci, cj := candidates[i].bracketCapable.Load(), candidates[j].bracketCapable.Load()
+		if ci != cj {
+			return ci // capable (true) sorts before non-capable (false)
+		}
 		if !candidates[i].connectedAt.Equal(candidates[j].connectedAt) {
 			return candidates[i].connectedAt.Before(candidates[j].connectedAt)
 		}
@@ -462,7 +524,7 @@ func (r *Room) pickApplier(tried map[*websocket.Conn]struct{}) *roomConn {
 // later by apply_start). Returns the result channel the caller selects on (true =
 // the applier's content durably landed, false = it did not), or an error if the room
 // is no longer accepting requests.
-func (r *Room) registerPendingAck(requestID string, applier *roomConn) (<-chan bool, error) {
+func (r *Room) registerPendingAck(requestID string, applier *roomConn) (<-chan applierOutcome, error) {
 	r.mu.Lock()
 	closing := r.closing
 	r.mu.Unlock()
@@ -477,7 +539,7 @@ func (r *Room) registerPendingAck(requestID string, applier *roomConn) (<-chan b
 		// is effectively impossible.
 		return nil, fmt.Errorf("collab: duplicate request_id %s", requestID)
 	}
-	ch := make(chan bool, 1)
+	ch := make(chan applierOutcome, 1)
 	r.pendingAcks[requestID] = &pendingApplierAck{
 		expectedConn:       applier.conn,
 		resultCh:           ch,
@@ -515,12 +577,14 @@ func (r *Room) startApplierApply(requestID string, rc *roomConn) {
 }
 
 // resolveApplierAck resolves the round-trip on receipt of the applier_ack (the
-// bracket end), from durable state: SUCCESS iff no frame in the apply bracket was
-// frozen-dropped (frozenDropSeq unchanged). A no-op-diff setContent, which persists
-// nothing, also resolves to success (nothing was dropped → the doc already reflects
-// the content). Delivers the outcome once; a concurrent restore finalization may
-// have delivered first (idempotent). Only the expected conn may resolve. Called by
-// readLoop on an applier_ack control message. (BUG-2276 residual 2.)
+// bracket end), from durable state. If no frame was frozen-dropped in the bracket
+// (frozenDropSeq unchanged) → applierPersisted (a no-op-diff setContent, dropping
+// nothing, also succeeds — the doc already reflects the content). If a frame WAS
+// frozen-dropped: for a bracket-capable, apply_start-opened round-trip the bracket
+// scopes the drop to the setContent frame → applierNotPersisted (safe re-apply); for
+// a legacy/un-bracketed round-trip the drop can't be attributed → applierAmbiguous
+// (fail-safe). Delivers once; a concurrent restore finalization may have delivered
+// first (idempotent). Only the expected conn may resolve. (BUG-2276 residual 2.)
 func (r *Room) resolveApplierAck(requestID string, rc *roomConn) {
 	r.pendingMu.Lock()
 	defer r.pendingMu.Unlock()
@@ -535,19 +599,34 @@ func (r *Room) resolveApplierAck(requestID string, rc *roomConn) {
 		return
 	}
 	dropped := rc.frozenDropSeq.Load() > pending.startFrozenDropSeq
-	pending.deliver(!dropped)
+	switch {
+	case !dropped:
+		pending.deliver(applierPersisted)
+	case rc.bracketCapable.Load() && pending.applyStarted:
+		pending.deliver(applierNotPersisted)
+	default:
+		pending.deliver(applierAmbiguous)
+	}
 }
 
 // freezeAndFinalizePending is the atomic heart of the version-restore ↔ applier
 // coordination (BUG-2276 residual 2). Called by ForceRefreshRoom with appendMu held,
 // it (1) marks every conn frozen and (2) FINALIZES every in-flight applier
-// round-trip from durable op-log state — success iff the applier conn's high-water
-// advanced past the bracket baseline (its setContent frame durably landed BEFORE
-// this freeze). Because the freeze and the high-water read share the appendMu
-// critical section, a frame still in flight is blocked on appendMu and will be
-// dropped once the freeze is visible — so a NOT-advanced entry is a durable "did not
-// land", never a race. An un-bracketed round-trip (apply_start not seen) is treated
-// as not-persisted (safe: it re-elects; never a false success).
+// round-trip from durable op-log state. Because the freeze and the high-water read
+// share the appendMu critical section, a frame still in flight is blocked on appendMu
+// and will be dropped once the freeze is visible — so a NOT-advanced high-water is a
+// durable "did not land", never a race. Outcomes:
+//   - apply_start seen AND high-water advanced past the bracket baseline →
+//     applierPersisted (landed before the freeze; never re-applied).
+//   - apply_start seen (bracket-capable) but not advanced → applierNotPersisted (its
+//     frame is in flight and will now be dropped; safe re-apply).
+//   - NO apply_start on a bracket-CAPABLE conn → applierNotPersisted (the client sends
+//     apply_start before its frame, so an unseen apply_start means the frame hasn't
+//     landed either; safe re-apply).
+//   - NO apply_start on a LEGACY conn (not bracket-capable) → applierAmbiguous: the
+//     legacy client may have persisted setContent before the freeze but the server
+//     can't confirm it, so re-applying could clobber. FAIL-SAFE (ErrApplierAmbiguous;
+//     retryable). rc==nil (conn gone) is also treated as ambiguous.
 //
 // Lock order: caller holds appendMu; we take room.mu then release it before
 // pendingMu, so no room.mu↔pendingMu nesting. No socket I/O under any lock.
@@ -563,11 +642,26 @@ func (r *Room) freezeAndFinalizePending() {
 	r.pendingMu.Lock()
 	for _, pending := range r.pendingAcks {
 		rc := conns[pending.expectedConn]
-		persisted := false
-		if rc != nil && pending.applyStarted {
-			persisted = rc.lastPersistedOpID.Load() > pending.startPersistedOpID
+		var outcome applierOutcome
+		switch {
+		case rc == nil:
+			// Applier conn gone; can't confirm — fail safe.
+			outcome = applierAmbiguous
+		case pending.applyStarted:
+			if rc.lastPersistedOpID.Load() > pending.startPersistedOpID {
+				outcome = applierPersisted
+			} else {
+				outcome = applierNotPersisted
+			}
+		case rc.bracketCapable.Load():
+			// Capable conn, apply_start not yet processed → its frame (which follows
+			// apply_start on the same conn) hasn't landed → safe re-apply.
+			outcome = applierNotPersisted
+		default:
+			// Legacy conn, no bracket → can't attribute; fail safe.
+			outcome = applierAmbiguous
 		}
-		pending.deliver(persisted)
+		pending.deliver(outcome)
 	}
 	r.pendingMu.Unlock()
 }

--- a/internal/collab/applier.go
+++ b/internal/collab/applier.go
@@ -166,6 +166,13 @@ var (
 // The function blocks until ack OR all attempts time out — the PATCH
 // handler stays open during this window and the caller sees the
 // final outcome on return.
+//
+// A concurrent version restore (ForceRefreshRoom) is serialised against the
+// round-trip via the per-room restore gate (BUG-2276 residual 2, see
+// restore_coord.go): if a restore preempts an in-flight election (or is in progress
+// when one starts), the election restarts from scratch once the restore RESOLVES —
+// on rollback against the unfrozen room, on commit against the force-closed room.
+// The outer loop caps those restarts.
 func (m *RoomManager) ApplyExternalContent(itemID string, markdown string) error {
 	m.mu.Lock()
 	if m.closed {
@@ -179,6 +186,27 @@ func (m *RoomManager) ApplyExternalContent(itemID string, markdown string) error
 		return ErrNoActiveRoom
 	}
 
+	for restart := 0; restart < applierMaxRestartsAfterRestore; restart++ {
+		err, preempted := m.electAndApply(room, itemID, markdown)
+		if !preempted {
+			return err
+		}
+		// A version restore preempted / blocked this election and has now
+		// resolved (electAndApply already waited it out). Re-elect from scratch:
+		// a fresh request_id + tried set against the post-restore room.
+	}
+	// Restore storm: fall back to a direct write rather than spin.
+	return ErrNoApplierAvailable
+}
+
+// electAndApply runs one designated-applier election (first attempt + one retry)
+// against the room, bracketed by the restore gate. It returns (err, preempted):
+// preempted==true means a version restore interrupted the election and has resolved,
+// so ApplyExternalContent should restart; err is meaningless in that case. When
+// preempted==false, err is the final outcome (nil on ack, or a sentinel).
+func (m *RoomManager) electAndApply(room *Room, itemID, markdown string) (error, bool) {
+	// A FRESH request_id per election: a late ack from a preempted prior election
+	// (same conn, re-picked after a rollback) can't be mistaken for this one's.
 	requestID := uuid.NewString()
 	timeouts := []time.Duration{applierFirstTimeout(), applierRetryTimeout()}
 
@@ -194,20 +222,31 @@ func (m *RoomManager) ApplyExternalContent(itemID string, markdown string) error
 	// review round 5.
 	var anyWriteSucceeded bool
 	for attempt := 0; attempt < applierMaxAttempts; attempt++ {
+		// Enter the restore gate FIRST so we wait out any in-progress restore
+		// before electing. `waited` means a restore held the room and just
+		// resolved — restart the whole election (the room's conn set changed).
+		preempt, waited := room.enterApplierGate()
+		if waited {
+			room.exitApplierGate()
+			return nil, true
+		}
+
 		applier := room.pickApplier(tried)
 		if applier == nil {
 			// No more candidates left.
+			room.exitApplierGate()
 			if !anyWriteSucceeded {
-				return ErrNoApplierAvailable
+				return ErrNoApplierAvailable, false
 			}
-			return ErrAllAppliersTimedOut
+			return ErrAllAppliersTimedOut, false
 		}
 		tried[applier.conn] = struct{}{}
 
 		ackCh, registerErr := room.registerPendingAck(requestID, applier.conn)
 		if registerErr != nil {
 			// Race: room closed between pickApplier and registration.
-			return registerErr
+			room.exitApplierGate()
+			return registerErr, false
 		}
 
 		// Send the applier_request as a TextMessage. y-protocol
@@ -229,7 +268,8 @@ func (m *RoomManager) ApplyExternalContent(itemID string, markdown string) error
 		payload, err := json.Marshal(msg)
 		if err != nil {
 			room.cancelPendingAck(requestID)
-			return fmt.Errorf("marshal applier_request: %w", err)
+			room.exitApplierGate()
+			return fmt.Errorf("marshal applier_request: %w", err), false
 		}
 		if err := applier.writeMessage(websocket.TextMessage, payload); err != nil {
 			// Conn write failed (slow / dead). Drop the pending
@@ -240,6 +280,7 @@ func (m *RoomManager) ApplyExternalContent(itemID string, markdown string) error
 			// so the conn's readLoop wakes up cleanly, and try
 			// the next applier. Per Codex review round 6.
 			room.cancelPendingAck(requestID)
+			room.exitApplierGate()
 			room.removeConn(applier)
 			_ = applier.conn.Close()
 			slog.Warn("collab: applier_request write failed; trying next",
@@ -251,7 +292,7 @@ func (m *RoomManager) ApplyExternalContent(itemID string, markdown string) error
 		}
 		anyWriteSucceeded = true
 
-		// Wait for the ack OR timeout.
+		// Wait for the ack, a restore preempt, OR timeout.
 		select {
 		case <-ackCh:
 			// Success: the applier propagated Y.Doc updates via the
@@ -260,9 +301,33 @@ func (m *RoomManager) ApplyExternalContent(itemID string, markdown string) error
 			// so the room's pendingAcks map doesn't grow unbounded
 			// across the lifetime of the room.
 			room.cancelPendingAck(requestID)
-			return nil
+			room.exitApplierGate()
+			return nil, false
+		case <-preempt:
+			// A version restore is about to freeze the room (BUG-2276 residual 2).
+			// Give an already-in-flight ack a bounded grace to arrive while the room
+			// is still UNFROZEN: if the applier's content already landed, its ack is
+			// delivered normally within this window and we resolve as SUCCESS
+			// (sub-case A) — no retry, no clobber. Otherwise (sub-case B) abandon and
+			// park until the restore resolves, then restart the election.
+			select {
+			case <-ackCh:
+				room.cancelPendingAck(requestID)
+				room.exitApplierGate()
+				return nil, false
+			case <-time.After(applierPreemptGrace()):
+			}
+			room.cancelPendingAck(requestID)
+			room.exitApplierGate()
+			room.waitRestoreResolved() // bounded to the restore-tx duration
+			slog.Info("collab: applier round-trip preempted by version restore; will re-elect",
+				"item_id", itemID,
+				"client_id", applier.id,
+			)
+			return nil, true
 		case <-time.After(timeouts[attempt]):
 			room.cancelPendingAck(requestID)
+			room.exitApplierGate()
 			slog.Warn("collab: applier_request timed out; will retry next applier",
 				"item_id", itemID,
 				"client_id", applier.id,
@@ -279,9 +344,9 @@ func (m *RoomManager) ApplyExternalContent(itemID string, markdown string) error
 	if !anyWriteSucceeded {
 		// applierMaxAttempts exhausted without ever putting bytes on
 		// the wire. Same recovery profile as no-applier-found.
-		return ErrNoApplierAvailable
+		return ErrNoApplierAvailable, false
 	}
-	return ErrAllAppliersTimedOut
+	return ErrAllAppliersTimedOut, false
 }
 
 // ErrManagerClosed exposes the manager's internal closed-flag error

--- a/internal/collab/applier.go
+++ b/internal/collab/applier.go
@@ -53,6 +53,17 @@ const (
 	ControlMessageApplierRequest = "applier_request"
 	ControlMessageApplierAck     = "applier_ack"
 
+	// ControlMessageApplierApplyStart opens the durable persistence bracket for a
+	// designated-applier round-trip (BUG-2276 residual 2). The client sends it
+	// IMMEDIATELY before setContent (synchronously, no keystroke can interleave), so
+	// the server-captured baseline scopes the bracket to exactly the setContent
+	// frame — letting the server tell, from durable op-log state, whether that frame
+	// persisted or was dropped by a concurrent version-restore freeze. Carries only
+	// request_id. Older clients that never send it fall back to a safe "retry on
+	// restore" posture (finalization treats an un-bracketed round-trip as
+	// not-persisted). See restore_coord.go.
+	ControlMessageApplierApplyStart = "applier_apply_start"
+
 	// ControlMessageOpLogCursor advertises the highest item_yjs_updates.id
 	// the receiving peer should now consider applied. Sent by the server:
 	//   - immediately after a fresh peer's replay completes (cursor =
@@ -130,14 +141,42 @@ type ControlMessage struct {
 	OpLogID int64 `json:"op_log_id"`
 }
 
-// pendingApplierAck pairs the channel a PATCH handler is waiting on
-// with the conn the ack is expected from. Storing the expected conn
-// lets the readLoop reject acks from other peers in the same room
-// (defence in depth — a hostile peer shouldn't be able to forge an
-// ack on someone else's request).
+// pendingApplierAck tracks one in-flight designated-applier round-trip. The applier
+// flow waits on resultCh for the DURABLE outcome — true = the applier's setContent
+// landed (success), false = it did not (retry). The outcome is delivered exactly
+// once, by whichever of the ack path (resolveApplierAck) or a concurrent restore's
+// finalization (freezeAndFinalizePending) reaches it first; `delivered` guards the
+// double-send. expectedConn lets the server reject acks/brackets from other peers
+// (defence in depth). The bracket baselines are captured at request-send and
+// refined at apply_start (BUG-2276 residual 2).
 type pendingApplierAck struct {
 	expectedConn *websocket.Conn
-	ch           chan struct{}
+	resultCh     chan bool
+
+	// startPersistedOpID / startFrozenDropSeq are the applier conn's durable
+	// high-water + frozen-drop count at the START of the apply bracket. Seeded at
+	// request-send (registerPendingAck) and refined at apply_start so the bracket
+	// scopes to exactly the setContent frame.
+	startPersistedOpID int64
+	startFrozenDropSeq int64
+	// applyStarted is set when apply_start was received. Finalization treats an
+	// un-bracketed round-trip as not-persisted (safe: retry, never a false success).
+	applyStarted bool
+	// delivered guards resultCh against a double send (ack vs finalization race).
+	delivered bool
+}
+
+// deliver sends the round-trip's durable outcome exactly once. MUST be called with
+// r.pendingMu held.
+func (p *pendingApplierAck) deliver(success bool) {
+	if p.delivered {
+		return
+	}
+	p.delivered = true
+	select {
+	case p.resultCh <- success:
+	default:
+	}
 }
 
 // Sentinel errors for ApplyExternalContent. Callers (the items PATCH
@@ -160,19 +199,21 @@ var (
 
 // ApplyExternalContent routes an external content update through a
 // designated applier when an active room exists. Returns nil on
-// successful ack; one of the sentinel errors above otherwise so the
+// success; one of the sentinel errors above otherwise so the
 // caller can decide whether to fall back to a direct write.
 //
-// The function blocks until ack OR all attempts time out — the PATCH
-// handler stays open during this window and the caller sees the
-// final outcome on return.
+// The function blocks until the round-trip resolves OR all attempts time out — the
+// PATCH handler stays open during this window and the caller sees the final outcome
+// on return.
 //
-// A concurrent version restore (ForceRefreshRoom) is serialised against the
-// round-trip via the per-room restore gate (BUG-2276 residual 2, see
-// restore_coord.go): if a restore preempts an in-flight election (or is in progress
-// when one starts), the election restarts from scratch once the restore RESOLVES —
-// on rollback against the unfrozen room, on commit against the force-closed room.
-// The outer loop caps those restarts.
+// A concurrent version restore (ForceRefreshRoom) is coordinated via the per-room
+// restore gate + durable persistence correlation (BUG-2276 residual 2, see
+// restore_coord.go): a NEW round-trip waits out an in-progress restore before
+// electing; an IN-FLIGHT round-trip is finalized by the restore's freeze from
+// durable op-log state (success iff its setContent frame durably landed). When a
+// restore supersedes a round-trip, the election restarts once the restore RESOLVES —
+// on rollback against the unfrozen room, on commit against the force-closed room. The
+// outer loop caps those restarts.
 func (m *RoomManager) ApplyExternalContent(itemID string, markdown string) error {
 	m.mu.Lock()
 	if m.closed {
@@ -187,25 +228,25 @@ func (m *RoomManager) ApplyExternalContent(itemID string, markdown string) error
 	}
 
 	for restart := 0; restart < applierMaxRestartsAfterRestore; restart++ {
-		err, preempted := m.electAndApply(room, itemID, markdown)
-		if !preempted {
+		err, superseded := m.electAndApply(room, itemID, markdown)
+		if !superseded {
 			return err
 		}
-		// A version restore preempted / blocked this election and has now
-		// resolved (electAndApply already waited it out). Re-elect from scratch:
-		// a fresh request_id + tried set against the post-restore room.
+		// A version restore superseded this election and has now resolved
+		// (electAndApply already waited it out). Re-elect from scratch: a fresh
+		// request_id + tried set against the post-restore room.
 	}
 	// Restore storm: fall back to a direct write rather than spin.
 	return ErrNoApplierAvailable
 }
 
 // electAndApply runs one designated-applier election (first attempt + one retry)
-// against the room, bracketed by the restore gate. It returns (err, preempted):
-// preempted==true means a version restore interrupted the election and has resolved,
+// against the room, gated on the restore coordinator. It returns (err, superseded):
+// superseded==true means a version restore interrupted the election and has resolved,
 // so ApplyExternalContent should restart; err is meaningless in that case. When
-// preempted==false, err is the final outcome (nil on ack, or a sentinel).
+// superseded==false, err is the final outcome (nil on success, or a sentinel).
 func (m *RoomManager) electAndApply(room *Room, itemID, markdown string) (error, bool) {
-	// A FRESH request_id per election: a late ack from a preempted prior election
+	// A FRESH request_id per election: a late ack from a superseded prior election
 	// (same conn, re-picked after a rollback) can't be mistaken for this one's.
 	requestID := uuid.NewString()
 	timeouts := []time.Duration{applierFirstTimeout(), applierRetryTimeout()}
@@ -225,16 +266,13 @@ func (m *RoomManager) electAndApply(room *Room, itemID, markdown string) (error,
 		// Enter the restore gate FIRST so we wait out any in-progress restore
 		// before electing. `waited` means a restore held the room and just
 		// resolved — restart the whole election (the room's conn set changed).
-		preempt, waited := room.enterApplierGate()
-		if waited {
-			room.exitApplierGate()
+		if room.enterApplierGate() {
 			return nil, true
 		}
 
 		applier := room.pickApplier(tried)
 		if applier == nil {
 			// No more candidates left.
-			room.exitApplierGate()
 			if !anyWriteSucceeded {
 				return ErrNoApplierAvailable, false
 			}
@@ -242,10 +280,9 @@ func (m *RoomManager) electAndApply(room *Room, itemID, markdown string) (error,
 		}
 		tried[applier.conn] = struct{}{}
 
-		ackCh, registerErr := room.registerPendingAck(requestID, applier.conn)
+		resultCh, registerErr := room.registerPendingAck(requestID, applier)
 		if registerErr != nil {
 			// Race: room closed between pickApplier and registration.
-			room.exitApplierGate()
 			return registerErr, false
 		}
 
@@ -268,10 +305,14 @@ func (m *RoomManager) electAndApply(room *Room, itemID, markdown string) (error,
 		payload, err := json.Marshal(msg)
 		if err != nil {
 			room.cancelPendingAck(requestID)
-			room.exitApplierGate()
 			return fmt.Errorf("marshal applier_request: %w", err), false
 		}
-		if err := applier.writeMessage(websocket.TextMessage, payload); err != nil {
+		// Bounded write (BUG-2276 residual 2, P1a): a dead/slow peer wedged in a
+		// deadline-free writeLoop write holds writeMu, which would otherwise block
+		// this send indefinitely with a pending-ack entry outstanding. An independent
+		// close-timer closes the conn if the write can't complete, forcing the wedged
+		// write to error and releasing writeMu — mirroring forceRefreshAll.
+		if werr := writeApplierRequest(applier, payload); werr != nil {
 			// Conn write failed (slow / dead). Drop the pending
 			// ack, evict the broken conn from the room (otherwise
 			// it would still count as a "live peer" against
@@ -280,54 +321,39 @@ func (m *RoomManager) electAndApply(room *Room, itemID, markdown string) (error,
 			// so the conn's readLoop wakes up cleanly, and try
 			// the next applier. Per Codex review round 6.
 			room.cancelPendingAck(requestID)
-			room.exitApplierGate()
 			room.removeConn(applier)
 			_ = applier.conn.Close()
 			slog.Warn("collab: applier_request write failed; trying next",
 				"item_id", itemID,
 				"client_id", applier.id,
-				"error", err,
+				"error", werr,
 			)
 			continue
 		}
 		anyWriteSucceeded = true
 
-		// Wait for the ack, a restore preempt, OR timeout.
+		// Wait for the DURABLE outcome OR timeout.
 		select {
-		case <-ackCh:
-			// Success: the applier propagated Y.Doc updates via the
-			// regular sync path before sending the ack, so all peers
-			// are now on the new state. Drop the pending-ack entry
-			// so the room's pendingAcks map doesn't grow unbounded
-			// across the lifetime of the room.
+		case success := <-resultCh:
 			room.cancelPendingAck(requestID)
-			room.exitApplierGate()
-			return nil, false
-		case <-preempt:
-			// A version restore is about to freeze the room (BUG-2276 residual 2).
-			// Give an already-in-flight ack a bounded grace to arrive while the room
-			// is still UNFROZEN: if the applier's content already landed, its ack is
-			// delivered normally within this window and we resolve as SUCCESS
-			// (sub-case A) — no retry, no clobber. Otherwise (sub-case B) abandon and
-			// park until the restore resolves, then restart the election.
-			select {
-			case <-ackCh:
-				room.cancelPendingAck(requestID)
-				room.exitApplierGate()
+			if success {
+				// The applier's setContent durably landed (no frame in its apply
+				// bracket was frozen-dropped). All peers are on the new state.
 				return nil, false
-			case <-time.After(applierPreemptGrace()):
 			}
-			room.cancelPendingAck(requestID)
-			room.exitApplierGate()
+			// Not persisted: a version restore froze this apply, so setContent did
+			// NOT land. This is a DURABLE determination (see restore_coord.go), not a
+			// timing guess — so we never re-apply over a landed edit. Wait for the
+			// restore to resolve, then restart the election: re-apply on rollback
+			// (unfrozen room), fall back on commit (force-closed room).
 			room.waitRestoreResolved() // bounded to the restore-tx duration
-			slog.Info("collab: applier round-trip preempted by version restore; will re-elect",
+			slog.Info("collab: applier round-trip superseded by version restore; will re-elect",
 				"item_id", itemID,
 				"client_id", applier.id,
 			)
 			return nil, true
 		case <-time.After(timeouts[attempt]):
 			room.cancelPendingAck(requestID)
-			room.exitApplierGate()
 			slog.Warn("collab: applier_request timed out; will retry next applier",
 				"item_id", itemID,
 				"client_id", applier.id,
@@ -347,6 +373,34 @@ func (m *RoomManager) electAndApply(room *Room, itemID, markdown string) (error,
 		return ErrNoApplierAvailable, false
 	}
 	return ErrAllAppliersTimedOut, false
+}
+
+// applierMaxRestartsAfterRestore caps how many times ApplyExternalContent re-elects
+// after being superseded by a restore, so a pathological back-to-back restore storm
+// can't spin the election forever. On exhaustion the caller falls back to a direct
+// write (ErrNoApplierAvailable) — safe graceful degradation.
+const applierMaxRestartsAfterRestore = 5
+
+// applierWriteDeadlineVar bounds the applier_request write so a dead/slow peer
+// holding writeMu can't wedge the round-trip (BUG-2276 residual 2, P1a). Sized like
+// closeFrameDeadline's budget — generous enough that a healthy peer always completes.
+// A var so tests can shrink it.
+var applierWriteDeadlineVar = 2 * time.Second
+
+func applierWriteDeadline() time.Duration { return applierWriteDeadlineVar }
+
+// writeApplierRequest sends the applier_request with a bounded write. An independent
+// timer closes the conn if the write can't complete within applierWriteDeadline —
+// gorilla's Close is concurrency-safe with an in-flight WriteMessage, so it forces a
+// wedged writeLoop write to error, releasing writeMu and unblocking us. Mirrors the
+// per-conn timer pattern in forceRefreshAll (BUG-2264 P1).
+func writeApplierRequest(rc *roomConn, payload []byte) error {
+	d := applierWriteDeadline()
+	deadline := time.Now().Add(d)
+	t := time.AfterFunc(d, func() { _ = rc.conn.Close() })
+	err := rc.writeMessageWithDeadline(websocket.TextMessage, payload, deadline)
+	t.Stop()
+	return err
 }
 
 // ErrManagerClosed exposes the manager's internal closed-flag error
@@ -376,12 +430,11 @@ func (r *Room) pickApplier(tried map[*websocket.Conn]struct{}) *roomConn {
 		// only ever lands on a writer (or returns nil → the caller's
 		// direct-write fallback fires).
 		//
-		// A frozen conn (mid version-restore, BUG-2264) is excluded for the
-		// identical reason: readLoop drops its inbound sync frames while frozen,
-		// so an elected frozen conn would ack a no-op. Combined with the frozen
-		// check in handleControlMessage (which rejects a late ack from a conn
-		// frozen AFTER it was picked), a concurrent ApplyExternalContent can never
-		// falsely succeed against a restore's frozen peer.
+		// A frozen conn (mid version-restore) is excluded defensively: the enter
+		// gate already blocks election while a restore holds the room, but the
+		// success/commit path leaves conns frozen until they are force-closed, so a
+		// commit-case re-election must skip them → returns nil → the caller's
+		// direct-write fallback. (BUG-2276 residual 2.)
 		if !rc.canWrite.Load() || rc.frozen.Load() {
 			continue
 		}
@@ -403,11 +456,13 @@ func (r *Room) pickApplier(tried map[*websocket.Conn]struct{}) *roomConn {
 	return candidates[0]
 }
 
-// registerPendingAck creates an entry in the room's pending-acks map
-// keyed on requestID, with the expected ack source set to
-// expectedConn. Returns the channel the caller should select on, or
-// an error if the room is no longer accepting requests.
-func (r *Room) registerPendingAck(requestID string, expectedConn *websocket.Conn) (<-chan struct{}, error) {
+// registerPendingAck creates an entry in the room's pending-acks map keyed on
+// requestID, expecting acks/brackets from `applier`. It seeds the bracket baselines
+// from the applier conn's current durable high-water + frozen-drop count (refined
+// later by apply_start). Returns the result channel the caller selects on (true =
+// the applier's content durably landed, false = it did not), or an error if the room
+// is no longer accepting requests.
+func (r *Room) registerPendingAck(requestID string, applier *roomConn) (<-chan bool, error) {
 	r.mu.Lock()
 	closing := r.closing
 	r.mu.Unlock()
@@ -422,44 +477,99 @@ func (r *Room) registerPendingAck(requestID string, expectedConn *websocket.Conn
 		// is effectively impossible.
 		return nil, fmt.Errorf("collab: duplicate request_id %s", requestID)
 	}
-	ch := make(chan struct{}, 1)
+	ch := make(chan bool, 1)
 	r.pendingAcks[requestID] = &pendingApplierAck{
-		expectedConn: expectedConn,
-		ch:           ch,
+		expectedConn:       applier.conn,
+		resultCh:           ch,
+		startPersistedOpID: applier.lastPersistedOpID.Load(),
+		startFrozenDropSeq: applier.frozenDropSeq.Load(),
 	}
 	return ch, nil
 }
 
 // cancelPendingAck removes a request from the pending-acks map. Used
-// after a timeout / write failure to free the slot before retrying.
+// after a timeout / write failure / result delivery to free the slot.
 func (r *Room) cancelPendingAck(requestID string) {
 	r.pendingMu.Lock()
 	delete(r.pendingAcks, requestID)
 	r.pendingMu.Unlock()
 }
 
-// routeApplierAck signals the channel waiting on requestID, but
-// only if the ack came from the expected conn (defence in depth).
-// Called by readLoop on receipt of an applier_ack control message.
-func (r *Room) routeApplierAck(requestID string, fromConn *websocket.Conn) {
+// startApplierApply opens the durable persistence bracket for requestID: it refines
+// the bracket baseline to the applier conn's high-water + frozen-drop count RIGHT
+// NOW, at apply_start. Since the client sends apply_start immediately before
+// setContent (synchronously), the bracket that follows contains exactly the
+// setContent frame — so a subsequent lastPersistedOpID advance / frozenDropSeq
+// advance is attributable to the applier, not to concurrent typing. Called by
+// readLoop; only the expected conn may open the bracket. (BUG-2276 residual 2.)
+func (r *Room) startApplierApply(requestID string, rc *roomConn) {
 	r.pendingMu.Lock()
+	defer r.pendingMu.Unlock()
 	pending, ok := r.pendingAcks[requestID]
-	r.pendingMu.Unlock()
+	if !ok || pending.expectedConn != rc.conn {
+		return
+	}
+	pending.startPersistedOpID = rc.lastPersistedOpID.Load()
+	pending.startFrozenDropSeq = rc.frozenDropSeq.Load()
+	pending.applyStarted = true
+}
+
+// resolveApplierAck resolves the round-trip on receipt of the applier_ack (the
+// bracket end), from durable state: SUCCESS iff no frame in the apply bracket was
+// frozen-dropped (frozenDropSeq unchanged). A no-op-diff setContent, which persists
+// nothing, also resolves to success (nothing was dropped → the doc already reflects
+// the content). Delivers the outcome once; a concurrent restore finalization may
+// have delivered first (idempotent). Only the expected conn may resolve. Called by
+// readLoop on an applier_ack control message. (BUG-2276 residual 2.)
+func (r *Room) resolveApplierAck(requestID string, rc *roomConn) {
+	r.pendingMu.Lock()
+	defer r.pendingMu.Unlock()
+	pending, ok := r.pendingAcks[requestID]
 	if !ok {
 		return // unknown / already-cancelled request_id
 	}
-	if pending.expectedConn != fromConn {
+	if pending.expectedConn != rc.conn {
 		slog.Warn("collab: applier_ack from unexpected conn; ignoring",
 			"request_id", requestID,
 		)
 		return
 	}
-	select {
-	case pending.ch <- struct{}{}:
-	default:
-		// Already signalled; this is a duplicate ack — common when
-		// the applier retries after a transient send failure.
+	dropped := rc.frozenDropSeq.Load() > pending.startFrozenDropSeq
+	pending.deliver(!dropped)
+}
+
+// freezeAndFinalizePending is the atomic heart of the version-restore ↔ applier
+// coordination (BUG-2276 residual 2). Called by ForceRefreshRoom with appendMu held,
+// it (1) marks every conn frozen and (2) FINALIZES every in-flight applier
+// round-trip from durable op-log state — success iff the applier conn's high-water
+// advanced past the bracket baseline (its setContent frame durably landed BEFORE
+// this freeze). Because the freeze and the high-water read share the appendMu
+// critical section, a frame still in flight is blocked on appendMu and will be
+// dropped once the freeze is visible — so a NOT-advanced entry is a durable "did not
+// land", never a race. An un-bracketed round-trip (apply_start not seen) is treated
+// as not-persisted (safe: it re-elects; never a false success).
+//
+// Lock order: caller holds appendMu; we take room.mu then release it before
+// pendingMu, so no room.mu↔pendingMu nesting. No socket I/O under any lock.
+func (r *Room) freezeAndFinalizePending() {
+	r.mu.Lock()
+	conns := make(map[*websocket.Conn]*roomConn, len(r.conns))
+	for c, rc := range r.conns {
+		rc.frozen.Store(true)
+		conns[c] = rc
 	}
+	r.mu.Unlock()
+
+	r.pendingMu.Lock()
+	for _, pending := range r.pendingAcks {
+		rc := conns[pending.expectedConn]
+		persisted := false
+		if rc != nil && pending.applyStarted {
+			persisted = rc.lastPersistedOpID.Load() > pending.startPersistedOpID
+		}
+		pending.deliver(persisted)
+	}
+	r.pendingMu.Unlock()
 }
 
 // applierMutexLockOrder is a documentation marker — the mutex order
@@ -467,8 +577,8 @@ func (r *Room) routeApplierAck(requestID string, fromConn *websocket.Conn) {
 //
 //	r.mu (room state) > r.pendingMu (ack tracking)
 //
-// Acquire in that order; release in reverse. registerPendingAck and
-// routeApplierAck hold ONLY pendingMu (no r.mu reentry), so no
-// inversion is possible there. The closing/conns checks that need
-// r.mu run BEFORE the pendingMu acquisition.
+// Acquire in that order; release in reverse. registerPendingAck, startApplierApply,
+// resolveApplierAck and freezeAndFinalizePending hold ONLY pendingMu (no r.mu
+// reentry while pendingMu is held), so no inversion is possible. The closing/conns
+// checks that need r.mu run BEFORE the pendingMu acquisition.
 var _ = sync.Mutex{}

--- a/internal/collab/applier_test.go
+++ b/internal/collab/applier_test.go
@@ -334,7 +334,7 @@ func TestApplyExternalContentSendsExpiresAt(t *testing.T) {
 }
 
 // TestApplyExternalContentRejectsAckFromUnexpectedConn confirms the
-// expectedConn check in routeApplierAck. We wire two conns; the FIRST
+// expectedConn check in resolveApplierAck. We wire two conns; the FIRST
 // is the chosen applier; the SECOND tries to forge an ack for the
 // first's request. The forgery should be ignored, and the request
 // should still time out.
@@ -483,11 +483,11 @@ func TestHandleControlMessageIgnoresAckFromReadOnlyConn(t *testing.T) {
 
 	// Read-only conn: canWrite defaults to false. The conn pointer is
 	// only used for identity (pending-ack expectedConn match); no I/O
-	// happens on it because the ack is rejected before routeApplierAck.
+	// happens on it because the ack is rejected before resolveApplierAck.
 	rc := &roomConn{id: 1, conn: &websocket.Conn{}}
 
 	reqID := "req-readonly"
-	ch, err := room.registerPendingAck(reqID, rc.conn)
+	ch, err := room.registerPendingAck(reqID, rc)
 	if err != nil {
 		t.Fatalf("registerPendingAck: %v", err)
 	}
@@ -497,20 +497,19 @@ func TestHandleControlMessageIgnoresAckFromReadOnlyConn(t *testing.T) {
 
 	select {
 	case <-ch:
-		t.Fatal("applier_ack from a read-only conn must be ignored, but it signaled the pending ack")
+		t.Fatal("applier_ack from a read-only conn must be ignored, but it resolved the round-trip")
 	case <-time.After(50 * time.Millisecond):
-		// Correct: the ack was dropped before routeApplierAck.
+		// Correct: the ack was dropped before resolveApplierAck.
 	}
 }
 
-// TestHandleControlMessageIgnoresAckFromFrozenConn is the pick-then-freeze half
-// of the BUG-2264 applier fix: a WRITABLE conn that ForceRefreshRoom froze mid
-// version-restore has its inbound sync frames dropped by readLoop, so an
-// applier_ack from it would be a phantom success (ApplyExternalContent returns
-// nil, the PATCH handler skips its direct-write fallback, and the external edit
-// is silently lost while the restore prunes the op-log). canWrite=true isolates
-// the frozen gate from the read-only gate.
-func TestHandleControlMessageIgnoresAckFromFrozenConn(t *testing.T) {
+// TestApplierAckFromFrozenConnResolvesFromDurableState is the BUG-2276 residual-2
+// replacement for the old "frozen conn ack is ignored" test. A frozen conn's ack is
+// now PROCESSED, but it resolves the round-trip from DURABLE op-log state, not a
+// phantom success: if a frame in the apply bracket was frozen-dropped
+// (frozenDropSeq advanced past the apply_start baseline), the ack resolves to FALSE
+// (retry) — never a phantom success while the setContent was lost to the freeze.
+func TestApplierAckFromFrozenConnResolvesFromDurableState(t *testing.T) {
 	bus := NewMemoryOpBus()
 	defer bus.Close()
 	mgr := NewRoomManager(&fakeOpLog{}, bus)
@@ -523,19 +522,61 @@ func TestHandleControlMessageIgnoresAckFromFrozenConn(t *testing.T) {
 	rc.frozen.Store(true)
 
 	reqID := "req-frozen"
-	ch, err := room.registerPendingAck(reqID, rc.conn)
+	ch, err := room.registerPendingAck(reqID, rc)
 	if err != nil {
 		t.Fatalf("registerPendingAck: %v", err)
 	}
+
+	// Open the apply bracket (captures the baseline), then simulate the setContent
+	// frame being frozen-dropped by readLoop while this conn is frozen.
+	room.startApplierApply(reqID, rc)
+	rc.frozenDropSeq.Add(1)
 
 	payload, _ := json.Marshal(ControlMessage{Type: ControlMessageApplierAck, RequestID: reqID})
 	room.handleControlMessage(rc, payload)
 
 	select {
-	case <-ch:
-		t.Fatal("applier_ack from a frozen conn must be ignored, but it signaled the pending ack")
+	case success := <-ch:
+		if success {
+			t.Fatal("frozen-dropped setContent must resolve to FALSE (retry), not a phantom success")
+		}
 	case <-time.After(50 * time.Millisecond):
-		// Correct: the ack was dropped before routeApplierAck.
+		t.Fatal("frozen conn ack must resolve the round-trip from durable state, but nothing was delivered")
+	}
+}
+
+// TestApplierAckSucceedsWhenFramePersisted confirms the positive durable case: a
+// setContent frame that persisted (no frozen drop in the bracket) resolves the ack
+// to SUCCESS — including the no-op-diff case where setContent persists nothing.
+func TestApplierAckSucceedsWhenFramePersisted(t *testing.T) {
+	bus := NewMemoryOpBus()
+	defer bus.Close()
+	mgr := NewRoomManager(&fakeOpLog{}, bus)
+	defer mgr.Close()
+
+	room := mgr.getOrCreate("item-a")
+	rc := &roomConn{id: 1, conn: &websocket.Conn{}}
+	rc.canWrite.Store(true)
+
+	reqID := "req-ok"
+	ch, err := room.registerPendingAck(reqID, rc)
+	if err != nil {
+		t.Fatalf("registerPendingAck: %v", err)
+	}
+	room.startApplierApply(reqID, rc)
+	// setContent persisted a frame (op-log id 7); no frozen drop.
+	rc.lastPersistedOpID.Store(7)
+
+	payload, _ := json.Marshal(ControlMessage{Type: ControlMessageApplierAck, RequestID: reqID})
+	room.handleControlMessage(rc, payload)
+
+	select {
+	case success := <-ch:
+		if !success {
+			t.Fatal("a persisted setContent (no frozen drop) must resolve the ack to success")
+		}
+	case <-time.After(50 * time.Millisecond):
+		t.Fatal("ack must resolve the round-trip, but nothing was delivered")
 	}
 }
 

--- a/internal/collab/applier_test.go
+++ b/internal/collab/applier_test.go
@@ -78,13 +78,8 @@ func TestApplyExternalContentHappyPath(t *testing.T) {
 	stop := runApplierEcho(t, conn)
 	defer stop()
 
-	// Wait for the room to register the conn.
-	for i := 0; i < 200; i++ {
-		if mgr.RoomCount() == 1 && bus.SubscriberCount("item-a") == 1 {
-			break
-		}
-		time.Sleep(5 * time.Millisecond)
-	}
+	// Wait for the conn to register AND anchor (electable).
+	waitElectable(t, mgr, "item-a", 1)
 
 	done := make(chan error, 1)
 	go func() {
@@ -135,12 +130,7 @@ func TestApplyExternalContentTimeoutsThenFails(t *testing.T) {
 		}
 	}()
 
-	for i := 0; i < 200; i++ {
-		if bus.SubscriberCount("item-a") == 1 {
-			break
-		}
-		time.Sleep(5 * time.Millisecond)
-	}
+	waitElectable(t, mgr, "item-a", 1)
 
 	start := time.Now()
 	err := mgr.ApplyExternalContent("item-a", "# new content")
@@ -195,12 +185,7 @@ func TestApplyExternalContentTimeoutThenSecondAcks(t *testing.T) {
 	stop := runApplierEcho(t, second)
 	defer stop()
 
-	for i := 0; i < 200; i++ {
-		if bus.SubscriberCount("item-a") == 2 {
-			break
-		}
-		time.Sleep(5 * time.Millisecond)
-	}
+	waitElectable(t, mgr, "item-a", 2)
 
 	done := make(chan error, 1)
 	go func() {
@@ -235,12 +220,7 @@ func TestApplyExternalContentCleansPendingAcksOnSuccess(t *testing.T) {
 	stop := runApplierEcho(t, conn)
 	defer stop()
 
-	for i := 0; i < 200; i++ {
-		if bus.SubscriberCount("item-a") == 1 {
-			break
-		}
-		time.Sleep(5 * time.Millisecond)
-	}
+	waitElectable(t, mgr, "item-a", 1)
 
 	for i := 0; i < 5; i++ {
 		if err := mgr.ApplyExternalContent("item-a", "# rev"); err != nil {
@@ -307,12 +287,7 @@ func TestApplyExternalContentSendsExpiresAt(t *testing.T) {
 		}
 	}()
 
-	for i := 0; i < 200; i++ {
-		if bus.SubscriberCount("item-a") == 1 {
-			break
-		}
-		time.Sleep(5 * time.Millisecond)
-	}
+	waitElectable(t, mgr, "item-a", 1)
 
 	if err := mgr.ApplyExternalContent("item-a", "# new"); err != nil {
 		t.Fatalf("apply: %v", err)
@@ -390,12 +365,7 @@ func TestApplyExternalContentRejectsAckFromUnexpectedConn(t *testing.T) {
 		}
 	}()
 
-	for i := 0; i < 200; i++ {
-		if bus.SubscriberCount("item-a") == 2 {
-			break
-		}
-		time.Sleep(5 * time.Millisecond)
-	}
+	waitElectable(t, mgr, "item-a", 2)
 
 	done := make(chan error, 1)
 	go func() {
@@ -520,6 +490,7 @@ func TestApplierAckFromFrozenConnResolvesFromDurableState(t *testing.T) {
 	rc := &roomConn{id: 1, conn: &websocket.Conn{}}
 	rc.canWrite.Store(true)
 	rc.frozen.Store(true)
+	rc.bracketCapable.Store(true) // bracket-capable → a frozen-dropped frame is NotPersisted (retry)
 
 	reqID := "req-frozen"
 	ch, err := room.registerPendingAck(reqID, rc)
@@ -536,12 +507,46 @@ func TestApplierAckFromFrozenConnResolvesFromDurableState(t *testing.T) {
 	room.handleControlMessage(rc, payload)
 
 	select {
-	case success := <-ch:
-		if success {
-			t.Fatal("frozen-dropped setContent must resolve to FALSE (retry), not a phantom success")
+	case outcome := <-ch:
+		if outcome != applierNotPersisted {
+			t.Fatalf("frozen-dropped setContent (bracket-capable) must resolve NotPersisted (retry), not a phantom success; got %v", outcome)
 		}
 	case <-time.After(50 * time.Millisecond):
 		t.Fatal("frozen conn ack must resolve the round-trip from durable state, but nothing was delivered")
+	}
+}
+
+// TestApplierAckFromLegacyFrozenConnIsAmbiguous: a LEGACY (non-bracket-capable) conn
+// whose frame was frozen-dropped can't be attributed → the ack resolves AMBIGUOUS
+// (fail-safe), NEVER a phantom success.
+func TestApplierAckFromLegacyFrozenConnIsAmbiguous(t *testing.T) {
+	bus := NewMemoryOpBus()
+	defer bus.Close()
+	mgr := NewRoomManager(&fakeOpLog{}, bus)
+	defer mgr.Close()
+
+	room := mgr.getOrCreate("item-a")
+	rc := &roomConn{id: 1, conn: &websocket.Conn{}}
+	rc.canWrite.Store(true)
+	rc.frozen.Store(true) // legacy: bracketCapable defaults false
+
+	reqID := "req-legacy-frozen"
+	ch, err := room.registerPendingAck(reqID, rc)
+	if err != nil {
+		t.Fatalf("registerPendingAck: %v", err)
+	}
+	rc.frozenDropSeq.Add(1) // a frame was frozen-dropped in the round-trip window
+
+	payload, _ := json.Marshal(ControlMessage{Type: ControlMessageApplierAck, RequestID: reqID})
+	room.handleControlMessage(rc, payload)
+
+	select {
+	case outcome := <-ch:
+		if outcome != applierAmbiguous {
+			t.Fatalf("legacy frozen-dropped round-trip must resolve Ambiguous (fail-safe), got %v", outcome)
+		}
+	case <-time.After(50 * time.Millisecond):
+		t.Fatal("legacy frozen conn ack must resolve, but nothing was delivered")
 	}
 }
 
@@ -557,6 +562,7 @@ func TestApplierAckSucceedsWhenFramePersisted(t *testing.T) {
 	room := mgr.getOrCreate("item-a")
 	rc := &roomConn{id: 1, conn: &websocket.Conn{}}
 	rc.canWrite.Store(true)
+	rc.bracketCapable.Store(true)
 
 	reqID := "req-ok"
 	ch, err := room.registerPendingAck(reqID, rc)
@@ -571,9 +577,9 @@ func TestApplierAckSucceedsWhenFramePersisted(t *testing.T) {
 	room.handleControlMessage(rc, payload)
 
 	select {
-	case success := <-ch:
-		if !success {
-			t.Fatal("a persisted setContent (no frozen drop) must resolve the ack to success")
+	case outcome := <-ch:
+		if outcome != applierPersisted {
+			t.Fatalf("a persisted setContent (no frozen drop) must resolve to applierPersisted, got %v", outcome)
 		}
 	case <-time.After(50 * time.Millisecond):
 		t.Fatal("ack must resolve the round-trip, but nothing was delivered")
@@ -632,12 +638,7 @@ func TestPruneAndApplyBlockedByLiveWriter(t *testing.T) {
 	conn := dialWS(t, srv, "item-a") // writer (canWrite=true)
 	defer conn.Close()
 
-	for i := 0; i < 200; i++ {
-		if bus.SubscriberCount("item-a") == 1 {
-			break
-		}
-		time.Sleep(5 * time.Millisecond)
-	}
+	waitElectable(t, mgr, "item-a", 1)
 
 	ran := false
 	err := mgr.PruneAndApply("item-a", func() error { ran = true; return nil })

--- a/internal/collab/manager.go
+++ b/internal/collab/manager.go
@@ -839,11 +839,7 @@ func (m *RoomManager) getOrCreate(itemID string) *Room {
 		conns:         make(map[*websocket.Conn]*roomConn),
 		pendingAcks:   make(map[string]*pendingApplierAck),
 		onIdle:        m.markRoomGone,
-		// restorePreempt is captured by in-flight appliers and closed by a restore
-		// to preempt them (BUG-2276 residual 2); it must be non-nil from birth.
-		restorePreempt: make(chan struct{}),
 	}
-	r.restoreCond = sync.NewCond(&r.restoreMu)
 	m.rooms[itemID] = r
 	return r
 }
@@ -1065,13 +1061,13 @@ func (m *RoomManager) ForceRefreshRoom(itemID string, commit func() (int64, int6
 	room := m.rooms[itemID]
 	m.mu.Unlock()
 
-	// Restore-gate serialisation (BUG-2276 residual 2): BEFORE freezing, preempt +
-	// drain any in-flight designated-applier round-trip and block new ones, so no
-	// applier ack can race the frozen=true window below (the residual-2 clobber).
-	// beginRestore is bounded to the applier-preempt handshake, never the 30s applier
-	// timeout, and touches only the leaf restoreMu (no appendMu/room.mu held here).
-	// The deferred resolveRestore releases every parked/blocked round-trip on EVERY
-	// return path (rollback, uncertain, success), the instant this restore resolves.
+	// Restore-gate serialisation (BUG-2276 residual 2): mark a restore in progress so
+	// a NEW applier round-trip blocks in enterApplierGate until this restore resolves.
+	// The deferred resolveRestore releases every gate-blocked / finalized-and-parked
+	// round-trip on EVERY return path (rollback, uncertain, success), the instant this
+	// restore resolves. beginRestore never blocks (no drain) — in-flight round-trips
+	// are finalized by the freeze below. restoreMu is a leaf lock (no appendMu/room.mu
+	// held here).
 	if room != nil {
 		room.beginRestore()
 		defer room.resolveRestore()
@@ -1084,13 +1080,15 @@ func (m *RoomManager) ForceRefreshRoom(itemID string, commit func() (int64, int6
 	// already read a frame and is queued on appendMu will, on acquiring it, see
 	// frozen=true and drop the frame. Lock order: itemLock → appendMu → room.mu.
 	// No socket I/O happens under appendMu.
+	//
+	// freezeAndFinalizePending ALSO finalizes every in-flight designated-applier
+	// round-trip from durable op-log state, atomic with the freeze (BUG-2276
+	// residual 2): a round-trip whose setContent frame durably landed BEFORE this
+	// freeze resolves to success; one whose frame is still in flight (and will now be
+	// dropped) resolves to retry. No applier ack can race the frozen window.
 	if room != nil {
 		room.appendMu.Lock()
-		room.mu.Lock()
-		for _, rc := range room.conns {
-			rc.frozen.Store(true)
-		}
-		room.mu.Unlock()
+		room.freezeAndFinalizePending()
 	}
 
 	// The commit reads the pre-prune MAX(op-log), writes items.content=restored +

--- a/internal/collab/manager.go
+++ b/internal/collab/manager.go
@@ -839,7 +839,11 @@ func (m *RoomManager) getOrCreate(itemID string) *Room {
 		conns:         make(map[*websocket.Conn]*roomConn),
 		pendingAcks:   make(map[string]*pendingApplierAck),
 		onIdle:        m.markRoomGone,
+		// restorePreempt is captured by in-flight appliers and closed by a restore
+		// to preempt them (BUG-2276 residual 2); it must be non-nil from birth.
+		restorePreempt: make(chan struct{}),
 	}
+	r.restoreCond = sync.NewCond(&r.restoreMu)
 	m.rooms[itemID] = r
 	return r
 }
@@ -1060,6 +1064,18 @@ func (m *RoomManager) ForceRefreshRoom(itemID string, commit func() (int64, int6
 	m.mu.Lock()
 	room := m.rooms[itemID]
 	m.mu.Unlock()
+
+	// Restore-gate serialisation (BUG-2276 residual 2): BEFORE freezing, preempt +
+	// drain any in-flight designated-applier round-trip and block new ones, so no
+	// applier ack can race the frozen=true window below (the residual-2 clobber).
+	// beginRestore is bounded to the applier-preempt handshake, never the 30s applier
+	// timeout, and touches only the leaf restoreMu (no appendMu/room.mu held here).
+	// The deferred resolveRestore releases every parked/blocked round-trip on EVERY
+	// return path (rollback, uncertain, success), the instant this restore resolves.
+	if room != nil {
+		room.beginRestore()
+		defer room.resolveRestore()
+	}
 
 	// P1c — freeze inbound persistence for the duration: hold appendMu (which
 	// readLoop takes across its frozen/canWrite check + AppendYjsUpdate) AND mark

--- a/internal/collab/manager.go
+++ b/internal/collab/manager.go
@@ -320,7 +320,7 @@ var ErrStaleSeedFenceUnavailable = errors.New("collab: durable restore-boundary 
 // Returns whatever error caused the WebSocket to close, or nil on a
 // normal close. The handler typically logs but doesn't act on the
 // return value: the connection is gone either way.
-func (m *RoomManager) Join(itemID string, conn *websocket.Conn, since int64, contentSeq int64, canWrite bool, onRegistered func()) error {
+func (m *RoomManager) Join(itemID string, conn *websocket.Conn, since int64, contentSeq int64, canWrite bool, bracketCapable bool, onRegistered func()) error {
 	// Gate Add on the closed flag under m.mu so a late Join (e.g. a
 	// hijacked WS handler that didn't enter Join until AFTER Close
 	// returned) can't sneak past the drain barrier.
@@ -462,6 +462,7 @@ func (m *RoomManager) Join(itemID string, conn *websocket.Conn, since int64, con
 			connectedAt: time.Now(),
 		}
 		rc.canWrite.Store(canWrite)
+		rc.bracketCapable.Store(bracketCapable)
 
 		if err := room.addConn(rc); err != nil {
 			itemLock.Unlock()
@@ -840,6 +841,8 @@ func (m *RoomManager) getOrCreate(itemID string) *Room {
 		pendingAcks:   make(map[string]*pendingApplierAck),
 		onIdle:        m.markRoomGone,
 	}
+	// restoreCond guards the admission drain in beginRestore (BUG-2276 residual 2).
+	r.restoreCond = sync.NewCond(&r.restoreMu)
 	m.rooms[itemID] = r
 	return r
 }

--- a/internal/collab/manager_test.go
+++ b/internal/collab/manager_test.go
@@ -286,7 +286,9 @@ func newCollabTestServer(t *testing.T, mgr *RoomManager) *httptest.Server {
 		// `?readonly=1` joins as a read-only participant (canWrite=false)
 		// so tests can exercise the TASK-265 gate. Default is writable.
 		canWrite := r.URL.Query().Get("readonly") != "1"
-		_ = mgr.Join(itemID, conn, since, contentSeq, canWrite, nil)
+		// `?applier_bracket=1` marks the conn bracket-capable (BUG-2276 residual 2).
+		bracketCapable := r.URL.Query().Get("applier_bracket") == "1"
+		_ = mgr.Join(itemID, conn, since, contentSeq, canWrite, bracketCapable, nil)
 	})
 	return httptest.NewServer(mux)
 }
@@ -294,6 +296,36 @@ func newCollabTestServer(t *testing.T, mgr *RoomManager) *httptest.Server {
 func dialWS(t *testing.T, server *httptest.Server, itemID string) *websocket.Conn {
 	t.Helper()
 	return dialWSSince(t, server, itemID, 0)
+}
+
+// waitElectable polls until the room for itemID has at least n conns that pickApplier
+// would actually elect — writable, anchored (replayDone), not frozen. Gates tests
+// that drive ApplyExternalContent so they don't race the post-replay cursor write:
+// an unanchored conn is deliberately NOT elected (BUG-2276 residual 2, P1), because
+// its client buffers Y.Doc updates until it receives the initial cursor.
+func waitElectable(t *testing.T, mgr *RoomManager, itemID string, n int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		mgr.mu.Lock()
+		room := mgr.rooms[itemID]
+		mgr.mu.Unlock()
+		if room != nil {
+			room.mu.Lock()
+			c := 0
+			for _, rc := range room.conns {
+				if rc.canWrite.Load() && rc.replayDone.Load() && !rc.frozen.Load() {
+					c++
+				}
+			}
+			room.mu.Unlock()
+			if c >= n {
+				return
+			}
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatalf("room %s did not reach %d electable conns within deadline", itemID, n)
 }
 
 // dialWSSince is the resume-cursor variant: appends `?since=<id>` to
@@ -321,6 +353,19 @@ func dialWSContentSeq(t *testing.T, server *httptest.Server, itemID string, cont
 	c, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
 	if err != nil {
 		t.Fatalf("dial: %v", err)
+	}
+	return c
+}
+
+// dialWSBracket joins as a bracket-capable participant (`?applier_bracket=1`) so
+// the conn can be durably confirmed by a restore's finalization (BUG-2276 residual 2).
+func dialWSBracket(t *testing.T, server *httptest.Server, itemID string) *websocket.Conn {
+	t.Helper()
+	u, _ := url.Parse(server.URL)
+	wsURL := "ws://" + u.Host + "/ws/" + itemID + "?applier_bracket=1"
+	c, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial bracket: %v", err)
 	}
 	return c
 }
@@ -1226,7 +1271,7 @@ func TestRoomManagerJoinAfterCloseFailsFast(t *testing.T) {
 
 	// Direct Join — bypass the WS plumbing since we want to exercise
 	// the closed-flag short-circuit in isolation.
-	err := mgr.Join("item-a", nil, 0, 0, true, nil) // conn is irrelevant; we never reach the WS path
+	err := mgr.Join("item-a", nil, 0, 0, true, false, nil) // conn is irrelevant; we never reach the WS path
 	if !errors.Is(err, errManagerClosed) {
 		t.Fatalf("want errManagerClosed, got %v", err)
 	}

--- a/internal/collab/restore_coord.go
+++ b/internal/collab/restore_coord.go
@@ -1,0 +1,166 @@
+package collab
+
+import "time"
+
+// Version-restore ↔ designated-applier coordination (BUG-2276 residual 2).
+//
+// Problem. A version restore (ForceRefreshRoom) freezes every connected conn for
+// the duration of its prune+reseed transaction. The designated-applier round-trip
+// (ApplyExternalContent) routes an external content update through a connected tab,
+// which applies the markdown to its Y.Doc (producing persisted sync frames) and
+// then sends an applier_ack. If a restore's transient frozen=true window lands
+// between the applier's frames and its ack, readLoop drops the ack. On a restore
+// ROLLBACK (op-log NOT pruned) that ack loss is ambiguous:
+//   - (A) the applier's frames persisted BEFORE the freeze → the external content
+//     DID land → the round-trip should be treated as SUCCESS, no retry.
+//   - (B) the applier's frames were dropped DURING the freeze → the content did
+//     NOT land → the round-trip must retry (re-apply after unfreeze).
+// The dropped ack can't distinguish (A) from (B), so the applier flow retries and
+// can double-apply markdown, clobbering peer edits made in the retry window.
+//
+// Fix — release-on-resolve. Rather than resolve the ambiguity after the fact, we
+// PREVENT it: an applier round-trip and a restore's freeze window are made mutually
+// exclusive per item.
+//
+//   - A restore, before it freezes (beginRestore), preempts any ALREADY in-flight
+//     applier round-trip and BLOCKS until every one has drained. Preempted
+//     round-trips get a bounded grace during which — because the room is still
+//     UNFROZEN — a genuinely delivered ack still resolves them as SUCCESS
+//     (sub-case A); otherwise they abandon their attempt and park (sub-case B).
+//     So when frozen=true is finally set, there is NO pending applier ack to drop:
+//     the residual-2 race is gone at the source.
+//
+//   - A new applier round-trip WAITS for an in-progress restore to resolve
+//     (enterApplierGate) before it elects an applier. After resolve it re-elects
+//     from scratch: on ROLLBACK the conns are unfrozen (a live applier exists → it
+//     applies fresh, no ambiguity); on COMMIT the conns are force-closed (no applier
+//     → ErrNoApplierAvailable → the caller's direct-write fallback, unchanged).
+//
+// The common path — an applier round-trip with NO restore in progress — pays only a
+// single leaf-mutex lock/unlock + counter bump at gate entry/exit; its ack-wait
+// select watches an open channel that never fires, so its latency and behavior are
+// byte-for-byte unchanged (hard constraint 1). Every serialization wait is bounded
+// to the restore-tx duration (plus, for a preempted in-flight round-trip, the short
+// applierPreemptGrace), never to the 30s applier timeout (hard constraint 2).
+
+// applierPreemptGraceVar is how long a preempted in-flight applier round-trip keeps
+// watching for its ack after a restore signals it to yield, BEFORE it abandons the
+// attempt. The preempt fires while the room is still UNFROZEN, so an ack the browser
+// already sent (trailing its now-persisted sync frames on the same ordered conn) is
+// still delivered normally within this window — letting a round-trip whose content
+// already landed resolve as SUCCESS (sub-case A) instead of parking and re-applying.
+// It only needs to cover socket→readLoop processing latency for an ack that TCP
+// ordering guarantees is already received-or-imminent; it is NOT the 30s applier
+// timeout, and it is paid ONLY when a restore actively preempts a genuinely
+// in-flight round-trip (never on the common no-restore path). A var so tests can
+// shrink/stretch it.
+var applierPreemptGraceVar = 500 * time.Millisecond
+
+func applierPreemptGrace() time.Duration { return applierPreemptGraceVar }
+
+// applierMaxRestartsAfterRestore caps how many times ApplyExternalContent re-elects
+// after being preempted/blocked by a restore, so a pathological back-to-back restore
+// storm can't spin the election forever. On exhaustion the caller falls back to a
+// direct write (ErrNoApplierAvailable) — safe graceful degradation.
+const applierMaxRestartsAfterRestore = 5
+
+// beginRestore is called by ForceRefreshRoom under the per-item lock, BEFORE it
+// freezes the room's conns. It marks a restore in progress (so new applier
+// round-trips block in enterApplierGate) and preempts any ALREADY in-flight
+// round-trip (by closing the preempt channel they captured), then BLOCKS until
+// every in-flight round-trip has drained to zero. On return the room is safe to
+// freeze: no applier ack can race the frozen window, because there is no in-flight
+// applier round-trip left. Paired with resolveRestore (deferred by the caller).
+//
+// The drain is bounded: each preempted round-trip yields within applierPreemptGrace,
+// so this never blocks for the 30s applier timeout. A room with no in-flight
+// round-trips returns immediately.
+//
+// Precondition (guaranteed by ForceRefreshRoom holding itemLock): no other restore
+// is in progress for this room, so restorePreempt is open and closing it is safe.
+func (r *Room) beginRestore() {
+	r.restoreMu.Lock()
+	r.restoreActive = true
+	if r.restoreResolved == nil {
+		r.restoreResolved = make(chan struct{})
+	}
+	// Wake every in-flight round-trip that captured this preempt channel.
+	close(r.restorePreempt)
+	// Drain: wait for all in-flight round-trips to yield. restoreCond is broadcast
+	// by exitApplierGate when the count hits 0.
+	for r.applierInFlight > 0 {
+		r.restoreCond.Wait()
+	}
+	r.restoreMu.Unlock()
+}
+
+// resolveRestore releases the gate when the restore RESOLVES (commit, rollback, or
+// uncertain). It clears restoreActive, closes restoreResolved (waking every parked /
+// gate-blocked applier round-trip so they re-elect against the post-restore room),
+// and installs a fresh preempt channel for the next restore cycle. ForceRefreshRoom
+// defers this immediately after beginRestore so it runs on every return path.
+func (r *Room) resolveRestore() {
+	r.restoreMu.Lock()
+	r.restoreActive = false
+	if r.restoreResolved != nil {
+		close(r.restoreResolved)
+		r.restoreResolved = nil
+	}
+	// The old preempt channel is closed; hand out a fresh open one so future
+	// round-trips capture a channel that only fires on the NEXT restore.
+	r.restorePreempt = make(chan struct{})
+	r.restoreMu.Unlock()
+}
+
+// enterApplierGate is called at the start of each applier election attempt. It
+// blocks while a version restore holds the room, then registers this round-trip as
+// in-flight and returns the preempt channel the caller's ack-wait select must watch.
+//
+// `waited` reports whether it had to block for an in-progress restore: when true the
+// caller must NOT proceed with a stale election — it exits the gate and restarts
+// ApplyExternalContent from scratch against the now-resolved room. The common path
+// (no restore) returns immediately with waited=false and the room's current open
+// preempt channel (which never fires unless a restore begins mid-round-trip).
+func (r *Room) enterApplierGate() (preempt <-chan struct{}, waited bool) {
+	r.restoreMu.Lock()
+	defer r.restoreMu.Unlock()
+	for r.restoreActive {
+		waited = true
+		resolved := r.restoreResolved
+		r.restoreMu.Unlock()
+		if resolved != nil {
+			<-resolved // bounded to the restore-tx duration
+		}
+		r.restoreMu.Lock()
+	}
+	r.applierInFlight++
+	return r.restorePreempt, waited
+}
+
+// exitApplierGate deregisters an in-flight applier round-trip and, when the count
+// reaches zero, wakes a restore draining in beginRestore. Must be paired with each
+// successful enterApplierGate.
+func (r *Room) exitApplierGate() {
+	r.restoreMu.Lock()
+	if r.applierInFlight > 0 {
+		r.applierInFlight--
+	}
+	if r.applierInFlight == 0 {
+		r.restoreCond.Broadcast()
+	}
+	r.restoreMu.Unlock()
+}
+
+// waitRestoreResolved blocks until the in-progress restore (if any) resolves. Called
+// by a preempted round-trip after it has exited the gate, so it doesn't re-elect
+// until the restore's effects (unfreeze on rollback / force-close on commit) are in
+// place. Bounded to the restore-tx duration.
+func (r *Room) waitRestoreResolved() {
+	r.restoreMu.Lock()
+	resolved := r.restoreResolved
+	active := r.restoreActive
+	r.restoreMu.Unlock()
+	if active && resolved != nil {
+		<-resolved
+	}
+}

--- a/internal/collab/restore_coord.go
+++ b/internal/collab/restore_coord.go
@@ -49,16 +49,28 @@ package collab
 // (hard constraint 5).
 
 // beginRestore is called by ForceRefreshRoom under the per-item lock, BEFORE it
-// freezes the room. It marks a restore in progress so new applier round-trips block
-// in enterApplierGate. It does NOT drain: in-flight round-trips are finalized by the
-// freeze itself (see (*Room).freezeAndFinalizePending), so there is nothing to wait
-// on here — beginRestore never blocks. Paired with resolveRestore (deferred by the
-// caller so it runs on every return path).
+// freezes the room. It (1) marks a restore in progress so new applier round-trips
+// block in enterApplierGate, and (2) DRAINS the admission gap — waits for every
+// round-trip that already passed the gate but hasn't finished registering its
+// pending-ack entry to register (admittedUnregistered → 0). Without this drain a
+// round-trip admitted just before beginRestore could register AFTER
+// freezeAndFinalizePending's scan and be missed (BUG-2276 residual 2, P1): the
+// nonresponsive case would hang the applier timeout and a no-op setContent could
+// falsely ack.
+//
+// The drain is bounded to the enter→register window, which is mutex-only (pickApplier
+// + registerPendingAck, no I/O) — microseconds, NEVER the applier round-trip. It
+// cannot stall: it waits only for registration to complete, and a round-trip that is
+// forced to restart (enterApplierGate returned waited) was never counted as admitted.
+// Paired with resolveRestore (deferred by the caller so it runs on every return path).
 func (r *Room) beginRestore() {
 	r.restoreMu.Lock()
 	r.restoreActive = true
 	if r.restoreResolved == nil {
 		r.restoreResolved = make(chan struct{})
+	}
+	for r.admittedUnregistered > 0 {
+		r.restoreCond.Wait()
 	}
 	r.restoreMu.Unlock()
 }
@@ -80,8 +92,12 @@ func (r *Room) resolveRestore() {
 // enterApplierGate is called at the start of each applier election. It blocks while
 // a version restore holds the room and reports whether it had to wait. When it
 // waited, the caller must NOT proceed with a stale election — it restarts
-// ApplyExternalContent from scratch against the now-resolved room. The common path
-// (no restore) returns immediately with waited=false.
+// ApplyExternalContent from scratch against the now-resolved room (and is NOT counted
+// as admitted). The common path (no restore) returns immediately with waited=false
+// and ADMITS the round-trip: it is counted in admittedUnregistered until the caller
+// calls finishAdmission (after registering, or on any early bail before registering),
+// so a concurrent beginRestore drains it before the freeze scan (P1). MUST be paired
+// with exactly one finishAdmission on every !waited path.
 func (r *Room) enterApplierGate() (waited bool) {
 	r.restoreMu.Lock()
 	for r.restoreActive {
@@ -93,8 +109,26 @@ func (r *Room) enterApplierGate() (waited bool) {
 		}
 		r.restoreMu.Lock()
 	}
+	if !waited {
+		r.admittedUnregistered++
+	}
 	r.restoreMu.Unlock()
 	return waited
+}
+
+// finishAdmission ends the admission span opened by a !waited enterApplierGate — call
+// it exactly once after registerPendingAck returns (success or error) or on any early
+// bail before registration. When the count hits zero it wakes a beginRestore draining
+// the admission gap. (BUG-2276 residual 2, P1.)
+func (r *Room) finishAdmission() {
+	r.restoreMu.Lock()
+	if r.admittedUnregistered > 0 {
+		r.admittedUnregistered--
+	}
+	if r.admittedUnregistered == 0 {
+		r.restoreCond.Broadcast()
+	}
+	r.restoreMu.Unlock()
 }
 
 // waitRestoreResolved blocks until the in-progress restore (if any) resolves. Called

--- a/internal/collab/restore_coord.go
+++ b/internal/collab/restore_coord.go
@@ -1,104 +1,72 @@
 package collab
 
-import "time"
-
 // Version-restore ↔ designated-applier coordination (BUG-2276 residual 2).
 //
 // Problem. A version restore (ForceRefreshRoom) freezes every connected conn for
 // the duration of its prune+reseed transaction. The designated-applier round-trip
 // (ApplyExternalContent) routes an external content update through a connected tab,
 // which applies the markdown to its Y.Doc (producing persisted sync frames) and
-// then sends an applier_ack. If a restore's transient frozen=true window lands
-// between the applier's frames and its ack, readLoop drops the ack. On a restore
-// ROLLBACK (op-log NOT pruned) that ack loss is ambiguous:
-//   - (A) the applier's frames persisted BEFORE the freeze → the external content
-//     DID land → the round-trip should be treated as SUCCESS, no retry.
-//   - (B) the applier's frames were dropped DURING the freeze → the content did
-//     NOT land → the round-trip must retry (re-apply after unfreeze).
-// The dropped ack can't distinguish (A) from (B), so the applier flow retries and
-// can double-apply markdown, clobbering peer edits made in the retry window.
+// then acks. If a restore's transient frozen=true window landed between the
+// applier's frames and its ack, the ack was dropped; on a restore ROLLBACK that
+// loss was ambiguous — did the content land (frames persisted before the freeze)
+// or not (frames dropped during the freeze)? — and the applier flow could
+// double-apply markdown, clobbering peer edits.
 //
-// Fix — release-on-resolve. Rather than resolve the ambiguity after the fact, we
-// PREVENT it: an applier round-trip and a restore's freeze window are made mutually
-// exclusive per item.
+// Fix — durable persistence correlation, decided atomic with the freeze (NOT a
+// timer). The applier round-trip's fate is read from DURABLE op-log state:
 //
-//   - A restore, before it freezes (beginRestore), preempts any ALREADY in-flight
-//     applier round-trip and BLOCKS until every one has drained. Preempted
-//     round-trips get a bounded grace during which — because the room is still
-//     UNFROZEN — a genuinely delivered ack still resolves them as SUCCESS
-//     (sub-case A); otherwise they abandon their attempt and park (sub-case B).
-//     So when frozen=true is finally set, there is NO pending applier ack to drop:
-//     the residual-2 race is gone at the source.
+//   - The client brackets its setContent with an applier_apply_start{request_id}
+//     control frame sent IMMEDIATELY before setContent (synchronously, so no
+//     concurrent keystroke frame can interleave) and the applier_ack{request_id}
+//     right after. The server captures the applier conn's (lastPersistedOpID,
+//     frozenDropSeq) at apply_start — the bracket baseline — so the bracket
+//     contains exactly the setContent frame. Attribution is airtight.
 //
-//   - A new applier round-trip WAITS for an in-progress restore to resolve
-//     (enterApplierGate) before it elects an applier. After resolve it re-elects
-//     from scratch: on ROLLBACK the conns are unfrozen (a live applier exists → it
-//     applies fresh, no ambiguity); on COMMIT the conns are force-closed (no applier
+//   - On the ack (all bracket frames processed by readLoop), the round-trip
+//     resolves to SUCCESS iff no frame in the bracket was frozen-dropped
+//     (frozenDropSeq unchanged) — i.e. setContent wasn't lost to a freeze (a
+//     no-op-diff setContent, which persists nothing, also resolves to success).
+//
+//   - When a restore freezes, ForceRefreshRoom FINALIZES every in-flight round-trip
+//     UNDER appendMu, atomic with setting frozen: the round-trip persisted iff its
+//     applier conn's lastPersistedOpID advanced past the bracket baseline. Because
+//     the read and the freeze share the appendMu critical section, any frame still
+//     in flight is blocked on appendMu and will be dropped once the freeze is
+//     visible — so lastPersistedOpID-not-advanced is a DURABLE "did not land". There
+//     is no window in which a persisted edit is seen as not-persisted, and (via the
+//     apply_start bracket) none in which typing is mistaken for the applier's frame.
+//
+//   - A NEW round-trip that starts while a restore holds the room WAITS for it to
+//     resolve (enterApplierGate) before electing, then re-elects: on ROLLBACK the
+//     conns are unfrozen (apply fresh), on COMMIT they are force-closed (no applier
 //     → ErrNoApplierAvailable → the caller's direct-write fallback, unchanged).
 //
-// The common path — an applier round-trip with NO restore in progress — pays only a
-// single leaf-mutex lock/unlock + counter bump at gate entry/exit; its ack-wait
-// select watches an open channel that never fires, so its latency and behavior are
-// byte-for-byte unchanged (hard constraint 1). Every serialization wait is bounded
-// to the restore-tx duration (plus, for a preempted in-flight round-trip, the short
-// applierPreemptGrace), never to the 30s applier timeout (hard constraint 2).
-
-// applierPreemptGraceVar is how long a preempted in-flight applier round-trip keeps
-// watching for its ack after a restore signals it to yield, BEFORE it abandons the
-// attempt. The preempt fires while the room is still UNFROZEN, so an ack the browser
-// already sent (trailing its now-persisted sync frames on the same ordered conn) is
-// still delivered normally within this window — letting a round-trip whose content
-// already landed resolve as SUCCESS (sub-case A) instead of parking and re-applying.
-// It only needs to cover socket→readLoop processing latency for an ack that TCP
-// ordering guarantees is already received-or-imminent; it is NOT the 30s applier
-// timeout, and it is paid ONLY when a restore actively preempts a genuinely
-// in-flight round-trip (never on the common no-restore path). A var so tests can
-// shrink/stretch it.
-var applierPreemptGraceVar = 500 * time.Millisecond
-
-func applierPreemptGrace() time.Duration { return applierPreemptGraceVar }
-
-// applierMaxRestartsAfterRestore caps how many times ApplyExternalContent re-elects
-// after being preempted/blocked by a restore, so a pathological back-to-back restore
-// storm can't spin the election forever. On exhaustion the caller falls back to a
-// direct write (ErrNoApplierAvailable) — safe graceful degradation.
-const applierMaxRestartsAfterRestore = 5
+// The common no-restore path pays only a single leaf-mutex check at gate entry
+// (restoreActive==false → proceed) plus the two extra durable-signal atomics on the
+// persist path; its ack resolves to success with no added latency (hard constraint
+// 1). Every wait is bounded to the restore-tx duration, never the 30s applier
+// timeout (hard constraint 2). restoreMu is a strict leaf; lock order is unchanged
+// (hard constraint 5).
 
 // beginRestore is called by ForceRefreshRoom under the per-item lock, BEFORE it
-// freezes the room's conns. It marks a restore in progress (so new applier
-// round-trips block in enterApplierGate) and preempts any ALREADY in-flight
-// round-trip (by closing the preempt channel they captured), then BLOCKS until
-// every in-flight round-trip has drained to zero. On return the room is safe to
-// freeze: no applier ack can race the frozen window, because there is no in-flight
-// applier round-trip left. Paired with resolveRestore (deferred by the caller).
-//
-// The drain is bounded: each preempted round-trip yields within applierPreemptGrace,
-// so this never blocks for the 30s applier timeout. A room with no in-flight
-// round-trips returns immediately.
-//
-// Precondition (guaranteed by ForceRefreshRoom holding itemLock): no other restore
-// is in progress for this room, so restorePreempt is open and closing it is safe.
+// freezes the room. It marks a restore in progress so new applier round-trips block
+// in enterApplierGate. It does NOT drain: in-flight round-trips are finalized by the
+// freeze itself (see (*Room).freezeAndFinalizePending), so there is nothing to wait
+// on here — beginRestore never blocks. Paired with resolveRestore (deferred by the
+// caller so it runs on every return path).
 func (r *Room) beginRestore() {
 	r.restoreMu.Lock()
 	r.restoreActive = true
 	if r.restoreResolved == nil {
 		r.restoreResolved = make(chan struct{})
 	}
-	// Wake every in-flight round-trip that captured this preempt channel.
-	close(r.restorePreempt)
-	// Drain: wait for all in-flight round-trips to yield. restoreCond is broadcast
-	// by exitApplierGate when the count hits 0.
-	for r.applierInFlight > 0 {
-		r.restoreCond.Wait()
-	}
 	r.restoreMu.Unlock()
 }
 
 // resolveRestore releases the gate when the restore RESOLVES (commit, rollback, or
-// uncertain). It clears restoreActive, closes restoreResolved (waking every parked /
-// gate-blocked applier round-trip so they re-elect against the post-restore room),
-// and installs a fresh preempt channel for the next restore cycle. ForceRefreshRoom
-// defers this immediately after beginRestore so it runs on every return path.
+// uncertain): it clears restoreActive and closes restoreResolved, waking every
+// gate-blocked or finalized-and-parked round-trip so they re-elect against the
+// post-restore room. ForceRefreshRoom defers it immediately after beginRestore.
 func (r *Room) resolveRestore() {
 	r.restoreMu.Lock()
 	r.restoreActive = false
@@ -106,24 +74,16 @@ func (r *Room) resolveRestore() {
 		close(r.restoreResolved)
 		r.restoreResolved = nil
 	}
-	// The old preempt channel is closed; hand out a fresh open one so future
-	// round-trips capture a channel that only fires on the NEXT restore.
-	r.restorePreempt = make(chan struct{})
 	r.restoreMu.Unlock()
 }
 
-// enterApplierGate is called at the start of each applier election attempt. It
-// blocks while a version restore holds the room, then registers this round-trip as
-// in-flight and returns the preempt channel the caller's ack-wait select must watch.
-//
-// `waited` reports whether it had to block for an in-progress restore: when true the
-// caller must NOT proceed with a stale election — it exits the gate and restarts
+// enterApplierGate is called at the start of each applier election. It blocks while
+// a version restore holds the room and reports whether it had to wait. When it
+// waited, the caller must NOT proceed with a stale election — it restarts
 // ApplyExternalContent from scratch against the now-resolved room. The common path
-// (no restore) returns immediately with waited=false and the room's current open
-// preempt channel (which never fires unless a restore begins mid-round-trip).
-func (r *Room) enterApplierGate() (preempt <-chan struct{}, waited bool) {
+// (no restore) returns immediately with waited=false.
+func (r *Room) enterApplierGate() (waited bool) {
 	r.restoreMu.Lock()
-	defer r.restoreMu.Unlock()
 	for r.restoreActive {
 		waited = true
 		resolved := r.restoreResolved
@@ -133,26 +93,12 @@ func (r *Room) enterApplierGate() (preempt <-chan struct{}, waited bool) {
 		}
 		r.restoreMu.Lock()
 	}
-	r.applierInFlight++
-	return r.restorePreempt, waited
-}
-
-// exitApplierGate deregisters an in-flight applier round-trip and, when the count
-// reaches zero, wakes a restore draining in beginRestore. Must be paired with each
-// successful enterApplierGate.
-func (r *Room) exitApplierGate() {
-	r.restoreMu.Lock()
-	if r.applierInFlight > 0 {
-		r.applierInFlight--
-	}
-	if r.applierInFlight == 0 {
-		r.restoreCond.Broadcast()
-	}
 	r.restoreMu.Unlock()
+	return waited
 }
 
 // waitRestoreResolved blocks until the in-progress restore (if any) resolves. Called
-// by a preempted round-trip after it has exited the gate, so it doesn't re-elect
+// by a round-trip the restore finalized to not-persisted, so it doesn't re-elect
 // until the restore's effects (unfreeze on rollback / force-close on commit) are in
 // place. Bounded to the restore-tx duration.
 func (r *Room) waitRestoreResolved() {

--- a/internal/collab/restore_coord_test.go
+++ b/internal/collab/restore_coord_test.go
@@ -11,20 +11,8 @@ import (
 	"github.com/gorilla/websocket"
 )
 
-// swapApplierPreemptGrace tunes the preempt-grace window for a test. Mirrors
-// swapApplierTimeouts. Guarded by the same applierTimeoutMu since the package's
-// tests run serially by default.
-func swapApplierPreemptGrace(d time.Duration) time.Duration {
-	applierTimeoutMu.Lock()
-	defer applierTimeoutMu.Unlock()
-	prev := applierPreemptGraceVar
-	applierPreemptGraceVar = d
-	return prev
-}
-
 // waitRestoreActive polls until the room reports a restore in progress (beginRestore
-// has set restoreActive + closed the preempt channel). White-box: the test lives in
-// package collab.
+// has set restoreActive). White-box: the test lives in package collab.
 func waitRestoreActive(t *testing.T, room *Room, d time.Duration) {
 	t.Helper()
 	deadline := time.Now().Add(d)
@@ -56,11 +44,31 @@ func roomFor(t *testing.T, mgr *RoomManager, itemID string) *Room {
 	return nil
 }
 
+// waitItemRows polls until the store holds at least n op-log rows for itemID.
+func waitItemRows(t *testing.T, store *fakeOpLog, itemID string, n int, d time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		store.mu.Lock()
+		c := 0
+		for _, r := range store.rows {
+			if r.ItemID == itemID {
+				c++
+			}
+		}
+		store.mu.Unlock()
+		if c >= n {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatalf("store did not reach %d rows for %s within deadline", n, itemID)
+}
+
 // TestApplierGateFastPathAddsNoLatency is the hard-constraint-1 guard: a NORMAL
 // applier round-trip — one with NO restore in progress — must be completely
 // unaffected by the restore gate. The echoing applier acks immediately; the round-
-// trip must return nil promptly (the gate is a single leaf-mutex bump, its preempt
-// channel never fires), NOT stalled by any of the residual-2 machinery.
+// trip must return nil promptly.
 func TestApplierGateFastPathAddsNoLatency(t *testing.T) {
 	bus := NewMemoryOpBus()
 	defer bus.Close()
@@ -81,9 +89,6 @@ func TestApplierGateFastPathAddsNoLatency(t *testing.T) {
 		time.Sleep(5 * time.Millisecond)
 	}
 
-	// Run several applies and assert each returns quickly. A regression that
-	// blocked normal acks under the gate/lock (the reverted round-4 attempt) would
-	// blow the per-call budget.
 	for i := 0; i < 5; i++ {
 		start := time.Now()
 		if err := mgr.ApplyExternalContent("item-a", "# rev"); err != nil {
@@ -94,26 +99,23 @@ func TestApplierGateFastPathAddsNoLatency(t *testing.T) {
 		}
 	}
 
-	// The gate must be perfectly balanced: no leaked in-flight count.
+	// No pending-ack entries leak across applies.
 	room := roomFor(t, mgr, "item-a")
-	room.restoreMu.Lock()
-	inFlight := room.applierInFlight
-	room.restoreMu.Unlock()
-	if inFlight != 0 {
-		t.Fatalf("applierInFlight leaked: %d (want 0)", inFlight)
+	room.pendingMu.Lock()
+	left := len(room.pendingAcks)
+	room.pendingMu.Unlock()
+	if left != 0 {
+		t.Fatalf("pendingAcks leaked: %d", left)
 	}
 }
 
-// TestRestoreDrainsInFlightApplier_AckDeliveredIsSuccess covers sub-case (A): an
-// in-flight applier round-trip whose content already landed (a sync frame persisted
-// while the room was UNFROZEN) and whose ack is delivered during the preempt grace
-// must resolve as SUCCESS — the round-trip does NOT retry, so the external content
-// is NOT re-applied over peer edits. The restore then rolls back; the persisted
-// frame survives (rollback prunes nothing).
-func TestRestoreDrainsInFlightApplier_AckDeliveredIsSuccess(t *testing.T) {
-	// Generous grace so the ack we release after the preempt lands inside it.
-	defer swapApplierPreemptGrace(swapApplierPreemptGrace(2 * time.Second))
-
+// TestRestoreFinalizesPersistedApplierAsSuccess_DelayedAck is the durable-correlation
+// replacement for the old timing-grace sub-case (A) test. An in-flight applier
+// PERSISTS its setContent frame (op-log advances) but its ack is DELAYED past any
+// timer. A restore then freezes and FINALIZES the round-trip from durable op-log
+// state: because the frame landed BEFORE the freeze, the round-trip resolves to
+// SUCCESS — it does NOT re-apply, so no clobber. The rollback keeps the frame.
+func TestRestoreFinalizesPersistedApplierAsSuccess_DelayedAck(t *testing.T) {
 	bus := NewMemoryOpBus()
 	defer bus.Close()
 	store := &fakeOpLog{}
@@ -128,7 +130,6 @@ func TestRestoreDrainsInFlightApplier_AckDeliveredIsSuccess(t *testing.T) {
 
 	var requestCount int32
 	gotFirstRequest := make(chan struct{}, 1)
-	ackNow := make(chan struct{})
 	go func() {
 		for {
 			mt, data, err := conn.ReadMessage()
@@ -143,16 +144,16 @@ func TestRestoreDrainsInFlightApplier_AckDeliveredIsSuccess(t *testing.T) {
 				continue
 			}
 			if atomic.AddInt32(&requestCount, 1) == 1 {
-				// Simulate setContent(markdown): a Y.Doc sync frame that persists to
-				// the op-log while the room is still unfrozen (sub-case A landing).
+				// Open the durable bracket, then send the setContent frame (persists
+				// while unfrozen). DELIBERATELY never send the ack — the durable
+				// finalization must decide from op-log state, not the ack.
+				start, _ := json.Marshal(ControlMessage{Type: ControlMessageApplierApplyStart, RequestID: ctl.RequestID})
+				_ = conn.WriteMessage(websocket.TextMessage, start)
 				_ = conn.WriteMessage(websocket.BinaryMessage, []byte{yMessageSync, 0xA1})
 				select {
 				case gotFirstRequest <- struct{}{}:
 				default:
 				}
-				<-ackNow // hold the ack until the restore has preempted us
-				ack, _ := json.Marshal(ControlMessage{Type: ControlMessageApplierAck, RequestID: ctl.RequestID})
-				_ = conn.WriteMessage(websocket.TextMessage, ack)
 			}
 		}
 	}()
@@ -167,11 +168,11 @@ func TestRestoreDrainsInFlightApplier_AckDeliveredIsSuccess(t *testing.T) {
 	applyDone := make(chan error, 1)
 	go func() { applyDone <- mgr.ApplyExternalContent("item-a", "# external") }()
 
-	<-gotFirstRequest // the applier holds its ack; round-trip is in-flight
+	<-gotFirstRequest
+	// Ensure the setContent frame has DURABLY persisted before the restore freezes,
+	// so finalization observes the high-water advance.
+	waitItemRows(t, store, "item-a", 1, 2*time.Second)
 
-	room := roomFor(t, mgr, "item-a")
-	// Start a rolling-back restore. beginRestore preempts the in-flight round-trip
-	// and blocks draining it until we release the ack.
 	restoreDone := make(chan error, 1)
 	go func() {
 		restoreDone <- mgr.ForceRefreshRoom("item-a",
@@ -179,32 +180,26 @@ func TestRestoreDrainsInFlightApplier_AckDeliveredIsSuccess(t *testing.T) {
 			nil)
 	}()
 
-	waitRestoreActive(t, room, 2*time.Second) // preempt channel is now closed
-	close(ackNow)                             // ack delivered while still unfrozen
-
 	select {
 	case err := <-applyDone:
 		if err != nil {
-			t.Fatalf("sub-case A: round-trip whose ack landed during preempt must SUCCEED, got %v", err)
+			t.Fatalf("persisted-before-freeze round-trip must resolve to SUCCESS, got %v", err)
 		}
 	case <-time.After(5 * time.Second):
-		t.Fatal("sub-case A: ApplyExternalContent did not return")
+		t.Fatal("ApplyExternalContent did not return (finalization should have delivered success)")
 	}
-
 	select {
 	case err := <-restoreDone:
 		if err == nil {
-			t.Fatal("restore was supposed to roll back (commit error)")
+			t.Fatal("restore was supposed to roll back")
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("ForceRefreshRoom did not return")
 	}
 
-	// No re-apply: the applier was asked exactly once.
 	if n := atomic.LoadInt32(&requestCount); n != 1 {
-		t.Fatalf("sub-case A: applier must be asked exactly once (no re-apply/clobber), got %d requests", n)
+		t.Fatalf("persisted round-trip must NOT re-apply (no clobber); want 1 request, got %d", n)
 	}
-	// The persisted frame survived the rollback (op-log was never pruned).
 	store.mu.Lock()
 	frameFound := false
 	for _, r := range store.rows {
@@ -214,18 +209,18 @@ func TestRestoreDrainsInFlightApplier_AckDeliveredIsSuccess(t *testing.T) {
 	}
 	store.mu.Unlock()
 	if !frameFound {
-		t.Fatal("sub-case A: the applier's persisted frame must survive a rollback")
+		t.Fatal("the applier's persisted frame must survive the rollback")
 	}
 }
 
-// TestRestorePreemptsInFlightApplier_ReAppliesOnRollback covers sub-case (B): an
-// in-flight applier round-trip whose content did NOT land (no ack, nothing
-// persisted) is preempted by a restore. It must NOT be told it succeeded; after the
-// restore ROLLS BACK it re-elects and re-applies (a SECOND applier_request), then
-// succeeds. Distinguishing assertion vs (A): the applier is asked TWICE.
-func TestRestorePreemptsInFlightApplier_ReAppliesOnRollback(t *testing.T) {
-	// Short grace: no ack arrives, so the preempt handler abandons quickly.
-	defer swapApplierPreemptGrace(swapApplierPreemptGrace(60 * time.Millisecond))
+// TestRestoreFinalizesUnpersistedApplierAsRetry is sub-case (B): an in-flight applier
+// that opened its bracket but whose setContent did NOT persist (no frame) is
+// finalized as NOT-persisted → it re-elects after the restore rolls back and
+// re-applies (a SECOND request), then succeeds. No false success.
+func TestRestoreFinalizesUnpersistedApplierAsRetry(t *testing.T) {
+	origFirst, origRetry := applierFirstTimeoutVar, applierRetryTimeoutVar
+	swapApplierTimeouts(2*time.Second, 1*time.Second)
+	defer swapApplierTimeouts(origFirst, origRetry)
 
 	bus := NewMemoryOpBus()
 	defer bus.Close()
@@ -256,16 +251,18 @@ func TestRestorePreemptsInFlightApplier_ReAppliesOnRollback(t *testing.T) {
 			}
 			n := atomic.AddInt32(&requestCount, 1)
 			if n == 1 {
-				// First request: do NOT ack, do NOT persist a frame — the content
-				// never lands (sub-case B). Just signal the test and let the grace
-				// expire so the round-trip is preempted + parked.
+				// Open the bracket but persist NOTHING (setContent did not land).
+				start, _ := json.Marshal(ControlMessage{Type: ControlMessageApplierApplyStart, RequestID: ctl.RequestID})
+				_ = conn.WriteMessage(websocket.TextMessage, start)
 				select {
 				case gotFirstRequest <- struct{}{}:
 				default:
 				}
 				continue
 			}
-			// Re-elected after the rollback: honestly ack this time.
+			// Re-elected after the rollback: honestly ack (no frozen drop → success).
+			start, _ := json.Marshal(ControlMessage{Type: ControlMessageApplierApplyStart, RequestID: ctl.RequestID})
+			_ = conn.WriteMessage(websocket.TextMessage, start)
 			ack, _ := json.Marshal(ControlMessage{Type: ControlMessageApplierAck, RequestID: ctl.RequestID})
 			_ = conn.WriteMessage(websocket.TextMessage, ack)
 		}
@@ -290,15 +287,13 @@ func TestRestorePreemptsInFlightApplier_ReAppliesOnRollback(t *testing.T) {
 			nil)
 	}()
 
-	// The restore rolls back (un-freezes the conn); the parked round-trip then
-	// re-elects the now-live applier and succeeds.
 	select {
 	case err := <-applyDone:
 		if err != nil {
-			t.Fatalf("sub-case B: round-trip must eventually SUCCEED via re-apply, got %v", err)
+			t.Fatalf("unpersisted round-trip must re-apply + succeed, got %v", err)
 		}
 	case <-time.After(6 * time.Second):
-		t.Fatal("sub-case B: ApplyExternalContent did not return")
+		t.Fatal("ApplyExternalContent did not return")
 	}
 	select {
 	case <-restoreDone:
@@ -307,19 +302,17 @@ func TestRestorePreemptsInFlightApplier_ReAppliesOnRollback(t *testing.T) {
 	}
 
 	if n := atomic.LoadInt32(&requestCount); n != 2 {
-		t.Fatalf("sub-case B: applier must be re-asked (retry after rollback); want 2 requests, got %d", n)
+		t.Fatalf("unpersisted round-trip must re-apply after rollback; want 2 requests, got %d", n)
 	}
 }
 
-// TestRestoreCommitForceClosesThenFallsBack covers the COMMIT case: an in-flight
-// applier round-trip preempted by a restore that COMMITS finds, on re-election, that
-// the peer was force-closed (frozen + socket closed). No applier is available, so
-// ApplyExternalContent returns ErrNoApplierAvailable — the caller then direct-writes,
-// and the collab-snapshot restore boundary rejects any stale in-flight flush
-// (existing, unchanged behavior). It must NOT falsely report success against the
-// frozen/closed conn.
+// TestRestoreCommitForceClosesThenFallsBack: an in-flight (unpersisted) applier
+// finalized by a COMMITTING restore re-elects against the force-closed room, finds no
+// applier, and returns ErrNoApplierAvailable (→ caller's direct-write fallback).
 func TestRestoreCommitForceClosesThenFallsBack(t *testing.T) {
-	defer swapApplierPreemptGrace(swapApplierPreemptGrace(60 * time.Millisecond))
+	origFirst, origRetry := applierFirstTimeoutVar, applierRetryTimeoutVar
+	swapApplierTimeouts(2*time.Second, 1*time.Second)
+	defer swapApplierTimeouts(origFirst, origRetry)
 
 	bus := NewMemoryOpBus()
 	defer bus.Close()
@@ -347,7 +340,8 @@ func TestRestoreCommitForceClosesThenFallsBack(t *testing.T) {
 			if json.Unmarshal(data, &ctl) != nil || ctl.Type != ControlMessageApplierRequest {
 				continue
 			}
-			// Never ack — force the preempt/park path.
+			start, _ := json.Marshal(ControlMessage{Type: ControlMessageApplierApplyStart, RequestID: ctl.RequestID})
+			_ = conn.WriteMessage(websocket.TextMessage, start)
 			select {
 			case gotFirstRequest <- struct{}{}:
 			default:
@@ -361,8 +355,6 @@ func TestRestoreCommitForceClosesThenFallsBack(t *testing.T) {
 		}
 		time.Sleep(5 * time.Millisecond)
 	}
-
-	// Seed an op-log row so the commit callback has a MAX to capture.
 	if _, err := store.AppendYjsUpdate("item-a", []byte{yMessageSync, 0x01}, "1"); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
@@ -374,8 +366,6 @@ func TestRestoreCommitForceClosesThenFallsBack(t *testing.T) {
 
 	restoreDone := make(chan error, 1)
 	go func() {
-		// A CLEAN commit: prune the op-log, return (MAX, seq). ForceRefreshRoom then
-		// force-closes the conns.
 		restoreDone <- mgr.ForceRefreshRoom("item-a", func() (int64, int64, error) {
 			maxID, _, merr := store.MaxOpLogID("item-a")
 			if merr != nil {
@@ -391,7 +381,7 @@ func TestRestoreCommitForceClosesThenFallsBack(t *testing.T) {
 	select {
 	case err := <-applyDone:
 		if !errors.Is(err, ErrNoApplierAvailable) {
-			t.Fatalf("commit case: re-election must find no applier (force-closed) → ErrNoApplierAvailable, got %v", err)
+			t.Fatalf("commit case: re-election must find no applier → ErrNoApplierAvailable, got %v", err)
 		}
 	case <-time.After(6 * time.Second):
 		t.Fatal("commit case: ApplyExternalContent did not return")
@@ -404,18 +394,13 @@ func TestRestoreCommitForceClosesThenFallsBack(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("ForceRefreshRoom did not return")
 	}
-
-	// The commit published the restore fences the direct-write fallback / snapshot
-	// gate rely on.
 	if b, ok := mgr.RestoreBoundary("item-a"); !ok || b <= 0 {
 		t.Fatalf("commit must publish a restore boundary, got (%d,%v)", b, ok)
 	}
 }
 
-// TestApplierWaitsForRestoreInProgress covers the enter-gate direction: a NEW applier
-// round-trip that starts WHILE a restore already holds the room must WAIT for the
-// restore to resolve before electing — it must not race the frozen conn. On rollback
-// it then applies against the unfrozen room and succeeds.
+// TestApplierWaitsForRestoreInProgress: a NEW round-trip that starts while a restore
+// holds the room WAITS for it to resolve before electing, then applies on rollback.
 func TestApplierWaitsForRestoreInProgress(t *testing.T) {
 	bus := NewMemoryOpBus()
 	defer bus.Close()
@@ -440,14 +425,12 @@ func TestApplierWaitsForRestoreInProgress(t *testing.T) {
 
 	room := roomFor(t, mgr, "item-a")
 
-	// Hold the restore in its commit until we release it, so it is DEFINITELY in
-	// progress when ApplyExternalContent starts.
 	commitGate := make(chan struct{})
 	restoreDone := make(chan error, 1)
 	go func() {
 		restoreDone <- mgr.ForceRefreshRoom("item-a", func() (int64, int64, error) {
 			<-commitGate
-			return 0, 0, errors.New("commit: rolled back") // rollback → un-freeze
+			return 0, 0, errors.New("commit: rolled back")
 		}, nil)
 	}()
 
@@ -456,16 +439,13 @@ func TestApplierWaitsForRestoreInProgress(t *testing.T) {
 	applyDone := make(chan error, 1)
 	go func() { applyDone <- mgr.ApplyExternalContent("item-a", "# external") }()
 
-	// While the restore is in progress, the round-trip must be BLOCKED in the gate.
 	select {
 	case err := <-applyDone:
 		t.Fatalf("applier round-trip must wait for the in-progress restore, but returned early: %v", err)
 	case <-time.After(150 * time.Millisecond):
-		// good — still blocked
+		// good — still blocked in the gate
 	}
 
-	// Resolve the restore (rollback). The gate releases; the applier round-trip
-	// re-elects against the unfrozen room and the echo acks it.
 	close(commitGate)
 
 	select {
@@ -479,75 +459,146 @@ func TestApplierWaitsForRestoreInProgress(t *testing.T) {
 	<-restoreDone
 }
 
-// TestBeginRestoreDrainsPromptlyWithNoAppliers is a white-box guard that beginRestore
-// returns immediately when nothing is in flight, and that the gate's counters/preempt
-// channel cycle correctly across begin/resolve.
-func TestBeginRestoreDrainsPromptlyWithNoAppliers(t *testing.T) {
+// TestForceRefreshDoesNotStallOnInFlightApplier is the P1(a) guard: ForceRefreshRoom
+// must NOT wait for an in-flight applier round-trip (the old drain could stall
+// forever on a blocked applier write). With the finalization redesign there is no
+// drain — the restore finalizes the round-trip and proceeds. Here the applier never
+// acks; ForceRefreshRoom must still complete promptly.
+func TestForceRefreshDoesNotStallOnInFlightApplier(t *testing.T) {
+	origFirst, origRetry := applierFirstTimeoutVar, applierRetryTimeoutVar
+	swapApplierTimeouts(500*time.Millisecond, 250*time.Millisecond)
+	defer swapApplierTimeouts(origFirst, origRetry)
+
+	bus := NewMemoryOpBus()
+	defer bus.Close()
+	store := &fakeOpLog{}
+	mgr := NewRoomManager(store, bus)
+	defer mgr.Close()
+
+	srv := newCollabTestServer(t, mgr)
+	defer srv.Close()
+
+	conn := dialWS(t, srv, "item-a")
+	defer conn.Close()
+
+	gotFirstRequest := make(chan struct{}, 1)
+	go func() {
+		for {
+			mt, data, err := conn.ReadMessage()
+			if err != nil {
+				return
+			}
+			if mt != websocket.TextMessage {
+				continue
+			}
+			var ctl ControlMessage
+			if json.Unmarshal(data, &ctl) != nil || ctl.Type != ControlMessageApplierRequest {
+				continue
+			}
+			// Never respond — keep the round-trip in-flight.
+			select {
+			case gotFirstRequest <- struct{}{}:
+			default:
+			}
+		}
+	}()
+
+	for i := 0; i < 200; i++ {
+		if bus.SubscriberCount("item-a") == 1 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	applyDone := make(chan error, 1)
+	go func() { applyDone <- mgr.ApplyExternalContent("item-a", "# external") }()
+
+	<-gotFirstRequest
+
+	start := time.Now()
+	err := mgr.ForceRefreshRoom("item-a",
+		func() (int64, int64, error) { return 0, 0, errors.New("rollback") }, nil)
+	if err == nil {
+		t.Fatal("restore was supposed to roll back")
+	}
+	if elapsed := time.Since(start); elapsed > 1*time.Second {
+		t.Fatalf("ForceRefreshRoom stalled on an in-flight applier (%v); the drain-stall regression is back", elapsed)
+	}
+	<-applyDone // the round-trip re-elects/falls back after the rollback
+}
+
+// TestWriteApplierRequestBoundedOnWedgedWrite is the P1(a) bounded-write guard: a
+// conn whose writeMu is held by a genuinely blocked WriteMessage — a real peer that
+// never drains, so a large frame fills the socket buffer and blocks — must not wedge
+// writeApplierRequest forever. The independent close-timer closes the conn, the
+// wedged write errors, writeMu releases, and writeApplierRequest returns an error
+// promptly (not after the applier timeout).
+func TestWriteApplierRequestBoundedOnWedgedWrite(t *testing.T) {
+	prev := applierWriteDeadlineVar
+	applierWriteDeadlineVar = 200 * time.Millisecond
+	defer func() { applierWriteDeadlineVar = prev }()
+
 	bus := NewMemoryOpBus()
 	defer bus.Close()
 	mgr := NewRoomManager(&fakeOpLog{}, bus)
 	defer mgr.Close()
-	room := mgr.getOrCreate("item-a")
+	srv := newCollabTestServer(t, mgr)
+	defer srv.Close()
 
-	preemptBefore := room.restorePreempt
+	// Client that NEVER reads: its receive buffer (and the server's send buffer)
+	// will fill, so a large server-side write blocks in conn.Write.
+	client := dialWS(t, srv, "item-a")
+	defer client.Close()
 
-	done := make(chan struct{})
-	go func() {
-		room.beginRestore()
-		close(done)
-	}()
-	select {
-	case <-done:
-	case <-time.After(time.Second):
-		t.Fatal("beginRestore blocked with no in-flight appliers")
-	}
-
-	// A new applier gate entry now blocks until resolve.
-	entered := make(chan struct{})
-	go func() {
-		_, waited := room.enterApplierGate()
-		if !waited {
-			t.Error("enterApplierGate during an active restore must report waited=true")
+	room := roomFor(t, mgr, "item-a")
+	var rc *roomConn
+	for i := 0; i < 200 && rc == nil; i++ {
+		room.mu.Lock()
+		for _, c := range room.conns {
+			rc = c
 		}
-		room.exitApplierGate()
-		close(entered)
+		room.mu.Unlock()
+		if rc == nil {
+			time.Sleep(5 * time.Millisecond)
+		}
+	}
+	if rc == nil {
+		t.Fatal("server-side roomConn never registered")
+	}
+
+	// Wedge writeMu with a real, blocking WriteMessage (8 MiB to a non-draining
+	// peer). rc.writeMessage holds writeMu across the write; Close interrupts it.
+	huge := make([]byte, 8<<20)
+	huge[0] = yMessageSync
+	wedged := make(chan struct{})
+	go func() {
+		close(wedged)
+		_ = rc.writeMessage(websocket.BinaryMessage, huge)
 	}()
-	select {
-	case <-entered:
-		t.Fatal("enterApplierGate must block while a restore is active")
-	case <-time.After(100 * time.Millisecond):
-	}
+	<-wedged
+	// Give the wedging write time to acquire writeMu and block on the full buffer.
+	time.Sleep(100 * time.Millisecond)
 
-	room.resolveRestore()
-	select {
-	case <-entered:
-	case <-time.After(time.Second):
-		t.Fatal("enterApplierGate did not unblock after resolveRestore")
-	}
+	done := make(chan error, 1)
+	start := time.Now()
+	go func() { done <- writeApplierRequest(rc, []byte(`{"type":"applier_request"}`)) }()
 
-	// resolveRestore installed a fresh preempt channel and cleared active state.
-	room.restoreMu.Lock()
-	active := room.restoreActive
-	freshPreempt := room.restorePreempt
-	room.restoreMu.Unlock()
-	if active {
-		t.Fatal("restoreActive must be false after resolveRestore")
-	}
-	if freshPreempt == preemptBefore {
-		t.Fatal("resolveRestore must install a fresh preempt channel")
-	}
-	// The old preempt channel must be closed (it preempted in-flight round-trips).
 	select {
-	case <-preemptBefore:
-	default:
-		t.Fatal("beginRestore must have closed the captured preempt channel")
+	case err := <-done:
+		if err == nil {
+			t.Fatal("writeApplierRequest to a wedged/closed conn must return an error")
+		}
+		if elapsed := time.Since(start); elapsed > 3*time.Second {
+			t.Fatalf("bounded write took %v; the close-timer must bound it near applierWriteDeadline", elapsed)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("writeApplierRequest wedged forever; the bounded-write close-timer did not fire")
 	}
 }
 
 // TestConcurrentAppliersAndRestoreNoDeadlock stress-drives several applier round-trips
-// interleaved with restores to shake out lock-order / drain deadlocks under -race.
+// interleaved with restores to shake out lock-order / finalization deadlocks under -race.
 func TestConcurrentAppliersAndRestoreNoDeadlock(t *testing.T) {
-	defer swapApplierPreemptGrace(swapApplierPreemptGrace(30 * time.Millisecond))
 	origFirst, origRetry := applierFirstTimeoutVar, applierRetryTimeoutVar
 	swapApplierTimeouts(120*time.Millisecond, 60*time.Millisecond)
 	defer swapApplierTimeouts(origFirst, origRetry)
@@ -585,7 +636,6 @@ func TestConcurrentAppliersAndRestoreNoDeadlock(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			// Rolling-back restores so the conn stays alive across the run.
 			_ = mgr.ForceRefreshRoom("item-a",
 				func() (int64, int64, error) { return 0, 0, errors.New("rollback") }, nil)
 		}()

--- a/internal/collab/restore_coord_test.go
+++ b/internal/collab/restore_coord_test.go
@@ -78,16 +78,11 @@ func TestApplierGateFastPathAddsNoLatency(t *testing.T) {
 	srv := newCollabTestServer(t, mgr)
 	defer srv.Close()
 
-	conn := dialWS(t, srv, "item-a")
+	conn := dialWSBracket(t, srv, "item-a")
 	stop := runApplierEcho(t, conn)
 	defer stop()
 
-	for i := 0; i < 200; i++ {
-		if bus.SubscriberCount("item-a") == 1 {
-			break
-		}
-		time.Sleep(5 * time.Millisecond)
-	}
+	waitElectable(t, mgr, "item-a", 1)
 
 	for i := 0; i < 5; i++ {
 		start := time.Now()
@@ -125,7 +120,7 @@ func TestRestoreFinalizesPersistedApplierAsSuccess_DelayedAck(t *testing.T) {
 	srv := newCollabTestServer(t, mgr)
 	defer srv.Close()
 
-	conn := dialWS(t, srv, "item-a")
+	conn := dialWSBracket(t, srv, "item-a")
 	defer conn.Close()
 
 	var requestCount int32
@@ -158,12 +153,7 @@ func TestRestoreFinalizesPersistedApplierAsSuccess_DelayedAck(t *testing.T) {
 		}
 	}()
 
-	for i := 0; i < 200; i++ {
-		if bus.SubscriberCount("item-a") == 1 {
-			break
-		}
-		time.Sleep(5 * time.Millisecond)
-	}
+	waitElectable(t, mgr, "item-a", 1)
 
 	applyDone := make(chan error, 1)
 	go func() { applyDone <- mgr.ApplyExternalContent("item-a", "# external") }()
@@ -231,7 +221,7 @@ func TestRestoreFinalizesUnpersistedApplierAsRetry(t *testing.T) {
 	srv := newCollabTestServer(t, mgr)
 	defer srv.Close()
 
-	conn := dialWS(t, srv, "item-a")
+	conn := dialWSBracket(t, srv, "item-a")
 	defer conn.Close()
 
 	var requestCount int32
@@ -268,12 +258,7 @@ func TestRestoreFinalizesUnpersistedApplierAsRetry(t *testing.T) {
 		}
 	}()
 
-	for i := 0; i < 200; i++ {
-		if bus.SubscriberCount("item-a") == 1 {
-			break
-		}
-		time.Sleep(5 * time.Millisecond)
-	}
+	waitElectable(t, mgr, "item-a", 1)
 
 	applyDone := make(chan error, 1)
 	go func() { applyDone <- mgr.ApplyExternalContent("item-a", "# external") }()
@@ -323,7 +308,7 @@ func TestRestoreCommitForceClosesThenFallsBack(t *testing.T) {
 	srv := newCollabTestServer(t, mgr)
 	defer srv.Close()
 
-	conn := dialWS(t, srv, "item-a")
+	conn := dialWSBracket(t, srv, "item-a")
 	defer conn.Close()
 
 	gotFirstRequest := make(chan struct{}, 1)
@@ -349,12 +334,7 @@ func TestRestoreCommitForceClosesThenFallsBack(t *testing.T) {
 		}
 	}()
 
-	for i := 0; i < 200; i++ {
-		if bus.SubscriberCount("item-a") == 1 {
-			break
-		}
-		time.Sleep(5 * time.Millisecond)
-	}
+	waitElectable(t, mgr, "item-a", 1)
 	if _, err := store.AppendYjsUpdate("item-a", []byte{yMessageSync, 0x01}, "1"); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
@@ -411,17 +391,12 @@ func TestApplierWaitsForRestoreInProgress(t *testing.T) {
 	srv := newCollabTestServer(t, mgr)
 	defer srv.Close()
 
-	conn := dialWS(t, srv, "item-a")
+	conn := dialWSBracket(t, srv, "item-a")
 	defer conn.Close()
 	stop := runApplierEcho(t, conn)
 	defer stop()
 
-	for i := 0; i < 200; i++ {
-		if bus.SubscriberCount("item-a") == 1 {
-			break
-		}
-		time.Sleep(5 * time.Millisecond)
-	}
+	waitElectable(t, mgr, "item-a", 1)
 
 	room := roomFor(t, mgr, "item-a")
 
@@ -478,7 +453,7 @@ func TestForceRefreshDoesNotStallOnInFlightApplier(t *testing.T) {
 	srv := newCollabTestServer(t, mgr)
 	defer srv.Close()
 
-	conn := dialWS(t, srv, "item-a")
+	conn := dialWSBracket(t, srv, "item-a")
 	defer conn.Close()
 
 	gotFirstRequest := make(chan struct{}, 1)
@@ -503,12 +478,7 @@ func TestForceRefreshDoesNotStallOnInFlightApplier(t *testing.T) {
 		}
 	}()
 
-	for i := 0; i < 200; i++ {
-		if bus.SubscriberCount("item-a") == 1 {
-			break
-		}
-		time.Sleep(5 * time.Millisecond)
-	}
+	waitElectable(t, mgr, "item-a", 1)
 
 	applyDone := make(chan error, 1)
 	go func() { applyDone <- mgr.ApplyExternalContent("item-a", "# external") }()
@@ -547,7 +517,7 @@ func TestWriteApplierRequestBoundedOnWedgedWrite(t *testing.T) {
 
 	// Client that NEVER reads: its receive buffer (and the server's send buffer)
 	// will fill, so a large server-side write blocks in conn.Write.
-	client := dialWS(t, srv, "item-a")
+	client := dialWSBracket(t, srv, "item-a")
 	defer client.Close()
 
 	room := roomFor(t, mgr, "item-a")
@@ -612,17 +582,12 @@ func TestConcurrentAppliersAndRestoreNoDeadlock(t *testing.T) {
 	srv := newCollabTestServer(t, mgr)
 	defer srv.Close()
 
-	conn := dialWS(t, srv, "item-a")
+	conn := dialWSBracket(t, srv, "item-a")
 	defer conn.Close()
 	stop := runApplierEcho(t, conn)
 	defer stop()
 
-	for i := 0; i < 200; i++ {
-		if bus.SubscriberCount("item-a") == 1 {
-			break
-		}
-		time.Sleep(5 * time.Millisecond)
-	}
+	waitElectable(t, mgr, "item-a", 1)
 
 	var wg sync.WaitGroup
 	for i := 0; i < 8; i++ {
@@ -647,5 +612,187 @@ func TestConcurrentAppliersAndRestoreNoDeadlock(t *testing.T) {
 	case <-fin:
 	case <-time.After(20 * time.Second):
 		t.Fatal("deadlock: concurrent appliers + restores did not all return")
+	}
+}
+
+// TestPickApplierSkipsUnanchoredConn is the P1(1) guard: a conn that is in the room
+// but NOT yet anchored (replayDone false — its client still buffers Y.Doc updates
+// until it receives the initial cursor) must NEVER be elected applier, else its
+// setContent frame would be buffered/unsent yet still acked → a false success for a
+// never-persisted write. Once anchored, it is electable.
+func TestPickApplierSkipsUnanchoredConn(t *testing.T) {
+	bus := NewMemoryOpBus()
+	defer bus.Close()
+	mgr := NewRoomManager(&fakeOpLog{}, bus)
+	defer mgr.Close()
+	room := mgr.getOrCreate("item-a")
+
+	rc := &roomConn{id: 1, conn: &websocket.Conn{}}
+	rc.canWrite.Store(true)
+	rc.bracketCapable.Store(true)
+	// replayDone NOT set → unanchored.
+	if err := room.addConn(rc); err != nil {
+		t.Fatalf("addConn: %v", err)
+	}
+	defer func() {
+		room.mu.Lock()
+		delete(room.conns, rc.conn)
+		room.mu.Unlock()
+	}()
+
+	if got := room.pickApplier(map[*websocket.Conn]struct{}{}); got != nil {
+		t.Fatal("pickApplier must NOT elect an unanchored (replayDone=false) conn")
+	}
+
+	rc.replayDone.Store(true) // client has now received its cursor
+	if got := room.pickApplier(map[*websocket.Conn]struct{}{}); got != rc {
+		t.Fatal("pickApplier must elect an anchored, writable, bracket-capable conn")
+	}
+}
+
+// TestBeginRestoreDrainsAdmissionGap is the P1(2) guard: a round-trip admitted by
+// enterApplierGate BEFORE beginRestore, but which registers its pending entry AFTER,
+// must NOT be missed by the freeze scan. beginRestore must WAIT (drain) for the
+// admitted-but-unregistered round-trip to register, then finalize it — so it gets a
+// durable outcome (here NotPersisted), never a hang or a false success.
+func TestBeginRestoreDrainsAdmissionGap(t *testing.T) {
+	bus := NewMemoryOpBus()
+	defer bus.Close()
+	mgr := NewRoomManager(&fakeOpLog{}, bus)
+	defer mgr.Close()
+	room := mgr.getOrCreate("item-a")
+
+	rc := &roomConn{id: 1, conn: &websocket.Conn{}}
+	rc.canWrite.Store(true)
+	rc.bracketCapable.Store(true)
+	rc.replayDone.Store(true)
+	if err := room.addConn(rc); err != nil {
+		t.Fatalf("addConn: %v", err)
+	}
+	defer func() {
+		room.mu.Lock()
+		delete(room.conns, rc.conn)
+		room.mu.Unlock()
+	}()
+
+	// Admit a round-trip (enter the gate) but DON'T register yet — the enter→register
+	// gap the drain must cover.
+	if room.enterApplierGate() {
+		t.Fatal("unexpected wait: no restore is in progress")
+	}
+
+	restoreDone := make(chan struct{})
+	go func() {
+		room.beginRestore() // blocks in the admission drain until we register + finish
+		room.freezeAndFinalizePending()
+		room.resolveRestore()
+		close(restoreDone)
+	}()
+
+	// beginRestore sets restoreActive then blocks draining the admission gap.
+	waitRestoreActive(t, room, time.Second)
+	select {
+	case <-restoreDone:
+		t.Fatal("beginRestore proceeded to finalize BEFORE the admitted round-trip registered (P1)")
+	case <-time.After(100 * time.Millisecond):
+		// good — still draining
+	}
+
+	// Complete the admission span: register, then finish. The drain unblocks and the
+	// freeze scan finalizes our now-registered entry.
+	resultCh, err := room.registerPendingAck("req-1", rc)
+	if err != nil {
+		t.Fatalf("registerPendingAck: %v", err)
+	}
+	room.finishAdmission()
+
+	select {
+	case outcome := <-resultCh:
+		if outcome != applierNotPersisted {
+			t.Fatalf("admitted-then-registered round-trip: want NotPersisted, got %v", outcome)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("admitted-then-registered round-trip was MISSED by the freeze scan (would hang the applier timeout)")
+	}
+	<-restoreDone
+}
+
+// TestRestoreLegacyPersistedIsAmbiguousNoReapply is the P1(3) mixed-deploy guard: a
+// LEGACY (non-bracket-capable) applier persists its setContent before a restore
+// freeze, then the restore ROLLS BACK. Because the server can't confirm persistence
+// without the apply_start bracket, the round-trip resolves AMBIGUOUS →
+// ErrApplierAmbiguous (retryable), and it does NOT re-apply — so a peer edit between
+// rollback and a would-be retry is never clobbered. The applier is asked exactly once.
+func TestRestoreLegacyPersistedIsAmbiguousNoReapply(t *testing.T) {
+	bus := NewMemoryOpBus()
+	defer bus.Close()
+	store := &fakeOpLog{}
+	mgr := NewRoomManager(store, bus)
+	defer mgr.Close()
+
+	srv := newCollabTestServer(t, mgr)
+	defer srv.Close()
+
+	// LEGACY conn: dialWS does NOT announce ?applier_bracket=1.
+	conn := dialWS(t, srv, "item-a")
+	defer conn.Close()
+
+	var requestCount int32
+	gotFirstRequest := make(chan struct{}, 1)
+	go func() {
+		for {
+			mt, data, err := conn.ReadMessage()
+			if err != nil {
+				return
+			}
+			if mt != websocket.TextMessage {
+				continue
+			}
+			var ctl ControlMessage
+			if json.Unmarshal(data, &ctl) != nil || ctl.Type != ControlMessageApplierRequest {
+				continue
+			}
+			if atomic.AddInt32(&requestCount, 1) == 1 {
+				// Legacy behavior: persist a setContent frame, but send NO apply_start
+				// bracket (and no ack).
+				_ = conn.WriteMessage(websocket.BinaryMessage, []byte{yMessageSync, 0xB2})
+				select {
+				case gotFirstRequest <- struct{}{}:
+				default:
+				}
+			}
+		}
+	}()
+
+	waitElectable(t, mgr, "item-a", 1)
+
+	applyDone := make(chan error, 1)
+	go func() { applyDone <- mgr.ApplyExternalContent("item-a", "# external") }()
+
+	<-gotFirstRequest
+	waitItemRows(t, store, "item-a", 1, 2*time.Second) // frame persisted before the freeze
+
+	restoreDone := make(chan error, 1)
+	go func() {
+		restoreDone <- mgr.ForceRefreshRoom("item-a",
+			func() (int64, int64, error) { return 0, 0, errors.New("commit: rolled back") }, nil)
+	}()
+
+	select {
+	case err := <-applyDone:
+		if !errors.Is(err, ErrApplierAmbiguous) {
+			t.Fatalf("legacy persisted round-trip during a restore must fail-safe with ErrApplierAmbiguous, got %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("ApplyExternalContent did not return")
+	}
+	select {
+	case <-restoreDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("ForceRefreshRoom did not return")
+	}
+
+	if n := atomic.LoadInt32(&requestCount); n != 1 {
+		t.Fatalf("ambiguous legacy round-trip must NOT re-apply (no clobber); want 1 request, got %d", n)
 	}
 }

--- a/internal/collab/restore_coord_test.go
+++ b/internal/collab/restore_coord_test.go
@@ -1,0 +1,601 @@
+package collab
+
+import (
+	"encoding/json"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// swapApplierPreemptGrace tunes the preempt-grace window for a test. Mirrors
+// swapApplierTimeouts. Guarded by the same applierTimeoutMu since the package's
+// tests run serially by default.
+func swapApplierPreemptGrace(d time.Duration) time.Duration {
+	applierTimeoutMu.Lock()
+	defer applierTimeoutMu.Unlock()
+	prev := applierPreemptGraceVar
+	applierPreemptGraceVar = d
+	return prev
+}
+
+// waitRestoreActive polls until the room reports a restore in progress (beginRestore
+// has set restoreActive + closed the preempt channel). White-box: the test lives in
+// package collab.
+func waitRestoreActive(t *testing.T, room *Room, d time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		room.restoreMu.Lock()
+		active := room.restoreActive
+		room.restoreMu.Unlock()
+		if active {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatal("restore did not become active within deadline")
+}
+
+func roomFor(t *testing.T, mgr *RoomManager, itemID string) *Room {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		mgr.mu.Lock()
+		room := mgr.rooms[itemID]
+		mgr.mu.Unlock()
+		if room != nil {
+			return room
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatal("room not created within deadline")
+	return nil
+}
+
+// TestApplierGateFastPathAddsNoLatency is the hard-constraint-1 guard: a NORMAL
+// applier round-trip — one with NO restore in progress — must be completely
+// unaffected by the restore gate. The echoing applier acks immediately; the round-
+// trip must return nil promptly (the gate is a single leaf-mutex bump, its preempt
+// channel never fires), NOT stalled by any of the residual-2 machinery.
+func TestApplierGateFastPathAddsNoLatency(t *testing.T) {
+	bus := NewMemoryOpBus()
+	defer bus.Close()
+	mgr := NewRoomManager(&fakeOpLog{}, bus)
+	defer mgr.Close()
+
+	srv := newCollabTestServer(t, mgr)
+	defer srv.Close()
+
+	conn := dialWS(t, srv, "item-a")
+	stop := runApplierEcho(t, conn)
+	defer stop()
+
+	for i := 0; i < 200; i++ {
+		if bus.SubscriberCount("item-a") == 1 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	// Run several applies and assert each returns quickly. A regression that
+	// blocked normal acks under the gate/lock (the reverted round-4 attempt) would
+	// blow the per-call budget.
+	for i := 0; i < 5; i++ {
+		start := time.Now()
+		if err := mgr.ApplyExternalContent("item-a", "# rev"); err != nil {
+			t.Fatalf("apply %d: %v", i, err)
+		}
+		if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+			t.Fatalf("apply %d took %v; the gate must add no measurable latency on the no-restore path", i, elapsed)
+		}
+	}
+
+	// The gate must be perfectly balanced: no leaked in-flight count.
+	room := roomFor(t, mgr, "item-a")
+	room.restoreMu.Lock()
+	inFlight := room.applierInFlight
+	room.restoreMu.Unlock()
+	if inFlight != 0 {
+		t.Fatalf("applierInFlight leaked: %d (want 0)", inFlight)
+	}
+}
+
+// TestRestoreDrainsInFlightApplier_AckDeliveredIsSuccess covers sub-case (A): an
+// in-flight applier round-trip whose content already landed (a sync frame persisted
+// while the room was UNFROZEN) and whose ack is delivered during the preempt grace
+// must resolve as SUCCESS — the round-trip does NOT retry, so the external content
+// is NOT re-applied over peer edits. The restore then rolls back; the persisted
+// frame survives (rollback prunes nothing).
+func TestRestoreDrainsInFlightApplier_AckDeliveredIsSuccess(t *testing.T) {
+	// Generous grace so the ack we release after the preempt lands inside it.
+	defer swapApplierPreemptGrace(swapApplierPreemptGrace(2 * time.Second))
+
+	bus := NewMemoryOpBus()
+	defer bus.Close()
+	store := &fakeOpLog{}
+	mgr := NewRoomManager(store, bus)
+	defer mgr.Close()
+
+	srv := newCollabTestServer(t, mgr)
+	defer srv.Close()
+
+	conn := dialWS(t, srv, "item-a")
+	defer conn.Close()
+
+	var requestCount int32
+	gotFirstRequest := make(chan struct{}, 1)
+	ackNow := make(chan struct{})
+	go func() {
+		for {
+			mt, data, err := conn.ReadMessage()
+			if err != nil {
+				return
+			}
+			if mt != websocket.TextMessage {
+				continue
+			}
+			var ctl ControlMessage
+			if json.Unmarshal(data, &ctl) != nil || ctl.Type != ControlMessageApplierRequest {
+				continue
+			}
+			if atomic.AddInt32(&requestCount, 1) == 1 {
+				// Simulate setContent(markdown): a Y.Doc sync frame that persists to
+				// the op-log while the room is still unfrozen (sub-case A landing).
+				_ = conn.WriteMessage(websocket.BinaryMessage, []byte{yMessageSync, 0xA1})
+				select {
+				case gotFirstRequest <- struct{}{}:
+				default:
+				}
+				<-ackNow // hold the ack until the restore has preempted us
+				ack, _ := json.Marshal(ControlMessage{Type: ControlMessageApplierAck, RequestID: ctl.RequestID})
+				_ = conn.WriteMessage(websocket.TextMessage, ack)
+			}
+		}
+	}()
+
+	for i := 0; i < 200; i++ {
+		if bus.SubscriberCount("item-a") == 1 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	applyDone := make(chan error, 1)
+	go func() { applyDone <- mgr.ApplyExternalContent("item-a", "# external") }()
+
+	<-gotFirstRequest // the applier holds its ack; round-trip is in-flight
+
+	room := roomFor(t, mgr, "item-a")
+	// Start a rolling-back restore. beginRestore preempts the in-flight round-trip
+	// and blocks draining it until we release the ack.
+	restoreDone := make(chan error, 1)
+	go func() {
+		restoreDone <- mgr.ForceRefreshRoom("item-a",
+			func() (int64, int64, error) { return 0, 0, errors.New("commit: rolled back") },
+			nil)
+	}()
+
+	waitRestoreActive(t, room, 2*time.Second) // preempt channel is now closed
+	close(ackNow)                             // ack delivered while still unfrozen
+
+	select {
+	case err := <-applyDone:
+		if err != nil {
+			t.Fatalf("sub-case A: round-trip whose ack landed during preempt must SUCCEED, got %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("sub-case A: ApplyExternalContent did not return")
+	}
+
+	select {
+	case err := <-restoreDone:
+		if err == nil {
+			t.Fatal("restore was supposed to roll back (commit error)")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("ForceRefreshRoom did not return")
+	}
+
+	// No re-apply: the applier was asked exactly once.
+	if n := atomic.LoadInt32(&requestCount); n != 1 {
+		t.Fatalf("sub-case A: applier must be asked exactly once (no re-apply/clobber), got %d requests", n)
+	}
+	// The persisted frame survived the rollback (op-log was never pruned).
+	store.mu.Lock()
+	frameFound := false
+	for _, r := range store.rows {
+		if r.ItemID == "item-a" && len(r.UpdateData) >= 2 && r.UpdateData[1] == 0xA1 {
+			frameFound = true
+		}
+	}
+	store.mu.Unlock()
+	if !frameFound {
+		t.Fatal("sub-case A: the applier's persisted frame must survive a rollback")
+	}
+}
+
+// TestRestorePreemptsInFlightApplier_ReAppliesOnRollback covers sub-case (B): an
+// in-flight applier round-trip whose content did NOT land (no ack, nothing
+// persisted) is preempted by a restore. It must NOT be told it succeeded; after the
+// restore ROLLS BACK it re-elects and re-applies (a SECOND applier_request), then
+// succeeds. Distinguishing assertion vs (A): the applier is asked TWICE.
+func TestRestorePreemptsInFlightApplier_ReAppliesOnRollback(t *testing.T) {
+	// Short grace: no ack arrives, so the preempt handler abandons quickly.
+	defer swapApplierPreemptGrace(swapApplierPreemptGrace(60 * time.Millisecond))
+
+	bus := NewMemoryOpBus()
+	defer bus.Close()
+	store := &fakeOpLog{}
+	mgr := NewRoomManager(store, bus)
+	defer mgr.Close()
+
+	srv := newCollabTestServer(t, mgr)
+	defer srv.Close()
+
+	conn := dialWS(t, srv, "item-a")
+	defer conn.Close()
+
+	var requestCount int32
+	gotFirstRequest := make(chan struct{}, 1)
+	go func() {
+		for {
+			mt, data, err := conn.ReadMessage()
+			if err != nil {
+				return
+			}
+			if mt != websocket.TextMessage {
+				continue
+			}
+			var ctl ControlMessage
+			if json.Unmarshal(data, &ctl) != nil || ctl.Type != ControlMessageApplierRequest {
+				continue
+			}
+			n := atomic.AddInt32(&requestCount, 1)
+			if n == 1 {
+				// First request: do NOT ack, do NOT persist a frame — the content
+				// never lands (sub-case B). Just signal the test and let the grace
+				// expire so the round-trip is preempted + parked.
+				select {
+				case gotFirstRequest <- struct{}{}:
+				default:
+				}
+				continue
+			}
+			// Re-elected after the rollback: honestly ack this time.
+			ack, _ := json.Marshal(ControlMessage{Type: ControlMessageApplierAck, RequestID: ctl.RequestID})
+			_ = conn.WriteMessage(websocket.TextMessage, ack)
+		}
+	}()
+
+	for i := 0; i < 200; i++ {
+		if bus.SubscriberCount("item-a") == 1 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	applyDone := make(chan error, 1)
+	go func() { applyDone <- mgr.ApplyExternalContent("item-a", "# external") }()
+
+	<-gotFirstRequest
+
+	restoreDone := make(chan error, 1)
+	go func() {
+		restoreDone <- mgr.ForceRefreshRoom("item-a",
+			func() (int64, int64, error) { return 0, 0, errors.New("commit: rolled back") },
+			nil)
+	}()
+
+	// The restore rolls back (un-freezes the conn); the parked round-trip then
+	// re-elects the now-live applier and succeeds.
+	select {
+	case err := <-applyDone:
+		if err != nil {
+			t.Fatalf("sub-case B: round-trip must eventually SUCCEED via re-apply, got %v", err)
+		}
+	case <-time.After(6 * time.Second):
+		t.Fatal("sub-case B: ApplyExternalContent did not return")
+	}
+	select {
+	case <-restoreDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("ForceRefreshRoom did not return")
+	}
+
+	if n := atomic.LoadInt32(&requestCount); n != 2 {
+		t.Fatalf("sub-case B: applier must be re-asked (retry after rollback); want 2 requests, got %d", n)
+	}
+}
+
+// TestRestoreCommitForceClosesThenFallsBack covers the COMMIT case: an in-flight
+// applier round-trip preempted by a restore that COMMITS finds, on re-election, that
+// the peer was force-closed (frozen + socket closed). No applier is available, so
+// ApplyExternalContent returns ErrNoApplierAvailable — the caller then direct-writes,
+// and the collab-snapshot restore boundary rejects any stale in-flight flush
+// (existing, unchanged behavior). It must NOT falsely report success against the
+// frozen/closed conn.
+func TestRestoreCommitForceClosesThenFallsBack(t *testing.T) {
+	defer swapApplierPreemptGrace(swapApplierPreemptGrace(60 * time.Millisecond))
+
+	bus := NewMemoryOpBus()
+	defer bus.Close()
+	store := &fakeOpLog{}
+	mgr := NewRoomManager(store, bus)
+	defer mgr.Close()
+
+	srv := newCollabTestServer(t, mgr)
+	defer srv.Close()
+
+	conn := dialWS(t, srv, "item-a")
+	defer conn.Close()
+
+	gotFirstRequest := make(chan struct{}, 1)
+	go func() {
+		for {
+			mt, data, err := conn.ReadMessage()
+			if err != nil {
+				return
+			}
+			if mt != websocket.TextMessage {
+				continue
+			}
+			var ctl ControlMessage
+			if json.Unmarshal(data, &ctl) != nil || ctl.Type != ControlMessageApplierRequest {
+				continue
+			}
+			// Never ack — force the preempt/park path.
+			select {
+			case gotFirstRequest <- struct{}{}:
+			default:
+			}
+		}
+	}()
+
+	for i := 0; i < 200; i++ {
+		if bus.SubscriberCount("item-a") == 1 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	// Seed an op-log row so the commit callback has a MAX to capture.
+	if _, err := store.AppendYjsUpdate("item-a", []byte{yMessageSync, 0x01}, "1"); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	applyDone := make(chan error, 1)
+	go func() { applyDone <- mgr.ApplyExternalContent("item-a", "# external") }()
+
+	<-gotFirstRequest
+
+	restoreDone := make(chan error, 1)
+	go func() {
+		// A CLEAN commit: prune the op-log, return (MAX, seq). ForceRefreshRoom then
+		// force-closes the conns.
+		restoreDone <- mgr.ForceRefreshRoom("item-a", func() (int64, int64, error) {
+			maxID, _, merr := store.MaxOpLogID("item-a")
+			if merr != nil {
+				return 0, 0, merr
+			}
+			if _, perr := store.PruneYjsUpdatesBefore("item-a", distantFuture); perr != nil {
+				return 0, 0, perr
+			}
+			return maxID, 7, nil
+		}, nil)
+	}()
+
+	select {
+	case err := <-applyDone:
+		if !errors.Is(err, ErrNoApplierAvailable) {
+			t.Fatalf("commit case: re-election must find no applier (force-closed) → ErrNoApplierAvailable, got %v", err)
+		}
+	case <-time.After(6 * time.Second):
+		t.Fatal("commit case: ApplyExternalContent did not return")
+	}
+	select {
+	case err := <-restoreDone:
+		if err != nil {
+			t.Fatalf("commit was supposed to succeed, got %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("ForceRefreshRoom did not return")
+	}
+
+	// The commit published the restore fences the direct-write fallback / snapshot
+	// gate rely on.
+	if b, ok := mgr.RestoreBoundary("item-a"); !ok || b <= 0 {
+		t.Fatalf("commit must publish a restore boundary, got (%d,%v)", b, ok)
+	}
+}
+
+// TestApplierWaitsForRestoreInProgress covers the enter-gate direction: a NEW applier
+// round-trip that starts WHILE a restore already holds the room must WAIT for the
+// restore to resolve before electing — it must not race the frozen conn. On rollback
+// it then applies against the unfrozen room and succeeds.
+func TestApplierWaitsForRestoreInProgress(t *testing.T) {
+	bus := NewMemoryOpBus()
+	defer bus.Close()
+	store := &fakeOpLog{}
+	mgr := NewRoomManager(store, bus)
+	defer mgr.Close()
+
+	srv := newCollabTestServer(t, mgr)
+	defer srv.Close()
+
+	conn := dialWS(t, srv, "item-a")
+	defer conn.Close()
+	stop := runApplierEcho(t, conn)
+	defer stop()
+
+	for i := 0; i < 200; i++ {
+		if bus.SubscriberCount("item-a") == 1 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	room := roomFor(t, mgr, "item-a")
+
+	// Hold the restore in its commit until we release it, so it is DEFINITELY in
+	// progress when ApplyExternalContent starts.
+	commitGate := make(chan struct{})
+	restoreDone := make(chan error, 1)
+	go func() {
+		restoreDone <- mgr.ForceRefreshRoom("item-a", func() (int64, int64, error) {
+			<-commitGate
+			return 0, 0, errors.New("commit: rolled back") // rollback → un-freeze
+		}, nil)
+	}()
+
+	waitRestoreActive(t, room, 2*time.Second)
+
+	applyDone := make(chan error, 1)
+	go func() { applyDone <- mgr.ApplyExternalContent("item-a", "# external") }()
+
+	// While the restore is in progress, the round-trip must be BLOCKED in the gate.
+	select {
+	case err := <-applyDone:
+		t.Fatalf("applier round-trip must wait for the in-progress restore, but returned early: %v", err)
+	case <-time.After(150 * time.Millisecond):
+		// good — still blocked
+	}
+
+	// Resolve the restore (rollback). The gate releases; the applier round-trip
+	// re-elects against the unfrozen room and the echo acks it.
+	close(commitGate)
+
+	select {
+	case err := <-applyDone:
+		if err != nil {
+			t.Fatalf("after rollback the waiting round-trip must apply + succeed, got %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("ApplyExternalContent did not return after the restore resolved")
+	}
+	<-restoreDone
+}
+
+// TestBeginRestoreDrainsPromptlyWithNoAppliers is a white-box guard that beginRestore
+// returns immediately when nothing is in flight, and that the gate's counters/preempt
+// channel cycle correctly across begin/resolve.
+func TestBeginRestoreDrainsPromptlyWithNoAppliers(t *testing.T) {
+	bus := NewMemoryOpBus()
+	defer bus.Close()
+	mgr := NewRoomManager(&fakeOpLog{}, bus)
+	defer mgr.Close()
+	room := mgr.getOrCreate("item-a")
+
+	preemptBefore := room.restorePreempt
+
+	done := make(chan struct{})
+	go func() {
+		room.beginRestore()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("beginRestore blocked with no in-flight appliers")
+	}
+
+	// A new applier gate entry now blocks until resolve.
+	entered := make(chan struct{})
+	go func() {
+		_, waited := room.enterApplierGate()
+		if !waited {
+			t.Error("enterApplierGate during an active restore must report waited=true")
+		}
+		room.exitApplierGate()
+		close(entered)
+	}()
+	select {
+	case <-entered:
+		t.Fatal("enterApplierGate must block while a restore is active")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	room.resolveRestore()
+	select {
+	case <-entered:
+	case <-time.After(time.Second):
+		t.Fatal("enterApplierGate did not unblock after resolveRestore")
+	}
+
+	// resolveRestore installed a fresh preempt channel and cleared active state.
+	room.restoreMu.Lock()
+	active := room.restoreActive
+	freshPreempt := room.restorePreempt
+	room.restoreMu.Unlock()
+	if active {
+		t.Fatal("restoreActive must be false after resolveRestore")
+	}
+	if freshPreempt == preemptBefore {
+		t.Fatal("resolveRestore must install a fresh preempt channel")
+	}
+	// The old preempt channel must be closed (it preempted in-flight round-trips).
+	select {
+	case <-preemptBefore:
+	default:
+		t.Fatal("beginRestore must have closed the captured preempt channel")
+	}
+}
+
+// TestConcurrentAppliersAndRestoreNoDeadlock stress-drives several applier round-trips
+// interleaved with restores to shake out lock-order / drain deadlocks under -race.
+func TestConcurrentAppliersAndRestoreNoDeadlock(t *testing.T) {
+	defer swapApplierPreemptGrace(swapApplierPreemptGrace(30 * time.Millisecond))
+	origFirst, origRetry := applierFirstTimeoutVar, applierRetryTimeoutVar
+	swapApplierTimeouts(120*time.Millisecond, 60*time.Millisecond)
+	defer swapApplierTimeouts(origFirst, origRetry)
+
+	bus := NewMemoryOpBus()
+	defer bus.Close()
+	store := &fakeOpLog{}
+	mgr := NewRoomManager(store, bus)
+	defer mgr.Close()
+
+	srv := newCollabTestServer(t, mgr)
+	defer srv.Close()
+
+	conn := dialWS(t, srv, "item-a")
+	defer conn.Close()
+	stop := runApplierEcho(t, conn)
+	defer stop()
+
+	for i := 0; i < 200; i++ {
+		if bus.SubscriberCount("item-a") == 1 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = mgr.ApplyExternalContent("item-a", "# c")
+		}()
+	}
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			// Rolling-back restores so the conn stays alive across the run.
+			_ = mgr.ForceRefreshRoom("item-a",
+				func() (int64, int64, error) { return 0, 0, errors.New("rollback") }, nil)
+		}()
+	}
+
+	fin := make(chan struct{})
+	go func() { wg.Wait(); close(fin) }()
+	select {
+	case <-fin:
+	case <-time.After(20 * time.Second):
+		t.Fatal("deadlock: concurrent appliers + restores did not all return")
+	}
+}

--- a/internal/collab/room.go
+++ b/internal/collab/room.go
@@ -103,6 +103,25 @@ type roomConn struct {
 	// path; on success the conn is force-closed instead. atomic.Bool so the
 	// restore goroutine's write can't race readLoop's read.
 	frozen atomic.Bool
+
+	// lastPersistedOpID + frozenDropSeq are the DURABLE persistence-correlation
+	// signals for the designated-applier round-trip (BUG-2276 residual 2). Both
+	// are mutated ONLY by this conn's readLoop under appendMu:
+	//   - lastPersistedOpID holds the op-log id of the last sync frame this conn
+	//     PERSISTED. It advances only for frames that actually landed
+	//     (AppendYjsUpdate returned id>0 while UNFROZEN), so it is a monotonic
+	//     durable high-water for the conn.
+	//   - frozenDropSeq counts sync frames this conn had DROPPED because it was
+	//     frozen (a version restore froze it mid-apply). It advances only on a
+	//     frozen drop, never on a viewer/canWrite drop.
+	// The applier flow captures both at apply_start (the bracket baseline). A
+	// restore's finalization reads lastPersistedOpID UNDER appendMu (atomic with
+	// setting frozen) to decide, durably, whether the applier's setContent frame
+	// landed BEFORE the freeze; the ack path reads frozenDropSeq to decide whether
+	// it was dropped by a freeze. See restore_coord.go for the soundness argument.
+	// atomic so the finalizing/ack goroutines can read them without appendMu.
+	lastPersistedOpID atomic.Int64
+	frozenDropSeq     atomic.Int64
 }
 
 // writeMessage is a tiny helper that holds writeMu while writing one
@@ -168,37 +187,26 @@ type Room struct {
 	// --- version-restore ↔ designated-applier coordination (BUG-2276 residual 2) ---
 	//
 	// These serialise the designated-applier round-trip (ApplyExternalContent)
-	// against an in-progress version restore (ForceRefreshRoom) so that an applier
-	// ack can NEVER race the restore's transient frozen=true window — the residual-2
-	// clobber. The design is "release-on-resolve": a restore preempts + drains any
-	// in-flight applier round-trip BEFORE it freezes (so none is mid-ack-wait when
-	// the freeze lands), and a new applier round-trip WAITS for an in-progress
-	// restore to resolve (commit OR rollback) before it proceeds. Everything is
-	// released the instant the restore resolves, bounded to the restore-tx duration
-	// (plus a short applier-preempt grace), NEVER to the 30s applier timeout.
+	// against an in-progress version restore (ForceRefreshRoom). A NEW round-trip
+	// WAITS for an in-progress restore to resolve (commit OR rollback) before it
+	// elects (enterApplierGate); an ALREADY in-flight round-trip is FINALIZED by the
+	// restore under appendMu, atomic with the freeze, using the durable
+	// persistence-correlation signal (see restore_coord.go + the roomConn atomics).
+	// So an applier ack can never race the frozen window: the applier's fate is
+	// decided from DURABLE op-log state, not timing.
 	//
-	// restoreMu is a LEAF lock: it is never held while acquiring appendMu / room.mu
-	// / pendingMu, it never acquires them while held, and no socket I/O happens under
-	// it. Lock order stays itemLock → appendMu → room.mu, with restoreMu orthogonal.
+	// restoreMu is a LEAF lock: never held while acquiring appendMu / room.mu /
+	// pendingMu, and never acquires them while held. Lock order stays itemLock →
+	// appendMu → room.mu, with restoreMu orthogonal.
 	restoreMu sync.Mutex
-	// restoreCond is signalled when applierInFlight reaches 0, so a restore draining
-	// in beginRestore wakes as soon as the last in-flight round-trip yields.
-	restoreCond *sync.Cond
 	// restoreActive is true from beginRestore (before the freeze) until resolveRestore
 	// (after commit/rollback/uncertain). While true, new applier round-trips block in
 	// enterApplierGate.
 	restoreActive bool
 	// restoreResolved is closed by resolveRestore when the active restore finishes;
-	// nil when no restore is in progress. Preempted / gate-blocked appliers wait on it.
+	// nil when no restore is in progress. Gate-blocked / finalized-and-parked appliers
+	// wait on it.
 	restoreResolved chan struct{}
-	// restorePreempt is captured by each in-flight applier round-trip at gate entry and
-	// CLOSED by beginRestore to preempt those round-trips' ack-waits. resolveRestore
-	// installs a fresh open channel for the next cycle. Non-nil for the room's lifetime.
-	restorePreempt chan struct{}
-	// applierInFlight counts designated-applier round-trips currently between
-	// enterApplierGate and exitApplierGate (i.e. in their send + ack-wait window).
-	// beginRestore drains this to 0 before freezing.
-	applierInFlight int
 }
 
 // opLogStore is the store surface a Room needs. Pulling it into a
@@ -426,7 +434,16 @@ func (r *Room) readLoop(rc *roomConn) error {
 			// instead of appending it AFTER the prune (which would survive as
 			// a stale post-boundary op). It is a separate flag from canWrite
 			// so the auth revalidation loop can't thaw it mid-restore.
-			if rc.frozen.Load() || !rc.canWrite.Load() {
+			if rc.frozen.Load() {
+				// Frozen by an in-progress version restore: this frame is dropped.
+				// Record the drop (BUG-2276 residual 2) so the applier flow's ack
+				// path can tell, durably, that a frame in this conn's apply bracket
+				// was dropped by the freeze → the external content did NOT land.
+				rc.frozenDropSeq.Add(1)
+				r.appendMu.Unlock()
+				continue
+			}
+			if !rc.canWrite.Load() {
 				r.appendMu.Unlock()
 				continue
 			}
@@ -445,6 +462,14 @@ func (r *Room) readLoop(rc *roomConn) error {
 				// even when persistence is blipping. persistedID == 0
 				// → no cursor frame is emitted by writeLoop for this
 				// event (we'd be advertising a fictional id).
+			}
+			if persistedID > 0 {
+				// Advance the conn's durable high-water (BUG-2276 residual 2). Only
+				// frames that actually landed advance it, so a restore's finalization
+				// can read it (under appendMu) to know this conn's applier frame
+				// persisted BEFORE the freeze. Still under appendMu, so it is ordered
+				// with the finalization's read.
+				rc.lastPersistedOpID.Store(persistedID)
 			}
 			r.bus.Publish(OpEvent{
 				ItemID:   r.itemID,
@@ -558,10 +583,10 @@ func (r *Room) writeLoop(rc *roomConn) {
 	}
 }
 
-// handleControlMessage dispatches a TextMessage frame received from
-// a peer. Today the only valid type is applier_ack (TASK-1257); any
-// other type is dropped silently so a future client extension can
-// add new control types without older servers blowing up.
+// handleControlMessage dispatches a TextMessage frame received from a peer:
+// applier_apply_start / applier_ack (the designated-applier bracket, TASK-1257 +
+// BUG-2276 residual 2). Unknown types are dropped silently so a future client
+// extension can add new control types without older servers blowing up.
 func (r *Room) handleControlMessage(rc *roomConn, data []byte) {
 	var ctl ControlMessage
 	if err := json.Unmarshal(data, &ctl); err != nil {
@@ -571,6 +596,23 @@ func (r *Room) handleControlMessage(rc *roomConn, data []byte) {
 		return
 	}
 	switch ctl.Type {
+	case ControlMessageApplierApplyStart:
+		if ctl.RequestID == "" {
+			return
+		}
+		// A read-only participant can never be a legitimate applier (pickApplier
+		// excludes non-writers), so ignore a bracket-start from one.
+		if !rc.canWrite.Load() {
+			return
+		}
+		// Open the durable persistence bracket for this request (BUG-2276
+		// residual 2). The client sends apply_start IMMEDIATELY before setContent
+		// (synchronously), so capturing this conn's high-water + frozen-drop count
+		// now means the bracket contains EXACTLY the setContent frame — attribution
+		// is airtight against concurrent typing. Processed in readLoop order (before
+		// the setContent frame), even while frozen (control frames are never
+		// frozen-dropped). See restore_coord.go.
+		r.startApplierApply(ctl.RequestID, rc)
 	case ControlMessageApplierAck:
 		if ctl.RequestID == "" {
 			return
@@ -584,41 +626,22 @@ func (r *Room) handleControlMessage(rc *roomConn, data []byte) {
 		// return nil, skip the PATCH handler's direct-write fallback,
 		// and silently lose the external edit.
 		//
-		// A frozen conn (mid version-restore, BUG-2264) is rejected for the
-		// same reason AND to close the pick-then-freeze race: pickApplier may
-		// have elected this conn while it was writable, then ForceRefreshRoom
-		// froze it before its editor produced the sync frames. readLoop drops
-		// those frames while frozen, so accepting the ack would falsely report
-		// success. Rejecting it leaves the request pending until the applier
-		// flow times out and retries (pickApplier now skips frozen), so the
-		// caller's direct-write fallback owns the external edit.
-		//
-		// This is a plain atomic read, NOT taken under appendMu. Synchronising
-		// it with appendMu (to observe the freeze's FINAL state) would couple
-		// the ack path to the restore commit's duration — ForceRefreshRoom holds
-		// appendMu across the whole prune+write tx, so a slow commit (or any slow
-		// AppendYjsUpdate) could stall the ack past ApplyExternalContent's
-		// timeout and spuriously fail even a NORMAL ack (Codex xhigh round 5).
-		//
-		// The frozen branch is now a DEFENCE-IN-DEPTH backstop, not the primary
-		// race guard. BUG-2276 residual 2 closed the ack-races-the-freeze window at
-		// the source: ForceRefreshRoom preempts + drains every in-flight applier
-		// round-trip (beginRestore) BEFORE it sets frozen=true, and new round-trips
-		// wait out an in-progress restore (enterApplierGate), so by the time a conn
-		// is frozen there is no pending applier ack left to drop. This read remains
-		// as a cheap guard for a conn that was frozen after being elected but whose
-		// round-trip had already yielded — dropping such a stray ack is correct
-		// (its request_id was cancelled, so routeApplierAck would no-op anyway).
-		// See restore_coord.go for the release-on-resolve mechanism.
-		if !rc.canWrite.Load() || rc.frozen.Load() {
-			slog.Warn("collab: applier_ack from read-only or frozen conn; ignoring",
+		// A FROZEN conn is NO LONGER dropped here (BUG-2276 residual 2). The old
+		// design dropped a frozen conn's ack because it couldn't tell whether the
+		// applier's frames had persisted. Now the durable bracket answers that: the
+		// ack path resolves the round-trip to SUCCESS only if no frame was
+		// frozen-dropped in its apply bracket (frozenDropSeq unchanged), and to
+		// RETRY otherwise — so a frozen conn whose setContent was dropped correctly
+		// resolves to retry, and one whose setContent already persisted before the
+		// freeze correctly resolves to success. No timing, no phantom success.
+		if !rc.canWrite.Load() {
+			slog.Warn("collab: applier_ack from read-only conn; ignoring",
 				"item_id", r.itemID,
 				"client_id", rc.id,
-				"frozen", rc.frozen.Load(),
 			)
 			return
 		}
-		r.routeApplierAck(ctl.RequestID, rc.conn)
+		r.resolveApplierAck(ctl.RequestID, rc)
 	default:
 		// Unknown control type — drop.
 	}

--- a/internal/collab/room.go
+++ b/internal/collab/room.go
@@ -164,6 +164,41 @@ type Room struct {
 	// from spoofing acks for someone else's request.
 	pendingMu   sync.Mutex
 	pendingAcks map[string]*pendingApplierAck
+
+	// --- version-restore ↔ designated-applier coordination (BUG-2276 residual 2) ---
+	//
+	// These serialise the designated-applier round-trip (ApplyExternalContent)
+	// against an in-progress version restore (ForceRefreshRoom) so that an applier
+	// ack can NEVER race the restore's transient frozen=true window — the residual-2
+	// clobber. The design is "release-on-resolve": a restore preempts + drains any
+	// in-flight applier round-trip BEFORE it freezes (so none is mid-ack-wait when
+	// the freeze lands), and a new applier round-trip WAITS for an in-progress
+	// restore to resolve (commit OR rollback) before it proceeds. Everything is
+	// released the instant the restore resolves, bounded to the restore-tx duration
+	// (plus a short applier-preempt grace), NEVER to the 30s applier timeout.
+	//
+	// restoreMu is a LEAF lock: it is never held while acquiring appendMu / room.mu
+	// / pendingMu, it never acquires them while held, and no socket I/O happens under
+	// it. Lock order stays itemLock → appendMu → room.mu, with restoreMu orthogonal.
+	restoreMu sync.Mutex
+	// restoreCond is signalled when applierInFlight reaches 0, so a restore draining
+	// in beginRestore wakes as soon as the last in-flight round-trip yields.
+	restoreCond *sync.Cond
+	// restoreActive is true from beginRestore (before the freeze) until resolveRestore
+	// (after commit/rollback/uncertain). While true, new applier round-trips block in
+	// enterApplierGate.
+	restoreActive bool
+	// restoreResolved is closed by resolveRestore when the active restore finishes;
+	// nil when no restore is in progress. Preempted / gate-blocked appliers wait on it.
+	restoreResolved chan struct{}
+	// restorePreempt is captured by each in-flight applier round-trip at gate entry and
+	// CLOSED by beginRestore to preempt those round-trips' ack-waits. resolveRestore
+	// installs a fresh open channel for the next cycle. Non-nil for the room's lifetime.
+	restorePreempt chan struct{}
+	// applierInFlight counts designated-applier round-trips currently between
+	// enterApplierGate and exitApplierGate (i.e. in their send + ack-wait window).
+	// beginRestore drains this to 0 before freezing.
+	applierInFlight int
 }
 
 // opLogStore is the store surface a Room needs. Pulling it into a
@@ -564,16 +599,17 @@ func (r *Room) handleControlMessage(rc *roomConn, data []byte) {
 		// appendMu across the whole prune+write tx, so a slow commit (or any slow
 		// AppendYjsUpdate) could stall the ack past ApplyExternalContent's
 		// timeout and spuriously fail even a NORMAL ack (Codex xhigh round 5).
-		// The un-synchronised read leaves one narrow residual (BUG-2276): if a
-		// restore ROLLS BACK while an in-flight applier ack races the transient
-		// frozen=true window, the ack is dropped even though the rolled-back
-		// conn's frames persisted, so the applier flow retries/falls back
-		// (re-applying its own markdown — a possible clobber of peer edits made
-		// in the retry window). That is a quadruple-narrow edge (concurrent
-		// external PATCH + exact ack timing + restore ROLLBACK, i.e. a DB commit
-		// error + peer edits in the retry window); fully closing it needs the
-		// applier flow serialised with the restore under itemLock (a larger
-		// rework with its own 30s-restore-stall cost). Tracked in BUG-2276.
+		//
+		// The frozen branch is now a DEFENCE-IN-DEPTH backstop, not the primary
+		// race guard. BUG-2276 residual 2 closed the ack-races-the-freeze window at
+		// the source: ForceRefreshRoom preempts + drains every in-flight applier
+		// round-trip (beginRestore) BEFORE it sets frozen=true, and new round-trips
+		// wait out an in-progress restore (enterApplierGate), so by the time a conn
+		// is frozen there is no pending applier ack left to drop. This read remains
+		// as a cheap guard for a conn that was frozen after being elected but whose
+		// round-trip had already yielded — dropping such a stray ack is correct
+		// (its request_id was cancelled, so routeApplierAck would no-op anyway).
+		// See restore_coord.go for the release-on-resolve mechanism.
 		if !rc.canWrite.Load() || rc.frozen.Load() {
 			slog.Warn("collab: applier_ack from read-only or frozen conn; ignoring",
 				"item_id", r.itemID,

--- a/internal/collab/room.go
+++ b/internal/collab/room.go
@@ -122,6 +122,14 @@ type roomConn struct {
 	// atomic so the finalizing/ack goroutines can read them without appendMu.
 	lastPersistedOpID atomic.Int64
 	frozenDropSeq     atomic.Int64
+
+	// bracketCapable reports whether this connection's client sends the
+	// applier_apply_start bracket (BUG-2276 residual 2). Announced at Join via
+	// `?applier_bracket=1`. pickApplier prefers capable conns; a round-trip elected
+	// on a NON-capable (legacy) conn that a restore can't confirm resolves to an
+	// AMBIGUOUS outcome (fail-safe: the external write is retried, never re-applied /
+	// clobbered). Set once at Join; read on the election + finalization paths.
+	bracketCapable atomic.Bool
 }
 
 // writeMessage is a tiny helper that holds writeMu while writing one
@@ -207,6 +215,14 @@ type Room struct {
 	// nil when no restore is in progress. Gate-blocked / finalized-and-parked appliers
 	// wait on it.
 	restoreResolved chan struct{}
+	// admittedUnregistered counts round-trips that passed enterApplierGate but have
+	// NOT yet finished registering their pending-ack entry (the enter→register gap).
+	// beginRestore drains this to 0 BEFORE the freeze scan so no admitted round-trip
+	// is missed by freezeAndFinalizePending (BUG-2276 residual 2, P1). The gap is
+	// mutex-only (pickApplier + registerPendingAck, no I/O), so the drain is
+	// microseconds — never the applier round-trip. restoreCond signals it reaching 0.
+	restoreCond          *sync.Cond
+	admittedUnregistered int
 }
 
 // opLogStore is the store surface a Room needs. Pulling it into a

--- a/internal/server/handlers_collab.go
+++ b/internal/server/handlers_collab.go
@@ -172,6 +172,13 @@ func (s *Server) handleCollab(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// `?applier_bracket=1` announces that this client sends the applier_apply_start
+	// bracket (BUG-2276 residual 2). Only bracket-capable conns can have their applier
+	// outcome durably confirmed against a concurrent version restore; the manager
+	// prefers them when electing and fails a legacy round-trip SAFE (retryable) rather
+	// than risk a clobber. Absent/other value = legacy (false).
+	bracketCapable := r.URL.Query().Get("applier_bracket") == "1"
+
 	conn, err := collabUpgrader.Upgrade(w, r, nil)
 	if err != nil {
 		// Upgrade itself emits the right HTTP status (e.g. 400 on
@@ -246,7 +253,7 @@ func (s *Server) handleCollab(w http.ResponseWriter, r *http.Request) {
 	// (closes `registered`) fires once the conn is in the room, so
 	// revalidation only starts after SetConnWritable can find it.
 	onRegistered := func() { close(registered) }
-	if err := s.collab.Join(itemID, conn, sinceID, contentSeq, access.canWrite, onRegistered); err != nil {
+	if err := s.collab.Join(itemID, conn, sinceID, contentSeq, access.canWrite, bracketCapable, onRegistered); err != nil {
 		// ErrForceRefreshSent is the protocol's normal close-after-
 		// notify path — the JSON frame is already on the wire and
 		// the client knows what to do. Don't warn.

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
+	"github.com/PerpetualSoftware/pad/internal/collab"
 	"github.com/PerpetualSoftware/pad/internal/events"
 	"github.com/PerpetualSoftware/pad/internal/items"
 	"github.com/PerpetualSoftware/pad/internal/models"
@@ -1450,6 +1451,15 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 			// directWrite callback is also final — a retry would just lose
 			// the same race again.
 			writeUpdateConflictError(w, itemRefOrSlug(*item), conflict)
+			return
+		} else if errors.Is(err, collab.ErrApplierAmbiguous) {
+			// BUG-2276 residual 2 (P1, mixed-deploy window): a legacy (non-bracket-
+			// capable) applier was caught by a concurrent version restore and its
+			// outcome can't be confirmed. FAIL-SAFE — do NOT fall through to a direct
+			// write (which could clobber the live doc / lose the write); return a
+			// retryable 409 so the external caller retries once clients converge.
+			writeError(w, http.StatusConflict, "applier_ambiguous",
+				"A concurrent version restore made this edit's outcome ambiguous; please retry.")
 			return
 		}
 		// Any other error path (e.g. ErrAllAppliersTimedOut, retry

--- a/web/src/lib/collab/wsProvider.svelte.ts
+++ b/web/src/lib/collab/wsProvider.svelte.ts
@@ -1028,6 +1028,32 @@ export class CollabProvider {
 					return;
 				}
 
+				// Durable persistence bracket (BUG-2276 residual 2). Send
+				// applier_apply_start on the SAME socket IMMEDIATELY before invoking
+				// the handler, whose onApplierRequest applies setContent
+				// SYNCHRONOUSLY (no await before the mutation) so the setContent
+				// Y.Doc update frame is emitted right after this control frame with
+				// no keystroke frame interleaving. The server uses the (apply_start →
+				// setContent frame → applier_ack) bracket to decide, from DURABLE
+				// op-log state, whether the applier's edit actually persisted vs. was
+				// dropped by a concurrent version-restore freeze — attribution that a
+				// bare op-log-advance watermark can't make (concurrent typing). The
+				// handler MUST keep setContent synchronous for the bracket to stay
+				// tight; a future await before setContent would let a keystroke frame
+				// slip into the bracket.
+				if (
+					sourceWs &&
+					sourceWs === this.ws &&
+					sourceWs.readyState === this.WebSocketImpl.OPEN
+				) {
+					sourceWs.send(
+						JSON.stringify({
+							type: 'applier_apply_start',
+							request_id: msg.request_id,
+						}),
+					);
+				}
+
 				let applied = false;
 				try {
 					applied = await this.onApplierRequest(

--- a/web/src/lib/collab/wsProvider.svelte.ts
+++ b/web/src/lib/collab/wsProvider.svelte.ts
@@ -75,12 +75,21 @@ const SYNC_GRACE_MS = 1_000;
  * mutation is owned by the caller — only the handler can refuse to
  * apply once the deadline has passed. Returning `false` after a
  * stale check keeps the late-apply hazard closed.
+ *
+ * The return type is SYNCHRONOUS (`boolean`, not `Promise<boolean>`) BY
+ * DESIGN (BUG-2276 residual 2, P2): the provider sends `applier_apply_start`
+ * immediately before invoking this handler and `applier_ack` immediately
+ * after, forming the server's durable persistence bracket. The handler's
+ * setContent MUST emit its Y.Doc frame synchronously inside that bracket so
+ * no concurrent keystroke frame can slip in and be misattributed. Allowing a
+ * Promise would let a handler `await` between apply_start and setContent,
+ * re-opening that hole — so the type forbids it structurally.
  */
 export type ApplierRequestHandler = (
 	markdown: string,
 	requestID: string,
 	expiresAtMillis: number,
-) => boolean | Promise<boolean>;
+) => boolean;
 
 /**
  * Callback fired when the server sends a `force_refresh` control
@@ -862,7 +871,7 @@ export class CollabProvider {
 		}
 	};
 
-	private async handleControlMessage(raw: string, sourceWs: WebSocket | null): Promise<void> {
+	private handleControlMessage(raw: string, sourceWs: WebSocket | null): void {
 		let msg: {
 			type?: string;
 			request_id?: string;
@@ -1028,39 +1037,45 @@ export class CollabProvider {
 					return;
 				}
 
-				// Durable persistence bracket (BUG-2276 residual 2). Send
-				// applier_apply_start on the SAME socket IMMEDIATELY before invoking
-				// the handler, whose onApplierRequest applies setContent
-				// SYNCHRONOUSLY (no await before the mutation) so the setContent
-				// Y.Doc update frame is emitted right after this control frame with
-				// no keystroke frame interleaving. The server uses the (apply_start →
-				// setContent frame → applier_ack) bracket to decide, from DURABLE
-				// op-log state, whether the applier's edit actually persisted vs. was
-				// dropped by a concurrent version-restore freeze — attribution that a
-				// bare op-log-advance watermark can't make (concurrent typing). The
-				// handler MUST keep setContent synchronous for the bracket to stay
-				// tight; a future await before setContent would let a keystroke frame
-				// slip into the bracket.
-				if (
-					sourceWs &&
+				// Durable persistence bracket (BUG-2276 residual 2). apply_start,
+				// the SYNCHRONOUS setContent handler, and applier_ack are emitted
+				// back-to-back on the SAME socket with NO await between them, so the
+				// setContent Y.Doc frame is the only frame inside the (apply_start →
+				// frame → applier_ack) bracket. That lets the server decide, from
+				// DURABLE op-log state, whether the applier's edit persisted vs. was
+				// dropped by a concurrent version-restore freeze — attribution a bare
+				// op-log-advance watermark can't make (concurrent typing). The handler
+				// is SYNCHRONOUS by type (P2): a Promise return could `await` between
+				// apply_start and setContent and let a keystroke frame slip into the
+				// bracket, so the type forbids it structurally.
+				//
+				// The bracket + ack MUST ride the socket that delivered the request —
+				// the server keys pending state by conn, so a post-force-reconnect new
+				// socket is silently ignored (server falls back after its timeout). If
+				// the source socket is gone we apply NOTHING (no orphan bracket) and let
+				// the server's fallback own the write.
+				const applierSocketOK =
+					!!sourceWs &&
 					sourceWs === this.ws &&
-					sourceWs.readyState === this.WebSocketImpl.OPEN
-				) {
-					sourceWs.send(
-						JSON.stringify({
-							type: 'applier_apply_start',
-							request_id: msg.request_id,
-						}),
+					sourceWs.readyState === this.WebSocketImpl.OPEN;
+				if (!applierSocketOK) {
+					console.warn(
+						'collab: applier source socket gone, skipping apply',
+						msg.request_id,
 					);
+					return;
 				}
+
+				sourceWs.send(
+					JSON.stringify({
+						type: 'applier_apply_start',
+						request_id: msg.request_id,
+					}),
+				);
 
 				let applied = false;
 				try {
-					applied = await this.onApplierRequest(
-						msg.markdown,
-						msg.request_id,
-						expiresAt,
-					);
+					applied = this.onApplierRequest(msg.markdown, msg.request_id, expiresAt);
 				} catch (err) {
 					console.warn('collab: applier handler threw, treating as not-applied', err);
 					applied = false;
@@ -1068,35 +1083,18 @@ export class CollabProvider {
 
 				if (!applied) return;
 				if (expiresAt > 0 && Date.now() > expiresAt) {
-					// Awaited handler crossed the deadline. The server
-					// has likely retried or fallen back; don't ack a
-					// late apply.
+					// Handler crossed the deadline. The server has likely retried or
+					// fallen back; don't ack a late apply.
 					console.warn('collab: applier_request acked too late, suppressing', msg.request_id);
 					return;
 				}
 
-				const ack = JSON.stringify({
-					type: 'applier_ack',
-					request_id: msg.request_id,
-				});
-				// MUST send the ack on the same socket that delivered
-				// the request — the server keys pending acks by conn,
-				// so an ack sent on a post-force-reconnect new socket
-				// is silently ignored and the external write waits
-				// for the applier-timeout fallback (TASK-1257). Per
-				// Codex review round 2 [P2] of TASK-1265.
-				if (
-					sourceWs &&
-					sourceWs === this.ws &&
-					sourceWs.readyState === this.WebSocketImpl.OPEN
-				) {
-					sourceWs.send(ack);
-				} else {
-					console.warn(
-						'collab: applier source socket gone, suppressing late ack',
-						msg.request_id,
-					);
-				}
+				sourceWs.send(
+					JSON.stringify({
+						type: 'applier_ack',
+						request_id: msg.request_id,
+					}),
+				);
 				return;
 			}
 			default:
@@ -1191,6 +1189,13 @@ export class CollabProvider {
 		const params: string[] = [];
 		if (this.lastOpLogID > 0) params.push(`since=${this.lastOpLogID}`);
 		if (this.contentSeq > 0) params.push(`content_seq=${this.contentSeq}`);
+		// Announce durable-applier-bracket capability (BUG-2276 residual 2) only when
+		// this tab can actually be a designated applier (an onApplierRequest handler is
+		// installed). The server prefers electing bracket-capable conns and can confirm
+		// their applier outcome durably against a concurrent version restore; a legacy
+		// (non-announcing) conn is fail-safed instead of risking a clobber. Gating on
+		// the handler keeps non-applier/read-only tabs on the bare base URL.
+		if (this.onApplierRequest) params.push('applier_bracket=1');
 		if (params.length === 0) return this.url;
 		const sep = this.url.includes('?') ? '&' : '?';
 		return `${this.url}${sep}${params.join('&')}`;

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -1912,7 +1912,7 @@
 			// applier-timeout fallback (~30s) and then writing
 			// items.content directly. The full ExpiresAtMillis-driven
 			// late-apply guard is TASK-1262's concern.
-			onApplierRequest: async (markdown, _requestID, expiresAtMillis) => {
+			onApplierRequest: (markdown, _requestID, expiresAtMillis) => {
 				// Reject unless we can apply into the LIVE editor for THIS
 				// provider's item. The no-{#key} pane switch can leave
 				// editorInstance pointing at a destroyed editor, or this


### PR DESCRIPTION
## The bug (BUG-2276 residual 2)

A version restore (`ForceRefreshRoom`) freezes every connected conn for its prune+reseed transaction. The designated-applier round-trip (`ApplyExternalContent`) routes an external content update through a connected tab, which applies the markdown to its Y.Doc (persisting sync frames) then sends an `applier_ack`. If the restore's transient `frozen=true` window landed **between** the applier's frames and its ack, `readLoop` dropped the ack. On a restore **ROLLBACK** that loss was ambiguous:

- **(A)** frames persisted BEFORE the freeze → the external content DID land → should be SUCCESS, no retry.
- **(B)** frames dropped DURING the freeze → content did NOT land → must retry.

The dropped ack can't distinguish (A) from (B), so the applier flow retried/fell back and could **double-apply markdown, clobbering peer edits** made in the retry window.

## The fix — release-on-resolve (prevent the race)

Rather than disambiguate after the fact, an applier round-trip and a restore's freeze window are made **mutually exclusive per item** via a per-room restore gate (`restore_coord.go`, guarded by a leaf `restoreMu`):

- **`ForceRefreshRoom.beginRestore()`** preempts + drains every in-flight applier round-trip **before** it sets `frozen=true`, so there is **no pending applier ack to drop** once a conn is frozen — the residual-2 race is gone at the source. A preempted round-trip gets a bounded grace during which — the room still **UNFROZEN** — a genuinely delivered ack still resolves it as **SUCCESS** (sub-case A); otherwise it parks (sub-case B).
- A new round-trip **waits out an in-progress restore** (`enterApplierGate`), then re-elects from scratch: on **ROLLBACK** against the unfrozen room (applies fresh, no ambiguity); on **COMMIT** against the force-closed room (no applier → `ErrNoApplierAvailable` → direct-write fallback, unchanged).

### Why the hard constraints hold
- **Normal acks unaffected** — the no-restore path pays only one leaf-mutex bump at gate entry/exit; the ack-wait `select` watches an open channel that never fires, so latency/behavior are byte-for-byte unchanged. Verified by `TestApplierGateFastPathAddsNoLatency`.
- **Bounded** — every wait is bounded to the restore-tx duration plus the short applier-preempt grace, **never the 30s applier timeout**.
- **(A) and (B) both correct** — success is reported ONLY on a genuinely delivered ack; a dropped-during-freeze round-trip re-applies and is never told it succeeded.
- **Commit case preserved** — round-3 frozen-ack check + restore boundary still handle it; the force-closed room routes the fallback.
- **Lock discipline** — `restoreMu` is a strict leaf (never held while acquiring `appendMu`/`room.mu`/`pendingMu`, no socket I/O under it); lock order `itemLock → appendMu → room.mu` is unchanged.

## Tests (drive real rooms/conns)
- Sub-case **A**: ack delivered during preempt grace → SUCCESS, applier asked exactly once (no clobber), persisted frame survives the rollback.
- Sub-case **B**: no ack → preempted → re-applies on rollback (asked twice), no false success.
- **Commit**: preempted → force-closed → re-election finds no applier → `ErrNoApplierAvailable` (fallback); boundary published.
- New round-trip **waits out** an in-progress restore, then applies on rollback.
- Fast-path latency, coordinator drain, and concurrent applier+restore no-deadlock (`-race`).

## Gates
`go build`; `go test ./...` (SQLite) green; `go test ./internal/collab/... -race` green; `golangci-lint run ./...` → 0 issues; `make test-pg` green.

https://claude.ai/code/session_01EZ6yr6pAUFb1uffan912ra