### PR TITLE
fix(server): force-download unknown and disallowed stored MIME (BUG-2413)

### DIFF
--- a/internal/attachments/mime.go
+++ b/internal/attachments/mime.go
@@ -138,6 +138,48 @@ func LookupMIME(mime string) (MIMEEntry, bool) {
 	return e, ok
 }
 
+// inlineSafe is the EXPLICIT set of MIME types the read path may serve with
+// Content-Disposition: inline (BUG-2413). It is deliberately a standalone
+// allowlist and NOT a function of RenderMode. Deriving inline-safety from the
+// broad RenderInline bucket would auto-trust every future RenderInline entry, so
+// adding an active type (image/svg+xml, say) as RenderInline would silently
+// reintroduce same-origin execution. Listing the exact types here means a new
+// allowlist entry FAILS SAFE — it downloads until someone makes the explicit,
+// reviewable decision to add it here too, the same posture the `allowed` map
+// itself takes.
+//
+// Every member is a format the browser renders WITHOUT executing embedded
+// script: raster images, audio and video (all also embedded by the app via
+// <img>/<audio>/<video>), plus PDF (sandboxed viewer) and plain text. This is
+// the server mirror of the client's VIEWER_MIMES + BROWSER_PREVIEW_MIMES
+// (web/src/lib/attachments/display.ts). Notably absent: image/svg+xml and
+// application/xhtml+xml (active), text/xml + application/xml (SVG/XHTML wear
+// these after an extensionless sniff), and the whole RenderForceDownload bucket.
+var inlineSafe = map[string]struct{}{
+	// Raster images.
+	"image/png": {}, "image/jpeg": {}, "image/gif": {}, "image/webp": {},
+	"image/avif": {}, "image/heic": {}, "image/heif": {},
+	// Audio (inline via <audio controls>).
+	"audio/mpeg": {}, "audio/wav": {}, "audio/ogg": {}, "audio/webm": {},
+	"audio/flac": {}, "audio/aac": {}, "audio/mp4": {},
+	// Video the app plays inline via <video controls>.
+	"video/mp4": {}, "video/webm": {}, "video/quicktime": {},
+	// Preview-safe documents.
+	"application/pdf": {}, "text/plain": {},
+}
+
+// ServeInline reports whether an allowlisted attachment's bytes may be sent with
+// Content-Disposition: inline. It is the server-side safety gate for BUG-2413:
+// only the explicit passive-media / preview-safe types in `inlineSafe` are
+// inline; everything else — the rest of the RenderChip bucket, the whole
+// RenderForceDownload bucket, and (at the call site) any MIME not on the
+// allowlist at all — is served as an attachment so it cannot execute as
+// same-origin active content.
+func (e MIMEEntry) ServeInline() bool {
+	_, ok := inlineSafe[e.MIME]
+	return ok
+}
+
 // NormalizeMIME strips parameters and lowercases the type/subtype. We
 // match strictly against the allowlist after normalization so callers
 // can pass an http.DetectContentType result (which may include a charset

--- a/internal/attachments/mime_test.go
+++ b/internal/attachments/mime_test.go
@@ -67,6 +67,40 @@ func TestLookupMIME_RenderModes(t *testing.T) {
 	}
 }
 
+// BUG-2413: ServeInline is the read path's inline-safe gate. Passive media plus
+// PDF and plain text may be served inline; every other allowlisted type — the
+// rest of the RenderChip bucket and the whole force-download bucket — must not.
+func TestServeInline(t *testing.T) {
+	must := func(m string) MIMEEntry {
+		t.Helper()
+		e, ok := LookupMIME(m)
+		if !ok {
+			t.Fatalf("LookupMIME(%q) rejected", m)
+		}
+		return e
+	}
+	inline := []string{
+		"image/png", "image/jpeg", "image/gif", "image/webp", "image/avif",
+		"audio/mpeg", "video/mp4", // passive media the app embeds inline
+		"application/pdf", "text/plain", // the preview-safe chip subset
+	}
+	for _, m := range inline {
+		if !must(m).ServeInline() {
+			t.Errorf("ServeInline(%q) = false, want true (inline-safe)", m)
+		}
+	}
+	download := []string{
+		"text/xml", "application/xml", "application/json", "text/csv",
+		"text/markdown", "application/msword", "application/zip",
+		"text/html", "text/javascript", "application/javascript",
+	}
+	for _, m := range download {
+		if must(m).ServeInline() {
+			t.Errorf("ServeInline(%q) = true, want false (must download)", m)
+		}
+	}
+}
+
 // minimal PNG header
 var pngHeader = []byte{0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0, 0, 0, 0}
 

