### PR TITLE
revert(web): restore the pre-TASK-2328 item action bar, then make it fit (PLAN-2326 overturned)

### DIFF
--- a/web/e2e/item-action-bar-band.spec.ts
+++ b/web/e2e/item-action-bar-band.spec.ts
@@ -11,23 +11,30 @@ import type { SuiteFixture } from './fixtures';
  * labelled control shares one width and height (the ⋯ overflow trigger is the
  * deliberate exception — it sizes to its glyph).
  *
- * The reason this file exists rather than a unit test is the third assertion.
+ * The reason this file exists rather than a unit test is the sheet assertion.
  * `.meta-actions` carries `container-type: inline-size` so the narrow-width
  * padding rule can key off the BAND's width — the band lives in a docked pane
  * whose width is user-dragged and decoupled from the viewport, so a media query
- * cannot see it. Per the CSS Containment spec that ought to apply layout
- * containment and therefore make the band a containing block for
- * fixed-position descendants — and BOTH menus in the band render a
- * `position: fixed` BottomSheet on mobile, INSIDE the band, with no portal. If
- * that reading were what shipping engines implement, the mobile sheet would
- * collapse from the viewport into a ~342x34 strip: unusable.
+ * cannot see it. Both menus in the band render a non-portaled `position: fixed`
+ * BottomSheet on mobile, INSIDE that container.
  *
- * Measured in Chromium, it does not: the overlay resolves against the viewport
- * despite being a DOM descendant of the container. A Codex review raised this
- * as a P1 from the spec text and measurement refuted it. That makes it exactly
- * the class of thing to pin down in a test rather than argue about — if a
- * future engine version aligns to the stricter reading, this fails loudly
- * instead of silently shipping a broken mobile sheet.
+ * That is safe, but only narrowly: `container-type: inline-size` applies style
+ * and inline-size containment and NOT layout containment
+ * (css-conditional-5 §container-type). Layout containment is what makes an
+ * element a containing block for fixed-position descendants, so the sheet keeps
+ * resolving against the viewport. Add `contain: layout` to this band — or a
+ * transform/filter, which establish a containing block by a different route —
+ * and the sheet collapses into a ~342x34 strip instead.
+ *
+ * Hence a test rather than a comment: the invariant depends on the band NOT
+ * acquiring a property that a future styling change could plausibly add, and
+ * the failure mode is an unusable mobile sheet rather than anything visible on
+ * desktop. Mutation-tested by adding `contain: layout` to `.meta-actions`,
+ * which fails this spec on overlay width.
+ *
+ * (PLAN-2326's DR-3 asserts `container-type: inline-size` implies
+ * `contain: layout style inline-size`. It does not. A Codex review reached the
+ * opposite conclusion from the same wrong premise. Measure, don't infer.)
  *
  * jsdom computes no layout, so none of this is unit-testable.
  */
@@ -148,30 +155,55 @@ test('action bar: the mobile bottom sheet is not trapped by the band container',
 	const vp = page.viewportSize()!;
 	expect(bandBox.height).toBeLessThan(vp.height / 4);
 
-	await page.locator('button.pane-more-btn').click();
+	// Both menus in the band get their own pass. They share the Menu +
+	// BottomSheet path today, but they are separate wrappers with separate
+	// styling (.menu-anchor vs .quick-actions-menu), so asserting one does not
+	// establish the other.
+	for (const trigger of [
+		{ label: '⋯ overflow', sel: 'button.pane-more-btn' },
+		{ label: '⚡ quick actions', sel: 'button.trigger-btn[title="Quick actions"]' },
+	]) {
+		const btn = page.locator(trigger.sel);
+		if ((await btn.count()) === 0) {
+			// The ⚡ trigger only renders when the collection has quick actions or
+			// the viewer is an owner. Fail rather than skip silently: on this
+			// fixture the admin IS the owner, so absence means something changed.
+			throw new Error(`${trigger.label} trigger not present — expected it on an owner-viewed item`);
+		}
+		await btn.first().click();
 
-	const overlay = page.locator('.bs-overlay');
-	await expect(overlay).toBeVisible();
+		const overlay = page.locator('.bs-overlay');
+		await expect(overlay, `${trigger.label}: sheet opens`).toBeVisible();
 
-	// The overlay must be a DOM descendant of the container — otherwise this
-	// test proves nothing about containment (e.g. if BottomSheet ever starts
-	// portaling to <body>, delete this test rather than letting it pass
-	// vacuously).
-	expect(
-		await overlay.evaluate((el) => !!el.closest('.meta-actions')),
-		'sheet is rendered inside .meta-actions — if this fails, BottomSheet now portals and this test is moot',
-	).toBe(true);
+		// The overlay must be a DOM descendant of the container — otherwise this
+		// test proves nothing about containment (e.g. if BottomSheet ever starts
+		// portaling to <body>, delete this test rather than letting it pass
+		// vacuously).
+		expect(
+			await overlay.evaluate((el) => !!el.closest('.meta-actions')),
+			`${trigger.label}: sheet is rendered inside .meta-actions — if this fails, BottomSheet now portals and this test is moot`,
+		).toBe(true);
 
-	// The actual invariant: despite living inside the query container, the
-	// fixed overlay resolves against the viewport.
-	const box = (await overlay.boundingBox())!;
-	expect(Math.round(box.width), 'overlay spans the viewport width').toBe(vp.width);
-	expect(Math.round(box.height), 'overlay spans the viewport height').toBe(vp.height);
-	expect(Math.round(box.y), 'overlay starts at the top of the viewport, not at the band').toBe(0);
+		// The actual invariant: despite living inside the query container, the
+		// fixed overlay resolves against the viewport.
+		const box = (await overlay.boundingBox())!;
+		expect(Math.round(box.width), `${trigger.label}: overlay spans the viewport width`).toBe(vp.width);
+		expect(Math.round(box.height), `${trigger.label}: overlay spans the viewport height`).toBe(vp.height);
+		expect(
+			Math.round(box.y),
+			`${trigger.label}: overlay starts at the top of the viewport, not at the band`,
+		).toBe(0);
 
-	// And the sheet itself is a usable size, not a collapsed strip.
-	const sheet = page.locator('.bs-sheet');
-	await expect(sheet).toBeVisible();
-	const sheetBox = (await sheet.boundingBox())!;
-	expect(sheetBox.height, 'sheet is a real panel, not a collapsed strip').toBeGreaterThan(100);
+		// And the sheet itself is a usable size, not a collapsed strip.
+		const sheet = page.locator('.bs-sheet');
+		await expect(sheet).toBeVisible();
+		const sheetBox = (await sheet.boundingBox())!;
+		expect(
+			sheetBox.height,
+			`${trigger.label}: sheet is a real panel, not a collapsed strip`,
+		).toBeGreaterThan(100);
+
+		await page.keyboard.press('Escape');
+		await expect(overlay, `${trigger.label}: sheet closes for the next pass`).toHaveCount(0);
+	}
 });

