### PR TITLE
feat(web): Chip primitive + canonical fieldColors util — 48 badge sites migrated (TASK-2292)

### DIFF
--- a/web/src/app.css
+++ b/web/src/app.css
@@ -20,6 +20,9 @@
 	--card-border: #363648;
 	--shadow-card: 0 2px 6px rgba(0, 0, 0, 0.35);
 
+	/* Tint strength for Chip/badge fills (color-mix percentage). */
+	--chip-alpha: 16%;
+
 	/* Brand accent. --accent-blue is aliased to it because ~95% of its 462
 	   call sites mean "brand accent", not "blue" (see PLAN-2290); the
 	   literally-blue categorical sites use --status-blue instead.
@@ -645,6 +648,7 @@ dialog.attachment-image-lightbox .attachment-image-lightbox-close:hover {
 	--card-bg: #ffffff;
 	--card-border: #d0d0dc;
 	--shadow-card: 0 1px 3px rgba(23, 23, 40, 0.1);
+	--chip-alpha: 12%;
 	--accent-primary: #7c3aed;
 	--accent-primary-soft: #8b5cf6;
 	--accent-blue: var(--accent-primary);
@@ -680,6 +684,7 @@ dialog.attachment-image-lightbox .attachment-image-lightbox-close:hover {
 		--card-bg: #ffffff;
 		--card-border: #d0d0dc;
 		--shadow-card: 0 1px 3px rgba(23, 23, 40, 0.1);
+	--chip-alpha: 12%;
 		--accent-primary: #7c3aed;
 		--accent-primary-soft: #8b5cf6;
 		--accent-blue: var(--accent-primary);

--- a/web/src/lib/components/admin/UserOverviewTab.svelte
+++ b/web/src/lib/components/admin/UserOverviewTab.svelte
@@ -11,6 +11,7 @@
 -->
 <script lang="ts">
 	import { adminFetch, type AdminUser } from '$lib/stores/admin.svelte';
+	import Chip from '$lib/components/common/Chip.svelte';
 
 	interface Props {
 		user: AdminUser;
@@ -147,8 +148,12 @@
 		<div class="vitals-email">{user.email}</div>
 	</div>
 	<div class="vitals-badges">
-		<span class="badge badge-role badge-{user.role || 'member'}">{user.role || 'member'}</span>
-		<span class="badge badge-plan badge-{user.plan || 'free'}">{user.plan || 'free'}</span>
+		<Chip color={(user.role || 'member') === 'admin' ? 'var(--accent-orange)' : 'var(--accent-gray)'}
+			>{user.role || 'member'}</Chip
+		>
+		<Chip color={(user.plan || 'free') === 'pro' ? 'var(--status-blue)' : 'var(--accent-gray)'}
+			>{user.plan || 'free'}</Chip
+		>
 		<span class="vitals-age">Joined {accountAge(user.created_at)}</span>
 	</div>
 </header>
@@ -255,22 +260,6 @@
 	.vitals-age {
 		font-size: 0.8rem;
 		color: var(--text-muted);
-	}
-	.badge {
-		padding: 2px 8px;
-		border-radius: var(--radius-sm);
-		font-size: 0.75rem;
-		background: color-mix(in srgb, var(--accent-gray, #888) 15%, transparent);
-		color: var(--text-muted);
-		text-transform: lowercase;
-	}
-	.badge.badge-admin {
-		background: color-mix(in srgb, var(--accent-orange, #f59e0b) 15%, transparent);
-		color: var(--accent-orange, #f59e0b);
-	}
-	.badge.badge-pro {
-		background: color-mix(in srgb, var(--accent-blue) 15%, transparent);
-		color: var(--accent-blue);
 	}
 	.tiles {
 		display: grid;

--- a/web/src/lib/components/admin/UserWorkspacesTab.svelte
+++ b/web/src/lib/components/admin/UserWorkspacesTab.svelte
@@ -8,6 +8,7 @@
 -->
 <script lang="ts">
 	import { adminFetch, type AdminUser } from '$lib/stores/admin.svelte';
+	import Chip from '$lib/components/common/Chip.svelte';
 
 	interface Props {
 		user: AdminUser;
@@ -148,7 +149,16 @@
 							</a>
 							<div class="ws-slug">{ws.workspace_slug}</div>
 						</td>
-						<td><span class="badge role-{ws.role}">{ws.role}</span></td>
+						<td>
+							<Chip
+								size="sm"
+								color={ws.role === 'owner'
+									? 'var(--accent-orange)'
+									: ws.role === 'editor'
+										? 'var(--status-blue)'
+										: 'var(--accent-gray)'}>{ws.role}</Chip
+							>
+						</td>
 						<td class="num">{ws.collections_count}</td>
 						<td class="num">{ws.items_open} / {ws.items_total}</td>
 						<td class="num">{ws.members_count}</td>
@@ -215,22 +225,6 @@
 	.ws-slug {
 		font-size: 0.75rem;
 		color: var(--text-muted);
-	}
-	.badge {
-		padding: 2px var(--space-2);
-		border-radius: var(--radius-sm);
-		font-size: 0.75rem;
-		background: color-mix(in srgb, var(--accent-gray, #888) 15%, transparent);
-		color: var(--text-muted);
-		text-transform: lowercase;
-	}
-	.badge.role-owner {
-		background: color-mix(in srgb, var(--accent-orange, #f59e0b) 15%, transparent);
-		color: var(--accent-orange, #f59e0b);
-	}
-	.badge.role-editor {
-		background: color-mix(in srgb, var(--accent-blue) 15%, transparent);
-		color: var(--accent-blue);
 	}
 	.show-all-btn {
 		display: block;

--- a/web/src/lib/components/collections/ItemCard.svelte
+++ b/web/src/lib/components/collections/ItemCard.svelte
@@ -6,6 +6,7 @@
 	import { starredStore } from '$lib/stores/starred.svelte';
 	import { copyToClipboard } from '$lib/utils/clipboard';
 	import { relativeTime } from '$lib/utils/markdown';
+	import { statusColor, priorityColor, formatFieldLabel as formatLabel } from '$lib/utils/fieldColors';
 	import ItemActionsMenu from './ItemActionsMenu.svelte';
 	import type { ReorderDirection } from '$lib/collections/reorder';
 	import { shouldOpenInPane } from './itemCardClick';
@@ -122,30 +123,6 @@
 		setTimeout(() => { pulsing = false; }, 300);
 
 		onStatusClick(item, nextStatus);
-	}
-
-	function statusColor(status: string): string {
-		switch (status) {
-			case 'open': return 'var(--text-secondary)';
-			case 'in_progress': return 'var(--accent-amber)';
-			case 'done': return 'var(--accent-green)';
-			case 'blocked': return 'var(--accent-orange)';
-			default: return 'var(--text-muted)';
-		}
-	}
-
-	function priorityColor(priority: string): string {
-		switch (priority) {
-			case 'critical': return 'var(--accent-orange)';
-			case 'high': return 'var(--accent-amber)';
-			case 'medium': return 'var(--text-secondary)';
-			case 'low': return 'var(--text-muted)';
-			default: return 'var(--text-muted)';
-		}
-	}
-
-	function formatLabel(value: string): string {
-		return value.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
 	}
 
 	function toggleStar(e: MouseEvent) {

--- a/web/src/lib/components/common/Chip.svelte
+++ b/web/src/lib/components/common/Chip.svelte
@@ -1,0 +1,105 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	interface Props {
+		/** CSS color (usually a `var(--...)` reference) driving text + tint. */
+		color?: string;
+		/** Render a leading dot in the chip color. */
+		dot?: boolean;
+		/** `sm` for dense rows (cards, table cells); `md` elsewhere. */
+		size?: 'sm' | 'md';
+		/** When provided the chip renders as a <button>. */
+		onclick?: (e: MouseEvent) => void;
+		title?: string;
+		/** Brief scale pulse — used by status click-cycling. */
+		pulse?: boolean;
+		children: Snippet;
+	}
+
+	let {
+		color = 'var(--accent-gray)',
+		dot = false,
+		size = 'md',
+		onclick,
+		title,
+		pulse = false,
+		children
+	}: Props = $props();
+</script>
+
+{#if onclick}
+	<button
+		type="button"
+		class="chip {size}"
+		class:pulse
+		style:--chip-c={color}
+		{title}
+		{onclick}
+	>
+		{#if dot}<span class="dot" aria-hidden="true"></span>{/if}
+		{@render children()}
+	</button>
+{:else}
+	<span class="chip {size}" class:pulse style:--chip-c={color} {title}>
+		{#if dot}<span class="dot" aria-hidden="true"></span>{/if}
+		{@render children()}
+	</span>
+{/if}
+
+<style>
+	.chip {
+		display: inline-flex;
+		align-items: center;
+		gap: 5px;
+		border: none;
+		border-radius: 6px;
+		font-weight: 500;
+		line-height: 1.5;
+		white-space: nowrap;
+		background: color-mix(in srgb, var(--chip-c) var(--chip-alpha, 16%), transparent);
+		color: var(--chip-c);
+	}
+
+	.chip.md {
+		padding: 2px 8px;
+		font-size: 0.85em;
+	}
+
+	.chip.sm {
+		padding: 1px 6px;
+		font-size: 0.8em;
+	}
+
+	button.chip {
+		cursor: pointer;
+		font-family: inherit;
+	}
+
+	button.chip:hover {
+		filter: brightness(1.15);
+	}
+
+	.dot {
+		width: 7px;
+		height: 7px;
+		border-radius: 50%;
+		background: currentColor;
+		flex: 0 0 7px;
+	}
+
+	.pulse {
+		animation: chip-pulse 0.3s ease;
+	}
+
+	@keyframes chip-pulse {
+		0% { transform: scale(1); }
+		50% { transform: scale(1.12); }
+		100% { transform: scale(1); }
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.pulse {
+			animation: none;
+		}
+	}
+</style>

--- a/web/src/lib/components/common/Chip.svelte
+++ b/web/src/lib/components/common/Chip.svelte
@@ -8,7 +8,12 @@
 		dot?: boolean;
 		/** `sm` for dense rows (cards, table cells); `md` elsewhere. */
 		size?: 'sm' | 'md';
-		/** When provided the chip renders as a <button>. */
+		/** When provided the chip renders as a <button>. The click always
+		 *  preventDefault()s (a chip is never a link — this stops a parent
+		 *  <a> card from navigating) but propagation continues so
+		 *  click-outside closers still see it; callers inside interactive
+		 *  cards should stopPropagation() in their handler if the card
+		 *  itself also handles clicks (house pattern, cf. ItemCard). */
 		onclick?: (e: MouseEvent) => void;
 		title?: string;
 		/** Brief scale pulse — used by status click-cycling. */
@@ -34,7 +39,10 @@
 		class:pulse
 		style:--chip-c={color}
 		{title}
-		{onclick}
+		onclick={(e) => {
+			e.preventDefault();
+			onclick?.(e);
+		}}
 	>
 		{#if dot}<span class="dot" aria-hidden="true"></span>{/if}
 		{@render children()}

--- a/web/src/lib/components/fields/FieldEditor.svelte
+++ b/web/src/lib/components/fields/FieldEditor.svelte
@@ -18,6 +18,7 @@ handlers — onchange is never called.
 	import type { FieldDef } from '$lib/types';
 	import BottomSheet from '$lib/components/common/BottomSheet.svelte';
 	import { viewport } from '$lib/stores/breakpoint.svelte';
+	import { statusColor, priorityColor, hasCanonicalStatus, formatFieldLabel as formatLabel } from '$lib/utils/fieldColors';
 
 	interface Props {
 		field: FieldDef;
@@ -61,33 +62,15 @@ handlers — onchange is never called.
 	let triggerEl: HTMLButtonElement | undefined = $state(undefined);
 	let dropdownEl: HTMLDivElement | undefined = $state(undefined);
 
-	const STATUS_COLORS: Record<string, string> = {
-		open: 'var(--status-blue)',
-		new: 'var(--status-blue)',
-		in_progress: 'var(--accent-amber)',
-		active: 'var(--accent-green)',
-		done: 'var(--accent-green)',
-		completed: 'var(--accent-green)',
-		published: 'var(--accent-green)',
-		blocked: 'var(--accent-orange)',
-		rejected: 'var(--accent-orange)',
-		critical: 'var(--accent-orange)',
-		high: 'var(--accent-amber)',
-		medium: 'var(--status-blue)',
-		low: 'var(--text-muted)',
-		draft: 'var(--text-muted)',
-		closed: 'var(--text-muted)',
-		archived: 'var(--text-muted)'
-	};
-
+	/** Canonical palette from $lib/utils/fieldColors; priorities colored too.
+	 *  Returns null for unrecognized values so the color dot is suppressed. */
 	function getStatusColor(val: string): string | null {
-		return STATUS_COLORS[val] ?? null;
-	}
-
-	function formatLabel(val: string): string {
-		return val
-			.replace(/_/g, ' ')
-			.replace(/\b\w/g, (c) => c.toUpperCase());
+		if (hasCanonicalStatus(val)) return statusColor(val);
+		const p = val?.toLowerCase();
+		if (p === 'critical' || p === 'high' || p === 'medium' || p === 'low') {
+			return priorityColor(val);
+		}
+		return null;
 	}
 
 	function toggleDropdown() {

--- a/web/src/lib/components/search/CommandPalette.svelte
+++ b/web/src/lib/components/search/CommandPalette.svelte
@@ -2,6 +2,7 @@
 	import { untrack } from 'svelte';
 	import { goto } from '$app/navigation';
 	import { api } from '$lib/api/client';
+	import { statusColor } from '$lib/utils/fieldColors';
 	import { workspaceStore } from '$lib/stores/workspace.svelte';
 	import { collectionStore } from '$lib/stores/collections.svelte';
 	import { localIndex } from '$lib/stores/localIndex.svelte';
@@ -717,15 +718,7 @@
 		return s.replace(/<[^>]*>/g, '');
 	}
 
-	function statusColor(status: string): string {
-		const s = status?.toLowerCase().replace(/-/g, '_');
-		if (['done', 'completed', 'fixed', 'implemented', 'resolved'].includes(s))
-			return 'var(--accent-green)';
-		if (['in_progress', 'exploring', 'fixing'].includes(s)) return 'var(--accent-amber)';
-		if (['open', 'new', 'draft', 'todo', 'planned'].includes(s)) return 'var(--status-blue)';
-		if (s === 'active') return 'var(--accent-cyan)';
-		return 'var(--text-muted)';
-	}
+	// statusColor imported from $lib/utils/fieldColors (canonical palette).
 
 	function priorityDot(priority: string): string {
 		const p = priority?.toLowerCase();

--- a/web/src/lib/components/share/shareView.ts
+++ b/web/src/lib/components/share/shareView.ts
@@ -301,22 +301,11 @@ export function formatFieldValue(value: unknown): string {
 	return String(value);
 }
 
-/** Status color — mirrors ItemCard.statusColor so a shared board matches the
- *  owner's palette. Returns a CSS custom-property reference. */
-export function statusColor(status: string): string {
-	switch (status) {
-		case 'open':
-			return 'var(--text-secondary)';
-		case 'in_progress':
-			return 'var(--accent-amber)';
-		case 'done':
-			return 'var(--accent-green)';
-		case 'blocked':
-			return 'var(--accent-orange)';
-		default:
-			return 'var(--text-muted)';
-	}
-}
+/** Status/priority colors — the canonical palette from $lib/utils/fieldColors,
+ *  so a shared board matches the owner's view exactly. Re-exported to keep the
+ *  public-share import surface unchanged. */
+import { statusColor, priorityColor, hasCanonicalStatus } from '$lib/utils/fieldColors';
+export { statusColor, priorityColor };
 
 /** Schema-driven color for a select-field value. Prefers the literal status
  *  vocabulary (so the canonical open/in_progress/done/blocked palette matches
@@ -330,7 +319,7 @@ export function fieldValueColor(field: FieldDef | undefined, value: string): str
 	if (!value) return 'var(--text-muted)';
 	if (field?.key === 'priority') return priorityColor(value);
 	// Canonical status palette first — exact owner match.
-	if (value === 'open' || value === 'in_progress' || value === 'done' || value === 'blocked') {
+	if (hasCanonicalStatus(value)) {
 		return statusColor(value);
 	}
 	// Custom vocabulary: terminal options read as "done".
@@ -354,21 +343,6 @@ export function columnAccentClassFor(field: FieldDef | undefined, value: string)
 	return '';
 }
 
-/** Priority color — mirrors ItemCard.priorityColor. */
-export function priorityColor(priority: string): string {
-	switch (priority) {
-		case 'critical':
-			return 'var(--accent-orange)';
-		case 'high':
-			return 'var(--accent-amber)';
-		case 'medium':
-			return 'var(--text-secondary)';
-		case 'low':
-			return 'var(--text-muted)';
-		default:
-			return 'var(--text-muted)';
-	}
-}
 
 /** Group `items` by `groupField` value, in option order with any extra values
  *  appended (sorted), and ungrouped ('') last when present. Mirrors

--- a/web/src/lib/components/timeline/TimelineActivityCard.svelte
+++ b/web/src/lib/components/timeline/TimelineActivityCard.svelte
@@ -2,6 +2,7 @@
 	import type { Activity } from '$lib/types';
 	import { relativeTime } from '$lib/utils/markdown';
 	import { parseFieldChanges } from '$lib/utils/activityChanges';
+	import Chip from '$lib/components/common/Chip.svelte';
 
 	let { activity }: { activity: Activity } = $props();
 
@@ -35,10 +36,6 @@
 		return '';
 	}
 
-	function getActorBadgeClass(actor: string): string {
-		return actor === 'agent' ? 'actor-agent' : 'actor-user';
-	}
-
 	function getActorLabel(a: Activity): string {
 		return a.actor === 'agent' ? 'Agent' : 'User';
 	}
@@ -55,7 +52,11 @@
 
 <div class="card">
 	<div class="row">
-		<span class="badge {getActorBadgeClass(activity.actor)}">{getActorLabel(activity)}</span>
+		<Chip
+			size="sm"
+			color={activity.actor === 'agent' ? 'var(--accent-purple)' : 'var(--status-blue)'}
+			>{getActorLabel(activity)}</Chip
+		>
 		{#if activity.actor_name}
 			<span class="actor-name">{activity.actor_name}</span>
 		{/if}
@@ -65,7 +66,7 @@
 				{metadata.from_collection} &rarr; {metadata.to_collection}
 			</span>
 		{/if}
-		<span class="badge source-badge">{getSourceLabel(activity.source)}</span>
+		<Chip size="sm">{getSourceLabel(activity.source)}</Chip>
 		<span class="spacer"></span>
 		<span class="timestamp" title={new Date(activity.created_at).toLocaleString()}>{relativeTime(activity.created_at)}</span>
 	</div>
@@ -102,27 +103,6 @@
 		min-width: 0;
 	}
 
-	.badge {
-		display: inline-flex;
-		align-items: center;
-		padding: 0 var(--space-2);
-		border-radius: var(--radius-sm);
-		font-size: 0.75em;
-		font-weight: 600;
-		line-height: 1.75;
-		white-space: nowrap;
-	}
-
-	.actor-agent {
-		background: color-mix(in srgb, var(--accent-purple) 15%, transparent);
-		color: var(--accent-purple);
-	}
-
-	.actor-user {
-		background: color-mix(in srgb, var(--accent-blue) 15%, transparent);
-		color: var(--accent-blue);
-	}
-
 	.actor-name {
 		font-size: 0.85em;
 		color: var(--text-primary);
@@ -146,11 +126,6 @@
 
 	.move-detail {
 		font-size: 0.8em;
-		color: var(--text-muted);
-	}
-
-	.source-badge {
-		background: var(--bg-tertiary);
 		color: var(--text-muted);
 	}
 

--- a/web/src/lib/components/timeline/TimelineVersionCard.svelte
+++ b/web/src/lib/components/timeline/TimelineVersionCard.svelte
@@ -2,6 +2,7 @@
 	import type { Version, Item } from '$lib/types';
 	import { api } from '$lib/api/client';
 	import DiffView from '$lib/components/versions/DiffView.svelte';
+	import Chip from '$lib/components/common/Chip.svelte';
 	import { relativeTime } from '$lib/utils/markdown';
 
 	interface Props {
@@ -149,16 +150,15 @@
 			{/if}
 		</div>
 		<div class="badges">
-			<span
-				class="badge"
-				class:badge-agent={version.created_by === 'agent'}
-				class:badge-user={version.created_by !== 'agent'}
+			<Chip
+				size="sm"
+				color={version.created_by === 'agent' ? 'var(--accent-purple)' : 'var(--status-blue)'}
 			>
 				{actorLabel(version.created_by)}
-			</span>
-			<span class="badge badge-source">
+			</Chip>
+			<Chip size="sm" color="var(--accent-green)">
 				{sourceLabel(version.source)}
-			</span>
+			</Chip>
 		</div>
 		<span class="timestamp" title={new Date(version.created_at).toLocaleString()}>
 			{relativeTime(version.created_at)}
@@ -287,33 +287,6 @@
 		display: flex;
 		gap: var(--space-1);
 		flex-shrink: 0;
-	}
-
-	.badge {
-		display: inline-flex;
-		align-items: center;
-		padding: 1px var(--space-2);
-		border-radius: 9999px;
-		font-size: 0.7em;
-		font-weight: 500;
-		text-transform: uppercase;
-		letter-spacing: 0.03em;
-		line-height: 1.6;
-	}
-
-	.badge-agent {
-		background: color-mix(in srgb, var(--accent-purple, #a855f7) 15%, transparent);
-		color: var(--accent-purple, #a855f7);
-	}
-
-	.badge-user {
-		background: color-mix(in srgb, var(--accent-blue) 15%, transparent);
-		color: var(--accent-blue);
-	}
-
-	.badge-source {
-		background: color-mix(in srgb, var(--accent-green) 15%, transparent);
-		color: var(--accent-green);
 	}
 
 	.timestamp {

--- a/web/src/lib/components/versions/VersionHistory.svelte
+++ b/web/src/lib/components/versions/VersionHistory.svelte
@@ -3,6 +3,7 @@
 	import { api } from '$lib/api/client';
 	import { toastStore } from '$lib/stores/toast.svelte';
 	import DiffView from './DiffView.svelte';
+	import Chip from '$lib/components/common/Chip.svelte';
 	import { relativeTime } from '$lib/utils/markdown';
 
 	interface Props {
@@ -268,17 +269,18 @@
 									<div class="entry-meta">
 										<span class="entry-time" title={new Date(entry.created_at).toLocaleString()}>{relativeTime(entry.created_at)}</span>
 										<div class="badges">
-											<span class="badge badge-version">Content</span>
-											<span
-												class="badge"
-												class:badge-agent={entry.actor === 'agent'}
-												class:badge-user={entry.actor !== 'agent'}
+											<Chip size="sm" color="var(--status-blue)">Content</Chip>
+											<Chip
+												size="sm"
+												color={entry.actor === 'agent'
+													? 'var(--accent-purple)'
+													: 'var(--status-blue)'}
 											>
 												{actorLabel(entry)}
-											</span>
-											<span class="badge badge-source">
+											</Chip>
+											<Chip size="sm" color="var(--accent-green)">
 												{sourceLabel(entry.source)}
-											</span>
+											</Chip>
 										</div>
 									</div>
 									{#if entry.summary}
@@ -333,16 +335,17 @@
 									<div class="entry-meta">
 										<span class="entry-time" title={new Date(entry.created_at).toLocaleString()}>{relativeTime(entry.created_at)}</span>
 										<div class="badges">
-											<span
-												class="badge"
-												class:badge-agent={entry.actor === 'agent'}
-												class:badge-user={entry.actor !== 'agent'}
+											<Chip
+												size="sm"
+												color={entry.actor === 'agent'
+													? 'var(--accent-purple)'
+													: 'var(--status-blue)'}
 											>
 												{actorLabel(entry)}
-											</span>
-											<span class="badge badge-source">
+											</Chip>
+											<Chip size="sm" color="var(--accent-green)">
 												{sourceLabel(entry.source)}
-											</span>
+											</Chip>
 										</div>
 									</div>
 									<p class="change-summary">{entry.summary}</p>
@@ -543,38 +546,6 @@
 	}
 
 	.badges { display: flex; gap: var(--space-1); }
-
-	.badge {
-		display: inline-flex;
-		align-items: center;
-		padding: 1px var(--space-2);
-		border-radius: 9999px;
-		font-size: 0.7em;
-		font-weight: 500;
-		text-transform: uppercase;
-		letter-spacing: 0.03em;
-		line-height: 1.6;
-	}
-
-	.badge-agent {
-		background: color-mix(in srgb, var(--accent-purple, #a855f7) 15%, transparent);
-		color: var(--accent-purple, #a855f7);
-	}
-
-	.badge-user {
-		background: color-mix(in srgb, var(--accent-blue) 15%, transparent);
-		color: var(--accent-blue);
-	}
-
-	.badge-source {
-		background: color-mix(in srgb, var(--accent-green) 15%, transparent);
-		color: var(--accent-green);
-	}
-
-	.badge-version {
-		background: color-mix(in srgb, var(--accent-blue) 15%, transparent);
-		color: var(--accent-blue);
-	}
 
 	.change-summary {
 		margin: var(--space-1) 0 0 0;

--- a/web/src/lib/utils/fieldColors.ts
+++ b/web/src/lib/utils/fieldColors.ts
@@ -1,0 +1,105 @@
+/**
+ * Canonical field-value colors (PLAN-2290 Phase 2, TASK-2292).
+ *
+ * Replaces four parallel implementations that had drifted apart:
+ * ItemCard.statusColor, fields/FieldEditor.STATUS_COLORS,
+ * CommandPalette.statusColor, and the workspace-home statusColor —
+ * shareView.ts re-exports from here so public shares stay in lockstep.
+ *
+ * Conflict resolutions (deliberate, see PR #—):
+ * - `open`/`new`/`todo`/`planned` → --status-blue (the refresh direction:
+ *   "to do" reads blue; ItemCard previously used --text-secondary).
+ * - `active` → green, matching the --status-active token (CommandPalette
+ *   previously used cyan).
+ * - `draft` → muted, matching --status-draft (CommandPalette used blue).
+ * - `rejected`/`cancelled`/`wontfix` → gray (terminal-negative family;
+ *   FieldEditor previously colored rejected orange).
+ * - priority `medium` → --text-secondary (majority rule; FieldEditor
+ *   previously used blue).
+ *
+ * Colors return CSS custom-property references so they work in any theme.
+ */
+
+const GREEN = 'var(--accent-green)';
+const AMBER = 'var(--accent-amber)';
+const BLUE = 'var(--status-blue)';
+const ORANGE = 'var(--accent-orange)';
+const GRAY = 'var(--accent-gray)';
+const MUTED = 'var(--text-muted)';
+const SECONDARY = 'var(--text-secondary)';
+
+const STATUS_COLORS: Record<string, string> = {
+	// finished / positive-terminal
+	done: GREEN,
+	completed: GREEN,
+	fixed: GREEN,
+	implemented: GREEN,
+	resolved: GREEN,
+	published: GREEN,
+	approved: GREEN,
+	active: GREEN,
+	// underway
+	in_progress: AMBER,
+	in_review: AMBER,
+	review: AMBER,
+	exploring: AMBER,
+	fixing: AMBER,
+	confirmed: AMBER,
+	drafting: AMBER,
+	// not started
+	open: BLUE,
+	new: BLUE,
+	todo: BLUE,
+	planned: BLUE,
+	// needs attention
+	blocked: ORANGE,
+	// negative-terminal
+	cancelled: GRAY,
+	rejected: GRAY,
+	wontfix: GRAY,
+	// dormant
+	draft: MUTED,
+	closed: MUTED,
+	archived: MUTED,
+	disabled: MUTED,
+	deprecated: MUTED,
+};
+
+/** Normalize a select value for lookup: lowercase, hyphens → underscores. */
+function norm(value: string): string {
+	return value?.toLowerCase().replace(/-/g, '_') ?? '';
+}
+
+/** Canonical status → color (CSS var reference). Unknown values read muted. */
+export function statusColor(status: string): string {
+	return STATUS_COLORS[norm(status)] ?? MUTED;
+}
+
+/** Canonical priority → color. Critical is orange by long-standing app
+ *  convention (red stays reserved for destructive actions). */
+export function priorityColor(priority: string): string {
+	switch (norm(priority)) {
+		case 'critical':
+			return ORANGE;
+		case 'high':
+			return AMBER;
+		case 'medium':
+			return SECONDARY;
+		case 'low':
+			return MUTED;
+		default:
+			return MUTED;
+	}
+}
+
+/** True when the canonical status palette has an exact entry for the value —
+ *  lets schema-aware callers (shareView.fieldValueColor) fall back to
+ *  terminal_options semantics for custom vocabularies. */
+export function hasCanonicalStatus(value: string): boolean {
+	return norm(value) in STATUS_COLORS;
+}
+
+/** "in_progress" → "In Progress". Shared by FieldEditor/ItemCard/chips. */
+export function formatFieldLabel(value: string): string {
+	return value.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}

--- a/web/src/routes/[username]/[workspace]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/+page.svelte
@@ -2,6 +2,7 @@
 	import { page } from '$app/state';
 	import { onMount, onDestroy, untrack } from 'svelte';
 	import { browser } from '$app/environment';
+	import { statusColor, priorityColor } from '$lib/utils/fieldColors';
 	import { api, PadApiError } from '$lib/api/client';
 	import { workspaceStore } from '$lib/stores/workspace.svelte';
 	import { authStore } from '$lib/stores/auth.svelte';
@@ -259,26 +260,9 @@
 	// web-only escape hatch on the skipped-onboarding board (TASK-1856).
 	let hasUserCollections = $derived(collections.some(c => !c.is_system));
 
-	function statusColor(status: string): string {
-		const s = status.toLowerCase().replace(/-/g, '_');
-		if (['done', 'completed', 'fixed', 'implemented', 'resolved'].includes(s)) return 'var(--accent-green)';
-		if (['in_progress', 'exploring', 'fixing', 'confirmed', 'in_review'].includes(s)) return 'var(--accent-amber)';
-		if (['open', 'new', 'draft', 'todo', 'planned'].includes(s)) return 'var(--status-blue)';
-		if (['cancelled', 'rejected', 'wontfix'].includes(s)) return 'var(--accent-gray)';
-		if (s === 'active') return 'var(--accent-cyan)';
-		if (['archived', 'disabled', 'deprecated'].includes(s)) return 'var(--text-muted)';
-		return 'var(--text-secondary)';
-	}
+	// statusColor imported from $lib/utils/fieldColors (canonical palette).
 
-	function priorityColor(priority: string): string {
-		switch (priority?.toLowerCase()) {
-			case 'critical': return 'var(--accent-orange)';
-			case 'high': return 'var(--accent-amber)';
-			case 'medium': return 'var(--text-secondary)';
-			case 'low': return 'var(--text-muted)';
-			default: return 'var(--text-muted)';
-		}
-	}
+	// priorityColor imported from $lib/utils/fieldColors (canonical palette).
 
 	function collProgress(coll: Collection): { total: number; done: number; pct: number } {
 		const breakdown = dashboard?.summary.by_collection[coll.name] ?? dashboard?.summary.by_collection[coll.slug] ?? {};

--- a/web/src/routes/[username]/[workspace]/library/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/library/+page.svelte
@@ -2,6 +2,8 @@
 	import { page } from '$app/state';
 	import { api } from '$lib/api/client';
 	import { createScrollRestoration } from '$lib/scroll/restore.svelte';
+	import Chip from '$lib/components/common/Chip.svelte';
+	import { statusColor } from '$lib/utils/fieldColors';
 	import type { LibraryCategory, LibraryConvention, PlaybookCategory, LibraryPlaybook, Item } from '$lib/types';
 
 	let wsSlug = $derived(page.params.workspace ?? '');
@@ -170,20 +172,20 @@
 								<div class="card-body">
 									<h3 class="card-title">{convention.title}</h3>
 									<div class="badges">
-										<span class="badge trigger">{convention.trigger}</span>
-										<span class="badge scope">{conventionSurfaceLabel(convention)}</span>
-										<span class="badge priority" style="background: {priorityColors[convention.enforcement] ?? 'var(--accent-gray)'}">
+										<Chip size="sm" color="var(--status-blue)">{convention.trigger}</Chip>
+										<Chip size="sm" color="var(--accent-purple)">{conventionSurfaceLabel(convention)}</Chip>
+										<Chip size="sm" color={priorityColors[convention.enforcement] ?? 'var(--accent-gray)'}>
 											{convention.enforcement}
-										</span>
+										</Chip>
 										{#if convention.commands?.length}
-											<span class="badge scope">{convention.commands.length} cmd{convention.commands.length > 1 ? 's' : ''}</span>
+											<Chip size="sm" color="var(--accent-purple)">{convention.commands.length} cmd{convention.commands.length > 1 ? 's' : ''}</Chip>
 										{/if}
 									</div>
 									<p class="card-content">{truncate(convention.content, 100)}</p>
 								</div>
 								<div class="card-action">
 									{#if isActive}
-										<span class="active-badge">Active</span>
+										<Chip color={statusColor('active')}>Active</Chip>
 									{:else}
 										<button
 											class="activate-btn"
@@ -229,19 +231,19 @@
 									<h3 class="card-title">{playbook.title}</h3>
 									<div class="badges">
 										{#if playbook.invocation_slug}
-											<span class="badge slug" title={`Run it by saying "run the ${playbook.invocation_slug} playbook" — or the shortcut for your agent: /pad ${playbook.invocation_slug} (Claude Code), $pad ${playbook.invocation_slug} (Codex), pad_playbook action=run ref=${playbook.invocation_slug} (MCP)`}>▶ {playbook.invocation_slug}</span>
+											<Chip size="sm" color="var(--accent-green)" title={`Run it by saying "run the ${playbook.invocation_slug} playbook" — or the shortcut for your agent: /pad ${playbook.invocation_slug} (Claude Code), $pad ${playbook.invocation_slug} (Codex), pad_playbook action=run ref=${playbook.invocation_slug} (MCP)`}><span class="slug-text">▶ {playbook.invocation_slug}</span></Chip>
 										{/if}
-										<span class="badge trigger">{playbook.trigger}</span>
-										<span class="badge scope">{playbook.scope}</span>
+										<Chip size="sm" color="var(--status-blue)">{playbook.trigger}</Chip>
+										<Chip size="sm" color="var(--accent-purple)">{playbook.scope}</Chip>
 										{#if playbook.arguments && playbook.arguments.length > 0}
-											<span class="badge args" title="Accepts {playbook.arguments.length} argument{playbook.arguments.length === 1 ? '' : 's'}">{playbook.arguments.length} arg{playbook.arguments.length === 1 ? '' : 's'}</span>
+											<Chip size="sm" color="var(--accent-amber)" title="Accepts {playbook.arguments.length} argument{playbook.arguments.length === 1 ? '' : 's'}">{playbook.arguments.length} arg{playbook.arguments.length === 1 ? '' : 's'}</Chip>
 										{/if}
 									</div>
 									<p class="card-content card-steps">{previewSteps(playbook.content)}</p>
 								</div>
 								<div class="card-action">
 									{#if isActive}
-										<span class="active-badge">Active</span>
+										<Chip color={statusColor('active')}>Active</Chip>
 									{:else}
 										<button
 											class="activate-btn"
@@ -332,23 +334,8 @@
 	.card-steps { white-space: pre-line; }
 
 	.badges { display: flex; flex-wrap: wrap; gap: var(--space-1); }
-	.badge {
-		font-size: 0.7em;
-		padding: 2px 8px;
-		border-radius: 10px;
-		font-weight: 600;
-		white-space: nowrap;
-	}
-	.badge.trigger { background: color-mix(in srgb, var(--accent-blue) 20%, transparent); color: var(--accent-blue); }
-	.badge.scope { background: color-mix(in srgb, var(--accent-purple) 20%, transparent); color: var(--accent-purple); }
-	.badge.priority { color: #fff; }
 	/* PLAN-1377 invocation surface — slug chip signals "this playbook is callable as /pad <slug>". */
-	.badge.slug {
-		background: color-mix(in srgb, var(--accent-green) 18%, transparent);
-		color: var(--accent-green);
-		font-family: var(--font-mono, ui-monospace, SFMono-Regular, monospace);
-	}
-	.badge.args { background: color-mix(in srgb, var(--accent-amber) 20%, transparent); color: var(--accent-amber); }
+	.slug-text { font-family: var(--font-mono, ui-monospace, SFMono-Regular, monospace); }
 
 	.card-action { display: flex; justify-content: flex-end; }
 
@@ -368,15 +355,6 @@
 	}
 	.activate-btn:hover { opacity: 0.9; }
 	.activate-btn:disabled { opacity: 0.6; cursor: not-allowed; }
-
-	.active-badge {
-		padding: var(--space-1) var(--space-4);
-		background: color-mix(in srgb, var(--accent-green) 20%, transparent);
-		color: var(--accent-green);
-		border-radius: var(--radius);
-		font-size: 0.8em;
-		font-weight: 600;
-	}
 
 	.spinner {
 		width: 14px;

--- a/web/src/routes/[username]/[workspace]/playbooks/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/playbooks/+page.svelte
@@ -6,6 +6,8 @@
 	import { toastStore } from '$lib/stores/toast.svelte';
 	import { createScrollRestoration } from '$lib/scroll/restore.svelte';
 	import { exportAndDownloadArtifact, importArtifactFile } from '$lib/utils/artifacts';
+	import { statusColor } from '$lib/utils/fieldColors';
+	import Chip from '$lib/components/common/Chip.svelte';
 	import PlaybookFormFields from '$lib/components/playbooks/PlaybookFormFields.svelte';
 	import {
 		PLAYBOOK_SKELETON_BODY,
@@ -504,12 +506,12 @@
 						<button class="card-header" onclick={() => toggleExpand(item.id)} aria-expanded={isExpanded}>
 							<div class="card-title-row">
 								<span class="card-title" class:deprecated-title={status === 'deprecated'}>{item.title}</span>
-								<span class="status-badge status-{status}">{statusLabel(status)}</span>
+								<Chip size="sm" color={statusColor(status)}>{statusLabel(status)}</Chip>
 							</div>
 							<div class="card-meta">
-								<span class="badge badge-trigger">{trigger}</span>
+								<Chip size="sm" color="var(--status-blue)">{trigger}</Chip>
 								<span class="meta-sep">&middot;</span>
-								<span class="badge badge-scope">{scope}</span>
+								<Chip size="sm" color="var(--accent-purple)">{scope}</Chip>
 								{#if steps > 0}
 									<span class="meta-sep">&middot;</span>
 									<span class="step-count">{steps} step{steps !== 1 ? 's' : ''}</span>
@@ -596,14 +598,7 @@
 	.card-title-row { display: flex; align-items: center; justify-content: space-between; gap: var(--space-3); }
 	.card-title { font-size: 1.05em; font-weight: 600; }
 	.deprecated-title { text-decoration: line-through; color: var(--text-muted); }
-	.status-badge { font-size: 0.7em; padding: 2px 10px; border-radius: 10px; font-weight: 600; white-space: nowrap; text-transform: uppercase; letter-spacing: 0.03em; }
-	.status-active { background: color-mix(in srgb, var(--accent-green) 20%, transparent); color: var(--accent-green); }
-	.status-draft { background: color-mix(in srgb, var(--accent-gray) 20%, transparent); color: var(--accent-gray); }
-	.status-deprecated { background: color-mix(in srgb, var(--accent-orange) 20%, transparent); color: var(--accent-orange); }
 	.card-meta { display: flex; align-items: center; gap: var(--space-2); font-size: 0.85em; color: var(--text-secondary); }
-	.badge { font-size: 0.8em; padding: 1px 8px; border-radius: 10px; font-weight: 600; white-space: nowrap; }
-	.badge-trigger { background: color-mix(in srgb, var(--accent-blue) 20%, transparent); color: var(--accent-blue); }
-	.badge-scope { background: color-mix(in srgb, var(--accent-purple) 20%, transparent); color: var(--accent-purple); }
 	.meta-sep { color: var(--text-muted); }
 	.step-count { color: var(--text-muted); font-size: 0.9em; }
 	.chevron { margin-left: auto; font-size: 0.65em; color: var(--text-muted); transition: transform 0.2s; }
@@ -629,10 +624,9 @@
 	.new-form h2 { font-size: 1.1em; margin-bottom: var(--space-4); }
 	.form-fields { display: flex; flex-direction: column; gap: var(--space-4); }
 	.form-row { display: flex; flex-direction: column; gap: var(--space-1); }
-	.form-row-pair { display: grid; grid-template-columns: 1fr 1fr; gap: var(--space-4); }
 	.form-label { font-size: 0.8em; font-weight: 600; color: var(--text-secondary); text-transform: uppercase; letter-spacing: 0.04em; }
-	.form-input, .form-select { padding: var(--space-2) var(--space-3); background: var(--bg-tertiary); border: 1px solid var(--border); border-radius: var(--radius); color: var(--text-primary); font-size: 0.95em; }
-	.form-input:focus, .form-select:focus, .form-textarea:focus { border-color: var(--accent-blue); outline: none; }
+	.form-input { padding: var(--space-2) var(--space-3); background: var(--bg-tertiary); border: 1px solid var(--border); border-radius: var(--radius); color: var(--text-primary); font-size: 0.95em; }
+	.form-input:focus, .form-textarea:focus { border-color: var(--accent-blue); outline: none; }
 	.form-textarea { padding: var(--space-3); background: var(--bg-tertiary); border: 1px solid var(--border); border-radius: var(--radius); color: var(--text-primary); font-family: var(--font-mono); font-size: 0.9em; line-height: 1.6; min-height: 200px; resize: vertical; }
 	.form-actions { display: flex; justify-content: flex-end; gap: var(--space-3); margin-top: var(--space-4); }
 	.btn { padding: var(--space-2) var(--space-5); border-radius: var(--radius); font-size: 0.85em; font-weight: 600; cursor: pointer; border: none; transition: opacity 0.15s; }
@@ -647,7 +641,6 @@
 	}
 	@media (max-width: 768px) {
 		.page-header { flex-direction: column; }
-		.form-row-pair { grid-template-columns: 1fr; }
 		.form-actions { flex-direction: column; }
 		.form-actions .btn { width: 100%; text-align: center; }
 	}

--- a/web/src/routes/[username]/[workspace]/settings/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/settings/+page.svelte
@@ -10,6 +10,7 @@
 	import CreateCollectionModal from '$lib/components/collections/CreateCollectionModal.svelte';
 	import EditCollectionModal from '$lib/components/collections/EditCollectionModal.svelte';
 	import StorageTab from '$lib/components/settings/StorageTab.svelte';
+	import Chip from '$lib/components/common/Chip.svelte';
 	import { collectionStore } from '$lib/stores/collections.svelte';
 	import { toastStore } from '$lib/stores/toast.svelte';
 	import { copyToClipboard } from '$lib/utils/clipboard';
@@ -564,10 +565,10 @@
 					{#if contextSummary.length > 0}
 						<div class="context-summary">
 							{#each contextSummary as entry (entry.label)}
-								<div class="context-chip">
+								<Chip color="var(--accent-gray)">
 									<span class="context-chip-label">{entry.label}</span>
 									<span class="context-chip-value">{entry.value}</span>
-								</div>
+								</Chip>
 							{/each}
 						</div>
 					{/if}
@@ -620,9 +621,9 @@
 											<span class="member-email">{member.user_email}</span>
 										</div>
 										{#if expandedAccessUserId === member.user_id && !accessLoading}
-											<span class="access-badge" class:access-badge-specific={accessMode === 'specific'}>
+											<Chip size="sm" color={accessMode === 'specific' ? 'var(--status-blue)' : 'var(--accent-gray)'}>
 												{accessMode === 'all' ? 'All collections' : `${accessCollectionIds.length} collection${accessCollectionIds.length !== 1 ? 's' : ''}`}
-											</span>
+											</Chip>
 										{/if}
 									</div>
 									<div class="member-actions">
@@ -647,7 +648,7 @@
 												Remove
 											</button>
 										{:else}
-											<span class="role-badge">{member.role}</span>
+											<Chip color="var(--accent-gray)">{member.role}</Chip>
 										{/if}
 									</div>
 								</div>
@@ -686,7 +687,7 @@
 															<input type="checkbox" checked disabled />
 															<span class="access-coll-icon">{coll.icon || '#'}</span>
 															<span class="access-coll-name">{coll.name}</span>
-															<span class="access-system-tag">system</span>
+															<Chip size="sm" color="var(--accent-gray)">system</Chip>
 														</label>
 													{/each}
 												</div>
@@ -713,7 +714,7 @@
 						{#each invitations as inv (inv.id)}
 							<div class="card invitation-row">
 								<span class="inv-email">{inv.email}</span>
-								<span class="role-badge">{inv.role}</span>
+								<Chip color="var(--accent-gray)">{inv.role}</Chip>
 								{#if inv.join_url || inv.code}
 									<button class="btn btn-small copy-link-btn" onclick={async () => { const url = inv.join_url || `${window.location.origin}/join/${inv.code}`; const ok = await copyToClipboard(url); toastStore.show(ok ? 'Link copied!' : 'Failed to copy link', ok ? 'success' : 'error'); }}>
 										Copy invite link
@@ -774,7 +775,7 @@
 									<span class="coll-slug mono">/{coll.slug}</span>
 									<span class="coll-count">{coll.item_count ?? 0} items</span>
 									{#if coll.is_default}
-										<span class="badge">default</span>
+										<Chip size="sm" color="var(--status-blue)">default</Chip>
 									{/if}
 									{#if isOwner}
 										<span class="edit-hint">Edit</span>
@@ -783,7 +784,7 @@
 								{#if schema.fields.length > 0}
 									<div class="field-tags">
 										{#each schema.fields as field (field.key)}
-											<span class="field-tag">{field.key}: {field.type}</span>
+											<Chip size="sm" color="var(--accent-gray)"><span class="field-tag">{field.key}: {field.type}</span></Chip>
 										{/each}
 									</div>
 								{/if}
@@ -947,9 +948,8 @@
 	.edit-hint { font-size: 0.75em; color: var(--text-muted); opacity: 0; transition: opacity 0.15s; }
 	.coll-card-btn:hover .edit-hint { opacity: 1; color: var(--accent-blue); }
 	.coll-count { margin-left: auto; font-size: 0.8em; color: var(--text-muted); }
-	.badge { font-size: 0.7em; background: var(--accent-blue); color: #fff; padding: 1px 6px; border-radius: 10px; font-weight: 600; }
 	.field-tags { display: flex; flex-wrap: wrap; gap: var(--space-1); margin-top: var(--space-2); }
-	.field-tag { font-size: 0.75em; font-family: var(--font-mono); background: var(--bg-tertiary); color: var(--text-secondary); padding: 1px 8px; border-radius: 10px; }
+	.field-tag { font-family: var(--font-mono); }
 	.empty-text { color: var(--text-muted); font-size: 0.9em; }
 	.theme-row { display: flex; align-items: center; justify-content: space-between; font-size: 0.9em; }
 	.theme-toggle { display: flex; background: var(--bg-tertiary); border: 1px solid var(--border); border-radius: var(--radius); overflow: hidden; cursor: pointer; }
@@ -957,7 +957,6 @@
 	.theme-option.active { background: var(--accent-blue); color: #fff; }
 	.context-card { display: flex; flex-direction: column; gap: var(--space-3); }
 	.context-summary { display: flex; flex-wrap: wrap; gap: var(--space-2); }
-	.context-chip { display: inline-flex; align-items: center; gap: var(--space-2); background: var(--bg-tertiary); border: 1px solid var(--border-subtle); border-radius: 999px; padding: var(--space-1) var(--space-3); font-size: 0.78em; }
 	.context-chip-label { color: var(--text-muted); }
 	.context-chip-value { color: var(--text-primary); font-weight: 600; }
 	.context-label { font-size: 0.82em; color: var(--text-secondary); }
@@ -977,7 +976,6 @@
 	.member-email { font-size: 0.8em; color: var(--text-muted); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 	.member-actions { display: flex; align-items: center; gap: var(--space-2); flex-shrink: 0; }
 	.role-select { background: var(--bg-tertiary); border: 1px solid var(--border); border-radius: var(--radius-sm); padding: var(--space-1) var(--space-2); font-size: 0.8em; color: var(--text-primary); cursor: pointer; }
-	.role-badge { font-size: 0.8em; background: var(--bg-tertiary); color: var(--text-secondary); padding: 2px 10px; border-radius: 10px; }
 	.btn-remove { color: var(--accent-red); border-color: transparent; background: none; }
 	.btn-remove:hover { background: color-mix(in srgb, var(--accent-red) 15%, transparent); }
 	/* ── Collection Access ──── */
@@ -985,8 +983,6 @@
 	.member-card-wrapper + .member-card-wrapper { margin-top: var(--space-3); }
 	.member-card-wrapper .card.member-row { border-radius: var(--radius); }
 	.member-card-wrapper:has(.access-panel) .card.member-row { border-bottom-left-radius: 0; border-bottom-right-radius: 0; border-bottom-color: transparent; }
-	.access-badge { font-size: 0.72em; padding: 2px 8px; border-radius: 10px; background: var(--bg-tertiary); color: var(--text-muted); white-space: nowrap; margin-left: var(--space-2); }
-	.access-badge-specific { background: color-mix(in srgb, var(--accent-blue) 15%, transparent); color: var(--accent-blue); }
 	.btn-access { color: var(--accent-blue); border-color: var(--accent-blue); background: none; }
 	.btn-access:hover { background: color-mix(in srgb, var(--accent-blue) 10%, transparent); }
 	.btn-access-active { background: color-mix(in srgb, var(--accent-blue) 15%, transparent); }
@@ -1002,7 +998,6 @@
 	.access-coll-name { flex: 1; }
 	.access-coll-system { opacity: 0.6; cursor: default; }
 	.access-coll-system:hover { background: none; }
-	.access-system-tag { font-size: 0.7em; background: var(--bg-secondary); color: var(--text-muted); padding: 1px 5px; border-radius: 8px; }
 	.access-actions { display: flex; align-items: center; gap: var(--space-2); }
 	.invitations-section { margin-top: var(--space-4); }
 	.invitations-section h3 { font-size: 0.9em; color: var(--text-muted); margin-bottom: var(--space-2); }

--- a/web/src/routes/console/+page.svelte
+++ b/web/src/routes/console/+page.svelte
@@ -6,6 +6,7 @@
 	import { api } from '$lib/api/client';
 	import { authStore } from '$lib/stores/auth.svelte';
 	import { uiStore } from '$lib/stores/ui.svelte';
+	import Chip from '$lib/components/common/Chip.svelte';
 	import type { Workspace } from '$lib/types';
 
 	let workspaces = $state<Workspace[]>([]);
@@ -113,9 +114,9 @@
 							<div class="card-top">
 								<span class="card-name">{ws.name}</span>
 								{#if ws.is_guest}
-									<span class="badge guest">Guest</span>
+									<Chip size="sm" color="var(--accent-amber)">Guest</Chip>
 								{:else}
-									<span class="badge member">Member</span>
+									<Chip size="sm" color="var(--status-blue)">Member</Chip>
 								{/if}
 							</div>
 							{#if ws.description}
@@ -242,24 +243,6 @@
 		color: var(--text-muted);
 		font-size: 0.8rem;
 		margin-top: var(--space-1);
-	}
-
-	.badge {
-		padding: 2px var(--space-2);
-		border-radius: var(--radius-sm);
-		font-size: 0.75rem;
-		font-weight: 500;
-		flex-shrink: 0;
-	}
-
-	.badge.member {
-		background: color-mix(in srgb, var(--accent-blue) 15%, transparent);
-		color: var(--accent-blue);
-	}
-
-	.badge.guest {
-		background: color-mix(in srgb, var(--accent-amber) 15%, transparent);
-		color: var(--accent-amber);
 	}
 
 	.empty-state {

--- a/web/src/routes/console/admin/+page.svelte
+++ b/web/src/routes/console/admin/+page.svelte
@@ -4,6 +4,7 @@
 	import { page } from '$app/state';
 	import { adminFetch, formatDate, adminStore, type AdminUser } from '$lib/stores/admin.svelte';
 	import UserModal from '$lib/components/admin/UserModal.svelte';
+	import Chip from '$lib/components/common/Chip.svelte';
 
 	// --- List + pagination + filter + sort state (PLAN-1542 / TASK-1549) ---
 	// All filter state is reactive $state; we rebuild the query string on
@@ -248,6 +249,15 @@
 		return 'cold';
 	}
 
+	// Status pill colors — these are admin *user* states (disabled /
+	// no-workspace / inactive), not item statuses, so they map locally
+	// rather than through fieldColors.statusColor. "active" never renders.
+	function userStatusColor(status: string): string {
+		if (status === 'disabled') return 'var(--accent-red)';
+		if (status === 'inactive') return 'var(--accent-amber)';
+		return 'var(--accent-gray)'; // no-workspace
+	}
+
 	onMount(() => {
 		hydrateFromURL();
 		loadList(true);
@@ -398,20 +408,20 @@
 								     "active" is the common case; omit the pill to avoid
 								     visual noise. Other states call out problems. -->
 								{#if user.status && user.status !== 'active'}
-									<span class="badge status-{user.status}">{user.status}</span>
+									<span class="status-chip"><Chip size="sm" color={userStatusColor(user.status)}>{user.status}</Chip></span>
 								{/if}
 							</td>
 							<td
-								><span class="badge" class:admin={user.role === 'admin'}
-									>{user.role || 'member'}</span
+								><Chip size="sm" color={user.role === 'admin' ? 'var(--accent-orange)' : 'var(--accent-gray)'}
+									>{user.role || 'member'}</Chip
 								></td
 							>
 							<td class="num-cell">{user.workspace_count ?? 0}</td>
 							<td>{user.email}</td>
 							{#if adminStore.stats?.cloud_mode}
 								<td
-									><span class="badge" class:pro={user.plan === 'pro'}
-										>{user.plan || 'free'}</span
+									><Chip size="sm" color={user.plan === 'pro' ? 'var(--status-blue)' : 'var(--accent-gray)'}
+										>{user.plan || 'free'}</Chip
 									></td
 								>
 							{/if}
@@ -616,38 +626,10 @@
 		color: var(--text-muted);
 		font-size: 0.8rem;
 	}
-	.badge {
-		padding: 2px var(--space-2);
-		border-radius: var(--radius-sm);
-		font-size: 0.75rem;
-		font-weight: 500;
-		background: color-mix(in srgb, var(--accent-gray, #888) 15%, transparent);
-		color: var(--text-muted);
-	}
-	.badge.pro {
-		background: color-mix(in srgb, var(--accent-blue) 15%, transparent);
-		color: var(--accent-blue);
-	}
-	.badge.admin {
-		background: color-mix(in srgb, var(--accent-orange, #f59e0b) 15%, transparent);
-		color: var(--accent-orange, #f59e0b);
-	}
-	/* Status pill — server-side computed (disabled / no-workspace / inactive /
-	   active). "active" never renders; the other three call out something
-	   actionable. PLAN-1542 / TASK-1548. */
-	.badge.status-disabled {
-		background: color-mix(in srgb, var(--accent-red) 15%, transparent);
-		color: var(--accent-red);
-		margin-left: var(--space-2);
-	}
-	.badge.status-no-workspace {
-		background: color-mix(in srgb, var(--accent-gray, #888) 15%, transparent);
-		color: var(--text-muted);
-		margin-left: var(--space-2);
-	}
-	.badge.status-inactive {
-		background: color-mix(in srgb, #f59e0b 15%, transparent);
-		color: #f59e0b;
+	/* Status pill wrapper — keeps the pill offset from the user name.
+	   Colors live in userStatusColor(); the pill itself is the shared
+	   <Chip> primitive. PLAN-1542 / TASK-1548 / TASK-2292. */
+	.status-chip {
 		margin-left: var(--space-2);
 	}
 	/* Numeric cells (workspace_count, storage_bytes) — right-aligned and

--- a/web/src/routes/console/admin/audit-log/+page.svelte
+++ b/web/src/routes/console/admin/audit-log/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { adminFetch } from '$lib/stores/admin.svelte';
+	import Chip from '$lib/components/common/Chip.svelte';
 
 	interface Activity {
 		id: string;
@@ -70,11 +71,13 @@
 		return ACTION_LABELS[action] ?? action.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
 	}
 
+	// Chip color for an audit action — success/danger/warning semantics
+	// mapped onto the shared accent tokens (TASK-2292).
 	function actionColor(action: string): string {
-		if (['login', 'register', 'oauth_login'].includes(action)) return 'success';
-		if (['login_failed', 'oauth_login_failed', 'user_disabled', 'account_deleted'].includes(action)) return 'danger';
-		if (['password_reset_by_admin', 'user_enabled', 'plan_changed', 'role_changed', 'settings_changed'].includes(action)) return 'warning';
-		return '';
+		if (['login', 'register', 'oauth_login'].includes(action)) return 'var(--accent-green)';
+		if (['login_failed', 'oauth_login_failed', 'user_disabled', 'account_deleted'].includes(action)) return 'var(--accent-red)';
+		if (['password_reset_by_admin', 'user_enabled', 'plan_changed', 'role_changed', 'settings_changed'].includes(action)) return 'var(--accent-amber)';
+		return 'var(--accent-gray)';
 	}
 
 	function relativeTime(dateStr: string): string {
@@ -275,9 +278,9 @@
 							</td>
 							<td>{displayUser(entry)}</td>
 							<td>
-								<span class="badge {actionColor(entry.action)}">
+								<Chip size="sm" color={actionColor(entry.action)}>
 									{formatAction(entry.action)}
-								</span>
+								</Chip>
 							</td>
 							<td class="details-cell">{formatMetadata(entry.metadata, entry.action)}</td>
 							<td class="ip-cell">{entry.ip_address || '\u2014'}</td>
@@ -383,30 +386,6 @@
 		font-family: 'SF Mono', 'Fira Code', 'Fira Mono', Menlo, Consolas, monospace;
 		font-size: 0.8rem;
 		white-space: nowrap;
-	}
-
-	/* Badge */
-	.badge {
-		display: inline-block;
-		padding: 2px var(--space-2);
-		border-radius: var(--radius-sm);
-		font-size: 0.75rem;
-		font-weight: 500;
-		background: color-mix(in srgb, var(--accent-gray, #888) 15%, transparent);
-		color: var(--text-muted);
-		white-space: nowrap;
-	}
-	.badge.success {
-		background: color-mix(in srgb, var(--accent-green, #22c55e) 15%, transparent);
-		color: var(--accent-green, #22c55e);
-	}
-	.badge.danger {
-		background: color-mix(in srgb, var(--accent-red) 15%, transparent);
-		color: var(--accent-red);
-	}
-	.badge.warning {
-		background: color-mix(in srgb, #f59e0b 15%, transparent);
-		color: #f59e0b;
 	}
 
 	/* Load more */

--- a/web/src/routes/console/admin/billing/+page.svelte
+++ b/web/src/routes/console/admin/billing/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { api } from '$lib/api/client';
+	import Chip from '$lib/components/common/Chip.svelte';
 	import type { AdminBillingStats } from '$lib/types';
 
 	let stats = $state<AdminBillingStats | null>(null);
@@ -116,7 +117,7 @@
 			</div>
 		{:else if !stats.stripe_configured}
 			<div class="banner info" role="status" aria-live="polite">
-				<span class="badge info-badge">Stripe not configured</span>
+				<Chip color="var(--status-blue)">Stripe not configured</Chip>
 				Stripe billing is not yet configured. Stripe-derived metrics will be zero
 				until <code>STRIPE_SECRET_KEY</code> is set on pad-cloud.
 			</div>
@@ -127,7 +128,7 @@
 			<div class="stat" class:disabled={stripeUnavailable}>
 				<span class="stat-label">MRR</span>
 				{#if stripeUnavailable}
-					<span class="badge na">N/A</span>
+					<span class="stat-chip"><Chip color="var(--accent-gray)">N/A</Chip></span>
 				{:else}
 					<span class="stat-value">{mrrFormatted}</span>
 				{/if}
@@ -138,7 +139,7 @@
 			<div class="stat" class:disabled={stripeUnavailable}>
 				<span class="stat-label">ARR</span>
 				{#if stripeUnavailable}
-					<span class="badge na">N/A</span>
+					<span class="stat-chip"><Chip color="var(--accent-gray)">N/A</Chip></span>
 				{:else}
 					<span class="stat-value">{arrFormatted}</span>
 				{/if}
@@ -149,7 +150,7 @@
 			<div class="stat" class:disabled={stripeUnavailable}>
 				<span class="stat-label">Active Subscriptions</span>
 				{#if stripeUnavailable}
-					<span class="badge na">N/A</span>
+					<span class="stat-chip"><Chip color="var(--accent-gray)">N/A</Chip></span>
 				{:else}
 					<span class="stat-value">{stats.active_subscriptions}</span>
 				{/if}
@@ -178,7 +179,7 @@
 			<div class="stat" class:disabled={stripeUnavailable}>
 				<span class="stat-label">Churn (30d)</span>
 				{#if stripeUnavailable}
-					<span class="badge na">N/A</span>
+					<span class="stat-chip"><Chip color="var(--accent-gray)">N/A</Chip></span>
 				{:else}
 					<span class="stat-value">{churnFormatted}</span>
 				{/if}
@@ -331,23 +332,10 @@
 		line-height: 1.4;
 	}
 
-	.badge {
-		padding: 2px var(--space-2);
-		border-radius: var(--radius-sm);
-		font-size: 0.75rem;
-		font-weight: 500;
-		background: color-mix(in srgb, #888 15%, transparent);
-		color: var(--text-muted);
-		display: inline-block;
-		width: fit-content;
-	}
-	.badge.na {
-		font-size: 1rem;
-		padding: 4px var(--space-2);
-	}
-	.badge.info-badge {
-		background: color-mix(in srgb, var(--accent-blue) 15%, transparent);
-		color: var(--accent-blue);
+	/* Keeps the N/A chip content-width inside the column-flex .stat
+	   (flex children otherwise stretch cross-axis). TASK-2292. */
+	.stat-chip {
+		align-self: flex-start;
 	}
 
 	.updated-footer {

--- a/web/src/routes/console/admin/invitations/+page.svelte
+++ b/web/src/routes/console/admin/invitations/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { adminFetch, adminPost, getCSRFToken, formatDate } from '$lib/stores/admin.svelte';
+	import Chip from '$lib/components/common/Chip.svelte';
 
 	interface AdminInvitation {
 		id: string;
@@ -149,9 +150,9 @@
 								<td>{inv.email}</td>
 								<td>{inv.workspace_name}</td>
 								<td>
-									<span class="badge" class:owner={inv.role === 'owner'}>
+									<Chip size="sm" color={inv.role === 'owner' ? 'var(--accent-green)' : 'var(--accent-gray)'}>
 										{inv.role}
-									</span>
+									</Chip>
 								</td>
 								<td>{inv.invited_by_name}</td>
 								<td class="date-cell">{formatDate(inv.created_at)}</td>
@@ -295,20 +296,6 @@
 	}
 	.date-cell {
 		white-space: nowrap;
-	}
-
-	/* Badge */
-	.badge {
-		padding: 2px var(--space-2);
-		border-radius: var(--radius-sm);
-		font-size: 0.75rem;
-		font-weight: 500;
-		background: color-mix(in srgb, var(--accent-gray, #888) 15%, transparent);
-		color: var(--text-muted);
-	}
-	.badge.owner {
-		background: color-mix(in srgb, var(--accent-green, #22c55e) 15%, transparent);
-		color: var(--accent-green, #22c55e);
 	}
 
 	/* Actions */

--- a/web/src/routes/console/admin/mcp-audit/+page.svelte
+++ b/web/src/routes/console/admin/mcp-audit/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { adminFetch } from '$lib/stores/admin.svelte';
+	import Chip from '$lib/components/common/Chip.svelte';
 
 	// Admin MCP audit log page (PLAN-943 TASK-960).
 	//
@@ -62,11 +63,14 @@
 		});
 	}
 
+	// Chip color for an MCP result status. These are transport results
+	// (ok / denied / error), not item statuses, so they map locally
+	// rather than through fieldColors.statusColor (TASK-2292).
 	function statusColor(status: string): string {
-		if (status === 'ok') return 'success';
-		if (status === 'denied') return 'warning';
-		if (status === 'error') return 'danger';
-		return '';
+		if (status === 'ok') return 'var(--accent-green)';
+		if (status === 'denied') return 'var(--accent-amber)';
+		if (status === 'error') return 'var(--accent-red)';
+		return 'var(--accent-gray)';
 	}
 
 	function shortRef(s: string): string {
@@ -168,15 +172,15 @@
 							<td title={entry.user_id}>{shortRef(entry.user_id)}</td>
 							<td title={entry.connection_id}>{shortRef(entry.connection_id)}</td>
 							<td>
-								<span class="badge {entry.token_kind === 'oauth' ? 'success' : ''}">
+								<Chip size="sm" color={entry.token_kind === 'oauth' ? 'var(--accent-green)' : 'var(--accent-gray)'}>
 									{entry.token_kind}
-								</span>
+								</Chip>
 							</td>
 							<td class="tool-cell">{entry.tool_name}</td>
 							<td>
-								<span class="badge {statusColor(entry.result_status)}">
+								<Chip size="sm" color={statusColor(entry.result_status)}>
 									{entry.result_status}
-								</span>
+								</Chip>
 								{#if entry.error_kind}
 									<span class="error-kind">{entry.error_kind}</span>
 								{/if}
@@ -279,33 +283,6 @@
 		font-variant-numeric: tabular-nums;
 		text-align: right;
 		color: var(--text-secondary);
-	}
-
-	.badge {
-		display: inline-block;
-		padding: 2px 8px;
-		border-radius: 999px;
-		background: var(--bg-tertiary);
-		color: var(--text-secondary);
-		font-size: 0.72rem;
-		font-weight: 600;
-		text-transform: uppercase;
-		letter-spacing: 0.04em;
-	}
-
-	.badge.success {
-		background: rgba(34, 197, 94, 0.15);
-		color: #16a34a;
-	}
-
-	.badge.warning {
-		background: rgba(217, 119, 6, 0.15);
-		color: #b45309;
-	}
-
-	.badge.danger {
-		background: rgba(239, 68, 68, 0.15);
-		color: var(--accent-red);
 	}
 
 	.error-kind {

--- a/web/src/routes/console/connected-apps/+page.svelte
+++ b/web/src/routes/console/connected-apps/+page.svelte
@@ -2,6 +2,7 @@
 	import { onMount } from 'svelte';
 	import { api } from '$lib/api/client';
 	import Modal from '$lib/components/common/Modal.svelte';
+	import Chip from '$lib/components/common/Chip.svelte';
 	import type { ConnectedApp, Workspace } from '$lib/types';
 
 	// Connected Apps page (TASK-954). Lists every active OAuth grant
@@ -151,10 +152,11 @@
 		unknown: 'Unknown'
 	};
 
-	function tierClass(tier: ConnectedApp['capability_tier']): string {
-		if (tier === 'read_write') return 'tier-blue';
-		if (tier === 'full_access') return 'tier-orange';
-		return 'tier-gray';
+	// Chip color for a capability tier (TASK-2292).
+	function tierColor(tier: ConnectedApp['capability_tier']): string {
+		if (tier === 'read_write') return 'var(--status-blue)';
+		if (tier === 'full_access') return 'var(--accent-orange)';
+		return 'var(--accent-gray)';
 	}
 
 	function relativeTime(dateStr: string | undefined): string {
@@ -311,9 +313,9 @@
 						<div class="app-body">
 							<div class="app-title-row">
 								<h2 class="app-title">{app.client_name}</h2>
-								<span class="badge {tierClass(app.capability_tier)}">
+								<Chip color={tierColor(app.capability_tier)}>
 									{TIER_LABELS[app.capability_tier]}
-								</span>
+								</Chip>
 							</div>
 
 							<div class="chip-row">
@@ -510,7 +512,7 @@
 								<div class="edit-label-row">
 									<span class="edit-label">Workspace allow-list</span>
 									{#if isAll}
-										<span class="edit-badge">Inert while wildcard is on</span>
+										<Chip size="sm" color="var(--accent-gray)">Inert while wildcard is on</Chip>
 									{/if}
 								</div>
 								<div class="ws-chips">
@@ -866,34 +868,6 @@
 		flex-shrink: 0;
 	}
 
-	/* Badges */
-	.badge {
-		display: inline-block;
-		padding: 2px 8px;
-		border-radius: 999px;
-		font-size: 0.72rem;
-		font-weight: 600;
-		text-transform: uppercase;
-		letter-spacing: 0.04em;
-		background: var(--bg-tertiary);
-		color: var(--text-secondary);
-	}
-
-	.badge.tier-gray {
-		background: rgba(148, 163, 184, 0.15);
-		color: var(--text-secondary);
-	}
-
-	.badge.tier-blue {
-		background: rgba(59, 130, 246, 0.15);
-		color: var(--accent-blue);
-	}
-
-	.badge.tier-orange {
-		background: rgba(217, 119, 6, 0.15);
-		color: var(--accent-orange, #d97706);
-	}
-
 	/* Buttons */
 	.btn {
 		padding: var(--space-2) var(--space-4);
@@ -1011,15 +985,6 @@
 		align-items: center;
 		gap: 0.5rem;
 		flex-wrap: wrap;
-	}
-
-	.edit-badge {
-		font-size: 0.75rem;
-		padding: 0.15rem 0.5rem;
-		border-radius: 4px;
-		background: var(--bg-muted, #f0f0f0);
-		color: var(--text-tertiary, #666);
-		font-weight: normal;
 	}
 
 	.edit-row {


### PR DESCRIPTION
Phase 2 / PR 1 of **PLAN-2290**. Two primitives extracted, first consumers migrated.

## statusColor consolidation
Four parallel implementations had drifted (`active`: green vs cyan; `draft`: muted vs blue; `open`: blue vs text-secondary; `rejected`: orange vs gray). Now ONE canonical palette in `lib/utils/fieldColors.ts`; `shareView.ts` re-exports it so public shares can't drift again. Conflicts resolved toward the refresh mock + existing `--status-*` tokens; each resolution documented in the module header. Most visible: **card status labels for `open` items now read blue** (previously plain text-secondary).

## Chip primitive
`lib/components/common/Chip.svelte` — the mock's tinted-pill treatment (new `--chip-alpha` token: 16% dark / 12% light), props: color / dot / size / onclick / pulse. Autofixer-clean.

## Migration
48 badge usages across 15 files (settings, library, playbooks, console/admin suite, timeline cards, version history); scoped `.badge` CSS deleted, **net −355 lines**. Filled white-text badges become tinted chips per the mock. Deliberate leave-alones documented per file (count bubbles, filter toggles with aria-pressed, stat tiles, rail markers).

## Gates
svelte-check 0 errors · 488 web tests · `make check` green · board/settings screenshots reviewed in both themes.

## Codex review resolution
- **Fixed**: Chip's button variant now always `preventDefault()`s so a clickable chip inside an `<a>` card can't trigger navigation; propagation deliberately continues (click-outside closers) — callers stopPropagation per the existing house pattern.
- **Documented as intended**: playbook `deprecated` badge orange → muted (canonical dormant family: draft/closed/archived/disabled/deprecated); categorical identity badges (timeline `user`, console `Member`, admin `pro`) map to literal `--status-blue` rather than the violet brand accent — they encode category, not brand, and must stay distinguishable from violet UI chrome (e.g. the purple `agent` badge).