--- a/internal/server/handlers_attachments.go
+++ b/internal/server/handlers_attachments.go
@@ -731,18 +731,36 @@ func (s *Server) handleGetAttachment(w http.ResponseWriter, r *http.Request) {
 
 	// Headers come BEFORE ServeContent / io.Copy so they make it onto
 	// the wire even when the response is a 304 / 206.
-	w.Header().Set("Content-Type", att.MimeType)
+	//
+	// Content-Type AND Content-Disposition are a security decision here, not a
+	// convenience (BUG-2413). FAIL CLOSED: serve inline only a stored MIME that is
+	// on the allowlist AND explicitly inline-safe (passive media the browser
+	// renders in place, plus PDF and plain text — see MIMEEntry.ServeInline).
+	// Everything else — the rest of the RenderChip bucket (xml/json/csv/office/
+	// archives), the RenderForceDownload bucket, and any MIME we don't recognize
+	// at all — is served as an attachment, so a legacy or mislabelled
+	// image/svg+xml, an extensionless SVG stored as text/xml, or an unknown row
+	// can never render as same-origin active content. The default was previously
+	// inline, which is exactly the fail-open this closes.
+	contentType := att.MimeType
+	disposition := "attachment"
+	if entry, ok := attachments.LookupMIME(att.MimeType); ok {
+		if entry.ServeInline() {
+			disposition = "inline"
+		}
+	} else {
+		// Not on the allowlist at all: don't echo back a type the browser might
+		// act on. Opaque bytes, paired with the attachment disposition and the
+		// nosniff below, make an unrecognized row inert.
+		contentType = "application/octet-stream"
+	}
+	w.Header().Set("Content-Type", contentType)
 	// Authorization has succeeded — replace the no-store denial directive
 	// set at the top of the handler with the positive one. Known and
 	// accepted: this one-hour positive browser cache outlives a permission
 	// revocation (PLAN-2391 DR-10).
 	w.Header().Set("Cache-Control", "private, max-age=3600")
 	w.Header().Set("X-Content-Type-Options", "nosniff")
-
-	disposition := "inline"
-	if entry, ok := attachments.LookupMIME(att.MimeType); ok && entry.RenderMode == attachments.RenderForceDownload {
-		disposition = "attachment"
-	}
 	w.Header().Set("Content-Disposition",
 		fmt.Sprintf(`%s; filename=%q`, disposition, sanitizeHeaderFilename(att.Filename)))
 

--- a/internal/server/handlers_attachments_download_mime_test.go
+++ b/internal/server/handlers_attachments_download_mime_test.go
@@ -1,0 +1,212 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/attachments"
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// BUG-2413: the attachment read path must fail CLOSED on Content-Disposition —
+// a stored MIME that is not explicitly inline-safe is served as an attachment,
+// so a legacy or mislabelled image/svg+xml, an extensionless SVG stored as
+// text/xml, or an unrecognized row can never render as same-origin active
+// content. The upload path rejects these MIME types today, so these tests seed
+// rows DIRECTLY in the store to stand in for legacy / mislabelled rows.
+
+// mimeDispoFixture is a server with an attachment registry plus a workspace,
+// collection, and item to hang seeded rows on. Returns the workspace slug (for
+// the request URL), the workspace id, and the item id.
+func mimeDispoFixture(t *testing.T) (srv *Server, slug, wsID, itemID string) {
+	t.Helper()
+	srv = testServer(t)
+	dir := t.TempDir()
+	fs, err := attachments.NewFSStore(dir)
+	if err != nil {
+		t.Fatalf("NewFSStore: %v", err)
+	}
+	reg := attachments.NewRegistry()
+	reg.Register(attachments.FSPrefix, fs)
+	srv.SetAttachments(reg, 0)
+
+	ws, err := srv.store.CreateWorkspace(models.WorkspaceCreate{Name: "MimeDispo"})
+	if err != nil {
+		t.Fatalf("CreateWorkspace: %v", err)
+	}
+	col, err := srv.store.CreateCollection(ws.ID, models.CollectionCreate{Name: "Tasks", Schema: `{"fields":[]}`})
+	if err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	item, err := srv.store.CreateItem(ws.ID, col.ID, models.ItemCreate{Title: "Has attachments", Fields: `{}`})
+	if err != nil {
+		t.Fatalf("CreateItem: %v", err)
+	}
+	return srv, ws.Slug, ws.ID, item.ID
+}
+
+// seedStoredRow writes body to the registry and creates a live attachment row
+// with an arbitrary stored MIME + filename attached to itemID. The row shape is
+// the one a legacy / mislabelled upload would leave behind. Optional parentID +
+// variant seed a derived (variant) row instead. Returns the new attachment id.
+func seedStoredRow(t *testing.T, srv *Server, wsID, itemID, mime, filename string, body []byte, parentID, variant string) string {
+	t.Helper()
+	sum := sha256.Sum256(body)
+	hash := hex.EncodeToString(sum[:])
+	st, err := srv.attachments.Resolve(attachments.FSPrefix + ":" + hash)
+	if err != nil {
+		t.Fatalf("resolve store: %v", err)
+	}
+	key, err := st.Put(context.Background(), hash, mime, bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	att := &models.Attachment{
+		WorkspaceID: wsID,
+		UploadedBy:  "system",
+		StorageKey:  key,
+		ContentHash: hash,
+		MimeType:    mime,
+		SizeBytes:   int64(len(body)),
+		Filename:    filename,
+	}
+	if itemID != "" {
+		iid := itemID
+		att.ItemID = &iid
+	}
+	if parentID != "" {
+		pid := parentID
+		att.ParentID = &pid
+	}
+	if variant != "" {
+		v := variant
+		att.Variant = &v
+	}
+	if err := srv.store.CreateAttachment(att); err != nil {
+		t.Fatalf("CreateAttachment: %v", err)
+	}
+	return att.ID
+}
+
+// serve issues a GET (method="GET") or HEAD against a seeded row and returns the
+// recorder. variant, when non-empty, is appended as ?variant=.
+func serveAttachment(t *testing.T, srv *Server, slug, id, method, variant string) *httptest.ResponseRecorder {
+	t.Helper()
+	url := "/api/v1/workspaces/" + slug + "/attachments/" + id
+	if variant != "" {
+		url += "?variant=" + variant
+	}
+	req := httptest.NewRequest(method, url, nil)
+	req.RemoteAddr = "127.0.0.1:1234"
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	return rr
+}
+
+func assertAttachmentDisposition(t *testing.T, rr *httptest.ResponseRecorder, wantPrefix string) {
+	t.Helper()
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rr.Code, rr.Body.String())
+	}
+	if got := rr.Header().Get("Content-Disposition"); !strings.HasPrefix(got, wantPrefix) {
+		t.Errorf("Content-Disposition = %q, want %s...", got, wantPrefix)
+	}
+	if got := rr.Header().Get("X-Content-Type-Options"); got != "nosniff" {
+		t.Errorf("X-Content-Type-Options = %q, want nosniff", got)
+	}
+}
+
+const svgBytes = `<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>`
+
+// A legacy row stored as image/svg+xml is force-downloaded — GET and HEAD both.
+func TestDownload_SVGLabeledRowForcedAsAttachment(t *testing.T) {
+	srv, slug, wsID, itemID := mimeDispoFixture(t)
+	id := seedStoredRow(t, srv, wsID, itemID, "image/svg+xml", "diagram.svg", []byte(svgBytes), "", "")
+
+	for _, method := range []string{"GET", "HEAD"} {
+		rr := serveAttachment(t, srv, slug, id, method, "")
+		assertAttachmentDisposition(t, rr, "attachment;")
+		if t.Failed() {
+			t.Fatalf("%s: image/svg+xml served inline — active content reachable same-origin", method)
+		}
+	}
+}
+
+// An extensionless SVG that was sniffed and stored as text/xml (on the upload
+// allowlist as a RenderChip type) is force-downloaded.
+func TestDownload_TextXMLForcedAsAttachment(t *testing.T) {
+	srv, slug, wsID, itemID := mimeDispoFixture(t)
+	id := seedStoredRow(t, srv, wsID, itemID, "text/xml", "drawing", []byte(svgBytes), "", "")
+
+	for _, method := range []string{"GET", "HEAD"} {
+		rr := serveAttachment(t, srv, slug, id, method, "")
+		assertAttachmentDisposition(t, rr, "attachment;")
+	}
+}
+
+// An unrecognized stored MIME is force-downloaded AND served as opaque
+// octet-stream bytes, never echoed back as a type the browser might act on.
+func TestDownload_UnknownMIMEForcedAsAttachmentOctetStream(t *testing.T) {
+	srv, slug, wsID, itemID := mimeDispoFixture(t)
+	id := seedStoredRow(t, srv, wsID, itemID, "application/x-not-a-real-type", "mystery.bin", []byte("whatever"), "", "")
+
+	for _, method := range []string{"GET", "HEAD"} {
+		rr := serveAttachment(t, srv, slug, id, method, "")
+		assertAttachmentDisposition(t, rr, "attachment;")
+		if got := rr.Header().Get("Content-Type"); got != "application/octet-stream" {
+			t.Errorf("%s Content-Type = %q, want application/octet-stream (unknown MIME must not be echoed back)", method, got)
+		}
+	}
+}
+
+// The variant endpoint shares the read handler, so the same disposition gate
+// applies: a derived row wearing a non-inline-safe MIME is force-downloaded too
+// (a contrived svg-typed variant stands in for the general case).
+func TestDownload_VariantForcedAsAttachment(t *testing.T) {
+	srv, slug, wsID, itemID := mimeDispoFixture(t)
+	parent := seedStoredRow(t, srv, wsID, itemID, "image/png", "pic.png", realPNG(), "", "")
+	// A derived variant carrying an unsafe MIME — the handler resolves it via the
+	// ?variant= lookup and must run the disposition gate on the VARIANT's type.
+	seedStoredRow(t, srv, wsID, itemID, "image/svg+xml", "pic.svg", []byte(svgBytes), parent, models.AttachmentVariantThumbMd)
+
+	rr := serveAttachment(t, srv, slug, parent, "GET", models.AttachmentVariantThumbMd)
+	assertAttachmentDisposition(t, rr, "attachment;")
+}
+
+// PDF stays inline (browser preview) — the fix must not break legitimate inline
+// types.
+func TestDownload_PDFStaysInline(t *testing.T) {
+	srv, slug, wsID, itemID := mimeDispoFixture(t)
+	id := seedStoredRow(t, srv, wsID, itemID, "application/pdf", "doc.pdf", []byte("%PDF-1.4 minimal"), "", "")
+
+	rr := serveAttachment(t, srv, slug, id, "GET", "")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d", rr.Code)
+	}
+	if got := rr.Header().Get("Content-Disposition"); !strings.HasPrefix(got, "inline;") {
+		t.Errorf("Content-Disposition = %q, want inline; ... (PDF must stay previewable)", got)
+	}
+	if got := rr.Header().Get("Content-Type"); got != "application/pdf" {
+		t.Errorf("Content-Type = %q, want application/pdf", got)
+	}
+}
+
+// Plain text stays inline.
+func TestDownload_PlainTextStaysInline(t *testing.T) {
+	srv, slug, wsID, itemID := mimeDispoFixture(t)
+	id := seedStoredRow(t, srv, wsID, itemID, "text/plain", "notes.txt", []byte("hello"), "", "")
+
+	rr := serveAttachment(t, srv, slug, id, "GET", "")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d", rr.Code)
+	}
+	if got := rr.Header().Get("Content-Disposition"); !strings.HasPrefix(got, "inline;") {
+		t.Errorf("Content-Disposition = %q, want inline; ... (text/plain must stay inline)", got)
+	}
+}


