### PR TITLE
feat(web): default new collections to Board — schema-aware (IDEA-2274, IDEA-2287)

### DIFF
--- a/cmd/pad/cmd_collection.go
+++ b/cmd/pad/cmd_collection.go
@@ -205,7 +205,7 @@ the --fields DSL does. Set "label" explicitly when you want a custom display nam
 				settings.Layout = "fields-primary"
 			}
 			if settings.DefaultView == "" {
-				settings.DefaultView = "list"
+				settings.DefaultView = "board"
 			}
 			settingsJSON, _ := json.Marshal(settings)
 
@@ -240,7 +240,7 @@ the --fields DSL does. Set "label" explicitly when you want a custom display nam
 	cmd.Flags().StringVar(&fieldsDSL, "fields", "", "field definitions DSL (key:type[:options]; ...); use --schema for terminal_options, computed, defaults, etc.")
 	cmd.Flags().StringVar(&schemaInput, "schema", "", "full CollectionSchema JSON: inline, @path, or - for stdin; mutually exclusive with --fields")
 	cmd.Flags().StringVar(&layout, "layout", "fields-primary", "item detail layout: fields-primary, content-primary, balanced")
-	cmd.Flags().StringVar(&defaultView, "default-view", "list", "default view type: list, board, table")
+	cmd.Flags().StringVar(&defaultView, "default-view", "board", "default view type: list, board, table")
 	cmd.Flags().StringVar(&boardGroup, "board-group-by", "status", "field to group by in board view")
 
 	return cmd

