### PR TITLE
feat(web): Menu/MenuItem primitive — 3 menus migrated, escape-stack + portal + pointerdown dismissal (TASK-2292)

### DIFF
--- a/web/e2e/pane-collection-migration-race.spec.ts
+++ b/web/e2e/pane-collection-migration-race.spec.ts
@@ -226,7 +226,7 @@ test('a collection migration completing after a rapid A->B pane switch refreshes
 
 	// Open Quick Actions -> Manage actions -> Edit Collection modal, Fields tab.
 	await pane.locator('button.trigger-btn[title="Quick actions"]').click();
-	await pane.locator('button.action-item.footer-row', { hasText: 'Manage actions' }).click();
+	await pane.getByRole('menuitem', { name: 'Manage actions' }).click();
 	await expect(page.locator('#edit-collection-title')).toBeVisible();
 	await page.locator('button.tab', { hasText: 'Fields' }).click();
 
@@ -399,7 +399,7 @@ test('a collection migration completing after a cross-collection navigation does
 	});
 
 	await page.locator('button.trigger-btn[title="Quick actions"]').click();
-	await page.locator('button.action-item.footer-row', { hasText: 'Manage actions' }).click();
+	await page.getByRole('menuitem', { name: 'Manage actions' }).click();
 	await expect(page.locator('#edit-collection-title')).toBeVisible();
 	await page.locator('button.tab', { hasText: 'Fields' }).click();
 

