### PR TITLE
fix(web): inert the collapsed sidebar so off-screen nav leaves the a11y tree (BUG-2282)

### DIFF
--- a/web/src/lib/components/layout/Sidebar.svelte
+++ b/web/src/lib/components/layout/Sidebar.svelte
@@ -390,10 +390,20 @@
 	<div class="backdrop" onclick={() => uiStore.closeSidebar()}></div>
 {/if}
 
+<!--
+	BUG-2282: collapsed = off-screen/hidden (mobile drawer slid out via
+	translateX; desktop width:0). `pointer-events:none` (see .sidebar.collapsed)
+	blocks the mouse but leaves the nav in the a11y tree + tab order — an SR
+	virtual cursor / Tab reaches off-screen links. `inert` removes it from both,
+	matching the same collapsed condition. Safe: the re-open control lives in
+	TopBar (outside the aside), so this never traps the user; swipe-to-open is a
+	window handler, not on the aside.
+-->
 <aside
 	class="sidebar"
 	class:collapsed={!uiStore.sidebarOpen}
 	class:mobile={uiStore.isMobile}
+	inert={!uiStore.sidebarOpen}
 	bind:this={sidebarEl}
 	ontouchstart={handleTouchStart}
 	ontouchmove={handleTouchMove}


### PR DESCRIPTION
## BUG-2282

The mobile sidebar drawer collapses via `transform: translateX(...)` + `pointer-events: none`, but nothing removed it from the accessibility tree or tab order — so a screen-reader virtual cursor **and** keyboard Tab still reached its off-screen nav links.

## Fix

One attribute on `<aside class="sidebar">`:

```svelte
inert={!uiStore.sidebarOpen}
```

Bound to the same `!sidebarOpen` condition that already drives `class:collapsed` and the `.sidebar.collapsed { pointer-events: none }` rule. A collapsed drawer now leaves both the a11y tree and the focus order — covering the mobile drawer **and** the latent desktop `width:0` collapse (same keyboard-focus gap). Plus an explanatory comment.

**Safe:** the re-open control lives in `TopBar.svelte` (`toggleSidebar`), *outside* the aside — nothing is trapped. Swipe-to-open is a `<svelte:window>` handler (not on the aside); the aside's own touch handlers only do swipe-to-close (open-state only).

## Verification

- `svelte-check`: 0 errors. `make install`: clean.
- **Playwright runtime verify** (real browser, cookie session):

  | Case | `inert` | link focusable |
  |---|---|---|
  | Mobile collapsed (the bug) | **true** | focus refused ✓ |
  | Mobile opened | false | focusable ✓ |
  | Desktop default (open) | **false** — no regression ✓ | focusable ✓ |
  | Desktop collapsed | true | refused ✓ |

- **6-lens adversarial review** (trap / gestures / Svelte-correctness / desktop-regression / a11y+e2e / timing): 6/6 OK, 0 confirmed defects. Confirmed `inert` is in Svelte 5's `DOM_BOOLEAN_ATTRIBUTES` (removed when false, never rendered as `inert="false"`), no e2e test focuses/clicks sidebar nav while collapsed, and the mobile-and-desktop condition is correct (a mobile-only guard would reintroduce the bug on desktop).

## Follow-up

`UP-2285` (low, keyboard) — optional focus handoff to the TopBar toggle on keyboard-driven collapse (currently focus drops to `<body>`, standard `inert` behavior; not a regression).

https://claude.ai/code/session_01EZ6yr6pAUFb1uffan912ra