### PR TITLE
feat(web): show an Uncategorized lane on the Board for items with no group value (IDEA-2275)

### DIFF
--- a/web/src/lib/collections/boardColumns.test.ts
+++ b/web/src/lib/collections/boardColumns.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import type { Item } from '$lib/types';
+import { bucketByColumn, UNCATEGORIZED } from './boardColumns';
+
+// Minimal Item-shaped fixture — bucketByColumn only reads `.fields` (via
+// parseFields, which JSON.parses it) and `.id`.
+const item = (id: string, fields: Record<string, unknown>): Item =>
+	({ id, fields: JSON.stringify(fields) }) as unknown as Item;
+
+const columns = ['open', 'in_progress', 'done'];
+
+describe('bucketByColumn', () => {
+	it('buckets items into their matching column', () => {
+		const items = [
+			item('a', { status: 'open' }),
+			item('b', { status: 'done' }),
+			item('c', { status: 'open' })
+		];
+		const result = bucketByColumn(items, 'status', columns);
+		expect(result['open'].map((i) => i.id)).toEqual(['a', 'c']);
+		expect(result['done'].map((i) => i.id)).toEqual(['b']);
+		expect(result['in_progress']).toEqual([]);
+	});
+
+	it('always seeds every known column and the uncategorized bucket', () => {
+		const result = bucketByColumn([], 'status', columns);
+		expect(Object.keys(result).sort()).toEqual(
+			[UNCATEGORIZED, 'done', 'in_progress', 'open'].sort()
+		);
+		expect(result[UNCATEGORIZED]).toEqual([]);
+	});
+
+	it('collects items with an empty group value into UNCATEGORIZED', () => {
+		const items = [item('a', { status: '' }), item('b', { status: 'open' })];
+		const result = bucketByColumn(items, 'status', columns);
+		expect(result[UNCATEGORIZED].map((i) => i.id)).toEqual(['a']);
+		expect(result['open'].map((i) => i.id)).toEqual(['b']);
+	});
+
+	it('treats a missing/null group value as uncategorized', () => {
+		const items = [
+			item('a', {}), // key absent
+			item('b', { status: null }),
+			item('c', { priority: 'high' }) // unrelated field only
+		];
+		const result = bucketByColumn(items, 'status', columns);
+		expect(result[UNCATEGORIZED].map((i) => i.id)).toEqual(['a', 'b', 'c']);
+	});
+
+	it('collects items whose value is not a known option (stale/removed) into UNCATEGORIZED', () => {
+		const items = [item('a', { status: 'archived' }), item('b', { status: 'open' })];
+		const result = bucketByColumn(items, 'status', columns);
+		expect(result[UNCATEGORIZED].map((i) => i.id)).toEqual(['a']);
+		expect(result['open'].map((i) => i.id)).toEqual(['b']);
+	});
+
+	it('leaves the uncategorized bucket empty when every item is categorized', () => {
+		const items = [item('a', { status: 'open' }), item('b', { status: 'done' })];
+		const result = bucketByColumn(items, 'status', columns);
+		expect(result[UNCATEGORIZED]).toEqual([]);
+	});
+
+	it('honours the chosen group field, not always status', () => {
+		const items = [
+			item('a', { status: 'open', impact: 'high' }),
+			item('b', { status: 'open' }) // no impact → uncategorized under impact grouping
+		];
+		const result = bucketByColumn(items, 'impact', ['low', 'medium', 'high']);
+		expect(result['high'].map((i) => i.id)).toEqual(['a']);
+		expect(result[UNCATEGORIZED].map((i) => i.id)).toEqual(['b']);
+	});
+});