--- a/web/e2e/item-action-bar-band.spec.ts
+++ b/web/e2e/item-action-bar-band.spec.ts
@@ -1,0 +1,177 @@
+import { test, expect } from './fixtures';
+import { browserLogin } from './lib/collab-helpers';
+import type { APIRequestContext } from '@playwright/test';
+import type { SuiteFixture } from './fixtures';
+
+/**
+ * Item action bar (`.meta-actions`) layout invariants.
+ *
+ * This band was reverted out of PLAN-2326's `.tab-strip` merge and then given
+ * two properties by hand: it stays ONE row at every container width, and every
+ * labelled control shares one width and height (the ⋯ overflow trigger is the
+ * deliberate exception — it sizes to its glyph).
+ *
+ * The reason this file exists rather than a unit test is the third assertion.
+ * `.meta-actions` carries `container-type: inline-size` so the narrow-width
+ * padding rule can key off the BAND's width — the band lives in a docked pane
+ * whose width is user-dragged and decoupled from the viewport, so a media query
+ * cannot see it. Per the CSS Containment spec that ought to apply layout
+ * containment and therefore make the band a containing block for
+ * fixed-position descendants — and BOTH menus in the band render a
+ * `position: fixed` BottomSheet on mobile, INSIDE the band, with no portal. If
+ * that reading were what shipping engines implement, the mobile sheet would
+ * collapse from the viewport into a ~342x34 strip: unusable.
+ *
+ * Measured in Chromium, it does not: the overlay resolves against the viewport
+ * despite being a DOM descendant of the container. A Codex review raised this
+ * as a P1 from the spec text and measurement refuted it. That makes it exactly
+ * the class of thing to pin down in a test rather than argue about — if a
+ * future engine version aligns to the stricter reading, this fails loudly
+ * instead of silently shipping a broken mobile sheet.
+ *
+ * jsdom computes no layout, so none of this is unit-testable.
+ */
+
+function authHeaders(fixture: SuiteFixture) {
+	return { Authorization: `Bearer ${fixture.apiToken}`, 'Content-Type': 'application/json' };
+}
+
+async function seedItem(
+	fixture: SuiteFixture,
+	request: APIRequestContext,
+	title: string,
+) {
+	const resp = await request.post(
+		`/api/v1/workspaces/${fixture.workspaceSlug}/collections/tasks/items`,
+		{
+			headers: authHeaders(fixture),
+			data: { title, fields: JSON.stringify({ status: 'open' }), content: '' },
+		},
+	);
+	if (!resp.ok()) throw new Error(`item create failed (${resp.status()}): ${await resp.text()}`);
+	return (await resp.json()) as { id: string; slug: string };
+}
+
+/** Geometry of every control in the band, in DOM order. */
+async function bandControls(page: import('@playwright/test').Page) {
+	return page.evaluate(() => {
+		const bar = document.querySelector('.meta-actions');
+		if (!bar) throw new Error('.meta-actions not found');
+		const kids = [...bar.children];
+		const box = bar.getBoundingClientRect();
+		const controls = kids.map((k) => {
+			const btn = (k.matches('button') ? k : k.querySelector('button')) as HTMLElement;
+			const r = btn.getBoundingClientRect();
+			return {
+				isMore: btn.classList.contains('pane-more-btn'),
+				w: Math.round(r.width * 10) / 10,
+				h: Math.round(r.height * 10) / 10,
+				// scrollWidth > clientWidth means the label is being cut off.
+				clipped: btn.scrollWidth - btn.clientWidth > 0,
+			};
+		});
+		const tallest = Math.max(...kids.map((k) => k.getBoundingClientRect().height));
+		return {
+			// A wrap shows up as the band growing taller than its tallest item.
+			wrapped: box.height > tallest + 2,
+			controls,
+		};
+	});
+}
+
+test('action bar: labelled controls share one width and height; ⋯ is exempt', async ({
+	page,
+	fixture,
+	request,
+}, testInfo) => {
+	test.skip(
+		testInfo.project.name !== 'desktop-chromium',
+		'uniform-sizing assertion is about the wide-container case',
+	);
+	test.setTimeout(30_000);
+
+	const it = await seedItem(fixture, request, 'action bar uniform sizing');
+	await browserLogin(page);
+	await page.goto(`/${fixture.adminUsername}/${fixture.workspaceSlug}/tasks/${it.slug}`);
+	await expect(page.locator('.title', { hasText: 'action bar uniform sizing' })).toBeVisible();
+	await expect(page.locator('.meta-actions')).toBeVisible();
+
+	const { wrapped, controls } = await bandControls(page);
+	expect(controls.length, 'band should render at least the star and ⋯ controls').toBeGreaterThan(1);
+	expect(wrapped, 'band must never wrap to a second row').toBe(false);
+
+	const labelled = controls.filter((c) => !c.isMore);
+	const more = controls.find((c) => c.isMore);
+	expect(more, 'the ⋯ overflow trigger should be present').toBeTruthy();
+
+	// One height for every control, ⋯ included.
+	const heights = [...new Set(controls.map((c) => c.h))];
+	expect(heights, `all controls share one height, got ${heights.join(',')}`).toHaveLength(1);
+
+	// One width for the labelled controls. Guarded to the wide case: a label
+	// wider than the 70px basis (e.g. a 3-digit child count) legitimately grows
+	// past it rather than truncating, and this seeded item has no such badge.
+	const widths = [...new Set(labelled.map((c) => c.w))];
+	expect(widths, `labelled controls share one width, got ${widths.join(',')}`).toHaveLength(1);
+
+	// The ⋯ is the deliberate exception: a control, not a labelled value.
+	expect(more!.w, '⋯ sizes to its glyph rather than the uniform width').toBeLessThan(widths[0]);
+
+	expect(controls.some((c) => c.clipped), 'no control may clip its label').toBe(false);
+});
+
+test('action bar: the mobile bottom sheet is not trapped by the band container', async ({
+	page,
+	fixture,
+	request,
+}, testInfo) => {
+	test.skip(
+		testInfo.project.name !== 'mobile-chromium',
+		'the BottomSheet only replaces the anchored panel at the mobile breakpoint',
+	);
+	test.setTimeout(30_000);
+
+	const it = await seedItem(fixture, request, 'action bar sheet containment');
+	await browserLogin(page);
+	await page.goto(`/${fixture.adminUsername}/${fixture.workspaceSlug}/tasks/${it.slug}`);
+	await expect(page.locator('.title', { hasText: 'action bar sheet containment' })).toBeVisible();
+
+	const band = page.locator('.meta-actions');
+	await expect(band).toBeVisible();
+	// Establish the premise: the band really is a query container, and really is
+	// much smaller than the viewport. Without this, a passing assertion below
+	// could just mean the container-type was dropped.
+	await expect
+		.poll(() => band.evaluate((el) => getComputedStyle(el).containerType))
+		.toBe('inline-size');
+	const bandBox = (await band.boundingBox())!;
+	const vp = page.viewportSize()!;
+	expect(bandBox.height).toBeLessThan(vp.height / 4);
+
+	await page.locator('button.pane-more-btn').click();
+
+	const overlay = page.locator('.bs-overlay');
+	await expect(overlay).toBeVisible();
+
+	// The overlay must be a DOM descendant of the container — otherwise this
+	// test proves nothing about containment (e.g. if BottomSheet ever starts
+	// portaling to <body>, delete this test rather than letting it pass
+	// vacuously).
+	expect(
+		await overlay.evaluate((el) => !!el.closest('.meta-actions')),
+		'sheet is rendered inside .meta-actions — if this fails, BottomSheet now portals and this test is moot',
+	).toBe(true);
+
+	// The actual invariant: despite living inside the query container, the
+	// fixed overlay resolves against the viewport.
+	const box = (await overlay.boundingBox())!;
+	expect(Math.round(box.width), 'overlay spans the viewport width').toBe(vp.width);
+	expect(Math.round(box.height), 'overlay spans the viewport height').toBe(vp.height);
+	expect(Math.round(box.y), 'overlay starts at the top of the viewport, not at the band').toBe(0);
+
+	// And the sheet itself is a usable size, not a collapsed strip.
+	const sheet = page.locator('.bs-sheet');
+	await expect(sheet).toBeVisible();
+	const sheetBox = (await sheet.boundingBox())!;
+	expect(sheetBox.height, 'sheet is a real panel, not a collapsed strip').toBeGreaterThan(100);
+});

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -6491,7 +6491,7 @@
 	   QuickActionsMenu and never carried `.action-btn`, so it rendered 41x22
 	   against its neighbours' 70x26 — a different width AND height. */
 	.meta-actions > .action-btn,
