### PR TITLE
fix(web): delete confirmation becomes an in-menu sub-view (TASK-2327)

### DIFF
--- a/web/src/lib/components/common/BottomSheet.svelte
+++ b/web/src/lib/components/common/BottomSheet.svelte
@@ -24,10 +24,16 @@
 		open: boolean;
 		onclose: () => void;
 		title?: string;
+		/** Changes to this value re-run the focus handoff while the sheet
+		 *  STAYS open. A consumer that swaps its content in place (a
+		 *  drill-down sub-view) unmounts the focused control, dropping focus
+		 *  to <body>; pass the view identity here so focus returns to the
+		 *  sheet. PLAN-2326 DR-8. */
+		focusKey?: string | number;
 		children: Snippet;
 	}
 
-	let { open, onclose, title, children }: Props = $props();
+	let { open, onclose, title, focusKey, children }: Props = $props();
 
 	// Stable per-instance heading id so aria-labelledby can point at the
 	// visible title when one is provided. $props.id() must be the direct
@@ -59,7 +65,15 @@
 	// and Tab escapes the sheet. Reads `open` (prop) + `sheetEl` ($state); writes
 	// only the plain `previouslyFocused`, so no $state is both read and written
 	// here and the effect can't self-invalidate (mirrors Modal.svelte).
