### PR TITLE
fix(web): untrack the copy dialog's open/close reset (BUG-2380)

### DIFF
--- a/web/e2e/copy-dialog.spec.ts
+++ b/web/e2e/copy-dialog.spec.ts
@@ -145,6 +145,66 @@ test.describe('cross-workspace copy dialog (PLAN-2373 / TASK-2355)', () => {
 		// navigates, so there is no stable node left to restore to.
 	});
 
+	test('the dialog reopens after a destination change and cancel (BUG: wedged scheduler)', async ({
+		page,
+		fixture,
+		request,
+	}, testInfo) => {
+		test.skip(testInfo.project.name !== 'desktop-chromium', 'viewport driven explicitly');
+		await page.setViewportSize(DESKTOP);
+		await browserLogin(page);
+		const { slug } = await seedDoc(fixture, request, 'Copy dialog reopen');
+		const dest = await seedDestination(request, fixture, 'reopen', {
+			name: 'Notes',
+			slug: 'notes',
+			fields: [],
+		});
+		await page.goto(itemUrl(fixture, slug));
+
+		// EVERY other test in this file opens the dialog exactly once, which is
+		// precisely why this shipped. The reset that runs on open writes
+		// `destWs` and then reads it back; tracked, that is a self-dependency
+		// that invalidates the effect performing it and wedges Svelte's
+		// scheduler. It cannot bite on the FIRST open — `destWs` already equals
+		// the source workspace there, so the write is a no-op. It needs a real
+		// destination change, a close, and a REOPEN.
+		//
+		// The failure is silent: no console error (a production build reports
+		// none), the dialog simply never appears, and every other control on the
+		// pane dies with it because the aborted flush strands unrelated
+		// reactivity. So this test asserts the pane is still ALIVE afterwards,
+		// not merely that the dialog came back.
+		await openCopyDialog(page);
+		const dialog = copyDialog(page);
+
+		const collectionsLoaded = page.waitForResponse(
+			(r) => r.url().includes(`/workspaces/${dest.wsSlug}/collections`) && r.status() === 200,
+		);
+		await dialog.getByLabel('Workspace', { exact: true }).selectOption(dest.wsSlug);
+		await collectionsLoaded;
+
+		await dialog.getByRole('button', { name: 'Cancel' }).click();
+		await expect(dialog).toBeHidden();
+
+		// Reopen. Before the fix this silently did nothing.
+		await openCopyDialog(page);
+		await expect(dialog).toBeVisible();
+
+		// The reset must actually have run: the destination is back to the
+		// current workspace, not still pointing at the previous choice.
+		await expect(dialog.getByLabel('Workspace', { exact: true })).toHaveValue(
+			fixture.workspaceSlug,
+		);
+
+		// And the rest of the pane still responds — the part a "did the dialog
+		// open?" assertion alone would miss.
+		await dialog.getByRole('button', { name: 'Cancel' }).click();
+		await expect(dialog).toBeHidden();
+		const more = paneMoreBtn(page);
+		await more.click();
+		await expect(page.getByRole('menuitem', { name: 'Copy or move to workspace…' })).toBeVisible();
+	});
+
 	test('a required destination field gates Confirm until supplied, then the copy commits', async ({
 		page,
 		fixture,

--- a/web/src/lib/components/items/CopyItemDialog.svelte
+++ b/web/src/lib/components/items/CopyItemDialog.svelte
@@ -43,7 +43,7 @@ their own recovery paths; swallowing those into outcome-unknown would send the
 user hunting for an item that provably does not exist.
 -->
 <script lang="ts">
-	import { tick } from 'svelte';
+	import { tick, untrack } from 'svelte';
 	import Modal from '$lib/components/common/Modal.svelte';
 	import FieldEditor from '$lib/components/fields/FieldEditor.svelte';
 	import { api, PadApiError } from '$lib/api/client';
@@ -305,12 +305,28 @@ user hunting for an item that provably does not exist.
 	let prevOpen = false;
 
 	$effect.pre(() => {
-		if (open && !prevOpen) {
-			resetForOpen();
-		} else if (!open && prevOpen) {
-			cancelPending();
-		}
-		prevOpen = open;
+		// `open` is the ONLY dependency this effect may have. Both branches are
+		// untracked because they write ~18 pieces of $state and read some of
+		// them back — `resetForOpen` writes `destWs` and then reads it again to
+		// kick off the collection load. Tracked, that is a self-dependency: the
+		// write invalidates the effect that performed it, the flush aborts, and
+		// Svelte's scheduler is left wedged (CONVE-1688).
+		//
+		// It survived review because it only bites on the SECOND open. On the
+		// first, `destWs` already equals `sourceWsSlug`, so the reset is a
+		// no-op write and nothing invalidates. Change the destination once and
+		// reopen, and the reset becomes a real change — the dialog silently
+		// fails to open and every other control on the pane dies with it, with
+		// no console error because a production build reports nothing.
+		const isOpen = open;
+		untrack(() => {
+			if (isOpen && !prevOpen) {
+				resetForOpen();
+			} else if (!isOpen && prevOpen) {
+				cancelPending();
+			}
+			prevOpen = isOpen;
+		});
 	});
 
 	$effect(() => {


### PR DESCRIPTION
Fixes the regression Dave hit immediately after #1051 merged.

## Repro

1. Open any item (split or full view)
2. ⋯ → **Copy or move to workspace…**
3. Change the **Workspace** dropdown
4. **Cancel**
5. Reopen → the dialog silently never appears, and the whole pane is dead: ⋯ stops opening, the split view can't be closed, the selected item can't be changed

No console error, desktop and mobile alike.

## Cause

`$effect.pre` called `resetForOpen()` inside its tracked scope. `resetForOpen` writes `destWs = sourceWsSlug` and then reads `destWs` back to start the collection load — so the effect depended on a value it had just written. The write invalidated the effect performing it, the flush aborted, and the aborted flush stranded unrelated reactivity across the pane. The CONVE-1688 hazard.

It cannot bite on the first open: `destWs` already equals `sourceWsSlug` there, so the reset is a no-op write. It needs a real destination change, a close, and a reopen.

## Fix

Both branches of the lifecycle effect run inside `untrack`, so `open` really is the only dependency.

## Test

Adds the reopen case to `web/e2e/copy-dialog.spec.ts`. It asserts the pane is still **alive** afterwards — reopening the ⋯ menu — rather than only that the dialog returned, since the visible symptom was the dead menu, not the dead dialog.

**Mutation-verified:** with the `untrack` removed the new test fails; restored, 11/11 pass.

Gates: `make check` green, `npm run check` 0 errors, 11/11 e2e.

## Why the review missed it

Worth recording, because both reasons generalize:

1. **All ten existing e2e cases opened the dialog exactly once**, and the bug is unreachable in a single-open flow. A stateful component needs at least one open → mutate → close → reopen cycle; "does it open" is a different test from "does it open again".
2. **The comment above the effect asserted the property that was false** — that `open` was its only dependency. Thirteen plan-review rounds, per-task Codex loops and four full-diff rounds all reasoned from that claim instead of checking it. A confidently-worded invariant in a comment suppresses the check it should invite.