### PR TITLE
PLAN-2392 phase 3b: desktop zoom for the attachment viewer

### DIFF
--- a/web/e2e/attachment-viewer-zoom.spec.ts
+++ b/web/e2e/attachment-viewer-zoom.spec.ts
@@ -1,0 +1,628 @@
+import { test, expect } from './fixtures';
+import type { SuiteFixture } from './fixtures';
+import type { Page, APIRequestContext } from '@playwright/test';
+import { browserLogin, seedDoc } from './lib/collab-helpers';
+import {
+	BIG_PNG,
+	DESKTOP,
+	HUGE_PNG,
+	MID_PNG,
+	TILE,
+	VIEWER,
+	VIEWER_IMAGE,
+	VIEWER_STAGE,
+	WIDE_PNG,
+	imageRect,
+	itemUrl,
+	renderedScale,
+	uploadAttachment,
+	viewerClose,
+	viewerTapLoad
+} from './lib/attachment-viewer';
+
+/**
+ * THE VIEWER'S ZOOM / PAN / LOADING BEHAVIOUR, IN A REAL BROWSER
+ * (PLAN-2392 phase 3b / TASK-2461, DR-9).
+ *
+ * jsdom has no layout, no CSS and no gestures, so the unit suite proves the
+ * zoom/pan MATH (zoom.test.ts) and the loader's request POLICY
+ * (viewerImageLoader.svelte.test.ts) but never that a wheel/key/drag reaches
+ * that math, that the transform actually paints, that a clamp holds against real
+ * geometry, or that a control stays clickable under a scaled image. Each test
+ * here is written against "what mutation would this catch that a jsdom-equivalent
+ * would survive?" — named at each test.
+ */
+
+const BIG_W = 1600;
+
+/**
+ * Open the viewer on a >1024px image and wait until the ORIGINAL has painted
+ * (naturalWidth === 1600), so geometry is settled past the thumb→original
+ * upgrade and every zoom/pan measurement below is deterministic.
+ */
+async function openBig(
+	page: Page,
+	fixture: SuiteFixture,
+	request: APIRequestContext,
+	title: string,
+	names: string[] = ['big.png'],
+	buffer: Buffer = BIG_PNG,
+	naturalWidth = BIG_W
+): Promise<void> {
+	await browserLogin(page);
+	const doc = await seedDoc(fixture, request, title);
+	for (const name of names) {
+		await uploadAttachment(fixture, request, doc.id, name, 'image/png', buffer);
+	}
+	await page.goto(itemUrl(fixture, doc.slug));
+	await expect(page.locator(TILE).first()).toBeVisible();
+	await page.locator(TILE).first().click();
+	await expect(page.locator(VIEWER_IMAGE)).toBeVisible();
+	// Settle on the original — the final, stable geometry.
+	await expect
+		.poll(() => page.locator(VIEWER_IMAGE).evaluate((el) => (el as HTMLImageElement).naturalWidth))
+		.toBe(naturalWidth);
+}
+
+/** Read the RENDERED scale once the CSS transition has settled (two equal reads). */
+async function settledScale(page: Page): Promise<number> {
+	let last = Number.NaN;
+	await expect
+		.poll(async () => {
+			const s = await renderedScale(page);
+			const stable = Math.abs(s - last) < 1e-3;
+			last = s;
+			return stable;
+		})
+		.toBe(true);
+	return renderedScale(page);
+}
+
+/**
+ * Zoom to maximum by pressing '+' ONE step at a time, settling each transition,
+ * until the scale stops climbing (the clamp). Per-step settling avoids the
+ * rapid-press race where two mid-animation reads look equal and stop early.
+ */
+async function zoomToMax(page: Page): Promise<number> {
+	let prev = await settledScale(page);
+	for (let i = 0; i < 20; i++) {
+		await page.keyboard.press('+');
+		// Wait for THIS press to take effect (the scale climbs past `prev`), up to a
+		// deadline; if it never climbs, we are at the clamp. This avoids the race
+		// where the press hasn't been processed yet and two equal reads look settled.
+		const deadline = Date.now() + 1500;
+		let climbed = false;
+		while (Date.now() < deadline) {
+			if ((await renderedScale(page)) > prev + 1e-3) {
+				climbed = true;
+				break;
+			}
+		}
+		if (!climbed) return prev; // clamp reached
+		prev = await settledScale(page);
+	}
+	return prev;
+}
+
+test.describe('attachment viewer — desktop zoom & pan (TASK-2461)', () => {
+	test.beforeEach(async ({ page }, testInfo) => {
+		test.skip(
+			testInfo.project.name !== 'desktop-chromium',
+			'desktop zoom/pan is viewport-driven; one project is enough'
+		);
+		await page.setViewportSize(DESKTOP);
+	});
+
+	test('wheel, ctrl-wheel, keyboard and double-click each transform the RENDERED image', async ({
+		page,
+		fixture,
+		request
+	}) => {
+		// jsdom has no layout, so `getComputedStyle(img).transform` is never a real
+		// matrix there — a handler wired to nothing (or to a no-op `zoomTo`) passes
+		// every unit test. Here the proof is the painted matrix moving off identity.
+		await openBig(page, fixture, request, 'Zoom transforms');
+		const stage = page.locator(VIEWER_STAGE);
+		const box = (await stage.boundingBox())!;
+		const cx = box.x + box.width / 2;
+		const cy = box.y + box.height / 2;
+
+		expect(await renderedScale(page), 'opens at fit (scale 1)').toBeCloseTo(1, 1);
+
+		// WHEEL (plain) in.
+		await page.mouse.move(cx, cy);
+		await page.mouse.wheel(0, -120);
+		await expect.poll(() => renderedScale(page)).toBeGreaterThan(1.05);
+		const afterWheel = await renderedScale(page);
+
+		// KEYBOARD '0' resets to fit.
+		await page.keyboard.press('0');
+		await expect.poll(() => renderedScale(page)).toBeCloseTo(1, 1);
+
+		// KEYBOARD '+' in.
+		await page.keyboard.press('+');
+		await expect.poll(() => renderedScale(page)).toBeGreaterThan(1.05);
+		await page.keyboard.press('0');
+
+		// CTRL+WHEEL in — a genuinely separate gesture path (Control HELD). We assert
+		// it zooms the IMAGE; that the viewer's `preventDefault` also suppresses the
+		// browser's own ctrl-wheel page-zoom is not reliably observable through
+		// Playwright (page zoom does not move visualViewport.scale), so it is left to
+		// the unit coverage of the non-passive listener.
+		expect(afterWheel, 'the plain-wheel leg zoomed').toBeGreaterThan(1.05);
+		await page.mouse.move(cx, cy);
+		await page.keyboard.down('Control');
+		await page.mouse.wheel(0, -120);
+		await page.keyboard.up('Control');
+		await expect.poll(() => renderedScale(page)).toBeGreaterThan(1.05);
+		await page.keyboard.press('0');
+
+		// DOUBLE-CLICK toggles fit → actual (a jump well past 1).
+		await page.mouse.dblclick(cx, cy);
+		await expect.poll(() => renderedScale(page)).toBeGreaterThan(1.05);
+	});
+
+	test('the close and nav controls stay clickable and focus-visible AT MAXIMUM ZOOM', async ({
+		page,
+		fixture,
+		request
+	}) => {
+		// The state where a transformed image can paint over the chrome and swallow
+		// its clicks. jsdom cannot see the stacking or the hit test, so only a real
+		// engine proves the controls survive a full-scale image on top of the stage.
+		// Two images so the nav buttons exist alongside close.
+		await openBig(page, fixture, request, 'Controls at max zoom', ['ctrl-a.png', 'ctrl-b.png']);
+		const scale = await zoomToMax(page);
+		expect(scale, 'reached a real maximum well past fit').toBeGreaterThan(2);
+
+		// HIT TEST — the point proof that the scaled image does not paint over the
+		// controls: `elementFromPoint` at each control's centre must return that
+		// control, not the IMG. jsdom cannot do this (no layout, no stacking).
+		const topAt = (sel: string) =>
+			page.evaluate((s) => {
+				const front = [...document.querySelectorAll('.attachment-viewer')].at(-1);
+				const el = front?.querySelector<HTMLElement>(s.replace('.attachment-viewer[role="dialog"] ', ''));
+				if (!el) return 'missing';
+				const r = el.getBoundingClientRect();
+				const hit = document.elementFromPoint(r.x + r.width / 2, r.y + r.height / 2);
+				return hit ? `${hit.tagName}.${(hit.closest('button')?.className ?? hit.className).split(' ').find((c) => c.startsWith('lightbox-')) ?? ''}` : 'none';
+			}, sel);
+		expect(await topAt(`${VIEWER} .lightbox-close`), 'close is the top surface at its centre').toContain('lightbox-close');
+		expect(await topAt(`${VIEWER} .lightbox-nav.next`), 'next is the top surface at its centre').toContain('lightbox-nav');
+
+		// TAB CYCLES at max zoom — focus never escapes the viewer.
+		const close = viewerClose(page);
+		await close.focus();
+		await expect(close).toBeFocused();
+		for (let i = 0; i < 4; i++) {
+			await page.keyboard.press('Tab');
+			expect(
+				await page.evaluate(() => !!document.activeElement?.closest('.attachment-viewer')),
+				`Tab ${i + 1} kept focus inside the viewer at max zoom`
+			).toBe(true);
+		}
+
+		// FOCUS-VISIBLE: the focused control shows an indicator, not `none`.
+		await close.focus();
+		const outline = await close.evaluate((el) => {
+			const cs = getComputedStyle(el);
+			return { outlineWidth: cs.outlineWidth, boxShadow: cs.boxShadow };
+		});
+		expect(
+			outline.outlineWidth !== '0px' || outline.boxShadow !== 'none',
+			'the focused control must show a visible focus ring at max zoom'
+		).toBe(true);
+
+		await close.click();
+		await expect(page.locator(VIEWER)).toHaveCount(0);
+	});
+
+	test('a wheel-zoom keeps the ANCHORED point under the cursor', async ({ page, fixture, request }) => {
+		// The property that separates pointer-anchored zoom (TASK-2457) from
+		// centre-anchored: the image content under the cursor stays under it. jsdom
+		// has no cursor and no rect, so the anchor math has never been exercised
+		// against real geometry. Mutating the anchor to the stage centre drifts the
+		// point away and fails this.
+		await openBig(page, fixture, request, 'Zoom anchor');
+		const stage = (await page.locator(VIEWER_STAGE).boundingBox())!;
+		// Off-centre, so a centre-anchored zoom would visibly move this point.
+		const px = stage.x + stage.width * 0.35;
+		const py = stage.y + stage.height * 0.4;
+		const before = await imageRect(page);
+		const fx = (px - before.x) / before.width;
+		const fy = (py - before.y) / before.height;
+
+		await page.mouse.move(px, py);
+		await page.mouse.wheel(0, -120); // one step in
+		await settledScale(page);
+		const after = await imageRect(page);
+		// The same image-fractional point, mapped through the NEW rect, is still
+		// under the cursor (uniform scale ⇒ linear map).
+		expect(Math.abs(after.x + fx * after.width - px), 'anchored X held').toBeLessThan(3);
+		expect(Math.abs(after.y + fy * after.height - py), 'anchored Y held').toBeLessThan(3);
+	});
+
+	test('pan CLAMPS: an in-bounds drag moves by the delta; an over-drag stops at the edge', async ({
+		page,
+		fixture,
+		request
+	}) => {
+		// TWO legs on purpose (TASK-2461): a one-legged "it panned" passes with the
+		// clamp disabled, and a one-legged "it stopped" passes with pan disabled
+		// entirely. jsdom clamps against all-zero geometry, so neither leg has run
+		// against real bounds.
+		await openBig(page, fixture, request, 'Pan clamp');
+		await zoomToMax(page); // heavy overflow ⇒ real pan room
+		const stage = (await page.locator(VIEWER_STAGE).boundingBox())!;
+		const cx = stage.x + stage.width / 2;
+		const cy = stage.y + stage.height / 2;
+
+		// Settle at the centred max-zoom position before measuring.
+		const r0 = await imageRect(page);
+		// POSITIVE leg — an 80px in-bounds drag moves the image ~80px to the RIGHT
+		// (the pan follows the pointer). A small hold at the start engages the drag
+		// cleanly past the 4px threshold.
+		await page.mouse.move(cx, cy);
+		await page.mouse.down();
+		await page.mouse.move(cx + 20, cy, { steps: 4 }); // engage past threshold
+		await page.mouse.move(cx + 80, cy, { steps: 8 });
+		await page.mouse.up();
+		const r1 = await imageRect(page);
+		expect(r1.x - r0.x, 'an in-bounds pan moved the image right by ~the drag delta').toBeGreaterThan(60);
+		expect(r1.x - r0.x).toBeLessThan(100);
+
+		// EDGE leg — a huge drag clamps at the stage edge, and dragging FURTHER in
+		// the same direction moves it no more. (Two drags, because "it stopped at the
+		// edge" is only proof of a clamp if a further push is a no-op.)
+		await page.mouse.move(cx, cy);
+		await page.mouse.down();
+		await page.mouse.move(cx + 6000, cy, { steps: 12 });
+		await page.mouse.up();
+		const r2 = await imageRect(page);
+		expect(Math.abs(r2.x - stage.x), 'the image left edge clamps to the stage left').toBeLessThan(3);
+		await page.mouse.move(cx, cy);
+		await page.mouse.down();
+		await page.mouse.move(cx + 3000, cy, { steps: 8 });
+		await page.mouse.up();
+		const r3 = await imageRect(page);
+		expect(Math.abs(r3.x - r2.x), 'at the clamp, more drag does not move the image').toBeLessThan(2);
+	});
+
+	test('dismissal: a plain backdrop click closes; a drag that releases over the backdrop does NOT', async ({
+		page,
+		fixture,
+		request
+	}) => {
+		// TASK-2458's "a drag that ends where it started is a click": a press that
+		// MOVES past threshold and RETURNS to its start on the backdrop synthesizes a
+		// real click at that point — and must be SUPPRESSED (a drag is not a
+		// dismissal). A drag that merely ended elsewhere would produce no click at
+		// all, so it would prove nothing about the suppress path; returning to the
+		// start is what makes leg 2 depend on the viewer's own logic. jsdom has no
+		// drag. Both legs, because the no-close leg alone passes against a viewer that
+		// never closes on any click.
+		await openBig(page, fixture, request, 'Dismiss drag');
+		const stage = (await page.locator(VIEWER_STAGE).boundingBox())!;
+		// A point in the left backdrop margin, clear of the fitted image (openBig
+		// uploads one image, so there are no nav buttons to hit here).
+		const px = Math.max(2, Math.round(stage.x / 2));
+		const py = Math.round(stage.y + stage.height / 2);
+
+		// LEG 2 first (it must NOT close): press, drag past threshold, return to the
+		// SAME backdrop point, release → a synthesized backdrop click that the drag
+		// must suppress.
+		await page.mouse.move(px, py);
+		await page.mouse.down();
+		await page.mouse.move(px + 140, py, { steps: 6 }); // past the 4px threshold
+		await page.mouse.move(px, py, { steps: 6 }); // ...back to the start
+		await page.mouse.up();
+		await expect(
+			page.locator(VIEWER),
+			'a drag that returns to its start is not a dismissal'
+		).toHaveCount(1);
+
+		// LEG 1 — a PLAIN backdrop click at the same point DOES dismiss.
+		await page.mouse.click(px, py);
+		await expect(page.locator(VIEWER), 'a plain backdrop click dismisses').toHaveCount(0);
+	});
+
+	test('a click on BLANK STAGE SPACE inside the stage box but outside the image dismisses', async ({
+		page,
+		fixture,
+		request
+	}) => {
+		// THE UNCOVERED POINT (TASK-2461). The existing suite clicks (4,4) — outside
+		// the centred stage — so a stage that swallowed letterbox clicks would stay
+		// green. A wide image is letterboxed top/bottom; a click in that band is
+		// INSIDE the stage box, off the image, and must reach the backdrop and close
+		// (the stage letterbox is `pointer-events: none`).
+		await openBig(page, fixture, request, 'Dismiss letterbox', ['wide.png'], WIDE_PNG, 1600);
+		const stage = (await page.locator(VIEWER_STAGE).boundingBox())!;
+		const img = await imageRect(page);
+		// A point inside the stage box, above the letterboxed image.
+		const bandY = (stage.y + img.top) / 2;
+		expect(bandY, 'there is a real letterbox band above the image').toBeLessThan(img.top - 5);
+		await page.mouse.click(stage.x + stage.width / 2, bandY);
+		await expect(page.locator(VIEWER)).toHaveCount(0);
+	});
+
+	test('resizing the window while zoomed to MAXIMUM clamps the scale down to the new bound', async ({
+		page,
+		fixture,
+		request
+	}) => {
+		// `maxScale` is geometry-dependent: ENLARGING the window lowers `actualScale`
+		// and with it the ceiling, stranding a previously-valid scale above it
+		// (TASK-2455). jsdom fires no resize with real geometry, so the re-clamp
+		// effect has never run against a live layout change.
+		await openBig(page, fixture, request, 'Resize clamp');
+		const maxBefore = await zoomToMax(page);
+		await page.setViewportSize({ width: DESKTOP.width + 500, height: DESKTOP.height + 400 });
+		// The ResizeObserver re-clamp fires async on layout — poll until the stranded
+		// scale is pulled down to the new, lower ceiling.
+		await expect.poll(() => renderedScale(page)).toBeLessThan(maxBefore - 0.2);
+		const after = await settledScale(page);
+		// Clamped DOWN to the new ceiling — but NOT reset to fit: a handler that
+		// snapped to `resetZoom()` would also be below the old max, so the "still
+		// zoomed" leg is what makes this a clamp and not a reset.
+		expect(after, 'the image is still zoomed in, not reset to fit').toBeGreaterThan(1.5);
+		// And it sits at the NEW maximum, not some arbitrary lower value: pressing '+'
+		// again does not climb (already at the clamp).
+		await page.keyboard.press('+');
+		expect(await settledScale(page), 'the clamped scale IS the new maximum').toBeCloseTo(after, 1);
+	});
+
+	test('reduced-motion suppresses the zoom ANIMATION, and normal mode keeps it', async ({
+		page,
+		fixture,
+		request
+	}) => {
+		// TWO legs (TASK-2461): the one-legged "reduced-motion has no transition"
+		// passes against a viewer that never animates at all. `Modal.svelte:207` is
+		// the precedent this follows.
+		await openBig(page, fixture, request, 'Reduced motion');
+		const transitionDuration = () =>
+			page.locator(VIEWER_IMAGE).evaluate((el) => getComputedStyle(el).transitionDuration);
+
+		await page.emulateMedia({ reducedMotion: 'reduce' });
+		expect(await transitionDuration(), 'reduced-motion: no zoom animation').toBe('0s');
+
+		await page.emulateMedia({ reducedMotion: 'no-preference' });
+		expect(
+			Number.parseFloat(await transitionDuration()),
+			'normal mode: the zoom DOES animate'
+		).toBeGreaterThan(0);
+	});
+
+	test('forced-colors keeps the controls and the image BOUNDARY visible (computed style)', async ({
+		page,
+		fixture,
+		request
+	}) => {
+		// DR-4. Under forced-colors the custom palette is discarded and the image's
+		// box-shadow BOUNDARY vanishes; the media block's explicit border is what
+		// keeps it visible. Asserted on COMPUTED STYLE (a border with real width),
+		// not DOM presence. jsdom has no forced-colors media and computes no border.
+		//
+		// The IMAGE border is the mutation-load-bearing proof: the base `.lightbox-
+		// image` has NO border, so its width>0 here comes ONLY from the media block
+		// (removing that rule fails this — verified). The CONTROLS already carry a
+		// base 1px border that forced-colors re-colours to a system colour, so they
+		// are visible regardless; the control leg is a genuine "still visible" check,
+		// not a proof of the media rule (border COLOUR under forced-colors resolves
+		// to opaque system values that are not worth pinning).
+		await openBig(page, fixture, request, 'Forced colors', ['fc-a.png', 'fc-b.png']);
+		await page.emulateMedia({ forcedColors: 'active' });
+		const styles = await page.evaluate(() => {
+			const front = [...document.querySelectorAll('.attachment-viewer')].at(-1);
+			const get = (sel: string) => {
+				const el = front?.querySelector<HTMLElement>(sel);
+				if (!el) return null;
+				const cs = getComputedStyle(el);
+				return { w: Number.parseFloat(cs.borderTopWidth), style: cs.borderTopStyle };
+			};
+			return { img: get('.lightbox-image'), close: get('.lightbox-close'), next: get('.lightbox-nav.next') };
+		});
+		expect(styles.img, 'the image element exists').not.toBeNull();
+		expect(styles.img!.w, 'the image keeps a visible boundary under forced-colors').toBeGreaterThan(0);
+		expect(styles.img!.style).toBe('solid');
+		expect(styles.close!.w, 'the close control stays visible (bordered)').toBeGreaterThan(0);
+		expect(styles.next!.w, 'the nav control stays visible (bordered)').toBeGreaterThan(0);
+	});
+});
+
+/** The viewer image's current `src` attribute (the URL the browser is loading). */
+function imageSrc(page: Page): Promise<string> {
+	return page.locator(VIEWER_IMAGE).evaluate((el) => el.getAttribute('src') ?? '');
+}
+/** The viewer image's decoded natural width — the observable of which variant painted. */
+function imageNat(page: Page): Promise<number> {
+	return page.locator(VIEWER_IMAGE).evaluate((el) => (el as HTMLImageElement).naturalWidth);
+}
+
+/**
+ * Intercept the attachment DOWNLOAD requests so the thumb→original swap is
+ * deterministic: `?variant=thumb-md` → a bounded 800px thumb, the no-variant
+ * original → the 1600px BIG_PNG (optionally delayed). Other variants — the
+ * strip's own tile thumbnail — fall through to the real server. The upload
+ * itself goes through the Node API context, not the page, so it is never
+ * intercepted and the server records the real 1600×1200 metadata.
+ */
+async function stubVariants(page: Page, originalDelayMs = 0): Promise<void> {
+	await page.route('**/attachments/*', async (route) => {
+		const url = new URL(route.request().url());
+		if (!/\/attachments\/[^/?]+$/.test(url.pathname)) return route.continue();
+		const variant = url.searchParams.get('variant');
+		if (variant === 'thumb-md') return route.fulfill({ contentType: 'image/png', body: MID_PNG });
+		if (!variant) {
+			if (originalDelayMs) await new Promise((r) => setTimeout(r, originalDelayMs));
+			return route.fulfill({ contentType: 'image/png', body: BIG_PNG });
+		}
+		return route.continue();
+	});
+}
+
+test.describe('attachment viewer — desktop loading policy (TASK-2461)', () => {
+	test.beforeEach(async ({ page }, testInfo) => {
+		test.skip(testInfo.project.name !== 'desktop-chromium', 'desktop policy; one project is enough');
+		await page.setViewportSize(DESKTOP);
+	});
+
+	test('the thumb→original swap is observable against a >1024px fixture', async ({ page, fixture, request }) => {
+		// DR-5b: a >1024px image paints the bounded thumb first, then upgrades to the
+		// original in the background. jsdom proves the request POLICY but never that
+		// the browser actually swaps the painted bitmap. A small original delay makes
+		// the thumb phase observable rather than a race.
+		// Record the viewer's OWN download requests (the tile's thumb-sm is filtered
+		// out). The swap is the request sequence thumb-md → original; the bitmap
+		// naturalWidth window at 800 is too brief to sample (the upgrade swaps `src`
+		// the instant the thumb decodes), so the network order is the reliable proof.
+		// An ordered timeline of the viewer's own attachment events (the tile's
+		// thumb-sm is filtered out). The swap PROOF is: the thumb-md response
+		// FINISHED before the original request STARTED — because the loader only
+		// requests the original from `decoded()`, i.e. after the thumb's bytes
+		// arrived AND painted. A mere request-order check would pass an impl that
+		// fired both immediately; the finish→start ordering rules that out.
+		const timeline: string[] = [];
+		const isViewerReq = (u: string) =>
+			/\/attachments\/[^/?]+(\?variant=(thumb-md|original))?$/.test(u) && !u.includes('thumb-sm');
+		page.on('request', (r) => {
+			if (isViewerReq(r.url())) timeline.push((r.url().includes('variant=thumb-md') ? 'thumb-md' : 'original') + ':start');
+		});
+		page.on('requestfinished', (r) => {
+			if (isViewerReq(r.url())) timeline.push((r.url().includes('variant=thumb-md') ? 'thumb-md' : 'original') + ':finish');
+		});
+		await stubVariants(page, 400);
+		await browserLogin(page);
+		const doc = await seedDoc(fixture, request, 'Swap');
+		await uploadAttachment(fixture, request, doc.id, 'swap.png', 'image/png', BIG_PNG);
+		await page.goto(itemUrl(fixture, doc.slug));
+		await page.locator(TILE).first().click();
+		await expect(page.locator(VIEWER_IMAGE)).toBeVisible();
+
+		// The final painted bitmap is the ORIGINAL (naturalWidth 1600, no variant).
+		await expect.poll(() => imageNat(page)).toBe(1600);
+		expect(await imageSrc(page)).not.toContain('variant=');
+		// The thumb was requested first, its response FINISHED (bytes arrived, the
+		// bitmap painted), and ONLY THEN the original was requested — the upgrade.
+		const thumbStart = timeline.indexOf('thumb-md:start');
+		const thumbFinish = timeline.indexOf('thumb-md:finish');
+		const origStart = timeline.indexOf('original:start');
+		expect(thumbStart, 'the viewer requested the bounded thumb').toBeGreaterThanOrEqual(0);
+		expect(thumbFinish, 'the thumb response arrived (the bitmap could paint)').toBeGreaterThan(thumbStart);
+		expect(origStart, 'the original was requested only AFTER the thumb painted').toBeGreaterThan(thumbFinish);
+	});
+
+	test('a rapid A→B→A with a slow original leaves the LIVE image correct (switch-safety / generation fence)', async ({
+		page,
+		fixture,
+		request
+	}) => {
+		// TASK-2459's carried-forward concern, proven in a real engine. The originals
+		// are SLOW, so a rapid A→B→A navigates away while A's first original is still
+		// in flight: the first A element is torn down (the `{#key loadToken}` remount)
+		// with a pending load, and a fresh element takes over for the third visit. The
+		// live A must end on ITS OWN original — not B's content, not a broken image,
+		// not an error — which is what the per-mount generation fence + load key
+		// guarantee. jsdom has no real network timing to stage this.
+		//
+		// NOTE (honest scope): Chromium ABORTS a detached <img>'s in-flight request,
+		// so the exact "detached element fires a late ERROR that clobbers the live
+		// one" case the data-gen fence guards is not reachable in a browser — the
+		// engine cancels first. That case is covered by the unit tests
+		// (viewerImageLoader / Lightbox); this leg proves the rapid-nav END-STATE
+		// integrity, the practical half of the concern.
+		await browserLogin(page);
+		const doc = await seedDoc(fixture, request, 'Gen fence');
+		const aId = await uploadAttachment(fixture, request, doc.id, 'gen-a.png', 'image/png', BIG_PNG);
+		const bId = await uploadAttachment(fixture, request, doc.id, 'gen-b.png', 'image/png', BIG_PNG);
+
+		// thumb-md → the bounded thumb (fast); the original → BIG, but SLOW, so the
+		// nav races the in-flight upgrade.
+		await stubVariants(page, 1500);
+
+		// Persistent listener (set up BEFORE navigation, so it can't miss the fast
+		// upgrade request the way a late `waitForRequest` would).
+		let aOriginalRequested = false;
+		page.on('request', (r) => {
+			if (r.url().includes(aId) && !r.url().includes('variant=')) aOriginalRequested = true;
+		});
+		await page.goto(itemUrl(fixture, doc.slug));
+		await expect(page.locator(TILE)).toHaveCount(2);
+		await page.locator(`${TILE}[aria-label*="gen-a.png"]`).click();
+		await expect(page.locator(VIEWER)).toHaveCount(1);
+		// A's (slow) original request is in flight before we navigate.
+		await expect.poll(() => aOriginalRequested).toBe(true);
+
+		// A→B→A: the first A element is torn down mid-load; a fresh one takes over.
+		await page.keyboard.press('ArrowRight');
+		await expect.poll(() => imageSrc(page)).toContain(bId); // showing B
+		await page.keyboard.press('ArrowLeft');
+		await expect.poll(() => imageSrc(page)).toContain(aId); // back to A (fresh element)
+
+		// The LIVE A resolves to ITS OWN original — 1600px, A's URL, no error, no
+		// stale B content and no broken bitmap.
+		await expect.poll(() => imageNat(page)).toBe(1600);
+		expect(await imageSrc(page), 'the live image is A, not the B we passed through').toContain(aId);
+		expect(await imageSrc(page)).not.toContain(bId);
+		expect(await imageSrc(page)).not.toContain('variant=');
+		await expect(page.locator(`${VIEWER} .lightbox-error`), 'no stale load clobbered the live image').toHaveCount(0);
+	});
+});
+
+test.describe('attachment viewer — mobile DR-5b (TASK-2461)', () => {
+	test.beforeEach(async ({}, testInfo) => {
+		test.skip(
+			testInfo.project.name !== 'mobile-chromium',
+			'the DR-5b mobile policy needs a real mobile (Pixel 7) project'
+		);
+	});
+
+	test('a large image issues NO automatic request until the tap affordance is used', async ({
+		page,
+		fixture,
+		request
+	}) => {
+		// DR-5b mobile (TASK-2460): a large image auto-fetches NOTHING — a tap-to-load
+		// affordance stands in, and only a real tap issues the original request. The
+		// no-request half is the assertion that fails if the deferral is dropped; the
+		// tap half proves the affordance is a live, hit-testable control (not pointer-
+		// dead under the stage's `pointer-events: none`). Needs a real mobile project:
+		// the policy keys on `viewport.isMobile`.
+		let originalRequests = 0;
+		await page.route('**/attachments/*', async (route) => {
+			const url = new URL(route.request().url());
+			if (/\/attachments\/[^/?]+$/.test(url.pathname) && !url.searchParams.get('variant')) {
+				originalRequests++;
+				return route.fulfill({ contentType: 'image/png', body: BIG_PNG });
+			}
+			if (url.searchParams.get('variant') === 'thumb-md')
+				return route.fulfill({ contentType: 'image/png', body: MID_PNG });
+			return route.continue();
+		});
+		await browserLogin(page);
+		const doc = await seedDoc(fixture, request, 'Mobile deferred');
+		// A genuinely large image (>8 MP) so mobile classifies it as the DEFERRED
+		// cell — a 1.9 MP image is only the mobile thumb cell.
+		await uploadAttachment(fixture, request, doc.id, 'mobile-huge.png', 'image/png', HUGE_PNG);
+		await page.goto(itemUrl(fixture, doc.slug));
+		await page.locator(TILE).first().click();
+		await expect(page.locator(VIEWER)).toHaveCount(1);
+
+		// The deferred cell: the tap affordance is shown, NO image, NO original fetch.
+		await expect(viewerTapLoad(page)).toBeVisible();
+		await expect(page.locator(VIEWER_IMAGE)).toHaveCount(0);
+		expect(originalRequests, 'no original fetched before the tap').toBe(0);
+
+		// A REAL tap loads the original — the request fires, the bitmap DECODES
+		// (naturalWidth settles), and no error state appears.
+		await viewerTapLoad(page).tap();
+		await expect(page.locator(VIEWER_IMAGE)).toBeVisible();
+		await expect.poll(() => imageNat(page)).toBe(1600); // the stubbed original decoded
+		expect(await imageSrc(page)).not.toContain('variant=');
+		await expect(page.locator(`${VIEWER} .lightbox-error`)).toHaveCount(0);
+		// EXACTLY one original request — the tap loads it once (dedup), not zero and
+		// not a double-fetch.
+		expect(originalRequests, 'the tap issued exactly one original request').toBe(1);
+	});
+});

--- a/web/e2e/lib/attachment-viewer.ts
+++ b/web/e2e/lib/attachment-viewer.ts
@@ -56,6 +56,40 @@ function buildPng(width: number, height: number, rgb: [number, number, number]):
 
 export const REAL_PNG = buildPng(200, 150, [200, 120, 60]);
 
+/**
+ * A decodable PNG whose LONG EDGE EXCEEDS 1024 px (TASK-2461). The server derives
+ * a `thumb-md` (1024 px long edge) only when the source is bigger, and the DR-5b
+ * loader paints that thumb first and upgrades to this original — so the swap is
+ * observable only against a fixture this size. Kept flat-colour so `deflate`
+ * keeps it small despite the pixel count.
+ */
+export const BIG_PNG = buildPng(1600, 1200, [40, 110, 190]);
+
+/**
+ * A >1024px WIDE fixture (4:1). Fitted into the 4:3 desktop stage it is
+ * letterboxed top and bottom, so there is blank stage space INSIDE the stage box
+ * but outside the image — the click target the dismiss test needs (TASK-2461).
+ */
+export const WIDE_PNG = buildPng(1600, 400, [190, 90, 40]);
+
+/**
+ * A bounded (<= 1024px long edge) PNG to stand in for the server's `thumb-md`
+ * variant under route interception (TASK-2461): the loader's fallback detector
+ * treats a decode this size as a real thumbnail and upgrades, so serving it for
+ * `?variant=thumb-md` and {@link BIG_PNG} for the original makes the swap
+ * deterministic and observable (a 800→1600 naturalWidth jump).
+ */
+export const MID_PNG = buildPng(800, 600, [90, 170, 90]);
+
+/**
+ * A genuinely LARGE fixture — 4000×2500 = 10 MP, OVER the 8 MP
+ * `AUTO_LOAD_MAX_PIXELS` — so the DR-5b classifier calls it `large`, not just
+ * `small`-but-long. On mobile that is the DEFERRED cell (tap-to-load, no
+ * automatic request); a 1.9 MP image is only the mobile thumb cell (TASK-2461).
+ * Flat colour keeps the deflated bytes tiny despite the pixel count.
+ */
+export const HUGE_PNG = buildPng(4000, 2500, [150, 60, 150]);
+
 export const DESKTOP = { width: 1200, height: 900 };
 /** Below the 639.98px mobile breakpoint — BottomNav / DockedSheet branch. */
 export const MOBILE = { width: 390, height: 844 };
@@ -71,6 +105,8 @@ export const TILE = `${STRIP} .att-tile`;
 export const VIEWER = '.attachment-viewer[role="dialog"]';
 export const VIEWER_IMAGE = `${VIEWER} .lightbox-image`;
 export const VIEWER_COUNTER = `${VIEWER} .lightbox-counter`;
+/** The zoom/pan stage (the letterbox around the image). */
+export const VIEWER_STAGE = `${VIEWER} .lightbox-stage`;
 
 /** The viewer's controls, addressed by the accessible names TASK-2429 gave them. */
 export const viewerClose = (page: Page) => page.locator(VIEWER).getByRole('button', { name: 'Close' });
@@ -78,6 +114,40 @@ export const viewerNext = (page: Page) =>
 	page.locator(VIEWER).getByRole('button', { name: 'Next image' });
 export const viewerPrev = (page: Page) =>
 	page.locator(VIEWER).getByRole('button', { name: 'Previous image' });
+/** The DR-5b mobile tap-to-load affordance (TASK-2460 / TASK-2461). */
+export const viewerTapLoad = (page: Page) =>
+	page.locator(VIEWER).getByRole('button', { name: 'Tap to load full image' });
+
+/**
+ * The `scale(...)` factor the browser has actually applied to the viewer image,
+ * read from its COMPUTED transform matrix (`matrix(a, …)`, a === scale). NaN when
+ * there is no image or no transform — the thing jsdom cannot produce, since it
+ * has no layout and computes no matrix.
+ */
+export function renderedScale(page: Page, selector = VIEWER_IMAGE): Promise<number> {
+	return page.evaluate((sel) => {
+		// Last match = the FRONTMOST viewer, in case two are stacked (the shared lib
+		// is used by specs that stack viewers).
+		const all = document.querySelectorAll<HTMLElement>(sel);
+		const el = all[all.length - 1];
+		if (!el) return NaN;
+		const t = getComputedStyle(el).transform;
+		if (!t || t === 'none') return 1; // identity — fit
+		const m = /matrix\(([^)]+)\)/.exec(t);
+		return m ? Number(m[1].split(',')[0]) : NaN;
+	}, selector);
+}
+
+/** The viewer image's on-screen rectangle (post-transform), for anchor/pan math. */
+export function imageRect(page: Page, selector = VIEWER_IMAGE): Promise<DOMRect> {
+	return page.evaluate((sel) => {
+		const all = document.querySelectorAll<HTMLElement>(sel);
+		const el = all[all.length - 1]; // frontmost viewer (see renderedScale)
+		if (!el) throw new Error(`imageRect: no element for ${sel}`);
+		const r = el.getBoundingClientRect();
+		return { x: r.x, y: r.y, width: r.width, height: r.height, top: r.top, left: r.left, right: r.right, bottom: r.bottom } as DOMRect;
+	}, selector);
+}
 
 export function itemUrl(fixture: SuiteFixture, slug: string): string {
 	return `/${fixture.adminUsername}/${fixture.workspaceSlug}/docs/${slug}`;

--- a/web/src/lib/attachments/events.test.ts
+++ b/web/src/lib/attachments/events.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import type { AttachmentUploadResult } from '$lib/types';
 import {
 	createAttachmentHostToken,
 	isAttachmentPanelEventForHost,
@@ -7,6 +8,7 @@ import {
 	notifyViewerOpen,
 	registerAttachmentPanelListener,
 	registerAttachmentViewerListener,
+	toUploadedAttachment,
 	type AttachmentPanelOpenEvent,
 	type AttachmentViewerOpenEvent,
 	type LightboxImage,
@@ -522,5 +524,31 @@ describe('viewer open channel', () => {
 		expect(viewerSeen).toHaveLength(1);
 		expect(panelSeen).toHaveLength(1);
 		expect(viewerSeen[0].attachmentId).toBe('att-1');
+	});
+});
+
+describe('toUploadedAttachment (TASK-2459)', () => {
+	it('threads the dimensions the narrowing used to drop', () => {
+		const out = toUploadedAttachment({
+			id: 'a1',
+			filename: 'big.png',
+			mime: 'image/png',
+			size: 4096,
+			width: 4000,
+			height: 3000,
+		} as AttachmentUploadResult);
+		expect(out.width).toBe(4000);
+		expect(out.height).toBe(3000);
+	});
+
+	it('leaves dimensions null when the response omits them', () => {
+		const out = toUploadedAttachment({
+			id: 'a1',
+			filename: 'f.bin',
+			mime: 'application/octet-stream',
+			size: 10,
+		} as AttachmentUploadResult);
+		expect(out.width).toBeNull();
+		expect(out.height).toBeNull();
 	});
 });

--- a/web/src/lib/attachments/events.ts
+++ b/web/src/lib/attachments/events.ts
@@ -84,12 +84,21 @@ export interface UploadedAttachment {
 	filename: string;
 	mime_type: string;
 	size_bytes: number;
+	/**
+	 * Pixel dimensions, when the server returned them (nullable — a non-image, or
+	 * an image whose dimensions it couldn't read). Carried so a freshly uploaded
+	 * image opened in the viewer can classify for the DR-5b loading policy
+	 * (TASK-2459) instead of falling to `unknown` and pulling the original
+	 * outright; the upload response has them, this narrowing used to DROP them.
+	 */
+	width: number | null;
+	height: number | null;
 }
 
 /**
  * Narrow an upload response to what subscribers need. Both upload paths (body
- * editor, comment composer) were hand-mapping the same four fields, which is
- * how the two drift apart.
+ * editor, comment composer) were hand-mapping the same fields, which is how the
+ * two drift apart.
  */
 export function toUploadedAttachment(result: AttachmentUploadResult): UploadedAttachment {
 	return {
@@ -97,6 +106,8 @@ export function toUploadedAttachment(result: AttachmentUploadResult): UploadedAt
 		filename: result.filename,
 		mime_type: result.mime,
 		size_bytes: result.size,
+		width: result.width ?? null,
+		height: result.height ?? null,
 	};
 }
 
@@ -282,8 +293,9 @@ export interface LightboxImage {
 	 * Metadata the viewer may caption with, all NULLABLE for the same reason
 	 * the panel's three are: an emitter knows only what its own surface gives
 	 * it, and an inline image's HEAD probe may not have completed or may have
-	 * failed, while an upload event carries only four fields
-	 * (`UploadedAttachment`).
+	 * failed, while an upload event carries only the `UploadedAttachment` fields
+	 * (which now include the pixel dimensions, threaded for the DR-5b policy —
+	 * TASK-2459).
 	 *
 	 * `mime_type` is not decoration: it is what lets a CONSUMER re-state the
 	 * DR-16 open gate over a whole set rather than trusting the one element

--- a/web/src/lib/attachments/viewerImageLoader.svelte.test.ts
+++ b/web/src/lib/attachments/viewerImageLoader.svelte.test.ts
@@ -50,16 +50,110 @@ describe('viewerImageLoader — the decision table as requests (TASK-2459)', () 
 		expect(loader.displaySrc).toBe(ORIGINAL('A'));
 	});
 
-	it('large / unknown on mobile: NO request (idle — the tap affordance is TASK-2460)', () => {
+	it('large / unknown on mobile: NO request — `deferred`, the tap affordance (TASK-2460)', () => {
 		const large = createViewerImageLoader();
 		large.load(image('A', { width: 5000, height: 5000 }), 'ws', 'mobile');
-		expect(large.displaySrc).toBe('');
-		expect(large.phase).toBe('idle');
+		expect(large.displaySrc).toBe(''); // no request issued
+		expect(large.phase).toBe('deferred'); // NOT 'idle' — the original is on tap
 
 		const unknown = createViewerImageLoader();
 		unknown.load(image('B', { width: null, height: 900 }), 'ws', 'mobile');
 		expect(unknown.displaySrc).toBe('');
-		expect(unknown.phase).toBe('idle');
+		expect(unknown.phase).toBe('deferred');
+	});
+});
+
+describe('viewerImageLoader — mobile on-demand original (TASK-2460)', () => {
+	it('deferred cell: loadOriginal (tap) requests the ORIGINAL directly, once', () => {
+		const loader = createViewerImageLoader();
+		loader.load(image('A', { width: 5000, height: 5000 }), 'ws', 'mobile');
+		expect(loader.phase).toBe('deferred');
+		expect(loader.displaySrc).toBe('');
+
+		loader.loadOriginal(); // the tap
+		expect(loader.displaySrc).toBe(ORIGINAL('A'));
+		expect(loader.phase).toBe('loading');
+
+		// A second trigger (a second tap, or a zoom-past-fit racing it) is a no-op.
+		const t = loader.loadToken;
+		loader.loadOriginal();
+		expect(loader.displaySrc).toBe(ORIGINAL('A'));
+		expect(loader.loadToken).toBe(t);
+
+		loader.decoded(5000, 5000, loader.displaySrc, loader.loadToken);
+		expect(loader.phase).toBe('ready');
+	});
+
+	it('mobile thumb cell: thumb paints, then loadOriginal (zoom-past-fit) upgrades once', () => {
+		const loader = createViewerImageLoader();
+		loader.load(image('A', { width: 2000, height: 100 }), 'ws', 'mobile');
+		expect(loader.displaySrc).toBe(THUMB('A')); // thumb painted, no auto-upgrade
+		const thumbToken = loader.loadToken;
+		loader.decoded(1024, 51, loader.displaySrc, loader.loadToken);
+		expect(loader.displaySrc).toBe(THUMB('A')); // mobile: still the thumb
+
+		loader.loadOriginal(); // zoom past fit
+		expect(loader.displaySrc).toBe(ORIGINAL('A'));
+		// SAME element reused (token unchanged) so the thumb stays until the original
+		// decodes — no flash.
+		expect(loader.loadToken).toBe(thumbToken);
+
+		// A second zoom step past fit does not re-request.
+		loader.loadOriginal();
+		expect(loader.displaySrc).toBe(ORIGINAL('A'));
+		expect(loader.loadToken).toBe(thumbToken);
+	});
+
+	it('mobile thumb cell whose thumb-md SERVED THE ORIGINAL issues no zoom re-fetch', () => {
+		// The fallback detector must run on the mobile path too: a fresh upload /
+		// WebP / AVIF has no derived thumb, so `?variant=thumb-md` returns the
+		// ORIGINAL. Without clearing `originalDeferred`, a later zoom-past-fit would
+		// download and decode the original a SECOND time.
+		const loader = createViewerImageLoader();
+		loader.load(image('A', { width: 2000, height: 100 }), 'ws', 'mobile');
+		expect(loader.displaySrc).toBe(THUMB('A'));
+		// The "thumb" decoded ABOVE the bound → it WAS the original.
+		loader.decoded(2000, 100, loader.displaySrc, loader.loadToken);
+		expect(loader.phase).toBe('ready');
+		// Zoom past fit now finds nothing deferred — no second request.
+		loader.loadOriginal();
+		expect(loader.displaySrc).toBe(THUMB('A')); // unchanged
+	});
+
+	it('desktop never defers: loadOriginal is a no-op (auto-upgrade owns the original)', () => {
+		const loader = createViewerImageLoader();
+		loader.load(image('A', { width: 5000, height: 5000 }), 'ws', 'desktop');
+		expect(loader.displaySrc).toBe(THUMB('A'));
+		const before = loader.displaySrc;
+		loader.loadOriginal(); // no-op on desktop
+		expect(loader.displaySrc).toBe(before);
+	});
+
+	it('retry after an on-demand original FAILS re-requests the original, not the affordance', () => {
+		const loader = createViewerImageLoader();
+		loader.load(image('A', { width: 5000, height: 5000 }), 'ws', 'mobile');
+		loader.loadOriginal(); // tap
+		expect(loader.displaySrc).toBe(ORIGINAL('A'));
+		loader.errored(loader.displaySrc, loader.loadToken);
+		expect(loader.phase).toBe('error');
+
+		const t = loader.loadToken;
+		loader.retry();
+		// Back to the ORIGINAL (a fresh token remounts to refetch) — NOT reverted to
+		// the 'deferred' tap affordance.
+		expect(loader.phase).toBe('loading');
+		expect(loader.displaySrc).toBe(ORIGINAL('A'));
+		expect(loader.loadToken).toBeGreaterThan(t);
+	});
+
+	it('retry after the INITIAL thumb fails re-requests the thumb (start path)', () => {
+		const loader = createViewerImageLoader();
+		loader.load(image('A', { width: 2000, height: 100 }), 'ws', 'mobile');
+		expect(loader.displaySrc).toBe(THUMB('A'));
+		loader.errored(loader.displaySrc, loader.loadToken);
+		expect(loader.phase).toBe('error');
+		loader.retry();
+		expect(loader.displaySrc).toBe(THUMB('A')); // the initial policy, re-run
 	});
 });
 

--- a/web/src/lib/attachments/viewerImageLoader.svelte.test.ts
+++ b/web/src/lib/attachments/viewerImageLoader.svelte.test.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect } from 'vitest';
+import { createViewerImageLoader } from './viewerImageLoader.svelte';
+import type { LightboxImage } from './events';
+
+// TASK-2459 — the DR-5b loader. `displaySrc` IS the request: the canonical
+// attachment URL the viewer's <img> loads natively (a `?variant=thumb-md` first,
+// the plain original second). The acceptance is phrased in requests — a DR-16
+// gate is "no request issued", the fallback detector is "no SECOND request", the
+// upgrade is "the second request is the original" — and each is a `displaySrc`
+// transition here.
+//
+// `decoded`/`errored` carry the `gen` (the `loadToken` the reporting element was
+// mounted under); the current generation is `loader.loadToken`, so a live decode
+// passes `loader.loadToken` and a DETACHED element's stale decode passes the
+// token captured when it loaded.
+
+function image(id: string, over: Partial<LightboxImage> = {}): LightboxImage {
+	return {
+		id,
+		alt: id,
+		filename: null,
+		mime_type: 'image/png',
+		size_bytes: null,
+		width: null,
+		height: null,
+		...over,
+	};
+}
+
+const THUMB = (id: string) => `/api/v1/workspaces/ws/attachments/${id}?variant=thumb-md`;
+const ORIGINAL = (id: string) => `/api/v1/workspaces/ws/attachments/${id}`;
+
+describe('viewerImageLoader — the decision table as requests (TASK-2459)', () => {
+	it('small, long edge <= 1024: ONE request, the original directly (no variant)', () => {
+		const loader = createViewerImageLoader();
+		loader.load(image('A', { width: 800, height: 600 }), 'ws', 'desktop');
+		expect(loader.displaySrc).toBe(ORIGINAL('A'));
+		expect(loader.phase).toBe('loading');
+		loader.decoded(800, 600, loader.displaySrc, loader.loadToken);
+		// No upgrade — it IS the original.
+		expect(loader.displaySrc).toBe(ORIGINAL('A'));
+		expect(loader.phase).toBe('ready');
+	});
+
+	it('unknown dims on desktop: the original directly (one request)', () => {
+		const loader = createViewerImageLoader();
+		loader.load(image('A', { width: null, height: 900 }), 'ws', 'desktop');
+		expect(loader.displaySrc).toBe(ORIGINAL('A'));
+		loader.decoded(600, 900, loader.displaySrc, loader.loadToken);
+		expect(loader.displaySrc).toBe(ORIGINAL('A'));
+	});
+
+	it('large / unknown on mobile: NO request (idle — the tap affordance is TASK-2460)', () => {
+		const large = createViewerImageLoader();
+		large.load(image('A', { width: 5000, height: 5000 }), 'ws', 'mobile');
+		expect(large.displaySrc).toBe('');
+		expect(large.phase).toBe('idle');
+
+		const unknown = createViewerImageLoader();
+		unknown.load(image('B', { width: null, height: 900 }), 'ws', 'mobile');
+		expect(unknown.displaySrc).toBe('');
+		expect(unknown.phase).toBe('idle');
+	});
+});
+
+describe('viewerImageLoader — thumb then original, the four bound ways (TASK-2459)', () => {
+	it('large on desktop: first request bounded, second the original, the bitmap CHANGES', () => {
+		const loader = createViewerImageLoader();
+		loader.load(image('A', { width: 5000, height: 5000 }), 'ws', 'desktop');
+		// (1) first response bounded.
+		expect(loader.displaySrc).toBe(THUMB('A'));
+
+		// The thumb decoded at a bounded size → the background upgrade fires.
+		loader.decoded(1024, 768, loader.displaySrc, loader.loadToken);
+		// (2) second request is explicitly the original (canonical, no variant).
+		expect(loader.displaySrc).toBe(ORIGINAL('A'));
+		// (3) the displayed bitmap visibly CHANGES (thumb URL → original URL).
+		expect(loader.displaySrc).not.toBe(THUMB('A'));
+
+		loader.decoded(5000, 5000, loader.displaySrc, loader.loadToken);
+		expect(loader.phase).toBe('ready');
+	});
+
+	it('small, long edge > 1024 on desktop: thumb-md then upgrade; on mobile: thumb-md, no upgrade', () => {
+		const desktop = createViewerImageLoader();
+		desktop.load(image('A', { width: 2000, height: 100 }), 'ws', 'desktop');
+		expect(desktop.displaySrc).toBe(THUMB('A'));
+		desktop.decoded(1024, 51, desktop.displaySrc, desktop.loadToken);
+		expect(desktop.displaySrc).toBe(ORIGINAL('A'));
+
+		const mobile = createViewerImageLoader();
+		mobile.load(image('A', { width: 2000, height: 100 }), 'ws', 'mobile');
+		expect(mobile.displaySrc).toBe(THUMB('A'));
+		mobile.decoded(1024, 51, mobile.displaySrc, mobile.loadToken);
+		expect(mobile.displaySrc).toBe(THUMB('A')); // NO auto upgrade on mobile
+	});
+
+	it('(4) the FALLBACK case issues NO second request: a thumb-md served the original', () => {
+		const loader = createViewerImageLoader();
+		loader.load(image('A', { width: 5000, height: 5000 }), 'ws', 'desktop');
+		expect(loader.displaySrc).toBe(THUMB('A'));
+		// The "thumb" decoded ABOVE the thumbnail bound → it WAS the original.
+		loader.decoded(5000, 5000, loader.displaySrc, loader.loadToken);
+		expect(loader.displaySrc).toBe(THUMB('A')); // never upgraded — no double decode
+		expect(loader.phase).toBe('ready');
+	});
+});
+
+describe('viewerImageLoader — DR-16 as a LOADING gate (TASK-2459)', () => {
+	it('issues NO request for an unsafe MIME', () => {
+		const loader = createViewerImageLoader();
+		loader.load(image('A', { mime_type: 'image/svg+xml', width: 800, height: 600 }), 'ws', 'desktop');
+		expect(loader.displaySrc).toBe('');
+		expect(loader.phase).toBe('idle');
+	});
+
+	it('issues NO request for an unresolved MIME', () => {
+		const loader = createViewerImageLoader();
+		loader.load(image('A', { mime_type: null, width: 800, height: 600 }), 'ws', 'desktop');
+		expect(loader.displaySrc).toBe('');
+	});
+
+	it('issues NO request for no image', () => {
+		const loader = createViewerImageLoader();
+		loader.load(undefined, 'ws', 'desktop');
+		expect(loader.displaySrc).toBe('');
+	});
+});
+
+describe('viewerImageLoader — staleness / abort on navigate + shrink (TASK-2459)', () => {
+	it('repointing DROPS the old URL immediately (abort by src reassignment)', () => {
+		const loader = createViewerImageLoader();
+		loader.load(image('A', { width: 5000, height: 5000 }), 'ws', 'desktop');
+		expect(loader.displaySrc).toBe(THUMB('A'));
+		// Navigate to B before A finishes: the old URL is gone at once.
+		loader.load(image('B', { width: 800, height: 600 }), 'ws', 'desktop');
+		expect(loader.displaySrc).toBe(ORIGINAL('B'));
+		expect(loader.displaySrc).not.toContain('/A');
+	});
+
+	it('a LATE decode for a navigated-away image does NOT drive the new image', () => {
+		const loader = createViewerImageLoader();
+		loader.load(image('A', { width: 5000, height: 5000 }), 'ws', 'desktop');
+		const staleSrc = loader.displaySrc; // A's thumb
+		const staleGen = loader.loadToken; // A's generation
+		loader.load(image('B', { width: 800, height: 600 }), 'ws', 'desktop');
+		expect(loader.displaySrc).toBe(ORIGINAL('B'));
+
+		// A's thumbnail finishes decoding LATE, at a fallback size (>1024). Without
+		// the src fence this would flip B into an unexpected upgrade / phase.
+		loader.decoded(5000, 5000, staleSrc, staleGen);
+		expect(loader.displaySrc).toBe(ORIGINAL('B')); // untouched
+	});
+
+	it('the GENERATION fence rejects an A→B→A same-URL stale decode', () => {
+		// The URL fence alone is insufficient: navigating A→B→A reuses A's exact
+		// URL, so the detached first A element's late decode has the SAME src as the
+		// live third request. Only the captured generation tells them apart.
+		const loader = createViewerImageLoader();
+		loader.load(image('A', { width: 5000, height: 5000 }), 'ws', 'desktop');
+		const firstA = loader.loadToken; // the detached A element's generation
+		loader.load(image('B', { width: 5000, height: 5000 }), 'ws', 'desktop');
+		loader.load(image('A', { width: 5000, height: 5000 }), 'ws', 'desktop');
+		expect(loader.displaySrc).toBe(THUMB('A')); // the live third request
+
+		// The FIRST A element decodes late at a fallback size (>1024). If accepted it
+		// would call `servedOriginal` true and SUPPRESS the live A's upgrade.
+		loader.decoded(5000, 5000, THUMB('A'), firstA);
+		// Live A is untouched — its own decode still drives the upgrade.
+		loader.decoded(1024, 768, loader.displaySrc, loader.loadToken);
+		expect(loader.displaySrc).toBe(ORIGINAL('A')); // upgraded, not suppressed
+	});
+
+	it('the GENERATION fence rejects an A→B→A same-URL stale ERROR', () => {
+		const loader = createViewerImageLoader();
+		loader.load(image('A', { width: 800, height: 600 }), 'ws', 'desktop');
+		const firstA = loader.loadToken;
+		loader.load(image('B', { width: 800, height: 600 }), 'ws', 'desktop');
+		loader.load(image('A', { width: 800, height: 600 }), 'ws', 'desktop');
+		// The live third A decodes successfully.
+		loader.decoded(800, 600, loader.displaySrc, loader.loadToken);
+		expect(loader.phase).toBe('ready');
+		// The detached first A element errors LATE at the same URL — it must NOT
+		// flip the live, ready image into 'error'.
+		loader.errored(ORIGINAL('A'), firstA);
+		expect(loader.phase).toBe('ready');
+	});
+
+	it('dispose (close / shrink to empty) drops the load', () => {
+		const loader = createViewerImageLoader();
+		loader.load(image('A', { width: 800, height: 600 }), 'ws', 'desktop');
+		expect(loader.displaySrc).not.toBe('');
+		loader.dispose();
+		expect(loader.displaySrc).toBe('');
+		expect(loader.phase).toBe('idle');
+		// A stale decode after dispose is inert.
+		loader.decoded(800, 600, ORIGINAL('A'), loader.loadToken);
+		expect(loader.phase).toBe('idle');
+	});
+});
+
+describe('viewerImageLoader — error + retry (TASK-2459)', () => {
+	it('a load failure shows a retryable error; retry RE-REQUESTS (never replays)', () => {
+		const loader = createViewerImageLoader();
+		loader.load(image('A', { width: 800, height: 600 }), 'ws', 'desktop');
+		const url = loader.displaySrc;
+		loader.errored(url, loader.loadToken);
+		expect(loader.phase).toBe('error');
+
+		loader.retry();
+		// Re-issued: the src is reset then set again (a real re-request, not a
+		// replay of the failed one).
+		expect(loader.displaySrc).toBe(url);
+		expect(loader.phase).toBe('loading');
+		loader.decoded(800, 600, loader.displaySrc, loader.loadToken);
+		expect(loader.phase).toBe('ready');
+	});
+
+	it('retry bumps the load token so the viewer re-requests a same-URL failure', () => {
+		const loader = createViewerImageLoader();
+		loader.load(image('A', { width: 800, height: 600 }), 'ws', 'desktop');
+		const t1 = loader.loadToken;
+		loader.errored(loader.displaySrc, loader.loadToken);
+		loader.retry();
+		// Same URL, but a NEW token — the viewer re-mounts the <img> and re-fetches.
+		expect(loader.displaySrc).toBe(ORIGINAL('A'));
+		expect(loader.loadToken).toBeGreaterThan(t1);
+	});
+
+	it('the thumb→original UPGRADE does NOT bump the load token (element reused)', () => {
+		const loader = createViewerImageLoader();
+		loader.load(image('A', { width: 5000, height: 5000 }), 'ws', 'desktop');
+		const t1 = loader.loadToken;
+		loader.decoded(1024, 768, loader.displaySrc, loader.loadToken); // upgrade
+		expect(loader.displaySrc).toBe(ORIGINAL('A'));
+		expect(loader.loadToken).toBe(t1); // unchanged — same element, no flash
+	});
+
+	it('ignores an error for a stale (already-navigated-away) src', () => {
+		const loader = createViewerImageLoader();
+		loader.load(image('A', { width: 800, height: 600 }), 'ws', 'desktop');
+		const staleSrc = loader.displaySrc;
+		const staleGen = loader.loadToken;
+		loader.load(image('B', { width: 800, height: 600 }), 'ws', 'desktop');
+		loader.errored(staleSrc, staleGen);
+		expect(loader.phase).toBe('loading'); // B is unaffected
+	});
+});

--- a/web/src/lib/attachments/viewerImageLoader.svelte.ts
+++ b/web/src/lib/attachments/viewerImageLoader.svelte.ts
@@ -32,12 +32,20 @@ import { decideFirstRequest, servedOriginal, type Platform } from './viewerLoadi
 import type { LightboxImage } from './events';
 
 export type LoadPhase =
-	/** Nothing to load — no image, an unsafe/unresolved entry (DR-16), or a
-	 *  mobile large/unknown cell whose original arrives on tap (TASK-2460). */
+	/** Nothing to load and nothing to offer — no image, or an unsafe/unresolved
+	 *  entry (DR-16). No `<img>`, no affordance. */
 	| 'idle'
-	/** A request is in flight (first paint, or the background upgrade). */
+	/** A mobile large/unknown cell: nothing auto-loads, but the ORIGINAL is
+	 *  available on demand — the viewer shows the tap-to-load affordance, and a
+	 *  tap (or zoom-past-fit once a bitmap exists) calls {@link
+	 *  ViewerImageLoader.loadOriginal} (TASK-2460). Distinct from `idle`, which
+	 *  offers nothing. */
+	| 'deferred'
+	/** A request is in flight (first paint, or the on-demand / background
+	 *  original). */
 	| 'loading'
-	/** A bitmap is displayed. The background upgrade may still be running. */
+	/** A bitmap is displayed. A background/on-demand original may still be
+	 *  running. */
 	| 'ready'
 	/** The image failed to load; retryable. */
 	| 'error';
@@ -55,12 +63,31 @@ export interface ViewerImageLoader {
 	 */
 	readonly loadToken: number;
 	/**
+	 * Whether a bitmap has DECODED for the current image and is on screen (a thumb
+	 * or the original). False from `load` until the first decode, and in `idle` /
+	 * `deferred`; stays true across the thumb→original upgrade. The viewer's
+	 * zoom-past-fit trigger reads it so a zoom made BEFORE the thumb paints still
+	 * upgrades the moment it does — and, because `loadOriginal` never writes it, the
+	 * trigger effect can track it without self-invalidating (CONVE-1688).
+	 */
+	readonly painted: boolean;
+	/**
 	 * Point the loader at `img` in workspace `wsSlug` on `platform`, superseding
 	 * any prior load (its in-flight request is dropped by the `src` change). An
 	 * `idle` no-op for no image, an unsafe/unresolved MIME (DR-16), or a cell that
 	 * loads nothing now.
 	 */
 	load(img: LightboxImage | undefined, wsSlug: string, platform: Platform): void;
+	/**
+	 * Request the ORIGINAL on demand — the mobile fetch DR-5b defers. Called by
+	 * BOTH the tap affordance (the `deferred` cell, where nothing painted) and by
+	 * zoom-past-fit (the mobile thumb cell, where a thumbnail painted). The two are
+	 * ONE deduplicated fetch: a call while the original is already requested or
+	 * in flight is a no-op, so a tap racing a zoom, 3d's pinch, or a retry can
+	 * never issue a second request (TASK-2460). A no-op on desktop and on any cell
+	 * that already loaded the original directly, where nothing is deferred.
+	 */
+	loadOriginal(): void;
 	/**
 	 * The `<img>` decoded `decodedSrc` at `naturalWidth x naturalHeight`. `gen` is
 	 * the `loadToken` the reporting element was mounted under. Ignored unless BOTH
@@ -93,6 +120,15 @@ interface ActiveLoad {
 	upgradePending: boolean;
 	/** True once the original request has been issued. */
 	upgrading: boolean;
+	/**
+	 * Whether the ORIGINAL is available to fetch ON DEMAND and has not been
+	 * requested yet — the mobile deferral (TASK-2460). True for a mobile
+	 * large/unknown cell (fetched on tap) AND a mobile thumb cell (fetched on
+	 * zoom-past-fit); false on desktop (auto-upgrades) and where the original was
+	 * loaded directly. {@link loadOriginal}'s dedup guard reads it: it flips false
+	 * on the first fetch, so a second trigger is a no-op.
+	 */
+	originalDeferred: boolean;
 }
 
 /**
@@ -112,9 +148,24 @@ export function createViewerImageLoader(): ViewerImageLoader {
 	// Bumped on each fresh request so the viewer can key its <img> and force a
 	// re-request even when the URL is unchanged (a retry) — see `loadToken`.
 	let loadToken = $state(0);
+	// Whether a bitmap has decoded for the current image (see the interface). The
+	// zoom-past-fit trigger TRACKS this; `loadOriginal` deliberately never writes
+	// it, so that tracking cannot self-invalidate the trigger's flush (CONVE-1688).
+	let painted = $state(false);
 	// Non-reactive: never read in an $effect's tracked scope, so writing it can't
 	// self-invalidate a flush (CONVE-1688).
 	let active: ActiveLoad | null = null;
+
+	// Retire to the neutral state — no active load, no URL, nothing decoded, no
+	// affordance. ONE cleanup so every "give up on this entry" site keeps the
+	// `painted === false in idle` contract; sprinkling the resets inline is how one
+	// gets left stale.
+	function toIdle(): void {
+		active = null;
+		displaySrc = '';
+		painted = false;
+		phase = 'idle';
+	}
 
 	function start(): void {
 		const a = active;
@@ -126,24 +177,30 @@ export function createViewerImageLoader(): ViewerImageLoader {
 		// renderer), because the renderer showing nothing is not the same as the
 		// loader asking for nothing.
 		if (!canOpenInViewer(a.img.mime_type)) {
-			active = null;
-			displaySrc = '';
-			phase = 'idle';
+			toIdle();
 			return;
 		}
-		// A NEW request (load / retry). The upgrade in `decoded` does NOT call
-		// `start`, so it never bumps this — the element (and its bitmap) is reused.
+		// A NEW request (load / retry). The upgrade in `decoded` and the on-demand
+		// `loadOriginal` do NOT call `start`, so neither bumps this — the element
+		// (and its bitmap) is reused.
 		loadToken++;
 		const decision = decideFirstRequest(a.img.width, a.img.height, a.platform);
+		a.upgrading = false;
+		// The original is DEFERRED (fetched on tap / zoom-past-fit) precisely when
+		// the platform is mobile and the first request is not already the original:
+		// the mobile large/unknown cell (nothing painted) and the mobile thumb cell
+		// (a thumbnail painted, no auto-upgrade). Desktop auto-upgrades; a
+		// direct-original cell has nothing left to fetch (TASK-2460).
+		a.originalDeferred = a.platform === 'mobile' && decision.variant !== 'original';
+		a.upgradePending = decision.variant === 'thumb-md' && decision.upgrade === true;
 		if (decision.variant === null) {
-			// Mobile large/unknown: nothing loads now (the tap affordance is
-			// TASK-2460). Not an error — an intentional idle.
-			phase = 'idle';
+			// Mobile large/unknown: nothing auto-loads. `deferred` (NOT `idle`) so the
+			// viewer shows the tap-to-load affordance; the original arrives via
+			// `loadOriginal` on tap.
+			phase = 'deferred';
 			displaySrc = '';
 			return;
 		}
-		a.upgradePending = decision.variant === 'thumb-md' && decision.upgrade === true;
-		a.upgrading = false;
 		phase = 'loading';
 		displaySrc = variantUrl(a.wsSlug, a.img.id, decision.variant);
 	}
@@ -153,14 +210,44 @@ export function createViewerImageLoader(): ViewerImageLoader {
 		// request. No reference to release — nothing is retained across images.
 		active = null;
 		displaySrc = '';
+		painted = false; // a new image has nothing decoded yet
 		if (!img) {
 			// No image to show. The DR-16 MIME gate lives in `start()` — the request
 			// chokepoint, so retry is gated too — leaving only "no image" here.
 			phase = 'idle';
 			return;
 		}
-		active = { img, wsSlug, platform, upgradePending: false, upgrading: false };
+		active = { img, wsSlug, platform, upgradePending: false, upgrading: false, originalDeferred: false };
 		start();
+	}
+
+	function loadOriginal(): void {
+		const a = active;
+		// Dedup: only fetch when an original is DEFERRED and none is already in
+		// flight. This single guard makes the two triggers (tap, zoom-past-fit) one
+		// fetch and closes every race — a second tap, 3d's pinch reaching
+		// zoom-past-fit again, or a retry that overlaps a zoom all find
+		// `originalDeferred` already false (or `upgrading` true) and no-op.
+		if (!a || !a.originalDeferred || a.upgrading) return;
+		// DR-16 restated at this request edge too (defensive: an entry only becomes
+		// `originalDeferred` in `start()` AFTER its gate, so `a.img` is already safe —
+		// but every place that issues a request re-checks, so the invariant is local
+		// rather than argued). RETIRE the entry to `idle` — the same cleanup `start`
+		// and `retry` do — rather than only clearing the flag, which would leave the
+		// tap affordance rendered (`phase` stuck `'deferred'`) over a dead, no-op
+		// button.
+		if (!canOpenInViewer(a.img.mime_type)) {
+			toIdle();
+			return;
+		}
+		a.originalDeferred = false;
+		a.upgrading = true;
+		// No `loadToken` bump: the mobile THUMB cell reuses its painted element so
+		// the thumbnail stays visible until the original decodes (no flash, like the
+		// desktop upgrade); the DEFERRED cell has no element yet, so one mounts fresh
+		// at the current token. `phase` returns to 'loading' while it is in flight.
+		phase = 'loading';
+		displaySrc = variantUrl(a.wsSlug, a.img.id, 'original');
 	}
 
 	function decoded(naturalWidth: number, naturalHeight: number, decodedSrc: string, gen: number): void {
@@ -172,14 +259,30 @@ export function createViewerImageLoader(): ViewerImageLoader {
 		// then handles the within-element thumb→original sequencing.
 		if (!a || gen !== loadToken || decodedSrc === '' || decodedSrc !== displaySrc) return;
 		phase = 'ready';
-		if (!a.upgradePending || a.upgrading) return;
-		// The first (thumb-md) bitmap decoded. If its long edge exceeds the
-		// thumbnail bound the server fell back to the ORIGINAL — do NOT request it
-		// again (the double decode the whole policy exists to prevent).
+		// A bitmap is now on screen (thumb or original) — this is the paint the
+		// zoom-past-fit trigger waits for, so a pre-paint zoom upgrades the instant
+		// it becomes true.
+		painted = true;
+		// Decoding the ORIGINAL (a desktop upgrade or a mobile on-demand fetch is in
+		// flight): nothing left to decide.
+		if (a.upgrading) return;
+		// Decoding the FIRST request (thumb-md, or an original-direct cell). The
+		// fallback detector runs on EVERY first decode, desktop or mobile: if the
+		// long edge exceeds the thumbnail bound the server served the ORIGINAL
+		// (thumb-md absent — fresh upload, or a WebP/AVIF it can't derive). There is
+		// then nothing more to fetch on EITHER path — clear the desktop upgrade AND
+		// the mobile deferred original, so neither a background upgrade nor a mobile
+		// zoom-past-fit re-requests bytes we already have (the double decode the
+		// whole policy exists to prevent).
 		if (servedOriginal(naturalWidth, naturalHeight)) {
 			a.upgradePending = false;
+			a.originalDeferred = false;
 			return;
 		}
+		// A real thumbnail (<= bound) decoded. The mobile thumb cell leaves
+		// `originalDeferred` true and waits for the zoom-past-fit trigger; only the
+		// DESKTOP cell background-upgrades now.
+		if (!a.upgradePending) return;
 		// DR-16 restated at the upgrade request edge too. Defensive: `a.img` is the
 		// same entry `start()` already gated, but every place that issues a request
 		// re-checks, so the invariant is local rather than argued.
@@ -203,17 +306,32 @@ export function createViewerImageLoader(): ViewerImageLoader {
 	}
 
 	function retry(): void {
-		if (!active) return;
+		const a = active;
+		if (!a) return;
 		// A fresh request, never a replay: the `src` is cleared and reissued, and
 		// the server may now have the variant (derivation completes async).
 		displaySrc = '';
+		if (a.upgrading) {
+			// The failed request was the on-demand / background ORIGINAL (a mobile tap
+			// or zoom-past-fit, or a desktop upgrade). Re-request the ORIGINAL directly
+			// — NOT the initial policy, which for a mobile deferred cell would revert
+			// to the tap affordance and drop the user's committed load intent. A fresh
+			// token remounts the element so the same URL actually refetches.
+			// DR-16 restated at this request edge too (like `start`).
+			if (!canOpenInViewer(a.img.mime_type)) {
+				toIdle();
+				return;
+			}
+			loadToken++;
+			phase = 'loading';
+			displaySrc = variantUrl(a.wsSlug, a.img.id, 'original');
+			return;
+		}
 		start();
 	}
 
 	function dispose(): void {
-		active = null;
-		displaySrc = '';
-		phase = 'idle';
+		toIdle();
 	}
 
 	return {
@@ -226,7 +344,11 @@ export function createViewerImageLoader(): ViewerImageLoader {
 		get loadToken() {
 			return loadToken;
 		},
+		get painted() {
+			return painted;
+		},
 		load,
+		loadOriginal,
 		decoded,
 		errored,
 		retry,

--- a/web/src/lib/attachments/viewerImageLoader.svelte.ts
+++ b/web/src/lib/attachments/viewerImageLoader.svelte.ts
@@ -1,0 +1,235 @@
+/**
+ * The attachment viewer's image LOADER (PLAN-2392 / TASK-2459) — the desktop
+ * thumb-then-original path with the DR-5b memory policy from
+ * {@link ./viewerLoading}.
+ *
+ * MODEL. The viewer's `<img>` is loaded NATIVELY — `displaySrc` is the canonical
+ * attachment URL (a `?variant=thumb-md` first, the plain original second), and
+ * the browser fetches, decodes, caches and (on `src` reassignment) CANCELS each
+ * request. That reassignment is the abort: repointing the loader immediately
+ * drops the URL the user navigated away from, and no cross-image reference —
+ * off-DOM `Image`, object URL, fetch controller — is ever retained, so arrowing
+ * through twenty images can leak nothing. The bytes stay under the browser's own
+ * cache, not a hand-rolled blob store.
+ *
+ * STALENESS (the no-`{#key}` switch-safety class). The `<img>` persists across
+ * navigation, so a bitmap that finishes decoding LATE could report the wrong
+ * image's pixels. Every `decoded()` therefore carries the src that decoded and
+ * is ignored unless it still equals `displaySrc` — the fence that keeps a stale
+ * completion from driving the fallback detector / upgrade for the image the user
+ * has already left. The workspace slug is the CAPTURED one the caller passes
+ * (the pane can switch workspace under a mounted viewer).
+ *
+ * The FALLBACK DETECTOR ({@link servedOriginal}) is the load-bearing piece: when
+ * a `thumb-md` request is served the original (fresh upload mid-derivation, or a
+ * WebP/AVIF the server can't derive), the decoded long edge exceeds the
+ * thumbnail bound and the background original request is SKIPPED — the double
+ * decode the whole policy exists to prevent.
+ */
+import { attachmentDownloadUrl } from '$lib/markdown/attachments';
+import { canOpenInViewer } from '$lib/attachments/display';
+import { decideFirstRequest, servedOriginal, type Platform } from './viewerLoading';
+import type { LightboxImage } from './events';
+
+export type LoadPhase =
+	/** Nothing to load — no image, an unsafe/unresolved entry (DR-16), or a
+	 *  mobile large/unknown cell whose original arrives on tap (TASK-2460). */
+	| 'idle'
+	/** A request is in flight (first paint, or the background upgrade). */
+	| 'loading'
+	/** A bitmap is displayed. The background upgrade may still be running. */
+	| 'ready'
+	/** The image failed to load; retryable. */
+	| 'error';
+
+export interface ViewerImageLoader {
+	/** The URL the viewer's `<img>` should show (canonical attachment URL), or `''`. */
+	readonly displaySrc: string;
+	readonly phase: LoadPhase;
+	/**
+	 * A token that changes on every fresh REQUEST — a load or a retry, but NOT the
+	 * thumb→original upgrade. The viewer keys its `<img>` on this so a retry (whose
+	 * URL is often unchanged) actually re-mounts and re-requests, and so a nav
+	 * gets a fresh element (tearing down the previous one's stale load listener),
+	 * while the upgrade reuses the element and does not flash.
+	 */
+	readonly loadToken: number;
+	/**
+	 * Point the loader at `img` in workspace `wsSlug` on `platform`, superseding
+	 * any prior load (its in-flight request is dropped by the `src` change). An
+	 * `idle` no-op for no image, an unsafe/unresolved MIME (DR-16), or a cell that
+	 * loads nothing now.
+	 */
+	load(img: LightboxImage | undefined, wsSlug: string, platform: Platform): void;
+	/**
+	 * The `<img>` decoded `decodedSrc` at `naturalWidth x naturalHeight`. `gen` is
+	 * the `loadToken` the reporting element was mounted under. Ignored unless BOTH
+	 * `gen` is the current `loadToken` (the generation fence) AND `decodedSrc` is
+	 * still the current `displaySrc`. The generation fence is load-bearing where
+	 * the URL fence is not: an A→B→A navigation reuses A's exact URL, so a detached
+	 * first element's late completion has the same `decodedSrc` as the live request
+	 * — only the per-mount `gen` tells them apart (the no-`{#key}` switch-safety
+	 * class). Drives the fallback detector and the thumb→original upgrade.
+	 */
+	decoded(naturalWidth: number, naturalHeight: number, decodedSrc: string, gen: number): void;
+	/**
+	 * The `<img>` failed to load `erroredSrc`. `gen` is the reporting element's
+	 * mount `loadToken`. Ignored unless it is the current generation AND src —
+	 * without the generation fence a detached same-URL element's late error would
+	 * clobber the live element's success (A→B→A).
+	 */
+	errored(erroredSrc: string, gen: number): void;
+	/** Retry a failed load — RE-REQUESTS from scratch, never replays a failure. */
+	retry(): void;
+	/** Drop the current load (on close / set-shrink to empty). */
+	dispose(): void;
+}
+
+interface ActiveLoad {
+	img: LightboxImage;
+	wsSlug: string;
+	platform: Platform;
+	/** Whether a background original upgrade is still owed (desktop thumb-md). */
+	upgradePending: boolean;
+	/** True once the original request has been issued. */
+	upgrading: boolean;
+}
+
+/**
+ * The URL for one variant. `original` is the CANONICAL, no-`?variant` download —
+ * that is what "the original" IS on the server (it serves the original when no
+ * derived row exists); the thumb↔original distinction IS the query param.
+ */
+function variantUrl(wsSlug: string, id: string, variant: 'thumb-md' | 'original'): string {
+	return variant === 'original'
+		? attachmentDownloadUrl(wsSlug, id)
+		: attachmentDownloadUrl(wsSlug, id, 'thumb-md');
+}
+
+export function createViewerImageLoader(): ViewerImageLoader {
+	let displaySrc = $state('');
+	let phase = $state<LoadPhase>('idle');
+	// Bumped on each fresh request so the viewer can key its <img> and force a
+	// re-request even when the URL is unchanged (a retry) — see `loadToken`.
+	let loadToken = $state(0);
+	// Non-reactive: never read in an $effect's tracked scope, so writing it can't
+	// self-invalidate a flush (CONVE-1688).
+	let active: ActiveLoad | null = null;
+
+	function start(): void {
+		const a = active;
+		if (!a) return;
+		// DR-16 as a LOADING gate, at the request CHOKEPOINT: both load() and
+		// retry() funnel through here, so an unsafe or unresolved MIME never issues
+		// a request from either — even were a prior state to leave `active` set. The
+		// gate is restated where the request is actually made (not only at the
+		// renderer), because the renderer showing nothing is not the same as the
+		// loader asking for nothing.
+		if (!canOpenInViewer(a.img.mime_type)) {
+			active = null;
+			displaySrc = '';
+			phase = 'idle';
+			return;
+		}
+		// A NEW request (load / retry). The upgrade in `decoded` does NOT call
+		// `start`, so it never bumps this — the element (and its bitmap) is reused.
+		loadToken++;
+		const decision = decideFirstRequest(a.img.width, a.img.height, a.platform);
+		if (decision.variant === null) {
+			// Mobile large/unknown: nothing loads now (the tap affordance is
+			// TASK-2460). Not an error — an intentional idle.
+			phase = 'idle';
+			displaySrc = '';
+			return;
+		}
+		a.upgradePending = decision.variant === 'thumb-md' && decision.upgrade === true;
+		a.upgrading = false;
+		phase = 'loading';
+		displaySrc = variantUrl(a.wsSlug, a.img.id, decision.variant);
+	}
+
+	function load(img: LightboxImage | undefined, wsSlug: string, platform: Platform): void {
+		// Repoint: the `src` reassignment below (or the '' here) drops the old
+		// request. No reference to release — nothing is retained across images.
+		active = null;
+		displaySrc = '';
+		if (!img) {
+			// No image to show. The DR-16 MIME gate lives in `start()` — the request
+			// chokepoint, so retry is gated too — leaving only "no image" here.
+			phase = 'idle';
+			return;
+		}
+		active = { img, wsSlug, platform, upgradePending: false, upgrading: false };
+		start();
+	}
+
+	function decoded(naturalWidth: number, naturalHeight: number, decodedSrc: string, gen: number): void {
+		const a = active;
+		// Staleness fence, two parts. The generation fence (`gen !== loadToken`)
+		// rejects a DETACHED element's late completion even when it carries the
+		// live URL — an A→B→A nav reuses A's exact URL, so the src check alone would
+		// let the old A element's late decode drive the new A load. The src check
+		// then handles the within-element thumb→original sequencing.
+		if (!a || gen !== loadToken || decodedSrc === '' || decodedSrc !== displaySrc) return;
+		phase = 'ready';
+		if (!a.upgradePending || a.upgrading) return;
+		// The first (thumb-md) bitmap decoded. If its long edge exceeds the
+		// thumbnail bound the server fell back to the ORIGINAL — do NOT request it
+		// again (the double decode the whole policy exists to prevent).
+		if (servedOriginal(naturalWidth, naturalHeight)) {
+			a.upgradePending = false;
+			return;
+		}
+		// DR-16 restated at the upgrade request edge too. Defensive: `a.img` is the
+		// same entry `start()` already gated, but every place that issues a request
+		// re-checks, so the invariant is local rather than argued.
+		if (!canOpenInViewer(a.img.mime_type)) {
+			a.upgradePending = false;
+			return;
+		}
+		// Background-request the original. `phase` returns to 'loading' while it is
+		// in flight; the thumbnail stays displayed until the original decodes.
+		a.upgrading = true;
+		a.upgradePending = false;
+		phase = 'loading';
+		displaySrc = variantUrl(a.wsSlug, a.img.id, 'original');
+	}
+
+	function errored(erroredSrc: string, gen: number): void {
+		// Generation + src fence (see `decoded`): a detached same-URL element's late
+		// error must not flip the live element's success into 'error'.
+		if (!active || gen !== loadToken || erroredSrc === '' || erroredSrc !== displaySrc) return;
+		phase = 'error';
+	}
+
+	function retry(): void {
+		if (!active) return;
+		// A fresh request, never a replay: the `src` is cleared and reissued, and
+		// the server may now have the variant (derivation completes async).
+		displaySrc = '';
+		start();
+	}
+
+	function dispose(): void {
+		active = null;
+		displaySrc = '';
+		phase = 'idle';
+	}
+
+	return {
+		get displaySrc() {
+			return displaySrc;
+		},
+		get phase() {
+			return phase;
+		},
+		get loadToken() {
+			return loadToken;
+		},
+		load,
+		decoded,
+		errored,
+		retry,
+		dispose,
+	};
+}

--- a/web/src/lib/attachments/viewerLoading.test.ts
+++ b/web/src/lib/attachments/viewerLoading.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import {
+	THUMB_LONG_EDGE,
+	AUTO_LOAD_MAX_PIXELS,
+	classify,
+	decideFirstRequest,
+	servedOriginal,
+} from './viewerLoading';
+
+describe('viewerLoading constants', () => {
+	it('mirror the server bounds by value', () => {
+		expect(THUMB_LONG_EDGE).toBe(1024);
+		expect(AUTO_LOAD_MAX_PIXELS).toBe(8_000_000);
+	});
+});
+
+describe('classify — pixels only, never bytes', () => {
+	it('is small at or under the pixel ceiling, large strictly above', () => {
+		expect(classify(2000, 2000)).toBe('small'); // 4 MP
+		expect(classify(4000, 2000)).toBe('small'); // exactly 8 MP — still small
+		expect(classify(4000, 2001)).toBe('large'); // just over
+		expect(classify(5000, 5000)).toBe('large'); // 25 MP
+	});
+
+	it('classifies a SMALL-byte, LARGE-pixel image as large (bytes are never consulted)', () => {
+		// A heavily-compressed 50 MP JPEG is a few MB on the wire but 200 MiB
+		// decoded — `large` is about the decoded cost, not the download.
+		expect(classify(10000, 5000)).toBe('large'); // 50 MP
+	});
+
+	it('yields `unknown` (a third value, NOT `large`) when a dimension is missing', () => {
+		expect(classify(null, 900)).toBe('unknown');
+		expect(classify(900, null)).toBe('unknown');
+		expect(classify(null, null)).toBe('unknown');
+		expect(classify(undefined, 900)).toBe('unknown');
+		// Explicitly distinct from `large`.
+		expect(classify(null, 900)).not.toBe('large');
+	});
+
+	it('treats non-finite / non-positive dimensions as `unknown`', () => {
+		expect(classify(0, 900)).toBe('unknown');
+		expect(classify(-1, 900)).toBe('unknown');
+		expect(classify(NaN, 900)).toBe('unknown');
+		expect(classify(Infinity, 900)).toBe('unknown');
+	});
+});
+
+describe('decideFirstRequest — the DR-5b decision table', () => {
+	it('small, long edge <= 1024: the original directly, either platform', () => {
+		expect(decideFirstRequest(800, 600, 'desktop')).toEqual({ variant: 'original' });
+		expect(decideFirstRequest(800, 600, 'mobile')).toEqual({ variant: 'original' });
+		expect(decideFirstRequest(1024, 700, 'desktop')).toEqual({ variant: 'original' }); // exactly 1024
+	});
+
+	it('small, long edge > 1024: thumb-md — upgrade on desktop, not on mobile', () => {
+		// 2000x100 = 200k px (small) but long edge 2000 > 1024.
+		expect(decideFirstRequest(2000, 100, 'desktop')).toEqual({ variant: 'thumb-md', upgrade: true });
+		expect(decideFirstRequest(2000, 100, 'mobile')).toEqual({ variant: 'thumb-md', upgrade: false });
+	});
+
+	it('large (dims known): desktop thumb-md+upgrade, mobile nothing (tap)', () => {
+		expect(decideFirstRequest(5000, 5000, 'desktop')).toEqual({ variant: 'thumb-md', upgrade: true });
+		expect(decideFirstRequest(5000, 5000, 'mobile')).toEqual({ variant: null });
+	});
+
+	it('unknown dims: desktop the original DIRECTLY (one request), mobile nothing (tap)', () => {
+		// The unknown-desktop cell must not request a thumb — a bounded fallback
+		// original would defeat the detector and cause a second request.
+		expect(decideFirstRequest(null, 900, 'desktop')).toEqual({ variant: 'original' });
+		expect(decideFirstRequest(null, null, 'desktop')).toEqual({ variant: 'original' });
+		expect(decideFirstRequest(null, 900, 'mobile')).toEqual({ variant: null });
+	});
+});
+
+describe('servedOriginal — the fallback detector', () => {
+	it('is true when the decoded long edge exceeds the thumbnail bound', () => {
+		// The thumb request was served the original (variant absent).
+		expect(servedOriginal(2048, 1200)).toBe(true);
+		expect(servedOriginal(1200, 2048)).toBe(true); // long edge on either axis
+		expect(servedOriginal(1025, 10)).toBe(true);
+	});
+
+	it('is false when the decoded bitmap fits the thumbnail bound (a real thumb)', () => {
+		expect(servedOriginal(1024, 768)).toBe(false); // exactly at the bound
+		expect(servedOriginal(1000, 500)).toBe(false);
+	});
+
+	it('is false (never crashes) on missing / degenerate dimensions', () => {
+		expect(servedOriginal(null, null)).toBe(false);
+		expect(servedOriginal(0, 0)).toBe(false);
+		expect(servedOriginal(NaN, undefined)).toBe(false);
+	});
+});

--- a/web/src/lib/attachments/viewerLoading.ts
+++ b/web/src/lib/attachments/viewerLoading.ts
@@ -1,0 +1,152 @@
+/**
+ * DR-5b image-loading policy for the attachment viewer (PLAN-2392 / TASK-2459).
+ *
+ * The memory-safety half of DR-5b: decide, from an image's PIXEL dimensions and
+ * the platform, what the viewer requests first and whether it upgrades to the
+ * original in the background — so a desktop promised a bounded first paint never
+ * silently decodes a 50 MP original twice, and a phone never auto-pulls one at
+ * all.
+ *
+ * PIXELS, NEVER BYTES. `size_bytes` is COMPRESSED size; a 3 MB JPEG can decode
+ * to 50 MP. The only honest ceiling for "how much RAM will this bitmap cost" is
+ * `width x height x 4` (RGBA), so classification reads dimensions and nothing
+ * else. When a dimension is missing the class is {@link SizeClass.unknown} — a
+ * genuine third value, NOT an alias for `large`: only the mobile
+ * no-auto-request decision treats the two alike; the desktop paths differ
+ * (unknown asks for the original directly, large asks for the thumbnail).
+ *
+ * This is a MEMORY POLICY, not a security boundary — the server authorizes the
+ * parent before it resolves any variant (`handlers_storage.go`). It is also
+ * FORMAT-BLIND on purpose: the load-bearing piece, {@link servedOriginal}, reads
+ * the decoded bitmap's own long edge rather than mirroring the server's decoder
+ * set, which would be a silently-rotting copy (the mirror DR-3a's shared fixture
+ * exists to avoid).
+ */
+
+/**
+ * The `thumb-md` variant's long-edge bound, in CSS px — it mirrors the server's
+ * (`handlers_attachments.go`: a 1024 px long-edge derivation). A decoded bitmap
+ * whose long edge EXCEEDS this cannot be that thumbnail, which is exactly what
+ * {@link servedOriginal} keys off.
+ */
+export const THUMB_LONG_EDGE = 1024;
+
+/**
+ * The pixel ceiling for auto-fetching an ORIGINAL without asking: ~8 MP, about
+ * 32 MiB decoded RGBA. At or below it a dimensioned image is `small`; above it
+ * `large`. This is a CLIENT policy threshold, distinct from the server's 64 MP
+ * upload ceiling (`MaxPixelsDefault`).
+ */
+export const AUTO_LOAD_MAX_PIXELS = 8_000_000;
+
+/**
+ * The size class of an image, from its pixels alone.
+ *
+ *  - `small`   — dimensioned, at or under {@link AUTO_LOAD_MAX_PIXELS}.
+ *  - `large`   — dimensioned, over it.
+ *  - `unknown` — a dimension is missing / non-finite / non-positive. A THIRD
+ *    value, never folded into `large`.
+ */
+export type SizeClass = 'small' | 'large' | 'unknown';
+
+export type Platform = 'desktop' | 'mobile';
+
+function usableDimension(value: number | null | undefined): value is number {
+	return typeof value === 'number' && Number.isFinite(value) && value > 0;
+}
+
+/**
+ * Classify on `width x height` and NOTHING else (never `size_bytes`).
+ *
+ * `classify(null, 900) === 'unknown'` — one missing dimension is enough, because
+ * a policy that can't see one axis can't bound the pixel count. A dimensioned
+ * image is `large` strictly ABOVE the ceiling, so an exactly-ceiling image is
+ * still `small`.
+ */
+export function classify(
+	width: number | null | undefined,
+	height: number | null | undefined
+): SizeClass {
+	if (!usableDimension(width) || !usableDimension(height)) return 'unknown';
+	return width * height > AUTO_LOAD_MAX_PIXELS ? 'large' : 'small';
+}
+
+/**
+ * True when the image's OWN pixels already fit inside the thumbnail bound, so
+ * the server would skip derivation and the download IS the original. Only
+ * meaningful for a dimensioned (`small`) image; `unknown` can't answer it.
+ */
+function withinThumbBound(width: number, height: number): boolean {
+	return Math.max(width, height) <= THUMB_LONG_EDGE;
+}
+
+/** Which variant the viewer requests for FIRST paint, and whether it upgrades. */
+export type FirstRequest =
+	/** Request the original directly; there is no separate upgrade. */
+	| { variant: 'original' }
+	/**
+	 * Request the bounded thumbnail. `upgrade` is whether to background-fetch the
+	 * original once it paints (desktop yes; mobile no — the original arrives on
+	 * zoom past fit, TASK-2460). Suppressed anyway if {@link servedOriginal}.
+	 */
+	| { variant: 'thumb-md'; upgrade: boolean }
+	/** Request NOTHING now — the mobile tap affordance loads it (TASK-2460). */
+	| { variant: null };
+
+/**
+ * The DR-5b decision table, as one pure function.
+ *
+ * | dims                       | desktop                    | mobile                 |
+ * | -------------------------- | -------------------------- | ---------------------- |
+ * | small, long edge <= 1024   | original directly          | original directly      |
+ * | small, long edge > 1024    | thumb-md, upgrade           | thumb-md, no upgrade    |
+ * | large (dims known)         | thumb-md, upgrade           | nothing (tap)          |
+ * | unknown dims               | original directly          | nothing (tap)          |
+ *
+ * The `unknown`-desktop cell asks for the ORIGINAL, not a thumb: an unknown
+ * image whose original is <= 1024 px would defeat {@link servedOriginal} (the
+ * fallback serves that bounded original and the detector, seeing <= 1024,
+ * wrongly concludes it got a real thumbnail and fetches again). Requesting the
+ * original outright is exactly one request, always.
+ */
+export function decideFirstRequest(
+	width: number | null | undefined,
+	height: number | null | undefined,
+	platform: Platform
+): FirstRequest {
+	const cls = classify(width, height);
+	if (cls === 'unknown') {
+		return platform === 'desktop' ? { variant: 'original' } : { variant: null };
+	}
+	if (cls === 'small' && withinThumbBound(width as number, height as number)) {
+		// The image IS within the thumbnail bound — the download is the original.
+		return { variant: 'original' };
+	}
+	// small-but-long (> 1024 px long edge) OR large, both with known dims.
+	if (platform === 'mobile') {
+		// large → tap affordance (nothing now); small-but-long → thumb, no auto original.
+		return cls === 'large' ? { variant: null } : { variant: 'thumb-md', upgrade: false };
+	}
+	return { variant: 'thumb-md', upgrade: true };
+}
+
+/**
+ * THE FALLBACK DETECTOR — the load-bearing piece.
+ *
+ * A cell that requested `thumb-md` but got a bitmap whose long edge exceeds the
+ * thumbnail bound was served the ORIGINAL (the server falls back to it when the
+ * variant is absent — a fresh upload mid-derivation, or any format the pure-Go
+ * processor doesn't derive: WebP / AVIF). Two distinct URLs would then decode
+ * the original TWICE, so the background upgrade is skipped.
+ *
+ * Format-blind and dimension-free: it reads only the decoded bitmap, so it can't
+ * rot when the server's decoder set changes.
+ */
+export function servedOriginal(
+	naturalWidth: number | null | undefined,
+	naturalHeight: number | null | undefined
+): boolean {
+	const w = usableDimension(naturalWidth) ? naturalWidth : 0;
+	const h = usableDimension(naturalHeight) ? naturalHeight : 0;
+	return Math.max(w, h) > THUMB_LONG_EDGE;
+}

--- a/web/src/lib/attachments/zoom.test.ts
+++ b/web/src/lib/attachments/zoom.test.ts
@@ -1,0 +1,836 @@
+import { describe, it, expect } from 'vitest';
+import {
+	FIT,
+	FIT_EPSILON,
+	MAX_SCALE_FACTOR,
+	TOGGLE_SMALL_SCALE,
+	ZOOM_STEP,
+	actualScale,
+	clampPan,
+	clampScale,
+	clampState,
+	isAtFit,
+	maxScale,
+	reset,
+	stageCenter,
+	toggleFitOrActual,
+	zoomTo,
+	type Geometry,
+	type Point,
+	type ZoomState,
+} from './zoom';
+
+// ---------------------------------------------------------------------------
+// Helpers
+//
+// Geometry is built the way the BROWSER builds it — `object-fit: contain`,
+// which scales down to fit and never up — so the fixtures cannot drift from the
+// coordinate system the module documents. Re-typing fitted sizes by hand is how
+// a test ends up asserting against a geometry the CSS never produces.
+// ---------------------------------------------------------------------------
+
+function containScale(stageW: number, stageH: number, natW: number, natH: number): number {
+	return Math.min(stageW / natW, stageH / natH, 1);
+}
+
+function geom(stageW: number, stageH: number, natW: number, natH: number): Geometry {
+	const k = containScale(stageW, stageH, natW, natH);
+	return { stageW, stageH, fittedW: natW * k, fittedH: natH * k, naturalW: natW, naturalH: natH };
+}
+
+/**
+ * The image-space point currently painted under `anchor`, measured in UNSCALED
+ * fitted-box px from the image's centre. This is the quantity an anchored zoom
+ * must leave unchanged; computing it from the documented transform rather than
+ * from the implementation is what makes the invariance assertions independent.
+ */
+function imagePointUnder(state: ZoomState, g: Geometry, anchor: Point): Point {
+	return {
+		x: (anchor.x - g.stageW / 2 - state.x) / state.scale,
+		y: (anchor.y - g.stageH / 2 - state.y) / state.scale,
+	};
+}
+
+/** Where an image-space point paints, in stage-local px. Inverse of the above. */
+function stagePointOf(state: ZoomState, g: Geometry, d: Point): Point {
+	return {
+		x: g.stageW / 2 + state.x + state.scale * d.x,
+		y: g.stageH / 2 + state.y + state.scale * d.y,
+	};
+}
+
+function expectClose(actual: number, expected: number, tol = 1e-9): void {
+	expect(Math.abs(actual - expected)).toBeLessThanOrEqual(tol);
+}
+
+/** The pan bound the module promises for one axis, recomputed independently. */
+function bound(stageExtent: number, fittedExtent: number, scale: number): number {
+	return Math.max(0, (fittedExtent * scale - stageExtent) / 2);
+}
+
+function expectWithinBounds(state: ZoomState, g: Geometry, tol = 1e-9): void {
+	const bx = bound(g.stageW, g.fittedW, state.scale);
+	const by = bound(g.stageH, g.fittedH, state.scale);
+	expect(state.x).toBeLessThanOrEqual(bx + tol);
+	expect(state.x).toBeGreaterThanOrEqual(-bx - tol);
+	expect(state.y).toBeLessThanOrEqual(by + tol);
+	expect(state.y).toBeGreaterThanOrEqual(-by - tol);
+	// The centring rule: an axis that does not overflow is pinned to 0, not
+	// merely "within a zero-width bound" — assert it as its own property so a
+	// bound-only implementation that leaves 1e-16 drift is still caught.
+	if (bx === 0) expect(state.x).toBe(0);
+	if (by === 0) expect(state.y).toBe(0);
+}
+
+// A square-ish image whose fitted box exactly fills the stage: the only shape
+// for which a CORNER-anchored zoom lands exactly on the pan bound rather than
+// outside it, so anchor invariance is testable there without the bounds
+// legitimately overriding it.
+const EXACT = geom(1000, 800, 2000, 1600);
+// Landscape image in a landscape stage: fills the width, letterboxed vertically.
+const WIDE = geom(1000, 800, 4000, 1000);
+// Portrait image in a landscape stage: fills the height, pillarboxed.
+const TALL = geom(1000, 800, 1000, 4000);
+// Landscape image in a PORTRAIT stage.
+const WIDE_IN_PORTRAIT = geom(800, 1000, 4000, 1000);
+// An image smaller than the stage on both axes: `contain` does not upscale, so
+// fit already is 1:1.
+const SMALL = geom(1000, 800, 400, 300);
+
+describe('geometry fixtures', () => {
+	it('are built by the same contain rule the CSS applies', () => {
+		expect(EXACT.fittedW).toBe(1000);
+		expect(EXACT.fittedH).toBe(800);
+		expect(WIDE.fittedW).toBe(1000);
+		expect(WIDE.fittedH).toBe(250);
+		expect(TALL.fittedW).toBe(200);
+		expect(TALL.fittedH).toBe(800);
+		expect(SMALL.fittedW).toBe(400);
+		expect(SMALL.fittedH).toBe(300);
+	});
+});
+
+describe('the contract constants', () => {
+	// THE ONE PLACE a literal from the spec is written down. Every other test
+	// references the exported constant, so behaviour tests cannot drift into
+	// re-typed magic numbers — but without this, renumbering MAX_SCALE_FACTOR to
+	// 5 or TOGGLE_SMALL_SCALE to 3 would silently change the product and keep the
+	// whole suite green, because every assertion would move with it.
+	it('carry the values PLAN-2392 specifies', () => {
+		expect(FIT).toBe(1);
+		expect(MAX_SCALE_FACTOR).toBe(4);
+		expect(TOGGLE_SMALL_SCALE).toBe(2);
+		expect(FIT_EPSILON).toBe(0.001);
+		expect(ZOOM_STEP).toBe(1.25);
+	});
+});
+
+describe('reset', () => {
+	it('is fit, centred', () => {
+		expect(reset()).toEqual({ scale: FIT, x: 0, y: 0 });
+	});
+
+	it('returns a fresh object each call so callers cannot alias state', () => {
+		const a = reset();
+		a.x = 99;
+		expect(reset().x).toBe(0);
+	});
+});
+
+describe('actualScale', () => {
+	it('is the painted bitmap over the fitted box', () => {
+		expect(actualScale(WIDE)).toBe(4000 / 1000);
+		expect(actualScale(TALL)).toBe(1000 / 200);
+	});
+
+	it('is exactly fit for an image smaller than the stage — contain never upscales', () => {
+		expect(actualScale(SMALL)).toBe(FIT);
+	});
+
+	it('is the WIDTH pair, not the height pair', () => {
+		// `contain` preserves the aspect ratio, so on every realistic fixture the
+		// two ratios agree and a height-based implementation is indistinguishable.
+		// Pin the axis the contract names with a deliberately non-uniform
+		// geometry — measurements DO diverge slightly per-axis once layout is
+		// snapped to a fractional device-pixel grid.
+		const nonUniform: Geometry = {
+			stageW: 1000,
+			stageH: 800,
+			fittedW: 1000,
+			fittedH: 100,
+			naturalW: 3000,
+			naturalH: 900,
+		};
+		expect(actualScale(nonUniform)).toBe(3);
+		expect(actualScale(nonUniform)).not.toBe(nonUniform.naturalH / nonUniform.fittedH);
+	});
+
+	it('falls back to fit rather than dividing by a degenerate measurement', () => {
+		expect(actualScale({ ...WIDE, fittedW: 0 })).toBe(FIT);
+		expect(actualScale({ ...WIDE, fittedW: Number.NaN })).toBe(FIT);
+		expect(actualScale({ ...WIDE, naturalW: 0 })).toBe(FIT);
+	});
+
+	it('grows when a higher-resolution bitmap swaps in under the same layout', () => {
+		// The thumb-then-original path (TASK-2459): same fitted box, bigger
+		// bitmap, so 1:1 — and with it the zoom ceiling — moves.
+		const thumb = { ...WIDE, naturalW: 1024, naturalH: 256 };
+		const original = { ...WIDE, naturalW: 4000, naturalH: 1000 };
+		expect(maxScale(original)).toBeGreaterThan(maxScale(thumb));
+	});
+});
+
+describe('maxScale', () => {
+	it('is MAX_SCALE_FACTOR times 1:1', () => {
+		expect(maxScale(WIDE)).toBe(actualScale(WIDE) * MAX_SCALE_FACTOR);
+	});
+
+	it('stays finite when a nonsensical bitmap size overflows the multiplication', () => {
+		// A finite ratio can still overflow: an infinite ceiling would disable the
+		// scale clamp altogether rather than merely raising it.
+		// fittedW must be 1 for the RATIO itself to reach MAX_VALUE — with a
+		// larger fitted box the ratio is small enough that x4 stays finite and the
+		// guard is never exercised.
+		const absurd: Geometry = {
+			stageW: 1,
+			stageH: 1,
+			fittedW: 1,
+			fittedH: 1,
+			naturalW: Number.MAX_VALUE,
+			naturalH: Number.MAX_VALUE,
+		};
+		expect(actualScale(absurd)).toBe(Number.MAX_VALUE);
+		expect(Number.isFinite(actualScale(absurd))).toBe(true);
+		expect(Number.isFinite(maxScale(absurd))).toBe(true);
+		expect(clampScale(Number.MAX_VALUE, absurd)).toBeLessThanOrEqual(maxScale(absurd));
+	});
+
+	it('floors at fit so a small image still has a zoom range', () => {
+		expect(maxScale(SMALL)).toBe(MAX_SCALE_FACTOR);
+		// A nonsensical sub-1 actual scale must not invert the bounds.
+		const upscaled: Geometry = { ...SMALL, fittedW: 800, fittedH: 600 };
+		expect(actualScale(upscaled)).toBeLessThan(FIT);
+		expect(maxScale(upscaled)).toBe(MAX_SCALE_FACTOR);
+	});
+});
+
+describe('clampScale', () => {
+	it('clamps to the fit floor and the maxScale ceiling', () => {
+		expect(clampScale(0.25, WIDE)).toBe(FIT);
+		expect(clampScale(1e6, WIDE)).toBe(maxScale(WIDE));
+		expect(clampScale(2.5, WIDE)).toBe(2.5);
+	});
+
+	it('coerces a non-finite scale to fit rather than emitting NaN into a CSS string', () => {
+		// Infinity falls back rather than saturating: it only ever arrives from a
+		// caller-side arithmetic bug, and snapping it to maximum zoom would look
+		// like a deliberate gesture.
+		expect(clampScale(Number.NaN, WIDE)).toBe(FIT);
+		expect(clampScale(Number.POSITIVE_INFINITY, WIDE)).toBe(FIT);
+		expect(clampScale(Number.NEGATIVE_INFINITY, WIDE)).toBe(FIT);
+	});
+
+	it('normalises negative zero away — a centred axis is exactly +0', () => {
+		expect(Object.is(clampPan({ scale: 2, x: -5, y: -5 }, WIDE).y, 0)).toBe(true);
+		expect(Object.is(clampPan({ scale: 2, x: -0, y: -0 }, WIDE).x, 0)).toBe(true);
+	});
+});
+
+describe('clampPan', () => {
+	it('centres an axis whose scaled extent fits inside the stage', () => {
+		// WIDE at 2x: the width overflows, the height still does not.
+		const clamped = clampPan({ scale: 2, x: 300, y: 300 }, WIDE);
+		expect(clamped.y).toBe(0);
+		expect(clamped.x).toBe(300);
+	});
+
+	it('centres BOTH axes at fit — the parity property', () => {
+		for (const g of [EXACT, WIDE, TALL, WIDE_IN_PORTRAIT, SMALL]) {
+			expect(clampPan({ scale: FIT, x: 500, y: -500 }, g)).toEqual({ scale: FIT, x: 0, y: 0 });
+		}
+	});
+
+	it('bounds all four edges of a wider-than-stage image', () => {
+		const g = WIDE;
+		const s = 2;
+		const bx = bound(g.stageW, g.fittedW, s); // 500
+		expect(bx).toBe(500);
+		expect(clampPan({ scale: s, x: 10_000, y: 0 }, g).x).toBe(bx);
+		expect(clampPan({ scale: s, x: -10_000, y: 0 }, g).x).toBe(-bx);
+		// The vertical axis is the non-overflowing one here: both directions pin to 0.
+		expect(clampPan({ scale: s, x: 0, y: 10_000 }, g).y).toBe(0);
+		expect(clampPan({ scale: s, x: 0, y: -10_000 }, g).y).toBe(0);
+	});
+
+	it('bounds all four edges of a taller-than-stage image', () => {
+		const g = TALL;
+		const s = 3;
+		const bx = bound(g.stageW, g.fittedW, s); // 200*3=600 > 1000? no -> 0
+		const by = bound(g.stageH, g.fittedH, s); // 800*3=2400 -> 800
+		expect(bx).toBe(0);
+		expect(by).toBe(800);
+		expect(clampPan({ scale: s, x: 10_000, y: 0 }, g).x).toBe(0);
+		expect(clampPan({ scale: s, x: -10_000, y: 0 }, g).x).toBe(0);
+		expect(clampPan({ scale: s, x: 0, y: 10_000 }, g).y).toBe(by);
+		expect(clampPan({ scale: s, x: 0, y: -10_000 }, g).y).toBe(-by);
+	});
+
+	it('bounds a corner — both axes at once, in both orientations', () => {
+		for (const g of [EXACT, WIDE_IN_PORTRAIT]) {
+			const s = 4;
+			const bx = bound(g.stageW, g.fittedW, s);
+			const by = bound(g.stageH, g.fittedH, s);
+			for (const [sx, sy] of [
+				[1, 1],
+				[1, -1],
+				[-1, 1],
+				[-1, -1],
+			]) {
+				const c = clampPan({ scale: s, x: sx * 10_000, y: sy * 10_000 }, g);
+				// `|| 0` only normalises the -0 a zero bound produces on the test
+				// side; a real bound is never zero, so no expectation is weakened.
+				expect(c.x).toBe(sx * bx || 0);
+				expect(c.y).toBe(sy * by || 0);
+			}
+		}
+	});
+
+	it('leaves an in-bounds offset untouched', () => {
+		expect(clampPan({ scale: 2, x: 123.5, y: 0 }, WIDE)).toEqual({ scale: 2, x: 123.5, y: 0 });
+	});
+
+	it('does not mutate its argument', () => {
+		const state = { scale: 2, x: 10_000, y: 10_000 };
+		clampPan(state, WIDE);
+		expect(state).toEqual({ scale: 2, x: 10_000, y: 10_000 });
+	});
+
+	it('passes scale through — clamping it is clampScale/clampState work', () => {
+		expect(clampPan({ scale: 99, x: 0, y: 0 }, WIDE).scale).toBe(99);
+		expect(clampPan({ scale: Number.NaN, x: 0, y: 0 }, WIDE).scale).toBe(FIT);
+	});
+});
+
+describe('clampState (the resize path)', () => {
+	it('clamps scale FIRST, then bounds pan against the NEW scale', () => {
+		// Enlarging the window lowers actualScale and with it maxScale, stranding
+		// a scale above the new ceiling (TASK-2455).
+		const before = geom(1000, 800, 4000, 1000); // actual 4 -> max 16
+		const after = geom(2000, 1600, 4000, 1000); // fitted 2000x500, actual 2 -> max 8
+		const zoomed = { scale: 16, x: bound(before.stageW, before.fittedW, 16), y: 0 };
+		const next = clampState(zoomed, after);
+		expect(next.scale).toBe(maxScale(after));
+		expectWithinBounds(next, after);
+		// Pan-first would have kept the OLD scale's much larger bound and left x
+		// far outside the new one; assert the value, not just the invariant.
+		expect(next.x).toBe(bound(after.stageW, after.fittedW, maxScale(after)));
+	});
+
+	it('preserves a scale that is still inside the new bounds', () => {
+		const after = geom(2000, 1600, 4000, 1000);
+		expect(clampState({ scale: 3, x: 0, y: 0 }, after).scale).toBe(3);
+	});
+});
+
+describe('zoomTo anchor invariance', () => {
+	const anchors: Array<[string, Point]> = [
+		['stage centre', { x: 500, y: 400 }],
+		['an off-centre interior point', { x: 250, y: 600 }],
+		['the top-left corner', { x: 0, y: 0 }],
+	];
+
+	for (const [label, anchor] of anchors) {
+		it(`keeps the image point under ${label} under it`, () => {
+			const from: ZoomState = { scale: 1, x: 0, y: 0 };
+			const before = imagePointUnder(from, EXACT, anchor);
+			const after = zoomTo(from, 2, anchor, EXACT);
+			const painted = stagePointOf(after, EXACT, before);
+			expectClose(painted.x, anchor.x);
+			expectClose(painted.y, anchor.y);
+		});
+	}
+
+	it('holds across a chain of steps from an already-panned state', () => {
+		const anchor = { x: 812.5, y: 137.25 };
+		let state: ZoomState = clampPan({ scale: 2, x: -200, y: -150 }, EXACT);
+		for (let i = 0; i < 6; i++) {
+			const before = imagePointUnder(state, EXACT, anchor);
+			const next = zoomTo(state, state.scale * ZOOM_STEP, anchor, EXACT);
+			// Once the chain reaches the ceiling the scale stops changing, and an
+			// unchanged scale trivially preserves the anchor — assert only while
+			// the step is real.
+			if (next.scale !== state.scale) {
+				const painted = stagePointOf(next, EXACT, before);
+				expectClose(painted.x, anchor.x, 1e-8);
+				expectClose(painted.y, anchor.y, 1e-8);
+			}
+			state = next;
+		}
+		expect(state.scale).toBeGreaterThan(2);
+	});
+
+	it('is not a no-op dressed up as invariance — the transform actually moves', () => {
+		// The invariance assertions above all pass for an implementation that
+		// refuses to zoom at all. This is the control leg.
+		const out = zoomTo({ scale: 1, x: 0, y: 0 }, 2, { x: 0, y: 0 }, EXACT);
+		expect(out.scale).toBe(2);
+		expect(out.x).not.toBe(0);
+		expect(out.y).not.toBe(0);
+	});
+
+	it('lets the pan bounds win over the anchor when they conflict', () => {
+		// A corner anchor on a letterboxed image would need an offset outside the
+		// bound; showing blank stage past an image edge is worse than losing the
+		// anchor, so the bound wins — and the non-overflowing axis stays centred.
+		const out = zoomTo({ scale: 1, x: 0, y: 0 }, 2, { x: 0, y: 0 }, WIDE);
+		expectWithinBounds(out, WIDE);
+		expect(out.x).toBe(bound(WIDE.stageW, WIDE.fittedW, 2));
+		expect(out.y).toBe(0);
+	});
+
+	it('clamps the target scale into [FIT, maxScale]', () => {
+		const g = WIDE;
+		expect(zoomTo({ scale: 2, x: 0, y: 0 }, 0.1, { x: 0, y: 0 }, g).scale).toBe(FIT);
+		expect(zoomTo({ scale: 2, x: 0, y: 0 }, 1e6, { x: 0, y: 0 }, g).scale).toBe(maxScale(g));
+	});
+
+	it('zooming back out to fit re-centres both axes', () => {
+		const zoomed = zoomTo({ scale: 1, x: 0, y: 0 }, 3, { x: 0, y: 0 }, EXACT);
+		const back = zoomTo(zoomed, FIT, { x: 0, y: 0 }, EXACT);
+		expect(back).toEqual({ scale: FIT, x: 0, y: 0 });
+	});
+
+	it('falls back to the stage centre for a non-finite anchor', () => {
+		const centred = zoomTo({ scale: 1, x: 0, y: 0 }, 2, stageCenter(EXACT), EXACT);
+		const nan = zoomTo({ scale: 1, x: 0, y: 0 }, 2, { x: Number.NaN, y: Number.NaN }, EXACT);
+		expect(nan).toEqual(centred);
+	});
+
+	it('does not mutate its argument', () => {
+		const state = { scale: 1, x: 0, y: 0 };
+		zoomTo(state, 3, { x: 0, y: 0 }, EXACT);
+		expect(state).toEqual({ scale: 1, x: 0, y: 0 });
+	});
+
+	it('normalises an already-invalid incoming state before anchoring', () => {
+		// The shape a consumer hits after a resize lowers the ceiling under a state
+		// it has not re-clamped yet. Clamping the incoming SCALE while trusting its
+		// PAN would apply a pan belonging to the old scale, so the invariant must
+		// be stated against the normalised state — assert it exactly that way.
+		const g = WIDE;
+		// Pan out of bounds for its own scale, which is what a shrinking resize
+		// leaves behind. Bound at scale 2 is 500, so 700 is 200px past it.
+		const stale: ZoomState = { scale: 2, x: 700, y: 0 };
+		const normalised = clampState(stale, g);
+		expect(normalised.x).toBe(500);
+
+		const out = zoomTo(stale, 2.2, stageCenter(g), g);
+		expect(out).toEqual(zoomTo(normalised, 2.2, stageCenter(g), g));
+		expectWithinBounds(out, g);
+
+		// Not vacuous: the rejected alternative — clamp the incoming SCALE, trust
+		// the incoming PAN — is written out here and lands somewhere else, so the
+		// assertion above has something to catch. A centre anchor scales the pan
+		// by k, and 700 * 1.1 = 770 exceeds the new bound while 500 * 1.1 does not.
+		expect(out.x).toBe(550);
+		expect(clampPan({ scale: 2.2, x: 700 * 1.1, y: 0 }, g).x).toBe(600);
+	});
+});
+
+describe('the drag contract (TASK-2458 consumes this)', () => {
+	// A drag MUST be computed from the state captured at pointer-down plus the
+	// total pointer delta. These two legs pin why: clamping is lossy, so feeding
+	// each move delta into the previous clamped result silently changes the
+	// gesture's feel at an edge.
+	const g = WIDE;
+	const scale = 2;
+	const bx = bound(g.stageW, g.fittedW, scale); // 500
+
+	it('takes up the slack when the drag is computed from the pointer-down baseline', () => {
+		const start: ZoomState = { scale, x: 0, y: 0 };
+		const overshoot = clampPan({ ...start, x: bx + 150 }, g);
+		expect(overshoot.x).toBe(bx);
+		// Pointer comes back 30px: total delta is +bx+120, still inside the bound.
+		const back = clampPan({ ...start, x: bx + 150 - 30 }, g);
+		expect(back.x).toBe(bx);
+	});
+
+	it('moves immediately — the wrong feel — if deltas are accumulated instead', () => {
+		// The control leg. Same pointer path, incremental composition: the image
+		// starts moving the instant the pointer reverses, 30px early.
+		const wrong = clampPan({ scale, x: clampPan({ scale, x: bx + 150, y: 0 }, g).x - 30, y: 0 }, g);
+		expect(wrong.x).toBe(bx - 30);
+		expect(wrong.x).not.toBe(bx);
+	});
+
+	it('an in-bounds drag moves by exactly the pointer delta', () => {
+		// The positive leg: "pan is clamped" alone passes with pan disabled.
+		const moved = clampPan({ scale, x: 0 + 123.75, y: 0 }, g);
+		expect(moved.x).toBe(123.75);
+	});
+});
+
+describe('stageCenter', () => {
+	it('is half the stage box', () => {
+		expect(stageCenter(WIDE)).toEqual({ x: 500, y: 400 });
+	});
+});
+
+describe('isAtFit / toggleFitOrActual', () => {
+	it('at fit, goes to actual size anchored at the pointer', () => {
+		const anchor = { x: 700, y: 300 };
+		const before = imagePointUnder(reset(), WIDE, anchor);
+		const out = toggleFitOrActual(reset(), anchor, WIDE);
+		expect(out.scale).toBe(actualScale(WIDE));
+		// Anchored, to the extent the bounds allow: the overflowing axis keeps the
+		// point, the centred axis cannot.
+		const painted = stagePointOf(out, WIDE, before);
+		expectClose(painted.x, anchor.x);
+		expectWithinBounds(out, WIDE);
+	});
+
+	it('away from fit, goes back to fit CENTRED regardless of the anchor', () => {
+		const zoomed = zoomTo(reset(), 3, { x: 0, y: 0 }, WIDE);
+		expect(toggleFitOrActual(zoomed, { x: 900, y: 700 }, WIDE)).toEqual(reset());
+	});
+
+	it('returns on a second toggle — the gesture is two-way', () => {
+		const anchor = { x: 700, y: 300 };
+		const once = toggleFitOrActual(reset(), anchor, WIDE);
+		const twice = toggleFitOrActual(once, anchor, WIDE);
+		expect(once.scale).toBeGreaterThan(FIT);
+		expect(twice).toEqual(reset());
+	});
+
+	it('treats the epsilon boundary as at-fit, and just past it as not', () => {
+		const inside: ZoomState = { scale: FIT + FIT_EPSILON, x: 0, y: 0 };
+		const outside: ZoomState = { scale: FIT + FIT_EPSILON * 2, x: 0, y: 0 };
+		expect(isAtFit(inside)).toBe(true);
+		expect(isAtFit(outside)).toBe(false);
+		expect(toggleFitOrActual(inside, { x: 500, y: 400 }, WIDE).scale).toBe(actualScale(WIDE));
+		expect(toggleFitOrActual(outside, { x: 500, y: 400 }, WIDE)).toEqual(reset());
+	});
+
+	it('is never a no-op on an image whose actual size IS fit', () => {
+		const out = toggleFitOrActual(reset(), { x: 500, y: 400 }, SMALL);
+		expect(actualScale(SMALL)).toBe(FIT);
+		expect(out.scale).toBe(TOGGLE_SMALL_SCALE);
+		// And it still toggles back.
+		expect(toggleFitOrActual(out, { x: 500, y: 400 }, SMALL)).toEqual(reset());
+	});
+
+	it('is never a no-op when fractional geometry puts actual size a hair above fit', () => {
+		// A 1:1 image measured at dpr 2.75: the ratio is 1.0000000004, not 1, so an
+		// `=== 1` test would toggle to a scale the user cannot see.
+		const hair: Geometry = { ...SMALL, naturalW: 400.0000001, naturalH: 300.0000001 };
+		expect(actualScale(hair)).toBeGreaterThan(FIT);
+		expect(toggleFitOrActual(reset(), { x: 500, y: 400 }, hair).scale).toBe(TOGGLE_SMALL_SCALE);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Fractional geometry / non-integer devicePixelRatio.
+//
+// The browser lays out on DEVICE-pixel boundaries, which are not CSS-pixel
+// boundaries at dpr 1.25 / 1.5 / 2.75 — so every measurement the viewer reads
+// is fractional there. An implementation that rounds looks correct on the
+// integer fixtures above and drifts the anchored point visibly across a
+// sequence of steps.
+// ---------------------------------------------------------------------------
+
+describe('fractional geometry and non-integer devicePixelRatio', () => {
+	function snap(css: number, dpr: number): number {
+		return Math.round(css * dpr) / dpr;
+	}
+
+	const dprs = [1.25, 1.5, 1.75, 2.5, 2.75];
+
+	for (const dpr of dprs) {
+		describe(`dpr ${dpr}`, () => {
+			// 92vw x 92vh of an odd viewport, snapped to the device grid.
+			const stageW = snap(0.92 * 1367, dpr);
+			const stageH = snap(0.92 * 769, dpr);
+			const g = geom(stageW, stageH, 3021, 2013);
+
+			it('produces non-integer geometry (otherwise the case proves nothing)', () => {
+				expect(Number.isInteger(g.fittedW) && Number.isInteger(g.fittedH)).toBe(false);
+			});
+
+			it('keeps the anchored point under the cursor to well under one device pixel', () => {
+				const tol = 1 / dpr / 1000;
+				const anchor = { x: stageW * 0.317, y: stageH * 0.733 };
+				let state = reset();
+				for (let i = 0; i < 8; i++) {
+					const before = imagePointUnder(state, g, anchor);
+					const next = zoomTo(state, state.scale * ZOOM_STEP, anchor, g);
+					const bx = bound(g.stageW, g.fittedW, next.scale);
+					const by = bound(g.stageH, g.fittedH, next.scale);
+					const painted = stagePointOf(next, g, before);
+					// Only where the bounds did not legitimately override the anchor.
+					if (Math.abs(next.x) < bx - 1 && next.scale !== state.scale) {
+						expectClose(painted.x, anchor.x, tol);
+					}
+					if (Math.abs(next.y) < by - 1 && next.scale !== state.scale) {
+						expectClose(painted.y, anchor.y, tol);
+					}
+					expectWithinBounds(next, g);
+					state = next;
+				}
+			});
+
+			it('does not round the transform to whole CSS pixels', () => {
+				const out = zoomTo(reset(), 2.5, { x: stageW * 0.13, y: stageH * 0.87 }, g);
+				expect(Number.isInteger(out.x) && Number.isInteger(out.y)).toBe(false);
+			});
+
+			it('bounds a fractional geometry exactly, with no gap or overshoot', () => {
+				const s = maxScale(g);
+				const far = clampPan({ scale: s, x: 1e9, y: 1e9 }, g);
+				expectClose(far.x, bound(g.stageW, g.fittedW, s), 0);
+				expectClose(far.y, bound(g.stageH, g.fittedH, s), 0);
+			});
+		});
+	}
+});
+
+// ---------------------------------------------------------------------------
+// RTL.
+//
+// The module's coordinates are STAGE-LOCAL — measured from the stage box's
+// physical left edge, which is what `getBoundingClientRect()` reports in either
+// direction. `direction: rtl` mirrors the LAYOUT, not that measurement, so the
+// math must be exactly direction-symmetric: mirror the anchor and the pan, and
+// the result must be the mirror of the original. Any place the implementation
+// leaked a signed horizontal direction (an inline-start assumption, a
+// `stageW - x`) breaks this and nothing else does.
+// ---------------------------------------------------------------------------
+
+describe('RTL / horizontal direction symmetry', () => {
+	function mirrorPoint(p: Point, g: Geometry): Point {
+		return { x: g.stageW - p.x, y: p.y };
+	}
+	function mirrorState(s: ZoomState): ZoomState {
+		return { scale: s.scale, x: -s.x, y: s.y };
+	}
+
+	const cases: Array<[string, Geometry]> = [
+		['exact fill', EXACT],
+		['landscape in landscape', WIDE],
+		['portrait in landscape', TALL],
+		['landscape in portrait', WIDE_IN_PORTRAIT],
+	];
+
+	for (const [label, g] of cases) {
+		it(`zoomTo is mirror-symmetric (${label})`, () => {
+			const anchor = { x: g.stageW * 0.19, y: g.stageH * 0.62 };
+			const start: ZoomState = clampPan({ scale: 2, x: 37.5, y: -12.25 }, g);
+			const out = zoomTo(start, 3.5, anchor, g);
+			const mirrored = zoomTo(mirrorState(start), 3.5, mirrorPoint(anchor, g), g);
+			expect(mirrored.scale).toBe(out.scale);
+			expectClose(mirrored.x, -out.x, 1e-9);
+			expectClose(mirrored.y, out.y, 1e-9);
+		});
+
+		it(`clampPan is mirror-symmetric (${label})`, () => {
+			const s = 3;
+			const state: ZoomState = { scale: s, x: 1e9, y: 1e9 };
+			const a = clampPan(state, g);
+			const b = clampPan(mirrorState(state), g);
+			expectClose(b.x, -a.x, 0);
+		});
+	}
+
+	it('the symmetry assertion can fail — a direction-flipped anchor breaks it', () => {
+		// Control leg: proves the mirror test is load-bearing rather than
+		// tautological. Mirroring the anchor WITHOUT mirroring the pan is exactly
+		// the bug shape the test exists to catch.
+		const g = EXACT;
+		const anchor = { x: g.stageW * 0.19, y: g.stageH * 0.62 };
+		const start: ZoomState = { scale: 2, x: 37.5, y: 0 };
+		const out = zoomTo(start, 3.5, anchor, g);
+		const halfMirrored = zoomTo(start, 3.5, mirrorPoint(anchor, g), g);
+		expect(Math.abs(halfMirrored.x - -out.x)).toBeGreaterThan(1);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// The hard bound: NO sequence of operations escapes [FIT, maxScale] or the pan
+// bounds. Individually-correct operations can still compose into an escape —
+// this is the property the phase's review round called binding.
+// ---------------------------------------------------------------------------
+
+describe('bounds no sequence of operations can escape', () => {
+	function lcg(seed: number): () => number {
+		let s = seed >>> 0;
+		return () => {
+			s = (Math.imul(s, 1664525) + 1013904223) >>> 0;
+			return s / 0x1_0000_0000;
+		};
+	}
+
+	const fixtures: Array<[string, Geometry]> = [
+		['exact fill', EXACT],
+		['landscape in landscape', WIDE],
+		['portrait in landscape', TALL],
+		['landscape in portrait', WIDE_IN_PORTRAIT],
+		['smaller than the stage', SMALL],
+		['fractional', geom(1257.6, 707.2, 3021, 2013)],
+	];
+
+	for (const [label, g] of fixtures) {
+		it(`holds over 2000 pseudo-random operations (${label})`, () => {
+			const rand = lcg(0xc0ffee);
+			let state = reset();
+			let sawCeiling = false;
+			let sawFloor = false;
+			let sawBoundedPan = false;
+
+			for (let i = 0; i < 2000; i++) {
+				const anchor = { x: rand() * g.stageW * 1.4 - g.stageW * 0.2, y: rand() * g.stageH * 1.4 - g.stageH * 0.2 };
+				const roll = rand();
+				if (roll < 0.35) {
+					state = zoomTo(state, state.scale * ZOOM_STEP, anchor, g);
+				} else if (roll < 0.6) {
+					state = zoomTo(state, state.scale / ZOOM_STEP, anchor, g);
+				} else if (roll < 0.7) {
+					// A wild target, as a wheel burst or a hostile caller would give.
+					state = zoomTo(state, (rand() - 0.5) * 1e4, anchor, g);
+				} else if (roll < 0.85) {
+					// A drag: an unclamped offset handed straight to clampPan.
+					state = clampPan(
+						{ ...state, x: state.x + (rand() - 0.5) * 4000, y: state.y + (rand() - 0.5) * 4000 },
+						g,
+					);
+				} else if (roll < 0.95) {
+					state = toggleFitOrActual(state, anchor, g);
+				} else {
+					state = clampState(state, g);
+				}
+
+				expect(Number.isFinite(state.scale)).toBe(true);
+				expect(Number.isFinite(state.x)).toBe(true);
+				expect(Number.isFinite(state.y)).toBe(true);
+				expect(state.scale).toBeGreaterThanOrEqual(FIT);
+				expect(state.scale).toBeLessThanOrEqual(maxScale(g));
+				expectWithinBounds(state, g);
+
+				if (state.scale === maxScale(g)) sawCeiling = true;
+				if (state.scale === FIT) sawFloor = true;
+				if (
+					state.scale > FIT &&
+					Math.abs(state.x) === bound(g.stageW, g.fittedW, state.scale) &&
+					state.x !== 0
+				) {
+					sawBoundedPan = true;
+				}
+			}
+
+			// Coverage guards: without these the invariants above could pass on a
+			// walk that never approached a bound.
+			expect(sawCeiling).toBe(true);
+			expect(sawFloor).toBe(true);
+			expect(sawBoundedPan).toBe(true);
+		});
+	}
+});
+
+describe('degenerate geometry', () => {
+	const zero: Geometry = { stageW: 0, stageH: 0, fittedW: 0, fittedH: 0, naturalW: 0, naturalH: 0 };
+
+	it('never emits NaN into the transform', () => {
+		for (const out of [
+			zoomTo(reset(), 3, { x: 10, y: 10 }, zero),
+			clampPan({ scale: 3, x: 10, y: 10 }, zero),
+			toggleFitOrActual(reset(), { x: 10, y: 10 }, zero),
+			clampState({ scale: 99, x: 10, y: 10 }, zero),
+		]) {
+			expect(Number.isFinite(out.scale)).toBe(true);
+			expect(Number.isFinite(out.x)).toBe(true);
+			expect(Number.isFinite(out.y)).toBe(true);
+		}
+	});
+
+	it('centres everything when there is no geometry to pan within', () => {
+		expect(clampPan({ scale: 3, x: 10, y: 10 }, zero)).toEqual({ scale: 3, x: 0, y: 0 });
+	});
+});
+
+/**
+ * Round 3 of the per-task Codex review took the numerical-robustness angle and
+ * found three P2s. Each is pinned here by a test that FAILS against the code as
+ * it stood before the fix — the point of the exercise, since a test that passes
+ * either way would have let all three back in.
+ */
+describe('extreme finite geometry (round 3)', () => {
+	it('keeps the pan bound finite when extent * scale would overflow', () => {
+		// Before the fix `fittedW * scale` was Infinity, so the bound was
+		// Infinity, so clampSymmetric left ANY offset untouched — the clamp
+		// silently stopped clamping and blank stage could show past the image.
+		const huge: Geometry = {
+			stageW: Number.MAX_VALUE,
+			stageH: 1000,
+			fittedW: Number.MAX_VALUE * 0.6,
+			fittedH: 800,
+			naturalW: Number.MAX_VALUE * 0.6,
+			naturalH: 800,
+		};
+		const out = clampPan({ scale: 2, x: Number.MAX_VALUE, y: 0 }, huge);
+		expect(Number.isFinite(out.x)).toBe(true);
+		expect(out.x).toBeLessThan(Number.MAX_VALUE);
+	});
+
+	it('does not let a subnormal fitted extent turn actualScale infinite', () => {
+		const subnormal: Geometry = {
+			stageW: 1000,
+			stageH: 1000,
+			fittedW: Number.MIN_VALUE,
+			fittedH: Number.MIN_VALUE,
+			naturalW: 4000,
+			naturalH: 4000,
+		};
+		expect(Number.isFinite(actualScale(subnormal))).toBe(true);
+	});
+
+	it('leaves the double-click toggle doing something visible on that geometry', () => {
+		// The regression this guards: an infinite actualScale reached zoomTo,
+		// clampScale rejected it as non-finite and fell back to fit, and the
+		// toggle became the silent no-op TOGGLE_SMALL_SCALE exists to prevent.
+		const subnormal: Geometry = {
+			stageW: 1000,
+			stageH: 1000,
+			fittedW: Number.MIN_VALUE,
+			fittedH: Number.MIN_VALUE,
+			naturalW: 4000,
+			naturalH: 4000,
+		};
+		const out = toggleFitOrActual(reset(), { x: 500, y: 500 }, subnormal);
+		expect(out.scale).toBeGreaterThan(FIT + FIT_EPSILON);
+	});
+});
+
+describe('the fit epsilon boundary is asymmetric, and cannot matter (round 3)', () => {
+	it('reads FIT + FIT_EPSILON as at-fit but FIT - FIT_EPSILON as not', () => {
+		// Neither value is exactly representable in binary; the subtraction lands
+		// a few ulps outside the window. Pinned rather than papered over.
+		expect(isAtFit({ scale: FIT + FIT_EPSILON, x: 0, y: 0 })).toBe(true);
+		expect(isAtFit({ scale: FIT - FIT_EPSILON, x: 0, y: 0 })).toBe(false);
+	});
+
+	it('cannot arise, because no emitted scale is ever below FIT', () => {
+		// This is what makes the asymmetry unobservable in practice. If the floor
+		// ever stops being FIT, this fails and the asymmetry becomes real.
+		const g: Geometry = {
+			stageW: 1000,
+			stageH: 800,
+			fittedW: 900,
+			fittedH: 700,
+			naturalW: 3600,
+			naturalH: 2800,
+		};
+		for (const attempt of [-99, 0, FIT - FIT_EPSILON, 0.5, Number.MIN_VALUE]) {
+			expect(clampScale(attempt, g)).toBeGreaterThanOrEqual(FIT);
+			expect(clampState({ scale: attempt, x: 0, y: 0 }, g).scale).toBeGreaterThanOrEqual(FIT);
+			expect(zoomTo(reset(), attempt, { x: 0, y: 0 }, g).scale).toBeGreaterThanOrEqual(FIT);
+		}
+	});
+});

--- a/web/src/lib/attachments/zoom.ts
+++ b/web/src/lib/attachments/zoom.ts
@@ -1,0 +1,403 @@
+/**
+ * Zoom / pan math for the attachment viewer — DOM-free, framework-free, and
+ * the single owner of every number the viewer's transform is built from
+ * (PLAN-2392 phase 3b / TASK-2454).
+ *
+ * WHY IT IS A SEPARATE MODULE. jsdom reports all-zero rects, so nothing that
+ * reads layout can be unit-tested there. Keeping the arithmetic here means the
+ * hard properties — anchor invariance, the pan bounds, the scale floor and
+ * ceiling — are provable without a browser, and the component (TASK-2455) is
+ * left with measuring, wiring and clamping on resize.
+ *
+ * TWO WORDS, ONE MEANING EACH.
+ *
+ *  - The **fitted box** is the rendered size `object-fit: contain` gives the
+ *    image inside the stage. The browser computes it; this module never
+ *    re-derives it from natural-image pixels.
+ *  - **fit** is `scale === 1`, i.e. {@link FIT}. There is no third quantity
+ *    called a "fit scale" — conflating the two is what put the CSS and the
+ *    module in different coordinate systems in an early revision of the design.
+ *
+ * THE COORDINATE SYSTEM. The stage is a box sized as the old bare `<img>` was
+ * (92vw x 92vh, centred), with the `<img>` inside it at `max-width: 100%;
+ * max-height: 100%; object-fit: contain`. The transform is
+ *
+ *     translate(<x>px, <y>px) scale(<scale>)      transform-origin: center
+ *
+ * so a point sitting `d` CSS px from the image's centre (measured in UNSCALED
+ * fitted-box px) paints at
+ *
+ *     stageCentre + (x, y) + scale * d
+ *
+ * At `scale === 1, x === 0, y === 0` that is byte-identical to today's
+ * rendering — the parity property the phase is built around.
+ *
+ * All exported functions are pure: none mutates its arguments, and every one
+ * that returns a {@link ZoomState} returns a fresh object.
+ *
+ * TWO PROPERTIES CONSUMERS MUST NOT ASSUME, both consequences of clamping every
+ * result rather than tracking an unclamped shadow state:
+ *
+ *  - **A gesture is not associative.** Ten small {@link zoomTo} steps do not
+ *    equal one big one once a pan bound is reached — the intermediate results
+ *    were clamped and the excess is gone. So a DRAG must be computed from the
+ *    state captured at pointer-down plus the total pointer delta, never by
+ *    feeding each `pointermove` delta into the previous clamped result:
+ *    overshooting a bound and coming back would otherwise move the image
+ *    immediately instead of taking up the slack (TASK-2458).
+ *  - **Clamping is lossy.** Pan discarded because the stage shrank does not come
+ *    back when it grows again. A consumer that wants that must keep its own
+ *    unclamped intent; the viewer deliberately does not (TASK-2455).
+ *
+ * NOTHING HERE ROUNDS. Geometry arrives fractional on any non-integer
+ * `devicePixelRatio` (the browser lays elements out on device-pixel boundaries,
+ * which are not CSS-pixel boundaries at dpr 1.25 / 1.5 / 2.75), and rounding
+ * intermediate values there drifts the anchored point visibly across a sequence
+ * of zoom steps.
+ */
+
+/**
+ * The measured geometry of one painted image, in CSS px.
+ *
+ * Every field is expected finite and positive — a caller with no decoded bitmap
+ * has nothing to zoom and does not call in at all (TASK-2460 keeps the
+ * transform inert until one exists). The functions below are nevertheless
+ * defensive about zeros and non-finite values, because geometry is read from
+ * live layout and a mid-teardown measurement can produce either; a degenerate
+ * geometry must still yield a finite, in-bounds transform — never `NaN` or
+ * `Infinity` in a CSS string.
+ *
+ * MEASURING `fittedW/H` (TASK-2455). They are the image's UNSCALED box, so they
+ * cannot come from `getBoundingClientRect()` on the transformed `<img>` — that
+ * returns the box AFTER `scale()`, and feeding it back in would make the bounds
+ * grow with the zoom. Read the untransformed layout box (`offsetWidth` /
+ * `offsetHeight`, which transforms do not affect), or measure once at fit.
+ */
+export interface Geometry {
+	/** Stage box width. */
+	stageW: number;
+	/** Stage box height. */
+	stageH: number;
+	/** Rendered image width at `scale === 1`. Never exceeds `stageW`. */
+	fittedW: number;
+	/** Rendered image height at `scale === 1`. Never exceeds `stageH`. */
+	fittedH: number;
+	/**
+	 * The CURRENTLY PAINTED bitmap's intrinsic width — not the original's.
+	 * While only a `thumb-md` variant has decoded, "actual size" means 1:1 with
+	 * the thumb, and {@link maxScale} grows when the original swaps in
+	 * (TASK-2459). NOTE: this is not the mobile fetch trigger; that trigger is
+	 * `scale > 1`, i.e. past fit (TASK-2460).
+	 */
+	naturalW: number;
+	/** The currently painted bitmap's intrinsic height. See {@link Geometry.naturalW}. */
+	naturalH: number;
+}
+
+/** A point in stage-local CSS px, measured from the stage's top-left corner. */
+export interface Point {
+	x: number;
+	y: number;
+}
+
+/**
+ * The viewer's transform state.
+ *
+ * `scale` is relative to fit, which is what makes {@link FIT} a constant rather
+ * than a derived quantity. `x` / `y` are the image centre's offset from the
+ * stage centre in CSS px.
+ */
+export interface ZoomState {
+	scale: number;
+	x: number;
+	y: number;
+}
+
+/**
+ * `scale` at fit — the floor {@link clampScale} and {@link clampState} enforce.
+ *
+ * Not enforced by {@link clampPan}, which passes any finite scale through so it
+ * stays orthogonal to the scale bounds; use {@link clampState} when both matter.
+ */
+export const FIT = 1;
+
+/** {@link maxScale} is this multiple of 1:1 (or of fit, whichever is larger). */
+export const MAX_SCALE_FACTOR = 4;
+
+/**
+ * Where {@link toggleFitOrActual} goes when the image is already at 1:1 at fit
+ * (an image smaller than the stage: `object-fit: contain` never upscales, so
+ * fit IS actual size). Without this, double-click would be a no-op on exactly
+ * the images where a user is most likely to try it.
+ */
+export const TOGGLE_SMALL_SCALE = 2;
+
+/**
+ * How close to {@link FIT} still counts as "at fit" for {@link isAtFit} and
+ * therefore for {@link toggleFitOrActual}'s direction.
+ *
+ * A tolerance rather than an equality test because a wheel or pinch gesture
+ * lands on 1.0000000002 routinely, and a double-click there must zoom IN, not
+ * perform a visually-invisible reset.
+ */
+export const FIT_EPSILON = 0.001;
+
+/**
+ * The multiplicative step for one discrete zoom command — the `+` / `-` keys
+ * (TASK-2455). Exported so no call site re-types the literal.
+ */
+export const ZOOM_STEP = 1.25;
+
+/**
+ * Coerce a possibly-NaN/Infinite measurement to something usable.
+ *
+ * Infinity takes the fallback rather than saturating at a bound: an infinite
+ * scale or offset is always a caller-side arithmetic bug (a pinch handler
+ * dividing by a zero pointer distance is the likely one), and quietly snapping
+ * it to maximum zoom hides the bug behind plausible-looking behaviour, where
+ * falling back to the neutral value shows it.
+ */
+function finiteOr(value: number, fallback: number): number {
+	return Number.isFinite(value) ? value : fallback;
+}
+
+/**
+ * Clamp to `[-bound, bound]`, normalising negative zero away.
+ *
+ * `Math.max(-0, -5)` is `-0`, so a centred axis would otherwise emit
+ * `translate(-0px)` and, more importantly, make `Object.is(x, 0)` false for a
+ * value this module documents as exactly zero.
+ *
+ * It deliberately does NOT re-guard a negative bound: {@link panBound} is the
+ * single owner of the centring rule, and a second copy of it here would make
+ * that one untestable — breaking the real rule would look correct because this
+ * function silently repaired it.
+ */
+function clampSymmetric(value: number, bound: number): number {
+	const clamped = Math.min(bound, Math.max(-bound, value));
+	return clamped === 0 ? 0 : clamped;
+}
+
+/** True only for a measurement that can be divided by. */
+function usable(value: number): boolean {
+	return Number.isFinite(value) && value > 0;
+}
+
+/**
+ * The largest extent any axis is allowed to claim, in CSS px.
+ *
+ * Ten million px is four orders of magnitude past any layout a browser will
+ * produce (the widest real stage is a few thousand), and its purpose is purely
+ * arithmetic: it makes `extent * scale` unable to overflow to `Infinity`.
+ *
+ * That overflow is not cosmetic. {@link panBound} subtracts the stage from the
+ * scaled extent, and `Infinity - stage` is `Infinity`, so the pan bound becomes
+ * infinite and the clamp silently stops clamping — the one failure mode that
+ * lets blank stage show past an image edge. Saturating the inputs instead keeps
+ * every bound finite and ordered.
+ */
+const MAX_EXTENT = 1e7;
+
+/** Saturate a measurement into `[0, MAX_EXTENT]` so products cannot overflow. */
+function saneExtent(value: number): number {
+	const v = finiteOr(value, 0);
+	if (v <= 0) return 0;
+	return v > MAX_EXTENT ? MAX_EXTENT : v;
+}
+
+/** The stage's centre, in stage-local px. The anchor for centre-origin zooms. */
+export function stageCenter(g: Geometry): Point {
+	return {
+		x: finiteOr(g.stageW, 0) / 2,
+		y: finiteOr(g.stageH, 0) / 2,
+	};
+}
+
+/**
+ * The `scale` at which the painted bitmap is displayed 1:1 with its own pixels.
+ *
+ * Measured on the WIDTH axis, as the contract specifies. `object-fit: contain`
+ * preserves the aspect ratio, so for any geometry the browser actually produces
+ * the height ratio is the same number; a hand-built non-uniform `Geometry` is
+ * the only way to make them disagree, and the width pair wins there.
+ *
+ * `object-fit: contain` never upscales, so an image smaller than the stage has
+ * `fittedW === naturalW` and this returns exactly 1 — fit already IS actual
+ * size for it.
+ */
+export function actualScale(g: Geometry): number {
+	if (!usable(g.fittedW) || !usable(g.naturalW)) return FIT;
+	const ratio = g.naturalW / g.fittedW;
+	// A subnormal `fittedW` divides to `Infinity` even though both inputs passed
+	// `usable`. Returning it would not merely be untidy: `toggleFitOrActual`
+	// hands this value straight to `zoomTo`, whose `clampScale` treats a
+	// non-finite target as invalid and falls back to fit — turning the toggle
+	// into the silent no-op the small-image rule exists to prevent. Falling back
+	// to FIT here instead routes that geometry to TOGGLE_SMALL_SCALE, so the
+	// gesture still does something visible.
+	return Number.isFinite(ratio) ? ratio : FIT;
+}
+
+/**
+ * The upper bound on `scale`, i.e. the contract's `MAX_SCALE(g)`.
+ *
+ * `max(actualScale, 1)` rather than `actualScale` so a small image — whose
+ * actual scale is 1 — still gets a real zoom range instead of being pinned at
+ * fit, and so a nonsensical sub-1 actual scale can never invert the bounds.
+ */
+export function maxScale(g: Geometry): number {
+	const ceiling = Math.max(actualScale(g), FIT) * MAX_SCALE_FACTOR;
+	// A finite ratio can still overflow when multiplied: a bitmap reported at
+	// Number.MAX_VALUE px gives a finite actual scale and an infinite ceiling,
+	// which would silently disable the scale clamp entirely.
+	return Number.isFinite(ceiling) ? ceiling : Number.MAX_VALUE;
+}
+
+/** Clamp a scale into `[FIT, maxScale(g)]`. */
+export function clampScale(scale: number, g: Geometry): number {
+	const max = maxScale(g);
+	const s = finiteOr(scale, FIT);
+	if (s < FIT) return FIT;
+	if (s > max) return max;
+	return s;
+}
+
+/** The largest `|offset|` an axis may take before a stage edge shows past the image. */
+function panBound(stageExtent: number, fittedExtent: number, scale: number): number {
+	// Saturated, not merely finiteness-checked: the product is what overflows,
+	// and a finite `fittedExtent` near Number.MAX_VALUE times a finite scale is
+	// still `Infinity`, which would make the bound infinite and disable the
+	// clamp entirely.
+	const stage = saneExtent(stageExtent);
+	const scaled = saneExtent(saneExtent(fittedExtent) * finiteOr(scale, FIT));
+	// An axis that does not overflow the stage is CENTRED, not free to roam.
+	if (scaled <= stage) return 0;
+	return (scaled - stage) / 2;
+}
+
+/**
+ * Clamp the pan offsets for the state's own scale.
+ *
+ * Per axis: if the scaled extent is at most the stage, the offset is forced to
+ * 0 — a smaller-than-stage axis is CENTRED, never draggable. Otherwise the
+ * offset is bounded so no stage edge can show past the image edge.
+ *
+ * `scale` is passed through untouched (only sanitised for finiteness) — clamping
+ * it is {@link clampScale}'s job, and {@link clampState} composes the two in the
+ * order a resize needs.
+ */
+export function clampPan(state: ZoomState, g: Geometry): ZoomState {
+	const scale = finiteOr(state.scale, FIT);
+	const bx = panBound(g.stageW, g.fittedW, scale);
+	const by = panBound(g.stageH, g.fittedH, scale);
+	const x = finiteOr(state.x, 0);
+	const y = finiteOr(state.y, 0);
+	return {
+		scale,
+		x: clampSymmetric(x, bx),
+		y: clampSymmetric(y, by),
+	};
+}
+
+/**
+ * Clamp scale FIRST, then pan — the order a geometry change requires.
+ *
+ * `maxScale` is geometry-dependent and geometry is viewport-dependent, so
+ * ENLARGING the window lowers `actualScale` and with it `maxScale`, stranding a
+ * previously-valid scale above the new ceiling. Clamping pan first would bound
+ * it against a scale that is about to change (TASK-2455).
+ */
+export function clampState(state: ZoomState, g: Geometry): ZoomState {
+	return clampPan({ ...state, scale: clampScale(state.scale, g) }, g);
+}
+
+/**
+ * Zoom to `targetScale` keeping the image point currently under `anchor` under
+ * `anchor` afterwards.
+ *
+ * The invariant, with `u` the anchor relative to the stage centre and
+ * `k = newScale / oldScale`:
+ *
+ *     t' = u - k * (u - t)
+ *
+ * Anchor invariance holds exactly UNLESS the result has to be pan-clamped —
+ * the bounds win, because letting the anchor survive would mean showing blank
+ * stage past an image edge. A non-finite anchor falls back to the stage centre.
+ *
+ * The incoming state is normalised through {@link clampState} first, so the
+ * invariant is stated against a VALID starting state. Clamping the incoming
+ * scale while trusting its pan would mix a pan belonging to one scale with
+ * another, and the invariant would then be false for the one caller shape most
+ * likely to hit it — a geometry change that lowered the ceiling under a state
+ * the consumer has not re-clamped yet.
+ */
+export function zoomTo(
+	state: ZoomState,
+	targetScale: number,
+	anchor: Point,
+	g: Geometry,
+): ZoomState {
+	const current = clampState(state, g);
+	const from = current.scale;
+	const to = clampScale(targetScale, g);
+	const centre = stageCenter(g);
+	const ux = finiteOr(anchor?.x, centre.x) - centre.x;
+	const uy = finiteOr(anchor?.y, centre.y) - centre.y;
+	// `from` came out of clampScale, so it is at least FIT — never a zero divide.
+	const k = to / from;
+	const x = ux - k * (ux - current.x);
+	const y = uy - k * (uy - current.y);
+	return clampPan({ scale: to, x, y }, g);
+}
+
+/**
+ * Whether `state` is at fit, within {@link FIT_EPSILON}.
+ *
+ * ASYMMETRIC AT THE BOUNDARY, AND DELIBERATELY LEFT SO. `FIT + FIT_EPSILON`
+ * reads as at-fit while `FIT - FIT_EPSILON` does not, because neither value is
+ * exactly representable in binary and the subtraction lands a few ulps outside
+ * the window. Widening the comparison to hide that would be papering over an
+ * unreachable case: every scale this module emits has been through
+ * {@link clampScale}, whose floor is FIT, so a sub-fit state cannot arise from
+ * any sequence of operations on it. The asymmetry is only observable on a
+ * hand-constructed state, and both legs are pinned by tests so a future change
+ * to the floor cannot make it matter silently.
+ */
+export function isAtFit(state: ZoomState): boolean {
+	return Math.abs(finiteOr(state.scale, FIT) - FIT) <= FIT_EPSILON;
+}
+
+/**
+ * The double-click / double-tap toggle: fit <-> actual size.
+ *
+ * At fit (within {@link FIT_EPSILON}) it goes to {@link actualScale} anchored at
+ * `anchor`; anywhere else it goes back to fit, centred. When actual size IS fit
+ * — an image smaller than the stage — it goes to {@link TOGGLE_SMALL_SCALE}
+ * instead, so the gesture always does something visible.
+ *
+ * DELIBERATE GENERALISATION OF THE CONTRACT. The written rule says "when
+ * `actualScale === 1`, go to {@link TOGGLE_SMALL_SCALE}"; this uses
+ * `actualScale <= FIT + FIT_EPSILON` instead. Exact equality serves the rule's
+ * PURPOSE only on integer geometry — at a fractional `devicePixelRatio` a 1:1
+ * image measures 1.0000000004 and at a rounded layout it can measure 1.0005,
+ * and a toggle to either is a zoom of at most 0.05%: invisible, i.e. exactly
+ * the no-op the rule exists to prevent. The epsilon is the same one
+ * {@link isAtFit} uses, so "already at fit" and "actual size is fit" cannot
+ * disagree about the same image.
+ */
+export function toggleFitOrActual(state: ZoomState, anchor: Point, g: Geometry): ZoomState {
+	if (!isAtFit(state)) return reset();
+	const actual = actualScale(g);
+	const target = actual > FIT + FIT_EPSILON ? actual : TOGGLE_SMALL_SCALE;
+	return zoomTo(state, target, anchor, g);
+}
+
+/**
+ * The identity transform: fit, centred.
+ *
+ * Takes no geometry, which is precisely what makes it safe to call before a
+ * bitmap exists — on open, on image change, and on close (TASK-2455).
+ */
+export function reset(): ZoomState {
+	return { scale: FIT, x: 0, y: 0 };
+}

--- a/web/src/lib/collections/paneFocus.svelte.test.ts
+++ b/web/src/lib/collections/paneFocus.svelte.test.ts
@@ -5,6 +5,7 @@ import {
 	nextTrapTarget,
 	resolvePaneReturnTarget,
 	inExemptSurface,
+	handoffFocus,
 } from './paneFocus';
 
 // jsdom has no layout engine, so `offsetParent` / `getClientRects` can't gate
@@ -207,5 +208,120 @@ describe('resolvePaneReturnTarget', () => {
 	it('returns null when there is neither a focused row nor a live trigger', () => {
 		const root = mount(`<a href="/a" class="item-card">a</a>`);
 		expect(resolvePaneReturnTarget(root, null)).toBeNull();
+	});
+});
+
+describe('handoffFocus (TASK-2456)', () => {
+	// The modal-focus-retention helper: when a focused control leaves a surface
+	// (removed or disabled), focus must not fall to <body> behind the inerted
+	// background. Two shapes — reactive (no `departing`, repair after the fact)
+	// and imperative (pass `departing`, hand off before removal/disable).
+
+	it('CONTROL: without the handoff, removing a focused control strands focus on <body>', () => {
+		// The defect the helper exists to fix, proven real in this environment so
+		// the positive legs below are not vacuous: jsdom (like a real engine) drops
+		// focus to <body> when the focused element is removed.
+		const el = mount(`<button id="close">close</button><button id="next">next</button>`);
+		const next = document.getElementById('next')!;
+		next.focus();
+		expect(document.activeElement).toBe(next);
+		next.remove();
+		expect(document.activeElement).toBe(document.body);
+	});
+
+	it('reactive shape: pulls focus off <body> back to the first tabbable fallback', () => {
+		const el = mount(`<button id="close">close</button><button id="next">next</button>`);
+		const next = document.getElementById('next')!;
+		next.focus();
+		next.remove();
+		expect(document.activeElement).toBe(document.body);
+
+		handoffFocus(el, null, allVisible);
+		expect(document.activeElement).toBe(document.getElementById('close'));
+	});
+
+	it('reactive shape: leaves a live focus INSIDE the surface untouched', () => {
+		// Only repairs a focus that has LEFT the surface — a focus resting on a
+		// real control must not be yanked to the first tabbable.
+		const el = mount(`<button id="close">close</button><button id="next">next</button>`);
+		const close = document.getElementById('close')!;
+		close.focus();
+		handoffFocus(el, null, allVisible);
+		expect(document.activeElement).toBe(close);
+	});
+
+	it('imperative shape: hands focus off a control about to be DISABLED, never back onto it', () => {
+		// A real engine drops focus to <body> the instant a focused control is
+		// disabled; jsdom keeps it there, so the imperative shape blurs explicitly
+		// while the control still holds focus. This is the call TASK-2459/2460 make
+		// before setting `disabled` on their retry / tap-to-load control.
+		//
+		// The departing control is ordered FIRST on purpose: it is `paneFocusables()
+		// [0]`, so a fallback that did not EXCLUDE it would re-select the very
+		// control about to be disabled — dropping focus to <body> on a real engine.
+		const el = mount(`<button id="retry">retry</button><button id="close">close</button>`);
+		const retry = document.getElementById('retry') as HTMLButtonElement;
+		retry.focus();
+		expect(document.activeElement).toBe(retry);
+
+		handoffFocus(el, retry, allVisible);
+		// The caller now DISABLES the control it just handed focus off — the exact
+		// sequence TASK-2459/2460 run. On a real engine this is the step that would
+		// drop focus to <body> had it still been on `retry`; because the handoff
+		// moved focus to Close first, the disable is now harmless.
+		retry.disabled = true;
+		expect(document.activeElement).toBe(document.getElementById('close'));
+		expect(document.activeElement).not.toBe(retry);
+		expect(document.activeElement).not.toBe(document.body);
+	});
+
+	it('imperative shape: falls back to the container when the departing control is the ONLY tabbable', () => {
+		// Mid-load a viewer's tap-to-load / retry control can be the only focusable
+		// thing. Handing off before disabling it must NOT re-select it (→ <body> on
+		// disable) — it lands on the container (`tabindex="-1"`), still inside the
+		// surface.
+		const el = mount(`<button id="tap">tap to load</button>`);
+		el.tabIndex = -1;
+		const tap = document.getElementById('tap') as HTMLButtonElement;
+		tap.focus();
+		handoffFocus(el, tap, allVisible);
+		expect(document.activeElement).toBe(el);
+		expect(document.activeElement).not.toBe(tap);
+	});
+
+	it('imperative shape: no-op when the departing control is not the focused one', () => {
+		const el = mount(`<button id="close">close</button><button id="next">next</button>`);
+		const close = document.getElementById('close')!;
+		close.focus();
+		const next = document.getElementById('next')!;
+		handoffFocus(el, next, allVisible);
+		expect(document.activeElement).toBe(close);
+	});
+
+	it('drops to the container when the preferred fallback REFUSES focus (inert / hidden)', () => {
+		// jsdom cannot reproduce inert (it always focuses), so stub the close
+		// button's focus() to no-op — the real-engine shape of a fallback that sits
+		// under an inert / hidden ancestor. Focus must still land INSIDE the surface
+		// (the tabindex="-1" container), never on <body>.
+		const el = mount(`<button id="close">close</button><button id="next">next</button>`);
+		el.tabIndex = -1;
+		const next = document.getElementById('next')!;
+		next.focus();
+		next.remove();
+		const close = document.getElementById('close') as HTMLButtonElement;
+		close.focus = () => {}; // refuses focus, like an inert control
+		handoffFocus(el, null, allVisible);
+		expect(document.activeElement).toBe(el);
+		expect(document.activeElement).not.toBe(document.body);
+	});
+
+	it('falls back to the container itself when it has no tabbable control', () => {
+		// Mid-load a viewer can have no focusable control yet; the container is
+		// `tabindex="-1"` so focus still lands inside the surface, never on <body>.
+		const el = mount(`<span>loading…</span>`);
+		el.tabIndex = -1;
+		expect(document.activeElement).toBe(document.body);
+		handoffFocus(el, null, allVisible);
+		expect(document.activeElement).toBe(el);
 	});
 });

--- a/web/src/lib/collections/paneFocus.ts
+++ b/web/src/lib/collections/paneFocus.ts
@@ -4,7 +4,10 @@
  * Split out of `[collection]/+page.svelte` so the DOM-selection and
  * focus-trap-cycle logic is unit testable without a full component mount
  * (mirrors `paneUrlParams` / `boardNav`). The `.svelte` side owns the effects
- * that install/tear these down; this module is pure, side-effect-free DOM math.
+ * that install/tear these down; the selection + cycle helpers are pure DOM math.
+ * The one exception is {@link handoffFocus}, which deliberately MOVES focus (its
+ * whole job) — the `.svelte` side calls it from an effect, but it is exported
+ * here so it lives with the focus math it builds on.
  */
 
 /**
@@ -111,6 +114,72 @@ export function nextTrapTarget(
 	}
 	if (active === last || !inside) return first;
 	return null;
+}
+
+/**
+ * Keep focus INSIDE a modal surface when a focused control leaves it — is
+ * removed from the DOM, or becomes `disabled` (PLAN-2392 / TASK-2456).
+ *
+ * `aria-modal="true"` promises focus never escapes the surface while it is open,
+ * yet a conditionally-rendered control that had focus drops focus to `<body>`
+ * when it unmounts, and a control that becomes `disabled` does the same on a real
+ * engine — landing focus BEHIND the surface's own inerted background. Neither the
+ * Tab trap (fires only on a later Tab) nor the teardown restore (only at close)
+ * repairs that gap; this does, moving focus to the surface's stable fallback.
+ *
+ * Two call shapes, one helper (the house pattern from
+ * `editor/attachment-image.ts` — blur the departing control, focus its
+ * replacement):
+ *
+ *  - BEFORE an imperative removal/disable, pass the `departing` control: if it
+ *    currently holds focus it is blurred and focus moves to the fallback. This
+ *    is the shape TASK-2459's retry and TASK-2460's tap-to-load use (a real
+ *    engine drops focus to `<body>` the instant a focused control is disabled,
+ *    so the handoff must run while the control is still focused).
+ *  - AFTER a reactive removal (a Svelte `{#if}` dropped the control), pass no
+ *    `departing`: if focus has ALREADY fallen out of `container`, it is pulled
+ *    back within the same synchronous flush, so `<body>` is never observably
+ *    focused. A focus still resting on a live control inside `container` is left
+ *    untouched.
+ *
+ * The fallback is the first tabbable control (for the viewer, its close button),
+ * else `container` itself — the same target entry focus uses, so it is always
+ * reachable even mid-load with no other control yet.
+ */
+export function handoffFocus(
+	container: HTMLElement,
+	departing: Element | null = null,
+	isVisible: (el: HTMLElement) => boolean = isFocusableVisible,
+): void {
+	if (typeof document === 'undefined') return;
+	const active = document.activeElement;
+	// Imperative (departing given): act only while that control still owns focus,
+	// so a handoff for a control the user already left is a no-op. Reactive (no
+	// departing): act only once focus has left the surface — a live focus inside
+	// it is fine and must not be yanked to the fallback.
+	const leaving =
+		departing !== null
+			? active === departing
+			: active === null || active === document.body || !container.contains(active);
+	if (!leaving) return;
+	if (departing instanceof HTMLElement) departing.blur();
+	// EXCLUDE `departing` from the candidates: in the imperative shape it is still
+	// enabled and in the DOM at call time (the caller disables/removes it AFTER
+	// this), so a departing control that is the first — or only — tabbable would
+	// otherwise be re-selected here and then dropped to <body> the instant the
+	// caller disables it. When it is the only one, fall through to the container.
+	const fallback =
+		paneFocusables(container, isVisible).find((el) => el !== departing) ?? container;
+	fallback.focus({ preventScroll: true });
+	// Verify it took, then drop to the container — the same verified-restore
+	// pattern the viewer uses on close. `paneFocusables`' visibility filter is
+	// geometry-only, so it cannot see that a candidate sits under `inert` /
+	// `visibility: hidden` (a real engine refuses focus there); if the preferred
+	// target refuses, the container (a `tabindex="-1"` surface root) still keeps
+	// focus INSIDE the surface rather than letting it fall to <body>.
+	if (fallback !== container && document.activeElement !== fallback) {
+		container.focus({ preventScroll: true });
+	}
 }
 
 /**

--- a/web/src/lib/components/common/Lightbox.svelte
+++ b/web/src/lib/components/common/Lightbox.svelte
@@ -35,7 +35,9 @@
 	import {
 		reset as resetZoom,
 		clampState,
+		clampPan,
 		zoomTo,
+		toggleFitOrActual,
 		stageCenter,
 		ZOOM_STEP,
 		type Geometry,
@@ -228,6 +230,7 @@
 		const g = readGeometry();
 		if (!g) return;
 		zoom = zoomTo(zoom, zoom.scale * factor, stageCenter(g), g);
+		rebaseDrag(); // keyboard zoom mid-drag must not desync the pan baseline
 	}
 
 	// Wheel / ctrl-cmd-wheel zoom, anchored at the CURSOR (TASK-2457 / DR-4). Both
@@ -258,6 +261,254 @@
 		// Wheel up / away (deltaY < 0) zooms in.
 		const factor = e.deltaY < 0 ? ZOOM_STEP : 1 / ZOOM_STEP;
 		zoom = zoomTo(zoom, zoom.scale * factor, anchor, g);
+		// A wheel DURING a captured drag just moved `zoom.{x,y}` from this pointer
+		// position — rebase so the next pointermove continues from here.
+		lastClientX = e.clientX;
+		lastClientY = e.clientY;
+		rebaseDrag();
+	}
+
+	// ── Double-click toggle + drag-to-pan (PLAN-2392 / TASK-2458) ────────────
+	//
+	// Desktop single-pointer half of the drag-pan work (3d keeps two-pointer
+	// pinch, double-TAP and touch semantics). Modelled on the captured-drag house
+	// pattern at `graph/ItemGraph.svelte` — arm on pointerdown, capture only once a
+	// real drag engages (capturing on down would swallow the dblclick), re-check
+	// the arbitration gates on every move so a gesture that STRADDLES a
+	// frontmost/modal change aborts instead of panning an image the user no longer
+	// owns, and suppress the synthesized click a pan produces.
+	const DRAG_THRESHOLD = 4; // CSS px below which the gesture is a click, not a pan
+	let maybeDrag = false;
+	// `$state` so the template can drop the transform TRANSITION while dragging —
+	// otherwise the image eases toward each pan target and visibly trails the
+	// pointer. Read/written only in pointer handlers (never an $effect's tracked
+	// scope), so no CONVE-1688 self-write.
+	let dragging = $state(false);
+	let suppressClick = false;
+	let capturedPointerId: number | null = null;
+	// The pointer that OWNS the current gesture, captured at pointerdown. Every
+	// later move/up/cancel/lost must come from it: a touch or a second pointer
+	// (pen) is not captured, so its events still reach this root and would
+	// otherwise engage or terminate an in-flight mouse drag (touch stays native
+	// until 3d).
+	let gesturePointerId: number | null = null;
+	let dragStartClientX = 0;
+	let dragStartClientY = 0;
+	let dragOriginX = 0; // zoom.x at drag baseline
+	let dragOriginY = 0; // zoom.y at drag baseline
+	let lastClientX = 0; // last pointer position seen during the gesture
+	let lastClientY = 0;
+
+	// Re-baseline the gesture to the CURRENT zoom + last pointer position. The drag
+	// computes `origin + total delta`, so anything that moves `zoom.{x,y}` from
+	// OUTSIDE the drag — wheel, `+`/`-`/`0` keys, a resize re-clamp — must rebase,
+	// or the next move snaps the pan back to the pre-change origin (a visible jump).
+	// Rebases an ARMED gesture too (not only a live drag): a zoom that lands
+	// between pointerdown and the drag threshold would otherwise leave the engage
+	// baseline stale. A no-op when no gesture is in flight.
+	function rebaseDrag(): void {
+		if (!maybeDrag && !dragging) return;
+		dragOriginX = zoom.x;
+		dragOriginY = zoom.y;
+		dragStartClientX = lastClientX;
+		dragStartClientY = lastClientY;
+	}
+	// A SINGLE owned timer for clearing `suppressClick`, so an EARLIER gesture's
+	// pending clear can never fire during a LATER one and unsuppress its pan's
+	// click. `cancelSuppressClear` runs whenever a new gesture is armed or a drag
+	// engages (the flag is held true for the whole drag); `armSuppressClear` runs
+	// once at the END of a pan to drop it on the next tick, after the synthesized
+	// click has been (and gone).
+	let suppressClickTimer: ReturnType<typeof setTimeout> | null = null;
+	function cancelSuppressClear(): void {
+		if (suppressClickTimer !== null) {
+			clearTimeout(suppressClickTimer);
+			suppressClickTimer = null;
+		}
+	}
+	function armSuppressClear(): void {
+		suppressClick = true;
+		cancelSuppressClear();
+		suppressClickTimer = setTimeout(() => {
+			suppressClick = false;
+			suppressClickTimer = null;
+		}, 0);
+	}
+
+	// The same gates `onKeydown` / `onWheel` carry: only the frontmost, non-blocked
+	// viewer owns the pointer. Applied at EVERY entry point (down / move / up /
+	// dblclick / backdrop click), not just the start.
+	function pointerGatesOpen(el: HTMLElement): boolean {
+		return isViewerFrontmost(el) && !isBlockedByModal(el);
+	}
+
+	function releaseCapture(e: PointerEvent): void {
+		if (capturedPointerId !== null) {
+			try {
+				(e.currentTarget as Element).releasePointerCapture(capturedPointerId);
+			} catch {
+				// already released — ignore.
+			}
+			capturedPointerId = null;
+		}
+	}
+
+	// Tear a gesture down mid-flight: release the capture (an early return alone
+	// would leave the pointer captured and `dragging` latched, still delivering
+	// moves), and — if a real pan was underway — still swallow the click it
+	// produces. The transform is LEFT WHERE IT WAS (the abort does not undo pan).
+	function abortGesture(e: PointerEvent): void {
+		const wasDragging = dragging;
+		maybeDrag = false;
+		dragging = false;
+		gesturePointerId = null;
+		releaseCapture(e);
+		if (wasDragging) armSuppressClear();
+	}
+
+	function onPointerDown(e: PointerEvent) {
+		if (e.button !== 0) return; // primary button only
+		if (e.pointerType === 'touch') return; // touch stays native until 3d
+		// A second pointer (a pen, say) pressing mid-drag must NOT seize the gesture:
+		// re-arming below would replace `gesturePointerId` and hand the pan to the
+		// interloper. An active drag is owned until its own pointer releases.
+		if (dragging) return;
+		// A new primary press supersedes any STALE armed gesture — one whose
+		// pointerup was missed off-root (no capture yet, so it was never delivered).
+		// Clear it before any early return below, or a later control / gated press
+		// leaves `maybeDrag` latched and the next move engages a phantom drag from a
+		// dead baseline. (We already returned above if a drag is live.)
+		maybeDrag = false;
+		// A press ON a control (close / nav) is that control's click, never a pan:
+		// arming here would let a drag OFF a button still fire its click, since the
+		// buttons' own handlers don't consult `suppressClick` (the house pattern in
+		// ItemGraph excludes its interactive overlays the same way).
+		if ((e.target as Element | null)?.closest?.('.lightbox-close, .lightbox-nav')) return;
+		const el = rootEl;
+		if (!el || !pointerGatesOpen(el)) return; // START gate
+		maybeDrag = true;
+		dragging = false;
+		gesturePointerId = e.pointerId;
+		suppressClick = false;
+		cancelSuppressClear(); // a fresh gesture — drop any prior pan's pending clear
+		dragStartClientX = e.clientX;
+		dragStartClientY = e.clientY;
+		lastClientX = e.clientX;
+		lastClientY = e.clientY;
+		// Capture the pan origin from the state at pointer-down, so every move
+		// computes origin + TOTAL delta — never delta-of-delta, which the zoom
+		// module warns loses the slack at a bound (its "gesture is not associative"
+		// note). No `setPointerCapture` yet: capturing here would swallow dblclick.
+		dragOriginX = zoom.x;
+		dragOriginY = zoom.y;
+	}
+
+	function onPointerMove(e: PointerEvent) {
+		if (!maybeDrag) return;
+		if (e.pointerId !== gesturePointerId) return; // only the owning pointer drives
+		const el = rootEl;
+		// WHOLE-GESTURE arbitration: the press may have been captured before another
+		// viewer / a native modal became frontmost. Abort rather than early-return.
+		if (!el || !pointerGatesOpen(el)) {
+			abortGesture(e);
+			return;
+		}
+		// Primary button no longer held — a pointerup we never received (it ended
+		// off-target pre-capture, or was swallowed after a drag engaged). Tear the
+		// whole gesture down, not just `maybeDrag`: a full `abortGesture` also
+		// releases any capture and clears `dragging`, so nothing leaks into the next
+		// pointerdown (a bare `maybeDrag = false` left a live capture + `dragging`).
+		if ((e.buttons & 1) === 0) {
+			abortGesture(e);
+			return;
+		}
+		lastClientX = e.clientX;
+		lastClientY = e.clientY;
+		const dx = e.clientX - dragStartClientX;
+		const dy = e.clientY - dragStartClientY;
+		if (!dragging) {
+			if (Math.hypot(dx, dy) < DRAG_THRESHOLD) return;
+			dragging = true;
+			// This gesture is a pan, not a click: suppress until the drag ENDS. Held
+			// true for the whole drag; cancel any prior gesture's pending clear so it
+			// can't fire mid-pan and unsuppress us.
+			suppressClick = true;
+			cancelSuppressClear();
+			capturedPointerId = e.pointerId;
+			try {
+				(e.currentTarget as Element).setPointerCapture(e.pointerId);
+			} catch {
+				// capture unsupported/failed — panning still works while over the root
+			}
+		}
+		const g = readGeometry();
+		if (!g) return;
+		// Clamp PAN only — the drag never changes scale — from the captured origin
+		// plus the total delta. `clampPan` keeps a stage edge from showing past the
+		// image; at fit the bound is zero, so a drag is a no-op pan.
+		zoom = clampPan({ scale: zoom.scale, x: dragOriginX + dx, y: dragOriginY + dy }, g);
+	}
+
+	function onPointerUp(e: PointerEvent) {
+		if (!maybeDrag && !dragging) return; // not a gesture we started
+		if (e.pointerId !== gesturePointerId) return; // a foreign pointer can't end ours
+		const el = rootEl;
+		// Re-check on release too (spec): a gesture that straddled a
+		// frontmost/modal change aborts rather than finalising a pan.
+		if (!el || !pointerGatesOpen(el)) {
+			abortGesture(e);
+			return;
+		}
+		maybeDrag = false;
+		gesturePointerId = null;
+		if (dragging) {
+			dragging = false;
+			releaseCapture(e);
+			// Keep the click this pan produces swallowed, then clear on the next tick
+			// so a later genuine click is unaffected.
+			armSuppressClear();
+		}
+	}
+
+	function onPointerCancel(e: PointerEvent) {
+		if (!maybeDrag && !dragging) return; // no gesture to cancel
+		if (e.pointerId !== gesturePointerId) return;
+		abortGesture(e);
+	}
+
+	function onLostPointerCapture(e: PointerEvent) {
+		if (!maybeDrag && !dragging) return; // no gesture; ignore a stray capture-loss
+		if (e.pointerId !== gesturePointerId) return;
+		// Capture taken away (OS/browser, or our own release) — the gesture is over.
+		// Clear WITHOUT releasing (already gone); keep the click suppressed if a pan
+		// was underway. Idempotent with `onPointerUp`, which sets `dragging` false
+		// before releasing, so a release-driven event here is a no-op.
+		const wasDragging = dragging;
+		maybeDrag = false;
+		dragging = false;
+		capturedPointerId = null;
+		gesturePointerId = null;
+		if (wasDragging) armSuppressClear();
+	}
+
+	// Double-click toggles fit <-> actual size, anchored at the pointer
+	// (`toggleFitOrActual`). A pan suppresses its clicks, so a dblclick only fires
+	// on a genuine double-click, never after a drag.
+	function onDoubleClick(e: MouseEvent) {
+		// A pan just ended (its click is being swallowed) — don't also toggle: a
+		// gesture is either a drag or a double-click, never both. Same swallow the
+		// backdrop click consults.
+		if (suppressClick) return;
+		// A double-click ON a control (close / nav) is that control's, not a zoom
+		// toggle — without this, double-clicking Next navigates twice AND toggles.
+		if ((e.target as Element | null)?.closest?.('.lightbox-close, .lightbox-nav')) return;
+		const el = rootEl;
+		if (!el || !pointerGatesOpen(el)) return;
+		const g = readGeometry();
+		const rect = stageEl?.getBoundingClientRect();
+		if (!g || !rect) return;
+		const anchor = { x: e.clientX - rect.left, y: e.clientY - rect.top };
+		zoom = toggleFitOrActual(zoom, anchor, g);
 	}
 
 	// Stepped from `shownIndex`, not from `current`: after the set shrinks they
@@ -393,6 +644,12 @@
 		if (id === lastResetForId) return;
 		lastResetForId = id;
 		zoom = resetZoom();
+		// A drag live ACROSS the image change (arrow-nav mid-drag) is left with a
+		// stale baseline, and deliberately so: `resetZoom` is fit, where `clampPan`
+		// pins the pan to 0 for ANY baseline, so the next move can't jump; and the
+		// next wheel/keyboard zoom rebases via `rebaseDrag`. Re-seeding here would be
+		// unobservable — and calling `rebaseDrag` (which reads `zoom`) inside this
+		// `zoom`-writing effect would self-invalidate it (CONVE-1688).
 	});
 
 	// Re-clamp on stage resize. `maxScale` is geometry-dependent and geometry is
@@ -408,7 +665,10 @@
 		if (!stage || typeof ResizeObserver === 'undefined') return;
 		const ro = new ResizeObserver(() => {
 			const g = readGeometry();
-			if (g) zoom = clampState(zoom, g);
+			if (g) {
+				zoom = clampState(zoom, g);
+				rebaseDrag(); // a resize re-clamp mid-drag must not desync the baseline
+			}
 		});
 		ro.observe(stage);
 		return () => ro.disconnect();
@@ -520,6 +780,7 @@
 		} else if (e.key === '0') {
 			e.preventDefault();
 			zoom = resetZoom();
+			rebaseDrag(); // keyboard reset mid-drag must not desync the pan baseline
 		}
 		// NO Escape branch. See the registration above.
 	}
@@ -528,6 +789,16 @@
 	// controls have a different target, so they don't dismiss. This avoids
 	// putting a click handler (and its a11y burden) on the <img>.
 	function onBackdropClick(e: MouseEvent) {
+		// A pan that released here produced this click — a drag is not a dismissal
+		// (TASK-2458). A below-threshold press (still a click) leaves this false, so
+		// it still closes; a plain click on the backdrop closes as before.
+		if (suppressClick) return;
+		const el = rootEl;
+		// Same gates as every other pointer entry point. Background inertness makes
+		// the normal path unreachable, so this is robustness, not a live fix — but a
+		// pointer owner that skips the gates the keyboard owner carries is the drift
+		// that breeds the next BUG-2441.
+		if (!el || !pointerGatesOpen(el)) return;
 		if (e.target === e.currentTarget) onClose();
 	}
 </script>
@@ -549,6 +820,12 @@
 	aria-label={dialogLabel}
 	tabindex="-1"
 	onclick={onBackdropClick}
+	ondblclick={onDoubleClick}
+	onpointerdown={onPointerDown}
+	onpointermove={onPointerMove}
+	onpointerup={onPointerUp}
+	onpointercancel={onPointerCancel}
+	onlostpointercapture={onLostPointerCapture}
 >
 	<!--
 		Explicit `aria-label`s: the glyph IS the label otherwise ("✕", "‹", "›"),
@@ -598,11 +875,14 @@
 	-->
 	<div class="lightbox-stage" bind:this={stageEl}>
 		{#if img}
+			<!-- draggable=false: a native image drag would otherwise pre-empt the pan. -->
 			<img
 				bind:this={imgEl}
 				class="lightbox-image"
+				class:panning={dragging}
 				{src}
 				alt={img.alt || 'Attachment'}
+				draggable="false"
 				style="transform: translate({zoom.x}px, {zoom.y}px) scale({zoom.scale});"
 			/>
 		{/if}
@@ -658,6 +938,11 @@
 		background: rgba(0, 0, 0, 0.82);
 		backdrop-filter: blur(2px);
 		cursor: zoom-out;
+		/* A drag-to-pan surface: no text should get selected mid-drag (the counter
+		   is the only text, and it is not meant to be selectable). draggable=false
+		   on the <img> handles the image; this handles selection (TASK-2458). */
+		user-select: none;
+		-webkit-user-select: none;
 	}
 
 	.lightbox-stage {
@@ -688,6 +973,13 @@
 		pointer-events: auto;
 		transform-origin: center;
 		transition: transform 0.15s ease-out;
+	}
+
+	/* While DRAGGING, the image must track the pointer 1:1 — the easing transition
+	   would make it lag behind the cursor (TASK-2458). Discrete zoom (keys / wheel /
+	   double-click) keeps the transition. */
+	.lightbox-image.panning {
+		transition: none;
 	}
 
 	/* Reduced motion suppresses the TRANSITION only — the zoom still works

--- a/web/src/lib/components/common/Lightbox.svelte
+++ b/web/src/lib/components/common/Lightbox.svelte
@@ -230,6 +230,36 @@
 		zoom = zoomTo(zoom, zoom.scale * factor, stageCenter(g), g);
 	}
 
+	// Wheel / ctrl-cmd-wheel zoom, anchored at the CURSOR (TASK-2457 / DR-4). Both
+	// plain AND ctrl/cmd wheel zoom, so there is no modifier gate — but the
+	// listener is registered NON-PASSIVELY (see the effect below) so
+	// `preventDefault` takes effect: the inert page behind must not scroll, and
+	// ctrl/cmd+wheel must not trigger the browser's own page zoom. `stopPropagation`
+	// as well, so the page's scroll-restoration listener does not count this as a
+	// user scroll (belt; `restore.svelte.ts` also ignores viewer input — braces).
+	function onWheel(e: WheelEvent) {
+		const el = rootEl;
+		// Same gates as `onKeydown`: only the frontmost, non-blocked viewer acts.
+		if (!el || !isViewerFrontmost(el) || isBlockedByModal(el)) return;
+		// We own the wheel while frontmost — consume it even before the bitmap is
+		// measurable, so a scroll can never leak past the modal into the inert app.
+		e.preventDefault();
+		e.stopPropagation();
+		// A horizontal-only wheel (`deltaY === 0`, e.g. a trackpad side-swipe) is
+		// still consumed — the modal owns the wheel — but must NOT zoom, or it would
+		// read as a zoom-out. Direction comes from `deltaY` alone.
+		if (e.deltaY === 0) return;
+		const g = readGeometry();
+		const rect = stageEl?.getBoundingClientRect();
+		if (!g || !rect) return;
+		// Anchor in stage-local px (top-left origin) — the coordinate system the
+		// zoom module documents. The stage is untransformed, so its rect is stable.
+		const anchor = { x: e.clientX - rect.left, y: e.clientY - rect.top };
+		// Wheel up / away (deltaY < 0) zooms in.
+		const factor = e.deltaY < 0 ? ZOOM_STEP : 1 / ZOOM_STEP;
+		zoom = zoomTo(zoom, zoom.scale * factor, anchor, g);
+	}
+
 	// Stepped from `shownIndex`, not from `current`: after the set shrinks they
 	// differ, and moving from the raw value would jump relative to a position
 	// the user was never on. Both are no-ops on an empty set — reachable only
@@ -382,6 +412,18 @@
 		});
 		ro.observe(stage);
 		return () => ro.disconnect();
+	});
+
+	// Register the wheel listener imperatively with `{ passive: false }` so
+	// `preventDefault` is guaranteed to take effect (a declarative `onwheel`
+	// binding's passivity is not something to rely on), and on the viewer ROOT so
+	// a wheel over the backdrop letterbox is consumed too — scrolling "past" the
+	// modal into the inert app is exactly what the contract forbids (TASK-2457).
+	$effect(() => {
+		const el = rootEl;
+		if (!el) return;
+		el.addEventListener('wheel', onWheel, { passive: false });
+		return () => el.removeEventListener('wheel', onWheel);
 	});
 
 	// aria-modal promises focus never leaves the surface, but a focused nav button

--- a/web/src/lib/components/common/Lightbox.svelte
+++ b/web/src/lib/components/common/Lightbox.svelte
@@ -22,7 +22,7 @@
 	 */
 	import { untrack } from 'svelte';
 	import { attachmentDownloadUrl } from '$lib/markdown/attachments';
-	import { paneFocusables, nextTrapTarget } from '$lib/collections/paneFocus';
+	import { paneFocusables, nextTrapTarget, handoffFocus } from '$lib/collections/paneFocus';
 	import {
 		acquire,
 		isBlockedByModal,
@@ -382,6 +382,30 @@
 		});
 		ro.observe(stage);
 		return () => ro.disconnect();
+	});
+
+	// aria-modal promises focus never leaves the surface, but a focused nav button
+	// is CONDITIONALLY rendered (`hasMultiple`) — when the set shrinks to one it
+	// unmounts, dropping focus to <body> behind the inerted app until the next Tab
+	// (TASK-2456; a 3a defect every control 3b adds inherits). Keyed on the
+	// control-visibility signal, this hands focus back to the stable fallback
+	// (close button, else root) within the SAME flush the removal happens in, so
+	// <body> is never observably focused. `handoffFocus` with no `departing` is
+	// the reactive-removal shape; TASK-2459/2460 will call the same helper with
+	// THEIR departing control before disabling it.
+	//
+	// Guarded to the frontmost, non-blocked viewer: a surface stacked OVER this
+	// one owns focus, and pulling it back here would be the wrong direction (the
+	// same reason the key handler stands down for those). Reads only derived /
+	// element state and mutates focus — a DOM side effect, not $state — so it
+	// cannot self-invalidate its own flush (CONVE-1688).
+	$effect(() => {
+		// Tracked so the effect re-runs when a focus-holding control mounts or
+		// unmounts; a true→false flip is the shrink that removes the focused button.
+		void hasMultiple;
+		const el = rootEl;
+		if (!el || !isViewerFrontmost(el) || isBlockedByModal(el)) return;
+		handoffFocus(el);
 	});
 
 	function onKeydown(e: KeyboardEvent) {

--- a/web/src/lib/components/common/Lightbox.svelte
+++ b/web/src/lib/components/common/Lightbox.svelte
@@ -2,9 +2,11 @@
 	/**
 	 * Full-screen image viewer for attachment thumbnails (IDEA-1660).
 	 * Opened by a host that captures a click on an `img[data-attachment-id]`
-	 * and passes the attachment id(s) — the lightbox loads the ORIGINAL
-	 * (un-variant) blob so the expanded view is full resolution regardless
-	 * of the thumbnail variant shown inline.
+	 * and passes the attachment id(s). Loading follows the DR-5b memory policy
+	 * (PLAN-2392 phase 3b): a bounded `thumb-md` paints first and the viewer
+	 * upgrades to the full-resolution original in the background on desktop, while
+	 * a large image on mobile defers the original behind a tap-to-load affordance
+	 * (TASK-2459 / TASK-2460) — see `$lib/attachments/viewerImageLoader`.
 	 *
 	 * MODAL CONTRACT (PLAN-2392 phase 3a / TASK-2429, DR-4b). This is a real
 	 * modal now: `role="dialog"` + `aria-modal`, portaled to `<body>`, focus
@@ -59,7 +61,8 @@
 	 *
 	 * Everything past `id` / `alt` is NULLABLE and this component treats it as
 	 * such: an inline image's metadata comes from a HEAD probe that may not have
-	 * completed, and an upload event carries only four fields.
+	 * completed, and an upload event carries only the `UploadedAttachment` fields
+	 * (filename, MIME, size, and — since TASK-2459 — the pixel dimensions).
 	 *
 	 * Producers that mount this component directly import the type from the
 	 * CHANNEL too, not from here — a `.svelte` module cannot re-export a type,
@@ -201,12 +204,14 @@
 	// alone must not reload — desktop→mobile must not abort an in-flight original,
 	// mobile→desktop must not retroactively auto-fetch (TASK-2459).
 	let platform = $derived<Platform>(viewport.isMobile ? 'mobile' : 'desktop');
-	// Whether an <img> exists to zoom. False in the mobile `deferred` cell (a
-	// placeholder, nothing decoded) and when there is no image — zoom is then
-	// DISABLED, not merely a no-op (TASK-2460). Non-`deferred` states (loading /
-	// ready / error) all set `displaySrc`, so the guard is exactly "the deferred
-	// placeholder is showing" without singling the phase out.
-	let bitmapPresent = $derived(!!img && !!loader.displaySrc);
+	// Whether a decoded bitmap exists to zoom / pan. False in the mobile `deferred`
+	// cell (a placeholder, nothing decoded), when there is no image, AND in the
+	// `error` state: `errored()` flips only the phase, leaving `displaySrc` set (the
+	// failed URL), so without the phase guard drag-arming and the zoom keys would
+	// act over the error UI with nothing decoded behind it. Zoom is then DISABLED,
+	// not merely a no-op (TASK-2460). A successful retry returns to loading/ready
+	// and re-enables it.
+	let bitmapPresent = $derived(!!img && !!loader.displaySrc && loader.phase !== 'error');
 	// The tap-to-load placeholder's box. Where dimensions are known it takes the
 	// image's own aspect ratio (so the affordance previews the shape that will
 	// arrive); where they are not, a neutral box (TASK-2460).
@@ -283,6 +288,10 @@
 		// measurable, so a scroll can never leak past the modal into the inert app.
 		e.preventDefault();
 		e.stopPropagation();
+		// Consumed (the modal owns the wheel) but INERT with no decoded bitmap — the
+		// mobile deferred placeholder or the error UI, where the broken `<img>` still
+		// satisfies `readGeometry` (TASK-2461). Same guard the keys use.
+		if (!bitmapPresent) return;
 		// A horizontal-only wheel (`deltaY === 0`, e.g. a trackpad side-swipe) is
 		// still consumed — the modal owns the wheel — but must NOT zoom, or it would
 		// read as a zoom-out. Direction comes from `deltaY` alone.
@@ -455,6 +464,13 @@
 			abortGesture(e);
 			return;
 		}
+		// The bitmap vanished mid-drag — the background original failed and the phase
+		// went to `error` while a pan was live (TASK-2461). Abort: there is nothing
+		// left to pan, and continuing would move the (broken) error UI.
+		if (!bitmapPresent) {
+			abortGesture(e);
+			return;
+		}
 		// Primary button no longer held — a pointerup we never received (it ended
 		// off-target pre-capture, or was swallowed after a drag engaged). Tear the
 		// whole gesture down, not just `maybeDrag`: a full `abortGesture` also
@@ -545,6 +561,9 @@
 		// zoom toggle — without this, double-clicking Next navigates twice AND
 		// toggles, or a double-click on Retry toggles zoom on the broken stage.
 		if ((e.target as Element | null)?.closest?.('.lightbox-close, .lightbox-nav, .lightbox-retry, .lightbox-tap-load')) return;
+		// Inert with no decoded bitmap (deferred placeholder / error UI) — the same
+		// guard the keys and wheel use (TASK-2461).
+		if (!bitmapPresent) return;
 		const el = rootEl;
 		if (!el || !pointerGatesOpen(el)) return;
 		const g = readGeometry();
@@ -1005,6 +1024,24 @@
 					onload={(e) => {
 						const el = e.currentTarget as HTMLImageElement;
 						loader.decoded(el.naturalWidth, el.naturalHeight, el.getAttribute('src') ?? '', Number(el.dataset.gen));
+						// RE-CLAMP on a fresh bitmap. A same-id reload can change the geometry
+						// (an async dimension fill swaps a large original for a smaller thumb,
+						// lowering actualScale and MAX_SCALE), stranding the current scale above
+						// the new ceiling with out-of-bounds pan. The reset effect fires only on
+						// image CHANGE (id) and the ResizeObserver only on stage resize, so
+						// neither catches this. `clampState`, NOT reset — the same image's valid
+						// zoom survives; only an over-ceiling scale/pan is pulled back. Geometry
+						// is measurable only post-decode. Gated to the LIVE element (`el ===
+						// imgEl`, the same fence `decoded` applies) so a stale detached load can't
+						// drive the current zoom. Event handler, so the `zoom` read/write is not a
+						// CONVE-1688 self-write.
+						if (el === imgEl) {
+							const g = readGeometry();
+							if (g) {
+								zoom = clampState(zoom, g);
+								rebaseDrag(); // a re-clamp mid-drag must not desync the pan baseline
+							}
+						}
 					}}
 					onerror={(e) => {
 						const el = e.currentTarget as HTMLImageElement;

--- a/web/src/lib/components/common/Lightbox.svelte
+++ b/web/src/lib/components/common/Lightbox.svelte
@@ -16,7 +16,9 @@
 	 *
 	 * Keyboard: Esc closes (through `escapeStack`, NOT a local listener),
 	 * ←/→ navigate when multiple images were passed, Tab cycles within the
-	 * viewer. Backdrop click closes; clicking the image itself does not.
+	 * viewer, `+`/`-` zoom about the stage centre and `0` resets (PLAN-2392
+	 * phase 3b / TASK-2455). Backdrop click closes; clicking the image itself
+	 * does not.
 	 */
 	import { untrack } from 'svelte';
 	import { attachmentDownloadUrl } from '$lib/markdown/attachments';
@@ -30,6 +32,15 @@
 	} from '$lib/a11y/viewerBackdrop';
 	import { pushEscapeHandler, ESCAPE_PRIORITY } from '$lib/stores/escapeStack';
 	import { canOpenInViewer } from '$lib/attachments/display';
+	import {
+		reset as resetZoom,
+		clampState,
+		zoomTo,
+		stageCenter,
+		ZOOM_STEP,
+		type Geometry,
+		type ZoomState,
+	} from '$lib/attachments/zoom';
 	/**
 	 * ONE definition of what an image in this viewer is (PLAN-2392 / TASK-2431).
 	 *
@@ -173,6 +184,52 @@
 	// a flush (CONVE-1688).
 	let rootEl = $state<HTMLElement | null>(null);
 
+	// ── Zoom / pan (PLAN-2392 phase 3b / TASK-2455) ──────────────────────────
+	//
+	// The transform is `translate(x,y) scale(scale)` on the <img>, about the
+	// stage centre. Every number comes from `$lib/attachments/zoom` (TASK-2454),
+	// which owns the arithmetic and its bounds; this component only MEASURES the
+	// rendered geometry, wires the keys, and re-clamps on resize.
+	let zoom = $state<ZoomState>(resetZoom());
+	// The stage is the 92vw×92vh box the bare <img> used to be; the <img> sits
+	// inside it, `object-fit: contain`. Both are read live for geometry — never
+	// through `getBoundingClientRect()` on the transformed image, which returns
+	// the POST-scale box and would make the pan bounds grow with the zoom.
+	let stageEl = $state<HTMLElement | null>(null);
+	let imgEl = $state<HTMLImageElement | null>(null);
+
+	/**
+	 * The measured geometry, or null before there is anything to measure.
+	 *
+	 * `offsetWidth` / `offsetHeight` are the UNSCALED layout box — transforms do
+	 * not touch them, which is the whole reason they, not `getBoundingClientRect`,
+	 * are the source here. A not-yet-decoded bitmap reads back all zeros; the zoom
+	 * module is defensive about that and still returns an in-bounds transform, so
+	 * no guard is needed here.
+	 */
+	function readGeometry(): Geometry | null {
+		const stage = stageEl;
+		const image = imgEl;
+		if (!stage || !image) return null;
+		return {
+			stageW: stage.clientWidth,
+			stageH: stage.clientHeight,
+			fittedW: image.offsetWidth,
+			fittedH: image.offsetHeight,
+			naturalW: image.naturalWidth,
+			naturalH: image.naturalHeight,
+		};
+	}
+
+	// `+` / `-` zoom about the stage centre. Reading and writing `zoom` from an
+	// EVENT handler is fine — the CONVE-1688 rule is about `$effect`s that read
+	// the state they write, not about handlers.
+	function stepZoom(factor: number) {
+		const g = readGeometry();
+		if (!g) return;
+		zoom = zoomTo(zoom, zoom.scale * factor, stageCenter(g), g);
+	}
+
 	// Stepped from `shownIndex`, not from `current`: after the set shrinks they
 	// differ, and moving from the raw value would jump relative to a position
 	// the user was never on. Both are no-ops on an empty set — reachable only
@@ -289,6 +346,44 @@
 		};
 	});
 
+	// Reset the transform whenever the SHOWN image changes — arrow nav, or the
+	// set shrinking under `current` so a different member is shown (TASK-2455).
+	// Close needs no handling: every producer keys the mount, so closing
+	// unmounts this instance and the next open starts from `resetZoom()`.
+	//
+	// `lastResetForId` is a PLAIN let, not `$state`: an effect that read and wrote
+	// the same `$state` would self-depend and abort its own flush (CONVE-1688),
+	// stranding unrelated reactivity nearby. This effect reads `img?.id` (tracked)
+	// and writes `zoom` (which it never reads) plus this sentinel (a plain let, so
+	// never tracked) — nothing it writes is anything it reads. Seeded to the
+	// current id so the mount does not fire a redundant reset.
+	let lastResetForId: string | undefined = untrack(() => img?.id);
+	$effect(() => {
+		const id = img?.id;
+		if (id === lastResetForId) return;
+		lastResetForId = id;
+		zoom = resetZoom();
+	});
+
+	// Re-clamp on stage resize. `maxScale` is geometry-dependent and geometry is
+	// viewport-dependent, so ENLARGING the window lowers the ceiling and can
+	// strand a previously-valid scale above it. `clampState` re-clamps SCALE
+	// first, then pan — the order a geometry change needs; clamping pan first
+	// would bound it against a scale that is about to change. The callback runs
+	// outside any tracked scope, so its `zoom` read/write is not a self-write.
+	// Guarded for environments without `ResizeObserver` (SSR); the jsdom test
+	// project ships a global stand-in (`src/test/setup-jsdom.ts`).
+	$effect(() => {
+		const stage = stageEl;
+		if (!stage || typeof ResizeObserver === 'undefined') return;
+		const ro = new ResizeObserver(() => {
+			const g = readGeometry();
+			if (g) zoom = clampState(zoom, g);
+		});
+		ro.observe(stage);
+		return () => ro.disconnect();
+	});
+
 	function onKeydown(e: KeyboardEvent) {
 		// A control that already handled this key owns it.
 		if (e.defaultPrevented) return;
@@ -327,9 +422,38 @@
 		if (e.key === 'ArrowLeft' && hasMultiple) {
 			e.preventDefault();
 			prev();
-		} else if (e.key === 'ArrowRight' && hasMultiple) {
+			return;
+		}
+		if (e.key === 'ArrowRight' && hasMultiple) {
 			e.preventDefault();
 			next();
+			return;
+		}
+
+		// Zoom: `+` / `-` about the stage centre, `0` resets. INSIDE the gates
+		// above by construction — placed after `defaultPrevented`,
+		// `isViewerFrontmost` and `isBlockedByModal` have each had their say, so a
+		// zoom key can never steal a press another owner or a layer above is due.
+		//
+		// The modifier rule is a CONTRACT, not a nicety: this listens on `window`,
+		// so acting on Ctrl/Cmd/Alt-`-`/`0` would swallow the browser's own
+		// page-zoom (and OS) shortcuts from every surface while a viewer is open.
+		// Leave those keys entirely — do not act, and do NOT `preventDefault`, or
+		// the native shortcut is cancelled even though we declined to handle it.
+		// `shiftKey` is fine (on most layouts `+` IS Shift+`=`), so it is absent
+		// from the guard.
+		if (e.ctrlKey || e.metaKey || e.altKey) return;
+		if (e.key === '+' || e.key === '=') {
+			// `+` — including the numpad, whose `.key` is also `'+'` — and bare `=`.
+			e.preventDefault();
+			stepZoom(ZOOM_STEP);
+		} else if (e.key === '-') {
+			// `-`, including the numpad, whose `.key` is also `'-'`.
+			e.preventDefault();
+			stepZoom(1 / ZOOM_STEP);
+		} else if (e.key === '0') {
+			e.preventDefault();
+			zoom = resetZoom();
 		}
 		// NO Escape branch. See the registration above.
 	}
@@ -397,9 +521,26 @@
 		</button>
 	{/if}
 
-	{#if img}
-		<img class="lightbox-image" {src} alt={img.alt || 'Attachment'} />
-	{/if}
+	<!--
+		The STAGE is the 92vw×92vh box the bare <img> used to be; the image sits
+		inside it, `object-fit: contain`, and carries the zoom transform. The stage
+		is `pointer-events: none` so a click on the empty letterbox around the image
+		falls through to the backdrop and closes (exactly as it did when the image
+		was the only thing here); the image re-enables pointer events so a click ON
+		it does not close — and so 3c's drag / 3d's pinch have a target. The controls
+		sit ABOVE the stage (their own `z-index`), never inside it.
+	-->
+	<div class="lightbox-stage" bind:this={stageEl}>
+		{#if img}
+			<img
+				bind:this={imgEl}
+				class="lightbox-image"
+				{src}
+				alt={img.alt || 'Attachment'}
+				style="transform: translate({zoom.x}px, {zoom.y}px) scale({zoom.scale});"
+			/>
+		{/if}
+	</div>
 
 	{#if hasMultiple}
 		<!-- `shownIndex`, so the counter names the image actually on screen even
@@ -453,17 +594,49 @@
 		cursor: zoom-out;
 	}
 
+	.lightbox-stage {
+		/* The box the bare <img> used to occupy — TASK-2454's coordinate system. */
+		width: 92vw;
+		height: 92vh;
+		flex: none;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		/*
+		 * The empty letterbox around the image is transparent to pointer events, so
+		 * a click there reaches the backdrop and closes — the pre-zoom behaviour.
+		 * The image below re-enables them. Deliberately NOT `touch-action: none`
+		 * here: that would kill native pinch before 3d's handler exists, leaving
+		 * phone users no zoom at all in the interval (out of TASK-2455's scope).
+		 */
+		pointer-events: none;
+	}
+
 	.lightbox-image {
-		max-width: 92vw;
-		max-height: 92vh;
+		max-width: 100%;
+		max-height: 100%;
 		object-fit: contain;
 		border-radius: var(--radius);
 		box-shadow: 0 8px 40px rgba(0, 0, 0, 0.5);
 		cursor: default;
+		pointer-events: auto;
+		transform-origin: center;
+		transition: transform 0.15s ease-out;
+	}
+
+	/* Reduced motion suppresses the TRANSITION only — the zoom still works
+	   (Modal.svelte's precedent). */
+	@media (prefers-reduced-motion: reduce) {
+		.lightbox-image {
+			transition: none;
+		}
 	}
 
 	.lightbox-close {
 		position: absolute;
+		/* Above the stage's stacking context. Small on purpose: the viewer's own
+		   z-index sweep (TASK-2436) forbids any app overlay at or above 100000. */
+		z-index: 1;
 		top: var(--space-3);
 		right: var(--space-3);
 		width: 40px;
@@ -486,6 +659,7 @@
 
 	.lightbox-nav {
 		position: absolute;
+		z-index: 1;
 		top: 50%;
 		transform: translateY(-50%);
 		width: 48px;
@@ -516,6 +690,7 @@
 
 	.lightbox-counter {
 		position: absolute;
+		z-index: 1;
 		bottom: var(--space-3);
 		left: 50%;
 		transform: translateX(-50%);

--- a/web/src/lib/components/common/Lightbox.svelte
+++ b/web/src/lib/components/common/Lightbox.svelte
@@ -1339,4 +1339,21 @@
 		color: #fff;
 		font-size: 0.8rem;
 	}
+
+	/* Forced-colors (PLAN-2392 DR-4). The custom palette is discarded, so the
+	   image's box-shadow boundary vanishes — give the image a real BORDER so its
+	   boundary stays visible. LAST in the sheet so it wins over the controls' own
+	   (equal-specificity) border rules above, giving them explicit system-colour
+	   borders rather than relying on the UA's forced-colors adjustment. */
+	@media (forced-colors: active) {
+		.lightbox-image {
+			border: 2px solid CanvasText;
+		}
+		.lightbox-close,
+		.lightbox-nav,
+		.lightbox-retry,
+		.lightbox-tap-load {
+			border: 1px solid ButtonText;
+		}
+	}
 </style>

--- a/web/src/lib/components/common/Lightbox.svelte
+++ b/web/src/lib/components/common/Lightbox.svelte
@@ -41,6 +41,7 @@
 		zoomTo,
 		toggleFitOrActual,
 		stageCenter,
+		isAtFit,
 		ZOOM_STEP,
 		type Geometry,
 		type ZoomState,
@@ -200,6 +201,20 @@
 	// alone must not reload — desktop→mobile must not abort an in-flight original,
 	// mobile→desktop must not retroactively auto-fetch (TASK-2459).
 	let platform = $derived<Platform>(viewport.isMobile ? 'mobile' : 'desktop');
+	// Whether an <img> exists to zoom. False in the mobile `deferred` cell (a
+	// placeholder, nothing decoded) and when there is no image — zoom is then
+	// DISABLED, not merely a no-op (TASK-2460). Non-`deferred` states (loading /
+	// ready / error) all set `displaySrc`, so the guard is exactly "the deferred
+	// placeholder is showing" without singling the phase out.
+	let bitmapPresent = $derived(!!img && !!loader.displaySrc);
+	// The tap-to-load placeholder's box. Where dimensions are known it takes the
+	// image's own aspect ratio (so the affordance previews the shape that will
+	// arrive); where they are not, a neutral box (TASK-2460).
+	let placeholderStyle = $derived(
+		img?.width && img?.height
+			? `aspect-ratio: ${img.width} / ${img.height}; width: min(70vw, 520px); max-width: 90%; max-height: 80%;`
+			: `width: min(60vw, 360px); height: min(45vh, 270px); max-width: 90%; max-height: 80%;`
+	);
 
 	// The portaled root. `$state` so the effect below re-runs once `bind:this`
 	// lands; read-only inside every effect, so nothing here can self-invalidate
@@ -405,7 +420,12 @@
 		// (the house pattern in ItemGraph excludes its interactive overlays the same
 		// way). Retry sits over the (broken) stage in the error state, so it needs
 		// the same exclusion as the always-present chrome.
-		if ((e.target as Element | null)?.closest?.('.lightbox-close, .lightbox-nav, .lightbox-retry')) return;
+		if ((e.target as Element | null)?.closest?.('.lightbox-close, .lightbox-nav, .lightbox-retry, .lightbox-tap-load')) return;
+		// No decoded bitmap to pan (the mobile `deferred` placeholder shows no
+		// `<img>`) — do NOT arm a drag, so the gesture stays fully inert instead of
+		// capturing the pointer and latching `dragging` for a pan that can never
+		// happen (TASK-2460). A plain press still reaches the backdrop to close.
+		if (!bitmapPresent) return;
 		const el = rootEl;
 		if (!el || !pointerGatesOpen(el)) return; // START gate
 		maybeDrag = true;
@@ -524,7 +544,7 @@
 		// A double-click ON a control (close / nav / retry) is that control's, not a
 		// zoom toggle — without this, double-clicking Next navigates twice AND
 		// toggles, or a double-click on Retry toggles zoom on the broken stage.
-		if ((e.target as Element | null)?.closest?.('.lightbox-close, .lightbox-nav, .lightbox-retry')) return;
+		if ((e.target as Element | null)?.closest?.('.lightbox-close, .lightbox-nav, .lightbox-retry, .lightbox-tap-load')) return;
 		const el = rootEl;
 		if (!el || !pointerGatesOpen(el)) return;
 		const g = readGeometry();
@@ -689,6 +709,24 @@
 	// Drop the load on unmount (close) — one teardown, no dependencies.
 	$effect(() => () => loader.dispose());
 
+	// Zoom-past-fit is the mobile THUMB cell's trigger to fetch the original
+	// (TASK-2460): once a thumbnail has PAINTED, zooming past FIT (`scale > 1`, not
+	// past the thumb's own 1:1) upgrades to the original. Threshold is
+	// `!isAtFit(zoom)` — exactly "past fit", robust to the FIT_EPSILON float noise.
+	// Depends on `zoom` AND `loader.painted` (both tracked): gating on `painted`
+	// means a pre-paint zoom cannot fetch the original early, AND — because the flip
+	// to painted RE-RUNS this effect — a zoom made WHILE the thumb was still loading
+	// still upgrades the instant it paints (not stranded on the thumbnail).
+	// `loadOriginal` writes neither `zoom` nor `painted`, so tracking them cannot
+	// self-invalidate the flush (CONVE-1688). Fires on every zoom step past fit, but
+	// `loadOriginal`'s own dedup makes all but the first a no-op — the original is
+	// requested exactly once — and it no-ops entirely wherever nothing is deferred
+	// (desktop, or an already-loaded cell).
+	$effect(() => {
+		if (isAtFit(zoom) || !loader.painted) return;
+		untrack(() => loader.loadOriginal());
+	});
+
 	// Re-clamp on stage resize. `maxScale` is geometry-dependent and geometry is
 	// viewport-dependent, so ENLARGING the window lowers the ceiling and can
 	// strand a previously-valid scale above it. `clampState` re-clamps SCALE
@@ -740,13 +778,15 @@
 	// cannot self-invalidate its own flush (CONVE-1688).
 	$effect(() => {
 		// Tracked so the effect re-runs whenever a focus-holding control mounts or
-		// unmounts: the nav buttons (`hasMultiple`), the DR-10 retry button
-		// (`phase === 'error'`), and the image itself (`img`) — a set shrinking to
-		// empty removes the image, and an errored image navigated away removes the
-		// retry button, either of which could otherwise strand focus on <body>
-		// (TASK-2459).
+		// unmounts: the nav buttons (`hasMultiple`), the phase-gated controls (the
+		// DR-10 retry button in `error`, the tap-to-load button in `deferred` — both
+		// replaced by the image they load, TASK-2459 / TASK-2460), and the image
+		// itself (`img`). A set shrinking to empty, an errored image navigated away,
+		// or a tap that swaps the affordance for the bitmap could otherwise strand
+		// focus on <body>. Tracking the whole `phase` covers every such transition;
+		// `handoffFocus` no-ops while focus is still inside the surface.
 		void hasMultiple;
-		void (loader.phase === 'error');
+		void loader.phase;
 		void img;
 		const el = rootEl;
 		if (!el || !isViewerFrontmost(el) || isBlockedByModal(el)) return;
@@ -812,6 +852,16 @@
 		// `shiftKey` is fine (on most layouts `+` IS Shift+`=`), so it is absent
 		// from the guard.
 		if (e.ctrlKey || e.metaKey || e.altKey) return;
+		// Zoom keys are DISABLED, not merely no-ops, while no bitmap exists — the
+		// mobile `deferred` cell shows a placeholder with nothing to zoom
+		// (TASK-2460). Consume the key so it can't leak past the modal, but do not
+		// act. (`+`/`-` are already inert via `readGeometry`; `0` would otherwise
+		// still reset.)
+		const isZoomKey = e.key === '+' || e.key === '=' || e.key === '-' || e.key === '0';
+		if (isZoomKey && !bitmapPresent) {
+			e.preventDefault();
+			return;
+		}
 		if (e.key === '+' || e.key === '=') {
 			// `+` — including the numpad, whose `.key` is also `'+'` — and bare `=`.
 			e.preventDefault();
@@ -970,6 +1020,29 @@
 			     stage; the spinner is decoration over the (loading) image. -->
 			<div class="lightbox-status lightbox-loading" role="status" aria-label="Loading image">
 				<span class="lightbox-spinner" aria-hidden="true"></span>
+			</div>
+		{/if}
+
+		{#if img && loader.phase === 'deferred'}
+			<!-- The mobile large/unknown cell: DR-5b auto-fetches nothing here, so this
+			     is a TAP-TO-LOAD affordance, not a spinner (TASK-2460). The layer is
+			     inert; the button itself re-enables pointer events (the stage turns
+			     them off) so a tap can reach it — the one failure mode this cell exists
+			     to avoid. The whole placeholder is the button (a large touch target),
+			     sized to the image's aspect ratio when known. On tap it is replaced by
+			     the image it loads, so it hands focus off first (TASK-2456). -->
+			<div class="lightbox-status lightbox-deferred">
+				<button
+					class="lightbox-tap-load"
+					type="button"
+					style={placeholderStyle}
+					onclick={() => {
+						handoffFocus(rootEl!, rootEl?.querySelector('.lightbox-tap-load') ?? null);
+						loader.loadOriginal();
+					}}
+				>
+					<span class="lightbox-tap-label">Tap to load full image</span>
+				</button>
 			</div>
 		{/if}
 
@@ -1161,6 +1234,41 @@
 
 	.lightbox-retry:hover {
 		background: rgba(0, 0, 0, 0.75);
+	}
+
+	/* Tap-to-load placeholder for the mobile deferred cell (TASK-2460). The layer
+	   is inert; the button re-enables pointer events below. */
+	.lightbox-deferred {
+		pointer-events: none;
+	}
+
+	.lightbox-tap-load {
+		/* EXPLICIT: the stage sets `pointer-events: none`, so the tap target has to
+		   turn them back on — a control the user cannot tap is the failure this cell
+		   exists to avoid (TASK-2460). */
+		pointer-events: auto;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		/* Sizing (aspect ratio when known, neutral box otherwise) comes from the
+		   inline `placeholderStyle`. */
+		background: rgba(255, 255, 255, 0.06);
+		border: 1px dashed rgba(255, 255, 255, 0.35);
+		border-radius: var(--radius);
+		color: #fff;
+		cursor: pointer;
+	}
+
+	.lightbox-tap-load:hover,
+	.lightbox-tap-load:focus-visible {
+		background: rgba(255, 255, 255, 0.12);
+		border-color: rgba(255, 255, 255, 0.6);
+	}
+
+	.lightbox-tap-label {
+		padding: var(--space-2) var(--space-4);
+		font-size: 0.95rem;
+		font-weight: 500;
 	}
 
 	.lightbox-close {

--- a/web/src/lib/components/common/Lightbox.svelte
+++ b/web/src/lib/components/common/Lightbox.svelte
@@ -21,8 +21,10 @@
 	 * does not.
 	 */
 	import { untrack } from 'svelte';
-	import { attachmentDownloadUrl } from '$lib/markdown/attachments';
 	import { paneFocusables, nextTrapTarget, handoffFocus } from '$lib/collections/paneFocus';
+	import { createViewerImageLoader } from '$lib/attachments/viewerImageLoader.svelte';
+	import type { Platform } from '$lib/attachments/viewerLoading';
+	import { viewport } from '$lib/stores/breakpoint.svelte';
 	import {
 		acquire,
 		isBlockedByModal,
@@ -175,11 +177,29 @@
 		Math.min(Math.max(current, 0), Math.max(viewable.length - 1, 0))
 	);
 	let img = $derived(viewable[shownIndex]);
-	let src = $derived(img ? attachmentDownloadUrl(openWsSlug, img.id) : '');
 	// The accessible name: the image's own alt where there is one, else a
 	// generic label. Never empty — an unnamed `role="dialog"` is announced as
 	// nothing at all.
 	let dialogLabel = $derived(img?.alt || 'Attachment viewer');
+
+	// ── Image loading (PLAN-2392 phase 3b / TASK-2459) ────────────────────────
+	//
+	// The DR-5b thumb-then-original policy. The loader owns which URL the <img>
+	// shows (`displaySrc`, the canonical attachment URL) and the load phase; this
+	// component drives it from the shown image and reports each decode / error.
+	const loader = createViewerImageLoader();
+	// The id AND the pixel dimensions, as ONE stable primitive string — never the
+	// `img` object. A prop re-emit with the same VALUES (a re-derived `viewable`
+	// array) must not re-fire the load effect, but a genuine dimension change (an
+	// async metadata fill that flips `unknown` → a sized class) MUST: the DR-5b
+	// policy is a function of the pixels, so a stale dimension is a stale policy.
+	// A shrink to no image collapses to `'::'`, still a change → the effect fires
+	// and releases the load.
+	let loadKey = $derived(`${img?.id ?? ''}:${img?.width ?? ''}:${img?.height ?? ''}`);
+	// Captured NON-reactively at load time (see the effect): a breakpoint flip
+	// alone must not reload — desktop→mobile must not abort an in-flight original,
+	// mobile→desktop must not retroactively auto-fetch (TASK-2459).
+	let platform = $derived<Platform>(viewport.isMobile ? 'mobile' : 'desktop');
 
 	// The portaled root. `$state` so the effect below re-runs once `bind:this`
 	// lands; read-only inside every effect, so nothing here can self-invalidate
@@ -379,11 +399,13 @@
 		// leaves `maybeDrag` latched and the next move engages a phantom drag from a
 		// dead baseline. (We already returned above if a drag is live.)
 		maybeDrag = false;
-		// A press ON a control (close / nav) is that control's click, never a pan:
-		// arming here would let a drag OFF a button still fire its click, since the
-		// buttons' own handlers don't consult `suppressClick` (the house pattern in
-		// ItemGraph excludes its interactive overlays the same way).
-		if ((e.target as Element | null)?.closest?.('.lightbox-close, .lightbox-nav')) return;
+		// A press ON a control (close / nav / the DR-10 retry) is that control's
+		// click, never a pan: arming here would let a drag OFF a button still fire
+		// its click, since the buttons' own handlers don't consult `suppressClick`
+		// (the house pattern in ItemGraph excludes its interactive overlays the same
+		// way). Retry sits over the (broken) stage in the error state, so it needs
+		// the same exclusion as the always-present chrome.
+		if ((e.target as Element | null)?.closest?.('.lightbox-close, .lightbox-nav, .lightbox-retry')) return;
 		const el = rootEl;
 		if (!el || !pointerGatesOpen(el)) return; // START gate
 		maybeDrag = true;
@@ -499,9 +521,10 @@
 		// gesture is either a drag or a double-click, never both. Same swallow the
 		// backdrop click consults.
 		if (suppressClick) return;
-		// A double-click ON a control (close / nav) is that control's, not a zoom
-		// toggle — without this, double-clicking Next navigates twice AND toggles.
-		if ((e.target as Element | null)?.closest?.('.lightbox-close, .lightbox-nav')) return;
+		// A double-click ON a control (close / nav / retry) is that control's, not a
+		// zoom toggle — without this, double-clicking Next navigates twice AND
+		// toggles, or a double-click on Retry toggles zoom on the broken stage.
+		if ((e.target as Element | null)?.closest?.('.lightbox-close, .lightbox-nav, .lightbox-retry')) return;
 		const el = rootEl;
 		if (!el || !pointerGatesOpen(el)) return;
 		const g = readGeometry();
@@ -652,6 +675,20 @@
 		// `zoom`-writing effect would self-invalidate it (CONVE-1688).
 	});
 
+	// (Re)load whenever the SHOWN image changes — nav, a dimension fill, or a set
+	// shrink. This is also the ABORT + release point: `loader.load` drops the URL
+	// the user left, and it re-runs on the set shrinking to empty (`loadKey` →
+	// `'::'`) so a closed / emptied viewer holds no in-flight request. Reads only
+	// `loadKey` (tracked, a stable string so a same-values prop re-emit doesn't
+	// re-fire); `img`, `openWsSlug` and `platform` are captured non-reactively so a
+	// breakpoint flip alone can't reload (TASK-2459).
+	$effect(() => {
+		void loadKey;
+		untrack(() => loader.load(img, openWsSlug, platform));
+	});
+	// Drop the load on unmount (close) — one teardown, no dependencies.
+	$effect(() => () => loader.dispose());
+
 	// Re-clamp on stage resize. `maxScale` is geometry-dependent and geometry is
 	// viewport-dependent, so ENLARGING the window lowers the ceiling and can
 	// strand a previously-valid scale above it. `clampState` re-clamps SCALE
@@ -702,9 +739,15 @@
 	// element state and mutates focus — a DOM side effect, not $state — so it
 	// cannot self-invalidate its own flush (CONVE-1688).
 	$effect(() => {
-		// Tracked so the effect re-runs when a focus-holding control mounts or
-		// unmounts; a true→false flip is the shrink that removes the focused button.
+		// Tracked so the effect re-runs whenever a focus-holding control mounts or
+		// unmounts: the nav buttons (`hasMultiple`), the DR-10 retry button
+		// (`phase === 'error'`), and the image itself (`img`) — a set shrinking to
+		// empty removes the image, and an errored image navigated away removes the
+		// retry button, either of which could otherwise strand focus on <body>
+		// (TASK-2459).
 		void hasMultiple;
+		void (loader.phase === 'error');
+		void img;
 		const el = rootEl;
 		if (!el || !isViewerFrontmost(el) || isBlockedByModal(el)) return;
 		handoffFocus(el);
@@ -874,17 +917,79 @@
 		sit ABOVE the stage (their own `z-index`), never inside it.
 	-->
 	<div class="lightbox-stage" bind:this={stageEl}>
-		{#if img}
-			<!-- draggable=false: a native image drag would otherwise pre-empt the pan. -->
-			<img
-				bind:this={imgEl}
-				class="lightbox-image"
-				class:panning={dragging}
-				{src}
-				alt={img.alt || 'Attachment'}
-				draggable="false"
-				style="transform: translate({zoom.x}px, {zoom.y}px) scale({zoom.scale});"
-			/>
+		{#if img && loader.displaySrc}
+			<!--
+				KEYED ON THE LOAD TOKEN (TASK-2459). The <img> would otherwise persist
+				across navigation, and a bitmap that finished decoding LATE would fire
+				`load` reading the NEW image's src — labelling A's fallback decode as B
+				and suppressing B's upgrade (the no-`{#key}` switch-safety class). A
+				fresh element per REQUEST tears the stale element's listener down. The
+				token changes on load / retry but NOT on the thumb→original upgrade, so
+				the upgrade reuses the SAME element (no flash) while a retry — whose URL
+				is usually unchanged — still re-mounts and re-requests. The decode is
+				read from the EVENT's own target, and the loader fences on the decoded
+				src too, belt and braces.
+			-->
+			{#key loader.loadToken}
+				<!-- draggable=false: a native image drag would otherwise pre-empt the pan. -->
+				<!--
+					`data-gen` is the generation this element was mounted under, read back
+					in the handlers via `dataset.gen` — the SAME frozen-DOM-attribute
+					snapshot the src fence uses (`getAttribute('src')`). A DOM attribute on
+					a DETACHED element is not updated, so it is a true per-element snapshot;
+					a plain `{@const}` would compile to a lazy `$derived` and re-read the
+					CURRENT `loadToken` when a late event fires, defeating the fence in an
+					A→B→A navigation (the third A reuses A's exact URL, so only the
+					generation tells the detached first element apart). The `{#key}` gives a
+					fresh element per load / retry; the thumb→original upgrade reuses the
+					SAME element (token unchanged), so `data-gen` is stable across it.
+				-->
+				<img
+					bind:this={imgEl}
+					class="lightbox-image"
+					class:panning={dragging}
+					src={loader.displaySrc}
+					data-gen={loader.loadToken}
+					alt={img.alt || 'Attachment'}
+					draggable="false"
+					onload={(e) => {
+						const el = e.currentTarget as HTMLImageElement;
+						loader.decoded(el.naturalWidth, el.naturalHeight, el.getAttribute('src') ?? '', Number(el.dataset.gen));
+					}}
+					onerror={(e) => {
+						const el = e.currentTarget as HTMLImageElement;
+						loader.errored(el.getAttribute('src') ?? '', Number(el.dataset.gen));
+					}}
+					style="transform: translate({zoom.x}px, {zoom.y}px) scale({zoom.scale});"
+				/>
+			{/key}
+		{/if}
+
+		{#if img && loader.phase === 'loading'}
+			<!-- pointer-events:none so it never intercepts a pan / dblclick over the
+			     stage; the spinner is decoration over the (loading) image. -->
+			<div class="lightbox-status lightbox-loading" role="status" aria-label="Loading image">
+				<span class="lightbox-spinner" aria-hidden="true"></span>
+			</div>
+		{/if}
+
+		{#if img && loader.phase === 'error'}
+			<div class="lightbox-status lightbox-error" role="alert">
+				<p class="lightbox-error-text">This image couldn't be loaded.</p>
+				<!-- pointer-events:auto EXPLICITLY: the stage turns pointer events off,
+				     and this control must be clickable. On a successful retry it
+				     disappears, so it hands focus off first (TASK-2456). -->
+				<button
+					class="lightbox-retry"
+					type="button"
+					onclick={() => {
+						handoffFocus(rootEl!, rootEl?.querySelector('.lightbox-retry') ?? null);
+						loader.retry();
+					}}
+				>
+					Retry
+				</button>
+			</div>
 		{/if}
 	</div>
 
@@ -988,6 +1093,74 @@
 		.lightbox-image {
 			transition: none;
 		}
+	}
+
+	/* Loading spinner + error, centred over the stage (TASK-2459). */
+	.lightbox-status {
+		position: absolute;
+		inset: 0;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		gap: var(--space-3);
+		z-index: 1;
+	}
+
+	.lightbox-loading {
+		/* Never intercept a pan / double-click over the stage. */
+		pointer-events: none;
+	}
+
+	.lightbox-spinner {
+		width: 42px;
+		height: 42px;
+		border: 3px solid rgba(255, 255, 255, 0.25);
+		border-top-color: rgba(255, 255, 255, 0.9);
+		border-radius: 50%;
+		animation: lightbox-spin 0.8s linear infinite;
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		/* Slowed, not stopped — it must still read as "in progress". */
+		.lightbox-spinner {
+			animation-duration: 2.4s;
+		}
+	}
+
+	@keyframes lightbox-spin {
+		to {
+			transform: rotate(360deg);
+		}
+	}
+
+	.lightbox-error {
+		/* The layer is inert; the button re-enables itself below. */
+		pointer-events: none;
+		color: #fff;
+		text-align: center;
+	}
+
+	.lightbox-error-text {
+		margin: 0;
+		font-size: 0.95rem;
+	}
+
+	.lightbox-retry {
+		/* EXPLICIT: the stage sets `pointer-events: none`, so the one interactive
+		   control in this layer has to turn them back on (TASK-2459). */
+		pointer-events: auto;
+		padding: var(--space-2) var(--space-4);
+		background: rgba(0, 0, 0, 0.5);
+		border: 1px solid rgba(255, 255, 255, 0.3);
+		border-radius: var(--radius);
+		color: #fff;
+		font-size: 0.9rem;
+		cursor: pointer;
+	}
+
+	.lightbox-retry:hover {
+		background: rgba(0, 0, 0, 0.75);
 	}
 
 	.lightbox-close {

--- a/web/src/lib/components/common/Lightbox.svelte.test.ts
+++ b/web/src/lib/components/common/Lightbox.svelte.test.ts
@@ -2677,3 +2677,98 @@ describe('Lightbox — mobile tap-to-load and zoom-past-fit (TASK-2460)', () => 
 		expect(root().querySelector('.lightbox-tap-load')).not.toBeNull();
 	});
 });
+
+// ── TASK-2461 final-pass fixes ──────────────────────────────────────────────
+describe('Lightbox — re-clamp on same-id decode + inert error state (TASK-2461)', () => {
+	it('re-clamps a stranded scale when a same-id reload decodes a SMALLER bitmap', () => {
+		// A same-id dimension fill reloads the image with a smaller bitmap (a large
+		// original swapped for a thumb), lowering actualScale and MAX_SCALE. The reset
+		// effect fires only on image CHANGE and the ResizeObserver only on stage
+		// resize — neither catches this; the DECODE (onload) must re-clamp.
+		mountViewer();
+		const image = root().querySelector<HTMLImageElement>('.lightbox-image')!;
+		const stage = root().querySelector<HTMLElement>('.lightbox-stage')!;
+		// Big bitmap fitted small → actualScale 10, ceiling 40 — lots of headroom.
+		let fitted = 100;
+		let natural = 1000;
+		Object.defineProperty(image, 'offsetWidth', { configurable: true, get: () => fitted });
+		Object.defineProperty(image, 'offsetHeight', { configurable: true, get: () => fitted });
+		Object.defineProperty(image, 'naturalWidth', { configurable: true, get: () => natural });
+		Object.defineProperty(image, 'naturalHeight', { configurable: true, get: () => natural });
+		Object.defineProperty(stage, 'clientWidth', { configurable: true, get: () => fitted });
+		Object.defineProperty(stage, 'clientHeight', { configurable: true, get: () => fitted });
+
+		for (let i = 0; i < 8; i++) press('+');
+		expect(scaleOf(), 'zoomed well past the eventual ceiling').toBeGreaterThan(5);
+
+		// The reload decodes a 1:1 bitmap: actualScale → 1, ceiling → 4. The stranded
+		// scale (~5.96) must be pulled back to 4 by the onload re-clamp.
+		natural = fitted;
+		image.dispatchEvent(new Event('load'));
+		flushSync();
+		expect(scaleOf(), 'the decode re-clamped the stranded scale to the new max').toBeCloseTo(4);
+	});
+
+	it('disables zoom keys and drag in the ERROR state, and re-enables them after a successful retry', () => {
+		mountViewer({ images: [sized(IMG_A, 'a', 5000, 5000)] });
+		mockGeometry(root(), OVERFLOW_G);
+		fireLoad(1024, 768); // thumb decoded → ready, background original in flight
+		expect(press('+')).toBe(true);
+		const zoomed = scaleOf();
+		expect(zoomed, 'zoom works with a decoded bitmap').toBeGreaterThan(1);
+
+		// The original FAILS → error state. `errored()` flips only the phase;
+		// `displaySrc` stays set, so without the phase guard `bitmapPresent` would
+		// still be true and gestures would act over the error UI.
+		root().querySelector<HTMLImageElement>('.lightbox-image')!.dispatchEvent(new Event('error'));
+		flushSync();
+		expect(root().querySelector('.lightbox-error')).not.toBeNull();
+
+		// ALL zoom gestures inert — the transform does not move: keys, wheel AND
+		// double-click (each of which the broken <img>'s geometry would otherwise let
+		// through).
+		press('+');
+		press('0');
+		wheel(root(), { clientX: 500, clientY: 500, deltaY: -1 });
+		root().dispatchEvent(new MouseEvent('dblclick', { bubbles: true, clientX: 500, clientY: 500 }));
+		flushSync();
+		expect(scaleOf(), 'keys / wheel / dblclick are inert in the error state').toBeCloseTo(zoomed);
+		// DRAG inert — a pointerdown does not arm/capture.
+		const capture = vi.fn();
+		(root() as unknown as { setPointerCapture: unknown }).setPointerCapture = capture;
+		root().dispatchEvent(pointerEvent('pointerdown', 500, 500));
+		root().dispatchEvent(pointerEvent('pointermove', 700, 500));
+		flushSync();
+		expect(capture, 'drag does not arm in the error state').not.toHaveBeenCalled();
+
+		// CONTROL — a successful retry re-enables gestures.
+		root().querySelector<HTMLButtonElement>('.lightbox-retry')!.click();
+		flushSync();
+		mockGeometry(root(), OVERFLOW_G); // the retry remounted the <img>
+		fireLoad(2000, 2000); // the original re-decodes → ready
+		expect(press('+')).toBe(true);
+		expect(scaleOf(), 'zoom works again after a successful retry').toBeGreaterThan(zoomed);
+	});
+
+	it('aborts a LIVE drag when the bitmap vanishes mid-drag (background original fails)', () => {
+		mountViewer({ images: [sized(IMG_A, 'a', 5000, 5000)] });
+		mockGeometry(root(), OVERFLOW_G);
+		fireLoad(1024, 768); // thumb ready; background original in flight
+		zoomToActual(); // pan room
+		const capture = vi.fn();
+		(root() as unknown as { setPointerCapture: unknown }).setPointerCapture = capture;
+		root().dispatchEvent(pointerEvent('pointerdown', 500, 500));
+		root().dispatchEvent(pointerEvent('pointermove', 560, 500)); // engage the drag
+		flushSync();
+		expect(capture, 'the drag armed on a decoded bitmap').toHaveBeenCalled();
+		const panned = panX();
+
+		// The original FAILS mid-drag → error. A further move must ABORT, not pan the
+		// broken UI.
+		root().querySelector<HTMLImageElement>('.lightbox-image')!.dispatchEvent(new Event('error'));
+		flushSync();
+		root().dispatchEvent(pointerEvent('pointermove', 720, 500));
+		flushSync();
+		expect(panX(), 'the drag aborted; no further pan over the error UI').toBeCloseTo(panned);
+	});
+});

--- a/web/src/lib/components/common/Lightbox.svelte.test.ts
+++ b/web/src/lib/components/common/Lightbox.svelte.test.ts
@@ -15,6 +15,7 @@ import {
 	ESCAPE_PRIORITY,
 	_resetEscapeStackForTests,
 } from '$lib/stores/escapeStack';
+import { reset as resetZoom, zoomTo, ZOOM_STEP, type Geometry } from '$lib/attachments/zoom';
 
 // TASK-2429 — the DR-4b modal contract on the attachment viewer.
 //
@@ -1469,5 +1470,203 @@ describe('Lightbox — Tab still cycles at maximum zoom (TASK-2456)', () => {
 		expect(press('Tab')).toBe(true);
 		expect(root().contains(document.activeElement)).toBe(true);
 		expect(document.activeElement).toBe(closeButton());
+	});
+});
+
+// TASK-2457 — wheel / ctrl-cmd-wheel zoom, anchored at the cursor.
+//
+// The listener is registered NON-PASSIVELY on the viewer root, so a dispatched
+// WheelEvent's `defaultPrevented` reflects the handler's `preventDefault` — the
+// direct assertion the acceptance requires (never inferred from "the page did
+// not scroll", which jsdom can't show anyway).
+
+/** Dispatch a wheel on `scope` (the viewer root, where the listener lives). */
+function wheel(scope: HTMLElement, init: WheelEventInit): boolean {
+	const e = new WheelEvent('wheel', { cancelable: true, bubbles: true, ...init });
+	scope.dispatchEvent(e);
+	flushSync();
+	return e.defaultPrevented;
+}
+
+/** Mock the geometry the viewer reads, so the cursor anchor is observable. */
+function mockGeometry(scope: HTMLElement, g: Geometry, rectLeft = 0, rectTop = 0): void {
+	const image = scope.querySelector<HTMLImageElement>('.lightbox-image')!;
+	const stage = scope.querySelector<HTMLElement>('.lightbox-stage')!;
+	Object.defineProperty(image, 'offsetWidth', { configurable: true, get: () => g.fittedW });
+	Object.defineProperty(image, 'offsetHeight', { configurable: true, get: () => g.fittedH });
+	Object.defineProperty(image, 'naturalWidth', { configurable: true, get: () => g.naturalW });
+	Object.defineProperty(image, 'naturalHeight', { configurable: true, get: () => g.naturalH });
+	Object.defineProperty(stage, 'clientWidth', { configurable: true, get: () => g.stageW });
+	Object.defineProperty(stage, 'clientHeight', { configurable: true, get: () => g.stageH });
+	stage.getBoundingClientRect = () =>
+		({
+			left: rectLeft,
+			top: rectTop,
+			width: g.stageW,
+			height: g.stageH,
+			right: rectLeft + g.stageW,
+			bottom: rectTop + g.stageH,
+			x: rectLeft,
+			y: rectTop,
+			toJSON() {},
+		}) as DOMRect;
+}
+
+describe('Lightbox — wheel zoom (TASK-2457)', () => {
+	function mockOpenModals(modals: Element[]): void {
+		const realQueryAll = document.querySelectorAll.bind(document);
+		vi.spyOn(document, 'querySelectorAll').mockImplementation((selector: string) => {
+			if (selector !== 'dialog:modal') return realQueryAll(selector);
+			return Array.from(realQueryAll('dialog')).filter((d) =>
+				modals.includes(d)
+			) as unknown as NodeListOf<Element>;
+		});
+		const realMatches = Element.prototype.matches;
+		vi.spyOn(Element.prototype, 'matches').mockImplementation(function (
+			this: Element,
+			selector: string
+		) {
+			if (selector !== 'dialog:modal') return realMatches.call(this, selector);
+			return realMatches.call(this, 'dialog') && modals.includes(this);
+		});
+	}
+
+	it('zooms IN and leaves the cursor point anchored — matching the module exactly', () => {
+		// A geometry where the image nearly fills the stage, so ONE wheel step
+		// overflows and an off-centre cursor produces an observable, module-defined
+		// pan (jsdom's zero geometry would hide it — the same limit the anchor key
+		// test noted). The image point under the cursor stays there because the
+		// component delegates to `zoomTo` with the cursor as the anchor: the
+		// resulting transform must equal `zoomTo`'s output byte for byte.
+		mountViewer();
+		const g: Geometry = {
+			stageW: 1000,
+			stageH: 1000,
+			fittedW: 900,
+			fittedH: 900,
+			naturalW: 2000,
+			naturalH: 2000,
+		};
+		// A NONZERO stage offset in the viewport, so the anchor must be computed
+		// stage-LOCAL (clientX − rect.left). An implementation that fed viewport
+		// coordinates straight in would anchor 120/60px off and fail this.
+		const rectLeft = 120;
+		const rectTop = 60;
+		mockGeometry(root(), g, rectLeft, rectTop);
+		const clientX = 800;
+		const clientY = 500;
+		const anchor = { x: clientX - rectLeft, y: clientY - rectTop };
+		const expected = zoomTo(resetZoom(), 1 * ZOOM_STEP, anchor, g);
+
+		expect(wheel(root(), { clientX, clientY, deltaY: -1 })).toBe(true);
+		expect(transformOf()).toBe(
+			`translate(${expected.x}px, ${expected.y}px) scale(${expected.scale})`
+		);
+		// The off-centre anchor genuinely moved the pan (not a centred no-op), so
+		// this is a real anchor assertion, not a vacuous one.
+		expect(expected.x).not.toBe(0);
+	});
+
+	it('stops propagation while frontmost so restoration never sees the wheel; lets it through otherwise', () => {
+		// The `stopPropagation` half — belt to the restoration guard. A frontmost
+		// viewer's wheel must not reach a `window` listener (the scroll-restoration
+		// one); a non-frontmost viewer declines, so its event DOES bubble through
+		// (there, restoration's OWN guard is what protects it — asserted in
+		// restore.svelte.test.ts).
+		const seen = vi.fn();
+		window.addEventListener('wheel', seen);
+		try {
+			mountViewer();
+			const back = root();
+			mountViewer();
+			const front = root();
+
+			const e1 = new WheelEvent('wheel', {
+				cancelable: true,
+				bubbles: true,
+				clientX: 10,
+				clientY: 10,
+				deltaY: -1,
+			});
+			front.dispatchEvent(e1);
+			flushSync();
+			expect(e1.defaultPrevented).toBe(true);
+			expect(seen).not.toHaveBeenCalled();
+
+			const e2 = new WheelEvent('wheel', {
+				cancelable: true,
+				bubbles: true,
+				clientX: 10,
+				clientY: 10,
+				deltaY: -1,
+			});
+			back.dispatchEvent(e2);
+			flushSync();
+			expect(seen).toHaveBeenCalledTimes(1);
+		} finally {
+			window.removeEventListener('wheel', seen);
+		}
+	});
+
+	it('ctrl/cmd+wheel ALSO zooms (both plain and modified) and is preventDefaulted', () => {
+		// The modifier is NOT a gate for wheel (unlike the +/- keys): ctrl/cmd wheel
+		// is the browser's page-zoom, which the viewer overrides while open — hence
+		// the non-passive preventDefault.
+		mountViewer();
+		expect(wheel(root(), { clientX: 10, clientY: 10, deltaY: -1, ctrlKey: true })).toBe(true);
+		expect(scaleOf()).toBeCloseTo(1.25);
+		mountViewer();
+		expect(wheel(root(), { clientX: 10, clientY: 10, deltaY: -1, metaKey: true })).toBe(true);
+		expect(scaleOf()).toBeCloseTo(1.25);
+	});
+
+	it('a horizontal-only wheel (deltaY 0) is consumed but does NOT zoom', () => {
+		// A trackpad side-swipe must not read as a zoom-out; direction is deltaY
+		// only. Seed a zoom-in FIRST so a spurious zoom-out would be observable —
+		// from fit it would just clamp back to 1 and hide the bug.
+		mountViewer();
+		wheel(root(), { clientX: 10, clientY: 10, deltaY: -1 });
+		expect(scaleOf()).toBeCloseTo(1.25);
+		// Still preventDefaulted (the modal owns the wheel), but the zoom is left put.
+		expect(wheel(root(), { clientX: 10, clientY: 10, deltaX: 120, deltaY: 0 })).toBe(true);
+		expect(scaleOf()).toBeCloseTo(1.25);
+	});
+
+	it('a downward wheel zooms OUT (back toward fit)', () => {
+		mountViewer();
+		wheel(root(), { clientX: 10, clientY: 10, deltaY: -1 });
+		wheel(root(), { clientX: 10, clientY: 10, deltaY: -1 });
+		expect(scaleOf()).toBeCloseTo(1.25 * 1.25);
+		expect(wheel(root(), { clientX: 10, clientY: 10, deltaY: 1 })).toBe(true);
+		expect(scaleOf()).toBeCloseTo(1.25);
+	});
+
+	it('no-ops (and does NOT preventDefault) when not the frontmost viewer; the front one acts', () => {
+		mountViewer();
+		const back = root();
+		mountViewer();
+		const front = root();
+		expect(back).not.toBe(front);
+
+		// Dispatched on the BACKGROUND viewer: it must decline AND leave the event
+		// uncancelled (nothing behind it to own the wheel either way).
+		expect(wheel(back, { clientX: 10, clientY: 10, deltaY: -1 })).toBe(false);
+		expect(scaleOf(back)).toBe(1);
+
+		// Positive control: the FRONT viewer zooms and cancels.
+		expect(wheel(front, { clientX: 10, clientY: 10, deltaY: -1 })).toBe(true);
+		expect(scaleOf(front)).toBeCloseTo(1.25);
+	});
+
+	it('no-ops while a showModal() dialog is above it, and resumes after it closes', () => {
+		const dialog = document.body.appendChild(document.createElement('dialog'));
+		mockOpenModals([dialog]);
+		mountViewer();
+		expect(wheel(root(), { clientX: 10, clientY: 10, deltaY: -1 })).toBe(false);
+		expect(scaleOf()).toBe(1);
+
+		mockOpenModals([]);
+		expect(wheel(root(), { clientX: 10, clientY: 10, deltaY: -1 })).toBe(true);
+		expect(scaleOf()).toBeCloseTo(1.25);
 	});
 });

--- a/web/src/lib/components/common/Lightbox.svelte.test.ts
+++ b/web/src/lib/components/common/Lightbox.svelte.test.ts
@@ -2265,3 +2265,236 @@ describe('Lightbox — drag-to-pan and double-click (TASK-2458)', () => {
 		expect(scaleOf(front)).toBeCloseTo(2000 / 900); // frontmost did
 	});
 });
+
+// TASK-2459 — the DR-5b loader WIRED into the viewer. The request logic is
+// proven in viewerImageLoader.svelte.test.ts; these pin the wiring: the <img>
+// shows the loader's URL, its decode feeds the fallback detector / upgrade, and
+// the spinner / error / retry states render.
+
+/** A LightboxImage with explicit pixel dimensions. */
+function sized(id: string, alt: string, width: number, height: number, mime = 'image/png'): LightboxImage {
+	return { id, alt, filename: null, mime_type: mime, size_bytes: null, width, height };
+}
+/** Simulate the <img> decoding at `naturalWidth x naturalHeight`, then flush. */
+function fireLoad(naturalWidth: number, naturalHeight: number, scope: HTMLElement = root()): void {
+	const el = scope.querySelector<HTMLImageElement>('.lightbox-image');
+	if (!el) throw new Error('no image to load');
+	Object.defineProperty(el, 'naturalWidth', { configurable: true, get: () => naturalWidth });
+	Object.defineProperty(el, 'naturalHeight', { configurable: true, get: () => naturalHeight });
+	el.dispatchEvent(new Event('load'));
+	flushSync();
+}
+
+describe('Lightbox — DR-5b image loading (TASK-2459)', () => {
+	it('a large image loads the THUMBNAIL first, then upgrades to the original on decode', () => {
+		mountViewer({ images: [sized(IMG_A, 'big', 5000, 5000)] });
+		expect(imageSrc()).toContain('variant=thumb-md');
+		expect(imageSrc()).toContain(IMG_A);
+
+		// The thumb decodes at a bounded size → the background upgrade swaps in.
+		fireLoad(1024, 768);
+		expect(imageSrc()).toContain(IMG_A);
+		expect(imageSrc()).not.toContain('variant='); // the original, no variant
+	});
+
+	it('the FALLBACK case does not upgrade (a thumb-md request served the original)', () => {
+		mountViewer({ images: [sized(IMG_A, 'big', 5000, 5000)] });
+		expect(imageSrc()).toContain('variant=thumb-md');
+		// Decoded ABOVE the thumbnail bound → it WAS the original: no second request.
+		fireLoad(5000, 5000);
+		expect(imageSrc()).toContain('variant=thumb-md');
+	});
+
+	it('an unknown-dimensions image requests the ORIGINAL directly (no thumb)', () => {
+		mountViewer({ images: [image(IMG_A, 'a')] }); // the helper leaves dims null
+		expect(imageSrc()).toContain(IMG_A);
+		expect(imageSrc()).not.toContain('variant=');
+	});
+
+	it('shows a loading spinner until the image decodes, then hides it', () => {
+		mountViewer({ images: [sized(IMG_A, 'big', 5000, 5000)] });
+		expect(root().querySelector('.lightbox-loading')).not.toBeNull();
+		fireLoad(1024, 768); // thumb decoded → upgrade requested (still loading)
+		expect(root().querySelector('.lightbox-loading')).not.toBeNull();
+		fireLoad(5000, 5000); // original decoded → ready
+		expect(root().querySelector('.lightbox-loading')).toBeNull();
+	});
+
+	it('a load error shows a retryable error; retry RE-REQUESTS and hands off focus', () => {
+		mountViewer({ images: [sized(IMG_A, 'big', 5000, 5000)] });
+		const el = root().querySelector<HTMLImageElement>('.lightbox-image')!;
+		el.dispatchEvent(new Event('error'));
+		flushSync();
+		expect(root().querySelector('.lightbox-error')).not.toBeNull();
+
+		const retry = root().querySelector<HTMLButtonElement>('.lightbox-retry')!;
+		// The retry control carries pointer-events:auto explicitly (the stage is off).
+		expect(getComputedStyle(retry).pointerEvents).not.toBe('none');
+		retry.focus();
+		retry.click();
+		flushSync();
+		// Re-requested → loading again → the error (and its button) are gone, and
+		// focus was handed off before the button disappeared (TASK-2456).
+		expect(root().querySelector('.lightbox-error')).toBeNull();
+		expect(document.activeElement).toBe(closeButton());
+	});
+
+	it('ABORTS on navigate: the src points at the new image, dropping the old URL', () => {
+		mountViewer({
+			images: [sized(IMG_A, 'a', 5000, 5000), sized(IMG_B, 'b', 800, 600, 'image/jpeg')],
+		});
+		expect(imageSrc()).toContain(IMG_A);
+		expect(imageSrc()).toContain('variant=thumb-md');
+
+		expect(press('ArrowRight')).toBe(true);
+		expect(imageSrc()).toContain(IMG_B);
+		expect(imageSrc()).not.toContain(IMG_A); // the old URL is gone at once
+		expect(imageSrc()).not.toContain('variant='); // B is small ≤1024 → original
+	});
+
+	it('retry RE-MOUNTS the <img> so a same-URL failure is actually re-requested', () => {
+		mountViewer({ images: [image(IMG_A, 'a')] }); // unknown dims → original URL directly
+		const before = root().querySelector<HTMLImageElement>('.lightbox-image')!;
+		const beforeSrc = before.getAttribute('src');
+		before.dispatchEvent(new Event('error'));
+		flushSync();
+		root().querySelector<HTMLButtonElement>('.lightbox-retry')!.click();
+		flushSync();
+		const after = root().querySelector<HTMLImageElement>('.lightbox-image');
+		// A NEW element (the load token changed the {#key}) at the SAME URL — the
+		// browser re-requests even though a naive `src=''`→same-URL would no-op.
+		expect(after).not.toBe(before);
+		expect(after?.getAttribute('src')).toBe(beforeSrc);
+	});
+
+	it('a focused retry that unmounts on set-shrink does not strand focus on <body>', () => {
+		liveProps.images = [image(IMG_A, 'a')];
+		const app = mount(Lightbox, { target: appRoot, props: liveProps });
+		mounted.push(app);
+		flushSync();
+		root().querySelector<HTMLImageElement>('.lightbox-image')!.dispatchEvent(new Event('error'));
+		flushSync();
+		const retry = root().querySelector<HTMLButtonElement>('.lightbox-retry')!;
+		retry.focus();
+		expect(document.activeElement).toBe(retry);
+
+		// The set shrinks to empty — the errored image and its retry button unmount.
+		liveProps.images = [];
+		flushSync();
+		expect(root().querySelector('.lightbox-retry')).toBeNull();
+		expect(document.activeElement).toBe(closeButton());
+		expect(document.activeElement).not.toBe(document.body);
+	});
+
+	it('a LATE decode for a navigated-away image does not corrupt the current one', () => {
+		mountViewer({
+			images: [sized(IMG_A, 'a', 5000, 5000), sized(IMG_B, 'b', 5000, 5000, 'image/jpeg')],
+		});
+		const staleImg = root().querySelector<HTMLImageElement>('.lightbox-image')!; // A's element
+		expect(staleImg.getAttribute('src')).toContain('variant=thumb-md');
+
+		// Navigate to B — the id-keyed <img> remounts, detaching A's element.
+		expect(press('ArrowRight')).toBe(true);
+		expect(imageSrc()).toContain(IMG_B);
+		expect(imageSrc()).toContain('variant=thumb-md');
+
+		// A's thumbnail finishes decoding LATE at a FALLBACK size (>1024) on the now
+		// detached element. It must not mark B ready or suppress B's upgrade.
+		Object.defineProperty(staleImg, 'naturalWidth', { configurable: true, get: () => 5000 });
+		Object.defineProperty(staleImg, 'naturalHeight', { configurable: true, get: () => 5000 });
+		staleImg.dispatchEvent(new Event('load'));
+		flushSync();
+		expect(imageSrc()).toContain(IMG_B);
+		expect(imageSrc()).toContain('variant=thumb-md'); // B untouched
+
+		// B's OWN decode still drives B's upgrade.
+		fireLoad(1024, 768);
+		expect(imageSrc()).toContain(IMG_B);
+		expect(imageSrc()).not.toContain('variant=');
+	});
+
+	it('zoom/pan still work on the image the loader RE-MOUNTED after navigation', () => {
+		// The {#key} remounts the <img> on nav, rebinding `imgEl`. The zoom reads
+		// geometry from `imgEl`; a stale bind would read the detached element and
+		// pan nothing.
+		mountViewer({
+			images: [sized(IMG_A, 'a', 5000, 5000), sized(IMG_B, 'b', 5000, 5000, 'image/jpeg')],
+		});
+		expect(press('ArrowRight')).toBe(true);
+		expect(imageSrc()).toContain(IMG_B);
+
+		mockGeometry(root(), OVERFLOW_G); // mocks the NEW (B's) image element
+		root().dispatchEvent(new MouseEvent('dblclick', { bubbles: true, clientX: 500, clientY: 500 }));
+		flushSync();
+		expect(scaleOf()).toBeCloseTo(2000 / 900); // zoom read the rebound element
+
+		root().dispatchEvent(pointerEvent('pointerdown', 500, 500));
+		root().dispatchEvent(pointerEvent('pointermove', 600, 500));
+		flushSync();
+		expect(panX()).toBeCloseTo(100);
+	});
+
+	it('DR-16: an all-unsafe set renders no image and issues no request', () => {
+		mountViewer({ images: [image(IMG_A, 'svg', 'image/svg+xml')] });
+		expect(root().querySelector('.lightbox-image')).toBeNull();
+		expect(root().querySelector('.lightbox-loading')).toBeNull();
+	});
+
+	it('a same-id re-emit that FILLS dimensions re-runs the DR-5b policy', () => {
+		// The load key is id + dimensions, so a re-derived set with the SAME values
+		// does not reload, but an async metadata fill (unknown → sized) MUST — a
+		// stale dimension is a stale policy.
+		liveProps.images = [image(IMG_A, 'a')]; // unknown dims → original directly
+		const app = mount(Lightbox, { target: appRoot, props: liveProps });
+		mounted.push(app);
+		flushSync();
+		expect(imageSrc()).not.toContain('variant='); // unknown → the original
+
+		// The same id re-emits with LARGE dimensions filled in.
+		liveProps.images = [sized(IMG_A, 'a', 5000, 5000)];
+		flushSync();
+		expect(imageSrc()).toContain('variant=thumb-md'); // policy re-ran → thumb first
+	});
+
+	it('the retry button is excluded from pan + zoom-toggle gestures over the stage', () => {
+		mountViewer({ images: [sized(IMG_A, 'a', 5000, 5000)] });
+		root().querySelector<HTMLImageElement>('.lightbox-image')!.dispatchEvent(new Event('error'));
+		flushSync();
+		mockGeometry(root(), OVERFLOW_G);
+		const retry = root().querySelector<HTMLButtonElement>('.lightbox-retry')!;
+		const before = scaleOf();
+		// A double-click ON retry must not toggle zoom (excluded like close / nav).
+		retry.dispatchEvent(new MouseEvent('dblclick', { bubbles: true, clientX: 500, clientY: 500 }));
+		flushSync();
+		expect(scaleOf()).toBeCloseTo(before);
+		// A drag STARTING on retry must not pan the broken stage.
+		retry.dispatchEvent(pointerEvent('pointerdown', 500, 500));
+		root().dispatchEvent(pointerEvent('pointermove', 600, 500));
+		flushSync();
+		expect(panX()).toBeCloseTo(0);
+	});
+
+	it('an A→B→A same-URL late error on the DETACHED element does not clobber the live image', () => {
+		// The third A load reuses A's exact URL, so the URL fence alone cannot tell
+		// the detached first A element's late error from the live one — the per-mount
+		// generation is what rejects it (the no-`{#key}` switch-safety class).
+		mountViewer({
+			images: [sized(IMG_A, 'a', 800, 600), sized(IMG_B, 'b', 800, 600, 'image/jpeg')],
+		});
+		const firstA = root().querySelector<HTMLImageElement>('.lightbox-image')!; // E1
+		expect(press('ArrowRight')).toBe(true); // → B (E1 detaches)
+		expect(press('ArrowLeft')).toBe(true); // → A again (E3 mounts, same URL)
+		const liveA = root().querySelector<HTMLImageElement>('.lightbox-image')!;
+		expect(liveA).not.toBe(firstA);
+		expect(liveA.getAttribute('src')).toBe(firstA.getAttribute('src')); // same URL
+
+		fireLoad(800, 600); // the LIVE A decodes fine → ready, no error
+		expect(root().querySelector('.lightbox-error')).toBeNull();
+
+		// The detached E1 errors LATE at the same URL — the generation fence must
+		// reject it so the live, ready image is not flipped into 'error'.
+		firstA.dispatchEvent(new Event('error'));
+		flushSync();
+		expect(root().querySelector('.lightbox-error')).toBeNull();
+	});
+});

--- a/web/src/lib/components/common/Lightbox.svelte.test.ts
+++ b/web/src/lib/components/common/Lightbox.svelte.test.ts
@@ -15,7 +15,13 @@ import {
 	ESCAPE_PRIORITY,
 	_resetEscapeStackForTests,
 } from '$lib/stores/escapeStack';
-import { reset as resetZoom, zoomTo, ZOOM_STEP, type Geometry } from '$lib/attachments/zoom';
+import {
+	reset as resetZoom,
+	zoomTo,
+	toggleFitOrActual,
+	ZOOM_STEP,
+	type Geometry,
+} from '$lib/attachments/zoom';
 
 // TASK-2429 — the DR-4b modal contract on the attachment viewer.
 //
@@ -1668,5 +1674,594 @@ describe('Lightbox — wheel zoom (TASK-2457)', () => {
 		mockOpenModals([]);
 		expect(wheel(root(), { clientX: 10, clientY: 10, deltaY: -1 })).toBe(true);
 		expect(scaleOf()).toBeCloseTo(1.25);
+	});
+});
+
+// TASK-2458 — drag-to-pan + double-click toggle (probe).
+const REAL_PC = {
+	setPointerCapture: Element.prototype.setPointerCapture,
+	releasePointerCapture: Element.prototype.releasePointerCapture,
+};
+let captured: number[] = [];
+let released: number[] = [];
+
+function pointerEvent(
+	type: string,
+	x: number,
+	y: number,
+	opts: { buttons?: number; pointerType?: string; button?: number; pointerId?: number } = {}
+): Event {
+	const e = new MouseEvent(type, { bubbles: true, cancelable: true, clientX: x, clientY: y });
+	Object.defineProperty(e, 'pointerId', { value: opts.pointerId ?? 1 });
+	Object.defineProperty(e, 'buttons', { value: opts.buttons ?? 1 });
+	Object.defineProperty(e, 'button', { value: opts.button ?? 0 });
+	Object.defineProperty(e, 'pointerType', { value: opts.pointerType ?? 'mouse' });
+	return e;
+}
+
+function panX(scope: HTMLElement = root()): number {
+	const m = /translate\(([-\d.]+)px,/.exec(transformOf(scope));
+	return m ? Number(m[1]) : NaN;
+}
+
+const OVERFLOW_G: Geometry = {
+	stageW: 1000,
+	stageH: 1000,
+	fittedW: 900,
+	fittedH: 900,
+	naturalW: 2000,
+	naturalH: 2000,
+};
+
+/** dblclick at the stage centre → actual size, so drags have pan room. */
+function zoomToActual(scope: HTMLElement = root()): void {
+	scope.dispatchEvent(new MouseEvent('dblclick', { bubbles: true, clientX: 500, clientY: 500 }));
+	flushSync();
+}
+/** The pan bound at `actualScale` for OVERFLOW_G: (900·(2000/900) − 1000)/2. */
+const ACTUAL_BOUND = (OVERFLOW_G.fittedW * (OVERFLOW_G.naturalW / OVERFLOW_G.fittedW) - OVERFLOW_G.stageW) / 2;
+
+function mockOpenModals(modals: Element[]): void {
+	const realQueryAll = document.querySelectorAll.bind(document);
+	vi.spyOn(document, 'querySelectorAll').mockImplementation((selector: string) => {
+		if (selector !== 'dialog:modal') return realQueryAll(selector);
+		return Array.from(realQueryAll('dialog')).filter((d) =>
+			modals.includes(d)
+		) as unknown as NodeListOf<Element>;
+	});
+	const realMatches = Element.prototype.matches;
+	vi.spyOn(Element.prototype, 'matches').mockImplementation(function (this: Element, selector: string) {
+		if (selector !== 'dialog:modal') return realMatches.call(this, selector);
+		return realMatches.call(this, 'dialog') && modals.includes(this);
+	});
+}
+
+describe('Lightbox — drag-to-pan and double-click (TASK-2458)', () => {
+	beforeEach(() => {
+		captured = [];
+		released = [];
+		(Element.prototype as unknown as Record<string, unknown>).setPointerCapture = function (id: number) {
+			captured.push(id);
+		};
+		(Element.prototype as unknown as Record<string, unknown>).releasePointerCapture = function (id: number) {
+			released.push(id);
+		};
+	});
+	afterEach(() => {
+		if (REAL_PC.setPointerCapture === undefined)
+			delete (Element.prototype as unknown as Record<string, unknown>).setPointerCapture;
+		else Element.prototype.setPointerCapture = REAL_PC.setPointerCapture;
+		if (REAL_PC.releasePointerCapture === undefined)
+			delete (Element.prototype as unknown as Record<string, unknown>).releasePointerCapture;
+		else Element.prototype.releasePointerCapture = REAL_PC.releasePointerCapture;
+	});
+
+	// ── pan, positively AND clamped (the anti-false-green acceptance) ──
+	it('pans in-bounds by the drag delta, then clamps at the edge and moves NO FURTHER', () => {
+		mountViewer();
+		mockGeometry(root(), OVERFLOW_G);
+		zoomToActual(); // scale ~2.22, pan bound ±ACTUAL_BOUND (500), pan still 0
+		expect(scaleOf()).toBeCloseTo(2000 / 900);
+
+		root().dispatchEvent(pointerEvent('pointerdown', 500, 500));
+		// A small in-bounds drag MOVES the transform by exactly the delta.
+		root().dispatchEvent(pointerEvent('pointermove', 600, 500));
+		flushSync();
+		expect(captured).toContain(1); // a real drag engaged + captured
+		expect(panX()).toBeCloseTo(100);
+
+		// Over-drag to the same edge: it clamps at the bound...
+		root().dispatchEvent(pointerEvent('pointermove', 500 + ACTUAL_BOUND + 300, 500));
+		flushSync();
+		expect(panX()).toBeCloseTo(ACTUAL_BOUND);
+		// ...and dragging further still moves it no further (the clamp, not the delta).
+		root().dispatchEvent(pointerEvent('pointermove', 500 + ACTUAL_BOUND + 900, 500));
+		flushSync();
+		expect(panX()).toBeCloseTo(ACTUAL_BOUND);
+
+		root().dispatchEvent(pointerEvent('pointerup', 500 + ACTUAL_BOUND + 900, 500, { buttons: 0 }));
+		expect(released).toContain(1);
+	});
+
+	// ── double-click toggle, anchored, RETURNS ──
+	/** The realistic sequence a browser fires for a double-click on `el`. */
+	function doubleClick(el: Element, clientX: number, clientY: number): void {
+		el.dispatchEvent(new MouseEvent('click', { bubbles: true, clientX, clientY }));
+		el.dispatchEvent(new MouseEvent('click', { bubbles: true, clientX, clientY }));
+		el.dispatchEvent(new MouseEvent('dblclick', { bubbles: true, clientX, clientY }));
+		flushSync();
+	}
+
+	it('two successive anchored double-clicks ON THE IMAGE toggle fit → actual → fit, never closing', () => {
+		const onClose = vi.fn();
+		mountViewer({ onClose });
+		mockGeometry(root(), OVERFLOW_G);
+		const image = root().querySelector<HTMLImageElement>('.lightbox-image')!;
+		expect(scaleOf()).toBe(1);
+
+		// The full click/click/dblclick sequence on the IMAGE (target !== backdrop),
+		// off-centre so the toggle-to-actual is genuinely anchored. The constituent
+		// clicks must NOT dismiss.
+		doubleClick(image, 800, 500);
+		expect(onClose).not.toHaveBeenCalled();
+		const expected = toggleFitOrActual(resetZoom(), { x: 800, y: 500 }, OVERFLOW_G);
+		expect(transformOf()).toBe(
+			`translate(${expected.x}px, ${expected.y}px) scale(${expected.scale})`
+		);
+		expect(expected.scale).toBeGreaterThan(1);
+		expect(expected.x).not.toBe(0);
+
+		// The SECOND double-click returns to fit, centred — the toggle is two-way.
+		doubleClick(image, 800, 500);
+		expect(onClose).not.toHaveBeenCalled();
+		expect(transformOf()).toBe('translate(0px, 0px) scale(1)');
+	});
+
+	it('a double-click while a pan is still being suppressed does NOT toggle (drag XOR toggle)', () => {
+		mountViewer();
+		mockGeometry(root(), OVERFLOW_G);
+		const image = root().querySelector<HTMLImageElement>('.lightbox-image')!;
+		// Engage and release a pan — its click is now being swallowed (suppressClick).
+		root().dispatchEvent(pointerEvent('pointerdown', 500, 500));
+		root().dispatchEvent(pointerEvent('pointermove', 600, 500));
+		root().dispatchEvent(pointerEvent('pointerup', 600, 500, { buttons: 0 }));
+		flushSync();
+		// A double-click landing while that suppression is still live must stand
+		// down — a gesture is a drag OR a toggle, never both (same swallow the
+		// backdrop click consults).
+		image.dispatchEvent(new MouseEvent('dblclick', { bubbles: true, clientX: 800, clientY: 500 }));
+		flushSync();
+		expect(scaleOf()).toBe(1);
+	});
+
+	it('a double-click does NOT toggle while a native modal is above it; it resumes after', () => {
+		const dialog = document.body.appendChild(document.createElement('dialog'));
+		mockOpenModals([dialog]);
+		mountViewer();
+		mockGeometry(root(), OVERFLOW_G);
+		const image = root().querySelector<HTMLImageElement>('.lightbox-image')!;
+
+		image.dispatchEvent(new MouseEvent('dblclick', { bubbles: true, clientX: 500, clientY: 500 }));
+		flushSync();
+		expect(scaleOf()).toBe(1); // gated out by isBlockedByModal
+
+		mockOpenModals([]);
+		image.dispatchEvent(new MouseEvent('dblclick', { bubbles: true, clientX: 500, clientY: 500 }));
+		flushSync();
+		expect(scaleOf()).toBeCloseTo(2000 / 900); // resumes
+	});
+
+	// ── drag-vs-click disambiguation ──
+	it('a below-threshold press released over the backdrop still CLOSES', () => {
+		const onClose = vi.fn();
+		mountViewer({ onClose });
+		root().dispatchEvent(pointerEvent('pointerdown', 100, 100));
+		root().dispatchEvent(pointerEvent('pointermove', 102, 101)); // < 4px → still a click
+		root().dispatchEvent(pointerEvent('pointerup', 102, 101, { buttons: 0 }));
+		flushSync();
+		// The click the press synthesizes, on the backdrop itself.
+		root().dispatchEvent(new MouseEvent('click', { bubbles: true }));
+		expect(onClose).toHaveBeenCalledTimes(1);
+		expect(captured).toEqual([]); // never engaged a drag
+	});
+
+	it('a past-threshold DRAG released over the backdrop does NOT close', () => {
+		const onClose = vi.fn();
+		mountViewer({ onClose });
+		root().dispatchEvent(pointerEvent('pointerdown', 100, 100));
+		root().dispatchEvent(pointerEvent('pointermove', 200, 200)); // > 4px → a pan
+		root().dispatchEvent(pointerEvent('pointerup', 200, 200, { buttons: 0 }));
+		flushSync();
+		// The click a pan synthesizes is suppressed (cleared only on the next tick,
+		// which this synchronous dispatch beats).
+		root().dispatchEvent(new MouseEvent('click', { bubbles: true }));
+		expect(onClose).not.toHaveBeenCalled();
+		expect(captured).toContain(1);
+	});
+
+	it('CONTROL: a plain backdrop click (no gesture) still closes', () => {
+		const onClose = vi.fn();
+		mountViewer({ onClose });
+		root().dispatchEvent(new MouseEvent('click', { bubbles: true }));
+		expect(onClose).toHaveBeenCalledTimes(1);
+	});
+
+	// ── arbitration: the START gate ──
+	it('does not START a pan when the viewer is not frontmost; the front one does', () => {
+		mountViewer();
+		const back = root();
+		mockGeometry(back, OVERFLOW_G);
+		mountViewer();
+		const front = root();
+		mockGeometry(front, OVERFLOW_G);
+		zoomToActual(front);
+
+		// Drag on the BACKGROUND viewer: no capture, no pan.
+		back.dispatchEvent(pointerEvent('pointerdown', 500, 500));
+		back.dispatchEvent(pointerEvent('pointermove', 600, 500));
+		flushSync();
+		expect(captured).toEqual([]);
+
+		// Positive control: the FRONT viewer pans.
+		front.dispatchEvent(pointerEvent('pointerdown', 500, 500));
+		front.dispatchEvent(pointerEvent('pointermove', 600, 500));
+		flushSync();
+		expect(captured).toContain(1);
+		expect(panX(front)).toBeCloseTo(100);
+	});
+
+	// ── arbitration: whole-gesture, a STACKED-VIEWER transition mid-drag ──
+	it('ABORTS a captured drag when a SECOND viewer becomes frontmost mid-gesture', () => {
+		mountViewer();
+		const first = root();
+		mockGeometry(first, OVERFLOW_G);
+		zoomToActual(first);
+
+		first.dispatchEvent(pointerEvent('pointerdown', 500, 500));
+		first.dispatchEvent(pointerEvent('pointermove', 600, 500)); // positive control: pans to 100
+		flushSync();
+		expect(captured).toContain(1);
+		expect(panX(first)).toBeCloseTo(100);
+		const frozen = panX(first);
+
+		// A second viewer opens — `first` is no longer frontmost.
+		mountViewer();
+
+		// A further move on `first` (still captured there) must ABORT: release the
+		// capture, leave the transform where it was.
+		first.dispatchEvent(pointerEvent('pointermove', 900, 500));
+		flushSync();
+		expect(released).toContain(1);
+		expect(panX(first)).toBeCloseTo(frozen);
+	});
+
+	// ── arbitration: whole-gesture, a NATIVE-MODAL transition mid-drag ──
+	it('ABORTS a captured drag when a native modal opens above it mid-gesture', () => {
+		const dialog = document.body.appendChild(document.createElement('dialog'));
+		// Establish `:modal` support with NO modal first (jsdom throws on the
+		// pseudo-class, and the manager caches support on its first probe), so the
+		// drag can start; then add the dialog mid-gesture.
+		mockOpenModals([]);
+		mountViewer();
+		mockGeometry(root(), OVERFLOW_G);
+		zoomToActual();
+
+		root().dispatchEvent(pointerEvent('pointerdown', 500, 500));
+		root().dispatchEvent(pointerEvent('pointermove', 600, 500)); // positive control: pans
+		flushSync();
+		expect(captured).toContain(1);
+		expect(panX()).toBeCloseTo(100);
+		const frozen = panX();
+
+		mockOpenModals([dialog]); // a showModal() dialog is now above the viewer
+
+		root().dispatchEvent(pointerEvent('pointermove', 900, 500));
+		flushSync();
+		expect(released).toContain(1);
+		expect(panX()).toBeCloseTo(frozen);
+	});
+
+	// ── integration details ──
+	it('marks the image non-draggable so a native image drag cannot pre-empt the pan', () => {
+		mountViewer();
+		expect(root().querySelector('.lightbox-image')?.getAttribute('draggable')).toBe('false');
+	});
+
+	it('ignores a TOUCH pointer (native until 3d); a mouse pointer pans', () => {
+		mountViewer();
+		mockGeometry(root(), OVERFLOW_G);
+		zoomToActual();
+
+		root().dispatchEvent(pointerEvent('pointerdown', 500, 500, { pointerType: 'touch' }));
+		root().dispatchEvent(pointerEvent('pointermove', 600, 500, { pointerType: 'touch' }));
+		flushSync();
+		expect(captured).toEqual([]);
+
+		root().dispatchEvent(pointerEvent('pointerdown', 500, 500));
+		root().dispatchEvent(pointerEvent('pointermove', 600, 500));
+		flushSync();
+		expect(captured).toContain(1);
+		expect(panX()).toBeCloseTo(100);
+	});
+
+	it('drops the transform transition while dragging (image tracks the pointer), restoring it after', () => {
+		// jsdom applies no transitions, so assert the mechanism: the `panning` class
+		// (which sets transition:none) is present only for the duration of the drag.
+		mountViewer();
+		mockGeometry(root(), OVERFLOW_G);
+		zoomToActual();
+		const image = root().querySelector<HTMLImageElement>('.lightbox-image')!;
+		expect(image.classList.contains('panning')).toBe(false);
+
+		root().dispatchEvent(pointerEvent('pointerdown', 500, 500));
+		root().dispatchEvent(pointerEvent('pointermove', 600, 500));
+		flushSync();
+		expect(image.classList.contains('panning')).toBe(true);
+
+		root().dispatchEvent(pointerEvent('pointerup', 600, 500, { buttons: 0 }));
+		flushSync();
+		expect(image.classList.contains('panning')).toBe(false);
+	});
+
+	it('a TOUCH or second pointer cannot move or END an active mouse drag', () => {
+		mountViewer();
+		mockGeometry(root(), OVERFLOW_G);
+		zoomToActual();
+		// Mouse drag engaged (pointerId 1).
+		root().dispatchEvent(pointerEvent('pointerdown', 500, 500));
+		root().dispatchEvent(pointerEvent('pointermove', 600, 500));
+		flushSync();
+		expect(panX()).toBeCloseTo(100);
+
+		// A touch move with a DIFFERENT pointerId (not captured) must not pan...
+		root().dispatchEvent(
+			pointerEvent('pointermove', 900, 500, { pointerId: 2, pointerType: 'touch' })
+		);
+		flushSync();
+		expect(panX()).toBeCloseTo(100);
+
+		// ...and a touch pointerup must not END the mouse drag.
+		root().dispatchEvent(
+			pointerEvent('pointerup', 900, 500, { pointerId: 2, pointerType: 'touch', buttons: 0 })
+		);
+		flushSync();
+		expect(released).not.toContain(2);
+
+		// The mouse (pointerId 1) is still driving: its move pans further.
+		root().dispatchEvent(pointerEvent('pointermove', 700, 500));
+		flushSync();
+		expect(panX()).toBeCloseTo(200);
+	});
+
+	it('a second primary pointerdown mid-drag does NOT hijack the gesture', () => {
+		mountViewer();
+		mockGeometry(root(), OVERFLOW_G);
+		zoomToActual();
+		root().dispatchEvent(pointerEvent('pointerdown', 500, 500)); // mouse id 1
+		root().dispatchEvent(pointerEvent('pointermove', 600, 500)); // captured, x = 100
+		flushSync();
+		expect(panX()).toBeCloseTo(100);
+
+		// A second primary press (a pen, id 2) lands mid-drag — it must be ignored,
+		// not re-arm the gesture onto itself.
+		root().dispatchEvent(
+			pointerEvent('pointerdown', 200, 200, { pointerId: 2, pointerType: 'pen' })
+		);
+		// The ORIGINAL pointer (id 1) still drives the pan.
+		root().dispatchEvent(pointerEvent('pointermove', 700, 500));
+		flushSync();
+		expect(panX()).toBeCloseTo(200);
+		// ...and the interloper's own move does nothing.
+		root().dispatchEvent(
+			pointerEvent('pointermove', 900, 900, { pointerId: 2, pointerType: 'pen' })
+		);
+		flushSync();
+		expect(panX()).toBeCloseTo(200);
+	});
+
+	it('releases the capture on pointercancel', () => {
+		mountViewer();
+		mockGeometry(root(), OVERFLOW_G);
+		zoomToActual();
+		root().dispatchEvent(pointerEvent('pointerdown', 500, 500));
+		root().dispatchEvent(pointerEvent('pointermove', 600, 500));
+		flushSync();
+		expect(captured).toContain(1);
+		root().dispatchEvent(pointerEvent('pointercancel', 600, 500));
+		expect(released).toContain(1);
+	});
+
+	// ── gesture-state hygiene (round 1) ──
+	it('a wheel DURING a captured drag does not snap the pan back (rebases the baseline)', () => {
+		mountViewer();
+		mockGeometry(root(), OVERFLOW_G);
+		zoomToActual();
+		root().dispatchEvent(pointerEvent('pointerdown', 500, 500));
+		root().dispatchEvent(pointerEvent('pointermove', 700, 500)); // captured, x = 200
+		flushSync();
+		expect(panX()).toBeCloseTo(200);
+
+		// A wheel arrives mid-drag, anchored at the stage CENTRE (500) — distinct
+		// from the drag position — so it moves the pan to a value the pre-wheel
+		// origin+delta does NOT reproduce. The baseline must rebase to the wheel's
+		// pointer position (500) and post-wheel pan, so a following pointermove to
+		// that same point (zero net delta) leaves the transform where the wheel put
+		// it. Without the rebase, that move snaps the pan back to the pre-wheel
+		// origin (0) — a visible jump.
+		wheel(root(), { clientX: 500, clientY: 500, deltaY: -1 });
+		const afterWheel = transformOf();
+		expect(panX()).not.toBeCloseTo(200); // the wheel genuinely moved the pan
+		root().dispatchEvent(pointerEvent('pointermove', 500, 500));
+		flushSync();
+		expect(transformOf()).toBe(afterWheel);
+	});
+
+	it('a keyboard zoom (+) DURING a captured drag does not snap the pan back', () => {
+		mountViewer();
+		mockGeometry(root(), OVERFLOW_G);
+		zoomToActual();
+		root().dispatchEvent(pointerEvent('pointerdown', 500, 500));
+		root().dispatchEvent(pointerEvent('pointermove', 700, 500)); // captured, x = 200
+		flushSync();
+		expect(panX()).toBeCloseTo(200);
+
+		// `+` zooms about the stage centre mid-drag, moving the pan; the drag
+		// baseline must rebase to the last pointer position (700), so a move back to
+		// that point is a zero net delta and holds. Without the rebase it snaps to
+		// the pre-key origin + total delta.
+		expect(press('+')).toBe(true);
+		const afterKey = transformOf();
+		expect(panX()).not.toBeCloseTo(200);
+		root().dispatchEvent(pointerEvent('pointermove', 700, 500));
+		flushSync();
+		expect(transformOf()).toBe(afterKey);
+	});
+
+	it('an external zoom while ARMED (before the drag threshold) rebases, so engaging does not jump', () => {
+		mountViewer();
+		mockGeometry(root(), OVERFLOW_G);
+		zoomToActual();
+		// Arm the gesture (pointerdown) but stay below the 4px threshold.
+		root().dispatchEvent(pointerEvent('pointerdown', 500, 500));
+		// A wheel zooms while merely ARMED (not yet dragging), anchored off-centre so
+		// it moves the pan.
+		wheel(root(), { clientX: 800, clientY: 500, deltaY: -1 });
+		const afterWheelPan = panX();
+		expect(afterWheelPan).not.toBeCloseTo(0);
+
+		// Cross the threshold with a small move from the WHEEL pointer position: the
+		// engage must continue from the post-wheel pan (armed rebase), NOT snap to
+		// origin(0) + the full delta from the original press point.
+		root().dispatchEvent(pointerEvent('pointermove', 810, 500));
+		flushSync();
+		expect(captured).toContain(1);
+		expect(panX()).toBeCloseTo(afterWheelPan + 10);
+	});
+
+	it('a stale armed gesture (missed pointerup) does not resume as a phantom drag on a later control press', () => {
+		mountViewer({ images: [image(IMG_A, 'a'), image(IMG_B, 'b', 'image/jpeg')] });
+		mockGeometry(root(), OVERFLOW_G);
+		zoomToActual();
+		// Arm a gesture whose pointerup never arrives (the pointer left the root
+		// before the drag threshold, so there was no capture to deliver it).
+		root().dispatchEvent(pointerEvent('pointerdown', 100, 100));
+		// A later press lands on a control — excluded from starting a pan, and must
+		// also clear the stale arm so the following move can't engage from a dead
+		// baseline.
+		const close = closeButton();
+		close.dispatchEvent(pointerEvent('pointerdown', 20, 20));
+		close.dispatchEvent(pointerEvent('pointermove', 300, 300)); // far past threshold
+		flushSync();
+		expect(captured).toEqual([]);
+	});
+
+	it('a double-click on a nav control does NOT also toggle zoom', () => {
+		mountViewer({ images: [image(IMG_A, 'a'), image(IMG_B, 'b', 'image/jpeg')] });
+		mockGeometry(root(), OVERFLOW_G);
+		const next = root().querySelector<HTMLButtonElement>('.lightbox-nav.next')!;
+		expect(scaleOf()).toBe(1);
+		next.dispatchEvent(new MouseEvent('dblclick', { bubbles: true, clientX: 20, clientY: 20 }));
+		flushSync();
+		expect(scaleOf()).toBe(1); // the toggle stood down for the control
+	});
+
+	it('a mid-capture ABORT leaves the SAME viewer able to start a clean next gesture', () => {
+		const dialog = document.body.appendChild(document.createElement('dialog'));
+		mockOpenModals([]); // establish :modal support with nothing open
+		mountViewer();
+		mockGeometry(root(), OVERFLOW_G);
+		zoomToActual();
+		root().dispatchEvent(pointerEvent('pointerdown', 500, 500));
+		root().dispatchEvent(pointerEvent('pointermove', 600, 500));
+		flushSync();
+		expect(captured).toContain(1);
+
+		mockOpenModals([dialog]); // blocked → the next move aborts
+		root().dispatchEvent(pointerEvent('pointermove', 900, 500));
+		flushSync();
+		expect(released).toContain(1);
+		mockOpenModals([]); // unblocked; same viewer frontmost again
+
+		// A fresh gesture engages cleanly — no stuck `dragging` / capture from abort.
+		captured.length = 0;
+		released.length = 0;
+		root().dispatchEvent(pointerEvent('pointerdown', 500, 500));
+		root().dispatchEvent(pointerEvent('pointermove', 560, 500));
+		flushSync();
+		expect(captured).toContain(1);
+		root().dispatchEvent(pointerEvent('pointerup', 560, 500, { buttons: 0 }));
+		expect(released).toContain(1);
+	});
+
+	it('a buttons-released move after a drag releases capture, not leaking into the next gesture', () => {
+		mountViewer();
+		mockGeometry(root(), OVERFLOW_G);
+		zoomToActual();
+		root().dispatchEvent(pointerEvent('pointerdown', 500, 500));
+		root().dispatchEvent(pointerEvent('pointermove', 600, 500));
+		flushSync();
+		expect(captured).toContain(1);
+
+		// A move with the primary button no longer held — a pointerup we never saw.
+		root().dispatchEvent(pointerEvent('pointermove', 650, 500, { buttons: 0 }));
+		flushSync();
+		expect(released).toContain(1);
+
+		captured.length = 0;
+		released.length = 0;
+		root().dispatchEvent(pointerEvent('pointerdown', 500, 500));
+		root().dispatchEvent(pointerEvent('pointermove', 560, 500));
+		flushSync();
+		expect(captured).toContain(1);
+	});
+
+	it('lostpointercapture ends the gesture; the next one starts clean', () => {
+		mountViewer();
+		mockGeometry(root(), OVERFLOW_G);
+		zoomToActual();
+		root().dispatchEvent(pointerEvent('pointerdown', 500, 500));
+		root().dispatchEvent(pointerEvent('pointermove', 600, 500));
+		flushSync();
+		expect(captured).toContain(1);
+
+		root().dispatchEvent(pointerEvent('lostpointercapture', 600, 500));
+		flushSync();
+
+		captured.length = 0;
+		root().dispatchEvent(pointerEvent('pointerdown', 500, 500));
+		root().dispatchEvent(pointerEvent('pointermove', 560, 500));
+		flushSync();
+		expect(captured).toContain(1);
+	});
+
+	it('a press ON a control (close / nav) never starts a pan', () => {
+		mountViewer({ images: [image(IMG_A, 'a'), image(IMG_B, 'b', 'image/jpeg')] });
+		mockGeometry(root(), OVERFLOW_G);
+		zoomToActual();
+		const close = closeButton();
+		// Press on the control, then move well past the threshold: a drag OFF a
+		// button must not engage a pan (its own click stays intact).
+		close.dispatchEvent(pointerEvent('pointerdown', 20, 20));
+		close.dispatchEvent(pointerEvent('pointermove', 200, 200));
+		flushSync();
+		expect(captured).toEqual([]);
+	});
+
+	// ── the pointer entry points carry the same gates ──
+	it('double-click does NOT toggle when the viewer is not frontmost; the front one does', () => {
+		mountViewer();
+		const back = root();
+		mockGeometry(back, OVERFLOW_G);
+		mountViewer();
+		const front = root();
+		mockGeometry(front, OVERFLOW_G);
+
+		back.dispatchEvent(new MouseEvent('dblclick', { bubbles: true, clientX: 500, clientY: 500 }));
+		flushSync();
+		expect(scaleOf(back)).toBe(1); // background viewer did not toggle
+
+		front.dispatchEvent(new MouseEvent('dblclick', { bubbles: true, clientX: 500, clientY: 500 }));
+		flushSync();
+		expect(scaleOf(front)).toBeCloseTo(2000 / 900); // frontmost did
 	});
 });

--- a/web/src/lib/components/common/Lightbox.svelte.test.ts
+++ b/web/src/lib/components/common/Lightbox.svelte.test.ts
@@ -23,6 +23,30 @@ import {
 	type Geometry,
 } from '$lib/attachments/zoom';
 
+// TASK-2460 — the mobile DR-5b cells. `viewport.isMobile` is module state read
+// from matchMedia at init (false under jsdom), so a controllable mock lets a few
+// tests drive the mobile path. It DEFAULTS to desktop, so every other test in this
+// file is unchanged; flip `mobileFlag` BEFORE mounting (the loader captures the
+// platform at load time) and the mobile describe restores it.
+//
+// The mock delegates through a hoisted holder to a module-level `$state`, so a
+// flip is genuinely REACTIVE — the viewer's `platform` derived re-runs. A plain
+// object getter would be read once at mount and never invalidate, which would make
+// the breakpoint-flip test vacuous (it would pass whether or not the load effect
+// wrongly tracked `platform`). `.svelte.test.ts` supports runes.
+const mobileHolder = vi.hoisted(() => ({ read: () => false }));
+vi.mock('$lib/stores/breakpoint.svelte', () => ({
+	viewport: {
+		get isMobile() {
+			return mobileHolder.read();
+		},
+	},
+	MOBILE_BREAKPOINT: 768,
+	MOBILE_MEDIA_QUERY: '(max-width: 768px)',
+}));
+let mobileFlag = $state(false);
+mobileHolder.read = () => mobileFlag;
+
 // TASK-2429 — the DR-4b modal contract on the attachment viewer.
 //
 // WHAT JSDOM CANNOT PROVE, and is therefore TASK-2436's browser suite (DR-9):
@@ -2496,5 +2520,160 @@ describe('Lightbox — DR-5b image loading (TASK-2459)', () => {
 		firstA.dispatchEvent(new Event('error'));
 		flushSync();
 		expect(root().querySelector('.lightbox-error')).toBeNull();
+	});
+});
+
+// ── TASK-2460: the mobile DR-5b cells wired into the viewer ──────────────────
+// The request policy is proven in viewerImageLoader.svelte.test.ts; these pin the
+// WIRING under a mobile viewport — the tap affordance renders and issues the
+// request, zoom-past-fit upgrades the thumb, and zoom is disabled with no bitmap.
+describe('Lightbox — mobile tap-to-load and zoom-past-fit (TASK-2460)', () => {
+	beforeEach(() => {
+		mobileFlag = true;
+		flushSync();
+	});
+	afterEach(() => {
+		mobileFlag = false;
+		flushSync();
+	});
+
+	function tapButton(scope: HTMLElement = root()): HTMLButtonElement {
+		return scope.querySelector<HTMLButtonElement>('.lightbox-tap-load')!;
+	}
+
+	it('mobile + large: NO automatic request — a named tap affordance instead', () => {
+		mountViewer({ images: [sized(IMG_A, 'big', 5000, 5000)] });
+		// The assertion that fails if the deferral is dropped: no <img>, no request.
+		expect(root().querySelector('.lightbox-image')).toBeNull();
+		const tap = tapButton();
+		expect(tap).not.toBeNull();
+		// Named, and NOT pointer-dead under the stage's `pointer-events: none`.
+		expect(tap.textContent?.trim()).toBe('Tap to load full image');
+		expect(getComputedStyle(tap).pointerEvents).not.toBe('none');
+	});
+
+	it('mobile + unknown dims: also deferred (tap affordance, no request)', () => {
+		mountViewer({ images: [image(IMG_A, 'unknown')] }); // helper leaves dims null
+		expect(root().querySelector('.lightbox-image')).toBeNull();
+		expect(tapButton()).not.toBeNull();
+	});
+
+	it('TAP-ONLY leg: the tap itself issues the request (the original, no variant)', () => {
+		mountViewer({ images: [sized(IMG_A, 'big', 5000, 5000)] });
+		expect(root().querySelector('.lightbox-image')).toBeNull();
+		tapButton().click();
+		flushSync();
+		// The tap loaded the ORIGINAL directly (mobile large has no thumb).
+		expect(imageSrc()).toContain(IMG_A);
+		expect(imageSrc()).not.toContain('variant=');
+		// The affordance is gone (replaced by the image it loads).
+		expect(root().querySelector('.lightbox-tap-load')).toBeNull();
+	});
+
+	it('a focused tap that unmounts on load hands focus off (does not strand <body>)', () => {
+		mountViewer({ images: [sized(IMG_A, 'big', 5000, 5000)] });
+		const tap = tapButton();
+		tap.focus();
+		expect(document.activeElement).toBe(tap);
+		tap.click();
+		flushSync();
+		expect(root().querySelector('.lightbox-tap-load')).toBeNull();
+		expect(document.activeElement).not.toBe(document.body);
+	});
+
+	it('the placeholder takes the image aspect ratio when known, a neutral box otherwise', () => {
+		// Genuinely LARGE (> 8 MP) so it is the deferred cell, not the thumb cell.
+		mountViewer({ images: [sized(IMG_A, 'big', 5000, 2500)] });
+		expect(tapButton().getAttribute('style')).toContain('aspect-ratio: 5000 / 2500');
+		unmount(mounted.pop()!);
+
+		mountViewer({ images: [image(IMG_B, 'unknown')] });
+		const style = tapButton().getAttribute('style') ?? '';
+		expect(style).not.toContain('aspect-ratio');
+		expect(style).toContain('height'); // a neutral, explicitly-sized box
+	});
+
+	it('mobile thumb cell: zoom-past-fit upgrades to the original exactly once', () => {
+		mountViewer({ images: [sized(IMG_A, 'wide', 2000, 100)] });
+		expect(imageSrc()).toContain('variant=thumb-md'); // thumb painted, no auto-upgrade
+		fireLoad(1024, 51);
+		expect(imageSrc()).toContain('variant=thumb-md'); // mobile: stays the thumb
+
+		// Zoom past fit — the same element is reused (no flash), src swaps to original.
+		const thumbEl = root().querySelector<HTMLImageElement>('.lightbox-image');
+		expect(press('+')).toBe(true);
+		expect(scaleOf()).toBeGreaterThan(1); // actually past fit
+		expect(imageSrc()).toContain(IMG_A);
+		expect(imageSrc()).not.toContain('variant='); // the original
+		expect(root().querySelector('.lightbox-image')).toBe(thumbEl); // reused, no remount
+
+		// Further zoom steps do NOT re-request — one fetch, not one per step.
+		expect(press('+')).toBe(true);
+		expect(imageSrc()).not.toContain('variant=');
+		expect(root().querySelector('.lightbox-image')).toBe(thumbEl);
+	});
+
+	it('a zoom-past-fit made BEFORE the thumb paints upgrades the moment it paints', () => {
+		mountViewer({ images: [sized(IMG_A, 'wide', 2000, 100)] });
+		expect(imageSrc()).toContain('variant=thumb-md'); // loading, not yet decoded
+		// Zoom past fit while still loading — no original yet (the trigger waits for
+		// a painted bitmap).
+		expect(press('+')).toBe(true);
+		expect(scaleOf()).toBeGreaterThan(1);
+		expect(imageSrc()).toContain('variant=thumb-md'); // no upgrade before paint
+
+		// The thumb paints while ALREADY zoomed past fit → the original is fetched
+		// now, with no further gesture, so the user is never stranded on the thumb.
+		fireLoad(1024, 51);
+		expect(imageSrc()).not.toContain('variant=');
+	});
+
+	it('zoom is DISABLED while nothing is decoded (the deferred cell): keys do nothing', () => {
+		mountViewer({ images: [sized(IMG_A, 'big', 5000, 5000)] });
+		expect(root().querySelector('.lightbox-image')).toBeNull();
+		// The zoom keys are consumed (owned by the modal) but inert — no image loads,
+		// the affordance stays, and nothing throws.
+		expect(press('0')).toBe(true);
+		expect(press('+')).toBe(true);
+		expect(press('-')).toBe(true);
+		expect(root().querySelector('.lightbox-image')).toBeNull();
+		expect(tapButton()).not.toBeNull();
+	});
+
+	it('a drag over the deferred placeholder is inert: it captures nothing', () => {
+		mountViewer({ images: [sized(IMG_A, 'big', 5000, 5000)] });
+		// The pan handlers live on the backdrop and `setPointerCapture` there once a
+		// drag engages past threshold. WITHOUT the `bitmapPresent` gate the move below
+		// would arm a drag and capture; the gate keeps it fully inert. Spying on the
+		// capture makes this regression-sensitive (a passed pointerup would otherwise
+		// clear `dragging` and mask a missing gate).
+		// jsdom has no `setPointerCapture` (the production code try/catches it), so
+		// install a mock fn to observe the attempt rather than spying a missing method.
+		const captureSpy = vi.fn();
+		(root() as unknown as { setPointerCapture: unknown }).setPointerCapture = captureSpy;
+		root().dispatchEvent(pointerEvent('pointerdown', 100, 100));
+		root().dispatchEvent(pointerEvent('pointermove', 320, 100)); // well past threshold
+		flushSync();
+		expect(captureSpy).not.toHaveBeenCalled();
+		root().dispatchEvent(pointerEvent('pointerup', 320, 100));
+		flushSync();
+		// Nothing loaded; the affordance is intact and the tap still issues the request.
+		expect(root().querySelector('.lightbox-image')).toBeNull();
+		expect(tapButton()).not.toBeNull();
+		tapButton().click();
+		flushSync();
+		expect(imageSrc()).toContain(IMG_A);
+	});
+
+	it('mobile→desktop breakpoint flip does NOT retro-fetch: the affordance stays', () => {
+		mountViewer({ images: [sized(IMG_A, 'big', 5000, 5000)] });
+		expect(tapButton()).not.toBeNull();
+		// Flip to desktop AFTER the load captured mobile — the reactive flip now
+		// really invalidates `platform`, and the load effect (which untracks it) must
+		// still not re-run, so nothing is fetched and the affordance stays.
+		mobileFlag = false;
+		flushSync();
+		expect(root().querySelector('.lightbox-image')).toBeNull();
+		expect(root().querySelector('.lightbox-tap-load')).not.toBeNull();
 	});
 });

--- a/web/src/lib/components/common/Lightbox.svelte.test.ts
+++ b/web/src/lib/components/common/Lightbox.svelte.test.ts
@@ -120,6 +120,26 @@ function closeButton(scope: HTMLElement = root()): HTMLButtonElement {
 	return scope.querySelector<HTMLButtonElement>('.lightbox-close')!;
 }
 
+/** The `transform` inline style on the viewer's image (empty before it mounts). */
+function transformOf(scope: HTMLElement = root()): string {
+	return scope.querySelector<HTMLImageElement>('.lightbox-image')?.style.transform ?? '';
+}
+
+/**
+ * The `scale(...)` factor currently on the image, or NaN if there is none.
+ *
+ * jsdom lays nothing out, so the geometry the zoom module reads is all zeros —
+ * but `maxScale` FALLS BACK to `4` on an unusable geometry (a small image still
+ * needs a zoom range), so `zoomTo` still moves off fit here. That is what makes
+ * the scale observable in jsdom at all; the pan bounds, which DO need real
+ * geometry, are exercised in the browser suite (TASK-2436) and proven in
+ * `zoom.test.ts`.
+ */
+function scaleOf(scope: HTMLElement = root()): number {
+	const m = /scale\(([-\d.]+)\)/.exec(transformOf(scope));
+	return m ? Number(m[1]) : NaN;
+}
+
 /** A cancelable window keydown, returning whether the app consumed it. */
 function press(key: string, init: KeyboardEventInit = {}): boolean {
 	const event = new KeyboardEvent('keydown', { key, cancelable: true, bubbles: true, ...init });
@@ -154,6 +174,9 @@ afterEach(() => {
 	_resetEscapeStackForTests();
 	HTMLElement.prototype.getClientRects = realGetClientRects;
 	vi.restoreAllMocks();
+	// The zoom resize test installs a driving `ResizeObserver` via `vi.stubGlobal`;
+	// restore the setup-file's global inert shim so it can't leak into a later test.
+	vi.unstubAllGlobals();
 });
 
 describe('Lightbox — dialog semantics', () => {
@@ -1016,5 +1039,328 @@ describe('Lightbox — background inertness (delegated)', () => {
 		flushSync();
 		expect(document.activeElement).not.toBe(invokerFront);
 		expect(back.contains(document.activeElement)).toBe(true);
+	});
+});
+
+// TASK-2455 — the zoom transform wired into the viewer (PLAN-2392 phase 3b).
+//
+// jsdom has no layout, so these assert the WIRING and the ARBITRATION, not the
+// pan geometry: which key does what, that the modifier / gate rules hold, and
+// that the transform resets when the shown image changes. The arithmetic those
+// keys drive is proven browser-free in `zoom.test.ts`; the pixel geometry is
+// TASK-2436's browser suite.
+
+describe('Lightbox — zoom keys', () => {
+	it('zooms IN on + (identity → one step), centred', () => {
+		mountViewer();
+		expect(scaleOf()).toBe(1);
+		expect(transformOf()).toBe('translate(0px, 0px) scale(1)');
+
+		expect(press('+')).toBe(true);
+		expect(scaleOf()).toBeCloseTo(1.25);
+		// A centre-anchored zoom leaves the pan at zero.
+		expect(transformOf()).toContain('translate(0px, 0px)');
+	});
+
+	it('accepts a bare = as zoom-IN (the unshifted key on most layouts)', () => {
+		mountViewer();
+		expect(press('=')).toBe(true);
+		expect(scaleOf()).toBeCloseTo(1.25);
+	});
+
+	it('accepts the numpad plus — matched on .key, so .code is irrelevant', () => {
+		// The numpad's `+` reports `key === '+'` (only `code` says `NumpadAdd`), so
+		// a code-based match would silently miss it. This pins the key-based one.
+		mountViewer();
+		const event = new KeyboardEvent('keydown', {
+			key: '+',
+			code: 'NumpadAdd',
+			cancelable: true,
+			bubbles: true,
+		});
+		window.dispatchEvent(event);
+		flushSync();
+		expect(event.defaultPrevented).toBe(true);
+		expect(scaleOf()).toBeCloseTo(1.25);
+	});
+
+	it('zooms OUT on - (back toward fit)', () => {
+		mountViewer();
+		press('+');
+		press('+');
+		expect(scaleOf()).toBeCloseTo(1.25 * 1.25);
+		expect(press('-')).toBe(true);
+		expect(scaleOf()).toBeCloseTo(1.25);
+	});
+
+	it('does not zoom below fit: - at fit is a no-op', () => {
+		// The floor is FIT (=1); `clampScale` holds it, so `-` at fit changes
+		// nothing rather than shrinking the image past its fitted box.
+		mountViewer();
+		expect(press('-')).toBe(true);
+		expect(scaleOf()).toBe(1);
+	});
+
+	it('resets to fit, centred, on 0', () => {
+		mountViewer();
+		press('+');
+		press('+');
+		expect(scaleOf()).toBeGreaterThan(1);
+		expect(press('0')).toBe(true);
+		expect(scaleOf()).toBe(1);
+		expect(transformOf()).toBe('translate(0px, 0px) scale(1)');
+	});
+
+	it('IGNORES + when Alt is held — and does NOT preventDefault', () => {
+		// Alt-modified is the OS's, not ours. Acting would be wrong; ALSO
+		// preventing default would cancel the OS shortcut even though we declined.
+		mountViewer();
+		expect(press('+', { altKey: true })).toBe(false);
+		expect(scaleOf()).toBe(1);
+	});
+
+	it('IGNORES - when Ctrl is held (browser page-zoom-out) — and does NOT preventDefault', () => {
+		// The whole reason the modifier rule is a contract: this listens on
+		// `window`, so swallowing Ctrl+- would break page-zoom from every surface
+		// while a viewer is open.
+		mountViewer();
+		expect(press('-', { ctrlKey: true })).toBe(false);
+		expect(scaleOf()).toBe(1);
+	});
+
+	it('IGNORES 0 when Cmd is held (browser reset-zoom) — and does NOT preventDefault', () => {
+		mountViewer();
+		press('+');
+		expect(scaleOf()).toBeCloseTo(1.25);
+		// Cmd+0 is the browser's reset — leave the viewer's own zoom untouched and
+		// let the event through.
+		expect(press('0', { metaKey: true })).toBe(false);
+		expect(scaleOf()).toBeCloseTo(1.25);
+	});
+});
+
+describe('Lightbox — zoom keys are ARBITRATED, not just handled', () => {
+	// A `+`/`-`/`0` branch placed BEFORE the existing gates would pass every zoom
+	// test above while stealing a press another owner or a layer is due. Each gate
+	// gets its own leg with a positive control.
+
+	function mockOpenModals(modals: Element[]): void {
+		const realQueryAll = document.querySelectorAll.bind(document);
+		vi.spyOn(document, 'querySelectorAll').mockImplementation((selector: string) => {
+			if (selector !== 'dialog:modal') return realQueryAll(selector);
+			return Array.from(realQueryAll('dialog')).filter((d) =>
+				modals.includes(d)
+			) as unknown as NodeListOf<Element>;
+		});
+		const realMatches = Element.prototype.matches;
+		vi.spyOn(Element.prototype, 'matches').mockImplementation(function (
+			this: Element,
+			selector: string
+		) {
+			if (selector !== 'dialog:modal') return realMatches.call(this, selector);
+			return realMatches.call(this, 'dialog') && modals.includes(this);
+		});
+	}
+
+	it('declines a key another control already handled (defaultPrevented) — control: an un-consumed one acts', () => {
+		mountViewer();
+		const consumed = new KeyboardEvent('keydown', { key: '+', cancelable: true, bubbles: true });
+		consumed.preventDefault();
+		window.dispatchEvent(consumed);
+		flushSync();
+		expect(scaleOf()).toBe(1);
+
+		// Positive control: the SAME key, not pre-consumed, does zoom.
+		expect(press('+')).toBe(true);
+		expect(scaleOf()).toBeCloseTo(1.25);
+	});
+
+	it('zooms only the FRONTMOST viewer, never the one behind it', () => {
+		mountViewer();
+		const back = root();
+		mountViewer();
+		const front = root();
+		expect(back).not.toBe(front);
+
+		expect(press('+')).toBe(true);
+		expect(scaleOf(front)).toBeCloseTo(1.25);
+		expect(scaleOf(back)).toBe(1);
+	});
+
+	it('stands down while a showModal() dialog is above it, and resumes after it closes', () => {
+		// The emulation goes in BEFORE the mount: the manager probes `:modal` on
+		// its first reconcile and jsdom's throw makes it cache "unsupported" for
+		// the module's life, so mocking afterwards would be ignored.
+		const dialog = document.body.appendChild(document.createElement('dialog'));
+		mockOpenModals([dialog]);
+		mountViewer();
+
+		expect(press('+')).toBe(false);
+		expect(scaleOf()).toBe(1);
+
+		mockOpenModals([]);
+		expect(press('+')).toBe(true);
+		expect(scaleOf()).toBeCloseTo(1.25);
+	});
+});
+
+describe('Lightbox — the transform resets when the shown image changes (TASK-2455)', () => {
+	function mountLive() {
+		const app = mount(Lightbox, { target: appRoot, props: liveProps });
+		mounted.push(app);
+		flushSync();
+		return app;
+	}
+
+	it('resets on arrow navigation', () => {
+		mountViewer({ images: [image(IMG_A, 'first'), image(IMG_B, 'second')] });
+		press('+');
+		expect(scaleOf()).toBeCloseTo(1.25);
+
+		expect(press('ArrowRight')).toBe(true);
+		expect(imageSrc()).toContain(IMG_B);
+		expect(scaleOf()).toBe(1);
+	});
+
+	it('resets when the set shrinks under `current` so a DIFFERENT image is shown', () => {
+		liveProps.images = [image(IMG_A, 'png'), image(IMG_B, 'later-svg')];
+		mountLive();
+		press('ArrowRight');
+		expect(imageSrc()).toContain(IMG_B);
+		press('+');
+		expect(scaleOf()).toBeCloseTo(1.25);
+
+		// B's MIME resolves unsafe → it drops out → the shown image becomes A →
+		// the transform is back at fit.
+		liveProps.images = [image(IMG_A, 'png'), image(IMG_B, 'later-svg', 'image/svg+xml')];
+		flushSync();
+		expect(imageSrc()).toContain(IMG_A);
+		expect(scaleOf()).toBe(1);
+	});
+
+	it('does NOT reset (and keeps the zoom) when an image is added AFTER the shown one', () => {
+		// The reset keys on the shown image's identity, not on the array changing:
+		// growing the set past `current` leaves the shown image — and its zoom —
+		// alone.
+		liveProps.images = [image(IMG_A, 'only')];
+		mountLive();
+		press('+');
+		expect(scaleOf()).toBeCloseTo(1.25);
+
+		liveProps.images = [image(IMG_A, 'only'), image(IMG_C, 'second', 'image/jpeg')];
+		flushSync();
+		expect(imageSrc()).toContain(IMG_A);
+		expect(scaleOf()).toBeCloseTo(1.25);
+	});
+
+	it('a reset does not wedge the scheduler: unrelated reactivity still flushes AFTER a navigate', () => {
+		// Acceptance #3. The symptom of an $effect writing a $state it also reads is
+		// that OTHER reactivity near it silently strands. So the test must FIRE the
+		// reset effect (the effect that writes `zoom`) and THEN prove an unrelated
+		// derived still recomputes. Navigation is what fires it; growing the set
+		// without navigating leaves `img.id` unchanged, so the reset effect never
+		// runs and could not have wedged anything — a weaker test that a
+		// self-dependent reset would still pass.
+		liveProps.images = [image(IMG_A, 'first'), image(IMG_B, 'second')];
+		mountLive();
+		press('+');
+		expect(scaleOf()).toBeCloseTo(1.25);
+
+		// Navigation fires the reset effect (img A → B), taking the transform back
+		// to fit — the write a self-dependent effect would abort mid-flush.
+		expect(press('ArrowRight')).toBe(true);
+		expect(scaleOf()).toBe(1);
+
+		// UNRELATED to the reset: grow the set past the shown image. Its counter
+		// derived must still recompute — a wedged scheduler would strand it at the
+		// pre-update value.
+		liveProps.images = [
+			image(IMG_A, 'first'),
+			image(IMG_B, 'second'),
+			image(IMG_C, 'third', 'image/jpeg'),
+		];
+		flushSync();
+		expect(root().querySelector('.lightbox-counter')?.textContent).toBe('2 / 3');
+	});
+});
+
+describe('Lightbox — resize re-clamps SCALE first, then pan (TASK-2455)', () => {
+	it('pulls a now-out-of-range scale down when the stage grows and lowers the ceiling', () => {
+		// jsdom fires no ResizeObserver, so DRIVE one by hand and mock the geometry
+		// the component reads. The scenario is the headline one: enlarging the
+		// window lowers `actualScale` and with it `maxScale`, stranding a
+		// previously-valid scale above the new ceiling. Only `clampState` (scale
+		// THEN pan) fixes it — `clampPan` alone would leave the scale untouched.
+		let roCallback: ResizeObserverCallback | null = null;
+		let observed: Element | null = null;
+		vi.stubGlobal(
+			'ResizeObserver',
+			class {
+				constructor(cb: ResizeObserverCallback) {
+					roCallback = cb;
+				}
+				observe(target: Element) {
+					observed = target;
+				}
+				unobserve() {}
+				disconnect() {}
+			}
+		);
+
+		mountViewer();
+		const image = root().querySelector<HTMLImageElement>('.lightbox-image')!;
+		const stage = root().querySelector<HTMLElement>('.lightbox-stage')!;
+		// It observes the STAGE (whose size IS the viewport-dependent geometry),
+		// not the image or the backdrop.
+		expect(observed).toBe(stage);
+
+		// A big bitmap fitted into a small box: actualScale = 1000/100 = 10, so the
+		// ceiling starts at 40 — lots of headroom to zoom into.
+		let fitted = 100;
+		Object.defineProperty(image, 'offsetWidth', { configurable: true, get: () => fitted });
+		Object.defineProperty(image, 'offsetHeight', { configurable: true, get: () => fitted });
+		Object.defineProperty(image, 'naturalWidth', { configurable: true, get: () => 1000 });
+		Object.defineProperty(image, 'naturalHeight', { configurable: true, get: () => 1000 });
+		Object.defineProperty(stage, 'clientWidth', { configurable: true, get: () => fitted });
+		Object.defineProperty(stage, 'clientHeight', { configurable: true, get: () => fitted });
+
+		// Zoom well past 4 (1.25^8 ≈ 5.96), which the ceiling of 40 permits.
+		for (let i = 0; i < 8; i++) press('+');
+		expect(scaleOf()).toBeGreaterThan(5);
+
+		// The stage grows until the image fits 1:1: actualScale → 1, ceiling → 4.
+		// The current scale (~5.96) is now above it.
+		fitted = 1000;
+		expect(roCallback).not.toBeNull();
+		roCallback!([] as unknown as ResizeObserverEntry[], null as unknown as ResizeObserver);
+		flushSync();
+
+		// Re-clamped to the new ceiling — proof the SCALE was clamped, not only pan.
+		expect(scaleOf()).toBeCloseTo(4);
+	});
+});
+
+describe('Lightbox — + / - anchor at the stage centre (TASK-2455)', () => {
+	it('keeps the pan at ZERO when zooming a centred image that overflows the stage', () => {
+		// The only leg that pins the ANCHOR. Everywhere else jsdom's all-zero
+		// geometry forces `stageCenter` to (0,0) and the pan to 0, so an off-centre
+		// anchor is invisible. Here the (mocked) geometry lets the zoomed image
+		// OVERFLOW the stage, freeing the pan — and a centre-anchored zoom of an
+		// already-centred image must still leave it at (0,0). A top-left (or any
+		// non-centre) anchor would push a non-zero translate and fail this.
+		mountViewer();
+		const image = root().querySelector<HTMLImageElement>('.lightbox-image')!;
+		const stage = root().querySelector<HTMLElement>('.lightbox-stage')!;
+		Object.defineProperty(image, 'offsetWidth', { configurable: true, get: () => 400 });
+		Object.defineProperty(image, 'offsetHeight', { configurable: true, get: () => 400 });
+		Object.defineProperty(image, 'naturalWidth', { configurable: true, get: () => 2000 });
+		Object.defineProperty(image, 'naturalHeight', { configurable: true, get: () => 2000 });
+		Object.defineProperty(stage, 'clientWidth', { configurable: true, get: () => 1000 });
+		Object.defineProperty(stage, 'clientHeight', { configurable: true, get: () => 1000 });
+
+		// 400 × 1.25^5 ≈ 1220 > 1000, so the image overflows and pan is unclamped.
+		for (let i = 0; i < 5; i++) press('+');
+		expect(scaleOf()).toBeGreaterThan(2.5);
+		expect(transformOf()).toContain('translate(0px, 0px)');
 	});
 });

--- a/web/src/lib/components/common/Lightbox.svelte.test.ts
+++ b/web/src/lib/components/common/Lightbox.svelte.test.ts
@@ -1364,3 +1364,110 @@ describe('Lightbox — + / - anchor at the stage centre (TASK-2455)', () => {
 		expect(transformOf()).toContain('translate(0px, 0px)');
 	});
 });
+
+// TASK-2456 — focus handoff when a focused viewer control disappears.
+//
+// aria-modal promises focus never leaves the surface, but a conditionally
+// rendered nav button that had focus drops focus to <body> behind the inerted
+// app when the set shrinks to one. These are SAME-INSTANCE (a remount would hide
+// the whole thing) and assert focus lands on a control INSIDE the viewer.
+
+describe('Lightbox — focus handoff on a shrinking set (TASK-2456)', () => {
+	function mountLive() {
+		const app = mount(Lightbox, { target: appRoot, props: liveProps });
+		mounted.push(app);
+		flushSync();
+		return app;
+	}
+
+	it('CONTROL: a removed focused control drops focus to <body> in this environment', () => {
+		// The defect reproduced honestly, so the positive test below is not
+		// vacuous: removing a focused element strands focus on <body> here just as
+		// it does in a real engine. (Done on a detached fixture so it does not fight
+		// Svelte for ownership of a live viewer node.)
+		const fixture = appRoot.appendChild(document.createElement('div'));
+		const btn = fixture.appendChild(document.createElement('button'));
+		btn.focus();
+		expect(document.activeElement).toBe(btn);
+		btn.remove();
+		expect(document.activeElement).toBe(document.body);
+	});
+
+	it('hands focus to the close button when the focused Next control is removed by a shrink', () => {
+		liveProps.images = [image(IMG_A, 'png'), image(IMG_B, 'jpeg', 'image/jpeg')];
+		mountLive();
+		const before = root();
+		const nextBtn = before.querySelector<HTMLButtonElement>('.lightbox-nav.next')!;
+		nextBtn.focus();
+		// Precondition, so the assertion is about a real handoff and not a viewer
+		// that happened to already have focus on the close button.
+		expect(document.activeElement).toBe(nextBtn);
+
+		// The set shrinks to one: the nav buttons unmount. Without the handoff,
+		// focus would now be on <body>, behind everything the viewer inerted.
+		liveProps.images = [image(IMG_A, 'png')];
+		flushSync();
+
+		// SAME instance — this is the same-instance property the acceptance names;
+		// a keyed remount would trivially start focused and false-green the rest.
+		expect(root()).toBe(before);
+		expect(before.querySelector('.lightbox-nav')).toBeNull();
+		// INSIDE the viewer — not merely "not on body".
+		expect(before.contains(document.activeElement)).toBe(true);
+		expect(document.activeElement).toBe(closeButton(before));
+		expect(document.activeElement).not.toBe(document.body);
+	});
+
+	it('does not steal focus when it is already on a surviving control', () => {
+		// A shrink while focus is on the CLOSE button (which survives) must leave
+		// it there — the handoff repairs a lost focus, it does not re-home a fine one.
+		liveProps.images = [image(IMG_A, 'png'), image(IMG_B, 'jpeg', 'image/jpeg')];
+		mountLive();
+		closeButton().focus();
+		expect(document.activeElement).toBe(closeButton());
+
+		liveProps.images = [image(IMG_A, 'png')];
+		flushSync();
+		expect(document.activeElement).toBe(closeButton());
+	});
+
+	it('a BACKGROUND viewer does not grab focus when ITS OWN set shrinks', () => {
+		// The isViewerFrontmost guard on the repair effect. With a second viewer
+		// stacked over the first, the front one owns focus; a shrink in the BACK
+		// viewer must not pull focus out of the front into the inert background.
+		// Without the guard the reactive repair would see "focus is not inside ME"
+		// and yank it to the back viewer's fallback.
+		liveProps.images = [image(IMG_A, 'back-a'), image(IMG_B, 'back-b', 'image/jpeg')];
+		const backApp = mount(Lightbox, { target: appRoot, props: liveProps });
+		mounted.push(backApp);
+		flushSync();
+		const back = root();
+		mountViewer({ images: [image(IMG_A, 'front-a'), image(IMG_B, 'front-b')] });
+		const front = root();
+		expect(front).not.toBe(back);
+		expect(front.contains(document.activeElement)).toBe(true);
+
+		liveProps.images = [image(IMG_A, 'back-a')];
+		flushSync();
+
+		expect(front.contains(document.activeElement)).toBe(true);
+		expect(back.contains(document.activeElement)).toBe(false);
+	});
+});
+
+describe('Lightbox — Tab still cycles at maximum zoom (TASK-2456)', () => {
+	it('wraps forward off the last control to the close button even at the zoom ceiling', () => {
+		// At max zoom the transformed image visually overlaps the controls, but the
+		// trap is JS-based (paneFocus) and the image is not focusable, so Tab order
+		// is unaffected. Driving the zoom to the ceiling first proves it.
+		mountViewer({ images: [image(IMG_A, 'first'), image(IMG_B, 'second')] });
+		for (let i = 0; i < 10; i++) press('+');
+		expect(scaleOf()).toBeCloseTo(4);
+
+		const nextBtn = root().querySelector<HTMLButtonElement>('.lightbox-nav.next')!;
+		nextBtn.focus();
+		expect(press('Tab')).toBe(true);
+		expect(root().contains(document.activeElement)).toBe(true);
+		expect(document.activeElement).toBe(closeButton());
+	});
+});

--- a/web/src/lib/components/editor/attachmentImageViewerHost.svelte.test.ts
+++ b/web/src/lib/components/editor/attachmentImageViewerHost.svelte.test.ts
@@ -151,9 +151,15 @@ describe('inline image → viewer host → Lightbox', () => {
 			expect(viewer.getAttribute('role')).toBe('dialog');
 			expect(viewer.parentElement).toBe(document.body);
 			const shown = viewer.querySelector<HTMLImageElement>('img.lightbox-image');
+			// The URL is built from the CAPTURED workspace this NodeView emitted in
+			// (the pane can switch workspace under a mounted viewer) — this pins
+			// which workspace, which is why it survives the DR-5b loading rework.
 			expect(shown?.getAttribute('src')).toContain(UUID);
-			// The full-resolution blob, as the deleted dialog loaded: the viewer
-			// asks for the canonical URL with no `variant`.
+			// NO `?variant`: an inline editor image carries no dimensions, so it is
+			// `unknown` to the DR-5b classifier, and the unknown-dims desktop cell
+			// requests the ORIGINAL directly — the canonical, no-variant URL — never
+			// a thumbnail (TASK-2459). A dimensioned large image WOULD ship
+			// `?variant=thumb-md` first; that path is covered in the loader tests.
 			expect(shown?.getAttribute('src')).not.toContain('variant=');
 		});
 	}

--- a/web/src/lib/components/items/ItemAttachmentStrip.svelte
+++ b/web/src/lib/components/items/ItemAttachmentStrip.svelte
@@ -152,11 +152,11 @@
 		size_bytes: number;
 		/**
 		 * Intrinsic pixels, OPTIONAL and nullable (TASK-2431). The list row has
-		 * them, an upload event does not (`UploadedAttachment` is four fields),
-		 * and no tile reads them — they are carried so the set handed to the
-		 * viewer is complete, which is what keeps phase 3b's pixel-based loading
-		 * policy from having to reopen every producer. Optional rather than
-		 * required precisely so the upload buffer stays assignable to this type.
+		 * them, and since TASK-2459 an upload event (`UploadedAttachment`) carries
+		 * them too — nullable, because a non-image upload has none. No tile reads
+		 * them; they are carried so the set handed to the viewer is complete, which
+		 * is what keeps phase 3b's pixel-based loading policy from having to reopen
+		 * every producer.
 		 */
 		width?: number | null;
 		height?: number | null;

--- a/web/src/lib/components/items/ItemAttachmentStrip.svelte.test.ts
+++ b/web/src/lib/components/items/ItemAttachmentStrip.svelte.test.ts
@@ -1499,6 +1499,8 @@ describe('ItemAttachmentStrip', () => {
 		filename: `${id}.png`,
 		mime_type: 'image/png',
 		size_bytes: 4096,
+		width: null,
+		height: null,
 	});
 
 	it('shows a dropped file immediately, without a refetch', async () => {

--- a/web/src/lib/scroll/fixtures/RestoreHarness.svelte
+++ b/web/src/lib/scroll/fixtures/RestoreHarness.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+	// Test-only wrapper: `createScrollRestoration` calls `onDestroy`, which needs a
+	// real component context (`$effect.root` does not provide one), so the restore
+	// integration tests (TASK-2457) mount this and drive the returned snapshot.
+	import { createScrollRestoration } from '../restore.svelte';
+	import type { Snapshot } from '@sveltejs/kit';
+
+	let {
+		ready,
+		scrollTarget,
+		expose,
+	}: {
+		ready: () => boolean;
+		scrollTarget: () => HTMLElement | Window | null;
+		expose: (snap: Snapshot<number>) => void;
+	} = $props();
+
+	// Wrap the prop functions so the factory reads the current prop on each call
+	// rather than capturing the init value (state_referenced_locally).
+	const restoration = createScrollRestoration({
+		ready: () => ready(),
+		scrollTarget: () => scrollTarget(),
+	});
+	$effect(() => {
+		expose(restoration.snapshot);
+	});
+</script>

--- a/web/src/lib/scroll/restore.svelte.test.ts
+++ b/web/src/lib/scroll/restore.svelte.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mount, unmount, flushSync } from 'svelte';
+import type { Snapshot } from '@sveltejs/kit';
+import RestoreHarness from './fixtures/RestoreHarness.svelte';
+import {
+	acquire,
+	__resetViewerBackdropForTests,
+	VIEWER_ROOT_CLASS,
+} from '$lib/a11y/viewerBackdrop';
+import { isModalViewerScrollInput } from './restore.svelte';
+
+// TASK-2457 — a page scroll-restoration must not be aborted by input the user
+// aimed at the frontmost attachment viewer (its own wheel-zoom / arrow-nav),
+// nor by any event a modal already handled (`defaultPrevented`). A GENUINE
+// non-viewer scroll still aborts, exactly as before.
+//
+// The restoration installs passive window listeners (wheel / touchmove /
+// keydown) during a restore and bails the moment one fires. These tests drive a
+// real restore to the point those listeners are live, dispatch an event, and
+// observe whether the restore PROCEEDED (its `scrollTo` ran) or ABORTED.
+
+let rafQueue: FrameRequestCallback[] = [];
+const mounted: ReturnType<typeof mount>[] = [];
+let appRoot: HTMLElement;
+
+function frame(): void {
+	const cb = rafQueue.shift();
+	if (cb) cb(performance.now());
+}
+
+beforeEach(() => {
+	rafQueue = [];
+	// Drive requestAnimationFrame by hand so the restore loop is deterministic.
+	vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+		rafQueue.push(cb);
+		return rafQueue.length;
+	});
+	appRoot = document.body.appendChild(document.createElement('div'));
+});
+
+afterEach(() => {
+	while (mounted.length) unmount(mounted.pop()!);
+	// Drain any queued restore frames so their window wheel/touch/key listeners
+	// self-remove now that the harness is unmounted (alive === false → the loop
+	// calls cleanupListeners). A "proceeded" restore never reaches its completion
+	// frame here (the fake target's scrollTop never advances), so without this the
+	// listeners would leak across tests — harmless (they mutate dead closures) but
+	// untidy.
+	while (rafQueue.length) frame();
+	document.body.innerHTML = '';
+	rafQueue = [];
+	__resetViewerBackdropForTests();
+	vi.unstubAllGlobals();
+	vi.restoreAllMocks();
+});
+
+/** A stand-in scroll container; `scrollTo` firing is the "restore proceeded" signal. */
+function makeTarget() {
+	return {
+		scrollTop: 0,
+		scrollHeight: 5000,
+		scrollTo: vi.fn(),
+	} as unknown as HTMLElement;
+}
+
+/**
+ * Mount the harness, seed a pending restore so the input listeners go live, run
+ * `dispatch`, then advance to the first scroll attempt. Returns whether the
+ * restore PROCEEDED (its `scrollTo` ran) — i.e. the dispatched input was NOT
+ * treated as the user scrolling the page.
+ */
+function driveRestore(dispatch: () => void): boolean {
+	const target = makeTarget();
+	let snap: Snapshot<number> | undefined;
+	const app = mount(RestoreHarness, {
+		target: appRoot,
+		props: {
+			ready: () => true,
+			scrollTarget: () => target,
+			expose: (s: Snapshot<number>) => (snap = s),
+		},
+	});
+	mounted.push(app);
+	flushSync();
+
+	// Seed a pending restore: the gated effect registers the wheel / touch / key
+	// listeners on `window` and schedules the double-RAF scroll loop.
+	snap!.restore!(100);
+	flushSync();
+
+	dispatch();
+
+	// Double-RAF, then the first `tryScroll`: it bails at the top when the user
+	// scrolled, otherwise it calls `scrollTo`.
+	frame();
+	frame();
+	return (target.scrollTo as unknown as ReturnType<typeof vi.fn>).mock.calls.length > 0;
+}
+
+/**
+ * A body-attached element carrying the viewer class, made the frontmost lease.
+ * Attached to `<body>` directly, as the real viewer portals itself, so the
+ * backdrop manager's inert bookkeeping has the body child it expects.
+ */
+function frontmostViewer(): HTMLElement {
+	const v = document.body.appendChild(document.createElement('div'));
+	v.classList.add(VIEWER_ROOT_CLASS);
+	acquire(v);
+	return v;
+}
+
+function plain(): HTMLElement {
+	return appRoot.appendChild(document.createElement('div'));
+}
+
+describe('scroll restoration — ignores frontmost-viewer and handled input (TASK-2457)', () => {
+	it('SANITY: with no interfering input, a pending restore proceeds to scrollTo', () => {
+		// Proves the harness actually reaches the scroll — without this, every
+		// "proceeded" assertion below could be a false green.
+		expect(driveRestore(() => {})).toBe(true);
+	});
+
+	// ── wheel ──
+	it('a WHEEL originating in the frontmost viewer does NOT abort the restore', () => {
+		expect(
+			driveRestore(() => frontmostViewer().dispatchEvent(new WheelEvent('wheel', { bubbles: true })))
+		).toBe(true);
+	});
+
+	it('CONTROL: a genuine non-viewer WHEEL aborts the restore', () => {
+		expect(
+			driveRestore(() => plain().dispatchEvent(new WheelEvent('wheel', { bubbles: true })))
+		).toBe(false);
+	});
+
+	// ── key (the viewer's arrow-nav, shipped 3a) ──
+	it('an ARROW key originating in the frontmost viewer does NOT abort the restore', () => {
+		expect(
+			driveRestore(() =>
+				frontmostViewer().dispatchEvent(
+					new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true })
+				)
+			)
+		).toBe(true);
+	});
+
+	it('a defaultPrevented ARROW key (handled by a modal) does NOT abort, even from outside a viewer', () => {
+		// The `defaultPrevented` branch, independent of origin — the viewer
+		// preventDefaults its arrows, so the next modal inherits the fix.
+		expect(
+			driveRestore(() => {
+				const e = new KeyboardEvent('keydown', {
+					key: 'ArrowLeft',
+					bubbles: true,
+					cancelable: true,
+				});
+				e.preventDefault();
+				plain().dispatchEvent(e);
+			})
+		).toBe(true);
+	});
+
+	it('CONTROL: a genuine non-viewer scroll key aborts the restore', () => {
+		expect(
+			driveRestore(() =>
+				plain().dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }))
+			)
+		).toBe(false);
+	});
+
+	// ── touch (still native until 3d, so NOT defaultPrevented — only the origin check catches it) ──
+	it('a TOUCHMOVE originating in the frontmost viewer does NOT abort the restore', () => {
+		expect(
+			driveRestore(() => frontmostViewer().dispatchEvent(new Event('touchmove', { bubbles: true })))
+		).toBe(true);
+	});
+
+	it('CONTROL: a genuine non-viewer TOUCHMOVE aborts the restore', () => {
+		expect(
+			driveRestore(() => plain().dispatchEvent(new Event('touchmove', { bubbles: true })))
+		).toBe(false);
+	});
+});
+
+describe('isModalViewerScrollInput (TASK-2457)', () => {
+	it('true for a defaultPrevented event, whatever its target', () => {
+		const e = new WheelEvent('wheel', { cancelable: true });
+		e.preventDefault();
+		expect(isModalViewerScrollInput(e)).toBe(true);
+	});
+
+	it('true for an event originating inside the FRONTMOST viewer', () => {
+		const v = frontmostViewer();
+		const child = v.appendChild(document.createElement('button'));
+		expect(isModalViewerScrollInput({ defaultPrevented: false, target: child } as unknown as Event)).toBe(
+			true
+		);
+	});
+
+	it('false for an event inside a viewer that is NOT frontmost', () => {
+		const back = frontmostViewer(); // acquired first
+		frontmostViewer(); // a second viewer is now frontmost
+		expect(
+			isModalViewerScrollInput({ defaultPrevented: false, target: back } as unknown as Event)
+		).toBe(false);
+	});
+
+	it('false for an event outside any viewer', () => {
+		expect(
+			isModalViewerScrollInput({ defaultPrevented: false, target: plain() } as unknown as Event)
+		).toBe(false);
+	});
+
+	it('false for a non-Element target', () => {
+		expect(
+			isModalViewerScrollInput({ defaultPrevented: false, target: window } as unknown as Event)
+		).toBe(false);
+	});
+});

--- a/web/src/lib/scroll/restore.svelte.ts
+++ b/web/src/lib/scroll/restore.svelte.ts
@@ -48,6 +48,31 @@
 
 import type { Snapshot } from '@sveltejs/kit';
 import { onDestroy } from 'svelte';
+import { isViewerFrontmost, VIEWER_ROOT_CLASS } from '$lib/a11y/viewerBackdrop';
+
+/**
+ * True when an input event must NOT be treated as the user scrolling the page,
+ * so a pending scroll restoration is not aborted by it (TASK-2457):
+ *
+ *  - it was already handled (`defaultPrevented`) — so the NEXT modal to consume
+ *    wheel / keys inherits this without re-plumbing the restoration; OR
+ *  - it originates inside the FRONTMOST attachment viewer, a modal that owns
+ *    wheel / key / touch while open (the page behind is inert), so its own zoom
+ *    / arrow-nav must not count as the user driving the page underneath it.
+ *
+ * Generalized across wheel / key / touch on purpose, not wheel-only: touch stays
+ * native until phase 3d, so a viewer `touchmove` is NOT `defaultPrevented` and
+ * only the origin check catches it; the viewer's arrow-nav (shipped 3a) IS
+ * `defaultPrevented`, so either branch catches that. A genuine, non-viewer,
+ * un-handled scroll passes both checks and still aborts the restore, as before.
+ */
+export function isModalViewerScrollInput(e: Event): boolean {
+	if (e.defaultPrevented) return true;
+	const target = e.target;
+	if (!(target instanceof Element)) return false;
+	const viewer = target.closest(`.${VIEWER_ROOT_CLASS}`);
+	return viewer !== null && isViewerFrontmost(viewer);
+}
 
 // The app's primary scroll container lives in the root layout
 // (`.main-content { overflow-y: auto }`), not `window`. Capturing
@@ -362,7 +387,13 @@ export function createScrollRestoration(
 		// previous diff check treated it as one and bailed mid-restore,
 		// leaving the user 200-400px past their target. BUG-1425 round 12.
 		let userScrolled = false;
-		const markUserScroll = () => {
+		// Ignore input the user did not aim at the PAGE: an event a modal already
+		// handled (`defaultPrevented`) or one originating inside the frontmost
+		// attachment viewer (which owns wheel/key/touch while open). Without this,
+		// the viewer's own zoom / arrow-nav aborts a restore running underneath it
+		// (TASK-2457). See {@link isModalViewerScrollInput}.
+		const markUserScroll = (e: Event) => {
+			if (isModalViewerScrollInput(e)) return;
 			userScrolled = true;
 		};
 		const isScrollKey = (e: KeyboardEvent) =>
@@ -376,6 +407,7 @@ export function createScrollRestoration(
 			e.key === 'End' ||
 			e.key === ' ';
 		const handleKey = (e: KeyboardEvent) => {
+			if (isModalViewerScrollInput(e)) return;
 			if (isScrollKey(e)) userScrolled = true;
 		};
 		window.addEventListener('wheel', markUserScroll, { passive: true });

--- a/web/src/test/setup-jsdom.ts
+++ b/web/src/test/setup-jsdom.ts
@@ -117,3 +117,26 @@ if (typeof window !== 'undefined' && typeof window.matchMedia !== 'function') {
 		} as MediaQueryList;
 	};
 }
+
+// jsdom has no `ResizeObserver`. The attachment viewer (`Lightbox`) observes its
+// stage to re-clamp the zoom on viewport changes, and several suites mount it —
+// directly (`Lightbox.svelte.test.ts`) and through its producers
+// (`AttachmentViewerHost`, `ItemTimeline`, `ItemAttachmentStrip`). The component
+// GUARDS on `typeof ResizeObserver === 'undefined'` (for SSR), so without this
+// shim it would not throw — it would simply SKIP the observer branch entirely,
+// leaving the resize path untested and unexercised in every suite that mounts
+// the viewer. The shim makes that branch actually run (construct + observe). The
+// repo's only prior shim is LOCAL to `TopBar.svelte.test.ts` (and DRIVES a size,
+// to force overflow) — this global one is deliberately INERT: jsdom lays nothing
+// out, so there is no size to report, and firing a zero-rect callback would only
+// exercise a no-op clamp. A test that needs to DRIVE a resize installs its own
+// via `vi.stubGlobal`, which layers over this default and is cleared by
+// `vi.unstubAllGlobals()`.
+if (typeof globalThis.ResizeObserver === 'undefined') {
+	class ResizeObserverShim {
+		observe(): void {}
+		unobserve(): void {}
+		disconnect(): void {}
+	}
+	globalThis.ResizeObserver = ResizeObserverShim as unknown as typeof ResizeObserver;
+}


### PR DESCRIPTION
Phase 3b of [[PLAN-2392]] — desktop zoom on the unified attachment viewer that phase 3a shipped (PR #1060).

Scale/translate state, wheel + ctrl/⌘-wheel + keyboard + double-click, desktop drag-to-pan, and DR-5b's thumb-then-original loading policy. Touch (two-pointer pinch, double-tap, `touch-action`) stays in phase 3d.

## Tasks

- [x] TASK-2454 — pure zoom/pan math module (`zoom.ts`)
- [x] TASK-2455 — wire the transform into `Lightbox.svelte`; keyboard zoom; reset on navigate; resize
- [x] TASK-2456 — focus handoff when a focused control disappears
- [x] TASK-2457 — wheel / ctrl-wheel zoom anchored at the pointer; scroll-restoration guard
- [x] TASK-2458 — double-click toggle; desktop drag-to-pan; click disambiguation
- [x] TASK-2459 — DR-5b classification and the desktop thumb→original path
- [x] TASK-2460 — DR-5b mobile policy: tap-to-load and fetch-on-zoom-past-fit
- [x] TASK-2461 — browser proof (desktop-chromium and the mobile project)

## Decisions worth knowing when reading this

**The CSS stays the fit engine.** The existing `92vw/92vh` + `object-fit: contain` already does the fit math, so `scale` is defined *relative to fit* — `FIT` is the constant 1, not a derived quantity. At `scale = 1` the rendering is identical to today's. Deriving fit independently in the module would have put the stylesheet and the math in two coordinate systems, which is how anchoring and pan bounds come out inconsistent.

**Desktop drag-pan moved here from phase 3d.** The plan's phase map assigns drag-pan and clamping to 3d (touch). Zoom you cannot pan only ever shows the centre of the image, and with Pointer Events the mouse path is the same code. 3d keeps genuine multi-touch. Critically, `touch-action: none` does **not** ship in 3b — it would leave phone users with no zoom at all until 3d's pinch handler exists.

**The `thumb-md` fallback is not harmless, and the fix needs no server change.** WebP/AVIF have no server-derived thumbnail (the pure-Go processor decodes gif/jpeg/png/bmp/tiff only) and derivation is asynchronous, so `?variant=thumb-md` can return the *original*. A cell that requests the thumb and then prefetches the original therefore decodes it twice — ~400 MiB for a 50 MP image. Rather than mirroring the server's decoder list client-side (a mirror that rots silently), the client uses the fact that `thumb-md` is bounded at a 1024 px long edge *by definition*: a decoded bitmap longer than that means the fallback served the original, so the prefetch is skipped. Works with null dimensions.

**One pre-existing `aria-modal` violation is folded in.** On `main` today, when a MIME resolves unsafe and the viewer's set shrinks to one, the focused "Next image" button is removed and nothing catches focus — it lands on `<body>`, behind a surface that has inerted everything else. TASK-2456 fixes it; 3b would otherwise have multiplied it, since the tap-to-load affordance is replaced by the image it loads and retry vanishes on success.

## Review process

The decomposition went through 19 adversarial Codex rounds before any code was written, finding 11 P1s and 22 P2s. Two fresh-angle rounds returned CLEAN before it was declared converged. Rounds 17-19 were a pure coherence sweep and found nine self-contradictions the earlier revisions had accumulated — including "fit scale" silently naming two different quantities.

Each task additionally gets its own adversarial round against the branch tip, and every test carries the phase-3a bar: *would this fail if the implementation were wrong?* Phase 3a found nine of twelve tasks first shipped tests that could not fail on their own hardest property, and the gates caught none of them.

## Test plan

Per task: the web vitest suite plus `npm run check`. TASK-2461 adds the browser proof on desktop-chromium and the mobile project, mutation-checked against the binary Playwright's `webServer` actually launches. No Go changes, so `make test-pg` is not required — the plan's DR-13 records why.

**Gates actually run on the final tip (rebased on main):** `make check` exit 0 (golangci-lint, `go test ./...`, govulncheck, npm audit + svelte-check 0 errors, vitest 1319/1319); attachment e2e suites 50 passed / 0 failed across desktop-chromium and Pixel 7 (mobile-chromium); every TASK-2461 assertion mutation-checked against the worktree binary. `make test-pg` not run — no Go changes (recorded in the plan).

Discovered and routed out: **BUG-2453** (the editor's block-drag owner has no modal arbitration — a gap in the contract 3a shipped).