### PR TITLE
PLAN-2392 phase 3c-i: the attachment surface grows its chrome

### DIFF
--- a/web/e2e/attachment-surface-chrome.spec.ts
+++ b/web/e2e/attachment-surface-chrome.spec.ts
@@ -1,0 +1,358 @@
+import { test, expect } from './fixtures';
+import type { Page } from '@playwright/test';
+import { browserLogin, seedDoc } from './lib/collab-helpers';
+import {
+	BIG_PNG,
+	DESKTOP,
+	REAL_PNG,
+	TILE,
+	VIEWER,
+	VIEWER_IMAGE,
+	VIEWER_COUNTER,
+	VIEWER_TOOLBAR,
+	VIEWER_META,
+	VIEWER_META_NAME,
+	VIEWER_META_DETAIL,
+	VIEWER_STAGE,
+	dropFileIntoEditor,
+	imageRect,
+	itemUrl,
+	postComment,
+	uploadAttachment,
+	viewerOpenAnchor,
+	viewerDownloadAnchor,
+	viewerCopyLink,
+	viewerDelete,
+	viewerConfirmDeleteRow,
+	viewerConfirmCancelRow,
+	renderedScale
+} from './lib/attachment-viewer';
+
+/**
+ * 3c-i SURFACE CHROME — the browser proof (TASK-2484, DR-9).
+ *
+ * The A-E chain (2473-2477) built the viewer's toolbar, metadata header, icon
+ * fallback and deletion reconciliation. DR-9's rule: the a11y and interaction
+ * work is verified in a browser or it is not verified. jsdom cannot show the
+ * anchor semantics a real `<a download>` carries, the inert-label pointer
+ * behaviour, the no-bytes network invariant, or the peek permission threading
+ * through the real ItemDetail — so those legs live here. Desktop-chromium only:
+ * the sheet layout has no mobile e2e until 3c-ii.
+ */
+
+const INLINE_IMG = '.editor-content .ProseMirror img[data-attachment-id]';
+
+/** The timeline (and its comment images) live under the item's Activity tab. */
+async function openActivityTab(page: Page): Promise<void> {
+	await page.getByRole('tab', { name: 'Activity' }).click();
+	await expect(page.locator('.timeline')).toBeVisible();
+}
+
+test.describe('attachment viewer — 3c-i surface chrome (TASK-2484)', () => {
+	test.beforeEach(async ({ page }, testInfo) => {
+		test.skip(testInfo.project.name !== 'desktop-chromium', 'desktop legs only');
+		await page.setViewportSize(DESKTOP);
+	});
+
+	test('toolbar renders on the STRIP origin, with real Open/Download anchors', async ({
+		page,
+		fixture,
+		request
+	}) => {
+		await browserLogin(page);
+		const doc = await seedDoc(fixture, request, 'Chrome strip toolbar');
+		const id = await uploadAttachment(fixture, request, doc.id, 'strip-tool.png');
+		await page.goto(itemUrl(fixture, doc.slug));
+		await page.locator(TILE).first().click();
+		await expect(page.locator(VIEWER_IMAGE)).toBeVisible();
+
+		// The toolbar is present, drawn over the stage.
+		await expect(page.locator(VIEWER_TOOLBAR)).toBeVisible();
+
+		// Open and Download are REAL anchors (role "link"), carrying the attachment
+		// href — the DR-16 semantics jsdom cannot render (an <a download> saves; a
+		// button would not).
+		// The EXACT canonical, variant-less URL — not merely "contains the id", so a
+		// wrong variant / query or a truncated path is caught.
+		const canonical = new RegExp(
+			`^/api/v1/workspaces/${fixture.workspaceSlug}/attachments/${id}$`
+		);
+		const open = viewerOpenAnchor(page);
+		await expect(open).toHaveAttribute('href', canonical);
+		await expect(open).toHaveAttribute('target', '_blank');
+		const download = viewerDownloadAnchor(page);
+		await expect(download).toHaveAttribute('href', canonical);
+		// The EXACT filename, so a `download=""` regression (which reopens the
+		// navigate-instead-of-save hole) is caught.
+		await expect(download).toHaveAttribute('download', 'strip-tool.png');
+
+		// Copy-link is a button (JS action), not an anchor.
+		await expect(viewerCopyLink(page)).toBeVisible();
+		// The admin owns the item and is not peeking → Delete is offered.
+		await expect(viewerDelete(page)).toBeVisible();
+	});
+
+	test('toolbar renders on the TIMELINE origin', async ({ page, fixture, request }) => {
+		await browserLogin(page);
+		const doc = await seedDoc(fixture, request, 'Chrome timeline toolbar');
+		const one = await uploadAttachment(fixture, request, doc.id, 'tl-tool.png');
+		await postComment(fixture, request, doc.slug, `shot\n\n![first](pad-attachment:${one})\n`);
+		await page.goto(itemUrl(fixture, doc.slug));
+		await openActivityTab(page);
+		await page.locator('.timeline img[data-attachment-id]').first().click();
+		await expect(page.locator(VIEWER_IMAGE)).toBeVisible();
+		await expect(page.locator(VIEWER_TOOLBAR)).toBeVisible();
+		const tlCanonical = new RegExp(
+			`^/api/v1/workspaces/${fixture.workspaceSlug}/attachments/${one}$`
+		);
+		await expect(viewerOpenAnchor(page)).toHaveAttribute('href', tlCanonical);
+		await expect(viewerDownloadAnchor(page)).toHaveAttribute('href', tlCanonical);
+	});
+
+	test('toolbar renders on the BODY NodeView origin', async ({ page, fixture, request }) => {
+		await browserLogin(page);
+		const doc = await seedDoc(fixture, request, 'Chrome body toolbar');
+		await page.goto(itemUrl(fixture, doc.slug));
+		await dropFileIntoEditor(page, 'body-tool.png', REAL_PNG.toString('base64'));
+		await expect(page.locator(INLINE_IMG)).toHaveCount(1);
+		await page.locator(INLINE_IMG).first().click();
+		await expect(page.locator(VIEWER_IMAGE)).toBeVisible();
+		await expect(page.locator(VIEWER_TOOLBAR)).toBeVisible();
+		// The drop's attachment id isn't captured here, so pin the Download anchor to
+		// the SHOWN image: both resolve the same attachment, so its download href must
+		// name the same id as the <img> src.
+		const shownId = (await page.locator(VIEWER_IMAGE).getAttribute('src'))!.match(
+			/attachments\/([0-9a-f-]+)/
+		)![1];
+		const bodyCanonical = new RegExp(
+			`^/api/v1/workspaces/${fixture.workspaceSlug}/attachments/${shownId}$`
+		);
+		await expect(viewerOpenAnchor(page)).toHaveAttribute('href', bodyCanonical);
+		await expect(viewerDownloadAnchor(page)).toHaveAttribute('href', bodyCanonical);
+	});
+
+	test('the peeked side withholds the delete affordance; the active side viewer offers Delete', async ({
+		page,
+		fixture,
+		request
+	}) => {
+		// The browser proof of C1's permission threading (TASK-2474). SCOPE, stated
+		// honestly: a viewer OPENED from a peeked side cannot be observed here — the
+		// only way to open one is a content click on that side, and the
+		// invisible-freeze model (BUG-2263) RE-ACTIVATES a side on any such click
+		// (deterministically un-peeking it before the viewer captures
+		// mutationsEnabled). So the peeked-side no-Delete VIEWER is jsdom-proven
+		// (TASK-2474's timeline/viewer-host peek legs); what a browser proves is the
+		// two ends this rests on: (a) mutationsEnabled=false really reaches a peeked
+		// side (its delete affordance is gone), and (b) an ACTIVE side's viewer
+		// toolbar really offers Delete. Same fixture, opposite permission.
+		await browserLogin(page);
+		const master = await seedDoc(fixture, request, 'Chrome peek master');
+		const related = await seedDoc(fixture, request, 'Chrome peek related');
+		await uploadAttachment(fixture, request, master.id, 'master-img.png');
+		await uploadAttachment(fixture, request, related.id, 'pane-img.png');
+
+		// Clicking INTO the pane freezes the MASTER into the peeking state — the
+		// reliable direction the strip spec drives.
+		await page.goto(`${itemUrl(fixture, master.slug)}?item=${encodeURIComponent(related.slug)}`);
+		const pane = page.locator('.item-pane');
+		const masterHost = page.locator('.item-page-host > .item-page');
+		await expect(pane).toBeVisible();
+		await pane.locator('.editor-wrapper .ProseMirror').first().click();
+		await expect(masterHost.locator('.editor-wrapper .ProseMirror').first()).toHaveAttribute(
+			'contenteditable',
+			'false'
+		);
+		// (a) The peeked master's strip still SHOWS its tiles (a read affordance) but
+		// its delete control is GONE — mutationsEnabled=false reached the side. This
+		// is the wiring that regresses silently if ItemDetail passes raw canEdit.
+		await expect(masterHost.locator(TILE)).toHaveCount(1);
+		await expect(masterHost.locator('.att-delete')).toHaveCount(0);
+
+		// (b) The ACTIVE pane's viewer toolbar OFFERS Delete.
+		await pane.locator(TILE).first().click();
+		await expect(page.locator(VIEWER_TOOLBAR)).toBeVisible();
+		await expect(viewerDelete(page)).toBeVisible();
+	});
+
+	test('toolbar Delete → drill-down (keyboard) → confirm advances, and the strip tile goes', async ({
+		page,
+		fixture,
+		request
+	}) => {
+		await browserLogin(page);
+		const doc = await seedDoc(fixture, request, 'Chrome viewer delete');
+		const a = await uploadAttachment(fixture, request, doc.id, 'del-a.png');
+		await uploadAttachment(fixture, request, doc.id, 'del-b.png');
+		await page.goto(itemUrl(fixture, doc.slug));
+		await expect(page.locator(TILE)).toHaveCount(2);
+		// Open del-a specifically (by name — the list order is created_at DESC, so its
+		// POSITION isn't fixed). The counter shows "· / 2" (two in the set); which
+		// index del-a lands on is incidental.
+		await page.locator(`${TILE}[aria-label*="del-a.png"]`).click();
+		await expect(page.locator(VIEWER_COUNTER)).toHaveText(/^[12] \/ 2$/);
+		await expect(page.locator(VIEWER_IMAGE)).toHaveAttribute('src', new RegExp(`/attachments/${a}`));
+
+		// Open the drill-down and reach the confirm rows BY KEYBOARD. Focus Delete,
+		// Enter opens it, focus enters the menu on the first row (Cancel).
+		await viewerDelete(page).focus();
+		await page.keyboard.press('Enter');
+		const cancel = viewerConfirmCancelRow(page);
+		const del = viewerConfirmDeleteRow(page);
+		await expect(cancel).toBeVisible();
+		await expect(cancel).toBeFocused();
+		// ROVING TABINDEX: exactly the active row is the tab stop (0), the rest -1 —
+		// so Tab exits the menu and Up/Down move between the rows (TASK-2477).
+		await expect(cancel).toHaveAttribute('tabindex', '0');
+		await expect(del).toHaveAttribute('tabindex', '-1');
+		await page.keyboard.press('ArrowDown');
+		await expect(del).toBeFocused();
+		await expect(del).toHaveAttribute('tabindex', '0');
+		await expect(cancel).toHaveAttribute('tabindex', '-1');
+		// Confirm by KEYBOARD (Enter), not a click — the drill-down is keyboard-usable
+		// end to end.
+		await page.keyboard.press('Enter');
+
+		// The viewer ADVANCES to the survivor (del-b), not closes — the retired C1
+		// latch — and the deleted tile disappears from the strip (bus reconciliation).
+		await expect(page.locator(VIEWER)).toHaveCount(1);
+		await expect(page.locator(VIEWER_IMAGE)).toHaveAttribute('src', new RegExp('/attachments/'));
+		await expect(page.locator(VIEWER_IMAGE)).not.toHaveAttribute('src', new RegExp(`/attachments/${a}`));
+		await expect(page.locator(`${TILE}[aria-label*="del-a.png"]`)).toHaveCount(0);
+		await expect(page.locator(TILE)).toHaveCount(1);
+	});
+
+	test('the metadata header shows name/type/size, ellipsizes a long name, and is inert to a press', async ({
+		page,
+		fixture,
+		request
+	}) => {
+		await browserLogin(page);
+		const doc = await seedDoc(fixture, request, 'Chrome header');
+		const long = `${'x'.repeat(180)}.png`;
+		// BIG_PNG (1600×1200) OVERFLOWS the stage, so zooming makes a real pan
+		// possible — a smaller image stays inside the stage and clampPan pins the pan
+		// to 0, which would hide a missing header exclusion (Codex round 2).
+		await uploadAttachment(fixture, request, doc.id, long, 'image/png', BIG_PNG);
+		await page.goto(itemUrl(fixture, doc.slug));
+		await page.locator(TILE).first().click();
+		await expect(page.locator(VIEWER_IMAGE)).toBeVisible();
+
+		// Filename + a type · size detail line.
+		const name = page.locator(VIEWER_META_NAME);
+		await expect(name).toHaveText(long);
+		await expect(page.locator(VIEWER_META_DETAIL)).toContainText('·'); // type · size
+		// DR-13: the FULL value is in title, and the box CLIPS WITH AN ELLIPSIS — the
+		// resolved style, not just overflow (a clip without `text-overflow: ellipsis`
+		// would still overflow but drop the "…", which jsdom cannot show).
+		await expect(name).toHaveAttribute('title', long);
+		const clip = await name.evaluate((el) => {
+			const cs = getComputedStyle(el);
+			return {
+				clipped: el.scrollWidth > el.clientWidth + 1,
+				textOverflow: cs.textOverflow,
+				whiteSpace: cs.whiteSpace,
+				overflow: cs.overflow
+			};
+		});
+		expect(clip.clipped, 'the long filename must overflow its clipped box').toBe(true);
+		expect(clip.textOverflow).toBe('ellipsis');
+		expect(clip.whiteSpace).toBe('nowrap');
+		expect(clip.overflow).toBe('hidden');
+
+		// The inert-label contract. ZOOM IN so a pan is actually possible, and wait for
+		// the 150ms transform TRANSITION to SETTLE (two equal scale reads) before
+		// sampling — otherwise a mid-transition rect makes the comparison flaky.
+		await page.keyboard.press('+');
+		await page.keyboard.press('+');
+		let lastScale = NaN;
+		await expect
+			.poll(async () => {
+				const s = await renderedScale(page);
+				const stable = s > 1 && s === lastScale;
+				lastScale = s;
+				return stable;
+			})
+			.toBe(true);
+		const rectBefore = await imageRect(page);
+		// A DRAG starting ON the header must not pan the image; the on-screen image
+		// rect stays put (a missing exclusion would move it).
+		const metaBox = (await page.locator(VIEWER_META).boundingBox())!;
+		await page.mouse.move(metaBox.x + 8, metaBox.y + metaBox.height / 2);
+		await page.mouse.down();
+		await page.mouse.move(metaBox.x + 220, metaBox.y + metaBox.height / 2, { steps: 6 });
+		await page.mouse.up();
+		const rectAfter = await imageRect(page);
+		expect(Math.abs(rectAfter.x - rectBefore.x), 'a drag on the header did not pan (x)').toBeLessThan(2);
+		expect(Math.abs(rectAfter.y - rectBefore.y), 'a drag on the header did not pan (y)').toBeLessThan(2);
+		await expect(page.locator(VIEWER)).toHaveCount(1); // and it did not dismiss
+	});
+
+	// THE FALLBACK ARM + no-bytes invariant is NOT reachable through the real
+	// producers in a browser, and is jsdom-proven instead (TASK-2476). Why: the
+	// icon fallback only ever draws a NAVIGABLE unsafe entry, which exists solely
+	// from a MID-VIEW safe→unsafe MIME flip — and every producer SNAPSHOTS the
+	// viewer's image set at open (`ItemAttachmentStrip.openLightbox` copies the
+	// derived array; `AttachmentViewerHost` spreads `request.images`), so a shown
+	// image's MIME cannot change under the open viewer here. The AT-OPEN unsafe
+	// case never reaches the viewer either: the producers filter `canOpenInViewer`
+	// before emitting, so the last-mile gate (`unsafeAtOpenIds`) is defense in
+	// depth. Route-intercepting the metadata probe flips the HEADER's fetched MIME,
+	// which the seed overrides — it does not change the arm. The jsdom suite drives
+	// the flip by mutating the prop directly (the one thing a component test can do
+	// and a browser cannot), and asserts the no-bytes invariant (no <img>, detached
+	// src cleared, loader disposed) there. Left as a visible `fixme` rather than
+	// omitted so the coverage boundary is explicit.
+	test.fixme(
+		'the fallback arm on a mid-view MIME flip (jsdom-proven — unreachable via real producers)',
+		async () => {}
+	);
+
+	test('a wheel over the toolbar neither zooms the image nor scrolls the page', async ({
+		page,
+		fixture,
+		request
+	}) => {
+		await browserLogin(page);
+		const doc = await seedDoc(fixture, request, 'Chrome wheel seam');
+		await uploadAttachment(fixture, request, doc.id, 'wheel.png');
+		await page.goto(itemUrl(fixture, doc.slug));
+		await page.locator(TILE).first().click();
+		await expect(page.locator(VIEWER_IMAGE)).toBeVisible();
+		// WAIT FOR DECODE: zoom is disabled until a bitmap exists (bitmapPresent), so
+		// a wheel before the image decodes is inert regardless of the exclusion — the
+		// exclusion is only observable once zoom is live (a false-pass without this).
+		await expect
+			.poll(() =>
+				page.locator(VIEWER_IMAGE).evaluate((img) => (img as HTMLImageElement).naturalWidth)
+			)
+			.toBeGreaterThan(0);
+
+		const scaleBefore = await renderedScale(page);
+		const scrollBefore = await page.evaluate(() => window.scrollY);
+		// Wheel directly over a toolbar control. deltaY NEGATIVE (zoom IN): a
+		// positive delta at fit is clamped to fit and would be a no-op regardless of
+		// the exclusion — so an inbound zoom is what makes the exclusion observable.
+		const box = (await page.locator(VIEWER_TOOLBAR).boundingBox())!;
+		await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+		await page.mouse.wheel(0, -300);
+		await page.mouse.wheel(0, -300);
+		// Settle past the 150ms zoom transition before sampling: a mutation that let
+		// the toolbar wheel through would animate the scale up, and reading too soon
+		// could catch a still-near-baseline value (Codex round 3). Asserting the
+		// ABSENCE of a zoom has nothing to poll for, so a bounded wait is right here.
+		await page.waitForTimeout(250);
+
+		// The image did not zoom, and the inert page behind did not scroll.
+		expect(await renderedScale(page)).toBeCloseTo(scaleBefore);
+		expect(await page.evaluate(() => window.scrollY)).toBe(scrollBefore);
+		// A control wheel over the STAGE image DOES zoom — proving the exclusion is
+		// what stopped the toolbar wheel, not a dead wheel path.
+		const stage = (await page.locator(VIEWER_STAGE).boundingBox())!;
+		await page.mouse.move(stage.x + stage.width / 2, stage.y + stage.height / 2);
+		await page.mouse.wheel(0, -300);
+		await expect
+			.poll(() => renderedScale(page))
+			.toBeGreaterThan(scaleBefore);
+	});
+});

