### PR TITLE
feat(web): define missing design-token families + zero-visual-change drift sweep (TASK-2291)

### DIFF
--- a/web/src/app.css
+++ b/web/src/app.css
@@ -20,6 +20,14 @@
 	--accent-orange: #fb923c;
 	--accent-gray: #9ca3af;
 	--accent-brown: #a8896c;
+	--accent-red: #ef4444;
+
+	/* Literal blue for categorical uses (status maps, charts, info badges).
+	   Stays blue even if the brand accent changes — see PLAN-2290. */
+	--status-blue: #4a9eff;
+
+	/* Text color on accent-filled surfaces (buttons, filled badges). */
+	--text-on-accent: #ffffff;
 
 	--status-draft: #666666;
 	--status-active: #4ade80;
@@ -49,6 +57,16 @@
 	--radius: 6px;
 	--radius-sm: 4px;
 	--radius-lg: 8px;
+
+	/* Elevation scale. Values match the long-standing inline fallbacks
+	   (ItemActionsMenu/LaneActionsMenu/BoardView/Modal) so defining them
+	   is behavior-preserving. Theme-invariant for now — PLAN-2290 PR B
+	   may tune per theme. */
+	--shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.12);
+	--shadow-md: 0 4px 12px rgba(0, 0, 0, 0.15);
+	--shadow-lg: 0 10px 30px rgba(0, 0, 0, 0.3);
+	--modal-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
+	--scrim: rgba(0, 0, 0, 0.5);
 }
 
 * {
@@ -614,6 +632,8 @@ dialog.attachment-image-lightbox .attachment-image-lightbox-close:hover {
 	--accent-orange: #ea580c;
 	--accent-gray: #6b7280;
 	--accent-brown: #92400e;
+	--accent-red: #ef4444;
+	--status-blue: #2563eb;
 	--status-draft: #999999;
 	--status-active: #16a34a;
 	--status-completed: #2563eb;
@@ -640,6 +660,8 @@ dialog.attachment-image-lightbox .attachment-image-lightbox-close:hover {
 		--accent-orange: #ea580c;
 		--accent-gray: #6b7280;
 		--accent-brown: #92400e;
+		--accent-red: #ef4444;
+		--status-blue: #2563eb;
 		--status-draft: #999999;
 		--status-active: #16a34a;
 		--status-completed: #2563eb;

--- a/web/src/lib/components/ChildChart.svelte
+++ b/web/src/lib/components/ChildChart.svelte
@@ -211,7 +211,7 @@
 						y1={0}
 						x2={chartData.todayX}
 						y2={chartH}
-						stroke="var(--accent-blue)"
+						stroke="var(--status-blue)"
 						stroke-width="1"
 						stroke-dasharray="4 3"
 						opacity="0.7"
@@ -220,7 +220,7 @@
 						x={chartData.todayX}
 						y={-6}
 						text-anchor="middle"
-						fill="var(--accent-blue)"
+						fill="var(--status-blue)"
 						font-size="10"
 						opacity="0.8"
 					>

--- a/web/src/lib/components/ChildItems.svelte
+++ b/web/src/lib/components/ChildItems.svelte
@@ -1098,8 +1098,8 @@
 
 	.error-msg {
 		padding: var(--space-2) var(--space-3);
-		background: color-mix(in srgb, var(--accent-red, #ef4444) 12%, transparent);
-		color: var(--accent-red, #ef4444);
+		background: color-mix(in srgb, var(--accent-red) 12%, transparent);
+		color: var(--accent-red);
 		border-radius: var(--radius);
 		font-size: 0.85em;
 	}

--- a/web/src/lib/components/OpenChildrenDialog.svelte
+++ b/web/src/lib/components/OpenChildrenDialog.svelte
@@ -285,7 +285,7 @@
 	}
 
 	.btn-danger {
-		background: var(--color-danger, #dc2626);
+		background: var(--accent-red);
 		color: white;
 	}
 	.btn-danger:hover {

--- a/web/src/lib/components/SSEStatusIndicator.svelte
+++ b/web/src/lib/components/SSEStatusIndicator.svelte
@@ -74,11 +74,11 @@
 
 	.sse-state-disconnected,
 	.sse-state-unauthorized {
-		color: var(--accent-red, #c0392b);
+		color: var(--accent-red);
 	}
 	.sse-state-disconnected .sse-state-dot,
 	.sse-state-unauthorized .sse-state-dot {
-		background: var(--accent-red, #c0392b);
+		background: var(--accent-red);
 	}
 
 	@keyframes sse-pulse {

--- a/web/src/lib/components/ShareDialog.svelte
+++ b/web/src/lib/components/ShareDialog.svelte
@@ -510,8 +510,8 @@
 	.error-msg {
 		margin-top: var(--space-2);
 		padding: var(--space-2) var(--space-3);
-		background: color-mix(in srgb, var(--accent-red, #ef4444) 12%, transparent);
-		color: var(--accent-red, #ef4444);
+		background: color-mix(in srgb, var(--accent-red) 12%, transparent);
+		color: var(--accent-red);
 		border-radius: var(--radius);
 		font-size: 0.82em;
 	}
@@ -598,9 +598,9 @@
 	}
 
 	.revoke-btn:hover:not(:disabled) {
-		color: var(--accent-red, #ef4444);
-		background: color-mix(in srgb, var(--accent-red, #ef4444) 10%, transparent);
-		border-color: color-mix(in srgb, var(--accent-red, #ef4444) 20%, transparent);
+		color: var(--accent-red);
+		background: color-mix(in srgb, var(--accent-red) 10%, transparent);
+		border-color: color-mix(in srgb, var(--accent-red) 20%, transparent);
 	}
 
 	.revoke-btn:disabled {

--- a/web/src/lib/components/admin/UserActivityTab.svelte
+++ b/web/src/lib/components/admin/UserActivityTab.svelte
@@ -339,7 +339,7 @@
 		text-align: center;
 	}
 	.state-msg.error {
-		color: #ef4444;
+		color: var(--accent-red);
 	}
 	.state-msg.empty {
 		font-style: italic;
@@ -415,7 +415,7 @@
 		padding: var(--space-3) 0 0;
 	}
 	.load-more-error {
-		color: #ef4444;
+		color: var(--accent-red);
 		font-size: 0.8rem;
 	}
 	.btn {

--- a/web/src/lib/components/admin/UserModal.svelte
+++ b/web/src/lib/components/admin/UserModal.svelte
@@ -218,8 +218,8 @@
 		font-size: 0.7rem;
 		padding: 2px 8px;
 		border-radius: var(--radius-sm);
-		background: color-mix(in srgb, #ef4444 15%, transparent);
-		color: #ef4444;
+		background: color-mix(in srgb, var(--accent-red) 15%, transparent);
+		color: var(--accent-red);
 	}
 	.user-modal-close {
 		background: transparent;

--- a/web/src/lib/components/admin/UserOverviewTab.svelte
+++ b/web/src/lib/components/admin/UserOverviewTab.svelte
@@ -299,7 +299,7 @@
 		color: #f59e0b;
 	}
 	.tile-cold .tile-value {
-		color: #ef4444;
+		color: var(--accent-red);
 	}
 	.tile-never .tile-value {
 		color: var(--text-muted);
@@ -357,7 +357,7 @@
 		text-align: center;
 	}
 	.state-msg.error {
-		color: #ef4444;
+		color: var(--accent-red);
 	}
 	.state-msg.empty {
 		font-style: italic;

--- a/web/src/lib/components/admin/UserSettingsForm.svelte
+++ b/web/src/lib/components/admin/UserSettingsForm.svelte
@@ -554,7 +554,7 @@
 	}
 	.hint.error,
 	.msg.error {
-		color: #ef4444;
+		color: var(--accent-red);
 	}
 	.msg {
 		font-size: 0.85rem;
@@ -614,11 +614,11 @@
 		filter: brightness(1.1);
 	}
 	.btn-danger {
-		color: #ef4444;
-		border-color: color-mix(in srgb, #ef4444 50%, transparent);
+		color: var(--accent-red);
+		border-color: color-mix(in srgb, var(--accent-red) 50%, transparent);
 	}
 	.btn-danger:hover {
-		background: color-mix(in srgb, #ef4444 10%, transparent);
+		background: color-mix(in srgb, var(--accent-red) 10%, transparent);
 	}
 	.btn-sub {
 		background: transparent;
@@ -676,9 +676,9 @@
 		flex-direction: column;
 		gap: var(--space-2);
 		padding: var(--space-3);
-		border: 1px solid color-mix(in srgb, #ef4444 30%, transparent);
+		border: 1px solid color-mix(in srgb, var(--accent-red) 30%, transparent);
 		border-radius: var(--radius);
-		background: color-mix(in srgb, #ef4444 5%, transparent);
+		background: color-mix(in srgb, var(--accent-red) 5%, transparent);
 	}
 	.confirm-text {
 		margin: 0;

--- a/web/src/lib/components/admin/UserWorkspacesTab.svelte
+++ b/web/src/lib/components/admin/UserWorkspacesTab.svelte
@@ -173,7 +173,7 @@
 		text-align: center;
 	}
 	.state-msg.error {
-		color: #ef4444;
+		color: var(--accent-red);
 	}
 	.state-msg.empty {
 		font-style: italic;

--- a/web/src/lib/components/collections/BoardView.svelte
+++ b/web/src/lib/components/collections/BoardView.svelte
@@ -944,7 +944,7 @@
 		background: var(--bg-primary);
 		border: 1px solid var(--accent-blue);
 		border-radius: var(--radius-md);
-		box-shadow: var(--shadow-sm, 0 1px 3px rgba(0, 0, 0, 0.12));
+		box-shadow: var(--shadow-sm);
 	}
 
 	.lane-draft-input {

--- a/web/src/lib/components/collections/CreateCollectionModal.svelte
+++ b/web/src/lib/components/collections/CreateCollectionModal.svelte
@@ -635,8 +635,8 @@
 
 	.error-banner {
 		padding: var(--space-2) var(--space-3);
-		background: color-mix(in srgb, var(--accent-red, #ef4444) 12%, transparent);
-		color: var(--accent-red, #ef4444);
+		background: color-mix(in srgb, var(--accent-red) 12%, transparent);
+		color: var(--accent-red);
 		border-radius: var(--radius);
 		font-size: 0.85em;
 	}

--- a/web/src/lib/components/collections/EditCollectionModal.svelte
+++ b/web/src/lib/components/collections/EditCollectionModal.svelte
@@ -941,8 +941,8 @@
 	.error-banner {
 		margin: var(--space-3) var(--space-6) 0;
 		padding: var(--space-2) var(--space-3);
-		background: color-mix(in srgb, var(--accent-red, #ef4444) 12%, transparent);
-		color: var(--accent-red, #ef4444);
+		background: color-mix(in srgb, var(--accent-red) 12%, transparent);
+		color: var(--accent-red);
 		border-radius: var(--radius);
 		font-size: 0.85em;
 		flex-shrink: 0;
@@ -1155,8 +1155,8 @@
 	.danger-zone {
 		margin-top: var(--space-6);
 		padding: var(--space-4);
-		background: color-mix(in srgb, #ef4444 6%, var(--bg-secondary));
-		border: 1px solid color-mix(in srgb, #ef4444 30%, var(--border));
+		background: color-mix(in srgb, var(--accent-red) 6%, var(--bg-secondary));
+		border: 1px solid color-mix(in srgb, var(--accent-red) 30%, var(--border));
 		border-radius: var(--radius);
 	}
 
@@ -1170,7 +1170,7 @@
 		font-weight: 600;
 		text-transform: uppercase;
 		letter-spacing: 0.05em;
-		color: #ef4444;
+		color: var(--accent-red);
 	}
 
 	.danger-zone-hint {
@@ -1183,9 +1183,9 @@
 	.btn-archive {
 		padding: var(--space-2) var(--space-4);
 		background: transparent;
-		border: 1px solid #ef4444;
+		border: 1px solid var(--accent-red);
 		border-radius: var(--radius);
-		color: #ef4444;
+		color: var(--accent-red);
 		font-size: 0.88em;
 		font-weight: 500;
 		cursor: pointer;
@@ -1193,7 +1193,7 @@
 	}
 
 	.btn-archive:hover {
-		background: #ef4444;
+		background: var(--accent-red);
 		color: #fff;
 	}
 
@@ -1210,7 +1210,7 @@
 	}
 
 	.danger-zone-confirm-msg strong {
-		color: #ef4444;
+		color: var(--accent-red);
 	}
 
 	.danger-zone-confirm-actions {
@@ -1220,8 +1220,8 @@
 
 	.btn-archive-confirm {
 		padding: var(--space-2) var(--space-4);
-		background: #ef4444;
-		border: 1px solid #ef4444;
+		background: var(--accent-red);
+		border: 1px solid var(--accent-red);
 		border-radius: var(--radius);
 		color: #fff;
 		font-size: 0.88em;

--- a/web/src/lib/components/collections/FieldEditor.svelte
+++ b/web/src/lib/components/collections/FieldEditor.svelte
@@ -679,8 +679,8 @@
 	}
 
 	.field-key-input.has-error {
-		border-color: var(--accent-red, #ef4444);
-		background: color-mix(in srgb, var(--accent-red, #ef4444) 4%, transparent);
+		border-color: var(--accent-red);
+		background: color-mix(in srgb, var(--accent-red) 4%, transparent);
 	}
 
 	.field-key-error,
@@ -691,7 +691,7 @@
 	}
 
 	.field-key-error {
-		color: var(--accent-red, #ef4444);
+		color: var(--accent-red);
 	}
 
 	.field-key-hint {
@@ -732,8 +732,8 @@
 	}
 
 	.field-remove-btn:hover {
-		color: var(--accent-red, #ef4444);
-		background: color-mix(in srgb, var(--accent-red, #ef4444) 10%, transparent);
+		color: var(--accent-red);
+		background: color-mix(in srgb, var(--accent-red) 10%, transparent);
 	}
 
 	/* ── Options area (select / multi_select) ──────────────────────────────── */
@@ -900,8 +900,8 @@
 	}
 
 	.option-remove-btn:hover {
-		color: var(--accent-red, #ef4444);
-		background: color-mix(in srgb, var(--accent-red, #ef4444) 10%, transparent);
+		color: var(--accent-red);
+		background: color-mix(in srgb, var(--accent-red) 10%, transparent);
 	}
 
 	.option-add-btn {
@@ -1083,7 +1083,7 @@
 	}
 
 	.advanced-clear:hover:not(:disabled) {
-		color: var(--accent-red, #ef4444);
+		color: var(--accent-red);
 	}
 
 	.advanced-clear:disabled {

--- a/web/src/lib/components/collections/ItemActionsMenu.svelte
+++ b/web/src/lib/components/collections/ItemActionsMenu.svelte
@@ -283,7 +283,7 @@
 		background: var(--bg-primary);
 		border: 1px solid var(--border);
 		border-radius: var(--radius-md);
-		box-shadow: var(--shadow-md, 0 4px 12px rgba(0, 0, 0, 0.15));
+		box-shadow: var(--shadow-md);
 		display: flex;
 		flex-direction: column;
 		gap: 2px;

--- a/web/src/lib/components/collections/ItemCard.svelte
+++ b/web/src/lib/components/collections/ItemCard.svelte
@@ -96,7 +96,7 @@
 		switch (state?.toUpperCase()) {
 			case 'OPEN': return 'var(--accent-green)';
 			case 'MERGED': return 'var(--accent-purple, #8b5cf6)';
-			case 'CLOSED': return 'var(--accent-red, #ef4444)';
+			case 'CLOSED': return 'var(--accent-red)';
 			case 'DRAFT': return 'var(--text-muted)';
 			default: return 'var(--text-muted)';
 		}

--- a/web/src/lib/components/collections/LaneActionsMenu.svelte
+++ b/web/src/lib/components/collections/LaneActionsMenu.svelte
@@ -296,7 +296,7 @@
 		background: var(--bg-primary);
 		border: 1px solid var(--border);
 		border-radius: var(--radius-md);
-		box-shadow: var(--shadow-md, 0 4px 12px rgba(0, 0, 0, 0.15));
+		box-shadow: var(--shadow-md);
 		display: flex;
 		flex-direction: column;
 		gap: 2px;
@@ -322,11 +322,11 @@
 	}
 
 	.lane-menu-item.lmi-danger {
-		color: var(--accent-red, #ef4444);
+		color: var(--accent-red);
 	}
 
 	.lane-menu-item.lmi-danger:hover {
-		background: color-mix(in srgb, var(--accent-red, #ef4444) 10%, transparent);
+		background: color-mix(in srgb, var(--accent-red) 10%, transparent);
 	}
 
 	.lmi-icon {
@@ -391,7 +391,7 @@
 	.lmc-yes {
 		flex: 1;
 		padding: 6px 10px;
-		background: var(--accent-red, #ef4444);
+		background: var(--accent-red);
 		border: none;
 		border-radius: var(--radius-sm);
 		color: #fff;

--- a/web/src/lib/components/collections/ListView.svelte
+++ b/web/src/lib/components/collections/ListView.svelte
@@ -470,7 +470,7 @@
 	.archive-yes {
 		background: none;
 		border: none;
-		color: var(--accent-red, #ef4444);
+		color: var(--accent-red);
 		font-size: 0.78em;
 		cursor: pointer;
 		padding: 2px 6px;
@@ -479,7 +479,7 @@
 	}
 
 	.archive-yes:hover {
-		background: color-mix(in srgb, var(--accent-red, #ef4444) 10%, transparent);
+		background: color-mix(in srgb, var(--accent-red) 10%, transparent);
 	}
 
 	.archive-no {

--- a/web/src/lib/components/collections/QuickActionsEditor.svelte
+++ b/web/src/lib/components/collections/QuickActionsEditor.svelte
@@ -372,8 +372,8 @@
 	}
 
 	.qa-remove-btn:hover {
-		color: var(--accent-red, #ef4444);
-		background: color-mix(in srgb, var(--accent-red, #ef4444) 10%, transparent);
+		color: var(--accent-red);
+		background: color-mix(in srgb, var(--accent-red) 10%, transparent);
 	}
 
 	.qa-reorder-btn:disabled {
@@ -457,8 +457,8 @@
 	}
 
 	.qa-seg-unknown {
-		color: var(--accent-red, #ef4444);
-		background: color-mix(in srgb, var(--accent-red, #ef4444) 14%, transparent);
+		color: var(--accent-red);
+		background: color-mix(in srgb, var(--accent-red) 14%, transparent);
 		padding: 0 2px;
 		border-radius: 2px;
 		text-decoration: underline wavy currentColor;

--- a/web/src/lib/components/collections/TagFilter.svelte
+++ b/web/src/lib/components/collections/TagFilter.svelte
@@ -81,8 +81,8 @@
 		background: var(--bg-hover, var(--bg-tertiary));
 	}
 	.tag-chip.active {
-		background: var(--accent-blue, #3b82f6);
-		border-color: var(--accent-blue, #3b82f6);
+		background: var(--accent-blue);
+		border-color: var(--accent-blue);
 		color: #fff;
 		font-weight: 600;
 	}

--- a/web/src/lib/components/comments/CommentThread.svelte
+++ b/web/src/lib/components/comments/CommentThread.svelte
@@ -237,8 +237,8 @@
 
 	.error-msg {
 		padding: var(--space-2) var(--space-3);
-		background: color-mix(in srgb, var(--accent-red, #ef4444) 12%, transparent);
-		color: var(--accent-red, #ef4444);
+		background: color-mix(in srgb, var(--accent-red) 12%, transparent);
+		color: var(--accent-red);
 		border-radius: var(--radius);
 		font-size: 0.85em;
 	}
@@ -331,8 +331,8 @@
 	}
 
 	.delete-btn:hover {
-		color: var(--accent-red, #ef4444);
-		background: color-mix(in srgb, var(--accent-red, #ef4444) 10%, transparent);
+		color: var(--accent-red);
+		background: color-mix(in srgb, var(--accent-red) 10%, transparent);
 	}
 
 	.delete-btn:disabled {

--- a/web/src/lib/components/common/Modal.svelte
+++ b/web/src/lib/components/common/Modal.svelte
@@ -152,7 +152,7 @@
 		background: var(--modal-bg, var(--bg-secondary));
 		border: var(--modal-border, 1px solid var(--border));
 		border-radius: var(--modal-radius, var(--radius-lg));
-		box-shadow: var(--modal-shadow, 0 20px 60px rgba(0, 0, 0, 0.5));
+		box-shadow: var(--modal-shadow);
 	}
 
 	/* The dialog is always mounted (visibility driven by showModal()/close()).

--- a/web/src/lib/components/common/NotificationPanel.svelte
+++ b/web/src/lib/components/common/NotificationPanel.svelte
@@ -20,8 +20,8 @@
 	function dotColor(type: HistoryEntry['type']): string {
 		switch (type) {
 			case 'success': return 'var(--accent-green)';
-			case 'error': return 'var(--accent-red, #ef4444)';
-			case 'info': return 'var(--accent-blue)';
+			case 'error': return 'var(--accent-red)';
+			case 'info': return 'var(--status-blue)';
 		}
 	}
 

--- a/web/src/lib/components/common/ToastContainer.svelte
+++ b/web/src/lib/components/common/ToastContainer.svelte
@@ -100,10 +100,10 @@
 	}
 
 	.toast-error {
-		border-left: 3px solid var(--accent-red, #ef4444);
+		border-left: 3px solid var(--accent-red);
 	}
 	.toast-error .toast-icon {
-		color: var(--accent-red, #ef4444);
+		color: var(--accent-red);
 	}
 
 	.toast-info {

--- a/web/src/lib/components/editor/Editor.svelte
+++ b/web/src/lib/components/editor/Editor.svelte
@@ -1585,7 +1585,7 @@
 		color: var(--accent-blue);
 	}
 	:global(.block-menu-item-danger) {
-		color: #ef4444;
+		color: var(--accent-red);
 	}
 	:global(.block-menu-item-danger:hover) {
 		background: rgba(239, 68, 68, 0.1);
@@ -2005,7 +2005,7 @@
 	}
 	.tt-btn-danger:hover {
 		background: rgba(239, 68, 68, 0.1);
-		color: #ef4444;
+		color: var(--accent-red);
 	}
 	.tt-sep {
 		width: 1px;

--- a/web/src/lib/components/editor/EditorBubbleMenu.svelte
+++ b/web/src/lib/components/editor/EditorBubbleMenu.svelte
@@ -439,7 +439,7 @@
 
 	.form-error {
 		font-size: 0.8em;
-		color: #ef4444;
+		color: var(--accent-red);
 		padding: 0 var(--space-1);
 	}
 </style>

--- a/web/src/lib/components/editor/EditorLinkPopover.svelte
+++ b/web/src/lib/components/editor/EditorLinkPopover.svelte
@@ -397,7 +397,7 @@
 
 	.link-btn-danger:hover {
 		background: rgba(239, 68, 68, 0.1);
-		color: #ef4444;
+		color: var(--accent-red);
 	}
 
 	.link-edit {

--- a/web/src/lib/components/fields/FieldEditor.svelte
+++ b/web/src/lib/components/fields/FieldEditor.svelte
@@ -62,8 +62,8 @@ handlers — onchange is never called.
 	let dropdownEl: HTMLDivElement | undefined = $state(undefined);
 
 	const STATUS_COLORS: Record<string, string> = {
-		open: 'var(--accent-blue)',
-		new: 'var(--accent-blue)',
+		open: 'var(--status-blue)',
+		new: 'var(--status-blue)',
 		in_progress: 'var(--accent-amber)',
 		active: 'var(--accent-green)',
 		done: 'var(--accent-green)',
@@ -73,7 +73,7 @@ handlers — onchange is never called.
 		rejected: 'var(--accent-orange)',
 		critical: 'var(--accent-orange)',
 		high: 'var(--accent-amber)',
-		medium: 'var(--accent-blue)',
+		medium: 'var(--status-blue)',
 		low: 'var(--text-muted)',
 		draft: 'var(--text-muted)',
 		closed: 'var(--text-muted)',

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -5698,9 +5698,9 @@
 	.collab-state-reconnecting .collab-state-dot {
 		background: var(--accent-yellow, #d4a017);
 	}
-	.collab-state-offline { color: var(--accent-red, #c0392b); }
+	.collab-state-offline { color: var(--accent-red); }
 	.collab-state-offline .collab-state-dot {
-		background: var(--accent-red, #c0392b);
+		background: var(--accent-red);
 	}
 
 	/* Layout variants */

--- a/web/src/lib/components/layout/Sidebar.svelte
+++ b/web/src/lib/components/layout/Sidebar.svelte
@@ -1215,7 +1215,7 @@
 		min-width: 16px;
 		height: 16px;
 		padding: 0 4px;
-		background: var(--accent-red, #ef4444);
+		background: var(--accent-red);
 		color: #fff;
 		font-size: 0.65em;
 		font-weight: 700;

--- a/web/src/lib/components/search/CommandPalette.svelte
+++ b/web/src/lib/components/search/CommandPalette.svelte
@@ -722,7 +722,7 @@
 		if (['done', 'completed', 'fixed', 'implemented', 'resolved'].includes(s))
 			return 'var(--accent-green)';
 		if (['in_progress', 'exploring', 'fixing'].includes(s)) return 'var(--accent-amber)';
-		if (['open', 'new', 'draft', 'todo', 'planned'].includes(s)) return 'var(--accent-blue)';
+		if (['open', 'new', 'draft', 'todo', 'planned'].includes(s)) return 'var(--status-blue)';
 		if (s === 'active') return 'var(--accent-cyan)';
 		return 'var(--text-muted)';
 	}

--- a/web/src/lib/components/settings/StorageTab.svelte
+++ b/web/src/lib/components/settings/StorageTab.svelte
@@ -482,13 +482,13 @@
 	}
 
 	.btn-remove {
-		color: #ef4444;
+		color: var(--accent-red);
 		border-color: transparent;
 		background: none;
 	}
 
 	.btn-remove:hover {
-		background: color-mix(in srgb, #ef4444 15%, transparent);
+		background: color-mix(in srgb, var(--accent-red) 15%, transparent);
 	}
 
 	.role-select {
@@ -568,7 +568,7 @@
 	}
 
 	.usage-fill.crit {
-		background: color-mix(in srgb, #ef4444 85%, transparent);
+		background: color-mix(in srgb, var(--accent-red) 85%, transparent);
 	}
 
 	.usage-subline {
@@ -675,8 +675,8 @@
 		margin-left: var(--space-1);
 		font-size: 0.7em;
 		text-transform: uppercase;
-		color: #ef4444;
-		background: color-mix(in srgb, #ef4444 12%, transparent);
+		color: var(--accent-red);
+		background: color-mix(in srgb, var(--accent-red) 12%, transparent);
 		padding: 0 var(--space-1);
 		border-radius: var(--radius-sm);
 	}

--- a/web/src/lib/components/timeline/ItemTimeline.svelte
+++ b/web/src/lib/components/timeline/ItemTimeline.svelte
@@ -617,10 +617,10 @@
 
 	.error {
 		padding: var(--space-2) var(--space-3);
-		background: color-mix(in srgb, var(--accent-red, #ef4444) 10%, transparent);
-		border: 1px solid color-mix(in srgb, var(--accent-red, #ef4444) 30%, transparent);
+		background: color-mix(in srgb, var(--accent-red) 10%, transparent);
+		border: 1px solid color-mix(in srgb, var(--accent-red) 30%, transparent);
 		border-radius: var(--radius);
-		color: var(--accent-red, #ef4444);
+		color: var(--accent-red);
 		font-size: 0.85em;
 	}
 

--- a/web/src/lib/components/versions/DiffView.svelte
+++ b/web/src/lib/components/versions/DiffView.svelte
@@ -371,7 +371,7 @@
 	}
 
 	.label-old {
-		color: var(--accent-red, #ef4444);
+		color: var(--accent-red);
 	}
 
 	.label-new {
@@ -401,8 +401,8 @@
 	}
 
 	.stat-removed {
-		color: var(--accent-red, #ef4444);
-		background: color-mix(in srgb, var(--accent-red, #ef4444) 12%, transparent);
+		color: var(--accent-red);
+		background: color-mix(in srgb, var(--accent-red) 12%, transparent);
 	}
 
 	.stat-none {
@@ -439,12 +439,12 @@
 	}
 
 	.diff-line.removed {
-		background: color-mix(in srgb, var(--accent-red, #ef4444) 10%, var(--bg-primary, #1a1a1a));
+		background: color-mix(in srgb, var(--accent-red) 10%, var(--bg-primary, #1a1a1a));
 	}
 
 	.diff-line.removed .line-content,
 	.diff-line.removed .line-prefix {
-		color: var(--accent-red, #ef4444);
+		color: var(--accent-red);
 	}
 
 	.line-num {
@@ -528,7 +528,7 @@
 		font-weight: 600;
 	}
 	.html-block-chunk-stat-removed {
-		color: var(--accent-red, #ef4444);
+		color: var(--accent-red);
 		font-weight: 600;
 	}
 	.html-block-chunk-lines {

--- a/web/src/lib/components/versions/VersionHistory.svelte
+++ b/web/src/lib/components/versions/VersionHistory.svelte
@@ -430,8 +430,8 @@
 
 	.error-msg {
 		padding: var(--space-2) var(--space-3);
-		background: color-mix(in srgb, var(--accent-red, #ef4444) 12%, transparent);
-		color: var(--accent-red, #ef4444);
+		background: color-mix(in srgb, var(--accent-red) 12%, transparent);
+		color: var(--accent-red);
 		border-radius: var(--radius);
 		font-size: 0.85em;
 	}

--- a/web/src/routes/[username]/[workspace]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/+page.svelte
@@ -263,7 +263,7 @@
 		const s = status.toLowerCase().replace(/-/g, '_');
 		if (['done', 'completed', 'fixed', 'implemented', 'resolved'].includes(s)) return 'var(--accent-green)';
 		if (['in_progress', 'exploring', 'fixing', 'confirmed', 'in_review'].includes(s)) return 'var(--accent-amber)';
-		if (['open', 'new', 'draft', 'todo', 'planned'].includes(s)) return 'var(--accent-blue)';
+		if (['open', 'new', 'draft', 'todo', 'planned'].includes(s)) return 'var(--status-blue)';
 		if (['cancelled', 'rejected', 'wontfix'].includes(s)) return 'var(--accent-gray)';
 		if (s === 'active') return 'var(--accent-cyan)';
 		if (['archived', 'disabled', 'deprecated'].includes(s)) return 'var(--text-muted)';
@@ -653,7 +653,7 @@
 							{:else if activity.source === 'cli'}
 								<span class="actor-badge cli">cli</span>
 							{/if}
-							<span class="activity-dot" style="color: {activity.action === 'created' ? 'var(--accent-green)' : activity.action === 'archived' ? 'var(--text-muted)' : 'var(--accent-blue)'};">{activityIcon(activity.action)}</span>
+							<span class="activity-dot" style="color: {activity.action === 'created' ? 'var(--accent-green)' : activity.action === 'archived' ? 'var(--text-muted)' : 'var(--status-blue)'};">{activityIcon(activity.action)}</span>
 							<span class="activity-verb">{activityVerb(activity.action)}</span>
 							{#if activity.item_ref}
 								<span class="activity-ref">{activity.item_ref}</span>

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -3380,7 +3380,7 @@
 	maxWidth="360px"
 	placement="center"
 	--modal-bg="var(--bg-primary)"
-	--modal-shadow="var(--shadow-lg, 0 10px 30px rgba(0, 0, 0, 0.3))"
+	--modal-shadow="var(--shadow-lg)"
 >
 	{#if showLeaveDialog}
 		<div class="leave-dialog">
@@ -3433,8 +3433,8 @@
 	}
 	.leave-discard {
 		background: none;
-		border-color: var(--accent-red, #ef4444) !important;
-		color: var(--accent-red, #ef4444);
+		border-color: var(--accent-red) !important;
+		color: var(--accent-red);
 	}
 	.leave-save {
 		background: var(--accent-blue);

--- a/web/src/routes/[username]/[workspace]/activity/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/activity/+page.svelte
@@ -207,7 +207,7 @@
 			case 'moved':
 				return 'var(--accent-amber)';
 			default:
-				return 'var(--accent-blue)';
+				return 'var(--status-blue)';
 		}
 	}
 

--- a/web/src/routes/[username]/[workspace]/conventions/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/conventions/+page.svelte
@@ -745,8 +745,8 @@
 	.btn-secondary { background: var(--bg-tertiary); color: var(--text-primary); border: 1px solid var(--border); }
 	.btn-secondary:hover { background: var(--bg-hover); text-decoration: none; }
 	.btn-small { padding: 2px var(--space-3); font-size: 0.8em; }
-	.btn-danger { background: #dc2626; color: #fff; }
-	.btn-danger-outline { background: none; color: #dc2626; border: 1px solid #dc2626; }
+	.btn-danger { background: var(--accent-red); color: #fff; }
+	.btn-danger-outline { background: none; color: var(--accent-red); border: 1px solid var(--accent-red); }
 	.btn-danger-outline:hover { background: rgba(220,38,38,0.1); }
 
 	/* Create form */
@@ -825,7 +825,7 @@
 	.edit-textarea { width: 100%; padding: var(--space-2) var(--space-3); background: var(--bg-tertiary); border: 1px solid var(--border); border-radius: var(--radius); color: var(--text-primary); font-size: 0.85em; font-family: inherit; line-height: 1.6; resize: vertical; margin-bottom: var(--space-3); box-sizing: border-box; }
 	.edit-textarea:focus { border-color: var(--accent-blue); outline: none; }
 	.edit-hint { font-size: 0.75em; color: var(--text-muted); margin-left: auto; }
-	.confirm-text { font-size: 0.8em; color: #dc2626; }
+	.confirm-text { font-size: 0.8em; color: var(--accent-red); }
 
 	@media (max-width: 640px) {
 		.page-header { flex-direction: column; }

--- a/web/src/routes/[username]/[workspace]/insights/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/insights/+page.svelte
@@ -1005,7 +1005,7 @@
 		color: var(--accent-green);
 	}
 	.stat-value.negative {
-		color: var(--accent-red, #ef4444);
+		color: var(--accent-red);
 	}
 
 	/* ── Cards ────────────────────────────────────────────────────────── */

--- a/web/src/routes/[username]/[workspace]/insights/print/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/insights/print/+page.svelte
@@ -569,7 +569,7 @@
 		color: var(--accent-green);
 	}
 	.stat-value.negative {
-		color: var(--accent-red, #ef4444);
+		color: var(--accent-red);
 	}
 
 	/* ── Blocks ──────────────────────────────────────────────────────────── */

--- a/web/src/routes/[username]/[workspace]/settings/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/settings/+page.svelte
@@ -912,8 +912,8 @@
 	}
 	.tab-icon { font-size: 0.9em; }
 	.tab.danger { color: var(--text-muted); }
-	.tab.danger:hover { color: #ef4444; }
-	.tab.danger.active { color: #ef4444; border-bottom-color: #ef4444; }
+	.tab.danger:hover { color: var(--accent-red); }
+	.tab.danger.active { color: var(--accent-red); border-bottom-color: var(--accent-red); }
 	/* ── Sections ──── */
 	.section { margin-bottom: var(--space-8); }
 	.section h2 { font-size: 1.1em; color: var(--text-secondary); margin-bottom: var(--space-4); }
@@ -965,7 +965,7 @@
 	.context-editor:focus { outline: none; border-color: var(--accent-blue); }
 	.context-help { margin: 0; font-size: 0.8em; color: var(--text-muted); }
 	.context-help code { font-family: var(--font-mono); font-size: 0.95em; }
-	.context-error { margin: 0; font-size: 0.82em; color: #ef4444; }
+	.context-error { margin: 0; font-size: 0.82em; color: var(--accent-red); }
 	.context-actions { display: flex; flex-wrap: wrap; align-items: center; gap: var(--space-2); }
 	/* ── Members ──── */
 	.members-list { display: flex; flex-direction: column; }
@@ -978,8 +978,8 @@
 	.member-actions { display: flex; align-items: center; gap: var(--space-2); flex-shrink: 0; }
 	.role-select { background: var(--bg-tertiary); border: 1px solid var(--border); border-radius: var(--radius-sm); padding: var(--space-1) var(--space-2); font-size: 0.8em; color: var(--text-primary); cursor: pointer; }
 	.role-badge { font-size: 0.8em; background: var(--bg-tertiary); color: var(--text-secondary); padding: 2px 10px; border-radius: 10px; }
-	.btn-remove { color: #ef4444; border-color: transparent; background: none; }
-	.btn-remove:hover { background: color-mix(in srgb, #ef4444 15%, transparent); }
+	.btn-remove { color: var(--accent-red); border-color: transparent; background: none; }
+	.btn-remove:hover { background: color-mix(in srgb, var(--accent-red) 15%, transparent); }
 	/* ── Collection Access ──── */
 	.member-card-wrapper { display: flex; flex-direction: column; }
 	.member-card-wrapper + .member-card-wrapper { margin-top: var(--space-3); }
@@ -1017,25 +1017,25 @@
 	.invite-row input { flex: 1; min-width: 180px; max-width: 300px; }
 	.invite-result { font-size: 0.82em; margin-top: var(--space-2); }
 	.invite-success { color: var(--accent-green); }
-	.invite-error { color: #ef4444; }
+	.invite-error { color: var(--accent-red); }
 	/* ── Danger Zone ──── */
-	.danger-banner { background: color-mix(in srgb, #ef4444 8%, var(--bg-secondary)); border: 1px solid color-mix(in srgb, #ef4444 25%, var(--border)); border-radius: var(--radius); padding: var(--space-3) var(--space-4); margin-bottom: var(--space-4); }
-	.danger-banner p { font-size: 0.88em; color: #ef4444; margin: 0; }
-	.danger-card { border-color: color-mix(in srgb, #ef4444 30%, var(--border)); }
+	.danger-banner { background: color-mix(in srgb, var(--accent-red) 8%, var(--bg-secondary)); border: 1px solid color-mix(in srgb, var(--accent-red) 25%, var(--border)); border-radius: var(--radius); padding: var(--space-3) var(--space-4); margin-bottom: var(--space-4); }
+	.danger-banner p { font-size: 0.88em; color: var(--accent-red); margin: 0; }
+	.danger-card { border-color: color-mix(in srgb, var(--accent-red) 30%, var(--border)); }
 	.danger-row { display: flex; align-items: center; justify-content: space-between; gap: var(--space-4); }
 	.danger-info { flex: 1; }
 	.danger-info strong { font-size: 0.9em; }
 	.danger-info p { font-size: 0.8em; color: var(--text-muted); margin: var(--space-1) 0 0; }
-	.btn-danger { padding: var(--space-2) var(--space-4); background: none; border: 1px solid #ef4444; border-radius: var(--radius); color: #ef4444; font-size: 0.85em; cursor: pointer; white-space: nowrap; font-weight: 500; }
-	.btn-danger:hover:not(:disabled) { background: #ef4444; color: #fff; }
+	.btn-danger { padding: var(--space-2) var(--space-4); background: none; border: 1px solid var(--accent-red); border-radius: var(--radius); color: var(--accent-red); font-size: 0.85em; cursor: pointer; white-space: nowrap; font-weight: 500; }
+	.btn-danger:hover:not(:disabled) { background: var(--accent-red); color: #fff; }
 	.btn-danger:disabled { opacity: 0.4; cursor: not-allowed; }
 	.danger-confirm { display: flex; flex-direction: column; gap: var(--space-3); }
 	.danger-warning { font-size: 0.88em; color: var(--text-primary); margin: 0; }
-	.danger-warning strong { color: #ef4444; }
+	.danger-warning strong { color: var(--accent-red); }
 	.danger-input-row { display: flex; align-items: center; gap: var(--space-2); flex-wrap: wrap; }
 	.slug-hint { font-size: 0.82em; padding: var(--space-1) var(--space-2); background: var(--bg-tertiary); border-radius: var(--radius-sm); color: var(--text-muted); font-family: var(--font-mono); }
 	.danger-input { flex: 1; min-width: 180px; max-width: 300px; padding: var(--space-2); font-size: 0.88em; background: var(--bg-tertiary); border: 1px solid var(--border); border-radius: var(--radius); color: var(--text-primary); font-family: var(--font-mono); }
-	.danger-input:focus { outline: none; border-color: #ef4444; }
+	.danger-input:focus { outline: none; border-color: var(--accent-red); }
 	.danger-actions { display: flex; gap: var(--space-2); }
 	.section-desc { font-size: 0.85em; color: var(--text-muted); margin-bottom: var(--space-3); }
 </style>

--- a/web/src/routes/auth/cli/[code]/+page.svelte
+++ b/web/src/routes/auth/cli/[code]/+page.svelte
@@ -219,13 +219,13 @@
 	}
 
 	.error-message {
-		color: #ef4444;
+		color: var(--accent-red);
 		font-size: 0.85rem;
 		line-height: 1.5;
 	}
 
 	.error {
-		color: #ef4444;
+		color: var(--accent-red);
 		font-size: 0.85rem;
 		text-align: left;
 		margin-bottom: var(--space-4);

--- a/web/src/routes/console/+page.svelte
+++ b/web/src/routes/console/+page.svelte
@@ -146,7 +146,7 @@
 	}
 
 	.error-msg {
-		color: #ef4444;
+		color: var(--accent-red);
 		padding: var(--space-6);
 		background: var(--bg-secondary);
 		border: 1px solid var(--border);

--- a/web/src/routes/console/admin/+layout.svelte
+++ b/web/src/routes/console/admin/+layout.svelte
@@ -95,7 +95,7 @@
 		color: var(--text-muted); padding: var(--space-10) 0; text-align: center; font-size: 0.95rem;
 	}
 	.error-msg {
-		color: #ef4444; padding: var(--space-6); background: var(--bg-secondary);
+		color: var(--accent-red); padding: var(--space-6); background: var(--bg-secondary);
 		border: 1px solid var(--border); border-radius: var(--radius);
 	}
 

--- a/web/src/routes/console/admin/+page.svelte
+++ b/web/src/routes/console/admin/+page.svelte
@@ -636,8 +636,8 @@
 	   active). "active" never renders; the other three call out something
 	   actionable. PLAN-1542 / TASK-1548. */
 	.badge.status-disabled {
-		background: color-mix(in srgb, #ef4444 15%, transparent);
-		color: #ef4444;
+		background: color-mix(in srgb, var(--accent-red) 15%, transparent);
+		color: var(--accent-red);
 		margin-left: var(--space-2);
 	}
 	.badge.status-no-workspace {
@@ -660,7 +660,7 @@
 	/* Last-write recency coloring — see writeRecency() in the script. */
 	.date-cell.write-recent { color: #10b981; }
 	.date-cell.write-stale { color: #f59e0b; }
-	.date-cell.write-cold { color: #ef4444; }
+	.date-cell.write-cold { color: var(--accent-red); }
 	.date-cell.write-never {
 		color: var(--text-muted);
 		font-style: italic;
@@ -686,7 +686,7 @@
 		font-size: 0.9rem;
 	}
 	.error-msg {
-		color: #ef4444;
+		color: var(--accent-red);
 		padding: var(--space-6);
 		background: var(--bg-secondary);
 		border: 1px solid var(--border);

--- a/web/src/routes/console/admin/audit-log/+page.svelte
+++ b/web/src/routes/console/admin/audit-log/+page.svelte
@@ -401,8 +401,8 @@
 		color: var(--accent-green, #22c55e);
 	}
 	.badge.danger {
-		background: color-mix(in srgb, #ef4444 15%, transparent);
-		color: #ef4444;
+		background: color-mix(in srgb, var(--accent-red) 15%, transparent);
+		color: var(--accent-red);
 	}
 	.badge.warning {
 		background: color-mix(in srgb, #f59e0b 15%, transparent);
@@ -450,7 +450,7 @@
 		font-size: 0.9rem;
 	}
 	.error-msg {
-		color: #ef4444;
+		color: var(--accent-red);
 		padding: var(--space-6);
 		background: var(--bg-secondary);
 		border: 1px solid var(--border);

--- a/web/src/routes/console/admin/billing/+page.svelte
+++ b/web/src/routes/console/admin/billing/+page.svelte
@@ -206,7 +206,7 @@
 		font-size: 0.9rem;
 	}
 	.error-msg {
-		color: #ef4444;
+		color: var(--accent-red);
 		padding: var(--space-6);
 		background: var(--bg-secondary);
 		border: 1px solid var(--border);

--- a/web/src/routes/console/admin/invitations/+page.svelte
+++ b/web/src/routes/console/admin/invitations/+page.svelte
@@ -256,11 +256,11 @@
 		opacity: 0.9;
 	}
 	.btn.danger {
-		border-color: #ef4444;
-		color: #ef4444;
+		border-color: var(--accent-red);
+		color: var(--accent-red);
 	}
 	.btn.danger:hover {
-		background: color-mix(in srgb, #ef4444 10%, transparent);
+		background: color-mix(in srgb, var(--accent-red) 10%, transparent);
 	}
 	.btn:disabled {
 		opacity: 0.5;
@@ -366,7 +366,7 @@
 		font-size: 0.9rem;
 	}
 	.error-msg {
-		color: #ef4444;
+		color: var(--accent-red);
 		padding: var(--space-6);
 		background: var(--bg-secondary);
 		border: 1px solid var(--border);

--- a/web/src/routes/console/admin/mcp-audit/+page.svelte
+++ b/web/src/routes/console/admin/mcp-audit/+page.svelte
@@ -305,7 +305,7 @@
 
 	.badge.danger {
 		background: rgba(239, 68, 68, 0.15);
-		color: #dc2626;
+		color: var(--accent-red);
 	}
 
 	.error-kind {

--- a/web/src/routes/console/connected-apps/+page.svelte
+++ b/web/src/routes/console/connected-apps/+page.svelte
@@ -636,7 +636,7 @@
 	}
 
 	.error-msg {
-		color: #ef4444;
+		color: var(--accent-red);
 		padding: var(--space-4) var(--space-6);
 		background: var(--bg-secondary);
 		border: 1px solid var(--border);
@@ -764,7 +764,7 @@
 	.chip-any {
 		font-family: inherit;
 		background: rgba(59, 130, 246, 0.1);
-		color: var(--accent-blue, #3b82f6);
+		color: var(--accent-blue);
 		border-color: rgba(59, 130, 246, 0.3);
 	}
 
@@ -812,7 +812,7 @@
 		background: none;
 		border: none;
 		padding: 0;
-		color: var(--accent-blue, #3b82f6);
+		color: var(--accent-blue);
 		font-size: 0.8rem;
 		cursor: pointer;
 		font-weight: 500;
@@ -886,7 +886,7 @@
 
 	.badge.tier-blue {
 		background: rgba(59, 130, 246, 0.15);
-		color: var(--accent-blue, #3b82f6);
+		color: var(--accent-blue);
 	}
 
 	.badge.tier-orange {
@@ -917,13 +917,13 @@
 	}
 
 	.btn-danger {
-		color: #ef4444;
+		color: var(--accent-red);
 		border-color: rgba(239, 68, 68, 0.4);
 	}
 
 	.btn-danger:hover:not(:disabled) {
 		background: rgba(239, 68, 68, 0.1);
-		border-color: #ef4444;
+		border-color: var(--accent-red);
 	}
 
 	/* Modal — surface/backdrop/Escape come from the shared <Modal> primitive
@@ -951,7 +951,7 @@
 	.modal-error {
 		margin: 0;
 		font-size: 0.85rem;
-		color: #ef4444;
+		color: var(--accent-red);
 		padding: var(--space-2) var(--space-3);
 		background: rgba(239, 68, 68, 0.08);
 		border: 1px solid rgba(239, 68, 68, 0.3);

--- a/web/src/routes/console/deleted-workspaces/+page.svelte
+++ b/web/src/routes/console/deleted-workspaces/+page.svelte
@@ -169,7 +169,7 @@
 	}
 
 	.error-msg {
-		color: #ef4444;
+		color: var(--accent-red);
 		padding: var(--space-4) var(--space-6);
 		background: var(--bg-secondary);
 		border: 1px solid var(--border);
@@ -278,7 +278,7 @@
 
 	.days-badge.low {
 		background: rgba(239, 68, 68, 0.1);
-		color: #ef4444;
+		color: var(--accent-red);
 		border-color: rgba(239, 68, 68, 0.3);
 	}
 

--- a/web/src/routes/console/settings/+page.svelte
+++ b/web/src/routes/console/settings/+page.svelte
@@ -981,7 +981,7 @@
 	}
 
 	.error {
-		color: #ef4444;
+		color: var(--accent-red);
 		font-size: 0.85rem;
 	}
 
@@ -1133,8 +1133,8 @@
 	}
 
 	.delete-btn:hover {
-		color: #ef4444;
-		border-color: #ef4444;
+		color: var(--accent-red);
+		border-color: var(--accent-red);
 	}
 
 	.empty-text {
@@ -1295,9 +1295,9 @@
 		align-self: flex-start;
 		padding: var(--space-2) var(--space-4);
 		background: transparent;
-		border: 1px solid #ef4444;
+		border: 1px solid var(--accent-red);
 		border-radius: var(--radius);
-		color: #ef4444;
+		color: var(--accent-red);
 		font-size: 0.85rem;
 		font-weight: 500;
 		font-family: var(--font-ui);
@@ -1306,7 +1306,7 @@
 	}
 
 	.danger-btn:hover:not(:disabled) {
-		background: color-mix(in srgb, #ef4444 10%, transparent);
+		background: color-mix(in srgb, var(--accent-red) 10%, transparent);
 	}
 
 	.danger-btn:disabled {
@@ -1322,12 +1322,12 @@
 
 	/* Danger Zone (TASK-1961) — red header/border per the danger palette */
 	.danger-card {
-		border-color: color-mix(in srgb, #ef4444 40%, var(--border));
+		border-color: color-mix(in srgb, var(--accent-red) 40%, var(--border));
 	}
 
 	.danger-title {
-		color: #ef4444;
-		border-bottom-color: color-mix(in srgb, #ef4444 40%, var(--border));
+		color: var(--accent-red);
+		border-bottom-color: color-mix(in srgb, var(--accent-red) 40%, var(--border));
 	}
 
 	.danger-row {
@@ -1374,7 +1374,7 @@
 	}
 
 	.delete-warnings strong {
-		color: #ef4444;
+		color: var(--accent-red);
 	}
 
 	/* Inline "Export my data" link inside the delete confirm nudge (TASK-1962) */

--- a/web/src/routes/forgot-password/+page.svelte
+++ b/web/src/routes/forgot-password/+page.svelte
@@ -194,7 +194,7 @@
 	input:disabled { opacity: 0.6; }
 
 	.error {
-		color: #ef4444;
+		color: var(--accent-red);
 		font-size: 0.85rem;
 		text-align: left;
 	}

--- a/web/src/routes/join/[code]/+page.svelte
+++ b/web/src/routes/join/[code]/+page.svelte
@@ -465,7 +465,7 @@
 	}
 
 	.error-text {
-		color: #ef4444;
+		color: var(--accent-red);
 	}
 
 	.form {
@@ -503,7 +503,7 @@
 	}
 
 	.error {
-		color: #ef4444;
+		color: var(--accent-red);
 		font-size: 0.85rem;
 	}
 
@@ -582,6 +582,6 @@
 	}
 
 	.username-status.taken {
-		color: #ef4444;
+		color: var(--accent-red);
 	}
 </style>

--- a/web/src/routes/login/+page.svelte
+++ b/web/src/routes/login/+page.svelte
@@ -495,7 +495,7 @@
 	}
 
 	.error {
-		color: #ef4444;
+		color: var(--accent-red);
 		font-size: 0.85rem;
 		text-align: left;
 	}

--- a/web/src/routes/register/+page.svelte
+++ b/web/src/routes/register/+page.svelte
@@ -433,7 +433,7 @@
 	}
 
 	.error {
-		color: #ef4444;
+		color: var(--accent-red);
 		font-size: 0.85rem;
 		text-align: left;
 	}
@@ -515,7 +515,7 @@
 	}
 
 	.username-status.taken {
-		color: #ef4444;
+		color: var(--accent-red);
 	}
 
 	.verify-notice {

--- a/web/src/routes/reset-password/[token]/+page.svelte
+++ b/web/src/routes/reset-password/[token]/+page.svelte
@@ -169,7 +169,7 @@
 	input:disabled { opacity: 0.6; }
 
 	.error {
-		color: #ef4444;
+		color: var(--accent-red);
 		font-size: 0.85rem;
 		text-align: left;
 	}

--- a/web/src/routes/s/[token]/+page.svelte
+++ b/web/src/routes/s/[token]/+page.svelte
@@ -1005,7 +1005,7 @@
 	}
 
 	.password-error {
-		color: var(--accent-red, #e53e3e);
+		color: var(--accent-red);
 		font-size: 0.85em;
 		margin: 0;
 	}

--- a/web/src/routes/setup/+page.svelte
+++ b/web/src/routes/setup/+page.svelte
@@ -409,7 +409,7 @@
 	}
 
 	.error {
-		color: #ef4444;
+		color: var(--accent-red);
 		font-size: 0.85rem;
 		text-align: left;
 	}

--- a/web/src/routes/verify-email/[token]/+page.svelte
+++ b/web/src/routes/verify-email/[token]/+page.svelte
@@ -192,7 +192,7 @@
 	}
 
 	.error {
-		color: #ef4444;
+		color: var(--accent-red);
 		font-size: 0.85rem;
 		text-align: left;
 	}


### PR DESCRIPTION
Phase 1 / PR A of **PLAN-2290** (UI refresh — violet token system + component consolidation). Tracked by TASK-2291.

## What
Defines the token families the codebase already *references but never defined*, then mechanically migrates the drift literals onto them. **No intentional visual change** — PR B (the violet retheme) is where values change.

- `--accent-red` — was referenced 60× via `var(--accent-red, fallback)` but **never defined**; 3 bare `var(--accent-red)` sites resolved to nothing (broken danger styling — now fixed). All `#ef4444`/`#dc2626` literals migrated; `#c0392b`/`#e53e3e`/`#dc2626` outliers deliberately unify to `#ef4444`.
- `--status-blue` — literal blue for categorical uses. 10 sites repointed (status maps in FieldEditor/CommandPalette/workspace home/activity, ChildChart stroke+fill, NotificationPanel info) so the future brand-accent flip can't drag status colors.
- `--text-on-accent`, `--scrim` — defined for PR B adoption.
- `--shadow-sm/md/lg`, `--modal-shadow` — defined with values **byte-identical to the existing self-defensive fallbacks** (ItemActionsMenu, LaneActionsMenu, BoardView, Modal, collection page); fallback forms collapsed.
- Phantom `var(--color-danger, #dc2626)` (OpenChildrenDialog) repointed to `--accent-red`.

## Verification
- svelte-check: 0 errors · vitest: 488/488 · `make check` green
- Playwright before/after pixel diff, 4 surfaces × 2 themes: **identical except the sidebar build-id string** (62×8px bbox; ~0.03% of pixels)

## Follow-up
PR B introduces `--accent-primary` (violet) + aliases `--accent-blue` to it, retunes the neutral scale/card tokens/AA muted text per the token table in PLAN-2290.

## Codex review resolution
Codex (CLEAN otherwise) correctly noted the zero-change claim under-counted: defining previously-undefined tokens **activates four pre-existing bare `var()` sites** — all verified as intended fixes, now claimed explicitly:
- `TimelineActivityCard.svelte:143` — archived action label now renders red (matches its `.action-*` siblings)
- `TimelineCommentCard.svelte:485-486` — delete-button hover now renders red text + red tint
- `ItemDetail.svelte:5526` — 'Copied!' tooltip now white-on-green as authored (was inheriting)
- `[collection]/+page.svelte:3383` — leave-guard modal's `--modal-shadow="var(--shadow-lg)"` previously resolved invalid (no shadow); now renders `--shadow-lg`