--- a/web/src/lib/collections/boardColumns.ts
+++ b/web/src/lib/collections/boardColumns.ts
@@ -1,0 +1,59 @@
+// Board-column bucketing (IDEA-2275).
+//
+// The kanban board groups items into lanes by a select field's value. Its
+// original bucketing seeded a lane for every known schema option and pushed
+// each item into the lane matching its value — but SILENTLY DROPPED any item
+// whose value was empty, missing, or no longer a valid option. Those items
+// then had no home on the board and could only be found in other views.
+//
+// This helper collects every such item into a single UNCATEGORIZED ('') lane
+// instead, so nothing is invisible. The '' key matches the convention used by
+// ListView and the public share board, and is exactly what a drop into the
+// lane writes back to the field (clearing it).
+import type { Item } from '$lib/types';
+import { parseFields } from '$lib/types';
+
+/** Lane key for items with no (or an unrecognised) group value. */
+export const UNCATEGORIZED = '';
+
+/**
+ * Normalise a raw field value to the string lane key it groups under.
+ * Non-strings coerce (a lone `null`/`undefined` → ''); arrays/objects
+ * stringify and simply won't match a known option, landing in UNCATEGORIZED.
+ */
+function laneValue(raw: unknown): string {
+	if (typeof raw === 'string') return raw;
+	if (raw == null) return '';
+	return String(raw);
+}
+
+/**
+ * Bucket `items` into board lanes keyed by their `groupField` value.
+ *
+ * Every known column in `columns` gets a bucket (so empty real lanes still
+ * render), plus an always-present UNCATEGORIZED ('') bucket. Any item whose
+ * value is empty, missing, or not one of `columns` lands in UNCATEGORIZED
+ * rather than being dropped. The returned map always contains the '' key
+ * (possibly empty) — callers decide whether to render the lane based on its
+ * length, so it only appears "if needed".
+ */
+export function bucketByColumn(
+	items: Item[],
+	groupField: string,
+	columns: string[]
+): Record<string, Item[]> {
+	const known = new Set(columns);
+	const result: Record<string, Item[]> = { [UNCATEGORIZED]: [] };
+	for (const col of columns) {
+		result[col] = [];
+	}
+	for (const item of items) {
+		const value = laneValue(parseFields(item)[groupField]);
+		if (value && known.has(value)) {
+			result[value].push(item);
+		} else {
+			result[UNCATEGORIZED].push(item);
+		}
+	}
+	return result;
+}

--- a/web/src/lib/components/collections/BoardView.svelte
+++ b/web/src/lib/components/collections/BoardView.svelte
@@ -3,6 +3,7 @@
 	import { parseSchema, parseFields } from '$lib/types';
 	import { itemComparator, type SortMode } from '$lib/collections/itemSort';
 	import { reorderGroup, disabledDirections, adjacentColumn, type ReorderDirection } from '$lib/collections/reorder';
+	import { bucketByColumn, UNCATEGORIZED } from '$lib/collections/boardColumns';
 	import { dndzone, TRIGGERS, SHADOW_ITEM_MARKER_PROPERTY_NAME } from 'svelte-dnd-action';
 	import type { DndEvent } from 'svelte-dnd-action';
 	import ItemCard from './ItemCard.svelte';
