### PR TITLE
Cross-workspace item copy — Phase 3: web UI (PLAN-2373)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,6 +172,14 @@ pad item copy <ref> --to-workspace <slug> --collection <slug> [--dry-run] [--arc
                               # --dry-run previews the field mapping + warnings.
                               # Refuses rather than guessing when a destination field needs a value,
                               # and NEVER retries the mutating call (no idempotency key — PLAN-2357 DR-13).
+                              # Content semantics: markdown is copied verbatim except `pad-attachment:`
+                              # refs that resolve to a LIVE attachment in the SOURCE workspace — those are
+                              # repointed at the clones (+ variants). Foreign / soft-deleted / dangling ids
+                              # are left literal and counted as unresolvable, never cloned.
+                              # `[[wiki-links]]` are NOT rewritten — they re-resolve in the DESTINATION,
+                              # so a link can silently retarget to a different item or break;
+                              # `[[workspace::REF]]` stays a genuine cross-workspace reference.
+                              # The web dialog (item pane ⋯ → "Copy or move to workspace…") says the same.
 pad item search "query"
 pad project dashboard         # Project dashboard
 pad project next              # Recommended next task

--- a/cmd/pad/cmd_item.go
+++ b/cmd/pad/cmd_item.go
@@ -1311,6 +1311,18 @@ blocked-by / related), the assignee when they are not a member of the
 destination workspace, and the agent role (role slugs are workspace-local).
 --dry-run reports all of it before anything happens.
 
+The content is copied as written, with two exceptions worth knowing:
+
+  - pad-attachment: references that resolve to a LIVE attachment in the source
+    workspace are repointed at the copied attachments (originals and their
+    thumbnail variants). Any other reference — an id from another workspace, a
+    soft-deleted one, or one that never existed — is left in the text
+    unchanged and reported as unresolvable; it does not become a copy.
+  - [[wiki-links]] are NOT rewritten. The copy is re-resolved in the
+    DESTINATION workspace, so a link can end up pointing at a different item
+    there, or at nothing at all. An explicit [[workspace::REF]] link stays a
+    genuine cross-workspace reference to the original.
+
 --dry-run calls a read-only preview endpoint and changes nothing. Without it,
 the preview still runs first: if any destination field needs a value you have
 not supplied, the copy is refused before any mutating request is sent.

