### PR TITLE
fix(cli): surface actionable errors for cloud-mode setup failures

### DIFF
--- a/cmd/pad/cmd_auth.go
+++ b/cmd/pad/cmd_auth.go
@@ -691,11 +691,16 @@ func saveCredentials(cfg *config.Config, resp *cli.LoginResponse) error {
 }
 
 func printSetupRequiredHint(cfg *config.Config) {
-	fmt.Println("This Pad instance has not been initialized yet.")
 	switch cfg.Mode {
-	case config.ModeRemote, config.ModeCloud:
+	case config.ModeCloud:
+		fmt.Println("You're configured in Cloud mode but don't have an account on Pad Cloud yet.")
+		fmt.Printf("  Sign up at %s/register, then run 'pad auth login'.\n", config.CloudBaseURL)
+		fmt.Println("  Or switch to a local server with 'pad auth configure --mode local'.")
+	case config.ModeRemote:
+		fmt.Println("This Pad instance has not been initialized yet.")
 		fmt.Println("Run 'pad auth setup' on the machine or container running the Pad server, then try again.")
 	default:
+		fmt.Println("This Pad instance has not been initialized yet.")
 		fmt.Println("Run 'pad auth setup' to create the first admin account, then try again.")
 	}
 }

--- a/cmd/pad/init.go
+++ b/cmd/pad/init.go
@@ -198,6 +198,9 @@ Examples:
 					// --cli-prompt requires a TTY there too. Use --email/--name/
 					// --password to bootstrap a remote instance non-interactively.
 					printSetupRequiredHint(cfg)
+					if cfg.Mode == config.ModeCloud {
+						return fmt.Errorf("Pad Cloud account required")
+					}
 					return fmt.Errorf("this Pad instance has not been initialized yet")
 				} else if !canPromptForConfig() {
 					printSetupRequiredHint(cfg)

--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -1612,6 +1612,9 @@ func parseErrorBody(status int, body []byte) error {
 		Error APIError `json:"error"`
 	}
 	if err := json.Unmarshal(body, &errResp); err == nil && errResp.Error.Message != "" {
+		if errResp.Error.Code == "csrf_error" {
+			errResp.Error.Message = "Session authentication error. Run 'pad auth login' to re-authenticate."
+		}
 		return &errResp.Error
 	}
 	return fmt.Errorf("API error: %d %s", status, string(body))


### PR DESCRIPTION
## What does this PR do?

When a user picks Cloud mode during `pad init` but hasn't signed up for Pad Cloud, the CLI hits `app.getpad.dev` and surfaces raw server errors -- typically "Missing CSRF token" -- instead of telling the user what actually went wrong. This happened to me on a fresh Fedora 43 install; I spent a while debugging what I assumed was a server-side CSRF bug before realizing the CLI was talking to a remote server I had no account on.

Three small changes:

1. `printSetupRequiredHint` now has a dedicated Cloud branch -- tells the user to sign up at `app.getpad.dev/register` or switch to local mode, instead of the generic "run `pad auth setup` on the server" message.
2. `pad init` returns a cloud-specific error ("Pad Cloud account required") when `setup_required` is true in Cloud mode.
3. The CLI HTTP client intercepts `csrf_error` responses and replaces the raw server message with "Session authentication error. Run `pad auth login` to re-authenticate." The CLI uses Bearer auth exclusively, so a `csrf_error` always indicates a session state problem, not something the user can act on directly.

Closes #1057

## How to test

1. `pad auth configure --mode cloud` (or pick Cloud during `pad init`)
2. Without a Pad Cloud account, run `pad init`
3. Should now see the sign-up URL and local-mode fallback instead of "Missing CSRF token"

## Checklist

- [x] `make build` passes
- [x] `make test` passes
- [x] New features have tests (if applicable)
- [x] TypeScript types updated (if API changed)
- [x] CLI help text updated (if new command)