-	.meta-actions > :global(.quick-actions-menu) {
+	.meta-actions > :global(div.quick-actions-menu) {
 		flex: 0 1 70px;
 		min-width: auto;
 	}
@@ -6500,9 +6500,19 @@
 	   without `display: flex` here the ⋯ and ⚡ triggers sit at their
 	   block min-content width and refuse to participate in the compression.
 	   `.menu-anchor` keeps `position: relative` — Menu's anchored mode
-	   positions against it. */
+	   positions against it.
+
+	   The `div` qualifier on the ⚡ wrapper is load-bearing, not stylistic
+	   (Codex P2). QuickActionsMenu sets `.quick-actions-menu { display:
+	   inline-block }`, which Svelte scopes to `.quick-actions-menu.svelte-hash`
+	   — also (0,2,0). A bare `:global(.quick-actions-menu)` here would TIE it
+	   and be settled by cross-file stylesheet order, so a chunking change could
+	   silently restore `inline-block`: the wrapper would still take the 70px
+	   basis while the ⚡ inside it snapped back to intrinsic width, quietly
+	   undoing the uniform width and shrinking the touch target. The element
+	   selector takes this to (0,2,1) and wins outright. */
 	.menu-anchor,
-	.meta-actions :global(.quick-actions-menu) {
+	.meta-actions :global(div.quick-actions-menu) {
 		display: flex;
 	}
 	/* Fill the wrapper the basis was applied to, and match `.action-btn`'s box

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -6427,7 +6427,20 @@
 		align-items: center;
 		gap: var(--space-2);
 		margin-bottom: var(--space-6);
-		flex-wrap: wrap;
+		/* Single row at every container width. The band lives in the docked
+		   pane (user-draggable, 312-672px) as well as the full page, so the
+		   old `wrap` gave back a whole row of vertical space the moment the
+		   pane got narrow. Buttons compress instead — see the
+		   `.meta-actions .action-btn` flex rule below. */
+		flex-wrap: nowrap;
+		/* Query container for the narrow-width padding tightening below. Keyed
+		   off the BAND, not the viewport, because the docked pane's width is
+		   user-dragged and decoupled from it (PLAN-2326 DR-2). Safe here per
+		   DR-3: `inline-size` implies `contain: layout style inline-size` with
+		   no PAINT containment, so the ⋯ / ⚡ anchored menus still escape the
+		   band's box. Verified by measurement, not inference. */
+		container-type: inline-size;
+		container-name: item-action-bar;
 	}
 	.action-btn {
 		padding: var(--space-1) var(--space-3);
@@ -6439,7 +6452,14 @@
 		color: var(--text-secondary);
 		font-size: 0.85em;
 		cursor: pointer;
-		transition: all 0.1s;
+		/* Was `all 0.1s`, which is fine for a hover but wrong now that width
+		   and padding are width-derived: dragging the pane animated every
+		   button's padding, so the row visibly wobbled behind the drag and
+		   settled ~100ms late. Enumerate the hover properties instead. */
+		transition:
+			background 0.1s,
+			color 0.1s,
+			border-color 0.1s;
 		white-space: nowrap;
 	}
 	.action-btn:hover {
@@ -6450,6 +6470,50 @@
 		background: var(--accent-blue);
 		border-color: var(--accent-blue);
 		color: #fff;
+	}
+
+	/* Fluid action-bar buttons. Scoped to `.meta-actions` on purpose: the
+	   graph drawer's `.action-btn`s ("Close ✕", "Retry") are wider than 70px
+	   and must keep the plain `min-width` floor, not a 70px flex basis.
+
+	   `flex-basis: 70px` reproduces the old comfortable width when there is
+	   room, so nothing moves on a wide container. `flex-shrink: 1` lets the
+	   row compress when there isn't. `min-width: auto` (NOT 0) is what makes
+	   this safe — a flex item's automatic minimum is its content size, so
+	   shrinking stops at the label rather than clipping "🌳 12/34" down to
+	   nothing. Overriding the 70px floor above is the whole point; without
+	   this line the floor and the basis are the same number and nothing
+	   shrinks. */
+	.meta-actions .action-btn {
+		flex: 0 1 70px;
+		min-width: auto;
+	}
+	/* Both of these wrap a button in a plain div, which would otherwise be a
+	   block-layout flex item: the basis above only applies to a flex ITEM, so
+	   without `display: flex` here the ⋯ and ⚡ triggers sit at their
+	   block min-content width and refuse to participate in the compression.
+	   `.menu-anchor` keeps `position: relative` — Menu's anchored mode
+	   positions against it. */
+	.menu-anchor,
+	.meta-actions :global(.quick-actions-menu) {
+		display: flex;
+	}
+
+	/* Last resort before overflow. Once every control has shrunk to its own
+	   label the row can still exceed a 264px band (a 312px pane — the draggable
+	   minimum — with star + ⚡ + 🌳 + 📎 + ⋯ measured -3.4px, and -29.8px with a
+	   3-digit child count). Reclaiming 4px of padding per side per control buys
+	   ~40px, which clears both. Deliberately NOT `overflow-x: auto` here: a
+	   scrollport under `scrollbar-width: none` is what made controls silently
+	   unreachable the first time round (DR-12).
+
+	   Two-selector specificity (0,2,0) on purpose — `@container` contributes
+	   none of its own, so a bare `.action-btn` here would tie with the base
+	   rule above and be decided by source order. */
+	@container item-action-bar (max-width: 339.98px) {
+		.meta-actions .action-btn {
+			padding-inline: var(--space-2);
+		}
 	}
 
 	/* Per-item dependency graph drawer (PLAN-1780 / TASK-1784). Right-docked

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -6483,8 +6483,15 @@
 	   shrinking stops at the label rather than clipping "🌳 12/34" down to
 	   nothing. Overriding the 70px floor above is the whole point; without
 	   this line the floor and the basis are the same number and nothing
-	   shrinks. */
-	.meta-actions .action-btn {
+	   shrinks.
+
+	   Applies to the DIRECT-child buttons (star, 🌳, 📎) plus the ⚡ trigger's
+	   wrapper, so every labelled control in the band is one width. The ⚡ is
+	   the reason this list isn't just `.action-btn`: it belongs to
+	   QuickActionsMenu and never carried `.action-btn`, so it rendered 41x22
+	   against its neighbours' 70x26 — a different width AND height. */
+	.meta-actions > .action-btn,
+	.meta-actions > :global(.quick-actions-menu) {
 		flex: 0 1 70px;
 		min-width: auto;
 	}
@@ -6497,6 +6504,50 @@
 	.menu-anchor,
 	.meta-actions :global(.quick-actions-menu) {
 		display: flex;
+	}
+	/* Fill the wrapper the basis was applied to, and match `.action-btn`'s box
+	   metrics exactly — the trigger's own rule uses `2px` block padding, which
+	   is what made it 4px shorter than everything beside it.
+
+	   Specificity: the child component's scoped rule compiles to
+	   `.trigger-btn.svelte-<hash>` (0,2,0), so a bare `:global(.trigger-btn)`
+	   would TIE and be resolved by cross-file source order — unreliable. The
+	   child combinator takes this to 0,3,0 and wins outright. */
+	.meta-actions :global(.quick-actions-menu > .trigger-btn) {
+		flex: 1 1 auto;
+		min-width: auto;
+	}
+	/* One height for every control in the band, set in one place — the ⚡
+	   trigger's own rule used 2px block padding against `.action-btn`'s 4px,
+	   which is why it sat 4px shorter than its neighbours.
+
+	   `line-height` is pinned so glyph metrics can't leak into the height:
+	   "⋯" and "☆" resolved 1px apart, which `align-items: center` then showed
+	   as a misaligned row. 1.35 reproduces the line box the band had before
+	   this change (1.2 measured 24.3px tall overall).
+
+	   `--space-2` block padding is the requested ~30% taller: 16.1px line +
+	   16px padding + 2px border = 34.1px, against 26.1px at `--space-1`.
+	   Padding rather than a fixed height so the box still grows if the label
+	   ever wraps to a second line or the root font size changes. */
+	.meta-actions > .action-btn,
+	.meta-actions .pane-more-btn,
+	.meta-actions :global(.quick-actions-menu > .trigger-btn) {
+		line-height: 1.35;
+		padding-block: var(--space-2);
+	}
+	/* The overflow trigger is the deliberate exception to the uniform width
+	   (user's call): it's a control rather than a labelled value, so it sizes
+	   to its glyph instead of padding out to 70px.
+
+	   `min-width: auto` is required, not decorative: `.action-btn`'s base
+	   `min-width: 70px` reaches this button too (it is a grandchild, so the
+	   direct-child override above misses it), and a 70px floor kept it padded
+	   out to 70px no matter what flex-basis said. */
+	.meta-actions > .menu-anchor,
+	.meta-actions .pane-more-btn {
+		flex: 0 0 auto;
+		min-width: auto;
 	}
 
 	/* Last resort before overflow. Once every control has shrunk to its own
@@ -6511,7 +6562,8 @@
 	   none of its own, so a bare `.action-btn` here would tie with the base
 	   rule above and be decided by source order. */
 	@container item-action-bar (max-width: 339.98px) {
-		.meta-actions .action-btn {
+		.meta-actions .action-btn,
+		.meta-actions :global(.quick-actions-menu > .trigger-btn) {
 			padding-inline: var(--space-2);
 		}
 	}

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -6435,10 +6435,24 @@
 		flex-wrap: nowrap;
 		/* Query container for the narrow-width padding tightening below. Keyed
 		   off the BAND, not the viewport, because the docked pane's width is
-		   user-dragged and decoupled from it (PLAN-2326 DR-2). Safe here per
-		   DR-3: `inline-size` implies `contain: layout style inline-size` with
-		   no PAINT containment, so the ⋯ / ⚡ anchored menus still escape the
-		   band's box. Verified by measurement, not inference. */
+		   user-dragged and decoupled from it (PLAN-2326 DR-2).
+
+		   Safe for the two menus this band contains, but NOT for the reason
+		   DR-3 gives. DR-3 says `inline-size` implies
+		   `contain: layout style inline-size`; that is wrong, and it's the
+		   dangerous direction to be wrong in. `container-type: inline-size`
+		   applies STYLE and INLINE-SIZE containment only — NOT layout
+		   containment (css-conditional-5 §container-type). Layout containment
+		   is the thing that would make this band a containing block for
+		   fixed-position descendants, and both menus render a non-portaled
+		   `position: fixed` BottomSheet on mobile, so under DR-3's reading the
+		   mobile sheet would collapse into a ~342x34 strip.
+
+		   It doesn't, and the absence of layout containment is why. Do not add
+		   `contain: layout` (or a transform/filter, which create a containing
+		   block by a different route) to this element — that WOULD trap the
+		   sheet. e2e/item-action-bar-band.spec.ts pins this and was
+		   mutation-tested against exactly that change. */
 		container-type: inline-size;
 		container-name: item-action-bar;
 	}

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -6550,15 +6550,17 @@
 	   as a misaligned row. 1.35 reproduces the line box the band had before
 	   this change (1.2 measured 24.3px tall overall).
 
-	   `--space-2` block padding is the requested ~30% taller: 16.1px line +
-	   16px padding + 2px border = 34.1px, against 26.1px at `--space-1`.
-	   Padding rather than a fixed height so the box still grows if the label
-	   ever wraps to a second line or the root font size changes. */
+	   `--space-1` keeps the band's original 26.1px control height (16.1px line +
+	   8px padding + 2px border) on every surface. A `--space-2` variant was
+	   tried at 34.1px (+30%) and rejected as too tall — desktop first, then
+	   mobile too, so there is deliberately no per-breakpoint split here. It is
+	   padding rather than a fixed height so the box still grows if a label ever
+	   wraps to a second line or the root font size changes. */
 	.meta-actions > .action-btn,
 	.meta-actions .pane-more-btn,
 	.meta-actions :global(.quick-actions-menu > .trigger-btn) {
 		line-height: 1.35;
-		padding-block: var(--space-2);
+		padding-block: var(--space-1);
 	}
 	/* The overflow trigger is the deliberate exception to the uniform width
 	   (user's call): it's a control rather than a labelled value, so it sizes

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -4353,310 +4353,281 @@
 			{/if}
 		</div>
 
-		<!-- Tab strip (PLAN-2326 / TASK-2328). One band: the tablist plus the
-		     right-aligned action group that used to sit in its own `.meta-actions`
-		     row above it.
-
-		     `.strip-actions` is a SIBLING of `.pane-tabs`, never a child.
-		     `role="tablist"` is on `.pane-tabs` ITSELF, so actions nested inside
-		     it would be non-tab children of a tablist (an a11y defect) and would
-		     fall in range of the arrow-key handler's `querySelectorAll(
-		     '[role="tab"]')` walk (DR-4). The tablist below is otherwise
-		     untouched — same role, aria-label, roving tabindex and handler. -->
-		<div class="tab-strip">
-			<!-- Pane tabs (PLAN-2290 Phase 4). Panels below are CSS-hidden, never
-			     unmounted — see the PaneTab block in the script. -->
-			<div
-				class="pane-tabs"
-				role="tablist"
-				aria-label="Item sections"
-				tabindex={-1}
-				onkeydown={(e) => {
-					if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') return;
-					const tabs = Array.from(
-						(e.currentTarget as HTMLElement).querySelectorAll<HTMLElement>('[role="tab"]')
-					);
-					const idx = tabs.indexOf(document.activeElement as HTMLElement);
-					if (idx === -1) return;
-					e.preventDefault();
-					const next = e.key === 'ArrowRight'
-						? (idx + 1) % tabs.length
-						: (idx - 1 + tabs.length) % tabs.length;
-					// Automatic activation: panels are display-toggles (always
-					// mounted), so activating on arrow-focus is free and keeps the
-					// roving tabindex consistent (tabindex derives from activeTab).
-					activeTab = PANE_TABS[next].id;
-					tabs[next].focus();
-				}}
+		<!-- Actions -->
+		<div class="meta-actions">
+			<!-- Star is a per-user, itemId-keyed REST toggle available to viewers too,
+			     and cannot collide across sides — so it is NOT frozen while peeking
+			     (BUG-2263). No canEdit or peeking gate. -->
+			<button
+				class="action-btn star-btn"
+				class:starred={starredStore.isStarred(item.id)}
+				onclick={() => { if (!item) return; starredStore.toggle(wsSlug, item.slug, item.id); }}
+				title={starredStore.isStarred(item.id) ? 'Unstar' : 'Star'}
 			>
-				{#each PANE_TABS as t (t.id)}
-					<!-- pointerdown + click both activate (idempotent): pointerdown wins
-					     the race against the focus-follows activation cascade — on a
-					     peeking master the pointerdown-triggered re-render can swallow
-					     the subsequent click on slow machines (CI caught it; same
-					     same-click detach class as BUG-2281). click remains for
-					     keyboard (Enter/Space). -->
-					<button
-						class="pane-tab"
-						class:on={activeTab === t.id}
-						role="tab"
-						aria-selected={activeTab === t.id}
-						aria-controls={t.id === 'activity' || t.id === 'versions'
-							? `pane-panel-feed-${uid}`
-							: `pane-panel-${t.id}-${uid}`}
-						tabindex={activeTab === t.id ? 0 : -1}
-						onpointerdown={(e) => {
-							// Mouse only: touch pointerdown fires on scroll-start, and a
-							// drag beginning on a tab must not switch panels (Codex).
-							// Mobile has no peeking master, so the click-swallow race
-							// this guards against doesn't exist there.
-							if (e.pointerType === 'mouse') activeTab = t.id;
+				{starredStore.isStarred(item.id) ? '★' : '☆'}
+			</button>
+			<!-- Quick-actions menu: the prompt-copy actions are read-only and stay
+			     visible on the peeking side (invisible freeze, BUG-2263). But the
+			     owner "New / Manage actions" controls WRITE the whole collection
+			     `settings` JSON from this instance's local snapshot with no merge —
+			     and master + pane can be DIFFERENT items in the SAME collection, so
+			     two concurrent saves are last-write-wins. So `canEdit` (which gates
+			     ONLY those write controls) folds in `!peeking`: the collection-config
+			     writes are confined to the active side, the prompts stay on both. -->
+			{#if collection && (quickActions.length > 0 || isOwner)}
+				<!-- {#key itemSlug}: structural containment (PLAN-2105 / TASK-2112).
+				     Remount this item-scoped menu on every item switch so the
+				     child's OWN local state (open form, in-progress inputs) resets.
+				     Keyed on itemSlug (the URL/ref identity), NOT item.id, so it
+				     resets the instant the ref changes rather than waiting for B to
+				     load. NOTE: the remount does NOT cancel a destroyed instance's
+				     in-flight save promise — that promise still fires
+				     oncollectionupdated into this persistent parent (see the
+				     switch-safety note on the callback). -->
+				{#key itemSlug}
+					<QuickActionsMenu
+						actions={quickActions}
+						{item}
+						{collection}
+						scope="item"
+						{wsSlug}
+						canEdit={isOwner && !peeking}
+						onmanage={() => {
+							editCollectionSection = 'actions';
+							editCollectionOpen = true;
 						}}
-						onclick={() => (activeTab = t.id)}
-					>
-						{t.label}
-					</button>
-				{/each}
-			</div>
-
-			<!-- Relocated from the deleted `.meta-actions` band (TASK-2328).
-			     `.menu-anchor` below moves INTACT: it is the `position: relative`
-			     containing block for the anchored Menu, so lifting the `⋯` button
-			     out of it on its own would break the panel's positioning. -->
-			<div class="strip-actions">
-				<!-- Star is a per-user, itemId-keyed REST toggle available to viewers too,
-				     and cannot collide across sides — so it is NOT frozen while peeking
-				     (BUG-2263). No canEdit or peeking gate. -->
+						oncollectionupdated={(updated) => {
+							// Switch-safety note (BUG-2280 — investigated, NOT a live
+							// bug; do NOT add a template-side {@const keyedSlug =
+							// itemSlug} "snapshot" fence here). A quick-action save can
+							// resolve AFTER an A->B switch and fire this callback from a
+							// destroyed {#key} instance, but it's already safe by two
+							// independent layers, so no parent fence is needed:
+							//   1. QuickActionsMenu's OWN child-side guard
+							//      (`collection?.id !== baseCollection.id`, captured
+							//      pre-await) drops the callback on a CROSS-collection
+							//      switch: a destroyed instance's `collection` prop reads
+							//      the LIVE parent value (B's collection), not a frozen
+							//      A — so the guard fails and oncollectionupdated is
+							//      never invoked. (A {@const} snapshot would NOT freeze
+							//      in Svelte 5 — it's a lazily-pulled derived that reads
+							//      the current itemSlug — so a keyedSlug fence here is a
+							//      no-op: the literal BUG-2129 trap. Verified empirically.)
+							//   2. On a SAME-collection switch the callback DOES fire,
+							//      but `updated` is that same collection, so assigning it
+							//      is correct; and loadData's collection write
+							//      (`collGen === collectionGen || collection?.id !==
+							//      collData.id`) forces the right collection regardless
+							//      of the collectionGen bump below.
+							// Bump the unified fence so an in-flight stale load/refresh
+							// can't revert this fresh write (Codex).
+							collectionGen++;
+							collection = updated;
+						}}
+					/>
+				{/key}
+			{/if}
+			{#if childTotal > 0}
+				<!--
+					Children jump badge (IDEA-2133). Mirrors the "📎 N" backlinks
+					badge below: surfaces the child completion count (done/total)
+					in the action bar and smooth-scrolls to the Children section.
+					Placed before the backlinks badge so the two jump affordances
+					match the page's reading order (children → backlinks →
+					timeline). Hidden when the item has no children. The count is
+					derived from computedOverrides — the same source the ChildItems
+					section header renders — so badge and section always agree.
+				-->
 				<button
-					class="action-btn star-btn"
-					class:starred={starredStore.isStarred(item.id)}
-					onclick={() => { if (!item) return; starredStore.toggle(wsSlug, item.slug, item.id); }}
-					title={starredStore.isStarred(item.id) ? 'Unstar' : 'Star'}
+					class="action-btn"
+					title="{childTotal} child item{childTotal === 1 ? '' : 's'}, {childDone} done"
+					aria-label="Jump to Children — {childDone} of {childTotal} done"
+					onclick={() => jumpToSection('relationships', 'item-children')}
 				>
-					{starredStore.isStarred(item.id) ? '★' : '☆'}
+					🌳 {childDone}/{childTotal}
 				</button>
-				<!-- Quick-actions menu: the prompt-copy actions are read-only and stay
-				     visible on the peeking side (invisible freeze, BUG-2263). But the
-				     owner "New / Manage actions" controls WRITE the whole collection
-				     `settings` JSON from this instance's local snapshot with no merge —
-				     and master + pane can be DIFFERENT items in the SAME collection, so
-				     two concurrent saves are last-write-wins. So `canEdit` (which gates
-				     ONLY those write controls) folds in `!peeking`: the collection-config
-				     writes are confined to the active side, the prompts stay on both. -->
-				{#if collection && (quickActions.length > 0 || isOwner)}
-					<!-- {#key itemSlug}: structural containment (PLAN-2105 / TASK-2112).
-					     Remount this item-scoped menu on every item switch so the
-					     child's OWN local state (open form, in-progress inputs) resets.
-					     Keyed on itemSlug (the URL/ref identity), NOT item.id, so it
-					     resets the instant the ref changes rather than waiting for B to
-					     load. NOTE: the remount does NOT cancel a destroyed instance's
-					     in-flight save promise — that promise still fires
-					     oncollectionupdated into this persistent parent (see the
-					     switch-safety note on the callback). -->
-					{#key itemSlug}
-						<QuickActionsMenu
-							actions={quickActions}
-							{item}
-							{collection}
-							scope="item"
-							{wsSlug}
-							canEdit={isOwner && !peeking}
-							onmanage={() => {
-								editCollectionSection = 'actions';
-								editCollectionOpen = true;
-							}}
-							oncollectionupdated={(updated) => {
-								// Switch-safety note (BUG-2280 — investigated, NOT a live
-								// bug; do NOT add a template-side {@const keyedSlug =
-								// itemSlug} "snapshot" fence here). A quick-action save can
-								// resolve AFTER an A->B switch and fire this callback from a
-								// destroyed {#key} instance, but it's already safe by two
-								// independent layers, so no parent fence is needed:
-								//   1. QuickActionsMenu's OWN child-side guard
-								//      (`collection?.id !== baseCollection.id`, captured
-								//      pre-await) drops the callback on a CROSS-collection
-								//      switch: a destroyed instance's `collection` prop reads
-								//      the LIVE parent value (B's collection), not a frozen
-								//      A — so the guard fails and oncollectionupdated is
-								//      never invoked. (A {@const} snapshot would NOT freeze
-								//      in Svelte 5 — it's a lazily-pulled derived that reads
-								//      the current itemSlug — so a keyedSlug fence here is a
-								//      no-op: the literal BUG-2129 trap. Verified empirically.)
-								//   2. On a SAME-collection switch the callback DOES fire,
-								//      but `updated` is that same collection, so assigning it
-								//      is correct; and loadData's collection write
-								//      (`collGen === collectionGen || collection?.id !==
-								//      collData.id`) forces the right collection regardless
-								//      of the collectionGen bump below.
-								// Bump the unified fence so an in-flight stale load/refresh
-								// can't revert this fresh write (Codex).
-								collectionGen++;
-								collection = updated;
-							}}
-						/>
-					{/key}
-				{/if}
-				{#if childTotal > 0}
-					<!--
-						Children jump badge (IDEA-2133). Mirrors the "📎 N" backlinks
-						badge below: surfaces the child completion count (done/total)
-						in the action bar and smooth-scrolls to the Children section.
-						Placed before the backlinks badge so the two jump affordances
-						match the page's reading order (children → backlinks →
-						timeline). Hidden when the item has no children. The count is
-						derived from computedOverrides — the same source the ChildItems
-						section header renders — so badge and section always agree.
-
-						Icon and count are separate spans (TASK-2328 / DR-9) so
-						TASK-2329's compact tier can hide the icon and keep the count
-						— a container query cannot address half a text node. The
-						single space BETWEEN them is deliberate: it is the same text
-						node the pre-split markup rendered, so the computed
-						accessible name is byte-identical. `title` / `aria-label`
-						are untouched for the same reason.
-					-->
-					<button
-						class="action-btn"
-						title="{childTotal} child item{childTotal === 1 ? '' : 's'}, {childDone} done"
-						aria-label="Jump to Children — {childDone} of {childTotal} done"
-						onclick={() => jumpToSection('relationships', 'item-children')}
-					>
-						<span class="badge-icon">🌳</span> <span class="badge-count">{childDone}/{childTotal}</span>
-					</button>
-				{/if}
-				{#if backlinksCount > 0}
-					<!--
-						Mention badge (PLAN-1593 / TASK-1596). Surfaces the inbound
-						`[[...]]` reference count in the action bar so users can see
-						at a glance that this item is referenced from elsewhere AND
-						jump straight to the panel without scrolling. Hidden when
-						the count is 0 so items with no inbound links don't
-						advertise an empty surface. The count is driven by
-						BacklinksPanel's onCountChange callback so the two stay in
-						sync without a separate API call.
-
-						Split into icon + count spans for TASK-2329's compact tier,
-						exactly as the children badge above. This badge has NO
-						`aria-label`, so its accessible name is computed from the
-						content — hence no `aria-hidden` on the icon and the literal
-						space between the spans: both would change the name.
-					-->
-					<button
-						class="action-btn"
-						title="Mentioned in {backlinksCount} other item{backlinksCount === 1 ? '' : 's'}"
-						onclick={() => jumpToSection('relationships', 'item-backlinks')}
-					>
-						<span class="badge-icon">📎</span> <span class="badge-count">{backlinksCount}</span>
-					</button>
-				{/if}
-				<!-- Pane ⋯ overflow (PLAN-2290 Phase 4 PR B): graph / move / share /
-				     delete per the mock. Triggers stay LIVE while peeking (BUG-2263 —
-				     these dispatch side-independent REST/dialog actions); opening the
-				     menu on a peeking side activates it like any other control. -->
-				<div class="menu-anchor">
-					<button
-						class="action-btn pane-more-btn"
-						bind:this={paneMenuTrigger}
-						aria-haspopup="menu"
-						aria-expanded={paneMenuOpen}
-						aria-label="More item actions"
-						title="More"
-						disabled={moving}
-						onclick={() => {
-							paneMenuView = 'root';
-							paneMenuOpen = !paneMenuOpen;
-						}}
-					>⋯</button>
-					<Menu
-						open={paneMenuOpen}
-						onclose={() => { paneMenuOpen = false; paneMenuView = 'root'; }}
-						trigger={paneMenuTrigger}
-						mode="anchored"
-						sheetOnMobile
-						sheetTitle="Item actions"
-						ariaLabel="Item actions"
-						focusKey={paneMenuView}
-					>
-						{#if paneMenuView === 'root'}
-							{#if graphFocusRef}
-								<MenuItem icon="🕸" onclick={() => { paneMenuOpen = false; openGraph(); }}>
-									Dependency graph
-								</MenuItem>
-							{/if}
-							{#if canEdit}
-								<MenuItem icon="⇄" hint="›" onclick={() => (paneMenuView = 'move')} disabled={moving}>
-									{moving ? 'Moving…' : 'Move to collection…'}
-								</MenuItem>
-							{/if}
-							{#if isOwner}
-								<MenuItem icon="⇗" onclick={() => { paneMenuOpen = false; shareDialogOpen = true; }}>
-									Share…
-								</MenuItem>
-							{/if}
-							{#if canEdit}
-								<div class="menu-divider" role="separator"></div>
-								<!-- Drill down rather than close: the confirmation is a
-								     'delete' sub-view of THIS panel (PLAN-2326 DR-6), so
-								     the menu stays open and Menu's focusKey hands focus
-								     to the sub-view's first row. -->
-								<MenuItem icon="🗑" danger hint="›" onclick={() => (paneMenuView = 'delete')}>
-									Delete…
-								</MenuItem>
-							{/if}
-						{:else if paneMenuView === 'move'}
-							<MenuItem icon="‹" onclick={() => (paneMenuView = 'root')}>Back</MenuItem>
-							<div class="menu-divider" role="separator"></div>
-							{#each moveTargets as target (target.slug)}
-								<MenuItem
-									icon={target.icon || '📁'}
-									disabled={moving}
-									onclick={() => handleMove(target.slug)}
-								>
-									{target.name}
-								</MenuItem>
-							{/each}
-						{:else if paneMenuView === 'delete'}
-							<!--
-								Delete confirmation, as a drill-down view (PLAN-2326 DR-6).
-								Cancel comes FIRST so the focusKey handoff lands keyboard
-								focus on the non-destructive row — Enter on arrival must
-								never delete.
-
-								The prompt carries `role="presentation"`: a `role="menu"`
-								owns menuitem / separator / group children, and this says
-								explicitly that the prompt is none of them rather than
-								leaving an undeclared div among them (the `.menu-divider`
-								below is the separator case).
-
-								It is NOT what keeps the prompt out of Menu's arrow-key
-								walk — that selector is `[role^="menuitem"]`, so a bare div
-								was already excluded. The consequence that matters is the
-								same either way: the prompt is never announced on its own,
-								hence the aria-describedby pointing back at it from the
-								destructive row. `role="presentation"` drops the element's
-								own semantics but NOT its text, so that description still
-								computes — verified against the rendered a11y tree, where
-								the row reports name "Delete item" / description "Delete
-								this item?" and Cancel reports no description.
-							-->
-							<div class="menu-confirm-note" role="presentation" id="delete-confirm-note-{uid}">
-								Delete this item?
-							</div>
-							<MenuItem icon="‹" onclick={() => (paneMenuView = 'root')}>Cancel</MenuItem>
-							<div class="menu-divider" role="separator"></div>
-							<MenuItem
-								icon="🗑"
-								danger
-								describedBy="delete-confirm-note-{uid}"
-								disabled={deleting || !canEdit}
-								onclick={handleDelete}
-							>
-								{deleting ? 'Deleting…' : 'Delete item'}
+			{/if}
+			{#if backlinksCount > 0}
+				<!--
+					Mention badge (PLAN-1593 / TASK-1596). Surfaces the inbound
+					`[[...]]` reference count in the action bar so users can see
+					at a glance that this item is referenced from elsewhere AND
+					jump straight to the panel without scrolling. Hidden when
+					the count is 0 so items with no inbound links don't
+					advertise an empty surface. The count is driven by
+					BacklinksPanel's onCountChange callback so the two stay in
+					sync without a separate API call.
+				-->
+				<button
+					class="action-btn"
+					title="Mentioned in {backlinksCount} other item{backlinksCount === 1 ? '' : 's'}"
+					onclick={() => jumpToSection('relationships', 'item-backlinks')}
+				>
+					📎 {backlinksCount}
+				</button>
+			{/if}
+			<!-- Pane ⋯ overflow (PLAN-2290 Phase 4 PR B): graph / move / share /
+			     delete per the mock. Triggers stay LIVE while peeking (BUG-2263 —
+			     these dispatch side-independent REST/dialog actions); opening the
+			     menu on a peeking side activates it like any other control. -->
+			<div class="menu-anchor">
+				<button
+					class="action-btn pane-more-btn"
+					bind:this={paneMenuTrigger}
+					aria-haspopup="menu"
+					aria-expanded={paneMenuOpen}
+					aria-label="More item actions"
+					title="More"
+					disabled={moving}
+					onclick={() => {
+						paneMenuView = 'root';
+						paneMenuOpen = !paneMenuOpen;
+					}}
+				>⋯</button>
+				<Menu
+					open={paneMenuOpen}
+					onclose={() => { paneMenuOpen = false; paneMenuView = 'root'; }}
+					trigger={paneMenuTrigger}
+					mode="anchored"
+					sheetOnMobile
+					sheetTitle="Item actions"
+					ariaLabel="Item actions"
+					focusKey={paneMenuView}
+				>
+					{#if paneMenuView === 'root'}
+						{#if graphFocusRef}
+							<MenuItem icon="🕸" onclick={() => { paneMenuOpen = false; openGraph(); }}>
+								Dependency graph
 							</MenuItem>
 						{/if}
-					</Menu>
-				</div>
+						{#if canEdit}
+							<MenuItem icon="⇄" hint="›" onclick={() => (paneMenuView = 'move')} disabled={moving}>
+								{moving ? 'Moving…' : 'Move to collection…'}
+							</MenuItem>
+						{/if}
+						{#if isOwner}
+							<MenuItem icon="⇗" onclick={() => { paneMenuOpen = false; shareDialogOpen = true; }}>
+								Share…
+							</MenuItem>
+						{/if}
+						{#if canEdit}
+							<div class="menu-divider" role="separator"></div>
+							<!-- Drill down rather than close: the confirmation is a
+							     'delete' sub-view of THIS panel (PLAN-2326 DR-6), so
+							     the menu stays open and Menu's focusKey hands focus
+							     to the sub-view's first row. -->
+							<MenuItem icon="🗑" danger hint="›" onclick={() => (paneMenuView = 'delete')}>
+								Delete…
+							</MenuItem>
+						{/if}
+					{:else if paneMenuView === 'move'}
+						<MenuItem icon="‹" onclick={() => (paneMenuView = 'root')}>Back</MenuItem>
+						<div class="menu-divider" role="separator"></div>
+						{#each moveTargets as target (target.slug)}
+							<MenuItem
+								icon={target.icon || '📁'}
+								disabled={moving}
+								onclick={() => handleMove(target.slug)}
+							>
+								{target.name}
+							</MenuItem>
+						{/each}
+					{:else if paneMenuView === 'delete'}
+						<!--
+							Delete confirmation, as a drill-down view (PLAN-2326 DR-6).
+							Cancel comes FIRST so the focusKey handoff lands keyboard
+							focus on the non-destructive row — Enter on arrival must
+							never delete.
+
+							The prompt carries `role="presentation"`: a `role="menu"`
+							owns menuitem / separator / group children, and this says
+							explicitly that the prompt is none of them rather than
+							leaving an undeclared div among them (the `.menu-divider`
+							below is the separator case).
+
+							It is NOT what keeps the prompt out of Menu's arrow-key
+							walk — that selector is `[role^="menuitem"]`, so a bare div
+							was already excluded. The consequence that matters is the
+							same either way: the prompt is never announced on its own,
+							hence the aria-describedby pointing back at it from the
+							destructive row. `role="presentation"` drops the element's
+							own semantics but NOT its text, so that description still
+							computes — verified against the rendered a11y tree, where
+							the row reports name "Delete item" / description "Delete
+							this item?" and Cancel reports no description.
+						-->
+						<div class="menu-confirm-note" role="presentation" id="delete-confirm-note-{uid}">
+							Delete this item?
+						</div>
+						<MenuItem icon="‹" onclick={() => (paneMenuView = 'root')}>Cancel</MenuItem>
+						<div class="menu-divider" role="separator"></div>
+						<MenuItem
+							icon="🗑"
+							danger
+							describedBy="delete-confirm-note-{uid}"
+							disabled={deleting || !canEdit}
+							onclick={handleDelete}
+						>
+							{deleting ? 'Deleting…' : 'Delete item'}
+						</MenuItem>
+					{/if}
+				</Menu>
 			</div>
+		</div>
+
+		<!-- Pane tabs (PLAN-2290 Phase 4). Panels below are CSS-hidden, never
+		     unmounted — see the PaneTab block in the script. -->
+		<div
+			class="pane-tabs"
+			role="tablist"
+			aria-label="Item sections"
+			tabindex={-1}
+			onkeydown={(e) => {
+				if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') return;
+				const tabs = Array.from(
+					(e.currentTarget as HTMLElement).querySelectorAll<HTMLElement>('[role="tab"]')
+				);
+				const idx = tabs.indexOf(document.activeElement as HTMLElement);
+				if (idx === -1) return;
+				e.preventDefault();
+				const next = e.key === 'ArrowRight'
+					? (idx + 1) % tabs.length
+					: (idx - 1 + tabs.length) % tabs.length;
+				// Automatic activation: panels are display-toggles (always
+				// mounted), so activating on arrow-focus is free and keeps the
+				// roving tabindex consistent (tabindex derives from activeTab).
+				activeTab = PANE_TABS[next].id;
+				tabs[next].focus();
+			}}
+		>
+			{#each PANE_TABS as t (t.id)}
+				<!-- pointerdown + click both activate (idempotent): pointerdown wins
+				     the race against the focus-follows activation cascade — on a
+				     peeking master the pointerdown-triggered re-render can swallow
+				     the subsequent click on slow machines (CI caught it; same
+				     same-click detach class as BUG-2281). click remains for
+				     keyboard (Enter/Space). -->
+				<button
+					class="pane-tab"
+					class:on={activeTab === t.id}
+					role="tab"
+					aria-selected={activeTab === t.id}
+					aria-controls={t.id === 'activity' || t.id === 'versions'
+						? `pane-panel-feed-${uid}`
+						: `pane-panel-${t.id}-${uid}`}
+					tabindex={activeTab === t.id ? 0 : -1}
+					onpointerdown={(e) => {
+						// Mouse only: touch pointerdown fires on scroll-start, and a
+						// drag beginning on a tab must not switch panels (Codex).
+						// Mobile has no peeking master, so the click-swallow race
+						// this guards against doesn't exist there.
+						if (e.pointerType === 'mouse') activeTab = t.id;
+					}}
+					onclick={() => (activeTab = t.id)}
+				>
+					{t.label}
+				</button>
+			{/each}
 		</div>
 
 		<div class="tab-panel" class:tab-hidden={activeTab !== 'details'} role="tabpanel" id="pane-panel-details-{uid}" aria-label="Details">
@@ -5544,80 +5515,12 @@
 		color: var(--text-muted);
 	}
 
-	/* ── Tab strip (PLAN-2326 / TASK-2328) ────────────────────────────────
-	   One band: the `.pane-tabs` tablist plus the right-aligned
-	   `.strip-actions` group, which before TASK-2328 was its own
-	   `.meta-actions` row above. The divider that used to belong to
-	   `.pane-tabs` lives here now so it runs the full width of the strip
-	   rather than stopping where the tabs do.
-
-	   `container-type: inline-size` makes this the query container for
-	   TASK-2329's tier rule. It has to be here rather than on an ancestor:
-	   the docked pane's width is user-dragged and persisted, decoupled from
-	   the viewport, so a media query cannot see it (DR-2).
-
-	   Deliberately NO `overflow`, `contain`, `clip-path`, `transform`,
-	   `filter` or `will-change` on this element — it is an ancestor of both
-	   `.menu-anchor` and QuickActionsMenu's anchor, and any of those would
-	   clip the anchored panels they position. DR-9's scroll rule goes on
-	   `.pane-tabs`, which is their SIBLING. (`container-type` itself is
-	   safe: it applies layout/style/inline-size containment but not PAINT
-	   containment, so the panels still escape — DR-3, re-verified in
-	   Chromium against this markup, including the mobile BottomSheet's
-	   `position: fixed` overlay, which still resolves against the
-	   viewport.) */
-	.tab-strip {
-		display: flex;
-		align-items: center;
-		gap: var(--space-3);
-		container-type: inline-size;
-		container-name: item-tab-strip;
-		border-bottom: 1px solid var(--border-subtle);
-		margin: var(--space-4) 0;
-	}
-
 	/* ── Pane tabs (PLAN-2290 Phase 4) ────────────────────────────────── */
 	.pane-tabs {
 		display: flex;
 		gap: 2px;
-		/* DR-9 width allocation: `.strip-actions` never shrinks, so the tab
-		   list scrolls horizontally instead of wrapping to a second row or
-		   crushing the actions. `min-width: 0` is what lets a flex item
-		   shrink below its content width at all. */
-		min-width: 0;
-		overflow-x: auto;
-		scrollbar-width: none;
-		/* `overflow-x: auto` computes `overflow-y` to `auto` too, which would
-		   clip `.pane-tab`'s `margin-bottom: -1px` overlap and leave the
-		   active tab with a 1px accent sitting on 1px of divider instead of a
-		   solid 2px underline (measured). Extending the padding box by the
-		   same 1px keeps the overlap inside the scrollport; the negative
-		   margin pulls the outer box back so the strip's height and the
-		   divider's position are unchanged. */
-		padding-bottom: 1px;
-		margin-bottom: -1px;
-	}
-
-	.pane-tabs::-webkit-scrollbar {
-		display: none;
-	}
-
-	/* `margin-left: auto` right-aligns the group however few tabs there are;
-	   `flex: 0 0 auto` is DR-9's other half — the actions hold their size and
-	   the tab list gives way. */
-	.strip-actions {
-		display: flex;
-		align-items: center;
-		gap: var(--space-2);
-		margin-left: auto;
-		flex: 0 0 auto;
-	}
-
-	/* `.action-btn`'s 70px floor exists for the standalone graph-drawer
-	   controls, which are text buttons. In the strip these are icon-sized, so
-	   the floor is overridden HERE rather than removed from the base rule. */
-	.strip-actions .action-btn {
-		min-width: 0;
+		border-bottom: 1px solid var(--border-subtle);
+		margin: var(--space-4) 0 var(--space-4);
 	}
 
 	.pane-tab {
@@ -5654,14 +5557,7 @@
 		.tab-hidden {
 			display: block !important;
 		}
-		/* All three named explicitly. Before TASK-2328 this rule hid
-		   `.pane-tabs` and the print block further down hid `.meta-actions`;
-		   the new `.tab-strip` wrapper inherits NEITHER, so hiding it is not
-		   free (DR-5). Its children are listed alongside it so the strip
-		   stays hidden even if the wrapper is later restyled. */
-		.tab-strip,
-		.pane-tabs,
-		.strip-actions {
+		.pane-tabs {
 			display: none !important;
 		}
 	}
@@ -6525,9 +6421,14 @@
 		border-top: 1px solid var(--border);
 	}
 
-	/* History. `.action-btn` is generic — the graph-drawer controls below use
-	   it too, which is why `.strip-actions` overrides `min-width` rather than
-	   this rule dropping it. */
+	/* History */
+	.meta-actions {
+		display: flex;
+		align-items: center;
+		gap: var(--space-2);
+		margin-bottom: var(--space-6);
+		flex-wrap: wrap;
+	}
 	.action-btn {
 		padding: var(--space-1) var(--space-3);
 		min-width: 70px;
@@ -6662,12 +6563,10 @@
 			padding: 0;
 		}
 
-		/* Hide interactive / screen-only chrome inside the item page.
-		   `.meta-actions` is gone (TASK-2328) — its contents now print-hide
-		   with `.tab-strip` / `.strip-actions` in the tab-strip print block
-		   above. */
+		/* Hide interactive / screen-only chrome inside the item page. */
 		.sticky-header,
 		.pane-header,
+		.meta-actions,
 		.editor-mode-toggle,
 		.add-relationship-section,
 		.save-status,


### PR DESCRIPTION
Reverts the PLAN-2326 tab-strip merge and rebuilds the action bar the user actually wants.

## Why

`10a5ae22` (TASK-2328, #1033) dissolved the item action bar into a `.tab-strip` wrapper. In use that was judged a significant regression, so this branch reverts it and fixes the original band's real problem — wrapping — directly.

PLAN-2326 is being closed as overturned. `feat/item-header-slim` (the TASK-2329 work) is preserved and untouched.

## Commits

| | |
|---|---|
| `0b4d72aa` | Revert of `10a5ae22`. `ItemDetail.svelte` returns byte-identical to `53dc0b7d` — verified by an empty `git diff 53dc0b7d`. |
| `92f8a6e2` | The band holds one row and compresses to the container width. |
| `5bd799aa` | One width and one height for every control; ⋯ exempt. |
| `224bd5b1` | Codex P2 fix + the containment regression test. |
| `1f02def6` | Containment-claim correction; both menus covered. |
| `2432132b` | Control height back to 26.1px (the taller variant was rejected). |

TASK-2327's in-menu delete confirmation and TASK-2294's pane tabs are **kept** — only the strip merge is reverted.

## What changed in the band

The band was `flex-wrap: wrap` with a hard `min-width: 70px` per button, so five controls needed ~340px and wrapped to a second row in any pane narrower than that.

- `flex: 0 1 70px` scoped to `.meta-actions` replaces the hard floor. The 70px basis reproduces the old width when there's room; `min-width: auto` bounds the shrink at each button's own label, so nothing clips. The graph drawer's `.action-btn`s keep the plain floor — their labels exceed 70px.
- The ⚡ quick-actions trigger belongs to `QuickActionsMenu` and never carried `.action-btn`, so it rendered **41×22** beside its neighbours' **70×26**. It now matches.
- The ⋯ overflow trigger is a deliberate exception and sizes to its glyph (38px).
- Below a 340px band, a container query reclaims 4px of inline padding per side, which covers the 312px pane minimum with the full control set.

Deliberately **not** `overflow-x: auto`: an invisible scrollport is what made controls silently unreachable in TASK-2328.

## Verification

Measured in Chromium at 216–864px band widths, worst case (star + ⚡ + 🌳 + 📎 + ⋯, 3-digit child count): no wrap and no clipped label at any width, one 26.1px height throughout, zero overflow from a 264px band up (the 312px draggable pane minimum).

## Containment, and a correction to DR-3

`.meta-actions` now carries `container-type: inline-size` — the band's width is what the tier rule needs, and a docked pane's width is user-dragged and decoupled from the viewport.

Both menus render a **non-portaled `position: fixed` BottomSheet** on mobile, inside that container. Codex raised this as a P1: layout containment would make the band a fixed-position containing block and collapse the sheet into a ~342×34 strip.

It doesn't, and the reason matters: **`container-type: inline-size` applies style and inline-size containment, NOT layout containment** (css-conditional-5 §container-type). PLAN-2326's DR-3 states the opposite — that `inline-size` implies `contain: layout style inline-size` — and that error is what produced the P1. The sheet is safe by spec, not by luck.

Since the invariant depends on the band *not* later acquiring `contain: layout` or a transform, `web/e2e/item-action-bar-band.spec.ts` pins it: it checks its own premise (the band really is a query container, and much smaller than the viewport), asserts DOM ancestry so it can't pass vacuously, and covers both the ⋯ and ⚡ menus. Mutation-tested — adding `contain: layout` fails it with `overlay spans the viewport width: expected 412, received 364`.

## Gates

svelte-check 0 errors · 490 vitest · Go suite green · Playwright: the new spec plus the 39 tests across the five specs that drive these controls · Codex CLI review to CLEAN per CONVE-735.

https://claude.ai/code/session_01E2fRi12n8rARczvdEa2LYT