### PR TITLE
fix(e2e): graph tests open via the pane ⋯ overflow (un-reds E2E after #1029)

### DIFF
--- a/web/e2e/pane-content-link-anchors.spec.ts
+++ b/web/e2e/pane-content-link-anchors.spec.ts
@@ -252,7 +252,9 @@ test.describe('content-link anchor interception (PLAN-2154 / TASK-2159)', () => 
 		await expect(pane).toBeVisible();
 		const paneUrlAtParent = page.url();
 
-		await pane.locator('button[title="View this item\'s dependency graph"]').click();
+		// Graph opens from the pane ⋯ overflow now (PLAN-2290 Phase 4 PR B).
+		await pane.locator('button.pane-more-btn').click();
+		await pane.getByRole('menuitem', { name: 'Dependency graph' }).click();
 		const drawer = pane.locator('.graph-drawer');
 		await expect(drawer).toBeVisible();
 		const childNode = drawer.locator('.node', { hasText: childRef });
@@ -288,7 +290,9 @@ test.describe('content-link anchor interception (PLAN-2154 / TASK-2159)', () => 
 		await expect(pane).toBeVisible();
 		const paneUrlAtParent = page.url();
 
-		await pane.locator('button[title="View this item\'s dependency graph"]').click();
+		// Graph opens from the pane ⋯ overflow now (PLAN-2290 Phase 4 PR B).
+		await pane.locator('button.pane-more-btn').click();
+		await pane.getByRole('menuitem', { name: 'Dependency graph' }).click();
 		const drawer = pane.locator('.graph-drawer');
 		await expect(drawer).toBeVisible();
 


### PR DESCRIPTION
#1029 moved the 🕸 graph button into the pane ⋯ menu but the two graph e2e tests still clicked the old title locator — and my pre-merge local run only covered capstone+host. Both graph-open sites repointed; full anchors spec 7/7 locally; repo-wide grep confirms no other references to removed controls.