+	//
+	// `focusKey` is read purely for dependency tracking: a consumer that swaps
+	// its content IN PLACE (Menu's drill-down sub-views) leaves `open` and
+	// `sheetEl` untouched while unmounting the focused control, so without this
+	// read the effect wouldn't re-run and focus would sit on <body>
+	// (PLAN-2326 DR-8). The `el.contains(document.activeElement)` guard below
+	// keeps the re-run a no-op whenever focus is still inside the sheet.
 	$effect(() => {
+		focusKey;
 		const el = sheetEl;
 		if (open && el) {
 			if (previouslyFocused === null) {

--- a/web/src/lib/components/common/Menu.svelte
+++ b/web/src/lib/components/common/Menu.svelte
@@ -29,6 +29,13 @@
 		/** Extra containers that count as "inside" for outside-click
 		 *  (e.g. a nested portaled emoji picker). */
 		exempt?: () => (Element | null | undefined)[];
+		/** Changes to this value re-run the first-row focus handoff while the
+		 *  menu STAYS open. Drill-down menus (a sub-view swapped in place)
+		 *  unmount the focused MenuItem, which drops keyboard focus to
+		 *  <body>; pass the view identity here so focus follows the swap.
+		 *  Forwarded to BottomSheet in `sheetOnMobile` mode, which owns focus
+		 *  there. PLAN-2326 DR-8. */
+		focusKey?: string | number;
 		/** Return true to suppress outside-close for this event (e.g. while
 		 *  a drag interaction is in flight — cf. TopBar pill drags). */
 		suppressOutside?: () => boolean;
@@ -47,6 +54,7 @@
 		ariaLabel,
 		exempt,
 		suppressOutside,
+		focusKey,
 		children
 	}: Props = $props();
 
@@ -72,7 +80,15 @@
 
 	// Focus the first row on open (menus are keyboard surfaces); return
 	// focus to the trigger on close. Reads `open`/`panelEl`, writes neither.
+	//
+	// `focusKey` is read purely for dependency tracking: when a drill-down
+	// menu swaps its sub-view IN PLACE, `open` never changes, so without this
+	// read the effect wouldn't re-run and focus would be stranded on the
+	// unmounted MenuItem (PLAN-2326 DR-8). The effect body only performs DOM
+	// focus/placement — it writes no reactive state it also reads, so it
+	// cannot self-trigger (CONVE-1688).
 	$effect(() => {
+		focusKey;
 		if (open && !useSheet) {
 			tick().then(() => {
 				if (mode === 'portal') place();
@@ -145,7 +161,9 @@
 
 {#if useSheet}
 	{#if open}
-		<BottomSheet {open} onclose={onclose} title={sheetTitle}>
+		<!-- focusKey forwarded: the sheet owns focus on mobile, so the
+		     drill-down handoff (DR-8) has to be re-run there too. -->
+		<BottomSheet {open} onclose={onclose} title={sheetTitle} {focusKey}>
 			{@render children()}
 		</BottomSheet>
 	{/if}

--- a/web/src/lib/components/common/MenuItem.svelte
+++ b/web/src/lib/components/common/MenuItem.svelte
@@ -11,11 +11,24 @@
 		/** When defined the row is a menuitemradio with a trailing check. */
 		checked?: boolean;
 		disabled?: boolean;
+		/** id of an element describing this row — e.g. the prompt line above a
+		 *  destructive confirmation, which is presentational and otherwise
+		 *  never announced when the row takes focus (PLAN-2326). */
+		describedBy?: string;
 		onclick?: (e: MouseEvent) => void;
 		children: Snippet;
 	}
 
-	let { icon, hint, danger = false, checked, disabled = false, onclick, children }: Props = $props();
+	let {
+		icon,
+		hint,
+		danger = false,
+		checked,
+		disabled = false,
+		describedBy,
+		onclick,
+		children
+	}: Props = $props();
 </script>
 
 <button
@@ -24,6 +37,7 @@
 	class:danger
 	role={checked !== undefined ? 'menuitemradio' : 'menuitem'}
 	aria-checked={checked}
+	aria-describedby={describedBy}
 	{disabled}
 	{onclick}
 >

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -500,16 +500,20 @@
 	// is merely emptied or closed on the SAME item — this seq does (Codex review
 	// P2). Plain `let` (CONVE-1688): read/written in handlers only.
 	let addLinkSearchSeq = 0;
-	let confirmDelete = $state(false);
 	let deleting = $state(false);
 	let restoring = $state(false);
 	let rawMode = $state(false);
 	// Pane ⋯ overflow (PLAN-2290 Phase 4 PR B): graph / move / share /
-	// delete consolidate here per the mock; 'move' is a drill-down view
-	// inside the same panel (LaneActionsMenu precedent).
+	// delete consolidate here per the mock; 'move' and 'delete' are
+	// drill-down views inside the same panel (LaneActionsMenu precedent).
+	// 'delete' is the destructive-confirm step — it replaced the inline
+	// `.delete-confirm` band that used to live in `.meta-actions`, which
+	// couldn't survive a 360px pane (PLAN-2326 DR-6). It doubles as the
+	// armed-confirmation state, so it MUST be reset wherever an
+	// item-scoped control is dismissed (item switch, peek freeze, close).
 	let paneMenuOpen = $state(false);
 	let paneMenuTrigger = $state<HTMLElement | undefined>(undefined);
-	let paneMenuView = $state<'root' | 'move'>('root');
+	let paneMenuView = $state<'root' | 'move' | 'delete'>('root');
 	let moving = $state(false);
 	let itemLinks = $state<ItemLink[]>([]);
 	let workspaceMembers = $state<{ user_id: string; user_name: string; user_email: string; role: string }[]>([]);
@@ -1370,15 +1374,17 @@
 		// Reset item-scoped ephemeral UI so an armed / open control from the
 		// PREVIOUS item can't act on the newly-loaded one across the no-{#key}
 		// prop-update switch (PLAN-2105 / TASK-2112; coordinator P2).
-		// confirmDelete is the dangerous one — armed on A, switch to B, and a
-		// confirming click would delete B — but every open menu / dialog / drawer,
-		// the in-place title edit, and the add-relationship search box are
-		// item-scoped and must not survive the swap. The in-flight operation
-		// flags (deleting / moving / restoring) are cleared too: they gate the
-		// CURRENTLY-shown item's buttons, so B must start clean — the previous
-		// item's op continues under its own switch-fenced handler, whose finally
-		// settles the flag again harmlessly.
-		confirmDelete = false;
+		// The armed delete confirmation is the dangerous one — armed on A,
+		// switch to B, and a confirming click would delete B. It now lives in
+		// the ⋯ menu as `paneMenuView === 'delete'`, so the paneMenuOpen /
+		// paneMenuView reset below covers it (PLAN-2326 DR-6). Every open menu
+		// / dialog / drawer, the in-place title edit, and the add-relationship
+		// search box are likewise item-scoped and must not survive the swap.
+		// The in-flight operation flags (deleting / moving / restoring) are
+		// cleared too: they gate the CURRENTLY-shown item's buttons, so B must
+		// start clean — the previous item's op continues under its own
+		// switch-fenced handler, whose finally settles the flag again
+		// harmlessly.
 		deleting = false;
 		moving = false;
 		restoring = false;
@@ -3704,7 +3710,14 @@
 			if (switchedAway(targetItem, gen)) return;
 			toastStore.show('Failed to delete item', 'error');
 			deleting = false;
-			confirmDelete = false;
+			// Disarm and dismiss the ⋯ menu's delete drill-down: the toast
+			// carries the failure, and leaving a primed confirmation open over
+			// it invites a second blind click. The confirming row is unmounting
+			// here, so hand focus back to the trigger rather than letting it
+			// fall to <body> (PLAN-2326 DR-6).
+			paneMenuOpen = false;
+			paneMenuView = 'root';
+			paneMenuTrigger?.focus();
 		}
 	}
 
@@ -4453,17 +4466,6 @@
 					📎 {backlinksCount}
 				</button>
 			{/if}
-			{#if canEdit && confirmDelete}
-				<span class="delete-confirm">
-					Delete this item?
-					<button class="delete-confirm-btn yes" disabled={deleting} onclick={handleDelete}>
-						{deleting ? '...' : 'Yes'}
-					</button>
-					<button class="delete-confirm-btn no" onclick={() => { confirmDelete = false; }}>
-						No
-					</button>
-				</span>
-			{/if}
 			<!-- Pane ⋯ overflow (PLAN-2290 Phase 4 PR B): graph / move / share /
 			     delete per the mock. Triggers stay LIVE while peeking (BUG-2263 —
 			     these dispatch side-independent REST/dialog actions); opening the
@@ -4490,6 +4492,7 @@
 					sheetOnMobile
 					sheetTitle="Item actions"
 					ariaLabel="Item actions"
+					focusKey={paneMenuView}
 				>
 					{#if paneMenuView === 'root'}
 						{#if graphFocusRef}
@@ -4509,11 +4512,15 @@
 						{/if}
 						{#if canEdit}
 							<div class="menu-divider" role="separator"></div>
-							<MenuItem icon="🗑" danger onclick={() => { paneMenuOpen = false; confirmDelete = true; }}>
+							<!-- Drill down rather than close: the confirmation is a
+							     'delete' sub-view of THIS panel (PLAN-2326 DR-6), so
+							     the menu stays open and Menu's focusKey hands focus
+							     to the sub-view's first row. -->
+							<MenuItem icon="🗑" danger hint="›" onclick={() => (paneMenuView = 'delete')}>
 								Delete…
 							</MenuItem>
 						{/if}
-					{:else}
+					{:else if paneMenuView === 'move'}
 						<MenuItem icon="‹" onclick={() => (paneMenuView = 'root')}>Back</MenuItem>
 						<div class="menu-divider" role="separator"></div>
 						{#each moveTargets as target (target.slug)}
@@ -4525,6 +4532,29 @@
 								{target.name}
 							</MenuItem>
 						{/each}
+					{:else if paneMenuView === 'delete'}
+						<!--
+							Delete confirmation, as a drill-down view (PLAN-2326 DR-6).
+							Cancel comes FIRST so the focusKey handoff lands keyboard
+							focus on the non-destructive row — Enter on arrival must
+							never delete. The prompt is a presentational div, not a
+							MenuItem, so it stays out of Menu's `[role^="menuitem"]`
+							arrow-key walk — which also means it is never announced on
+							its own, hence the aria-describedby on the destructive row
+							(Codex).
+						-->
+						<div class="menu-confirm-note" id="delete-confirm-note-{uid}">Delete this item?</div>
+						<MenuItem icon="‹" onclick={() => (paneMenuView = 'root')}>Cancel</MenuItem>
+						<div class="menu-divider" role="separator"></div>
+						<MenuItem
+							icon="🗑"
+							danger
+							describedBy="delete-confirm-note-{uid}"
+							disabled={deleting || !canEdit}
+							onclick={handleDelete}
+						>
+							{deleting ? 'Deleting…' : 'Delete item'}
+						</MenuItem>
 					{/if}
 				</Menu>
 			</div>
@@ -6148,7 +6178,8 @@
 		color: var(--text-secondary);
 	}
 	/* Archived banner (TASK-1829) — accent-bordered callout matching the
-	   .link-row.tone-* idiom; Restore mirrors .delete-confirm-btn.yes. */
+	   .link-row.tone-* idiom; Restore uses the same accent-orange
+	   outline-fills-on-hover treatment. */
 	.archived-banner {
 		display: flex;
 		align-items: center;
@@ -6479,38 +6510,15 @@
 		border-top: 1px solid var(--border-subtle);
 		margin: 5px 4px;
 	}
-	.delete-confirm {
-		display: flex;
-		align-items: center;
-		gap: var(--space-2);
-		font-size: 0.85em;
-		color: var(--accent-orange);
+	/* Prompt line of the ⋯ menu's 'delete' drill-down (PLAN-2326 DR-6).
+	   Presentational only — the actionable rows beneath it are MenuItems,
+	   so Menu's `[role^="menuitem"]` arrow-key walk skips this. */
+	.menu-confirm-note {
+		padding: 6px 9px 4px;
+		font-size: 12.5px;
+		line-height: 1.35;
 		font-weight: 500;
-	}
-	.delete-confirm-btn {
-		padding: 2px var(--space-2);
-		border-radius: var(--radius);
-		font-size: 0.85em;
-		cursor: pointer;
-		border: 1px solid var(--border);
-		background: var(--bg-secondary);
-		color: var(--text-secondary);
-	}
-	.delete-confirm-btn.yes {
 		color: var(--accent-orange);
-		border-color: var(--accent-orange);
-	}
-	.delete-confirm-btn.yes:hover {
-		background: var(--accent-orange);
-		color: #fff;
-	}
-	.delete-confirm-btn.no:hover {
-		background: var(--bg-tertiary);
-		color: var(--text-primary);
-	}
-	.delete-confirm-btn:disabled {
-		opacity: 0.5;
-		cursor: not-allowed;
 	}
 	@media (max-width: 768px) {
 		.layout-balanced .fields-panel {

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -4537,13 +4537,28 @@
 							Delete confirmation, as a drill-down view (PLAN-2326 DR-6).
 							Cancel comes FIRST so the focusKey handoff lands keyboard
 							focus on the non-destructive row — Enter on arrival must
-							never delete. The prompt is a presentational div, not a
-							MenuItem, so it stays out of Menu's `[role^="menuitem"]`
-							arrow-key walk — which also means it is never announced on
-							its own, hence the aria-describedby on the destructive row
-							(Codex).
+							never delete.
+
+							The prompt carries `role="presentation"`: a `role="menu"`
+							owns menuitem / separator / group children, and this says
+							explicitly that the prompt is none of them rather than
+							leaving an undeclared div among them (the `.menu-divider`
+							below is the separator case).
+
+							It is NOT what keeps the prompt out of Menu's arrow-key
+							walk — that selector is `[role^="menuitem"]`, so a bare div
+							was already excluded. The consequence that matters is the
+							same either way: the prompt is never announced on its own,
+							hence the aria-describedby pointing back at it from the
+							destructive row. `role="presentation"` drops the element's
+							own semantics but NOT its text, so that description still
+							computes — verified against the rendered a11y tree, where
+							the row reports name "Delete item" / description "Delete
+							this item?" and Cancel reports no description.
 						-->
-						<div class="menu-confirm-note" id="delete-confirm-note-{uid}">Delete this item?</div>
+						<div class="menu-confirm-note" role="presentation" id="delete-confirm-note-{uid}">
+							Delete this item?
+						</div>
 						<MenuItem icon="‹" onclick={() => (paneMenuView = 'root')}>Cancel</MenuItem>
 						<div class="menu-divider" role="separator"></div>
 						<MenuItem

--- a/web/src/lib/components/items/masterFreeze/FreezeProbe.svelte
+++ b/web/src/lib/components/items/masterFreeze/FreezeProbe.svelte
@@ -24,12 +24,18 @@
 		canRestore = true,
 		isOwner = true,
 		quickActionsPresent = false,
+		moving = false,
+		deleting = false,
+		deleteViewArmed = false,
 	}: {
 		canEdit?: boolean;
 		peeking?: boolean;
 		canRestore?: boolean;
 		isOwner?: boolean;
 		quickActionsPresent?: boolean;
+		moving?: boolean;
+		deleting?: boolean;
+		deleteViewArmed?: boolean;
 	} = $props();
 
 	// The exact derived from ItemDetail.svelte — now scopes to content chrome only.
@@ -60,15 +66,58 @@
      `if (peeking) return` onclick guards are the backstop for a re-peek mid-flush. -->
 <button data-testid="mode-toggle">Rich / Markdown</button>
 
-<!-- REST mutation UI — gated on `canEdit` alone, present on both sides. -->
+<!-- REST mutation UI — gated on `canEdit` alone, present on both sides.
+
+     Delete and Move are NOT bar buttons any more. Both are rows inside the pane
+     ⋯ overflow (#1029 / TASK-2294 moved Move; TASK-2327 moved Delete's
+     confirmation there as a drill-down sub-view), so reaching either has TWO
+     parts and the probe mirrors both. Mirroring only the row is what let the
+     earlier `move-btn` drift sit here unnoticed: this file would stay green if
+     the TRIGGER ever grew a `!peeking` gate, even though that would take delete
+     AND move off the peeking side at once.
+
+       1. The ⋯ trigger — no `canEdit` and no `peeking` gate at all. It renders
+          on the peeking side like every other invisible-freeze control, and a
+          click activates that side first (host pointerdown-capture) before the
+          menu opens. Its only gate is `disabled={moving}`, an in-flight guard.
+          Note it is deliberately NOT in the test's REST_LIVE_SURFACES list:
+          that list asserts canEdit-gated controls, and the trigger stays present
+          for a true viewer (it still carries Dependency graph / Share).
+       2. The row inside it — `{#if canEdit}`, unchanged by the move into the
+          menu. -->
+<button data-testid="pane-more-btn" disabled={moving}>⋯</button>
 {#if canEdit}
-	<button data-testid="delete-btn">Delete</button>
+	<button data-testid="delete-btn">Delete…</button>
 {/if}
 {#if canEdit}
-	<button data-testid="move-btn">Move to…</button>
+	<button data-testid="move-btn" disabled={moving}>Move to collection…</button>
 {/if}
 {#if canEdit}
 	<button data-testid="add-relationship-btn">+ Add relationship</button>
+{/if}
+
+<!-- Delete's THIRD step: the ⋯ drill-down's confirm row (TASK-2327). Modelled
+     separately from `delete-btn` because its gate is genuinely different, and
+     getting this wrong is easy (Codex caught a first attempt that wrapped it in
+     `{#if canEdit}`):
+
+       - It is NOT canEdit-gated. It renders whenever the 'delete' sub-view is
+         the active view (`paneMenuView === 'delete'` — mirrored here by
+         `deleteViewArmed`) and REFUSES via `disabled={deleting || !canEdit}`.
+         So a mid-confirm permission loss leaves the row present but inert,
+         rather than yanking it out from under the cursor. A viewer never gets
+         here anyway — the route in (`delete-btn`) is canEdit-gated — but the
+         row's own guard is defence in depth and must be mirrored as written.
+
+       - It IS the one delete-related surface the freeze genuinely touches, and
+         in the opposite direction to everything else in this file: peek-begin
+         force-disarms it (`paneMenuOpen = false; paneMenuView = 'root'` in
+         ItemDetail's peek handler), so an ARMED confirmation can never survive
+         into a peek. That is a deliberate safety property, not the invisible
+         freeze — the affordance itself (trigger + Delete… row) stays live on
+         the peeking side like every other REST control above. -->
+{#if deleteViewArmed && !peeking}
+	<button data-testid="delete-confirm-btn" disabled={deleting || !canEdit}>Delete item</button>
 {/if}
 
 <!-- Editor bubble/link popover is CONTENT chrome — it only appears on an editor

--- a/web/src/lib/components/items/masterFreeze/FreezeProbe.svelte
+++ b/web/src/lib/components/items/masterFreeze/FreezeProbe.svelte
@@ -98,25 +98,29 @@
 
 <!-- Delete's THIRD step: the ⋯ drill-down's confirm row (TASK-2327). Modelled
      separately from `delete-btn` because its gate is genuinely different, and
-     getting this wrong is easy (Codex caught a first attempt that wrapped it in
-     `{#if canEdit}`):
+     getting this wrong is easy — Codex caught a first attempt that wrapped it
+     in `{#if canEdit}`. The real row is NOT canEdit-gated: it renders on
+     `paneMenuView === 'delete'` ALONE (mirrored here by `deleteViewArmed`) and
+     refuses via `disabled={deleting || !canEdit}`, so a mid-confirm permission
+     loss leaves it present but inert rather than yanking it out from under the
+     cursor. A viewer never reaches it — the route in (`delete-btn`) IS
+     canEdit-gated — but the row's own guard is defence in depth and has to be
+     mirrored as written.
 
-       - It is NOT canEdit-gated. It renders whenever the 'delete' sub-view is
-         the active view (`paneMenuView === 'delete'` — mirrored here by
-         `deleteViewArmed`) and REFUSES via `disabled={deleting || !canEdit}`.
-         So a mid-confirm permission loss leaves the row present but inert,
-         rather than yanking it out from under the cursor. A viewer never gets
-         here anyway — the route in (`delete-btn`) is canEdit-gated — but the
-         row's own guard is defence in depth and must be mirrored as written.
-
-       - It IS the one delete-related surface the freeze genuinely touches, and
-         in the opposite direction to everything else in this file: peek-begin
-         force-disarms it (`paneMenuOpen = false; paneMenuView = 'root'` in
-         ItemDetail's peek handler), so an ARMED confirmation can never survive
-         into a peek. That is a deliberate safety property, not the invisible
-         freeze — the affordance itself (trigger + Delete… row) stays live on
-         the peeking side like every other REST control above. -->
-{#if deleteViewArmed && !peeking}
+     DELIBERATELY NOT CLAIMED HERE: that an armed confirmation cannot survive
+     into a peek. That property is real, but it is an EMERGENT effect of
+     ItemDetail's peek-begin handler resetting `paneMenuOpen`/`paneMenuView`
+     (alongside editingTitle / shareDialogOpen / editCollectionOpen /
+     showAddLink, none of which this probe covers either) — it is NOT a gate on
+     this row. A second draft encoded it as `{#if deleteViewArmed && !peeking}`,
+     which is worse than no assertion at all: delete the reset from ItemDetail
+     and the probe stays green off its own hard-coded `!peeking`, mirroring
+     nothing. A static prop-driven mirror cannot express a transition, and e2e
+     can't discriminate it either — every click that causes a peek is also an
+     outside-click that closes the menu on its own. So the render condition is
+     mirrored exactly as written and the reset is left to ItemDetail's list.
+     Coverage for that reset is tracked separately (TASK-2337). -->
+{#if deleteViewArmed}
 	<button data-testid="delete-confirm-btn" disabled={deleting || !canEdit}>Delete item</button>
 {/if}
 

--- a/web/src/lib/components/items/masterFreeze/masterFreeze.svelte.test.ts
+++ b/web/src/lib/components/items/masterFreeze/masterFreeze.svelte.test.ts
@@ -36,7 +36,16 @@ function disabled(root: HTMLElement, testid: string): boolean {
 	return (root.querySelector(`[data-testid="${testid}"]`) as HTMLButtonElement | null)?.disabled ?? false;
 }
 
-// REST surfaces that stay LIVE on the peeking side (invisible freeze).
+// REST surfaces that stay LIVE on the peeking side (invisible freeze) AND are
+// gated on `canEdit` — the viewer test below asserts every entry is absent when
+// canEdit is false, so a control that survives for viewers does not belong here
+// (see `pane-more-btn`, asserted separately).
+//
+// Delete and Move now live inside the pane ⋯ overflow rather than the action
+// bar, so `delete-btn` / `move-btn` mirror the ROWS; the trigger that reaches
+// them is mirrored by `pane-more-btn`, asserted separately because it is not
+// canEdit-gated. Delete's confirm row (`delete-confirm-btn`) has a different
+// gate again and gets its own test below.
 const REST_LIVE_SURFACES = [
 	'delete-btn',
 	'move-btn',
@@ -54,6 +63,9 @@ describe('invisible master/pane freeze wiring (BUG-2263)', () => {
 		canRestore?: boolean;
 		isOwner?: boolean;
 		quickActionsPresent?: boolean;
+		moving?: boolean;
+		deleting?: boolean;
+		deleteViewArmed?: boolean;
 	}) {
 		root = target();
 		instance = mount(FreezeProbe, { target: root, props });
@@ -95,6 +107,12 @@ describe('invisible master/pane freeze wiring (BUG-2263)', () => {
 		for (const surface of REST_LIVE_SURFACES) {
 			expect(present(r, surface), `${surface} must stay live while peeking`).toBe(true);
 		}
+		// The ⋯ overflow trigger — the only route to delete/move since they moved
+		// into the menu — is present AND enabled on the peeking side. If this ever
+		// grew a `!peeking` gate, both surfaces would go dark on the passive side
+		// while the row assertions above stayed green.
+		expect(present(r, 'pane-more-btn')).toBe(true);
+		expect(disabled(r, 'pane-more-btn')).toBe(false);
 		// Title shows its editable affordance (not the viewer heading).
 		expect(present(r, 'title-readonly')).toBe(false);
 		// Archived restore, star (enabled), Share stay live.
@@ -131,6 +149,8 @@ describe('invisible master/pane freeze wiring (BUG-2263)', () => {
 		for (const surface of REST_LIVE_SURFACES) {
 			expect(present(r, surface), `${surface} must be live`).toBe(true);
 		}
+		expect(present(r, 'pane-more-btn')).toBe(true);
+		expect(disabled(r, 'pane-more-btn')).toBe(false);
 		expect(present(r, 'title-readonly')).toBe(false);
 		expect(present(r, 'archived-restore-btn')).toBe(true);
 		expect(disabled(r, 'star-btn')).toBe(false);
@@ -178,11 +198,93 @@ describe('invisible master/pane freeze wiring (BUG-2263)', () => {
 			}
 			// Star stays available to viewers.
 			expect(disabled(r, 'star-btn')).toBe(false);
+			// ...and so does the ⋯ trigger: it is not canEdit-gated, because it
+			// still carries the viewer-safe rows (Dependency graph, Share). Only
+			// the mutation ROWS inside it disappear — asserted by the loop above.
+			expect(present(r, 'pane-more-btn')).toBe(true);
 			unmount(instance!);
 			root!.remove();
 			instance = null;
 			root = null;
 		}
+	});
+
+	it('the ⋯ menu route to delete/move is gated by in-flight ops, not by peeking (TASK-2327)', () => {
+		// Delete and Move are reached through the ⋯ overflow, so the probe mirrors
+		// the trigger's own gate as well as the rows'. The in-flight guard is
+		// operation state, NOT freeze state — identical on the peeking and active
+		// sides.
+		for (const peeking of [false, true]) {
+			// A move in flight disables the trigger and the move row.
+			const r = render({ canEdit: true, peeking, moving: true });
+			expect(disabled(r, 'pane-more-btn'), `moving disables ⋯ (peeking=${peeking})`).toBe(true);
+			expect(disabled(r, 'move-btn')).toBe(true);
+			unmount(instance!);
+			root!.remove();
+			instance = null;
+			root = null;
+		}
+		// Idle: nothing is disabled, on either side.
+		for (const peeking of [false, true]) {
+			const r = render({ canEdit: true, peeking });
+			expect(disabled(r, 'pane-more-btn'), `⋯ enabled when idle (peeking=${peeking})`).toBe(false);
+			expect(disabled(r, 'move-btn')).toBe(false);
+			unmount(instance!);
+			root!.remove();
+			instance = null;
+			root = null;
+		}
+	});
+
+	it("the delete drill-down's confirm row refuses via `disabled`, and never survives into a peek (TASK-2327)", () => {
+		// Unlike every other control in this file, the confirm row is NOT
+		// canEdit-gated: it renders whenever the 'delete' sub-view is active and
+		// refuses via `disabled={deleting || !canEdit}`. Mirroring it as
+		// `{#if canEdit}` was a real mistake in the first draft of this probe
+		// (Codex) — it would have claimed the row vanishes on permission loss when
+		// the real component leaves it present but inert.
+
+		// Armed, active side, full permission: present and operable.
+		let r = render({ canEdit: true, peeking: false, deleteViewArmed: true });
+		expect(present(r, 'delete-confirm-btn')).toBe(true);
+		expect(disabled(r, 'delete-confirm-btn')).toBe(false);
+		unmount(instance!);
+		root!.remove();
+		instance = null;
+		root = null;
+
+		// Delete in flight: still present (so the pending state is visible), inert.
+		r = render({ canEdit: true, peeking: false, deleteViewArmed: true, deleting: true });
+		expect(present(r, 'delete-confirm-btn')).toBe(true);
+		expect(disabled(r, 'delete-confirm-btn')).toBe(true);
+		// The trigger stays enabled so the menu can still be dismissed.
+		expect(disabled(r, 'pane-more-btn')).toBe(false);
+		unmount(instance!);
+		root!.remove();
+		instance = null;
+		root = null;
+
+		// Permission lost mid-confirm: present but inert — NOT unmounted.
+		r = render({ canEdit: false, peeking: false, deleteViewArmed: true });
+		expect(present(r, 'delete-confirm-btn'), 'confirm row survives permission loss').toBe(true);
+		expect(disabled(r, 'delete-confirm-btn')).toBe(true);
+		// ...while the route IN is gone, so a viewer can never reach it fresh.
+		expect(present(r, 'delete-btn')).toBe(false);
+		unmount(instance!);
+		root!.remove();
+		instance = null;
+		root = null;
+
+		// The one place the freeze DOES touch delete, and in the opposite
+		// direction to the rest of this file: peek-begin force-disarms the view
+		// (ItemDetail's peek handler resets paneMenuOpen/paneMenuView), so an armed
+		// confirmation can never persist into a peek.
+		r = render({ canEdit: true, peeking: true, deleteViewArmed: true });
+		expect(present(r, 'delete-confirm-btn'), 'armed confirm must not survive a peek').toBe(false);
+		// The affordance itself is untouched — trigger and Delete… row stay live.
+		expect(present(r, 'pane-more-btn')).toBe(true);
+		expect(disabled(r, 'pane-more-btn')).toBe(false);
+		expect(present(r, 'delete-btn')).toBe(true);
 	});
 
 	it('archived restore rides `canRestore` alone (not peeking) — archived items force canEdit false', () => {

--- a/web/src/lib/components/items/masterFreeze/masterFreeze.svelte.test.ts
+++ b/web/src/lib/components/items/masterFreeze/masterFreeze.svelte.test.ts
@@ -236,7 +236,7 @@ describe('invisible master/pane freeze wiring (BUG-2263)', () => {
 		}
 	});
 
-	it("the delete drill-down's confirm row refuses via `disabled`, and never survives into a peek (TASK-2327)", () => {
+	it("the delete drill-down's confirm row refuses via `disabled` rather than unmounting (TASK-2327)", () => {
 		// Unlike every other control in this file, the confirm row is NOT
 		// canEdit-gated: it renders whenever the 'delete' sub-view is active and
 		// refuses via `disabled={deleting || !canEdit}`. Mirroring it as
@@ -275,13 +275,19 @@ describe('invisible master/pane freeze wiring (BUG-2263)', () => {
 		instance = null;
 		root = null;
 
-		// The one place the freeze DOES touch delete, and in the opposite
-		// direction to the rest of this file: peek-begin force-disarms the view
-		// (ItemDetail's peek handler resets paneMenuOpen/paneMenuView), so an armed
-		// confirmation can never persist into a peek.
+		// The row has NO peeking gate — `peeking` does not appear in its render
+		// condition, so the mirror must not invent one. What actually keeps an armed
+		// confirmation off the peeking side is ItemDetail's peek-begin handler
+		// resetting paneMenuOpen/paneMenuView, i.e. it drives `deleteViewArmed`
+		// false rather than gating the row. That combination (armed AND peeking) is
+		// therefore unreachable in the real component, and this assertion documents
+		// the render condition rather than the reachability — see FreezeProbe's
+		// comment for why encoding the reset as a gate here would be worse than
+		// asserting nothing, and TASK-2337 for the reset's own coverage.
 		r = render({ canEdit: true, peeking: true, deleteViewArmed: true });
-		expect(present(r, 'delete-confirm-btn'), 'armed confirm must not survive a peek').toBe(false);
-		// The affordance itself is untouched — trigger and Delete… row stay live.
+		expect(present(r, 'delete-confirm-btn'), 'render condition is paneMenuView alone').toBe(true);
+		// The affordance itself is untouched by peeking — trigger and Delete… row
+		// stay live, like every other REST control in this file.
 		expect(present(r, 'pane-more-btn')).toBe(true);
 		expect(disabled(r, 'pane-more-btn')).toBe(false);
 		expect(present(r, 'delete-btn')).toBe(true);


### PR DESCRIPTION
Task 1 of PLAN-2326 (DR-6, DR-8). Implements TASK-2327.

## What

The item pane's delete confirmation moves out of the `.meta-actions` action bar and into the `⋯` overflow menu as a third drill-down view alongside `move`.

The inline `.delete-confirm` band was a ~180px text-plus-two-buttons control. TASK-2328 (the strip refactor) right-aligns `.meta-actions`' contents into the tab strip, which must survive a 360px docked pane — that band would obscure tabs or actions there. As a menu sub-view it is width-independent by construction, and `sheetOnMobile` gives mobile a bottom sheet for free.

**This has to land before the strip refactor.** `.meta-actions` contains the live confirmation, and the `⋯` menu's Delete row armed `confirmDelete`. Deleting the band first would leave "Delete…" setting state with no confirmation UI rendered — a broken intermediate commit on main.

## Changes

**`ItemDetail.svelte`**
- `paneMenuView` widened from `'root' | 'move'` to `'root' | 'move' | 'delete'` (`:512`).
- The `{:else}` branch that rendered the move-target list for **every** non-`'root'` view is split into explicit `{:else if paneMenuView === 'move'}` / `{:else if paneMenuView === 'delete'}` branches (`:4523`, `:4535`). Without this, Delete opened the move list.
- The Delete row drills down instead of closing the menu (`:4519`).
- The inline `.delete-confirm` markup and its CSS are gone, along with the `confirmDelete` state.
- `handleDelete`'s failure path disarms the sub-view, dismisses the menu, and returns focus to the `⋯` trigger (`:3714`).
- Cancel is listed **first** so the focus handoff lands on the non-destructive row — Enter on arrival can never delete. The prompt is a presentational `div`, so Menu's `[role^="menuitem"]` arrow-key walk sees exactly the two actionable rows.

**Reset-on-switch is unchanged.** `confirmDelete` was reset on the no-`{#key}` item switch so an armed confirmation on A couldn't delete B. `paneMenuView` now carries that role, and the existing item-switch (`:1395`) and peek-freeze (`:837`) resets already covered it. The peek-freeze case is a small improvement: `confirmDelete` was *not* in that list, so freezing a peeking side left the old band armed.

**`Menu.svelte` — the DR-8 fix, folded in.** The focus `$effect` only ran when `open` changed, so swapping a drill-down view in place stranded keyboard focus on the unmounted `MenuItem`. This was a **pre-existing defect in the `move` view** that DR-6 would otherwise have extended to delete. `Menu` gains an optional `focusKey` prop that the effect reads purely for dependency tracking; the body still only performs DOM focus/placement, so it writes no `$state` it also reads (CONVE-1688). `ItemDetail` passes `focusKey={paneMenuView}`, fixing move and delete together.

**`BottomSheet.svelte` / `MenuItem.svelte` — from Codex review.**
- `BottomSheet` had the same gap on the mobile path: `Menu` skips its own focus handoff when `useSheet`, and the sheet's effect didn't re-run for an in-place content swap, so focus dropped to `<body>`. `focusKey` is forwarded and read the same way; the existing `el.contains(document.activeElement)` guard keeps the re-run a no-op whenever focus is already inside.
- `MenuItem` gains an optional `describedBy` → `aria-describedby`. The prompt is presentational and never announced on its own, so a screen-reader user arriving at the destructive row would otherwise hear only "Delete item".

## Verification

Gates, all run:

| Gate | Result |
| --- | --- |
| `cd web && npm run check` | 1039 files, **0 errors**, 6 warnings (all pre-existing) |
| `make check` | **exit 0** (golangci-lint, `go test ./...`, govulncheck, svelte-check, 488 vitest tests) |
| `make install` + manual | see below |
| `npx playwright test` (full e2e, local) | 76 passed, 1 failed — see below |
| CI (all six jobs) | **green** (E2E passed on re-run) |

### The one e2e failure is pre-existing on `main`, not this change

`pane-content-link-anchors.spec.ts:238` (the graph "Open item" anchor test) fails with `locator.click: Test timeout` and `<span class="toast-message"> … intercepts pointer events`. The failure screenshot shows the cause directly: the SSE `E2E Admin created: …` toasts from concurrently-seeding specs stack bottom-right, exactly over the graph drawer's `.detail-card`.

Established by control experiment rather than assumption: **I built a `pad` binary from unmodified `main` (c676e080) and ran the same suite against it on the same machine — identical failure, same test, same interception.** It also passed on a CI re-run. Filed as **BUG-2334** with repro and fix directions; deliberately not folded in here, since fixing it means touching an unrelated spec (or the toast fixture) in a different feature area.

Manual verification drove the real app at `localhost:7777` after `make install` — 40 scripted browser assertions across full-page, docked pane, mobile bottom sheet and dark theme:

- Opening `⋯` → Delete… switches the view **in place**; the menu stays open, root rows are gone, the prompt renders.
- Cancel returns to root; Escape closes and returns focus to the `⋯` trigger; reopening lands on root, not a stale sub-view.
- **DR-8:** entering the sub-view moves focus **into** it (on `Cancel`) — verified for the delete view *and* for the pre-existing `move` view, which was the defect. Back/Cancel returns focus into the root view. On mobile the swap keeps focus inside `.bs-sheet`.
- Arrow-key walk inside the sub-view visits exactly Cancel and Delete item, wrapping — the prompt is correctly skipped.
- Keyboard-only path: arrow to Delete…, Enter, and focus lands on Cancel — Enter-on-arrival cannot delete.
- `aria-describedby` on the destructive row resolves to the prompt element.
- Confirming actually deletes: the page left the item and the API shows `deleted_at` set.

Screenshots (light full-page, dark, mobile sheet) reviewed; the prompt reads legibly in both themes.

## Follow-up commit: FreezeProbe mirror fix

`FreezeProbe.svelte` (BUG-2263) is a hand-written mirror of ItemDetail's freeze/permission gate expressions. Its `delete-btn` / `move-btn` still rendered **bar buttons**, which no longer exist — #1029 moved Move into the ⋯ overflow and this PR moved Delete's confirmation there. The probe stayed green while mirroring markup that was gone; `move-btn` had been stale that way since #1029.

The row gate (`{#if canEdit}`) was in fact still correct. What was missing was the **reachability** half: both surfaces now go through one trigger, so the probe mirrors `pane-more-btn` — no canEdit and no peeking gate, `disabled={moving}`. Without it, gating the trigger on `!peeking` would take delete *and* move off the passive side with every existing assertion still passing.

Delete's confirm row gets its own model and test, because its gate differs in two ways:

- **Not canEdit-gated.** It renders whenever the `'delete'` sub-view is active and refuses via `disabled={deleting || !canEdit}`, so a mid-confirm permission loss leaves it present but inert. A first draft wrapped it in `{#if canEdit}`; Codex caught that, since it would have claimed the row vanishes when the real one does not.
- **It is the one delete-related surface the freeze touches**, and in the opposite direction to everything else in that file: peek-begin force-disarms it (the peek handler resets `paneMenuOpen` / `paneMenuView`), so an armed confirmation can never survive into a peek. The affordance itself stays live on the peeking side as before.

Mutation-tested — all four bite, each failing exactly one test: peek-no-longer-disarms; confirm-drops-the-permission-guard; canEdit-gate-the-confirm (the Codex finding); trigger-drops-its-in-flight-guard.

### Review round 2 — two corrections

**The probe's peek gate was an invented mirror; dropped.** The first pass gated the confirm row on `deleteViewArmed && !peeking`. That reintroduced the very drift it was fixing: the real row renders on `paneMenuView === 'delete'` **alone**, and peek safety is an *emergent* effect of ItemDetail's peek-begin handler resetting `paneMenuOpen`/`paneMenuView` — not a gate on the row. Encoding it as one is worse than asserting nothing: delete the reset from ItemDetail and the probe stays green off its own hard-coded `!peeking`. The mutation testing didn't catch this, because mutating the *probe* only proves the test is sensitive to the probe.

The gate is gone and the render condition is mirrored exactly. The peek-disarm property is now explicitly **not claimed**, with the reasoning in the file: a static prop-driven mirror can't express a transition, and e2e can't discriminate it either — every click that causes a peek is *also* an outside-click that closes the menu on its own, so a passing assertion would prove nothing. Filed **TASK-2337** for real coverage; that reset guards five other surfaces (`editingTitle`, `shareDialogOpen`, `editCollectionOpen`, `showAddLink`) and nothing asserts any of them today.

Mutation testing re-run on what remains — all four still bite, one test each: confirm-drops-the-permission-guard; canEdit-gate-the-confirm; trigger-drops-its-in-flight-guard; move-row-drops-its-in-flight-guard.

**The prompt div is now `role="presentation"`.** Verified against the rendered a11y tree rather than assumed: the destructive row reports name `"Delete item"` / description `"Delete this item?"`, Cancel reports no description, and the menu's direct children are `[presentation, menuitem, separator, menuitem]`. A follow-up Codex note corrected two overstatements in my comment — `role="presentation"` is not what excludes the prompt from the `[role^="menuitem"]` walk (a bare div already was), and a menu owns `separator`/`group` children too, not only menuitems.

## Menu clipping

Nothing in this diff puts `overflow`, `contain`, `clip-path`, `transform`, `filter` or `will-change` on any ancestor of `.menu-anchor` — the only CSS added is `.menu-confirm-note` (padding / font-size / line-height / font-weight / color), and it lives *inside* the menu panel. The eight `getByRole('menuitem')` locators in `pane-content-link-anchors.spec.ts` and `pane-full-page-capstone.spec.ts` all pass, locally and in CI.

## Not in scope

The strip refactor itself (TASK-2328) and the header slimming / tier rule (TASK-2329).


https://claude.ai/code/session_01E2fRi12n8rARczvdEa2LYT
