### PR TITLE
fix(web): stop paneOverlay ref-count effect self-looping on mobile (BUG-2284)

### DIFF
--- a/web/e2e/pane-controller.spec.ts
+++ b/web/e2e/pane-controller.spec.ts
@@ -795,7 +795,12 @@ test.describe('pane controller: depth/ownership state machine (PLAN-2154 / TASK-
 		// itself on open — so `document.activeElement` stays on the trigger
 		// button back inside `.item-pane` while the sheet is showing.
 		await pane.locator('button.trigger-btn[title="Quick actions"]').click();
-		const sheet = page.locator('[role="dialog"]', { hasText: 'Quick actions' });
+		// Target the sheet by ACCESSIBLE NAME, not `[role="dialog"]` + text: on the
+		// mobile overlay the pane itself is now `role="dialog"` (TASK-2131) and it
+		// CONTAINS the sheet, so a text filter matches both the pane and the sheet
+		// (strict-mode violation). The pane's accessible name is "Item detail"; the
+		// BottomSheet's is "Quick actions" (its `aria-labelledby` heading) — unique.
+		const sheet = page.getByRole('dialog', { name: 'Quick actions' });
 		await expect(sheet).toBeVisible();
 
 		// ESC must be owned entirely by the sheet (it has its own window
@@ -1175,6 +1180,10 @@ test.describe('pane controller: depth/ownership state machine (PLAN-2154 / TASK-
 		await expect.poll(() => page.url()).not.toContain(`item=${a.slug}`);
 	});
 
+	// Also the regression guard for BUG-2284: the mobile overlay's `paneOverlay`
+	// ref-count effect must not self-loop (`effect_update_depth_exceeded`) and
+	// strand `paneMintForRoute` — if it does, the pane renders EMPTY and the Back
+	// chevron below never mounts.
 	test('Back chevron: works from the mobile full-screen overlay too', async ({
 		page,
 		fixture,

--- a/web/src/lib/stores/paneOverlay.svelte.test.ts
+++ b/web/src/lib/stores/paneOverlay.svelte.test.ts
@@ -10,6 +10,15 @@ beforeEach(() => {
 	vi.resetModules();
 });
 
+// NOTE (BUG-2284): the mutators `untrack` their `overlayCount` read so a
+// caller writing them from inside an `$effect` (PaneHost is the only writer)
+// can't take a reactive dependency on the signal it writes — which would loop
+// (`effect_update_depth_exceeded`) and abort the flush. That runaway only
+// manifests under the real browser scheduler, not jsdom/vitest, so the loop
+// regression is guarded by the E2E `pane-controller.spec.ts` mobile-overlay
+// tests. The ref-count semantics below still lock the mutators' behavior so the
+// untrack change can't silently break counting.
+
 describe('paneOverlay', () => {
 	it('starts inactive', async () => {
 		const { paneOverlay } = await import('./paneOverlay.svelte');

--- a/web/src/lib/stores/paneOverlay.svelte.ts
+++ b/web/src/lib/stores/paneOverlay.svelte.ts
@@ -17,8 +17,19 @@
 // writer (one `enter`/`leave` per active overlay via an `$effect`); the layout
 // is the only reader. This one-way split satisfies CONVE-1688 — a store must
 // never read state it also writes.
+import { untrack } from 'svelte';
+
 let overlayCount = $state(0);
 
+// The mutators are called from a PaneHost `$effect` (the only writer). A naive
+// `overlayCount += 1` READS `overlayCount` inside that tracked scope, so the
+// effect would take a reactive dependency on the very signal it writes —
+// enter() dirties the effect, which re-runs, enter()s again, ad infinitum:
+// `effect_update_depth_exceeded`, which aborts the flush and strands the rest
+// of the subtree's reactivity (BUG-2284 — the mobile pane rendered empty
+// because `paneMintForRoute` stopped recomputing). `untrack` the read so a
+// write never establishes that self-dependency; the write still notifies the
+// layout reader normally.
 export const paneOverlay = {
 	/** True while ≥1 mobile detail-pane overlay is active. Read by the workspace layout. */
 	get mobileOverlayActive() {
@@ -26,10 +37,10 @@ export const paneOverlay = {
 	},
 	/** Register a newly-active mobile overlay. Pair every call with `leave()`. */
 	enter() {
-		overlayCount += 1;
+		overlayCount = untrack(() => overlayCount) + 1;
 	},
 	/** Release a mobile overlay that stopped being active (unmount / breakpoint / close). */
 	leave() {
-		overlayCount = Math.max(0, overlayCount - 1);
+		overlayCount = Math.max(0, untrack(() => overlayCount) - 1);
 	},
 };


### PR DESCRIPTION
## What

Fixes the red E2E on `main` — two failures introduced by #1007 (TASK-2131, "full ARIA-modal isolation for the mobile detail pane"), both stemming from making the mobile pane `role="dialog"`.

## 1. The real defect — mobile pane renders empty (`effect_update_depth_exceeded`)

#1007 added a PaneHost `$effect` that calls `paneOverlay.enter()`/`leave()` to `inert` the app-shell chrome behind the mobile overlay. `enter()`'s `overlayCount += 1` **reads** `overlayCount` inside that tracked effect scope, so the effect took a reactive dependency on the very signal it writes:

```
effect runs → enter() writes overlayCount → effect dirty → re-run → enter() → … → effect_update_depth_exceeded
```

Svelte aborts the flush, which strands the rest of the subtree's reactivity: `paneMintForRoute` (in the collection page) stopped recomputing, so `{#if paneMintForRoute}` stayed false and the mobile pane rendered **completely empty** — no item content, no Back chevron. #1007's manual Playwright check verified the ARIA attributes but not that item content still rendered.

**Fix:** `untrack` the count read in `enter()`/`leave()` so a write from an effect never establishes a self-dependency. The write still notifies the layout's `mobileOverlayActive` reader normally. The ref-count mutators are written from effects *by design*, so the `untrack` belongs in the store (matches the existing `untrack`-the-write idiom in `UserSettingsForm.svelte` / `Lightbox.svelte`).

## 2. Test-locator collision

The pane is now `role="dialog"` on mobile, so `pane-controller.spec.ts:771`'s `[role="dialog"]` + text locator matched **both** the pane (which contains the sheet) and the BottomSheet → strict-mode violation. Target the sheet by accessible name (`getByRole('dialog', { name: 'Quick actions' })`) — the pane's is "Item detail".

## Diagnosis

Bisected the red E2E to #1007 (parent `316e25a6` green, `b76abdd6` red). Instrumented the collection page + PaneHost to trace the nav/mint sequence and captured the `effect_update_depth_exceeded` pageerror; confirmed by isolation that disabling the overlay effect removed the loop, and that restoring it with `untrack` keeps #1007's a11y isolation working.

## Verification

- `cd web && npm run check` — svelte-check **0 errors**
- `paneOverlay.svelte.test.ts` — **4 pass** (ref-count semantics)
- `pane-controller` (771 + 1178) now **pass**; `pane-controller` + `pane-a11y-focus` + `pane-mobile-overlay` suite — **28 pass** (1 unrelated documented tie-break flake, BUG-2270/2279)
- Codex CLI review — **CLEAN**

The `effect_update_depth_exceeded` runaway only manifests under the real browser scheduler (not jsdom/vitest), so the E2E overlay tests own the loop regression; the unit tests lock the ref-count semantics.

Fixes BUG-2284. Unblocks #1008 (IDEA-2135), whose E2E inherited this red.

https://claude.ai/code/session_01EZ6yr6pAUFb1uffan912ra