### PR TITLE
PLAN-2392 phase 3a: viewer unification (parity commit + DR-4b a11y contract)

### DIFF
--- a/web/e2e/attachment-viewer-modal.spec.ts
+++ b/web/e2e/attachment-viewer-modal.spec.ts
@@ -1,0 +1,854 @@
+import { test, expect } from './fixtures';
+import { browserLogin, seedDoc } from './lib/collab-helpers';
+import {
+	DESKTOP,
+	MOBILE,
+	REAL_PNG,
+	TILE,
+	VIEWER,
+	VIEWER_IMAGE,
+	activeInViewer,
+	clearProbes,
+	collectionUrl,
+	dropFileIntoEditor,
+	expectBackgroundInert,
+	focusAttemptTakes,
+	isFocusable,
+	itemUrl,
+	uploadAttachment,
+	viewerClose
+} from './lib/attachment-viewer';
+
+/**
+ * THE ATTACHMENT VIEWER'S MODAL CONTRACT, IN A REAL BROWSER
+ * (PLAN-2392 phase 3a / TASK-2436, DR-9).
+ *
+ * Phase 3a deleted a native `<dialog>` that `showModal()` had been giving five
+ * guarantees for free — top-layer stacking, background inertness, a focus trap,
+ * focus restore, and Escape — and replaced each with hand-written code. jsdom's
+ * `<dialog>` polyfill (`web/src/test/setup-jsdom.ts`) only toggles attributes,
+ * so it can see NONE of them: no inertness, no top layer, no `:modal`, no real
+ * Tab traversal, no stacking. Every unit test in the phase would pass against
+ * an implementation that got all five wrong.
+ *
+ * So each test here is written against the question "what mutation would this
+ * catch, that a jsdom-equivalent implementation would survive?" — the specific
+ * escapes are named at each test. The four-surface parity matrix and the
+ * keyboard-activation cases live in `attachment-viewer-parity.spec.ts`; the
+ * seven global key/gesture owners in `attachment-viewer-owners.spec.ts`.
+ *
+ * Viewport is driven explicitly, so one Playwright project is enough (the
+ * mobile-viewport tests set MOBILE themselves and still run under
+ * `desktop-chromium`).
+ */
+
+test.describe('attachment viewer — modal contract (TASK-2436)', () => {
+	test.beforeEach(async ({ page }, testInfo) => {
+		test.skip(
+			testInfo.project.name !== 'desktop-chromium',
+			'viewport is driven explicitly; one project is enough'
+		);
+		await page.setViewportSize(DESKTOP);
+	});
+
+	test('portals to <body> with viewport-fixed geometry, names itself, and takes focus on open', async ({
+		page,
+		fixture,
+		request
+	}) => {
+		// PORTAL CORRECTNESS is a precondition for every other test in this file:
+		// a `position: fixed` overlay is only viewport-fixed while no ancestor
+		// establishes a containing block, and `transform` / `filter` /
+		// `contain: layout` on ANY ancestor silently does. Trapped in such an
+		// ancestor the viewer would still pass every jsdom assertion — same DOM,
+		// same attributes — while covering a fraction of the screen and leaving
+		// the manager inerting the subtree it lives in.
+		await browserLogin(page);
+		const doc = await seedDoc(fixture, request, 'Viewer portal');
+		await uploadAttachment(fixture, request, doc.id, 'portal.png');
+		await page.goto(itemUrl(fixture, doc.slug));
+
+		const tile = page.locator(TILE).first();
+		await expect(tile).toBeVisible();
+		await tile.click();
+
+		const viewer = page.locator(VIEWER);
+		await expect(viewer).toBeVisible();
+		// Named by the image, never anonymous — an unnamed role="dialog" is
+		// announced as nothing at all.
+		await expect(page.getByRole('dialog', { name: 'portal.png' })).toBeVisible();
+		await expect(viewer).toHaveAttribute('aria-modal', 'true');
+
+		const geometry = await page.evaluate(() => {
+			const el = document.querySelector<HTMLElement>('.attachment-viewer')!;
+			const cs = getComputedStyle(el);
+			const rect = el.getBoundingClientRect();
+			return {
+				parentIsBody: el.parentElement === document.body,
+				position: cs.position,
+				zIndex: cs.zIndex,
+				rect: { x: rect.x, y: rect.y, width: rect.width, height: rect.height },
+				viewport: { width: window.innerWidth, height: window.innerHeight }
+			};
+		});
+		expect(geometry.parentIsBody, 'the viewer must be a DIRECT child of <body>').toBe(true);
+		expect(geometry.position).toBe('fixed');
+		// FULL VIEWPORT, measured — not `inset: 0` read back from the cascade.
+		// A containing-block ancestor changes the RECT while leaving the
+		// declaration untouched.
+		expect(geometry.rect.x).toBe(0);
+		expect(geometry.rect.y).toBe(0);
+		expect(geometry.rect.width).toBe(geometry.viewport.width);
+		expect(geometry.rect.height).toBe(geometry.viewport.height);
+
+		// FOCUS ENTRY lands on the first tabbable DESCENDANT (the close button),
+		// not on the container — jsdom cannot decide this, because
+		// `paneFocusables` filters on layout the jsdom DOM does not have.
+		await expect(viewerClose(page)).toBeFocused();
+	});
+
+	test('every background body child goes inert — proven by injected probes and by the REAL top bar', async ({
+		page,
+		fixture,
+		request
+	}) => {
+		// THE CENTRAL jsdom BLIND SPOT. The unit suite asserts the `inert`
+		// ATTRIBUTE on the elements the manager chose; that passes even if the
+		// choice is wrong, because jsdom never enforces inertness. Here the proof
+		// is behavioural: an element that cannot take focus.
+		//
+		// The top bar is asserted SEPARATELY and deliberately: it is NOT a body
+		// child, it is a grandchild through the SvelteKit `display: contents`
+		// wrapper (`app.html:16`), so it can only go inert by CASCADE. An
+		// implementation that inerted a hand-picked list of app-shell elements
+		// instead of body children would pass the probe assertions and fail this.
+		await browserLogin(page);
+		const doc = await seedDoc(fixture, request, 'Viewer inert');
+		await uploadAttachment(fixture, request, doc.id, 'inert.png');
+		await page.goto(itemUrl(fixture, doc.slug));
+		await expect(page.locator(TILE).first()).toBeVisible();
+
+		const topbarToggle = '[aria-label="Hide sidebar"], [aria-label="Show sidebar"]';
+		expect(
+			await isFocusable(page, topbarToggle),
+			'baseline: the top-bar control is reachable with no viewer open'
+		).toBe(true);
+
+		await page.locator(TILE).first().click();
+		await expect(page.locator(VIEWER)).toBeVisible();
+
+		await expectBackgroundInert(page);
+		expect(
+			await isFocusable(page, topbarToggle),
+			'the real top-bar control must go inert THROUGH ITS ANCESTOR'
+		).toBe(false);
+
+		// ...and it all comes back. Without this the inert half could be
+		// permanent damage rather than a lease.
+		await page.keyboard.press('Escape');
+		await expect(page.locator(VIEWER)).toHaveCount(0);
+		expect(await isFocusable(page, topbarToggle)).toBe(true);
+		const after = await page.evaluate(() =>
+			Array.from(document.body.children).some((c) => c.hasAttribute('inert'))
+		);
+		expect(after, 'no body child may be left inert once the lease is released').toBe(false);
+		await clearProbes(page);
+	});
+
+	test('focus returns to the INVOKER, which is only possible if the lease is released first', async ({
+		page,
+		fixture,
+		request
+	}) => {
+		// THE ORDERING MUTATION (TASK-2429, Codex): moving the focus restore
+		// BEFORE the backdrop release passes every jsdom test, because jsdom lets
+		// you focus an inert element. In a browser it silently does nothing and
+		// the keyboard user is left on `<body>`.
+		//
+		// So the test asserts BOTH ends: the invoker is genuinely unfocusable
+		// while the viewer is up (otherwise "focus went back to it" would prove
+		// nothing about ordering), and it HOLDS focus once the viewer is gone.
+		await browserLogin(page);
+		const doc = await seedDoc(fixture, request, 'Viewer restore');
+		await uploadAttachment(fixture, request, doc.id, 'restore.png');
+		await page.goto(itemUrl(fixture, doc.slug));
+
+		const tile = page.locator(TILE).first();
+		await expect(tile).toBeVisible();
+		await tile.click();
+		await expect(page.locator(VIEWER)).toBeVisible();
+
+		expect(
+			await isFocusable(page, `${TILE}`),
+			'the invoking tile must be INERT while the viewer is open — this is what makes ' +
+				'a restore-before-release a no-op in a real browser'
+		).toBe(false);
+
+		await viewerClose(page).click();
+		await expect(page.locator(VIEWER)).toHaveCount(0);
+		await expect(tile).toBeFocused();
+	});
+
+	test('a native showModal() dialog stays interactive above the viewer; show() and [open] do not', async ({
+		page,
+		fixture,
+		request
+	}) => {
+		// `:modal` vs `[open]` (TASK-2427). jsdom has no `:modal` at all, so
+		// "a declaratively-open NON-modal dialog does not block" passes there
+		// VACUOUSLY — the fallback branch is what runs. Only a real engine can
+		// contrast the two, and getting it wrong in the mutator's direction
+		// writes `inert` onto a live top-layer modal: a dialog the user can see,
+		// cannot operate, and cannot dismiss.
+		await browserLogin(page);
+		const doc = await seedDoc(fixture, request, 'Viewer native dialog');
+		await uploadAttachment(fixture, request, doc.id, 'native.png');
+		await page.goto(itemUrl(fixture, doc.slug));
+		await page.locator(TILE).first().click();
+		await expect(page.locator(VIEWER)).toBeVisible();
+
+		expect(
+			await page.evaluate(() => {
+				try {
+					document.querySelectorAll('dialog:modal');
+					return true;
+				} catch {
+					return false;
+				}
+			}),
+			'this engine must support :modal, or the contrast below is meaningless'
+		).toBe(true);
+
+		await page.evaluate(() => {
+			const make = (id: string) => {
+				const d = document.createElement('dialog');
+				d.id = id;
+				const b = document.createElement('button');
+				b.dataset.dlg = id;
+				b.textContent = id;
+				d.appendChild(b);
+				document.body.appendChild(d);
+				return d;
+			};
+			make('probe-modal').showModal();
+			make('probe-nonmodal').show();
+			// A dialog mounted CLOSED, opened modally LATER — the case the
+			// original childList-only observer missed, and the reason the manager
+			// observes the `open` ATTRIBUTE. Its failure mode is a dead modal.
+			make('probe-late');
+		});
+		// The manager reconciles from a MutationObserver, i.e. on a microtask.
+		await expect
+			.poll(() => page.evaluate(() => document.getElementById('probe-late')!.hasAttribute('inert')))
+			.toBe(true);
+
+		const before = await page.evaluate(() => ({
+			modalInert: document.getElementById('probe-modal')!.hasAttribute('inert'),
+			nonModalInert: document.getElementById('probe-nonmodal')!.hasAttribute('inert')
+		}));
+		expect(before.modalInert, 'a showModal() dialog must NOT be inerted').toBe(false);
+		expect(
+			before.nonModalInert,
+			'a show() dialog is NOT in the top layer and must be inerted like any other body child'
+		).toBe(true);
+		expect(await isFocusable(page, '[data-dlg="probe-modal"]')).toBe(true);
+		expect(await isFocusable(page, '[data-dlg="probe-nonmodal"]')).toBe(false);
+
+		// The late modal: inert while closed, released the moment it is shown.
+		await page.evaluate(() =>
+			(document.getElementById('probe-late') as HTMLDialogElement).showModal()
+		);
+		await expect
+			.poll(() => page.evaluate(() => document.getElementById('probe-late')!.hasAttribute('inert')))
+			.toBe(false);
+		expect(
+			await isFocusable(page, '[data-dlg="probe-late"]'),
+			'a dialog mounted closed and shown modally later must be operable, not dead'
+		).toBe(true);
+
+		await page.evaluate(() => {
+			for (const id of ['probe-modal', 'probe-nonmodal', 'probe-late']) {
+				const d = document.getElementById(id) as HTMLDialogElement | null;
+				d?.close();
+				d?.remove();
+			}
+		});
+	});
+
+	test('the viewer PAINTS above the highest body-portaled overlay in the app (z-index 99999)', async ({
+		page,
+		fixture,
+		request
+	}) => {
+		// DR-4c. Body-portaled overlays coexist by z-index alone, and the desktop
+		// emoji picker's dropdown sits at 99999 — the reason the viewer is
+		// 100000 rather than 1000. jsdom cannot see stacking at all, so the only
+		// existing evidence is the declaration itself.
+		//
+		// HIT TESTING, not the declaration. One wrinkle makes the naive version
+		// vacuous: Chromium excludes INERT subtrees from hit testing, so a rival
+		// injected under a live lease would lose `elementFromPoint` at ANY
+		// z-index. The rival's `inert` is therefore removed before measuring (the
+		// manager does not re-apply it — it observes childList and dialog `open`,
+		// not `inert`), and the raised-z-index control below proves the
+		// measurement is genuinely sensitive to stacking rather than to inertness.
+		await browserLogin(page);
+		const doc = await seedDoc(fixture, request, 'Viewer paint order');
+		await uploadAttachment(fixture, request, doc.id, 'paint.png');
+		await page.goto(itemUrl(fixture, doc.slug));
+		await page.locator(TILE).first().click();
+		await expect(page.locator(VIEWER_IMAGE)).toBeVisible();
+
+		await page.evaluate(() => {
+			const rival = document.createElement('div');
+			rival.id = 'rival-overlay';
+			// Stands in for EmojiPickerButton's body-portaled desktop dropdown,
+			// at the same z-index it declares.
+			rival.style.cssText = 'position:fixed;inset:0;z-index:99999;';
+			document.body.appendChild(rival);
+		});
+		await expect
+			.poll(() => page.evaluate(() => document.getElementById('rival-overlay')!.hasAttribute('inert')))
+			.toBe(true);
+
+		const hits = await page.evaluate(() => {
+			const rival = document.getElementById('rival-overlay')!;
+			rival.removeAttribute('inert');
+			const at = () => {
+				const el = document.elementFromPoint(window.innerWidth / 2, window.innerHeight / 2);
+				return el ? `${el.tagName}#${el.id}` : 'none';
+			};
+			const at99999 = at();
+			rival.style.zIndex = '100001';
+			const raised = at();
+			rival.remove();
+			return { at99999, raised };
+		});
+		expect(
+			hits.at99999,
+			'the viewer must be the topmost painted surface over a 99999 body-portaled overlay'
+		).toBe('IMG#');
+		expect(
+			hits.raised,
+			'CONTROL: the same measurement must flip when the rival is raised above the viewer — ' +
+				'otherwise the assertion above proves nothing about stacking'
+		).toBe('DIV#rival-overlay');
+
+		// Complementary regression net for "a new overlay above this value is a
+		// bug": nothing else in the app's own stylesheets may declare a z-index
+		// at or above the viewer's. Declaration-based on purpose — it catches a
+		// NEW overlay that no test has thought to hit-test yet.
+		const scan = await page.evaluate(() => {
+			const found: string[] = [];
+			const unreadable: string[] = [];
+			for (const sheet of Array.from(document.styleSheets)) {
+				let rules: CSSRuleList;
+				try {
+					rules = sheet.cssRules;
+				} catch {
+					// FAIL CLOSED: an unreadable sheet could declare anything. The
+					// app ships no cross-origin CSS, so this is reported, not skipped.
+					unreadable.push(sheet.href ?? '(inline)');
+					continue;
+				}
+				const walk = (list: CSSRuleList) => {
+					for (const rule of Array.from(list)) {
+						if ('cssRules' in rule) walk((rule as CSSGroupingRule).cssRules);
+						const style = (rule as CSSStyleRule).style;
+						const selector = (rule as CSSStyleRule).selectorText;
+						if (!style || !selector) continue;
+						const z = Number(style.getPropertyValue('z-index'));
+						if (Number.isFinite(z) && z >= 100000 && !selector.includes('lightbox-backdrop')) {
+							found.push(`${selector} { z-index: ${z} }`);
+						}
+					}
+				};
+				walk(rules);
+			}
+			return { found, unreadable };
+		});
+		expect(
+			scan.unreadable,
+			'every stylesheet must be readable, or the sweep below is not a sweep'
+		).toEqual([]);
+		expect(scan.found, 'no app overlay may declare a z-index at or above the viewer').toEqual([]);
+	});
+
+	test('Escape closes exactly the viewer on the ITEM route, leaving the page it sits over', async ({
+		page,
+		fixture,
+		request
+	}) => {
+		// Route guard 1 of 2. The unit coverage for this uses a LOCAL COPY of the
+		// escape driver rather than mounting either route (TASK-2429), so "Escape
+		// reaches the viewer through the real guard" has never actually been
+		// executed. WHICH layer closed is the assertion — a count decreasing
+		// would be satisfied by the page navigating away.
+		await browserLogin(page);
+		const doc = await seedDoc(fixture, request, 'Viewer esc item');
+		await uploadAttachment(fixture, request, doc.id, 'esc-item.png');
+		const target = itemUrl(fixture, doc.slug);
+		await page.goto(target);
+		await page.locator(TILE).first().click();
+		await expect(page.locator(VIEWER)).toHaveCount(1);
+
+		await page.keyboard.press('Escape');
+		await expect(page.locator(VIEWER)).toHaveCount(0);
+		expect(new URL(page.url()).pathname, 'the route must not have navigated').toBe(target);
+		await expect(page.locator('.item-page').first()).toBeVisible();
+	});
+
+	test('Escape closes exactly the viewer on the COLLECTION route, leaving the pane open beneath it', async ({
+		page,
+		fixture,
+		request
+	}) => {
+		// Route guard 2 of 2 — the duplicated handler in
+		// `[collection]/+page.svelte`. This one has a LAYER UNDER the viewer (the
+		// detail pane, itself an escape-stack member), so it can distinguish
+		// "the top layer closed" from "an Escape closed something".
+		await browserLogin(page);
+		const doc = await seedDoc(fixture, request, 'Viewer esc collection');
+		await uploadAttachment(fixture, request, doc.id, 'esc-coll.png');
+		await page.goto(collectionUrl(fixture, `?item=${encodeURIComponent(doc.slug)}`));
+
+		const pane = page.locator('.item-pane');
+		await expect(pane).toBeVisible();
+		const paneTile = page.locator(`.item-pane ${TILE}`).first();
+		await expect(paneTile).toBeVisible();
+		await paneTile.click();
+		await expect(page.locator(VIEWER)).toHaveCount(1);
+
+		await page.keyboard.press('Escape');
+		await expect(page.locator(VIEWER)).toHaveCount(0);
+		// EXACTLY ONE layer: the pane is still open and still in the URL.
+		await expect(pane).toBeVisible();
+		expect(new URL(page.url()).searchParams.get('item')).toBe(doc.slug);
+
+		// ...and the layer beneath is still live: the NEXT Escapes reach it, one
+		// level per press. (From inside the pane: ESC returns focus to the list
+		// and the pane STAYS; a second ESC from the list closes it.) The
+		// intermediate assertion is what makes this two distinct levels rather
+		// than "some number of Escapes eventually closed something".
+		await page.keyboard.press('Escape');
+		await expect(pane, 'the first press returns focus to the list, it does not close').toBeVisible();
+		await page.keyboard.press('Escape');
+		await expect(pane).toHaveCount(0);
+	});
+
+	test('two viewers: Tab stays in the frontmost, and closing it hands focus DOWN, not into inert chrome', async ({
+		page,
+		fixture,
+		request
+	}) => {
+		// Two mounted viewers is a real state — the strip mounts `Lightbox`
+		// directly while `AttachmentViewerHost` mounts another for inline images
+		// (the hosts are deliberately not consolidated until 3c). jsdom cannot
+		// isolate them: the trap only means something if Tab actually traverses,
+		// and inertness only means something if the browser enforces it.
+		//
+		// The second viewer is opened with a programmatic `click()` because the
+		// first one has (correctly) made the inline image unreachable to a user.
+		// The state under test is the one the implementation documents as safe,
+		// not a state a user is expected to reach.
+		await browserLogin(page);
+		const doc = await seedDoc(fixture, request, 'Viewer stack');
+		await uploadAttachment(fixture, request, doc.id, 'alpha.png');
+		await page.goto(itemUrl(fixture, doc.slug));
+		await dropFileIntoEditor(page, 'bravo.png', REAL_PNG.toString('base64'));
+		const inline = page.locator('.editor-content .ProseMirror img[data-attachment-id]').first();
+		await expect(inline).toBeVisible();
+
+		const alphaTile = page.locator(`${TILE}[aria-label*="alpha.png"]`);
+		await expect(alphaTile).toBeVisible();
+		await alphaTile.click();
+		await expect(page.getByRole('dialog', { name: 'alpha.png' })).toBeVisible();
+
+		await inline.evaluate((el) => (el as HTMLElement).click());
+		await expect(page.locator(VIEWER)).toHaveCount(2);
+
+		const stacked = await page.evaluate(() =>
+			Array.from(document.querySelectorAll('.attachment-viewer')).map((v) => ({
+				label: v.getAttribute('aria-label'),
+				inert: v.hasAttribute('inert')
+			}))
+		);
+		expect(stacked.map((s) => s.label)).toEqual(['alpha.png', 'bravo.png']);
+		expect(stacked[0].inert, 'the BACKGROUND viewer must be inert like any other body child').toBe(
+			true
+		);
+		expect(stacked[1].inert).toBe(false);
+
+		// The trap holds INSIDE the frontmost: several Tabs, focus never leaves.
+		for (let i = 0; i < 5; i++) {
+			await page.keyboard.press('Tab');
+			expect(await activeInViewer(page), `Tab ${i + 1} escaped the frontmost viewer`).toBe(true);
+		}
+		// ...and the background viewer is unreachable for a reason Tab alone
+		// cannot show: a JS trap would keep Tab inside the front viewer even if
+		// the layer behind it were fully interactive. So aim focus straight at
+		// the BACKGROUND viewer's close button and confirm it refuses.
+		expect(
+			await focusAttemptTakes(page, '.attachment-viewer:not(:last-of-type) .lightbox-close'),
+			"the background viewer's own control must be inert, not merely skipped by the trap"
+		).toBe(false);
+
+		// One Escape closes EXACTLY the front one...
+		await page.keyboard.press('Escape');
+		await expect(page.locator(VIEWER)).toHaveCount(1);
+		await expect(page.getByRole('dialog', { name: 'alpha.png' })).toBeVisible();
+		// ...and the handoff puts focus INSIDE the newly frontmost viewer — not on
+		// `<body>`, and not back into the app, which is still inert.
+		expect(
+			await page.evaluate(() => {
+				const v = document.querySelector('.attachment-viewer')!;
+				return {
+					inert: v.hasAttribute('inert'),
+					holdsFocus: !!document.activeElement && v.contains(document.activeElement)
+				};
+			})
+		).toEqual({ inert: false, holdsFocus: true });
+
+		// And the last one out restores the original invoker.
+		await page.keyboard.press('Escape');
+		await expect(page.locator(VIEWER)).toHaveCount(0);
+		await expect(alphaTile).toBeFocused();
+	});
+
+	test('the trap holds BACKWARD too: Shift+Tab wraps to the last control, and a single-control viewer keeps focus', async ({
+		page,
+		fixture,
+		request
+	}) => {
+		// THE BACKWARD-WRAP BRANCH. `nextTrapTarget` returns `last` only when
+		// Shift is held AND focus is on the FIRST control (paneFocus.ts:108-111);
+		// nothing in this suite executed that branch in a browser until now, so a
+		// trap that held forward and leaked backward would have shipped green. It
+		// cannot be reached in jsdom either — the whole thing rests on `focus()`
+		// actually moving and on `preventDefault` actually suppressing the UA's
+		// own traversal.
+		await browserLogin(page);
+		const many = await seedDoc(fixture, request, 'Viewer trap back');
+		await uploadAttachment(fixture, request, many.id, 'trap-a.png');
+		await uploadAttachment(fixture, request, many.id, 'trap-b.png');
+		await page.goto(itemUrl(fixture, many.slug));
+		await expect(page.locator(TILE)).toHaveCount(2);
+		await page.locator(`${TILE}[aria-label*="trap-a.png"]`).click();
+		await expect(page.locator(VIEWER)).toHaveCount(1);
+
+		// Two images ⇒ three controls, in DOM order: Close, Previous, Next.
+		const focused = () => page.evaluate(() => document.activeElement?.getAttribute('aria-label') ?? null);
+		expect(await focused(), 'focus entry is the first control').toBe('Close');
+
+		// FIRST → wraps to LAST. This is the branch.
+		await page.keyboard.press('Shift+Tab');
+		expect(await focused(), 'Shift+Tab from the first control must wrap to the LAST').toBe(
+			'Next image'
+		);
+		// ...and from the middle of the set it simply steps backward, so the
+		// wrap above is a wrap and not "Shift+Tab always lands on Next".
+		await page.keyboard.press('Shift+Tab');
+		expect(await focused()).toBe('Previous image');
+		await page.keyboard.press('Shift+Tab');
+		expect(await focused()).toBe('Close');
+		expect(await activeInViewer(page), 'backward traversal never left the viewer').toBe(true);
+
+		// The FORWARD wrap, asserted by name rather than by containment: from the
+		// last control, Tab returns to the first.
+		await page.locator(VIEWER).getByRole('button', { name: 'Next image' }).focus();
+		await page.keyboard.press('Tab');
+		expect(await focused(), 'Tab from the last control must wrap to the FIRST').toBe('Close');
+
+		// SINGLE-CONTROL VIEWER: with one image there are no nav buttons, so
+		// `first === last` and BOTH directions resolve to the same element. A
+		// trap that only handled the multi-control case would let focus escape
+		// here — into a background that is inert, i.e. onto `<body>`.
+		const one = await seedDoc(fixture, request, 'Viewer trap single');
+		await uploadAttachment(fixture, request, one.id, 'trap-solo.png');
+		await page.goto(itemUrl(fixture, one.slug));
+		await page.locator(TILE).first().click();
+		await expect(page.locator(VIEWER)).toHaveCount(1);
+		await expect(page.locator(VIEWER).getByRole('button', { name: 'Next image' })).toHaveCount(0);
+		expect(await focused()).toBe('Close');
+		for (const key of ['Tab', 'Shift+Tab', 'Tab']) {
+			await page.keyboard.press(key);
+			expect(await focused(), `${key} in a single-control viewer must stay on it`).toBe('Close');
+		}
+	});
+
+	test('a native showModal() dialog over the viewer wins Escape AND Tab outright', async ({
+		page,
+		fixture,
+		request
+	}) => {
+		// THE PRECEDENCE RULE, in an engine. `hasForeignEscapeOwner()`'s native
+		// branch says a `dialog:modal` out-ranks a viewer lease, so the route
+		// driver stands down and the viewer's Escape (which lives only on
+		// `escapeStack`) must NOT run. jsdom throws on `:modal` and has no top
+		// layer, so the rule was written deliberately and never executed.
+		//
+		// Both halves are asserted because they fail differently: getting Escape
+		// wrong closes two layers on one press, getting Tab wrong drags focus out
+		// of the dialog and into the viewer underneath it.
+		await browserLogin(page);
+		const doc = await seedDoc(fixture, request, 'Viewer native precedence');
+		// TWO images, so the viewer has nav controls and therefore a Tab the trap
+		// genuinely OWNS — that is the control leg below.
+		await uploadAttachment(fixture, request, doc.id, 'precedence-a.png');
+		await uploadAttachment(fixture, request, doc.id, 'precedence-b.png');
+		await page.goto(itemUrl(fixture, doc.slug));
+		await expect(page.locator(TILE)).toHaveCount(2);
+		await page.locator(`${TILE}[aria-label*="precedence-a.png"]`).click();
+		await expect(page.locator(VIEWER)).toHaveCount(1);
+
+		// INSTRUMENT `defaultPrevented`, because focus alone cannot distinguish the
+		// mutation (Codex round 4). With `isBlockedByModal(el)` removed from
+		// `Lightbox.onKeydown`, the viewer WOULD act — `preventDefault()` and aim
+		// focus at its own Close button — but `showModal()` inerts the rest of the
+		// document, so that focus attempt is refused and focus stays in the dialog
+		// anyway. The observable difference is whether the viewer consumed the key.
+		// The listener is registered AFTER the viewer mounted, so it runs after
+		// `Lightbox`'s own handler in the same dispatch.
+		await page.evaluate(() => {
+			(window as unknown as { __tab: boolean[] }).__tab = [];
+			window.addEventListener('keydown', (e) => {
+				if (e.key === 'Tab') (window as unknown as { __tab: boolean[] }).__tab.push(e.defaultPrevented);
+			});
+		});
+		const tabPrevented = () => page.evaluate(() => (window as unknown as { __tab: boolean[] }).__tab);
+
+		// CONTROL, viewer alone: a Tab the trap OWNS (from the last control, which
+		// wraps to the first) IS consumed. Without this the assertion below would
+		// pass against a viewer whose key handler never runs at all.
+		await page.locator(VIEWER).getByRole('button', { name: 'Next image' }).focus();
+		await page.keyboard.press('Tab');
+		expect(
+			(await tabPrevented()).at(-1),
+			'control: with no dialog, the viewer OWNS a wrapping Tab'
+		).toBe(true);
+
+		await page.evaluate(() => {
+			(window as unknown as { __tab: boolean[] }).__tab = [];
+			const d = document.createElement('dialog');
+			d.id = 'over-viewer';
+			d.innerHTML =
+				'<button data-dlg="a">first</button><button data-dlg="b">second</button>';
+			document.body.appendChild(d);
+			d.showModal();
+		});
+		const dialogOpen = () =>
+			page.evaluate(() => (document.getElementById('over-viewer') as HTMLDialogElement).open);
+		expect(await dialogOpen()).toBe(true);
+
+		// TAB: the viewer's own key handler stands down for the top layer.
+		//
+		// The assertion is "focus never lands INSIDE THE VIEWER", not "focus is
+		// always inside the dialog": the UA cycles a modal dialog's sequential
+		// navigation through the document root between passes, so a strict
+		// in-dialog check fails on a browser detail rather than on the rule. What
+		// the rule forbids is the viewer's trap reaching up into the top layer
+		// and dragging focus down into itself, and that is what this measures.
+		await page.locator('[data-dlg="a"]').focus();
+		const landings: string[] = [];
+		for (let i = 0; i < 4; i++) {
+			await page.keyboard.press('Tab');
+			const where = await page.evaluate(() => {
+				const a = document.activeElement;
+				if (!a) return 'none';
+				if (a.closest('.attachment-viewer')) return 'VIEWER';
+				if (a.closest('#over-viewer')) return `dialog:${a.getAttribute('data-dlg')}`;
+				return a === document.body ? 'body' : a.tagName;
+			});
+			landings.push(where);
+			expect(where, `Tab ${i + 1} was pulled into the viewer under the native modal`).not.toBe(
+				'VIEWER'
+			);
+		}
+		// ...it really is cycling the dialog, so the check above is not passing
+		// merely because focus went nowhere at all...
+		expect(
+			landings.filter((l) => l.startsWith('dialog:')).length,
+			`Tab never returned into the native modal (landings: ${landings.join(', ')})`
+		).toBeGreaterThan(0);
+		// ...and the VIEWER never consumed any of those presses. This is the
+		// assertion that fails if the `isBlockedByModal` bail is removed; the
+		// containment checks above would survive it.
+		expect(
+			await tabPrevented(),
+			'the viewer must not consume Tab while a top-layer dialog owns the screen'
+		).toEqual([false, false, false, false]);
+
+		// ESCAPE #1 closes the DIALOG ONLY — the browser's own cancel — and the
+		// viewer beneath it is untouched.
+		await page.keyboard.press('Escape');
+		await expect.poll(dialogOpen).toBe(false);
+		await expect(
+			page.locator(VIEWER),
+			'the viewer must NOT close while a top-layer dialog owns the screen'
+		).toHaveCount(1);
+
+		// ESCAPE #2, with the dialog gone, reaches the viewer — so press #1 was
+		// arbitration, not a dead key.
+		await page.keyboard.press('Escape');
+		await expect(page.locator(VIEWER)).toHaveCount(0);
+
+		await page.evaluate(() => document.getElementById('over-viewer')?.remove());
+	});
+
+	test('a DETACHED invoker does not break the teardown: no stranded backdrop, lease released, app usable', async ({
+		page,
+		fixture,
+		request
+	}) => {
+		// `restoreFocus`'s DECLINE path. The invoker here is an editor NodeView
+		// `<img>`, and that NodeView is re-rendered on any document change — so
+		// "the element that opened the viewer is no longer in the document by the
+		// time it closes" is the ordinary case, not a hypothetical.
+		//
+		// WHAT THIS TEST DOES AND DOES NOT KILL (Codex round 4, recorded rather
+		// than papered over). It does NOT kill removal of the
+		// `openInvoker.isConnected` check: in Chromium `focus()` on a detached
+		// node is a no-op, so guarded and unguarded end in the same state. Nor
+		// does it kill a change to the release/restore/remove ORDER — with a
+		// detached invoker there is no focus target either way (that ordering is
+		// killed by the 'focus returns to the INVOKER' test above, which uses a
+		// CONNECTED invoker that is inert until the lease drops).
+		//
+		// What it does kill is a THROW in the teardown. `el.remove()` runs AFTER
+		// the restore, and the node has been reparented out of its Svelte anchor,
+		// so an exception in `restoreFocus` strands the backdrop in the DOM over
+		// an app that has already been un-inerted. That is a user-visible wedge,
+		// and it is what the assertions below are aimed at.
+		// Any uncaught exception in the teardown surfaces here, so the failure
+		// names the cause instead of only its symptom.
+		const pageErrors: string[] = [];
+		page.on('pageerror', (err) => pageErrors.push(String(err)));
+
+		await browserLogin(page);
+		const doc = await seedDoc(fixture, request, 'Viewer detached invoker');
+		await page.goto(itemUrl(fixture, doc.slug));
+		await dropFileIntoEditor(page, 'detached.png', REAL_PNG.toString('base64'));
+		const inline = page.locator('.editor-content .ProseMirror img[data-attachment-id]').first();
+		await expect(inline).toBeVisible();
+		await inline.click();
+		await expect(page.locator(VIEWER)).toHaveCount(1);
+
+		// Replace the invoker with an identical clone — what a NodeView re-render
+		// does to it. The captured reference is now detached; the document still
+		// shows an image, so nothing about the page looks different.
+		const detached = await page.evaluate(() => {
+			const img = document.querySelector<HTMLElement>(
+				'.editor-content .ProseMirror img[data-attachment-id]'
+			)!;
+			img.replaceWith(img.cloneNode(true));
+			return !img.isConnected;
+		});
+		expect(detached, 'the captured invoker must actually be out of the document').toBe(true);
+
+		await page.keyboard.press('Escape');
+		await expect(page.locator(VIEWER)).toHaveCount(0);
+
+		const after = await page.evaluate(() => ({
+			// A throw in the restore would skip `el.remove()` and strand the
+			// backdrop — the count above is checked on `.attachment-viewer`, so
+			// this is the same element by a different name for clarity.
+			strandedBackdrops: document.querySelectorAll('.lightbox-backdrop').length,
+			anyInert: Array.from(document.body.children).some((c) => c.hasAttribute('inert')),
+			// WEAK, and kept as a sanity check rather than as proof: removing the
+			// focused viewer parks focus on `<body>` whether or not the restore
+			// ran at all. It is here to catch focus being left somewhere absurd,
+			// not to demonstrate the decline path.
+			activeIsBodyOrNone:
+				document.activeElement === document.body || document.activeElement === null
+		}));
+		expect(pageErrors, 'the teardown must not throw with a detached invoker').toEqual([]);
+		expect(
+			after.strandedBackdrops,
+			'a throw in the restore would skip `el.remove()` and strand the backdrop'
+		).toBe(0);
+		expect(after.anyInert, 'the lease must be released even when the restore declines').toBe(false);
+		expect(after.activeIsBodyOrNone, 'focus must not be left on a detached element').toBe(true);
+
+		// The app is genuinely usable again — the consequence a user would feel
+		// if the teardown had thrown half-way.
+		expect(
+			await isFocusable(page, '[aria-label="Hide sidebar"], [aria-label="Show sidebar"]')
+		).toBe(true);
+	});
+
+	test('over the mobile pane: the exact inert set at pane-only, viewer-over-pane, and close', async ({
+		page,
+		fixture,
+		request
+	}) => {
+		// THE REAL PANE INTEGRATION. Two independent inert writers meet here and
+		// neither exists in jsdom: the mobile pane overlay inerts NESTED
+		// `display: contents` wrappers in the workspace layout, while the viewer
+		// backdrop inerts BODY CHILDREN. The claim in `viewerBackdrop.ts` is that
+		// they never touch the same elements — untestable in a unit test, since
+		// `paneOverlay` and the layout attributes only exist in a browser.
+		await page.setViewportSize(MOBILE);
+		await browserLogin(page);
+		const doc = await seedDoc(fixture, request, 'Viewer pane inert');
+		await uploadAttachment(fixture, request, doc.id, 'pane.png');
+		await page.goto(collectionUrl(fixture, `?item=${encodeURIComponent(doc.slug)}`));
+
+		const pane = page.locator('.item-pane');
+		await expect(pane).toBeVisible();
+
+		const snapshot = () =>
+			page.evaluate(() => ({
+				bodyChildrenInert: Array.from(document.body.children).map((c) => c.hasAttribute('inert')),
+				// Everything inert that is NOT a body child — i.e. the pane
+				// overlay's own writes, described stably enough to compare sets
+				// across transitions.
+				nestedInert: Array.from(document.querySelectorAll('[inert]'))
+					.filter((el) => el.parentElement !== document.body)
+					.map((el) => `${el.tagName}.${String(el.className).split(' ')[0]}`)
+					.sort(),
+				paneReachable: (() => {
+					const el = document.querySelector<HTMLElement>('.item-pane');
+					if (!el) return false;
+					el.focus();
+					return document.activeElement === el;
+				})()
+			}));
+
+		// PANE ONLY — the mobile overlay owns the chrome, no body child is inert.
+		const paneOnly = await snapshot();
+		expect(paneOnly.bodyChildrenInert.some(Boolean), 'no viewer lease exists yet').toBe(false);
+		expect(
+			paneOnly.nestedInert.length,
+			'the mobile pane overlay must have inerted the app-shell chrome'
+		).toBeGreaterThan(0);
+		expect(paneOnly.paneReachable, 'the pane itself stays interactive').toBe(true);
+
+		// VIEWER OVER PANE — the backdrop adds body-child inertness ON TOP,
+		// and the pane (a descendant of a body child) goes inert WITH it.
+		await page.locator(`.item-pane ${TILE}`).first().click();
+		await expect(page.locator(VIEWER)).toHaveCount(1);
+		await expectBackgroundInert(page);
+		const over = await snapshot();
+		expect(
+			over.nestedInert,
+			"the pane's own inert writes are untouched by the viewer's — different elements, " +
+				'which is the claim `viewerBackdrop.ts` makes and cannot prove in jsdom'
+		).toEqual(paneOnly.nestedInert);
+		expect(over.paneReachable, 'the pane is behind the viewer and must be unreachable').toBe(false);
+
+		// CLOSE — back to exactly the pane-only set, not to "nothing inert".
+		await page.keyboard.press('Escape');
+		await expect(page.locator(VIEWER)).toHaveCount(0);
+		await expect(pane).toBeVisible();
+		const closed = await snapshot();
+		expect(closed.bodyChildrenInert.some(Boolean), 'the lease released every body child').toBe(
+			false
+		);
+		expect(
+			closed.nestedInert,
+			'the pane overlay must still own exactly what it owned before'
+		).toEqual(paneOnly.nestedInert);
+		expect(closed.paneReachable).toBe(true);
+		await clearProbes(page);
+	});
+});

--- a/web/e2e/attachment-viewer-owners.spec.ts
+++ b/web/e2e/attachment-viewer-owners.spec.ts
@@ -1,0 +1,715 @@
+import { test, expect } from './fixtures';
+import type { Page } from '@playwright/test';
+import { browserLogin, seedDoc } from './lib/collab-helpers';
+import {
+	DESKTOP,
+	MOBILE,
+	TILE,
+	VIEWER,
+	activeInViewer,
+	collectionUrl,
+	deleteWorkspace,
+	focusAttemptTakes,
+	itemUrl,
+	uploadAttachment
+} from './lib/attachment-viewer';
+
+/**
+ * THE SEVEN GLOBAL KEY / GESTURE OWNERS, DEFERRING TO A FRONTMOST VIEWER
+ * (TASK-2430, proven in a browser by TASK-2436).
+ *
+ * TASK-2430 routed seven global owners through `isBlockedByModal()`. Its own
+ * tests mount each component in jsdom and drive its handler directly, which
+ * proves the GUARD is called — but not that the owner is actually the thing
+ * that would have acted on a real page, nor that the app is genuinely inert
+ * around it, nor that a captured touch gesture behaves. Its commit message
+ * says so: the native top-layer leg "is not asserted against a real engine …
+ * end-to-end proof belongs to TASK-2436's Playwright suite".
+ *
+ * EVERY owner here is asserted twice: once with a viewer frontmost (must stand
+ * down) and once with an EMPTY stack (must behave exactly as it always did).
+ * The empty-stack half is the contract TASK-2430 promises and the half a
+ * blanket "always decline" mutation would break.
+ *
+ * A viewer is frequently opened with a programmatic `click()` on a tile: once
+ * ANY overlay is up the tile may be covered, and once the viewer is up the
+ * page is inert by design. The state under test is "a viewer is frontmost",
+ * which is what the guards key on — not the path the user took to get there.
+ */
+
+/**
+ * Long enough for the collection route's j/k pane-follow debounce to land, so
+ * consecutive presses in a test are consecutive presses to the app too.
+ */
+const PANE_FOLLOW_SETTLE_MS = 400;
+
+/**
+ * Assert the collection list's cursor MOVES, without depending on which
+ * direction is available: the focused row can be the last of its group, where
+ * `j` legitimately does nothing. Used for the before and after legs of the
+ * arbitration test, where the claim is "navigation is live", not "j moves down".
+ */
+async function expectCursorMoves(
+	page: Page,
+	focusedCard: () => Promise<string | null>,
+	message: string
+): Promise<void> {
+	const before = await focusedCard();
+	await page.keyboard.press('j');
+	if ((await focusedCard()) === before) {
+		await page.waitForTimeout(PANE_FOLLOW_SETTLE_MS);
+		await page.keyboard.press('k');
+	}
+	await expect.poll(focusedCard, { message }).not.toBe(before);
+}
+
+/** Open a viewer from the first strip tile, past whatever is covering it. */
+async function openViewer(page: Page): Promise<void> {
+	await page
+		.locator(TILE)
+		.first()
+		.evaluate((el) => (el as HTMLElement).click());
+	await expect(page.locator(VIEWER)).toHaveCount(1);
+}
+
+test.describe('attachment viewer — global key & gesture owners (TASK-2436)', () => {
+	test.beforeEach(async ({ page }, testInfo) => {
+		test.skip(
+			testInfo.project.name !== 'desktop-chromium',
+			'viewport is driven explicitly; one project is enough'
+		);
+		await page.setViewportSize(DESKTOP);
+	});
+
+	test('owner 1 — the root app-shell shortcuts all stand down, and all still fire with no viewer', async ({
+		page,
+		fixture,
+		request
+	}) => {
+		// The root shortcuts were entirely unguarded before TASK-2430, and
+		// `isInputFocused()` cannot help: a focused viewer BUTTON is not a text
+		// control, so every one of them used to fire straight through the viewer.
+		// All six are checked, because the guard is one `return` covering all of
+		// them — and a test for only one of them would leave five that a
+		// re-ordering could resurrect.
+		await browserLogin(page);
+		const doc = await seedDoc(fixture, request, 'Owner shortcuts');
+		await uploadAttachment(fixture, request, doc.id, 'shortcuts.png');
+		await page.goto(collectionUrl(fixture, `?item=${encodeURIComponent(doc.slug)}`));
+		await expect(page.locator(`.item-pane ${TILE}`).first()).toBeVisible();
+
+		const state = () =>
+			page.evaluate(() => ({
+				palette: !!document.querySelector('.palette'),
+				shortcutsModal: !!document.querySelector('#keyboard-shortcuts-title'),
+				quickAdd: !!document.querySelector('.quick-add-modal'),
+				detailPanel: localStorage.getItem('pad-detail-panel'),
+				sidebarCollapsed: !!document.querySelector('aside.sidebar.collapsed'),
+				filterBar: !!document.querySelector('.filter-bar'),
+				// Cmd+F's effect once the bar is already open is to FOCUS the
+				// search input. Without this the blocked pass would be asserting
+				// that an already-true boolean stayed true — i.e. nothing.
+				searchFocused: !!document.activeElement?.classList.contains('search-input')
+			}));
+
+		// ── BASELINE: with no viewer, each shortcut does what it always did ──
+		await page.keyboard.press('Control+k');
+		await expect.poll(async () => (await state()).palette).toBe(true);
+		await page.keyboard.press('Escape');
+		await expect.poll(async () => (await state()).palette).toBe(false);
+
+		const detailBefore = (await state()).detailPanel;
+		await page.keyboard.press('Control+]');
+		await expect.poll(async () => (await state()).detailPanel).not.toBe(detailBefore);
+		const detailAfterToggle = (await state()).detailPanel;
+
+		const sidebarBefore = (await state()).sidebarCollapsed;
+		await page.keyboard.press('Control+\\');
+		await expect.poll(async () => (await state()).sidebarCollapsed).toBe(!sidebarBefore);
+		const sidebarAfterToggle = !sidebarBefore;
+
+		await page.keyboard.press('Control+n');
+		await expect.poll(async () => (await state()).quickAdd).toBe(true);
+		await page.keyboard.press('Escape');
+		await expect.poll(async () => (await state()).quickAdd).toBe(false);
+
+		// `?` BEFORE Cmd+F, deliberately: Cmd+F focuses the filter bar's search
+		// INPUT, and `?` is (correctly) ignored while a text control has focus.
+		await page.keyboard.press('?');
+		await expect.poll(async () => (await state()).shortcutsModal).toBe(true);
+		await page.keyboard.press('Escape');
+		await expect.poll(async () => (await state()).shortcutsModal).toBe(false);
+
+		await page.keyboard.press('Control+f');
+		await expect.poll(async () => (await state()).filterBar).toBe(true);
+		await expect.poll(async () => (await state()).searchFocused).toBe(true);
+		// Leave the search input, so the `?` in the blocked pass below is a real
+		// test of the viewer guard rather than of `isInputFocused()`, and so the
+		// Cmd+F assertion below has something to move.
+		await page.evaluate(() => (document.activeElement as HTMLElement | null)?.blur());
+		await expect.poll(async () => (await state()).searchFocused).toBe(false);
+
+		// ── WITH A VIEWER FRONTMOST: nothing moves ──
+		await openViewer(page);
+		const before = await state();
+		for (const key of ['Control+k', 'Control+]', 'Control+\\', 'Control+n', 'Control+f', '?']) {
+			await page.keyboard.press(key);
+		}
+		// Give any of them a chance to land before asserting nothing did.
+		await page.waitForTimeout(300);
+		expect(await state(), 'no root shortcut may act while a viewer is frontmost').toEqual(before);
+		// Sanity: the values asserted-unchanged are the ones the baseline moved,
+		// so "unchanged" is a real claim about six live shortcuts.
+		expect(before.detailPanel).toBe(detailAfterToggle);
+		expect(before.sidebarCollapsed).toBe(sidebarAfterToggle);
+		expect(before.filterBar).toBe(true);
+		expect(
+			before.searchFocused,
+			'Cmd+F re-focuses the search input when the bar is already open — the blocked pass ' +
+				'asserts that it did NOT, which needs it unfocused first'
+		).toBe(false);
+		await expect(page.locator(VIEWER)).toHaveCount(1);
+	});
+
+	test('owner 2 — the collection route stops navigating the list under the viewer, and resumes after', async ({
+		page,
+		fixture,
+		request
+	}) => {
+		// The collection route's keydown handler is the one with TWO halves: the
+		// Escape dispatch (which must NOT be arbitrated, or the viewer becomes
+		// undismissable) and the navigation switch below it (which must be).
+		// This asserts the second half; the first is asserted in
+		// `attachment-viewer-modal.spec.ts` — together they pin the guard between
+		// its two bounds.
+		//
+		// Every reading is taken RELATIVE to the one immediately before it, never
+		// against a value captured earlier in the test. The suite runs fully
+		// parallel against one server, so rows from other specs land in the
+		// shared list and re-sort it — the interference the pre-existing
+		// `pane-a11y-focus` j/k test suffers from. What this test claims is only
+		// "these keys moved the cursor" / "these keys did not", which survives it.
+		await browserLogin(page);
+		const alpha = await seedDoc(fixture, request, 'Owner nav alpha');
+		await seedDoc(fixture, request, 'Owner nav bravo');
+		await uploadAttachment(fixture, request, alpha.id, 'nav.png');
+		await page.goto(collectionUrl(fixture, `?item=${encodeURIComponent(alpha.slug)}`));
+		await expect(page.locator('.item-pane')).toBeVisible();
+		await expect(page.locator(`.item-pane ${TILE}`).first()).toBeVisible();
+
+		const focusedCard = () =>
+			page.evaluate(() => document.querySelector('.item-card.focused')?.textContent?.trim() ?? null);
+
+		await page.locator('.item-card').first().click();
+		await expect.poll(focusedCard).not.toBe(null);
+
+		// BASELINE: the list cursor moves. DIRECTION-AGNOSTIC and one press per
+		// direction — the row the cursor lands on can be the last of its group,
+		// where `j` legitimately does nothing, and the shared list gains rows
+		// from other specs mid-run. The claim is "navigation is live", and the
+		// anti-cancellation property belongs to the BLOCKED loop below, which is
+		// what this test actually turns on.
+		await expectCursorMoves(page, focusedCard, 'baseline: list navigation is live');
+		// The cursor re-targets the pane on a debounce; settle before doing
+		// anything else so this test measures the arbitration guard rather than
+		// the follow debounce.
+		await page.waitForTimeout(PANE_FOLLOW_SETTLE_MS);
+
+		// Back to the row that HAS the attachment: j/k re-target the pane as they
+		// move (that is the behaviour under test), so the cursor has walked the
+		// pane onto a doc with no strip.
+		await page.locator('.item-card', { hasText: 'Owner nav alpha' }).first().click();
+		await expect(page.locator(`.item-pane ${TILE}`).first()).toBeVisible();
+		await page.waitForTimeout(PANE_FOLLOW_SETTLE_MS);
+
+		// WITH A VIEWER: nothing moves, asserted after every individual press.
+		// The reference reading is re-taken each time, so a row arriving from
+		// another spec (the suite is fully parallel and this is the shared list)
+		// cannot be mistaken for a keystroke landing.
+		await openViewer(page);
+		for (const key of ['j', 'j', 'ArrowDown', 'ArrowDown', 'k', 'ArrowUp']) {
+			const before = await focusedCard();
+			await page.keyboard.press(key);
+			expect(await focusedCard(), `${key} must not move the list under the viewer`).toBe(before);
+		}
+
+		// AND IT RESUMES — the guard is a lease, not a latch.
+		await page.keyboard.press('Escape');
+		await expect(page.locator(VIEWER)).toHaveCount(0);
+		// Focus went back to the invoking tile INSIDE the pane; list navigation
+		// belongs to the list, so click back onto a row first, as a user would —
+		// a row OTHER than the one the pane already shows, since re-selecting the
+		// open row re-targets the pane through a null item instead of just moving
+		// the cursor.
+		await page.locator('.item-card', { hasText: 'Owner nav bravo' }).first().click();
+		// Same settle as the baseline: the click re-targets the pane, and a press
+		// arriving mid-traversal is deliberately dropped by the route.
+		await page.waitForTimeout(PANE_FOLLOW_SETTLE_MS);
+
+		await expectCursorMoves(
+			page,
+			focusedCard,
+			'list navigation must be live again once the viewer closes'
+		);
+	});
+
+	test('owner 3 — a DockedSheet keeps its Escape while no viewer is open', async ({
+		page,
+		fixture,
+		request
+	}) => {
+		// EMPTY-STACK REGRESSION for `DockedSheet`. Paired with the
+		// viewer-frontmost case in the next test.
+		await page.setViewportSize(MOBILE);
+		await browserLogin(page);
+		const doc = await seedDoc(fixture, request, 'Owner docked baseline');
+		await uploadAttachment(fixture, request, doc.id, 'docked.png');
+		await page.goto(itemUrl(fixture, doc.slug));
+
+		await page.getByRole('button', { name: /You/ }).first().click();
+		await expect(page.locator('.ds-panel')).toBeVisible();
+		await page.keyboard.press('Escape');
+		await expect(page.locator('.ds-panel')).toHaveCount(0);
+	});
+
+	test('owner 3 — one Escape over a DockedSheet closes the viewer ONLY', async ({
+		page,
+		fixture,
+		request
+	}) => {
+		// ─────────────────────────────────────────────────────────────────────
+		// KNOWN DEFECT (BUG-2441) — this test asserts the CONTRACT and currently
+		// FAILS.
+		// `test.fail()` runs it and requires the failure, so the day the defect
+		// is fixed this file goes red and the annotation has to come off.
+		//
+		// WHAT HAPPENS: one Escape closes BOTH layers. Both the route's escape
+		// driver and `DockedSheet.onKeydown` are `window` keydown listeners, and
+		// Svelte flushes the viewer's teardown SYNCHRONOUSLY inside the driver's
+		// handler — so by the time the sheet's listener runs, in the SAME event,
+		// the lease is already released and `isBlockedByModal(panelEl)` answers
+		// `false`. The guard is correct; the moment it is read is not.
+		//
+		// It is invisible to the unit suite because that suite drives one
+		// component's handler in isolation, so nothing releases a lease
+		// mid-dispatch. It is invisible to a CLICK-driven test too: closing the
+		// same viewer with its Close button leaves the sheet open, which is how
+		// this was isolated. `BottomSheet` has the identical shape (next test).
+		// ─────────────────────────────────────────────────────────────────────
+		// NOTE the PLACEMENT of `test.fail()` below: it is called AFTER setup, not
+		// here. Annotating the whole test would let a login, seed, upload or
+		// navigation failure be reported as the expected BUG-2441 failure.
+		await page.setViewportSize(MOBILE);
+		await browserLogin(page);
+		const doc = await seedDoc(fixture, request, 'Owner docked viewer');
+		await uploadAttachment(fixture, request, doc.id, 'docked.png');
+		await page.goto(itemUrl(fixture, doc.slug));
+
+		await page.getByRole('button', { name: /You/ }).first().click();
+		const sheet = page.locator('.ds-panel');
+		await expect(sheet).toBeVisible();
+
+		await openViewer(page);
+		// The sheet is BEHIND the viewer — inert through its ancestor, since
+		// unlike the viewer it is not body-portaled.
+		expect(
+			await page.evaluate(() => !!document.querySelector('.ds-panel')?.closest('[inert]'))
+		).toBe(true);
+
+		// Setup is complete and verified; from here the assertion is the one
+		// BUG-2441 breaks.
+		test.fail(
+			true,
+			'BUG-2441: the lease is released mid-dispatch, so a later window Escape ' +
+				'listener sees an empty stack and closes a second layer'
+		);
+
+		await page.keyboard.press('Escape');
+		await expect(page.locator(VIEWER)).toHaveCount(0);
+		// SETTLE FIRST. `DockedSheet` leaves on a fly/fade transition, so it is
+		// still in the DOM and still visible for ~200ms after `onclose()` — an
+		// assertion made immediately after the press passes even when the sheet
+		// HAS been closed. This wait is what makes the test able to fail.
+		await page.waitForTimeout(600);
+		await expect(sheet, 'the sheet is a LOWER layer and must survive the press').toBeVisible();
+	});
+
+	test('owner 4 — a BottomSheet keeps Escape and its Tab trap with no viewer', async ({
+		page,
+		fixture,
+		request
+	}) => {
+		// EMPTY-STACK REGRESSION for `BottomSheet`. The strip's own options panel
+		// is a `Menu` with `sheetOnMobile`, i.e. a real `BottomSheet`, so this
+		// uses the surface a user actually meets.
+		await page.setViewportSize(MOBILE);
+		await browserLogin(page);
+		const doc = await seedDoc(fixture, request, 'Owner sheet baseline');
+		await uploadAttachment(fixture, request, doc.id, 'pic.png');
+		await uploadAttachment(
+			fixture,
+			request,
+			doc.id,
+			'notes.txt',
+			'text/plain',
+			Buffer.from('notes\n')
+		);
+		await page.goto(itemUrl(fixture, doc.slug));
+
+		await page.locator(`${TILE}[aria-label*="notes.txt"]`).click();
+		const sheet = page.locator('.bs-sheet');
+		await expect(sheet).toBeVisible();
+		// The trap holds: Tab keeps focus inside the sheet.
+		for (let i = 0; i < 4; i++) {
+			await page.keyboard.press('Tab');
+			expect(
+				await page.evaluate(
+					() => !!document.activeElement?.closest('.bs-sheet')
+				),
+				'with no viewer the sheet still traps Tab'
+			).toBe(true);
+		}
+		await page.keyboard.press('Escape');
+		await expect(sheet).toHaveCount(0);
+	});
+
+	test("owner 4 — a BottomSheet's Tab trap stands down while the viewer is frontmost", async ({
+		page,
+		fixture,
+		request
+	}) => {
+		// The half of `BottomSheet`'s guard that is NOT affected by the release
+		// ordering: `Tab` is not consumed by the escape driver, so the sheet's
+		// handler is the only one that could act — and it must not, or it would
+		// drag focus out of the viewer and into inert chrome.
+		await page.setViewportSize(MOBILE);
+		await browserLogin(page);
+		const doc = await seedDoc(fixture, request, 'Owner sheet tab');
+		await uploadAttachment(fixture, request, doc.id, 'pic.png');
+		await uploadAttachment(
+			fixture,
+			request,
+			doc.id,
+			'notes.txt',
+			'text/plain',
+			Buffer.from('notes\n')
+		);
+		await page.goto(itemUrl(fixture, doc.slug));
+
+		await page.locator(`${TILE}[aria-label*="notes.txt"]`).click();
+		await expect(page.locator('.bs-sheet')).toBeVisible();
+		await page
+			.locator(`${TILE}[aria-label*="pic.png"]`)
+			.evaluate((el) => (el as HTMLElement).click());
+		await expect(page.locator(VIEWER)).toHaveCount(1);
+
+		for (let i = 0; i < 5; i++) {
+			await page.keyboard.press('Tab');
+			expect(await activeInViewer(page), `Tab ${i + 1} took focus out of the viewer`).toBe(true);
+		}
+		// Tab staying put would ALSO be explained by the viewer's own trap over a
+		// sheet that is still fully interactive, so aim focus straight at the
+		// sheet and confirm the browser refuses it.
+		expect(
+			await focusAttemptTakes(page, '.bs-sheet button'),
+			'the sheet behind the viewer must be inert, not merely skipped by the trap'
+		).toBe(false);
+	});
+
+	test('owner 4 — one Escape over a BottomSheet closes the viewer ONLY', async ({
+		page,
+		fixture,
+		request
+	}) => {
+		// ─────────────────────────────────────────────────────────────────────
+		// KNOWN DEFECT (BUG-2441), same shape as owner 3's — recorded separately because
+		// `BottomSheet` and `DockedSheet` are different components with
+		// different guards, and the task specifies this one by name.
+		//
+		// One Escape closes both the viewer and the sheet beneath it. The
+		// sheet's `isBlockedByModal(sheetEl)` guard is correct; it is READ too
+		// late, after the escape driver's handler has already closed the viewer
+		// and Svelte has synchronously released the backdrop lease inside the
+		// SAME event dispatch.
+		// ─────────────────────────────────────────────────────────────────────
+		// `test.fail()` is called after setup — see the DockedSheet test above.
+		await page.setViewportSize(MOBILE);
+		await browserLogin(page);
+		const doc = await seedDoc(fixture, request, 'Owner sheet escape');
+		await uploadAttachment(fixture, request, doc.id, 'pic.png');
+		await uploadAttachment(
+			fixture,
+			request,
+			doc.id,
+			'notes.txt',
+			'text/plain',
+			Buffer.from('notes\n')
+		);
+		await page.goto(itemUrl(fixture, doc.slug));
+
+		await page.locator(`${TILE}[aria-label*="notes.txt"]`).click();
+		const sheet = page.locator('.bs-sheet');
+		await expect(sheet).toBeVisible();
+		await page
+			.locator(`${TILE}[aria-label*="pic.png"]`)
+			.evaluate((el) => (el as HTMLElement).click());
+		await expect(page.locator(VIEWER)).toHaveCount(1);
+
+		test.fail(
+			true,
+			'BUG-2441: the lease is released mid-dispatch, so a later window Escape ' +
+				'listener sees an empty stack and closes a second layer'
+		);
+
+		await page.keyboard.press('Escape');
+		await expect(page.locator(VIEWER)).toHaveCount(0);
+		// Settle past the sheet's leave transition — see owner 3.
+		await page.waitForTimeout(600);
+		await expect(sheet, 'the sheet is a LOWER layer and must survive the press').toBeVisible();
+	});
+
+	test('owner 5 — the TopBar overflow menu keeps Escape with no viewer, and stands down under one', async ({
+		page,
+		fixture,
+		request
+	}) => {
+		// The overflow menu only exists when workspaces do not fit the bar, so
+		// the test manufactures that condition and cleans up after itself.
+		// (Its Up/Down branch is knowingly dead in a browser —
+		// `svelte-dnd-action` rewrites the roles it queries — and TASK-2430
+		// deliberately left it that way, so only Escape is asserted.)
+		// Creation happens INSIDE the try, appending as it goes, so a failure
+		// half-way through still cleans up what was already made.
+		const created: string[] = [];
+		try {
+			for (let i = 0; i < 6; i++) {
+				const resp = await request.post('/api/v1/workspaces', {
+					headers: {
+						Authorization: `Bearer ${fixture.apiToken}`,
+						'Content-Type': 'application/json'
+					},
+					data: { name: `Viewer overflow ${Date.now()}-${i}` }
+				});
+				expect(resp.ok(), await resp.text()).toBe(true);
+				created.push(((await resp.json()) as { slug: string }).slug);
+			}
+			await page.setViewportSize({ width: 900, height: 900 });
+			await browserLogin(page);
+			const doc = await seedDoc(fixture, request, 'Owner overflow');
+			await uploadAttachment(fixture, request, doc.id, 'overflow.png');
+			await page.goto(itemUrl(fixture, doc.slug));
+
+			const trigger = page.locator('[aria-controls="workspace-overflow-menu"]');
+			await expect(trigger).toBeVisible();
+			const menu = page.locator('#workspace-overflow-menu.open');
+
+			// BASELINE: Escape closes the menu.
+			await trigger.click();
+			await expect(menu).toHaveCount(1);
+			await page.keyboard.press('Escape');
+			await expect(menu).toHaveCount(0);
+
+			// WITH A VIEWER: the menu's window handler must not consume the key.
+			//
+			// ORDER MATTERS, and not for a test-convenience reason: TopBar's
+			// outside-CLICK dismisser is deliberately left unguarded (a pointer
+			// dismisser only tears down lower UI), so opening the viewer by
+			// clicking a tile legitimately closes an already-open overflow menu.
+			// The state under test — menu open BEHIND a frontmost viewer — is
+			// therefore reached by opening the menu second.
+			await openViewer(page);
+			await trigger.evaluate((el) => (el as HTMLElement).click());
+			await expect(menu).toHaveCount(1);
+			await page.keyboard.press('Escape');
+			await expect(page.locator(VIEWER)).toHaveCount(0);
+			await page.waitForTimeout(400);
+			await expect(menu, 'the overflow menu is a LOWER layer and must survive').toHaveCount(1);
+		} finally {
+			for (const slug of created) await deleteWorkspace(fixture, request, slug);
+		}
+	});
+
+	test('owner 6 — the sidebar edge swipe: opens with no viewer, declines under one, and a STRADDLING gesture is abandoned', async ({
+		page,
+		fixture,
+		request
+	}) => {
+		// The gesture owners are the ones a keyboard-only suite cannot reach at
+		// all, and the STRADDLE — a swipe that begins before the viewer opens and
+		// continues after — is the case the start gate alone does not cover:
+		// touch events keep going to their original target.
+		//
+		// Touch events are synthesised rather than driven through
+		// `page.touchscreen` because the straddle needs the viewer to open
+		// BETWEEN two moves of one gesture, which the high-level API cannot
+		// express.
+		await page.setViewportSize(MOBILE);
+		await browserLogin(page);
+		const doc = await seedDoc(fixture, request, 'Owner swipe');
+		await uploadAttachment(fixture, request, doc.id, 'swipe.png');
+		await page.goto(itemUrl(fixture, doc.slug));
+		await expect(page.locator(TILE).first()).toBeVisible();
+
+		const installTouch = () =>
+			page.evaluate(() => {
+				(window as any).__touch = (x: number, type: string) => {
+					const t = new Touch({ identifier: 1, target: document.body, clientX: x, clientY: 400 });
+					window.dispatchEvent(
+						new TouchEvent(type, {
+							touches: type === 'touchend' ? [] : [t],
+							targetTouches: [t],
+							changedTouches: [t],
+							bubbles: true,
+							cancelable: true
+						})
+					);
+				};
+			});
+		await installTouch();
+		const swipeOpen = async () => {
+			await page.evaluate(() => {
+				const t = (window as any).__touch;
+				t(5, 'touchstart');
+				t(90, 'touchmove');
+				t(150, 'touchmove');
+				t(150, 'touchend');
+			});
+			await page.waitForTimeout(250);
+		};
+		const sidebarOpen = () =>
+			page.evaluate(() => !document.querySelector('aside.sidebar')?.classList.contains('collapsed'));
+
+		// BASELINE: the edge swipe opens the drawer.
+		expect(await sidebarOpen()).toBe(false);
+		await swipeOpen();
+		expect(await sidebarOpen(), 'baseline: an edge swipe opens the sidebar').toBe(true);
+
+		// Close it again so the next two cases start from the same place.
+		await page.evaluate(() => {
+			document.querySelector<HTMLElement>('.sidebar-backdrop, .mobile-backdrop')?.click();
+		});
+		await page.reload();
+		await expect(page.locator(TILE).first()).toBeVisible();
+		await installTouch();
+		expect(await sidebarOpen()).toBe(false);
+
+		// WITH A VIEWER: the start gate declines.
+		await openViewer(page);
+		await swipeOpen();
+		expect(await sidebarOpen(), 'the edge swipe must not open the sidebar under a viewer').toBe(
+			false
+		);
+		await page.keyboard.press('Escape');
+		await expect(page.locator(VIEWER)).toHaveCount(0);
+
+		// STRADDLE: the gesture BEGINS with no viewer and ends with one.
+		await page.evaluate(() => {
+			const t = (window as any).__touch;
+			t(5, 'touchstart');
+			// SHORT of the open threshold, so the gesture is genuinely still in
+			// flight when the viewer appears — a longer first move would have
+			// opened the sidebar before there was anything to straddle.
+			t(20, 'touchmove');
+		});
+		await openViewer(page);
+		await page.evaluate(() => {
+			const t = (window as any).__touch;
+			t(150, 'touchmove');
+			t(150, 'touchend');
+		});
+		await page.waitForTimeout(250);
+		expect(
+			await sidebarOpen(),
+			'a swipe that straddles the viewer opening must be abandoned, not completed'
+		).toBe(false);
+	});
+
+	test('owner 7 — the co-mounted item graph stops zooming under the viewer, and zooms again after', async ({
+		page,
+		fixture,
+		request
+	}) => {
+		// The graph is the owner that CO-MOUNTS with the viewer: its drawer stays
+		// in the DOM while a viewer opens over it. A user's wheel cannot reach it
+		// then (the viewer covers the screen), so the event is dispatched at the
+		// graph viewport directly — which is exactly the reachability the guard
+		// exists for, and the only way to distinguish "the guard declined" from
+		// "the pointer never got there".
+		await browserLogin(page);
+		const doc = await seedDoc(fixture, request, 'Owner graph');
+		await uploadAttachment(fixture, request, doc.id, 'graph.png');
+		await page.goto(itemUrl(fixture, doc.slug));
+
+		await page.getByRole('button', { name: 'More item actions' }).first().click();
+		await page.getByRole('menuitem', { name: /Dependency graph/ }).click();
+		await expect(page.locator('.graph-drawer .item-graph')).toBeVisible();
+		const scale = () =>
+			page.evaluate(() => {
+				const g = document.querySelector('.graph-drawer svg g');
+				const m = /scale\(([-\d.]+)\)/.exec(g?.getAttribute('transform') ?? '');
+				return m ? Number(m[1]) : null;
+			});
+		// The graph fits itself to the viewport after its data lands, so the
+		// scale moves on its own for a moment. Wait for it to STOP moving —
+		// otherwise the baseline below is a reading of the fit, not of the wheel.
+		await expect
+			.poll(
+				async () => {
+					const a = await scale();
+					await page.waitForTimeout(250);
+					return a !== null && a === (await scale());
+				},
+				{ timeout: 15_000 }
+			)
+			.toBe(true);
+
+		// Dispatched at the graph viewport rather than delivered by the browser:
+		// with the viewer up, a real wheel CANNOT reach the graph (the viewer
+		// covers the screen), so a real-input version of the blocked leg would
+		// pass whether or not the guard exists. Dispatching directly is the only
+		// way to distinguish "the guard declined" from "the pointer never got
+		// there". The baseline below uses real input as well, so the handler is
+		// known to be wired to what a user actually does.
+		const wheel = () =>
+			page.evaluate(() => {
+				const target = document.querySelector<HTMLElement>('.graph-drawer .viewport')!;
+				const rect = target.getBoundingClientRect();
+				target.dispatchEvent(
+					new WheelEvent('wheel', {
+						// ZOOM OUT. The graph fits itself on load and can land on
+						// MAX_SCALE, where a zoom-IN wheel is clamped to a no-op —
+						// which would make the baseline leg unfalsifiable.
+						deltaY: 240,
+						clientX: rect.left + rect.width / 2,
+						clientY: rect.top + rect.height / 2,
+						bubbles: true,
+						cancelable: true
+					})
+				);
+			});
+
+		// BASELINE: a REAL wheel, delivered by the browser to whatever is under
+		// the pointer, zooms. (Only the baseline can use real input — once the
+		// viewer covers the screen no real wheel can reach the graph, which is
+		// the whole point of the guard.)
+		const baseline = await scale();
+		const box = await page.locator('.graph-drawer .viewport').boundingBox();
+		await page.mouse.move(box!.x + box!.width / 2, box!.y + box!.height / 2);
+		await page.mouse.wheel(0, 240);
+		await expect.poll(scale).not.toBe(baseline);
+		const zoomed = await scale();
+
+		// WITH A VIEWER: it does not.
+		await openViewer(page);
+		await wheel();
+		await page.waitForTimeout(250);
+		expect(await scale(), 'the graph must not zoom under the viewer').toBe(zoomed);
+
+		// AND IT RESUMES — through the same dispatched event, so this leg and the
+		// blocked leg above differ ONLY in whether a viewer is up.
+		await page.keyboard.press('Escape');
+		await expect(page.locator(VIEWER)).toHaveCount(0);
+		await wheel();
+		await expect.poll(scale).not.toBe(zoomed);
+	});
+});

--- a/web/e2e/attachment-viewer-owners.spec.ts
+++ b/web/e2e/attachment-viewer-owners.spec.ts
@@ -278,17 +278,20 @@ test.describe('attachment viewer — global key & gesture owners (TASK-2436)', (
 		request
 	}) => {
 		// ─────────────────────────────────────────────────────────────────────
-		// KNOWN DEFECT (BUG-2441) — this test asserts the CONTRACT and currently
-		// FAILS.
-		// `test.fail()` runs it and requires the failure, so the day the defect
-		// is fixed this file goes red and the annotation has to come off.
+		// BUG-2441, FIXED BY TASK-2448 — this asserted the contract and FAILED
+		// until the fix landed; the `test.fail()` annotation is retired with it.
 		//
-		// WHAT HAPPENS: one Escape closes BOTH layers. Both the route's escape
-		// driver and `DockedSheet.onKeydown` are `window` keydown listeners, and
-		// Svelte flushes the viewer's teardown SYNCHRONOUSLY inside the driver's
-		// handler — so by the time the sheet's listener runs, in the SAME event,
-		// the lease is already released and `isBlockedByModal(panelEl)` answers
-		// `false`. The guard is correct; the moment it is read is not.
+		// WHAT USED TO HAPPEN: one Escape closed BOTH layers. Both the route's
+		// escape driver and `DockedSheet.onKeydown` are `window` keydown
+		// listeners, and Svelte flushes the viewer's teardown SYNCHRONOUSLY inside
+		// the driver's handler — so by the time the sheet's listener ran, in the
+		// SAME event, the lease was already released and `isBlockedByModal(panelEl)`
+		// answered `false`. The guard was correct; the moment it was read was not.
+		//
+		// WHAT FIXES IT: the viewer marks the EVENT it consumed
+		// (`noteEscapeConsumedByViewer`), and the sheet passes that event to
+		// `isBlockedByModal` — so the mark outlives the lease and this listener
+		// stands down. Remove either half and this test fails again.
 		//
 		// It is invisible to the unit suite because that suite drives one
 		// component's handler in isolation, so nothing releases a lease
@@ -296,9 +299,6 @@ test.describe('attachment viewer — global key & gesture owners (TASK-2436)', (
 		// same viewer with its Close button leaves the sheet open, which is how
 		// this was isolated. `BottomSheet` has the identical shape (next test).
 		// ─────────────────────────────────────────────────────────────────────
-		// NOTE the PLACEMENT of `test.fail()` below: it is called AFTER setup, not
-		// here. Annotating the whole test would let a login, seed, upload or
-		// navigation failure be reported as the expected BUG-2441 failure.
 		await page.setViewportSize(MOBILE);
 		await browserLogin(page);
 		const doc = await seedDoc(fixture, request, 'Owner docked viewer');
@@ -317,13 +317,7 @@ test.describe('attachment viewer — global key & gesture owners (TASK-2436)', (
 		).toBe(true);
 
 		// Setup is complete and verified; from here the assertion is the one
-		// BUG-2441 breaks.
-		test.fail(
-			true,
-			'BUG-2441: the lease is released mid-dispatch, so a later window Escape ' +
-				'listener sees an empty stack and closes a second layer'
-		);
-
+		// BUG-2441 used to break.
 		await page.keyboard.press('Escape');
 		await expect(page.locator(VIEWER)).toHaveCount(0);
 		// SETTLE FIRST. `DockedSheet` leaves on a fly/fade transition, so it is
@@ -332,6 +326,12 @@ test.describe('attachment viewer — global key & gesture owners (TASK-2436)', (
 		// HAS been closed. This wait is what makes the test able to fail.
 		await page.waitForTimeout(600);
 		await expect(sheet, 'the sheet is a LOWER layer and must survive the press').toBeVisible();
+
+		// ...and the SECOND press closes it: "one Escape closes one layer" is a
+		// claim about ordering, not about the sheet having gone deaf. Without this
+		// the fix could pass by permanently disabling the sheet's Escape.
+		await page.keyboard.press('Escape');
+		await expect(sheet).toHaveCount(0);
 	});
 
 	test('owner 4 — a BottomSheet keeps Escape and its Tab trap with no viewer', async ({
@@ -422,17 +422,17 @@ test.describe('attachment viewer — global key & gesture owners (TASK-2436)', (
 		request
 	}) => {
 		// ─────────────────────────────────────────────────────────────────────
-		// KNOWN DEFECT (BUG-2441), same shape as owner 3's — recorded separately because
-		// `BottomSheet` and `DockedSheet` are different components with
-		// different guards, and the task specifies this one by name.
+		// BUG-2441, FIXED BY TASK-2448 — same shape as owner 3's, kept separate
+		// because `BottomSheet` and `DockedSheet` are different components with
+		// different guards, and the bug specifies this one by name.
 		//
-		// One Escape closes both the viewer and the sheet beneath it. The
-		// sheet's `isBlockedByModal(sheetEl)` guard is correct; it is READ too
-		// late, after the escape driver's handler has already closed the viewer
-		// and Svelte has synchronously released the backdrop lease inside the
-		// SAME event dispatch.
+		// One Escape used to close both the viewer and the sheet beneath it. The
+		// sheet's `isBlockedByModal(sheetEl)` guard was correct; it was READ too
+		// late, after the escape driver's handler had already closed the viewer
+		// and Svelte had synchronously released the backdrop lease inside the
+		// SAME event dispatch. The guard now takes the EVENT as well, and the
+		// viewer marks the event it consumed before closing.
 		// ─────────────────────────────────────────────────────────────────────
-		// `test.fail()` is called after setup — see the DockedSheet test above.
 		await page.setViewportSize(MOBILE);
 		await browserLogin(page);
 		const doc = await seedDoc(fixture, request, 'Owner sheet escape');
@@ -455,17 +455,16 @@ test.describe('attachment viewer — global key & gesture owners (TASK-2436)', (
 			.evaluate((el) => (el as HTMLElement).click());
 		await expect(page.locator(VIEWER)).toHaveCount(1);
 
-		test.fail(
-			true,
-			'BUG-2441: the lease is released mid-dispatch, so a later window Escape ' +
-				'listener sees an empty stack and closes a second layer'
-		);
-
 		await page.keyboard.press('Escape');
 		await expect(page.locator(VIEWER)).toHaveCount(0);
 		// Settle past the sheet's leave transition — see owner 3.
 		await page.waitForTimeout(600);
 		await expect(sheet, 'the sheet is a LOWER layer and must survive the press').toBeVisible();
+
+		// A SECOND press closes it — the sheet keeps its Escape, it just doesn't
+		// get to spend the viewer's one (see owner 3).
+		await page.keyboard.press('Escape');
+		await expect(sheet).toHaveCount(0);
 	});
 
 	test('owner 5 — the TopBar overflow menu keeps Escape with no viewer, and stands down under one', async ({

--- a/web/e2e/attachment-viewer-parity.spec.ts
+++ b/web/e2e/attachment-viewer-parity.spec.ts
@@ -1,0 +1,589 @@
+import { test, expect } from './fixtures';
+import type { APIRequestContext, Page } from '@playwright/test';
+import { browserLogin, seedDoc } from './lib/collab-helpers';
+import {
+	DESKTOP,
+	REAL_PNG,
+	TILE,
+	VIEWER,
+	VIEWER_COUNTER,
+	VIEWER_IMAGE,
+	authJson,
+	createCollection,
+	createItem,
+	deleteCollection,
+	deleteWorkspace,
+	dropFileIntoEditor,
+	itemUrl,
+	postComment,
+	uploadAttachment,
+	viewerClose,
+	viewerNext,
+	viewerPrev
+} from './lib/attachment-viewer';
+
+/**
+ * FOUR-SURFACE PARITY + ACTIVATION + HOSTILE NAMES (TASK-2436).
+ *
+ * "Behaves as before" is the claim phase 3a makes about every surface it
+ * touched, and it is not falsifiable without a finite matrix. This file is
+ * that matrix: four producers × {open, ←/→, Escape, backdrop click, close},
+ * plus the keyboard activation TASK-2432 introduced and the accessible names
+ * TASK-2429/2431/2433 introduced.
+ *
+ * The four producers are genuinely different code paths, which is why one of
+ * them passing says nothing about the others:
+ *
+ *   1. STRIP — `ItemAttachmentStrip` mounts `Lightbox` directly.
+ *   2. TIMELINE — `ItemTimeline` mounts `Lightbox` directly, from a DELEGATED
+ *      click/keydown on imperatively-annotated `{@html}` thumbnails.
+ *   3. ITEM BODY — the editor's `attachment-image` NodeView emits on the
+ *      open-viewer BUS; `AttachmentViewerHost` is what mounts the viewer.
+ *   4. COMMENT EDITOR — the same NodeView inside a live `CommentEditor`,
+ *      nested INSIDE the timeline's delegation scope, which is the collision
+ *      the NodeView's unconditional `stopPropagation` exists to prevent.
+ *
+ * Producers 3 and 4 emit a SINGLE-image set by design ("this NodeView knows
+ * about ITS node and nothing else"), so their ←/→ cell is "no nav controls,
+ * arrows are no-ops" — asserted rather than skipped, since a future producer
+ * quietly assembling a set here would change what ←/→ pages through.
+ */
+
+const INLINE_IMG = '.editor-content .ProseMirror img[data-attachment-id]';
+const COMMENT_EDITOR = '.comment-editor .ProseMirror';
+
+/**
+ * The timeline (and with it the comment composer) lives under the item's
+ * ACTIVITY tab; on the Details tab it is mounted but has no box at all, so
+ * every locator inside it is "not visible". Two of the four surfaces live
+ * here, which is itself part of what makes them different code paths.
+ */
+async function openActivityTab(page: Page): Promise<void> {
+	await page.getByRole('tab', { name: 'Activity' }).click();
+	await expect(page.locator('.timeline')).toBeVisible();
+}
+
+/** open → ←/→ → Escape → reopen → backdrop click → reopen → Close button. */
+async function runParityMatrix(
+	page: Page,
+	open: () => Promise<void>,
+	opts: { multiple: boolean }
+): Promise<void> {
+	// OPEN
+	await open();
+	await expect(page.locator(VIEWER)).toHaveCount(1);
+	await expect(page.locator(VIEWER_IMAGE)).toBeVisible();
+
+	// ←/→
+	if (opts.multiple) {
+		await expect(page.locator(VIEWER_COUNTER)).toHaveText('1 / 2');
+		await page.keyboard.press('ArrowRight');
+		await expect(page.locator(VIEWER_COUNTER)).toHaveText('2 / 2');
+		await page.keyboard.press('ArrowLeft');
+		await expect(page.locator(VIEWER_COUNTER)).toHaveText('1 / 2');
+		// The same two steps through the CONTROLS, addressed by their accessible
+		// names — the keys and the buttons must not drift apart.
+		await viewerNext(page).click();
+		await expect(page.locator(VIEWER_COUNTER)).toHaveText('2 / 2');
+		await viewerPrev(page).click();
+		await expect(page.locator(VIEWER_COUNTER)).toHaveText('1 / 2');
+	} else {
+		await expect(page.locator(VIEWER_COUNTER)).toHaveCount(0);
+		await expect(viewerNext(page)).toHaveCount(0);
+		await expect(viewerPrev(page)).toHaveCount(0);
+		const src = await page.locator(VIEWER_IMAGE).getAttribute('src');
+		await page.keyboard.press('ArrowRight');
+		await page.keyboard.press('ArrowLeft');
+		await expect(page.locator(VIEWER_IMAGE)).toHaveAttribute('src', src!);
+		await expect(page.locator(VIEWER)).toHaveCount(1);
+	}
+
+	// ESCAPE
+	await page.keyboard.press('Escape');
+	await expect(page.locator(VIEWER)).toHaveCount(0);
+
+	// BACKDROP CLICK — the backdrop itself, not the image (which must NOT close).
+	await open();
+	await expect(page.locator(VIEWER)).toHaveCount(1);
+	await page.locator(VIEWER_IMAGE).click();
+	await expect(page.locator(VIEWER), 'clicking the image must not dismiss').toHaveCount(1);
+	await page.locator(VIEWER).click({ position: { x: 4, y: 4 } });
+	await expect(page.locator(VIEWER)).toHaveCount(0);
+
+	// CLOSE BUTTON
+	await open();
+	await expect(page.locator(VIEWER)).toHaveCount(1);
+	await viewerClose(page).click();
+	await expect(page.locator(VIEWER)).toHaveCount(0);
+}
+
+test.describe('attachment viewer — four-surface parity (TASK-2436)', () => {
+	test.beforeEach(async ({ page }, testInfo) => {
+		test.skip(
+			testInfo.project.name !== 'desktop-chromium',
+			'viewport is driven explicitly; one project is enough'
+		);
+		await page.setViewportSize(DESKTOP);
+	});
+
+	test('surface 1 — the attachment strip', async ({ page, fixture, request }) => {
+		await browserLogin(page);
+		const doc = await seedDoc(fixture, request, 'Parity strip');
+		await uploadAttachment(fixture, request, doc.id, 'strip-a.png');
+		await uploadAttachment(fixture, request, doc.id, 'strip-b.png');
+		await page.goto(itemUrl(fixture, doc.slug));
+		await expect(page.locator(TILE)).toHaveCount(2);
+
+		await runParityMatrix(
+			page,
+			async () => {
+				await page.locator(`${TILE}[aria-label*="strip-a.png"]`).click();
+			},
+			{ multiple: true }
+		);
+	});
+
+	test('surface 2 — a saved comment in the timeline', async ({ page, fixture, request }) => {
+		await browserLogin(page);
+		const doc = await seedDoc(fixture, request, 'Parity timeline');
+		const one = await uploadAttachment(fixture, request, doc.id, 'tl-a.png');
+		const two = await uploadAttachment(fixture, request, doc.id, 'tl-b.png');
+		await postComment(
+			fixture,
+			request,
+			doc.slug,
+			`two shots\n\n![first](pad-attachment:${one})\n\n![second](pad-attachment:${two})\n`
+		);
+		await page.goto(itemUrl(fixture, doc.slug));
+		await openActivityTab(page);
+
+		const thumbs = page.locator('.timeline img[data-attachment-id]');
+		await expect(thumbs).toHaveCount(2);
+		// The imperative semantics pass is what makes these keyboard-reachable
+		// controls at all — `{@html}` cannot wrap them in a <button>.
+		await expect(thumbs.first()).toHaveAttribute('role', 'button');
+		await expect(thumbs.first()).toHaveAttribute('aria-label', 'View image: first');
+
+		await runParityMatrix(
+			page,
+			async () => {
+				await thumbs.first().click();
+			},
+			{ multiple: true }
+		);
+	});
+
+	test('surface 3 — an inline image in the item body', async ({ page, fixture, request }) => {
+		await browserLogin(page);
+		const doc = await seedDoc(fixture, request, 'Parity body');
+		await page.goto(itemUrl(fixture, doc.slug));
+		await dropFileIntoEditor(page, 'body-a.png', REAL_PNG.toString('base64'));
+		await expect(page.locator(INLINE_IMG)).toHaveCount(1);
+		await expect(page.locator(INLINE_IMG).first()).toHaveAttribute('role', 'button');
+
+		await runParityMatrix(
+			page,
+			async () => {
+				await page.locator(INLINE_IMG).first().click();
+			},
+			{ multiple: false }
+		);
+	});
+
+	test('surface 4 — a draft image inside the comment editor', async ({ page, fixture, request }) => {
+		// The nested case: this NodeView lives INSIDE `ItemTimeline`'s delegation
+		// scope, so without the NodeView's unconditional `stopPropagation` one
+		// activation would open TWO viewers. `toHaveCount(1)` in the matrix is
+		// what catches that, and only a real browser dispatches through both.
+		await browserLogin(page);
+		const doc = await seedDoc(fixture, request, 'Parity comment editor');
+		await page.goto(itemUrl(fixture, doc.slug));
+		await openActivityTab(page);
+
+		await page.locator(COMMENT_EDITOR).first().click();
+		await dropFileIntoEditor(page, 'draft-a.png', REAL_PNG.toString('base64'), 'image/png', COMMENT_EDITOR);
+		const draftImg = page.locator(`${COMMENT_EDITOR} img[data-attachment-id]`);
+		await expect(draftImg).toHaveCount(1);
+
+		await runParityMatrix(
+			page,
+			async () => {
+				await draftImg.first().click();
+			},
+			{ multiple: false }
+		);
+	});
+
+	test('Enter and Space open an inline image; a MODIFIED Enter is the comment editor\'s submit', async ({
+		page,
+		fixture,
+		request
+	}) => {
+		// TASK-2432 made inline images keyboard-activatable, and the guard that
+		// lets a MODIFIED Enter through is the difference between "Cmd+Enter posts
+		// the comment" and "Cmd+Enter opens a viewer and the comment is lost".
+		// jsdom cannot prove either half: it does not synthesise activation, and
+		// the ProseMirror keymap needs a real focused editor.
+		await browserLogin(page);
+		const doc = await seedDoc(fixture, request, 'Parity keys');
+		await page.goto(itemUrl(fixture, doc.slug));
+		await dropFileIntoEditor(page, 'key-a.png', REAL_PNG.toString('base64'));
+		const img = page.locator(INLINE_IMG).first();
+		await expect(img).toBeVisible();
+
+		for (const key of ['Enter', ' ']) {
+			await img.focus();
+			await expect(img).toBeFocused();
+			await page.keyboard.press(key);
+			// EXACTLY ONE viewer per press — two would mean a hand-rolled handler
+			// racing something else, which is the shape the timeline delegation
+			// would produce without the NodeView's `stopPropagation`.
+			await expect(page.locator(VIEWER), `${key} must open exactly one viewer`).toHaveCount(1);
+			await page.keyboard.press('Escape');
+			await expect(page.locator(VIEWER)).toHaveCount(0);
+			await expect(img, 'focus returns to the image it was activated from').toBeFocused();
+		}
+
+		// A HELD key repeats, and every repeat is another keydown — the NodeView
+		// bails on `event.repeat` so one gesture is one viewer. `keyboard.down()`
+		// does NOT auto-repeat (it sends a single keydown), so the repeats are
+		// dispatched explicitly with the flag the handler reads.
+		await img.focus();
+		await page.keyboard.press('Enter');
+		await expect(page.locator(VIEWER)).toHaveCount(1);
+		// Stamp the mounted viewer so a SECOND activation is detectable. Counting
+		// viewers is not enough on its own: a repeat that re-activated would tear
+		// the first instance down and mount a new one, leaving the count at 1.
+		// The host remounts per open (`{#key request}`), so a surviving stamp is
+		// proof that no second activation happened.
+		await page.evaluate(() => {
+			(document.querySelector('.attachment-viewer') as HTMLElement & { __stamp?: number }).__stamp = 7;
+		});
+		// One dispatch per task, so nothing can be coalesced into a single event.
+		for (let i = 0; i < 3; i++) {
+			await page.evaluate(() => {
+				const el = document.querySelector<HTMLElement>(
+					'.editor-content .ProseMirror img[data-attachment-id]'
+				)!;
+				el.dispatchEvent(
+					new KeyboardEvent('keydown', { key: 'Enter', repeat: true, bubbles: true, cancelable: true })
+				);
+			});
+			await page.waitForTimeout(100);
+		}
+		await expect(page.locator(VIEWER)).toHaveCount(1);
+		expect(
+			await page.evaluate(
+				() =>
+					(document.querySelector('.attachment-viewer') as HTMLElement & { __stamp?: number })
+						?.__stamp === 7
+			),
+			'a HELD Enter is ONE activation: the viewer must be the SAME instance, not a remount'
+		).toBe(true);
+		await page.keyboard.press('Escape');
+		await expect(page.locator(VIEWER)).toHaveCount(0);
+
+		// ── The modified-key case, in the surface that owns the shortcut ──
+		await openActivityTab(page);
+		await page.locator(COMMENT_EDITOR).first().click();
+		await dropFileIntoEditor(
+			page,
+			'key-b.png',
+			REAL_PNG.toString('base64'),
+			'image/png',
+			COMMENT_EDITOR
+		);
+		const draftImg = page.locator(`${COMMENT_EDITOR} img[data-attachment-id]`).first();
+		await expect(draftImg).toBeVisible();
+		await draftImg.focus();
+		await page.keyboard.press('Control+Enter');
+		// The comment POSTS (it appears in the timeline) and no viewer opens.
+		await expect(page.locator(VIEWER), 'Cmd/Ctrl+Enter is SUBMIT, not activation').toHaveCount(0);
+		await expect(page.locator('.timeline img[data-attachment-id]')).toHaveCount(1);
+	});
+
+	test('hostile and RTL accessible names survive, and the viewer stays inside the viewport under RTL', async ({
+		page,
+		fixture,
+		request
+	}) => {
+		// The names 3a INTRODUCES are built from user-controlled filenames: the
+		// dialog's own `aria-label` and the strip tile's "View <name>". A long or
+		// bidi-control-bearing name must still produce an addressable control and
+		// a dialog that names itself — not an empty name, not a truncated one,
+		// and not a layout that pushes the page sideways.
+		const longName = `${'long-'.repeat(30)}name.png`;
+		const bidiName = 'start ‮reversed‬ مرحبا.png';
+
+		await browserLogin(page);
+		const doc = await seedDoc(fixture, request, 'Parity hostile names');
+		await uploadAttachment(fixture, request, doc.id, longName);
+		await uploadAttachment(fixture, request, doc.id, bidiName);
+		await page.goto(itemUrl(fixture, doc.slug));
+		await expect(page.locator(TILE)).toHaveCount(2);
+
+		for (const name of [longName, bidiName]) {
+			// Addressable BY NAME — the accessible name is the whole filename,
+			// exactly as stored.
+			// ANCHORED at BOTH ends of the filename: on the action verb (the
+			// tile's delete control carries the same filename, so an unanchored
+			// name matches two controls) and on the comma that follows it in the
+			// label, so a truncated or mangled name cannot satisfy the match.
+			const tile = page.getByRole('button', { name: new RegExp(`^View ${escapeRe(name)},`) });
+			await expect(tile).toHaveCount(1);
+			await tile.click();
+			// EXACT: the dialog's whole accessible name is the filename.
+			await expect(page.getByRole('dialog', { name, exact: true })).toHaveCount(1);
+			await page.keyboard.press('Escape');
+			await expect(page.locator(VIEWER)).toHaveCount(0);
+		}
+
+		// RTL: the viewer is positioned with `inset` (direction-agnostic), so it
+		// must still cover exactly the viewport and must not introduce a
+		// horizontal overflow — the failure a physical `left`/`right` pair would
+		// produce if the layout depended on it.
+		await page.evaluate(() => document.documentElement.setAttribute('dir', 'rtl'));
+		await page.getByRole('button', { name: new RegExp(`^View ${escapeRe(bidiName)},`) }).click();
+		await expect(page.locator(VIEWER)).toHaveCount(1);
+		const rtl = await page.evaluate(() => {
+			const el = document.querySelector<HTMLElement>('.attachment-viewer')!;
+			const rect = el.getBoundingClientRect();
+			const close = el.querySelector<HTMLElement>('.lightbox-close')!.getBoundingClientRect();
+			return {
+				rect: { x: rect.x, y: rect.y, width: rect.width, height: rect.height },
+				viewport: { width: window.innerWidth, height: window.innerHeight },
+				closeInside:
+					close.left >= 0 &&
+					close.top >= 0 &&
+					close.right <= window.innerWidth &&
+					close.bottom <= window.innerHeight,
+				overflows: document.documentElement.scrollWidth > window.innerWidth
+			};
+		});
+		expect(rtl.rect).toEqual({
+			x: 0,
+			y: 0,
+			width: rtl.viewport.width,
+			height: rtl.viewport.height
+		});
+		expect(rtl.closeInside, 'the close control must stay on screen under RTL').toBe(true);
+		expect(rtl.overflows, 'the viewer must not push the page sideways under RTL').toBe(false);
+		await page.evaluate(() => document.documentElement.setAttribute('dir', 'ltr'));
+	});
+
+	test('the viewer closes on a CLIENT-SIDE resource switch, with the document still mounted', async ({
+		page,
+		fixture,
+		request
+	}) => {
+		// `AttachmentViewerHost`'s lifecycle rule, and the reason this is driven
+		// through the PANE rather than `page.goto()`: a full navigation unloads
+		// the document, so the viewer would vanish whatever the host did — the
+		// assertion would be about the browser, not about the rule. The pane
+		// switches the loaded item with the host still mounted, which is the only
+		// place `itemId` / `resourceGen` actually transition.
+		//
+		// The CONTROL that keeps "the viewer closed" from being satisfied by a
+		// host that closes on anything is the separate same-resource refresh test
+		// below. A same-item RE-SELECT is deliberately not used for it: it also
+		// closes the viewer today (the pane re-targets through a null `itemId`,
+		// and the host's documented rule counts a change to null as the start of
+		// a switch), so it says nothing either way.
+		await browserLogin(page);
+		const a = await seedDoc(fixture, request, 'Lifecycle alpha');
+		const b = await seedDoc(fixture, request, 'Lifecycle bravo');
+		await uploadAttachment(fixture, request, a.id, 'life-a.png');
+		await uploadAttachment(fixture, request, b.id, 'life-b.png');
+
+		await page.goto(
+			`/${fixture.adminUsername}/${fixture.workspaceSlug}/docs?item=${encodeURIComponent(a.slug)}`
+		);
+		await expect(page.locator('.item-pane')).toBeVisible();
+		await expect(page.locator(`.item-pane ${TILE}`).first()).toBeVisible();
+		// Stamp the document AND the pane's own element: a reload would clear the
+		// first, and a host remount (which would make the viewer disappear for a
+		// reason that has nothing to do with the lifecycle rule) would replace
+		// the second.
+		await page.evaluate(() => {
+			(window as unknown as { __spa?: number }).__spa = 1;
+			(document.querySelector('.item-pane') as HTMLElement & { __pane?: number }).__pane = 2;
+		});
+
+		const openFromPane = async () => {
+			await page
+				.locator(`.item-pane ${TILE}`)
+				.first()
+				.evaluate((el) => (el as HTMLElement).click());
+			await expect(page.locator(VIEWER)).toHaveCount(1);
+		};
+		const stillSameDocument = () =>
+			page.evaluate(() => (window as unknown as { __spa?: number }).__spa === 1);
+		// The card click has to be programmatic: the open viewer has (correctly)
+		// made the list inert, which is the state under test.
+		const selectCard = async (title: string) => {
+			await page
+				.locator('.item-card', { hasText: title })
+				.first()
+				.evaluate((el) => (el as HTMLElement).click());
+		};
+
+		await openFromPane();
+		await expect(page.getByRole('dialog', { name: 'life-a.png' })).toHaveCount(1);
+
+		// A → B, client-side: the resource under the host changed, so it closes.
+		await selectCard('Lifecycle bravo');
+		await expect(page.locator(VIEWER)).toHaveCount(0);
+		expect(await stillSameDocument(), 'the switch must not have been a page load').toBe(true);
+		expect(
+			await page.evaluate(
+				() => (document.querySelector('.item-pane') as HTMLElement & { __pane?: number })?.__pane === 2
+			),
+			'the pane (and with it the viewer host) must have SURVIVED the switch — a remount ' +
+				'would remove the viewer for a reason unrelated to the lifecycle rule'
+		).toBe(true);
+		await expect(page.locator('.item-pane')).toContainText('Lifecycle bravo');
+	});
+
+	test('a client-side WORKSPACE switch closes the viewer', async ({ page, fixture, request }) => {
+		// The other half of "resource switch": the host addresses by item UUID,
+		// and the viewer's URLs are built from a workspace slug captured at open,
+		// so a viewer left standing across a workspace change would be pointing
+		// at another workspace's endpoint.
+		//
+		// The TopBar's workspace entries are real `<a href>`s, so this is a
+		// SvelteKit client-side navigation — the document survives, which is what
+		// makes the assertion about the host rather than about unloading.
+		const headers = authJson(fixture);
+		const resp = await request.post('/api/v1/workspaces', {
+			headers,
+			data: { name: `Viewer ws switch ${Date.now()}` }
+		});
+		expect(resp.ok(), await resp.text()).toBe(true);
+		const other = (await resp.json()) as { slug: string };
+		try {
+			await browserLogin(page);
+			const doc = await seedDoc(fixture, request, 'Lifecycle ws');
+			await uploadAttachment(fixture, request, doc.id, 'life-ws.png');
+			await page.goto(itemUrl(fixture, doc.slug));
+			const link = page.locator(`a[href$="/${other.slug}"]`).first();
+			await expect(link).toHaveCount(1);
+
+			await page.locator(TILE).first().click();
+			await expect(page.locator(VIEWER)).toHaveCount(1);
+			await page.evaluate(() => ((window as unknown as { __spa?: number }).__spa = 1));
+
+			await link.evaluate((el) => (el as HTMLElement).click());
+			await expect(page).toHaveURL(new RegExp(`/${other.slug}(/|$)`));
+			await expect(page.locator(VIEWER)).toHaveCount(0);
+			expect(
+				await page.evaluate(() => (window as unknown as { __spa?: number }).__spa === 1),
+				'this must be a client-side navigation, or the assertion is about unloading'
+			).toBe(true);
+		} finally {
+			await deleteWorkspace(fixture, request, other.slug);
+		}
+	});
+
+	test('a same-resource REFRESH under the viewer leaves it open', async ({
+		page,
+		fixture,
+		request
+	}) => {
+		// Lifecycle rule, half two — and the mutation it exists to catch is
+		// specific: keying the host on `ItemDetail`'s `loadGeneration` (bumped by
+		// EVERY `loadData()`) instead of on `resourceGen` passes every unit test
+		// and tears the viewer down whenever something reloads the item under it.
+		//
+		// The trigger is a real one: another session edits the COLLECTION, which
+		// broadcasts `collection_updated` and makes this page re-read its schema
+		// for the SAME item. A dedicated collection is created for it so the
+		// broadcast cannot disturb specs running in parallel.
+		const ws = fixture.workspaceSlug;
+		const coll = await createCollection(fixture, request, `Viewer refresh probe ${Date.now()}`);
+		try {
+			const item = await createItem(fixture, request, coll.slug, 'Refresh under viewer');
+			await uploadAttachment(fixture, request, item.id, 'refresh.png');
+
+			await browserLogin(page);
+			await page.goto(`/${fixture.adminUsername}/${ws}/${coll.slug}/${item.slug}`);
+			await page.locator(TILE).first().click();
+			await expect(page.locator(VIEWER)).toHaveCount(1);
+
+			await request.patch(`/api/v1/workspaces/${ws}/collections/${coll.slug}`, {
+				headers: authJson(fixture),
+				data: { icon: '🧪' }
+			});
+			// Wait for the refresh to actually ARRIVE — otherwise "still open" is a
+			// statement about a reload that never happened.
+			// Scoped to the ITEM PAGE's own breadcrumb — that link renders from this
+			// page's `collection` snapshot, so the new icon appearing there is the
+			// same-item reload actually landing. `body` would also match the icon
+			// turning up anywhere else on the page.
+			await expect(page.locator('nav.breadcrumb')).toContainText('🧪');
+			await expect(
+				page.locator(VIEWER),
+				'a same-resource reload must not tear the viewer down'
+			).toHaveCount(1);
+			// Still a working viewer, not a stranded husk.
+			await page.keyboard.press('Escape');
+			await expect(page.locator(VIEWER)).toHaveCount(0);
+		} finally {
+			await deleteCollection(fixture, request, coll.slug);
+		}
+	});
+
+	test('a viewer opened in one host does not also open in the other (two-host isolation)', async ({
+		page,
+		fixture,
+		request
+	}) => {
+		// Two `ItemDetail` mounts co-exist at runtime — the master and the pane —
+		// and each mounts its own `AttachmentViewerHost` with its own token. The
+		// addressing rule is the load-bearing half of DR-8, and with both hosts
+		// listening on ONE module-global bus a token mix-up opens the viewer in
+		// both. Only a real page has two real hosts minting two real tokens.
+		await browserLogin(page);
+		const master = await seedDoc(fixture, request, 'Isolation master');
+		const other = await seedDoc(fixture, request, 'Isolation pane');
+		await page.goto(itemUrl(fixture, master.slug));
+		await dropFileIntoEditor(page, 'master-inline.png', REAL_PNG.toString('base64'));
+		await expect(page.locator(INLINE_IMG)).toHaveCount(1);
+
+		// Open the pane beside the master: two hosts, one page.
+		await page.goto(`${itemUrl(fixture, master.slug)}?item=${encodeURIComponent(other.slug)}`);
+		await expect(page.locator('.item-pane')).toBeVisible();
+		const masterImg = page.locator(`.item-page-host ${INLINE_IMG}`).first();
+		await expect(masterImg).toBeVisible();
+
+		await masterImg.evaluate((el) => (el as HTMLElement).click());
+		// EXACTLY ONE viewer — a broken token would mount one per host — and it
+		// is named for the image that opened it. An `|Attachment viewer` fallback
+		// here would let an unnamed viewer satisfy the assertion.
+		await expect(page.locator(VIEWER)).toHaveCount(1);
+		await expect(
+			page.getByRole('dialog', { name: 'master-inline.png', exact: true })
+		).toHaveCount(1);
+	});
+});
+
+/** Upload bound to an item in an ARBITRARY workspace (the lifecycle test). */
+async function uploadAttachmentTo(
+	fixture: { apiToken: string },
+	request: APIRequestContext,
+	ws: string,
+	itemId: string,
+	filename: string
+): Promise<void> {
+	const resp = await request.post(
+		`/api/v1/workspaces/${ws}/attachments?item_id=${encodeURIComponent(itemId)}`,
+		{
+			headers: { Authorization: `Bearer ${fixture.apiToken}` },
+			multipart: { file: { name: filename, mimeType: 'image/png', buffer: REAL_PNG } }
+		}
+	);
+	if (!resp.ok()) throw new Error(`upload failed (${resp.status()}): ${await resp.text()}`);
+}
+
+function escapeRe(s: string): string {
+	return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/web/e2e/lib/attachment-viewer.ts
+++ b/web/e2e/lib/attachment-viewer.ts
@@ -1,0 +1,404 @@
+import { expect, type APIRequestContext, type Page } from '@playwright/test';
+import { crc32, deflateSync } from 'node:zlib';
+import type { SuiteFixture } from '../fixtures';
+
+/**
+ * Shared scaffolding for the attachment-viewer browser suite (TASK-2436).
+ *
+ * Lives here rather than in a spec because THREE specs address the same
+ * surfaces (`attachment-viewer-modal`, `-owners`, `-parity`) and a
+ * selector that drifts between them would silently retarget one of them.
+ *
+ * SELECTOR RULE, load-bearing: never a bare `[role="dialog"]`. The viewer,
+ * the detail pane, `BottomSheet` and `DockedSheet` are ALL `role="dialog"`
+ * now, so a bare locator matches whichever mounted last. Every locator here
+ * is either class-qualified or addressed by accessible NAME.
+ */
+
+/**
+ * A real, decodable 200x150 PNG — deliberately NOT the 1x1 fixture the older
+ * attachment specs share.
+ *
+ * TWO reasons, both of which cost a debugging round to find:
+ *
+ *  • That fixture carries a BAD IDAT checksum. The server accepts it, but
+ *    thumbnail decoding logs `decode png: invalid checksum` and skips, so the
+ *    rendered `<img>` has no intrinsic size. A zero-box element is "not
+ *    visible" to Playwright and cannot be clicked — which is exactly what an
+ *    inline attachment in a comment body then is.
+ *  • It has to be BIG. The editor's own image toolbar is absolutely positioned
+ *    at the image's top-right, so a thumbnail smaller than the toolbar
+ *    intercepts every pointer event aimed at the image itself.
+ */
+function buildPng(width: number, height: number, rgb: [number, number, number]): Buffer {
+	const chunk = (type: string, data: Buffer) => {
+		const body = Buffer.concat([Buffer.from(type, 'ascii'), data]);
+		const len = Buffer.alloc(4);
+		len.writeUInt32BE(data.length);
+		const crc = Buffer.alloc(4);
+		crc.writeUInt32BE(crc32(body) >>> 0);
+		return Buffer.concat([len, body, crc]);
+	};
+	const ihdr = Buffer.alloc(13);
+	ihdr.writeUInt32BE(width, 0);
+	ihdr.writeUInt32BE(height, 4);
+	ihdr[8] = 8; // bit depth
+	ihdr[9] = 2; // colour type: truecolour
+	const row = Buffer.concat([Buffer.from([0]), Buffer.from(Array.from({ length: width }, () => rgb).flat())]);
+	const raw = Buffer.concat(Array.from({ length: height }, () => row));
+	return Buffer.concat([
+		Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+		chunk('IHDR', ihdr),
+		chunk('IDAT', deflateSync(raw)),
+		chunk('IEND', Buffer.alloc(0))
+	]);
+}
+
+export const REAL_PNG = buildPng(200, 150, [200, 120, 60]);
+
+export const DESKTOP = { width: 1200, height: 900 };
+/** Below the 639.98px mobile breakpoint — BottomNav / DockedSheet branch. */
+export const MOBILE = { width: 390, height: 844 };
+
+const STRIP = '.attachment-strip';
+export const TILE = `${STRIP} .att-tile`;
+/**
+ * The viewer root. Class-qualified on PURPOSE (see the selector rule above);
+ * `VIEWER_ROOT_CLASS` in `$lib/a11y/viewerBackdrop` is the same string, and
+ * the manager's arbitration keys on it, so a rename that broke this locator
+ * would also be a real regression.
+ */
+export const VIEWER = '.attachment-viewer[role="dialog"]';
+export const VIEWER_IMAGE = `${VIEWER} .lightbox-image`;
+export const VIEWER_COUNTER = `${VIEWER} .lightbox-counter`;
+
+/** The viewer's controls, addressed by the accessible names TASK-2429 gave them. */
+export const viewerClose = (page: Page) => page.locator(VIEWER).getByRole('button', { name: 'Close' });
+export const viewerNext = (page: Page) =>
+	page.locator(VIEWER).getByRole('button', { name: 'Next image' });
+export const viewerPrev = (page: Page) =>
+	page.locator(VIEWER).getByRole('button', { name: 'Previous image' });
+
+export function itemUrl(fixture: SuiteFixture, slug: string): string {
+	return `/${fixture.adminUsername}/${fixture.workspaceSlug}/docs/${slug}`;
+}
+
+export function collectionUrl(fixture: SuiteFixture, query = ''): string {
+	return `/${fixture.adminUsername}/${fixture.workspaceSlug}/docs${query}`;
+}
+
+/** Upload a file bound to `itemId` so it lands in that item's strip. */
+export async function uploadAttachment(
+	fixture: SuiteFixture,
+	request: APIRequestContext,
+	itemId: string,
+	filename: string,
+	mimeType = 'image/png',
+	buffer: Buffer = REAL_PNG
+): Promise<string> {
+	const ws = fixture.workspaceSlug;
+	const resp = await request.post(
+		`/api/v1/workspaces/${ws}/attachments?item_id=${encodeURIComponent(itemId)}`,
+		{
+			headers: { Authorization: `Bearer ${fixture.apiToken}` },
+			multipart: { file: { name: filename, mimeType, buffer } }
+		}
+	);
+	if (!resp.ok()) throw new Error(`upload failed (${resp.status()}): ${await resp.text()}`);
+	return ((await resp.json()) as { id: string }).id;
+}
+
+/** Post a comment on `itemSlug`; `body` is markdown. */
+export async function postComment(
+	fixture: SuiteFixture,
+	request: APIRequestContext,
+	itemSlug: string,
+	body: string
+): Promise<void> {
+	const resp = await request.post(
+		`/api/v1/workspaces/${fixture.workspaceSlug}/items/${itemSlug}/comments`,
+		{
+			headers: {
+				Authorization: `Bearer ${fixture.apiToken}`,
+				'Content-Type': 'application/json'
+			},
+			data: { body }
+		}
+	);
+	if (!resp.ok()) throw new Error(`comment failed (${resp.status()}): ${await resp.text()}`);
+}
+
+/**
+ * Create a throwaway collection in the suite workspace.
+ *
+ * Two of these tests need a list (or a `collection_updated` broadcast) that
+ * NOTHING ELSE touches: the suite runs fully parallel against one server, so
+ * the shared `docs` list gains rows from other specs mid-test — which is
+ * exactly the interference the pre-existing `pane-a11y-focus` j/k test suffers
+ * from. Isolating the collection removes the whole class.
+ */
+export async function createCollection(
+	fixture: SuiteFixture,
+	request: APIRequestContext,
+	name: string
+): Promise<{ slug: string }> {
+	const resp = await request.post(`/api/v1/workspaces/${fixture.workspaceSlug}/collections`, {
+		headers: authJson(fixture),
+		data: { name }
+	});
+	if (!resp.ok()) throw new Error(`collection create failed (${resp.status()}): ${await resp.text()}`);
+	return (await resp.json()) as { slug: string };
+}
+
+/**
+ * Best-effort cleanup. It WARNS rather than throws on failure, deliberately:
+ * every caller runs it from a `finally`, and an exception thrown there would
+ * REPLACE the test's real failure with a cleanup error. A leaked scratch
+ * collection is visible in the warning and harmless to later specs; a
+ * swallowed assertion failure is neither.
+ */
+export async function deleteCollection(
+	fixture: SuiteFixture,
+	request: APIRequestContext,
+	slug: string
+): Promise<void> {
+	try {
+		const resp = await request.delete(
+			`/api/v1/workspaces/${fixture.workspaceSlug}/collections/${slug}`,
+			{ headers: { Authorization: `Bearer ${fixture.apiToken}` } }
+		);
+		if (!resp.ok()) {
+			console.warn(`[attachment-viewer] leaked collection ${slug}: delete returned ${resp.status()}`);
+		}
+	} catch (err) {
+		// A REJECTED request (the context is torn down after a timeout, say) would
+		// propagate out of the caller's `finally` and replace the real failure,
+		// which is the whole thing this helper exists to avoid.
+		console.warn(`[attachment-viewer] leaked collection ${slug}: ${String(err)}`);
+	}
+}
+
+/** Same contract as {@link deleteCollection}, for a scratch workspace. */
+export async function deleteWorkspace(
+	fixture: SuiteFixture,
+	request: APIRequestContext,
+	slug: string
+): Promise<void> {
+	try {
+		const resp = await request.delete(`/api/v1/workspaces/${slug}`, {
+			headers: { Authorization: `Bearer ${fixture.apiToken}` }
+		});
+		if (!resp.ok()) {
+			console.warn(`[attachment-viewer] leaked workspace ${slug}: delete returned ${resp.status()}`);
+		}
+	} catch (err) {
+		console.warn(`[attachment-viewer] leaked workspace ${slug}: ${String(err)}`);
+	}
+}
+
+/** Create an item in an arbitrary collection of the suite workspace. */
+export async function createItem(
+	fixture: SuiteFixture,
+	request: APIRequestContext,
+	collectionSlug: string,
+	title: string
+): Promise<{ id: string; slug: string; ref: string }> {
+	const resp = await request.post(
+		`/api/v1/workspaces/${fixture.workspaceSlug}/collections/${collectionSlug}/items`,
+		{ headers: authJson(fixture), data: { title, fields: '{}', content: '' } }
+	);
+	if (!resp.ok()) throw new Error(`item create failed (${resp.status()}): ${await resp.text()}`);
+	return (await resp.json()) as { id: string; slug: string; ref: string };
+}
+
+export function authJson(fixture: SuiteFixture): Record<string, string> {
+	return {
+		Authorization: `Bearer ${fixture.apiToken}`,
+		'Content-Type': 'application/json'
+	};
+}
+
+/**
+ * Drop a file onto the live editor, the way a user does — the upload plugin
+ * listens for a real `drop` with a DataTransfer. Same shape as
+ * `item-attachment-strip.spec.ts`, which predates this module.
+ */
+export async function dropFileIntoEditor(
+	page: Page,
+	filename: string,
+	base64: string,
+	mimeType = 'image/png',
+	editorSelector = '.editor-content .ProseMirror'
+): Promise<void> {
+	const target = page.locator(editorSelector).first();
+	await target.waitFor({ state: 'visible' });
+	await target.evaluate(
+		(el, { filename, base64, mimeType }) => {
+			const bytes = Uint8Array.from(atob(base64), (c) => c.charCodeAt(0));
+			const file = new File([bytes], filename, { type: mimeType });
+			const dt = new DataTransfer();
+			dt.items.add(file);
+			const rect = el.getBoundingClientRect();
+			el.dispatchEvent(
+				new DragEvent('drop', {
+					bubbles: true,
+					cancelable: true,
+					dataTransfer: dt,
+					clientX: rect.left + 8,
+					clientY: rect.top + 8
+				})
+			);
+		},
+		{ filename, base64, mimeType }
+	);
+}
+
+/**
+ * Can `selector` actually TAKE focus right now?
+ *
+ * This is the inertness oracle for the whole suite: an inert element (or one
+ * inside an inert subtree) refuses `focus()` silently, and jsdom's polyfill
+ * cannot reproduce that — it only toggles the attribute. Asserting the
+ * ATTRIBUTE would pass against a manager that wrote `inert` on the wrong
+ * elements; asserting focusability cannot.
+ */
+export function isFocusable(page: Page, selector: string): Promise<boolean> {
+	return page.evaluate((sel) => {
+		const el = document.querySelector<HTMLElement>(sel);
+		if (!el) throw new Error(`isFocusable: no element for ${sel}`);
+		const before = document.activeElement;
+		el.focus();
+		const took = document.activeElement === el;
+		if (!took && before instanceof HTMLElement) before.focus();
+		return took;
+	}, selector);
+}
+
+/** Is focus inside the frontmost `.attachment-viewer`? */
+export function activeInViewer(page: Page): Promise<boolean> {
+	return page.evaluate(() => {
+		const viewers = Array.from(document.querySelectorAll('.attachment-viewer'));
+		const front = viewers[viewers.length - 1];
+		return !!front && !!document.activeElement && front.contains(document.activeElement);
+	});
+}
+
+/**
+ * Append a focusable PROBE button to every `<body>` child and report which of
+ * them can take focus right now.
+ *
+ * Why probes at all: the app's own body children are mostly portal roots that
+ * are empty (or `display: none`) between overlays, so "nothing in them is
+ * focusable" would be true with or without a backdrop. A probe makes each
+ * child's inertness observable INDEPENDENTLY of what the app happens to have
+ * rendered there.
+ *
+ * Returns one entry per body child in document order. `viewer` marks the
+ * viewer's own root so a caller can assert the exemption.
+ */
+interface BodyChildProbe {
+	index: number;
+	viewer: boolean;
+	inert: boolean;
+	probeFocusable: boolean;
+	/** false for the `display: none` portal roots, where focusability proves nothing. */
+	probeMeaningful: boolean;
+}
+
+function probeBodyChildren(page: Page): Promise<BodyChildProbe[]> {
+	return page.evaluate(() => {
+		const results: BodyChildProbe[] = [];
+		Array.from(document.body.children).forEach((child, index) => {
+			let probe = child.querySelector<HTMLButtonElement>(':scope > [data-viewer-probe]');
+			if (!probe) {
+				probe = document.createElement('button');
+				probe.dataset.viewerProbe = String(index);
+				probe.textContent = 'probe';
+				// Fixed + on-screen so nothing about layout (a zero-size or
+				// off-screen parent) is what makes it unfocusable.
+				probe.style.cssText = 'position:fixed;top:0;left:0;opacity:0;';
+				child.appendChild(probe);
+			}
+			const before = document.activeElement;
+			probe.focus();
+			const probeFocusable = document.activeElement === probe;
+			if (!probeFocusable && before instanceof HTMLElement) before.focus();
+			results.push({
+				index,
+				viewer: child.classList.contains('attachment-viewer'),
+				inert: child.hasAttribute('inert'),
+				probeFocusable,
+				// A probe inside a `display: none` root is unfocusable for reasons
+				// that have nothing to do with the backdrop; the caller must not
+				// count it as evidence either way.
+				probeMeaningful: getComputedStyle(child).display !== 'none'
+			});
+		});
+		return results;
+	}) as Promise<BodyChildProbe[]>;
+}
+
+/**
+ * Every body child except the viewer must be inert, and every MEANINGFUL probe
+ * outside the viewer must have lost focusability — while the viewer's own
+ * probe keeps it.
+ *
+ * `minMeaningful` guards against the whole assertion going vacuous if the app
+ * shell ever stops rendering the children this depends on. ONE is the floor,
+ * not the observed count: `<body>` has four children on these pages (the
+ * SvelteKit `display: contents` wrapper, an offscreen portal root, and two
+ * `display: none` portal roots), but only the wrapper is guaranteed — and it
+ * is the one whose inertness the app depends on. Requiring more would turn an
+ * unrelated portal change into a failure of this assertion.
+ */
+export async function expectBackgroundInert(page: Page, minMeaningful = 1): Promise<void> {
+	const probes = await probeBodyChildren(page);
+	const viewers = probes.filter((p) => p.viewer);
+	expect(viewers.length, 'a viewer body child must exist').toBeGreaterThan(0);
+	const background = probes.filter((p) => !p.viewer);
+	const meaningful = background.filter((p) => p.probeMeaningful);
+	expect(
+		meaningful.length,
+		'the focusability half of this assertion needs at least one laid-out background body child'
+	).toBeGreaterThanOrEqual(minMeaningful);
+	for (const p of background) {
+		expect(p.inert, `body child ${p.index} must be inert while a viewer is open`).toBe(true);
+		if (p.probeMeaningful) {
+			expect(
+				p.probeFocusable,
+				`an injected button in body child ${p.index} must be unreachable`
+			).toBe(false);
+		}
+	}
+	// The FRONTMOST viewer stays interactive. A background viewer (two stacked)
+	// is inert like everything else, which is asserted where that case is set up.
+	const front = viewers[viewers.length - 1];
+	expect(front.inert, 'the frontmost viewer must not be inert').toBe(false);
+	expect(front.probeFocusable, 'the frontmost viewer must stay reachable').toBe(true);
+}
+
+/**
+ * Try to move focus to `selector` and report whether it took — WITHOUT leaving
+ * focus there if it did. The counterpart to {@link isFocusable} for "prove the
+ * background really is unreachable" assertions inside a Tab-trap test, where
+ * observing only that Tab stayed put would also pass against a JS trap running
+ * over a background that is not actually inert.
+ */
+export async function focusAttemptTakes(page: Page, selector: string): Promise<boolean> {
+	return page.evaluate((sel) => {
+		const el = document.querySelector<HTMLElement>(sel);
+		if (!el) throw new Error(`focusAttemptTakes: no element for ${sel}`);
+		const before = document.activeElement;
+		el.focus();
+		const took = document.activeElement === el;
+		if (before instanceof HTMLElement) before.focus();
+		return took;
+	}, selector);
+}
+
+/** Remove every injected probe so a later assertion can't trip over them. */
+export function clearProbes(page: Page): Promise<void> {
+	return page.evaluate(() => {
+		document.querySelectorAll('[data-viewer-probe]').forEach((p) => p.remove());
+	});
+}

--- a/web/e2e/workspace-bundle-roundtrip.spec.ts
+++ b/web/e2e/workspace-bundle-roundtrip.spec.ts
@@ -201,7 +201,12 @@ test('workspace export → import round-trip via web UI', async ({ page, fixture
 		await page.getByRole('button', { name: /\+ new workspace/i }).click();
 	}
 
-	await expect(page.getByRole('dialog')).toBeVisible();
+	// Target by ACCESSIBLE NAME, not a bare `dialog` role (TASK-2430): the app
+	// now hosts several concurrent `role="dialog"` surfaces (the mobile item
+	// pane, BottomSheet/DockedSheet, the body-portaled attachment viewer), so a
+	// bare locator is ambiguous — it resolves to whichever happens to be
+	// mounted, and strict mode fails outright once two are.
+	await expect(page.getByRole('dialog', { name: /new workspace/i })).toBeVisible();
 
 	// Modal opens in 'create' mode; switch to import.
 	const importTab = page.getByRole('button', { name: /^import$/i });

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -854,7 +854,12 @@ dialog.attachment-image-lightbox .attachment-image-lightbox-close:hover {
 	   is covered by the `dialog[open]` selector above.
 	   `:not(.item-pane)` keeps the detail pane printable: on mobile the pane
 	   carries role="dialog" (TASK-2131) but IS the content being printed, not a
-	   transient overlay to strip. */
+	   transient overlay to strip.
+	   The body-portaled attachment viewer (`.lightbox-backdrop.attachment-viewer`,
+	   TASK-2429) DOES match here, and should: it is a transient full-screen
+	   overlay, and printing with one open must print the item underneath, not a
+	   black rectangle. Audited deliberately — a JS-only grep for `role="dialog"`
+	   consumers misses this rule entirely. */
 	[role="dialog"]:not(.item-pane),
 	[role="tooltip"],
 	[role="menu"] {

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -637,55 +637,6 @@ dialog.attachment-crop-modal::backdrop {
 	filter: brightness(1.1);
 }
 
-/* Lightbox dialog — appended to document.body when an attachment image
-   is clicked, so styles must be global rather than scoped to Editor.svelte.
-   Uses the native <dialog> element; the ::backdrop pseudo handles the
-   overlay shade. The dialog content fills the viewport with a centered
-   image and a single close button. */
-dialog.attachment-image-lightbox {
-	border: none;
-	background: transparent;
-	padding: 0;
-	max-width: 100vw;
-	max-height: 100vh;
-	overflow: visible;
-	color: #fff;
-}
-dialog.attachment-image-lightbox::backdrop {
-	background: rgba(0, 0, 0, 0.85);
-	backdrop-filter: blur(2px);
-}
-dialog.attachment-image-lightbox .attachment-image-lightbox-img {
-	max-width: 95vw;
-	max-height: 95vh;
-	display: block;
-	margin: 0 auto;
-	box-shadow: 0 12px 40px rgba(0, 0, 0, 0.55);
-	cursor: zoom-out;
-	border-radius: var(--radius);
-}
-dialog.attachment-image-lightbox .attachment-image-lightbox-close {
-	position: fixed;
-	top: 16px;
-	right: 16px;
-	width: 40px;
-	height: 40px;
-	border-radius: 50%;
-	border: none;
-	background: rgba(0, 0, 0, 0.6);
-	color: #fff;
-	font-size: 28px;
-	line-height: 1;
-	cursor: pointer;
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	z-index: 1;
-}
-dialog.attachment-image-lightbox .attachment-image-lightbox-close:hover {
-	background: rgba(0, 0, 0, 0.85);
-}
-
 /* Light mode */
 [data-theme="light"] {
 	--bg-primary: #f5f5f9;

--- a/web/src/lib/a11y/escapeGuardWiring.svelte.test.ts
+++ b/web/src/lib/a11y/escapeGuardWiring.svelte.test.ts
@@ -142,6 +142,24 @@ describe.each(ROUTES)('ESC guard wiring in %s', (relative) => {
 		expect(guardAt).toBeLessThan(stackAt);
 	});
 
+	it('forwards the keydown EVENT into the stack (TASK-2448)', () => {
+		// The driver half of BUG-2441's fix. The viewer marks the dispatch it
+		// consumed so later `window` listeners stand down — and it can only do
+		// that if the driver hands it the event. Dropping the argument back to a
+		// bare `runTopEscape()` restores the double-close, silently: every unit
+		// test still passes, because the marking side is intact and simply never
+		// runs. That is precisely the kind of quiet revert a grep contract is
+		// here for.
+		//
+		// The identifier is read from the handler's own signature rather than
+		// assumed to be `e`, so a rename can't fail this for the wrong reason.
+		const handler = pageKeydownHandler(code);
+		expect(handler).not.toBeNull();
+		const param = handler!.match(/function\s+\w+\s*\(\s*(\w+)/);
+		expect(param).not.toBeNull();
+		expect(code).toMatch(new RegExp(`runTopEscape\\s*\\(\\s*${param![1]}\\s*\\)`));
+	});
+
 	// ── TASK-2430: Escape must still REACH the stack ───────────────────────
 	//
 	// The single most dangerous way to get TASK-2430 wrong is to hoist an

--- a/web/src/lib/a11y/escapeGuardWiring.svelte.test.ts
+++ b/web/src/lib/a11y/escapeGuardWiring.svelte.test.ts
@@ -1,6 +1,17 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
+import {
+	acquire,
+	isBlockedByModal,
+	hasForeignEscapeOwner,
+	__resetViewerBackdropForTests,
+} from './viewerBackdrop';
+import {
+	pushEscapeHandler,
+	topEscapePriority,
+	ESCAPE_PRIORITY,
+} from '$lib/stores/escapeStack';
 
 /**
  * WIRING CONTRACT for the two route ESC guards (TASK-2429).
@@ -34,6 +45,14 @@ import { fileURLToPath } from 'node:url';
  * exactly the viewer and not the pane beneath it — belongs to TASK-2436's
  * Playwright suite (DR-9), together with the inertness and stacking guarantees
  * jsdom cannot see either.
+ *
+ * TASK-2430 EXTENDS this file rather than starting a new one, because the
+ * subject is the same two handlers. It adds (a) the same scoped contract for
+ * the ARBITRATION guard plus its ordering against the legacy guard and the nav
+ * keys, and (b) a behavioural route-shaped-driver suite at the bottom that
+ * exercises the empty-stack and viewer-frontmost legs of the precedence rule
+ * for real. The native top-layer leg stays with TASK-2436 — jsdom has no top
+ * layer and no `:modal`.
  */
 
 const ROUTES = [
@@ -71,6 +90,24 @@ function escapeHandlerPrologue(code: string): string | null {
 	return code.slice(start, call);
 }
 
+/** The TASK-2430 arbitration bail, tolerant of formatting. */
+const ARBITRATION_GUARD = /if\s*\(\s*isBlockedByModal\(\s*null\s*\)\s*\)\s*\{?\s*return\s*;/;
+
+/**
+ * The body of the route's WINDOW keydown handler — the one wired to
+ * `<svelte:window onkeydown={…}>`. Found by name from that binding rather than
+ * hard-coded, and sliced to the next top-level `function` so a guard sitting in
+ * some neighbouring helper cannot satisfy these assertions.
+ */
+function pageKeydownHandler(code: string): string | null {
+	const wiring = code.match(/<svelte:window[^>]*onkeydown=\{(\w+)\}/);
+	if (!wiring) return null;
+	const start = code.search(new RegExp(`function\\s+${wiring[1]}\\s*\\(`));
+	if (start === -1) return null;
+	const next = code.slice(start + 1).search(/\n\tfunction\s/);
+	return next === -1 ? code.slice(start) : code.slice(start, start + 1 + next);
+}
+
 describe.each(ROUTES)('ESC guard wiring in %s', (relative) => {
 	const source = readFileSync(fileURLToPath(new URL(relative, import.meta.url)), 'utf8');
 	const code = stripComments(source);
@@ -105,11 +142,279 @@ describe.each(ROUTES)('ESC guard wiring in %s', (relative) => {
 		expect(guardAt).toBeLessThan(stackAt);
 	});
 
+	// ── TASK-2430: Escape must still REACH the stack ───────────────────────
+	//
+	// The single most dangerous way to get TASK-2430 wrong is to hoist an
+	// `isBlockedByModal` bail to the top of these handlers. It reads plausibly —
+	// "a viewer is in front, so stand down" — and it silently kills the viewer's
+	// OWN Escape: the viewer registers on `escapeStack`, and these handlers are
+	// the only code that runs the stack. That is exactly the dead key TASK-2429
+	// existed to fix, reintroduced.
+	//
+	// Escape's three-way precedence is already complete WITHOUT an arbitration
+	// bail: `hasForeignEscapeOwner()` stands down for a native `dialog:modal`
+	// and for foreign sheets, and deliberately EXCLUDES the viewer so the stack
+	// dispatches to it. So the contract here is a NEGATIVE one.
+
+	it('does not bail on arbitration before running the escape stack', () => {
+		// Scoped to the prologue — the region between the handler's `function`
+		// keyword and `runTopEscape()`. A bail anywhere in there returns before
+		// the viewer's Escape can be dispatched.
+		const prologue = escapeHandlerPrologue(code);
+		expect(prologue).not.toBeNull();
+		expect(prologue!).not.toMatch(ARBITRATION_GUARD);
+	});
+
 	it('no longer bails on a raw role="dialog" query', () => {
 		// The pre-TASK-2429 inline check, re-introduced by hand or by a bad merge
 		// resolution, is the regression this file exists to catch: it matches the
 		// viewer's own `role="dialog"` root and kills its Escape. Matched by shape
 		// rather than by one exact quoting, so a reformatted revert still trips it.
 		expect(code).not.toMatch(RAW_DIALOG_QUERY);
+	});
+});
+
+/**
+ * The collection route is the one whose keydown handler owns MORE than Escape:
+ * `j`/`k`/arrows/`Enter`/`Tab` drive list + board navigation. Escape was never
+ * the only key at stake, so that half DOES need the arbitration guard — placed
+ * BELOW the Escape dispatch (so it cannot swallow the viewer's Escape) and
+ * ABOVE the nav switch (so it actually guards it). Both bounds are asserted;
+ * either one alone is satisfiable by a guard in the wrong place.
+ */
+describe('collection route — nav keys are behind the arbitration guard', () => {
+	const source = readFileSync(fileURLToPath(new URL(ROUTES[0], import.meta.url)), 'utf8');
+	const code = stripComments(source);
+
+	it('imports the arbitration helper from the a11y module', () => {
+		expect(code).toMatch(
+			/import\s*\{[^}]*\bisBlockedByModal\b[^}]*\}\s*from\s*'\$lib\/a11y\/viewerBackdrop'/
+		);
+	});
+
+	it('guards AFTER the escape dispatch and BEFORE the nav switch', () => {
+		const body = pageKeydownHandler(code);
+		expect(body).not.toBeNull();
+		const arbitrationAt = body!.search(ARBITRATION_GUARD);
+		const escapeDispatchAt = body!.search(/runTopEscape\s*\(/);
+		// The `j` case is the first arm of the nav switch; `moveBoardFocus` is the
+		// board half. Both must be downstream of the guard.
+		const navAt = body!.search(/case\s+'j'\s*:/);
+		const boardAt = body!.search(/moveBoardFocus\s*\(/);
+		for (const at of [arbitrationAt, escapeDispatchAt, navAt, boardAt]) {
+			expect(at).toBeGreaterThan(-1);
+		}
+		expect(escapeDispatchAt).toBeLessThan(arbitrationAt);
+		expect(arbitrationAt).toBeLessThan(navAt);
+		expect(arbitrationAt).toBeLessThan(boardAt);
+	});
+});
+
+/**
+ * The full-page item host's keydown owns ONLY Escape, so it must carry NO
+ * arbitration bail at all — there is no navigation half for one to guard, and
+ * any bail would sit upstream of the stack dispatch.
+ */
+describe('item route — no arbitration bail in its Escape-only handler', () => {
+	const code = stripComments(
+		readFileSync(fileURLToPath(new URL(ROUTES[1], import.meta.url)), 'utf8'),
+	);
+
+	it('does not call isBlockedByModal anywhere in the file', () => {
+		expect(code).not.toMatch(/isBlockedByModal\s*\(/);
+	});
+});
+
+/**
+ * BEHAVIOURAL proof of the precedence rules, in the shape the collection route
+ * actually has: an ESCAPE path that must reach the escape stack, and a
+ * NAVIGATION path that must not act while anything is in front.
+ *
+ * This is the counterpart to the source contracts above — they prove the route
+ * calls things in the right ORDER; this proves the order decides correctly. The
+ * asymmetry is the whole point and is where TASK-2430 was first implemented
+ * WRONG: a single arbitration bail at the top satisfies every "nav key did not
+ * act" assertion while silently killing the viewer's Escape.
+ *
+ * The NATIVE top-layer leg is deliberately absent — jsdom implements neither
+ * the top layer nor `:modal` (the selector throws, which is the unsupported
+ * path `isBlockedByModal` answers "no native modal" for), so a jsdom assertion
+ * there would test the fallback rather than the contract. It belongs to
+ * TASK-2436's Playwright suite.
+ */
+describe('route-shaped driver — Escape reaches the stack, nav keys do not act', () => {
+	/**
+	 * The collection route's shape, INCLUDING the two priority-gated pane
+	 * branches that sit between the foreign-modal guard and the stack dispatch.
+	 * They are modelled because they are the branches that could still close a
+	 * layer UNDER the viewer, and they are driven by the REAL `escapeStack`
+	 * (`topEscapePriority()`), not by a hand-rolled stand-in — so a change to the
+	 * viewer's registered priority would surface here.
+	 */
+	function drive(
+		e: KeyboardEvent,
+		runStack: () => boolean,
+		navigate: () => void,
+		panePop?: () => void,
+	): 'foreign' | 'pane-pop' | 'stack' | 'blocked' | 'navigated' {
+		if (e.key === 'Escape') {
+			if (hasForeignEscapeOwner()) return 'foreign';
+			if (topEscapePriority() === ESCAPE_PRIORITY.pane) {
+				panePop?.();
+				return 'pane-pop';
+			}
+			runStack();
+			return 'stack';
+		}
+		if (isBlockedByModal(null)) return 'blocked';
+		navigate();
+		return 'navigated';
+	}
+
+	const unregister: Array<() => void> = [];
+
+	afterEach(() => {
+		while (unregister.length) unregister.pop()!();
+		__resetViewerBackdropForTests();
+		document.body.innerHTML = '';
+	});
+
+	function press(key: string): KeyboardEvent {
+		return new KeyboardEvent('keydown', { key, cancelable: true });
+	}
+
+	/** Register a handler on the REAL escape stack for the duration of a test. */
+	function register(fn: () => boolean, priority: number) {
+		unregister.push(pushEscapeHandler(fn, priority));
+	}
+
+	function mountViewer(): HTMLElement {
+		const viewer = document.createElement('div');
+		// The marker class is precisely what makes the LEGACY guard ignore it, so
+		// that Escape falls through to the stack instead of standing down.
+		viewer.className = 'attachment-viewer';
+		viewer.setAttribute('role', 'dialog');
+		document.body.appendChild(viewer);
+		return viewer;
+	}
+
+	it('EMPTY STACK: Escape runs the stack and nav keys navigate', () => {
+		const runStack = vi.fn(() => true);
+		const navigate = vi.fn();
+		expect(drive(press('Escape'), runStack, navigate)).toBe('stack');
+		expect(drive(press('j'), runStack, navigate)).toBe('navigated');
+		expect(runStack).toHaveBeenCalledTimes(1);
+		expect(navigate).toHaveBeenCalledTimes(1);
+	});
+
+	it('EMPTY STACK with a foreign sheet: the legacy guard owns Escape', () => {
+		// A shipped `role="dialog"` sheet with no lease and no stack registration
+		// — the case TASK-2429's guard exists for, and which must be UNCHANGED.
+		const sheet = document.createElement('div');
+		sheet.setAttribute('role', 'dialog');
+		document.body.appendChild(sheet);
+
+		const runStack = vi.fn(() => true);
+		expect(drive(press('Escape'), runStack, vi.fn())).toBe('foreign');
+		expect(runStack).not.toHaveBeenCalled();
+	});
+
+	it('VIEWER FRONTMOST: Escape STILL reaches the stack — it is the viewer\u2019s own key', () => {
+		// The regression guard for TASK-2430's first implementation. A blanket
+		// `isBlockedByModal` bail here would return before the stack ran, and the
+		// viewer — whose Escape lives ONLY on that stack — would become
+		// undismissable by keyboard.
+		const lease = acquire(mountViewer());
+		const runStack = vi.fn(() => true);
+		expect(drive(press('Escape'), runStack, vi.fn())).toBe('stack');
+		expect(runStack).toHaveBeenCalledTimes(1);
+		lease.release();
+	});
+
+	it('VIEWER FRONTMOST: the priority-gated pane branch stands down', () => {
+		// With a pane registered and NO viewer, Escape takes the pane branch —
+		// today's behaviour. Once a viewer registers ABOVE it, that branch must
+		// stop firing, or one press would pop a pane layer underneath the viewer.
+		// Driven through the real stack, so this tracks the actual priorities.
+		register(() => true, ESCAPE_PRIORITY.pane);
+		const panePop = vi.fn();
+		const runStack = vi.fn(() => true);
+		expect(drive(press('Escape'), runStack, vi.fn(), panePop)).toBe('pane-pop');
+		expect(panePop).toHaveBeenCalledTimes(1);
+
+		const lease = acquire(mountViewer());
+		register(() => true, ESCAPE_PRIORITY.viewer);
+		expect(drive(press('Escape'), runStack, vi.fn(), panePop)).toBe('stack');
+		expect(panePop).toHaveBeenCalledTimes(1);
+		expect(runStack).toHaveBeenCalledTimes(1);
+		lease.release();
+	});
+
+	it('VIEWER FRONTMOST OVER AN OPEN SHEET: Escape is still owned by the stack', () => {
+		// The dead-key cross-product (found in review round 5). A `role="dialog"`
+		// sheet open BENEATH the viewer used to make `hasForeignEscapeOwner()`
+		// true, so the driver returned 'foreign' — while the sheet itself,
+		// correctly guarded by TASK-2430, declined. Nobody owned the key.
+		const sheet = document.createElement('div');
+		sheet.setAttribute('role', 'dialog');
+		document.body.appendChild(sheet);
+		const runStack = vi.fn(() => true);
+		// Sheet alone: it owns Escape, exactly as before.
+		expect(drive(press('Escape'), runStack, vi.fn())).toBe('foreign');
+
+		const lease = acquire(mountViewer());
+		expect(drive(press('Escape'), runStack, vi.fn())).toBe('stack');
+		expect(runStack).toHaveBeenCalledTimes(1);
+
+		// Viewer gone → the sheet is frontmost again and reclaims the key.
+		lease.release();
+		expect(drive(press('Escape'), runStack, vi.fn())).toBe('foreign');
+	});
+
+	it('VIEWER FRONTMOST: nav keys are blocked, and resume on release', () => {
+		const lease = acquire(mountViewer());
+		const navigate = vi.fn();
+		expect(drive(press('j'), vi.fn(() => true), navigate)).toBe('blocked');
+		expect(drive(press('Enter'), vi.fn(() => true), navigate)).toBe('blocked');
+		expect(drive(press('Tab'), vi.fn(() => true), navigate)).toBe('blocked');
+		expect(navigate).not.toHaveBeenCalled();
+
+		lease.release();
+		expect(drive(press('j'), vi.fn(() => true), navigate)).toBe('navigated');
+		expect(navigate).toHaveBeenCalledTimes(1);
+	});
+});
+
+/**
+ * TWO FURTHER GLOBAL ESCAPE OWNERS, found by TASK-2430's round-2 sweep and
+ * NOT in the task's original owner list. Neither route can host an attachment
+ * viewer (neither mounts `ItemDetail`, so neither mounts a viewer host), but
+ * `+layout.svelte` mounts `CreateWorkspaceModal` / `OpenChildrenDialog` on BOTH
+ * — so a native top-layer dialog CAN sit in front of them, and one press would
+ * otherwise cancel the dialog and mutate the layer underneath it.
+ *
+ * The console shell has a real behavioural suite
+ * (`routes/console/consoleShellEscape.svelte.test.ts`). The workspace GRAPH
+ * route does not: it is a 3d-force-graph host with a WebGL renderer, which
+ * jsdom cannot mount, so this source contract — deletion-proof, comment-
+ * stripped, scoped to the handler — is the coverage it gets here. Its
+ * behavioural proof belongs with TASK-2436.
+ */
+describe('other global Escape owners carry the arbitration guard', () => {
+	const OTHERS = [
+		'../../routes/[username]/[workspace]/graph/+page.svelte',
+		'../../routes/console/+layout.svelte',
+	] as const;
+
+	it.each(OTHERS)('%s guards its window keydown handler', (relative) => {
+		const code = stripComments(
+			readFileSync(fileURLToPath(new URL(relative, import.meta.url)), 'utf8'),
+		);
+		expect(code).toMatch(
+			/import\s*\{[^}]*\bisBlockedByModal\b[^}]*\}\s*from\s*'\$lib\/a11y\/viewerBackdrop'/
+		);
+		const body = pageKeydownHandler(code);
+		expect(body).not.toBeNull();
+		expect(body!).toMatch(ARBITRATION_GUARD);
 	});
 });

--- a/web/src/lib/a11y/escapeGuardWiring.svelte.test.ts
+++ b/web/src/lib/a11y/escapeGuardWiring.svelte.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * WIRING CONTRACT for the two route ESC guards (TASK-2429).
+ *
+ * The viewer's Escape has exactly one owner — `escapeStack` — and the only code
+ * that runs it is the keydown handler in each of these two route files. Both
+ * used to bail on an inline
+ * `document.querySelector('dialog[open], [role="dialog"]:not(.item-pane)')`,
+ * which the body-portaled viewer now MATCHES; without the shared
+ * `hasForeignEscapeOwner()` (which excludes it) the guard returns early, the
+ * stack never runs, and Escape closes nothing at all. That is a silent,
+ * app-wide dead key.
+ *
+ * WHY A SOURCE ASSERTION. The unit tests around `Lightbox` drive a
+ * ROUTE-SHAPED driver they define themselves, so they prove the shape works —
+ * not that either route still calls it. Mounting a SvelteKit route under vitest
+ * to prove the real thing costs far more than it is worth (a 2,900-line
+ * component, its stores, its data loaders), while the actual regression risk is
+ * mundane: someone deletes or reverts the call, or re-inlines the old selector
+ * during a merge. A grep-shaped contract catches exactly that, and nothing else
+ * pretends to be covered here.
+ *
+ * TWO THINGS KEEP IT FROM BEING A GREP THAT LIES:
+ *   • COMMENTS ARE STRIPPED FIRST. Every one of these strings appears in prose
+ *     in these files (this commit added several), so a whole-file search could
+ *     be satisfied by a comment while the handler ran unguarded.
+ *   • ASSERTIONS ARE SCOPED TO THE HANDLER that actually calls `runTopEscape`,
+ *     not to the file. A guard in some unrelated helper is not this contract.
+ *
+ * The BEHAVIOURAL proof — a real Escape press, in a real browser, closing
+ * exactly the viewer and not the pane beneath it — belongs to TASK-2436's
+ * Playwright suite (DR-9), together with the inertness and stacking guarantees
+ * jsdom cannot see either.
+ */
+
+const ROUTES = [
+	'../../routes/[username]/[workspace]/[collection]/+page.svelte',
+	'../../routes/[username]/[workspace]/[collection]/[slug]/+page.svelte',
+] as const;
+
+/** The guard call, tolerant of formatting (prettier reflow, added braces). */
+const GUARD = /if\s*\(\s*hasForeignEscapeOwner\(\)\s*\)\s*\{?\s*return\s*;/;
+/** Any `querySelector` whose selector string reaches for a `role="dialog"`. */
+const RAW_DIALOG_QUERY = /querySelector\w*\(\s*(['"`])[^'"`]*\[\s*role\s*=\s*\\?["']?dialog/;
+
+/**
+ * Source with comments removed. Line comments are matched only when the `//`
+ * is not preceded by `:`, so URLs (`https://…`) survive — the point is to drop
+ * PROSE, not to be a parser.
+ */
+function stripComments(source: string): string {
+	return source
+		.replace(/\/\*[\s\S]*?\*\//g, '')
+		.replace(/<!--[\s\S]*?-->/g, '')
+		.replace(/(^|[^:])\/\/[^\n]*/g, '$1');
+}
+
+/**
+ * The body of the function that calls `runTopEscape()`, from its `function`
+ * keyword up to that call — i.e. exactly the region the guard must sit in.
+ * Returns null when there is no such call at all, which is itself a failure.
+ */
+function escapeHandlerPrologue(code: string): string | null {
+	const call = code.search(/runTopEscape\s*\(/);
+	if (call === -1) return null;
+	const start = code.lastIndexOf('function ', call);
+	if (start === -1) return null;
+	return code.slice(start, call);
+}
+
+describe.each(ROUTES)('ESC guard wiring in %s', (relative) => {
+	const source = readFileSync(fileURLToPath(new URL(relative, import.meta.url)), 'utf8');
+	const code = stripComments(source);
+
+	it('imports the shared guard from the a11y module', () => {
+		expect(code).toMatch(
+			/import\s*\{[^}]*\bhasForeignEscapeOwner\b[^}]*\}\s*from\s*'\$lib\/a11y\/viewerBackdrop'/
+		);
+	});
+
+	it('calls it as an early return INSIDE the handler that runs the stack', () => {
+		// Scoped, not file-wide: this is the assertion that would otherwise be
+		// satisfiable by prose or by an unrelated helper. `return` (not
+		// `preventDefault`) is the point — a foreign modal owns the key outright,
+		// so the stack must not run at all.
+		const prologue = escapeHandlerPrologue(code);
+		expect(prologue).not.toBeNull();
+		expect(prologue!).toMatch(GUARD);
+	});
+
+	it('does not reach the stack without passing the guard first', () => {
+		// The ordering IS the contract: running the stack first would close the
+		// viewer out from under a modal that owns the key, and guarding after the
+		// fact would do nothing. Falls out of the scoping above — the prologue
+		// ends AT the call — so this re-states it against the whole file, where a
+		// second, unguarded `runTopEscape` would also show up.
+		const occurrences = code.match(/runTopEscape\s*\(/g) ?? [];
+		expect(occurrences).toHaveLength(1);
+		const guardAt = code.search(GUARD);
+		const stackAt = code.search(/runTopEscape\s*\(/);
+		expect(guardAt).toBeGreaterThan(-1);
+		expect(guardAt).toBeLessThan(stackAt);
+	});
+
+	it('no longer bails on a raw role="dialog" query', () => {
+		// The pre-TASK-2429 inline check, re-introduced by hand or by a bad merge
+		// resolution, is the regression this file exists to catch: it matches the
+		// viewer's own `role="dialog"` root and kills its Escape. Matched by shape
+		// rather than by one exact quoting, so a reformatted revert still trips it.
+		expect(code).not.toMatch(RAW_DIALOG_QUERY);
+	});
+});

--- a/web/src/lib/a11y/viewerBackdrop.svelte.test.ts
+++ b/web/src/lib/a11y/viewerBackdrop.svelte.test.ts
@@ -721,15 +721,26 @@ describe('hasForeignEscapeOwner', () => {
 
 	/**
 	 * Emulate an engine where `dialog:modal` IS supported (jsdom throws on it —
-	 * probed, not assumed), with `modals` as the open modal dialogs. Only the
-	 * combined selector the module builds is intercepted.
+	 * probed, not assumed), with `modals` as the open modal dialogs. Intercepts
+	 * ANY selector starting with `dialog:modal` — the module asks it both
+	 * standalone and combined with the ARIA branch, and delegating the combined
+	 * form's tail unconditionally would turn the standalone form back into a
+	 * throwing `dialog:modal` query and silently drop the caller onto the
+	 * unsupported-engine path.
 	 */
 	function mockModalSupport(modals: Element[]): void {
 		const real = document.querySelector.bind(document);
 		vi.spyOn(document, 'querySelector').mockImplementation((selector: string) => {
 			if (!selector.startsWith('dialog:modal')) return real(selector);
-			const rest = selector.slice(selector.indexOf(',') + 1).trim();
-			return modals[0] ?? real(rest);
+			if (modals[0]) return modals[0];
+			// Shape-agnostic (TASK-2430): the helper may ask `dialog:modal` on its
+			// own or combined with the ARIA branch. Delegating `slice(indexOf(',')
+			// + 1)` unconditionally turned the standalone form back into
+			// `real('dialog:modal')`, which THROWS in jsdom and pushed the helper
+			// down its unsupported-engine fallback — the opposite of what a test
+			// named "on a supporting engine" is asking about.
+			const comma = selector.indexOf(',');
+			return comma === -1 ? null : real(selector.slice(comma + 1).trim());
 		});
 	}
 
@@ -761,12 +772,101 @@ describe('hasForeignEscapeOwner', () => {
 		expect(hasForeignEscapeOwner()).toBe(false);
 	});
 
-	it('still sees a sheet opened WHILE a viewer is up', () => {
-		// The exclusion is targeted at the viewer, not a blanket "a viewer is
-		// open, so nothing else counts".
+	it('still sees a sheet when a viewer ELEMENT exists but holds no lease', () => {
+		// The exclusion is targeted at the viewer element, not a blanket "a viewer
+		// is in the DOM, so nothing else counts". With no lease held, the viewer
+		// is not in front of anything — a mid-teardown viewer is exactly this
+		// state — and the sheet owns its Escape as it always did.
 		viewerRoot();
 		bodyChild('sheet').setAttribute('role', 'dialog');
 		expect(hasForeignEscapeOwner()).toBe(true);
+	});
+
+	it('stops seeing a sheet once a viewer LEASE is frontmost (TASK-2430)', () => {
+		// THE DEAD-KEY FENCE. Once the sheets consult `isBlockedByModal` (3b),
+		// a sheet under a frontmost viewer stands down — so if this still answered
+		// `true`, the route driver would return, the sheet would decline, and the
+		// viewer's Escape (which lives ONLY on the stack) would run nowhere.
+		// Nobody would own the key.
+		const sheet = bodyChild('sheet');
+		sheet.setAttribute('role', 'dialog');
+		expect(hasForeignEscapeOwner()).toBe(true);
+
+		const lease = acquire(viewerRoot());
+		expect(hasForeignEscapeOwner()).toBe(false);
+
+		// Released → the sheet is the front layer again and reclaims the key.
+		lease.release();
+		expect(hasForeignEscapeOwner()).toBe(true);
+	});
+
+	it('is lease-aware on a `:modal`-SUPPORTING engine too, not just the fallback', () => {
+		// jsdom throws on `:modal`, so every test in this describe that does not
+		// install an emulation exercises the FALLBACK branch — which would leave
+		// the branch real browsers take unfenced for the LEASE case specifically.
+		// Emulating support needs BOTH probes mocked, not just
+		// `querySelector`: `acquire()` runs `reconcile()`, which calls
+		// `el.matches('dialog:modal')` on body children, and an unmocked throw
+		// there latches `modalSelectorSupported = false` and silently drops the
+		// helper onto the fallback path mid-test. `mockOpenModals` covers both.
+		const modals: Element[] = [];
+		mockOpenModals((el) => modals.includes(el));
+		// `hasForeignEscapeOwner` asks `querySelector`, which `mockOpenModals`
+		// does not intercept — route it to the same oracle.
+		const realQuery = document.querySelector.bind(document);
+		vi.spyOn(document, 'querySelector').mockImplementation((selector: string) => {
+			if (selector !== 'dialog:modal') return realQuery(selector);
+			return modals[0] ?? null;
+		});
+
+		const sheet = bodyChild('sheet');
+		sheet.setAttribute('role', 'dialog');
+		expect(hasForeignEscapeOwner()).toBe(true);
+
+		const lease = acquire(viewerRoot());
+		expect(hasForeignEscapeOwner()).toBe(false);
+
+		// ...and a real `showModal()` dialog still wins over the held lease.
+		modals.push(openModal());
+		expect(hasForeignEscapeOwner()).toBe(true);
+		lease.release();
+	});
+
+	it('STILL sees a sheet nested INSIDE the frontmost viewer', () => {
+		// The containment half of the lease-aware branch. A sheet that lives
+		// inside the viewer root is IN FRONT of the viewer's own content, so it
+		// genuinely owns its Escape — and `isBlockedByModal(sheetEl)` agrees
+		// (contained by the front root ⇒ not blocked). A blanket "a lease exists
+		// ⇒ no ARIA owner" would let the route driver run the stack and close the
+		// viewer out from under the sheet it is showing: two layers, one press.
+		const viewer = viewerRoot();
+		const nested = document.createElement('div');
+		nested.setAttribute('role', 'dialog');
+		viewer.appendChild(nested);
+		acquire(viewer);
+
+		expect(hasForeignEscapeOwner()).toBe(true);
+
+		// ...while a sheet BEHIND the same viewer is still invisible to it.
+		nested.remove();
+		bodyChild('sheet').setAttribute('role', 'dialog');
+		expect(hasForeignEscapeOwner()).toBe(false);
+	});
+
+	it('does NOT apply the liveness rule to the `dialog[open]` fallback', () => {
+		// The containment rule is deliberately ARIA-only. Nothing in the app
+		// guards a native `<dialog>`, so unlike a sheet it has not stood down for
+		// the viewer and does still own Escape — and on this branch a real
+		// `showModal()` dialog is indistinguishable from a non-modal one, so
+		// letting the lease out-rank it would fire the browser's native `cancel`
+		// AND run the stack: two layers on one press.
+		const dialog = openModal();
+		dialog.setAttribute('open', '');
+		expect(hasForeignEscapeOwner()).toBe(true);
+
+		const lease = acquire(viewerRoot());
+		expect(hasForeignEscapeOwner()).toBe(true);
+		lease.release();
 	});
 
 	it('falls back to `dialog[open]` where `:modal` is unsupported', () => {

--- a/web/src/lib/a11y/viewerBackdrop.svelte.test.ts
+++ b/web/src/lib/a11y/viewerBackdrop.svelte.test.ts
@@ -4,6 +4,8 @@ import {
 	isBlockedByModal,
 	isViewerFrontmost,
 	hasForeignEscapeOwner,
+	noteEscapeConsumedByViewer,
+	isEscapeConsumedByViewer,
 	VIEWER_ROOT_CLASS,
 	__resetViewerBackdropForTests,
 } from './viewerBackdrop';
@@ -701,6 +703,74 @@ describe('isBlockedByModal', () => {
 			// ...and against any `[open]` fallback: the open dialog must not count.
 			expect(isBlockedByModal(dialog.querySelector('#d'))).toBe(false);
 		});
+	});
+});
+
+describe('event-scoped Escape consumption (TASK-2448 / BUG-2441)', () => {
+	const esc = () => new KeyboardEvent('keydown', { key: 'Escape' });
+
+	it('survives the release of the lease that recorded it', () => {
+		// The whole point: the mark answers for a viewer that no longer exists.
+		const app = bodyChild('app', '<button id="a">a</button>');
+		const viewer = bodyChild('viewer');
+		const lease = acquire(viewer);
+		const event = esc();
+
+		noteEscapeConsumedByViewer(event);
+		lease.release();
+
+		expect(isBlockedByModal(app, null)).toBe(false); // live state: nothing in front
+		expect(isBlockedByModal(app, event)).toBe(true); // ...but this press is spent
+	});
+
+	it('is scoped to ONE event — the next press is unaffected', () => {
+		const app = bodyChild('app');
+		const consumed = esc();
+		noteEscapeConsumedByViewer(consumed);
+
+		expect(isBlockedByModal(app, consumed)).toBe(true);
+		expect(isBlockedByModal(app, esc())).toBe(false);
+	});
+
+	it('blocks an owner INSIDE the closing viewer too', () => {
+		// A viewer that has spent the press has spent it for everyone: the
+		// surface that won it is being torn down, so "inside it" is not a licence
+		// to act on the same key.
+		const viewer = bodyChild('viewer', '<button id="v">v</button>');
+		const lease = acquire(viewer);
+		const event = esc();
+		noteEscapeConsumedByViewer(event);
+
+		expect(isBlockedByModal(viewer.querySelector('#v'), event)).toBe(true);
+		lease.release();
+	});
+
+	it('changes NOTHING with an unmarked event, at any lease state', () => {
+		// The empty-stack contract, stated as an equivalence: passing an event
+		// nobody marked must give the same answer as not passing one at all.
+		const app = bodyChild('app', '<button id="a">a</button>');
+		const owner = app.querySelector('#a');
+		const event = esc();
+
+		expect(isBlockedByModal(owner, event)).toBe(isBlockedByModal(owner));
+		expect(isBlockedByModal(owner, event)).toBe(false);
+
+		const viewer = bodyChild('viewer');
+		const lease = acquire(viewer);
+		expect(isBlockedByModal(owner, event)).toBe(isBlockedByModal(owner));
+		expect(isBlockedByModal(owner, event)).toBe(true);
+		expect(isBlockedByModal(viewer, event)).toBe(isBlockedByModal(viewer));
+		expect(isBlockedByModal(viewer, event)).toBe(false);
+		lease.release();
+	});
+
+	it('reports the mark directly, and treats a missing event as unmarked', () => {
+		const event = esc();
+		expect(isEscapeConsumedByViewer(event)).toBe(false);
+		noteEscapeConsumedByViewer(event);
+		expect(isEscapeConsumedByViewer(event)).toBe(true);
+		expect(isEscapeConsumedByViewer(null)).toBe(false);
+		expect(isEscapeConsumedByViewer(undefined)).toBe(false);
 	});
 });
 

--- a/web/src/lib/a11y/viewerBackdrop.svelte.test.ts
+++ b/web/src/lib/a11y/viewerBackdrop.svelte.test.ts
@@ -1,0 +1,703 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+	acquire,
+	isBlockedByModal,
+	isViewerFrontmost,
+	__resetViewerBackdropForTests,
+} from './viewerBackdrop';
+
+// jsdom has no layout engine, so the production visibility predicate behind
+// `paneFocusables` (offsetParent / getClientRects) reports EVERYTHING hidden.
+// Stub `getClientRects` so focus-handoff assertions exercise the real
+// selection path instead of always seeing an empty candidate list.
+const realGetClientRects = HTMLElement.prototype.getClientRects;
+
+/** A direct child of `<body>` — the shape a portaled viewer root has. */
+function bodyChild(id: string, html = ''): HTMLElement {
+	const el = document.createElement('div');
+	el.id = id;
+	el.innerHTML = html;
+	document.body.appendChild(el);
+	return el;
+}
+
+/** A body-level `<dialog>` standing in for a `showModal()` one. */
+function openModal(html = ''): HTMLDialogElement {
+	const dialog = document.createElement('dialog');
+	dialog.innerHTML = html;
+	document.body.appendChild(dialog);
+	return dialog;
+}
+
+/**
+ * jsdom implements neither `showModal()` top-layer state nor the `:modal`
+ * pseudo-class (it throws on it), so emulate a supporting engine: `dialogs`
+ * are the open modal ones, everything else answers normally. Both probes the
+ * module makes — `document.querySelectorAll` and `Element.matches` — are
+ * covered, and `selectorLog` (when given) records every selector asked for.
+ */
+function mockOpenModals(
+	oracle: Element[] | ((el: Element) => boolean),
+	selectorLog?: string[],
+): void {
+	const isModal = (el: Element) =>
+		typeof oracle === 'function' ? oracle(el) : oracle.includes(el);
+	const realQueryAll = document.querySelectorAll.bind(document);
+	vi.spyOn(document, 'querySelectorAll').mockImplementation((selector: string) => {
+		selectorLog?.push(selector);
+		if (selector !== 'dialog:modal') return realQueryAll(selector);
+		// Evaluated per call, so an oracle keyed on live state (a dialog that
+		// opens mid-lease) is reflected the way a real engine would.
+		return Array.from(realQueryAll('dialog')).filter(isModal) as unknown as NodeListOf<Element>;
+	});
+	const realMatches = Element.prototype.matches;
+	vi.spyOn(Element.prototype, 'matches').mockImplementation(function (
+		this: Element,
+		selector: string,
+	) {
+		selectorLog?.push(selector);
+		if (selector !== 'dialog:modal') return realMatches.call(this, selector);
+		return realMatches.call(this, 'dialog') && isModal(this);
+	});
+}
+
+/**
+ * Observer-lifecycle probe: counts constructions / observe / disconnect so a
+ * leaked or duplicated observer is visible (a leak is otherwise silent — at
+ * zero leases the desired inert set is empty either way).
+ */
+const observerLog: { observed: number; disconnected: number }[] = [];
+class TrackingMutationObserver extends MutationObserver {
+	#record = { observed: 0, disconnected: 0 };
+	constructor(callback: MutationCallback) {
+		super(callback);
+		observerLog.push(this.#record);
+	}
+	observe(target: Node, options?: MutationObserverInit) {
+		this.#record.observed++;
+		super.observe(target, options);
+	}
+	disconnect() {
+		this.#record.disconnected++;
+		super.disconnect();
+	}
+}
+
+/** The exact set of body-child ids currently carrying `inert`. */
+function inertIds(): string[] {
+	return Array.from(document.body.children)
+		.filter((el) => el.hasAttribute('inert'))
+		.map((el) => el.id)
+		.sort();
+}
+
+/** Let the shared MutationObserver deliver its childList records. */
+function flushObserver(): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+beforeEach(() => {
+	HTMLElement.prototype.getClientRects = function () {
+		return [{}] as unknown as DOMRectList;
+	};
+	document.body.innerHTML = '';
+});
+
+afterEach(() => {
+	__resetViewerBackdropForTests();
+	document.body.innerHTML = '';
+	HTMLElement.prototype.getClientRects = realGetClientRects;
+	vi.restoreAllMocks();
+	vi.unstubAllGlobals();
+});
+
+describe('acquire / release', () => {
+	it('inerts every body child except the exempt root, and restores on release', () => {
+		const app = bodyChild('app');
+		const viewer = bodyChild('viewer');
+
+		const lease = acquire(viewer);
+		expect(inertIds()).toEqual(['app']);
+		expect(lease.exemptRoot).toBe(viewer);
+		expect(viewer.hasAttribute('inert')).toBe(false);
+
+		expect(lease.release()).toEqual({ released: true, stackEmpty: true });
+		expect(inertIds()).toEqual([]);
+	});
+
+	it('is a no-op on repeat release', () => {
+		const app = bodyChild('app');
+		const viewer = bodyChild('viewer');
+
+		const lease = acquire(viewer);
+		expect(lease.release()).toEqual({ released: true, stackEmpty: true });
+		expect(lease.release()).toEqual({ released: false, stackEmpty: true });
+		expect(app.hasAttribute('inert')).toBe(false);
+	});
+
+	it('refcounts: an inner lease keeps the backdrop up until the outer releases', () => {
+		bodyChild('app');
+		const first = bodyChild('first');
+		const second = bodyChild('second');
+
+		const a = acquire(first);
+		const b = acquire(second);
+		// Only the FRONTMOST root stays interactive — otherwise two viewers
+		// would inert each other.
+		expect(inertIds()).toEqual(['app', 'first']);
+
+		expect(b.release()).toEqual({ released: true, stackEmpty: false });
+		expect(inertIds()).toEqual(['app', 'second']);
+
+		expect(a.release()).toEqual({ released: true, stackEmpty: true });
+		expect(inertIds()).toEqual([]);
+	});
+
+	it('recomputes rather than undoing its own writes on out-of-order release', () => {
+		bodyChild('app');
+		const first = bodyChild('first');
+		const second = bodyChild('second');
+
+		const a = acquire(first);
+		const b = acquire(second);
+
+		// Releasing the BACKGROUND lease must leave `first` inert — `second` is
+		// still frontmost, so the desired set is unchanged.
+		expect(a.release()).toEqual({ released: true, stackEmpty: false });
+		expect(inertIds()).toEqual(['app', 'first']);
+
+		expect(b.release()).toEqual({ released: true, stackEmpty: true });
+		expect(inertIds()).toEqual([]);
+	});
+
+	it('leaves pre-existing inert alone (records only what it set)', () => {
+		const app = bodyChild('app');
+		const other = bodyChild('other');
+		other.setAttribute('inert', '');
+		const viewer = bodyChild('viewer');
+
+		const lease = acquire(viewer);
+		expect(inertIds()).toEqual(['app', 'other']);
+
+		lease.release();
+		// `app` is ours to clear; `other` was inert before we arrived.
+		expect(app.hasAttribute('inert')).toBe(false);
+		expect(other.hasAttribute('inert')).toBe(true);
+	});
+
+	it('never inerts the exempt root, even across stack transitions', () => {
+		const app = bodyChild('app');
+		const first = bodyChild('first');
+		const second = bodyChild('second');
+
+		const a = acquire(first);
+		expect(first.hasAttribute('inert')).toBe(false);
+		// Paired positive assertion, so a "never write inert at all" mutant can't
+		// satisfy the negative ones.
+		expect(app.hasAttribute('inert')).toBe(true);
+
+		const b = acquire(second);
+		expect(second.hasAttribute('inert')).toBe(false);
+		expect(first.hasAttribute('inert')).toBe(true);
+
+		b.release();
+		expect(first.hasAttribute('inert')).toBe(false);
+		expect(second.hasAttribute('inert')).toBe(true);
+		a.release();
+		expect(inertIds()).toEqual([]);
+	});
+
+	it('warns when the exempt root is not a direct child of <body>', () => {
+		const app = bodyChild('app', '<div id="nested"></div>');
+		const nested = app.querySelector<HTMLElement>('#nested')!;
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+		const lease = acquire(nested);
+		expect(warn).toHaveBeenCalled();
+		// The containing body child is inerted, which is exactly why it's wrong.
+		expect(app.hasAttribute('inert')).toBe(true);
+		lease.release();
+	});
+});
+
+describe('shared child-list observer', () => {
+	it('inerts a sibling appended after acquisition', async () => {
+		bodyChild('app');
+		const viewer = bodyChild('viewer');
+		const lease = acquire(viewer);
+
+		bodyChild('late');
+		await flushObserver();
+		expect(inertIds()).toEqual(['app', 'late']);
+
+		lease.release();
+		expect(inertIds()).toEqual([]);
+	});
+
+	it('keeps observing across a nested acquire/release pair', async () => {
+		bodyChild('app');
+		const first = bodyChild('first');
+		const second = bodyChild('second');
+
+		const a = acquire(first);
+		const b = acquire(second);
+		b.release();
+
+		bodyChild('late');
+		await flushObserver();
+		expect(inertIds()).toEqual(['app', 'late', 'second']);
+		a.release();
+	});
+
+	it('constructs ONE observer for the whole stack and disconnects it at zero leases', () => {
+		observerLog.length = 0;
+		vi.stubGlobal('MutationObserver', TrackingMutationObserver);
+		const seen = observerLog;
+
+		bodyChild('app');
+		const a = acquire(bodyChild('first'));
+		const b = acquire(bodyChild('second'));
+		// ONE observer instance for the whole stack, with two observe targets:
+		// `<body>` (the child set) and `<html>` (to catch a body swap).
+		expect(seen.length).toBe(1);
+		expect(seen[0].observed).toBe(2);
+
+		b.release();
+		expect(seen[0].disconnected).toBe(0);
+		a.release();
+		expect(seen[0].disconnected).toBe(1);
+	});
+
+	it('leaves no observer activity after the last release', async () => {
+		observerLog.length = 0;
+		vi.stubGlobal('MutationObserver', TrackingMutationObserver);
+		bodyChild('app');
+		const viewer = bodyChild('viewer');
+		const lease = acquire(viewer);
+		lease.release();
+
+		bodyChild('late');
+		await flushObserver();
+		expect(inertIds()).toEqual([]);
+		// The DOM result alone can't tell a torn-down observer from a leaked one
+		// (an empty stack reconciles to nothing either way), so assert teardown.
+		expect(observerLog[0].disconnected).toBe(1);
+	});
+
+	// Asserts the OUTCOME (the inert set is undisturbed), not the reconcile
+	// count — a broader observer filter would be wasteful, not wrong, since
+	// reconcile is idempotent.
+	it('is undisturbed by mutations that cannot change the body-child set', async () => {
+		const app = bodyChild('app', '<details id="det"><summary>s</summary></details>');
+		const viewer = bodyChild('viewer');
+		const lease = acquire(viewer);
+		const before = inertIds();
+
+		// Nested childList + a non-dialog `open` toggle deep in the app: neither
+		// can add or remove a body child, so neither needs a reconcile.
+		app.appendChild(document.createElement('button'));
+		document.getElementById('det')?.setAttribute('open', '');
+		await flushObserver();
+
+		expect(inertIds()).toEqual(before);
+		expect(viewer.hasAttribute('inert')).toBe(false);
+		lease.release();
+	});
+
+	it('re-arms on a replaced <body> without needing another acquire', async () => {
+		const firstBody = document.body;
+		bodyChild('app');
+		const viewer = bodyChild('viewer');
+		const lease = acquire(viewer);
+
+		const nextBody = document.createElement('body');
+		firstBody.replaceWith(nextBody);
+		expect(document.body).toBe(nextBody);
+		nextBody.appendChild(viewer);
+		const app2 = bodyChild('app2');
+		await flushObserver();
+
+		// The swap itself re-arms the observer — the lease may never see another
+		// acquire, so waiting for one would leave the backdrop watching a
+		// detached body.
+		expect(app2.hasAttribute('inert')).toBe(true);
+
+		bodyChild('late');
+		await flushObserver();
+		expect(document.getElementById('late')?.hasAttribute('inert')).toBe(true);
+		expect(viewer.hasAttribute('inert')).toBe(false);
+		lease.release();
+	});
+});
+
+describe('focus handoff', () => {
+	it('focuses the new frontmost root’s first tabbable descendant', () => {
+		bodyChild('app');
+		const first = bodyChild(
+			'first',
+			'<div id="pad" tabindex="-1"></div><button id="a">a</button><button id="b">b</button>',
+		);
+		const second = bodyChild('second', '<button id="c">c</button>');
+
+		const a = acquire(first);
+		const b = acquire(second);
+		(document.getElementById('c') as HTMLElement).focus();
+
+		b.release();
+		expect(document.activeElement?.id).toBe('a');
+		a.release();
+	});
+
+	it('does not steal focus when a BACKGROUND lease is released', () => {
+		bodyChild('app');
+		const first = bodyChild('first', '<button id="a">a</button>');
+		// TWO controls, with focus on the second: a handoff that ignored
+		// `wasFrontmost` would focus this root's FIRST tabbable, which is a
+		// different element — so the assertion can actually catch it.
+		const second = bodyChild('second', '<button id="c">c</button><button id="c2">c2</button>');
+
+		const a = acquire(first);
+		const b = acquire(second);
+		const c2 = document.getElementById('c2') as HTMLElement;
+		c2.focus();
+
+		a.release();
+		expect(document.activeElement).toBe(c2);
+		b.release();
+	});
+
+	it('does not hand off when the stack empties', () => {
+		const app = bodyChild('app', '<button id="a">a</button>');
+		const viewer = bodyChild('viewer', '<button id="v">v</button>');
+		const lease = acquire(viewer);
+		const v = document.getElementById('v') as HTMLElement;
+		v.focus();
+
+		expect(lease.release()).toEqual({ released: true, stackEmpty: true });
+		// Caller restores its own invoker on `stackEmpty`; we must not have moved
+		// focus ourselves — it stays exactly where the viewer left it.
+		expect(document.activeElement).toBe(v);
+		expect(app.contains(document.activeElement)).toBe(false);
+	});
+
+	it('leaves focus alone when it sits outside the closing viewer', () => {
+		bodyChild('app');
+		const first = bodyChild('first', '<button id="a">a</button>');
+		const second = bodyChild('second', '<button id="c">c</button>');
+		const elsewhere = bodyChild('elsewhere', '<button id="e">e</button>');
+
+		const a = acquire(first);
+		const b = acquire(second);
+		// Something layered over the viewer (a native modal, say) took focus.
+		const e = document.getElementById('e') as HTMLElement;
+		e.focus();
+
+		b.release();
+		expect(document.activeElement).toBe(e);
+		a.release();
+	});
+
+	it('defers to a native modal nested inside the closing viewer', () => {
+		bodyChild('app');
+		const first = bodyChild('first', '<button id="a">a</button>');
+		const second = bodyChild('second', '<button id="c">c</button>');
+		// A dialog opened FROM the closing viewer lives inside it, so plain
+		// containment would read "focus is ours" and yank it out of the dialog.
+		const dialog = document.createElement('dialog');
+		dialog.innerHTML = '<button id="d">d</button>';
+		second.appendChild(dialog);
+		mockOpenModals([dialog]);
+
+		const a = acquire(first);
+		const b = acquire(second);
+		const d = document.getElementById('d') as HTMLElement;
+		d.focus();
+
+		b.release();
+		expect(document.activeElement).toBe(d);
+		a.release();
+	});
+
+	it('defers to a nested native modal even when focus is adrift on <body>', () => {
+		bodyChild('app');
+		const first = bodyChild('first', '<button id="a">a</button>');
+		const second = bodyChild('second', '<button id="c">c</button>');
+		const dialog = document.createElement('dialog');
+		dialog.innerHTML = '<button id="d">d</button>';
+		second.appendChild(dialog);
+		mockOpenModals([dialog]);
+
+		const a = acquire(first);
+		const b = acquire(second);
+		(document.getElementById('d') as HTMLElement).focus();
+		(document.getElementById('d') as HTMLElement).blur();
+		expect(document.activeElement).toBe(document.body);
+
+		b.release();
+		// The dialog is still open and still on top — adrift focus is not a
+		// licence to pull it into the viewer beneath.
+		expect(document.activeElement).toBe(document.body);
+		a.release();
+	});
+
+	it('defers to an open native modal that sits OUTSIDE the closing viewer', () => {
+		bodyChild('app');
+		const first = bodyChild('first', '<button id="a">a</button>');
+		const second = bodyChild('second', '<button id="c">c</button>');
+		// Body-level dialog: neither inside the closing viewer nor containing
+		// the (adrift) active element — but still the top layer.
+		const dialog = openModal('<button id="d">d</button>');
+		mockOpenModals([dialog]);
+
+		const a = acquire(first);
+		const b = acquire(second);
+		expect(document.activeElement).toBe(document.body);
+
+		b.release();
+		expect(document.activeElement).toBe(document.body);
+		a.release();
+	});
+
+	it('hands off when focus is adrift on <body> after teardown', () => {
+		bodyChild('app');
+		const first = bodyChild('first', '<button id="a">a</button>');
+		const second = bodyChild('second', '<button id="c">c</button>');
+
+		const a = acquire(first);
+		const b = acquire(second);
+		(document.getElementById('c') as HTMLElement).focus();
+		(document.getElementById('c') as HTMLElement).blur();
+		expect(document.activeElement).toBe(document.body);
+
+		b.release();
+		expect(document.activeElement?.id).toBe('a');
+		a.release();
+	});
+
+	it('focuses the new frontmost root itself when it has no tabbable descendant', () => {
+		bodyChild('app');
+		const first = bodyChild('first', '<div id="static">no controls</div>');
+		const second = bodyChild('second', '<button id="c">c</button>');
+
+		const a = acquire(first);
+		const b = acquire(second);
+		(document.getElementById('c') as HTMLElement).focus();
+
+		b.release();
+		// Focus must not be left on the closing viewer — it's about to unmount,
+		// and the caller only restores its invoker on `stackEmpty`.
+		expect(document.activeElement).toBe(first);
+		expect(first.getAttribute('tabindex')).toBe('-1');
+		a.release();
+	});
+});
+
+describe('isViewerFrontmost', () => {
+	it('tracks the top of the stack', () => {
+		const first = bodyChild('first');
+		const second = bodyChild('second');
+
+		expect(isViewerFrontmost(first)).toBe(false);
+		const a = acquire(first);
+		expect(isViewerFrontmost(first)).toBe(true);
+
+		const b = acquire(second);
+		expect(isViewerFrontmost(first)).toBe(false);
+		expect(isViewerFrontmost(second)).toBe(true);
+
+		b.release();
+		expect(isViewerFrontmost(first)).toBe(true);
+		a.release();
+		expect(isViewerFrontmost(first)).toBe(false);
+	});
+});
+
+describe('isBlockedByModal', () => {
+	it('returns false on an empty stack', () => {
+		const app = bodyChild('app', '<button id="a">a</button>');
+		expect(isBlockedByModal()).toBe(false);
+		expect(isBlockedByModal(app.querySelector('#a'))).toBe(false);
+		expect(isBlockedByModal(null)).toBe(false);
+	});
+
+	it('blocks an owner outside the frontmost viewer, not one inside it', () => {
+		const app = bodyChild('app', '<button id="a">a</button>');
+		const viewer = bodyChild('viewer', '<button id="v">v</button>');
+		const lease = acquire(viewer);
+
+		expect(isBlockedByModal(app.querySelector('#a'))).toBe(true);
+		expect(isBlockedByModal(viewer.querySelector('#v'))).toBe(false);
+		expect(isBlockedByModal(viewer)).toBe(false);
+		// An owner-less caller can't prove it's the frontmost surface.
+		expect(isBlockedByModal()).toBe(true);
+
+		lease.release();
+		expect(isBlockedByModal(app.querySelector('#a'))).toBe(false);
+	});
+
+	it('blocks against a BACKGROUND viewer only via the frontmost root', () => {
+		const first = bodyChild('first', '<button id="a">a</button>');
+		const second = bodyChild('second', '<button id="c">c</button>');
+		const a = acquire(first);
+		const b = acquire(second);
+
+		expect(isBlockedByModal(first.querySelector('#a'))).toBe(true);
+		expect(isBlockedByModal(second.querySelector('#c'))).toBe(false);
+
+		b.release();
+		expect(isBlockedByModal(first.querySelector('#a'))).toBe(false);
+		a.release();
+	});
+
+	it('derives from lease state, not from DOM inert', () => {
+		const app = bodyChild('app', '<button id="a">a</button>');
+		app.setAttribute('inert', '');
+		expect(isBlockedByModal(app.querySelector('#a'))).toBe(false);
+	});
+
+	describe('native dialog branch', () => {
+		it('blocks an owner outside the open modal dialog, not one inside it', () => {
+			const app = bodyChild('app', '<button id="a">a</button>');
+			const dialog = openModal('<button id="d">d</button>');
+			mockOpenModals([dialog]);
+
+			expect(isBlockedByModal(app.querySelector('#a'))).toBe(true);
+			expect(isBlockedByModal(dialog.querySelector('#d'))).toBe(false);
+		});
+
+		it('takes precedence over a held viewer lease (top layer wins)', () => {
+			const viewer = bodyChild('viewer', '<button id="v">v</button>');
+			const dialog = openModal('<button id="d">d</button>');
+			mockOpenModals([dialog]);
+			const lease = acquire(viewer);
+
+			// A `showModal()` dialog opened OVER the viewer is above it, so the
+			// viewer's own controls are blocked while the dialog's are not.
+			expect(isBlockedByModal(dialog.querySelector('#d'))).toBe(false);
+			expect(isBlockedByModal(viewer.querySelector('#v'))).toBe(true);
+
+			vi.restoreAllMocks();
+			expect(isBlockedByModal(viewer.querySelector('#v'))).toBe(false);
+			lease.release();
+		});
+
+		it('exempts EVERY open modal, since top-layer order is not observable', () => {
+			bodyChild('app');
+			const lower = openModal('<button id="lo">lo</button>');
+			const upper = openModal('<button id="hi">hi</button>');
+			mockOpenModals([lower, upper]);
+
+			expect(isBlockedByModal(upper.querySelector('#hi'))).toBe(false);
+			expect(isBlockedByModal(lower.querySelector('#lo'))).toBe(false);
+			expect(isBlockedByModal(document.getElementById('app'))).toBe(true);
+		});
+
+		it('never inerts an open modal dialog (an inert dialog is dead)', () => {
+			bodyChild('app');
+			const dialog = openModal('<button id="d">d</button>');
+			// A second, NON-modal dialog: it must still be inerted, so a lazy
+			// "skip every <dialog>" implementation can't pass.
+			const inactive = openModal();
+			inactive.id = 'inactive';
+			const viewer = bodyChild('viewer');
+			mockOpenModals([dialog]);
+
+			const lease = acquire(viewer);
+			// A modal dialog escapes an inert ANCESTOR, but `inert` ON the dialog
+			// still disables it — so it must stay out of the backdrop's set.
+			expect(dialog.hasAttribute('inert')).toBe(false);
+			expect(inactive.hasAttribute('inert')).toBe(true);
+			expect(document.getElementById('app')?.hasAttribute('inert')).toBe(true);
+			lease.release();
+		});
+
+		it('does not inert a genuinely modal dialog when `:modal` is unsupported', () => {
+			bodyChild('app');
+			const dialog = openModal('<button id="d">d</button>');
+			const closed = openModal();
+			closed.id = 'closed';
+			const viewer = bodyChild('viewer');
+
+			// jsdom's real behaviour: `:modal` throws. The arbitration fallback
+			// ("no modal") is safe, but applying it to the MUTATOR would write
+			// `inert` onto a live `showModal()` dialog and kill it.
+			dialog.showModal();
+			const lease = acquire(viewer);
+
+			expect(dialog.open).toBe(true);
+			expect(dialog.hasAttribute('inert')).toBe(false);
+			// A CLOSED dialog is still just another body child.
+			expect(closed.hasAttribute('inert')).toBe(true);
+
+			dialog.close();
+			lease.release();
+		});
+
+		it('un-inerts a body-level dialog that goes modal DURING a lease', async () => {
+			bodyChild('app');
+			const dialog = openModal('<button id="d">d</button>');
+			const viewer = bodyChild('viewer');
+			// Modal-ness tracks the live `open` state, as in a real engine.
+			mockOpenModals((el) => el === dialog && dialog.hasAttribute('open'));
+
+			const lease = acquire(viewer);
+			// Closed at acquisition: it's just another body child, correctly inert.
+			expect(dialog.hasAttribute('inert')).toBe(true);
+
+			dialog.showModal();
+			await flushObserver();
+
+			// `showModal()` is an attribute change, not a childList one — without
+			// open-state observation the dialog would stay inert, i.e. dead.
+			expect(dialog.open).toBe(true);
+			expect(dialog.hasAttribute('inert')).toBe(false);
+			expect(isBlockedByModal(dialog.querySelector('#d'))).toBe(false);
+
+			dialog.close();
+			lease.release();
+		});
+
+		it('probes `dialog:modal`, never `[open]`', () => {
+			const app = bodyChild('app', '<button id="a">a</button>');
+			const dialog = openModal();
+			dialog.setAttribute('open', '');
+
+			// jsdom has no `:modal` pseudo-class, so asserting "a declarative
+			// `<dialog open>` doesn't block" would pass trivially through the
+			// unsupported-selector fallback. Emulate a supporting engine instead
+			// (where `show()` / declarative-open dialogs do NOT match `:modal`)
+			// and assert the selector the module actually asks for.
+			const selectors: string[] = [];
+			mockOpenModals([], selectors);
+
+			expect(isBlockedByModal(app.querySelector('#a'))).toBe(false);
+			expect(selectors).toContain('dialog:modal');
+			expect(selectors.some((s) => s.includes('[open]'))).toBe(false);
+		});
+
+		it('falls back to no native modal when `:modal` is unsupported', () => {
+			const app = bodyChild('app', '<button id="a">a</button>');
+			// A declaratively-open, NON-modal dialog: an implementation that
+			// answered the unsupported `:modal` with an `[open]` query would find
+			// this and wrongly block, so the fixture can catch that regression.
+			const dialog = openModal('<button id="d">d</button>');
+			dialog.setAttribute('open', '');
+
+			const realQueryAll = document.querySelectorAll.bind(document);
+			const probe = vi
+				.spyOn(document, 'querySelectorAll')
+				.mockImplementation((selector: string) => {
+					if (selector === 'dialog:modal') {
+						throw new SyntaxError('unsupported pseudo-class');
+					}
+					return realQueryAll(selector);
+				});
+
+			expect(isBlockedByModal(app.querySelector('#a'))).toBe(false);
+			// Guards against a "return false without asking" implementation.
+			expect(probe).toHaveBeenCalledWith('dialog:modal');
+			// ...and against any `[open]` fallback: the open dialog must not count.
+			expect(isBlockedByModal(dialog.querySelector('#d'))).toBe(false);
+		});
+	});
+});

--- a/web/src/lib/a11y/viewerBackdrop.svelte.test.ts
+++ b/web/src/lib/a11y/viewerBackdrop.svelte.test.ts
@@ -3,6 +3,8 @@ import {
 	acquire,
 	isBlockedByModal,
 	isViewerFrontmost,
+	hasForeignEscapeOwner,
+	VIEWER_ROOT_CLASS,
 	__resetViewerBackdropForTests,
 } from './viewerBackdrop';
 
@@ -699,5 +701,118 @@ describe('isBlockedByModal', () => {
 			// ...and against any `[open]` fallback: the open dialog must not count.
 			expect(isBlockedByModal(dialog.querySelector('#d'))).toBe(false);
 		});
+	});
+});
+
+describe('hasForeignEscapeOwner', () => {
+	// The shared form of the existence check the two route ESC guards used to
+	// hand-roll (TASK-2429). It answers a NARROWER question than
+	// `isBlockedByModal`: not "is something in front of me" but "does a surface
+	// that owns Escape ITSELF exist" — so a driver of the escape stack knows
+	// whether to stand down entirely.
+
+	/** The shape a portaled viewer root has, including the marker class. */
+	function viewerRoot(): HTMLElement {
+		const el = bodyChild('viewer');
+		el.setAttribute('role', 'dialog');
+		el.classList.add(VIEWER_ROOT_CLASS);
+		return el;
+	}
+
+	/**
+	 * Emulate an engine where `dialog:modal` IS supported (jsdom throws on it —
+	 * probed, not assumed), with `modals` as the open modal dialogs. Only the
+	 * combined selector the module builds is intercepted.
+	 */
+	function mockModalSupport(modals: Element[]): void {
+		const real = document.querySelector.bind(document);
+		vi.spyOn(document, 'querySelector').mockImplementation((selector: string) => {
+			if (!selector.startsWith('dialog:modal')) return real(selector);
+			const rest = selector.slice(selector.indexOf(',') + 1).trim();
+			return modals[0] ?? real(rest);
+		});
+	}
+
+	it('is false with nothing open, so today’s guards are unchanged', () => {
+		bodyChild('app', '<button id="a">a</button>');
+		expect(hasForeignEscapeOwner()).toBe(false);
+	});
+
+	it('is true for an ARIA sheet — the shipped BottomSheet / DockedSheet', () => {
+		// The regression fence for the branch that must NOT be dropped: both are
+		// `role="dialog"` Escape owners with no escape-stack registration, so a
+		// guard that stopped seeing them would let one press close two layers.
+		bodyChild('sheet').setAttribute('role', 'dialog');
+		expect(hasForeignEscapeOwner()).toBe(true);
+	});
+
+	it('is false for the pane’s own mobile overlay', () => {
+		const pane = bodyChild('pane');
+		pane.setAttribute('role', 'dialog');
+		pane.classList.add('item-pane');
+		expect(hasForeignEscapeOwner()).toBe(false);
+	});
+
+	it('is false for the attachment viewer: its Escape is on the stack', () => {
+		// The whole reason this helper exists. A guard that treated the viewer as
+		// a foreign modal would return before running the stack, and Escape would
+		// close nothing at all.
+		viewerRoot();
+		expect(hasForeignEscapeOwner()).toBe(false);
+	});
+
+	it('still sees a sheet opened WHILE a viewer is up', () => {
+		// The exclusion is targeted at the viewer, not a blanket "a viewer is
+		// open, so nothing else counts".
+		viewerRoot();
+		bodyChild('sheet').setAttribute('role', 'dialog');
+		expect(hasForeignEscapeOwner()).toBe(true);
+	});
+
+	it('falls back to `dialog[open]` where `:modal` is unsupported', () => {
+		// jsdom is that engine (it throws on the pseudo-class), so this is the
+		// path every other test here runs on. The fallback is deliberately the
+		// PRE-TASK-2429 selector: where the narrower question can't be asked, the
+		// answer is exactly today's behaviour, never something wider.
+		const dialog = openModal();
+		dialog.setAttribute('open', '');
+		expect(hasForeignEscapeOwner()).toBe(true);
+	});
+
+	it('does not count a CLOSED native <dialog> in the fallback path', () => {
+		// `Modal.svelte` keeps its native <dialog> mounted at all times and drives
+		// it with showModal()/close(), so a fallback that dropped the `[open]`
+		// qualifier would report a foreign Escape owner on every page that merely
+		// HAS a Modal — swallowing the viewer's Escape everywhere.
+		openModal();
+		expect(hasForeignEscapeOwner()).toBe(false);
+	});
+
+	it('asks for `dialog:modal` before falling back', () => {
+		// Guards against an implementation that simply hard-codes `[open]`.
+		const seen: string[] = [];
+		const real = document.querySelector.bind(document);
+		vi.spyOn(document, 'querySelector').mockImplementation((selector: string) => {
+			seen.push(selector);
+			if (selector.startsWith('dialog:modal')) throw new SyntaxError('unsupported');
+			return real(selector);
+		});
+		hasForeignEscapeOwner();
+		expect(seen.some((s) => s.startsWith('dialog:modal'))).toBe(true);
+		expect(seen.some((s) => s.includes('dialog[open]'))).toBe(true);
+	});
+
+	it('on a supporting engine, an open NON-modal <dialog> does not count', () => {
+		// The one behaviour change from the hand-rolled `dialog[open]` string: a
+		// `show()` / declarative-open dialog never owned Escape, and
+		// `Modal.svelte` keeps a native <dialog> mounted at all times.
+		const dialog = openModal();
+		dialog.setAttribute('open', '');
+		mockModalSupport([]);
+		expect(hasForeignEscapeOwner()).toBe(false);
+
+		// ...while a real `showModal()` one does.
+		mockModalSupport([dialog]);
+		expect(hasForeignEscapeOwner()).toBe(true);
 	});
 });

--- a/web/src/lib/a11y/viewerBackdrop.ts
+++ b/web/src/lib/a11y/viewerBackdrop.ts
@@ -375,23 +375,74 @@ export const VIEWER_ROOT_CLASS = 'attachment-viewer';
  * a sheet that doesn't move focus into itself leaves `document.activeElement`
  * on the trigger underneath, so a `closest()` test would miss it.
  *
- * TASK-2430 folds this into {@link isBlockedByModal}'s three-way precedence
- * across all seven global Escape/key owners; 3a needs only the two route
- * guards to stop swallowing the viewer's Escape.
+ * TASK-2430 makes the ARIA branch LEASE-AWARE, and the reason is a change of
+ * premise rather than a change of mind. When 3a shipped, `BottomSheet` and
+ * `DockedSheet` acted on every Escape unconditionally, so a sheet open beneath
+ * a viewer genuinely still owned the key and this helper had to say so. 3b
+ * makes those sheets consult {@link isBlockedByModal} and stand down while a
+ * viewer is frontmost — at which point a `true` here would leave Escape with NO
+ * owner at all: the route driver returns, the sheet declines, and the viewer's
+ * Escape (which lives only on `escapeStack`) never runs. So:
+ *
+ *  • NATIVE branch first, and it still wins outright — a `showModal()` dialog
+ *    is in the top layer, ABOVE any body-portaled viewer.
+ *  • Otherwise the ARIA branch counts only sheets that are NOT behind the
+ *    frontmost viewer. A sheet BEHIND it has stood down, so it owns nothing; a
+ *    sheet nested INSIDE it is in front of the viewer's own content and does
+ *    still own its Escape (`isBlockedByModal(sheetEl)` agrees — the sheet is
+ *    contained by the front root, so it is not blocked). Containment, not a
+ *    blanket "a lease exists ⇒ ignore every sheet", which would let one press
+ *    close a nested sheet AND the viewer under it.
+ *  • With no lease, the ARIA branch is exactly as before.
+ *
+ * Deliberately keyed on LEASE STATE, not on "a `.attachment-viewer` element
+ * exists" — a viewer mid-teardown has dropped its lease and its sheets are live
+ * again, which is the correct moment for them to reclaim the key.
  */
 export function hasForeignEscapeOwner(): boolean {
 	if (!hasDocument()) return false;
-	const aria = `[role="dialog"]:not(.item-pane):not(.${VIEWER_ROOT_CLASS})`;
 	if (modalSelectorSupported !== false) {
 		try {
-			const found = !!document.querySelector(`dialog:modal, ${aria}`);
+			const nativeModal = !!document.querySelector('dialog:modal');
 			modalSelectorSupported = true;
-			return found;
+			if (nativeModal) return true;
+			return hasLiveAriaEscapeOwner();
 		} catch {
 			modalSelectorSupported = false;
 		}
 	}
-	return !!document.querySelector(`dialog[open], ${aria}`);
+	// UNSUPPORTED `:modal`. `dialog[open]` still SHORT-CIRCUITS, and the
+	// containment rule below deliberately does NOT apply to it: nothing in the
+	// app guards a native `<dialog>`, so unlike an ARIA sheet it has not stood
+	// down for the viewer and does still own Escape. Routing it through the
+	// liveness rule instead was tried and reverted — it makes a real
+	// `showModal()` dialog (indistinguishable from a non-modal one on this
+	// branch) stop out-ranking the lease, so one press would fire the browser's
+	// native `cancel` AND run the stack: two layers closed.
+	//
+	// RESIDUAL, KNOWINGLY ACCEPTED: on this branch a NON-modal `<dialog open>`
+	// held open beside a viewer would be reported as an Escape owner while
+	// {@link isBlockedByModal} answers "no native modal" — the route would stand
+	// down for a surface that owns nothing, and Escape would do nothing. It is
+	// unreachable in this app twice over: `Modal.svelte` is the only `<dialog>`
+	// in the tree and drives it exclusively through `showModal()`/`close()`, and
+	// every engine that ships `<dialog>` also ships `:modal`, so this branch is
+	// jsdom and legacy only. Fixing it costs the real-modal case above, which is
+	// the one that can actually happen.
+	if (document.querySelector('dialog[open]')) return true;
+	return hasLiveAriaEscapeOwner();
+}
+
+/**
+ * Is there an ARIA-dialog Escape owner that is actually LIVE — i.e. not one the
+ * viewer backdrop has put behind itself? With no lease every match counts, as
+ * it always did; with one, only matches INSIDE the frontmost viewer do.
+ */
+function hasLiveAriaEscapeOwner(): boolean {
+	const aria = `[role="dialog"]:not(.item-pane):not(.${VIEWER_ROOT_CLASS})`;
+	const front = frontRoot();
+	if (!front) return !!document.querySelector(aria);
+	return Array.from(document.querySelectorAll(aria)).some((el) => front.contains(el));
 }
 
 /** Test seam: drop all leases and observers without running focus handoff. */

--- a/web/src/lib/a11y/viewerBackdrop.ts
+++ b/web/src/lib/a11y/viewerBackdrop.ts
@@ -317,8 +317,49 @@ function keepInteractiveAsDialog(el: Element): boolean {
 }
 
 /**
+ * Events a VIEWER has already consumed (TASK-2448 / BUG-2441).
+ *
+ * A lease-state question cannot arbitrate a dispatch that MUTATES lease state
+ * halfway through. `Lightbox`'s escape-stack handler calls `onClose()`
+ * synchronously, and Svelte flushes the teardown — hence `lease.release()` —
+ * inside that same call. Every `window` keydown listener that runs LATER in the
+ * SAME dispatch therefore asks `isBlockedByModal` against an empty stack, is
+ * told "nothing is in front of you", and closes a second layer.
+ *
+ * So consumption is recorded per EVENT rather than inferred from the lease: the
+ * viewer marks the dispatch it consumed, and that mark outlives its own lease.
+ * Keyed on the event OBJECT (a `WeakSet`, so nothing is retained past the
+ * dispatch) rather than on `defaultPrevented`, because `defaultPrevented` says
+ * only "somebody handled this key" — it is set by controls that are not viewers
+ * at all, and honouring it would change how sheets behave with NO viewer
+ * present. That is exactly the unannounced change TASK-2430 shipped and
+ * reverted. This mark can only ever be set while a viewer is frontmost, so on
+ * an empty lease stack it is unreachable by construction and every consumer
+ * below behaves as it did before.
+ */
+let viewerConsumedEscapes = new WeakSet<Event>();
+
+/**
+ * Record that a viewer consumed `event`. Called by the viewer's escape-stack
+ * handler BEFORE it closes, since closing is what destroys the lease.
+ */
+export function noteEscapeConsumedByViewer(event: Event): void {
+	viewerConsumedEscapes.add(event);
+}
+
+/** Has a viewer already consumed this exact event? */
+export function isEscapeConsumedByViewer(event?: Event | null): boolean {
+	return !!event && viewerConsumedEscapes.has(event);
+}
+
+/**
  * Should `owner` — the SURFACE asking to act, NOT `event.target` — decline
  * because something is in front of it?
+ *
+ * Pass `event` from a keydown owner to get the EVENT-SCOPED answer as well: a
+ * viewer that consumed this very dispatch blocks every later owner in it,
+ * whatever the lease says by the time they ask (TASK-2448). Owners that don't
+ * pass one get the unchanged lease-state answer.
  *
  * Derives from LEASE STATE, never from DOM `inert`, and returns **false on an
  * empty stack** (with no native modal open) so existing guards keep exactly
@@ -332,7 +373,13 @@ function keepInteractiveAsDialog(el: Element): boolean {
  * genuine top dialog. Owners in a lower dialog are already inert by the
  * browser's own top-layer rules, so the permissive answer costs nothing.
  */
-export function isBlockedByModal(owner?: Element | null): boolean {
+export function isBlockedByModal(owner?: Element | null, event?: Event | null): boolean {
+	// FIRST, and unconditionally: a viewer that consumed this dispatch has
+	// already spent it. Checked ahead of the native-dialog branch because it is
+	// the one answer that does not depend on live state at all — the surface that
+	// won the key may no longer exist by now, which is the whole point.
+	if (isEscapeConsumedByViewer(event)) return true;
+
 	const modals = openNativeModals();
 	if (modals.length > 0) return !modals.some((d) => d.contains(owner ?? null));
 
@@ -452,4 +499,7 @@ export function __resetViewerBackdropForTests(): void {
 	stopObserver();
 	owned.clear();
 	modalSelectorSupported = null;
+	// A `WeakSet` can't be cleared, so drop the whole set — otherwise a marked
+	// event object reused across cases would carry a stale consumption.
+	viewerConsumedEscapes = new WeakSet<Event>();
 }

--- a/web/src/lib/a11y/viewerBackdrop.ts
+++ b/web/src/lib/a11y/viewerBackdrop.ts
@@ -1,0 +1,352 @@
+/**
+ * Viewer backdrop manager (PLAN-2392 phase 3a / TASK-2427).
+ *
+ * A refcounted, lease-stacked owner of `inert` on `document.body.children` for
+ * body-portaled VIEWER surfaces (the attachment viewer and friends), plus the
+ * modal-arbitration helpers that let unrelated guards ask "is a viewer in
+ * front of me right now?".
+ *
+ * Scope — this is a VIEWER backdrop, not a modal registry. `Modal`,
+ * `BottomSheet` and `DockedSheet` are deliberately NOT registered here:
+ * inventing promotion/ordering semantics for every overlay in the tree is a
+ * different job. {@link isBlockedByModal} answers "is a viewer lease
+ * frontmost", plus a native `dialog:modal` branch so narrowing the manager
+ * doesn't narrow the arbitration.
+ *
+ * Why body children only: `body` has ONE child in practice — the SvelteKit
+ * `display: contents` wrapper (`app.html:16`) — plus whatever is portaled
+ * alongside it. `inert` cascades, so that single write inerts the entire app,
+ * including the collection pane. There is NO ownership conflict with the
+ * pane's own `inert`: the pane writes NESTED wrappers
+ * (`[username]/[workspace]/+layout.svelte`), never body children. Different
+ * elements, so no attribute observer or re-application logic is needed here.
+ */
+
+import { paneFocusables } from '$lib/collections/paneFocus';
+
+/** A held backdrop lease. Release is idempotent and lease-identity-bound. */
+export interface ViewerBackdropLease {
+	/** The portaled body child that stays interactive while this lease is frontmost. */
+	readonly exemptRoot: HTMLElement;
+	/**
+	 * Drop the lease. `released` is false on a repeat call (no-op). `stackEmpty`
+	 * reports whether any lease remains AFTER this release — the caller uses it
+	 * to decide between letting the manager hand focus to the next viewer and
+	 * restoring its own invoker.
+	 */
+	release(): { released: boolean; stackEmpty: boolean };
+}
+
+interface LeaseRecord {
+	root: HTMLElement;
+	released: boolean;
+}
+
+/** Front of the stack is the LAST entry — the topmost viewer. */
+const stack: LeaseRecord[] = [];
+
+/**
+ * Elements this module set `inert` on. Anything already inert when we looked
+ * (someone else's write, or authored markup) is never recorded and never
+ * cleared — we only undo our own writes.
+ */
+const owned = new Set<Element>();
+
+/** ONE shared observer for all leases; disconnected when the stack empties. */
+let observer: MutationObserver | null = null;
+/** The `body` the live observer is attached to, so a replaced body re-arms it. */
+let observedBody: HTMLElement | null = null;
+
+function hasDocument(): boolean {
+	return typeof document !== 'undefined' && !!document.body;
+}
+
+function frontRoot(): HTMLElement | null {
+	return stack.length > 0 ? stack[stack.length - 1].root : null;
+}
+
+/**
+ * The exact set of body children that SHOULD be inert right now: everything
+ * except the frontmost lease's exempt root — and except an open modal
+ * `<dialog>`, which lives in the TOP LAYER above the viewer. A modal dialog
+ * escapes an inert ANCESTOR, but an `inert` attribute on the dialog itself
+ * still disables it, so writing one here would kill a dialog opened over the
+ * viewer. Open-state changes are watched (see {@link startObserver}) because
+ * they are not childList mutations: a dialog mounted CLOSED before the lease
+ * is inerted, and would STAY inert through a later `showModal()` — a dead
+ * modal — without that.
+ */
+function desiredInertSet(): Set<Element> {
+	const front = frontRoot();
+	if (!front || !hasDocument()) return new Set();
+	const desired = new Set<Element>();
+	for (const child of Array.from(document.body.children)) {
+		if (child === front || keepInteractiveAsDialog(child)) continue;
+		desired.add(child);
+	}
+	return desired;
+}
+
+/**
+ * Recompute and apply the desired inert set from scratch. This is the ONLY
+ * mutator: release doesn't undo its own writes, it re-derives the truth from
+ * the current stack, which is what makes out-of-order release correct
+ * (A→B→release-A must leave A's root inert, since B is still frontmost).
+ */
+function reconcile(): void {
+	if (!hasDocument()) return;
+	const desired = desiredInertSet();
+
+	for (const el of Array.from(owned)) {
+		if (desired.has(el)) continue;
+		el.removeAttribute('inert');
+		owned.delete(el);
+	}
+
+	for (const el of desired) {
+		if (owned.has(el)) continue;
+		// Pre-existing `inert` belongs to whoever wrote it — leave it, and don't
+		// take ownership, so we never clear it on release.
+		if (el.hasAttribute('inert')) continue;
+		el.setAttribute('inert', '');
+		owned.add(el);
+	}
+}
+
+function startObserver(): void {
+	if (!hasDocument() || typeof MutationObserver === 'undefined') return;
+	// Re-arm if `document.body` was replaced under us — the old observer is
+	// still attached to a body nobody renders into any more.
+	if (observer && observedBody === document.body) return;
+	stopObserver();
+	observer = new MutationObserver((records) => {
+		// `<body>` itself was swapped: this observer is now watching a detached
+		// element, so re-arm on the live body before reconciling. Detected here
+		// (rather than only on the next `acquire`) because the lease may never
+		// see another acquire.
+		if (observedBody !== document.body) {
+			startObserver();
+			reconcile();
+			return;
+		}
+		for (const record of records) {
+			// Only two mutations can change the desired set, and both are scoped
+			// to `<body>`'s own children:
+			//
+			//  • childList ON body — a portal arriving mid-lease must be inerted
+			//    too. Nested childList records can't change the body-child set,
+			//    so they're ignored (subtree:true is only on for the attribute
+			//    filter below).
+			//  • `open` on a body-child `<dialog>` — `showModal()` on a dialog
+			//    mounted closed has to un-inert it, and that is an attribute
+			//    change, not a childList one. Deeper `open` toggles and non-dialog
+			//    `open` (`<details>`) are irrelevant.
+			//
+			// This deliberately does NOT observe `inert`: re-applying `inert`
+			// against other writers is the design that was tried and reverted.
+			const target = record.target as Element;
+			const relevant =
+				record.type === 'childList'
+					? target === document.body
+					: target.parentElement === document.body && target.tagName === 'DIALOG';
+			if (relevant) {
+				reconcile();
+				return;
+			}
+		}
+	});
+	observer.observe(document.body, {
+		childList: true,
+		attributes: true,
+		attributeFilter: ['open'],
+		subtree: true,
+	});
+	// `<html>`'s child list is what tells us `<body>` itself got replaced —
+	// nothing on the old body fires once it is detached.
+	observer.observe(document.documentElement, { childList: true });
+	observedBody = document.body;
+}
+
+function stopObserver(): void {
+	observer?.disconnect();
+	observer = null;
+	observedBody = null;
+}
+
+/**
+ * Was focus inside `root` (or nowhere in particular)? `<body>` / `null` is the
+ * "adrift" state a viewer teardown leaves behind, and counts as ours to move.
+ */
+function focusWasInside(root: HTMLElement): boolean {
+	if (!hasDocument()) return false;
+	// ANY open `showModal()` dialog owns the top layer, wherever it sits in the
+	// tree — inside the closing viewer, alongside it, anywhere. While one is
+	// open the handoff must not run at all: it would pull focus into a viewer
+	// that is, by the browser's own layering, behind the dialog. Checked BEFORE
+	// the adrift case, since focus resting on `<body>` is not a licence either.
+	if (openNativeModals().length > 0) return false;
+	const active = document.activeElement;
+	if (active === null || active === document.body) return true;
+	return root.contains(active);
+}
+
+/**
+ * Hand focus into `root`'s first tabbable descendant. When the viewer beneath
+ * has no tabbable control (still loading, image-only), focus the root itself —
+ * made programmatically focusable if it isn't already — rather than letting
+ * focus fall to `<body>` once the closing viewer unmounts. Nobody else would
+ * catch it: the caller only restores its own invoker on `stackEmpty`.
+ */
+function focusInto(root: HTMLElement): void {
+	const target = paneFocusables(root)[0];
+	if (target) {
+		target.focus();
+		return;
+	}
+	if (!root.hasAttribute('tabindex')) root.setAttribute('tabindex', '-1');
+	root.focus();
+}
+
+/**
+ * Take a backdrop lease for `exemptRoot`, inerting every OTHER body child.
+ *
+ * `exemptRoot` MUST be a direct child of `<body>` (the portal target). A nested
+ * element would leave its containing body child inerted, which inerts the
+ * "exempt" subtree along with everything else.
+ */
+export function acquire(exemptRoot: HTMLElement): ViewerBackdropLease {
+	if (import.meta.env?.DEV && hasDocument() && exemptRoot.parentElement !== document.body) {
+		console.warn(
+			'[viewerBackdrop] exemptRoot is not a direct child of <body>; ' +
+				'its containing body child will be inerted, including the exempt subtree.',
+			exemptRoot,
+		);
+	}
+
+	const record: LeaseRecord = { root: exemptRoot, released: false };
+	stack.push(record);
+	startObserver();
+	reconcile();
+
+	return {
+		exemptRoot,
+		release(): { released: boolean; stackEmpty: boolean } {
+			if (record.released) return { released: false, stackEmpty: stack.length === 0 };
+			record.released = true;
+
+			const index = stack.indexOf(record);
+			const wasFrontmost = index === stack.length - 1;
+			if (index !== -1) stack.splice(index, 1);
+
+			reconcile();
+
+			const next = frontRoot();
+			// Releasing a BACKGROUND lease changes nothing visible and must not
+			// steal focus; only the frontmost hands off to the viewer beneath it.
+			// And only when focus was actually IN the closing viewer (or already
+			// adrift on `<body>`): if it sits somewhere else — a native modal
+			// opened over the viewer, say — that surface owns it, and yanking it
+			// into the viewer beneath would be the theft this handoff exists to
+			// prevent.
+			try {
+				if (wasFrontmost && next && focusWasInside(exemptRoot)) focusInto(next);
+			} finally {
+				// Belt and braces: the handoff only runs when a lease REMAINS, so
+				// today a throwing focus handler can't reach the empty-stack
+				// teardown anyway. The `finally` keeps that true if the ordering
+				// is ever changed.
+				if (stack.length === 0) stopObserver();
+			}
+
+			return { released: true, stackEmpty: stack.length === 0 };
+		},
+	};
+}
+
+/** True when `root` is the frontmost viewer's exempt root. */
+export function isViewerFrontmost(root: Element): boolean {
+	return stack.length > 0 && stack[stack.length - 1].root === root;
+}
+
+/**
+ * `:modal` matches ONLY dialogs opened with `showModal()` — unlike `[open]`,
+ * which also matches non-modal `show()` dialogs and declarative
+ * `<dialog open>`. Not every engine (or jsdom) supports it, so probe once and
+ * fall back to "no native modal" rather than to a wrong selector.
+ */
+let modalSelectorSupported: boolean | null = null;
+
+/** Every `showModal()` dialog currently open, or `[]` where `:modal` is unsupported. */
+function openNativeModals(): Element[] {
+	if (!hasDocument() || modalSelectorSupported === false) return [];
+	try {
+		const found = Array.from(document.querySelectorAll('dialog:modal'));
+		modalSelectorSupported = true;
+		return found;
+	} catch {
+		// Unsupported pseudo-class: answer "no native modal" rather than fall
+		// back to a selector that would be wrong.
+		modalSelectorSupported = false;
+		return [];
+	}
+}
+
+/**
+ * Should `el` be kept OUT of the inert set as a top-layer dialog?
+ *
+ * The fallback differs from {@link openNativeModals} on purpose, because the
+ * two failure modes are not symmetric. For arbitration, guessing "modal" where
+ * there is none would block real surfaces, so an unsupported `:modal` answers
+ * "no modal". For the MUTATOR, guessing "not modal" writes `inert` ONTO a real
+ * `showModal()` dialog and kills it — the user is left with a modal they cannot
+ * operate or dismiss. So where `:modal` is unsupported we fall back to `open`,
+ * accepting that a non-modal open `<dialog>` also escapes the backdrop: a
+ * slightly leaky backdrop beats a dead modal. (Every engine that ships
+ * `<dialog>` today supports `:modal`; this is the jsdom / legacy path.)
+ */
+function keepInteractiveAsDialog(el: Element): boolean {
+	if (modalSelectorSupported === false) return el.matches('dialog[open]');
+	try {
+		const match = el.matches('dialog:modal');
+		modalSelectorSupported = true;
+		return match;
+	} catch {
+		modalSelectorSupported = false;
+		return el.matches('dialog[open]');
+	}
+}
+
+/**
+ * Should `owner` — the SURFACE asking to act, NOT `event.target` — decline
+ * because something is in front of it?
+ *
+ * Derives from LEASE STATE, never from DOM `inert`, and returns **false on an
+ * empty stack** (with no native modal open) so existing guards keep exactly
+ * today's behaviour. An owner inside whatever IS in front is not blocked.
+ *
+ * A `showModal()` dialog is in the TOP LAYER, above any body-portaled viewer,
+ * so it wins the precedence question outright: when one is open, only owners
+ * inside it may act — even if a viewer lease is also held. With SEVERAL open,
+ * ANY of them exempts its own owners: top-layer order is not observable from
+ * the DOM (it is not document order), and guessing wrong would block the
+ * genuine top dialog. Owners in a lower dialog are already inert by the
+ * browser's own top-layer rules, so the permissive answer costs nothing.
+ */
+export function isBlockedByModal(owner?: Element | null): boolean {
+	const modals = openNativeModals();
+	if (modals.length > 0) return !modals.some((d) => d.contains(owner ?? null));
+
+	const front = frontRoot();
+	if (front) return !front.contains(owner ?? null);
+
+	return false;
+}
+
+/** Test seam: drop all leases and observers without running focus handoff. */
+export function __resetViewerBackdropForTests(): void {
+	stack.length = 0;
+	reconcile();
+	stopObserver();
+	owned.clear();
+	modalSelectorSupported = null;
+}

--- a/web/src/lib/a11y/viewerBackdrop.ts
+++ b/web/src/lib/a11y/viewerBackdrop.ts
@@ -342,6 +342,58 @@ export function isBlockedByModal(owner?: Element | null): boolean {
 	return false;
 }
 
+/**
+ * Class carried by every body-portaled VIEWER root (TASK-2429). The viewer is a
+ * `role="dialog"`, so without a marker it is indistinguishable from the foreign
+ * modals the app's ESC guards stand down for — and standing down for it would
+ * leave Escape with NO owner, since the viewer's own Escape lives on
+ * `escapeStack`. Exported (rather than typed twice) so the markup and the
+ * selector below cannot drift apart.
+ */
+export const VIEWER_ROOT_CLASS = 'attachment-viewer';
+
+/**
+ * Is a modal surface open that owns Escape ITSELF, so an escape-stack driver
+ * must stand down entirely?
+ *
+ * This is the shared form of the existence check the two route keydown handlers
+ * hand-rolled as `document.querySelector('dialog[open], [role="dialog"]:not(.item-pane)')`.
+ * Two deliberate differences from that string:
+ *
+ *  • The NATIVE branch is feature-detected `dialog:modal`, not `dialog[open]`.
+ *    A non-modal `show()` / declarative `<dialog open>` never owned Escape, and
+ *    `Modal.svelte` is always mounted — so `[open]` was over-broad. Where the
+ *    pseudo-class is unsupported (jsdom, legacy engines) it falls back to
+ *    `dialog[open]`, i.e. exactly today's behaviour, never to something wider.
+ *  • The ARIA branch additionally excludes {@link VIEWER_ROOT_CLASS}. It is
+ *    otherwise UNCHANGED and deliberately kept: `BottomSheet` and `DockedSheet`
+ *    are shipped `role="dialog"` Escape owners with no stack registration, and
+ *    dropping the branch would regress both. `.item-pane` stays excluded for
+ *    the reason it always was (TASK-2131) — it is on the stack too.
+ *
+ * Existence-based, not target-based, for the reason recorded at the call sites:
+ * a sheet that doesn't move focus into itself leaves `document.activeElement`
+ * on the trigger underneath, so a `closest()` test would miss it.
+ *
+ * TASK-2430 folds this into {@link isBlockedByModal}'s three-way precedence
+ * across all seven global Escape/key owners; 3a needs only the two route
+ * guards to stop swallowing the viewer's Escape.
+ */
+export function hasForeignEscapeOwner(): boolean {
+	if (!hasDocument()) return false;
+	const aria = `[role="dialog"]:not(.item-pane):not(.${VIEWER_ROOT_CLASS})`;
+	if (modalSelectorSupported !== false) {
+		try {
+			const found = !!document.querySelector(`dialog:modal, ${aria}`);
+			modalSelectorSupported = true;
+			return found;
+		} catch {
+			modalSelectorSupported = false;
+		}
+	}
+	return !!document.querySelector(`dialog[open], ${aria}`);
+}
+
 /** Test seam: drop all leases and observers without running focus handoff. */
 export function __resetViewerBackdropForTests(): void {
 	stack.length = 0;

--- a/web/src/lib/attachments/editorOwnedImage.svelte.test.ts
+++ b/web/src/lib/attachments/editorOwnedImage.svelte.test.ts
@@ -1,0 +1,103 @@
+// `isEditorOwnedImage` — the boundary between markup a surface rendered and
+// DOM a live editor owns (PLAN-2392 DR-12 / TASK-2432).
+//
+// Both produce `img[data-attachment-id]`, so a delegated handler cannot tell
+// them apart by selector. Getting this predicate wrong in either direction is a
+// real failure: too broad and ItemTimeline stops opening its OWN thumbnails;
+// too narrow and it keeps stripping semantics off a live CommentEditor's
+// images and opening viewers on keys that editor needs.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { isEditorOwnedImage } from './editorOwnedImage';
+
+describe('isEditorOwnedImage', () => {
+	let root: HTMLElement;
+
+	beforeEach(() => {
+		root = document.body.appendChild(document.createElement('div'));
+	});
+
+	afterEach(() => root.remove());
+
+	function build(html: string): HTMLElement {
+		root.innerHTML = html;
+		const img = root.querySelector('img[data-attachment-id]');
+		if (!img) throw new Error('fixture has no attachment image');
+		return img as HTMLElement;
+	}
+
+	it('claims an image inside a live editor', () => {
+		// The shape CommentEditor mounts inside a timeline comment card.
+		const img = build(`
+			<div class="entry-list">
+				<div class="comment-card">
+					<div class="ce-surface">
+						<div class="ProseMirror" contenteditable="true">
+							<p><span class="attachment-image-wrapper"
+								><img data-attachment-id="u1" alt="draft"
+							/></span></p>
+						</div>
+					</div>
+				</div>
+			</div>`);
+		expect(isEditorOwnedImage(img)).toBe(true);
+	});
+
+	it('does NOT claim a rendered comment body image', () => {
+		// The `{@html}` output ItemTimeline legitimately owns — nested just as
+		// deeply, so depth is not what the predicate is keying on.
+		const img = build(`
+			<div class="entry-list">
+				<div class="comment-card">
+					<div class="comment-body">
+						<p><img data-attachment-id="u1" alt="posted" /></p>
+					</div>
+				</div>
+			</div>`);
+		expect(isEditorOwnedImage(img)).toBe(false);
+	});
+
+	it('does not claim a rendered body that merely SITS NEXT TO an editor', () => {
+		// A comment card showing a posted body while a reply editor is open
+		// below it. A predicate that keyed on the entry list, the card, or "this
+		// subtree contains an editor" would get this one wrong.
+		root.innerHTML = `
+			<div class="comment-card">
+				<div class="comment-body"><img data-attachment-id="posted" /></div>
+				<div class="ProseMirror" contenteditable="true">
+					<img data-attachment-id="draft" />
+				</div>
+			</div>`;
+		const posted = root.querySelector<HTMLElement>('img[data-attachment-id="posted"]')!;
+		const draft = root.querySelector<HTMLElement>('img[data-attachment-id="draft"]')!;
+		expect(isEditorOwnedImage(posted)).toBe(false);
+		expect(isEditorOwnedImage(draft)).toBe(true);
+	});
+
+	it('is not fooled by a comment body that CLAIMS to be an editor', () => {
+		// Rendered markdown may carry raw HTML, and the sanitizer allows both
+		// `class` and `data-attachment-id` — so this is ordinary user content,
+		// not an editor. A class-only test would hand it to nobody: no
+		// delegation, no accessibility pass, no way to open it at all.
+		const img = build(`
+			<div class="comment-body">
+				<div class="ProseMirror"><img data-attachment-id="u1" /></div>
+			</div>`);
+		expect(isEditorOwnedImage(img)).toBe(false);
+	});
+
+	it('claims a READ-ONLY editor too', () => {
+		// A frozen editor still owns its DOM; ProseMirror marks it
+		// contenteditable="false", so presence — not truthiness — is the test.
+		const img = build(`
+			<div class="ProseMirror" contenteditable="false">
+				<img data-attachment-id="u1" />
+			</div>`);
+		expect(isEditorOwnedImage(img)).toBe(true);
+	});
+
+	it('does not claim a detached image', () => {
+		const img = document.createElement('img');
+		img.setAttribute('data-attachment-id', 'u1');
+		expect(isEditorOwnedImage(img)).toBe(false);
+	});
+});

--- a/web/src/lib/attachments/editorOwnedImage.ts
+++ b/web/src/lib/attachments/editorOwnedImage.ts
@@ -1,0 +1,44 @@
+/**
+ * Is this attachment image owned by a LIVE editor rather than by rendered
+ * markup? (PLAN-2392 DR-12 / TASK-2432.)
+ *
+ * Two very different things produce `<img data-attachment-id="…">`:
+ *
+ *   - sanitized `{@html}` output from `$lib/markdown/attachments.ts` — inert
+ *     markup, so whichever surface rendered it also owns its interactivity;
+ *   - the AttachmentImage Tiptap NodeView inside a live editor — which owns
+ *     its OWN activation, semantics and propagation (see
+ *     `$lib/components/editor/attachment-image.ts`).
+ *
+ * A surface that delegates over a subtree containing BOTH cannot tell them
+ * apart by selector, and ItemTimeline is exactly that surface: its delegated
+ * thumbnail handlers and its role/tabindex pass cover the whole entry list,
+ * and that list contains live CommentEditor instances
+ * (`TimelineCommentCard.svelte`). Two concrete failures follow from treating
+ * the NodeView's image as one of its own:
+ *
+ *   - its accessibility pass strips role/tabindex/aria-label from a NodeView
+ *     image whose UUID isn't in `attMeta` — which is every image in a DRAFT
+ *     comment, because `attMeta` is probed from SAVED bodies only. The image
+ *     silently stops being keyboard-reachable.
+ *   - its delegated keydown matches Enter/Space with no modifier check, so a
+ *     MODIFIED activation key — which the NodeView deliberately lets through,
+ *     because Cmd/Ctrl+Enter is CommentEditor's submit binding — opens a
+ *     viewer on top of the submit.
+ *
+ * `.ProseMirror` is the class ProseMirror puts on every view root — but the
+ * CLASS ALONE IS FORGEABLE. Rendered markdown may carry raw HTML, and
+ * `sanitizeMarkdownHtml` allows both `class` and `data-attachment-id`
+ * (`$lib/utils/markdown.ts`), so a comment body containing
+ * `<div class="ProseMirror"><img data-attachment-id="…"></div>` is ordinary
+ * user content that the class test alone would hand to nobody: invisible to
+ * the timeline's delegation AND to its accessibility pass.
+ *
+ * `contenteditable` is what makes the marker sound. ProseMirror sets it on
+ * every view root (`"false"` on a read-only one, so presence — not value — is
+ * the test), and it is NOT in the sanitizer's attribute allowlist, so rendered
+ * markdown cannot produce it.
+ */
+export function isEditorOwnedImage(el: Element): boolean {
+	return el.closest('.ProseMirror[contenteditable]') !== null;
+}

--- a/web/src/lib/attachments/events.test.ts
+++ b/web/src/lib/attachments/events.test.ts
@@ -2,9 +2,14 @@ import { describe, expect, it } from 'vitest';
 import {
 	createAttachmentHostToken,
 	isAttachmentPanelEventForHost,
+	isAttachmentViewerEventForHost,
 	notifyAttachmentPanelOpen,
+	notifyViewerOpen,
 	registerAttachmentPanelListener,
+	registerAttachmentViewerListener,
 	type AttachmentPanelOpenEvent,
+	type AttachmentViewerOpenEvent,
+	type LightboxImage,
 } from './events';
 
 /**
@@ -164,5 +169,234 @@ describe('the panel channel with two live hosts', () => {
 		off();
 		notifyAttachmentPanelOpen(event({ hostToken: host.hostToken }));
 		expect(seen).toHaveLength(1);
+	});
+});
+
+/**
+ * The addressing layer for the image viewer (PLAN-2392 phase 3a / TASK-2428).
+ *
+ * Same shape of test as the panel channel above, and for the same reason: the
+ * bus is module-global while `ItemDetail` is mounted twice (master + peeked
+ * pane), so every case below has a concrete two-viewer bug behind it. The two
+ * channels are exercised separately because they are separate predicates —
+ * a shared rule stated twice is exactly what regresses in one place only.
+ */
+function image(over: Partial<LightboxImage> = {}): LightboxImage {
+	return {
+		id: 'att-1',
+		alt: 'a diagram',
+		filename: 'diagram.png',
+		mime_type: 'image/png',
+		size_bytes: 4096,
+		width: 800,
+		height: 600,
+		...over,
+	};
+}
+
+function viewerEvent(over: Partial<AttachmentViewerOpenEvent> = {}): AttachmentViewerOpenEvent {
+	return {
+		attachmentId: 'att-1',
+		workspaceSlug: 'ws-1',
+		itemId: 'item-1',
+		hostToken: 'host-a',
+		images: [image()],
+		index: 0,
+		invoker: null,
+		...over,
+	};
+}
+
+describe('isAttachmentViewerEventForHost', () => {
+	const host = { itemId: 'item-1', hostToken: 'host-a' };
+
+	it('matches when BOTH the item and the token are the host’s', () => {
+		expect(isAttachmentViewerEventForHost(viewerEvent(), host)).toBe(true);
+	});
+
+	it('ignores an event that matches only the item (the two-panes-one-item case)', () => {
+		expect(isAttachmentViewerEventForHost(viewerEvent({ hostToken: 'host-b' }), host)).toBe(
+			false
+		);
+	});
+
+	it('ignores an event that matches only the token', () => {
+		expect(isAttachmentViewerEventForHost(viewerEvent({ itemId: 'item-2' }), host)).toBe(false);
+	});
+
+	it('never matches on a missing half, on either side', () => {
+		// Two absences are not a match: a surface given no token must not be
+		// able to address every host at once, and a host without one must not
+		// consume unaddressed events.
+		expect(isAttachmentViewerEventForHost(viewerEvent({ hostToken: '' }), host)).toBe(false);
+		expect(isAttachmentViewerEventForHost(viewerEvent({ itemId: '' }), host)).toBe(false);
+		expect(
+			isAttachmentViewerEventForHost(viewerEvent(), { itemId: 'item-1', hostToken: '' })
+		).toBe(false);
+		expect(isAttachmentViewerEventForHost(viewerEvent(), { itemId: null, hostToken: null })).toBe(
+			false
+		);
+		expect(
+			isAttachmentViewerEventForHost(viewerEvent({ hostToken: '', itemId: '' }), {
+				itemId: '',
+				hostToken: '',
+			})
+		).toBe(false);
+	});
+
+	it('tolerates a null/undefined event', () => {
+		expect(isAttachmentViewerEventForHost(null, host)).toBe(false);
+		expect(isAttachmentViewerEventForHost(undefined, host)).toBe(false);
+	});
+});
+
+describe('viewer open channel', () => {
+	it('delivers to the addressed host only, with two hosts subscribed', () => {
+		const master = { itemId: 'item-1', hostToken: createAttachmentHostToken() };
+		const peeked = { itemId: 'item-1', hostToken: createAttachmentHostToken() };
+		const masterSeen: AttachmentViewerOpenEvent[] = [];
+		const peekedSeen: AttachmentViewerOpenEvent[] = [];
+		const offMaster = registerAttachmentViewerListener((e) => {
+			if (isAttachmentViewerEventForHost(e, master)) masterSeen.push(e);
+		});
+		const offPeeked = registerAttachmentViewerListener((e) => {
+			if (isAttachmentViewerEventForHost(e, peeked)) peekedSeen.push(e);
+		});
+		try {
+			notifyViewerOpen(viewerEvent({ hostToken: peeked.hostToken }));
+			expect(masterSeen).toHaveLength(0);
+			expect(peekedSeen).toHaveLength(1);
+
+			notifyViewerOpen(viewerEvent({ attachmentId: 'att-2', hostToken: master.hostToken }));
+			expect(masterSeen).toHaveLength(1);
+			expect(masterSeen[0].attachmentId).toBe('att-2');
+			expect(peekedSeen).toHaveLength(1);
+		} finally {
+			offMaster();
+			offPeeked();
+		}
+	});
+
+	it('carries the emit-time workspace, the set, the index and the invoker through unchanged', () => {
+		// The workspace is CAPTURED, not resolved by the host: the pane can
+		// switch workspace without remounting, so a host that read it live
+		// could serve a viewer opened in ws1 from ws2's endpoint.
+		const host = { itemId: 'item-1', hostToken: createAttachmentHostToken() };
+		// A stand-in element: this suite runs in the node environment, and the
+		// bus only ever carries the reference — the host is where it is used.
+		const invoker = { tagName: 'IMG' } as unknown as HTMLElement;
+		const images = [image(), image({ id: 'att-2', alt: 'second' })];
+		let received: AttachmentViewerOpenEvent | null = null;
+		const off = registerAttachmentViewerListener((e) => {
+			if (isAttachmentViewerEventForHost(e, host)) received = e;
+		});
+		try {
+			notifyViewerOpen(
+				viewerEvent({
+					attachmentId: 'att-2',
+					workspaceSlug: 'other-ws',
+					hostToken: host.hostToken,
+					images,
+					index: 1,
+					invoker,
+				})
+			);
+		} finally {
+			off();
+		}
+		const got = received as AttachmentViewerOpenEvent | null;
+		expect(got).not.toBeNull();
+		expect(got!.workspaceSlug).toBe('other-ws');
+		expect(got!.images).toEqual(images);
+		expect(got!.index).toBe(1);
+		// The event's own invariant: the index names the attachment it opened on.
+		expect(got!.images[got!.index]?.id).toBe(got!.attachmentId);
+		expect(got!.invoker).toBe(invoker);
+	});
+
+	it('passes incomplete image metadata through as nulls', () => {
+		// An inline image knows only what its NodeView options give it, and its
+		// HEAD probe may not have completed. The viewer opens anyway.
+		const host = { itemId: 'item-1', hostToken: createAttachmentHostToken() };
+		let received: AttachmentViewerOpenEvent | null = null;
+		const off = registerAttachmentViewerListener((e) => {
+			if (isAttachmentViewerEventForHost(e, host)) received = e;
+		});
+		try {
+			notifyViewerOpen(
+				viewerEvent({
+					hostToken: host.hostToken,
+					images: [
+						image({
+							filename: null,
+							mime_type: null,
+							size_bytes: null,
+							width: null,
+							height: null,
+						}),
+					],
+				})
+			);
+		} finally {
+			off();
+		}
+		const got = received as AttachmentViewerOpenEvent | null;
+		expect(got).not.toBeNull();
+		expect(got!.images[0].filename).toBeNull();
+		expect(got!.images[0].width).toBeNull();
+	});
+
+	it('drops an unaddressable or empty emission rather than broadcasting it', () => {
+		const seen: AttachmentViewerOpenEvent[] = [];
+		const off = registerAttachmentViewerListener((e) => seen.push(e));
+		try {
+			notifyViewerOpen(viewerEvent({ hostToken: '' }));
+			notifyViewerOpen(viewerEvent({ itemId: '' }));
+			notifyViewerOpen(viewerEvent({ attachmentId: '' }));
+			// A full-screen viewer with nothing to show is worse than no viewer.
+			notifyViewerOpen(viewerEvent({ images: [] }));
+			// The slug is a path segment of every image URL, and the host does
+			// not substitute its own: without it the viewer opens on 404s.
+			notifyViewerOpen(viewerEvent({ workspaceSlug: '' }));
+		} finally {
+			off();
+		}
+		expect(seen).toHaveLength(0);
+	});
+
+	it('returns a disposer that stops delivery', () => {
+		const host = { itemId: 'item-1', hostToken: createAttachmentHostToken() };
+		const seen: AttachmentViewerOpenEvent[] = [];
+		const off = registerAttachmentViewerListener((e) => {
+			if (isAttachmentViewerEventForHost(e, host)) seen.push(e);
+		});
+		notifyViewerOpen(viewerEvent({ hostToken: host.hostToken }));
+		expect(typeof off).toBe('function');
+		off();
+		notifyViewerOpen(viewerEvent({ hostToken: host.hostToken }));
+		expect(seen).toHaveLength(1);
+		// Disposing twice is a no-op, not a throw — teardown paths can double-fire.
+		expect(() => off()).not.toThrow();
+	});
+
+	it('keeps the two channels separate', () => {
+		// One host, both channels: a panel emission must not open a viewer and
+		// a viewer emission must not open a panel, even though the identity
+		// fields (and the TOKEN — one per host, not one per channel) are shared.
+		const host = { itemId: 'item-1', hostToken: createAttachmentHostToken() };
+		const viewerSeen: AttachmentViewerOpenEvent[] = [];
+		const panelSeen: AttachmentPanelOpenEvent[] = [];
+		const offViewer = registerAttachmentViewerListener((e) => viewerSeen.push(e));
+		const offPanel = registerAttachmentPanelListener((e) => panelSeen.push(e));
+		try {
+			notifyAttachmentPanelOpen(event({ hostToken: host.hostToken }));
+			notifyViewerOpen(viewerEvent({ hostToken: host.hostToken }));
+		} finally {
+			offViewer();
+			offPanel();
+		}
+		expect(viewerSeen).toHaveLength(1);
+		expect(panelSeen).toHaveLength(1);
+		expect(viewerSeen[0].attachmentId).toBe('att-1');
 	});
 });

--- a/web/src/lib/attachments/events.test.ts
+++ b/web/src/lib/attachments/events.test.ts
@@ -10,6 +10,8 @@ import {
 	type AttachmentPanelOpenEvent,
 	type AttachmentViewerOpenEvent,
 	type LightboxImage,
+	type ViewerOpenRequest,
+	type ViewerReadyImage,
 } from './events';
 
 /**
@@ -194,13 +196,28 @@ function image(over: Partial<LightboxImage> = {}): LightboxImage {
 	};
 }
 
-function viewerEvent(over: Partial<AttachmentViewerOpenEvent> = {}): AttachmentViewerOpenEvent {
+// Typed as the EMITTER's shape (`ViewerOpenRequest`), not the event's: the
+// producer half of this channel must resolve the MIME before it asks for a
+// viewer, and that is now a type, so the fixture has to satisfy it. The one
+// case that deliberately violates it casts, and asserts the runtime guard.
+/**
+ * The same member in the PRODUCER's shape. The cast is confined to this one
+ * helper: every field but `mime_type` is identical, and the default IS a
+ * resolved allowlisted type, so the assertion is true of everything it returns.
+ * A case that deliberately wants an unresolved or refused MIME calls `image()`
+ * and casts at ITS call site, where the violation is visible.
+ */
+function viewable(over: Partial<LightboxImage> = {}): ViewerReadyImage {
+	return image({ mime_type: 'image/png', ...over }) as ViewerReadyImage;
+}
+
+function viewerEvent(over: Partial<ViewerOpenRequest> = {}): ViewerOpenRequest {
 	return {
 		attachmentId: 'att-1',
 		workspaceSlug: 'ws-1',
 		itemId: 'item-1',
 		hostToken: 'host-a',
-		images: [image()],
+		images: [viewable()],
 		index: 0,
 		invoker: null,
 		...over,
@@ -285,7 +302,7 @@ describe('viewer open channel', () => {
 		// A stand-in element: this suite runs in the node environment, and the
 		// bus only ever carries the reference — the host is where it is used.
 		const invoker = { tagName: 'IMG' } as unknown as HTMLElement;
-		const images = [image(), image({ id: 'att-2', alt: 'second' })];
+		const images = [viewable(), viewable({ id: 'att-2', alt: 'second' })];
 		let received: AttachmentViewerOpenEvent | null = null;
 		const off = registerAttachmentViewerListener((e) => {
 			if (isAttachmentViewerEventForHost(e, host)) received = e;
@@ -314,9 +331,13 @@ describe('viewer open channel', () => {
 		expect(got!.invoker).toBe(invoker);
 	});
 
-	it('passes incomplete image metadata through as nulls', () => {
-		// An inline image knows only what its NodeView options give it, and its
-		// HEAD probe may not have completed. The viewer opens anyway.
+	it('passes the CAPTION metadata through as nulls', () => {
+		// An inline image knows only what its NodeView options give it: there is
+		// no filename on the node's attrs and the HEAD probe carries no
+		// dimensions. Those are captions — absent is a fact about the producer,
+		// not a reason to refuse — so the viewer opens anyway. `mime_type` is
+		// deliberately NOT in this list; it is the gate, and the next test is
+		// about it.
 		const host = { itemId: 'item-1', hostToken: createAttachmentHostToken() };
 		let received: AttachmentViewerOpenEvent | null = null;
 		const off = registerAttachmentViewerListener((e) => {
@@ -327,9 +348,8 @@ describe('viewer open channel', () => {
 				viewerEvent({
 					hostToken: host.hostToken,
 					images: [
-						image({
+						viewable({
 							filename: null,
-							mime_type: null,
 							size_bytes: null,
 							width: null,
 							height: null,
@@ -344,6 +364,110 @@ describe('viewer open channel', () => {
 		expect(got).not.toBeNull();
 		expect(got!.images[0].filename).toBeNull();
 		expect(got!.images[0].width).toBeNull();
+	});
+
+	it('refuses a set whose MIME is unresolved or not allowlisted', () => {
+		// THE GATE, at the boundary rather than in each producer (TASK-2433).
+		//
+		// This test used to assert the opposite — that a null `mime_type` was
+		// passed through — on the reasoning that what is viewable is the
+		// emitter's judgement. TASK-2431 ended that: `Lightbox` FAILS CLOSED on
+		// an unresolved MIME, so an emission the viewer will filter to nothing
+		// is not a permissive channel, it is an image that does not open with
+		// nothing thrown and nothing logged. A producer that forgets is now
+		// refused here, where every producer passes.
+		//
+		// The casts are the point, not a workaround: `notifyViewerOpen` takes
+		// `ViewerOpenRequest`, so each of these is ALREADY a compile error at an
+		// honest call site. What is asserted here is the runtime half — the one
+		// that still holds for a JS caller, an `any`, or a value that arrived
+		// from outside the type system.
+		const seen: AttachmentViewerOpenEvent[] = [];
+		const off = registerAttachmentViewerListener((e) => seen.push(e));
+		try {
+			// Unresolved: the probe never answered, or the producer never asked.
+			notifyViewerOpen(viewerEvent({ images: [image({ mime_type: null }) as ViewerReadyImage] }));
+			// Resolved, and refused: `image/svg+xml` can carry active content
+			// (DR-16). `image/*` is not sufficient reason to display something.
+			notifyViewerOpen(
+				viewerEvent({ images: [image({ mime_type: 'image/svg+xml' }) as ViewerReadyImage] })
+			);
+			notifyViewerOpen(
+				viewerEvent({ images: [image({ mime_type: 'application/pdf' }) as ViewerReadyImage] })
+			);
+			// ONE bad entry poisons the whole emission rather than being filtered
+			// out of it: `index` and `attachmentId` name a position in the set the
+			// PRODUCER built, and silently renumbering it would open the viewer on
+			// a different image than the one the user activated.
+			notifyViewerOpen(
+				viewerEvent({
+					images: [viewable(), image({ id: 'att-2', mime_type: null }) as ViewerReadyImage],
+				})
+			);
+		} finally {
+			off();
+		}
+		expect(seen).toHaveLength(0);
+	});
+
+	it('refuses a malformed set instead of throwing out of a notify call', () => {
+		// A boundary's input is only as good as its caller, and a THROW here is
+		// worse than a drop: it unwinds out of a notify function into whatever
+		// the producer was doing — for the inline image NodeView, into the
+		// `.then` of its MIME resolution, as an unhandled rejection.
+		//
+		// The sparse case is the one a type cannot catch and `.some` silently
+		// permits: holes are SKIPPED by `.some`, so a hole-only array passes an
+		// every-entry check that is written with it and arrives at a viewer with
+		// nothing to show.
+		const seen: AttachmentViewerOpenEvent[] = [];
+		const off = registerAttachmentViewerListener((e) => seen.push(e));
+		const bad = (images: unknown) =>
+			notifyViewerOpen({ ...viewerEvent(), images } as unknown as ViewerOpenRequest);
+		try {
+			expect(() => bad({ length: 1 })).not.toThrow();
+			expect(() => bad(new Array(1))).not.toThrow();
+			expect(() => bad([undefined])).not.toThrow();
+			expect(() => bad([{ id: 'att-1', alt: '', mime_type: 42 }])).not.toThrow();
+			expect(() => bad('image/png')).not.toThrow();
+			expect(() => bad(null)).not.toThrow();
+		} finally {
+			off();
+		}
+		expect(seen).toHaveLength(0);
+	});
+
+	it('delivers a FROZEN set unchanged — readonly is the contract, not a rejection', () => {
+		// The set is `readonly` on the event because the viewer must not reorder
+		// or mutate something the emitter still owns, so a producer freezing its
+		// own array is the contract being honoured, not a malformed input.
+		const seen: AttachmentViewerOpenEvent[] = [];
+		const off = registerAttachmentViewerListener((e) => seen.push(e));
+		const images = Object.freeze([viewable()]);
+		try {
+			notifyViewerOpen(viewerEvent({ images }));
+		} finally {
+			off();
+		}
+		expect(seen).toHaveLength(1);
+		expect(seen[0].images).toBe(images);
+	});
+
+	it('still delivers a set whose every entry is allowlisted', () => {
+		// The control. A gate that refused everything would satisfy the test
+		// above and close the channel.
+		const seen: AttachmentViewerOpenEvent[] = [];
+		const off = registerAttachmentViewerListener((e) => seen.push(e));
+		try {
+			notifyViewerOpen(
+				viewerEvent({
+					images: [viewable(), viewable({ id: 'att-2', mime_type: 'image/webp' })],
+				})
+			);
+		} finally {
+			off();
+		}
+		expect(seen).toHaveLength(1);
 	});
 
 	it('drops an unaddressable or empty emission rather than broadcasting it', () => {

--- a/web/src/lib/attachments/events.ts
+++ b/web/src/lib/attachments/events.ts
@@ -247,3 +247,153 @@ export function notifyAttachmentPanelOpen(event: AttachmentPanelOpenEvent): void
 	if (!event?.attachmentId || !event.itemId || !event.hostToken) return;
 	for (const fn of panelListeners) fn(event);
 }
+
+/**
+ * Image viewer (PLAN-2392 phase 3a, TASK-2428).
+ *
+ * Tapping an image — an inline editor image, and in phase 3c the surfaces that
+ * still mount their own viewer — opens the full-screen `Lightbox`. Same problem
+ * as the panel channel above, same answer: the emitters include Tiptap
+ * NodeViews, which are imperative DOM and cannot mount a Svelte component, so
+ * they signal through this bus and an `ItemDetail`-owned host does the mounting.
+ *
+ * ADDRESSING is DR-8's, unchanged and shared: a host consumes an event only
+ * when BOTH `itemId` and `hostToken` are its own, because the bus is global
+ * while `ItemDetail` is mounted more than once (master pane + peeked pane).
+ * The token is the SAME one the panel channel uses — one token per HOST, not
+ * one per channel — so `createAttachmentHostToken` is not duplicated here.
+ *
+ * WHY THE STRIP AND THE TIMELINE ARE NOT ON THIS CHANNEL: they mount `Lightbox`
+ * directly and keep doing so. The a11y contract lives in the component, and the
+ * lease stack makes coexisting mounts safe, so consolidating producers buys
+ * nothing until 3c gives them a single surface to consolidate ONTO. A decision,
+ * not an omission.
+ *
+ * `mutationsEnabled` is deliberately absent from this channel and from the
+ * host: 3a's viewer has no mutating action, so it would be a dead prop. It is a
+ * hard prerequisite of 3c's Delete, and when it arrives its source must be the
+ * host's own gate.
+ */
+export interface LightboxImage {
+	id: string;
+	alt: string;
+	/**
+	 * Metadata the viewer may caption with, all NULLABLE for the same reason
+	 * the panel's three are: an emitter knows only what its own surface gives
+	 * it, and an inline image's HEAD probe may not have completed or may have
+	 * failed. Structurally a superset of the `Lightbox` component's own
+	 * `LightboxImage` ({id, alt}), so a set built for this channel is passed
+	 * straight through to it.
+	 */
+	filename: string | null;
+	mime_type: string | null;
+	size_bytes: number | null;
+	width: number | null;
+	height: number | null;
+}
+
+export interface AttachmentViewerOpenEvent {
+	/** UUID of the attachment the viewer opens ON. */
+	attachmentId: string;
+	/**
+	 * Workspace the images are read from, CAPTURED AT EMIT — never read live
+	 * from the host. The pane switches workspace without remounting, so a host
+	 * that resolved the slug itself at render time could serve a viewer opened
+	 * in ws1 from ws2's endpoint. The emitter knows which workspace the click
+	 * happened in; that is the answer the viewer must keep.
+	 */
+	workspaceSlug: string;
+	/**
+	 * UUID of the item whose `ItemDetail` mount should SHOW the viewer.
+	 *
+	 * ROUTING, not ownership — see `AttachmentPanelOpenEvent.itemId` for the
+	 * full argument. It names the host in front of the user; it asserts nothing
+	 * about which item the attachment belongs to, and nothing about permission.
+	 */
+	itemId: string;
+	/** Identity of the `ItemDetail` mount that owns the emitting surface. */
+	hostToken: string;
+	/**
+	 * The set the viewer's ←/→ page through, in the emitting surface's own
+	 * order. Readonly because the viewer must not reorder or mutate a set the
+	 * emitter still owns.
+	 */
+	images: readonly LightboxImage[];
+	/** Index to open at. `images[index]?.id === attachmentId` at emit. */
+	index: number;
+	/**
+	 * The element the viewer returns focus to on close. Null when the emitter
+	 * has no stable element to offer.
+	 */
+	invoker: HTMLElement | null;
+}
+
+const viewerListeners = new Set<(event: AttachmentViewerOpenEvent) => void>();
+
+/**
+ * "Is this event mine?" — the single predicate every viewer host must use.
+ *
+ * Deliberately a separate function from the panel's rather than one generic
+ * over both: the two events are different shapes, and a shared predicate would
+ * have to be typed loosely enough to accept anything with two string fields.
+ * The RULE is identical and stated once, in `isAddressable`: both sides must be
+ * fully addressable before a comparison means anything — two empty tokens are
+ * not a match, they are two absences.
+ *
+ * The event parameter accepts `null | undefined` where the panel's does not.
+ * That is the signature TASK-2428 specifies, and it matches what both
+ * functions have always DONE at runtime (`if (!event) return false`) — the
+ * panel's type is simply narrower than its behaviour. Widening the panel's to
+ * match is a change to a shipped surface and belongs to whoever next touches
+ * it, not to this task.
+ */
+export function isAttachmentViewerEventForHost(
+	event: AttachmentViewerOpenEvent | null | undefined,
+	host: { itemId: string | null | undefined; hostToken: string | null | undefined }
+): boolean {
+	if (!event) return false;
+	const from = { itemId: event.itemId, hostToken: event.hostToken };
+	const to = { itemId: host?.itemId ?? '', hostToken: host?.hostToken ?? '' };
+	if (!isAddressable(from) || !isAddressable(to)) return false;
+	return from.itemId === to.itemId && from.hostToken === to.hostToken;
+}
+
+/**
+ * Subscribe to open-viewer requests. Returns a dispose function — call it from
+ * the host's teardown, or the listener leaks and fires into a dead component.
+ * Listeners receive EVERY emission; filter with
+ * `isAttachmentViewerEventForHost`.
+ */
+export function registerAttachmentViewerListener(
+	fn: (event: AttachmentViewerOpenEvent) => void
+): () => void {
+	viewerListeners.add(fn);
+	return () => viewerListeners.delete(fn);
+}
+
+/**
+ * Request that the owning host open the image viewer.
+ *
+ * No-op when the event can't address a host, can't be fetched, or carries no
+ * images: an emission missing any identity field would either reach nobody or
+ * invite a "matches anything" reading of the predicate; one without a workspace
+ * would open a viewer whose every image URL 404s (the slug is a path segment,
+ * and the host deliberately does not substitute its own); and an empty set
+ * would open a full-screen viewer showing nothing.
+ *
+ * What it deliberately does NOT police: the `index` (the viewer clamps, and
+ * dropping the whole emission over an off-by-one would be a silent no-op where
+ * showing the neighbouring image is harmless), and the MIME types in the set —
+ * what is viewable is the EMITTER's judgement, made against the surface it is
+ * emitting from, not a rule this channel can state for every future producer.
+ *
+ * (Named per TASK-2428's normative signature — `notifyViewerOpen`, without the
+ * `Attachment` infix the sibling emitters carry. The task spells the exported
+ * surface out explicitly, so it wins over the local naming rhyme.)
+ */
+export function notifyViewerOpen(event: AttachmentViewerOpenEvent): void {
+	if (!event?.attachmentId || !event.itemId || !event.hostToken) return;
+	if (!event.workspaceSlug) return;
+	if (!event.images?.length) return;
+	for (const fn of viewerListeners) fn(event);
+}

--- a/web/src/lib/attachments/events.ts
+++ b/web/src/lib/attachments/events.ts
@@ -22,6 +22,7 @@
 import { invalidateAttachmentMetadata } from '$lib/components/editor/attachment-metadata';
 import type { AttachmentUploadResult } from '$lib/types';
 import { isAddressable } from '$lib/attachments/hostAddress';
+import { canOpenInViewer } from '$lib/attachments/display';
 
 const listeners = new Set<(uuid: string) => void>();
 
@@ -338,6 +339,31 @@ export interface AttachmentViewerOpenEvent {
 	invoker: HTMLElement | null;
 }
 
+/**
+ * An image a producer has RESOLVED as viewable — same shape as `LightboxImage`
+ * with the one field that is a GATE rather than a caption made non-nullable.
+ *
+ * Two types rather than one, deliberately, because the two directions have
+ * genuinely different obligations. A PRODUCER must know the MIME before it
+ * asks for a viewer (TASK-2433), so `notifyViewerOpen` takes this and a
+ * `mime_type: null` emission is a compile error at the call site rather than a
+ * silent no-op at runtime. A CONSUMER must keep accepting the nullable shape:
+ * `Lightbox` is mounted directly by the strip and the timeline as well, its
+ * records are live and can lose their MIME, and its own filter is what covers
+ * a row that turns unsafe after the viewer is already open.
+ *
+ * The other three nullable fields stay nullable in both directions — phase 3b's
+ * loading policy wants `width` / `height` when a producer has them and must
+ * still work when it does not, and no producer has a filename for an inline
+ * body image at all.
+ */
+export type ViewerReadyImage = Omit<LightboxImage, 'mime_type'> & { mime_type: string };
+
+/** What `notifyViewerOpen` accepts: the event, with the set already resolved. */
+export interface ViewerOpenRequest extends Omit<AttachmentViewerOpenEvent, 'images'> {
+	images: readonly ViewerReadyImage[];
+}
+
 const viewerListeners = new Set<(event: AttachmentViewerOpenEvent) => void>();
 
 /**
@@ -391,19 +417,52 @@ export function registerAttachmentViewerListener(
  * and the host deliberately does not substitute its own); and an empty set
  * would open a full-screen viewer showing nothing.
  *
+ * IT ALSO POLICES THE MIME (TASK-2433). This channel used to leave that to the
+ * emitter, on the reasoning that what is viewable is a judgement about the
+ * surface it is emitted from. That reasoning stopped holding when TASK-2431
+ * made `Lightbox` FAIL CLOSED on an unresolved MIME: a set the viewer will
+ * filter to nothing does not produce an error, it produces an image that does
+ * not open, with nothing thrown and nothing logged. "Resolve the MIME before
+ * you emit" was then a convention, and a convention the next producer breaks
+ * silently is not an invariant — so it is enforced here, where every producer
+ * passes.
+ *
+ * THE WHOLE EMISSION IS DROPPED, not the offending entry. Filtering the set
+ * would desynchronize it from `index` and `attachmentId` — the event's own
+ * stated invariant is `images[index]?.id === attachmentId`, and a bus that
+ * quietly renumbered a producer's set would open the viewer on a different
+ * image than the one that was activated. `Lightbox`'s own `$derived` filter
+ * stays as the second line: it re-applies the gate over the live records, so a
+ * row that becomes unsafe AFTER the viewer opened is still dropped.
+ *
  * What it deliberately does NOT police: the `index` (the viewer clamps, and
  * dropping the whole emission over an off-by-one would be a silent no-op where
- * showing the neighbouring image is harmless), and the MIME types in the set —
- * what is viewable is the EMITTER's judgement, made against the surface it is
- * emitting from, not a rule this channel can state for every future producer.
+ * showing the neighbouring image is harmless).
  *
  * (Named per TASK-2428's normative signature — `notifyViewerOpen`, without the
  * `Attachment` infix the sibling emitters carry. The task spells the exported
  * surface out explicitly, so it wins over the local naming rhyme.)
  */
-export function notifyViewerOpen(event: AttachmentViewerOpenEvent): void {
+export function notifyViewerOpen(event: ViewerOpenRequest): void {
 	if (!event?.attachmentId || !event.itemId || !event.hostToken) return;
 	if (!event.workspaceSlug) return;
-	if (!event.images?.length) return;
+	// `Array.isArray` rather than a truthy `length`, and an INDEXED loop rather
+	// than `.some`, because this is a boundary and its input is only as good as
+	// the caller. An array-like `{length: 1}` would make `.some` throw — out of
+	// a notify function, into a producer's `.then`, as an unhandled rejection —
+	// and a SPARSE array's holes are skipped by `.some` entirely, so `new
+	// Array(1)` would sail through the gate and reach a viewer with nothing in
+	// it. A type is not a runtime guarantee for a shared module.
+	if (!Array.isArray(event.images) || event.images.length === 0) return;
+	for (let i = 0; i < event.images.length; i++) {
+		const img = event.images[i];
+		// POSITIVELY allowlisted, every entry. `canOpenInViewer` answers false
+		// for null and undefined alike, so "unresolved" and "resolved to
+		// something we will not display" are refused by the same call — which is
+		// the point: to the user they are the same non-event, and only one of
+		// them was ever spelled out in a producer's comments.
+		if (!img || typeof img.mime_type !== 'string') return;
+		if (!canOpenInViewer(img.mime_type)) return;
+	}
 	for (const fn of viewerListeners) fn(event);
 }

--- a/web/src/lib/attachments/events.ts
+++ b/web/src/lib/attachments/events.ts
@@ -281,9 +281,19 @@ export interface LightboxImage {
 	 * Metadata the viewer may caption with, all NULLABLE for the same reason
 	 * the panel's three are: an emitter knows only what its own surface gives
 	 * it, and an inline image's HEAD probe may not have completed or may have
-	 * failed. Structurally a superset of the `Lightbox` component's own
-	 * `LightboxImage` ({id, alt}), so a set built for this channel is passed
-	 * straight through to it.
+	 * failed, while an upload event carries only four fields
+	 * (`UploadedAttachment`).
+	 *
+	 * `mime_type` is not decoration: it is what lets a CONSUMER re-state the
+	 * DR-16 open gate over a whole set rather than trusting the one element
+	 * that was clicked (TASK-2431). `width` / `height` are here ahead of any
+	 * reader — phase 3b's pixel-based loading policy needs them, and adding
+	 * them now costs one nullable field per producer instead of reopening the
+	 * event, the host and every producer later.
+	 *
+	 * This is the ONLY declaration of the shape. `Lightbox.svelte` used to
+	 * carry its own `{id, alt}` twin; it now re-exports this one, so the
+	 * component's props and the channel's payload cannot drift.
 	 */
 	filename: string | null;
 	mime_type: string | null;

--- a/web/src/lib/attachments/events.ts
+++ b/web/src/lib/attachments/events.ts
@@ -293,7 +293,7 @@ export interface LightboxImage {
 	 * event, the host and every producer later.
 	 *
 	 * This is the ONLY declaration of the shape. `Lightbox.svelte` used to
-	 * carry its own `{id, alt}` twin; it now re-exports this one, so the
+	 * carry its own `{id, alt}` twin; it now imports this one, so the
 	 * component's props and the channel's payload cannot drift.
 	 */
 	filename: string | null;

--- a/web/src/lib/attachments/viewerResource.svelte.ts
+++ b/web/src/lib/attachments/viewerResource.svelte.ts
@@ -1,0 +1,59 @@
+import { untrack } from 'svelte';
+import { nextViewerResourceGen, viewerResourceKey } from './viewerResource';
+
+/**
+ * The viewer-resource generation as a live counter (TASK-2428).
+ *
+ * The pure rule lives next door in `viewerResource.ts`; this is the reactive
+ * wrapper `ItemDetail` actually uses. It is a module rather than four lines
+ * inline in a 7,000-line component for one reason: the `$effect` below is the
+ * subtlest thing in this task, and inline it could only ever be exercised
+ * through `AttachmentViewerHost`'s props — which are handed the answer and so
+ * cannot tell a correct counter from one that never moves, nor a healthy flush
+ * from a self-invalidating one (Codex round 6).
+ *
+ * SELF-WRITE DISCIPLINE (CONVE-1688). The effect writes `gen`, which it must
+ * therefore never READ in its tracked scope: an `$effect` that depends on what
+ * it writes aborts the flush, and an aborted flush strands unrelated reactivity
+ * elsewhere in the same batch while reporting nothing in a production build.
+ * So the tracked scope reads ONLY the caller's inputs, and both the comparison
+ * and the write happen inside `untrack`. `lastKey` is a plain `let` for the
+ * same reason — as `$state` it would reintroduce exactly that dependency.
+ *
+ * Must be called during component initialisation, like any `$effect` owner.
+ */
+export interface ViewerResourceInput {
+	/** Workspace the CURRENTLY LOADED item belongs to, not the route's. */
+	workspaceSlug: string;
+	/** UUID of the loaded item. */
+	itemId: string | null | undefined;
+	/** Whether the loaded item matches the requested ref (the switch boundary). */
+	loaded: boolean;
+}
+
+export interface ViewerResourceGen {
+	/** Advances only on a real loaded-item resource change. */
+	readonly current: number;
+}
+
+export function createViewerResourceGen(read: () => ViewerResourceInput): ViewerResourceGen {
+	let gen = $state(0);
+	let lastKey = '';
+
+	$effect(() => {
+		const input = read();
+		const key = viewerResourceKey(input.workspaceSlug, input.itemId, input.loaded);
+		untrack(() => {
+			const next = nextViewerResourceGen(key, lastKey, gen);
+			if (next === gen) return;
+			lastKey = key;
+			gen = next;
+		});
+	});
+
+	return {
+		get current() {
+			return gen;
+		},
+	};
+}

--- a/web/src/lib/attachments/viewerResource.test.ts
+++ b/web/src/lib/attachments/viewerResource.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import { nextViewerResourceGen, viewerResourceKey } from './viewerResource';
+
+/**
+ * The generation half of the viewer's lifecycle rule (TASK-2428).
+ *
+ * Extracted from `ItemDetail` precisely so these sequences can be stated: a
+ * host-level test cannot distinguish a correct generation from one that simply
+ * never moves, because all it ever sees is the number it was handed.
+ *
+ * The sequences below are the ones `ItemDetail` actually produces — the key is
+ * `itemMatchesRef ? {ws, item.id} : ''`, which reads empty mid-switch.
+ */
+describe('viewerResourceKey', () => {
+	it('is empty until the loaded item matches the requested ref', () => {
+		expect(viewerResourceKey('ws', 'item-a', false)).toBe('');
+		expect(viewerResourceKey('ws', undefined, true)).toBe('');
+		expect(viewerResourceKey('ws', 'item-a', true)).not.toBe('');
+	});
+
+	it('includes the workspace, so the same ref in two workspaces is two resources', () => {
+		// A reused pane can navigate ws1→ws2 carrying `?item=<ref>` where both
+		// workspaces own that ref (IDEA-2135).
+		expect(viewerResourceKey('ws1', 'item-a', true)).not.toBe(
+			viewerResourceKey('ws2', 'item-a', true)
+		);
+	});
+
+	it('contains no control characters', () => {
+		// A NUL separator makes the whole source file binary to grep — caught
+		// in review on the first draft of this rule.
+		expect(viewerResourceKey('ws', 'item-a', true)).toMatch(/^[\x20-\x7e]+$/);
+	});
+});
+
+describe('nextViewerResourceGen', () => {
+	/** Replays a key sequence, returning the generation after each step. */
+	function replay(keys: string[]): number[] {
+		let gen = 0;
+		let lastKey = '';
+		return keys.map((key) => {
+			const next = nextViewerResourceGen(key, lastKey, gen);
+			if (next !== gen) {
+				lastKey = key;
+				gen = next;
+			}
+			return gen;
+		});
+	}
+
+	it('advances once when the first item loads', () => {
+		expect(replay(['', 'ws A'])).toEqual([0, 1]);
+	});
+
+	it('does NOT advance on a same-item reload', () => {
+		// The whole point: a collection schema edit refetches the item already
+		// on screen. `loadGeneration` moves; this must not.
+		expect(replay(['ws A', 'ws A', 'ws A'])).toEqual([1, 1, 1]);
+	});
+
+	it('counts an A→B switch once, through the empty mid-switch key', () => {
+		expect(replay(['ws A', '', 'ws B'])).toEqual([1, 1, 2]);
+	});
+
+	it('does not count a boundary flap that lands back on the same item', () => {
+		expect(replay(['ws A', '', 'ws A'])).toEqual([1, 1, 1]);
+	});
+
+	it('counts A→B→A as three distinct resources, not two', () => {
+		// Rapid j/k paging. Coming BACK to A is a resource change too: whatever
+		// was open belonged to B.
+		expect(replay(['ws A', '', 'ws B', '', 'ws A'])).toEqual([1, 1, 2, 2, 3]);
+	});
+
+	it('counts a cross-workspace switch that keeps the ref', () => {
+		expect(replay(['ws1 A', 'ws2 A'])).toEqual([1, 2]);
+	});
+
+	it('never advances on the empty key alone', () => {
+		expect(replay(['', '', ''])).toEqual([0, 0, 0]);
+	});
+});

--- a/web/src/lib/attachments/viewerResource.ts
+++ b/web/src/lib/attachments/viewerResource.ts
@@ -1,0 +1,48 @@
+/**
+ * The viewer's resource-identity rule (PLAN-2392 phase 3a, TASK-2428).
+ *
+ * `AttachmentViewerHost` closes an open viewer on a RESOURCE SWITCH and on
+ * nothing else. Half of that is the host's own `itemId`; the other half is a
+ * generation counter, because the id alone cannot tell a same-item resource
+ * change from a same-item RELOAD — and `ItemDetail` reloads constantly (a
+ * collection schema edit refetches the item it is already showing).
+ *
+ * The two counters `ItemDetail` already has are both wrong for this:
+ * `loadGeneration` is a non-reactive fence bumped by EVERY `loadData()`, and
+ * `itemGen` is bumped by every optimistic item write. Keying a viewer on either
+ * tears it down on a refresh that changed nothing the user can see.
+ *
+ * This module is the rule itself, extracted from the component for one reason:
+ * `ItemDetail` is 7,000 lines with no unit harness, so a rule left inline is
+ * only ever tested through the host's props — which cannot see whether the
+ * generation was computed correctly in the first place.
+ */
+
+/** Identity of a loaded item resource, or `''` for "nothing loaded". */
+export function viewerResourceKey(
+	workspaceSlug: string | null | undefined,
+	itemId: string | null | undefined,
+	loaded: boolean
+): string {
+	if (!loaded || !itemId) return '';
+	// The workspace is part of the identity, not decoration: a reused pane can
+	// navigate ws1→ws2 carrying the same `?item=<ref>` where both workspaces
+	// own that ref (IDEA-2135). A plain `::` separator, deliberately: the first
+	// draft used a NUL, which makes the whole source file binary to grep.
+	return `${workspaceSlug ?? ''}::${itemId}`;
+}
+
+/**
+ * The next generation for an observed key. Returns the CURRENT generation
+ * unchanged when nothing advanced, so the caller's write is a no-op.
+ *
+ * An EMPTY key never advances it. Empty is "no loaded resource right now" —
+ * what the switch boundary reads mid-load — so A→''→B is ONE transition and
+ * counts once, at B. (Going empty still closes an open viewer: that is the
+ * host's `itemId` arm, which fires immediately rather than waiting for a
+ * replacement that may never arrive.)
+ */
+export function nextViewerResourceGen(key: string, lastKey: string, gen: number): number {
+	if (!key || key === lastKey) return gen;
+	return gen + 1;
+}

--- a/web/src/lib/attachments/viewerResourceGen.svelte.test.ts
+++ b/web/src/lib/attachments/viewerResourceGen.svelte.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { flushSync } from 'svelte';
+import { createViewerResourceGen } from './viewerResource.svelte';
+
+/**
+ * The generation EFFECT (TASK-2428) — the production one `ItemDetail` calls,
+ * not a copy of it.
+ *
+ * Two things are under test, and the second is why this file exists at all:
+ *
+ *  1. Which transitions advance the counter. Driven through the same inputs
+ *     `ItemDetail` supplies (`loadedItemWsSlug`, `item?.id`, `itemMatchesRef`),
+ *     replaying the sequences a real session produces — a route alias, a
+ *     schema-edit reload, an A→B switch through the empty mid-switch boundary,
+ *     a cross-workspace nav that keeps the ref.
+ *
+ *  2. That the effect keeps the FLUSH alive. An `$effect` that reads a `$state`
+ *     it also writes in its tracked scope aborts the flush and strands
+ *     unrelated reactivity in the same batch, reporting nothing in a production
+ *     build (CONVE-1688). A test that only checks the counter's VALUE passes
+ *     through that, because the counter is what the aborted effect already
+ *     wrote. So every case below runs beside an independent probe effect that
+ *     must keep observing — the neighbour is the assertion.
+ */
+
+// One reactive input object, the shape ItemDetail's reader closes over.
+const input = $state({ workspaceSlug: '', itemId: null as string | null, loaded: false });
+
+interface Harness {
+	gen: () => number;
+	/** Values the neighbouring effect observed, in order. */
+	probeSeen: number[];
+	/** How many times the neighbour re-ran. */
+	probeRuns: () => number;
+	stop: () => void;
+}
+
+let running: Harness | null = null;
+
+function start(): Harness {
+	const probeSeen: number[] = [];
+	let probeRuns = 0;
+	let read!: () => number;
+	const stop = $effect.root(() => {
+		const resource = createViewerResourceGen(() => ({
+			workspaceSlug: input.workspaceSlug,
+			itemId: input.itemId,
+			loaded: input.loaded,
+		}));
+		read = () => resource.current;
+		// The neighbour. It depends on the counter, so a stranded flush shows up
+		// as a value it never sees — and it is a SEPARATE effect, so an aborted
+		// batch takes it down with the one that aborted.
+		$effect(() => {
+			probeSeen.push(resource.current);
+			probeRuns += 1;
+		});
+	});
+	flushSync();
+	running = { gen: () => read(), probeSeen, probeRuns: () => probeRuns, stop };
+	return running;
+}
+
+/** Applies one observable state of the loaded item, then settles. */
+function set(next: Partial<typeof input>) {
+	Object.assign(input, next);
+	flushSync();
+}
+
+/** The mid-switch boundary: `itemMatchesRef` false, item not yet adopted. */
+const MID_SWITCH = { loaded: false };
+
+afterEach(() => {
+	running?.stop();
+	running = null;
+	Object.assign(input, { workspaceSlug: '', itemId: null, loaded: false });
+});
+
+describe('createViewerResourceGen', () => {
+	it('advances once when the first item loads, and the neighbour sees it', () => {
+		const h = start();
+		expect(h.gen()).toBe(0);
+
+		set({ workspaceSlug: 'ws', itemId: 'item-a', loaded: true });
+		expect(h.gen()).toBe(1);
+		// Not just the value: the downstream effect actually re-ran with it.
+		expect(h.probeSeen).toEqual([0, 1]);
+	});
+
+	it('does NOT advance on a collection-only or username-only route alias', () => {
+		// `/dave/ws/tasks/TASK-1` → `/dave/ws/bugs/TASK-1` (or a different
+		// username for the same workspace). The route change triggers a
+		// `loadData()`, which re-adopts the SAME item under the SAME workspace,
+		// so every input this effect reads is re-asserted unchanged. That is
+		// the whole reason the route is not one of its inputs.
+		const h = start();
+		set({ workspaceSlug: 'ws', itemId: 'item-a', loaded: true });
+		const runsBefore = h.probeRuns();
+
+		set({ workspaceSlug: 'ws', itemId: 'item-a', loaded: true });
+		set({ workspaceSlug: 'ws', itemId: 'item-a', loaded: true });
+
+		expect(h.gen()).toBe(1);
+		// The neighbour did not re-run either: nothing downstream was disturbed
+		// by a refresh that changed nothing.
+		expect(h.probeRuns()).toBe(runsBefore);
+	});
+
+	it('does NOT advance on the reload that follows a collection schema edit', () => {
+		// `loadData()` flips `loading` and re-adopts the same item. On this
+		// path `itemMatchesRef` never goes false (the item is not nulled), so
+		// the inputs never leave the loaded state.
+		const h = start();
+		set({ workspaceSlug: 'ws', itemId: 'item-a', loaded: true });
+		set({ workspaceSlug: 'ws', itemId: 'item-a', loaded: true });
+
+		expect(h.gen()).toBe(1);
+		expect(h.probeSeen).toEqual([0, 1]);
+	});
+
+	it('counts an A→B switch ONCE, through the empty mid-switch boundary', () => {
+		const h = start();
+		set({ workspaceSlug: 'ws', itemId: 'item-a', loaded: true });
+
+		set(MID_SWITCH);
+		expect(h.gen()).toBe(1); // the gap is not a resource
+		set({ workspaceSlug: 'ws', itemId: 'item-b', loaded: true });
+
+		expect(h.gen()).toBe(2);
+		expect(h.probeSeen).toEqual([0, 1, 2]);
+	});
+
+	it('counts a boundary flap that lands back on the same item as NOTHING', () => {
+		const h = start();
+		set({ workspaceSlug: 'ws', itemId: 'item-a', loaded: true });
+		const runsBefore = h.probeRuns();
+
+		set(MID_SWITCH);
+		set({ workspaceSlug: 'ws', itemId: 'item-a', loaded: true });
+
+		expect(h.gen()).toBe(1);
+		expect(h.probeRuns()).toBe(runsBefore);
+	});
+
+	it('advances on a same-ref DIFFERENT-WORKSPACE change', () => {
+		// A reused pane navigating ws1→ws2 while carrying `?item=<ref>`, where
+		// both workspaces own that ref (IDEA-2135). The plain item id would
+		// miss it if the two happened to resolve to the same id; the workspace
+		// is part of the identity precisely so it cannot.
+		const h = start();
+		set({ workspaceSlug: 'ws1', itemId: 'item-a', loaded: true });
+		set({ workspaceSlug: 'ws2', itemId: 'item-a', loaded: true });
+
+		expect(h.gen()).toBe(2);
+		expect(h.probeSeen).toEqual([0, 1, 2]);
+	});
+
+	it('counts A→B→A as three resources, keeping the neighbour live throughout', () => {
+		// Rapid j/k paging. Coming back to A is a change too: whatever was open
+		// belonged to B. This is also the sequence a self-invalidating effect
+		// survives longest, because its first write is a no-op.
+		const h = start();
+		set({ workspaceSlug: 'ws', itemId: 'item-a', loaded: true });
+		set(MID_SWITCH);
+		set({ workspaceSlug: 'ws', itemId: 'item-b', loaded: true });
+		set(MID_SWITCH);
+		set({ workspaceSlug: 'ws', itemId: 'item-a', loaded: true });
+
+		expect(h.gen()).toBe(3);
+		expect(h.probeSeen).toEqual([0, 1, 2, 3]);
+		// Still reacting after five transitions — the flush was never aborted.
+		set(MID_SWITCH);
+		set({ workspaceSlug: 'ws', itemId: 'item-c', loaded: true });
+		expect(h.probeSeen).toEqual([0, 1, 2, 3, 4]);
+	});
+
+	it('never advances while nothing is loaded', () => {
+		const h = start();
+		set({ workspaceSlug: 'ws', itemId: 'item-a', loaded: false });
+		set({ workspaceSlug: 'ws', itemId: null, loaded: false });
+
+		expect(h.gen()).toBe(0);
+		expect(h.probeSeen).toEqual([0]);
+	});
+});

--- a/web/src/lib/collections/paneFocus.ts
+++ b/web/src/lib/collections/paneFocus.ts
@@ -64,6 +64,14 @@ export function paneFocusables(
  * the `:not`, `closest()` from any in-pane element would match the pane and
  * wrongly mark the whole pane exempt (killing the mobile Tab trap and confusing
  * the classifier). A genuinely nested dialog opened FROM the pane still matches.
+ *
+ * The attachment viewer (TASK-2429) matches the ARIA branch, and MUST: it is a
+ * body-portaled `role="dialog"` that runs its own Tab trap and key handling, so
+ * both consumers have to leave it alone — exactly the case this set exists for.
+ * That is the opposite of the route ESC guards, which have to look PAST it
+ * (`hasForeignEscapeOwner`, `$lib/a11y/viewerBackdrop`) because its Escape is on
+ * the shared stack. Same attribute, two different questions; audited as part of
+ * TASK-2429's collision sweep.
  */
 export const PANE_EXEMPT_SURFACE_SELECTOR =
 	'dialog, [role="dialog"]:not(.item-pane), [role="menu"], [role="listbox"], .block-context-menu';

--- a/web/src/lib/components/CommentEditor.svelte
+++ b/web/src/lib/components/CommentEditor.svelte
@@ -158,8 +158,11 @@
 					workspaceSlug: wsSlug,
 					// Panel / viewer addressing (PLAN-2392 DR-8).
 					address: readHostAddress,
-					// Rotate/crop stays disabled in comments — keep it lean.
-					supportedFormats: [] as string[],
+					// Rotate/crop stays DISABLED in comments — keep it lean. This
+					// reader is deliberately constant: the body editor wires its
+					// reader to the server's capabilities (BUG-2426), and the
+					// comment composer must not follow it there.
+					supportedFormats: () => [],
 					transform: async () => {
 						throw new Error('Image transforms are not available in comments.');
 					}

--- a/web/src/lib/components/attachments/AttachmentViewerHost.svelte
+++ b/web/src/lib/components/attachments/AttachmentViewerHost.svelte
@@ -1,0 +1,170 @@
+<!--
+	AttachmentViewerHost — the ONE consumer of the open-viewer channel for one
+	`ItemDetail` mount (PLAN-2392 phase 3a, TASK-2428).
+
+	Sibling of `AttachmentPanelHost`, same reasons: the emitters — inline editor
+	image NodeViews — are imperative DOM and cannot mount a Svelte component, so
+	they signal through the module-global bus in `$lib/attachments/events` and
+	something on the other side owns the viewer. That owner is `ItemDetail`,
+	which mounts exactly one of these with the SAME `hostToken` it gives the
+	panel host: one token per HOST, not one per channel.
+
+	Kept a separate component rather than a block inside `ItemDetail` for the
+	same reason as the panel host: the addressing rule is the load-bearing part
+	of DR-8 and has to be testable with TWO hosts mounted at once, which is what
+	the pane host does at runtime (a master pane plus a peeked pane). Folded into
+	a 6,000-line component it would be unreachable by any test.
+
+	THE STRIP AND THE TIMELINE ARE NOT ROUTED HERE. They mount `Lightbox`
+	directly and keep doing so; task 1's lease stack makes coexisting mounts
+	safe, and consolidating producers belongs with 3c's convergence, where there
+	is a single surface to host. A decision, not an omission.
+
+	WORKSPACE COMES OFF THE EVENT. `wsSlug` is captured at emit and carried on
+	the request, never read live from the host — the pane switches workspace
+	without remounting, so a live read could serve a viewer opened in ws1 from
+	ws2's endpoint.
+
+	NO `mutationsEnabled`. 3a's viewer has no mutating action, so threading a
+	permission here would be a dead prop. It is 3c's, together with Delete.
+
+	LIFECYCLE — ONE RULE. Clear on a RESOURCE SWITCH: the host's `itemId`
+	changing, or `resourceGen` advancing. Nothing else closes the viewer.
+
+	  - NOT the route. A collection-only or username-only change preserves the
+	    loaded item, and a viewer must not close because a URL segment moved.
+	  - NOT `ItemDetail`'s `loadGeneration`, which is a non-reactive counter
+	    bumped by EVERY `loadData()` — including a same-item schema reload after
+	    a collection edit. Keying on it would tear the viewer down on a refresh
+	    that changed nothing the viewer can see. `resourceGen` is the dedicated
+	    reactive counter that advances only when the LOADED item resource
+	    actually changes.
+
+	DR-5c's delete-tracks-by-id and DR-14's archive/restore are 3c's, and are
+	deliberately absent here even though the panel host has them.
+-->
+<script lang="ts">
+	import { untrack } from 'svelte';
+	import Lightbox from '$lib/components/common/Lightbox.svelte';
+	import {
+		isAttachmentViewerEventForHost,
+		registerAttachmentViewerListener,
+		type AttachmentViewerOpenEvent,
+	} from '$lib/attachments/events';
+
+	interface Props {
+		/** Parent item UUID. Null/undefined while the item is loading or mid-switch. */
+		itemId: string | null | undefined;
+		/** This `ItemDetail` mount's identity on the bus — the panel host's token. */
+		hostToken: string;
+		/**
+		 * Reactive generation of the LOADED item resource. Advances only on a
+		 * real resource change, never on a same-item refresh. See the lifecycle
+		 * note above for why this is not `loadGeneration`.
+		 */
+		resourceGen?: number;
+	}
+
+	let { itemId, hostToken, resourceGen = 0 }: Props = $props();
+
+	let request = $state<AttachmentViewerOpenEvent | null>(null);
+
+	/**
+	 * Builds a close handler BOUND to the request it was rendered for, so a
+	 * stale continuation cannot dismiss a newer viewer — the shape
+	 * `AttachmentPanelHost` uses, for the same reason: the child is destroyed by
+	 * nulling `request` (item switch), but a callback it already scheduled can
+	 * still land afterwards and would otherwise clear whatever is current BY
+	 * THEN.
+	 */
+	function closeRequest(target: AttachmentViewerOpenEvent | null): () => void {
+		return () => {
+			if (target && request !== target) return;
+			request = null;
+			// Focus returns to the element that opened the viewer — the only use
+			// this host makes of `invoker`. `Lightbox` manages no focus of its
+			// own, so without this a close leaves focus on <body> and the
+			// keyboard user restarts from the top of the document.
+			//
+			// `isConnected` because the opener can be gone by now: an editor
+			// NodeView is re-rendered on any document change, and focusing a
+			// detached node silently does nothing on some engines and moves
+			// focus to <body> on others.
+			const invoker = target?.invoker;
+			if (invoker?.isConnected) invoker.focus();
+			// Deliberately only on a USER close. The lifecycle teardown below
+			// does not return focus: it fires because the item under the viewer
+			// is being replaced, so the invoker is part of a subtree on its way
+			// out — putting focus back into it would land the user inside
+			// content that is about to disappear. Where focus goes after a
+			// switch is the pane's business, not the viewer's.
+		};
+	}
+
+	// Plain `let`, not $state: written and read only inside `untrack`ed effect
+	// bodies. As $state they would make each effect depend on what it writes,
+	// which aborts the flush and strands unrelated reactivity (CONVE-1688).
+	// Both are seeded from the initial props DELIBERATELY (hence `untrack`): a
+	// host that mounts on an already-loaded item has nothing to clear — only a
+	// TRANSITION is a resource switch.
+	let lastItemId = untrack(() => itemId ?? '');
+	let lastResourceGen = untrack(() => resourceGen);
+
+	// Subscribe once. `itemId` / `hostToken` are read inside the callback at
+	// EMIT time, so the comparison always uses the host's current address —
+	// deliberately not captured, since this component (like `ItemDetail`) can
+	// outlive an A→B item switch. The disposer returned by the registration is
+	// the effect's teardown, so an unmounted host stops receiving events.
+	$effect(() => {
+		return registerAttachmentViewerListener((event) => {
+			if (!isAttachmentViewerEventForHost(event, { itemId, hostToken })) return;
+			request = event;
+		});
+	});
+
+	// The one lifecycle rule. Both arms are the same event — "the resource under
+	// this host changed" — so they share one effect and one clear.
+	//
+	// ANY change of the id counts, INCLUDING one to null. The id is
+	// `ItemDetail`'s `itemMatchesRef ? item?.id : null`, so null means "the
+	// item this viewer belongs to is no longer the one on screen" — the start
+	// of a switch, a cross-workspace nav, an unload. Treating null as merely
+	// "not a resource yet" and waiting for the next non-empty id leaves the
+	// viewer stranded over a skeleton or an error page whenever the incoming
+	// item never arrives (Codex round 3).
+	//
+	// A same-resource REFRESH never reaches this branch: `loadData()` does not
+	// null `item`, and `itemMatchesRef` does not depend on the collection or
+	// username segments, so a refresh and a collection-only route change both
+	// keep the id exactly where it was. That is what makes clearing on every id
+	// change safe, and it is why the generation exists — it is the ONLY thing
+	// that can tell a same-id resource change from a same-id reload.
+	$effect(() => {
+		const id = itemId ?? '';
+		const gen = resourceGen;
+		untrack(() => {
+			if (id === lastItemId && gen === lastResourceGen) return;
+			lastItemId = id;
+			lastResourceGen = gen;
+			request = null;
+		});
+	});
+</script>
+
+<!--
+	Remounted per open via `{#key request}`: `Lightbox` seeds its index once
+	through `untrack`, so prop-sync does not work — opening a second image while
+	the first viewer is up must produce a NEW component instance.
+
+	`wsSlug` comes off the request, per the note above.
+-->
+{#key request}
+	{#if request}
+		<Lightbox
+			images={[...request.images]}
+			index={request.index}
+			wsSlug={request.workspaceSlug}
+			onClose={closeRequest(request)}
+		/>
+	{/if}
+{/key}

--- a/web/src/lib/components/attachments/AttachmentViewerHost.svelte
+++ b/web/src/lib/components/attachments/AttachmentViewerHost.svelte
@@ -81,23 +81,26 @@
 		return () => {
 			if (target && request !== target) return;
 			request = null;
-			// Focus returns to the element that opened the viewer — the only use
-			// this host makes of `invoker`. `Lightbox` manages no focus of its
-			// own, so without this a close leaves focus on <body> and the
-			// keyboard user restarts from the top of the document.
+			// FOCUS RESTORE IS NOT DONE HERE (TASK-2429). It used to be — this
+			// host focused `target.invoker` itself, because `Lightbox` managed no
+			// focus at all. Now the viewer holds a backdrop lease that makes every
+			// other body child `inert`, and the invoker is inside one of them: an
+			// inert element is NOT FOCUSABLE, so a focus() from here — which runs
+			// while the viewer is still mounted and the lease still held — would
+			// silently do nothing and leave the keyboard user on <body>.
 			//
-			// `isConnected` because the opener can be gone by now: an editor
-			// NodeView is re-rendered on any document change, and focusing a
-			// detached node silently does nothing on some engines and moves
-			// focus to <body> on others.
-			const invoker = target?.invoker;
-			if (invoker?.isConnected) invoker.focus();
-			// Deliberately only on a USER close. The lifecycle teardown below
-			// does not return focus: it fires because the item under the viewer
-			// is being replaced, so the invoker is part of a subtree on its way
-			// out — putting focus back into it would land the user inside
-			// content that is about to disappear. Where focus goes after a
-			// switch is the pane's business, not the viewer's.
+			// The only correct moment is AFTER the lease is released, which is
+			// inside the viewer's own teardown. So the invoker is threaded down as
+			// a prop instead (see the markup below) and `Lightbox` owns the whole
+			// restore, including the still-connected / still-focusable check that
+			// an editor NodeView re-render makes necessary.
+			//
+			// This does mean the restore now also runs on the LIFECYCLE teardown
+			// (an item switch), which this host previously refused on the grounds
+			// that the invoker is in a subtree on its way out. That refusal is no
+			// longer worth a special case: the viewer verifies the invoker still
+			// takes focus, and where it doesn't, focus lands on <body> — which is
+			// exactly where the old no-op left it.
 		};
 	}
 
@@ -156,7 +159,9 @@
 	through `untrack`, so prop-sync does not work — opening a second image while
 	the first viewer is up must produce a NEW component instance.
 
-	`wsSlug` comes off the request, per the note above.
+	`wsSlug` comes off the request, per the note above. So does `invoker`: the
+	viewer restores focus itself, after releasing the inert lease — see
+	`closeRequest` for why this host must not do it.
 -->
 {#key request}
 	{#if request}
@@ -164,6 +169,7 @@
 			images={[...request.images]}
 			index={request.index}
 			wsSlug={request.workspaceSlug}
+			invoker={request.invoker}
 			onClose={closeRequest(request)}
 		/>
 	{/if}

--- a/web/src/lib/components/attachments/AttachmentViewerHost.svelte.test.ts
+++ b/web/src/lib/components/attachments/AttachmentViewerHost.svelte.test.ts
@@ -1,0 +1,419 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+
+// TASK-2428. The viewer is exercised THROUGH its host, because the host is
+// where the two rules that matter live: an event is consumed only when both
+// `itemId` and `hostToken` are this host's own (DR-8), and an open viewer is
+// closed by a RESOURCE SWITCH and by nothing else. Nothing routes into it yet —
+// the emitters land in the next task — so these tests emit on the bus directly,
+// which is also the only way to drive a NodeView-originated open.
+//
+// The bus stays REAL: addressing is the thing under test.
+//
+// What jsdom CANNOT prove here, and is therefore the browser suite's: focus
+// entry, background inertness, and the viewer's real stacking against a panel
+// or a menu opened at the same time.
+
+// The bus stays REAL, with ONE wrapper: the registration is counted and its
+// disposer is tracked, because "an unmounted host stops receiving events" is
+// otherwise untestable through the DOM — a destroyed component renders nothing
+// whether or not its listener leaked, so a leak would pass silently.
+const subs = vi.hoisted(() => ({ registered: 0, disposed: 0 }));
+vi.mock('$lib/attachments/events', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('$lib/attachments/events')>();
+	return {
+		...actual,
+		registerAttachmentViewerListener: (fn: Parameters<
+			typeof actual.registerAttachmentViewerListener
+		>[0]) => {
+			subs.registered += 1;
+			const off = actual.registerAttachmentViewerListener(fn);
+			return () => {
+				subs.disposed += 1;
+				off();
+			};
+		},
+	};
+});
+
+const { notifyViewerOpen } = await import('$lib/attachments/events');
+type ViewerEvent = import('$lib/attachments/events').AttachmentViewerOpenEvent;
+type LightboxImage = import('$lib/attachments/events').LightboxImage;
+const { default: AttachmentViewerHost } = await import('./AttachmentViewerHost.svelte');
+
+const ATT_ID = '11111111-2222-4333-8444-555555555555';
+const ATT_ID_2 = '99999999-8888-4777-8666-555555555555';
+
+function image(over: Partial<LightboxImage> = {}): LightboxImage {
+	return {
+		id: ATT_ID,
+		alt: 'a diagram',
+		filename: 'diagram.png',
+		mime_type: 'image/png',
+		size_bytes: 4096,
+		width: 800,
+		height: 600,
+		...over,
+	};
+}
+
+function openEvent(over: Partial<ViewerEvent> = {}): ViewerEvent {
+	return {
+		attachmentId: ATT_ID,
+		workspaceSlug: 'ws',
+		itemId: 'item-a',
+		hostToken: 'host-1',
+		images: [image()],
+		index: 0,
+		invoker: null,
+		...over,
+	};
+}
+
+/**
+ * The viewer is a fixed-position overlay rendered into its host's own mount
+ * container, which is what lets a two-host test say WHICH host opened rather
+ * than only how many viewers exist.
+ */
+function viewers(scope: ParentNode = document): HTMLElement[] {
+	return Array.from(scope.querySelectorAll<HTMLElement>('.lightbox-backdrop'));
+}
+
+function viewer(): HTMLElement | null {
+	return viewers()[0] ?? null;
+}
+
+function viewerImage(): HTMLImageElement | null {
+	return document.querySelector<HTMLImageElement>('.lightbox-image');
+}
+
+interface HostProps {
+	itemId: string | null;
+	hostToken: string;
+	resourceGen: number;
+}
+
+// Two reactive props objects, declared at the top level because `$state(...)`
+// may only initialize a declaration. Two of them because the pane host runs a
+// master and a peeked ItemDetail at once, which is exactly what DR-8's
+// addressing exists for.
+const propsA = $state<HostProps>({ itemId: 'item-a', hostToken: 'host-1', resourceGen: 1 });
+const propsB = $state<HostProps>({ itemId: 'item-a', hostToken: 'host-2', resourceGen: 1 });
+
+describe('AttachmentViewerHost', () => {
+	let target: HTMLElement;
+	const mounted: ReturnType<typeof mount>[] = [];
+
+	beforeEach(() => {
+		subs.registered = 0;
+		subs.disposed = 0;
+		Object.assign(propsA, { itemId: 'item-a', hostToken: 'host-1', resourceGen: 1 });
+		Object.assign(propsB, { itemId: 'item-a', hostToken: 'host-2', resourceGen: 1 });
+		target = document.body.appendChild(document.createElement('div'));
+	});
+
+	afterEach(() => {
+		while (mounted.length) unmount(mounted.pop()!);
+		target.remove();
+		document.querySelectorAll('.viewer-host-target').forEach((el) => el.remove());
+	});
+
+	/** Mounts a host in its OWN container, and hands that container back. */
+	function mountHost(props: HostProps): HTMLElement {
+		const container = target.appendChild(document.createElement('div'));
+		container.className = 'viewer-host-target';
+		mounted.push(mount(AttachmentViewerHost, { target: container, props }));
+		flushSync();
+		return container;
+	}
+
+	it('opens for an event addressed to it, on the event’s workspace', () => {
+		mountHost(propsA);
+		notifyViewerOpen(openEvent());
+		flushSync();
+
+		expect(viewer()).not.toBeNull();
+		// The workspace is the one CAPTURED at emit, not one the host resolved:
+		// the pane switches workspace without remounting.
+		expect(viewerImage()?.getAttribute('src')).toContain('/workspaces/ws/attachments/');
+		expect(viewerImage()?.getAttribute('alt')).toBe('a diagram');
+	});
+
+	it('serves the emit-time workspace even when it is not the host’s current one', () => {
+		mountHost(propsA);
+		notifyViewerOpen(openEvent({ workspaceSlug: 'other-ws' }));
+		flushSync();
+
+		expect(viewerImage()?.getAttribute('src')).toContain('/workspaces/other-ws/attachments/');
+	});
+
+	it('ignores an event addressed to the OTHER host, with both mounted', () => {
+		const containerA = mountHost(propsA);
+		const containerB = mountHost(propsB);
+
+		// Same item, other host token: exactly one viewer may open, and it must
+		// be the ADDRESSED one — counting viewers alone would pass if the wrong
+		// host opened. Matching on itemId alone would open two.
+		notifyViewerOpen(openEvent({ hostToken: 'host-2' }));
+		flushSync();
+
+		expect(viewers()).toHaveLength(1);
+		expect(viewers(containerB)).toHaveLength(1);
+		expect(viewers(containerA)).toHaveLength(0);
+
+		// ...and the reverse direction, so neither host is simply inert.
+		notifyViewerOpen(openEvent({ hostToken: 'host-1' }));
+		flushSync();
+		expect(viewers(containerA)).toHaveLength(1);
+		expect(viewers()).toHaveLength(2);
+	});
+
+	it('ignores an event for a different item on its own token', () => {
+		mountHost(propsA);
+		notifyViewerOpen(openEvent({ itemId: 'item-b' }));
+		flushSync();
+
+		expect(viewer()).toBeNull();
+	});
+
+	it('opens at the requested index and pages through the whole set', () => {
+		mountHost(propsA);
+		notifyViewerOpen(
+			openEvent({
+				attachmentId: ATT_ID_2,
+				images: [image(), image({ id: ATT_ID_2, alt: 'second' })],
+				index: 1,
+			})
+		);
+		flushSync();
+
+		expect(viewerImage()?.getAttribute('src')).toContain(ATT_ID_2);
+		document.querySelector<HTMLButtonElement>('.lightbox-nav.prev')!.click();
+		flushSync();
+		expect(viewerImage()?.getAttribute('src')).toContain(ATT_ID);
+	});
+
+	it('REMOUNTS on a second open, so the new index is honoured', () => {
+		// Lightbox seeds `current` once through `untrack`, so a prop update
+		// would leave the second open showing the first image.
+		mountHost(propsA);
+		const images = [image(), image({ id: ATT_ID_2, alt: 'second' })];
+		notifyViewerOpen(openEvent({ images, index: 0 }));
+		flushSync();
+		expect(viewerImage()?.getAttribute('src')).toContain(ATT_ID);
+
+		notifyViewerOpen(openEvent({ attachmentId: ATT_ID_2, images, index: 1 }));
+		flushSync();
+		expect(viewers()).toHaveLength(1);
+		expect(viewerImage()?.getAttribute('src')).toContain(ATT_ID_2);
+	});
+
+	it('closes on the viewer’s own close control', () => {
+		mountHost(propsA);
+		notifyViewerOpen(openEvent());
+		flushSync();
+		document.querySelector<HTMLButtonElement>('.lightbox-close')!.click();
+		flushSync();
+
+		expect(viewer()).toBeNull();
+	});
+
+	it('returns focus to the invoker on close', () => {
+		const invoker = target.appendChild(document.createElement('button'));
+		mountHost(propsA);
+		notifyViewerOpen(openEvent({ invoker }));
+		flushSync();
+		document.querySelector<HTMLButtonElement>('.lightbox-close')!.click();
+		flushSync();
+
+		expect(document.activeElement).toBe(invoker);
+	});
+
+	it('does not throw when the invoker is gone by the time the viewer closes', () => {
+		// An editor NodeView is re-rendered on any document change, so the
+		// element that opened the viewer can be detached by now.
+		const invoker = target.appendChild(document.createElement('button'));
+		mountHost(propsA);
+		notifyViewerOpen(openEvent({ invoker }));
+		flushSync();
+		invoker.remove();
+		expect(() =>
+			document.querySelector<HTMLButtonElement>('.lightbox-close')!.click()
+		).not.toThrow();
+		flushSync();
+		expect(viewer()).toBeNull();
+	});
+
+	it('closes when the host switches item', () => {
+		mountHost(propsA);
+		notifyViewerOpen(openEvent());
+		flushSync();
+		expect(viewer()).not.toBeNull();
+
+		propsA.itemId = 'item-b';
+		flushSync();
+		expect(viewer()).toBeNull();
+	});
+
+	it('closes when the loaded resource changes under a stable item id', () => {
+		// The generation is the arm that survives a mid-switch where the id
+		// prop never visibly settles on a different value.
+		mountHost(propsA);
+		notifyViewerOpen(openEvent());
+		flushSync();
+
+		propsA.resourceGen = 2;
+		flushSync();
+		expect(viewer()).toBeNull();
+	});
+
+	it('does NOT close on a same-resource refresh', () => {
+		// The whole reason for a dedicated generation: ItemDetail's
+		// `loadGeneration` is bumped by every loadData(), including the
+		// same-item reload after a collection schema edit. Keying on that would
+		// tear the viewer down on a refresh that changed nothing it can see.
+		//
+		// This is the shape a refresh has at this boundary: `loadData()` does
+		// not null `item`, and `itemMatchesRef` ignores the collection and
+		// username segments, so both a reload and a collection-only route
+		// change leave the id AND the generation exactly where they were —
+		// re-asserted, never absent. (The `loading` flip that used to destroy
+		// this host outright is why it is mounted at ItemDetail's top level.)
+		mountHost(propsA);
+		notifyViewerOpen(openEvent());
+		flushSync();
+
+		propsA.itemId = 'item-a';
+		propsA.resourceGen = 1;
+		flushSync();
+
+		expect(viewer()).not.toBeNull();
+		expect(viewerImage()?.getAttribute('src')).toContain(ATT_ID);
+	});
+
+	it('closes when the item goes away without another arriving', () => {
+		// The id is `itemMatchesRef ? item?.id : null`, so null means the item
+		// this viewer belongs to is no longer the one on screen. Waiting for the
+		// next non-empty id instead would strand the viewer over a skeleton or
+		// an error page whenever the incoming item never loads.
+		mountHost(propsA);
+		notifyViewerOpen(openEvent());
+		flushSync();
+		expect(viewer()).not.toBeNull();
+
+		propsA.itemId = null;
+		flushSync();
+		expect(viewer()).toBeNull();
+	});
+
+	it('opens normally on a host that mounted with an already-loaded resource', () => {
+		// The lifecycle rule is about TRANSITIONS. A host seeded from its
+		// initial props has nothing to clear, and must not swallow the first
+		// event because its own mount looked like a change.
+		mountHost(propsA);
+		flushSync();
+		notifyViewerOpen(openEvent());
+		flushSync();
+		expect(viewer()).not.toBeNull();
+	});
+
+	it('unsubscribes from the bus on unmount, so a dead host receives nothing', () => {
+		// Asserted through the disposer, not the DOM: a destroyed component
+		// renders nothing whether or not its listener leaked, so a DOM-only
+		// check here would pass with the subscription still live and firing
+		// into a dead view for the rest of the session.
+		const before = subs.registered;
+		mountHost(propsA);
+		notifyViewerOpen(openEvent());
+		flushSync();
+		expect(viewer()).not.toBeNull();
+		expect(subs.registered).toBe(before + 1);
+		expect(subs.disposed).toBe(0);
+
+		unmount(mounted.pop()!);
+		flushSync();
+		expect(subs.disposed).toBe(1);
+
+		notifyViewerOpen(openEvent());
+		flushSync();
+		expect(viewer()).toBeNull();
+	});
+
+	it('subscribes ONCE and still addresses on its CURRENT item after a switch', () => {
+		// The registration effect reads `itemId` / `hostToken` inside the
+		// callback at EMIT time rather than in its tracked scope. Reading them
+		// outside would both re-run the effect on every item switch (tearing the
+		// listener down and re-adding it) AND capture the address, so the host
+		// would keep answering for the item it mounted on. Counting
+		// registrations catches the first half; the emissions below catch the
+		// second, which is the one that silently breaks a tap after a switch.
+		const before = subs.registered;
+		mountHost(propsA);
+		propsA.itemId = 'item-b';
+		propsA.resourceGen = 2;
+		flushSync();
+
+		// The address it mounted with is now stale and must be ignored...
+		notifyViewerOpen(openEvent({ itemId: 'item-a' }));
+		flushSync();
+		expect(viewer()).toBeNull();
+
+		// ...while the item it is showing NOW is answered.
+		notifyViewerOpen(openEvent({ itemId: 'item-b' }));
+		flushSync();
+		expect(viewer()).not.toBeNull();
+
+		expect(subs.registered).toBe(before + 1);
+		expect(subs.disposed).toBe(0);
+	});
+
+	it('keeps the flush alive: a teardown does not strand neighbouring reactivity', () => {
+		// The self-write hazard (CONVE-1688): an $effect that writes a $state it
+		// also reads in its tracked scope ABORTS the flush, which strands
+		// unrelated reactivity elsewhere in the same flush and reports nothing
+		// in a production build. A test that only checks this host's own
+		// counter can pass while the component is quietly breaking its
+		// neighbours, so the assertion has to be about a NEIGHBOUR.
+		//
+		// Two hosts driven by ONE props object: they share a flush, so if the
+		// first one's lifecycle effect aborts it, the second's teardown never
+		// runs and its viewer stays on screen. Exercised open → mutate →
+		// teardown → RE-open → mutate, because a hazard that no-ops on its
+		// first write only shows once the state has actually moved.
+		const first = mountHost(propsA);
+		const neighbour = mountHost(propsA);
+
+		notifyViewerOpen(openEvent());
+		flushSync();
+		expect(viewers(first)).toHaveLength(1);
+		expect(viewers(neighbour)).toHaveLength(1);
+
+		propsA.resourceGen = 2;
+		flushSync();
+		expect(viewers(first)).toHaveLength(0);
+		expect(viewers(neighbour)).toHaveLength(0);
+
+		// Re-open on the same (now current) resource and drive it again.
+		notifyViewerOpen(openEvent());
+		flushSync();
+		expect(viewers(neighbour)).toHaveLength(1);
+
+		propsA.itemId = 'item-b';
+		flushSync();
+		expect(viewers(first)).toHaveLength(0);
+		expect(viewers(neighbour)).toHaveLength(0);
+
+		// And the neighbour is still LIVE, not merely emptied: it answers the
+		// new address, which it could not do if its effects had been stranded.
+		notifyViewerOpen(openEvent({ itemId: 'item-b' }));
+		flushSync();
+		expect(viewers(neighbour)).toHaveLength(1);
+	});
+
+	// The bound-close invariant is NOT tested here: driving it needs the close
+	// callback of a viewer the host has already destroyed, and a click on the
+	// detached button never reaches Svelte's delegated root handler — the
+	// version of this test written that way passed with the guard deleted.
+	// It lives in `AttachmentViewerHostClose.svelte.test.ts`, against a stubbed
+	// Lightbox that hands the callback back.
+});

--- a/web/src/lib/components/attachments/AttachmentViewerHost.svelte.test.ts
+++ b/web/src/lib/components/attachments/AttachmentViewerHost.svelte.test.ts
@@ -40,13 +40,30 @@ vi.mock('$lib/attachments/events', async (importOriginal) => {
 
 const { notifyViewerOpen } = await import('$lib/attachments/events');
 type ViewerEvent = import('$lib/attachments/events').AttachmentViewerOpenEvent;
+// What `notifyViewerOpen` ACCEPTS, which is narrower than what it delivers: a
+// producer must have resolved the MIME (TASK-2433), so the emitter's set is
+// `ViewerReadyImage` while the host still consumes the nullable event shape.
+// The fixture below is an emitter, so it is typed as the request.
+//
+// This file is `*.svelte.test.ts`, which `tsconfig.json` EXCLUDES, so
+// `npm run check` would not have caught the mismatch — a reason to keep the
+// annotation honest by hand rather than a reason it does not matter.
+type ViewerRequest = import('$lib/attachments/events').ViewerOpenRequest;
+type ViewerReadyImage = import('$lib/attachments/events').ViewerReadyImage;
 type LightboxImage = import('$lib/attachments/events').LightboxImage;
 const { default: AttachmentViewerHost } = await import('./AttachmentViewerHost.svelte');
 
 const ATT_ID = '11111111-2222-4333-8444-555555555555';
 const ATT_ID_2 = '99999999-8888-4777-8666-555555555555';
 
-function image(over: Partial<LightboxImage> = {}): LightboxImage {
+/**
+ * A member of an emitted set, in the PRODUCER's shape: `notifyViewerOpen`
+ * requires a resolved MIME (TASK-2433). The cast is confined here and the
+ * default IS a resolved allowlisted type, so the assertion holds for
+ * everything this returns; overrides stay in the nullable shape so a case that
+ * wants an unresolved one is written — and read — as a deliberate exception.
+ */
+function image(over: Partial<LightboxImage> = {}): ViewerReadyImage {
 	return {
 		id: ATT_ID,
 		alt: 'a diagram',
@@ -56,10 +73,10 @@ function image(over: Partial<LightboxImage> = {}): LightboxImage {
 		width: 800,
 		height: 600,
 		...over,
-	};
+	} as ViewerReadyImage;
 }
 
-function openEvent(over: Partial<ViewerEvent> = {}): ViewerEvent {
+function openEvent(over: Partial<ViewerRequest> = {}): ViewerRequest {
 	return {
 		attachmentId: ATT_ID,
 		workspaceSlug: 'ws',

--- a/web/src/lib/components/attachments/AttachmentViewerHost.svelte.test.ts
+++ b/web/src/lib/components/attachments/AttachmentViewerHost.svelte.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { flushSync, mount, unmount } from 'svelte';
+import { __resetViewerBackdropForTests } from '$lib/a11y/viewerBackdrop';
+import { _resetEscapeStackForTests } from '$lib/stores/escapeStack';
 
 // TASK-2428. The viewer is exercised THROUGH its host, because the host is
 // where the two rules that matter live: an event is consumed only when both
@@ -71,12 +73,16 @@ function openEvent(over: Partial<ViewerEvent> = {}): ViewerEvent {
 }
 
 /**
- * The viewer is a fixed-position overlay rendered into its host's own mount
- * container, which is what lets a two-host test say WHICH host opened rather
- * than only how many viewers exist.
+ * Every open viewer in the document.
+ *
+ * DOM SCOPE CANNOT ANSWER "WHICH HOST" ANY MORE (TASK-2429): the viewer now
+ * portals to `<body>`, so both hosts' viewers are siblings there regardless of
+ * where their host is mounted. A two-host test proves ownership by DESTROYING
+ * one host and watching which viewer goes with it, plus the two-direction count
+ * below — not by querying inside a container.
  */
-function viewers(scope: ParentNode = document): HTMLElement[] {
-	return Array.from(scope.querySelectorAll<HTMLElement>('.lightbox-backdrop'));
+function viewers(): HTMLElement[] {
+	return Array.from(document.body.querySelectorAll<HTMLElement>('.lightbox-backdrop'));
 }
 
 function viewer(): HTMLElement | null {
@@ -116,6 +122,11 @@ describe('AttachmentViewerHost', () => {
 		while (mounted.length) unmount(mounted.pop()!);
 		target.remove();
 		document.querySelectorAll('.viewer-host-target').forEach((el) => el.remove());
+		// The viewer holds a backdrop lease and an ESC-stack registration
+		// (TASK-2429). Both are module-global, so a case that ends with one open
+		// would otherwise leak `inert` writes and a handler into the next test.
+		__resetViewerBackdropForTests();
+		_resetEscapeStackForTests();
 	});
 
 	/** Mounts a host in its OWN container, and hands that container back. */
@@ -148,24 +159,37 @@ describe('AttachmentViewerHost', () => {
 	});
 
 	it('ignores an event addressed to the OTHER host, with both mounted', () => {
-		const containerA = mountHost(propsA);
-		const containerB = mountHost(propsB);
+		mountHost(propsA);
+		const hostA = mounted[mounted.length - 1];
+		mountHost(propsB);
 
-		// Same item, other host token: exactly one viewer may open, and it must
-		// be the ADDRESSED one — counting viewers alone would pass if the wrong
-		// host opened. Matching on itemId alone would open two.
+		// DISTINGUISHABLE PAYLOADS, because counting alone cannot see a
+		// CROSS-SWAP — A answering host-2's event while B answers host-1's
+		// produces exactly the same counts as the correct routing. Each event
+		// carries its own image id, so the surviving viewer's `src` says which
+		// EVENT it came from, and destroying a known host says which HOST held it.
 		notifyViewerOpen(openEvent({ hostToken: 'host-2' }));
 		flushSync();
-
+		// Exactly one viewer may open. Matching on itemId alone would open two.
 		expect(viewers()).toHaveLength(1);
-		expect(viewers(containerB)).toHaveLength(1);
-		expect(viewers(containerA)).toHaveLength(0);
 
 		// ...and the reverse direction, so neither host is simply inert.
-		notifyViewerOpen(openEvent({ hostToken: 'host-1' }));
+		notifyViewerOpen(
+			openEvent({ hostToken: 'host-1', attachmentId: ATT_ID_2, images: [image({ id: ATT_ID_2 })] })
+		);
 		flushSync();
-		expect(viewers(containerA)).toHaveLength(1);
 		expect(viewers()).toHaveLength(2);
+
+		// Destroy host A: the viewer that goes with it must be the one opened by
+		// A's OWN token (the ATT_ID_2 event), leaving B's ATT_ID one behind. A
+		// cross-swap fails here — it would leave the ATT_ID_2 viewer standing.
+		unmount(mounted.splice(mounted.indexOf(hostA), 1)[0]);
+		flushSync();
+		const survivors = viewers();
+		expect(survivors).toHaveLength(1);
+		expect(
+			survivors[0].querySelector('.lightbox-image')?.getAttribute('src')
+		).toContain(ATT_ID);
 	});
 
 	it('ignores an event for a different item on its own token', () => {
@@ -380,34 +404,35 @@ describe('AttachmentViewerHost', () => {
 		// runs and its viewer stays on screen. Exercised open → mutate →
 		// teardown → RE-open → mutate, because a hazard that no-ops on its
 		// first write only shows once the state has actually moved.
-		const first = mountHost(propsA);
-		const neighbour = mountHost(propsA);
+		//
+		// Counted across the whole document rather than per container (the
+		// viewer portals to <body> now): both hosts answer the same address, so
+		// a stranded teardown shows up as a count that fails to reach 0.
+		mountHost(propsA);
+		mountHost(propsA);
 
 		notifyViewerOpen(openEvent());
 		flushSync();
-		expect(viewers(first)).toHaveLength(1);
-		expect(viewers(neighbour)).toHaveLength(1);
+		expect(viewers()).toHaveLength(2);
 
 		propsA.resourceGen = 2;
 		flushSync();
-		expect(viewers(first)).toHaveLength(0);
-		expect(viewers(neighbour)).toHaveLength(0);
+		expect(viewers()).toHaveLength(0);
 
 		// Re-open on the same (now current) resource and drive it again.
 		notifyViewerOpen(openEvent());
 		flushSync();
-		expect(viewers(neighbour)).toHaveLength(1);
+		expect(viewers()).toHaveLength(2);
 
 		propsA.itemId = 'item-b';
 		flushSync();
-		expect(viewers(first)).toHaveLength(0);
-		expect(viewers(neighbour)).toHaveLength(0);
+		expect(viewers()).toHaveLength(0);
 
-		// And the neighbour is still LIVE, not merely emptied: it answers the
-		// new address, which it could not do if its effects had been stranded.
+		// And both are still LIVE, not merely emptied: they answer the new
+		// address, which they could not do if their effects had been stranded.
 		notifyViewerOpen(openEvent({ itemId: 'item-b' }));
 		flushSync();
-		expect(viewers(neighbour)).toHaveLength(1);
+		expect(viewers()).toHaveLength(2);
 	});
 
 	// The bound-close invariant is NOT tested here: driving it needs the close

--- a/web/src/lib/components/attachments/AttachmentViewerHostClose.svelte.test.ts
+++ b/web/src/lib/components/attachments/AttachmentViewerHostClose.svelte.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+
+/**
+ * The bound-close invariant, on its own because it needs `Lightbox` stubbed
+ * (TASK-2428).
+ *
+ * `AttachmentViewerHost` hands each viewer a close handler BOUND to the request
+ * it was rendered for, so a continuation from a viewer the host has already
+ * destroyed cannot dismiss the one the user opened since. Driving that through
+ * the real component is impossible in jsdom: the old close button is detached
+ * by then, and a click on a detached node never reaches Svelte's delegated root
+ * handler — a test written that way passes with the guard deleted (Codex round
+ * 4). Holding the callback directly is the only honest way to fire it.
+ */
+vi.mock('$lib/components/common/Lightbox.svelte', async () => ({
+	default: (await import('./fixtures/LightboxStub.svelte')).default,
+}));
+
+const { notifyViewerOpen } = await import('$lib/attachments/events');
+const { lightboxStubCalls } = await import('./fixtures/lightboxStub');
+const { default: AttachmentViewerHost } = await import('./AttachmentViewerHost.svelte');
+type ViewerEvent = import('$lib/attachments/events').AttachmentViewerOpenEvent;
+
+const ATT_ID = '11111111-2222-4333-8444-555555555555';
+const ATT_ID_2 = '99999999-8888-4777-8666-555555555555';
+
+function openEvent(over: Partial<ViewerEvent> = {}): ViewerEvent {
+	return {
+		attachmentId: ATT_ID,
+		workspaceSlug: 'ws',
+		itemId: 'item-a',
+		hostToken: 'host-1',
+		images: [
+			{
+				id: ATT_ID,
+				alt: 'a diagram',
+				filename: 'diagram.png',
+				mime_type: 'image/png',
+				size_bytes: 4096,
+				width: 800,
+				height: 600,
+			},
+		],
+		index: 0,
+		invoker: null,
+		...over,
+	};
+}
+
+function stub(): HTMLElement | null {
+	return document.querySelector<HTMLElement>('.lightbox-stub');
+}
+
+const props = $state({ itemId: 'item-a' as string | null, hostToken: 'host-1', resourceGen: 1 });
+
+describe('AttachmentViewerHost — bound close', () => {
+	let target: HTMLElement;
+	const mounted: ReturnType<typeof mount>[] = [];
+
+	beforeEach(() => {
+		lightboxStubCalls.length = 0;
+		Object.assign(props, { itemId: 'item-a', hostToken: 'host-1', resourceGen: 1 });
+		target = document.body.appendChild(document.createElement('div'));
+		mounted.push(mount(AttachmentViewerHost, { target, props }));
+		flushSync();
+	});
+
+	afterEach(() => {
+		while (mounted.length) unmount(mounted.pop()!);
+		target.remove();
+	});
+
+	it('remounts the viewer per open, rather than re-using one instance', () => {
+		// Lightbox seeds its index once through `untrack`, so a re-used instance
+		// would silently keep showing the first image.
+		notifyViewerOpen(openEvent());
+		flushSync();
+		notifyViewerOpen(openEvent({ attachmentId: ATT_ID_2, images: [{ ...openEvent().images[0], id: ATT_ID_2 }] }));
+		flushSync();
+
+		expect(lightboxStubCalls).toHaveLength(2);
+		expect(stub()?.dataset.attachmentId).toBe(ATT_ID_2);
+	});
+
+	it('a close from a DESTROYED viewer cannot dismiss the newer one', () => {
+		notifyViewerOpen(openEvent());
+		flushSync();
+		const staleClose = lightboxStubCalls[0].onClose;
+
+		notifyViewerOpen(openEvent({ attachmentId: ATT_ID_2, images: [{ ...openEvent().images[0], id: ATT_ID_2 }] }));
+		flushSync();
+
+		staleClose();
+		flushSync();
+
+		expect(stub()).not.toBeNull();
+		expect(stub()?.dataset.attachmentId).toBe(ATT_ID_2);
+	});
+
+	it('the CURRENT viewer’s close still closes it', () => {
+		// The guard must not be so broad that it makes closing impossible.
+		notifyViewerOpen(openEvent());
+		flushSync();
+		lightboxStubCalls[0].onClose();
+		flushSync();
+
+		expect(stub()).toBeNull();
+	});
+
+	it('a close from a viewer torn down by a resource switch does not close the next one', () => {
+		notifyViewerOpen(openEvent());
+		flushSync();
+		const staleClose = lightboxStubCalls[0].onClose;
+
+		// The host switches item, destroying that viewer...
+		props.itemId = 'item-b';
+		props.resourceGen = 2;
+		flushSync();
+		expect(stub()).toBeNull();
+
+		// ...and one opens on the new item.
+		notifyViewerOpen(openEvent({ itemId: 'item-b', attachmentId: ATT_ID_2 }));
+		flushSync();
+		expect(stub()).not.toBeNull();
+
+		staleClose();
+		flushSync();
+		expect(stub()).not.toBeNull();
+	});
+
+	it('returns focus to the invoker only on the bound close', () => {
+		const invoker = target.appendChild(document.createElement('button'));
+		const other = target.appendChild(document.createElement('button'));
+		other.focus();
+
+		notifyViewerOpen(openEvent({ invoker }));
+		flushSync();
+		lightboxStubCalls[0].onClose();
+		flushSync();
+		expect(document.activeElement).toBe(invoker);
+
+		// A stale close returns nothing: it did not close anything, so moving
+		// the user's focus would be a jump out of whatever they are now in.
+		notifyViewerOpen(openEvent({ invoker }));
+		flushSync();
+		const staleClose = lightboxStubCalls[1].onClose;
+		notifyViewerOpen(openEvent({ attachmentId: ATT_ID_2, invoker: null }));
+		flushSync();
+		other.focus();
+		staleClose();
+		flushSync();
+		expect(document.activeElement).toBe(other);
+	});
+});

--- a/web/src/lib/components/attachments/AttachmentViewerHostClose.svelte.test.ts
+++ b/web/src/lib/components/attachments/AttachmentViewerHostClose.svelte.test.ts
@@ -21,11 +21,21 @@ const { notifyViewerOpen } = await import('$lib/attachments/events');
 const { lightboxStubCalls } = await import('./fixtures/lightboxStub');
 const { default: AttachmentViewerHost } = await import('./AttachmentViewerHost.svelte');
 type ViewerEvent = import('$lib/attachments/events').AttachmentViewerOpenEvent;
+// What `notifyViewerOpen` ACCEPTS, which is narrower than what it delivers: a
+// producer must have resolved the MIME (TASK-2433), so the emitter's set is
+// `ViewerReadyImage` while the host still consumes the nullable event shape.
+// The fixture below is an emitter, so it is typed as the request.
+//
+// This file is `*.svelte.test.ts`, which `tsconfig.json` EXCLUDES, so
+// `npm run check` would not have caught the mismatch — a reason to keep the
+// annotation honest by hand rather than a reason it does not matter.
+type ViewerRequest = import('$lib/attachments/events').ViewerOpenRequest;
+type ViewerReadyImage = import('$lib/attachments/events').ViewerReadyImage;
 
 const ATT_ID = '11111111-2222-4333-8444-555555555555';
 const ATT_ID_2 = '99999999-8888-4777-8666-555555555555';
 
-function openEvent(over: Partial<ViewerEvent> = {}): ViewerEvent {
+function openEvent(over: Partial<ViewerRequest> = {}): ViewerRequest {
 	return {
 		attachmentId: ATT_ID,
 		workspaceSlug: 'ws',

--- a/web/src/lib/components/attachments/AttachmentViewerHostClose.svelte.test.ts
+++ b/web/src/lib/components/attachments/AttachmentViewerHostClose.svelte.test.ts
@@ -129,26 +129,22 @@ describe('AttachmentViewerHost — bound close', () => {
 		expect(stub()).not.toBeNull();
 	});
 
-	it('returns focus to the invoker only on the bound close', () => {
+	it('threads the invoker down and never moves focus itself', () => {
+		// TASK-2429 moved the restore INTO the viewer. It has to happen after the
+		// backdrop lease is released — while the lease is held, the invoker is
+		// inside an `inert` body child and simply will not take focus — and the
+		// only code that runs at that moment is the viewer's own teardown. So the
+		// host's job is reduced to handing the invoker over, and its close handler
+		// must leave `document.activeElement` exactly where it was.
 		const invoker = target.appendChild(document.createElement('button'));
 		const other = target.appendChild(document.createElement('button'));
 		other.focus();
 
 		notifyViewerOpen(openEvent({ invoker }));
 		flushSync();
-		lightboxStubCalls[0].onClose();
-		flushSync();
-		expect(document.activeElement).toBe(invoker);
+		expect(lightboxStubCalls[0].invoker).toBe(invoker);
 
-		// A stale close returns nothing: it did not close anything, so moving
-		// the user's focus would be a jump out of whatever they are now in.
-		notifyViewerOpen(openEvent({ invoker }));
-		flushSync();
-		const staleClose = lightboxStubCalls[1].onClose;
-		notifyViewerOpen(openEvent({ attachmentId: ATT_ID_2, invoker: null }));
-		flushSync();
-		other.focus();
-		staleClose();
+		lightboxStubCalls[0].onClose();
 		flushSync();
 		expect(document.activeElement).toBe(other);
 	});

--- a/web/src/lib/components/attachments/fixtures/LightboxStub.svelte
+++ b/web/src/lib/components/attachments/fixtures/LightboxStub.svelte
@@ -7,9 +7,10 @@
 <script lang="ts">
 	import { untrack } from 'svelte';
 	import { lightboxStubCalls, type LightboxStubCall } from './lightboxStub';
+	import type { LightboxImage } from '$lib/attachments/events';
 
 	interface Props {
-		images: { id: string }[];
+		images: LightboxImage[];
 		index?: number;
 		wsSlug: string;
 		invoker?: HTMLElement | null;

--- a/web/src/lib/components/attachments/fixtures/LightboxStub.svelte
+++ b/web/src/lib/components/attachments/fixtures/LightboxStub.svelte
@@ -1,0 +1,27 @@
+<!--
+	Test double for `Lightbox` (TASK-2428). Records the props of every mount so
+	a test can invoke a DESTROYED viewer's `onClose`, and renders a marker with
+	the image it was opened on. Deliberately dumb: the real component's
+	behaviour is covered against the real component elsewhere.
+-->
+<script lang="ts">
+	import { untrack } from 'svelte';
+	import { lightboxStubCalls, type LightboxStubCall } from './lightboxStub';
+
+	interface Props {
+		images: { id: string }[];
+		index?: number;
+		wsSlug: string;
+		onClose: () => void;
+	}
+
+	let { images, index = 0, wsSlug, onClose }: Props = $props();
+
+	// Captured ONCE at mount, `untrack`ed like the real component's index seed:
+	// the host remounts per open, so a recorded call belongs to exactly one
+	// viewer instance — which is the whole point of the recording.
+	const call: LightboxStubCall = untrack(() => ({ images, index, wsSlug, onClose }));
+	lightboxStubCalls.push(call);
+</script>
+
+<div class="lightbox-stub" data-attachment-id={images[index]?.id ?? ''} data-ws={wsSlug}></div>

--- a/web/src/lib/components/attachments/fixtures/LightboxStub.svelte
+++ b/web/src/lib/components/attachments/fixtures/LightboxStub.svelte
@@ -12,15 +12,16 @@
 		images: { id: string }[];
 		index?: number;
 		wsSlug: string;
+		invoker?: HTMLElement | null;
 		onClose: () => void;
 	}
 
-	let { images, index = 0, wsSlug, onClose }: Props = $props();
+	let { images, index = 0, wsSlug, invoker = null, onClose }: Props = $props();
 
 	// Captured ONCE at mount, `untrack`ed like the real component's index seed:
 	// the host remounts per open, so a recorded call belongs to exactly one
 	// viewer instance — which is the whole point of the recording.
-	const call: LightboxStubCall = untrack(() => ({ images, index, wsSlug, onClose }));
+	const call: LightboxStubCall = untrack(() => ({ images, index, wsSlug, invoker, onClose }));
 	lightboxStubCalls.push(call);
 </script>
 

--- a/web/src/lib/components/attachments/fixtures/lightboxStub.ts
+++ b/web/src/lib/components/attachments/fixtures/lightboxStub.ts
@@ -10,6 +10,8 @@ export interface LightboxStubCall {
 	images: { id: string }[];
 	index: number;
 	wsSlug: string;
+	/** Threaded down by the host since TASK-2429; the viewer owns the restore. */
+	invoker: HTMLElement | null;
 	onClose: () => void;
 }
 

--- a/web/src/lib/components/attachments/fixtures/lightboxStub.ts
+++ b/web/src/lib/components/attachments/fixtures/lightboxStub.ts
@@ -1,3 +1,5 @@
+import type { LightboxImage } from '$lib/attachments/events';
+
 /**
  * Recording surface for `LightboxStub.svelte` (TASK-2428).
  *
@@ -7,7 +9,12 @@
  * proves nothing (Codex round 4 found the click-based version vacuous).
  */
 export interface LightboxStubCall {
-	images: { id: string }[];
+	/**
+	 * The FULL records, not `{id}` (TASK-2431): the metadata a producer threads
+	 * onto each image — `mime_type` above all — is part of what it must get
+	 * right, and a narrower type here would make that unassertable.
+	 */
+	images: LightboxImage[];
 	index: number;
 	wsSlug: string;
 	/** Threaded down by the host since TASK-2429; the viewer owns the restore. */

--- a/web/src/lib/components/attachments/fixtures/lightboxStub.ts
+++ b/web/src/lib/components/attachments/fixtures/lightboxStub.ts
@@ -1,0 +1,16 @@
+/**
+ * Recording surface for `LightboxStub.svelte` (TASK-2428).
+ *
+ * Exists so a test can hold a viewer's `onClose` AFTER that viewer has been
+ * destroyed — the only way to drive the stale-continuation case, since a click
+ * on a detached button never reaches Svelte's delegated root handler and so
+ * proves nothing (Codex round 4 found the click-based version vacuous).
+ */
+export interface LightboxStubCall {
+	images: { id: string }[];
+	index: number;
+	wsSlug: string;
+	onClose: () => void;
+}
+
+export const lightboxStubCalls: LightboxStubCall[] = [];

--- a/web/src/lib/components/attachments/viewerImagePayload.svelte.test.ts
+++ b/web/src/lib/components/attachments/viewerImagePayload.svelte.test.ts
@@ -1,0 +1,403 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { flushSync, mount, unmount, tick } from 'svelte';
+import type {
+	AttachmentListItem,
+	AttachmentListResponse,
+	Comment,
+	TimelineEntry,
+	TimelineResponse,
+} from '$lib/types';
+
+/**
+ * WHAT THE PRODUCERS PUT ON EACH IMAGE (PLAN-2392 / TASK-2431).
+ *
+ * The strip and the timeline mount `Lightbox` directly, so what they hand it is
+ * only observable by standing in for the component — hence the stub, and hence
+ * a file of its own (a `vi.mock` is file-scoped, and the behavioural suites for
+ * both components deliberately drive the REAL viewer).
+ *
+ * The claim under test is narrow and unglamorous: every image carries its
+ * `mime_type` and the nullable metadata beside it. `mime_type` is what lets a
+ * consumer re-state the DR-16 gate over a set it did not build, and
+ * `width` / `height` are here for 3b's pixel-based loading policy — no reader
+ * today, which is exactly why a test has to hold them. Dropped fields are
+ * silent: nothing renders them, nothing type-errors (they are nullable), and
+ * the next phase would rediscover the gap by reopening every producer.
+ */
+
+vi.mock('$lib/components/common/Lightbox.svelte', async () => ({
+	default: (await import('./fixtures/LightboxStub.svelte')).default,
+}));
+
+// ─── strip mocks ────────────────────────────────────────────────────────────
+
+const listMock = vi.fn<(ws: string, filters: Record<string, unknown>) => Promise<AttachmentListResponse>>();
+const timelineListMock = vi.fn<(ws: string, slug: string) => Promise<TimelineResponse>>();
+
+class FakeApiError extends Error {
+	code: string;
+	constructor(code: string) {
+		super(code);
+		this.code = code;
+	}
+}
+
+vi.mock('$lib/api/client', () => ({
+	PadApiError: FakeApiError,
+	api: {
+		attachments: {
+			list: (ws: string, filters: Record<string, unknown>) => listMock(ws, filters),
+			downloadUrl: (ws: string, id: string, variant?: string) =>
+				`/api/v1/workspaces/${ws}/attachments/${id}${variant ? `?variant=${variant}` : ''}`,
+			delete: vi.fn(),
+		},
+		timeline: { list: (ws: string, slug: string) => timelineListMock(ws, slug) },
+		comments: { create: vi.fn(), update: vi.fn(), delete: vi.fn() },
+	},
+}));
+
+vi.mock('$lib/stores/toast.svelte', () => ({
+	toastStore: { show: vi.fn() },
+}));
+
+vi.mock('$lib/services/sse.svelte', () => ({
+	sseService: { onItemEvent: () => () => {} },
+}));
+
+vi.mock('$lib/stores/auth.svelte', () => ({
+	authStore: { userId: 'user-1', user: { id: 'user-1', role: 'member' } },
+}));
+
+vi.mock('$lib/stores/workspace.svelte', () => ({
+	workspaceStore: { canEditItem: () => false },
+}));
+
+const PNG = '11111111-1111-4111-8111-111111111111';
+const SVG = '22222222-2222-4222-8222-222222222222';
+/** Resolves to nothing — the unresolved-MIME case the set must exclude. */
+const UNPROBED = '33333333-3333-4333-8333-333333333333';
+
+vi.mock('$lib/components/editor/attachment-metadata', () => ({
+	fetchAttachmentMetadata: (_ws: string, uuid: string) =>
+		Promise.resolve(
+			uuid === PNG
+				? { status: 'ok' as const, mime: 'image/png', size: 4096 }
+				: uuid === SVG
+					? { status: 'ok' as const, mime: 'image/svg+xml', size: 512 }
+					: { status: 'transient' as const }
+		),
+	invalidateAttachmentMetadata: vi.fn(),
+}));
+
+vi.mock('$lib/components/CommentEditor.svelte', async () => ({
+	default: (await import('../timeline/fixtures/InertCommentEditor.svelte')).default,
+}));
+
+const { lightboxStubCalls } = await import('./fixtures/lightboxStub');
+const { default: ItemAttachmentStrip } = await import('../items/ItemAttachmentStrip.svelte');
+const { default: ItemTimeline } = await import('../timeline/ItemTimeline.svelte');
+
+let target: HTMLElement;
+let instance: ReturnType<typeof mount> | undefined;
+
+beforeEach(() => {
+	lightboxStubCalls.length = 0;
+	listMock.mockReset();
+	timelineListMock.mockReset();
+	target = document.body.appendChild(document.createElement('div'));
+});
+
+afterEach(() => {
+	if (instance) unmount(instance);
+	instance = undefined;
+	target.remove();
+});
+
+async function settle() {
+	for (let i = 0; i < 8; i++) {
+		await tick();
+		flushSync();
+	}
+}
+
+describe('strip → viewer payload (TASK-2431)', () => {
+	function row(over: Partial<AttachmentListItem> & { id: string }): AttachmentListItem {
+		return {
+			workspace_id: 'ws-1',
+			uploaded_by: 'u-1',
+			storage_key: `key/${over.id}`,
+			content_hash: `hash-${over.id}`,
+			mime_type: 'image/png',
+			size_bytes: 2048,
+			filename: `${over.id}.png`,
+			created_at: '2026-08-01T00:00:00Z',
+			...over,
+		};
+	}
+
+	it('threads the full row — mime, size and dimensions — onto every image', async () => {
+		listMock.mockResolvedValue({
+			attachments: [row({ id: 'img1', size_bytes: 9001, width: 800, height: 600 })],
+			total: 1,
+			limit: 50,
+			offset: 0,
+		});
+		instance = mount(ItemAttachmentStrip, {
+			target,
+			props: {
+				wsSlug: 'ws',
+				username: 'dave',
+				itemId: 'item-a',
+				canDelete: false,
+				hostToken: 'host-1',
+			},
+		});
+		flushSync();
+		await settle();
+
+		const tile = target.querySelector<HTMLElement>('.att-tile')!;
+		tile.click();
+		flushSync();
+
+		expect(lightboxStubCalls).toHaveLength(1);
+		expect(lightboxStubCalls[0].images).toEqual([
+			{
+				id: 'img1',
+				alt: 'img1.png',
+				filename: 'img1.png',
+				mime_type: 'image/png',
+				size_bytes: 9001,
+				width: 800,
+				height: 600,
+			},
+		]);
+	});
+
+	it('passes the tile itself as the invoker, so focus returns to it', async () => {
+		listMock.mockResolvedValue({
+			attachments: [row({ id: 'img1' })],
+			total: 1,
+			limit: 50,
+			offset: 0,
+		});
+		instance = mount(ItemAttachmentStrip, {
+			target,
+			props: {
+				wsSlug: 'ws',
+				username: 'dave',
+				itemId: 'item-a',
+				canDelete: false,
+				hostToken: 'host-1',
+			},
+		});
+		flushSync();
+		await settle();
+
+		const tile = target.querySelector<HTMLElement>('.att-tile')!;
+		tile.click();
+		flushSync();
+
+		// The viewer's own fallback ("whatever held focus at open") cannot stand
+		// in for this: a click does not focus a button on every engine, and by
+		// the time the viewer restores, focus may have been anywhere.
+		expect(lightboxStubCalls[0].invoker).toBe(tile);
+	});
+
+	it('emits ONLY allowlisted rows, whatever else the item holds', async () => {
+		// The payload assertions above are all safe inputs, so they cannot catch
+		// a gate regression on their own — this one feeds the producer an SVG, an
+		// undecodable raster and a row with no MIME at all, and pins what comes
+		// out the other side (Codex: stub-based payload tests with only safe
+		// inputs prove nothing about the gate).
+		listMock.mockResolvedValue({
+			attachments: [
+				row({ id: 'svg', mime_type: 'image/svg+xml', filename: 'logo.svg' }),
+				row({ id: 'img1' }),
+				row({ id: 'tiff', mime_type: 'image/tiff', filename: 'scan.tiff' }),
+				row({ id: 'blank', mime_type: '', filename: 'mystery' }),
+				row({ id: 'img2' }),
+			],
+			total: 5,
+			limit: 50,
+			offset: 0,
+		});
+		instance = mount(ItemAttachmentStrip, {
+			target,
+			props: {
+				wsSlug: 'ws',
+				username: 'dave',
+				itemId: 'item-a',
+				canDelete: false,
+				hostToken: 'host-1',
+			},
+		});
+		flushSync();
+		await settle();
+
+		// Only the two PNGs render as IMAGE tiles (a thumbnail inside the
+		// button); the rest take the file branch, which is the same `.att-tile`
+		// class with an icon and opens the options panel instead.
+		const tiles = Array.from(target.querySelectorAll<HTMLElement>('.att-tile'));
+		expect(tiles).toHaveLength(5);
+		const imageTiles = tiles.filter((t) => t.querySelector('img') !== null);
+		expect(imageTiles).toHaveLength(2);
+		imageTiles[0].click();
+		flushSync();
+
+		expect(lightboxStubCalls).toHaveLength(1);
+		expect(lightboxStubCalls[0].images.map((im) => im.id)).toEqual(['img1', 'img2']);
+		expect(lightboxStubCalls[0].images.every((im) => im.mime_type === 'image/png')).toBe(true);
+		// Opened on the clicked one, at its position in the FILTERED set.
+		expect(lightboxStubCalls[0].index).toBe(0);
+	});
+
+	it('leaves dimensions null when the row has none, rather than inventing them', async () => {
+		listMock.mockResolvedValue({
+			attachments: [row({ id: 'img1', width: null, height: null })],
+			total: 1,
+			limit: 50,
+			offset: 0,
+		});
+		instance = mount(ItemAttachmentStrip, {
+			target,
+			props: {
+				wsSlug: 'ws',
+				username: 'dave',
+				itemId: 'item-a',
+				canDelete: false,
+				hostToken: 'host-1',
+			},
+		});
+		flushSync();
+		await settle();
+
+		target.querySelector<HTMLElement>('.att-tile')!.click();
+		flushSync();
+
+		expect(lightboxStubCalls[0].images[0].width).toBeNull();
+		expect(lightboxStubCalls[0].images[0].height).toBeNull();
+	});
+});
+
+describe('timeline → viewer payload (TASK-2431)', () => {
+	function timelineResponse(): TimelineResponse {
+		const comment: Comment = {
+			id: 'c1',
+			item_id: 'item-a',
+			workspace_id: 'ws-1',
+			author: 'alice',
+			body: `![a diagram](pad-attachment:${PNG})`,
+			created_by: 'alice',
+			source: 'web',
+			created_at: '2026-01-01T00:00:00Z',
+			updated_at: '2026-01-01T00:00:00Z',
+		};
+		const entry: TimelineEntry = {
+			id: 'e1',
+			kind: 'comment',
+			created_at: comment.created_at,
+			actor: 'alice',
+			source: 'web',
+			comment,
+		};
+		return { entries: [entry], has_more: false };
+	}
+
+	it('emits ONLY resolved, allowlisted images — never an SVG or an unprobed id', async () => {
+		// Same reason as the strip's: a stub fed only safe inputs cannot fail
+		// when the gate does. The body embeds a PNG, an SVG and an id whose probe
+		// never resolves; the SVG renders as an <img> (the renderer emits one for
+		// any image/*, deliberately) and must still be absent from the set.
+		const comment: Comment = {
+			id: 'c1',
+			item_id: 'item-a',
+			workspace_id: 'ws-1',
+			author: 'alice',
+			body: `![png](pad-attachment:${PNG})\n\n![svg](pad-attachment:${SVG})\n\n![unknown](pad-attachment:${UNPROBED})`,
+			created_by: 'alice',
+			source: 'web',
+			created_at: '2026-01-01T00:00:00Z',
+			updated_at: '2026-01-01T00:00:00Z',
+		};
+		timelineListMock.mockResolvedValue({
+			entries: [
+				{
+					id: 'e1',
+					kind: 'comment',
+					created_at: comment.created_at,
+					actor: 'alice',
+					source: 'web',
+					comment,
+				},
+			],
+			has_more: false,
+		});
+		instance = mount(ItemTimeline, {
+			target,
+			props: {
+				wsSlug: 'ws',
+				username: 'alice',
+				itemSlug: 'TASK-1',
+				currentContent: '',
+				itemId: 'item-a',
+				collectionId: 'coll-1',
+			},
+		});
+		await settle();
+
+		const rendered = Array.from(target.querySelectorAll<HTMLElement>('img[data-attachment-id]'));
+		// The SVG IS rendered — if it ever stops being, this test goes vacuous.
+		expect(rendered.map((el) => el.getAttribute('data-attachment-id'))).toContain(SVG);
+
+		const png = rendered.find((el) => el.getAttribute('data-attachment-id') === PNG)!;
+		png.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+		flushSync();
+
+		expect(lightboxStubCalls).toHaveLength(1);
+		expect(lightboxStubCalls[0].images.map((im) => im.id)).toEqual([PNG]);
+
+		// ...and the SVG opens nothing at all.
+		lightboxStubCalls.length = 0;
+		const svg = rendered.find((el) => el.getAttribute('data-attachment-id') === SVG)!;
+		svg.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+		flushSync();
+		expect(lightboxStubCalls).toHaveLength(0);
+	});
+
+	it('carries the probed mime and size, nulls what HEAD cannot know, and names the invoker', async () => {
+		timelineListMock.mockResolvedValue(timelineResponse());
+		instance = mount(ItemTimeline, {
+			target,
+			props: {
+				wsSlug: 'ws',
+				username: 'alice',
+				itemSlug: 'TASK-1',
+				currentContent: '',
+				itemId: 'item-a',
+				collectionId: 'coll-1',
+			},
+		});
+		await settle();
+
+		const thumb = target.querySelector<HTMLElement>('img[data-attachment-id]')!;
+		thumb.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+		flushSync();
+
+		expect(lightboxStubCalls).toHaveLength(1);
+		expect(lightboxStubCalls[0].images).toEqual([
+			{
+				id: PNG,
+				alt: 'a diagram',
+				// The probe deliberately stores no filename (the alt text is the
+				// label), and a HEAD response carries no intrinsic dimensions —
+				// null is the honest answer, not a placeholder.
+				filename: null,
+				mime_type: 'image/png',
+				size_bytes: 4096,
+				width: null,
+				height: null,
+			},
+		]);
+		expect(lightboxStubCalls[0].invoker).toBe(thumb);
+	});
+});

--- a/web/src/lib/components/collections/PaneHost.svelte
+++ b/web/src/lib/components/collections/PaneHost.svelte
@@ -350,6 +350,9 @@
 		// menu). Recognised by role/tag/class so pane-owned popups that portal out
 		// to <body> are all covered — the shared `inExemptSurface` set (paneFocus.ts)
 		// is the SAME one the host's focus-follows classifier reuses (PLAN-2179).
+		// The attachment viewer (TASK-2429) is one of those portaled dialogs and is
+		// exempt for the same reason: it runs its own trap, so this one must not
+		// pull focus back out of it.
 		// (Focus already inside `.item-pane` is handled by the `region.contains`
 		// check at each call site.)
 		function onTrapKeydown(e: KeyboardEvent) {

--- a/web/src/lib/components/collections/PaneHost.svelte
+++ b/web/src/lib/components/collections/PaneHost.svelte
@@ -28,6 +28,7 @@
 	import { viewport } from '$lib/stores/breakpoint.svelte';
 	import { paneOverlay } from '$lib/stores/paneOverlay.svelte';
 	import { paneFocusables, nextTrapTarget, inExemptSurface } from '$lib/collections/paneFocus';
+	import { isBlockedByModal } from '$lib/a11y/viewerBackdrop';
 	import type { PaneTarget } from '$lib/types';
 
 	interface Props {
@@ -470,9 +471,26 @@
 		}
 	});
 
+	/**
+	 * TASK-2430 — the divider is a resize surface in the app shell. While a
+	 * viewer (or a native `showModal()` dialog) is in front, dragging or
+	 * arrow-nudging the layout underneath it is exactly the deference this task
+	 * is about.
+	 *
+	 * The owner is the divider element — the surface asking to act — passed from
+	 * `e.currentTarget` (the listener's own element), NOT `e.target`.
+	 * `isBlockedByModal` returns false on an empty stack, so with no viewer open
+	 * drag and keyboard resize behave exactly as before.
+	 */
+	function dividerBlocked(e: Event): boolean {
+		return isBlockedByModal((e.currentTarget as Element | null) ?? null);
+	}
+
 	function onDividerPointerDown(e: PointerEvent) {
 		// Left button / touch / pen only; ignore right-click etc.
 		if (e.button !== 0) return;
+		// Gesture START gate (TASK-2430).
+		if (dividerBlocked(e)) return;
 		// Stop the browser from starting a text selection or handing the
 		// gesture to the list (row-click nav) mid-drag.
 		e.preventDefault();
@@ -485,6 +503,14 @@
 
 	function onDividerPointerMove(e: PointerEvent) {
 		if (!resizingPane || !paneEl) return;
+		// STRADDLE gate (TASK-2430) — the drag may have begun before the viewer
+		// opened, and the divider holds the pointer capture, so it keeps
+		// receiving moves. End the resize (releasing capture and restoring the
+		// global drag chrome) rather than merely skipping this frame.
+		if (dividerBlocked(e)) {
+			endPaneResize(e);
+			return;
+		}
 		// The pane is right-docked, so its width is (its right edge − pointer
 		// x). Reading the live rect keeps this correct regardless of page
 		// padding or the pane's current size.
@@ -517,6 +543,8 @@
 	// ArrowLeft grows the pane (divider moves left), ArrowRight shrinks it,
 	// matching the drag direction.
 	function onDividerKeydown(e: KeyboardEvent) {
+		// TASK-2430 — arrows must not resize the layout under a frontmost viewer.
+		if (dividerBlocked(e)) return;
 		const step = e.shiftKey ? 32 : 16;
 		const current = currentPaneWidth();
 		if (e.key === 'ArrowLeft') {

--- a/web/src/lib/components/collections/PaneHost.svelte.test.ts
+++ b/web/src/lib/components/collections/PaneHost.svelte.test.ts
@@ -1,0 +1,259 @@
+// Runs in the jsdom vitest project (filename ends `.svelte.test.ts`).
+//
+// TASK-2430 — the split-pane divider is an app-shell resize surface with BOTH a
+// pointer-captured drag and an arrow-key nudge. Both must defer to a frontmost
+// viewer; the drag additionally has to survive the straddle case, since it
+// holds the pointer capture from the moment it engages.
+//
+// Each blocked case is paired with an EMPTY-STACK REGRESSION.
+//
+// HOW TO READ THE PAIRS. The BLOCKED tests are what fail if a guard is deleted
+// or weakened. The EMPTY-STACK REGRESSIONS are the opposite check — they fail
+// if a guard declines UNCONDITIONALLY, which is the way a "deference" change
+// silently breaks the app for the 99% of the time no viewer is open. Neither
+// half subsumes the other, and an empty-stack test passing with the guard
+// removed is by design, not a false green. Every guard in the files under test
+// was mutation-verified to kill at least one case here (one documented
+// exception, flagged at the guard itself).
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/svelte';
+import { tick, flushSync } from 'svelte';
+
+// ItemDetail (mounted inside the pane) is a large data-driven component; it is
+// irrelevant to the divider, so stub the whole API surface it reaches for.
+vi.mock('$lib/api/client', () => {
+	const never = () => new Promise(() => {});
+	return {
+		api: new Proxy(
+			{},
+			{
+				get: () =>
+					new Proxy(
+						{},
+						{
+							get: () => never,
+						},
+					),
+			},
+		),
+		isPlanLimitError: () => false,
+		planLimitMessage: () => '',
+	};
+});
+
+import PaneHost from './PaneHost.svelte';
+import { acquire, __resetViewerBackdropForTests } from '$lib/a11y/viewerBackdrop';
+
+function divider(): HTMLElement {
+	const el = document.querySelector('.pane-divider');
+	if (!el) throw new Error('.pane-divider not found');
+	return el as HTMLElement;
+}
+
+function paneWidth(): number {
+	return Number(divider().getAttribute('aria-valuenow'));
+}
+
+function mountViewer(): HTMLElement {
+	const root = document.createElement('div');
+	root.className = 'attachment-viewer';
+	root.setAttribute('role', 'dialog');
+	document.body.appendChild(root);
+	return root;
+}
+
+function pointer(type: string, x: number): Event {
+	const e = new MouseEvent(type, { bubbles: true, cancelable: true, clientX: x, clientY: 0 });
+	Object.defineProperty(e, 'pointerId', { value: 3 });
+	Object.defineProperty(e, 'button', { value: 0 });
+	return e;
+}
+
+function arrow(k: 'ArrowLeft' | 'ArrowRight'): KeyboardEvent {
+	return new KeyboardEvent('keydown', { key: k, bubbles: true, cancelable: true });
+}
+
+let captured: number[] = [];
+let released: number[] = [];
+/**
+ * `vi.restoreAllMocks()` does NOT undo a raw prototype assignment, and these
+ * three are raw (jsdom implements neither pointer-capture method, and the rect
+ * stub has to be a plain function to branch on the element). Keep the originals
+ * and put them back, so nothing here can leak into another test in this file —
+ * or, if vitest is ever run with `isolate: false`, into another file.
+ */
+/**
+ * Put a prototype method back EXACTLY as it was. jsdom ships neither
+ * pointer-capture method, so assigning the captured `undefined` would CREATE an
+ * own property and flip `in` / `hasOwn` feature detection for later tests —
+ * delete instead.
+ */
+function restoreProto(name: string, original: unknown) {
+	if (original === undefined) {
+		delete (Element.prototype as unknown as Record<string, unknown>)[name];
+	} else {
+		(Element.prototype as unknown as Record<string, unknown>)[name] = original;
+	}
+}
+
+const REAL = {
+	setPointerCapture: Element.prototype.setPointerCapture,
+	releasePointerCapture: Element.prototype.releasePointerCapture,
+	getBoundingClientRect: Element.prototype.getBoundingClientRect,
+};
+
+beforeEach(async () => {
+	captured = [];
+	released = [];
+	(Element.prototype as unknown as Record<string, unknown>).setPointerCapture = function (
+		id: number,
+	) {
+		captured.push(id);
+	};
+	(Element.prototype as unknown as Record<string, unknown>).releasePointerCapture = function (
+		id: number,
+	) {
+		released.push(id);
+	};
+	// jsdom reports a zero-size rect, and the component's fit/clamp bounds are
+	// derived from the CONTAINER width — with everything zero, every width pins
+	// to the same clamped value and no assertion here could distinguish a resize
+	// from a no-op.
+	//
+	// So describe ONE COHERENT LAYOUT rather than convenient numbers: a 2000px
+	// container spanning [0, 2000], with the right-docked pane occupying its
+	// right edge — [1600, 2000], i.e. 400 wide, its `right` equal to the
+	// container's. The divider therefore sits at x≈1600, and the drag math
+	// (`pane.right - clientX`) reads as it does in a browser: dragging to 1400
+	// gives a 600px pane, and the list keeps 1400px.
+	Element.prototype.getBoundingClientRect = function (this: Element) {
+		if (this.classList?.contains('item-pane')) {
+			return { right: 2000, left: 1600, top: 0, bottom: 800, width: 400, height: 800, x: 1600, y: 0 } as DOMRect;
+		}
+		return { right: 2000, left: 0, top: 0, bottom: 800, width: 2000, height: 800, x: 0, y: 0 } as DOMRect;
+	};
+	localStorage.removeItem('pad-pane-width');
+
+	render(PaneHost, {
+		props: {
+			openItemRef: 'TASK-1',
+			username: 'u',
+			wsSlug: 'ws',
+			collSlug: 'tasks',
+			paneMintForRoute: 'TASK-1',
+			onClose: vi.fn(),
+			onGone: vi.fn(),
+			onNavigateAway: vi.fn(),
+			onOpenTarget: vi.fn(),
+			onBack: vi.fn(),
+		},
+	});
+	await tick();
+	flushSync();
+});
+
+afterEach(() => {
+	cleanup();
+	__resetViewerBackdropForTests();
+	restoreProto('setPointerCapture', REAL.setPointerCapture);
+	restoreProto('releasePointerCapture', REAL.releasePointerCapture);
+	restoreProto('getBoundingClientRect', REAL.getBoundingClientRect);
+	// The component PERSISTS the width it computes; without this the next test's
+	// baseline is the previous test's drag result.
+	localStorage.removeItem('pad-pane-width');
+	vi.restoreAllMocks();
+	document.body.innerHTML = '';
+});
+
+describe('PaneHost divider — keyboard resize (TASK-2430)', () => {
+	it('EMPTY-STACK REGRESSION: an arrow still nudges the width with no lease held', async () => {
+		const before = paneWidth();
+		const e = arrow('ArrowLeft');
+		divider().dispatchEvent(e);
+		await tick();
+		flushSync();
+		expect(e.defaultPrevented).toBe(true);
+		expect(paneWidth()).toBeGreaterThan(before);
+	});
+
+	it('ignores arrows while a viewer lease is frontmost, and resumes on release', async () => {
+		const lease = acquire(mountViewer());
+		const before = paneWidth();
+		const blocked = arrow('ArrowLeft');
+		divider().dispatchEvent(blocked);
+		await tick();
+		flushSync();
+		expect(blocked.defaultPrevented).toBe(false);
+		expect(paneWidth()).toBe(before);
+
+		lease.release();
+		const after = arrow('ArrowLeft');
+		divider().dispatchEvent(after);
+		await tick();
+		flushSync();
+		expect(after.defaultPrevented).toBe(true);
+		expect(paneWidth()).toBeGreaterThan(before);
+	});
+});
+
+describe('PaneHost divider — drag resize (TASK-2430)', () => {
+	it('EMPTY-STACK REGRESSION: a drag still engages, captures and resizes', async () => {
+		const d = divider();
+		const down = pointer('pointerdown', 1600);
+		d.dispatchEvent(down);
+		expect(down.defaultPrevented).toBe(true);
+		expect(captured).toEqual([3]);
+
+		d.dispatchEvent(pointer('pointermove', 1400));
+		await tick();
+		flushSync();
+		// `pane.right (2000) - clientX (1400)` = 600, inside the clamp bounds for
+		// a 2000px container.
+		expect(paneWidth()).toBe(600);
+	});
+
+	it('does not START a drag while a viewer lease is frontmost', async () => {
+		acquire(mountViewer());
+		const before = paneWidth();
+		const d = divider();
+		const down = pointer('pointerdown', 1600);
+		d.dispatchEvent(down);
+		expect(down.defaultPrevented).toBe(false);
+		expect(captured).toEqual([]);
+
+		d.dispatchEvent(pointer('pointermove', 1400));
+		await tick();
+		flushSync();
+		expect(paneWidth()).toBe(before);
+		// The global drag chrome was never installed either.
+		expect(document.body.style.cursor).toBe('');
+	});
+
+	it('STRADDLE: a drag in flight is ENDED when the viewer opens, not merely paused', async () => {
+		const d = divider();
+		d.dispatchEvent(pointer('pointerdown', 1600));
+		d.dispatchEvent(pointer('pointermove', 1400));
+		await tick();
+		flushSync();
+		expect(paneWidth()).toBe(600);
+		expect(document.body.style.cursor).toBe('col-resize');
+
+		acquire(mountViewer());
+		d.dispatchEvent(pointer('pointermove', 1300));
+		await tick();
+		flushSync();
+		// Width unchanged, capture released, and the global drag chrome restored
+		// — an early `return` alone would have left all three wrong.
+		expect(paneWidth()).toBe(600);
+		expect(released).toEqual([3]);
+		expect(document.body.style.cursor).toBe('');
+		expect(document.body.style.userSelect).toBe('');
+
+		// The drag is genuinely over: a further move does nothing even if the
+		// viewer were to close.
+		d.dispatchEvent(pointer('pointermove', 1250));
+		await tick();
+		flushSync();
+		expect(paneWidth()).toBe(600);
+	});
+});

--- a/web/src/lib/components/common/BottomSheet.svelte
+++ b/web/src/lib/components/common/BottomSheet.svelte
@@ -121,6 +121,11 @@
 
 	function handleKeydown(e: KeyboardEvent) {
 		if (!open) return;
+		// A HELD Escape auto-repeats as FRESH event objects, which the viewer's
+		// per-event mark (BUG-2441) cannot cover once its lease is released —
+		// a hold would close the viewer and then this sheet. Only the initial
+		// press acts, matching the route guards (TASK-2448).
+		if (e.key === 'Escape' && e.repeat) return;
 		// TASK-2430 — front layer wins. `isFrontmostSheet()` only arbitrates
 		// between SHEETS; a body-portaled viewer (or a native `showModal()`
 		// dialog) sits above every sheet and is invisible to that check, so ask

--- a/web/src/lib/components/common/BottomSheet.svelte
+++ b/web/src/lib/components/common/BottomSheet.svelte
@@ -19,6 +19,7 @@
 <script lang="ts">
 	import type { Snippet } from 'svelte';
 	import { paneFocusables, nextTrapTarget } from '$lib/collections/paneFocus';
+	import { isBlockedByModal } from '$lib/a11y/viewerBackdrop';
 
 	interface Props {
 		open: boolean;
@@ -120,6 +121,16 @@
 
 	function handleKeydown(e: KeyboardEvent) {
 		if (!open) return;
+		// TASK-2430 — front layer wins. `isFrontmostSheet()` only arbitrates
+		// between SHEETS; a body-portaled viewer (or a native `showModal()`
+		// dialog) sits above every sheet and is invisible to that check, so ask
+		// the shared arbitration helper as well. The argument is this sheet — the
+		// surface asking to act — not `event.target`: a viewer launched FROM this
+		// sheet still has the sheet as the keydown target.
+		//
+		// Empty stack + no native modal ⇒ `false`, so with no viewer open both
+		// the Escape close and the Tab trap behave exactly as before.
+		if (isBlockedByModal(sheetEl)) return;
 		if (!isFrontmostSheet()) return;
 		if (e.key === 'Escape') {
 			e.preventDefault();

--- a/web/src/lib/components/common/BottomSheet.svelte
+++ b/web/src/lib/components/common/BottomSheet.svelte
@@ -130,7 +130,20 @@
 		//
 		// Empty stack + no native modal ⇒ `false`, so with no viewer open both
 		// the Escape close and the Tab trap behave exactly as before.
-		if (isBlockedByModal(sheetEl)) return;
+		//
+		// DELIBERATE, NAMED BEHAVIOUR CHANGE (TASK-2448 / BUG-2441) — the FOURTH
+		// named parity exception of PLAN-2392 phase 3a. The `event` argument makes
+		// the question EVENT-SCOPED as well as live: the viewer's escape handler
+		// runs earlier in this same dispatch and releases its lease synchronously,
+		// so the live question answers "nothing in front of you" and this sheet
+		// closes as a second layer on one press. A viewer that consumed the press
+		// marks it, and the mark outlives the lease.
+		//
+		// This is NOT the `defaultPrevented` bail TASK-2430 shipped and reverted:
+		// that fired with no viewer present. This marker is only ever set by a
+		// frontmost viewer, so with an empty lease stack it is unreachable and
+		// this line behaves exactly as `isBlockedByModal(sheetEl)` did.
+		if (isBlockedByModal(sheetEl, e)) return;
 		if (!isFrontmostSheet()) return;
 		if (e.key === 'Escape') {
 			e.preventDefault();

--- a/web/src/lib/components/common/BottomSheet.svelte.test.ts
+++ b/web/src/lib/components/common/BottomSheet.svelte.test.ts
@@ -8,6 +8,7 @@ import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, cleanup } from '@testing-library/svelte';
 import { createRawSnippet, tick, flushSync } from 'svelte';
 import BottomSheet from './BottomSheet.svelte';
+import { acquire, __resetViewerBackdropForTests } from '$lib/a11y/viewerBackdrop';
 
 // Two focusable controls so the Tab-trap wrap has a first/last to cycle between.
 const bodySnippet = createRawSnippet(() => ({
@@ -188,5 +189,104 @@ describe('BottomSheet.svelte', () => {
 		flushSync();
 
 		expect(document.activeElement).toBe(trigger);
+	});
+});
+
+// ── TASK-2430: front layer wins ──────────────────────────────────────────
+//
+// `isFrontmostSheet()` only arbitrates between SHEETS. A body-portaled viewer
+// sits above every sheet and is invisible to it, so the sheet also has to
+// consult the shared arbitration helper. Each case is paired with an
+// EMPTY-STACK REGRESSION: with no lease held, Escape and the Tab trap must
+// behave exactly as they did before.
+describe('BottomSheet.svelte — defers to a frontmost viewer (TASK-2430)', () => {
+	/** A body-portaled viewer root, exactly the shape `acquire` expects. */
+	function mountViewer(): HTMLElement {
+		const root = document.createElement('div');
+		root.className = 'attachment-viewer';
+		root.setAttribute('role', 'dialog');
+		document.body.appendChild(root);
+		return root;
+	}
+
+	afterEach(() => {
+		__resetViewerBackdropForTests();
+	});
+
+	it('EMPTY-STACK REGRESSION: still closes on Escape with no lease held', async () => {
+		const onclose = vi.fn();
+		render(BottomSheet, { props: baseProps({ open: true, onclose }) });
+		await tick();
+		flushSync();
+
+		window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+		expect(onclose).toHaveBeenCalledTimes(1);
+	});
+
+	it('declines Escape while a viewer lease is frontmost, and takes it back on release', async () => {
+		const onclose = vi.fn();
+		render(BottomSheet, { props: baseProps({ open: true, onclose }) });
+		await tick();
+		flushSync();
+
+		const lease = acquire(mountViewer());
+		window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+		expect(onclose).not.toHaveBeenCalled();
+
+		lease.release();
+		window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+		expect(onclose).toHaveBeenCalledTimes(1);
+	});
+
+	it('OWNER ARGUMENT: an Escape ORIGINATING inside the viewer is still declined', async () => {
+		// The discriminating case for "the argument is the SURFACE ASKING TO ACT,
+		// not `event.target`". The blocked test above dispatches on `window`,
+		// where the target is outside the viewer too, so it would ALSO pass with
+		// the wrong argument. This is the realistic press — the viewer holds
+		// focus, so the target is a viewer control, and an `e.target` owner would
+		// answer "not blocked" and close the sheet underneath it.
+		const onclose = vi.fn();
+		render(BottomSheet, { props: baseProps({ open: true, onclose }) });
+		await tick();
+		flushSync();
+
+		const viewer = mountViewer();
+		const btn = document.createElement('button');
+		viewer.appendChild(btn);
+		acquire(viewer);
+
+		btn.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+		expect(onclose).not.toHaveBeenCalled();
+	});
+
+	it('EMPTY-STACK REGRESSION: still traps Tab with no lease held, and stops trapping under a viewer', async () => {
+		// Same visibility stub the positive Tab tests above use: without it jsdom
+		// reports every control as invisible, `paneFocusables` returns [], and the
+		// trap falls back to focusing the sheet container — which would still
+		// satisfy the assertions below without ever exercising the real wrap.
+		vi.spyOn(HTMLElement.prototype, 'getClientRects').mockReturnValue([
+			{ width: 1, height: 1 } as DOMRect
+		] as unknown as DOMRectList);
+		render(BottomSheet, { props: baseProps({ open: true }) });
+		await tick();
+		flushSync();
+
+		const last = document.getElementById('last-btn') as HTMLButtonElement;
+		last.focus();
+		const trapped = new KeyboardEvent('keydown', { key: 'Tab', cancelable: true });
+		window.dispatchEvent(trapped);
+		// The trap wrapped focus to the sheet's FIRST focusable — the header close
+		// button — and consumed the key.
+		expect(trapped.defaultPrevented).toBe(true);
+		expect(document.activeElement).toBe(getSheet().querySelector('.bs-close'));
+
+		// Under a viewer the sheet must NOT pull focus back into itself — the
+		// viewer runs its own trap.
+		acquire(mountViewer());
+		last.focus();
+		const passed = new KeyboardEvent('keydown', { key: 'Tab', cancelable: true });
+		window.dispatchEvent(passed);
+		expect(passed.defaultPrevented).toBe(false);
+		expect(document.activeElement).toBe(last);
 	});
 });

--- a/web/src/lib/components/common/BottomSheet.svelte.test.ts
+++ b/web/src/lib/components/common/BottomSheet.svelte.test.ts
@@ -8,7 +8,11 @@ import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, cleanup } from '@testing-library/svelte';
 import { createRawSnippet, tick, flushSync } from 'svelte';
 import BottomSheet from './BottomSheet.svelte';
-import { acquire, __resetViewerBackdropForTests } from '$lib/a11y/viewerBackdrop';
+import {
+	acquire,
+	noteEscapeConsumedByViewer,
+	__resetViewerBackdropForTests
+} from '$lib/a11y/viewerBackdrop';
 
 // Two focusable controls so the Tab-trap wrap has a first/last to cycle between.
 const bodySnippet = createRawSnippet(() => ({
@@ -234,6 +238,40 @@ describe('BottomSheet.svelte — defers to a frontmost viewer (TASK-2430)', () =
 		expect(onclose).not.toHaveBeenCalled();
 
 		lease.release();
+		window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+		expect(onclose).toHaveBeenCalledTimes(1);
+	});
+
+	it('declines an Escape a VIEWER already consumed, after the lease is gone', async () => {
+		// TASK-2448 / BUG-2441. The lease is released BEFORE the dispatch on
+		// purpose — that is what the browser does, since the viewer's escape
+		// handler runs earlier in the same event and Svelte flushes its teardown
+		// synchronously. The lease-state guard above cannot see this; only the
+		// event-scoped mark can.
+		const onclose = vi.fn();
+		render(BottomSheet, { props: baseProps({ open: true, onclose }) });
+		await tick();
+		flushSync();
+
+		const lease = acquire(mountViewer());
+		const consumed = new KeyboardEvent('keydown', { key: 'Escape' });
+		noteEscapeConsumedByViewer(consumed);
+		lease.release();
+		window.dispatchEvent(consumed);
+		expect(onclose).not.toHaveBeenCalled();
+
+		// One Escape closes ONE layer — the sheet still owns the next press.
+		window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+		expect(onclose).toHaveBeenCalledTimes(1);
+	});
+
+	it('EMPTY-STACK REGRESSION: an unmarked Escape still closes it after a viewer has gone', async () => {
+		const onclose = vi.fn();
+		render(BottomSheet, { props: baseProps({ open: true, onclose }) });
+		await tick();
+		flushSync();
+
+		acquire(mountViewer()).release();
 		window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
 		expect(onclose).toHaveBeenCalledTimes(1);
 	});

--- a/web/src/lib/components/common/Lightbox.svelte
+++ b/web/src/lib/components/common/Lightbox.svelte
@@ -6,11 +6,28 @@
 	 * (un-variant) blob so the expanded view is full resolution regardless
 	 * of the thumbnail variant shown inline.
 	 *
-	 * Keyboard: Esc closes, ←/→ navigate when multiple images were passed.
-	 * Backdrop click closes; clicking the image itself does not.
+	 * MODAL CONTRACT (PLAN-2392 phase 3a / TASK-2429, DR-4b). This is a real
+	 * modal now: `role="dialog"` + `aria-modal`, portaled to `<body>`, focus
+	 * entry + restore, a Tab trap, background inertness through the shared
+	 * viewer-backdrop manager, and Escape via the shared `escapeStack`. It is
+	 * the contract the editor's hand-rolled `showModal()` dialog was getting
+	 * from the platform for free, written out by hand — because 3a's later
+	 * tasks delete that dialog and route the inline body images here.
+	 *
+	 * Keyboard: Esc closes (through `escapeStack`, NOT a local listener),
+	 * ←/→ navigate when multiple images were passed, Tab cycles within the
+	 * viewer. Backdrop click closes; clicking the image itself does not.
 	 */
 	import { untrack } from 'svelte';
 	import { attachmentDownloadUrl } from '$lib/markdown/attachments';
+	import { paneFocusables, nextTrapTarget } from '$lib/collections/paneFocus';
+	import {
+		acquire,
+		isBlockedByModal,
+		isViewerFrontmost,
+		VIEWER_ROOT_CLASS,
+	} from '$lib/a11y/viewerBackdrop';
+	import { pushEscapeHandler, ESCAPE_PRIORITY } from '$lib/stores/escapeStack';
 
 	export interface LightboxImage {
 		id: string;
@@ -23,9 +40,16 @@
 		index?: number;
 		wsSlug: string;
 		onClose: () => void;
+		/**
+		 * The control that opened the viewer — focus goes back to it on close.
+		 * OPTIONAL: the strip, the timeline and the NodeView thread real values in
+		 * TASK-2431 / TASK-2433. Until then it falls back to whatever held focus
+		 * at open (see below), which is the same element in every current path.
+		 */
+		invoker?: HTMLElement | null;
 	}
 
-	let { images, index = 0, wsSlug, onClose }: Props = $props();
+	let { images, index = 0, wsSlug, onClose, invoker = null }: Props = $props();
 
 	// Seeded once at mount — the host remounts (null → set) on each open, so
 	// no prop-sync effect is needed. untrack makes the initial-value capture
@@ -34,9 +58,39 @@
 		untrack(() => Math.min(Math.max(index, 0), Math.max(images.length - 1, 0)))
 	);
 
+	// CAPTURED AT OPEN, never read live (TASK-2429). The pane switches workspace
+	// without remounting whatever is above it, so a live read could rebuild the
+	// URLs of already-captured attachment ids against a DIFFERENT workspace —
+	// serving a 404, or worse, another workspace's attachment at the same id.
+	// `invoker` is captured for the same reason: the value that opened this
+	// viewer is the one to return focus to.
+	const openWsSlug = untrack(() => wsSlug);
+	// The invoker falls back to WHATEVER HELD FOCUS AT OPEN (the pattern
+	// `BottomSheet` uses), not to nothing. Focus entry is about to move focus
+	// into the viewer, so without this the producers that don't thread an
+	// invoker yet — the strip and the timeline, until TASK-2431 — would be
+	// strictly worse off than before this component managed focus at all: they
+	// keep focus on the clicked tile today, and a null invoker would drop it to
+	// `<body>` on close. Captured at init, BEFORE the entry focus runs.
+	const openInvoker = untrack(() => {
+		if (invoker) return invoker;
+		if (typeof document === 'undefined') return null;
+		const active = document.activeElement;
+		return active && active !== document.body ? (active as HTMLElement) : null;
+	});
+
 	let hasMultiple = $derived(images.length > 1);
 	let img = $derived(images[current]);
-	let src = $derived(img ? attachmentDownloadUrl(wsSlug, img.id) : '');
+	let src = $derived(img ? attachmentDownloadUrl(openWsSlug, img.id) : '');
+	// The accessible name: the image's own alt where there is one, else a
+	// generic label. Never empty — an unnamed `role="dialog"` is announced as
+	// nothing at all.
+	let dialogLabel = $derived(img?.alt || 'Attachment viewer');
+
+	// The portaled root. `$state` so the effect below re-runs once `bind:this`
+	// lands; read-only inside every effect, so nothing here can self-invalidate
+	// a flush (CONVE-1688).
+	let rootEl = $state<HTMLElement | null>(null);
 
 	function prev() {
 		current = (current - 1 + images.length) % images.length;
@@ -45,14 +99,144 @@
 		current = (current + 1) % images.length;
 	}
 
-	function onKeydown(e: KeyboardEvent) {
-		if (e.key === 'Escape') {
+	/**
+	 * Return focus where it came from, on close.
+	 *
+	 * Declines when focus has ALREADY moved somewhere outside this viewer —
+	 * a surface opened over the viewer owns focus outright, and so does a
+	 * producer that moves focus from its own close handler (which runs BEFORE
+	 * this teardown). `AttachmentViewerHost` used to be exactly that producer;
+	 * TASK-2429 moved the restore here precisely because its version ran while
+	 * the invoker was still inert, so this guard is now about the surfaces the
+	 * viewer does not control rather than about that host. Focus resting on
+	 * `<body>` / nowhere is the adrift state a teardown leaves behind, and
+	 * counts as ours to move.
+	 *
+	 * The invoker is verified rather than trusted: it can have been detached
+	 * (an editor NodeView is re-rendered on any document change), hidden, or
+	 * inerted since it was captured, and `focus()` on such an element silently
+	 * does nothing on some engines and drops focus to `<body>` on others. So we
+	 * focus it and CHECK, falling back to parking focus on `<body>` — which is
+	 * where the browser would have put it anyway, but deterministically, and
+	 * without leaving focus inside a subtree that is about to be removed.
+	 */
+	function restoreFocus(root: HTMLElement): void {
+		const active = document.activeElement;
+		if (active !== null && active !== document.body && !root.contains(active)) return;
+
+		if (openInvoker?.isConnected) {
+			openInvoker.focus?.({ preventScroll: true });
+			if (document.activeElement === openInvoker) return;
+		}
+		(document.activeElement as HTMLElement | null)?.blur?.();
+	}
+
+	// ONE effect owns the whole modal contract, because the steps are ordered
+	// with respect to each other and to teardown: portal → lease → focus entry →
+	// Escape registration, unwound in reverse.
+	$effect(() => {
+		const el = rootEl;
+		if (!el) return;
+
+		// PORTAL TO <body> DIRECTLY — deliberately NOT `portalAction.ts`, which
+		// targets the nearest ancestor `<dialog>` when there is one: exactly the
+		// wrong target for a surface that must sit ABOVE everything. A `position:
+		// fixed` overlay is only viewport-fixed while no ancestor establishes a
+		// containing block, and `transform` / `filter` / `contain: layout` on any
+		// ancestor silently does (see the container-query foot-gun). `<body>` is
+		// the only parent with no such ancestor, and it is what the backdrop
+		// manager's inert bookkeeping requires: it writes `inert` on BODY CHILDREN
+		// and exempts this one.
+		document.body.appendChild(el);
+
+		// Background inertness is the manager's, not ours — no hand-rolled
+		// `inert`, no `aria-hidden` sweep. It refcounts, so two viewers stacked
+		// (the strip's and a NodeView's) can't clobber each other's writes.
+		const lease = acquire(el);
+
+		// Focus ENTRY goes to the first tabbable DESCENDANT (the close button),
+		// not the root: a screen-reader user landing on the container has to
+		// discover the controls, and the trap below cycles from wherever focus is.
+		// The root is `tabindex="-1"` purely as the fallback for a viewer with no
+		// tabbable control yet (single image, still loading) — focus must not stay
+		// on whatever is behind the backdrop.
+		const entry = paneFocusables(el)[0] ?? el;
+		entry.focus({ preventScroll: true });
+
+		// Escape has ONE owner: the shared stack. The local `<svelte:window>`
+		// Escape branch this component used to carry was DELETED rather than
+		// gated — it ignored `defaultPrevented`, so with the stack also running,
+		// a single press closed the viewer AND the layer beneath it.
+		//
+		// Registered ABOVE `menu` (40) so the viewer is the innermost layer.
+		// Declines (returns false) unless this viewer is the FRONTMOST lease, so
+		// with two viewers open one press closes exactly the top one and the
+		// stack falls through to it rather than to an unrelated layer.
+		const unregisterEscape = pushEscapeHandler(() => {
+			if (!isViewerFrontmost(el)) return false;
 			onClose();
-		} else if (e.key === 'ArrowLeft' && hasMultiple) {
+			return true;
+		}, ESCAPE_PRIORITY.viewer);
+
+		return () => {
+			unregisterEscape();
+			// Release BEFORE restoring focus, and let the RESULT decide: when a
+			// viewer remains beneath this one the manager has already handed focus
+			// into it, and restoring our own invoker would yank focus out of a
+			// viewer the user is still looking at. Only the last one out restores.
+			const { stackEmpty } = lease.release();
+			if (stackEmpty) restoreFocus(el);
+			// Svelte removes the node itself, but it is reparented out of its
+			// anchor — remove it explicitly so the DOM can never be left with a
+			// stranded backdrop, and so the manager's next reconcile sees the
+			// body child list it expects.
+			el.remove();
+		};
+	});
+
+	function onKeydown(e: KeyboardEvent) {
+		// A control that already handled this key owns it.
+		if (e.defaultPrevented) return;
+		const el = rootEl;
+		// Every mounted viewer listens on `window`, so ONLY the frontmost may act.
+		// This matters more than the usual layer-isolation argument: `nextTrapTarget`
+		// deliberately pulls out-of-container focus back INWARD, so a background
+		// viewer running the trap would drag focus into itself, out of the viewer
+		// in front of it.
+		if (!el || !isViewerFrontmost(el)) return;
+		// ...and a `showModal()` dialog opened OVER the viewer owns the top layer,
+		// above any body-portaled surface, so the frontmost LEASE is not
+		// necessarily the frontmost SURFACE. Without this the viewer's trap would
+		// fight a native modal for Tab and pull focus back out of it — the exact
+		// inward-redirect hazard the frontmost gate exists to prevent, one layer
+		// up. The manager already keeps such a dialog out of the inert set
+		// (`keepInteractiveAsDialog`), so it is reachable and this is real.
+		if (isBlockedByModal(el)) return;
+
+		if (e.key === 'Tab') {
+			// Reuses the pane's tested trap math (paneFocus.ts) — one trap
+			// implementation for the whole app, not a second one here.
+			const target = nextTrapTarget(
+				paneFocusables(el),
+				document.activeElement,
+				e.shiftKey,
+				el
+			);
+			if (target) {
+				e.preventDefault();
+				target.focus({ preventScroll: true });
+			}
+			return;
+		}
+
+		if (e.key === 'ArrowLeft' && hasMultiple) {
+			e.preventDefault();
 			prev();
 		} else if (e.key === 'ArrowRight' && hasMultiple) {
+			e.preventDefault();
 			next();
 		}
+		// NO Escape branch. See the registration above.
 	}
 
 	// Close only on a click of the backdrop itself — clicks on the image or
@@ -65,20 +249,55 @@
 
 <svelte:window onkeydown={onKeydown} />
 
+<!--
+	The backdrop click has no keyboard twin ON THIS ELEMENT by design: the
+	keyboard route out is Escape (through the shared stack) and the close
+	button, which is the first thing focus lands on. Adding a key handler here
+	would put a second, undocumented dismissal on the container.
+-->
+<!-- svelte-ignore a11y_click_events_have_key_events -->
 <div
-	class="lightbox-backdrop"
-	role="presentation"
+	bind:this={rootEl}
+	class="lightbox-backdrop {VIEWER_ROOT_CLASS}"
+	role="dialog"
+	aria-modal="true"
+	aria-label={dialogLabel}
+	tabindex="-1"
 	onclick={onBackdropClick}
 >
-	<button class="lightbox-close" type="button" title="Close (Esc)" onclick={onClose}>
+	<!--
+		Explicit `aria-label`s: the glyph IS the label otherwise ("✕", "‹", "›"),
+		and `title` does not win over element content for the accessible name. The
+		browser suite (TASK-2436) also addresses these controls BY NAME, never by
+		class or a bare `[role="dialog"]`.
+	-->
+	<button
+		class="lightbox-close"
+		type="button"
+		title="Close (Esc)"
+		aria-label="Close"
+		onclick={onClose}
+	>
 		&#10005;
 	</button>
 
 	{#if hasMultiple}
-		<button class="lightbox-nav prev" type="button" title="Previous (←)" onclick={prev}>
+		<button
+			class="lightbox-nav prev"
+			type="button"
+			title="Previous (←)"
+			aria-label="Previous image"
+			onclick={prev}
+		>
 			&#8249;
 		</button>
-		<button class="lightbox-nav next" type="button" title="Next (→)" onclick={next}>
+		<button
+			class="lightbox-nav next"
+			type="button"
+			title="Next (→)"
+			aria-label="Next image"
+			onclick={next}
+		>
 			&#8250;
 		</button>
 	{/if}
@@ -96,7 +315,39 @@
 	.lightbox-backdrop {
 		position: fixed;
 		inset: 0;
-		z-index: 1000;
+		/*
+		 * ABOVE EVERY OTHER OVERLAY IN THE APP (TASK-2429). The viewer is a modal:
+		 * it inerts every other body child, so anything that PAINTS over it is a
+		 * surface the user can see but cannot touch — the worst of both. The app
+		 * shell wrapper is `display: contents` (`app.html`), which creates no
+		 * stacking context, so every fixed overlay in the tree competes with this
+		 * one in the ROOT stacking context — being a body child is not by itself
+		 * protection.
+		 *
+		 * What this value must out-rank, highest first (swept for TASK-2429 — CSS
+		 * declarations AND `style.cssText` written from TypeScript, which a CSS-only
+		 * grep misses):
+		 *   99999  EmojiPickerButton's desktop dropdown (`EmojiPickerButton.svelte`,
+		 *          body-portaled via `portalAction`) — the highest in the tree by
+		 *          two orders of magnitude, and the reason 1000 was not enough
+		 *    1000  the editor's block-drag ghost, appended to `<body>` and styled
+		 *          inline (`editor/block-drag-handle.ts::createGhost`)
+		 *     200  Menu (body-portaled) and the editor's slash/link popovers
+		 *     199  the editor's block context menu
+		 *     100  toasts, the notification panel, the editor's mobile toolbar
+		 *   45-60  DockedSheet / BottomSheet / Sidebar / CommandPalette / TopBar
+		 * (`ItemDetail`'s 1000 is a `@media print` footer, not a runtime overlay.)
+		 *
+		 * A NEW OVERLAY ABOVE THIS VALUE IS A BUG unless it is meant to cover a
+		 * modal viewer. One thing legitimately renders above it and needs no
+		 * z-index to do so: a native `showModal()` dialog, which the platform puts
+		 * in the TOP LAYER — the manager deliberately leaves those interactive
+		 * (`viewerBackdrop.ts::keepInteractiveAsDialog`) and the key handler stands
+		 * down for them (`isBlockedByModal`).
+		 *
+		 * jsdom cannot see any of this; the paint-order proof is TASK-2436's.
+		 */
+		z-index: 100000;
 		display: flex;
 		align-items: center;
 		justify-content: center;

--- a/web/src/lib/components/common/Lightbox.svelte
+++ b/web/src/lib/components/common/Lightbox.svelte
@@ -28,11 +28,28 @@
 		VIEWER_ROOT_CLASS,
 	} from '$lib/a11y/viewerBackdrop';
 	import { pushEscapeHandler, ESCAPE_PRIORITY } from '$lib/stores/escapeStack';
-
-	export interface LightboxImage {
-		id: string;
-		alt: string;
-	}
+	import { canOpenInViewer } from '$lib/attachments/display';
+	/**
+	 * ONE definition of what an image in this viewer is (PLAN-2392 / TASK-2431).
+	 *
+	 * It used to be declared here as `{id, alt}` and again — as a superset — on
+	 * the open-viewer channel, with a comment noting the two were structurally
+	 * compatible. Two declarations of the same thing drift the moment one gains
+	 * a field, which is exactly what TASK-2431 does (`mime_type` is what makes
+	 * the DR-16 open gate total, and `size_bytes` / `width` / `height` land now
+	 * so phase 3b's pixel-based loading policy need not reopen the event, the
+	 * host and every producer). The channel's is now the only one.
+	 *
+	 * Everything past `id` / `alt` is NULLABLE and this component treats it as
+	 * such: an inline image's metadata comes from a HEAD probe that may not have
+	 * completed, and an upload event carries only four fields.
+	 *
+	 * Producers that mount this component directly import the type from the
+	 * CHANNEL too, not from here — a `.svelte` module cannot re-export a type,
+	 * and a local `interface … extends` would be a second declaration, which is
+	 * the drift this consolidation removes.
+	 */
+	import type { LightboxImage } from '$lib/attachments/events';
 
 	interface Props {
 		images: LightboxImage[];
@@ -51,11 +68,62 @@
 
 	let { images, index = 0, wsSlug, onClose, invoker = null }: Props = $props();
 
+	/**
+	 * THE LAST-MILE GATE (PLAN-2392 DR-16 / TASK-2431).
+	 *
+	 * Every producer filters its own set before opening — that is where the
+	 * gate belongs, because only the producer knows which of its rows are
+	 * images at all. This is the same rule re-stated at the point of USE, and it
+	 * is not redundant with them:
+	 *
+	 *  - `←/→` page through a set the producer chose ONCE. A producer's filter
+	 *    is a statement about the moment it built the list; this one has to hold
+	 *    for every frame the viewer shows.
+	 *  - the set is `readonly` on the channel but a plain array as a prop, and a
+	 *    producer that mutates it — or a record inside it — after emitting is
+	 *    not a hypothesis this component can rule out.
+	 *  - a producer added later inherits the rule instead of having to know it.
+	 *
+	 * IT FAILS CLOSED. Only a POSITIVELY allowlisted `mime_type` is viewable; a
+	 * null / undefined / unresolved one is not. "Not yet known" is not evidence
+	 * that a file is a PNG, and this is the last thing standing between a set
+	 * and a rendered image — the place where the benefit of the doubt is worth
+	 * least. An earlier revision admitted null on the grounds that an inline
+	 * image's probe is often unasked at click time; that reasoning belongs to
+	 * the PRODUCER, which can wait for the probe, and it had the effect of
+	 * letting an emitter hand over `[safe, unresolved]` and letting the user
+	 * arrow onto the unresolved one. The producers that exist today lose
+	 * nothing: the strip always has the MIME from its list row, and the timeline
+	 * already excludes unresolved entries from the set it builds.
+	 *
+	 * THE CONTRACT FOR NEW PRODUCERS, therefore: resolve the MIME before you
+	 * emit. Passing a possibly-null value is not "let the viewer decide", it is
+	 * an image that silently will not open.
+	 *
+	 * DERIVED, NOT CAPTURED. Every other open-time value here is `untrack`ed
+	 * because the props are constant for the instance's life — but that is a
+	 * claim about the CURRENT producers, and this filter is exactly the thing
+	 * that must not rest on one. As a `$derived` it re-runs when the array is
+	 * replaced or when a record's MIME resolves to something unsafe after the
+	 * viewer opened, so a stale capture cannot outlive its own truth.
+	 */
+	let viewable = $derived(images.filter((im) => canOpenInViewer(im.mime_type)));
+
 	// Seeded once at mount — the host remounts (null → set) on each open, so
 	// no prop-sync effect is needed. untrack makes the initial-value capture
-	// explicit (props are constant for this component's lifetime).
+	// explicit.
+	//
+	// Resolved through the ID rather than carried across as a number: filtering
+	// reindexes everything after a refusal, so the requested POSITION can name a
+	// different image (or none) in the filtered set. Where the requested image
+	// is the one refused, there is nothing to land on and the first viewable
+	// image is what opens.
 	let current = $state(
-		untrack(() => Math.min(Math.max(index, 0), Math.max(images.length - 1, 0)))
+		untrack(() => {
+			const wanted = images[Math.min(Math.max(index, 0), Math.max(images.length - 1, 0))];
+			const at = wanted ? viewable.findIndex((im) => im.id === wanted.id) : -1;
+			return at < 0 ? 0 : at;
+		})
 	);
 
 	// CAPTURED AT OPEN, never read live (TASK-2429). The pane switches workspace
@@ -79,8 +147,20 @@
 		return active && active !== document.body ? (active as HTMLElement) : null;
 	});
 
-	let hasMultiple = $derived(images.length > 1);
-	let img = $derived(images[current]);
+	// EVERYTHING PAST THIS POINT READS `viewable`, NEVER `images` — the nav
+	// wrap-around, the counter and the rendered `<img>` alike. A single read of
+	// the unfiltered prop below would reopen the hole this filter closes.
+	let hasMultiple = $derived(viewable.length > 1);
+	// The position actually shown, clamped. `current` is what the user's ←/→
+	// moved, but the set can SHRINK underneath it — a record whose MIME resolves
+	// to something unsafe after open drops out of `viewable`, and the array can
+	// be replaced outright. Clamping in a derived (rather than writing `current`
+	// from an effect, which would be an effect writing state it reads) keeps the
+	// viewer on a real member instead of blanking or showing `undefined`.
+	let shownIndex = $derived(
+		Math.min(Math.max(current, 0), Math.max(viewable.length - 1, 0))
+	);
+	let img = $derived(viewable[shownIndex]);
 	let src = $derived(img ? attachmentDownloadUrl(openWsSlug, img.id) : '');
 	// The accessible name: the image's own alt where there is one, else a
 	// generic label. Never empty — an unnamed `role="dialog"` is announced as
@@ -92,11 +172,18 @@
 	// a flush (CONVE-1688).
 	let rootEl = $state<HTMLElement | null>(null);
 
+	// Stepped from `shownIndex`, not from `current`: after the set shrinks they
+	// differ, and moving from the raw value would jump relative to a position
+	// the user was never on. Both are no-ops on an empty set — reachable only
+	// through the nav controls / arrow keys, which `hasMultiple` already hides
+	// and gates, but written so the modulo can never be `% 0`.
 	function prev() {
-		current = (current - 1 + images.length) % images.length;
+		if (viewable.length === 0) return;
+		current = (shownIndex - 1 + viewable.length) % viewable.length;
 	}
 	function next() {
-		current = (current + 1) % images.length;
+		if (viewable.length === 0) return;
+		current = (shownIndex + 1) % viewable.length;
 	}
 
 	/**
@@ -307,7 +394,9 @@
 	{/if}
 
 	{#if hasMultiple}
-		<div class="lightbox-counter">{current + 1} / {images.length}</div>
+		<!-- `shownIndex`, so the counter names the image actually on screen even
+		     after the set shrank under `current`. -->
+		<div class="lightbox-counter">{shownIndex + 1} / {viewable.length}</div>
 	{/if}
 </div>
 

--- a/web/src/lib/components/common/Lightbox.svelte
+++ b/web/src/lib/components/common/Lightbox.svelte
@@ -25,6 +25,7 @@
 		acquire,
 		isBlockedByModal,
 		isViewerFrontmost,
+		noteEscapeConsumedByViewer,
 		VIEWER_ROOT_CLASS,
 	} from '$lib/a11y/viewerBackdrop';
 	import { pushEscapeHandler, ESCAPE_PRIORITY } from '$lib/stores/escapeStack';
@@ -259,8 +260,15 @@
 		// Declines (returns false) unless this viewer is the FRONTMOST lease, so
 		// with two viewers open one press closes exactly the top one and the
 		// stack falls through to it rather than to an unrelated layer.
-		const unregisterEscape = pushEscapeHandler(() => {
+		const unregisterEscape = pushEscapeHandler((event) => {
 			if (!isViewerFrontmost(el)) return false;
+			// Mark the DISPATCH before closing, not after (TASK-2448 / BUG-2441).
+			// `onClose()` runs the teardown below synchronously — the lease is gone
+			// by the time it returns — so a later `window` listener in this same
+			// event would be told "no viewer" and close a second layer. The mark is
+			// the only thing that survives that, and it has to be in place before
+			// the state it stands in for is destroyed.
+			if (event) noteEscapeConsumedByViewer(event);
 			onClose();
 			return true;
 		}, ESCAPE_PRIORITY.viewer);

--- a/web/src/lib/components/common/Lightbox.svelte.test.ts
+++ b/web/src/lib/components/common/Lightbox.svelte.test.ts
@@ -5,6 +5,7 @@ import type { LightboxImage } from '$lib/attachments/events';
 import {
 	acquire,
 	hasForeignEscapeOwner,
+	isBlockedByModal,
 	__resetViewerBackdropForTests,
 	VIEWER_ROOT_CLASS,
 } from '$lib/a11y/viewerBackdrop';
@@ -750,6 +751,60 @@ describe('Lightbox — Escape ownership', () => {
 		expect(onClose).toHaveBeenCalledTimes(1);
 		// ONE layer: the pane underneath must not also close on the same press.
 		expect(paneClose).not.toHaveBeenCalled();
+	});
+
+	it('BUG-2441: a LATER window listener stands down even though the lease is already gone', () => {
+		// The bug reproduced honestly in jsdom, which needs the one thing the
+		// other cases in this file leave out: an `onClose` that actually TEARS THE
+		// VIEWER DOWN, synchronously, inside the driver's handler — which is what
+		// Svelte does in the browser, and what releases the lease mid-dispatch.
+		// With a `vi.fn()` onClose the lease survives the press and the sheet's
+		// live guard answers correctly all by itself; that is exactly why the
+		// unit suite missed this and TASK-2436's browser suite caught it.
+		//
+		// The sheet stand-in is deliberately shaped like `DockedSheet` /
+		// `BottomSheet`: a `window` keydown listener registered AFTER the driver,
+		// guarded by `isBlockedByModal(ownEl, event)`.
+		const app = mountViewer({
+			onClose: () => {
+				unmount(mounted.splice(mounted.indexOf(app), 1)[0]);
+				flushSync();
+			},
+		});
+
+		const sheetEl = appRoot.appendChild(document.createElement('div'));
+		const sheetClose = vi.fn();
+
+		const routeDriver = (e: KeyboardEvent) => {
+			if (e.key !== 'Escape') return;
+			if (hasForeignEscapeOwner()) return;
+			if (runTopEscape(e)) e.preventDefault();
+		};
+		const sheetOwner = (e: KeyboardEvent) => {
+			if (e.key !== 'Escape') return;
+			if (isBlockedByModal(sheetEl, e)) return;
+			sheetClose();
+		};
+		window.addEventListener('keydown', routeDriver);
+		window.addEventListener('keydown', sheetOwner);
+		try {
+			press('Escape');
+			// The viewer is gone — so the sheet's LIVE guard now answers "nothing
+			// in front of you". Asserted, because it is the premise of the bug: if
+			// this were false the test would prove nothing.
+			expect(roots()).toHaveLength(0);
+			expect(isBlockedByModal(sheetEl)).toBe(false);
+			// ...and yet the sheet did not act, because the press was already spent.
+			expect(sheetClose).not.toHaveBeenCalled();
+
+			// EMPTY-STACK REGRESSION, on the same wiring: the NEXT press is the
+			// sheet's. The fix must not leave it permanently deaf.
+			press('Escape');
+			expect(sheetClose).toHaveBeenCalledTimes(1);
+		} finally {
+			window.removeEventListener('keydown', routeDriver);
+			window.removeEventListener('keydown', sheetOwner);
+		}
 	});
 
 	it('unregisters on close, so a later Escape reaches the layer beneath', () => {

--- a/web/src/lib/components/common/Lightbox.svelte.test.ts
+++ b/web/src/lib/components/common/Lightbox.svelte.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { flushSync, mount, unmount } from 'svelte';
 import Lightbox from './Lightbox.svelte';
+import type { LightboxImage } from '$lib/attachments/events';
 import {
 	acquire,
 	hasForeignEscapeOwner,
@@ -42,8 +43,29 @@ const realGetClientRects = HTMLElement.prototype.getClientRects;
 const IMG_A = 'aaaaaaaa-1111-4111-8111-aaaaaaaaaaaa';
 const IMG_B = 'bbbbbbbb-2222-4222-8222-bbbbbbbbbbbb';
 
+const IMG_C = 'cccccccc-3333-4333-8333-cccccccccccc';
+
+/**
+ * A member of the viewer's set. `mime_type` defaults to an ALLOWLISTED type,
+ * because the gate fails closed: a record without one is not viewable, so a
+ * null default would silently empty the viewer for every case in this file
+ * that is about something else. Pass `null` explicitly to test the unresolved
+ * case.
+ */
+function image(id: string, alt: string, mime: string | null = 'image/png'): LightboxImage {
+	return {
+		id,
+		alt,
+		filename: null,
+		mime_type: mime,
+		size_bytes: null,
+		width: null,
+		height: null,
+	};
+}
+
 interface Props {
-	images: { id: string; alt: string }[];
+	images: LightboxImage[];
 	index?: number;
 	wsSlug: string;
 	onClose: () => void;
@@ -53,7 +75,7 @@ interface Props {
 // Reactive props for the capture-at-open cases ($state may only initialize a
 // declaration, hence top level).
 const liveProps = $state<Props>({
-	images: [{ id: IMG_A, alt: 'a diagram' }],
+	images: [image(IMG_A, 'a diagram')],
 	index: 0,
 	wsSlug: 'ws-one',
 	onClose: () => {},
@@ -67,7 +89,7 @@ function mountViewer(props: Partial<Props> = {}): ReturnType<typeof mount> {
 	const app = mount(Lightbox, {
 		target: appRoot,
 		props: {
-			images: [{ id: IMG_A, alt: 'a diagram' }],
+			images: [image(IMG_A, 'a diagram')],
 			index: 0,
 			wsSlug: 'ws-one',
 			onClose: () => {},
@@ -115,7 +137,7 @@ beforeEach(() => {
 		return [{}] as unknown as DOMRectList;
 	};
 	Object.assign(liveProps, {
-		images: [{ id: IMG_A, alt: 'a diagram' }],
+		images: [image(IMG_A, 'a diagram')],
 		index: 0,
 		wsSlug: 'ws-one',
 		onClose: () => {},
@@ -144,7 +166,7 @@ describe('Lightbox — dialog semantics', () => {
 	it('falls back to a generic name when the image has no alt', () => {
 		// An unnamed dialog is announced as nothing at all, so the fallback is
 		// part of the contract rather than a nicety.
-		mountViewer({ images: [{ id: IMG_A, alt: '' }] });
+		mountViewer({ images: [image(IMG_A, '')] });
 		expect(root().getAttribute('aria-label')).toBe('Attachment viewer');
 	});
 
@@ -155,8 +177,8 @@ describe('Lightbox — dialog semantics', () => {
 		// addresses surfaces BY NAME) would have nothing to target.
 		mountViewer({
 			images: [
-				{ id: IMG_A, alt: 'first' },
-				{ id: IMG_B, alt: 'second' },
+				image(IMG_A, 'first'),
+				image(IMG_B, 'second'),
 			],
 		});
 		expect(closeButton().getAttribute('aria-label')).toBe('Close');
@@ -171,14 +193,204 @@ describe('Lightbox — dialog semantics', () => {
 	it('names itself after the image CURRENTLY shown, not the one it opened on', () => {
 		mountViewer({
 			images: [
-				{ id: IMG_A, alt: 'first' },
-				{ id: IMG_B, alt: 'second' },
+				image(IMG_A, 'first'),
+				image(IMG_B, 'second'),
 			],
 		});
 		expect(root().getAttribute('aria-label')).toBe('first');
 		root().querySelector<HTMLButtonElement>('.lightbox-nav.next')!.click();
 		flushSync();
 		expect(root().getAttribute('aria-label')).toBe('second');
+	});
+});
+
+describe('Lightbox — the last-mile open gate (TASK-2431)', () => {
+	/**
+	 * The producers filter their own sets, and these do not replace that. They
+	 * cover the case a producer's filter structurally cannot: the set is
+	 * captured at open, and ←/→ page through it for as long as the viewer is
+	 * up. Anything that arrives in the array — a stale capture, a future
+	 * producer that forgets — must still be unreachable frame by frame.
+	 */
+	function shown(): string {
+		return root().querySelector<HTMLImageElement>('.lightbox-image')?.getAttribute('alt') ?? '';
+	}
+
+	it('never shows a known non-allowlisted type, even when asked to open ON it', () => {
+		mountViewer({
+			images: [image(IMG_A, 'png', 'image/png'), image(IMG_B, 'svg', 'image/svg+xml')],
+			index: 1,
+		});
+
+		// The requested image is refused, so the viewer opens on what is left
+		// rather than on the SVG — and with one member, there is no ←/→ at all.
+		expect(shown()).toBe('png');
+		expect(imageSrc()).toContain(IMG_A);
+		expect(root().querySelector('.lightbox-counter')).toBeNull();
+		expect(root().querySelector('.lightbox-nav')).toBeNull();
+	});
+
+	it('cannot be paged onto one with ←/→', () => {
+		mountViewer({
+			images: [
+				image(IMG_A, 'png', 'image/png'),
+				image(IMG_B, 'svg', 'image/svg+xml'),
+				image(IMG_C, 'jpeg', 'image/jpeg'),
+			],
+		});
+
+		expect(root().querySelector('.lightbox-counter')?.textContent).toBe('1 / 2');
+
+		const seen = [shown()];
+		for (let i = 0; i < 3; i++) {
+			press('ArrowRight');
+			seen.push(shown());
+		}
+		press('ArrowLeft');
+		seen.push(shown());
+
+		expect(seen).toEqual(['png', 'jpeg', 'png', 'jpeg', 'png']);
+		expect(seen).not.toContain('svg');
+	});
+
+	it('keeps the requested image when EARLIER members are filtered out', () => {
+		// The requested image is at position 1 in the given set and position 0
+		// in the filtered one. Carrying the NUMBER across — even clamped to the
+		// filtered length, which is the plausible wrong version — lands on the
+		// image after it. Only resolving by id opens what was asked for.
+		mountViewer({
+			images: [
+				image(IMG_B, 'svg', 'image/svg+xml'),
+				image(IMG_A, 'png', 'image/png'),
+				image(IMG_C, 'jpeg', 'image/jpeg'),
+			],
+			index: 1,
+		});
+
+		expect(shown()).toBe('png');
+		expect(root().querySelector('.lightbox-counter')?.textContent).toBe('1 / 2');
+	});
+
+	it('REFUSES an image whose type is not resolved', () => {
+		// This test previously asserted the opposite, on the reasoning that an
+		// inline image's probe is often unasked at click time. That reasoning
+		// belongs to the PRODUCER — which can wait for the probe — and asserting
+		// it HERE pinned open the exact hole the task exists to close: an emitter
+		// could hand over `[safe, unresolved]` and the user could arrow onto the
+		// unresolved one. This is the last thing between a set and a rendered
+		// image; "not yet known" is not evidence that a file is a PNG.
+		mountViewer({ images: [image(IMG_A, 'unprobed', null)] });
+		expect(root().querySelector('.lightbox-image')).toBeNull();
+	});
+
+	it('cannot be paged onto an unresolved sibling', () => {
+		mountViewer({
+			images: [image(IMG_A, 'png'), image(IMG_B, 'unprobed', null), image(IMG_C, 'jpeg', 'image/jpeg')],
+		});
+
+		expect(root().querySelector('.lightbox-counter')?.textContent).toBe('1 / 2');
+		const seen = [shown()];
+		for (let i = 0; i < 3; i++) {
+			press('ArrowRight');
+			seen.push(shown());
+		}
+		expect(seen).toEqual(['png', 'jpeg', 'png', 'jpeg']);
+		expect(seen).not.toContain('unprobed');
+	});
+
+	it('shows nothing at all rather than one refused image', () => {
+		mountViewer({ images: [image(IMG_B, 'svg', 'image/svg+xml')] });
+
+		expect(root().querySelector('.lightbox-image')).toBeNull();
+		// Still a real dialog with a way out — the failure mode is an empty
+		// viewer, never a rendered one.
+		expect(closeButton()).not.toBeNull();
+		// And the arrows cannot divide by an empty set.
+		press('ArrowRight');
+		press('ArrowLeft');
+		expect(root().querySelector('.lightbox-image')).toBeNull();
+	});
+});
+
+describe('Lightbox — the set changing under an OPEN viewer (TASK-2431)', () => {
+	/**
+	 * The producers hand over a set once and the viewer pages through it for as
+	 * long as it is up, so "was safe when the list was built" is not the claim
+	 * that has to hold — "is safe on the frame being shown" is. These drive the
+	 * live props (`liveProps`, the reactive object the file already uses for the
+	 * capture-at-open cases) rather than remounting, which is the only way to
+	 * reach a set that changes under a viewer that is already open.
+	 */
+	function shown(): string {
+		return root().querySelector<HTMLImageElement>('.lightbox-image')?.getAttribute('alt') ?? '';
+	}
+
+	function mountLive() {
+		const app = mount(Lightbox, { target: appRoot, props: liveProps });
+		mounted.push(app);
+		flushSync();
+		return app;
+	}
+
+	it('drops a record whose MIME resolves to something unsafe AFTER open', () => {
+		liveProps.images = [image(IMG_A, 'png'), image(IMG_B, 'later-svg')];
+		mountLive();
+		expect(root().querySelector('.lightbox-counter')?.textContent).toBe('1 / 2');
+
+		// The late answer arrives: what was believed safe is not. A set captured
+		// once would keep paging onto it.
+		liveProps.images = [image(IMG_A, 'png'), image(IMG_B, 'later-svg', 'image/svg+xml')];
+		flushSync();
+
+		expect(shown()).toBe('png');
+		expect(root().querySelector('.lightbox-counter')).toBeNull();
+		press('ArrowRight');
+		expect(shown()).toBe('png');
+	});
+
+	it('keeps showing a real image when the one under it is removed', () => {
+		liveProps.images = [image(IMG_A, 'png'), image(IMG_C, 'jpeg', 'image/jpeg')];
+		mountLive();
+		press('ArrowRight');
+		expect(shown()).toBe('jpeg');
+
+		// The set shrinks beneath the position the user navigated to — a delete
+		// from another surface, a reload. The index must clamp, not blank out or
+		// render `undefined`.
+		liveProps.images = [image(IMG_A, 'png')];
+		flushSync();
+
+		expect(shown()).toBe('png');
+		expect(imageSrc()).toContain(IMG_A);
+	});
+
+	it('cannot be navigated onto an unsafe entry ADDED after open', () => {
+		liveProps.images = [image(IMG_A, 'png')];
+		mountLive();
+
+		liveProps.images = [
+			image(IMG_A, 'png'),
+			image(IMG_B, 'svg', 'image/svg+xml'),
+			image(IMG_C, 'unprobed', null),
+		];
+		flushSync();
+
+		// Both additions are refused, so the viewer is still single-image.
+		expect(root().querySelector('.lightbox-counter')).toBeNull();
+		press('ArrowRight');
+		press('ArrowLeft');
+		expect(shown()).toBe('png');
+	});
+
+	it('empties rather than showing an unsafe replacement', () => {
+		liveProps.images = [image(IMG_A, 'png')];
+		mountLive();
+		expect(shown()).toBe('png');
+
+		liveProps.images = [image(IMG_B, 'svg', 'image/svg+xml')];
+		flushSync();
+
+		expect(root().querySelector('.lightbox-image')).toBeNull();
 	});
 });
 
@@ -231,8 +443,8 @@ describe('Lightbox — workspace captured at open', () => {
 		// all, which would be a different bug. This is the counterweight.
 		mountViewer({
 			images: [
-				{ id: IMG_A, alt: 'first' },
-				{ id: IMG_B, alt: 'second' },
+				image(IMG_A, 'first'),
+				image(IMG_B, 'second'),
 			],
 		});
 		expect(imageSrc()).toContain(IMG_A);
@@ -250,8 +462,8 @@ describe('Lightbox — focus', () => {
 		// LAST candidate.
 		mountViewer({
 			images: [
-				{ id: IMG_A, alt: 'first' },
-				{ id: IMG_B, alt: 'second' },
+				image(IMG_A, 'first'),
+				image(IMG_B, 'second'),
 			],
 		});
 		const controls = Array.from(root().querySelectorAll('button'));
@@ -368,8 +580,8 @@ describe('Lightbox — Tab trap', () => {
 	it('wraps forward off the last focusable', () => {
 		mountViewer({
 			images: [
-				{ id: IMG_A, alt: 'first' },
-				{ id: IMG_B, alt: 'second' },
+				image(IMG_A, 'first'),
+				image(IMG_B, 'second'),
 			],
 		});
 		const next = root().querySelector<HTMLButtonElement>('.lightbox-nav.next')!;
@@ -382,8 +594,8 @@ describe('Lightbox — Tab trap', () => {
 	it('wraps backward off the first focusable', () => {
 		mountViewer({
 			images: [
-				{ id: IMG_A, alt: 'first' },
-				{ id: IMG_B, alt: 'second' },
+				image(IMG_A, 'first'),
+				image(IMG_B, 'second'),
 			],
 		});
 		closeButton().focus();
@@ -401,8 +613,8 @@ describe('Lightbox — Tab trap', () => {
 		const outside = appRoot.appendChild(document.createElement('button'));
 		mountViewer({
 			images: [
-				{ id: IMG_A, alt: 'first' },
-				{ id: IMG_B, alt: 'second' },
+				image(IMG_A, 'first'),
+				image(IMG_B, 'second'),
 			],
 		});
 		outside.focus();
@@ -423,8 +635,8 @@ describe('Lightbox — Tab trap', () => {
 		// the natural order inside the viewer.
 		mountViewer({
 			images: [
-				{ id: IMG_A, alt: 'first' },
-				{ id: IMG_B, alt: 'second' },
+				image(IMG_A, 'first'),
+				image(IMG_B, 'second'),
 			],
 		});
 		closeButton().focus();
@@ -494,8 +706,8 @@ describe('Lightbox — Escape ownership', () => {
 		// Escape branch had.
 		mountViewer({
 			images: [
-				{ id: IMG_A, alt: 'first' },
-				{ id: IMG_B, alt: 'second' },
+				image(IMG_A, 'first'),
+				image(IMG_B, 'second'),
 			],
 		});
 		expect(imageSrc()).toContain(IMG_A);
@@ -559,16 +771,16 @@ describe('Lightbox — only the frontmost viewer acts', () => {
 		mountViewer({
 			onClose: onCloseBack,
 			images: [
-				{ id: IMG_A, alt: 'back-first' },
-				{ id: IMG_B, alt: 'back-second' },
+				image(IMG_A, 'back-first'),
+				image(IMG_B, 'back-second'),
 			],
 		});
 		const back = root();
 		mountViewer({
 			onClose: onCloseFront,
 			images: [
-				{ id: IMG_A, alt: 'front-first' },
-				{ id: IMG_B, alt: 'front-second' },
+				image(IMG_A, 'front-first'),
+				image(IMG_B, 'front-second'),
 			],
 		});
 		const front = root();
@@ -655,8 +867,8 @@ describe('Lightbox — a native modal opened OVER the viewer', () => {
 		mockOpenModals([dialog]);
 		mountViewer({
 			images: [
-				{ id: IMG_A, alt: 'first' },
-				{ id: IMG_B, alt: 'second' },
+				image(IMG_A, 'first'),
+				image(IMG_B, 'second'),
 			],
 		});
 		inDialog.focus();
@@ -670,8 +882,8 @@ describe('Lightbox — a native modal opened OVER the viewer', () => {
 		mockOpenModals([dialog]);
 		mountViewer({
 			images: [
-				{ id: IMG_A, alt: 'first' },
-				{ id: IMG_B, alt: 'second' },
+				image(IMG_A, 'first'),
+				image(IMG_B, 'second'),
 			],
 		});
 
@@ -685,8 +897,8 @@ describe('Lightbox — a native modal opened OVER the viewer', () => {
 		mockOpenModals([dialog]);
 		mountViewer({
 			images: [
-				{ id: IMG_A, alt: 'first' },
-				{ id: IMG_B, alt: 'second' },
+				image(IMG_A, 'first'),
+				image(IMG_B, 'second'),
 			],
 		});
 		expect(press('ArrowRight')).toBe(false);

--- a/web/src/lib/components/common/Lightbox.svelte.test.ts
+++ b/web/src/lib/components/common/Lightbox.svelte.test.ts
@@ -1,0 +1,753 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+import Lightbox from './Lightbox.svelte';
+import {
+	acquire,
+	hasForeignEscapeOwner,
+	__resetViewerBackdropForTests,
+	VIEWER_ROOT_CLASS,
+} from '$lib/a11y/viewerBackdrop';
+import {
+	pushEscapeHandler,
+	runTopEscape,
+	ESCAPE_PRIORITY,
+	_resetEscapeStackForTests,
+} from '$lib/stores/escapeStack';
+
+// TASK-2429 — the DR-4b modal contract on the attachment viewer.
+//
+// WHAT JSDOM CANNOT PROVE, and is therefore TASK-2436's browser suite (DR-9):
+//
+//  • REAL INERTNESS. jsdom parses the `inert` attribute but does not implement
+//    its semantics: a control inside an inert subtree is still clickable and
+//    focusable here. So the tests below assert that the manager WAS ASKED (the
+//    attribute lands on the right body children and is removed again), never
+//    that the background is genuinely unreachable.
+//  • LAYOUT AND STACKING. There is no layout engine, so "fixed, covering the
+//    viewport, above everything" is unassertable — including the one that
+//    actually bites: an ancestor with `transform` / `filter` / `contain` making
+//    a `position: fixed` overlay scroll with the page. What IS assertable is
+//    the structural precondition, and it is asserted: the root is a DIRECT
+//    child of `<body>`, so no ancestor can establish a containing block.
+//  • REAL TAB TRAVERSAL. jsdom does not move focus on a Tab keydown at all, so
+//    the trap is exercised through the handler's own decision (it preventDefaults
+//    and focuses explicitly) rather than through browser behaviour.
+//  • VISIBILITY. `offsetParent` / `getClientRects` report everything hidden, so
+//    `paneFocusables` would return an empty set for every element. The stub
+//    below (the shape `viewerBackdrop.svelte.test.ts` uses) makes the real
+//    selection path run instead of always seeing nothing.
+
+const realGetClientRects = HTMLElement.prototype.getClientRects;
+
+const IMG_A = 'aaaaaaaa-1111-4111-8111-aaaaaaaaaaaa';
+const IMG_B = 'bbbbbbbb-2222-4222-8222-bbbbbbbbbbbb';
+
+interface Props {
+	images: { id: string; alt: string }[];
+	index?: number;
+	wsSlug: string;
+	onClose: () => void;
+	invoker?: HTMLElement | null;
+}
+
+// Reactive props for the capture-at-open cases ($state may only initialize a
+// declaration, hence top level).
+const liveProps = $state<Props>({
+	images: [{ id: IMG_A, alt: 'a diagram' }],
+	index: 0,
+	wsSlug: 'ws-one',
+	onClose: () => {},
+});
+
+/** The app shell's stand-in: a body child, so the manager has something to inert. */
+let appRoot: HTMLElement;
+const mounted: ReturnType<typeof mount>[] = [];
+
+function mountViewer(props: Partial<Props> = {}): ReturnType<typeof mount> {
+	const app = mount(Lightbox, {
+		target: appRoot,
+		props: {
+			images: [{ id: IMG_A, alt: 'a diagram' }],
+			index: 0,
+			wsSlug: 'ws-one',
+			onClose: () => {},
+			...props,
+		},
+	});
+	mounted.push(app);
+	flushSync();
+	return app;
+}
+
+function roots(): HTMLElement[] {
+	return Array.from(document.body.querySelectorAll<HTMLElement>('.lightbox-backdrop'));
+}
+
+function root(): HTMLElement {
+	const found = roots();
+	if (found.length === 0) throw new Error('no viewer mounted');
+	return found[found.length - 1];
+}
+
+function imageSrc(scope: HTMLElement = root()): string {
+	return scope.querySelector<HTMLImageElement>('.lightbox-image')?.getAttribute('src') ?? '';
+}
+
+function closeButton(scope: HTMLElement = root()): HTMLButtonElement {
+	return scope.querySelector<HTMLButtonElement>('.lightbox-close')!;
+}
+
+/** A cancelable window keydown, returning whether the app consumed it. */
+function press(key: string, init: KeyboardEventInit = {}): boolean {
+	const event = new KeyboardEvent('keydown', { key, cancelable: true, bubbles: true, ...init });
+	window.dispatchEvent(event);
+	flushSync();
+	return event.defaultPrevented;
+}
+
+/** Body children currently carrying `inert` (see the jsdom caveat above). */
+function inertBodyChildren(): Element[] {
+	return Array.from(document.body.children).filter((el) => el.hasAttribute('inert'));
+}
+
+beforeEach(() => {
+	HTMLElement.prototype.getClientRects = function () {
+		return [{}] as unknown as DOMRectList;
+	};
+	Object.assign(liveProps, {
+		images: [{ id: IMG_A, alt: 'a diagram' }],
+		index: 0,
+		wsSlug: 'ws-one',
+		onClose: () => {},
+	});
+	appRoot = document.body.appendChild(document.createElement('div'));
+	appRoot.id = 'app';
+});
+
+afterEach(() => {
+	while (mounted.length) unmount(mounted.pop()!);
+	document.body.innerHTML = '';
+	__resetViewerBackdropForTests();
+	_resetEscapeStackForTests();
+	HTMLElement.prototype.getClientRects = realGetClientRects;
+	vi.restoreAllMocks();
+});
+
+describe('Lightbox — dialog semantics', () => {
+	it('is an aria-modal dialog named after the image', () => {
+		mountViewer();
+		expect(root().getAttribute('role')).toBe('dialog');
+		expect(root().getAttribute('aria-modal')).toBe('true');
+		expect(root().getAttribute('aria-label')).toBe('a diagram');
+	});
+
+	it('falls back to a generic name when the image has no alt', () => {
+		// An unnamed dialog is announced as nothing at all, so the fallback is
+		// part of the contract rather than a nicety.
+		mountViewer({ images: [{ id: IMG_A, alt: '' }] });
+		expect(root().getAttribute('aria-label')).toBe('Attachment viewer');
+	});
+
+	it('gives every control a real accessible name, not a glyph', () => {
+		// The button text is "✕" / "‹" / "›", and `title` does not win over
+		// element content for the accessible name — so without these the controls
+		// are announced as punctuation, and TASK-2436's browser suite (which
+		// addresses surfaces BY NAME) would have nothing to target.
+		mountViewer({
+			images: [
+				{ id: IMG_A, alt: 'first' },
+				{ id: IMG_B, alt: 'second' },
+			],
+		});
+		expect(closeButton().getAttribute('aria-label')).toBe('Close');
+		expect(
+			root().querySelector('.lightbox-nav.prev')?.getAttribute('aria-label')
+		).toBe('Previous image');
+		expect(
+			root().querySelector('.lightbox-nav.next')?.getAttribute('aria-label')
+		).toBe('Next image');
+	});
+
+	it('names itself after the image CURRENTLY shown, not the one it opened on', () => {
+		mountViewer({
+			images: [
+				{ id: IMG_A, alt: 'first' },
+				{ id: IMG_B, alt: 'second' },
+			],
+		});
+		expect(root().getAttribute('aria-label')).toBe('first');
+		root().querySelector<HTMLButtonElement>('.lightbox-nav.next')!.click();
+		flushSync();
+		expect(root().getAttribute('aria-label')).toBe('second');
+	});
+});
+
+describe('Lightbox — portal', () => {
+	it('portals to <body> DIRECTLY, not into its mount container', () => {
+		// The structural half of the fixed-overlay contract: with `<body>` as the
+		// parent there is no ancestor left to establish a containing block with
+		// `transform` / `filter` / `contain`, which is the failure mode that
+		// silently traps a `position: fixed` overlay. The geometric half needs a
+		// layout engine and belongs to TASK-2436.
+		mountViewer();
+		expect(root().parentElement).toBe(document.body);
+		expect(appRoot.contains(root())).toBe(false);
+	});
+
+	it('carries the viewer-root class the app-wide guards key off', () => {
+		// `hasForeignEscapeOwner` excludes this class so the route ESC guards
+		// look PAST the viewer to the escape stack. A rename that touched only
+		// the markup would make Escape dead app-wide, hence the shared constant.
+		mountViewer();
+		expect(root().classList.contains(VIEWER_ROOT_CLASS)).toBe(true);
+	});
+
+	it('takes the portaled root back out of <body> on close', () => {
+		const app = mountViewer();
+		expect(roots()).toHaveLength(1);
+		unmount(mounted.splice(mounted.indexOf(app), 1)[0]);
+		flushSync();
+		expect(roots()).toHaveLength(0);
+	});
+});
+
+describe('Lightbox — workspace captured at open', () => {
+	it('keeps serving the open-time workspace after the prop changes', () => {
+		mounted.push(mount(Lightbox, { target: appRoot, props: liveProps }));
+		flushSync();
+		expect(imageSrc()).toContain('/workspaces/ws-one/');
+
+		// The pane switches workspace WITHOUT remounting what is above it, so a
+		// live read would rebuild already-captured attachment ids against the new
+		// workspace — a 404 at best, another workspace's blob at worst.
+		liveProps.wsSlug = 'ws-two';
+		flushSync();
+		expect(imageSrc()).toContain('/workspaces/ws-one/');
+		expect(imageSrc()).not.toContain('ws-two');
+	});
+
+	it('still rebuilds the src when the SHOWN IMAGE changes', () => {
+		// The guard above would also pass against a src that never updates at
+		// all, which would be a different bug. This is the counterweight.
+		mountViewer({
+			images: [
+				{ id: IMG_A, alt: 'first' },
+				{ id: IMG_B, alt: 'second' },
+			],
+		});
+		expect(imageSrc()).toContain(IMG_A);
+		expect(press('ArrowRight')).toBe(true);
+		expect(imageSrc()).toContain(IMG_B);
+		expect(imageSrc()).toContain('/workspaces/ws-one/');
+	});
+});
+
+describe('Lightbox — focus', () => {
+	it('moves focus to the FIRST tabbable descendant, not the root or any other', () => {
+		// Multi-image on purpose: with three controls (close, prev, next) this
+		// separates "the first tabbable" from "a tabbable" and from "the root".
+		// A single-control fixture would pass for an implementation that took the
+		// LAST candidate.
+		mountViewer({
+			images: [
+				{ id: IMG_A, alt: 'first' },
+				{ id: IMG_B, alt: 'second' },
+			],
+		});
+		const controls = Array.from(root().querySelectorAll('button'));
+		expect(controls).toHaveLength(3);
+		expect(document.activeElement).toBe(controls[0]);
+		expect(document.activeElement).toBe(closeButton());
+		expect(document.activeElement).not.toBe(root());
+	});
+
+	it('returns focus to the invoker on close', () => {
+		const invoker = appRoot.appendChild(document.createElement('button'));
+		const app = mountViewer({ invoker });
+		expect(document.activeElement).toBe(closeButton());
+
+		unmount(mounted.splice(mounted.indexOf(app), 1)[0]);
+		flushSync();
+		expect(document.activeElement).toBe(invoker);
+	});
+
+	it('falls back to <body> when the invoker was detached while the viewer was up', () => {
+		// An editor NodeView is re-rendered on any document change, so the
+		// element that opened the viewer is routinely gone by close time.
+		const invoker = appRoot.appendChild(document.createElement('button'));
+		const app = mountViewer({ invoker });
+		invoker.remove();
+		// `activeElement` alone can't see the `isConnected` check: focusing a
+		// DETACHED element is a no-op in jsdom, so focus would land on <body>
+		// either way. Asserting the call never happens is what pins the check —
+		// and on a real engine an unguarded focus() on a detached node moves
+		// focus to <body> on some engines and nowhere on others.
+		const attempted = vi.spyOn(invoker, 'focus');
+
+		unmount(mounted.splice(mounted.indexOf(app), 1)[0]);
+		flushSync();
+		expect(attempted).not.toHaveBeenCalled();
+		expect(document.activeElement).toBe(document.body);
+	});
+
+	it('falls back to <body> when the invoker is connected but not focusable', () => {
+		// `isConnected` alone is not enough: deletion can leave the node in the
+		// tree but unfocusable (hidden, inerted, or never focusable to begin
+		// with). The restore focuses it and VERIFIES, rather than trusting.
+		//
+		// `activeElement` ALONE cannot see the difference here, and a test that
+		// stopped at it would be vacuous: focus sitting inside the root the
+		// teardown then removes ends up on `<body>` either way. What separates a
+		// verified restore from a trusting one is that the verified path parks
+		// focus DELIBERATELY instead of relying on node-removal fallout — so the
+		// blur is asserted too. (Whether a real engine refuses focus on an inert
+		// or hidden invoker is TASK-2436's; jsdom's `focus()` no-ops on a
+		// non-focusable element, which is the same shape.)
+		const blurred = vi.spyOn(HTMLElement.prototype, 'blur');
+		const invoker = appRoot.appendChild(document.createElement('div'));
+		const app = mountViewer({ invoker });
+
+		unmount(mounted.splice(mounted.indexOf(app), 1)[0]);
+		flushSync();
+		expect(document.activeElement).toBe(document.body);
+		expect(blurred).toHaveBeenCalled();
+	});
+
+	it('falls back to whatever held focus at open when no invoker is threaded', () => {
+		// The strip and the timeline don't pass an invoker until TASK-2431, and
+		// they keep focus on the clicked tile today. Focus entry is about to move
+		// focus INTO the viewer, so without this capture those two producers would
+		// come out of this commit strictly worse than before it.
+		const tile = appRoot.appendChild(document.createElement('button'));
+		tile.focus();
+
+		const app = mountViewer();
+		expect(document.activeElement).toBe(closeButton());
+
+		unmount(mounted.splice(mounted.indexOf(app), 1)[0]);
+		flushSync();
+		expect(document.activeElement).toBe(tile);
+	});
+
+	it('falls back to <body> when nothing held focus at open either', () => {
+		const app = mountViewer();
+		unmount(mounted.splice(mounted.indexOf(app), 1)[0]);
+		flushSync();
+		expect(document.activeElement).toBe(document.body);
+	});
+
+	it('prefers an explicit invoker over the element that held focus', () => {
+		const tile = appRoot.appendChild(document.createElement('button'));
+		const invoker = appRoot.appendChild(document.createElement('button'));
+		tile.focus();
+
+		const app = mountViewer({ invoker });
+		unmount(mounted.splice(mounted.indexOf(app), 1)[0]);
+		flushSync();
+		expect(document.activeElement).toBe(invoker);
+	});
+
+	it('does NOT yank focus back when something else already owns it', () => {
+		// A producer that moves focus from its own close handler runs BEFORE this
+		// teardown, and a surface opened over the viewer owns focus outright.
+		// Either way the restore must decline rather than move focus a second
+		// time. (`AttachmentViewerHost` was the first case until TASK-2429 moved
+		// the restore here; the guard still covers every other owner.)
+		const invoker = appRoot.appendChild(document.createElement('button'));
+		const elsewhere = appRoot.appendChild(document.createElement('button'));
+		const app = mountViewer({ invoker });
+
+		elsewhere.focus();
+		unmount(mounted.splice(mounted.indexOf(app), 1)[0]);
+		flushSync();
+		expect(document.activeElement).toBe(elsewhere);
+	});
+});
+
+describe('Lightbox — Tab trap', () => {
+	it('wraps forward off the last focusable', () => {
+		mountViewer({
+			images: [
+				{ id: IMG_A, alt: 'first' },
+				{ id: IMG_B, alt: 'second' },
+			],
+		});
+		const next = root().querySelector<HTMLButtonElement>('.lightbox-nav.next')!;
+		next.focus();
+
+		expect(press('Tab')).toBe(true);
+		expect(document.activeElement).toBe(closeButton());
+	});
+
+	it('wraps backward off the first focusable', () => {
+		mountViewer({
+			images: [
+				{ id: IMG_A, alt: 'first' },
+				{ id: IMG_B, alt: 'second' },
+			],
+		});
+		closeButton().focus();
+
+		expect(press('Tab', { shiftKey: true })).toBe(true);
+		expect(document.activeElement).toBe(
+			root().querySelector<HTMLButtonElement>('.lightbox-nav.next')
+		);
+	});
+
+	it('pulls focus back to the leading edge when it has escaped the viewer', () => {
+		// The exact target matters: `nextTrapTarget` returns the FIRST focusable
+		// on a forward Tab from outside. Asserting only "somewhere inside" would
+		// pass for an implementation that focused the root instead.
+		const outside = appRoot.appendChild(document.createElement('button'));
+		mountViewer({
+			images: [
+				{ id: IMG_A, alt: 'first' },
+				{ id: IMG_B, alt: 'second' },
+			],
+		});
+		outside.focus();
+
+		expect(press('Tab')).toBe(true);
+		expect(document.activeElement).toBe(closeButton());
+
+		// ...and the trailing edge on a back Tab from outside.
+		outside.focus();
+		expect(press('Tab', { shiftKey: true })).toBe(true);
+		expect(document.activeElement).toBe(
+			root().querySelector('.lightbox-nav.next')
+		);
+	});
+
+	it('leaves a mid-cycle Tab to the browser', () => {
+		// Only the wrap is the trap's business; preventing every Tab would break
+		// the natural order inside the viewer.
+		mountViewer({
+			images: [
+				{ id: IMG_A, alt: 'first' },
+				{ id: IMG_B, alt: 'second' },
+			],
+		});
+		closeButton().focus();
+		expect(press('Tab')).toBe(false);
+	});
+});
+
+describe('Lightbox — Escape ownership', () => {
+	it('does NOT close on a raw window keydown: the stack is the sole owner', () => {
+		// The local Escape branch was DELETED, not gated. It ignored
+		// `defaultPrevented`, so keeping it alongside the stack gave Escape two
+		// owners and let one press collapse two layers.
+		const onClose = vi.fn();
+		mountViewer({ onClose });
+
+		expect(press('Escape')).toBe(false);
+		expect(onClose).not.toHaveBeenCalled();
+
+		expect(runTopEscape()).toBe(true);
+		expect(onClose).toHaveBeenCalledTimes(1);
+	});
+
+	it('outranks the menu layer', () => {
+		// A menu is inert behind the viewer, so the viewer must win the key.
+		//
+		// The menu handler is registered AFTER the viewer deliberately:
+		// `escapeStack` breaks EQUAL-priority ties toward the most recently
+		// registered handler, so registering it first would let the viewer win on
+		// the tie-break alone and the test would pass even at `menu` priority.
+		// Registered last, only a strictly higher priority can win.
+		const onClose = vi.fn();
+		mountViewer({ onClose });
+		const menuClose = vi.fn(() => true);
+		pushEscapeHandler(menuClose, ESCAPE_PRIORITY.menu);
+
+		expect(runTopEscape()).toBe(true);
+		expect(onClose).toHaveBeenCalledTimes(1);
+		expect(menuClose).not.toHaveBeenCalled();
+	});
+
+	it('declines Escape once it is no longer the frontmost lease', () => {
+		// The gate that the two-viewer case cannot isolate: with two viewers,
+		// registration order and lease order agree, so `escapeStack`'s
+		// newest-wins tie-break would pick the front one even with the gate
+		// deleted. Taking a lease DIRECTLY puts something above the viewer whose
+		// escape handler is NOT on the stack at all, so lease order and
+		// registration order finally disagree — the viewer must decline, and with
+		// nothing else registered the whole stack must decline with it.
+		const onClose = vi.fn();
+		mountViewer({ onClose });
+		const above = document.body.appendChild(document.createElement('div'));
+		const lease = acquire(above);
+
+		expect(runTopEscape()).toBe(false);
+		expect(onClose).not.toHaveBeenCalled();
+
+		// ...and it takes the key again the moment it is frontmost once more.
+		lease.release();
+		expect(runTopEscape()).toBe(true);
+		expect(onClose).toHaveBeenCalledTimes(1);
+	});
+
+	it('ignores a key another control already handled', () => {
+		// The `defaultPrevented` early return. Without it the viewer would page
+		// on an arrow a control underneath (or a layer above) has already
+		// consumed — the exact two-owners-one-press shape the deleted local
+		// Escape branch had.
+		mountViewer({
+			images: [
+				{ id: IMG_A, alt: 'first' },
+				{ id: IMG_B, alt: 'second' },
+			],
+		});
+		expect(imageSrc()).toContain(IMG_A);
+
+		const event = new KeyboardEvent('keydown', {
+			key: 'ArrowRight',
+			cancelable: true,
+			bubbles: true,
+		});
+		event.preventDefault();
+		window.dispatchEvent(event);
+		flushSync();
+		expect(imageSrc()).toContain(IMG_A);
+	});
+
+	it('closes through a ROUTE-SHAPED driver, and closes exactly one layer', () => {
+		// The integration the component depends on, exercised in the shape the
+		// two route handlers actually have: bail on a foreign modal, else run the
+		// stack and preventDefault. Calling `runTopEscape()` directly (as the
+		// tests above do) skips the `hasForeignEscapeOwner()` guard, which is the
+		// half that would silently swallow the viewer's Escape if the viewer were
+		// not excluded from that selector.
+		const paneClose = vi.fn(() => true);
+		pushEscapeHandler(paneClose, ESCAPE_PRIORITY.pane);
+		const onClose = vi.fn();
+		mountViewer({ onClose });
+
+		const routeDriver = (e: KeyboardEvent) => {
+			if (e.key !== 'Escape') return;
+			if (hasForeignEscapeOwner()) return;
+			if (runTopEscape()) e.preventDefault();
+		};
+		window.addEventListener('keydown', routeDriver);
+		try {
+			expect(press('Escape')).toBe(true);
+		} finally {
+			window.removeEventListener('keydown', routeDriver);
+		}
+
+		expect(onClose).toHaveBeenCalledTimes(1);
+		// ONE layer: the pane underneath must not also close on the same press.
+		expect(paneClose).not.toHaveBeenCalled();
+	});
+
+	it('unregisters on close, so a later Escape reaches the layer beneath', () => {
+		const paneClose = vi.fn(() => true);
+		pushEscapeHandler(paneClose, ESCAPE_PRIORITY.pane);
+		const app = mountViewer({ onClose: () => {} });
+
+		unmount(mounted.splice(mounted.indexOf(app), 1)[0]);
+		flushSync();
+		expect(runTopEscape()).toBe(true);
+		expect(paneClose).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe('Lightbox — only the frontmost viewer acts', () => {
+	function mountTwo() {
+		const onCloseBack = vi.fn();
+		const onCloseFront = vi.fn();
+		mountViewer({
+			onClose: onCloseBack,
+			images: [
+				{ id: IMG_A, alt: 'back-first' },
+				{ id: IMG_B, alt: 'back-second' },
+			],
+		});
+		const back = root();
+		mountViewer({
+			onClose: onCloseFront,
+			images: [
+				{ id: IMG_A, alt: 'front-first' },
+				{ id: IMG_B, alt: 'front-second' },
+			],
+		});
+		const front = root();
+		expect(back).not.toBe(front);
+		return { back, front, onCloseBack, onCloseFront };
+	}
+
+	it('closes exactly the front viewer on one Escape', () => {
+		// HONEST SCOPE: this asserts the user-visible contract, but it cannot
+		// isolate the component's `isViewerFrontmost` gate. `escapeStack` breaks
+		// equal-priority ties toward the most recently registered handler, and
+		// registration order and lease order are the same thing here (both are
+		// mount order), so the press would land on the front viewer even with the
+		// gate removed — verified by mutation. The gate is kept because it makes
+		// the ownership rule LOCAL rather than a consequence of another module's
+		// tie-break, and because the arrow / Tab gates on the same predicate ARE
+		// load-bearing (the two tests below fail without them).
+		const { onCloseBack, onCloseFront } = mountTwo();
+		expect(runTopEscape()).toBe(true);
+		expect(onCloseFront).toHaveBeenCalledTimes(1);
+		expect(onCloseBack).not.toHaveBeenCalled();
+	});
+
+	it('pages only the front viewer on an arrow key', () => {
+		const { back, front } = mountTwo();
+		expect(press('ArrowRight')).toBe(true);
+		expect(imageSrc(front)).toContain(IMG_B);
+		expect(imageSrc(back)).toContain(IMG_A);
+	});
+
+	it('does not let the BACK viewer steal focus on Tab', () => {
+		// The sharp edge: `nextTrapTarget` deliberately pulls out-of-container
+		// focus INWARD, so a background viewer running the trap would drag focus
+		// out of the viewer in front of it. Handlers are global; the frontmost
+		// check is what stops it.
+		const { back, front } = mountTwo();
+		expect(front.contains(document.activeElement)).toBe(true);
+
+		press('Tab');
+		expect(back.contains(document.activeElement)).toBe(false);
+		expect(front.contains(document.activeElement)).toBe(true);
+	});
+});
+
+describe('Lightbox — a native modal opened OVER the viewer', () => {
+	/**
+	 * jsdom throws on the `:modal` pseudo-class, so emulate an engine that
+	 * supports it — the shape `viewerBackdrop.svelte.test.ts` uses. Both probes
+	 * the module makes (`querySelectorAll` and `Element.matches`) are covered.
+	 */
+	function mockOpenModals(modals: Element[]): void {
+		const realQueryAll = document.querySelectorAll.bind(document);
+		vi.spyOn(document, 'querySelectorAll').mockImplementation((selector: string) => {
+			if (selector !== 'dialog:modal') return realQueryAll(selector);
+			return Array.from(realQueryAll('dialog')).filter((d) =>
+				modals.includes(d)
+			) as unknown as NodeListOf<Element>;
+		});
+		const realMatches = Element.prototype.matches;
+		vi.spyOn(Element.prototype, 'matches').mockImplementation(function (
+			this: Element,
+			selector: string
+		) {
+			if (selector !== 'dialog:modal') return realMatches.call(this, selector);
+			return realMatches.call(this, 'dialog') && modals.includes(this);
+		});
+	}
+
+	it('stops trapping Tab while a showModal() dialog is above it', () => {
+		// The frontmost LEASE is not the frontmost SURFACE: a `showModal()` dialog
+		// lives in the top layer, above any body-portaled viewer, and the manager
+		// deliberately leaves it OUT of the inert set so it stays operable. If the
+		// viewer kept trapping, `nextTrapTarget` would pull focus out of that
+		// dialog and back into the viewer underneath it — the inward-redirect
+		// hazard one layer up. Reachable today: the app shell's `?` shortcut opens
+		// the Keyboard Shortcuts modal while a viewer is up (TASK-2430 stops the
+		// shortcut; this stops the viewer fighting the result either way).
+		// The emulation goes in BEFORE the mount: the manager probes `:modal` on
+		// its first reconcile, and jsdom's throw makes it cache "unsupported" for
+		// the rest of the module's life. Mocking afterwards would be ignored — and
+		// the test would then pass for the wrong reason.
+		const dialog = document.body.appendChild(document.createElement('dialog'));
+		const inDialog = dialog.appendChild(document.createElement('button'));
+		mockOpenModals([dialog]);
+		mountViewer({
+			images: [
+				{ id: IMG_A, alt: 'first' },
+				{ id: IMG_B, alt: 'second' },
+			],
+		});
+		inDialog.focus();
+
+		expect(press('Tab')).toBe(false);
+		expect(document.activeElement).toBe(inDialog);
+	});
+
+	it('stops paging on arrows while a showModal() dialog is above it', () => {
+		const dialog = document.body.appendChild(document.createElement('dialog'));
+		mockOpenModals([dialog]);
+		mountViewer({
+			images: [
+				{ id: IMG_A, alt: 'first' },
+				{ id: IMG_B, alt: 'second' },
+			],
+		});
+
+		expect(press('ArrowRight')).toBe(false);
+		expect(imageSrc()).toContain(IMG_A);
+	});
+
+	it('resumes once the dialog closes', () => {
+		// The stand-down must be conditional, not a permanent disable.
+		const dialog = document.body.appendChild(document.createElement('dialog'));
+		mockOpenModals([dialog]);
+		mountViewer({
+			images: [
+				{ id: IMG_A, alt: 'first' },
+				{ id: IMG_B, alt: 'second' },
+			],
+		});
+		expect(press('ArrowRight')).toBe(false);
+
+		mockOpenModals([]);
+		expect(press('ArrowRight')).toBe(true);
+		expect(imageSrc()).toContain(IMG_B);
+	});
+});
+
+describe('Lightbox — background inertness (delegated)', () => {
+	it('asks the manager to inert the app shell, and releases it on close', () => {
+		// jsdom has no inertness semantics, so this asserts the manager was
+		// DRIVEN — the attribute on the right body children, gone again after
+		// close. Whether the background is really unreachable is TASK-2436's.
+		const app = mountViewer();
+		expect(inertBodyChildren()).toEqual([appRoot]);
+
+		unmount(mounted.splice(mounted.indexOf(app), 1)[0]);
+		flushSync();
+		expect(inertBodyChildren()).toEqual([]);
+	});
+
+	it('keeps the app inert while a SECOND viewer is still open', () => {
+		// The refcount is the manager's, but the release ordering is this
+		// component's: releasing without the lease stack would un-inert the app
+		// behind a viewer that is still up.
+		const first = mountViewer();
+		const back = root();
+		mountViewer();
+		// Only the FRONT viewer stays interactive: the app shell AND the viewer
+		// beneath it are both inert, which is the stacking the lease order buys.
+		expect(inertBodyChildren()).toEqual([appRoot, back]);
+
+		unmount(mounted.splice(mounted.indexOf(first), 1)[0]);
+		flushSync();
+		expect(inertBodyChildren()).toEqual([appRoot]);
+	});
+
+	it('hands focus to the viewer beneath instead of restoring its own invoker', () => {
+		// The `stackEmpty` half of the teardown: with a viewer still open,
+		// restoring the invoker would yank focus out of the surface the user is
+		// actually looking at. The manager owns the handoff; this component's job
+		// is to STAND DOWN.
+		//
+		// HONEST SCOPE, again: the two defences overlap. The manager's handoff
+		// has already moved focus INTO the viewer beneath by the time the restore
+		// would run, so `restoreFocus`'s own "someone else owns focus" guard
+		// declines even with the `stackEmpty` gate removed — verified by
+		// mutation. What IS asserted is the contract that matters: on closing the
+		// front viewer, focus lands in the one beneath and never on the closed
+		// viewer's invoker.
+		const invokerBack = appRoot.appendChild(document.createElement('button'));
+		const invokerFront = appRoot.appendChild(document.createElement('button'));
+		mountViewer({ invoker: invokerBack });
+		const back = root();
+		const front = mountViewer({ invoker: invokerFront });
+
+		unmount(mounted.splice(mounted.indexOf(front), 1)[0]);
+		flushSync();
+		expect(document.activeElement).not.toBe(invokerFront);
+		expect(back.contains(document.activeElement)).toBe(true);
+	});
+});

--- a/web/src/lib/components/editor/Editor.svelte
+++ b/web/src/lib/components/editor/Editor.svelte
@@ -873,6 +873,13 @@
 		const getAttachmentUrl = (uuid: string, variant?: AttachmentVariant) =>
 			wsSlug ? api.attachments.downloadUrl(wsSlug, uuid, variant) : `pad-attachment:${uuid}`;
 
+		// The server's image-processor formats, filled in by the async
+		// capabilities fetch below and read LIVE by the AttachmentImage
+		// NodeViews (BUG-2426). Held here rather than written onto the
+		// extension because a post-configure write to Tiptap's options is a
+		// no-op — see `SupportedFormatsReader` in attachment-image.ts.
+		let serverImageFormats: string[] = [];
+
 		// Reads the CURRENT host address at emit time (PLAN-2392 DR-8). This
 		// editor is remounted per item behind a {#key}, so a captured value
 		// would in fact be correct here — it is a reader anyway so both editor
@@ -953,13 +960,13 @@
 				// the life of a mount — ItemDetail remounts this editor per
 				// item ({#key item.id}) and mints one token per ItemDetail.
 				address: readHostAddress,
-				// Initial supportedFormats is empty — server capabilities
-				// are fetched async below. The toolbar starts disabled
-				// for all formats until capabilities resolve, then
-				// updates per-button via refreshToolbarState. The
-				// editor lifetime is long-lived so the one-call cost
-				// is amortized; no per-render fetch.
-				supportedFormats: [] as string[],
+				// Read live: server capabilities are fetched async below, so
+				// the list is empty when this editor is constructed and full
+				// once the fetch lands. The toolbar starts disabled for all
+				// formats and updates per-button via refreshToolbarState.
+				// The editor lifetime is long-lived so the one-call cost is
+				// amortized; no per-render fetch.
+				supportedFormats: () => serverImageFormats,
 				transform: async (uuid, payload) => {
 					if (!wsSlug) {
 						throw new Error('No workspace context — open the image inside a workspace to edit it.');
@@ -1149,19 +1156,20 @@
 		lastMarkdown = unescapeDocLinks((editor.storage as any).markdown.getMarkdown());
 		onEditor?.(editor);
 
-		// Fetch the server's image-processor capabilities and push the
-		// supported-formats list into the AttachmentImage extension so
-		// its rotate toolbar can gate per-format. Async / fire-and-
-		// forget — the toolbar starts disabled (empty list) and
-		// snaps to the right state once this resolves. The endpoint
-		// is public, so the fetch works pre-login on shared-item
-		// preview surfaces too.
+		// Fetch the server's image-processor capabilities so the rotate
+		// toolbar can gate per-format. Async / fire-and-forget — the
+		// toolbar starts disabled (empty list) and snaps to the right
+		// state once this resolves. The endpoint is public, so the fetch
+		// works pre-login on shared-item preview surfaces too.
+		//
+		// The list lands in `serverImageFormats`, which the extension reads
+		// through its `supportedFormats` reader. It is NOT written onto
+		// `ext.options`: that assignment used to live here and never
+		// reached the NodeViews, because Tiptap's `options` is a getter
+		// returning a fresh spread per access (BUG-2426).
 		api.server.capabilities()
 			.then((caps) => {
-				const ext = editor?.extensionManager.extensions.find(
-					(e: { name: string }) => e.name === 'attachmentImage'
-				);
-				if (ext) ext.options.supportedFormats = caps.image.image_formats;
+				serverImageFormats = caps.image.image_formats;
 				// Push the new list to any toolbars that were already
 				// open before this fetch resolved — without this, a
 				// user who selected an image during the in-flight

--- a/web/src/lib/components/editor/attachment-image.ts
+++ b/web/src/lib/components/editor/attachment-image.ts
@@ -76,15 +76,44 @@ function registerToolbarRefresher(fn: () => void): () => void {
 
 /**
  * Re-run every active toolbar's refresh hook. Called by Editor.svelte
- * after `api.server.capabilities()` resolves and the new
- * `supportedFormats` list has been pushed onto the AttachmentImage
- * extension's options. Any toolbar that was sitting in the
- * "all-disabled" pre-capabilities state snaps to its correct
- * per-format gating.
+ * once `api.server.capabilities()` resolves, so that any toolbar sitting
+ * in the "all-disabled" pre-capabilities state re-reads the formats
+ * reader and snaps to its correct per-format gating.
+ *
+ * The push is about EXISTING toolbar DOM only — the value itself is read
+ * live through `options.supportedFormats()`, so a toolbar built after
+ * capabilities resolved is already correct without a notification.
  */
 export function notifyAttachmentImageCapabilitiesChanged(): void {
 	for (const fn of toolbarRefreshers) fn();
 }
+
+/**
+ * Reads the image formats the SERVER's processor supports, at the moment
+ * the toolbar needs them.
+ *
+ * A reader, not a `string[]`, for the reason `$lib/attachments/hostAddress`
+ * spells out at length: the list is only known after an async
+ * `/server/capabilities` fetch that resolves LONG after `configure()`, and
+ * Tiptap's `options` is a GETTER returning a fresh spread per access
+ * (`@tiptap/core@3.22.5`), so `ext.options.supportedFormats = caps` mutates
+ * a temporary that is thrown away on the next line. The NodeView compounds
+ * it by snapshotting `this.options` once at construction. Both look like
+ * they work; together they left the rotate/crop toolbar permanently in its
+ * degraded "no image processor" state (BUG-2426).
+ *
+ * The host supplies a closure over its own live capability state, so the
+ * value is current whenever it is read — no write ever has to land.
+ */
+export type SupportedFormatsReader = () => string[];
+
+/**
+ * Default option value: no processor. An editor that never wires
+ * capabilities gets the degraded toolbar, which is the honest answer —
+ * and is what `CommentEditor` configures DELIBERATELY, since comments
+ * do not offer transforms at all.
+ */
+export const readNoSupportedFormats: SupportedFormatsReader = () => [];
 
 /**
  * Result of a server-side image transform. The editor uses the new
@@ -123,12 +152,18 @@ export interface AttachmentImageOptions {
 	 */
 	address: AttachmentHostAddressReader;
 	/**
-	 * Image formats the server-side processor supports. Drives the
-	 * rotate toolbar's enabled state per attachment: a button is
-	 * disabled (with tooltip) when the image's MIME isn't in this
-	 * list. Empty list ⇒ all transforms disabled (degraded build).
+	 * Reads the image formats the server-side processor supports. Drives
+	 * the rotate toolbar's enabled state per attachment: a button is
+	 * disabled (with tooltip) when the image's MIME isn't in the list.
+	 * Empty list ⇒ all transforms disabled (degraded build, or a surface
+	 * like the comment composer that switches transforms off on purpose).
+	 *
+	 * A reader rather than a list because the list arrives from an async
+	 * capabilities fetch after `configure()` — see
+	 * `SupportedFormatsReader` above for why writing it in afterwards
+	 * cannot work (BUG-2426).
 	 */
-	supportedFormats: string[];
+	supportedFormats: SupportedFormatsReader;
 	/**
 	 * Calls the server's /transform endpoint. Set by Editor.svelte to
 	 * `api.attachments.transform(workspaceSlug, uuid, payload)`.
@@ -182,7 +217,7 @@ export const AttachmentImage = Node.create<AttachmentImageOptions>({
 			getDownloadUrl: (uuid: string) => `${PAD_ATTACHMENT_PREFIX}${uuid}`,
 			workspaceSlug: '',
 			address: readUnaddressed,
-			supportedFormats: [] as string[],
+			supportedFormats: readNoSupportedFormats,
 			transform: async () => {
 				throw new Error('AttachmentImage: configure({ transform }) is required to use rotate/crop');
 			},
@@ -1016,7 +1051,11 @@ export const AttachmentImage = Node.create<AttachmentImageOptions>({
 						});
 					return;
 				}
-				refreshToolbarState(toolbar, knownMime, opts.supportedFormats);
+				// Read through the option, never a captured list: `opts` is a
+				// snapshot of `this.options` taken when this NodeView was built,
+				// which for a toolbar that predates the capabilities fetch is
+				// before the server's formats are known (BUG-2426).
+				refreshToolbarState(toolbar, knownMime, opts.supportedFormats());
 			};
 			const ensureToolbar = (): HTMLElement => {
 				if (toolbar) return toolbar;

--- a/web/src/lib/components/editor/attachment-image.ts
+++ b/web/src/lib/components/editor/attachment-image.ts
@@ -38,7 +38,11 @@ import {
 	mimeToFormat
 } from './attachment-metadata';
 import { openCropModal, type CropResult } from './attachment-crop-modal';
-import { notifyViewerOpen, registerAttachmentDeletionListener } from '$lib/attachments/events';
+import {
+	notifyAttachmentPanelOpen,
+	notifyViewerOpen,
+	registerAttachmentDeletionListener
+} from '$lib/attachments/events';
 import {
 	type AttachmentHostAddressReader,
 	readUnaddressed
@@ -290,6 +294,16 @@ export const AttachmentImage = Node.create<AttachmentImageOptions>({
 			// Latched by a confirmed deletion (not by a mere load failure).
 			// Deletion is authoritative: a load still in flight when it lands
 			// must not be allowed to paint the image back (Codex round 15).
+			//
+			// SEAM WITH PLAN-2411 (stated, not built here): this latch is cleared
+			// ONLY by an authoritative RESTORE signal on 2411's channel — never by
+			// editor undo. DR-17 requires Ctrl-Z to leave an inert placeholder
+			// rather than resurrect a working attachment: the delete was a REST row
+			// mutation that Tiptap/Yjs history cannot roll back, so an undo that
+			// re-inserted the node would otherwise present a live-looking image for
+			// a row the server no longer has. `deleted` is closure-private and the
+			// bus is deletion-only, so 2411 must extend both; that is its work, and
+			// nothing in THIS file may clear the latch on a document event.
 			let deleted = false;
 			// True once the NodeView is torn down. Async continuations (HEAD
 			// probes, transform results) must not touch DOM after that.
@@ -329,22 +343,24 @@ export const AttachmentImage = Node.create<AttachmentImageOptions>({
 			 *     role+tabindex would be a focus stop that announces itself as a
 			 *     button and does nothing. (The placeholder itself carries the
 			 *     retry affordance while the failure is still transient.)
-			 *   - a KNOWN MIME outside the viewer allowlist — activate() refuses it
-			 *     (DR-16), so the same dead stop applies. An UNPROBED node keeps the
-			 *     semantics: "not yet asked" is not "not viewable", and the probe is
-			 *     lazy. This mirrors ItemTimeline.svelte's semantics pass, which is
-			 *     likewise able to take the semantics back OFF when a probe resolves.
-			 *
-			 *     Consequence, accepted deliberately: because the probe is lazy, a
-			 *     refused image can be FOCUSED before its MIME resolves and lose
-			 *     focus when it does. The alternative is leaving an SVG as a focus
-			 *     stop that announces itself as a button and does nothing, which is
-			 *     the failure this whole rule exists to prevent — and the same
-			 *     trade the placeholder below already makes.
+			 * A KNOWN MIME outside the viewer allowlist is NOT one of them, as of
+			 * TASK-2434. It used to be: the gate was binary — viewer or nothing —
+			 * so a resolved `image/svg+xml` made the image a control that refused,
+			 * and the semantics had to come off. The matrix replaced that refusal
+			 * with a REDIRECT (DR-7): a non-allowlisted attachment is in the
+			 * options PANEL's scope, so the image stays a perfectly real activation
+			 * target — only its destination changes. Taking the semantics off now
+			 * would hide a working control instead of retiring a dead one, and
+			 * would break it for the mouse too, since click and key share one gate:
+			 * the first tap would open the panel, resolve the MIME, and leave the
+			 * image inert for every tap after it.
 			 *
 			 * The accessible name comes from alt with a GENERIC fallback: there is
 			 * no filename on the node's attrs and the HEAD metadata does not carry
 			 * one either, so the filename form DR-12 sketches has no source here.
+			 * It also has to name the DESTINATION rather than always promising a
+			 * viewer — a resolved non-raster type announces the panel it actually
+			 * opens.
 			 */
 			/**
 			 * Is this image an activation target right now?
@@ -356,6 +372,13 @@ export const AttachmentImage = Node.create<AttachmentImageOptions>({
 			 * below was, briefly, only in the semantics half — so the placeholder
 			 * hid the image and stripped its role, while a stale or synthetic
 			 * event on the hidden <img> still opened a viewer.
+			 *
+			 * It answers "does activation DO something", not "does it open the
+			 * viewer". The MIME decides WHICH surface (see activate()), and it is
+			 * deliberately absent from here: this predicate is also what a
+			 * post-await continuation re-checks, and folding a viewer-only clause
+			 * into it would make the panel branch unreachable the moment it wrote
+			 * the MIME it was branching on.
 			 */
 			function canActivate(): boolean {
 				return (
@@ -364,9 +387,18 @@ export const AttachmentImage = Node.create<AttachmentImageOptions>({
 					// Hidden means the placeholder has taken over: either a
 					// confirmed deletion or a load failure. Neither has an image
 					// to show, so neither has anything to open.
-					img.style.display !== 'none' &&
-					!(knownMime && !canOpenInViewer(knownMime))
+					img.style.display !== 'none'
 				);
+			}
+
+			/**
+			 * What activation would open, as far as anything KNOWN says. Unprobed
+			 * reads as the viewer — "not yet asked" is not "not viewable", and the
+			 * probe is lazy — which is exactly what the name has to say before the
+			 * HEAD lands. activate() never trusts it: it resolves the MIME itself.
+			 */
+			function announcesPanel(): boolean {
+				return !!knownMime && !canOpenInViewer(knownMime);
 			}
 
 			function applyImageSemantics() {
@@ -383,8 +415,35 @@ export const AttachmentImage = Node.create<AttachmentImageOptions>({
 				img.setAttribute('tabindex', '0');
 				img.setAttribute(
 					'aria-label',
-					currentAlt ? `View image: ${currentAlt}` : 'View attachment image'
+					announcesPanel()
+						? currentAlt
+							? `Attachment options: ${currentAlt}`
+							: 'Attachment options'
+						: currentAlt
+							? `View image: ${currentAlt}`
+							: 'View attachment image'
 				);
+			}
+
+			/**
+			 * The pending contract, minimal (TASK-2434).
+			 *
+			 * Activation awaits a HEAD. On a cache hit that is one microtask and
+			 * nothing is visible; cold, it is a round trip during which a click
+			 * that does nothing reads as broken. This NodeView has no
+			 * metadata-pending affordance — the placeholder below is for LOAD
+			 * failure, a different thing — so the smallest honest one: `aria-busy`
+			 * for assistive tech and a wait cursor for everyone else. No spinner
+			 * chrome in a parity commit.
+			 */
+			function setActivationPending(pending: boolean): void {
+				if (pending) {
+					img.setAttribute('aria-busy', 'true');
+					img.style.cursor = 'progress';
+					return;
+				}
+				img.removeAttribute('aria-busy');
+				img.style.cursor = '';
 			}
 
 			function showMissing() {
@@ -533,6 +592,48 @@ export const AttachmentImage = Node.create<AttachmentImageOptions>({
 				const base = opts.getDownloadUrl(currentUuid, 'thumb-md');
 				loadImage(`${base}${base.includes('?') ? '&' : '?'}retry=${Date.now()}`);
 			}
+			/**
+			 * The `transient` arm of the matrix (TASK-2434 / DR-17).
+			 *
+			 * `transient` says NOTHING about whether the row exists — a 5xx, a
+			 * proxy hiccup, a network throw — so it must never latch and must
+			 * never open. Before this task it also did nothing at all, which left
+			 * the worst of the three: a focused image announcing itself as a button
+			 * whose activation silently returned, with no way for the user to learn
+			 * that anything failed or to try again. Repeat presses would have gone
+			 * on doing nothing forever.
+			 *
+			 * So it hands over to the RETRYABLE placeholder — the one affordance
+			 * this NodeView already has for "this did not work, click to retry",
+			 * reached here by a different route than a failed `load`. Nothing is
+			 * latched: `deleted` stays false, the transient result is not cached
+			 * (`fetchAttachmentMetadata` evicts it on settle), and Retry re-issues
+			 * both the image load and, on a second failure, the HEAD.
+			 *
+			 * Retry does NOT resume the activation, deliberately. It is the
+			 * placeholder's existing affordance and it means "load this image
+			 * again", not "open it" — a reload control that opened a viewer would
+			 * be doing something the user did not ask for. The user gets the image
+			 * back and activates it again if they still want to, and that second
+			 * gesture really does re-probe: a transient result is evicted from the
+			 * metadata cache as it settles, so nothing replays the failure.
+			 *
+			 * The cost, accepted: an image that had rendered FINE is replaced by
+			 * the placeholder when only its HEAD failed. It is one click to undo
+			 * and it is recoverable; a control that silently does nothing is
+			 * neither. Anything gentler would be a third failure state — an inline
+			 * error, a toast — which is new chrome this commit does not add.
+			 */
+			function showTransientProbeFailure(): void {
+				// Keyboard activation is the case that matters: showMissing() takes
+				// the semantics off the <img> and blurs it, so without this the
+				// keypress that reported the failure also drops focus to <body>.
+				// The placeholder is the retry control, so focus belongs on it.
+				const hadFocus = document.activeElement === img;
+				showMissing();
+				if (hadFocus) missing.focus();
+			}
+
 			missing.addEventListener('click', retryLoad);
 			missing.addEventListener('keydown', (event) => {
 				if (event.key === 'Enter' || event.key === ' ') {
@@ -570,8 +671,12 @@ export const AttachmentImage = Node.create<AttachmentImageOptions>({
 			 * viewer that mounts and renders no image. The producer's half of that
 			 * contract is this function: either the cache answers (the common
 			 * case — the toolbar probe and the strip both warm the same entry) or
-			 * we await one HEAD, and we emit ONLY on a positively-known
-			 * allowlisted answer.
+			 * we await one HEAD, and we ask the VIEWER for only a
+			 * positively-known allowlisted answer. (Since TASK-2434 a
+			 * positively-known NON-allowlisted answer is not dropped — it goes to
+			 * the options panel instead. The rule the viewer cares about is
+			 * unchanged: nothing unresolved and nothing outside the allowlist
+			 * reaches it.)
 			 *
 			 * The channel enforces the same rule at the boundary as of TASK-2433 —
 			 * `notifyViewerOpen` takes a set whose `mime_type` is non-nullable and
@@ -580,14 +685,26 @@ export const AttachmentImage = Node.create<AttachmentImageOptions>({
 			 * open. It is still where the answer is OBTAINED, and the payload needs
 			 * it either way.
 			 *
-			 * What that COSTS, deliberately and temporarily: an image whose probe
-			 * comes back `transient` (or whose surface has no workspace to probe
-			 * with) keeps its button semantics and does not open. That is a dead
-			 * focus stop, and it is TASK-2434's — the four-branch matrix
-			 * (ok → viewer, unsafe → panel redirect, missing → inert placeholder,
-			 * transient → retryable) is what makes this gate TOTAL. This task is
-			 * the surface swap, and the swap must not be the thing that reopens
-			 * the hole TASK-2431 closed.
+			 * TASK-2434 made the gate TOTAL rather than binary. Every probe result
+			 * now has a destination, and none of them is "return quietly":
+			 *
+			 *   - `ok` + allowlisted raster  → the viewer.
+			 *   - `ok` + anything else       → the options PANEL (DR-7). A
+			 *     REDIRECT, not a refusal: an SVG or a PDF referenced as an inline
+			 *     image is a real attachment with real options, it is just not
+			 *     something to hand a viewer that would execute it.
+			 *   - `missing` (an authoritative 404) → the permanent placeholder,
+			 *     latched. Nothing opens.
+			 *   - `transient` → the RETRYABLE placeholder. Never an open, and
+			 *     never a latch: only a 404 is authoritative (DR-17).
+			 *
+			 * The two that were dead focus stops before this — `transient`, and a
+			 * resolved non-allowlisted MIME — are the two the matrix exists for.
+			 *
+			 * The one remaining silent return is a surface with NO WORKSPACE to
+			 * probe with (SSR / preview). It is not a dead stop in practice: those
+			 * surfaces have no host mounted to receive either event, so there is
+			 * nothing to route to and nothing to say.
 			 *
 			 * It also closes a mid-phase bypass Codex found: the old gate read
 			 * `knownMime` only when truthy, so a click landing before the lazy
@@ -608,13 +725,26 @@ export const AttachmentImage = Node.create<AttachmentImageOptions>({
 				// from, so probing under one workspace and emitting under another
 				// would serve ws1's click from ws2's endpoint. Snapshot once, then
 				// re-check at emit (below) rather than re-reading and trusting it.
-				const from = opts.address();
+				//
+				// DESTRUCTURED INTO PRIMITIVES, not held as the returned object.
+				// `opts.address()` is a reader the HOST supplies, and both live
+				// implementations happen to build a fresh object literal per call —
+				// so holding the reference would be safe today. It would be safe
+				// only for that reason. A host that returned a stable object it
+				// mutated in place would rewrite the very snapshot this fence
+				// compares against, and the comparison would pass unconditionally
+				// while looking exactly as it looks now. Three string copies buy
+				// independence from a property no interface states and no test
+				// could plausibly catch.
+				const { workspaceSlug: fromWs, itemId: fromItem, hostToken: fromHost } =
+					opts.address();
 				// No workspace ⇒ no probe ⇒ nothing can be positively known. An
 				// SSR/preview surface simply does not open a viewer.
-				if (!from.workspaceSlug) return;
+				if (!fromWs) return;
 				activating = true;
 				const seq = ++activationSeq;
-				void fetchAttachmentMetadata(from.workspaceSlug, forUuid, opts.getDownloadUrl)
+				setActivationPending(true);
+				void fetchAttachmentMetadata(fromWs, forUuid, opts.getDownloadUrl)
 					.then((result) => {
 						// Everything the gate asserted at gesture time has to still
 						// hold at emit time: the NodeView can be torn down, the node
@@ -629,32 +759,145 @@ export const AttachmentImage = Node.create<AttachmentImageOptions>({
 						// finds its own uuid in place and emits for a gesture two
 						// swaps ago.
 						if (activationSeq !== seq) return;
+						// DELETION, checked explicitly and BEFORE the result is read.
+						// It is the one invalidation the uuid comparison structurally
+						// cannot catch: a delete does not change which attachment the
+						// node points at, so a probe issued before it can resolve `ok`
+						// afterwards with `forUuid` still current — describing a row
+						// the server has since dropped. `canActivate()` restates this
+						// below; it is spelled out here because the branches between
+						// the two must not act on that answer either.
+						//
+						// The two guards happen to be equivalent TODAY — every path
+						// that sets `deleted` also hides the image — but nothing
+						// enforces that, and inferring "the row is gone" from "the
+						// placeholder is showing" would silently stop holding the
+						// moment a deletion state exists that does not hide.
+						if (deleted) return;
+
+						// AUTHORITATIVE 404. The row is gone: latch the permanent
+						// placeholder (the same end state the deletion broadcast
+						// reaches) and open nothing. This runs even when the image is
+						// already hidden behind a retryable placeholder — upgrading a
+						// transient failure to a confirmed one is exactly what a 404
+						// is for, so it deliberately precedes the presentability
+						// check below.
+						if (result.status === 'missing') {
+							latchMissing(forUuid);
+							return;
+						}
+						// NOT AUTHORITATIVE. Stay retryable, latch nothing, open
+						// nothing — and stop being a control that silently does
+						// nothing (see showTransientProbeFailure).
+						if (result.status === 'transient') {
+							showTransientProbeFailure();
+							return;
+						}
+
+						// A positively-known MIME. Record it: the semantics pass and
+						// the transform toolbar both read `knownMime`, and this
+						// activation is often the FIRST thing to learn it (the
+						// toolbar's own probe only runs once the node is selected).
+						// Without this the image would keep announcing "View image"
+						// for something that opens the panel.
+						//
+						// The SEMANTICS follow, and deliberately nothing else. The
+						// rotate/crop toolbar reads `knownMime` too, but refreshing
+						// it from here would settle its per-format gating earlier
+						// than it does today — a behaviour change this task's
+						// contract does not ask for. It is also unnecessary: a
+						// toolbar only exists once the node has been selected, and
+						// selection runs its own probe for the same uuid which
+						// refreshes on arrival. The window is a moment of staleness
+						// that closes itself.
+						knownMime = result.mime;
+						applyImageSemantics();
+
+						// The gesture-time gate, restated on state that may have
+						// moved: a load failure inside the await window hands over to
+						// the placeholder, and there is then no image to act on.
 						if (!canActivate()) return;
-						// `transient` and `missing` are both "not positively known".
-						if (result.status !== 'ok') return;
-						// DR-16, restated on the resolved answer rather than on the
-						// absence of one: `image/svg+xml` can carry active content.
-						if (!canOpenInViewer(result.mime)) return;
+
 						// The host may have MOVED while the HEAD was in flight — the
 						// comment composer is deliberately reused across an item
 						// switch (see hostAddress.ts), so its address is live. The
 						// gesture belonged to the old address: emitting there opens a
-						// viewer over a pane the user has left, and emitting at the
+						// surface over a pane the user has left, and emitting at the
 						// new one attributes the gesture to a different item. Neither
 						// is what the user did, so drop it.
+						//
+						// Read ONCE, compared against the FULL captured address, and
+						// every emission below uses the CAPTURED values — never a
+						// re-read. The check and the emit are adjacent and
+						// synchronous; deferring either behind a timer or a microtask
+						// would reopen the window this closes.
+						//
+						// WHAT THIS FENCE DOES NOT CATCH, stated because it is a real
+						// gap and not an oversight: it compares VALUES, so an address
+						// that leaves and RETURNS (A→B→A) reads as unchanged. That is
+						// reachable — the pane's `ItemDetail` has no `{#key}` (PLAN-2105
+						// / TASK-2112), so an A→B→A item switch keeps one host token,
+						// and the comment composer it owns is reused across it.
+						//
+						// It is left as-is deliberately, on two grounds. First, the
+						// outcome differs from what the fence exists to prevent: the
+						// user has NOT left the pane (they are back on it), and the
+						// gesture is NOT re-attributed (same node, same attachment,
+						// same host), so what opens is the image they clicked over the
+						// pane they are looking at. Compare the uuid A→B→A case just
+						// below, which IS fenced by `activationSeq` — there the
+						// SUBJECT of the gesture changes, which is a different and
+						// worse thing than a destination that round-trips to itself.
+						//
+						// Second, it is not fixable from inside this NodeView. Telling
+						// A→B→A from A needs a generation that advances on every
+						// address CHANGE, and this NodeView cannot observe one: it
+						// only READS the address (`AttachmentHostAddressReader` is a
+						// getter, with no subscription and no epoch), so a B that
+						// arrives and leaves between the two reads is invisible here
+						// by construction. Closing it means adding an epoch to
+						// `AttachmentHostAddress` and bumping it in every host — a
+						// cross-surface API change that also lands on the chip
+						// NodeView, which is outside this task's contract. Tracked as
+						// a fence-completeness follow-up rather than smuggled in here.
 						const to = opts.address();
 						if (
-							to.workspaceSlug !== from.workspaceSlug ||
-							to.itemId !== from.itemId ||
-							to.hostToken !== from.hostToken
+							to.workspaceSlug !== fromWs ||
+							to.itemId !== fromItem ||
+							to.hostToken !== fromHost
 						) {
+							return;
+						}
+
+						// DR-16 / DR-7, on the resolved answer rather than the absence
+						// of one: `image/svg+xml` can carry active content, so it does
+						// not go to the viewer — but it is still an attachment the
+						// user just activated, and the options panel is the surface
+						// that owns everything the viewer will not take. A redirect,
+						// not a refusal.
+						//
+						// `filename` is null for the same reason it is on the viewer
+						// payload: the node's attrs carry none and the HEAD does not
+						// either. The panel fetches what it needs itself — its three
+						// metadata fields are nullable precisely for emitters like
+						// this one.
+						if (!canOpenInViewer(result.mime)) {
+							notifyAttachmentPanelOpen({
+								attachmentId: forUuid,
+								itemId: fromItem,
+								hostToken: fromHost,
+								anchor: img,
+								filename: null,
+								mime_type: result.mime,
+								size_bytes: result.size,
+							});
 							return;
 						}
 						notifyViewerOpen({
 							attachmentId: forUuid,
-							workspaceSlug: from.workspaceSlug,
-							itemId: from.itemId,
-							hostToken: from.hostToken,
+							workspaceSlug: fromWs,
+							itemId: fromItem,
+							hostToken: fromHost,
 							// A single-image set: this NodeView knows about ITS node
 							// and nothing else. The body's other images are a set the
 							// editor could offer, but assembling one here would make
@@ -688,8 +931,19 @@ export const AttachmentImage = Node.create<AttachmentImageOptions>({
 						// Only if this activation is still the one holding the latch.
 						// A uuid swap bumps the counter, so a stale resolution
 						// landing afterwards cannot unlock the request that
-						// replaced it.
-						if (activationSeq === seq) activating = false;
+						// replaced it — nor clear a pending state the request that
+						// replaced it is still entitled to show.
+						if (activationSeq !== seq) return;
+						activating = false;
+						// The DOM write, unlike the latch release, is subject to
+						// this file's teardown rule: `destroyed` means every async
+						// continuation stops touching the node. Harmless in
+						// practice — the element is detached — but the `.then()`
+						// above fences on it and a finalizer that does not is the
+						// kind of asymmetry that stops being harmless the first
+						// time someone puts something real in here.
+						if (destroyed) return;
+						setActivationPending(false);
 					});
 			}
 
@@ -998,6 +1252,11 @@ export const AttachmentImage = Node.create<AttachmentImageOptions>({
 						// the user made two swaps ago.
 						activationSeq += 1;
 						activating = false;
+						// And the pending affordance goes with the latch: the bump
+						// above retires the old request's finalizer, so leaving
+						// `aria-busy` on would strand the NEW image as permanently
+						// busy.
+						setActivationPending(false);
 						resetMissing();
 						if (newUuid) {
 							loadImage(opts.getDownloadUrl(newUuid, 'thumb-md'));

--- a/web/src/lib/components/editor/attachment-image.ts
+++ b/web/src/lib/components/editor/attachment-image.ts
@@ -295,6 +295,85 @@ export const AttachmentImage = Node.create<AttachmentImageOptions>({
 			// probes, transform results) must not touch DOM after that.
 			let destroyed = false;
 
+			// The MIME this node's attachment is KNOWN to have, from a HEAD probe. Null
+			// until one has answered — the probe is lazy (toolbar construction, uuid
+			// swap), so "null" means "not yet asked", never "not an image".
+			//
+			// Declared HERE rather than next to its first reader so that
+			// applyImageSemantics() — which the load/missing paths call — can read it
+			// without a temporal-dead-zone hazard.
+			let knownMime: string | null = null;
+
+			/**
+			 * DR-12: the inline body image is an activation target, so it carries a
+			 * button's semantics — but ONLY while it is actually one.
+			 *
+			 * The three states that make it not one:
+			 *
+			 *   - no uuid — activate() has nothing to open;
+			 *   - a confirmed deletion, or any load failure that swapped the
+			 *     placeholder in — the <img> is hidden and activate() refuses, so
+			 *     role+tabindex would be a focus stop that announces itself as a
+			 *     button and does nothing. (The placeholder itself carries the
+			 *     retry affordance while the failure is still transient.)
+			 *   - a KNOWN MIME outside the viewer allowlist — activate() refuses it
+			 *     (DR-16), so the same dead stop applies. An UNPROBED node keeps the
+			 *     semantics: "not yet asked" is not "not viewable", and the probe is
+			 *     lazy. This mirrors ItemTimeline.svelte's semantics pass, which is
+			 *     likewise able to take the semantics back OFF when a probe resolves.
+			 *
+			 *     Consequence, accepted deliberately: because the probe is lazy, a
+			 *     refused image can be FOCUSED before its MIME resolves and lose
+			 *     focus when it does. The alternative is leaving an SVG as a focus
+			 *     stop that announces itself as a button and does nothing, which is
+			 *     the failure this whole rule exists to prevent — and the same
+			 *     trade the placeholder below already makes.
+			 *
+			 * The accessible name comes from alt with a GENERIC fallback: there is
+			 * no filename on the node's attrs and the HEAD metadata does not carry
+			 * one either, so the filename form DR-12 sketches has no source here.
+			 */
+			/**
+			 * Is this image an activation target right now?
+			 *
+			 * ONE predicate, read by activate() AND by applyImageSemantics(),
+			 * because "can be opened" and "announces itself as openable" are the
+			 * same question and a dead focus stop is exactly what they look like
+			 * when they disagree. Two copies would drift: the load-failure clause
+			 * below was, briefly, only in the semantics half — so the placeholder
+			 * hid the image and stripped its role, while a stale or synthetic
+			 * event on the hidden <img> still opened a viewer.
+			 */
+			function canActivate(): boolean {
+				return (
+					!!currentUuid &&
+					!deleted &&
+					// Hidden means the placeholder has taken over: either a
+					// confirmed deletion or a load failure. Neither has an image
+					// to show, so neither has anything to open.
+					img.style.display !== 'none' &&
+					!(knownMime && !canOpenInViewer(knownMime))
+				);
+			}
+
+			function applyImageSemantics() {
+				if (!canActivate()) {
+					// Removing tabindex from the focused element would strand focus on
+					// something no further keystroke can leave.
+					if (document.activeElement === img) img.blur();
+					img.removeAttribute('role');
+					img.removeAttribute('tabindex');
+					img.removeAttribute('aria-label');
+					return;
+				}
+				img.setAttribute('role', 'button');
+				img.setAttribute('tabindex', '0');
+				img.setAttribute(
+					'aria-label',
+					currentAlt ? `View image: ${currentAlt}` : 'View attachment image'
+				);
+			}
+
 			function showMissing() {
 				missing.textContent = `📎 ${currentAlt || 'Attachment unavailable'}`;
 				// Distinct copy per cause: a confirmed deletion is permanent and
@@ -321,6 +400,10 @@ export const AttachmentImage = Node.create<AttachmentImageOptions>({
 				if (currentUuid) missing.setAttribute('data-attachment-id', currentUuid);
 				missing.style.display = '';
 				img.style.display = 'none';
+				// The <img> the placeholder replaces stops being a control too —
+				// see applyImageSemantics for why a hidden/dead image must not
+				// keep announcing itself as one.
+				applyImageSemantics();
 			}
 
 			// Re-armed on every uuid swap in update() below, so a rotate/crop
@@ -330,6 +413,7 @@ export const AttachmentImage = Node.create<AttachmentImageOptions>({
 				if (deleted) return;
 				missing.style.display = 'none';
 				img.style.display = '';
+				applyImageSemantics();
 			}
 
 			// Load events carry no identity, and this NodeView outlives a uuid
@@ -409,6 +493,7 @@ export const AttachmentImage = Node.create<AttachmentImageOptions>({
 			}
 
 			if (currentUuid) loadImage(opts.getDownloadUrl(currentUuid, 'thumb-md'));
+			applyImageSemantics();
 
 			const disposeDeletionListener = registerAttachmentDeletionListener((deletedUuid) => {
 				if (deletedUuid !== currentUuid) return;
@@ -443,10 +528,37 @@ export const AttachmentImage = Node.create<AttachmentImageOptions>({
 				}
 			});
 
-			// The MIME this node's attachment is KNOWN to have, from a HEAD probe. Null
-			// until one has answered — the probe is lazy (toolbar construction, uuid
-			// swap), so "null" means "not yet asked", never "not an image".
-			let knownMime: string | null = null;
+			/**
+			 * THE single activation path for this node — every route that opens the
+			 * image goes through here.
+			 *
+			 * The MIME gate used to live inside the click handler, which made it a
+			 * property of the MOUSE rather than of activation: a keyboard path that
+			 * opened on its own would have bypassed it entirely. One function owns
+			 * the gate so there is exactly one place a route can be added to and
+			 * exactly one place the gate can be strengthened (the viewer bus and its
+			 * fence land on this same seam in the tasks that follow).
+			 *
+			 * The gate itself is `canActivate()`, shared with the semantics pass so
+			 * an image can never be openable and un-announced, or announced and
+			 * dead.
+			 *
+			 * DR-16: the EXACT raster allowlist gates every open-the-viewer path,
+			 * not just the strip's — `image/svg+xml` can carry active content, and a
+			 * node being labelled image/* is not sufficient reason to hand it to a
+			 * viewer.
+			 *
+			 * Gated on what is POSITIVELY KNOWN, deliberately: this node's MIME comes
+			 * from a lazy HEAD probe, so at activation time it is often simply
+			 * unasked. Refusing on unknown would stop ordinary images opening — a
+			 * certain regression traded for a marginal risk — so an unprobed node
+			 * keeps today's behaviour and a probed non-allowlisted one is refused.
+			 */
+			function activate(): void {
+				if (!canActivate()) return;
+				const fullUrl = opts.getDownloadUrl(currentUuid, 'original');
+				openImageLightbox(fullUrl, currentAlt);
+			}
 
 			img.addEventListener('click', (event) => {
 				// In a contenteditable, ProseMirror handles selection on
@@ -458,23 +570,43 @@ export const AttachmentImage = Node.create<AttachmentImageOptions>({
 				if (event.detail > 1) return;
 				event.preventDefault();
 				event.stopPropagation();
-				if (!currentUuid) return;
-				// DR-16: the EXACT raster allowlist gates every open-the-viewer
-				// path, not just the strip's — `image/svg+xml` can carry active
-				// content, and a node being labelled image/* is not sufficient
-				// reason to hand it to a viewer.
+				activate();
+			});
+
+			img.addEventListener('keydown', (event) => {
+				const isSpace = event.key === ' ' || event.key === 'Spacebar';
+				if (event.key !== 'Enter' && !isSpace) return;
+				// A modified key is a SHORTCUT, not an activation — the same guard
+				// the file chip next door carries (attachment-chip.ts). Without it
+				// this handler swallows Ctrl/Cmd+Enter, which is CommentEditor's
+				// submit binding (CommentEditor.svelte's handleKeyDown): focus an
+				// image in a comment, press Cmd+Enter, and the comment does not
+				// post — it opens a viewer instead.
+				if (event.ctrlKey || event.metaKey || event.altKey || event.shiftKey) return;
+				// Space would otherwise scroll the page, and inside a
+				// contenteditable both keys would additionally be taken as text
+				// input against the selected atom.
+				event.preventDefault();
+				// UNCONDITIONAL, and before activate(): ItemTimeline delegates its
+				// own thumbnail click/keydown handlers across the whole entry list,
+				// and that list CONTAINS live CommentEditor instances whose bodies
+				// render this very NodeView — an `img[data-attachment-id]`, which is
+				// exactly the selector that delegation matches. Without this, one
+				// keypress opens two viewers.
 				//
-				// Gated on what is POSITIVELY KNOWN, deliberately: this node's
-				// MIME comes from a lazy HEAD probe, so at click time it is often
-				// simply unasked. Refusing on unknown would stop ordinary images
-				// opening — a certain regression traded for a marginal risk — so
-				// an unprobed node keeps today's behaviour and a probed
-				// non-allowlisted one is refused. Phase 3a's unified viewer
-				// threads `mime_type` onto the image list itself (DR-16), which
-				// is what turns this into a complete gate.
-				if (knownMime && !canOpenInViewer(knownMime)) return;
-				const fullUrl = opts.getDownloadUrl(currentUuid, 'original');
-				openImageLightbox(fullUrl, currentAlt);
+				// Note this is the ONLY activation the key produces: the browser
+				// synthesizes a click from Enter/Space for real <button>s, not for
+				// an <img role="button">, so there is no second fire to suppress.
+				event.stopPropagation();
+				// A HELD key repeats, and every repeat is another keydown — leaning
+				// on Enter would stack one viewer per repeat. "Fires exactly once"
+				// has to mean once per GESTURE, not once per event.
+				//
+				// Suppressed above rather than below: the repeat still belongs to
+				// this activation, so letting it escape would hand the surrounding
+				// surface a key the user only pressed once.
+				if (event.repeat) return;
+				activate();
 			});
 
 			// Build the toolbar lazily — only when the node is first
@@ -534,10 +666,16 @@ export const AttachmentImage = Node.create<AttachmentImageOptions>({
 							// load path acts on (DR-17), and this probe may
 							// well beat the <img> to it.
 							if (result.status === 'missing') latchMissing(probeUuid);
-							if (!toolbar) return;
 							// `transient` leaves the MIME unknown rather than
 							// wrong: gating falls back to supportedFormats.
 							knownMime = result.status === 'ok' ? result.mime : null;
+							// A resolved MIME can turn this image from
+							// viewable-by-assumption into refused, which has to take
+							// the button semantics back off. Applied BEFORE the
+							// toolbar bail-out: the semantics are a property of the
+							// image, not of whether a toolbar happens to exist.
+							applyImageSemantics();
+							if (!toolbar) return;
 							refresh();
 						}
 					);
@@ -731,6 +869,11 @@ export const AttachmentImage = Node.create<AttachmentImageOptions>({
 						// state stays correct across the swap.
 						knownMime = null;
 						refresh();
+						// The new uuid is unprobed, so the image is activatable
+						// again on the same "unknown ⇒ today's behaviour" rule the
+						// gate uses; a stale refusal must not outlive the image it
+						// was about.
+						applyImageSemantics();
 						const updateProbeWs = opts.address().workspaceSlug;
 						if (toolbar && newUuid && updateProbeWs) {
 							const probeUuid = newUuid;
@@ -742,8 +885,9 @@ export const AttachmentImage = Node.create<AttachmentImageOptions>({
 								if (destroyed) return;
 								if (currentUuid !== probeUuid) return;
 								if (result.status === 'missing') latchMissing(probeUuid);
-								if (!toolbar) return;
 								knownMime = result.status === 'ok' ? result.mime : null;
+								applyImageSemantics();
+								if (!toolbar) return;
 								refresh();
 							});
 						}
@@ -753,6 +897,10 @@ export const AttachmentImage = Node.create<AttachmentImageOptions>({
 						currentAlt = newAlt;
 						if (newAlt) img.alt = newAlt;
 						else img.removeAttribute('alt');
+						// The accessible name is derived from alt, so it has to
+						// follow a peer's (or a local) alt edit rather than keep
+						// announcing the old text.
+						applyImageSemantics();
 					}
 
 					return true;

--- a/web/src/lib/components/editor/attachment-image.ts
+++ b/web/src/lib/components/editor/attachment-image.ts
@@ -38,7 +38,7 @@ import {
 	mimeToFormat
 } from './attachment-metadata';
 import { openCropModal, type CropResult } from './attachment-crop-modal';
-import { registerAttachmentDeletionListener } from '$lib/attachments/events';
+import { notifyViewerOpen, registerAttachmentDeletionListener } from '$lib/attachments/events';
 import {
 	type AttachmentHostAddressReader,
 	readUnaddressed
@@ -304,6 +304,19 @@ export const AttachmentImage = Node.create<AttachmentImageOptions>({
 			// without a temporal-dead-zone hazard.
 			let knownMime: string | null = null;
 
+			// True while an activation's MIME resolution is in flight. See
+			// activate() for why one is enough — and why "exactly once" now needs
+			// a latch rather than only the key-repeat guard.
+			//
+			// The counter is what makes RELEASING it safe. The latch is dropped in
+			// two places — the resolution's own finalizer, and a uuid swap, which
+			// must not leave the NEW image latched behind the old one's request —
+			// and an unconditional finalizer would let a superseded activation
+			// release a latch that a LATER one is holding. Each activation stamps
+			// its own number and releases only if it is still the current holder.
+			let activating = false;
+			let activationSeq = 0;
+
 			/**
 			 * DR-12: the inline body image is an activation target, so it carries a
 			 * button's semantics — but ONLY while it is actually one.
@@ -536,8 +549,9 @@ export const AttachmentImage = Node.create<AttachmentImageOptions>({
 			 * property of the MOUSE rather than of activation: a keyboard path that
 			 * opened on its own would have bypassed it entirely. One function owns
 			 * the gate so there is exactly one place a route can be added to and
-			 * exactly one place the gate can be strengthened (the viewer bus and its
-			 * fence land on this same seam in the tasks that follow).
+			 * exactly one place the gate can be strengthened — which is what
+			 * TASK-2433 then did on this same seam: the viewer bus, the MIME
+			 * resolution and the address fence all live inside this one function.
 			 *
 			 * The gate itself is `canActivate()`, shared with the semantics pass so
 			 * an image can never be openable and un-announced, or announced and
@@ -548,16 +562,135 @@ export const AttachmentImage = Node.create<AttachmentImageOptions>({
 			 * node being labelled image/* is not sufficient reason to hand it to a
 			 * viewer.
 			 *
-			 * Gated on what is POSITIVELY KNOWN, deliberately: this node's MIME comes
-			 * from a lazy HEAD probe, so at activation time it is often simply
-			 * unasked. Refusing on unknown would stop ordinary images opening — a
-			 * certain regression traded for a marginal risk — so an unprobed node
-			 * keeps today's behaviour and a probed non-allowlisted one is refused.
+			 * THE MIME IS RESOLVED BEFORE ANYTHING IS EMITTED (TASK-2433, revising
+			 * the decomposition's "keep the positively-known gate"). `Lightbox`
+			 * FAILS CLOSED on an unresolved MIME as of TASK-2431 — it filters the
+			 * set it was handed and admits only allowlisted entries — so an event
+			 * carrying `mime_type: null` is not "let the viewer decide", it is a
+			 * viewer that mounts and renders no image. The producer's half of that
+			 * contract is this function: either the cache answers (the common
+			 * case — the toolbar probe and the strip both warm the same entry) or
+			 * we await one HEAD, and we emit ONLY on a positively-known
+			 * allowlisted answer.
+			 *
+			 * The channel enforces the same rule at the boundary as of TASK-2433 —
+			 * `notifyViewerOpen` takes a set whose `mime_type` is non-nullable and
+			 * refuses one that is not allowlisted — so this is no longer the only
+			 * thing between a forgetful producer and an image that quietly does not
+			 * open. It is still where the answer is OBTAINED, and the payload needs
+			 * it either way.
+			 *
+			 * What that COSTS, deliberately and temporarily: an image whose probe
+			 * comes back `transient` (or whose surface has no workspace to probe
+			 * with) keeps its button semantics and does not open. That is a dead
+			 * focus stop, and it is TASK-2434's — the four-branch matrix
+			 * (ok → viewer, unsafe → panel redirect, missing → inert placeholder,
+			 * transient → retryable) is what makes this gate TOTAL. This task is
+			 * the surface swap, and the swap must not be the thing that reopens
+			 * the hole TASK-2431 closed.
+			 *
+			 * It also closes a mid-phase bypass Codex found: the old gate read
+			 * `knownMime` only when truthy, so a click landing before the lazy
+			 * probe resolved opened the original file in the legacy dialog, and a
+			 * later `unsafe` answer did not close it.
 			 */
 			function activate(): void {
 				if (!canActivate()) return;
-				const fullUrl = opts.getDownloadUrl(currentUuid, 'original');
-				openImageLightbox(fullUrl, currentAlt);
+				// One activation at a time. The MIME resolution is asynchronous
+				// even on a cache hit (a settled promise still resolves on a
+				// microtask), so two gestures inside one tick would otherwise both
+				// clear the gate and emit — and "fires exactly once" has to survive
+				// the await that was just introduced, not only the key repeat.
+				if (activating) return;
+				const forUuid = currentUuid;
+				// The address the GESTURE happened at. The workspace half is what
+				// keys the metadata cache and what the viewer reads every image URL
+				// from, so probing under one workspace and emitting under another
+				// would serve ws1's click from ws2's endpoint. Snapshot once, then
+				// re-check at emit (below) rather than re-reading and trusting it.
+				const from = opts.address();
+				// No workspace ⇒ no probe ⇒ nothing can be positively known. An
+				// SSR/preview surface simply does not open a viewer.
+				if (!from.workspaceSlug) return;
+				activating = true;
+				const seq = ++activationSeq;
+				void fetchAttachmentMetadata(from.workspaceSlug, forUuid, opts.getDownloadUrl)
+					.then((result) => {
+						// Everything the gate asserted at gesture time has to still
+						// hold at emit time: the NodeView can be torn down, the node
+						// can be pointed at a different attachment (rotate/crop, a
+						// peer's op), and the deletion broadcast can land — all
+						// inside the await window.
+						if (destroyed || currentUuid !== forUuid) return;
+						// And this must still be the CURRENT activation. Comparing
+						// the uuid is not enough on its own: the node can be pointed
+						// away and back again (a rotate the user undoes, a peer's op
+						// reverted), and then a request from before the round trip
+						// finds its own uuid in place and emits for a gesture two
+						// swaps ago.
+						if (activationSeq !== seq) return;
+						if (!canActivate()) return;
+						// `transient` and `missing` are both "not positively known".
+						if (result.status !== 'ok') return;
+						// DR-16, restated on the resolved answer rather than on the
+						// absence of one: `image/svg+xml` can carry active content.
+						if (!canOpenInViewer(result.mime)) return;
+						// The host may have MOVED while the HEAD was in flight — the
+						// comment composer is deliberately reused across an item
+						// switch (see hostAddress.ts), so its address is live. The
+						// gesture belonged to the old address: emitting there opens a
+						// viewer over a pane the user has left, and emitting at the
+						// new one attributes the gesture to a different item. Neither
+						// is what the user did, so drop it.
+						const to = opts.address();
+						if (
+							to.workspaceSlug !== from.workspaceSlug ||
+							to.itemId !== from.itemId ||
+							to.hostToken !== from.hostToken
+						) {
+							return;
+						}
+						notifyViewerOpen({
+							attachmentId: forUuid,
+							workspaceSlug: from.workspaceSlug,
+							itemId: from.itemId,
+							hostToken: from.hostToken,
+							// A single-image set: this NodeView knows about ITS node
+							// and nothing else. The body's other images are a set the
+							// editor could offer, but assembling one here would make
+							// ←/→ page through a list this surface does not own.
+							images: [
+								{
+									id: forUuid,
+									alt: currentAlt,
+									// The node's attrs carry no filename and the HEAD
+									// metadata does not either — the same absence
+									// `applyImageSemantics` names its fallback for.
+									filename: null,
+									mime_type: result.mime,
+									size_bytes: result.size,
+									// 3b's pixel-based loading policy wants these; the
+									// HEAD probe has no source for them today.
+									width: null,
+									height: null,
+								},
+							],
+							index: 0,
+							// Where the viewer aims focus on close. The <img> is a real
+							// focus stop as of TASK-2432, so this is a stable target
+							// rather than whatever happened to hold focus at open —
+							// though `Lightbox` still falls back to the body if the
+							// element has since become unfocusable or detached.
+							invoker: img,
+						});
+					})
+					.finally(() => {
+						// Only if this activation is still the one holding the latch.
+						// A uuid swap bumps the counter, so a stale resolution
+						// landing afterwards cannot unlock the request that
+						// replaced it.
+						if (activationSeq === seq) activating = false;
+					});
 			}
 
 			img.addEventListener('click', (event) => {
@@ -851,6 +984,20 @@ export const AttachmentImage = Node.create<AttachmentImageOptions>({
 						// The old uuid's state — whether a 404 placeholder or a
 						// confirmed deletion — says nothing about the new one.
 						deleted = false;
+						// Nor does an activation still resolving for it. That
+						// request is already fenced (its continuation compares
+						// `currentUuid`), so the latch is guarding nothing but the
+						// NEW image — and this NodeView deliberately outlives the
+						// swap, so a HEAD that never settles would leave the image
+						// in front of the user permanently unopenable.
+						//
+						// The bump is what retires any request still resolving for
+						// the old attachment: its continuation checks the generation
+						// before emitting, so a swap AWAY AND BACK cannot let it
+						// find its own uuid in place and open a viewer for a gesture
+						// the user made two swaps ago.
+						activationSeq += 1;
+						activating = false;
 						resetMissing();
 						if (newUuid) {
 							loadImage(opts.getDownloadUrl(newUuid, 'thumb-md'));
@@ -1103,38 +1250,22 @@ function refreshToolbarState(
 	});
 }
 
-/**
- * Open a centered <dialog> showing the full-resolution attachment.
- * Closes on backdrop click, the close button, or the Esc key.
+/*
+ * THERE IS NO LIGHTBOX IN THIS FILE, AND THERE MUST NOT BE ONE AGAIN.
+ *
+ * `openImageLightbox` / `closeLightbox` used to live here: a hand-rolled
+ * `<dialog>` this NodeView appended to `document.body` and `showModal()`d.
+ * TASK-2433 deleted them. Inline images now emit on the viewer channel
+ * (`notifyViewerOpen`, in activate() above) and the `AttachmentViewerHost` that
+ * `ItemDetail` owns mounts the `Lightbox` for THIS route — which is where the
+ * modal contract lives: the lease-stacked backdrop, the focus trap and restore,
+ * the Escape ordering, and the DR-16 filter re-applied over the whole set. (The
+ * strip and the timeline still mount `Lightbox` themselves, by decision rather
+ * than omission — see the channel's own note in `$lib/attachments/events`.)
+ *
+ * A NodeView cannot mount a Svelte component, which is the entire reason the
+ * bus exists. Re-adding an imperative overlay here would not be a shortcut, it
+ * would be a second viewer with none of that contract — so
+ * `attachmentImageNoOverlay.test.ts` asserts, statically, that this file
+ * creates no dialog and calls no `showModal`.
  */
-function openImageLightbox(fullUrl: string, alt: string): void {
-	if (typeof document === 'undefined') return;
-	const dialog = document.createElement('dialog');
-	dialog.className = 'attachment-image-lightbox';
-
-	const closeBtn = document.createElement('button');
-	closeBtn.type = 'button';
-	closeBtn.className = 'attachment-image-lightbox-close';
-	closeBtn.setAttribute('aria-label', 'Close image preview');
-	closeBtn.textContent = '×';
-	closeBtn.addEventListener('click', () => closeLightbox(dialog));
-
-	const img = document.createElement('img');
-	img.className = 'attachment-image-lightbox-img';
-	img.src = fullUrl;
-	if (alt) img.alt = alt;
-	// Prevent clicks on the image itself from bubbling to the backdrop
-	// handler below (which closes the dialog).
-	img.addEventListener('click', (event) => event.stopPropagation());
-
-	dialog.append(closeBtn, img);
-	dialog.addEventListener('click', () => closeLightbox(dialog));
-	dialog.addEventListener('close', () => dialog.remove());
-
-	document.body.appendChild(dialog);
-	dialog.showModal();
-}
-
-function closeLightbox(dialog: HTMLDialogElement): void {
-	if (dialog.open) dialog.close();
-}

--- a/web/src/lib/components/editor/attachmentImageKeyboard.svelte.test.ts
+++ b/web/src/lib/components/editor/attachmentImageKeyboard.svelte.test.ts
@@ -111,7 +111,7 @@ function makeEditor(element: HTMLElement, content: string = BODY_CONTENT): Edito
 				getDownloadUrl: (uuid: string, variant?: string) =>
 					`/api/v1/workspaces/ws/attachments/${uuid}?variant=${variant ?? 'thumb-md'}`,
 				address: () => address,
-				supportedFormats: ['png'],
+				supportedFormats: () => ['png'],
 				transform: async () => {
 					throw new Error('not used');
 				},
@@ -137,7 +137,7 @@ function makeCommentEditor(element: HTMLElement): Editor {
 				getDownloadUrl: (uuid: string) => `/api/v1/workspaces/ws/attachments/${uuid}`,
 				workspaceSlug: 'ws',
 				address: () => address,
-				supportedFormats: [] as string[],
+				supportedFormats: () => [] as string[],
 				transform: async () => {
 					throw new Error('Image transforms are not available in comments.');
 				},

--- a/web/src/lib/components/editor/attachmentImageKeyboard.svelte.test.ts
+++ b/web/src/lib/components/editor/attachmentImageKeyboard.svelte.test.ts
@@ -6,15 +6,27 @@
 // no name. This spec pins the button contract that closes that, and — more
 // importantly — pins the two ways the contract is easy to get WRONG:
 //
-//   - activation firing TWICE. A keyed remount or a fast dialog can hide a
-//     duplicate visually, so every activation assertion here is a COUNT
-//     (`dialog.attachment-image-lightbox` elements in the document), never a
-//     truthiness check. `toBe(1)` fails on 2; `not.toBeNull()` does not.
+//   - activation firing TWICE. A duplicate is easy to hide visually, so every
+//     activation assertion here is a COUNT of open-viewer REQUESTS on the bus,
+//     never a truthiness check. `toBe(1)` fails on 2; `not.toBeNull()` does not.
+//     Counting requests rather than DOM is also what survived TASK-2433: the
+//     NodeView no longer opens anything itself, so a spec that counted overlays
+//     would now assert 0 forever and pass against an implementation that emits
+//     nothing at all.
 //
 //   - the KEYBOARD path bypassing the MIME gate. The gate used to live inside
 //     the click handler, which made it a property of the mouse. Both routes now
 //     call one `activate()`, and the refusal is asserted through the KEYBOARD,
 //     which is the assertion that would have caught a second emitter.
+//
+// THIS FILE IS THE PRODUCER LAYER, and its counts are counts of REQUESTS on the
+// bus, not of viewers on screen: `notifyViewerOpen` is mocked, so "opens once"
+// here means "asks once". That is the right layer for the keyboard contract —
+// which is about how many times activation fires, and under which gestures —
+// but it is deliberately blind to whether anything is listening. The end of the
+// route (real bus → real `AttachmentViewerHost` → real `Lightbox`, and a real
+// viewer in the document) is pinned next door in
+// `attachmentImageViewerHost.svelte.test.ts`.
 //
 // Driven through a REAL Tiptap editor, like the placeholder spec next door: the
 // semantics live on imperative NodeView DOM and a hand-built element would pin
@@ -25,18 +37,38 @@ import StarterKit from '@tiptap/starter-kit';
 import { isEditorOwnedImage } from '$lib/attachments/editorOwnedImage';
 
 const deletionListeners = new Set<(uuid: string) => void>();
+// Open-viewer requests, captured RAW — before the channel's addressability
+// filter, so what is asserted is what THIS NodeView produced.
+const emitted: Array<Record<string, unknown>> = [];
 vi.mock('$lib/attachments/events', () => ({
 	notifyAttachmentPanelOpen: () => {},
+	notifyViewerOpen: (event: Record<string, unknown>) => {
+		emitted.push(event);
+	},
 	registerAttachmentDeletionListener: (fn: (uuid: string) => void) => {
 		deletionListeners.add(fn);
 		return () => deletionListeners.delete(fn);
 	},
 }));
 
-const probeMock = vi.fn(async () => ({ status: 'transient' as const }));
+// The probe's full result union, spelled out. Without it `vi.fn` infers the
+// type of the DEFAULT implementation alone, and every `mockResolvedValue` for a
+// different arm is a type error — invisible under `npm run check`, which
+// excludes `*.svelte.test.ts`, and a trap for whoever widens that exclude.
+type ProbeResult =
+	| { status: 'ok'; mime: string; size: number }
+	| { status: 'missing' }
+	| { status: 'transient' };
+
+// Args are passed through so a test can answer PER ATTACHMENT — the uuid-swap
+// case below needs one image's probe to still be in flight while another's
+// answers.
+const probeMock = vi.fn<(ws?: string, uuid?: string) => Promise<ProbeResult>>(async () => ({
+	status: 'transient',
+}));
 vi.mock('./attachment-metadata', () => ({
-	fetchAttachmentMetadata: () => probeMock(),
-	revalidateAttachmentMetadata: () => probeMock(),
+	fetchAttachmentMetadata: (ws: string, uuid: string) => probeMock(ws, uuid),
+	revalidateAttachmentMetadata: (ws: string, uuid: string) => probeMock(ws, uuid),
 	invalidateAttachmentMetadata: () => {},
 	mimeToFormat: () => null,
 }));
@@ -44,6 +76,14 @@ vi.mock('./attachment-metadata', () => ({
 const { AttachmentImage } = await import('./attachment-image');
 
 const BODY_CONTENT = '<p><img data-attachment-id="uuid-1" src="/api/v1/x" alt="A diagram"></p>';
+
+/**
+ * The address every editor below reads through. MUTABLE, because the real
+ * reader is: `CommentEditor` is deliberately reused across an item switch and
+ * its address changes under a mounted NodeView (see hostAddress.ts). Activation
+ * now spans an await, so that switch can land mid-flight.
+ */
+let address = { workspaceSlug: 'ws', itemId: 'item-A', hostToken: 'apanel-1' };
 
 /** The item-body configuration (Editor.svelte): transforms enabled. */
 function makeEditor(element: HTMLElement, content: string = BODY_CONTENT): Editor {
@@ -55,7 +95,7 @@ function makeEditor(element: HTMLElement, content: string = BODY_CONTENT): Edito
 				workspaceSlug: 'ws',
 				getDownloadUrl: (uuid: string, variant?: string) =>
 					`/api/v1/workspaces/ws/attachments/${uuid}?variant=${variant ?? 'thumb-md'}`,
-				address: () => ({ workspaceSlug: 'ws', itemId: 'item-A', hostToken: 'apanel-1' }),
+				address: () => address,
 				supportedFormats: ['png'],
 				transform: async () => {
 					throw new Error('not used');
@@ -81,7 +121,7 @@ function makeCommentEditor(element: HTMLElement): Editor {
 			AttachmentImage.configure({
 				getDownloadUrl: (uuid: string) => `/api/v1/workspaces/ws/attachments/${uuid}`,
 				workspaceSlug: 'ws',
-				address: () => ({ workspaceSlug: 'ws', itemId: 'item-A', hostToken: 'apanel-1' }),
+				address: () => address,
 				supportedFormats: [] as string[],
 				transform: async () => {
 					throw new Error('Image transforms are not available in comments.');
@@ -93,9 +133,25 @@ function makeCommentEditor(element: HTMLElement): Editor {
 	});
 }
 
-/** How many times activation actually fired. One dialog per open. */
+/** How many times activation actually fired. One request per open. */
 function openCount(): number {
-	return document.querySelectorAll('dialog.attachment-image-lightbox').length;
+	return emitted.length;
+}
+
+/**
+ * Activation resolves the image's MIME BEFORE emitting (TASK-2433), so it is
+ * asynchronous even on a cache hit. Every post-gesture count goes through here;
+ * a synchronous read would be 0 regardless of what the implementation did.
+ */
+async function opened(): Promise<number> {
+	// TWO turns of the macrotask queue, not one. A count read too early is
+	// conservative for the "opens once" cases (an emission that had not
+	// happened yet reads as 0 and FAILS the assertion) but not for the "opens
+	// nothing" ones, where an implementation that emitted one tick later would
+	// pass. The second await closes that.
+	await new Promise((resolve) => setTimeout(resolve, 0));
+	await new Promise((resolve) => setTimeout(resolve, 0));
+	return emitted.length;
 }
 
 /**
@@ -126,9 +182,13 @@ function timelineDelegation(
 		// not the only surface that could ever delegate over one.
 		if (opts.ownership && isEditorOwnedImage(img)) return;
 		onFire();
-		const dialog = document.createElement('dialog');
-		dialog.className = 'attachment-image-lightbox';
-		document.body.appendChild(dialog);
+		// A stand-in for the timeline's OWN viewer, deliberately a different
+		// element from anything the NodeView produces: these tests are about
+		// two viewers from one gesture, which is only observable if the two
+		// are distinguishable.
+		const stub = document.createElement('div');
+		stub.className = 'timeline-viewer-stub';
+		document.body.appendChild(stub);
 	};
 }
 
@@ -139,8 +199,16 @@ describe('inline body image — keyboard activation (DR-12)', () => {
 
 	beforeEach(() => {
 		deletionListeners.clear();
+		address = { workspaceSlug: 'ws', itemId: 'item-A', hostToken: 'apanel-1' };
 		probeMock.mockClear();
-		probeMock.mockResolvedValue({ status: 'transient' as const });
+		// The ORDINARY case is an image whose MIME resolves to an allowlisted
+		// raster type, and as of TASK-2433 that is a PRECONDITION of opening at
+		// all: activation resolves the MIME first and emits only on a positive
+		// answer, because `Lightbox` fails closed on an unresolved one. A
+		// `transient` default would make every "opens exactly once" test below
+		// assert 0 for a reason that has nothing to do with the keyboard.
+		probeMock.mockResolvedValue({ status: 'ok' as const, mime: 'image/png', size: 4096 });
+		emitted.length = 0;
 		host = document.body.appendChild(document.createElement('div'));
 		target = host.appendChild(document.createElement('div'));
 	});
@@ -149,7 +217,8 @@ describe('inline body image — keyboard activation (DR-12)', () => {
 		editor?.destroy();
 		editor = undefined;
 		host.remove();
-		document.querySelectorAll('dialog.attachment-image-lightbox').forEach((d) => d.remove());
+		emitted.length = 0;
+		document.querySelectorAll('.timeline-viewer-stub').forEach((d) => d.remove());
 	});
 
 	function image(): HTMLImageElement {
@@ -200,7 +269,7 @@ describe('inline body image — keyboard activation (DR-12)', () => {
 		expect(image().getAttribute('aria-label')).toBe('View attachment image');
 	});
 
-	it('opens on Enter, exactly once', () => {
+	it('opens on Enter, exactly once', async () => {
 		editor = makeEditor(target);
 		expect(openCount()).toBe(0);
 
@@ -209,22 +278,60 @@ describe('inline body image — keyboard activation (DR-12)', () => {
 		// A COUNT, not a truthiness check: a second emitter (a keyboard path that
 		// activated on its own AND a synthesized click) shows up here as 2 and is
 		// invisible to `not.toBeNull()`.
-		expect(openCount()).toBe(1);
+		expect(await opened()).toBe(1);
 	});
 
-	it('opens on Space exactly once and suppresses the page scroll', () => {
+	it('emits the viewer request the deleted dialog used to open', async () => {
+		// TASK-2433 deleted this NodeView's hand-rolled `<dialog>`. Every other
+		// test in this file counts activations, and a count is satisfied by an
+		// emission of any shape — so exactly one test has to pin the CONTENT, or
+		// "the dialog is gone" would be provable by an implementation that
+		// replaced it with nothing.
+		editor = makeEditor(target);
+		const img = image();
+
+		press(img, 'Enter');
+		await opened();
+
+		expect(emitted).toEqual([
+			{
+				attachmentId: 'uuid-1',
+				workspaceSlug: 'ws',
+				itemId: 'item-A',
+				hostToken: 'apanel-1',
+				images: [
+					{
+						id: 'uuid-1',
+						alt: 'A diagram',
+						filename: null,
+						mime_type: 'image/png',
+						size_bytes: 4096,
+						width: null,
+						height: null,
+					},
+				],
+				index: 0,
+				// The focus-restore target. The <img> is a real focus stop as of
+				// TASK-2432, so the keyboard path has a stable one to offer —
+				// which is the whole reason `invoker` is on the event.
+				invoker: img,
+			},
+		]);
+	});
+
+	it('opens on Space exactly once and suppresses the page scroll', async () => {
 		editor = makeEditor(target);
 		expect(openCount()).toBe(0);
 
 		const ev = press(image(), ' ');
 
-		expect(openCount()).toBe(1);
+		expect(await opened()).toBe(1);
 		// Unhandled Space scrolls the document — and inside a contenteditable it
 		// would also be taken as text input against the selected atom.
 		expect(ev.defaultPrevented).toBe(true);
 	});
 
-	it('accepts the legacy "Spacebar" key name too', () => {
+	it('accepts the legacy "Spacebar" key name too', async () => {
 		// Same alias the file chip next door accepts — older engines report Space
 		// under this name, and an image that ignored it would be inert there.
 		editor = makeEditor(target);
@@ -232,22 +339,22 @@ describe('inline body image — keyboard activation (DR-12)', () => {
 
 		const ev = press(image(), 'Spacebar');
 
-		expect(openCount()).toBe(1);
+		expect(await opened()).toBe(1);
 		expect(ev.defaultPrevented).toBe(true);
 	});
 
-	it('opens on a mouse click, exactly once', () => {
+	it('opens on a mouse click, exactly once', async () => {
 		editor = makeEditor(target);
 		expect(openCount()).toBe(0);
 		click(image());
-		expect(openCount()).toBe(1);
+		expect(await opened()).toBe(1);
 	});
 
 	// Both activation keys, because the propagation stop is per-key: a handler
 	// that stopped for Enter and not Space would pass an Enter-only test and
 	// still double-open on the key most people press.
 	for (const key of ['Enter', ' ']) {
-		it(`does not double-open when ${key === ' ' ? 'Space' : key} lands inside a delegated container`, () => {
+		it(`does not double-open when ${key === ' ' ? 'Space' : key} lands inside a delegated container`, async () => {
 			// ItemTimeline delegates thumbnail click/keydown across its whole entry
 			// list, and that list CONTAINS live CommentEditor instances whose bodies
 			// render this NodeView — an `img[data-attachment-id]`, which is exactly
@@ -269,7 +376,7 @@ describe('inline body image — keyboard activation (DR-12)', () => {
 			press(image(), key);
 
 			expect(delegated).toBe(0);
-			expect(openCount()).toBe(1);
+			expect(await opened()).toBe(1);
 		});
 	}
 
@@ -283,7 +390,7 @@ describe('inline body image — keyboard activation (DR-12)', () => {
 		['Shift+Enter', { shiftKey: true }],
 		['Alt+Space', { altKey: true }],
 	] as const) {
-		it(`treats ${label} as a shortcut, not an activation`, () => {
+		it(`treats ${label} as a shortcut, not an activation`, async () => {
 			let seen = 0;
 			let timelineOpened = 0;
 			host.addEventListener('keydown', () => (seen += 1));
@@ -305,7 +412,7 @@ describe('inline body image — keyboard activation (DR-12)', () => {
 			// instead of the handler under test.
 			const solo = new KeyboardEvent('keydown', { key, cancelable: true, ...mods });
 			image().dispatchEvent(solo);
-			expect(openCount()).toBe(0);
+			expect(await opened()).toBe(0);
 			expect(solo.defaultPrevented).toBe(false);
 
 			// Then bubbling, for the other half: the event must still REACH the
@@ -314,12 +421,12 @@ describe('inline body image — keyboard activation (DR-12)', () => {
 			// just as thoroughly as one that opened a viewer.
 			press(image(), key, mods);
 			expect(seen).toBe(1);
-			expect(openCount()).toBe(0);
+			expect(await opened()).toBe(0);
 			expect(timelineOpened).toBe(0);
 		});
 	}
 
-	it('opens once for a HELD key, not once per repeat', () => {
+	it('opens once for a HELD key, not once per repeat', async () => {
 		// Every repeat is another keydown. Without a guard, leaning on Enter
 		// stacks a viewer per repeat — "exactly once" has to mean once per
 		// gesture. A truthiness check would not see this at all.
@@ -334,14 +441,14 @@ describe('inline body image — keyboard activation (DR-12)', () => {
 		press(img, 'Enter');
 		for (let i = 0; i < 4; i++) press(img, 'Enter', { repeat: true });
 
-		expect(openCount()).toBe(1);
+		expect(await opened()).toBe(1);
 		// And the repeats stay suppressed: they belong to the activation the
 		// user made once, so letting them escape would hand the surrounding
 		// surface four keypresses that never happened.
 		expect(delegated).toBe(0);
 	});
 
-	it('still reaches the delegated container for keys it does not handle', () => {
+	it('still reaches the delegated container for keys it does not handle', async () => {
 		// The propagation stop is scoped to the activation keys; swallowing
 		// everything would break Escape, Tab-adjacent handlers and the editor's
 		// own key handling on the surrounding surface.
@@ -355,19 +462,22 @@ describe('inline body image — keyboard activation (DR-12)', () => {
 		// Nor is it swallowed: an Escape the node consumed would never reach the
 		// surface that closes a pane or a dialog.
 		expect(ev.defaultPrevented).toBe(false);
-		expect(openCount()).toBe(0);
+		expect(await opened()).toBe(0);
 	});
 
 	it('refuses a probed non-raster type through the KEYBOARD, not just the mouse', async () => {
 		// The gate used to live inside the click handler. A keyboard path that
 		// emitted on its own would have sailed straight past it, so the refusal
 		// is asserted on the route that would have bypassed it.
-		probeMock.mockResolvedValue({ status: 'ok', mime: 'image/svg+xml' });
+		probeMock.mockResolvedValue({ status: 'ok', mime: 'image/svg+xml' , size: 4096 });
 		editor = makeEditor(target);
 
-		// BEFORE the probe answers, this is an ordinary activatable button (the
-		// documented "unknown ⇒ keep today's behaviour" path). Pinning that here
-		// is what makes the refusal below attributable to the RESOLVED MIME
+		// BEFORE the probe answers, this still LOOKS like an ordinary button:
+		// the semantics pass keeps role/tabindex while the MIME is merely
+		// unasked, because "not yet asked" is not "not viewable". (Activation
+		// itself no longer trusts that — TASK-2433 made it resolve the MIME
+		// first — but the two are separate claims and this one is the premise.)
+		// Pinning it here is what makes the refusal below attributable to the RESOLVED MIME
 		// rather than to any other inertness route — an empty uuid, a latched
 		// deletion, a hidden image — all of which would already be true now.
 		expect(image().getAttribute('role')).toBe('button');
@@ -376,7 +486,7 @@ describe('inline body image — keyboard activation (DR-12)', () => {
 		expect(probeMock).toHaveBeenCalled();
 
 		press(image(), 'Enter');
-		expect(openCount()).toBe(0);
+		expect(await opened()).toBe(0);
 
 		// And it stops being a focus stop at all, rather than announcing itself
 		// as a button that does nothing.
@@ -385,10 +495,265 @@ describe('inline body image — keyboard activation (DR-12)', () => {
 		expect(image().getAttribute('aria-label')).toBeNull();
 	});
 
+	it('refuses an UNPROBED non-raster type — the gesture that beats the lazy probe', async () => {
+		// The bypass this task's revised gate closes, and the one the test above
+		// cannot see: `settleProbe()` selects the node, which builds the toolbar
+		// and runs the lazy HEAD, so by then `canActivate()` already knows the
+		// MIME and refuses before activation does any work of its own. An
+		// UNSELECTED body image — the state every image is in until the user
+		// touches it — has `knownMime === null`, and the old gate read it only
+		// when truthy: the click sailed past and opened the ORIGINAL file.
+		//
+		// So: never selected, no toolbar, nothing probed. The refusal here can
+		// only come from activation resolving the MIME itself before emitting.
+		probeMock.mockResolvedValue({ status: 'ok', mime: 'image/svg+xml' , size: 4096 });
+		editor = makeEditor(target);
+
+		// The premise: nothing has asked yet, so the image still looks openable.
+		expect(probeMock).not.toHaveBeenCalled();
+		expect(image().getAttribute('role')).toBe('button');
+
+		press(image(), 'Enter');
+		expect(await opened()).toBe(0);
+		click(image());
+		expect(await opened()).toBe(0);
+		// And it did ask — a refusal reached by never probing at all would be
+		// the same count for the wrong reason.
+		expect(probeMock).toHaveBeenCalled();
+	});
+
+	it('emits once when two gestures land inside one resolution window', async () => {
+		// Resolving the MIME before emitting introduced an await where there was
+		// none, and "fires exactly once" has to survive it: two activations
+		// entering that window would each clear the gate and each emit, which is
+		// two viewers from one user intent. The key-repeat guard does not cover
+		// this — these are two distinct, unrepeated gestures.
+		editor = makeEditor(target);
+		const img = image();
+
+		press(img, 'Enter');
+		press(img, 'Enter');
+		click(img);
+
+		expect(await opened()).toBe(1);
+
+		// And the latch RELEASES: a gesture after the window closes opens again,
+		// so this is not "the second one is swallowed forever".
+		press(img, 'Enter');
+		expect(await opened()).toBe(2);
+	});
+
+	it('drops the request when the attachment is deleted mid-resolution', async () => {
+		// The await opened a window, and everything the gate checked at gesture
+		// time can stop being true inside it. A deletion is the sharpest case:
+		// it is authoritative, it arrives from another surface at any moment, and
+		// a request emitted after it opens a viewer on a row that is gone.
+		editor = makeEditor(target);
+		const img = image();
+
+		press(img, 'Enter');
+		// Same tick as the gesture, before the HEAD resolves.
+		for (const fn of deletionListeners) fn('uuid-1');
+
+		expect(await opened()).toBe(0);
+	});
+
+	it('never probes, and never emits, on a surface with no workspace', async () => {
+		// An SSR / preview surface configures the extension with the unaddressed
+		// reader. There is no workspace to probe under, so nothing can be
+		// positively known — and the rule is "emit only on a positive answer",
+		// not "emit when we could not check".
+		address = { workspaceSlug: '', itemId: 'item-A', hostToken: 'apanel-1' };
+		editor = makeEditor(target);
+
+		press(image(), 'Enter');
+		click(image());
+
+		expect(await opened()).toBe(0);
+		// Not merely refused after asking — never asked. A probe keyed on an
+		// empty workspace is a cache entry under the wrong key.
+		expect(probeMock).not.toHaveBeenCalled();
+	});
+
+	it('does not emit for a row the probe says is GONE', async () => {
+		// `missing` is authoritative and distinct from `transient`: one is "the
+		// row is not there", the other is "we could not tell". Neither is a
+		// positively-known MIME, so neither opens — but they are separate
+		// branches of the result union and a gate written as
+		// `status === 'transient'` would let this one through.
+		probeMock.mockResolvedValue({ status: 'missing' });
+		editor = makeEditor(target);
+
+		press(image(), 'Enter');
+
+		expect(await opened()).toBe(0);
+	});
+
+	it('drops the request when the NodeView is torn down mid-resolution', async () => {
+		// The await outlives the editor: an item switch or a pane remount
+		// destroys the view while the HEAD is in flight, and a request emitted
+		// afterwards asks a host to open a viewer for a surface that is gone.
+		editor = makeEditor(target);
+
+		press(image(), 'Enter');
+		editor.destroy();
+		editor = undefined;
+
+		expect(await opened()).toBe(0);
+	});
+
+	// Each field SEPARATELY, because the fence is three comparisons and a test
+	// that moved only one leaves the other two free to be deleted. The workspace
+	// is what every image URL is read from, `itemId` is which pane shows the
+	// viewer, and `hostToken` is which of two concurrently-mounted panes it is.
+	for (const [label, moved] of [
+		['workspace', { workspaceSlug: 'ws2', itemId: 'item-A', hostToken: 'apanel-1' }],
+		['item', { workspaceSlug: 'ws', itemId: 'item-B', hostToken: 'apanel-1' }],
+		['owning mount', { workspaceSlug: 'ws', itemId: 'item-A', hostToken: 'apanel-2' }],
+	] as const) {
+		it(`drops the request when the ${label} moves mid-resolution`, async () => {
+			// `CommentEditor` is reused across an item switch — its address
+			// changes under a mounted NodeView. The gesture belonged to the OLD
+			// address: emitting there opens a viewer over a pane the user has
+			// left, and emitting at the new one attributes the gesture to a
+			// different item.
+			editor = makeCommentEditor(target);
+
+			press(image(), 'Enter');
+			address = { ...moved };
+
+			expect(await opened()).toBe(0);
+
+			// The control: with the address settled, the very next gesture emits
+			// — so the drop above is the fence, not a composer that stopped
+			// working.
+			press(image(), 'Enter');
+			expect(await opened()).toBe(1);
+			expect(emitted[0].workspaceSlug).toBe(moved.workspaceSlug);
+			expect(emitted[0].itemId).toBe(moved.itemId);
+			expect(emitted[0].hostToken).toBe(moved.hostToken);
+		});
+	}
+
+	it('does not leave the NEW image dead when a swap lands mid-resolution', async () => {
+		// The one-at-a-time latch is per NodeView, and this NodeView deliberately
+		// SURVIVES a uuid swap (rotate/crop, or a peer's op) rather than being
+		// recreated. So a latch taken for the old attachment would still be held
+		// when the new one is clicked — and since a HEAD has no timeout, an
+		// activation that never settles would leave the image in front of the
+		// user permanently unopenable.
+		const pending = new Promise<never>(() => {});
+		probeMock.mockImplementation((_ws?: string, uuid?: string) =>
+			uuid === 'uuid-1'
+				? (pending as unknown as Promise<{ status: 'transient' }>)
+				: Promise.resolve({ status: 'ok', mime: 'image/png', size: 4096 } as never)
+		);
+		editor = makeEditor(target);
+
+		press(image(), 'Enter');
+		expect(await opened()).toBe(0);
+
+		// The swap the NodeView is built to survive.
+		editor.commands.setNodeSelection(1);
+		editor.commands.updateAttributes('attachmentImage', { uuid: 'uuid-2' });
+		await opened();
+
+		press(image(), 'Enter');
+		const requests = await opened();
+		expect(requests).toBe(1);
+		expect(emitted[0].attachmentId).toBe('uuid-2');
+	});
+
+	it('does not let a superseded activation unlock the one that replaced it', async () => {
+		// The other half of the swap fix, and the one it is easy to get wrong:
+		// the latch is released in TWO places now — the resolution's finalizer
+		// and the swap — so an unconditional release lets the OLD image's HEAD,
+		// landing late, unlock a request the NEW image is still holding. Two
+		// gestures then both emit, which is the duplicate the latch exists to
+		// prevent.
+		// ONE promise per attachment, handed to every caller — the real cache
+		// does exactly this (`fetchAttachmentMetadata` installs the in-flight
+		// promise and shares it), and it is load-bearing here: a fresh promise
+		// per call would leave the duplicate activation's continuation pending
+		// forever, hiding the very duplicate this test is about.
+		let releaseOld: () => void = () => {};
+		let releaseNew: () => void = () => {};
+		const oldProbe = new Promise((resolve) => {
+			releaseOld = () => resolve({ status: 'ok', mime: 'image/png', size: 1 });
+		});
+		const newProbe = new Promise((resolve) => {
+			releaseNew = () => resolve({ status: 'ok', mime: 'image/png', size: 4096 });
+		});
+		probeMock.mockImplementation(
+			(_ws?: string, uuid?: string) => (uuid === 'uuid-1' ? oldProbe : newProbe) as never
+		);
+		editor = makeEditor(target);
+
+		// A's activation goes in flight and is then superseded by a swap.
+		press(image(), 'Enter');
+		editor.commands.setNodeSelection(1);
+		editor.commands.updateAttributes('attachmentImage', { uuid: 'uuid-2' });
+		await opened();
+
+		// B's activation takes the latch...
+		press(image(), 'Enter');
+		await opened();
+		// ...and A's late answer must not hand it back.
+		releaseOld();
+		await opened();
+
+		// A second gesture while B is still resolving. With the latch correctly
+		// held this is a no-op; with it wrongly released, this starts a SECOND
+		// resolution and both emit.
+		press(image(), 'Enter');
+		releaseNew();
+
+		expect(await opened()).toBe(1);
+		expect(emitted[0].attachmentId).toBe('uuid-2');
+	});
+
+	it('drops a request whose image was swapped AWAY AND BACK', async () => {
+		// Comparing the uuid alone is not enough, and this is the interleaving
+		// that shows it: a rotate the user immediately undoes, or a peer's op
+		// reverted, puts the ORIGINAL attachment back under a request that is
+		// still resolving for it. It would then find its own uuid in place and
+		// open a viewer for a gesture made two swaps ago — against an image the
+		// user has since acted on twice.
+		let releaseFirst: () => void = () => {};
+		const firstProbe = new Promise((resolve) => {
+			releaseFirst = () => resolve({ status: 'ok', mime: 'image/png', size: 1 });
+		});
+		probeMock.mockImplementation(
+			(_ws?: string, uuid?: string) =>
+				(uuid === 'uuid-1'
+					? firstProbe
+					: Promise.resolve({ status: 'ok', mime: 'image/png', size: 4096 })) as never
+		);
+		editor = makeEditor(target);
+
+		press(image(), 'Enter');
+		expect(await opened()).toBe(0);
+
+		editor.commands.setNodeSelection(1);
+		editor.commands.updateAttributes('attachmentImage', { uuid: 'uuid-2' });
+		await opened();
+		editor.commands.setNodeSelection(1);
+		editor.commands.updateAttributes('attachmentImage', { uuid: 'uuid-1' });
+		await opened();
+		// The premise: the ORIGINAL attachment really is back under the node.
+		// Without it the stale request would be blocked by the uuid comparison
+		// and this test would pass for the wrong reason.
+		expect(image().getAttribute('data-attachment-id')).toBe('uuid-1');
+
+		releaseFirst();
+
+		expect(await opened()).toBe(0);
+	});
+
 	it('still opens an allowlisted raster type after the probe resolves', async () => {
 		// The control for the refusal above: same code path, same probe, same
 		// number of awaits — only the MIME differs.
-		probeMock.mockResolvedValue({ status: 'ok', mime: 'image/png' });
+		probeMock.mockResolvedValue({ status: 'ok', mime: 'image/png' , size: 4096 });
 		editor = makeEditor(target);
 		await settleProbe();
 		expect(probeMock).toHaveBeenCalled();
@@ -396,10 +761,10 @@ describe('inline body image — keyboard activation (DR-12)', () => {
 		expect(image().getAttribute('role')).toBe('button');
 		expect(openCount()).toBe(0);
 		press(image(), 'Enter');
-		expect(openCount()).toBe(1);
+		expect(await opened()).toBe(1);
 	});
 
-	it('makes a deleted image inert rather than a dead focus stop', () => {
+	it('makes a deleted image inert rather than a dead focus stop', async () => {
 		editor = makeEditor(target);
 		const img = image();
 		expect(img.getAttribute('role')).toBe('button');
@@ -414,7 +779,7 @@ describe('inline body image — keyboard activation (DR-12)', () => {
 		// no longer exists.
 		press(img, 'Enter');
 		click(img);
-		expect(openCount()).toBe(0);
+		expect(await opened()).toBe(0);
 	});
 
 	it('does not strand focus on an image that just went inert', () => {
@@ -430,7 +795,7 @@ describe('inline body image — keyboard activation (DR-12)', () => {
 		expect(document.activeElement).not.toBe(img);
 	});
 
-	it('gives a comment editor the same contract as an item body', () => {
+	it('gives a comment editor the same contract as an item body', async () => {
 		// CommentEditor.svelte configures AttachmentImage independently, so
 		// "works in the body" is not evidence it works in a comment.
 		editor = makeCommentEditor(target);
@@ -442,10 +807,10 @@ describe('inline body image — keyboard activation (DR-12)', () => {
 
 		expect(openCount()).toBe(0);
 		press(img, 'Enter');
-		expect(openCount()).toBe(1);
+		expect(await opened()).toBe(1);
 	});
 
-	it('will not ACTIVATE while the image is showing a load-failure placeholder', () => {
+	it('will not ACTIVATE while the image is showing a load-failure placeholder', async () => {
 		// Attributes are not the contract — activation is. Stripping role and
 		// tabindex hides the image from Tab, but a stale event still in flight, a
 		// synthetic one, or focus that predates the failure all reach the
@@ -460,7 +825,7 @@ describe('inline body image — keyboard activation (DR-12)', () => {
 		press(img, ' ');
 		click(img);
 
-		expect(openCount()).toBe(0);
+		expect(await opened()).toBe(0);
 	});
 
 	it('is not a focus stop while the image is showing a load-failure placeholder', () => {

--- a/web/src/lib/components/editor/attachmentImageKeyboard.svelte.test.ts
+++ b/web/src/lib/components/editor/attachmentImageKeyboard.svelte.test.ts
@@ -40,8 +40,16 @@ const deletionListeners = new Set<(uuid: string) => void>();
 // Open-viewer requests, captured RAW — before the channel's addressability
 // filter, so what is asserted is what THIS NodeView produced.
 const emitted: Array<Record<string, unknown>> = [];
+// Open-the-PANEL requests, same treatment. TASK-2434 makes this NodeView a
+// producer on BOTH channels — a non-allowlisted MIME is redirected to the
+// options panel rather than refused — so a spec that captured only the viewer
+// channel could not tell a redirect from a silent drop, which is exactly the
+// distinction the matrix is about.
+const panelEmitted: Array<Record<string, unknown>> = [];
 vi.mock('$lib/attachments/events', () => ({
-	notifyAttachmentPanelOpen: () => {},
+	notifyAttachmentPanelOpen: (event: Record<string, unknown>) => {
+		panelEmitted.push(event);
+	},
 	notifyViewerOpen: (event: Record<string, unknown>) => {
 		emitted.push(event);
 	},
@@ -66,9 +74,16 @@ type ProbeResult =
 const probeMock = vi.fn<(ws?: string, uuid?: string) => Promise<ProbeResult>>(async () => ({
 	status: 'transient',
 }));
+// The load-failure path's REVALIDATION, separable from the cached read above.
+// It delegates to `probeMock` by default, so for almost every test the two are
+// one mock and answer alike. Exactly one test needs them to differ: proving
+// that a 404 reaching the ACTIVATION branch upgrades an already-hidden
+// placeholder requires the error path's own probe not to be the thing that
+// latches it, or the assertion could not tell the two routes apart.
+const revalidateMock = vi.fn<(ws?: string, uuid?: string) => Promise<ProbeResult>>();
 vi.mock('./attachment-metadata', () => ({
 	fetchAttachmentMetadata: (ws: string, uuid: string) => probeMock(ws, uuid),
-	revalidateAttachmentMetadata: (ws: string, uuid: string) => probeMock(ws, uuid),
+	revalidateAttachmentMetadata: (ws: string, uuid: string) => revalidateMock(ws, uuid),
 	invalidateAttachmentMetadata: () => {},
 	mimeToFormat: () => null,
 }));
@@ -133,7 +148,15 @@ function makeCommentEditor(element: HTMLElement): Editor {
 	});
 }
 
-/** How many times activation actually fired. One request per open. */
+/**
+ * How many times activation asked for the VIEWER. One request per open.
+ *
+ * Deliberately not "how many times activation fired": since TASK-2434 an
+ * activation can instead land on the panel channel, which `panelEmitted`
+ * counts. Reading this as a count of activations would make every redirect
+ * look like a dropped gesture — the exact confusion the two arrays exist to
+ * keep apart.
+ */
 function openCount(): number {
 	return emitted.length;
 }
@@ -208,7 +231,10 @@ describe('inline body image — keyboard activation (DR-12)', () => {
 		// `transient` default would make every "opens exactly once" test below
 		// assert 0 for a reason that has nothing to do with the keyboard.
 		probeMock.mockResolvedValue({ status: 'ok' as const, mime: 'image/png', size: 4096 });
+		revalidateMock.mockClear();
+		revalidateMock.mockImplementation((ws?: string, uuid?: string) => probeMock(ws, uuid));
 		emitted.length = 0;
+		panelEmitted.length = 0;
 		host = document.body.appendChild(document.createElement('div'));
 		target = host.appendChild(document.createElement('div'));
 	});
@@ -218,6 +244,7 @@ describe('inline body image — keyboard activation (DR-12)', () => {
 		editor = undefined;
 		host.remove();
 		emitted.length = 0;
+		panelEmitted.length = 0;
 		document.querySelectorAll('.timeline-viewer-stub').forEach((d) => d.remove());
 	});
 
@@ -465,7 +492,7 @@ describe('inline body image — keyboard activation (DR-12)', () => {
 		expect(await opened()).toBe(0);
 	});
 
-	it('refuses a probed non-raster type through the KEYBOARD, not just the mouse', async () => {
+	it('keeps a probed non-raster type OUT of the viewer through the KEYBOARD, not just the mouse', async () => {
 		// The gate used to live inside the click handler. A keyboard path that
 		// emitted on its own would have sailed straight past it, so the refusal
 		// is asserted on the route that would have bypassed it.
@@ -488,12 +515,570 @@ describe('inline body image — keyboard activation (DR-12)', () => {
 		press(image(), 'Enter');
 		expect(await opened()).toBe(0);
 
-		// And it stops being a focus stop at all, rather than announcing itself
-		// as a button that does nothing.
-		expect(image().getAttribute('role')).toBeNull();
-		expect(image().getAttribute('tabindex')).toBeNull();
-		expect(image().getAttribute('aria-label')).toBeNull();
+		// TASK-2434: it is a REDIRECT, not a refusal. Asserting only "the viewer
+		// did not open" would be satisfied by an implementation that dropped the
+		// gesture on the floor — which is what this used to do, and the dead
+		// focus stop the matrix exists to close.
+		expect(panelEmitted).toHaveLength(1);
+		// So it stays a real control, and it says where it goes.
+		expect(image().getAttribute('role')).toBe('button');
+		expect(image().getAttribute('tabindex')).toBe('0');
+		expect(image().getAttribute('aria-label')).toBe('Attachment options: A diagram');
 	});
+
+	it('redirects a non-allowlisted MIME to the panel, with the whole payload', async () => {
+		// The `ok` + not-allowlisted arm of the matrix, asserted on what is
+		// EMITTED. A count alone is satisfied by an event of any shape, and the
+		// panel's routing fields are exactly what a producer gets wrong: the
+		// address decides which of two mounted hosts opens it, and the three
+		// metadata fields are what the panel renders before its own fetch lands.
+		probeMock.mockResolvedValue({ status: 'ok', mime: 'application/pdf', size: 1234 });
+		editor = makeEditor(target);
+		const img = image();
+
+		press(img, 'Enter');
+		expect(await opened()).toBe(0);
+
+		expect(panelEmitted).toEqual([
+			{
+				attachmentId: 'uuid-1',
+				itemId: 'item-A',
+				hostToken: 'apanel-1',
+				anchor: img,
+				// No filename anywhere on this surface — the node's attrs carry
+				// none and the HEAD does not either. Null, not a fabricated one.
+				filename: null,
+				mime_type: 'application/pdf',
+				size_bytes: 1234,
+			},
+		]);
+		// It ASKED. A payload alone is satisfiable by an implementation that
+		// skipped the probe and assumed a MIME — which is precisely the gate
+		// this whole path exists to close.
+		expect(probeMock).toHaveBeenCalled();
+		// And the pending affordance is cleared on THIS branch too. The
+		// finalizer is shared, but a clear moved into the viewer branch would
+		// leave every redirect permanently `aria-busy`.
+		expect(img.getAttribute('aria-busy')).toBeNull();
+		expect(img.style.cursor).toBe('');
+	});
+
+	it('keeps redirecting on every activation, not just the first', async () => {
+		// The regression the semantics rewrite exists to prevent, and the one an
+		// attribute-only assertion would miss entirely. Activation now WRITES the
+		// resolved MIME onto the node. If the activation gate still refused a
+		// known non-allowlisted MIME — as it did before this task — the first tap
+		// would open the panel and every tap after it would silently do nothing,
+		// because the gate would be reading the answer the first tap recorded.
+		probeMock.mockResolvedValue({ status: 'ok', mime: 'image/svg+xml', size: 10 });
+		editor = makeEditor(target);
+		const img = image();
+
+		press(img, 'Enter');
+		await opened();
+		expect(panelEmitted).toHaveLength(1);
+
+		// The premise: the MIME really is on the node now (the label proves it,
+		// and it is the same state the gate would have been reading).
+		expect(img.getAttribute('aria-label')).toBe('Attachment options: A diagram');
+
+		press(img, 'Enter');
+		await opened();
+		click(img);
+		await opened();
+
+		expect(panelEmitted).toHaveLength(3);
+		expect(await opened()).toBe(0);
+		// The LAST one, not just the count: a redirect that kept firing with a
+		// payload frozen at the first gesture would be a count of three and a
+		// panel that opens on whatever the node used to be.
+		expect(panelEmitted[2]).toMatchObject({
+			attachmentId: 'uuid-1',
+			itemId: 'item-A',
+			hostToken: 'apanel-1',
+			anchor: img,
+			mime_type: 'image/svg+xml',
+			size_bytes: 10,
+		});
+	});
+
+	it('never opens the panel for a MIME the viewer WILL take', async () => {
+		// The other direction of the redirect, which a one-sided spec would leave
+		// free: an implementation that emitted BOTH events would satisfy every
+		// panel assertion above and open two surfaces from one gesture.
+		editor = makeEditor(target);
+
+		press(image(), 'Enter');
+
+		expect(await opened()).toBe(1);
+		expect(panelEmitted).toEqual([]);
+		// Reached by ASKING, not by assuming: an implementation that skipped the
+		// probe for images it liked the look of would pass the two assertions
+		// above and be exactly the bypass TASK-2433 closed.
+		expect(probeMock).toHaveBeenCalled();
+	});
+
+	it('latches the permanent placeholder on an authoritative 404, and opens nothing', async () => {
+		// The `missing` arm. `missing` is the ONLY result that may latch (DR-17),
+		// and the latch is what keeps editor undo from resurrecting a deleted
+		// attachment as a live-looking node.
+		probeMock.mockResolvedValue({ status: 'missing' });
+		editor = makeEditor(target);
+		const img = image();
+
+		press(img, 'Enter');
+		await opened();
+
+		expect(await opened()).toBe(0);
+		expect(panelEmitted).toEqual([]);
+
+		const placeholder = target.querySelector<HTMLElement>('.attachment-missing');
+		expect(img.style.display).toBe('none');
+		expect(placeholder?.style.display).not.toBe('none');
+		// PERMANENT, and the copy says so: a deleted row is not retryable, so the
+		// placeholder is deliberately NOT a control. A retryable placeholder here
+		// would invite a click that can only 404.
+		expect(placeholder?.title).toBe('This attachment has been deleted');
+		expect(placeholder?.getAttribute('role')).toBeNull();
+		expect(placeholder?.getAttribute('tabindex')).toBeNull();
+		// And the latch holds against BOTH ways back. A click cannot retry it...
+		placeholder?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+		expect(img.style.display).toBe('none');
+		// ...and neither can a `load` that was already in flight when the 404
+		// landed. The implementation stops that twice over — the latch detaches
+		// the listener AND `resetMissing` refuses to run once `deleted` — so this
+		// pins the OUTCOME rather than either mechanism, which is the honest
+		// claim to make about a guard with a redundant partner.
+		img.dispatchEvent(new Event('load'));
+		expect(img.style.display).toBe('none');
+		expect(img.getAttribute('aria-busy')).toBeNull();
+	});
+
+	it('leaves a transient failure RETRYABLE — no open, no latch', async () => {
+		// The `transient` arm, and the dead focus stop TASK-2433 left behind: it
+		// emitted nothing and did nothing, so a focused image announced itself as
+		// a button and silently swallowed every press.
+		probeMock.mockResolvedValue({ status: 'transient' });
+		editor = makeEditor(target);
+		const img = image();
+		img.focus();
+
+		press(img, 'Enter');
+		await opened();
+
+		expect(await opened()).toBe(0);
+		expect(panelEmitted).toEqual([]);
+
+		const placeholder = target.querySelector<HTMLElement>('.attachment-missing');
+		expect(img.style.display).toBe('none');
+		expect(placeholder?.style.display).not.toBe('none');
+		// RETRYABLE, not latched — the copy, the semantics and the focus all say
+		// the same thing. This is the assertion that separates it from `missing`:
+		// an implementation that treated the two alike would pass every "did not
+		// open" check above and permanently strand a row that is perfectly fine.
+		expect(placeholder?.title).toContain('Click to retry');
+		expect(placeholder?.getAttribute('role')).toBe('button');
+		expect(placeholder?.getAttribute('tabindex')).toBe('0');
+		// The keypress that reported the failure must not drop focus to <body>.
+		expect(document.activeElement).toBe(placeholder);
+
+		// And the latch really is absent: Retry restores the image, which
+		// `missing` above cannot do.
+		expect(img.getAttribute('aria-busy')).toBeNull();
+		const srcBefore = img.getAttribute('src');
+		placeholder?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+		expect(img.style.display).toBe('');
+		expect(placeholder?.style.display).toBe('none');
+		// Retry means a NEW REQUEST, not just an un-hidden element: without the
+		// cache-busting query the browser replays the failed entry and the retry
+		// is theatre. Restoring the DOM alone would pass the two lines above.
+		expect(img.getAttribute('src')).not.toBe(srcBefore);
+		expect(img.getAttribute('src')).toContain('retry=');
+	});
+
+	it('does not let a transient failure latch permanently across a recovery', async () => {
+		// DR-17's rule stated over TIME rather than over one result: only an
+		// authoritative 404 latches, so a blip followed by a healthy probe must
+		// leave the image fully openable again. An implementation that reused the
+		// `missing` path for `transient` would fail here and NOWHERE else — every
+		// single-shot assertion above would still pass.
+		probeMock.mockResolvedValue({ status: 'transient' });
+		editor = makeEditor(target);
+		const img = image();
+
+		press(img, 'Enter');
+		await opened();
+		const placeholder = target.querySelector<HTMLElement>('.attachment-missing');
+		// The premise, and it is load-bearing: without it this passes against an
+		// implementation whose `transient` arm does nothing at all — there would
+		// be no latch to survive, and the recovery below would prove nothing.
+		expect(img.style.display).toBe('none');
+		expect(placeholder?.getAttribute('role')).toBe('button');
+		placeholder?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+		probeMock.mockResolvedValue({ status: 'ok', mime: 'image/png', size: 4096 });
+		press(img, 'Enter');
+
+		expect(await opened()).toBe(1);
+	});
+
+	it('shows a pending affordance while the MIME is still resolving', async () => {
+		// A cold probe is a round trip, and a click that does nothing for its
+		// duration reads as broken. Deliberately minimal: `aria-busy` and a
+		// cursor, no new chrome.
+		let release: () => void = () => {};
+		probeMock.mockImplementation(
+			() =>
+				new Promise((resolve) => {
+					release = () => resolve({ status: 'ok', mime: 'image/png', size: 4096 });
+				})
+		);
+		editor = makeEditor(target);
+		const img = image();
+		expect(img.getAttribute('aria-busy')).toBeNull();
+
+		press(img, 'Enter');
+
+		// Set SYNCHRONOUSLY with the gesture — a pending state that waits for a
+		// tick is not covering the wait it exists for.
+		expect(img.getAttribute('aria-busy')).toBe('true');
+		expect(img.style.cursor).toBe('progress');
+
+		release();
+		expect(await opened()).toBe(1);
+		// And cleared, or the image announces itself as permanently busy.
+		expect(img.getAttribute('aria-busy')).toBeNull();
+		expect(img.style.cursor).toBe('');
+	});
+
+	it('clears the pending affordance when a swap supersedes the request', async () => {
+		// The finalizer only runs for the request that still holds the latch, so
+		// a swap has to clear the pending state itself — otherwise a HEAD that
+		// never settles leaves the NEW image permanently `aria-busy`.
+		probeMock.mockImplementation(() => new Promise<never>(() => {}));
+		editor = makeEditor(target);
+		press(image(), 'Enter');
+		expect(image().getAttribute('aria-busy')).toBe('true');
+
+		// The SAME element across the swap: this NodeView deliberately survives a
+		// uuid change, and reacquiring by selector would let a destroy/recreate
+		// implementation pass without ever clearing anything.
+		const before = image();
+		editor.commands.setNodeSelection(1);
+		editor.commands.updateAttributes('attachmentImage', { uuid: 'uuid-2' });
+
+		expect(image()).toBe(before);
+		expect(before.getAttribute('aria-busy')).toBeNull();
+		expect(before.style.cursor).toBe('');
+	});
+
+	it('opens NOTHING when a delete lands mid-probe and the answer comes back ok', async () => {
+		// The race the uuid comparison structurally cannot catch: a delete does
+		// not change which attachment the node points at, so `forUuid` is still
+		// current when the probe resolves — with a perfectly valid `ok` describing
+		// a row the server has since dropped.
+		//
+		// The implementation states this TWICE — an explicit `deleted` re-check
+		// and `canActivate()`'s hidden-placeholder clause — and mutation testing
+		// confirms this spec fails only when BOTH are gone. That is the honest
+		// claim: it pins the BEHAVIOUR, not either line. (The two are equivalent
+		// today only because every path that sets `deleted` also hides the image;
+		// nothing enforces that, which is why the check is stated on its own
+		// terms rather than inferred from the placeholder.)
+		//
+		// A test that let the probe resolve BEFORE the delete would pass against
+		// an implementation with no `deleted` check at all, so the ordering here
+		// is the whole point: the answer is held until after the broadcast.
+		let release: () => void = () => {};
+		probeMock.mockImplementation(
+			() =>
+				new Promise((resolve) => {
+					release = () => resolve({ status: 'ok', mime: 'image/png', size: 4096 });
+				})
+		);
+		editor = makeEditor(target);
+		const img = image();
+
+		press(img, 'Enter');
+		for (const fn of deletionListeners) fn('uuid-1');
+		// The premise: the node still points at the very attachment the probe is
+		// about. Without this the drop could be the uuid fence doing the work.
+		expect(img.getAttribute('data-attachment-id')).toBe('uuid-1');
+		release();
+
+		expect(await opened()).toBe(0);
+		// BOTH channels. A `deleted` check placed after the allowlist branch
+		// would still leak the redirect.
+		expect(panelEmitted).toEqual([]);
+	});
+
+	it('opens NO PANEL either when a delete lands mid-probe on a non-raster type', async () => {
+		// The same race down the redirect branch, which is new surface: the
+		// `missing`/`transient`/`ok` split gave the continuation three more places
+		// to act on a row that is gone.
+		let release: () => void = () => {};
+		probeMock.mockImplementation(
+			() =>
+				new Promise((resolve) => {
+					release = () => resolve({ status: 'ok', mime: 'image/svg+xml', size: 10 });
+				})
+		);
+		editor = makeEditor(target);
+
+		press(image(), 'Enter');
+		for (const fn of deletionListeners) fn('uuid-1');
+		release();
+
+		await opened();
+		expect(panelEmitted).toEqual([]);
+		expect(await opened()).toBe(0);
+
+		// THE CONTROL, and it is the whole test: `expect no panel` is satisfied
+		// by an implementation that has no redirect at all — the pre-TASK-2434
+		// binary refusal passes it outright. So prove the branch works on an
+		// undeleted node under the identical probe.
+		editor.destroy();
+		probeMock.mockResolvedValue({ status: 'ok', mime: 'image/svg+xml', size: 10 });
+		editor = makeEditor(target);
+		press(image(), 'Enter');
+		await opened();
+		expect(panelEmitted).toHaveLength(1);
+	});
+
+	// The address fence, restated on the PANEL branch. It is a second emission
+	// site with its own copy of the captured address, so the three comparisons
+	// have to hold for it independently — a fence that only guarded the viewer
+	// would let a redirect open a panel over a pane the user has left.
+	for (const [label, moved] of [
+		['workspace', { workspaceSlug: 'ws2', itemId: 'item-A', hostToken: 'apanel-1' }],
+		['item', { workspaceSlug: 'ws', itemId: 'item-B', hostToken: 'apanel-1' }],
+		['owning mount', { workspaceSlug: 'ws', itemId: 'item-A', hostToken: 'apanel-2' }],
+	] as const) {
+		it(`drops the PANEL redirect when the ${label} moves mid-resolution`, async () => {
+			probeMock.mockResolvedValue({ status: 'ok', mime: 'image/svg+xml', size: 10 });
+			editor = makeCommentEditor(target);
+
+			press(image(), 'Enter');
+			address = { ...moved };
+
+			await opened();
+			expect(panelEmitted).toEqual([]);
+
+			// The control: settled, the next gesture DOES redirect — so the drop
+			// above is the fence, not a branch that never worked.
+			press(image(), 'Enter');
+			await opened();
+			expect(panelEmitted).toHaveLength(1);
+			expect(panelEmitted[0].itemId).toBe(moved.itemId);
+			expect(panelEmitted[0].hostToken).toBe(moved.hostToken);
+		});
+	}
+
+	it('emits with the address CAPTURED at the gesture, even if the reader mutates in place', async () => {
+		// The fence holds three PRIMITIVES, not the object the reader returned.
+		// Both live readers build a fresh object literal per call, so holding the
+		// reference would be safe — for that reason alone, which no interface
+		// states. This pins the independence: a reader that hands back ONE object
+		// and mutates it in place would, if the fence held the reference, rewrite
+		// the snapshot it compares against and pass unconditionally.
+		const shared = { workspaceSlug: 'ws', itemId: 'item-A', hostToken: 'apanel-1' };
+		address = shared;
+		let release: () => void = () => {};
+		probeMock.mockImplementation(
+			() =>
+				new Promise((resolve) => {
+					release = () => resolve({ status: 'ok', mime: 'image/png', size: 4096 });
+				})
+		);
+		editor = makeCommentEditor(target);
+
+		press(image(), 'Enter');
+		// The host "moves" by mutating the object the reader keeps handing out.
+		shared.itemId = 'item-B';
+		shared.hostToken = 'apanel-2';
+		release();
+
+		// Dropped. Holding the reference would compare item-B against item-B.
+		expect(await opened()).toBe(0);
+	});
+
+	it('DOES emit when the address leaves and returns (A→B→A) — documented, accepted', async () => {
+		// The fence compares VALUES, so an address that round-trips reads as
+		// unchanged. Reachable: the pane's `ItemDetail` has no `{#key}`
+		// (PLAN-2105 / TASK-2112), so an A→B→A item switch keeps one host token
+		// and the composer it owns is reused across it.
+		//
+		// PINNED AS THE CURRENT BEHAVIOUR, not asserted as ideal. It is accepted
+		// because the outcome differs from what the fence prevents — the user is
+		// back on the pane, and the gesture is not re-attributed: the same node,
+		// the same attachment, the same host. Contrast the uuid A→B→A case below,
+		// which IS dropped, because there the SUBJECT of the gesture changed.
+		//
+		// Telling A→B→A from A needs an epoch on `AttachmentHostAddress` that
+		// every host bumps; this NodeView only READS the address, so a B between
+		// the two reads is invisible to it by construction. When that epoch
+		// lands, this expectation flips to 0 and this comment is its changelog.
+		let release: () => void = () => {};
+		probeMock.mockImplementation(
+			() =>
+				new Promise((resolve) => {
+					release = () => resolve({ status: 'ok', mime: 'image/png', size: 4096 });
+				})
+		);
+		editor = makeCommentEditor(target);
+		const original = { ...address };
+
+		press(image(), 'Enter');
+		address = { workspaceSlug: 'ws', itemId: 'item-B', hostToken: 'apanel-1' };
+		address = { ...original };
+		release();
+
+		expect(await opened()).toBe(1);
+		// And it emits at A — not at the B it passed through.
+		expect(emitted[0].itemId).toBe(original.itemId);
+		expect(emitted[0].hostToken).toBe(original.hostToken);
+	});
+
+	it('UPGRADES an already-hidden retryable placeholder when a 404 arrives', async () => {
+		// The transient→missing transition, and the only DR-17 boundary that had
+		// no test. The mutant it exists for is exact: an implementation that
+		// processed `missing` only when `canActivate()` is true would pass every
+		// other test in this file, because the placeholder-showing state is
+		// precisely where `canActivate()` is already false. That is why the
+		// `missing` branch deliberately runs BEFORE the presentability check — a
+		// 404 is authoritative whatever the node happens to be showing.
+		//
+		// Reaching that state takes care. An activation cannot START while the
+		// placeholder is up (the gesture-time gate refuses), and Retry UN-hides
+		// the image — so a naive "fail, retry, 404" sequence lands the 404 on a
+		// VISIBLE image and tests nothing new. The image has to go behind the
+		// placeholder DURING the await, which is what the load `error` does.
+		let release: () => void = () => {};
+		probeMock.mockImplementation(
+			() =>
+				new Promise((resolve) => {
+					release = () => resolve({ status: 'missing' });
+				})
+		);
+		// The error path runs its OWN revalidation, which latches on a 404 too.
+		// Keeping it transient is what makes the latch below attributable to the
+		// activation branch rather than to the load failure's probe.
+		revalidateMock.mockResolvedValue({ status: 'transient' });
+		editor = makeEditor(target);
+		const img = image();
+
+		press(img, 'Enter');
+		img.dispatchEvent(new Event('error'));
+		await opened();
+
+		const placeholder = target.querySelector<HTMLElement>('.attachment-missing');
+		// The premise, and the whole point: hidden, and still RETRYABLE. Without
+		// both, the 404 below would be landing on a state some other test covers.
+		expect(img.style.display).toBe('none');
+		expect(placeholder?.getAttribute('role')).toBe('button');
+		expect(placeholder?.title).toContain('Click to retry');
+
+		// The 404 lands while the placeholder is up.
+		release();
+		await opened();
+
+		// Upgraded: permanent, inert, no longer inviting a retry that can only
+		// 404 again.
+		expect(placeholder?.title).toBe('This attachment has been deleted');
+		expect(placeholder?.getAttribute('role')).toBeNull();
+		expect(placeholder?.getAttribute('tabindex')).toBeNull();
+		// And the latch holds — a retry click cannot undo an authoritative 404.
+		placeholder?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+		expect(img.style.display).toBe('none');
+		expect(await opened()).toBe(0);
+		expect(panelEmitted).toEqual([]);
+	});
+
+	it('opens nothing when a load failure hides the image mid-probe and the MIME is FINE', async () => {
+		// The post-await `canActivate()` guard, which nothing else reaches. The
+		// spec below ("will not ACTIVATE while the image is showing a
+		// load-failure placeholder") fails the load FIRST and gestures after, so
+		// it is stopped by the GESTURE-time gate and would pass with the
+		// post-await check deleted entirely.
+		//
+		// This is the other order, and it is the reachable one: the gesture lands
+		// on a healthy image, the load fails while the HEAD is in flight, and the
+		// HEAD comes back with a perfectly good `image/png`. Nothing is deleted
+		// and nothing is missing — the only reason not to open is that there is
+		// no longer an image on screen to open. Emitting here would put a viewer
+		// over a placeholder.
+		let release: () => void = () => {};
+		probeMock.mockImplementation(
+			() =>
+				new Promise((resolve) => {
+					release = () => resolve({ status: 'ok', mime: 'image/png', size: 4096 });
+				})
+		);
+		// The error path's own revalidation stays transient, so the placeholder
+		// remains the RETRYABLE one — this test is about a healthy MIME meeting a
+		// hidden image, not about a latch.
+		revalidateMock.mockResolvedValue({ status: 'transient' });
+		editor = makeEditor(target);
+		const img = image();
+
+		press(img, 'Enter');
+		img.dispatchEvent(new Event('error'));
+		const placeholder = target.querySelector<HTMLElement>('.attachment-missing');
+		// The premise: hidden, retryable, NOT deleted — so every other guard in
+		// the continuation (uuid, generation, `deleted`) is satisfied and only
+		// presentability is left to do the work.
+		expect(img.style.display).toBe('none');
+		expect(placeholder?.getAttribute('role')).toBe('button');
+
+		release();
+		await opened();
+
+		expect(await opened()).toBe(0);
+		expect(panelEmitted).toEqual([]);
+		// And it stayed retryable: refusing to open must not cost the user the
+		// retry affordance.
+		expect(placeholder?.getAttribute('role')).toBe('button');
+	});
+
+	it('emits SYNCHRONOUSLY with the fence check, not on a later turn', async () => {
+		// The fence's correctness rests on the check and the emit being
+		// adjacent: anything queued between them — a timer, a microtask hop — is
+		// a new window for the address to go stale across, which is the whole
+		// hazard the fence exists for. Nothing else in this file would notice a
+		// refactor that queued delivery, because every other assertion goes
+		// through `opened()`, which waits two MACROtask turns and would happily
+		// observe a `setTimeout(0)` emission.
+		//
+		// So: resolve the probe and read the count after a bounded number of
+		// MICROtasks. A delivery queued behind a timer cannot be observed here;
+		// a synchronous one always is.
+		let release: () => void = () => {};
+		probeMock.mockImplementation(
+			() =>
+				new Promise((resolve) => {
+					release = () => resolve({ status: 'ok', mime: 'image/png', size: 4096 });
+				})
+		);
+		editor = makeEditor(target);
+
+		press(image(), 'Enter');
+		release();
+
+		// Three microtasks is generous for the implementation's own `.then`
+		// chain and still strictly inside the current macrotask.
+		await Promise.resolve();
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(emitted).toHaveLength(1);
+	});
+
+	// NOTE, deliberately not a test: "stamps the CAPTURED address rather than a
+	// re-read one" is UNOBSERVABLE from outside this function, and writing a test
+	// that appears to prove it would be worse than leaving the gap named. The
+	// fence refuses to emit whenever the two differ, so every emission happens in
+	// a state where captured and re-read are equal — a spec that moved the address
+	// away and back would assert the same values under either implementation. The
+	// enforceable half is the drop, and that is asserted per field above.
 
 	it('refuses an UNPROBED non-raster type — the gesture that beats the lazy probe', async () => {
 		// The bypass this task's revised gate closes, and the one the test above
@@ -520,6 +1105,10 @@ describe('inline body image — keyboard activation (DR-12)', () => {
 		// And it did ask — a refusal reached by never probing at all would be
 		// the same count for the wrong reason.
 		expect(probeMock).toHaveBeenCalled();
+		// TASK-2434: and neither gesture was DROPPED. Asserting only "no viewer"
+		// is satisfied by the silent return this task replaced; the unprobed
+		// gesture has to reach the panel exactly as the probed one does.
+		expect(panelEmitted).toHaveLength(2);
 	});
 
 	it('emits once when two gestures land inside one resolution window', async () => {
@@ -587,6 +1176,10 @@ describe('inline body image — keyboard activation (DR-12)', () => {
 		press(image(), 'Enter');
 
 		expect(await opened()).toBe(0);
+		// And nothing else opened either — `missing` is the one result with no
+		// destination at all. An implementation that fell through to the panel
+		// redirect would offer options for a row that is gone.
+		expect(panelEmitted).toEqual([]);
 	});
 
 	it('drops the request when the NodeView is torn down mid-resolution', async () => {
@@ -629,6 +1222,10 @@ describe('inline body image — keyboard activation (DR-12)', () => {
 			// working.
 			press(image(), 'Enter');
 			expect(await opened()).toBe(1);
+			// The probe ran under the address the GESTURE happened at — the
+			// workspace keys the metadata cache, so probing under the wrong one
+			// answers a question about a different workspace's row.
+			expect(probeMock).toHaveBeenLastCalledWith(moved.workspaceSlug, 'uuid-1');
 			expect(emitted[0].workspaceSlug).toBe(moved.workspaceSlug);
 			expect(emitted[0].itemId).toBe(moved.itemId);
 			expect(emitted[0].hostToken).toBe(moved.hostToken);

--- a/web/src/lib/components/editor/attachmentImageKeyboard.svelte.test.ts
+++ b/web/src/lib/components/editor/attachmentImageKeyboard.svelte.test.ts
@@ -1,0 +1,483 @@
+// The inline body image's keyboard contract (PLAN-2392 DR-12 / TASK-2432).
+//
+// An inline `![alt](pad-attachment:UUID)` in an item body or a comment renders
+// through the AttachmentImage NodeView, and until now that `<img>` opened the
+// viewer on click and was unreachable by any other means: no role, no tabindex,
+// no name. This spec pins the button contract that closes that, and — more
+// importantly — pins the two ways the contract is easy to get WRONG:
+//
+//   - activation firing TWICE. A keyed remount or a fast dialog can hide a
+//     duplicate visually, so every activation assertion here is a COUNT
+//     (`dialog.attachment-image-lightbox` elements in the document), never a
+//     truthiness check. `toBe(1)` fails on 2; `not.toBeNull()` does not.
+//
+//   - the KEYBOARD path bypassing the MIME gate. The gate used to live inside
+//     the click handler, which made it a property of the mouse. Both routes now
+//     call one `activate()`, and the refusal is asserted through the KEYBOARD,
+//     which is the assertion that would have caught a second emitter.
+//
+// Driven through a REAL Tiptap editor, like the placeholder spec next door: the
+// semantics live on imperative NodeView DOM and a hand-built element would pin
+// nothing about the code under test.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Editor } from '@tiptap/core';
+import StarterKit from '@tiptap/starter-kit';
+import { isEditorOwnedImage } from '$lib/attachments/editorOwnedImage';
+
+const deletionListeners = new Set<(uuid: string) => void>();
+vi.mock('$lib/attachments/events', () => ({
+	notifyAttachmentPanelOpen: () => {},
+	registerAttachmentDeletionListener: (fn: (uuid: string) => void) => {
+		deletionListeners.add(fn);
+		return () => deletionListeners.delete(fn);
+	},
+}));
+
+const probeMock = vi.fn(async () => ({ status: 'transient' as const }));
+vi.mock('./attachment-metadata', () => ({
+	fetchAttachmentMetadata: () => probeMock(),
+	revalidateAttachmentMetadata: () => probeMock(),
+	invalidateAttachmentMetadata: () => {},
+	mimeToFormat: () => null,
+}));
+
+const { AttachmentImage } = await import('./attachment-image');
+
+const BODY_CONTENT = '<p><img data-attachment-id="uuid-1" src="/api/v1/x" alt="A diagram"></p>';
+
+/** The item-body configuration (Editor.svelte): transforms enabled. */
+function makeEditor(element: HTMLElement, content: string = BODY_CONTENT): Editor {
+	return new Editor({
+		element,
+		extensions: [
+			StarterKit,
+			AttachmentImage.configure({
+				workspaceSlug: 'ws',
+				getDownloadUrl: (uuid: string, variant?: string) =>
+					`/api/v1/workspaces/ws/attachments/${uuid}?variant=${variant ?? 'thumb-md'}`,
+				address: () => ({ workspaceSlug: 'ws', itemId: 'item-A', hostToken: 'apanel-1' }),
+				supportedFormats: ['png'],
+				transform: async () => {
+					throw new Error('not used');
+				},
+			}),
+		],
+		content,
+		editable: true,
+	});
+}
+
+/**
+ * The COMMENT configuration, copied from CommentEditor.svelte: it configures
+ * AttachmentImage independently, with transforms deliberately switched off.
+ * Asserted separately because "the other surface configures it too" is exactly
+ * the kind of thing that gets the behaviour only on the surface you tested.
+ */
+function makeCommentEditor(element: HTMLElement): Editor {
+	return new Editor({
+		element,
+		extensions: [
+			StarterKit,
+			AttachmentImage.configure({
+				getDownloadUrl: (uuid: string) => `/api/v1/workspaces/ws/attachments/${uuid}`,
+				workspaceSlug: 'ws',
+				address: () => ({ workspaceSlug: 'ws', itemId: 'item-A', hostToken: 'apanel-1' }),
+				supportedFormats: [] as string[],
+				transform: async () => {
+					throw new Error('Image transforms are not available in comments.');
+				},
+			}),
+		],
+		content: BODY_CONTENT,
+		editable: true,
+	});
+}
+
+/** How many times activation actually fired. One dialog per open. */
+function openCount(): number {
+	return document.querySelectorAll('dialog.attachment-image-lightbox').length;
+}
+
+/**
+ * A stand-in for ItemTimeline's delegated keydown handler, built from the same
+ * pieces as the real one: the same `img[data-attachment-id]` selector, the same
+ * activation keys, the same modifier guard, and — critically — the same
+ * `isEditorOwnedImage` ownership check that keeps it off a live editor's DOM.
+ *
+ * It OPENS rather than just counting. A counter alone proves the event escaped
+ * but leaves openCount() at 1, so the failure that actually matters — two
+ * viewers on screen from one keypress — would not show up in the assertion.
+ */
+function timelineDelegation(
+	onFire: () => void,
+	opts: { ownership: boolean } = { ownership: true }
+): (e: Event) => void {
+	return (e: Event) => {
+		const ev = e as KeyboardEvent;
+		if (ev.key !== 'Enter' && ev.key !== ' ') return;
+		if (ev.ctrlKey || ev.metaKey || ev.altKey || ev.shiftKey) return;
+		const img = (e.target as HTMLElement | null)?.closest<HTMLElement>(
+			'img[data-attachment-id]'
+		);
+		if (!img) return;
+		// `ownership: false` is the PRE-TASK-2432 shape, kept deliberately: the
+		// node's own stopPropagation has to hold up against a delegated opener
+		// that does NOT know to skip editor-owned DOM, because ItemTimeline is
+		// not the only surface that could ever delegate over one.
+		if (opts.ownership && isEditorOwnedImage(img)) return;
+		onFire();
+		const dialog = document.createElement('dialog');
+		dialog.className = 'attachment-image-lightbox';
+		document.body.appendChild(dialog);
+	};
+}
+
+describe('inline body image — keyboard activation (DR-12)', () => {
+	let host: HTMLElement;
+	let target: HTMLElement;
+	let editor: Editor | undefined;
+
+	beforeEach(() => {
+		deletionListeners.clear();
+		probeMock.mockClear();
+		probeMock.mockResolvedValue({ status: 'transient' as const });
+		host = document.body.appendChild(document.createElement('div'));
+		target = host.appendChild(document.createElement('div'));
+	});
+
+	afterEach(() => {
+		editor?.destroy();
+		editor = undefined;
+		host.remove();
+		document.querySelectorAll('dialog.attachment-image-lightbox').forEach((d) => d.remove());
+	});
+
+	function image(): HTMLImageElement {
+		const el = target.querySelector<HTMLImageElement>('img[data-attachment-id]');
+		if (!el) throw new Error('image NodeView did not render');
+		return el;
+	}
+
+	function press(el: HTMLElement, key: string, mods: KeyboardEventInit = {}): KeyboardEvent {
+		const ev = new KeyboardEvent('keydown', {
+			key,
+			bubbles: true,
+			cancelable: true,
+			...mods,
+		});
+		el.dispatchEvent(ev);
+		return ev;
+	}
+
+	function click(el: HTMLElement): MouseEvent {
+		const ev = new MouseEvent('click', { bubbles: true, cancelable: true, detail: 1 });
+		el.dispatchEvent(ev);
+		return ev;
+	}
+
+	/** Let the lazy HEAD probe (armed by selecting the node) settle. */
+	async function settleProbe() {
+		editor?.commands.setNodeSelection(1);
+		await Promise.resolve();
+		await Promise.resolve();
+		await Promise.resolve();
+	}
+
+	it('is a named, focusable button', () => {
+		editor = makeEditor(target);
+		const img = image();
+
+		expect(img.getAttribute('role')).toBe('button');
+		expect(img.getAttribute('tabindex')).toBe('0');
+		// Name from alt. There is no filename on the node's attrs and the HEAD
+		// metadata carries none either, so the filename form DR-12 sketches has
+		// no source here — alt, then a generic fallback.
+		expect(img.getAttribute('aria-label')).toBe('View image: A diagram');
+	});
+
+	it('falls back to a generic name when the image has no alt', () => {
+		editor = makeEditor(target, '<p><img data-attachment-id="uuid-1" src="/api/v1/x"></p>');
+		expect(image().getAttribute('aria-label')).toBe('View attachment image');
+	});
+
+	it('opens on Enter, exactly once', () => {
+		editor = makeEditor(target);
+		expect(openCount()).toBe(0);
+
+		press(image(), 'Enter');
+
+		// A COUNT, not a truthiness check: a second emitter (a keyboard path that
+		// activated on its own AND a synthesized click) shows up here as 2 and is
+		// invisible to `not.toBeNull()`.
+		expect(openCount()).toBe(1);
+	});
+
+	it('opens on Space exactly once and suppresses the page scroll', () => {
+		editor = makeEditor(target);
+		expect(openCount()).toBe(0);
+
+		const ev = press(image(), ' ');
+
+		expect(openCount()).toBe(1);
+		// Unhandled Space scrolls the document — and inside a contenteditable it
+		// would also be taken as text input against the selected atom.
+		expect(ev.defaultPrevented).toBe(true);
+	});
+
+	it('accepts the legacy "Spacebar" key name too', () => {
+		// Same alias the file chip next door accepts — older engines report Space
+		// under this name, and an image that ignored it would be inert there.
+		editor = makeEditor(target);
+		expect(openCount()).toBe(0);
+
+		const ev = press(image(), 'Spacebar');
+
+		expect(openCount()).toBe(1);
+		expect(ev.defaultPrevented).toBe(true);
+	});
+
+	it('opens on a mouse click, exactly once', () => {
+		editor = makeEditor(target);
+		expect(openCount()).toBe(0);
+		click(image());
+		expect(openCount()).toBe(1);
+	});
+
+	// Both activation keys, because the propagation stop is per-key: a handler
+	// that stopped for Enter and not Space would pass an Enter-only test and
+	// still double-open on the key most people press.
+	for (const key of ['Enter', ' ']) {
+		it(`does not double-open when ${key === ' ' ? 'Space' : key} lands inside a delegated container`, () => {
+			// ItemTimeline delegates thumbnail click/keydown across its whole entry
+			// list, and that list CONTAINS live CommentEditor instances whose bodies
+			// render this NodeView — an `img[data-attachment-id]`, which is exactly
+			// the selector the delegation matches. Without stopPropagation, one
+			// keypress activates the node AND the timeline's own opener: two viewers.
+			//
+			// The stand-in ancestor OPENS, rather than just counting: a counter
+			// alone proves the event escaped but leaves the count at 1, so the
+			// failure it is actually about — two viewers on screen — would not be
+			// visible in the assertion that matters.
+			let delegated = 0;
+			host.addEventListener(
+				'keydown',
+				timelineDelegation(() => (delegated += 1), { ownership: false })
+			);
+			editor = makeCommentEditor(target);
+			expect(openCount()).toBe(0);
+
+			press(image(), key);
+
+			expect(delegated).toBe(0);
+			expect(openCount()).toBe(1);
+		});
+	}
+
+	// A modified key is a shortcut, not an activation. Cmd/Ctrl+Enter is
+	// CommentEditor's SUBMIT binding and an image is a perfectly ordinary thing
+	// to have focused when you post — an activation handler that matched on
+	// `key` alone would swallow it and open a viewer instead of posting.
+	for (const [label, mods] of [
+		['Ctrl+Enter', { ctrlKey: true }],
+		['Meta+Enter', { metaKey: true }],
+		['Shift+Enter', { shiftKey: true }],
+		['Alt+Space', { altKey: true }],
+	] as const) {
+		it(`treats ${label} as a shortcut, not an activation`, () => {
+			let seen = 0;
+			let timelineOpened = 0;
+			host.addEventListener('keydown', () => (seen += 1));
+			// The REAL ItemTimeline delegation, ownership check included. A
+			// modified key is deliberately let through so CommentEditor's submit
+			// binding can see it — which means it also reaches this handler, and
+			// that handler must not turn a submit into a viewer.
+			host.addEventListener(
+				'keydown',
+				timelineDelegation(() => (timelineOpened += 1))
+			);
+			editor = makeCommentEditor(target);
+			const key = label.endsWith('Space') ? ' ' : 'Enter';
+
+			// Isolated first — NOT bubbling, so nothing but this node's own
+			// listener can touch the event. ProseMirror's keymap legitimately
+			// consumes some of these combinations once they reach the editor
+			// root, and asserting on the bubbled event would be measuring that
+			// instead of the handler under test.
+			const solo = new KeyboardEvent('keydown', { key, cancelable: true, ...mods });
+			image().dispatchEvent(solo);
+			expect(openCount()).toBe(0);
+			expect(solo.defaultPrevented).toBe(false);
+
+			// Then bubbling, for the other half: the event must still REACH the
+			// surface that owns the shortcut. A handler that declined to
+			// activate but kept swallowing the event would break the binding
+			// just as thoroughly as one that opened a viewer.
+			press(image(), key, mods);
+			expect(seen).toBe(1);
+			expect(openCount()).toBe(0);
+			expect(timelineOpened).toBe(0);
+		});
+	}
+
+	it('opens once for a HELD key, not once per repeat', () => {
+		// Every repeat is another keydown. Without a guard, leaning on Enter
+		// stacks a viewer per repeat — "exactly once" has to mean once per
+		// gesture. A truthiness check would not see this at all.
+		let delegated = 0;
+		host.addEventListener(
+			'keydown',
+			timelineDelegation(() => (delegated += 1), { ownership: false })
+		);
+		editor = makeEditor(target);
+
+		const img = image();
+		press(img, 'Enter');
+		for (let i = 0; i < 4; i++) press(img, 'Enter', { repeat: true });
+
+		expect(openCount()).toBe(1);
+		// And the repeats stay suppressed: they belong to the activation the
+		// user made once, so letting them escape would hand the surrounding
+		// surface four keypresses that never happened.
+		expect(delegated).toBe(0);
+	});
+
+	it('still reaches the delegated container for keys it does not handle', () => {
+		// The propagation stop is scoped to the activation keys; swallowing
+		// everything would break Escape, Tab-adjacent handlers and the editor's
+		// own key handling on the surrounding surface.
+		let seen = 0;
+		host.addEventListener('keydown', () => (seen += 1));
+		editor = makeEditor(target);
+
+		const ev = press(image(), 'Escape');
+
+		expect(seen).toBe(1);
+		// Nor is it swallowed: an Escape the node consumed would never reach the
+		// surface that closes a pane or a dialog.
+		expect(ev.defaultPrevented).toBe(false);
+		expect(openCount()).toBe(0);
+	});
+
+	it('refuses a probed non-raster type through the KEYBOARD, not just the mouse', async () => {
+		// The gate used to live inside the click handler. A keyboard path that
+		// emitted on its own would have sailed straight past it, so the refusal
+		// is asserted on the route that would have bypassed it.
+		probeMock.mockResolvedValue({ status: 'ok', mime: 'image/svg+xml' });
+		editor = makeEditor(target);
+
+		// BEFORE the probe answers, this is an ordinary activatable button (the
+		// documented "unknown ⇒ keep today's behaviour" path). Pinning that here
+		// is what makes the refusal below attributable to the RESOLVED MIME
+		// rather than to any other inertness route — an empty uuid, a latched
+		// deletion, a hidden image — all of which would already be true now.
+		expect(image().getAttribute('role')).toBe('button');
+
+		await settleProbe();
+		expect(probeMock).toHaveBeenCalled();
+
+		press(image(), 'Enter');
+		expect(openCount()).toBe(0);
+
+		// And it stops being a focus stop at all, rather than announcing itself
+		// as a button that does nothing.
+		expect(image().getAttribute('role')).toBeNull();
+		expect(image().getAttribute('tabindex')).toBeNull();
+		expect(image().getAttribute('aria-label')).toBeNull();
+	});
+
+	it('still opens an allowlisted raster type after the probe resolves', async () => {
+		// The control for the refusal above: same code path, same probe, same
+		// number of awaits — only the MIME differs.
+		probeMock.mockResolvedValue({ status: 'ok', mime: 'image/png' });
+		editor = makeEditor(target);
+		await settleProbe();
+		expect(probeMock).toHaveBeenCalled();
+
+		expect(image().getAttribute('role')).toBe('button');
+		expect(openCount()).toBe(0);
+		press(image(), 'Enter');
+		expect(openCount()).toBe(1);
+	});
+
+	it('makes a deleted image inert rather than a dead focus stop', () => {
+		editor = makeEditor(target);
+		const img = image();
+		expect(img.getAttribute('role')).toBe('button');
+
+		for (const fn of deletionListeners) fn('uuid-1');
+
+		expect(img.getAttribute('role')).toBeNull();
+		expect(img.getAttribute('tabindex')).toBeNull();
+		expect(img.getAttribute('aria-label')).toBeNull();
+		// Inert, not merely unreachable: activation itself refuses, so a
+		// synthetic event or a stale focus can't open a viewer on a row that
+		// no longer exists.
+		press(img, 'Enter');
+		click(img);
+		expect(openCount()).toBe(0);
+	});
+
+	it('does not strand focus on an image that just went inert', () => {
+		editor = makeEditor(target);
+		const img = image();
+		img.focus();
+		expect(document.activeElement).toBe(img);
+
+		for (const fn of deletionListeners) fn('uuid-1');
+
+		// Removing tabindex from the focused element would otherwise leave focus
+		// somewhere no further keystroke can leave.
+		expect(document.activeElement).not.toBe(img);
+	});
+
+	it('gives a comment editor the same contract as an item body', () => {
+		// CommentEditor.svelte configures AttachmentImage independently, so
+		// "works in the body" is not evidence it works in a comment.
+		editor = makeCommentEditor(target);
+		const img = image();
+
+		expect(img.getAttribute('role')).toBe('button');
+		expect(img.getAttribute('tabindex')).toBe('0');
+		expect(img.getAttribute('aria-label')).toBe('View image: A diagram');
+
+		expect(openCount()).toBe(0);
+		press(img, 'Enter');
+		expect(openCount()).toBe(1);
+	});
+
+	it('will not ACTIVATE while the image is showing a load-failure placeholder', () => {
+		// Attributes are not the contract — activation is. Stripping role and
+		// tabindex hides the image from Tab, but a stale event still in flight, a
+		// synthetic one, or focus that predates the failure all reach the
+		// listeners directly, and there is nothing behind a transient failure to
+		// open. Asserting only the attributes leaves this hole wide open, which
+		// is precisely the shape of bug this phase keeps shipping.
+		editor = makeEditor(target);
+		const img = image();
+		img.dispatchEvent(new Event('error'));
+
+		press(img, 'Enter');
+		press(img, ' ');
+		click(img);
+
+		expect(openCount()).toBe(0);
+	});
+
+	it('is not a focus stop while the image is showing a load-failure placeholder', () => {
+		// The placeholder next to it carries the retry affordance; two controls
+		// for one thing, one of which is invisible, is not a contract.
+		editor = makeEditor(target);
+		const img = image();
+		img.dispatchEvent(new Event('error'));
+
+		// The premise first: the image really did hand over to the placeholder.
+		// Stripping the semantics off a still-visible image would be a different
+		// (and wrong) implementation that these two assertions alone would accept.
+		const placeholder = target.querySelector<HTMLElement>('.attachment-missing');
+		expect(placeholder?.style.display).not.toBe('none');
+		expect(img.style.display).toBe('none');
+
+		expect(img.getAttribute('role')).toBeNull();
+		expect(img.getAttribute('tabindex')).toBeNull();
+	});
+});

--- a/web/src/lib/components/editor/attachmentImageMissing.svelte.test.ts
+++ b/web/src/lib/components/editor/attachmentImageMissing.svelte.test.ts
@@ -11,22 +11,42 @@
 // Driven through a REAL Tiptap editor, like the chip spec: the placeholder is
 // imperative NodeView DOM and its accessibility semantics are properties of
 // that DOM, which a hand-built element would not pin.
+//
+// The viewer assertions here are PRODUCER-level — `notifyViewerOpen` is mocked,
+// so "opens" means "asks". A broken or absent host would be invisible to them;
+// that half of the route is `attachmentImageViewerHost.svelte.test.ts`'s.
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { Editor } from '@tiptap/core';
 import StarterKit from '@tiptap/starter-kit';
 
 const deletionListeners = new Set<(uuid: string) => void>();
+// Every open-the-viewer request this NodeView makes, captured RAW — before the
+// channel's own addressability filter. The gate under test is the NodeView's;
+// routing is `events.ts`'s and has its own spec.
+const emitted: Array<Record<string, unknown>> = [];
 vi.mock('$lib/attachments/events', () => ({
 	notifyAttachmentPanelOpen: () => {},
+	notifyViewerOpen: (event: Record<string, unknown>) => {
+		emitted.push(event);
+	},
 	registerAttachmentDeletionListener: (fn: (uuid: string) => void) => {
 		deletionListeners.add(fn);
 		return () => deletionListeners.delete(fn);
 	},
 }));
 
-// No probe: these tests are about what the placeholder IS, not how it is
-// discovered, and a real HEAD would make them asynchronous for no gain.
-const probeMock = vi.fn(async () => ({ status: 'transient' as const }));
+// The probe's full result union, spelled out. Without it `vi.fn` infers the
+// type of the DEFAULT implementation alone, and every `mockResolvedValue` for a
+// different arm is a type error — invisible under `npm run check`, which
+// excludes `*.svelte.test.ts`, and a trap for whoever widens that exclude.
+type ProbeResult =
+	| { status: 'ok'; mime: string; size: number }
+	| { status: 'missing' }
+	| { status: 'transient' };
+
+// No probe by default: these tests are about what the placeholder IS, not how
+// it is discovered, and a real HEAD would make them asynchronous for no gain.
+const probeMock = vi.fn<() => Promise<ProbeResult>>(async () => ({ status: 'transient' }));
 vi.mock('./attachment-metadata', () => ({
 	fetchAttachmentMetadata: () => probeMock(),
 	revalidateAttachmentMetadata: () => probeMock(),
@@ -65,6 +85,7 @@ describe('inline image missing placeholder', () => {
 
 	beforeEach(() => {
 		deletionListeners.clear();
+		emitted.length = 0;
 		probeMock.mockClear();
 		target = document.body.appendChild(document.createElement('div'));
 	});
@@ -82,6 +103,16 @@ describe('inline image missing placeholder', () => {
 		return el;
 	}
 
+	/**
+	 * Let the lazy HEAD probe AND the activation's own MIME resolution settle.
+	 * Activation is asynchronous as of TASK-2433 — it resolves the MIME before
+	 * emitting — so a synchronous assertion after a click would read `[]` no
+	 * matter what the implementation does.
+	 */
+	async function settle() {
+		await new Promise((resolve) => setTimeout(resolve, 0));
+	}
+
 	function failLoad() {
 		const img = target.querySelector<HTMLImageElement>('img[data-attachment-id]');
 		if (!img) throw new Error('image NodeView did not render');
@@ -92,41 +123,91 @@ describe('inline image missing placeholder', () => {
 		// The allowlist gates EVERY open-the-viewer path, not just the strip's:
 		// image/svg+xml can carry active content, and a node being labelled
 		// image/* is not sufficient reason to hand it to a viewer.
-		probeMock.mockResolvedValue({ status: 'ok', mime: 'image/svg+xml' });
+		probeMock.mockResolvedValue({ status: 'ok', mime: 'image/svg+xml' , size: 4096 });
 		editor = makeEditor(target);
 		const img = target.querySelector<HTMLImageElement>('img[data-attachment-id]');
 		if (!img) throw new Error('image NodeView did not render');
 
 		// Select the node so the lazy MIME probe runs, then let it settle.
 		editor.commands.setNodeSelection(1);
-		await Promise.resolve();
-		await Promise.resolve();
+		await settle();
 
 		img.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, detail: 1 }));
-		expect(document.querySelector('dialog.attachment-image-lightbox')).toBeNull();
+		await settle();
+		// NOTHING is emitted — not an event carrying the unsafe MIME for the
+		// viewer to reject at the other end. The gate is the producer's, because
+		// a request that reached the bus would be visible to any future consumer.
+		expect(emitted).toEqual([]);
 	});
 
-	it('still opens an allowlisted raster type', async () => {
-		// The gate must not cost the common case: a PNG opens as it always did.
-		probeMock.mockResolvedValue({ status: 'ok', mime: 'image/png' });
+	it('emits a fully-stamped viewer request for an allowlisted raster type', async () => {
+		// The gate must not cost the common case: a PNG opens as it always did —
+		// and this is the assertion the deletion of the old `<dialog>` rests on.
+		// "The dialog is gone" is satisfied by an implementation that opens
+		// NOTHING, so the claim has to be about what is EMITTED.
+		probeMock.mockResolvedValue({ status: 'ok', mime: 'image/png', size: 4096 });
 		editor = makeEditor(target);
 		const img = target.querySelector<HTMLImageElement>('img[data-attachment-id]');
 		if (!img) throw new Error('image NodeView did not render');
 
 		editor.commands.setNodeSelection(1);
-		await Promise.resolve();
-		await Promise.resolve();
+		await settle();
 
 		img.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, detail: 1 }));
-		expect(document.querySelector('dialog.attachment-image-lightbox')).not.toBeNull();
-		document.querySelector('dialog.attachment-image-lightbox')?.remove();
+		await settle();
+
+		// The WHOLE payload, field by field. Each one is load-bearing and each
+		// has a plausible wrong value: the address routes the event to one of
+		// several mounted hosts (DR-8), `workspaceSlug` is what every image URL
+		// is read from, `mime_type` is what lets `Lightbox` re-state the DR-16
+		// gate over the set (it FAILS CLOSED on null as of TASK-2431, so an
+		// event with an unresolved MIME mounts a viewer that renders no image),
+		// and `invoker` is where the viewer aims focus on close.
+		expect(emitted).toEqual([
+			{
+				attachmentId: 'uuid-1',
+				workspaceSlug: 'ws',
+				itemId: 'item-A',
+				hostToken: 'apanel-1',
+				images: [
+					{
+						id: 'uuid-1',
+						alt: 'A diagram',
+						filename: null,
+						mime_type: 'image/png',
+						size_bytes: 4096,
+						width: null,
+						height: null,
+					},
+				],
+				index: 0,
+				invoker: img,
+			},
+		]);
+	});
+
+	it('emits nothing at all when the MIME cannot be resolved', async () => {
+		// The revised rule for this task (TASK-2431's adversarial round): a
+		// `transient` probe is NOT "unknown, so keep today's behaviour" any more.
+		// `Lightbox` fails closed on an unresolved MIME, so emitting one would be
+		// a request that opens nothing while looking, on the bus, exactly like a
+		// request that does. The retryable branch is TASK-2434's.
+		probeMock.mockResolvedValue({ status: 'transient' });
+		editor = makeEditor(target);
+		const img = target.querySelector<HTMLImageElement>('img[data-attachment-id]');
+		if (!img) throw new Error('image NodeView did not render');
+
+		img.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, detail: 1 }));
+		await settle();
+
+		expect(emitted).toEqual([]);
 	});
 
 	it('inertizes the transform toolbar when the attachment is deleted', async () => {
 		// A confirmed deletion inertizes the WHOLE node. Rotate and crop against
 		// a row that is gone can only 404, and leaving them live is the same
 		// dead-control gap the placeholder's role/tabindex removal closes.
-		probeMock.mockResolvedValue({ status: 'ok', mime: 'image/png' });
+		probeMock.mockResolvedValue({ status: 'ok', mime: 'image/png' , size: 4096 });
 		editor = makeEditor(target);
 		editor.commands.setNodeSelection(1);
 		await Promise.resolve();

--- a/web/src/lib/components/editor/attachmentImageMissing.svelte.test.ts
+++ b/web/src/lib/components/editor/attachmentImageMissing.svelte.test.ts
@@ -68,7 +68,7 @@ function makeEditor(element: HTMLElement): Editor {
 				// reads, and with an empty one it never runs (which is itself the
 				// documented "unknown ⇒ keep today's behaviour" path).
 				address: () => ({ workspaceSlug: 'ws', itemId: 'item-A', hostToken: 'apanel-1' }),
-				supportedFormats: [],
+				supportedFormats: () => [],
 				transform: async () => {
 					throw new Error('not used');
 				},

--- a/web/src/lib/components/editor/attachmentImageNoOverlay.test.ts
+++ b/web/src/lib/components/editor/attachmentImageNoOverlay.test.ts
@@ -1,0 +1,143 @@
+// The inline image NodeView owns NO overlay (PLAN-2392 phase 3a / TASK-2433).
+//
+// This is a STATIC check, deliberately, because the thing it guards is an
+// absence and a behavioural test cannot see one. TASK-2433 deleted
+// `openImageLightbox` / `closeLightbox` — a hand-rolled `<dialog>` the NodeView
+// appended to `document.body` and `showModal()`d — and routed activation onto
+// the viewer channel instead, so the `Lightbox` that `AttachmentViewerHost`
+// mounts is the only viewer on THIS route. Everything the modal contract is
+// made of lives there: the lease-stacked backdrop, the focus trap and restore, the Escape
+// ordering, and the DR-16 filter re-applied over the whole set.
+//
+// A future edit that "just pops a quick preview" from the NodeView would
+// silently reintroduce a second viewer with none of that — and it would pass
+// every PRODUCER spec in this directory, because those assert what the NodeView
+// emits and a stray overlay emits nothing. `attachmentImageViewerHost.svelte.test.ts`
+// asserts a real viewer appears, which is the other half, but it counts
+// `.lightbox-backdrop` roots and would not see an extra overlay of a different
+// shape either. Hence: read the source.
+//
+// The CSS half is checked here too. `.attachment-image-lightbox` lived in
+// `app.css`, not in the TS file, so a JS-only sweep would have left a rule for
+// a dialog nothing constructs — dead weight that also reads, to the next
+// person, as evidence the dialog is still a supported surface.
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SRC = fileURLToPath(new URL('../../..', import.meta.url));
+const NODEVIEW = join(SRC, 'lib/components/editor/attachment-image.ts');
+
+/** Source with block and line comments stripped — the prose above mentions
+ *  every banned token by name, and a check that matched its own warning label
+ *  would be unfalsifiable. */
+function code(path: string): string {
+	return readFileSync(path, 'utf8')
+		.replace(/\/\*[\s\S]*?\*\//g, '')
+		.replace(/^\s*\/\/.*$/gm, '');
+}
+
+function walk(dir: string, out: string[] = []): string[] {
+	for (const name of readdirSync(dir)) {
+		if (name === 'node_modules' || name === '.svelte-kit') continue;
+		const full = join(dir, name);
+		if (statSync(full).isDirectory()) walk(full, out);
+		else if (/\.(ts|js|svelte|css)$/.test(name)) out.push(full);
+	}
+	return out;
+}
+
+describe('attachment-image.ts defines no overlay of its own', () => {
+	const source = code(NODEVIEW);
+
+	it('constructs no dialog and opens no modal', () => {
+		expect(source).not.toMatch(/createElement\(\s*['"]dialog['"]\s*\)/);
+		expect(source).not.toMatch(/\bshowModal\b/);
+		expect(source).not.toMatch(/\bHTMLDialogElement\b/);
+	});
+
+	it('reaches for nothing on the document but the two things it needs', () => {
+		// An ALLOWLIST, not a list of forbidden names. `document.body` was the
+		// deleted lightbox's route out of this subtree, but `document['body']`,
+		// `document.querySelector('body')` and `document.getElementById(…)` are
+		// the same move spelled differently, and a blacklist only ever catches
+		// the spellings someone thought of. This NodeView legitimately needs
+		// exactly two members — one to build its own DOM, one to check where
+		// focus is — so anything else is a reach for a root it does not own.
+		const allowedMembers = new Set(['createElement', 'activeElement']);
+		const members = Array.from(source.matchAll(/\bdocument\s*\.\s*([A-Za-z_$][\w$]*)/g)).map(
+			(m) => m[1]
+		);
+		expect(members.length).toBeGreaterThan(0);
+		expect(members.filter((m) => !allowedMembers.has(m))).toEqual([]);
+		// Computed access would slip straight past the allowlist above.
+		expect(source).not.toMatch(/\bdocument\s*\[/);
+
+		// Named roots are only the obvious half. The check that survives a
+		// creative reimplementation is on the RECEIVER of every insertion —
+		// `someParent.appendChild(overlay)`, a portal into a captured root —
+		// where a blacklist of names would only catch the ones already thought
+		// of.
+		//
+		// The rule is DERIVED, not a list of blessed identifiers: every receiver
+		// must be an element this file CREATED. Combined with the member
+		// allowlist above, that is what confines the whole NodeView to its own
+		// subtree — a locally created element has no route into the document
+		// except the `dom` this NodeView returns, so anything appended into one
+		// is inside what ProseMirror mounts. Renaming `wrapper` to `container`
+		// keeps passing; appending into anything that arrived from elsewhere
+		// does not.
+		const created = new Set(
+			Array.from(source.matchAll(/\b(?:const|let|var)\s+([A-Za-z_$][\w$]*)[^=\n]*=\s*document\.createElement\(/g)).map((m) => m[1])
+		);
+		const INSERTERS = 'append|appendChild|prepend|insertBefore|replaceChildren|insertAdjacentElement';
+		// The receiver is the WHOLE expression, dots included, so a reach through
+		// something this file was handed (`opts.host.appendChild(overlay)`) is a
+		// receiver of `opts.host` — not in `created`, and not silently skipped
+		// the way a bare-identifier pattern would skip it.
+		const receivers = Array.from(
+			source.matchAll(new RegExp(String.raw`([A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*)\.(?:${INSERTERS})\(`, 'g'))
+		).map((m) => m[1]);
+		expect(created.size).toBeGreaterThan(0);
+		expect(receivers.length).toBeGreaterThan(0);
+		expect(receivers.filter((r) => !created.has(r))).toEqual([]);
+		// And the same call spelled computed (`x['appendChild'](overlay)`), which
+		// no dot-pattern can see.
+		expect(source).not.toMatch(new RegExp(String.raw`\[\s*['"\`](?:${INSERTERS})['"\`]\s*\]`));
+		// WHAT THIS CANNOT SEE, stated so nobody mistakes it for a proof. It is
+		// a regex over source: it has no scopes, no bindings and no call graph.
+		// An overlay built by an imported helper is invisible to it, and so is
+		// a name that `created` knows about being REASSIGNED to something
+		// foreign before it is appended into. Closing those needs an AST pass
+		// with binding resolution, which is a disproportionate amount of
+		// machinery for a guard whose job is to make a deliberate re-addition
+		// of the deleted dialog fail loudly. The narrower claim it does make —
+		// this file appends only into elements it created, and reaches for
+		// nothing on the document but `createElement` and `activeElement` — is
+		// the one that would have caught the code this task removed.
+	});
+
+	it('names the deleted lightbox nowhere', () => {
+		expect(source).not.toMatch(/openImageLightbox|closeLightbox|attachment-image-lightbox/);
+	});
+
+	it('routes activation through the viewer channel instead', () => {
+		// The other half of the same claim: "no overlay" is only the right
+		// absence if something else opens the viewer. A file that deleted the
+		// dialog and emitted nothing satisfies every assertion above.
+		expect(source).toMatch(/notifyViewerOpen\(/);
+	});
+
+	it('leaves no reference to the lightbox class anywhere in the app', () => {
+		// Including `app.css`, whose rules a JS-only sweep does not see, and the
+		// specs — a test still counting `dialog.attachment-image-lightbox` would
+		// be counting an element nothing can create, i.e. asserting 0 forever.
+		const offenders = walk(SRC)
+			// This file, which cannot check for a name without naming it.
+			.filter((f) => f !== fileURLToPath(import.meta.url))
+			.filter((f) => readFileSync(f, 'utf8').includes('attachment-image-lightbox'))
+			.map((f) => f.slice(SRC.length));
+		expect(offenders).toEqual([]);
+	});
+});

--- a/web/src/lib/components/editor/attachmentImageViewerHost.svelte.test.ts
+++ b/web/src/lib/components/editor/attachmentImageViewerHost.svelte.test.ts
@@ -24,6 +24,11 @@ import { Editor } from '@tiptap/core';
 import StarterKit from '@tiptap/starter-kit';
 import { __resetViewerBackdropForTests } from '$lib/a11y/viewerBackdrop';
 import { _resetEscapeStackForTests } from '$lib/stores/escapeStack';
+import {
+	isAttachmentPanelEventForHost,
+	registerAttachmentPanelListener,
+	type AttachmentPanelOpenEvent,
+} from '$lib/attachments/events';
 
 const UUID = '11111111-1111-4111-8111-111111111111';
 const ITEM_ID = 'item-A';
@@ -42,6 +47,9 @@ vi.mock('./attachment-metadata', () => ({
 const { AttachmentImage } = await import('./attachment-image');
 const { default: AttachmentViewerHost } = await import(
 	'$lib/components/attachments/AttachmentViewerHost.svelte'
+);
+const { default: AttachmentPanelHost } = await import(
+	'$lib/components/attachments/AttachmentPanelHost.svelte'
 );
 
 let address = { workspaceSlug: 'ws', itemId: ITEM_ID, hostToken: HOST_TOKEN };
@@ -192,6 +200,91 @@ describe('inline image → viewer host → Lightbox', () => {
 		await settle();
 
 		expect(viewers()).toHaveLength(0);
+	});
+
+	it('REDIRECTS a non-allowlisted type into the real panel host', async () => {
+		// The whole route for the redirect arm, with nothing between the NodeView
+		// and the panel stubbed: the real bus, the real `AttachmentPanelHost`, the
+		// real panel it mounts. The producer specs next door mock the bus, so a
+		// host that stopped consuming — or an address that could not route —
+		// would leave them green and leave the user with an image that does
+		// nothing, which is the exact failure this task replaced.
+		probeMock.mockResolvedValue({ status: 'ok', mime: 'image/svg+xml', size: 100 } as never);
+		mountHost({ itemId: ITEM_ID, hostToken: HOST_TOKEN });
+		const panelHost = mount(AttachmentPanelHost, {
+			target: hostTarget,
+			props: {
+				wsSlug: 'ws',
+				itemId: ITEM_ID,
+				hostToken: HOST_TOKEN,
+				mutationsEnabled: false,
+			},
+		}) as Record<string, unknown>;
+		try {
+			editor = makeEditor(editorTarget);
+
+			image().dispatchEvent(
+				new MouseEvent('click', { bubbles: true, cancelable: true, detail: 1 })
+			);
+			await settle();
+
+			// No viewer — the security half.
+			expect(viewers()).toHaveLength(0);
+			// And a real panel on screen, for the attachment that was activated —
+			// the completeness half. A redirect nobody consumes is still a tap
+			// that does nothing.
+			const panel = document.body.querySelector<HTMLElement>('[role="menu"] .ap-header');
+			expect(panel).not.toBeNull();
+			// And it is about THIS attachment, not merely present: the MIME the
+			// probe returned and a download target carrying the uuid. A panel that
+			// opened on the wrong row would satisfy a presence check.
+			expect(panel?.querySelector('.ap-meta')?.getAttribute('title')).toBe('image/svg+xml');
+			expect(
+				document.body.querySelector<HTMLAnchorElement>('[role="menu"] a[download]')?.getAttribute('href')
+			).toContain(UUID);
+		} finally {
+			unmount(panelHost);
+		}
+	});
+
+	it('REDIRECTS a non-allowlisted type onto the real panel channel', async () => {
+		// TASK-2434's redirect, asserted through the REAL bus rather than a mock.
+		// The producer specs next door mock `notifyAttachmentPanelOpen`, so they
+		// see the call and are blind to what the channel does with it — and the
+		// channel drops any emission it judges unaddressable. An event that never
+		// leaves the bus is indistinguishable, from the producer's side, from the
+		// silent refusal this task replaced.
+		const seen: AttachmentPanelOpenEvent[] = [];
+		const dispose = registerAttachmentPanelListener((e) => seen.push(e));
+		try {
+			probeMock.mockResolvedValue({ status: 'ok', mime: 'image/svg+xml', size: 100 } as never);
+			mountHost({ itemId: ITEM_ID, hostToken: HOST_TOKEN });
+			editor = makeEditor(editorTarget);
+
+			image().dispatchEvent(
+				new MouseEvent('click', { bubbles: true, cancelable: true, detail: 1 })
+			);
+			await settle();
+
+			// No viewer — the security half.
+			expect(viewers()).toHaveLength(0);
+			// And it went SOMEWHERE — the completeness half.
+			expect(seen).toHaveLength(1);
+			expect(seen[0].attachmentId).toBe(UUID);
+			expect(seen[0].mime_type).toBe('image/svg+xml');
+			// Addressed well enough for a host to claim it. The channel's own
+			// predicate, not a re-implementation of it: a payload that reached a
+			// raw subscriber but that no host would match is still a tap that
+			// does nothing.
+			expect(
+				isAttachmentPanelEventForHost(seen[0], { itemId: ITEM_ID, hostToken: HOST_TOKEN })
+			).toBe(true);
+			expect(
+				isAttachmentPanelEventForHost(seen[0], { itemId: ITEM_ID, hostToken: 'another-mount' })
+			).toBe(false);
+		} finally {
+			dispose();
+		}
 	});
 
 	it('does not open for a MIME the viewer would filter back out', async () => {

--- a/web/src/lib/components/editor/attachmentImageViewerHost.svelte.test.ts
+++ b/web/src/lib/components/editor/attachmentImageViewerHost.svelte.test.ts
@@ -64,7 +64,7 @@ function makeEditor(element: HTMLElement): Editor {
 				getDownloadUrl: (uuid: string, variant?: string) =>
 					`/api/v1/workspaces/ws/attachments/${uuid}?variant=${variant ?? 'thumb-md'}`,
 				address: () => address,
-				supportedFormats: ['png'],
+				supportedFormats: () => ['png'],
 				transform: async () => {
 					throw new Error('not used');
 				},

--- a/web/src/lib/components/editor/attachmentImageViewerHost.svelte.test.ts
+++ b/web/src/lib/components/editor/attachmentImageViewerHost.svelte.test.ts
@@ -1,0 +1,211 @@
+// The whole route: inline image NodeView → the REAL bus → the REAL
+// `AttachmentViewerHost` → the REAL `Lightbox` (PLAN-2392 phase 3a / TASK-2433).
+//
+// Every other spec for this change stops at the producer: they mock
+// `notifyViewerOpen` and assert the payload, which is the right shape for
+// asking "did the NodeView emit the correct request" and is deliberately blind
+// to whether anything is listening. That leaves the commit's actual headline
+// claim — a deleted `<dialog>` REPLACED by the shared viewer, not removed —
+// resting on two halves nobody joins. A host that stopped consuming, an
+// address that could not route, a payload the viewer filters back out: all of
+// them keep the producer specs green and leave the user with an image that
+// does nothing.
+//
+// So nothing here is stubbed but the network. The bus is real, the host is
+// real, `Lightbox` is real, and the assertion is a viewer in the document with
+// the clicked attachment in it.
+//
+// What jsdom still cannot prove — real inertness, real Tab traversal, layout
+// and stacking — is `Lightbox`'s own contract and belongs to the browser suite
+// (TASK-2436), not to a jsdom test that would pass vacuously here.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+import { Editor } from '@tiptap/core';
+import StarterKit from '@tiptap/starter-kit';
+import { __resetViewerBackdropForTests } from '$lib/a11y/viewerBackdrop';
+import { _resetEscapeStackForTests } from '$lib/stores/escapeStack';
+
+const UUID = '11111111-1111-4111-8111-111111111111';
+const ITEM_ID = 'item-A';
+const HOST_TOKEN = 'apanel-1';
+
+// The one stub: the HEAD probe. Everything the viewer path is made of stays
+// real, because the point of this file is the wiring between the parts.
+const probeMock = vi.fn(async () => ({ status: 'ok' as const, mime: 'image/png', size: 4096 }));
+vi.mock('./attachment-metadata', () => ({
+	fetchAttachmentMetadata: () => probeMock(),
+	revalidateAttachmentMetadata: () => probeMock(),
+	invalidateAttachmentMetadata: () => {},
+	mimeToFormat: () => null,
+}));
+
+const { AttachmentImage } = await import('./attachment-image');
+const { default: AttachmentViewerHost } = await import(
+	'$lib/components/attachments/AttachmentViewerHost.svelte'
+);
+
+let address = { workspaceSlug: 'ws', itemId: ITEM_ID, hostToken: HOST_TOKEN };
+
+function makeEditor(element: HTMLElement): Editor {
+	return new Editor({
+		element,
+		extensions: [
+			StarterKit,
+			AttachmentImage.configure({
+				workspaceSlug: 'ws',
+				getDownloadUrl: (uuid: string, variant?: string) =>
+					`/api/v1/workspaces/ws/attachments/${uuid}?variant=${variant ?? 'thumb-md'}`,
+				address: () => address,
+				supportedFormats: ['png'],
+				transform: async () => {
+					throw new Error('not used');
+				},
+			}),
+		],
+		content: `<p><img data-attachment-id="${UUID}" src="/api/v1/x" alt="A diagram"></p>`,
+		editable: true,
+	});
+}
+
+describe('inline image → viewer host → Lightbox', () => {
+	let editorTarget: HTMLElement;
+	let hostTarget: HTMLElement;
+	let editor: Editor | undefined;
+	let host: Record<string, unknown> | null = null;
+
+	function mountHost(props: { itemId: string; hostToken: string }) {
+		host = mount(AttachmentViewerHost, { target: hostTarget, props }) as Record<string, unknown>;
+		flushSync();
+	}
+
+	/** Viewers actually on screen — the real component's root. */
+	function viewers(): HTMLElement[] {
+		return Array.from(document.body.querySelectorAll<HTMLElement>('.lightbox-backdrop'));
+	}
+
+	function image(): HTMLImageElement {
+		const el = editorTarget.querySelector<HTMLImageElement>('img[data-attachment-id]');
+		if (!el) throw new Error('image NodeView did not render');
+		return el;
+	}
+
+	/** Activation resolves the MIME before emitting, so it spans a task. */
+	async function settle() {
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		flushSync();
+	}
+
+	beforeEach(() => {
+		_resetEscapeStackForTests();
+		__resetViewerBackdropForTests();
+		address = { workspaceSlug: 'ws', itemId: ITEM_ID, hostToken: HOST_TOKEN };
+		probeMock.mockClear();
+		probeMock.mockResolvedValue({ status: 'ok', mime: 'image/png', size: 4096 });
+		editorTarget = document.body.appendChild(document.createElement('div'));
+		hostTarget = document.body.appendChild(document.createElement('div'));
+	});
+
+	afterEach(() => {
+		editor?.destroy();
+		editor = undefined;
+		if (host) unmount(host);
+		host = null;
+		editorTarget.remove();
+		hostTarget.remove();
+		document.body.querySelectorAll('.lightbox-backdrop').forEach((el) => el.remove());
+	});
+
+	// Run against TWO different addresses. One fixed pair cannot tell a producer
+	// that STAMPS the address from one that hard-codes the constants this file
+	// happens to use — and a hard-coded address is exactly what DR-8 exists to
+	// prevent, since it would route every editor's images at one pane.
+	for (const [label, addr] of [
+		['the default address', { itemId: ITEM_ID, hostToken: HOST_TOKEN }],
+		['a different item and mount', { itemId: 'item-Z', hostToken: 'apanel-9' }],
+	] as const) {
+		it(`opens the shared viewer on the image the user activated — ${label}`, async () => {
+			address = { workspaceSlug: 'ws', ...addr };
+			mountHost(addr);
+			editor = makeEditor(editorTarget);
+			expect(viewers()).toHaveLength(0);
+
+			image().dispatchEvent(
+				new MouseEvent('click', { bubbles: true, cancelable: true, detail: 1 })
+			);
+			await settle();
+
+			// ONE viewer, and it is the real component: a `role="dialog"` root
+			// portaled to `<body>`, showing the attachment that was clicked. The
+			// deleted `<dialog>` is not merely gone — something took its place.
+			expect(viewers()).toHaveLength(1);
+			const viewer = viewers()[0];
+			expect(viewer.getAttribute('role')).toBe('dialog');
+			expect(viewer.parentElement).toBe(document.body);
+			const shown = viewer.querySelector<HTMLImageElement>('img.lightbox-image');
+			expect(shown?.getAttribute('src')).toContain(UUID);
+			// The full-resolution blob, as the deleted dialog loaded: the viewer
+			// asks for the canonical URL with no `variant`.
+			expect(shown?.getAttribute('src')).not.toContain('variant=');
+		});
+	}
+
+	it('opens on the KEYBOARD too, exactly once', async () => {
+		// The route the deleted dialog never had. A count, so a second emitter
+		// anywhere along the chain is visible.
+		mountHost({ itemId: ITEM_ID, hostToken: HOST_TOKEN });
+		editor = makeEditor(editorTarget);
+
+		image().dispatchEvent(
+			new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true })
+		);
+		await settle();
+
+		expect(viewers()).toHaveLength(1);
+	});
+
+	it('reaches only the host it is ADDRESSED to', async () => {
+		// DR-8's rule, asserted end to end rather than on the channel alone: a
+		// master pane and a peeked pane are both mounted, and a NodeView's event
+		// must open the viewer over the one that owns it. A producer that
+		// stamped a constant, or a host that consumed everything, both show up
+		// here as a viewer in the wrong place.
+		mountHost({ itemId: ITEM_ID, hostToken: 'a-different-mount' });
+		editor = makeEditor(editorTarget);
+
+		image().dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, detail: 1 }));
+		await settle();
+
+		expect(viewers()).toHaveLength(0);
+	});
+
+	it('opens nothing at all when no host is mounted', async () => {
+		// The honest statement of what this surface now depends on: an editor
+		// outside an `ItemDetail` announces a button and, with nobody listening,
+		// opens nothing. Every real mount threads a token (both `<Editor>`s and
+		// every `CommentEditor` come from `ItemDetail`), so this is the
+		// boundary, not a live bug — pinned so a future reusable-editor surface
+		// discovers it here rather than as a dead control in front of a user.
+		editor = makeEditor(editorTarget);
+
+		image().dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, detail: 1 }));
+		await settle();
+
+		expect(viewers()).toHaveLength(0);
+	});
+
+	it('does not open for a MIME the viewer would filter back out', async () => {
+		// The producer's gate and the viewer's are the same gate, stated twice
+		// on purpose (TASK-2431). If the producer ever emitted an SVG, the
+		// viewer would filter it and mount an empty shell — the failure this
+		// asserts is absent.
+		probeMock.mockResolvedValue({ status: 'ok', mime: 'image/svg+xml', size: 100 });
+		mountHost({ itemId: ITEM_ID, hostToken: HOST_TOKEN });
+		editor = makeEditor(editorTarget);
+
+		image().dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, detail: 1 }));
+		await settle();
+
+		expect(viewers()).toHaveLength(0);
+	});
+});

--- a/web/src/lib/components/editor/editorCapabilitiesDelivery.svelte.test.ts
+++ b/web/src/lib/components/editor/editorCapabilitiesDelivery.svelte.test.ts
@@ -1,0 +1,293 @@
+// Do the server's image-processor capabilities actually REACH the inline
+// image NodeView? (BUG-2426 / PLAN-2392 phase 3a / TASK-2435.)
+//
+// They used to not. `Editor.svelte` fetched `/server/capabilities` and wrote
+// the format list onto the extension — `ext.options.supportedFormats = …` —
+// and Tiptap's `options` is a GETTER that returns a fresh spread per access,
+// so the write landed on a temporary and was gone by the next statement. The
+// NodeView compounds it by snapshotting `this.options` once when it is built.
+// Every visible symptom (rotate + crop permanently disabled with the "not
+// available in this build" tooltip) came from a line that reads like it works.
+//
+// That is why NONE of the assertions below are about the assignment, the
+// option value, or the notification: they are about a REAL `Editor.svelte`
+// mount, its REAL toolbar DOM, and whether the buttons a user would click are
+// enabled. **Reverting the reader to `ext.options.supportedFormats = …` must
+// turn this file red** — which it does at three independent points: the
+// pre-capabilities toolbar never leaves its degraded state, a toolbar built
+// AFTER capabilities resolve is degraded too (the case the notification cannot
+// paper over), and the per-format assertions below cannot be satisfied by any
+// implementation that merely enables everything once the fetch lands.
+//
+// The COMMENT composer is the other half, and it is NOT the same case:
+// `CommentEditor` configures transforms off ON PURPOSE. A "fix" that hands it
+// the server's formats would be a regression, so its config is pinned here
+// too — after capabilities resolve and after the change notification has been
+// fanned out to every live toolbar.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mount, unmount, flushSync } from 'svelte';
+import type { Editor as TiptapEditor } from '@tiptap/core';
+import type { ServerCapabilities } from '$lib/types';
+
+const PNG = '11111111-1111-4111-8111-111111111111';
+const TIFF = '22222222-2222-4222-8222-222222222222';
+
+/** What the server says its libvips build can process. TIFF is absent. */
+const SERVER_FORMATS = ['png', 'jpeg'];
+
+/**
+ * The list THIS test's server reports. Mutable, and one test below sets it to
+ * a build that cannot do PNG: a "fix" that ignored the response and hard-coded
+ * the common list would satisfy every other assertion here (Codex round 1), so
+ * the only thing that separates delivery from a constant is asking a second
+ * server a different question.
+ */
+let serverFormats: string[] = SERVER_FORMATS;
+
+const MIMES: Record<string, string> = {
+	[PNG]: 'image/png',
+	[TIFF]: 'image/tiff',
+};
+
+// The capabilities fetch, held OPEN until a test resolves it. Every editor
+// below therefore mounts in the pre-capabilities world — which is the world
+// the bug lived in, and the only one where "did the value arrive later" is a
+// question with two possible answers.
+let releaseCapabilities: (() => void) | null = null;
+const capabilitiesMock = vi.fn<() => Promise<ServerCapabilities>>(
+	() =>
+		new Promise<ServerCapabilities>((resolve) => {
+			releaseCapabilities = () =>
+				resolve({ image: { image_formats: serverFormats, can_transcode: true, max_pixels: 1e8 } });
+		})
+);
+
+vi.mock('$lib/api/client', () => ({
+	api: {
+		server: { capabilities: () => capabilitiesMock() },
+		attachments: {
+			downloadUrl: (ws: string, id: string, variant?: string) =>
+				`/api/v1/workspaces/${ws}/attachments/${id}?variant=${variant ?? 'thumb-md'}`,
+			transform: vi.fn(),
+			upload: vi.fn(),
+		},
+		items: { list: vi.fn(async () => []) },
+	},
+}));
+
+// Only the network HEAD probe is stubbed; `mimeToFormat` — the mapping the
+// per-format gate is actually made of — stays REAL, so a test asserting that
+// TIFF is refused is asserting against production's own format table.
+vi.mock('./attachment-metadata', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('./attachment-metadata')>();
+	return {
+		...actual,
+		fetchAttachmentMetadata: async (_ws: string, uuid: string) =>
+			MIMES[uuid] ? { status: 'ok' as const, mime: MIMES[uuid], size: 4096 } : { status: 'transient' as const },
+		revalidateAttachmentMetadata: async (_ws: string, uuid: string) =>
+			MIMES[uuid] ? { status: 'ok' as const, mime: MIMES[uuid], size: 4096 } : { status: 'transient' as const },
+		invalidateAttachmentMetadata: () => {},
+	};
+});
+
+// The two REAL mount sites. Nothing here re-declares their extension config —
+// a local `AttachmentImage.configure({ … })` would pin a copy of the thing
+// under test and stay green through the bug.
+const { default: BodyEditor } = await import('./Editor.svelte');
+const { default: CommentEditor } = await import('$lib/components/CommentEditor.svelte');
+const { AttachmentImage } = await import('./attachment-image');
+
+const { page } = await import('$app/state');
+
+type Mounted = Record<string, unknown>;
+
+describe('server image capabilities reach the inline image NodeView (BUG-2426)', () => {
+	let target: HTMLElement;
+	const mounted: Mounted[] = [];
+
+	beforeEach(() => {
+		serverFormats = SERVER_FORMATS;
+		releaseCapabilities = null;
+		capabilitiesMock.mockClear();
+		page.params.workspace = 'ws';
+		target = document.body.appendChild(document.createElement('div'));
+	});
+
+	afterEach(() => {
+		while (mounted.length) unmount(mounted.pop() as Mounted);
+		target.remove();
+		document.querySelectorAll('.attachment-image-toolbar').forEach((el) => el.remove());
+	});
+
+	/** Mount the REAL body editor and hand back its Tiptap instance. */
+	function mountBody(markdown: string): TiptapEditor {
+		let tiptap: TiptapEditor | null = null;
+		mounted.push(
+			mount(BodyEditor, {
+				target,
+				props: {
+					content: markdown,
+					itemId: 'item-A',
+					hostToken: 'apanel-1',
+					onEditor: (e: TiptapEditor) => {
+						tiptap = e;
+					},
+				},
+			}) as Mounted
+		);
+		flushSync();
+		if (!tiptap) throw new Error('Editor.svelte did not construct a Tiptap editor');
+		return tiptap;
+	}
+
+	/**
+	 * Select the image node so its NodeView builds the toolbar (`selectNode`),
+	 * then return the toolbar's buttons. Selection is driven through the
+	 * editor's own command rather than a synthetic mouse event: jsdom has no
+	 * layout, so ProseMirror's coordinate-based click-to-select cannot run.
+	 */
+	function toolbarButtons(tiptap: TiptapEditor, uuid: string): HTMLButtonElement[] {
+		let pos: number | null = null;
+		tiptap.state.doc.descendants((node, at) => {
+			if (node.type.name === 'attachmentImage' && node.attrs.uuid === uuid) pos = at;
+			return true;
+		});
+		if (pos === null) throw new Error(`no attachmentImage node for ${uuid} in the parsed document`);
+		tiptap.commands.setNodeSelection(pos);
+		const wrapper = tiptap.view.dom.querySelector<HTMLElement>(
+			`.attachment-image-wrapper:has(img[data-attachment-id="${uuid}"]), [data-attachment-id="${uuid}"]`
+		);
+		const toolbar =
+			wrapper?.closest('.attachment-image-wrapper')?.querySelector('.attachment-image-toolbar') ??
+			tiptap.view.dom.querySelector('.attachment-image-toolbar');
+		if (!toolbar) throw new Error('selecting the image did not build a toolbar');
+		return Array.from(toolbar.querySelectorAll<HTMLButtonElement>('.attachment-image-toolbar-btn'));
+	}
+
+	/** Let the capabilities promise + the MIME probe settle. */
+	async function settle() {
+		for (let i = 0; i < 4; i++) await new Promise((r) => setTimeout(r, 0));
+		flushSync();
+	}
+
+	async function resolveCapabilities() {
+		if (!releaseCapabilities) throw new Error('Editor.svelte never called api.server.capabilities()');
+		releaseCapabilities();
+		await settle();
+	}
+
+	it('enables a toolbar that was built BEFORE capabilities resolved', async () => {
+		const tiptap = mountBody(`![A diagram](pad-attachment:${PNG})`);
+		await settle();
+
+		// Pre-capabilities: the honest degraded state. Asserted so the
+		// post-resolution assertion cannot pass vacuously against buttons that
+		// were enabled the whole time.
+		const before = toolbarButtons(tiptap, PNG);
+		expect(before.length).toBeGreaterThan(0);
+		expect(before.every((b) => b.disabled)).toBe(true);
+		expect(before[0].title).toMatch(/not available in this build/i);
+
+		await resolveCapabilities();
+
+		// Same buttons — the toolbar is not rebuilt — now live.
+		const after = toolbarButtons(tiptap, PNG);
+		expect(after).toEqual(before);
+		expect(after.some((b) => b.disabled)).toBe(false);
+		expect(after[0].title).not.toMatch(/not available in this build/i);
+	});
+
+	it('enables a toolbar built AFTER capabilities resolved', async () => {
+		// The case the capability-change NOTIFICATION cannot rescue: this
+		// toolbar does not exist when the fan-out runs, so its state comes
+		// entirely from reading the option at build time. Under the old
+		// post-configure assignment this stayed disabled forever.
+		const tiptap = mountBody(`![A diagram](pad-attachment:${PNG})`);
+		await settle();
+		await resolveCapabilities();
+
+		const btns = toolbarButtons(tiptap, PNG);
+		await settle();
+		expect(btns.length).toBeGreaterThan(0);
+		expect(btns.some((b) => b.disabled)).toBe(false);
+	});
+
+	it('still refuses a format the server does not support', async () => {
+		// The guard against a "fix" that just enables everything once the
+		// fetch lands: TIFF is a real image with a real MIME, absent from
+		// SERVER_FORMATS, and must stay disabled with the format-specific
+		// message — which is only reachable if the ACTUAL list arrived.
+		const tiptap = mountBody(`![A scan](pad-attachment:${TIFF})`);
+		await settle();
+		await resolveCapabilities();
+
+		const btns = toolbarButtons(tiptap, TIFF);
+		await settle();
+		expect(btns.every((b) => b.disabled)).toBe(true);
+		expect(btns[0].title).toContain('image/tiff');
+		expect(btns[0].title).toContain(SERVER_FORMATS.join(', '));
+	});
+
+	it('reports the formats THIS server sent, not a hard-coded list', async () => {
+		// Same PNG image, a build whose processor cannot do PNG. Every other
+		// assertion in this file is satisfiable by an implementation that
+		// ignores the response and hard-codes the usual list; this one is not.
+		serverFormats = ['jpeg'];
+		const tiptap = mountBody(`![A diagram](pad-attachment:${PNG})`);
+		await settle();
+		await resolveCapabilities();
+
+		const btns = toolbarButtons(tiptap, PNG);
+		await settle();
+		expect(btns.every((b) => b.disabled)).toBe(true);
+		expect(btns[0].title).toContain('image/png');
+		expect(btns[0].title).toContain('this build supports jpeg');
+	});
+
+	it('leaves the COMMENT composer with transforms off, capabilities or not', async () => {
+		// `CommentEditor` switches transforms off deliberately, and shares the
+		// module-level capability fan-out with the body editor — so "the body
+		// editor now receives capabilities" is exactly the change that could
+		// leak into comments.
+		//
+		// Its Tiptap instance is not exposed to hosts, so this asserts the
+		// configuration the REAL component hands the REAL extension, captured
+		// through `configure` and INVOKED at the same moment the NodeView
+		// would invoke it (after capabilities resolved, after the fan-out).
+		// It is the same value `refreshToolbarState` gates on; the body tests
+		// above are what tie that value to the buttons.
+		// Capture without disturbing behaviour: wrap the real method, and hand
+		// back what it really returns, so both editors mount for real.
+		const realConfigure = AttachmentImage.configure.bind(AttachmentImage);
+		const captured: Array<{ supportedFormats: () => string[] }> = [];
+		vi.spyOn(AttachmentImage, 'configure').mockImplementation((opts) => {
+			captured.push(opts as unknown as { supportedFormats: () => string[] });
+			return realConfigure(opts);
+		});
+
+		try {
+			const tiptap = mountBody(`![A diagram](pad-attachment:${PNG})`);
+			mounted.push(
+				mount(CommentEditor, {
+					target: document.body.appendChild(document.createElement('div')),
+					props: { wsSlug: 'ws', itemId: 'item-A', hostToken: 'apanel-1', onSubmit: () => {} },
+				}) as Mounted
+			);
+			flushSync();
+			await settle();
+			await resolveCapabilities();
+
+			// Two mount sites, two readers, one shared capability fetch.
+			expect(captured.length).toBe(2);
+			const [bodyOpts, commentOpts] = captured;
+			expect(bodyOpts.supportedFormats()).toEqual(SERVER_FORMATS);
+			expect(commentOpts.supportedFormats()).toEqual([]);
+
+			// And the body editor's own toolbar agrees, so the reader that
+			// stayed empty is the comment one, not a mis-captured pair.
+			expect(toolbarButtons(tiptap, PNG).some((b) => b.disabled)).toBe(false);
+		} finally {
+			vi.restoreAllMocks();
+		}
+	});
+});

--- a/web/src/lib/components/graph/ItemGraph.svelte
+++ b/web/src/lib/components/graph/ItemGraph.svelte
@@ -18,6 +18,7 @@
 	import { createCollectionColorMap } from '$lib/graph/palette';
 	import { sseService, type ItemEvent } from '$lib/services/sse.svelte';
 	import { shouldOpenInPane } from '$lib/components/collections/itemCardClick';
+	import { isBlockedByModal } from '$lib/a11y/viewerBackdrop';
 
 	let {
 		workspace,
@@ -440,7 +441,23 @@
 	let dragOriginTx = 0;
 	let dragOriginTy = 0;
 
+	/**
+	 * TASK-2430 — the graph CO-MOUNTS with the attachment viewer (an item's
+	 * drawer stays in the DOM while a viewer opens over it), so its pan/zoom must
+	 * defer to a frontmost viewer or native `showModal()` dialog.
+	 *
+	 * The owner is the graph viewport — the surface asking to act — never
+	 * `event.target`. `isBlockedByModal` returns false on an empty stack, so with
+	 * no viewer open pan and zoom behave exactly as before.
+	 */
+	function graphBlocked(): boolean {
+		return isBlockedByModal(viewport);
+	}
+
 	function onWheel(e: WheelEvent) {
+		// Gate BEFORE `preventDefault()`: while a viewer is in front the wheel
+		// belongs to whatever is under the cursor up there, not to this canvas.
+		if (graphBlocked()) return;
 		e.preventDefault();
 		const rect = viewport?.getBoundingClientRect();
 		if (!rect) return;
@@ -457,6 +474,8 @@
 
 	function onPointerDown(e: PointerEvent) {
 		if (e.button !== 0) return;
+		// Gesture START gate (TASK-2430).
+		if (graphBlocked()) return;
 		// Don't start a pan when the press lands on an interactive overlay
 		// (legend toggles, detail-card actions, error retry) — they sit inside the
 		// viewport, so without this a click on them would also begin a drag.
@@ -471,8 +490,44 @@
 		// NOTE: no setPointerCapture here — capturing on pointerdown would swallow
 		// the node's click/dblclick. We capture only once a real drag starts.
 	}
+	/**
+	 * Tear a pan down mid-gesture (TASK-2430). This canvas has NO
+	 * `lostpointercapture` handler, and once a real drag engages it OWNS the
+	 * pointer via `setPointerCapture` — so a gesture that began before a viewer
+	 * opened keeps delivering moves to this viewport afterwards. Releasing the
+	 * capture here is what actually stops it, not just the early return.
+	 */
+	function abortPan(e: PointerEvent) {
+		const wasDragging = dragging;
+		maybeDrag = false;
+		dragging = false;
+		if (capturedPointerId !== null) {
+			try {
+				(e.currentTarget as Element).releasePointerCapture(capturedPointerId);
+			} catch {
+				// already released — ignore.
+			}
+			capturedPointerId = null;
+		}
+		if (wasDragging) {
+			// The gesture WAS a pan, so still swallow the click it produces, and
+			// clear on the next tick exactly as the normal end-of-pan path does.
+			suppressClick = true;
+			setTimeout(() => {
+				suppressClick = false;
+			}, 0);
+		}
+	}
+
 	function onPointerMove(e: PointerEvent) {
 		if (!maybeDrag) return;
+		// STRADDLE gate (TASK-2430) — the press may have landed before the viewer
+		// opened. Abort rather than early-return: an early return alone would
+		// leave the pointer captured and `dragging` latched.
+		if (graphBlocked()) {
+			abortPan(e);
+			return;
+		}
 		// If the primary button is no longer held, the press ended off-viewport
 		// before a drag engaged (no capture yet, so we never got pointerup) — abort
 		// rather than start a ghost pan with no button down.
@@ -496,6 +551,18 @@
 		tx = dragOriginTx + dx;
 		ty = dragOriginTy + dy;
 	}
+	// NO arbitration gate on pointerup, deliberately. The obvious symmetry with
+	// the move gate above would be dead code: this path's ONLY job is teardown —
+	// drop the flags, release the capture, swallow the click — which is byte for
+	// byte what `abortPan` does, so a gate here cannot change any outcome and no
+	// test can fail on its removal (mutation-verified). A guard that cannot fail
+	// is decoration, and decoration in a security-shaped review reads as
+	// coverage. The straddle is already handled: the move gate tears the pan
+	// down the moment the viewer appears, and a pointerup arriving with no
+	// intervening move performs the same teardown either way.
+	//
+	// This stops being true the moment the un-blocked path grows a real side
+	// effect (a navigation, a persist). Add the gate then — with a test.
 	function onPointerUp(e: PointerEvent) {
 		maybeDrag = false;
 		if (dragging) {

--- a/web/src/lib/components/graph/ItemGraph.svelte.test.ts
+++ b/web/src/lib/components/graph/ItemGraph.svelte.test.ts
@@ -1,0 +1,313 @@
+// Runs in the jsdom vitest project (filename ends `.svelte.test.ts`).
+//
+// TASK-2430 — the per-item dependency graph CO-MOUNTS with the attachment
+// viewer: the drawer stays in the DOM while a viewer opens over it. Its
+// pan/zoom must therefore defer to a frontmost viewer.
+//
+// The straddle cases matter more here than anywhere else in the app: this
+// viewport has NO `lostpointercapture` handler and calls `setPointerCapture`
+// once a real drag engages, so a pan that begins before the viewer opens keeps
+// receiving moves afterwards and CANNOT be stopped by a start-gate alone.
+//
+// Every blocked case is paired with an EMPTY-STACK REGRESSION proving the
+// gesture is untouched with no lease held. Every guard in ItemGraph.svelte is
+// mutation-verified to kill at least one case below — there is no guard here
+// that a test cannot fail on, because the one that would have been (pointerup)
+// was deleted rather than kept as decoration.
+//
+// HOW TO READ THE PAIRS. The BLOCKED tests are what fail if a guard is deleted
+// or weakened. The EMPTY-STACK REGRESSIONS are the opposite check — they fail
+// if a guard declines UNCONDITIONALLY, which is the way a "deference" change
+// silently breaks the app for the 99% of the time no viewer is open. Neither
+// half subsumes the other, and an empty-stack test passing with the guard
+// removed is by design, not a false green. Every guard in the files under test
+// was mutation-verified to kill at least one case here (one documented
+// exception, flagged at the guard itself).
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/svelte';
+import { tick, flushSync } from 'svelte';
+
+vi.mock('$lib/api/client', () => ({
+	api: {
+		graph: {
+			// A single focused node is enough to reach `loadState === 'ready'`,
+			// which is what renders the pannable <g transform=…> the pan
+			// assertions read.
+			getFocused: vi.fn(async () => ({
+				nodes: [
+					{
+						id: 'id-1',
+						ref: 'TASK-1',
+						title: 'Focus',
+						collection: 'tasks',
+						status: 'todo',
+						is_terminal: false,
+						child_count: 0,
+						updated_at: '2026-01-01T00:00:00Z',
+					},
+				],
+				edges: [],
+			})),
+		},
+	},
+}));
+vi.mock('$lib/services/sse.svelte', () => ({
+	sseService: {
+		onItemEvent: () => () => {},
+		onSyncRequired: () => () => {},
+	},
+}));
+
+import ItemGraph from './ItemGraph.svelte';
+import { acquire, __resetViewerBackdropForTests } from '$lib/a11y/viewerBackdrop';
+
+function baseProps(overrides: Record<string, unknown> = {}) {
+	return {
+		workspace: 'ws',
+		focusRef: 'TASK-1',
+		itemHref: () => '/x',
+		onOpenTarget: vi.fn(),
+		...overrides,
+	};
+}
+
+function viewport(): HTMLElement {
+	const el = document.querySelector('.viewport');
+	if (!el) throw new Error('.viewport not found');
+	return el as HTMLElement;
+}
+
+/** The pannable content transform — the observable proof a pan moved anything. */
+function transform(): string {
+	const el = document.querySelector('.viewport svg g[transform^="translate"]');
+	return el?.getAttribute('transform') ?? '';
+}
+
+function mountViewer(): HTMLElement {
+	const root = document.createElement('div');
+	root.className = 'attachment-viewer';
+	root.setAttribute('role', 'dialog');
+	document.body.appendChild(root);
+	return root;
+}
+
+/** jsdom has no PointerEvent; MouseEvent + the pointer fields the code reads. */
+function pointer(type: string, x: number, y: number, buttons = 1): Event {
+	const e = new MouseEvent(type, { bubbles: true, cancelable: true, clientX: x, clientY: y });
+	Object.defineProperty(e, 'pointerId', { value: 7 });
+	Object.defineProperty(e, 'buttons', { value: buttons });
+	Object.defineProperty(e, 'button', { value: 0 });
+	return e;
+}
+
+let captured: number[] = [];
+let released: number[] = [];
+/** Raw prototype assignments below; `vi.restoreAllMocks()` cannot undo those. */
+/**
+ * Put a prototype method back EXACTLY as it was. jsdom ships neither
+ * pointer-capture method, so assigning the captured `undefined` would CREATE an
+ * own property and flip `in` / `hasOwn` feature detection for later tests —
+ * delete instead.
+ */
+function restoreProto(name: string, original: unknown) {
+	if (original === undefined) {
+		delete (Element.prototype as unknown as Record<string, unknown>)[name];
+	} else {
+		(Element.prototype as unknown as Record<string, unknown>)[name] = original;
+	}
+}
+
+const REAL = {
+	setPointerCapture: Element.prototype.setPointerCapture,
+	releasePointerCapture: Element.prototype.releasePointerCapture,
+};
+
+beforeEach(() => {
+	captured = [];
+	released = [];
+	// jsdom implements neither; record the calls so the straddle tests can
+	// assert the capture is actually RELEASED, not merely ignored.
+	(Element.prototype as unknown as Record<string, unknown>).setPointerCapture = function (
+		id: number,
+	) {
+		captured.push(id);
+	};
+	(Element.prototype as unknown as Record<string, unknown>).releasePointerCapture = function (
+		id: number,
+	) {
+		released.push(id);
+	};
+});
+
+afterEach(() => {
+	cleanup();
+	__resetViewerBackdropForTests();
+	restoreProto('setPointerCapture', REAL.setPointerCapture);
+	restoreProto('releasePointerCapture', REAL.releasePointerCapture);
+	vi.restoreAllMocks();
+	document.body.innerHTML = '';
+});
+
+async function mount() {
+	render(ItemGraph, { props: baseProps() });
+	// Mount kicks off the fetch; the resolved payload then lays out with dagre.
+	// Poll rather than count ticks — the chain is async and layout-dependent.
+	for (let i = 0; i < 50 && !document.querySelector('.viewport svg .node'); i++) {
+		await new Promise((r) => setTimeout(r, 5));
+		flushSync();
+	}
+	// FAIL LOUDLY rather than fall through. Every blocked-gesture assertion below
+	// is negative ("nothing moved"), so a viewport still stuck in `loading` — no
+	// pannable <g>, no nodes — would satisfy all of them vacuously. Assert the
+	// component actually reached its ready state before any test runs.
+	expect(document.querySelector('.viewport svg .node')).not.toBeNull();
+	expect(document.querySelector('.viewport .state-overlay')).toBeNull();
+	expect(transform()).toMatch(/^translate\(/);
+	return viewport();
+}
+
+describe('ItemGraph — wheel zoom (TASK-2430)', () => {
+	it('EMPTY-STACK REGRESSION: consumes the wheel and zooms with no lease held', async () => {
+		const vp = await mount();
+		const e = new WheelEvent('wheel', { bubbles: true, cancelable: true, deltaY: -100 });
+		vp.dispatchEvent(e);
+		// `preventDefault()` is the first thing the un-blocked path does, so it is
+		// the cleanest observable signal that the handler ran.
+		expect(e.defaultPrevented).toBe(true);
+	});
+
+	it('leaves the wheel alone while a viewer lease is frontmost, and takes it back on release', async () => {
+		const vp = await mount();
+		const lease = acquire(mountViewer());
+
+		const blocked = new WheelEvent('wheel', { bubbles: true, cancelable: true, deltaY: -100 });
+		vp.dispatchEvent(blocked);
+		expect(blocked.defaultPrevented).toBe(false);
+
+		lease.release();
+		const after = new WheelEvent('wheel', { bubbles: true, cancelable: true, deltaY: -100 });
+		vp.dispatchEvent(after);
+		expect(after.defaultPrevented).toBe(true);
+	});
+});
+
+describe('ItemGraph — pan (TASK-2430)', () => {
+	it('EMPTY-STACK REGRESSION: a drag still engages and captures the pointer', async () => {
+		const vp = await mount();
+		const baseline = transform();
+		vp.dispatchEvent(pointer('pointerdown', 100, 100));
+		vp.dispatchEvent(pointer('pointermove', 200, 200));
+		flushSync();
+		expect(captured).toEqual([7]);
+		expect(transform()).not.toBe(baseline);
+
+		vp.dispatchEvent(pointer('pointerup', 200, 200, 0));
+		expect(released).toEqual([7]);
+	});
+
+	it('does not START a pan while a viewer lease is frontmost', async () => {
+		const vp = await mount();
+		const baseline = transform();
+		acquire(mountViewer());
+
+		vp.dispatchEvent(pointer('pointerdown', 100, 100));
+		vp.dispatchEvent(pointer('pointermove', 200, 200));
+		flushSync();
+		expect(captured).toEqual([]);
+		expect(transform()).toBe(baseline);
+	});
+
+	it('a press made under a viewer does not become a pan when the viewer closes', async () => {
+		// The move gate alone would satisfy the "does not START" test above — it
+		// aborts on the next event either way. This is what makes the START gate
+		// itself load-bearing: the press never armed the drag, so nothing resumes.
+		const vp = await mount();
+		const baseline = transform();
+		const lease = acquire(mountViewer());
+		vp.dispatchEvent(pointer('pointerdown', 100, 100));
+
+		lease.release();
+		vp.dispatchEvent(pointer('pointermove', 300, 300));
+		flushSync();
+		expect(captured).toEqual([]);
+		expect(transform()).toBe(baseline);
+	});
+
+	it('STRADDLE: a pan already holding the pointer capture is torn down when the viewer opens', async () => {
+		const vp = await mount();
+		const baseline = transform();
+		// Engage a real pan first — capture is now held by the viewport.
+		vp.dispatchEvent(pointer('pointerdown', 100, 100));
+		vp.dispatchEvent(pointer('pointermove', 150, 150));
+		flushSync();
+		expect(captured).toEqual([7]);
+		const engaged = transform();
+		expect(engaged).not.toBe(baseline);
+
+		// The viewer opens mid-gesture.
+		acquire(mountViewer());
+		vp.dispatchEvent(pointer('pointermove', 400, 400));
+		flushSync();
+		// The pan neither advanced…
+		expect(transform()).toBe(engaged);
+		// …nor kept the capture — which is the part an early `return` alone would
+		// get wrong, leaving this canvas swallowing every pointer event on the
+		// page while the viewer is up.
+		expect(released).toEqual([7]);
+
+		// And a further move changes nothing: the drag is genuinely over.
+		vp.dispatchEvent(pointer('pointermove', 800, 800));
+		flushSync();
+		expect(transform()).toBe(engaged);
+	});
+
+	// There is deliberately NO arbitration gate on pointerup (see the note at
+	// `onPointerUp` in ItemGraph.svelte — it would be unfalsifiable dead code).
+	// This asserts the INVARIANT that must hold without one: a viewer opening
+	// between the last move and the release still leaves nothing captured.
+	it('a press whose pointerup RETARGETS to the viewer cannot resume a pan later', async () => {
+		// The one sequence the move/end gates cannot see (review round 10): the
+		// press never crosses DRAG_THRESHOLD, so no capture is taken; the viewer
+		// then opens and the release lands on the PORTALED viewer, so this
+		// viewport's `onPointerUp` never runs at all and `maybeDrag` stays
+		// latched. Pre-existing — capture-less presses ending off-viewport have
+		// always been possible — and the existing `(e.buttons & 1) === 0` abort in
+		// `onPointerMove` is the mitigation. Asserted here so the deletion of the
+		// pointerup gate cannot be blamed for it, and so the mitigation cannot be
+		// removed silently.
+		const vp = await mount();
+		const baseline = transform();
+		vp.dispatchEvent(pointer('pointerdown', 100, 100));
+
+		// Viewer opens; the release goes to the viewer, never to the viewport.
+		const viewer = mountViewer();
+		const lease = acquire(viewer);
+		viewer.dispatchEvent(pointer('pointerup', 120, 120, 0));
+		lease.release();
+
+		// A later move with NO button held must abort the stale press, not pan.
+		vp.dispatchEvent(pointer('pointermove', 600, 600, 0));
+		flushSync();
+		expect(captured).toEqual([]);
+		expect(transform()).toBe(baseline);
+
+		// ...and the press is genuinely dead: even a button-held move does nothing
+		// until a fresh pointerdown arrives.
+		vp.dispatchEvent(pointer('pointermove', 700, 700));
+		flushSync();
+		expect(captured).toEqual([]);
+		expect(transform()).toBe(baseline);
+	});
+
+	it('STRADDLE: a viewer opening between the last move and pointerup still releases the capture', async () => {
+		const vp = await mount();
+		vp.dispatchEvent(pointer('pointerdown', 100, 100));
+		vp.dispatchEvent(pointer('pointermove', 150, 150));
+		flushSync();
+		expect(captured).toEqual([7]);
+
+		acquire(mountViewer());
+		vp.dispatchEvent(pointer('pointerup', 150, 150, 0));
+		expect(released).toEqual([7]);
+	});
+});

--- a/web/src/lib/components/items/ItemAttachmentStrip.svelte
+++ b/web/src/lib/components/items/ItemAttachmentStrip.svelte
@@ -53,7 +53,7 @@
 	import AttachmentDeleteConfirm, {
 		attachmentDeletePrompt,
 	} from '$lib/components/attachments/AttachmentDeleteConfirm.svelte';
-	import Lightbox, { type LightboxImage } from '$lib/components/common/Lightbox.svelte';
+	import Lightbox from '$lib/components/common/Lightbox.svelte';
 	import { attachmentRefsIn } from '$lib/utils/commentAttachments';
 	import { invalidateAttachmentMetadata } from '$lib/components/editor/attachment-metadata';
 	import { toastStore } from '$lib/stores/toast.svelte';
@@ -62,6 +62,10 @@
 		notifyAttachmentPanelOpen,
 		registerAttachmentDeletionListener,
 		registerAttachmentUploadListener,
+		// The viewer's image shape lives on the channel, not on the component
+		// (TASK-2431) — one declaration for the direct mounts and the bus alike.
+		// A type-only import, so the test's module mock is unaffected.
+		type LightboxImage,
 	} from '$lib/attachments/events';
 	import { viewIdentity, createFence, createPaintFence } from '$lib/attachments/viewFence';
 
@@ -146,6 +150,16 @@
 		filename: string;
 		mime_type: string;
 		size_bytes: number;
+		/**
+		 * Intrinsic pixels, OPTIONAL and nullable (TASK-2431). The list row has
+		 * them, an upload event does not (`UploadedAttachment` is four fields),
+		 * and no tile reads them — they are carried so the set handed to the
+		 * viewer is complete, which is what keeps phase 3b's pixel-based loading
+		 * policy from having to reopen every producer. Optional rather than
+		 * required precisely so the upload buffer stays assignable to this type.
+		 */
+		width?: number | null;
+		height?: number | null;
 	}
 
 	function toStripAttachment(row: AttachmentListItem): StripAttachment {
@@ -154,6 +168,8 @@
 			filename: row.filename,
 			mime_type: row.mime_type,
 			size_bytes: row.size_bytes,
+			width: row.width ?? null,
+			height: row.height ?? null,
 		};
 	}
 
@@ -164,7 +180,12 @@
 
 	let attachments = $state<StripAttachment[]>([]);
 	let expanded = $state(false);
-	let lightbox = $state<{ images: LightboxImage[]; index: number } | null>(null);
+	let lightbox = $state<{
+		images: LightboxImage[];
+		index: number;
+		/** The tile that opened it — focus goes back here on close (TASK-2431). */
+		invoker: HTMLElement | null;
+	} | null>(null);
 	/**
 	 * The delete confirmation currently on screen, if any (PLAN-2392 DR-18 /
 	 * TASK-2425). One at a time: opening a second supersedes the first, which
@@ -653,16 +674,36 @@
 	// reaches the viewer, because SVG can carry active content. Both this list
 	// and the tile branch below read the same predicate, so a file tile can
 	// never be a member of the lightbox's set.
+	//
+	// The full row is threaded, not just `{id, alt}` (TASK-2431): `mime_type`
+	// so the set carries its own evidence of why each member passed the gate,
+	// and `size_bytes` / `width` / `height` so 3b's loading policy has them.
+	// The strip is the one producer that knows all of it from its list row.
 	let lightboxImages = $derived<LightboxImage[]>(
 		attachments
 			.filter((a) => canOpenInViewer(a.mime_type))
-			.map((a) => ({ id: a.id, alt: displayFilename(a.filename) }))
+			.map((a) => ({
+				id: a.id,
+				alt: displayFilename(a.filename),
+				filename: a.filename || null,
+				mime_type: a.mime_type,
+				size_bytes: a.size_bytes ?? null,
+				width: a.width ?? null,
+				height: a.height ?? null,
+			}))
 	);
 
-	function openLightbox(att: StripAttachment) {
+	/**
+	 * `invoker` is the tile's own button — the viewer returns focus to it on
+	 * close. It has to be passed rather than inferred: `Lightbox` falls back to
+	 * whatever held focus at open, which is right for a click but says nothing
+	 * useful when the open came from somewhere else, and the fallback runs
+	 * AFTER the viewer's own focus entry in some orders.
+	 */
+	function openLightbox(att: StripAttachment, invoker: HTMLElement | null = null) {
 		const index = lightboxImages.findIndex((img) => img.id === att.id);
 		if (index < 0) return;
-		lightbox = { images: lightboxImages, index };
+		lightbox = { images: lightboxImages, index, invoker };
 	}
 
 	/** What the file IS — the tooltip, and the base of the accessible name. */
@@ -924,7 +965,7 @@
 									class="att-tile"
 									title={tileLabel(att)}
 									aria-label={tileActionLabel(att)}
-									onclick={() => openLightbox(att)}
+									onclick={(e) => openLightbox(att, e.currentTarget)}
 								>
 									<img
 										src={api.attachments.downloadUrl(wsSlug, att.id, 'thumb-sm')}
@@ -1042,14 +1083,36 @@
 	</Menu>
 {/if}
 
-{#if lightbox}
-	<Lightbox
-		images={lightbox.images}
-		index={lightbox.index}
-		{wsSlug}
-		onClose={() => (lightbox = null)}
-	/>
-{/if}
+<!--
+	Keyed per open (TASK-2431), the shape `AttachmentViewerHost` uses. `Lightbox`
+	seeds its INDEX once through `untrack`, so replacing `lightbox` while a
+	viewer is already up would reuse the instance and open the new set at the old
+	position. (Its MIME filter is `$derived` and would re-answer on its own —
+	the index is what cannot.) Nothing reaches that state today, the open viewer
+	being inert over everything that could cause it, which is why this belongs in
+	the structure rather than resting on a fact about the current UI.
+
+	Accepted cost, recorded: a keyed block DESTROYS the old instance before
+	creating the new one, so a viewer→viewer swap briefly releases the last
+	backdrop lease (un-inerting the app) and runs the old viewer's focus restore
+	before the new one takes focus. That is the same transient
+	`AttachmentViewerHost` has carried since TASK-2428, it is unreachable from
+	the UI (the open viewer inerts every control that could trigger it), and the
+	alternative — a reused instance showing a stale set — is the worse of the
+	two. Only a viewer→NULL→viewer sequence happens in practice, where the
+	release is meant to happen anyway.
+-->
+{#key lightbox}
+	{#if lightbox}
+		<Lightbox
+			images={lightbox.images}
+			index={lightbox.index}
+			{wsSlug}
+			invoker={lightbox.invoker}
+			onClose={() => (lightbox = null)}
+		/>
+	{/if}
+{/key}
 
 <style>
 	.attachment-strip {

--- a/web/src/lib/components/items/ItemAttachmentStrip.svelte.test.ts
+++ b/web/src/lib/components/items/ItemAttachmentStrip.svelte.test.ts
@@ -356,6 +356,33 @@ describe('ItemAttachmentStrip', () => {
 		expect(document.querySelector('.lightbox-counter')?.textContent).toBe('2 / 2');
 	});
 
+	it('opens a FRESH viewer when a second tile is activated (TASK-2431)', async () => {
+		// The viewer seeds its index — and its own MIME filter — once at mount,
+		// so the mount must be keyed per open. Without that, a second open reuses
+		// the instance and keeps showing the first image.
+		//
+		// In the app an open viewer inerts the tiles behind it, so this is
+		// insurance rather than a live path; jsdom does not implement inertness,
+		// which is what makes the invariant testable at all.
+		listMock.mockResolvedValue(response([att({ id: 'img1' }), att({ id: 'img2' })]));
+		mountStrip('item-a');
+		await settle();
+
+		tiles()[0].click();
+		flushSync();
+		expect(
+			document.querySelector<HTMLImageElement>('.lightbox-image')?.getAttribute('alt')
+		).toBe('img1.png');
+
+		tiles()[1].click();
+		flushSync();
+		expect(
+			document.querySelector<HTMLImageElement>('.lightbox-image')?.getAttribute('alt')
+		).toBe('img2.png');
+		// ...and exactly one viewer, not two stacked.
+		expect(document.querySelectorAll('.lightbox-backdrop')).toHaveLength(1);
+	});
+
 	it('opens the lightbox at the IMAGE index, not the attachment index', async () => {
 		// Interleaved non-images: a naive `attachments.indexOf(att)` would open
 		// the wrong image, since the lightbox only ever receives image rows.

--- a/web/src/lib/components/items/ItemAttachmentStrip.svelte.test.ts
+++ b/web/src/lib/components/items/ItemAttachmentStrip.svelte.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { flushSync, mount, unmount } from 'svelte';
 import type { AttachmentListItem, AttachmentListResponse } from '$lib/types';
 import type { UploadedAttachment } from '$lib/attachments/events';
+import { runTopEscape, _resetEscapeStackForTests } from '$lib/stores/escapeStack';
 
 // TASK-2383. The strip is mounted OUTSIDE ItemDetail's `{#key itemSlug}`
 // block, so it PERSISTS across an A→B item switch — the no-{#key} bug class
@@ -163,6 +164,9 @@ describe('ItemAttachmentStrip', () => {
 		if (instance) unmount(instance);
 		instance = undefined;
 		target.remove();
+		// The viewer registers on the shared ESC stack (TASK-2429); a case that
+		// leaves one open would otherwise leak a handler into the next test.
+		_resetEscapeStackForTests();
 	});
 
 	function mountStrip(itemId: string | null) {
@@ -381,7 +385,16 @@ describe('ItemAttachmentStrip', () => {
 			'img1.png'
 		);
 
+		// Escape is no longer a local `window` listener on the viewer (TASK-2429):
+		// the shared `escapeStack` is its ONE owner, driven by the route host. So
+		// the close is exercised the way the app reaches it — through the stack —
+		// and a raw keydown is asserted to do NOTHING, which is the regression
+		// that would reintroduce the two-owners-one-press bug.
 		window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+		flushSync();
+		expect(document.querySelector('.lightbox-backdrop')).not.toBeNull();
+
+		expect(runTopEscape()).toBe(true);
 		flushSync();
 		expect(document.querySelector('.lightbox-backdrop')).toBeNull();
 	});

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -43,7 +43,9 @@
 	import CopyItemDialog from '$lib/components/items/CopyItemDialog.svelte';
 	import ItemAttachmentStrip from '$lib/components/items/ItemAttachmentStrip.svelte';
 	import AttachmentPanelHost from '$lib/components/attachments/AttachmentPanelHost.svelte';
+	import AttachmentViewerHost from '$lib/components/attachments/AttachmentViewerHost.svelte';
 	import { createAttachmentHostToken } from '$lib/attachments/events';
+	import { createViewerResourceGen } from '$lib/attachments/viewerResource.svelte';
 	import { copyToClipboard } from '$lib/utils/clipboard';
 	import { repairDeadItemLastRoute } from '$lib/collections/paneUrlParams';
 	import { isSamePaneTarget, breadcrumbParentTarget } from '$lib/collections/paneTarget';
@@ -409,6 +411,36 @@
 	$effect(() => {
 		onReady?.(scrollReady);
 	});
+
+	// Viewer-resource generation (PLAN-2392 / TASK-2428). A DEDICATED reactive
+	// counter that advances only when the LOADED item resource actually changes
+	// — the item this instance is showing, workspace included (IDEA-2135's
+	// same-ref-different-workspace case), and only once it matches the requested
+	// ref rather than mid-switch.
+	//
+	// It exists because neither of the two counters already here can be used:
+	// `loadGeneration` is a plain non-reactive fence bumped by EVERY loadData()
+	// — including the same-item reload after a collection schema edit — so a
+	// consumer keyed on it would tear down on a refresh that changed nothing it
+	// can see, and `itemGen` is bumped by every optimistic item write. The route
+	// is not usable either: a collection-only or username-only URL change
+	// preserves the item.
+	//
+	// Derived-then-observed rather than incremented at each `item = ...` site:
+	// there are ~30 of those and most are same-item writes. One key comparison
+	// states the rule once and cannot be forgotten by a future assignment.
+	//
+	// Both the rule and the effect that applies it live in
+	// `$lib/attachments/viewerResource*` so they are unit-testable: inline here
+	// they could only be exercised through the host's props, which are handed the
+	// answer and so cannot tell a correct counter from one that never moves
+	// (Codex round 6). The self-write discipline this effect needs — never read
+	// `gen` in the tracked scope — is documented and pinned there.
+	const viewerResource = createViewerResourceGen(() => ({
+		workspaceSlug: loadedItemWsSlug,
+		itemId: item?.id,
+		loaded: itemMatchesRef && item !== null,
+	}));
 
 	// Resolved identity for the host's `?item == master` guard (TASK-2173). Non-
 	// reactive-write $derived (CONVE-1688: the emit effect below only READS it):
@@ -5815,6 +5847,29 @@
 		{/key}
 	{/if}
 {/if}
+
+<!-- The image viewer's host (PLAN-2392 phase 3a / TASK-2428). One per
+     `ItemDetail` mount, sharing the token the panel host uses — one token per
+     HOST, not one per channel — and carrying no `mutationsEnabled`, because
+     3a's viewer has no mutating action and a dead prop is worse than none.
+
+     TOP LEVEL, not beside `AttachmentPanelHost` inside the `{:else if item &&
+     collection}` branch, and that placement is the whole lifecycle rule: every
+     `loadData()` sets `loading = true`, which swaps that entire subtree for the
+     skeleton — including a same-item schema reload after a collection edit.
+     Mounted in there, an open viewer would be destroyed by a background refresh
+     that changed nothing the user can see. Out here it survives, and closes on
+     exactly one thing: a resource switch, via the props below.
+
+     `itemId` is gated on `itemMatchesRef` (the TASK-2112 switch boundary) so a
+     mid-switch host addresses nothing; `resourceGen` is the dedicated counter
+     that advances only on a real loaded-item resource change — never on
+     `loadGeneration`, which every refresh bumps. -->
+<AttachmentViewerHost
+	itemId={itemMatchesRef ? item?.id : null}
+	hostToken={attachmentHostToken}
+	resourceGen={viewerResource.current}
+/>
 
 <style>
 	.center-message {

--- a/web/src/lib/components/layout/DockedSheet.svelte
+++ b/web/src/lib/components/layout/DockedSheet.svelte
@@ -13,6 +13,7 @@
 	import type { Snippet } from 'svelte';
 	import { fly, fade } from 'svelte/transition';
 	import { cubicOut } from 'svelte/easing';
+	import { isBlockedByModal } from '$lib/a11y/viewerBackdrop';
 
 	let {
 		open,
@@ -33,15 +34,61 @@
 	let startY = 0;
 	const DISMISS_PX = 90;
 
+	let panelEl = $state<HTMLElement | null>(null);
+
+	/**
+	 * TASK-2430 — this sheet is a GLOBAL Escape/gesture owner (three instances
+	 * stay mounted by `BottomNav`), so it has to ask whether something is in
+	 * FRONT of it before acting. `isBlockedByModal` is the shared arbitration
+	 * helper: it answers from viewer LEASE state plus the native `dialog:modal`
+	 * top layer, and returns **false on an empty stack** — with no viewer and no
+	 * native modal open, every path below behaves exactly as it did before.
+	 *
+	 * The argument is the SURFACE ASKING TO ACT (our own panel), not
+	 * `event.target`: a viewer opened FROM this sheet leaves focus/target inside
+	 * the sheet, and target-based arbitration would then wrongly let the sheet
+	 * dismiss itself out from under the viewer it launched.
+	 */
+	function blockedByFrontLayer(): boolean {
+		return isBlockedByModal(panelEl);
+	}
+
+	function cancelDrag() {
+		dragging = false;
+		dragY = 0;
+	}
+
 	function onTouchStart(e: TouchEvent) {
+		// Gesture START gate.
+		if (blockedByFrontLayer()) return;
 		startY = e.touches[0].clientY;
 		dragging = true;
 	}
 	function onTouchMove(e: TouchEvent) {
 		if (!dragging) return;
+		// STRADDLE gate: a swipe can begin before a viewer opens and keep
+		// delivering moves afterwards (touch events continue to their original
+		// target). Abandon the drag rather than keep translating the panel.
+		if (blockedByFrontLayer()) {
+			cancelDrag();
+			return;
+		}
 		dragY = Math.max(0, e.touches[0].clientY - startY);
 	}
 	function onTouchEnd() {
+		// STRADDLE gate on the terminal event — the release is what would actually
+		// call `onclose()`, so this is the one that must not fire under a viewer.
+		//
+		// The gate is the ONLY addition: no `if (!dragging) return` above it, so
+		// the un-blocked path below is byte for byte the original terminal
+		// cleanup. An early bail there was tried and removed — with a stray or
+		// duplicate touchend it skipped `dragging = false` / `dragY = 0`, which is
+		// a state-path difference in a task that promises none without a viewer,
+		// for no benefit (`dragY` is only ever non-zero while `dragging`).
+		if (blockedByFrontLayer()) {
+			cancelDrag();
+			return;
+		}
 		dragging = false;
 		if (dragY > DISMISS_PX) {
 			onclose();
@@ -50,7 +97,15 @@
 	}
 
 	function onKeydown(e: KeyboardEvent) {
-		if (open && e.key === 'Escape') onclose();
+		if (!open || e.key !== 'Escape') return;
+		// ONLY the frontmost-layer check. This handler still closes on an Escape a
+		// control already handled, exactly as it always has — TASK-2430 added a
+		// `defaultPrevented` bail here and it was REVERTED: it is a defensible
+		// change on its own merits, but it fires with NO viewer present, and this
+		// task's contract is that an empty lease leaves behaviour untouched. It
+		// belongs in its own item, not smuggled into an attachments phase.
+		if (blockedByFrontLayer()) return;
+		onclose();
 	}
 </script>
 
@@ -61,6 +116,7 @@
 	<!-- svelte-ignore a11y_no_static_element_interactions -->
 	<div class="ds-backdrop" onclick={onclose} transition:fade={{ duration: 160 }}></div>
 	<div
+		bind:this={panelEl}
 		class="ds-panel"
 		role="dialog"
 		aria-modal="true"

--- a/web/src/lib/components/layout/DockedSheet.svelte
+++ b/web/src/lib/components/layout/DockedSheet.svelte
@@ -48,9 +48,19 @@
 	 * `event.target`: a viewer opened FROM this sheet leaves focus/target inside
 	 * the sheet, and target-based arbitration would then wrongly let the sheet
 	 * dismiss itself out from under the viewer it launched.
+	 *
+	 * TASK-2448 adds the optional `event`. `isBlockedByModal` alone answers "is a
+	 * viewer in front RIGHT NOW", and for a KEYDOWN that is the wrong moment to
+	 * ask: the viewer's own Escape handler runs earlier in the same dispatch and
+	 * tears the viewer down synchronously, so by the time this listener runs the
+	 * lease is already gone and the honest answer to the live question is "no".
+	 * Passing the event asks the EVENT-SCOPED question instead — "has a viewer
+	 * already spent this press" — which the viewer answered before it died. The
+	 * gesture paths below keep the live question: a touch sequence is not one
+	 * dispatch, and nothing marks it.
 	 */
-	function blockedByFrontLayer(): boolean {
-		return isBlockedByModal(panelEl);
+	function blockedByFrontLayer(event?: Event): boolean {
+		return isBlockedByModal(panelEl, event);
 	}
 
 	function cancelDrag() {
@@ -104,7 +114,15 @@
 		// change on its own merits, but it fires with NO viewer present, and this
 		// task's contract is that an empty lease leaves behaviour untouched. It
 		// belongs in its own item, not smuggled into an attachments phase.
-		if (blockedByFrontLayer()) return;
+		//
+		// DELIBERATE, NAMED BEHAVIOUR CHANGE (TASK-2448 / BUG-2441) — the FOURTH
+		// named parity exception of PLAN-2392 phase 3a. This sheet now declines an
+		// Escape a VIEWER has already consumed in the same dispatch. It is not the
+		// reverted `defaultPrevented` bail: this marker is set ONLY by a frontmost
+		// viewer's escape handler, so with no viewer open it can never be set and
+		// this line is exactly `blockedByFrontLayer()` as before — the empty-stack
+		// contract 2430 broke is kept intact.
+		if (blockedByFrontLayer(e)) return;
 		onclose();
 	}
 </script>

--- a/web/src/lib/components/layout/DockedSheet.svelte
+++ b/web/src/lib/components/layout/DockedSheet.svelte
@@ -108,6 +108,14 @@
 
 	function onKeydown(e: KeyboardEvent) {
 		if (!open || e.key !== 'Escape') return;
+		// A HELD Escape fires many auto-repeat keydowns, and each is a FRESH
+		// event object — so the viewer's per-event consumption mark (BUG-2441)
+		// cannot cover them: by the second repeat its lease is already gone and
+		// the event is unmarked, so a hold would close the viewer and then this
+		// sheet. Only the initial physical press acts. The two route guards
+		// already do exactly this ([collection]/+page.svelte, [slug]/+page.svelte);
+		// this closes the same hole for the owners that did not (TASK-2448).
+		if (e.repeat) return;
 		// ONLY the frontmost-layer check. This handler still closes on an Escape a
 		// control already handled, exactly as it always has — TASK-2430 added a
 		// `defaultPrevented` bail here and it was REVERTED: it is a defensible

--- a/web/src/lib/components/layout/DockedSheet.svelte.test.ts
+++ b/web/src/lib/components/layout/DockedSheet.svelte.test.ts
@@ -70,6 +70,16 @@ function escape(): KeyboardEvent {
 	return new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true });
 }
 
+/** An auto-repeat Escape — what a HELD key fires after the first press. */
+function escapeRepeat(): KeyboardEvent {
+	return new KeyboardEvent('keydown', {
+		key: 'Escape',
+		bubbles: true,
+		cancelable: true,
+		repeat: true,
+	});
+}
+
 afterEach(() => {
 	cleanup();
 	__resetViewerBackdropForTests();
@@ -88,6 +98,35 @@ describe('DockedSheet — Escape ownership (TASK-2430)', () => {
 		expect(onclose).toHaveBeenCalledTimes(1);
 	});
 
+	it('ignores an auto-repeat Escape, so a HELD key cannot cascade past the viewer', async () => {
+		// BUG-2441's per-event consumption mark cannot cover a hold: every
+		// auto-repeat is a FRESH event object, and by the second one the
+		// viewer's lease is already released — so an unguarded handler would
+		// close the viewer on the first press and this sheet on the second,
+		// from ONE physical press. Found by the final full-diff review
+		// (TASK-2448); the two route guards already rejected repeats.
+		const onclose = vi.fn();
+		render(DockedSheet, { props: baseProps({ onclose }) });
+		await tick();
+		flushSync();
+
+		window.dispatchEvent(escapeRepeat());
+		expect(onclose).not.toHaveBeenCalled();
+	});
+	it('EMPTY-STACK REGRESSION: a repeat is ignored but the next REAL press still closes', async () => {
+		// The other half: the guard must reject repeats WITHOUT deadening the
+		// handler. A guard that declined unconditionally would pass the test
+		// above and break the sheet entirely.
+		const onclose = vi.fn();
+		render(DockedSheet, { props: baseProps({ onclose }) });
+		await tick();
+		flushSync();
+
+		window.dispatchEvent(escapeRepeat());
+		expect(onclose).not.toHaveBeenCalled();
+		window.dispatchEvent(escape());
+		expect(onclose).toHaveBeenCalledTimes(1);
+	});
 	it('declines Escape while a viewer lease is frontmost', async () => {
 		const onclose = vi.fn();
 		render(DockedSheet, { props: baseProps({ onclose }) });

--- a/web/src/lib/components/layout/DockedSheet.svelte.test.ts
+++ b/web/src/lib/components/layout/DockedSheet.svelte.test.ts
@@ -1,0 +1,263 @@
+// Runs in the jsdom vitest project (filename ends `.svelte.test.ts`).
+//
+// TASK-2430 — DockedSheet is a GLOBAL Escape + touch-gesture owner: three
+// instances stay mounted by `BottomNav`, its Escape listener is on `window`,
+// and it is a `role="dialog"` that is NOT registered with any escape stack.
+// Before this change it closed on EVERY Escape — including one meant for a
+// viewer stacked above it — and its swipe-to-dismiss could start before a
+// viewer opened and still dismiss the sheet afterwards.
+//
+// Every case here comes in a pair: BLOCKED (a viewer lease is frontmost) and
+// the EMPTY-STACK REGRESSION (no lease at all → byte-identical old behaviour).
+// The regressions are the half that would hide a real bug: a guard that
+// declines unconditionally passes every "does not close" assertion.
+//
+// HOW TO READ THE PAIRS. The BLOCKED tests are what fail if a guard is deleted
+// or weakened. The EMPTY-STACK REGRESSIONS are the opposite check — they fail
+// if a guard declines UNCONDITIONALLY, which is the way a "deference" change
+// silently breaks the app for the 99% of the time no viewer is open. Neither
+// half subsumes the other, and an empty-stack test passing with the guard
+// removed is by design, not a false green. Every guard in the files under test
+// was mutation-verified to kill at least one case here (one documented
+// exception, flagged at the guard itself).
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/svelte';
+import { createRawSnippet, tick, flushSync } from 'svelte';
+import DockedSheet from './DockedSheet.svelte';
+import { acquire, __resetViewerBackdropForTests } from '$lib/a11y/viewerBackdrop';
+
+const bodySnippet = createRawSnippet(() => ({
+	render: () => `<div><button type="button">Inside</button></div>`,
+}));
+
+function baseProps(overrides: Record<string, unknown> = {}) {
+	return { open: true, onclose: vi.fn(), label: 'Menu', children: bodySnippet, ...overrides };
+}
+
+function panel(): HTMLElement {
+	const el = document.querySelector('.ds-panel');
+	if (!el) throw new Error('.ds-panel not found');
+	return el as HTMLElement;
+}
+
+function grip(): HTMLElement {
+	const el = document.querySelector('.ds-grip');
+	if (!el) throw new Error('.ds-grip not found');
+	return el as HTMLElement;
+}
+
+/** A body-portaled viewer root, exactly the shape `acquire` expects. */
+function mountViewer(): HTMLElement {
+	const root = document.createElement('div');
+	root.className = 'attachment-viewer';
+	root.setAttribute('role', 'dialog');
+	document.body.appendChild(root);
+	return root;
+}
+
+/** jsdom has no TouchEvent constructor; a plain Event with `touches` suffices. */
+function touch(type: string, clientY: number): Event {
+	const e = new Event(type, { bubbles: true, cancelable: true });
+	Object.defineProperty(e, 'touches', { value: [{ clientX: 0, clientY }] });
+	return e;
+}
+
+function escape(): KeyboardEvent {
+	return new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true });
+}
+
+afterEach(() => {
+	cleanup();
+	__resetViewerBackdropForTests();
+	vi.restoreAllMocks();
+	document.body.innerHTML = '';
+});
+
+describe('DockedSheet — Escape ownership (TASK-2430)', () => {
+	it('EMPTY-STACK REGRESSION: closes on Escape when no viewer lease exists', async () => {
+		const onclose = vi.fn();
+		render(DockedSheet, { props: baseProps({ onclose }) });
+		await tick();
+		flushSync();
+
+		window.dispatchEvent(escape());
+		expect(onclose).toHaveBeenCalledTimes(1);
+	});
+
+	it('declines Escape while a viewer lease is frontmost', async () => {
+		const onclose = vi.fn();
+		render(DockedSheet, { props: baseProps({ onclose }) });
+		await tick();
+		flushSync();
+
+		const lease = acquire(mountViewer());
+		window.dispatchEvent(escape());
+		expect(onclose).not.toHaveBeenCalled();
+
+		// …and takes Escape back the moment the viewer goes away, which is what
+		// proves the guard is lease-driven rather than a blanket refusal.
+		lease.release();
+		window.dispatchEvent(escape());
+		expect(onclose).toHaveBeenCalledTimes(1);
+	});
+
+	it('OWNER ARGUMENT: an Escape ORIGINATING inside the viewer is still declined', async () => {
+		// The discriminating case for "the argument is the SURFACE ASKING TO ACT,
+		// not `event.target`". The blocked test above dispatches on `window`,
+		// where the target is outside the viewer too, so it would ALSO pass with
+		// the wrong argument. This is the REALISTIC press: the viewer holds
+		// focus, so the event's target is a viewer control — and an `e.target`
+		// owner would answer "not blocked" and close the sheet underneath.
+		const onclose = vi.fn();
+		render(DockedSheet, { props: baseProps({ onclose }) });
+		await tick();
+		flushSync();
+
+		const viewer = mountViewer();
+		const btn = document.createElement('button');
+		viewer.appendChild(btn);
+		acquire(viewer);
+
+		btn.dispatchEvent(escape());
+		expect(onclose).not.toHaveBeenCalled();
+	});
+
+	it('EMPTY-STACK REGRESSION: still closes on an already-`defaultPrevented` Escape', () => {
+		// Unchanged behaviour, asserted so it stays that way. An earlier revision
+		// of TASK-2430 added a `defaultPrevented` bail here; it was reverted
+		// because it fires with no viewer present, which this task promises not to
+		// do. If that check is ever wanted, this test is the one to update — and
+		// updating it should be a deliberate act, not a silent side effect.
+		const onclose = vi.fn();
+		render(DockedSheet, { props: baseProps({ onclose }) });
+		flushSync();
+
+		const e = escape();
+		e.preventDefault();
+		window.dispatchEvent(e);
+		expect(onclose).toHaveBeenCalledTimes(1);
+	});
+
+	it('ignores Escape while closed (unchanged)', async () => {
+		const onclose = vi.fn();
+		render(DockedSheet, { props: baseProps({ open: false, onclose }) });
+		await tick();
+		flushSync();
+
+		window.dispatchEvent(escape());
+		expect(onclose).not.toHaveBeenCalled();
+	});
+});
+
+describe('DockedSheet — swipe-to-dismiss (TASK-2430)', () => {
+	it('EMPTY-STACK REGRESSION: a past-threshold swipe still dismisses', async () => {
+		const onclose = vi.fn();
+		render(DockedSheet, { props: baseProps({ onclose }) });
+		await tick();
+		flushSync();
+
+		const g = grip();
+		g.dispatchEvent(touch('touchstart', 0));
+		g.dispatchEvent(touch('touchmove', 200));
+		flushSync();
+		expect(panel().style.transform).toBe('translateY(200px)');
+		g.dispatchEvent(touch('touchend', 200));
+		expect(onclose).toHaveBeenCalledTimes(1);
+	});
+
+	it('EMPTY-STACK REGRESSION: a short swipe still snaps back without closing', async () => {
+		const onclose = vi.fn();
+		render(DockedSheet, { props: baseProps({ onclose }) });
+		await tick();
+		flushSync();
+
+		const g = grip();
+		g.dispatchEvent(touch('touchstart', 0));
+		g.dispatchEvent(touch('touchmove', 10));
+		g.dispatchEvent(touch('touchend', 10));
+		expect(onclose).not.toHaveBeenCalled();
+	});
+
+	it('does not START a swipe while a viewer lease is frontmost', async () => {
+		const onclose = vi.fn();
+		render(DockedSheet, { props: baseProps({ onclose }) });
+		await tick();
+		flushSync();
+
+		acquire(mountViewer());
+		const g = grip();
+		g.dispatchEvent(touch('touchstart', 0));
+		g.dispatchEvent(touch('touchmove', 200));
+		flushSync();
+		// Never engaged, so the panel never moved.
+		expect(panel().style.transform).toBe('');
+		g.dispatchEvent(touch('touchend', 200));
+		expect(onclose).not.toHaveBeenCalled();
+	});
+
+	it('a swipe STARTED under a viewer does not come alive when the viewer closes', async () => {
+		// The move/end gates alone would satisfy the "does not START" test above —
+		// they cancel the drag on the next event either way. This is what makes
+		// the START gate itself load-bearing: the touch under the viewer never
+		// armed the gesture, so nothing resumes once the lease is gone.
+		const onclose = vi.fn();
+		render(DockedSheet, { props: baseProps({ onclose }) });
+		await tick();
+		flushSync();
+
+		const lease = acquire(mountViewer());
+		const g = grip();
+		g.dispatchEvent(touch('touchstart', 0));
+
+		lease.release();
+		g.dispatchEvent(touch('touchmove', 200));
+		flushSync();
+		expect(panel().style.transform).toBe('');
+		g.dispatchEvent(touch('touchend', 200));
+		expect(onclose).not.toHaveBeenCalled();
+	});
+
+	it('STRADDLE: a swipe that began BEFORE the viewer opened is abandoned, not completed', async () => {
+		const onclose = vi.fn();
+		render(DockedSheet, { props: baseProps({ onclose }) });
+		await tick();
+		flushSync();
+
+		const g = grip();
+		// Gesture starts with no viewer — legitimately engages and drags.
+		g.dispatchEvent(touch('touchstart', 0));
+		g.dispatchEvent(touch('touchmove', 120));
+		flushSync();
+		expect(panel().style.transform).toBe('translateY(120px)');
+
+		// …the viewer opens mid-gesture. Touch events keep arriving at the same
+		// target, so the START gate alone would let this dismiss the sheet under
+		// the viewer.
+		acquire(mountViewer());
+		g.dispatchEvent(touch('touchmove', 200));
+		flushSync();
+		expect(panel().style.transform).toBe('');
+
+		g.dispatchEvent(touch('touchend', 200));
+		expect(onclose).not.toHaveBeenCalled();
+	});
+
+	it('STRADDLE: a viewer that opens between the last move and the release still blocks the dismiss', async () => {
+		const onclose = vi.fn();
+		render(DockedSheet, { props: baseProps({ onclose }) });
+		await tick();
+		flushSync();
+
+		const g = grip();
+		g.dispatchEvent(touch('touchstart', 0));
+		g.dispatchEvent(touch('touchmove', 200));
+		flushSync();
+		// Past the dismiss threshold and still un-blocked at this point — so the
+		// ONLY thing that can stop the close is the gate on the terminal event.
+		expect(panel().style.transform).toBe('translateY(200px)');
+
+		acquire(mountViewer());
+		g.dispatchEvent(touch('touchend', 200));
+		expect(onclose).not.toHaveBeenCalled();
+	});
+});

--- a/web/src/lib/components/layout/DockedSheet.svelte.test.ts
+++ b/web/src/lib/components/layout/DockedSheet.svelte.test.ts
@@ -24,7 +24,11 @@ import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, cleanup } from '@testing-library/svelte';
 import { createRawSnippet, tick, flushSync } from 'svelte';
 import DockedSheet from './DockedSheet.svelte';
-import { acquire, __resetViewerBackdropForTests } from '$lib/a11y/viewerBackdrop';
+import {
+	acquire,
+	noteEscapeConsumedByViewer,
+	__resetViewerBackdropForTests,
+} from '$lib/a11y/viewerBackdrop';
 
 const bodySnippet = createRawSnippet(() => ({
 	render: () => `<div><button type="button">Inside</button></div>`,
@@ -135,6 +139,44 @@ describe('DockedSheet — Escape ownership (TASK-2430)', () => {
 		const e = escape();
 		e.preventDefault();
 		window.dispatchEvent(e);
+		expect(onclose).toHaveBeenCalledTimes(1);
+	});
+
+	it('declines an Escape a VIEWER already consumed, after the lease is gone', async () => {
+		// TASK-2448 / BUG-2441 — the real dispatch, reproduced. The viewer's own
+		// escape handler runs earlier in the same event and tears itself down
+		// synchronously, so this listener genuinely sees an EMPTY lease stack:
+		// the test releases the lease before dispatching, exactly as the browser
+		// does. Only the event-scoped mark can save the sheet here.
+		const onclose = vi.fn();
+		render(DockedSheet, { props: baseProps({ onclose }) });
+		await tick();
+		flushSync();
+
+		const lease = acquire(mountViewer());
+		const e = escape();
+		noteEscapeConsumedByViewer(e); // what Lightbox does before `onClose()`
+		lease.release(); // what Svelte's synchronous teardown does next
+		window.dispatchEvent(e);
+		expect(onclose).not.toHaveBeenCalled();
+
+		// The NEXT press is the sheet's — one Escape closes one layer, it does
+		// not make the sheet permanently deaf.
+		window.dispatchEvent(escape());
+		expect(onclose).toHaveBeenCalledTimes(1);
+	});
+
+	it('EMPTY-STACK REGRESSION: an unmarked Escape still closes it', async () => {
+		// The other half of the pair above: the marker is the ONLY thing that
+		// changed, so a press no viewer touched behaves exactly as before —
+		// including when a viewer once existed and has since gone.
+		const onclose = vi.fn();
+		render(DockedSheet, { props: baseProps({ onclose }) });
+		await tick();
+		flushSync();
+
+		acquire(mountViewer()).release();
+		window.dispatchEvent(escape());
 		expect(onclose).toHaveBeenCalledTimes(1);
 	});
 

--- a/web/src/lib/components/layout/Sidebar.svelte
+++ b/web/src/lib/components/layout/Sidebar.svelte
@@ -15,6 +15,7 @@
 	import { toastStore } from '$lib/stores/toast.svelte';
 	import NotificationPanel from '$lib/components/common/NotificationPanel.svelte';
 	import CreateCollectionModal from '$lib/components/collections/CreateCollectionModal.svelte';
+	import { isBlockedByModal } from '$lib/a11y/viewerBackdrop';
 
 	let notificationPanelOpen = $state(false);
 	let showCreateCollection = $state(false);
@@ -292,7 +293,33 @@
 		} catch {}
 	});
 
+	/**
+	 * TASK-2430 — the sidebar's swipe gestures are global surfaces: the OPEN
+	 * swipe is a `<svelte:window>` touch handler that fires anywhere on the page,
+	 * and the CLOSE swipe rides on the `<aside>` itself. Both must stand down
+	 * while a viewer (or a native `showModal()` dialog) is in front — opening or
+	 * closing app chrome underneath a modal surface is exactly the deference this
+	 * task is about.
+	 *
+	 * The owner is the sidebar element, i.e. the surface asking to act, not
+	 * `event.target`. `isBlockedByModal` returns false on an empty stack, so with
+	 * no viewer open both gestures behave exactly as before.
+	 */
+	function swipeBlocked(): boolean {
+		return isBlockedByModal(sidebarEl ?? null);
+	}
+
+	function cancelCloseSwipe() {
+		isSwiping = false;
+		if (sidebarEl) {
+			sidebarEl.style.transform = '';
+			sidebarEl.style.transition = '';
+		}
+	}
+
 	function handleTouchStart(e: TouchEvent) {
+		// Gesture START gate.
+		if (swipeBlocked()) return;
 		// Don't initiate swipe-to-close if the touch started inside a
 		// horizontally scrollable element (e.g. the mobile workspace list)
 		let el = e.target as HTMLElement | null;
@@ -307,6 +334,13 @@
 
 	function handleTouchMove(e: TouchEvent) {
 		if (!isSwiping) return;
+		// STRADDLE gate — a swipe that began before the viewer opened keeps
+		// delivering moves to its original target afterwards. Abandon it and undo
+		// the in-progress transform rather than keep dragging the drawer.
+		if (swipeBlocked()) {
+			cancelCloseSwipe();
+			return;
+		}
 		touchCurrentX = e.touches[0].clientX;
 
 		const delta = touchCurrentX - touchStartX;
@@ -319,6 +353,12 @@
 
 	function handleTouchEnd() {
 		if (!isSwiping || !sidebarEl) return;
+		// STRADDLE gate on the terminal event — this is the one that would
+		// actually call `closeSidebar()`.
+		if (swipeBlocked()) {
+			cancelCloseSwipe();
+			return;
+		}
 		isSwiping = false;
 
 		const delta = touchCurrentX - touchStartX;
@@ -336,6 +376,8 @@
 <svelte:window
 	ontouchstart={(e) => {
 		if (!uiStore.isMobile || uiStore.sidebarOpen) return;
+		// Gesture START gate (TASK-2430) — see `swipeBlocked`.
+		if (swipeBlocked()) return;
 		const x = e.touches[0].clientX;
 		if (x <= 16) {
 			// Don't activate if the touch is inside a horizontally scrollable container
@@ -353,6 +395,12 @@
 	}}
 	ontouchmove={(e) => {
 		if (!openSwipeTracking) return;
+		// STRADDLE gate — an edge swipe that began before the viewer opened must
+		// not go on to open the sidebar underneath it.
+		if (swipeBlocked()) {
+			openSwipeTracking = false;
+			return;
+		}
 		const x = e.touches[0].clientX;
 		const y = e.touches[0].clientY;
 		const dx = x - openSwipeStartX;

--- a/web/src/lib/components/layout/Sidebar.svelte.test.ts
+++ b/web/src/lib/components/layout/Sidebar.svelte.test.ts
@@ -1,0 +1,241 @@
+// Runs in the jsdom vitest project (filename ends `.svelte.test.ts`).
+//
+// TASK-2430 — the sidebar owns two swipe gestures that are global surfaces: the
+// CLOSE swipe on the `<aside>` itself, and the mobile left-edge OPEN swipe,
+// which is a `<svelte:window>` touch handler firing anywhere on the page. Both
+// must stand down while a viewer is frontmost, at gesture START **and** on the
+// captured move/end — a touch sequence keeps being delivered to its original
+// target after the viewer opens.
+//
+// Every blocked case is paired with an EMPTY-STACK REGRESSION.
+//
+// HOW TO READ THE PAIRS. The BLOCKED tests are what fail if a guard is deleted
+// or weakened. The EMPTY-STACK REGRESSIONS are the opposite check — they fail
+// if a guard declines UNCONDITIONALLY, which is the way a "deference" change
+// silently breaks the app for the 99% of the time no viewer is open. Neither
+// half subsumes the other, and an empty-stack test passing with the guard
+// removed is by design, not a false green. Every guard in the files under test
+// was mutation-verified to kill at least one case here (one documented
+// exception, flagged at the guard itself).
+import { describe, it, expect, vi, beforeEach, afterEach, afterAll } from 'vitest';
+import { render, cleanup } from '@testing-library/svelte';
+import { tick, flushSync } from 'svelte';
+
+// Force the MOBILE viewport BEFORE any import is evaluated: `breakpoint.svelte.ts`
+// reads `matchMedia` at MODULE LOAD, so a `beforeEach` stub is far too late and
+// the edge-open swipe (gated on `uiStore.isMobile`) would be unreachable.
+//
+// ASSUMES PER-FILE MODULE ISOLATION — vitest's default, and what this repo runs
+// (`npm run test`, no `--no-isolate`, no pool override, in the config or in CI).
+// Under a shared module graph `breakpoint.svelte.ts` may already have been
+// imported and its viewport flag resolved against the DESKTOP default before
+// this hoisted stub runs, and this file's edge-swipe tests would fail. That is
+// not a regression introduced here: the suite already has order-dependent
+// failures under `--no-isolate` (verified on the base commit, in a different
+// file), so the mode is unsupported today rather than newly broken. Storage
+// leakage specifically is covered regardless — `setup-jsdom.ts` clears both
+// Storages before every test, not per setup-file load.
+const { realMatchMedia } = vi.hoisted(() => {
+	const real = (globalThis as unknown as { matchMedia: unknown }).matchMedia;
+	(globalThis as unknown as { matchMedia: unknown }).matchMedia = (query: string) => ({
+		matches: true,
+		media: query,
+		onchange: null,
+		addEventListener: () => {},
+		removeEventListener: () => {},
+		addListener: () => {},
+		removeListener: () => {},
+		dispatchEvent: () => false,
+	});
+	return { realMatchMedia: real };
+});
+
+// A raw assignment is NOT undone by `vi.restoreAllMocks()`, and `setup-jsdom.ts`
+// only installs its desktop default when `matchMedia` is missing — so without
+// this the mobile stub would survive this file and make any later file that
+// reads the breakpoint at module load order-dependent.
+afterAll(() => {
+	(globalThis as unknown as { matchMedia: unknown }).matchMedia = realMatchMedia;
+});
+
+vi.mock('$lib/api/client', () => ({
+	api: {
+		health: vi.fn(async () => ({ version: 'dev', commit: 'abcdef0' })),
+		collections: { list: vi.fn(async () => []) },
+	},
+	isPlanLimitError: () => false,
+	planLimitMessage: () => '',
+}));
+
+import Sidebar from './Sidebar.svelte';
+import { uiStore } from '$lib/stores/ui.svelte';
+import { acquire, __resetViewerBackdropForTests } from '$lib/a11y/viewerBackdrop';
+
+function aside(): HTMLElement {
+	const el = document.querySelector('aside.sidebar');
+	if (!el) throw new Error('aside.sidebar not found');
+	return el as HTMLElement;
+}
+
+function mountViewer(): HTMLElement {
+	const root = document.createElement('div');
+	root.className = 'attachment-viewer';
+	root.setAttribute('role', 'dialog');
+	document.body.appendChild(root);
+	return root;
+}
+
+/** jsdom has no TouchEvent constructor; a plain Event with `touches` suffices. */
+function touch(type: string, clientX: number, clientY = 300, target?: HTMLElement): Event {
+	const e = new Event(type, { bubbles: true, cancelable: true });
+	Object.defineProperty(e, 'touches', { value: [{ clientX, clientY }] });
+	if (target) Object.defineProperty(e, 'target', { value: target });
+	return e;
+}
+
+beforeEach(async () => {
+	uiStore.openSidebar();
+	render(Sidebar, { props: {} });
+	await tick();
+	flushSync();
+});
+
+afterEach(() => {
+	cleanup();
+	__resetViewerBackdropForTests();
+	vi.restoreAllMocks();
+	document.body.innerHTML = '';
+});
+
+describe('Sidebar — swipe-to-close (TASK-2430)', () => {
+	it('EMPTY-STACK REGRESSION: a past-threshold swipe still closes the sidebar', () => {
+		expect(uiStore.sidebarOpen).toBe(true);
+		const el = aside();
+		el.dispatchEvent(touch('touchstart', 200));
+		el.dispatchEvent(touch('touchmove', 40));
+		flushSync();
+		// The drawer visibly followed the finger — proof the gesture engaged.
+		expect(el.style.transform).toBe('translateX(-160px)');
+		el.dispatchEvent(touch('touchend', 40));
+		expect(uiStore.sidebarOpen).toBe(false);
+	});
+
+	it('does not START a close swipe while a viewer lease is frontmost', () => {
+		acquire(mountViewer());
+		const el = aside();
+		el.dispatchEvent(touch('touchstart', 200));
+		el.dispatchEvent(touch('touchmove', 40));
+		flushSync();
+		expect(el.style.transform).toBe('');
+		el.dispatchEvent(touch('touchend', 40));
+		expect(uiStore.sidebarOpen).toBe(true);
+	});
+
+	it('STRADDLE: a close swipe begun before the viewer opened is abandoned mid-drag', () => {
+		const el = aside();
+		el.dispatchEvent(touch('touchstart', 200));
+		el.dispatchEvent(touch('touchmove', 100));
+		flushSync();
+		expect(el.style.transform).toBe('translateX(-100px)');
+
+		acquire(mountViewer());
+		el.dispatchEvent(touch('touchmove', 20));
+		flushSync();
+		// The in-progress transform is UNDONE, not merely frozen.
+		expect(el.style.transform).toBe('');
+
+		el.dispatchEvent(touch('touchend', 20));
+		expect(uiStore.sidebarOpen).toBe(true);
+	});
+
+	it('STRADDLE: a viewer opening between the last move and the release still blocks the close', () => {
+		const el = aside();
+		el.dispatchEvent(touch('touchstart', 200));
+		el.dispatchEvent(touch('touchmove', 40));
+		flushSync();
+		// Already past the threshold and un-blocked to here, so only the gate on
+		// the terminal event can stop the close.
+		expect(el.style.transform).toBe('translateX(-160px)');
+
+		acquire(mountViewer());
+		el.dispatchEvent(touch('touchend', 40));
+		expect(uiStore.sidebarOpen).toBe(true);
+	});
+
+	it('a gesture STARTED under a viewer does not come alive when the viewer closes', () => {
+		// The move/end gates alone would pass the "does not START" test above —
+		// they cancel the drag on the next event either way. This is what makes
+		// the START gate itself load-bearing: with it, the press under the viewer
+		// never armed the gesture, so nothing resumes once the lease is gone.
+		const lease = acquire(mountViewer());
+		const el = aside();
+		el.dispatchEvent(touch('touchstart', 200));
+
+		lease.release();
+		el.dispatchEvent(touch('touchmove', 40));
+		flushSync();
+		expect(el.style.transform).toBe('');
+		el.dispatchEvent(touch('touchend', 40));
+		expect(uiStore.sidebarOpen).toBe(true);
+	});
+
+	it('takes the gesture back once the lease is released', () => {
+		const lease = acquire(mountViewer());
+		const el = aside();
+		el.dispatchEvent(touch('touchstart', 200));
+		el.dispatchEvent(touch('touchend', 40));
+		expect(uiStore.sidebarOpen).toBe(true);
+
+		lease.release();
+		el.dispatchEvent(touch('touchstart', 200));
+		el.dispatchEvent(touch('touchmove', 40));
+		el.dispatchEvent(touch('touchend', 40));
+		expect(uiStore.sidebarOpen).toBe(false);
+	});
+});
+
+describe('Sidebar — mobile left-edge swipe-to-open (TASK-2430)', () => {
+	// The window handler only arms when the sidebar is CLOSED on mobile.
+	beforeEach(() => {
+		uiStore.closeSidebar();
+	});
+
+	it('EMPTY-STACK REGRESSION: an edge swipe still opens the sidebar', () => {
+		window.dispatchEvent(touch('touchstart', 4, 300, document.body));
+		window.dispatchEvent(touch('touchmove', 40, 300, document.body));
+		window.dispatchEvent(touch('touchmove', 120, 300, document.body));
+		expect(uiStore.sidebarOpen).toBe(true);
+	});
+
+	it('does not START an edge swipe while a viewer lease is frontmost', () => {
+		acquire(mountViewer());
+		window.dispatchEvent(touch('touchstart', 4, 300, document.body));
+		window.dispatchEvent(touch('touchmove', 40, 300, document.body));
+		window.dispatchEvent(touch('touchmove', 120, 300, document.body));
+		expect(uiStore.sidebarOpen).toBe(false);
+	});
+
+	it('an edge swipe STARTED under a viewer does not come alive when the viewer closes', () => {
+		// Same point as the close-swipe case: proves the START gate, which the
+		// move gate would otherwise mask.
+		const lease = acquire(mountViewer());
+		window.dispatchEvent(touch('touchstart', 4, 300, document.body));
+
+		lease.release();
+		window.dispatchEvent(touch('touchmove', 40, 300, document.body));
+		window.dispatchEvent(touch('touchmove', 200, 300, document.body));
+		expect(uiStore.sidebarOpen).toBe(false);
+	});
+
+	it('STRADDLE: an edge swipe begun before the viewer opened does not go on to open it', () => {
+		// Arm and direction-lock the gesture with no viewer present…
+		window.dispatchEvent(touch('touchstart', 4, 300, document.body));
+		window.dispatchEvent(touch('touchmove', 40, 300, document.body));
+		expect(uiStore.sidebarOpen).toBe(false); // locked, not yet far enough
+
+		// …then the viewer opens before the swipe reaches its open distance.
+		acquire(mountViewer());
+		window.dispatchEvent(touch('touchmove', 200, 300, document.body));
+		expect(uiStore.sidebarOpen).toBe(false);
+	});
+});

--- a/web/src/lib/components/layout/TopBar.svelte
+++ b/web/src/lib/components/layout/TopBar.svelte
@@ -15,11 +15,14 @@
 	import Menu from '$lib/components/common/Menu.svelte';
 	import MenuItem from '$lib/components/common/MenuItem.svelte';
 	import { workspaceRestoreTarget } from '$lib/utils/workspace-route';
+	import { isBlockedByModal } from '$lib/a11y/viewerBackdrop';
 
 	let { mobile = false }: { mobile?: boolean } = $props();
 
 	let userMenuOpen = $state(false);
 	let userTriggerEl: HTMLButtonElement | undefined = $state(undefined);
+	/** The overflow menu panel — the arbitration OWNER for its window keydown. */
+	let overflowMenuEl: HTMLElement | undefined = $state(undefined);
 	let currentTheme = $state<'dark' | 'light'>('dark');
 	let connectOpen = $state(false);
 
@@ -570,6 +573,17 @@
 	// ── Overflow menu keyboard ───────────────────────────────────────────
 	function handleOverflowKeydown(e: KeyboardEvent) {
 		if (!overflowOpen) return;
+		// TASK-2430 — this is a WINDOW handler owning Escape and Up/Down for a
+		// menu that lives in the app shell. While a viewer (or a native
+		// `showModal()` dialog) is in front, the shell is inert: consuming those
+		// keys would steal Escape from the frontmost surface, and the arrow keys
+		// would call `.focus()` on menu items UNDER it — pulling focus out of the
+		// frontmost surface and into inert chrome.
+		//
+		// The owner is the menu element itself; `isBlockedByModal` returns false
+		// on an empty stack, so with no viewer/native modal this handler behaves
+		// exactly as before.
+		if (isBlockedByModal(overflowMenuEl ?? null)) return;
 		if (e.key === 'Escape') {
 			e.preventDefault();
 			closeOverflow();
@@ -578,6 +592,17 @@
 		}
 		if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
 			e.preventDefault();
+			// KNOWN DEAD IN THE BROWSER, deliberately left that way here.
+			// `svelte-dnd-action` REWRITES the authored roles on this zone and its
+			// children (`role="menu"`→`list`, `menuitem`→`listitem`) unless
+			// `autoAriaDisabled` is set, so this query matches nothing and the
+			// roving focus below never runs — only the `preventDefault()` above
+			// takes effect. TASK-2430 briefly widened the selector to
+			// `[role="listitem"]` too and it was REVERTED: reviving the branch
+			// changes what ArrowUp/Down do with NO viewer present, and this task's
+			// contract is that an empty lease leaves behaviour untouched. Worth
+			// fixing — in its own item, where the a11y change can be reviewed as
+			// such.
 			const items = Array.from(
 				document.querySelectorAll<HTMLElement>('#workspace-overflow-menu [role="menuitem"]')
 			);
@@ -615,6 +640,15 @@
 	onmouseup={disarmMenu}
 	onclick={(e) => {
 		const target = e.target as HTMLElement;
+		// DELIBERATELY UNGUARDED by `isBlockedByModal` (TASK-2430). Unlike the
+		// keydown handler above, this is a pointer-DISMISSER: its only effect is
+		// to close the menu, i.e. to tear down LOWER UI. A click inside a
+		// frontmost viewer closing chrome that is already obscured and inert is
+		// the correct outcome, not a leak — the same reasoning that keeps
+		// `clickOutside.ts`, the emoji/reaction pickers and the sidebar's
+		// collection picker unguarded. Adding a gate here would leave a stale
+		// menu open behind the viewer instead.
+		//
 		// Don't close on outside-click during a drag — the click event
 		// fired on mouseup at drag end would otherwise tear down the
 		// menu while finalize handlers are still wiring up state.
@@ -860,6 +894,7 @@
 				{#if overflowZone.length > 0}
 					<!-- svelte-ignore a11y_no_static_element_interactions -->
 					<div
+						bind:this={overflowMenuEl}
 						id="workspace-overflow-menu"
 						class="overflow-menu"
 						class:open={menuVisible}

--- a/web/src/lib/components/layout/TopBar.svelte
+++ b/web/src/lib/components/layout/TopBar.svelte
@@ -573,6 +573,11 @@
 	// ── Overflow menu keyboard ───────────────────────────────────────────
 	function handleOverflowKeydown(e: KeyboardEvent) {
 		if (!overflowOpen) return;
+		// A HELD Escape auto-repeats as FRESH event objects, so the viewer's
+		// per-event consumption mark (BUG-2441) cannot cover them once its lease
+		// is gone — a hold would close the viewer and then this menu. Only the
+		// initial press acts, matching the route guards (TASK-2448).
+		if (e.key === 'Escape' && e.repeat) return;
 		// TASK-2430 — this is a WINDOW handler owning Escape and Up/Down for a
 		// menu that lives in the app shell. While a viewer (or a native
 		// `showModal()` dialog) is in front, the shell is inert: consuming those

--- a/web/src/lib/components/layout/TopBar.svelte
+++ b/web/src/lib/components/layout/TopBar.svelte
@@ -583,7 +583,15 @@
 		// The owner is the menu element itself; `isBlockedByModal` returns false
 		// on an empty stack, so with no viewer/native modal this handler behaves
 		// exactly as before.
-		if (isBlockedByModal(overflowMenuEl ?? null)) return;
+		//
+		// TASK-2448 passes the EVENT too, so the answer is event-scoped as well as
+		// live. This owner is not known to be broken today — its `window` listener
+		// is registered by the layout, so it happens to run BEFORE the route's
+		// escape driver and still sees the lease held. That is listener-order
+		// luck, not a guarantee; the same latent double-close as `DockedSheet` /
+		// `BottomSheet` is one mount-order change away. With no viewer open the
+		// marker can never be set, so this is byte-identical to before.
+		if (isBlockedByModal(overflowMenuEl ?? null, e)) return;
 		if (e.key === 'Escape') {
 			e.preventDefault();
 			closeOverflow();

--- a/web/src/lib/components/layout/TopBar.svelte.test.ts
+++ b/web/src/lib/components/layout/TopBar.svelte.test.ts
@@ -1,0 +1,214 @@
+// Runs in the jsdom vitest project (filename ends `.svelte.test.ts`).
+//
+// TASK-2430 — the workspace overflow menu owns Escape and Up/Down on a WINDOW
+// keydown handler. While a viewer is frontmost the app shell is inert, so this
+// handler must not consume Escape (the viewer's) and must not `.focus()` menu
+// items underneath it — which would pull focus out of the frontmost surface and
+// into inert chrome.
+//
+// Each blocked case is paired with an EMPTY-STACK REGRESSION.
+//
+// HOW TO READ THE PAIRS. The BLOCKED tests are what fail if a guard is deleted
+// or weakened. The EMPTY-STACK REGRESSIONS are the opposite check — they fail
+// if a guard declines UNCONDITIONALLY, which is the way a "deference" change
+// silently breaks the app for the 99% of the time no viewer is open. Neither
+// half subsumes the other, and an empty-stack test passing with the guard
+// removed is by design, not a false green. Every guard in the files under test
+// was mutation-verified to kill at least one case here (one documented
+// exception, flagged at the guard itself).
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/svelte';
+import { tick, flushSync } from 'svelte';
+
+const WORKSPACES = [
+	{ id: 'w1', slug: 'alpha', name: 'Alpha', owner_username: 'u' },
+	{ id: 'w2', slug: 'beta', name: 'Beta', owner_username: 'u' },
+	{ id: 'w3', slug: 'gamma', name: 'Gamma', owner_username: 'u' },
+];
+
+vi.mock('$lib/api/client', () => ({
+	api: {
+		workspaces: {
+			list: vi.fn(async () => WORKSPACES),
+			reorder: vi.fn(async () => {}),
+		},
+	},
+}));
+
+import TopBar from './TopBar.svelte';
+import { workspaceStore } from '$lib/stores/workspace.svelte';
+import { acquire, __resetViewerBackdropForTests } from '$lib/a11y/viewerBackdrop';
+
+function mountViewer(): HTMLElement {
+	const root = document.createElement('div');
+	root.className = 'attachment-viewer';
+	root.setAttribute('role', 'dialog');
+	document.body.appendChild(root);
+	return root;
+}
+
+/**
+ * The menu's rendered rows. Matched on the dnd-rewritten role: `svelte-dnd-action`
+ * overwrites the authored `role="menu"`/`menuitem"` on this zone with
+ * `list`/`listitem`. That is ALSO why the component's own roving-focus query
+ * (menuitem-only) matches nothing and its arrow branch does not move focus — a
+ * pre-existing defect this task deliberately does not fix, so the arrow tests
+ * below assert only what the handler really does today: consume the key.
+ */
+function menuRows(): HTMLElement[] {
+	return Array.from(
+		document.querySelectorAll<HTMLElement>('#workspace-overflow-menu [role="listitem"]'),
+	);
+}
+
+function key(k: string): KeyboardEvent {
+	return new KeyboardEvent('keydown', { key: k, bubbles: true, cancelable: true });
+}
+
+let offsetWidthSpy: PropertyDescriptor | undefined;
+
+beforeEach(async () => {
+	// jsdom lays nothing out, so the visible/overflow split would put every
+	// workspace in the VISIBLE zone and never mount the overflow menu at all.
+	// A tiny available width plus wide pills forces the whole set to overflow.
+	vi.stubGlobal(
+		'ResizeObserver',
+		class {
+			cb: ResizeObserverCallback;
+			constructor(cb: ResizeObserverCallback) {
+				this.cb = cb;
+			}
+			observe(target: Element) {
+				this.cb(
+					[{ target, contentRect: { width: 40 } } as unknown as ResizeObserverEntry],
+					this as unknown as ResizeObserver,
+				);
+			}
+			unobserve() {}
+			disconnect() {}
+		},
+	);
+	offsetWidthSpy = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetWidth');
+	Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
+		configurable: true,
+		get: () => 500,
+	});
+
+	await workspaceStore.loadAll();
+	render(TopBar, { props: {} });
+	// The pill measurement is rAF-deferred; poll until the menu is mounted.
+	for (let i = 0; i < 50 && menuRows().length === 0; i++) {
+		await new Promise((r) => setTimeout(r, 5));
+		flushSync();
+	}
+	// Open the menu through its real trigger.
+	const trigger = document.querySelector<HTMLElement>('.overflow-trigger-wrap button');
+	trigger?.click();
+	await tick();
+	flushSync();
+});
+
+afterEach(() => {
+	cleanup();
+	__resetViewerBackdropForTests();
+	// Restore precisely: if `offsetWidth` was NOT an own property of the
+	// prototype, re-defining is wrong — delete, so the stub cannot outlive this
+	// file. (`vi.restoreAllMocks()` does not undo a raw `defineProperty`.)
+	if (offsetWidthSpy) {
+		Object.defineProperty(HTMLElement.prototype, 'offsetWidth', offsetWidthSpy);
+	} else {
+		delete (HTMLElement.prototype as unknown as Record<string, unknown>).offsetWidth;
+	}
+	vi.unstubAllGlobals();
+	vi.restoreAllMocks();
+	document.body.innerHTML = '';
+});
+
+describe('TopBar overflow menu — defers to a frontmost viewer (TASK-2430)', () => {
+	it('mounts an open overflow menu with rows (test fixture sanity)', () => {
+		expect(menuRows().length).toBeGreaterThan(0);
+		expect(document.querySelector('#workspace-overflow-menu')?.classList).toContain('open');
+	});
+
+	it('EMPTY-STACK REGRESSION: Escape still closes the menu with no lease held', async () => {
+		window.dispatchEvent(key('Escape'));
+		await tick();
+		flushSync();
+		expect(document.querySelector('#workspace-overflow-menu')?.classList).not.toContain('open');
+	});
+
+	it('EMPTY-STACK REGRESSION: ArrowDown is still CONSUMED by the open menu', () => {
+		// What the handler actually does today: `preventDefault()` runs before the
+		// roving-focus query, which (see `menuRows`) matches nothing. So consuming
+		// the key is the whole observable effect, and it is what must not change
+		// when no viewer is present.
+		const before = document.activeElement;
+		const e = key('ArrowDown');
+		window.dispatchEvent(e);
+		expect(e.defaultPrevented).toBe(true);
+		expect(document.activeElement).toBe(before);
+	});
+
+	it('does not consume Escape while a viewer lease is frontmost', async () => {
+		acquire(mountViewer());
+		window.dispatchEvent(key('Escape'));
+		await tick();
+		flushSync();
+		// Menu untouched — the viewer's own Escape owner gets the key.
+		expect(document.querySelector('#workspace-overflow-menu')?.classList).toContain('open');
+	});
+
+	it('does not consume ArrowDown while a viewer lease is frontmost', () => {
+		// The viewer pages its own images with the arrow keys, so the inert menu
+		// underneath must not swallow them — nor reach the `.focus()` call that
+		// follows in the handler, which would pull focus out of the viewer and
+		// into inert chrome the moment the dnd role rewrite is ever fixed.
+		const viewer = mountViewer();
+		const inViewer = document.createElement('button');
+		viewer.appendChild(inViewer);
+		acquire(viewer);
+		inViewer.focus();
+
+		const e = key('ArrowDown');
+		window.dispatchEvent(e);
+		expect(e.defaultPrevented).toBe(false);
+		expect(document.activeElement).toBe(inViewer);
+	});
+
+	it('OWNER ARGUMENT: an Escape ORIGINATING inside the viewer is still declined', async () => {
+		// The discriminating case for "the argument is the SURFACE ASKING TO ACT,
+		// not `event.target`". The other blocked tests dispatch on `window`,
+		// where the target is outside the viewer too, so they would ALSO pass
+		// with the wrong argument. Here the key is pressed with focus inside the
+		// viewer — an `e.target` owner would report "not blocked" and close the
+		// menu underneath it.
+		const viewer = mountViewer();
+		const btn = document.createElement('button');
+		viewer.appendChild(btn);
+		acquire(viewer);
+
+		btn.dispatchEvent(key('Escape'));
+		await tick();
+		flushSync();
+		expect(document.querySelector('#workspace-overflow-menu')?.classList).toContain('open');
+	});
+
+	it('takes both keys back once the lease is released', async () => {
+		const lease = acquire(mountViewer());
+		window.dispatchEvent(key('Escape'));
+		await tick();
+		flushSync();
+		expect(document.querySelector('#workspace-overflow-menu')?.classList).toContain('open');
+
+		// Both keys, as the name says: the arrow is consumed again too.
+		lease.release();
+		const arrow = key('ArrowDown');
+		window.dispatchEvent(arrow);
+		expect(arrow.defaultPrevented).toBe(true);
+
+		window.dispatchEvent(key('Escape'));
+		await tick();
+		flushSync();
+		expect(document.querySelector('#workspace-overflow-menu')?.classList).not.toContain('open');
+	});
+});

--- a/web/src/lib/components/timeline/ItemTimeline.svelte
+++ b/web/src/lib/components/timeline/ItemTimeline.svelte
@@ -12,6 +12,7 @@
 	import { fetchAttachmentMetadata } from '$lib/components/editor/attachment-metadata';
 	import { attachmentDownloadUrl, type AttachmentMeta } from '$lib/markdown/attachments';
 	import { canOpenInViewer } from '$lib/attachments/display';
+	import { isEditorOwnedImage } from '$lib/attachments/editorOwnedImage';
 	// One declaration of the viewer's image shape, on the channel (TASK-2431).
 	import type { LightboxImage } from '$lib/attachments/events';
 	import Lightbox from '$lib/components/common/Lightbox.svelte';
@@ -263,19 +264,37 @@
 	// event for a thumbnail the viewer refuses would leave the click doing
 	// nothing at all, including whatever the surrounding markup would have done
 	// with it.
-	function onThumbClick(e: MouseEvent) {
+	/**
+	 * The image this delegated event is about, or null when the event is not
+	 * ours to act on.
+	 *
+	 * The entry list contains LIVE CommentEditor instances, whose inline images
+	 * are AttachmentImage NodeViews that own their own activation, semantics and
+	 * propagation (TASK-2432). They render the same `img[data-attachment-id]`
+	 * this selector matches, so without the ownership check this delegation acts
+	 * on elements belonging to another component — see `isEditorOwnedImage` for
+	 * the two failures that produced.
+	 */
+	function delegatedThumb(e: Event): HTMLElement | null {
 		const imgEl = (e.target as HTMLElement | null)?.closest(
 			'img[data-attachment-id]'
 		) as HTMLElement | null;
+		if (!imgEl || isEditorOwnedImage(imgEl)) return null;
+		return imgEl;
+	}
+
+	function onThumbClick(e: MouseEvent) {
+		const imgEl = delegatedThumb(e);
 		if (!imgEl) return;
 		if (openLightboxFromImg(imgEl)) e.preventDefault();
 	}
 
 	function onThumbKeydown(e: KeyboardEvent) {
 		if (e.key !== 'Enter' && e.key !== ' ') return;
-		const imgEl = (e.target as HTMLElement | null)?.closest(
-			'img[data-attachment-id]'
-		) as HTMLElement | null;
+		// A modified key is a shortcut, not an activation — the same guard the
+		// NodeView carries. Cmd/Ctrl+Enter is CommentEditor's submit binding.
+		if (e.ctrlKey || e.metaKey || e.altKey || e.shiftKey) return;
+		const imgEl = delegatedThumb(e);
 		if (!imgEl) return;
 		// Space would otherwise scroll the page — but only suppress it when the
 		// key actually did something.
@@ -332,6 +351,11 @@
 		tick().then(() => {
 			if (cancelled) return;
 			for (const img of el.querySelectorAll<HTMLElement>('img[data-attachment-id]')) {
+				// A live editor's NodeView owns its own semantics (TASK-2432) and
+				// `attMeta` is probed from SAVED bodies only — so every image in a
+				// DRAFT comment looks unresolved here, and this pass would strip
+				// the role/tabindex the NodeView just set.
+				if (isEditorOwnedImage(img)) continue;
 				if (viewerImageFor(img) === null) {
 					img.removeAttribute('role');
 					img.removeAttribute('tabindex');

--- a/web/src/lib/components/timeline/ItemTimeline.svelte
+++ b/web/src/lib/components/timeline/ItemTimeline.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { onDestroy, tick } from 'svelte';
+	import { onDestroy, tick, untrack } from 'svelte';
 	import { api } from '$lib/api/client';
 	import { sseService } from '$lib/services/sse.svelte';
 	import { authStore } from '$lib/stores/auth.svelte';
@@ -11,7 +11,10 @@
 	import { attachmentRefsIn } from '$lib/utils/commentAttachments';
 	import { fetchAttachmentMetadata } from '$lib/components/editor/attachment-metadata';
 	import { attachmentDownloadUrl, type AttachmentMeta } from '$lib/markdown/attachments';
-	import Lightbox, { type LightboxImage } from '$lib/components/common/Lightbox.svelte';
+	import { canOpenInViewer } from '$lib/attachments/display';
+	// One declaration of the viewer's image shape, on the channel (TASK-2431).
+	import type { LightboxImage } from '$lib/attachments/events';
+	import Lightbox from '$lib/components/common/Lightbox.svelte';
 	import CommentEditor from '$lib/components/CommentEditor.svelte';
 
 	interface Props {
@@ -172,30 +175,100 @@
 
 	// Lightbox state (IDEA-1660). Set when a thumbnail is activated; cleared
 	// on close. Null = closed, so the host remounts fresh on each open.
-	let lightbox: { images: LightboxImage[]; index: number } | null = $state(null);
+	let lightbox: { images: LightboxImage[]; index: number; invoker: HTMLElement | null } | null =
+		$state(null);
 	let entryListEl: HTMLElement | undefined = $state();
 
-	// Open the lightbox for a clicked/activated thumbnail, gathering sibling
-	// attachment images in the same comment/reply body so ←/→ can page them.
-	function openLightboxFromImg(imgEl: HTMLElement) {
+	/**
+	 * The DR-16 open gate, applied to ONE rendered thumbnail (TASK-2431).
+	 *
+	 * Returns the viewer's own record for an `<img data-attachment-id>`, or
+	 * null when that image may not be opened. Null is the answer in two
+	 * different situations and deliberately does not distinguish them:
+	 *
+	 *  - the MIME is known and is not on the allowlist. `image/svg+xml` is the
+	 *    one that matters — SVG carries active content, and the markdown
+	 *    renderer emits an `<img>` for ANY `image/*` (`markdown/attachments.ts`
+	 *    `isImageMime`), which is the correct decision for RENDERING and the
+	 *    wrong one for OPENING. That difference is the whole reason this
+	 *    function exists rather than a `startsWith('image/')` test.
+	 *  - the MIME is not known yet. Fail SAFE: an unresolved probe is not
+	 *    evidence that a file is a PNG. It costs nothing, because an image
+	 *    whose metadata has not resolved is not rendered as an `<img>` at all
+	 *    (the renderer shows a "missing" placeholder until `attMeta` has the
+	 *    row), so there is no cold-start case where this refuses something the
+	 *    user can see and could previously open. A later probe re-runs the
+	 *    semantics effect below and the thumbnail becomes clickable then.
+	 *
+	 * Read straight off the CACHED metadata — never a fresh HEAD per click.
+	 * `attMeta` is the same map the renderer resolved the image through, so the
+	 * gate and the picture on screen are answering from one source.
+	 */
+	function viewerImageFor(el: HTMLElement): LightboxImage | null {
+		const id = el.getAttribute('data-attachment-id') ?? '';
+		if (!id) return null;
+		const meta = attMeta.get(id);
+		if (!meta || !canOpenInViewer(meta.mime_type)) return null;
+		return {
+			id,
+			alt: el.getAttribute('alt') ?? '',
+			// The probe leaves filename empty (see probeAttachment) and HEAD
+			// carries no intrinsic dimensions, so most of these are null here.
+			// That is what nullable means on this type; the strip fills them.
+			filename: meta.filename || null,
+			mime_type: meta.mime_type,
+			size_bytes: meta.size_bytes ?? null,
+			width: meta.width ?? null,
+			height: meta.height ?? null,
+		};
+	}
+
+	/**
+	 * Open the viewer on an activated thumbnail, with its siblings in the same
+	 * comment/reply body so ←/→ can page them.
+	 *
+	 * THE WHOLE LIST IS GATED, not just the clicked image (TASK-2431). Before
+	 * this, the set was built from every `img[data-attachment-id]` in scope with
+	 * no MIME consulted at all, so opening a safe PNG and pressing → could land
+	 * on an SVG: gating the click alone is not a gate.
+	 *
+	 * And the index is derived from the clicked attachment's ID, not from its
+	 * position among the DOM elements — filtering reindexes everything after the
+	 * first refusal, so a DOM index would silently open the wrong image. When the
+	 * clicked image is itself refused it is not in the list, `findIndex` returns
+	 * -1, and nothing opens.
+	 */
+	function openLightboxFromImg(imgEl: HTMLElement): boolean {
+		const clickedId = imgEl.getAttribute('data-attachment-id') ?? '';
+		if (!clickedId) return false;
 		const scope = imgEl.closest('.comment-body, .reply-body') ?? imgEl.parentElement;
 		const els = scope
 			? Array.from(scope.querySelectorAll<HTMLElement>('img[data-attachment-id]'))
 			: [imgEl];
-		const list: LightboxImage[] = els
-			.map((el) => ({ id: el.getAttribute('data-attachment-id') ?? '', alt: el.getAttribute('alt') ?? '' }))
-			.filter((x) => x.id !== '');
-		if (list.length === 0) return;
-		lightbox = { images: list, index: Math.max(0, els.indexOf(imgEl)) };
+		const list = els
+			.map((el) => viewerImageFor(el))
+			.filter((x): x is LightboxImage => x !== null);
+		// A body can legitimately embed the same attachment twice; the first
+		// occurrence wins, which shows the image the user asked for.
+		const index = list.findIndex((x) => x.id === clickedId);
+		if (index < 0) return false;
+		lightbox = { images: list, index, invoker: imgEl };
+		return true;
 	}
 
+	// BOTH activation routes go through the one gated opener — a filter applied
+	// to the mouse path only would be no filter at all.
+	//
+	// `preventDefault` is now conditional on actually opening: swallowing the
+	// event for a thumbnail the viewer refuses would leave the click doing
+	// nothing at all, including whatever the surrounding markup would have done
+	// with it.
 	function onThumbClick(e: MouseEvent) {
 		const imgEl = (e.target as HTMLElement | null)?.closest(
 			'img[data-attachment-id]'
 		) as HTMLElement | null;
 		if (!imgEl) return;
-		e.preventDefault();
-		openLightboxFromImg(imgEl);
+		if (openLightboxFromImg(imgEl)) e.preventDefault();
 	}
 
 	function onThumbKeydown(e: KeyboardEvent) {
@@ -204,8 +277,9 @@
 			'img[data-attachment-id]'
 		) as HTMLElement | null;
 		if (!imgEl) return;
-		e.preventDefault(); // Space would otherwise scroll the page
-		openLightboxFromImg(imgEl);
+		// Space would otherwise scroll the page — but only suppress it when the
+		// key actually did something.
+		if (openLightboxFromImg(imgEl)) e.preventDefault();
 	}
 
 	// Delegated click + keydown on the entry list (rather than declarative
@@ -227,13 +301,43 @@
 	// Depends on BOTH `entries` (new comments) AND `attMeta` (an image only
 	// renders as an <img> once its metadata resolves — before that it's a
 	// "missing" placeholder span — so the pass must re-run on resolution).
+	//
+	// THE SEMANTICS ARE CONDITIONAL ON THE SAME GATE THE OPENER USES
+	// (TASK-2431). Previously every `image/*` thumbnail got `role="button"`, a
+	// tabindex and a "View image" name; with the opener now refusing the ones
+	// outside the allowlist, that would leave an SVG as a focus stop announced
+	// as a button whose activation does nothing — a worse outcome than the hole
+	// it replaces, and the reason this pass has to be able to take semantics
+	// BACK OFF an element (a probe can resolve a MIME that turns a thumbnail
+	// from viewable-by-assumption into refused).
 	$effect(() => {
-		void entries;
+		// `visibleEntries`, NOT `entries`: the pane's Activity / Versions tabs
+		// filter the rendered set without refetching, so flipping away from
+		// comments and back DESTROYS and rebuilds every comment card while
+		// `entries` never changes. Tracking the raw list left those rebuilt
+		// images mouse-openable (the delegated listeners live on the container,
+		// which survives) but with no role, no tabindex and no name — openable
+		// by mouse only, which is the dead-control failure in its other
+		// direction (Codex round 4). Reading the derived also reads `entries`,
+		// so nothing is lost by not naming it too.
+		void visibleEntries;
 		void attMeta;
 		const el = entryListEl;
 		if (!el) return;
+		// The DOM pass is deferred a tick, so it can land after an item /
+		// workspace switch has already replaced what it was written for. Nothing
+		// it does is destructive, but a cancelled continuation is the local house
+		// rule for every await-then-write here (TASK-2112).
+		let cancelled = false;
 		tick().then(() => {
+			if (cancelled) return;
 			for (const img of el.querySelectorAll<HTMLElement>('img[data-attachment-id]')) {
+				if (viewerImageFor(img) === null) {
+					img.removeAttribute('role');
+					img.removeAttribute('tabindex');
+					img.removeAttribute('aria-label');
+					continue;
+				}
 				if (img.getAttribute('role') === 'button') continue;
 				img.setAttribute('role', 'button');
 				img.setAttribute('tabindex', '0');
@@ -241,6 +345,9 @@
 				img.setAttribute('aria-label', alt ? `View image: ${alt}` : 'View attachment image');
 			}
 		});
+		return () => {
+			cancelled = true;
+		};
 	});
 
 	// Current user ID for reaction toggle — read from the global auth store.
@@ -301,9 +408,44 @@
 		}
 	}
 
+	/**
+	 * The view the currently painted timeline belongs to. Plain `let` + untrack,
+	 * NOT `$state`: the effect below both reads and writes it, and a `$state`
+	 * read inside its own writing effect self-depends, aborts the flush and
+	 * silently strands unrelated reactivity (CONVE-1688). Seeded from the
+	 * initial props so a fresh mount is not treated as a switch — there is
+	 * nothing to tear down on the first run.
+	 */
+	// The two parts are joined with a separator that cannot occur in a slug,
+	// so no pair of (workspace, item) values can collide into one key.
+	let lastView = untrack(() => `${wsSlug}/${itemSlug}`);
+
 	$effect(() => {
-		void wsSlug;
-		void itemSlug;
+		const ws = wsSlug;
+		const slug = itemSlug;
+		// A→B LIFECYCLE (TASK-2431). This component is reused across an item /
+		// workspace switch (no `{#key}`), and it had NO viewer reset at all —
+		// `lightbox` was cleared on close and nowhere else. So a switch left a
+		// full-screen viewer up over the incoming item, still holding the
+		// previous view's attachment ids while `Lightbox` rebuilt their URLs
+		// from the workspace it captured at open. The strip's reset is the
+		// pattern; this is the same rule stated for this component.
+		//
+		// `attMeta` is deliberately NOT cleared alongside it. It is keyed by a
+		// bare uuid where the shared HEAD cache is keyed `ws:uuid`, which looks
+		// like a workspace-scoped cache leaking across the switch — but an
+		// attachment id is a UUID belonging to exactly one workspace, so an
+		// entry can only ever answer for the id it describes. Clearing it would
+		// buy nothing and cost something real: the probe effect refills it only
+		// when `entries` next changes, so a FAILED load after the switch would
+		// leave every already-rendered image permanently un-openable for the
+		// rest of the mount (Codex round 3).
+		untrack(() => {
+			const view = `${ws}/${slug}`;
+			if (view === lastView) return;
+			lastView = view;
+			lightbox = null;
+		});
 		loadTimeline();
 	});
 
@@ -575,14 +717,36 @@
 	{/if}
 </section>
 
-{#if lightbox}
-	<Lightbox
-		images={lightbox.images}
-		index={lightbox.index}
-		{wsSlug}
-		onClose={() => (lightbox = null)}
-	/>
-{/if}
+<!--
+	Keyed per open (TASK-2431), the shape `AttachmentViewerHost` uses. `Lightbox`
+	seeds its INDEX once through `untrack`, so replacing `lightbox` while a
+	viewer is already up would reuse the instance and open the new set at the old
+	position. (Its MIME filter is `$derived` and would re-answer on its own —
+	the index is what cannot.) Nothing reaches that state today, the open viewer
+	being inert over everything that could cause it, which is why this belongs in
+	the structure rather than resting on a fact about the current UI.
+
+	Accepted cost, recorded: a keyed block DESTROYS the old instance before
+	creating the new one, so a viewer→viewer swap briefly releases the last
+	backdrop lease (un-inerting the app) and runs the old viewer's focus restore
+	before the new one takes focus. That is the same transient
+	`AttachmentViewerHost` has carried since TASK-2428, it is unreachable from
+	the UI (the open viewer inerts every control that could trigger it), and the
+	alternative — a reused instance showing a stale set — is the worse of the
+	two. Only a viewer→NULL→viewer sequence happens in practice, where the
+	release is meant to happen anyway.
+-->
+{#key lightbox}
+	{#if lightbox}
+		<Lightbox
+			images={lightbox.images}
+			index={lightbox.index}
+			{wsSlug}
+			invoker={lightbox.invoker}
+			onClose={() => (lightbox = null)}
+		/>
+	{/if}
+{/key}
 
 <style>
 	.timeline {

--- a/web/src/lib/components/timeline/ItemTimeline.svelte.test.ts
+++ b/web/src/lib/components/timeline/ItemTimeline.svelte.test.ts
@@ -1,0 +1,482 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { flushSync, mount, unmount, tick } from 'svelte';
+import type { Comment, TimelineEntry, TimelineResponse } from '$lib/types';
+import { __resetViewerBackdropForTests } from '$lib/a11y/viewerBackdrop';
+import { _resetEscapeStackForTests } from '$lib/stores/escapeStack';
+
+/**
+ * The timeline's open-the-viewer gate (PLAN-2392 DR-16 / TASK-2431).
+ *
+ * The hole these cover: the sibling list the viewer's ←/→ page through was
+ * built from every `img[data-attachment-id]` in the comment body with NO MIME
+ * consulted, while the markdown renderer emits an `<img>` for any `image/*` —
+ * so opening a safe PNG and pressing → could land on an `image/svg+xml`.
+ * Gating the CLICKED image alone is not a gate, which is why every assertion
+ * here is about the whole list and about both activation routes.
+ *
+ * Deliberately against the REAL `Lightbox` rather than a stub: the claim is
+ * "no unsafe image can be REACHED", and only the real component's ←/→ can
+ * demonstrate where an arrow key actually lands. The rendered `<img>`'s `src`
+ * carries the attachment id, so what the viewer is showing is observable.
+ *
+ * The markdown pipeline is real too — the `<img>` elements under test are the
+ * ones `renderMarkdown` + `sanitizeMarkdownHtml` actually produce.
+ */
+
+const PNG_A = '11111111-1111-4111-8111-111111111111';
+const SVG = '22222222-2222-4222-8222-222222222222';
+const PNG_B = '33333333-3333-4333-8333-333333333333';
+const TIFF = '44444444-4444-4444-8444-444444444444';
+const UNPROBED = '55555555-5555-4555-8555-555555555555';
+
+/** MIME per attachment id, as the HEAD probe would report it. */
+const MIMES: Record<string, string> = {
+	[PNG_A]: 'image/png',
+	[SVG]: 'image/svg+xml',
+	[PNG_B]: 'image/jpeg',
+	[TIFF]: 'image/tiff',
+};
+
+const timelineListMock = vi.fn<(ws: string, slug: string) => Promise<TimelineResponse>>();
+
+vi.mock('$lib/api/client', () => ({
+	api: {
+		timeline: {
+			list: (ws: string, slug: string) => timelineListMock(ws, slug),
+		},
+		comments: {
+			create: vi.fn(),
+			update: vi.fn(),
+			delete: vi.fn(),
+			addReaction: vi.fn(),
+			removeReaction: vi.fn(),
+		},
+		attachments: {
+			downloadUrl: (ws: string, id: string, variant?: string) =>
+				`/api/v1/workspaces/${ws}/attachments/${id}${variant ? `?variant=${variant}` : ''}`,
+		},
+	},
+}));
+
+vi.mock('$lib/services/sse.svelte', () => ({
+	sseService: { onItemEvent: () => () => {} },
+}));
+
+vi.mock('$lib/stores/auth.svelte', () => ({
+	authStore: { userId: 'user-1', user: { id: 'user-1', role: 'member' } },
+}));
+
+vi.mock('$lib/stores/workspace.svelte', () => ({
+	workspaceStore: { canEditItem: () => false },
+}));
+
+// The HEAD probe, answered from MIMES. An id absent from the table resolves as
+// `transient` — the "not known" case the gate must fail safe on.
+vi.mock('$lib/components/editor/attachment-metadata', () => ({
+	fetchAttachmentMetadata: (_ws: string, uuid: string) =>
+		Promise.resolve(
+			MIMES[uuid]
+				? { status: 'ok' as const, mime: MIMES[uuid], size: 4096 }
+				: { status: 'transient' as const }
+		),
+	invalidateAttachmentMetadata: vi.fn(),
+}));
+
+// Tiptap in jsdom is not what these tests are about; the composer is inert.
+vi.mock('$lib/components/CommentEditor.svelte', async () => ({
+	default: (await import('./fixtures/InertCommentEditor.svelte')).default,
+}));
+
+const { default: ItemTimeline } = await import('./ItemTimeline.svelte');
+
+function comment(body: string, id = 'c1'): Comment {
+	return {
+		id,
+		item_id: 'item-a',
+		workspace_id: 'ws-1',
+		author: 'alice',
+		body,
+		created_by: 'alice',
+		source: 'web',
+		created_at: '2026-01-01T00:00:00Z',
+		updated_at: '2026-01-01T00:00:00Z',
+	};
+}
+
+function entry(c: Comment): TimelineEntry {
+	return {
+		id: `e-${c.id}`,
+		kind: 'comment',
+		created_at: c.created_at,
+		actor: 'alice',
+		source: 'web',
+		comment: c,
+	};
+}
+
+/** A body embedding each id as an inline image, in order. */
+function bodyWith(ids: string[]): string {
+	return ids.map((id, i) => `![image ${i}](pad-attachment:${id})`).join('\n\n');
+}
+
+function respond(ids: string[]): TimelineResponse {
+	return { entries: [entry(comment(bodyWith(ids)))], has_more: false };
+}
+
+let host: HTMLElement;
+let app: Record<string, unknown> | null = null;
+
+// Reactive props object so a test can flip wsSlug / itemSlug the way ItemDetail
+// does — the timeline is mounted WITHOUT `{#key}` and is reused across the
+// switch, which is the whole point of the lifecycle tests below.
+const props = $state<{
+	wsSlug: string;
+	username: string;
+	itemSlug: string;
+	currentContent: string;
+	itemId: string;
+	collectionId: string;
+	visibleKinds: Array<'comment' | 'activity' | 'version'> | undefined;
+}>({
+	wsSlug: 'ws',
+	username: 'alice',
+	itemSlug: 'TASK-1',
+	currentContent: '',
+	itemId: 'item-a',
+	collectionId: 'coll-1',
+	visibleKinds: undefined,
+});
+
+function resetProps() {
+	props.wsSlug = 'ws';
+	props.username = 'alice';
+	props.itemSlug = 'TASK-1';
+	props.currentContent = '';
+	props.itemId = 'item-a';
+	props.collectionId = 'coll-1';
+	props.visibleKinds = undefined;
+}
+
+function render() {
+	app = mount(ItemTimeline, { target: host, props }) as Record<string, unknown>;
+	return app;
+}
+
+/**
+ * Let the timeline fetch, probe, render and run its deferred semantics pass.
+ * Several microtask hops: list() → entries → probe → attMeta → re-render →
+ * `tick()` inside the semantics effect.
+ */
+async function settle() {
+	for (let i = 0; i < 8; i++) {
+		await tick();
+		flushSync();
+	}
+}
+
+function thumbs(): HTMLElement[] {
+	return Array.from(host.querySelectorAll<HTMLElement>('img[data-attachment-id]'));
+}
+
+function thumbFor(id: string): HTMLElement {
+	const el = thumbs().find((t) => t.getAttribute('data-attachment-id') === id);
+	if (!el) throw new Error(`no thumbnail rendered for ${id}`);
+	return el;
+}
+
+/** The attachment id the open viewer is currently SHOWING, or null if closed. */
+function viewerShowing(): string | null {
+	const img = document.querySelector<HTMLImageElement>('.lightbox-backdrop .lightbox-image');
+	if (!img) return null;
+	const m = /attachments\/([0-9a-f-]+)/.exec(img.getAttribute('src') ?? '');
+	return m ? m[1] : null;
+}
+
+function viewerOpen(): boolean {
+	return document.querySelector('.lightbox-backdrop') !== null;
+}
+
+function click(el: HTMLElement) {
+	el.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+	flushSync();
+}
+
+function pressOn(el: HTMLElement, key: string) {
+	el.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true }));
+	flushSync();
+}
+
+/** The viewer listens on `window`, so its arrows are driven from there. */
+function pressGlobal(key: string) {
+	window.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true }));
+	flushSync();
+}
+
+beforeEach(() => {
+	host = document.createElement('div');
+	document.body.appendChild(host);
+	resetProps();
+	timelineListMock.mockReset();
+	timelineListMock.mockResolvedValue({ entries: [], has_more: false });
+});
+
+afterEach(() => {
+	// Unmount FIRST: that runs the viewer's own teardown, which is what
+	// unregisters its Escape handler and releases its backdrop lease. Ripping
+	// the portaled node out beforehand would leave both behind.
+	if (app) unmount(app);
+	app = null;
+	host.remove();
+	// The viewer portals to <body>; make sure nothing leaks between tests.
+	document.querySelectorAll('.lightbox-backdrop').forEach((n) => n.remove());
+	// ...and reset the two module-global registries a viewer touches, so a case
+	// that ends with one open cannot colour the next test (the strip suite's
+	// afterEach does the same).
+	__resetViewerBackdropForTests();
+	_resetEscapeStackForTests();
+});
+
+describe('ItemTimeline — viewer open gate (TASK-2431)', () => {
+	it('renders an <img> for the SVG — the render decision is not the gate', async () => {
+		timelineListMock.mockResolvedValue(respond([PNG_A, SVG]));
+		render();
+		await settle();
+
+		// If this ever stops holding, the tests below are vacuous: they would be
+		// proving that an element nobody renders cannot be clicked.
+		expect(thumbs().map((t) => t.getAttribute('data-attachment-id'))).toEqual([PNG_A, SVG]);
+	});
+
+	it('refuses a click on a non-allowlisted image', async () => {
+		timelineListMock.mockResolvedValue(respond([PNG_A, SVG]));
+		render();
+		await settle();
+
+		click(thumbFor(SVG));
+		expect(viewerOpen()).toBe(false);
+	});
+
+	it('refuses Enter and Space on a non-allowlisted image', async () => {
+		timelineListMock.mockResolvedValue(respond([PNG_A, SVG]));
+		render();
+		await settle();
+
+		pressOn(thumbFor(SVG), 'Enter');
+		expect(viewerOpen()).toBe(false);
+		pressOn(thumbFor(SVG), ' ');
+		expect(viewerOpen()).toBe(false);
+	});
+
+	it('opens on an allowlisted image, by mouse and by keyboard', async () => {
+		timelineListMock.mockResolvedValue(respond([PNG_A, SVG]));
+		render();
+		await settle();
+
+		click(thumbFor(PNG_A));
+		expect(viewerShowing()).toBe(PNG_A);
+
+		// Close and reopen from the keyboard.
+		(document.querySelector('.lightbox-close') as HTMLElement).click();
+		flushSync();
+		expect(viewerOpen()).toBe(false);
+
+		pressOn(thumbFor(PNG_A), 'Enter');
+		expect(viewerShowing()).toBe(PNG_A);
+	});
+
+	it('never pages onto an unsafe sibling with ←/→', async () => {
+		// Mixed: safe, unsafe, safe, undecodable, unprobed.
+		timelineListMock.mockResolvedValue(respond([PNG_A, SVG, PNG_B, TIFF, UNPROBED]));
+		render();
+		await settle();
+
+		click(thumbFor(PNG_A));
+		expect(viewerShowing()).toBe(PNG_A);
+
+		// The set is the two allowlisted images ONLY, so → wraps between them
+		// and every position is safe. Walk a full cycle in both directions.
+		const seen: (string | null)[] = [viewerShowing()];
+		for (let i = 0; i < 4; i++) {
+			pressGlobal('ArrowRight');
+			seen.push(viewerShowing());
+		}
+		for (let i = 0; i < 4; i++) {
+			pressGlobal('ArrowLeft');
+			seen.push(viewerShowing());
+		}
+		expect(seen).toEqual([PNG_A, PNG_B, PNG_A, PNG_B, PNG_A, PNG_B, PNG_A, PNG_B, PNG_A]);
+		expect(seen).not.toContain(SVG);
+		expect(seen).not.toContain(TIFF);
+		expect(seen).not.toContain(UNPROBED);
+
+		// ...and the counter agrees the set has two members, not five.
+		expect(document.querySelector('.lightbox-counter')?.textContent).toBe('1 / 2');
+	});
+
+	it('derives the index from the clicked ID, not the DOM position', async () => {
+		// PNG_B is DOM index 2 but list index 1 once the SVG is filtered out.
+		// A position-derived index would open on the wrong image — and with a
+		// leading run of refusals, past the end of the list entirely.
+		timelineListMock.mockResolvedValue(respond([SVG, TIFF, PNG_B, PNG_A]));
+		render();
+		await settle();
+
+		click(thumbFor(PNG_B));
+		expect(viewerShowing()).toBe(PNG_B);
+		expect(document.querySelector('.lightbox-counter')?.textContent).toBe('1 / 2');
+
+		pressGlobal('ArrowRight');
+		expect(viewerShowing()).toBe(PNG_A);
+	});
+
+	it('fails safe on a thumbnail whose MIME it holds no answer for', async () => {
+		// The gate's `!meta` branch, tested where it is REACHABLE rather than
+		// through the renderer. Asserting that an unprobed id renders no <img>
+		// would prove nothing about the gate — it is a fact about the markdown
+		// resolver, and it holds with the gate deleted.
+		//
+		// The handlers are delegated over the entry list and act on whatever
+		// `img[data-attachment-id]` is in the DOM, so an element the component
+		// has no metadata for is a real input: a node left over from a body that
+		// re-rendered, or one from a future surface. It must be refused, and it
+		// must not be a member of a NEIGHBOUR's set either.
+		timelineListMock.mockResolvedValue(respond([PNG_A]));
+		render();
+		await settle();
+
+		const body = host.querySelector('.comment-body, .reply-body')!;
+		const stray = document.createElement('img');
+		stray.setAttribute('data-attachment-id', UNPROBED);
+		stray.setAttribute('alt', 'unknown');
+		body.appendChild(stray);
+
+		click(stray);
+		expect(viewerOpen()).toBe(false);
+		pressOn(stray, 'Enter');
+		expect(viewerOpen()).toBe(false);
+
+		// ...and the PNG beside it opens a ONE-image viewer: no counter means no
+		// second member, so ← / → cannot page onto the stray.
+		click(thumbFor(PNG_A));
+		expect(viewerShowing()).toBe(PNG_A);
+		expect(document.querySelector('.lightbox-counter')).toBeNull();
+	});
+
+	it('admits an image once a later probe resolves its MIME', async () => {
+		// The other half of failing safe: refusal is provisional, not a latch.
+		MIMES[UNPROBED] = 'image/png';
+		try {
+			timelineListMock.mockResolvedValue(respond([UNPROBED, PNG_A]));
+			render();
+			await settle();
+
+			click(thumbFor(UNPROBED));
+			expect(viewerShowing()).toBe(UNPROBED);
+		} finally {
+			delete MIMES[UNPROBED];
+		}
+	});
+});
+
+describe('ItemTimeline — interactive semantics track the gate (TASK-2431)', () => {
+	it('marks allowlisted thumbnails as buttons and leaves refused ones inert', async () => {
+		timelineListMock.mockResolvedValue(respond([PNG_A, SVG, TIFF]));
+		render();
+		await settle();
+
+		const png = thumbFor(PNG_A);
+		expect(png.getAttribute('role')).toBe('button');
+		expect(png.getAttribute('tabindex')).toBe('0');
+		expect(png.getAttribute('aria-label')).toContain('View image');
+
+		for (const refused of [thumbFor(SVG), thumbFor(TIFF)]) {
+			// A focus stop announced as a button whose activation does nothing is
+			// worse than the hole it replaces.
+			expect(refused.getAttribute('role')).toBeNull();
+			expect(refused.getAttribute('tabindex')).toBeNull();
+			expect(refused.getAttribute('aria-label')).toBeNull();
+		}
+	});
+
+	it('re-applies them when the kind filter rebuilds the cards', async () => {
+		// The pane's Activity / Versions tabs filter the RENDERED set without
+		// refetching: `entries` is untouched while every comment card is
+		// destroyed and rebuilt. The rebuilt image keeps working by mouse (the
+		// listeners are delegated to the container), so a pass that missed this
+		// left it openable by mouse and unreachable by keyboard.
+		timelineListMock.mockResolvedValue(respond([PNG_A]));
+		props.visibleKinds = ['comment'];
+		render();
+		await settle();
+		expect(thumbFor(PNG_A).getAttribute('role')).toBe('button');
+
+		props.visibleKinds = ['activity'];
+		flushSync();
+		await settle();
+		expect(thumbs()).toHaveLength(0);
+
+		props.visibleKinds = ['comment'];
+		flushSync();
+		await settle();
+
+		const png = thumbFor(PNG_A);
+		expect(png.getAttribute('role')).toBe('button');
+		expect(png.getAttribute('tabindex')).toBe('0');
+		pressOn(png, 'Enter');
+		expect(viewerShowing()).toBe(PNG_A);
+	});
+});
+
+describe('ItemTimeline — A→B viewer lifecycle (TASK-2431)', () => {
+	it('closes an open viewer when the workspace switches under the same ref', async () => {
+		timelineListMock.mockResolvedValue(respond([PNG_A, PNG_B]));
+		props.wsSlug = 'ws-one';
+		render();
+		await settle();
+
+		click(thumbFor(PNG_A));
+		expect(viewerShowing()).toBe(PNG_A);
+		expect(document.querySelector('.lightbox-image')?.getAttribute('src')).toContain('ws-one');
+
+		// Same itemSlug, different workspace — the case the component had no
+		// reset for at all. A viewer left up here keeps showing ws-one's ids
+		// while the timeline underneath is ws-two's.
+		props.wsSlug = 'ws-two';
+		flushSync();
+		await settle();
+
+		expect(viewerOpen()).toBe(false);
+	});
+
+	it('closes an open viewer when the item switches', async () => {
+		timelineListMock.mockResolvedValue(respond([PNG_A, PNG_B]));
+		render();
+		await settle();
+
+		click(thumbFor(PNG_A));
+		expect(viewerOpen()).toBe(true);
+
+		props.itemSlug = 'TASK-2';
+		flushSync();
+		await settle();
+
+		expect(viewerOpen()).toBe(false);
+	});
+
+	it('leaves an open viewer alone when nothing switched', async () => {
+		timelineListMock.mockResolvedValue(respond([PNG_A, PNG_B]));
+		render();
+		await settle();
+
+		click(thumbFor(PNG_A));
+		expect(viewerOpen()).toBe(true);
+
+		// A prop that is not part of the view identity must not tear the viewer
+		// down — a reset keyed too broadly is its own bug.
+		props.username = 'bob';
+		flushSync();
+		await settle();
+
+		expect(viewerShowing()).toBe(PNG_A);
+	});
+});

--- a/web/src/lib/components/timeline/fixtures/InertCommentEditor.svelte
+++ b/web/src/lib/components/timeline/fixtures/InertCommentEditor.svelte
@@ -1,0 +1,17 @@
+<!--
+	Test double for `CommentEditor` (TASK-2431).
+
+	`ItemTimeline` mounts one as its composer, and it drags in Tiptap — which
+	these tests neither exercise nor need. The timeline's own behaviour under
+	test (which inline images may be handed to the viewer) is entirely in the
+	rendered comment bodies, so the composer is replaced with a marker.
+
+	Accepts and ignores every prop: a Svelte 5 rest-props catch-all, so adding a
+	prop to the real component can never break this file.
+-->
+<script lang="ts">
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	let _props: Record<string, unknown> = $props();
+</script>
+
+<div class="comment-editor-stub"></div>

--- a/web/src/lib/components/timeline/timelineEditorOwnedImages.svelte.test.ts
+++ b/web/src/lib/components/timeline/timelineEditorOwnedImages.svelte.test.ts
@@ -21,12 +21,20 @@
 // this file exists rather than another stand-in.
 //
 // The two viewers are distinguishable, which is what makes "exactly once"
-// observable: the NodeView opens its own `dialog.attachment-image-lightbox`,
-// the timeline opens the `Lightbox` component (`.lightbox-backdrop`).
+// observable: the NodeView emits an open-viewer REQUEST on the shared channel
+// (TASK-2433 deleted its hand-rolled `<dialog>`; an `AttachmentViewerHost` owned
+// by `ItemDetail` mounts the one `Lightbox` in response, and no `ItemDetail` is
+// mounted here), while the timeline mounts `Lightbox` itself
+// (`.lightbox-backdrop`). Requests are counted off the REAL bus, addressability
+// filter included — this file's whole premise is that nothing is restated.
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { flushSync, mount, unmount, tick } from 'svelte';
 import type { Comment, TimelineEntry, TimelineResponse } from '$lib/types';
 import { __resetViewerBackdropForTests } from '$lib/a11y/viewerBackdrop';
+import {
+	isAttachmentViewerEventForHost,
+	registerAttachmentViewerListener,
+} from '$lib/attachments/events';
 import { _resetEscapeStackForTests } from '$lib/stores/escapeStack';
 
 const PNG = '11111111-1111-4111-8111-111111111111';
@@ -129,6 +137,11 @@ const props = $state({
 	currentContent: '',
 	itemId: 'item-a',
 	collectionId: 'coll-1',
+	// The identity `ItemDetail` mints per mount and threads down to every
+	// CommentEditor. Without it the NodeView's events are unaddressable and the
+	// channel drops them — which would make every `node: 1` below unreachable
+	// for a reason that has nothing to do with the delegation under test.
+	hostToken: 'host-1',
 	visibleKinds: undefined as Array<'comment' | 'activity' | 'version'> | undefined,
 });
 
@@ -156,12 +169,37 @@ function bodyImage(): HTMLElement {
 	return el;
 }
 
-/** Viewers currently open, counted per owner so a double-open is visible. */
+/** Open-viewer requests the NodeView put on the bus, in this test's lifetime. */
+let nodeRequests: unknown[] = [];
+let disposeViewerListener: (() => void) | null = null;
+
+/**
+ * Counted per owner so a double-open is visible. NOTE THE ASYMMETRY, which is
+ * the shape of the change rather than a shortcut: `timeline` counts viewers
+ * actually mounted, because ItemTimeline still mounts `Lightbox` itself, while
+ * `node` counts open-viewer REQUESTS addressed to this host, because the
+ * NodeView no longer mounts anything — an `ItemDetail`-owned
+ * `AttachmentViewerHost` does, and no `ItemDetail` is mounted in this file.
+ * A request that would reach that host is the strongest statement available
+ * here; the request-to-viewer half is
+ * `editor/attachmentImageViewerHost.svelte.test.ts`'s.
+ */
 function viewers() {
 	return {
-		node: document.querySelectorAll('dialog.attachment-image-lightbox').length,
+		node: nodeRequests.length,
 		timeline: document.querySelectorAll('.lightbox-backdrop').length,
 	};
+}
+
+/**
+ * Activation resolves the image's MIME before emitting (TASK-2433), so it is
+ * asynchronous even on a cache hit. Counting without this reads 0 whatever the
+ * implementation does — the exact shape of vacuous green this phase keeps
+ * producing.
+ */
+async function flushActivation() {
+	await new Promise((resolve) => setTimeout(resolve, 0));
+	flushSync();
 }
 
 function press(el: HTMLElement, key: string, mods: KeyboardEventInit = {}) {
@@ -193,6 +231,20 @@ describe('ItemTimeline vs. a live editor inside it', () => {
 		commentUpdateMock.mockReset();
 		commentUpdateMock.mockResolvedValue(undefined);
 		props.visibleKinds = undefined;
+		nodeRequests = [];
+		// The REAL channel, not a mock: an event that fails its addressability
+		// check reaches no host at runtime either, and counting pre-filter
+		// emissions would score a misaddressed request as a viewer the user can
+		// see. `hostToken` is set on the props for the same reason.
+		disposeViewerListener = registerAttachmentViewerListener((event) => {
+			// Addressed to THIS host, by the same predicate `AttachmentViewerHost`
+			// uses. A raw count would score a misaddressed request as a viewer the
+			// user can see, when at runtime it reaches nobody.
+			if (!isAttachmentViewerEventForHost(event, { itemId: 'item-a', hostToken: 'host-1' })) {
+				return;
+			}
+			nodeRequests.push(event);
+		});
 		host = document.body.appendChild(document.createElement('div'));
 		app = mount(ItemTimeline, { target: host, props }) as Record<string, unknown>;
 		await settle();
@@ -201,10 +253,11 @@ describe('ItemTimeline vs. a live editor inside it', () => {
 	afterEach(() => {
 		if (app) unmount(app);
 		app = null;
+		disposeViewerListener?.();
+		disposeViewerListener = null;
+		nodeRequests = [];
 		host.remove();
-		document
-			.querySelectorAll('dialog.attachment-image-lightbox, .lightbox-backdrop')
-			.forEach((d) => d.remove());
+		document.querySelectorAll('.lightbox-backdrop').forEach((d) => d.remove());
 	});
 
 	it('mounts a live editor whose image already carries the NodeView contract', async () => {
@@ -233,6 +286,7 @@ describe('ItemTimeline vs. a live editor inside it', () => {
 		expect(viewers()).toEqual({ node: 0, timeline: 0 });
 
 		press(editorImage(), 'Enter');
+		await flushActivation();
 
 		expect(viewers()).toEqual({ node: 1, timeline: 0 });
 	});
@@ -240,12 +294,14 @@ describe('ItemTimeline vs. a live editor inside it', () => {
 	it('opens exactly one viewer on Space inside the editor', async () => {
 		await enterEditMode();
 		press(editorImage(), ' ');
+		await flushActivation();
 		expect(viewers()).toEqual({ node: 1, timeline: 0 });
 	});
 
 	it('opens exactly one viewer on a click inside the editor', async () => {
 		await enterEditMode();
 		click(editorImage());
+		await flushActivation();
 		expect(viewers()).toEqual({ node: 1, timeline: 0 });
 	});
 
@@ -263,6 +319,7 @@ describe('ItemTimeline vs. a live editor inside it', () => {
 
 		press(img, 'Enter', { metaKey: true });
 		await settle();
+		await flushActivation();
 
 		expect(viewers()).toEqual({ node: 0, timeline: 0 });
 		expect(commentUpdateMock).toHaveBeenCalledTimes(1);
@@ -282,6 +339,7 @@ describe('ItemTimeline vs. a live editor inside it', () => {
 		img.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, detail: 1 }));
 		img.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, detail: 2 }));
 		flushSync();
+		await flushActivation();
 
 		expect(viewers()).toEqual({ node: 1, timeline: 0 });
 	});
@@ -316,9 +374,21 @@ describe('ItemTimeline vs. a live editor inside it', () => {
 		expect(img.getAttribute('role')).toBe('button');
 		expect(img.getAttribute('tabindex')).toBe('0');
 		expect(img.getAttribute('aria-label')).toBe('View image: a sketch');
-		// And it still activates — semantics without activation is the dead stop
-		// in its other direction.
+		// Activation, however, is now gated on a RESOLVED MIME (TASK-2433), and
+		// this fixture's whole point is an image whose probe never resolves one:
+		// `Lightbox` fails closed on `mime_type: null`, so emitting for it would
+		// be a request that opens nothing. It stays shut here — and the dead
+		// focus stop that leaves (announced as a button, refuses to open) is
+		// exactly what TASK-2434's four-branch matrix is for, where a transient
+		// probe becomes retryable rather than silent.
 		press(img, 'Enter');
+		await flushActivation();
+		expect(viewers()).toEqual({ node: 0, timeline: 0 });
+
+		// The control, so the assertion above is not just "activation is broken":
+		// the PROBED image in the same live editor still opens.
+		press(editorImage(PNG), 'Enter');
+		await flushActivation();
 		expect(viewers()).toEqual({ node: 1, timeline: 0 });
 	});
 
@@ -334,11 +404,13 @@ describe('ItemTimeline vs. a live editor inside it', () => {
 		expect(img.getAttribute('tabindex')).toBe('0');
 
 		click(img);
+		await flushActivation();
 		expect(viewers()).toEqual({ node: 0, timeline: 1 });
 	});
 
 	it('still opens its OWN rendered thumbnail by keyboard', async () => {
 		press(bodyImage(), 'Enter');
+		await flushActivation();
 		expect(viewers()).toEqual({ node: 0, timeline: 1 });
 	});
 
@@ -346,9 +418,11 @@ describe('ItemTimeline vs. a live editor inside it', () => {
 		// The modifier guard is not scoped to editor-owned DOM: a shortcut is a
 		// shortcut wherever it is pressed.
 		press(bodyImage(), 'Enter', { metaKey: true });
+		await flushActivation();
 		expect(viewers()).toEqual({ node: 0, timeline: 0 });
 
 		press(bodyImage(), 'Enter');
+		await flushActivation();
 		expect(viewers()).toEqual({ node: 0, timeline: 1 });
 	});
 });

--- a/web/src/lib/components/timeline/timelineEditorOwnedImages.svelte.test.ts
+++ b/web/src/lib/components/timeline/timelineEditorOwnedImages.svelte.test.ts
@@ -1,0 +1,354 @@
+// The timeline vs. a LIVE editor mounted inside it (PLAN-2392 DR-12 / TASK-2432).
+//
+// ItemTimeline delegates thumbnail click/keydown across its whole entry list
+// and runs a role/tabindex pass over every `img[data-attachment-id]` in it.
+// That list CONTAINS live CommentEditor instances, whose inline images are
+// AttachmentImage NodeViews that own their own activation and semantics. Two
+// components reaching for the same DOM produced two failures:
+//
+//   - the semantics pass stripped role/tabindex/aria-label from a NodeView
+//     image, because `attMeta` is probed from SAVED bodies and an image being
+//     EDITED is not in it — leaving it mouse-openable and keyboard-dead;
+//   - the delegated keydown had no modifier check, so Cmd/Ctrl+Enter — which
+//     the NodeView deliberately lets through, because it is CommentEditor's
+//     submit binding — opened a viewer on top of the submit.
+//
+// EVERYTHING REAL: the real ItemTimeline, the real TimelineCommentCard, the
+// real CommentEditor with its real Tiptap/AttachmentImage configuration, the
+// real markdown pipeline, the real Lightbox. Nothing about the delegation or
+// the ownership check is restated here — a copy of that logic would stay green
+// after the guards were deleted from the component, which is the whole reason
+// this file exists rather than another stand-in.
+//
+// The two viewers are distinguishable, which is what makes "exactly once"
+// observable: the NodeView opens its own `dialog.attachment-image-lightbox`,
+// the timeline opens the `Lightbox` component (`.lightbox-backdrop`).
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { flushSync, mount, unmount, tick } from 'svelte';
+import type { Comment, TimelineEntry, TimelineResponse } from '$lib/types';
+import { __resetViewerBackdropForTests } from '$lib/a11y/viewerBackdrop';
+import { _resetEscapeStackForTests } from '$lib/stores/escapeStack';
+
+const PNG = '11111111-1111-4111-8111-111111111111';
+// An attachment whose HEAD probe does not resolve to a MIME, so it never
+// enters `attMeta`. This is what EVERY image in a draft comment looks like to
+// the timeline — `attMeta` is probed from SAVED bodies only — and it is the
+// case in which the timeline's accessibility pass would strip a NodeView's
+// semantics. An image the editor and a saved body SHARE is already probed, so
+// a fixture built only from that one cannot reach the bug.
+const UNPROBED = '99999999-9999-4999-8999-999999999999';
+
+const timelineListMock = vi.fn<(ws: string, slug: string) => Promise<TimelineResponse>>();
+// The comment-edit write. Observed rather than ignored: "Cmd+Enter does not
+// open a viewer" is only half the claim — the other half is that the SUBMIT it
+// was for still happened.
+const commentUpdateMock =
+	vi.fn<(ws: string, id: string, payload: { body: string }) => Promise<unknown>>();
+
+vi.mock('$lib/api/client', () => ({
+	api: {
+		timeline: { list: (ws: string, slug: string) => timelineListMock(ws, slug) },
+		comments: {
+			create: vi.fn(),
+			update: (ws: string, id: string, payload: { body: string }) =>
+				commentUpdateMock(ws, id, payload),
+			delete: vi.fn(),
+			addReaction: vi.fn(),
+			removeReaction: vi.fn(),
+		},
+		attachments: {
+			downloadUrl: (ws: string, id: string, variant?: string) =>
+				`/api/v1/workspaces/${ws}/attachments/${id}${variant ? `?variant=${variant}` : ''}`,
+			upload: vi.fn(),
+		},
+	},
+}));
+
+vi.mock('$lib/services/sse.svelte', () => ({
+	sseService: { onItemEvent: () => () => {} },
+}));
+
+// The comment's author, so its Edit affordance is offered and a real
+// CommentEditor can be mounted over its body.
+vi.mock('$lib/stores/auth.svelte', () => ({
+	authStore: { userId: 'user-1', user: { id: 'user-1', role: 'member' } },
+}));
+
+vi.mock('$lib/stores/workspace.svelte', () => ({
+	workspaceStore: { canEditItem: () => true },
+}));
+
+vi.mock('$lib/components/editor/attachment-metadata', () => ({
+	fetchAttachmentMetadata: (_ws: string, uuid: string) =>
+		Promise.resolve(
+			uuid === PNG
+				? { status: 'ok' as const, mime: 'image/png', size: 4096 }
+				: { status: 'transient' as const }
+		),
+	revalidateAttachmentMetadata: () => Promise.resolve({ status: 'transient' as const }),
+	invalidateAttachmentMetadata: vi.fn(),
+	mimeToFormat: () => null,
+}));
+
+// NOTE: CommentEditor is deliberately NOT stubbed here (the sibling
+// ItemTimeline spec stubs it, which is exactly why that spec cannot see any of
+// this). Tiptap runs for real.
+const { default: ItemTimeline } = await import('./ItemTimeline.svelte');
+
+function respond(): TimelineResponse {
+	const c: Comment = {
+		id: 'c1',
+		item_id: 'item-a',
+		workspace_id: 'ws-1',
+		author: 'alice',
+		user_id: 'user-1',
+		body: `![a diagram](pad-attachment:${PNG})\n\n![a sketch](pad-attachment:${UNPROBED})`,
+		created_by: 'alice',
+		source: 'web',
+		created_at: '2026-01-01T00:00:00Z',
+		updated_at: '2026-01-01T00:00:00Z',
+	} as Comment;
+	const e: TimelineEntry = {
+		id: 'e-c1',
+		kind: 'comment',
+		created_at: c.created_at,
+		actor: 'alice',
+		source: 'web',
+		comment: c,
+	};
+	return { entries: [e], has_more: false };
+}
+
+let host: HTMLElement;
+let app: Record<string, unknown> | null = null;
+
+const props = $state({
+	wsSlug: 'ws',
+	username: 'alice',
+	itemSlug: 'TASK-1',
+	currentContent: '',
+	itemId: 'item-a',
+	collectionId: 'coll-1',
+	visibleKinds: undefined as Array<'comment' | 'activity' | 'version'> | undefined,
+});
+
+/** Fetch → probe → render → the deferred semantics pass, plus Tiptap's mount. */
+async function settle() {
+	for (let i = 0; i < 10; i++) {
+		await tick();
+		flushSync();
+	}
+}
+
+/** The image the LIVE EDITOR owns, i.e. the NodeView's. */
+function editorImage(id: string = PNG): HTMLElement {
+	const el = host.querySelector<HTMLElement>(
+		`.ProseMirror[contenteditable] img[data-attachment-id="${id}"]`
+	);
+	if (!el) throw new Error(`no editor-owned image rendered for ${id}`);
+	return el;
+}
+
+/** The image the TIMELINE owns, i.e. rendered `{@html}` markup. */
+function bodyImage(): HTMLElement {
+	const el = host.querySelector<HTMLElement>('.comment-body img[data-attachment-id]');
+	if (!el) throw new Error('no rendered body image');
+	return el;
+}
+
+/** Viewers currently open, counted per owner so a double-open is visible. */
+function viewers() {
+	return {
+		node: document.querySelectorAll('dialog.attachment-image-lightbox').length,
+		timeline: document.querySelectorAll('.lightbox-backdrop').length,
+	};
+}
+
+function press(el: HTMLElement, key: string, mods: KeyboardEventInit = {}) {
+	el.dispatchEvent(
+		new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true, ...mods })
+	);
+	flushSync();
+}
+
+function click(el: HTMLElement) {
+	el.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, detail: 1 }));
+	flushSync();
+}
+
+/** Open the comment's inline edit form — a real CommentEditor over its body. */
+async function enterEditMode() {
+	const btn = host.querySelector<HTMLButtonElement>('.edit-btn');
+	if (!btn) throw new Error('no Edit affordance — check the author/admin gate');
+	btn.click();
+	await settle();
+}
+
+describe('ItemTimeline vs. a live editor inside it', () => {
+	beforeEach(async () => {
+		_resetEscapeStackForTests();
+		__resetViewerBackdropForTests();
+		timelineListMock.mockReset();
+		timelineListMock.mockResolvedValue(respond());
+		commentUpdateMock.mockReset();
+		commentUpdateMock.mockResolvedValue(undefined);
+		props.visibleKinds = undefined;
+		host = document.body.appendChild(document.createElement('div'));
+		app = mount(ItemTimeline, { target: host, props }) as Record<string, unknown>;
+		await settle();
+	});
+
+	afterEach(() => {
+		if (app) unmount(app);
+		app = null;
+		host.remove();
+		document
+			.querySelectorAll('dialog.attachment-image-lightbox, .lightbox-backdrop')
+			.forEach((d) => d.remove());
+	});
+
+	it('mounts a live editor whose image already carries the NodeView contract', async () => {
+		// The PREMISE the rest of this file rests on: entering edit mode really
+		// does produce a live ProseMirror root with a real AttachmentImage
+		// NodeView inside the timeline. This test does NOT cover the ownership
+		// check — the timeline's pass has not re-run at this point, so it stays
+		// green without it. "…when its semantics pass RE-RUNS" below is the one
+		// that carries that guard.
+		await enterEditMode();
+		const img = editorImage();
+
+		expect(img.getAttribute('role')).toBe('button');
+		expect(img.getAttribute('tabindex')).toBe('0');
+		expect(img.getAttribute('aria-label')).toBe('View image: a diagram');
+	});
+
+	// Exactly-once for the three ordinary gestures, end to end through both
+	// components. What actually keeps the timeline out of these is the
+	// NodeView's own stopPropagation, NOT the ownership check — they stay green
+	// with the ownership check deleted, and the double-click test below is the
+	// one that covers it. Kept because "one keypress, one viewer" is the
+	// headline claim and it should be asserted against the real pair.
+	it('opens exactly one viewer on Enter inside the editor', async () => {
+		await enterEditMode();
+		expect(viewers()).toEqual({ node: 0, timeline: 0 });
+
+		press(editorImage(), 'Enter');
+
+		expect(viewers()).toEqual({ node: 1, timeline: 0 });
+	});
+
+	it('opens exactly one viewer on Space inside the editor', async () => {
+		await enterEditMode();
+		press(editorImage(), ' ');
+		expect(viewers()).toEqual({ node: 1, timeline: 0 });
+	});
+
+	it('opens exactly one viewer on a click inside the editor', async () => {
+		await enterEditMode();
+		click(editorImage());
+		expect(viewers()).toEqual({ node: 1, timeline: 0 });
+	});
+
+	it('SUBMITS on Cmd/Ctrl+Enter inside the editor, and opens no viewer', async () => {
+		// The end-to-end statement of the bug this fixed: with an image focused,
+		// Cmd+Enter opened a viewer INSTEAD of posting. Both halves are asserted
+		// — "no viewer appeared" alone would also be satisfied by a keystroke
+		// that did nothing at all, which is the other way to break this.
+		//
+		// Not uniquely load-bearing for either guard on its own: the NodeView's
+		// modifier guard and the timeline's ownership check each independently
+		// keep the viewer shut. It is here for the user-visible behaviour.
+		await enterEditMode();
+		const img = editorImage();
+
+		press(img, 'Enter', { metaKey: true });
+		await settle();
+
+		expect(viewers()).toEqual({ node: 0, timeline: 0 });
+		expect(commentUpdateMock).toHaveBeenCalledTimes(1);
+		expect(commentUpdateMock.mock.calls[0][2].body).toContain(PNG);
+	});
+
+	it('opens NO timeline viewer on a DOUBLE-click inside the editor', async () => {
+		// The path the NodeView's own stopPropagation does NOT cover, and
+		// therefore the one the ownership check actually carries: multi-click is
+		// deliberately let through (`event.detail > 1`) so a user can drag-select
+		// around an image. Without the check, the second click of an ordinary
+		// double-click reaches the timeline's delegation and opens ITS viewer on
+		// top of the one the first click already opened.
+		await enterEditMode();
+		const img = editorImage();
+
+		img.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, detail: 1 }));
+		img.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, detail: 2 }));
+		flushSync();
+
+		expect(viewers()).toEqual({ node: 1, timeline: 0 });
+	});
+
+	it('leaves the editor-owned image alone when its semantics pass RE-RUNS', async () => {
+		// Two things both have to be true to reach the bug, and each of them
+		// alone makes this test vacuous:
+		//
+		//  - the pass is deferred and dependency-driven, so merely OPENING an
+		//    editor does not trigger it. Something must make it run again while
+		//    the editor is up. Flipping the pane's kind filter is the ordinary
+		//    way a user does that; entries are keyed, so the card and its live
+		//    editor survive the re-render.
+		//  - the image must be one `attMeta` does not know, since the pass only
+		//    strips what it cannot resolve. An image shared with the saved body
+		//    is already probed and would be skipped for the wrong reason.
+		await enterEditMode();
+		const before = editorImage(UNPROBED);
+		expect(before.getAttribute('role')).toBe('button');
+
+		props.visibleKinds = ['comment', 'activity', 'version'];
+		await settle();
+		props.visibleKinds = undefined;
+		await settle();
+
+		const img = editorImage(UNPROBED);
+		// The SAME element, not a replacement. If the flip had torn the card
+		// down and rebuilt it, a fresh NodeView would have re-applied its
+		// semantics and every assertion below would pass without the pass ever
+		// having had the chance to strip them.
+		expect(img).toBe(before);
+		expect(img.getAttribute('role')).toBe('button');
+		expect(img.getAttribute('tabindex')).toBe('0');
+		expect(img.getAttribute('aria-label')).toBe('View image: a sketch');
+		// And it still activates — semantics without activation is the dead stop
+		// in its other direction.
+		press(img, 'Enter');
+		expect(viewers()).toEqual({ node: 1, timeline: 0 });
+	});
+
+	// The control. Everything above is about the timeline declining to act; this
+	// is what it must still do, so a predicate that simply answered "true"
+	// everywhere is caught here. Split per gesture rather than opening twice in
+	// one test: tearing a mounted Lightbox down mid-test by hand would leave the
+	// component and the escape/backdrop registries disagreeing, and the second
+	// assertion would then be measuring that instead.
+	it('still opens its OWN rendered thumbnail by mouse', async () => {
+		const img = bodyImage();
+		expect(img.getAttribute('role')).toBe('button');
+		expect(img.getAttribute('tabindex')).toBe('0');
+
+		click(img);
+		expect(viewers()).toEqual({ node: 0, timeline: 1 });
+	});
+
+	it('still opens its OWN rendered thumbnail by keyboard', async () => {
+		press(bodyImage(), 'Enter');
+		expect(viewers()).toEqual({ node: 0, timeline: 1 });
+	});
+
+	it('still declines a MODIFIED key on its own rendered thumbnail', async () => {
+		// The modifier guard is not scoped to editor-owned DOM: a shortcut is a
+		// shortcut wherever it is pressed.
+		press(bodyImage(), 'Enter', { metaKey: true });
+		expect(viewers()).toEqual({ node: 0, timeline: 0 });
+
+		press(bodyImage(), 'Enter');
+		expect(viewers()).toEqual({ node: 0, timeline: 1 });
+	});
+});

--- a/web/src/lib/stores/escapeStack.test.ts
+++ b/web/src/lib/stores/escapeStack.test.ts
@@ -131,4 +131,37 @@ describe('escapeStack', () => {
 		runTopEscape();
 		expect(calls).toEqual(['second']);
 	});
+
+	it('forwards the driving event to every handler it invokes (TASK-2448)', () => {
+		const seen: (KeyboardEvent | undefined)[] = [];
+		// This suite runs in the NODE environment (no DOM globals), and the stack
+		// treats the event as an opaque token it forwards and never reads — so a
+		// stand-in is the honest fixture here.
+		const event = { key: 'Escape' } as KeyboardEvent;
+
+		// A DECLINING handler is asked first and must also receive the event —
+		// a handler that declines this time may consume the next press.
+		pushEscapeHandler((e) => {
+			seen.push(e);
+			return false;
+		}, ESCAPE_PRIORITY.viewer);
+		pushEscapeHandler((e) => {
+			seen.push(e);
+			return true;
+		}, ESCAPE_PRIORITY.pane);
+
+		expect(runTopEscape(event)).toBe(true);
+		expect(seen).toEqual([event, event]);
+	});
+
+	it('runs identically with no event, for callers that have none', () => {
+		const seen: (KeyboardEvent | undefined)[] = [];
+		pushEscapeHandler((e) => {
+			seen.push(e);
+			return true;
+		}, ESCAPE_PRIORITY.pane);
+
+		expect(runTopEscape()).toBe(true);
+		expect(seen).toEqual([undefined]);
+	});
 });

--- a/web/src/lib/stores/escapeStack.ts
+++ b/web/src/lib/stores/escapeStack.ts
@@ -30,6 +30,13 @@ export const ESCAPE_PRIORITY = {
 	// Dropdown menus are the innermost layer — ESC closes an open menu
 	// before it collapses the pane/drawer under it (PLAN-2290 Phase 2).
 	menu: 40,
+	// The body-portaled attachment viewer (PLAN-2392 phase 3a / TASK-2429). It
+	// sits ABOVE the menu layer because it is a real modal: while one is open
+	// the rest of the app — menus included — is inert behind it, so nothing
+	// lower can have a live layer for ESC to reach. Several viewers can be
+	// mounted at once (the strip's and a NodeView's); each declines unless it is
+	// the FRONTMOST backdrop lease, so one press closes exactly the top one.
+	viewer: 50,
 } as const;
 
 interface Entry {

--- a/web/src/lib/stores/escapeStack.ts
+++ b/web/src/lib/stores/escapeStack.ts
@@ -19,7 +19,13 @@
 // the stack — components push/pop imperatively and one listener reads the top
 // — so keeping it non-reactive makes it trivially unit-testable.
 
-export type EscapeHandler = () => boolean;
+// The keydown event that provoked this run, when the driver has one. It is
+// optional because the stack is also driven from tests and from non-event
+// callers, and because no existing handler needs it — only a handler that must
+// mark the DISPATCH itself does (TASK-2448 / BUG-2441: the viewer records that
+// it consumed THIS Escape, so later window listeners in the same dispatch can
+// stand down even after its lease is gone).
+export type EscapeHandler = (event?: KeyboardEvent) => boolean;
 
 // Higher priority = more "inner" = handled first. Gaps are intentional so a
 // future layer can slot between two without renumbering the others.
@@ -72,13 +78,17 @@ export function topEscapePriority(): number | null {
 // Invoke the highest-priority handler that consumes the ESC. Returns true if
 // some handler consumed it (the caller should then `preventDefault`), false if
 // every handler declined or the stack is empty (leave native ESC untouched).
-export function runTopEscape(): boolean {
+//
+// `event` is forwarded to each handler unchanged and is otherwise inert here —
+// the stack never reads it, never prevents default on it, and behaves
+// identically whether or not it is supplied.
+export function runTopEscape(event?: KeyboardEvent): boolean {
 	// Iterate over a COPY, highest priority first (newest wins ties), so a
 	// handler that unregisters itself (or another) during its own invocation
 	// can't corrupt the iteration.
 	const ordered = [...entries].sort((a, b) => b.priority - a.priority || b.id - a.id);
 	for (const entry of ordered) {
-		if (entry.handler()) return true;
+		if (entry.handler(event)) return true;
 	}
 	return false;
 }

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -17,6 +17,7 @@
 	import CreateWorkspaceModal from '$lib/components/layout/CreateWorkspaceModal.svelte';
 	import OpenChildrenDialog from '$lib/components/OpenChildrenDialog.svelte';
 	import { isMod, isInputFocused } from '$lib/utils/keyboard';
+	import { isBlockedByModal } from '$lib/a11y/viewerBackdrop';
 	import KeyboardShortcuts from '$lib/components/common/KeyboardShortcuts.svelte';
 
 	let { children } = $props();
@@ -150,6 +151,32 @@
 	});
 
 	function handleKeydown(e: KeyboardEvent) {
+		// TASK-2430 — the root app-shell shortcuts were entirely unguarded. Every
+		// one of them mutates SHELL state (search palette, sidebar/topbar, detail
+		// panel, quick-add, collection search, the shortcuts modal) that sits
+		// UNDER a frontmost viewer, and `isInputFocused()` cannot help: it only
+		// recognises text controls, so a focused viewer BUTTON reads as "not
+		// typing" and every shortcut below fires straight through the viewer.
+		//
+		// The owner argument is `null` on purpose: the surface asking to act is
+		// the app shell itself, which by construction is never inside a viewer
+		// portal or a top-layer `<dialog>` — so ANY frontmost surface blocks it.
+		// That also gives the native-dialog branch its due: a `showModal()` dialog
+		// owns the screen, and Cmd+K must not open a search palette behind it.
+		//
+		// `isBlockedByModal` returns false on an empty stack, so with no viewer
+		// and no open native modal every shortcut behaves exactly as before.
+		//
+		// ONE DELIBERATE COLLATERAL CHANGE, from the native-dialog branch: `?`
+		// no longer toggles the Keyboard Shortcuts modal CLOSED from inside
+		// itself (it is a `Modal`, i.e. a `showModal()` dialog). Escape and its
+		// close button both still dismiss it — `Modal.svelte` owns `cancel` —
+		// so nothing becomes undismissable, and a global shortcut acting from
+		// inside a modal that owns the screen was the bug, not the feature. The
+		// Escape branches below are likewise now unreachable while that modal is
+		// up; they remain as the backstop for the non-modal `searchOpen` palette,
+		// which is a plain overlay and not a dialog.
+		if (isBlockedByModal(null)) return;
 		if (isMod(e) && e.key === 'k') {
 			e.preventDefault();
 			uiStore.toggleSearch();

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -52,6 +52,7 @@
 	import { resolvePaneReturnTarget } from '$lib/collections/paneFocus';
 	import { createPaneMintSettle, PANE_MINT_SETTLE_MS } from '$lib/collections/paneMintSettle';
 	import { pushEscapeHandler, runTopEscape, topEscapePriority, ESCAPE_PRIORITY } from '$lib/stores/escapeStack';
+	import { hasForeignEscapeOwner } from '$lib/a11y/viewerBackdrop';
 	import { boardKeyNav, type BoardNavColumn, type BoardNavDirection } from '$lib/collections/boardNav';
 
 	type ViewMode = 'list' | 'board' | 'table';
@@ -2231,7 +2232,15 @@
 			// EXCLUDED via `:not(.item-pane)` — its ESC is owned by its own escape-
 			// stack handler, and counting it here would swallow ESC-to-close / pop.
 			// The graph drawer isn't a dialog, so the chain is otherwise unblocked.
-			if (document.querySelector('dialog[open], [role="dialog"]:not(.item-pane)')) return;
+			//
+			// Now the SHARED helper (TASK-2429): the attachment viewer is a
+			// body-portaled `role="dialog"` whose ESC is also on the stack, so the
+			// same exclusion it applies to the pane applies to it — without that,
+			// this guard would return here and the viewer's Escape would be dead.
+			// The helper keeps the ARIA branch (BottomSheet / DockedSheet own their
+			// own ESC and are NOT on the stack) and narrows only the native branch
+			// to a feature-detected `dialog:modal`.
+			if (hasForeignEscapeOwner()) return;
 			// A HELD key fires many auto-repeat keydowns (`e.repeat === true`).
 			// Consumed here, BEFORE any layer-close/pop decision, so a hold can
 			// never cascade through the chain — only the initial physical press

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -2315,7 +2315,10 @@
 				e.preventDefault();
 				return;
 			}
-			if (runTopEscape()) e.preventDefault();
+			// The event is forwarded (TASK-2448) purely so a handler can mark the
+			// DISPATCH it consumed — the stack itself neither reads it nor acts on
+			// it.
+			if (runTopEscape(e)) e.preventDefault();
 			return;
 		}
 

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -52,7 +52,7 @@
 	import { resolvePaneReturnTarget } from '$lib/collections/paneFocus';
 	import { createPaneMintSettle, PANE_MINT_SETTLE_MS } from '$lib/collections/paneMintSettle';
 	import { pushEscapeHandler, runTopEscape, topEscapePriority, ESCAPE_PRIORITY } from '$lib/stores/escapeStack';
-	import { hasForeignEscapeOwner } from '$lib/a11y/viewerBackdrop';
+	import { hasForeignEscapeOwner, isBlockedByModal } from '$lib/a11y/viewerBackdrop';
 	import { boardKeyNav, type BoardNavColumn, type BoardNavDirection } from '$lib/collections/boardNav';
 
 	type ViewMode = 'list' | 'board' | 'table';
@@ -2318,6 +2318,29 @@
 			if (runTopEscape()) e.preventDefault();
 			return;
 		}
+
+		// ── Everything below is NAVIGATION, and it stops at a front layer ──
+		//
+		// THREE-WAY PRECEDENCE (TASK-2430), and note WHERE this sits: BELOW the
+		// Escape block, deliberately.
+		//
+		//   1. EMPTY viewer lease, no native modal → false. Nav keys behave
+		//      exactly as before; nothing changes without a viewer.
+		//   2. Viewer lease frontmost → true. `j`/`k`/`Enter`/Tab would otherwise
+		//      keep re-targeting the list UNDER the viewer, which is the half of
+		//      this handler Escape-only guards never covered.
+		//   3. Native top-layer `<dialog>` co-present → true; it owns the screen.
+		//
+		// It must NOT be hoisted above the Escape block. Escape's own three-way
+		// rule is already complete up there: `hasForeignEscapeOwner()` stands
+		// down for a native `dialog:modal` and for foreign sheets, and
+		// deliberately EXCLUDES the viewer — because the viewer's Escape lives on
+		// `escapeStack`, and THIS handler is the only code that runs the stack
+		// (TASK-2429). A blanket `isBlockedByModal` bail at the top of the
+		// function would therefore return before `runTopEscape()` and leave the
+		// viewer's Escape with no owner at all: a silently dead key, and the
+		// exact regression TASK-2429 exists to prevent.
+		if (isBlockedByModal(null)) return;
 
 		// Navigation keys (j/k/arrows/Enter): don't capture when focus is in an
 		// input/textarea/select or when quick-create is open.

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -479,7 +479,9 @@
 		// Otherwise let the escape stack close exactly one layer, innermost-first
 		// (a graph drawer → the pane). No-op with nothing registered (stack empty →
 		// returns false → native ESC untouched).
-		if (runTopEscape()) e.preventDefault();
+		// The event is forwarded (TASK-2448) purely so a handler can mark the
+		// DISPATCH it consumed — the stack itself neither reads it nor acts on it.
+		if (runTopEscape(e)) e.preventDefault();
 	}
 
 	// Test-only hook (PLAN-2154 / TASK-2175): exposes the SAME pane-controller

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -13,6 +13,7 @@
 	import { inExemptSurface } from '$lib/collections/paneFocus';
 	import { viewport } from '$lib/stores/breakpoint.svelte';
 	import { runTopEscape, topEscapePriority, ESCAPE_PRIORITY } from '$lib/stores/escapeStack';
+	import { hasForeignEscapeOwner } from '$lib/a11y/viewerBackdrop';
 	import type { PaneTarget, ResolvedItemIdentity } from '$lib/types';
 
 	// Full-page pane HOST (PLAN-2154 Phase 2 / Architecture E, bullet 5 /
@@ -430,11 +431,12 @@
 		const target = e.target as HTMLElement | null;
 		// Text-editing targets own ESC locally — don't hijack into a layer-close.
 		if (isTextEntryTarget(target)) return;
-		// A native <dialog> / role="dialog" sheet owns its own ESC. The pane's own
-		// mobile overlay is `role="dialog"` too (TASK-2131) but is EXCLUDED via
-		// `:not(.item-pane)` — it's the layer this ESC is meant to close, handled
-		// through the shared escape stack, not a foreign modal to defer to.
-		if (document.querySelector('dialog[open], [role="dialog"]:not(.item-pane)')) return;
+		// A native modal <dialog> / role="dialog" sheet owns its own ESC. The
+		// pane's own mobile overlay is `role="dialog"` too (TASK-2131) and so is
+		// the body-portaled attachment viewer (TASK-2429), but BOTH are EXCLUDED
+		// by the shared helper — they are layers this ESC is meant to close,
+		// handled through the escape stack, not foreign modals to defer to.
+		if (hasForeignEscapeOwner()) return;
 		// A HELD key auto-repeats; only the initial physical press acts.
 		if (e.repeat) {
 			e.preventDefault();

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -428,6 +428,24 @@
 		// A control that already handled this key (preventDefault) owns it.
 		if (e.defaultPrevented) return;
 		if (e.key !== 'Escape') return;
+		// NO `isBlockedByModal` BAIL HERE, deliberately (TASK-2430). This handler
+		// owns ONLY Escape, and it is the sole code path that runs the escape
+		// stack on this route — which is where the VIEWER's Escape lives
+		// (TASK-2429). An arbitration bail would return before `runTopEscape()`
+		// and leave a frontmost viewer's Escape with no owner at all.
+		//
+		// Escape's three-way precedence is already complete without one:
+		//   1. empty lease, no native modal → `hasForeignEscapeOwner()` is false →
+		//      today's behaviour, unchanged;
+		//   2. viewer lease frontmost → the helper EXCLUDES the viewer, so we fall
+		//      through and the stack dispatches to it (the depth-aware branches
+		//      below are gated on `topEscapePriority() === pane`, which a viewer
+		//      registered above `pane` makes false, so nothing double-closes);
+		//   3. native top-layer `<dialog>` → the helper's feature-detected
+		//      `dialog:modal` branch is true → we stand down and it wins.
+		// The sibling collection route DOES carry the bail, but below its Escape
+		// block, guarding its list/board navigation keys — which this host has
+		// none of.
 		const target = e.target as HTMLElement | null;
 		// Text-editing targets own ESC locally — don't hijack into a layer-close.
 		if (isTextEntryTarget(target)) return;

--- a/web/src/routes/[username]/[workspace]/graph/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/graph/+page.svelte
@@ -15,6 +15,7 @@
 	import type { NodeObject, LinkObject } from '3d-force-graph';
 	import type { GraphResponse, Item } from '$lib/types';
 	import { GRAPH_PALETTE } from '$lib/graph/palette';
+	import { isBlockedByModal } from '$lib/a11y/viewerBackdrop';
 	import DetailCard from './DetailCard.svelte';
 	import GraphToolbar from './GraphToolbar.svelte';
 
@@ -947,6 +948,13 @@
 	// Escape exits focus mode — but only when a node is selected, so it doesn't
 	// swallow the key from other handlers (spirit of CONVE-639).
 	function onKeydown(e: KeyboardEvent) {
+		// TASK-2430 — one owner per Escape. This route mounts no `ItemDetail`, so
+		// no attachment viewer can be in front of it, but `+layout.svelte`'s
+		// global `CreateWorkspaceModal` / `OpenChildrenDialog` can: with one open
+		// this handler would `preventDefault()` the dialog's own native cancel AND
+		// deselect the graph node underneath, two layers from one press. Empty
+		// stack + no native modal ⇒ false, so ordinary Escape is unchanged.
+		if (isBlockedByModal(null)) return;
 		if (e.key === 'Escape' && selectedRef !== null) {
 			e.preventDefault();
 			deselect();

--- a/web/src/routes/console/+layout.svelte
+++ b/web/src/routes/console/+layout.svelte
@@ -4,6 +4,7 @@
 	import { authStore } from '$lib/stores/auth.svelte';
 	import { api } from '$lib/api/client';
 	import { onMount } from 'svelte';
+	import { isBlockedByModal } from '$lib/a11y/viewerBackdrop';
 
 	let { children } = $props();
 	let ready = $state(false);
@@ -49,6 +50,13 @@
 	}
 
 	function handleWindowKeydown(event: KeyboardEvent) {
+		// TASK-2430 — one owner per Escape. The console shell renders no item
+		// detail, so no attachment viewer can exist here, but `+layout.svelte`
+		// DOES mount `CreateWorkspaceModal` / `OpenChildrenDialog` on console
+		// routes: with one of those native dialogs open, this handler would close
+		// the mobile nav underneath it on the same press that cancels the dialog.
+		// Empty stack + no native modal ⇒ false, so ordinary Escape is unchanged.
+		if (isBlockedByModal(null)) return;
 		if (event.key === 'Escape' && mobileMenuOpen) {
 			mobileMenuOpen = false;
 		}

--- a/web/src/routes/console/consoleShellEscape.svelte.test.ts
+++ b/web/src/routes/console/consoleShellEscape.svelte.test.ts
@@ -1,0 +1,109 @@
+// Runs in the jsdom vitest project (filename ends `.svelte.test.ts`).
+//
+// TASK-2430 (round-2 sweep) — the console shell owns a global Escape that
+// closes its collapsible nav. (The nav's toggle is CSS-hidden above the mobile
+// breakpoint, but the gating is PURELY CSS — there is no JS media query in this
+// component — so the handler's behaviour under test is identical at any width,
+// and no media stub is needed. Nothing here claims to render at a mobile size.)
+//
+// No attachment viewer can exist on console routes (no
+// `ItemDetail`, so no viewer host), but the root layout DOES mount
+// `CreateWorkspaceModal` / `OpenChildrenDialog` here, so a native dialog can be
+// in front of this handler — and one press would then close the nav underneath
+// it as well. This is the same one-owner-per-Escape rule as the seven owners,
+// applied to a route the original owner list did not enumerate.
+//
+// HOW TO READ THE PAIRS: the BLOCKED test fails if the guard is deleted; the
+// EMPTY-STACK REGRESSION fails if it declines unconditionally.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/svelte';
+import { createRawSnippet, tick, flushSync } from 'svelte';
+
+vi.mock('$lib/api/client', () => {
+	const never = () => new Promise(() => {});
+	return {
+		api: new Proxy({}, { get: () => new Proxy({}, { get: () => never }) }),
+	};
+});
+
+vi.mock('$lib/stores/auth.svelte', () => ({
+	authStore: {
+		load: async () => ({ authenticated: true }),
+		user: { name: 'E2E', email: 'e2e@example.com', role: 'admin' },
+		cloudMode: false,
+		authenticated: true,
+	},
+}));
+
+import ConsoleLayout from './+layout.svelte';
+import { acquire, __resetViewerBackdropForTests } from '$lib/a11y/viewerBackdrop';
+
+const childSnippet = createRawSnippet(() => ({ render: () => `<div>child</div>` }));
+
+/**
+ * The nav has no exported state, so drive it through its real toggle and read
+ * the toggle's `aria-expanded` — the user-visible truth.
+ */
+function toggle(): HTMLElement {
+	const el = document.querySelector<HTMLElement>('[aria-expanded]');
+	if (!el) throw new Error('menu toggle not found');
+	return el;
+}
+
+function menuOpen(): boolean {
+	return toggle().getAttribute('aria-expanded') === 'true';
+}
+
+function mountViewer(): HTMLElement {
+	const root = document.createElement('div');
+	root.className = 'attachment-viewer';
+	root.setAttribute('role', 'dialog');
+	document.body.appendChild(root);
+	return root;
+}
+
+beforeEach(async () => {
+	render(ConsoleLayout, { props: { children: childSnippet } });
+	// `{#if ready}` waits on the auth probe; poll until the shell renders.
+	for (let i = 0; i < 50 && !document.querySelector('[aria-expanded]'); i++) {
+		await new Promise((r) => setTimeout(r, 5));
+		flushSync();
+	}
+	toggle().click();
+	await tick();
+	flushSync();
+});
+
+afterEach(() => {
+	cleanup();
+	__resetViewerBackdropForTests();
+	vi.restoreAllMocks();
+	document.body.innerHTML = '';
+});
+
+describe('console shell Escape — defers to a frontmost surface (TASK-2430)', () => {
+	it('opens the nav through its real toggle (fixture sanity)', () => {
+		expect(menuOpen()).toBe(true);
+	});
+
+	it('EMPTY-STACK REGRESSION: Escape still closes the nav', async () => {
+		window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+		await tick();
+		flushSync();
+		expect(menuOpen()).toBe(false);
+	});
+
+	it('declines Escape while a lease is frontmost, and takes it back on release', async () => {
+		const lease = acquire(mountViewer());
+		window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+		await tick();
+		flushSync();
+		expect(menuOpen()).toBe(true);
+
+		lease.release();
+		window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+		await tick();
+		flushSync();
+		expect(menuOpen()).toBe(false);
+	});
+});

--- a/web/src/routes/layoutShortcuts.svelte.test.ts
+++ b/web/src/routes/layoutShortcuts.svelte.test.ts
@@ -1,0 +1,183 @@
+// Runs in the jsdom vitest project (filename ends `.svelte.test.ts`).
+//
+// TASK-2430 — the ROOT app-shell shortcuts in `+layout.svelte` were entirely
+// unguarded. Every one of them mutates shell state that sits UNDER a frontmost
+// viewer, and `isInputFocused()` cannot help: it only recognises text controls,
+// so a focused viewer BUTTON reads as "not typing" and each shortcut fires
+// straight through the viewer.
+//
+// The layout's `<svelte:window onkeydown>` is declared OUTSIDE its `authReady`
+// gate, so the handler is live from mount even though the app shell itself
+// renders nothing here — which is exactly the surface under test.
+//
+// Every blocked case is paired with an EMPTY-STACK REGRESSION.
+//
+// HOW TO READ THE PAIRS. The BLOCKED tests are what fail if a guard is deleted
+// or weakened. The EMPTY-STACK REGRESSIONS are the opposite check — they fail
+// if a guard declines UNCONDITIONALLY, which is the way a "deference" change
+// silently breaks the app for the 99% of the time no viewer is open. Neither
+// half subsumes the other, and an empty-stack test passing with the guard
+// removed is by design, not a false green. Every guard in the files under test
+// was mutation-verified to kill at least one case here (one documented
+// exception, flagged at the guard itself).
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/svelte';
+import { createRawSnippet, tick, flushSync } from 'svelte';
+
+// The layout's children and its whole chrome are irrelevant to the shortcut
+// handler; stub the network so `onMount`'s auth probe simply fails closed.
+vi.mock('$lib/api/client', () => {
+	const never = () => new Promise(() => {});
+	return {
+		api: new Proxy({}, { get: () => new Proxy({}, { get: () => never }) }),
+		setAccessRevokedHandler: () => {},
+		setRateLimitHandler: () => {},
+		isPlanLimitError: () => false,
+		planLimitMessage: () => '',
+	};
+});
+
+import Layout from './+layout.svelte';
+import { uiStore } from '$lib/stores/ui.svelte';
+import { acquire, __resetViewerBackdropForTests } from '$lib/a11y/viewerBackdrop';
+
+const childSnippet = createRawSnippet(() => ({ render: () => `<div>child</div>` }));
+
+function mountViewer(): HTMLElement {
+	const root = document.createElement('div');
+	root.className = 'attachment-viewer';
+	root.setAttribute('role', 'dialog');
+	document.body.appendChild(root);
+	return root;
+}
+
+function press(key: string, mod = false): KeyboardEvent {
+	const e = new KeyboardEvent('keydown', {
+		key,
+		metaKey: mod,
+		bubbles: true,
+		cancelable: true,
+	});
+	window.dispatchEvent(e);
+	return e;
+}
+
+beforeEach(async () => {
+	render(Layout, { props: { children: childSnippet } });
+	await tick();
+	flushSync();
+	if (uiStore.searchOpen) uiStore.closeSearch();
+});
+
+afterEach(() => {
+	cleanup();
+	__resetViewerBackdropForTests();
+	if (uiStore.searchOpen) uiStore.closeSearch();
+	vi.restoreAllMocks();
+	document.body.innerHTML = '';
+});
+
+describe('+layout app-shell shortcuts — defer to a frontmost surface (TASK-2430)', () => {
+	it('EMPTY-STACK REGRESSION: Cmd+K still opens the search palette', () => {
+		const e = press('k', true);
+		flushSync();
+		expect(e.defaultPrevented).toBe(true);
+		expect(uiStore.searchOpen).toBe(true);
+	});
+
+	it('EMPTY-STACK REGRESSION: Cmd+\\ still toggles the sidebar', () => {
+		const before = uiStore.sidebarOpen;
+		const e = press('\\', true);
+		flushSync();
+		expect(e.defaultPrevented).toBe(true);
+		expect(uiStore.sidebarOpen).toBe(!before);
+	});
+
+	it('declines EVERY shortcut this handler owns while a viewer lease is frontmost', () => {
+		// All of them, not a sample: a per-key guard (rather than the single
+		// handler-level bail) would let whichever keys it missed straight
+		// through, and a sampled test would not see it.
+		acquire(mountViewer());
+		const before = uiStore.sidebarOpen;
+		const topbarBefore = uiStore.topbarOpen;
+
+		for (const [key, mod] of [
+			['k', true],
+			['\\', true],
+			[']', true],
+			['n', true],
+			['f', true],
+			['?', false],
+			['Escape', false],
+		] as const) {
+			expect({ key, prevented: press(key, mod).defaultPrevented }).toEqual({
+				key,
+				prevented: false,
+			});
+		}
+		flushSync();
+
+		expect(uiStore.searchOpen).toBe(false);
+		expect(uiStore.sidebarOpen).toBe(before);
+		expect(uiStore.topbarOpen).toBe(topbarBefore);
+	});
+
+	it('OWNER ARGUMENT: a keydown ORIGINATING inside the viewer is still declined', () => {
+		// The discriminating case for "the argument is the SURFACE ASKING TO ACT,
+		// not `event.target`". Every other blocked test here dispatches on
+		// `window`, where `event.target` is outside the viewer too — so they
+		// would ALSO pass if the handler wrongly passed `e.target`. Here the key
+		// is typed with focus inside the viewer, which is the realistic case: an
+		// `e.target` owner would report "not blocked" and fire the shortcut.
+		const viewer = mountViewer();
+		const btn = document.createElement('button');
+		viewer.appendChild(btn);
+		acquire(viewer);
+
+		const e = new KeyboardEvent('keydown', {
+			key: 'k',
+			metaKey: true,
+			bubbles: true,
+			cancelable: true,
+		});
+		btn.dispatchEvent(e);
+		flushSync();
+		expect(e.defaultPrevented).toBe(false);
+		expect(uiStore.searchOpen).toBe(false);
+	});
+
+	it('a focused viewer BUTTON is not enough on its own — the lease is what blocks', () => {
+		// `isInputFocused()` returns false for a button, so this is precisely the
+		// case the old handler got wrong: focus inside the viewer, shortcut fires.
+		const viewer = mountViewer();
+		const btn = document.createElement('button');
+		viewer.appendChild(btn);
+		const lease = acquire(viewer);
+		btn.focus();
+
+		expect(press('k', true).defaultPrevented).toBe(false);
+		flushSync();
+		expect(uiStore.searchOpen).toBe(false);
+
+		// Same focused button, no lease → the shortcut works again, proving the
+		// guard keys off lease state and not off "something is focused".
+		lease.release();
+		expect(press('k', true).defaultPrevented).toBe(true);
+		flushSync();
+		expect(uiStore.searchOpen).toBe(true);
+	});
+
+	// NOT PROVABLE HERE — the NATIVE `showModal()` branch of the precedence rule
+	// ("a top-layer dialog wins outright") needs a real engine. jsdom implements
+	// neither the top layer nor the `:modal` pseudo-class (verified: the
+	// selector THROWS, which is exactly the unsupported path `isBlockedByModal`
+	// answers "no native modal" for), and `setup-jsdom.ts` only fakes
+	// `showModal()` by reflecting the `open` attribute. A jsdom test here would
+	// assert the fallback, not the contract, and would pass whatever the guard
+	// did — so there is no test here at all rather than an assertion-free
+	// placeholder. That guarantee belongs to TASK-2436's Playwright suite,
+	// alongside the inertness and stacking guarantees jsdom cannot see either.
+	// (`viewerBackdrop.svelte.test.ts` does fence the helper's own native branch
+	// by emulating a supporting engine; what cannot be reproduced here is the
+	// real top layer this handler would sit beneath.)
+});

--- a/web/src/test/mocks/app-navigation.ts
+++ b/web/src/test/mocks/app-navigation.ts
@@ -1,0 +1,27 @@
+// Test-only stand-in for SvelteKit's `$app/navigation`.
+//
+// Same reason as `app-environment.ts` / `app-state.ts`: the jsdom vitest
+// project runs without the SvelteKit vite plugin, so `$app/navigation` has no
+// provider and every component importing it fails to RESOLVE — which is a
+// load-time error `vi.mock` cannot rescue, since resolution happens first.
+// That put whole components (`Sidebar`, `TopBar`, `PaneHost` and everything
+// they pull in) out of reach of component tests entirely.
+//
+// Navigation is a NO-OP here rather than a spy: a test that wants to assert on
+// it should `vi.mock('$app/navigation', …)` in its own file, which works fine
+// once the specifier resolves at all. `goto` resolves so `await goto(...)`
+// doesn't hang.
+
+export async function goto(_url: string | URL, _opts?: unknown): Promise<void> {}
+export async function invalidate(_resource?: unknown): Promise<void> {}
+export async function invalidateAll(): Promise<void> {}
+export async function preloadData(_href: string): Promise<unknown> {
+	return { type: 'loaded', status: 200, data: {} };
+}
+export async function preloadCode(..._pathnames: string[]): Promise<void> {}
+export function pushState(_url: string | URL, _state: unknown): void {}
+export function replaceState(_url: string | URL, _state: unknown): void {}
+export function beforeNavigate(_fn: unknown): void {}
+export function afterNavigate(_fn: unknown): void {}
+export function onNavigate(_fn: unknown): void {}
+export function disableScrollHandling(): void {}

--- a/web/src/test/setup-jsdom.ts
+++ b/web/src/test/setup-jsdom.ts
@@ -1,6 +1,7 @@
 // Setup for the jsdom vitest project (see vitest.config.ts). Only loaded when
 // the browser test deps are installed, so importing them here is safe.
 import '@testing-library/jest-dom/vitest';
+import { beforeEach } from 'vitest';
 
 // jsdom does not implement the native <dialog> top-layer methods
 // (`HTMLDialogElement.prototype.showModal` / `.close` are either missing or
@@ -22,6 +23,73 @@ if (typeof HTMLDialogElement !== 'undefined') {
 		this.dispatchEvent(new Event('close'));
 	};
 }
+
+// This jsdom build exposes a `localStorage` OBJECT with no working methods
+// (it warns `--localstorage-file was provided without a valid path`), so
+// `localStorage.getItem is not a function` blows up at MODULE-LOAD time for
+// every store that reads a persisted preference — `ui.svelte.ts` does, which
+// takes `Sidebar`/`TopBar` and everything importing them out of reach of
+// component tests entirely (TASK-2430). A `typeof … !== 'function'` probe
+// (not a truthiness check on the object) is what actually detects it.
+//
+// SCOPE: do NOT assume a fresh instance per file. Whether the jsdom environment
+// (and therefore this shim) is rebuilt per test file depends on vitest's pool /
+// isolation config, and the `getItem` probe below deliberately skips
+// re-installation when a working Storage already exists — so a shim installed
+// for an earlier file can survive into a later one, carrying its keys with it.
+// That would make FILE ORDER observable through any module that reads a
+// persisted preference (`ui.svelte.ts` reads `pad-topbar` at import time, and
+// `PaneHost` persists a pane width on every drag).
+//
+// This repo runs plain `npm run test` with vitest's DEFAULT per-file isolation
+// (no `--no-isolate`, no pool override, in the config or in CI — checked), but
+// the `beforeEach` clear below does not rely on that: storage is emptied before
+// every TEST, so the shim stays deterministic if the pool config ever changes.
+// A test that needs a seeded value seeds it in its own `beforeEach`, which runs
+// after this one. Seeding in `beforeAll` will NOT survive — deliberately, since
+// that is precisely the pattern that makes order matter.
+//
+// TRADE-OFF WORTH KNOWING: this replaces BOTH `localStorage` and
+// `sessionStorage` with in-memory stand-ins. They are dumb maps — no quota, no
+// `StorageEvent`, no cross-document semantics, no serialization of non-strings
+// beyond `String(v)`. A genuine persistence bug that only reproduces against
+// real browser Storage will therefore pass here. If you are chasing one, that
+// is the first thing to rule out; the honest test for it is Playwright.
+if (typeof globalThis.localStorage?.getItem !== 'function') {
+	const makeStorage = (): Storage => {
+		const map = new Map<string, string>();
+		return {
+			get length() {
+				return map.size;
+			},
+			key: (i: number) => Array.from(map.keys())[i] ?? null,
+			getItem: (k: string) => (map.has(k) ? (map.get(k) as string) : null),
+			setItem: (k: string, v: string) => void map.set(k, String(v)),
+			removeItem: (k: string) => void map.delete(k),
+			clear: () => map.clear(),
+		} as Storage;
+	};
+	Object.defineProperty(globalThis, 'localStorage', {
+		value: makeStorage(),
+		configurable: true,
+		writable: true,
+	});
+	Object.defineProperty(globalThis, 'sessionStorage', {
+		value: makeStorage(),
+		configurable: true,
+		writable: true,
+	});
+}
+
+// Unconditional, and per TEST rather than per setup-file load: covers BOTH
+// branches above (freshly installed shim, or a real / previously-installed
+// Storage the probe skipped over) under any isolation setting.
+globalThis.localStorage?.clear?.();
+globalThis.sessionStorage?.clear?.();
+beforeEach(() => {
+	globalThis.localStorage?.clear?.();
+	globalThis.sessionStorage?.clear?.();
+});
 
 // jsdom does not implement `window.matchMedia`. Several client-only stores
 // (`breakpoint.svelte.ts`, `ui.svelte.ts`) call it at MODULE-LOAD time,

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -36,6 +36,7 @@ const projectRoot = fileURLToPath(new URL('.', import.meta.url));
 const $lib = fileURLToPath(new URL('./src/lib', import.meta.url));
 const appEnvironmentMock = fileURLToPath(new URL('./src/test/mocks/app-environment.ts', import.meta.url));
 const appStateMock = fileURLToPath(new URL('./src/test/mocks/app-state.ts', import.meta.url));
+const appNavigationMock = fileURLToPath(new URL('./src/test/mocks/app-navigation.ts', import.meta.url));
 
 // Agent worktrees symlink `web/node_modules` to the main checkout's
 // node_modules rather than `npm install`-ing a copy (installing clobbers a
@@ -98,6 +99,9 @@ export default defineConfig(async () => {
 					// since resolution happens first).
 					'$app/environment': appEnvironmentMock,
 					'$app/state': appStateMock,
+					// `$app/navigation` for the same reason (TASK-2430) — without it
+					// Sidebar / TopBar / PaneHost can't even be IMPORTED under jsdom.
+					'$app/navigation': appNavigationMock,
 				},
 			},
 			server: nodeModulesRealPath


### PR DESCRIPTION
Phase 3a of **PLAN-2392**. Retires the editor's hand-rolled `<dialog>` lightbox and unifies every attachment-image surface onto one body-portaled viewer with a real modal contract; makes the raster MIME allowlist gate total on every open path; and makes the app shell's global key and gesture owners defer to a frontmost viewer.

**Not in this phase:** zoom (3b), the action toolbar and DR-20 convergence (3c), touch (3d). Images open the unified viewer; files open the phase-2 panel, exactly as merged.

## Why this phase is the risky one

It **deletes a working native modal**. `showModal()` was providing five guarantees for free — top-layer stacking, an inert background, a focus trap, focus restore, and Escape — and this PR is where each stops being free. Nothing downstream catches a gap in them, and jsdom's `<dialog>` polyfill only toggles attributes, so none are visible to a unit test.

| Guarantee | Replacement | Proven by |
|---|---|---|
| Top-layer stacking | body portal + `z-index: 100000` — **not equivalent** | hit-test vs a synthetic rival; **paint order for the platform top layer is unproven** |
| Inert background | `viewerBackdrop` refcounted lease stack | focusable probes in every body child, focus **refusal** as the oracle, real top bar inert **by cascade** |
| Focus trap | `Lightbox` Tab handler + `paneFocusables` | Shift+Tab wrap asserted **by name**; two-viewer case |
| Focus restore | `restoreFocus()` on teardown | invoker unfocusable while open, focused after close — so restore-before-release cannot pass |
| Escape | `escapeStack`, sole owner | both real route guards, asserting **which** layer closed |
| `show()` vs `showModal()` | feature-detected `dialog:modal` | fully closed — the one row jsdom cannot touch at all |

## Decision record (highlights)

- **DR-4a/4b** — one viewer, and retiring `<dialog>` means re-implementing what it gave for free. `role="dialog"` + `aria-modal`, portal to `<body>` (**not** `portalAction`, which targets the nearest ancestor dialog), focus entry to the first tabbable descendant, Tab trap reusing `paneFocus.ts`, real `inert` on every body child, `escapeStack` as sole Escape owner.
- **DR-16** — the viewer opens for an **exact raster allowlist**, enforced by one helper every path calls. `Lightbox` **fails closed**: an entry whose MIME is not positively allowlisted is not viewable. The filter is `$derived`, so a record resolving to unsafe *after* open is re-filtered.
- **DR-8** — `{itemId, hostToken}` addressing, so a master and a peeked pane cannot consume each other's events. Permission never travels on the event.
- Lifecycle is keyed on the **item resource** (`item.id` + a dedicated generation), not the route: a collection-only URL change preserves the item and must not close the viewer; a same-resource refresh must not either.

## Parity exceptions (four, all named)

1. **Navigation** — the timeline's ←/→ list is filtered by the allowlist and indexed by attachment id. The gate cannot be total while a sibling list is built without MIME.
2. **Lifecycle** — the viewer clears on a resource switch (PLAN-2105 switch-safety class).
3. **BUG-2426** — the Tiptap capabilities push was a no-op; unrelated to viewer parity, carried here because it lives in the file this phase rewrites.
4. **BUG-2441** — Escape consumption is now event-scoped, which deliberately changes `DockedSheet`/`BottomSheet`/`TopBar` Escape handling. Every touched owner has an **empty-stack regression** proving behaviour with no viewer present is byte-identical.

`TASK-2430`'s global sweep is **modal-contract work, not parity work**: it intentionally changes route, graph, pane, sidebar and sheet behaviour *while a viewer is frontmost*.

## Defects found and fixed inside this PR

- The timeline's ←/→ list was built from `img[data-attachment-id]` with **no MIME**, so opening a safe PNG and pressing Right could reach an SVG.
- The viewer **failed open** on unresolved MIME — and a test asserted that behaviour.
- `z-index: 1000` let the body-portaled emoji picker (99999) paint **over** the viewer — DR-4c's layering hazard returning via z-index.
- `activate()` survived a transient load failure, so a stale event could still open a hidden image.
- The timeline's a11y pass stripped `role`/`tabindex` from **draft-comment** images (`attMeta` covers saved bodies only), and its delegated keydown had no modifier check, so `Cmd/Ctrl+Enter` — the comment editor's submit — also opened a viewer.
- **BUG-2441**, twice: once as a stale lease mid-dispatch, then again via a **held** Escape, whose auto-repeats are fresh unmarked events.

## Test plan — gates that actually ran

- `make check` green on the integrated tip: `golangci-lint`, `go test ./...`, `govulncheck`, `npm audit`, `svelte-check`.
- **1092 web unit tests** (746 on `main`).
- **32/32 browser tests**, run from the main checkout against a correctly-built binary, with **no** expected-failures.
- **Mutation-verified**, not argued: removing the event-scoped Escape check fails both BUG-2441 tests; disabling `nextTrapTarget`'s Shift wrap fails the trap test with `Received: null`; removing the repeat guard fails both held-Escape tests. Sources restored and rebuilt each time.
- `make test-pg` **not required** — no Go, no store query.

Known pre-existing e2e flakes, not from this branch: **BUG-2334** and **BUG-2447**, both passing in isolation and reproduced on baselines without these specs.

## Filed, not fixed

- **BUG-2447** — `pane-collab-teardown` flakes under parallel load (pre-existing).
- **IDEA-2437** — an address epoch so an A→B→A round-trip is distinguishable. Documented, tested as accepted behaviour, and not fixable from inside the NodeView (the address reader is a getter with no epoch).

## Review note

Nine of twelve tasks first shipped green tests that **could not fail** on their own hardest property — one asserted the vulnerability it existed to close; one I reviewed and endorsed was false-green. All were caught by a per-task adversarial review round asking *"would this fail if the implementation were wrong?"*, and none by the gates. That question is the reason the defect list above exists.

Draft: **do not merge without Dave.**

https://claude.ai/code/session_01LmbFxQFDjcYKBLcTnor6DC