### PR TITLE
fix(attachments): close cross-workspace metadata leak and grant-guest blob 403

### DIFF
--- a/internal/mcp/resources_http_attachment_acl_test.go
+++ b/internal/mcp/resources_http_attachment_acl_test.go
@@ -1,0 +1,285 @@
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/attachments"
+	"github.com/PerpetualSoftware/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/server"
+	"github.com/PerpetualSoftware/pad/internal/store"
+)
+
+// The MCP image resource pad://workspace/{ws}/attachments/{id} is a SECOND
+// byte path for attachments. It reaches the canonical blob handler through
+// the same in-process handler chain the tool dispatcher uses, so PLAN-2391
+// DR-10's item-visibility gate should cover it automatically — but the
+// acceptance criteria require that be ASSERTED, not assumed.
+//
+// The existing resource tests (resources_test.go, resources_http_test.go)
+// drive fake fetchers, which can't see a real ACL. These run the fetcher
+// against a real *server.Server so the grant chain is genuinely exercised.
+
+// attachmentACLFixture is a workspace with one item, one attachment bound to
+// it, and a real blob on disk.
+type attachmentACLFixture struct {
+	srv    *server.Server
+	st     *store.Store
+	wsSlug string
+	wsID   string
+	itemID string
+	attID  string
+	body   []byte
+}
+
+func newAttachmentACLFixture(t *testing.T) attachmentACLFixture {
+	t.Helper()
+
+	srv, st := newPadServer(t)
+
+	fs, err := attachments.NewFSStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewFSStore: %v", err)
+	}
+	reg := attachments.NewRegistry()
+	reg.Register(attachments.FSPrefix, fs)
+	srv.SetAttachments(reg, 0)
+
+	ws, err := st.CreateWorkspace(models.WorkspaceCreate{Name: "MCP Attach ACL"})
+	if err != nil {
+		t.Fatalf("CreateWorkspace: %v", err)
+	}
+	col, err := st.CreateCollection(ws.ID, models.CollectionCreate{
+		Name: "Tasks", Schema: `{"fields":[]}`,
+	})
+	if err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	item, err := st.CreateItem(ws.ID, col.ID, models.ItemCreate{Title: "Shared", Fields: `{}`})
+	if err != nil {
+		t.Fatalf("CreateItem: %v", err)
+	}
+
+	// A real PNG (1x1 transparent) so the resource's image-MIME gate passes.
+	body := []byte{
+		0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+		0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+		0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+		0x08, 0x06, 0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4,
+		0x89, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x44, 0x41,
+		0x54, 0x78, 0x9c, 0x63, 0x00, 0x01, 0x00, 0x00,
+		0x05, 0x00, 0x01, 0x0d, 0x0a, 0x2d, 0xb4, 0x00,
+		0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae,
+		0x42, 0x60, 0x82,
+	}
+	sum := sha256.Sum256(body)
+	hash := hex.EncodeToString(sum[:])
+	blobStore, err := reg.Resolve(attachments.FSPrefix + ":" + hash)
+	if err != nil {
+		t.Fatalf("resolve blob store: %v", err)
+	}
+	key, err := blobStore.Put(context.Background(), hash, "image/png", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("blob Put: %v", err)
+	}
+
+	att := &models.Attachment{
+		WorkspaceID: ws.ID,
+		ItemID:      &item.ID,
+		UploadedBy:  "system",
+		StorageKey:  key,
+		ContentHash: hash,
+		MimeType:    "image/png",
+		SizeBytes:   int64(len(body)),
+		Filename:    "shared.png",
+	}
+	if err := st.CreateAttachment(att); err != nil {
+		t.Fatalf("CreateAttachment: %v", err)
+	}
+
+	return attachmentACLFixture{
+		srv: srv, st: st,
+		wsSlug: ws.Slug, wsID: ws.ID,
+		itemID: item.ID, attID: att.ID,
+		body: body,
+	}
+}
+
+func (f attachmentACLFixture) fetcherFor(user *models.User) *HTTPResourceFetcher {
+	return NewHTTPResourceFetcher(&HTTPHandlerDispatcher{
+		Handler:      f.srv,
+		UserResolver: fixedUserResolver(user),
+	})
+}
+
+func (f attachmentACLFixture) resourceArgs() (show, download []string) {
+	show = []string{
+		"attachment", "show", f.attID,
+		"--workspace", f.wsSlug,
+		"--variant", attachmentResourceVariant,
+		"--format", "json",
+	}
+	download = []string{
+		"attachment", "download", f.attID, "-",
+		"--workspace", f.wsSlug,
+		"--variant", attachmentResourceVariant,
+	}
+	return show, download
+}
+
+func mkACLUser(t *testing.T, st *store.Store, email string) *models.User {
+	t.Helper()
+	u, err := st.CreateUser(models.UserCreate{
+		Email: email, Name: email,
+		Password: "correct-horse-battery-staple",
+		Role:     "member",
+	})
+	if err != nil {
+		t.Fatalf("CreateUser %s: %v", email, err)
+	}
+	return u
+}
+
+// TestMCPAttachmentResource_GrantGuestCanRead asserts the DR-10 gate reaches
+// the MCP image resource in the permissive direction: a guest holding an
+// item grant — who the old flat requireMinRole("viewer") rejected outright —
+// gets both the metadata and the bytes.
+func TestMCPAttachmentResource_GrantGuestCanRead(t *testing.T) {
+	f := newAttachmentACLFixture(t)
+	guest := mkACLUser(t, f.st, "mcp-item-grant@test.com")
+	if _, err := f.st.CreateItemGrant(f.wsID, f.itemID, guest.ID, "view", guest.ID); err != nil {
+		t.Fatalf("CreateItemGrant: %v", err)
+	}
+
+	fetcher := f.fetcherFor(guest)
+	show, download := f.resourceArgs()
+
+	metadata, err := fetcher.Fetch(context.Background(), show)
+	if err != nil {
+		t.Fatalf("item-grant guest metadata fetch: %v", err)
+	}
+	if !strings.Contains(metadata, "image/png") {
+		t.Errorf("metadata = %s, want an image/png MIME", metadata)
+	}
+
+	got, err := fetcher.FetchBytes(context.Background(), download)
+	if err != nil {
+		t.Fatalf("item-grant guest byte fetch: %v", err)
+	}
+	// No thumb-md row exists, so the handler's documented fallback serves
+	// the original — the bytes still have to be THIS attachment's.
+	if !bytes.Equal(got, f.body) {
+		t.Errorf("served %d bytes, want the %d-byte fixture blob", len(got), len(f.body))
+	}
+}
+
+// TestMCPAttachmentResource_CollectionGrantGuestCanRead — same, one level up
+// the grant chain.
+func TestMCPAttachmentResource_CollectionGrantGuestCanRead(t *testing.T) {
+	f := newAttachmentACLFixture(t)
+	guest := mkACLUser(t, f.st, "mcp-coll-grant@test.com")
+
+	item, err := f.st.GetItem(f.itemID)
+	if err != nil || item == nil {
+		t.Fatalf("GetItem: %v (item=%v)", err, item)
+	}
+	if _, err := f.st.CreateCollectionGrant(f.wsID, item.CollectionID, guest.ID, "view", guest.ID); err != nil {
+		t.Fatalf("CreateCollectionGrant: %v", err)
+	}
+
+	_, download := f.resourceArgs()
+	got, err := f.fetcherFor(guest).FetchBytes(context.Background(), download)
+	if err != nil {
+		t.Fatalf("collection-grant guest byte fetch: %v", err)
+	}
+	if !bytes.Equal(got, f.body) {
+		t.Errorf("served %d bytes, want the %d-byte fixture blob", len(got), len(f.body))
+	}
+}
+
+// TestMCPAttachmentResource_UngrantedUserIsDenied asserts the gate in the
+// restrictive direction — the half that actually matters for security.
+//
+// The caller is deliberately REACHABLE: a guest holding a grant on a
+// different item in the same workspace, so RequireWorkspaceAccess admits
+// them and the blob handler's own item-visibility check is what denies. A
+// plain non-member would be turned away by middleware first and the test
+// would pass without exercising the gate at all.
+func TestMCPAttachmentResource_UngrantedUserIsDenied(t *testing.T) {
+	f := newAttachmentACLFixture(t)
+	stranger := mkACLUser(t, f.st, "mcp-stranger@test.com")
+
+	item, err := f.st.GetItem(f.itemID)
+	if err != nil || item == nil {
+		t.Fatalf("GetItem: %v (item=%v)", err, item)
+	}
+	decoy, err := f.st.CreateItem(f.wsID, item.CollectionID, models.ItemCreate{
+		Title: "Decoy", Fields: `{}`,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem decoy: %v", err)
+	}
+	if _, err := f.st.CreateItemGrant(f.wsID, decoy.ID, stranger.ID, "view", stranger.ID); err != nil {
+		t.Fatalf("CreateItemGrant decoy: %v", err)
+	}
+
+	fetcher := f.fetcherFor(stranger)
+	show, download := f.resourceArgs()
+
+	if metadata, err := fetcher.Fetch(context.Background(), show); err == nil {
+		t.Errorf("ungranted metadata fetch succeeded: %s", metadata)
+	} else if !strings.Contains(err.Error(), "HTTP 404") {
+		// 404, not 403: a 403 would mean middleware turned the caller away
+		// before the handler ran (making the test vacuous), or that the
+		// handler disclosed the attachment's existence.
+		t.Errorf("ungranted metadata fetch error = %v, want an HTTP 404 from the blob handler", err)
+	}
+
+	got, err := fetcher.FetchBytes(context.Background(), download)
+	if err == nil {
+		t.Fatalf("ungranted byte fetch succeeded, returned %d bytes", len(got))
+	}
+	if !strings.Contains(err.Error(), "HTTP 404") {
+		t.Errorf("ungranted byte fetch error = %v, want an HTTP 404 from the blob handler", err)
+	}
+	if bytes.Equal(got, f.body) {
+		t.Fatal("ungranted byte fetch returned the fixture blob despite the error")
+	}
+}
+
+// TestMCPAttachmentResource_SoftDeletedParentIsDenied — DR-13 reaches this
+// surface too: archiving the parent takes the resource offline for a caller
+// who could read it a moment earlier.
+//
+// The reader is a full workspace VIEWER, not a grant-only guest, so
+// RequireWorkspaceAccess admits them identically before and after the
+// archive. That isolates the blob handler's GetItem lookup as the only thing
+// that changes between the two fetches.
+func TestMCPAttachmentResource_SoftDeletedParentIsDenied(t *testing.T) {
+	f := newAttachmentACLFixture(t)
+	viewer := mkACLUser(t, f.st, "mcp-archived@test.com")
+	if err := f.st.AddWorkspaceMember(f.wsID, viewer.ID, "viewer"); err != nil {
+		t.Fatalf("AddWorkspaceMember: %v", err)
+	}
+
+	fetcher := f.fetcherFor(viewer)
+	_, download := f.resourceArgs()
+
+	if _, err := fetcher.FetchBytes(context.Background(), download); err != nil {
+		t.Fatalf("pre-archive byte fetch: %v", err)
+	}
+	if err := f.st.DeleteItem(f.itemID); err != nil {
+		t.Fatalf("DeleteItem: %v", err)
+	}
+	got, err := fetcher.FetchBytes(context.Background(), download)
+	if err == nil {
+		t.Fatalf("post-archive byte fetch succeeded, returned %d bytes", len(got))
+	}
+	if !strings.Contains(err.Error(), "HTTP 404") {
+		t.Errorf("post-archive byte fetch error = %v, want an HTTP 404 from the blob handler", err)
+	}
+}

--- a/internal/server/attachments_authz.go
+++ b/internal/server/attachments_authz.go
@@ -122,3 +122,118 @@ func (s *Server) attachmentCallerIsRestricted(r *http.Request, workspaceID strin
 	}
 	return fullCollIDs != nil || grantedItemIDs != nil, nil
 }
+
+// attachmentCopyAuthorizer builds the per-row visibility check the
+// cross-workspace copy planner applies to every attachment reference it
+// resolves in the SOURCE workspace (TASK-2408 / BUG-2407).
+//
+// It is the read path's rule, not a weaker cousin of it: the same
+// resolveAttachmentParentItem outcomes, the same includeArchived=false
+// (DR-13 — an archived parent is not readable, so it is not copyable), the
+// same checkItemVisible, and the same orphan gate in the same ORDER, ahead
+// of the role check. handleGetAttachment is the sibling to compare against
+// line for line; the only difference is the shape of the denial, and that
+// difference is forced: this one has no response to write, so it answers
+// false and the planner turns that into "unresolvable".
+//
+// workspaceID is the SOURCE workspace, which is also the request's own
+// workspace — the planner never resolves anything outside it, so
+// guestResourceFilter and workspaceRole(r), both of which describe the
+// caller's standing in the request workspace, are the right inputs. The
+// destination side is authorized separately and earlier, by the ladder in
+// resolveAuthorizedCopy.
+//
+// MEMOIZED PER PARENT ITEM, which is not an optimization detail but the
+// difference between one query and N. With workspaceID and the caller
+// fixed, the verdict is a pure function of the row's item_id: nothing
+// below reads any other column. So the ordinary body — one item's images
+// plus two thumbnail variants each — costs ONE item load and ONE
+// visibility query instead of three per image, and the planner cannot turn
+// a long reference list into an N+1 storm inside the copy's transaction,
+// where both workspace advisory locks are held (Codex round 4). The
+// restricted-ness verdict, a membership query used only by the orphan
+// branch, is resolved once for the same reason. Errors are memoized too: a
+// database that is failing should be asked once, not once per row.
+//
+// The memo therefore pins the caller's ACLs for the duration of ONE
+// planner pass, which is the same point-in-time semantics the rest of this
+// file has (resolveAttachmentParentItem's "do not read a passing check as
+// a lock") and the same the plan itself has (PlanAttachmentCopy's
+// STALENESS CONTRACT): a grant revoked mid-pass may not be observed by the
+// remaining rows. Nothing is cached ACROSS requests — the closure is built
+// per call of resolveAuthorizedCopy, so the preflight and the copy each
+// re-derive every verdict from scratch.
+//
+// RESIDUAL: the query count is still linear in the number of DISTINCT
+// parent items referenced. Bounding that would mean batching the item
+// loads, which the per-row callback shape cannot express; it is bounded in
+// practice by the attachments that actually exist in the source workspace,
+// since an unresolvable reference never reaches this function at all.
+func (s *Server) attachmentCopyAuthorizer(r *http.Request, workspaceID string) func(models.Attachment) (bool, error) {
+	type verdict struct {
+		allowed bool
+		err     error
+	}
+	var (
+		restricted      bool
+		restrictedKnown bool
+		byParentItem    = map[string]verdict{}
+	)
+
+	decide := func(att models.Attachment) (bool, error) {
+		item, outcome, err := s.resolveAttachmentParentItem(&att, false)
+		if err != nil {
+			return false, err
+		}
+		switch outcome {
+		case attachmentParentOK:
+			return s.checkItemVisible(workspaceID, item, currentUser(r), workspaceRole(r), isBearerAuth(r))
+		case attachmentParentOrphan:
+			// The orphan rule (PLAN-2382 DR-4), and the restriction check
+			// BEFORE the role check for the reason every sibling path
+			// documents: a denial reachable only for rows that exist is
+			// itself the oracle. Here both denials collapse into the same
+			// "unresolvable" count anyway, but keeping the order identical
+			// to the read path is what makes the two comparable.
+			if !restrictedKnown {
+				isRestricted, err := s.attachmentCallerIsRestricted(r, workspaceID)
+				if err != nil {
+					return false, err
+				}
+				restricted = isRestricted
+				restrictedKnown = true
+			}
+			if restricted {
+				return false, nil
+			}
+			return requireRole(r, "viewer"), nil
+		default: // Gone (missing, hard-deleted, or ARCHIVED parent), Foreign
+			return false, nil
+		}
+	}
+
+	return func(att models.Attachment) (bool, error) {
+		// Defense in depth: the planner scopes every query to the source
+		// workspace already, so this cannot fire today. It costs nothing
+		// and means the authorizer is safe to hand to any future caller
+		// without re-deriving that guarantee.
+		//
+		// Checked BEFORE the memo, because the memo is keyed by item_id
+		// alone and is only sound while every row belongs to workspaceID.
+		if att.WorkspaceID != workspaceID {
+			return false, nil
+		}
+
+		// Orphans are not memoized: they have no item_id to key on, and
+		// their branch runs no per-row query anyway.
+		if att.ItemID == nil || *att.ItemID == "" {
+			return decide(att)
+		}
+		if v, ok := byParentItem[*att.ItemID]; ok {
+			return v.allowed, v.err
+		}
+		allowed, err := decide(att)
+		byParentItem[*att.ItemID] = verdict{allowed: allowed, err: err}
+		return allowed, err
+	}
+}

