### PR TITLE
feat(web): show abbreviated item age on board & list cards (IDEA-2286)

### DIFF
--- a/web/src/lib/components/collections/ItemCard.svelte
+++ b/web/src/lib/components/collections/ItemCard.svelte
@@ -5,6 +5,7 @@
 	import { parseFields, parseSchema, parseTags, formatItemRef, itemUrlId } from '$lib/types';
 	import { starredStore } from '$lib/stores/starred.svelte';
 	import { copyToClipboard } from '$lib/utils/clipboard';
+	import { relativeTime } from '$lib/utils/markdown';
 	import ItemActionsMenu from './ItemActionsMenu.svelte';
 	import type { ReorderDirection } from '$lib/collections/reorder';
 	import { shouldOpenInPane } from './itemCardClick';
@@ -63,6 +64,12 @@
 	let itemUrl = $derived(`/${username}/${wsSlug}/${collection.slug}/${itemUrlId(item)}`);
 	let itemRef = $derived(formatItemRef(item));
 	let tags = $derived(parseTags(item));
+
+	// Absolute created timestamp for the age element's tooltip (IDEA-2286); the
+	// visible label is the abbreviated relativeTime() the item-detail header uses.
+	let createdAtTitle = $derived(
+		item.created_at ? `Created ${new Date(item.created_at).toLocaleString()}` : ''
+	);
 
 	function tagUrl(tag: string): string {
 		return `/${username}/${wsSlug}/tags/${encodeURIComponent(tag)}`;
@@ -275,8 +282,12 @@
 				{#if item.agent_role_icon}{item.agent_role_icon} {/if}{item.agent_role_name}
 			</span>
 		{/if}
+		<span class="meta-spacer"></span>
 		{#if item.assigned_user_name}
 			<span class="meta-assignee">{item.assigned_user_name}</span>
+		{/if}
+		{#if item.created_at}
+			<span class="meta-age" title={createdAtTitle}>{relativeTime(item.created_at)}</span>
 		{/if}
 	</div>
 
@@ -582,7 +593,23 @@
 		font-size: 0.7em;
 		font-weight: 500;
 		color: var(--accent-blue);
-		margin-left: auto;
+		white-space: nowrap;
+	}
+
+	/* Spacer pushes the assignee + age cluster to the right edge so the age sits
+	   opposite the status (IDEA-2286). A dedicated spacer — rather than
+	   margin-left:auto on both assignee and age — keeps the layout deterministic:
+	   two competing auto margins would split the free space and strand the
+	   assignee mid-row. */
+	.meta-spacer {
+		flex: 1 1 0;
+		min-width: 0;
+	}
+
+	.meta-age {
+		font-size: 0.7em;
+		font-weight: 500;
+		color: var(--text-muted);
 		white-space: nowrap;
 	}
 


### PR DESCRIPTION
## What

Adds an item's **age** (from `created_at`) to the shared `ItemCard`, right-justified in the `.card-meta` row so it sits **opposite the status** — visible at a glance. Lands on both **Board** (compact) and **List** views; **Table** view renders its own rows and is unaffected (it already has columns).

Resolves **IDEA-2286**.

## How

- Reuses the shared `relativeTime()` (`web/src/lib/utils/markdown.ts`) that the item-detail header already uses — `3h ago`, `5d ago`, then a short date for older items. (Per Dave: the literal `1w 1d` weeks format from the idea was just a first thought; the existing "N ago -> date" behavior is fine.)
- A dedicated `.meta-spacer` (`flex: 1 1 0`) pushes the assignee + age cluster to the right edge, instead of putting `margin-left: auto` on both the assignee and the age. Two competing auto-margins would split the free space and strand the assignee mid-row; the spacer keeps the layout deterministic.
- Absolute timestamp on hover via a `title` tooltip.

Card layout (Board): `NEW` on the left, `3h ago` justified on the right of the same row. With an assignee present: `assignee  age` cluster on the right, status still left.

## Verification

- `make check` — green (golangci-lint, `go test ./...`, govulncheck, web-check; 487 web tests pass).
- `cd web && npm run check` — 0 errors.
- Two Codex review passes (`main...HEAD`) — both CLEAN.
- Browser-verified (Playwright, embedded build) on Board + List: status left, age right-justified on the same row, tooltip shows the absolute created time. Confirmed the assignee-present case clusters `assignee age` on the right with no split/overlap.

https://claude.ai/code/session_01EZ6yr6pAUFb1uffan912ra