### PR TITLE
fix(web): un-combine the item tab strip below 560px + header slim groundwork (TASK-2329)

### DIFF
--- a/web/e2e/pane-full-page-capstone.spec.ts
+++ b/web/e2e/pane-full-page-capstone.spec.ts
@@ -306,11 +306,18 @@ test.describe('full-page pane host CAPSTONE (PLAN-2154 Phase 2 / TASK-2175)', ()
 		const masterEditor = col.locator(EDITOR_SELECTOR);
 		await expect(masterEditor).toBeVisible({ timeout: SYNC_TIMEOUT });
 		await expect(masterEditor).toHaveAttribute('contenteditable', 'true');
-		// Action bar (above the tabs): Star enabled; Quick-actions visible;
+		// Tab strip (PLAN-2326): Star VISIBLE; Quick-actions visible;
 		// Share/Move/Delete live in the pane ⋯ overflow (PLAN-2290 Phase 4 PR B) —
 		// open it (master is active; the menu is an activating control) and
 		// verify the rows, then dismiss.
-		await expect(col.locator('button.star-btn')).toBeEnabled();
+		//
+		// `toBeVisible`, not `toBeEnabled` (PLAN-2326 DR-11): the star now folds
+		// via CSS in the strip's compact tier with the node RETAINED, so
+		// `toBeEnabled` — which only requires *attached* — would pass on a folded
+		// star and assert nothing. No pane is open yet, so the master strip is
+		// 892px at this suite's 1200px viewport: the FULL tier, where the star is
+		// genuinely visible and this is the stronger claim it reads as.
+		await expect(col.locator('button.star-btn')).toBeVisible();
 		await expect(col.locator('button.trigger-btn[title="Quick actions"]')).toBeVisible();
 		await col.locator('button.pane-more-btn').click();
 		await expect(col.getByRole('menuitem', { name: 'Share…' })).toBeVisible();
@@ -357,11 +364,23 @@ test.describe('full-page pane host CAPSTONE (PLAN-2154 Phase 2 / TASK-2175)', ()
 		await expect(col.locator('.field-row', { hasText: 'Note' }).locator('.readonly-display')).toHaveCount(0);
 		// Comment composer: still present (not peeking-gated — ItemTimeline frozen={false}).
 		await expect(col.locator('.compose')).toHaveCount(1);
-		// Star: still enabled (never gated on peeking anymore).
+		// Star: still live while peeking (never gated on peeking anymore).
+		//
+		// Deliberately NOT `toBeVisible` here, unlike the pre-peek assertion
+		// above. With the pane docked, this master column's strip measures 526px
+		// at the suite's 1200px viewport, so PLAN-2326's compact tier CSS-folds
+		// the star. Visibility at this width is a TIER property, not a freeze
+		// property — asserting it would be testing the container query, and would
+		// go red the day the default pane width changes. What BUG-2263 owns is
+		// that peeking neither removes the node nor disables it; that is what is
+		// asserted. The reachability half of the guarantee is carried by the ⋯
+		// trigger below, which never folds at any tier.
+		await expect(col.locator('button.star-btn')).toHaveCount(1);
 		await expect(col.locator('button.star-btn')).toBeEnabled();
 		// Share/Move/Delete live in the ⋯ overflow now: the BUG-2263 guarantee is
 		// that the trigger stays LIVE on the peeking side (opening it would
-		// activate this side, so assert enabled, not open).
+		// activate this side, so assert reachable-but-unopened, not open).
+		await expect(col.locator('button.pane-more-btn')).toBeVisible();
 		await expect(col.locator('button.pane-more-btn')).toBeEnabled();
 		// Add-relationship + per-link remove: still present (side-independent single-item REST — no freeze).
 		await expect(col.locator('button.add-relationship-btn')).toHaveCount(1);

--- a/web/e2e/pane-tab-strip-tiers.spec.ts
+++ b/web/e2e/pane-tab-strip-tiers.spec.ts
@@ -1,0 +1,266 @@
+import { test, expect } from './fixtures';
+import { browserLogin, seedDoc, SYNCED_BADGE_SELECTOR } from './lib/collab-helpers';
+import type { APIRequestContext, Locator, Page } from '@playwright/test';
+import type { SuiteFixture } from './fixtures';
+
+/**
+ * Tab-strip TIER rule (PLAN-2326 DR-7 / DR-9 / DR-10 / TASK-2329).
+ *
+ * The strip carries `container-type: inline-size` and a single
+ * `@container item-tab-strip (max-width: 699px)` rule: below 700px of STRIP
+ * width the badge icons drop to bare counts, the star folds away (node
+ * retained), the collab badge keeps its dot but drops its label, and an idle
+ * save-status leaves the flow.
+ *
+ * Two things are worth a real browser here, and neither is unit-testable:
+ *
+ *   1. The tier keys off the CONTAINER, not the viewport. This is the whole
+ *      reason DR-2 chose `@container`: the docked pane's width is dragged by
+ *      the user and persisted (`PaneHost.svelte` — `clamp(360px, 38%, 640px)`
+ *      by CSS, `PANE_WIDTH_MIN 360` / `PANE_WIDTH_MAX 720` by JS), so it is
+ *      decoupled from the viewport entirely. A `@media (min-width: 700px)`
+ *      rule would sail through every assertion in test 1 — the viewport never
+ *      changes size in it. Squeezing the FULL-PAGE master by opening a pane
+ *      beside it drives the flip in place, at a fixed viewport, with no
+ *      reload and no remount.
+ *
+ *   2. DR-9's width allocation actually holds at the 360px pane floor. Four
+ *      tabs, two count badges, quick actions and the ⋯ overflow have to share
+ *      a ~312px strip; `.strip-actions` is `flex: 0 0 auto` and `.pane-tabs`
+ *      scrolls, so the contract is "one row, every tab still reachable" — not
+ *      "everything fits". That is a layout property of the real box model.
+ *
+ * Measured strip widths this rule was calibrated against (TASK-2329):
+ *   full page 892-912px (capped by `--content-max-width`, identical at 1440
+ *   and 2560) · full page with a pane docked 526-678px · docked pane 312-672px
+ *   · mobile overlay 342px. Only the pane-free full page reaches the full tier.
+ *
+ * Desktop-split concern, so the desktop project alone covers it.
+ */
+
+const DESKTOP = { width: 1200, height: 900 };
+const WIDE = { width: 1440, height: 1000 };
+const SYNC_TIMEOUT = 20_000;
+
+function authHeaders(fixture: SuiteFixture) {
+	return { Authorization: `Bearer ${fixture.apiToken}`, 'Content-Type': 'application/json' };
+}
+
+interface SeededItem {
+	id: string;
+	slug: string;
+	title: string;
+}
+
+async function seedDocWith(
+	fixture: SuiteFixture,
+	request: APIRequestContext,
+	titlePrefix: string,
+	{ content = '', parent = '' }: { content?: string; parent?: string } = {},
+): Promise<SeededItem> {
+	const title = `${titlePrefix} ${Date.now()}${Math.floor(Math.random() * 1000)}`;
+	const resp = await request.post(
+		`/api/v1/workspaces/${fixture.workspaceSlug}/collections/docs/items`,
+		{
+			headers: authHeaders(fixture),
+			data: { title, fields: parent ? JSON.stringify({ parent }) : '{}', content },
+		},
+	);
+	if (!resp.ok()) throw new Error(`doc create failed (${resp.status()}): ${await resp.text()}`);
+	return { ...((await resp.json()) as { id: string; slug: string }), title };
+}
+
+async function seedRelatedLink(
+	fixture: SuiteFixture,
+	request: APIRequestContext,
+	sourceSlug: string,
+	targetId: string,
+): Promise<void> {
+	const resp = await request.post(
+		`/api/v1/workspaces/${fixture.workspaceSlug}/items/${sourceSlug}/links`,
+		{ headers: authHeaders(fixture), data: { target_id: targetId, link_type: 'related' } },
+	);
+	if (!resp.ok()) throw new Error(`link create failed (${resp.status()}): ${await resp.text()}`);
+}
+
+/** The full-page master column — the `.item-page` the host renders directly. */
+function masterCol(page: Page): Locator {
+	return page.locator('.item-page-host > .item-page');
+}
+
+/** Rendered width of a strip, straight off the box model. */
+async function stripWidth(scope: Locator): Promise<number> {
+	return Math.round(
+		await scope.locator('.tab-strip').evaluate((n) => n.getBoundingClientRect().width),
+	);
+}
+
+test.describe('tab-strip tiers (PLAN-2326 / TASK-2329)', () => {
+	test.beforeEach(({}, testInfo) => {
+		test.skip(
+			testInfo.project.name !== 'desktop-chromium',
+			'the pane is a desktop-split concern; one project is enough',
+		);
+	});
+
+	test('the tier keys off the STRIP CONTAINER, not the viewport: squeezing the full-page master with a docked pane flips it compact in place — and closing the pane flips it back (DR-2 / DR-10)', async ({
+		page,
+		fixture,
+		request,
+	}) => {
+		await page.setViewportSize(DESKTOP);
+		await browserLogin(page);
+
+		// Master with a CHILD (renders the 🌳 badge) plus a RELATED item to open
+		// in the pane. The child badge is what proves `.badge-icon` folds while
+		// `.badge-count` survives — a text-node split TASK-2328 made possible.
+		const master = await seedDocWith(fixture, request, 'Tier master');
+		await seedDocWith(fixture, request, 'Tier child', { parent: master.id });
+		const related = await seedDocWith(fixture, request, 'Tier related');
+		await seedRelatedLink(fixture, request, master.slug, related.id);
+
+		await page.goto(`/${fixture.adminUsername}/${fixture.workspaceSlug}/docs/${master.slug}`);
+
+		const col = masterCol(page);
+		const star = col.locator('button.star-btn');
+		const badgeIcon = col.locator('.strip-actions .badge-icon');
+		const badgeCount = col.locator('.strip-actions .badge-count');
+
+		// ── FULL tier. 892px of strip at this viewport, comfortably over 700. ──
+		await expect(col.locator('.tab-strip')).toBeVisible();
+		await expect(badgeCount.first()).toBeVisible(); // children badge has arrived
+		expect(await stripWidth(col)).toBeGreaterThanOrEqual(700);
+		await expect(star).toBeVisible();
+		await expect(badgeIcon.first()).toBeVisible();
+		await expect(col.locator('.collab-state-label')).toBeVisible();
+
+		// ── Squeeze it. Open the pane from the Relationships tab — same route,
+		//    same viewport, no reload: ONLY the master column's width changes. ──
+		await col.getByRole('tab', { name: 'Relationships' }).click();
+		await col
+			.locator('.relationship-group', { hasText: 'Related' })
+			.locator('a.link-target', { hasText: 'Tier related' })
+			.click();
+		await expect(page.locator('.item-pane')).toBeVisible();
+
+		// The viewport is byte-identical to what it was in the full tier above.
+		// A media query cannot distinguish these two states; a container query can.
+		expect(page.viewportSize()).toEqual(DESKTOP);
+
+		// ── COMPACT tier, driven purely by the container shrinking. ──
+		await expect(star).toBeHidden();
+		expect(await stripWidth(col)).toBeLessThan(700);
+		await expect(badgeIcon.first()).toBeHidden();
+		// DR-11: the star FOLDS, it is not removed. The BUG-2263 freeze
+		// assertions in pane-full-page-capstone.spec.ts depend on the node.
+		await expect(star).toHaveCount(1);
+		// The count survives the icon — the point of DR-9's span split.
+		await expect(badgeCount.first()).toBeVisible();
+		// The collab badge keeps its class AND its box (SYNCED_BADGE_SELECTOR is
+		// asserted visible by four other suites); only the label word folds —
+		// and VISUALLY only. The dot is `aria-hidden`, so the label is the
+		// badge's only textual state; it folds sr-only (clipped to a 1px box,
+		// still in the accessibility tree) rather than `display: none`, which
+		// would leave a colour-only status indicator.
+		await expect(col.locator(SYNCED_BADGE_SELECTOR)).toBeVisible({ timeout: SYNC_TIMEOUT });
+		const foldedLabel = col.locator('.collab-state-label');
+		expect(Math.round((await foldedLabel.boundingBox())?.width ?? -1)).toBeLessThanOrEqual(1);
+		await expect(foldedLabel).toHaveText('Synced');
+		// ⋯ never folds at any tier — it is the compact tier's escape hatch, and
+		// it carries the Star the strip just folded away.
+		await expect(col.locator('button.pane-more-btn')).toBeVisible();
+		await col.locator('button.pane-more-btn').click();
+		await expect(col.getByRole('menuitem', { name: /^(Star|Unstar)$/ })).toBeVisible();
+		await page.keyboard.press('Escape');
+
+		// ── Close the pane → the container widens again and the tier reverts.
+		//    A one-way rule would pass every assertion above. ──
+		await page.locator('.item-pane').getByRole('button', { name: 'Close pane' }).click();
+		await expect(page.locator('.item-pane')).toHaveCount(0);
+		expect(await stripWidth(col)).toBeGreaterThanOrEqual(700);
+		await expect(star).toBeVisible();
+		await expect(badgeIcon.first()).toBeVisible();
+	});
+
+	test('worst case at the 360px pane floor — children + backlinks + quick actions + owner rights: the strip stays ONE row and every tab is still reachable through the scroll (DR-9)', async ({
+		page,
+		fixture,
+		request,
+	}) => {
+		await page.setViewportSize(WIDE);
+		await browserLogin(page);
+
+		// Every action the strip can hold at once: a child badge, a backlink
+		// badge, the owner quick-actions trigger (the fixture user owns the
+		// workspace, so it renders even with no seeded prompt actions), and ⋯.
+		const master = await seedDocWith(fixture, request, 'Tier worst');
+		await seedDocWith(fixture, request, 'Tier worst child', { parent: master.id });
+		await seedDocWith(fixture, request, 'Tier worst mention', {
+			content: `mentions [[${master.title}]] here`,
+		});
+
+		await page.goto(
+			`/${fixture.adminUsername}/${fixture.workspaceSlug}/docs?item=${master.slug}`,
+		);
+		const pane = page.locator('.item-pane');
+		await expect(pane.locator('.tab-strip')).toBeVisible();
+
+		// Drag the divider hard right — `clampPaneWidth` pins it at the 360px
+		// floor, the narrowest the pane can ever be on a roomy container.
+		const divider = page.locator('.pane-divider');
+		const box = await divider.boundingBox();
+		if (!box) throw new Error('pane divider has no box');
+		await page.mouse.move(box.x + box.width / 2, box.y + 200);
+		await page.mouse.down();
+		await page.mouse.move(box.x + box.width / 2 + 600, box.y + 200, { steps: 20 });
+		await page.mouse.up();
+		await expect
+			.poll(async () => Math.round(await pane.evaluate((n) => n.getBoundingClientRect().width)))
+			.toBe(360);
+
+		// Both badges present (the strip is at its most crowded).
+		await expect(pane.locator('.strip-actions .badge-count')).toHaveCount(2);
+		await expect(pane.locator('button.trigger-btn[title="Quick actions"]')).toBeVisible();
+		await expect(pane.locator('button.pane-more-btn')).toBeVisible();
+		// Compact tier throughout.
+		await expect(pane.locator('button.star-btn')).toBeHidden();
+		await expect(pane.locator('button.star-btn')).toHaveCount(1);
+		await expect(pane.locator('.strip-actions .badge-icon').first()).toBeHidden();
+
+		// ── ONE ROW. `.strip-actions` holds its size and `.pane-tabs` scrolls
+		//    rather than wrapping, so all four tabs share a single offsetTop. ──
+		const tabTops = await pane.locator('.pane-tabs').evaluate((n) => {
+			const tabs = Array.from(n.querySelectorAll<HTMLElement>('[role="tab"]'));
+			return Array.from(new Set(tabs.map((t) => Math.round(t.getBoundingClientRect().top))));
+		});
+		expect(tabTops).toHaveLength(1);
+
+		// ── EVERY TAB REACHABLE. The tablist is a scrollport narrower than its
+		//    content; each tab must scroll into it and take the selection. ──
+		const tabs = pane.getByRole('tab');
+		await expect(tabs).toHaveCount(4);
+		for (const name of ['Details', 'Relationships', 'Activity', 'Versions']) {
+			const tab = pane.getByRole('tab', { name });
+			await tab.scrollIntoViewIfNeeded();
+			await expect(tab).toBeInViewport();
+			await tab.click();
+			await expect(tab).toHaveAttribute('aria-selected', 'true');
+		}
+
+		// The ⋯ panel is anchored inside `.strip-actions`, a sibling of the
+		// scrolling tablist. Nothing on `.tab-strip` clips it — proving the
+		// "no overflow/contain on the container" constraint still holds at the
+		// narrowest width, where a clip would be most visible.
+		await pane.locator('button.pane-more-btn').click();
+		await expect(pane.getByRole('menuitem', { name: 'Move to collection…' })).toBeVisible();
+
+		// ── The folded star's escape hatch actually WORKS here. This is the
+		//    width the mobile overlay always runs at, so "Star lives in ⋯" has
+		//    to be a working action, not just a rendered row. ──
+		await pane.getByRole('menuitem', { name: 'Star' }).click();
+		await expect(pane.getByRole('menuitem', { name: 'Star' })).toHaveCount(0); // menu closed
+		await pane.locator('button.pane-more-btn').click();
+		await expect(pane.getByRole('menuitem', { name: 'Unstar' })).toBeVisible();
+		await page.keyboard.press('Escape');
+	});
+});

--- a/web/e2e/pane-tab-strip-tiers.spec.ts
+++ b/web/e2e/pane-tab-strip-tiers.spec.ts
@@ -8,9 +8,8 @@ import type { SuiteFixture } from './fixtures';
  *
  * The strip carries `container-type: inline-size` and a single
  * `@container item-tab-strip (max-width: 699px)` rule: below 700px of STRIP
- * width the badge icons drop to bare counts, the star folds away (node
- * retained), the collab badge keeps its dot but drops its label, and an idle
- * save-status leaves the flow.
+ * width the badge icons drop to bare counts and the star folds away, node
+ * retained.
  *
  * Two things are worth a real browser here, and neither is unit-testable:
  *
@@ -132,7 +131,6 @@ test.describe('tab-strip tiers (PLAN-2326 / TASK-2329)', () => {
 		expect(await stripWidth(col)).toBeGreaterThanOrEqual(700);
 		await expect(star).toBeVisible();
 		await expect(badgeIcon.first()).toBeVisible();
-		await expect(col.locator('.collab-state-label')).toBeVisible();
 
 		// ── Squeeze it. Open the pane from the Relationships tab — same route,
 		//    same viewport, no reload: ONLY the master column's width changes. ──
@@ -156,16 +154,11 @@ test.describe('tab-strip tiers (PLAN-2326 / TASK-2329)', () => {
 		await expect(star).toHaveCount(1);
 		// The count survives the icon — the point of DR-9's span split.
 		await expect(badgeCount.first()).toBeVisible();
-		// The collab badge keeps its class AND its box (SYNCED_BADGE_SELECTOR is
-		// asserted visible by four other suites); only the label word folds —
-		// and VISUALLY only. The dot is `aria-hidden`, so the label is the
-		// badge's only textual state; it folds sr-only (clipped to a 1px box,
-		// still in the accessibility tree) rather than `display: none`, which
-		// would leave a colour-only status indicator.
+		// The collab badge is untouched by the tier rule — it lives in
+		// `.meta-info`, outside the query container entirely. Asserted here
+		// only because SYNCED_BADGE_SELECTOR is load-bearing for four other
+		// suites and this is the narrowest surface any of them exercise.
 		await expect(col.locator(SYNCED_BADGE_SELECTOR)).toBeVisible({ timeout: SYNC_TIMEOUT });
-		const foldedLabel = col.locator('.collab-state-label');
-		expect(Math.round((await foldedLabel.boundingBox())?.width ?? -1)).toBeLessThanOrEqual(1);
-		await expect(foldedLabel).toHaveText('Synced');
 		// ⋯ never folds at any tier — it is the compact tier's escape hatch, and
 		// it carries the Star the strip just folded away.
 		await expect(col.locator('button.pane-more-btn')).toBeVisible();

--- a/web/e2e/pane-tab-strip-tiers.spec.ts
+++ b/web/e2e/pane-tab-strip-tiers.spec.ts
@@ -106,6 +106,13 @@ async function stripWidth(scope: Locator): Promise<number> {
 	);
 }
 
+/** How much slack the fit has, at minimum, before a tab starts to clip.
+ *  20px is the floor: CI's fonts render these four labels 17.5% wider than a
+ *  dev box's (measured — see the header comment), so a fit tuned to 0 on one
+ *  machine overflows by 25px on the other. Anything below this is a design
+ *  with no margin, not a passing test. */
+const MIN_SLACK_PX = 20;
+
 interface StripLayout {
 	/** true when `.strip-actions` sits on its own row above the tablist. */
 	split: boolean;
@@ -113,11 +120,21 @@ interface StripLayout {
 	tabsOnOneRow: boolean;
 	/** the tablist is not overflowing: all four labels are actually shown. */
 	tabsFit: boolean;
+	/** Room to spare, in px, measured as strip width minus tablist CONTENT
+	 *  width. NOT `clientWidth - scrollWidth`: `.pane-tabs` has no
+	 *  `flex-grow`, so while the content fits its clientWidth IS its content
+	 *  width and that difference is pinned at 0 — it looks like zero slack at
+	 *  every width and cannot distinguish "just fits" from "loads of room".
+	 *  Negative means overflowing. */
+	slackPx: number;
 	/** active tab's border-box bottom minus the strip's — 0 means it covers
 	 *  the 1px divider exactly, which is the designed overlap. */
 	underlineOffset: number;
 	/** the action group must never become a child of the tablist (DR-4). */
 	tablistContainsActions: boolean;
+	/** Diagnostic detail, printed in assertion messages so a failure on a
+	 *  machine we cannot attach a debugger to still hands over the numbers. */
+	diag: string;
 }
 
 async function stripLayout(scope: Locator): Promise<StripLayout> {
@@ -129,15 +146,26 @@ async function stripLayout(scope: Locator): Promise<StripLayout> {
 		const sr = strip.getBoundingClientRect();
 		const tr = tabs.getBoundingClientRect();
 		const ar = acts.getBoundingClientRect();
+		const cs = getComputedStyle(tabEls[0]);
 		return {
 			split: ar.bottom <= tr.top + 1,
 			tabsOnOneRow:
 				new Set(tabEls.map((t) => Math.round(t.getBoundingClientRect().top))).size === 1,
 			tabsFit: tabs.scrollWidth <= tabs.clientWidth,
+			slackPx: Math.round(sr.width - tabs.scrollWidth),
 			underlineOffset: active
 				? Math.round(active.getBoundingClientRect().bottom - sr.bottom)
 				: NaN,
 			tablistContainsActions: tabs.contains(acts),
+			diag:
+				`strip=${sr.width.toFixed(1)} content=${tabs.scrollWidth} port=${tabs.clientWidth}` +
+				` font="${cs.fontFamily}" @${cs.fontSize}/${cs.fontWeight}` +
+				` tabs=${JSON.stringify(
+					tabEls.map((t) => [
+						(t.textContent || '').trim(),
+						+t.getBoundingClientRect().width.toFixed(1),
+					]),
+				)}`,
 		};
 	});
 }
@@ -271,60 +299,31 @@ test.describe('tab-strip tiers (PLAN-2326 / TASK-2329)', () => {
 		await expect(pane.locator('button.star-btn')).toBeVisible();
 		await expect(pane.locator('.strip-actions .badge-icon').first()).toBeVisible();
 
-		// ── TEMPORARY DIAGNOSTIC (TASK-2329) ──────────────────────────────────
-		// This test passes locally and failed twice on CI. The fit derivation
-		// rests on `tabs.scrollWidth === 321`, which is four English labels in
-		// whatever `--font-ui` resolves to — and that stack is
-		// `-apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif`,
-		// every entry of which MISSES on Linux, so `system-ui` is resolved by
-		// fontconfig and differs between a dev box and ubuntu-latest. Dump the
-		// real numbers from whatever environment is running, rather than
-		// inferring them. Remove once the slack fix lands.
-		const diag = await pane.locator('.tab-strip').evaluate((strip) => {
-			const tabs = strip.querySelector('.pane-tabs') as HTMLElement;
-			const tabEls = Array.from(tabs.querySelectorAll<HTMLElement>('[role="tab"]'));
-			const cs = getComputedStyle(tabEls[0]);
-			// Width of each label's text alone, font-independent of padding.
-			const canvas = document.createElement('canvas');
-			const ctx = canvas.getContext('2d')!;
-			ctx.font = `${cs.fontWeight} ${cs.fontSize} ${cs.fontFamily}`;
-			const scrollContainer = strip.closest('.item-pane, .item-page') as HTMLElement | null;
-			return {
-				stripW: +strip.getBoundingClientRect().width.toFixed(2),
-				tabsScrollW: tabs.scrollWidth,
-				tabsClientW: tabs.clientWidth,
-				slackPx: tabs.clientWidth - tabs.scrollWidth,
-				tabs: tabEls.map((t) => ({
-					text: (t.textContent || '').trim(),
-					w: +t.getBoundingClientRect().width.toFixed(2),
-					textOnly: +ctx.measureText((t.textContent || '').trim()).width.toFixed(2),
-					padL: getComputedStyle(t).paddingLeft,
-					padR: getComputedStyle(t).paddingRight,
-				})),
-				font: {
-					family: cs.fontFamily,
-					size: cs.fontSize,
-					weight: cs.fontWeight,
-					letterSpacing: cs.letterSpacing,
-				},
-				scrollbarPx: scrollContainer
-					? scrollContainer.offsetWidth - scrollContainer.clientWidth
-					: null,
-				dpr: devicePixelRatio,
-				ua: navigator.userAgent,
-			};
-		});
-		// eslint-disable-next-line no-console
-		console.log('TAB_FIT_DIAG ' + JSON.stringify(diag));
-
 		const layout = await stripLayout(pane);
 		expect(layout.split).toBe(true);
 		expect(layout.tabsOnOneRow).toBe(true);
-		// The whole point: FIT, not "reachable by scrolling".
+
+		// The whole point: the four tabs FIT, not "are reachable by scrolling".
+		//
+		// And they must fit with REAL MARGIN, which is why the slack is asserted
+		// rather than just `tabsFit`. The first version of this test asserted only
+		// `tabsFit`, passed locally with exactly 0px to spare, and failed on CI by
+		// 25px: `--font-ui` is `-apple-system, BlinkMacSystemFont, 'Segoe UI',
+		// system-ui, sans-serif`, every entry of which misses on Linux, so
+		// `system-ui` resolves through fontconfig to different font FILES on a dev
+		// box and on ubuntu-latest — the same declaration, 17.5% wider glyphs.
+		// A fit tuned until the numbers meet is not a fit; it is a coin flip on
+		// the next environment, font, zoom level or translation.
+		//
+		// Both messages print the measured widths and the resolved font, so a
+		// failure on a machine nobody can attach to still hands over the numbers
+		// instead of `true !== false`.
+		expect(layout.tabsFit, `tabs must fit without scrolling — ${layout.diag}`).toBe(true);
 		expect(
-			layout.tabsFit,
-			`tabs must fit without scrolling — measured scrollWidth ${diag.tabsScrollW} vs clientWidth ${diag.tabsClientW} (slack ${diag.slackPx}px) in font ${diag.font.family} @ ${diag.font.size}; per-tab ${JSON.stringify(diag.tabs.map((t) => [t.text, t.w]))}`,
-		).toBe(true);
+			layout.slackPx,
+			`fit must keep >=${MIN_SLACK_PX}px of slack so a wider font cannot clip a tab — ${layout.diag}`,
+		).toBeGreaterThanOrEqual(MIN_SLACK_PX);
+
 		expect(layout.tablistContainsActions).toBe(false);
 
 		// Every tab genuinely on screen and selectable.
@@ -339,13 +338,32 @@ test.describe('tab-strip tiers (PLAN-2326 / TASK-2329)', () => {
 
 		// `order: -1` is visual only — DOM order is untouched, so the tablist's
 		// arrow-key roving tabindex still walks exactly the four tabs.
+		//
+		// Identified by ACCESSIBLE NAME, not `textContent`. At this width the
+		// Relationships tab carries both labels in the DOM — the full one for
+		// the accessible name, the short `Links` one visible — so `textContent`
+		// reads "RelationshipsLinks". The accessible name is the identity that
+		// matters and the thing ~5 other specs address these tabs by.
 		await pane.locator('.pane-tab').first().focus();
 		const walk: string[] = [];
 		for (let i = 0; i < 4; i++) {
-			walk.push(await page.evaluate(() => (document.activeElement?.textContent || '').trim()));
+			walk.push(
+				await page.evaluate(() => {
+					const a = document.activeElement;
+					return (a?.getAttribute('aria-label') || a?.textContent || '').trim();
+				}),
+			);
 			await page.keyboard.press('ArrowRight');
 		}
 		expect(walk).toEqual(['Details', 'Relationships', 'Activity', 'Versions']);
+
+		// The short label is VISIBLE text only — the accessible name never
+		// changes, at any width. This is the guarantee the ~5 specs using
+		// `getByRole('tab', { name: 'Relationships' })` depend on.
+		await expect(pane.getByRole('tab', { name: 'Relationships' })).toHaveCount(1);
+		await expect(pane.getByRole('tab', { name: 'Links' })).toHaveCount(0);
+		await expect(pane.locator('.pane-tabs .tab-label-short')).toBeVisible();
+		await expect(pane.locator('.pane-tabs .tab-label-full')).toBeHidden();
 
 		// The ⋯ panel is anchored inside `.strip-actions`. Nothing on
 		// `.tab-strip` clips it — the "no overflow/contain on the container"
@@ -400,6 +418,63 @@ test.describe('tab-strip tiers (PLAN-2326 / TASK-2329)', () => {
 		await pane.locator('button.pane-more-btn').click();
 		await expect(pane.getByRole('menuitem', { name: 'Unstar' })).toBeVisible();
 		await page.keyboard.press('Escape');
+	});
+
+	test('overflow degrades VISIBLY: with the tabs fitting there is no mask at all, and if they ever do overflow a fade appears only on the edge that has more content', async ({
+		page,
+		fixture,
+		request,
+	}) => {
+		// The fit now carries 20px+ of slack, so overflow needs a font far wider
+		// than any we have measured. That makes this a fallback — but a
+		// load-bearing one: `.pane-tabs` scrolls with `scrollbar-width: none`,
+		// and a silently truncated tablist is precisely the defect this whole
+		// task exists to fix (two of four tabs invisible at 430px, unhinted).
+		// So overflow must be made visible, and the affordance must NOT appear
+		// when everything fits.
+		await page.setViewportSize({ width: 1440, height: 1000 });
+		await page.addInitScript(() => localStorage.setItem('pad-pane-width', '360'));
+		await browserLogin(page);
+		const master = await seedDocWith(fixture, request, 'Tier overflow');
+		await page.goto(`/${fixture.adminUsername}/${fixture.workspaceSlug}/docs?item=${master.slug}`);
+		const pane = page.locator('.item-pane');
+		const tabs = pane.locator('.pane-tabs');
+		await expect(pane.locator('.tab-strip')).toBeVisible();
+
+		// ── FITTING: no mask, both edges crisp. ──
+		expect((await stripLayout(pane)).tabsFit).toBe(true);
+		await expect(tabs).not.toHaveClass(/masked/);
+
+		// ── Force an overflow the only way that is environment-independent:
+		//    inflate the tab font well past anything real. ──
+		await page.addStyleTag({ content: '.pane-tab{font-size:1.75em !important;}' });
+		await expect(tabs).toHaveClass(/masked/);
+
+		const fadeAt = () =>
+			tabs.evaluate((el) => ({
+				left: getComputedStyle(el).getPropertyValue('--fade-l').trim(),
+				right: getComputedStyle(el).getPropertyValue('--fade-r').trim(),
+				scrollLeft: Math.round(el.scrollLeft),
+				max: el.scrollWidth - el.clientWidth,
+			}));
+
+		// At the start there is content to the RIGHT only.
+		await expect.poll(async () => (await fadeAt()).right).not.toBe('0px');
+		expect((await fadeAt()).left).toBe('0px');
+
+		// Scrolled to the end: content to the LEFT only.
+		await tabs.evaluate((el) => (el.scrollLeft = el.scrollWidth));
+		await expect.poll(async () => (await fadeAt()).left).not.toBe('0px');
+		expect((await fadeAt()).right).toBe('0px');
+
+		// Mid-scroll: content BOTH ways, so both edges fade.
+		await tabs.evaluate((el) => (el.scrollLeft = Math.round((el.scrollWidth - el.clientWidth) / 2)));
+		await expect.poll(async () => (await fadeAt()).left).not.toBe('0px');
+		expect((await fadeAt()).right).not.toBe('0px');
+
+		// The mask is a PAINT effect: the active tab still overlaps the strip's
+		// 1px divider exactly as it does with no mask.
+		expect((await stripLayout(pane)).underlineOffset).toBe(0);
 	});
 
 	test('the tier boundaries have no sub-pixel gap: a fractional strip width either side of 560 and 640 still lands in the right tier', async ({

--- a/web/e2e/pane-tab-strip-tiers.spec.ts
+++ b/web/e2e/pane-tab-strip-tiers.spec.ts
@@ -271,12 +271,60 @@ test.describe('tab-strip tiers (PLAN-2326 / TASK-2329)', () => {
 		await expect(pane.locator('button.star-btn')).toBeVisible();
 		await expect(pane.locator('.strip-actions .badge-icon').first()).toBeVisible();
 
+		// ── TEMPORARY DIAGNOSTIC (TASK-2329) ──────────────────────────────────
+		// This test passes locally and failed twice on CI. The fit derivation
+		// rests on `tabs.scrollWidth === 321`, which is four English labels in
+		// whatever `--font-ui` resolves to — and that stack is
+		// `-apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif`,
+		// every entry of which MISSES on Linux, so `system-ui` is resolved by
+		// fontconfig and differs between a dev box and ubuntu-latest. Dump the
+		// real numbers from whatever environment is running, rather than
+		// inferring them. Remove once the slack fix lands.
+		const diag = await pane.locator('.tab-strip').evaluate((strip) => {
+			const tabs = strip.querySelector('.pane-tabs') as HTMLElement;
+			const tabEls = Array.from(tabs.querySelectorAll<HTMLElement>('[role="tab"]'));
+			const cs = getComputedStyle(tabEls[0]);
+			// Width of each label's text alone, font-independent of padding.
+			const canvas = document.createElement('canvas');
+			const ctx = canvas.getContext('2d')!;
+			ctx.font = `${cs.fontWeight} ${cs.fontSize} ${cs.fontFamily}`;
+			const scrollContainer = strip.closest('.item-pane, .item-page') as HTMLElement | null;
+			return {
+				stripW: +strip.getBoundingClientRect().width.toFixed(2),
+				tabsScrollW: tabs.scrollWidth,
+				tabsClientW: tabs.clientWidth,
+				slackPx: tabs.clientWidth - tabs.scrollWidth,
+				tabs: tabEls.map((t) => ({
+					text: (t.textContent || '').trim(),
+					w: +t.getBoundingClientRect().width.toFixed(2),
+					textOnly: +ctx.measureText((t.textContent || '').trim()).width.toFixed(2),
+					padL: getComputedStyle(t).paddingLeft,
+					padR: getComputedStyle(t).paddingRight,
+				})),
+				font: {
+					family: cs.fontFamily,
+					size: cs.fontSize,
+					weight: cs.fontWeight,
+					letterSpacing: cs.letterSpacing,
+				},
+				scrollbarPx: scrollContainer
+					? scrollContainer.offsetWidth - scrollContainer.clientWidth
+					: null,
+				dpr: devicePixelRatio,
+				ua: navigator.userAgent,
+			};
+		});
+		// eslint-disable-next-line no-console
+		console.log('TAB_FIT_DIAG ' + JSON.stringify(diag));
+
 		const layout = await stripLayout(pane);
 		expect(layout.split).toBe(true);
 		expect(layout.tabsOnOneRow).toBe(true);
-		// The whole point: FIT, not "reachable by scrolling". At 312px of strip
-		// the ≤330px padding rule trims the tabs from 321px to 297px.
-		expect(layout.tabsFit).toBe(true);
+		// The whole point: FIT, not "reachable by scrolling".
+		expect(
+			layout.tabsFit,
+			`tabs must fit without scrolling — measured scrollWidth ${diag.tabsScrollW} vs clientWidth ${diag.tabsClientW} (slack ${diag.slackPx}px) in font ${diag.font.family} @ ${diag.font.size}; per-tab ${JSON.stringify(diag.tabs.map((t) => [t.text, t.w]))}`,
+		).toBe(true);
 		expect(layout.tablistContainsActions).toBe(false);
 
 		// Every tab genuinely on screen and selectable.

--- a/web/e2e/pane-tab-strip-tiers.spec.ts
+++ b/web/e2e/pane-tab-strip-tiers.spec.ts
@@ -1,38 +1,44 @@
 import { test, expect } from './fixtures';
-import { browserLogin, seedDoc, SYNCED_BADGE_SELECTOR } from './lib/collab-helpers';
+import { browserLogin, SYNCED_BADGE_SELECTOR } from './lib/collab-helpers';
 import type { APIRequestContext, Locator, Page } from '@playwright/test';
 import type { SuiteFixture } from './fixtures';
 
 /**
- * Tab-strip TIER rule (PLAN-2326 DR-7 / DR-9 / DR-10 / TASK-2329).
+ * Tab-strip TIER rules (PLAN-2326 / TASK-2329).
  *
- * The strip carries `container-type: inline-size` and a single
- * `@container item-tab-strip (max-width: 699px)` rule: below 700px of STRIP
- * width the badge icons drop to bare counts and the star folds away, node
- * retained.
+ * `.tab-strip` is `container-type: inline-size` and carries three rules keyed
+ * on its OWN width, not the viewport's:
  *
- * Two things are worth a real browser here, and neither is unit-testable:
+ *   < 560px   SPLIT — `.strip-actions` takes a full row of its own, `order:
+ *             -1` so it sits ABOVE the tablist, and the tabs get the full
+ *             width. Everything the shared row folded comes back.
+ *   560-699   FOLD  — still one row, but tight: badge icons drop to bare
+ *             counts and the star folds (node retained, DR-11).
+ *   <= 330px  the tabs' horizontal padding trims 11px -> 8px, the last 24px
+ *             needed to fit four tabs in a 312px strip.
  *
- *   1. The tier keys off the CONTAINER, not the viewport. This is the whole
- *      reason DR-2 chose `@container`: the docked pane's width is dragged by
- *      the user and persisted (`PaneHost.svelte` — `clamp(360px, 38%, 640px)`
- *      by CSS, `PANE_WIDTH_MIN 360` / `PANE_WIDTH_MAX 720` by JS), so it is
- *      decoupled from the viewport entirely. A `@media (min-width: 700px)`
- *      rule would sail through every assertion in test 1 — the viewport never
- *      changes size in it. Squeezing the FULL-PAGE master by opening a pane
- *      beside it drives the flip in place, at a fixed viewport, with no
- *      reload and no remount.
+ * Why the split exists at all: combining tabs and actions on one row is not
+ * survivable at phone widths and no amount of folding fixes it. The four tab
+ * labels are a fixed 321px, and even a hypothetical action group of nothing
+ * but `⋯` (38px) needs 359px against the 342px a 390px phone has. Measured on
+ * the WIDEST common phone before this change, 430px: 382px of strip, 179px of
+ * tab scrollport, two of four tabs clipped — under `scrollbar-width: none`,
+ * so with no hint they existed.
  *
- *   2. DR-9's width allocation actually holds at the 360px pane floor. Four
- *      tabs, two count badges, quick actions and the ⋯ overflow have to share
- *      a ~312px strip; `.strip-actions` is `flex: 0 0 auto` and `.pane-tabs`
- *      scrolls, so the contract is "one row, every tab still reachable" — not
- *      "everything fits". That is a layout property of the real box model.
+ * Three things here need a real browser:
  *
- * Measured strip widths this rule was calibrated against (TASK-2329):
- *   full page 892-912px (capped by `--content-max-width`, identical at 1440
- *   and 2560) · full page with a pane docked 526-678px · docked pane 312-672px
- *   · mobile overlay 342px. Only the pane-free full page reaches the full tier.
+ *   1. The rules key off the CONTAINER. The docked pane's width is dragged by
+ *      the user and persisted (`PaneHost.svelte`: `PANE_WIDTH_MIN 360` /
+ *      `PANE_WIDTH_MAX 720`), so it is decoupled from the viewport entirely,
+ *      and the full page's own strip is capped at 912px by
+ *      `--content-max-width` at ANY monitor size. Test 1 drives the split at
+ *      a FIXED viewport by squeezing the full-page master with a docked pane;
+ *      a `@media` rule would sail through every assertion in it.
+ *   2. Whether four tabs actually fit once they own a row. That is a box-model
+ *      fact, and the ≤330px padding trim is what makes it true at 360.
+ *   3. That the split did not break the active tab's 1px overlap of the
+ *      strip's bottom divider — the reason the actions go ABOVE rather than
+ *      below.
  *
  * Desktop-split concern, so the desktop project alone covers it.
  */
@@ -87,11 +93,47 @@ function masterCol(page: Page): Locator {
 	return page.locator('.item-page-host > .item-page');
 }
 
-/** Rendered width of a strip, straight off the box model. */
+/** Rendered width of the strip inside `scope`, straight off the box model. */
 async function stripWidth(scope: Locator): Promise<number> {
 	return Math.round(
 		await scope.locator('.tab-strip').evaluate((n) => n.getBoundingClientRect().width),
 	);
+}
+
+interface StripLayout {
+	/** true when `.strip-actions` sits on its own row above the tablist. */
+	split: boolean;
+	/** every tab shares one offsetTop — the tablist itself never wraps. */
+	tabsOnOneRow: boolean;
+	/** the tablist is not overflowing: all four labels are actually shown. */
+	tabsFit: boolean;
+	/** active tab's border-box bottom minus the strip's — 0 means it covers
+	 *  the 1px divider exactly, which is the designed overlap. */
+	underlineOffset: number;
+	/** the action group must never become a child of the tablist (DR-4). */
+	tablistContainsActions: boolean;
+}
+
+async function stripLayout(scope: Locator): Promise<StripLayout> {
+	return scope.locator('.tab-strip').evaluate((strip) => {
+		const tabs = strip.querySelector('.pane-tabs') as HTMLElement;
+		const acts = strip.querySelector('.strip-actions') as HTMLElement;
+		const tabEls = Array.from(tabs.querySelectorAll<HTMLElement>('[role="tab"]'));
+		const active = tabs.querySelector('.pane-tab.on');
+		const sr = strip.getBoundingClientRect();
+		const tr = tabs.getBoundingClientRect();
+		const ar = acts.getBoundingClientRect();
+		return {
+			split: ar.bottom <= tr.top + 1,
+			tabsOnOneRow:
+				new Set(tabEls.map((t) => Math.round(t.getBoundingClientRect().top))).size === 1,
+			tabsFit: tabs.scrollWidth <= tabs.clientWidth,
+			underlineOffset: active
+				? Math.round(active.getBoundingClientRect().bottom - sr.bottom)
+				: NaN,
+			tablistContainsActions: tabs.contains(acts),
+		};
+	});
 }
 
 test.describe('tab-strip tiers (PLAN-2326 / TASK-2329)', () => {
@@ -102,7 +144,7 @@ test.describe('tab-strip tiers (PLAN-2326 / TASK-2329)', () => {
 		);
 	});
 
-	test('the tier keys off the STRIP CONTAINER, not the viewport: squeezing the full-page master with a docked pane flips it compact in place — and closing the pane flips it back (DR-2 / DR-10)', async ({
+	test('the SPLIT keys off the strip CONTAINER, not the viewport: docking a pane beside the full-page master splits its strip in place at a fixed viewport, and closing the pane rejoins it', async ({
 		page,
 		fixture,
 		request,
@@ -111,8 +153,7 @@ test.describe('tab-strip tiers (PLAN-2326 / TASK-2329)', () => {
 		await browserLogin(page);
 
 		// Master with a CHILD (renders the 🌳 badge) plus a RELATED item to open
-		// in the pane. The child badge is what proves `.badge-icon` folds while
-		// `.badge-count` survives — a text-node split TASK-2328 made possible.
+		// in the pane.
 		const master = await seedDocWith(fixture, request, 'Tier master');
 		await seedDocWith(fixture, request, 'Tier child', { parent: master.id });
 		const related = await seedDocWith(fixture, request, 'Tier related');
@@ -125,10 +166,15 @@ test.describe('tab-strip tiers (PLAN-2326 / TASK-2329)', () => {
 		const badgeIcon = col.locator('.strip-actions .badge-icon');
 		const badgeCount = col.locator('.strip-actions .badge-count');
 
-		// ── FULL tier. 892px of strip at this viewport, comfortably over 700. ──
+		// ── SHARED ROW. 892px of strip at this viewport, way over 699. ──
 		await expect(col.locator('.tab-strip')).toBeVisible();
 		await expect(badgeCount.first()).toBeVisible(); // children badge has arrived
 		expect(await stripWidth(col)).toBeGreaterThanOrEqual(700);
+		let layout = await stripLayout(col);
+		expect(layout.split).toBe(false);
+		expect(layout.tabsFit).toBe(true);
+		expect(layout.tablistContainsActions).toBe(false);
+		const sharedRowUnderline = layout.underlineOffset;
 		await expect(star).toBeVisible();
 		await expect(badgeIcon.first()).toBeVisible();
 
@@ -141,41 +187,41 @@ test.describe('tab-strip tiers (PLAN-2326 / TASK-2329)', () => {
 			.click();
 		await expect(page.locator('.item-pane')).toBeVisible();
 
-		// The viewport is byte-identical to what it was in the full tier above.
+		// The viewport is byte-identical to what it was on the shared row above.
 		// A media query cannot distinguish these two states; a container query can.
 		expect(page.viewportSize()).toEqual(DESKTOP);
 
-		// ── COMPACT tier, driven purely by the container shrinking. ──
-		await expect(star).toBeHidden();
-		expect(await stripWidth(col)).toBeLessThan(700);
-		await expect(badgeIcon.first()).toBeHidden();
-		// DR-11: the star FOLDS, it is not removed. The BUG-2263 freeze
-		// assertions in pane-full-page-capstone.spec.ts depend on the node.
-		await expect(star).toHaveCount(1);
-		// The count survives the icon — the point of DR-9's span split.
-		await expect(badgeCount.first()).toBeVisible();
-		// The collab badge is untouched by the tier rule — it lives in
-		// `.meta-info`, outside the query container entirely. Asserted here
-		// only because SYNCED_BADGE_SELECTOR is load-bearing for four other
-		// suites and this is the narrowest surface any of them exercise.
-		await expect(col.locator(SYNCED_BADGE_SELECTOR)).toBeVisible({ timeout: SYNC_TIMEOUT });
-		// ⋯ never folds at any tier — it is the compact tier's escape hatch, and
-		// it carries the Star the strip just folded away.
-		await expect(col.locator('button.pane-more-btn')).toBeVisible();
-		await col.locator('button.pane-more-btn').click();
-		await expect(col.getByRole('menuitem', { name: /^(Star|Unstar)$/ })).toBeVisible();
-		await page.keyboard.press('Escape');
-
-		// ── Close the pane → the container widens again and the tier reverts.
-		//    A one-way rule would pass every assertion above. ──
-		await page.locator('.item-pane').getByRole('button', { name: 'Close pane' }).click();
-		await expect(page.locator('.item-pane')).toHaveCount(0);
-		expect(await stripWidth(col)).toBeGreaterThanOrEqual(700);
+		// ── SPLIT, driven purely by the container shrinking to ~526px. ──
+		await expect
+			.poll(async () => (await stripLayout(col)).split, { timeout: 5000 })
+			.toBe(true);
+		expect(await stripWidth(col)).toBeLessThan(560);
+		layout = await stripLayout(col);
+		expect(layout.tabsOnOneRow).toBe(true);
+		expect(layout.tabsFit).toBe(true);
+		expect(layout.tablistContainsActions).toBe(false);
+		// Actions ABOVE, not below: the strip owns the bottom divider and the
+		// active tab overlaps it by 1px. Keeping the tablist last preserves that,
+		// so the underline offset is unchanged from the shared row.
+		expect(layout.underlineOffset).toBe(sharedRowUnderline);
+		// Below 560 the actions have room again, so what the FOLD band hides is
+		// visible here. This is the behaviour a single <700 fold got wrong.
 		await expect(star).toBeVisible();
 		await expect(badgeIcon.first()).toBeVisible();
+		// The collab badge lives in `.meta-info`, outside the query container —
+		// asserted only because SYNCED_BADGE_SELECTOR is load-bearing for four
+		// other suites and this is the narrowest surface any of them exercises.
+		await expect(col.locator(SYNCED_BADGE_SELECTOR)).toBeVisible({ timeout: SYNC_TIMEOUT });
+
+		// ── Close the pane → the container widens and the rows rejoin. A
+		//    one-way rule would pass every assertion above. ──
+		await page.locator('.item-pane').getByRole('button', { name: 'Close pane' }).click();
+		await expect(page.locator('.item-pane')).toHaveCount(0);
+		await expect.poll(async () => (await stripLayout(col)).split, { timeout: 5000 }).toBe(false);
+		expect(await stripWidth(col)).toBeGreaterThanOrEqual(700);
 	});
 
-	test('worst case at the 360px pane floor — children + backlinks + quick actions + owner rights: the strip stays ONE row and every tab is still reachable through the scroll (DR-9)', async ({
+	test('worst case at the 360px pane floor — children + backlinks + quick actions + owner rights: actions take their own row and all four tabs FIT without scrolling', async ({
 		page,
 		fixture,
 		request,
@@ -192,9 +238,7 @@ test.describe('tab-strip tiers (PLAN-2326 / TASK-2329)', () => {
 			content: `mentions [[${master.title}]] here`,
 		});
 
-		await page.goto(
-			`/${fixture.adminUsername}/${fixture.workspaceSlug}/docs?item=${master.slug}`,
-		);
+		await page.goto(`/${fixture.adminUsername}/${fixture.workspaceSlug}/docs?item=${master.slug}`);
 		const pane = page.locator('.item-pane');
 		await expect(pane.locator('.tab-strip')).toBeVisible();
 
@@ -211,47 +255,91 @@ test.describe('tab-strip tiers (PLAN-2326 / TASK-2329)', () => {
 			.poll(async () => Math.round(await pane.evaluate((n) => n.getBoundingClientRect().width)))
 			.toBe(360);
 
-		// Both badges present (the strip is at its most crowded).
+		// The strip is at its most crowded: both badges + quick actions + ⋯.
 		await expect(pane.locator('.strip-actions .badge-count')).toHaveCount(2);
 		await expect(pane.locator('button.trigger-btn[title="Quick actions"]')).toBeVisible();
 		await expect(pane.locator('button.pane-more-btn')).toBeVisible();
-		// Compact tier throughout.
-		await expect(pane.locator('button.star-btn')).toBeHidden();
-		await expect(pane.locator('button.star-btn')).toHaveCount(1);
-		await expect(pane.locator('.strip-actions .badge-icon').first()).toBeHidden();
+		// And the star is VISIBLE here, not folded — below 560 the actions own a
+		// row, so there is room for it. (A single <700 fold hid it on every
+		// phone; that was the bug this keying fixes.)
+		await expect(pane.locator('button.star-btn')).toBeVisible();
+		await expect(pane.locator('.strip-actions .badge-icon').first()).toBeVisible();
 
-		// ── ONE ROW. `.strip-actions` holds its size and `.pane-tabs` scrolls
-		//    rather than wrapping, so all four tabs share a single offsetTop. ──
-		const tabTops = await pane.locator('.pane-tabs').evaluate((n) => {
-			const tabs = Array.from(n.querySelectorAll<HTMLElement>('[role="tab"]'));
-			return Array.from(new Set(tabs.map((t) => Math.round(t.getBoundingClientRect().top))));
-		});
-		expect(tabTops).toHaveLength(1);
+		const layout = await stripLayout(pane);
+		expect(layout.split).toBe(true);
+		expect(layout.tabsOnOneRow).toBe(true);
+		// The whole point: FIT, not "reachable by scrolling". At 312px of strip
+		// the ≤330px padding rule trims the tabs from 321px to 297px.
+		expect(layout.tabsFit).toBe(true);
+		expect(layout.tablistContainsActions).toBe(false);
 
-		// ── EVERY TAB REACHABLE. The tablist is a scrollport narrower than its
-		//    content; each tab must scroll into it and take the selection. ──
+		// Every tab genuinely on screen and selectable.
 		const tabs = pane.getByRole('tab');
 		await expect(tabs).toHaveCount(4);
 		for (const name of ['Details', 'Relationships', 'Activity', 'Versions']) {
 			const tab = pane.getByRole('tab', { name });
-			await tab.scrollIntoViewIfNeeded();
 			await expect(tab).toBeInViewport();
 			await tab.click();
 			await expect(tab).toHaveAttribute('aria-selected', 'true');
 		}
 
-		// The ⋯ panel is anchored inside `.strip-actions`, a sibling of the
-		// scrolling tablist. Nothing on `.tab-strip` clips it — proving the
-		// "no overflow/contain on the container" constraint still holds at the
-		// narrowest width, where a clip would be most visible.
+		// `order: -1` is visual only — DOM order is untouched, so the tablist's
+		// arrow-key roving tabindex still walks exactly the four tabs.
+		await pane.locator('.pane-tab').first().focus();
+		const walk: string[] = [];
+		for (let i = 0; i < 4; i++) {
+			walk.push(await page.evaluate(() => (document.activeElement?.textContent || '').trim()));
+			await page.keyboard.press('ArrowRight');
+		}
+		expect(walk).toEqual(['Details', 'Relationships', 'Activity', 'Versions']);
+
+		// The ⋯ panel is anchored inside `.strip-actions`. Nothing on
+		// `.tab-strip` clips it — the "no overflow/contain on the container"
+		// constraint still holds at the narrowest width, where a clip would be
+		// most visible.
 		await pane.locator('button.pane-more-btn').click();
 		await expect(pane.getByRole('menuitem', { name: 'Move to collection…' })).toBeVisible();
+		await page.keyboard.press('Escape');
+	});
 
-		// ── The folded star's escape hatch actually WORKS here. This is the
-		//    width the mobile overlay always runs at, so "Star lives in ⋯" has
-		//    to be a working action, not just a rendered row. ──
+	test('the FOLD band (560-699px) still folds: a pane dragged to its 720px maximum keeps one row and drops the badge icons + star, with Star still reachable in the ⋯ menu', async ({
+		page,
+		fixture,
+		request,
+	}) => {
+		// A 720px pane (PANE_WIDTH_MAX) is a 672px strip — inside the fold band
+		// and the ONLY way to reach it from a docked pane.
+		await page.addInitScript(() => localStorage.setItem('pad-pane-width', '720'));
+		await page.setViewportSize({ width: 2000, height: 1000 });
+		await browserLogin(page);
+
+		const master = await seedDocWith(fixture, request, 'Tier fold');
+		await seedDocWith(fixture, request, 'Tier fold child', { parent: master.id });
+
+		await page.goto(`/${fixture.adminUsername}/${fixture.workspaceSlug}/docs?item=${master.slug}`);
+		const pane = page.locator('.item-pane');
+		await expect(pane.locator('.tab-strip')).toBeVisible();
+		await expect(pane.locator('.strip-actions .badge-count').first()).toBeVisible();
+
+		const width = await stripWidth(pane);
+		expect(width).toBeGreaterThanOrEqual(560);
+		expect(width).toBeLessThan(700);
+
+		const layout = await stripLayout(pane);
+		expect(layout.split).toBe(false);
+		expect(layout.tabsFit).toBe(true);
+
+		// Folded: icons gone, counts kept, star hidden but RETAINED (DR-11 — the
+		// BUG-2263 freeze assertions in pane-full-page-capstone.spec.ts need the
+		// node to exist).
+		await expect(pane.locator('.strip-actions .badge-icon').first()).toBeHidden();
+		await expect(pane.locator('.strip-actions .badge-count').first()).toBeVisible();
+		await expect(pane.locator('button.star-btn')).toBeHidden();
+		await expect(pane.locator('button.star-btn')).toHaveCount(1);
+
+		// The folded star still has a home, and it works.
+		await pane.locator('button.pane-more-btn').click();
 		await pane.getByRole('menuitem', { name: 'Star' }).click();
-		await expect(pane.getByRole('menuitem', { name: 'Star' })).toHaveCount(0); // menu closed
 		await pane.locator('button.pane-more-btn').click();
 		await expect(pane.getByRole('menuitem', { name: 'Unstar' })).toBeVisible();
 		await page.keyboard.press('Escape');

--- a/web/e2e/pane-tab-strip-tiers.spec.ts
+++ b/web/e2e/pane-tab-strip-tiers.spec.ts
@@ -12,10 +12,16 @@ import type { SuiteFixture } from './fixtures';
  *   < 560px   SPLIT — `.strip-actions` takes a full row of its own, `order:
  *             -1` so it sits ABOVE the tablist, and the tabs get the full
  *             width. Everything the shared row folded comes back.
- *   560-699   FOLD  — still one row, but tight: badge icons drop to bare
- *             counts and the star folds (node retained, DR-11).
+ *   560-639   FOLD  — still one row, but tight: badge icons drop to bare
+ *             counts and the star folds (node retained, DR-11) with its
+ *             affordance moving to a `.strip-star-row` in the ⋯ menu, gated
+ *             by the same query so exactly one of the two ever shows.
  *   <= 330px  the tabs' horizontal padding trims 11px -> 8px, the last 24px
  *             needed to fit four tabs in a 312px strip.
+ *
+ * The boundaries are measured, not chosen: the action group is 191px folded
+ * (row needs 524px), 274px full (607px), and 301px with absurd badge counts
+ * like "199/199" + "999" (634px).
  *
  * Why the split exists at all: combining tabs and actions on one row is not
  * survivable at phone widths and no amount of folding fixes it. The four tab
@@ -166,7 +172,7 @@ test.describe('tab-strip tiers (PLAN-2326 / TASK-2329)', () => {
 		const badgeIcon = col.locator('.strip-actions .badge-icon');
 		const badgeCount = col.locator('.strip-actions .badge-count');
 
-		// ── SHARED ROW. 892px of strip at this viewport, way over 699. ──
+		// ── SHARED ROW. 892px of strip at this viewport, way over 640. ──
 		await expect(col.locator('.tab-strip')).toBeVisible();
 		await expect(badgeCount.first()).toBeVisible(); // children badge has arrived
 		expect(await stripWidth(col)).toBeGreaterThanOrEqual(700);
@@ -302,15 +308,16 @@ test.describe('tab-strip tiers (PLAN-2326 / TASK-2329)', () => {
 		await page.keyboard.press('Escape');
 	});
 
-	test('the FOLD band (560-699px) still folds: a pane dragged to its 720px maximum keeps one row and drops the badge icons + star, with Star still reachable in the ⋯ menu', async ({
+	test('the FOLD band (560-639px) folds the badge icons + star, and the Star affordance moves into the ⋯ menu — exactly one of the two exists at any width', async ({
 		page,
 		fixture,
 		request,
 	}) => {
-		// A 720px pane (PANE_WIDTH_MAX) is a 672px strip — inside the fold band
-		// and the ONLY way to reach it from a docked pane.
-		await page.addInitScript(() => localStorage.setItem('pad-pane-width', '720'));
-		await page.setViewportSize({ width: 2000, height: 1000 });
+		// A 640px pane is a 592px strip: inside the fold band. The band is only
+		// reachable by dragging the pane to 608-687px, so it has to be set up
+		// rather than stumbled into.
+		await page.addInitScript(() => localStorage.setItem('pad-pane-width', '640'));
+		await page.setViewportSize({ width: 1800, height: 1000 });
 		await browserLogin(page);
 
 		const master = await seedDocWith(fixture, request, 'Tier fold');
@@ -323,7 +330,7 @@ test.describe('tab-strip tiers (PLAN-2326 / TASK-2329)', () => {
 
 		const width = await stripWidth(pane);
 		expect(width).toBeGreaterThanOrEqual(560);
-		expect(width).toBeLessThan(700);
+		expect(width).toBeLessThan(640);
 
 		const layout = await stripLayout(pane);
 		expect(layout.split).toBe(false);
@@ -337,11 +344,111 @@ test.describe('tab-strip tiers (PLAN-2326 / TASK-2329)', () => {
 		await expect(pane.locator('button.star-btn')).toBeHidden();
 		await expect(pane.locator('button.star-btn')).toHaveCount(1);
 
-		// The folded star still has a home, and it works.
+		// ...and the menu row takes over, gated by the SAME query. The folded
+		// star must have exactly one home: here.
 		await pane.locator('button.pane-more-btn').click();
+		await expect(page.locator('.strip-star-row')).toBeVisible();
 		await pane.getByRole('menuitem', { name: 'Star' }).click();
 		await pane.locator('button.pane-more-btn').click();
 		await expect(pane.getByRole('menuitem', { name: 'Unstar' })).toBeVisible();
 		await page.keyboard.press('Escape');
+	});
+
+	test('the tier boundaries have no sub-pixel gap: a fractional strip width either side of 560 and 640 still lands in the right tier', async ({
+		page,
+		fixture,
+		request,
+	}) => {
+		// Container widths are NOT integers — the docked pane's default is
+		// `clamp(360px, 38%, 640px)` and PaneHost's JS floors are `usable * 0.4`
+		// — so a strip can genuinely measure 559.5px. Encoded as three adjacent
+		// integer bands (`max-width: 559` / `560..639` / `640+`) that width
+		// matches NOTHING and silently falls back to the full shared row, which
+		// needs 607px. The fix is nested ranges plus `.99` bounds; this is the
+		// regression guard, and it needs fractional widths that no other test
+		// here produces.
+		await page.setViewportSize({ width: 1800, height: 1000 });
+		await browserLogin(page);
+		const master = await seedDocWith(fixture, request, 'Tier subpixel');
+		await seedDocWith(fixture, request, 'Tier subpixel child', { parent: master.id });
+		await page.goto(`/${fixture.adminUsername}/${fixture.workspaceSlug}/docs?item=${master.slug}`);
+		const pane = page.locator('.item-pane');
+		await expect(pane.locator('.tab-strip')).toBeVisible();
+
+		// pane width - 48px of padding = strip width.
+		const cases: Array<[number, 'split' | 'fold' | 'full']> = [
+			[607.5, 'split'], // strip 559.50 — was in the gap
+			[607.99, 'split'], // strip 559.99 — was in the gap
+			[608.5, 'fold'], // strip 560.50
+			[687.5, 'fold'], // strip 639.50 — was in the gap
+			[687.99, 'fold'], // strip 639.99 — was in the gap
+			[688.5, 'full'], // strip 640.50
+		];
+
+		for (const [paneWidth, expected] of cases) {
+			await page.addStyleTag({ content: `.item-pane{flex:0 0 ${paneWidth}px !important;}` });
+			const state = await expect
+				.poll(
+					async () =>
+						pane.locator('.tab-strip').evaluate((strip) => {
+							const tabs = strip.querySelector('.pane-tabs') as HTMLElement;
+							const acts = strip.querySelector('.strip-actions') as HTMLElement;
+							const split =
+								acts.getBoundingClientRect().bottom <= tabs.getBoundingClientRect().top + 1;
+							const starHidden =
+								getComputedStyle(strip.querySelector('.star-btn') as HTMLElement).display ===
+								'none';
+							return `${split ? 'split' : starHidden ? 'fold' : 'full'}|${
+								tabs.scrollWidth <= tabs.clientWidth
+							}`;
+						}),
+					{ timeout: 3000 },
+				)
+				.toBe(`${expected}|true`)
+				.then(() => expected);
+			expect(state).toBe(expected);
+		}
+	});
+
+	test('the Star affordance is never duplicated and never absent: the ⋯ menu row appears ONLY where the chip is folded', async ({
+		page,
+		fixture,
+		request,
+	}) => {
+		await browserLogin(page);
+		const master = await seedDocWith(fixture, request, 'Tier symmetry');
+		await seedDocWith(fixture, request, 'Tier symmetry child', { parent: master.id });
+		const paneUrl = `/${fixture.adminUsername}/${fixture.workspaceSlug}/docs?item=${master.slug}`;
+
+		// [label, viewport, stored pane width, expected tier]
+		const widths: Array<[string, { width: number; height: number }, number, 'split' | 'fold' | 'full']> = [
+			['360px pane (strip 312)', { width: 1440, height: 1000 }, 360, 'split'],
+			['448px pane (strip 400)', { width: 1440, height: 1000 }, 448, 'split'],
+			['620px pane (strip 572)', { width: 1600, height: 1000 }, 620, 'fold'],
+			['720px pane (strip 672)', { width: 2000, height: 1000 }, 720, 'full'],
+		];
+
+		for (const [label, viewport, paneWidth, tier] of widths) {
+			await page.setViewportSize(viewport);
+			await page.addInitScript((w) => localStorage.setItem('pad-pane-width', String(w)), paneWidth);
+			await page.goto(paneUrl);
+			const pane = page.locator('.item-pane');
+			await expect(pane.locator('.tab-strip')).toBeVisible();
+
+			const chip = pane.locator('button.star-btn');
+			const row = page.locator('.strip-star-row');
+			// Open the ⋯ so the row is mounted and measurable.
+			await pane.locator('button.pane-more-btn').click();
+			await expect(row).toHaveCount(1); // always in the DOM, gated by CSS only
+
+			if (tier === 'fold') {
+				await expect(chip, label).toBeHidden();
+				await expect(row, label).toBeVisible();
+			} else {
+				await expect(chip, label).toBeVisible();
+				await expect(row, label).toBeHidden();
+			}
+			await page.keyboard.press('Escape');
+		}
 	});
 });

--- a/web/src/lib/components/common/MenuItem.svelte
+++ b/web/src/lib/components/common/MenuItem.svelte
@@ -15,6 +15,12 @@
 		 *  destructive confirmation, which is presentational and otherwise
 		 *  never announced when the row takes focus (PLAN-2326). */
 		describedBy?: string;
+		/** Extra class on the row, for callers that need to address it from
+		 *  their own stylesheet — e.g. a container query that shows a row only
+		 *  at widths where the equivalent toolbar button is folded away
+		 *  (ItemDetail's Star row, TASK-2329). Reach it with `:global()`: the
+		 *  caller's scoping hash is not applied to this element. */
+		class?: string;
 		onclick?: (e: MouseEvent) => void;
 		children: Snippet;
 	}
@@ -26,6 +32,7 @@
 		checked,
 		disabled = false,
 		describedBy,
+		class: extraClass,
 		onclick,
 		children
 	}: Props = $props();
@@ -33,7 +40,7 @@
 
 <button
 	type="button"
-	class="mi"
+	class="mi {extraClass ?? ''}"
 	class:danger
 	role={checked !== undefined ? 'menuitemradio' : 'menuitem'}
 	aria-checked={checked}

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -4583,21 +4583,29 @@
 						focusKey={paneMenuView}
 					>
 						{#if paneMenuView === 'root'}
-							<!-- Star also lives here, not only as the strip chip
-							     (TASK-2329, Codex round 2). The compact tier folds
-							     the chip away with `display: none`, and the mobile
-							     overlay is ALWAYS compact — so without this row
-							     starring would be unreachable on phones entirely.
-							     PLAN-2326's premise is "zero affordances removed",
-							     which a CSS fold only honours if the action still
-							     has a home. Rendered at every tier: a duplicate row
-							     in an overflow menu costs nothing, and hiding it in
-							     the full tier would mean container-querying inside
-							     the Menu — whose mobile form is a BottomSheet, i.e.
-							     exactly the surface that needs the row most.
-							     Unconditional, like the chip: starring is a
-							     per-user REST toggle open to viewers too. -->
+							<!-- Star's stand-in for the FOLD band ONLY (TASK-2329).
+							     Between 560 and 639px of strip the `.star-btn`
+							     chip is `display: none`, which would leave the
+							     action with nowhere to go; PLAN-2326's premise is
+							     "zero affordances removed". Outside that band the
+							     chip is visible and this row is hidden, so the
+							     affordance exists in exactly one place at every
+							     width — never zero, never two, and never
+							     announced twice (`display: none` also drops it
+							     from the accessibility tree).
+
+							     Gated by `.strip-star-row` under the SAME
+							     container query that folds the chip; see the CSS.
+							     This Menu renders inside `.menu-anchor` ->
+							     `.strip-actions` -> `.tab-strip`, so it IS a
+							     descendant of the query container and the rule
+							     reaches it — on the anchored desktop panel and
+							     the mobile BottomSheet alike, neither of which
+							     portals out of the subtree. Unconditional in
+							     markup, like the chip: starring is a per-user
+							     REST toggle open to viewers too. -->
 							<MenuItem
+								class="strip-star-row"
 								icon={starredStore.isStarred(item.id) ? '★' : '☆'}
 								onclick={() => {
 									if (!item) return;
@@ -5695,20 +5703,116 @@
 	   implies: `PaneHost.svelte`'s JS `PANE_WIDTH_MAX = 720` is the real
 	   ceiling and it wins.
 
-	   ── SPLIT, below 560px ──
+   ── The two boundaries, DERIVED FROM MEASUREMENT ──
+	   Measured on the worst-case item above, with the tab labels at their
+	   natural 321px and a 12px column gap:
+
+	     action group, FOLDED (icons off, star off)   191px -> row needs 524px
+	     action group, FULL                           274px -> row needs 607px
+	     action group, FULL, badge counts inflated
+	       to an absurd "199/199" + "999"             301px -> row needs 634px
+
+	   So SPLIT below 560 (36px of slack over the folded row's 524), and FULL
+	   at 640 and up (6px over the absurd case, 33px over the real one). The
+	   fold band is what is left in between.
+
+	   640 rather than the 700 this task was scoped with: that figure was
+	   derived while Saved/Synced were still in the strip, and they were worth
+	   115px of the group. With them back in `.meta-info` the full row needs
+	   607px, not 722px, so a 700px boundary would have folded the star and
+	   the badge icons on the two widest surfaces that fold at all — a pane
+	   dragged to its 672px maximum and a 1440px full page with a pane docked
+	   (678px) — both of which have room to spare.
+
+	   ── The two blocks NEST, they do not abut (Codex) ──
+	   The obvious encoding is three adjacent bands: `max-width: 559`,
+	   `560..639`, `640+`. That leaves a hole. Container widths are not
+	   integers — the docked pane's default is `clamp(360px, 38%, 640px)` and
+	   `PaneHost`'s JS floors are `usable * 0.4` — so a strip can genuinely
+	   measure 559.5px, which matches NEITHER `max-width: 559px` NOR
+	   `min-width: 560px`, and silently falls back to the full shared row that
+	   needs 607px. A sub-pixel window, but a real one, and invisible to
+	   integer-width tests.
+
+	   Two things close it. First the blocks NEST: FOLD covers everything at
+	   or below the full threshold, and SPLIT is a strict SUBSET of it that
+	   both re-shapes the rows and UN-folds what the outer block hid. That
+	   alone bounds the damage — measured at 559.5px the strip folds instead
+	   of splitting, and the folded shared row needs only 524px, so the tabs
+	   still fit. Second the bounds are `.99`, not integers, so the leftover
+	   window is [559.99, 560), which no engine can land in: layout precision
+	   is 1/64px in Chromium and WebKit and 1/60px in Gecko, all coarser than
+	   0.01. Verified by forcing the strip to 559.50 / 559.99 / 639.50 /
+	   639.99 and checking the tier each time.
+
+	   (`(560px <= width < 640px)` range syntax would be exact and read
+	   better, but a browser that cannot parse it drops the whole block —
+	   which on a phone means the broken shared row comes back. `max-width`
+	   is universally supported wherever `@container` is.)
+
+	   ── FOLD, at or below 639px ──
+	   The two still share a row but it is tight, so the badge icons drop to
+	   bare counts and the star folds. The star folds by `display: none` with
+	   the node RETAINED (DR-11) — `.star-btn` must stay in the DOM for the
+	   BUG-2263 freeze assertions in pane-full-page-capstone.spec.ts.
+
+	   `.strip-star-row` is the `⋯` menu's stand-in for the folded chip, gated
+	   by the SAME query, inverted: hidden by default, shown only here.
+	   Symmetric by construction — the affordance exists in exactly one place
+	   at every width, never zero and never two, and `display: none` keeps the
+	   hidden one out of the accessibility tree so it is never announced
+	   alongside the visible chip.
+
+	   `:global()` because the row is a `MenuItem` child component: this
+	   component's scoping hash is not applied to its button. The Menu still
+	   renders INSIDE `.menu-anchor` -> `.strip-actions` -> `.tab-strip`
+	   (anchored panel and mobile BottomSheet alike — neither portals out), so
+	   it is a descendant of the query container and the rule reaches it.
+
+	   DESCENDED FROM `.menu-anchor` deliberately, not a bare
+	   `:global(.strip-star-row)`. MenuItem's own `.mi { display: flex }`
+	   carries that component's scoping hash, so it is (0,2,0) and a bare
+	   global class selector (0,1,0) loses to it — measured: the row rendered
+	   `display: flex` at every width, breaking the symmetry in the direction
+	   that shows the star TWICE. Prefixing with this component's own
+	   `.menu-anchor` makes every one of these rules (0,3,0), which wins
+	   deterministically and keeps the global reach inside our own subtree. */
+	.menu-anchor :global(.strip-star-row) {
+		display: none;
+	}
+
+	@container item-tab-strip (max-width: 639.99px) {
+		.badge-icon {
+			display: none;
+		}
+		.star-btn {
+			display: none;
+		}
+		.menu-anchor :global(.strip-star-row) {
+			display: flex;
+		}
+	}
+
+	/* ── SPLIT, at or below 559px — a strict subset of the FOLD block ──
 	   The actions take a row of their own and the tablist gets the full
 	   width. This is the fix for the phone case, where sharing a row is not
 	   survivable at any action-group size (see the note on `.tab-strip`).
-	   560 is the boundary because the shared row needs 321px of tabs plus a
-	   ~190px compact action group plus the 12px column gap.
 
 	   ABOVE the tabs, not below (`order: -1`, visual only — DOM order and
 	   therefore the tablist's roving tabindex are untouched). `.tab-strip`
 	   owns the bottom divider and `.pane-tab.on` overlaps it by 1px via
 	   `margin-bottom: -1px`; keeping the tablist as the LAST row preserves
 	   that overlap. Actions-below would orphan the active-tab underline
-	   ~31px above the divider. */
-	@container item-tab-strip (max-width: 559px) {
+	   ~31px above the divider.
+
+	   The three UN-FOLD declarations are what make the nesting work: with a
+	   row to themselves the actions have room, so the star and the badge
+	   icons come back and the menu row stands down. The values restore what
+	   the elements compute to outside the fold — `.badge-icon` is a plain
+	   inline `<span>`, and `.star-btn` is a flex item of `.strip-actions` so
+	   its used display is `block` regardless. Both measured, and asserted by
+	   the symmetry test in pane-tab-strip-tiers.spec.ts. */
+	@container item-tab-strip (max-width: 559.99px) {
 		.strip-actions {
 			order: -1;
 			flex: 0 0 100%;
@@ -5716,23 +5820,13 @@
 			justify-content: flex-end;
 			flex-wrap: wrap;
 		}
-	}
-
-	/* ── FOLD, 560-699px ──
-	   Only in this band. Here the two still share a row but it is tight, so
-	   the badge icons drop to bare counts and the star folds. Below 560 they
-	   both come BACK: the actions have their own row and the space to show
-	   them. Above 699 everything fits outright.
-
-	   The star folds by `display: none` with the node RETAINED (DR-11) —
-	   `.star-btn` must stay in the DOM for the BUG-2263 freeze assertions in
-	   pane-full-page-capstone.spec.ts. Star is also a row in the `⋯` menu,
-	   so the action still has a home while the chip is folded. */
-	@container item-tab-strip (min-width: 560px) and (max-width: 699px) {
 		.badge-icon {
-			display: none;
+			display: inline;
 		}
 		.star-btn {
+			display: block;
+		}
+		.menu-anchor :global(.strip-star-row) {
 			display: none;
 		}
 	}

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -4328,22 +4328,29 @@
 			</div>
 		{/if}
 
-		<!-- Provenance line. SCREEN-HIDDEN wholesale since TASK-2329 (DR-5):
-		     created/updated is provenance that the Activity and Versions tabs
-		     now own, and hiding the band whole — rather than its two spans —
-		     is what removes the stray `.meta-sep` "·" and the band's bottom
-		     margin along with it.
-
-		     It stays in the DOM because it is load-bearing for PRINT: the
-		     `@media print` block resets it to `display: block` and gives it
-		     the `border-bottom` that divides the page-1 document header from
-		     the properties card (BUG-626). The transient Saved / Synced
-		     indicators moved OUT of here into `.strip-actions` below — they
-		     are live status, not provenance, and print hides them anyway. -->
+		<!-- Meta info -->
 		<div class="meta-info">
 			<span title={new Date(item.created_at).toLocaleString()}>Created {relativeTime(item.created_at)} by {item.created_by || 'unknown'}</span>
 			<span class="meta-sep">·</span>
 			<span title={new Date(item.updated_at).toLocaleString()}>Updated {relativeTime(item.updated_at)}</span>
+			<span class="save-status" class:saving={saveStatus === 'saving'} class:saved={saveStatus === 'saved'} class:visible={saveStatus !== 'idle'}>
+				{#if saveStatus === 'saving'}Saving...{:else}✓ Saved{/if}
+			</span>
+			{#if collabProvider}
+				<!-- Pending-sync indicator (TASK-1264). Visible only while
+				     the WS provider exists, which means: canEdit && !rawMode.
+				     Read-only / share-page / raw mode never see this badge.
+				     Colour map matches the four-state machine in
+				     wsProvider.svelte.ts: green=synced, yellow=connecting/
+				     reconnecting, red=offline. -->
+				<span
+					class="collab-state collab-state-{collabProvider.state}"
+					title={collabStateTitle(collabProvider.state)}
+				>
+					<span class="collab-state-dot" aria-hidden="true"></span>
+					<span class="collab-state-label">{collabStateLabel(collabProvider.state)}</span>
+				</span>
+			{/if}
 		</div>
 
 		<!-- Tab strip (PLAN-2326 / TASK-2328). One band: the tablist plus the
@@ -4417,37 +4424,6 @@
 			     containing block for the anchored Menu, so lifting the `⋯` button
 			     out of it on its own would break the panel's positioning. -->
 			<div class="strip-actions">
-				<!-- Saved / Synced, relocated out of `.meta-info` (TASK-2329).
-				     They lead the group so the icon controls stay flush right.
-
-				     `.collab-state-synced` keeps its class AND its visibility at
-				     every tier — it is `SYNCED_BADGE_SELECTOR` in
-				     `web/e2e/lib/collab-helpers.ts`, asserted visible across
-				     several suites including inside a narrow docked pane. Only
-				     its `.collab-state-label` word folds in the compact tier,
-				     and only visually — it stays in the accessibility tree, so
-				     the badge is never a colour-only status. The coloured dot
-				     (the primary signal) always renders. The
-				     badge's CSS was never scoped through `.meta-info`, so the
-				     move is purely positional. -->
-				<span class="save-status" class:saving={saveStatus === 'saving'} class:saved={saveStatus === 'saved'} class:visible={saveStatus !== 'idle'}>
-					{#if saveStatus === 'saving'}Saving...{:else}✓ Saved{/if}
-				</span>
-				{#if collabProvider}
-					<!-- Pending-sync indicator (TASK-1264). Visible only while
-					     the WS provider exists, which means: canEdit && !rawMode.
-					     Read-only / share-page / raw mode never see this badge.
-					     Colour map matches the four-state machine in
-					     wsProvider.svelte.ts: green=synced, yellow=connecting/
-					     reconnecting, red=offline. -->
-					<span
-						class="collab-state collab-state-{collabProvider.state}"
-						title={collabStateTitle(collabProvider.state)}
-					>
-						<span class="collab-state-dot" aria-hidden="true"></span>
-						<span class="collab-state-label">{collabStateLabel(collabProvider.state)}</span>
-					</span>
-				{/if}
 				<!-- Star is a per-user, itemId-keyed REST toggle available to viewers too,
 				     and cannot collide across sides — so it is NOT frozen while peeking
 				     (BUG-2263). No canEdit or peeking gate. -->
@@ -5673,16 +5649,6 @@
 		min-width: 0;
 	}
 
-	/* Saved / Synced were relocated here out of `.meta-info` (TASK-2329). They
-	   each carried their own `margin-left` for spacing inside that band; the
-	   group's `gap` owns spacing now, so the margin would just double it.
-	   Overridden under `.strip-actions` rather than removed from the base
-	   rules so the badges keep their standalone styling. */
-	.strip-actions .save-status,
-	.strip-actions .collab-state {
-		margin-left: 0;
-	}
-
 	/* ── Compact tier (PLAN-2326 DR-7 / DR-9 / DR-10) ──────────────────────
 	   `@container`, NOT `@media`: the docked pane is
 	   `flex: 0 0 var(--pane-width, clamp(360px, 38%, 640px))` — a width the
@@ -5721,49 +5687,12 @@
 	   required duplicate badge markup outside this subtree.
 
 	   The star folds by `display: none` with the node RETAINED (DR-11) —
-	   `.star-btn` must stay in the DOM for the BUG-2263 freeze assertions.
-	   `.collab-state` itself never folds (it is `SYNCED_BADGE_SELECTOR`,
-	   asserted visible inside narrow panes); only its label word folds, and
-	   VISUALLY only — see the sr-only note on that rule. The coloured dot,
-	   the primary signal, always renders. */
+	   `.star-btn` must stay in the DOM for the BUG-2263 freeze assertions. */
 	@container item-tab-strip (max-width: 699px) {
 		.badge-icon {
 			display: none;
 		}
 		.star-btn {
-			display: none;
-		}
-		/* VISUALLY hidden, not `display: none` (Codex round 2). The dot is
-		   `aria-hidden`, so this label is the badge's ONLY textual state —
-		   `display: none` would drop it out of the accessibility tree and
-		   leave a colour-only indicator, which is exactly the failure mode
-		   the label exists to prevent. The clip-rect idiom takes it out of
-		   the visual flow (0 layout width, no paint) while keeping it
-		   readable by assistive tech. `clip-path` here is on a LEAF span —
-		   not on `.tab-strip` or any ancestor of `.menu-anchor`, where it
-		   would clip the anchored panels. */
-		.collab-state-label {
-			position: absolute;
-			width: 1px;
-			height: 1px;
-			padding: 0;
-			margin: -1px;
-			overflow: hidden;
-			clip: rect(0 0 0 0);
-			clip-path: inset(50%);
-			white-space: nowrap;
-			border: 0;
-		}
-		/* `.save-status` sits at `opacity: 0` when idle, which still RESERVES
-		   its ~48px. Harmless in the 912px full tier; in a 360px pane that is
-		   18% of the strip taken by something invisible, and every px here
-		   comes straight out of the tab list's scrollport (38px -> 94px with
-		   this rule). Dropping it from the flow costs no button movement: the
-		   group is right-aligned and `.save-status` LEADS it, so a save
-		   extends the group's left edge and nothing to its right shifts. The
-		   only casualty is the 0.2s fade-OUT at the end of the 2s `saved`
-		   window (`display: none` snaps); the fade-IN still plays. */
-		.save-status:not(.visible) {
 			display: none;
 		}
 	}
@@ -6130,20 +6059,15 @@
 		line-height: 1;
 	}
 
-	/* Meta — the created/updated provenance line.
-
-	   SCREEN-HIDDEN WHOLESALE (TASK-2329 / DR-5). Hiding the band rather than
-	   its spans is deliberate: a spans-only hide would leave the `.meta-sep`
-	   "·" orphaned on its own row plus the band's bottom margin. Activity and
-	   Versions are the tabs that own provenance now.
-
-	   The element stays in the DOM because print needs it: the `@media print`
-	   block restores `display: block` and re-declares every property it cares
-	   about there (font-size, colour, margins, and the `border-bottom` that
-	   divides the page-1 document header from the properties card — BUG-626),
-	   so none of the old screen-side flex properties are missed. */
+	/* Meta */
 	.meta-info {
-		display: none;
+		display: flex;
+		align-items: center;
+		gap: var(--space-2);
+		font-size: 0.8em;
+		color: var(--text-muted);
+		margin-bottom: var(--space-2);
+		flex-wrap: wrap;
 	}
 	.meta-sep { color: var(--text-muted); }
 	.save-status {
@@ -6913,14 +6837,7 @@
 
 		/* Meta info subtitle (created / updated by). Border-bottom
 		   separates the page-1 document header block from the
-		   properties card below. BUG-626.
-
-		   `display: block` was already here before TASK-2329 and is what
-		   makes the band's wholesale SCREEN hide safe — it un-hides the
-		   provenance line for print. Do not drop it. Saved / Synced used to
-		   live inside this band and moved to `.strip-actions`; they were
-		   already print-hidden by the global selectors above, so the printed
-		   text is unchanged. */
+		   properties card below. BUG-626. */
 		.meta-info {
 			font-size: 9pt;
 			color: #555;

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -5573,32 +5573,53 @@
 		color: var(--text-muted);
 	}
 
-	/* ── Tab strip (PLAN-2326 / TASK-2328) ────────────────────────────────
-	   One band: the `.pane-tabs` tablist plus the right-aligned
-	   `.strip-actions` group, which before TASK-2328 was its own
-	   `.meta-actions` row above. The divider that used to belong to
-	   `.pane-tabs` lives here now so it runs the full width of the strip
-	   rather than stopping where the tabs do.
+	/* ── Tab strip (PLAN-2326 / TASK-2328, re-keyed by TASK-2329) ─────────
+	   The `.pane-tabs` tablist plus the `.strip-actions` group, which before
+	   TASK-2328 was its own `.meta-actions` row above. The divider that used
+	   to belong to `.pane-tabs` lives here now so it runs the full width of
+	   the strip rather than stopping where the tabs do.
 
-	   `container-type: inline-size` makes this the query container for
-	   TASK-2329's tier rule. It has to be here rather than on an ancestor:
-	   the docked pane's width is user-dragged and persisted, decoupled from
-	   the viewport, so a media query cannot see it (DR-2).
+	   ONE band when there is room, TWO when there is not. Combining them
+	   unconditionally does not work below ~560px and no amount of folding
+	   fixes it: the four tab labels are a fixed 321px, and even the most
+	   aggressive action group anyone proposed (⋯ alone, 38px) needs 359px
+	   against the 342px a 390px phone actually has. Measured on the widest
+	   common phone, 430px: 382px of strip, 179px of tab scrollport, two of
+	   four tabs clipped — under `scrollbar-width: none`, so with no hint
+	   they exist. Below 560 the actions therefore take a row of their own
+	   and the tablist gets the full width.
+
+	   `container-type: inline-size` makes this the query container. It has
+	   to be here rather than on an ancestor: the docked pane's width is
+	   user-dragged and persisted, decoupled from the viewport, so a media
+	   query cannot see it (DR-2). A 360px pane on a 1920px monitor splits;
+	   the full page behind it does not.
+
+	   `flex-wrap` / `column-gap` / `row-gap` MUST live in THIS rule and not
+	   in the `@container` block below. A container query cannot style its
+	   own query container, and `.tab-strip` IS `item-tab-strip` — a
+	   `flex-wrap: wrap` written in there is silently dropped. Not inert:
+	   with `flex-basis: 100%` on `.strip-actions` while `nowrap` is still in
+	   force, `.pane-tabs` collapses to 0px.
 
 	   Deliberately NO `overflow`, `contain`, `clip-path`, `transform`,
 	   `filter` or `will-change` on this element — it is an ancestor of both
 	   `.menu-anchor` and QuickActionsMenu's anchor, and any of those would
-	   clip the anchored panels they position. DR-9's scroll rule goes on
+	   clip the anchored panels they position. The scroll rule goes on
 	   `.pane-tabs`, which is their SIBLING. (`container-type` itself is
 	   safe: it applies layout/style/inline-size containment but not PAINT
 	   containment, so the panels still escape — DR-3, re-verified in
 	   Chromium against this markup, including the mobile BottomSheet's
-	   `position: fixed` overlay, which still resolves against the
-	   viewport.) */
+	   `position: fixed` overlay, which still resolves against the viewport.
+	   Chromium reports `contain: none` here despite `container-type`; that
+	   is expected — do NOT "fix" it by adding `contain: layout`, which DOES
+	   trap the sheet's `position: fixed`.) */
 	.tab-strip {
 		display: flex;
 		align-items: center;
-		gap: var(--space-3);
+		column-gap: var(--space-3);
+		row-gap: var(--space-2);
+		flex-wrap: wrap;
 		container-type: inline-size;
 		container-name: item-tab-strip;
 		border-bottom: 1px solid var(--border-subtle);
@@ -5609,10 +5630,15 @@
 	.pane-tabs {
 		display: flex;
 		gap: 2px;
-		/* DR-9 width allocation: `.strip-actions` never shrinks, so the tab
-		   list scrolls horizontally instead of wrapping to a second row or
-		   crushing the actions. `min-width: 0` is what lets a flex item
-		   shrink below its content width at all. */
+		/* `.strip-actions` never shrinks, so whatever room is left goes to the
+		   tab list and it scrolls rather than crushing the actions.
+		   `min-width: 0` is what lets a flex item shrink below its content
+		   width at all. Above 560px the two share one row and the scroll is
+		   the overflow valve; below 560 the actions take their own row and
+		   the tablist gets the full width, at which point the four tabs fit
+		   outright at every phone width (the ≤330px rule trims tab padding
+		   for the last 9px). The scroll stays as the backstop for a future
+		   fifth tab or a longer label. */
 		min-width: 0;
 		overflow-x: auto;
 		scrollbar-width: none;
@@ -5631,9 +5657,11 @@
 		display: none;
 	}
 
-	/* `margin-left: auto` right-aligns the group however few tabs there are;
-	   `flex: 0 0 auto` is DR-9's other half — the actions hold their size and
-	   the tab list gives way. */
+	/* Shared-row shape (>=560px of strip): `margin-left: auto` right-aligns
+	   the group however few tabs there are, and `flex: 0 0 auto` holds its
+	   size so the tab list is what gives way. Both are overridden in the
+	   split tier below, where the group owns a full row and right-aligns via
+	   `justify-content` instead. */
 	.strip-actions {
 		display: flex;
 		align-items: center;
@@ -5649,46 +5677,58 @@
 		min-width: 0;
 	}
 
-	/* ── Compact tier (PLAN-2326 DR-7 / DR-9 / DR-10) ──────────────────────
-	   `@container`, NOT `@media`: the docked pane is
-	   `flex: 0 0 var(--pane-width, clamp(360px, 38%, 640px))` — a width the
-	   user drags and we persist, decoupled from the viewport — so a 360px
-	   pane on a 1440px screen still matches `@media (min-width: 900px)`.
-	   Only the container knows how much room the strip actually has.
+	/* ── Tier rules, all keyed on the STRIP's own width ────────────────────
+	   Measured strip widths, which is what the three boundaries below are
+	   drawn against (worst-case item: both count badges + quick actions +
+	   owner rights):
 
-	   THRESHOLD — 700px, measured rather than assumed (DR-10). The strip's
-	   content box tops out at 912px on the full page at ANY monitor width
-	   (`--content-max-width: 960px` less 2x `--space-6` — verified identical
-	   at 1440 and 2560), so the mock's 900px boundary would have made the
-	   compact tier the near-universal state. Measured strip widths bracket
-	   700 cleanly:
+	     full page                     892-912px  (capped by
+	                                   --content-max-width; identical at 1440
+	                                   and 2560, so a viewport media query
+	                                   could never have keyed this)
+	     full page @1024 / @768            716-720px
+	     full page + a docked pane         526-678px
+	     docked pane (360-720px wide)      312-672px
+	     phone full page / overlay         312-382px
 
-	     full page                     892-912px -> full
-	     full page + docked pane       526-678px -> compact
-	     docked pane                   312-672px -> compact
-	     mobile overlay                    342px -> compact
+	   Note the docked pane reaches 672, not the 592 the CSS `clamp(...640px)`
+	   implies: `PaneHost.svelte`'s JS `PANE_WIDTH_MAX = 720` is the real
+	   ceiling and it wins.
 
-	   The pane's 672px ceiling is `PaneHost.svelte`'s JS `PANE_WIDTH_MAX =
-	   720` less the pane's 2x24px padding — a harder bound than the CSS
-	   `clamp()`'s 640, and the tightest margin the threshold has (28px). If
-	   that constant ever grows past ~750 a dragged-wide pane would enter the
-	   full tier, which is the correct outcome anyway: it would have the room.
+	   ── SPLIT, below 560px ──
+	   The actions take a row of their own and the tablist gets the full
+	   width. This is the fix for the phone case, where sharing a row is not
+	   survivable at any action-group size (see the note on `.tab-strip`).
+	   560 is the boundary because the shared row needs 321px of tabs plus a
+	   ~190px compact action group plus the 12px column gap.
 
-	   So the rule is "does the full tier fit", not "which surface is this":
-	   a full page whose master column has been squeezed by an open pane
-	   compacts too, which is the point of querying the container. (The full
-	   tier's own worst-case content measures ~722px — 321px of tabs plus the
-	   widest observed action group. 700 is 22px optimistic, which only bites
-	   in the ~30px-wide viewport band where a pane-squeezed master lands
-	   between the two; there the tab list just scrolls a few px, silently,
-	   exactly as DR-9 designed it to.)
+	   ABOVE the tabs, not below (`order: -1`, visual only — DOM order and
+	   therefore the tablist's roving tabindex are untouched). `.tab-strip`
+	   owns the bottom divider and `.pane-tab.on` overlaps it by 1px via
+	   `margin-bottom: -1px`; keeping the tablist as the LAST row preserves
+	   that overlap. Actions-below would orphan the active-tab underline
+	   ~31px above the divider. */
+	@container item-tab-strip (max-width: 559px) {
+		.strip-actions {
+			order: -1;
+			flex: 0 0 100%;
+			margin-left: 0;
+			justify-content: flex-end;
+			flex-wrap: wrap;
+		}
+	}
 
-	   TWO tiers, not the mock's three (DR-7): the `<600px` tier would have
-	   required duplicate badge markup outside this subtree.
+	/* ── FOLD, 560-699px ──
+	   Only in this band. Here the two still share a row but it is tight, so
+	   the badge icons drop to bare counts and the star folds. Below 560 they
+	   both come BACK: the actions have their own row and the space to show
+	   them. Above 699 everything fits outright.
 
 	   The star folds by `display: none` with the node RETAINED (DR-11) —
-	   `.star-btn` must stay in the DOM for the BUG-2263 freeze assertions. */
-	@container item-tab-strip (max-width: 699px) {
+	   `.star-btn` must stay in the DOM for the BUG-2263 freeze assertions in
+	   pane-full-page-capstone.spec.ts. Star is also a row in the `⋯` menu,
+	   so the action still has a home while the chip is folded. */
+	@container item-tab-strip (min-width: 560px) and (max-width: 699px) {
 		.badge-icon {
 			display: none;
 		}
@@ -5718,6 +5758,25 @@
 	.pane-tab.on {
 		color: var(--text-primary);
 		border-bottom-color: var(--accent-primary, var(--accent-blue));
+	}
+
+	/* ── TAB PADDING, below 330px of strip ──
+	   At the 360px pane floor / a 360px phone the strip is 312px and the four
+	   tabs need 321px even with a full row to themselves. Trimming 11px -> 8px
+	   of horizontal padding buys 24px, which clears it (321 -> 297). Vertical
+	   padding is untouched so the strip's height and the active tab's 1px
+	   divider overlap do not move.
+
+	   Placement is load-bearing: this MUST sit after the base `.pane-tab`
+	   rule. A container query adds no specificity, so the two `.pane-tab`
+	   selectors tie and source order decides — written above the base rule it
+	   is silently overridden and the tabs still overflow. (Caught by
+	   measurement: `scrollWidth` stayed 321 at a 312px strip.) */
+	@container item-tab-strip (max-width: 330px) {
+		.pane-tab {
+			padding-left: 8px;
+			padding-right: 8px;
+		}
 	}
 
 	/* Hidden tab panels stay MOUNTED (collab editor, SSE feeds, backlink

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -539,9 +539,53 @@
 	// Stable per-instance suffix so tab/panel aria-controls pairs stay unique
 	// when TWO ItemDetail instances mount (full-page master + docked pane).
 	const uid = $props.id();
-	const PANE_TABS: Array<{ id: PaneTab; label: string }> = [
+
+	// ── Tablist overflow affordance (TASK-2329) ──────────────────────────
+	// `.pane-tabs` scrolls with `scrollbar-width: none`, so without this a
+	// cut-off tab is invisible AND unhinted — the exact defect this task
+	// exists to fix. CSS cannot ask "is this element scrolling", which is why
+	// this one measurement is scripted while every TIER rule stays a container
+	// query (DR-2 is about tier logic, and still holds).
+	//
+	// Writes only; nothing here reads these back, so there is no
+	// effect-self-write loop (CONVE-1688). `mask-image` is a paint effect, so
+	// flipping these cannot resize the element and cannot re-trigger the
+	// observer.
+	let tabsEl = $state<HTMLElement | null>(null);
+	let tabsAtStart = $state(true);
+	let tabsAtEnd = $state(true);
+	$effect(() => {
+		const el = tabsEl;
+		if (!el) return;
+		const measure = () => {
+			const max = el.scrollWidth - el.clientWidth;
+			// 1px tolerance: sub-pixel layout leaves scrollLeft fractionally
+			// short of `max` at the end of a scroll, and scrollWidth a hair
+			// over clientWidth when the content actually fits.
+			tabsAtStart = el.scrollLeft <= 1;
+			tabsAtEnd = max <= 1 || el.scrollLeft >= max - 1;
+		};
+		measure();
+		const ro = new ResizeObserver(measure);
+		ro.observe(el);
+		el.addEventListener('scroll', measure, { passive: true });
+		return () => {
+			ro.disconnect();
+			el.removeEventListener('scroll', measure);
+		};
+	});
+	// `short` is a NARROW-WIDTH VISIBLE label only (TASK-2329). The accessible
+	// name always stays `label`, pinned by `aria-label` on the tab, because
+	// roughly five specs address these tabs by
+	// `getByRole('tab', { name: 'Relationships' })` — the visible text may
+	// change with the container width, the accessible name may never.
+	//
+	// Only Relationships gets one. It is by far the longest label (98px of
+	// glyphs on CI's font vs 50-62 for the others) and the sole reason four
+	// tabs did not fit a 312px strip; the rest are already short.
+	const PANE_TABS: Array<{ id: PaneTab; label: string; short?: string }> = [
 		{ id: 'details', label: 'Details' },
-		{ id: 'relationships', label: 'Relationships' },
+		{ id: 'relationships', label: 'Relationships', short: 'Links' },
 		{ id: 'activity', label: 'Activity' },
 		{ id: 'versions', label: 'Versions' }
 	];
@@ -4368,6 +4412,10 @@
 			     unmounted — see the PaneTab block in the script. -->
 			<div
 				class="pane-tabs"
+				class:masked={!tabsAtStart || !tabsAtEnd}
+				style:--fade-l={tabsAtStart ? '0px' : '18px'}
+				style:--fade-r={tabsAtEnd ? '0px' : '18px'}
+				bind:this={tabsEl}
 				role="tablist"
 				aria-label="Item sections"
 				tabindex={-1}
@@ -4413,8 +4461,21 @@
 							if (e.pointerType === 'mouse') activeTab = t.id;
 						}}
 						onclick={() => (activeTab = t.id)}
+						aria-label={t.short ? t.label : undefined}
 					>
-						{t.label}
+						{#if t.short}
+							<!-- Two labels, one accessible name (TASK-2329). `aria-label`
+							     above pins the name to the FULL label, so
+							     `getByRole('tab', { name: 'Relationships' })` keeps
+							     resolving at every width — the ~5 specs that use it are
+							     untouched, and a screen reader never hears "Links".
+							     Only the VISIBLE text swaps, by container query. -->
+							<span class="tab-label-full">{t.label}</span><span class="tab-label-short"
+								>{t.short}</span
+							>
+						{:else}
+							{t.label}
+						{/if}
 					</button>
 				{/each}
 			</div>
@@ -5676,12 +5737,24 @@
 		   width at all. Above 560px the two share one row and the scroll is
 		   the overflow valve; below 560 the actions take their own row and
 		   the tablist gets the full width, at which point the four tabs fit
-		   outright at every phone width (the ≤330px rule trims tab padding
-		   for the last 9px). The scroll stays as the backstop for a future
-		   fifth tab or a longer label. */
+		   outright at every phone width (the short `Links` label plus the
+		   ≤330px padding trim buy the slack). The scroll stays as the backstop
+		   for a future fifth tab, a longer label, a translation, or a font we
+		   have not measured.
+
+		   That backstop USED to be silent: `scrollbar-width: none` hides the
+		   only native signal that content is cut off, which is exactly the
+		   discoverability defect that started this whole episode (two of four
+		   tabs invisible at 430px with nothing to indicate it). The
+		   `background` below restores a signal without giving the scrollbar
+		   back — see the note on it. */
 		min-width: 0;
 		overflow-x: auto;
 		scrollbar-width: none;
+		/* Fade widths for the overflow affordance below — 0 unless the script
+		   has measured content past that edge. */
+		--fade-l: 0px;
+		--fade-r: 0px;
 		/* `overflow-x: auto` computes `overflow-y` to `auto` too, which would
 		   clip `.pane-tab`'s `margin-bottom: -1px` overlap and leave the
 		   active tab with a 1px accent sitting on 1px of divider instead of a
@@ -5695,6 +5768,44 @@
 
 	.pane-tabs::-webkit-scrollbar {
 		display: none;
+	}
+
+	/* ── OVERFLOW AFFORDANCE (TASK-2329) ──────────────────────────────────
+	   `scrollbar-width: none` hides the only native signal that content is
+	   cut off — which IS the defect that started this episode: two of four
+	   tabs invisible at 430px with nothing to say so. The label fix means
+	   overflow now needs a font ~30% wider than CI's before it happens at
+	   all, but "needs an unusual font" is not "cannot happen" (translations,
+	   user zoom, a future fifth tab), so it must degrade visibly rather than
+	   silently truncate.
+
+	   A soft edge fade, applied ONLY on an edge that actually has more
+	   content past it, so at rest there is no mask at all.
+
+	   Why this is script-measured and not a container query: CSS cannot ask
+	   "is this element scrolling". That is the opposite situation to the tier
+	   rules, where CSS expresses the question natively and DR-2 rightly
+	   rejected JS — here JS is the only tool that can answer it. It reads
+	   `scrollWidth`/`clientWidth` and writes two booleans; it does not
+	   participate in the tier logic at all.
+
+	   A pure-CSS attempt came first and was rejected on measurement, not
+	   taste: the two-layer `background-attachment: local/scroll` scroll-shadow
+	   idiom is conditional by construction, but backgrounds paint BEHIND the
+	   tab text, and sampling the rendered edge pixels showed no legible
+	   signal in either theme. Recorded so nobody re-tries it.
+
+	   `mask-image` on `.pane-tabs` is safe: it is a paint effect (the -1px
+	   divider overlap still measures 0 in both tiers) and `.pane-tabs` is a
+	   SIBLING of `.menu-anchor`, so it cannot clip the anchored panels. */
+	.pane-tabs.masked {
+		mask-image: linear-gradient(
+			to right,
+			transparent 0,
+			#000 var(--fade-l),
+			#000 calc(100% - var(--fade-r)),
+			transparent 100%
+		);
 	}
 
 	/* Shared-row shape (>=560px of strip): `margin-left: auto` right-aligns
@@ -5912,6 +6023,45 @@
 		.pane-tab {
 			padding-left: 8px;
 			padding-right: 8px;
+		}
+	}
+
+	/* ── TAB LABELS: short form below 560px of strip ───────────────────────
+	   `Relationships` -> `Links`, visible text only. The accessible name is
+	   pinned to the full label by `aria-label` on the tab, so
+	   `getByRole('tab', { name: 'Relationships' })` — used by ~5 specs — keeps
+	   resolving, and a screen reader never hears "Links".
+
+	   This is what buys the fit REAL SLACK instead of a tuned zero. CI proved
+	   the previous derivation was environment-specific: `--font-ui` is
+	   `-apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif`,
+	   every entry of which misses on Linux, so `system-ui` resolves through
+	   fontconfig to different font FILES on a dev box and on ubuntu-latest.
+	   Same declaration, 17.5% wider glyphs, measured:
+
+	                       dev box    CI      delta
+	     four tab labels     297px   337px    +40px
+	     strip at 360 pane   312px   312px
+	     slack                +15     -25     <-- CI overflowed by 25px
+
+	   Ten candidate families forced locally spanned 273-297px, so CI is wider
+	   than the entire local envelope — this was not findable without the
+	   runner. `Relationships` alone was 84px of glyphs locally and 98px on CI.
+	   Swapping it for `Links` takes 51px off the row (measured), which turns
+	   CI's -25px into roughly +34px and every local font into +60px or more.
+
+	   ⚠ Same ordering rule as the padding block above: these tie with the base
+	   `.tab-label-*` rules at (0,2,0), so the query MUST stay after them. */
+	.tab-label-short {
+		display: none;
+	}
+
+	@container item-tab-strip (max-width: 559.99px) {
+		.tab-label-full {
+			display: none;
+		}
+		.tab-label-short {
+			display: inline;
 		}
 	}
 

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -5610,18 +5610,50 @@
 	   with `flex-basis: 100%` on `.strip-actions` while `nowrap` is still in
 	   force, `.pane-tabs` collapses to 0px.
 
-	   Deliberately NO `overflow`, `contain`, `clip-path`, `transform`,
-	   `filter` or `will-change` on this element — it is an ancestor of both
-	   `.menu-anchor` and QuickActionsMenu's anchor, and any of those would
-	   clip the anchored panels they position. The scroll rule goes on
-	   `.pane-tabs`, which is their SIBLING. (`container-type` itself is
-	   safe: it applies layout/style/inline-size containment but not PAINT
-	   containment, so the panels still escape — DR-3, re-verified in
-	   Chromium against this markup, including the mobile BottomSheet's
-	   `position: fixed` overlay, which still resolves against the viewport.
-	   Chromium reports `contain: none` here despite `container-type`; that
-	   is expected — do NOT "fix" it by adding `contain: layout`, which DOES
-	   trap the sheet's `position: fixed`.) */
+	   Deliberately NO `contain`, `transform`, `filter`, `perspective`,
+	   `will-change` or `clip-path` on this element. It is an ancestor of both
+	   `.menu-anchor` and QuickActionsMenu's anchor, and each of those breaks
+	   the anchored panels — but by DIFFERENT mechanisms, and being sloppy
+	   about which is which is how the audit went wrong once already:
+
+	     `transform` / `filter` / `perspective` / `will-change`
+	         make this a containing block for `position: fixed`, so the mobile
+	         BottomSheet would resolve against this 33px strip instead of the
+	         viewport. They do NOT add paint containment.
+	     `contain: layout` (and `strict` / `content`)
+	         same containing-block effect; `contain: paint` additionally clips.
+	     `clip-path`
+	         does NOT form that containing block, but DOES visually clip
+	         descendants — including fixed ones. Dangerous for a different
+	         reason, not the same one.
+	     `overflow`
+	         none of the above. NOT in this set, and not a problem here.
+
+	   That last one matters: the app already has five overflow ancestors above
+	   this strip — `.item-page`, `.item-page-host`, `.main-content`,
+	   `.app-shell`, `.app-layout`, all pre-existing scroll containers — and
+	   the panels are fine, because `overflow` alone forms no fixed containing
+	   block and the anchored panel is `position: absolute` sized to fit. So
+	   the rule is "do not add a containment/transform property HERE", not "no
+	   ancestor may ever scroll". Verified by walking the computed styles of
+	   the whole chain to `<html>` (nothing establishes a fixed containing
+	   block) and by corner hit-testing the open panel at 1440 plus the sheet
+	   at 430 and 360 (four corners owned, inside the viewport, every time).
+
+	   The horizontal scroll rule goes on `.pane-tabs`, which is the anchors'
+	   SIBLING, so it cannot clip them either way.
+
+	   `container-type: inline-size` is itself SAFE — and this is worth stating
+	   with its evidence, because reading the containment spec suggests
+	   otherwise: `container-type` implies layout containment, and layout
+	   containment is specified to make an element a containing block for fixed
+	   descendants. Chromium does not apply that here. Measured directly by
+	   injecting a `position: fixed; inset: 0` probe as a real child of this
+	   element at a 390px viewport: the probe laid out 390x844 (the full
+	   viewport), NOT 342x67 (the strip). Chromium also reports `contain: none`
+	   on this element despite `container-type`. Do NOT "fix" that by adding
+	   `contain: layout` — a three-way control confirmed that one DOES collapse
+	   a fixed child into the strip. */
 	.tab-strip {
 		display: flex;
 		align-items: center;
@@ -5861,11 +5893,21 @@
 	   padding is untouched so the strip's height and the active tab's 1px
 	   divider overlap do not move.
 
-	   Placement is load-bearing: this MUST sit after the base `.pane-tab`
-	   rule. A container query adds no specificity, so the two `.pane-tab`
-	   selectors tie and source order decides — written above the base rule it
-	   is silently overridden and the tabs still overflow. (Caught by
-	   measurement: `scrollWidth` stayed 321 at a 312px strip.) */
+	   ⚠ DO NOT MOVE THIS BLOCK ABOVE THE BASE `.pane-tab` RULE, and do not
+	   group it with the other `@container` blocks further up "for tidiness".
+
+	   A container query adds NO specificity. `.pane-tab` here and `.pane-tab`
+	   in the base rule are both (0,2,0) once Svelte's scoping hash is applied,
+	   so they tie and SOURCE ORDER is the only thing that decides. Placed
+	   before the base rule this whole block is silently discarded.
+
+	   The reason to spell that out: the failure is silent AND partial, so it
+	   does not look like a broken rule. The tabs still render, still scroll,
+	   and only the last one clips at 360px — which reads as "the 330 threshold
+	   is slightly off" rather than "these four declarations never applied at
+	   all". It cost a build to find and it is invisible to code review; the
+	   only thing that surfaces it is measuring `scrollWidth`, which stayed at
+	   321px inside a 312px strip instead of dropping to 297px. */
 	@container item-tab-strip (max-width: 330px) {
 		.pane-tab {
 			padding-left: 8px;

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -4328,29 +4328,22 @@
 			</div>
 		{/if}
 
-		<!-- Meta info -->
+		<!-- Provenance line. SCREEN-HIDDEN wholesale since TASK-2329 (DR-5):
+		     created/updated is provenance that the Activity and Versions tabs
+		     now own, and hiding the band whole — rather than its two spans —
+		     is what removes the stray `.meta-sep` "·" and the band's bottom
+		     margin along with it.
+
+		     It stays in the DOM because it is load-bearing for PRINT: the
+		     `@media print` block resets it to `display: block` and gives it
+		     the `border-bottom` that divides the page-1 document header from
+		     the properties card (BUG-626). The transient Saved / Synced
+		     indicators moved OUT of here into `.strip-actions` below — they
+		     are live status, not provenance, and print hides them anyway. -->
 		<div class="meta-info">
 			<span title={new Date(item.created_at).toLocaleString()}>Created {relativeTime(item.created_at)} by {item.created_by || 'unknown'}</span>
 			<span class="meta-sep">·</span>
 			<span title={new Date(item.updated_at).toLocaleString()}>Updated {relativeTime(item.updated_at)}</span>
-			<span class="save-status" class:saving={saveStatus === 'saving'} class:saved={saveStatus === 'saved'} class:visible={saveStatus !== 'idle'}>
-				{#if saveStatus === 'saving'}Saving...{:else}✓ Saved{/if}
-			</span>
-			{#if collabProvider}
-				<!-- Pending-sync indicator (TASK-1264). Visible only while
-				     the WS provider exists, which means: canEdit && !rawMode.
-				     Read-only / share-page / raw mode never see this badge.
-				     Colour map matches the four-state machine in
-				     wsProvider.svelte.ts: green=synced, yellow=connecting/
-				     reconnecting, red=offline. -->
-				<span
-					class="collab-state collab-state-{collabProvider.state}"
-					title={collabStateTitle(collabProvider.state)}
-				>
-					<span class="collab-state-dot" aria-hidden="true"></span>
-					<span class="collab-state-label">{collabStateLabel(collabProvider.state)}</span>
-				</span>
-			{/if}
 		</div>
 
 		<!-- Tab strip (PLAN-2326 / TASK-2328). One band: the tablist plus the
@@ -4424,6 +4417,37 @@
 			     containing block for the anchored Menu, so lifting the `⋯` button
 			     out of it on its own would break the panel's positioning. -->
 			<div class="strip-actions">
+				<!-- Saved / Synced, relocated out of `.meta-info` (TASK-2329).
+				     They lead the group so the icon controls stay flush right.
+
+				     `.collab-state-synced` keeps its class AND its visibility at
+				     every tier — it is `SYNCED_BADGE_SELECTOR` in
+				     `web/e2e/lib/collab-helpers.ts`, asserted visible across
+				     several suites including inside a narrow docked pane. Only
+				     its `.collab-state-label` word folds in the compact tier,
+				     and only visually — it stays in the accessibility tree, so
+				     the badge is never a colour-only status. The coloured dot
+				     (the primary signal) always renders. The
+				     badge's CSS was never scoped through `.meta-info`, so the
+				     move is purely positional. -->
+				<span class="save-status" class:saving={saveStatus === 'saving'} class:saved={saveStatus === 'saved'} class:visible={saveStatus !== 'idle'}>
+					{#if saveStatus === 'saving'}Saving...{:else}✓ Saved{/if}
+				</span>
+				{#if collabProvider}
+					<!-- Pending-sync indicator (TASK-1264). Visible only while
+					     the WS provider exists, which means: canEdit && !rawMode.
+					     Read-only / share-page / raw mode never see this badge.
+					     Colour map matches the four-state machine in
+					     wsProvider.svelte.ts: green=synced, yellow=connecting/
+					     reconnecting, red=offline. -->
+					<span
+						class="collab-state collab-state-{collabProvider.state}"
+						title={collabStateTitle(collabProvider.state)}
+					>
+						<span class="collab-state-dot" aria-hidden="true"></span>
+						<span class="collab-state-label">{collabStateLabel(collabProvider.state)}</span>
+					</span>
+				{/if}
 				<!-- Star is a per-user, itemId-keyed REST toggle available to viewers too,
 				     and cannot collide across sides — so it is NOT frozen while peeking
 				     (BUG-2263). No canEdit or peeking gate. -->
@@ -4536,14 +4560,19 @@
 						sync without a separate API call.
 
 						Split into icon + count spans for TASK-2329's compact tier,
-						exactly as the children badge above. This badge has NO
-						`aria-label`, so its accessible name is computed from the
-						content — hence no `aria-hidden` on the icon and the literal
-						space between the spans: both would change the name.
+						exactly as the children badge above.
+
+						TASK-2328 left this badge without an `aria-label` so its
+						accessible name stayed the computed "📎 4". TASK-2329's
+						compact tier `display:none`s `.badge-icon`, which drops it
+						out of the accessibility tree too and would degrade that
+						name to a bare "4". An explicit label — mirroring the
+						children badge's — pins the name across BOTH tiers instead.
 					-->
 					<button
 						class="action-btn"
 						title="Mentioned in {backlinksCount} other item{backlinksCount === 1 ? '' : 's'}"
+						aria-label="Jump to Mentions — mentioned in {backlinksCount} other item{backlinksCount === 1 ? '' : 's'}"
 						onclick={() => jumpToSection('relationships', 'item-backlinks')}
 					>
 						<span class="badge-icon">📎</span> <span class="badge-count">{backlinksCount}</span>
@@ -4578,6 +4607,30 @@
 						focusKey={paneMenuView}
 					>
 						{#if paneMenuView === 'root'}
+							<!-- Star also lives here, not only as the strip chip
+							     (TASK-2329, Codex round 2). The compact tier folds
+							     the chip away with `display: none`, and the mobile
+							     overlay is ALWAYS compact — so without this row
+							     starring would be unreachable on phones entirely.
+							     PLAN-2326's premise is "zero affordances removed",
+							     which a CSS fold only honours if the action still
+							     has a home. Rendered at every tier: a duplicate row
+							     in an overflow menu costs nothing, and hiding it in
+							     the full tier would mean container-querying inside
+							     the Menu — whose mobile form is a BottomSheet, i.e.
+							     exactly the surface that needs the row most.
+							     Unconditional, like the chip: starring is a
+							     per-user REST toggle open to viewers too. -->
+							<MenuItem
+								icon={starredStore.isStarred(item.id) ? '★' : '☆'}
+								onclick={() => {
+									if (!item) return;
+									paneMenuOpen = false;
+									starredStore.toggle(wsSlug, item.slug, item.id);
+								}}
+							>
+								{starredStore.isStarred(item.id) ? 'Unstar' : 'Star'}
+							</MenuItem>
 							{#if graphFocusRef}
 								<MenuItem icon="🕸" onclick={() => { paneMenuOpen = false; openGraph(); }}>
 									Dependency graph
@@ -5620,6 +5673,101 @@
 		min-width: 0;
 	}
 
+	/* Saved / Synced were relocated here out of `.meta-info` (TASK-2329). They
+	   each carried their own `margin-left` for spacing inside that band; the
+	   group's `gap` owns spacing now, so the margin would just double it.
+	   Overridden under `.strip-actions` rather than removed from the base
+	   rules so the badges keep their standalone styling. */
+	.strip-actions .save-status,
+	.strip-actions .collab-state {
+		margin-left: 0;
+	}
+
+	/* ── Compact tier (PLAN-2326 DR-7 / DR-9 / DR-10) ──────────────────────
+	   `@container`, NOT `@media`: the docked pane is
+	   `flex: 0 0 var(--pane-width, clamp(360px, 38%, 640px))` — a width the
+	   user drags and we persist, decoupled from the viewport — so a 360px
+	   pane on a 1440px screen still matches `@media (min-width: 900px)`.
+	   Only the container knows how much room the strip actually has.
+
+	   THRESHOLD — 700px, measured rather than assumed (DR-10). The strip's
+	   content box tops out at 912px on the full page at ANY monitor width
+	   (`--content-max-width: 960px` less 2x `--space-6` — verified identical
+	   at 1440 and 2560), so the mock's 900px boundary would have made the
+	   compact tier the near-universal state. Measured strip widths bracket
+	   700 cleanly:
+
+	     full page                     892-912px -> full
+	     full page + docked pane       526-678px -> compact
+	     docked pane                   312-672px -> compact
+	     mobile overlay                    342px -> compact
+
+	   The pane's 672px ceiling is `PaneHost.svelte`'s JS `PANE_WIDTH_MAX =
+	   720` less the pane's 2x24px padding — a harder bound than the CSS
+	   `clamp()`'s 640, and the tightest margin the threshold has (28px). If
+	   that constant ever grows past ~750 a dragged-wide pane would enter the
+	   full tier, which is the correct outcome anyway: it would have the room.
+
+	   So the rule is "does the full tier fit", not "which surface is this":
+	   a full page whose master column has been squeezed by an open pane
+	   compacts too, which is the point of querying the container. (The full
+	   tier's own worst-case content measures ~722px — 321px of tabs plus the
+	   widest observed action group. 700 is 22px optimistic, which only bites
+	   in the ~30px-wide viewport band where a pane-squeezed master lands
+	   between the two; there the tab list just scrolls a few px, silently,
+	   exactly as DR-9 designed it to.)
+
+	   TWO tiers, not the mock's three (DR-7): the `<600px` tier would have
+	   required duplicate badge markup outside this subtree.
+
+	   The star folds by `display: none` with the node RETAINED (DR-11) —
+	   `.star-btn` must stay in the DOM for the BUG-2263 freeze assertions.
+	   `.collab-state` itself never folds (it is `SYNCED_BADGE_SELECTOR`,
+	   asserted visible inside narrow panes); only its label word folds, and
+	   VISUALLY only — see the sr-only note on that rule. The coloured dot,
+	   the primary signal, always renders. */
+	@container item-tab-strip (max-width: 699px) {
+		.badge-icon {
+			display: none;
+		}
+		.star-btn {
+			display: none;
+		}
+		/* VISUALLY hidden, not `display: none` (Codex round 2). The dot is
+		   `aria-hidden`, so this label is the badge's ONLY textual state —
+		   `display: none` would drop it out of the accessibility tree and
+		   leave a colour-only indicator, which is exactly the failure mode
+		   the label exists to prevent. The clip-rect idiom takes it out of
+		   the visual flow (0 layout width, no paint) while keeping it
+		   readable by assistive tech. `clip-path` here is on a LEAF span —
+		   not on `.tab-strip` or any ancestor of `.menu-anchor`, where it
+		   would clip the anchored panels. */
+		.collab-state-label {
+			position: absolute;
+			width: 1px;
+			height: 1px;
+			padding: 0;
+			margin: -1px;
+			overflow: hidden;
+			clip: rect(0 0 0 0);
+			clip-path: inset(50%);
+			white-space: nowrap;
+			border: 0;
+		}
+		/* `.save-status` sits at `opacity: 0` when idle, which still RESERVES
+		   its ~48px. Harmless in the 912px full tier; in a 360px pane that is
+		   18% of the strip taken by something invisible, and every px here
+		   comes straight out of the tab list's scrollport (38px -> 94px with
+		   this rule). Dropping it from the flow costs no button movement: the
+		   group is right-aligned and `.save-status` LEADS it, so a save
+		   extends the group's left edge and nothing to its right shifts. The
+		   only casualty is the 0.2s fade-OUT at the end of the 2s `saved`
+		   window (`display: none` snaps); the fade-IN still plays. */
+		.save-status:not(.visible) {
+			display: none;
+		}
+	}
+
 	.pane-tab {
 		padding: 7px 11px 9px;
 		font-size: 0.92em;
@@ -5886,6 +6034,18 @@
 		white-space: nowrap;
 		flex-shrink: 0;
 	}
+	/* SCREEN-HIDDEN since TASK-2329: the ref already renders in the
+	   breadcrumb tail on the full page and in `.pane-header-ref-text` inside
+	   the pane, so the chip was the second or third copy within ~40px.
+
+	   Kept in the DOM for PRINT, where it IS the document header's ref
+	   (`order: 2` flips it right of the title). The print block below
+	   restores `display` EXPLICITLY — same specificity, later in source, so
+	   it wins inside `@media print`. Without that reset this rule would
+	   survive into print and drop the ref from page 1 (BUG-626 / DR-5). */
+	.title-row .item-ref {
+		display: none;
+	}
 	.title {
 		display: block;
 		font-size: 1.6em;
@@ -5970,15 +6130,20 @@
 		line-height: 1;
 	}
 
-	/* Meta */
+	/* Meta — the created/updated provenance line.
+
+	   SCREEN-HIDDEN WHOLESALE (TASK-2329 / DR-5). Hiding the band rather than
+	   its spans is deliberate: a spans-only hide would leave the `.meta-sep`
+	   "·" orphaned on its own row plus the band's bottom margin. Activity and
+	   Versions are the tabs that own provenance now.
+
+	   The element stays in the DOM because print needs it: the `@media print`
+	   block restores `display: block` and re-declares every property it cares
+	   about there (font-size, colour, margins, and the `border-bottom` that
+	   divides the page-1 document header from the properties card — BUG-626),
+	   so none of the old screen-side flex properties are missed. */
 	.meta-info {
-		display: flex;
-		align-items: center;
-		gap: var(--space-2);
-		font-size: 0.8em;
-		color: var(--text-muted);
-		margin-bottom: var(--space-2);
-		flex-wrap: wrap;
+		display: none;
 	}
 	.meta-sep { color: var(--text-muted); }
 	.save-status {
@@ -6698,6 +6863,14 @@
 			border: none;
 		}
 		.title-row .item-ref {
+			/* MANDATORY reset (TASK-2329 / DR-5). The chip is screen-hidden
+			   with `display: none` now, and this rule previously set every
+			   print property EXCEPT `display` — so without this line the
+			   screen hide survives into print and the ref disappears from the
+			   page-1 document header, regressing BUG-626. `block` is what the
+			   old `inline` computed to anyway once `.title-row`'s print
+			   `display: flex` blockified it, so print output is unchanged. */
+			display: block;
 			order: 2;
 			flex: 0 0 auto;
 			font-size: 10pt;
@@ -6740,7 +6913,14 @@
 
 		/* Meta info subtitle (created / updated by). Border-bottom
 		   separates the page-1 document header block from the
-		   properties card below. BUG-626. */
+		   properties card below. BUG-626.
+
+		   `display: block` was already here before TASK-2329 and is what
+		   makes the band's wholesale SCREEN hide safe — it un-hides the
+		   provenance line for print. Do not drop it. Saved / Synced used to
+		   live inside this band and moved to `.strip-actions`; they were
+		   already print-hidden by the global selectors above, so the printed
+		   text is unchanged. */
 		.meta-info {
 			font-size: 9pt;
 			color: #555;


### PR DESCRIPTION
TASK-2329 of **PLAN-2326**. Five commits: the original header work, a revert of the part of it that was wrong, the actual mobile fix, a boundary re-derivation + Star gating, and a comment-accuracy pass.

> **Body rewritten.** The first version of this description documented a 700px single-fold design that Dave's review of the running build rejected as unusable on phones. That design is reverted in `8c3e0c2b` and replaced in `e97d7425`. Nothing below describes the old approach except where it is the "before" measurement.

## What was wrong

Combining the tablist and the action group on one row is not survivable at phone widths, and no amount of folding fixes it. The four tab labels are a fixed **321px**; even a hypothetical action group of nothing but `⋯` (38px) needs 359px against the **342px** a 390px phone has.

Measured on the **widest** common phone, 430px, on `bd030124`:

| | strip | tabs need | tabs shown | clipped |
|---|---|---|---|---|
| 430px phone | 382px | 321px | 179px | **2 of 4** |
| 390px phone | 342px | 321px | 139px | **3 of 4** |
| 360px phone | 312px | 321px | 109px | **3 of 4** |

…with `scrollbar-width: none`, so no hint the missing tabs existed.

## `8c3e0c2b` — revert

- **Saved / Synced go back inside `.meta-info`**, byte-identical to main. Relocating them into `.strip-actions` pushed 115px into a strip that was already overflowing and inflated the badges (39→48, 40→50) by escaping `.meta-info`'s `0.8em`.
- **`.save-status:not(.visible) { display: none }` reverted** — measurably harmful. In a real 448px pane, toggling it moved the action group 87→143px and the tab scrollport 301→245px: a 56px reflow on every save cycle, under a hidden scrollbar.
- `.collab-state-label`'s sr-only fold, now dead — the query container *is* `.tab-strip` and the badge no longer lives inside it.
- **`.meta-info { display: none }` reverted for SEQUENCING**, not because it was wrong. `.collab-state-synced` is `SYNCED_BADGE_SELECTOR` and five specs across four suites assert it visible. It returns once the badges have a new home.

**Kept:** the `@media print { .title-row .item-ref { display: block } }` reset — a latent-bug fix predating this PR, since main's print rule sets twelve properties and no `display`, so *any* screen-side `display:none` on the chip would silently drop the ref from the page-1 document header (BUG-626). Also the screen-side ref hide, the backlinks `aria-label`, the ⋯ Star row, and the capstone spec's strengthened assertions.

## `e97d7425` — the fix: un-combine below 560px

    < 560       split — actions own a row, ABOVE the tabs
    560 - 639   fold  — one row, badge icons → bare counts, star folds
    <= 330      tab padding 11px → 8px (the last 24px needed at 312px)

Below 560 **the star and the badge icons come back** — the single `<700` fold hid them on every phone and in the default-width docked pane, exactly the widths with the least need to economise once the actions have their own row.

**Actions ABOVE the tabs** (`order: -1`, visual only). `.tab-strip` owns the bottom divider and `.pane-tab.on` overlaps it by 1px via `margin-bottom: -1px`; keeping the tablist last preserves that — measured identical (offset 0) in both shapes. Actions-below would orphan the underline ~31px above the divider.

### Two placement traps, both caught by measurement rather than reasoning

1. **`flex-wrap` must be in the base `.tab-strip` rule, not the `@container` block.** A container query cannot style its own query container. Verified by mutation: moved inside, `nowrap` stays in force while `flex: 0 0 100%` still applies to `.strip-actions`, and **`.pane-tabs` collapses to 0px** with all four tabs clipped at every phone width. Both new tests go red on it.
2. **The `<= 330` rule must sit *after* the base `.pane-tab` rule.** Container queries add no specificity, so the selectors tie and source order decides. Written above it, the tabs kept `scrollWidth: 321` inside a 312px strip and one tab stayed clipped.

## Measured (worst case: both badges + quick actions + owner rights)

**Desktop — must be unchanged, and is, to the pixel:**

| viewport | rows | header | tabs | underline |
|---|---|---|---|---|
| 1440 / 1200 | 1 | 148.8px | fit | 0 |
| 1024 / 768 | 1 | 174.8px | fit | 0 |

**Phone — tabs now fit where two to three were clipped:**

| width | strip | tabs (need / shown) | before |
|---|---|---|---|
| 360 | 312 | 297 / 297 ✓ | 321 / 109, 3 clipped |
| 390 | 342 | 321 / 321 ✓ | 321 / 139, 3 clipped |
| 412 | 364 | 321 / 321 ✓ | 321 / 161, 3 clipped |
| 430 | 382 | 321 / 321 ✓ | 321 / 179, 2 clipped |

Docked pane 360 / 448 / 600 → split; 720 (`PANE_WIDTH_MAX`, a 672px strip) → **full**, after the boundary re-derivation below.

**Container-query proof:** a 360px pane on a **1920px** viewport splits, while the full page at that same viewport stays on one row. No media query can do that.

**Cost:** the strip goes 33px → 67px on phones, so the header grows ~34px there. That is the trade for four reachable tabs.

**Also audited:** `.menu-anchor` gained no `overflow`/`contain`/`transform`/`filter`/`clip-path`/`will-change` ancestor at any width (walked the computed styles); the desktop ⋯ panel and the 430/360 bottom sheets own all four corners by hit-test; the arrow-key roving walk still visits exactly the four tabs in a 360px pane. Chromium reports `contain: none` on `.tab-strip` despite `container-type` — expected, and deliberately not "fixed" with `contain: layout`, which *does* trap the sheet's `position: fixed`.

## `2c05297f` — re-derive the boundary, gate the Star row

**The 699 upper boundary was measuring the wrong thing.** It was derived while Saved/Synced still sat in `.strip-actions`, worth 115px of the group. Re-measured post-salvage on the worst-case item:

| action group | width | shared row needs |
|---|---|---|
| folded (icons off, star off) | 191px | 524px |
| full | 274px | **607px** |
| full, counts inflated to an absurd `199/199` + `999` | 301px | 634px |

So 699 was folding the star and badge icons on the two **widest** surfaces that fold at all — a pane dragged to its 672px max, and a 1440px page with a pane docked at 678px — both with ~65px to spare. Boundary moves to **639** (full at 640+). The 560 split boundary is measurement-backed and unchanged: the folded row needs 524px, so it carries 36px of slack.

**The Star `⋯` row is now gated to exactly the fold band.** It was unconditional, costing every user a permanent extra row. Now hidden by default and shown only by the same query that folds `.star-btn` — the affordance exists in exactly one place at every width, never zero and never two, and `display: none` keeps the hidden one out of the a11y tree. Verified at eight widths, both directions; the 390px case exercises the mobile BottomSheet, confirming the container query reaches into it.

Two more traps this turned up, neither visible by reading:

3. **`.menu-anchor :global(.strip-star-row)`, not a bare `:global()`.** MenuItem's own `.mi { display: flex }` carries that component's scope hash and is `(0,2,0)`; a bare global class selector is `(0,1,0)` and loses. Measured: the row rendered `display: flex` at all eight widths — symmetry broken toward showing the star *twice*.
4. **A sub-pixel gap between the bands** (Codex). Encoded as adjacent integers, a strip at 559.5px matched *neither* query and fell back to the full shared row. Container widths are not integers — the pane default is `clamp(360px, 38%, 640px)`. Fixed by nesting the blocks (fold ⊃ split, with the split un-folding) *and* using `.99` bounds. Verified by forcing the strip to 559.50 / 559.99 / 560.50 / 639.50 / 639.99 / 640.50: all six now correct, four were wrong before. Regression test added — it is the only one that produces fractional widths.

That is **four** specificity/order/precision traps in one small block of container queries. Container queries add no specificity, and their bounds are not integers; every rule here had to be checked against what it overrides.

**Slow drag through the boundaries:** 563 → 688px in 5px steps produced exactly three distinct states across 27 samples — split (strip 515, 67px tall, star shown) → fold at strip 560 (33px, star folded) → full at strip 640 (33px, star shown). Tabs fit in every sample. Deliberate, not glitchy.

## Tests

`pane-tab-strip-tiers.spec.ts` rewritten — its old "strip stays ONE row" assertion contradicted this design, and its worst-case test asserted the *mechanism* ("every tab reachable via scroll") rather than the *outcome*, which stayed true and useless at a 94px scrollport with no scrollbar. Five tests now, all asserting outcomes: the container-driven split at a fixed viewport, the 360px worst case asserting tabs **fit**, the fold band, the sub-pixel boundary guard, and Star-affordance symmetry across four widths.

`pane-full-page-capstone.spec.ts` star assertions strengthened (DR-11): `toBeEnabled()` requires *attached*, not visible, so a CSS fold would leave them green while asserting nothing.

## Gates

- `cd web && npm run check` — 0 errors, 6 pre-existing warnings
- `make check` — Go tests all ok, govulncheck "No vulnerabilities found", svelte-check 0 errors, 490/490 web unit tests
- `make install` + Playwright measurement on every surface above, both themes
- Tier spec 5/5, capstone 8/8; full e2e 81 passed with **one cross-spec flake per run** — `pane-collab-teardown:137` on one run, `pane-content-link-anchors:238` on the next, a different test each time and both green in isolation. That is BUG-2334's shared-instance toast interference, not a regression.
- Codex review: **CLEAN**

Currently **draft** only because it was requested mid-review; the reviewer has since said non-draft is fine. Flipping draft→ready is left to the reviewer. Refs TASK-2329, PLAN-2326.

<details><summary>Star affordance — verified at the accessibility-tree level</summary>

`display: none` removing the row from the a11y tree was an assertion worth proving rather than stating. `ariaSnapshot()` with the ⋯ open:

- **390px phone** (split, bottom sheet) — menuitems: `Dependency graph`, `Move to collection…`, `Share…`, `Delete…`. **No `Star`.** The row is in the sheet's DOM but `display: none`, so a `querySelectorAll` hit is not evidence it is announced.
- **620px pane** (fold, anchored panel) — menuitems include **`menuitem "Star"`**, and clicking it really stars: `chip.starred false → true`, title `Star → Unstar`, row label `☆ Star → ★ Unstar`.

Announced in exactly one tier.
</details>

<details><summary>Containment audit — corrected</summary>

An earlier claim of "zero risky ancestors" was wrong: that probe excluded `auto` and stopped walking at `.item-page`. Re-audited to `<html>`, there are five pre-existing overflow ancestors (`.item-page`, `.item-page-host`, `.main-content`, `.app-shell`, `.app-layout`). None is a problem — `overflow` forms no containing block for `position: fixed`.

`container-type: inline-size` reads as unsafe in the containment spec (layout containment is specified to form a fixed containing block). Chromium does not apply that: a `position: fixed; inset: 0` probe injected as a real child of `.tab-strip` at a 390px viewport laid out **390×844** (full viewport), not **342×67** (the strip). `contain: layout` *does* collapse it — hence the standing warning not to add it.
</details>