@@ -201,7 +202,9 @@
 	}
 
 	function handleColumnDragOver(e: DragEvent, colValue: string) {
-		if (!draggedColumn || draggedColumn === colValue) return;
+		// The pinned UNCATEGORIZED lane isn't a reorder target — a real column
+		// can't be moved to its left (DR-1), so don't show a drop indicator on it.
+		if (!draggedColumn || draggedColumn === colValue || colValue === UNCATEGORIZED) return;
 		e.preventDefault();
 		if (e.dataTransfer) e.dataTransfer.dropEffect = 'move';
 		dragOverColumn = colValue;
@@ -241,25 +244,17 @@
 	let columnData: Record<string, Item[]> = $state({});
 
 	let propColumnData = $derived.by(() => {
-		const result: Record<string, Item[]> = {};
-		for (const col of columns) {
-			result[col] = [];
-		}
-		for (const item of items) {
-			const fields = parseFields(item);
-			const value = fields[groupField] ?? '';
-			if (result[value]) {
-				result[value].push(item);
-			}
-		}
+		// Bucket items into their lanes, routing empty/unknown-value items
+		// into the UNCATEGORIZED ('') lane instead of dropping them (IDEA-2275).
+		const result = bucketByColumn(items, groupField, columns);
 		// `preserveOrder` opts out of the in-column sort so search rank
 		// from the parent isn't overridden — TASK-1367. Otherwise sort
 		// each lane by its effective mode — the per-lane override if set,
 		// else the page-wide sort (TASK-1670 / TASK-1673); 'manual'
 		// resolves to the stored sort_order, preserving prior behavior.
 		if (!preserveOrder) {
-			for (const col of columns) {
-				result[col].sort(itemComparator(laneSortFor(col), collection));
+			for (const key of Object.keys(result)) {
+				result[key].sort(itemComparator(laneSortFor(key), collection));
 			}
 		}
 		return result;
@@ -268,12 +263,29 @@
 	// Cooldown after a drop — suppress syncs while reorder API calls + SSE events settle
 	let dropCooldown = $state(false);
 
+	// Whether the UNCATEGORIZED lane is shown — true when any item lacks a
+	// valid group value (IDEA-2275: "only if needed"). Synced from the settled
+	// prop data in the SAME gate as columnData so the lane doesn't vanish
+	// mid-drag when its last card leaves. Written here, only ever READ in the
+	// `renderColumns` derivation below — never read inside this effect
+	// (CONVE-1688).
+	let showUncategorized = $state(false);
+
 	$effect(() => {
 		const data = propColumnData;
 		if (!isDragging && !dropCooldown) {
 			columnData = data;
+			showUncategorized = (data[UNCATEGORIZED]?.length ?? 0) > 0;
 		}
 	});
+
+	// The lanes to render, left→right: the pinned UNCATEGORIZED lane first when
+	// needed (DR-1), then the user-orderable real columns. UNCATEGORIZED is
+	// deliberately kept OUT of `columnOrder` (the persisted, drag-reorderable
+	// set) so it can't be reordered into the middle or written to saved order.
+	let renderColumns = $derived(
+		showUncategorized ? [UNCATEGORIZED, ...columnOrder] : columnOrder
+	);
 
 	// Surface the board's rendered column structure to the parent for keyboard
 	// navigation (PLAN-2105 / TASK-2119). Visual column order (`columnOrder`,
@@ -283,7 +295,7 @@
 	// is the single source of truth — the parent navigates THIS, never a
 	// re-derived grouping that could disagree with what's on screen.
 	let navColumns = $derived(
-		columnOrder.map((col) => ({
+		renderColumns.map((col) => ({
 			value: col,
 			items: (columnData[col] ?? []).filter((i: any) => !i[SHADOW_ITEM_MARKER_PROPERTY_NAME]),
 		}))
@@ -370,6 +382,7 @@
 	}
 
 	function formatLabel(value: string): string {
+		if (!value) return 'Uncategorized';
 		return value.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
 	}
 
@@ -396,8 +409,11 @@
 	// insert it at the target lane's head BEFORE committing; otherwise the
 	// card would render in BOTH lanes until the cooldown/SSE settle (DR-7).
 	function moveItem(columnValue: string, item: Item, dir: 'left' | 'right') {
-		const target = adjacentColumn(columnOrder, columnValue, dir);
-		if (!target) return;
+		// Adjacency follows the RENDER order (which includes the pinned
+		// UNCATEGORIZED lane), so a card can move right out of it into the
+		// first real column, or left into it — the menu counterpart to a drag.
+		const target = adjacentColumn(renderColumns, columnValue, dir);
+		if (target === null) return;
 
 		const source = (columnData[columnValue] ?? []).filter((i) => i.id !== item.id);
 		const dest = [item, ...(columnData[target] ?? []).filter((i) => i.id !== item.id)];
@@ -428,9 +444,12 @@
 		const disabled: Set<ReorderDirection | 'left' | 'right'> = new Set(
 			disabledDirections(index, length)
 		);
-		const colIdx = columnOrder.indexOf(columnValue);
+		// Horizontal edges follow the RENDER order (incl. the pinned
+		// UNCATEGORIZED lane) so the hidden left/right options match where
+		// moveItem can actually land the card.
+		const colIdx = renderColumns.indexOf(columnValue);
 		if (colIdx <= 0) disabled.add('left');
-		if (colIdx >= columnOrder.length - 1) disabled.add('right');
+		if (colIdx >= renderColumns.length - 1) disabled.add('right');
 		return disabled;
 	}
 
@@ -454,12 +473,15 @@
 	<EmptyState {collection} {wsSlug} {oncreate} />
 {:else}
 <div class="board-view">
-	{#each columnOrder as colValue (colValue)}
+	{#each renderColumns as colValue (colValue)}
 		{@const colItems = columnData[colValue] ?? []}
+		{@const isUncategorized = colValue === UNCATEGORIZED}
+		{@const colDraggable = canEdit && !isUncategorized}
 		<div
 			class="kanban-column"
 			class:drag-over-left={dragOverColumn === colValue}
 			class:dragging-source={draggedColumn === colValue}
+			class:uncategorized-column={isUncategorized}
 			role="group"
 			aria-label="{formatLabel(colValue)} column"
 			ondragover={(e) => handleColumnDragOver(e, colValue)}
@@ -469,13 +491,13 @@
 			<!-- svelte-ignore a11y_no_static_element_interactions -->
 			<div
 				class="column-header {columnCssClass(colValue)}"
-				draggable={canEdit}
+				draggable={colDraggable}
 				role="toolbar"
 				tabindex="0"
-				ondragstart={canEdit ? (e) => handleColumnDragStart(e, colValue) : undefined}
-				ondragend={canEdit ? handleColumnDragEnd : undefined}
+				ondragstart={colDraggable ? (e) => handleColumnDragStart(e, colValue) : undefined}
+				ondragend={colDraggable ? handleColumnDragEnd : undefined}
 			>
-				{#if canEdit}
+				{#if colDraggable}
 					<span class="column-drag-handle" title="Drag to reorder">⠿</span>
 				{/if}
 				<span class="column-name">{formatLabel(colValue)}</span>
@@ -487,8 +509,11 @@
 					     verbs are owner/editor-gated by the page). Don't gate
 					     on `canEdit`, or an owner/editor without a collection
 					     edit grant (canBulkEdit true, canEdit false) couldn't
-					     open the menu at all. TASK-1672 / Codex round 4. -->
-					{#if onCreateInColumn}
+					     open the menu at all. TASK-1672 / Codex round 4. The
+					     UNCATEGORIZED lane hides "add" (creating an explicitly
+					     uncategorized item makes no sense) but keeps the bulk
+					     ⋯ menu — "move/tag/assign all" is useful for triage. -->
+					{#if onCreateInColumn && !isUncategorized}
 						<button
 							class="lane-btn lane-add-btn"
 							title="Add item to {formatLabel(colValue).toLowerCase()}"
@@ -521,7 +546,7 @@
 									laneSort={laneSortOverrides[colValue]}
 									onSetLaneSort={(m) => setLaneSort(colValue, m)}
 									onClose={closeMenu}
-									onAddItem={onCreateInColumn ? () => openDraft(colValue) : undefined}
+									onAddItem={onCreateInColumn && !isUncategorized ? () => openDraft(colValue) : undefined}
 									onArchive={onArchiveColumn ? () => onArchiveColumn?.(colItems) : undefined}
 									onMove={onMoveColumn ? (status) => onMoveColumn?.(colItems, status) : undefined}
 									onTag={onTagColumn ? (tag) => onTagColumn?.(colItems, tag) : undefined}
@@ -697,6 +722,17 @@
 
 	.column-header.col-blocked {
 		border-bottom-color: var(--accent-orange);
+	}
+
+	/* The pinned Uncategorized lane (IDEA-2275) — a triage bucket for items
+	   with no valid group value. It isn't draggable/reorderable, so drop the
+	   grab cursor, and a dashed muted accent distinguishes it from the real
+	   status columns. */
+	.uncategorized-column .column-header {
+		cursor: default;
+		border-bottom-style: dashed;
+		border-bottom-color: var(--text-muted);
+		color: var(--text-secondary);
 	}
 
 	.column-drag-handle {

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -2840,6 +2840,7 @@
 	}
 
 	function formatLabel(value: string): string {
+		if (!value) return 'Uncategorized';
 		return value.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
 	}
 </script>


### PR DESCRIPTION
## Summary

The kanban **Board** view only bucketed items into the group field's known select `options`, **silently dropping** any item whose value was empty, missing, or a stale/removed option. Those items were invisible on the board and could only be found in other views (IDEA-2275).

This adds a pinned **Uncategorized** lane that collects every such item, so nothing is invisible. It renders **only when uncategorized items exist** ("only if needed").

## Design decisions

- **Position — leftmost** (honors the IDEA's "left hand column"; surfaces untriaged items first). Deliberately diverges from ListView, which appends its Uncategorized group last.
- **Droppable** — dragging a card in sets the group field to `""` (a valid server-side clear, reversible), same as any column. Confirmed safe: the field validator only enforces required-ness on absent/`null` keys, not empty strings, and the board reconstructs the full fields blob so no other fields are disturbed.
- The lane is kept **out of the persisted, drag-reorderable `columnOrder`** so it can't be reordered into the middle or written to saved column order; adjacency (menu-move left/right, keyboard nav) follows the **render order** instead, so cards move in/out of the lane correctly.
- Header **drops the drag handle and the "+" add affordance** (creating an explicitly-uncategorized item makes no sense) but keeps the bulk **⋯** menu — "move/tag/assign all" is genuinely useful for triage. A dashed muted accent distinguishes it from real status columns.

## Implementation

- New pure, unit-tested helper `web/src/lib/collections/boardColumns.ts` (`bucketByColumn`) routes empty/unknown-value items into an `UNCATEGORIZED` (`''`) bucket instead of dropping them (7 tests).
- `BoardView.svelte`: `renderColumns` prepends the lane when `showUncategorized`; `formatLabel('') → "Uncategorized"`; adjacency/nav use render order; column-reorder guarded against the pinned lane.
- Page toast `formatLabel` also labels the empty value.

## Testing

- `cd web && npm run test` — 487 pass (incl. 7 new `bucketByColumn` tests)
- `cd web && npm run check` — 0 errors
- `make check` — green (Go lint/test/vuln + web-check). No store/dialect changes, so `make test-pg` N/A.
- **Codex review**: CLEAN (no falsy-`''`-key regressions, render-order vs persisted order correctly separated, no effect write/read loop).
- **Live-verified**: Ideas board grouped by `impact` renders `Uncategorized(202)` leftmost with Low/Medium/High, no console errors.

Closes IDEA-2275.

https://claude.ai/code/session_01EZ6yr6pAUFb1uffan912ra