### PR TITLE
feat(web): TableView + share parity; fix subgrid collapse + hyphenated lane accents (TASK-2293/2208/2213)

### DIFF
--- a/web/src/lib/components/collections/TableView.svelte
+++ b/web/src/lib/components/collections/TableView.svelte
@@ -4,6 +4,8 @@
 	import { itemComparator, type SortMode } from '$lib/collections/itemSort';
 	import { reorderGroup, disabledDirections, type ReorderDirection } from '$lib/collections/reorder';
 	import { page } from '$app/state';
+	import { statusColor, priorityColor, hasCanonicalStatus, formatFieldLabel as formatLabel } from '$lib/utils/fieldColors';
+	import Chip from '$lib/components/common/Chip.svelte';
 	import EmptyState from '../common/EmptyState.svelte';
 	import ItemActionsMenu from './ItemActionsMenu.svelte';
 
@@ -138,17 +140,33 @@
 		}
 	}
 
+	// Per-row pulse for the status click-cycle chip (mirrors ItemCard's
+	// `pulsing`, keyed by item id since the table renders many rows).
+	let pulsingId = $state<string | null>(null);
+
 	function cycleStatus(item: Item, options: string[]) {
 		if (!onStatusChange) return;
 		const fields = parseFields(item);
 		const current = fields.status ?? '';
 		const idx = options.indexOf(current);
 		const next = options[(idx + 1) % options.length];
+		pulsingId = item.id;
+		setTimeout(() => {
+			if (pulsingId === item.id) pulsingId = null;
+		}, 300);
 		onStatusChange(item, next);
 	}
 
