### PR TITLE
feat(attachments): file-type icons, an options panel, and a zoomable viewer (PLAN-2392)

### DIFF
--- a/internal/attachments/mime_families_test.go
+++ b/internal/attachments/mime_families_test.go
@@ -1,0 +1,112 @@
+package attachments
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+)
+
+// mimeFamiliesFixture is the shared MIME -> icon-family map the web client
+// uses to pick an attachment's file-type icon (PLAN-2392 DR-3a).
+//
+// It lives under the web root rather than next to this file because vitest's
+// `server.fs.allow` only permits the web root and node_modules, so the web
+// test cannot read across the repo — Go can, so the Go side reads the web
+// side's copy instead of the other way around.
+const mimeFamiliesFixture = "../../web/src/lib/attachments/mime-families.json"
+
+type mimeFamilies struct {
+	Families []string          `json:"families"`
+	MIME     map[string]string `json:"mime"`
+}
+
+func loadMIMEFamilies(t *testing.T) mimeFamilies {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Clean(mimeFamiliesFixture))
+	if err != nil {
+		t.Fatalf("read %s: %v", mimeFamiliesFixture, err)
+	}
+	var fixture mimeFamilies
+	if err := json.Unmarshal(raw, &fixture); err != nil {
+		t.Fatalf("parse %s: %v", mimeFamiliesFixture, err)
+	}
+	if len(fixture.Families) == 0 || len(fixture.MIME) == 0 {
+		t.Fatalf("%s is empty — families=%d mime=%d", mimeFamiliesFixture,
+			len(fixture.Families), len(fixture.MIME))
+	}
+	return fixture
+}
+
+// TestMIMEFamiliesCoverAllowlist is the drift guard between this package's
+// upload allowlist and the client's icon mapping. The allowlist is private Go
+// data, so a hand-maintained web-side copy would rot silently: adding a MIME
+// here without adding it to the fixture would leave real uploads rendering the
+// generic-file fallback with nothing to notice it. This test is what notices.
+func TestMIMEFamiliesCoverAllowlist(t *testing.T) {
+	fixture := loadMIMEFamilies(t)
+
+	known := make(map[string]bool, len(fixture.Families))
+	for _, family := range fixture.Families {
+		known[family] = true
+	}
+
+	var missing []string
+	for mime := range allowed {
+		family, ok := fixture.MIME[mime]
+		if !ok {
+			missing = append(missing, mime)
+			continue
+		}
+		if !known[family] {
+			t.Errorf("%s maps %q to unknown family %q (known: %v)",
+				mimeFamiliesFixture, mime, family, fixture.Families)
+		}
+	}
+
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		t.Errorf("allowlisted MIME types missing from %s: %v\n"+
+			"Add each to the fixture's \"mime\" object with the icon family it "+
+			"should render as, so the web client doesn't fall back to the "+
+			"generic file icon for a format we accept.",
+			mimeFamiliesFixture, missing)
+	}
+}
+
+// TestMIMEFamiliesFixtureHasNoStrays is the other direction: an entry in the
+// fixture that is not (and is no longer) on the allowlist is dead weight, and
+// usually means a MIME was removed from the allowlist without the client being
+// updated. Prefix and extension fallbacks cover anything unlisted, so the
+// fixture has no reason to carry non-allowlisted MIMEs.
+func TestMIMEFamiliesFixtureHasNoStrays(t *testing.T) {
+	fixture := loadMIMEFamilies(t)
+
+	var strays []string
+	for mime := range fixture.MIME {
+		if _, ok := allowed[mime]; !ok {
+			strays = append(strays, mime)
+		}
+	}
+
+	if len(strays) > 0 {
+		sort.Strings(strays)
+		t.Errorf("%s lists MIME types that are not on the upload allowlist: %v",
+			mimeFamiliesFixture, strays)
+	}
+}
+
+// TestMIMEFamiliesKeysAreNormalized keeps fixture lookups honest: the client
+// normalizes a MIME (strip parameters, lowercase) before indexing this map,
+// exactly as LookupMIME does, so a key that isn't already normalized could
+// never match.
+func TestMIMEFamiliesKeysAreNormalized(t *testing.T) {
+	fixture := loadMIMEFamilies(t)
+
+	for mime := range fixture.MIME {
+		if got := NormalizeMIME(mime); got != mime {
+			t.Errorf("%s key %q is not normalized (want %q)", mimeFamiliesFixture, mime, got)
+		}
+	}
+}

--- a/web/e2e/item-attachment-strip.spec.ts
+++ b/web/e2e/item-attachment-strip.spec.ts
@@ -136,9 +136,19 @@ test.describe('item attachment strip', () => {
 		await browserLogin(page);
 
 		const doc = await seedDoc(fixture, request, 'Strip host empty');
+		// Arm BEFORE navigating: absence is only meaningful once the strip's
+		// list request has actually answered. Without this the assertion can
+		// pass while the fetch is still in flight — and since TASK-2418 a slow
+		// fetch deliberately paints a loading row, which would make the timing
+		// visible rather than merely unproven.
+		const listSettled = page.waitForResponse(
+			(r) => r.request().method() === 'GET' && r.url().includes('/attachments?'),
+			{ timeout: 15_000 }
+		);
 		await page.goto(itemUrl(fixture, doc.slug));
 		// Wait for the editor so we know the page settled before asserting absence.
 		await expect(page.locator('.editor-content .ProseMirror').first()).toBeVisible();
+		await listSettled;
 		await expect(page.locator(STRIP)).toHaveCount(0);
 	});
 
@@ -164,12 +174,22 @@ test.describe('item attachment strip', () => {
 			await route.fallback();
 		});
 
+		// `listCalls` counts REQUESTS (the route handler runs at request time),
+		// so it can't tell us the load finished — wait on the RESPONSE for
+		// that. Armed before navigating, per the empty-item test above.
+		const listSettled = page.waitForResponse(
+			(r) => r.request().method() === 'GET' && r.url().includes('/attachments?'),
+			{ timeout: 15_000 }
+		);
 		await page.goto(itemUrl(fixture, doc.slug));
 		await expect(page.locator('.editor-content .ProseMirror').first()).toBeVisible();
-		await expect(page.locator(STRIP)).toHaveCount(0);
-		// Let the initial GET settle before the drop, so the count below is a
-		// clean baseline AND the fetch-vs-upload merge isn't what we're relying on.
+		// Let the initial GET settle FIRST, so the count below is a clean
+		// baseline, the fetch-vs-upload merge isn't what we're relying on, and
+		// the absence assertion isn't racing the in-flight load (which since
+		// TASK-2418 paints a loading row when it is slow).
+		await listSettled;
 		await expect.poll(() => listCalls, { timeout: 10_000 }).toBeGreaterThan(0);
+		await expect(page.locator(STRIP)).toHaveCount(0);
 		const callsBeforeDrop = listCalls;
 
 		// TASK-2385: the upload announces on the attachment event bus and the

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -372,10 +372,35 @@ input:focus, textarea:focus {
 	border-color: color-mix(in srgb, var(--accent-blue) 35%, var(--border));
 	text-decoration: none;
 }