--- a/web/e2e/pane-controller.spec.ts
+++ b/web/e2e/pane-controller.spec.ts
@@ -417,7 +417,7 @@ test.describe('pane controller: depth/ownership state machine (PLAN-2154 / TASK-
 		// (old→new slug) while preserving `?item=` — routed through
 		// onNavigateAway (must replaceState + rebase ownership).
 		await pane.locator('button.trigger-btn[title="Quick actions"]').click();
-		await pane.locator('button.action-item.footer-row', { hasText: 'Manage actions' }).click();
+		await pane.getByRole('menuitem', { name: 'Manage actions' }).click();
 		await expect(page.locator('#edit-collection-title')).toBeVisible();
 		// "Manage actions" opens the modal on the Actions tab — switch to General
 		// to reach the collection-name field.

--- a/web/e2e/pane-full-page-capstone.spec.ts
+++ b/web/e2e/pane-full-page-capstone.spec.ts
@@ -423,9 +423,9 @@ test.describe('full-page pane host CAPSTONE (PLAN-2154 Phase 2 / TASK-2175)', ()
 		// owner write controls are all present.
 		await expect(trigger).toBeVisible();
 		await trigger.click();
-		await expect(col.locator('.action-label', { hasText: 'Summarize' })).toBeVisible();
-		await expect(col.locator('.action-label', { hasText: 'New quick action' })).toBeVisible();
-		await expect(col.locator('.action-label', { hasText: 'Manage actions' })).toBeVisible();
+		await expect(col.getByRole('menuitem', { name: 'Summarize' })).toBeVisible();
+		await expect(col.getByRole('menuitem', { name: 'New quick action' })).toBeVisible();
+		await expect(col.getByRole('menuitem', { name: 'Manage actions' })).toBeVisible();
 		await trigger.click(); // close
 
 		// Open the pane and activate it → the master becomes the peeking side.

--- a/web/e2e/quickactions-inline-form.spec.ts
+++ b/web/e2e/quickactions-inline-form.spec.ts
@@ -24,6 +24,12 @@ import type { SuiteFixture } from './fixtures';
  * Pre-fix: the create form never appears. Post-fix (stopPropagation): it
  * opens and stays, and Cancel returns to the action list instead of
  * closing the whole menu.
+ *
+ * PLAN-2290 Phase 2 update: QuickActionsMenu now rides the shared Menu
+ * primitive, whose pointerdown-based instance-scoped outside-click fires
+ * BEFORE row clicks mutate state — the stopPropagation workaround is gone
+ * because the detach hazard is structurally impossible. This test stays
+ * as regression coverage for the same user-visible behavior.
  */
 
 function authHeaders(fixture: SuiteFixture) {
@@ -101,7 +107,7 @@ test("the inline 'New quick action' form opens and stays open (BUG-2281)", async
 	await expect(page.locator('.title', { hasText: 'BUG-2281 form item' })).toBeVisible();
 
 	await page.locator('button.trigger-btn[title="Quick actions"]').click();
-	const openFormBtn = page.locator('button.action-item.footer-row', { hasText: 'New quick action' });
+	const openFormBtn = page.getByRole('menuitem', { name: 'New quick action' });
 	await expect(openFormBtn).toBeVisible();
 	await openFormBtn.click();
 
@@ -120,7 +126,7 @@ test("the inline 'New quick action' form opens and stays open (BUG-2281)", async
 	await page.locator('button.qa-btn.qa-btn-cancel', { hasText: 'Cancel' }).click();
 	await expect(page.locator('input.qa-label-input')).toHaveCount(0);
 	await expect(
-		page.locator('button.action-item.footer-row', { hasText: 'New quick action' }),
+		page.getByRole('menuitem', { name: 'New quick action' }),
 		'Cancel returns to the action list rather than closing the whole menu',
 	).toBeVisible();
 });

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -4,6 +4,9 @@
 	--bg-primary: #0b0b10;
 	--bg-secondary: #14141b;
 	--bg-tertiary: #1c1c25;
+	/* Elevated overlay surfaces (menus, popovers). Same as tertiary in
+	   dark; pure white in light where tertiary is a gray input tone. */
+	--bg-raised: #1c1c25;
 	--bg-hover: #22222d;
 	--bg-active: #2a2a36;
 
@@ -644,6 +647,7 @@ dialog.attachment-image-lightbox .attachment-image-lightbox-close:hover {
 	--bg-primary: #f5f5f9;
 	--bg-secondary: #ffffff;
 	--bg-tertiary: #efeff4;
+	--bg-raised: #ffffff;
 	--bg-hover: #ededf3;
 	--bg-active: #e3e3ec;
 	--text-primary: #191922;
@@ -681,6 +685,7 @@ dialog.attachment-image-lightbox .attachment-image-lightbox-close:hover {
 		--bg-primary: #f5f5f9;
 		--bg-secondary: #ffffff;
 		--bg-tertiary: #efeff4;
+	--bg-raised: #ffffff;
 		--bg-hover: #ededf3;
 		--bg-active: #e3e3ec;
 		--text-primary: #191922;

--- a/web/src/lib/components/collections/ItemActionsMenu.svelte
+++ b/web/src/lib/components/collections/ItemActionsMenu.svelte
@@ -9,8 +9,20 @@
 	The host (ListView / BoardView / TableView / ChildItems) owns all
 	ordering context — it passes a bound `onReorder(dir)` and the set of
 	`disabledDirs` for this item's position. This component is purely the
-	menu surface: open/close, positioning, a11y, and emitting the chosen
-	direction.
+	trigger + emitting the chosen direction; the shared Menu primitive
+	(PLAN-2290 Phase 2) owns positioning, outside-click, keyboard nav,
+	and menu a11y.
+
+	Menu runs in PORTAL mode here, non-negotiably: ItemCard's host rows
+	establish paint containment via `content-visibility: auto` (ListView
+	rows, BoardView cards, TableView rows — all for off-screen
+	virtualization), which clips absolutely-positioned descendants to the
+	row box. The portal's body-level fixed panel escapes the containment
+	entirely.
+
+	No mobile sheet on purpose: the small fixed dropdown works on every
+	viewport (a 188px panel fits even on a 320px phone), and a sheet for
+	a 4-item menu read as "taking over the card".
 
 	Why a dedicated component (not QuickActionsMenu): QuickActionsMenu is
 	coupled to prompt-template quick actions (resolve/copy, inline create
@@ -18,9 +30,10 @@
 	component is simpler than bending that one.
 -->
 <script lang="ts">
-	import { tick } from 'svelte';
 	import type { Item } from '$lib/types';
 	import type { ReorderDirection } from '$lib/collections/reorder';
+	import Menu from '$lib/components/common/Menu.svelte';
+	import MenuItem from '$lib/components/common/MenuItem.svelte';
 
 	// Horizontal (adjacent-column) moves ride a SEPARATE optional callback so
 	// the shared vertical `onReorder` type stays 'top'|'bottom'|'up'|'down'
@@ -70,58 +83,6 @@
 
 	let open = $state(false);
 	let triggerEl = $state<HTMLButtonElement>();
-	let panelEl = $state<HTMLDivElement>();
-	let x = $state(0);
-	let y = $state(0);
-	let activeIndex = $state(0);
-
-	const PANEL_W = 188;
-	const ROW_H = 38;
-
-	/**
-	 * Portal the desktop panel to <body>. ItemCard's host rows establish
-	 * paint containment via `content-visibility: auto` (ListView rows,
-	 * BoardView cards, TableView rows — all for off-screen virtualization),
-	 * which clips descendant overflow to the row box. An absolutely-
-	 * positioned dropdown would be sheared off at ~36–60px; a body-level
-	 * portal with fixed coords escapes the containment entirely. Mirrors
-	 * the EmojiPickerButton pattern.
-	 */
-	function portal(node: HTMLElement) {
-		document.body.appendChild(node);
-		return {
-			destroy() {
-				node.remove();
-			}
-		};
-	}
-
-	function openMenu() {
-		if (!triggerEl || actions.length === 0) return;
-		const r = triggerEl.getBoundingClientRect();
-		// Right-align the panel under the trigger; flip above if it would
-		// leave the viewport, clamp to the left edge. The small fixed
-		// dropdown works on every viewport (it fits a 188px panel even on a
-		// 320px phone), so there's no separate mobile sheet — a sheet for a
-		// 4-item menu read as "taking over the card".
-		let left = r.right - PANEL_W;
-		if (left < 8) left = 8;
-		const estH = actions.length * ROW_H + 8;
-		let top = r.bottom + 4;
-		if (top + estH > window.innerHeight - 8) {
-			top = Math.max(8, r.top - estH - 4);
-		}
-		x = left;
-		y = top;
-		open = true;
-		activeIndex = 0;
-		tick().then(() => focusItem(0));
-	}
-
-	function closeMenu(returnFocus = true) {
-		open = false;
-		if (returnFocus) triggerEl?.focus();
-	}
 
 	function pick(dir: MenuDirection) {
 		if (disabledDirs?.has(dir)) return;
@@ -129,7 +90,7 @@
 		// the optimistic reorder state — a second move needs a reopen, by
 		// which point the new order has settled. (Drag is naturally
 		// debounced; menu clicks are not.)
-		closeMenu(false);
+		open = false;
 		if (dir === 'left' || dir === 'right') {
 			onMove?.(dir);
 		} else {
@@ -139,64 +100,14 @@
 
 	function onTriggerClick(e: MouseEvent) {
 		// The trigger lives inside the card's <a>; stop the click from
-		// navigating (mirrors toggleStar in ItemCard).
+		// navigating (mirrors toggleStar in ItemCard). This is card
+		// behavior, NOT an outside-click workaround — it stays under the
+		// Menu primitive.
 		e.preventDefault();
 		e.stopPropagation();
-		if (open) closeMenu();
-		else openMenu();
+		open = !open;
 	}
-
-	function focusItem(i: number) {
-		const btns = panelEl?.querySelectorAll<HTMLButtonElement>('.iam-item');
-		btns?.[i]?.focus();
-	}
-
-	function onPanelKeydown(e: KeyboardEvent) {
-		if (e.key === 'Escape') {
-			e.preventDefault();
-			closeMenu();
-		} else if (e.key === 'ArrowDown') {
-			e.preventDefault();
-			activeIndex = (activeIndex + 1) % actions.length;
-			focusItem(activeIndex);
-		} else if (e.key === 'ArrowUp') {
-			e.preventDefault();
-			activeIndex = (activeIndex - 1 + actions.length) % actions.length;
-			focusItem(activeIndex);
-		} else if (e.key === 'Home') {
-			e.preventDefault();
-			activeIndex = 0;
-			focusItem(0);
-		} else if (e.key === 'End') {
-			e.preventDefault();
-			activeIndex = actions.length - 1;
-			focusItem(activeIndex);
-		}
-	}
-
-	// Instance-scoped outside-click: don't match a shared class (that would
-	// also match OTHER item menus' triggers and keep this one open when
-	// another opens). Check this instance's own trigger + portaled panel.
-	function onWindowClick(e: MouseEvent) {
-		if (!open) return;
-		const t = e.target as Node | null;
-		if (!t) return;
-		if (triggerEl?.contains(t) || panelEl?.contains(t)) return;
-		closeMenu(false);
-	}
-
-	// A scroll while open detaches the fixed panel from its row — close it.
-	// Capture catches inner scroll containers (board column, table scroll)
-	// in addition to the window. Only listens while open.
-	$effect(() => {
-		if (!open) return;
-		const onScroll = () => closeMenu(false);
-		window.addEventListener('scroll', onScroll, true);
-		return () => window.removeEventListener('scroll', onScroll, true);
-	});
 </script>
-
-<svelte:window onclick={onWindowClick} />
 
 {#if actions.length > 0}
 	<span class="item-actions-menu">
@@ -214,30 +125,18 @@
 			⋮
 		</button>
 
-		{#if open}
-			<div
-				bind:this={panelEl}
-				class="iam-panel"
-				role="menu"
-				tabindex="-1"
-				use:portal
-				style="position:fixed; left:{x}px; top:{y}px; z-index:99999;"
-				onkeydown={onPanelKeydown}
-			>
-				{#each actions as a, i (a.dir)}
-					<button
-						type="button"
-						class="iam-item"
-						role="menuitem"
-						tabindex={i === activeIndex ? 0 : -1}
-						onclick={() => pick(a.dir)}
-					>
-						<span class="iam-icon" aria-hidden="true">{a.icon}</span>
-						{a.text}
-					</button>
-				{/each}
-			</div>
-		{/if}
+		<Menu
+			{open}
+			onclose={() => (open = false)}
+			trigger={triggerEl}
+			mode="portal"
+			width={188}
+			ariaLabel={label ? `Reorder ${label}` : 'Reorder item'}
+		>
+			{#each actions as a (a.dir)}
+				<MenuItem icon={a.icon} onclick={() => pick(a.dir)}>{a.text}</MenuItem>
+			{/each}
+		</Menu>
 	</span>
 {/if}
 
@@ -272,55 +171,5 @@
 		opacity: 1;
 		outline: 2px solid var(--accent-blue);
 		outline-offset: 1px;
-	}
-
-	/* Portaled panel lives at <body>, so it can't rely on any ancestor
-	   variables being in scope — it uses the same global custom props the
-	   rest of the app's surfaces use. */
-	:global(.iam-panel) {
-		min-width: 188px;
-		padding: var(--space-1);
-		background: var(--bg-primary);
-		border: 1px solid var(--border);
-		border-radius: var(--radius-md);
-		box-shadow: var(--shadow-md);
-		display: flex;
-		flex-direction: column;
-		gap: 2px;
-	}
-
-	:global(.iam-item) {
-		display: flex;
-		align-items: center;
-		gap: var(--space-2);
-		width: 100%;
-		padding: 8px 10px;
-		background: none;
-		border: none;
-		border-radius: var(--radius-sm);
-		color: var(--text-primary);
-		font-size: 0.875em;
-		text-align: left;
-		cursor: pointer;
-	}
-
-	:global(.iam-item:hover),
-	:global(.iam-item:focus-visible) {
-		background: var(--bg-hover);
-		outline: none;
-	}
-
-	:global(.iam-icon) {
-		width: 1.1em;
-		text-align: center;
-		flex-shrink: 0;
-		color: var(--text-muted);
-	}
-
-	/* Comfortable tap targets on touch without a separate sheet. */
-	@media (pointer: coarse) {
-		:global(.iam-item) {
-			padding: 12px 12px;
-		}
 	}
 </style>

--- a/web/src/lib/components/common/Menu.svelte
+++ b/web/src/lib/components/common/Menu.svelte
@@ -1,0 +1,205 @@
+<script lang="ts">
+	import { tick } from 'svelte';
+	import type { Snippet } from 'svelte';
+	import { pushEscapeHandler, ESCAPE_PRIORITY } from '$lib/stores/escapeStack';
+	import { clickOutside } from '$lib/utils/clickOutside';
+	import { portal } from '$lib/utils/portalAction';
+	import { viewport } from '$lib/stores/breakpoint.svelte';
+	import BottomSheet from './BottomSheet.svelte';
+
+
+	interface Props {
+		/** Controlled by the parent (trigger owns the state). */
+		open: boolean;
+		onclose: () => void;
+		/** The trigger element — focus returns here on close and it is
+		 *  exempt from outside-click. */
+		trigger?: HTMLElement;
+		/** anchored = absolute below a position:relative wrapper;
+		 *  portal = fixed coords portaled to <body> (escapes overflow and
+		 *  content-visibility containment; flips above when cramped). */
+		mode?: 'anchored' | 'portal';
+		align?: 'right' | 'left';
+		/** Portal mode: panel width used for viewport clamping. */
+		width?: number;
+		/** Swap to BottomSheet at the mobile breakpoint. */
+		sheetOnMobile?: boolean;
+		sheetTitle?: string;
+		ariaLabel?: string;
+		/** Extra containers that count as "inside" for outside-click
+		 *  (e.g. a nested portaled emoji picker). */
+		exempt?: () => (Element | null | undefined)[];
+		children: Snippet;
+	}
+
+	let {
+		open,
+		onclose,
+		trigger,
+		mode = 'anchored',
+		align = 'right',
+		width = 220,
+		sheetOnMobile = false,
+		sheetTitle,
+		ariaLabel,
+		exempt,
+		children
+	}: Props = $props();
+
+	let panelEl: HTMLDivElement | undefined = $state(undefined);
+	let coords = $state({ top: 0, left: 0 });
+
+	const useSheet = $derived(sheetOnMobile && viewport.isMobile);
+
+	// Portal-mode placement: fixed coords from the trigger rect, flipping
+	// above when there's no room below and clamping to the viewport.
+	function place() {
+		if (!trigger) return;
+		const r = trigger.getBoundingClientRect();
+		const panelH = panelEl?.offsetHeight ?? 240;
+		const below = r.bottom + 6;
+		const top = below + panelH > window.innerHeight && r.top - panelH - 6 > 0
+			? r.top - panelH - 6
+			: below;
+		let left = align === 'right' ? r.right - width : r.left;
+		left = Math.max(8, Math.min(left, window.innerWidth - width - 8));
+		coords = { top, left };
+	}
+
+	// Focus the first row on open (menus are keyboard surfaces); return
+	// focus to the trigger on close. Reads `open`/`panelEl`, writes neither.
+	$effect(() => {
+		if (open && !useSheet) {
+			tick().then(() => {
+				if (mode === 'portal') place();
+				firstItem()?.focus();
+			});
+		}
+	});
+
+	// ESC chain registration while open (desktop panel only — BottomSheet
+	// owns ESC on mobile).
+	$effect(() => {
+		if (!open || useSheet) return;
+		const unregister = pushEscapeHandler(() => {
+			close();
+			return true;
+		}, ESCAPE_PRIORITY.menu);
+		return unregister;
+	});
+
+	// Portal mode: any scroll closes (coords would go stale).
+	$effect(() => {
+		if (!open || useSheet || mode !== 'portal') return;
+		const onScroll = () => close();
+		window.addEventListener('scroll', onScroll, { capture: true, passive: true });
+		return () => window.removeEventListener('scroll', onScroll, { capture: true });
+	});
+
+	function close() {
+		onclose();
+		trigger?.focus();
+	}
+
+	function items(): HTMLElement[] {
+		if (!panelEl) return [];
+		return Array.from(
+			panelEl.querySelectorAll<HTMLElement>('[role^="menuitem"]:not(:disabled)')
+		);
+	}
+
+	function firstItem(): HTMLElement | undefined {
+		return items()[0];
+	}
+
+	function onKeydown(e: KeyboardEvent) {
+		if (e.key === 'Escape') {
+			e.stopPropagation();
+			close();
+			return;
+		}
+		const list = items();
+		if (list.length === 0) return;
+		const idx = list.indexOf(document.activeElement as HTMLElement);
+		let next = -1;
+		if (e.key === 'ArrowDown') next = idx < list.length - 1 ? idx + 1 : 0;
+		else if (e.key === 'ArrowUp') next = idx > 0 ? idx - 1 : list.length - 1;
+		else if (e.key === 'Home') next = 0;
+		else if (e.key === 'End') next = list.length - 1;
+		if (next >= 0) {
+			e.preventDefault();
+			list[next].focus();
+		}
+	}
+</script>
+
+{#if useSheet}
+	{#if open}
+		<BottomSheet {open} onclose={onclose} title={sheetTitle}>
+			{@render children()}
+		</BottomSheet>
+	{/if}
+{:else if open}
+	{#if mode === 'portal'}
+		<div
+			class="menu-panel portal"
+			style:top="{coords.top}px"
+			style:left="{coords.left}px"
+			style:width="{width}px"
+			role="menu"
+			aria-label={ariaLabel}
+			tabindex="-1"
+			bind:this={panelEl}
+			use:portal
+			use:clickOutside={{ onOutside: onclose, extra: () => [trigger, ...(exempt?.() ?? [])] }}
+			onkeydown={onKeydown}
+		>
+			{@render children()}
+		</div>
+	{:else}
+		<div
+			class="menu-panel anchored"
+			class:align-left={align === 'left'}
+			role="menu"
+			aria-label={ariaLabel}
+			tabindex="-1"
+			bind:this={panelEl}
+			use:clickOutside={{ onOutside: onclose, extra: () => [trigger, ...(exempt?.() ?? [])] }}
+			onkeydown={onKeydown}
+		>
+			{@render children()}
+		</div>
+	{/if}
+{/if}
+
+<style>
+	.menu-panel {
+		background: var(--bg-raised, var(--bg-tertiary));
+		border: 1px solid var(--border);
+		border-radius: var(--radius-lg);
+		box-shadow: var(--shadow-md);
+		padding: 5px;
+		min-width: 180px;
+		max-height: 340px;
+		overflow-y: auto;
+		z-index: 200;
+	}
+
+	.anchored {
+		position: absolute;
+		top: calc(100% + 6px);
+		right: 0;
+	}
+
+	.anchored.align-left {
+		right: auto;
+		left: 0;
+	}
+
+	/* Portaled panels can't use scoped descendant selectors on children —
+	   rows are MenuItem components with their own scoped styles, so the
+	   panel shell itself is all that needs styling here. */
+	.portal {
+		position: fixed;
+	}
+</style>

--- a/web/src/lib/components/common/Menu.svelte
+++ b/web/src/lib/components/common/Menu.svelte
@@ -29,6 +29,9 @@
 		/** Extra containers that count as "inside" for outside-click
 		 *  (e.g. a nested portaled emoji picker). */
 		exempt?: () => (Element | null | undefined)[];
+		/** Return true to suppress outside-close for this event (e.g. while
+		 *  a drag interaction is in flight — cf. TopBar pill drags). */
+		suppressOutside?: () => boolean;
 		children: Snippet;
 	}
 
@@ -43,6 +46,7 @@
 		sheetTitle,
 		ariaLabel,
 		exempt,
+		suppressOutside,
 		children
 	}: Props = $props();
 
@@ -88,12 +92,18 @@
 		return unregister;
 	});
 
-	// Portal mode: any scroll closes (coords would go stale).
+	// Portal mode: any scroll or resize closes (coords would go stale).
+	// Deliberately onclose() and NOT close(): refocusing the trigger here
+	// would scroll the card back into view and fight the user's scroll.
 	$effect(() => {
 		if (!open || useSheet || mode !== 'portal') return;
-		const onScroll = () => close();
-		window.addEventListener('scroll', onScroll, { capture: true, passive: true });
-		return () => window.removeEventListener('scroll', onScroll, { capture: true });
+		const dismiss = () => onclose();
+		window.addEventListener('scroll', dismiss, { capture: true, passive: true });
+		window.addEventListener('resize', dismiss, { passive: true });
+		return () => {
+			window.removeEventListener('scroll', dismiss, { capture: true });
+			window.removeEventListener('resize', dismiss);
+		};
 	});
 
 	function close() {
@@ -151,7 +161,7 @@
 			tabindex="-1"
 			bind:this={panelEl}
 			use:portal
-			use:clickOutside={{ onOutside: onclose, extra: () => [trigger, ...(exempt?.() ?? [])] }}
+			use:clickOutside={{ onOutside: onclose, extra: () => [trigger, ...(exempt?.() ?? [])], suppress: suppressOutside }}
 			onkeydown={onKeydown}
 		>
 			{@render children()}
@@ -164,7 +174,7 @@
 			aria-label={ariaLabel}
 			tabindex="-1"
 			bind:this={panelEl}
-			use:clickOutside={{ onOutside: onclose, extra: () => [trigger, ...(exempt?.() ?? [])] }}
+			use:clickOutside={{ onOutside: onclose, extra: () => [trigger, ...(exempt?.() ?? [])], suppress: suppressOutside }}
 			onkeydown={onKeydown}
 		>
 			{@render children()}

--- a/web/src/lib/components/common/MenuItem.svelte
+++ b/web/src/lib/components/common/MenuItem.svelte
@@ -1,0 +1,106 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	interface Props {
+		/** Leading icon/emoji. */
+		icon?: string;
+		/** Right-aligned hint (shortcut, count). */
+		hint?: string;
+		/** Red row for destructive actions. */
+		danger?: boolean;
+		/** When defined the row is a menuitemradio with a trailing check. */
+		checked?: boolean;
+		disabled?: boolean;
+		onclick?: (e: MouseEvent) => void;
+		children: Snippet;
+	}
+
+	let { icon, hint, danger = false, checked, disabled = false, onclick, children }: Props = $props();
+</script>
+
+<button
+	type="button"
+	class="mi"
+	class:danger
+	role={checked !== undefined ? 'menuitemradio' : 'menuitem'}
+	aria-checked={checked}
+	{disabled}
+	{onclick}
+>
+	{#if icon}<span class="mi-icon" aria-hidden="true">{icon}</span>{/if}
+	<span class="mi-label">{@render children()}</span>
+	{#if hint}<span class="mi-hint">{hint}</span>{/if}
+	{#if checked}<span class="mi-check" aria-hidden="true">✓</span>{/if}
+</button>
+
+<style>
+	.mi {
+		display: flex;
+		align-items: center;
+		gap: 9px;
+		width: 100%;
+		padding: 7px 9px;
+		border: none;
+		border-radius: var(--radius-sm);
+		background: none;
+		color: var(--text-primary);
+		font: inherit;
+		font-size: 13px;
+		text-align: left;
+		cursor: pointer;
+	}
+
+	.mi:hover:not(:disabled),
+	.mi:focus-visible {
+		background: var(--bg-hover);
+	}
+
+	.mi:focus-visible {
+		outline: none;
+	}
+
+	.mi:disabled {
+		opacity: 0.5;
+		cursor: default;
+	}
+
+	.mi-icon {
+		width: 18px;
+		text-align: center;
+		flex: 0 0 18px;
+		opacity: 0.85;
+	}
+
+	.mi-label {
+		flex: 1;
+		min-width: 0;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	.mi-hint {
+		color: var(--text-muted);
+		font-size: 11.5px;
+		flex: 0 0 auto;
+	}
+
+	.mi-check {
+		color: var(--accent-primary-soft, var(--accent-blue));
+		flex: 0 0 auto;
+	}
+
+	.mi.danger {
+		color: var(--accent-red);
+	}
+
+	.mi.danger:hover:not(:disabled) {
+		background: color-mix(in srgb, var(--accent-red) 12%, transparent);
+	}
+
+	@media (pointer: coarse) {
+		.mi {
+			padding: 11px 10px;
+		}
+	}
+</style>

--- a/web/src/lib/components/common/QuickActionsMenu.svelte
+++ b/web/src/lib/components/common/QuickActionsMenu.svelte
@@ -3,8 +3,8 @@
 	import { parseFields, formatItemRef, parseSettings } from '$lib/types';
 	import { api, isConflictOrNotFound } from '$lib/api/client';
 	import { toastStore } from '$lib/stores/toast.svelte';
-	import BottomSheet from '$lib/components/common/BottomSheet.svelte';
-	import { viewport } from '$lib/stores/breakpoint.svelte';
+	import Menu from '$lib/components/common/Menu.svelte';
+	import MenuItem from '$lib/components/common/MenuItem.svelte';
 	import EmojiPickerButton from '$lib/components/common/EmojiPickerButton.svelte';
 
 	interface Props {
@@ -31,11 +31,16 @@
 
 	let open = $state(false);
 	let alignLeft = $state(false);
-	let triggerEl = $state<HTMLButtonElement | null>(null);
+	let triggerEl = $state<HTMLButtonElement>();
 
 	// ── Inline create-form state ─────────────────────────────────────────
 	// `showCreateForm` collapses the action list and swaps in the inline
 	// form when the user clicks "+ New quick action" in the footer.
+	//
+	// The BUG-2281 stopPropagation workaround (open/cancel clicks racing the
+	// window click-outside handler on a detached target) is retired: the Menu
+	// primitive's outside-click is pointerdown-based and fires BEFORE a row
+	// click mutates state, so the detach hazard is structurally gone.
 	let showCreateForm = $state(false);
 	let newLabel = $state('');
 	let newPrompt = $state('');
@@ -43,9 +48,6 @@
 	let saving = $state(false);
 
 	let filtered = $derived(actions.filter((a) => a.scope === scope));
-
-	// Mobile viewport swaps the absolute-positioned popover for a BottomSheet
-	// that never clips off-screen. Uses the shared breakpoint store (TASK-2028).
 
 	function resolvePrompt(action: QuickAction): string {
 		let prompt = action.prompt;
@@ -110,30 +112,6 @@
 		newLabel = '';
 		newPrompt = '';
 		newIcon = '';
-	}
-
-	function handleOpenCreateForm(e: MouseEvent) {
-		// stopPropagation, mirroring handleTriggerClick (BUG-2281): flipping
-		// showCreateForm unmounts the footer's {:else} branch (this very
-		// button). Svelte 5 flushSyncs after a delegated event handler, so by
-		// the time this click bubbles on to the <svelte:window> click-outside
-		// handler the button is DETACHED — `target.closest('.quick-actions-menu')`
-		// then returns null, and handleWindowClick treats it as an outside
-		// click and closes the whole menu (open=false + resetCreateForm),
-		// wiping the create form the instant it opens. Stopping propagation
-		// keeps the click from reaching the window handler at all.
-		e.stopPropagation();
-		showCreateForm = true;
-	}
-
-	function handleCancelCreateForm(e: MouseEvent) {
-		// Same detach-then-window-close race as handleOpenCreateForm (BUG-2281):
-		// resetCreateForm unmounts the create form (this Cancel button), so
-		// without stopPropagation the bubbling click would hit the window
-		// handler on a detached target and close the whole menu instead of
-		// returning to the action list.
-		e.stopPropagation();
-		resetCreateForm();
 	}
 
 	function handleManage() {
@@ -233,15 +211,14 @@
 		}
 	}
 
-	function handleTriggerClick(e: MouseEvent) {
-		e.stopPropagation();
+	function handleTriggerClick() {
 		const nextOpen = !open;
-		// Only compute alignment when opening on desktop; the mobile branch
-		// renders a BottomSheet which doesn't need trigger-relative positioning.
-		if (nextOpen && !viewport.isMobile && triggerEl) {
+		if (nextOpen && triggerEl) {
 			const rect = triggerEl.getBoundingClientRect();
 			// If the trigger is too close to the left edge, the default
-			// right-anchored 200px dropdown would clip — switch to left-anchored.
+			// right-anchored dropdown would clip — switch to left-anchored.
+			// (Only matters for the desktop anchored panel; the mobile
+			// BottomSheet ignores alignment, so computing it is harmless.)
 			alignLeft = rect.left < 220;
 		}
 		if (!nextOpen) {
@@ -252,31 +229,23 @@
 		open = nextOpen;
 	}
 
-	function handleWindowClick(e: MouseEvent) {
-		// On mobile the BottomSheet owns dismissal (backdrop tap, Escape,
-		// swipe-down) — skip the outside-click handler so it doesn't race.
-		if (viewport.isMobile) return;
-		const target = e.target as HTMLElement;
-		if (!target) return;
-		// The EmojiPickerButton portals its dropdown to document.body (or the
-		// nearest <dialog>); clicks inside the portal (.epb-dropdown) or on
-		// the emoji trigger itself (.emoji-picker-button) should NOT close
-		// the menu, or the in-progress emoji selection is lost before the
-		// bound value can update.
-		if (target.closest('.epb-dropdown') || target.closest('.emoji-picker-button')) return;
-		if (!target.closest('.quick-actions-menu')) {
-			open = false;
-			resetCreateForm();
-		}
-	}
-
-	function handleBottomSheetClose() {
+	function closeMenu() {
 		open = false;
 		resetCreateForm();
 	}
-</script>
 
-<svelte:window onclick={handleWindowClick} />
+	// The EmojiPickerButton portals its dropdown to document.body (or the
+	// nearest <dialog>), so it is NOT inside the Menu panel's DOM — pass its
+	// containers as outside-click exemptions or the in-progress emoji
+	// selection closes the whole menu before the bound value can update.
+	// Queried from document because of the portal.
+	function emojiPickerContainers(): (Element | null | undefined)[] {
+		return [
+			...document.querySelectorAll('.epb-dropdown'),
+			...document.querySelectorAll('.emoji-picker-button')
+		];
+	}
+</script>
 
 {#snippet createForm()}
 	<div class="create-form">
@@ -299,7 +268,7 @@
 			Template variables: {'{ref}'} {'{title}'} {'{status}'} {'{priority}'} {'{collection}'} {'{content}'} {'{fields}'}
 		</div>
 		<div class="qa-actions">
-			<button class="qa-btn qa-btn-cancel" type="button" onclick={handleCancelCreateForm}>
+			<button class="qa-btn qa-btn-cancel" type="button" onclick={resetCreateForm}>
 				Cancel
 			</button>
 			<button
@@ -319,24 +288,15 @@
 		{@render createForm()}
 	{:else}
 		{#each filtered as action (action.label)}
-			<button class="action-item" onclick={() => handleAction(action)}>
-				{#if action.icon}
-					<span class="action-icon">{action.icon}</span>
-				{/if}
-				<span class="action-label">{action.label}</span>
-			</button>
+			<MenuItem icon={action.icon} onclick={() => handleAction(action)}>
+				{action.label}
+			</MenuItem>
 		{/each}
 		<div class="dropdown-tagline">Copy a prompt to your agent</div>
 		{#if canEdit}
 			<div class="footer-divider"></div>
-			<button class="action-item footer-row" type="button" onclick={handleOpenCreateForm}>
-				<span class="action-icon">+</span>
-				<span class="action-label">New quick action</span>
-			</button>
-			<button class="action-item footer-row" type="button" onclick={handleManage}>
-				<span class="action-icon">&#9881;</span>
-				<span class="action-label">Manage actions</span>
-			</button>
+			<MenuItem icon="+" onclick={() => (showCreateForm = true)}>New quick action</MenuItem>
+			<MenuItem icon="⚙" onclick={handleManage}>Manage actions</MenuItem>
 		{/if}
 	{/if}
 {/snippet}
@@ -346,26 +306,34 @@
 		<button
 			bind:this={triggerEl}
 			class="trigger-btn"
+			aria-haspopup="menu"
+			aria-expanded={open}
 			onclick={handleTriggerClick}
 			title="Quick actions"
 		>
 			&#9889;
 		</button>
 
-		{#if viewport.isMobile}
-			<BottomSheet {open} onclose={handleBottomSheetClose} title="Quick actions">
-				{@render actionList()}
-			</BottomSheet>
-		{:else if open}
-			<div class="dropdown" class:align-left={alignLeft}>
+		<Menu
+			{open}
+			onclose={closeMenu}
+			trigger={triggerEl}
+			align={alignLeft ? 'left' : 'right'}
+			sheetOnMobile
+			sheetTitle="Quick actions"
+			ariaLabel="Quick actions"
+			exempt={emojiPickerContainers}
+		>
+			<div class="qa-body">
 				{@render actionList()}
 			</div>
-		{/if}
+		</Menu>
 	</div>
 {/if}
 
 <style>
 	.quick-actions-menu {
+		/* Anchor for Menu's anchored mode. */
 		position: relative;
 		display: inline-block;
 	}
@@ -386,57 +354,13 @@
 		color: var(--text-primary);
 	}
 
-	.dropdown {
-		position: absolute;
-		top: 100%;
-		right: 0;
-		margin-top: var(--space-1);
-		min-width: 240px;
-		/* Defensive cap so the popover can never overflow the viewport
-		   horizontally, even if trigger placement or zoom produces an
-		   edge case we didn't anticipate. */
+	/* Sizes the slotted content (Menu's panel is min-width 180px on its
+	   own — too narrow for the inline create form). The viewport cap is
+	   defensive: the popover should never overflow horizontally even if
+	   trigger placement or zoom produces an edge case we didn't anticipate. */
+	.qa-body {
+		min-width: 230px;
 		max-width: calc(100vw - var(--space-4));
-		background: var(--bg-secondary);
-		border: 1px solid var(--border);
-		border-radius: var(--radius);
-		box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-		z-index: 50;
-		padding: var(--space-1) 0;
-	}
-
-	/* When the trigger sits near the viewport's left edge, flip to
-	   left-anchored so the dropdown opens rightward and stays on-screen. */
-	.dropdown.align-left {
-		right: auto;
-		left: 0;
-	}
-
-	.action-item {
-		display: flex;
-		align-items: center;
-		gap: var(--space-2);
-		width: 100%;
-		padding: var(--space-2) var(--space-3);
-		background: none;
-		border: none;
-		color: var(--text-primary);
-		font-size: 0.85em;
-		cursor: pointer;
-		text-align: left;
-		transition: background 0.1s;
-	}
-
-	.action-item:hover {
-		background: var(--bg-tertiary);
-	}
-
-	.action-icon {
-		flex-shrink: 0;
-	}
-
-	.action-label {
-		flex: 1;
-		min-width: 0;
 	}
 
 	.dropdown-tagline {
@@ -447,21 +371,12 @@
 		text-align: center;
 	}
 
-	/* ── Footer rows (gated by canEdit) ─────────────────────────────── */
+	/* ── Footer (gated by canEdit) ──────────────────────────────────── */
 
 	.footer-divider {
 		height: 1px;
 		background: var(--border);
 		margin: var(--space-1) 0;
-	}
-
-	.footer-row {
-		color: var(--text-secondary);
-	}
-
-	.footer-row:hover {
-		color: var(--text-primary);
-		background: var(--bg-tertiary);
 	}
 
 	/* ── Inline create form ─────────────────────────────────────────── */

--- a/web/src/lib/components/common/QuickActionsMenu.svelte
+++ b/web/src/lib/components/common/QuickActionsMenu.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { tick } from 'svelte';
 	import type { QuickAction, Item, Collection } from '$lib/types';
 	import { parseFields, formatItemRef, parseSettings } from '$lib/types';
 	import { api, isConflictOrNotFound } from '$lib/api/client';
@@ -42,6 +43,17 @@
 	// primitive's outside-click is pointerdown-based and fires BEFORE a row
 	// click mutates state, so the detach hazard is structurally gone.
 	let showCreateForm = $state(false);
+	let labelInputEl: HTMLInputElement | undefined = $state(undefined);
+
+	// The focused "New quick action" row unmounts when the form swaps in —
+	// hand focus to the label input so keyboard users aren't dropped on
+	// <body> (PR #1022 Codex finding). Reads showCreateForm, writes only
+	// DOM focus.
+	$effect(() => {
+		if (showCreateForm) {
+			tick().then(() => labelInputEl?.focus());
+		}
+	});
 	let newLabel = $state('');
 	let newPrompt = $state('');
 	let newIcon = $state('');
@@ -256,6 +268,7 @@
 				type="text"
 				placeholder="Action label"
 				bind:value={newLabel}
+				bind:this={labelInputEl}
 			/>
 		</div>
 		<textarea

--- a/web/src/lib/components/layout/TopBar.svelte
+++ b/web/src/lib/components/layout/TopBar.svelte
@@ -12,11 +12,14 @@
 	import WorkspaceSwitcher from '$lib/components/layout/WorkspaceSwitcher.svelte';
 	import UserMenuResources from '$lib/components/layout/UserMenuResources.svelte';
 	import ConnectWorkspaceModal from '$lib/components/ConnectWorkspaceModal.svelte';
+	import Menu from '$lib/components/common/Menu.svelte';
+	import MenuItem from '$lib/components/common/MenuItem.svelte';
 	import { workspaceRestoreTarget } from '$lib/utils/workspace-route';
 
 	let { mobile = false }: { mobile?: boolean } = $props();
 
 	let userMenuOpen = $state(false);
+	let userTriggerEl: HTMLButtonElement | undefined = $state(undefined);
 	let currentTheme = $state<'dark' | 'light'>('dark');
 	let connectOpen = $state(false);
 
@@ -590,13 +593,28 @@
 	}
 </script>
 
+<!--
+	This window handler now serves ONLY the dnd-entangled workspace
+	overflow menu. The user menu moved onto the shared Menu primitive
+	(PLAN-2290 Phase 2 / TASK-2292), which owns its own instance-scoped
+	pointerdown outside-click.
+
+	The overflow menu deliberately stays on window `click` with the
+	`!isDragging` guard rather than the primitive's pointerdown-based
+	outside-close:
+	  • pointerdown fires at drag START — mousedown on a workspace pill
+	    (outside the menu) is exactly how a reorder drag begins, so a
+	    pointerdown-based close would tear the menu down as the user
+	    starts dragging toward it.
+	  • the `click` fired on mouseup at drag END must NOT close the menu
+	    either — finalize handlers are still wiring up state at that
+	    point (drop animation / finalize ordering), hence the
+	    `!isDragging` guard below.
+-->
 <svelte:window
 	onmouseup={disarmMenu}
 	onclick={(e) => {
 		const target = e.target as HTMLElement;
-		if (userMenuOpen && !target.closest('.user-menu-container')) {
-			closeUserMenu();
-		}
 		// Don't close on outside-click during a drag — the click event
 		// fired on mouseup at drag end would otherwise tear down the
 		// menu while finalize handlers are still wiring up state.
@@ -611,6 +629,108 @@
 	}}
 	onkeydown={handleOverflowKeydown}
 />
+
+<!--
+	User menu — shared by the desktop and mobile branches (the two copies
+	were previously duplicated verbatim). Migrated onto the shared Menu
+	primitive (PLAN-2290 Phase 2 / TASK-2292): the primitive owns the
+	panel skin, pointerdown outside-click, ESC via the escape stack,
+	roving keyboard nav over [role^=menuitem], and focus-return to the
+	trigger. Rows that navigate stay real <a>s (role="menuitem" so the
+	roving nav picks them up); action rows are MenuItem buttons.
+
+	The inner .user-dropdown wrapper is a styling hook, not a panel:
+	UserMenuResources' scoped styles target :global(.user-dropdown)
+	(see its <style> block), so the class must survive even though the
+	Menu primitive now owns the panel itself.
+-->
+{#snippet userMenu()}
+	{#if authStore.user}
+		<div class="user-menu-container">
+			<button
+				class="user-trigger"
+				bind:this={userTriggerEl}
+				aria-haspopup="menu"
+				aria-expanded={userMenuOpen}
+				aria-label="User menu"
+				onclick={() => (userMenuOpen = !userMenuOpen)}
+			>
+				<span class="user-avatar" style="background: {wsColor(authStore.user.name || authStore.user.email)}">
+					{(authStore.user.name || authStore.user.email).charAt(0).toUpperCase()}
+				</span>
+			</button>
+
+			<Menu
+				open={userMenuOpen}
+				onclose={closeUserMenu}
+				trigger={userTriggerEl}
+				mode="anchored"
+				ariaLabel="User menu"
+			>
+				<div class="user-dropdown">
+					<div class="user-info">
+						<span class="user-dropdown-name">{authStore.user?.name}</span>
+						<span class="user-dropdown-email">{authStore.user?.email}</span>
+					</div>
+					<div class="dropdown-divider"></div>
+					<a href="/console" class="menu-link" role="menuitem" onclick={closeUserMenu}>
+						Workspaces
+					</a>
+					<a href="/console/settings" class="menu-link" role="menuitem" onclick={closeUserMenu}>
+						Settings
+					</a>
+					{#if authStore.cloudMode}
+						<a href="/console/billing" class="menu-link" role="menuitem" onclick={closeUserMenu}>
+							Billing
+						</a>
+					{/if}
+					{#if authStore.user?.role === 'admin'}
+						<a href="/console/admin" class="menu-link" role="menuitem" onclick={closeUserMenu}>
+							Admin
+						</a>
+					{/if}
+					<!--
+						Theme toggle deliberately does NOT close the menu — matches
+						the pre-migration behavior (the label flips in place so the
+						user can toggle back without reopening).
+					-->
+					<MenuItem onclick={toggleTheme}>
+						{currentTheme === 'dark' ? 'Light mode' : 'Dark mode'}
+					</MenuItem>
+
+					<!--
+						Resources block (TASK-905). Replaces the prior inline Cloud
+						Support/Status pair — that block became a special case of
+						the unified Resources component, which adds Docs, Changelog,
+						and GitHub on Cloud and a trimmed Docs/GitHub list on
+						self-hosted. Closes the product → marketing handoff seam.
+					-->
+					<UserMenuResources cloudMode={authStore.cloudMode} onclose={closeUserMenu} />
+
+					<!--
+						"Connect a project…" sits after the Resources block and just
+						above the Sign-out divider — it's a CLI-onboarding action,
+						semantically closer to Settings/Resources than to account
+						actions, but visually we want it adjacent to the divider so
+						it reads as a discrete action rather than another link.
+					-->
+					{#if workspaceStore.current?.slug}
+						<MenuItem
+							onclick={() => {
+								closeUserMenu();
+								connectOpen = true;
+							}}
+						>
+							Connect a project…
+						</MenuItem>
+					{/if}
+					<div class="dropdown-divider"></div>
+					<MenuItem danger onclick={handleLogout}>Sign out</MenuItem>
+				</div>
+			</Menu>
+		</div>
+	{/if}
+{/snippet}
 
 {#if !mobile}
 	<!-- ── Desktop ────────────────────────────────────────────────────────── -->
@@ -819,79 +939,7 @@
 					<path d="M3 11L8 6L13 11" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
 				</svg>
 			</button>
-			{#if authStore.user}
-				<div class="user-menu-container">
-					<button
-						class="user-trigger"
-						onclick={() => userMenuOpen = !userMenuOpen}
-					>
-						<span class="user-avatar" style="background: {wsColor(authStore.user.name || authStore.user.email)}">
-							{(authStore.user.name || authStore.user.email).charAt(0).toUpperCase()}
-						</span>
-					</button>
-
-					{#if userMenuOpen}
-						<div class="user-dropdown">
-							<div class="user-info">
-								<span class="user-dropdown-name">{authStore.user.name}</span>
-								<span class="user-dropdown-email">{authStore.user.email}</span>
-							</div>
-							<div class="dropdown-divider"></div>
-							<a href="/console" class="dropdown-item" onclick={closeUserMenu}>
-								Workspaces
-							</a>
-							<a href="/console/settings" class="dropdown-item" onclick={closeUserMenu}>
-								Settings
-							</a>
-							{#if authStore.cloudMode}
-								<a href="/console/billing" class="dropdown-item" onclick={closeUserMenu}>
-									Billing
-								</a>
-							{/if}
-							{#if authStore.user?.role === 'admin'}
-								<a href="/console/admin" class="dropdown-item" onclick={closeUserMenu}>
-									Admin
-								</a>
-							{/if}
-							<button class="dropdown-item" onclick={toggleTheme}>
-								{currentTheme === 'dark' ? 'Light mode' : 'Dark mode'}
-							</button>
-
-							<!--
-								Resources block (TASK-905). Replaces the prior inline Cloud
-								Support/Status pair — that block became a special case of
-								the unified Resources component, which adds Docs, Changelog,
-								and GitHub on Cloud and a trimmed Docs/GitHub list on
-								self-hosted. Closes the product → marketing handoff seam.
-							-->
-							<UserMenuResources cloudMode={authStore.cloudMode} onclose={closeUserMenu} />
-
-							<!--
-								"Connect a project…" sits after the Resources block and just
-								above the Sign-out divider — it's a CLI-onboarding action,
-								semantically closer to Settings/Resources than to account
-								actions, but visually we want it adjacent to the divider so
-								it reads as a discrete action rather than another link.
-							-->
-							{#if workspaceStore.current?.slug}
-								<button
-									class="dropdown-item"
-									onclick={() => {
-										closeUserMenu();
-										connectOpen = true;
-									}}
-								>
-									Connect a project…
-								</button>
-							{/if}
-							<div class="dropdown-divider"></div>
-							<button class="dropdown-item logout" onclick={handleLogout}>
-								Sign out
-							</button>
-						</div>
-					{/if}
-				</div>
-			{/if}
+			{@render userMenu()}
 		</div>
 
 		<!--
@@ -972,67 +1020,7 @@
 				<path d="M10.5 10.5L13.5 13.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
 			</svg>
 		</button>
-		{#if authStore.user}
-			<div class="user-menu-container">
-				<button
-					class="user-trigger"
-					onclick={() => userMenuOpen = !userMenuOpen}
-				>
-					<span class="user-avatar" style="background: {wsColor(authStore.user.name || authStore.user.email)}">
-						{(authStore.user.name || authStore.user.email).charAt(0).toUpperCase()}
-					</span>
-				</button>
-
-				{#if userMenuOpen}
-					<div class="user-dropdown">
-						<div class="user-info">
-							<span class="user-dropdown-name">{authStore.user.name}</span>
-							<span class="user-dropdown-email">{authStore.user.email}</span>
-						</div>
-						<div class="dropdown-divider"></div>
-						<a href="/console" class="dropdown-item" onclick={closeUserMenu}>
-							Workspaces
-						</a>
-						<a href="/console/settings" class="dropdown-item" onclick={closeUserMenu}>
-							Settings
-						</a>
-						{#if authStore.cloudMode}
-							<a href="/console/billing" class="dropdown-item" onclick={closeUserMenu}>
-								Billing
-							</a>
-						{/if}
-						{#if authStore.user?.role === 'admin'}
-							<a href="/console/admin" class="dropdown-item" onclick={closeUserMenu}>
-								Admin
-							</a>
-						{/if}
-						<button class="dropdown-item" onclick={toggleTheme}>
-							{currentTheme === 'dark' ? 'Light mode' : 'Dark mode'}
-						</button>
-
-						<!-- Resources — see desktop branch for placement rationale. -->
-						<UserMenuResources cloudMode={authStore.cloudMode} onclose={closeUserMenu} />
-
-						<!-- Connect a project — see desktop branch for placement rationale. -->
-						{#if workspaceStore.current?.slug}
-							<button
-								class="dropdown-item"
-								onclick={() => {
-									closeUserMenu();
-									connectOpen = true;
-								}}
-							>
-								Connect a project…
-							</button>
-						{/if}
-						<div class="dropdown-divider"></div>
-						<button class="dropdown-item logout" onclick={handleLogout}>
-							Sign out
-						</button>
-					</div>
-				{/if}
-			</div>
-		{/if}
+		{@render userMenu()}
 
 		<!-- Same Connect modal pattern as the desktop branch — see notes above. -->
 		{#if workspaceStore.current?.slug}
@@ -1459,6 +1447,8 @@
 		background: var(--bg-hover);
 	}
 
+	/* Anchored-mode wrapper for the user Menu — the primitive's panel is
+	   position: absolute against this. */
 	.user-menu-container {
 		position: relative;
 	}
@@ -1486,23 +1476,9 @@
 		color: #fff;
 	}
 
-	.user-dropdown {
-		position: absolute;
-		top: calc(100% + 6px);
-		right: 0;
-		min-width: 200px;
-		background: var(--bg-secondary);
-		border: 1px solid var(--border);
-		border-radius: var(--radius-lg);
-		box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
-		z-index: 50;
-		overflow: hidden;
-		animation: dropdown-in 0.12s ease-out;
-	}
-	@keyframes dropdown-in {
-		from { opacity: 0; transform: translateY(-4px); }
-		to { opacity: 1; transform: translateY(0); }
-	}
+	/* Panel skin/positioning now lives in the Menu primitive. The
+	   .user-dropdown class survives markup-side as a styling hook for
+	   UserMenuResources' :global(.user-dropdown) rules. */
 
 	.user-info {
 		padding: var(--space-3) var(--space-4);
@@ -1525,26 +1501,31 @@
 		background: var(--border);
 	}
 
-	.dropdown-item {
-		display: block;
+	/* Anchor rows inside the user Menu. Links stay real <a>s (they
+	   navigate; role="menuitem" keeps them in the primitive's roving
+	   keyboard nav), so they can't be MenuItem buttons — mirror
+	   MenuItem's .mi metrics here so link rows and button rows read
+	   as one set. */
+	.menu-link {
+		display: flex;
+		align-items: center;
 		width: 100%;
-		text-align: left;
-		padding: var(--space-2) var(--space-4);
-		font-size: 0.85em;
-		color: var(--text-secondary);
-		text-decoration: none;
-		transition: background 0.1s, color 0.1s;
-	}
-	.dropdown-item:hover {
-		background: var(--bg-hover);
+		padding: 7px 9px;
+		border-radius: var(--radius-sm);
+		font-size: 13px;
 		color: var(--text-primary);
 		text-decoration: none;
 	}
-	.dropdown-item.logout {
-		color: var(--accent-orange);
+	.menu-link:hover,
+	.menu-link:focus-visible {
+		background: var(--bg-hover);
+		text-decoration: none;
+		outline: none;
 	}
-	.dropdown-item.logout:hover {
-		background: color-mix(in srgb, var(--accent-orange) 10%, var(--bg-hover));
+	@media (pointer: coarse) {
+		.menu-link {
+			padding: 11px 10px;
+		}
 	}
 
 </style>

--- a/web/src/lib/components/layout/TopBar.svelte
+++ b/web/src/lib/components/layout/TopBar.svelte
@@ -666,6 +666,7 @@
 				trigger={userTriggerEl}
 				mode="anchored"
 				ariaLabel="User menu"
+				suppressOutside={() => isDragging || dragArmed}
 			>
 				<div class="user-dropdown">
 					<div class="user-info">

--- a/web/src/lib/components/layout/UserMenuResources.svelte
+++ b/web/src/lib/components/layout/UserMenuResources.svelte
@@ -77,6 +77,7 @@
 		target="_blank"
 		rel="noopener noreferrer"
 		class="dropdown-item resources-item"
+		role="menuitem"
 		onclick={() => onclose?.()}
 	>
 		<span>{link.label}</span>

--- a/web/src/lib/stores/escapeStack.ts
+++ b/web/src/lib/stores/escapeStack.ts
@@ -27,6 +27,9 @@ export const ESCAPE_PRIORITY = {
 	listFocus: 10,
 	pane: 20,
 	graphDrawer: 30,
+	// Dropdown menus are the innermost layer — ESC closes an open menu
+	// before it collapses the pane/drawer under it (PLAN-2290 Phase 2).
+	menu: 40,
 } as const;
 
 interface Entry {

--- a/web/src/lib/utils/clickOutside.ts
+++ b/web/src/lib/utils/clickOutside.ts
@@ -1,0 +1,46 @@
+/**
+ * Instance-scoped outside-click action (PLAN-2290 Phase 2).
+ *
+ * Listens on capture-phase `pointerdown`, NOT `click`: a row handler that
+ * mutates state can detach the row before a window `click` listener runs,
+ * making `node.contains(target)` false and slamming the menu shut on the
+ * same interaction (BUG-2281's detach hazard — previously papered over
+ * with stopPropagation on every row). pointerdown fires before any click
+ * handler mutates state, so containment checks see the live DOM.
+ *
+ * Instance-scoped by design: each consumer checks ITS OWN node (+ extras),
+ * never a shared class — sibling menus must not cross-close each other.
+ */
+interface ClickOutsideOptions {
+	enabled?: boolean;
+	/** Called when a pointerdown lands outside the node and all extras. */
+	onOutside: () => void;
+	/** Additional containers that count as "inside" (trigger element,
+	 *  portaled sub-popovers like EmojiPicker). */
+	extra?: () => (Element | null | undefined)[];
+}
+
+export function clickOutside(node: HTMLElement, options: ClickOutsideOptions) {
+	let opts = options;
+
+	function onPointerDown(e: PointerEvent) {
+		if (opts.enabled === false) return;
+		const target = e.target as Element | null;
+		if (!target) return;
+		if (node.contains(target)) return;
+		for (const el of opts.extra?.() ?? []) {
+			if (el && el.contains(target)) return;
+		}
+		opts.onOutside();
+	}
+
+	document.addEventListener('pointerdown', onPointerDown, true);
+	return {
+		update(next: ClickOutsideOptions) {
+			opts = next;
+		},
+		destroy() {
+			document.removeEventListener('pointerdown', onPointerDown, true);
+		}
+	};
+}

--- a/web/src/lib/utils/clickOutside.ts
+++ b/web/src/lib/utils/clickOutside.ts
@@ -18,6 +18,9 @@ interface ClickOutsideOptions {
 	/** Additional containers that count as "inside" (trigger element,
 	 *  portaled sub-popovers like EmojiPicker). */
 	extra?: () => (Element | null | undefined)[];
+	/** Evaluated per event — return true to skip the outside-close (e.g.
+	 *  while a drag interaction is in flight; cf. the TopBar pill drags). */
+	suppress?: () => boolean;
 }
 
 export function clickOutside(node: HTMLElement, options: ClickOutsideOptions) {
@@ -25,6 +28,7 @@ export function clickOutside(node: HTMLElement, options: ClickOutsideOptions) {
 
 	function onPointerDown(e: PointerEvent) {
 		if (opts.enabled === false) return;
+		if (opts.suppress?.()) return;
 		const target = e.target as Element | null;
 		if (!target) return;
 		if (node.contains(target)) return;

--- a/web/src/lib/utils/portalAction.ts
+++ b/web/src/lib/utils/portalAction.ts
@@ -1,0 +1,18 @@
+/**
+ * Portal a node to <body> (or the nearest open <dialog>, so portaled UI
+ * stays interactive inside native dialogs). Extracted from the hand-copied
+ * versions in ItemActionsMenu and EmojiPickerButton (PLAN-2290 Phase 2).
+ *
+ * Why portal at all: triggers that live under `content-visibility: auto`
+ * containment (board/list cards) clip absolutely-positioned descendants —
+ * a fixed-position panel portaled to the body escapes that.
+ */
+export function portal(node: HTMLElement) {
+	const dialog = node.closest('dialog');
+	(dialog ?? document.body).appendChild(node);
+	return {
+		destroy() {
+			node.remove();
+		}
+	};
+}


### PR DESCRIPTION
Phase 2 / PR 4 of PLAN-2290 — the final primitive. Menu (anchored/portal modes, escapeStack ESC at menu=40, pointerdown outside-click killing the BUG-2281 workaround class, roving keyboard nav, BottomSheet mobile swap) + MenuItem rows + extracted clickOutside/portal utils + --bg-raised token. ItemActionsMenu, QuickActionsMenu, and the TopBar user menu migrated (user menu gains a11y it never had); e2e locators moved to accessible-name form. Leave-alones documented: the workspace-overflow dndzone menu (drag-entangled), LaneActionsMenu drill-down, WorkspaceSwitcher. Runtime-verified with Playwright interaction tests.