### PR TITLE
fix(e2e): de-flake pane j/k re-target test (BUG-2279)

### DIFF
--- a/web/e2e/pane-controller.spec.ts
+++ b/web/e2e/pane-controller.spec.ts
@@ -170,7 +170,13 @@ test.describe('pane controller: depth/ownership state machine (PLAN-2154 / TASK-
 		await page.goto(docsUrl(fixture));
 
 		const prePaneUrl = page.url();
-		const row = page.locator('.item-card', { hasText: 'Ctrl regress alpha' }).first();
+		// Open the FIRST rendered row (not a NAMED one) so the `j` (down) below
+		// always has a row beneath it to re-target to. The two seeds share a
+		// same-second `created_at`, so their list order is a non-deterministic
+		// tie-break (BUG-2270); a named row could land LAST, where `j` clamps at
+		// the final index and the pane-follow correctly finds nothing new to
+		// target — a test-ordering artifact, not a follow-logic bug (BUG-2279).
+		const row = page.locator('.item-card').first();
 		await expect(row).toBeVisible();
 		await row.click();
 
@@ -181,8 +187,9 @@ test.describe('pane controller: depth/ownership state machine (PLAN-2154 / TASK-
 		// First-open MINTS ownership at depth 0.
 		await expect.poll(() => paneState(page)).toEqual({ paneDepth: 0, paneOwned: true });
 
-		// j moves the list cursor; the pane FOLLOWS (re-target replace) — still
-		// depth 0, still owned, and NO new history entry (the PLAN-2105 fix).
+		// j moves the list cursor to the row below; the pane FOLLOWS (re-target
+		// replace) — still depth 0, still owned, and NO new history entry (the
+		// PLAN-2105 fix).
 		const lenAfterOpen = await historyLength(page);
 		await page.keyboard.press('j');
 		await expect.poll(() => openItemParam(page)).not.toBe(refA);


### PR DESCRIPTION
## Root cause (via instrumentation)

`pane-controller.spec.ts:160` flaked ~50% at line 188 (`openItemParam(page)).not.toBe(refA)`). Instrumented logging showed the real mechanism: the test opened a **named** seeded row and pressed `j` (down), but the two seeds share a same-second `created_at`, so their list order is a **non-deterministic tie-break** (cf. BUG-2270). When the named row landed **last**, `j` clamps at `Math.min(idx+1, len-1)` and the cursor doesn't move — the pane-follow then correctly sees the focused row is already the paned item and skips. `openItemParam` stays put → assertion fails.

**Not a product bug** — the follow logic is correct (I first hypothesized a follow-logic race and a `focusPaneRegion` starve; instrumentation ruled both out). The fix is **test-only**.

## Fix

Open the **first rendered row** instead of a named one, so `j` (down) always has a row beneath it to re-target to, independent of the seed tie-break order.

## Verification

- `:160` now **10/10 stable** in isolation (was ~50-60% flaky-then-pass).
- Full `pane-controller.spec.ts`: **21 passed**.
- Codex review: **CLEAN**.

Closes BUG-2279.

https://claude.ai/code/session_01EZ6yr6pAUFb1uffan912ra