--- a/internal/server/handlers_items_copy.go
+++ b/internal/server/handlers_items_copy.go
@@ -8,8 +8,6 @@ import (
 	"net/http"
 	"runtime/debug"
 
-	"github.com/go-chi/chi/v5"
-
 	"github.com/PerpetualSoftware/pad/internal/events"
 	"github.com/PerpetualSoftware/pad/internal/models"
 	"github.com/PerpetualSoftware/pad/internal/store"
@@ -295,86 +293,32 @@ func (e *copyPreCheckDenial) Error() string {
 // handleCopyItem copies one item into another workspace, optionally
 // archiving the source. See the file header for the full contract.
 func (s *Server) handleCopyItem(w http.ResponseWriter, r *http.Request) {
-	sourceWorkspaceID, ok := s.getWorkspaceID(w, r)
+	// Resolution plus the four-step authorization ladder, DR-10a/DR-10b —
+	// ONE implementation, shared with handleCopyItemPreflight, ordering
+	// included. Diverging here would let a caller preview a copy they cannot
+	// perform, or worse, perform one they cannot preview; the whole point of
+	// the shared helper is that neither handler owns the sequence.
+	//
+	// The actor refusal lives in there too, rather than being left to the
+	// store, which answers a bare "actor is required" that would be mapped to
+	// the ambiguous 500 and send the user hunting for an item nothing ever
+	// tried to create.
+	ac, ok := s.resolveAuthorizedCopy(w, r)
 	if !ok {
 		return
 	}
+	sourceWorkspaceID := ac.sourceWorkspaceID
+	item := ac.item
+	input := ac.input
+	src := ac.source
+	dst := ac.destination
+	targetColl := ac.targetCollection
+	actorID := ac.actorID
 
-	itemSlug := chi.URLParam(r, "itemSlug")
-	item, err := s.store.ResolveItem(sourceWorkspaceID, itemSlug)
-	if err != nil {
-		writeInternalError(w, err)
-		return
-	}
-	if item == nil {
-		// ResolveItem filters soft-deleted rows, so this covers "absent" AND
-		// "archived"; writeItemResolveError separates them exactly as the
-		// preflight, move and update paths do.
-		s.writeItemResolveError(w, r, sourceWorkspaceID, itemSlug)
-		return
-	}
-
-	// ---- Authorization, DR-10a/DR-10b, four checks in order --------------
-	//
-	// Identical to the preflight's, statement for statement, including the
-	// early return between the source and destination halves: a destination
-	// verdict built for a caller who could not read the source is itself a
-	// disclosure. Diverging here would let a caller preview a copy they
-	// cannot perform, or worse, perform one they cannot preview.
-	src := s.AuthorizeCrossWorkspaceEdit(r, sourceWorkspaceID, CrossWorkspaceItemScope(item))
-	if !src.Allowed {
-		src.WriteHidden(w, "Item")
-		return
-	}
-
-	var input itemCopyPreflightRequest
-	if err := decodeJSON(r, &input); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid_body", "Invalid JSON body")
-		return
-	}
-	if input.TargetWorkspace == "" {
-		writeError(w, http.StatusBadRequest, "missing_field", "target_workspace is required")
-		return
-	}
-	if input.TargetCollection == "" {
-		writeError(w, http.StatusBadRequest, "missing_field", "target_collection is required")
-		return
-	}
-
-	dstWS := s.AuthorizeCrossWorkspaceEdit(r, input.TargetWorkspace, CrossWorkspaceWorkspaceOnlyScope())
-	if !dstWS.Allowed {
-		dstWS.WriteDenied(w)
-		return
-	}
-
-	targetColl, err := s.store.GetCollectionBySlug(dstWS.WorkspaceID(), input.TargetCollection)
-	if err != nil {
-		writeInternalError(w, err)
-		return
-	}
-	if targetColl == nil {
-		writeError(w, http.StatusNotFound,
-			crossWorkspaceCollectionNotFoundCode, crossWorkspaceCollectionNotFoundMessage)
-		return
-	}
-
-	dst := s.AuthorizeCrossWorkspaceEdit(r, input.TargetWorkspace, CrossWorkspaceCollectionScope(targetColl.ID))
-	if !dst.Allowed {
-		dst.WriteCollectionNotFound(w)
-		return
-	}
-
-	// Refused HERE rather than left to the store, which answers a bare
-	// "actor is required" that would be mapped to the ambiguous 500 and send
-	// the user hunting for an item nothing ever tried to create. The
-	// preflight applies the identical guard, so the preview cannot promise a
-	// copy this would refuse (Codex round 4).
-	actorID := copyActorID(r, item)
-	if actorID == "" {
-		writeCopyActorRequired(w)
-		return
-	}
-
+	// SEPARATE from actorID, and deliberately not folded into the shared
+	// resolution: actorFromRequest carries actor/source AUDIT metadata used
+	// only by this mutating path and its post-commit events. The preflight
+	// has no counterpart, because it writes nothing to attribute.
 	actor, actorSource := actorFromRequest(r)
 
 	// ---- The copy. ONE call, no retry (DR-13). ---------------------------

--- a/internal/server/handlers_items_copy_parity_test.go
+++ b/internal/server/handlers_items_copy_parity_test.go
@@ -1,0 +1,612 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// The RESPONSE-PARITY MATRIX for the cross-workspace copy — TASK-2370.
+//
+// The preflight and the copy share one resolution + authorization ladder
+// (Server.resolveAuthorizedCopy). This file is the executable statement of
+// what that sharing has to mean, and it is deliberately the EXECUTABLE
+// acceptance criterion for the extraction: "one implementation, used by
+// both" is a code-review property a reviewer can be satisfied by while the
+// code drifts a month later.
+//
+// Be precise about what this does and does not prove. It is a BEHAVIOURAL
+// matrix: it fails when a handler's ladder DIVERGES — a different refusal,
+// a different code, a different order. A handler that re-inlined the ladder
+// and reproduced it exactly would still pass, because from a client's
+// vantage point nothing changed. The structural "one implementation"
+// property is a code-review property and stays one; what is pinned here is
+// the property that actually harms users when it breaks.
+//
+// Why this is not hypothetical: preflight/copy divergence is empirically the
+// number one defect source in PLAN-2357 — five separate divergences were
+// found and fixed in Phase 2 alone, and one of them was a disagreement about
+// the ORDER of refusals rather than the set. assertPreflightMatchesCopy
+// (handlers_items_copy_test.go) pins the FIELD MAPPING half of that
+// agreement. This is its sibling for the AUTHORIZATION half.
+//
+// Each row drives ONE arrangement through BOTH endpoints with a
+// byte-identical request and asserts the two answer with the same status
+// AND the same error code — including the rows where a naive extraction
+// would silently change the answer:
+//
+//   - the two unresolvable-source variants (404 absent / 409 archived), and
+//     the archived-but-hidden case that must NOT report 409;
+//   - a malformed body, which is only reachable AFTER source visibility has
+//     succeeded — decoding first would leak source existence;
+//   - both missing_field refusals, which sit BETWEEN source authorization
+//     and any destination lookup;
+//   - every destination-workspace denial variant: WriteDenied is not one
+//     outcome (500 / permission_denied / forbidden), and its `forbidden`
+//     arm is itself reached by three different denial reasons — workspace
+//     unresolvable, resolvable-but-no-role, and role-without-edit — which
+//     collapse to one response on purpose;
+//   - collection_not_found, for a collection that is absent and for one that
+//     is merely hidden — byte-identical, or the endpoint enumerates hidden
+//     collections one slug at a time;
+//   - the no-attributable-actor path, whose POSITION (after the fourth check,
+//     before any field handling) is itself a divergence class this feature
+//     has been bitten by;
+//   - and the SUCCESSFUL resolved snapshot, so the matrix is not satisfiable
+//     by a ladder that refuses everything.
+//
+// MUTATION-VERIFIED: reordering either handler's ladder (e.g. hoisting the
+// body decode above the source check, or hoisting the destination lookup
+// above the required-field checks) fails rows here. See the note on
+// TestCopyAuthorizationParityMatrix_Ordering.
+
+// bothRR is the pair of recorders one arrangement produced.
+type bothRR struct {
+	pre  *httptest.ResponseRecorder
+	copy *httptest.ResponseRecorder
+}
+
+// callBothRaw drives handleCopyItemPreflight and handleCopyItem over the
+// SAME request bytes, the same context, and the same route params — the only
+// difference is the path suffix and the handler. Sharing the construction is
+// load-bearing: a difference in how the two are invoked would weaken every
+// assertion in this file.
+func (f *copyPreflightFixture) callBothRaw(user *models.User, o reqOpts, itemSlug string, raw []byte) bothRR {
+	f.t.Helper()
+
+	build := func(path string) *http.Request {
+		r := httptest.NewRequest("POST", path, bytes.NewReader(raw))
+		r.Header.Set("Content-Type", "application/json")
+
+		ctx := r.Context()
+		if !o.noUser && user != nil {
+			ctx = WithCurrentUser(ctx, user)
+		}
+		if o.setAllowed {
+			ctx = WithTokenAllowedWorkspaces(ctx, o.allowed)
+		}
+		if o.tokenWorkspaceID != "" {
+			ctx = WithTokenWorkspaceID(ctx, o.tokenWorkspaceID)
+		}
+		role := o.wsRoleCtx
+		if role == "" {
+			role = "owner"
+		}
+		ctx = contextWithWorkspaceRoleForTest(ctx, role)
+		ctx = contextWithResolvedWorkspaceIDForTest(ctx, f.wsA.ID)
+
+		rctx := chi.NewRouteContext()
+		rctx.URLParams.Add("slug", f.wsA.Slug)
+		rctx.URLParams.Add("itemSlug", itemSlug)
+		ctx = context.WithValue(ctx, chi.RouteCtxKey, rctx)
+
+		r = r.WithContext(ctx)
+		if o.bearer {
+			r.Header.Set("Authorization", "Bearer test-token")
+		}
+		return r
+	}
+
+	base := "/api/v1/workspaces/" + f.wsA.Slug + "/items/" + itemSlug
+	preRR := httptest.NewRecorder()
+	f.srv.handleCopyItemPreflight(preRR, build(base+"/copy/preflight"))
+	copyRR := httptest.NewRecorder()
+	f.srv.handleCopyItem(copyRR, build(base+"/copy"))
+	return bothRR{pre: preRR, copy: copyRR}
+}
+
+// callBoth is callBothRaw with a JSON-encodable body.
+func (f *copyPreflightFixture) callBoth(user *models.User, o reqOpts, body map[string]any) bothRR {
+	f.t.Helper()
+	raw, err := json.Marshal(body)
+	if err != nil {
+		f.t.Fatalf("marshal body: %v", err)
+	}
+	return f.callBothRaw(user, o, f.source.Slug, raw)
+}
+
+// assertRefusalParity is the matrix's single assertion: the two endpoints
+// refused with the same status, the same error code, and — since every
+// refusal on this path goes through a shared writer — the same bytes.
+func assertRefusalParity(t *testing.T, got bothRR, wantStatus int, wantCode string) {
+	t.Helper()
+
+	if got.pre.Code != got.copy.Code {
+		t.Fatalf("the preview and the copy answered with different statuses — a client that "+
+			"previewed successfully can be refused by the copy, or worse:\n preflight: %d %s\n copy:      %d %s",
+			got.pre.Code, got.pre.Body.String(), got.copy.Code, got.copy.Body.String())
+	}
+	if got.pre.Body.String() != got.copy.Body.String() {
+		t.Fatalf("the preview and the copy answered with different bodies:\n preflight: %s\n copy:      %s",
+			got.pre.Body.String(), got.copy.Body.String())
+	}
+	if got.copy.Code != wantStatus {
+		t.Fatalf("status = %d, want %d: %s", got.copy.Code, wantStatus, got.copy.Body.String())
+	}
+	if code := errCode(t, got.copy); code != wantCode {
+		t.Fatalf("error code = %q, want %q: %s", code, wantCode, got.copy.Body.String())
+	}
+}
+
+// TestCopyAuthorizationParityMatrix is the matrix proper. Each subtest
+// arranges one refusal and requires both endpoints to produce it identically.
+func TestCopyAuthorizationParityMatrix(t *testing.T) {
+	// --- unresolvable source, both variants -----------------------------
+	//
+	// Resolution runs BEFORE the body is decoded in both handlers. If it did
+	// not, a caller who cannot see the item would learn whether their JSON
+	// was well-formed and a caller who can see it would not — which is the
+	// leak the ordering exists to prevent.
+
+	t.Run("source absent", func(t *testing.T) {
+		f := newCopyPreflightFixture(t)
+		raw, _ := json.Marshal(f.resolvableBody())
+		got := f.callBothRaw(f.owner, reqOpts{}, "definitely-not-an-item", raw)
+		assertRefusalParity(t, got, http.StatusNotFound, "not_found")
+	})
+
+	t.Run("source archived and visible to the caller", func(t *testing.T) {
+		f := newCopyPreflightFixture(t)
+		if err := f.srv.store.DeleteItem(f.source.ID); err != nil {
+			t.Fatalf("DeleteItem: %v", err)
+		}
+		// writeItemResolveError's 404-vs-409 split. Both endpoints must keep
+		// it: an archived source is neither absent nor copyable, and a client
+		// can say something useful about the difference.
+		assertRefusalParity(t, f.callBoth(f.owner, reqOpts{}, f.resolvableBody()),
+			http.StatusConflict, "archived")
+	})
+
+	t.Run("source archived but hidden from the caller", func(t *testing.T) {
+		f := newCopyPreflightFixture(t)
+		if err := f.srv.store.DeleteItem(f.source.ID); err != nil {
+			t.Fatalf("DeleteItem: %v", err)
+		}
+		otherA := mustSchemaCollection(t, f.srv, f.wsA.ID, "Other A", srcSchemaJSON)
+		u := f.restrictedEditor("parity-arch-hidden@example.com", "parityarchhidden",
+			[]string{otherA.ID}, []string{f.collB.ID})
+		// The OTHER half of the split: a caller who could not see the row must
+		// not learn it is archived. Both endpoints collapse to the bare 404.
+		assertRefusalParity(t, f.callBoth(u, reqOpts{wsRoleCtx: "editor"}, f.resolvableBody()),
+			http.StatusNotFound, "not_found")
+	})
+
+	// --- source authorization, checks 1 and 2 ---------------------------
+
+	t.Run("source item not visible", func(t *testing.T) {
+		f := newCopyPreflightFixture(t)
+		otherA := mustSchemaCollection(t, f.srv, f.wsA.ID, "Other A", srcSchemaJSON)
+		u := f.restrictedEditor("parity-hidden-src@example.com", "parityhiddensrc",
+			[]string{otherA.ID}, []string{f.collB.ID})
+		assertRefusalParity(t, f.callBoth(u, reqOpts{wsRoleCtx: "editor"}, f.resolvableBody()),
+			http.StatusNotFound, "not_found")
+	})
+
+	t.Run("source edit denied", func(t *testing.T) {
+		f := newCopyPreflightFixture(t)
+		viewer := mustUser(t, f.srv, "parity-viewer-a@example.com", "parityviewera", "")
+		if err := f.srv.store.AddWorkspaceMember(f.wsA.ID, viewer.ID, "viewer"); err != nil {
+			t.Fatalf("AddWorkspaceMember A: %v", err)
+		}
+		if err := f.srv.store.AddWorkspaceMember(f.wsB.ID, viewer.ID, "editor"); err != nil {
+			t.Fatalf("AddWorkspaceMember B: %v", err)
+		}
+		assertRefusalParity(t, f.callBoth(viewer, reqOpts{wsRoleCtx: "viewer"}, f.resolvableBody()),
+			http.StatusNotFound, "not_found")
+	})
+
+	// --- decode and required fields, BETWEEN the two halves -------------
+	//
+	// These sit after source authorization and before any destination
+	// lookup. Hoisting the destination lookup earlier would disclose
+	// destination state to a caller sending a bad body.
+
+	t.Run("malformed body", func(t *testing.T) {
+		f := newCopyPreflightFixture(t)
+		got := f.callBothRaw(f.owner, reqOpts{}, f.source.Slug, []byte("{not json"))
+		assertRefusalParity(t, got, http.StatusBadRequest, "invalid_body")
+	})
+
+	t.Run("missing target_workspace", func(t *testing.T) {
+		f := newCopyPreflightFixture(t)
+		assertRefusalParity(t,
+			f.callBoth(f.owner, reqOpts{}, map[string]any{"target_collection": f.collB.Slug}),
+			http.StatusBadRequest, "missing_field")
+	})
+
+	t.Run("missing target_collection", func(t *testing.T) {
+		f := newCopyPreflightFixture(t)
+		assertRefusalParity(t,
+			f.callBoth(f.owner, reqOpts{}, map[string]any{"target_workspace": f.wsB.Slug}),
+			http.StatusBadRequest, "missing_field")
+	})
+
+	// --- destination workspace denial: all THREE variants ---------------
+	//
+	// WriteDenied is not one outcome. An extraction that collapsed it to a
+	// single denial shape would be both a behaviour change and a disclosure
+	// change.
+
+	// WriteDenied's default arm is reached by three DIFFERENT denial
+	// reasons, and all three are rows here. They collapse to one response on
+	// purpose — that collapse is the disclosure posture — so the only way to
+	// know each reason still lands on it is to arrange each reason.
+
+	t.Run("destination workspace unresolvable (by slug)", func(t *testing.T) {
+		f := newCopyPreflightFixture(t)
+		outsider := mustUser(t, f.srv, "parity-outsider@example.com", "parityoutsider", "")
+		wsC := mustWorkspace(t, f.srv, "Parity Unreachable WS", outsider.ID)
+
+		// Slug resolution is ACL-scoped, so this never reaches the role check:
+		// the workspace resolves to nil and the reason is
+		// CrossWorkspaceWorkspaceNotFound. Distinct from the UUID row below,
+		// which DOES reach the role check — and the whole point is that a
+		// caller cannot tell the two apart.
+		body := f.resolvableBody()
+		body["target_workspace"] = wsC.Slug
+		assertRefusalParity(t, f.callBoth(f.owner, reqOpts{}, body),
+			http.StatusForbidden, "forbidden")
+	})
+
+	t.Run("destination workspace resolvable but caller has no role (by UUID)", func(t *testing.T) {
+		f := newCopyPreflightFixture(t)
+		outsider := mustUser(t, f.srv, "parity-uuid-outsider@example.com", "parityuuidoutsider", "")
+		wsC := mustWorkspace(t, f.srv, "Parity UUID WS", outsider.ID)
+
+		// resolveWorkspace's UUID branch is NOT ACL-scoped, so the workspace
+		// resolves and crossWorkspaceRole returns "" —
+		// CrossWorkspaceNoWorkspaceAccess. Byte-identical to the slug row.
+		body := f.resolvableBody()
+		body["target_workspace"] = wsC.ID
+		assertRefusalParity(t, f.callBoth(f.owner, reqOpts{}, body),
+			http.StatusForbidden, "forbidden")
+	})
+
+	t.Run("destination workspace edit denied", func(t *testing.T) {
+		f := newCopyPreflightFixture(t)
+		u := mustUser(t, f.srv, "parity-viewer-b@example.com", "parityviewerb", "")
+		if err := f.srv.store.AddWorkspaceMember(f.wsA.ID, u.ID, "editor"); err != nil {
+			t.Fatalf("AddWorkspaceMember A: %v", err)
+		}
+		if err := f.srv.store.AddWorkspaceMember(f.wsB.ID, u.ID, "viewer"); err != nil {
+			t.Fatalf("AddWorkspaceMember B: %v", err)
+		}
+		// The third reason: the caller has a role in the destination but it
+		// is not a writing one — CrossWorkspaceInsufficientPermission, refused
+		// at the WORKSPACE-only stage, before the collection is ever named.
+		//
+		// Note this is where a read-only destination member is stopped, not at
+		// check 4: a caller who clears the workspace-only edit gate has a base
+		// role of editor or better, which clears the collection-scoped edit
+		// gate too. The collection stage's reachable denial is the visibility
+		// collapse — collection_not_found, covered by the two rows below.
+		assertRefusalParity(t, f.callBoth(u, reqOpts{wsRoleCtx: "editor"}, f.resolvableBody()),
+			http.StatusForbidden, "forbidden")
+	})
+
+	t.Run("destination workspace outside the token allow-list", func(t *testing.T) {
+		f := newCopyPreflightFixture(t)
+		got := f.callBoth(f.owner, reqOpts{
+			bearer: true, setAllowed: true, allowed: []string{f.wsA.Slug},
+		}, f.resolvableBody())
+		assertRefusalParity(t, got, http.StatusForbidden, "permission_denied")
+	})
+
+	t.Run("destination workspace lookup failure", func(t *testing.T) {
+		f := newCopyPreflightFixture(t)
+
+		// A caller who is a full-access member of the SOURCE workspace and a
+		// stranger to the destination, naming the destination by UUID.
+		//
+		// That combination is what isolates the failure to the destination
+		// half. resolveWorkspace's UUID branch is not ACL-scoped, so the
+		// destination reaches crossWorkspaceRole, which — finding no
+		// membership row — asks UserHasGrantsInWorkspace. The SOURCE half
+		// never gets there: a member with collection_access="all" is answered
+		// out of workspace_members, and the base-role branch of
+		// crossWorkspaceEditAllowed short-circuits before any grant lookup.
+		// So breaking the grant tables breaks exactly one of the two lookups.
+		u := mustUser(t, f.srv, "parity-lookup@example.com", "paritylookup", "")
+		if err := f.srv.store.AddWorkspaceMember(f.wsA.ID, u.ID, "editor"); err != nil {
+			t.Fatalf("AddWorkspaceMember A: %v", err)
+		}
+
+		body := f.resolvableBody()
+		body["target_workspace"] = f.wsB.ID
+
+		// CONTROL, before anything is broken: the same request is an ordinary
+		// 403 forbidden. Without this the 500 below could be any failure at
+		// all rather than the WriteDenied branch under test.
+		assertRefusalParity(t, f.callBoth(u, reqOpts{wsRoleCtx: "editor"}, body),
+			http.StatusForbidden, "forbidden")
+
+		f.breakGrantLookups()
+		assertRefusalParity(t, f.callBoth(u, reqOpts{wsRoleCtx: "editor"}, body),
+			http.StatusInternalServerError, "internal_error")
+	})
+
+	// --- destination collection, checks 3 and 4 -------------------------
+
+	t.Run("destination collection absent", func(t *testing.T) {
+		f := newCopyPreflightFixture(t)
+		body := f.resolvableBody()
+		body["target_collection"] = "definitely-not-a-collection"
+		assertRefusalParity(t, f.callBoth(f.owner, reqOpts{}, body),
+			http.StatusNotFound, crossWorkspaceCollectionNotFoundCode)
+	})
+
+	t.Run("destination collection hidden", func(t *testing.T) {
+		f := newCopyPreflightFixture(t)
+		u := f.restrictedEditor("parity-hidden-dst@example.com", "parityhiddendst",
+			[]string{f.collA.ID}, []string{f.collB.ID})
+		body := f.resolvableBody()
+		body["target_collection"] = f.hiddenB.Slug
+		// Same status AND same code as "absent" above, on both endpoints —
+		// otherwise a restricted member enumerates the destination's hidden
+		// collections one slug at a time.
+		assertRefusalParity(t, f.callBoth(u, reqOpts{wsRoleCtx: "editor"}, body),
+			http.StatusNotFound, crossWorkspaceCollectionNotFoundCode)
+	})
+
+	// --- source before destination --------------------------------------
+
+	t.Run("source verdict wins when both halves would refuse", func(t *testing.T) {
+		f := newCopyPreflightFixture(t)
+		otherA := mustSchemaCollection(t, f.srv, f.wsA.ID, "Other A", srcSchemaJSON)
+		u := mustUser(t, f.srv, "parity-both-fail@example.com", "paritybothfail", "")
+		if err := f.srv.store.AddWorkspaceMember(f.wsA.ID, u.ID, "editor"); err != nil {
+			t.Fatalf("AddWorkspaceMember A: %v", err)
+		}
+		if err := f.srv.store.SetMemberCollectionAccess(f.wsA.ID, u.ID, "specific", []string{otherA.ID}); err != nil {
+			t.Fatalf("SetMemberCollectionAccess: %v", err)
+		}
+		// The caller can see neither the source item nor the destination
+		// workspace. The SOURCE's non-disclosing 404 must win on both
+		// endpoints — a destination verdict built for a caller who could not
+		// read the source is itself a disclosure.
+		assertRefusalParity(t, f.callBoth(u, reqOpts{wsRoleCtx: "editor"}, f.resolvableBody()),
+			http.StatusNotFound, "not_found")
+	})
+}
+
+// breakGrantLookups renames the two grant tables out from under the store so
+// UserHasGrantsInWorkspace fails, and restores them at the end of the test.
+//
+// This is the only way to reach CrossWorkspaceLookupFailed end to end: a
+// store failure is not otherwise inducible from a request, which is exactly
+// why WriteDenied's own doc comment says an attacker cannot provoke one. The
+// arm still has to be covered, because it is one of the three shapes
+// WriteDenied emits and a "one denial" extraction would swallow it.
+func (f *copyPreflightFixture) breakGrantLookups() {
+	f.t.Helper()
+	renames := [][2]string{
+		{"collection_grants", "collection_grants_parity_broken"},
+		{"item_grants", "item_grants_parity_broken"},
+	}
+
+	// Cleanup is registered BEFORE the first rename and restores only what
+	// actually got renamed. Registering it after the loop would leave the
+	// first table renamed if the second DDL failed — the fixture database is
+	// per-test so nothing else would notice, but a half-restored schema turns
+	// one failure into a confusing cascade inside this test.
+	var done [][2]string
+	f.t.Cleanup(func() {
+		for _, rn := range done {
+			if _, err := f.srv.store.DB().Exec(`ALTER TABLE ` + rn[1] + ` RENAME TO ` + rn[0]); err != nil {
+				f.t.Errorf("restore %s: %v", rn[0], err)
+			}
+		}
+	})
+	for _, rn := range renames {
+		if _, err := f.srv.store.DB().Exec(`ALTER TABLE ` + rn[0] + ` RENAME TO ` + rn[1]); err != nil {
+			f.t.Fatalf("rename %s: %v", rn[0], err)
+		}
+		done = append(done, rn)
+	}
+}
+
+// TestCopyAuthorizationParityMatrix_ResolvedSnapshot is the matrix's
+// positive row, and it is not optional: without it every assertion above is
+// satisfied by a ladder that refuses everything.
+//
+// The two endpoints differ in status by design — 200 for a preview, 201 for
+// a creation — so what is compared is the RESOLVED SNAPSHOT the shared step
+// produced: the same source item in the same source workspace, the same
+// destination workspace and collection, and the same archive_source reading.
+// A ladder that resolved a different destination on one path would fail here
+// even though every denial row still passed.
+func TestCopyAuthorizationParityMatrix_ResolvedSnapshot(t *testing.T) {
+	f := newCopyPreflightFixture(t)
+	body := f.resolvableBody()
+
+	got := f.callBoth(f.owner, reqOpts{}, body)
+	if got.pre.Code != http.StatusOK {
+		t.Fatalf("preflight: got %d, want 200: %s", got.pre.Code, got.pre.Body.String())
+	}
+	if got.copy.Code != http.StatusCreated {
+		t.Fatalf("copy: got %d, want 201: %s", got.copy.Code, got.copy.Body.String())
+	}
+
+	var pre ItemCopyPreflight
+	if err := json.Unmarshal(got.pre.Body.Bytes(), &pre); err != nil {
+		t.Fatalf("parse preflight: %v", err)
+	}
+	var res ItemCopyResult
+	if err := json.Unmarshal(got.copy.Body.Bytes(), &res); err != nil {
+		t.Fatalf("parse copy: %v", err)
+	}
+
+	for _, c := range []struct {
+		what      string
+		pre, copy string
+	}{
+		{"source workspace", pre.Source.WorkspaceSlug, res.Source.WorkspaceSlug},
+		{"source ref", pre.Source.Ref, res.Source.Ref},
+		{"destination workspace", pre.Destination.WorkspaceSlug, res.Destination.WorkspaceSlug},
+		{"destination collection", pre.Destination.CollectionSlug, res.Destination.CollectionSlug},
+	} {
+		if c.pre != c.copy {
+			t.Errorf("the preview and the copy resolved a different %s: %q vs %q", c.what, c.pre, c.copy)
+		}
+	}
+	if pre.Destination.WorkspaceSlug != f.wsB.Slug || pre.Destination.CollectionSlug != f.collB.Slug {
+		t.Errorf("resolved destination = %s/%s, want %s/%s",
+			pre.Destination.WorkspaceSlug, pre.Destination.CollectionSlug, f.wsB.Slug, f.collB.Slug)
+	}
+	if pre.ArchiveSource != res.Source.Archived {
+		t.Errorf("archive_source disagreement: preview echoed %v, copy archived = %v",
+			pre.ArchiveSource, res.Source.Archived)
+	}
+}
+
+// TestCopyAuthorizationParityMatrix_NoAttributableActor is the matrix's
+// actor row. It needs a whole different world — a FRESH INSTALL with zero
+// users, the only state in which the actor can be unresolvable — so it does
+// not fit the fixture the rest of the matrix shares.
+//
+// The row matters because actor resolution's POSITION is itself a divergence
+// class this feature has already been bitten by: an earlier preflight
+// resolved it down by the attachment planner, so a request that fails BOTH
+// ways (no actor AND a malformed override) got the override from one endpoint
+// and the actor from the other. TestCopyEndpoint_PreflightAndCopyAgreeWith-
+// NoAttributableActor covers that ordering interaction in depth; this row
+// keeps the plain case inside the matrix so the matrix is complete on its
+// own terms.
+func TestCopyAuthorizationParityMatrix_NoAttributableActor(t *testing.T) {
+	srv := testServer(t)
+	// CreateWorkspace WITHOUT a membership row: with no users there is nobody
+	// to be a member, and workspace_members has a foreign key onto users.
+	mustFreshWS := func(name string) *models.Workspace {
+		ws, err := srv.store.CreateWorkspace(models.WorkspaceCreate{Name: name})
+		if err != nil {
+			t.Fatalf("CreateWorkspace(%s): %v", name, err)
+		}
+		return ws
+	}
+	wsA := mustFreshWS("Parity Fresh Source")
+	wsB := mustFreshWS("Parity Fresh Dest")
+	collA := mustSchemaCollection(t, srv, wsA.ID, "Parity Fresh A", srcSchemaJSON)
+	collB := mustSchemaCollection(t, srv, wsB.ID, "Parity Fresh B", srcSchemaJSON)
+
+	source, err := srv.store.CreateItem(wsA.ID, collA.ID, models.ItemCreate{
+		Title: "Unattributable", Fields: `{"status":"open"}`,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem: %v", err)
+	}
+	if n, err := srv.store.UserCount(); err != nil || n != 0 {
+		t.Fatalf("fixture precondition: want a fresh install with 0 users, got %d (%v)", n, err)
+	}
+	// CreateItem defaults created_by to "user", so the unattributable state
+	// has to be forced. That is the point of the case: legacy/corrupt data,
+	// not something a write path produces.
+	if _, err := srv.store.DB().Exec(
+		srv.store.D().Rebind(`UPDATE items SET created_by = '' WHERE id = ?`), source.ID,
+	); err != nil {
+		t.Fatalf("blank created_by: %v", err)
+	}
+
+	raw, err := json.Marshal(map[string]any{
+		"target_workspace": wsB.Slug, "target_collection": collB.Slug,
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	build := func(path string) *http.Request {
+		r := httptest.NewRequest("POST", path, bytes.NewReader(raw))
+		r.Header.Set("Content-Type", "application/json")
+		ctx := contextWithWorkspaceRoleForTest(r.Context(), "owner")
+		ctx = contextWithResolvedWorkspaceIDForTest(ctx, wsA.ID)
+		rctx := chi.NewRouteContext()
+		rctx.URLParams.Add("slug", wsA.Slug)
+		rctx.URLParams.Add("itemSlug", source.Slug)
+		return r.WithContext(context.WithValue(ctx, chi.RouteCtxKey, rctx))
+	}
+
+	base := "/api/v1/workspaces/" + wsA.Slug + "/items/" + source.Slug
+	preRR := httptest.NewRecorder()
+	srv.handleCopyItemPreflight(preRR, build(base+"/copy/preflight"))
+	copyRR := httptest.NewRecorder()
+	srv.handleCopyItem(copyRR, build(base+"/copy"))
+
+	assertRefusalParity(t, bothRR{pre: preRR, copy: copyRR},
+		http.StatusForbidden, "actor_required")
+}
+
+// TestCopyAuthorizationParityMatrix_Ordering states the ordering properties
+// the matrix exists to catch, as claims about a SINGLE endpoint's response
+// rather than about the pair. They are what a reordering mutation breaks
+// first, and they are here so the failure message names the ordering rather
+// than leaving a reader to infer it from a parity mismatch.
+//
+// HOW TO VERIFY THE MATRIX BITES (the harness this task requires, kept in
+// the file it exercises): move the decodeJSON block in resolveAuthorizedCopy
+// above the ResolveItem call, or move the destination lookup above the
+// required-field checks. Either mutation fails this test and several rows of
+// the matrix above; revert it afterwards.
+func TestCopyAuthorizationParityMatrix_Ordering(t *testing.T) {
+	// Resolve BEFORE decode: a malformed body sent for an item the caller
+	// cannot see must report the ITEM, not the body. Reporting invalid_body
+	// here tells a stranger their JSON reached a real resolution step.
+	t.Run("resolve runs before decode", func(t *testing.T) {
+		f := newCopyPreflightFixture(t)
+		otherA := mustSchemaCollection(t, f.srv, f.wsA.ID, "Other A", srcSchemaJSON)
+		u := f.restrictedEditor("parity-order-decode@example.com", "parityorderdecode",
+			[]string{otherA.ID}, []string{f.collB.ID})
+
+		got := f.callBothRaw(u, reqOpts{wsRoleCtx: "editor"}, f.source.Slug, []byte("{not json"))
+		assertRefusalParity(t, got, http.StatusNotFound, "not_found")
+	})
+
+	// Required-field checks BEFORE the destination lookup: a body missing
+	// target_collection while naming a destination workspace the caller
+	// cannot reach must report missing_field, not the destination's verdict.
+	t.Run("required fields precede the destination lookup", func(t *testing.T) {
+		f := newCopyPreflightFixture(t)
+		outsider := mustUser(t, f.srv, "parity-order-dest@example.com", "parityorderdest", "")
+		wsC := mustWorkspace(t, f.srv, "Parity Order WS", outsider.ID)
+
+		got := f.callBoth(f.owner, reqOpts{}, map[string]any{"target_workspace": wsC.Slug})
+		assertRefusalParity(t, got, http.StatusBadRequest, "missing_field")
+	})
+
+	// Source authorization BEFORE the body is even considered: a caller who
+	// cannot edit the source and sends a body naming an unreachable
+	// destination gets the source's 404.
+	t.Run("source authorization precedes everything downstream", func(t *testing.T) {
+		f := newCopyPreflightFixture(t)
+		viewer := mustUser(t, f.srv, "parity-order-src@example.com", "parityordersrc", "")
+		if err := f.srv.store.AddWorkspaceMember(f.wsA.ID, viewer.ID, "viewer"); err != nil {
+			t.Fatalf("AddWorkspaceMember A: %v", err)
+		}
+		got := f.callBothRaw(viewer, reqOpts{wsRoleCtx: "viewer"}, f.source.Slug, []byte("{not json"))
+		assertRefusalParity(t, got, http.StatusNotFound, "not_found")
+	})
+}

--- a/internal/server/handlers_items_copy_preflight.go
+++ b/internal/server/handlers_items_copy_preflight.go
@@ -7,8 +7,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/go-chi/chi/v5"
-
 	"github.com/PerpetualSoftware/pad/internal/items"
 	"github.com/PerpetualSoftware/pad/internal/models"
 	"github.com/PerpetualSoftware/pad/internal/store"
@@ -471,125 +469,23 @@ func buildHierarchyLinkTypes() map[string]bool {
 // handleCopyItemPreflight answers "what would this cross-workspace copy
 // do?" without doing any of it. See the file header for the full contract.
 func (s *Server) handleCopyItemPreflight(w http.ResponseWriter, r *http.Request) {
-	sourceWorkspaceID, ok := s.getWorkspaceID(w, r)
+	// Resolution plus the four-step authorization ladder, DR-10a/DR-10b —
+	// ONE implementation, shared with handleCopyItem, ordering included.
+	// See resolveAuthorizedCopy for why each step sits where it does; the
+	// dry run and the mutation must agree about the ORDER of refusals, not
+	// merely the set, and the only way to guarantee that is to have one
+	// copy of the sequence.
+	ac, ok := s.resolveAuthorizedCopy(w, r)
 	if !ok {
 		return
 	}
-
-	itemSlug := chi.URLParam(r, "itemSlug")
-	item, err := s.store.ResolveItem(sourceWorkspaceID, itemSlug)
-	if err != nil {
-		writeInternalError(w, err)
-		return
-	}
-	if item == nil {
-		// ResolveItem filters soft-deleted rows, so this covers "absent"
-		// AND "archived". writeItemResolveError separates them the same
-		// way the move and update paths do — 409 archived when the caller
-		// can independently SEE the archived row, 404 otherwise — so the
-		// distinction is never made for someone who could not see it.
-		s.writeItemResolveError(w, r, sourceWorkspaceID, itemSlug)
-		return
-	}
-
-	// ---- Authorization, DR-10a/DR-10b, four checks in order -----------
-	//
-	// Checks 1 and 2 (source item visibility, then source edit) compose
-	// out of one AuthorizeCrossWorkspaceEdit call with an item scope; 3
-	// and 4 (destination collection visibility, then destination edit)
-	// out of one with a collection scope. The early return between them
-	// is part of the ordering, not style: a destination verdict built for
-	// a caller who could not read the source is itself a disclosure.
-	//
-	// The helper is used for the SOURCE too, even though it is the
-	// request's own workspace, because it derives the role from
-	// membership rather than from workspaceRole(r) — the same answer the
-	// front door gives, computed without the context value the
-	// destination half must not touch. One code path, one ordering.
-	src := s.AuthorizeCrossWorkspaceEdit(r, sourceWorkspaceID, CrossWorkspaceItemScope(item))
-	if !src.Allowed {
-		// WriteHidden: absence and forbidden-ness are one 404. A preflight
-		// that confirmed a hidden item exists would be the leak DR-10b is
-		// about.
-		src.WriteHidden(w, "Item")
-		return
-	}
-
-	// decodeJSON, not json.NewDecoder: it wraps the body in a
-	// MaxBytesReader so field_overrides cannot be used to make the server
-	// allocate a multi-GB map on an endpoint that is designed to be called
-	// repeatedly from a live UI (Codex round 7).
-	var input itemCopyPreflightRequest
-	if err := decodeJSON(r, &input); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid_body", "Invalid JSON body")
-		return
-	}
-	if input.TargetWorkspace == "" {
-		writeError(w, http.StatusBadRequest, "missing_field", "target_workspace is required")
-		return
-	}
-	if input.TargetCollection == "" {
-		writeError(w, http.StatusBadRequest, "missing_field", "target_collection is required")
-		return
-	}
-
-	// Check 3, part one: workspace-level access to the destination. This
-	// is the narrow legitimate use of the workspace-only scope — an early
-	// reject BEFORE the collection is known, because resolving a
-	// collection slug requires the destination workspace's ID and doing
-	// that lookup first would answer a question about a workspace the
-	// caller may have no business addressing.
-	dstWS := s.AuthorizeCrossWorkspaceEdit(r, input.TargetWorkspace, CrossWorkspaceWorkspaceOnlyScope())
-	if !dstWS.Allowed {
-		// WriteDenied, not WriteHidden: the caller named this workspace
-		// themselves, so acknowledging the refusal tells them nothing they
-		// did not already assert. It still refuses to separate "absent"
-		// from "forbidden".
-		dstWS.WriteDenied(w)
-		return
-	}
-
-	targetColl, err := s.store.GetCollectionBySlug(dstWS.WorkspaceID(), input.TargetCollection)
-	if err != nil {
-		writeInternalError(w, err)
-		return
-	}
-	if targetColl == nil {
-		writeError(w, http.StatusNotFound,
-			crossWorkspaceCollectionNotFoundCode, crossWorkspaceCollectionNotFoundMessage)
-		return
-	}
-
-	// Checks 3 (collection visibility) and 4 (collection edit). The
-	// collection-scoped denial is written by WriteCollectionNotFound,
-	// which collapses "hidden" onto the same 404 the nil branch above
-	// emits — otherwise a restricted member of the destination could
-	// enumerate the collections they were excluded from.
-	dst := s.AuthorizeCrossWorkspaceEdit(r, input.TargetWorkspace, CrossWorkspaceCollectionScope(targetColl.ID))
-	if !dst.Allowed {
-		dst.WriteCollectionNotFound(w)
-		return
-	}
-
-	// Who the copy would be attributed to, resolved through the SAME function
-	// the mutating copy uses and refused here on the same terms. Nothing is
-	// written on this path, so a placeholder would work — and that is exactly
-	// the trap: an earlier version supplied a `"preflight"` literal as a last
-	// resort, so this endpoint happily previewed a copy the mutation would
-	// refuse outright for want of an actor (Codex round 4).
-	//
-	// Placed HERE, immediately after the fourth authorization check and
-	// BEFORE any field or override handling, because the mutating copy checks
-	// it in the same position. Leaving it down by the attachment planner made
-	// the two disagree about a request that fails BOTH ways — no actor and a
-	// malformed override — with the preview reporting the override and the
-	// copy the actor (Codex round 5). Agreement is about the ORDER of
-	// refusals, not just the set.
-	actorID := copyActorID(r, item)
-	if actorID == "" {
-		writeCopyActorRequired(w)
-		return
-	}
+	sourceWorkspaceID := ac.sourceWorkspaceID
+	item := ac.item
+	input := ac.input
+	src := ac.source
+	dst := ac.destination
+	targetColl := ac.targetCollection
+	actorID := ac.actorID
 
 	// ---- Everything below this line is authorized and read-only -------
 	//

--- a/internal/server/handlers_items_copy_resolve.go
+++ b/internal/server/handlers_items_copy_resolve.go
@@ -1,0 +1,215 @@
+package server
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// authorizedCopy is everything a cross-workspace copy request resolves to
+// once it has passed resolution and the full authorization ladder. It is the
+// single output of resolveAuthorizedCopy and the single input to both
+// consumers — the dry run (handleCopyItemPreflight) and the mutation
+// (handleCopyItem).
+//
+// NEVER PUT THIS STRUCT IN A RESPONSE. It embeds two CrossWorkspaceAccess
+// verdicts, which carry the resolved workspace, role and denial reason the
+// disclosure rules forbid surfacing. See CrossWorkspaceAccess's own note.
+type authorizedCopy struct {
+	// sourceWorkspaceID is the request's own workspace, resolved by
+	// getWorkspaceID — i.e. the workspace in the URL, not the destination.
+	sourceWorkspaceID string
+
+	// item is the resolved, visible, editable source item.
+	item *models.Item
+
+	// input is the decoded request body. Both endpoints take the same
+	// shape, which is why itemCopyPreflightRequest names both.
+	input itemCopyPreflightRequest
+
+	// source / destination are the two authorization verdicts, both
+	// Allowed. destination is COLLECTION-scoped (the fourth check), so it
+	// is the verdict WriteCollectionNotFound was built for.
+	source      CrossWorkspaceAccess
+	destination CrossWorkspaceAccess
+
+	// targetCollection is the resolved destination collection.
+	targetCollection *models.Collection
+
+	// actorID is who the copy is attributed to — see copyActorID. It is
+	// NOT the actor/source audit pair from actorFromRequest, which is a
+	// different thing entirely and belongs only to the mutating path.
+	actorID string
+}
+
+// resolveAuthorizedCopy performs the resolution and the four-step
+// authorization ladder shared by the copy preflight and the copy itself.
+//
+// It returns ok=false when the request was refused; the response has ALREADY
+// been written in that case and the caller must simply return.
+//
+// WHY THIS EXISTS. Both endpoints ran this sequence statement for statement,
+// and the preflight/copy divergence class is empirically the number one
+// defect source in PLAN-2357 — five separate divergences were found and fixed
+// in Phase 2 alone, one of which was a disagreement about the ORDER of
+// refusals rather than the set. The ordering below is therefore not an
+// implementation detail of either handler; it is the contract, expressed
+// once. TestCopyAuthorizationParityMatrix pins the observable half of that
+// contract as an executable claim — if the two endpoints ever answer a
+// refusal differently, or in a different order, it fails. Keeping the
+// sequence in ONE place is what makes that hard to break in the first
+// place; the test is the backstop, not the guarantee.
+//
+// THE ORDERING, and why each step sits where it does:
+//
+//  1. Source workspace + item resolution, BEFORE the body is decoded.
+//     Inverting this leaks source existence: a caller who cannot see the item
+//     would learn whether their JSON was well-formed, and a caller who could
+//     see it would not. writeItemResolveError keeps its 404-vs-409 split —
+//     409 archived only when the caller can independently SEE the archived
+//     row, 404 otherwise.
+//
+//  2. Checks 1 and 2 (source item visibility, then source edit), composed out
+//     of one AuthorizeCrossWorkspaceEdit call with an item scope. The early
+//     return before the destination half is part of the ordering, not style:
+//     a destination verdict built for a caller who could not read the source
+//     is itself a disclosure. WriteHidden collapses absence and
+//     forbidden-ness onto one 404 (DR-10b).
+//
+//     The helper is used for the SOURCE too, even though it is the request's
+//     own workspace, because it derives the role from membership rather than
+//     from workspaceRole(r) — the same answer the front door gives, computed
+//     without the context value the destination half must not touch.
+//
+//  3. Body decode and required-field checks, which sit HERE — after source
+//     authorization, before any destination lookup. Hoisting the destination
+//     lookup earlier would disclose destination state to a caller sending a
+//     bad body.
+//
+//  4. Check 3, part one: workspace-level access to the destination. This is
+//     the narrow legitimate use of the workspace-only scope — an early reject
+//     BEFORE the collection is known, because resolving a collection slug
+//     requires the destination workspace's ID and doing that lookup first
+//     would answer a question about a workspace the caller may have no
+//     business addressing. WriteDenied, not WriteHidden: the caller named
+//     this workspace themselves. Note it is not one outcome — it emits 500,
+//     permission_denied or forbidden depending on the reason.
+//
+//  5. Destination collection lookup, then checks 3 (collection visibility)
+//     and 4 (collection edit). WriteCollectionNotFound collapses "hidden"
+//     onto the same 404 the nil branch emits, or delegates back to
+//     WriteDenied — otherwise a restricted member of the destination could
+//     enumerate the collections they were excluded from.
+//
+//  6. Actor attribution, immediately after the fourth check and BEFORE any
+//     field or override handling. Position matters: an earlier version
+//     resolved it down by the attachment planner, so the two endpoints
+//     disagreed about a request that fails BOTH ways — no actor and a
+//     malformed override — with the preview reporting the override and the
+//     copy the actor.
+//
+// NOT read here, deliberately: `force`, or any query parameter at all.
+// archive_source is JSON input. The intra-workspace move handler's force
+// semantics are its own and must not be inherited by proximity.
+func (s *Server) resolveAuthorizedCopy(w http.ResponseWriter, r *http.Request) (authorizedCopy, bool) {
+	var out authorizedCopy
+
+	sourceWorkspaceID, ok := s.getWorkspaceID(w, r)
+	if !ok {
+		return out, false
+	}
+	out.sourceWorkspaceID = sourceWorkspaceID
+
+	itemSlug := chi.URLParam(r, "itemSlug")
+	item, err := s.store.ResolveItem(sourceWorkspaceID, itemSlug)
+	if err != nil {
+		writeInternalError(w, err)
+		return out, false
+	}
+	if item == nil {
+		// ResolveItem filters soft-deleted rows, so this covers "absent"
+		// AND "archived". writeItemResolveError separates them the same
+		// way the move and update paths do — 409 archived when the caller
+		// can independently SEE the archived row, 404 otherwise — so the
+		// distinction is never made for someone who could not see it.
+		s.writeItemResolveError(w, r, sourceWorkspaceID, itemSlug)
+		return out, false
+	}
+	out.item = item
+
+	// ---- Authorization, DR-10a/DR-10b, four checks in order -----------
+	src := s.AuthorizeCrossWorkspaceEdit(r, sourceWorkspaceID, CrossWorkspaceItemScope(item))
+	if !src.Allowed {
+		// WriteHidden: absence and forbidden-ness are one 404. A response
+		// that confirmed a hidden item exists would be the leak DR-10b is
+		// about.
+		src.WriteHidden(w, "Item")
+		return out, false
+	}
+	out.source = src
+
+	// decodeJSON, not json.NewDecoder: it wraps the body in a
+	// MaxBytesReader so field_overrides cannot be used to make the server
+	// allocate a multi-GB map on an endpoint that is designed to be called
+	// repeatedly from a live UI (Codex round 7).
+	var input itemCopyPreflightRequest
+	if err := decodeJSON(r, &input); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_body", "Invalid JSON body")
+		return out, false
+	}
+	if input.TargetWorkspace == "" {
+		writeError(w, http.StatusBadRequest, "missing_field", "target_workspace is required")
+		return out, false
+	}
+	if input.TargetCollection == "" {
+		writeError(w, http.StatusBadRequest, "missing_field", "target_collection is required")
+		return out, false
+	}
+	out.input = input
+
+	dstWS := s.AuthorizeCrossWorkspaceEdit(r, input.TargetWorkspace, CrossWorkspaceWorkspaceOnlyScope())
+	if !dstWS.Allowed {
+		// WriteDenied, not WriteHidden: the caller named this workspace
+		// themselves, so acknowledging the refusal tells them nothing they
+		// did not already assert. It still refuses to separate "absent"
+		// from "forbidden".
+		dstWS.WriteDenied(w)
+		return out, false
+	}
+
+	targetColl, err := s.store.GetCollectionBySlug(dstWS.WorkspaceID(), input.TargetCollection)
+	if err != nil {
+		writeInternalError(w, err)
+		return out, false
+	}
+	if targetColl == nil {
+		writeError(w, http.StatusNotFound,
+			crossWorkspaceCollectionNotFoundCode, crossWorkspaceCollectionNotFoundMessage)
+		return out, false
+	}
+
+	dst := s.AuthorizeCrossWorkspaceEdit(r, input.TargetWorkspace, CrossWorkspaceCollectionScope(targetColl.ID))
+	if !dst.Allowed {
+		dst.WriteCollectionNotFound(w)
+		return out, false
+	}
+	out.destination = dst
+	out.targetCollection = targetColl
+
+	// Who the copy is attributed to, resolved through ONE function and
+	// refused on one set of terms. The preflight writes nothing, so a
+	// placeholder would "work" there — and that is exactly the trap: an
+	// earlier version supplied a `"preflight"` literal as a last resort, so
+	// the dry run happily previewed a copy the mutation would refuse
+	// outright for want of an actor (Codex round 4).
+	actorID := copyActorID(r, item)
+	if actorID == "" {
+		writeCopyActorRequired(w)
+		return out, false
+	}
+	out.actorID = actorID
+
+	return out, true
+}

--- a/internal/server/handlers_items_copy_test.go
+++ b/internal/server/handlers_items_copy_test.go
@@ -1651,9 +1651,9 @@ func TestCopyEndpoint_MoveArchivesTheSource(t *testing.T) {
 	if live, err := f.srv.store.GetItem(f.source.ID); err != nil || live != nil {
 		t.Errorf("the source is still live after a move (err=%v)", err)
 	}
-	moves, err := f.srv.store.ListItemWorkspaceMovesBySource(f.source.ID)
+	moves, err := f.srv.store.ListArchivedItemWorkspaceMovesBySource(f.source.ID, 10)
 	if err != nil {
-		t.Fatalf("ListItemWorkspaceMovesBySource: %v", err)
+		t.Fatalf("ListArchivedItemWorkspaceMovesBySource: %v", err)
 	}
 	if len(moves) != 1 || moves[0].TargetItemID != res.Item.ID || !moves[0].ArchivedSource {
 		t.Fatalf("provenance rows = %+v, want one archived pointer at %s", moves, res.Item.ID)

--- a/internal/store/collections.go
+++ b/internal/store/collections.go
@@ -83,17 +83,71 @@ func (s *Store) CreateCollection(workspaceID string, input models.CollectionCrea
 	return s.GetCollection(id)
 }
 
-func (s *Store) GetCollection(id string) (*models.Collection, error) {
+// collectionColumns is the ONE full-row projection of the collections table.
+// Every accessor that hydrates a COMPLETE models.Collection from a single row
+// selects exactly this list, in this order, and scans it through
+// scanCollectionRow — so adding a stored column to those accessors is a single
+// edit rather than a hunt for copies that silently drift apart (TASK-2368).
+//
+// SCOPE: the single-row accessors — GetCollection, GetCollectionAnyState, and
+// the transactional getCollectionInWorkspaceTx. ListCollections is
+// deliberately NOT folded in and remains a separate projection: it is an
+// aggregate multi-row query with table-aliased columns, a trailing
+// COUNT(i.id), and no deleted_at (its WHERE already excludes deleted rows).
+// Sharing a list across those shapes would need a second, count-aware scanner
+// and would reshape a hot aggregate for no correctness gain.
+//
+// SO IF YOU ARE ADDING A STORED COLLECTION COLUMN, this list is one of four
+// edits, not the only one. The others are ListCollections (above), and
+// ExportWorkspace / ImportWorkspace in export.go, which carry their own
+// projection over models.CollectionExport — a portability format, deliberately
+// not this model: it omits workspace_id and deleted_at because an import
+// assigns a fresh workspace and an export skips deleted rows. A column added
+// here but not there hydrates everywhere and still vanishes on export/import.
+const collectionColumns = `id, workspace_id, name, slug, prefix, icon, description, schema, settings, sort_order, is_default, is_system, created_at, updated_at, deleted_at`
+
+// collectionSelect is the shared prefix each single-row accessor completes
+// with its own predicate. Assembled from constants, so the full statement is
+// built at COMPILE time — no per-call concatenation on GetCollection's hot
+// path, and no runtime-assembled SQL fragment for s.q to rewrite.
+const collectionSelect = `SELECT ` + collectionColumns + ` FROM collections WHERE `
+
+const (
+	getCollectionQuery            = collectionSelect + `id = ? AND deleted_at IS NULL`
+	getCollectionAnyStateQuery    = collectionSelect + `id = ?`
+	getCollectionInWorkspaceQuery = collectionSelect + `id = ? AND workspace_id = ? AND deleted_at IS NULL`
+)
+
+// scanCollectionRow reads one collection row through q and hydrates the model.
+// The WHERE predicate is the only per-caller difference — scope and
+// deleted-state are the callers' decisions, and for the transactional copy
+// path the workspace scope is a security boundary, not a hint. Callers pass a
+// full constant statement rather than a fragment, so there is no dynamic SQL
+// here for a future caller to interpolate into.
+//
+// Parameterized over rowQueryer (the uniqueSlugQ / validateAssignmentScopeQ
+// pattern from TASK-2362) so the same read runs against *sql.DB or inside a
+// caller's *sql.Tx, under the locks that transaction already holds. The read
+// executes on whatever q is given and never falls back to s.db, so it cannot
+// escape the caller's transaction — but rowQueryer accepts both, so CHOOSING
+// the wrong one is a semantic error the compiler will not catch. A caller that
+// needs the read under its own locks must pass its tx; getCollectionInWorkspaceTx
+// is the existing example, and its *sql.Tx signature is what enforces that at
+// its call sites.
+//
+// s.q rewrites the placeholders for the active dialect here, so every caller
+// gets that for free and none may skip it.
+//
+// A MISS IS NOT AN ERROR: sql.ErrNoRows returns (nil, nil), matching every
+// caller's contract. Real failures are returned unwrapped so each accessor can
+// apply its own distinct error prefix.
+func (s *Store) scanCollectionRow(q rowQueryer, query string, args ...any) (*models.Collection, error) {
 	var c models.Collection
 	var createdAt, updatedAt string
 	var deletedAt *string
 	var isDefault bool
 
-	err := s.db.QueryRow(s.q(`
-		SELECT id, workspace_id, name, slug, prefix, icon, description, schema, settings, sort_order, is_default, is_system, created_at, updated_at, deleted_at
-		FROM collections
-		WHERE id = ? AND deleted_at IS NULL
-	`), id).Scan(
+	err := q.QueryRow(s.q(query), args...).Scan(
 		&c.ID, &c.WorkspaceID, &c.Name, &c.Slug, &c.Prefix, &c.Icon, &c.Description,
 		&c.Schema, &c.Settings, &c.SortOrder, &isDefault, &c.IsSystem,
 		&createdAt, &updatedAt, &deletedAt,
@@ -102,7 +156,7 @@ func (s *Store) GetCollection(id string) (*models.Collection, error) {
 		return nil, nil
 	}
 	if err != nil {
-		return nil, fmt.Errorf("get collection: %w", err)
+		return nil, err
 	}
 
 	c.IsDefault = isDefault
@@ -110,6 +164,14 @@ func (s *Store) GetCollection(id string) (*models.Collection, error) {
 	c.UpdatedAt = parseTime(updatedAt)
 	c.DeletedAt = parseTimePtr(deletedAt)
 	return &c, nil
+}
+
+func (s *Store) GetCollection(id string) (*models.Collection, error) {
+	c, err := s.scanCollectionRow(s.db, getCollectionQuery, id)
+	if err != nil {
+		return nil, fmt.Errorf("get collection: %w", err)
+	}
+	return c, nil
 }
 
 // GetCollectionAnyState is GetCollection without the
@@ -124,31 +186,11 @@ func (s *Store) GetCollection(id string) (*models.Collection, error) {
 // doneFiltersForWorkspace, both of which already include soft-deleted
 // collections for exactly this reason.
 func (s *Store) GetCollectionAnyState(id string) (*models.Collection, error) {
-	var c models.Collection
-	var createdAt, updatedAt string
-	var deletedAt *string
-	var isDefault bool
-
-	err := s.db.QueryRow(s.q(`
-		SELECT id, workspace_id, name, slug, prefix, icon, description, schema, settings, sort_order, is_default, is_system, created_at, updated_at, deleted_at
-		FROM collections
-		WHERE id = ?
-	`), id).Scan(
-		&c.ID, &c.WorkspaceID, &c.Name, &c.Slug, &c.Prefix, &c.Icon, &c.Description,
-		&c.Schema, &c.Settings, &c.SortOrder, &isDefault, &c.IsSystem,
-		&createdAt, &updatedAt, &deletedAt,
-	)
-	if err == sql.ErrNoRows {
-		return nil, nil
-	}
+	c, err := s.scanCollectionRow(s.db, getCollectionAnyStateQuery, id)
 	if err != nil {
 		return nil, fmt.Errorf("get collection (any state): %w", err)
 	}
-	c.IsDefault = isDefault
-	c.CreatedAt = parseTime(createdAt)
-	c.UpdatedAt = parseTime(updatedAt)
-	c.DeletedAt = parseTimePtr(deletedAt)
-	return &c, nil
+	return c, nil
 }
 
 func (s *Store) GetCollectionBySlug(workspaceID, slug string) (*models.Collection, error) {

--- a/internal/store/collections_test.go
+++ b/internal/store/collections_test.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/PerpetualSoftware/pad/internal/models"
 )
@@ -770,4 +771,200 @@ func collectionSlugs(colls []models.Collection) []string {
 		out = append(out, c.Slug)
 	}
 	return out
+}
+
+// TestCollectionAccessorsShareOneHydration is the TASK-2368 outcome guard.
+//
+// Three accessors read a full collection row — GetCollection,
+// GetCollectionAnyState and the transactional getCollectionInWorkspaceTx used
+// by the cross-workspace copy. They used to carry three verbatim copies of the
+// same 15-column projection and scan block, so a column added to the model in
+// one place drifted silently in the other two. They now share
+// collectionColumns + scanCollectionRow, and the WHERE predicate is the only
+// per-caller difference.
+//
+// Equality alone would pass just as well with three copies (it tests
+// behaviour that was already true), so this also pins the two properties the
+// duplication actually threatened: every scanned column is populated with a
+// DISTINCT non-zero value, so a mis-ordered or dropped column in a future edit
+// shows up as a mismatch rather than two zero values agreeing; and the
+// predicates that differ still differ — soft-delete state and workspace scope
+// are checked below.
+func TestCollectionAccessorsShareOneHydration(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Hydration")
+	other := createTestWorkspace(t, s, "Elsewhere")
+
+	created, err := s.CreateCollection(ws.ID, models.CollectionCreate{
+		Name:        "Distinctive",
+		Slug:        "distinctive",
+		Prefix:      "DIST",
+		Icon:        "sparkles",
+		Description: "every scanned column carries a distinct value",
+		Schema:      `{"fields":[{"key":"status","label":"Status","type":"select","options":["open","done"]}]}`,
+		Settings:    `{"board_group_by":"status"}`,
+		IsDefault:   true,
+		IsSystem:    true,
+	})
+	if err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	// sort_order is 0 on insert, and created_at/updated_at are stamped equal;
+	// give all three distinct known values so a dropped or transposed column
+	// cannot pass by matching another column's value.
+	const (
+		wantCreatedAt = "2021-03-04T05:06:07Z"
+		wantUpdatedAt = "2022-08-09T10:11:12Z"
+	)
+	if _, err := s.db.Exec(
+		s.q(`UPDATE collections SET sort_order = ?, created_at = ?, updated_at = ? WHERE id = ?`),
+		7, wantCreatedAt, wantUpdatedAt, created.ID,
+	); err != nil {
+		t.Fatalf("set distinct column values: %v", err)
+	}
+
+	readTx := func(t *testing.T, collectionID, workspaceID string) *models.Collection {
+		t.Helper()
+		tx, err := s.db.Begin()
+		if err != nil {
+			t.Fatalf("Begin: %v", err)
+		}
+		defer func() { _ = tx.Rollback() }()
+		c, err := s.getCollectionInWorkspaceTx(tx, collectionID, workspaceID)
+		if err != nil {
+			t.Fatalf("getCollectionInWorkspaceTx: %v", err)
+		}
+		return c
+	}
+
+	get, err := s.GetCollection(created.ID)
+	if err != nil {
+		t.Fatalf("GetCollection: %v", err)
+	}
+	anyState, err := s.GetCollectionAnyState(created.ID)
+	if err != nil {
+		t.Fatalf("GetCollectionAnyState: %v", err)
+	}
+	inTx := readTx(t, created.ID, ws.ID)
+
+	if get == nil || anyState == nil || inTx == nil {
+		t.Fatalf("live collection missed by an accessor: get=%v anyState=%v inTx=%v", get, anyState, inTx)
+	}
+
+	// Every column is checked against a LITERAL expected value, not against
+	// another accessor's output. Cross-accessor equality alone cannot catch a
+	// mutation in the shared projection or scan — transposing `slug` and
+	// `prefix` in collectionColumns while leaving the scan destinations put
+	// would make all three agree on the same wrong answer. Every value here is
+	// distinct and non-zero, so a transposition or a jointly-dropped
+	// column/destination pair lands as a mismatch rather than two zero values
+	// agreeing.
+	for _, tc := range []struct {
+		field     string
+		got, want any
+	}{
+		{"ID", get.ID, created.ID},
+		{"WorkspaceID", get.WorkspaceID, ws.ID},
+		{"Name", get.Name, "Distinctive"},
+		{"Slug", get.Slug, "distinctive"},
+		{"Prefix", get.Prefix, "DIST"},
+		{"Icon", get.Icon, "sparkles"},
+		{"Description", get.Description, "every scanned column carries a distinct value"},
+		{"SortOrder", get.SortOrder, 7},
+		{"IsDefault", get.IsDefault, true},
+		{"IsSystem", get.IsSystem, true},
+	} {
+		if tc.got != tc.want {
+			t.Errorf("hydrated %s = %#v, want %#v — the shared projection and scan destinations disagree", tc.field, tc.got, tc.want)
+		}
+	}
+	// Schema and Settings are compared SEMANTICALLY: Postgres stores them as
+	// JSONB and re-serializes on readback, so key order and spacing differ from
+	// the literals the fixture sent. They still pin the two columns against
+	// each other — the two documents share no keys, so a transposition fails.
+	sameJSON := func(t *testing.T, field, got, want string) {
+		t.Helper()
+		var g, w any
+		if err := json.Unmarshal([]byte(got), &g); err != nil {
+			t.Errorf("hydrated %s is not valid JSON (%q): %v", field, got, err)
+			return
+		}
+		if err := json.Unmarshal([]byte(want), &w); err != nil {
+			t.Fatalf("fixture %s is not valid JSON: %v", field, err)
+		}
+		if !reflect.DeepEqual(g, w) {
+			t.Errorf("hydrated %s = %s, want %s — the shared projection and scan destinations disagree", field, got, want)
+		}
+	}
+	sameJSON(t, "Schema", get.Schema, `{"fields":[{"key":"status","label":"Status","type":"select","options":["open","done"]}]}`)
+	sameJSON(t, "Settings", get.Settings, `{"board_group_by":"status"}`)
+
+	// The two timestamps are set to DIFFERENT instants above, so transposing
+	// created_at and updated_at fails here rather than passing on two equal
+	// stamps. deleted_at is the one column with no distinct live value; it is
+	// pinned instead by the soft-delete branch at the end, which is the only
+	// state in which it is non-nil.
+	if got := get.CreatedAt.UTC().Format(time.RFC3339); got != wantCreatedAt {
+		t.Errorf("hydrated CreatedAt = %s, want %s", got, wantCreatedAt)
+	}
+	if got := get.UpdatedAt.UTC().Format(time.RFC3339); got != wantUpdatedAt {
+		t.Errorf("hydrated UpdatedAt = %s, want %s", got, wantUpdatedAt)
+	}
+	if get.DeletedAt != nil {
+		t.Errorf("live collection hydrated DeletedAt = %v, want nil", get.DeletedAt)
+	}
+
+	if !reflect.DeepEqual(get, anyState) {
+		t.Errorf("GetCollectionAnyState hydration differs from GetCollection:\n get      = %+v\n anyState = %+v", get, anyState)
+	}
+	if !reflect.DeepEqual(get, inTx) {
+		t.Errorf("getCollectionInWorkspaceTx hydration differs from GetCollection:\n get  = %+v\n inTx = %+v", get, inTx)
+	}
+
+	// A miss is not an error, at every accessor — the copy path's sentinels
+	// depend on (nil, nil) rather than a wrapped ErrNoRows.
+	if c, err := s.GetCollection("no-such-collection"); err != nil || c != nil {
+		t.Errorf("GetCollection(miss) = (%v, %v), want (nil, nil)", c, err)
+	}
+	if c, err := s.GetCollectionAnyState("no-such-collection"); err != nil || c != nil {
+		t.Errorf("GetCollectionAnyState(miss) = (%v, %v), want (nil, nil)", c, err)
+	}
+	if c := readTx(t, "no-such-collection", ws.ID); c != nil {
+		t.Errorf("getCollectionInWorkspaceTx(miss) = %v, want nil", c)
+	}
+
+	// The transactional read stays WORKSPACE-SCOPED. That scope is the
+	// security boundary which makes a foreign collection a not-found rather
+	// than a cross-workspace write, so it must survive the unification.
+	if c := readTx(t, created.ID, other.ID); c != nil {
+		t.Errorf("getCollectionInWorkspaceTx read a collection from another workspace: %+v", c)
+	}
+
+	// The deleted-state predicates still differ: only GetCollectionAnyState
+	// sees a soft-deleted row, and it is the only one that can hydrate
+	// DeletedAt.
+	// DeleteCollection refuses a default collection, and the fixture is one so
+	// is_default is exercised above; clear the flag rather than weaken it.
+	if _, err := s.db.Exec(s.q(`UPDATE collections SET is_default = ? WHERE id = ?`), s.dialect.BoolToInt(false), created.ID); err != nil {
+		t.Fatalf("clear is_default: %v", err)
+	}
+	if err := s.DeleteCollection(created.ID, ""); err != nil {
+		t.Fatalf("DeleteCollection: %v", err)
+	}
+	if c, err := s.GetCollection(created.ID); err != nil || c != nil {
+		t.Errorf("GetCollection(soft-deleted) = (%v, %v), want (nil, nil)", c, err)
+	}
+	if c := readTx(t, created.ID, ws.ID); c != nil {
+		t.Errorf("getCollectionInWorkspaceTx(soft-deleted) = %+v, want nil", c)
+	}
+	deleted, err := s.GetCollectionAnyState(created.ID)
+	if err != nil {
+		t.Fatalf("GetCollectionAnyState(soft-deleted): %v", err)
+	}
+	if deleted == nil {
+		t.Fatal("GetCollectionAnyState(soft-deleted) = nil; it must ignore deleted_at")
+	}
+	if deleted.DeletedAt == nil {
+		t.Error("GetCollectionAnyState(soft-deleted).DeletedAt is nil; the deleted_at column is not being hydrated")
+	}
 }

--- a/internal/store/item_workspace_moves.go
+++ b/internal/store/item_workspace_moves.go
@@ -17,18 +17,23 @@ const itemWorkspaceMoveColumns = `id, source_workspace_id, source_item_id,
 	target_workspace_id, target_item_id, archived_source, source_seq,
 	created_by, created_at`
 
-// itemWorkspaceMoveOrder is the shared newest-first ordering.
+// itemWorkspaceMoveOrder is the newest-first ordering.
 //
-// created_at leads because the forward lookup returns copies AND moves, and
-// copies carry no source_seq at all — ordering by seq first would bury every
-// copy behind every move regardless of recency. created_at is UTC RFC3339
-// TEXT, so lexicographic order is chronological order.
+// created_at leads because source_seq is only as trustworthy as whatever the
+// caller passed: imports, backfills and hand-repaired rows can carry a high
+// seq with an old created_at, and under a seq-primary order such a row
+// silently becomes the head. created_at is UTC RFC3339 TEXT, so lexicographic
+// order is chronological order.
 //
 // source_seq breaks the ties created_at cannot: it is second-precision, and
 // archive → restore → move again inside one second is legal (DR-2a). Within a
 // single second the higher source_seq is unambiguously the later move.
 // COALESCE rather than "NULLS LAST" because SQLite and Postgres disagree on
 // default NULL placement in DESC order; -1 sorts below every real seq on both.
+// The COALESCE is defensive rather than load-bearing today — the one
+// production query using this ordering reads archived rows only, and
+// RecordItemWorkspaceMoveTx requires a seq on those — but it costs nothing and
+// keeps the ordering total if the predicate ever widens.
 //
 // id is a final tiebreak so the ordering is total and the result set is
 // stable across calls.
@@ -108,54 +113,21 @@ func (s *Store) RecordItemWorkspaceMoveTx(tx *sql.Tx, m models.ItemWorkspaceMove
 	return &m, nil
 }
 
-// ListItemWorkspaceMovesBySource returns every destination one source item was
-// copied or moved to, newest first.
-//
-// A SET, not a row: one source can be copied into several workspaces, and can
-// additionally be moved after being restored. The caller decides how to render
-// multiples.
-//
-// This is the BROAD lookup — copies and moves alike — for callers that want
-// the whole provenance picture. The archived-source "moved to" pointer is not
-// one of them: it reads only ArchivedSource rows (DR-2a) and needs a bound on
-// how many it will authorize, so it uses
-// ListArchivedItemWorkspaceMovesBySource instead of filtering this result.
-func (s *Store) ListItemWorkspaceMovesBySource(sourceItemID string) ([]models.ItemWorkspaceMove, error) {
-	rows, err := s.db.Query(s.q(`
-		SELECT `+itemWorkspaceMoveColumns+`
-		FROM item_workspace_moves
-		WHERE source_item_id = ?`+itemWorkspaceMoveOrder,
-	), sourceItemID)
-	if err != nil {
-		return nil, fmt.Errorf("list item workspace moves by source: %w", err)
-	}
-	defer rows.Close()
-
-	moves := []models.ItemWorkspaceMove{}
-	for rows.Next() {
-		m, err := scanItemWorkspaceMove(rows)
-		if err != nil {
-			return nil, fmt.Errorf("list item workspace moves by source: %w", err)
-		}
-		moves = append(moves, *m)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("list item workspace moves by source: %w", err)
-	}
-	return moves, nil
-}
-
 // ListArchivedItemWorkspaceMovesBySource returns at most `limit` MOVE rows for
 // one source — rows with archived_source true — newest first.
 //
-// The narrow counterpart to ListItemWorkspaceMovesBySource, for the one
-// consumer that wants moves and only moves: the archived-source "moved to"
-// pointer (PLAN-2357 DR-2a / TASK-2359). Its reason to exist is that the
-// caller bounds how many destinations it will AUTHORIZE, and that bound is
-// only meaningful if the row set it authorizes over is bounded too. Filtering
-// in Go instead would leave a source with a long tail of plain COPIES loading,
-// scanning and allocating every one of them on every read of the source, while
-// none of them can ever contribute to the result.
+// It serves the one consumer that wants moves and only moves: the
+// archived-source "moved to" pointer (PLAN-2357 DR-2a / TASK-2359). The
+// archived_source predicate and the LIMIT are both pushed into SQL rather than
+// applied by the caller, because the caller bounds how many destinations it
+// will AUTHORIZE, and that bound is only meaningful if the row set it
+// authorizes over is bounded too. Filtering in Go over an unfiltered forward
+// lookup instead would leave a source with a long tail of plain COPIES
+// loading, scanning and allocating every one of them on every read of the
+// source, while none of them can ever contribute to the result. A broad
+// copies-and-moves forward lookup existed alongside this one until TASK-2374
+// and was deleted unused; a "copied from" affordance that wanted it back would
+// need its own dual-sided disclosure design (DR-20) before the query matters.
 //
 // What the LIMIT bounds is rows RETURNED — materialized, scanned into structs,
 // and handed to the caller's per-row authorization. It is not a promise about
@@ -167,21 +139,21 @@ func (s *Store) ListItemWorkspaceMovesBySource(sourceItemID string) ([]models.It
 // source are inherently tiny — one per copy or move of a single item — so the
 // equality lookup on idx_item_workspace_moves_source is the part that matters.
 //
-// The ordering is itemWorkspaceMoveOrder, shared VERBATIM with the broad
-// forward lookup, and that is a deliberate refusal to specialize. Ordering
+// The ordering is itemWorkspaceMoveOrder, and leading with created_at rather
+// than source_seq is a deliberate refusal to specialize. Ordering
 // archived-only rows by `source_seq DESC` alone would match the partial
 // index's columns and reads as strictly better — source_seq is NOT NULL for a
 // move (RecordItemWorkspaceMoveTx enforces it) and is workspace-A-monotonic
-// when the copy path supplies the seq the archive assigned. But the STORE
-// cannot enforce that it is that seq: the column takes whatever the caller
-// passes, there is no production writer yet to establish the habit, and
-// imports, backfills and hand-repaired rows can carry a high seq with an old
+// when the copy path supplies the seq the archive assigned — which the one
+// production writer, CopyItemAcrossWorkspaces, does. But the STORE cannot
+// enforce that it is that seq: the column takes whatever the caller passes, no
+// constraint ties it to the source workspace's sequence, and imports,
+// backfills and hand-repaired rows can carry a high seq with an old
 // created_at. Under a seq-primary order such a row silently becomes the head —
 // and with the cap, evicts the genuinely newest destination. Leading with
 // created_at makes the pathological case merely mis-tiebroken instead of
-// inverted, and keeps two queries over the same rows from disagreeing about
-// what "newest" means. source_seq stays as the second term, which is the tie
-// DR-2a actually needs it for.
+// inverted. source_seq stays as the second term, which is the tie DR-2a
+// actually needs it for.
 //
 // A non-positive limit returns no rows rather than every row: this is a bound,
 // and a caller that forgot to set one should get the safe answer.
@@ -213,31 +185,6 @@ func (s *Store) ListArchivedItemWorkspaceMovesBySource(sourceItemID string, limi
 		return nil, fmt.Errorf("list archived item workspace moves by source: %w", err)
 	}
 	return moves, nil
-}
-
-// GetItemWorkspaceMoveByTarget returns where a destination item came from, or
-// (nil, nil) when the item was not produced by a cross-workspace copy.
-//
-// One row, unlike the forward lookup, and that is enforced rather than
-// assumed: a destination item is created by exactly one copy operation whose
-// provenance row is written in the same transaction, and
-// uq_item_workspace_moves_target makes a second row naming the same target
-// impossible. No ordering or LIMIT is needed as a result.
-func (s *Store) GetItemWorkspaceMoveByTarget(targetItemID string) (*models.ItemWorkspaceMove, error) {
-	row := s.db.QueryRow(s.q(`
-		SELECT `+itemWorkspaceMoveColumns+`
-		FROM item_workspace_moves
-		WHERE target_item_id = ?`,
-	), targetItemID)
-
-	m, err := scanItemWorkspaceMove(row)
-	if err == sql.ErrNoRows {
-		return nil, nil
-	}
-	if err != nil {
-		return nil, fmt.Errorf("get item workspace move by target: %w", err)
-	}
-	return m, nil
 }
 
 // scanner (api_tokens.go) is satisfied by both *sql.Row and *sql.Rows.

--- a/internal/store/item_workspace_moves_test.go
+++ b/internal/store/item_workspace_moves_test.go
@@ -67,10 +67,44 @@ func (f moveFixture) record(t *testing.T, m models.ItemWorkspaceMove) *models.It
 
 func seqPtr(v int64) *int64 { return &v }
 
-// TestRecordItemWorkspaceMoveTx_RoundTrip covers insert-in-tx plus both
-// lookups, and asserts every column survives the dialect round-trip —
-// notably archived_source (INTEGER on SQLite, BOOLEAN on Postgres) and the
-// nullable source_seq.
+// bySource reads back every provenance row for one source, newest first.
+//
+// A test-local query rather than a store accessor: the only production read of
+// this table is the archived-only "moved to" lookup, and the write-path tests
+// below have to see plain COPIES too — rows that lookup deliberately excludes.
+// A broad forward accessor existed for exactly this until TASK-2374 and was
+// deleted with no non-test caller; keeping the breadth here, where it is
+// actually wanted, is the honest place for it.
+func (f moveFixture) bySource(t *testing.T, sourceItemID string) []models.ItemWorkspaceMove {
+	t.Helper()
+
+	rows, err := f.s.db.Query(f.s.q(`
+		SELECT `+itemWorkspaceMoveColumns+`
+		FROM item_workspace_moves
+		WHERE source_item_id = ?`+itemWorkspaceMoveOrder,
+	), sourceItemID)
+	if err != nil {
+		t.Fatalf("read back provenance rows: %v", err)
+	}
+	defer rows.Close()
+
+	moves := []models.ItemWorkspaceMove{}
+	for rows.Next() {
+		m, err := scanItemWorkspaceMove(rows)
+		if err != nil {
+			t.Fatalf("scan provenance row: %v", err)
+		}
+		moves = append(moves, *m)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("read back provenance rows: %v", err)
+	}
+	return moves
+}
+
+// TestRecordItemWorkspaceMoveTx_RoundTrip covers insert-in-tx and asserts
+// every column survives the dialect round-trip — notably archived_source
+// (INTEGER on SQLite, BOOLEAN on Postgres) and the nullable source_seq.
 func TestRecordItemWorkspaceMoveTx_RoundTrip(t *testing.T) {
 	f := newMoveFixture(t, "RoundTrip")
 	target := f.dest(t, f.dstWS, "Copy")
@@ -91,14 +125,11 @@ func TestRecordItemWorkspaceMoveTx_RoundTrip(t *testing.T) {
 		t.Fatal("CreatedAt not generated")
 	}
 
-	forward, err := f.s.ListItemWorkspaceMovesBySource(f.source.ID)
-	if err != nil {
-		t.Fatalf("ListItemWorkspaceMovesBySource: %v", err)
+	readBack := f.bySource(t, f.source.ID)
+	if len(readBack) != 1 {
+		t.Fatalf("read back: got %d rows, want 1", len(readBack))
 	}
-	if len(forward) != 1 {
-		t.Fatalf("forward lookup: got %d rows, want 1", len(forward))
-	}
-	got := forward[0]
+	got := readBack[0]
 	if got.ID != stored.ID {
 		t.Errorf("ID: got %q, want %q", got.ID, stored.ID)
 	}
@@ -121,25 +152,17 @@ func TestRecordItemWorkspaceMoveTx_RoundTrip(t *testing.T) {
 		t.Errorf("CreatedAt: got %q, want %q", got.CreatedAt, stored.CreatedAt)
 	}
 
-	// Back lookup finds the same row from the destination side.
-	back, err := f.s.GetItemWorkspaceMoveByTarget(target.ID)
+	// The row is a MOVE, so the production archived-only lookup must see it
+	// with every column intact — the write path exists to feed that read.
+	moves, err := f.s.ListArchivedItemWorkspaceMovesBySource(f.source.ID, 10)
 	if err != nil {
-		t.Fatalf("GetItemWorkspaceMoveByTarget: %v", err)
+		t.Fatalf("ListArchivedItemWorkspaceMovesBySource: %v", err)
 	}
-	if back == nil {
-		t.Fatal("back lookup returned nil for a recorded target")
+	if len(moves) != 1 || moves[0].ID != stored.ID {
+		t.Fatalf("archived lookup = %+v, want the recorded row %s", moves, stored.ID)
 	}
-	if back.ID != stored.ID || back.SourceItemID != f.source.ID {
-		t.Errorf("back lookup returned wrong row: %+v", back)
-	}
-
-	// A target with no provenance is (nil, nil), not an error.
-	none, err := f.s.GetItemWorkspaceMoveByTarget(f.source.ID)
-	if err != nil {
-		t.Fatalf("GetItemWorkspaceMoveByTarget (absent): %v", err)
-	}
-	if none != nil {
-		t.Errorf("expected nil for an item that was never a copy target, got %+v", none)
+	if moves[0].SourceSeq == nil || *moves[0].SourceSeq != 42 {
+		t.Errorf("archived lookup lost source_seq: %v", moves[0].SourceSeq)
 	}
 }
 
@@ -159,18 +182,25 @@ func TestRecordItemWorkspaceMoveTx_CopyLeavesSeqNull(t *testing.T) {
 		CreatedBy:         f.actor,
 	})
 
-	forward, err := f.s.ListItemWorkspaceMovesBySource(f.source.ID)
-	if err != nil {
-		t.Fatalf("forward lookup: %v", err)
+	stored := f.bySource(t, f.source.ID)
+	if len(stored) != 1 {
+		t.Fatalf("got %d rows, want 1", len(stored))
 	}
-	if len(forward) != 1 {
-		t.Fatalf("got %d rows, want 1", len(forward))
-	}
-	if forward[0].ArchivedSource {
+	if stored[0].ArchivedSource {
 		t.Error("ArchivedSource: got true, want false for a plain copy")
 	}
-	if forward[0].SourceSeq != nil {
-		t.Errorf("SourceSeq: got %v, want nil for a plain copy", *forward[0].SourceSeq)
+	if stored[0].SourceSeq != nil {
+		t.Errorf("SourceSeq: got %v, want nil for a plain copy", *stored[0].SourceSeq)
+	}
+
+	// And the copy is invisible to the moved-to lookup — a copy did not move
+	// the source anywhere (DR-2a).
+	moves, err := f.s.ListArchivedItemWorkspaceMovesBySource(f.source.ID, 10)
+	if err != nil {
+		t.Fatalf("ListArchivedItemWorkspaceMovesBySource: %v", err)
+	}
+	if len(moves) != 0 {
+		t.Errorf("a plain copy surfaced as a moved-to pointer: %+v", moves)
 	}
 }
 
@@ -184,82 +214,6 @@ const (
 	lexHighMoveID = "ffffffff-ffff-ffff-ffff-ffffffffffff"
 	lexLowMoveID  = "00000000-0000-0000-0000-000000000000"
 )
-
-// TestListItemWorkspaceMovesBySource_MultipleDestinationsNewestFirst covers
-// the "forward lookup returns a SET" contract: one source copied into several
-// workspaces yields several rows, newest first — and only that source's rows.
-func TestListItemWorkspaceMovesBySource_MultipleDestinationsNewestFirst(t *testing.T) {
-	f := newMoveFixture(t, "MultiDest")
-	first := f.dest(t, f.dstWS, "First")
-	second := f.dest(t, f.dst2WS, "Second")
-
-	// The OLDER row gets the lexically HIGHER id, so the created_at ordering
-	// is the only thing that can put `second` in front.
-	f.record(t, models.ItemWorkspaceMove{
-		ID:                lexHighMoveID,
-		SourceWorkspaceID: f.srcWS.ID, SourceItemID: f.source.ID,
-		TargetWorkspaceID: f.dstWS.ID, TargetItemID: first.ID,
-		CreatedBy: f.actor, CreatedAt: "2026-01-01T00:00:00Z",
-	})
-	f.record(t, models.ItemWorkspaceMove{
-		ID:                lexLowMoveID,
-		SourceWorkspaceID: f.srcWS.ID, SourceItemID: f.source.ID,
-		TargetWorkspaceID: f.dst2WS.ID, TargetItemID: second.ID,
-		CreatedBy: f.actor, CreatedAt: "2026-01-02T00:00:00Z",
-	})
-
-	// A row belonging to a DIFFERENT source in the same workspace. Without it
-	// the lookup's WHERE clause could be deleted entirely and every
-	// assertion here would still hold.
-	otherSource := createTestItem(t, f.s, f.srcWS.ID,
-		createTestCollection(t, f.s, f.srcWS.ID, "Other Src").ID, "Other Source", "")
-	otherTarget := f.dest(t, f.dstWS, "Other Target")
-	f.record(t, models.ItemWorkspaceMove{
-		SourceWorkspaceID: f.srcWS.ID, SourceItemID: otherSource.ID,
-		TargetWorkspaceID: f.dstWS.ID, TargetItemID: otherTarget.ID,
-		CreatedBy: f.actor, CreatedAt: "2026-01-03T00:00:00Z",
-	})
-
-	forward, err := f.s.ListItemWorkspaceMovesBySource(f.source.ID)
-	if err != nil {
-		t.Fatalf("forward lookup: %v", err)
-	}
-	if len(forward) != 2 {
-		t.Fatalf("got %d rows, want 2 (the other source's row must be excluded)", len(forward))
-	}
-	for _, m := range forward {
-		if m.SourceItemID != f.source.ID {
-			t.Errorf("forward lookup leaked a row for source %q", m.SourceItemID)
-		}
-	}
-	if forward[0].TargetItemID != second.ID {
-		t.Errorf("newest-first violated: first row targets %q, want the later copy %q",
-			forward[0].TargetItemID, second.ID)
-	}
-	if forward[1].TargetItemID != first.ID {
-		t.Errorf("second row targets %q, want the earlier copy %q", forward[1].TargetItemID, first.ID)
-	}
-
-	// Each destination resolves back to its OWN row — asserting the target
-	// too, so a lookup ignoring its WHERE clause is caught here as well.
-	backCases := map[*models.Item]string{first: f.source.ID, second: f.source.ID, otherTarget: otherSource.ID}
-	for target, wantSource := range backCases {
-		back, err := f.s.GetItemWorkspaceMoveByTarget(target.ID)
-		if err != nil {
-			t.Fatalf("back lookup for %s: %v", target.ID, err)
-		}
-		if back == nil {
-			t.Errorf("back lookup for %s returned nil", target.ID)
-			continue
-		}
-		if back.TargetItemID != target.ID {
-			t.Errorf("back lookup for %s returned a row targeting %q", target.ID, back.TargetItemID)
-		}
-		if back.SourceItemID != wantSource {
-			t.Errorf("back lookup for %s resolved to source %q, want %q", target.ID, back.SourceItemID, wantSource)
-		}
-	}
-}
 
 // TestRecordItemWorkspaceMoveTx_RollbackLeavesNoRow proves the row is bound to
 // the caller's transaction: this is the whole reason the helper is tx-taking
@@ -283,19 +237,13 @@ func TestRecordItemWorkspaceMoveTx_RollbackLeavesNoRow(t *testing.T) {
 		t.Fatalf("rollback: %v", err)
 	}
 
-	forward, err := f.s.ListItemWorkspaceMovesBySource(f.source.ID)
-	if err != nil {
-		t.Fatalf("forward lookup: %v", err)
+	if got := f.bySource(t, f.source.ID); len(got) != 0 {
+		t.Errorf("rolled-back tx left %d provenance rows behind", len(got))
 	}
-	if len(forward) != 0 {
-		t.Errorf("rolled-back tx left %d provenance rows behind", len(forward))
-	}
-	back, err := f.s.GetItemWorkspaceMoveByTarget(target.ID)
-	if err != nil {
-		t.Fatalf("back lookup: %v", err)
-	}
-	if back != nil {
-		t.Errorf("rolled-back tx left a back-pointer: %+v", back)
+	// Asserted table-wide too, so a row written against some other source
+	// (i.e. a rollback that committed the wrong thing) is caught as well.
+	if got := f.s.countRows(t, `SELECT COUNT(*) FROM item_workspace_moves`); got != 0 {
+		t.Errorf("rolled-back tx left %d rows in item_workspace_moves", got)
 	}
 }
 
@@ -410,123 +358,6 @@ func TestItemWorkspaceMoves_TargetIsUnique(t *testing.T) {
 	}
 }
 
-// TestItemWorkspaceMoves_MovedToIgnoresCopies is DR-2a's first acceptance
-// criterion: copy twice, then move. The archived source advertises the MOVE
-// target only — neither copy claims the source went anywhere.
-func TestItemWorkspaceMoves_MovedToIgnoresCopies(t *testing.T) {
-	f := newMoveFixture(t, "MovedToIgnoresCopies")
-	copyA := f.dest(t, f.dstWS, "Copy A")
-	copyB := f.dest(t, f.dst2WS, "Copy B")
-	moveTarget := f.dest(t, f.dstWS, "Move Target")
-
-	// Two plain copies FIRST, then the move — and the copies carry LATER
-	// created_at values than the move, so a naive "newest row wins" that
-	// forgets to filter on archived_source picks a copy and fails here.
-	f.record(t, models.ItemWorkspaceMove{
-		SourceWorkspaceID: f.srcWS.ID, SourceItemID: f.source.ID,
-		TargetWorkspaceID: f.dstWS.ID, TargetItemID: copyA.ID,
-		ArchivedSource: false, CreatedBy: f.actor, CreatedAt: "2026-03-02T00:00:00Z",
-	})
-	f.record(t, models.ItemWorkspaceMove{
-		SourceWorkspaceID: f.srcWS.ID, SourceItemID: f.source.ID,
-		TargetWorkspaceID: f.dst2WS.ID, TargetItemID: copyB.ID,
-		ArchivedSource: false, CreatedBy: f.actor, CreatedAt: "2026-03-03T00:00:00Z",
-	})
-	f.record(t, models.ItemWorkspaceMove{
-		SourceWorkspaceID: f.srcWS.ID, SourceItemID: f.source.ID,
-		TargetWorkspaceID: f.dstWS.ID, TargetItemID: moveTarget.ID,
-		ArchivedSource: true, SourceSeq: seqPtr(10),
-		CreatedBy: f.actor, CreatedAt: "2026-03-01T00:00:00Z",
-	})
-
-	forward, err := f.s.ListItemWorkspaceMovesBySource(f.source.ID)
-	if err != nil {
-		t.Fatalf("forward lookup: %v", err)
-	}
-	if len(forward) != 3 {
-		t.Fatalf("got %d rows, want 3", len(forward))
-	}
-
-	movedTo := firstArchived(forward)
-	if movedTo == nil {
-		t.Fatal("no archived_source row found; the move produced no moved-to pointer")
-	}
-	if movedTo.TargetItemID != moveTarget.ID {
-		t.Errorf("moved-to resolved to %q, want the move target %q", movedTo.TargetItemID, moveTarget.ID)
-	}
-}
-
-// TestItemWorkspaceMoves_MovedToSameSecondUsesSourceSeq is the criterion that
-// justifies source_seq existing at all: two restore→move cycles inside the
-// SAME second. created_at is second-precision RFC3339, so it ties, and only
-// source_seq can say which destination is the later one. Without the seq
-// ordering this test passes or fails by luck.
-func TestItemWorkspaceMoves_MovedToSameSecondUsesSourceSeq(t *testing.T) {
-	f := newMoveFixture(t, "SameSecond")
-	earlier := f.dest(t, f.dstWS, "Earlier Move")
-	later := f.dest(t, f.dst2WS, "Later Move")
-
-	const sameSecond = "2026-04-01T12:00:00Z"
-
-	// Insert the LATER move first so row insertion order can't be what makes
-	// the assertion pass — and give it the lexically LOWEST id while the
-	// earlier move gets the highest. created_at is identical, so with the
-	// source_seq term removed from the ordering the query falls through to
-	// `id DESC` and returns `earlier` DETERMINISTICALLY. That is the point:
-	// with random UUIDs this test would still pass half the time against a
-	// query that had lost the very ordering it exists to prove.
-	f.record(t, models.ItemWorkspaceMove{
-		ID:                lexLowMoveID,
-		SourceWorkspaceID: f.srcWS.ID, SourceItemID: f.source.ID,
-		TargetWorkspaceID: f.dst2WS.ID, TargetItemID: later.ID,
-		ArchivedSource: true, SourceSeq: seqPtr(200),
-		CreatedBy: f.actor, CreatedAt: sameSecond,
-	})
-	f.record(t, models.ItemWorkspaceMove{
-		ID:                lexHighMoveID,
-		SourceWorkspaceID: f.srcWS.ID, SourceItemID: f.source.ID,
-		TargetWorkspaceID: f.dstWS.ID, TargetItemID: earlier.ID,
-		ArchivedSource: true, SourceSeq: seqPtr(100),
-		CreatedBy: f.actor, CreatedAt: sameSecond,
-	})
-
-	forward, err := f.s.ListItemWorkspaceMovesBySource(f.source.ID)
-	if err != nil {
-		t.Fatalf("forward lookup: %v", err)
-	}
-	if len(forward) != 2 {
-		t.Fatalf("got %d rows, want 2 (restore-then-move-again must NOT be deduped)", len(forward))
-	}
-
-	movedTo := firstArchived(forward)
-	if movedTo == nil {
-		t.Fatal("no archived_source row found")
-	}
-	if movedTo.TargetItemID != later.ID {
-		t.Errorf("same-second tie resolved to %q, want the higher-seq destination %q",
-			movedTo.TargetItemID, later.ID)
-	}
-	if movedTo.SourceSeq == nil || *movedTo.SourceSeq != 200 {
-		t.Errorf("moved-to row carries seq %v, want 200", movedTo.SourceSeq)
-	}
-}
-
-// firstArchived picks the newest row whose source was archived — the head of
-// what the moved-to pointer considers.
-//
-// It is a TEST helper for exercising the broad forward lookup's ordering, not
-// a mirror of the consumer: the real consumer (TASK-2359) queries
-// ListArchivedItemWorkspaceMovesBySource and ACL-filters the whole bounded
-// set per destination rather than taking the first entry.
-func firstArchived(moves []models.ItemWorkspaceMove) *models.ItemWorkspaceMove {
-	for i := range moves {
-		if moves[i].ArchivedSource {
-			return &moves[i]
-		}
-	}
-	return nil
-}
-
 // TestPurgeWorkspaceData_ClearsItemWorkspaceMovesBothDirections covers the FK
 // hazard the two-workspace shape introduces: item_workspace_moves references
 // workspaces(id) twice with RESTRICT, so a purge that cleared only one
@@ -623,7 +454,15 @@ func TestItemWorkspaceMoves_TargetDeleteCascades(t *testing.T) {
 
 // TestListArchivedItemWorkspaceMovesBySource covers the narrow, SQL-bounded
 // query the moved-to pointer reads (TASK-2359): archived_source rows only,
-// newest first, capped. The cap has to be real in SQL rather than applied by
+// newest first, capped.
+//
+// It is also where DR-2a's first acceptance criterion now lives — copy twice,
+// then move; the archived source advertises the MOVE target only. That
+// criterion had a second home asserted through the broad forward lookup until
+// TASK-2374 deleted it; this is the version that runs against the query
+// production actually reads.
+//
+// The cap has to be real in SQL rather than applied by
 // the caller — otherwise a source with a long tail of plain copies pays to
 // load, sort, scan and allocate every one of them on every read of the source,
 // and none of them can ever contribute to the result.
@@ -696,18 +535,18 @@ func TestListArchivedItemWorkspaceMovesBySource(t *testing.T) {
 		}
 	}
 
-	// And the broad forward lookup is untouched — it still sees everything.
-	all, err := f.s.ListItemWorkspaceMovesBySource(f.source.ID)
-	if err != nil {
-		t.Fatalf("forward lookup: %v", err)
-	}
-	if len(all) != 4 {
-		t.Errorf("the broad forward lookup should still return all 4 rows, got %d", len(all))
+	// The two copies are still on disk — the lookup filtered them out, it did
+	// not fail to write them, so the exclusion above is a real exclusion.
+	if got := f.s.countRows(t,
+		`SELECT COUNT(*) FROM item_workspace_moves WHERE source_item_id = ?`,
+		f.source.ID); got != 4 {
+		t.Errorf("the source has %d provenance rows on disk, want all 4", got)
 	}
 }
 
 // TestListArchivedItemWorkspaceMovesBySource_SameSecondUsesSourceSeq is the
-// archived-only query's copy of DR-2a's decisive case. Two
+// sole surviving home of DR-2a's decisive case (the broad forward lookup's
+// duplicate went with TASK-2374's deletion). Two
 // archive→restore→move cycles inside one second tie on created_at — that tie
 // is the entire reason source_seq exists — so without the seq term the
 // ordering falls through to the id tiebreak and returns an arbitrary

--- a/internal/store/items_cross_workspace_copy.go
+++ b/internal/store/items_cross_workspace_copy.go
@@ -941,31 +941,11 @@ func (s *Store) lockCollectionRows(tx *sql.Tx, collectionIDs ...string) error {
 // it was taken without the FOR UPDATE pin above, so it can be stale by the
 // time the copy commits.
 func (s *Store) getCollectionInWorkspaceTx(tx *sql.Tx, collectionID, workspaceID string) (*models.Collection, error) {
-	var c models.Collection
-	var createdAt, updatedAt string
-	var deletedAt *string
-	var isDefault bool
-
-	err := tx.QueryRow(s.q(`
-		SELECT id, workspace_id, name, slug, prefix, icon, description, schema, settings, sort_order, is_default, is_system, created_at, updated_at, deleted_at
-		FROM collections
-		WHERE id = ? AND workspace_id = ? AND deleted_at IS NULL
-	`), collectionID, workspaceID).Scan(
-		&c.ID, &c.WorkspaceID, &c.Name, &c.Slug, &c.Prefix, &c.Icon, &c.Description,
-		&c.Schema, &c.Settings, &c.SortOrder, &isDefault, &c.IsSystem,
-		&createdAt, &updatedAt, &deletedAt,
-	)
-	if err == sql.ErrNoRows {
-		return nil, nil
-	}
+	c, err := s.scanCollectionRow(tx, getCollectionInWorkspaceQuery, collectionID, workspaceID)
 	if err != nil {
 		return nil, fmt.Errorf("copy item across workspaces: read collection: %w", err)
 	}
-	c.IsDefault = isDefault
-	c.CreatedAt = parseTime(createdAt)
-	c.UpdatedAt = parseTime(updatedAt)
-	c.DeletedAt = parseTimePtr(deletedAt)
-	return &c, nil
+	return c, nil
 }
 
 // migrateCopyFields runs the DR-12 field pipeline: migrate the source fields

--- a/internal/store/items_cross_workspace_copy_pg_test.go
+++ b/internal/store/items_cross_workspace_copy_pg_test.go
@@ -1,31 +1,343 @@
 package store
 
 import (
+	"database/sql"
 	"errors"
 	"fmt"
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
-// Postgres-only tests for CopyItemAcrossWorkspaces — PLAN-2357 / TASK-2363.
+// Postgres-only tests for CopyItemAcrossWorkspaces — PLAN-2357 / TASK-2363,
+// hardened by TASK-2372.
 //
 // These are the tests DR-9 says the lock ordering needs in order to be a
 // decision rather than a comment. On SQLite they cannot fail: BEGIN IMMEDIATE
 // serializes every writer, so two opposing copies never interleave and there
 // is no advisory lock to order. `make test-pg` is where they run.
+//
+// --- Why these tests contend BY CONSTRUCTION (TASK-2372) --------------------
+//
+// The original shape was `close(start)` and hope: nothing established that the
+// two transactions were ever inside the contested region at the same time, so
+// a run in which they happened to execute serially passed just as green. That
+// is a test that catches the regression by TIMING, which is the property that
+// rots silently.
+//
+// The obvious fix — a rendezvous barrier immediately AFTER the first lock —
+// cannot work here and would hang a CORRECT implementation. The sorted
+// acquisition means both transactions request the SAME key first: transaction
+// 1 takes it and waits at the barrier, transaction 2 blocks on the lock and
+// never arrives (PLAN-2373, Phase D round 1).
+//
+// So the rendezvous is external and BELOW the code under test:
+// advisoryLockGate holds the very workspace advisory keys the copy protocol
+// acquires. Both copies therefore block on their FIRST lock request, whatever
+// and wherever it is, and the gate does not release until pg_locks shows both
+// of them queued as ungranted waiters. That is stronger than "both goroutines
+// started" — it is "both transactions are open and parked in the contested
+// region", verified in the database rather than assumed.
+//
+// Determinism follows from Postgres's FIFO lock queues:
+//
+//   - CORRECT (sorted) acquisition: both copies queue on the same min key.
+//     The gate releases, one is granted, takes the second key uncontended,
+//     commits; the other then proceeds. No cycle, no hang. This is the case
+//     the after-the-first-lock design would have deadlocked.
+//   - BROKEN acquisition (removed or mis-sorted): the two copies queue on
+//     DIFFERENT keys. Both are already queued when the gate releases, so both
+//     are granted their first key, and each then requests the key the other
+//     holds — a cycle, every time, aborted with SQLSTATE 40P01. Not a
+//     probability: the queue order is fixed before either can proceed.
+//
+// Because contention is constructed rather than sampled, a handful of rounds
+// carries the weight forty sampled ones used to. Five executions are still
+// evidence rather than proof — what changed is that a passing run no longer
+// depends on the scheduler having happened to interleave them.
+//
+// --- MUTATION HARNESS (re-runnable; TASK-2372 round-5 amendment) ------------
+//
+// Each mutation below was applied to the production code, observed to fail,
+// and reverted (2026-07-31, TASK-2372, against this commit's production
+// code). The "Observed" lines are RECORDED RESULTS: nothing in the tree can
+// substantiate them, which is the point of writing down the exact edit. Re-run
+// with:
+//
+//	docker compose -f docker-compose.test.yml up -d --wait
+//	PAD_TEST_POSTGRES_URL="postgres://pad:pad@localhost:5445/pad?sslmode=disable" \
+//	  go test ./internal/store/ -run 'CrossWorkspaces_Opposing|JointlyExceedQuota' -count=1
+//
+// MUTATION A — remove the outer acquisition entirely.
+//
+//	items_cross_workspace_copy.go, copyItemAcrossWorkspacesTx, step 1: delete
+//	the `if _, err := s.acquireWorkspaceLocksOrdered(tx, sourceWorkspaceID,
+//	req.TargetWorkspaceID); err != nil { return nil, err }` block.
+//
+//	Observed: TestCopyItemAcrossWorkspaces_OpposingMovesDoNotDeadlock fails
+//	on round 0 with "opposing cross-workspace MOVES deadlocked: acquire
+//	workspace seq lock: ERROR: deadlock detected (SQLSTATE 40P01)".
+//	TestCopyItemAcrossWorkspaces_OpposingDirectionsDoNotDeadlock fails too,
+//	but on the gate's readiness check rather than a deadlock ("only 1 of 2
+//	transactions reached the contested region within 30s"): with no outer
+//	acquisition a plain copy takes exactly one workspace key, and the two
+//	directions serialize on their OVERLAPPING collection FOR UPDATE rows
+//	instead, so the second copy never becomes an advisory waiter. Either way
+//	the mutation cannot pass, and the message says which shape broke.
+//
+// MUTATION B — drop the ordering: acquire in argument order.
+//
+//	items_cross_workspace_copy.go, in acquireWorkspaceLocksOrdered, replace
+//	`ordered := sortedDedupedLockKeys(keys)` with `ordered := keys`. That is
+//	argument order — source, then target — so an A->B copy and a B->A copy
+//	take the two keys in opposite orders.
+//
+//	NOT what this mutation models, and worth stating because it is the
+//	intuitive reading: sorting by workspace ID rather than lock key. That is
+//	still a total order, and both directions of a pair sort the same way, so
+//	it does not deadlock — verified by mutating acquireWorkspaceLocksOrdered
+//	to sort the IDs and lock in that order, which leaves both tests green.
+//	The lock-KEY requirement is therefore not what these two tests defend;
+//	it is defended by TestAcquireWorkspaceLocksOrdered_CollidingKeysTakeOneLock
+//	(hashtext collisions collapse to one key) and by the re-entrancy with the
+//	hashtext-keyed acquisitions elsewhere in the pipeline. What these tests
+//	defend is that SOME consistent order is taken, and that the acquisition
+//	happens at all.
+//
+//	Observed: BOTH deadlock tests fail, on round 0 and on every subsequent
+//	round, with "... deadlocked: acquire workspace lock N: ERROR: deadlock
+//	detected (SQLSTATE 40P01)" — the copy test because argument order is not
+//	key order, the move test because it takes the same two keys the same
+//	wrong way. (This mutation also drops the dedup, so
+//	TestAcquireWorkspaceLocksOrdered_CollidingKeysTakeOneLock fails
+//	alongside them; that is the mutation being crude, not a third signal.)
+//
+// MUTATION D — absorb the deadlock instead of surfacing it.
+//
+//	Not a lock-ordering mutation: the vacuity a retry wrapper would introduce
+//	(Codex round 6). Apply mutation B, and additionally, in
+//	CopyItemAcrossWorkspaces, wrap the call:
+//
+//		result, err := s.copyItemAcrossWorkspacesTx(req, sourceWorkspaceID)
+//		for i := 0; err != nil && isDeadlockError(err) && i < 5; i++ { // MUTATION D
+//			result, err = s.copyItemAcrossWorkspacesTx(req, sourceWorkspaceID)
+//		}
+//
+//	Observed: with only the returned-error assertions this passes — the retry
+//	completes serially and every count is right. With the deadlocksSettled
+//	check BOTH tests fail, on "Postgres recorded 5 deadlock(s) during opposing
+//	copies/moves, want 0". That check is why the tests assert the cycle did not
+//	FORM, not merely that no caller saw it.
+//
+// The two Postgres deadlock tests prove different halves — the move test that
+// the outer acquisition must EXIST, the copy test that it must be ORDERED —
+// so a mutation failing only one of them is expected, and both mutations
+// together must fail at least one each.
+
+// advisoryLockGate parks concurrent copy transactions on the workspace
+// advisory locks they are about to take, and holds them there until every
+// contender is verifiably queued.
+//
+// It is deliberately NOT a seam in the production code. Nothing about the copy
+// protocol is instrumented or made test-aware: the gate holds the same keys by
+// the same rule (hashtext(workspace_id)::bigint) from an ordinary transaction
+// on another connection, so the code under test cannot tell it apart from a
+// concurrent writer — which is precisely what it is standing in for.
+type advisoryLockGate struct {
+	t    *testing.T
+	s    *Store
+	tx   *sql.Tx
+	keys []int64
+}
+
+// newAdvisoryLockGate opens a transaction and takes the advisory lock for
+// every supplied workspace, in sorted key order (the gate obeys the same
+// protocol it is testing, so it can never be half of a cycle itself).
+func newAdvisoryLockGate(t *testing.T, s *Store, workspaceIDs ...string) *advisoryLockGate {
+	t.Helper()
+	if s.dialect.Driver() != DriverPostgres {
+		t.Fatal("advisoryLockGate requires Postgres")
+	}
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		t.Fatalf("advisory gate: begin: %v", err)
+	}
+	keys := make([]int64, 0, len(workspaceIDs))
+	for _, id := range workspaceIDs {
+		var key int64
+		if err := tx.QueryRow("SELECT hashtext($1)::bigint", id).Scan(&key); err != nil {
+			tx.Rollback() //nolint:errcheck // best effort on a failed setup
+			t.Fatalf("advisory gate: lock key for %q: %v", id, err)
+		}
+		keys = append(keys, key)
+	}
+	g := &advisoryLockGate{t: t, s: s, tx: tx, keys: sortedDedupedLockKeys(keys)}
+	// Backstop: a gate that never reaches release() — a panic, or a Fatalf on
+	// some other assertion mid-round — would otherwise hold its keys and its
+	// pooled connection for the rest of the test. Rollback after a successful
+	// Commit is ErrTxDone, which is exactly the no-op wanted here.
+	t.Cleanup(func() { tx.Rollback() }) //nolint:errcheck // no-op once released
+	for _, key := range g.keys {
+		if _, err := tx.Exec("SELECT pg_advisory_xact_lock($1)", key); err != nil {
+			tx.Rollback() //nolint:errcheck // best effort on a failed setup
+			t.Fatalf("advisory gate: acquire %d: %v", key, err)
+		}
+	}
+	return g
+}
+
+// waitForContenders blocks until `n` distinct backends are queued as ungranted
+// waiters on the gate's keys — i.e. until n copy transactions are open and
+// parked at their first lock request.
+//
+// Returns an error rather than calling Fatalf so the caller can release the
+// gate first; leaving it held would strand the contenders forever.
+func (g *advisoryLockGate) waitForContenders(n int) error {
+	g.t.Helper()
+	deadline := time.Now().Add(30 * time.Second)
+	var last int
+	for time.Now().Before(deadline) {
+		got, err := g.waiters()
+		if err != nil {
+			return err
+		}
+		if got >= n {
+			return nil
+		}
+		last = got
+		time.Sleep(2 * time.Millisecond)
+	}
+	return fmt.Errorf("only %d of %d transactions reached the contested region within 30s: "+
+		"they are not queued on the workspace advisory locks. The lock protocol changed shape — "+
+		"the acquisition was removed, something else now blocks first (the collection FOR UPDATE "+
+		"rows are the near neighbour), or a lock this gate does not hold serializes them earlier", last, n)
+}
+
+// waiters counts distinct backends waiting on the gate's advisory keys in THIS
+// database. Advisory keys land in pg_locks as classid = key>>32, objid = key
+// (both 32-bit), so the pair is derived from the key rather than matched
+// loosely — an unrelated advisory waiter must not count.
+//
+// The split is unsigned, and hashtext returns int4, so NEGATIVE keys are the
+// interesting half. Verified against the server rather than assumed: key
+// -469100607 appears as (classid 4294967295, objid 3825866689), which is what
+// the uint32 conversions below produce. A signed shift would have looked
+// right for positive keys and silently matched nothing for negative ones —
+// i.e. it would have degraded into the 30s readiness timeout for roughly half
+// of all workspace pairs.
+//
+// objsubid distinguishes the one-bigint form (1) from the two-int form (2),
+// which can present the same classid/objid pair. Pad only ever takes the
+// bigint form, so the filter is a guard against a future two-int caller being
+// miscounted as a contender here — a false-ready, which is the direction that
+// would make a test pass vacuously.
+func (g *advisoryLockGate) waiters() (int, error) {
+	query := `
+		SELECT COUNT(DISTINCT pid) FROM pg_locks
+		WHERE locktype = 'advisory'
+		  AND NOT granted
+		  AND objsubid = 1
+		  AND database = (SELECT oid FROM pg_database WHERE datname = current_database())
+		  AND (`
+	args := make([]any, 0, len(g.keys)*2)
+	for i, key := range g.keys {
+		if i > 0 {
+			query += " OR "
+		}
+		query += fmt.Sprintf("(classid::bigint = $%d AND objid::bigint = $%d)", len(args)+1, len(args)+2)
+		args = append(args, int64(uint32(uint64(key)>>32)), int64(uint32(uint64(key))))
+	}
+	query += ")"
+
+	var n int
+	if err := g.s.db.QueryRow(query, args...).Scan(&n); err != nil {
+		return 0, fmt.Errorf("advisory gate: count waiters: %w", err)
+	}
+	return n, nil
+}
+
+// release commits the holding transaction, freeing every queued contender at
+// once. Idempotent-ish: a second call is a no-op error that the test ignores.
+func (g *advisoryLockGate) release() {
+	g.t.Helper()
+	if err := g.tx.Commit(); err != nil && !errors.Is(err, sql.ErrTxDone) {
+		g.t.Fatalf("advisory gate: release: %v", err)
+	}
+}
+
+// deadlocksDetected reads this database's cumulative deadlock counter.
+//
+// The error channel alone cannot prove no deadlock HAPPENED — only that none
+// SURFACED. A future retry-on-40P01 wrapper around CopyItemAcrossWorkspaces
+// would absorb the abort, complete serially, and leave both deadlock tests
+// green while the cycle they exist to forbid formed on every round (Codex
+// round 6). Postgres counts the aborts itself, below the layer any retry could
+// hide, so the tests assert on the counter as well as on the returned errors.
+//
+// Read before and after; assert the delta is zero. The counter is cumulative
+// per database and each test has its own database (testStorePostgres), so no
+// other test can contribute to the delta.
+//
+// Stats flushing can lag a transaction's end — a backend flushes its pending
+// counts at most about once a second — so a bare read taken immediately after
+// wg.Wait() could still see zero for a deadlock that did happen. Callers use
+// deadlocksSettled, which waits that window out.
+func deadlocksDetected(t *testing.T, s *Store) int64 {
+	t.Helper()
+	var n int64
+	if err := s.db.QueryRow(
+		`SELECT deadlocks FROM pg_stat_database WHERE datname = current_database()`,
+	).Scan(&n); err != nil {
+		t.Fatalf("read deadlock counter: %v", err)
+	}
+	return n
+}
+
+// deadlocksSettled returns how many deadlocks were recorded since `before`,
+// having given Postgres's statistics flush time to catch up.
+//
+// It returns the moment the counter moves — a failing run reports immediately
+// — and otherwise waits out the flush window before agreeing that zero is
+// zero. Without the wait the assertion would be a coin flip on a fast machine:
+// the copies' backends stay pooled and idle after wg.Wait(), so their pending
+// counts can sit unflushed for up to about a second (Codex round 7).
+func deadlocksSettled(t *testing.T, s *Store, before int64) int64 {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		if got := deadlocksDetected(t, s) - before; got != 0 {
+			return got
+		}
+		if time.Now().After(deadline) {
+			return 0
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}
 
 // TestCopyItemAcrossWorkspaces_OpposingDirectionsDoNotDeadlock drives A->B and
 // B->A copies simultaneously, repeatedly.
 //
 // This is the test that FAILS without the sorted lock acquisition. With an
-// unordered (or ID-sorted, which does not order the hashes) acquisition, one
+// UNORDERED acquisition — the keys taken in argument order, source then
+// target — one
 // goroutine holds hashtext(A) and waits on hashtext(B) while the other holds
 // hashtext(B) and waits on hashtext(A); Postgres detects the cycle and aborts
 // one transaction with SQLSTATE 40P01. With the keys sorted, both transactions
 // request the same key first, so the cycle cannot form.
+//
+// (An ID-SORTED acquisition would also be a consistent order for a pair and
+// does NOT deadlock — see mutation B in the file header. This test proves the
+// acquisition is ordered, not that it is ordered by lock key specifically.)
+//
+// The overlap is constructed, not sampled: advisoryLockGate holds both
+// workspace keys until pg_locks shows both copies queued on them. See the
+// file header for why the barrier sits BEFORE the first acquisition and for
+// mutation B, which this test is the one to catch.
 func TestCopyItemAcrossWorkspaces_OpposingDirectionsDoNotDeadlock(t *testing.T) {
 	requirePostgresForConcurrency(t)
 
@@ -35,7 +347,10 @@ func TestCopyItemAcrossWorkspaces_OpposingDirectionsDoNotDeadlock(t *testing.T) 
 	colA := createTestCollection(t, s, wsA.ID, "Tasks A")
 	colB := createTestCollection(t, s, wsB.ID, "Tasks B")
 
-	const rounds = 40
+	// A handful of rounds, not forty: each round is a constructed collision,
+	// so the rounds buy durability against a future change of shape, not
+	// probability of hitting the race.
+	const rounds = 5
 	sourcesA := make([]*models.Item, rounds)
 	sourcesB := make([]*models.Item, rounds)
 	for i := 0; i < rounds; i++ {
@@ -43,13 +358,9 @@ func TestCopyItemAcrossWorkspaces_OpposingDirectionsDoNotDeadlock(t *testing.T) 
 		sourcesB[i] = createTestItem(t, s, wsB.ID, colB.ID, fmt.Sprintf("B-%d", i), "body")
 	}
 
-	var wg sync.WaitGroup
 	errs := make(chan error, rounds*2)
-	start := make(chan struct{})
-
-	run := func(src *models.Item, targetWS, targetCol string) {
+	run := func(wg *sync.WaitGroup, src *models.Item, targetWS, targetCol string) {
 		defer wg.Done()
-		<-start
 		_, err := s.CopyItemAcrossWorkspaces(CrossWorkspaceCopyRequest{
 			SourceItemID:       src.ID,
 			TargetWorkspaceID:  targetWS,
@@ -61,13 +372,27 @@ func TestCopyItemAcrossWorkspaces_OpposingDirectionsDoNotDeadlock(t *testing.T) 
 		}
 	}
 
+	deadlocksBefore := deadlocksDetected(t, s)
+
+	// A readiness failure does not Fatal inside the loop: the accumulated
+	// copy errors are the more informative signal and would otherwise be
+	// thrown away unread (Codex round 6). Break, report those first, then the
+	// readiness failure.
+	var readyFailure error
 	for i := 0; i < rounds; i++ {
+		gate := newAdvisoryLockGate(t, s, wsA.ID, wsB.ID)
+		var wg sync.WaitGroup
 		wg.Add(2)
-		go run(sourcesA[i], wsB.ID, colB.ID) // A -> B
-		go run(sourcesB[i], wsA.ID, colA.ID) // B -> A
+		go run(&wg, sourcesA[i], wsB.ID, colB.ID) // A -> B
+		go run(&wg, sourcesB[i], wsA.ID, colA.ID) // B -> A
+		readyErr := gate.waitForContenders(2)
+		gate.release()
+		wg.Wait()
+		if readyErr != nil {
+			readyFailure = fmt.Errorf("round %d: %w", i, readyErr)
+			break
+		}
 	}
-	close(start)
-	wg.Wait()
 	close(errs)
 
 	for err := range errs {
@@ -75,6 +400,14 @@ func TestCopyItemAcrossWorkspaces_OpposingDirectionsDoNotDeadlock(t *testing.T) 
 			t.Fatalf("opposing cross-workspace copies deadlocked: %v", err)
 		}
 		t.Fatalf("opposing cross-workspace copy failed: %v", err)
+	}
+	if readyFailure != nil {
+		t.Fatal(readyFailure)
+	}
+
+	// No deadlock was ABSORBED either — see deadlocksDetected.
+	if got := deadlocksSettled(t, s, deadlocksBefore); got != 0 {
+		t.Fatalf("Postgres recorded %d deadlock(s) during opposing copies, want 0", got)
 	}
 
 	// Every copy landed. A deadlock aborts a transaction, so a silent loss
@@ -112,8 +445,10 @@ func TestCopyItemAcrossWorkspaces_OpposingDirectionsDoNotDeadlock(t *testing.T) 
 //
 // The two Postgres deadlock tests therefore prove different halves: this one
 // proves the outer acquisition must EXIST, and the plain-copy one above proves
-// it must be SORTED BY LOCK KEY (an unsorted acquisition deadlocks there even
-// though every transaction takes both keys).
+// it must be ORDERED (an unsorted acquisition deadlocks there even though every
+// transaction takes both keys). Ordering by lock KEY rather than by workspace
+// ID is a separate requirement, defended by the collision test rather than by
+// either of these — see mutation B in the file header.
 func TestCopyItemAcrossWorkspaces_OpposingMovesDoNotDeadlock(t *testing.T) {
 	requirePostgresForConcurrency(t)
 
@@ -127,7 +462,7 @@ func TestCopyItemAcrossWorkspaces_OpposingMovesDoNotDeadlock(t *testing.T) {
 	colBOut := createTestCollection(t, s, wsB.ID, "B Outbound")
 	colAIn := createTestCollection(t, s, wsA.ID, "A Inbound")
 
-	const rounds = 40
+	const rounds = 5
 	sourcesA := make([]*models.Item, rounds)
 	sourcesB := make([]*models.Item, rounds)
 	for i := 0; i < rounds; i++ {
@@ -135,13 +470,9 @@ func TestCopyItemAcrossWorkspaces_OpposingMovesDoNotDeadlock(t *testing.T) {
 		sourcesB[i] = createTestItem(t, s, wsB.ID, colBOut.ID, fmt.Sprintf("mB-%d", i), "body")
 	}
 
-	var wg sync.WaitGroup
 	errs := make(chan error, rounds*2)
-	start := make(chan struct{})
-
-	run := func(src *models.Item, targetWS, targetCol string) {
+	run := func(wg *sync.WaitGroup, src *models.Item, targetWS, targetCol string) {
 		defer wg.Done()
-		<-start
 		_, err := s.CopyItemAcrossWorkspaces(CrossWorkspaceCopyRequest{
 			SourceItemID:       src.ID,
 			TargetWorkspaceID:  targetWS,
@@ -154,13 +485,28 @@ func TestCopyItemAcrossWorkspaces_OpposingMovesDoNotDeadlock(t *testing.T) {
 		}
 	}
 
+	// Same constructed collision as the copy test. It works here even though
+	// the mutation this test catches (a REMOVED acquisition) takes its first
+	// workspace key much later in the transaction — at the create in B and the
+	// archive in A — because the gate holds both keys and waits for both
+	// transactions to queue, wherever in the pipeline they reach them.
+	deadlocksBefore := deadlocksDetected(t, s)
+
+	var readyFailure error
 	for i := 0; i < rounds; i++ {
+		gate := newAdvisoryLockGate(t, s, wsA.ID, wsB.ID)
+		var wg sync.WaitGroup
 		wg.Add(2)
-		go run(sourcesA[i], wsB.ID, colBIn.ID) // A -> B, archiving in A
-		go run(sourcesB[i], wsA.ID, colAIn.ID) // B -> A, archiving in B
+		go run(&wg, sourcesA[i], wsB.ID, colBIn.ID) // A -> B, archiving in A
+		go run(&wg, sourcesB[i], wsA.ID, colAIn.ID) // B -> A, archiving in B
+		readyErr := gate.waitForContenders(2)
+		gate.release()
+		wg.Wait()
+		if readyErr != nil {
+			readyFailure = fmt.Errorf("round %d: %w", i, readyErr)
+			break
+		}
 	}
-	close(start)
-	wg.Wait()
 	close(errs)
 
 	for err := range errs {
@@ -168,6 +514,13 @@ func TestCopyItemAcrossWorkspaces_OpposingMovesDoNotDeadlock(t *testing.T) {
 			t.Fatalf("opposing cross-workspace MOVES deadlocked: %v", err)
 		}
 		t.Fatalf("opposing cross-workspace move failed: %v", err)
+	}
+	if readyFailure != nil {
+		t.Fatal(readyFailure)
+	}
+
+	if got := deadlocksSettled(t, s, deadlocksBefore); got != 0 {
+		t.Fatalf("Postgres recorded %d deadlock(s) during opposing moves, want 0", got)
 	}
 
 	// Every move landed: each workspace archived its own `rounds` sources and
@@ -221,14 +574,19 @@ func TestCopyItemAcrossWorkspaces_ConcurrentCopiesCannotJointlyExceedQuota(t *te
 	src1 := createTestItem(t, s, wsA.ID, colA.ID, "One", "body")
 	src2 := createTestItem(t, s, wsA.ID, colA.ID, "Two", "body")
 
+	// Constructed overlap, as in the deadlock tests: the gate holds the
+	// destination key so BOTH copies are open transactions queued on it before
+	// either can read the quota. Without that, the two calls could run
+	// end-to-end serially and the assertion below would hold vacuously — the
+	// second copy would see the committed row because it started afterwards,
+	// not because the lock made it.
+	gate := newAdvisoryLockGate(t, s, wsA.ID, wsB.ID)
 	var wg sync.WaitGroup
 	results := make(chan error, 2)
-	start := make(chan struct{})
 	for _, src := range []*models.Item{src1, src2} {
 		wg.Add(1)
 		go func(src *models.Item) {
 			defer wg.Done()
-			<-start
 			_, err := s.CopyItemAcrossWorkspaces(CrossWorkspaceCopyRequest{
 				SourceItemID:       src.ID,
 				TargetWorkspaceID:  wsB.ID,
@@ -239,9 +597,13 @@ func TestCopyItemAcrossWorkspaces_ConcurrentCopiesCannotJointlyExceedQuota(t *te
 			results <- err
 		}(src)
 	}
-	close(start)
+	readyErr := gate.waitForContenders(2)
+	gate.release()
 	wg.Wait()
 	close(results)
+	if readyErr != nil {
+		t.Fatal(readyErr)
+	}
 
 	var ok, rejected int
 	for err := range results {

--- a/internal/store/items_cross_workspace_copy_test.go
+++ b/internal/store/items_cross_workspace_copy_test.go
@@ -13,8 +13,9 @@ import (
 
 // Tests for CopyItemAcrossWorkspaces — PLAN-2357 / TASK-2363.
 //
-// The concurrency and lock-ordering tests live at the bottom and are
-// Postgres-only by construction (see requirePostgresForConcurrency).
+// The concurrency and lock-ordering tests live in
+// items_cross_workspace_copy_pg_test.go and are Postgres-only by
+// construction (see requirePostgresForConcurrency).
 
 // copyFixture is workspace A (source), workspace B (destination), and a third
 // workspace C used for the confused-deputy negative cases.
@@ -554,8 +555,9 @@ func TestCopyItemAcrossWorkspaces_AttachmentsClonedAndRefsRewritten(t *testing.T
 	}
 
 	// A reference in the body, one inside a fenced code block (the rewriter
-	// is a plain ReplaceAll, so a fenced ref gets rewritten either way and
-	// must therefore be cloned either way), and one in the fields.
+	// tokenizes with attachmentRefRE and is markdown-blind, so a fenced ref
+	// gets rewritten either way and must therefore be cloned either way), and
+	// one in the fields.
 	content := fmt.Sprintf("![d](pad-attachment:%s)\n\n```\nsee pad-attachment:%s\n```\n", orig.ID, thumb.ID)
 	src, err := f.s.CreateItem(f.wsA.ID, srcColl.ID, models.ItemCreate{
 		Title:   "Has attachments",
@@ -585,7 +587,9 @@ func TestCopyItemAcrossWorkspaces_AttachmentsClonedAndRefsRewritten(t *testing.T
 	}
 
 	// No workspace-A UUID survives the rewrite, anywhere — body or fields,
-	// fenced or not. A surviving ref renders broken AND 403s on download.
+	// fenced or not. A surviving ref renders broken AND 404s on download —
+	// handlers_attachments.go answers a cross-workspace id with not_found
+	// rather than forbidden, deliberately.
 	for _, oldID := range []string{orig.ID, thumb.ID} {
 		if strings.Contains(res.Item.Content, oldID) {
 			t.Errorf("copied content still references workspace-A attachment %s", oldID)
@@ -624,6 +628,7 @@ func TestCopyItemAcrossWorkspaces_AttachmentsClonedAndRefsRewritten(t *testing.T
 	if newOriginal == nil {
 		t.Fatal("no cloned original in workspace B")
 	}
+	var newVariant *models.Attachment
 	for i := range rows {
 		a := rows[i]
 		if a.ParentID == nil {
@@ -634,13 +639,54 @@ func TestCopyItemAcrossWorkspaces_AttachmentsClonedAndRefsRewritten(t *testing.T
 		if *a.ParentID != newOriginal.ID {
 			t.Errorf("cloned variant parent_id = %s, want the new original %s", *a.ParentID, newOriginal.ID)
 		}
+		cp := a
+		newVariant = &cp
+	}
+	if newVariant == nil {
+		t.Fatal("no cloned variant in workspace B")
 	}
 
-	// The rewritten refs actually resolve in B.
-	for _, id := range []string{newOriginal.ID} {
-		if !strings.Contains(res.Item.Content, "pad-attachment:"+id) {
-			t.Errorf("copied content does not reference the new original %s", id)
-		}
+	// The whole rewrite, not a spot check on the original's id.
+	//
+	// TASK-2372: the old assertion was "no workspace-A id survives" plus "the
+	// new ORIGINAL's id appears", which a rewrite that DROPPED the variant
+	// reference passes — the thumb row is cloned, the old id is gone, the
+	// original resolves, and the copy renders with a missing thumbnail. An
+	// exact old->new comparison of the entire body is the form chosen: it
+	// pins every reference at its own location, including a fenced one, and
+	// for this fixture rules out extra, missing or reordered text as well.
+	// (An offset-aware per-reference assertion would pin the references just
+	// as tightly, but only whole-body equality also catches the body being
+	// otherwise altered, so that is the form kept.)
+	//
+	// MUTATION C (re-runnable; round-5 amendment). In
+	// items_cross_workspace_copy.go, immediately after
+	// `newContent := remapAttachmentRefs(source.Content, plan.IDMap)`, insert:
+	//
+	//	for _, row := range plan.Rows { // MUTATION C
+	//		if row.Attachment.ParentID != nil {
+	//			newContent = strings.ReplaceAll(newContent, attachmentRefPrefix+row.Attachment.ID, "")
+	//		}
+	//	}
+	//
+	// The variant row is still cloned and still reparented; only its
+	// reference is stripped from the rewritten body. Recorded observation
+	// (2026-07-31, against this commit's production code): this test fails on
+	// "copied content = ... want the exact old->new rewrite", and a full
+	// `go test ./internal/store/` run reported that one failure and no other.
+	// That exclusivity is a recorded result, not something the source can
+	// establish — re-run it rather than trust it:
+	//
+	//	go test ./internal/store/ -run AttachmentsClonedAndRefsRewritten -count=1
+	wantContent := fmt.Sprintf("![d](pad-attachment:%s)\n\n```\nsee pad-attachment:%s\n```\n", newOriginal.ID, newVariant.ID)
+	if res.Item.Content != wantContent {
+		t.Errorf("copied content = %q,\nwant the exact old->new rewrite %q", res.Item.Content, wantContent)
+	}
+	// The field-borne reference is rewritten to the same new original. Fields
+	// are compared by substring rather than whole-string because the JSON
+	// re-encode is free to reorder keys and apply schema defaults.
+	if !strings.Contains(res.Item.Fields, "pad-attachment:"+newOriginal.ID) {
+		t.Errorf("copied fields = %q, want a reference to the new original %s", res.Item.Fields, newOriginal.ID)
 	}
 
 	// Workspace A keeps its rows, untouched.

--- a/internal/store/items_cross_workspace_copy_test.go
+++ b/internal/store/items_cross_workspace_copy_test.go
@@ -229,12 +229,17 @@ func TestCopyItemAcrossWorkspaces_PlainCopyLandsInDestination(t *testing.T) {
 	if res.Move.SourceSeq != nil {
 		t.Errorf("plain copy recorded source_seq=%d, want nil", *res.Move.SourceSeq)
 	}
-	back, err := f.s.GetItemWorkspaceMoveByTarget(res.Item.ID)
-	if err != nil || back == nil {
-		t.Fatalf("back-pointer lookup failed: %v", err)
+	// The row the result reports is really committed, and it names the source.
+	// Read straight from the table: the only production read of this table is
+	// the archived-only moved-to lookup, which by design cannot see a copy.
+	var gotSource string
+	if err := f.s.db.QueryRow(f.s.q(
+		`SELECT source_item_id FROM item_workspace_moves WHERE target_item_id = ?`,
+	), res.Item.ID).Scan(&gotSource); err != nil {
+		t.Fatalf("read back the provenance row: %v", err)
 	}
-	if back.SourceItemID != src.ID {
-		t.Errorf("back-pointer source = %s, want %s", back.SourceItemID, src.ID)
+	if gotSource != src.ID {
+		t.Errorf("provenance row source = %s, want %s", gotSource, src.ID)
 	}
 }
 

--- a/web/e2e/copy-dialog.spec.ts
+++ b/web/e2e/copy-dialog.spec.ts
@@ -1,0 +1,642 @@
+import { test, expect } from './fixtures';
+import { browserLogin, seedDoc } from './lib/collab-helpers';
+import type { APIRequestContext, Locator, Page } from '@playwright/test';
+import type { SuiteFixture } from './fixtures';
+
+/**
+ * Cross-workspace copy / move dialog (PLAN-2373 / TASK-2355).
+ *
+ * Existing pane coverage asserts only that the "Move to collection…" menu ROW
+ * is visible (pane-full-page-capstone.spec.ts), and the native-dialog/mobile-
+ * pane interaction is exercised through an INJECTED generic dialog
+ * (pane-a11y-focus.spec.ts:283) — that generic trap test is deliberately not
+ * duplicated here. This suite drives the real product dialog: its destination
+ * pickers, the needs_value gate, the same-workspace Move lock, and the three
+ * failure presentations that are easy to get backwards.
+ *
+ * Locator policy: the MOBILE PANE IS ITSELF A DIALOG, so nothing here uses a
+ * bare `[role="dialog"]` locator — every reference targets the copy dialog by
+ * its accessible name ("Copy or move <REF>"). Everything waits on a
+ * deterministic API response, never a timeout, and no click is forced: a forced
+ * click would mask exactly the toast-interception regression the pane suite
+ * guards against.
+ */
+
+const DESKTOP = { width: 1280, height: 900 };
+const MOBILE = { width: 768, height: 1024 };
+
+function headers(fixture: SuiteFixture) {
+	return { Authorization: `Bearer ${fixture.apiToken}`, 'Content-Type': 'application/json' };
+}
+
+/** The copy dialog, addressed by accessible name (never `[role="dialog"]`). */
+function copyDialog(page: Page): Locator {
+	return page.getByRole('dialog', { name: /^Copy or move / });
+}
+
+function paneMoreBtn(page: Page): Locator {
+	return page.getByRole('button', { name: 'More item actions' }).first();
+}
+
+/** Create a fresh destination workspace with one collection carrying `schema`. */
+async function seedDestination(
+	request: APIRequestContext,
+	fixture: SuiteFixture,
+	label: string,
+	collection: { name: string; slug: string; fields: unknown[] },
+): Promise<{ wsSlug: string; wsName: string; collSlug: string }> {
+	const wsName = `Copy Dest ${label} ${Date.now()}`;
+	const wsResp = await request.post('/api/v1/workspaces', {
+		headers: headers(fixture),
+		data: { name: wsName, template: 'blank' },
+	});
+	if (!wsResp.ok()) throw new Error(`workspace create failed (${wsResp.status()}): ${await wsResp.text()}`);
+	const ws = (await wsResp.json()) as { slug: string };
+
+	const collResp = await request.post(`/api/v1/workspaces/${ws.slug}/collections`, {
+		headers: headers(fixture),
+		data: {
+			name: collection.name,
+			slug: collection.slug,
+			schema: JSON.stringify({ fields: collection.fields }),
+		},
+	});
+	if (!collResp.ok())
+		throw new Error(`collection create failed (${collResp.status()}): ${await collResp.text()}`);
+
+	return { wsSlug: ws.slug, wsName, collSlug: collection.slug };
+}
+
+const REQUIRED_SELECT = {
+	key: 'severity',
+	label: 'Severity',
+	type: 'select',
+	options: ['low', 'high'],
+	required: true,
+};
+
+function itemUrl(fixture: SuiteFixture, slug: string): string {
+	return `/${fixture.adminUsername}/${fixture.workspaceSlug}/docs/${slug}`;
+}
+
+/** Open the pane ⋯ menu and launch the copy dialog. Returns the ⋯ trigger. */
+async function openCopyDialog(page: Page): Promise<Locator> {
+	const more = paneMoreBtn(page);
+	await expect(more).toBeVisible();
+	await more.click();
+	await page.getByRole('menuitem', { name: 'Copy or move to workspace…' }).click();
+	await expect(copyDialog(page)).toBeVisible();
+	return more;
+}
+
+test.describe('cross-workspace copy dialog (PLAN-2373 / TASK-2355)', () => {
+	test('same-workspace destination locks to Move and submits through the MOVE endpoint', async ({
+		page,
+		fixture,
+		request,
+	}, testInfo) => {
+		test.skip(testInfo.project.name !== 'desktop-chromium', 'viewport driven explicitly');
+		await page.setViewportSize(DESKTOP);
+		await browserLogin(page);
+		const { slug } = await seedDoc(fixture, request, 'Copy dialog same-ws');
+		await page.goto(itemUrl(fixture, slug));
+
+		// Record which mutating endpoint is hit. Routing a same-workspace
+		// destination through /copy would mint a new item id, drop the parent and
+		// clone attachments instead of relocating the item — and, with an
+		// `archive_source` matching the Move label this destination presents,
+		// archive the original too (DR-18). So the assertion is not "it worked"
+		// but "it went through /move and never /copy".
+		const hits: string[] = [];
+		await page.route('**/api/v1/workspaces/**/items/**', async (route) => {
+			const url = route.request().url();
+			if (route.request().method() === 'POST' && (url.includes('/move') || /\/copy(\?|$)/.test(url))) {
+				hits.push(url.includes('/move') ? 'move' : 'copy');
+			}
+			await route.continue();
+		});
+
+		await openCopyDialog(page);
+		const dialog = copyDialog(page);
+
+		// Destination defaults to the current workspace → Copy is not selectable
+		// and Move is the effective action.
+		const copyRadio = dialog.getByRole('radio', { name: /^Copy — / });
+		await expect(copyRadio).toBeDisabled();
+		await expect(dialog.getByRole('radio', { name: /Move to another collection/ })).toBeChecked();
+
+		const preflight = page.waitForResponse(
+			(r) => r.url().includes('/copy/preflight') && r.status() === 200,
+		);
+		await dialog.getByLabel('Collection', { exact: true }).selectOption('tasks');
+		await preflight;
+
+		const confirm = dialog.getByRole('button', { name: 'Move', exact: true });
+		await expect(confirm).toBeEnabled();
+		await confirm.click();
+
+		// Post-move navigation: handleMove's navIfStillCurrent lands on the
+		// target collection's route for the same slug.
+		await page.waitForURL(`**/${fixture.adminUsername}/${fixture.workspaceSlug}/tasks/${slug}`);
+		expect(hits).toEqual(['move']);
+		await expect(copyDialog(page)).toBeHidden();
+		// Focus restoration is asserted on the paths where the page SURVIVES the
+		// close (the copy test and the mobile Escape test). A successful move
+		// navigates, so there is no stable node left to restore to.
+	});
+
+	test('a required destination field gates Confirm until supplied, then the copy commits', async ({
+		page,
+		fixture,
+		request,
+	}, testInfo) => {
+		test.skip(testInfo.project.name !== 'desktop-chromium', 'viewport driven explicitly');
+		await page.setViewportSize(DESKTOP);
+		await browserLogin(page);
+		const dest = await seedDestination(request, fixture, 'happy', {
+			name: 'Bugs',
+			slug: 'bugs',
+			fields: [REQUIRED_SELECT],
+		});
+		const { slug } = await seedDoc(fixture, request, 'Copy dialog happy');
+		await page.goto(itemUrl(fixture, slug));
+
+		const trigger = await openCopyDialog(page);
+		const dialog = copyDialog(page);
+
+		await dialog.getByLabel('Workspace', { exact: true }).selectOption(dest.wsSlug);
+		const firstPreflight = page.waitForResponse(
+			(r) => r.url().includes('/copy/preflight') && r.status() === 200,
+		);
+		await dialog.getByLabel('Collection', { exact: true }).selectOption(dest.collSlug);
+		await firstPreflight;
+
+		// The content-semantics note is permanent, not conditional — wiki-link
+		// RETARGETING is the surprising outcome and must always be stated.
+		await expect(dialog.getByText(/are not rewritten/)).toBeVisible();
+
+		// Confirm is gated on the server's own answer (needs_value empty).
+		const confirm = dialog.getByRole('button', { name: 'Copy', exact: true });
+		await expect(confirm).toBeDisabled();
+		await expect(dialog.getByText('Needs a value')).toBeVisible();
+
+		// Supply it through the composed FieldEditor select (not a rebuilt control).
+		const secondPreflight = page.waitForResponse(
+			(r) => r.url().includes('/copy/preflight') && r.status() === 200,
+		);
+		await dialog.locator('.select-trigger').click();
+		await dialog.getByRole('option', { name: 'High' }).click();
+		await secondPreflight;
+
+		await expect(confirm).toBeEnabled();
+		const copyResp = page.waitForResponse(
+			(r) => /\/copy(\?|$)/.test(r.url()) && r.request().method() === 'POST',
+		);
+		await confirm.click();
+		expect((await copyResp).status()).toBe(201);
+
+		await expect(copyDialog(page)).toBeHidden();
+		await expect(trigger).toBeFocused();
+
+		// The copy really landed in the destination, with the supplied value.
+		const listed = await request.get(
+			`/api/v1/workspaces/${dest.wsSlug}/collections/${dest.collSlug}/items`,
+			{ headers: headers(fixture) },
+		);
+		expect(listed.ok()).toBeTruthy();
+		const items = (await listed.json()) as { title: string; fields: string }[];
+		expect(items).toHaveLength(1);
+		// `fields` is a JSON *string* on the wire.
+		expect(JSON.parse(items[0].fields)).toMatchObject({ severity: 'high' });
+
+		// A plain copy leaves the source alone — no archived banner, and no
+		// provenance banner: `moved_to` is absent, and absent must produce
+		// nothing (no second lookup, no client-side reconstruction).
+		await expect(page.locator('.archived-banner')).toHaveCount(0);
+		await expect(page.locator('.moved-banner')).toHaveCount(0);
+	});
+
+	test('a required multi_select renders a blocked state, never a text box', async ({
+		page,
+		fixture,
+		request,
+	}, testInfo) => {
+		test.skip(testInfo.project.name !== 'desktop-chromium', 'viewport driven explicitly');
+		await page.setViewportSize(DESKTOP);
+		await browserLogin(page);
+		// multi_select is the dangerous gap: FieldEditor falls it through to the
+		// TEXT fallback, which yields a string where the server requires []any —
+		// enterable and silently invalid.
+		const dest = await seedDestination(request, fixture, 'blocked', {
+			name: 'Tagged',
+			slug: 'tagged',
+			fields: [
+				{ key: 'labels', label: 'Labels', type: 'multi_select', options: ['a', 'b'], required: true },
+			],
+		});
+		const { slug } = await seedDoc(fixture, request, 'Copy dialog blocked');
+		await page.goto(itemUrl(fixture, slug));
+
+		await openCopyDialog(page);
+		const dialog = copyDialog(page);
+		await dialog.getByLabel('Workspace', { exact: true }).selectOption(dest.wsSlug);
+		const preflight = page.waitForResponse(
+			(r) => r.url().includes('/copy/preflight') && r.status() === 200,
+		);
+		await dialog.getByLabel('Collection', { exact: true }).selectOption(dest.collSlug);
+		await preflight;
+
+		// Asserted with toContainText: the sentence is split across <strong> /
+		// <code> children, which getByText's element-text engine does not join.
+		const blocked = dialog.locator('.notice-error').first();
+		await expect(blocked).toContainText('can’t collect a value for that type safely');
+		await expect(blocked).toContainText('multi_select');
+		await expect(blocked).toContainText('pad item copy');
+		// No control was rendered for it — the whole point is not to accept a
+		// value the server would reject or misread.
+		await expect(dialog.locator('.needs-row')).toHaveCount(0);
+		await expect(dialog.getByRole('button', { name: 'Copy', exact: true })).toBeDisabled();
+	});
+
+	test('an in-flight copy resists Escape and backdrop, and is dispatched exactly once', async ({
+		page,
+		fixture,
+		request,
+	}, testInfo) => {
+		test.skip(testInfo.project.name !== 'desktop-chromium', 'viewport driven explicitly');
+		await page.setViewportSize(DESKTOP);
+		await browserLogin(page);
+		const dest = await seedDestination(request, fixture, 'inflight', {
+			name: 'Inbox',
+			slug: 'inbox',
+			fields: [],
+		});
+		const { slug } = await seedDoc(fixture, request, 'Copy dialog in-flight');
+		await page.goto(itemUrl(fixture, slug));
+
+		// HOLD the mutation rather than racing it — that is what makes the
+		// dismissal attempts deterministic.
+		let release!: () => void;
+		const held = new Promise<void>((r) => (release = r));
+		let dispatches = 0;
+		await page.route(/\/copy(\?|$)/, async (route) => {
+			if (route.request().method() !== 'POST') return route.continue();
+			dispatches++;
+			await held;
+			await route.continue();
+		});
+
+		await openCopyDialog(page);
+		const dialog = copyDialog(page);
+		await dialog.getByLabel('Workspace', { exact: true }).selectOption(dest.wsSlug);
+		const preflight = page.waitForResponse(
+			(r) => r.url().includes('/copy/preflight') && r.status() === 200,
+		);
+		await dialog.getByLabel('Collection', { exact: true }).selectOption(dest.collSlug);
+		await preflight;
+
+		await dialog.getByRole('button', { name: 'Copy', exact: true }).click();
+		await expect(dialog.getByText(/don’t close this window/)).toBeVisible();
+
+		// Escape is forwarded by Modal UNCONDITIONALLY and cannot be suppressed
+		// by prop — the veto lives in the dialog's onclose handler. Dismissal is
+		// not rollback: the copy commits regardless.
+		await page.keyboard.press('Escape');
+		await expect(dialog).toBeVisible();
+		// Backdrop.
+		await page.mouse.click(5, 5);
+		await expect(dialog).toBeVisible();
+		await expect(dialog.getByRole('button', { name: 'Cancel' })).toBeDisabled();
+
+		release();
+		await expect(copyDialog(page)).toBeHidden();
+		expect(dispatches).toBe(1);
+	});
+
+	test('an opaque 502 answered after dispatch presents outcome-unknown with no retry', async ({
+		page,
+		fixture,
+		request,
+	}, testInfo) => {
+		test.skip(testInfo.project.name !== 'desktop-chromium', 'viewport driven explicitly');
+		await page.setViewportSize(DESKTOP);
+		await browserLogin(page);
+		const dest = await seedDestination(request, fixture, 'opaque', {
+			name: 'Inbox',
+			slug: 'inbox',
+			fields: [],
+		});
+		const { slug } = await seedDoc(fixture, request, 'Copy dialog opaque');
+		await page.goto(itemUrl(fixture, slug));
+
+		// A non-JSON 502 from an intermediary carries no `copy_failed` code, but
+		// is exactly as ambiguous to the CLIENT: the request was dispatched, and
+		// a real intermediary can answer 502 either before or after the server
+		// commits. Fulfilling at the route stands in for that intermediary — so
+		// what is under test is the client's CLASSIFICATION of an opaque reply
+		// to a dispatched mutation, not the server's state, which by definition
+		// the client cannot observe here.
+		await page.route(/\/copy(\?|$)/, async (route) => {
+			if (route.request().method() !== 'POST') return route.continue();
+			await route.fulfill({ status: 502, contentType: 'text/html', body: '<html>502</html>' });
+		});
+
+		await openCopyDialog(page);
+		const dialog = copyDialog(page);
+		await dialog.getByLabel('Workspace', { exact: true }).selectOption(dest.wsSlug);
+		const preflight = page.waitForResponse(
+			(r) => r.url().includes('/copy/preflight') && r.status() === 200,
+		);
+		await dialog.getByLabel('Collection', { exact: true }).selectOption(dest.collSlug);
+		await preflight;
+		await dialog.getByRole('button', { name: 'Copy', exact: true }).click();
+
+		await expect(dialog.getByText(/outcome of this copy is unknown/i)).toBeVisible();
+		await expect(dialog.getByText(/do\s*not\s*retry/i)).toBeVisible();
+		// No retry affordance: Confirm stays locked, and the only way out is Close.
+		await expect(dialog.getByRole('button', { name: 'Copy', exact: true })).toBeDisabled();
+		await expect(
+			dialog.locator('.modal-footer').getByRole('button', { name: 'Close', exact: true }),
+		).toBeEnabled();
+	});
+
+	test('a destination archived mid-flow returns to destination selection, NOT outcome-unknown', async ({
+		page,
+		fixture,
+		request,
+	}, testInfo) => {
+		test.skip(testInfo.project.name !== 'desktop-chromium', 'viewport driven explicitly');
+		await page.setViewportSize(DESKTOP);
+		await browserLogin(page);
+		const dest = await seedDestination(request, fixture, 'gone', {
+			name: 'Doomed',
+			slug: 'doomed',
+			fields: [REQUIRED_SELECT],
+		});
+		// A second, surviving collection to fall back to. It declares the SAME
+		// field, so the value entered for Doomed must survive the switch.
+		await request.post(`/api/v1/workspaces/${dest.wsSlug}/collections`, {
+			headers: headers(fixture),
+			data: {
+				name: 'Survivor',
+				slug: 'survivor',
+				schema: JSON.stringify({ fields: [REQUIRED_SELECT] }),
+			},
+		});
+		const { slug } = await seedDoc(fixture, request, 'Copy dialog dest-gone');
+		await page.goto(itemUrl(fixture, slug));
+
+		let dispatches = 0;
+		await page.route(/\/copy(\?|$)/, async (route) => {
+			if (route.request().method() === 'POST') dispatches++;
+			await route.continue();
+		});
+
+		await openCopyDialog(page);
+		const dialog = copyDialog(page);
+		await dialog.getByLabel('Workspace', { exact: true }).selectOption(dest.wsSlug);
+		const preflight = page.waitForResponse(
+			(r) => r.url().includes('/copy/preflight') && r.status() === 200,
+		);
+		await dialog.getByLabel('Collection', { exact: true }).selectOption(dest.collSlug);
+		await preflight;
+
+		// Supply the required value for Doomed.
+		const afterValue = page.waitForResponse(
+			(r) => r.url().includes('/copy/preflight') && r.status() === 200,
+		);
+		await dialog.locator('.select-trigger').click();
+		await dialog.getByRole('option', { name: 'High' }).click();
+		await afterValue;
+		await expect(dialog.getByRole('button', { name: 'Copy', exact: true })).toBeEnabled();
+
+		// Archive the chosen destination AFTER the review, BEFORE confirm. The
+		// server's sentinel is explicit that this is a PRE-WRITE rejection, so
+		// the user must not be sent hunting for an item that does not exist.
+		const del = await request.delete(
+			`/api/v1/workspaces/${dest.wsSlug}/collections/${dest.collSlug}`,
+			{ headers: headers(fixture) },
+		);
+		expect(del.ok()).toBeTruthy();
+
+		await dialog.getByRole('button', { name: 'Copy', exact: true }).click();
+		await expect(dialog.getByText(/no longer available/)).toBeVisible();
+		await expect(dialog.getByText(/outcome of this copy is unknown/i)).toHaveCount(0);
+		expect(dispatches).toBe(0);
+		// Back at destination selection with a replacement offered — and the
+		// entered value is retained, so picking the replacement does not make the
+		// user type it again.
+		await expect(dialog.getByLabel('Collection', { exact: true })).toBeVisible();
+		await expect(dialog.getByLabel('Collection', { exact: true }).getByText('Survivor')).toHaveCount(1);
+		const replacement = page.waitForResponse(
+			(r) => r.url().includes('/copy/preflight') && r.status() === 200,
+		);
+		await dialog.getByLabel('Collection', { exact: true }).selectOption('survivor');
+		await replacement;
+		await expect(dialog.getByRole('button', { name: 'Copy', exact: true })).toBeEnabled();
+		await expect(dialog.getByText('your value')).toBeVisible();
+		expect(dispatches).toBe(0);
+	});
+
+	test('a cross-workspace MOVE archives the source and shows the provenance banner', async ({
+		page,
+		fixture,
+		request,
+	}, testInfo) => {
+		test.skip(testInfo.project.name !== 'desktop-chromium', 'viewport driven explicitly');
+		await page.setViewportSize(DESKTOP);
+		await browserLogin(page);
+		const dest = await seedDestination(request, fixture, 'move', {
+			name: 'Inbox',
+			slug: 'inbox',
+			fields: [],
+		});
+		const { slug } = await seedDoc(fixture, request, 'Copy dialog move');
+		await page.goto(itemUrl(fixture, slug));
+
+		await openCopyDialog(page);
+		const dialog = copyDialog(page);
+		await dialog.getByLabel('Workspace', { exact: true }).selectOption(dest.wsSlug);
+		const preflight = page.waitForResponse(
+			(r) => r.url().includes('/copy/preflight') && r.status() === 200,
+		);
+		await dialog.getByLabel('Collection', { exact: true }).selectOption(dest.collSlug);
+		await preflight;
+
+		// Cross-workspace: Copy is selectable here, and Move adds archive_source.
+		await dialog.getByRole('radio', { name: /^Move — / }).check();
+		const copyResp = page.waitForResponse(
+			(r) => /\/copy(\?|$)/.test(r.url()) && r.request().method() === 'POST',
+		);
+		await dialog.getByRole('button', { name: 'Move', exact: true }).click();
+		expect((await copyResp).status()).toBe(201);
+		await expect(copyDialog(page)).toBeHidden();
+
+		// The source is archived in place and carries PROVENANCE — worded as
+		// history ("was moved to"), never as a current location (DR-2a).
+		await expect(page.locator('.archived-banner')).toBeVisible();
+		const moved = page.locator('.moved-banner');
+		await expect(moved).toBeVisible();
+		await expect(moved).toContainText('was moved to');
+		await expect(moved).toContainText(dest.wsName);
+		// Linked to the destination, using the slugs the server supplied.
+		await expect(moved.getByRole('link')).toHaveAttribute(
+			'href',
+			new RegExp(`/${dest.wsSlug}/${dest.collSlug}/`),
+		);
+	});
+
+	test('a stale preflight cannot displace a newer destination', async ({
+		page,
+		fixture,
+		request,
+	}, testInfo) => {
+		test.skip(testInfo.project.name !== 'desktop-chromium', 'viewport driven explicitly');
+		await page.setViewportSize(DESKTOP);
+		await browserLogin(page);
+		const dest = await seedDestination(request, fixture, 'race', {
+			name: 'Alpha',
+			slug: 'alpha',
+			fields: [{ key: 'alpha_field', label: 'Alpha Field', type: 'text', required: true }],
+		});
+		await request.post(`/api/v1/workspaces/${dest.wsSlug}/collections`, {
+			headers: headers(fixture),
+			data: {
+				name: 'Beta',
+				slug: 'beta',
+				schema: JSON.stringify({
+					fields: [{ key: 'beta_field', label: 'Beta Field', type: 'text', required: true }],
+				}),
+			},
+		});
+		const { slug } = await seedDoc(fixture, request, 'Copy dialog race');
+		await page.goto(itemUrl(fixture, slug));
+
+		// HOLD Alpha's preflight, so the destination switch provably happens
+		// while it is outstanding. Holding rather than racing is what makes the
+		// ordering deterministic.
+		let releaseAlpha!: () => void;
+		const alphaHeld = new Promise<void>((r) => (releaseAlpha = r));
+		let started = 0;
+		await page.route('**/copy/preflight', async (route) => {
+			started++;
+			if (started === 1) await alphaHeld;
+			await route.continue();
+		});
+
+		await openCopyDialog(page);
+		const dialog = copyDialog(page);
+		await dialog.getByLabel('Workspace', { exact: true }).selectOption(dest.wsSlug);
+		await dialog.getByLabel('Collection', { exact: true }).selectOption('alpha');
+		await expect.poll(() => started).toBe(1);
+
+		// Switch destination while Alpha is outstanding, then let Alpha resolve
+		// LAST. Its result must never be displayed, and its required-field row
+		// must never join Beta's sticky set — entering a value there would ship
+		// an override Beta does not declare (400 malformed_override).
+		await dialog.getByLabel('Collection', { exact: true }).selectOption('beta');
+		releaseAlpha();
+		await expect(dialog.getByText('Beta Field')).toBeVisible();
+		await expect(dialog.getByText('Alpha Field')).toHaveCount(0);
+
+	});
+
+	test('override edits collapse to one in-flight preflight plus one trailing run', async ({
+		page,
+		fixture,
+		request,
+	}, testInfo) => {
+		test.skip(testInfo.project.name !== 'desktop-chromium', 'viewport driven explicitly');
+		await page.setViewportSize(DESKTOP);
+		await browserLogin(page);
+		// THREE required selects. Selects emit immediately (no FieldEditor
+		// typing debounce), so each pick is a distinct override change — which
+		// is what makes this test the dialog's runner rather than FieldEditor's
+		// internal 500ms text debounce.
+		const opts = ['low', 'high'];
+		const dest = await seedDestination(request, fixture, 'coalesce', {
+			name: 'Triple',
+			slug: 'triple',
+			fields: [1, 2, 3].map((n) => ({
+				key: `sev${n}`,
+				label: `Sev ${n}`,
+				type: 'select',
+				options: opts,
+				required: true,
+			})),
+		});
+		const { slug } = await seedDoc(fixture, request, 'Copy dialog coalesce');
+		await page.goto(itemUrl(fixture, slug));
+
+		let started = 0;
+		let releaseSecond!: () => void;
+		const secondHeld = new Promise<void>((r) => (releaseSecond = r));
+		await page.route('**/copy/preflight', async (route) => {
+			started++;
+			// #1 is the initial preview; hold #2 (the first override's preview)
+			// so the remaining picks land while it is genuinely in flight.
+			if (started === 2) await secondHeld;
+			await route.continue();
+		});
+
+		await openCopyDialog(page);
+		const dialog = copyDialog(page);
+		await dialog.getByLabel('Workspace', { exact: true }).selectOption(dest.wsSlug);
+		await dialog.getByLabel('Collection', { exact: true }).selectOption(dest.collSlug);
+		await expect.poll(() => started).toBe(1);
+		await expect(dialog.locator('.needs-row')).toHaveCount(3);
+
+		const pick = async (i: number) => {
+			await dialog.locator('.select-trigger').nth(i).click();
+			await dialog.getByRole('option', { name: 'High' }).click();
+		};
+		// First pick → one preview, which the route now HOLDS. Waiting for it to
+		// start (rather than sleeping past the debounce) is what makes the next
+		// two picks land while a preflight is genuinely in flight.
+		await pick(0);
+		await expect.poll(() => started).toBe(2);
+
+		await pick(1);
+		await pick(2);
+		// Single-flight: neither pick issued a request of its own.
+		expect(started).toBe(2);
+		releaseSecond();
+		await expect(dialog.getByRole('button', { name: 'Copy', exact: true })).toBeEnabled();
+		// …and both were served by ONE trailing run, not one request each.
+		expect(started).toBe(3);
+	});
+
+	test('mobile: the dialog opens over the active pane and returns focus to ⋯ on Escape', async ({
+		page,
+		fixture,
+		request,
+	}, testInfo) => {
+		test.skip(testInfo.project.name !== 'desktop-chromium', 'viewport driven explicitly');
+		await page.setViewportSize(MOBILE);
+		await browserLogin(page);
+		const { slug } = await seedDoc(fixture, request, 'Copy dialog mobile');
+		// The collection page with `?item=` — at ≤768px the pane is a
+		// full-screen overlay that runs its OWN focus trap, which defers to a
+		// native <dialog>. That deferral is what this asserts on the real
+		// product dialog (the generic injected-dialog trap test stays where it
+		// is, in pane-a11y-focus.spec.ts).
+		await page.goto(`/${fixture.adminUsername}/${fixture.workspaceSlug}/docs?item=${slug}`);
+		await expect(page.locator('.item-pane')).toBeVisible();
+
+		const more = page.locator('.item-pane').getByRole('button', { name: 'More item actions' });
+		await expect(more).toBeVisible();
+		await more.click();
+		await page.getByRole('menuitem', { name: 'Copy or move to workspace…' }).click();
+
+		const dialog = copyDialog(page);
+		await expect(dialog).toBeVisible();
+		// Focus is inside the dialog, not left behind in the pane.
+		await expect(dialog.getByLabel('Workspace', { exact: true })).toBeFocused();
+
+		await page.keyboard.press('Escape');
+		await expect(copyDialog(page)).toBeHidden();
+		// The pane itself must still be open — Escape closed the dialog only.
+		await expect(page.locator('.item-pane')).toBeVisible();
+		await expect(more).toBeFocused();
+	});
+});

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -12,6 +12,9 @@ import type {
 	BulkItemsResponse,
 	ItemChangeRow,
 	ItemChangesResponse,
+	ItemCopyPreflight,
+	ItemCopyPreflightRequest,
+	ItemCopyResult,
 	ItemCreate,
 	TagCount,
 	ItemIndexResponse,
@@ -1267,6 +1270,55 @@ export const api = {
 					})
 				}
 			),
+
+		/**
+		 * Cross-workspace copy DRY RUN (PLAN-2357 / TASK-2365).
+		 *
+		 * Read-only and safe to call repeatedly: it writes nothing, emits no
+		 * activity/SSE/webhook, and advances neither workspace's seq. Call it
+		 * again whenever the destination or an override changes. It is still an
+		 * ordinary authenticated request, so it spends rate-limit budget —
+		 * callers debounce/coalesce (see CopyItemDialog's single-flight runner).
+		 *
+		 * `signal` lets a superseded preview abort in flight; an aborted request
+		 * rejects with a DOMException, which callers discard behind their own
+		 * generation fence rather than surfacing.
+		 *
+		 * See `ItemCopyPreflight` in $lib/types for the response contract and
+		 * the error codes worth branching on.
+		 */
+		copyPreflight: (
+			ws: string,
+			slug: string,
+			req: ItemCopyPreflightRequest,
+			opts?: { signal?: AbortSignal }
+		) =>
+			request<ItemCopyPreflight>(`/workspaces/${ws}/items/${slug}/copy/preflight`, {
+				method: 'POST',
+				body: JSON.stringify(req),
+				signal: opts?.signal
+			}),
+
+		/**
+		 * Cross-workspace copy — the MUTATION (PLAN-2357 / TASK-2365). With
+		 * `archive_source: true` it is the MOVE.
+		 *
+		 * ⚠ NEVER RETRY THIS CALL (DR-13). There is no idempotency key, so a
+		 * retry after a request that already committed creates a DUPLICATE item,
+		 * and a caller that lost the response cannot tell which happened. On a
+		 * 500 `copy_failed` — or on ANY unstructured transport failure once this
+		 * call has been dispatched — the outcome is unknown: tell the user to
+		 * check the destination workspace, and do not offer a retry.
+		 *
+		 * Deliberately no `signal` param: aborting tells you nothing about
+		 * whether the server committed, and the shared `request` never retries
+		 * non-idempotent methods, which is what keeps this aligned with DR-13.
+		 */
+		copy: (ws: string, slug: string, req: ItemCopyPreflightRequest) =>
+			request<ItemCopyResult>(`/workspaces/${ws}/items/${slug}/copy`, {
+				method: 'POST',
+				body: JSON.stringify(req)
+			}),
 
 		/**
 		 * Inbound `[[...]]` references to an item — the "Mentioned in"

--- a/web/src/lib/components/fields/FieldEditor.svelte
+++ b/web/src/lib/components/fields/FieldEditor.svelte
@@ -25,9 +25,19 @@ handlers — onchange is never called.
 		value: any;
 		onchange: (value: any) => void;
 		readonly?: boolean;
+		/**
+		 * Accessible name for the rendered control. Optional: on the item
+		 * detail page the visible field label sits beside the control in a
+		 * `.field-row`, so the default (undefined → no `aria-label`) leaves
+		 * that markup exactly as it was. Consumers that render the control
+		 * WITHOUT an associated <label> — e.g. the cross-workspace copy
+		 * dialog's needs-a-value rows — pass the field name here so the
+		 * input/trigger is not announced as an unnamed edit field or button.
+		 */
+		ariaLabel?: string;
 	}
 
-	let { field, value, onchange, readonly = false }: Props = $props();
+	let { field, value, onchange, readonly = false, ariaLabel }: Props = $props();
 
 	// ── Viewport detection ───────────────────────────────────────────────
 	// On mobile the absolute-positioned select dropdown can clip at the
@@ -362,6 +372,7 @@ handlers — onchange is never called.
 			bind:this={triggerEl}
 			class="select-trigger"
 			type="button"
+			aria-label={ariaLabel}
 			aria-haspopup="listbox"
 			aria-expanded={dropdownOpen}
 			onclick={toggleDropdown}
@@ -426,6 +437,7 @@ handlers — onchange is never called.
 		<button
 			class="select-trigger date-trigger"
 			type="button"
+			aria-label={ariaLabel}
 			onclick={() => dateInputEl?.showPicker()}
 		>
 			{#if value}
@@ -482,6 +494,7 @@ handlers — onchange is never called.
 		<input
 			class="number-input"
 			type="text"
+			aria-label={ariaLabel}
 			inputmode="numeric"
 			value={value ?? ''}
 			oninput={handleNumberInput}
@@ -512,6 +525,7 @@ handlers — onchange is never called.
 		<input
 			class="field-input url-input"
 			type="url"
+			aria-label={ariaLabel}
 			value={value ?? ''}
 			oninput={handleTextInput}
 			onblur={flushPendingSave}
@@ -548,6 +562,7 @@ handlers — onchange is never called.
 	<input
 		class="field-input"
 		type="text"
+		aria-label={ariaLabel}
 		value={value ?? ''}
 		oninput={handleTextInput}
 		onblur={flushPendingSave}

--- a/web/src/lib/components/items/CopyItemDialog.svelte
+++ b/web/src/lib/components/items/CopyItemDialog.svelte
@@ -1,0 +1,1476 @@
+<!--
+@component
+CopyItemDialog — the cross-workspace copy / move review dialog (PLAN-2373 /
+TASK-2355, backend contract PLAN-2357).
+
+Built on the shared `Modal` primitive (native `<dialog>`) rather than the pane
+menu's drill-down pattern: the field-mapping step needs more room than the menu
+affords, and the native dialog gives focus trap + Escape + top-layer rendering,
+which PaneHost's mobile focus trap deliberately defers to. Consumer obligations
+from Modal's docs are honored: it is NOT wrapped in `{#if open}`, and
+`labelledby` points at the heading.
+
+Two submit paths behind one dialog (DR-18):
+
+  - destination workspace == the source workspace → `onmove()`, which delegates
+    to the page's existing `handleMove` (POST /items/{slug}/move). That path
+    keeps its open-children force retry and its `navIfStillCurrent` route
+    identity fencing. The copy endpoint has NO same-workspace guard, so routing
+    a same-workspace destination through it would mint a NEW item id, drop the
+    parent and clone attachments instead of relocating the item — and since
+    this destination presents as Move, an `archive_source` matching that label
+    would archive the original on top. A silent behaviour regression on an
+    existing surface either way. Same-workspace *copy* (duplicate in place) is
+    deliberately out of scope, so a same-workspace destination locks the toggle
+    to Move.
+  - destination workspace != the source workspace → the preflight + copy
+    endpoints, with `archive_source` on the move path.
+
+The preflight drives BOTH paths' field mapping, which is what finally closes
+the intra-workspace "Required fields missing: …" dead end — the old move call
+site passed `field_overrides: undefined` and turned the server's refusal into
+an unactionable toast.
+
+Ambiguity rule (DR-13 / round-10 amendment). Ambiguity is decided by "was the
+mutation dispatched?", NOT by the server returning `copy_failed`. Once the copy
+POST is dispatched, any UNSTRUCTURED failure (rejected fetch, non-JSON 502,
+timeout) is as ambiguous to the user as an explicit `copy_failed`: the server
+may have committed. Both render the same outcome-unknown state, which
+PROHIBITS retry (there is no idempotency key) and sends the user to look at the
+destination. Structured PRE-WRITE refusals — `collection_not_found`, a
+destination `forbidden`, `plan_limit_exceeded`, the validation family — keep
+their own recovery paths; swallowing those into outcome-unknown would send the
+user hunting for an item that provably does not exist.
+-->
+<script lang="ts">
+	import { tick } from 'svelte';
+	import Modal from '$lib/components/common/Modal.svelte';
+	import FieldEditor from '$lib/components/fields/FieldEditor.svelte';
+	import { api, PadApiError } from '$lib/api/client';
+	import { canEditCollection } from '$lib/utils/permissions';
+	import { parseSchema } from '$lib/types';
+	import type {
+		Collection,
+		FieldDef,
+		Item,
+		ItemCopyPreflight,
+		ItemCopyPreflightNeedsValue,
+		ItemCopyPreflightRequest,
+		ItemCopyResult,
+		Workspace,
+		WorkspaceMembership
+	} from '$lib/types';
+
+	interface Props {
+		open: boolean;
+		/** Dismissal request from Escape / backdrop / Cancel / a completed submit.
+		 *  The parent flips `open` and restores focus to the ⋯ trigger. */
+		onclose: () => void;
+		sourceWsSlug: string;
+		/** The item's ACTUAL collection slug, not the route's. */
+		sourceCollectionSlug: string;
+		item: Item;
+		/** Human ref for the heading, e.g. "TASK-14". */
+		sourceRef: string;
+		/**
+		 * True when the source item can no longer be copied — archived or
+		 * deleted, including a remote archive/delete that arrived over SSE while
+		 * this dialog was open. Disables Confirm immediately.
+		 */
+		sourceUnavailable?: boolean;
+		/**
+		 * Foreground-flush the live collab editor into `items.content` and resolve
+		 * false if it FAILED. `items.content` can lag the authoritative Y.Doc by
+		 * up to the 5s flush debounce, and copying content the user just typed but
+		 * that never reached the server is the worst outcome available here — so a
+		 * failed flush BLOCKS the copy.
+		 */
+		flushContent: () => Promise<boolean>;
+		/** Same-workspace destination: delegate to the page's `handleMove`. */
+		onmove: (
+			targetCollection: string,
+			fieldOverrides: Record<string, unknown>
+		) => Promise<{ status: 'ok' | 'cancelled' | 'failed'; message?: string }>;
+		/** Cross-workspace success. The parent owns navigation / toasts. */
+		oncopied: (result: ItemCopyResult) => void;
+	}
+
+	let {
+		open,
+		onclose,
+		sourceWsSlug,
+		sourceCollectionSlug,
+		item,
+		sourceRef,
+		sourceUnavailable = false,
+		flushContent,
+		onmove,
+		oncopied
+	}: Props = $props();
+
+	const uid = $props.id();
+	const titleId = `copy-dialog-title-${uid}`;
+
+	// ── Preflight timing ──────────────────────────────────────────────────
+	// Typed overrides re-run the preflight, which rescans relationships and
+	// replans attachments server-side — real work, on a rate-limited endpoint.
+	// So: a debounce, PLUS single-flight trailing coalescing (round-12 fold-in).
+	// At most one preflight is in flight at any moment; edits that settle while
+	// one is running collapse into exactly ONE trailing run.
+	const PREFLIGHT_DEBOUNCE_MS = 250;
+
+	/**
+	 * Types the dialog can safely collect a value for — the set `FieldEditor`
+	 * implements as real typed controls.
+	 *
+	 * Everything else is NOT rendered as a text box. `json` is deliberately
+	 * read-only in FieldEditor (a plain text input would store the string
+	 * "[]" where an array belongs), `relation` has no picker here, and
+	 * `multi_select` falls through FieldEditor's TEXT fallback — which yields a
+	 * string where the server's validation requires `[]any`. That last one is
+	 * the dangerous case: enterable and silently invalid. So a required field of
+	 * any uncollectable type renders an explicit blocked state naming the field
+	 * and its type, rather than a dead Confirm or a lying input.
+	 */
+	const COLLECTABLE_TYPES = new Set(['text', 'number', 'select', 'date', 'checkbox', 'url']);
+
+	// ── Destination selection ─────────────────────────────────────────────
+	let workspaces = $state<Workspace[]>([]);
+	let workspacesLoading = $state(false);
+	let workspacesError = $state('');
+
+	let destWs = $state('');
+	let destColl = $state('');
+
+	let destCollections = $state<Collection[]>([]);
+	let destCollectionsLoading = $state(false);
+	let destCollectionsError = $state('');
+
+	let mode = $state<'copy' | 'move'>('copy');
+
+	// ── Preview ───────────────────────────────────────────────────────────
+	let preflight = $state<ItemCopyPreflight | null>(null);
+	let preflightLoading = $state(false);
+	let preflightError = $state('');
+
+	/**
+	 * Sticky override rows. A field the user has satisfied leaves the NEXT
+	 * preflight's `needs_value` bucket — if the inputs were rendered straight
+	 * from that bucket, the control would vanish (and take focus with it) the
+	 * moment it was filled in. So rows accumulate here per destination
+	 * collection and are cleared when the destination changes.
+	 */
+	let overrideRows = $state<ItemCopyPreflightNeedsValue[]>([]);
+	/**
+	 * What is actually SENT. Restricted to keys the CURRENT destination's schema
+	 * DECLARES — the server rejects an override naming an undeclared key with a
+	 * 400 `malformed_override`, so retained values from a previous destination
+	 * must not be sent blind.
+	 */
+	let overrides = $state<Record<string, unknown>>({});
+	/**
+	 * Everything the user has typed, kept across destination changes (round-8
+	 * amendment: entered values are still valid input for a replacement
+	 * destination). Re-applied to `overrides` only once the new destination's
+	 * preflight confirms it declares the key.
+	 */
+	let retainedValues = $state<Record<string, unknown>>({});
+
+	// ── Submission ────────────────────────────────────────────────────────
+	/** Pre-dispatch work (collab flush + the final preflight). Disables Confirm
+	 *  but does NOT veto dismissal — nothing has been dispatched yet. */
+	let preparing = $state(false);
+	/** Set once the mutation is DISPATCHED. Vetoes Escape / backdrop / Cancel:
+	 *  dismissal is not rollback, and the copy commits regardless. */
+	let submitting = $state(false);
+	let submitError = $state('');
+	/** Outcome unknown — the copy may or may not have committed. Terminal:
+	 *  Confirm stays locked, and no retry is offered (DR-13). */
+	let outcomeUnknown = $state('');
+	/** The preview changed between review and submit — advisory only (see
+	 *  `reviewFingerprint`). Requires an explicit re-confirmation. */
+	let staleReview = $state('');
+	/** The destination went away (soft-deleted collection / revoked access) —
+	 *  a PRE-WRITE refusal, so it must NOT read as outcome-unknown. */
+	let destinationLost = $state('');
+
+	/**
+	 * DIALOG-level fence: bumped on open, on close, and on a destination
+	 * WORKSPACE change — i.e. whenever the in-flight workspace/collection/
+	 * membership loads become irrelevant. Every await-then-write re-checks it:
+	 * this dialog lives inside `ItemDetail`, a persistent pane with no `{#key}`,
+	 * so a late continuation could otherwise write into a dialog the user has
+	 * already re-pointed or closed.
+	 */
+	let flowGen = 0;
+
+	/**
+	 * PREVIEW-level fence: bumped by anything that invalidates the preview —
+	 * workspace, collection, or copy/move mode. Separate from `flowGen` on
+	 * purpose: a collection or mode change must discard an in-flight preflight
+	 * WITHOUT stranding an unrelated in-flight collections/membership load
+	 * behind a generation it can no longer match.
+	 *
+	 * Without it, a preflight for collection A could resolve after the user
+	 * picked B and merge A's required-field rows into B's sticky row set —
+	 * inviting an override naming a key B does not declare, which the server
+	 * rejects with 400 `malformed_override`.
+	 */
+	let previewGen = 0;
+
+	// ── Derived ───────────────────────────────────────────────────────────
+
+	let crossWorkspace = $derived(!!destWs && destWs !== sourceWsSlug);
+
+	/**
+	 * The action that will actually run. A same-workspace destination is LOCKED
+	 * to Move — same-workspace copy is out of scope, and this is a `$derived`
+	 * rather than an `$effect` writing `mode` so the conversion is atomic with
+	 * the destination change: there is no frame in which Confirm is enabled
+	 * while the UI still says "Copy".
+	 */
+	let effectiveMode = $derived<'copy' | 'move'>(crossWorkspace ? mode : 'move');
+	let archiveSource = $derived(crossWorkspace && effectiveMode === 'move');
+
+	let destWorkspaceName = $derived(
+		workspaces.find((w) => w.slug === destWs)?.name ?? destWs
+	);
+
+	/** Required destination fields the dialog cannot safely collect a value for. */
+	let blockedFields = $derived(
+		(preflight?.fields.needs_value ?? []).filter(
+			(f) => !COLLECTABLE_TYPES.has(f.type ?? 'text')
+		)
+	);
+
+	let warnings = $derived(preflight?.warnings ?? null);
+
+	let linkRows = $derived(
+		warnings
+			? [
+					...Object.entries(warnings.outgoing_links).map(([t, n]) => ({
+						dir: 'outgoing' as const,
+						type: t,
+						count: n
+					})),
+					...Object.entries(warnings.incoming_links).map(([t, n]) => ({
+						dir: 'incoming' as const,
+						type: t,
+						count: n
+					}))
+				].filter((r) => r.count > 0)
+			: []
+	);
+
+	let canConfirm = $derived(
+		!!destWs &&
+			!!destColl &&
+			!!preflight &&
+			preflight.valid &&
+			blockedFields.length === 0 &&
+			!preflightLoading &&
+			!preparing &&
+			!submitting &&
+			!outcomeUnknown &&
+			!destinationLost &&
+			!sourceUnavailable
+	);
+
+	let confirmLabel = $derived(
+		submitting
+			? effectiveMode === 'move'
+				? 'Moving…'
+				: 'Copying…'
+			: preparing
+				? 'Checking…'
+				: staleReview
+					? effectiveMode === 'move'
+						? 'Move anyway'
+						: 'Copy anyway'
+					: effectiveMode === 'move'
+						? 'Move'
+						: 'Copy'
+	);
+
+	// ── Open / close lifecycle ────────────────────────────────────────────
+	// Plain variable (NOT $state) for edge detection: a $state written inside an
+	// effect that also reads it self-invalidates and wedges the scheduler in a
+	// production build (CONVE-1688).
+	let prevOpen = false;
+
+	$effect.pre(() => {
+		if (open && !prevOpen) {
+			resetForOpen();
+		} else if (!open && prevOpen) {
+			cancelPending();
+		}
+		prevOpen = open;
+	});
+
+	$effect(() => {
+		return () => cancelPending();
+	});
+
+	function resetForOpen() {
+		flowGen++;
+		previewGen++;
+		destWs = sourceWsSlug;
+		destColl = '';
+		mode = 'copy';
+		destCollections = [];
+		destCollectionsError = '';
+		preflight = null;
+		preflightError = '';
+		overrideRows = [];
+		overrides = {};
+		retainedValues = {};
+		preparing = false;
+		submitting = false;
+		submitError = '';
+		outcomeUnknown = '';
+		staleReview = '';
+		destinationLost = '';
+		void loadWorkspaces();
+		void loadDestCollections(destWs);
+	}
+
+	function cancelPending() {
+		flowGen++;
+		invalidatePreview();
+	}
+
+	/** Discard the current preview and anything in flight for it. */
+	function invalidatePreview() {
+		previewGen++;
+		clearTimeout(debounceTimer);
+		debounceTimer = undefined;
+		trailingQueued = false;
+		preflightLoading = false;
+		abortInFlightPreflight();
+	}
+
+	/**
+	 * The single dismissal seam. `Modal` forwards Escape UNCONDITIONALLY (it
+	 * preventDefaults the native close and calls `onclose`, so the parent stays
+	 * the single source of truth) and there is no prop that suppresses it — so
+	 * the in-flight veto has to live here. Backdrop is additionally gated by
+	 * `closeOnBackdrop` below; Escape is not, which is exactly why this check
+	 * exists. Dismissing is not rollback: the mutation commits regardless, and
+	 * "I pressed Escape" must never read as "nothing happened".
+	 */
+	function handleDismiss() {
+		if (submitting) return;
+		cancelPending();
+		onclose();
+	}
+
+	// ── Destination loading ───────────────────────────────────────────────
+
+	async function loadWorkspaces() {
+		const gen = flowGen;
+		workspacesLoading = true;
+		workspacesError = '';
+		try {
+			const list = await api.workspaces.list();
+			if (gen !== flowGen) return;
+			workspaces = list;
+		} catch (e: any) {
+			if (gen !== flowGen) return;
+			workspacesError = e?.message ?? 'Could not load your workspaces.';
+		} finally {
+			if (gen === flowGen) workspacesLoading = false;
+		}
+	}
+
+	/**
+	 * Load the destination's collections and filter them through
+	 * `canEditCollection` for the caller's permissions IN THAT WORKSPACE
+	 * (DR-19). Nav visibility is strictly weaker than collection-create
+	 * permission, which is what the server actually enforces before copying, so
+	 * an unfiltered picker would offer destinations the copy will reject.
+	 *
+	 * The membership is fetched with `api.workspaces.me(slug)` directly rather
+	 * than through `workspaceStore.setCurrent` — this pane is persistent, and
+	 * pointing the ambient permission store at another workspace would leak into
+	 * every other affordance on the page.
+	 *
+	 * Always refetched, never cached: revocation is one of the two cases the
+	 * filter exists to catch.
+	 */
+	async function loadDestCollections(wsSlug: string) {
+		const gen = flowGen;
+		destCollectionsLoading = true;
+		destCollectionsError = '';
+		destCollections = [];
+		try {
+			const [colls, membership] = await Promise.all([
+				api.collections.list(wsSlug),
+				api.workspaces.me(wsSlug) as Promise<WorkspaceMembership | null>
+			]);
+			if (gen !== flowGen) return;
+			destCollections = colls.filter((c) => {
+				if (!canEditCollection(membership, c.id)) return false;
+				// A same-workspace "move" into the item's own collection is a
+				// no-op; mirror the pane menu's move-target filter.
+				if (wsSlug === sourceWsSlug && c.slug === sourceCollectionSlug) return false;
+				return true;
+			});
+		} catch (e: any) {
+			if (gen !== flowGen) return;
+			destCollectionsError = e?.message ?? 'Could not load collections for that workspace.';
+		} finally {
+			if (gen === flowGen) destCollectionsLoading = false;
+		}
+	}
+
+	function handleWorkspaceChange(slug: string) {
+		if (slug === destWs) return;
+		// A destination change invalidates the preview and the collection
+		// selection, but NOT the values the user has typed — they are still
+		// valid input for the replacement destination.
+		flowGen++;
+		invalidatePreview();
+		destWs = slug;
+		destColl = '';
+		preflight = null;
+		preflightError = '';
+		submitError = '';
+		staleReview = '';
+		destinationLost = '';
+		overrideRows = [];
+		// `overrides` is destination-scoped and must not carry blind (an
+		// undeclared key is a 400); `retainedValues` survives and is re-applied
+		// per key once the new destination reports it in `needs_value`.
+		overrides = {};
+		void loadDestCollections(slug);
+	}
+
+	/**
+	 * Re-apply retained values to the keys the chosen destination DECLARES.
+	 *
+	 * Gating on the destination's schema rather than on its `needs_value` rows
+	 * matters: a value entered for a field that is REQUIRED in destination A and
+	 * merely OPTIONAL in destination B would otherwise be silently neither sent
+	 * nor shown — the user's input would vanish without a word. Declared-key
+	 * gating also keeps `malformed_override` off the table.
+	 *
+	 * A value that the destination declares but rejects (e.g. a select option it
+	 * doesn't have) comes back as a `needs_value` row with reason
+	 * `invalid_value` and the server's message, which is visible and fixable.
+	 */
+	function seedOverridesForCollection(slug: string) {
+		const coll = destCollections.find((c) => c.slug === slug);
+		if (!coll) {
+			overrides = {};
+			return;
+		}
+		const declared = new Set(parseSchema(coll).fields.map((f) => f.key));
+		const next: Record<string, unknown> = {};
+		for (const [k, v] of Object.entries(retainedValues)) {
+			if (declared.has(k)) next[k] = v;
+		}
+		overrides = next;
+	}
+
+	function handleCollectionChange(slug: string) {
+		// Fence + abort: a preflight for the PREVIOUS collection must not merge
+		// its required-field rows into this one's sticky set.
+		invalidatePreview();
+		destColl = slug;
+		preflight = null;
+		preflightError = '';
+		submitError = '';
+		staleReview = '';
+		destinationLost = '';
+		overrideRows = [];
+		seedOverridesForCollection(slug);
+		schedulePreflight({ immediate: true });
+	}
+
+	function handleModeChange(next: 'copy' | 'move') {
+		// The mode changes `archive_source`, so the in-flight preview describes
+		// the other operation's consequences — discard it.
+		invalidatePreview();
+		mode = next;
+		staleReview = '';
+		submitError = '';
+		schedulePreflight({ immediate: true });
+	}
+
+	function handleOverrideChange(key: string, value: unknown) {
+		// NOT a preview invalidation: the rows stay, the destination is the same,
+		// and the debounce + single-flight runner already collapse rapid edits.
+		overrides = { ...overrides, [key]: value };
+		retainedValues = { ...retainedValues, [key]: value };
+		staleReview = '';
+		schedulePreflight();
+	}
+
+	// ── Preflight runner: debounce + single-flight trailing coalescing ─────
+
+	let debounceTimer: ReturnType<typeof setTimeout> | undefined;
+	let preflightInFlight = false;
+	let trailingQueued = false;
+	let preflightAbort: AbortController | null = null;
+
+	function abortInFlightPreflight() {
+		preflightAbort?.abort();
+		preflightAbort = null;
+	}
+
+	function schedulePreflight(opts?: { immediate?: boolean }) {
+		clearTimeout(debounceTimer);
+		if (opts?.immediate) {
+			void runPreflight();
+			return;
+		}
+		debounceTimer = setTimeout(() => {
+			debounceTimer = undefined;
+			void runPreflight();
+		}, PREFLIGHT_DEBOUNCE_MS);
+	}
+
+	function buildRequest(): ItemCopyPreflightRequest {
+		return {
+			target_workspace: destWs,
+			target_collection: destColl,
+			field_overrides: Object.keys(overrides).length ? { ...overrides } : undefined,
+			archive_source: archiveSource
+		};
+	}
+
+	async function runPreflight() {
+		if (!destWs || !destColl) {
+			preflightLoading = false;
+			return;
+		}
+		// Single-flight: at most ONE preflight is ever in flight. A request that
+		// arrives while one is running sets the trailing flag, and exactly one
+		// trailing run fires when the current one settles — so a burst of edits
+		// across many inputs collapses to (in-flight + 1) rather than N.
+		if (preflightInFlight) {
+			trailingQueued = true;
+			return;
+		}
+		const gen = flowGen;
+		const pgen = previewGen;
+		preflightInFlight = true;
+		preflightLoading = true;
+		preflightError = '';
+		const ctl = new AbortController();
+		preflightAbort = ctl;
+		try {
+			const result = await api.items.copyPreflight(sourceWsSlug, item.slug, buildRequest(), {
+				signal: ctl.signal
+			});
+			if (gen !== flowGen || pgen !== previewGen) return;
+			preflight = result;
+			// A retained value that this destination turns out to declare has
+			// just been applied — re-preview so the buckets reflect it. This
+			// converges: the re-run's needs_value can only shrink, so no further
+			// retained key can be newly applied.
+			if (mergeOverrideRows(result.fields.needs_value)) trailingQueued = true;
+		} catch (e: any) {
+			if (gen !== flowGen || pgen !== previewGen || ctl.signal.aborted) return;
+			if (isDestinationGoneError(e)) {
+				handleDestinationLost();
+				return;
+			}
+			// The destination schema drifted between the collection list fetch and
+			// this preview, so a seeded override names a key it no longer
+			// declares. Drop the seeds and re-preview once rather than dead-ending
+			// on an error the user never caused; the values stay in
+			// `retainedValues` and reappear if the destination asks for them.
+			if (errorCode(e) === 'malformed_override' && Object.keys(overrides).length > 0) {
+				overrides = {};
+				trailingQueued = true;
+				return;
+			}
+			preflight = null;
+			preflightError = e?.message ?? 'Could not preview the copy.';
+		} finally {
+			if (preflightAbort === ctl) preflightAbort = null;
+			preflightInFlight = false;
+			// The trailing run re-reads the CURRENT destination, so it fires
+			// regardless of which generation this settling run belonged to — and
+			// it owns `preflightLoading` from here. Clearing the flag in the
+			// no-trailing branch only is what keeps a superseded run from
+			// stranding the spinner (or the Confirm gate) on.
+			if (trailingQueued) {
+				trailingQueued = false;
+				void runPreflight();
+			} else {
+				preflightLoading = false;
+			}
+		}
+	}
+
+	/**
+	 * Accumulate newly-reported needs_value rows without dropping satisfied
+	 * ones, and re-apply any retained value now that this destination has been
+	 * confirmed to declare the key. Returns true when a retained value was
+	 * newly applied, so the caller can re-preview with it.
+	 */
+	function mergeOverrideRows(rows: ItemCopyPreflightNeedsValue[]): boolean {
+		const byKey = new Map(overrideRows.map((r) => [r.key, r]));
+		for (const r of rows) byKey.set(r.key, r);
+		overrideRows = [...byKey.values()];
+		// Backstop for a destination whose schema the client could not read
+		// (e.g. an unparseable schema string): a key the server itself reports
+		// as needing a value is, by construction, declared there.
+		let applied = false;
+		const next = { ...overrides };
+		for (const r of rows) {
+			if (!(r.key in overrides) && r.key in retainedValues) {
+				next[r.key] = retainedValues[r.key];
+				applied = true;
+			}
+		}
+		if (applied) overrides = next;
+		return applied;
+	}
+
+	function toFieldDef(row: ItemCopyPreflightNeedsValue): FieldDef {
+		return {
+			key: row.key,
+			label: row.label || row.key,
+			type: (row.type ?? 'text') as FieldDef['type'],
+			options: row.options,
+			required: row.required
+		};
+	}
+
+	// ── Error classification ──────────────────────────────────────────────
+
+	function errorCode(e: unknown): string | undefined {
+		return e instanceof PadApiError ? e.code : undefined;
+	}
+
+	/** PRE-WRITE destination failures: the target collection was soft-deleted, or
+	 *  access to the destination was revoked. The server's own sentinels are
+	 *  explicit that nothing was inserted, so these must never render as
+	 *  outcome-unknown — that would send the user hunting for an item that
+	 *  provably does not exist. */
+	function isDestinationGoneError(e: unknown): boolean {
+		const code = errorCode(e);
+		return code === 'collection_not_found' || code === 'forbidden' || code === 'permission_denied';
+	}
+
+	/**
+	 * Structured codes the server raises BEFORE any write. Everything NOT on
+	 * this list — including a generic `Error("API error: 502")`, a rejected
+	 * fetch, and any structured code we don't recognise — is treated as
+	 * outcome-unknown once the mutation has been dispatched. Erring toward
+	 * "unknown" is the safe direction: it withholds a retry that could
+	 * duplicate, and tells the user to look.
+	 */
+	const PRE_WRITE_CODES = new Set([
+		// The copy handler's own documented refusals (handlers_items_copy.go):
+		'invalid_body', // 400 — the body did not decode
+		'missing_field', // 400 — target_workspace / target_collection absent
+		'malformed_override', // 400 — override names an undeclared field
+		'validation_error', // 400 — the FINAL destination fields are invalid
+		'not_found', // 404 — source item absent or not visible
+		'actor_required', // 403 — nothing to attribute the copy to
+		'conflict', // 409 — unique collision in the destination
+		'cross_backend_attachments', // 409 — attachments would cross backends
+		// Shared with the preflight / the middleware stack:
+		'invalid_override',
+		'missing_required_fields',
+		'archived',
+		'plan_limit_exceeded',
+		'rate_limited',
+		'unauthorized'
+	]);
+
+	function planLimitMessage(e: unknown): string {
+		const d = (e instanceof PadApiError ? e.details : undefined) ?? {};
+		const plan = typeof d.plan === 'string' ? d.plan : '';
+		const limit = typeof d.limit === 'number' ? d.limit : undefined;
+		const current = typeof d.current === 'number' ? d.current : undefined;
+		const detail =
+			limit !== undefined && current !== undefined
+				? ` It holds ${current} of ${limit} items${plan ? ` on the ${plan} plan` : ''}.`
+				: '';
+		return `${destWorkspaceName} is at its item limit, so the copy was refused — nothing was created.${detail}`;
+	}
+
+	function handleDestinationLost() {
+		// Retain `overrides` — the entered values are still valid input for a
+		// replacement destination. Invalidate everything that names the old one.
+		destinationLost = `That destination is no longer available — the collection may have been archived, or your access to ${destWorkspaceName} changed. Pick another destination; your entered values are kept.`;
+		preflight = null;
+		preflightError = '';
+		submitError = '';
+		destColl = '';
+		overrideRows = [];
+		overrides = {};
+		// Refetch + re-filter through canEditCollection: revocation is exactly
+		// why this list is refetched rather than cached.
+		void loadDestCollections(destWs);
+	}
+
+	// ── Submit ────────────────────────────────────────────────────────────
+
+	/**
+	 * A fingerprint of what the user actually REVIEWED — the three buckets and
+	 * the warning set. Compared against the pre-submit preflight to detect the
+	 * source changing under an open dialog.
+	 *
+	 * ADVISORY ONLY, deliberately. The preflight is an unlocked snapshot and the
+	 * mutation copies the latest LOCKED source, so this cannot promise
+	 * preview/commit consistency — it only catches a change that happened to
+	 * land between the two reads. A server-side revision token was evaluated and
+	 * cut (IDEA-2378): `updated_at` is second-precision, so it could not have
+	 * delivered the guarantee either. Do not over-trust this check.
+	 */
+	function reviewFingerprint(p: ItemCopyPreflight): string {
+		return JSON.stringify({ f: p.fields, w: p.warnings, a: p.archive_source });
+	}
+
+	async function handleConfirm() {
+		if (!canConfirm || !preflight) return;
+		const gen = flowGen;
+		// Capture the preview generation AND the request. The form stays
+		// interactive while we flush + re-check (nothing has been dispatched, so
+		// dismissal and edits are still legitimate), which means the destination
+		// could change underneath us — and re-reading it at dispatch time would
+		// submit to a destination the user never reviewed. A change here simply
+		// abandons this attempt; the new destination re-previews and Confirm
+		// re-enables.
+		const pgen = previewGen;
+		const req = buildRequest();
+		const superseded = () => gen !== flowGen || pgen !== previewGen;
+		const reviewed = reviewFingerprint(preflight);
+		preparing = true;
+		submitError = '';
+		staleReview = '';
+		try {
+			// 1. Flush the live collab document. `items.content` can lag the
+			//    Y.Doc by up to 5s, and the copy reads items.content — so a failed
+			//    flush BLOCKS rather than silently copying stale content.
+			const flushed = await flushContent();
+			if (superseded()) return;
+			if (!flushed) {
+				submitError =
+					'Your latest edits could not be saved, so the copy was not started. Try again in a moment.';
+				return;
+			}
+
+			// 2. Re-run the preflight immediately before dispatch (advisory).
+			let fresh: ItemCopyPreflight;
+			try {
+				fresh = await api.items.copyPreflight(sourceWsSlug, item.slug, req);
+			} catch (e: any) {
+				if (superseded()) return;
+				if (isDestinationGoneError(e)) {
+					handleDestinationLost();
+					return;
+				}
+				// Nothing has been dispatched yet, so this is an ordinary,
+				// freely-retryable failure.
+				submitError = e?.message ?? 'Could not re-check the copy. Nothing was copied.';
+				return;
+			}
+			if (superseded()) return;
+			preflight = fresh;
+			mergeOverrideRows(fresh.fields.needs_value);
+			if (!fresh.valid) {
+				submitError =
+					'This item changed and the destination now needs more information. Review the fields below.';
+				return;
+			}
+			if (reviewFingerprint(fresh) !== reviewed) {
+				staleReview =
+					'This item changed since you reviewed it. The preview below has been refreshed — confirm again to proceed.';
+				return;
+			}
+
+			// 3. Dispatch. From here, dismissal is vetoed and no failure may be
+			//    presented as "nothing happened".
+			if (crossWorkspace) {
+				await dispatchCopy(gen, req);
+			} else {
+				// Same captured request for both paths, so the two can never
+				// disagree about what was submitted.
+				await dispatchMove(gen, req.target_collection, req.field_overrides ?? {});
+			}
+		} finally {
+			// Cleared UNCONDITIONALLY. `preparing` is a busy flag for this dialog
+			// instance, not per-attempt state, and `canConfirm` already prevents a
+			// second overlapping attempt — so there is nothing for a generation
+			// guard to protect, while guarding it strands the flag (and Confirm
+			// with it) whenever the destination changes mid-flush.
+			preparing = false;
+		}
+	}
+
+	async function dispatchCopy(gen: number, req: ItemCopyPreflightRequest) {
+		submitting = true;
+		try {
+			const result = await api.items.copy(sourceWsSlug, item.slug, req);
+			if (gen !== flowGen) return;
+			oncopied(result);
+			onclose();
+		} catch (e: any) {
+			if (gen !== flowGen) return;
+			const code = errorCode(e);
+			if (isDestinationGoneError(e)) {
+				handleDestinationLost();
+				return;
+			}
+			if (code === 'plan_limit_exceeded') {
+				submitError = planLimitMessage(e);
+				return;
+			}
+			if (code === 'conflict') {
+				submitError = `${e?.message ?? 'A conflicting item already exists in the destination.'} Nothing was copied.`;
+				return;
+			}
+			if (code && PRE_WRITE_CODES.has(code)) {
+				submitError = `${e?.message ?? 'The copy was refused.'} Nothing was copied.`;
+				return;
+			}
+			// `copy_failed`, an unstructured non-JSON response, a rejected fetch,
+			// a timeout, or a structured code we don't recognise — the request was
+			// DISPATCHED, so the outcome is unknown. No retry (DR-13).
+			outcomeUnknown =
+				e?.message ??
+				'The connection was lost after the request was sent, so the outcome is unknown.';
+		} finally {
+			// Unconditional for the same reason as `preparing` above.
+			submitting = false;
+		}
+	}
+
+	async function dispatchMove(
+		gen: number,
+		targetCollection: string,
+		fieldOverrides: Record<string, unknown>,
+	) {
+		submitting = true;
+		try {
+			const outcome = await onmove(targetCollection, fieldOverrides);
+			if (gen !== flowGen) return;
+			if (outcome.status === 'ok') {
+				onclose();
+				return;
+			}
+			if (outcome.status === 'cancelled') {
+				submitError = 'Move cancelled. Nothing was changed.';
+				return;
+			}
+			submitError = outcome.message ?? 'Could not move the item.';
+		} finally {
+			submitting = false;
+		}
+	}
+
+	// ── Formatting ────────────────────────────────────────────────────────
+
+	function formatBytes(n: number): string {
+		if (!n) return '0 B';
+		const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+		let v = n;
+		let i = 0;
+		while (v >= 1024 && i < units.length - 1) {
+			v /= 1024;
+			i++;
+		}
+		return `${v >= 10 || i === 0 ? Math.round(v) : v.toFixed(1)} ${units[i]}`;
+	}
+
+	function humanizeLinkType(t: string): string {
+		return t.replace(/[_-]+/g, ' ');
+	}
+
+	function displayValue(v: unknown): string {
+		if (v === null || v === undefined || v === '') return '—';
+		if (Array.isArray(v)) return v.join(', ');
+		if (typeof v === 'object') return JSON.stringify(v);
+		return String(v);
+	}
+
+	function dropReason(reason: string): string {
+		switch (reason) {
+			case 'no_target_field':
+				return 'no matching field in the destination';
+			case 'incompatible_type':
+				return 'the destination field has a different type';
+			case 'undeclared_source_field':
+				return 'not declared by this item’s own collection';
+			case 'assignee_not_a_member':
+				return 'the assignee is not a member of the destination';
+			case 'agent_role_not_portable':
+				return 'agent roles are workspace-local';
+			default:
+				return reason;
+		}
+	}
+
+	/** Focus the first destination control when the dialog opens, so keyboard
+	 *  users land on the thing they must choose rather than the heading. */
+	let wsSelectEl = $state<HTMLSelectElement | undefined>(undefined);
+	$effect(() => {
+		if (open && wsSelectEl) {
+			void tick().then(() => wsSelectEl?.focus());
+		}
+	});
+</script>
+
+<Modal
+	{open}
+	onclose={handleDismiss}
+	labelledby={titleId}
+	maxWidth="620px"
+	closeOnBackdrop={!submitting}
+	class="copy-dialog"
+>
+	<div class="modal-header">
+		<h2 id={titleId}>Copy or move {sourceRef}</h2>
+		<button
+			class="close-btn"
+			type="button"
+			aria-label="Close"
+			disabled={submitting}
+			onclick={handleDismiss}>&#10005;</button
+		>
+	</div>
+
+	<div class="modal-body">
+		{#if sourceUnavailable}
+			<p class="notice notice-error" role="status">
+				This item is no longer available — it was archived or deleted. Nothing can be copied
+				from it.
+			</p>
+		{/if}
+
+		<!-- ── Destination ───────────────────────────────────────────────── -->
+		<section class="section">
+			<h3 class="section-title">Destination</h3>
+
+			{#if workspacesLoading}
+				<p class="muted">Loading workspaces…</p>
+			{:else if workspacesError}
+				<p class="notice notice-error" role="alert">{workspacesError}</p>
+			{:else}
+				<label class="field-label" for="copy-dest-ws-{uid}">Workspace</label>
+				<select
+					id="copy-dest-ws-{uid}"
+					class="select"
+					bind:this={wsSelectEl}
+					value={destWs}
+					disabled={submitting}
+					onchange={(e) => handleWorkspaceChange(e.currentTarget.value)}
+				>
+					{#each workspaces as ws (ws.slug)}
+						<option value={ws.slug}>{ws.name}{ws.slug === sourceWsSlug ? ' (current)' : ''}</option
+						>
+					{/each}
+				</select>
+			{/if}
+
+			{#if destinationLost}
+				<p class="notice notice-error" role="alert">{destinationLost}</p>
+			{/if}
+
+			<label class="field-label" for="copy-dest-coll-{uid}">Collection</label>
+			{#if destCollectionsLoading}
+				<p class="muted">Loading collections…</p>
+			{:else if destCollectionsError}
+				<p class="notice notice-error" role="alert">{destCollectionsError}</p>
+			{:else if destCollections.length === 0}
+				<p class="muted">No editable collections in this workspace.</p>
+			{:else}
+				<select
+					id="copy-dest-coll-{uid}"
+					class="select"
+					value={destColl}
+					disabled={submitting}
+					onchange={(e) => handleCollectionChange(e.currentTarget.value)}
+				>
+					<option value="">Choose a collection…</option>
+					{#each destCollections as c (c.slug)}
+						<option value={c.slug}>{c.name}</option>
+					{/each}
+				</select>
+			{/if}
+		</section>
+
+		<!-- ── Copy vs move ──────────────────────────────────────────────── -->
+		<section class="section">
+			<h3 class="section-title" id="copy-mode-label-{uid}">Action</h3>
+			<div class="mode-toggle" role="radiogroup" aria-labelledby="copy-mode-label-{uid}">
+				<label class="mode-option" class:disabled={!crossWorkspace}>
+					<input
+						type="radio"
+						name="copy-mode-{uid}"
+						value="copy"
+						checked={effectiveMode === 'copy'}
+						disabled={!crossWorkspace || submitting}
+						onchange={() => handleModeChange('copy')}
+					/>
+					<span>Copy — leave the original in place</span>
+				</label>
+				<label class="mode-option">
+					<input
+						type="radio"
+						name="copy-mode-{uid}"
+						value="move"
+						checked={effectiveMode === 'move'}
+						disabled={submitting}
+						onchange={() => handleModeChange('move')}
+					/>
+					<span>
+						{crossWorkspace
+							? 'Move — copy, then archive the original'
+							: 'Move to another collection in this workspace'}
+					</span>
+				</label>
+			</div>
+			{#if !crossWorkspace}
+				<p class="muted">
+					Within this workspace only a move is available — the item keeps its ID, parent,
+					relationships and attachments. Choose another workspace to copy.
+				</p>
+			{/if}
+		</section>
+
+		<!-- ── Preview ───────────────────────────────────────────────────── -->
+		{#if destColl}
+			<section class="section">
+				<h3 class="section-title">Preview</h3>
+				{#if preflightLoading && !preflight}
+					<p class="muted">Checking what carries over…</p>
+				{:else if preflightError}
+					<p class="notice notice-error" role="alert">{preflightError}</p>
+				{:else if preflight}
+					<div class="preview" class:stale={preflightLoading}>
+						<!-- Carried -->
+						<div class="bucket">
+							<h4 class="bucket-title">Carried over ({preflight.fields.carried.length})</h4>
+							{#if preflight.fields.carried.length === 0}
+								<p class="muted">Nothing carries over from this item’s fields.</p>
+							{:else}
+								<ul class="bucket-list">
+									{#each preflight.fields.carried as f (f.key)}
+										<li>
+											<span class="k">{f.label || f.key}</span>
+											<span class="v">{displayValue(f.value)}</span>
+											{#if f.from !== 'migrated'}
+												<span class="tag">{f.from === 'override' ? 'your value' : 'default'}</span>
+											{/if}
+										</li>
+									{/each}
+								</ul>
+							{/if}
+						</div>
+
+						<!-- Dropped -->
+						{#if preflight.fields.dropped.length > 0}
+							<div class="bucket">
+								<h4 class="bucket-title">
+									Not carried over ({preflight.fields.dropped.length})
+								</h4>
+								<ul class="bucket-list">
+									{#each preflight.fields.dropped as f (f.key + f.kind)}
+										<li>
+											<span class="k">{f.label || f.key}</span>
+											<span class="v muted">{dropReason(f.reason)}</span>
+										</li>
+									{/each}
+								</ul>
+							</div>
+						{/if}
+
+						<!-- Needs a value -->
+						{#if overrideRows.length > 0}
+							<div class="bucket">
+								<h4 class="bucket-title">Needs a value</h4>
+								{#if blockedFields.length > 0}
+									<p class="notice notice-error" role="alert">
+										{#each blockedFields as f (f.key)}
+											<span class="blocked-line">
+												<strong>{f.label || f.key}</strong> is a required
+												<code>{f.type ?? 'unknown'}</code> field. This dialog can’t collect a value
+												for that type safely.
+											</span>
+										{/each}
+										Use the CLI instead:
+										<code
+											>pad item copy {sourceRef} --to-workspace {destWs} --collection {destColl}
+											--field {blockedFields[0].key}=value</code
+										>
+									</p>
+								{/if}
+								<div class="needs-list">
+									{#each overrideRows as row (row.key)}
+										{#if COLLECTABLE_TYPES.has(row.type ?? 'text')}
+											<div class="needs-row">
+												<span class="k">
+													{row.label || row.key}
+													{#if row.required}<span class="req" aria-hidden="true">*</span>{/if}
+												</span>
+												<div class="needs-control">
+													<FieldEditor
+														field={toFieldDef(row)}
+														ariaLabel={row.label || row.key}
+														value={overrides[row.key]}
+														readonly={submitting}
+														onchange={(v) => handleOverrideChange(row.key, v)}
+													/>
+													{#if row.message}
+														<span class="muted">{row.message}</span>
+													{/if}
+												</div>
+											</div>
+										{/if}
+									{/each}
+								</div>
+							</div>
+						{/if}
+
+						<!-- Warnings. Cross-workspace only: on an intra-workspace move
+						     the item keeps its id, parent, links and attachments, so the
+						     preflight's copy-shaped warnings would state the opposite of
+						     what happens. -->
+						{#if crossWorkspace && warnings}
+							<div class="bucket">
+								<h4 class="bucket-title">What you should know</h4>
+								<ul class="warn-list">
+									{#if warnings.child_count > 0}
+										<li>
+											{warnings.child_count} child item{warnings.child_count === 1 ? '' : 's'}
+											{warnings.children_orphaned
+												? ' will be left behind in this workspace with their parent archived.'
+												: ' will NOT be copied and stay here.'}
+										</li>
+									{/if}
+									{#if warnings.dropped_parent}
+										<li>The copy will have no parent — the parent link is not carried.</li>
+									{/if}
+									{#each linkRows as r (r.dir + r.type)}
+										<li>
+											{r.count}
+											{humanizeLinkType(r.type)}
+											{r.dir === 'outgoing' ? 'relationship' : 'inbound relationship'}{r.count === 1
+												? ''
+												: 's'} will not be carried.
+										</li>
+									{/each}
+									{#if warnings.dropped_assignee}
+										<li>The assignee is not a member of the destination, so it is cleared.</li>
+									{/if}
+									{#if warnings.dropped_agent_role}
+										<li>The agent role is workspace-local and is cleared.</li>
+									{/if}
+									{#if warnings.attachment_count > 0}
+										<li>
+											{warnings.attachment_count} attachment{warnings.attachment_count === 1
+												? ''
+												: 's'} ({formatBytes(warnings.attachment_bytes)}, including thumbnails)
+											will be copied — this ADDS that much to {preflight.destination.workspace_name}.
+										</li>
+									{/if}
+									{#if warnings.unresolvable_ref_count > 0}
+										<li>
+											{warnings.unresolvable_ref_count} attachment reference{warnings.unresolvable_ref_count ===
+											1
+												? ''
+												: 's'} in the content already resolve to nothing and stay broken.
+										</li>
+									{/if}
+									{#if !warnings.child_count && !warnings.dropped_parent && linkRows.length === 0 && !warnings.dropped_assignee && !warnings.dropped_agent_role && !warnings.attachment_count && !warnings.unresolvable_ref_count}
+										<li>Nothing else is affected.</li>
+									{/if}
+								</ul>
+								{#if warnings.relationships_partial}
+									<!-- Floor qualifier, NOT a warning row. Some of this
+									     item's relatives are on items this account cannot
+									     see, and the server does not count what it will not
+									     show. Rendered only when true — a marker that fires
+									     on the common case becomes noise. `children_orphaned`
+									     is qualified only on the move path: a plain copy
+									     archives nothing, so no hidden child can be orphaned
+									     by it and `false` is the complete answer there. -->
+									<p class="notice notice-info">
+										These relationship counts are a <strong>floor, not a total</strong>: at least
+										one of this item’s relationships is on an item you can’t see, and isn’t
+										counted{archiveSource ? ', including any children that would be left behind' : ''}.
+									</p>
+								{/if}
+							</div>
+						{/if}
+
+						<!-- Permanent content-semantics note (DR-21). Not conditional:
+						     the counts alone never tell the user what happens to the
+						     body of their item, and wiki-link RETARGETING is the
+						     surprising outcome. -->
+						{#if crossWorkspace}
+							<p class="notice notice-info content-note">
+								The content is copied as written. Attachment references are repointed at the
+								copied files — but only those that still resolve to a live attachment in this
+								workspace; any others are left as they are and counted above. And
+								<code>[[wiki-links]]</code> are not rewritten: they are re-resolved in
+								{preflight.destination.workspace_name}, so a link can end up pointing at a
+								<strong>different item</strong> there, or at nothing. Explicit
+								<code>[[workspace::REF]]</code> links keep pointing back here.
+							</p>
+						{/if}
+					</div>
+				{/if}
+			</section>
+		{/if}
+
+		<!-- ── Outcome states ────────────────────────────────────────────── -->
+		{#if outcomeUnknown}
+			<p class="notice notice-error" role="alert">
+				<strong>The outcome of this {effectiveMode} is unknown.</strong>
+				{outcomeUnknown} The request had already been sent, so it may have completed. Open
+				<strong>{destWorkspaceName}</strong> and check before doing anything else — do
+				<strong>not</strong> retry, or you may create a duplicate.
+			</p>
+		{:else if staleReview}
+			<p class="notice notice-warn" role="status">{staleReview}</p>
+		{:else if submitError}
+			<p class="notice notice-error" role="alert">{submitError}</p>
+		{/if}
+	</div>
+
+	<div class="modal-footer">
+		{#if submitting}
+			<span class="muted footer-status" role="status">
+				{effectiveMode === 'move' ? 'Moving' : 'Copying'} — don’t close this window.
+			</span>
+		{/if}
+		<button class="btn" type="button" disabled={submitting} onclick={handleDismiss}>
+			{outcomeUnknown ? 'Close' : 'Cancel'}
+		</button>
+		<button class="btn btn-primary" type="button" disabled={!canConfirm} onclick={handleConfirm}>
+			{confirmLabel}
+		</button>
+	</div>
+</Modal>
+
+<style>
+	.modal-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: var(--space-3);
+		padding: var(--space-4);
+		border-bottom: 1px solid var(--border);
+		flex-shrink: 0;
+	}
+	.modal-header h2 {
+		margin: 0;
+		font-size: 1rem;
+		font-weight: 600;
+	}
+	.close-btn {
+		background: none;
+		border: none;
+		color: var(--text-muted);
+		cursor: pointer;
+		font-size: 1rem;
+		line-height: 1;
+		padding: var(--space-1);
+	}
+	.close-btn:disabled {
+		opacity: 0.4;
+		cursor: not-allowed;
+	}
+
+	/* The body is the ONLY scroll container: Modal caps the dialog at 85vh and
+	   hides overflow, and this dialog can carry the full warning set plus one
+	   typed input per unsatisfied required field. Keeping the scroll here means
+	   the footer controls stay reachable at every viewport. */
+	.modal-body {
+		padding: var(--space-4);
+		overflow-y: auto;
+		flex: 1 1 auto;
+		min-height: 0;
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-4);
+	}
+
+	.modal-footer {
+		display: flex;
+		align-items: center;
+		justify-content: flex-end;
+		gap: var(--space-2);
+		padding: var(--space-3) var(--space-4);
+		border-top: 1px solid var(--border);
+		flex-shrink: 0;
+	}
+	.footer-status {
+		margin-right: auto;
+	}
+
+	.section {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-2);
+	}
+	.section-title {
+		margin: 0;
+		font-size: 0.75rem;
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+		color: var(--text-muted);
+	}
+	.field-label {
+		font-size: 0.8rem;
+		color: var(--text-secondary);
+	}
+	.select {
+		width: 100%;
+		padding: var(--space-2);
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+		background: var(--bg-primary);
+		color: var(--text-primary);
+		font-size: 0.9rem;
+	}
+
+	.mode-toggle {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-1);
+	}
+	.mode-option {
+		display: flex;
+		align-items: center;
+		gap: var(--space-2);
+		font-size: 0.9rem;
+	}
+	.mode-option.disabled {
+		opacity: 0.55;
+	}
+
+	.preview {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-3);
+	}
+	.preview.stale {
+		opacity: 0.6;
+	}
+	.bucket {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-2);
+	}
+	.bucket-title {
+		margin: 0;
+		font-size: 0.85rem;
+		font-weight: 600;
+	}
+	.bucket-list,
+	.warn-list {
+		margin: 0;
+		padding-left: var(--space-4);
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-1);
+		font-size: 0.85rem;
+	}
+	.bucket-list {
+		list-style: none;
+		padding-left: 0;
+	}
+	.bucket-list li {
+		display: flex;
+		gap: var(--space-2);
+		align-items: baseline;
+		flex-wrap: wrap;
+	}
+	.k {
+		font-weight: 500;
+		min-width: 8rem;
+	}
+	.v {
+		color: var(--text-secondary);
+		overflow-wrap: anywhere;
+	}
+	.tag {
+		font-size: 0.7rem;
+		padding: 0 var(--space-1);
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+		color: var(--text-muted);
+	}
+	.req {
+		color: var(--accent-orange);
+	}
+
+	.needs-list {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-2);
+	}
+	.needs-row {
+		display: flex;
+		gap: var(--space-2);
+		align-items: center;
+		flex-wrap: wrap;
+	}
+	.needs-control {
+		flex: 1 1 12rem;
+		min-width: 0;
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-1);
+	}
+
+	.notice {
+		margin: 0;
+		padding: var(--space-2) var(--space-3);
+		border-radius: var(--radius);
+		font-size: 0.85rem;
+		border: 1px solid var(--border);
+		background: var(--bg-secondary);
+	}
+	.notice-error {
+		border-left: 3px solid var(--accent-red, var(--accent-orange));
+	}
+	.notice-warn {
+		border-left: 3px solid var(--accent-orange);
+	}
+	.notice-info {
+		border-left: 3px solid var(--border);
+		color: var(--text-secondary);
+	}
+	.content-note code {
+		font-size: 0.8em;
+	}
+	.blocked-line {
+		display: block;
+	}
+
+	.muted {
+		margin: 0;
+		color: var(--text-muted);
+		font-size: 0.8rem;
+	}
+
+	.btn {
+		padding: var(--space-2) var(--space-3);
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+		background: var(--bg-secondary);
+		color: var(--text-primary);
+		font-size: 0.85rem;
+		cursor: pointer;
+	}
+	.btn:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+	.btn-primary {
+		background: var(--accent);
+		border-color: var(--accent);
+		color: #fff;
+	}
+</style>

--- a/web/src/lib/components/items/CopyItemDialog.svelte
+++ b/web/src/lib/components/items/CopyItemDialog.svelte
@@ -217,6 +217,12 @@ user hunting for an item that provably does not exist.
 	 * rejects with 400 `malformed_override`.
 	 */
 	let previewGen = 0;
+	// Bumped by every override edit. SEPARATE from previewGen on purpose:
+	// previewGen cancels in-flight preflights, and an override edit must NOT do
+	// that — the debounce + single-flight runner already collapse rapid edits.
+	// What an override edit MUST do is supersede an in-progress confirm, whose
+	// request was built from the OLD values (final-review P1).
+	let overrideGen = 0;
 
 	// ── Derived ───────────────────────────────────────────────────────────
 
@@ -503,6 +509,10 @@ user hunting for an item that provably does not exist.
 		overrides = { ...overrides, [key]: value };
 		retainedValues = { ...retainedValues, [key]: value };
 		staleReview = '';
+		// Supersede any confirm currently flushing/re-checking: its captured
+		// request carries the pre-edit values, and dispatching it would copy
+		// something the user can see is no longer what they entered.
+		overrideGen++;
 		schedulePreflight();
 	}
 
@@ -739,8 +749,10 @@ user hunting for an item that provably does not exist.
 		// abandons this attempt; the new destination re-previews and Confirm
 		// re-enables.
 		const pgen = previewGen;
+		const ogen = overrideGen;
 		const req = buildRequest();
-		const superseded = () => gen !== flowGen || pgen !== previewGen;
+		const superseded = () =>
+			gen !== flowGen || pgen !== previewGen || ogen !== overrideGen;
 		const reviewed = reviewFingerprint(preflight);
 		preparing = true;
 		submitError = '';
@@ -1116,7 +1128,7 @@ user hunting for an item that provably does not exist.
 														field={toFieldDef(row)}
 														ariaLabel={row.label || row.key}
 														value={overrides[row.key]}
-														readonly={submitting}
+														readonly={submitting || preparing}
 														onchange={(v) => handleOverrideChange(row.key, v)}
 													/>
 													{#if row.message}

--- a/web/src/lib/components/items/CopyItemDialog.svelte
+++ b/web/src/lib/components/items/CopyItemDialog.svelte
@@ -690,7 +690,19 @@ user hunting for an item that provably does not exist.
 		'archived',
 		'plan_limit_exceeded',
 		'rate_limited',
-		'unauthorized'
+		'unauthorized',
+		// Rejected by the middleware stack BEFORE handleCopyItem runs, so they
+		// provably cannot have created anything (final review round 2):
+		'csrf_error', // 403 — CSRF check failed at the perimeter
+		'email_not_verified', // 403 — unverified email may not mutate content
+		// 500 internal_error is pre-write ON THIS ROUTE specifically: the only
+		// writeInternalError call sites reachable here are in
+		// resolveAuthorizedCopy (handlers_items_copy_resolve.go:128,184), both
+		// before the store call. A post-commit panic deliberately does NOT
+		// emit it — afterCopyCommit logs and lets the response stand — and
+		// chi's Recoverer returns a bodiless 500, which has no code and so
+		// still falls through to outcome-unknown below.
+		'internal_error'
 	]);
 
 	function planLimitMessage(e: unknown): string {

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -29,7 +29,7 @@
 	import { relativeTime, wikiLinksToMarkdown, markdownToWikiLinks, cleanBrokenLinks, unescapeDocLinks } from '$lib/utils/markdown';
 	import { toastStore } from '$lib/stores/toast.svelte';
 	import { editorStore } from '$lib/stores/editor.svelte';
-	import type { Item, Collection, CollectionSettings, QuickAction, ItemLink, AgentRole, PaneTarget, ResolvedItemIdentity } from '$lib/types';
+	import type { Item, Collection, CollectionSettings, QuickAction, ItemLink, AgentRole, PaneTarget, ResolvedItemIdentity, ItemCopyResult } from '$lib/types';
 	import { parseFields, parseSchema, parseSettings, parseTags, formatItemRef, itemUrlId, getTerminalOptions } from '$lib/types';
 	import QuickActionsMenu from '$lib/components/common/QuickActionsMenu.svelte';
 	import BottomSheet from '$lib/components/common/BottomSheet.svelte';
@@ -40,6 +40,7 @@
 	import ContentError from '$lib/components/common/ContentError.svelte';
 	import EditCollectionModal from '$lib/components/collections/EditCollectionModal.svelte';
 	import ShareDialog from '$lib/components/ShareDialog.svelte';
+	import CopyItemDialog from '$lib/components/items/CopyItemDialog.svelte';
 	import { copyToClipboard } from '$lib/utils/clipboard';
 	import { repairDeadItemLastRoute } from '$lib/collections/paneUrlParams';
 	import { isSamePaneTarget, breadcrumbParentTarget } from '$lib/collections/paneTarget';
@@ -1399,6 +1400,11 @@
 		addLinkResults = [];
 		addLinkLoading = false;
 		shareDialogOpen = false;
+		// The copy dialog is {#key itemSlug}-remounted, but `open` is owned
+		// HERE — leaving it true would tear down A's dialog and immediately
+		// re-open a fresh one pointed at B, silently retargeting a mutation the
+		// user set up for A.
+		copyDialogOpen = false;
 		editCollectionOpen = false;
 		showGraph = false;
 		backlinksCount = 0;
@@ -3690,6 +3696,105 @@
 		// for this narrow case.
 	}
 
+	// ── Cross-workspace copy / move dialog (PLAN-2373 / TASK-2355) ──────────
+
+	let copyDialogOpen = $state(false);
+
+	/**
+	 * Close the copy dialog and put focus back on the ⋯ pane-menu trigger.
+	 *
+	 * Modal restores focus to whatever was focused when it OPENED, and only if
+	 * that node is still connected — but the launcher here is a menu item that
+	 * the menu unmounts on close, so the generic restore lands on nothing. The
+	 * ⋯ button is the stable anchor, and this runs on EVERY close path (Escape,
+	 * backdrop, Cancel, success, failure) because it is the dialog's only
+	 * `onclose`.
+	 *
+	 * The `await tick()` matters: while the native dialog is still open the rest
+	 * of the document is inert, so focusing the trigger before Modal's effect
+	 * has run `close()` would be a no-op.
+	 */
+	async function closeCopyDialog() {
+		copyDialogOpen = false;
+		await tick();
+		paneMenuTrigger?.focus();
+	}
+
+	/**
+	 * Foreground-flush whatever the user has typed into `items.content` before a
+	 * copy previews or commits. Resolves false when the flush FAILED, which
+	 * blocks the copy: the cross-workspace copy reads `items.content`, and under
+	 * live collab that can lag the authoritative Y.Doc by the full 5s debounce.
+	 * Silently copying content the user just typed but that never reached the
+	 * server is the worst outcome this dialog can produce.
+	 *
+	 * Mirrors `flushCollabBeforeRestore`'s fences (captured ctx, id agreement)
+	 * and adds the raw-markdown path, which has its own pending-save queue.
+	 */
+	async function flushContentBeforeCopy(): Promise<boolean> {
+		if (!item) return false;
+		// Raw markdown mode: no collab provider; drain the debounced PATCH queue.
+		if (rawMode) return await flushRawIfPending();
+		// No LIVE collab editor to drain (non-collab item, viewer, editor not
+		// mounted): items.content is already canonical.
+		if (!collabProvider || !editorInstance || editorInstance.isDestroyed) return true;
+		const ctx = activeCollabContext;
+		if (!ctx || ctx.itemId !== item.id) return true;
+		let md: string | null = null;
+		try {
+			const raw = (editorInstance.storage as any).markdown?.getMarkdown?.();
+			if (typeof raw === 'string') md = raw;
+		} catch {
+			// Live read failed — fall through to the per-edit shadow.
+		}
+		if (md == null) md = lastEditorMarkdown;
+		if (md == null) return true;
+		const result = await collabFlusher.flush(ctx, md, false);
+		// 'deduped' — the server already has this markdown. 'skipped' —
+		// force-refresh recovery, where the local Y.Doc is the stale side and
+		// items.content is canonical, so the copy would read the right thing
+		// either way. Only an attempted-and-rejected PATCH is a loss.
+		return result !== 'failed';
+	}
+
+	/**
+	 * A cross-workspace copy (or move) committed. The parent owns the feedback.
+	 *
+	 * Deliberately does NOT wait for SSE: the browser holds one workspace's SSE
+	 * connection at a time, so while we sit in the source workspace we can never
+	 * receive the destination's `item_created`. A plain copy changes nothing
+	 * here and needs no invalidation at all; a move re-fetches the source so its
+	 * archived + provenance banners render now rather than on the next load.
+	 */
+	async function handleCopied(result: ItemCopyResult) {
+		const dest = result.destination;
+		const label = dest.ref ?? dest.slug;
+		toastStore.show(
+			result.source.archived
+				? `Moved to ${dest.workspace_name} as ${label}`
+				: `Copied to ${dest.workspace_name} as ${label}`,
+			'success',
+		);
+		if (!result.source.archived) return;
+		const targetItem = item;
+		if (!targetItem) return;
+		const gen = loadGeneration;
+		const ws = wsSlug;
+		const slug = itemSlug;
+		try {
+			const refreshed = await api.items.get(ws, slug);
+			if (switchedAway(targetItem, gen)) return;
+			// Don't clobber a NEWER snapshot: an SSE/sync update (or another
+			// client restoring the source) can land while this GET is in flight,
+			// and `seq` is the workspace-scoped mutation cursor stamped on every
+			// write. Equal seq is fine to adopt — it's the same revision.
+			if ((item?.seq ?? 0) > (refreshed.seq ?? 0)) return;
+			item = adoptServerItem(refreshed);
+		} catch {
+			// Non-fatal: the archived state surfaces on the next load.
+		}
+	}
+
 	async function handleDelete() {
 		if (!item || !canEdit) return;
 		// Capture identity before the await. The DELETE targets `targetItem.id`
@@ -3937,8 +4042,26 @@
 		}
 	}
 
-	async function handleMove(targetSlug: string) {
-		if (!item || moving || !canEdit) return;
+	/**
+	 * Move the item to another collection IN THIS WORKSPACE.
+	 *
+	 * Two call sites: the pane menu's move drill-down (fire-and-forget), and
+	 * CopyItemDialog when the chosen destination workspace IS this one (DR-18) —
+	 * which finally passes `fieldOverrides`, closing the intra-workspace dead
+	 * end where the server's `missing_required_fields` refusal became an
+	 * unactionable toast because this call site hardcoded `undefined`.
+	 *
+	 * The outcome is RETURNED (rather than only toasted) so the dialog can
+	 * decide whether to close; the toasts, the open-children force retry, and
+	 * `navIfStillCurrent`'s route-identity fencing are unchanged.
+	 */
+	async function handleMove(
+		targetSlug: string,
+		fieldOverrides?: Record<string, unknown>,
+	): Promise<{ status: 'ok' | 'cancelled' | 'failed'; message?: string }> {
+		if (!item || moving || !canEdit) {
+			return { status: 'failed', message: moving ? 'A move is already in progress.' : undefined };
+		}
 		moving = true;
 		paneMenuOpen = false;
 		paneMenuView = 'root';
@@ -3962,7 +4085,7 @@
 		const gen = loadGeneration;
 		const stillOnSource = () => !switchedAway(sourceItem, gen);
 		const doMove = (force: boolean) =>
-			api.items.move(sourceWs, sourceSlug, targetSlug, undefined, force ? { force: true } : undefined);
+			api.items.move(sourceWs, sourceSlug, targetSlug, fieldOverrides, force ? { force: true } : undefined);
 		// After the modal resolves, only honor the success path's
 		// navigation/toast if the page is STILL on the source item.
 		// We check both `item.id` (cheap object-identity guard) AND
@@ -3989,6 +4112,7 @@
 			const moved = await doMove(false);
 			if (stillOnSource()) toastStore.show(`Moved to ${targetSlug}`, 'success');
 			navIfStillCurrent(moved.slug);
+			return { status: 'ok' };
 		} catch (e: any) {
 			// BUG-1538 / Codex review round 1: the server's
 			// open-children guard also fires on POST /move when the
@@ -3998,7 +4122,7 @@
 			if (isOpenChildrenError(e)) {
 				// Don't open the confirm dialog (or fire its forced retry) if the
 				// pane already switched away from the source item.
-				if (!stillOnSource()) return;
+				if (!stillOnSource()) return { status: 'cancelled' };
 				let forced;
 				try {
 					forced = await confirmOpenChildrenOrThrow(e, parentRef, () => {
@@ -4008,17 +4132,21 @@
 				} catch (retryErr: any) {
 					console.error('Forced move failed:', retryErr);
 					if (stillOnSource()) toastStore.show(retryErr?.message ?? 'Failed to move item', 'error');
-					return; // outer finally still resets `moving`
+					// outer finally still resets `moving`
+					return { status: 'failed', message: retryErr?.message ?? 'Failed to move item' };
 				}
 				if (forced) {
 					if (stillOnSource()) toastStore.show(`Moved to ${targetSlug}`, 'success');
 					navIfStillCurrent(forced.slug);
-				} else if (stillOnSource()) {
+					return { status: 'ok' };
+				}
+				if (stillOnSource()) {
 					toastStore.show('Move cancelled', 'info');
 				}
-				return;
+				return { status: 'cancelled' };
 			}
 			if (stillOnSource()) toastStore.show(e.message ?? 'Failed to move item', 'error');
+			return { status: 'failed', message: e?.message ?? 'Failed to move item' };
 		} finally {
 			// Guard against clobbering a NEWER item's move: a superseded move's
 			// finally must not clear the flag the current item's handler set.
@@ -4503,6 +4631,21 @@
 						{#if canEdit}
 							<MenuItem icon="⇄" hint="›" onclick={() => (paneMenuView = 'move')} disabled={moving}>
 								{moving ? 'Moving…' : 'Move to collection…'}
+							</MenuItem>
+							<!-- Launcher only — the review step itself is a Modal (PLAN-2373).
+							     Stays `canEdit`-gated like the move row: that correctly admits
+							     an item-edit-grant guest, which the server also admits. The
+							     DESTINATION side is gated separately, inside the dialog. -->
+							<MenuItem
+								icon="⧉"
+								onclick={() => {
+									paneMenuOpen = false;
+									paneMenuView = 'root';
+									copyDialogOpen = true;
+								}}
+								disabled={moving}
+							>
+								Copy or move to workspace…
 							</MenuItem>
 						{/if}
 						{#if isOwner}
@@ -5316,6 +5459,32 @@
 		{/key}
 
 	</div>
+
+	{#if item}
+		<!--
+			Cross-workspace copy / move dialog (PLAN-2373 / TASK-2355).
+
+			{#key itemSlug}: this pane is persistent (no {#key} of its own), so
+			remount the dialog on an item switch — its destination selection,
+			entered override values and preview all belong to ONE source item.
+			Note the dialog itself is NOT wrapped in {#if open}: Modal is always
+			mounted and driven by its `open` prop (its consumer contract).
+		-->
+		{#key itemSlug}
+			<CopyItemDialog
+				open={copyDialogOpen}
+				onclose={closeCopyDialog}
+				sourceWsSlug={wsSlug}
+				sourceCollectionSlug={effectiveCollSlug}
+				{item}
+				sourceRef={formatItemRef(item) || item.slug}
+				sourceUnavailable={isArchived}
+				flushContent={flushContentBeforeCopy}
+				onmove={handleMove}
+				oncopied={handleCopied}
+			/>
+		{/key}
+	{/if}
 
 	{#if isOwner && item}
 		<!-- {#key itemSlug}: remount the item-scoped share dialog on switch. -->

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -4374,6 +4374,55 @@
 			</div>
 		{/if}
 
+		<!--
+			Moved-to PROVENANCE banner (PLAN-2357 / TASK-2359, DR-2a).
+
+			Wording is deliberate: "was moved to", never "lives at". The server
+			returns the ACL-FILTERED set of destinations, newest-first, with no
+			"current" marker — a marker would itself announce that a newer
+			destination exists and is being withheld, which is the leak the
+			set-return exists to avoid. So this is history, not a redirect.
+
+			Renders ONLY what the server supplied. `moved_to` is absent (key
+			omitted) whenever there is nothing this caller may see, and there is
+			no client-side reconstruction or second lookup — absent means
+			"nothing to show", and it must not be distinguishable from "there is
+			one you may not see", because there isn't a distinction.
+		-->
+		{#if item.moved_to && item.moved_to.length > 0}
+			<div class="moved-banner" role="status">
+				<span class="moved-icon" aria-hidden="true">⧉</span>
+				<div class="moved-text">
+					<strong
+						>This item was moved to {item.moved_to.length === 1
+							? 'another workspace'
+							: 'other workspaces'}</strong
+					>
+					<ul class="moved-list">
+						{#each item.moved_to as dest (dest.workspace_slug + '/' + dest.item_slug)}
+							{@const href =
+								dest.workspace_owner_username && dest.collection_slug
+									? `/${dest.workspace_owner_username}/${dest.workspace_slug}/${dest.collection_slug}/${dest.item_slug}`
+									: null}
+							<li>
+								{#if href}
+									<a {href}>{dest.ref ? `${dest.ref} — ` : ''}{dest.title}</a>
+								{:else}
+									<span>{dest.ref ? `${dest.ref} — ` : ''}{dest.title}</span>
+								{/if}
+								<span class="moved-ws">in {dest.workspace_name ?? dest.workspace_slug}</span>
+								{#if dest.moved_at}
+									<span class="moved-when" title={new Date(dest.moved_at).toLocaleString()}
+										>{relativeTime(dest.moved_at)}</span
+									>
+								{/if}
+							</li>
+						{/each}
+					</ul>
+				</div>
+			</div>
+		{/if}
+
 		<!-- Title -->
 		<div class="title-row">
 			{#if formatItemRef(item)}
@@ -6413,6 +6462,43 @@
 	.archived-restore-btn:disabled {
 		opacity: 0.5;
 		cursor: not-allowed;
+	}
+	.moved-banner {
+		display: flex;
+		align-items: flex-start;
+		gap: var(--space-3);
+		margin-bottom: var(--space-4);
+		padding: var(--space-3);
+		background: var(--bg-secondary);
+		border: 1px solid var(--border);
+		border-left: 3px solid var(--accent);
+		border-radius: var(--radius);
+	}
+	.moved-icon {
+		flex-shrink: 0;
+		color: var(--accent);
+	}
+	.moved-text {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-1);
+		font-size: 0.9em;
+		color: var(--text-secondary);
+		min-width: 0;
+	}
+	.moved-text strong {
+		color: var(--text-primary);
+	}
+	.moved-list {
+		margin: 0;
+		padding-left: var(--space-4);
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-1);
+	}
+	.moved-ws,
+	.moved-when {
+		color: var(--text-muted);
 	}
 	.link-row {
 		display: flex;


### PR DESCRIPTION
Phase 3 of cross-workspace item copy. Phases 1–2 (backend + CLI) merged as #1048.

Gives the web UI a copy/move surface on the already-merged preflight + copy endpoints, plus the backend hygiene the Phase 2 review deliberately deferred.

## Tasks

- [x] **TASK-2370** — extract `resolveAuthorizedCopy`, shared by the preflight and copy handlers
- [x] **TASK-2368** — unify three duplicated collection column-list/scan sites
- [x] **TASK-2372** — make the concurrency and attachment assertions actually bite
- [x] **TASK-2374** — delete two dead provenance accessors (DR-20)
- [x] **TASK-2355** — the copy dialog, provenance banner, API client methods, CLI docs, e2e

## Decision Record

Extends PLAN-2357's DR-1…DR-17, which remains the contract.

- **DR-18** — a same-workspace destination routes to `api.items.move`, not the copy endpoint. The copy path has no same-workspace guard, so uniform routing would silently mint a new item ID, drop the parent, clone attachments and archive the original. Implemented as a derivation (`effectiveMode = crossWorkspace ? mode : 'move'`) so no stale-mode window exists. Passing the dialog's overrides to `move` also closes the pre-existing intra-workspace field-override dead-end — `handleMove` passed `undefined` before this PR. Same-workspace *copy* split to IDEA-2375.
- **DR-19** — destination pickers gate on `canEditCollection` in the *destination* workspace, not nav visibility, which is strictly weaker than collection-create permission. The source launcher stays `canEdit`-gated, deliberately permissive enough for an item-edit-grant guest, matching the server.
- **DR-20** — the two dead provenance accessors are deleted, not consumed. A "copied from" back-pointer needs its own dual-sided disclosure design (a destination viewer must not learn the source's identity merely by seeing the destination), which is outside a UI PR.
- **DR-21** — the dialog carries a permanent content-semantics note; per-link wiki-link outcome counts deferred to IDEA-2377. Wiki-links are *not* rewritten on copy — they re-resolve in the destination and can silently retarget.
- **DR-22** — **reversed and cut.** See below.
- **DR-22a** — preview/commit staleness is handled client-side and advisorily only: flush the collab document before preflight and submit (a failed flush blocks the copy), re-preflight before submit, reconfirm on change. No server contract change.

## Notable: DR-22 was adopted, then cut

Round 5 of the plan review correctly found that the copy commits the latest *locked* source snapshot, not the previewed one — so a user can commit something they never reviewed, with no idempotency key and DR-13 forbidding a retry. The prescribed fix was an `expected_updated_at` OCC guard.

Round 6 refuted it. Item writes stamp second-precision `now()` (`internal/store/store.go:846`), and `nowNano()` exists in this codebase *specifically* because second precision collides when a timestamp doubles as a concurrency token (BUG-2265). A same-second edit would pass the guard, and the deterministic stale test the DR demanded as an acceptance criterion is unachievable with that token. The guarantee was also unachievable in principle — the preflight is an explicitly unlocked advisory snapshot. Reasoning preserved in IDEA-2378 so the same unsound remedy is not re-prescribed.

## What the final full-diff review caught

Two P1s that no per-task review could structurally have seen, each fixed as its own commit:

- **`33598bcc`** — a stale-override dispatch race. `handleConfirm` captured the request, then awaited a collab flush and a final preflight; override controls stayed live across that window and `handleOverrideChange` advanced no generation the confirm was fenced against, so an edit mid-flight dispatched the *pre-edit* values. The user watches their new value on screen while the old one is copied — and on the move path that commits wrong data with no retry available.
- **`83e59581`** — the inverse of the DR-13 hazard. `PRE_WRITE_CODES` omitted `csrf_error`, `email_not_verified` and structured `internal_error`, so three provably-safe refusals rendered as "may have committed, do not retry, go check the destination" — sending users hunting for an item that was never created. Verified safe on this route specifically: the post-commit panic handler deliberately does not emit `internal_error` (it logs and lets the response stand), and chi's `Recoverer` returns a bodiless 500 that correctly stays ambiguous.

## Test plan

Gates actually run on the final tip (`83e59581`):

- `make check` — green (lint, `go test ./...`, govulncheck, `npm audit`, svelte-check 1040 files / 0 errors)
- `make test-pg` — green (full suite against Postgres; required — this branch touches `internal/store` twice)
- `web/e2e/copy-dialog.spec.ts` — added

Mutation-verified rather than asserted, by the integrator rather than the implementing agent:

- **TASK-2370** — hoisting the decode block above `ResolveItem` makes an unauthorized caller receive `invalid_body`/400 instead of `not_found`/404, leaking item existence. Two ordering subtests fail; pass on revert.
- **TASK-2368** — neutering the workspace-scope predicate makes `TestCollectionAccessorsShareOneHydration` fail with "read a collection from another workspace".
- **TASK-2372** — against real Postgres: argument-order acquisition fails both deadlock tests deterministically (40P01 every round); correct acquisition passes in ~7.7s with no hang. An **ID-sorted** acquisition also passes, which corrects a wrong pre-existing comment: these tests defend "an ordered acquisition exists", not "ordered by lock key" — the lock-key requirement is defended by the hashtext-collision test. A second vacuity was closed: a retry-on-deadlock wrapper made both tests pass under a misordered acquisition, so both now assert a zero `pg_stat_database.deadlocks` delta.
- **TASK-2374** — the three deleted tests were traced to surviving retained-accessor equivalents; no coverage lost.

## Review

13 adversarial Codex rounds on the plan (2 fresh-angle CLEANs to converge), per-task loops during implementation, and 4 full-diff rounds at the end. Two rounds corrected the review itself: round 6 reversed round 5's remedy, and round 3 caught a contradiction introduced by round 2's own amendment.