-	function formatLabel(value: string): string {
-		return value.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+	/** FieldEditor's canonical-value resolution: canonical statuses + the four
+	 *  priorities get the fieldColors palette; unknown values return null so
+	 *  the cell renders as plain text instead of a chip. */
+	function selectValueColor(val: string): string | null {
+		if (hasCanonicalStatus(val)) return statusColor(val);
+		const p = val?.toLowerCase();
+		if (p === 'critical' || p === 'high' || p === 'medium' || p === 'low') {
+			return priorityColor(val);
+		}
+		return null;
 	}
 
 	function relativeTime(dateStr: string): string {
@@ -190,11 +208,17 @@
 	 * columns bracket a `minmax(200px, 1fr)` Title and `auto`-sized
 	 * field columns, matching the pre-refactor `.col-*` widths.
 	 */
+	/* Field columns are EXTRINSIC (minmax + fr, no `auto`): every row
+	 * resolves the same track list against the same width, so per-row
+	 * `grid-template-columns: inherit` aligns identically WITHOUT subgrid.
+	 * That matters because content-visibility:auto implies layout
+	 * containment, which disables subgrid on the same element per spec —
+	 * rows collapsed to a single stacked column in Chromium (TASK-2208). */
 	let gridTemplate = $derived(
 		[
 			'70px',
 			'minmax(200px, 1fr)',
-			...visibleFields.map(() => 'auto'),
+			...visibleFields.map(() => 'minmax(90px, 0.55fr)'),
 			'90px',
 			...(canReorder ? ['44px'] : [])
 		].join(' ')
@@ -242,9 +266,22 @@
 				{#each visibleFields as field (field.key)}
 					<div class="table-cell" role="cell">
 						{#if field.key === 'status' && field.options && onStatusChange}
-							<button class="cell-status" onclick={() => cycleStatus(item, field.options!)} title="Click to cycle">
+							<Chip
+								size="sm"
+								color={statusColor(fields[field.key] ?? '')}
+								pulse={pulsingId === item.id}
+								onclick={() => cycleStatus(item, field.options!)}
+								title="Click to cycle status"
+							>
 								{formatLabel(fields[field.key] ?? '')}
-							</button>
+							</Chip>
+						{:else if field.options && typeof fields[field.key] === 'string' && fields[field.key]}
+							{@const chipColor = selectValueColor(fields[field.key])}
+							{#if chipColor}
+								<Chip size="sm" color={chipColor}>{formatLabel(fields[field.key])}</Chip>
+							{:else}
+								<span class="cell-value">{fields[field.key]}</span>
+							{/if}
 						{:else}
 							<span class="cell-value">{fields[field.key] ?? ''}</span>
 						{/if}
@@ -282,25 +319,19 @@
 	}
 
 	/*
-	 * Each row inherits the parent grid's columns via `subgrid`. This
-	 * keeps cell alignment perfect across rows AND lets the row itself
-	 * be the unit that content-visibility can skip.
-	 *
-	 * subgrid: Chrome 117+ / Firefox 71+ / Safari 16+. Browsers without
-	 * subgrid fall back to the same column template as the parent — see
-	 * the @supports block below.
+	 * Rows inherit the parent's (fully extrinsic) column template instead
+	 * of using subgrid: content-visibility:auto implies layout containment,
+	 * which DISABLES subgrid on the same element per spec — every row
+	 * collapsed to a single stacked column in Chromium (TASK-2208). With
+	 * no `auto` tracks in the template, `inherit` yields pixel-identical
+	 * columns on every row, and rows stay the unit content-visibility
+	 * can skip.
 	 */
 	.table-row {
 		display: grid;
-		grid-template-columns: subgrid;
+		grid-template-columns: inherit;
 		grid-column: 1 / -1;
 		border-bottom: 1px solid var(--border-subtle, var(--border));
-	}
-
-	@supports not (grid-template-columns: subgrid) {
-		.table-row {
-			grid-template-columns: inherit;
-		}
 	}
 
 	.table-row.table-header {
@@ -334,10 +365,13 @@
 		background: var(--bg-hover);
 	}
 
-	/* Highlight the row whose detail pane is open (PLAN-2105 / TASK-2112). */
+	/* Highlight the row whose detail pane is open (PLAN-2105 / TASK-2112).
+	   Violet tint + left accent bar — the table-row adaptation of ItemCard's
+	   selected ring (PLAN-2290 Phase 3). E2E asserts the .focused CLASS, not
+	   these styles — keep the class name stable. */
 	.table-row:not(.table-header).focused {
-		background: var(--bg-hover);
-		box-shadow: inset 2px 0 0 var(--accent-blue);
+		background: color-mix(in srgb, var(--accent-primary, var(--accent-blue)) 7%, transparent);
+		box-shadow: inset 2px 0 0 var(--accent-primary, var(--accent-blue));
 	}
 
 	.table-cell {
@@ -396,22 +430,9 @@
 		font-size: 0.9em;
 	}
 
-	.cell-status {
-		background: none;
-		border: none;
-		font: inherit;
-		font-size: 0.85em;
-		color: var(--text-secondary);
-		cursor: pointer;
-		padding: 2px 8px;
-		border-radius: var(--radius-sm);
-		background: var(--bg-tertiary);
-	}
-
-	.cell-status:hover {
-		background: var(--bg-hover);
-		color: var(--text-primary);
-	}
+	/* Status + recognized select values render as Chip primitives now
+	   (tinted pills per the refresh mock); the chip carries the
+	   click-cycle + pulse. */
 
 	.cell-date {
 		font-size: 0.8em;

--- a/web/src/lib/components/collections/TableView.svelte
+++ b/web/src/lib/components/collections/TableView.svelte
@@ -142,7 +142,11 @@
 
 	// Per-row pulse for the status click-cycle chip (mirrors ItemCard's
 	// `pulsing`, keyed by item id since the table renders many rows).
+	// pulseSeq fences the timeout: two rapid clicks on the SAME row would
+	// otherwise let the first click's timer clear the second click's pulse
+	// early (PR #1024 Codex finding — the timer-fence bug class).
 	let pulsingId = $state<string | null>(null);
+	let pulseSeq = 0;
 
 	function cycleStatus(item: Item, options: string[]) {
 		if (!onStatusChange) return;
@@ -151,8 +155,9 @@
 		const idx = options.indexOf(current);
 		const next = options[(idx + 1) % options.length];
 		pulsingId = item.id;
+		const seq = ++pulseSeq;
 		setTimeout(() => {
-			if (pulsingId === item.id) pulsingId = null;
+			if (pulseSeq === seq) pulsingId = null;
 		}, 300);
 		onStatusChange(item, next);
 	}

--- a/web/src/lib/components/share/PublicItemCard.svelte
+++ b/web/src/lib/components/share/PublicItemCard.svelte
@@ -4,8 +4,9 @@
 	// Strictly presentational: no links, no star, no status cycling, no drag.
 	// Renders the title, ref, and a small meta row (status + priority) styled
 	// for an anonymous audience. Mirrors the in-app ItemCard's visual language
-	// (status/priority colors, uppercase status) without any of its coupling to
-	// page.params / mutation handlers.
+	// (PLAN-2290 Phase 3: card skin tokens + tinted chip pills for
+	// status/priority) without any of its coupling to page.params / mutation
+	// handlers.
 	//
 	// Inline read-only expand (TASK-1684): the optional `onactivate` callback +
 	// `expandable` flag turn the card into a button-like toggle affordance. When
@@ -89,13 +90,12 @@
 		{#if (statusFieldDef && status) || (priorityFieldDef && priority)}
 			<div class="card-meta">
 				{#if statusFieldDef && status}
-					<span class="meta-status" style:color={fieldValueColor(statusFieldDef, status)}>
-						{formatLabel(status).toUpperCase()}
+					<span class="meta-status" style:--chip-c={fieldValueColor(statusFieldDef, status)}>
+						{formatLabel(status)}
 					</span>
 				{/if}
 				{#if priorityFieldDef && priority}
-					{#if statusFieldDef && status}<span class="meta-sep">&middot;</span>{/if}
-					<span class="meta-priority" style:color={fieldValueColor(priorityFieldDef, priority)}>
+					<span class="meta-priority" style:--chip-c={fieldValueColor(priorityFieldDef, priority)}>
 						{formatLabel(priority)}
 					</span>
 				{/if}
@@ -118,20 +118,23 @@
 		min-width: 0;
 	}
 
+	/* Card skin — same tokens as the in-app ItemCard (PLAN-2290 Phase 3) so a
+	   shared board card looks like the owner's. */
 	.public-card {
 		display: flex;
 		flex-direction: column;
 		gap: var(--space-2);
-		background: var(--bg-primary);
-		border: 1px solid var(--border);
-		border-radius: var(--radius);
+		background: var(--card-bg, var(--bg-primary));
+		border: 1px solid var(--card-border, var(--border));
+		border-radius: var(--radius-lg);
+		box-shadow: var(--shadow-card, none);
 		padding: var(--space-3) var(--space-4);
 		min-width: 0;
 	}
 
 	.public-card-wrap.expanded .public-card {
 		border-bottom: none;
-		border-radius: var(--radius) var(--radius) 0 0;
+		border-radius: var(--radius-lg) var(--radius-lg) 0 0;
 	}
 
 	.public-card.interactive {
@@ -140,12 +143,11 @@
 	}
 
 	.public-card.interactive:hover {
-		background: var(--bg-hover);
-		border-color: var(--text-tertiary, var(--text-secondary));
+		border-color: var(--border-strong, var(--border));
 	}
 
 	.public-card.interactive:focus-visible {
-		outline: 2px solid var(--accent-blue);
+		outline: 2px solid var(--accent-primary, var(--accent-blue));
 		outline-offset: -2px;
 	}
 
@@ -180,22 +182,21 @@
 		min-width: 0;
 	}
 
-	.meta-status {
-		font-size: 0.7em;
-		font-weight: 700;
-		text-transform: uppercase;
-		letter-spacing: 0.02em;
-		white-space: nowrap;
-	}
-
-	.meta-sep {
-		font-size: 0.7em;
-		color: var(--text-muted);
-	}
-
+	/* Status/priority read as tinted chip pills — the in-app Chip primitive's
+	   `sm` metrics (padding 1px 6px, radius 6px, 0.8em/500) without its
+	   interactivity. `--chip-c` is set inline from fieldValueColor so custom
+	   terminal vocabularies keep the owner's palette. */
+	.meta-status,
 	.meta-priority {
-		font-size: 0.7em;
-		font-weight: 600;
+		display: inline-flex;
+		align-items: center;
+		padding: 1px 6px;
+		border-radius: 6px;
+		font-size: 0.8em;
+		font-weight: 500;
+		line-height: 1.5;
 		white-space: nowrap;
+		background: color-mix(in srgb, var(--chip-c, var(--accent-gray)) var(--chip-alpha, 16%), transparent);
+		color: color-mix(in srgb, var(--chip-c, var(--accent-gray)) var(--chip-text-mix, 100%), #000);
 	}
 </style>

--- a/web/src/lib/components/share/PublicItemExpansion.svelte
+++ b/web/src/lib/components/share/PublicItemExpansion.svelte
@@ -53,11 +53,9 @@
 	}
 
 	function displayValue(field: FieldDef, value: string): string {
-		const base = isCategorical(field)
-			? field.key === 'status'
-				? formatLabel(value).toUpperCase()
-				: formatLabel(value)
-			: value;
+		// Title Case for categorical values — matches the chip pills on the
+		// card/list/table surfaces (PLAN-2290 Phase 3; no more SHOUTED status).
+		const base = isCategorical(field) ? formatLabel(value) : value;
 		return field.suffix ? `${base} ${field.suffix}` : base;
 	}
 </script>
@@ -87,15 +85,17 @@
 </div>
 
 <style>
+	/* Card skin tokens (PLAN-2290 Phase 3) so the panel seams with the
+	   card/row it expands from — same background/border, joined corners. */
 	.item-expansion {
 		display: flex;
 		flex-direction: column;
 		gap: var(--space-4);
 		padding: var(--space-4);
-		background: var(--bg-primary);
-		border: 1px solid var(--border-subtle, var(--border));
+		background: var(--card-bg, var(--bg-primary));
+		border: 1px solid var(--card-border, var(--border));
 		border-top: none;
-		border-radius: 0 0 var(--radius) var(--radius);
+		border-radius: 0 0 var(--radius-lg) var(--radius-lg);
 	}
 
 	.expansion-fields {

--- a/web/src/lib/components/share/PublicListView.svelte
+++ b/web/src/lib/components/share/PublicListView.svelte
@@ -102,13 +102,13 @@
 						<span class="row-title">{item.title}</span>
 						<span class="row-meta">
 							{#if priorityFieldDef && priority}
-								<span class="row-priority" style:color={fieldValueColor(priorityFieldDef, priority)}
+								<span class="row-priority" style:--chip-c={fieldValueColor(priorityFieldDef, priority)}
 									>{formatLabel(priority)}</span
 								>
 							{/if}
 							{#if statusFieldDef && status}
-								<span class="row-status" style:color={fieldValueColor(statusFieldDef, status)}
-									>{formatLabel(status).toUpperCase()}</span
+								<span class="row-status" style:--chip-c={fieldValueColor(statusFieldDef, status)}
+									>{formatLabel(status)}</span
 								>
 							{/if}
 						</span>
@@ -170,31 +170,34 @@
 		min-width: 0;
 	}
 
+	/* Row skin — the in-app card tokens (PLAN-2290 Phase 3) so shared list
+	   rows read like the owner's list of cards. */
 	.list-row {
 		display: flex;
 		align-items: center;
 		gap: var(--space-3);
 		padding: var(--space-3) var(--space-4);
-		background: var(--bg-secondary);
-		border: 1px solid var(--border-subtle, var(--border));
-		border-radius: var(--radius);
+		background: var(--card-bg, var(--bg-primary));
+		border: 1px solid var(--card-border, var(--border));
+		border-radius: var(--radius-lg);
+		box-shadow: var(--shadow-card, none);
 		min-width: 0;
 	}
 
 	.row-wrap.expanded .list-row {
 		border-bottom: none;
-		border-radius: var(--radius) var(--radius) 0 0;
+		border-radius: var(--radius-lg) var(--radius-lg) 0 0;
 	}
 
 	.list-row.interactive {
 		cursor: pointer;
-		transition: background 0.1s;
+		transition: background 0.1s, border-color 0.1s;
 	}
 	.list-row.interactive:hover {
-		background: var(--bg-hover);
+		border-color: var(--border-strong, var(--border));
 	}
 	.list-row.interactive:focus-visible {
-		outline: 2px solid var(--accent-blue);
+		outline: 2px solid var(--accent-primary, var(--accent-blue));
 		outline-offset: -2px;
 	}
 
@@ -217,22 +220,24 @@
 	.row-meta {
 		display: flex;
 		align-items: center;
-		gap: var(--space-3);
+		gap: var(--space-2);
 		flex-shrink: 0;
 	}
 
-	.row-priority {
-		font-size: 0.75em;
-		font-weight: 600;
-		white-space: nowrap;
-	}
-
+	/* Status/priority as tinted chip pills — the in-app Chip primitive's `sm`
+	   metrics; `--chip-c` set inline from fieldValueColor. */
+	.row-priority,
 	.row-status {
-		font-size: 0.72em;
-		font-weight: 700;
-		text-transform: uppercase;
-		letter-spacing: 0.02em;
+		display: inline-flex;
+		align-items: center;
+		padding: 1px 6px;
+		border-radius: 6px;
+		font-size: 0.8em;
+		font-weight: 500;
+		line-height: 1.5;
 		white-space: nowrap;
+		background: color-mix(in srgb, var(--chip-c, var(--accent-gray)) var(--chip-alpha, 16%), transparent);
+		color: color-mix(in srgb, var(--chip-c, var(--accent-gray)) var(--chip-text-mix, 100%), #000);
 	}
 
 	.group-empty {

--- a/web/src/lib/components/share/PublicTableView.svelte
+++ b/web/src/lib/components/share/PublicTableView.svelte
@@ -31,11 +31,15 @@
 	let columns = $derived(visibleFields(collection.fields));
 	let hasRefs = $derived(items.some((i) => !!i.ref));
 
+	/* Extrinsic tracks only (no `auto`): rows use grid-template-columns:
+	 * inherit, and content-visibility's layout containment disables
+	 * subgrid per spec (TASK-2208) — see TableView.svelte for the full
+	 * rationale. */
 	let gridTemplate = $derived(
 		[
 			...(hasRefs ? ['70px'] : []),
 			'minmax(200px, 1fr)',
-			...columns.map(() => 'auto')
+			...columns.map(() => 'minmax(90px, 0.55fr)')
 		].join(' ')
 	);
 
@@ -98,8 +102,20 @@
 					{@const text = formatFieldValue(raw)}
 					{@const color = typeof raw === 'string' ? cellColor(field, raw) : undefined}
 					<div class="table-cell" role="cell">
-						{#if field.key === 'status' && text}
-							<span class="cell-status" style:color>{formatLabel(text).toUpperCase()}</span>
+						{#if (field.key === 'status' || field.key === 'priority') && color && text}
+							<!-- Tinted chip pill (Phase 3 card language); .cell-status kept
+							     as the status cell's stable hook. -->
+							<span
+								class="cell-chip"
+								class:cell-status={field.key === 'status'}
+								style:--chip-c={color}>{formatLabel(text)}</span
+							>
+						{:else if field.type === 'multi_select' && Array.isArray(raw) && raw.length > 0}
+							<span class="cell-tags">
+								{#each raw as tag, i (i)}
+									<span class="cell-tag">{formatFieldValue(tag)}</span>
+								{/each}
+							</span>
 						{:else if color && text}
 							<span class="cell-value" style:color>{formatLabel(text)}</span>
 						{:else}
@@ -137,17 +153,14 @@
 		font-size: 0.88em;
 	}
 
+	/* inherit, not subgrid: content-visibility containment disables subgrid
+	   on the same element (TASK-2208); template is fully extrinsic so every
+	   row aligns identically. */
 	.table-row {
 		display: grid;
-		grid-template-columns: subgrid;
+		grid-template-columns: inherit;
 		grid-column: 1 / -1;
 		border-bottom: 1px solid var(--border-subtle, var(--border));
-	}
-
-	@supports not (grid-template-columns: subgrid) {
-		.table-row {
-			grid-template-columns: inherit;
-		}
 	}
 
 	.table-row.table-header {
@@ -170,7 +183,7 @@
 		background: var(--bg-hover);
 	}
 	.table-row.interactive:focus-visible {
-		outline: 2px solid var(--accent-blue);
+		outline: 2px solid var(--accent-primary, var(--accent-blue));
 		outline-offset: -2px;
 	}
 
@@ -228,11 +241,43 @@
 		white-space: nowrap;
 	}
 
-	.cell-status {
+	/* Status/priority as tinted chip pills — the in-app Chip primitive's `sm`
+	   metrics; `--chip-c` set inline from the schema-aware cellColor. */
+	.cell-chip {
+		display: inline-flex;
+		align-items: center;
+		padding: 1px 6px;
+		border-radius: 6px;
+		font-size: 0.8em;
+		font-weight: 500;
+		line-height: 1.5;
+		white-space: nowrap;
+		background: color-mix(in srgb, var(--chip-c, var(--accent-gray)) var(--chip-alpha, 16%), transparent);
+		color: color-mix(in srgb, var(--chip-c, var(--accent-gray)) var(--chip-text-mix, 100%), #000);
+	}
+
+	.cell-tags {
+		display: flex;
+		flex-wrap: wrap;
+		gap: var(--space-1, 0.25rem);
+		min-width: 0;
+	}
+
+	/* Multi-select values as purple tag pills — mirrors ItemCard's .card-tag
+	   tint treatment. */
+	.cell-tag {
+		display: inline-flex;
+		align-items: center;
+		padding: 1px 6px;
+		border-radius: 6px;
 		font-size: 0.78em;
-		font-weight: 700;
-		text-transform: uppercase;
-		letter-spacing: 0.02em;
+		font-weight: 500;
+		line-height: 1.5;
+		background: color-mix(in srgb, var(--accent-purple) var(--chip-alpha, 16%), transparent);
+		color: color-mix(in srgb, var(--accent-purple) var(--chip-text-mix, 100%), #000);
+		max-width: 12rem;
+		overflow: hidden;
+		text-overflow: ellipsis;
 		white-space: nowrap;
 	}
 </style>

--- a/web/src/lib/utils/fieldColors.ts
+++ b/web/src/lib/utils/fieldColors.ts
@@ -104,26 +104,28 @@ export function formatFieldLabel(value: string): string {
 	return value.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
 }
 
-/** Board-column accent class for a lane value. Literal statuses map to the
- *  canonical lane palette; a custom terminal option (e.g. "shipped") reads
- *  as a done lane. Shared by BoardView AND the public-share fork
- *  (shareView.ts re-exports) so lane accents can never drift between them. */
+/** Board-column accent class for a lane value, derived from the SAME
+ *  canonical STATUS_COLORS map as the chips — so lane accents, chip colors,
+ *  and hyphen/underscore vocabularies can never disagree (TASK-2213: the
+ *  default template ships 'in-progress', which the old hard-coded switch
+ *  missed). Negative-terminal values (cancelled/rejected/wontfix → gray/
+ *  muted family) deliberately get NO accent — a cancelled lane must not
+ *  read as done-green. Custom terminal options (e.g. "shipped") still read
+ *  as done lanes. Shared by BoardView AND the public-share fork
+ *  (shareView.ts re-exports). */
+const COLOR_TO_COLUMN_CLASS: Record<string, string> = {
+	[GREEN]: 'col-done',
+	[AMBER]: 'col-in-progress',
+	[BLUE]: 'col-open',
+	[ORANGE]: 'col-blocked',
+};
+
 export function columnAccentClassFor(
 	field: { terminal_options?: string[] } | undefined,
 	value: string
 ): string {
-	switch (value) {
-		case 'open':
-		case 'new':
-		case 'todo':
-		case 'planned':
-			return 'col-open';
-		case 'in_progress':
-			return 'col-in-progress';
-		case 'done':
-			return 'col-done';
-		case 'blocked':
-			return 'col-blocked';
+	if (hasCanonicalStatus(value)) {
+		return COLOR_TO_COLUMN_CLASS[statusColor(value)] ?? '';
 	}
 	if (value && field?.terminal_options?.includes(value)) return 'col-done';
 	return '';


### PR DESCRIPTION
Phase 3 / PR A2 of PLAN-2290, absorbing two July-audit bugs it collided with: TASK-2208 (content-visibility containment disables subgrid per spec — tables were single-column stacks in Chromium 147; fixed via fully-extrinsic template + inherit, runtime-verified 72px rows) and TASK-2213 (lane accents now derive from the canonical STATUS_COLORS map — hyphen-normalized, so the default template's 'in-progress' finally gets amber; cancelled lanes no longer read done-green). Parity: TableView chips w/ click-cycle, Public* fork on the card language via terminal-aware fieldValueColor.