### PR TITLE
feat(web): item pane tabs — Details/Relationships/Activity/Versions, editor never unmounts (TASK-2294)

### DIFF
--- a/web/e2e/pane-collection-migration-race.spec.ts
+++ b/web/e2e/pane-collection-migration-race.spec.ts
@@ -432,6 +432,9 @@ test('a collection migration completing after a cross-collection navigation does
 	// `goto(B's full-page URL)`, dropping `?item=` and re-driving the SAME master
 	// instance from collA/A to collB/B exactly as the pre-pane relationship-link
 	// nav did.
+	// Relationships moved under the Relationships tab (PLAN-2290 Phase 4) — activate
+	// it on the master before clicking the related link.
+	await page.locator('.item-page-host > .item-page').getByRole('tab', { name: 'Relationships' }).click();
 	await page
 		.locator('.relationship-group', { hasText: 'Related' })
 		.locator('a.link-target', { hasText: bTitle })

--- a/web/e2e/pane-content-link-anchors.spec.ts
+++ b/web/e2e/pane-content-link-anchors.spec.ts
@@ -158,6 +158,8 @@ test.describe('content-link anchor interception (PLAN-2154 / TASK-2159)', () => 
 		await expect.poll(() => openItemParam(page)).not.toBeNull();
 		const paneUrlAtParent = page.url();
 
+		// Children moved under the Relationships tab (PLAN-2290 Phase 4).
+		await pane.getByRole('tab', { name: 'Relationships' }).click();
 		const childRow = pane.locator('.child-row', { hasText: 'Anchors children kid' });
 		await expect(childRow).toBeVisible();
 
@@ -177,6 +179,8 @@ test.describe('content-link anchor interception (PLAN-2154 / TASK-2159)', () => 
 		// the pane's own `?item=` must stay put (proving our handler bailed).
 		await page.goto(paneUrlAtParent);
 		await expect(pane).toBeVisible();
+		// The pane retarget reset the tab to Details — re-activate Relationships.
+		await pane.getByRole('tab', { name: 'Relationships' }).click();
 		await expect(childRow).toBeVisible();
 		const [popup] = await Promise.all([
 			page.context().waitForEvent('page'),
@@ -205,6 +209,8 @@ test.describe('content-link anchor interception (PLAN-2154 / TASK-2159)', () => 
 		await expect(pane).toBeVisible();
 		const paneUrlAtA = page.url();
 
+		// Relationships moved under the Relationships tab (PLAN-2290 Phase 4).
+		await pane.getByRole('tab', { name: 'Relationships' }).click();
 		const relLink = pane.locator('.link-target', { hasText: 'Anchors rel bravo' });
 		await expect(relLink).toBeVisible();
 
@@ -217,6 +223,8 @@ test.describe('content-link anchor interception (PLAN-2154 / TASK-2159)', () => 
 		// pane's own `?item=` is untouched.
 		await page.goto(paneUrlAtA);
 		await expect(pane).toBeVisible();
+		// The pane retarget reset the tab to Details — re-activate Relationships.
+		await pane.getByRole('tab', { name: 'Relationships' }).click();
 		await expect(relLink).toBeVisible();
 		const [popup] = await Promise.all([
 			page.context().waitForEvent('page'),
@@ -385,6 +393,8 @@ test.describe('focus per hop (PLAN-2154 / TASK-2162)', () => {
 		// DRILL A→B by clicking the related-item link. Its anchor lives inside a
 		// `{#key itemSlug}` subtree that this very drill remounts — the exact R1
 		// "clicked link destroyed, focus falls to <body>" case.
+		// The related link lives under the Relationships tab (PLAN-2290 Phase 4).
+		await pane.getByRole('tab', { name: 'Relationships' }).click();
 		const relLink = pane.locator('.link-target', { hasText: 'Focus hop rel bravo' });
 		await expect(relLink).toBeVisible();
 		await relLink.click();
@@ -425,6 +435,8 @@ test.describe('focus per hop (PLAN-2154 / TASK-2162)', () => {
 
 		const releaseB = await gateItemFetch(page, bRef);
 
+		// The related link lives under the Relationships tab (PLAN-2290 Phase 4).
+		await pane.getByRole('tab', { name: 'Relationships' }).click();
 		const relLink = pane.locator('.link-target', { hasText: 'Focus hop kbd bravo' });
 		await expect(relLink).toBeVisible();
 		// KEYBOARD drill: focus the anchor and activate it with Enter (an <a>
@@ -458,6 +470,8 @@ test.describe('focus per hop (PLAN-2154 / TASK-2162)', () => {
 		await expect(pane).toBeVisible();
 		const aRef = openItemParam(page)!;
 
+		// The related link lives under the Relationships tab (PLAN-2290 Phase 4).
+		await pane.getByRole('tab', { name: 'Relationships' }).click();
 		const relLink = pane.locator('.link-target', { hasText: 'Focus hop back bravo' });
 		await expect(relLink).toBeVisible();
 		await relLink.click();

--- a/web/e2e/pane-full-page-capstone.spec.ts
+++ b/web/e2e/pane-full-page-capstone.spec.ts
@@ -237,6 +237,9 @@ function collabRoom(url: string): string | null {
 /** Open the pane by clicking a MASTER relationship link (the host's real
  *  first-open path — `handleMasterOpenTarget` → `openItemPaneByRef`). */
 async function openPaneViaRelated(page: Page, titlePrefix: string): Promise<void> {
+	// Relationships moved under the Relationships tab (PLAN-2290 Phase 4) — activate
+	// it on the master before clicking the related link.
+	await masterCol(page).getByRole('tab', { name: 'Relationships' }).click();
 	await masterCol(page)
 		.locator('.relationship-group', { hasText: 'Related' })
 		.locator('a.link-target', { hasText: titlePrefix })
@@ -286,32 +289,39 @@ test.describe('full-page pane host CAPSTONE (PLAN-2154 Phase 2 / TASK-2175)', ()
 		await page.goto(fullPageUrl(fixture, coll.slug, master.slug));
 		const col = masterCol(page);
 
-		// ── Pre-peek: the master is fully EDITABLE (no pane yet). ──
+		// ── Pre-peek: the master is fully EDITABLE (no pane yet). The Phase-4 tabs
+		//    (PLAN-2290) split the surfaces across Details / Relationships / Activity, so
+		//    verify each tab's editable surface HERE, before the peek; the peek-era
+		//    checks below stay DOM-based (the exhaustive per-surface freeze audit lives
+		//    in masterFreeze.svelte.test.ts + mutationGate.test.ts). ──
 		await expect(page.locator('.item-page-host')).toBeVisible();
 		const editableTitle = col.locator('button.title', { hasText: 'FP freeze master' });
 		await expect(editableTitle).toBeVisible();
-		// The Note field is an editable input (FieldEditor, not readonly-display).
+		// Details tab (default): the Note field is an editable input (FieldEditor, not
+		// readonly-display), and the rich editor is the live, synced, EDITABLE collab editor.
 		const noteInput = col.locator('.field-row', { hasText: 'Note' }).locator('input.field-input');
 		await expect(noteInput).toBeVisible();
 		await expect(noteInput).toBeEnabled();
-		// The comment composer is present.
-		await expect(col.locator('.compose')).toBeVisible();
-		// Star is enabled; Share + Quick-actions + Delete are present.
+		await expect(col.locator(SYNCED_BADGE_SELECTOR)).toBeVisible({ timeout: SYNC_TIMEOUT });
+		const masterEditor = col.locator(EDITOR_SELECTOR);
+		await expect(masterEditor).toBeVisible({ timeout: SYNC_TIMEOUT });
+		await expect(masterEditor).toHaveAttribute('contenteditable', 'true');
+		// Action bar (above the tabs): Star enabled; Share + Quick-actions + Delete + Move present.
 		await expect(col.locator('button.star-btn')).toBeEnabled();
 		await expect(col.locator('button.action-btn', { hasText: 'Share' })).toBeVisible();
 		await expect(col.locator('button.trigger-btn[title="Quick actions"]')).toBeVisible();
 		await expect(col.locator('button.delete-btn')).toBeVisible();
 		await expect(col.locator('button.action-btn', { hasText: 'Move to' })).toBeVisible();
-		// Relationship mutation surfaces (the master HAS a `related` link): the
-		// per-link remove button (rendered but `display:none` until row-hover, so
-		// assert DOM presence, not visibility) and the "+ Add relationship" opener.
+		// Relationships tab: the per-link remove button (rendered but `display:none`
+		// until row-hover, so assert DOM presence) and the "+ Add relationship" opener.
+		await col.getByRole('tab', { name: 'Relationships' }).click();
 		await expect(col.locator('button.link-delete-btn')).toHaveCount(1);
 		await expect(col.locator('button.add-relationship-btn')).toBeVisible();
-		// The rich editor is the live collab editor and is EDITABLE.
-		await expect(col.locator(SYNCED_BADGE_SELECTOR)).toBeVisible({ timeout: SYNC_TIMEOUT });
-		const masterEditor = col.locator(EDITOR_SELECTOR);
-		await expect(masterEditor).toBeVisible({ timeout: SYNC_TIMEOUT });
-		await expect(masterEditor).toHaveAttribute('contenteditable', 'true');
+		// Activity tab: the comment composer.
+		await col.getByRole('tab', { name: 'Activity' }).click();
+		await expect(col.locator('.compose')).toBeVisible();
+		// Return to Details so the peek-era editor checks read the right tab.
+		await col.getByRole('tab', { name: 'Details' }).click();
 
 		// ── Open the pane → focus-follows-editing (PLAN-2179 DR-2 / TASK-2181) keeps
 		//    the MASTER editable (the pane opens as a read-only PREVIEW). Then click
@@ -325,29 +335,31 @@ test.describe('full-page pane host CAPSTONE (PLAN-2154 Phase 2 / TASK-2175)', ()
 		// Activate the pane (click its title) → the master becomes the frozen side.
 		await pane.locator('.title', { hasText: 'FP freeze target' }).click();
 
-		// ── Peeking (BUG-2263): the freeze is INVISIBLE. The ONLY thing that
-		//    changes on the master is that its content editor stops being typeable
-		//    (contenteditable=false). Every other surface stays EXACTLY as pre-peek —
-		//    the master/pane freeze exists solely to keep one typeable collab editor,
-		//    and must be transparent to the user everywhere else. ──
+		// ── Peeking (BUG-2263): the freeze is INVISIBLE. The ONLY thing that changes
+		//    on the master is its content editor stops being typeable
+		//    (contenteditable=false). Every OTHER surface stays live — but Phase-4 put
+		//    the field / relationships / composer under inactive tabs here, so their
+		//    "not frozen" guarantee is asserted DOM-based (present + enabled), not by
+		//    visibility on a hidden tab (their visual editability was verified per-tab
+		//    pre-peek). ──
 		await expect(masterEditor).toHaveAttribute('contenteditable', 'false');
 		// Title: STILL a click-to-edit button (no degraded <h1>).
 		await expect(col.locator('button.title', { hasText: 'FP freeze master' })).toBeVisible();
 		await expect(col.locator('h1.title.title-readonly')).toHaveCount(0);
-		// Field: STILL an editable input (no readonly-display swap).
-		await expect(noteInput).toBeVisible();
+		// Field: STILL an editable input (present + enabled, no readonly-display swap).
+		await expect(noteInput).toHaveCount(1);
 		await expect(noteInput).toBeEnabled();
 		await expect(col.locator('.field-row', { hasText: 'Note' }).locator('.readonly-display')).toHaveCount(0);
-		// Comment composer: still present.
-		await expect(col.locator('.compose')).toBeVisible();
+		// Comment composer: still present (not peeking-gated — ItemTimeline frozen={false}).
+		await expect(col.locator('.compose')).toHaveCount(1);
 		// Star: still enabled (never gated on peeking anymore).
 		await expect(col.locator('button.star-btn')).toBeEnabled();
-		// Share + Delete + Move + Add-relationship + per-link remove: all still
-		// present (side-independent single-item REST — no freeze).
+		// Share + Delete + Move (action bar, above the tabs): all still present.
 		await expect(col.locator('button.action-btn', { hasText: 'Share' })).toBeVisible();
 		await expect(col.locator('button.delete-btn')).toBeVisible();
 		await expect(col.locator('button.action-btn', { hasText: 'Move to' })).toBeVisible();
-		await expect(col.locator('button.add-relationship-btn')).toBeVisible();
+		// Add-relationship + per-link remove: still present (side-independent single-item REST — no freeze).
+		await expect(col.locator('button.add-relationship-btn')).toHaveCount(1);
 		await expect(col.locator('button.link-delete-btn')).toHaveCount(1);
 		// EXCEPTION (Codex P1): the owner quick-actions menu's "Manage/New" controls
 		// WRITE the whole collection settings from a per-item snapshot (last-write-
@@ -356,14 +368,16 @@ test.describe('full-page pane host CAPSTONE (PLAN-2154 Phase 2 / TASK-2175)', ()
 		// controls gated the trigger has nothing to show and is hidden on the peeking
 		// side (prompt actions, when present, would keep it visible — unit-tested).
 		await expect(col.locator('button.trigger-btn[title="Quick actions"]')).toHaveCount(0);
-		// Rich editor: retained + visible (no teardown) — only not typeable.
-		await expect(masterEditor).toBeVisible();
+		// Rich editor: retained (no teardown) — only not typeable.
+		await expect(masterEditor).toHaveCount(1);
 
 		// ── RUNTIME MUTATION (Codex P2): the invisible freeze is not merely visual —
-		//    a field edit typed on the FROZEN master must actually PATCH the CORRECT
-		//    item. Type into the note field while peeking and assert it persists to
-		//    THIS master's fields (server-side), proving updateField fired for the
-		//    right item id from the frozen side. ──
+		//    a field edit must actually PATCH the CORRECT item. The field lives under
+		//    the master's Details tab (Phase-4); switching to it re-activates the master
+		//    per focus-follows (the same un-peek a field click always triggered), then
+		//    the edit must persist to THIS master's fields (server-side), proving
+		//    updateField fired for the right item id. ──
+		await col.getByRole('tab', { name: 'Details' }).click();
 		await noteInput.fill('edited-while-peeking');
 		await expect
 			.poll(
@@ -382,12 +396,13 @@ test.describe('full-page pane host CAPSTONE (PLAN-2154 Phase 2 / TASK-2175)', ()
 			.toBe('edited-while-peeking');
 
 		// ── Close (un-peek) → the content editor is typeable again; nothing else was
-		//    ever frozen, so it is unchanged. ──
+		//    ever frozen, so it is unchanged (composer asserted DOM-present — it's under
+		//    the Activity tab). ──
 		await pane.locator('button[aria-label="Close pane"]').click();
 		await expect(pane).toBeHidden();
 		await expect(col.locator('button.title', { hasText: 'FP freeze master' })).toBeVisible();
 		await expect(noteInput).toBeVisible();
-		await expect(col.locator('.compose')).toBeVisible();
+		await expect(col.locator('.compose')).toHaveCount(1);
 		await expect(masterEditor).toHaveAttribute('contenteditable', 'true', { timeout: SYNC_TIMEOUT });
 	});
 
@@ -516,6 +531,9 @@ test.describe('full-page pane host CAPSTONE (PLAN-2154 Phase 2 / TASK-2175)', ()
 		// pane provider RE-TARGETS: `related`'s socket is torn down, the grandchild's
 		// minted — master + grandchild = STILL 2 distinct rooms, not
 		// {master, related, grandchild}. This is "one pane provider that re-targets, not N".
+		// Children moved under the Relationships tab (PLAN-2290 Phase 4); revealing
+		// the child-row needs the pane's Relationships tab active first.
+		await pane.getByRole('tab', { name: 'Relationships' }).click();
 		await pane.locator('.child-row', { hasText: 'FP ws grandchild' }).click();
 		await expect(pane.locator('.title', { hasText: 'FP ws grandchild' })).toBeVisible();
 		await expect

--- a/web/e2e/pane-full-page-host.spec.ts
+++ b/web/e2e/pane-full-page-host.spec.ts
@@ -142,6 +142,8 @@ test.describe('full-page pane host (PLAN-2154 Phase 2 / TASK-2174)', () => {
 		expect(openItemParam(page)).toBeNull();
 
 		// Click the RELATED link on the master → FIRST-OPEN the pane beside it.
+		// Relationships moved under the Relationships tab (PLAN-2290 Phase 4).
+		await page.locator('.item-page-host > .item-page').getByRole('tab', { name: 'Relationships' }).click();
 		await page
 			.locator('.relationship-group', { hasText: 'Related' })
 			.locator('a.link-target', { hasText: 'FP host related' })
@@ -164,10 +166,12 @@ test.describe('full-page pane host (PLAN-2154 Phase 2 / TASK-2174)', () => {
 		// Depth 0: the pane's Back chevron is hidden.
 		await expect(pane.locator('button.pane-back-btn')).toHaveCount(0);
 
-		// Drill a CHILD row directly from the preview — on the FIRST click. The drill
-		// is pane-internal, so it ALSO activates the pane — pane editable, master
-		// frozen (PLAN-2179 DR-2 / TASK-2181). No pre-activation click.
+		// Drill a CHILD row from the preview. Children live under the pane's
+		// Relationships tab (PLAN-2290 Phase 4), so reveal it first; the child-row click
+		// then drills AND (being a pane-side control) activates the pane — pane editable,
+		// master frozen (PLAN-2179 DR-2 / TASK-2181).
 		const masterPathname = new URL(page.url()).pathname;
+		await pane.getByRole('tab', { name: 'Relationships' }).click();
 		await pane.locator('.child-row', { hasText: 'FP host grandchild' }).click();
 		await expect.poll(() => openItemParam(page)).toBe(grandchildRef);
 		expect(new URL(page.url()).pathname).toBe(masterPathname);
@@ -189,10 +193,11 @@ test.describe('full-page pane host (PLAN-2154 Phase 2 / TASK-2174)', () => {
 		await expect(paneEditor).toHaveAttribute('contenteditable', 'true');
 		await expect(masterEditor).toHaveAttribute('contenteditable', 'false');
 
-		// Click BACK into the MASTER content editor → the pointerdown activator
-		// re-activates the master (and the same click lands the caret in the now-
-		// editable view — one gesture), and the desktop backstop must NOT yank focus
-		// back to the pane. Master editable again; pane freezes. Exactly one side.
+		// Click BACK into the MASTER content editor. It lives under the master's Details
+		// tab (PLAN-2290 Phase 4); switching to it + clicking the editor are master-side
+		// controls, so the pointerdown activator re-activates the master (exactly one
+		// editable side), and the desktop backstop must NOT yank focus back to the pane.
+		await page.locator('.item-page-host > .item-page').getByRole('tab', { name: 'Details' }).click();
 		await masterEditor.click();
 		await expect(masterEditor).toHaveAttribute('contenteditable', 'true');
 		await expect(paneEditor).toHaveAttribute('contenteditable', 'false');
@@ -246,6 +251,8 @@ test.describe('full-page pane host (PLAN-2154 Phase 2 / TASK-2174)', () => {
 		// Open the pane → focus-follows keeps the MASTER active (DR-2), so its editor
 		// stays editable and the SAME DOM node stays connected — no open-driven remount.
 		const pane = page.locator('.item-pane');
+		// Relationships moved under the Relationships tab (PLAN-2290 Phase 4).
+		await page.locator('.item-page-host > .item-page').getByRole('tab', { name: 'Relationships' }).click();
 		await page
 			.locator('.relationship-group', { hasText: 'Related' })
 			.locator('a.link-target', { hasText: 'FP host reactive-freeze related' })
@@ -317,6 +324,8 @@ test.describe('full-page pane host (PLAN-2154 Phase 2 / TASK-2174)', () => {
 		// the SAME paragraph must NOT reveal the handle — the reactive-editable choke
 		// (onMouseMove/update bail on !editorView.editable) keeps it hidden.
 		const pane = page.locator('.item-pane');
+		// Relationships moved under the Relationships tab (PLAN-2290 Phase 4).
+		await page.locator('.item-page-host > .item-page').getByRole('tab', { name: 'Relationships' }).click();
 		await page
 			.locator('.relationship-group', { hasText: 'Related' })
 			.locator('a.link-target', { hasText: 'FP host drag-handle related' })
@@ -324,16 +333,19 @@ test.describe('full-page pane host (PLAN-2154 Phase 2 / TASK-2174)', () => {
 		await expect(pane).toBeVisible();
 		await expect.poll(() => openItemParam(page)).toBe(relatedRef);
 		await pane.locator('.editor-wrapper .ProseMirror').click();
+		// Peeking freezes the master editor (contenteditable=false). The block-drag-
+		// handle choke keys off `editorView.editable`, so this DOM state IS the handle-
+		// suppression guarantee; the master editor now sits under the inactive Details
+		// tab (PLAN-2290 Phase 4), so a hover probe here isn't meaningful — the hover-
+		// suppression path is unit-covered (masterFreeze.svelte.test.ts).
 		await expect(masterMain).toHaveAttribute('contenteditable', 'false');
-		await page.mouse.move(5, 5); // leave the editor first
-		await masterMain.locator('p').first().hover({ force: true });
-		await page.waitForTimeout(250);
-		expect(await handleDisplay()).toBe('none');
 
-		// CLOSE: the master thaws → hovering reveals the handle again.
+		// CLOSE: the master thaws → back on its Details tab (PLAN-2290 Phase 4), hovering
+		// a paragraph reveals the handle again.
 		await page.locator('button[title="Close pane"]').click();
 		await expect(page.locator('.item-pane')).toHaveCount(0);
 		await expect(masterMain).toHaveAttribute('contenteditable', 'true');
+		await page.locator('.item-page-host > .item-page').getByRole('tab', { name: 'Details' }).click();
 		await page.mouse.move(5, 5);
 		await masterMain.locator('p').first().hover();
 		await expect.poll(handleDisplay, { timeout: 3000 }).not.toBe('none');
@@ -362,6 +374,8 @@ test.describe('full-page pane host (PLAN-2154 Phase 2 / TASK-2174)', () => {
 		// Open the pane → the master stays active (DR-2); the pane is a read-only
 		// preview. NEW (BUG-2263 follow-up): the peeking PANE shows the mode toggle —
 		// previously it was hidden on the peeking side.
+		// Relationships moved under the Relationships tab (PLAN-2290 Phase 4).
+		await page.locator('.item-page-host > .item-page').getByRole('tab', { name: 'Relationships' }).click();
 		await page
 			.locator('.relationship-group', { hasText: 'Related' })
 			.locator('a.link-target', { hasText: 'FP mode-toggle related' })
@@ -376,11 +390,16 @@ test.describe('full-page pane host (PLAN-2154 Phase 2 / TASK-2174)', () => {
 		// Click into the pane → the MASTER becomes the peeking side; its toggle stays.
 		await paneEditor.click();
 		await expect(masterEditor).toHaveAttribute('contenteditable', 'false');
-		await expect(masterToggle).toBeVisible();
+		// BUG-2263 (PLAN-2290 Phase 4): the mode toggle is NOT peeking-gated — it stays
+		// in the DOM on the peeking side (it lives under the master's Details tab, so it's
+		// tab-hidden here, not freeze-hidden; its visibility was asserted pre-peek above).
+		await expect(masterToggle).toHaveCount(1);
 
-		// ONE GESTURE: click the peeking master's "Markdown" button. Its onclick bails
-		// on `if (peeking) return`, so a successful flip PROVES the pointerdown
-		// activator un-peeked the master FIRST, in the same gesture.
+		// Flip Rich→Markdown from the master. Switching to its Details tab (PLAN-2290
+		// Phase 4) is a master-side control, so it re-activates the master per focus-
+		// follows (PLAN-2179) — the product's deliberate un-peek-on-interaction — then
+		// the Markdown button flips in place.
+		await masterCol.getByRole('tab', { name: 'Details' }).click();
 		await masterCol.locator('.editor-mode-toggle .mode-btn', { hasText: 'Markdown' }).click();
 		await expect(masterCol.locator('.editor-mode-toggle .mode-btn', { hasText: 'Markdown' })).toHaveClass(/active/);
 		// Master is now in raw markdown mode: the ProseMirror unmounted, and the pane
@@ -487,6 +506,8 @@ test.describe('full-page pane host (PLAN-2154 Phase 2 / TASK-2174)', () => {
 		const relatedRef = await itemRef(fixture, request, related.slug);
 
 		await page.goto(fullPageUrl(fixture, master.slug));
+		// Relationships moved under the Relationships tab (PLAN-2290 Phase 4).
+		await page.locator('.item-page-host > .item-page').getByRole('tab', { name: 'Relationships' }).click();
 		await page
 			.locator('.relationship-group', { hasText: 'Related' })
 			.locator('a.link-target', { hasText: 'FP host expand related' })

--- a/web/e2e/pane-full-page-host.spec.ts
+++ b/web/e2e/pane-full-page-host.spec.ts
@@ -333,12 +333,21 @@ test.describe('full-page pane host (PLAN-2154 Phase 2 / TASK-2174)', () => {
 		await expect(pane).toBeVisible();
 		await expect.poll(() => openItemParam(page)).toBe(relatedRef);
 		await pane.locator('.editor-wrapper .ProseMirror').click();
-		// Peeking freezes the master editor (contenteditable=false). The block-drag-
-		// handle choke keys off `editorView.editable`, so this DOM state IS the handle-
-		// suppression guarantee; the master editor now sits under the inactive Details
-		// tab (PLAN-2290 Phase 4), so a hover probe here isn't meaningful — the hover-
-		// suppression path is unit-covered (masterFreeze.svelte.test.ts).
 		await expect(masterMain).toHaveAttribute('contenteditable', 'false');
+
+		// INTEGRATION: put the master's Details tab back on-screen so the hover
+		// probe is meaningful (clicking the master tab bar ACTIVATES the master —
+		// focus-follows, PLAN-2290 Phase 4), then re-peek by clicking back into
+		// the pane. Master is now frozen WITH its editor visible: hovering the
+		// same paragraph must NOT reveal the handle — the reactive-editable
+		// choke (onMouseMove/update bail on !editorView.editable) end-to-end.
+		await page.locator('.item-page-host > .item-page').getByRole('tab', { name: 'Details' }).click();
+		await expect(masterMain).toHaveAttribute('contenteditable', 'true');
+		await pane.locator('.editor-wrapper .ProseMirror').click();
+		await expect(masterMain).toHaveAttribute('contenteditable', 'false');
+		await page.mouse.move(5, 5);
+		await masterMain.locator('p').first().hover({ force: true });
+		await expect.poll(handleDisplay, { timeout: 3000 }).toBe('none');
 
 		// CLOSE: the master thaws → back on its Details tab (PLAN-2290 Phase 4), hovering
 		// a paragraph reveals the handle again.

--- a/web/e2e/version-restore-collab.spec.ts
+++ b/web/e2e/version-restore-collab.spec.ts
@@ -332,6 +332,8 @@ test('an unflushed live edit is captured in the restore undo-point via the UI (B
 			r.ok(),
 		{ timeout: 30_000 }
 	);
+	// Version cards moved under the Versions tab (PLAN-2290 Phase 4).
+	await page.getByRole('tab', { name: 'Versions' }).click();
 	const card = page.locator('#item-timeline .version-card').first();
 	await card.locator('.card-header').click(); // expand
 	await card.getByRole('button', { name: 'Restore this version' }).click();

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -4539,6 +4539,10 @@
 				const next = e.key === 'ArrowRight'
 					? (idx + 1) % tabs.length
 					: (idx - 1 + tabs.length) % tabs.length;
+				// Automatic activation: panels are display-toggles (always
+				// mounted), so activating on arrow-focus is free and keeps the
+				// roving tabindex consistent (tabindex derives from activeTab).
+				activeTab = PANE_TABS[next].id;
 				tabs[next].focus();
 			}}
 		>

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -525,6 +525,9 @@
 	// retargeted pane never opens on a stale tab.
 	type PaneTab = 'details' | 'relationships' | 'activity' | 'versions';
 	let activeTab = $state<PaneTab>('details');
+	// Stable per-instance suffix so tab/panel aria-controls pairs stay unique
+	// when TWO ItemDetail instances mount (full-page master + docked pane).
+	const uid = $props.id();
 	const PANE_TABS: Array<{ id: PaneTab; label: string }> = [
 		{ id: 'details', label: 'Details' },
 		{ id: 'relationships', label: 'Relationships' },
@@ -2420,8 +2423,11 @@
 		if (e.key === 'Enter') {
 			e.preventDefault();
 			saveTitle();
-			// Move focus to the editor so you can start writing immediately
-			requestAnimationFrame(() => editorInstance?.commands.focus());
+			// Move focus to the editor so you can start writing immediately.
+			// The editor lives under the Details tab — surface it first or the
+			// focus lands on a display:none node (PR #1027 Codex finding).
+			activeTab = 'details';
+			tick().then(() => requestAnimationFrame(() => editorInstance?.commands.focus()));
 		} else if (e.key === 'Escape') {
 			editingTitle = false;
 		}
@@ -4517,13 +4523,35 @@
 
 		<!-- Pane tabs (PLAN-2290 Phase 4). Panels below are CSS-hidden, never
 		     unmounted — see the PaneTab block in the script. -->
-		<div class="pane-tabs" role="tablist" aria-label="Item sections">
+		<div
+			class="pane-tabs"
+			role="tablist"
+			aria-label="Item sections"
+			tabindex={-1}
+			onkeydown={(e) => {
+				if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') return;
+				const tabs = Array.from(
+					(e.currentTarget as HTMLElement).querySelectorAll<HTMLElement>('[role="tab"]')
+				);
+				const idx = tabs.indexOf(document.activeElement as HTMLElement);
+				if (idx === -1) return;
+				e.preventDefault();
+				const next = e.key === 'ArrowRight'
+					? (idx + 1) % tabs.length
+					: (idx - 1 + tabs.length) % tabs.length;
+				tabs[next].focus();
+			}}
+		>
 			{#each PANE_TABS as t (t.id)}
 				<button
 					class="pane-tab"
 					class:on={activeTab === t.id}
 					role="tab"
 					aria-selected={activeTab === t.id}
+					aria-controls={t.id === 'activity' || t.id === 'versions'
+						? `pane-panel-feed-${uid}`
+						: `pane-panel-${t.id}-${uid}`}
+					tabindex={activeTab === t.id ? 0 : -1}
 					onclick={() => (activeTab = t.id)}
 				>
 					{t.label}
@@ -4531,7 +4559,7 @@
 			{/each}
 		</div>
 
-		<div class="tab-panel" class:tab-hidden={activeTab !== 'details'} role="tabpanel" aria-label="Details">
+		<div class="tab-panel" class:tab-hidden={activeTab !== 'details'} role="tabpanel" id="pane-panel-details-{uid}" aria-label="Details">
 		{#if codeContext}
 			<div class="code-context-section">
 				<h3 class="section-title">Code Context</h3>
@@ -5050,7 +5078,7 @@
 		     to B — the child's OWN prop check can't catch it (its prop is frozen
 		     at A). PLAN-2105 / TASK-2112; coordinator. -->
 		{@const keyedSlug = itemSlug}
-		<div class="tab-panel" class:tab-hidden={activeTab !== 'relationships'} role="tabpanel" aria-label="Relationships">
+		<div class="tab-panel" class:tab-hidden={activeTab !== 'relationships'} role="tabpanel" id="pane-panel-relationships-{uid}" aria-label="Relationships">
 		{#if relationshipGroups.length > 0}
 			<div class="relationships-section">
 				<h3 class="section-title">Relationships</h3>
@@ -5187,6 +5215,7 @@
 			class="tab-panel"
 			class:tab-hidden={activeTab !== 'activity' && activeTab !== 'versions'}
 			role="tabpanel"
+			id="pane-panel-feed-{uid}"
 			aria-label={activeTab === 'versions' ? 'Versions' : 'Activity'}
 		>
 		<div id="item-timeline" class="timeline-section">

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -513,6 +513,44 @@
 	// (and its dagre layout lib) are dynamically imported on first open so they
 	// stay out of the item-page bundle.
 	let showGraph = $state(false);
+
+	// ── Pane tabs (PLAN-2290 Phase 4 / TASK-2294) ─────────────────────────
+	// Details / Relationships / Activity / Versions. HARD RULE: panels are
+	// CSS-hidden (`.tab-hidden`), NEVER `{#if}`-unmounted — the collab
+	// editor, ChildItems/ItemTimeline SSE subscriptions, and BacklinksPanel's
+	// count callback all carry mount-time side effects that must survive tab
+	// switches (see the section-map recon on TASK-2294). Tab switching stays
+	// interactive while `peeking` (view-only, side-independent — same class
+	// as star/quick-action prompts). Resets to Details on item switch so a
+	// retargeted pane never opens on a stale tab.
+	type PaneTab = 'details' | 'relationships' | 'activity' | 'versions';
+	let activeTab = $state<PaneTab>('details');
+	const PANE_TABS: Array<{ id: PaneTab; label: string }> = [
+		{ id: 'details', label: 'Details' },
+		{ id: 'relationships', label: 'Relationships' },
+		{ id: 'activity', label: 'Activity' },
+		{ id: 'versions', label: 'Versions' }
+	];
+
+	// The action-bar jump buttons scroll to sections that may live in a
+	// hidden tab: switch first, let the panel become visible, then scroll.
+	async function jumpToSection(tab: PaneTab, anchorId: string) {
+		activeTab = tab;
+		await tick();
+		document.getElementById(anchorId)?.scrollIntoView({ behavior: 'smooth' });
+	}
+
+	// Item switch (the no-{#key} A→B retarget) lands on Details — mirrors
+	// the fields/data-panels {#key itemSlug} remounts. Guarded write: only
+	// touches activeTab when the slug actually changed (no read-write loop;
+	// lastTabSlug is a plain let, not $state).
+	let lastTabSlug: string | undefined;
+	$effect(() => {
+		if (itemSlug !== lastTabSlug) {
+			lastTabSlug = itemSlug;
+			activeTab = 'details';
+		}
+	});
 	// The graph focuses by issue ref (e.g. TASK-5); null when the item has no
 	// number (shouldn't happen, but gates the button so we never focus on '').
 	let graphFocusRef = $derived(item ? formatItemRef(item) : null);
@@ -4362,7 +4400,7 @@
 			{/if}
 			<button
 				class="action-btn"
-				onclick={() => { document.getElementById('item-timeline')?.scrollIntoView({ behavior: 'smooth' }); }}
+				onclick={() => jumpToSection('activity', 'item-timeline')}
 			>
 				Timeline
 			</button>
@@ -4390,7 +4428,7 @@
 					class="action-btn"
 					title="{childTotal} child item{childTotal === 1 ? '' : 's'}, {childDone} done"
 					aria-label="Jump to Children — {childDone} of {childTotal} done"
-					onclick={() => { document.getElementById('item-children')?.scrollIntoView({ behavior: 'smooth' }); }}
+					onclick={() => jumpToSection('relationships', 'item-children')}
 				>
 					🌳 {childDone}/{childTotal}
 				</button>
@@ -4409,7 +4447,7 @@
 				<button
 					class="action-btn"
 					title="Mentioned in {backlinksCount} other item{backlinksCount === 1 ? '' : 's'}"
-					onclick={() => { document.getElementById('item-backlinks')?.scrollIntoView({ behavior: 'smooth' }); }}
+					onclick={() => jumpToSection('relationships', 'item-backlinks')}
 				>
 					📎 {backlinksCount}
 				</button>
@@ -4477,6 +4515,23 @@
 			{/if}
 		</div>
 
+		<!-- Pane tabs (PLAN-2290 Phase 4). Panels below are CSS-hidden, never
+		     unmounted — see the PaneTab block in the script. -->
+		<div class="pane-tabs" role="tablist" aria-label="Item sections">
+			{#each PANE_TABS as t (t.id)}
+				<button
+					class="pane-tab"
+					class:on={activeTab === t.id}
+					role="tab"
+					aria-selected={activeTab === t.id}
+					onclick={() => (activeTab = t.id)}
+				>
+					{t.label}
+				</button>
+			{/each}
+		</div>
+
+		<div class="tab-panel" class:tab-hidden={activeTab !== 'details'} role="tabpanel" aria-label="Details">
 		{#if codeContext}
 			<div class="code-context-section">
 				<h3 class="section-title">Code Context</h3>
@@ -4978,6 +5033,7 @@
 				{/if}
 			</div>
 		</div>
+		</div><!-- /tab-panel Details -->
 
 		<!-- {#key itemSlug}: structural containment (PLAN-2105 / TASK-2112).
 		     Remounts the item-scoped data panels below (relationships, add-link
@@ -4994,6 +5050,7 @@
 		     to B — the child's OWN prop check can't catch it (its prop is frozen
 		     at A). PLAN-2105 / TASK-2112; coordinator. -->
 		{@const keyedSlug = itemSlug}
+		<div class="tab-panel" class:tab-hidden={activeTab !== 'relationships'} role="tabpanel" aria-label="Relationships">
 		{#if relationshipGroups.length > 0}
 			<div class="relationships-section">
 				<h3 class="section-title">Relationships</h3>
@@ -5120,8 +5177,18 @@
 				/>
 			</div>
 		{/if}
+		</div><!-- /tab-panel Relationships -->
 
-		<!-- Unified Timeline (comments + activity + versions) -->
+		<!-- Unified Timeline (comments + activity + versions). ONE mounted
+		     instance serves both the Activity and Versions tabs — the
+		     visibleKinds render-filter switches with the tab, the SSE
+		     subscription and merged feed survive (PLAN-2290 Phase 4). -->
+		<div
+			class="tab-panel"
+			class:tab-hidden={activeTab !== 'activity' && activeTab !== 'versions'}
+			role="tabpanel"
+			aria-label={activeTab === 'versions' ? 'Versions' : 'Activity'}
+		>
 		<div id="item-timeline" class="timeline-section">
 			<!-- Timeline COMMENTS/REACTIONS are per-item / per-user REST entities,
 			     side-independent, so they are NOT frozen while peeking (BUG-2263) —
@@ -5142,8 +5209,10 @@
 				collectionId={item.collection_id}
 				frozen={false}
 				restoreFrozen={peeking}
+				visibleKinds={activeTab === 'versions' ? ['version'] : ['comment', 'activity']}
 			/>
 		</div>
+		</div><!-- /tab-panel Activity/Versions -->
 		{/key}
 
 	</div>
@@ -5344,6 +5413,53 @@
 		justify-content: center;
 		height: 50vh;
 		color: var(--text-muted);
+	}
+
+	/* ── Pane tabs (PLAN-2290 Phase 4) ────────────────────────────────── */
+	.pane-tabs {
+		display: flex;
+		gap: 2px;
+		border-bottom: 1px solid var(--border-subtle);
+		margin: var(--space-4) 0 var(--space-4);
+	}
+
+	.pane-tab {
+		padding: 7px 11px 9px;
+		font-size: 0.92em;
+		font-weight: 550;
+		color: var(--text-muted);
+		background: none;
+		border: none;
+		border-bottom: 2px solid transparent;
+		margin-bottom: -1px;
+		border-radius: var(--radius-sm) var(--radius-sm) 0 0;
+		cursor: pointer;
+	}
+
+	.pane-tab:hover {
+		color: var(--text-secondary);
+		background: var(--bg-hover);
+	}
+
+	.pane-tab.on {
+		color: var(--text-primary);
+		border-bottom-color: var(--accent-primary, var(--accent-blue));
+	}
+
+	/* Hidden tab panels stay MOUNTED (collab editor, SSE feeds, backlink
+	   counts — see the PaneTab script block). display:none only. */
+	.tab-hidden {
+		display: none;
+	}
+
+	/* Print renders the full document: every panel visible, no tab chrome. */
+	@media print {
+		.tab-hidden {
+			display: block !important;
+		}
+		.pane-tabs {
+			display: none !important;
+		}
 	}
 
 	.item-page {

--- a/web/src/lib/components/timeline/ItemTimeline.svelte
+++ b/web/src/lib/components/timeline/ItemTimeline.svelte
@@ -37,6 +37,11 @@
 		itemId?: string;
 		collectionId?: string;
 		/**
+		 * Which entry kinds render (undefined = all). Filter-only: the merged
+		 * feed still fetches every kind, so switching kinds never refetches.
+		 */
+		visibleKinds?: Array<'comment' | 'activity' | 'version'>;
+		/**
 		 * `frozen` freezes the COMMENT/REACTION surfaces (composer, reply, edit,
 		 * delete, reaction). These are per-item / per-user REST entities, so under
 		 * the invisible-freeze model (BUG-2263) the full-page host leaves this
@@ -65,7 +70,7 @@
 		flushBeforeRestore?: () => Promise<void>;
 	}
 
-	let { wsSlug, username = '', itemSlug, currentContent, items = [], onRestore, itemId, collectionId, frozen = false, restoreFrozen = false, flushBeforeRestore }: Props = $props();
+	let { wsSlug, username = '', itemSlug, currentContent, items = [], onRestore, itemId, collectionId, frozen = false, restoreFrozen = false, flushBeforeRestore, visibleKinds }: Props = $props();
 
 	// Resolve canEditItem reactively; falls to false if itemId/collectionId
 	// aren't supplied (e.g. an older caller). Folds in the master-freeze gate
@@ -79,6 +84,14 @@
 	);
 
 	let entries: TimelineEntry[] = $state([]);
+
+	// Render-side filter over the one merged feed. The instance stays
+	// mounted across filter changes (SSE subscriptions live on) — the pane's
+	// Activity/Versions tabs drive this (PLAN-2290 Phase 4). undefined = all.
+	let visibleEntries = $derived(
+		visibleKinds ? entries.filter((e) => visibleKinds.includes(e.kind)) : entries
+	);
+	let showComposer = $derived(!visibleKinds || visibleKinds.includes('comment'));
 	let hasMore: boolean = $state(false);
 	let loading: boolean = $state(false);
 	let loadingMore: boolean = $state(false);
@@ -453,7 +466,7 @@
 	     opened is orphaned when the composer unmounts on freeze — the ACCEPTED,
 	     tracked BUG-2177 tradeoff (its upload bails via attachment-upload.ts's
 	     view.isDestroyed check; no crash, no committed-content loss). -->
-	{#if canEdit}
+	{#if canEdit && showComposer}
 		<div class="compose">
 			<CommentEditor
 				{wsSlug}
@@ -479,7 +492,7 @@
 
 	{#if !loading || entries.length > 0}
 		<div class="entry-list" bind:this={entryListEl}>
-			{#each entries as entry (entry.id)}
+			{#each visibleEntries as entry (entry.id)}
 				<div class="entry">
 					<div class="entry-rail">
 						<span class="dot {dotClass(entry.kind)}"></span>


### PR DESCRIPTION
Phase 4 / PR A of PLAN-2290 — the mock's tabbed item pane. Architecture per the section-map recon: CSS-hidden always-mounted panels (every section carries SSE/collab mount effects), one ItemTimeline instance filtered by visibleKinds for Activity vs Versions, jump buttons switch-then-scroll, tabs reset on retarget, print expands everything. Tab bar deliberately NOT an activation-exempt surface (peeking is a visual preview; controls activate their side). Five e2e specs updated incl. four frozen-master reworks (per-tab visuals pre-peek + DOM freeze proxies while peeking). Local gate: 27/27 across the five specs; collab-survival runtime-verified.