### PR DESCRIPTION
Closes the fail-open attachment read path: Content-Disposition now defaults to `attachment`, with `inline` only for an explicit inline-safe allowlist (passive raster/audio/video the app embeds, plus PDF and plain text — mirroring the client's viewer/preview sets). A MIME not on the allowlist at all is additionally served as `application/octet-stream`, so a legacy or mislabelled `image/svg+xml`, an extensionless SVG stored as `text/xml`, or an unknown row can never render as same-origin active content. nosniff already present, kept.

Escalated from PLAN-2392's 3c-ii consensus loop: the converged attachment surface gives every stored row a one-click Copy-link, so this fix is a merge-gate for the convergence PR.

- Deliberately an explicit allowlist, NOT derived from RenderMode — a future inline-render type fails SAFE (downloads until explicitly listed).
- Single choke point verified: GET/HEAD/share-link/?variant= all flow through handleGetAttachment; variant reassignment happens before the gate (pinned by a test).
- Regression tests: SVG-labeled, text/xml, unknown → attachment+octet-stream (GET and HEAD, variant path); PNG/PDF/plain-text stay inline. Mutation-verified: reverting the default fails exactly the security tests.

Test plan: `go test ./internal/server/... ./internal/attachments/...` green; `make test` exit 0. No store/query changes (no test-pg needed). Codex review: 2 rounds (drift finding fixed), CLEAN.

https://claude.ai/code/session_01WFBYxdBuSZs2tjipATxAZu