### PR TITLE
fix(web): pane tabs activate on pointerdown (focus-follows click-swallow, CI-caught)

### DIFF
--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -4562,7 +4562,13 @@
 						? `pane-panel-feed-${uid}`
 						: `pane-panel-${t.id}-${uid}`}
 					tabindex={activeTab === t.id ? 0 : -1}
-					onpointerdown={() => (activeTab = t.id)}
+					onpointerdown={(e) => {
+						// Mouse only: touch pointerdown fires on scroll-start, and a
+						// drag beginning on a tab must not switch panels (Codex).
+						// Mobile has no peeking master, so the click-swallow race
+						// this guards against doesn't exist there.
+						if (e.pointerType === 'mouse') activeTab = t.id;
+					}}
 					onclick={() => (activeTab = t.id)}
 				>
 					{t.label}

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -4547,6 +4547,12 @@
 			}}
 		>
 			{#each PANE_TABS as t (t.id)}
+				<!-- pointerdown + click both activate (idempotent): pointerdown wins
+				     the race against the focus-follows activation cascade — on a
+				     peeking master the pointerdown-triggered re-render can swallow
+				     the subsequent click on slow machines (CI caught it; same
+				     same-click detach class as BUG-2281). click remains for
+				     keyboard (Enter/Space). -->
 				<button
 					class="pane-tab"
 					class:on={activeTab === t.id}
@@ -4556,6 +4562,7 @@
 						? `pane-panel-feed-${uid}`
 						: `pane-panel-${t.id}-${uid}`}
 					tabindex={activeTab === t.id ? 0 : -1}
+					onpointerdown={() => (activeTab = t.id)}
 					onclick={() => (activeTab = t.id)}
 				>
 					{t.label}


### PR DESCRIPTION
Un-reds main's E2E job after #1027: on slow runners, a peeking master's tab click is swallowed by the pointerdown-triggered focus-follows re-render cascade (same detach class as BUG-2281). Tabs now activate on pointerdown (click kept for keyboard — idempotent). Both CI-failing tests green locally at 3x repeat pressure (45/45).