--- a/internal/server/attachments_authz.go
+++ b/internal/server/attachments_authz.go
@@ -1,0 +1,124 @@
+package server
+
+import (
+	"net/http"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// attachmentParentOutcome classifies the result of resolving an attachment
+// row's parent item.
+//
+// The four cases exist because attachments.item_id carries NO foreign key and
+// NO same-workspace constraint (fixed at the source by TASK-2400, repaired for
+// existing rows by PLAN-2397). "Resolves to an item" and "is a legitimate
+// parent for THIS row" are therefore different questions, and every caller has
+// to ask both. Splitting the outcomes rather than returning a bare bool keeps
+// the malformed cases distinguishable for callers that want to log them
+// (derivation does) without forcing that distinction onto callers that must
+// NOT surface it (the HTTP paths, where any split is an existence oracle).
+type attachmentParentOutcome int
+
+const (
+	// attachmentParentOrphan — item_id IS NULL. There is no parent to
+	// authorize against, so the caller applies its own orphan rule; see
+	// attachmentCallerIsRestricted for the one the HTTP paths share.
+	attachmentParentOrphan attachmentParentOutcome = iota
+	// attachmentParentOK — resolved to an item of the attachment's own
+	// workspace. Live, unless the caller passed includeArchived.
+	attachmentParentOK
+	// attachmentParentGone — item_id names nothing the lookup returned:
+	// soft-deleted (when includeArchived is false), hard-deleted, or a
+	// dangling id that never named an item.
+	attachmentParentGone
+	// attachmentParentForeign — resolves to an item in ANOTHER workspace.
+	// Malformed for this row: a grant on that foreign item must never
+	// authorize anything against this workspace's bytes.
+	attachmentParentForeign
+)
+
+// resolveAttachmentParentItem loads and validates the parent item of an
+// attachment row that has ALREADY been established as live and belonging to
+// the request workspace.
+//
+// This is the one place the attachment-parent invariant lives. Before it, the
+// blob read, the transform, thumbnail derivation and the delete path each
+// hand-rolled "load the parent, check workspace identity, check liveness" in
+// its own shape, and the three implementations drifted apart far enough to
+// open two real gaps (see the commit that introduced this helper). The
+// invariant is now shared; the DENIAL behaviour deliberately is not.
+//
+// What the callers keep for themselves, and why:
+//
+//   - the blob read (handleGetAttachment) and transform
+//     (handleTransformAttachment) funnel every outcome except OK through
+//     writeAttachmentNotFound, so a missing attachment, a foreign parent, an
+//     archived parent and an invisible item are byte-identical;
+//   - derivation (deriveThumbnails) has no HTTP response to shape at all: it
+//     logs a distinct WARN per outcome — the malformed cases are meant to be
+//     greppable ahead of PLAN-2397's repair — and skips;
+//   - the delete path passes includeArchived, because the storage listing
+//     intentionally surfaces attachments whose parent item is soft-deleted:
+//     they still consume quota and the user needs a path to delete the blob.
+//
+// includeArchived selects GetItemIncludeDeleted over GetItem. With it false,
+// "live" means exactly what the read gate (PLAN-2391 DR-13) means by it, and
+// an archived parent reports Gone.
+//
+// Point-in-time, by construction: this is a read, and item deletion commits in
+// its own transaction, so a caller that does unbounded work between this call
+// and a write has a window. Transform closes its window with
+// store.CreateAttachmentForLiveItem; derivation deliberately does not (see the
+// comment on deriveThumbnails). Do not read a passing check here as a lock.
+func (s *Server) resolveAttachmentParentItem(att *models.Attachment, includeArchived bool) (*models.Item, attachmentParentOutcome, error) {
+	if att.ItemID == nil || *att.ItemID == "" {
+		return nil, attachmentParentOrphan, nil
+	}
+
+	var (
+		item *models.Item
+		err  error
+	)
+	if includeArchived {
+		item, err = s.store.GetItemIncludeDeleted(*att.ItemID)
+	} else {
+		item, err = s.store.GetItem(*att.ItemID)
+	}
+	if err != nil {
+		return nil, attachmentParentGone, err
+	}
+	if item == nil {
+		return nil, attachmentParentGone, nil
+	}
+	// Workspace identity is checked HERE, ahead of every caller's own
+	// visibility/permission logic, because none of those catch a foreign
+	// parent on their own: checkItemVisible admits any collection id when
+	// the caller is unrestricted, and both the item-grant lookup and
+	// requireEditPermission match by item id. Without this guard a grant on
+	// a foreign item would authorize acting on THIS workspace's bytes.
+	if item.WorkspaceID != att.WorkspaceID {
+		return item, attachmentParentForeign, nil
+	}
+	return item, attachmentParentOK, nil
+}
+
+// attachmentCallerIsRestricted reports whether the caller's access to the
+// workspace is narrowed to specific collections or items rather than being
+// full workspace access.
+//
+// It is the orphan-row gate (PLAN-2382 DR-4), shared by the read, transform
+// and delete paths. An orphan attachment (item_id IS NULL) belongs to no
+// collection, so collection visibility cannot gate it — and the storage
+// LISTING already hides orphans from restricted members. Without this, a
+// restricted member who guesses an orphan's UUID gets confirmation it exists,
+// which is the same disclosure the item-bound paths refuse.
+//
+// Callers MUST apply it AHEAD of any role gate that would answer 403: a 403
+// reached only for rows that exist is itself the oracle.
+func (s *Server) attachmentCallerIsRestricted(r *http.Request, workspaceID string) (bool, error) {
+	fullCollIDs, grantedItemIDs, err := s.guestResourceFilter(r, workspaceID)
+	if err != nil {
+		return false, err
+	}
+	return fullCollIDs != nil || grantedItemIDs != nil, nil
+}

--- a/internal/server/attachments_authz.go
+++ b/internal/server/attachments_authz.go
@@ -169,6 +169,20 @@ func (s *Server) attachmentCallerIsRestricted(r *http.Request, workspaceID strin
 // loads, which the per-row callback shape cannot express; it is bounded in
 // practice by the attachments that actually exist in the source workspace,
 // since an unresolvable reference never reaches this function at all.
+//
+// RESIDUAL, and the more consequential one: these queries go through the
+// connection POOL, and on the mutating path the planner runs inside a
+// transaction holding advisory locks on BOTH workspaces. Enough concurrent
+// copies could therefore occupy every pooled connection with lock-waiters
+// while the lock HOLDER waits for a spare — starvation presenting as a
+// hang. The memo above is what keeps this bounded rather than per-row. The
+// hazard is not new (PlanAttachmentCopy already reads through the pool
+// under the same locks, attachments_copy_plan.go) and the real fix is to
+// make the lock-held reads transaction-bound, which means threading the
+// *sql.Tx through the planner and giving this callback a tx-aware form.
+// Tracked as BUG-2409; deliberately NOT done here, because it is a change
+// to the store's transaction plumbing rather than to this authorization
+// rule.
 func (s *Server) attachmentCopyAuthorizer(r *http.Request, workspaceID string) func(models.Attachment) (bool, error) {
 	type verdict struct {
 		allowed bool

--- a/internal/server/handlers_attachments.go
+++ b/internal/server/handlers_attachments.go
@@ -492,9 +492,40 @@ func renderModeString(m attachments.RenderMode) string {
 	}
 }
 
+// writeAttachmentNotFound is the single denial writer for the blob read
+// path. Every authorization-dependent refusal — attachment missing, wrong
+// workspace, soft-deleted, foreign parent item, archived parent, parent not
+// visible to the caller — emits this exact response. Byte-identical bodies
+// are the point: a distinguishable error code or message would turn the
+// response into an existence oracle for rows and items the caller may not
+// see (the house rule TASK-2400 established).
+func writeAttachmentNotFound(w http.ResponseWriter) {
+	writeError(w, http.StatusNotFound, "not_found", "Attachment not found")
+}
+
 // handleGetAttachment streams an attachment back to the caller. Auth is
-// enforced by the route's RequireWorkspaceAccess middleware; we
-// additionally require viewer+ here.
+// enforced by the route's RequireWorkspaceAccess middleware; this handler
+// then authorizes per-attachment.
+//
+// Authorization (PLAN-2391 DR-10), in this exact order:
+//
+//  1. Load the attachment; 404 unless it is live and belongs to the
+//     request workspace.
+//  2. Item-bound rows: load the parent, verify the parent's workspace
+//     identity, then requireItemVisible. Item visibility IS blob-read
+//     permission — a guest holding an item or collection grant can fetch
+//     the bytes rendered inside the item they were shared. The handler
+//     used to open with a flat requireMinRole("viewer"), and roleLevel
+//     ("guest") is 0, so every grant-based guest was 403'd before any
+//     item-level check ran (BUG-2386) and inline images broke for them.
+//  3. Orphan (item_id IS NULL) rows keep the flat viewer+ gate — there is
+//     no item context to authorize against.
+//
+// The parent is loaded with GetItem, not GetItemIncludeDeleted (DR-13): a
+// soft-deleted parent 404s here. Archiving an item hides it, so its bytes
+// should not stay downloadable behind a URL. The DELETE path deliberately
+// diverges — it keeps GetItemIncludeDeleted so an owner can still reclaim
+// quota from an archived item's attachments.
 //
 // The handler:
 //   - Looks up the row by ID (TASK-871's UUID), refusing with 404 if it
@@ -518,9 +549,19 @@ func renderModeString(m attachments.RenderMode) string {
 //   - Sets a short Cache-Control: private, max-age=3600. Phase 3 will
 //     revisit for CDN caching.
 func (s *Server) handleGetAttachment(w http.ResponseWriter, r *http.Request) {
-	if !requireMinRole(w, r, "viewer") {
-		return
-	}
+	// FIRST statement, before any lookup or gate. Every denial below is
+	// authorization-dependent, and an unlabelled 404 is heuristically
+	// cacheable BY URL — a CDN or browser could retain it and go on
+	// denying a caller who has since been granted access. writeError →
+	// writeJSON calls WriteHeader immediately, so a header set after the
+	// first denial path never reaches the wire. Overwritten with the
+	// positive directive only once authorization has succeeded.
+	//
+	// Scope note: middleware can reject before this handler ever runs
+	// (missing auth, no workspace access). Those denials are outside this
+	// header's coverage.
+	w.Header().Set("Cache-Control", "private, no-store")
+
 	if s.attachments == nil {
 		writeError(w, http.StatusServiceUnavailable, "attachments_disabled",
 			"Attachment storage is not configured on this server")
@@ -545,7 +586,61 @@ func (s *Server) handleGetAttachment(w http.ResponseWriter, r *http.Request) {
 	// Cross-workspace defense: 404 (not 403) so an attacker can't
 	// distinguish "exists in another workspace" from "doesn't exist".
 	if att == nil || att.WorkspaceID != workspaceID || att.DeletedAt != nil {
-		writeError(w, http.StatusNotFound, "not_found", "Attachment not found")
+		writeAttachmentNotFound(w)
+		return
+	}
+
+	// Item-level authorization (PLAN-2391 DR-10). Runs BEFORE the variant
+	// lookup and before any byte access.
+	if att.ItemID != nil {
+		// GetItem, not GetItemIncludeDeleted — DR-13. A soft-deleted
+		// parent resolves to nil here and the blob 404s.
+		item, err := s.store.GetItem(*att.ItemID)
+		if err != nil {
+			writeInternalError(w, err)
+			return
+		}
+		// Workspace identity FIRST, before visibility. attachments.item_id
+		// has no FK or same-workspace constraint, and neither downstream
+		// check catches a foreign parent on its own: checkItemVisible
+		// admits any collection id when the caller is unrestricted, and
+		// item-grant lookup matches by item_id. Without this guard a view
+		// grant on a foreign item would authorize reading THIS workspace's
+		// bytes. Mirrors the delete path (handlers_storage.go).
+		if item == nil || item.WorkspaceID != workspaceID {
+			writeAttachmentNotFound(w)
+			return
+		}
+		// checkItemVisible rather than requireItemVisible: same rule set
+		// (requireItemVisible is a thin wrapper over it), but this handler
+		// writes its own denial so that "no such attachment", "foreign
+		// parent", "archived parent", and "item not visible to you" are
+		// byte-identical responses. requireItemVisible's own 404 body says
+		// "Item not found", which would distinguish the visibility denial
+		// from the lookup miss and leak existence.
+		visible, err := s.checkItemVisible(workspaceID, item, currentUser(r), workspaceRole(r), isBearerAuth(r))
+		if err != nil {
+			writeInternalError(w, err)
+			return
+		}
+		if !visible {
+			writeAttachmentNotFound(w)
+			return
+		}
+	} else if !requireRole(r, "viewer") {
+		// Orphan attachments carry no item context to authorize against,
+		// so they keep the flat workspace viewer-role gate — same strength
+		// as before, only the denial SHAPE changes.
+		//
+		// requireRole (the write-free predicate) rather than requireMinRole
+		// (which writes its own 403): the attachment row has already been
+		// loaded by this point, so a 403 here would mean "this id names a
+		// live orphan in this workspace" while a bad id answers 404. That
+		// split is an existence oracle for orphan UUIDs — one the old code
+		// didn't have only because its flat role gate ran BEFORE the
+		// lookup. Reordering the gate reintroduced it; routing the denial
+		// through the shared 404 writer closes it again.
+		writeAttachmentNotFound(w)
 		return
 	}
 
@@ -561,7 +656,12 @@ func (s *Server) handleGetAttachment(w http.ResponseWriter, r *http.Request) {
 				"Unknown variant — supported: thumb-sm, thumb-md")
 			return
 		}
-		if derived, dErr := s.store.GetAttachmentVariant(att.ID, variant); dErr != nil {
+		// Workspace-scoped (DR-16). parent_id alone is not a trustworthy
+		// scope: a variant row in another workspace can carry this
+		// attachment's id as its parent, and serving that child after
+		// authorizing this parent would defeat the gate above. The scope
+		// lives in the store method so the derivation worker gets it too.
+		if derived, dErr := s.store.GetAttachmentVariant(workspaceID, att.ID, variant); dErr != nil {
 			writeInternalError(w, dErr)
 			return
 		} else if derived != nil {
@@ -594,6 +694,10 @@ func (s *Server) handleGetAttachment(w http.ResponseWriter, r *http.Request) {
 	// Headers come BEFORE ServeContent / io.Copy so they make it onto
 	// the wire even when the response is a 304 / 206.
 	w.Header().Set("Content-Type", att.MimeType)
+	// Authorization has succeeded — replace the no-store denial directive
+	// set at the top of the handler with the positive one. Known and
+	// accepted: this one-hour positive browser cache outlives a permission
+	// revocation (PLAN-2391 DR-10).
 	w.Header().Set("Cache-Control", "private, max-age=3600")
 	w.Header().Set("X-Content-Type-Options", "nosniff")
 

--- a/internal/server/handlers_attachments.go
+++ b/internal/server/handlers_attachments.go
@@ -41,12 +41,109 @@ const defaultAttachmentMaxBytes = 25 << 20 // 25 MiB
 // the desired behavior for large uploads.
 const multipartParseMemory = 1 << 20 // 1 MiB
 
+// multipartValues reads a field's values from the parsed multipart form
+// ONLY. Unlike (*http.Request).FormValue it does not fall back to the
+// URL query string, which keeps the two item_id input channels distinct
+// so they can be resolved and cross-checked independently.
+func multipartValues(r *http.Request, key string) []string {
+	if r.MultipartForm == nil {
+		return nil
+	}
+	return r.MultipartForm.Value[key]
+}
+
+// maxUploadItemIDValues bounds how many item_id values one input channel
+// may carry. Every distinct value costs a ResolveItem lookup, and semantic
+// aliases of the same item (TASK-7 / task-7 / TASK-0007 all resolve alike)
+// defeat exact-string deduplication — so the count is capped rather than
+// relying on dedup to bound the work. No real client sends more than one.
+const maxUploadItemIDValues = 8
+
+// resolveUploadItemID resolves every distinct non-empty value a single
+// item_id input channel carried, and returns the one item they all denote.
+//
+// A channel can legitimately carry several spellings of the same item (a
+// UUID and a ref resolve identically), and net/http silently keeps only the
+// first of a repeated field — so rather than first-wins, every value is
+// resolved and they must agree. Returns (nil, true) when the channel
+// carried no value at all (absent and explicitly-empty are the same thing,
+// compared after TrimSpace); (nil, false) means a response was already
+// written and the caller must return.
+//
+// Each resolved item is visibility-gated HERE, before the values are
+// compared. That ordering matters: requireItemVisible writes a 404, so an
+// item the caller cannot see is indistinguishable from one that does not
+// exist. Comparing first would leak a hidden item's existence through the
+// 400-vs-404 split (send a visible id plus the id being probed: a conflict
+// means it exists, a 404 means it does not).
+func (s *Server) resolveUploadItemID(w http.ResponseWriter, r *http.Request, workspaceID string, raw []string) (*models.Item, bool) {
+	if len(raw) > maxUploadItemIDValues {
+		writeError(w, http.StatusBadRequest, "bad_request",
+			fmt.Sprintf("At most %d item_id values are accepted", maxUploadItemIDValues))
+		return nil, false
+	}
+
+	var resolved *models.Item
+	seen := make(map[string]struct{}, len(raw))
+	for _, value := range raw {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, dup := seen[value]; dup {
+			continue
+		}
+		seen[value] = struct{}{}
+
+		item, err := s.store.ResolveItem(workspaceID, value)
+		if err != nil {
+			writeInternalError(w, err)
+			return nil, false
+		}
+		if item == nil {
+			// Deliberately identical to requireItemVisible's 404 below
+			// (server.go). A distinct code/message here would restore the
+			// existence oracle the visibility-before-compare ordering was
+			// added to close: "hidden" and "does not exist" must be
+			// indistinguishable to the caller.
+			writeError(w, http.StatusNotFound, "not_found", "Item not found")
+			return nil, false
+		}
+		if !s.requireItemVisible(w, r, workspaceID, item) {
+			return nil, false
+		}
+		if resolved == nil {
+			resolved = item
+			continue
+		}
+		if item.ID != resolved.ID {
+			writeError(w, http.StatusBadRequest, "item_id_conflict",
+				"Conflicting item_id values refer to different items")
+			return nil, false
+		}
+	}
+	return resolved, true
+}
+
+// requireUploadItemEdit applies the edit gate to an upload's resolved
+// parent item. Visibility was already established by resolveUploadItemID;
+// this adds the 403 for an item the caller can see but not edit.
+//
+// Note that requireEditPermission's editor/owner fast path does not consult
+// collection visibility on its own — the visibility gate ahead of it is what
+// stops a member with collection_access="specific" attaching to an item in a
+// collection hidden from them.
+func (s *Server) requireUploadItemEdit(w http.ResponseWriter, r *http.Request, workspaceID string, item *models.Item) bool {
+	return s.requireEditPermission(w, r, workspaceID, item.ID, item.CollectionID)
+}
+
 // handleUploadAttachment accepts a multipart upload and writes it into
 // the attachments table + the configured AttachmentStore.
 //
 // Flow:
-//  1. Auth: editor+ role on the workspace (already gated by the route's
-//     RequireWorkspaceAccess middleware; we additionally require editor).
+//  1. Auth: grant-aware edit permission on the associated item, or —
+//     for an upload with no item context — editor+ role on the workspace
+//     (on top of the route's RequireWorkspaceAccess middleware).
 //  2. Cap the body via MaxBytesReader to attachmentMaxBytes(s).
 //  3. Stream the multipart "file" part into a temp file, sha256ing as
 //     we go so we never hold the whole payload in RAM.
@@ -74,31 +171,28 @@ func (s *Server) handleUploadAttachment(w http.ResponseWriter, r *http.Request) 
 	// editor, comment composer) gate their affordance on grant-aware edit
 	// permission, so a guest holding an item/collection edit grant via a
 	// share link — but no workspace editor role — must be able to attach
-	// (BUG-1661). When the caller supplies an ?item_id we authorize against
-	// that item's grant chain via requireEditPermission. Free-floating
-	// uploads (new-item creation, storage settings) carry no item context,
-	// so they keep the flat workspace editor-role gate.
+	// (BUG-1661). When the caller associates the upload with an item we
+	// authorize against that item's grant chain via requireEditPermission.
+	// Free-floating uploads (new-item creation, storage settings) carry no
+	// item context, so they keep the flat workspace editor-role gate.
 	//
-	// We read item_id from the query string here (before spooling the
-	// multipart body) so a denied upload trips early; the value is also
-	// re-read from the form below for association. A bogus/unresolvable
-	// item_id falls back to the editor-role check rather than leaking item
-	// existence.
-	if authItemID := strings.TrimSpace(r.URL.Query().Get("item_id")); authItemID != "" {
-		item, err := s.store.ResolveItem(workspaceID, authItemID)
-		if err != nil {
-			writeInternalError(w, err)
-			return
-		}
-		if item != nil {
-			if !s.requireEditPermission(w, r, workspaceID, item.ID, item.CollectionID) {
-				return
-			}
-		} else if !requireMinRole(w, r, "editor") {
-			return
-		}
-	} else if !requireMinRole(w, r, "editor") {
+	// item_id arrives on TWO channels: the query string (the web client
+	// sends both, web/src/lib/api/client.ts) and the multipart form (the
+	// CLI sends form-only, internal/cli/client.go). Only the query channel
+	// can be read before the body is spooled, so authorization is split:
+	// the query value is resolved and authorized here (cheap, so a doomed
+	// upload never spools), and the form value is resolved after parsing
+	// (see below). The no-item editor gate is DEFERRED until after parsing
+	// — firing it here would 403 a form-only item-grant guest before the
+	// association is even known (PLAN-2391 DR-2).
+	resolvedItem, ok := s.resolveUploadItemID(w, r, workspaceID, r.URL.Query()["item_id"])
+	if !ok {
 		return
+	}
+	if resolvedItem != nil {
+		if !s.requireUploadItemEdit(w, r, workspaceID, resolvedItem) {
+			return
+		}
 	}
 	// Attribution: prefer the logged-in user. On a fresh install (no
 	// users yet) RequireWorkspaceAccess grants implicit owner access
@@ -119,6 +213,19 @@ func (s *Server) handleUploadAttachment(w http.ResponseWriter, r *http.Request) 
 	// is exceeded, which we surface as 413 below.
 	r.Body = http.MaxBytesReader(w, r.Body, maxBytes+(1<<16)) // +64KiB headroom for multipart envelope
 
+	// ParseMultipartForm spills anything past multipartParseMemory to a
+	// temp file under TMPDIR. file.Close() below closes the handle but
+	// does NOT remove that file — only RemoveAll does. Registered before
+	// the parse call (and nil-guarded) so it also covers the partial form
+	// a failed parse can leave behind, and so it runs on EVERY exit path
+	// including success (PLAN-2391 DR-2). Defers are LIFO, so this runs
+	// after the `defer file.Close()` registered below it.
+	defer func() {
+		if r.MultipartForm != nil {
+			_ = r.MultipartForm.RemoveAll()
+		}
+	}()
+
 	if err := r.ParseMultipartForm(multipartParseMemory); err != nil {
 		var maxErr *http.MaxBytesError
 		if errors.As(err, &maxErr) {
@@ -137,19 +244,57 @@ func (s *Server) handleUploadAttachment(w http.ResponseWriter, r *http.Request) 
 	}
 	defer file.Close()
 
-	// Optional ?item_id=<slug-or-id> associates the attachment with an
-	// item at upload time. The editor will normally upload first,
-	// receive the UUID, insert the markdown reference, and then PATCH
-	// the item — at which point the attachment can be associated via a
-	// follow-up call. For now the parameter is optional and stored
-	// verbatim if supplied.
-	itemID := strings.TrimSpace(r.URL.Query().Get("item_id"))
-	if itemID == "" {
-		itemID = strings.TrimSpace(r.FormValue("item_id"))
+	// Second item_id channel: the multipart form. Resolved in-workspace
+	// just like the query channel. Two raw strings can legitimately denote
+	// the SAME item (query "TASK-12", form "<uuid>"), so the comparison is
+	// on the resolved canonical IDs — not on the caller's spelling. Absent
+	// and explicitly-empty both mean "no value". Deliberately reads
+	// r.MultipartForm.Value rather than r.FormValue, which merges the query
+	// string back in and would collapse the two channels into one.
+	formItem, ok := s.resolveUploadItemID(w, r, workspaceID, multipartValues(r, "item_id"))
+	if !ok {
+		return
 	}
+	if formItem != nil {
+		switch {
+		case resolvedItem == nil:
+			// Form-only association (the CLI's shape): authorize through
+			// this item's grant chain now that we know what it is.
+			if !s.requireUploadItemEdit(w, r, workspaceID, formItem) {
+				return
+			}
+			resolvedItem = formItem
+		case formItem.ID != resolvedItem.ID:
+			writeError(w, http.StatusBadRequest, "item_id_conflict",
+				"Query and form item_id refer to different items")
+			return
+		}
+	}
+
+	// No item context at all → the flat workspace editor-role gate. This
+	// is the gate that used to fire before parsing; it can only run here,
+	// once both channels are known to be empty.
+	//
+	// Accepted cost of moving it (PLAN-2391 DR-2): a caller below editor
+	// now spools the body before being rejected here, where previously a
+	// free-floating viewer was turned away pre-parse. Bounded by
+	// attachmentMaxBytes (25 MiB default) and reachable only by an
+	// authenticated workspace member, so it is temp-disk/CPU pressure —
+	// never an attachment-write bypass, since no row and no blob are
+	// written on this path. The gate CANNOT move back: the form channel
+	// is unreadable until the body is parsed, and firing early is exactly
+	// the bug that 403'd form-only item-grant guests.
+	if resolvedItem == nil && !requireMinRole(w, r, "editor") {
+		return
+	}
+
+	// Persist the canonical UUID, never the caller's string — ResolveItem
+	// accepts a UUID, a ref, or a slug, and a ref stored in item_id is a
+	// malformed row (PLAN-2391 DR-2).
 	var itemIDPtr *string
-	if itemID != "" {
-		itemIDPtr = &itemID
+	if resolvedItem != nil {
+		canonicalItemID := resolvedItem.ID
+		itemIDPtr = &canonicalItemID
 	}
 
 	// Sanitize the filename: strip path components so a client can't

--- a/internal/server/handlers_attachments.go
+++ b/internal/server/handlers_attachments.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/PerpetualSoftware/pad/internal/attachments"
 	"github.com/PerpetualSoftware/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/store"
 
 	// Stdlib decoders for width/height probing on the formats Phase 1
 	// has to inspect server-side. WebP/AVIF/HEIC are not in the stdlib;
@@ -385,7 +386,7 @@ func (s *Server) handleUploadAttachment(w http.ResponseWriter, r *http.Request) 
 		writeInternalError(w, fmt.Errorf("rewind upload temp for store.Put: %w", err))
 		return
 	}
-	store, err := s.attachments.Resolve(attachments.FSPrefix + ":" + hash)
+	blobStore, err := s.attachments.Resolve(attachments.FSPrefix + ":" + hash)
 	if err != nil {
 		writeInternalError(w, fmt.Errorf("resolve attachment store: %w", err))
 		return
@@ -399,7 +400,7 @@ func (s *Server) handleUploadAttachment(w http.ResponseWriter, r *http.Request) 
 	// CreateAttachment call below (whether it succeeds or fails).
 	releaseInFlight := s.markUploadInFlight(hash)
 	defer releaseInFlight()
-	storageKey, err := store.Put(r.Context(), hash, entry.MIME, tmp)
+	storageKey, err := blobStore.Put(r.Context(), hash, entry.MIME, tmp)
 	if err != nil {
 		writeInternalError(w, fmt.Errorf("attachment store.Put: %w", err))
 		return
@@ -418,11 +419,32 @@ func (s *Server) handleUploadAttachment(w http.ResponseWriter, r *http.Request) 
 		Width:       width,
 		Height:      height,
 	}
-	if err := s.store.CreateAttachment(att); err != nil {
+	// CreateAttachmentForLiveItem, not CreateAttachment: the parent item was
+	// validated near the top of this handler, but everything since — spooling
+	// the body to a temp file, hashing it, probing dimensions, store.Put —
+	// is unbounded work, and item deletion commits in its own transaction.
+	// Without the re-check under a row lock inside the insert, an item
+	// archived during the upload window leaves a quota-counted live row bound
+	// to an archived parent whose bytes the read gate (DR-13) then refuses to
+	// serve. Same invariant, same helper, and for the same reason as the
+	// transform path (PLAN-2391 DR-14).
+	//
+	// Derivation is the deliberate exception and stays on the unlocked path —
+	// see the comment on thumbnailParentItemLive for that trade.
+	if err := s.store.CreateAttachmentForLiveItem(att); err != nil {
+		if errors.Is(err, store.ErrAttachmentParentItemGone) {
+			// The same 404 every other attachment denial writes. The caller
+			// must not be able to tell "your item was archived mid-upload"
+			// from "no such attachment", and the row would be unreadable
+			// under DR-13 regardless.
+			writeAttachmentNotFound(w)
+			return
+		}
 		// Note: the blob is now an orphan on disk. Orphan GC (TASK-886)
 		// will reclaim it past the grace period; we do NOT delete it
 		// here because the same hash may still be used by a concurrent
-		// upload that succeeded its DB insert.
+		// upload that succeeded its DB insert. The refusal above lands in
+		// the same shape — BUG-2406 tracks the rowless-blob reclaim.
 		writeInternalError(w, fmt.Errorf("create attachment row: %w", err))
 		return
 	}
@@ -592,25 +614,16 @@ func (s *Server) handleGetAttachment(w http.ResponseWriter, r *http.Request) {
 
 	// Item-level authorization (PLAN-2391 DR-10). Runs BEFORE the variant
 	// lookup and before any byte access.
-	if att.ItemID != nil {
-		// GetItem, not GetItemIncludeDeleted — DR-13. A soft-deleted
-		// parent resolves to nil here and the blob 404s.
-		item, err := s.store.GetItem(*att.ItemID)
-		if err != nil {
-			writeInternalError(w, err)
-			return
-		}
-		// Workspace identity FIRST, before visibility. attachments.item_id
-		// has no FK or same-workspace constraint, and neither downstream
-		// check catches a foreign parent on its own: checkItemVisible
-		// admits any collection id when the caller is unrestricted, and
-		// item-grant lookup matches by item_id. Without this guard a view
-		// grant on a foreign item would authorize reading THIS workspace's
-		// bytes. Mirrors the delete path (handlers_storage.go).
-		if item == nil || item.WorkspaceID != workspaceID {
-			writeAttachmentNotFound(w)
-			return
-		}
+	//
+	// includeArchived=false — DR-13. A soft-deleted parent reports Gone and
+	// the blob 404s. The delete path is the one caller that passes true.
+	item, parentOutcome, err := s.resolveAttachmentParentItem(att, false)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	switch parentOutcome {
+	case attachmentParentOK:
 		// checkItemVisible rather than requireItemVisible: same rule set
 		// (requireItemVisible is a thin wrapper over it), but this handler
 		// writes its own denial so that "no such attachment", "foreign
@@ -618,19 +631,39 @@ func (s *Server) handleGetAttachment(w http.ResponseWriter, r *http.Request) {
 		// byte-identical responses. requireItemVisible's own 404 body says
 		// "Item not found", which would distinguish the visibility denial
 		// from the lookup miss and leak existence.
-		visible, err := s.checkItemVisible(workspaceID, item, currentUser(r), workspaceRole(r), isBearerAuth(r))
-		if err != nil {
-			writeInternalError(w, err)
+		visible, vErr := s.checkItemVisible(workspaceID, item, currentUser(r), workspaceRole(r), isBearerAuth(r))
+		if vErr != nil {
+			writeInternalError(w, vErr)
 			return
 		}
 		if !visible {
 			writeAttachmentNotFound(w)
 			return
 		}
-	} else if !requireRole(r, "viewer") {
-		// Orphan attachments carry no item context to authorize against,
-		// so they keep the flat workspace viewer-role gate — same strength
-		// as before, only the denial SHAPE changes.
+	case attachmentParentOrphan:
+		// Orphan attachments carry no item context to authorize against.
+		//
+		// Full-access only, matching the transform and DELETE paths
+		// (PLAN-2382 DR-4) — and ahead of the role check, for the reason
+		// those paths document: an orphan belongs to no collection, so
+		// collection visibility cannot gate it, and the storage LISTING
+		// already hides orphans from restricted members. Reading one must
+		// not confirm it exists to a member the listing hides it from.
+		// This gate was missing here while transform and DELETE both had
+		// it, so a restricted editor or viewer who guessed an orphan's
+		// UUID could download it.
+		restricted, rErr := s.attachmentCallerIsRestricted(r, workspaceID)
+		if rErr != nil {
+			writeInternalError(w, rErr)
+			return
+		}
+		if restricted {
+			writeAttachmentNotFound(w)
+			return
+		}
+		// Then the flat workspace viewer-role gate — same strength as
+		// before this handler grew per-attachment authorization, only the
+		// denial SHAPE changed.
 		//
 		// requireRole (the write-free predicate) rather than requireMinRole
 		// (which writes its own 403): the attachment row has already been
@@ -640,6 +673,11 @@ func (s *Server) handleGetAttachment(w http.ResponseWriter, r *http.Request) {
 		// didn't have only because its flat role gate ran BEFORE the
 		// lookup. Reordering the gate reintroduced it; routing the denial
 		// through the shared 404 writer closes it again.
+		if !requireRole(r, "viewer") {
+			writeAttachmentNotFound(w)
+			return
+		}
+	default: // Gone, Foreign
 		writeAttachmentNotFound(w)
 		return
 	}

--- a/internal/server/handlers_attachments_download_authz_test.go
+++ b/internal/server/handlers_attachments_download_authz_test.go
@@ -514,6 +514,72 @@ func TestDownload_OrphanKeepsFlatViewerGate(t *testing.T) {
 	assertBlobServed(t, rr, http.MethodGet, f.orphanBody, "orphan as viewer")
 }
 
+// TestDownload_OrphanRefusedToRestrictedMember — an orphan belongs to no
+// collection, so collection visibility cannot gate it, and the storage
+// LISTING already hides orphans from restricted members. Reading one must not
+// confirm it exists to a member the listing hides it from.
+//
+// This gate was present on transform and DELETE but MISSING here: the read
+// path checked only the workspace role, and roleLevel("editor") clears
+// viewer, so a restricted editor who guessed an orphan's UUID got the bytes.
+// The role check alone cannot catch it — a restricted member holds a real
+// workspace role; "restricted" is a separate axis (collection_access).
+//
+// Both restricted roles are covered because the flat gate admits both.
+func TestDownload_OrphanRefusedToRestrictedMember(t *testing.T) {
+	srv, _ := testServerWithAttachments(t)
+	f := newDownloadAuthzFixture(t, srv)
+
+	// The lookup-miss baseline, taken as an unrestricted viewer so it is a
+	// genuine "no such attachment" and not itself a restriction denial.
+	unrestricted := mkUser(t, srv, "orphan-restricted-baseline@test.com")
+	if err := srv.store.AddWorkspaceMember(f.wsID, unrestricted.ID, "viewer"); err != nil {
+		t.Fatalf("AddWorkspaceMember baseline: %v", err)
+	}
+	missing := downloadAs(srv, http.MethodGet, f.wsID,
+		"00000000-0000-0000-0000-000000000000", "", unrestricted, "viewer")
+	assertBlobDenied(t, missing, http.MethodGet, "nonexistent attachment")
+
+	for _, role := range []string{"editor", "viewer"} {
+		user := mkUser(t, srv, "orphan-restricted-"+role+"@test.com")
+		if err := srv.store.AddWorkspaceMember(f.wsID, user.ID, role); err != nil {
+			t.Fatalf("AddWorkspaceMember %s: %v", role, err)
+		}
+		// Restricted TO THE ITEM'S OWN COLLECTION on purpose. The member can
+		// see the item and read its attachment (asserted below), so the
+		// orphan denial cannot be explained away as blanket loss of access —
+		// it isolates the orphan rule from collection visibility.
+		if err := srv.store.SetMemberCollectionAccess(f.wsID, user.ID, "specific",
+			[]string{f.colID}); err != nil {
+			t.Fatalf("SetMemberCollectionAccess %s: %v", role, err)
+		}
+
+		for _, method := range []string{http.MethodGet, http.MethodHead} {
+			rr := downloadAs(srv, method, f.wsID, f.orphanID, "", user, role)
+			if rr.Code == http.StatusOK {
+				t.Fatalf("%s orphan read by a restricted %s succeeded — a member the "+
+					"storage listing hides orphans from must not be able to download "+
+					"one by guessing its UUID", method, role)
+			}
+			assertBlobDenied(t, rr, method, "orphan as restricted "+role)
+			if method == http.MethodGet {
+				if got, want := rr.Body.String(), missing.Body.String(); got != want {
+					t.Errorf("restricted %s orphan denial body = %q, lookup-miss body = %q — "+
+						"must be byte-identical", role, got, want)
+				}
+			}
+		}
+
+		// Control: the restriction is scoped to orphans, not a blanket
+		// denial. The same caller still reads the item-bound attachment in
+		// the collection they DO have access to — so a fixture that had
+		// broken all reads would fail here rather than pass the assertions
+		// above vacuously.
+		rr := downloadAs(srv, http.MethodGet, f.wsID, f.origID, "", user, role)
+		assertBlobServed(t, rr, http.MethodGet, f.origBody, "item-bound as restricted "+role)
+	}
+}
+
 // TestDownload_ViewerStillReadsItemBoundAttachment — the gate replaced a
 // role check with a visibility check; an ordinary unrestricted viewer must
 // still be served.

--- a/internal/server/handlers_attachments_download_authz_test.go
+++ b/internal/server/handlers_attachments_download_authz_test.go
@@ -1,0 +1,551 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/attachments"
+	"github.com/PerpetualSoftware/pad/internal/models"
+	"github.com/go-chi/chi/v5"
+)
+
+// Blob-read authorization tests for PLAN-2391 / TASK-2401 (BUG-2386).
+//
+// handleGetAttachment used to open with a flat requireMinRole("viewer").
+// roleLevel("guest") is 0 — below viewer's 1 — so every grant-based guest
+// was rejected before any item-level check ran, and inline images broke in
+// items shared with them. The handler now authorizes per-attachment:
+// item-bound rows go through workspace-identity → item visibility; orphans
+// keep the flat viewer+ gate.
+//
+// Coverage here: the grant matrix (original + both variants × GET + HEAD),
+// the non-disclosure 404s, the soft-deleted parent (DR-13), the foreign
+// variant IDOR (DR-16), and the denial-path cache directive.
+
+// putBlob writes body into the attachment registry and creates the matching
+// row. Unlike the delete-authz fixtures, the read path actually streams the
+// blob, so the bytes have to exist on disk.
+func putBlob(t *testing.T, srv *Server, att *models.Attachment, body []byte) *models.Attachment {
+	t.Helper()
+	sum := sha256.Sum256(body)
+	hash := hex.EncodeToString(sum[:])
+
+	st, err := srv.attachments.Resolve(attachments.FSPrefix + ":" + hash)
+	if err != nil {
+		t.Fatalf("resolve attachment store: %v", err)
+	}
+	key, err := st.Put(context.Background(), hash, "image/png", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("store.Put: %v", err)
+	}
+
+	att.StorageKey = key
+	att.ContentHash = hash
+	att.MimeType = "image/png"
+	att.SizeBytes = int64(len(body))
+	if att.UploadedBy == "" {
+		att.UploadedBy = "system"
+	}
+	if att.Filename == "" {
+		att.Filename = "blob.png"
+	}
+	if err := srv.store.CreateAttachment(att); err != nil {
+		t.Fatalf("CreateAttachment(%s): %v", att.Filename, err)
+	}
+	return att
+}
+
+// downloadAuthzFixture is one workspace holding an item with an attachment
+// (plus both derived variants, each with distinct bytes so a mis-served
+// variant is detectable) and one orphan attachment.
+type downloadAuthzFixture struct {
+	wsID   string
+	colID  string
+	itemID string
+
+	origID string
+	smID   string
+	mdID   string
+
+	origBody []byte
+	smBody   []byte
+	mdBody   []byte
+
+	orphanID   string
+	orphanBody []byte
+}
+
+func newDownloadAuthzFixture(t *testing.T, srv *Server) downloadAuthzFixture {
+	t.Helper()
+
+	ws, err := srv.store.CreateWorkspace(models.WorkspaceCreate{Name: "DownloadAuthz"})
+	if err != nil {
+		t.Fatalf("CreateWorkspace: %v", err)
+	}
+	col, err := srv.store.CreateCollection(ws.ID, models.CollectionCreate{
+		Name: "Tasks", Schema: `{"fields":[]}`,
+	})
+	if err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	item, err := srv.store.CreateItem(ws.ID, col.ID, models.ItemCreate{
+		Title: "Shared", Fields: `{}`,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem: %v", err)
+	}
+
+	f := downloadAuthzFixture{
+		wsID:       ws.ID,
+		colID:      col.ID,
+		itemID:     item.ID,
+		origBody:   distinctPNG(t, 0x11),
+		smBody:     distinctPNG(t, 0x22),
+		mdBody:     distinctPNG(t, 0x33),
+		orphanBody: distinctPNG(t, 0x44),
+	}
+
+	orig := putBlob(t, srv, &models.Attachment{
+		WorkspaceID: ws.ID, ItemID: &item.ID, Filename: "orig.png",
+	}, f.origBody)
+	f.origID = orig.ID
+
+	for _, v := range []struct {
+		key  string
+		body []byte
+		out  *string
+	}{
+		{models.AttachmentVariantThumbSm, f.smBody, &f.smID},
+		{models.AttachmentVariantThumbMd, f.mdBody, &f.mdID},
+	} {
+		variant := v.key
+		row := putBlob(t, srv, &models.Attachment{
+			WorkspaceID: ws.ID,
+			ItemID:      &item.ID,
+			ParentID:    &orig.ID,
+			Variant:     &variant,
+			Filename:    "orig-" + variant + ".png",
+		}, v.body)
+		*v.out = row.ID
+	}
+
+	orphan := putBlob(t, srv, &models.Attachment{
+		WorkspaceID: ws.ID, Filename: "orphan.png",
+	}, f.orphanBody)
+	f.orphanID = orphan.ID
+
+	return f
+}
+
+// distinctPNG returns a valid PNG whose bytes differ per seed, so an
+// assertion on served content can tell one blob from another. The download
+// handler never decodes, so trailing filler is fine — but the row still has
+// to be a real image for MIME-driven disposition to behave.
+func distinctPNG(t *testing.T, seed byte) []byte {
+	t.Helper()
+	out := append([]byte(nil), realPNG()...)
+	return append(out, seed, seed, seed, seed)
+}
+
+// downloadAs issues GET or HEAD on the blob endpoint as a specific user +
+// workspace role, bypassing the auth middleware the same way deleteAsUser
+// does. variant "" means the original.
+func downloadAs(srv *Server, method, wsID, attachmentID, variant string, user *models.User, role string) *httptest.ResponseRecorder {
+	path := "/api/v1/workspaces/x/attachments/" + attachmentID
+	if variant != "" {
+		path += "?variant=" + variant
+	}
+	req := httptest.NewRequest(method, path, nil)
+	req.RemoteAddr = "127.0.0.1:1234"
+
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("attachmentID", attachmentID)
+
+	ctx := req.Context()
+	ctx = context.WithValue(ctx, ctxResolvedWorkspaceID, wsID)
+	ctx = context.WithValue(ctx, ctxCurrentUser, user)
+	ctx = context.WithValue(ctx, ctxWorkspaceRole, role)
+	ctx = context.WithValue(ctx, chi.RouteCtxKey, rctx)
+	req = req.WithContext(ctx)
+
+	rr := httptest.NewRecorder()
+	srv.handleGetAttachment(rr, req)
+	return rr
+}
+
+// assertBlobServed checks a 200 whose body is want (GET) or whose headers say so
+// (HEAD — no body on the wire, so Content-Type + the positive cache
+// directive are all that can be asserted).
+func assertBlobServed(t *testing.T, rr *httptest.ResponseRecorder, method string, want []byte, label string) {
+	t.Helper()
+	if rr.Code != http.StatusOK {
+		t.Fatalf("%s %s: status = %d, want 200; body = %s", method, label, rr.Code, rr.Body.String())
+	}
+	if got := rr.Header().Get("Cache-Control"); got != "private, max-age=3600" {
+		t.Errorf("%s %s: Cache-Control = %q, want the positive directive", method, label, got)
+	}
+	if method == http.MethodHead {
+		return
+	}
+	if !bytes.Equal(rr.Body.Bytes(), want) {
+		t.Errorf("%s %s: served %d bytes, want the %d-byte fixture blob",
+			method, label, rr.Body.Len(), len(want))
+	}
+}
+
+// assertBlobDenied pins the shared denial shape: 404, no-store, and the exact
+// body every other denial writes.
+func assertBlobDenied(t *testing.T, rr *httptest.ResponseRecorder, method, label string) {
+	t.Helper()
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("%s %s: status = %d, want 404; body = %s", method, label, rr.Code, rr.Body.String())
+	}
+	if got := rr.Header().Get("Cache-Control"); got != "private, no-store" {
+		t.Errorf("%s %s: Cache-Control = %q, want \"private, no-store\" — an unlabelled "+
+			"404 is heuristically cacheable by URL and would keep denying a caller "+
+			"who later becomes authorized", method, label, got)
+	}
+}
+
+// TestDownload_ItemGrantGuestCanFetch is the core BUG-2386 regression: a
+// guest holding an item VIEW grant (no workspace viewer role) can fetch the
+// attachment's bytes. Covers the full matrix the acceptance criteria name —
+// original + both variants × GET + HEAD.
+func TestDownload_ItemGrantGuestCanFetch(t *testing.T) {
+	srv, _ := testServerWithAttachments(t)
+	f := newDownloadAuthzFixture(t, srv)
+
+	guest := mkUser(t, srv, "item-grant@test.com")
+	if _, err := srv.store.CreateItemGrant(f.wsID, f.itemID, guest.ID, "view", guest.ID); err != nil {
+		t.Fatalf("CreateItemGrant: %v", err)
+	}
+
+	for _, method := range []string{http.MethodGet, http.MethodHead} {
+		for _, tc := range []struct {
+			label   string
+			variant string
+			want    []byte
+		}{
+			{"original", "", f.origBody},
+			{"thumb-sm", models.AttachmentVariantThumbSm, f.smBody},
+			{"thumb-md", models.AttachmentVariantThumbMd, f.mdBody},
+		} {
+			rr := downloadAs(srv, method, f.wsID, f.origID, tc.variant, guest, "guest")
+			assertBlobServed(t, rr, method, tc.want, "item-grant guest "+tc.label)
+		}
+	}
+}
+
+// TestDownload_CollectionGrantGuestCanFetch — same, one level up the grant
+// chain. The guest holds no item grant; visibility comes from the
+// collection.
+func TestDownload_CollectionGrantGuestCanFetch(t *testing.T) {
+	srv, _ := testServerWithAttachments(t)
+	f := newDownloadAuthzFixture(t, srv)
+
+	guest := mkUser(t, srv, "coll-grant@test.com")
+	if _, err := srv.store.CreateCollectionGrant(f.wsID, f.colID, guest.ID, "view", guest.ID); err != nil {
+		t.Fatalf("CreateCollectionGrant: %v", err)
+	}
+
+	for _, method := range []string{http.MethodGet, http.MethodHead} {
+		for _, tc := range []struct {
+			label   string
+			variant string
+			want    []byte
+		}{
+			{"original", "", f.origBody},
+			{"thumb-sm", models.AttachmentVariantThumbSm, f.smBody},
+			{"thumb-md", models.AttachmentVariantThumbMd, f.mdBody},
+		} {
+			rr := downloadAs(srv, method, f.wsID, f.origID, tc.variant, guest, "guest")
+			assertBlobServed(t, rr, method, tc.want, "collection-grant guest "+tc.label)
+		}
+	}
+}
+
+// TestDownload_DirectVariantFetchHonorsTheGate — a derived row can be
+// addressed by its OWN id, not just via ?variant= on the parent. That path
+// must run the same gate (variants carry the parent's item_id, so it does).
+func TestDownload_DirectVariantFetchHonorsTheGate(t *testing.T) {
+	srv, _ := testServerWithAttachments(t)
+	f := newDownloadAuthzFixture(t, srv)
+
+	guest := mkUser(t, srv, "direct-variant@test.com")
+	if _, err := srv.store.CreateItemGrant(f.wsID, f.itemID, guest.ID, "view", guest.ID); err != nil {
+		t.Fatalf("CreateItemGrant: %v", err)
+	}
+	stranger := mkUser(t, srv, "direct-variant-stranger@test.com")
+
+	rr := downloadAs(srv, http.MethodGet, f.wsID, f.smID, "", guest, "guest")
+	assertBlobServed(t, rr, http.MethodGet, f.smBody, "granted guest direct thumb-sm")
+
+	rr = downloadAs(srv, http.MethodGet, f.wsID, f.smID, "", stranger, "guest")
+	assertBlobDenied(t, rr, http.MethodGet, "ungranted guest direct thumb-sm")
+}
+
+// TestDownload_InvisibleItemIs404NotForbidden pins the non-disclosure
+// posture AND the byte-identical-denial rule TASK-2400 established.
+//
+// The actor is an authenticated guest with no grants — NOT a non-member. A
+// non-member is refused by RequireWorkspaceAccess with a 403 before this
+// handler runs, so that fixture would pass vacuously and prove nothing about
+// the handler's own ordering or its cache header.
+func TestDownload_InvisibleItemIs404NotForbidden(t *testing.T) {
+	srv, _ := testServerWithAttachments(t)
+	f := newDownloadAuthzFixture(t, srv)
+
+	stranger := mkUser(t, srv, "no-grants@test.com")
+
+	for _, method := range []string{http.MethodGet, http.MethodHead} {
+		denied := downloadAs(srv, method, f.wsID, f.origID, "", stranger, "guest")
+		if denied.Code == http.StatusForbidden {
+			t.Fatalf("%s invisible item: got 403 — that confirms the attachment exists", method)
+		}
+		assertBlobDenied(t, denied, method, "invisible item")
+
+		// Byte-identical to a plain lookup miss: a different error code or
+		// message would turn the response into an existence oracle.
+		missing := downloadAs(srv, method, f.wsID, "00000000-0000-0000-0000-000000000000", "", stranger, "guest")
+		assertBlobDenied(t, missing, method, "nonexistent attachment")
+
+		if got, want := denied.Body.String(), missing.Body.String(); got != want {
+			t.Errorf("%s: visibility denial body = %q, lookup-miss body = %q — must be "+
+				"byte-identical or the error distinguishes them", method, got, want)
+		}
+	}
+}
+
+// TestDownload_SoftDeletedParentIs404 — DR-13. The read path loads the
+// parent with GetItem (not GetItemIncludeDeleted), so archiving an item
+// takes its attachments' bytes offline. The DELETE path deliberately
+// diverges; TestDeleteAttachment_* covers that side.
+func TestDownload_SoftDeletedParentIs404(t *testing.T) {
+	srv, _ := testServerWithAttachments(t)
+	f := newDownloadAuthzFixture(t, srv)
+
+	owner := mkUser(t, srv, "archive-owner@test.com")
+	if err := srv.store.AddWorkspaceMember(f.wsID, owner.ID, "owner"); err != nil {
+		t.Fatalf("AddWorkspaceMember: %v", err)
+	}
+
+	// Readable before the archive — otherwise the post-archive 404 could be
+	// explained by any unrelated denial.
+	rr := downloadAs(srv, http.MethodGet, f.wsID, f.origID, "", owner, "owner")
+	assertBlobServed(t, rr, http.MethodGet, f.origBody, "owner pre-archive")
+
+	if err := srv.store.DeleteItem(f.itemID); err != nil {
+		t.Fatalf("DeleteItem: %v", err)
+	}
+
+	for _, method := range []string{http.MethodGet, http.MethodHead} {
+		for _, tc := range []struct{ label, variant string }{
+			{"original", ""},
+			{"thumb-sm", models.AttachmentVariantThumbSm},
+			{"thumb-md", models.AttachmentVariantThumbMd},
+		} {
+			rr := downloadAs(srv, method, f.wsID, f.origID, tc.variant, owner, "owner")
+			assertBlobDenied(t, rr, method, "soft-deleted parent "+tc.label)
+		}
+	}
+}
+
+// TestDownload_ForeignItemParentIs404 — attachments.item_id has no
+// same-workspace constraint, so a row in workspace A can name an item in B.
+// A view grant in B must not authorize reading A's bytes. The workspace
+// identity check runs before visibility, so this is a 404 either way.
+func TestDownload_ForeignItemParentIs404(t *testing.T) {
+	srv, _ := testServerWithAttachments(t)
+	b := newDownloadAuthzFixture(t, srv)
+
+	wsA, err := srv.store.CreateWorkspace(models.WorkspaceCreate{Name: "VictimA"})
+	if err != nil {
+		t.Fatalf("CreateWorkspace A: %v", err)
+	}
+	secret := distinctPNG(t, 0x55)
+	crossed := putBlob(t, srv, &models.Attachment{
+		WorkspaceID: wsA.ID,
+		ItemID:      &b.itemID, // foreign parent — the whole point
+		Filename:    "crossed.png",
+	}, secret)
+
+	attacker := mkUser(t, srv, "cross-ws-read@test.com")
+	// Full (unrestricted) VIEWER membership in A. Without it the caller is
+	// restricted in A and checkItemVisible denies on its own, so the test
+	// would pass with the workspace-identity guard deleted — it has to be
+	// the guard, not the visibility filter, doing the work here.
+	if err := srv.store.AddWorkspaceMember(wsA.ID, attacker.ID, "viewer"); err != nil {
+		t.Fatalf("AddWorkspaceMember A: %v", err)
+	}
+	// ...plus a real view grant on the B item the crossed row names.
+	if _, err := srv.store.CreateItemGrant(b.wsID, b.itemID, attacker.ID, "view", attacker.ID); err != nil {
+		t.Fatalf("CreateItemGrant B: %v", err)
+	}
+
+	rr := downloadAs(srv, http.MethodGet, wsA.ID, crossed.ID, "", attacker, "viewer")
+	if rr.Code == http.StatusOK {
+		t.Fatalf("cross-workspace read succeeded: a grant in B must not authorize " +
+			"reading an attachment in A")
+	}
+	assertBlobDenied(t, rr, http.MethodGet, "foreign parent item")
+}
+
+// TestDownload_ForeignVariantIsNotServed pins DR-16.
+//
+// GetAttachmentVariant used to scope on parent_id + variant + deleted_at
+// only, so a variant row in ANOTHER workspace carrying this attachment's id
+// as its parent would be served to a caller authorized for the parent.
+//
+// A 200 assertion proves nothing here: when the variant is absent the
+// handler documents a fallback that serves the ORIGINAL, so the correct
+// behaviour and the broken one both answer 200. The assertion has to be on
+// the BYTES — the foreign child's content must never appear.
+func TestDownload_ForeignVariantIsNotServed(t *testing.T) {
+	srv, _ := testServerWithAttachments(t)
+
+	// Workspace A: the caller is authorized for this original, which has no
+	// local thumb-sm of its own.
+	wsA, err := srv.store.CreateWorkspace(models.WorkspaceCreate{Name: "VariantVictim"})
+	if err != nil {
+		t.Fatalf("CreateWorkspace A: %v", err)
+	}
+	colA, err := srv.store.CreateCollection(wsA.ID, models.CollectionCreate{
+		Name: "Tasks", Schema: `{"fields":[]}`,
+	})
+	if err != nil {
+		t.Fatalf("CreateCollection A: %v", err)
+	}
+	itemA, err := srv.store.CreateItem(wsA.ID, colA.ID, models.ItemCreate{
+		Title: "Local", Fields: `{}`,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem A: %v", err)
+	}
+	originalBody := distinctPNG(t, 0x66)
+	original := putBlob(t, srv, &models.Attachment{
+		WorkspaceID: wsA.ID, ItemID: &itemA.ID, Filename: "local.png",
+	}, originalBody)
+
+	// Workspace B: a planted variant whose parent_id points at A's original.
+	wsB, err := srv.store.CreateWorkspace(models.WorkspaceCreate{Name: "VariantAttacker"})
+	if err != nil {
+		t.Fatalf("CreateWorkspace B: %v", err)
+	}
+	variant := models.AttachmentVariantThumbSm
+	foreignBody := distinctPNG(t, 0x77)
+	foreign := putBlob(t, srv, &models.Attachment{
+		WorkspaceID: wsB.ID,
+		ParentID:    &original.ID, // cross-workspace parent — representable today
+		Variant:     &variant,
+		Filename:    "foreign-thumb.png",
+	}, foreignBody)
+
+	reader := mkUser(t, srv, "variant-reader@test.com")
+	if err := srv.store.AddWorkspaceMember(wsA.ID, reader.ID, "viewer"); err != nil {
+		t.Fatalf("AddWorkspaceMember A: %v", err)
+	}
+
+	for _, method := range []string{http.MethodGet, http.MethodHead} {
+		rr := downloadAs(srv, method, wsA.ID, original.ID, variant, reader, "viewer")
+		if rr.Code != http.StatusOK {
+			t.Fatalf("%s ?variant=%s: status = %d, want 200 (fallback to the original); body = %s",
+				method, variant, rr.Code, rr.Body.String())
+		}
+		if method == http.MethodHead {
+			continue
+		}
+		if bytes.Equal(rr.Body.Bytes(), foreignBody) {
+			t.Fatalf("%s ?variant=%s served workspace B's planted variant (%s) — "+
+				"the variant lookup is not workspace-scoped", method, variant, foreign.ID)
+		}
+		if !bytes.Equal(rr.Body.Bytes(), originalBody) {
+			t.Errorf("%s ?variant=%s: expected the fallback to A's original bytes, got %d bytes",
+				method, variant, rr.Body.Len())
+		}
+	}
+}
+
+// TestDownload_OrphanKeepsFlatViewerGate — an orphan carries no item context
+// to authorize against, so it keeps the flat viewer-role gate. A guest with a
+// real grant on some other item must not reach it.
+//
+// The denial is a 404, matching every other denial in this handler. The gate
+// is exactly as strong as before; only the response shape changed. It has to:
+// the attachment row is loaded before the role check now, so a 403 would mean
+// "this id names a live orphan here" while a bad id answers 404 — an
+// existence oracle for orphan UUIDs that the old pre-lookup gate didn't have.
+func TestDownload_OrphanKeepsFlatViewerGate(t *testing.T) {
+	srv, _ := testServerWithAttachments(t)
+	f := newDownloadAuthzFixture(t, srv)
+
+	guest := mkUser(t, srv, "orphan-read@test.com")
+	if _, err := srv.store.CreateItemGrant(f.wsID, f.itemID, guest.ID, "view", guest.ID); err != nil {
+		t.Fatalf("CreateItemGrant: %v", err)
+	}
+
+	rr := downloadAs(srv, http.MethodGet, f.wsID, f.orphanID, "", guest, "guest")
+	if rr.Code == http.StatusOK {
+		t.Fatalf("orphan read by a guest holding an unrelated item grant succeeded — " +
+			"the flat viewer gate must not be weakened")
+	}
+	assertBlobDenied(t, rr, http.MethodGet, "orphan as grant-only guest")
+
+	// ...and byte-identical to a plain lookup miss, so the denial can't be
+	// used to confirm the orphan exists.
+	missing := downloadAs(srv, http.MethodGet, f.wsID,
+		"00000000-0000-0000-0000-000000000000", "", guest, "guest")
+	assertBlobDenied(t, missing, http.MethodGet, "nonexistent attachment as guest")
+	if got, want := rr.Body.String(), missing.Body.String(); got != want {
+		t.Errorf("orphan denial body = %q, lookup-miss body = %q — must be byte-identical",
+			got, want)
+	}
+
+	// ...and a real viewer still gets the bytes.
+	viewer := mkUser(t, srv, "orphan-viewer@test.com")
+	if err := srv.store.AddWorkspaceMember(f.wsID, viewer.ID, "viewer"); err != nil {
+		t.Fatalf("AddWorkspaceMember: %v", err)
+	}
+	rr = downloadAs(srv, http.MethodGet, f.wsID, f.orphanID, "", viewer, "viewer")
+	assertBlobServed(t, rr, http.MethodGet, f.orphanBody, "orphan as viewer")
+}
+
+// TestDownload_ViewerStillReadsItemBoundAttachment — the gate replaced a
+// role check with a visibility check; an ordinary unrestricted viewer must
+// still be served.
+func TestDownload_ViewerStillReadsItemBoundAttachment(t *testing.T) {
+	srv, _ := testServerWithAttachments(t)
+	f := newDownloadAuthzFixture(t, srv)
+
+	viewer := mkUser(t, srv, "plain-viewer@test.com")
+	if err := srv.store.AddWorkspaceMember(f.wsID, viewer.ID, "viewer"); err != nil {
+		t.Fatalf("AddWorkspaceMember: %v", err)
+	}
+
+	rr := downloadAs(srv, http.MethodGet, f.wsID, f.origID, "", viewer, "viewer")
+	assertBlobServed(t, rr, http.MethodGet, f.origBody, "unrestricted viewer")
+}
+
+// TestDownload_CrossWorkspaceAttachmentIs404 — the pre-existing
+// wrong-workspace guard, re-pinned with the cache directive the denial now
+// carries.
+func TestDownload_CrossWorkspaceAttachmentIs404(t *testing.T) {
+	srv, _ := testServerWithAttachments(t)
+	f := newDownloadAuthzFixture(t, srv)
+
+	other, err := srv.store.CreateWorkspace(models.WorkspaceCreate{Name: "Other"})
+	if err != nil {
+		t.Fatalf("CreateWorkspace: %v", err)
+	}
+	viewer := mkUser(t, srv, "other-ws-viewer@test.com")
+	if err := srv.store.AddWorkspaceMember(other.ID, viewer.ID, "viewer"); err != nil {
+		t.Fatalf("AddWorkspaceMember: %v", err)
+	}
+
+	rr := downloadAs(srv, http.MethodGet, other.ID, f.origID, "", viewer, "viewer")
+	assertBlobDenied(t, rr, http.MethodGet, "attachment in another workspace")
+}

--- a/internal/server/handlers_attachments_test.go
+++ b/internal/server/handlers_attachments_test.go
@@ -11,12 +11,15 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"os"
 	"strings"
 	"sync"
 	"testing"
 
 	"github.com/PerpetualSoftware/pad/internal/attachments"
 	"github.com/PerpetualSoftware/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/store"
 )
 
 // testServerWithAttachments returns a fresh test server with the
@@ -128,17 +131,37 @@ func TestUpload_HappyPathPNG(t *testing.T) {
 // non-empty, rides in the ?item_id query string so the handler authorizes
 // via the item's grant chain (BUG-1661).
 func uploadAsGuest(srv *Server, wsID, itemID string, guest *models.User, body []byte) *httptest.ResponseRecorder {
+	return uploadAsGuestChannels(srv, wsID, itemID, "", guest, body)
+}
+
+// uploadAsGuestChannels is uploadAsGuest with independent control over the
+// two item_id input channels: queryItemID rides the query string (the web
+// client's shape) and formItemID rides the multipart form (the CLI's).
+// Either, both, or neither may be empty.
+func uploadAsGuestChannels(srv *Server, wsID, queryItemID, formItemID string, guest *models.User, body []byte) *httptest.ResponseRecorder {
+	var queryIDs, formIDs []string
+	if queryItemID != "" {
+		queryIDs = []string{queryItemID}
+	}
+	if formItemID != "" {
+		formIDs = []string{formItemID}
+	}
+	return uploadAsGuestRepeated(srv, wsID, queryIDs, formIDs, guest, body)
+}
+
+// uploadAsGuestRepeated is uploadAsGuestChannels with an arbitrary number of
+// item_id values on each channel.
+func uploadAsGuestRepeated(srv *Server, wsID string, queryIDs, formIDs []string, guest *models.User, body []byte) *httptest.ResponseRecorder {
 	var buf bytes.Buffer
 	mw := multipart.NewWriter(&buf)
+	for _, id := range formIDs {
+		mw.WriteField("item_id", id)
+	}
 	part, _ := mw.CreateFormFile("file", "shot.png")
 	part.Write(body)
 	mw.Close()
 
-	path := "/api/v1/workspaces/" + wsID + "/attachments"
-	if itemID != "" {
-		path += "?item_id=" + itemID
-	}
-	req := httptest.NewRequest("POST", path, &buf)
+	req := httptest.NewRequest("POST", uploadPathWithItemIDs("/api/v1/workspaces/"+wsID+"/attachments", queryIDs), &buf)
 	req.Header.Set("Content-Type", mw.FormDataContentType())
 	req.RemoteAddr = "127.0.0.1:1234"
 
@@ -151,6 +174,19 @@ func uploadAsGuest(srv *Server, wsID, itemID string, guest *models.User, body []
 	rr := httptest.NewRecorder()
 	srv.handleUploadAttachment(rr, req)
 	return rr
+}
+
+// uploadPathWithItemIDs appends any number of item_id query parameters.
+func uploadPathWithItemIDs(path string, ids []string) string {
+	for i, id := range ids {
+		if i == 0 {
+			path += "?"
+		} else {
+			path += "&"
+		}
+		path += "item_id=" + url.QueryEscape(id)
+	}
+	return path
 }
 
 // TestUpload_GrantBasedEditorCanAttach covers BUG-1661: a guest holding an
@@ -207,6 +243,440 @@ func TestUpload_GrantBasedEditorCanAttach(t *testing.T) {
 	if rr.Code != http.StatusForbidden {
 		t.Fatalf("free-floating guest upload: status = %d, want 403; body = %s", rr.Code, rr.Body.String())
 	}
+
+	// The regression PLAN-2391 DR-2 exists for: the CLI sends item_id in
+	// the multipart FORM only. The no-item editor gate used to fire before
+	// the body was parsed, so this guest was 403'd before the association
+	// that authorizes them was ever read.
+	rr = uploadAsGuestChannels(srv, ws.ID, "", item.ID, guest, realPNG())
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("form-only granted upload: status = %d, want 201; body = %s", rr.Code, rr.Body.String())
+	}
+	if got := attachmentItemID(t, srv, uploadedAttachmentID(t, rr)); got != item.ID {
+		t.Errorf("form-only upload stored item_id = %q, want %q", got, item.ID)
+	}
+
+	// Both channels, agreeing (the web client's shape).
+	rr = uploadAsGuestChannels(srv, ws.ID, item.ID, item.ID, guest, realPNG())
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("both-channel granted upload: status = %d, want 201; body = %s", rr.Code, rr.Body.String())
+	}
+
+	// An item this guest holds NO grant on answers 404 — the same answer an
+	// item_id that doesn't exist gets, so the status split can't be used as
+	// an existence oracle for items the caller can't see.
+	ungranted, err := srv.store.CreateItem(ws.ID, col.ID, models.ItemCreate{
+		Title: "Not granted", Fields: `{}`,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem: %v", err)
+	}
+	for _, tc := range []struct{ name, query, form string }{
+		{"query channel", ungranted.ID, ""},
+		{"form channel", "", ungranted.ID},
+	} {
+		rr = uploadAsGuestChannels(srv, ws.ID, tc.query, tc.form, guest, realPNG())
+		if rr.Code != http.StatusNotFound {
+			t.Errorf("ungranted item upload (%s): status = %d, want 404; body = %s",
+				tc.name, rr.Code, rr.Body.String())
+		}
+	}
+
+	// Pairing a granted id with a probe id must not turn the conflict
+	// rejection into an existence oracle: a hidden item and a nonexistent
+	// one both answer 404, never 400.
+	for _, tc := range []struct {
+		name  string
+		probe string
+	}{
+		{"hidden item", ungranted.ID},
+		{"nonexistent item", "no-such-item"},
+	} {
+		rr = uploadAsGuestRepeated(srv, ws.ID, nil, []string{item.ID, tc.probe}, guest, realPNG())
+		if rr.Code != http.StatusNotFound {
+			t.Errorf("granted id + %s: status = %d, want 404; body = %s",
+				tc.name, rr.Code, rr.Body.String())
+		}
+	}
+}
+
+// TestUpload_RejectsTooManyItemIDValues pins the bound on per-channel
+// item_id values. Exact-string dedup can't bound the ResolveItem lookups on
+// its own — TASK-7, task-7 and TASK-0007 are distinct strings that resolve
+// to the same item — so the count is capped outright.
+func TestUpload_RejectsTooManyItemIDValues(t *testing.T) {
+	srv, _ := testServerWithAttachments(t)
+	slug, item := uploadItemFixture(t, srv, "Flood")
+
+	ids := make([]string, maxUploadItemIDValues+1)
+	for i := range ids {
+		ids[i] = item.ID
+	}
+
+	rr := uploadRepeatedItemIDs(srv, slug, ids, nil, realPNG())
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("flooded query item_id: status = %d, want 400; body = %s", rr.Code, rr.Body.String())
+	}
+	rr = uploadRepeatedItemIDs(srv, slug, nil, ids, realPNG())
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("flooded form item_id: status = %d, want 400; body = %s", rr.Code, rr.Body.String())
+	}
+
+	// The cap itself is still accepted.
+	rr = uploadRepeatedItemIDs(srv, slug, nil, ids[:maxUploadItemIDValues], realPNG())
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("at-cap form item_id: status = %d, want 201; body = %s", rr.Code, rr.Body.String())
+	}
+}
+
+// uploadedAttachmentID pulls the new attachment's id out of a 201 upload
+// response body.
+func uploadedAttachmentID(t *testing.T, rr *httptest.ResponseRecorder) string {
+	t.Helper()
+	var resp struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode upload response: %v body=%s", err, rr.Body.String())
+	}
+	if resp.ID == "" {
+		t.Fatalf("upload response missing id: %s", rr.Body.String())
+	}
+	return resp.ID
+}
+
+// attachmentItemID reads back the persisted item_id for an attachment,
+// returning "" for a NULL association.
+func attachmentItemID(t *testing.T, srv *Server, attachmentID string) string {
+	t.Helper()
+	att, err := srv.store.GetAttachment(attachmentID)
+	if err != nil {
+		t.Fatalf("GetAttachment: %v", err)
+	}
+	if att == nil {
+		t.Fatalf("attachment %s not found", attachmentID)
+	}
+	if att.ItemID == nil {
+		return ""
+	}
+	return *att.ItemID
+}
+
+// uploadItemFixture creates a workspace + collection + item for the
+// item_id-invariant tests, returning the workspace slug and the item.
+func uploadItemFixture(t *testing.T, srv *Server, wsName string) (string, *models.Item) {
+	t.Helper()
+	ws, err := srv.store.CreateWorkspace(models.WorkspaceCreate{Name: wsName})
+	if err != nil {
+		t.Fatalf("CreateWorkspace: %v", err)
+	}
+	col, err := srv.store.CreateCollection(ws.ID, models.CollectionCreate{
+		Name: "Tasks", Schema: `{"fields":[]}`,
+	})
+	if err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	item, err := srv.store.CreateItem(ws.ID, col.ID, models.ItemCreate{
+		Title: "Target", Fields: `{}`,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem: %v", err)
+	}
+	return ws.Slug, item
+}
+
+// uploadChannels drives the real route (no users exist in these tests, so
+// RequireWorkspaceAccess grants implicit owner) with independent control
+// over the query-string and multipart-form item_id channels.
+func uploadChannels(srv *Server, slug, queryItemID, formItemID string, body []byte) *httptest.ResponseRecorder {
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	if formItemID != "" {
+		mw.WriteField("item_id", formItemID)
+	}
+	part, _ := mw.CreateFormFile("file", "shot.png")
+	part.Write(body)
+	mw.Close()
+
+	path := "/api/v1/workspaces/" + slug + "/attachments"
+	if queryItemID != "" {
+		path += "?item_id=" + queryItemID
+	}
+	req := httptest.NewRequest("POST", path, &buf)
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	req.RemoteAddr = "127.0.0.1:1234"
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	return rr
+}
+
+// TestUpload_ItemIDStoredAsCanonicalUUID covers PLAN-2391 DR-2: ResolveItem
+// accepts a UUID, a ref, or a slug, so the caller's spelling must never be
+// what lands in attachments.item_id — the resolved UUID must.
+func TestUpload_ItemIDStoredAsCanonicalUUID(t *testing.T) {
+	srv, _ := testServerWithAttachments(t)
+	slug, item := uploadItemFixture(t, srv, "Canonical")
+
+	cases := []struct {
+		name        string
+		query, form string
+	}{
+		{"query slug", item.Slug, ""},
+		{"form slug", "", item.Slug},
+		{"different spellings, same item", item.Slug, item.ID},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rr := uploadChannels(srv, slug, tc.query, tc.form, realPNG())
+			if rr.Code != http.StatusCreated {
+				t.Fatalf("status = %d, want 201; body = %s", rr.Code, rr.Body.String())
+			}
+			if got := attachmentItemID(t, srv, uploadedAttachmentID(t, rr)); got != item.ID {
+				t.Errorf("stored item_id = %q, want canonical %q", got, item.ID)
+			}
+		})
+	}
+}
+
+// TestUpload_RejectsUnresolvableItemID pins the status contract: an item_id
+// that does not resolve in the request workspace is a 404 on either channel
+// — including a well-formed UUID belonging to another workspace, which is
+// exactly the malformed cross-workspace row BUG-2387 leaks through.
+func TestUpload_RejectsUnresolvableItemID(t *testing.T) {
+	srv, _ := testServerWithAttachments(t)
+	slug, _ := uploadItemFixture(t, srv, "Home")
+	_, foreign := uploadItemFixture(t, srv, "Foreign")
+
+	cases := []struct {
+		name        string
+		query, form string
+	}{
+		{"query garbage", "no-such-item", ""},
+		{"form garbage", "", "no-such-item"},
+		{"query cross-workspace uuid", foreign.ID, ""},
+		{"form cross-workspace uuid", "", foreign.ID},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			before := countAttachments(t, srv, slug)
+			rr := uploadChannels(srv, slug, tc.query, tc.form, realPNG())
+			if rr.Code != http.StatusNotFound {
+				t.Fatalf("status = %d, want 404; body = %s", rr.Code, rr.Body.String())
+			}
+			if after := countAttachments(t, srv, slug); after != before {
+				t.Errorf("attachment rows = %d, want unchanged at %d", after, before)
+			}
+		})
+	}
+}
+
+// TestUpload_HiddenAndMissingItemsAreIndistinguishable pins the existence
+// oracle closed. resolveUploadItemID visibility-gates each resolved item
+// BEFORE comparing channels, so a caller cannot use the 400-vs-404 split to
+// probe for items they cannot see. That ordering is only half the fix: the
+// two 404s must also be byte-identical, or the error code/message leaks the
+// same bit ("item_not_found" => it really is absent; "not_found" => it
+// exists but is hidden from you).
+//
+// Found by the Codex review of TASK-2400 after the ordering fix landed.
+func TestUpload_HiddenAndMissingItemsAreIndistinguishable(t *testing.T) {
+	srv, _ := testServerWithAttachments(t)
+
+	ws, err := srv.store.CreateWorkspace(models.WorkspaceCreate{Name: "Oracle"})
+	if err != nil {
+		t.Fatalf("CreateWorkspace: %v", err)
+	}
+	col, err := srv.store.CreateCollection(ws.ID, models.CollectionCreate{
+		Name: "Tasks", Schema: `{"fields":[]}`,
+	})
+	if err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	hidden, err := srv.store.CreateItem(ws.ID, col.ID, models.ItemCreate{
+		Title: "Hidden", Fields: `{}`,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem: %v", err)
+	}
+
+	// A guest with NO grant on the item: it exists, but is invisible to them.
+	guest, err := srv.store.CreateUser(models.UserCreate{
+		Email:    "prober@test.com",
+		Name:     "Prober",
+		Password: "correct-horse-battery-staple",
+		Role:     "member",
+	})
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	existsButHidden := uploadAsGuestChannels(srv, ws.ID, hidden.ID, "", guest, realPNG())
+	doesNotExist := uploadAsGuestChannels(srv, ws.ID, "00000000-0000-4000-8000-000000000000", "", guest, realPNG())
+
+	if existsButHidden.Code != http.StatusNotFound || doesNotExist.Code != http.StatusNotFound {
+		t.Fatalf("status: hidden = %d, missing = %d; want 404 for both",
+			existsButHidden.Code, doesNotExist.Code)
+	}
+	if existsButHidden.Body.String() != doesNotExist.Body.String() {
+		t.Errorf("404 bodies differ, leaking item existence:\n hidden  = %s\n missing = %s",
+			existsButHidden.Body.String(), doesNotExist.Body.String())
+	}
+}
+
+// TestUpload_RejectsConflictingItemIDChannels covers the other half of the
+// status contract: two channels that each resolve, but to DIFFERENT items,
+// is malformed input → 400. (Two spellings of the same item is not a
+// conflict — see TestUpload_ItemIDStoredAsCanonicalUUID.)
+func TestUpload_RejectsConflictingItemIDChannels(t *testing.T) {
+	srv, _ := testServerWithAttachments(t)
+	slug, item := uploadItemFixture(t, srv, "Conflict")
+	other, err := srv.store.CreateItem(item.WorkspaceID, item.CollectionID, models.ItemCreate{
+		Title: "Other", Fields: `{}`,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem: %v", err)
+	}
+
+	before := countAttachments(t, srv, slug)
+	rr := uploadChannels(srv, slug, item.ID, other.ID, realPNG())
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body = %s", rr.Code, rr.Body.String())
+	}
+	if after := countAttachments(t, srv, slug); after != before {
+		t.Errorf("attachment rows = %d, want unchanged at %d", after, before)
+	}
+}
+
+// TestUpload_RejectsRepeatedConflictingItemID covers the within-channel
+// case: net/http keeps only the first value of a repeated field, so a
+// first-wins read would authorize and associate item A while silently
+// discarding a second, different item_id the caller also sent. Every value
+// on a channel is resolved, and they must agree.
+func TestUpload_RejectsRepeatedConflictingItemID(t *testing.T) {
+	srv, _ := testServerWithAttachments(t)
+	slug, item := uploadItemFixture(t, srv, "Repeated")
+	other, err := srv.store.CreateItem(item.WorkspaceID, item.CollectionID, models.ItemCreate{
+		Title: "Other", Fields: `{}`,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem: %v", err)
+	}
+
+	// Repeated in the query string.
+	before := countAttachments(t, srv, slug)
+	rr := uploadRepeatedItemIDs(srv, slug, []string{item.ID, other.ID}, nil, realPNG())
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("repeated query item_id: status = %d, want 400; body = %s", rr.Code, rr.Body.String())
+	}
+
+	// Repeated in the multipart form.
+	rr = uploadRepeatedItemIDs(srv, slug, nil, []string{item.ID, other.ID}, realPNG())
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("repeated form item_id: status = %d, want 400; body = %s", rr.Code, rr.Body.String())
+	}
+	if after := countAttachments(t, srv, slug); after != before {
+		t.Errorf("attachment rows = %d, want unchanged at %d", after, before)
+	}
+
+	// Two spellings of the SAME item repeated on one channel is agreement,
+	// not conflict.
+	rr = uploadRepeatedItemIDs(srv, slug, nil, []string{item.ID, item.Slug}, realPNG())
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("repeated same-item form item_id: status = %d, want 201; body = %s", rr.Code, rr.Body.String())
+	}
+	if got := attachmentItemID(t, srv, uploadedAttachmentID(t, rr)); got != item.ID {
+		t.Errorf("stored item_id = %q, want %q", got, item.ID)
+	}
+}
+
+// uploadRepeatedItemIDs drives the upload route with an arbitrary number of
+// item_id values on each channel.
+func uploadRepeatedItemIDs(srv *Server, slug string, queryIDs, formIDs []string, body []byte) *httptest.ResponseRecorder {
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	for _, id := range formIDs {
+		mw.WriteField("item_id", id)
+	}
+	part, _ := mw.CreateFormFile("file", "shot.png")
+	part.Write(body)
+	mw.Close()
+
+	req := httptest.NewRequest("POST", uploadPathWithItemIDs("/api/v1/workspaces/"+slug+"/attachments", queryIDs), &buf)
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	req.RemoteAddr = "127.0.0.1:1234"
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	return rr
+}
+
+// countAttachments counts live attachment rows in a workspace.
+func countAttachments(t *testing.T, srv *Server, slug string) int {
+	t.Helper()
+	ws, err := srv.store.GetWorkspaceBySlug(slug)
+	if err != nil || ws == nil {
+		t.Fatalf("GetWorkspaceBySlug(%q): %v", slug, err)
+	}
+	_, total, err := srv.store.WorkspaceAttachments(ws.ID, store.AttachmentListFilters{Limit: 200})
+	if err != nil {
+		t.Fatalf("WorkspaceAttachments: %v", err)
+	}
+	return total
+}
+
+// TestUpload_RemovesMultipartSpool covers the third leg of PLAN-2391 DR-2:
+// file.Close() closes the spooled multipart temp file but never removes it
+// — only r.MultipartForm.RemoveAll() does, and it has to run on EVERY exit
+// path, success included.
+//
+// This needs a deliberate fixture: net/http only spills to disk past
+// multipartParseMemory (1 MiB), so the tiny in-memory bodies the other
+// upload tests use would pass whether or not the leak is fixed. TMPDIR is
+// redirected at a dedicated dir so the assertion is "nothing at all is
+// left behind" rather than a fragile diff against the shared system temp.
+func TestUpload_RemovesMultipartSpool(t *testing.T) {
+	// Build the fixture BEFORE redirecting TMPDIR — t.TempDir() resolves
+	// against os.TempDir() at call time, so the store/blob dirs would
+	// otherwise land inside spoolDir and defeat the emptiness assertion.
+	srv, _ := testServerWithAttachments(t)
+	slug, item := uploadItemFixture(t, srv, "Spool")
+
+	spoolDir := t.TempDir()
+	t.Setenv("TMPDIR", spoolDir)
+
+	// > multipartParseMemory so net/http spills the part to disk. The
+	// MIME sniff only reads the first 512 bytes, so a real PNG header
+	// with a large zero tail is accepted.
+	big := append(realPNG(), make([]byte, 2*multipartParseMemory)...)
+
+	assertSpoolDirEmpty := func(t *testing.T, when string) {
+		t.Helper()
+		entries, err := os.ReadDir(spoolDir)
+		if err != nil {
+			t.Fatalf("ReadDir(%s): %v", spoolDir, err)
+		}
+		if len(entries) != 0 {
+			names := make([]string, 0, len(entries))
+			for _, e := range entries {
+				names = append(names, e.Name())
+			}
+			t.Fatalf("%s: temp dir not empty, leftover files: %v", when, names)
+		}
+	}
+
+	// Success path — the leak PLAN-2391 DR-2 notes exists here too.
+	rr := uploadChannels(srv, slug, item.ID, "", big)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("spooled upload: status = %d, want 201; body = %s", rr.Code, rr.Body.String())
+	}
+	assertSpoolDirEmpty(t, "after successful upload")
+
+	// Post-parse rejection path — the form item_id can only be judged
+	// after the body has already been spooled.
+	rr = uploadChannels(srv, slug, "", "no-such-item", big)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("spooled rejection: status = %d, want 404; body = %s", rr.Code, rr.Body.String())
+	}
+	assertSpoolDirEmpty(t, "after post-parse rejection")
 }
 
 func TestUpload_RejectsExeAsPNG(t *testing.T) {

--- a/internal/server/handlers_attachments_thumbnails.go
+++ b/internal/server/handlers_attachments_thumbnails.go
@@ -38,6 +38,9 @@ var thumbnailSpecs = []struct {
 //
 // Skip cases (logged but not failed):
 //   - Original row missing or already deleted (race with delete).
+//   - Parent ITEM soft-deleted, or item_id malformed so it resolves
+//     to nothing in this workspace (PLAN-2391 DR-14 — see the note
+//     at the check).
 //   - Source format not supported by the configured processor (e.g.
 //     pure-Go on a WebP upload — the original survives, the user
 //     just sees the original at native resolution).
@@ -64,6 +67,9 @@ func (s *Server) deriveThumbnails(parentID string) {
 		// Original was deleted between upload completion and our
 		// goroutine running. Nothing to do — the orphan blob (if any)
 		// will be cleaned up by orphan GC.
+		return
+	}
+	if !s.thumbnailParentItemLive(parent) {
 		return
 	}
 
@@ -122,6 +128,69 @@ func (s *Server) deriveThumbnails(parentID string) {
 	// thumbnail bytes; the upload handler already invalidated when
 	// inserting the original, but thumbnail rows land later.
 	s.storageInfoCache.invalidate(parent.WorkspaceID)
+}
+
+// thumbnailParentItemLive reports whether it is worth deriving variants
+// for parent — i.e. whether parent is an orphan (no item at all) or is
+// bound to an item that is live and in parent's own workspace.
+//
+// Why derivation cares about the ITEM at all (PLAN-2391 DR-14). Each
+// derived row copies parent.ItemID, so a variant of an archived item's
+// attachment is quota-counted storage that nobody can ever read: DR-13
+// makes the blob path 404 for a soft-deleted parent item, so the bytes
+// are written, charged, and refused. The same holds for a malformed
+// item_id — the column carries no FK and no same-workspace constraint,
+// so a row can name an item in another workspace or no item at all
+// (that invariant is fixed at the source by TASK-2400 and repaired for
+// existing rows by PLAN-2397), and such a row is likewise unreadable.
+// Deriving for either is pure waste, so skip both.
+//
+// THE POST-CHECK WINDOW IS DELIBERATELY ACCEPTED — this is not an
+// oversight, please don't file it as a bug. The check is point-in-time:
+// item deletion commits in its own transaction (store.DeleteItem), and
+// everything between here and persistThumbnail's insert — the blob read,
+// decode, resize, encode, Put — is unbounded work. So an item archived
+// mid-flight can still get a variant row written against it.
+//
+// Transform (TASK-2402) closes its equivalent window with an item row
+// lock inside the insert (store.CreateAttachmentForLiveItem). Derivation
+// deliberately makes the OPPOSITE trade and does NOT use it: transform is
+// user-initiated and low-volume, whereas derivation is a background worker
+// that fans out from EVERY image upload, so an item lock on this path is
+// disproportionate to the harm. And the harm is small: what leaks through
+// the window is a thumbnail — a small derived file, unreadable under DR-13
+// for exactly as long as its item stays archived, and tombstoned by the
+// delete cascade along with its parent attachment. If profiling later shows
+// the lock is cheap here, tightening this is a follow-up, not a defect.
+func (s *Server) thumbnailParentItemLive(parent *models.Attachment) bool {
+	if parent.ItemID == nil {
+		return true // orphan row: nothing to check.
+	}
+	// GetItem, not GetItemIncludeDeleted: a soft-deleted item resolves
+	// to nil, which is exactly the "archived" case we skip. Same call
+	// the blob read path uses, so the two agree on what "live" means.
+	item, err := s.store.GetItem(*parent.ItemID)
+	if err != nil {
+		slog.Warn("thumbnails: get parent item failed",
+			"attachment_id", parent.ID, "item_id", *parent.ItemID, "error", err)
+		return false
+	}
+	if item == nil {
+		slog.Warn("thumbnails: skipped, parent item is archived or unresolvable",
+			"attachment_id", parent.ID, "item_id", *parent.ItemID)
+		return false
+	}
+	// Workspace identity, checked separately from resolution: an item_id
+	// that resolves to a FOREIGN workspace's item is malformed for this
+	// row, and a variant derived under it would be as unreadable as one
+	// under an archived item.
+	if item.WorkspaceID != parent.WorkspaceID {
+		slog.Warn("thumbnails: skipped, parent item belongs to another workspace",
+			"attachment_id", parent.ID, "item_id", *parent.ItemID,
+			"attachment_workspace_id", parent.WorkspaceID, "item_workspace_id", item.WorkspaceID)
+		return false
+	}
+	return true
 }
 
 // openOriginalForThumbnail resolves the parent row's storage key

--- a/internal/server/handlers_attachments_thumbnails.go
+++ b/internal/server/handlers_attachments_thumbnails.go
@@ -162,35 +162,40 @@ func (s *Server) deriveThumbnails(parentID string) {
 // for exactly as long as its item stays archived, and tombstoned by the
 // delete cascade along with its parent attachment. If profiling later shows
 // the lock is cheap here, tightening this is a follow-up, not a defect.
+// The invariant itself lives in resolveAttachmentParentItem, shared with the
+// blob read, transform and delete paths (includeArchived=false, so "live"
+// means exactly what the read path means by it). Only the REACTION is local:
+// this is background work with no HTTP response, so there is no 404 shape to
+// match — each malformed outcome gets its own WARN so it stays greppable ahead
+// of PLAN-2397's repair, which is the opposite of what the HTTP paths need.
 func (s *Server) thumbnailParentItemLive(parent *models.Attachment) bool {
-	if parent.ItemID == nil {
-		return true // orphan row: nothing to check.
-	}
-	// GetItem, not GetItemIncludeDeleted: a soft-deleted item resolves
-	// to nil, which is exactly the "archived" case we skip. Same call
-	// the blob read path uses, so the two agree on what "live" means.
-	item, err := s.store.GetItem(*parent.ItemID)
+	item, outcome, err := s.resolveAttachmentParentItem(parent, false)
 	if err != nil {
 		slog.Warn("thumbnails: get parent item failed",
-			"attachment_id", parent.ID, "item_id", *parent.ItemID, "error", err)
+			"attachment_id", parent.ID, "item_id", derefOrEmpty(parent.ItemID), "error", err)
 		return false
 	}
-	if item == nil {
-		slog.Warn("thumbnails: skipped, parent item is archived or unresolvable",
-			"attachment_id", parent.ID, "item_id", *parent.ItemID)
-		return false
-	}
-	// Workspace identity, checked separately from resolution: an item_id
-	// that resolves to a FOREIGN workspace's item is malformed for this
-	// row, and a variant derived under it would be as unreadable as one
-	// under an archived item.
-	if item.WorkspaceID != parent.WorkspaceID {
+	switch outcome {
+	case attachmentParentOrphan, attachmentParentOK:
+		return true
+	case attachmentParentForeign:
 		slog.Warn("thumbnails: skipped, parent item belongs to another workspace",
-			"attachment_id", parent.ID, "item_id", *parent.ItemID,
+			"attachment_id", parent.ID, "item_id", derefOrEmpty(parent.ItemID),
 			"attachment_workspace_id", parent.WorkspaceID, "item_workspace_id", item.WorkspaceID)
 		return false
+	default: // attachmentParentGone
+		slog.Warn("thumbnails: skipped, parent item is archived or unresolvable",
+			"attachment_id", parent.ID, "item_id", derefOrEmpty(parent.ItemID))
+		return false
 	}
-	return true
+}
+
+// derefOrEmpty renders a nullable id for a log field.
+func derefOrEmpty(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
 }
 
 // openOriginalForThumbnail resolves the parent row's storage key

--- a/internal/server/handlers_attachments_thumbnails.go
+++ b/internal/server/handlers_attachments_thumbnails.go
@@ -99,7 +99,7 @@ func (s *Server) deriveThumbnails(parentID string) {
 			*parent.Width <= spec.MaxLong && *parent.Height <= spec.MaxLong {
 			continue
 		}
-		if existing, err := s.store.GetAttachmentVariant(parent.ID, spec.Variant); err == nil && existing != nil {
+		if existing, err := s.store.GetAttachmentVariant(parent.WorkspaceID, parent.ID, spec.Variant); err == nil && existing != nil {
 			continue
 		}
 

--- a/internal/server/handlers_attachments_thumbnails_parent_test.go
+++ b/internal/server/handlers_attachments_thumbnails_parent_test.go
@@ -1,0 +1,191 @@
+//go:build !libvips
+
+package server
+
+import (
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// Thumbnail-derivation parent-item tests for PLAN-2391 / TASK-2404 (DR-14).
+//
+// deriveThumbnails checked only that the parent ATTACHMENT row was live and
+// then copied parent.ItemID into every derived row. After TASK-2401's read
+// gate a variant of an archived item's attachment is quota-counted storage
+// that the blob path refuses to serve, so derivation now skips a parent whose
+// ITEM is soft-deleted or whose item_id resolves to nothing in the row's own
+// workspace.
+//
+// These tests cover the SEQUENTIAL cases only — the item is already gone
+// before derivation starts. The raced case (item archived after the check,
+// while the resize is running) is deliberately NOT asserted: that window is
+// accepted behaviour, documented on thumbnailParentItemLive, so an assertion
+// either way would pin down something the design leaves free.
+
+// derivationFixture is a workspace + collection + item, on a server with the
+// attachment registry and the pure-Go image processor wired.
+type derivationFixture struct {
+	srv    *Server
+	wsID   string
+	colID  string
+	itemID string
+}
+
+func newDerivationFixture(t *testing.T) derivationFixture {
+	t.Helper()
+	srv, _ := testServerWithAttachments(t)
+
+	ws, err := srv.store.CreateWorkspace(models.WorkspaceCreate{Name: "DeriveParent"})
+	if err != nil {
+		t.Fatalf("CreateWorkspace: %v", err)
+	}
+	col, err := srv.store.CreateCollection(ws.ID, models.CollectionCreate{
+		Name: "Tasks", Schema: `{"fields":[]}`,
+	})
+	if err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	item, err := srv.store.CreateItem(ws.ID, col.ID, models.ItemCreate{
+		Title: "Parent", Fields: `{}`,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem: %v", err)
+	}
+	return derivationFixture{srv: srv, wsID: ws.ID, colID: col.ID, itemID: item.ID}
+}
+
+// attachTo writes a real 2000x1500 PNG — big enough that BOTH specs must
+// scale down, so a skip is unambiguous — and returns the new row's id.
+// Width/Height are left nil so the "source already within bounds" skip
+// cannot be what suppresses derivation.
+func (f derivationFixture) attachTo(t *testing.T, itemID *string) string {
+	t.Helper()
+	return putBlob(t, f.srv, &models.Attachment{
+		WorkspaceID: f.wsID,
+		ItemID:      itemID,
+		Filename:    "screenshot.png",
+	}, makeIntegrationPNG(t, 2000, 1500)).ID
+}
+
+// assertNoVariants fails if any spec produced a row.
+func assertNoVariants(t *testing.T, srv *Server, parentID string) {
+	t.Helper()
+	for _, variant := range []string{models.AttachmentVariantThumbSm, models.AttachmentVariantThumbMd} {
+		row, err := variantRow(t, srv, parentID, variant)
+		if err != nil {
+			t.Fatalf("GetAttachmentVariant(%s): %v", variant, err)
+		}
+		if row != nil {
+			t.Errorf("variant %q was derived; derivation should have been skipped", variant)
+		}
+	}
+}
+
+// assertVariants fails unless every spec produced a row. This is the control
+// that keeps the skip tests honest: same fixture, same bytes, live parent.
+func assertVariants(t *testing.T, srv *Server, parentID string) {
+	t.Helper()
+	for _, variant := range []string{models.AttachmentVariantThumbSm, models.AttachmentVariantThumbMd} {
+		row, err := variantRow(t, srv, parentID, variant)
+		if err != nil {
+			t.Fatalf("GetAttachmentVariant(%s): %v", variant, err)
+		}
+		if row == nil {
+			t.Fatalf("variant %q missing; the fixture does not derive at all, "+
+				"so the skip assertions elsewhere in this file prove nothing", variant)
+		}
+	}
+}
+
+// TestThumbnails_DerivedForLiveParentItem is the control. It shares the
+// fixture and the source bytes with the skip tests below, so if this one
+// fails they stop being evidence.
+func TestThumbnails_DerivedForLiveParentItem(t *testing.T) {
+	f := newDerivationFixture(t)
+	attID := f.attachTo(t, &f.itemID)
+
+	f.srv.deriveThumbnails(attID)
+
+	assertVariants(t, f.srv, attID)
+}
+
+// TestThumbnails_SkippedForArchivedParentItem — the sequential DR-14 case.
+// The item is soft-deleted before derivation runs, so the variants would be
+// quota-counted bytes that the blob path (DR-13) refuses to serve.
+func TestThumbnails_SkippedForArchivedParentItem(t *testing.T) {
+	f := newDerivationFixture(t)
+	attID := f.attachTo(t, &f.itemID)
+
+	if err := f.srv.store.DeleteItem(f.itemID); err != nil {
+		t.Fatalf("DeleteItem: %v", err)
+	}
+	// Sanity: DeleteItem must be a SOFT delete, or this test would be
+	// asserting the wrong mechanism.
+	item, err := f.srv.store.GetItemIncludeDeleted(f.itemID)
+	if err != nil {
+		t.Fatalf("GetItemIncludeDeleted: %v", err)
+	}
+	if item == nil || item.DeletedAt == nil {
+		t.Fatalf("item is not soft-deleted after DeleteItem: %+v", item)
+	}
+
+	f.srv.deriveThumbnails(attID)
+
+	assertNoVariants(t, f.srv, attID)
+}
+
+// TestThumbnails_SkippedForUnresolvableParentItem — a malformed item_id that
+// names no item at all. attachments.item_id carries no FK, so this shape is
+// representable until PLAN-2397's repair lands.
+func TestThumbnails_SkippedForUnresolvableParentItem(t *testing.T) {
+	f := newDerivationFixture(t)
+	ghost := "00000000-0000-0000-0000-0000000000ff"
+	attID := f.attachTo(t, &ghost)
+
+	f.srv.deriveThumbnails(attID)
+
+	assertNoVariants(t, f.srv, attID)
+}
+
+// TestThumbnails_SkippedForForeignWorkspaceParentItem — a malformed item_id
+// that resolves, but to an item in ANOTHER workspace. Resolution alone would
+// pass; only the workspace-identity half of the check catches it.
+func TestThumbnails_SkippedForForeignWorkspaceParentItem(t *testing.T) {
+	f := newDerivationFixture(t)
+
+	other, err := f.srv.store.CreateWorkspace(models.WorkspaceCreate{Name: "Elsewhere"})
+	if err != nil {
+		t.Fatalf("CreateWorkspace other: %v", err)
+	}
+	otherCol, err := f.srv.store.CreateCollection(other.ID, models.CollectionCreate{
+		Name: "Tasks", Schema: `{"fields":[]}`,
+	})
+	if err != nil {
+		t.Fatalf("CreateCollection other: %v", err)
+	}
+	otherItem, err := f.srv.store.CreateItem(other.ID, otherCol.ID, models.ItemCreate{
+		Title: "Foreign", Fields: `{}`,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem other: %v", err)
+	}
+
+	attID := f.attachTo(t, &otherItem.ID)
+
+	f.srv.deriveThumbnails(attID)
+
+	assertNoVariants(t, f.srv, attID)
+}
+
+// TestThumbnails_DerivedForOrphanAttachment — an orphan row (item_id NULL)
+// has no item to check, so derivation must still run. Guards against the
+// skip being implemented as "no live item ⇒ skip".
+func TestThumbnails_DerivedForOrphanAttachment(t *testing.T) {
+	f := newDerivationFixture(t)
+	attID := f.attachTo(t, nil)
+
+	f.srv.deriveThumbnails(attID)
+
+	assertVariants(t, f.srv, attID)
+}

--- a/internal/server/handlers_attachments_thumbnails_test.go
+++ b/internal/server/handlers_attachments_thumbnails_test.go
@@ -18,6 +18,23 @@ import (
 	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
+// variantRow looks up a derived variant of parentID. GetAttachmentVariant is
+// workspace-scoped (PLAN-2391 DR-16), so the scope is read back off the
+// parent row rather than threaded through every call site — these tests care
+// about derivation behaviour, not about the scope itself, which
+// TestDownload_ForeignVariantIsNotServed pins directly.
+func variantRow(t *testing.T, srv *Server, parentID, variant string) (*models.Attachment, error) {
+	t.Helper()
+	parent, err := srv.store.GetAttachment(parentID)
+	if err != nil {
+		t.Fatalf("GetAttachment(%s): %v", parentID, err)
+	}
+	if parent == nil {
+		t.Fatalf("GetAttachment(%s): parent row missing", parentID)
+	}
+	return srv.store.GetAttachmentVariant(parent.WorkspaceID, parentID, variant)
+}
+
 // makeIntegrationPNG returns a real PNG large enough that both
 // thumb-sm (256px) and thumb-md (1024px) variants must scale down.
 // Filled with a stripe pattern so the encoder doesn't reduce it to a
@@ -81,7 +98,7 @@ func TestThumbnails_GeneratedOnPNGUpload(t *testing.T) {
 	srv.Stop()
 
 	for _, variant := range []string{models.AttachmentVariantThumbSm, models.AttachmentVariantThumbMd} {
-		row, err := srv.store.GetAttachmentVariant(resp.ID, variant)
+		row, err := variantRow(t, srv, resp.ID, variant)
 		if err != nil {
 			t.Fatalf("GetAttachmentVariant(%s): %v", variant, err)
 		}
@@ -140,7 +157,7 @@ func TestThumbnails_GeneratedOnJPEGUpload(t *testing.T) {
 	_ = json.Unmarshal(rr.Body.Bytes(), &resp)
 
 	srv.Stop()
-	row, err := srv.store.GetAttachmentVariant(resp.ID, models.AttachmentVariantThumbSm)
+	row, err := variantRow(t, srv, resp.ID, models.AttachmentVariantThumbSm)
 	if err != nil || row == nil {
 		t.Fatalf("thumb-sm missing: row=%v err=%v", row, err)
 	}
@@ -167,7 +184,7 @@ func TestThumbnails_SkippedForSmallSourceImage(t *testing.T) {
 
 	srv.Stop()
 	for _, variant := range []string{models.AttachmentVariantThumbSm, models.AttachmentVariantThumbMd} {
-		if row, _ := srv.store.GetAttachmentVariant(resp.ID, variant); row != nil {
+		if row, _ := variantRow(t, srv, resp.ID, variant); row != nil {
 			t.Errorf("variant %q should be skipped for small source, got row %s", variant, row.ID)
 		}
 	}

--- a/internal/server/handlers_attachments_transform.go
+++ b/internal/server/handlers_attachments_transform.go
@@ -163,32 +163,23 @@ func (s *Server) handleTransformAttachment(w http.ResponseWriter, r *http.Reques
 
 	// Item-level authorization, before the source blob is read and before
 	// any work is done. See the ordering note on the handler.
-	if parent.ItemID != nil {
-		// GetItem, not GetItemIncludeDeleted (DR-13): an archived parent
-		// resolves to nil and the transform is refused.
-		item, err := s.store.GetItem(*parent.ItemID)
-		if err != nil {
-			writeInternalError(w, err)
-			return
-		}
-		// Workspace identity FIRST. attachments.item_id has no FK or
-		// same-workspace constraint, so a row here can name an item in
-		// another workspace, and neither check below catches that on its
-		// own: checkItemVisible admits any collection id for an
-		// unrestricted caller, and requireEditPermission's grant lookup
-		// matches by item id. Without this guard a grant on a foreign item
-		// would authorize transforming THIS workspace's bytes. It also
-		// rejects a malformed non-null item_id that resolves nowhere.
-		if item == nil || item.WorkspaceID != workspaceID {
-			writeAttachmentNotFound(w)
-			return
-		}
+	// includeArchived=false (DR-13): an archived parent reports Gone and the
+	// transform is refused. Foreign and dangling item_ids are refused by the
+	// same switch — the helper separates those outcomes, this handler
+	// deliberately collapses them into one response.
+	item, parentOutcome, err := s.resolveAttachmentParentItem(parent, false)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	switch parentOutcome {
+	case attachmentParentOK:
 		// checkItemVisible (the predicate), not requireItemVisible — the
 		// latter writes its own "Item not found" body, which would make a
 		// visibility denial distinguishable from a lookup miss.
-		visible, err := s.checkItemVisible(workspaceID, item, currentUser(r), workspaceRole(r), isBearerAuth(r))
-		if err != nil {
-			writeInternalError(w, err)
+		visible, vErr := s.checkItemVisible(workspaceID, item, currentUser(r), workspaceRole(r), isBearerAuth(r))
+		if vErr != nil {
+			writeInternalError(w, vErr)
 			return
 		}
 		if !visible {
@@ -201,7 +192,7 @@ func (s *Server) handleTransformAttachment(w http.ResponseWriter, r *http.Reques
 		if !s.requireEditPermission(w, r, workspaceID, item.ID, item.CollectionID) {
 			return
 		}
-	} else {
+	case attachmentParentOrphan:
 		// Orphan rows keep the flat workspace editor gate — no item to
 		// authorize against. The viewer predicate runs first, and denies
 		// with the shared 404: the row has already been loaded here, so a
@@ -213,24 +204,25 @@ func (s *Server) handleTransformAttachment(w http.ResponseWriter, r *http.Reques
 			writeAttachmentNotFound(w)
 			return
 		}
-		// ...and, like the DELETE path (PLAN-2382 DR-4), full-access only.
-		// An orphan belongs to no collection, so collection visibility
-		// cannot gate it — and the storage LISTING already hides orphans
-		// from restricted members (handlers_storage.go). Without this a
-		// restricted editor who guesses an orphan's UUID gets confirmation
-		// it exists plus a derived row, which is the same disclosure this
-		// task closes for item-bound rows. Ahead of the editor gate so a
-		// restricted caller never gets the 403 that would confirm it.
-		if fullCollIDs, grantedItemIDs, gErr := s.guestResourceFilter(r, workspaceID); gErr != nil {
-			writeInternalError(w, gErr)
+		// ...and, like the read and DELETE paths (PLAN-2382 DR-4),
+		// full-access only. See attachmentCallerIsRestricted for why.
+		// Ahead of the editor gate so a restricted caller never gets the
+		// 403 that would confirm the row exists.
+		restricted, rErr := s.attachmentCallerIsRestricted(r, workspaceID)
+		if rErr != nil {
+			writeInternalError(w, rErr)
 			return
-		} else if fullCollIDs != nil || grantedItemIDs != nil {
+		}
+		if restricted {
 			writeAttachmentNotFound(w)
 			return
 		}
 		if !requireMinRole(w, r, "editor") {
 			return
 		}
+	default: // Gone, Foreign
+		writeAttachmentNotFound(w)
+		return
 	}
 
 	var req transformRequest

--- a/internal/server/handlers_attachments_transform.go
+++ b/internal/server/handlers_attachments_transform.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/PerpetualSoftware/pad/internal/attachments"
 	"github.com/PerpetualSoftware/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/store"
 )
 
 // transformRequest is the body shape for POST /transform. Operation
@@ -62,10 +63,13 @@ type transformResponse struct {
 // Phase 1 supports two operations: "rotate" (TASK-879) and "crop"
 // (TASK-880). Both follow the same flow:
 //
-//  1. Auth: editor+ on the workspace.
+//  1. Reject if attachment storage or the image processor isn't wired
+//     (a libvips build that hasn't shipped Phase 2 yet, or a self-host
+//     that opted out). These are build/config facts, so they answer
+//     ahead of everything data-dependent — see the note at the checks.
 //  2. Load the parent attachment row (cross-workspace = 404).
-//  3. Reject if no image processor is wired (libvips build that
-//     hasn't shipped Phase 2 yet, or a self-host that opted out).
+//  3. Auth: item visibility, then grant-aware edit permission on the
+//     parent item — see the authorization note below.
 //  4. Decode the original — defends against unsupported MIMEs and
 //     oversized inputs via the processor's Decode rules.
 //  5. Apply the operation. Each op validates its own params.
@@ -76,19 +80,58 @@ type transformResponse struct {
 //     so identical transforms collapse onto the same blob).
 //  8. Insert a NEW attachments row owned by the same workspace /
 //     uploaded_by / item as the parent. The original is left in
-//     place — orphan GC reclaims it past the grace period
-//     (TASK-886) once the editor swaps its reference.
+//     place, and whether it is ever reclaimed depends on the branch.
+//     The orphan GC selects rows that are soft-deleted OR have
+//     item_id IS NULL past the grace period (store.OrphanedAttachments):
+//     an ORPHAN original stays GC-eligible, but an ITEM-BOUND one does
+//     not — the editor swapping its node's UUID does not touch that
+//     row, which remains live and item-bound, so the pre-rotate blob
+//     survives until someone deletes it explicitly. Pre-existing
+//     (TASK-886 era) and unchanged here; recorded because the comment
+//     used to claim GC reclaimed it unconditionally.
 //  9. Return the new row's ID/URL/dimensions so the editor can
 //     update its node attrs without a follow-up GET.
+//
+// Authorization (PLAN-2391 DR-10/DR-14). The handler used to open with a
+// flat requireMinRole("editor") and never look at the attachment's parent
+// item at all, so a member whose collection access excluded that item could
+// transform its attachment given only the attachment id — reading the source
+// blob and getting back output metadata for an item they cannot see. The
+// order now mirrors the blob read path exactly:
+//
+//	load the attachment -> workspace identity -> load the parent item ->
+//	parent workspace identity -> item visibility -> edit permission
+//
+// Every denial in that chain goes through writeAttachmentNotFound, so
+// "no such attachment", "foreign parent", "archived parent" and "parent not
+// visible to you" are byte-identical; a distinguishable code or message
+// would be an existence oracle.
+//
+// Edit permission is requireEditPermission, not the flat editor role: an
+// item- or collection-grant editor can already ATTACH to the item
+// (BUG-1661, handleUploadAttachment), so refusing them a rotate on what
+// they uploaded would be an inconsistency, not a boundary. Orphan rows carry
+// no item context to authorize against, so they keep the flat editor gate
+// AND — matching the DELETE path — require unrestricted workspace access:
+// a restricted member cannot see orphans in the storage listing, so they
+// must not be able to transform one either.
+//
+// The parent item is loaded with GetItem, not GetItemIncludeDeleted, so an
+// archived parent 404s here the same way it does on the read path (DR-13).
+// That check is point-in-time; the enforcement that actually holds is the
+// item lock CreateAttachmentForLiveItem takes around the insert (DR-14).
 func (s *Server) handleTransformAttachment(w http.ResponseWriter, r *http.Request) {
-	if !requireMinRole(w, r, "editor") {
-		return
-	}
 	if s.attachments == nil {
 		writeError(w, http.StatusServiceUnavailable, "attachments_disabled",
 			"Attachment storage is not configured on this server")
 		return
 	}
+	// The two 503s stay ahead of the authorization chain even though the
+	// role gate no longer precedes them. They describe the server BUILD, not
+	// this workspace's data: the answer is the same for every caller and
+	// every attachment id, so they distinguish nothing an authorized-vs-not
+	// caller could learn. Everything below this point is data-dependent and
+	// is ordered accordingly.
 	if s.imageProcessor == nil {
 		writeError(w, http.StatusServiceUnavailable, "image_processor_disabled",
 			"Image transformation is not available on this build (the libvips backend has not shipped yet)")
@@ -114,8 +157,80 @@ func (s *Server) handleTransformAttachment(w http.ResponseWriter, r *http.Reques
 	// 403 vs 404 here would let a member of workspace B enumerate
 	// attachment IDs in workspace A.
 	if parent == nil || parent.WorkspaceID != workspaceID || parent.DeletedAt != nil {
-		writeError(w, http.StatusNotFound, "not_found", "Attachment not found")
+		writeAttachmentNotFound(w)
 		return
+	}
+
+	// Item-level authorization, before the source blob is read and before
+	// any work is done. See the ordering note on the handler.
+	if parent.ItemID != nil {
+		// GetItem, not GetItemIncludeDeleted (DR-13): an archived parent
+		// resolves to nil and the transform is refused.
+		item, err := s.store.GetItem(*parent.ItemID)
+		if err != nil {
+			writeInternalError(w, err)
+			return
+		}
+		// Workspace identity FIRST. attachments.item_id has no FK or
+		// same-workspace constraint, so a row here can name an item in
+		// another workspace, and neither check below catches that on its
+		// own: checkItemVisible admits any collection id for an
+		// unrestricted caller, and requireEditPermission's grant lookup
+		// matches by item id. Without this guard a grant on a foreign item
+		// would authorize transforming THIS workspace's bytes. It also
+		// rejects a malformed non-null item_id that resolves nowhere.
+		if item == nil || item.WorkspaceID != workspaceID {
+			writeAttachmentNotFound(w)
+			return
+		}
+		// checkItemVisible (the predicate), not requireItemVisible — the
+		// latter writes its own "Item not found" body, which would make a
+		// visibility denial distinguishable from a lookup miss.
+		visible, err := s.checkItemVisible(workspaceID, item, currentUser(r), workspaceRole(r), isBearerAuth(r))
+		if err != nil {
+			writeInternalError(w, err)
+			return
+		}
+		if !visible {
+			writeAttachmentNotFound(w)
+			return
+		}
+		// Only now the permission check. A 403 past this point is safe:
+		// the caller can already see the item and read its attachment's
+		// bytes, so refusing the WRITE reveals nothing about existence.
+		if !s.requireEditPermission(w, r, workspaceID, item.ID, item.CollectionID) {
+			return
+		}
+	} else {
+		// Orphan rows keep the flat workspace editor gate — no item to
+		// authorize against. The viewer predicate runs first, and denies
+		// with the shared 404: the row has already been loaded here, so a
+		// 403 to a caller who cannot even READ an orphan would confirm
+		// that this id names a live orphan in this workspace while a bad
+		// id answers 404. A viewer, who can read orphans, gets the honest
+		// 403 from the editor gate below.
+		if !requireRole(r, "viewer") {
+			writeAttachmentNotFound(w)
+			return
+		}
+		// ...and, like the DELETE path (PLAN-2382 DR-4), full-access only.
+		// An orphan belongs to no collection, so collection visibility
+		// cannot gate it — and the storage LISTING already hides orphans
+		// from restricted members (handlers_storage.go). Without this a
+		// restricted editor who guesses an orphan's UUID gets confirmation
+		// it exists plus a derived row, which is the same disclosure this
+		// task closes for item-bound rows. Ahead of the editor gate so a
+		// restricted caller never gets the 403 that would confirm it.
+		if fullCollIDs, grantedItemIDs, gErr := s.guestResourceFilter(r, workspaceID); gErr != nil {
+			writeInternalError(w, gErr)
+			return
+		} else if fullCollIDs != nil || grantedItemIDs != nil {
+			writeAttachmentNotFound(w)
+			return
+		}
+		if !requireMinRole(w, r, "editor") {
+			return
+		}
 	}
 
 	var req transformRequest
@@ -192,8 +307,10 @@ func (s *Server) handleTransformAttachment(w http.ResponseWriter, r *http.Reques
 
 	// Inherit attribution + item linkage from the parent. The new
 	// row is a peer (NOT a derived/variant row — that's only for
-	// thumbnails) so ParentID and Variant stay nil; the editor
-	// swaps its reference and the original ages into orphan GC.
+	// thumbnails) so ParentID and Variant stay nil; the editor swaps
+	// its reference and — if the parent was an ORPHAN — the original
+	// ages into orphan GC. An item-bound original does not: see step 8
+	// on the handler.
 	//
 	// UploadedBy inherits from the parent — same policy as the
 	// thumbnail pipeline. A user who rotates someone else's upload
@@ -213,7 +330,35 @@ func (s *Server) handleTransformAttachment(w http.ResponseWriter, r *http.Reques
 		Width:       &tw,
 		Height:      &th,
 	}
-	if err := s.store.CreateAttachment(row); err != nil {
+	// CreateAttachmentForLiveItem, not CreateAttachment (PLAN-2391 DR-14).
+	// The parent-item check above is point-in-time: item deletion commits in
+	// its own transaction, and everything between that check and here — the
+	// blob read, decode, transform, encode, Put — is unbounded work, so the
+	// item can be archived mid-flight. The store re-checks the parent under
+	// a row lock inside the insert's transaction, so the row is either
+	// written against a live item or not written at all. Transform is
+	// user-initiated and low volume; the lock is affordable and the window
+	// is not accepted here (thumbnail derivation, TASK-2404, makes the
+	// opposite trade).
+	//
+	// The refusal is the shared 404: the blob it would have produced is
+	// unreadable under DR-13 anyway, and the caller must not be able to
+	// tell "your item was archived just now" from "no such attachment".
+	//
+	// The already-written blob is left on disk. It carries no row, so no
+	// quota is charged for it (usage is derived from live rows) — but note
+	// that the orphan GC walks attachment ROWS, so a rowless blob is not
+	// reclaimed by it either. That is the pre-existing shape of every
+	// Put-then-insert failure window in this codebase (upload and thumbnail
+	// derivation have the same one); this refusal makes it reachable on one
+	// more, rare path rather than introducing it. Deleting the blob here
+	// would be wrong without the GC's dedupe guard: the same content hash
+	// may already back another live row.
+	if err := s.store.CreateAttachmentForLiveItem(row); err != nil {
+		if errors.Is(err, store.ErrAttachmentParentItemGone) {
+			writeAttachmentNotFound(w)
+			return
+		}
 		writeInternalError(w, fmt.Errorf("create transformed row: %w", err))
 		return
 	}

--- a/internal/server/handlers_attachments_transform_authz_test.go
+++ b/internal/server/handlers_attachments_transform_authz_test.go
@@ -1,0 +1,484 @@
+//go:build !libvips
+
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"image"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/PerpetualSoftware/pad/internal/attachments"
+	"github.com/PerpetualSoftware/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/store"
+)
+
+// Transform authorization tests for PLAN-2391 / TASK-2402.
+//
+// handleTransformAttachment used to open with a flat requireMinRole("editor")
+// and never look at the attachment's parent item, so a restricted editor
+// could transform an attachment on an item they cannot see — reading the
+// source blob and getting output metadata plus a new row back. It also
+// checked nothing about the parent at insert time, so an item archived
+// mid-transform still got a quota-counted live attachment whose bytes DR-13
+// then refuses to serve.
+//
+// Coverage: the visibility gate and its byte-identical denials, the foreign
+// and malformed parents, the archived parent (sequential AND raced), the
+// grant-based editor who must still be able to transform, and the orphan
+// row's flat gate.
+
+// transformFixture is one workspace with a hidden collection + item + a
+// transformable attachment, a second visible collection to make restricted
+// access meaningful, and an orphan attachment.
+type transformFixture struct {
+	wsID string
+
+	hiddenColID  string
+	visibleColID string
+	itemID       string
+
+	attID    string
+	orphanID string
+}
+
+func newTransformFixture(t *testing.T, srv *Server) transformFixture {
+	t.Helper()
+
+	ws, err := srv.store.CreateWorkspace(models.WorkspaceCreate{Name: "TransformAuthz"})
+	if err != nil {
+		t.Fatalf("CreateWorkspace: %v", err)
+	}
+	hidden, err := srv.store.CreateCollection(ws.ID, models.CollectionCreate{
+		Name: "Secrets", Schema: `{"fields":[]}`,
+	})
+	if err != nil {
+		t.Fatalf("CreateCollection hidden: %v", err)
+	}
+	visible, err := srv.store.CreateCollection(ws.ID, models.CollectionCreate{
+		Name: "Tasks", Schema: `{"fields":[]}`,
+	})
+	if err != nil {
+		t.Fatalf("CreateCollection visible: %v", err)
+	}
+	item, err := srv.store.CreateItem(ws.ID, hidden.ID, models.ItemCreate{
+		Title: "Hidden", Fields: `{}`,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem: %v", err)
+	}
+
+	f := transformFixture{
+		wsID:         ws.ID,
+		hiddenColID:  hidden.ID,
+		visibleColID: visible.ID,
+		itemID:       item.ID,
+	}
+	f.attID = putBlob(t, srv, &models.Attachment{
+		WorkspaceID: ws.ID, ItemID: &item.ID, Filename: "shot.png",
+	}, makeIntegrationPNG(t, 20, 10)).ID
+	f.orphanID = putBlob(t, srv, &models.Attachment{
+		WorkspaceID: ws.ID, Filename: "orphan.png",
+	}, makeIntegrationPNG(t, 20, 10)).ID
+	return f
+}
+
+// transformAs POSTs a rotate as a specific user + workspace role, bypassing
+// the auth middleware the same way downloadAs does.
+func transformAs(srv *Server, wsID, attachmentID string, user *models.User, role string) *httptest.ResponseRecorder {
+	body, _ := json.Marshal(transformRequestBody{Operation: "rotate", Degrees: 90})
+	req := httptest.NewRequest(http.MethodPost,
+		"/api/v1/workspaces/x/attachments/"+attachmentID+"/transform", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.RemoteAddr = "127.0.0.1:1234"
+
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("slug", "x")
+	rctx.URLParams.Add("attachmentID", attachmentID)
+
+	ctx := req.Context()
+	ctx = context.WithValue(ctx, ctxResolvedWorkspaceID, wsID)
+	ctx = context.WithValue(ctx, ctxCurrentUser, user)
+	ctx = context.WithValue(ctx, ctxWorkspaceRole, role)
+	ctx = context.WithValue(ctx, chi.RouteCtxKey, rctx)
+	req = req.WithContext(ctx)
+
+	rr := httptest.NewRecorder()
+	srv.handleTransformAttachment(rr, req)
+	return rr
+}
+
+// assertTransformDenied pins the shared denial: 404 with the exact body every
+// other attachment denial writes.
+func assertTransformDenied(t *testing.T, rr *httptest.ResponseRecorder, label string) {
+	t.Helper()
+	if rr.Code == http.StatusForbidden {
+		t.Fatalf("%s: got 403 — that confirms the attachment exists", label)
+	}
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("%s: status = %d, want 404; body = %s", label, rr.Code, rr.Body.String())
+	}
+}
+
+// liveAttachmentCount counts the workspace's live, non-derived attachment
+// rows — the quota-counted surface a refused transform must not grow.
+func liveAttachmentCount(t *testing.T, srv *Server, wsID string) int {
+	t.Helper()
+	_, total, err := srv.store.WorkspaceAttachments(wsID, store.AttachmentListFilters{})
+	if err != nil {
+		t.Fatalf("WorkspaceAttachments: %v", err)
+	}
+	return total
+}
+
+// TestTransform_InvisibleItemIs404 is the core TASK-2402 regression: a
+// workspace EDITOR whose collection access excludes the parent item must not
+// be able to transform its attachment, and the denial must be
+// indistinguishable from a plain lookup miss.
+//
+// The actor is a full editor, not a guest — a guest would be denied by any
+// role gate, so the test would pass with the visibility check deleted and
+// prove nothing.
+func TestTransform_InvisibleItemIs404(t *testing.T) {
+	srv, _ := testServerWithAttachments(t)
+	defer srv.Stop()
+	f := newTransformFixture(t, srv)
+
+	restricted := mkUser(t, srv, "restricted-editor@test.com")
+	if err := srv.store.AddWorkspaceMember(f.wsID, restricted.ID, "editor"); err != nil {
+		t.Fatalf("AddWorkspaceMember: %v", err)
+	}
+	// Access to the OTHER collection only — the parent item is invisible.
+	if err := srv.store.SetMemberCollectionAccess(f.wsID, restricted.ID, "specific",
+		[]string{f.visibleColID}); err != nil {
+		t.Fatalf("SetMemberCollectionAccess: %v", err)
+	}
+
+	before := liveAttachmentCount(t, srv, f.wsID)
+
+	denied := transformAs(srv, f.wsID, f.attID, restricted, "editor")
+	assertTransformDenied(t, denied, "restricted editor, invisible item")
+
+	// Byte-identical to a lookup miss: a distinguishable code or message
+	// would turn the response into an existence oracle for attachment ids.
+	missing := transformAs(srv, f.wsID, "00000000-0000-0000-0000-000000000000", restricted, "editor")
+	assertTransformDenied(t, missing, "nonexistent attachment")
+	if got, want := denied.Body.String(), missing.Body.String(); got != want {
+		t.Errorf("visibility denial body = %q, lookup-miss body = %q — must be byte-identical", got, want)
+	}
+
+	if after := liveAttachmentCount(t, srv, f.wsID); after != before {
+		t.Errorf("live attachment rows = %d, want %d — the refused transform still wrote a row", after, before)
+	}
+}
+
+// TestTransform_UnrestrictedEditorStillWorks — the gate replaced a role check
+// with visibility + edit permission; the ordinary case must be unaffected.
+func TestTransform_UnrestrictedEditorStillWorks(t *testing.T) {
+	srv, _ := testServerWithAttachments(t)
+	defer srv.Stop()
+	f := newTransformFixture(t, srv)
+
+	editor := mkUser(t, srv, "plain-editor@test.com")
+	if err := srv.store.AddWorkspaceMember(f.wsID, editor.ID, "editor"); err != nil {
+		t.Fatalf("AddWorkspaceMember: %v", err)
+	}
+
+	rr := transformAs(srv, f.wsID, f.attID, editor, "editor")
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("unrestricted editor transform: status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+}
+
+// TestTransform_ItemGrantEditorCanTransform pins the deliberate widening: the
+// gate is requireEditPermission, not the flat editor role, so a guest holding
+// an item EDIT grant — who can already attach to that item (BUG-1661) — can
+// rotate what they uploaded. A view-only grant must not be enough.
+func TestTransform_ItemGrantEditorCanTransform(t *testing.T) {
+	srv, _ := testServerWithAttachments(t)
+	defer srv.Stop()
+	f := newTransformFixture(t, srv)
+
+	viewer := mkUser(t, srv, "grant-viewer@test.com")
+	if _, err := srv.store.CreateItemGrant(f.wsID, f.itemID, viewer.ID, "view", viewer.ID); err != nil {
+		t.Fatalf("CreateItemGrant view: %v", err)
+	}
+	rr := transformAs(srv, f.wsID, f.attID, viewer, "guest")
+	if rr.Code != http.StatusForbidden {
+		t.Errorf("view-grant guest: status = %d, want 403 (visible but not editable)", rr.Code)
+	}
+
+	editor := mkUser(t, srv, "grant-editor@test.com")
+	if _, err := srv.store.CreateItemGrant(f.wsID, f.itemID, editor.ID, "edit", editor.ID); err != nil {
+		t.Fatalf("CreateItemGrant edit: %v", err)
+	}
+	rr = transformAs(srv, f.wsID, f.attID, editor, "guest")
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("edit-grant guest: status = %d, want 201; body = %s", rr.Code, rr.Body.String())
+	}
+}
+
+// TestTransform_ForeignItemParentIs404 — attachments.item_id has no
+// same-workspace constraint, so a row in workspace A can name an item in B. A
+// grant in B must not authorize transforming A's bytes.
+func TestTransform_ForeignItemParentIs404(t *testing.T) {
+	srv, _ := testServerWithAttachments(t)
+	defer srv.Stop()
+	b := newTransformFixture(t, srv)
+
+	wsA, err := srv.store.CreateWorkspace(models.WorkspaceCreate{Name: "TransformVictim"})
+	if err != nil {
+		t.Fatalf("CreateWorkspace A: %v", err)
+	}
+	crossed := putBlob(t, srv, &models.Attachment{
+		WorkspaceID: wsA.ID,
+		ItemID:      &b.itemID, // foreign parent — the whole point
+		Filename:    "crossed.png",
+	}, makeIntegrationPNG(t, 20, 10))
+
+	attacker := mkUser(t, srv, "cross-ws-transform@test.com")
+	// Full, UNRESTRICTED editor in A: without this the caller is restricted
+	// in A and checkItemVisible denies on its own, so the test would pass
+	// with the workspace-identity guard deleted.
+	if err := srv.store.AddWorkspaceMember(wsA.ID, attacker.ID, "editor"); err != nil {
+		t.Fatalf("AddWorkspaceMember A: %v", err)
+	}
+	// ...plus a real edit grant on the B item the crossed row names.
+	if _, err := srv.store.CreateItemGrant(b.wsID, b.itemID, attacker.ID, "edit", attacker.ID); err != nil {
+		t.Fatalf("CreateItemGrant B: %v", err)
+	}
+
+	rr := transformAs(srv, wsA.ID, crossed.ID, attacker, "editor")
+	assertTransformDenied(t, rr, "foreign parent item")
+}
+
+// TestTransform_MalformedParentIs404 — a non-null item_id that resolves to
+// nothing at all is rejected too, not silently treated as an orphan.
+func TestTransform_MalformedParentIs404(t *testing.T) {
+	srv, _ := testServerWithAttachments(t)
+	defer srv.Stop()
+	f := newTransformFixture(t, srv)
+
+	ghost := "00000000-0000-0000-0000-0000000000ff"
+	malformed := putBlob(t, srv, &models.Attachment{
+		WorkspaceID: f.wsID, ItemID: &ghost, Filename: "malformed.png",
+	}, makeIntegrationPNG(t, 20, 10))
+
+	owner := mkUser(t, srv, "malformed-owner@test.com")
+	if err := srv.store.AddWorkspaceMember(f.wsID, owner.ID, "owner"); err != nil {
+		t.Fatalf("AddWorkspaceMember: %v", err)
+	}
+
+	before := liveAttachmentCount(t, srv, f.wsID)
+	rr := transformAs(srv, f.wsID, malformed.ID, owner, "owner")
+	assertTransformDenied(t, rr, "malformed non-null parent")
+	if after := liveAttachmentCount(t, srv, f.wsID); after != before {
+		t.Errorf("live attachment rows = %d, want %d", after, before)
+	}
+}
+
+// TestTransform_SoftDeletedParentIs404 — DR-14's sequential half. Archiving
+// the item takes its attachments out of the transform surface, so no quota is
+// burned producing bytes DR-13 refuses to serve.
+func TestTransform_SoftDeletedParentIs404(t *testing.T) {
+	srv, _ := testServerWithAttachments(t)
+	defer srv.Stop()
+	f := newTransformFixture(t, srv)
+
+	owner := mkUser(t, srv, "transform-archive-owner@test.com")
+	if err := srv.store.AddWorkspaceMember(f.wsID, owner.ID, "owner"); err != nil {
+		t.Fatalf("AddWorkspaceMember: %v", err)
+	}
+
+	// Transformable before the archive, so the post-archive 404 can't be
+	// explained by an unrelated denial.
+	rr := transformAs(srv, f.wsID, f.attID, owner, "owner")
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("pre-archive transform: status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+
+	if err := srv.store.DeleteItem(f.itemID); err != nil {
+		t.Fatalf("DeleteItem: %v", err)
+	}
+
+	before := liveAttachmentCount(t, srv, f.wsID)
+	rr = transformAs(srv, f.wsID, f.attID, owner, "owner")
+	assertTransformDenied(t, rr, "soft-deleted parent")
+	if after := liveAttachmentCount(t, srv, f.wsID); after != before {
+		t.Errorf("live attachment rows = %d, want %d", after, before)
+	}
+}
+
+// hookedProcessor runs fn inside Encode, once, and ONLY while armed. Encode
+// sits between the handler's up-front parent check and its insert, so an armed
+// hook is a deterministic harness for the check-then-work window DR-14
+// describes.
+//
+// Arming is not ceremony. The fixture's upload spawns background thumbnail
+// derivation, which calls Encode too — an unconditional sync.Once fires on
+// whichever Encode wins, and under load that is the derivation goroutine. The
+// hook then archives the item on a thread the test is not synchronised with,
+// leaving the transform to run start-to-finish against a still-live row: a
+// 201, a green SQLite run, and an intermittent Postgres failure whose message
+// points at the production fix rather than at the harness. Arm immediately
+// before the request under test so only the transform's own Encode can fire.
+type hookedProcessor struct {
+	attachments.Processor
+	mu    sync.Mutex
+	armed bool
+	fired bool
+	fn    func()
+}
+
+// arm allows the next Encode to fire fn. Call it directly before the request
+// whose window is under test.
+func (p *hookedProcessor) arm() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.armed = true
+}
+
+// didFire reports whether fn ran, under the same lock that sets it, so the
+// assertion is not a data race against a background derivation goroutine.
+func (p *hookedProcessor) didFire() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.fired
+}
+
+func (p *hookedProcessor) Encode(img image.Image, format string, w io.Writer) error {
+	p.mu.Lock()
+	run := p.armed && !p.fired
+	if run {
+		p.fired = true
+	}
+	p.mu.Unlock()
+	if run {
+		p.fn()
+	}
+	return p.Processor.Encode(img, format, w)
+}
+
+// TestTransform_ParentArchivedMidFlightWritesNoRow is the raced half of
+// DR-14, and the reason the insert takes an item lock rather than trusting
+// the up-front check.
+//
+// The item is archived DURING the transform — after the handler validated the
+// parent, before it inserts. Without the re-check inside the write, the
+// handler inserts a live, quota-counted attachment row hanging off an already
+// archived item, whose bytes the read gate then refuses to serve.
+func TestTransform_ParentArchivedMidFlightWritesNoRow(t *testing.T) {
+	srv, _ := testServerWithAttachments(t)
+	defer srv.Stop()
+	f := newTransformFixture(t, srv)
+
+	owner := mkUser(t, srv, "midflight-owner@test.com")
+	if err := srv.store.AddWorkspaceMember(f.wsID, owner.ID, "owner"); err != nil {
+		t.Fatalf("AddWorkspaceMember: %v", err)
+	}
+
+	var archiveMu sync.Mutex
+	var archiveErr error
+	hook := &hookedProcessor{
+		Processor: attachments.NewProcessor(),
+		fn: func() {
+			archiveMu.Lock()
+			defer archiveMu.Unlock()
+			archiveErr = srv.store.DeleteItem(f.itemID)
+		},
+	}
+	srv.SetImageProcessor(hook)
+
+	before := liveAttachmentCount(t, srv, f.wsID)
+	// Arm only now, so the fixture's background thumbnail derivation cannot
+	// consume the hook and archive the item on a thread this test is not
+	// synchronised with. fn runs synchronously inside the transform's own
+	// Encode, so archiveErr is settled by the time the request returns.
+	hook.arm()
+	rr := transformAs(srv, f.wsID, f.attID, owner, "owner")
+	archiveMu.Lock()
+	deleteErr := archiveErr
+	archiveMu.Unlock()
+	if deleteErr != nil {
+		t.Fatalf("mid-flight DeleteItem: %v", deleteErr)
+	}
+	// Without this the test passes vacuously: any earlier 404 — a broken
+	// fixture, a denial from the gate above — would satisfy the assertions
+	// below while the mid-flight window was never entered at all.
+	if !hook.didFire() {
+		t.Fatal("the archive hook never ran — the request was refused before Encode, " +
+			"so this exercised the up-front check rather than the mid-flight window")
+	}
+	assertTransformDenied(t, rr, "parent archived mid-transform")
+
+	if after := liveAttachmentCount(t, srv, f.wsID); after != before {
+		t.Errorf("live attachment rows = %d, want %d — the transform inserted a row "+
+			"against an item archived while it ran", after, before)
+	}
+}
+
+// TestTransform_OrphanKeepsFlatEditorGate — an orphan carries no item context
+// to authorize against, so it keeps the flat workspace editor gate.
+//
+// A caller below viewer gets the shared 404, not a 403: the row is loaded
+// before the role check now, so a 403 would confirm that this id names a live
+// orphan here while a bad id answers 404. A viewer, who can already READ
+// orphans, gets the honest 403.
+func TestTransform_OrphanKeepsFlatEditorGate(t *testing.T) {
+	srv, _ := testServerWithAttachments(t)
+	defer srv.Stop()
+	f := newTransformFixture(t, srv)
+
+	guest := mkUser(t, srv, "orphan-transform-guest@test.com")
+	if _, err := srv.store.CreateItemGrant(f.wsID, f.itemID, guest.ID, "edit", guest.ID); err != nil {
+		t.Fatalf("CreateItemGrant: %v", err)
+	}
+	denied := transformAs(srv, f.wsID, f.orphanID, guest, "guest")
+	assertTransformDenied(t, denied, "orphan as grant-only guest")
+	missing := transformAs(srv, f.wsID, "00000000-0000-0000-0000-000000000000", guest, "guest")
+	assertTransformDenied(t, missing, "nonexistent attachment as guest")
+	if got, want := denied.Body.String(), missing.Body.String(); got != want {
+		t.Errorf("orphan denial body = %q, lookup-miss body = %q — must be byte-identical", got, want)
+	}
+
+	viewer := mkUser(t, srv, "orphan-transform-viewer@test.com")
+	if err := srv.store.AddWorkspaceMember(f.wsID, viewer.ID, "viewer"); err != nil {
+		t.Fatalf("AddWorkspaceMember viewer: %v", err)
+	}
+	if rr := transformAs(srv, f.wsID, f.orphanID, viewer, "viewer"); rr.Code != http.StatusForbidden {
+		t.Errorf("orphan as viewer: status = %d, want 403", rr.Code)
+	}
+
+	// A RESTRICTED editor is refused with the shared 404, matching the
+	// DELETE path: the storage listing hides orphans from them, so the
+	// transform must not confirm one exists.
+	restricted := mkUser(t, srv, "orphan-transform-restricted@test.com")
+	if err := srv.store.AddWorkspaceMember(f.wsID, restricted.ID, "editor"); err != nil {
+		t.Fatalf("AddWorkspaceMember restricted: %v", err)
+	}
+	if err := srv.store.SetMemberCollectionAccess(f.wsID, restricted.ID, "specific",
+		[]string{f.visibleColID}); err != nil {
+		t.Fatalf("SetMemberCollectionAccess: %v", err)
+	}
+	rr := transformAs(srv, f.wsID, f.orphanID, restricted, "editor")
+	assertTransformDenied(t, rr, "orphan as restricted editor")
+	if got, want := rr.Body.String(), missing.Body.String(); got != want {
+		t.Errorf("restricted-editor orphan denial body = %q, lookup-miss body = %q — "+
+			"must be byte-identical", got, want)
+	}
+
+	editor := mkUser(t, srv, "orphan-transform-editor@test.com")
+	if err := srv.store.AddWorkspaceMember(f.wsID, editor.ID, "editor"); err != nil {
+		t.Fatalf("AddWorkspaceMember editor: %v", err)
+	}
+	if rr := transformAs(srv, f.wsID, f.orphanID, editor, "editor"); rr.Code != http.StatusCreated {
+		t.Fatalf("orphan as editor: status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+}

--- a/internal/server/handlers_attachments_upload_live_item_test.go
+++ b/internal/server/handlers_attachments_upload_live_item_test.go
@@ -1,0 +1,165 @@
+package server
+
+import (
+	"context"
+	"io"
+	"sync"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/attachments"
+	"github.com/PerpetualSoftware/pad/internal/store"
+)
+
+// Upload-path live-parent tests (PLAN-2391 DR-14).
+//
+// handleUploadAttachment validated the parent item near the top of the
+// handler and inserted the row with plain CreateAttachment at the bottom.
+// Everything in between — spooling the multipart body to a temp file,
+// hashing it, probing dimensions, store.Put — is unbounded work, and item
+// deletion commits in its own transaction, so an item archived during the
+// upload window left a quota-counted live row bound to an archived parent
+// whose bytes the read gate (DR-13) then refuses to serve. The handler now
+// inserts through store.CreateAttachmentForLiveItem, which re-checks the
+// parent under a row lock inside the insert's own transaction.
+//
+// Transform closes the same window the same way. Derivation deliberately
+// does NOT — see the comment on thumbnailParentItemLive.
+
+// archivingStore wraps an AttachmentStore and runs fn inside Put, once, and
+// ONLY while armed. Put is the last thing the upload handler does before the
+// insert, so it is a deterministic harness for the check-then-work window.
+//
+// Armed rather than an unconditional sync.Once for the reason the transform
+// test's Encode hook documents: thumbnail derivation calls Put too, on a
+// background goroutine this test is not synchronised with, and an unarmed
+// hook would fire on whichever Put wins.
+type archivingStore struct {
+	attachments.AttachmentStore
+
+	mu    sync.Mutex
+	armed bool
+	fired bool
+	fn    func()
+}
+
+func (s *archivingStore) arm() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.armed = true
+}
+
+func (s *archivingStore) didFire() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.fired
+}
+
+func (s *archivingStore) Put(ctx context.Context, hash, mime string, r io.Reader) (string, error) {
+	s.mu.Lock()
+	run := s.armed && !s.fired
+	if run {
+		s.fired = true
+		s.armed = false
+	}
+	s.mu.Unlock()
+	if run {
+		s.fn()
+	}
+	return s.AttachmentStore.Put(ctx, hash, mime, r)
+}
+
+// TestUpload_ItemArchivedMidUploadIsRefused drives the window directly: the
+// item is archived from inside store.Put, strictly after the handler's
+// up-front validation and strictly before the insert.
+//
+// The assertion is on the persisted state as much as the status: a row bound
+// to the archived item is exactly the artifact the fix exists to prevent,
+// and it would be unreadable and quota-counted for as long as the item stays
+// archived.
+func TestUpload_ItemArchivedMidUploadIsRefused(t *testing.T) {
+	srv, _ := testServerWithAttachments(t)
+
+	dir := t.TempDir()
+	fs, err := attachments.NewFSStore(dir)
+	if err != nil {
+		t.Fatalf("NewFSStore: %v", err)
+	}
+	slug, item := uploadItemFixture(t, srv, "UploadMidArchive")
+
+	var archiveErr error
+	hooked := &archivingStore{AttachmentStore: fs}
+	hooked.fn = func() { archiveErr = srv.store.DeleteItem(item.ID) }
+
+	reg := attachments.NewRegistry()
+	reg.Register(attachments.FSPrefix, hooked)
+	srv.SetAttachments(reg, 0)
+
+	hooked.arm()
+	rr := uploadChannels(srv, slug, item.ID, "", realPNG())
+
+	if !hooked.didFire() {
+		t.Fatal("the archive hook never ran — the request was refused before store.Put, " +
+			"so this test says nothing about the check-then-work window it exists for")
+	}
+	if archiveErr != nil {
+		t.Fatalf("DeleteItem from the hook: %v", archiveErr)
+	}
+	// Sanity: DeleteItem really is a soft delete, so GetItem resolving to
+	// nil below means "archived" and not "hard gone".
+	if live, gErr := srv.store.GetItemIncludeDeleted(item.ID); gErr != nil || live == nil {
+		t.Fatalf("GetItemIncludeDeleted after archive: item=%v err=%v — the hook did "+
+			"something other than a soft delete", live, gErr)
+	}
+
+	if rr.Code != 404 {
+		t.Fatalf("upload against an item archived mid-flight: status = %d, want 404; body = %s",
+			rr.Code, rr.Body.String())
+	}
+	// ...and byte-identical to every other attachment denial: the caller must
+	// not be able to tell "your item was archived just now" from anything else.
+	if got, want := rr.Body.String(),
+		`{"error":{"code":"not_found","message":"Attachment not found"}}`+"\n"; got != want {
+		t.Errorf("denial body = %q, want the shared attachment 404 %q", got, want)
+	}
+
+	// The listing deliberately surfaces attachments whose parent item is
+	// soft-deleted (they still consume quota), so a row bound to the archived
+	// item WOULD show up here if one had been written.
+	_, total, lErr := srv.store.WorkspaceAttachments(
+		itemWorkspaceID(t, srv, item.ID), store.AttachmentListFilters{ItemID: item.ID})
+	if lErr != nil {
+		t.Fatalf("WorkspaceAttachments: %v", lErr)
+	}
+	if total != 0 {
+		t.Fatalf("%d attachment row(s) were written against the archived item — the "+
+			"insert must refuse rather than bind to an archived parent", total)
+	}
+}
+
+// TestUpload_LiveItemStillSucceeds is the control for the test above: the
+// same fixture and the same bytes, with no archival, must still produce a row
+// bound to the item. Without it a handler that refused EVERY item-bound
+// upload would pass the refusal assertions vacuously.
+func TestUpload_LiveItemStillSucceeds(t *testing.T) {
+	srv, _ := testServerWithAttachments(t)
+	slug, item := uploadItemFixture(t, srv, "UploadLiveControl")
+
+	rr := uploadChannels(srv, slug, item.ID, "", realPNG())
+	if rr.Code != 201 {
+		t.Fatalf("upload against a live item: status = %d, want 201; body = %s",
+			rr.Code, rr.Body.String())
+	}
+	if got := attachmentItemID(t, srv, uploadedAttachmentID(t, rr)); got != item.ID {
+		t.Errorf("stored item_id = %q, want %q", got, item.ID)
+	}
+}
+
+// itemWorkspaceID resolves an item's workspace, including after a soft delete.
+func itemWorkspaceID(t *testing.T, srv *Server, itemID string) string {
+	t.Helper()
+	item, err := srv.store.GetItemIncludeDeleted(itemID)
+	if err != nil || item == nil {
+		t.Fatalf("GetItemIncludeDeleted(%s): item=%v err=%v", itemID, item, err)
+	}
+	return item.WorkspaceID
+}

--- a/internal/server/handlers_items_copy.go
+++ b/internal/server/handlers_items_copy.go
@@ -342,6 +342,11 @@ func (s *Server) handleCopyItem(w http.ResponseWriter, r *http.Request) {
 		// call sites get it together.
 		TargetBackend: "",
 
+		// The SAME authorizer the preflight passed (TASK-2408): both read
+		// it off the shared resolution, so whatever the preview called
+		// unresolvable, this copy refuses to clone.
+		AttachmentAuthorizer: ac.attachmentAuth,
+
 		// s.cloudMode, NEVER an unconditional true: EnforceItemLimit mirrors
 		// enforcePlanLimit's `if !s.cloudMode { return true }` gate, and
 		// forcing it on would apply free-tier item caps to self-hosted users

--- a/internal/server/handlers_items_copy_attachment_authz_test.go
+++ b/internal/server/handlers_items_copy_attachment_authz_test.go
@@ -1,0 +1,462 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/attachments"
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// Attachment authorization for the cross-workspace copy — TASK-2408 /
+// BUG-2407.
+//
+// The hole: PlanAttachmentCopy scoped every lookup to the SOURCE WORKSPACE
+// (DR-11a) and stopped there. The workspace is not the caller, so a
+// restricted member who could edit any item in workspace A could paste
+// `pad-attachment:<uuid>` for an attachment hanging off an item they could
+// not see, copy that item into a workspace they own, and read the bytes
+// through the ordinary blob endpoint.
+//
+// What these tests pin, in the order the acceptance criteria state it:
+//
+//  1. the hidden reference is NOT cloned, and the clone is not readable in
+//     the destination (the mutation-verified core);
+//  2. the preflight's counts for a hidden reference are BYTE-IDENTICAL to
+//     its counts for a dangling one — if they diverge, the fix moved the
+//     existence oracle instead of closing it;
+//  3. the same treatment for an archived parent, a foreign parent and (for
+//     a restricted caller) an orphan;
+//  4. the CONTROL: attachments the caller can see still copy, variants
+//     included, and are readable in the destination. A fix that authorizes
+//     nothing through is not a fix;
+//  5. preflight and copy agree, because they share one authorizer.
+
+// --- fixture -----------------------------------------------------------
+
+// copyAttachmentFixture extends the shared copy fixture with a real
+// attachment registry (the blob endpoint has to serve bytes for the
+// "readable in the destination" half of the proof), a collection in A the
+// attacker cannot see, and an item inside it carrying an attachment.
+type copyAttachmentFixture struct {
+	*copyPreflightFixture
+
+	// attacker is a restricted editor: A limited to the SOURCE collection
+	// (so they may edit the item being copied) and B limited to the
+	// destination collection (so the copy itself is authorized).
+	attacker *models.User
+
+	secretItem *models.Item
+	secretAtt  *models.Attachment
+	secretBody []byte
+}
+
+func newCopyAttachmentFixture(t *testing.T) *copyAttachmentFixture {
+	t.Helper()
+	f := newCopyPreflightFixture(t)
+
+	dir := t.TempDir()
+	fs, err := attachments.NewFSStore(dir)
+	if err != nil {
+		t.Fatalf("NewFSStore: %v", err)
+	}
+	reg := attachments.NewRegistry()
+	reg.Register(attachments.FSPrefix, fs)
+	f.srv.SetAttachments(reg, 0)
+
+	secretColl := mustSchemaCollection(t, f.srv, f.wsA.ID, "Secrets A", srcSchemaJSON)
+	secretItem, err := f.srv.store.CreateItem(f.wsA.ID, secretColl.ID, models.ItemCreate{
+		Title: "The Secret", Fields: `{}`, CreatedBy: f.owner.ID,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem(secret): %v", err)
+	}
+
+	body := distinctPNG(t, 0x5a)
+	secretAtt := putBlob(t, f.srv, &models.Attachment{
+		WorkspaceID: f.wsA.ID, ItemID: &secretItem.ID, Filename: "secret.png",
+	}, body)
+
+	return &copyAttachmentFixture{
+		copyPreflightFixture: f,
+		attacker: f.restrictedEditor("copy-att-attacker@example.com", "copyattattacker",
+			[]string{f.collA.ID}, []string{f.collB.ID}),
+		secretItem: secretItem,
+		secretAtt:  secretAtt,
+		secretBody: body,
+	}
+}
+
+// setSourceContent rewrites the source item's body — the attacker's own
+// legitimate edit of an item they hold, which is the whole vector.
+func (f *copyAttachmentFixture) setSourceContent(content string) {
+	f.t.Helper()
+	if _, err := f.srv.store.UpdateItem(f.source.ID, models.ItemUpdate{Content: &content}); err != nil {
+		f.t.Fatalf("UpdateItem(content): %v", err)
+	}
+}
+
+// preflightAsAttacker runs the dry run as the restricted editor and returns
+// both the parsed response and the RAW bytes, because one of the assertions
+// below is on the bytes.
+func (f *copyAttachmentFixture) preflightAsAttacker() (ItemCopyPreflight, []byte) {
+	f.t.Helper()
+	rr := f.call(f.attacker, reqOpts{wsRoleCtx: "editor"}, f.resolvableBody())
+	if rr.Code != http.StatusOK {
+		f.t.Fatalf("preflight as the restricted editor: got %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+	var out ItemCopyPreflight
+	if err := json.Unmarshal(rr.Body.Bytes(), &out); err != nil {
+		f.t.Fatalf("parse preflight: %v\nbody: %s", err, rr.Body.String())
+	}
+	return out, rr.Body.Bytes()
+}
+
+func (f *copyAttachmentFixture) copyAsAttacker() ItemCopyResult {
+	f.t.Helper()
+	rr := f.callCopy(f.attacker, reqOpts{wsRoleCtx: "editor"}, f.resolvableBody())
+	if rr.Code != http.StatusCreated {
+		f.t.Fatalf("copy as the restricted editor: got %d, want 201: %s", rr.Code, rr.Body.String())
+	}
+	var out ItemCopyResult
+	if err := json.Unmarshal(rr.Body.Bytes(), &out); err != nil {
+		f.t.Fatalf("parse copy result: %v\nbody: %s", err, rr.Body.String())
+	}
+	return out
+}
+
+// preflightAs / copyAs select the caller: the restricted attacker, or the
+// unrestricted owner. Which one a case uses is load-bearing — see
+// TestCopy_UnauthorizedParentsAreAllUnresolvable.
+func (f *copyAttachmentFixture) preflightAs(restricted bool) ItemCopyPreflight {
+	f.t.Helper()
+	if restricted {
+		out, _ := f.preflightAsAttacker()
+		return out
+	}
+	return f.ok(f.resolvableBody())
+}
+
+func (f *copyAttachmentFixture) copyAs(restricted bool) ItemCopyResult {
+	f.t.Helper()
+	if restricted {
+		return f.copyAsAttacker()
+	}
+	return f.copyOK(f.resolvableBody())
+}
+
+// destinationAttachments lists every live attachment row in workspace B,
+// read straight out of the database rather than from any response: the
+// claim is about what the copy PERSISTED.
+func (f *copyAttachmentFixture) destinationAttachments() []models.Attachment {
+	f.t.Helper()
+	rows, err := f.srv.store.DB().Query(f.srv.store.D().Rebind(
+		`SELECT id, content_hash FROM attachments WHERE workspace_id = ? AND deleted_at IS NULL`),
+		f.wsB.ID)
+	if err != nil {
+		f.t.Fatalf("query destination attachments: %v", err)
+	}
+	defer rows.Close()
+	var out []models.Attachment
+	for rows.Next() {
+		var a models.Attachment
+		if err := rows.Scan(&a.ID, &a.ContentHash); err != nil {
+			f.t.Fatalf("scan destination attachment: %v", err)
+		}
+		out = append(out, a)
+	}
+	if err := rows.Err(); err != nil {
+		f.t.Fatalf("iterate destination attachments: %v", err)
+	}
+	return out
+}
+
+// destinationContent reads the copied item's stored body.
+func (f *copyAttachmentFixture) destinationContent(itemID string) string {
+	f.t.Helper()
+	item, err := f.srv.store.GetItem(itemID)
+	if err != nil {
+		f.t.Fatalf("GetItem(copy): %v", err)
+	}
+	if item == nil {
+		f.t.Fatalf("GetItem(copy): the copied item is missing")
+	}
+	return item.Content
+}
+
+// --- 1. the mutation-verified core -------------------------------------
+
+// TestCopy_HiddenAttachmentIsNotCloned is BUG-2407's headline regression.
+//
+// MUTATION-VERIFIED: with the authorizer removed from the two call sites,
+// this test fails on the cloned-row assertion AND on the download — the
+// secret PNG comes back 200 with its exact bytes from workspace B, which is
+// the exfiltration the bug describes.
+func TestCopy_HiddenAttachmentIsNotCloned(t *testing.T) {
+	f := newCopyAttachmentFixture(t)
+	f.setSourceContent("![](pad-attachment:" + f.secretAtt.ID + ")")
+
+	// Precondition: the attacker genuinely cannot read these bytes by the
+	// front door. Without this the test could pass for the wrong reason.
+	if rr := downloadAs(f.srv, http.MethodGet, f.wsA.ID, f.secretAtt.ID, "", f.attacker, "editor"); rr.Code != http.StatusNotFound {
+		t.Fatalf("fixture precondition: the attacker can already read the secret blob directly (%d)", rr.Code)
+	}
+
+	pre, _ := f.preflightAsAttacker()
+	if pre.Warnings.AttachmentCount != 0 || pre.Warnings.AttachmentBytes != 0 {
+		t.Errorf("preflight promised the hidden attachment: count=%d bytes=%d, want 0/0",
+			pre.Warnings.AttachmentCount, pre.Warnings.AttachmentBytes)
+	}
+	if pre.Warnings.UnresolvableRefCount != 1 {
+		t.Errorf("unresolvable_ref_count = %d, want 1 — a hidden reference is unresolvable",
+			pre.Warnings.UnresolvableRefCount)
+	}
+
+	res := f.copyAsAttacker()
+	if res.Warnings.AttachmentCount != 0 {
+		t.Errorf("the copy reported %d cloned attachments, want 0", res.Warnings.AttachmentCount)
+	}
+	if got := f.destinationAttachments(); len(got) != 0 {
+		t.Fatalf("the copy cloned %d attachment row(s) into workspace B; the hidden blob leaked", len(got))
+	}
+
+	// The literal reference survives in the copied body, exactly as a
+	// dangling one does — the copy renders as broken as the source did for
+	// this caller, and nothing was rewritten to point anywhere readable.
+	if content := f.destinationContent(res.Item.ID); !bytes.Contains([]byte(content), []byte(f.secretAtt.ID)) {
+		t.Errorf("the copied body no longer carries the literal reference: %q", content)
+	}
+
+	// And the source is untouched: refusing to clone is not deleting.
+	if att, err := f.srv.store.GetAttachment(f.secretAtt.ID); err != nil || att == nil || att.DeletedAt != nil {
+		t.Errorf("the source attachment did not survive the refused copy (err=%v, row=%v)", err, att)
+	}
+}
+
+// --- 2. the preflight must stay oracle-free ----------------------------
+
+// TestCopyPreflight_HiddenAttachmentReadsAsDangling is the anti-oracle
+// assertion, and it is on the RESPONSE BYTES rather than on the three
+// counters, because the counters are only the part of the response we
+// happen to have thought of. A preflight is read-only and repeatable, so
+// any difference at all between "this UUID names a live attachment you
+// cannot see" and "this UUID names nothing" is an oracle the caller can
+// query at will.
+func TestCopyPreflight_HiddenAttachmentReadsAsDangling(t *testing.T) {
+	f := newCopyAttachmentFixture(t)
+
+	f.setSourceContent("![](pad-attachment:" + f.secretAtt.ID + ")")
+	hidden, hiddenRaw := f.preflightAsAttacker()
+
+	f.setSourceContent("![](pad-attachment:00000000-0000-4000-8000-000000000000)")
+	dangling, danglingRaw := f.preflightAsAttacker()
+
+	if !bytes.Equal(hiddenRaw, danglingRaw) {
+		t.Fatalf("a hidden attachment reference is distinguishable from a dangling one:\n"+
+			" hidden:   %s\n dangling: %s", hiddenRaw, danglingRaw)
+	}
+	// Belt and braces: identical is only interesting if it is identically
+	// UNRESOLVABLE rather than identically empty.
+	if hidden.Warnings.UnresolvableRefCount != 1 || dangling.Warnings.UnresolvableRefCount != 1 {
+		t.Fatalf("both cases should count one unresolvable reference, got hidden=%d dangling=%d",
+			hidden.Warnings.UnresolvableRefCount, dangling.Warnings.UnresolvableRefCount)
+	}
+}
+
+// --- 3. the rest of the outcome set ------------------------------------
+
+// TestCopy_UnauthorizedParentsAreAllUnresolvable walks the outcomes
+// resolveAttachmentParentItem distinguishes, plus the orphan rule, and
+// requires every one of them to land in the same bucket. The read path
+// collapses these onto one 404; the copy collapses them onto one
+// unresolvable count, which is the same claim in this endpoint's vocabulary.
+//
+// EACH CASE RUNS AS THE CALLER THAT ISOLATES ITS GATE, which is not a
+// detail. Run as the restricted attacker, the archived and foreign cases
+// would pass on collection visibility alone — they would keep passing with
+// includeArchived flipped to true, or with the workspace-identity check
+// deleted, and would be proving nothing about the branch they name. Both
+// therefore run as the OWNER, who can see the secret item perfectly well
+// and must still be refused. Only the orphan case needs a restricted
+// caller, because the orphan rule IS about restriction (Codex round 2).
+func TestCopy_UnauthorizedParentsAreAllUnresolvable(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		// setup returns the attachment id to reference.
+		setup func(f *copyAttachmentFixture) string
+		// restricted selects the caller: the restricted attacker, or the
+		// unrestricted owner.
+		restricted bool
+	}{
+		{
+			// DR-13: an archived parent is not readable, so it is not
+			// copyable. As the OWNER — who could see this item until the
+			// moment it was archived — so the refusal can only be coming
+			// from the liveness gate.
+			name: "archived parent",
+			setup: func(f *copyAttachmentFixture) string {
+				if err := f.srv.store.DeleteItem(f.secretItem.ID); err != nil {
+					f.t.Fatalf("DeleteItem(secret): %v", err)
+				}
+				return f.secretAtt.ID
+			},
+		},
+		{
+			// item_id pointing into ANOTHER workspace. The planner's own
+			// scope does not catch this: it checks the ATTACHMENT's
+			// workspace, and this row is in A. Also as the OWNER, who CAN
+			// see the foreign item — that is exactly the confused deputy
+			// resolveAttachmentParentItem's workspace-identity check
+			// exists to stop, and a restricted caller would mask it.
+			name: "foreign parent",
+			setup: func(f *copyAttachmentFixture) string {
+				foreign, err := f.srv.store.CreateItem(f.wsB.ID, f.collB.ID, models.ItemCreate{
+					Title: "Elsewhere", Fields: `{}`, CreatedBy: f.owner.ID,
+				})
+				if err != nil {
+					f.t.Fatalf("CreateItem(foreign): %v", err)
+				}
+				if _, err := f.srv.store.DB().Exec(f.srv.store.D().Rebind(
+					`UPDATE attachments SET item_id = ? WHERE id = ?`), foreign.ID, f.secretAtt.ID); err != nil {
+					f.t.Fatalf("point the attachment at a foreign item: %v", err)
+				}
+				return f.secretAtt.ID
+			},
+		},
+		{
+			// item_id NULL. The orphan rule (PLAN-2382 DR-4): the storage
+			// listing hides orphans from restricted members, so cloning one
+			// for a restricted member would confirm what the listing
+			// refuses to.
+			name: "orphan, restricted caller",
+			setup: func(f *copyAttachmentFixture) string {
+				if _, err := f.srv.store.DB().Exec(f.srv.store.D().Rebind(
+					`UPDATE attachments SET item_id = NULL WHERE id = ?`), f.secretAtt.ID); err != nil {
+					f.t.Fatalf("orphan the attachment: %v", err)
+				}
+				return f.secretAtt.ID
+			},
+			restricted: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newCopyAttachmentFixture(t)
+			id := tc.setup(f)
+			f.setSourceContent("![](pad-attachment:" + id + ")")
+
+			pre := f.preflightAs(tc.restricted)
+			if pre.Warnings.AttachmentCount != 0 || pre.Warnings.UnresolvableRefCount != 1 {
+				t.Errorf("preflight: count=%d unresolvable=%d, want 0/1",
+					pre.Warnings.AttachmentCount, pre.Warnings.UnresolvableRefCount)
+			}
+
+			res := f.copyAs(tc.restricted)
+			if res.Warnings.AttachmentCount != 0 {
+				t.Errorf("the copy cloned %d attachment(s), want 0", res.Warnings.AttachmentCount)
+			}
+			if got := f.destinationAttachments(); len(got) != 0 {
+				t.Errorf("the copy persisted %d attachment row(s) in workspace B, want 0", len(got))
+			}
+		})
+	}
+}
+
+// TestCopy_OrphanCopiesForAnUnrestrictedCaller is the counterweight to the
+// orphan case above: the rule is about RESTRICTED callers, not about
+// orphans, and applying it to everyone would silently stop legitimate
+// copies of workspace-level uploads. Same rule, same asymmetry, as the read
+// path's orphan gate.
+func TestCopy_OrphanCopiesForAnUnrestrictedCaller(t *testing.T) {
+	f := newCopyAttachmentFixture(t)
+	orphan := putBlob(t, f.srv, &models.Attachment{
+		WorkspaceID: f.wsA.ID, Filename: "orphan.png",
+	}, distinctPNG(t, 0x77))
+	f.setSourceContent("![](pad-attachment:" + orphan.ID + ")")
+
+	res := f.copyOK(f.resolvableBody()) // the owner: unrestricted in A
+	if res.Warnings.AttachmentCount != 1 {
+		t.Fatalf("an unrestricted caller could not copy an orphan attachment: count=%d, want 1",
+			res.Warnings.AttachmentCount)
+	}
+}
+
+// --- 4. the control ----------------------------------------------------
+
+// TestCopy_VisibleAttachmentsStillClone is the assertion that keeps the fix
+// honest. Refusing everything would satisfy every test above.
+//
+// It uses the SAME restricted attacker, referencing an attachment on the
+// source item — which they hold — so what is being pinned is precisely the
+// visibility boundary and not the caller's role.
+func TestCopy_VisibleAttachmentsStillClone(t *testing.T) {
+	f := newCopyAttachmentFixture(t)
+
+	origBody := distinctPNG(t, 0x11)
+	orig := putBlob(t, f.srv, &models.Attachment{
+		WorkspaceID: f.wsA.ID, ItemID: &f.source.ID, Filename: "mine.png",
+	}, origBody)
+	variantKey := models.AttachmentVariantThumbMd
+	variantBody := distinctPNG(t, 0x22)
+	variant := putBlob(t, f.srv, &models.Attachment{
+		WorkspaceID: f.wsA.ID, ItemID: &f.source.ID, ParentID: &orig.ID, Variant: &variantKey,
+		Filename: "mine-thumb.png",
+	}, variantBody)
+
+	f.setSourceContent("![](pad-attachment:" + orig.ID + ")")
+
+	pre, _ := f.preflightAsAttacker()
+	// Two rows: the original and its variant. Variants are cloned with
+	// their parent — a half-copied variant set is worse than neither.
+	if pre.Warnings.AttachmentCount != 2 {
+		t.Errorf("preflight attachment_count = %d, want 2 (original + variant)", pre.Warnings.AttachmentCount)
+	}
+	if want := orig.SizeBytes + variant.SizeBytes; pre.Warnings.AttachmentBytes != want {
+		t.Errorf("preflight attachment_bytes = %d, want %d", pre.Warnings.AttachmentBytes, want)
+	}
+	if pre.Warnings.UnresolvableRefCount != 0 {
+		t.Errorf("unresolvable_ref_count = %d, want 0 — this caller can see this attachment",
+			pre.Warnings.UnresolvableRefCount)
+	}
+
+	res := f.copyAsAttacker()
+	if res.Warnings.AttachmentCount != pre.Warnings.AttachmentCount ||
+		res.Warnings.AttachmentBytes != pre.Warnings.AttachmentBytes ||
+		res.Warnings.UnresolvableRefCount != pre.Warnings.UnresolvableRefCount {
+		t.Errorf("preflight and copy disagree: preflight %+v, copy %+v", pre.Warnings, res.Warnings)
+	}
+
+	cloned := f.destinationAttachments()
+	if len(cloned) != 2 {
+		t.Fatalf("workspace B has %d attachment rows, want 2", len(cloned))
+	}
+
+	// The clone is REAL: the rewritten body points at the new id, and the
+	// bytes come back through the destination workspace.
+	content := f.destinationContent(res.Item.ID)
+	if bytes.Contains([]byte(content), []byte(orig.ID)) {
+		t.Errorf("the copied body still points at workspace A's id: %q", content)
+	}
+	var served bool
+	for _, c := range cloned {
+		if c.ContentHash != orig.ContentHash {
+			continue
+		}
+		if !bytes.Contains([]byte(content), []byte(c.ID)) {
+			continue
+		}
+		rr := downloadAs(f.srv, http.MethodGet, f.wsB.ID, c.ID, "", f.attacker, "editor")
+		if rr.Code != http.StatusOK {
+			t.Fatalf("the cloned attachment is not readable in workspace B: %d %s", rr.Code, rr.Body.String())
+		}
+		if !bytes.Equal(rr.Body.Bytes(), origBody) {
+			t.Errorf("the cloned attachment served %d bytes, want the %d-byte original",
+				rr.Body.Len(), len(origBody))
+		}
+		served = true
+	}
+	if !served {
+		t.Fatal("no cloned row matched the rewritten reference — the copy did not actually carry the attachment")
+	}
+}

--- a/internal/server/handlers_items_copy_preflight.go
+++ b/internal/server/handlers_items_copy_preflight.go
@@ -983,6 +983,13 @@ func (s *Server) handleCopyItemPreflight(w http.ResponseWriter, r *http.Request)
 		UploadedBy:        actorID,
 		Content:           item.Content,
 		Fields:            final,
+
+		// The caller's own visibility, applied to every reference the
+		// planner resolves (TASK-2408). A reference the caller cannot see
+		// lands in UnresolvableRefs, so it is reported here exactly as a
+		// dangling or foreign id is — no count distinguishes them — and
+		// the copy will not clone it, because it is the same authorizer.
+		Authorize: ac.attachmentAuth,
 	})
 	if err != nil {
 		writeInternalError(w, err)

--- a/internal/server/handlers_items_copy_resolve.go
+++ b/internal/server/handlers_items_copy_resolve.go
@@ -6,6 +6,7 @@ import (
 	"github.com/go-chi/chi/v5"
 
 	"github.com/PerpetualSoftware/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/store"
 )
 
 // authorizedCopy is everything a cross-workspace copy request resolves to
@@ -37,6 +38,13 @@ type authorizedCopy struct {
 
 	// targetCollection is the resolved destination collection.
 	targetCollection *models.Collection
+
+	// attachmentAuth is the per-attachment visibility check both consumers
+	// hand to the planner (TASK-2408). It lives HERE, on the shared
+	// resolution, for the same reason the ladder above does: the preflight
+	// and the copy must decide "which references are unresolvable" with one
+	// function, or the preview stops predicting the copy. Never nil.
+	attachmentAuth store.AttachmentAuthorizer
 
 	// actorID is who the copy is attributed to — see copyActorID. It is
 	// NOT the actor/source audit pair from actorFromRequest, which is a
@@ -210,6 +218,12 @@ func (s *Server) resolveAuthorizedCopy(w http.ResponseWriter, r *http.Request) (
 		return out, false
 	}
 	out.actorID = actorID
+
+	// Built against the SOURCE workspace: it authorizes the rows the
+	// planner resolves, and the planner resolves only source-workspace
+	// rows. Cheap to build (it queries nothing until called) so it is
+	// created unconditionally rather than lazily by each consumer.
+	out.attachmentAuth = s.attachmentCopyAuthorizer(r, sourceWorkspaceID)
 
 	return out, true
 }

--- a/internal/server/handlers_storage.go
+++ b/internal/server/handlers_storage.go
@@ -314,16 +314,6 @@ func (s *Server) handleDeleteWorkspaceAttachment(w http.ResponseWriter, r *http.
 		writeAttachmentNotFound(w)
 		return
 	}
-	// Refuse to delete derived (thumbnail) rows directly — they're
-	// auto-managed and deleting the original cascades. A direct
-	// delete here would leave the original without thumbnails until
-	// a future "regenerate" job runs.
-	if att.ParentID != nil {
-		writeError(w, http.StatusBadRequest, "derived_attachment",
-			"Cannot delete a thumbnail directly — delete the original.")
-		return
-	}
-
 	// Item-level visibility check. An editor with restricted collection
 	// access shouldn't be able to delete attachments in collections
 	// they can't see — even if they obtain the attachment ID some
@@ -404,6 +394,25 @@ func (s *Server) handleDeleteWorkspaceAttachment(w http.ResponseWriter, r *http.
 		// an edit grant on a foreign item would authorize deleting an
 		// attachment in THIS workspace.
 		writeAttachmentNotFound(w)
+		return
+	}
+
+	// Refuse to delete derived (thumbnail) rows directly — they're
+	// auto-managed and deleting the original cascades. A direct delete
+	// here would leave the original without thumbnails until a future
+	// "regenerate" job runs.
+	//
+	// Deliberately AFTER authorization, not before. This 400 is
+	// reachable only for a row that exists and is live, so emitting it
+	// ahead of the gates let a caller distinguish a guessed live
+	// thumbnail id (400) from an absent, foreign, or deleted one (the
+	// shared 404) — and hidden-parent and restricted callers got the 400
+	// too. Same existence oracle as the read and orphan paths; the
+	// classification is a usage error, so it may only be reported to
+	// someone already authorized to act on the row.
+	if att.ParentID != nil {
+		writeError(w, http.StatusBadRequest, "derived_attachment",
+			"Cannot delete a thumbnail directly — delete the original.")
 		return
 	}
 

--- a/internal/server/handlers_storage.go
+++ b/internal/server/handlers_storage.go
@@ -311,7 +311,7 @@ func (s *Server) handleDeleteWorkspaceAttachment(w http.ResponseWriter, r *http.
 		return
 	}
 	if att == nil || att.WorkspaceID != workspaceID || att.DeletedAt != nil {
-		writeError(w, http.StatusNotFound, "not_found", "Attachment not found")
+		writeAttachmentNotFound(w)
 		return
 	}
 	// Refuse to delete derived (thumbnail) rows directly — they're
@@ -327,44 +327,34 @@ func (s *Server) handleDeleteWorkspaceAttachment(w http.ResponseWriter, r *http.
 	// Item-level visibility check. An editor with restricted collection
 	// access shouldn't be able to delete attachments in collections
 	// they can't see — even if they obtain the attachment ID some
-	// other way. Mirrors requireItemVisible's logic but operates on
-	// the attachment's parent item id rather than a fully-loaded item.
+	// other way.
 	//
-	// GetItemIncludeDeleted is used (not GetItem) because the storage
-	// list intentionally surfaces attachments whose parent item is
-	// soft-deleted — they're still consuming quota and the user
-	// needs a path to delete the blob. The collection_id stays set
-	// after a soft delete, so the visibility predicate still works.
-	if att.ItemID != nil {
-		item, err := s.store.GetItemIncludeDeleted(*att.ItemID)
-		if err != nil {
-			writeInternalError(w, err)
+	// includeArchived=true here, and NOWHERE else: the storage list
+	// intentionally surfaces attachments whose parent item is soft-deleted
+	// — they're still consuming quota and the user needs a path to delete
+	// the blob. The collection_id stays set after a soft delete, so the
+	// visibility predicate still works. The read and transform paths pass
+	// false, where an archived parent means "refuse" (DR-13).
+	item, parentOutcome, err := s.resolveAttachmentParentItem(att, true)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	switch parentOutcome {
+	case attachmentParentOK:
+		// checkItemVisible (the predicate), not requireItemVisible: the
+		// latter writes its own "Item not found" body, which would make an
+		// invisible parent distinguishable from a missing attachment — the
+		// same existence oracle the read and transform paths closed by
+		// funnelling every denial through writeAttachmentNotFound. This
+		// path now shares that writer.
+		visible, vErr := s.checkItemVisible(workspaceID, item, currentUser(r), workspaceRole(r), isBearerAuth(r))
+		if vErr != nil {
+			writeInternalError(w, vErr)
 			return
 		}
-		// Workspace identity FIRST, before visibility or permission.
-		//
-		// attachments.item_id has no FK or same-workspace constraint, and the
-		// upload handler associates the raw ?item_id string (it authorizes
-		// against a workspace-scoped ResolveItem, but stores the value
-		// verbatim), so a row in workspace A can carry an item id belonging to
-		// workspace B. Neither downstream check catches that on its own:
-		// checkItemVisible admits any collection id when the caller is
-		// unrestricted, and ResolveUserPermission matches item grants by
-		// item_id alone with no workspace scoping (store/grants.go). Without
-		// this guard, an edit grant on a foreign item would authorize deleting
-		// an attachment in THIS workspace. 404, not 403 — same non-disclosure
-		// posture as the rest of the handler.
-		if item != nil && item.WorkspaceID != workspaceID {
-			writeError(w, http.StatusNotFound, "not_found", "Attachment not found")
-			return
-		}
-		if item == nil || !s.requireItemVisible(w, r, workspaceID, item) {
-			// requireItemVisible already wrote a 404 on its denial path.
-			// Two cases land us here: the item was hard-deleted out from
-			// under us (item == nil) or the user can't see it.
-			if item == nil {
-				writeError(w, http.StatusNotFound, "not_found", "Attachment not found")
-			}
+		if !visible {
+			writeAttachmentNotFound(w)
 			return
 		}
 		// Edit permission on the PARENT ITEM, checked strictly AFTER
@@ -375,29 +365,42 @@ func (s *Server) handleDeleteWorkspaceAttachment(w http.ResponseWriter, r *http.
 		if !s.requireEditPermission(w, r, workspaceID, item.ID, item.CollectionID) {
 			return
 		}
-	} else {
+	case attachmentParentOrphan:
 		// Orphan attachments carry no item context to authorize against,
 		// so they keep the flat workspace editor-role gate.
 		if !requireMinRole(w, r, "editor") {
 			return
 		}
-		// Orphan attachments (item_id IS NULL) are not associated with
-		// any collection, so collection-level visibility doesn't apply.
-		// Restricted members shouldn't reach here because the LIST
-		// endpoint hides orphans from them, but a direct DELETE with a
-		// guessed UUID could — gate orphans on full-access editors.
-		if fullCollIDs, grantedItemIDs, gErr := s.guestResourceFilter(r, workspaceID); gErr != nil {
-			writeInternalError(w, gErr)
-			return
-		} else if fullCollIDs != nil || grantedItemIDs != nil {
-			writeError(w, http.StatusNotFound, "not_found", "Attachment not found")
+		// ...and full access only (PLAN-2382 DR-4) — see
+		// attachmentCallerIsRestricted. The LIST endpoint hides orphans
+		// from restricted members, but a direct DELETE with a guessed UUID
+		// could still reach here.
+		restricted, rErr := s.attachmentCallerIsRestricted(r, workspaceID)
+		if rErr != nil {
+			writeInternalError(w, rErr)
 			return
 		}
+		if restricted {
+			writeAttachmentNotFound(w)
+			return
+		}
+	default: // Gone (hard-deleted out from under us), Foreign
+		// Foreign matters even with includeArchived: a row in workspace A
+		// can carry an item id belonging to workspace B (the upload handler
+		// authorizes against a workspace-scoped ResolveItem but stores the
+		// raw value), and neither downstream check catches it —
+		// checkItemVisible admits any collection id for an unrestricted
+		// caller, and ResolveUserPermission matches item grants by item_id
+		// alone with no workspace scoping (store/grants.go). Without this,
+		// an edit grant on a foreign item would authorize deleting an
+		// attachment in THIS workspace.
+		writeAttachmentNotFound(w)
+		return
 	}
 
 	if err := s.store.SoftDeleteAttachment(id); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			writeError(w, http.StatusNotFound, "not_found", "Attachment not found")
+			writeAttachmentNotFound(w)
 			return
 		}
 		writeInternalError(w, err)

--- a/internal/server/handlers_storage.go
+++ b/internal/server/handlers_storage.go
@@ -367,14 +367,20 @@ func (s *Server) handleDeleteWorkspaceAttachment(w http.ResponseWriter, r *http.
 		}
 	case attachmentParentOrphan:
 		// Orphan attachments carry no item context to authorize against,
-		// so they keep the flat workspace editor-role gate.
-		if !requireMinRole(w, r, "editor") {
-			return
-		}
-		// ...and full access only (PLAN-2382 DR-4) — see
-		// attachmentCallerIsRestricted. The LIST endpoint hides orphans
-		// from restricted members, but a direct DELETE with a guessed UUID
-		// could still reach here.
+		// so they keep the flat workspace editor-role gate — but the
+		// full-access check comes FIRST (PLAN-2382 DR-4).
+		//
+		// Order is the whole point, and getting it backwards is a live
+		// oracle rather than a style nit: requireMinRole answers 403, and
+		// it is only reachable once the row has been loaded, so a
+		// restricted caller who guesses an orphan's UUID would get 403
+		// where a bad UUID gets 404 — confirming the row exists. That is
+		// exactly what attachmentCallerIsRestricted's contract warns
+		// about ("callers MUST apply it AHEAD of any role gate that would
+		// answer 403"), and this path violated it until the convergence
+		// review of PLAN-2391 caught it. The LIST endpoint hides orphans
+		// from restricted members; a direct DELETE with a guessed UUID is
+		// how they would otherwise still be probed.
 		restricted, rErr := s.attachmentCallerIsRestricted(r, workspaceID)
 		if rErr != nil {
 			writeInternalError(w, rErr)
@@ -382,6 +388,9 @@ func (s *Server) handleDeleteWorkspaceAttachment(w http.ResponseWriter, r *http.
 		}
 		if restricted {
 			writeAttachmentNotFound(w)
+			return
+		}
+		if !requireMinRole(w, r, "editor") {
 			return
 		}
 	default: // Gone (hard-deleted out from under us), Foreign

--- a/internal/server/handlers_storage_delete_authz_test.go
+++ b/internal/server/handlers_storage_delete_authz_test.go
@@ -275,3 +275,111 @@ func TestDeleteAttachment_OrphanStillRequiresEditorRole(t *testing.T) {
 		t.Fatalf("orphan delete by editor: status = %d, want 204; body = %s", rr.Code, rr.Body.String())
 	}
 }
+
+// TestDeleteAttachment_DenialBodiesAreByteIdentical pins the non-disclosure
+// invariant on the DELETE path at the level it actually has to hold: the
+// RESPONSE BODY, not just the status code.
+//
+// Every test above asserts 404 and stops there, which let a real oracle sit
+// in plain sight — invisible parents were routed through requireItemVisible,
+// whose body says "Item not found", while a missing or foreign attachment
+// said "Attachment not found". Same status, different bytes: enough to sort
+// "this id names an attachment on an item you can't see" from "this id names
+// nothing". The read and transform paths closed the same oracle class by
+// funnelling every denial through writeAttachmentNotFound; this path now
+// shares that writer, and this test is what keeps it shared.
+//
+// The four denials compared are the ones a prober can actually reach.
+func TestDeleteAttachment_DenialBodiesAreByteIdentical(t *testing.T) {
+	srv, _ := testServerWithAttachments(t)
+	f := newDeleteAuthzFixture(t, srv)
+
+	// An attachment in f.wsID whose item_id points into ANOTHER workspace.
+	otherWS, err := srv.store.CreateWorkspace(models.WorkspaceCreate{Name: "DenialForeign"})
+	if err != nil {
+		t.Fatalf("CreateWorkspace foreign: %v", err)
+	}
+	otherCol, err := srv.store.CreateCollection(otherWS.ID, models.CollectionCreate{
+		Name: "Tasks", Schema: `{"fields":[]}`,
+	})
+	if err != nil {
+		t.Fatalf("CreateCollection foreign: %v", err)
+	}
+	otherItem, err := srv.store.CreateItem(otherWS.ID, otherCol.ID, models.ItemCreate{
+		Title: "Foreign", Fields: `{}`,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem foreign: %v", err)
+	}
+	foreignParent := &models.Attachment{
+		WorkspaceID: f.wsID,
+		ItemID:      &otherItem.ID,
+		UploadedBy:  "system",
+		StorageKey:  "fs:denial-foreign",
+		ContentHash: "authzhash-denial-foreign",
+		MimeType:    "image/png",
+		SizeBytes:   64,
+		Filename:    "foreign-parent.png",
+	}
+	if err := srv.store.CreateAttachment(foreignParent); err != nil {
+		t.Fatalf("CreateAttachment foreignParent: %v", err)
+	}
+
+	// A second collection in f.wsID, so a restricted member can hold
+	// "specific" collection access to something real while still being
+	// restricted — that is the axis the orphan gate keys on.
+	sideCol, err := srv.store.CreateCollection(f.wsID, models.CollectionCreate{
+		Name: "Side", Schema: `{"fields":[]}`,
+	})
+	if err != nil {
+		t.Fatalf("CreateCollection side: %v", err)
+	}
+
+	// The baseline: a plain lookup miss, taken as a full-access owner so it
+	// is unambiguously "no such attachment" and not itself an authz denial.
+	owner := mkUser(t, srv, "denial-owner@test.com")
+	if err := srv.store.AddWorkspaceMember(f.wsID, owner.ID, "owner"); err != nil {
+		t.Fatalf("AddWorkspaceMember owner: %v", err)
+	}
+	baseline := deleteAsUser(srv, f.wsID, "00000000-0000-0000-0000-000000000000", owner, "owner")
+	if baseline.Code != http.StatusNotFound {
+		t.Fatalf("baseline lookup miss: status = %d, want 404; body = %s",
+			baseline.Code, baseline.Body.String())
+	}
+
+	// An unrestricted-but-nonmember caller: the item is invisible to them, so
+	// this is the requireItemVisible path that used to answer "Item not found".
+	stranger := mkUser(t, srv, "denial-stranger@test.com")
+
+	// A restricted editor probing the orphan.
+	restricted := mkUser(t, srv, "denial-restricted@test.com")
+	if err := srv.store.AddWorkspaceMember(f.wsID, restricted.ID, "editor"); err != nil {
+		t.Fatalf("AddWorkspaceMember restricted: %v", err)
+	}
+	if err := srv.store.SetMemberCollectionAccess(f.wsID, restricted.ID, "specific",
+		[]string{sideCol.ID}); err != nil {
+		t.Fatalf("SetMemberCollectionAccess: %v", err)
+	}
+
+	for _, tc := range []struct {
+		label string
+		attID string
+		user  *models.User
+		role  string
+	}{
+		{"invisible parent item", f.attID, stranger, "guest"},
+		{"foreign parent item", foreignParent.ID, owner, "owner"},
+		{"orphan as restricted editor", f.orphan, restricted, "editor"},
+	} {
+		rr := deleteAsUser(srv, f.wsID, tc.attID, tc.user, tc.role)
+		if rr.Code != http.StatusNotFound {
+			t.Errorf("%s: status = %d, want 404; body = %s", tc.label, rr.Code, rr.Body.String())
+			continue
+		}
+		if got, want := rr.Body.String(), baseline.Body.String(); got != want {
+			t.Errorf("%s: body = %q, lookup-miss body = %q — must be byte-identical, "+
+				"otherwise the response distinguishes a real attachment from a bad id",
+				tc.label, got, want)
+		}
+	}
+}

--- a/internal/server/handlers_storage_delete_authz_test.go
+++ b/internal/server/handlers_storage_delete_authz_test.go
@@ -49,6 +49,7 @@ func deleteAsUser(srv *Server, wsID, attachmentID string, user *models.User, rol
 type authzFixture struct {
 	wsID   string
 	itemID string
+	colID  string
 	attID  string
 	orphan string
 }
@@ -100,7 +101,7 @@ func newDeleteAuthzFixture(t *testing.T, srv *Server) authzFixture {
 		t.Fatalf("CreateAttachment orphan: %v", err)
 	}
 
-	return authzFixture{wsID: ws.ID, itemID: item.ID, attID: bound.ID, orphan: orphan.ID}
+	return authzFixture{wsID: ws.ID, itemID: item.ID, colID: col.ID, attID: bound.ID, orphan: orphan.ID}
 }
 
 func mkUser(t *testing.T, srv *Server, email string) *models.User {
@@ -380,6 +381,66 @@ func TestDeleteAttachment_DenialBodiesAreByteIdentical(t *testing.T) {
 			t.Errorf("%s: body = %q, lookup-miss body = %q — must be byte-identical, "+
 				"otherwise the response distinguishes a real attachment from a bad id",
 				tc.label, got, want)
+		}
+	}
+}
+
+// TestDeleteAttachment_OrphanRefusedToRestrictedMember covers the ORDER of the
+// orphan gate, which is load-bearing rather than cosmetic.
+//
+// attachmentCallerIsRestricted's contract says callers must apply it AHEAD of
+// any role gate that would answer 403. This path did the opposite until the
+// convergence review of PLAN-2391: requireMinRole("editor") ran first, and it
+// is only reachable once the row has been loaded — so a restricted member who
+// guessed a live orphan's UUID got 403 while a bad UUID got 404, confirming
+// the row exists. The blob read had the same bug in a different shape; both
+// are the same oracle.
+//
+// Both restricted roles are covered because the flat editor gate would answer
+// differently for each (403 for a viewer, success for an editor) — and NEITHER
+// may be distinguishable from the lookup miss.
+func TestDeleteAttachment_OrphanRefusedToRestrictedMember(t *testing.T) {
+	srv, _ := testServerWithAttachments(t)
+	f := newDeleteAuthzFixture(t, srv)
+
+	// Lookup-miss baseline, taken as an unrestricted OWNER so it is a genuine
+	// "no such attachment" rather than itself a restriction or role denial.
+	owner := mkUser(t, srv, "del-orphan-baseline@test.com")
+	if err := srv.store.AddWorkspaceMember(f.wsID, owner.ID, "owner"); err != nil {
+		t.Fatalf("AddWorkspaceMember baseline: %v", err)
+	}
+	missing := deleteAsUser(srv, f.wsID, "00000000-0000-0000-0000-000000000000", owner, "owner")
+	if missing.Code != http.StatusNotFound {
+		t.Fatalf("baseline missing attachment: status = %d, want 404", missing.Code)
+	}
+
+	for _, role := range []string{"editor", "viewer"} {
+		user := mkUser(t, srv, "del-orphan-restricted-"+role+"@test.com")
+		if err := srv.store.AddWorkspaceMember(f.wsID, user.ID, role); err != nil {
+			t.Fatalf("AddWorkspaceMember %s: %v", role, err)
+		}
+		// Restricted to the item's OWN collection on purpose: the member
+		// retains real access in this workspace, so an orphan denial cannot
+		// be explained away as blanket loss of access.
+		if err := srv.store.SetMemberCollectionAccess(f.wsID, user.ID, "specific",
+			[]string{f.colID}); err != nil {
+			t.Fatalf("SetMemberCollectionAccess %s: %v", role, err)
+		}
+
+		rr := deleteAsUser(srv, f.wsID, f.orphan, user, role)
+		if rr.Code == http.StatusNoContent {
+			t.Fatalf("orphan DELETE by a restricted %s succeeded — a member the storage "+
+				"listing hides orphans from must not be able to delete one by guessing "+
+				"its UUID", role)
+		}
+		if rr.Code != http.StatusNotFound {
+			t.Errorf("restricted %s orphan DELETE: status = %d, want 404 — a 403 here is "+
+				"reachable only for rows that exist, which confirms the orphan is real",
+				role, rr.Code)
+		}
+		if got, want := rr.Body.String(), missing.Body.String(); got != want {
+			t.Errorf("restricted %s orphan DELETE body = %q, lookup-miss body = %q — "+
+				"must be byte-identical", role, got, want)
 		}
 	}
 }

--- a/internal/server/handlers_storage_delete_authz_test.go
+++ b/internal/server/handlers_storage_delete_authz_test.go
@@ -444,3 +444,87 @@ func TestDeleteAttachment_OrphanRefusedToRestrictedMember(t *testing.T) {
 		}
 	}
 }
+
+// TestDeleteAttachment_DerivedRowIsNotAnOracle covers WHERE the derived-row
+// refusal sits relative to authorization.
+//
+// Deleting a thumbnail directly is a usage error and answers 400. But that
+// 400 is reachable only for a row that exists and is live, so emitting it
+// before the gates let anyone probe a guessed UUID: 400 meant "a live
+// thumbnail lives here", while an absent, foreign, or deleted id answered the
+// shared 404. Hidden-parent and restricted callers got the 400 too, learning
+// about a row they cannot see. Fifth instance of this branch's existence
+// oracle, found by the convergence sweep of PLAN-2391.
+//
+// The 400 is still correct FOR AN AUTHORIZED CALLER — asserted here so the
+// fix cannot regress into blanket-404ing a legitimate mistake.
+func TestDeleteAttachment_DerivedRowIsNotAnOracle(t *testing.T) {
+	srv, _ := testServerWithAttachments(t)
+	f := newDeleteAuthzFixture(t, srv)
+
+	variant := "thumb-md"
+	derived := &models.Attachment{
+		WorkspaceID: f.wsID,
+		ItemID:      &f.itemID,
+		ParentID:    &f.attID,
+		Variant:     &variant,
+		UploadedBy:  "system",
+		StorageKey:  "fs:authz-derived",
+		ContentHash: "authzhash-derived",
+		MimeType:    "image/png",
+		SizeBytes:   32,
+		Filename:    "bound.thumb-md.png",
+	}
+	if err := srv.store.CreateAttachment(derived); err != nil {
+		t.Fatalf("CreateAttachment derived: %v", err)
+	}
+
+	// An owner IS authorized, so they get the honest usage error.
+	owner := mkUser(t, srv, "derived-owner@test.com")
+	if err := srv.store.AddWorkspaceMember(f.wsID, owner.ID, "owner"); err != nil {
+		t.Fatalf("AddWorkspaceMember owner: %v", err)
+	}
+	authorized := deleteAsUser(srv, f.wsID, derived.ID, owner, "owner")
+	if authorized.Code != http.StatusBadRequest {
+		t.Fatalf("authorized derived delete: status = %d, want 400 — the usage error "+
+			"must survive for someone entitled to act on the row", authorized.Code)
+	}
+
+	// The lookup-miss baseline, same caller so only the id differs.
+	missing := deleteAsUser(srv, f.wsID, "00000000-0000-0000-0000-000000000000", owner, "owner")
+	if missing.Code != http.StatusNotFound {
+		t.Fatalf("baseline missing: status = %d, want 404", missing.Code)
+	}
+
+	// A restricted member must NOT be able to tell the live derived row from
+	// a nonexistent one.
+	restricted := mkUser(t, srv, "derived-restricted@test.com")
+	if err := srv.store.AddWorkspaceMember(f.wsID, restricted.ID, "editor"); err != nil {
+		t.Fatalf("AddWorkspaceMember restricted: %v", err)
+	}
+	otherCol, err := srv.store.CreateCollection(f.wsID, models.CollectionCreate{
+		Name: "Other", Schema: `{"fields":[]}`,
+	})
+	if err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	if err := srv.store.SetMemberCollectionAccess(f.wsID, restricted.ID, "specific",
+		[]string{otherCol.ID}); err != nil {
+		t.Fatalf("SetMemberCollectionAccess: %v", err)
+	}
+
+	probe := deleteAsUser(srv, f.wsID, derived.ID, restricted, "editor")
+	if probe.Code == http.StatusBadRequest {
+		t.Fatalf("restricted derived delete returned 400 — that answer is reachable only " +
+			"for a live row, so it confirms the thumbnail exists to someone who cannot " +
+			"see its parent")
+	}
+	if probe.Code != http.StatusNotFound {
+		t.Errorf("restricted derived delete: status = %d, want 404", probe.Code)
+	}
+	probeMissing := deleteAsUser(srv, f.wsID, "00000000-0000-0000-0000-000000000000", restricted, "editor")
+	if got, want := probe.Body.String(), probeMissing.Body.String(); got != want {
+		t.Errorf("restricted derived denial body = %q, lookup-miss body = %q — "+
+			"must be byte-identical", got, want)
+	}
+}

--- a/internal/store/attachments.go
+++ b/internal/store/attachments.go
@@ -375,6 +375,12 @@ func mimeInPredicate(mimes []string) (string, []any, bool) {
 // with item fields nulled out — the attachment is still visible
 // (a deleted item could still be restored), but the link target
 // isn't reachable.
+//
+// Both joins are scoped to the attachment's own workspace, so an
+// attachment whose item_id points at another workspace's item lists
+// with NULL item/collection metadata rather than leaking a foreign
+// title (TASK-2399). The row itself still lists — it consumes quota
+// and must remain visible and repairable.
 func (s *Store) WorkspaceAttachments(workspaceID string, filters AttachmentListFilters) ([]AttachmentListItem, int, error) {
 	// Build the WHERE clause incrementally. Every branch parameter
 	// goes through the placeholder slice — no string concatenation of
@@ -452,10 +458,17 @@ func (s *Store) WorkspaceAttachments(workspaceID string, filters AttachmentListF
 	// them and the collection-level visibility predicate
 	// (i.collection_id IN ...) must keep working. The handler's
 	// delete path uses GetItemIncludeDeleted for the same reason.
+	//
+	// The workspace predicate belongs in the ON clause, NOT in WHERE:
+	// in WHERE the LEFT JOIN degenerates into an inner join and a row
+	// whose item_id points at another workspace's item would vanish
+	// from the listing entirely — hiding quota-consuming rows and
+	// making them unrepairable. In ON, a mismatched parent simply
+	// yields NULL item metadata and the row survives (TASK-2399).
 	var total int
 	if err := s.db.QueryRow(s.q(`
 		SELECT COUNT(*) FROM attachments a
-		LEFT JOIN items i ON i.id = a.item_id
+		LEFT JOIN items i ON i.id = a.item_id AND i.workspace_id = a.workspace_id
 		WHERE `+where), args...).Scan(&total); err != nil {
 		return nil, 0, fmt.Errorf("count workspace attachments: %w", err)
 	}
@@ -489,13 +502,27 @@ func (s *Store) WorkspaceAttachments(workspaceID string, filters AttachmentListF
 	// ACL predicate sees a non-NULL i.collection_id. The response
 	// surfaces deleted_at on the joined item via item_deleted so the
 	// UI can render a "(deleted)" tag instead of a clickable link.
+	//
+	// Same workspace scoping as the count query above, and for the
+	// same reason — the two must stay consistent or a restricted
+	// user's count would diverge from their results. Collections are
+	// reached through the now-scoped item join, so a foreign parent
+	// nulls out the collection columns too.
+	//
+	// The collections join carries its own workspace predicate as
+	// well: items.collection_id has no composite workspace foreign
+	// key (migrations/005_collections.sql), so an item can reference
+	// a collection in another workspace and would otherwise surface
+	// that collection's slug/name here. Same ON-clause rule — a
+	// mismatch nulls the collection columns, it does not drop the
+	// row.
 	q := `
 		SELECT ` + aliasedAttachmentColumns + `,
 		       i.title, i.slug, i.deleted_at,
 		       c.slug, c.name
 		FROM attachments a
-		LEFT JOIN items i       ON i.id = a.item_id
-		LEFT JOIN collections c ON c.id = i.collection_id
+		LEFT JOIN items i       ON i.id = a.item_id AND i.workspace_id = a.workspace_id
+		LEFT JOIN collections c ON c.id = i.collection_id AND c.workspace_id = i.workspace_id
 		WHERE ` + where + `
 		ORDER BY ` + orderBy + `
 		LIMIT ? OFFSET ?`

--- a/internal/store/attachments.go
+++ b/internal/store/attachments.go
@@ -150,12 +150,22 @@ func (s *Store) GetAttachment(id string) (*models.Attachment, error) {
 // ?variant=thumb-sm — TASK-878 will populate these rows; TASK-872
 // implements the lookup so the handler degrades gracefully when no
 // thumbnail exists yet.
-func (s *Store) GetAttachmentVariant(parentID, variant string) (*models.Attachment, error) {
+//
+// workspaceID scopes the lookup (PLAN-2391 DR-16). parent_id has no FK or
+// same-workspace constraint, so a variant row in workspace B can carry a
+// parent_id belonging to workspace A — the copy planner demonstrates that
+// shape (internal/store/attachments_copy_plan_test.go). Without the scope,
+// the download handler authorizes A's original and then serves B's child,
+// which defeats the entire item-visibility gate. The scope lives here rather
+// than in the handler because the OTHER caller — thumbnail derivation — has
+// its own stake in it: an unscoped "does this variant already exist?" probe
+// would let a foreign row suppress generation of a legitimate local one.
+func (s *Store) GetAttachmentVariant(workspaceID, parentID, variant string) (*models.Attachment, error) {
 	a, err := scanAttachment(s.db.QueryRow(s.q(`
 		SELECT `+attachmentColumns+` FROM attachments
-		WHERE parent_id = ? AND variant = ? AND deleted_at IS NULL
+		WHERE workspace_id = ? AND parent_id = ? AND variant = ? AND deleted_at IS NULL
 		LIMIT 1
-	`), parentID, variant))
+	`), workspaceID, parentID, variant))
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}

--- a/internal/store/attachments.go
+++ b/internal/store/attachments.go
@@ -3,6 +3,7 @@ package store
 import (
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -94,6 +95,87 @@ func (s *Store) CreateAttachment(a *models.Attachment) error {
 // AttachmentCopyPlan.Rows in the order the planner emitted them.
 func (s *Store) CreateAttachmentTx(tx *sql.Tx, a *models.Attachment) error {
 	return s.createAttachmentOn(tx, a)
+}
+
+// ErrAttachmentParentItemGone reports that the item an attachment is being
+// written against is no longer a live item of the attachment's workspace —
+// archived, hard-gone, or never in this workspace at all.
+//
+// It is a caller-facing sentinel, not an internal failure: handlers turn it
+// into the same not-found response every other attachment denial writes, so
+// it must not be wrapped in a way that hides it from errors.Is.
+var ErrAttachmentParentItemGone = errors.New("attachment parent item is not live in this workspace")
+
+// CreateAttachmentForLiveItem inserts an attachment row, refusing when its
+// item_id does not name a LIVE item of the same workspace — re-checked and
+// pinned inside the insert's own transaction.
+//
+// Why a transaction rather than a check in the handler (PLAN-2391 DR-14):
+// producing an attachment is check-then-work. A handler that validates the
+// parent up front and inserts afterwards leaves a window — item deletion
+// commits in a separate transaction (DeleteItem) and can land in the middle,
+// so the insert writes a quota-counted live row hanging off an item that is
+// already archived, whose bytes the read gate (DR-13) then refuses to serve.
+// Locking the item row for the duration of the insert closes the window
+// instead of narrowing it.
+//
+// Postgres takes the row lock with FOR NO KEY UPDATE; a concurrent DeleteItem
+// blocks on it and, once this transaction commits, its UPDATE ... WHERE
+// deleted_at IS NULL still matches, so archival is delayed but never lost. In
+// the other interleaving DeleteItem commits first, and the re-read —
+// re-evaluated after the lock is released — no longer matches the deleted_at
+// IS NULL predicate, so this call fails closed.
+//
+// FOR NO KEY UPDATE rather than FOR UPDATE: it is the exact strength needed
+// and no more. DeleteItem's UPDATE touches no key column, so Postgres takes
+// FOR NO KEY UPDATE for it, and two FOR NO KEY UPDATE holders conflict — the
+// archival still blocks. What it does NOT block is FOR KEY SHARE, the lock an
+// INSERT into any of the many tables with a `REFERENCES items(id)` foreign key
+// takes on the parent row (comments, stars, the Yjs op-log — the last of which
+// writes continuously while someone is editing the item). Plain FOR UPDATE
+// would stall those for the duration of this transaction to buy nothing.
+//
+// SQLite skips the lock: its DSN sets _txlock=immediate, so every db.Begin()
+// is a BEGIN IMMEDIATE and writers already serialize, and the row-locking
+// clause is a syntax error there — the dialect gate is not an optimization.
+//
+// An orphan row (nil/empty ItemID) has no parent to pin and takes the plain
+// insert path, identical to CreateAttachment.
+func (s *Store) CreateAttachmentForLiveItem(a *models.Attachment) error {
+	if a.ItemID == nil || *a.ItemID == "" {
+		return s.createAttachmentOn(s.db, a)
+	}
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin create attachment tx: %w", err)
+	}
+	defer tx.Rollback() // no-op after Commit
+
+	query := `SELECT workspace_id FROM items WHERE id = ? AND deleted_at IS NULL`
+	if s.dialect.Driver() == DriverPostgres {
+		query += ` FOR NO KEY UPDATE`
+	}
+	var itemWorkspaceID string
+	switch err := tx.QueryRow(s.q(query), *a.ItemID).Scan(&itemWorkspaceID); {
+	case err == sql.ErrNoRows:
+		// Missing or archived — indistinguishable on purpose.
+		return ErrAttachmentParentItemGone
+	case err != nil:
+		return fmt.Errorf("lock attachment parent item: %w", err)
+	}
+	// Workspace identity is part of the invariant, not a redundant check:
+	// attachments.item_id carries no FK or same-workspace constraint, so a
+	// malformed association naming a live item in ANOTHER workspace would
+	// otherwise pass the liveness re-check and write a cross-workspace row.
+	if itemWorkspaceID != a.WorkspaceID {
+		return ErrAttachmentParentItemGone
+	}
+
+	if err := s.createAttachmentOn(tx, a); err != nil {
+		return err
+	}
+	return tx.Commit()
 }
 
 // createAttachmentOn is the shared insert body, parameterized over the pool or

--- a/internal/store/attachments_copy_plan.go
+++ b/internal/store/attachments_copy_plan.go
@@ -168,7 +168,58 @@ type AttachmentCopyRequest struct {
 	// ':'. Empty means "same backend as the source", the same-instance
 	// case, and disables cross-backend detection.
 	TargetBackend string
+
+	// Authorize is the CALLER's per-row authorization decision (TASK-2408).
+	// See AttachmentAuthorizer.
+	Authorize AttachmentAuthorizer
 }
+
+// AttachmentAuthorizer answers one question about one already-scoped
+// attachment row: may the caller who asked for this copy see it?
+//
+// It exists because DR-11a's scope is the WORKSPACE, and the workspace is
+// not the caller. Every lookup in the planner carries `workspace_id =
+// SourceWorkspaceID AND deleted_at IS NULL`, which stops a foreign blob
+// from being cloned — but a restricted member of the source workspace can
+// still edit some item they DO hold, paste `pad-attachment:<uuid>` for an
+// attachment hanging off an item they CANNOT see, and copy that item into
+// a workspace they own. The clone lands with them as uploader and the
+// bytes are then readable through the ordinary blob endpoint. The scope
+// held; the visibility check was simply never made (BUG-2407).
+//
+// It is a CALLBACK, and deliberately so. The rule it applies is the read
+// path's — resolve the parent item, reject a foreign or non-live one,
+// check item visibility, apply the orphan rule — and every input to that
+// rule (the *http.Request, the session user, the role, the per-collection
+// grants) lives in package server. The store has none of them and must not
+// grow them. Neither, though, can the check happen BEFORE planning: the
+// mutating copy re-reads the source item's content under its own locks and
+// computes the destination fields inside its transaction, so a reference
+// set enumerated by the caller beforehand is not the set the planner will
+// actually resolve. Authorizing the rows the planner ACTUALLY resolved, in
+// the planner's own pass, is the only shape that keeps the dry run and the
+// copy on one path — which is the property DR-11 spends this whole file
+// protecting.
+//
+// A false verdict is applied by DELETING the row from the resolution map,
+// so it is indistinguishable from a row that was never there: the
+// reference lands in UnresolvableRefs beside dangling, soft-deleted and
+// foreign ids, and attachment_count / attachment_bytes /
+// unresolvable_ref_count read identically. That equivalence is the point —
+// a preflight that answered differently for "hidden" than for "absent"
+// would be an existence oracle for attachment UUIDs, which is precisely
+// the class of hole PLAN-2391 has been closing.
+//
+// An error is fatal to the plan, never a silent denial: a failed
+// membership lookup must not read as "you may not see this".
+//
+// NIL MEANS NO CALLER-LEVEL AUTHORIZATION — every row that passes the
+// workspace scope is cloned. That is correct only for callers with no user
+// to authorize against (store-level tests). BOTH HTTP entry points, the
+// preflight and the copy, set it from the one place their shared
+// authorization ladder runs (server.resolveAuthorizedCopy), so a new
+// endpoint cannot reach the planner without going past it.
+type AttachmentAuthorizer func(models.Attachment) (bool, error)
 
 // AttachmentCopyRow is one attachment row to create in workspace B, plus
 // the source-side facts the caller needs in order to move bytes if it has
@@ -326,9 +377,19 @@ func (s *Store) PlanAttachmentCopy(req AttachmentCopyRequest) (*AttachmentCopyPl
 		return plan, nil
 	}
 
-	// Pass 1 — resolve the referenced ids, scoped.
+	// Pass 1 — resolve the referenced ids, scoped, then authorized.
+	//
+	// The authorization filter runs on EVERY resolution pass below, and
+	// always immediately after the load: a denied row is deleted from the
+	// map, so from this point on "the caller may not see it" and "it does
+	// not exist" are the same fact, expressed the same way, and every
+	// downstream classification treats them identically without knowing
+	// the difference exists (TASK-2408).
 	resolved, err := s.attachmentsByIDInWorkspace(req.SourceWorkspaceID, refs)
 	if err != nil {
+		return nil, err
+	}
+	if err := filterAuthorizedAttachments(resolved, req.Authorize); err != nil {
 		return nil, err
 	}
 
@@ -359,6 +420,12 @@ func (s *Store) PlanAttachmentCopy(req AttachmentCopyRequest) (*AttachmentCopyPl
 	if len(missingParents) > 0 {
 		parents, err := s.attachmentsByIDInWorkspace(req.SourceWorkspaceID, missingParents)
 		if err != nil {
+			return nil, err
+		}
+		// A parent the caller cannot see is not a clone root, exactly as a
+		// parent in another workspace is not: the reference below finds no
+		// entry and becomes unresolvable.
+		if err := filterAuthorizedAttachments(parents, req.Authorize); err != nil {
 			return nil, err
 		}
 		for id, a := range parents {
@@ -413,6 +480,29 @@ func (s *Store) PlanAttachmentCopy(req AttachmentCopyRequest) (*AttachmentCopyPl
 	if err != nil {
 		return nil, err
 	}
+	// Variants are authorized individually rather than inherited from the
+	// root. For well-formed data the two are the same answer — a derived
+	// row carries its parent's item_id — so this costs nothing on the
+	// legitimate path. For the malformed rows PLAN-2397 exists to repair
+	// (item_id pointing at another item, or at nothing) inheritance would
+	// be the confused-deputy escalation one level down, which is the exact
+	// mistake the DR-11a scope comment warns about for the workspace.
+	// A denied variant drops out of the plan; its root still clones.
+	if req.Authorize != nil {
+		for parentID, variants := range variantsByParent {
+			kept := variants[:0]
+			for _, v := range variants {
+				ok, err := req.Authorize(v)
+				if err != nil {
+					return nil, fmt.Errorf("plan attachment copy: authorize variant: %w", err)
+				}
+				if ok {
+					kept = append(kept, v)
+				}
+			}
+			variantsByParent[parentID] = kept
+		}
+	}
 
 	for _, root := range roots {
 		newRootID := plan.appendRow(req, root, nil)
@@ -421,6 +511,30 @@ func (s *Store) PlanAttachmentCopy(req AttachmentCopyRequest) (*AttachmentCopyPl
 		}
 	}
 	return plan, nil
+}
+
+// filterAuthorizedAttachments removes from rows every entry the caller's
+// authorizer denies. A nil authorizer keeps everything (see
+// AttachmentAuthorizer).
+//
+// Deletion, rather than a parallel "denied" set, is what makes a denial
+// unobservable: the planner's classification asks only whether an id is
+// present in the map, so the denied reference takes the identical branch a
+// dangling one takes and produces identical counts.
+func filterAuthorizedAttachments(rows map[string]models.Attachment, authorize AttachmentAuthorizer) error {
+	if authorize == nil {
+		return nil
+	}
+	for id, a := range rows {
+		ok, err := authorize(a)
+		if err != nil {
+			return fmt.Errorf("plan attachment copy: authorize %s: %w", id, err)
+		}
+		if !ok {
+			delete(rows, id)
+		}
+	}
+	return nil
 }
 
 // appendRow builds one destination row from a source attachment and adds

--- a/internal/store/attachments_copy_plan_test.go
+++ b/internal/store/attachments_copy_plan_test.go
@@ -950,3 +950,143 @@ func TestPlanAttachmentCopy_ManyRefsChunked(t *testing.T) {
 		t.Errorf("TotalBytes = %d, want %d", plan.TotalBytes, len(want))
 	}
 }
+
+// --- the caller's authorization hook (TASK-2408) ---------------------------
+//
+// DR-11a's scope is the workspace; the workspace is not the caller. The
+// planner therefore consults an AttachmentAuthorizer supplied by the
+// server, and a denial must be INDISTINGUISHABLE from a row that was never
+// there — same bucket, same counts — because the preflight publishes those
+// counts to anyone who can edit the source item.
+
+// TestPlanAttachmentCopy_DeniedRefIsExactlyDangling is the anti-oracle
+// claim at the planner's own level: the plan produced for a live-but-denied
+// reference equals, field for field, the plan produced for a UUID that
+// names nothing at all.
+func TestPlanAttachmentCopy_DeniedRefIsExactlyDangling(t *testing.T) {
+	f := newPlanFixture(t)
+	secret := f.attach(t, f.wsA, "secret.png", 4096)
+	f.variant(t, f.wsA, secret, models.AttachmentVariantThumbMd, 20)
+
+	denied := f.plan(t, withAuthorizer(f.req(imageRef(secret.ID), nil), denyAll))
+
+	missing := newID()
+	dangling := f.plan(t, f.req(imageRef(missing), nil))
+
+	if len(denied.Rows) != 0 || denied.TotalBytes != 0 {
+		t.Fatalf("a denied reference was planned: %d rows, %d bytes", len(denied.Rows), denied.TotalBytes)
+	}
+	if len(denied.IDMap) != 0 {
+		t.Errorf("IDMap = %v, want empty — a denied reference must not be rewritten", denied.IDMap)
+	}
+	if len(denied.UnresolvableRefs) != 1 || denied.UnresolvableRefs[0] != secret.ID {
+		t.Errorf("UnresolvableRefs = %v, want exactly the denied ref", denied.UnresolvableRefs)
+	}
+	if len(dangling.UnresolvableRefs) != len(denied.UnresolvableRefs) ||
+		len(dangling.Rows) != len(denied.Rows) ||
+		dangling.TotalBytes != denied.TotalBytes ||
+		dangling.CrossBackend != denied.CrossBackend {
+		t.Errorf("a denied reference is distinguishable from a dangling one:\n denied:   %+v\n dangling: %+v",
+			denied, dangling)
+	}
+}
+
+// TestPlanAttachmentCopy_DeniedParentSinksTheVariantRef is the one-level-down
+// case, mirroring TestPlanAttachmentCopy_RefToVariantWithForeignParent: a
+// reference naming a VARIANT whose original the caller may not see cannot
+// smuggle that original in as its clone root.
+func TestPlanAttachmentCopy_DeniedParentSinksTheVariantRef(t *testing.T) {
+	f := newPlanFixture(t)
+	orig := f.attach(t, f.wsA, "shot.png", 1000)
+	thumb := f.variant(t, f.wsA, orig, models.AttachmentVariantThumbSm, 10)
+
+	// Everything is visible EXCEPT the original.
+	req := withAuthorizer(f.req(imageRef(thumb.ID), nil), func(a models.Attachment) (bool, error) {
+		return a.ID != orig.ID, nil
+	})
+	plan := f.plan(t, req)
+
+	if len(plan.Rows) != 0 {
+		t.Fatalf("planned %v; a variant whose parent is denied must clone nothing", sourceIDs(plan))
+	}
+	if len(plan.UnresolvableRefs) != 1 || plan.UnresolvableRefs[0] != thumb.ID {
+		t.Errorf("UnresolvableRefs = %v, want the variant reference", plan.UnresolvableRefs)
+	}
+}
+
+// TestPlanAttachmentCopy_DeniedVariantDropsOnlyItself is the other
+// direction, and the reason variants are authorized individually rather
+// than inherited from an authorized root: a derived row that (through the
+// malformed item_id data PLAN-2397 repairs) belongs somewhere the caller
+// cannot see drops out on its own, without taking the legitimate original
+// with it.
+func TestPlanAttachmentCopy_DeniedVariantDropsOnlyItself(t *testing.T) {
+	f := newPlanFixture(t)
+	orig := f.attach(t, f.wsA, "shot.png", 1000)
+	sm := f.variant(t, f.wsA, orig, models.AttachmentVariantThumbSm, 10)
+	md := f.variant(t, f.wsA, orig, models.AttachmentVariantThumbMd, 20)
+
+	req := withAuthorizer(f.req(imageRef(orig.ID), nil), func(a models.Attachment) (bool, error) {
+		return a.ID != md.ID, nil
+	})
+	plan := f.plan(t, req)
+
+	assertSourceSet(t, plan, orig.ID, sm.ID)
+	if plan.TotalBytes != 1010 {
+		t.Errorf("TotalBytes = %d, want 1010 — the denied variant's bytes must not be counted", plan.TotalBytes)
+	}
+	if len(plan.UnresolvableRefs) != 0 {
+		t.Errorf("UnresolvableRefs = %v, want none — the REFERENCE resolved fine", plan.UnresolvableRefs)
+	}
+}
+
+// TestPlanAttachmentCopy_AuthorizerErrorIsFatal: a failed membership lookup
+// must not read as "you may not see this". Silently denying would turn a
+// transient database error into a copy that quietly drops the user's
+// images.
+func TestPlanAttachmentCopy_AuthorizerErrorIsFatal(t *testing.T) {
+	f := newPlanFixture(t)
+	a := f.attach(t, f.wsA, "shot.png", 10)
+
+	req := withAuthorizer(f.req(imageRef(a.ID), nil), func(models.Attachment) (bool, error) {
+		return false, fmt.Errorf("membership lookup exploded")
+	})
+	if _, err := f.s.PlanAttachmentCopy(req); err == nil {
+		t.Fatal("PlanAttachmentCopy swallowed the authorizer's error")
+	}
+}
+
+// TestPlanAttachmentCopy_AuthorizerSeesEveryClonedRow pins the coverage
+// claim itself: every row the plan emits was offered to the authorizer.
+// The gate is only worth what it is asked about.
+func TestPlanAttachmentCopy_AuthorizerSeesEveryClonedRow(t *testing.T) {
+	f := newPlanFixture(t)
+	orig := f.attach(t, f.wsA, "shot.png", 1000)
+	sm := f.variant(t, f.wsA, orig, models.AttachmentVariantThumbSm, 10)
+	other := f.attach(t, f.wsA, "spec.pdf", 50)
+
+	seen := map[string]bool{}
+	req := withAuthorizer(f.req(imageRef(sm.ID)+fileRef(other.ID), nil), func(a models.Attachment) (bool, error) {
+		seen[a.ID] = true
+		return true, nil
+	})
+	plan := f.plan(t, req)
+
+	for _, row := range plan.Rows {
+		if !seen[row.SourceID] {
+			t.Errorf("row %s was cloned without ever being authorized", row.SourceID)
+		}
+	}
+	// Including the PARENT pulled in by the variant reference, which is not
+	// itself a reference the caller wrote.
+	if !seen[orig.ID] {
+		t.Error("the variant's parent was adopted as a clone root without being authorized")
+	}
+}
+
+func withAuthorizer(req AttachmentCopyRequest, auth AttachmentAuthorizer) AttachmentCopyRequest {
+	req.Authorize = auth
+	return req
+}
+
+func denyAll(models.Attachment) (bool, error) { return false, nil }

--- a/internal/store/attachments_live_item_test.go
+++ b/internal/store/attachments_live_item_test.go
@@ -1,0 +1,236 @@
+package store
+
+import (
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// Store-level tests for CreateAttachmentForLiveItem — PLAN-2391 DR-14 /
+// TASK-2402. The handler-level coverage lives in internal/server; these pin
+// the invariant at the layer that actually enforces it.
+
+// liveItemAttachmentFixture is a workspace + collection + live item, plus a
+// ready-to-insert attachment row pointed at that item.
+func liveItemAttachmentFixture(t *testing.T, s *Store) (wsID string, itemID string, row *models.Attachment) {
+	t.Helper()
+	ws := createTestWorkspace(t, s, "LiveItemAttachments")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+	item := createTestItem(t, s, ws.ID, col.ID, "Parent", "")
+	return ws.ID, item.ID, &models.Attachment{
+		WorkspaceID: ws.ID,
+		ItemID:      &item.ID,
+		UploadedBy:  "system",
+		StorageKey:  "fs:" + newID(),
+		ContentHash: newID(),
+		MimeType:    "image/png",
+		SizeBytes:   1,
+		Filename:    "derived.png",
+	}
+}
+
+func countLiveAttachments(t *testing.T, s *Store, wsID string) int {
+	t.Helper()
+	var n int
+	if err := s.db.QueryRow(s.q(
+		`SELECT COUNT(*) FROM attachments WHERE workspace_id = ? AND deleted_at IS NULL`,
+	), wsID).Scan(&n); err != nil {
+		t.Fatalf("count attachments: %v", err)
+	}
+	return n
+}
+
+func TestCreateAttachmentForLiveItem_LiveParentInserts(t *testing.T) {
+	s := testStore(t)
+	wsID, _, row := liveItemAttachmentFixture(t, s)
+
+	if err := s.CreateAttachmentForLiveItem(row); err != nil {
+		t.Fatalf("CreateAttachmentForLiveItem: %v", err)
+	}
+	if got, err := s.GetAttachment(row.ID); err != nil || got == nil {
+		t.Fatalf("row not persisted (err = %v)", err)
+	}
+	if n := countLiveAttachments(t, s, wsID); n != 1 {
+		t.Errorf("live attachments = %d, want 1", n)
+	}
+}
+
+func TestCreateAttachmentForLiveItem_ArchivedParentRefuses(t *testing.T) {
+	s := testStore(t)
+	wsID, itemID, row := liveItemAttachmentFixture(t, s)
+
+	if err := s.DeleteItem(itemID); err != nil {
+		t.Fatalf("DeleteItem: %v", err)
+	}
+	err := s.CreateAttachmentForLiveItem(row)
+	if !errors.Is(err, ErrAttachmentParentItemGone) {
+		t.Fatalf("err = %v, want ErrAttachmentParentItemGone", err)
+	}
+	if n := countLiveAttachments(t, s, wsID); n != 0 {
+		t.Errorf("live attachments = %d, want 0 — the refusal still wrote a row", n)
+	}
+}
+
+// A non-null item_id that names nothing at all is refused, not silently
+// written as if it were an orphan.
+func TestCreateAttachmentForLiveItem_MalformedParentRefuses(t *testing.T) {
+	s := testStore(t)
+	wsID, _, row := liveItemAttachmentFixture(t, s)
+
+	ghost := newID()
+	row.ItemID = &ghost
+	if err := s.CreateAttachmentForLiveItem(row); !errors.Is(err, ErrAttachmentParentItemGone) {
+		t.Fatalf("err = %v, want ErrAttachmentParentItemGone", err)
+	}
+	if n := countLiveAttachments(t, s, wsID); n != 0 {
+		t.Errorf("live attachments = %d, want 0", n)
+	}
+}
+
+// item_id carries no FK or same-workspace constraint, so a live item in
+// ANOTHER workspace would pass a liveness-only re-check.
+func TestCreateAttachmentForLiveItem_ForeignWorkspaceParentRefuses(t *testing.T) {
+	s := testStore(t)
+	wsID, _, row := liveItemAttachmentFixture(t, s)
+
+	otherWS := createTestWorkspace(t, s, "Other")
+	otherCol := createTestCollection(t, s, otherWS.ID, "Tasks")
+	foreign := createTestItem(t, s, otherWS.ID, otherCol.ID, "Foreign", "")
+	row.ItemID = &foreign.ID
+
+	if err := s.CreateAttachmentForLiveItem(row); !errors.Is(err, ErrAttachmentParentItemGone) {
+		t.Fatalf("err = %v, want ErrAttachmentParentItemGone", err)
+	}
+	if n := countLiveAttachments(t, s, wsID); n != 0 {
+		t.Errorf("live attachments = %d, want 0", n)
+	}
+}
+
+// An orphan row has no parent to pin and takes the plain insert path.
+func TestCreateAttachmentForLiveItem_OrphanInserts(t *testing.T) {
+	s := testStore(t)
+	wsID, _, row := liveItemAttachmentFixture(t, s)
+	row.ItemID = nil
+
+	if err := s.CreateAttachmentForLiveItem(row); err != nil {
+		t.Fatalf("orphan insert: %v", err)
+	}
+	if n := countLiveAttachments(t, s, wsID); n != 1 {
+		t.Errorf("live attachments = %d, want 1", n)
+	}
+}
+
+// waitForLockWait blocks until Postgres reports some backend running a
+// statement containing needle AND waiting on a lock. It is the barrier that
+// makes "the insert is blocked" an observation rather than an inference: a
+// sleep cannot distinguish blocked-on-the-row from not-yet-scheduled or
+// waiting-for-a-pool-connection, and both of those would pass while the lock
+// was absent.
+//
+// done is watched at the same time. If the call under test completes while we
+// are waiting for it to block, it never blocked at all — the lock is missing
+// and the row was written.
+func waitForLockWait(t *testing.T, s *Store, needle string, done <-chan error) {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		select {
+		case err := <-done:
+			t.Fatalf("the insert completed (err = %v) instead of blocking on the "+
+				"item row held by an uncommitted archival — it read around the lock", err)
+		default:
+		}
+
+		var waiting bool
+		err := s.db.QueryRow(`
+			SELECT EXISTS (
+				SELECT 1 FROM pg_stat_activity
+				WHERE pid <> pg_backend_pid()
+				  -- pg_stat_activity is CLUSTER-wide, and go test runs packages
+				  -- concurrently against one server, so scope to this test's own
+				  -- database or another package's backend could satisfy the
+				  -- barrier.
+				  AND datname = current_database()
+				  AND state = 'active'
+				  AND wait_event_type = 'Lock'
+				  -- The needle is BOUND, not interpolated, so this poller's own
+				  -- query text (which pg_stat_activity reports with the $1
+				  -- placeholder intact) can never match itself.
+				  AND query LIKE '%' || $1 || '%'
+			)`, needle).Scan(&waiting)
+		if err != nil {
+			t.Fatalf("poll pg_stat_activity: %v", err)
+		}
+		if waiting {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("no backend reported waiting on a lock for a statement containing %q "+
+				"within the deadline", needle)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+// TestCreateAttachmentForLiveItem_BlocksOnArchivingWriter is the Postgres-only
+// half: it proves the FOR NO KEY UPDATE row lock is what closes the window,
+// not the point-in-time re-read.
+//
+// The interleaving is constructed, not sampled. An uncommitted transaction
+// holds the item row after stamping deleted_at; the insert must BLOCK on that
+// row rather than reading around it. Without the lock, read-committed hands
+// the insert the pre-update snapshot immediately, it sees a live item, and it
+// writes a quota-counted row against an item that is about to be archived.
+// Once the archiving transaction commits, the re-read is re-evaluated, no
+// longer matches `deleted_at IS NULL`, and the call fails closed.
+//
+// "Blocked" is verified IN THE DATABASE, not by elapsed time. waitForLockWait
+// polls pg_stat_activity until the goroutine's statement is registered as
+// waiting on a lock. A bare sleep would pass just as green if the goroutine
+// were merely unscheduled or parked waiting for a pool connection — which is
+// exactly the kind of timing-dependent assertion that rots silently.
+//
+// SQLite is excluded rather than skipped for convenience: its DSN sets
+// _txlock=immediate, so the second writer cannot even open its transaction
+// while the first is live — the interleaving this test constructs is
+// unrepresentable there, which is why the locking clause is dialect-gated.
+func TestCreateAttachmentForLiveItem_BlocksOnArchivingWriter(t *testing.T) {
+	pgURL := os.Getenv("PAD_TEST_POSTGRES_URL")
+	if pgURL == "" {
+		t.Skip("PAD_TEST_POSTGRES_URL not set — the lock only exists on Postgres")
+	}
+	s := testStorePostgres(t, pgURL)
+	wsID, itemID, row := liveItemAttachmentFixture(t, s)
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		t.Fatalf("begin archiving tx: %v", err)
+	}
+	defer tx.Rollback() // no-op after Commit
+	ts := now()
+	if _, err := tx.Exec(s.q(
+		`UPDATE items SET deleted_at = ?, updated_at = ? WHERE id = ?`,
+	), ts, ts, itemID); err != nil {
+		t.Fatalf("archive item in tx: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- s.CreateAttachmentForLiveItem(row) }()
+
+	// Wait until Postgres itself reports the statement as lock-blocked. If
+	// it instead finishes, it read around the lock and the insert landed.
+	waitForLockWait(t, s, "FOR NO KEY UPDATE", done)
+
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit archival: %v", err)
+	}
+	if err := <-done; !errors.Is(err, ErrAttachmentParentItemGone) {
+		t.Fatalf("err = %v, want ErrAttachmentParentItemGone", err)
+	}
+	if n := countLiveAttachments(t, s, wsID); n != 0 {
+		t.Errorf("live attachments = %d, want 0", n)
+	}
+}

--- a/internal/store/attachments_test.go
+++ b/internal/store/attachments_test.go
@@ -325,6 +325,268 @@ func TestWorkspaceAttachments_SurfacesSoftDeletedParents(t *testing.T) {
 	}
 }
 
+// TestWorkspaceAttachments_ForeignParentYieldsNullMetadata pins
+// TASK-2399 (PLAN-2391 DR-3): an attachment whose item_id points at
+// an item in ANOTHER workspace must not borrow that item's title,
+// slug, or collection through the LEFT JOINs.
+//
+// The workspace predicate lives in the JOIN's ON clause, not in
+// WHERE. That distinction is the whole point of this test: in WHERE
+// the LEFT JOIN degenerates into an inner join and the malformed row
+// would vanish from the listing entirely — hiding a row that still
+// consumes quota and that the PLAN-2397 repair needs to be able to
+// see. In ON, the row survives with NULL metadata.
+//
+// Count and result queries must agree — a restricted caller's total
+// must match the rows they actually get back.
+func TestWorkspaceAttachments_ForeignParentYieldsNullMetadata(t *testing.T) {
+	s := testStore(t)
+
+	wsA, wsB := newID(), newID()
+	collA, collB := newID(), newID()
+	itemA, itemB := newID(), newID()
+	ts := time.Now().UTC().Format(time.RFC3339)
+
+	for _, w := range []struct{ id, slug string }{{wsA, "ws-a"}, {wsB, "ws-b"}} {
+		if _, err := s.db.Exec(s.q(`INSERT INTO workspaces (id, slug, name, settings, created_at, updated_at)
+			VALUES (?, ?, ?, ?, ?, ?)`),
+			w.id, w.slug, w.slug, "{}", ts, ts); err != nil {
+			t.Fatalf("insert workspace %s: %v", w.slug, err)
+		}
+	}
+	for _, c := range []struct{ id, ws, slug, name string }{
+		{collA, wsA, "tasks", "Tasks"},
+		{collB, wsB, "secrets", "Secrets"},
+	} {
+		if _, err := s.db.Exec(s.q(`INSERT INTO collections (id, workspace_id, name, slug, schema, created_at, updated_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?)`),
+			c.id, c.ws, c.name, c.slug, `{"fields":[]}`, ts, ts); err != nil {
+			t.Fatalf("insert collection %s: %v", c.slug, err)
+		}
+	}
+	for _, it := range []struct{ id, ws, coll, title, slug string }{
+		{itemA, wsA, collA, "Local Task", "local-task"},
+		{itemB, wsB, collB, "Foreign Secret", "foreign-secret"},
+	} {
+		if _, err := s.db.Exec(s.q(`INSERT INTO items (id, workspace_id, collection_id, title, slug, created_at, updated_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?)`),
+			it.id, it.ws, it.coll, it.title, it.slug, ts, ts); err != nil {
+			t.Fatalf("insert item %s: %v", it.slug, err)
+		}
+	}
+
+	// Two attachments in workspace A: one well-formed, one whose
+	// item_id points at workspace B's item (the malformed row the
+	// upload invariant in TASK-2400 stops from being created, and
+	// that the PLAN-2397 repair has to be able to find).
+	mkAttach := func(itemID *string, filename string) string {
+		t.Helper()
+		a := &models.Attachment{
+			WorkspaceID: wsA,
+			ItemID:      itemID,
+			UploadedBy:  "system",
+			StorageKey:  "fs:" + newID(),
+			ContentHash: newID(),
+			MimeType:    "image/png",
+			SizeBytes:   100,
+			Filename:    filename,
+		}
+		if err := s.CreateAttachment(a); err != nil {
+			t.Fatalf("CreateAttachment(%s): %v", filename, err)
+		}
+		return a.ID
+	}
+	mkAttach(&itemA, "local.png")
+	mkAttach(&itemB, "malformed.png")
+
+	byName := func(rows []AttachmentListItem) map[string]AttachmentListItem {
+		m := make(map[string]AttachmentListItem, len(rows))
+		for _, r := range rows {
+			m[r.Filename] = r
+		}
+		return m
+	}
+
+	// 1. Full-access viewer sees BOTH rows — the malformed one must
+	//    not be filtered out by the workspace-scoped join.
+	rows, total, err := s.WorkspaceAttachments(wsA, AttachmentListFilters{})
+	if err != nil {
+		t.Fatalf("admin list: %v", err)
+	}
+	if total != 2 || len(rows) != 2 {
+		t.Fatalf("admin: total=%d rows=%d, want 2/2 (foreign-parent row must still list)", total, len(rows))
+	}
+
+	got := byName(rows)
+	local, ok := got["local.png"]
+	if !ok {
+		t.Fatalf("admin: local.png missing from %v", got)
+	}
+	if local.ItemTitle == nil || *local.ItemTitle != "Local Task" {
+		t.Errorf("local row: item_title=%v, want Local Task", local.ItemTitle)
+	}
+	if local.CollectionSlug == nil || *local.CollectionSlug != "tasks" {
+		t.Errorf("local row: collection_slug=%v, want tasks", local.CollectionSlug)
+	}
+
+	bad, ok := got["malformed.png"]
+	if !ok {
+		t.Fatalf("admin: malformed.png missing — the workspace predicate must be in ON, not WHERE")
+	}
+	if bad.ItemTitle != nil {
+		t.Errorf("foreign-parent row: item_title=%q, want nil (leaked another workspace's title)", *bad.ItemTitle)
+	}
+	if bad.ItemSlug != nil {
+		t.Errorf("foreign-parent row: item_slug=%q, want nil", *bad.ItemSlug)
+	}
+	if bad.CollectionSlug != nil {
+		t.Errorf("foreign-parent row: collection_slug=%q, want nil", *bad.CollectionSlug)
+	}
+	if bad.ItemDeleted {
+		t.Errorf("foreign-parent row: item_deleted=true, want false")
+	}
+	// The raw (malformed) association is still reported so the
+	// repair in PLAN-2397 can act on it.
+	if bad.ItemID == nil || *bad.ItemID != itemB {
+		t.Errorf("foreign-parent row: item_id=%v, want %s (raw value must survive for repair)", bad.ItemID, itemB)
+	}
+
+	// 2. A restricted caller scoped to workspace A's collection sees
+	//    only the well-formed row — the foreign parent contributes no
+	//    collection_id, so it fails the visibility predicate. Count
+	//    and rows must agree (they're separate queries).
+	rows, total, err = s.WorkspaceAttachments(wsA, AttachmentListFilters{
+		Restricted:        true,
+		FullCollectionIDs: []string{collA},
+	})
+	if err != nil {
+		t.Fatalf("restricted-collA list: %v", err)
+	}
+	if total != 1 || len(rows) != 1 {
+		t.Fatalf("restricted-collA: total=%d rows=%d, want 1/1", total, len(rows))
+	}
+	if rows[0].Filename != "local.png" {
+		t.Errorf("restricted-collA: filename=%q, want local.png", rows[0].Filename)
+	}
+
+	// 3. Naming the FOREIGN collection must not surface the malformed
+	//    row either — the collection columns are reached through the
+	//    scoped item join, so there is nothing to match.
+	rows, total, err = s.WorkspaceAttachments(wsA, AttachmentListFilters{
+		Restricted:        true,
+		FullCollectionIDs: []string{collB},
+	})
+	if err != nil {
+		t.Fatalf("restricted-collB list: %v", err)
+	}
+	if total != 0 || len(rows) != 0 {
+		t.Errorf("restricted-collB: total=%d rows=%d, want 0/0", total, len(rows))
+	}
+
+	// 4. The CollectionID filter goes through the same scoped join.
+	rows, total, err = s.WorkspaceAttachments(wsA, AttachmentListFilters{CollectionID: collB})
+	if err != nil {
+		t.Fatalf("collection-filter list: %v", err)
+	}
+	if total != 0 || len(rows) != 0 {
+		t.Errorf("collection-filter (foreign collection): total=%d rows=%d, want 0/0", total, len(rows))
+	}
+
+	// 5. Count/result consistency for an item-grant caller. The grant
+	//    predicate matches on a.item_id directly, so a grant naming
+	//    the foreign item still selects the malformed row — but the
+	//    two queries must at least agree with each other. Scoping the
+	//    grant LOOKUP by workspace is DR-5 (a separate task); this
+	//    only pins that the count doesn't diverge from the rows.
+	rows, total, err = s.WorkspaceAttachments(wsA, AttachmentListFilters{
+		Restricted:     true,
+		GrantedItemIDs: []string{itemB},
+	})
+	if err != nil {
+		t.Fatalf("item-grant list: %v", err)
+	}
+	if total != len(rows) {
+		t.Errorf("item-grant: total=%d but got %d rows — count and result queries diverged", total, len(rows))
+	}
+	for _, r := range rows {
+		if r.ItemTitle != nil {
+			t.Errorf("item-grant: foreign-parent row leaked item_title=%q", *r.ItemTitle)
+		}
+	}
+}
+
+// TestWorkspaceAttachments_ForeignCollectionYieldsNullCollectionMetadata
+// covers the second hop of the same leak (TASK-2399, found in review):
+// items.collection_id has no composite workspace foreign key
+// (migrations/005_collections.sql), so a local item can reference a
+// collection in another workspace. Reaching collections through the
+// now workspace-scoped item join is not enough on its own — the
+// collections join needs its own workspace predicate, or the listing
+// renders a foreign collection's slug.
+//
+// Again the predicate belongs in ON: the row must still list, with
+// only the collection columns nulled.
+func TestWorkspaceAttachments_ForeignCollectionYieldsNullCollectionMetadata(t *testing.T) {
+	s := testStore(t)
+
+	wsA, wsB := newID(), newID()
+	collA, collB := newID(), newID()
+	itemA := newID()
+	ts := time.Now().UTC().Format(time.RFC3339)
+
+	for _, w := range []struct{ id, slug string }{{wsA, "ws-a"}, {wsB, "ws-b"}} {
+		if _, err := s.db.Exec(s.q(`INSERT INTO workspaces (id, slug, name, settings, created_at, updated_at)
+			VALUES (?, ?, ?, ?, ?, ?)`),
+			w.id, w.slug, w.slug, "{}", ts, ts); err != nil {
+			t.Fatalf("insert workspace %s: %v", w.slug, err)
+		}
+	}
+	for _, c := range []struct{ id, ws, slug, name string }{
+		{collA, wsA, "tasks", "Tasks"},
+		{collB, wsB, "secrets", "Secrets"},
+	} {
+		if _, err := s.db.Exec(s.q(`INSERT INTO collections (id, workspace_id, name, slug, schema, created_at, updated_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?)`),
+			c.id, c.ws, c.name, c.slug, `{"fields":[]}`, ts, ts); err != nil {
+			t.Fatalf("insert collection %s: %v", c.slug, err)
+		}
+	}
+	// A workspace-A item pointing at workspace B's collection.
+	if _, err := s.db.Exec(s.q(`INSERT INTO items (id, workspace_id, collection_id, title, slug, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?)`),
+		itemA, wsA, collB, "Local Task", "local-task", ts, ts); err != nil {
+		t.Fatalf("insert item: %v", err)
+	}
+	if err := s.CreateAttachment(&models.Attachment{
+		WorkspaceID: wsA,
+		ItemID:      &itemA,
+		UploadedBy:  "system",
+		StorageKey:  "fs:" + newID(),
+		ContentHash: newID(),
+		MimeType:    "image/png",
+		SizeBytes:   100,
+		Filename:    "cross-coll.png",
+	}); err != nil {
+		t.Fatalf("CreateAttachment: %v", err)
+	}
+
+	rows, total, err := s.WorkspaceAttachments(wsA, AttachmentListFilters{})
+	if err != nil {
+		t.Fatalf("admin list: %v", err)
+	}
+	if total != 1 || len(rows) != 1 {
+		t.Fatalf("admin: total=%d rows=%d, want 1/1 (the row must still list)", total, len(rows))
+	}
+	// The item itself is local, so its metadata is legitimate.
+	if rows[0].ItemTitle == nil || *rows[0].ItemTitle != "Local Task" {
+		t.Errorf("item_title=%v, want Local Task (the item is in this workspace)", rows[0].ItemTitle)
+	}
+	// The collection is not.
+	if rows[0].CollectionSlug != nil {
+		t.Errorf("collection_slug=%q, want nil (leaked another workspace's collection)", *rows[0].CollectionSlug)
+	}
+}
+
 // TestWorkspaceAttachments_CategoryFilters covers the document/text/
 // archive/other filter buckets per Codex P2 from PR #303 round 1:
 // the earlier prefix-only mapping silently passed those filters

--- a/internal/store/grants.go
+++ b/internal/store/grants.go
@@ -288,11 +288,22 @@ func (s *Store) ResolveUserPermission(workspaceID, userID, itemID, collectionID 
 	}
 
 	// 2. Item-level grant?
+	//
+	// Scoped by workspace_id (PLAN-2391 DR-5). The grant rows already carry
+	// the workspace they were minted in (CreateItemGrant, and the same
+	// scoping listUserItemGrants uses), and every caller passes the
+	// workspace the item was resolved in — so this narrows nothing
+	// legitimate. What it closes is a caller handing us an itemID from a
+	// FOREIGN workspace alongside the request's own workspaceID: without
+	// the predicate, that foreign item's grant resolved and answered for
+	// the wrong workspace. That is the shape of the delete escalation
+	// PLAN-2382 fixed at the handler (internal/server/handlers_storage.go);
+	// this closes it at the lookup so the next caller need not remember.
 	if itemID != "" {
 		var perm string
 		err := s.db.QueryRow(s.q(
-			"SELECT permission FROM item_grants WHERE item_id = ? AND user_id = ?"),
-			itemID, userID).Scan(&perm)
+			"SELECT permission FROM item_grants WHERE workspace_id = ? AND item_id = ? AND user_id = ?"),
+			workspaceID, itemID, userID).Scan(&perm)
 		if err == nil {
 			return perm, nil
 		}
@@ -302,11 +313,16 @@ func (s *Store) ResolveUserPermission(workspaceID, userID, itemID, collectionID 
 	}
 
 	// 3. Collection-level grant?
+	//
+	// Workspace-scoped for the same reason as the item grant above — the
+	// defect and its safety argument are identical, so the two are fixed
+	// together rather than leaving a second unscoped lookup three lines
+	// below the one DR-5 names.
 	if collectionID != "" {
 		var perm string
 		err := s.db.QueryRow(s.q(
-			"SELECT permission FROM collection_grants WHERE collection_id = ? AND user_id = ?"),
-			collectionID, userID).Scan(&perm)
+			"SELECT permission FROM collection_grants WHERE workspace_id = ? AND collection_id = ? AND user_id = ?"),
+			workspaceID, collectionID, userID).Scan(&perm)
 		if err == nil {
 			return perm, nil
 		}

--- a/internal/store/grants_test.go
+++ b/internal/store/grants_test.go
@@ -1,0 +1,80 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// TestResolveUserPermission_GrantsDoNotCrossWorkspaces pins PLAN-2391 DR-5.
+//
+// A guest holds grants in workspace B only. Resolving with workspace A's ID
+// while passing B's item/collection ID — the shape a caller produces when it
+// trusts a resource ID that was never verified to belong to the request's
+// workspace — must resolve to no permission at all. Before the fix the item
+// and collection grant lookups matched on the resource ID alone, so B's grant
+// answered for a request scoped to A.
+//
+// The positive half of each assertion (same grant, correct workspace) is what
+// keeps the added predicate from being a silent lockout of legitimate guests.
+func TestResolveUserPermission_GrantsDoNotCrossWorkspaces(t *testing.T) {
+	s := testStore(t)
+
+	owner := createTestUser(t, s, "owner@example.com", "Owner", "password123")
+	guest := createTestUser(t, s, "guest@example.com", "Guest", "password123")
+
+	wsA, err := s.CreateWorkspace(models.WorkspaceCreate{Name: "Workspace A", OwnerID: owner.ID})
+	if err != nil {
+		t.Fatalf("create workspace A: %v", err)
+	}
+	wsB, err := s.CreateWorkspace(models.WorkspaceCreate{Name: "Workspace B", OwnerID: owner.ID})
+	if err != nil {
+		t.Fatalf("create workspace B: %v", err)
+	}
+
+	collB := createTestCollection(t, s, wsB.ID, "Tasks")
+	itemB := createTestItem(t, s, wsB.ID, collB.ID, "Secret B Item", "")
+
+	if _, err := s.CreateItemGrant(wsB.ID, itemB.ID, guest.ID, "edit", owner.ID); err != nil {
+		t.Fatalf("create item grant: %v", err)
+	}
+
+	// Item grant, wrong workspace → denied.
+	perm, err := s.ResolveUserPermission(wsA.ID, guest.ID, itemB.ID, "")
+	if err != nil {
+		t.Fatalf("resolve (foreign workspace, item grant): %v", err)
+	}
+	if perm != "" {
+		t.Fatalf("item grant in workspace B resolved for a request scoped to workspace A: got %q, want \"\"", perm)
+	}
+
+	// Item grant, own workspace → still works.
+	perm, err = s.ResolveUserPermission(wsB.ID, guest.ID, itemB.ID, "")
+	if err != nil {
+		t.Fatalf("resolve (own workspace, item grant): %v", err)
+	}
+	if perm != "edit" {
+		t.Fatalf("item grant did not resolve in its own workspace: got %q, want \"edit\"", perm)
+	}
+
+	// Same boundary for the collection grant lookup.
+	if _, err := s.CreateCollectionGrant(wsB.ID, collB.ID, guest.ID, "view", owner.ID); err != nil {
+		t.Fatalf("create collection grant: %v", err)
+	}
+
+	perm, err = s.ResolveUserPermission(wsA.ID, guest.ID, "", collB.ID)
+	if err != nil {
+		t.Fatalf("resolve (foreign workspace, collection grant): %v", err)
+	}
+	if perm != "" {
+		t.Fatalf("collection grant in workspace B resolved for a request scoped to workspace A: got %q, want \"\"", perm)
+	}
+
+	perm, err = s.ResolveUserPermission(wsB.ID, guest.ID, "", collB.ID)
+	if err != nil {
+		t.Fatalf("resolve (own workspace, collection grant): %v", err)
+	}
+	if perm != "view" {
+		t.Fatalf("collection grant did not resolve in its own workspace: got %q, want \"view\"", perm)
+	}
+}

--- a/internal/store/items_cross_workspace_copy.go
+++ b/internal/store/items_cross_workspace_copy.go
@@ -206,6 +206,16 @@ type CrossWorkspaceCopyRequest struct {
 	// single-backend deployment. See ErrCopyCrossBackendAttachments.
 	TargetBackend string
 
+	// AttachmentAuthorizer is the caller's per-attachment visibility check,
+	// handed straight to the planner (TASK-2408). It is the SAME value the
+	// preflight passes — both come out of resolveAuthorizedCopy — so the two
+	// endpoints agree about which references are unresolvable for the same
+	// reason they agree about everything else: one path, not two.
+	//
+	// See store.AttachmentAuthorizer for what nil means and why this is a
+	// callback rather than a pre-filtered id set.
+	AttachmentAuthorizer AttachmentAuthorizer
+
 	// PreCheck, when non-nil, runs INSIDE the transaction once every input has
 	// been re-read under the locks and before anything is written. Returning
 	// an error rolls the whole copy back.
@@ -663,6 +673,7 @@ func (s *Store) copyItemAcrossWorkspacesTx(req CrossWorkspaceCopyRequest, source
 		Content:           source.Content,
 		Fields:            finalFields,
 		TargetBackend:     req.TargetBackend,
+		Authorize:         req.AttachmentAuthorizer,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Closes the two attachment **security** defects surfaced by the Codex review of PLAN-2382, plus the data invariant beneath them.

First of three PRs splitting that work (PLAN-2391). Lifecycle (PLAN-2397) and rendering (PLAN-2398) follow.

## Why

`attachments.item_id` has no FK and no same-workspace constraint, and the upload handler persisted the caller-supplied value verbatim — so a workspace-A attachment row could point at a workspace-B item.

- **BUG-2387** — the attachment listing LEFT JOINed items without scoping the join, leaking another workspace's item title and slug.
- **BUG-2386** — the blob path opened with a flat `requireMinRole("viewer")`, and `roleLevel("guest")` is 0, so item-grant guests were rejected before any item-level check ran. Inline images broke in items shared with them.
- **BUG-2407** — cross-workspace copy authorized the source item and destination collection but never the individual attachments it cloned, so a restricted member could copy blobs they had no read access to into a workspace they own.

## Found during review, not in the original filings

Eleven rounds of plan review plus per-task and full-diff review surfaced **six** defects beyond the two bug reports:

| Defect | Where |
|---|---|
| Form-only item-grant guests 403'd before the association was parsed | upload |
| Existence oracle: 400-vs-404 distinguished hidden from missing items | upload |
| Existence oracle: error *code* still distinguished them after that fix | upload |
| Existence oracle: 403-vs-404 revealed live orphan UUIDs | blob read |
| No item-visibility gate **at all** | transform |
| Restricted members could download a guessed orphan UUID | blob read |
| Existence oracle: 403-vs-404 on the orphan gate ordering | delete |
| Existence oracle: `400 derived_attachment` emitted before authorization | delete |

BUG-2387 was also **worse than filed**: a restricted member filtering by a foreign collection received the attachment *row*, not just leaked metadata.

## Commits

| Commit | Change |
|---|---|
| `eae42b84` | Scope both `WorkspaceAttachments` JOINs (count *and* result) by workspace; reach collections through the scoped join |
| `27b71fe4` | Resolve `item_id` across both upload channels, persist the canonical UUID, defer the editor gate past parsing, clean up the multipart spool |
| `6e2b972f` | Gate blob reads on item visibility; workspace-scope the variant lookup; soft-deleted parent 404s |
| `380b75e1` | Gate transform on item visibility; lock the parent item inside the insert |
| `90eb871d` | Skip thumbnail derivation for an archived or malformed parent |
| `9ad71817` | Workspace-scope the item- and collection-grant lookups |
| `1da96106` | Centralize parent resolution; close orphan-read and delete-denial gaps found by the full-diff review |
| `ba848af8` | Check restriction before the role gate on orphan delete |
| `2318a17e` | Classify derived rows after authorization on delete |
| `e12feb46` | Authorize attachment references in cross-workspace copy (BUG-2407) |
| `b90e7eda` | Record the lock-held pool I/O hazard at the call site (BUG-2409) |

## Design notes

- **Denials are byte-identical by design.** Missing attachment, foreign parent, archived parent and invisible item all return the same 404 on every HTTP path. Three separate existence oracles were found and closed here; any new denial shape on these paths should be treated as a bug.
- **Read and delete diverge deliberately.** Read uses `GetItem` (archived parent → 404); delete keeps `GetItemIncludeDeleted` so owners can still reclaim quota from an archived item's attachments.
- **Transform locks, derivation doesn't.** Transform is user-initiated and low-volume, so it closes its check-then-work window with an item row lock (`FOR NO KEY UPDATE` — chosen over `FOR UPDATE` so it blocks archival without stalling the `FOR KEY SHARE` that inserts into the 13 tables referencing `items(id)` take, including the Yjs op-log). Derivation fans out from every image upload, so it accepts a documented window.
- **Item visibility IS blob-read permission.** If a future requirement says a guest may see an item but not download its attachments, that is a separate policy layer.

## Deliberately out of scope

- Share-token viewers still see missing-attachment placeholders — no new public byte-serving surface here (DR-1, → IDEA-2396).
- Attachment delete emits no SSE/webhook (DR-8, → IDEA-2395).
- The Put-then-insert untracked-blob window exists on upload, transform and derivation; the naive fix is wrong because storage is content-addressed (→ PLAN-2397 DR-18).
- Cross-workspace copy reads through the connection pool while holding both workspaces' advisory locks — an availability hazard, pre-existing in the planner, bounded here by per-parent-item memoization. The real fix is tx-bound reads, which is store transaction plumbing rather than an authorization change (→ BUG-2409).

## Test plan

- `make check` — exit 0
- `make test-pg` — exit 0, zero failures (`internal/store` 285s, `internal/server` 98s, `internal/mcp` 4.9s). Mandatory: every store-touching commit was gated on it, and it caught a test that passed on SQLite and failed intermittently on Postgres.
- Attachment authz suite under `-race -count=2` — clean
- **Every fix mutation-verified**: each was reverted in place and its tests confirmed to fail for the right reason
- New coverage: blob ACL matrix (original + both variants × GET/HEAD × item-grant / collection-grant / restricted / invisible / archived / orphan), MCP image-resource ACL, upload two-channel resolution and spool cleanup, transform authz and mid-flight archival, derivation parent guards, cross-workspace grant resolution

🤖 Generated with [Claude Code](https://claude.ai/code)