--- a/internal/collections/defaults.go
+++ b/internal/collections/defaults.go
@@ -102,7 +102,7 @@ func Defaults() []DefaultCollection {
 			},
 			Settings: models.CollectionSettings{
 				Layout:      "balanced",
-				DefaultView: "list",
+				DefaultView: "board",
 				ListSortBy:  "created_at",
 				ListGroupBy: "status",
 				QuickActions: []models.QuickAction{
@@ -151,7 +151,7 @@ func Defaults() []DefaultCollection {
 			},
 			Settings: models.CollectionSettings{
 				Layout:      "content-primary",
-				DefaultView: "list",
+				DefaultView: "board",
 				ListSortBy:  "sort_order",
 				QuickActions: []models.QuickAction{
 					{Label: "Plan this", Prompt: "/pad plan {ref} \"{title}\" — outline goals, deliverables, and timeline", Scope: "item", Icon: "📐"},
@@ -187,7 +187,7 @@ func Defaults() []DefaultCollection {
 			},
 			Settings: models.CollectionSettings{
 				Layout:      "content-primary",
-				DefaultView: "list",
+				DefaultView: "board",
 				ListSortBy:  "updated_at",
 				ListGroupBy: "category",
 				QuickActions: []models.QuickAction{

--- a/internal/collections/templates.go
+++ b/internal/collections/templates.go
@@ -162,7 +162,7 @@ func docsCollection(sortOrder int) DefaultCollection {
 		},
 		Settings: models.CollectionSettings{
 			Layout:      "content-primary",
-			DefaultView: "list",
+			DefaultView: "board",
 			ListSortBy:  "updated_at",
 			ListGroupBy: "category",
 		},
@@ -346,7 +346,7 @@ func conventionsCollection(sortOrder int, triggerOptions, scopeOptions []string)
 		},
 		Settings: models.CollectionSettings{
 			Layout:      "balanced",
-			DefaultView: "list",
+			DefaultView: "board",
 			ListSortBy:  "trigger",
 			ListGroupBy: "trigger",
 		},
@@ -414,7 +414,7 @@ func playbooksCollection(sortOrder int, triggerOptions, scopeOptions []string) D
 		},
 		Settings: models.CollectionSettings{
 			Layout:      "content-primary",
-			DefaultView: "list",
+			DefaultView: "board",
 			ListSortBy:  "updated_at",
 			ListGroupBy: "trigger",
 		},
@@ -666,7 +666,7 @@ var templates = []WorkspaceTemplate{
 				},
 				Settings: models.CollectionSettings{
 					Layout:      "balanced",
-					DefaultView: "list",
+					DefaultView: "board",
 					ListSortBy:  "created_at",
 					ListGroupBy: "status",
 				},

--- a/internal/collections/templates_hiring.go
+++ b/internal/collections/templates_hiring.go
@@ -164,7 +164,7 @@ func hiringLoopsCollection(sortOrder int) DefaultCollection {
 		},
 		Settings: models.CollectionSettings{
 			Layout:       "balanced",
-			DefaultView:  "list",
+			DefaultView:  "board",
 			ListSortBy:   "date",
 			BoardGroupBy: "result",
 		},
@@ -205,7 +205,7 @@ func hiringFeedbackCollection(sortOrder int) DefaultCollection {
 		},
 		Settings: models.CollectionSettings{
 			Layout:      "content-primary",
-			DefaultView: "list",
+			DefaultView: "board",
 			ListSortBy:  "updated_at",
 			// Group by "submitted" so the done-state pipeline
 			// (DoneFieldKey/TerminalValuesForDoneField) lines up with the

--- a/internal/collections/templates_interviewing.go
+++ b/internal/collections/templates_interviewing.go
@@ -234,6 +234,10 @@ func interviewingContactsCollection(sortOrder int) DefaultCollection {
 			Layout:      "balanced",
 			DefaultView: "board",
 			ListSortBy:  "last_contact",
+			// Contacts has no `status` field; group the board by relationship
+			// so the default board renders real lanes instead of a single
+			// Uncategorized column (Codex review round 2).
+			BoardGroupBy: "relationship",
 		},
 	}
 }

--- a/internal/collections/templates_interviewing.go
+++ b/internal/collections/templates_interviewing.go
@@ -146,7 +146,7 @@ func interviewingInterviewsCollection(sortOrder int) DefaultCollection {
 		},
 		Settings: models.CollectionSettings{
 			Layout:       "balanced",
-			DefaultView:  "list",
+			DefaultView:  "board",
 			ListSortBy:   "date",
 			BoardGroupBy: "prep_status",
 		},
@@ -191,7 +191,7 @@ func interviewingCompaniesCollection(sortOrder int) DefaultCollection {
 		},
 		Settings: models.CollectionSettings{
 			Layout:      "balanced",
-			DefaultView: "list",
+			DefaultView: "board",
 			ListSortBy:  "updated_at",
 		},
 	}
@@ -232,7 +232,7 @@ func interviewingContactsCollection(sortOrder int) DefaultCollection {
 		},
 		Settings: models.CollectionSettings{
 			Layout:      "balanced",
-			DefaultView: "list",
+			DefaultView: "board",
 			ListSortBy:  "last_contact",
 		},
 	}

--- a/internal/mcp/dispatch_http_project_test.go
+++ b/internal/mcp/dispatch_http_project_test.go
@@ -633,7 +633,7 @@ func TestMapCollectionCreate_ParsesFieldsDSL(t *testing.T) {
 	if settings["layout"] != "fields-primary" {
 		t.Errorf("default layout = %v", settings["layout"])
 	}
-	if settings["default_view"] != "list" {
+	if settings["default_view"] != "board" {
 		t.Errorf("default_view = %v", settings["default_view"])
 	}
 	if settings["board_group_by"] != "status" {

--- a/internal/mcp/dispatch_http_routes.go
+++ b/internal/mcp/dispatch_http_routes.go
@@ -451,7 +451,7 @@ func init() {
 //   - Auto-fill Label as title-cased(key with `_` → ` `).
 //   - First select-typed `status` field is marked required + default
 //     (matches CLI; the handler also enforces this on its side).
-//   - Layout defaults to "fields-primary"; default_view to "list";
+//   - Layout defaults to "fields-primary"; default_view to "board";
 //     board_group_by to "status" (matches CLI's flag defaults).
 //
 // Schema and Settings are JSON-encoded into strings before the POST
@@ -516,7 +516,7 @@ func mapCollectionCreate(input map[string]any) (string, string, []byte, error) {
 	}
 	defaultView, _ := input["default_view"].(string)
 	if defaultView == "" {
-		defaultView = "list"
+		defaultView = "board"
 	}
 	boardGroupBy, _ := input["board_group_by"].(string)
 	if boardGroupBy == "" {

--- a/web/e2e/pane-a11y-focus.spec.ts
+++ b/web/e2e/pane-a11y-focus.spec.ts
@@ -104,7 +104,10 @@ test.describe('pane accessibility & focus management (PLAN-2105 / TASK-2122)', (
 		await browserLogin(page);
 		await seedDoc(fixture, request, 'A11y split alpha');
 		await seedDoc(fixture, request, 'A11y split bravo');
-		await page.goto(docsUrl(fixture));
+		// Pin list view: this test exercises LIST j/k cursor nav. The workspace
+		// default is now Board (IDEA-2274), so request list explicitly rather
+		// than lean on board's single-lane collapse matching flat stepping.
+		await page.goto(docsUrl(fixture, '?view=list'));
 
 		await page.locator('.item-card').first().click();
 		const pane = page.locator('.item-pane');

--- a/web/e2e/pane-async-race.spec.ts
+++ b/web/e2e/pane-async-race.spec.ts
@@ -263,7 +263,10 @@ test.describe('pane async-race hardening (PLAN-2154 R14 / TASK-2167)', () => {
 			const item = await seedNoteItem(fixture, request, coll.slug, name, '');
 			slugByName.set(name, item.slug);
 		}
-		await page.goto(collUrl(fixture, coll.slug));
+		// Pin list view: this test dispatches `j` and asserts the `.focused`
+		// marker steps the flat LIST deterministically. The default is now Board
+		// (IDEA-2274), so request list explicitly.
+		await page.goto(collUrl(fixture, coll.slug, '?view=list'));
 
 		const pane = page.locator('.item-pane');
 		const cardTitles = page.locator('.list-column .item-card .card-title');

--- a/web/e2e/pane-controller.spec.ts
+++ b/web/e2e/pane-controller.spec.ts
@@ -167,7 +167,10 @@ test.describe('pane controller: depth/ownership state machine (PLAN-2154 / TASK-
 		await browserLogin(page);
 		await seedDoc(fixture, request, 'Ctrl regress alpha');
 		await seedDoc(fixture, request, 'Ctrl regress bravo');
-		await page.goto(docsUrl(fixture));
+		// Pin list view: this test exercises LIST j/k re-target. The workspace
+		// default is now Board (IDEA-2274), so request list explicitly rather
+		// than lean on board's single-lane collapse matching flat stepping.
+		await page.goto(docsUrl(fixture, '?view=list'));
 
 		const prePaneUrl = page.url();
 		// Open the FIRST rendered row (not a NAMED one) so the `j` (down) below

--- a/web/src/lib/collections/paneUrlParams.test.ts
+++ b/web/src/lib/collections/paneUrlParams.test.ts
@@ -82,6 +82,12 @@ describe('buildCollectionUrlParams', () => {
 		expect(params.get('item')).toBe('TASK-5');
 	});
 
+	it('serializes ?view=list explicitly so a copied List URL never resolves back to a board default (IDEA-2274)', () => {
+		const currentUrl = new URL('https://pad.test/alice/ws/tasks');
+		const params = buildCollectionUrlParams(state({ viewMode: 'list' }), currentUrl);
+		expect(params.get('view')).toBe('list');
+	});
+
 	it('preserves an existing ?item= across a tag/search change', () => {
 		const currentUrl = new URL('https://pad.test/alice/ws/tasks?item=DOC-2');
 		const params = buildCollectionUrlParams(

--- a/web/src/lib/collections/paneUrlParams.ts
+++ b/web/src/lib/collections/paneUrlParams.ts
@@ -47,8 +47,10 @@ export function preservePaneItemParam(params: URLSearchParams, currentUrl: URL):
 
 /** The filter/sort/view/search state `updateUrlFilters` serializes. */
 export interface CollectionUrlFilterState {
-	/** The page's `ViewMode` ('list' | 'board' | 'table'); 'list' is the
-	 *  default and omitted from the query string. */
+	/** The page's `ViewMode` ('list' | 'board' | 'table'). Always serialized
+	 *  to `?view=` — since a collection's default view can be Board (IDEA-2274),
+	 *  omitting `list` would make a copied List URL resolve back to Board for a
+	 *  viewer without the sender's localStorage. */
 	viewMode: string;
 	activeFilters: Record<string, string>;
 	selectedTags: string[];
@@ -67,7 +69,10 @@ export interface CollectionUrlFilterState {
  */
 export function buildCollectionUrlParams(state: CollectionUrlFilterState, currentUrl: URL): URLSearchParams {
 	const params = new URLSearchParams();
-	if (state.viewMode !== 'list') params.set('view', state.viewMode);
+	// Always serialize the view — a List selection on a board-default
+	// collection must survive a copied link (no localStorage) rather than
+	// silently resolving back to the collection's Board default (IDEA-2274).
+	params.set('view', state.viewMode);
 	for (const [k, v] of Object.entries(state.activeFilters)) {
 		params.set(k, v);
 	}

--- a/web/src/lib/components/collections/CreateCollectionModal.svelte
+++ b/web/src/lib/components/collections/CreateCollectionModal.svelte
@@ -53,7 +53,7 @@
 	// reveal defaults closed so the fast-path "pick a template, name it,
 	// create" flow stays uncluttered.
 	let showAdvanced = $state(false);
-	let defaultView = $state<'list' | 'board' | 'table'>('list');
+	let defaultView = $state<'list' | 'board' | 'table'>('board');
 	let layout = $state<'fields-primary' | 'content-primary' | 'balanced'>('balanced');
 	let boardGroupBy = $state('status');
 	let listGroupBy = $state('');
@@ -125,7 +125,7 @@
 			fields = [];
 			selectedSettings = null;
 			showAdvanced = false;
-			defaultView = 'list';
+			defaultView = 'board';
 			layout = 'balanced';
 			boardGroupBy = 'status';
 			listGroupBy = '';
@@ -167,7 +167,7 @@
 		fields = [];
 		selectedSettings = null;
 		showAdvanced = false;
-		defaultView = 'list';
+		defaultView = 'board';
 		layout = 'balanced';
 		boardGroupBy = 'status';
 		listGroupBy = '';

--- a/web/src/lib/components/collections/EditCollectionModal.svelte
+++ b/web/src/lib/components/collections/EditCollectionModal.svelte
@@ -191,7 +191,7 @@
 
 	// ── Display settings state ──────────────────────────────────────────────
 
-	let defaultView = $state<'list' | 'board' | 'table'>('list');
+	let defaultView = $state<'list' | 'board' | 'table'>('board');
 	let layout = $state<'fields-primary' | 'content-primary' | 'balanced'>('balanced');
 	let boardGroupBy = $state('status');
 	let listGroupBy = $state('');
@@ -313,7 +313,7 @@
 
 			// Sync display settings
 			const s = parseSettings(collection);
-			defaultView = (['board', 'list', 'table'].includes(s.default_view) ? s.default_view : 'list') as typeof defaultView;
+			defaultView = (['board', 'list', 'table'].includes(s.default_view) ? s.default_view : 'board') as typeof defaultView;
 			layout = (['fields-primary', 'content-primary', 'balanced'].includes(s.layout) ? s.layout : 'balanced') as typeof layout;
 			boardGroupBy = s.board_group_by || 'status';
 			listGroupBy = s.list_group_by || '';

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -453,7 +453,7 @@
 	let tags = $derived(parseTags(item));
 	let tagSuggestions = $state<string[]>([]);
 	let schema = $derived(collection ? parseSchema(collection) : { fields: [] });
-	let settings = $derived<CollectionSettings>(collection ? parseSettings(collection) : { layout: 'balanced', default_view: 'list' });
+	let settings = $derived<CollectionSettings>(collection ? parseSettings(collection) : { layout: 'balanced', default_view: 'board' });
 	let layout = $derived(settings.layout);
 	let quickActions = $derived<QuickAction[]>(settings.quick_actions ?? []);
 

--- a/web/src/lib/components/share/shareView.ts
+++ b/web/src/lib/components/share/shareView.ts
@@ -108,15 +108,15 @@ export function coerceFields(schema: unknown): FieldDef[] {
 	);
 }
 
-const DEFAULT_SETTINGS: PublicViewSettings = { default_view: 'list' };
+const DEFAULT_SETTINGS: PublicViewSettings = { default_view: 'board' };
 
 /** Normalize raw `settings` (string-or-object) into PublicViewSettings,
- *  validating `default_view` against the known set and defaulting to 'list'. */
+ *  validating `default_view` against the known set and defaulting to 'board'. */
 export function coerceSettings(settings: unknown): PublicViewSettings {
 	const obj = coerceObject(settings);
 	const view = obj.default_view;
 	const default_view: PublicViewSettings['default_view'] =
-		view === 'board' || view === 'table' || view === 'list' ? view : 'list';
+		view === 'board' || view === 'table' || view === 'list' ? view : 'board';
 	return {
 		default_view,
 		board_group_by: typeof obj.board_group_by === 'string' ? obj.board_group_by : undefined,

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -1640,7 +1640,7 @@ export function parseSchema(collection: Collection): CollectionSchema {
 	}
 }
 
-const settingsDefaults = (): CollectionSettings => ({ layout: 'balanced', default_view: 'list' });
+const settingsDefaults = (): CollectionSettings => ({ layout: 'balanced', default_view: 'board' });
 
 export function parseSettings(collection: Collection): CollectionSettings {
 	try {

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -73,7 +73,7 @@
 	// `indexError`/`deltaSyncFailed` retry box — instead of masking a
 	// live collection as deleted. Cleared at the top of every load.
 	let metaError = $state<Error | null>(null);
-	let viewMode = $state<ViewMode>('list');
+	let viewMode = $state<ViewMode>('board');
 	// Page-wide within-group sort (TASK-1670 / IDEA-1648). 'manual' is the
 	// stored sort_order (drag order). Persisted per collection.
 	let sortMode = $state<SortMode>('manual');
@@ -1203,7 +1203,7 @@
 			// Set view mode: URL param > localStorage > collection default
 			const settings = parseSettings(collData);
 			const defaultMode = (['board', 'list', 'table'].includes(settings.default_view))
-				? settings.default_view as ViewMode : 'list';
+				? settings.default_view as ViewMode : 'board';
 			viewMode = loadSavedViewMode(coll, defaultMode);
 			sortMode = loadSavedSortMode(coll);
 

--- a/web/src/routes/s/[token]/+page.svelte
+++ b/web/src/routes/s/[token]/+page.svelte
@@ -33,7 +33,7 @@
 	// Selection is a discriminated handle: either a base view type, or a saved
 	// view addressed by slug (which resolves to a base view_type for rendering).
 	let selectedKind = $state<'base' | 'saved'>('base');
-	let selectedBase = $state<BaseView>('list');
+	let selectedBase = $state<BaseView>('board');
 	let selectedSavedSlug = $state('');
 
 	let loading = $state(true);
@@ -71,7 +71,7 @@
 
 	// Owner's default base view, the fallback when nothing is selected.
 	let defaultView = $derived<BaseView>(
-		coerceBaseView(collectionData?.collection.settings?.default_view) ?? 'list'
+		coerceBaseView(collectionData?.collection.settings?.default_view) ?? 'board'
 	);
 
 	// The effective base view fed to PublicCollectionView. A saved-view


### PR DESCRIPTION
Two related changes to the default collection view.

## IDEA-2274 — Board becomes the baseline default (new collections only, no migration)
Board is now the default view everywhere a new collection's view is decided — frontend fallback, public-share page, create/edit modals, backend template seeds, CLI/MCP create defaults. Existing collections keep their stored `default_view` (verified: `ideas` still opens List).

- Fallbacks → board: `settingsDefaults`, collection-page `defaultMode`, `shareView` coerce, public-share owner-default, ItemDetail.
- Backend seeds: 12 `DefaultView: "list"` → `"board"`; Contacts (no `status`) gets `BoardGroupBy: relationship`.
- `buildCollectionUrlParams` always serializes `?view=` so a List selection on a board-default collection survives a copied link.
- E2E: three *list*-keyboard-nav pane specs pinned to `?view=list`.

## IDEA-2287 — Schema-aware: Board only when a groupable field exists
A blanket Board default put status-less collections (`--fields note:text`, a Contacts-style directory) into a single degenerate "Uncategorized" lane. Now the **defaulted** view is Board only when the board group field (`board_group_by`, default `status`) is a `select` field in the schema, else List. **Explicit choices are always respected** — only the unspecified case is schema-aware.

- Identical predicate both sides: `models.DefaultViewForSchema` + web `defaultViewForSchema` (select keyed to `board_group_by||status`; `multi_select` excluded, per `DoneFieldKey`). Guards malformed schemas (`[{}]`, `[null]`) and non-string/whitespace `board_group_by`.
- Wired at CLI `pad collection create` (`--default-view` defaults auto), server MCP `mapCollectionCreate`, browser **WebMCP** `collectionCreateSettings`, the create-modal picker (converging `$effect` + deterministic save-time recompute from `fieldDefs`), and the render/edit fallbacks (collection page, share page, EditCollectionModal — all detecting "unset" from raw settings, since `parseSettings` fills `default_view`). `board_group_by` normalized before derivation + persistence across all three create surfaces.

## Verification
- Gates: `go build` + Go tests (models/mcp/server/cmd), `svelte-check` (0 errors), full vitest (incl. new helper/WebMCP/normalization tests), web build.
- Runtime (in-browser + CLI): no-status→List, status→Board, explicit/`--default-view` respected, whitespace `board_group_by` normalized to `status`, settings-less API fallback→List, existing stored views unchanged, Edit modal on an unset status-less collection shows List (stored ideas/list, tasks/board unchanged), modal Blank→List + text-only save→List.
- Pane E2E green (the lone graph-test failure is a **pre-existing** flake — reproduced 3/5 at the IDEA-2274 baseline).
- **Codex review CLEAN** — IDEA-2274 (7 rounds) and IDEA-2287 (6 rounds), every finding fixed or a documented design decision.

Closes IDEA-2274, IDEA-2287.

https://claude.ai/code/session_01EZ6yr6pAUFb1uffan912ra