+/* The editor NodeView renders an SVG file-type icon here (TASK-2417); the
+   read-only markdown render path still emits a text glyph, so these rules
+   have to work for both. currentColor keeps the SVG themed and
+   forced-colors safe. */
 .file-chip-icon {
 	flex-shrink: 0;
+	display: flex;
+	align-items: center;
 	font-size: 1.05em;
 	line-height: 1;
+}
+.file-chip-icon > svg {
+	color: var(--text-secondary);
+}
+
+/* Deleted / missing target. The chip used to signal this by swapping its
+   glyph to a paperclip; the icon now says what KIND of file it is, so the
+   dead state gets its own treatment on the chip instead (TASK-2417). The
+   compound selector keeps this off the markdown renderer's bare
+   .attachment-missing span, which has its own inline marker. */
+.file-chip.attachment-missing {
+	color: var(--text-muted);
+	border-style: dashed;
+	cursor: default;
+	text-decoration: line-through;
+}
+.file-chip.attachment-missing:hover {
+	background: var(--bg-tertiary);
+	border-color: var(--border-subtle);
 }
 .file-chip-name {
 	overflow: hidden;

--- a/web/src/lib/attachments/display.test.ts
+++ b/web/src/lib/attachments/display.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from 'vitest';
+import { formatBytes, iconForAttachment, isImage } from './display';
+import { ATTACHMENT_ICON_IDS, ATTACHMENT_ICON_PATHS, iconSvg } from './icons/index';
+import familyFixture from './mime-families.json';
+
+/**
+ * Icon-mapping coverage per PLAN-2392 DR-3a: one representative MIME per
+ * family, plus the unknown-MIME and no-extension cases. Full coverage of the
+ * MIME list lives on the Go side (internal/attachments/mime_families_test.go),
+ * which asserts the shared fixture covers the server's upload allowlist — full
+ * coverage where drift happens, representative coverage where it doesn't.
+ */
+describe('iconForAttachment', () => {
+	const representative: Array<[string, string]> = [
+		['image/png', 'image'],
+		['video/mp4', 'video'],
+		['audio/mpeg', 'audio'],
+		['application/vnd.openxmlformats-officedocument.wordprocessingml.document', 'document'],
+		['application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', 'spreadsheet'],
+		['application/vnd.openxmlformats-officedocument.presentationml.presentation', 'presentation'],
+		['application/pdf', 'pdf'],
+		['application/zip', 'archive'],
+		['text/plain', 'text'],
+	];
+
+	it.each(representative)('maps %s to the %s icon', (mime, family) => {
+		expect(iconForAttachment(mime, 'file.bin')).toBe(family);
+	});
+
+	it('covers every icon family except the generic fallback', () => {
+		const covered = new Set(representative.map(([, family]) => family));
+		const uncovered = ATTACHMENT_ICON_IDS.filter((id) => id !== 'generic' && !covered.has(id));
+		expect(uncovered).toEqual([]);
+	});
+
+	it('falls back to the generic file icon for an unknown MIME, never a question mark', () => {
+		expect(iconForAttachment('application/octet-stream', 'mystery.bin')).toBe('generic');
+		expect(iconForAttachment('application/x-unheard-of')).toBe('generic');
+	});
+
+	it('falls back to the generic file icon when there is no extension at all', () => {
+		expect(iconForAttachment('', 'LICENSE')).toBe('generic');
+		expect(iconForAttachment(null, null)).toBe('generic');
+		expect(iconForAttachment(undefined, undefined)).toBe('generic');
+	});
+
+	it('uses the filename extension when the MIME is missing or unhelpful', () => {
+		// The editor chip renders before its HEAD probe resolves, so this is
+		// the chip's first paint, not a hypothetical.
+		expect(iconForAttachment(null, 'quarterly.xlsx')).toBe('spreadsheet');
+		expect(iconForAttachment('application/octet-stream', 'deck.pptx')).toBe('presentation');
+		expect(iconForAttachment('', 'notes.md')).toBe('text');
+	});
+
+	it('prefers a known MIME over a misleading extension', () => {
+		expect(iconForAttachment('application/pdf', 'report.docx')).toBe('pdf');
+		expect(iconForAttachment('text/plain', 'rows.csv')).toBe('text');
+	});
+
+	it('normalizes case and parameters like the server does', () => {
+		expect(iconForAttachment('TEXT/CSV', 'a')).toBe('spreadsheet');
+		expect(iconForAttachment('text/plain; charset=utf-8', 'a')).toBe('text');
+	});
+
+	it('still recognizes the office and archive families the old helpers matched by pattern', () => {
+		// Not on today's upload allowlist, but rows predating it can carry
+		// these — dropping them to the generic icon would be a regression.
+		expect(iconForAttachment('application/x-rar-compressed', 'old')).toBe('archive');
+		expect(iconForAttachment('application/vnd.ms-excel.sheet.macroEnabled.12', 'old')).toBe(
+			'spreadsheet',
+		);
+		expect(
+			iconForAttachment('application/vnd.ms-powerpoint.presentation.macroEnabled.12', 'old'),
+		).toBe('presentation');
+		expect(iconForAttachment('application/vnd.ms-word.document.macroEnabled.12', 'old')).toBe(
+			'document',
+		);
+	});
+
+	it('keeps the old helper "any other vendor office format is a document" tier', () => {
+		expect(iconForAttachment('application/vnd.ms-project', 'plan')).toBe('document');
+		expect(iconForAttachment('application/vnd.oasis.opendocument.graphics', 'draw')).toBe(
+			'document',
+		);
+		expect(iconForAttachment('application/vnd.openxmlformats-officedocument.theme+xml', 'x')).toBe(
+			'document',
+		);
+	});
+
+	it('does not claim a MIME that merely contains an archive word', () => {
+		expect(iconForAttachment('application/vnd.example.uncompressed-document', 'x')).toBe('generic');
+		// application/vnd.airzip.filesecure.azf is an encrypted document, not a
+		// ZIP — the archive patterns are token-delimited for exactly this.
+		expect(iconForAttachment('application/vnd.airzip.filesecure.azf', 'secure')).toBe('generic');
+		expect(iconForAttachment('application/zip', 'a')).toBe('archive');
+		expect(iconForAttachment('application/x-zip-compressed', 'a')).toBe('archive');
+		expect(iconForAttachment('application/x-rar-compressed', 'a')).toBe('archive');
+	});
+
+	it('recognizes unlisted media by type prefix', () => {
+		expect(iconForAttachment('image/jxl', 'future.jxl')).toBe('image');
+		expect(iconForAttachment('video/ogg', 'clip')).toBe('video');
+		expect(iconForAttachment('audio/x-aiff', 'take1')).toBe('audio');
+	});
+
+	it('lets an extension win over an UNLISTED text/* MIME', () => {
+		// text/* is the widest prefix fallback, so it is consulted last.
+		expect(iconForAttachment('text/x-comma-separated-values', 'rows.csv')).toBe('spreadsheet');
+		expect(iconForAttachment('text/x-nonsense', 'unnamed')).toBe('text');
+	});
+
+	it('only ever returns a renderable icon id', () => {
+		// The Go test checks the fixture covers the server allowlist and that
+		// each value is in the fixture's own `families` list — it has no way to
+		// know what the TS icon set actually renders. These two assertions are
+		// the other half of that contract: `families` IS the icon set, and
+		// every mapped MIME resolves to something renderable. Without them a
+		// fixture could be Go-green and still paint nothing.
+		expect([...familyFixture.families].sort()).toEqual([...ATTACHMENT_ICON_IDS].sort());
+		for (const family of Object.values(familyFixture.mime)) {
+			expect(ATTACHMENT_ICON_IDS).toContain(family);
+		}
+	});
+
+	it('renders every allowlisted MIME in the fixture as a real icon', () => {
+		for (const [mime, family] of Object.entries(familyFixture.mime)) {
+			expect(iconForAttachment(mime, 'no-extension')).toBe(family);
+			expect(iconSvg(iconForAttachment(mime, 'no-extension'))).toContain('<path d="');
+		}
+	});
+});
+
+describe('iconSvg', () => {
+	it('renders every family as a currentColor-driven SVG', () => {
+		for (const id of ATTACHMENT_ICON_IDS) {
+			const svg = iconSvg(id);
+			expect(svg).toContain('stroke="currentColor"');
+			expect(svg).toContain('aria-hidden="true"');
+			expect(svg).toContain(ATTACHMENT_ICON_PATHS[id]);
+		}
+	});
+
+	it('gives every family a distinct shape', () => {
+		const paths = new Set(Object.values(ATTACHMENT_ICON_PATHS));
+		expect(paths.size).toBe(ATTACHMENT_ICON_IDS.length);
+	});
+
+	it('renders the generic icon for an unknown id rather than throwing', () => {
+		expect(iconSvg('not-a-family')).toBe(iconSvg('generic'));
+	});
+
+	it('scales with the surrounding type by default and accepts an explicit size', () => {
+		expect(iconSvg('pdf')).toContain('width="1em"');
+		expect(iconSvg('pdf', { size: 24 })).toContain('width="24px"');
+		expect(iconSvg('pdf', { size: '2rem' })).toContain('width="2rem"');
+	});
+
+	it('refuses a size that would break out of the attribute', () => {
+		expect(iconSvg('pdf', { size: '1em" onload="alert(1)' })).toContain('width="1em"');
+		expect(iconSvg('pdf', { size: Number.NaN })).toContain('width="1em"');
+		expect(iconSvg('pdf', { size: -8 })).toContain('width="1em"');
+	});
+});
+
+describe('formatBytes', () => {
+	// Unchanged by TASK-2417 — pinned here because the editor chip now depends
+	// on it rendering "0 B" (the chip hides that at its own call site, DR-3b).
+	it('renders a zero size rather than an empty string', () => {
+		expect(formatBytes(0)).toBe('0 B');
+	});
+
+	it('picks a unit so the value stays under 1024', () => {
+		expect(formatBytes(999)).toBe('999 B');
+		expect(formatBytes(1024)).toBe('1.0 KB');
+		expect(formatBytes(1048575)).toBe('1.0 MB');
+		expect(formatBytes(15 * 1024 * 1024)).toBe('15 MB');
+	});
+});
+
+describe('isImage', () => {
+	it('still answers the general "is this a picture" question', () => {
+		expect(isImage('image/png')).toBe(true);
+		expect(isImage('application/pdf')).toBe(false);
+	});
+});

--- a/web/src/lib/attachments/display.ts
+++ b/web/src/lib/attachments/display.ts
@@ -1,15 +1,30 @@
 /**
- * Display helpers shared by every attachment surface (TASK-2383).
+ * Display helpers shared by every attachment surface (TASK-2383, TASK-2417).
  *
  * These were private to `$lib/components/settings/StorageTab.svelte` until the
- * item attachment strip needed the same mime table; extracted here verbatim so
- * there is exactly one icon mapping and one byte formatter to maintain.
+ * item attachment strip needed the same mime table; extracted here so there is
+ * exactly one icon mapping and one byte formatter to maintain.
+ *
+ * TASK-2417 (PLAN-2392 DR-3) folded the editor chip's two private icon helpers
+ * into `iconForAttachment` below, so the live attachment surfaces — strip,
+ * StorageTab, editor chip — now share one mapper. (The static markdown
+ * renderer's byte formatter and CopyItemDialog's are deliberately out of
+ * scope; this is "three live helpers become one", not "one formatter exists in
+ * the repo".)
  */
+
+import familyFixture from './mime-families.json';
+import { GENERIC_ICON_ID, isAttachmentIconId, type AttachmentIconId } from './icons/index';
 
 // Same algorithm as web/src/routes/console/billing/+page.svelte. Picks a
 // unit so the displayed value is < 1024; bump thresholds nudged down half
 // the previous unit so 1,048,575 bytes reads as "1.0 MB" rather than the
 // misleading "1024 KB" you'd get from a straight Math.round at the KB tier.
+//
+// Note this renders `0 B` for a zero byte count and does not special-case
+// non-finite input — deliberately (DR-3b). A surface that would rather show
+// nothing than "0 B" (the editor chip) keeps that conditional at its own call
+// site; the helper does not grow a mode.
 export function formatBytes(bytes: number): string {
 	if (bytes < 0) return `${bytes} B`;
 	const KB = 1024;
@@ -28,28 +43,179 @@ function formatUnit(value: number, unit: string): string {
 	return `${value.toFixed(1)} ${unit}`;
 }
 
-export function categoryIcon(mime: string): string {
-	if (mime.startsWith('image/')) return '🖼️';
-	if (mime.startsWith('video/')) return '🎬';
-	if (mime.startsWith('audio/')) return '🔊';
-	if (mime.startsWith('text/')) return '📄';
-	if (mime === 'application/pdf') return '📄';
-	if (
-		mime === 'application/zip' ||
-		mime === 'application/x-tar' ||
-		mime === 'application/gzip' ||
-		mime === 'application/x-7z-compressed' ||
-		mime === 'application/x-rar-compressed'
-	)
-		return '📦';
-	if (
-		mime.startsWith('application/vnd.openxmlformats') ||
-		mime.startsWith('application/vnd.ms-') ||
-		mime.startsWith('application/vnd.oasis') ||
-		mime === 'application/msword'
-	)
-		return '📄';
-	return '❓';
+/**
+ * MIME → icon family, from the shared fixture. A Go test asserts the server's
+ * upload allowlist is fully covered by that file (PLAN-2392 DR-3a), so the two
+ * lists cannot drift apart silently.
+ */
+const MIME_FAMILIES: Record<string, string> = familyFixture.mime;
+
+/**
+ * Extension → icon family for the fallback path. The editor chip renders
+ * before its HEAD probe returns a MIME, and a stored MIME can be a generic
+ * `application/octet-stream`, so the filename is a real second source rather
+ * than a theoretical one. Deliberately broader than the allowlist: an
+ * extension costs nothing to recognize even for a format we would refuse as an
+ * upload.
+ */
+const EXTENSION_FAMILIES: Record<string, AttachmentIconId> = {
+	png: 'image',
+	jpg: 'image',
+	jpeg: 'image',
+	gif: 'image',
+	webp: 'image',
+	avif: 'image',
+	heic: 'image',
+	heif: 'image',
+	bmp: 'image',
+	tif: 'image',
+	tiff: 'image',
+	svg: 'image',
+	mp4: 'video',
+	webm: 'video',
+	mov: 'video',
+	mkv: 'video',
+	avi: 'video',
+	mp3: 'audio',
+	wav: 'audio',
+	ogg: 'audio',
+	flac: 'audio',
+	aac: 'audio',
+	m4a: 'audio',
+	pdf: 'pdf',
+	doc: 'document',
+	docx: 'document',
+	odt: 'document',
+	rtf: 'document',
+	xls: 'spreadsheet',
+	xlsx: 'spreadsheet',
+	ods: 'spreadsheet',
+	csv: 'spreadsheet',
+	tsv: 'spreadsheet',
+	ppt: 'presentation',
+	pptx: 'presentation',
+	odp: 'presentation',
+	zip: 'archive',
+	tar: 'archive',
+	gz: 'archive',
+	tgz: 'archive',
+	bz2: 'archive',
+	'7z': 'archive',
+	rar: 'archive',
+	txt: 'text',
+	md: 'text',
+	json: 'text',
+	xml: 'text',
+	yaml: 'text',
+	yml: 'text',
+	toml: 'text',
+	html: 'text',
+	js: 'text',
+	ts: 'text',
+	css: 'text',
+	sh: 'text',
+	go: 'text',
+	py: 'text',
+};
+
+/**
+ * Pattern → family, checked after an exact fixture hit and the media-type
+ * prefixes. Order matters: the specific `…ml` / `opendocument.*` markers come
+ * first, so `application/vnd.ms-excel.sheet.macroEnabled.12` lands on
+ * spreadsheet rather than on a broader match.
+ *
+ * The archive patterns are token-delimited on purpose. A bare `includes('zip')`
+ * claims `application/vnd.airzip.filesecure.azf`, which is an encrypted
+ * FileSECURE document and not an archive at all (Codex review).
+ */
+const MIME_PATTERNS: ReadonlyArray<readonly [RegExp, AttachmentIconId]> = [
+	[/wordprocessingml/, 'document'],
+	[/spreadsheetml/, 'spreadsheet'],
+	[/presentationml/, 'presentation'],
+	[/opendocument\.text/, 'document'],
+	[/opendocument\.spreadsheet/, 'spreadsheet'],
+	[/opendocument\.presentation/, 'presentation'],
+	[/(^|[.\-+/])ms-?excel([.\-+]|$)/, 'spreadsheet'],
+	[/(^|[.\-+/])ms-?powerpoint([.\-+]|$)/, 'presentation'],
+	[/(^|[.\-+/])ms-?word([.\-+]|$)/, 'document'],
+	[/(^|[.\-+/])compressed([.\-+]|$)/, 'archive'],
+	[/(^|[.\-+/])g?zip([.\-+]|$)/, 'archive'],
+	[/(^|[.\-+/])rar([.\-+]|$)/, 'archive'],
+	[/(^|[.\-+/])x-tar([.\-+]|$)/, 'archive'],
+	// Generic office tier, last so the specific rules above win. These are the
+	// three prefixes the deleted `categoryIcon` treated as "a document": every
+	// vendor office format it didn't recognize more precisely (vnd.ms-project,
+	// opendocument.graphics, …) landed on the document glyph rather than the
+	// unknown one, and that is still the better answer than generic.
+	[/^application\/vnd\.openxmlformats/, 'document'],
+	[/^application\/vnd\.oasis/, 'document'],
+	[/^application\/vnd\.ms-/, 'document'],
+];
+
+/** Strip parameters and case, matching the server's `NormalizeMIME`. */
+function normalizeMime(mime: string | null | undefined): string {
+	if (!mime) return '';
+	const semi = mime.indexOf(';');
+	return (semi >= 0 ? mime.slice(0, semi) : mime).trim().toLowerCase();
+}
+
+function extensionOf(filename: string | null | undefined): string {
+	if (!filename) return '';
+	return filename.toLowerCase().match(/\.([a-z0-9]+)$/)?.[1] ?? '';
+}
+
+/**
+ * Pick the file-type icon for an attachment: MIME first, filename extension
+ * second, generic file last. Returns an icon *identifier* — resolve it with
+ * `AttachmentIcon.svelte` or `iconSvg()` from `./icons`.
+ *
+ * Renamed from `categoryIcon` in TASK-2417 (PLAN-2392 DR-3): it no longer
+ * returns an emoji, it takes the filename as a second source, and it
+ * deliberately does NOT correspond to the server's `Category` enum — that
+ * bucketing drives storage quotas and is too coarse to tell a spreadsheet from
+ * a slide deck.
+ *
+ * There is no "unknown" result: an unrecognized format gets the generic file
+ * icon, never a question mark (DR-3a). The upload allowlist accepts formats
+ * the extension table can't be relied on to catch — a valid upload may have no
+ * extension at all — so a calm default is the only honest fallback.
+ */
+export function iconForAttachment(
+	mime: string | null | undefined,
+	filename?: string | null,
+): AttachmentIconId {
+	const m = normalizeMime(mime);
+
+	const mapped = MIME_FAMILIES[m];
+	if (mapped && isAttachmentIconId(mapped)) return mapped;
+
+	// Type-prefix fallback for media the allowlist doesn't enumerate — a
+	// future `image/jxl` should still read as a picture.
+	if (m.startsWith('image/')) return 'image';
+	if (m.startsWith('video/')) return 'video';
+	if (m.startsWith('audio/')) return 'audio';
+
+	// Pattern fallback for office/archive families the allowlist doesn't
+	// enumerate. The helpers this replaced matched these by pattern, and rows
+	// predating the current allowlist can still carry them (`x-rar-compressed`
+	// was in the old `categoryIcon`), so dropping to the generic icon here
+	// would be a visible regression on existing data rather than a
+	// simplification.
+	for (const [pattern, family] of MIME_PATTERNS) {
+		if (pattern.test(m)) return family;
+	}
+
+	const byExtension = EXTENSION_FAMILIES[extensionOf(filename)];
+	if (byExtension) return byExtension;
+
+	// Last, and after the extension check: `text/*` is the widest of the
+	// prefixes, so an unlisted text MIME (`text/x-comma-separated-values`)
+	// should not out-vote a filename that says exactly what the file is. An
+	// EXACT MIME hit above still wins over the extension — a mislabelled
+	// filename shouldn't override a known type.
+	if (m.startsWith('text/')) return 'text';
+
+	return GENERIC_ICON_ID;
 }
 
 export function isImage(mime: string): boolean {

--- a/web/src/lib/attachments/icons/AttachmentIcon.svelte
+++ b/web/src/lib/attachments/icons/AttachmentIcon.svelte
@@ -1,0 +1,41 @@
+<!--
+	AttachmentIcon — the Svelte render path for the attachment file-type icon
+	set (PLAN-2392 DR-3b). Imperative consumers (the editor's chip NodeView)
+	call `iconSvg()` from ./index instead; both read the same path table, so
+	the two surfaces can't drift.
+
+	The icon is decorative — `aria-hidden` comes from ICON_SVG_ATTRS and every
+	call site labels the attachment with its filename in real text.
+-->
+<script lang="ts">
+	import {
+		ATTACHMENT_ICON_PATHS,
+		GENERIC_ICON_ID,
+		ICON_SVG_ATTRS,
+		iconSize,
+		isAttachmentIconId,
+	} from './index';
+
+	let {
+		id,
+		size = undefined,
+	}: {
+		/** An icon id — usually `iconForAttachment(mime, filename)`. Unknown ids render the generic file. */
+		id: string;
+		/** CSS length, or a number of pixels. Defaults to `1em` so it scales with the surface's type. */
+		size?: number | string;
+	} = $props();
+
+	const iconId = $derived(isAttachmentIconId(id) ? id : GENERIC_ICON_ID);
+	const box = $derived(iconSize(size));
+</script>
+
+<svg
+	xmlns="http://www.w3.org/2000/svg"
+	width={box}
+	height={box}
+	style="display:block"
+	{...ICON_SVG_ATTRS}
+>
+	<path d={ATTACHMENT_ICON_PATHS[iconId]} />
+</svg>

--- a/web/src/lib/attachments/icons/index.ts
+++ b/web/src/lib/attachments/icons/index.ts
@@ -1,0 +1,131 @@
+/**
+ * Attachment file-type icon set (PLAN-2392 DR-3b).
+ *
+ * One monochrome, `currentColor`-driven icon per format family. Monochrome
+ * and stroke-only is deliberate: the icons inherit the surrounding text
+ * color, so they theme with light/dark for free and stay visible under
+ * `forced-colors`, where a hard-coded palette would not.
+ *
+ * TWO RENDER PATHS, ONE DEFINITION. Svelte call sites mount
+ * `AttachmentIcon.svelte`; the editor's chip NodeView builds its DOM
+ * imperatively and cannot mount a component, so it calls `iconSvg()` for
+ * the same markup. Both read `ATTACHMENT_ICON_PATHS` and `ICON_SVG_ATTRS`
+ * below — add an icon here and both surfaces get it.
+ *
+ * Every icon is a single `<path d>` with multiple subpaths so the two
+ * render paths stay trivially equivalent (the component can render the
+ * path declaratively rather than reaching for `{@html}`).
+ *
+ * Icons are decorative: they always carry `aria-hidden="true"`, and every
+ * call site labels the attachment with its filename in real text.
+ */
+
+export const ATTACHMENT_ICON_IDS = [
+	'image',
+	'video',
+	'audio',
+	'document',
+	'spreadsheet',
+	'presentation',
+	'pdf',
+	'archive',
+	'text',
+	'generic',
+] as const;
+
+export type AttachmentIconId = (typeof ATTACHMENT_ICON_IDS)[number];
+
+/** The fallback for anything unrecognized — a plain file, never a "❓" (DR-3a). */
+export const GENERIC_ICON_ID: AttachmentIconId = 'generic';
+
+// The blank-page outline the document-ish icons are built on: a page with
+// a folded top-right corner.
+const PAGE = 'M13.5 2.5H7A2 2 0 0 0 5 4.5v15a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V8z M13.5 2.5V8H19';
+
+export const ATTACHMENT_ICON_PATHS: Record<AttachmentIconId, string> = {
+	// Framed picture: sun + horizon line.
+	image:
+		'M3.5 5.5A2 2 0 0 1 5.5 3.5h13a2 2 0 0 1 2 2v13a2 2 0 0 1-2 2h-13a2 2 0 0 1-2-2z ' +
+		'M10 9.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z ' +
+		'M3.5 17l4.5-4.5 3 3 3.5-3.5 6 6',
+	// Screen with a play triangle.
+	video:
+		'M3.5 6.5a2 2 0 0 1 2-2h13a2 2 0 0 1 2 2v11a2 2 0 0 1-2 2h-13a2 2 0 0 1-2-2z ' +
+		'M10 8.5l6 3.5-6 3.5z',
+	// Two-stem musical note.
+	audio: 'M9 18V6l10-2v12 M9 18a2.5 2.5 0 1 1-5 0 2.5 2.5 0 0 1 5 0z M19 16a2.5 2.5 0 1 1-5 0 2.5 2.5 0 0 1 5 0z',
+	// Page with lines of prose.
+	document: `${PAGE} M8 12.5h8 M8 16h8 M8 19h5`,
+	// Page with a cell grid.
+	spreadsheet: `${PAGE} M7.5 11.5h9v8h-9z M7.5 15.5h9 M12 11.5v8`,
+	// Projector screen on a stand.
+	presentation: 'M3 4h18 M4.5 4v10a2 2 0 0 0 2 2h11a2 2 0 0 0 2-2V4 M12 16v3 M9 20.5h6',
+	// Page with a bookmark ribbon.
+	pdf: `${PAGE} M9.5 11.5h5v7l-2.5-2.2-2.5 2.2z`,
+	// Crate with a lid and a latch.
+	archive: 'M3.5 8h17v10.5a2 2 0 0 1-2 2h-13a2 2 0 0 1-2-2z M2.5 3.5h19V8h-19z M10 11.5h4',
+	// Angle brackets with a slash — text and code share one family.
+	text: 'M8.5 8.5L4.5 12l4 3.5 M15.5 8.5l4 3.5-4 3.5 M13.5 5l-3 14',
+	// Bare page — the fallback.
+	generic: PAGE,
+};
+
+/**
+ * SVG element attributes shared by both render paths. `stroke="currentColor"`
+ * + `fill="none"` is what makes the set theme-aware and forced-colors-safe;
+ * `focusable="false"` keeps IE/legacy-Edge-style tab stops out of the chip.
+ */
+export const ICON_SVG_ATTRS = {
+	viewBox: '0 0 24 24',
+	fill: 'none',
+	stroke: 'currentColor',
+	'stroke-width': '1.5',
+	'stroke-linecap': 'round',
+	'stroke-linejoin': 'round',
+	'aria-hidden': 'true',
+	focusable: 'false',
+} as const;
+
+/** Narrow an arbitrary string to a known icon id, falling back to generic. */
+export function isAttachmentIconId(id: string): id is AttachmentIconId {
+	return (ATTACHMENT_ICON_IDS as readonly string[]).includes(id);
+}
+
+/**
+ * Default icon box. `1em` rather than a pixel count so an icon scales with
+ * whatever type size its surface uses — the same behavior the emoji this set
+ * replaces had for free.
+ */
+const DEFAULT_ICON_SIZE = '1em';
+
+const SIZE_PATTERN = /^[0-9]+(\.[0-9]+)?(px|em|rem|%)$/;
+
+/** Coerce a caller-supplied size to a safe CSS length. Numbers mean pixels. */
+export function iconSize(size: number | string | undefined): string {
+	if (typeof size === 'number') {
+		return Number.isFinite(size) && size > 0 ? `${size}px` : DEFAULT_ICON_SIZE;
+	}
+	if (typeof size === 'string' && SIZE_PATTERN.test(size)) return size;
+	return DEFAULT_ICON_SIZE;
+}
+
+/**
+ * Render an icon as SVG markup for imperative consumers (the editor's chip
+ * NodeView). Svelte call sites should use `AttachmentIcon.svelte` instead.
+ *
+ * Everything interpolated here is either a repo constant or run through
+ * `iconSize`, so the result is safe to assign to `innerHTML`.
+ */
+export function iconSvg(id: string, options: { size?: number | string } = {}): string {
+	const iconId = isAttachmentIconId(id) ? id : GENERIC_ICON_ID;
+	const size = iconSize(options.size);
+	const attrs = Object.entries(ICON_SVG_ATTRS)
+		.map(([key, value]) => `${key}="${value}"`)
+		.join(' ');
+	return (
+		`<svg xmlns="http://www.w3.org/2000/svg" width="${size}" height="${size}" ` +
+		`style="display:block" ${attrs}>` +
+		`<path d="${ATTACHMENT_ICON_PATHS[iconId]}"/>` +
+		`</svg>`
+	);
+}

--- a/web/src/lib/attachments/mime-families.json
+++ b/web/src/lib/attachments/mime-families.json
@@ -1,0 +1,73 @@
+{
+	"$comment": "Shared MIME -> icon-family map (PLAN-2392 DR-3a). Single source of truth for both sides: web/src/lib/attachments/display.ts imports it as its mapping table, and internal/attachments/mime_families_test.go asserts that EVERY MIME on the server upload allowlist (internal/attachments/mime.go) appears here. Add a MIME to the server allowlist without adding it here and the Go test fails; the web test asserts one representative MIME per family still renders the expected icon. This file lives inside the web root because vitest's server.fs.allow permits only the web root and node_modules, while Go can read across the repo freely. Entries are the allowlisted MIMEs only — anything else falls back to the type prefix, then the filename extension, then the generic-file icon (DR-3a: never a question mark).",
+	"families": [
+		"image",
+		"video",
+		"audio",
+		"document",
+		"spreadsheet",
+		"presentation",
+		"pdf",
+		"archive",
+		"text",
+		"generic"
+	],
+	"mime": {
+		"image/png": "image",
+		"image/jpeg": "image",
+		"image/gif": "image",
+		"image/webp": "image",
+		"image/avif": "image",
+		"image/heic": "image",
+		"image/heif": "image",
+
+		"video/mp4": "video",
+		"video/webm": "video",
+		"video/quicktime": "video",
+		"video/x-matroska": "video",
+		"video/x-msvideo": "video",
+
+		"audio/mpeg": "audio",
+		"audio/wav": "audio",
+		"audio/ogg": "audio",
+		"audio/webm": "audio",
+		"audio/flac": "audio",
+		"audio/aac": "audio",
+		"audio/mp4": "audio",
+
+		"application/pdf": "pdf",
+
+		"application/msword": "document",
+		"application/vnd.openxmlformats-officedocument.wordprocessingml.document": "document",
+		"application/vnd.oasis.opendocument.text": "document",
+		"application/rtf": "document",
+
+		"application/vnd.ms-excel": "spreadsheet",
+		"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": "spreadsheet",
+		"application/vnd.oasis.opendocument.spreadsheet": "spreadsheet",
+		"text/csv": "spreadsheet",
+		"text/tab-separated-values": "spreadsheet",
+
+		"application/vnd.ms-powerpoint": "presentation",
+		"application/vnd.openxmlformats-officedocument.presentationml.presentation": "presentation",
+		"application/vnd.oasis.opendocument.presentation": "presentation",
+
+		"application/zip": "archive",
+		"application/x-tar": "archive",
+		"application/gzip": "archive",
+		"application/x-bzip2": "archive",
+		"application/x-7z-compressed": "archive",
+
+		"text/plain": "text",
+		"text/markdown": "text",
+		"text/html": "text",
+		"text/xml": "text",
+		"text/javascript": "text",
+		"text/yaml": "text",
+		"application/json": "text",
+		"application/xml": "text",
+		"application/yaml": "text",
+		"application/toml": "text",
+		"application/javascript": "text"
+	}
+}

--- a/web/src/lib/attachments/storageFilters.test.ts
+++ b/web/src/lib/attachments/storageFilters.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { buildStorageFilters, hasActiveStorageFilters } from './storageFilters';
+
+// PLAN-2392 DR-18. The item attachment strip's "View all (N)" link hands off
+// `?attachment_item=<uuid>`; StorageTab seeds `item_id` from it. These pin the
+// receiving end's one non-obvious rule.
+
+const base = { limit: 50, offset: 0 };
+
+describe('buildStorageFilters', () => {
+	it('passes an item scope through as item_id', () => {
+		expect(buildStorageFilters({ ...base, itemId: 'item-uuid' })).toEqual({
+			limit: 50,
+			offset: 0,
+			item_id: 'item-uuid',
+		});
+	});
+
+	it('drops the attached/unattached selector while an item scope is set', () => {
+		// item_id + item=unattached is a contradiction server-side and returns
+		// an empty set — the scope must win rather than silently empty the list.
+		const f = buildStorageFilters({ ...base, itemId: 'item-uuid', item: 'unattached' });
+		expect(f.item_id).toBe('item-uuid');
+		expect(f.item).toBeUndefined();
+	});
+
+	it('honours the attached/unattached selector once the scope is cleared', () => {
+		const f = buildStorageFilters({ ...base, itemId: '', item: 'unattached' });
+		expect(f.item).toBe('unattached');
+		expect(f.item_id).toBeUndefined();
+	});
+
+	it('keeps the orthogonal filters alongside an item scope', () => {
+		const f = buildStorageFilters({
+			...base,
+			itemId: 'item-uuid',
+			category: 'image',
+			collection: 'coll-1',
+			sort: 'size_desc',
+		});
+		expect(f).toEqual({
+			limit: 50,
+			offset: 0,
+			item_id: 'item-uuid',
+			category: 'image',
+			collection: 'coll-1',
+			sort: 'size_desc',
+		});
+	});
+
+	it('omits every empty selection', () => {
+		expect(
+			buildStorageFilters({ ...base, category: '', item: '', itemId: '', collection: '', sort: '' })
+		).toEqual({ limit: 50, offset: 0 });
+	});
+});
+
+describe('hasActiveStorageFilters', () => {
+	it('is false with nothing selected', () => {
+		expect(hasActiveStorageFilters(base)).toBe(false);
+	});
+
+	it('is true for an item scope, so the empty state says "no match" not "none exist"', () => {
+		expect(hasActiveStorageFilters({ ...base, itemId: 'item-uuid' })).toBe(true);
+	});
+
+	it('is true for the orthogonal filters too', () => {
+		expect(hasActiveStorageFilters({ ...base, category: 'image' })).toBe(true);
+		expect(hasActiveStorageFilters({ ...base, collection: 'c' })).toBe(true);
+		expect(hasActiveStorageFilters({ ...base, item: 'attached' })).toBe(true);
+	});
+});

--- a/web/src/lib/attachments/storageFilters.ts
+++ b/web/src/lib/attachments/storageFilters.ts
@@ -1,0 +1,43 @@
+/**
+ * Filter assembly for Settings → Storage (PLAN-2392 DR-18).
+ *
+ * Extracted from StorageTab's `buildFilters()` so the one rule that is easy to
+ * get wrong — `item_id` and the attached/unattached selector are mutually
+ * exclusive — is pinned by a test instead of living only inside a component
+ * that no unit test mounts. The server treats `item_id` + `item=unattached` as
+ * a contradiction and returns nothing (see handlers_storage.go), so sending
+ * both would silently empty the list.
+ */
+import type { AttachmentListFilters } from '$lib/types';
+
+export interface StorageFilterSelections {
+	category?: string;
+	/** '' | 'attached' | 'unattached' — the workspace-wide selector. */
+	item?: string;
+	/** UUID of a single parent item. Wins over `item` when set. */
+	itemId?: string;
+	collection?: string;
+	sort?: string;
+	limit: number;
+	offset: number;
+}
+
+export function buildStorageFilters(sel: StorageFilterSelections): AttachmentListFilters {
+	const f: AttachmentListFilters = {
+		limit: sel.limit,
+		offset: sel.offset,
+	};
+	if (sel.sort) f.sort = sel.sort as AttachmentListFilters['sort'];
+	if (sel.category) f.category = sel.category as AttachmentListFilters['category'];
+	// Item scope wins: it is the narrower, explicitly-requested filter, and the
+	// two cannot be combined.
+	if (sel.itemId) f.item_id = sel.itemId;
+	else if (sel.item) f.item = sel.item as AttachmentListFilters['item'];
+	if (sel.collection) f.collection = sel.collection;
+	return f;
+}
+
+/** True when anything narrows the list — drives the empty-state wording. */
+export function hasActiveStorageFilters(sel: StorageFilterSelections): boolean {
+	return Boolean(sel.category || sel.itemId || sel.item || sel.collection);
+}

--- a/web/src/lib/attachments/viewFence.test.ts
+++ b/web/src/lib/attachments/viewFence.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect } from 'vitest';
+import { viewIdentity, createFence, createPaintFence } from './viewFence';
+
+// The invariant these fences encode failed four review rounds running, always
+// by comparing only PART of the identity. These tests pin the module directly:
+// the identity rules, then each of the three fences, then the two collapses
+// that a prior round proved are NOT safe.
+
+describe('viewIdentity', () => {
+	it('is the whole record, not any one part', () => {
+		let ws = 'ws-a';
+		let item = 'item-1';
+		const view = viewIdentity(() => ({ ws, item }));
+
+		const token = view.capture();
+		expect(token.changed()).toBe(false);
+
+		// The item half.
+		item = 'item-2';
+		expect(token.changed()).toBe(true);
+		item = 'item-1';
+		expect(token.changed()).toBe(false);
+
+		// The workspace half — the one that kept getting forgotten.
+		ws = 'ws-b';
+		expect(token.changed()).toBe(true);
+	});
+
+	it('is not addressable while any part is missing', () => {
+		let item: string | null = null;
+		const view = viewIdentity(() => ({ ws: 'ws-a', item }));
+
+		expect(view.key()).toBeNull();
+		// A half-identified view must not pass a fence just because the half it
+		// does know still matches.
+		const blank = view.capture();
+		expect(blank.changed()).toBe(true);
+
+		item = '';
+		expect(view.key()).toBeNull();
+
+		item = 'item-1';
+		expect(view.key()).not.toBeNull();
+		expect(view.capture().changed()).toBe(false);
+	});
+
+	it('never matches a null key', () => {
+		const view = viewIdentity(() => ({ ws: 'ws-a' }));
+		expect(view.matches(null)).toBe(false);
+		expect(view.matches(view.key())).toBe(true);
+	});
+
+	it('cannot confuse two different splits of the same characters', () => {
+		const a = viewIdentity(() => ({ ws: 'x', item: 'yz' })).key();
+		const b = viewIdentity(() => ({ ws: 'xy', item: 'z' })).key();
+		expect(a).not.toBe(b);
+	});
+
+	it('cannot be collided by parts that embed the serialiser\'s own syntax', () => {
+		// The specific way a delimiter join fails: a part containing the entry
+		// separator FOLLOWED BY the next part's name and the name/value
+		// separator re-creates the exact byte sequence the join itself emits, so
+		// two DIFFERENT identities serialise the same — and a stale fence passes,
+		// which is the failure this module exists to prevent (Codex round 1).
+		// Reproduced for the NUL/SOH join this module used to use, and for
+		// separators built from the characters JSON has to escape.
+		const shapes: [string, string][] = [
+			[String.fromCharCode(0), String.fromCharCode(1)],
+			['|', ':'],
+			['"', ','],
+			['\\', '"'],
+			[']', '['],
+		];
+		for (const [entrySep, pairSep] of shapes) {
+			const a = viewIdentity(() => ({ item: `x${entrySep}ws${pairSep}y`, ws: 'z' })).key();
+			const b = viewIdentity(() => ({ item: 'x', ws: `y${entrySep}ws${pairSep}z` })).key();
+			expect(a).not.toBeNull();
+			expect(a).not.toBe(b);
+		}
+
+		// A join that drops the part NAMES collides without any crafted run at
+		// all: `x<sep>y` + `z` and `x` + `y<sep>z` are the same list of values.
+		for (const sep of [',', '|', String.fromCharCode(0)]) {
+			expect(viewIdentity(() => ({ item: `x${sep}y`, ws: 'z' })).key()).not.toBe(
+				viewIdentity(() => ({ item: 'x', ws: `y${sep}z` })).key()
+			);
+		}
+	});
+
+	it('does not depend on the order the parts are written in', () => {
+		const a = viewIdentity(() => ({ ws: 'w', item: 'i' })).key();
+		const b = viewIdentity(() => ({ item: 'i', ws: 'w' })).key();
+		expect(a).toBe(b);
+	});
+
+	it('snapshots the parts, so a request reads back what it was ISSUED for', () => {
+		let ws = 'ws-a';
+		const view = viewIdentity(() => ({ ws }));
+		const token = view.capture();
+		ws = 'ws-b';
+		// This is what stops a continuation from calling the API — or keying a
+		// cache invalidation — with whichever workspace happens to be live.
+		expect(token.value.ws).toBe('ws-a');
+	});
+});
+
+describe('createFence (fences 1 and 2)', () => {
+	it('stales a token once the fence restarts — same identity', () => {
+		const view = viewIdentity(() => ({ ws: 'ws-a', item: 'item-1' }));
+		const fence = createFence(view);
+
+		const first = fence.begin();
+		expect(first.stale()).toBe(false);
+		const second = fence.restart();
+		// A→A: the identity matches, so only the generation can tell a
+		// superseded request from the current one.
+		expect(first.stale()).toBe(true);
+		expect(second.stale()).toBe(false);
+	});
+
+	it('stales a token once the identity moves — same generation', () => {
+		let ws = 'ws-a';
+		const fence = createFence(viewIdentity(() => ({ ws })));
+
+		const token = fence.begin();
+		expect(token.stale()).toBe(false);
+		ws = 'ws-b';
+		expect(token.stale()).toBe(true);
+	});
+
+	it('stales across an A→B→A round trip, where the identity matches again', () => {
+		let ws = 'ws-a';
+		const fence = createFence(viewIdentity(() => ({ ws })));
+
+		const first = fence.restart();
+		ws = 'ws-b';
+		fence.restart();
+		ws = 'ws-a';
+		const current = fence.restart();
+
+		// The identity is back to A, so the identity compare alone would let
+		// A's first response write over A's current one.
+		expect(first.stale()).toBe(true);
+		expect(current.stale()).toBe(false);
+	});
+
+	it('begin() does not supersede its siblings; restart() does', () => {
+		const fence = createFence(viewIdentity(() => ({ ws: 'ws-a' })));
+
+		// Two concurrent mutations must both still be allowed to reconcile.
+		const one = fence.begin();
+		const two = fence.begin();
+		expect(one.stale()).toBe(false);
+		expect(two.stale()).toBe(false);
+
+		fence.invalidate();
+		expect(one.stale()).toBe(true);
+		expect(two.stale()).toBe(true);
+	});
+
+	it('keeps the request and view fences independent', () => {
+		// The whole reason there are two: a Retry restarts the REQUEST fence
+		// (superseding its own in-flight listing) without touching the VIEW
+		// fence, so a delete of a row still on screen keeps reconciling.
+		const view = viewIdentity(() => ({ ws: 'ws-a', item: 'item-1' }));
+		const requests = createFence(view);
+		const views = createFence(view);
+
+		const del = views.begin();
+		requests.restart(); // the Retry
+		expect(del.stale()).toBe(false);
+
+		views.invalidate(); // a real switch, or unmount
+		expect(del.stale()).toBe(true);
+	});
+});
+
+describe('createPaintFence (fence 3)', () => {
+	it('answers about the DOM, lagging the live props on purpose', () => {
+		let ws = 'ws-a';
+		const view = viewIdentity(() => ({ ws }));
+		const paint = createPaintFence(view);
+
+		expect(paint.isCurrent()).toBe(false); // nothing painted yet
+		paint.record(view.capture());
+		expect(paint.isCurrent()).toBe(true);
+
+		// Props update synchronously; the effect that repaints flushes later.
+		// In that window the controls on screen still belong to ws-a, and a
+		// click on one must be refused.
+		ws = 'ws-b';
+		expect(paint.isCurrent()).toBe(false);
+		expect(paint.painted()?.value.ws).toBe('ws-a');
+
+		paint.record(view.capture());
+		expect(paint.isCurrent()).toBe(true);
+	});
+
+	it('claims nothing for an un-addressable view', () => {
+		let item: string | null = null;
+		const view = viewIdentity(() => ({ ws: 'ws-a', item }));
+		const paint = createPaintFence(view);
+
+		paint.record(view.capture());
+		expect(paint.painted()).toBeNull();
+		expect(paint.isCurrent()).toBe(false);
+
+		// And a run that bails on a missing id stops claiming the previous view.
+		item = 'item-1';
+		paint.record(view.capture());
+		expect(paint.isCurrent()).toBe(true);
+		item = null;
+		paint.record(view.capture());
+		expect(paint.painted()).toBeNull();
+	});
+
+	it('is not a generation fence: repainting the same view stays current', () => {
+		const view = viewIdentity(() => ({ ws: 'ws-a' }));
+		const paint = createPaintFence(view);
+		const first = view.capture();
+		paint.record(first);
+		paint.record(view.capture());
+		expect(paint.isCurrent()).toBe(true);
+		expect(first.changed()).toBe(false);
+	});
+});

--- a/web/src/lib/attachments/viewFence.ts
+++ b/web/src/lib/attachments/viewFence.ts
@@ -1,0 +1,207 @@
+/**
+ * The view-identity fence — ONE implementation of the invariant that a
+ * continuation resuming after an `await` may only write state belonging to the
+ * view the user is still looking at.
+ *
+ * WHY THIS EXISTS. Attachment surfaces (the item attachment strip, the Storage
+ * tab) stay MOUNTED across the navigations that change what they show: the
+ * strip lives outside ItemDetail's `{#key itemSlug}` block, and
+ * `/{user}/{ws}/settings` is one SvelteKit route, so a workspace switch changes
+ * `wsSlug` under a mounted tab. Every fetch, mutation and timer therefore has to
+ * say which view it belongs to. Written out by hand at each call site, that
+ * invariant failed the same way four review rounds running — always by
+ * comparing only PART of the identity, almost always by forgetting the
+ * workspace half. This module makes the identity a single value that is read in
+ * exactly one place per component and carried on a token, so no call site can
+ * assemble a partial one.
+ *
+ * THREE FENCES, THREE QUESTIONS. They are deliberately NOT collapsible into one
+ * — a prior review round established that merging any two loses either A→B
+ * suppression or same-item-Retry reconciliation:
+ *
+ *   1. REQUEST fence (`createFence`, restarted per request) — "is this RESPONSE
+ *      still the current one?" A Retry supersedes its own predecessor here.
+ *   2. VIEW fence (`createFence`, invalidated only when the view really
+ *      changes) — "may this async CONTINUATION still reconcile local state?" A
+ *      Retry is the same view reloading and must NOT invalidate it, or an
+ *      in-flight delete of a row still on screen stops rolling back.
+ *   3. PAINT-TIME fence (`createPaintFence`) — "does the CONTROL the user
+ *      clicked belong to what is on screen?" Props update synchronously and
+ *      effects flush later, so in between the DOM still shows the previous
+ *      view. This one has to be at ENTRY: the other two run after an await, and
+ *      no fence can unsend a request.
+ *
+ * Both (1) and (2) compare a captured GENERATION as well as the identity,
+ * because a counter alone misses A→B→A (the identity matches again) and an
+ * identity alone misses A→A (a superseded request for the same view).
+ */
+
+/**
+ * The parts that name a view. A record rather than a tuple so the captured
+ * snapshot can be read back by name — `token.value.ws` is the workspace the
+ * request was ISSUED for, which is what callers should pass to the API instead
+ * of re-reading the live prop.
+ */
+export type IdentityParts = Record<string, string | null | undefined>;
+
+/**
+ * Serialise the parts into a comparable key, or null when the view is not
+ * addressable yet.
+ *
+ * A MISSING PART MAKES THE WHOLE KEY NULL. That is the load-bearing rule: a
+ * view named by (workspace, item) is not identifiable while either half is
+ * unknown, and a null key never matches anything — so a half-identified view
+ * can't accidentally pass a fence.
+ */
+function serialize(parts: IdentityParts): string | null {
+	// Sorted so the key does not depend on property declaration order.
+	const names = Object.keys(parts).sort();
+	if (names.length === 0) return null;
+	const pairs: [string, string][] = [];
+	for (const name of names) {
+		const value = parts[name];
+		if (value === null || value === undefined || value === '') return null;
+		pairs.push([name, value]);
+	}
+	// JSON rather than a delimiter join: a hand-rolled separator has to be a
+	// character the parts cannot contain, and "identity parts are always slugs
+	// and uuids" is an assumption this module has no way to enforce. JSON quotes
+	// and escapes both halves, so no two distinct part sets can serialise the
+	// same — a collision here would silently let a stale fence pass, which is
+	// the exact failure this module exists to prevent (Codex round 1).
+	return JSON.stringify(pairs);
+}
+
+/** A captured identity: what the view was named when this token was taken. */
+export interface IdentityToken<T extends IdentityParts> {
+	/** Snapshot of the parts, for reading back the workspace/item that was captured. */
+	readonly value: T;
+	/** The comparable key, or null when the view wasn't addressable. */
+	readonly key: string | null;
+	/**
+	 * True when the live view no longer matches this capture — including when
+	 * the capture itself was never addressable.
+	 */
+	changed(): boolean;
+}
+
+export interface ViewIdentity<T extends IdentityParts> {
+	/** The live key, or null when a part is missing. */
+	key(): string | null;
+	/** True when `key` names the live view. A null key never matches. */
+	matches(key: string | null): boolean;
+	/** Take a token for the live view. */
+	capture(): IdentityToken<T>;
+}
+
+/**
+ * Declare what names a view. `read` is called on every capture/compare and must
+ * read the LIVE reactive values:
+ *
+ *     const view = viewIdentity(() => ({ ws: wsSlug, item: itemId }));
+ *
+ * This is the ONE place a component states its identity; every fence below is
+ * built from it, so there is no second call site that could state a shorter one.
+ */
+export function viewIdentity<T extends IdentityParts>(read: () => T): ViewIdentity<T> {
+	const identity: ViewIdentity<T> = {
+		key: () => serialize(read()),
+		matches: (key) => key !== null && key === serialize(read()),
+		capture: () => {
+			const value = { ...read() } as T;
+			const key = serialize(value);
+			return {
+				value,
+				key,
+				changed: () => key === null || !identity.matches(key),
+			};
+		},
+	};
+	return identity;
+}
+
+/** An identity token that also carries a generation. */
+export interface FenceToken<T extends IdentityParts> extends IdentityToken<T> {
+	/**
+	 * True when this token may no longer write: the fence was invalidated (or
+	 * restarted) since it was taken, or the view moved on.
+	 */
+	stale(): boolean;
+}
+
+export interface Fence<T extends IdentityParts> {
+	/**
+	 * Take a token WITHOUT superseding outstanding ones. For the view fence, and
+	 * for anything that must coexist with its siblings — two concurrent deletes
+	 * must not invalidate each other.
+	 */
+	begin(): FenceToken<T>;
+	/**
+	 * Supersede every outstanding token, then take a new one. For a request
+	 * fence: issuing request N+1 means request N's response may no longer write.
+	 */
+	restart(): FenceToken<T>;
+	/** Supersede every outstanding token without taking a new one. */
+	invalidate(): void;
+}
+
+/**
+ * A generation + identity fence. Two of these per surface: one restarted per
+ * request (fence 1) and one invalidated only on a real view change (fence 2).
+ */
+export function createFence<T extends IdentityParts>(identity: ViewIdentity<T>): Fence<T> {
+	let generation = 0;
+
+	function take(): FenceToken<T> {
+		const captured = identity.capture();
+		const gen = generation;
+		return {
+			value: captured.value,
+			key: captured.key,
+			changed: captured.changed,
+			stale: () => gen !== generation || captured.changed(),
+		};
+	}
+
+	return {
+		begin: take,
+		restart: () => {
+			generation++;
+			return take();
+		},
+		invalidate: () => {
+			generation++;
+		},
+	};
+}
+
+export interface PaintFence<T extends IdentityParts> {
+	/**
+	 * Claim what is now on screen. Recording a token whose key is null (an
+	 * un-addressable view) correctly claims nothing.
+	 */
+	record(token: IdentityToken<T> | null): void;
+	/** The identity the last paint claimed, for reading the parts back. */
+	painted(): IdentityToken<T> | null;
+	/** True when what is painted is what the live props name. */
+	isCurrent(): boolean;
+}
+
+/**
+ * Fence 3. Deliberately LAGS the live props by the prop-update → effect-flush
+ * window: that lag is the only thing that can answer "was this control rendered
+ * for the view that is on screen NOW?", which the live props cannot — they
+ * already read the NEW view while the OLD controls are still mounted.
+ */
+export function createPaintFence<T extends IdentityParts>(
+	identity: ViewIdentity<T>
+): PaintFence<T> {
+	let painted: IdentityToken<T> | null = null;
+	return {
+		record: (token) => {
+			painted = token && token.key !== null ? token : null;
+		},
+		painted: () => painted,
+		isCurrent: () => painted !== null && identity.matches(painted.key),
+	};
+}

--- a/web/src/lib/components/editor/attachment-chip.ts
+++ b/web/src/lib/components/editor/attachment-chip.ts
@@ -23,7 +23,14 @@
  * (cached module-globally) to read Content-Type and Content-Length from
  * the existing GET handler — no new API endpoint needed. The fetched
  * MIME upgrades the icon from the filename-extension guess to the
- * canonical category icon, and the size is rendered alongside the name.
+ * canonical file-type icon, and the size is rendered alongside the name.
+ *
+ * Icon and byte formatting are the shared attachment helpers'
+ * (`$lib/attachments/display` + `$lib/attachments/icons`) as of TASK-2417 —
+ * this file used to carry its own `iconForMime` / `iconForFilename` /
+ * `formatBytes`. The one behavior that stayed local is hiding an unknown or
+ * zero size: the shared formatter renders "0 B", and per PLAN-2392 DR-3b the
+ * call site keeps that conditional rather than the helper growing a mode.
  */
 
 import { Node, mergeAttributes } from '@tiptap/core';
@@ -34,6 +41,8 @@ import {
 	fetchAttachmentMetadata
 } from './attachment-metadata';
 import { registerAttachmentDeletionListener } from '$lib/attachments/events';
+import { formatBytes, iconForAttachment } from '$lib/attachments/display';
+import { iconSvg } from '$lib/attachments/icons/index';
 
 const PAD_ATTACHMENT_PREFIX = 'pad-attachment:';
 
@@ -59,89 +68,6 @@ declare module '@tiptap/core' {
 			setAttachmentChip: (options: { uuid: string; filename: string }) => ReturnType;
 		};
 	}
-}
-
-/**
- * Map a MIME type to a category icon. Mirrors the server-side category
- * enum in `internal/attachments/mime.go`. When MIME is unknown (HEAD
- * failed or hasn't returned yet), falls back to a filename-extension
- * heuristic — same buckets, same icons, just a coarser source.
- */
-function iconForMime(mime: string): string {
-	const m = mime.toLowerCase();
-	if (m.startsWith('image/')) return '🖼️';
-	if (m.startsWith('video/')) return '🎥';
-	if (m.startsWith('audio/')) return '🎵';
-	if (m === 'application/pdf') return '📑';
-	if (
-		m === 'application/zip' ||
-		m === 'application/x-tar' ||
-		m === 'application/gzip' ||
-		m === 'application/x-bzip2' ||
-		m === 'application/x-7z-compressed'
-	)
-		return '🗜️';
-	if (
-		m === 'application/msword' ||
-		m === 'application/rtf' ||
-		m.includes('wordprocessingml') ||
-		m.includes('opendocument.text')
-	)
-		return '📄';
-	if (
-		m === 'application/vnd.ms-excel' ||
-		m.includes('spreadsheetml') ||
-		m.includes('opendocument.spreadsheet') ||
-		m === 'text/csv' ||
-		m === 'text/tab-separated-values'
-	)
-		return '📊';
-	if (
-		m === 'application/vnd.ms-powerpoint' ||
-		m.includes('presentationml') ||
-		m.includes('opendocument.presentation')
-	)
-		return '📽️';
-	if (
-		m === 'text/plain' ||
-		m === 'text/markdown' ||
-		m === 'application/json' ||
-		m === 'application/xml' ||
-		m === 'text/xml' ||
-		m === 'application/yaml' ||
-		m === 'text/yaml' ||
-		m === 'application/toml'
-	)
-		return '📝';
-	return '';
-}
-
-function iconForFilename(filename: string): string {
-	const ext = filename.toLowerCase().match(/\.([a-z0-9]+)$/)?.[1] ?? '';
-	if (['pdf'].includes(ext)) return '📑';
-	if (['zip', 'tar', 'gz', '7z', 'bz2'].includes(ext)) return '🗜️';
-	if (['doc', 'docx', 'odt', 'rtf'].includes(ext)) return '📄';
-	if (['xls', 'xlsx', 'ods', 'csv', 'tsv'].includes(ext)) return '📊';
-	if (['ppt', 'pptx', 'odp'].includes(ext)) return '📽️';
-	if (['mp4', 'webm', 'mov', 'mkv', 'avi'].includes(ext)) return '🎥';
-	if (['mp3', 'wav', 'ogg', 'flac', 'aac', 'm4a'].includes(ext)) return '🎵';
-	if (['png', 'jpg', 'jpeg', 'gif', 'webp', 'avif', 'heic', 'heif'].includes(ext)) return '🖼️';
-	if (['txt', 'md', 'json', 'yaml', 'yml', 'xml', 'toml', 'html', 'js', 'ts'].includes(ext)) return '📝';
-	return '📎';
-}
-
-/** Format a byte count as a human-readable string ("832 B", "1.2 MB", "5 GB"). */
-function formatBytes(n: number): string {
-	if (!Number.isFinite(n) || n <= 0) return '';
-	if (n < 1024) return `${n} B`;
-	const units = ['KB', 'MB', 'GB', 'TB'];
-	let val = n / 1024;
-	let i = 0;
-	while (val >= 1024 && i < units.length - 1) {
-		val /= 1024;
-		i++;
-	}
-	return `${val < 10 ? val.toFixed(1) : Math.round(val).toString()} ${units[i]}`;
 }
 
 export const AttachmentChip = Node.create<AttachmentChipOptions>({
@@ -282,20 +208,15 @@ export const AttachmentChip = Node.create<AttachmentChipOptions>({
 				nameEl.textContent = currentFilename || 'attachment';
 			};
 
-			// Icon resolution mirrors the original logic: prefer the MIME
-			// category icon when HEAD has resolved AND it produced a
-			// non-empty result (iconForMime returns '' for unknown MIME).
-			// Otherwise fall back to the filename-extension heuristic so
-			// the chip is never left iconless.
+			// Icon resolution is the shared mapper's (TASK-2417): MIME first,
+			// filename-extension second, generic file last, so the chip is
+			// never left iconless and never shows a "❓". `currentMime` is
+			// null until the HEAD probe resolves, which is exactly the
+			// filename-fallback case the mapper's second argument exists for.
+			// innerHTML (not textContent) because the icons are SVG now;
+			// iconSvg() interpolates only repo constants.
 			const refreshIcon = (): void => {
-				if (currentMime) {
-					const refined = iconForMime(currentMime);
-					if (refined) {
-						iconEl.textContent = refined;
-						return;
-					}
-				}
-				iconEl.textContent = iconForFilename(currentFilename);
+				iconEl.innerHTML = iconSvg(iconForAttachment(currentMime, currentFilename));
 			};
 
 			/**
@@ -305,6 +226,14 @@ export const AttachmentChip = Node.create<AttachmentChipOptions>({
 			 * new tab (Codex round 13). The strip broadcasts deletions, so mark
 			 * the chip dead in place instead: same .attachment-missing
 			 * treatment the markdown renderer uses for a missing reference.
+			 *
+			 * The dead state is carried by the .attachment-missing CLASS, not by
+			 * the icon (TASK-2417). It used to swap the glyph to a paperclip,
+			 * which the SVG set can't reproduce without inventing a "missing"
+			 * icon that is a state rather than a format family — and a later
+			 * filename update calls refreshIcon() and would quietly overwrite it
+			 * anyway. app.css styles .file-chip.attachment-missing instead, so
+			 * type and state are independent and neither clobbers the other.
 			 */
 			let deleted = false;
 			const markDeleted = (): void => {
@@ -314,8 +243,12 @@ export const AttachmentChip = Node.create<AttachmentChipOptions>({
 				wrapper.removeAttribute('download');
 				wrapper.title = 'This attachment has been deleted';
 				sizeEl.textContent = '';
-				iconEl.textContent = '📎';
 			};
+
+			// Set by destroy(). A HEAD probe outlives the NodeView that started
+			// it, and writing to detached DOM after teardown is at best wasted
+			// work — same fence shape as the `forUuid` check below.
+			let destroyed = false;
 
 			const disposeDeletionListener = registerAttachmentDeletionListener((deletedUuid) => {
 				if (deletedUuid === currentUuid) markDeleted();
@@ -375,10 +308,17 @@ export const AttachmentChip = Node.create<AttachmentChipOptions>({
 					this.options.getDownloadUrl,
 				).then((meta) => {
 					if (!meta) return;
+					if (destroyed) return; // NodeView torn down while HEAD was in flight
+					if (deleted) return; // the target is gone; don't un-mark the chip
 					if (currentUuid !== forUuid) return; // superseded
 					currentMime = meta.mime;
 					refreshIcon();
-					const size = formatBytes(meta.size);
+					// The shared formatter renders "0 B" and doesn't guard
+					// non-finite input; a chip with no known size should show
+					// nothing at all, so the conditional lives here rather
+					// than in the helper (PLAN-2392 DR-3b).
+					const size =
+						Number.isFinite(meta.size) && meta.size > 0 ? formatBytes(meta.size) : '';
 					sizeEl.textContent = size ? `· ${size}` : '';
 				});
 			};
@@ -427,6 +367,7 @@ export const AttachmentChip = Node.create<AttachmentChipOptions>({
 					return true;
 				},
 				destroy() {
+					destroyed = true;
 					disposeDeletionListener();
 				},
 			};

--- a/web/src/lib/components/items/ItemAttachmentStrip.svelte
+++ b/web/src/lib/components/items/ItemAttachmentStrip.svelte
@@ -16,9 +16,34 @@
 	 * delete is treated as authoritative rather than as an error.
 	 *
 	 * Switch-safety: the mount point is OUTSIDE ItemDetail's `{#key itemSlug}`
-	 * block, so this component PERSISTS across an A→B item switch. Every
-	 * await-then-write path is fenced on a load generation + the requested
-	 * item id, per the no-{#key} bug class from PLAN-2105 / TASK-2112.
+	 * block, so this component PERSISTS across an A→B item switch, per the
+	 * no-{#key} bug class from PLAN-2105 / TASK-2112.
+	 *
+	 * THE FENCE MODEL. Identity is the PAIR (workspace, item) everywhere — see
+	 * `viewKey`. There are exactly three fences, because there are exactly
+	 * three distinct questions, each asked at a different moment:
+	 *
+	 *   1. `switchedAway(gen, item, ws)` — "is this RESPONSE still current?"
+	 *      Guards every await-then-write inside the load effect, against the
+	 *      REQUEST generation. A Retry supersedes its own predecessor here.
+	 *   2. `viewChanged(gen, item, ws)` — "may this async CONTINUATION still
+	 *      reconcile local state?" Guards mutation continuations, against the
+	 *      VIEW generation, which a Retry deliberately does not bump: a delete
+	 *      of a row still on screen must roll back and toast even if the user
+	 *      hit Retry while it was in flight.
+	 *   3. PAINT-TIME identity — "does the CONTROL the user clicked belong to
+	 *      what is on screen?" Props update synchronously and effects flush
+	 *      later, so in between, the DOM still shows the previous view. Every
+	 *      entry point reached from a rendered control validates against an
+	 *      identity RECORDED WHEN THE EFFECT PAINTED (`paintedView`), never
+	 *      against the live props. Both control entry points use it —
+	 *      `handleDelete` for a tile, `retryLoad` for the error row. This fence
+	 *      has to be at ENTRY: the other two run after an await, and no fence
+	 *      can unsend a request.
+	 *
+	 * (1) and (2) compare a captured generation AND the pair, because a
+	 * generation counter alone misses A→B→A and the pair alone misses A→B→A.
+	 * (3) is a pure pair compare: it asks about the DOM, not about ordering.
 	 */
 	import { onDestroy, untrack } from 'svelte';
 	import { api, PadApiError } from '$lib/api/client';
@@ -130,16 +155,6 @@
 	// a fetch failure from rendering as "no attachments"; `showLoading` is the
 	// delayed in-flight marker. Empty stays invisible — no section at all.
 	let loadFailed = $state(false);
-	/**
-	 * VIEW (see `viewKey`) whose load produced the CURRENTLY PAINTED error.
-	 * Retry validates against this rather than the live props: they update
-	 * synchronously but effects flush later, so a click landing in that window
-	 * would otherwise record a retry for the view the user just moved TO and
-	 * carry the old one's rows across the switch (Codex round 11). Keyed by
-	 * workspace AND item — an item-only key let a workspace change in that same
-	 * window claim the stale error (Codex confirm round).
-	 */
-	let loadFailedFor: string | null = null;
 	let showLoading = $state(false);
 	/**
 	 * How many of this item's attachments exist BEYOND the ones the strip
@@ -169,6 +184,19 @@
 	function viewKey(ws: string, id: string): string {
 		return `${ws}\u0000${id}`;
 	}
+
+	/**
+	 * VIEW the currently painted tiles belong to — written by the load effect,
+	 * so it lags the live props by exactly the prop-update → effect-flush
+	 * window. That lag is the point: it is the only thing that can answer "was
+	 * this control rendered for the view that is on screen NOW?", which the
+	 * live props cannot (they already read the NEW view while the OLD tiles are
+	 * still mounted). Entry fence for `handleDelete` — the `viewChanged` check
+	 * in its catch runs after the await and cannot unsend a DELETE aimed at the
+	 * wrong item or workspace (final review round 2). Non-reactive on purpose:
+	 * read at click time, it must not re-trigger the render it describes.
+	 */
+	let paintedView: string | null = null;
 
 	// Two generations, because "which request is this?" and "which item is on
 	// screen?" are different questions and a Retry answers them differently
@@ -236,6 +264,11 @@
 		// deleted. Wiping them would make a second failure lose rows the server
 		// and the editor both have (Codex round 1).
 		untrack(() => {
+			// Whatever this run paints — rows, error row, or nothing — belongs to
+			// this (workspace, item). Recorded unconditionally: a Retry repaints
+			// the SAME view, so the value is unchanged, and a run that bails
+			// below on a missing id must still stop claiming the previous view.
+			paintedView = reqItemId && reqWsSlug ? viewKey(reqWsSlug, reqItemId) : null;
 			if (!isRetry) {
 				// The view itself changed (new item / workspace), so in-flight
 				// mutations captured against the old one must stop reconciling.
@@ -248,7 +281,6 @@
 				beyondStripCount = 0;
 			}
 			loadFailed = false;
-			loadFailedFor = null;
 			showLoading = false;
 		});
 
@@ -258,7 +290,7 @@
 		// deferred write in this component.
 		let loadingTimer: ReturnType<typeof setTimeout> | null = setTimeout(() => {
 			loadingTimer = null;
-			if (switchedAway(gen, reqItemId)) return;
+			if (switchedAway(gen, reqItemId, reqWsSlug)) return;
 			showLoading = true;
 		}, LOADING_DELAY_MS);
 		function stopLoadingMarker() {
@@ -274,7 +306,7 @@
 					item_id: reqItemId,
 					limit: MAX_FETCH,
 				});
-				if (switchedAway(gen, reqItemId)) return;
+				if (switchedAway(gen, reqItemId, reqWsSlug)) return;
 				const raw = res.attachments ?? [];
 				const rows = raw.filter((a) => !deletedIds.has(a.id)).map(toStripAttachment);
 				const seen = new Set(rows.map((a) => a.id));
@@ -332,16 +364,15 @@
 				// roleLevel("guest") is below viewer, so they 403. That gap is
 				// pre-existing (inline images are already broken for them) and
 				// is tracked as BUG-2386, not absorbed here — PLAN-2382 DR-4b.
-				if (switchedAway(gen, reqItemId)) return;
+				if (switchedAway(gen, reqItemId, reqWsSlug)) return;
 				// Keep anything uploaded while this request was in flight: the
 				// upload SUCCEEDED, so dropping it would hide a row the editor
 				// and server both have, until a remount (Codex review round 2).
 				attachments = capped(pendingUploads.filter((a) => !deletedIds.has(a.id)));
 				loadFailed = true;
-				loadFailedFor = viewKey(reqWsSlug, reqItemId);
 			} finally {
 				stopLoadingMarker();
-				if (!switchedAway(gen, reqItemId)) showLoading = false;
+				if (!switchedAway(gen, reqItemId, reqWsSlug)) showLoading = false;
 			}
 		})();
 
@@ -380,12 +411,18 @@
 	 */
 	function retryLoad() {
 		if (!itemId || !wsSlug) return;
-		// The painted error must belong to the item that is current NOW. If the
-		// parent has already swapped `itemId` and this effect hasn't flushed yet, the
-		// click is stale: the incoming item's own load is already on its way,
-		// and honouring the retry would preserve the previous item's rows
-		// across the switch (Codex round 11).
-		if (loadFailedFor !== viewKey(wsSlug, itemId)) return;
+		// The same ENTRY fence the delete control uses (fence 3): the painted
+		// error must belong to the view that is on screen NOW. If the parent has
+		// already swapped `itemId` or `wsSlug` and this effect hasn't flushed
+		// yet, the click is stale — the incoming view's own load is already on
+		// its way, and honouring the retry would preserve the previous view's
+		// rows across the switch (Codex round 11).
+		//
+		// `loadFailed` is only ever set by a response that passed `switchedAway`
+		// under the run that also wrote `paintedView`, so the two together say
+		// exactly what a separate `loadFailedFor` field used to: WHICH view's
+		// failure is painted. One paint-time identity, not two kept in step.
+		if (!loadFailed || paintedView !== viewKey(wsSlug, itemId)) return;
 		for (const a of attachments) invalidateAttachmentMetadata(wsSlug, a.id);
 		retryRequestedFor = viewKey(wsSlug, itemId);
 		retryNonce++;
@@ -437,6 +474,15 @@
 	$effect(() => {
 		return registerAttachmentUploadListener((uploadItemId, uploaded) => {
 			if (uploadItemId !== itemId) return;
+			// Tombstones outrank uploads. The upload bus can re-announce (a
+			// delayed or duplicated event), and the load path already filters
+			// every response through `deletedIds` for exactly this reason —
+			// without the same guard here, a re-announced upload for a row the
+			// user has since deleted resurrects it in BOTH buffers, and
+			// `pendingUploads` then keeps re-merging it onto every subsequent
+			// response (final review round 2). A confirmed deletion is
+			// authoritative; a repeat of an older upload event is not.
+			if (deletedIds.has(uploaded.id)) return;
 			// Idempotence guard for the bus itself: the same event can reach us
 			// twice (a re-broadcast, or an upload announced while the initial
 			// list() was in flight and then present in its response). NOT about
@@ -459,10 +505,25 @@
 	});
 
 	// Mirrors ItemDetail's `switchedAway`: the generation catches a newer load,
-	// the id compare closes the A→B→A gap where generations could otherwise
-	// line up.
-	function switchedAway(gen: number, reqItemId: string): boolean {
-		return gen !== loadGeneration || itemId !== reqItemId;
+	// the identity compare closes the A→B→A gap where generations could
+	// otherwise line up.
+	//
+	// Identity is the (workspace, item) PAIR, exactly as `viewChanged` and
+	// `viewKey` treat it. Requests already capture the workspace they were
+	// issued against; checking only the item let a same-item workspace switch
+	// pass this fence, so a superseded response, failure or loading timer could
+	// write into the new view during the prop-update → effect-flush window
+	// (final review round 2).
+	//
+	// Deliberately untested, unlike the other two fences: a workspace change is
+	// a dependency of the load effect, and Svelte's scheduler always flushes
+	// that re-run — which clears every one of these fields — before a pending
+	// response continuation gets to write. So the omission has no observable
+	// symptom to pin a test to. It is fixed because "the next effect run happens
+	// to overwrite it" is a scheduling accident, not a fence, and because
+	// identity being the (workspace, item) pair should not have exceptions.
+	function switchedAway(gen: number, reqItemId: string, reqWsSlug: string): boolean {
+		return gen !== loadGeneration || itemId !== reqItemId || wsSlug !== reqWsSlug;
 	}
 
 	/**
@@ -578,7 +639,24 @@
 
 	async function handleDelete(att: StripAttachment) {
 		if (!canDelete) return;
+
+		const reqItemId = itemId;
+		const reqWsSlug = wsSlug;
+		if (!reqItemId || !reqWsSlug) return;
+		// ENTRY fence (fence 3 — see the header). The clicked tile was painted
+		// for `paintedView`; the live props may already name a different view,
+		// because they update synchronously and the load effect that repaints
+		// these tiles flushes later. In that window a click on a stale tile
+		// would send a DELETE while the user is looking at another item or
+		// workspace — and the `viewChanged` check in the catch below runs after
+		// the request, so it can suppress the rollback but cannot unsend the
+		// request (final review round 2). The only fix is to refuse here,
+		// before the confirm and before the call.
+		if (paintedView !== viewKey(reqWsSlug, reqItemId)) return;
+
 		if (typeof window !== 'undefined' && !window.confirm(confirmMessage(att))) return;
+		// window.confirm blocks the thread, so nothing can have moved between
+		// the fence above and here.
 
 		// Capture identity BEFORE the await: a switch mid-delete must not roll
 		// the tile back into a DIFFERENT item's strip, and must not toast over
@@ -588,8 +666,6 @@
 		// actually targeted, not whichever one is current when it resolves
 		// (Codex round 6).
 		const gen = viewGeneration;
-		const reqItemId = itemId;
-		const reqWsSlug = wsSlug;
 		const index = attachments.findIndex((a) => a.id === att.id);
 
 		// Optimistic removal.
@@ -602,8 +678,6 @@
 			// showing a healthy image the server no longer has until reload.
 			announceAttachmentDeleted(reqWsSlug, att.id);
 		} catch (err) {
-			if (viewChanged(gen, reqItemId ?? '', reqWsSlug)) return;
-
 			// A 404 means it's ALREADY gone. The in-process deletion bus covers
 			// other surfaces in THIS tab, but not another user, another tab, or
 			// a notification we missed — so the tile can still be stale by the
@@ -616,9 +690,20 @@
 				// gone, so it gets the same broadcast — otherwise an editor
 				// NodeView or another mounted strip in this tab stays stale
 				// precisely when we have proof it should not (Codex round 19).
+				//
+				// Deliberately AHEAD of the view fence, unlike everything below
+				// it: this is a GLOBAL side effect keyed by (workspace, id), not
+				// a write into this view's local state. A view switch says
+				// nothing about whether the row is gone — and if the broadcast
+				// is skipped, no later event replaces it, so every other mounted
+				// surface stays stale on proof we already have (final review
+				// round 2). The rollback, the toast and the tombstone check
+				// below stay fenced: those DO touch what is on screen.
 				announceAttachmentDeleted(reqWsSlug, att.id);
 				return;
 			}
+
+			if (viewChanged(gen, reqItemId, reqWsSlug)) return;
 
 			// Someone else announced this deletion while our own call was in
 			// flight — the row is gone regardless of why ours failed, so don't

--- a/web/src/lib/components/items/ItemAttachmentStrip.svelte
+++ b/web/src/lib/components/items/ItemAttachmentStrip.svelte
@@ -19,31 +19,22 @@
 	 * block, so this component PERSISTS across an A→B item switch, per the
 	 * no-{#key} bug class from PLAN-2105 / TASK-2112.
 	 *
-	 * THE FENCE MODEL. Identity is the PAIR (workspace, item) everywhere — see
-	 * `viewKey`. There are exactly three fences, because there are exactly
-	 * three distinct questions, each asked at a different moment:
+	 * THE FENCE MODEL lives in `$lib/attachments/viewFence`, which owns the
+	 * whole invariant — read its header for why there are exactly three fences
+	 * and why they cannot be collapsed. This component supplies the identity
+	 * once (`view`, the PAIR (workspace, item)) and builds all three from it:
 	 *
-	 *   1. `switchedAway(gen, item, ws)` — "is this RESPONSE still current?"
-	 *      Guards every await-then-write inside the load effect, against the
-	 *      REQUEST generation. A Retry supersedes its own predecessor here.
-	 *   2. `viewChanged(gen, item, ws)` — "may this async CONTINUATION still
-	 *      reconcile local state?" Guards mutation continuations, against the
-	 *      VIEW generation, which a Retry deliberately does not bump: a delete
-	 *      of a row still on screen must roll back and toast even if the user
-	 *      hit Retry while it was in flight.
-	 *   3. PAINT-TIME identity — "does the CONTROL the user clicked belong to
-	 *      what is on screen?" Props update synchronously and effects flush
-	 *      later, so in between, the DOM still shows the previous view. Every
-	 *      entry point reached from a rendered control validates against an
-	 *      identity RECORDED WHEN THE EFFECT PAINTED (`paintedView`), never
-	 *      against the live props. Both control entry points use it —
-	 *      `handleDelete` for a tile, `retryLoad` for the error row. This fence
-	 *      has to be at ENTRY: the other two run after an await, and no fence
-	 *      can unsend a request.
-	 *
-	 * (1) and (2) compare a captured generation AND the pair, because a
-	 * generation counter alone misses A→B→A and the pair alone misses A→B→A.
-	 * (3) is a pure pair compare: it asks about the DOM, not about ordering.
+	 *   1. `loadFence` — "is this RESPONSE still current?" Restarted per
+	 *      request; guards every await-then-write inside the load effect.
+	 *   2. `viewFence` — "may this async CONTINUATION still reconcile local
+	 *      state?" Invalidated only when the view really changes, so a Retry
+	 *      (the same view reloading) leaves it alone: a delete of a row still
+	 *      on screen must roll back and toast even if the user hit Retry while
+	 *      it was in flight.
+	 *   3. `paint` — "does the CONTROL the user clicked belong to what is on
+	 *      screen?" Both control entry points fence on it — `handleDelete` for
+	 *      a tile, `retryLoad` for the error row — at ENTRY, because the other
+	 *      two run after an await and no fence can unsend a request.
 	 */
 	import { onDestroy, untrack } from 'svelte';
 	import { api, PadApiError } from '$lib/api/client';
@@ -59,6 +50,7 @@
 		registerAttachmentDeletionListener,
 		registerAttachmentUploadListener,
 	} from '$lib/attachments/events';
+	import { viewIdentity, createFence, createPaintFence } from '$lib/attachments/viewFence';
 
 	interface Props {
 		wsSlug: string;
@@ -175,43 +167,36 @@
 	 */
 	let retryRequestedFor: string | null = null;
 	/**
-	 * View identity key. `itemId` alone isn't it: `wsSlug` is reactive and the
-	 * strip stays mounted across a workspace change, so keying on the item
-	 * would classify that as a same-view Retry — leaving the previous
-	 * workspace's rows painted and its in-flight mutations still reconciling
-	 * (Codex fresh-angle round 2).
+	 * The ONE statement of what names this view. `itemId` alone isn't it:
+	 * `wsSlug` is reactive and the strip stays mounted across a workspace
+	 * change, so keying on the item would classify that as a same-view Retry —
+	 * leaving the previous workspace's rows painted and its in-flight mutations
+	 * still reconciling (Codex fresh-angle round 2). Declared once here so no
+	 * individual fence call site can restate a shorter identity; every fence
+	 * below derives from it, and every captured workspace is read back off a
+	 * token rather than off the live prop.
 	 */
-	function viewKey(ws: string, id: string): string {
-		return `${ws}\u0000${id}`;
-	}
-
+	const view = viewIdentity(() => ({ ws: wsSlug, item: itemId }));
+	/** Fence 1 — request generation. Restarted on every (re)run of the load effect. */
+	const loadFence = createFence(view);
 	/**
-	 * VIEW the currently painted tiles belong to — written by the load effect,
-	 * so it lags the live props by exactly the prop-update → effect-flush
-	 * window. That lag is the point: it is the only thing that can answer "was
-	 * this control rendered for the view that is on screen NOW?", which the
-	 * live props cannot (they already read the NEW view while the OLD tiles are
-	 * still mounted). Entry fence for `handleDelete` — the `viewChanged` check
-	 * in its catch runs after the await and cannot unsend a DELETE aimed at the
-	 * wrong item or workspace (final review round 2). Non-reactive on purpose:
-	 * read at click time, it must not re-trigger the render it describes.
+	 * Fence 2 — view generation. Invalidated only when the view actually
+	 * changes: a different (item, workspace), or unmount. A Retry is the SAME
+	 * item reloading, so it leaves this alone: a delete of a row still on screen
+	 * must reconcile (roll back, toast) even if the user hit Retry while it was
+	 * in flight. Fencing mutations on the REQUEST generation instead made a
+	 * Retry masquerade as an item switch and swallowed the failure.
 	 */
-	let paintedView: string | null = null;
+	const viewFence = createFence(view);
+	/**
+	 * Fence 3 — the view the currently painted tiles belong to. Recorded by the
+	 * load effect, so it lags the live props by exactly the prop-update →
+	 * effect-flush window; that lag is what makes it the only thing that can
+	 * answer "was this control rendered for the view that is on screen NOW?"
+	 */
+	const paint = createPaintFence(view);
 
-	// Two generations, because "which request is this?" and "which item is on
-	// screen?" are different questions and a Retry answers them differently
-	// (final-review P2).
-	//
-	// REQUEST generation — bumped on every (re)run of the fetch effect,
-	// including a Retry, so a superseded list() response can never write.
-	let loadGeneration = 0;
-	// VIEW generation — bumped only when the view actually changes: a different
-	// (item, workspace), or unmount. A Retry is the SAME item reloading, so it
-	// leaves this alone. Mutations fence on this: a delete of a row still on
-	// screen must reconcile (roll back, toast, broadcast) even if the user hit
-	// Retry while it was in flight. Fencing them on the request generation made
-	// a Retry masquerade as an item switch and swallowed the failure.
-	let viewGeneration = 0;
+
 
 	// Ids confirmed deleted while this item's list was loading. A deletion
 	// broadcast only filters the CURRENT array, so a list() response that was
@@ -240,18 +225,19 @@
 	let pendingUploads: StripAttachment[] = [];
 
 	$effect(() => {
-		const reqItemId = itemId;
-		const reqWsSlug = wsSlug;
+		// Restarting the request fence supersedes any response still in flight
+		// AND captures the identity this run belongs to. Reading the identity
+		// here is what makes (workspace, item) the effect's dependencies.
+		const req = loadFence.restart();
+		const { ws: reqWsSlug, item: reqItemId } = req.value;
 		// Read (and discard) so Retry re-runs this effect. The value never
 		// matters — only the dependency does.
 		void retryNonce;
-		const gen = ++loadGeneration;
 
 		// Claim the retry marker whether or not this run goes on to fetch, so a
 		// stale claim can't leak into a later, unrelated load. Read BEFORE the
 		// reset below, which branches on it.
-		const isRetry =
-			retryRequestedFor !== null && retryRequestedFor === viewKey(reqWsSlug, reqItemId ?? '');
+		const isRetry = retryRequestedFor !== null && retryRequestedFor === req.key;
 		retryRequestedFor = null;
 
 		// Clear synchronously on switch. Without this, A's tiles stay painted
@@ -267,12 +253,13 @@
 			// Whatever this run paints — rows, error row, or nothing — belongs to
 			// this (workspace, item). Recorded unconditionally: a Retry repaints
 			// the SAME view, so the value is unchanged, and a run that bails
-			// below on a missing id must still stop claiming the previous view.
-			paintedView = reqItemId && reqWsSlug ? viewKey(reqWsSlug, reqItemId) : null;
+			// below on a missing id must still stop claiming the previous view
+			// (an un-addressable token records nothing).
+			paint.record(req);
 			if (!isRetry) {
 				// The view itself changed (new item / workspace), so in-flight
 				// mutations captured against the old one must stop reconciling.
-				viewGeneration++;
+				viewFence.invalidate();
 				attachments = [];
 				expanded = false;
 				lightbox = null;
@@ -290,7 +277,7 @@
 		// deferred write in this component.
 		let loadingTimer: ReturnType<typeof setTimeout> | null = setTimeout(() => {
 			loadingTimer = null;
-			if (switchedAway(gen, reqItemId, reqWsSlug)) return;
+			if (req.stale()) return;
 			showLoading = true;
 		}, LOADING_DELAY_MS);
 		function stopLoadingMarker() {
@@ -301,18 +288,56 @@
 		}
 
 		void (async () => {
+			// Ids the pending buffer ALREADY held when this request went out. A
+			// response can be authoritative about exactly these — the row existed
+			// before the GET, so its absence is proof the row is gone (deleted by
+			// another tab or another user, which the in-process event bus cannot
+			// see). Merging them back in resurrected such rows, and because
+			// nothing ever consumed the buffer it did so on every subsequent
+			// load, forever (final review round 4).
+			//
+			// Entries announced AFTER this point are the buffer's actual purpose
+			// and are never touched: the GET may predate them, so their absence
+			// from the response says nothing.
+			const pendingAtRequest = new Set(pendingUploads.map((a) => a.id));
 			try {
 				const res = await api.attachments.list(reqWsSlug, {
 					item_id: reqItemId,
 					limit: MAX_FETCH,
 				});
-				if (switchedAway(gen, reqItemId, reqWsSlug)) return;
+				if (req.stale()) return;
 				const raw = res.attachments ?? [];
 				const rows = raw.filter((a) => !deletedIds.has(a.id)).map(toStripAttachment);
 				const seen = new Set(rows.map((a) => a.id));
+				// ...but only a COMPLETE page is authoritative about absence. The
+				// request is bounded at MAX_FETCH, so a truncated page may simply
+				// not reach a row that is still perfectly alive — and retiring a
+				// live upload would delete a good tile permanently, which is a
+				// worse failure than the resurrection this is fixing (Codex
+				// round 2). `total` is the server's own statement of how many
+				// live rows there are and `offset` is always 0 here, so a page
+				// that holds all of them IS complete even when it is exactly
+				// MAX_FETCH long (Codex round 3). Only when the response omits
+				// `total` does the page length have to stand in for it.
+				const pageIsComplete =
+					typeof res.total === 'number' ? res.total <= raw.length : raw.length < MAX_FETCH;
+				const covered = pageIsComplete ? pendingAtRequest : new Set<string>();
 				const missed = pendingUploads.filter(
-					(a) => !seen.has(a.id) && !deletedIds.has(a.id)
+					(a) => !seen.has(a.id) && !deletedIds.has(a.id) && !covered.has(a.id)
 				);
+				// Consume what this response covered. The exclusion above already
+				// makes every LATER load ignore these ids (a later request's own
+				// snapshot would contain them too), so this is the retention half
+				// of the fix rather than a second correctness gate: without it the
+				// buffer only ever grows, holding rows that nothing will ever read
+				// again. Deliberately not separately observable — a mutation that
+				// deletes this line survives the suite, and that is expected.
+				//
+				// Only on SUCCESS, and only for what the page COVERED: a failure
+				// is not authoritative, the catch arm below still needs the buffer
+				// to repaint the rows a failed listing would otherwise hide, and a
+				// truncated page proves nothing about what it didn't reach.
+				pendingUploads = pendingUploads.filter((a) => !covered.has(a.id));
 				// Cap the MERGE, not just the response: `missed` rides on top of
 				// up to MAX_FETCH server rows (DR-11).
 				const merged = [...missed, ...rows];
@@ -364,7 +389,7 @@
 				// roleLevel("guest") is below viewer, so they 403. That gap is
 				// pre-existing (inline images are already broken for them) and
 				// is tracked as BUG-2386, not absorbed here — PLAN-2382 DR-4b.
-				if (switchedAway(gen, reqItemId, reqWsSlug)) return;
+				if (req.stale()) return;
 				// Keep anything uploaded while this request was in flight: the
 				// upload SUCCEEDED, so dropping it would hide a row the editor
 				// and server both have, until a remount (Codex review round 2).
@@ -372,7 +397,7 @@
 				loadFailed = true;
 			} finally {
 				stopLoadingMarker();
-				if (!switchedAway(gen, reqItemId, reqWsSlug)) showLoading = false;
+				if (!req.stale()) showLoading = false;
 			}
 		})();
 
@@ -387,7 +412,7 @@
 		// view generation here would put the Retry bug straight back. Unmount
 		// is handled by onDestroy below, which runs only on destroy.
 		return () => {
-			loadGeneration++;
+			loadFence.invalidate();
 			stopLoadingMarker();
 		};
 	});
@@ -395,7 +420,7 @@
 	// Destroy invalidates the VIEW too — an in-flight delete that resolves
 	// after the component is gone must not toast or write.
 	onDestroy(() => {
-		viewGeneration++;
+		viewFence.invalidate();
 	});
 
 	/**
@@ -410,7 +435,6 @@
 	 * uploaded while the request was in flight.
 	 */
 	function retryLoad() {
-		if (!itemId || !wsSlug) return;
 		// The same ENTRY fence the delete control uses (fence 3): the painted
 		// error must belong to the view that is on screen NOW. If the parent has
 		// already swapped `itemId` or `wsSlug` and this effect hasn't flushed
@@ -418,13 +442,19 @@
 		// its way, and honouring the retry would preserve the previous view's
 		// rows across the switch (Codex round 11).
 		//
-		// `loadFailed` is only ever set by a response that passed `switchedAway`
-		// under the run that also wrote `paintedView`, so the two together say
-		// exactly what a separate `loadFailedFor` field used to: WHICH view's
-		// failure is painted. One paint-time identity, not two kept in step.
-		if (!loadFailed || paintedView !== viewKey(wsSlug, itemId)) return;
-		for (const a of attachments) invalidateAttachmentMetadata(wsSlug, a.id);
-		retryRequestedFor = viewKey(wsSlug, itemId);
+		// `loadFailed` is only ever set by a response that passed the request
+		// fence under the run that also recorded the paint, so the two together
+		// say exactly what a separate `loadFailedFor` field used to: WHICH
+		// view's failure is painted. One paint-time identity, not two kept in
+		// step.
+		if (!loadFailed || !paint.isCurrent()) return;
+		const painted = paint.painted();
+		if (!painted) return;
+		// Workspace read back off the PAINTED identity, not the live prop:
+		// `isCurrent()` has just established they agree, and taking it from the
+		// token is what stops the two from ever drifting apart again.
+		for (const a of attachments) invalidateAttachmentMetadata(painted.value.ws, a.id);
+		retryRequestedFor = painted.key;
 		retryNonce++;
 	}
 
@@ -503,38 +533,6 @@
 			attachments = capped(next);
 		});
 	});
-
-	// Mirrors ItemDetail's `switchedAway`: the generation catches a newer load,
-	// the identity compare closes the A→B→A gap where generations could
-	// otherwise line up.
-	//
-	// Identity is the (workspace, item) PAIR, exactly as `viewChanged` and
-	// `viewKey` treat it. Requests already capture the workspace they were
-	// issued against; checking only the item let a same-item workspace switch
-	// pass this fence, so a superseded response, failure or loading timer could
-	// write into the new view during the prop-update → effect-flush window
-	// (final review round 2).
-	//
-	// Deliberately untested, unlike the other two fences: a workspace change is
-	// a dependency of the load effect, and Svelte's scheduler always flushes
-	// that re-run — which clears every one of these fields — before a pending
-	// response continuation gets to write. So the omission has no observable
-	// symptom to pin a test to. It is fixed because "the next effect run happens
-	// to overwrite it" is a scheduling accident, not a fence, and because
-	// identity being the (workspace, item) pair should not have exceptions.
-	function switchedAway(gen: number, reqItemId: string, reqWsSlug: string): boolean {
-		return gen !== loadGeneration || itemId !== reqItemId || wsSlug !== reqWsSlug;
-	}
-
-	/**
-	 * The mutation fence. Same shape as `switchedAway`, but against the VIEW
-	 * generation — a Retry re-runs the load without changing what is on screen,
-	 * so an in-flight delete for this item must still reconcile (final-review
-	 * P2). The id compare closes the A→B→A gap the counter alone can miss.
-	 */
-	function viewChanged(gen: number, reqItemId: string, reqWsSlug: string): boolean {
-		return gen !== viewGeneration || itemId !== reqItemId || wsSlug !== reqWsSlug;
-	}
 
 	let visible = $derived(expanded ? attachments : attachments.slice(0, COLLAPSED_TILES));
 	// Overflow is derived from the FETCHED ROWS, never the response's `total`
@@ -640,32 +638,30 @@
 	async function handleDelete(att: StripAttachment) {
 		if (!canDelete) return;
 
-		const reqItemId = itemId;
-		const reqWsSlug = wsSlug;
-		if (!reqItemId || !reqWsSlug) return;
 		// ENTRY fence (fence 3 — see the header). The clicked tile was painted
-		// for `paintedView`; the live props may already name a different view,
-		// because they update synchronously and the load effect that repaints
-		// these tiles flushes later. In that window a click on a stale tile
-		// would send a DELETE while the user is looking at another item or
-		// workspace — and the `viewChanged` check in the catch below runs after
-		// the request, so it can suppress the rollback but cannot unsend the
-		// request (final review round 2). The only fix is to refuse here,
-		// before the confirm and before the call.
-		if (paintedView !== viewKey(reqWsSlug, reqItemId)) return;
+		// for `paint`'s identity; the live props may already name a different
+		// view, because they update synchronously and the load effect that
+		// repaints these tiles flushes later. In that window a click on a stale
+		// tile would send a DELETE while the user is looking at another item or
+		// workspace — and the view-fence check in the catch below runs after the
+		// request, so it can suppress the rollback but cannot unsend the request
+		// (final review round 2). The only fix is to refuse here, before the
+		// confirm and before the call.
+		if (!paint.isCurrent()) return;
 
 		if (typeof window !== 'undefined' && !window.confirm(confirmMessage(att))) return;
 		// window.confirm blocks the thread, so nothing can have moved between
 		// the fence above and here.
 
-		// Capture identity BEFORE the await: a switch mid-delete must not roll
-		// the tile back into a DIFFERENT item's strip, and must not toast over
-		// it. The DELETE itself still lands — it targets an id, not a view.
-		// `wsSlug` is captured for the same reason: it is reactive, and the
-		// broadcast + metadata-cache key must name the workspace the DELETE
-		// actually targeted, not whichever one is current when it resolves
-		// (Codex round 6).
-		const gen = viewGeneration;
+		// Capture identity BEFORE the await (fence 2): a switch mid-delete must
+		// not roll the tile back into a DIFFERENT item's strip, and must not
+		// toast over it. The DELETE itself still lands — it targets an id, not a
+		// view. The workspace comes off the token for the same reason: it is
+		// reactive, and the request + broadcast + metadata-cache key must name
+		// the workspace the DELETE actually targeted, not whichever one is
+		// current when it resolves (Codex round 6).
+		const req = viewFence.begin();
+		const reqWsSlug = req.value.ws;
 		const index = attachments.findIndex((a) => a.id === att.id);
 
 		// Optimistic removal.
@@ -703,7 +699,7 @@
 				return;
 			}
 
-			if (viewChanged(gen, reqItemId, reqWsSlug)) return;
+			if (req.stale()) return;
 
 			// Someone else announced this deletion while our own call was in
 			// flight — the row is gone regardless of why ours failed, so don't

--- a/web/src/lib/components/items/ItemAttachmentStrip.svelte
+++ b/web/src/lib/components/items/ItemAttachmentStrip.svelte
@@ -27,6 +27,7 @@
 	import AttachmentIcon from '$lib/attachments/icons/AttachmentIcon.svelte';
 	import Lightbox, { type LightboxImage } from '$lib/components/common/Lightbox.svelte';
 	import { attachmentRefsIn } from '$lib/utils/commentAttachments';
+	import { invalidateAttachmentMetadata } from '$lib/components/editor/attachment-metadata';
 	import { toastStore } from '$lib/stores/toast.svelte';
 	import {
 		announceAttachmentDeleted,
@@ -71,11 +72,23 @@
 		liveContent = null,
 	}: Props = $props();
 
-	// Hard bound on what the strip will ever hold (DR-9). Past this the strip
-	// links out to Settings → Storage rather than paginating in place.
+	// Hard bound on what the strip will ever hold (DR-9 / DR-11). Past this the
+	// strip links out to Settings → Storage rather than paginating in place.
+	//
+	// This is a real bound, not just a fetch `limit`: EVERY path that grows the
+	// in-memory list runs through `capped()` — the load-time merge, the upload
+	// event, and the pending-upload buffer that feeds the merge. Bounding only
+	// the merged output would still let a long paste session grow
+	// `pendingUploads` without limit, and that list also feeds the lightbox
+	// (PLAN-2392 DR-11).
 	const MAX_FETCH = 50;
 	// Tiles shown before the `+N` chip. Expanding scrolls within one row.
 	const COLLAPSED_TILES = 8;
+	// Grace period before a load paints a "Loading attachments…" row. Most
+	// fetches land well inside it, so the common no-attachments item still
+	// renders nothing at all (DR-18) instead of flashing a block above the
+	// editor — while a genuinely slow load is still distinguishable from empty.
+	const LOADING_DELAY_MS = 200;
 
 	/**
 	 * Only what a tile renders. Deliberately narrower than AttachmentListItem:
@@ -100,9 +113,46 @@
 		};
 	}
 
+	/** Trim to the hard bound, newest-first order preserved (DR-11). */
+	function capped(list: StripAttachment[]): StripAttachment[] {
+		return list.length > MAX_FETCH ? list.slice(0, MAX_FETCH) : list;
+	}
+
 	let attachments = $state<StripAttachment[]>([]);
 	let expanded = $state(false);
 	let lightbox = $state<{ images: LightboxImage[]; index: number } | null>(null);
+
+	// Three distinguishable states, not two (DR-10). `loadFailed` is what stops
+	// a fetch failure from rendering as "no attachments"; `showLoading` is the
+	// delayed in-flight marker. Empty stays invisible — no section at all.
+	let loadFailed = $state(false);
+	/**
+	 * Item whose load produced the CURRENTLY PAINTED error. Retry validates
+	 * against this rather than the live `itemId`: props update synchronously
+	 * but effects flush later, so a click landing in that window would
+	 * otherwise record a retry for the item the user just moved TO and carry
+	 * the old item's rows across the switch (Codex round 11).
+	 */
+	let loadFailedFor: string | null = null;
+	let showLoading = $state(false);
+	/**
+	 * How many of this item's attachments exist BEYOND the ones the strip
+	 * holds — the response's `total` minus what it returned, plus anything the
+	 * MAX_FETCH cap shed. Deliberately a delta rather than an absolute total:
+	 * the strip mutates `attachments` locally (delete, upload) and a stored
+	 * absolute would drift, advertising a "View all (N)" for rows that are no
+	 * longer there. Zero means the strip holds everything (DR-18).
+	 */
+	let beyondStripCount = $state(0);
+	/** Bumped by Retry to re-run the load effect. */
+	let retryNonce = $state(0);
+	/**
+	 * Item id whose load was triggered by an explicit Retry, consumed by the
+	 * next effect run. Plain (non-reactive) on purpose: it must not itself
+	 * re-trigger the effect, and it is keyed by item id so a switch between the
+	 * click and the flush doesn't apply the retry to a different item.
+	 */
+	let retryRequestedFor: string | null = null;
 
 	// Monotonic load generation — bumped on every (re)run of the fetch effect
 	// so an in-flight response for item A can never write under item B.
@@ -125,20 +175,55 @@
 	$effect(() => {
 		const reqItemId = itemId;
 		const reqWsSlug = wsSlug;
+		// Read (and discard) so Retry re-runs this effect. The value never
+		// matters — only the dependency does.
+		void retryNonce;
 		const gen = ++loadGeneration;
+
+		// Claim the retry marker whether or not this run goes on to fetch, so a
+		// stale claim can't leak into a later, unrelated load. Read BEFORE the
+		// reset below, which branches on it.
+		const isRetry = retryRequestedFor !== null && retryRequestedFor === reqItemId;
+		retryRequestedFor = null;
 
 		// Clear synchronously on switch. Without this, A's tiles stay painted
 		// under B for the duration of B's request (or forever, if B has none).
 		// untrack: this effect must not depend on the state it writes.
+		//
+		// A Retry is the SAME item reloading, not a switch, so it keeps what
+		// the failure deliberately preserved — uploads that succeeded while the
+		// list request was in flight, and the tombstones for rows confirmed
+		// deleted. Wiping them would make a second failure lose rows the server
+		// and the editor both have (Codex round 1).
 		untrack(() => {
-			attachments = [];
-			expanded = false;
-			lightbox = null;
-			deletedIds = new Set();
-			pendingUploads = [];
+			if (!isRetry) {
+				attachments = [];
+				expanded = false;
+				lightbox = null;
+				deletedIds = new Set();
+				pendingUploads = [];
+				beyondStripCount = 0;
+			}
+			loadFailed = false;
+			loadFailedFor = null;
+			showLoading = false;
 		});
 
 		if (!reqItemId || !reqWsSlug) return;
+
+		// Delayed loading marker (see LOADING_DELAY_MS). Fenced like every other
+		// deferred write in this component.
+		let loadingTimer: ReturnType<typeof setTimeout> | null = setTimeout(() => {
+			loadingTimer = null;
+			if (switchedAway(gen, reqItemId)) return;
+			showLoading = true;
+		}, LOADING_DELAY_MS);
+		function stopLoadingMarker() {
+			if (loadingTimer !== null) {
+				clearTimeout(loadingTimer);
+				loadingTimer = null;
+			}
+		}
 
 		void (async () => {
 			try {
@@ -147,18 +232,58 @@
 					limit: MAX_FETCH,
 				});
 				if (switchedAway(gen, reqItemId)) return;
-				const rows = (res.attachments ?? [])
-					.filter((a) => !deletedIds.has(a.id))
-					.map(toStripAttachment);
+				const raw = res.attachments ?? [];
+				const rows = raw.filter((a) => !deletedIds.has(a.id)).map(toStripAttachment);
 				const seen = new Set(rows.map((a) => a.id));
 				const missed = pendingUploads.filter(
 					(a) => !seen.has(a.id) && !deletedIds.has(a.id)
 				);
-				attachments = [...missed, ...rows];
+				// Cap the MERGE, not just the response: `missed` rides on top of
+				// up to MAX_FETCH server rows (DR-11).
+				const merged = [...missed, ...rows];
+				attachments = capped(merged);
+				// The continuation count is anchored on the server's `total` —
+				// one authority, corrected — rather than summed from
+				// independent per-source deltas, which double-counted uploads
+				// the response also reported (Codex rounds 1 and 3).
+				//
+				// `res.total` counts every live row at query time. Three
+				// corrections:
+				//   - subtract rows the page returned that we know are deleted;
+				//     `total` predates those deletions. Only rows IN the page
+				//     are countable — `deletedIds` is a workspace-wide bus and
+				//     may hold ids belonging to other items.
+				//   - add the uploads this page did NOT return: the GET can have
+				//     been issued before they existed, so `total` predates them
+				//     (Codex round 5).
+				//   - floor it at what we actually hold, in case an upload beat
+				//     the count.
+				//
+				// Acknowledged approximation: uploads the PENDING BUFFER's own
+				// cap shed (>MAX_FETCH uploads during a single in-flight
+				// request) are not counted — we can't tell whether `total`
+				// already includes them, and counting them unconditionally
+				// double-counts the ordinary case where the response does
+				// (Codex rounds 3 and 5 pull in opposite directions here). The
+				// next successful load corrects it.
+				const reportedTotal = Math.max(0, (res.total ?? raw.length) - (raw.length - rows.length));
+				const trueTotal = Math.max(reportedTotal + missed.length, merged.length);
+				beyondStripCount = Math.max(0, trueTotal - attachments.length);
+				if (isRetry) {
+					// A retry is the user telling us the outage is over. The
+					// per-attachment HEAD cache latches `null` on failure and
+					// lives for the page lifetime, so chips and inline images
+					// for these same rows would stay poisoned from the same
+					// outage — drop their entries now that we have real ids
+					// (DR-10). Dropping a healthy entry is harmless: the cache
+					// holds immutable data and nothing refetches eagerly.
+					for (const a of attachments) invalidateAttachmentMetadata(reqWsSlug, a.id);
+				}
 			} catch {
-				// A failed fetch renders as "no attachments" — the strip is a
-				// secondary affordance and an error banner above the editor
-				// would be louder than the feature is worth.
+				// A failed fetch is NOT "no attachments" — it renders as a
+				// distinguishable, retryable error (DR-10). It used to be
+				// swallowed, which made a broken strip and an empty one
+				// identical.
 				//
 				// Item-grant GUESTS land here: the list endpoint is viewer+ and
 				// roleLevel("guest") is below viewer, so they 403. That gap is
@@ -168,18 +293,49 @@
 				// Keep anything uploaded while this request was in flight: the
 				// upload SUCCEEDED, so dropping it would hide a row the editor
 				// and server both have, until a remount (Codex review round 2).
-				attachments = pendingUploads.filter((a) => !deletedIds.has(a.id));
+				attachments = capped(pendingUploads.filter((a) => !deletedIds.has(a.id)));
+				loadFailed = true;
+				loadFailedFor = reqItemId;
+			} finally {
+				stopLoadingMarker();
+				if (!switchedAway(gen, reqItemId)) showLoading = false;
 			}
 		})();
 
 		// Teardown invalidates the captured generation too, so a request still
 		// in flight when the component is destroyed loses the fence instead of
 		// writing into a dead instance (Codex round 4). The api wrapper has no
-		// abort signal, so this is the only lever.
+		// abort signal, so this is the only lever. The pending loading timer
+		// goes with it — otherwise it fires into a dead instance.
 		return () => {
 			loadGeneration++;
+			stopLoadingMarker();
 		};
 	});
+
+	/**
+	 * Re-run the load after a failure (DR-10).
+	 *
+	 * Invalidates the shared per-attachment metadata cache for everything the
+	 * strip currently knows BEFORE refetching: `fetchAttachmentMetadata` caches
+	 * `null` on a failed HEAD for the page lifetime, so a retry that doesn't
+	 * clear it replays the cached failure on every surface that probed during
+	 * the outage. The rows the refetch returns get the same treatment (see the
+	 * `isRetry` arm above) — at failure time this list holds only whatever was
+	 * uploaded while the request was in flight.
+	 */
+	function retryLoad() {
+		if (!itemId || !wsSlug) return;
+		// The painted error must belong to the item that is current NOW. If the
+		// parent has already swapped `itemId` and this effect hasn't flushed yet, the
+		// click is stale: the incoming item's own load is already on its way,
+		// and honouring the retry would preserve the previous item's rows
+		// across the switch (Codex round 11).
+		if (loadFailedFor !== itemId) return;
+		for (const a of attachments) invalidateAttachmentMetadata(wsSlug, a.id);
+		retryRequestedFor = itemId;
+		retryNonce++;
+	}
 
 	// Deletions broadcast on the shared registry — from Settings → Storage, or
 	// from ANOTHER strip (the split-pane host mounts two ItemDetails, so two
@@ -187,6 +343,14 @@
 	// mounted strip agreeing with the editors, which already subscribe
 	// (Codex round 17). Emitting our own delete re-enters this harmlessly: the
 	// row is already gone, and the filter is idempotent.
+	//
+	// A deletion of a row the strip HOLDS shrinks `attachments`, and the
+	// continuation count (a delta) stays correct on its own. A deletion of a
+	// row PAST the bound can't be reconciled — this bus is workspace-wide, so
+	// an id we don't hold may belong to another item entirely, and decrementing
+	// on it would corrupt this item's count. The continuation can therefore
+	// overstate by one until the next load; that is the safe direction, and it
+	// self-corrects (Codex round 5).
 	$effect(() => {
 		return registerAttachmentDeletionListener((deletedUuid) => {
 			deletedIds.add(deletedUuid);
@@ -206,10 +370,18 @@
 			// content dedupe — identical bytes share a blob but still get their
 			// own attachment row and id.
 			if (!pendingUploads.some((a) => a.id === uploaded.id)) {
-				pendingUploads = [uploaded, ...pendingUploads];
+				// Capped like everything else (DR-11): this buffer is merged on
+				// top of a full page of server rows, so leaving it unbounded
+				// leaves the merge unbounded too.
+				pendingUploads = capped([uploaded, ...pendingUploads]);
 			}
 			if (attachments.some((a) => a.id === uploaded.id)) return;
-			attachments = [uploaded, ...attachments];
+			// Newest-first, so the cap sheds the oldest rows — but they still
+			// exist, so they move into the continuation's count rather than
+			// vanishing from it.
+			const next = [uploaded, ...attachments];
+			beyondStripCount += Math.max(0, next.length - MAX_FETCH);
+			attachments = capped(next);
 		});
 	});
 
@@ -225,9 +397,39 @@
 	// (DR-9) — otherwise an item with >50 attachments advertises a count that
 	// expanding cannot reveal.
 	let overflowCount = $derived(attachments.length - visible.length);
-	// At the bound we can't know whether more exist, so point at the one
-	// surface that can page through everything.
-	let atBound = $derived(attachments.length >= MAX_FETCH);
+	/** Whether anything exists beyond what the strip holds. */
+	let hasMoreThanStrip = $derived(beyondStripCount > 0);
+	/** The item's true attachment count, strip + everything past the bound. */
+	let continuationTotal = $derived(attachments.length + beyondStripCount);
+	/**
+	 * Header count (DR-18). When the strip holds everything, the fetched rows
+	 * ARE the total. When it doesn't — at the fetch bound — it says `50+`
+	 * rather than a precise figure expanding can never reach (DR-9); the exact
+	 * number rides on the "View all" link, which goes somewhere that can
+	 * actually show them.
+	 */
+	let headerCount = $derived(
+		!hasMoreThanStrip
+			? String(attachments.length)
+			: attachments.length > 0
+				? `${attachments.length}+`
+				: // Nothing held but rows exist past the bound (every held row
+					// deleted, say). We know the figure exactly here, so say it.
+					String(continuationTotal)
+	);
+	/** Whether the header has a count worth showing at all. */
+	let showCount = $derived(attachments.length > 0 || hasMoreThanStrip);
+	/**
+	 * Item-scoped continuation (DR-18): `attachment_item` is read by the
+	 * settings route and seeds StorageTab's `item_id` filter, so "View all"
+	 * lands on THIS item's attachments rather than dumping the user into the
+	 * workspace-wide list.
+	 */
+	let storageHref = $derived(
+		itemId
+			? `/${username}/${wsSlug}/settings?attachment_item=${encodeURIComponent(itemId)}#storage`
+			: `/${username}/${wsSlug}/settings#storage`
+	);
 
 	// Image tiles in strip order, so the lightbox's ←/→ page through the
 	// item's images (DR-8 — the existing Lightbox, not a second one).
@@ -298,19 +500,24 @@
 		// Capture identity BEFORE the await: a switch mid-delete must not roll
 		// the tile back into a DIFFERENT item's strip, and must not toast over
 		// it. The DELETE itself still lands — it targets an id, not a view.
+		// `wsSlug` is captured for the same reason: it is reactive, and the
+		// broadcast + metadata-cache key must name the workspace the DELETE
+		// actually targeted, not whichever one is current when it resolves
+		// (Codex round 6).
 		const gen = loadGeneration;
 		const reqItemId = itemId;
+		const reqWsSlug = wsSlug;
 		const index = attachments.findIndex((a) => a.id === att.id);
 
 		// Optimistic removal.
 		attachments = attachments.filter((a) => a.id !== att.id);
 
 		try {
-			await api.attachments.delete(wsSlug, att.id);
+			await api.attachments.delete(reqWsSlug, att.id);
 			// Tell the live views and drop the cached metadata. An <img> that
 			// already loaded never re-requests, so without this the body keeps
 			// showing a healthy image the server no longer has until reload.
-			announceAttachmentDeleted(wsSlug, att.id);
+			announceAttachmentDeleted(reqWsSlug, att.id);
 		} catch (err) {
 			if (switchedAway(gen, reqItemId ?? '')) return;
 
@@ -326,7 +533,7 @@
 				// gone, so it gets the same broadcast — otherwise an editor
 				// NodeView or another mounted strip in this tab stays stale
 				// precisely when we have proof it should not (Codex round 19).
-				announceAttachmentDeleted(wsSlug, att.id);
+				announceAttachmentDeleted(reqWsSlug, att.id);
 				return;
 			}
 
@@ -340,9 +547,15 @@
 			// snapshot would resurrect rows a concurrent delete removed
 			// successfully (delete A then B, B succeeds, A fails, A's snapshot
 			// brings B back — Codex round 2).
+			//
+			// Through capped() like every other growth path: an upload landing
+			// while the delete was in flight can have taken the list back to
+			// MAX_FETCH, so a bare re-insert would push it to 51
+			// (Codex round 1).
 			const restored = attachments.slice();
 			restored.splice(Math.max(0, Math.min(index, restored.length)), 0, att);
-			attachments = restored;
+			beyondStripCount += Math.max(0, restored.length - MAX_FETCH);
+			attachments = capped(restored);
 			toastStore.show(
 				code === 'forbidden'
 					? `You don't have permission to delete ${att.filename}.`
@@ -353,77 +566,110 @@
 	}
 </script>
 
-{#if attachments.length > 0}
+<!--
+	Three states, and only three (DR-10 / DR-18):
+	  loading  — a slow fetch, past the grace delay
+	  failed   — a distinguishable error with Retry
+	  loaded   — the tiles
+	An item with NO attachments renders no element at all; an empty wrapper
+	would still take the parent flex column's gap and leave a hole above the
+	editor, and an "Attachments — none" block on every un-attached item is
+	noise on the primary authoring surface.
+-->
+{#if showLoading || loadFailed || attachments.length > 0 || hasMoreThanStrip}
 	<section class="attachment-strip" aria-label="Attachments">
-		<div class="fields-header">Attachments · {attachments.length}</div>
-		<div class="strip-row">
-			{#each visible as att (att.id)}
-				<!-- The delete control can't nest inside the tile's own button /
-				     anchor, so each tile gets a positioned wrapper. -->
-				<div class="att-cell">
-					{#if isImage(att.mime_type)}
+		<div class="fields-header">
+			Attachments{showCount ? ` · ${headerCount}` : ''}
+		</div>
+
+		{#if showLoading && attachments.length === 0}
+			<div class="att-status" aria-live="polite">Loading attachments…</div>
+		{:else}
+			{#if loadFailed}
+				<div class="att-error" role="status">
+					<span class="att-error-mark" aria-hidden="true">⚠</span>
+					<span>Couldn't load attachments.</span>
+					<button type="button" class="att-retry" onclick={retryLoad}>Retry</button>
+				</div>
+			{/if}
+			{#if attachments.length > 0 || hasMoreThanStrip}
+				<div class="strip-row">
+					{#each visible as att (att.id)}
+						<!-- The delete control can't nest inside the tile's own button /
+						     anchor, so each tile gets a positioned wrapper. -->
+						<div class="att-cell">
+							{#if isImage(att.mime_type)}
+								<button
+									type="button"
+									class="att-tile"
+									title={tileLabel(att)}
+									aria-label={tileLabel(att)}
+									onclick={() => openLightbox(att)}
+								>
+									<img
+										src={api.attachments.downloadUrl(wsSlug, att.id, 'thumb-sm')}
+										alt=""
+										loading="lazy"
+									/>
+								</button>
+							{:else}
+								<a
+									class="att-tile"
+									href={api.attachments.downloadUrl(wsSlug, att.id)}
+									download={att.filename}
+									title={tileLabel(att)}
+									aria-label={tileLabel(att)}
+								>
+									<span class="att-icon">
+										<AttachmentIcon id={iconForAttachment(att.mime_type, att.filename)} />
+									</span>
+									<span class="att-name" aria-hidden="true">{att.filename}</span>
+								</a>
+							{/if}
+
+							{#if canDelete}
+								<!-- Always in the DOM (never hover-gated in markup) so it's
+								     keyboard reachable; CSS reveals it on hover / focus-within
+								     and it stays visible whenever it has focus. -->
+								<button
+									type="button"
+									class="att-delete"
+									title="Delete {att.filename}"
+									aria-label="Delete {att.filename}"
+									onclick={() => handleDelete(att)}
+								>
+									×
+								</button>
+							{/if}
+						</div>
+					{/each}
+
+					{#if overflowCount > 0}
 						<button
 							type="button"
-							class="att-tile"
-							title={tileLabel(att)}
-							aria-label={tileLabel(att)}
-							onclick={() => openLightbox(att)}
+							class="att-more att-more-expand"
+							onclick={() => (expanded = true)}
+							aria-label="Show {overflowCount} more attachment{overflowCount === 1 ? '' : 's'}"
 						>
-							<img
-								src={api.attachments.downloadUrl(wsSlug, att.id, 'thumb-sm')}
-								alt=""
-								loading="lazy"
-							/>
+							+{overflowCount}
 						</button>
-					{:else}
+					{/if}
+
+					{#if hasMoreThanStrip}
+						<!-- Item-scoped continuation (DR-18): always offered when there
+						     is more than the strip holds, not only once expanded, and
+						     scoped to this item rather than the workspace-wide list. -->
 						<a
-							class="att-tile"
-							href={api.attachments.downloadUrl(wsSlug, att.id)}
-							download={att.filename}
-							title={tileLabel(att)}
-							aria-label={tileLabel(att)}
+							class="att-more att-more-link"
+							href={storageHref}
+							title="View all attachments for this item"
 						>
-							<span class="att-icon">
-								<AttachmentIcon id={iconForAttachment(att.mime_type, att.filename)} />
-							</span>
-							<span class="att-name" aria-hidden="true">{att.filename}</span>
+							View all ({continuationTotal})
 						</a>
 					{/if}
-
-					{#if canDelete}
-						<!-- Always in the DOM (never hover-gated in markup) so it's
-						     keyboard reachable; CSS reveals it on hover / focus-within
-						     and it stays visible whenever it has focus. -->
-						<button
-							type="button"
-							class="att-delete"
-							title="Delete {att.filename}"
-							aria-label="Delete {att.filename}"
-							onclick={() => handleDelete(att)}
-						>
-							×
-						</button>
-					{/if}
 				</div>
-			{/each}
-
-			{#if overflowCount > 0}
-				<button
-					type="button"
-					class="att-more"
-					onclick={() => (expanded = true)}
-					aria-label="Show {overflowCount} more attachment{overflowCount === 1 ? '' : 's'}"
-				>
-					+{overflowCount}
-				</button>
 			{/if}
-
-			{#if atBound && expanded}
-				<a class="att-more att-more-link" href="/{username}/{wsSlug}/settings#storage">
-					All files
-				</a>
-			{/if}
-		</div>
+		{/if}
 	</section>
 {/if}
 
@@ -455,6 +701,41 @@
 		color: var(--text-muted);
 		padding: var(--space-2) 0;
 		margin-bottom: var(--space-1);
+	}
+
+	/* Loading / failed rows. Deliberately compact — the strip is a secondary
+	   affordance, so a failure states itself and offers a retry without
+	   turning into a banner (DR-10). */
+	.att-status,
+	.att-error {
+		display: flex;
+		align-items: center;
+		gap: var(--space-2);
+		font-size: 0.8em;
+		color: var(--text-muted);
+	}
+	/* The TEXT stays on --text-primary: --accent-red is #ef4444 in the light
+	   theme, roughly 3.5:1 on the page background, which fails AA for
+	   normal-size body text (Codex round 2). The red is carried by the
+	   decorative mark instead, where the 3:1 non-text threshold applies. */
+	.att-error {
+		color: var(--text-primary);
+	}
+	.att-error-mark {
+		color: var(--accent-red, #c00);
+	}
+
+	.att-retry {
+		padding: 2px var(--space-2);
+		border: 1px solid currentColor;
+		border-radius: var(--radius-sm, 4px);
+		background: transparent;
+		color: inherit;
+		font: inherit;
+		cursor: pointer;
+	}
+	.att-retry:hover {
+		background: var(--bg-secondary, transparent);
 	}
 
 	/* Single row, always — never wraps to a second line. */

--- a/web/src/lib/components/items/ItemAttachmentStrip.svelte
+++ b/web/src/lib/components/items/ItemAttachmentStrip.svelte
@@ -23,7 +23,8 @@
 	import { untrack } from 'svelte';
 	import { api, PadApiError } from '$lib/api/client';
 	import type { AttachmentListItem } from '$lib/types';
-	import { categoryIcon, formatBytes, isImage } from '$lib/attachments/display';
+	import { iconForAttachment, formatBytes, isImage } from '$lib/attachments/display';
+	import AttachmentIcon from '$lib/attachments/icons/AttachmentIcon.svelte';
 	import Lightbox, { type LightboxImage } from '$lib/components/common/Lightbox.svelte';
 	import { attachmentRefsIn } from '$lib/utils/commentAttachments';
 	import { toastStore } from '$lib/stores/toast.svelte';
@@ -382,7 +383,9 @@
 							title={tileLabel(att)}
 							aria-label={tileLabel(att)}
 						>
-							<span class="att-icon" aria-hidden="true">{categoryIcon(att.mime_type)}</span>
+							<span class="att-icon">
+								<AttachmentIcon id={iconForAttachment(att.mime_type, att.filename)} />
+							</span>
 							<span class="att-name" aria-hidden="true">{att.filename}</span>
 						</a>
 					{/if}
@@ -539,8 +542,11 @@
 		border-radius: 2px;
 	}
 
+	/* File-type icon (TASK-2417). Monochrome and currentColor-driven, so it
+	   themes with light/dark and stays visible under forced-colors. */
 	.att-icon {
-		font-size: 1.1em;
+		display: flex;
+		font-size: 1.4em;
 		line-height: 1;
 	}
 

--- a/web/src/lib/components/items/ItemAttachmentStrip.svelte
+++ b/web/src/lib/components/items/ItemAttachmentStrip.svelte
@@ -20,7 +20,7 @@
 	 * await-then-write path is fenced on a load generation + the requested
 	 * item id, per the no-{#key} bug class from PLAN-2105 / TASK-2112.
 	 */
-	import { untrack } from 'svelte';
+	import { onDestroy, untrack } from 'svelte';
 	import { api, PadApiError } from '$lib/api/client';
 	import type { AttachmentListItem } from '$lib/types';
 	import { iconForAttachment, formatBytes, isImage } from '$lib/attachments/display';
@@ -89,6 +89,10 @@
 	// renders nothing at all (DR-18) instead of flashing a block above the
 	// editor — while a genuinely slow load is still distinguishable from empty.
 	const LOADING_DELAY_MS = 200;
+	// Hard bound on the deletion tombstone set (see `deletedIds`). Generous
+	// relative to MAX_FETCH — a tombstone is one id, and shedding one too eagerly
+	// costs a resurrected row — but finite.
+	const MAX_TOMBSTONES = 500;
 
 	/**
 	 * Only what a tile renders. Deliberately narrower than AttachmentListItem:
@@ -127,11 +131,13 @@
 	// delayed in-flight marker. Empty stays invisible — no section at all.
 	let loadFailed = $state(false);
 	/**
-	 * Item whose load produced the CURRENTLY PAINTED error. Retry validates
-	 * against this rather than the live `itemId`: props update synchronously
-	 * but effects flush later, so a click landing in that window would
-	 * otherwise record a retry for the item the user just moved TO and carry
-	 * the old item's rows across the switch (Codex round 11).
+	 * VIEW (see `viewKey`) whose load produced the CURRENTLY PAINTED error.
+	 * Retry validates against this rather than the live props: they update
+	 * synchronously but effects flush later, so a click landing in that window
+	 * would otherwise record a retry for the view the user just moved TO and
+	 * carry the old one's rows across the switch (Codex round 11). Keyed by
+	 * workspace AND item — an item-only key let a workspace change in that same
+	 * window claim the stale error (Codex confirm round).
 	 */
 	let loadFailedFor: string | null = null;
 	let showLoading = $state(false);
@@ -153,10 +159,31 @@
 	 * click and the flush doesn't apply the retry to a different item.
 	 */
 	let retryRequestedFor: string | null = null;
+	/**
+	 * View identity key. `itemId` alone isn't it: `wsSlug` is reactive and the
+	 * strip stays mounted across a workspace change, so keying on the item
+	 * would classify that as a same-view Retry — leaving the previous
+	 * workspace's rows painted and its in-flight mutations still reconciling
+	 * (Codex fresh-angle round 2).
+	 */
+	function viewKey(ws: string, id: string): string {
+		return `${ws}\u0000${id}`;
+	}
 
-	// Monotonic load generation — bumped on every (re)run of the fetch effect
-	// so an in-flight response for item A can never write under item B.
+	// Two generations, because "which request is this?" and "which item is on
+	// screen?" are different questions and a Retry answers them differently
+	// (final-review P2).
+	//
+	// REQUEST generation — bumped on every (re)run of the fetch effect,
+	// including a Retry, so a superseded list() response can never write.
 	let loadGeneration = 0;
+	// VIEW generation — bumped only when the view actually changes: a different
+	// (item, workspace), or unmount. A Retry is the SAME item reloading, so it
+	// leaves this alone. Mutations fence on this: a delete of a row still on
+	// screen must reconcile (roll back, toast, broadcast) even if the user hit
+	// Retry while it was in flight. Fencing them on the request generation made
+	// a Retry masquerade as an item switch and swallowed the failure.
+	let viewGeneration = 0;
 
 	// Ids confirmed deleted while this item's list was loading. A deletion
 	// broadcast only filters the CURRENT array, so a list() response that was
@@ -164,6 +191,18 @@
 	// (Codex round 18). Every response is filtered through this, and a failed
 	// optimistic delete won't roll back an id that's in here. Cleared per item
 	// load — tombstones are meaningless once we refetch.
+	//
+	// Bounded like every other buffer here (DR-11): it survives a Retry, and
+	// the deletion bus is workspace-wide, so a long-lived pane watching a busy
+	// Storage tab would otherwise accumulate ids forever. Oldest are shed
+	// first — a tombstone only has to outlive the one in-flight list() that
+	// could resurrect its row, so the newest entries are the load-bearing ones.
+	//
+	// Accepted cost of bounding at all: MAX_TOMBSTONES *later* deletions during
+	// a single in-flight list() would evict an earlier one and let that row be
+	// painted back. That takes 500 deletions inside one request's latency, and
+	// the row disappears again on the next load. Unbounded growth is the worse
+	// failure — it is permanent.
 	let deletedIds = new Set<string>();
 
 	// Uploads announced while this item's list was still loading. The GET may
@@ -183,7 +222,8 @@
 		// Claim the retry marker whether or not this run goes on to fetch, so a
 		// stale claim can't leak into a later, unrelated load. Read BEFORE the
 		// reset below, which branches on it.
-		const isRetry = retryRequestedFor !== null && retryRequestedFor === reqItemId;
+		const isRetry =
+			retryRequestedFor !== null && retryRequestedFor === viewKey(reqWsSlug, reqItemId ?? '');
 		retryRequestedFor = null;
 
 		// Clear synchronously on switch. Without this, A's tiles stay painted
@@ -197,6 +237,9 @@
 		// and the editor both have (Codex round 1).
 		untrack(() => {
 			if (!isRetry) {
+				// The view itself changed (new item / workspace), so in-flight
+				// mutations captured against the old one must stop reconciling.
+				viewGeneration++;
 				attachments = [];
 				expanded = false;
 				lightbox = null;
@@ -295,7 +338,7 @@
 				// and server both have, until a remount (Codex review round 2).
 				attachments = capped(pendingUploads.filter((a) => !deletedIds.has(a.id)));
 				loadFailed = true;
-				loadFailedFor = reqItemId;
+				loadFailedFor = viewKey(reqWsSlug, reqItemId);
 			} finally {
 				stopLoadingMarker();
 				if (!switchedAway(gen, reqItemId)) showLoading = false;
@@ -307,10 +350,21 @@
 		// writing into a dead instance (Codex round 4). The api wrapper has no
 		// abort signal, so this is the only lever. The pending loading timer
 		// goes with it — otherwise it fires into a dead instance.
+		//
+		// Only the REQUEST generation, deliberately: this cleanup also runs
+		// before every re-run of the effect, Retry included, and bumping the
+		// view generation here would put the Retry bug straight back. Unmount
+		// is handled by onDestroy below, which runs only on destroy.
 		return () => {
 			loadGeneration++;
 			stopLoadingMarker();
 		};
+	});
+
+	// Destroy invalidates the VIEW too — an in-flight delete that resolves
+	// after the component is gone must not toast or write.
+	onDestroy(() => {
+		viewGeneration++;
 	});
 
 	/**
@@ -331,9 +385,9 @@
 		// click is stale: the incoming item's own load is already on its way,
 		// and honouring the retry would preserve the previous item's rows
 		// across the switch (Codex round 11).
-		if (loadFailedFor !== itemId) return;
+		if (loadFailedFor !== viewKey(wsSlug, itemId)) return;
 		for (const a of attachments) invalidateAttachmentMetadata(wsSlug, a.id);
-		retryRequestedFor = itemId;
+		retryRequestedFor = viewKey(wsSlug, itemId);
 		retryNonce++;
 	}
 
@@ -353,10 +407,29 @@
 	// self-corrects (Codex round 5).
 	$effect(() => {
 		return registerAttachmentDeletionListener((deletedUuid) => {
-			deletedIds.add(deletedUuid);
+			rememberDeleted(deletedUuid);
 			attachments = attachments.filter((a) => a.id !== deletedUuid);
 		});
 	});
+
+	/**
+	 * Record a tombstone, shedding the oldest once past MAX_TOMBSTONES. A Set
+	 * iterates in insertion order, so the first entries out are the ones least
+	 * likely to still be racing a list() response.
+	 */
+	function rememberDeleted(id: string) {
+		// Re-announcing an id refreshes its age: Set.add() on an existing key is
+		// a no-op for ordering, so without the delete the second announcement
+		// would leave it as eviction-eligible as the first did.
+		deletedIds.delete(id);
+		deletedIds.add(id);
+		let excess = deletedIds.size - MAX_TOMBSTONES;
+		if (excess <= 0) return;
+		for (const oldest of deletedIds) {
+			deletedIds.delete(oldest);
+			if (--excess <= 0) break;
+		}
+	}
 
 	// Uploads announced by the editor's paste / drag-drop plugin. Scoped to THIS
 	// item — the bus carries the id the server actually associated, so a file
@@ -390,6 +463,16 @@
 	// line up.
 	function switchedAway(gen: number, reqItemId: string): boolean {
 		return gen !== loadGeneration || itemId !== reqItemId;
+	}
+
+	/**
+	 * The mutation fence. Same shape as `switchedAway`, but against the VIEW
+	 * generation — a Retry re-runs the load without changing what is on screen,
+	 * so an in-flight delete for this item must still reconcile (final-review
+	 * P2). The id compare closes the A→B→A gap the counter alone can miss.
+	 */
+	function viewChanged(gen: number, reqItemId: string, reqWsSlug: string): boolean {
+		return gen !== viewGeneration || itemId !== reqItemId || wsSlug !== reqWsSlug;
 	}
 
 	let visible = $derived(expanded ? attachments : attachments.slice(0, COLLAPSED_TILES));
@@ -504,7 +587,7 @@
 		// broadcast + metadata-cache key must name the workspace the DELETE
 		// actually targeted, not whichever one is current when it resolves
 		// (Codex round 6).
-		const gen = loadGeneration;
+		const gen = viewGeneration;
 		const reqItemId = itemId;
 		const reqWsSlug = wsSlug;
 		const index = attachments.findIndex((a) => a.id === att.id);
@@ -519,7 +602,7 @@
 			// showing a healthy image the server no longer has until reload.
 			announceAttachmentDeleted(reqWsSlug, att.id);
 		} catch (err) {
-			if (switchedAway(gen, reqItemId ?? '')) return;
+			if (viewChanged(gen, reqItemId ?? '', reqWsSlug)) return;
 
 			// A 404 means it's ALREADY gone. The in-process deletion bus covers
 			// other surfaces in THIS tab, but not another user, another tab, or
@@ -552,10 +635,19 @@
 			// while the delete was in flight can have taken the list back to
 			// MAX_FETCH, so a bare re-insert would push it to 51
 			// (Codex round 1).
-			const restored = attachments.slice();
-			restored.splice(Math.max(0, Math.min(index, restored.length)), 0, att);
-			beyondStripCount += Math.max(0, restored.length - MAX_FETCH);
-			attachments = capped(restored);
+			//
+			// Skipped entirely when the row is already back: a reload that
+			// landed while the delete was in flight (a Retry, or the pending-
+			// upload buffer being re-merged after a second failure) can have
+			// restored it, and a blind splice would duplicate the id — which
+			// the keyed `{#each}` rejects outright. The toast still fires: the
+			// delete genuinely failed either way.
+			if (!attachments.some((a) => a.id === att.id)) {
+				const restored = attachments.slice();
+				restored.splice(Math.max(0, Math.min(index, restored.length)), 0, att);
+				beyondStripCount += Math.max(0, restored.length - MAX_FETCH);
+				attachments = capped(restored);
+			}
 			toastStore.show(
 				code === 'forbidden'
 					? `You don't have permission to delete ${att.filename}.`

--- a/web/src/lib/components/items/ItemAttachmentStrip.svelte.test.ts
+++ b/web/src/lib/components/items/ItemAttachmentStrip.svelte.test.ts
@@ -651,6 +651,30 @@ describe('ItemAttachmentStrip', () => {
 		expect(errorRow()).toBeNull();
 	});
 
+	it('ignores a Retry click that lands after the WORKSPACE already switched', async () => {
+		// Same stale-click window as the item-switch case, one prop over: the
+		// painted error belongs to the old workspace, so honouring the click
+		// would carry its rows (and its tombstones) into the new one.
+		listMock.mockRejectedValueOnce(new Error('offline'));
+		mountStrip('item-a');
+		await settle();
+		broadcastUpload('item-a', uploaded('ws1-only'));
+		flushSync();
+		expect(tiles()).toHaveLength(1);
+
+		listMock.mockResolvedValueOnce(response([att({ id: 'ws2-row' })]));
+		props.wsSlug = 'ws2';
+		// No flushSync between the switch and the click: that IS the window.
+		target.querySelector<HTMLButtonElement>('.att-retry')?.click();
+		flushSync();
+		await settle();
+
+		const names = tiles().map((el) => el.getAttribute('aria-label') ?? '');
+		expect(names.some((n) => n.includes('ws1-only'))).toBe(false);
+		expect(names.some((n) => n.includes('ws2-row.png'))).toBe(true);
+		expect(errorRow()).toBeNull();
+	});
+
 	it('does not carry a failure across an item switch', async () => {
 		listMock.mockRejectedValueOnce(new Error('boom'));
 		mountStrip('item-a');
@@ -967,6 +991,129 @@ describe('ItemAttachmentStrip', () => {
 		confirmSpy.mockRestore();
 	});
 
+	it('still rolls back and toasts when a Retry re-ran the load mid-delete', async () => {
+		// A Retry is the SAME item reloading, not a switch. Fencing mutations on
+		// the load generation made a Retry look like an A→B switch, so a delete
+		// failure landing during one was swallowed — no rollback, no toast, no
+		// broadcast (final-review P2). Reachable because a failed load still
+		// paints rows uploaded while it was in flight, delete control and all.
+		listMock.mockRejectedValue(new Error('offline'));
+		props.canDelete = true;
+		mountStrip('item-a');
+		await settle();
+		broadcastUpload('item-a', uploaded('survivor'));
+		flushSync();
+		expect(tiles()).toHaveLength(1);
+		expect(errorRow()).not.toBeNull();
+
+		let failDelete!: (err: Error) => void;
+		deleteMock.mockReturnValue(
+			new Promise<void>((_, reject) => {
+				failDelete = reject;
+			})
+		);
+		const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+		deleteButtons()[0].click();
+		flushSync();
+		expect(tiles()).toHaveLength(0); // optimistic removal
+
+		// Retry while the delete is still in flight.
+		target.querySelector<HTMLButtonElement>('.att-retry')?.click();
+		flushSync();
+		await settle();
+
+		failDelete(new Error('500'));
+		await settle();
+
+		expect(tiles()).toHaveLength(1);
+		expect(tiles()[0].getAttribute('aria-label')).toContain('survivor.png');
+		expect(toastMock).toHaveBeenCalledOnce();
+		expect(String(toastMock.mock.calls[0][0])).toContain('survivor.png');
+		expect(notifyDeletedMock).not.toHaveBeenCalled();
+		confirmSpy.mockRestore();
+	});
+
+	it('suppresses a failed delete when the WORKSPACE changed under it', async () => {
+		// `wsSlug` is reactive and the strip survives a workspace change, so
+		// view identity is (workspace, item) — keying it on the item alone would
+		// read that switch as a same-item Retry and roll A's row into B's strip
+		// (Codex fresh-angle round 2).
+		listMock.mockRejectedValue(new Error('offline'));
+		props.canDelete = true;
+		mountStrip('item-a');
+		await settle();
+		broadcastUpload('item-a', uploaded('survivor'));
+		flushSync();
+
+		let failDelete!: (err: Error) => void;
+		deleteMock.mockReturnValue(
+			new Promise<void>((_, reject) => {
+				failDelete = reject;
+			})
+		);
+		const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+		deleteButtons()[0].click();
+		flushSync();
+		expect(tiles()).toHaveLength(0);
+
+		// Retry clicked, THEN the workspace swapped before the effect flushed —
+		// the window where an item-keyed retry marker is claimed by the wrong
+		// view.
+		target.querySelector<HTMLButtonElement>('.att-retry')?.click();
+		listMock.mockResolvedValue(response([att({ id: 'other-ws' })]));
+		props.wsSlug = 'ws2';
+		flushSync();
+		await settle();
+
+		failDelete(new Error('500'));
+		await settle();
+
+		const names = tiles().map((el) => el.getAttribute('aria-label') ?? '');
+		expect(names.some((n) => n.includes('survivor.png'))).toBe(false);
+		expect(names.some((n) => n.includes('other-ws.png'))).toBe(true);
+		expect(toastMock).not.toHaveBeenCalled();
+		confirmSpy.mockRestore();
+	});
+
+	it('still suppresses a failed delete after an A→B→A round trip', async () => {
+		// The view generation, not just the id compare, is what closes this:
+		// `itemId` reads 'item-a' again by the time the delete rejects, but the
+		// row belongs to a view that has since been torn down and refetched —
+		// restoring it would resurrect a row A's newer load didn't return
+		// (PLAN-2105 / TASK-2112).
+		listMock.mockResolvedValue(response([att({ id: 'a1' })]));
+		props.canDelete = true;
+		mountStrip('item-a');
+		await settle();
+
+		let failDelete!: (err: Error) => void;
+		deleteMock.mockReturnValue(
+			new Promise<void>((_, reject) => {
+				failDelete = reject;
+			})
+		);
+		const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+		deleteButtons()[0].click();
+		flushSync();
+
+		listMock.mockResolvedValue(response([att({ id: 'b1' })]));
+		props.itemId = 'item-b';
+		flushSync();
+		await settle();
+
+		listMock.mockResolvedValue(response([]));
+		props.itemId = 'item-a';
+		flushSync();
+		await settle();
+
+		failDelete(new Error('500'));
+		await settle();
+
+		expect(tiles()).toHaveLength(0);
+		expect(toastMock).not.toHaveBeenCalled();
+		confirmSpy.mockRestore();
+	});
+
 	// ── Upload refresh (TASK-2385) ────────────────────────────────────────
 
 	const uploaded = (id: string): UploadedAttachment => ({
@@ -1131,6 +1278,35 @@ describe('ItemAttachmentStrip', () => {
 		const names = tiles().map((el) => el.getAttribute('aria-label') ?? '');
 		expect(names).toHaveLength(1);
 		expect(names[0]).toContain('a1.png');
+	});
+
+	it('bounds the tombstone set, shedding the oldest ids first', async () => {
+		// The tombstones survive a Retry and ride a workspace-wide bus, so the
+		// set needs the same hard bound as the list buffers (final-review P3).
+		// The newest tombstone is the one that can still be racing an in-flight
+		// response, so the cap sheds from the other end.
+		listMock.mockRejectedValueOnce(new Error('offline'));
+		mountStrip('item-a');
+		await settle();
+
+		broadcastDeletion('oldest');
+		for (let i = 0; i < 500; i++) broadcastDeletion(`bulk-${i}`);
+		broadcastDeletion('newest');
+		flushSync();
+
+		// Retry keeps the tombstones (an item switch would clear them).
+		listMock.mockResolvedValueOnce(
+			response([att({ id: 'oldest' }), att({ id: 'newest' }), att({ id: 'live' })])
+		);
+		target.querySelector<HTMLButtonElement>('.att-retry')?.click();
+		flushSync();
+		await settle();
+
+		const names = tiles().map((el) => el.getAttribute('aria-label') ?? '');
+		expect(names.some((n) => n.includes('newest.png'))).toBe(false);
+		expect(names.some((n) => n.includes('live.png'))).toBe(true);
+		// Shed by the cap, so it is no longer suppressed — the safe direction.
+		expect(names.some((n) => n.includes('oldest.png'))).toBe(true);
 	});
 
 	it('warns using UNFLUSHED editor content, not just the persisted body', async () => {

--- a/web/src/lib/components/items/ItemAttachmentStrip.svelte.test.ts
+++ b/web/src/lib/components/items/ItemAttachmentStrip.svelte.test.ts
@@ -68,6 +68,14 @@ vi.mock('$lib/attachments/events', () => ({
 // mock above splits them back out so tests can assert each half.
 const invalidateMock = vi.fn<(ws: string, uuid: string) => void>();
 
+// The strip also reaches the shared HEAD-metadata cache directly, on Retry
+// (PLAN-2392 DR-10) — a separate spy from the events bus's, so the two can be
+// asserted independently.
+const invalidateMetadataMock = vi.fn<(ws: string, uuid: string) => void>();
+vi.mock('$lib/components/editor/attachment-metadata', () => ({
+	invalidateAttachmentMetadata: (ws: string, uuid: string) => invalidateMetadataMock(ws, uuid),
+}));
+
 vi.mock('$lib/stores/toast.svelte', () => ({
 	toastStore: { show: (message: string, kind?: string) => toastMock(message, kind) },
 }));
@@ -131,6 +139,7 @@ describe('ItemAttachmentStrip', () => {
 		toastMock.mockReset();
 		notifyDeletedMock.mockReset();
 		invalidateMock.mockReset();
+		invalidateMetadataMock.mockReset();
 		props.wsSlug = 'ws';
 		props.username = 'dave';
 		props.itemId = null;
@@ -270,27 +279,154 @@ describe('ItemAttachmentStrip', () => {
 		await settle();
 
 		expect(tiles()).toHaveLength(8);
-		const more = target.querySelector<HTMLElement>('.att-more');
+		const more = target.querySelector<HTMLElement>('.att-more-expand');
 		expect(more?.textContent?.trim()).toBe('+4');
 
 		more?.click();
 		flushSync();
 		expect(tiles()).toHaveLength(12);
-		expect(target.querySelector('.att-more')).toBeNull();
+		expect(target.querySelector('.att-more-expand')).toBeNull();
 	});
 
-	it('links out to Settings → Storage once expanded at the 50-row bound', async () => {
+	it('offers an item-scoped "View all" continuation at the 50-row bound', async () => {
+		// PLAN-2392 DR-18: the continuation is offered WITHOUT expanding first,
+		// carries the item's real total, and lands on this item's attachments
+		// rather than the workspace-wide Storage list.
 		const rows = Array.from({ length: 50 }, (_, i) => att({ id: `a${i}` }));
 		listMock.mockResolvedValue({ attachments: rows, total: 120, limit: 50, offset: 0 });
 		mountStrip('item-a');
 		await settle();
 
-		expect(target.querySelector<HTMLElement>('.att-more')?.textContent?.trim()).toBe('+42');
-		target.querySelector<HTMLElement>('.att-more')?.click();
+		// The header can't claim 120 — expanding reaches only the 50 fetched —
+		// so it says "50+" and the exact figure lives on the link.
+		expect(target.querySelector('.fields-header')?.textContent?.trim()).toBe(
+			'Attachments · 50+'
+		);
+		expect(target.querySelector<HTMLElement>('.att-more-expand')?.textContent?.trim()).toBe(
+			'+42'
+		);
+
+		const link = target.querySelector<HTMLAnchorElement>('a.att-more-link');
+		expect(link?.textContent?.trim()).toBe('View all (120)');
+		expect(link?.getAttribute('href')).toBe('/dave/ws/settings?attachment_item=item-a#storage');
+	});
+
+	it('never grows the in-memory list past the 50-row bound (DR-11)', async () => {
+		// The documented cap used to bound only the fetch `limit`; the upload
+		// path prepended unconditionally, so a long paste session grew the list
+		// (and the lightbox set) without limit.
+		const rows = Array.from({ length: 50 }, (_, i) => att({ id: `a${i}` }));
+		listMock.mockResolvedValue({ attachments: rows, total: 50, limit: 50, offset: 0 });
+		mountStrip('item-a');
+		await settle();
+
+		for (let i = 0; i < 20; i++) broadcastUpload('item-a', uploaded(`paste-${i}`));
 		flushSync();
 
-		const link = target.querySelector<HTMLAnchorElement>('a.att-more');
-		expect(link?.getAttribute('href')).toBe('/dave/ws/settings#storage');
+		const more = target.querySelector<HTMLElement>('.att-more-expand');
+		more?.click();
+		flushSync();
+		expect(tiles()).toHaveLength(50);
+		// Newest-first, so the cap sheds the oldest rows, not the fresh ones.
+		expect(tiles()[0].getAttribute('aria-label')).toContain('paste-19.png');
+	});
+
+	it('bounds the pending-upload buffer too, not just the merged result', async () => {
+		// Uploads announced while the list request is in flight go into
+		// `pendingUploads`, which was itself unbounded — so bounding only the
+		// merge still let the buffer grow across a long paste session
+		// (DR-11, Codex rounds 4 and 6). Proven through the merge: 60 pending
+		// uploads must yield 50 rows, not 60 (and not 110 once rows land).
+		const pending = deferred<AttachmentListResponse>();
+		listMock.mockReturnValue(pending.promise);
+		mountStrip('item-a');
+		flushSync();
+
+		for (let i = 0; i < 60; i++) broadcastUpload('item-a', uploaded(`p${i}`));
+		flushSync();
+
+		// The GET was issued before the uploads existed, so both its page and
+		// its `total` predate them.
+		pending.resolve({
+			attachments: [att({ id: 'server1' }), att({ id: 'server2' })],
+			total: 2,
+			limit: 50,
+			offset: 0,
+		});
+		await settle();
+
+		target.querySelector<HTMLElement>('.att-more-expand')?.click();
+		flushSync();
+		expect(tiles()).toHaveLength(50);
+		// The rows the merge cap shed still exist, so the continuation counts
+		// them rather than pretending the strip holds everything. The 10 the
+		// PENDING buffer shed are the documented approximation — counting them
+		// would double-count the ordinary case where the response's `total`
+		// already includes the uploads; the next load corrects it.
+		expect(
+			target.querySelector<HTMLAnchorElement>('a.att-more-link')?.textContent?.trim()
+		).toBe('View all (52)');
+	});
+
+	it('still offers the continuation when every held row is deleted', async () => {
+		// 50 held + 70 past the bound. Deleting the held ones must not hide the
+		// section outright — there are still 70 attachments on this item, and
+		// the link is the only way to reach them (Codex round 5).
+		const rows = Array.from({ length: 50 }, (_, i) => att({ id: `a${i}` }));
+		listMock.mockResolvedValue({ attachments: rows, total: 120, limit: 50, offset: 0 });
+		mountStrip('item-a');
+		await settle();
+
+		for (const r of rows) broadcastDeletion(r.id);
+		flushSync();
+
+		expect(tiles()).toHaveLength(0);
+		expect(target.querySelector('.attachment-strip')).not.toBeNull();
+		expect(target.querySelector('.fields-header')?.textContent?.trim()).toBe('Attachments · 70');
+		expect(
+			target.querySelector<HTMLAnchorElement>('a.att-more-link')?.textContent?.trim()
+		).toBe('View all (70)');
+	});
+
+	it('does not double-count uploads the response already reported', async () => {
+		// The GET went out after the uploads, so its `total` already includes
+		// them. Adding a separate "pending overflow" on top produced
+		// "View all (70)" for 60 real attachments (Codex round 3).
+		const rows = Array.from({ length: 50 }, (_, i) => att({ id: `u${i}` }));
+		listMock.mockResolvedValue({ attachments: rows, total: 60, limit: 50, offset: 0 });
+		mountStrip('item-a');
+		await settle();
+
+		for (let i = 0; i < 10; i++) broadcastUpload('item-a', uploaded(`u${i}`));
+		flushSync();
+
+		expect(
+			target.querySelector<HTMLAnchorElement>('a.att-more-link')?.textContent?.trim()
+		).toBe('View all (60)');
+	});
+
+	it('does not count a row deleted while the request was in flight', async () => {
+		// `total` predates the deletion, so trusting it verbatim advertised
+		// "View all (2)" for a single remaining attachment (Codex round 3).
+		const pending = deferred<AttachmentListResponse>();
+		listMock.mockReturnValue(pending.promise);
+		mountStrip('item-a');
+		flushSync();
+
+		broadcastDeletion('gone');
+		flushSync();
+
+		pending.resolve({
+			attachments: [att({ id: 'gone' }), att({ id: 'stays' })],
+			total: 2,
+			limit: 50,
+			offset: 0,
+		});
+		await settle();
+
+		expect(tiles()).toHaveLength(1);
+		expect(target.querySelector('a.att-more-link')).toBeNull();
+		expect(target.querySelector('.fields-header')?.textContent?.trim()).toBe('Attachments · 1');
 	});
 
 	it('never paints item A attachments under item B (generation fence)', async () => {
@@ -369,13 +505,189 @@ describe('ItemAttachmentStrip', () => {
 		expect(target.querySelector('.attachment-strip')).toBeNull();
 	});
 
-	it('renders nothing when the fetch fails', async () => {
+	// ── Load failure (PLAN-2392 DR-10) ────────────────────────────────────
+	//
+	// This deliberately REPLACES the old "renders nothing when the fetch
+	// fails" expectation. Swallowing the error made a broken strip and an
+	// empty one indistinguishable, which is exactly what DR-10 forbids.
+
+	function errorRow(): HTMLElement | null {
+		return target.querySelector<HTMLElement>('.att-error');
+	}
+
+	it('shows a loading row for a slow fetch — loading, empty and failed differ', async () => {
+		vi.useFakeTimers();
+		try {
+			const pending = deferred<AttachmentListResponse>();
+			listMock.mockReturnValue(pending.promise);
+			mountStrip('item-a');
+			flushSync();
+
+			// Inside the grace period the strip is still invisible, so the
+			// common no-attachments item never flashes a block above the editor.
+			expect(target.querySelector('.attachment-strip')).toBeNull();
+
+			vi.advanceTimersByTime(250);
+			flushSync();
+			expect(target.querySelector('.att-status')?.textContent).toContain('Loading attachments');
+			expect(errorRow()).toBeNull();
+
+			pending.resolve(response([]));
+			await Promise.resolve();
+			await Promise.resolve();
+			flushSync();
+			// Empty: back to nothing at all (DR-18).
+			expect(target.querySelector('.attachment-strip')).toBeNull();
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it('drops the loading row when the item switches away mid-load', async () => {
+		vi.useFakeTimers();
+		try {
+			listMock.mockReturnValue(deferred<AttachmentListResponse>().promise);
+			mountStrip('item-a');
+			flushSync();
+
+			props.itemId = null;
+			flushSync();
+			// A's timer must not fire into B's (here: no) item.
+			vi.advanceTimersByTime(250);
+			flushSync();
+			expect(target.querySelector('.attachment-strip')).toBeNull();
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it('renders a distinguishable, retryable error when the fetch fails', async () => {
 		listMock.mockRejectedValue(new Error('boom'));
 		mountStrip('item-a');
 		await settle();
 
+		expect(target.querySelector('.attachment-strip')).not.toBeNull();
+		expect(errorRow()?.textContent).toContain("Couldn't load attachments");
+		expect(errorRow()?.querySelector('.att-retry')).not.toBeNull();
+		// Failed is not empty: no tiles, but the section is present and says so.
+		expect(tiles()).toHaveLength(0);
+	});
+
+	it('refetches on Retry and clears the error on success', async () => {
+		listMock.mockRejectedValueOnce(new Error('offline'));
+		mountStrip('item-a');
+		await settle();
+		expect(errorRow()).not.toBeNull();
+
+		listMock.mockResolvedValueOnce(response([att({ id: 'back' })]));
+		target.querySelector<HTMLButtonElement>('.att-retry')?.click();
+		flushSync();
+		await settle();
+
+		expect(listMock).toHaveBeenCalledTimes(2);
+		expect(errorRow()).toBeNull();
+		expect(tiles()).toHaveLength(1);
+		// The per-attachment HEAD cache latches `null` on failure for the page
+		// lifetime, so a Retry that doesn't clear it replays the cached failure
+		// on every other surface that probed during the same outage (DR-10).
+		expect(invalidateMetadataMock).toHaveBeenCalledWith('ws', 'back');
+	});
+
+	it('shows the error again when Retry fails too', async () => {
+		listMock.mockRejectedValue(new Error('still offline'));
+		mountStrip('item-a');
+		await settle();
+
+		target.querySelector<HTMLButtonElement>('.att-retry')?.click();
+		flushSync();
+		await settle();
+
+		expect(listMock).toHaveBeenCalledTimes(2);
+		expect(errorRow()).not.toBeNull();
+	});
+
+	it('keeps optimistic uploads across a Retry that fails again', async () => {
+		// A Retry is the same item reloading, not a switch — so it must not
+		// wipe the rows the first failure deliberately preserved. The upload
+		// succeeded; only the listing didn't.
+		listMock.mockRejectedValue(new Error('offline'));
+		mountStrip('item-a');
+		await settle();
+		broadcastUpload('item-a', uploaded('survivor'));
+		flushSync();
+		expect(tiles()).toHaveLength(1);
+
+		target.querySelector<HTMLButtonElement>('.att-retry')?.click();
+		flushSync();
+		await settle();
+
+		expect(errorRow()).not.toBeNull();
+		expect(tiles()).toHaveLength(1);
+		expect(tiles()[0].getAttribute('aria-label')).toContain('survivor.png');
+	});
+
+	it('ignores a Retry click that lands after the item already switched', async () => {
+		// Props update synchronously, effects flush later — so a click can land
+		// on item A's still-painted Retry when `itemId` already reads B. Taking
+		// it at face value would record a retry for B and preserve A's rows
+		// across the switch (Codex round 11).
+		listMock.mockRejectedValueOnce(new Error('offline'));
+		mountStrip('item-a');
+		await settle();
+		broadcastUpload('item-a', uploaded('a-only'));
+		flushSync();
+		expect(tiles()).toHaveLength(1);
+
+		listMock.mockResolvedValueOnce(response([att({ id: 'b1' })]));
+		props.itemId = 'item-b';
+		// No flushSync between the switch and the click: that IS the window.
+		target.querySelector<HTMLButtonElement>('.att-retry')?.click();
+		flushSync();
+		await settle();
+
+		const names = tiles().map((el) => el.getAttribute('aria-label') ?? '');
+		expect(names.some((n) => n.includes('a-only'))).toBe(false);
+		expect(names.some((n) => n.includes('b1.png'))).toBe(true);
+		expect(errorRow()).toBeNull();
+	});
+
+	it('does not carry a failure across an item switch', async () => {
+		listMock.mockRejectedValueOnce(new Error('boom'));
+		mountStrip('item-a');
+		await settle();
+		expect(errorRow()).not.toBeNull();
+
+		listMock.mockResolvedValueOnce(response([]));
+		props.itemId = 'item-b';
+		flushSync();
+		await settle();
+
+		// B has no attachments: no error, and no section at all (DR-18).
 		expect(target.querySelector('.attachment-strip')).toBeNull();
 	});
+
+	it('does not paint item A failure under item B (generation fence)', async () => {
+		let failA!: (err: Error) => void;
+		listMock.mockReturnValueOnce(
+			new Promise<AttachmentListResponse>((_, reject) => {
+				failA = reject;
+			})
+		);
+		mountStrip('item-a');
+		await settle();
+
+		listMock.mockResolvedValueOnce(response([att({ id: 'b1' })]));
+		props.itemId = 'item-b';
+		flushSync();
+		await settle();
+
+		failA(new Error('late failure'));
+		await settle();
+
+		expect(errorRow()).toBeNull();
+		expect(tiles()).toHaveLength(1);
+	});
+
 
 	// ── Delete (TASK-2384) ────────────────────────────────────────────────
 	//
@@ -753,6 +1065,9 @@ describe('ItemAttachmentStrip', () => {
 		const names = tiles().map((el) => el.getAttribute('aria-label') ?? '');
 		expect(names).toHaveLength(1);
 		expect(names[0]).toContain('survivor.png');
+		// ...and the failure is still stated alongside it (DR-10) — the tile
+		// isn't a claim that the list loaded.
+		expect(errorRow()).not.toBeNull();
 	});
 
 	it('ignores an upload announced for a DIFFERENT item', async () => {

--- a/web/src/lib/components/items/ItemAttachmentStrip.svelte.test.ts
+++ b/web/src/lib/components/items/ItemAttachmentStrip.svelte.test.ts
@@ -1264,6 +1264,115 @@ describe('ItemAttachmentStrip', () => {
 		expect(names.some((n) => n.includes('old1.png'))).toBe(true);
 	});
 
+	it('lets a later load retire a pending upload deleted outside this tab', async () => {
+		// `pendingUploads` was retained forever and no successful response ever
+		// consumed it, so it re-merged onto EVERY later load. The event bus is
+		// process-local, so a deletion from another tab or another user, followed
+		// by a load that legitimately returns no row, resurrected the tile — and
+		// kept resurrecting it (final review round 4).
+		//
+		// The rule: a response is authoritative about the entries the buffer
+		// already held when that request went OUT. Entries announced while it was
+		// in flight are the buffer's actual purpose and stay.
+		listMock.mockRejectedValueOnce(new Error('offline'));
+		mountStrip('item-a');
+		await settle();
+		expect(errorRow()).not.toBeNull();
+
+		// Uploaded during the outage: buffered, and rightly shown.
+		broadcastUpload('item-a', uploaded('elsewhere-deleted'));
+		flushSync();
+		expect(tiles()).toHaveLength(1);
+
+		// Retry. The GET goes out AFTER the upload, so the server's answer is
+		// authoritative — and it says the row is gone, because another tab
+		// deleted it.
+		listMock.mockResolvedValueOnce(response([att({ id: 'still-here' })]));
+		target.querySelector<HTMLButtonElement>('.att-retry')?.click();
+		flushSync();
+		await settle();
+
+		const names = tiles().map((el) => el.getAttribute('aria-label') ?? '');
+		expect(names.some((n) => n.includes('elsewhere-deleted'))).toBe(false);
+		expect(names.some((n) => n.includes('still-here.png'))).toBe(true);
+	});
+
+	it('does not retire a pending upload on a TRUNCATED page', async () => {
+		// The request is bounded at 50 rows, so a FULL page is not proof of
+		// absence — a still-live row can simply be past it. Retiring it there
+		// would delete a good tile permanently, which is worse than the
+		// resurrection the retirement rule exists to fix (Codex round 2).
+		listMock.mockRejectedValueOnce(new Error('offline'));
+		mountStrip('item-a');
+		await settle();
+
+		broadcastUpload('item-a', uploaded('past-the-bound'));
+		flushSync();
+
+		// The retry's page comes back FULL, and the server says there are more.
+		const full = Array.from({ length: 50 }, (_, i) => att({ id: `s${i}` }));
+		listMock.mockResolvedValueOnce({ attachments: full, total: 60, limit: 50, offset: 0 });
+		target.querySelector<HTMLButtonElement>('.att-retry')?.click();
+		flushSync();
+		await settle();
+
+		target.querySelector<HTMLElement>('.att-more-expand')?.click();
+		flushSync();
+		const names = tiles().map((el) => el.getAttribute('aria-label') ?? '');
+		expect(names.some((n) => n.includes('past-the-bound.png'))).toBe(true);
+	});
+
+	it('treats a page that holds every live row as complete, even at the bound', async () => {
+		// `total` is the server's own count and `offset` is always 0 here, so a
+		// page of exactly MAX_FETCH rows with `total: 50` HAS reached everything.
+		// Reading "full page" as "truncated" would leave an externally deleted
+		// upload buffered — resurrectable indefinitely (Codex round 3).
+		listMock.mockRejectedValueOnce(new Error('offline'));
+		mountStrip('item-a');
+		await settle();
+
+		broadcastUpload('item-a', uploaded('elsewhere-deleted'));
+		flushSync();
+
+		const full = Array.from({ length: 50 }, (_, i) => att({ id: `s${i}` }));
+		listMock.mockResolvedValueOnce({ attachments: full, total: 50, limit: 50, offset: 0 });
+		target.querySelector<HTMLButtonElement>('.att-retry')?.click();
+		flushSync();
+		await settle();
+
+		target.querySelector<HTMLElement>('.att-more-expand')?.click();
+		flushSync();
+		const names = tiles().map((el) => el.getAttribute('aria-label') ?? '');
+		expect(names.some((n) => n.includes('elsewhere-deleted'))).toBe(false);
+		expect(names).toHaveLength(50);
+	});
+
+	it('still keeps an upload announced while THIS request was in flight', async () => {
+		// The other side of the same rule, and the reason the buffer exists at
+		// all: this GET was issued BEFORE the upload, so its silence about the
+		// row proves nothing and the tile must survive the response. Pins the
+		// consumption above to entries the request could actually have covered.
+		listMock.mockRejectedValueOnce(new Error('offline'));
+		mountStrip('item-a');
+		await settle();
+
+		const pending = deferred<AttachmentListResponse>();
+		listMock.mockReturnValueOnce(pending.promise);
+		target.querySelector<HTMLButtonElement>('.att-retry')?.click();
+		flushSync();
+
+		// Announced AFTER the retry's request went out.
+		broadcastUpload('item-a', uploaded('mid-flight'));
+		flushSync();
+
+		pending.resolve(response([att({ id: 'server-row' })]));
+		await settle();
+
+		const names = tiles().map((el) => el.getAttribute('aria-label') ?? '');
+		expect(names.some((n) => n.includes('mid-flight.png'))).toBe(true);
+		expect(names.some((n) => n.includes('server-row.png'))).toBe(true);
+	});
+
 	it('does not double-count an upload the refetch also returns', async () => {
 		const pending = deferred<AttachmentListResponse>();
 		listMock.mockReturnValue(pending.promise);

--- a/web/src/lib/components/items/ItemAttachmentStrip.svelte.test.ts
+++ b/web/src/lib/components/items/ItemAttachmentStrip.svelte.test.ts
@@ -817,6 +817,55 @@ describe('ItemAttachmentStrip', () => {
 		confirmSpy.mockRestore();
 	});
 
+	it('refuses a delete click that lands after the ITEM already switched', async () => {
+		// The most serious hole the final review found. Props update
+		// synchronously and the load effect repaints later, so a click can land
+		// on item A's still-mounted tile when `itemId` already reads B — and
+		// unlike the rollback, a DELETE cannot be taken back once sent. The
+		// fence therefore has to be at ENTRY, against the identity the tile was
+		// PAINTED under, not against the live props (which already say B).
+		listMock.mockResolvedValueOnce(response([att({ id: 'a1' })]));
+		props.canDelete = true;
+		mountStrip('item-a');
+		await settle();
+		expect(deleteButtons()).toHaveLength(1);
+
+		listMock.mockResolvedValueOnce(response([att({ id: 'b1' })]));
+		const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+		props.itemId = 'item-b';
+		// No flushSync between the switch and the click: that IS the window.
+		deleteButtons()[0].click();
+		await settle();
+
+		// Not even prompted — the tile the user aimed at no longer exists.
+		expect(confirmSpy).not.toHaveBeenCalled();
+		expect(deleteMock).not.toHaveBeenCalled();
+		expect(notifyDeletedMock).not.toHaveBeenCalled();
+		expect(tiles()[0].getAttribute('aria-label')).toContain('b1.png');
+		confirmSpy.mockRestore();
+	});
+
+	it('refuses a delete click that lands after the WORKSPACE already switched', async () => {
+		// Same window, one prop over. `wsSlug` is reactive and the strip
+		// survives a workspace change, so an item-only entry fence would send
+		// the DELETE to the NEW workspace for the OLD workspace's row.
+		listMock.mockResolvedValueOnce(response([att({ id: 'a1' })]));
+		props.canDelete = true;
+		mountStrip('item-a');
+		await settle();
+
+		listMock.mockResolvedValueOnce(response([att({ id: 'ws2-row' })]));
+		const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+		props.wsSlug = 'ws2';
+		deleteButtons()[0].click();
+		await settle();
+
+		expect(confirmSpy).not.toHaveBeenCalled();
+		expect(deleteMock).not.toHaveBeenCalled();
+		expect(tiles()[0].getAttribute('aria-label')).toContain('ws2-row.png');
+		confirmSpy.mockRestore();
+	});
+
 	it('rolls the tile back and toasts when the delete fails', async () => {
 		listMock.mockResolvedValue(response([att({ id: 'a1' }), att({ id: 'a2' })]));
 		deleteMock.mockRejectedValue(new Error('403'));
@@ -923,6 +972,46 @@ describe('ItemAttachmentStrip', () => {
 
 		expect(notifyDeletedMock).toHaveBeenCalledWith('a1');
 		expect(invalidateMock).toHaveBeenCalledWith('ws', 'a1');
+		confirmSpy.mockRestore();
+	});
+
+	it('still announces a 404 delete when the view switched under it', async () => {
+		// A 404 is proof the row is gone — a fact about the WORKSPACE, not about
+		// this view. Fencing the whole catch block on `viewChanged` meant a
+		// switch mid-delete swallowed that proof, leaving every other mounted
+		// surface (editor NodeViews, the other pane's strip, the HEAD cache)
+		// stale with nothing left to correct them (final review round 2). Only
+		// the LOCAL reconciliation — rollback, toast — is view-scoped.
+		listMock.mockResolvedValue(response([att({ id: 'a1' })]));
+		props.canDelete = true;
+		mountStrip('item-a');
+		await settle();
+
+		let failDelete!: (err: Error) => void;
+		deleteMock.mockReturnValue(
+			new Promise<void>((_, reject) => {
+				failDelete = reject;
+			})
+		);
+		const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+		deleteButtons()[0].click();
+		flushSync();
+
+		listMock.mockResolvedValue(response([att({ id: 'b1' })]));
+		props.itemId = 'item-b';
+		flushSync();
+		await settle();
+
+		failDelete(new FakeApiError('not_found'));
+		await settle();
+
+		expect(notifyDeletedMock).toHaveBeenCalledWith('a1');
+		expect(invalidateMock).toHaveBeenCalledWith('ws', 'a1');
+		// ...and still nothing local: no rollback into B's strip, no toast.
+		const names = tiles().map((el) => el.getAttribute('aria-label') ?? '');
+		expect(names.some((n) => n.includes('a1.png'))).toBe(false);
+		expect(names.some((n) => n.includes('b1.png'))).toBe(true);
+		expect(toastMock).not.toHaveBeenCalled();
 		confirmSpy.mockRestore();
 	});
 
@@ -1241,6 +1330,34 @@ describe('ItemAttachmentStrip', () => {
 		flushSync();
 
 		expect(tiles()).toHaveLength(1);
+	});
+
+	it('does not let a re-announced upload resurrect a deleted row', async () => {
+		// The load path filters every response through the tombstones; the
+		// upload path did not, so a delayed or duplicated upload event for a row
+		// the user has since deleted put it straight back — into `attachments`
+		// AND into `pendingUploads`, which then re-merges it onto every later
+		// response (final review round 2). A confirmed deletion outranks a
+		// repeat of an older upload event.
+		listMock.mockResolvedValue(response([att({ id: 'a1' })]));
+		mountStrip('item-a');
+		await settle();
+
+		broadcastUpload('item-a', uploaded('late'));
+		flushSync();
+		expect(tiles()).toHaveLength(2);
+
+		broadcastDeletion('late');
+		flushSync();
+		expect(tiles()).toHaveLength(1);
+
+		// The bus re-announces the same upload after the deletion.
+		broadcastUpload('item-a', uploaded('late'));
+		flushSync();
+
+		const names = tiles().map((el) => el.getAttribute('aria-label') ?? '');
+		expect(names).toHaveLength(1);
+		expect(names.some((n) => n.includes('late.png'))).toBe(false);
 	});
 
 	it('drops a tile when another surface broadcasts its deletion', async () => {

--- a/web/src/lib/components/settings/StorageTab.svelte
+++ b/web/src/lib/components/settings/StorageTab.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { onMount, untrack } from 'svelte';
+	import { untrack } from 'svelte';
 	import { page } from '$app/state';
 	import { api, PadApiError } from '$lib/api/client';
 	import { announceAttachmentDeleted } from '$lib/attachments/events';
@@ -159,13 +159,56 @@
 		attachments.find((a) => a.item_id === filterItemId)?.item_title ?? ''
 	);
 
-	// Re-seed when the deep-link changes under a MOUNTED tab (same route, new
-	// `?attachment_item=`). Without it, the second "View all" link a user
-	// follows from the same settings page silently keeps the first item's
-	// scope (Codex round 3).
+	// The workspace whose view is currently loaded. A plain `let` (not `$state`)
+	// so writing it from the effect below can't re-trigger it.
+	let loadedWsSlug: string | null = null;
+
+	/**
+	 * The tab's only load trigger. It owns BOTH transitions, in one effect and
+	 * one dependency set, because they can arrive in the same flush and the
+	 * order matters:
+	 *
+	 *  - **Workspace change.** `/{user}/{ws}/settings` is one SvelteKit route,
+	 *    so switching workspaces changes `wsSlug` under a MOUNTED tab. Without
+	 *    a reactive reload the previous workspace's rows and usage figure stay
+	 *    on screen, and a list request that was in flight across the switch is
+	 *    dropped by `loadList`'s workspace fence — which, with no successor
+	 *    request, would strand `listLoading` at true forever (final review P1).
+	 *    Since this fires on mount too, it REPLACES the old `onMount` load
+	 *    rather than sitting alongside it — an effect plus `onMount` would
+	 *    fetch the first page twice.
+	 *  - **Deep-link change.** A new `?attachment_item=` on the same route
+	 *    (a second "View all" followed from an already-open settings page)
+	 *    retargets the scope instead of silently keeping the first item's
+	 *    (Codex round 3).
+	 *
+	 * A workspace change subsumes the deep-link branch: it re-seeds the scope
+	 * from the incoming link itself, so a single load covers both and the
+	 * deep-link branch can't fire a second one behind it.
+	 */
 	$effect(() => {
+		const ws = wsSlug;
 		const incoming = initialItemId;
 		untrack(() => {
+			if (ws !== loadedWsSlug) {
+				loadedWsSlug = ws;
+				// Everything workspace-scoped is meaningless in the new
+				// workspace and must not survive the switch: the rows and
+				// usage figure obviously, but also the two workspace-scoped
+				// filter values — an item uuid and a collection uuid from the
+				// old workspace would silently filter the new list down to
+				// nothing. Category / attached / sort / page size are plain
+				// preferences with no workspace identity, so they carry over.
+				seededItemId = incoming;
+				filterItemId = incoming;
+				filterCollection = '';
+				offset = 0;
+				attachments = [];
+				total = 0;
+				usage = null;
+				void loadWorkspaceView();
+				return;
+			}
 			if (incoming === seededItemId) return;
 			seededItemId = incoming;
 			filterItemId = incoming;
@@ -196,10 +239,24 @@
 		retargetScope();
 	}
 
+	let usageGen = 0;
+
 	async function loadUsage() {
+		// Both halves of the list load's fence, for the same reasons. The
+		// workspace check: this tab stays mounted across a workspace change, so a
+		// figure fetched for the workspace the user just left must not paint over
+		// the one they switched to (nor raise its error toast). The generation
+		// check: on an A→B→A round trip the workspace matches again, so only the
+		// generation can tell the first A request from the current one
+		// (Codex round 1).
+		const gen = ++usageGen;
+		const reqWsSlug = wsSlug;
 		try {
-			usage = await api.attachments.storageUsage(wsSlug);
+			const next = await api.attachments.storageUsage(reqWsSlug);
+			if (gen !== usageGen || reqWsSlug !== wsSlug) return;
+			usage = next;
 		} catch (err) {
+			if (gen !== usageGen || reqWsSlug !== wsSlug) return;
 			const msg = err instanceof Error ? err.message : 'Failed to load storage usage';
 			toastStore.show(msg, 'error');
 		}
@@ -267,13 +324,28 @@
 		await Promise.all([loadList(), loadUsage()]);
 	}
 
-	onMount(async () => {
+	/**
+	 * Load (or reload) everything the tab shows for the current workspace, behind
+	 * the whole-tab `loading` gate. Used on mount and on every workspace change.
+	 */
+	let viewGen = 0;
+
+	async function loadWorkspaceView() {
+		const gen = ++viewGen;
+		const reqWsSlug = wsSlug;
+		loading = true;
 		try {
 			await Promise.all([loadList(), loadUsage()]);
 		} finally {
-			loading = false;
+			// Only the NEWEST load lowers the gate; a superseded one doing it
+			// would reveal the next workspace's half-loaded view. The workspace
+			// check alone isn't enough — on an A→B→A round trip the first A load
+			// finishes with `wsSlug` back at A while A's current load is still in
+			// flight (Codex round 1). It can't strand: whatever supersedes a load
+			// is itself a load, and the newest one's `finally` always runs.
+			if (gen === viewGen && reqWsSlug === wsSlug) loading = false;
 		}
-	});
+	}
 
 	// Filter / sort changes reset to the first page and refetch. Using an
 	// explicit handler instead of an $effect keeps the side-effect tied to

--- a/web/src/lib/components/settings/StorageTab.svelte
+++ b/web/src/lib/components/settings/StorageTab.svelte
@@ -11,7 +11,8 @@
 		WorkspaceStorageInfo
 	} from '$lib/types';
 	import { toastStore } from '$lib/stores/toast.svelte';
-	import { categoryIcon, formatBytes, isImage } from '$lib/attachments/display';
+	import { iconForAttachment, formatBytes, isImage } from '$lib/attachments/display';
+	import AttachmentIcon from '$lib/attachments/icons/AttachmentIcon.svelte';
 
 	// ── Props ────────────────────────────────────────────────────────────────
 	interface Props {
@@ -45,8 +46,10 @@
 	let sortValue = $state<SortValue>('created_at_desc');
 
 	// ── Helpers ──────────────────────────────────────────────────────────────
-	// formatBytes / categoryIcon / isImage live in $lib/attachments/display
-	// (extracted in TASK-2383 so the item attachment strip shares them).
+	// formatBytes / iconForAttachment / isImage live in $lib/attachments/display
+	// (extracted in TASK-2383 so the item attachment strip shares them;
+	// categoryIcon became iconForAttachment in TASK-2417, which also moved the
+	// glyph to the shared SVG set in $lib/attachments/icons).
 
 	function formatDate(iso: string): string {
 		try {
@@ -344,7 +347,9 @@
 									loading="lazy"
 								/>
 							{:else}
-								<span aria-hidden="true">{categoryIcon(att.mime_type)}</span>
+								<span class="att-file-icon">
+									<AttachmentIcon id={iconForAttachment(att.mime_type, att.filename)} />
+								</span>
 							{/if}
 						</a>
 
@@ -589,6 +594,15 @@
 		font-size: 1.4em;
 		overflow: hidden;
 		text-decoration: none;
+	}
+
+	/* File-type icon (TASK-2417). Monochrome and currentColor-driven, so it
+	   themes with light/dark and stays visible under forced-colors. */
+	.att-file-icon {
+		display: flex;
+		color: var(--text-secondary);
+		font-size: 24px;
+		line-height: 1;
 	}
 
 	.att-thumb img {

--- a/web/src/lib/components/settings/StorageTab.svelte
+++ b/web/src/lib/components/settings/StorageTab.svelte
@@ -3,6 +3,7 @@
 	import { page } from '$app/state';
 	import { api, PadApiError } from '$lib/api/client';
 	import { announceAttachmentDeleted } from '$lib/attachments/events';
+	import { invalidateAttachmentMetadata } from '$lib/components/editor/attachment-metadata';
 	import type {
 		AttachmentListItem,
 		AttachmentListFilters,
@@ -143,16 +144,10 @@
 	// is narrowing the list (including a foreign or stale `attachment_item`
 	// uuid, which is indistinguishable from an item with no attachments);
 	// "nothing uploaded yet" is only true unfiltered (Codex round 2).
-	let anyFilterActive = $derived(
-		hasActiveStorageFilters({
-			limit,
-			offset,
-			category: filterCategory,
-			item: filterItem,
-			itemId: filterItemId,
-			collection: filterCollection
-		})
-	);
+	// One projection, not two: re-listing the fields here let the two drift
+	// (final-review P3). `selections()` reads the same $state, so the derived
+	// still tracks every filter.
+	let anyFilterActive = $derived(hasActiveStorageFilters(selections()));
 
 	/**
 	 * Label for the item-scope chip. The rows themselves carry the item title,
@@ -224,24 +219,47 @@
 	// conflation DR-10 removed from the item strip (Codex round 6).
 	let listError = $state(false);
 
-	async function loadList() {
+	/**
+	 * @param opts.retry - This load is an explicit Retry after a failure, so it
+	 * carries the same cache-invalidation duty the item strip's Retry does
+	 * (PLAN-2392 DR-10, final-review P2). `fetchAttachmentMetadata` latches
+	 * `null` on a failed HEAD for the page lifetime, so the outage that broke
+	 * this list also poisoned every chip and inline image that probed during
+	 * it. Dropping a healthy entry is harmless — the cache holds immutable data
+	 * and nothing refetches eagerly.
+	 */
+	async function loadList(opts: { retry?: boolean } = {}) {
 		const gen = ++listGen;
 		listLoading = true;
 		listError = false;
+		// `wsSlug` is reactive and this tab stays mounted across a workspace
+		// change, so the request's workspace is captured and re-checked: the
+		// generation alone can't tell a superseded workspace from the current
+		// one, and both the rows and the metadata-cache keys are workspace
+		// scoped (Codex fresh-angle round 2).
+		const reqWsSlug = wsSlug;
+		if (opts.retry) {
+			for (const a of attachments) invalidateAttachmentMetadata(reqWsSlug, a.id);
+		}
 		try {
-			const resp: AttachmentListResponse = await api.attachments.list(wsSlug, buildFilters());
-			if (gen !== listGen) return;
+			const resp: AttachmentListResponse = await api.attachments.list(reqWsSlug, buildFilters());
+			if (gen !== listGen || reqWsSlug !== wsSlug) return;
 			attachments = resp.attachments ?? [];
+			if (opts.retry) {
+				// The rows the refetch returned get the same treatment — at
+				// failure time the list held the stale page, or nothing at all.
+				for (const a of attachments) invalidateAttachmentMetadata(reqWsSlug, a.id);
+			}
 			total = resp.total ?? 0;
 			limit = resp.limit ?? limit;
 			offset = resp.offset ?? offset;
 		} catch (err) {
-			if (gen !== listGen) return;
+			if (gen !== listGen || reqWsSlug !== wsSlug) return;
 			listError = true;
 			const msg = err instanceof Error ? err.message : 'Failed to load attachments';
 			toastStore.show(msg, 'error');
 		} finally {
-			if (gen === listGen) listLoading = false;
+			if (gen === listGen && reqWsSlug === wsSlug) listLoading = false;
 		}
 	}
 
@@ -473,7 +491,9 @@
 		{:else if listError}
 			<p class="empty-text">
 				Couldn't load attachments.
-				<button type="button" class="scope-clear" onclick={() => loadList()}>Retry</button>
+				<button type="button" class="scope-clear" onclick={() => loadList({ retry: true })}>
+					Retry
+				</button>
 			</p>
 		{:else if total === 0}
 			<p class="empty-text">

--- a/web/src/lib/components/settings/StorageTab.svelte
+++ b/web/src/lib/components/settings/StorageTab.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
+	import { onMount, untrack } from 'svelte';
 	import { page } from '$app/state';
 	import { api, PadApiError } from '$lib/api/client';
 	import { announceAttachmentDeleted } from '$lib/attachments/events';
@@ -12,14 +12,36 @@
 	} from '$lib/types';
 	import { toastStore } from '$lib/stores/toast.svelte';
 	import { iconForAttachment, formatBytes, isImage } from '$lib/attachments/display';
+	import {
+		buildStorageFilters,
+		hasActiveStorageFilters,
+		type StorageFilterSelections
+	} from '$lib/attachments/storageFilters';
 	import AttachmentIcon from '$lib/attachments/icons/AttachmentIcon.svelte';
 
 	// ── Props ────────────────────────────────────────────────────────────────
 	interface Props {
 		wsSlug: string;
 		collections: Collection[];
+		/**
+		 * Parent-item UUID to scope the list to — the item attachment strip's
+		 * "View all (N)" continuation passes it via `?attachment_item=`
+		 * (PLAN-2392 DR-18). Seeds the filter, and re-seeds whenever the
+		 * deep-link CHANGES, so following a second item's link while this tab
+		 * is already mounted retargets instead of keeping the old scope
+		 * (Codex round 3). Clearing the scope in the UI rewrites the URL, which
+		 * is why this can go back to '' without fighting the user.
+		 */
+		initialItemId?: string;
+		/**
+		 * Called when the user clears the item scope, so the OWNER of the URL
+		 * can drop `?attachment_item=`. It lives up there because only a real
+		 * navigation updates `page.url` — which is what `initialItemId` is
+		 * derived from (Codex round 4).
+		 */
+		onClearScope?: () => void;
 	}
-	let { wsSlug, collections }: Props = $props();
+	let { wsSlug, collections, initialItemId = '', onClearScope }: Props = $props();
 
 	// ── State ────────────────────────────────────────────────────────────────
 	let loading = $state(true);
@@ -42,6 +64,20 @@
 
 	let filterCategory = $state<CategoryValue>('');
 	let filterItem = $state<ItemValue>('');
+	/**
+	 * Scope to a single parent item. Seeded from `initialItemId` (the strip's
+	 * "View all" handoff) and cleared by the user. Mutually exclusive with the
+	 * attached/unattached selector — combining `item_id` with `item=unattached`
+	 * yields an empty set server-side — so while it is set, that selector is
+	 * disabled and not sent.
+	 */
+	// untrack: the initializer takes the value at mount; ongoing changes are
+	// handled by the re-seed effect below (reading a prop directly in an
+	// initializer otherwise warns about capturing only the initial value).
+	let filterItemId = $state<string>(untrack(() => initialItemId));
+	// Last deep-link value applied, so the re-seed effect fires only on a
+	// genuine change and never fights a scope the user cleared by hand.
+	let seededItemId = untrack(() => initialItemId);
 	let filterCollection = $state<string>('');
 	let sortValue = $state<SortValue>('created_at_desc');
 
@@ -87,16 +123,82 @@
 
 	// ── Data loading ─────────────────────────────────────────────────────────
 
-	function buildFilters(): AttachmentListFilters {
-		const f: AttachmentListFilters = {
+	function selections(): StorageFilterSelections {
+		return {
 			limit,
 			offset,
-			sort: sortValue
+			sort: sortValue,
+			category: filterCategory,
+			item: filterItem,
+			itemId: filterItemId,
+			collection: filterCollection
 		};
-		if (filterCategory) f.category = filterCategory;
-		if (filterItem) f.item = filterItem;
-		if (filterCollection) f.collection = filterCollection;
-		return f;
+	}
+
+	function buildFilters(): AttachmentListFilters {
+		return buildStorageFilters(selections());
+	}
+
+	// Drives the empty-state wording: "nothing matches" is honest when a filter
+	// is narrowing the list (including a foreign or stale `attachment_item`
+	// uuid, which is indistinguishable from an item with no attachments);
+	// "nothing uploaded yet" is only true unfiltered (Codex round 2).
+	let anyFilterActive = $derived(
+		hasActiveStorageFilters({
+			limit,
+			offset,
+			category: filterCategory,
+			item: filterItem,
+			itemId: filterItemId,
+			collection: filterCollection
+		})
+	);
+
+	/**
+	 * Label for the item-scope chip. The rows themselves carry the item title,
+	 * so the chip names the item once the first page lands and falls back to a
+	 * generic phrasing before that (or when the item has no live attachments
+	 * left, which is exactly when the list is empty anyway).
+	 */
+	let scopedItemTitle = $derived(
+		attachments.find((a) => a.item_id === filterItemId)?.item_title ?? ''
+	);
+
+	// Re-seed when the deep-link changes under a MOUNTED tab (same route, new
+	// `?attachment_item=`). Without it, the second "View all" link a user
+	// follows from the same settings page silently keeps the first item's
+	// scope (Codex round 3).
+	$effect(() => {
+		const incoming = initialItemId;
+		untrack(() => {
+			if (incoming === seededItemId) return;
+			seededItemId = incoming;
+			filterItemId = incoming;
+			retargetScope();
+		});
+	});
+
+	/**
+	 * Refetch after the item scope changed. Clears the rendered rows first:
+	 * the `listGen` fence stops a stale RESPONSE from landing, but on its own
+	 * it would leave the previous item's rows on screen while the new request
+	 * runs — indefinitely if that request fails (Codex round 5).
+	 */
+	function retargetScope() {
+		attachments = [];
+		total = 0;
+		onFiltersChanged();
+	}
+
+	function clearItemScope() {
+		filterItemId = '';
+		// Pre-claim the incoming '' so the re-seed effect treats the resulting
+		// URL change as already applied and doesn't fire a second fetch.
+		seededItemId = '';
+		// Drop the deep-link too, or a tab switch / reload / restored route
+		// re-applies a scope the user just dismissed (Codex rounds 2-4).
+		onClearScope?.();
+		retargetScope();
 	}
 
 	async function loadUsage() {
@@ -108,16 +210,38 @@
 		}
 	}
 
+	// Every list load shares one generation, so a slower earlier request can
+	// never overwrite a newer one's rows/total/offset — the deep-link re-seed
+	// can now start a load while onMount's or a filter change's is still in
+	// flight (Codex round 4).
+	let listGen = 0;
+	// A list request is in flight. Only meaningful once the tab's initial
+	// `loading` gate is down — it keeps a scope retarget (which clears the
+	// rows) from flashing "no attachments match" before the new page lands.
+	let listLoading = $state(false);
+	// The last list request failed. Without it a failure renders as "no
+	// attachments match", which is the same misleading empty-vs-broken
+	// conflation DR-10 removed from the item strip (Codex round 6).
+	let listError = $state(false);
+
 	async function loadList() {
+		const gen = ++listGen;
+		listLoading = true;
+		listError = false;
 		try {
 			const resp: AttachmentListResponse = await api.attachments.list(wsSlug, buildFilters());
+			if (gen !== listGen) return;
 			attachments = resp.attachments ?? [];
 			total = resp.total ?? 0;
 			limit = resp.limit ?? limit;
 			offset = resp.offset ?? offset;
 		} catch (err) {
+			if (gen !== listGen) return;
+			listError = true;
 			const msg = err instanceof Error ? err.message : 'Failed to load attachments';
 			toastStore.show(msg, 'error');
+		} finally {
+			if (gen === listGen) listLoading = false;
 		}
 	}
 
@@ -276,6 +400,10 @@
 					class="role-select"
 					bind:value={filterItem}
 					onchange={onFiltersChanged}
+					disabled={!!filterItemId}
+					title={filterItemId
+						? 'Scoped to one item — clear the scope to filter by attached/unattached'
+						: undefined}
 				>
 					<option value="">All</option>
 					<option value="attached">Attached</option>
@@ -324,10 +452,36 @@
 			</label>
 		</div>
 
+		<!-- Item scope (PLAN-2392 DR-18): set by the item strip's "View all"
+		     link. Always visible while active, so the list is never silently
+		     filtered. -->
+		{#if filterItemId}
+			<div class="item-scope">
+				<span>
+					Showing attachments for
+					<strong>{scopedItemTitle || 'one item'}</strong>
+				</span>
+				<button type="button" class="scope-clear" onclick={clearItemScope}>
+					Show all attachments
+				</button>
+			</div>
+		{/if}
+
 		<!-- Attachment list -->
-		{#if total === 0}
+		{#if listLoading && attachments.length === 0}
+			<p class="empty-text">Loading attachments…</p>
+		{:else if listError}
 			<p class="empty-text">
-				No attachments yet — paste or drag a file into any item to upload one.
+				Couldn't load attachments.
+				<button type="button" class="scope-clear" onclick={() => loadList()}>Retry</button>
+			</p>
+		{:else if total === 0}
+			<p class="empty-text">
+				{#if anyFilterActive}
+					No attachments match the current filters.
+				{:else}
+					No attachments yet — paste or drag a file into any item to upload one.
+				{/if}
 			</p>
 		{:else}
 			<div class="att-list">
@@ -566,6 +720,30 @@
 		gap: var(--space-2);
 		font-size: 0.8em;
 		color: var(--text-secondary);
+	}
+
+	.item-scope {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		gap: var(--space-2);
+		margin-bottom: var(--space-3);
+		font-size: 0.85em;
+		color: var(--text-secondary);
+	}
+
+	.scope-clear {
+		padding: 2px var(--space-2);
+		border: 1px solid var(--border);
+		border-radius: var(--radius-sm, 4px);
+		background: transparent;
+		color: var(--text-secondary);
+		font: inherit;
+		cursor: pointer;
+	}
+	.scope-clear:hover {
+		color: var(--text-primary);
+		border-color: var(--accent, var(--border));
 	}
 
 	.att-list {

--- a/web/src/lib/components/settings/StorageTab.svelte
+++ b/web/src/lib/components/settings/StorageTab.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { untrack } from 'svelte';
+	import { onDestroy, untrack } from 'svelte';
 	import { page } from '$app/state';
 	import { api, PadApiError } from '$lib/api/client';
 	import { announceAttachmentDeleted } from '$lib/attachments/events';
@@ -19,6 +19,7 @@
 		type StorageFilterSelections
 	} from '$lib/attachments/storageFilters';
 	import AttachmentIcon from '$lib/attachments/icons/AttachmentIcon.svelte';
+	import { viewIdentity, createFence, createPaintFence } from '$lib/attachments/viewFence';
 
 	// ── Props ────────────────────────────────────────────────────────────────
 	interface Props {
@@ -159,9 +160,41 @@
 		attachments.find((a) => a.item_id === filterItemId)?.item_title ?? ''
 	);
 
-	// The workspace whose view is currently loaded. A plain `let` (not `$state`)
-	// so writing it from the effect below can't re-trigger it.
-	let loadedWsSlug: string | null = null;
+	// ── View identity + fences (PLAN-2392, shared with the item attachment
+	// strip) ─────────────────────────────────────────────────────────────────
+	//
+	// This tab lives at `/{user}/{ws}/settings` — ONE SvelteKit route — so a
+	// workspace switch changes `wsSlug` under a MOUNTED component and every
+	// request, continuation and rendered control has to say which workspace it
+	// belongs to. `$lib/attachments/viewFence` owns that invariant; see its
+	// header. The identity is stated ONCE here, so no individual fence can
+	// restate a shorter one, and each request reads its workspace back off its
+	// own token rather than off the live prop.
+	const view = viewIdentity(() => ({ ws: wsSlug }));
+	/**
+	 * Fence 2 — the view generation. Mutations fence on this rather than on the
+	 * paint alone: a paint token has no generation, so an A→B→A round trip (or
+	 * an unmount) leaves an identity that still matches and a stale continuation
+	 * would sail through (Codex round 3).
+	 */
+	const viewFence = createFence(view);
+	/** Fence 3 — the workspace whose view is currently painted (and loaded). */
+	const paint = createPaintFence(view);
+
+	// Destroy invalidates EVERY fence and un-paints. The strip gets its request
+	// fence invalidated for free (its load lives in an $effect, whose teardown
+	// runs on destroy); this tab's loaders are plain async functions, so nothing
+	// else retires their tokens — and a list or usage request that fails after
+	// unmount would otherwise raise an error toast for a tab that is gone
+	// (Codex round 5). "Nothing is painted any more" is exactly what the paint
+	// fence is for, so no separate destroyed flag is needed.
+	onDestroy(() => {
+		viewFence.invalidate();
+		listFence.invalidate();
+		usageFence.invalidate();
+		workspaceViewFence.invalidate();
+		paint.record(null);
+	});
 
 	/**
 	 * The tab's only load trigger. It owns BOTH transitions, in one effect and
@@ -187,11 +220,20 @@
 	 * deep-link branch can't fire a second one behind it.
 	 */
 	$effect(() => {
-		const ws = wsSlug;
+		// Captured outside `untrack` so `wsSlug` (via the identity) and
+		// `initialItemId` are this effect's dependencies.
+		const here = view.capture();
 		const incoming = initialItemId;
+		if (!here.key) return;
 		untrack(() => {
-			if (ws !== loadedWsSlug) {
-				loadedWsSlug = ws;
+			if (!paint.isCurrent()) {
+				paint.record(here);
+				// The view itself changed, so in-flight mutations captured
+				// against the old one must stop reconciling. Bumped here, not
+				// derived from the paint: an A→B→A round trip lands back on an
+				// identity that MATCHES, and only a generation can tell that
+				// apart from never having left (Codex round 3).
+				viewFence.invalidate();
 				// Everything workspace-scoped is meaningless in the new
 				// workspace and must not survive the switch: the rows and
 				// usage figure obviously, but also the two workspace-scoped
@@ -218,7 +260,7 @@
 
 	/**
 	 * Refetch after the item scope changed. Clears the rendered rows first:
-	 * the `listGen` fence stops a stale RESPONSE from landing, but on its own
+	 * the list fence stops a stale RESPONSE from landing, but on its own
 	 * it would leave the previous item's rows on screen while the new request
 	 * runs — indefinitely if that request fails (Codex round 5).
 	 */
@@ -239,34 +281,35 @@
 		retargetScope();
 	}
 
-	let usageGen = 0;
+	/**
+	 * Fence 1, usage channel. Both halves matter, for the same reasons as the
+	 * list's. The workspace check: this tab stays mounted across a workspace
+	 * change, so a figure fetched for the workspace the user just left must not
+	 * paint over the one they switched to (nor raise its error toast). The
+	 * generation check: on an A→B→A round trip the workspace matches again, so
+	 * only the generation can tell the first A request from the current one
+	 * (Codex round 1).
+	 */
+	const usageFence = createFence(view);
 
 	async function loadUsage() {
-		// Both halves of the list load's fence, for the same reasons. The
-		// workspace check: this tab stays mounted across a workspace change, so a
-		// figure fetched for the workspace the user just left must not paint over
-		// the one they switched to (nor raise its error toast). The generation
-		// check: on an A→B→A round trip the workspace matches again, so only the
-		// generation can tell the first A request from the current one
-		// (Codex round 1).
-		const gen = ++usageGen;
-		const reqWsSlug = wsSlug;
+		const req = usageFence.restart();
 		try {
-			const next = await api.attachments.storageUsage(reqWsSlug);
-			if (gen !== usageGen || reqWsSlug !== wsSlug) return;
+			const next = await api.attachments.storageUsage(req.value.ws);
+			if (req.stale()) return;
 			usage = next;
 		} catch (err) {
-			if (gen !== usageGen || reqWsSlug !== wsSlug) return;
+			if (req.stale()) return;
 			const msg = err instanceof Error ? err.message : 'Failed to load storage usage';
 			toastStore.show(msg, 'error');
 		}
 	}
 
-	// Every list load shares one generation, so a slower earlier request can
-	// never overwrite a newer one's rows/total/offset — the deep-link re-seed
-	// can now start a load while onMount's or a filter change's is still in
-	// flight (Codex round 4).
-	let listGen = 0;
+	// Every list load shares one fence, so a slower earlier request can never
+	// overwrite a newer one's rows/total/offset — the deep-link re-seed can
+	// start a load while onMount's or a filter change's is still in flight
+	// (Codex round 4).
+	const listFence = createFence(view);
 	// A list request is in flight. Only meaningful once the tab's initial
 	// `loading` gate is down — it keeps a scope retarget (which clears the
 	// rows) from flashing "no attachments match" before the new page lands.
@@ -286,21 +329,21 @@
 	 * and nothing refetches eagerly.
 	 */
 	async function loadList(opts: { retry?: boolean } = {}) {
-		const gen = ++listGen;
-		listLoading = true;
-		listError = false;
 		// `wsSlug` is reactive and this tab stays mounted across a workspace
 		// change, so the request's workspace is captured and re-checked: the
 		// generation alone can't tell a superseded workspace from the current
 		// one, and both the rows and the metadata-cache keys are workspace
 		// scoped (Codex fresh-angle round 2).
-		const reqWsSlug = wsSlug;
+		const req = listFence.restart();
+		const reqWsSlug = req.value.ws;
+		listLoading = true;
+		listError = false;
 		if (opts.retry) {
 			for (const a of attachments) invalidateAttachmentMetadata(reqWsSlug, a.id);
 		}
 		try {
 			const resp: AttachmentListResponse = await api.attachments.list(reqWsSlug, buildFilters());
-			if (gen !== listGen || reqWsSlug !== wsSlug) return;
+			if (req.stale()) return;
 			attachments = resp.attachments ?? [];
 			if (opts.retry) {
 				// The rows the refetch returned get the same treatment — at
@@ -311,12 +354,12 @@
 			limit = resp.limit ?? limit;
 			offset = resp.offset ?? offset;
 		} catch (err) {
-			if (gen !== listGen || reqWsSlug !== wsSlug) return;
+			if (req.stale()) return;
 			listError = true;
 			const msg = err instanceof Error ? err.message : 'Failed to load attachments';
 			toastStore.show(msg, 'error');
 		} finally {
-			if (gen === listGen && reqWsSlug === wsSlug) listLoading = false;
+			if (!req.stale()) listLoading = false;
 		}
 	}
 
@@ -328,11 +371,10 @@
 	 * Load (or reload) everything the tab shows for the current workspace, behind
 	 * the whole-tab `loading` gate. Used on mount and on every workspace change.
 	 */
-	let viewGen = 0;
+	const workspaceViewFence = createFence(view);
 
 	async function loadWorkspaceView() {
-		const gen = ++viewGen;
-		const reqWsSlug = wsSlug;
+		const req = workspaceViewFence.restart();
 		loading = true;
 		try {
 			await Promise.all([loadList(), loadUsage()]);
@@ -343,7 +385,7 @@
 			// finishes with `wsSlug` back at A while A's current load is still in
 			// flight (Codex round 1). It can't strand: whatever supersedes a load
 			// is itself a load, and the newest one's `finally` always runs.
-			if (gen === viewGen && reqWsSlug === wsSlug) loading = false;
+			if (!req.stale()) loading = false;
 		}
 	}
 
@@ -359,18 +401,53 @@
 	// ── Actions ──────────────────────────────────────────────────────────────
 
 	async function handleDelete(att: AttachmentListItem) {
+		// ENTRY fence (fence 3). The clicked row was painted for the workspace
+		// this tab has LOADED, which during the prop-update → effect-flush window
+		// is not necessarily the one `wsSlug` already names. Taking the workspace
+		// off the paint means the DELETE targets the row the user actually
+		// clicked; refusing when the paint is stale is the only lever that works
+		// at all, because every check below runs after the await and no fence can
+		// unsend a request.
+		const painted = paint.painted();
+		if (!painted || !paint.isCurrent()) return;
+		const reqWsSlug = painted.value.ws;
+		// Fence 2 for everything after the await. Deliberately NOT the paint
+		// token: that carries an identity but no generation, so an A→B→A round
+		// trip (or an unmount) would leave it matching again and let a stale
+		// continuation toast and refetch (Codex round 3).
+		const req = viewFence.begin();
+
 		const ok = confirm(
 			`Delete ${att.filename}? The blob is reclaimed by garbage collection after a grace period.`
 		);
 		if (!ok) return;
 		try {
-			await api.attachments.delete(wsSlug, att.id);
+			await api.attachments.delete(reqWsSlug, att.id);
 			// Same broadcast the item attachment strip does (PLAN-2382 /
 			// TASK-2384): an editor open in another tab-pane still holds live
 			// <img>/chip NodeViews for this attachment, and an already-loaded
 			// image never re-requests, so without this they keep presenting a
 			// row the server no longer has (Codex round 14).
-			announceAttachmentDeleted(wsSlug, att.id);
+			//
+			// Deliberately AHEAD of the fence, like the strip's: this is a GLOBAL
+			// side effect keyed by (workspace, id), not a write into this view's
+			// local state, and a workspace switch says nothing about whether the
+			// row is gone. Skipping it would leave every other mounted surface
+			// stale on proof we already have.
+			announceAttachmentDeleted(reqWsSlug, att.id);
+			// The toast DOES belong to a view: after an A→B switch mid-request it
+			// would announce A's deletion over B (final review round 4).
+			if (req.stale()) {
+				// The refetch does NOT. This tab holds no tombstones and does not
+				// subscribe to the deletion bus, so a list request that raced the
+				// DELETE can have repainted the row — and on an A→B→A round trip
+				// the fence above suppresses the only thing that heals it. A
+				// refetch is a request for the truth about what is ON SCREEN, not
+				// a write into a view the user left, so it is gated on the paint
+				// rather than on the generation (Codex round 4).
+				if (paint.isCurrent() && !painted.changed()) await reload();
+				return;
+			}
 			toastStore.show(`Deleted ${att.filename}`, 'success');
 			await reload();
 		} catch (err) {
@@ -380,11 +457,19 @@
 			// an error for something that is in fact already done
 			// (Codex round 20; matches the attachment strip's handling).
 			if (err instanceof PadApiError && err.code === 'not_found') {
-				announceAttachmentDeleted(wsSlug, att.id);
+				announceAttachmentDeleted(reqWsSlug, att.id);
+				if (req.stale()) {
+					// Same reasoning as the success arm: a 404 is just as
+					// authoritative that the row is gone, so the on-screen list
+					// still deserves the correction.
+					if (paint.isCurrent() && !painted.changed()) await reload();
+					return;
+				}
 				toastStore.show(`${att.filename} was already deleted`, 'info');
 				await reload();
 				return;
 			}
+			if (req.stale()) return;
 			const msg = err instanceof Error ? err.message : 'Failed to delete attachment';
 			toastStore.show(msg, 'error');
 		}

--- a/web/src/lib/components/settings/StorageTab.svelte.test.ts
+++ b/web/src/lib/components/settings/StorageTab.svelte.test.ts
@@ -1,0 +1,276 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+import type {
+	AttachmentListItem,
+	AttachmentListResponse,
+	WorkspaceStorageInfo,
+} from '$lib/types';
+
+// TASK-2418. The Storage tab lives at `/{user}/{ws}/settings` — ONE SvelteKit
+// route — so switching workspaces changes `wsSlug` under a MOUNTED component.
+// These tests drive that switch and pin the reactive reload: fresh rows, fresh
+// usage, no stale scope, and a loading state that can't strand when the switch
+// happens mid-flight.
+
+const listMock =
+	vi.fn<(ws: string, filters: Record<string, unknown>) => Promise<AttachmentListResponse>>();
+const usageMock = vi.fn<(ws: string) => Promise<WorkspaceStorageInfo>>();
+const toastMock = vi.fn<(message: string, kind?: string) => void>();
+
+class FakeApiError extends Error {
+	code: string;
+	constructor(code: string) {
+		super(code);
+		this.code = code;
+	}
+}
+
+vi.mock('$lib/api/client', () => ({
+	PadApiError: FakeApiError,
+	api: {
+		attachments: {
+			list: (ws: string, filters: Record<string, unknown>) => listMock(ws, filters),
+			storageUsage: (ws: string) => usageMock(ws),
+			downloadUrl: (ws: string, id: string, variant?: string) =>
+				`/api/v1/workspaces/${ws}/attachments/${id}${variant ? `?variant=${variant}` : ''}`,
+			delete: vi.fn(),
+		},
+	},
+}));
+
+vi.mock('$app/state', () => ({
+	page: { params: { username: 'dave', workspace: 'ws-a' }, url: new URL('http://x/') },
+}));
+
+vi.mock('$lib/attachments/events', () => ({
+	announceAttachmentDeleted: vi.fn(),
+}));
+
+vi.mock('$lib/components/editor/attachment-metadata', () => ({
+	invalidateAttachmentMetadata: vi.fn(),
+}));
+
+vi.mock('$lib/stores/toast.svelte', () => ({
+	toastStore: { show: (message: string, kind?: string) => toastMock(message, kind) },
+}));
+
+const { default: StorageTab } = await import('./StorageTab.svelte');
+
+function att(overrides: Partial<AttachmentListItem> & { id: string }): AttachmentListItem {
+	return {
+		workspace_id: 'ws-1',
+		uploaded_by: 'u-1',
+		storage_key: `key/${overrides.id}`,
+		content_hash: `hash-${overrides.id}`,
+		mime_type: 'application/pdf',
+		size_bytes: 2048,
+		filename: `${overrides.id}.pdf`,
+		created_at: '2026-08-01T00:00:00Z',
+		...overrides,
+	};
+}
+
+function response(attachments: AttachmentListItem[]): AttachmentListResponse {
+	return { attachments, total: attachments.length, limit: 50, offset: 0 };
+}
+
+function usage(used: number): WorkspaceStorageInfo {
+	return { used_bytes: used, limit_bytes: 1000, override_active: false } as WorkspaceStorageInfo;
+}
+
+/** A promise plus its resolver, so a test can control when a fetch lands. */
+function deferred<T>() {
+	let resolve!: (value: T) => void;
+	let reject!: (err: unknown) => void;
+	const promise = new Promise<T>((res, rej) => {
+		resolve = res;
+		reject = rej;
+	});
+	return { promise, resolve, reject };
+}
+
+// Reactive props object so a test can flip `wsSlug` the way the settings route
+// does when the user switches workspaces while this tab is open.
+const props = $state<{ wsSlug: string; collections: []; initialItemId: string }>({
+	wsSlug: 'ws-a',
+	collections: [],
+	initialItemId: '',
+});
+
+describe('StorageTab workspace switching', () => {
+	let target: HTMLElement;
+	let instance: ReturnType<typeof mount> | undefined;
+
+	beforeEach(() => {
+		listMock.mockReset();
+		listMock.mockResolvedValue(response([]));
+		usageMock.mockReset();
+		usageMock.mockResolvedValue(usage(1));
+		toastMock.mockReset();
+		props.wsSlug = 'ws-a';
+		props.initialItemId = '';
+		target = document.body.appendChild(document.createElement('div'));
+	});
+
+	afterEach(() => {
+		if (instance) unmount(instance);
+		instance = undefined;
+		target.remove();
+	});
+
+	function mountTab() {
+		instance = mount(StorageTab, { target, props });
+		flushSync();
+	}
+
+	async function settle() {
+		for (let i = 0; i < 6; i++) await Promise.resolve();
+		flushSync();
+	}
+
+	function rows(): HTMLElement[] {
+		return Array.from(target.querySelectorAll<HTMLElement>('.att-row'));
+	}
+
+	function text(): string {
+		return target.textContent ?? '';
+	}
+
+	it('loads exactly once on mount', async () => {
+		mountTab();
+		await settle();
+
+		expect(listMock).toHaveBeenCalledTimes(1);
+		expect(listMock).toHaveBeenCalledWith('ws-a', expect.anything());
+		expect(usageMock).toHaveBeenCalledTimes(1);
+		expect(usageMock).toHaveBeenCalledWith('ws-a');
+	});
+
+	it('reloads the list and the usage figure when the workspace changes', async () => {
+		listMock.mockResolvedValueOnce(response([att({ id: 'a1', filename: 'from-a.pdf' })]));
+		usageMock.mockResolvedValueOnce(usage(111));
+		mountTab();
+		await settle();
+		expect(rows()).toHaveLength(1);
+		expect(text()).toContain('from-a.pdf');
+		expect(text()).toContain('111 B');
+
+		listMock.mockResolvedValueOnce(response([att({ id: 'b1', filename: 'from-b.pdf' })]));
+		usageMock.mockResolvedValueOnce(usage(222));
+		props.wsSlug = 'ws-b';
+		flushSync();
+		await settle();
+
+		expect(listMock).toHaveBeenCalledTimes(2);
+		expect(listMock).toHaveBeenLastCalledWith('ws-b', expect.anything());
+		expect(usageMock).toHaveBeenLastCalledWith('ws-b');
+		expect(rows()).toHaveLength(1);
+		expect(text()).toContain('from-b.pdf');
+		expect(text()).not.toContain('from-a.pdf');
+		expect(text()).toContain('222 B');
+	});
+
+	it('drops the old workspace item scope when the workspace changes', async () => {
+		props.initialItemId = 'item-in-a';
+		mountTab();
+		await settle();
+		expect(listMock).toHaveBeenLastCalledWith(
+			'ws-a',
+			expect.objectContaining({ item_id: 'item-in-a' })
+		);
+		expect(target.querySelector('.item-scope')).not.toBeNull();
+
+		// A workspace switch without a deep link: the scope named an item in the
+		// workspace the user just left, so it must not narrow the new list.
+		props.wsSlug = 'ws-b';
+		props.initialItemId = '';
+		flushSync();
+		await settle();
+
+		expect(listMock).toHaveBeenCalledTimes(2);
+		expect(listMock).toHaveBeenLastCalledWith('ws-b', expect.not.objectContaining({ item_id: 'item-in-a' }));
+		expect(target.querySelector('.item-scope')).toBeNull();
+	});
+
+	it('does not strand the loading state when the switch happens mid-flight', async () => {
+		const slowA = deferred<AttachmentListResponse>();
+		listMock.mockReturnValueOnce(slowA.promise);
+		mountTab();
+		await settle();
+		expect(text()).toContain('Loading');
+
+		listMock.mockResolvedValueOnce(response([att({ id: 'b1', filename: 'from-b.pdf' })]));
+		props.wsSlug = 'ws-b';
+		flushSync();
+		await settle();
+
+		// B landed; the tab is showing B even though A is still outstanding.
+		expect(text()).toContain('from-b.pdf');
+		expect(text()).not.toContain('Loading attachments');
+
+		// A's superseded response resolves late and must change nothing — in
+		// particular it must not re-raise the loading gate or paint its rows.
+		slowA.resolve(response([att({ id: 'a1', filename: 'from-a.pdf' })]));
+		await settle();
+		expect(text()).toContain('from-b.pdf');
+		expect(text()).not.toContain('from-a.pdf');
+		expect(text()).not.toContain('Loading attachments');
+	});
+
+	it('ignores the first load of an A→B→A round trip, where the workspace matches again', async () => {
+		// The workspace fence can't see this one: by the time A's FIRST response
+		// lands, `wsSlug` is back at 'ws-a'. Only the generation distinguishes it
+		// from the load that is actually current (Codex round 1).
+		const staleA = deferred<AttachmentListResponse>();
+		const staleUsageA = deferred<WorkspaceStorageInfo>();
+		listMock.mockReturnValueOnce(staleA.promise);
+		usageMock.mockReturnValueOnce(staleUsageA.promise);
+		mountTab();
+		await settle();
+
+		props.wsSlug = 'ws-b';
+		flushSync();
+		await settle();
+
+		const freshA = deferred<AttachmentListResponse>();
+		listMock.mockReturnValueOnce(freshA.promise);
+		usageMock.mockResolvedValueOnce(usage(333));
+		props.wsSlug = 'ws-a';
+		flushSync();
+		await settle();
+
+		// The first A load resolves late. It must not lower the whole-tab gate
+		// (the current A load is still pending) nor paint its rows or usage.
+		staleA.resolve(response([att({ id: 'stale', filename: 'stale-a.pdf' })]));
+		staleUsageA.resolve(usage(999));
+		await settle();
+		expect(text()).toContain('Loading storage…');
+		expect(text()).not.toContain('stale-a.pdf');
+		expect(text()).not.toContain('999 B');
+
+		// The current one does.
+		freshA.resolve(response([att({ id: 'fresh', filename: 'fresh-a.pdf' })]));
+		await settle();
+		expect(text()).not.toContain('Loading storage…');
+		expect(text()).toContain('fresh-a.pdf');
+		expect(text()).not.toContain('stale-a.pdf');
+	});
+
+	it('ignores a superseded usage response and its error toast', async () => {
+		const slowA = deferred<WorkspaceStorageInfo>();
+		usageMock.mockReturnValueOnce(slowA.promise);
+		mountTab();
+		await settle();
+
+		usageMock.mockResolvedValueOnce(usage(222));
+		props.wsSlug = 'ws-b';
+		flushSync();
+		await settle();
+		expect(text()).toContain('222 B');
+
+		slowA.reject(new Error('workspace a is gone'));
+		await settle();
+		expect(text()).toContain('222 B');
+		expect(toastMock).not.toHaveBeenCalled();
+	});
+});

--- a/web/src/lib/components/settings/StorageTab.svelte.test.ts
+++ b/web/src/lib/components/settings/StorageTab.svelte.test.ts
@@ -15,6 +15,8 @@ import type {
 const listMock =
 	vi.fn<(ws: string, filters: Record<string, unknown>) => Promise<AttachmentListResponse>>();
 const usageMock = vi.fn<(ws: string) => Promise<WorkspaceStorageInfo>>();
+const deleteMock = vi.fn<(ws: string, id: string) => Promise<void>>();
+const announceMock = vi.fn<(ws: string, id: string) => void>();
 const toastMock = vi.fn<(message: string, kind?: string) => void>();
 
 class FakeApiError extends Error {
@@ -33,7 +35,7 @@ vi.mock('$lib/api/client', () => ({
 			storageUsage: (ws: string) => usageMock(ws),
 			downloadUrl: (ws: string, id: string, variant?: string) =>
 				`/api/v1/workspaces/${ws}/attachments/${id}${variant ? `?variant=${variant}` : ''}`,
-			delete: vi.fn(),
+			delete: (ws: string, id: string) => deleteMock(ws, id),
 		},
 	},
 }));
@@ -43,7 +45,7 @@ vi.mock('$app/state', () => ({
 }));
 
 vi.mock('$lib/attachments/events', () => ({
-	announceAttachmentDeleted: vi.fn(),
+	announceAttachmentDeleted: (ws: string, id: string) => announceMock(ws, id),
 }));
 
 vi.mock('$lib/components/editor/attachment-metadata', () => ({
@@ -106,6 +108,9 @@ describe('StorageTab workspace switching', () => {
 		listMock.mockResolvedValue(response([]));
 		usageMock.mockReset();
 		usageMock.mockResolvedValue(usage(1));
+		deleteMock.mockReset();
+		deleteMock.mockResolvedValue(undefined);
+		announceMock.mockReset();
 		toastMock.mockReset();
 		props.wsSlug = 'ws-a';
 		props.initialItemId = '';
@@ -254,6 +259,158 @@ describe('StorageTab workspace switching', () => {
 		expect(text()).not.toContain('Loading storage…');
 		expect(text()).toContain('fresh-a.pdf');
 		expect(text()).not.toContain('stale-a.pdf');
+	});
+
+	it('fences a delete on the workspace it was issued for', async () => {
+		// The delete used the LIVE `wsSlug` after its own await, so an A→B switch
+		// mid-request let A's success handling announce the deletion and reload
+		// against B — a success toast for a row the user is no longer looking at,
+		// and a refetch of B's list on A's completion (final review round 4).
+		//
+		// The broadcast is deliberately NOT fenced: it is a global side effect
+		// keyed by (workspace, id), and a switch says nothing about whether the
+		// row is gone.
+		listMock.mockResolvedValueOnce(response([att({ id: 'a1', filename: 'from-a.pdf' })]));
+		mountTab();
+		await settle();
+		expect(rows()).toHaveLength(1);
+
+		const slowDelete = deferred<void>();
+		deleteMock.mockReturnValueOnce(slowDelete.promise);
+		const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+		target.querySelector<HTMLButtonElement>('.btn-remove')?.click();
+		flushSync();
+		expect(deleteMock).toHaveBeenCalledWith('ws-a', 'a1');
+
+		listMock.mockResolvedValueOnce(response([att({ id: 'b1', filename: 'from-b.pdf' })]));
+		props.wsSlug = 'ws-b';
+		flushSync();
+		await settle();
+		expect(text()).toContain('from-b.pdf');
+		toastMock.mockClear();
+		const listCalls = listMock.mock.calls.length;
+
+		slowDelete.resolve();
+		await settle();
+
+		// Announced against the workspace the DELETE targeted...
+		expect(announceMock).toHaveBeenCalledWith('ws-a', 'a1');
+		// ...but no toast over B, and no reload of B on A's completion.
+		expect(toastMock).not.toHaveBeenCalled();
+		expect(listMock.mock.calls.length).toBe(listCalls);
+		expect(text()).toContain('from-b.pdf');
+		confirmSpy.mockRestore();
+	});
+
+	it('still suppresses a delete continuation after an A→B→A round trip', async () => {
+		// The identity is back to ws-a by the time the delete resolves, so an
+		// identity compare alone lets it through. Only a view GENERATION can tell
+		// "never left" from "left and came back" — which is why the mutation
+		// fence is not the paint token (Codex round 3).
+		listMock.mockResolvedValueOnce(response([att({ id: 'a1', filename: 'from-a.pdf' })]));
+		mountTab();
+		await settle();
+
+		const slowDelete = deferred<void>();
+		deleteMock.mockReturnValueOnce(slowDelete.promise);
+		const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+		target.querySelector<HTMLButtonElement>('.btn-remove')?.click();
+		flushSync();
+		expect(deleteMock).toHaveBeenCalledWith('ws-a', 'a1');
+
+		props.wsSlug = 'ws-b';
+		flushSync();
+		await settle();
+		props.wsSlug = 'ws-a';
+		flushSync();
+		await settle();
+
+		toastMock.mockClear();
+		const listCalls = listMock.mock.calls.length;
+		slowDelete.resolve();
+		await settle();
+
+		expect(announceMock).toHaveBeenCalledWith('ws-a', 'a1');
+		// No toast: it belongs to the view that was on screen when the delete
+		// started, and the user has been elsewhere since.
+		expect(toastMock).not.toHaveBeenCalled();
+		// But the tab IS showing ws-a again, and the list it repainted on the way
+		// back can have raced the DELETE — so the corrective refetch still runs,
+		// against ws-a (Codex round 4).
+		expect(listMock.mock.calls.length).toBe(listCalls + 1);
+		expect(listMock).toHaveBeenLastCalledWith('ws-a', expect.anything());
+		confirmSpy.mockRestore();
+	});
+
+	it('does not toast or refetch for a delete that resolves after unmount', async () => {
+		listMock.mockResolvedValueOnce(response([att({ id: 'a1', filename: 'from-a.pdf' })]));
+		mountTab();
+		await settle();
+
+		const slowDelete = deferred<void>();
+		deleteMock.mockReturnValueOnce(slowDelete.promise);
+		const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+		target.querySelector<HTMLButtonElement>('.btn-remove')?.click();
+		flushSync();
+
+		unmount(instance!);
+		instance = undefined;
+		toastMock.mockClear();
+		const listCalls = listMock.mock.calls.length;
+
+		slowDelete.resolve();
+		await settle();
+
+		// The broadcast still fires — other surfaces need the proof — but
+		// nothing writes into a dead instance.
+		expect(announceMock).toHaveBeenCalledWith('ws-a', 'a1');
+		expect(toastMock).not.toHaveBeenCalled();
+		expect(listMock.mock.calls.length).toBe(listCalls);
+		confirmSpy.mockRestore();
+	});
+
+	it('does not toast for a list or usage request that fails after unmount', async () => {
+		// The loaders are plain async functions, not effects, so nothing retires
+		// their tokens on destroy unless onDestroy does it — and an error toast
+		// for a tab that is gone is a global side effect the user still sees
+		// (Codex round 5).
+		const slowList = deferred<AttachmentListResponse>();
+		const slowUsage = deferred<WorkspaceStorageInfo>();
+		listMock.mockReturnValueOnce(slowList.promise);
+		usageMock.mockReturnValueOnce(slowUsage.promise);
+		mountTab();
+		await settle();
+
+		unmount(instance!);
+		instance = undefined;
+		toastMock.mockReset();
+
+		slowList.reject(new Error('list blew up'));
+		slowUsage.reject(new Error('usage blew up'));
+		await settle();
+
+		expect(toastMock).not.toHaveBeenCalled();
+	});
+
+	it('refuses a delete click that lands after the workspace already switched', async () => {
+		// Props update synchronously and the reload effect flushes later, so a
+		// click can land on the previous workspace's still-painted row while
+		// `wsSlug` already reads the next one. No fence after the await can
+		// unsend that request, so the entry fence has to refuse it.
+		listMock.mockResolvedValueOnce(response([att({ id: 'a1', filename: 'from-a.pdf' })]));
+		mountTab();
+		await settle();
+
+		const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+		props.wsSlug = 'ws-b';
+		// No flushSync between the switch and the click: that IS the window.
+		target.querySelector<HTMLButtonElement>('.btn-remove')?.click();
+		flushSync();
+		await settle();
+
+		expect(deleteMock).not.toHaveBeenCalled();
+		expect(confirmSpy).not.toHaveBeenCalled();
+		confirmSpy.mockRestore();
 	});
 
 	it('ignores a superseded usage response and its error toast', async () => {

--- a/web/src/routes/[username]/[workspace]/settings/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/settings/+page.svelte
@@ -18,6 +18,32 @@
 
 	let wsSlug = $derived(page.params.workspace ?? '');
 	let username = $derived(page.params.username ?? '');
+	/**
+	 * Item-scoped handoff from the item attachment strip's "View all (N)" link
+	 * (PLAN-2392 DR-18): `?attachment_item=<uuid>#storage`. Passed straight
+	 * through to StorageTab, which seeds its `item_id` filter from it — without
+	 * it, "item-scoped" would just be a workspace-wide list.
+	 */
+	let attachmentItemId = $derived(page.url.searchParams.get('attachment_item') ?? '');
+
+	/**
+	 * Drop the item scope from the URL when StorageTab's "Show all" is used.
+	 * A real (replacing) navigation rather than history.replaceState: only a
+	 * navigation updates `page.url`, and this route derives the prop from it —
+	 * with a bare history write the scope would come straight back on the next
+	 * tab switch or remount (Codex round 4). The route has no load function,
+	 * so this is a cheap client-side URL swap.
+	 */
+	function clearAttachmentItem() {
+		const url = new URL(page.url);
+		if (!url.searchParams.has('attachment_item')) return;
+		url.searchParams.delete('attachment_item');
+		void goto(`${url.pathname}${url.search}${url.hash}`, {
+			replaceState: true,
+			noScroll: true,
+			keepFocus: true,
+		});
+	}
 	let loading = $state(true);
 	let collections = $state<Collection[]>([]);
 	let wsName = $state('');
@@ -831,7 +857,12 @@
 			</section>
 		{:else if activeTab === 'storage'}
 			<section class="section">
-				<StorageTab {wsSlug} {collections} />
+				<StorageTab
+					{wsSlug}
+					{collections}
+					initialItemId={attachmentItemId}
+					onClearScope={clearAttachmentItem}
+				/>
 			</section>
 		{:else if activeTab === 'danger'}
 			<section class="section">

--- a/web/src/test/mocks/app-state.ts
+++ b/web/src/test/mocks/app-state.ts
@@ -1,0 +1,25 @@
+// Test-only stand-in for SvelteKit's `$app/state`.
+//
+// Same reason as `app-environment.ts`: the jsdom vitest project runs without
+// the SvelteKit vite plugin, so `$app/state` has no provider and any component
+// importing it fails to RESOLVE — before `vi.mock` ever gets a chance to
+// substitute it. vitest.config.ts aliases the import here so such components
+// are mountable at all; a test that cares about the values either mutates the
+// exported objects or `vi.mock`s the specifier itself.
+//
+// Plain mutable objects, not runes: components read `page.params.x` in
+// `$derived`, which works fine against a static object for tests that don't
+// need the read to be reactive.
+export const page = {
+	params: {} as Record<string, string>,
+	url: new URL('http://localhost/'),
+	route: { id: null as string | null },
+	status: 200,
+	error: null as unknown,
+	data: {} as Record<string, unknown>,
+	form: null as unknown,
+	state: {} as Record<string, unknown>,
+};
+
+export const navigating = { from: null, to: null, type: null, complete: null };
+export const updated = { current: false, check: async () => false };

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -35,6 +35,7 @@ function canResolve(id: string): boolean {
 const projectRoot = fileURLToPath(new URL('.', import.meta.url));
 const $lib = fileURLToPath(new URL('./src/lib', import.meta.url));
 const appEnvironmentMock = fileURLToPath(new URL('./src/test/mocks/app-environment.ts', import.meta.url));
+const appStateMock = fileURLToPath(new URL('./src/test/mocks/app-state.ts', import.meta.url));
 
 // Agent worktrees symlink `web/node_modules` to the main checkout's
 // node_modules rather than `npm install`-ing a copy (installing clobbers a
@@ -90,8 +91,13 @@ export default defineConfig(async () => {
 			resolve: {
 				alias: {
 					$lib,
-					// No SvelteKit plugin in this project, so provide `$app/environment`.
+					// No SvelteKit plugin in this project, so provide `$app/environment`
+					// and `$app/state` — without a provider these don't just come back
+					// undefined, they fail to RESOLVE, which is a load-time error for
+					// any component that imports them (and one `vi.mock` can't rescue,
+					// since resolution happens first).
 					'$app/environment': appEnvironmentMock,
+					'$app/state': appStateMock,
 				},
 			},
 			server: nodeModulesRealPath


### PR DESCRIPTION
Implements **PLAN-2392** — makes an item's attachments viewable and actionable: real file-type icons, an options panel that replaces the accidental-download tap, and one unified zoomable viewer.

Plan authored and hardened through 38 rounds of Codex adversarial review, which also split off two follow-up plans (PLAN-2411 undo-delete, PLAN-2416 recovery surface) and three bugs (BUG-2412, BUG-2413, BUG-2415).

## Decisions worth knowing before reviewing

- **There is one viewer.** `attachment-image.ts`'s hand-rolled `<dialog>` is deleted and body images route through `Lightbox.svelte`. That means re-implementing what `showModal()` gave for free — top-layer, inert background, focus trap, focus restore, Escape — as an explicit contract (DR-4b). Phase 3a is the highest-risk work here.
- **`role="dialog"` is a collision-class change.** Two route files already early-return on `[role="dialog"]:not(.item-pane)` *before* `escapeStack` runs, so registering the viewer alone would leave Escape broken. CSS and E2E locators need the same sweep.
- **The viewer's auto-load gate is megapixels, not bytes.** `size_bytes` is compressed; a 3 MB JPEG can be 50 MP (~200 MiB decoded).
- **No Undo in this PR.** The panel's Delete behaves exactly like today's tile Delete; PLAN-2411 adds the generation token, event change and toast to all three entry points at once (DR-19).

## Phases

- [x] **1** — SVG icon set + consolidate three icon helpers onto `display.ts` (TASK-2417)
- [x] **1b** — Bound strip buffers, loading/error states, item-scoped overflow (TASK-2418)
- [ ] **2** — `AttachmentDetails` panel: metadata + open/download/copy-link/delete, host-targeted and host-permissioned
- [ ] **3a** — Viewer unification + the a11y contract + strict raster open-gate
- [ ] **3b** — Desktop zoom + progressive loading
- [ ] **3c** — Viewer actions, delete-closes-viewer, parent-lifecycle, editor-undo
- [ ] **3d** — Touch: pinch, drag-pan, clamping; enable the Pixel 7 e2e project

## Test plan

`make check` · `cd web && npm run check` · extended e2e including a mobile project. **`make test-pg` is not required** — this plan adds one Go *test* (the shared MIME fixture assertion) and no runtime Go.

Deliberately out of scope: StorageTab's panel, static/share-page chips, rename/alt-text (companion plan), undo-delete (PLAN-2411).

---

**Wave 1 merged as its own PR.** PLAN-2392 has 7 phases; shipping them in one PR would breach the plan's own >2k-line / >3-phase reviewability smell. Phases 2 and 3a-3d land separately against this base.

Five final full-diff review rounds ran on this branch. The first four each found post-await view-staleness bugs — including one that could issue a DELETE against the wrong item — which the per-task reviews all passed. The fifth commit stopped patching and extracted the invariant into `web/src/lib/attachments/viewFence.ts`; all 592 baseline tests are unmodified by that refactor. Final pass CLEAN.