### PR TITLE
fix(web): make itemMatchesRef workspace-aware in ItemDetail (IDEA-2135)

### DIFF
--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -178,6 +178,16 @@
 		(onNavigateAway ?? ((u: string) => goto(u, { replaceState: true })))(url);
 
 	let item = $state<Item | null>(null);
+	// The wsSlug the currently-held `item` was actually loaded under. Stamped
+	// lock-stepped with every `item` adoption in loadData, so it can never
+	// disagree with `item`'s workspace. Folded into `itemMatchesRef` below so the
+	// switch boundary is workspace-aware: on a REUSED (no-{#key}) ItemDetail
+	// instance, a cross-workspace nav that preserves `?item=<ref>` for a ref both
+	// workspaces own (ws1?item=TASK-1 → ws2?item=TASK-1) would otherwise keep the
+	// predicate true across the switch — leaving `collabKey` pinned to ws1's
+	// item.id and rawMode carried over until ws2's load resolves (IDEA-2135).
+	// In single-workspace usage this always equals `wsSlug` → byte-identical.
+	let loadedItemWsSlug = $state('');
 	let collection = $state<Collection | null>(null);
 	let loading = $state(true);
 	let error = $state('');
@@ -376,8 +386,15 @@
 	// stale provider for the previous item tears down the instant `ref`
 	// changes — before the new fetch resolves — instead of lingering with a
 	// destroyed editor (PLAN-2105 / TASK-2112 switch-safety; Codex).
+	// The workspace arm (`loadedItemWsSlug === wsSlug`) makes the switch boundary
+	// workspace-aware (IDEA-2135): a reused instance navigating ws1→ws2 with the
+	// same `?item=<ref>`, where both workspaces own that ref, flips the predicate
+	// false the instant `wsSlug` changes — before ws2's load resolves — so
+	// `collabKey`/`scrollReady`/`resolvedIdentity` and the rawMode-reset gate all
+	// tighten together instead of lingering on the previous workspace's item.
 	let itemMatchesRef = $derived(
 		item !== null &&
+			loadedItemWsSlug === wsSlug &&
 			(item.id === itemSlug ||
 				item.slug === itemSlug ||
 				`${item.collection_prefix}-${item.item_number}` === itemSlug),
@@ -1404,7 +1421,15 @@
 			// Gate the ITEM snapshot on itemGen too: a newer item write (e.g. the
 			// migration refetch) that bumped itemGen but not loadGeneration must
 			// not be reverted by this in-flight load (round 9).
-			if (myItemGen === itemGen) item = withInflightTags(itemData);
+			// Stamp the workspace this item was loaded under in lockstep with the
+			// item adoption (IDEA-2135) — same gate, so `loadedItemWsSlug` and
+			// `item` can never disagree about which workspace `item` belongs to.
+			// `reqWsSlug` (captured at load start) is authoritative here: `myGen`
+			// was already checked above, so no newer load has moved `wsSlug` on.
+			if (myItemGen === itemGen) {
+				item = withInflightTags(itemData);
+				loadedItemWsSlug = reqWsSlug;
+			}
 			// Cross-collection `?item=` safety (PLAN-2105 / TASK-2112). The
 			// Promise.all above optimistically fetched the collection by the
 			// route's `collSlug` — correct for the common (row-click) case,


### PR DESCRIPTION
## What

Makes the no-`{#key}` switch-boundary predicate `itemMatchesRef` in `web/src/lib/components/items/ItemDetail.svelte` workspace-aware.

## Why (IDEA-2135)

`itemMatchesRef` compared only ref/slug/id identity, never workspace. On a **reused** embedded `ItemDetail` instance, navigating `ws1?item=TASK-1 → ws2?item=TASK-1` — where both workspaces own a `TASK-1` — kept the predicate `true` across the switch (`wsSlug` changed but `itemSlug` stayed `TASK-1` and the `{#if openItemRef}` never unmounts the pane). Consequences until `ws2`'s `loadData()` resolved:

1. **Stale `collabKey`** — stayed pinned to `ws1`'s `item.id`, mounting a collab provider mis-keyed to the old item.
2. **rawMode carry-over** — the TASK-2124 switch-gated reset keyed off `itemMatchesRef`, so raw markdown mode carried across the workspace switch.

`scrollReady`, `resolvedIdentity`, `collabKey`, and the rawMode-reset gate all derive from this one predicate, so the correct fix is at the predicate level — they then tighten together and stay consistent (the fix the idea asked for).

## How

- Stamp `loadedItemWsSlug = reqWsSlug` at the item-adoption point in `loadData`, **inside the existing `myItemGen === itemGen` gate** so it's lock-stepped with `item` and the two can never disagree about which workspace `item` belongs to.
- Fold `loadedItemWsSlug === wsSlug` into the `itemMatchesRef` `$derived`.

The `Item` type carries `workspace_id` (UUID) but the component only has `wsSlug` (slug); stamping the load-time slug avoids coupling to a slug→id resolver. Every other `item =` path (SSE refresh, archive, restore, migration refetch, sync, saves, version restore) operates on the *same* item in the *current* workspace, so `loadedItemWsSlug` can't go stale relative to `item`.

## Blast radius

In all single-workspace usage `loadedItemWsSlug === wsSlug` is always true → **byte-identical behavior**. The arm only flips `false` in the rare cross-workspace-reuse window (correctly). Barely reachable by design (no natural UI affordance preserves `?item=` across a workspace switch); filed as hardening.

## Gates

- `cd web && npm run check` — svelte-check **0 errors**.
- Codex CLI review (`-s read-only`, diff `main..HEAD`) — **CLEAN**; specifically probed whether `loadedItemWsSlug` can go stale and wrongly falsify the predicate in single-workspace usage (it can't).

Frontend-only; no `internal/store`/dialect, MCP catalog, or collab-schema surface touched.

Closes IDEA-2135. TASK-2283.

https://claude.ai/code/session_01EZ6yr6pAUFb1uffan912ra