--- a/web/e2e/attachment-viewer-modal.spec.ts
+++ b/web/e2e/attachment-viewer-modal.spec.ts
@@ -13,6 +13,7 @@ import {
 	dropFileIntoEditor,
 	expectBackgroundInert,
 	focusAttemptTakes,
+	focusViewerLastControl,
 	isFocusable,
 	itemUrl,
 	uploadAttachment,
@@ -536,33 +537,38 @@ test.describe('attachment viewer — modal contract (TASK-2436)', () => {
 		await page.locator(`${TILE}[aria-label*="trap-a.png"]`).click();
 		await expect(page.locator(VIEWER)).toHaveCount(1);
 
-		// Two images ⇒ three controls, in DOM order: Close, Previous, Next.
+		// The controls, in DOM (trap) order: Close, Previous, Next, then the toolbar
+		// (Open, Download, Copy, Delete — TASK-2474). The trap edges are DERIVED, not
+		// named: the toolbar moved the "last control" off the Next button.
 		const focused = () => page.evaluate(() => document.activeElement?.getAttribute('aria-label') ?? null);
 		expect(await focused(), 'focus entry is the first control').toBe('Close');
 
-		// FIRST → wraps to LAST. This is the branch.
+		// FIRST → wraps to LAST. This is the branch. The last control is the last
+		// toolbar action; focus it once to learn its label, then prove the wrap.
+		const lastLabel = await focusViewerLastControl(page);
+		expect(await focused()).toBe(lastLabel);
+		await page.locator(VIEWER).getByRole('button', { name: 'Close' }).focus();
 		await page.keyboard.press('Shift+Tab');
 		expect(await focused(), 'Shift+Tab from the first control must wrap to the LAST').toBe(
-			'Next image'
+			lastLabel
 		);
-		// ...and from the middle of the set it simply steps backward, so the
-		// wrap above is a wrap and not "Shift+Tab always lands on Next".
+		// ...and from the middle it simply steps backward, so the wrap above is a
+		// wrap and not "Shift+Tab always lands on the last".
+		await page.locator(VIEWER).getByRole('button', { name: 'Next image' }).focus();
 		await page.keyboard.press('Shift+Tab');
 		expect(await focused()).toBe('Previous image');
 		await page.keyboard.press('Shift+Tab');
 		expect(await focused()).toBe('Close');
 		expect(await activeInViewer(page), 'backward traversal never left the viewer').toBe(true);
 
-		// The FORWARD wrap, asserted by name rather than by containment: from the
-		// last control, Tab returns to the first.
-		await page.locator(VIEWER).getByRole('button', { name: 'Next image' }).focus();
+		// The FORWARD wrap: from the last control, Tab returns to the first.
+		await focusViewerLastControl(page);
 		await page.keyboard.press('Tab');
 		expect(await focused(), 'Tab from the last control must wrap to the FIRST').toBe('Close');
 
-		// SINGLE-CONTROL VIEWER: with one image there are no nav buttons, so
-		// `first === last` and BOTH directions resolve to the same element. A
-		// trap that only handled the multi-control case would let focus escape
-		// here — into a background that is inert, i.e. onto `<body>`.
+		// A ONE-IMAGE viewer has no nav buttons, but the toolbar still supplies
+		// controls, so the trap must still cycle among Close + the toolbar and never
+		// let focus escape into the inert background (onto `<body>`).
 		const one = await seedDoc(fixture, request, 'Viewer trap single');
 		await uploadAttachment(fixture, request, one.id, 'trap-solo.png');
 		await page.goto(itemUrl(fixture, one.slug));
@@ -570,10 +576,17 @@ test.describe('attachment viewer — modal contract (TASK-2436)', () => {
 		await expect(page.locator(VIEWER)).toHaveCount(1);
 		await expect(page.locator(VIEWER).getByRole('button', { name: 'Next image' })).toHaveCount(0);
 		expect(await focused()).toBe('Close');
-		for (const key of ['Tab', 'Shift+Tab', 'Tab']) {
-			await page.keyboard.press(key);
-			expect(await focused(), `${key} in a single-control viewer must stay on it`).toBe('Close');
-		}
+		// The WRAP still holds, asserted by name at both edges (not just containment,
+		// which a broken trap could satisfy by leaving focus put): from the last
+		// control Tab returns to Close, and Shift+Tab from Close returns to the last.
+		const soloLast = await focusViewerLastControl(page);
+		await page.keyboard.press('Tab');
+		expect(await focused(), 'nav-less: Tab from the last control wraps to Close').toBe('Close');
+		await page.keyboard.press('Shift+Tab');
+		expect(await focused(), 'nav-less: Shift+Tab from Close wraps to the last control').toBe(
+			soloLast
+		);
+		expect(await activeInViewer(page), 'focus never left the nav-less viewer').toBe(true);
 	});
 
 	test('a native showModal() dialog over the viewer wins Escape AND Tab outright', async ({
@@ -617,10 +630,11 @@ test.describe('attachment viewer — modal contract (TASK-2436)', () => {
 		});
 		const tabPrevented = () => page.evaluate(() => (window as unknown as { __tab: boolean[] }).__tab);
 
-		// CONTROL, viewer alone: a Tab the trap OWNS (from the last control, which
-		// wraps to the first) IS consumed. Without this the assertion below would
-		// pass against a viewer whose key handler never runs at all.
-		await page.locator(VIEWER).getByRole('button', { name: 'Next image' }).focus();
+		// CONTROL, viewer alone: a Tab the trap OWNS (from the LAST control, which
+		// wraps to the first) IS consumed. The last control is a toolbar action now
+		// (TASK-2474), so it is derived, not named. Without this the assertion below
+		// would pass against a viewer whose key handler never runs at all.
+		await focusViewerLastControl(page);
 		await page.keyboard.press('Tab');
 		expect(
 			(await tabPrevented()).at(-1),

--- a/web/e2e/lib/attachment-viewer.ts
+++ b/web/e2e/lib/attachment-viewer.ts
@@ -118,6 +118,72 @@ export const viewerPrev = (page: Page) =>
 export const viewerTapLoad = (page: Page) =>
 	page.locator(VIEWER).getByRole('button', { name: 'Tap to load full image' });
 
+// ── 3c-i surface chrome (TASK-2484) ─────────────────────────────────────────
+// The toolbar (TASK-2474), metadata header (TASK-2475), fallback arm (TASK-2476)
+// and delete drill-down (TASK-2473/2477). Class-qualified inside VIEWER, or —
+// for the interactive controls — addressed by the accessible NAME the code gives
+// them, per the selector rule above.
+export const VIEWER_TOOLBAR = `${VIEWER} .lightbox-toolbar`;
+export const VIEWER_META = `${VIEWER} .lightbox-meta`;
+export const VIEWER_META_NAME = `${VIEWER} .lightbox-meta-name`;
+export const VIEWER_META_DETAIL = `${VIEWER} .lightbox-meta-detail`;
+export const VIEWER_FALLBACK = `${VIEWER} .lightbox-fallback`;
+export const VIEWER_FALLBACK_NAME = `${VIEWER} .lightbox-fallback-name`;
+export const VIEWER_DELETE_CONFIRM = `${VIEWER} .lightbox-delete-confirm`;
+
+/** Open in new tab — a real anchor (role "link"), so href/target are assertable. */
+export const viewerOpenAnchor = (page: Page) =>
+	page.locator(VIEWER).getByRole('link', { name: 'Open in new tab' });
+/** Download — a real `<a download>` anchor. */
+export const viewerDownloadAnchor = (page: Page) =>
+	page.locator(VIEWER).getByRole('link', { name: 'Download' });
+/** Copy workspace link — a button (JS action, no href). */
+export const viewerCopyLink = (page: Page) =>
+	page.locator(VIEWER).getByRole('button', { name: 'Copy workspace link' });
+/** The toolbar's Delete — a button; `exact` so it never catches the confirm row
+ *  "Delete file". Absent entirely when the host withholds mutation permission. */
+export const viewerDelete = (page: Page) =>
+	page.locator(VIEWER).getByRole('button', { name: 'Delete', exact: true });
+/** The drill-down's confirm/cancel rows (role "menuitem", from MenuItem). */
+export const viewerConfirmDeleteRow = (page: Page) =>
+	page.locator(VIEWER_DELETE_CONFIRM).getByRole('menuitem', { name: 'Delete file' });
+export const viewerConfirmCancelRow = (page: Page) =>
+	page.locator(VIEWER_DELETE_CONFIRM).getByRole('menuitem', { name: 'Cancel' });
+
+/**
+ * The frontmost viewer's TABBABLE controls, in DOM (trap) order, as their
+ * accessible labels. Since TASK-2474 the toolbar adds controls AFTER the
+ * close/nav, so the trap's "last control" is no longer the Next button —
+ * anything asserting the trap edges must derive them rather than name a control.
+ */
+export function viewerFocusableLabels(page: Page): Promise<string[]> {
+	return page.evaluate((viewerSel) => {
+		const all = document.querySelectorAll(viewerSel);
+		const el = all[all.length - 1] as HTMLElement | undefined;
+		if (!el) return [];
+		return Array.from(el.querySelectorAll<HTMLElement>('a[href], button'))
+			.filter((n) => !(n as HTMLButtonElement).disabled && n.tabIndex !== -1 && n.offsetParent !== null)
+			.map((n) => n.getAttribute('aria-label') ?? n.textContent?.trim() ?? '');
+	}, VIEWER);
+}
+
+/** Focus the frontmost viewer's LAST tabbable control; returns its label. */
+export function focusViewerLastControl(page: Page): Promise<string> {
+	return page.evaluate((viewerSel) => {
+		const all = document.querySelectorAll(viewerSel);
+		const el = all[all.length - 1] as HTMLElement | undefined;
+		const nodes = el
+			? Array.from(el.querySelectorAll<HTMLElement>('a[href], button')).filter(
+					(n) => !(n as HTMLButtonElement).disabled && n.tabIndex !== -1 && n.offsetParent !== null
+				)
+			: [];
+		const last = nodes[nodes.length - 1];
+		if (!last) throw new Error('focusViewerLastControl: no focusable control');
+		last.focus();
+		return last.getAttribute('aria-label') ?? last.textContent?.trim() ?? '';
+	}, VIEWER);
+}
+
 /**
  * The `scale(...)` factor the browser has actually applied to the viewer image,
  * read from its COMPUTED transform matrix (`matrix(a, …)`, a === scale). NaN when

--- a/web/src/lib/attachments/actions.ts
+++ b/web/src/lib/attachments/actions.ts
@@ -9,11 +9,11 @@
  *
  * TODAY THERE IS ONE CONSUMER: the options panel, which draws them as a
  * menu/sheet. The unified image viewer — the second renderer, an inline
- * toolbar over the same list — arrives in phase 3a, which is also what will
+ * toolbar over the same list — arrives in phase 3c-i, which is also what will
  * consume the `address` option now threaded onto the image NodeView. Stated
  * plainly because "rendered twice" read as a description of the present and
  * was not one; a list with a single consumer is a shape held open on purpose,
- * and worth re-justifying if 3a ever stops coming.
+ * and worth re-justifying if 3c-i ever stops coming.
  *
  * TWO DESCRIPTOR SHAPES, not one, because the ELEMENT is part of the contract
  * (DR-5, round 35/36):
@@ -50,6 +50,7 @@ import { api } from '$lib/api/client';
 import { announceAttachmentDeleted } from '$lib/attachments/events';
 import { canBrowserPreview } from '$lib/attachments/display';
 import { copyToClipboard } from '$lib/utils/clipboard';
+import type { ActionIconId } from '$lib/attachments/icons/index';
 
 export type AttachmentActionId = 'open' | 'download' | 'copy-link' | 'delete';
 
@@ -97,8 +98,12 @@ interface BaseAttachmentAction {
 	id: AttachmentActionId;
 	/** Row/button label. Visible text, so it carries the honest semantics. */
 	label: string;
-	/** Leading glyph, in `MenuItem`'s string-icon vocabulary. */
-	icon: string;
+	/**
+	 * Leading icon — an ACTION-icon id from the shared registry (TASK-2472),
+	 * rendered via `AttachmentIcon` through `MenuItem`'s `iconSnippet`. Typed to
+	 * the union so a renderer cannot pass a glyph string or an unknown id.
+	 */
+	icon: ActionIconId;
 	/** Longer explanation for a tooltip / sublabel. */
 	description?: string;
 	/**
@@ -161,7 +166,7 @@ export const ATTACHMENT_ACTIONS: readonly AttachmentAction[] = [
 	{
 		id: 'open',
 		label: 'Open in new tab',
-		icon: '⇗',
+		icon: 'action-open',
 		description: 'Hands the file to the browser to preview.',
 		element: 'anchor',
 		// Only for what a browser previews natively. Never a Pad-rendered
@@ -176,7 +181,7 @@ export const ATTACHMENT_ACTIONS: readonly AttachmentAction[] = [
 	{
 		id: 'download',
 		label: 'Download',
-		icon: '⇩',
+		icon: 'action-download',
 		element: 'anchor',
 		applies: () => true,
 		enabled: addressable,
@@ -198,7 +203,7 @@ export const ATTACHMENT_ACTIONS: readonly AttachmentAction[] = [
 		// access to this workspace, not a public share link. Pad has no
 		// attachment share token.
 		label: 'Copy workspace link',
-		icon: '🔗',
+		icon: 'action-copy-link',
 		description: 'Opens only for people with access to this workspace.',
 		element: 'button',
 		applies: () => true,
@@ -214,7 +219,7 @@ export const ATTACHMENT_ACTIONS: readonly AttachmentAction[] = [
 	{
 		id: 'delete',
 		label: 'Delete',
-		icon: '🗑',
+		icon: 'action-delete',
 		element: 'button',
 		danger: true,
 		// ABSENT, not disabled, where the caller cannot mutate — a peeked pane,

--- a/web/src/lib/attachments/actions.ts
+++ b/web/src/lib/attachments/actions.ts
@@ -7,13 +7,12 @@
  * descriptors: a surface renders them, none of them owns the set, and adding an
  * action means adding one descriptor here.
  *
- * TODAY THERE IS ONE CONSUMER: the options panel, which draws them as a
- * menu/sheet. The unified image viewer — the second renderer, an inline
- * toolbar over the same list — arrives in phase 3c-i, which is also what will
- * consume the `address` option now threaded onto the image NodeView. Stated
- * plainly because "rendered twice" read as a description of the present and
- * was not one; a list with a single consumer is a shape held open on purpose,
- * and worth re-justifying if 3c-i ever stops coming.
+ * TWO CONSUMERS render this list now (phase 3c-i shipped): the options panel
+ * draws it as a menu/sheet, and the image viewer's `Lightbox` toolbar draws it
+ * as an inline toolbar over the stage — anchor vs button per the `element`
+ * discriminant, the delete descriptor's confirm gate wired to each surface's own
+ * drill-down. So "rendered twice" is now the literal present, which is the whole
+ * point of the descriptor list: one source of truth, two renderers.
  *
  * TWO DESCRIPTOR SHAPES, not one, because the ELEMENT is part of the contract
  * (DR-5, round 35/36):

--- a/web/src/lib/attachments/actions.ts
+++ b/web/src/lib/attachments/actions.ts
@@ -62,7 +62,15 @@ export type AttachmentActionId = 'open' | 'download' | 'copy-link' | 'delete';
 export interface AttachmentActionSubject {
 	id: string;
 	filename: string;
-	mime_type: string;
+	/**
+	 * NULLABLE (TASK-2474). The panel builds this from a HEAD probe that always
+	 * completes before it shows a row, but the viewer's toolbar builds it from
+	 * the open-viewer channel, whose `mime_type` is null until an inline image's
+	 * probe resolves. Every `applies()` below handles null CONSERVATIVELY: Open
+	 * needs a positively-previewable MIME (null → not offered, via
+	 * `canBrowserPreview`), while Download / Copy-link / Delete never consult it.
+	 */
+	mime_type: string | null;
 }
 
 export interface AttachmentActionContext {

--- a/web/src/lib/attachments/display.test.ts
+++ b/web/src/lib/attachments/display.test.ts
@@ -7,7 +7,12 @@ import {
 	iconForAttachment,
 	isImage
 } from './display';
-import { ATTACHMENT_ICON_IDS, ATTACHMENT_ICON_PATHS, iconSvg } from './icons/index';
+import {
+	ACTION_ICON_IDS,
+	ATTACHMENT_ICON_IDS,
+	ATTACHMENT_ICON_PATHS,
+	iconSvg
+} from './icons/index';
 import familyFixture from './mime-families.json';
 
 /**
@@ -147,9 +152,25 @@ describe('iconSvg', () => {
 		}
 	});
 
-	it('gives every family a distinct shape', () => {
+	it('gives every icon — family AND action — a distinct shape', () => {
 		const paths = new Set(Object.values(ATTACHMENT_ICON_PATHS));
-		expect(paths.size).toBe(ATTACHMENT_ICON_IDS.length);
+		expect(paths.size).toBe(ATTACHMENT_ICON_IDS.length + ACTION_ICON_IDS.length);
+	});
+
+	it('registers every ACTION icon with a non-empty currentColor path (TASK-2472)', () => {
+		// Drift guard: the four action ids the descriptors reference must exist in
+		// the registry and render a real SVG path — a descriptor pointing at a
+		// missing id would otherwise fall back to the generic file silently.
+		expect([...ACTION_ICON_IDS].sort()).toEqual(
+			['action-copy-link', 'action-delete', 'action-download', 'action-open'].sort()
+		);
+		for (const id of ACTION_ICON_IDS) {
+			expect(ATTACHMENT_ICON_PATHS[id], `${id} has a path`).toBeTruthy();
+			const svg = iconSvg(id);
+			expect(svg, `${id} renders its own path`).toContain(ATTACHMENT_ICON_PATHS[id]);
+			expect(svg).toContain('stroke="currentColor"');
+			expect(svg).not.toBe(iconSvg('generic')); // not the silent fallback
+		}
 	});
 
 	it('renders the generic icon for an unknown id rather than throwing', () => {

--- a/web/src/lib/attachments/events.ts
+++ b/web/src/lib/attachments/events.ts
@@ -281,10 +281,12 @@ export function notifyAttachmentPanelOpen(event: AttachmentPanelOpenEvent): void
  * nothing until 3c gives them a single surface to consolidate ONTO. A decision,
  * not an omission.
  *
- * `mutationsEnabled` is deliberately absent from this channel and from the
- * host: 3a's viewer has no mutating action, so it would be a dead prop. It is a
- * hard prerequisite of 3c's Delete, and when it arrives its source must be the
- * host's own gate.
+ * `mutationsEnabled` is on the HOST but deliberately NOT on this CHANNEL (since
+ * 3c-i's Delete, TASK-2474): it is a LIVE permission (the host's `canEdit &&
+ * !peeking`), read on the far side of an async confirmation, not a value an
+ * emitter could snapshot at open — so `AttachmentViewerHost` takes it (and the
+ * delete-warning content getters) as PROPS and forwards them to `Lightbox`,
+ * while the open EVENT stays permission-free.
  */
 export interface LightboxImage {
 	id: string;

--- a/web/src/lib/attachments/icons/AttachmentIcon.svelte
+++ b/web/src/lib/attachments/icons/AttachmentIcon.svelte
@@ -13,20 +13,27 @@
 		GENERIC_ICON_ID,
 		ICON_SVG_ATTRS,
 		iconSize,
-		isAttachmentIconId,
+		isIconId,
+		type IconId,
 	} from './index';
 
 	let {
 		id,
 		size = undefined,
 	}: {
-		/** An icon id — usually `iconForAttachment(mime, filename)`. Unknown ids render the generic file. */
-		id: string;
+		/**
+		 * A known registry icon id — a file family (`iconForAttachment(mime,
+		 * filename)`) or an action icon (`actions.ts`). Typed to the union so an
+		 * unknown id is a COMPILE error rather than a silent generic-file fallback.
+		 */
+		id: IconId;
 		/** CSS length, or a number of pixels. Defaults to `1em` so it scales with the surface's type. */
 		size?: number | string;
 	} = $props();
 
-	const iconId = $derived(isAttachmentIconId(id) ? id : GENERIC_ICON_ID);
+	// `id` is typed to the registry, so this is defensive (an `as` cast could still
+	// smuggle a bad string) and never falls through for a real id.
+	const iconId = $derived(isIconId(id) ? id : GENERIC_ICON_ID);
 	const box = $derived(iconSize(size));
 </script>
 

--- a/web/src/lib/attachments/icons/index.ts
+++ b/web/src/lib/attachments/icons/index.ts
@@ -35,6 +35,24 @@ export const ATTACHMENT_ICON_IDS = [
 
 export type AttachmentIconId = (typeof ATTACHMENT_ICON_IDS)[number];
 
+/**
+ * Action-toolbar icons (PLAN-2392 3c-i / TASK-2472). Same module, same style as
+ * the family set — monochrome, `currentColor`, forced-colors-safe — but for the
+ * shared attachment ACTIONS (`actions.ts`) rather than file families, so the two
+ * render paths (`AttachmentIcon.svelte`, `iconSvg`) draw them from one table too.
+ */
+export const ACTION_ICON_IDS = [
+	'action-open',
+	'action-download',
+	'action-copy-link',
+	'action-delete',
+] as const;
+
+export type ActionIconId = (typeof ACTION_ICON_IDS)[number];
+
+/** Every id the registry can render — file families AND toolbar actions. */
+export type IconId = AttachmentIconId | ActionIconId;
+
 /** The fallback for anything unrecognized — a plain file, never a "❓" (DR-3a). */
 export const GENERIC_ICON_ID: AttachmentIconId = 'generic';
 
@@ -42,7 +60,7 @@ export const GENERIC_ICON_ID: AttachmentIconId = 'generic';
 // a folded top-right corner.
 const PAGE = 'M13.5 2.5H7A2 2 0 0 0 5 4.5v15a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V8z M13.5 2.5V8H19';
 
-export const ATTACHMENT_ICON_PATHS: Record<AttachmentIconId, string> = {
+export const ATTACHMENT_ICON_PATHS: Record<IconId, string> = {
 	// Framed picture: sun + horizon line.
 	image:
 		'M3.5 5.5A2 2 0 0 1 5.5 3.5h13a2 2 0 0 1 2 2v13a2 2 0 0 1-2 2h-13a2 2 0 0 1-2-2z ' +
@@ -68,6 +86,18 @@ export const ATTACHMENT_ICON_PATHS: Record<AttachmentIconId, string> = {
 	text: 'M8.5 8.5L4.5 12l4 3.5 M15.5 8.5l4 3.5-4 3.5 M13.5 5l-3 14',
 	// Bare page — the fallback.
 	generic: PAGE,
+
+	// ── Action icons (TASK-2472) ────────────────────────────────────────────
+	// Open in new tab: a framed box with an arrow leaving the top-right corner.
+	'action-open': 'M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6 M15 3h6v6 M10 14L21 3',
+	// Download: a down arrow into a tray.
+	'action-download': 'M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4 M7 10l5 5 5-5 M12 15V3',
+	// Copy link: two interlocking chain halves.
+	'action-copy-link':
+		'M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71 ' +
+		'M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71',
+	// Delete: a trash can with a lid, handle, and two body strokes.
+	'action-delete': 'M3 6h18 M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2 M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6 M10 11v6 M14 11v6',
 };
 
 /**
@@ -86,9 +116,17 @@ export const ICON_SVG_ATTRS = {
 	focusable: 'false',
 } as const;
 
-/** Narrow an arbitrary string to a known icon id, falling back to generic. */
+/** Narrow an arbitrary string to a known FILE-FAMILY icon id (MIME → family). */
 export function isAttachmentIconId(id: string): id is AttachmentIconId {
 	return (ATTACHMENT_ICON_IDS as readonly string[]).includes(id);
+}
+
+/** Narrow an arbitrary string to ANY registry id — a family OR an action icon. */
+export function isIconId(id: string): id is IconId {
+	return (
+		(ATTACHMENT_ICON_IDS as readonly string[]).includes(id) ||
+		(ACTION_ICON_IDS as readonly string[]).includes(id)
+	);
 }
 
 /**
@@ -117,7 +155,10 @@ export function iconSize(size: number | string | undefined): string {
  * `iconSize`, so the result is safe to assign to `innerHTML`.
  */
 export function iconSvg(id: string, options: { size?: number | string } = {}): string {
-	const iconId = isAttachmentIconId(id) ? id : GENERIC_ICON_ID;
+	// Any registry id (family or action) renders; an unknown string still falls
+	// back to the generic file — the family-icon fallback the chip NodeView relies
+	// on stays intact.
+	const iconId = isIconId(id) ? id : GENERIC_ICON_ID;
 	const size = iconSize(options.size);
 	const attrs = Object.entries(ICON_SVG_ATTRS)
 		.map(([key, value]) => `${key}="${value}"`)

--- a/web/src/lib/attachments/surfaceDeleteConfirm.svelte.ts
+++ b/web/src/lib/attachments/surfaceDeleteConfirm.svelte.ts
@@ -1,0 +1,130 @@
+/**
+ * The attachment surface's delete-confirmation machine (PLAN-2392 3c-i /
+ * TASK-2473), lifted VERBATIM from `AttachmentDetailsPanel.svelte`'s internals
+ * so the panel and — later — the converged viewer share ONE implementation.
+ *
+ * THE PROMISE / UI SPLIT STAYS (DR-18). The delete DESCRIPTOR (`actions.ts`)
+ * owns the delete itself: it snapshots identity, awaits `ctx.confirmDelete()`
+ * (this module's gate), re-checks permission + identity on the far side, and
+ * only then calls the API. So this module owns the confirmation STATE — the
+ * pending resolver, the warning string, and the abandon rules — and the
+ * existing `AttachmentDeleteConfirm.svelte` keeps RENDERING it. It does NOT own
+ * the delete action; a module-owned `onConfirmed` would fire a second delete
+ * beside the descriptor's and defeat the identity snapshot the descriptor keeps.
+ *
+ * TWO ABANDON RULES, both of which reject the gate promise so the descriptor's
+ * `await` never dangles:
+ *   - PERMISSION WITHDRAWN mid-decision — the pane goes peeked or a role
+ *     changes while the confirmation is up; the surface is supposed to offer no
+ *     delete at all in that state, so the confirmation is abandoned (watched
+ *     here via `mutationsEnabled`).
+ *   - SUBJECT CHANGE / teardown — the surface moves to another attachment or is
+ *     torn down; the caller drives these through `cancel()` / `dispose()`.
+ *
+ * WHY A `.svelte.ts` MODULE. It holds `$state` and a `$effect` (the permission
+ * watch), so it is a rune module and must be created inside a component's init.
+ */
+import { untrack } from 'svelte';
+import { attachmentDeletePrompt } from '$lib/components/attachments/AttachmentDeleteConfirm.svelte';
+
+export interface DeleteConfirmDeps {
+	/** "May this user delete here" — the host's answer. The gate no-ops without it. */
+	mutationsEnabled: () => boolean;
+	/**
+	 * Whether THIS body references the attachment (the boolean `referencedHere()`
+	 * the panel computes from its live/saved content). Read at request time so it
+	 * sees unflushed editor edits.
+	 */
+	isReferenced: () => boolean;
+	/** The attachment's display name, for the prompt. */
+	displayName: () => string;
+}
+
+export interface SurfaceDeleteConfirm {
+	/** True while the confirmation sub-view is up. */
+	readonly pending: boolean;
+	/** The prompt string while pending (the shared two-arm wording), else null. */
+	readonly warning: string | null;
+	/**
+	 * Open the confirmation and resolve when the user answers — the descriptor's
+	 * `ctx.confirmDelete`. A no-op that resolves false when the caller may not
+	 * mutate. Supersedes any confirmation already up.
+	 */
+	request(): Promise<boolean>;
+	/** The sub-view's Delete row — resolve the gate true. */
+	confirm(): void;
+	/** The sub-view's Cancel row, and the subject-change abandon — resolve false. */
+	cancel(): void;
+	/** Teardown — reject any pending confirmation so the descriptor's await settles. */
+	dispose(): void;
+}
+
+/**
+ * Build the delete-confirmation machine. `mutationsEnabled` and `isReferenced`
+ * MUST read live reactive values on every call.
+ */
+export function createDeleteConfirm(deps: DeleteConfirmDeps): SurfaceDeleteConfirm {
+	/** 'root' = actions shown; 'delete' = confirmation up. */
+	let view = $state<'root' | 'delete'>('root');
+	let prompt = $state('');
+	/** Resolver for the confirmation currently on screen, if any. */
+	let pendingConfirm: ((confirmed: boolean) => void) | null = null;
+
+	function settle(confirmed: boolean) {
+		const resolve = pendingConfirm;
+		pendingConfirm = null;
+		view = 'root';
+		resolve?.(confirmed);
+	}
+
+	/**
+	 * Permission withdrawn while the confirmation is open (DR-8). Blocking the
+	 * request is not enough — the user is left looking at a live "Delete file"
+	 * button for an action that can no longer happen — so it is abandoned as a
+	 * rejection, exactly as a subject change abandons it.
+	 *
+	 * Plain latch + `untrack` for the writes: as `$state` this effect would depend
+	 * on what it writes, which aborts the flush and strands unrelated reactivity
+	 * (CONVE-1688).
+	 */
+	$effect(() => {
+		const mayMutate = deps.mutationsEnabled();
+		untrack(() => {
+			if (mayMutate || view !== 'delete') return;
+			settle(false);
+		});
+	});
+
+	function request(): Promise<boolean> {
+		// The gate no-ops for a caller who may not mutate — the descriptor already
+		// gates, but the module's own contract holds without it.
+		if (!deps.mutationsEnabled()) return Promise.resolve(false);
+		// The wording comes from the shared prompt — the same two arms the strip's
+		// tile shows (DR-18). Composed at request time so it reflects the live body.
+		prompt = attachmentDeletePrompt(deps.displayName(), deps.isReferenced());
+		return new Promise<boolean>((resolve) => {
+			// Supersede any confirmation already up — two open at once would leave a
+			// resolver dangling forever.
+			pendingConfirm?.(false);
+			pendingConfirm = resolve;
+			view = 'delete';
+		});
+	}
+
+	return {
+		get pending() {
+			return view === 'delete';
+		},
+		get warning() {
+			return view === 'delete' ? prompt : null;
+		},
+		request,
+		confirm: () => settle(true),
+		cancel: () => settle(false),
+		dispose: () => {
+			const resolve = pendingConfirm;
+			pendingConfirm = null;
+			resolve?.(false);
+		},
+	};
+}

--- a/web/src/lib/attachments/surfaceMetadata.svelte.ts
+++ b/web/src/lib/attachments/surfaceMetadata.svelte.ts
@@ -1,0 +1,271 @@
+/**
+ * The attachment surface's metadata machine (PLAN-2392 3c-i / TASK-2473),
+ * lifted VERBATIM from `AttachmentDetailsPanel.svelte`'s internals so the panel
+ * and — later — the converged viewer share ONE implementation rather than a
+ * copy each.
+ *
+ * SEED THEN FETCH (DR-2, DR-10). A surface opens IMMEDIATELY with whatever the
+ * open event carried (a list row has all three fields; a chip may have none)
+ * and completes the rest with a HEAD probe. The three settled states are
+ * distinguishable on purpose:
+ *
+ *   - `ok`        — the gaps are filled in place.
+ *   - `missing`   — the row is gone (404). AUTHORITATIVE and latched; every
+ *                   action goes inert rather than offering a Download that fails.
+ *   - `transient` — a non-404 failure, retryable, BESIDE what is already known
+ *                   (never a blank sheet). Retry routes through
+ *                   `revalidateAttachmentMetadata` (invalidate-then-fetch) so it
+ *                   cannot replay the cached failure.
+ *
+ * THE (workspace, attachment) FENCES. This surface stays MOUNTED across the
+ * navigations that change what it shows, so every fetch, timer and mutation has
+ * to name the view it belongs to (see `$lib/attachments/viewFence`). The three
+ * fences live here — the metadata read owns the request fence, and the view +
+ * paint fences are exposed for the consumer's own actions/close, which must
+ * fence against the same identity.
+ *
+ * WHY A `.svelte.ts` MODULE. It holds `$state` and a `$effect`, so it is a rune
+ * module and must be created inside a component's init (an `$effect` root).
+ */
+import { untrack } from 'svelte';
+import { api } from '$lib/api/client';
+import {
+	fetchAttachmentMetadata,
+	revalidateAttachmentMetadata,
+} from '$lib/components/editor/attachment-metadata';
+import {
+	createFence,
+	createPaintFence,
+	viewIdentity,
+	type Fence,
+	type PaintFence,
+} from '$lib/attachments/viewFence';
+
+/**
+ * How long a metadata read may hang before the surface calls it a failure.
+ * Generous: this is the "something is wrong" threshold, not a latency budget —
+ * a slow answer that arrives still wins.
+ */
+export const METADATA_SLOW_MS = 10_000;
+
+/** Seed metadata from the open event — all NULLABLE by contract (DR-2). */
+export interface SurfaceMetadataSeed {
+	filename: string | null;
+	mime_type: string | null;
+	size_bytes: number | null;
+}
+
+/** Everything the metadata machine reads — the live props, via a getter. */
+export interface SurfaceMetadataAddress {
+	ws: string;
+	attachmentId: string;
+	seed: SurfaceMetadataSeed;
+	/** Whether the surface is open — a closed surface fetches nothing. */
+	open: boolean;
+	/**
+	 * The parent item is archived, so reads 404 — the seed is not trustworthy as
+	 * evidence the file is REACHABLE, so probe even when it looks complete (DR-14).
+	 */
+	parentArchived: boolean;
+	/** Host revalidate signal — a bump forces an invalidate-then-fetch (DR-14). */
+	revalidateToken: number;
+}
+
+/** The settled metadata state a renderer branches on. */
+export type SurfaceMetadataPhase = 'seeded' | 'ok' | 'missing' | 'transient';
+
+export interface SurfaceMetadata {
+	/** `missing` / `transient` gate the render; `ok` / `seeded` both show the row. */
+	readonly phase: SurfaceMetadataPhase;
+	/** Seed merged with what the fetch filled — the event's value always wins. */
+	readonly fields: SurfaceMetadataSeed;
+	/** A read is in flight (the "Reading details…" / reachability-probe state). */
+	readonly slow: boolean;
+	/** The view fence — a consumer's own actions must fence against the same identity. */
+	readonly viewFence: Fence<{ ws: string; att: string }>;
+	/** The paint fence — "does the control the user clicked belong to what's on screen?" */
+	readonly paint: PaintFence<{ ws: string; att: string }>;
+	/** Re-read on demand (Retry) — the same invalidate-then-fetch path a restore uses. */
+	retry(): void;
+	/** Teardown: invalidate the fences so every in-flight continuation reads stale. */
+	dispose(): void;
+}
+
+/**
+ * Build the metadata machine for a surface. `address` MUST read the live
+ * reactive values on every call. `onSubjectChange` fires when the surface
+ * genuinely changes subject (not on a Retry of the same one), so the consumer
+ * can drop the OTHER per-subject state the machine does not own — the delete
+ * confirmation and any in-flight action — exactly as the panel did inline.
+ */
+export function createSurfaceMetadata(
+	address: () => SurfaceMetadataAddress,
+	{ onSubjectChange }: { onSubjectChange?: () => void } = {}
+): SurfaceMetadata {
+	const identity = viewIdentity(() => {
+		const a = address();
+		return { ws: a.ws, att: a.attachmentId };
+	});
+	// 1. Request fence — restarted per read, so a Retry supersedes its predecessor.
+	const loadFence = createFence(identity);
+	// 2. View fence — invalidated only on a real subject change, so an in-flight
+	//    delete of the row still on screen can reconcile even after a Retry reload.
+	const viewFence = createFence(identity);
+	// 3. Paint fence — checked at ENTRY by every control.
+	const paint = createPaintFence(identity);
+
+	// Plain `let`, never $state: read and written only inside the effect, and a
+	// $state here would make the effect depend on what it writes (CONVE-1688).
+	let paintedKey: string | null = null;
+	// The reload stamp already acted on — host revalidate + local Retry counter.
+	// Seeded from the incoming token so a host that already bumped its counter
+	// doesn't read as a pending reload on the first render.
+	let seenReload = untrack(() => `${address().revalidateToken}:0`);
+
+	// What the server told us, filling the gaps the event left.
+	let fetchedMime = $state<string | null>(null);
+	let fetchedSize = $state<number | null>(null);
+	let loading = $state(false);
+	/** 404 — authoritative. Actions go inert. */
+	let missing = $state(false);
+	/** Non-404 failure — inline, retryable, alongside what we already know. */
+	let loadFailed = $state(false);
+	/** Bumped by Retry; drives the effect's forced-revalidate path. */
+	let forceReload = $state(0);
+
+	const downloadUrl = (uuid: string, variant?: 'thumb-sm' | 'thumb-md' | 'original') =>
+		api.attachments.downloadUrl(address().ws, uuid, variant);
+
+	/**
+	 * Load whatever the event didn't carry, and re-read on demand.
+	 *
+	 * Reads only the address + fence identity in tracked scope; every piece of
+	 * state it writes (`loading`, `missing`, `fetched*`) is read only in `untrack`ed
+	 * blocks and by consumers, so the effect cannot self-invalidate.
+	 */
+	$effect(() => {
+		const a = address();
+		const req = loadFence.restart();
+		const isOpen = a.open;
+		const seedMime = a.seed.mime_type;
+		const seedSize = a.seed.size_bytes;
+		const reloadStamp = `${a.revalidateToken}:${forceReload}`;
+		const archivedParent = a.parentArchived;
+
+		let forced = false;
+		untrack(() => {
+			// A genuine subject change: drop everything the previous attachment left
+			// behind, stop any in-flight continuation from reconciling, and abandon a
+			// confirmation up for a file the user is no longer looking at.
+			if (req.key !== paintedKey) {
+				paintedKey = req.key;
+				viewFence.invalidate();
+				onSubjectChange?.();
+				fetchedMime = null;
+				fetchedSize = null;
+				missing = false;
+				loadFailed = false;
+			}
+			// Whatever this run paints belongs to this (workspace, attachment). An
+			// un-addressable token records nothing.
+			paint.record(req);
+			// An archived parent makes this a REACHABILITY question, and the cache
+			// can hold an `ok` observed before the archive — force it, routing through
+			// invalidate-then-fetch instead of replaying a stale success.
+			if (archivedParent) forced = true;
+			if (reloadStamp !== seenReload) {
+				seenReload = reloadStamp;
+				forced = true;
+				// A forced revalidation exists because the previous answer may no
+				// longer hold (DR-14). Drop the latched `missing` NOW rather than only
+				// on an `ok`: if this comes back transient, the render must fall through
+				// to the retryable error, not sit on "no longer available" (DR-10).
+				missing = false;
+			}
+		});
+
+		if (!isOpen || req.key === null) return;
+		// Nothing to complete: the strip's entry point always has all three. Unless
+		// the parent is archived — then "complete" and "reachable" differ, and only
+		// a probe settles the second.
+		if (!forced && !archivedParent && seedMime && seedSize !== null && seedSize !== undefined) {
+			return;
+		}
+
+		loading = true;
+		loadFailed = false;
+		// A HEAD that never settles is not a failure the fetch layer reports: no
+		// rejection arrives, so without this the surface sits on "Reading details…"
+		// forever with no Retry (DR-10). The request is NOT aborted: a late answer is
+		// still the truth and still allowed to correct the error state.
+		const slowTimer = setTimeout(() => {
+			if (req.stale()) return;
+			loading = false;
+			loadFailed = true;
+		}, METADATA_SLOW_MS);
+		void (async () => {
+			// The workspace comes off the TOKEN, not the live prop: the request must
+			// name the workspace it was issued for even if the surface has moved on.
+			const result = forced
+				? await revalidateAttachmentMetadata(req.value.ws, req.value.att, downloadUrl)
+				: await fetchAttachmentMetadata(req.value.ws, req.value.att, downloadUrl);
+			clearTimeout(slowTimer);
+			if (req.stale()) return;
+			loading = false;
+			if (result.status === 'ok') {
+				fetchedMime = result.mime;
+				fetchedSize = result.size;
+				missing = false;
+				loadFailed = false;
+			} else if (result.status === 'missing') {
+				// Authoritative. Latch it — the actions go inert.
+				missing = true;
+				loadFailed = false;
+			} else {
+				// Says nothing about whether the row exists: keep what we have and stay
+				// retryable.
+				loadFailed = true;
+			}
+		})();
+	});
+
+	function retry() {
+		// ENTRY fence: the clicked row was painted for `paint`'s identity, and the
+		// live props may already name a different attachment.
+		if (!paint.isCurrent()) return;
+		loadFailed = false;
+		// Goes through the effect's revalidate path rather than fetching here, so a
+		// user Retry and the host's restore signal (DR-14) are ONE path — both
+		// invalidate before refetching, the whole point of Retry (DR-10).
+		forceReload += 1;
+	}
+
+	function dispose() {
+		viewFence.invalidate();
+		loadFence.invalidate();
+		paint.record(null);
+	}
+
+	return {
+		get phase() {
+			if (missing) return 'missing';
+			if (loadFailed) return 'transient';
+			return fetchedMime !== null || fetchedSize !== null ? 'ok' : 'seeded';
+		},
+		get fields() {
+			const seed = address().seed;
+			return {
+				filename: seed.filename,
+				mime_type: seed.mime_type || fetchedMime,
+				size_bytes: seed.size_bytes ?? fetchedSize,
+			};
+		},
+		get slow() {
+			return loading;
+		},
+		viewFence,
+		paint,
+		retry,
+		dispose,
+	};
+}

--- a/web/src/lib/attachments/surfaceRenderers.test.ts
+++ b/web/src/lib/attachments/surfaceRenderers.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { getSurfaceRenderer } from './surfaceRenderers';
+
+// The single decision of WHICH renderer draws an attachment (TASK-2476). It is
+// defined AS the DR-16 raster allowlist, so this pins that it fails closed on
+// everything else — the invariant the viewer's no-bytes fallback rests on.
+describe('getSurfaceRenderer', () => {
+	it("returns 'raster-image' for every DR-16 raster type", () => {
+		for (const mime of [
+			'image/png',
+			'image/jpeg',
+			'image/gif',
+			'image/webp',
+			'image/avif',
+		]) {
+			expect(getSurfaceRenderer(mime)).toBe('raster-image');
+		}
+	});
+
+	it('returns null for an unsafe / active type (SVG), which becomes the fallback', () => {
+		// image/svg+xml carries active content — the exact hole the allowlist closes.
+		expect(getSurfaceRenderer('image/svg+xml')).toBeNull();
+	});
+
+	it('returns null for non-image types a browser cannot preview as a raster', () => {
+		for (const mime of ['application/pdf', 'text/plain', 'application/zip', 'image/tiff']) {
+			expect(getSurfaceRenderer(mime)).toBeNull();
+		}
+	});
+
+	it('fails closed on an unresolved (null) MIME', () => {
+		expect(getSurfaceRenderer(null)).toBeNull();
+	});
+});

--- a/web/src/lib/attachments/surfaceRenderers.ts
+++ b/web/src/lib/attachments/surfaceRenderers.ts
@@ -1,0 +1,44 @@
+/**
+ * The attachment SURFACE-RENDERER registry (PLAN-2392 phase 3c-i / TASK-2476,
+ * the seam PLAN-2393 extends).
+ *
+ * A surface (today just the image viewer) draws an attachment through one of a
+ * small, CLOSED set of renderers. This function is the single decision of WHICH
+ * one — a string id, not a component handshake: the consumer maps the id to its
+ * own markup arm internally, so a new renderer is a new id here plus an arm
+ * there, nothing wired across a boundary.
+ *
+ * TODAY THERE IS ONE: `'raster-image'`, for exactly the DR-16 raster allowlist
+ * (`canOpenInViewer`). Everything else — an unsafe/active type like SVG, an
+ * office document, an archive, or an UNRESOLVED (null) MIME — returns `null`,
+ * which the consumer renders as its no-bytes ICON FALLBACK. PLAN-2393 widens the
+ * union with `'pdf'` and `'text'`; the `null` arm stays the fallback for what no
+ * renderer claims.
+ *
+ * WHY IT WRAPS `canOpenInViewer` RATHER THAN RESTATING THE ALLOWLIST. DR-16 puts
+ * "what may this MIME become on screen" in ONE module (the display helpers) on
+ * purpose — a second copy of the raster list is a second thing to forget when
+ * the allowlist changes. This is the RENDERER-selection view of that one answer,
+ * not a competing source of truth: `'raster-image'` is defined AS the set
+ * `canOpenInViewer` admits.
+ *
+ * IT FAILS CLOSED, like the predicate it wraps: a null / unknown / unresolved
+ * MIME is not a renderer, so the caller shows the fallback, never a guessed arm.
+ */
+import { canOpenInViewer } from '$lib/attachments/display';
+
+/**
+ * The renderers a surface can draw an attachment through. A string-id union so
+ * PLAN-2393 can add `'pdf' | 'text'` without a component contract; the consumer
+ * switches on the id.
+ */
+export type SurfaceRendererId = 'raster-image';
+
+/**
+ * The renderer for a MIME, or `null` when none claims it (→ the icon fallback).
+ * `'raster-image'` is exactly the DR-16 raster allowlist; unsafe, unknown and
+ * unresolved (null) MIMEs all return `null`.
+ */
+export function getSurfaceRenderer(mime: string | null): SurfaceRendererId | null {
+	return canOpenInViewer(mime) ? 'raster-image' : null;
+}

--- a/web/src/lib/components/attachments/AttachmentDetailsPanel.extraction.test.ts
+++ b/web/src/lib/components/attachments/AttachmentDetailsPanel.extraction.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Grep-gate for TASK-2473 (PLAN-2392 3c-i-B).
+ *
+ * The panel's metadata machine and delete-confirm machinery were lifted into
+ * the shared `surfaceMetadata.svelte.ts` / `surfaceDeleteConfirm.svelte.ts`
+ * rune modules so the panel and the converged viewer share ONE implementation.
+ * This test fails if any of that machinery creeps back into the panel — the
+ * whole point of the extraction is that there is no second copy to drift.
+ *
+ * It reads the component SOURCE (not its behavior — the behavior is pinned by
+ * AttachmentPanelHost.svelte.test.ts) and asserts the machinery lives in the
+ * modules and the panel merely consumes them.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const panelSrc = readFileSync(
+	fileURLToPath(new URL('./AttachmentDetailsPanel.svelte', import.meta.url)),
+	'utf8'
+);
+
+// Only the <script> — the top-of-file doc comment legitimately NAMES the moved
+// helpers in prose, and gating on prose would be brittle nonsense.
+const scriptSrc = panelSrc.slice(panelSrc.indexOf('<script'));
+
+describe('AttachmentDetailsPanel machinery extraction (TASK-2473)', () => {
+	it('consumes the shared surface modules', () => {
+		expect(scriptSrc).toContain(
+			"import { createSurfaceMetadata } from '$lib/attachments/surfaceMetadata.svelte'"
+		);
+		expect(scriptSrc).toContain(
+			"import { createDeleteConfirm } from '$lib/attachments/surfaceDeleteConfirm.svelte'"
+		);
+	});
+
+	it('no longer imports the machinery the modules now own', () => {
+		// The metadata fetch layer and the fence factories are the modules'
+		// dependencies now, not the panel's.
+		expect(scriptSrc).not.toContain("from '$lib/components/editor/attachment-metadata'");
+		expect(scriptSrc).not.toContain("from '$lib/attachments/viewFence'");
+		// The prompt wording is composed inside the delete-confirm module.
+		expect(scriptSrc).not.toContain(
+			"import { attachmentDeletePrompt } from '$lib/components/attachments/AttachmentDeleteConfirm.svelte'"
+		);
+	});
+
+	it('no longer builds the fences or the metadata read locally', () => {
+		expect(scriptSrc).not.toMatch(/\bcreateFence\s*\(/);
+		expect(scriptSrc).not.toMatch(/\bcreatePaintFence\s*\(/);
+		expect(scriptSrc).not.toMatch(/\bviewIdentity\s*\(/);
+		expect(scriptSrc).not.toMatch(/\bfetchAttachmentMetadata\s*\(/);
+		expect(scriptSrc).not.toMatch(/\brevalidateAttachmentMetadata\s*\(/);
+	});
+
+	it('no longer owns the delete-confirmation state machine locally', () => {
+		// The 'root' | 'delete' sub-view state and its resolver moved out.
+		expect(scriptSrc).not.toMatch(/\$state<\s*'root'\s*\|\s*'delete'\s*>/);
+		expect(scriptSrc).not.toMatch(/\battachmentDeletePrompt\s*\(/);
+	});
+});

--- a/web/src/lib/components/attachments/AttachmentDetailsPanel.svelte
+++ b/web/src/lib/components/attachments/AttachmentDetailsPanel.svelte
@@ -60,13 +60,11 @@
 	entry points at once in PLAN-2411 (DR-19).
 -->
 <script lang="ts">
-	import { onDestroy, untrack } from 'svelte';
+	import { onDestroy } from 'svelte';
 	import Menu from '$lib/components/common/Menu.svelte';
 	import MenuItem from '$lib/components/common/MenuItem.svelte';
 	import AttachmentIcon from '$lib/attachments/icons/AttachmentIcon.svelte';
-	import AttachmentDeleteConfirm, {
-		attachmentDeletePrompt,
-	} from './AttachmentDeleteConfirm.svelte';
+	import AttachmentDeleteConfirm from './AttachmentDeleteConfirm.svelte';
 	import {
 		attachmentActionsFor,
 		type AttachmentActionContext,
@@ -78,14 +76,12 @@
 		formatBytes,
 		iconForAttachment,
 	} from '$lib/attachments/display';
-	import { api } from '$lib/api/client';
-	import {
-		fetchAttachmentMetadata,
-		revalidateAttachmentMetadata,
-	} from '$lib/components/editor/attachment-metadata';
 	import { attachmentRefsIn } from '$lib/utils/commentAttachments';
 	import { toastStore } from '$lib/stores/toast.svelte';
-	import { createFence, createPaintFence, viewIdentity } from '$lib/attachments/viewFence';
+	// The metadata + delete-confirm machinery lives in shared modules now
+	// (TASK-2473); this component is a consumer + the renderer.
+	import { createSurfaceMetadata } from '$lib/attachments/surfaceMetadata.svelte';
+	import { createDeleteConfirm } from '$lib/attachments/surfaceDeleteConfirm.svelte';
 
 	interface Props {
 		open: boolean;
@@ -152,61 +148,13 @@
 		onDeleted,
 	}: Props = $props();
 
-	/**
-	 * How long a metadata read may hang before the panel calls it a failure.
-	 * Generous: this is the "something is wrong" threshold, not a latency
-	 * budget — a slow answer that arrives still wins.
-	 */
-	const METADATA_SLOW_MS = 10_000;
-
 	const uid = $props.id();
 	const promptId = `attachment-delete-note-${uid}`;
 
-	// What the server told us, filling the gaps in what the event carried.
-	let fetchedMime = $state<string | null>(null);
-	let fetchedSize = $state<number | null>(null);
-	let loading = $state(false);
-	/** 404 — authoritative. Actions go inert. */
-	let missing = $state(false);
-	/** Non-404 failure — inline, retryable, alongside what we already know. */
-	let loadFailed = $state(false);
-	let view = $state<'root' | 'delete'>('root');
+	// Action-run state. The metadata + delete-confirm machinery moved out to the
+	// shared surface modules (TASK-2473); running the actions stays here.
 	let busy = $state(false);
 	let actionError = $state<string | null>(null);
-	let deletePrompt = $state('');
-	/** Bumped by Retry; drives the loader effect's forced-revalidate path. */
-	let forceReload = $state(0);
-
-	// --- fences (see $lib/attachments/viewFence) ------------------------------
-	// The identity of what this panel is showing. The PAIR, not the id alone:
-	// the workspace half is what a hand-rolled fence keeps forgetting.
-	const identity = viewIdentity(() => ({ ws: wsSlug, att: attachmentId }));
-	// 1. Request fence — restarted per metadata read, so a Retry supersedes
-	//    its own predecessor and only the newest response may write.
-	const loadFence = createFence(identity);
-	// 2. View fence — invalidated only when the panel really changes subject,
-	//    so an in-flight delete of the attachment still on screen can still
-	//    reconcile even after a Retry reloaded its metadata.
-	const viewFence = createFence(identity);
-	// 3. Paint fence — "does the control the user clicked belong to what is on
-	//    screen?" Checked at ENTRY by every control, because the other two run
-	//    after an await and no fence can unsend a request.
-	const paint = createPaintFence(identity);
-
-	// Plain `let`, never $state: read and written only inside effects, and a
-	// $state here would make the effect below depend on what it writes
-	// (CONVE-1688 — the self-write loop that silently aborts the flush).
-	let paintedKey: string | null = null;
-	/**
-	 * The reload stamp this component has already acted on — the host's
-	 * revalidate signal and the local Retry counter together. Seeded from the
-	 * incoming prop so a host that has already bumped its counter (an earlier
-	 * restore, before this panel existed) doesn't read as a pending reload on
-	 * the first render.
-	 */
-	let seenReload = untrack(() => `${revalidateToken}:0`);
-	/** Resolver for the in-app confirmation currently on screen, if any. */
-	let pendingConfirm: ((confirmed: boolean) => void) | null = null;
 	/**
 	 * Teardown latch and the deferred-close timer. Plain `let`, not `$state`:
 	 * nothing renders from them, and they are read by continuations that must
@@ -223,6 +171,44 @@
 	let deleteSignal = 0;
 
 	const displayName = $derived(displayFilename(filename));
+
+	// The delete-confirmation machine (DR-18). Owns the confirmation STATE — the
+	// pending resolver, the warning wording, the permission-withdrawn abandon —
+	// while the delete descriptor still owns the delete itself. `isReferenced`
+	// reads `referencedHere()` at request time so it sees unflushed editor edits.
+	const deleteConfirm = createDeleteConfirm({
+		mutationsEnabled: () => mutationsEnabled,
+		isReferenced: () => referencedHere(),
+		displayName: () => displayName,
+	});
+
+	// The metadata machine (DR-2, DR-10, DR-14). Seeds from the open event, fills
+	// the gaps with a HEAD, and owns the (workspace, attachment) fences the
+	// panel's own actions/close fence against. A genuine subject change drops the
+	// other per-subject state the machine does not own — the confirmation and any
+	// in-flight action — exactly as the panel did inline.
+	const surfaceMeta = createSurfaceMetadata(
+		() => ({
+			ws: wsSlug,
+			attachmentId,
+			seed: { filename, mime_type: mimeType, size_bytes: sizeBytes },
+			open,
+			parentArchived,
+			revalidateToken,
+		}),
+		{
+			onSubjectChange: () => {
+				deleteConfirm.cancel();
+				busy = false;
+				actionError = null;
+			},
+		}
+	);
+
+	// Render-facing views of the metadata machine's settled phase.
+	const missing = $derived(surfaceMeta.phase === 'missing');
+	const loadFailed = $derived(surfaceMeta.phase === 'transient');
+	const loading = $derived(surfaceMeta.slow);
 	/**
 	 * An archived parent's reachability probe is still in flight.
 	 *
@@ -234,9 +220,11 @@
 	 */
 	const unreachablePending = $derived(parentArchived && loading && !missing);
 	// The event's value wins when it has one — it came from a list row, which
-	// is at least as good as a HEAD and is available before any fetch.
-	const mime = $derived(mimeType || fetchedMime || '');
-	const size = $derived(sizeBytes ?? fetchedSize);
+	// is at least as good as a HEAD and is available before any fetch. The merge
+	// lives in the metadata machine now; the empty-string fallback stays here
+	// because `mime` feeds the icon/type helpers, which want a string.
+	const mime = $derived(surfaceMeta.fields.mime_type || '');
+	const size = $derived(surfaceMeta.fields.size_bytes);
 	const iconId = $derived(iconForAttachment(mime || null, filename));
 	const typeLabel = $derived(describeAttachmentType(mime || null, filename));
 	// Always says at least the type — a panel that opened on a chip with no
@@ -290,7 +278,7 @@
 			// already treats as authoritative.
 			return mutationsEnabled;
 		},
-		confirmDelete: () => confirmDelete(),
+		confirmDelete: () => deleteConfirm.request(),
 		onDeleted: (id) => {
 			deleteSignal += 1;
 			onDeleted?.(id);
@@ -299,148 +287,6 @@
 	};
 
 	const actions = $derived(attachmentActionsFor(ctx));
-
-	function downloadUrl(uuid: string, variant?: 'thumb-sm' | 'thumb-md' | 'original'): string {
-		return api.attachments.downloadUrl(wsSlug, uuid, variant);
-	}
-
-	/**
-	 * Load whatever the event didn't carry, and re-read on demand.
-	 *
-	 * Reads only props + the fence identity in tracked scope; every piece of
-	 * state it writes (`loading`, `missing`, `fetched*`) is read in the markup
-	 * and in `untrack`ed blocks only, so the effect cannot self-invalidate.
-	 */
-	$effect(() => {
-		const req = loadFence.restart();
-		const isOpen = open;
-		const seedMime = mimeType;
-		const seedSize = sizeBytes;
-		const reloadStamp = `${revalidateToken}:${forceReload}`;
-		const archivedParent = parentArchived;
-
-		let forced = false;
-		untrack(() => {
-			// A genuine subject change: drop everything the previous attachment
-			// left behind, stop any in-flight continuation from reconciling, and
-			// abandon a confirmation that was up for a file the user is no longer
-			// looking at.
-			if (req.key !== paintedKey) {
-				paintedKey = req.key;
-				viewFence.invalidate();
-				settleConfirm(false);
-				fetchedMime = null;
-				fetchedSize = null;
-				missing = false;
-				loadFailed = false;
-				busy = false;
-				actionError = null;
-			}
-			// Whatever this run paints belongs to this (workspace, attachment).
-			// An un-addressable token records nothing, which correctly stops the
-			// panel's controls claiming the previous subject.
-			paint.record(req);
-			// An archived parent makes this a REACHABILITY question, and the
-			// metadata cache can hold an `ok` observed before the archive — the
-			// same reason existence probes elsewhere revalidate rather than
-			// read. So force it, which also routes through the invalidate-then-
-			// fetch path instead of replaying a stale success.
-			if (archivedParent) forced = true;
-			if (reloadStamp !== seenReload) {
-				seenReload = reloadStamp;
-				forced = true;
-				// A forced revalidation exists because the previous answer may no
-				// longer hold — the parent was just restored (DR-14). So drop the
-				// latched `missing` NOW rather than only on an `ok`: if this
-				// revalidation comes back transient, the render must fall through
-				// to the retryable error. Leaving it latched shows "no longer
-				// available" with no way to ask again, which is the exact
-				// empty-vs-broken confusion DR-10 exists to prevent.
-				missing = false;
-			}
-		});
-
-		if (!isOpen || req.key === null) return;
-		// Nothing to complete: the strip's entry point always has all three.
-		// Unless the parent is archived — then "complete" and "reachable" are
-		// different claims, and only a probe settles the second one.
-		if (!forced && !archivedParent && seedMime && seedSize !== null && seedSize !== undefined) {
-			return;
-		}
-
-		loading = true;
-		loadFailed = false;
-		// A HEAD that never settles is not a failure the fetch layer can report:
-		// no rejection arrives, so without this the panel sits on "Reading
-		// details…" forever with no Retry — indistinguishable to the user from
-		// a hang, and the exact loading-vs-failed confusion DR-10 exists to
-		// prevent. The request is NOT aborted: if it does eventually answer, it
-		// is still the truth and still allowed to correct the error state.
-		const slowTimer = setTimeout(() => {
-			if (req.stale()) return;
-			loading = false;
-			loadFailed = true;
-		}, METADATA_SLOW_MS);
-		void (async () => {
-			// The workspace comes off the TOKEN, not the live prop: the request
-			// must name the workspace it was issued for even if the panel has
-			// since moved on.
-			const result = forced
-				? await revalidateAttachmentMetadata(req.value.ws, req.value.att, downloadUrl)
-				: await fetchAttachmentMetadata(req.value.ws, req.value.att, downloadUrl);
-			clearTimeout(slowTimer);
-			if (req.stale()) return;
-			loading = false;
-			if (result.status === 'ok') {
-				fetchedMime = result.mime;
-				fetchedSize = result.size;
-				missing = false;
-				loadFailed = false;
-			} else if (result.status === 'missing') {
-				// Authoritative. Latch it — the actions go inert below.
-				missing = true;
-				loadFailed = false;
-			} else {
-				// Says nothing about whether the row exists: keep showing what we
-				// have and stay retryable.
-				loadFailed = true;
-			}
-		})();
-	});
-
-	/**
-	 * Permission withdrawn while the confirmation is open.
-	 *
-	 * The pane can go peeked (or a role can change) between opening the
-	 * confirmation and answering it. Blocking the eventual request is not
-	 * enough: the user is left looking at a live "Delete file" button for an
-	 * action that can no longer happen, on a surface that is supposed to offer
-	 * no delete at all in that state. So the confirmation is abandoned as a
-	 * rejection, exactly as a subject change abandons it.
-	 *
-	 * Plain latch + `untrack` for the writes: as `$state` this effect would
-	 * depend on what it writes, which aborts the flush and strands unrelated
-	 * reactivity (CONVE-1688).
-	 */
-	$effect(() => {
-		const mayMutate = mutationsEnabled;
-		untrack(() => {
-			if (mayMutate || view !== 'delete') return;
-			settleConfirm(false);
-		});
-	});
-
-	function retry() {
-		// ENTRY fence: the clicked row was painted for `paint`'s identity, and
-		// the live props may already name a different attachment.
-		if (!paint.isCurrent()) return;
-		loadFailed = false;
-		// Goes through the loader effect's revalidate path rather than fetching
-		// here, so a user Retry and the host's restore signal (DR-14) are ONE
-		// code path — and both therefore invalidate before refetching, which is
-		// the whole point of Retry (DR-10).
-		forceReload += 1;
-	}
 
 	/**
 	 * Ids referenced by THIS item's body. A hit means deleting leaves a
@@ -458,45 +304,13 @@
 		return new Set(attachmentRefsIn(live ?? itemContent ?? '')).has(attachmentId);
 	}
 
-	/**
-	 * The confirmation, as a promise the delete descriptor awaits. The
-	 * descriptor snapshots identity BEFORE this and re-checks permission after
-	 * it resolves, which is the whole reason it is wired this way rather than
-	 * as a bespoke "confirm, then call the API" path here.
-	 *
-	 * The wording comes from the shared `attachmentDeletePrompt` — the same
-	 * two arms the strip's tile shows (DR-18). The hedged arm matters here for
-	 * one EXTRA reason beyond the shared one: the body this checks is the
-	 * HOST's, which is not necessarily the attachment's parent item. The
-	 * open-panel event's `itemId` is ROUTING, not ownership: a chip in a reused
-	 * comment composer's unsubmitted draft correctly routes to the host in
-	 * front of the user even after an item switch.
-	 */
-	function confirmDelete(): Promise<boolean> {
-		deletePrompt = attachmentDeletePrompt(displayName, referencedHere());
-		return new Promise<boolean>((resolve) => {
-			// Supersede any confirmation already up — two open at once would
-			// leave one resolver dangling forever.
-			pendingConfirm?.(false);
-			pendingConfirm = resolve;
-			view = 'delete';
-		});
-	}
-
-	function settleConfirm(confirmed: boolean) {
-		const resolve = pendingConfirm;
-		pendingConfirm = null;
-		view = 'root';
-		resolve?.(confirmed);
-	}
-
 	async function runAction(action: ButtonAttachmentAction) {
-		if (!paint.isCurrent()) return;
+		if (!surfaceMeta.paint.isCurrent()) return;
 		if (!action.enabled(ctx)) return;
 		// Fence 2: a subject change mid-action must not write this action's
 		// outcome onto a DIFFERENT attachment's panel. The request itself still
 		// lands — it targets an id, not a view.
-		const token = viewFence.begin();
+		const token = surfaceMeta.viewFence.begin();
 		const deletesBefore = deleteSignal;
 		actionError = null;
 		busy = true;
@@ -534,19 +348,17 @@
 		destroyed = true;
 		clearTimeout(deferredClose);
 		deferredClose = undefined;
-		viewFence.invalidate();
-		loadFence.invalidate();
-		paint.record(null);
-		const resolve = pendingConfirm;
-		pendingConfirm = null;
-		resolve?.(false);
+		// Invalidate the fences so every in-flight continuation reads stale, and
+		// reject any pending confirmation so the descriptor's `await` settles.
+		surfaceMeta.dispose();
+		deleteConfirm.dispose();
 	});
 
 	function handleClose() {
 		// A confirmation still on screen when the panel closes is a rejection:
 		// leaving the promise unresolved would strand the descriptor's `await`
 		// forever.
-		settleConfirm(false);
+		deleteConfirm.cancel();
 		onclose();
 	}
 
@@ -562,13 +374,13 @@
 		// attachment (tap a chip, tap another). Closing then would dismiss a
 		// panel the user just opened. Cleared on teardown so it cannot fire into
 		// a destroyed component either.
-		const token = viewFence.begin();
+		const token = surfaceMeta.viewFence.begin();
 		clearTimeout(deferredClose);
 		deferredClose = setTimeout(() => {
 			deferredClose = undefined;
 			if (destroyed) return;
 			if (token.stale()) return;
-			if (!paint.isCurrent()) return;
+			if (!surfaceMeta.paint.isCurrent()) return;
 			handleClose();
 		}, 0);
 	}
@@ -583,9 +395,9 @@
 	sheetOnMobile
 	sheetTitle={displayName}
 	ariaLabel={panelLabel}
-	focusKey={`${attachmentId}:${view}`}
+	focusKey={`${attachmentId}:${deleteConfirm.pending ? 'delete' : 'root'}`}
 >
-	{#if view === 'root'}
+	{#if !deleteConfirm.pending}
 		<!-- Header. `role="presentation"`, like the item menu's confirm note:
 		     a role="menu" owns menuitem / separator / group children, and this
 		     says explicitly that the header is none of them. -->
@@ -608,7 +420,7 @@
 		{:else if loadFailed}
 			<!-- Beside what we already know, never instead of it (DR-10). -->
 			<div class="ap-note ap-note-error" role="presentation">Couldn't load the file details.</div>
-			<MenuItem icon="↻" onclick={retry}>Retry</MenuItem>
+			<MenuItem icon="↻" onclick={() => surfaceMeta.retry()}>Retry</MenuItem>
 		{/if}
 
 		{#if actionError}
@@ -656,10 +468,10 @@
 			renders too — one confirmation for one object.
 		-->
 		<AttachmentDeleteConfirm
-			prompt={deletePrompt}
+			prompt={deleteConfirm.warning ?? ''}
 			{promptId}
-			oncancel={() => settleConfirm(false)}
-			onconfirm={() => settleConfirm(true)}
+			oncancel={() => deleteConfirm.cancel()}
+			onconfirm={() => deleteConfirm.confirm()}
 		/>
 	{/if}
 </Menu>

--- a/web/src/lib/components/attachments/AttachmentDetailsPanel.svelte
+++ b/web/src/lib/components/attachments/AttachmentDetailsPanel.svelte
@@ -618,9 +618,15 @@
 		<div class="menu-divider" role="separator"></div>
 
 		{#each actions as action (action.id)}
+			<!-- The action's SVG icon, drawn from the shared registry through
+			     MenuItem's snippet path — NOT a glyph string (TASK-2472). Declared
+			     per-iteration so it closes over THIS action's icon id. -->
+			{#snippet actionIcon()}
+				<AttachmentIcon id={action.icon} />
+			{/snippet}
 			{#if action.element === 'anchor'}
 				<MenuItem
-					icon={action.icon}
+					iconSnippet={actionIcon}
 					href={action.href(ctx)}
 					download={action.download?.(ctx)}
 					target={action.target}
@@ -633,7 +639,7 @@
 				</MenuItem>
 			{:else}
 				<MenuItem
-					icon={action.icon}
+					iconSnippet={actionIcon}
 					danger={action.danger}
 					title={action.description}
 					disabled={!action.enabled(ctx) || missing || busy || unreachablePending}

--- a/web/src/lib/components/attachments/AttachmentPanelHost.svelte.test.ts
+++ b/web/src/lib/components/attachments/AttachmentPanelHost.svelte.test.ts
@@ -241,6 +241,27 @@ describe('AttachmentPanelHost', () => {
 		expect(row('Delete')?.tagName).toBe('BUTTON');
 	});
 
+	it('draws each action-row icon as an SVG, never a glyph string (TASK-2472)', async () => {
+		mountHost(propsA);
+		notifyAttachmentPanelOpen(openEvent());
+		await settle();
+
+		// Every action row's leading icon is a rendered SVG (the shared registry via
+		// MenuItem's snippet path) — fails if the panel goes back to passing the
+		// descriptor's `icon` as MenuItem's TEXT `icon` prop.
+		for (const label of ['Open in new tab', 'Download', 'Copy workspace link', 'Delete']) {
+			const r = row(label);
+			expect(r, `row "${label}" exists`).toBeDefined();
+			expect(r!.querySelector('.mi-icon svg'), `"${label}" icon is an SVG`).not.toBeNull();
+		}
+		// ...and NONE of the glyph characters the descriptors used to carry survive
+		// anywhere in the panel's text.
+		const text = panel()?.textContent ?? '';
+		for (const glyph of ['⇗', '⇩', '🔗', '🗑']) {
+			expect(text, `the glyph "${glyph}" is gone`).not.toContain(glyph);
+		}
+	});
+
 	it('omits Open for a type the browser cannot preview', async () => {
 		mountHost(propsA);
 		notifyAttachmentPanelOpen(

--- a/web/src/lib/components/attachments/AttachmentViewerHost.svelte
+++ b/web/src/lib/components/attachments/AttachmentViewerHost.svelte
@@ -25,8 +25,11 @@
 	without remounting, so a live read could serve a viewer opened in ws1 from
 	ws2's endpoint.
 
-	NO `mutationsEnabled`. 3a's viewer has no mutating action, so threading a
-	permission here would be a dead prop. It is 3c's, together with Delete.
+	`mutationsEnabled` + CONTENT GETTERS (TASK-2474). 3c-i's viewer gained a
+	toolbar with a mutating action (Delete), so the permission and the
+	delete-warning content getters are threaded through here now — the same three
+	props, same names, the panel host already carries. Forwarded verbatim to the
+	`Lightbox`; this host adds no policy of its own.
 
 	LIFECYCLE — ONE RULE. Clear on a RESOURCE SWITCH: the host's `itemId`
 	changing, or `resourceGen` advancing. Nothing else closes the viewer.
@@ -63,9 +66,25 @@
 		 * note above for why this is not `loadGeneration`.
 		 */
 		resourceGen?: number;
+		/**
+		 * Viewer toolbar context (TASK-2474), forwarded verbatim to `Lightbox`.
+		 * `mutationsEnabled` gates Delete; the two content getters back its
+		 * delete-warning check. DEFAULT `mutationsEnabled=false` → a read-only
+		 * toolbar when a host doesn't thread it.
+		 */
+		mutationsEnabled?: boolean;
+		getItemContent?: () => string | null;
+		getLiveContent?: () => string | null;
 	}
 
-	let { itemId, hostToken, resourceGen = 0 }: Props = $props();
+	let {
+		itemId,
+		hostToken,
+		resourceGen = 0,
+		mutationsEnabled = false,
+		getItemContent,
+		getLiveContent,
+	}: Props = $props();
 
 	let request = $state<AttachmentViewerOpenEvent | null>(null);
 
@@ -170,6 +189,9 @@
 			index={request.index}
 			wsSlug={request.workspaceSlug}
 			invoker={request.invoker}
+			{mutationsEnabled}
+			{getItemContent}
+			{getLiveContent}
 			onClose={closeRequest(request)}
 		/>
 	{/if}

--- a/web/src/lib/components/attachments/AttachmentViewerHost.svelte.test.ts
+++ b/web/src/lib/components/attachments/AttachmentViewerHost.svelte.test.ts
@@ -114,6 +114,10 @@ interface HostProps {
 	itemId: string | null;
 	hostToken: string;
 	resourceGen: number;
+	// Viewer-toolbar context forwarded to Lightbox (TASK-2474).
+	mutationsEnabled?: boolean;
+	getItemContent?: () => string | null;
+	getLiveContent?: () => string | null;
 }
 
 // Two reactive props objects, declared at the top level because `$state(...)`
@@ -458,4 +462,36 @@ describe('AttachmentViewerHost', () => {
 	// version of this test written that way passed with the guard deleted.
 	// It lives in `AttachmentViewerHostClose.svelte.test.ts`, against a stubbed
 	// Lightbox that hands the callback back.
+
+	// ── Toolbar forwarding (TASK-2474) ───────────────────────────────────────
+	// The BUS/HOST origin of the three that mount a Lightbox. These prove the
+	// host threads its `mutationsEnabled` through to the viewer's toolbar.
+	function toolbarLabels(): string[] {
+		return Array.from(document.querySelectorAll<HTMLElement>('.lightbox-toolbar .lightbox-tool')).map(
+			(t) => t.getAttribute('aria-label') ?? ''
+		);
+	}
+
+	it('renders the viewer toolbar with Delete when the host grants mutations', () => {
+		mountHost({ ...propsA, mutationsEnabled: true });
+		notifyViewerOpen(openEvent());
+		flushSync();
+
+		expect(document.querySelector('.lightbox-toolbar')).not.toBeNull();
+		expect(toolbarLabels()).toContain('Delete');
+		expect(toolbarLabels()).toContain('Download');
+	});
+
+	it('renders a read-only toolbar (no Delete) when the host withholds mutations', () => {
+		// A peeked pane's host passes mutationsEnabled=false — the toolbar still
+		// renders its read-only actions, but Delete is absent, not merely disabled.
+		mountHost({ ...propsA, mutationsEnabled: false });
+		notifyViewerOpen(openEvent());
+		flushSync();
+
+		expect(document.querySelector('.lightbox-toolbar')).not.toBeNull();
+		const labels = toolbarLabels();
+		expect(labels).toContain('Open in new tab');
+		expect(labels).not.toContain('Delete');
+	});
 });

--- a/web/src/lib/components/common/Lightbox.svelte
+++ b/web/src/lib/components/common/Lightbox.svelte
@@ -70,6 +70,22 @@
 	 * the drift this consolidation removes.
 	 */
 	import type { LightboxImage } from '$lib/attachments/events';
+	// ── Toolbar (PLAN-2392 phase 3c-i / TASK-2474) ───────────────────────────
+	// The viewer's copy of the shared attachment-action list (DR-5) — the SAME
+	// descriptors the options panel renders, drawn here as an inline toolbar over
+	// the stage. Delete confirmation reuses the panel's B module (TASK-2473): the
+	// module owns the confirmation GATE, the descriptor owns the delete.
+	import {
+		attachmentActionsFor,
+		type AttachmentActionContext,
+		type ButtonAttachmentAction,
+	} from '$lib/attachments/actions';
+	import { createDeleteConfirm } from '$lib/attachments/surfaceDeleteConfirm.svelte';
+	import AttachmentIcon from '$lib/attachments/icons/AttachmentIcon.svelte';
+	import AttachmentDeleteConfirm from '$lib/components/attachments/AttachmentDeleteConfirm.svelte';
+	import { displayFilename } from '$lib/attachments/display';
+	import { attachmentRefsIn } from '$lib/utils/commentAttachments';
+	import { toastStore } from '$lib/stores/toast.svelte';
 
 	interface Props {
 		images: LightboxImage[];
@@ -84,9 +100,36 @@
 		 * at open (see below), which is the same element in every current path.
 		 */
 		invoker?: HTMLElement | null;
+		/**
+		 * Whether the viewer may offer MUTATING actions — Delete (TASK-2474). The
+		 * host's answer (`canEdit && !peeking`), threaded identically at every hop
+		 * (host / strip / timeline). DEFAULT false: an omitted prop degrades to a
+		 * read-only toolbar (open / download / copy-link), never a wrongly-gated
+		 * one. The timeline's OWN `canEdit` (which ignores peeking) is never the
+		 * source — a peeked master must show no Delete.
+		 */
+		mutationsEnabled?: boolean;
+		/**
+		 * The persisted item body + the editor's LIVE markdown, as getters — the
+		 * panel's pattern (`AttachmentDetailsPanel.svelte`). Used ONLY to warn when
+		 * a delete would break a live reference in this body (DR-5); read at
+		 * confirm time so the live getter sees unflushed edits. Absent → the
+		 * warning falls to its hedged arm.
+		 */
+		getItemContent?: () => string | null;
+		getLiveContent?: () => string | null;
 	}
 
-	let { images, index = 0, wsSlug, onClose, invoker = null }: Props = $props();
+	let {
+		images,
+		index = 0,
+		wsSlug,
+		onClose,
+		invoker = null,
+		mutationsEnabled = false,
+		getItemContent,
+		getLiveContent,
+	}: Props = $props();
 
 	/**
 	 * THE LAST-MILE GATE (PLAN-2392 DR-16 / TASK-2431).
@@ -185,6 +228,189 @@
 	// generic label. Never empty — an unnamed `role="dialog"` is announced as
 	// nothing at all.
 	let dialogLabel = $derived(img?.alt || 'Attachment viewer');
+
+	// ── Action toolbar (PLAN-2392 phase 3c-i / TASK-2474) ─────────────────────
+	//
+	// The SAME `attachmentActionsFor` list the options panel renders (DR-5), drawn
+	// as an inline toolbar over the stage. The viewer only ever holds IMAGES (the
+	// last-mile MIME gate above), so Open always applies; Download and Copy-link
+	// always apply; Delete applies only when the host granted `mutationsEnabled`.
+	const uid = $props.id();
+	const deletePromptId = `lightbox-delete-note-${uid}`;
+	// A non-null display name for the current image, for the download attribute and
+	// the delete prompt. The channel's `filename` is nullable; `alt` is the inline
+	// image's next-best name; the generic label is the last resort so a nameless
+	// image still downloads and can still be named in a confirmation (until C2's
+	// display-name chain lands, this inline fallback IS that chain).
+	let displayName = $derived(displayFilename(img?.filename ?? img?.alt ?? 'Attachment'));
+	// Counts confirmed deletes. The descriptor's `run()` resolves the same way
+	// whether the row was deleted or the user CANCELLED, so the counter is how the
+	// two are told apart — a delete closes the viewer, a cancel does not. Plain
+	// `let`: read/written only in the action handler, never a tracked scope.
+	let toolbarDeleteSignal = 0;
+	// Inline, transient error from a button action (a failed clipboard write). Sits
+	// in the toolbar beside the controls, never a blocking dialog.
+	let toolbarError = $state<string | null>(null);
+	let toolbarBusy = $state(false);
+
+	/**
+	 * Ids referenced by the host's body — the delete-warning check (DR-5). Read at
+	 * confirm time (not derived) so the live getter sees unflushed editor edits.
+	 * Both getters are optional: a producer that threads neither leaves the warning
+	 * on its hedged arm, which is the honest default.
+	 */
+	function toolbarReferencedHere(): boolean {
+		const id = img?.id;
+		if (!id) return false;
+		let live: string | null = null;
+		try {
+			live = getLiveContent?.() ?? null;
+		} catch {
+			live = null;
+		}
+		let persisted: string | null = null;
+		try {
+			persisted = getItemContent?.() ?? null;
+		} catch {
+			persisted = null;
+		}
+		return new Set(attachmentRefsIn(live ?? persisted ?? '')).has(id);
+	}
+
+	// The delete-confirmation machine (TASK-2473's B module). Owns the drill-down
+	// STATE — pending / warning / permission-withdrawn abandon; the descriptor owns
+	// the delete. `mutationsEnabled` is read live so a pane going peeked mid-confirm
+	// abandons it.
+	const deleteConfirm = createDeleteConfirm({
+		mutationsEnabled: () => mutationsEnabled,
+		isReferenced: () => toolbarReferencedHere(),
+		displayName: () => displayName,
+	});
+	// Teardown latch: an action's async continuation may land AFTER the viewer was
+	// unmounted (a keyed producer tore it down), and `onClose` is a stale
+	// producer callback by then — calling it would dismiss whatever viewer the
+	// producer has open BY NOW. Plain `let`, read only in the continuation.
+	let destroyed = false;
+	// Drop any pending confirmation on unmount so the descriptor's awaited
+	// `confirmDelete()` promise settles rather than dangling (the panel's teardown),
+	// and latch `destroyed` so no post-unmount continuation calls `onClose`.
+	$effect(() => () => {
+		destroyed = true;
+		deleteConfirm.dispose();
+	});
+
+	/**
+	 * The action context. GETTERS, not a snapshot: the delete descriptor re-reads
+	 * `mutationsEnabled` and the identity on the far side of the confirmation, and
+	 * a frozen object would defeat those re-checks. `workspaceSlug` comes off the
+	 * captured `openWsSlug` for the same reason every other URL here does — a live
+	 * read could name the wrong workspace after a pane switch.
+	 */
+	const toolbarCtx: AttachmentActionContext = {
+		get workspaceSlug() {
+			return openWsSlug;
+		},
+		get attachment() {
+			return {
+				id: img?.id ?? '',
+				filename: displayName,
+				mime_type: img?.mime_type ?? null,
+			};
+		},
+		get mutationsEnabled() {
+			return mutationsEnabled;
+		},
+		confirmDelete: () => deleteConfirm.request(),
+		onDeleted: () => {
+			toolbarDeleteSignal += 1;
+		},
+		onCopied: () => toastStore.show('Link copied to clipboard', 'success'),
+	};
+
+	let toolbarActions = $derived(attachmentActionsFor(toolbarCtx));
+
+	async function runToolbarAction(action: ButtonAttachmentAction) {
+		if (!action.enabled(toolbarCtx)) return;
+		const deletesBefore = toolbarDeleteSignal;
+		// The image this action was launched against. Closing on delete is gated on
+		// it still being the one shown, so a set-shrink / nav during the await can't
+		// close the viewer over a DIFFERENT image than the one deleted.
+		const targetId = img?.id;
+		toolbarError = null;
+		toolbarBusy = true;
+		try {
+			await action.run(toolbarCtx);
+			// The continuation may land after the viewer was torn down (a keyed
+			// producer remounts on the next open) — `onClose` is a stale callback then.
+			if (destroyed) return;
+			// A confirmed delete removed the image on screen — showing its now-404
+			// bytes is wrong, so close the viewer (the panel's onclose parallel). Close
+			// when the shown image is STILL the deleted one (the common case: the
+			// producer's set isn't mutated, so the 404'd image is what's on screen), OR
+			// when the set emptied out from under us (`!img` — nothing left to show).
+			// Only a set-shrink that moved a DIFFERENT image into view is left open —
+			// and the descriptor's own identity re-check already aborts a delete that
+			// raced an arrow-nav (no signal bump). A Cancel leaves the signal untouched.
+			if (toolbarDeleteSignal !== deletesBefore && (!img || img.id === targetId)) onClose();
+		} catch (err) {
+			if (destroyed) return;
+			toolbarError =
+				err instanceof Error ? err.message : `Couldn't ${action.label.toLowerCase()}`;
+		} finally {
+			if (!destroyed) toolbarBusy = false;
+		}
+	}
+
+	// The delete drill-down's rows, as a proper ARIA menu (TASK-2474). The confirm
+	// renders `role="menuitem"` buttons; a `role="menu"` parent is required, and a
+	// menu manages focus by ROVING TABINDEX — exactly ONE row is in the tab order
+	// (tabindex 0), the rest are -1, Up/Down move between them, and Tab moves OUT to
+	// the viewer chrome rather than cycling the rows. The Lightbox hosts the shared
+	// confirm inline (not inside a `Menu`), so it drives that itself.
+	function confirmMenuItems(): HTMLElement[] {
+		const el = rootEl;
+		if (!el) return [];
+		return Array.from(
+			el.querySelectorAll<HTMLElement>('.lightbox-delete-confirm [role="menuitem"]')
+		);
+	}
+	// Make `active` the single tab stop; every other row leaves the tab order. Tab
+	// then exits the menu (the trap's `paneFocusables` skips the -1 rows), while
+	// the active row can still be Tabbed BACK into — the ARIA menu contract.
+	function applyRoving(active: HTMLElement | null) {
+		const items = confirmMenuItems();
+		if (items.length === 0) return;
+		const target = active && items.includes(active) ? active : items[0];
+		for (const it of items) it.tabIndex = it === target ? 0 : -1;
+	}
+	function moveConfirmFocus(delta: number) {
+		const items = confirmMenuItems();
+		if (items.length === 0) return;
+		const at = items.indexOf(document.activeElement as HTMLElement);
+		const next = at < 0 ? 0 : (at + delta + items.length) % items.length;
+		const target = items[next];
+		applyRoving(target);
+		target?.focus({ preventScroll: true });
+	}
+
+	// When the drill-down OPENS, set the roving tab stop and move focus to its first
+	// row (Cancel), as the panel's `Menu` does — otherwise focus is stranded on the
+	// now-unmounted Delete button and the generic handoff would land it on Close,
+	// not Cancel. Plain sentinel so this fires only on the false→true edge, and
+	// reads `pending` (tracked) while writing only DOM (focus + tabindex) and the
+	// sentinel, never its own trigger.
+	let confirmWasPending = untrack(() => deleteConfirm.pending);
+	$effect(() => {
+		const pending = deleteConfirm.pending;
+		if (pending === confirmWasPending) return;
+		confirmWasPending = pending;
+		if (!pending) return;
+		untrack(() => {
+			const first = confirmMenuItems()[0] ?? null;
+			applyRoving(first);
+			first?.focus({ preventScroll: true });
+		});
+	});
 
 	// ── Image loading (PLAN-2392 phase 3b / TASK-2459) ────────────────────────
 	//
@@ -288,6 +514,11 @@
 		// measurable, so a scroll can never leak past the modal into the inert app.
 		e.preventDefault();
 		e.stopPropagation();
+		// A wheel over the TOOLBAR (or its delete drill-down) is consumed like every
+		// other wheel — the modal owns it, so the inert page can't scroll — but must
+		// NOT zoom the image behind it (TASK-2474). The same exclusion the pointerdown
+		// and double-click handlers carry, applied here too.
+		if ((e.target as Element | null)?.closest?.('.lightbox-toolbar')) return;
 		// Consumed (the modal owns the wheel) but INERT with no decoded bitmap — the
 		// mobile deferred placeholder or the error UI, where the broken `<img>` still
 		// satisfies `readGeometry` (TASK-2461). Same guard the keys use.
@@ -429,7 +660,7 @@
 		// (the house pattern in ItemGraph excludes its interactive overlays the same
 		// way). Retry sits over the (broken) stage in the error state, so it needs
 		// the same exclusion as the always-present chrome.
-		if ((e.target as Element | null)?.closest?.('.lightbox-close, .lightbox-nav, .lightbox-retry, .lightbox-tap-load')) return;
+		if ((e.target as Element | null)?.closest?.('.lightbox-close, .lightbox-nav, .lightbox-retry, .lightbox-tap-load, .lightbox-toolbar')) return;
 		// No decoded bitmap to pan (the mobile `deferred` placeholder shows no
 		// `<img>`) — do NOT arm a drag, so the gesture stays fully inert instead of
 		// capturing the pointer and latching `dragging` for a pan that can never
@@ -560,7 +791,7 @@
 		// A double-click ON a control (close / nav / retry) is that control's, not a
 		// zoom toggle — without this, double-clicking Next navigates twice AND
 		// toggles, or a double-click on Retry toggles zoom on the broken stage.
-		if ((e.target as Element | null)?.closest?.('.lightbox-close, .lightbox-nav, .lightbox-retry, .lightbox-tap-load')) return;
+		if ((e.target as Element | null)?.closest?.('.lightbox-close, .lightbox-nav, .lightbox-retry, .lightbox-tap-load, .lightbox-toolbar')) return;
 		// Inert with no decoded bitmap (deferred placeholder / error UI) — the same
 		// guard the keys and wheel use (TASK-2461).
 		if (!bitmapPresent) return;
@@ -662,6 +893,14 @@
 		// stack falls through to it rather than to an unrelated layer.
 		const unregisterEscape = pushEscapeHandler((event) => {
 			if (!isViewerFrontmost(el)) return false;
+			// The delete drill-down is an inner layer (TASK-2474): Escape backs OUT of
+			// it to the toolbar, and only a second Escape closes the viewer — the
+			// two-step the panel's Menu gives its own drill-down. Consume this press.
+			if (deleteConfirm.pending) {
+				if (event) noteEscapeConsumedByViewer(event);
+				deleteConfirm.cancel();
+				return true;
+			}
 			// Mark the DISPATCH before closing, not after (TASK-2448 / BUG-2441).
 			// `onClose()` runs the teardown below synchronously — the lease is gone
 			// by the time it returns — so a later `window` listener in this same
@@ -706,6 +945,12 @@
 		if (id === lastResetForId) return;
 		lastResetForId = id;
 		zoom = resetZoom();
+		// The shown image changed (arrow-nav, or a set-shrink moving a different
+		// member into view), so a delete confirmation still up is for a file the user
+		// is no longer looking at — abandon it (TASK-2474), exactly as the panel's
+		// subject-change does. `cancel()` writes the delete-confirm MODULE's state,
+		// not this effect's tracked `zoom`, so it cannot self-invalidate the flush.
+		deleteConfirm.cancel();
 		// A drag live ACROSS the image change (arrow-nav mid-drag) is left with a
 		// stale baseline, and deliberately so: `resetZoom` is fit, where `clampPan`
 		// pins the pan to 0 for ANY baseline, so the next move can't jump; and the
@@ -807,6 +1052,11 @@
 		void hasMultiple;
 		void loader.phase;
 		void img;
+		// The toolbar's drill-down swaps the action buttons for the confirm rows and
+		// back (TASK-2474); the control that had focus (the Delete button, or Cancel)
+		// unmounts across that switch, so track `pending` to re-home a focus stranded
+		// on <body> to the stable fallback within the same flush.
+		void deleteConfirm.pending;
 		const el = rootEl;
 		if (!el || !isViewerFrontmost(el) || isBlockedByModal(el)) return;
 		handoffFocus(el);
@@ -843,6 +1093,21 @@
 			if (target) {
 				e.preventDefault();
 				target.focus({ preventScroll: true });
+			}
+			return;
+		}
+
+		// The delete drill-down owns the arrow keys as a MENU while it is open
+		// (TASK-2474): Up/Down move between its rows, and it consumes Left/Right so a
+		// confirmation can't page the gallery behind it. Tab still cycles the rows
+		// through the trap above; Escape backs out (via the escape stack). Returns
+		// for every key, so zoom keys are inert over the confirm too.
+		if (deleteConfirm.pending) {
+			if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+				e.preventDefault();
+				moveConfirmFocus(e.key === 'ArrowDown' ? 1 : -1);
+			} else if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
+				e.preventDefault();
 			}
 			return;
 		}
@@ -974,6 +1239,80 @@
 		>
 			&#8250;
 		</button>
+	{/if}
+
+	<!--
+		ACTION TOOLBAR (TASK-2474). The shared descriptor list, drawn over the
+		stage. The `.lightbox-toolbar` wrapper is the positioned pill AND the
+		pointer control-exclusion hook — registered in BOTH lists above
+		(`onPointerDown` / `onDoubleClick` / `onWheel`) via `.lightbox-toolbar`, so
+		a press / double-click / wheel on it is that control's, never a pan or a
+		zoom. The ARIA ROLE lives on the inner state, not the wrapper: the actions
+		are a `role="toolbar"`, and the delete drill-down a `role="menu"` (its rows
+		are `role="menuitem"`, which a toolbar must not parent). Gated on `img`.
+	-->
+	{#if img}
+		<div class="lightbox-toolbar">
+			{#if deleteConfirm.pending}
+				<!--
+					Delete confirmation as a drill-down (DR-18) — the SAME shared component
+					the panel and the strip render, so the wording and shape can only ever
+					change in one place. The module owns the pending/warning state; the
+					descriptor's awaited gate resolves through confirm() / cancel(). It is a
+					`role="menu"` of `role="menuitem"` rows: focus enters the first row on
+					open, Up/Down move between them, Escape backs out (see the handlers).
+				-->
+				<div class="lightbox-delete-confirm" role="menu" aria-label="Confirm delete">
+					<AttachmentDeleteConfirm
+						prompt={deleteConfirm.warning ?? ''}
+						promptId={deletePromptId}
+						oncancel={() => deleteConfirm.cancel()}
+						onconfirm={() => deleteConfirm.confirm()}
+					/>
+				</div>
+			{:else}
+				<div class="lightbox-toolbar-actions" role="toolbar" aria-label="Attachment actions">
+					{#if toolbarError}
+						<div class="lightbox-toolbar-error" role="alert">{toolbarError}</div>
+					{/if}
+					{#each toolbarActions as action (action.id)}
+						{#snippet toolIcon()}
+							<AttachmentIcon id={action.icon} />
+						{/snippet}
+						{#if action.element === 'anchor'}
+							<a
+								class="lightbox-tool"
+								href={action.href(toolbarCtx)}
+								download={action.download?.(toolbarCtx)}
+								target={action.target}
+								rel={action.rel}
+								aria-label={action.label}
+								title={action.description ?? action.label}
+								aria-disabled={!action.enabled(toolbarCtx)}
+							>
+								<span class="lightbox-tool-icon" aria-hidden="true">{@render toolIcon()}</span>
+								<span class="lightbox-tool-label">{action.label}</span>
+							</a>
+						{:else}
+							<button
+								class="lightbox-tool"
+								class:danger={action.danger}
+								type="button"
+								aria-label={action.label}
+								title={action.description ?? action.label}
+								disabled={!action.enabled(toolbarCtx) || toolbarBusy}
+								onclick={() => runToolbarAction(action)}
+							>
+								<span class="lightbox-tool-icon" aria-hidden="true">{@render toolIcon()}</span>
+								<span class="lightbox-tool-label"
+									>{toolbarBusy && action.id === 'delete' ? 'Deleting…' : action.label}</span
+								>
+							</button>
+						{/if}
+					{/each}
+				</div>
+			{/if}
+		</div>
 	{/if}
 
 	<!--
@@ -1377,6 +1716,110 @@
 		font-size: 0.8rem;
 	}
 
+	/* Action toolbar (TASK-2474). The WRAPPER is positioning + the pointer-
+	   exclusion hook only; each inner state carries its own look. Top-centre,
+	   above the stage's stacking context (`z-index: 1`, like the other chrome). */
+	.lightbox-toolbar {
+		position: absolute;
+		z-index: 1;
+		top: var(--space-3);
+		left: 50%;
+		transform: translateX(-50%);
+		max-width: min(92vw, 640px);
+	}
+
+	/* The confirm panel is TALLER and WIDER than the action pill and would collide
+	   with the top-right close button at narrow widths — drop it below the close
+	   button's row (40px control at `top: var(--space-3)`). */
+	.lightbox-toolbar:has(.lightbox-delete-confirm) {
+		top: calc(var(--space-3) + 52px);
+	}
+
+	/* The action pill: a horizontal row of icon/label controls. */
+	.lightbox-toolbar-actions {
+		display: flex;
+		align-items: center;
+		gap: var(--space-2);
+		flex-wrap: wrap;
+		justify-content: center;
+		padding: var(--space-1) var(--space-2);
+		background: rgba(0, 0, 0, 0.5);
+		border: 1px solid rgba(255, 255, 255, 0.2);
+		border-radius: 9999px;
+	}
+
+	/* The delete drill-down: a small panel of stacked rows (the shared
+	   AttachmentDeleteConfirm), the same column shape the panel's menu gives it. */
+	.lightbox-delete-confirm {
+		display: flex;
+		flex-direction: column;
+		align-items: stretch;
+		border-radius: var(--radius);
+		padding: var(--space-2);
+		background: var(--bg-primary, #1a1a1a);
+		color: var(--text-primary, #fff);
+		border: 1px solid rgba(255, 255, 255, 0.2);
+		min-width: min(88vw, 320px);
+	}
+
+	.lightbox-tool {
+		display: inline-flex;
+		align-items: center;
+		gap: var(--space-1);
+		padding: var(--space-1) var(--space-2);
+		border: none;
+		border-radius: 9999px;
+		background: transparent;
+		color: #fff;
+		font: inherit;
+		font-size: 0.85rem;
+		line-height: 1;
+		cursor: pointer;
+		text-decoration: none;
+	}
+
+	.lightbox-tool:hover,
+	.lightbox-tool:focus-visible {
+		background: rgba(255, 255, 255, 0.16);
+	}
+
+	.lightbox-tool:disabled,
+	.lightbox-tool[aria-disabled='true'] {
+		opacity: 0.45;
+		cursor: default;
+		pointer-events: none;
+	}
+
+	.lightbox-tool.danger {
+		color: var(--accent-red, #ff6b6b);
+	}
+
+	.lightbox-tool-icon {
+		display: inline-flex;
+		width: 18px;
+		height: 18px;
+	}
+
+	/* DR-18: the label is ALWAYS in the accessible name (`aria-label`); its VISIBLE
+	   text shows on phone (≤768, the app's canonical breakpoint) and is hidden on
+	   the roomier desktop toolbar, which stays icon-only. */
+	.lightbox-tool-label {
+		display: none;
+	}
+
+	@media (max-width: 768px) {
+		.lightbox-tool-label {
+			display: inline;
+		}
+	}
+
+	.lightbox-toolbar-error {
+		flex-basis: 100%;
+		text-align: center;
+		color: var(--accent-red, #ff6b6b);
+		font-size: 0.8rem;
+	}
+
 	/* Forced-colors (PLAN-2392 DR-4). The custom palette is discarded, so the
 	   image's box-shadow boundary vanishes — give the image a real BORDER so its
 	   boundary stays visible. LAST in the sheet so it wins over the controls' own
@@ -1389,7 +1832,8 @@
 		.lightbox-close,
 		.lightbox-nav,
 		.lightbox-retry,
-		.lightbox-tap-load {
+		.lightbox-tap-load,
+		.lightbox-tool {
 			border: 1px solid ButtonText;
 		}
 	}

--- a/web/src/lib/components/common/Lightbox.svelte
+++ b/web/src/lib/components/common/Lightbox.svelte
@@ -72,7 +72,10 @@
 	 * and a local `interface … extends` would be a second declaration, which is
 	 * the drift this consolidation removes.
 	 */
-	import type { LightboxImage } from '$lib/attachments/events';
+	import {
+		registerAttachmentDeletionListener,
+		type LightboxImage,
+	} from '$lib/attachments/events';
 	// ── Toolbar (PLAN-2392 phase 3c-i / TASK-2474) ───────────────────────────
 	// The viewer's copy of the shared attachment-action list (DR-5) — the SAME
 	// descriptors the options panel renders, drawn here as an inline toolbar over
@@ -223,20 +226,28 @@
 			})
 	);
 
-	// Seeded once at mount — the host remounts (null → set) on each open, so
-	// no prop-sync effect is needed. untrack makes the initial-value capture
-	// explicit.
-	//
-	// Resolved through the ID rather than carried across as a number: filtering
-	// reindexes everything after a refusal, so the requested POSITION can name a
-	// different image (or none) in the filtered set. Where the requested image
-	// is the one refused, there is nothing to land on and the first navigable
-	// image is what opens.
-	let current = $state(
+	// DELETION TOMBSTONES (PLAN-2392 DR-5c / TASK-2477). Ids the deletion bus has
+	// announced gone while this viewer is open — the SURVIVING set is `navigable`
+	// minus these. Fresh per instance and never reset: every producer keys the
+	// mount, so a reopen is a new component with an empty set (no cross-open
+	// leakage), and a delete is authoritative for the life of the viewer that saw
+	// it. A `Set` reassigned (not mutated) on each add so the `survivors` derived
+	// re-runs.
+	let tombstones = $state<Set<string>>(new Set());
+
+	// THE SHOWN IMAGE, TRACKED BY ID (TASK-2477). The index is DERIVED from this,
+	// not the source of truth — so deleting an EARLIER image keeps the SAME image
+	// on screen (identity, not a position that now names a different member), and
+	// deleting the shown one advances by recomputing from the new survivor list.
+	// Seeded once at mount from the requested index, resolved through the id: the
+	// filter reindexes everything after a refusal, so the requested POSITION can
+	// name a different image (or none). Where the requested image is refused, the
+	// first navigable image opens.
+	let shownId = $state<string | null>(
 		untrack(() => {
 			const wanted = images[Math.min(Math.max(index, 0), Math.max(images.length - 1, 0))];
-			const at = wanted ? navigable.findIndex((im) => im.id === wanted.id) : -1;
-			return at < 0 ? 0 : at;
+			const at = wanted ? navigable.find((im) => im.id === wanted.id) : undefined;
+			return (at ?? navigable[0])?.id ?? null;
 		})
 	);
 
@@ -261,21 +272,25 @@
 		return active && active !== document.body ? (active as HTMLElement) : null;
 	});
 
-	// EVERYTHING PAST THIS POINT READS `navigable`, NEVER `images` — the nav
-	// wrap-around, the counter and the rendered `<img>` alike. A single read of
-	// the unfiltered prop below would reopen the hole this filter closes.
-	let hasMultiple = $derived(navigable.length > 1);
-	// The position actually shown, clamped. `current` is what the user's ←/→
-	// moved, but the set can SHRINK underneath it — an entry whose MIME resolves to
-	// UNRESOLVED, or is dropped from the array, leaves `navigable` (a flip to
-	// unsafe does NOT — it stays as the fallback arm). Clamping in a derived
-	// (rather than writing `current` from an effect, which would be an effect
-	// writing state it reads) keeps the viewer on a real member instead of blanking
-	// or showing `undefined`.
+	// THE SURVIVING SET — `navigable` minus the tombstones (TASK-2477). EVERYTHING
+	// PAST THIS POINT READS `survivors`, NEVER `images` or even `navigable`: the nav
+	// wrap-around, the counter and the rendered `<img>` alike. A read of the
+	// unfiltered prop would reopen the DR-16 hole `navigable` closes; a read of
+	// `navigable` (pre-tombstone) would page onto a deleted image.
+	let survivors = $derived(navigable.filter((im) => !tombstones.has(im.id)));
+	let hasMultiple = $derived(survivors.length > 1);
+	// The position actually shown, DERIVED from `shownId`. Falls to 0 when the id
+	// dangles — a shown image removed straight from the `images` prop (a producer's
+	// set change, not the deletion bus, which advances `shownId` itself). Deriving
+	// the index (rather than writing it from an effect that reads it) keeps the
+	// viewer on a real member instead of blanking or showing `undefined`.
 	let shownIndex = $derived(
-		Math.min(Math.max(current, 0), Math.max(navigable.length - 1, 0))
+		Math.max(
+			survivors.findIndex((im) => im.id === shownId),
+			0
+		)
 	);
-	let img = $derived(navigable[shownIndex]);
+	let img = $derived(survivors[shownIndex]);
 	// THE STAGE ARM (TASK-2476). The single decision of what the stage draws for
 	// the shown entry: `'raster-image'` → the `<img>`; `null` → the no-bytes icon
 	// fallback. A navigable entry always has a resolved MIME (unresolved is refused
@@ -343,11 +358,6 @@
 	// string. Shared by the metadata header, the download attribute and the delete
 	// prompt, so all three name the file identically.
 	let displayName = $derived(img?.filename ?? blankToNull(img?.alt) ?? 'Attachment');
-	// Counts confirmed deletes. The descriptor's `run()` resolves the same way
-	// whether the row was deleted or the user CANCELLED, so the counter is how the
-	// two are told apart — a delete closes the viewer, a cancel does not. Plain
-	// `let`: read/written only in the action handler, never a tracked scope.
-	let toolbarDeleteSignal = 0;
 	// Inline, transient error from a button action (a failed clipboard write). Sits
 	// in the toolbar beside the controls, never a blocking dialog.
 	let toolbarError = $state<string | null>(null);
@@ -424,9 +434,14 @@
 			return mutationsEnabled;
 		},
 		confirmDelete: () => deleteConfirm.request(),
-		onDeleted: () => {
-			toolbarDeleteSignal += 1;
-		},
+		// NO `onDeleted` (TASK-2477): the panel uses it to close on delete, but the
+		// viewer reconciles a delete through the DELETION BUS instead — the
+		// descriptor's `announceAttachmentDeleted` fires `handleDeletion`, which
+		// tombstones the id and advances (or closes when nothing survives). That is
+		// the SAME path an external delete takes, so an own-toolbar delete and a
+		// strip/other-tab delete are indistinguishable to the survivor logic. The
+		// C1 close-on-delete latch is retired: the viewer had no survivor logic then,
+		// so closing was the only sane outcome; now it advances when survivors remain.
 		onCopied: () => toastStore.show('Link copied to clipboard', 'success'),
 	};
 
@@ -434,27 +449,15 @@
 
 	async function runToolbarAction(action: ButtonAttachmentAction) {
 		if (!action.enabled(toolbarCtx)) return;
-		const deletesBefore = toolbarDeleteSignal;
-		// The image this action was launched against. Closing on delete is gated on
-		// it still being the one shown, so a set-shrink / nav during the await can't
-		// close the viewer over a DIFFERENT image than the one deleted.
-		const targetId = img?.id;
 		toolbarError = null;
 		toolbarBusy = true;
 		try {
 			await action.run(toolbarCtx);
-			// The continuation may land after the viewer was torn down (a keyed
-			// producer remounts on the next open) — `onClose` is a stale callback then.
+			// A confirmed delete is reconciled through the deletion bus (`handleDeletion`
+			// runs synchronously inside `run`'s announce) — advance or close — so nothing
+			// to do here. Copy-link and the rest simply finish. The `destroyed` guard
+			// covers a continuation landing after the bus close tore the viewer down.
 			if (destroyed) return;
-			// A confirmed delete removed the image on screen — showing its now-404
-			// bytes is wrong, so close the viewer (the panel's onclose parallel). Close
-			// when the shown image is STILL the deleted one (the common case: the
-			// producer's set isn't mutated, so the 404'd image is what's on screen), OR
-			// when the set emptied out from under us (`!img` — nothing left to show).
-			// Only a set-shrink that moved a DIFFERENT image into view is left open —
-			// and the descriptor's own identity re-check already aborts a delete that
-			// raced an arrow-nav (no signal bump). A Cancel leaves the signal untouched.
-			if (toolbarDeleteSignal !== deletesBefore && (!img || img.id === targetId)) onClose();
 		} catch (err) {
 			if (destroyed) return;
 			toolbarError =
@@ -963,18 +966,61 @@
 		zoom = toggleFitOrActual(zoom, anchor, g);
 	}
 
-	// Stepped from `shownIndex`, not from `current`: after the set shrinks they
-	// differ, and moving from the raw value would jump relative to a position
-	// the user was never on. Both are no-ops on an empty set — reachable only
-	// through the nav controls / arrow keys, which `hasMultiple` already hides
-	// and gates, but written so the modulo can never be `% 0`.
+	// Move `shownId` (identity), stepped from the DERIVED `shownIndex` over the
+	// SURVIVORS. Writing the id, not an index, is what keeps the viewer on a real
+	// member when the set changes under it. No-ops on an empty set — reachable only
+	// through the nav controls / arrow keys, which `hasMultiple` already hides and
+	// gates, but written so the modulo can never be `% 0`.
 	function prev() {
-		if (navigable.length === 0) return;
-		current = (shownIndex - 1 + navigable.length) % navigable.length;
+		if (survivors.length === 0) return;
+		shownId = survivors[(shownIndex - 1 + survivors.length) % survivors.length].id;
 	}
 	function next() {
-		if (navigable.length === 0) return;
-		current = (shownIndex + 1) % navigable.length;
+		if (survivors.length === 0) return;
+		shownId = survivors[(shownIndex + 1) % survivors.length].id;
+	}
+
+	// THE DELETION SUBSCRIPTION (PLAN-2392 DR-5c / TASK-2477). ONE path for both
+	// origins: the toolbar's own Delete announces on the bus (the descriptor's
+	// `announceAttachmentDeleted`), and an external surface (the strip, another
+	// tab) announces the same way — so this reacts identically to both, and the
+	// toolbar's ctx deliberately carries NO `onDeleted` (that close-on-delete is
+	// the PANEL's; the viewer advances instead). An event handler, not an $effect,
+	// so writing `shownId` / `tombstones` here is not a self-write.
+	function handleDeletion(uuid: string) {
+		if (!uuid || tombstones.has(uuid)) return;
+		// Snapshot BEFORE tombstoning: the position of the deleted entry decides
+		// where "advance" lands.
+		const before = survivors;
+		const i = before.findIndex((im) => im.id === uuid);
+		// NOT in our surviving set: an unsafe-at-open / unresolved entry (D excluded
+		// it), another item's attachment on the shared bus, or an already-dangling
+		// `shownId` (a producer removed the shown image straight from the prop). Still
+		// tombstone it — a delete is authoritative — but there is nothing to advance
+		// to or close over, so DON'T touch `shownId` (its index derives to a survivor)
+		// and DON'T read `after[-1]` or close an already-empty viewer.
+		if (i < 0) {
+			tombstones = new Set(tombstones).add(uuid);
+			return;
+		}
+		const deletingShown = uuid === shownId;
+		// Authoritative and latched for this viewer's life — reassign the Set so
+		// `survivors` recomputes.
+		tombstones = new Set(tombstones).add(uuid);
+		const after = survivors; // recomputed, minus uuid
+		if (after.length === 0) {
+			// Nothing left to show — zero-left / deleting-only → close.
+			onClose();
+			return;
+		}
+		if (deletingShown) {
+			// ADVANCE to the entry that FOLLOWED the deleted one — now at index `i` in
+			// the shrunk list — wrapping to the first when the last was deleted. The
+			// zoom transform resets through the existing id-keyed effect, since the
+			// shown id changes here. Deleting an EARLIER/LATER entry leaves `shownId`
+			// untouched: identity, not index, so the SAME image stays on screen.
+			shownId = after[i < after.length ? i : 0].id;
+		}
 	}
 
 	/**
@@ -1071,7 +1117,13 @@
 			return true;
 		}, ESCAPE_PRIORITY.viewer);
 
+		// Subscribe to the deletion bus (TASK-2477). Registered alongside the lease so
+		// it is DISPOSED in the same teardown — a leaked listener would fire
+		// `shownId` / `onClose` writes into a torn-down viewer.
+		const unregisterDeletion = registerAttachmentDeletionListener(handleDeletion);
+
 		return () => {
+			unregisterDeletion();
 			unregisterEscape();
 			// Release BEFORE restoring focus, and let the RESULT decide: when a
 			// viewer remains beneath this one the manager has already handed focus
@@ -1087,10 +1139,13 @@
 		};
 	});
 
-	// Reset the transform whenever the SHOWN image changes — arrow nav, or the
-	// set shrinking under `current` so a different member is shown (TASK-2455).
-	// Close needs no handling: every producer keys the mount, so closing
-	// unmounts this instance and the next open starts from `resetZoom()`.
+	// Reset the transform whenever the SHOWN image changes — arrow nav, or a delete
+	// that ADVANCES `shownId` to a survivor (TASK-2455 / TASK-2477). Keyed on
+	// `img?.id`, so it fires exactly when a DIFFERENT image is shown: deleting an
+	// earlier/later entry leaves `shownId` (and thus `img.id`) put, so the same
+	// image's zoom survives; advancing onto a new one resets it. Close needs no
+	// handling: every producer keys the mount, so closing unmounts this instance
+	// and the next open starts from `resetZoom()`.
 	//
 	// `lastResetForId` is a PLAIN let, not `$state`: an effect that read and wrote
 	// the same `$state` would self-depend and abort its own flush (CONVE-1688),
@@ -1658,9 +1713,9 @@
 	</div>
 
 	{#if hasMultiple}
-		<!-- `shownIndex`, so the counter names the image actually on screen even
-		     after the set shrank under `current`. -->
-		<div class="lightbox-counter">{shownIndex + 1} / {navigable.length}</div>
+		<!-- Derived `shownIndex` over the SURVIVORS, so the counter names the image
+		     actually on screen even after a deletion shrank the set. -->
+		<div class="lightbox-counter">{shownIndex + 1} / {survivors.length}</div>
 	{/if}
 
 	<!--

--- a/web/src/lib/components/common/Lightbox.svelte
+++ b/web/src/lib/components/common/Lightbox.svelte
@@ -83,9 +83,14 @@
 	import { createDeleteConfirm } from '$lib/attachments/surfaceDeleteConfirm.svelte';
 	import AttachmentIcon from '$lib/attachments/icons/AttachmentIcon.svelte';
 	import AttachmentDeleteConfirm from '$lib/components/attachments/AttachmentDeleteConfirm.svelte';
-	import { displayFilename } from '$lib/attachments/display';
 	import { attachmentRefsIn } from '$lib/utils/commentAttachments';
 	import { toastStore } from '$lib/stores/toast.svelte';
+	// ── Metadata header (PLAN-2392 phase 3c-i / TASK-2475) ───────────────────
+	// Filename / type / size for the shown image, seeded from the LightboxImage
+	// and completed by the SAME B metadata module the panel uses (TASK-2473): it
+	// fetches only what the seed left null (DR-2 — open now, fill after).
+	import { describeAttachmentType, formatBytes } from '$lib/attachments/display';
+	import { createSurfaceMetadata } from '$lib/attachments/surfaceMetadata.svelte';
 
 	interface Props {
 		images: LightboxImage[];
@@ -170,7 +175,28 @@
 	 * replaced or when a record's MIME resolves to something unsafe after the
 	 * viewer opened, so a stale capture cannot outlive its own truth.
 	 */
-	let viewable = $derived(images.filter((im) => canOpenInViewer(im.mime_type)));
+	// A blank/whitespace-only string is not a value — it is the ABSENCE of one, and
+	// the display chains (`filename ?? alt ?? …`) only skip null/undefined, so an
+	// empty string would win over the fallback and render nothing (TASK-2475).
+	// Normalized to a trimmed value or null, once, at ingestion below.
+	function blankToNull(s: string | null | undefined): string | null {
+		const t = (s ?? '').trim();
+		return t.length > 0 ? t : null;
+	}
+
+	// INGESTION (TASK-2475). Filter to viewable, then normalize each row's blank
+	// filename to null so the display-name chain (and the toolbar's download name)
+	// fall through to `alt` rather than showing an empty string. The identity of a
+	// row with an already-clean filename is preserved (no needless re-object), so
+	// the fences downstream that key on `img.id` are unaffected.
+	let viewable = $derived(
+		images
+			.filter((im) => canOpenInViewer(im.mime_type))
+			.map((im) => {
+				const clean = blankToNull(im.filename);
+				return clean === im.filename ? im : { ...im, filename: clean };
+			})
+	);
 
 	// Seeded once at mount — the host remounts (null → set) on each open, so
 	// no prop-sync effect is needed. untrack makes the initial-value capture
@@ -229,6 +255,44 @@
 	// nothing at all.
 	let dialogLabel = $derived(img?.alt || 'Attachment viewer');
 
+	// ── Metadata header (PLAN-2392 phase 3c-i / TASK-2475) ────────────────────
+	//
+	// Filename / type / size for the shown image. The B module (TASK-2473) seeds
+	// from the LightboxImage and completes only what is null — but a viewer image
+	// has always cleared the MIME gate, so MIME is known and the module fetches
+	// iff `size_bytes` is null. `filename` is never fetched (the HEAD does not
+	// return one), so the name comes straight off the seed; only type and size
+	// read through the module's merged `fields`. `open`/`parentArchived` are
+	// constant here (the viewer is always open; it has no archived-parent probe).
+	const headerMeta = createSurfaceMetadata(() => ({
+		ws: openWsSlug,
+		attachmentId: img?.id ?? '',
+		seed: {
+			filename: img?.filename ?? null,
+			mime_type: img?.mime_type ?? null,
+			size_bytes: img?.size_bytes ?? null,
+		},
+		open: !!img,
+		parentArchived: false,
+		revalidateToken: 0,
+	}));
+	// Type only when the MIME is known — no "unknown type" noise (DR-2). Size only
+	// when it is a real number — `formatBytes` is never fed null, and absent beats
+	// "0 B" (the chip call-site precedent).
+	let headerType = $derived(
+		headerMeta.fields.mime_type
+			? describeAttachmentType(headerMeta.fields.mime_type, headerMeta.fields.filename)
+			: null
+	);
+	let headerSize = $derived(
+		typeof headerMeta.fields.size_bytes === 'number' ? formatBytes(headerMeta.fields.size_bytes) : null
+	);
+	let headerDetail = $derived([headerType, headerSize].filter(Boolean).join(' · '));
+	// A non-404 fetch failure: show the DR-10 inline retry BESIDE what is already
+	// known (the name + type never blank out), and Retry revalidates through the
+	// module rather than replaying the cached failure.
+	let headerTransient = $derived(headerMeta.phase === 'transient');
+
 	// ── Action toolbar (PLAN-2392 phase 3c-i / TASK-2474) ─────────────────────
 	//
 	// The SAME `attachmentActionsFor` list the options panel renders (DR-5), drawn
@@ -237,12 +301,12 @@
 	// always apply; Delete applies only when the host granted `mutationsEnabled`.
 	const uid = $props.id();
 	const deletePromptId = `lightbox-delete-note-${uid}`;
-	// A non-null display name for the current image, for the download attribute and
-	// the delete prompt. The channel's `filename` is nullable; `alt` is the inline
-	// image's next-best name; the generic label is the last resort so a nameless
-	// image still downloads and can still be named in a confirmation (until C2's
-	// display-name chain lands, this inline fallback IS that chain).
-	let displayName = $derived(displayFilename(img?.filename ?? img?.alt ?? 'Attachment'));
+	// THE DISPLAY-NAME CHAIN (TASK-2475): filename ?? alt ?? 'Attachment'. `filename`
+	// is already blank-normalized at ingestion, so a nameless image falls through to
+	// `alt` (also blank-normalized) and then the generic label — never an empty
+	// string. Shared by the metadata header, the download attribute and the delete
+	// prompt, so all three name the file identically.
+	let displayName = $derived(img?.filename ?? blankToNull(img?.alt) ?? 'Attachment');
 	// Counts confirmed deletes. The descriptor's `run()` resolves the same way
 	// whether the row was deleted or the user CANCELLED, so the counter is how the
 	// two are told apart — a delete closes the viewer, a cancel does not. Plain
@@ -293,10 +357,13 @@
 	let destroyed = false;
 	// Drop any pending confirmation on unmount so the descriptor's awaited
 	// `confirmDelete()` promise settles rather than dangling (the panel's teardown),
-	// and latch `destroyed` so no post-unmount continuation calls `onClose`.
+	// and latch `destroyed` so no post-unmount continuation calls `onClose`. The
+	// metadata module's fences are invalidated here too so a late HEAD can't write
+	// into a torn-down header (TASK-2475).
 	$effect(() => () => {
 		destroyed = true;
 		deleteConfirm.dispose();
+		headerMeta.dispose();
 	});
 
 	/**
@@ -518,7 +585,7 @@
 		// other wheel — the modal owns it, so the inert page can't scroll — but must
 		// NOT zoom the image behind it (TASK-2474). The same exclusion the pointerdown
 		// and double-click handlers carry, applied here too.
-		if ((e.target as Element | null)?.closest?.('.lightbox-toolbar')) return;
+		if ((e.target as Element | null)?.closest?.('.lightbox-toolbar, .lightbox-meta')) return;
 		// Consumed (the modal owns the wheel) but INERT with no decoded bitmap — the
 		// mobile deferred placeholder or the error UI, where the broken `<img>` still
 		// satisfies `readGeometry` (TASK-2461). Same guard the keys use.
@@ -660,7 +727,7 @@
 		// (the house pattern in ItemGraph excludes its interactive overlays the same
 		// way). Retry sits over the (broken) stage in the error state, so it needs
 		// the same exclusion as the always-present chrome.
-		if ((e.target as Element | null)?.closest?.('.lightbox-close, .lightbox-nav, .lightbox-retry, .lightbox-tap-load, .lightbox-toolbar')) return;
+		if ((e.target as Element | null)?.closest?.('.lightbox-close, .lightbox-nav, .lightbox-retry, .lightbox-tap-load, .lightbox-toolbar, .lightbox-meta')) return;
 		// No decoded bitmap to pan (the mobile `deferred` placeholder shows no
 		// `<img>`) — do NOT arm a drag, so the gesture stays fully inert instead of
 		// capturing the pointer and latching `dragging` for a pan that can never
@@ -791,7 +858,7 @@
 		// A double-click ON a control (close / nav / retry) is that control's, not a
 		// zoom toggle — without this, double-clicking Next navigates twice AND
 		// toggles, or a double-click on Retry toggles zoom on the broken stage.
-		if ((e.target as Element | null)?.closest?.('.lightbox-close, .lightbox-nav, .lightbox-retry, .lightbox-tap-load, .lightbox-toolbar')) return;
+		if ((e.target as Element | null)?.closest?.('.lightbox-close, .lightbox-nav, .lightbox-retry, .lightbox-tap-load, .lightbox-toolbar, .lightbox-meta')) return;
 		// Inert with no decoded bitmap (deferred placeholder / error UI) — the same
 		// guard the keys and wheel use (TASK-2461).
 		if (!bitmapPresent) return;
@@ -1057,6 +1124,10 @@
 		// unmounts across that switch, so track `pending` to re-home a focus stranded
 		// on <body> to the stable fallback within the same flush.
 		void deleteConfirm.pending;
+		// The metadata header's Retry button unmounts the instant its own click
+		// clears the transient phase (TASK-2475), so a keyboard user who pressed it is
+		// left on <body>; track the transient flag to re-home them the same way.
+		void headerTransient;
 		const el = rootEl;
 		if (!el || !isViewerFrontmost(el) || isBlockedByModal(el)) return;
 		handoffFocus(el);
@@ -1447,6 +1518,36 @@
 		     after the set shrank under `current`. -->
 		<div class="lightbox-counter">{shownIndex + 1} / {viewable.length}</div>
 	{/if}
+
+	<!--
+		METADATA HEADER (TASK-2475). Filename / type / size for the shown image.
+		Bottom-left, NOT the top row: the two primary actions (the toolbar) and
+		Close own the top, and metadata must never crowd them on a phone (DR-18) —
+		placing it here keeps that true by construction. A LABEL like the counter,
+		not a dismiss target: it is excluded from the pan/zoom gestures (via
+		`.lightbox-meta` in the three lists) so a press on it is inert, and only the
+		Retry button acts. The name is truncated with the FULL value in `title`
+		(DR-13); the detail line adds type · size only when known.
+	-->
+	{#if img}
+		<div class="lightbox-meta">
+			<div class="lightbox-meta-name" title={displayName}>{displayName}</div>
+			{#if headerDetail}
+				<div class="lightbox-meta-detail">{headerDetail}</div>
+			{/if}
+			{#if headerTransient}
+				<!-- DR-10: retryable, BESIDE the name/type it already knows — never a
+				     blank sheet. Retry revalidates through the module. -->
+				<div class="lightbox-meta-error" role="status">
+					<span>Couldn't load details</span>
+					<span aria-hidden="true">·</span>
+					<button class="lightbox-meta-retry" type="button" onclick={() => headerMeta.retry()}
+						>Retry</button
+					>
+				</div>
+			{/if}
+		</div>
+	{/if}
 </div>
 
 <style>
@@ -1716,6 +1817,75 @@
 		font-size: 0.8rem;
 	}
 
+	/* Metadata header (TASK-2475). Bottom-left, clear of the top toolbar / close
+	   (DR-18). Logical properties + `min-width: 0` so a long filename ellipsizes
+	   inside its own box rather than blowing out the layout (DR-13). A LABEL, like
+	   the counter: it keeps its default pointer events so a press on it is the
+	   header's own (and is excluded from the pan/zoom gestures via `.lightbox-meta`
+	   in the three exclusion lists) rather than falling THROUGH to the image behind
+	   and arming a pan. It does not close the viewer — a filename is not a dismiss
+	   target — and only Retry inside it does anything. Width is capped short of the
+	   centred counter (reserve ~72px each side of centre) so the two never touch,
+	   at any width or in RTL. */
+	.lightbox-meta {
+		position: absolute;
+		z-index: 1;
+		inset-block-end: var(--space-3);
+		inset-inline-start: var(--space-3);
+		min-width: 0;
+		max-inline-size: min(calc(50% - 72px), 420px);
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+		color: #fff;
+		/* Legible over any image — a soft shadow rather than a plate, so it stays
+		   unobtrusive while the filename is still readable on a light photo. */
+		text-shadow: 0 1px 3px rgba(0, 0, 0, 0.9);
+	}
+
+	.lightbox-meta-name {
+		min-width: 0;
+		max-inline-size: 100%;
+		font-size: 0.85rem;
+		font-weight: 600;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	.lightbox-meta-detail {
+		min-width: 0;
+		font-size: 0.75rem;
+		opacity: 0.85;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	.lightbox-meta-error {
+		display: flex;
+		align-items: center;
+		gap: var(--space-1);
+		font-size: 0.75rem;
+		color: var(--accent-red, #ff6b6b);
+	}
+
+	.lightbox-meta-retry {
+		padding: 1px var(--space-1);
+		border: 1px solid currentColor;
+		border-radius: var(--radius-sm, 4px);
+		background: transparent;
+		color: inherit;
+		font: inherit;
+		font-size: 0.75rem;
+		cursor: pointer;
+	}
+
+	.lightbox-meta-retry:hover,
+	.lightbox-meta-retry:focus-visible {
+		background: rgba(255, 255, 255, 0.16);
+	}
+
 	/* Action toolbar (TASK-2474). The WRAPPER is positioning + the pointer-
 	   exclusion hook only; each inner state carries its own look. Top-centre,
 	   above the stage's stacking context (`z-index: 1`, like the other chrome). */
@@ -1833,7 +2003,8 @@
 		.lightbox-nav,
 		.lightbox-retry,
 		.lightbox-tap-load,
-		.lightbox-tool {
+		.lightbox-tool,
+		.lightbox-meta-retry {
 			border: 1px solid ButtonText;
 		}
 	}

--- a/web/src/lib/components/common/Lightbox.svelte
+++ b/web/src/lib/components/common/Lightbox.svelte
@@ -338,7 +338,9 @@
 	let headerDetail = $derived([headerType, headerSize].filter(Boolean).join(' · '));
 	// A non-404 fetch failure: show the DR-10 inline retry BESIDE what is already
 	// known (the name + type never blank out), and Retry revalidates through the
-	// module rather than replaying the cached failure.
+	// module rather than replaying the cached failure. The module's other authoritative
+	// phase — `missing` (404) — is NOT a header state: it means the shown file is
+	// gone, so it is routed through the deletion path instead (see the effect below).
 	let headerTransient = $derived(headerMeta.phase === 'transient');
 	// The fallback arm's large icon (TASK-2476): the same family glyph the strip /
 	// panel show for this type, from the shared registry.
@@ -449,21 +451,36 @@
 
 	async function runToolbarAction(action: ButtonAttachmentAction) {
 		if (!action.enabled(toolbarCtx)) return;
+		// Fence the whole action against the shown identity (the SAME view fence the
+		// metadata machine invalidates on a subject change). A confirmed delete of the
+		// shown image advances `shownId` to a survivor synchronously inside `run`'s
+		// announce, and a metadata `missing` for the shown image can advance it while a
+		// SLOW delete of that same image is still awaiting — either way the view has
+		// moved on, and this continuation must NOT write `toolbarBusy` / `toolbarError`
+		// onto the survivor now on screen. The subject-change reset (the id-keyed effect)
+		// clears the busy/error state for the new image; a stale continuation just
+		// bows out. A same-image failure (delete rejected, no advance) is NOT stale, so
+		// its error still shows against the image it belongs to.
+		const token = headerMeta.viewFence.begin();
 		toolbarError = null;
 		toolbarBusy = true;
 		try {
 			await action.run(toolbarCtx);
 			// A confirmed delete is reconciled through the deletion bus (`handleDeletion`
 			// runs synchronously inside `run`'s announce) — advance or close — so nothing
-			// to do here. Copy-link and the rest simply finish. The `destroyed` guard
-			// covers a continuation landing after the bus close tore the viewer down.
-			if (destroyed) return;
+			// to do here. Copy-link and the rest simply finish. The guards cover a
+			// continuation landing after the bus close tore the viewer down (`destroyed`)
+			// or after the view advanced off this image (`token.stale()`).
+			if (destroyed || token.stale()) return;
 		} catch (err) {
-			if (destroyed) return;
+			if (destroyed || token.stale()) return;
 			toolbarError =
 				err instanceof Error ? err.message : `Couldn't ${action.label.toLowerCase()}`;
 		} finally {
-			if (!destroyed) toolbarBusy = false;
+			// Only the still-current continuation clears the busy flag; a stale one leaves
+			// it for the subject-change reset to zero, so it can't un-busy the survivor
+			// mid-action.
+			if (!destroyed && !token.stale()) toolbarBusy = false;
 		}
 	}
 
@@ -982,11 +999,14 @@
 
 	// THE DELETION SUBSCRIPTION (PLAN-2392 DR-5c / TASK-2477). ONE path for both
 	// origins: the toolbar's own Delete announces on the bus (the descriptor's
-	// `announceAttachmentDeleted`), and an external surface (the strip, another
-	// tab) announces the same way — so this reacts identically to both, and the
+	// `announceAttachmentDeleted`), and another in-page surface (the strip, a body
+	// NodeView) announces the same way — so this reacts identically to both, and the
 	// toolbar's ctx deliberately carries NO `onDeleted` (that close-on-delete is
-	// the PANEL's; the viewer advances instead). An event handler, not an $effect,
-	// so writing `shownId` / `tombstones` here is not a self-write.
+	// the PANEL's; the viewer advances instead). The bus is PROCESS-LOCAL, so an
+	// out-of-page delete (another tab, a job, the API) reaches this viewer as a
+	// metadata `missing` phase instead — routed through here by the effect below.
+	// An event handler, not an $effect, so writing `shownId` / `tombstones` here is
+	// not a self-write.
 	function handleDeletion(uuid: string) {
 		if (!uuid || tombstones.has(uuid)) return;
 		// Snapshot BEFORE tombstoning: the position of the deleted entry decides
@@ -1022,6 +1042,47 @@
 			shownId = after[i < after.length ? i : 0].id;
 		}
 	}
+
+	// AN AUTHORITATIVE 404 IS A DELETION BY ANOTHER DOOR (PLAN-2392 DR-17 /
+	// 3c-i final fix). The deletion bus is PROCESS-LOCAL (`events.ts`), so a delete
+	// from another browser tab, a background job, or a direct API call never
+	// announces on it — but where the metadata machine PROBES the shown attachment,
+	// its HEAD returns the `missing` phase, which is just as authoritative (DR-17).
+	// Route that id through the SAME tombstone path so advance-or-close, the id-keyed
+	// zoom reset, focus handling, and the confirm-abandon all come for free — rather
+	// than leaving stale image bytes and live Open / Download / Copy / Delete on a
+	// file that is gone. ONLY `missing` latches; a `transient` (non-404) stays
+	// retryable and never gets here.
+	//
+	// SCOPE: the machine only HEAD-probes when a seed field is null (an inline / body
+	// image seeds no size, so it probes; a strip image seeds mime AND size and is not
+	// re-probed — `surfaceMetadata`'s "nothing to complete" short-circuit). So this
+	// catches an out-of-page delete for a probed image; a strip-opened image whose
+	// file is deleted elsewhere is reconciled only if that delete also crosses the
+	// in-page bus. A blanket reachability probe for every viewer image is deliberately
+	// NOT done here (a HEAD per open, for the uncommon cross-tab case) — 3c-ii owns
+	// any always-revalidate decision.
+	//
+	// A sentinel + `untrack` keep it CONVE-1688-safe. The ONLY tracked read is
+	// `headerMeta.phase`; `img?.id` is read untracked, so an arrow-nav that changes
+	// the shown id without changing the phase can't re-fire this, and the advance's
+	// subject change (which resets the machine's phase away from `missing`) is what
+	// re-runs it for the NEXT id. `handleDeletion` is idempotent, so a whole gone set
+	// cascades advance→advance→close, one 404 at a time, and terminates.
+	let lastMissingId: string | undefined = undefined;
+	$effect(() => {
+		const missing = headerMeta.phase === 'missing';
+		untrack(() => {
+			const missingId = missing ? img?.id : undefined;
+			if (!missingId) {
+				lastMissingId = undefined;
+				return;
+			}
+			if (missingId === lastMissingId) return;
+			lastMissingId = missingId;
+			handleDeletion(missingId);
+		});
+	});
 
 	/**
 	 * Return focus where it came from, on close.
@@ -1165,6 +1226,14 @@
 		// subject-change does. `cancel()` writes the delete-confirm MODULE's state,
 		// not this effect's tracked `zoom`, so it cannot self-invalidate the flush.
 		deleteConfirm.cancel();
+		// Drop the toolbar's per-image action state too: an action that was in flight
+		// on the PREVIOUS image (a slow delete raced by this advance, or the confirmed
+		// delete that caused it) fenced itself out of the `finally` that would clear
+		// `toolbarBusy`, so zero it here — otherwise the survivor shows "Deleting…" for
+		// a request that isn't about it. `toolbarError` likewise belonged to the old
+		// image. Both are `$state` this effect never reads, so no self-invalidation.
+		toolbarBusy = false;
+		toolbarError = null;
 		// A drag live ACROSS the image change (arrow-nav mid-drag) is left with a
 		// stale baseline, and deliberately so: `resetZoom` is fit, where `clampPan`
 		// pins the pan to 0 for ANY baseline, so the next move can't jump; and the

--- a/web/src/lib/components/common/Lightbox.svelte
+++ b/web/src/lib/components/common/Lightbox.svelte
@@ -35,7 +35,10 @@
 		VIEWER_ROOT_CLASS,
 	} from '$lib/a11y/viewerBackdrop';
 	import { pushEscapeHandler, ESCAPE_PRIORITY } from '$lib/stores/escapeStack';
-	import { canOpenInViewer } from '$lib/attachments/display';
+	// The renderer registry (TASK-2476): 'raster-image' for the DR-16 allowlist,
+	// null → the no-bytes icon fallback. This is the single gate that decides the
+	// stage's ARM; the old `canOpenInViewer` last-mile FILTER is gone.
+	import { getSurfaceRenderer, type SurfaceRendererId } from '$lib/attachments/surfaceRenderers';
 	import {
 		reset as resetZoom,
 		clampState,
@@ -89,7 +92,7 @@
 	// Filename / type / size for the shown image, seeded from the LightboxImage
 	// and completed by the SAME B metadata module the panel uses (TASK-2473): it
 	// fetches only what the seed left null (DR-2 — open now, fill after).
-	import { describeAttachmentType, formatBytes } from '$lib/attachments/display';
+	import { describeAttachmentType, formatBytes, iconForAttachment } from '$lib/attachments/display';
 	import { createSurfaceMetadata } from '$lib/attachments/surfaceMetadata.svelte';
 
 	interface Props {
@@ -152,7 +155,7 @@
 	 *    not a hypothesis this component can rule out.
 	 *  - a producer added later inherits the rule instead of having to know it.
 	 *
-	 * IT FAILS CLOSED. Only a POSITIVELY allowlisted `mime_type` is viewable; a
+	 * IT FAILS CLOSED. Only a POSITIVELY allowlisted `mime_type` is navigable; a
 	 * null / undefined / unresolved one is not. "Not yet known" is not evidence
 	 * that a file is a PNG, and this is the last thing standing between a set
 	 * and a rendered image — the place where the benefit of the doubt is worth
@@ -184,14 +187,36 @@
 		return t.length > 0 ? t : null;
 	}
 
-	// INGESTION (TASK-2475). Filter to viewable, then normalize each row's blank
-	// filename to null so the display-name chain (and the toolbar's download name)
-	// fall through to `alt` rather than showing an empty string. The identity of a
-	// row with an already-clean filename is preserved (no needless re-object), so
-	// the fences downstream that key on `img.id` are unaffected.
-	let viewable = $derived(
+	// THE OPEN GATE, CAPTURED (PLAN-2392 DR-16 / TASK-2476). Entries whose RESOLVED
+	// MIME is unsafe in the INITIAL set — the 3a open gate refuses them outright and
+	// they never navigate, exactly as before, through 3c-i (3c-ii adds the file
+	// route). Snapshotted ONCE at mount, because "unsafe at open" and "unsafe
+	// mid-view" are DIFFERENT cells: an entry that FLIPS to unsafe while the viewer
+	// is open — or is added unsafe — is kept and drawn as the no-bytes fallback,
+	// where dropping it used to be the only option. The distinction can only be an
+	// open-time snapshot; a live filter cannot tell the two apart.
+	const unsafeAtOpenIds = untrack(
+		() =>
+			new Set(
+				images
+					.filter((im) => im.mime_type != null && getSurfaceRenderer(im.mime_type) === null)
+					.map((im) => im.id)
+			)
+	);
+
+	// THE NAVIGABLE SET — what ←/→ page through and the counter counts. It now KEEPS
+	// unsafe-resolved entries that appeared or flipped MID-VIEW (drawn as the
+	// no-bytes fallback arm, see `shownRenderer`), and still REFUSES:
+	//   - unresolved (null) MIME — refused-from-navigation, exactly as today; and
+	//   - unsafe entries present AT OPEN — the 3a gate, held via `unsafeAtOpenIds`.
+	// Keeping an unsafe entry is safe because its arm mounts NO bytes — the gate
+	// that used to drop it now only decides the ARM. INGESTION (TASK-2475) also
+	// normalizes each row's blank filename to null here so the display-name chain
+	// falls through to `alt`; identity is preserved for an already-clean row so the
+	// downstream fences that key on `img.id` are unaffected.
+	let navigable = $derived(
 		images
-			.filter((im) => canOpenInViewer(im.mime_type))
+			.filter((im) => im.mime_type != null && !unsafeAtOpenIds.has(im.id))
 			.map((im) => {
 				const clean = blankToNull(im.filename);
 				return clean === im.filename ? im : { ...im, filename: clean };
@@ -205,12 +230,12 @@
 	// Resolved through the ID rather than carried across as a number: filtering
 	// reindexes everything after a refusal, so the requested POSITION can name a
 	// different image (or none) in the filtered set. Where the requested image
-	// is the one refused, there is nothing to land on and the first viewable
+	// is the one refused, there is nothing to land on and the first navigable
 	// image is what opens.
 	let current = $state(
 		untrack(() => {
 			const wanted = images[Math.min(Math.max(index, 0), Math.max(images.length - 1, 0))];
-			const at = wanted ? viewable.findIndex((im) => im.id === wanted.id) : -1;
+			const at = wanted ? navigable.findIndex((im) => im.id === wanted.id) : -1;
 			return at < 0 ? 0 : at;
 		})
 	);
@@ -236,20 +261,28 @@
 		return active && active !== document.body ? (active as HTMLElement) : null;
 	});
 
-	// EVERYTHING PAST THIS POINT READS `viewable`, NEVER `images` — the nav
+	// EVERYTHING PAST THIS POINT READS `navigable`, NEVER `images` — the nav
 	// wrap-around, the counter and the rendered `<img>` alike. A single read of
 	// the unfiltered prop below would reopen the hole this filter closes.
-	let hasMultiple = $derived(viewable.length > 1);
+	let hasMultiple = $derived(navigable.length > 1);
 	// The position actually shown, clamped. `current` is what the user's ←/→
-	// moved, but the set can SHRINK underneath it — a record whose MIME resolves
-	// to something unsafe after open drops out of `viewable`, and the array can
-	// be replaced outright. Clamping in a derived (rather than writing `current`
-	// from an effect, which would be an effect writing state it reads) keeps the
-	// viewer on a real member instead of blanking or showing `undefined`.
+	// moved, but the set can SHRINK underneath it — an entry whose MIME resolves to
+	// UNRESOLVED, or is dropped from the array, leaves `navigable` (a flip to
+	// unsafe does NOT — it stays as the fallback arm). Clamping in a derived
+	// (rather than writing `current` from an effect, which would be an effect
+	// writing state it reads) keeps the viewer on a real member instead of blanking
+	// or showing `undefined`.
 	let shownIndex = $derived(
-		Math.min(Math.max(current, 0), Math.max(viewable.length - 1, 0))
+		Math.min(Math.max(current, 0), Math.max(navigable.length - 1, 0))
 	);
-	let img = $derived(viewable[shownIndex]);
+	let img = $derived(navigable[shownIndex]);
+	// THE STAGE ARM (TASK-2476). The single decision of what the stage draws for
+	// the shown entry: `'raster-image'` → the `<img>`; `null` → the no-bytes icon
+	// fallback. A navigable entry always has a resolved MIME (unresolved is refused
+	// above), so this is `'raster-image'` for safe and `null` for unsafe-mid-view.
+	let shownRenderer = $derived<SurfaceRendererId | null>(
+		img ? getSurfaceRenderer(img.mime_type) : null
+	);
 	// The accessible name: the image's own alt where there is one, else a
 	// generic label. Never empty — an unnamed `role="dialog"` is announced as
 	// nothing at all.
@@ -292,6 +325,9 @@
 	// known (the name + type never blank out), and Retry revalidates through the
 	// module rather than replaying the cached failure.
 	let headerTransient = $derived(headerMeta.phase === 'transient');
+	// The fallback arm's large icon (TASK-2476): the same family glyph the strip /
+	// panel show for this type, from the shared registry.
+	let fallbackIconId = $derived(iconForAttachment(img?.mime_type ?? null, img?.filename ?? null));
 
 	// ── Action toolbar (PLAN-2392 phase 3c-i / TASK-2474) ─────────────────────
 	//
@@ -486,13 +522,18 @@
 	// component drives it from the shown image and reports each decode / error.
 	const loader = createViewerImageLoader();
 	// The id AND the pixel dimensions, as ONE stable primitive string — never the
-	// `img` object. A prop re-emit with the same VALUES (a re-derived `viewable`
+	// `img` object. A prop re-emit with the same VALUES (a re-derived `navigable`
 	// array) must not re-fire the load effect, but a genuine dimension change (an
 	// async metadata fill that flips `unknown` → a sized class) MUST: the DR-5b
 	// policy is a function of the pixels, so a stale dimension is a stale policy.
 	// A shrink to no image collapses to `'::'`, still a change → the effect fires
-	// and releases the load.
-	let loadKey = $derived(`${img?.id ?? ''}:${img?.width ?? ''}:${img?.height ?? ''}`);
+	// and releases the load. THE ARM JOINS THE KEY (TASK-2476): a same-id
+	// safe→unsafe MIME flip keeps id + dims identical, so without the renderer in
+	// the key the load effect would not re-fire and the SAFE bytes would stay on
+	// screen behind the fallback arm — the no-bytes invariant depends on this.
+	let loadKey = $derived(
+		`${img?.id ?? ''}:${img?.width ?? ''}:${img?.height ?? ''}:${shownRenderer ?? ''}`
+	);
 	// Captured NON-reactively at load time (see the effect): a breakpoint flip
 	// alone must not reload — desktop→mobile must not abort an in-flight original,
 	// mobile→desktop must not retroactively auto-fetch (TASK-2459).
@@ -504,7 +545,27 @@
 	// act over the error UI with nothing decoded behind it. Zoom is then DISABLED,
 	// not merely a no-op (TASK-2460). A successful retry returns to loading/ready
 	// and re-enables it.
-	let bitmapPresent = $derived(!!img && !!loader.displaySrc && loader.phase !== 'error');
+	// ...and only on the RASTER arm (TASK-2476): the fallback arm has nothing
+	// decoded to transform, so zoom / pan / the zoom keys are disabled over it.
+	let bitmapPresent = $derived(
+		shownRenderer === 'raster-image' && !!img && !!loader.displaySrc && loader.phase !== 'error'
+	);
+
+	// RELEASE THE BYTES AT UNMOUNT (TASK-2476). Disposing the loader clears its
+	// state, but the `<img>` Svelte is about to remove keeps its `src` — and thus a
+	// possibly in-flight native request and its decoded bitmap — alive on the
+	// detached element until GC. Clearing the src in the element's own `destroy`
+	// aborts that request the instant the element leaves the tree, on EVERY unmount
+	// path: the arm flip to fallback, a nav to another image, and close. Belt to
+	// the loader's dispose; together the no-bytes invariant holds without waiting
+	// on the garbage collector.
+	function releaseImg(node: HTMLImageElement) {
+		return {
+			destroy() {
+				node.removeAttribute('src');
+			},
+		};
+	}
 	// The tap-to-load placeholder's box. Where dimensions are known it takes the
 	// image's own aspect ratio (so the affordance previews the shape that will
 	// arrive); where they are not, a neutral box (TASK-2460).
@@ -708,6 +769,29 @@
 		if (wasDragging) armSuppressClear();
 	}
 
+	// The event-less twin of `abortGesture`, for a REACTIVE teardown (TASK-2476):
+	// the bitmap can vanish (the arm flips to fallback) with NO further pointer
+	// event to carry the abort — the user holds still while the prop changes. This
+	// tears the same state down and releases the capture through the root (no
+	// `currentTarget` to hand `abortGesture`), so a stale gesture can neither pan
+	// the reloaded image after an A→unsafe→A flip nor leak into the next press.
+	function cancelGesture(): void {
+		if (!maybeDrag && !dragging) return;
+		const wasDragging = dragging;
+		maybeDrag = false;
+		dragging = false;
+		gesturePointerId = null;
+		if (capturedPointerId !== null) {
+			try {
+				rootEl?.releasePointerCapture(capturedPointerId);
+			} catch {
+				// already released — ignore.
+			}
+			capturedPointerId = null;
+		}
+		if (wasDragging) armSuppressClear();
+	}
+
 	function onPointerDown(e: PointerEvent) {
 		if (e.button !== 0) return; // primary button only
 		if (e.pointerType === 'touch') return; // touch stays native until 3d
@@ -815,6 +899,14 @@
 			abortGesture(e);
 			return;
 		}
+		// The bitmap vanished before release — the shown entry flipped to the
+		// fallback arm (or errored) while the pointer was down (TASK-2476). ABORT,
+		// don't finalise: there is nothing to pan, and finalising would leave the
+		// suppress-click machinery armed over a stage with no image.
+		if (!bitmapPresent) {
+			abortGesture(e);
+			return;
+		}
 		maybeDrag = false;
 		gesturePointerId = null;
 		if (dragging) {
@@ -877,12 +969,12 @@
 	// through the nav controls / arrow keys, which `hasMultiple` already hides
 	// and gates, but written so the modulo can never be `% 0`.
 	function prev() {
-		if (viewable.length === 0) return;
-		current = (shownIndex - 1 + viewable.length) % viewable.length;
+		if (navigable.length === 0) return;
+		current = (shownIndex - 1 + navigable.length) % navigable.length;
 	}
 	function next() {
-		if (viewable.length === 0) return;
-		current = (shownIndex + 1) % viewable.length;
+		if (navigable.length === 0) return;
+		current = (shownIndex + 1) % navigable.length;
 	}
 
 	/**
@@ -1035,10 +1127,34 @@
 	// breakpoint flip alone can't reload (TASK-2459).
 	$effect(() => {
 		void loadKey;
-		untrack(() => loader.load(img, openWsSlug, platform));
+		untrack(() => {
+			// THE NO-BYTES INVARIANT (TASK-2476). The raster arm loads; EVERY other arm
+			// — the fallback (unsafe/no-preview) or no image at all — DISPOSES the
+			// loader, so the arm flip releases any in-flight or decoded bitmap and
+			// issues no request. `loadKey` carries the renderer, so a same-id
+			// safe→unsafe flip actually re-runs this and reaches the dispose. The
+			// loader's own DR-16 gate (`start()`) is the backstop; the Lightbox
+			// decides no-bytes explicitly here.
+			if (shownRenderer === 'raster-image') {
+				loader.load(img, openWsSlug, platform);
+			} else {
+				loader.dispose();
+			}
+		});
 	});
 	// Drop the load on unmount (close) — one teardown, no dependencies.
 	$effect(() => () => loader.dispose());
+
+	// Reactively abort a live gesture the instant the bitmap goes away (TASK-2476).
+	// The pointer handlers catch a flip that arrives WITH an event (move / up), but
+	// the arm can flip to fallback from a PROP change while the pointer is held
+	// still — no event to carry the abort. Reads `bitmapPresent` (tracked) and
+	// tears the gesture down in `untrack` (it writes `dragging` etc., never read
+	// here), so it cannot self-invalidate (CONVE-1688).
+	$effect(() => {
+		if (bitmapPresent) return;
+		untrack(() => cancelGesture());
+	});
 
 	// Zoom-past-fit is the mobile THUMB cell's trigger to fetch the original
 	// (TASK-2460): once a thumbnail has PAINTED, zooming past FIT (`scale > 1`, not
@@ -1128,6 +1244,10 @@
 		// clears the transient phase (TASK-2475), so a keyboard user who pressed it is
 		// left on <body>; track the transient flag to re-home them the same way.
 		void headerTransient;
+		// The stage arm swap (raster ↔ fallback, TASK-2476) unmounts whatever raster
+		// control had focus — the Retry/tap-load button — and the fallback arm has no
+		// focusable content, so track the arm to re-home a stranded focus.
+		void shownRenderer;
 		const el = rootEl;
 		if (!el || !isViewerFrontmost(el) || isBlockedByModal(el)) return;
 		handoffFocus(el);
@@ -1396,7 +1516,7 @@
 		sit ABOVE the stage (their own `z-index`), never inside it.
 	-->
 	<div class="lightbox-stage" bind:this={stageEl}>
-		{#if img && loader.displaySrc}
+		{#if shownRenderer === 'raster-image' && loader.displaySrc}
 			<!--
 				KEYED ON THE LOAD TOKEN (TASK-2459). The <img> would otherwise persist
 				across navigation, and a bitmap that finished decoding LATE would fire
@@ -1425,6 +1545,7 @@
 				-->
 				<img
 					bind:this={imgEl}
+					use:releaseImg
 					class="lightbox-image"
 					class:panning={dragging}
 					src={loader.displaySrc}
@@ -1462,7 +1583,7 @@
 			{/key}
 		{/if}
 
-		{#if img && loader.phase === 'loading'}
+		{#if shownRenderer === 'raster-image' && loader.phase === 'loading'}
 			<!-- pointer-events:none so it never intercepts a pan / dblclick over the
 			     stage; the spinner is decoration over the (loading) image. -->
 			<div class="lightbox-status lightbox-loading" role="status" aria-label="Loading image">
@@ -1470,7 +1591,7 @@
 			</div>
 		{/if}
 
-		{#if img && loader.phase === 'deferred'}
+		{#if shownRenderer === 'raster-image' && loader.phase === 'deferred'}
 			<!-- The mobile large/unknown cell: DR-5b auto-fetches nothing here, so this
 			     is a TAP-TO-LOAD affordance, not a spinner (TASK-2460). The layer is
 			     inert; the button itself re-enables pointer events (the stage turns
@@ -1493,7 +1614,7 @@
 			</div>
 		{/if}
 
-		{#if img && loader.phase === 'error'}
+		{#if shownRenderer === 'raster-image' && loader.phase === 'error'}
 			<div class="lightbox-status lightbox-error" role="alert">
 				<p class="lightbox-error-text">This image couldn't be loaded.</p>
 				<!-- pointer-events:auto EXPLICITLY: the stage turns pointer events off,
@@ -1511,12 +1632,35 @@
 				</button>
 			</div>
 		{/if}
+
+		<!--
+			THE FALLBACK ARM (TASK-2476). A navigable entry the viewer cannot draw as an
+			image — an unsafe/active type that flipped or was added while open. NO
+			BYTES: no `<img>`, no `src`, no request (the load effect disposed the
+			loader on the arm flip). Just the file's identity — the large family icon,
+			its name, type · size — and an honest "No preview available". Same chrome,
+			same modal contract, same lease as the raster arm; zoom is disabled
+			(`bitmapPresent` is false here). `pointer-events: none` like the other
+			stage overlays, so a click on the empty area still reaches the backdrop.
+		-->
+		{#if img && shownRenderer !== 'raster-image'}
+			<div class="lightbox-fallback" role="group" aria-label="No preview available">
+				<span class="lightbox-fallback-icon" aria-hidden="true">
+					<AttachmentIcon id={fallbackIconId} size={72} />
+				</span>
+				<p class="lightbox-fallback-name" title={displayName}>{displayName}</p>
+				{#if headerDetail}
+					<p class="lightbox-fallback-detail">{headerDetail}</p>
+				{/if}
+				<p class="lightbox-fallback-note">No preview available</p>
+			</div>
+		{/if}
 	</div>
 
 	{#if hasMultiple}
 		<!-- `shownIndex`, so the counter names the image actually on screen even
 		     after the set shrank under `current`. -->
-		<div class="lightbox-counter">{shownIndex + 1} / {viewable.length}</div>
+		<div class="lightbox-counter">{shownIndex + 1} / {navigable.length}</div>
 	{/if}
 
 	<!--
@@ -1660,6 +1804,53 @@
 	.lightbox-loading {
 		/* Never intercept a pan / double-click over the stage. */
 		pointer-events: none;
+	}
+
+	/* The no-bytes fallback arm (TASK-2476). Centred over the stage like the status
+	   overlays; inert, so a click on the surrounding area still reaches the backdrop
+	   and closes. Logical properties + min-width:0 so a long filename ellipsizes
+	   (DR-13) rather than blowing the box out. */
+	.lightbox-fallback {
+		position: absolute;
+		inset: 0;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		gap: var(--space-2);
+		padding: var(--space-4);
+		text-align: center;
+		color: #fff;
+		pointer-events: none;
+	}
+
+	.lightbox-fallback-icon {
+		display: inline-flex;
+		color: rgba(255, 255, 255, 0.85);
+	}
+
+	.lightbox-fallback-name {
+		margin: 0;
+		max-inline-size: min(80vw, 560px);
+		min-width: 0;
+		font-size: 1rem;
+		font-weight: 600;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	.lightbox-fallback-detail {
+		margin: 0;
+		font-size: 0.85rem;
+		opacity: 0.85;
+	}
+
+	.lightbox-fallback-note {
+		margin: 0;
+		margin-block-start: var(--space-1);
+		font-size: 0.85rem;
+		opacity: 0.7;
 	}
 
 	.lightbox-spinner {

--- a/web/src/lib/components/common/Lightbox.svelte.test.ts
+++ b/web/src/lib/components/common/Lightbox.svelte.test.ts
@@ -2,6 +2,9 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { flushSync, mount, unmount } from 'svelte';
 import Lightbox from './Lightbox.svelte';
 import type { LightboxImage } from '$lib/attachments/events';
+// TASK-2477 — the deletion bus is REAL in this suite (the viewer subscribes to
+// it); firing `notifyAttachmentDeleted` drives the survivor logic directly.
+import { notifyAttachmentDeleted } from '$lib/attachments/events';
 import {
 	acquire,
 	hasForeignEscapeOwner,
@@ -3401,5 +3404,217 @@ describe('Lightbox — the fallback arm (TASK-2476)', () => {
 		// The gesture was cancelled: the capture is released and the fallback shows.
 		expect(release, 'the reactive cancel released the capture').toHaveBeenCalled();
 		expect(fallback()).not.toBeNull();
+	});
+});
+
+describe('Lightbox — deletion subscription (DR-5c / TASK-2477)', () => {
+	// The viewer subscribes to the REAL deletion bus and reconciles by IDENTITY:
+	// the shown image is tracked by id, the index derived, so a delete advances or
+	// closes (never lands on a position that now names a different member). The
+	// bus is real in this suite, so `notifyAttachmentDeleted` drives it directly.
+	function mountLive() {
+		const app = mount(Lightbox, { target: appRoot, props: liveProps });
+		mounted.push(app);
+		flushSync();
+		return app;
+	}
+	function shownAlt(): string {
+		const raster = root().querySelector<HTMLImageElement>('.lightbox-image');
+		if (raster) return raster.getAttribute('alt') ?? '';
+		return root().querySelector('.lightbox-fallback-name')?.textContent ?? '';
+	}
+	function counterText(): string | null {
+		return root().querySelector('.lightbox-counter')?.textContent ?? null;
+	}
+	function del(id: string) {
+		notifyAttachmentDeleted(id);
+		flushSync();
+	}
+
+	it('deleting the ONLY image closes the viewer', () => {
+		const onClose = vi.fn();
+		mountViewer({ images: [image(IMG_A, 'a')], onClose });
+		del(IMG_A);
+		expect(onClose).toHaveBeenCalledTimes(1);
+	});
+
+	it('deleting the SHOWN image advances to the next survivor', () => {
+		mountViewer({
+			images: [image(IMG_A, 'a'), image(IMG_B, 'b', 'image/jpeg'), image(IMG_C, 'c', 'image/gif')],
+		});
+		expect(shownAlt()).toBe('a');
+		del(IMG_A);
+		// Advanced to the one that FOLLOWED A.
+		expect(shownAlt()).toBe('b');
+		expect(counterText()).toBe('1 / 2');
+	});
+
+	it('deleting the LAST shown image wraps to the first survivor', () => {
+		mountViewer({
+			images: [image(IMG_A, 'a'), image(IMG_B, 'b', 'image/jpeg'), image(IMG_C, 'c', 'image/gif')],
+		});
+		press('ArrowRight');
+		press('ArrowRight');
+		expect(shownAlt()).toBe('c'); // on the last
+		del(IMG_C);
+		// Wrap-around: the deleted last advances to the first survivor.
+		expect(shownAlt()).toBe('a');
+		expect(counterText()).toBe('1 / 2');
+	});
+
+	it('deleting an EARLIER image keeps the SAME image shown (identity, not index)', () => {
+		mountViewer({
+			images: [image(IMG_A, 'a'), image(IMG_B, 'b', 'image/jpeg'), image(IMG_C, 'c', 'image/gif')],
+		});
+		press('ArrowRight');
+		press('ArrowRight');
+		expect(shownAlt()).toBe('c'); // position 3 of 3
+		del(IMG_A);
+		// An index-based viewer would now show B (C shifted to index 1); identity
+		// keeps C on screen.
+		expect(shownAlt()).toBe('c');
+		expect(counterText()).toBe('2 / 2');
+	});
+
+	it('deleting down to ONE image drops the counter and nav', () => {
+		mountViewer({ images: [image(IMG_A, 'a'), image(IMG_B, 'b', 'image/jpeg')] });
+		expect(counterText()).toBe('1 / 2');
+		del(IMG_A);
+		expect(shownAlt()).toBe('b');
+		expect(root().querySelector('.lightbox-counter')).toBeNull();
+		expect(root().querySelector('.lightbox-nav')).toBeNull();
+	});
+
+	it('deleting every image (zero left) closes on the last one', () => {
+		const onClose = vi.fn();
+		mountViewer({ images: [image(IMG_A, 'a'), image(IMG_B, 'b', 'image/jpeg')], onClose });
+		del(IMG_A); // → advance to B, still open
+		expect(onClose).not.toHaveBeenCalled();
+		expect(shownAlt()).toBe('b');
+		del(IMG_B); // zero left → close
+		expect(onClose).toHaveBeenCalledTimes(1);
+	});
+
+	it('reopening (a fresh mount) clears tombstones — a re-added image shows again', () => {
+		const first = mountViewer({ images: [image(IMG_A, 'a'), image(IMG_B, 'b', 'image/jpeg')] });
+		del(IMG_A);
+		expect(shownAlt()).toBe('b'); // A tombstoned for THIS instance
+		unmount(mounted.splice(mounted.indexOf(first), 1)[0]);
+		flushSync();
+
+		// A fresh instance (every producer keys the mount) with A back in the list:
+		// no cross-open tombstone leakage, so A opens.
+		mountViewer({ images: [image(IMG_A, 'a'), image(IMG_B, 'b', 'image/jpeg')] });
+		expect(shownAlt()).toBe('a');
+	});
+
+	it('an OWN toolbar delete flows through the bus identically (advance)', () => {
+		// mutationsEnabled + a full confirm→delete, but api.attachments.delete is not
+		// mocked here — so drive the announce directly (what the descriptor does on a
+		// 204) and assert the viewer reconciles it via the SAME survivor path.
+		mountViewer({
+			images: [image(IMG_A, 'a'), image(IMG_B, 'b', 'image/jpeg')],
+			mutationsEnabled: true,
+		});
+		// The bus announce (own or external) is the one path.
+		del(IMG_A);
+		expect(shownAlt()).toBe('b');
+	});
+
+	it('deletes a non-image FALLBACK entry too', () => {
+		// The survivor logic composes with D's navigable: a fallback-arm entry (an
+		// unsafe MIME that flipped mid-view) is deletable, and deleting it advances.
+		liveProps.images = [image(IMG_A, 'a'), image(IMG_B, 'b')];
+		mountLive();
+		liveProps.images = [image(IMG_A, 'a'), image(IMG_B, 'b', 'image/svg+xml')]; // B → fallback
+		flushSync();
+		press('ArrowRight'); // → B, the fallback arm
+		expect(root().querySelector('.lightbox-fallback')).not.toBeNull();
+		del(IMG_B);
+		// Advanced off the fallback back to A (the raster arm).
+		expect(shownAlt()).toBe('a');
+		expect(root().querySelector('.lightbox-fallback')).toBeNull();
+	});
+
+	it('a delete of a DIFFERENT image while the confirm drill-down is up leaves it up', () => {
+		mountViewer({
+			images: [image(IMG_A, 'a'), image(IMG_B, 'b', 'image/jpeg')],
+			mutationsEnabled: true,
+		});
+		// Open the delete confirmation on the shown image A.
+		root().querySelector<HTMLButtonElement>(
+			'.lightbox-toolbar .lightbox-tool[aria-label="Delete"]'
+		)!.click();
+		flushSync();
+		expect(root().querySelector('.lightbox-delete-confirm')).not.toBeNull();
+
+		// An EXTERNAL delete of B (not shown) — A stays shown, its confirm stays up.
+		del(IMG_B);
+		expect(shownAlt()).toBe('a');
+		expect(root().querySelector('.lightbox-delete-confirm')).not.toBeNull();
+	});
+
+	it('a delete of an unrelated attachment (not in the set) is a harmless no-op', () => {
+		const onClose = vi.fn();
+		mountViewer({ images: [image(IMG_A, 'a'), image(IMG_B, 'b', 'image/jpeg')], onClose });
+		del('ffffffff-0000-4000-8000-ffffffffffff'); // never in the set
+		expect(onClose).not.toHaveBeenCalled();
+		expect(shownAlt()).toBe('a');
+		expect(counterText()).toBe('1 / 2');
+	});
+
+	it('a delete of an already-dangling shown id is a harmless no-op (no throw)', () => {
+		// The shown image is removed straight from the PROP (not the bus), so shownId
+		// dangles and the index derives to survivors[0]. A later bus delete of that
+		// gone id must not read after[-1] or advance.
+		liveProps.images = [image(IMG_A, 'a'), image(IMG_B, 'b', 'image/jpeg')];
+		mountLive();
+		press('ArrowRight'); // shownId = B
+		expect(shownAlt()).toBe('b');
+		liveProps.images = [image(IMG_A, 'a')]; // B removed from the prop → shownId dangles
+		flushSync();
+		expect(shownAlt()).toBe('a'); // derived falls to the survivor
+		del(IMG_B); // a bus delete of the gone B — must not throw or disturb A
+		expect(shownAlt()).toBe('a');
+	});
+
+	it('a delete on an already-empty viewer does not close it', () => {
+		const onClose = vi.fn();
+		liveProps.images = [image(IMG_A, 'a')];
+		liveProps.onClose = onClose;
+		mountLive();
+		liveProps.images = []; // all removed via the prop → empty, still mounted
+		flushSync();
+		expect(root().querySelector('.lightbox-image')).toBeNull();
+		// A delete (of the gone one, or an unrelated id) must NOT close the
+		// already-empty viewer — the close is for a delete that EMPTIES a set, not one
+		// that finds it already empty.
+		del(IMG_A);
+		del('ffffffff-0000-4000-8000-ffffffffffff');
+		expect(onClose).not.toHaveBeenCalled();
+	});
+
+	it('deleting the shown image mid-DRAG advances and resets the zoom (stale drag stays harmless)', () => {
+		mountViewer({
+			images: [sized(IMG_A, 'a', 5000, 5000), sized(IMG_B, 'b', 800, 600, 'image/jpeg')],
+		});
+		mockGeometry(root(), OVERFLOW_G);
+		fireLoad(1024, 768); // A decoded → bitmapPresent, pan room
+		zoomToActual();
+		expect(scaleOf()).toBeGreaterThan(1); // zoomed in on A
+		const capture = vi.fn();
+		(root() as unknown as { setPointerCapture: unknown }).setPointerCapture = capture;
+		root().dispatchEvent(pointerEvent('pointerdown', 500, 500));
+		root().dispatchEvent(pointerEvent('pointermove', 560, 500)); // engage the drag
+		flushSync();
+		expect(capture, 'the drag armed on A').toHaveBeenCalled();
+
+		// A is deleted while the drag is live → advance to B, and the id-keyed reset
+		// returns the transform to fit. The stale drag baseline is deliberately LEFT
+		// (as arrow-nav mid-drag does) but harmless: at fit `clampPan` pins the pan to
+		// 0, so no baseline can jump the image.
+		del(IMG_A);
+		expect(shownAlt()).toBe('b');
+		expect(scaleOf(), 'the advance reset the transform to fit').toBe(1);
 	});
 });

--- a/web/src/lib/components/common/Lightbox.svelte.test.ts
+++ b/web/src/lib/components/common/Lightbox.svelte.test.ts
@@ -3554,6 +3554,33 @@ describe('Lightbox — deletion subscription (DR-5c / TASK-2477)', () => {
 		expect(root().querySelector('.lightbox-delete-confirm')).not.toBeNull();
 	});
 
+	it('a delete of the SHOWN image while its own confirm is up advances with a CLEAN toolbar', () => {
+		// The confirm gate holds `runToolbarAction` awaiting inside `run`, so
+		// `toolbarBusy` is true the whole time the drill-down is up. An external delete
+		// of that same shown image (another in-page surface, or — via the metadata
+		// `missing` path — another tab) advances to a survivor; the subject-change reset
+		// must zero `toolbarBusy`, or the survivor's Delete shows a stale "Deleting…" for
+		// a request that was never about it. The fenced `finally` deliberately does NOT
+		// clear it (the continuation is stale), so this asserts the reset is load-bearing.
+		mountViewer({
+			images: [image(IMG_A, 'a'), image(IMG_B, 'b', 'image/jpeg')],
+			mutationsEnabled: true,
+		});
+		root().querySelector<HTMLButtonElement>(
+			'.lightbox-toolbar .lightbox-tool[aria-label="Delete"]'
+		)!.click();
+		flushSync();
+		expect(root().querySelector('.lightbox-delete-confirm')).not.toBeNull();
+
+		del(IMG_A); // the shown image is deleted from under the open confirm
+		expect(shownAlt()).toBe('b'); // advanced to the survivor
+		expect(root().querySelector('.lightbox-delete-confirm')).toBeNull(); // confirm abandoned
+		const deleteLabel = root()
+			.querySelector('.lightbox-toolbar .lightbox-tool[aria-label="Delete"] .lightbox-tool-label')
+			?.textContent?.trim();
+		expect(deleteLabel).toBe('Delete'); // NOT the stale "Deleting…"
+	});
+
 	it('a delete of an unrelated attachment (not in the set) is a harmless no-op', () => {
 		const onClose = vi.fn();
 		mountViewer({ images: [image(IMG_A, 'a'), image(IMG_B, 'b', 'image/jpeg')], onClose });
@@ -3616,5 +3643,68 @@ describe('Lightbox — deletion subscription (DR-5c / TASK-2477)', () => {
 		del(IMG_A);
 		expect(shownAlt()).toBe('b');
 		expect(scaleOf(), 'the advance reset the transform to fit').toBe(1);
+	});
+
+	// ── The metadata `missing` phase as a deletion (3c-i final fix) ────────────
+	// The deletion bus is process-local, so an out-of-page delete (another tab, a
+	// job, the API) reaches the viewer only as the metadata machine's authoritative
+	// `missing` (404) phase — which routes through the SAME tombstone path.
+	// Interleave a microtask drain with an effect flush per hop: a cascade (each 404
+	// advances to the next, whose OWN async HEAD then 404s) needs the effect to run
+	// BETWEEN async resolutions, not once at the end.
+	async function settleAsync() {
+		for (let i = 0; i < 8; i++) {
+			await Promise.resolve();
+			flushSync();
+		}
+	}
+
+	it('an authoritative metadata 404 (missing) for the shown image advances to a survivor', async () => {
+		metaFetch.mockImplementation((_ws: unknown, uuid: string) =>
+			Promise.resolve(
+				uuid === IMG_A
+					? { status: 'missing' as const }
+					: { status: 'ok' as const, mime: 'image/png', size: 2048 }
+			)
+		);
+		mountViewer({ images: [image(IMG_A, 'a'), image(IMG_B, 'b', 'image/jpeg')] });
+		await settleAsync();
+		// A's HEAD 404'd → A is tombstoned → advance to B; the set is now single.
+		expect(shownAlt()).toBe('b');
+		expect(counterText()).toBeNull();
+	});
+
+	it('an authoritative metadata 404 for the ONLY image closes the viewer', async () => {
+		const onClose = vi.fn();
+		metaFetch.mockResolvedValue({ status: 'missing' });
+		mountViewer({ images: [image(IMG_A, 'a')], onClose });
+		await settleAsync();
+		expect(onClose).toHaveBeenCalledTimes(1);
+	});
+
+	it('an ENTIRE set going missing cascades advance→advance→close (terminates)', async () => {
+		const onClose = vi.fn();
+		// Every image 404s: A advances to B, B's own probe 404s and advances to C,
+		// C's 404 empties the set → close. The effect re-runs once per subject change
+		// (each HEAD is async), so the cascade settles rather than looping.
+		metaFetch.mockResolvedValue({ status: 'missing' });
+		mountViewer({
+			images: [image(IMG_A, 'a'), image(IMG_B, 'b', 'image/jpeg'), image(IMG_C, 'c', 'image/gif')],
+			onClose,
+		});
+		await settleAsync();
+		expect(onClose).toHaveBeenCalledTimes(1);
+	});
+
+	it('a TRANSIENT metadata failure does NOT delete the shown image (DR-17)', async () => {
+		const onClose = vi.fn();
+		metaFetch.mockResolvedValue({ status: 'transient' });
+		mountViewer({ images: [image(IMG_A, 'a'), image(IMG_B, 'b', 'image/jpeg')], onClose });
+		await settleAsync();
+		// A non-404 failure is retryable, never a deletion — the viewer stays on A and
+		// shows the header's inline retry instead.
+		expect(shownAlt()).toBe('a');
+		expect(onClose).not.toHaveBeenCalled();
+		expect(root().querySelector('.lightbox-meta-error')).not.toBeNull();
 	});
 });

--- a/web/src/lib/components/common/Lightbox.svelte.test.ts
+++ b/web/src/lib/components/common/Lightbox.svelte.test.ts
@@ -27,6 +27,9 @@ import {
 // naming a specific control. The toolbar (TASK-2474) added controls after the
 // nav, so the trailing edge is no longer `.lightbox-nav.next`.
 import { paneFocusables } from '$lib/collections/paneFocus';
+// TASK-2475 — the metadata header renders type/size through these; the tests
+// compute their expected strings from the same helpers rather than hardcoding.
+import { describeAttachmentType, formatBytes } from '$lib/attachments/display';
 
 // TASK-2460 — the mobile DR-5b cells. `viewport.isMobile` is module state read
 // from matchMedia at init (false under jsdom), so a controllable mock lets a few
@@ -51,6 +54,19 @@ vi.mock('$lib/stores/breakpoint.svelte', () => ({
 }));
 let mobileFlag = $state(false);
 mobileHolder.read = () => mobileFlag;
+
+// TASK-2475 — the metadata header's B-module fetch. The viewer's images seed
+// `size_bytes: null` by default (the `image()` fixture), so the header module
+// fires a HEAD to fill it; controlling the result lets the header tests assert
+// the fill / transient-retry paths, and keeps the real (failing) fetch out of
+// every OTHER test. Defaulted to `ok` in `beforeEach`.
+const metaFetch = vi.hoisted(() => vi.fn());
+const metaRevalidate = vi.hoisted(() => vi.fn());
+vi.mock('$lib/components/editor/attachment-metadata', () => ({
+	fetchAttachmentMetadata: (...a: unknown[]) => metaFetch(...a),
+	revalidateAttachmentMetadata: (...a: unknown[]) => metaRevalidate(...a),
+	invalidateAttachmentMetadata: vi.fn(),
+}));
 
 // TASK-2429 — the DR-4b modal contract on the attachment viewer.
 //
@@ -216,6 +232,12 @@ function inertBodyChildren(): Element[] {
 }
 
 beforeEach(() => {
+	// Reset call history AND the resolved value each test, so a `toHaveBeenCalled`
+	// / call-count assertion can never read a prior test's invocation.
+	metaFetch.mockReset();
+	metaRevalidate.mockReset();
+	metaFetch.mockResolvedValue({ status: 'ok', mime: 'image/png', size: 2048 });
+	metaRevalidate.mockResolvedValue({ status: 'ok', mime: 'image/png', size: 2048 });
 	HTMLElement.prototype.getClientRects = function () {
 		return [{}] as unknown as DOMRectList;
 	};
@@ -3053,5 +3075,145 @@ describe('Lightbox — action toolbar (TASK-2474)', () => {
 			})
 		).toBe(true);
 		expect(scaleOf()).toBeGreaterThan(before);
+	});
+});
+
+describe('Lightbox — metadata header (TASK-2475)', () => {
+	// Filename / type / size for the shown image, seeded from the LightboxImage and
+	// completed by the B module. The metadata mock (top of file) controls the HEAD.
+	function metaImage(over: Partial<LightboxImage> = {}): LightboxImage {
+		return {
+			id: IMG_A,
+			alt: 'a diagram',
+			filename: 'photo.png',
+			mime_type: 'image/png',
+			size_bytes: 2048,
+			width: null,
+			height: null,
+			...over,
+		};
+	}
+	function metaName(): string | null {
+		return root().querySelector('.lightbox-meta-name')?.textContent ?? null;
+	}
+	function metaDetail(): string | null {
+		return root().querySelector('.lightbox-meta-detail')?.textContent ?? null;
+	}
+	function metaError(): HTMLElement | null {
+		return root().querySelector('.lightbox-meta-error');
+	}
+	async function settleAsync() {
+		for (let i = 0; i < 5; i++) await Promise.resolve();
+		flushSync();
+	}
+
+	it('renders filename, type and size from a complete seed without fetching', async () => {
+		mountViewer({ images: [metaImage()] });
+		await settleAsync();
+		expect(metaName()).toBe('photo.png');
+		expect(metaDetail()).toBe(
+			`${describeAttachmentType('image/png', 'photo.png')} · ${formatBytes(2048)}`
+		);
+		// Seed carries both MIME and size, so no HEAD fires (DR-2's "fetch only what
+		// is null").
+		expect(metaFetch).not.toHaveBeenCalled();
+	});
+
+	it('falls back filename → alt when the filename is null', async () => {
+		mountViewer({ images: [metaImage({ filename: null })] });
+		await settleAsync();
+		expect(metaName()).toBe('a diagram');
+	});
+
+	it('treats a whitespace-only filename as absent and uses alt', async () => {
+		mountViewer({ images: [metaImage({ filename: '   ' })] });
+		await settleAsync();
+		expect(metaName()).toBe('a diagram');
+	});
+
+	it('falls back to the generic label when filename AND alt are blank', async () => {
+		mountViewer({ images: [metaImage({ filename: null, alt: '' })] });
+		await settleAsync();
+		expect(metaName()).toBe('Attachment');
+	});
+
+	it('treats a whitespace-only alt as blank too, reaching the generic label', async () => {
+		// The chain blank-normalizes alt, not just filename — an all-spaces alt must
+		// not win over 'Attachment' as an empty-but-present string would.
+		mountViewer({ images: [metaImage({ filename: null, alt: '   ' })] });
+		await settleAsync();
+		expect(metaName()).toBe('Attachment');
+	});
+
+	it('omits the size half when size stays unknown — detail is type only, no "0 B"', async () => {
+		// A viewer image always has a known MIME (the last-mile gate), so the
+		// type-omitted branch is unreachable here; what IS reachable is a null size
+		// that the fetch fails to fill. The detail must then be TYPE ONLY, with no
+		// stray " · " and no "0 B" (formatBytes is never fed null).
+		metaFetch.mockResolvedValue({ status: 'transient' });
+		mountViewer({ images: [metaImage({ size_bytes: null })] });
+		await settleAsync();
+		expect(metaName()).toBe('photo.png');
+		expect(metaDetail()).toBe(describeAttachmentType('image/png', 'photo.png'));
+	});
+
+	it('fetches to fill a null size and updates the detail line', async () => {
+		metaFetch.mockResolvedValue({ status: 'ok', mime: 'image/png', size: 4096 });
+		mountViewer({ images: [metaImage({ size_bytes: null })] });
+		await settleAsync();
+		expect(metaFetch).toHaveBeenCalled();
+		expect(metaDetail()).toContain(formatBytes(4096));
+	});
+
+	it('a fetched field never overwrites a non-null seed', async () => {
+		// Seed MIME is the image PNG; the fetch returns a VISIBLY DIFFERENT type
+		// family (application/pdf) plus a size. The size fills (was null) but the type
+		// must stay the seed's — fields merge seed-wins. The fetched family is chosen
+		// distinct from the seed's on purpose: `image/gif` also labels as "Image", so
+		// an overwrite bug would have slipped through; a PDF label would not.
+		metaFetch.mockResolvedValue({ status: 'ok', mime: 'application/pdf', size: 4096 });
+		mountViewer({ images: [metaImage({ filename: null, size_bytes: null })] });
+		await settleAsync();
+		const seededType = describeAttachmentType('image/png', null);
+		expect(seededType).not.toBe(describeAttachmentType('application/pdf', null));
+		expect(metaDetail()).toBe(`${seededType} · ${formatBytes(4096)}`);
+	});
+
+	it('shows a retryable error beside the name on a transient failure, then recovers', async () => {
+		metaFetch.mockResolvedValue({ status: 'transient' });
+		mountViewer({ images: [metaImage({ size_bytes: null })] });
+		await settleAsync();
+		// Beside what it already knows — never a blank sheet (DR-10).
+		expect(metaName()).toBe('photo.png');
+		expect(metaError()).not.toBeNull();
+
+		// Retry REVALIDATES (invalidate-then-fetch), never replays the cached failure.
+		metaRevalidate.mockResolvedValue({ status: 'ok', mime: 'image/png', size: 8192 });
+		const retryBtn = root().querySelector<HTMLButtonElement>('.lightbox-meta-retry')!;
+		retryBtn.focus();
+		retryBtn.click();
+		await settleAsync();
+		expect(metaRevalidate).toHaveBeenCalled();
+		expect(metaError()).toBeNull();
+		expect(metaDetail()).toContain(formatBytes(8192));
+		// Retry unmounts on success (the transient state clears); focus must not be
+		// stranded on <body> outside the modal — it is re-homed into the viewer.
+		expect(document.activeElement).not.toBe(document.body);
+		expect(root().contains(document.activeElement)).toBe(true);
+	});
+
+	it('ellipsizes a 200-char filename while the accessible name carries it in full', async () => {
+		const long = 'a'.repeat(196) + '.png';
+		expect(long.length).toBe(200);
+		mountViewer({ images: [metaImage({ filename: long })] });
+		await settleAsync();
+		const nameEl = root().querySelector<HTMLElement>('.lightbox-meta-name')!;
+		// The FULL value is in title (DR-13) and in the element text — that is the
+		// info-preservation half, and it is what jsdom can prove. The VISUAL ellipsis
+		// (overflow/text-overflow/nowrap on `.lightbox-meta-name`) is not applied by
+		// jsdom's `getComputedStyle` (it ignores scoped `<style>` rules), so it is a
+		// browser-suite concern, like every other measured-layout claim in this file.
+		expect(nameEl.getAttribute('title')).toBe(long);
+		expect(nameEl.textContent).toBe(long);
 	});
 });

--- a/web/src/lib/components/common/Lightbox.svelte.test.ts
+++ b/web/src/lib/components/common/Lightbox.svelte.test.ts
@@ -22,6 +22,11 @@ import {
 	ZOOM_STEP,
 	type Geometry,
 } from '$lib/attachments/zoom';
+// The viewer's real focusable-selection path — the trap cycles over exactly this
+// set, so the tests below derive the leading / trailing edge from it rather than
+// naming a specific control. The toolbar (TASK-2474) added controls after the
+// nav, so the trailing edge is no longer `.lightbox-nav.next`.
+import { paneFocusables } from '$lib/collections/paneFocus';
 
 // TASK-2460 — the mobile DR-5b cells. `viewport.isMobile` is module state read
 // from matchMedia at init (false under jsdom), so a controllable mock lets a few
@@ -102,6 +107,10 @@ interface Props {
 	wsSlug: string;
 	onClose: () => void;
 	invoker?: HTMLElement | null;
+	// Toolbar context (TASK-2474).
+	mutationsEnabled?: boolean;
+	getItemContent?: () => string | null;
+	getLiveContent?: () => string | null;
 }
 
 // Reactive props for the capture-at-open cases ($state may only initialize a
@@ -111,6 +120,17 @@ const liveProps = $state<Props>({
 	index: 0,
 	wsSlug: 'ws-one',
 	onClose: () => {},
+});
+
+// Reactive props for the toolbar's permission-withdrawn case (TASK-2474): a
+// peek closes the mutation gate mid-confirmation, and `mutationsEnabled` has to
+// be flippable live to drive it.
+const toolbarProps = $state<Props>({
+	images: [image(IMG_A, 'a diagram')],
+	index: 0,
+	wsSlug: 'ws-one',
+	onClose: () => {},
+	mutationsEnabled: true,
 });
 
 /** The app shell's stand-in: a body child, so the manager has something to inert. */
@@ -149,6 +169,17 @@ function imageSrc(scope: HTMLElement = root()): string {
 
 function closeButton(scope: HTMLElement = root()): HTMLButtonElement {
 	return scope.querySelector<HTMLButtonElement>('.lightbox-close')!;
+}
+
+/** The viewer's focusable controls, in tab order — what the trap cycles over. */
+function focusables(scope: HTMLElement = root()): HTMLElement[] {
+	return paneFocusables(scope);
+}
+
+/** The trailing edge of the trap — the last focusable control. */
+function lastFocusable(scope: HTMLElement = root()): HTMLElement {
+	const f = focusables(scope);
+	return f[f.length - 1];
 }
 
 /** The `transform` inline style on the viewer's image (empty before it mounts). */
@@ -521,8 +552,10 @@ describe('Lightbox — focus', () => {
 				image(IMG_B, 'second'),
 			],
 		});
-		const controls = Array.from(root().querySelectorAll('button'));
-		expect(controls).toHaveLength(3);
+		// More than one focusable, so "first" is separable from "a"/"the root":
+		// close, prev, next, plus the toolbar's open/download/copy-link (TASK-2474).
+		const controls = focusables();
+		expect(controls.length).toBeGreaterThan(1);
 		expect(document.activeElement).toBe(controls[0]);
 		expect(document.activeElement).toBe(closeButton());
 		expect(document.activeElement).not.toBe(root());
@@ -639,8 +672,8 @@ describe('Lightbox — Tab trap', () => {
 				image(IMG_B, 'second'),
 			],
 		});
-		const next = root().querySelector<HTMLButtonElement>('.lightbox-nav.next')!;
-		next.focus();
+		// The trailing edge is the last toolbar control now, not the nav (TASK-2474).
+		lastFocusable().focus();
 
 		expect(press('Tab')).toBe(true);
 		expect(document.activeElement).toBe(closeButton());
@@ -656,9 +689,7 @@ describe('Lightbox — Tab trap', () => {
 		closeButton().focus();
 
 		expect(press('Tab', { shiftKey: true })).toBe(true);
-		expect(document.activeElement).toBe(
-			root().querySelector<HTMLButtonElement>('.lightbox-nav.next')
-		);
+		expect(document.activeElement).toBe(lastFocusable());
 	});
 
 	it('pulls focus back to the leading edge when it has escaped the viewer', () => {
@@ -680,9 +711,7 @@ describe('Lightbox — Tab trap', () => {
 		// ...and the trailing edge on a back Tab from outside.
 		outside.focus();
 		expect(press('Tab', { shiftKey: true })).toBe(true);
-		expect(document.activeElement).toBe(
-			root().querySelector('.lightbox-nav.next')
-		);
+		expect(document.activeElement).toBe(lastFocusable());
 	});
 
 	it('leaves a mid-cycle Tab to the browser', () => {
@@ -1495,8 +1524,7 @@ describe('Lightbox — Tab still cycles at maximum zoom (TASK-2456)', () => {
 		for (let i = 0; i < 10; i++) press('+');
 		expect(scaleOf()).toBeCloseTo(4);
 
-		const nextBtn = root().querySelector<HTMLButtonElement>('.lightbox-nav.next')!;
-		nextBtn.focus();
+		lastFocusable().focus();
 		expect(press('Tab')).toBe(true);
 		expect(root().contains(document.activeElement)).toBe(true);
 		expect(document.activeElement).toBe(closeButton());
@@ -2770,5 +2798,260 @@ describe('Lightbox — re-clamp on same-id decode + inert error state (TASK-2461
 		root().dispatchEvent(pointerEvent('pointermove', 720, 500));
 		flushSync();
 		expect(panX(), 'the drag aborted; no further pan over the error UI').toBeCloseTo(panned);
+	});
+});
+
+describe('Lightbox — action toolbar (TASK-2474)', () => {
+	// The shared descriptor list, drawn over the stage. The viewer only ever holds
+	// IMAGES, so Open/Download/Copy-link always apply; Delete is gated on the
+	// host's `mutationsEnabled`. `api.attachments.delete` is NOT mocked in this
+	// file, so these cases stop at the confirmation GATE (open / cancel / abandon)
+	// — the full delete network path is the strip/host origin tests' (which mock
+	// it). Here the module's own state machine is what is under test.
+	function toolbar(scope: HTMLElement = root()): HTMLElement | null {
+		return scope.querySelector<HTMLElement>('.lightbox-toolbar');
+	}
+	function tools(scope: HTMLElement = root()): HTMLElement[] {
+		return Array.from(scope.querySelectorAll<HTMLElement>('.lightbox-tool'));
+	}
+	function toolLabels(scope: HTMLElement = root()): string[] {
+		return tools(scope).map((t) => t.getAttribute('aria-label') ?? '');
+	}
+	function tool(label: string, scope: HTMLElement = root()): HTMLElement {
+		const found = tools(scope).find((t) => t.getAttribute('aria-label') === label);
+		if (!found) throw new Error(`no toolbar control labelled ${label}`);
+		return found;
+	}
+
+	beforeEach(() => {
+		Object.assign(toolbarProps, {
+			images: [image(IMG_A, 'a diagram')],
+			index: 0,
+			wsSlug: 'ws-one',
+			onClose: () => {},
+			mutationsEnabled: true,
+			getItemContent: undefined,
+			getLiveContent: undefined,
+		});
+	});
+
+	it('renders the read-only actions with no Delete when mutations are disabled', () => {
+		mountViewer({ mutationsEnabled: false });
+		expect(toolbar()).not.toBeNull();
+		const labels = toolLabels();
+		expect(labels).toContain('Open in new tab');
+		expect(labels).toContain('Download');
+		expect(labels).toContain('Copy workspace link');
+		expect(labels).not.toContain('Delete');
+	});
+
+	it('defaults to read-only (no Delete) when mutationsEnabled is omitted', () => {
+		mountViewer();
+		expect(toolbar()).not.toBeNull();
+		expect(toolLabels()).not.toContain('Delete');
+	});
+
+	it('offers Delete when the host granted mutationsEnabled', () => {
+		mountViewer({ mutationsEnabled: true });
+		expect(toolLabels()).toContain('Delete');
+	});
+
+	it('renders Open and Download as real anchors carrying href/download/target', () => {
+		mountViewer({ mutationsEnabled: false, images: [image(IMG_A, 'a diagram')] });
+		const open = tool('Open in new tab');
+		const download = tool('Download');
+		expect(open.tagName).toBe('A');
+		expect(open.getAttribute('href')).toContain(`/workspaces/ws-one/attachments/${IMG_A}`);
+		expect(open.getAttribute('target')).toBe('_blank');
+		expect(open.getAttribute('rel')).toBe('noopener noreferrer');
+		expect(download.tagName).toBe('A');
+		expect(download.getAttribute('href')).toContain(`/workspaces/ws-one/attachments/${IMG_A}`);
+		// A REAL download attribute, not decoration — the value is the display name.
+		expect(download.hasAttribute('download')).toBe(true);
+	});
+
+	it('renders Copy-link and Delete as buttons, not anchors', () => {
+		mountViewer({ mutationsEnabled: true });
+		expect(tool('Copy workspace link').tagName).toBe('BUTTON');
+		expect(tool('Delete').tagName).toBe('BUTTON');
+	});
+
+	it('drills down to the shared confirmation and back on Cancel (DR-18)', () => {
+		mountViewer({ mutationsEnabled: true });
+		tool('Delete').click();
+		flushSync();
+		// The action buttons are replaced by the shared confirm rows.
+		const confirm = root().querySelector('.lightbox-delete-confirm');
+		expect(confirm).not.toBeNull();
+		expect(tools()).toHaveLength(0);
+		// MenuItem rows carry a leading glyph in their text, so match on substrings.
+		const rows = Array.from(confirm!.querySelectorAll<HTMLElement>('button')).map(
+			(b) => b.textContent?.trim() ?? ''
+		);
+		expect(rows.some((r) => r.includes('Cancel'))).toBe(true);
+		expect(rows.some((r) => r.includes('Delete file'))).toBe(true);
+		// The hedged (not-referenced) arm, since no content getter was threaded.
+		expect(confirm!.querySelector('.attachment-delete-prompt')?.textContent).toContain(
+			'may still be referenced'
+		);
+
+		// Cancel returns to the toolbar without deleting anything.
+		Array.from(confirm!.querySelectorAll('button'))
+			.find((b) => b.textContent?.includes('Cancel'))!
+			.click();
+		flushSync();
+		expect(root().querySelector('.lightbox-delete-confirm')).toBeNull();
+		expect(toolLabels()).toContain('Delete');
+	});
+
+	it('warns about a live reference when the body still uses the attachment', () => {
+		// The delete-warning check reads the live getter at confirm time (DR-5).
+		mountViewer({
+			mutationsEnabled: true,
+			getLiveContent: () => `text ![x](pad-attachment:${IMG_A}) more`,
+		});
+		tool('Delete').click();
+		flushSync();
+		expect(root().querySelector('.attachment-delete-prompt')?.textContent).toContain(
+			"still used in this item's content"
+		);
+	});
+
+	it('abandons an open confirmation when mutation permission is withdrawn', () => {
+		// A pane going peeked closes the mutation gate mid-confirmation; the shared
+		// module abandons the drill-down rather than leaving a live Delete button for
+		// an action that can no longer happen (DR-8). Driven through a reactive prop.
+		mounted.push(mount(Lightbox, { target: appRoot, props: toolbarProps }));
+		flushSync();
+		tool('Delete').click();
+		flushSync();
+		expect(root().querySelector('.lightbox-delete-confirm')).not.toBeNull();
+
+		toolbarProps.mutationsEnabled = false;
+		flushSync();
+		// The confirmation is gone AND Delete is no longer offered.
+		expect(root().querySelector('.lightbox-delete-confirm')).toBeNull();
+		expect(toolLabels()).not.toContain('Delete');
+	});
+
+	it('shows no toolbar when the set is empty', () => {
+		// An unresolved-MIME image is filtered out of `viewable`, leaving no `img`.
+		mountViewer({ images: [image(IMG_A, 'unprobed', null)] });
+		expect(toolbar()).toBeNull();
+	});
+
+	// ── Codex-review fixes (TASK-2474) ────────────────────────────────────────
+
+	it('renders the drill-down as a role="menu" of role="menuitem" rows', () => {
+		// The confirm rows are role="menuitem" (from MenuItem); they must be parented
+		// by role="menu", NOT the actions' role="toolbar".
+		mountViewer({ mutationsEnabled: true });
+		tool('Delete').click();
+		flushSync();
+		const menu = root().querySelector('.lightbox-delete-confirm');
+		expect(menu?.getAttribute('role')).toBe('menu');
+		expect(menu?.querySelectorAll('[role="menuitem"]').length).toBeGreaterThanOrEqual(2);
+		// ...and the toolbar's role="toolbar" is gone while confirming (not nesting a
+		// menu inside a toolbar).
+		expect(root().querySelector('[role="toolbar"]')).toBeNull();
+	});
+
+	it('moves focus to the first drill-down row and rovers the tab stop', () => {
+		mountViewer({ mutationsEnabled: true });
+		tool('Delete').click();
+		flushSync();
+		const rows = Array.from(
+			root().querySelectorAll<HTMLElement>('.lightbox-delete-confirm [role="menuitem"]')
+		);
+		// Cancel is first (the shared confirm's order), and focus lands on it.
+		expect(document.activeElement).toBe(rows[0]);
+		// Roving tabindex: exactly the active row is in the tab order, the rest are
+		// -1 — so Tab EXITS the menu to the chrome (ARIA menu), not between rows.
+		expect(rows[0].tabIndex).toBe(0);
+		expect(rows.slice(1).every((r) => r.tabIndex === -1)).toBe(true);
+	});
+
+	it('Up/Down move focus between drill-down rows and roll the tab stop', () => {
+		mountViewer({ mutationsEnabled: true });
+		tool('Delete').click();
+		flushSync();
+		const rows = Array.from(
+			root().querySelectorAll<HTMLElement>('.lightbox-delete-confirm [role="menuitem"]')
+		);
+		expect(document.activeElement).toBe(rows[0]);
+		expect(press('ArrowDown')).toBe(true);
+		expect(document.activeElement).toBe(rows[1]);
+		expect(rows[1].tabIndex).toBe(0);
+		expect(rows[0].tabIndex).toBe(-1);
+	});
+
+	it('Escape backs out of the drill-down before it closes the viewer', () => {
+		const onClose = vi.fn();
+		mounted.push(
+			mount(Lightbox, { target: appRoot, props: { ...toolbarProps, onClose } })
+		);
+		flushSync();
+		tool('Delete').click();
+		flushSync();
+		expect(root().querySelector('.lightbox-delete-confirm')).not.toBeNull();
+
+		// First Escape cancels the confirmation; the viewer stays open.
+		expect(runTopEscape()).toBe(true);
+		flushSync();
+		expect(root().querySelector('.lightbox-delete-confirm')).toBeNull();
+		expect(onClose).not.toHaveBeenCalled();
+
+		// Second Escape closes the viewer.
+		expect(runTopEscape()).toBe(true);
+		flushSync();
+		expect(onClose).toHaveBeenCalledTimes(1);
+	});
+
+	it('abandons the drill-down when the shown image changes under it', () => {
+		// A delete elsewhere shrinks the set so a DIFFERENT member is shown; a
+		// confirmation for the gone image must not linger over the new one.
+		Object.assign(toolbarProps, {
+			images: [image(IMG_A, 'first'), image(IMG_B, 'second')],
+		});
+		mounted.push(mount(Lightbox, { target: appRoot, props: toolbarProps }));
+		flushSync();
+		tool('Delete').click();
+		flushSync();
+		expect(root().querySelector('.lightbox-delete-confirm')).not.toBeNull();
+
+		// The shown image (A) drops out; B moves into view.
+		toolbarProps.images = [image(IMG_B, 'second')];
+		flushSync();
+		expect(root().querySelector('.lightbox-delete-confirm')).toBeNull();
+	});
+
+	it('consumes a wheel over the toolbar without zooming the image', () => {
+		mountViewer({ mutationsEnabled: false });
+		fireLoad(2000, 2000);
+		mockGeometry(root(), {
+			stageW: 1000,
+			stageH: 1000,
+			fittedW: 900,
+			fittedH: 900,
+			naturalW: 2000,
+			naturalH: 2000,
+		});
+		const before = scaleOf();
+
+		// A wheel over a toolbar control is consumed (the modal owns the wheel) but
+		// must NOT zoom.
+		expect(wheel(tool('Download'), { deltaY: -100, clientX: 500, clientY: 500 })).toBe(true);
+		expect(scaleOf()).toBe(before);
+
+		// Control: the SAME wheel over the image DOES zoom — so the exclusion is what
+		// stopped the toolbar wheel, not a dead wheel path.
+		expect(
+			wheel(root().querySelector<HTMLElement>('.lightbox-image')!, {
+				deltaY: -100,
+				clientX: 500,
+				clientY: 500,
+			})
+		).toBe(true);
+		expect(scaleOf()).toBeGreaterThan(before);
 	});
 });

--- a/web/src/lib/components/common/Lightbox.svelte.test.ts
+++ b/web/src/lib/components/common/Lightbox.svelte.test.ts
@@ -338,6 +338,17 @@ describe('Lightbox — the last-mile open gate (TASK-2431)', () => {
 		expect(root().querySelector('.lightbox-nav')).toBeNull();
 	});
 
+	it('refuses an unsafe entry at open outright — NO fallback, not navigable (3a gate)', () => {
+		// TASK-2476 matrix, the security boundary: unsafe AT OPEN stays REFUSED (the
+		// 3a gate holds through 3c-i) — distinct from unsafe MID-VIEW, which is the
+		// fallback. So the SVG here is neither rendered NOR shown as a fallback, and
+		// the set is single-member.
+		mountViewer({ images: [image(IMG_A, 'png', 'image/png'), image(IMG_B, 'svg', 'image/svg+xml')] });
+		expect(root().querySelector('.lightbox-fallback')).toBeNull();
+		expect(root().querySelector('.lightbox-counter')).toBeNull();
+		expect(root().querySelector('.lightbox-image')?.getAttribute('alt')).toBe('png');
+	});
+
 	it('cannot be paged onto one with ←/→', () => {
 		mountViewer({
 			images: [
@@ -389,6 +400,9 @@ describe('Lightbox — the last-mile open gate (TASK-2431)', () => {
 		// image; "not yet known" is not evidence that a file is a PNG.
 		mountViewer({ images: [image(IMG_A, 'unprobed', null)] });
 		expect(root().querySelector('.lightbox-image')).toBeNull();
+		// An UNRESOLVED MIME is refused from navigation entirely — not even the
+		// fallback (that is for RESOLVED-unsafe mid-view entries, TASK-2476).
+		expect(root().querySelector('.lightbox-fallback')).toBeNull();
 	});
 
 	it('cannot be paged onto an unresolved sibling', () => {
@@ -410,6 +424,9 @@ describe('Lightbox — the last-mile open gate (TASK-2431)', () => {
 		mountViewer({ images: [image(IMG_B, 'svg', 'image/svg+xml')] });
 
 		expect(root().querySelector('.lightbox-image')).toBeNull();
+		// A single UNSAFE-at-open entry is refused outright — no image AND no
+		// fallback (the fallback is mid-view only, TASK-2476).
+		expect(root().querySelector('.lightbox-fallback')).toBeNull();
 		// Still a real dialog with a way out — the failure mode is an empty
 		// viewer, never a rendered one.
 		expect(closeButton()).not.toBeNull();
@@ -417,6 +434,7 @@ describe('Lightbox — the last-mile open gate (TASK-2431)', () => {
 		press('ArrowRight');
 		press('ArrowLeft');
 		expect(root().querySelector('.lightbox-image')).toBeNull();
+		expect(root().querySelector('.lightbox-fallback')).toBeNull();
 	});
 });
 
@@ -440,20 +458,26 @@ describe('Lightbox — the set changing under an OPEN viewer (TASK-2431)', () =>
 		return app;
 	}
 
-	it('drops a record whose MIME resolves to something unsafe AFTER open', () => {
+	it('shows the fallback (not drops) when a record resolves unsafe after open', () => {
+		// TASK-2476 matrix: safe→unsafe MID-VIEW is the FALLBACK cell — the entry
+		// stays navigable and counted, drawn as the no-bytes icon fallback, where
+		// pre-3c it was dropped from the set.
 		liveProps.images = [image(IMG_A, 'png'), image(IMG_B, 'later-svg')];
 		mountLive();
 		expect(root().querySelector('.lightbox-counter')?.textContent).toBe('1 / 2');
 
-		// The late answer arrives: what was believed safe is not. A set captured
-		// once would keep paging onto it.
+		// The late answer arrives: what was believed safe is not.
 		liveProps.images = [image(IMG_A, 'png'), image(IMG_B, 'later-svg', 'image/svg+xml')];
 		flushSync();
 
-		expect(shown()).toBe('png');
-		expect(root().querySelector('.lightbox-counter')).toBeNull();
+		// Still TWO entries — the flipped one is kept, not dropped.
+		expect(root().querySelector('.lightbox-counter')?.textContent).toBe('1 / 2');
 		press('ArrowRight');
-		expect(shown()).toBe('png');
+		// Landed on the flipped entry: the fallback arm, NO <img>.
+		expect(root().querySelector('.lightbox-image')).toBeNull();
+		const fb = root().querySelector('.lightbox-fallback');
+		expect(fb).not.toBeNull();
+		expect(fb?.textContent).toContain('No preview available');
 	});
 
 	it('keeps showing a real image when the one under it is removed', () => {
@@ -472,25 +496,33 @@ describe('Lightbox — the set changing under an OPEN viewer (TASK-2431)', () =>
 		expect(imageSrc()).toContain(IMG_A);
 	});
 
-	it('cannot be navigated onto an unsafe entry ADDED after open', () => {
+	it('shows the fallback for an unsafe entry ADDED after open, but still refuses an unresolved one', () => {
+		// TASK-2476 matrix: added-while-open UNSAFE → fallback (navigable);
+		// added-while-open UNRESOLVED → refused-from-navigation (unchanged).
 		liveProps.images = [image(IMG_A, 'png')];
 		mountLive();
 
 		liveProps.images = [
 			image(IMG_A, 'png'),
-			image(IMG_B, 'svg', 'image/svg+xml'),
-			image(IMG_C, 'unprobed', null),
+			image(IMG_B, 'svg', 'image/svg+xml'), // unsafe → fallback, navigable
+			image(IMG_C, 'unprobed', null), // unresolved → refused from nav
 		];
 		flushSync();
 
-		// Both additions are refused, so the viewer is still single-image.
-		expect(root().querySelector('.lightbox-counter')).toBeNull();
+		// A (raster) + B (fallback) navigable; C (unresolved) is not — so 1 / 2.
+		expect(root().querySelector('.lightbox-counter')?.textContent).toBe('1 / 2');
 		press('ArrowRight');
-		press('ArrowLeft');
+		// Landed on B: the fallback, no <img>.
+		expect(root().querySelector('.lightbox-image')).toBeNull();
+		expect(root().querySelector('.lightbox-fallback')).not.toBeNull();
+		// The next step WRAPS back to A (two members) — the unresolved C is never shown.
+		press('ArrowRight');
 		expect(shown()).toBe('png');
 	});
 
-	it('empties rather than showing an unsafe replacement', () => {
+	it('shows the fallback for an unsafe replacement rather than emptying', () => {
+		// TASK-2476: the only entry is replaced by an unsafe one — added-while-open,
+		// so the fallback cell, not an empty viewer.
 		liveProps.images = [image(IMG_A, 'png')];
 		mountLive();
 		expect(shown()).toBe('png');
@@ -499,6 +531,7 @@ describe('Lightbox — the set changing under an OPEN viewer (TASK-2431)', () =>
 		flushSync();
 
 		expect(root().querySelector('.lightbox-image')).toBeNull();
+		expect(root().querySelector('.lightbox-fallback')).not.toBeNull();
 	});
 });
 
@@ -1305,16 +1338,18 @@ describe('Lightbox — the transform resets when the shown image changes (TASK-2
 	});
 
 	it('resets when the set shrinks under `current` so a DIFFERENT image is shown', () => {
-		liveProps.images = [image(IMG_A, 'png'), image(IMG_B, 'later-svg')];
+		liveProps.images = [image(IMG_A, 'png'), image(IMG_B, 'second', 'image/jpeg')];
 		mountLive();
 		press('ArrowRight');
 		expect(imageSrc()).toContain(IMG_B);
 		press('+');
 		expect(scaleOf()).toBeCloseTo(1.25);
 
-		// B's MIME resolves unsafe → it drops out → the shown image becomes A →
-		// the transform is back at fit.
-		liveProps.images = [image(IMG_A, 'png'), image(IMG_B, 'later-svg', 'image/svg+xml')];
+		// B is REMOVED (a delete elsewhere) → the shown image becomes A → the
+		// transform is back at fit. A REMOVAL is used, not a safe→unsafe flip: since
+		// TASK-2476 a flip keeps the entry (same id) as the fallback, so it would not
+		// change the shown id and the reset would (correctly) not fire.
+		liveProps.images = [image(IMG_A, 'png')];
 		flushSync();
 		expect(imageSrc()).toContain(IMG_A);
 		expect(scaleOf()).toBe(1);
@@ -2512,6 +2547,9 @@ describe('Lightbox — DR-5b image loading (TASK-2459)', () => {
 		mountViewer({ images: [image(IMG_A, 'svg', 'image/svg+xml')] });
 		expect(root().querySelector('.lightbox-image')).toBeNull();
 		expect(root().querySelector('.lightbox-loading')).toBeNull();
+		// ...and NO fallback either: an all-unsafe set at open is refused outright
+		// (TASK-2476 — the fallback is a MID-VIEW cell, not an at-open one).
+		expect(root().querySelector('.lightbox-fallback')).toBeNull();
 	});
 
 	it('a same-id re-emit that FILLS dimensions re-runs the DR-5b policy', () => {
@@ -2548,25 +2586,30 @@ describe('Lightbox — DR-5b image loading (TASK-2459)', () => {
 		expect(panX()).toBeCloseTo(0);
 	});
 
-	it('an A→B→A same-URL late error on the DETACHED element does not clobber the live image', () => {
-		// The third A load reuses A's exact URL, so the URL fence alone cannot tell
-		// the detached first A element's late error from the live one — the per-mount
-		// generation is what rejects it (the no-`{#key}` switch-safety class).
+	it('releases a detached element on unmount, and a late error on it does not clobber the live image', () => {
+		// TASK-2476 hardens the detached-element handling: on unmount the `<img>`'s
+		// src is CLEARED (`releaseImg`), aborting its request so it can never issue or
+		// complete a same-URL late event. The GENERATION fence remains the
+		// loader-level defense (unit-tested in viewerImageLoader — the A→B→A same-URL
+		// stale decode/error cases); this covers the component wiring: the outgoing
+		// element is released, and a late error on it cannot flip the live image.
 		mountViewer({
 			images: [sized(IMG_A, 'a', 800, 600), sized(IMG_B, 'b', 800, 600, 'image/jpeg')],
 		});
 		const firstA = root().querySelector<HTMLImageElement>('.lightbox-image')!; // E1
-		expect(press('ArrowRight')).toBe(true); // → B (E1 detaches)
-		expect(press('ArrowLeft')).toBe(true); // → A again (E3 mounts, same URL)
+		expect(press('ArrowRight')).toBe(true); // → B (E1 detaches → src cleared)
+		expect(press('ArrowLeft')).toBe(true); // → A again (E3 mounts, fresh)
 		const liveA = root().querySelector<HTMLImageElement>('.lightbox-image')!;
 		expect(liveA).not.toBe(firstA);
-		expect(liveA.getAttribute('src')).toBe(firstA.getAttribute('src')); // same URL
+		// The detached element was RELEASED — its src is gone, its request aborted.
+		expect(firstA.getAttribute('src')).toBeNull();
+		// The live element holds A's URL.
+		expect(liveA.getAttribute('src')).toContain(IMG_A);
 
 		fireLoad(800, 600); // the LIVE A decodes fine → ready, no error
 		expect(root().querySelector('.lightbox-error')).toBeNull();
 
-		// The detached E1 errors LATE at the same URL — the generation fence must
-		// reject it so the live, ready image is not flipped into 'error'.
+		// A late error on the released detached element must not flip the live image.
 		firstA.dispatchEvent(new Event('error'));
 		flushSync();
 		expect(root().querySelector('.lightbox-error')).toBeNull();
@@ -3215,5 +3258,148 @@ describe('Lightbox — metadata header (TASK-2475)', () => {
 		// browser-suite concern, like every other measured-layout claim in this file.
 		expect(nameEl.getAttribute('title')).toBe(long);
 		expect(nameEl.textContent).toBe(long);
+	});
+});
+
+describe('Lightbox — the fallback arm (TASK-2476)', () => {
+	// The stage's second arm: a navigable entry the viewer cannot draw as an image
+	// (an unsafe/active type that flipped or was added while open). These drive the
+	// live props to reach it, since the open gate keeps unsafe entries out of the
+	// initial set.
+	function mountLive() {
+		const app = mount(Lightbox, { target: appRoot, props: liveProps });
+		mounted.push(app);
+		flushSync();
+		return app;
+	}
+	function fallback(): HTMLElement | null {
+		return root().querySelector('.lightbox-fallback');
+	}
+
+	it('mounts no <img>, disposes the loader AND releases the detached element on the arm flip', () => {
+		liveProps.images = [image(IMG_A, 'png')];
+		mountLive();
+		// The raster arm: an <img> holding A's src is mounted. Capture it — the flip
+		// detaches it, and the no-bytes invariant requires its request released too.
+		const priorImg = root().querySelector<HTMLImageElement>('.lightbox-image')!;
+		expect(priorImg).not.toBeNull();
+		expect(priorImg.getAttribute('src')).toContain(IMG_A);
+
+		// A flips unsafe — SAME id and dims, only the renderer arm differs. The load
+		// key carries the arm, so the load effect re-fires and DISPOSES the loader;
+		// without that the safe bytes would linger behind the fallback.
+		liveProps.images = [image(IMG_A, 'png', 'image/svg+xml')];
+		flushSync();
+
+		// No <img> in the tree, and the DETACHED element's src is CLEARED — its
+		// native request is aborted, not left in flight until GC (releaseImg).
+		expect(root().querySelector('.lightbox-image')).toBeNull();
+		expect(root().querySelector(`img[src*="${IMG_A}"]`)).toBeNull();
+		expect(priorImg.getAttribute('src')).toBeNull();
+		// The fallback is what shows instead.
+		expect(fallback()).not.toBeNull();
+	});
+
+	it('renders the icon, name, type · size and "No preview available"', () => {
+		liveProps.images = [image(IMG_A, 'png')];
+		mountLive();
+		liveProps.images = [
+			{
+				id: IMG_A,
+				alt: 'plans',
+				filename: 'plans.svg',
+				mime_type: 'image/svg+xml',
+				size_bytes: 4096,
+				width: null,
+				height: null,
+			},
+		];
+		flushSync();
+		const fb = fallback()!;
+		expect(fb).not.toBeNull();
+		// The large family icon (AttachmentIcon renders inline SVG).
+		expect(fb.querySelector('.lightbox-fallback-icon svg')).not.toBeNull();
+		// The display name, full value also in title (DR-13).
+		const nameEl = fb.querySelector('.lightbox-fallback-name');
+		expect(nameEl?.textContent).toBe('plans.svg');
+		expect(nameEl?.getAttribute('title')).toBe('plans.svg');
+		// Type · size and the honest note.
+		expect(fb.querySelector('.lightbox-fallback-detail')?.textContent).toContain(formatBytes(4096));
+		expect(fb.textContent).toContain('No preview available');
+	});
+
+	it('is navigable and counted, paged onto with ←/→', () => {
+		liveProps.images = [image(IMG_A, 'png')];
+		mountLive();
+		liveProps.images = [image(IMG_A, 'png'), image(IMG_B, 'diagram', 'image/svg+xml')];
+		flushSync();
+		// Two navigable members — the counter counts the fallback entry.
+		expect(root().querySelector('.lightbox-counter')?.textContent).toBe('1 / 2');
+		expect(root().querySelector('.lightbox-image')?.getAttribute('alt')).toBe('png');
+		press('ArrowRight');
+		// Paged onto the fallback entry.
+		expect(root().querySelector('.lightbox-image')).toBeNull();
+		expect(fallback()).not.toBeNull();
+	});
+
+	it('disables zoom on the fallback arm — nothing to transform', () => {
+		liveProps.images = [image(IMG_A, 'png')];
+		mountLive();
+		liveProps.images = [image(IMG_A, 'png', 'image/svg+xml')];
+		flushSync();
+		expect(fallback()).not.toBeNull();
+		// The zoom key is consumed (not leaked to the inert page) but inert — there
+		// is no bitmap, and none appears.
+		expect(press('+')).toBe(true);
+		expect(press('0')).toBe(true);
+		expect(root().querySelector('.lightbox-image')).toBeNull();
+	});
+
+	it('re-homes focus when the arm swap removes the focused raster control', () => {
+		liveProps.images = [image(IMG_A, 'png')];
+		mountLive();
+		// Drive to the error state so the Retry button exists, and focus it.
+		root().querySelector('.lightbox-image')!.dispatchEvent(new Event('error'));
+		flushSync();
+		const retry = root().querySelector<HTMLButtonElement>('.lightbox-retry')!;
+		retry.focus();
+		expect(document.activeElement).toBe(retry);
+
+		// A flips unsafe → the raster arm (with Retry) unmounts, the fallback mounts.
+		liveProps.images = [image(IMG_A, 'png', 'image/svg+xml')];
+		flushSync();
+		expect(root().querySelector('.lightbox-retry')).toBeNull();
+		expect(fallback()).not.toBeNull();
+		// Focus is not stranded on <body> outside the modal — it is re-homed.
+		expect(document.activeElement).not.toBe(document.body);
+		expect(root().contains(document.activeElement)).toBe(true);
+	});
+
+	it('reactively cancels a live drag when the bitmap vanishes via a prop flip', () => {
+		// The pointer handlers catch a flip that arrives WITH a move/up event, but the
+		// arm can flip from a PROP change while the pointer is held STILL — no event to
+		// carry the abort. The reactive cancel must tear the gesture down and release
+		// the capture, so a stale gesture cannot pan the reloaded image after an
+		// A→unsafe→A flip.
+		liveProps.images = [sized(IMG_A, 'a', 5000, 5000)];
+		mountLive();
+		mockGeometry(root(), OVERFLOW_G);
+		fireLoad(1024, 768); // decoded → bitmapPresent true
+		zoomToActual(); // pan room
+		const capture = vi.fn();
+		const release = vi.fn();
+		(root() as unknown as { setPointerCapture: unknown }).setPointerCapture = capture;
+		(root() as unknown as { releasePointerCapture: unknown }).releasePointerCapture = release;
+		root().dispatchEvent(pointerEvent('pointerdown', 500, 500));
+		root().dispatchEvent(pointerEvent('pointermove', 560, 500)); // engage the drag
+		flushSync();
+		expect(capture, 'the drag armed on the decoded bitmap').toHaveBeenCalled();
+
+		// A flips unsafe via a prop change — NO further pointer event.
+		liveProps.images = [sized(IMG_A, 'a', 5000, 5000, 'image/svg+xml')];
+		flushSync();
+		// The gesture was cancelled: the capture is released and the fallback shows.
+		expect(release, 'the reactive cancel released the capture').toHaveBeenCalled();
+		expect(fallback()).not.toBeNull();
 	});
 });

--- a/web/src/lib/components/common/MenuItem.svelte
+++ b/web/src/lib/components/common/MenuItem.svelte
@@ -161,7 +161,11 @@
 
 	.mi-icon {
 		width: 18px;
-		text-align: center;
+		/* Centre the slot's content on BOTH axes — a text glyph as before, and the
+		   `iconSnippet`'s `display:block` SVG, which `text-align` alone would leave
+		   left-aligned (TASK-2472). */
+		display: grid;
+		place-items: center;
 		flex: 0 0 18px;
 		opacity: 0.85;
 	}

--- a/web/src/lib/components/items/ItemAttachmentStrip.svelte
+++ b/web/src/lib/components/items/ItemAttachmentStrip.svelte
@@ -105,6 +105,17 @@
 		 * disables addressing rather than broadcasting to every host.
 		 */
 		hostToken?: string;
+		/**
+		 * Viewer-toolbar context (TASK-2474), forwarded verbatim to the `Lightbox`
+		 * this strip mounts. Distinct from the tile-delete props above by design:
+		 * these carry the SAME vocabulary the panel host / viewer host use
+		 * (`mutationsEnabled` + content GETTERS), so `ItemDetail` threads one
+		 * contract to every Lightbox origin. `mutationsEnabled` defaults false →
+		 * read-only toolbar.
+		 */
+		mutationsEnabled?: boolean;
+		getItemContent?: () => string | null;
+		getLiveContent?: () => string | null;
 	}
 	let {
 		wsSlug,
@@ -114,6 +125,9 @@
 		itemContent = null,
 		liveContent = null,
 		hostToken = '',
+		mutationsEnabled = false,
+		getItemContent,
+		getLiveContent,
 	}: Props = $props();
 
 	// Hard bound on what the strip will ever hold (DR-9 / DR-11). Past this the
@@ -1109,6 +1123,9 @@
 			index={lightbox.index}
 			{wsSlug}
 			invoker={lightbox.invoker}
+			{mutationsEnabled}
+			{getItemContent}
+			{getLiveContent}
 			onClose={() => (lightbox = null)}
 		/>
 	{/if}

--- a/web/src/lib/components/items/ItemAttachmentStrip.svelte.test.ts
+++ b/web/src/lib/components/items/ItemAttachmentStrip.svelte.test.ts
@@ -58,6 +58,11 @@ const panelOpenMock = vi.fn<(event: Record<string, unknown>) => void>();
 vi.mock('$lib/attachments/events', () => ({
 	announceAttachmentDeleted: (ws: string, uuid: string) => {
 		notifyDeletedMock(uuid);
+		// Fan out to the registered listeners, as the real one does (notify +
+		// invalidate). The viewer (TASK-2477) reconciles a delete through this bus,
+		// so an own-toolbar delete must reach its listener the same way an external
+		// delete does; the spy above still records the announce for assertions.
+		broadcastDeletion(uuid);
 		invalidateMock(ws, uuid);
 	},
 	notifyAttachmentPanelOpen: (event: Record<string, unknown>) => panelOpenMock(event),
@@ -1938,5 +1943,35 @@ describe('ItemAttachmentStrip', () => {
 		expect(notifyDeletedMock).toHaveBeenCalledWith('img1');
 		// The viewer closed over the deleted image.
 		expect(document.querySelector('.lightbox-backdrop')).toBeNull();
+	});
+
+	it('confirming Delete on ONE of TWO images ADVANCES the viewer, not closes it (TASK-2477)', async () => {
+		// The full toolbar → confirm → api.delete → announce → deletion-bus →
+		// survivor-advance path, with MORE THAN ONE image: the viewer must ADVANCE to
+		// the survivor rather than close (the retired C1 close-on-delete latch).
+		props.mutationsEnabled = true;
+		listMock.mockResolvedValue(response([att({ id: 'img1' }), att({ id: 'img2' })]));
+		mountStrip('item-a');
+		await settle();
+
+		tiles()[0].click(); // open the viewer on img1
+		flushSync();
+		expect(document.querySelector('.lightbox-counter')?.textContent).toBe('1 / 2');
+
+		document.querySelector<HTMLButtonElement>(
+			'.lightbox-toolbar .lightbox-tool[aria-label="Delete"]'
+		)!.click();
+		flushSync();
+		Array.from(document.querySelectorAll<HTMLButtonElement>('.lightbox-delete-confirm button'))
+			.find((b) => b.textContent?.includes('Delete file'))!
+			.click();
+		await settle();
+
+		expect(deleteMock).toHaveBeenCalledWith('ws', 'img1');
+		// The viewer stays OPEN, advanced to the surviving img2.
+		expect(document.querySelector('.lightbox-backdrop')).not.toBeNull();
+		expect(document.querySelector<HTMLImageElement>('.lightbox-image')?.getAttribute('alt')).toBe(
+			'img2.png'
+		);
 	});
 });

--- a/web/src/lib/components/items/ItemAttachmentStrip.svelte.test.ts
+++ b/web/src/lib/components/items/ItemAttachmentStrip.svelte.test.ts
@@ -79,7 +79,16 @@ const invalidateMock = vi.fn<(ws: string, uuid: string) => void>();
 // (PLAN-2392 DR-10) — a separate spy from the events bus's, so the two can be
 // asserted independently.
 const invalidateMetadataMock = vi.fn<(ws: string, uuid: string) => void>();
+// The strip mounts the real Lightbox, whose metadata header (TASK-2475) reads
+// through this module — so the mock must carry the fetch/revalidate exports too,
+// not just invalidate. Benign `ok` stubs: the strip's viewer tests use rows whose
+// size is already known (no fetch fires), but a complete contract keeps the mount
+// robust to any row shape.
 vi.mock('$lib/components/editor/attachment-metadata', () => ({
+	fetchAttachmentMetadata: () =>
+		Promise.resolve({ status: 'ok' as const, mime: 'image/png', size: 2048 }),
+	revalidateAttachmentMetadata: () =>
+		Promise.resolve({ status: 'ok' as const, mime: 'image/png', size: 2048 }),
 	invalidateAttachmentMetadata: (ws: string, uuid: string) => invalidateMetadataMock(ws, uuid),
 }));
 

--- a/web/src/lib/components/items/ItemAttachmentStrip.svelte.test.ts
+++ b/web/src/lib/components/items/ItemAttachmentStrip.svelte.test.ts
@@ -127,6 +127,9 @@ const props = $state<{
 	itemContent: string | null;
 	liveContent: (() => string | null) | null;
 	hostToken: string;
+	mutationsEnabled?: boolean;
+	getItemContent?: () => string | null;
+	getLiveContent?: () => string | null;
 }>({
 	wsSlug: 'ws',
 	username: 'dave',
@@ -135,6 +138,9 @@ const props = $state<{
 	itemContent: null,
 	liveContent: null,
 	hostToken: 'host-1',
+	mutationsEnabled: false,
+	getItemContent: undefined,
+	getLiveContent: undefined,
 });
 
 describe('ItemAttachmentStrip', () => {
@@ -157,6 +163,9 @@ describe('ItemAttachmentStrip', () => {
 		props.canDelete = false;
 		props.itemContent = null;
 		props.liveContent = null;
+		props.mutationsEnabled = false;
+		props.getItemContent = undefined;
+		props.getLiveContent = undefined;
 		target = document.body.appendChild(document.createElement('div'));
 	});
 
@@ -1856,5 +1865,69 @@ describe('ItemAttachmentStrip', () => {
 		openConfirm();
 
 		expect(promptText()).toContain("still used in this item's content");
+	});
+
+	// ── Viewer toolbar (TASK-2474) ───────────────────────────────────────────
+	// The STRIP origin of the three that mount a Lightbox. These prove the strip
+	// forwards its `mutationsEnabled` to the viewer's toolbar (separate from the
+	// tile-delete `canDelete` above).
+	function toolbarLabels(): string[] {
+		return Array.from(
+			document.querySelectorAll<HTMLElement>('.lightbox-toolbar .lightbox-tool')
+		).map((t) => t.getAttribute('aria-label') ?? '');
+	}
+
+	it('opens a viewer toolbar with Delete when the strip is granted mutations', async () => {
+		props.mutationsEnabled = true;
+		listMock.mockResolvedValue(response([att({ id: 'img1' })]));
+		mountStrip('item-a');
+		await settle();
+
+		tiles()[0].click();
+		flushSync();
+		expect(document.querySelector('.lightbox-toolbar')).not.toBeNull();
+		expect(toolbarLabels()).toContain('Delete');
+	});
+
+	it('opens a read-only viewer toolbar (no Delete) when mutations are withheld', async () => {
+		props.mutationsEnabled = false;
+		listMock.mockResolvedValue(response([att({ id: 'img1' })]));
+		mountStrip('item-a');
+		await settle();
+
+		tiles()[0].click();
+		flushSync();
+		expect(document.querySelector('.lightbox-toolbar')).not.toBeNull();
+		expect(toolbarLabels()).toContain('Download');
+		expect(toolbarLabels()).not.toContain('Delete');
+	});
+
+	it('confirming Delete in the toolbar deletes the attachment and closes the viewer', async () => {
+		// The full path: the descriptor owns the delete (api + announce), the module
+		// owns the gate, and a confirmed delete closes the viewer over the now-gone
+		// image. The same delete call the tile's × makes — one confirmation, one API.
+		props.mutationsEnabled = true;
+		listMock.mockResolvedValue(response([att({ id: 'img1' })]));
+		mountStrip('item-a');
+		await settle();
+
+		tiles()[0].click();
+		flushSync();
+		document.querySelector<HTMLButtonElement>(
+			'.lightbox-toolbar .lightbox-tool[aria-label="Delete"]'
+		)!.click();
+		flushSync();
+		// Drill-down up; confirm it.
+		const confirmRow = Array.from(
+			document.querySelectorAll<HTMLButtonElement>('.lightbox-delete-confirm button')
+		).find((b) => b.textContent?.includes('Delete file'))!;
+		expect(confirmRow).toBeDefined();
+		confirmRow.click();
+		await settle();
+
+		expect(deleteMock).toHaveBeenCalledWith('ws', 'img1');
+		expect(notifyDeletedMock).toHaveBeenCalledWith('img1');
+		// The viewer closed over the deleted image.
+		expect(document.querySelector('.lightbox-backdrop')).toBeNull();
 	});
 });

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -5867,8 +5867,9 @@
 
 <!-- The image viewer's host (PLAN-2392 phase 3a / TASK-2428). One per
      `ItemDetail` mount, sharing the token the panel host uses — one token per
-     HOST, not one per channel — and carrying no `mutationsEnabled`, because
-     3a's viewer has no mutating action and a dead prop is worse than none.
+     HOST, not one per channel. It now carries `mutationsEnabled` (= `canEdit &&
+     !peeking`) and the delete-warning content getters (3c-i's viewer toolbar
+     Delete, TASK-2474), threaded to `Lightbox` exactly as the panel host's are.
 
      TOP LEVEL, not beside `AttachmentPanelHost` inside the `{:else if item &&
      collection}` branch, and that placement is the whole lifecycle rule: every

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -843,6 +843,17 @@
 			return null;
 		}
 	}
+	/**
+	 * The PERSISTED item body as a stable getter (TASK-2474). The strip and panel
+	 * host take the raw value inline (`itemContent`), but the viewer toolbar's
+	 * contract is the panel's getter pattern — `getItemContent?: () => string |
+	 * null` — so it reads through this. `itemMatchesRef`-gated exactly as the
+	 * value form is, so a mid-switch read returns null rather than the outgoing
+	 * item's content.
+	 */
+	function itemPersistedMarkdown(): string | null {
+		return (itemMatchesRef ? item?.content : null) ?? null;
+	}
 	$effect(() => {
 		if (wsSlug && collSlug && itemSlug) {
 			loadData();
@@ -5087,6 +5098,9 @@
 				canDelete={mutationsEnabled}
 				itemContent={itemMatchesRef ? item?.content : null}
 				liveContent={liveEditorMarkdown}
+				{mutationsEnabled}
+				getItemContent={itemPersistedMarkdown}
+				getLiveContent={liveEditorMarkdown}
 			/>
 
 			<!-- The attachment options panel's host (PLAN-2392 DR-8 / TASK-2423).
@@ -5626,6 +5640,9 @@
 				frozen={false}
 				restoreFrozen={peeking}
 				visibleKinds={activeTab === 'versions' ? ['version'] : ['comment', 'activity']}
+				{mutationsEnabled}
+				getItemContent={itemPersistedMarkdown}
+				getLiveContent={liveEditorMarkdown}
 			/>
 		</div>
 		</div><!-- /tab-panel Activity/Versions -->
@@ -5869,6 +5886,9 @@
 	itemId={itemMatchesRef ? item?.id : null}
 	hostToken={attachmentHostToken}
 	resourceGen={viewerResource.current}
+	{mutationsEnabled}
+	getItemContent={itemPersistedMarkdown}
+	getLiveContent={liveEditorMarkdown}
 />
 
 <style>

--- a/web/src/lib/components/timeline/ItemTimeline.svelte
+++ b/web/src/lib/components/timeline/ItemTimeline.svelte
@@ -83,9 +83,20 @@
 		 * callers outside an ItemDetail) disables addressing.
 		 */
 		hostToken?: string;
+		/**
+		 * Viewer-toolbar context (TASK-2474), forwarded verbatim to the `Lightbox`
+		 * this timeline mounts. `mutationsEnabled` is the HOST's answer
+		 * (`canEdit && !peeking`) — deliberately NOT this component's own `canEdit`
+		 * below, which ignores peeking, so a peeked master's timeline viewer would
+		 * wrongly offer Delete. DEFAULT false → read-only toolbar. The two content
+		 * getters back the delete-warning check (DR-5).
+		 */
+		mutationsEnabled?: boolean;
+		getItemContent?: () => string | null;
+		getLiveContent?: () => string | null;
 	}
 
-	let { wsSlug, username = '', itemSlug, currentContent, items = [], onRestore, itemId, collectionId, frozen = false, restoreFrozen = false, flushBeforeRestore, visibleKinds, hostToken = '' }: Props = $props();
+	let { wsSlug, username = '', itemSlug, currentContent, items = [], onRestore, itemId, collectionId, frozen = false, restoreFrozen = false, flushBeforeRestore, visibleKinds, hostToken = '', mutationsEnabled = false, getItemContent, getLiveContent }: Props = $props();
 
 	// Resolve canEditItem reactively; falls to false if itemId/collectionId
 	// aren't supplied (e.g. an older caller). Folds in the master-freeze gate
@@ -767,6 +778,9 @@
 			index={lightbox.index}
 			{wsSlug}
 			invoker={lightbox.invoker}
+			{mutationsEnabled}
+			{getItemContent}
+			{getLiveContent}
 			onClose={() => (lightbox = null)}
 		/>
 	{/if}

--- a/web/src/lib/components/timeline/ItemTimeline.svelte.test.ts
+++ b/web/src/lib/components/timeline/ItemTimeline.svelte.test.ts
@@ -83,6 +83,14 @@ vi.mock('$lib/components/editor/attachment-metadata', () => ({
 				? { status: 'ok' as const, mime: MIMES[uuid], size: 4096 }
 				: { status: 'transient' as const }
 		),
+	// The timeline mounts the real Lightbox, whose metadata header (TASK-2475) calls
+	// this on a header Retry — mirror the fetch stub so the contract is complete.
+	revalidateAttachmentMetadata: (_ws: string, uuid: string) =>
+		Promise.resolve(
+			MIMES[uuid]
+				? { status: 'ok' as const, mime: MIMES[uuid], size: 4096 }
+				: { status: 'transient' as const }
+		),
 	invalidateAttachmentMetadata: vi.fn(),
 }));
 

--- a/web/src/lib/components/timeline/ItemTimeline.svelte.test.ts
+++ b/web/src/lib/components/timeline/ItemTimeline.svelte.test.ts
@@ -66,8 +66,12 @@ vi.mock('$lib/stores/auth.svelte', () => ({
 	authStore: { userId: 'user-1', user: { id: 'user-1', role: 'member' } },
 }));
 
+// Controllable so the TASK-2474 peek leg can set the timeline's OWN canEdit
+// TRUE while the host withholds `mutationsEnabled` — the only configuration that
+// makes "the viewer must not consult canEdit" falsifiable.
+const canEditMock = vi.hoisted(() => vi.fn(() => false));
 vi.mock('$lib/stores/workspace.svelte', () => ({
-	workspaceStore: { canEditItem: () => false },
+	workspaceStore: { canEditItem: canEditMock },
 }));
 
 // The HEAD probe, answered from MIMES. An id absent from the table resolves as
@@ -137,6 +141,9 @@ const props = $state<{
 	itemId: string;
 	collectionId: string;
 	visibleKinds: Array<'comment' | 'activity' | 'version'> | undefined;
+	mutationsEnabled?: boolean;
+	getItemContent?: () => string | null;
+	getLiveContent?: () => string | null;
 }>({
 	wsSlug: 'ws',
 	username: 'alice',
@@ -145,6 +152,9 @@ const props = $state<{
 	itemId: 'item-a',
 	collectionId: 'coll-1',
 	visibleKinds: undefined,
+	mutationsEnabled: false,
+	getItemContent: undefined,
+	getLiveContent: undefined,
 });
 
 function resetProps() {
@@ -155,6 +165,9 @@ function resetProps() {
 	props.itemId = 'item-a';
 	props.collectionId = 'coll-1';
 	props.visibleKinds = undefined;
+	props.mutationsEnabled = false;
+	props.getItemContent = undefined;
+	props.getLiveContent = undefined;
 }
 
 function render() {
@@ -216,6 +229,7 @@ beforeEach(() => {
 	host = document.createElement('div');
 	document.body.appendChild(host);
 	resetProps();
+	canEditMock.mockReturnValue(false);
 	timelineListMock.mockReset();
 	timelineListMock.mockResolvedValue({ entries: [], has_more: false });
 });
@@ -478,5 +492,50 @@ describe('ItemTimeline — A→B viewer lifecycle (TASK-2431)', () => {
 		await settle();
 
 		expect(viewerShowing()).toBe(PNG_A);
+	});
+});
+
+describe('ItemTimeline — viewer toolbar (TASK-2474)', () => {
+	// The TIMELINE origin of the three that mount a Lightbox. The peek leg is the
+	// one the plan calls out: the toolbar's Delete must follow the HOST's
+	// `mutationsEnabled`, NEVER this component's own `canEdit` (which ignores
+	// peeking) — so it is exercised with canEdit TRUE and mutationsEnabled FALSE.
+	function toolLabels(): string[] {
+		return Array.from(
+			document.querySelectorAll<HTMLElement>('.lightbox-toolbar .lightbox-tool')
+		).map((t) => t.getAttribute('aria-label') ?? '');
+	}
+
+	it('renders the toolbar with Delete when the host grants mutations', async () => {
+		props.mutationsEnabled = true;
+		timelineListMock.mockResolvedValue(respond([PNG_A]));
+		render();
+		await settle();
+
+		click(thumbFor(PNG_A));
+		flushSync();
+		expect(viewerOpen()).toBe(true);
+		expect(document.querySelector('.lightbox-toolbar')).not.toBeNull();
+		expect(toolLabels()).toContain('Delete');
+	});
+
+	it('shows NO Delete on a peeked pane even though its own canEdit is true', async () => {
+		// The peek: the host withholds mutation, but this timeline's own canEdit
+		// resolves TRUE (editable item, not frozen). If the viewer were wired to
+		// canEdit instead of the passed mutationsEnabled, Delete would appear — this
+		// leg is what fails in that case.
+		canEditMock.mockReturnValue(true);
+		props.mutationsEnabled = false;
+		timelineListMock.mockResolvedValue(respond([PNG_A]));
+		render();
+		await settle();
+
+		click(thumbFor(PNG_A));
+		flushSync();
+		expect(viewerOpen()).toBe(true);
+		expect(document.querySelector('.lightbox-toolbar')).not.toBeNull();
+		expect(toolLabels()).not.toContain('Delete');
+		// ...and the read-only actions are still there — read-only, not empty.
+		expect(toolLabels()).toContain('Download');
 	});
 });


### PR DESCRIPTION
Phase 3c-i of [PLAN-2392]: toolbar, metadata header, content slot + icon fallback, and the DR-5c viewer-side deletion subscription — on the existing viewer, with both open routes unchanged. Decomposed via a 7-round Codex consensus (see the amendment comment on the plan); DR-20's convergence proper follows in 3c-ii on its own branch.

## Tasks (serial)
- [x] TASK-2472 — action icons: MenuItem snippet path + actions.ts to SVG ids
- [x] TASK-2473 — extract panel metadata + delete-confirm machinery into shared modules
- [x] TASK-2474 — viewer toolbar + context props threaded to every mount
- [x] TASK-2475 — viewer metadata header
- [x] TASK-2476 — content slot + icon fallback
- [x] TASK-2477 — viewer deletion subscription (DR-5c, viewer side)
- [x] TASK-2484 — browser proof: toolbar, header, fallback, deletion (e2e)

## Key decisions (from the consensus loop)
- Lightbox GROWS into the one surface (AM-2); every task extracts at least as much as it adds.
- The icon-fallback arm is a no-bytes arm: no img, no src, no fetch; the slot arm joins the load key so a safe→unsafe MIME flip disposes the loader.
- Toolbar context (`mutationsEnabled`, content getters) threads from ItemDetail to ALL THREE viewer mount origins; the timeline's own canEdit is never consulted (peek-mode Delete leak).
- Through this PR both routes remain: images → viewer, files → panel. Release note if this ships alone: images gain toolbar + metadata; files keep the existing panel until 3c-ii.

## Test plan
Per task: web vitest + svelte-check; e2e parity/zoom extensions (toolbar on all origins, peek Delete-absent leg, metadata header, fallback via safe→unsafe). No Go changes.

https://claude.ai/code/session_01WFBYxdBuSZs2tjipATxAZu