### PR TITLE
feat(cli): markdown output for the list commands

### DIFF
--- a/cmd/pad/cmd_collection.go
+++ b/cmd/pad/cmd_collection.go
@@ -55,6 +55,11 @@ func collectionsCmd() *cobra.Command {
 				return cli.PrintJSON(colls)
 			}
 
+			if formatFlag == "markdown" {
+				cli.PrintCollectionMarkdown(colls)
+				return nil
+			}
+
 			cli.PrintCollectionTable(colls)
 			return nil
 		},

--- a/cmd/pad/cmd_item.go
+++ b/cmd/pad/cmd_item.go
@@ -397,15 +397,23 @@ Examples:
 				return cli.PrintJSON(cli.ToItemSummaries(items))
 			}
 
-			if len(items) == 0 {
+			// Grouped when listing across collections, a single table when
+			// scoped to one — markdown mirrors the table layout.
+			grouped := len(args) == 0 && groupBy == ""
+
+			switch {
+			case formatFlag == "markdown":
+				if grouped {
+					renderItemsGroupedByCollectionMarkdown(os.Stdout, items)
+				} else {
+					cli.PrintItemMarkdown(items)
+				}
+			case len(items) == 0:
 				fmt.Println("No items found.")
 				return nil
-			}
-
-			// Group by collection if listing all
-			if len(args) == 0 && groupBy == "" {
+			case grouped:
 				printItemsGroupedByCollection(items)
-			} else {
+			default:
 				cli.PrintItemTable(items)
 			}
 
@@ -439,6 +447,45 @@ Examples:
 	cmd.Flags().StringArrayVarP(&fieldFlags, "field", "f", nil, "filter by field value (repeatable): --field key=value")
 
 	return cmd
+}
+
+// renderItemsGroupedByCollectionMarkdown is the markdown counterpart of
+// printItemsGroupedByCollection (#898): one `## Icon Name (N)` heading per
+// collection, each followed by its own markdown table. Grouping is kept rather
+// than flattened so the markdown form carries the same information as the
+// table. Heading style matches `project changelog --format markdown`.
+func renderItemsGroupedByCollectionMarkdown(w io.Writer, items []models.Item) {
+	if len(items) == 0 {
+		fmt.Fprintln(w, "No items found.")
+		return
+	}
+
+	groups := make(map[string][]models.Item)
+	order := []string{}
+	for _, item := range items {
+		key := item.CollectionSlug
+		if _, exists := groups[key]; !exists {
+			order = append(order, key)
+		}
+		groups[key] = append(groups[key], item)
+	}
+
+	for i, key := range order {
+		groupItems := groups[key]
+		icon := ""
+		name := key
+		if groupItems[0].CollectionIcon != "" {
+			icon = groupItems[0].CollectionIcon + " "
+		}
+		if groupItems[0].CollectionName != "" {
+			name = groupItems[0].CollectionName
+		}
+		if i > 0 {
+			fmt.Fprintln(w)
+		}
+		fmt.Fprintf(w, "## %s%s (%d)\n\n", icon, name, len(groupItems))
+		cli.RenderItemMarkdown(w, groupItems)
+	}
 }
 
 func printItemsGroupedByCollection(items []models.Item) {
@@ -3079,6 +3126,11 @@ func starredCmd() *cobra.Command {
 
 			if formatFlag == "json" {
 				return cli.PrintJSON(items)
+			}
+
+			if formatFlag == "markdown" {
+				cli.PrintItemMarkdown(items)
+				return nil
 			}
 
 			if len(items) == 0 {

--- a/cmd/pad/cmd_item.go
+++ b/cmd/pad/cmd_item.go
@@ -472,18 +472,22 @@ func renderItemsGroupedByCollectionMarkdown(w io.Writer, items []models.Item) {
 
 	for i, key := range order {
 		groupItems := groups[key]
-		icon := ""
-		name := key
-		if groupItems[0].CollectionIcon != "" {
-			icon = groupItems[0].CollectionIcon + " "
-		}
+		// Sanitized, not raw: a newline or SGR sequence in a collection name or
+		// icon would otherwise inject document structure into the heading, which
+		// is the same hole the per-cell escaping closes inside the table.
+		// Sanitize the parts BEFORE joining, since sanitizing trims and would
+		// otherwise eat the separating space.
+		label := cli.SanitizeMarkdownText(key)
 		if groupItems[0].CollectionName != "" {
-			name = groupItems[0].CollectionName
+			label = cli.SanitizeMarkdownText(groupItems[0].CollectionName)
+		}
+		if icon := cli.SanitizeMarkdownText(groupItems[0].CollectionIcon); icon != "" {
+			label = icon + " " + label
 		}
 		if i > 0 {
 			fmt.Fprintln(w)
 		}
-		fmt.Fprintf(w, "## %s%s (%d)\n\n", icon, name, len(groupItems))
+		fmt.Fprintf(w, "## %s (%d)\n\n", label, len(groupItems))
 		cli.RenderItemMarkdown(w, groupItems)
 	}
 }
@@ -3128,13 +3132,16 @@ func starredCmd() *cobra.Command {
 				return cli.PrintJSON(items)
 			}
 
-			if formatFlag == "markdown" {
-				cli.PrintItemMarkdown(items)
+			// Checked before the markdown branch so both formats give the
+			// command-specific message; the shared renderer would say the
+			// generic "No items found." here.
+			if len(items) == 0 {
+				fmt.Println("No starred items.")
 				return nil
 			}
 
-			if len(items) == 0 {
-				fmt.Println("No starred items.")
+			if formatFlag == "markdown" {
+				cli.PrintItemMarkdown(items)
 				return nil
 			}
 

--- a/cmd/pad/format_markdown_list_test.go
+++ b/cmd/pad/format_markdown_list_test.go
@@ -56,6 +56,54 @@ func TestRenderItemsGroupedByCollectionMarkdown_GroupsWithHeadings(t *testing.T)
 	}
 }
 
+// The group heading interpolates the collection icon and name into "## …".
+// A newline in either injects document structure, which breaks the same
+// guarantee the per-cell escaping provides inside the table.
+// Reported by @xarmian in review of PR #1070.
+func TestRenderItemsGroupedByCollectionMarkdown_SanitizesHeading(t *testing.T) {
+	items := []models.Item{{
+		CollectionSlug: "tasks",
+		CollectionName: "Tasks\n## Injected Heading",
+		CollectionIcon: "✓",
+		// A stray SGR sequence must not survive into the heading either.
+		CollectionPrefix: "TASK", ItemNumber: mdNum(1),
+		Title: "t", Fields: `{"status":"ready"}`, UpdatedAt: time.Now(),
+	}}
+
+	var buf bytes.Buffer
+	renderItemsGroupedByCollectionMarkdown(&buf, items)
+	out := buf.String()
+
+	headings := 0
+	for _, line := range strings.Split(out, "\n") {
+		if strings.HasPrefix(line, "## ") {
+			headings++
+		}
+	}
+	if headings != 1 {
+		t.Errorf("got %d headings, want 1 — newline in the collection name injected structure:\n%s", headings, out)
+	}
+	if strings.Contains(out, "\n## Injected Heading") {
+		t.Errorf("injected heading survived:\n%s", out)
+	}
+}
+
+func TestRenderItemsGroupedByCollectionMarkdown_StripsANSIFromHeading(t *testing.T) {
+	items := []models.Item{{
+		CollectionSlug:   "tasks",
+		CollectionName:   "\x1b[1;31mTasks\x1b[0m",
+		CollectionPrefix: "TASK", ItemNumber: mdNum(1),
+		Title: "t", Fields: `{}`, UpdatedAt: time.Now(),
+	}}
+
+	var buf bytes.Buffer
+	renderItemsGroupedByCollectionMarkdown(&buf, items)
+
+	if strings.Contains(buf.String(), "\x1b[") {
+		t.Errorf("ANSI escape survived into the heading: %q", buf.String())
+	}
+}
+
 func TestRenderItemsGroupedByCollectionMarkdown_Empty(t *testing.T) {
 	var buf bytes.Buffer
 	renderItemsGroupedByCollectionMarkdown(&buf, nil)

--- a/cmd/pad/format_markdown_list_test.go
+++ b/cmd/pad/format_markdown_list_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+func mdNum(n int) *int { return &n }
+
+// `pad item list` with no collection argument groups by collection. The
+// markdown form has to keep that grouping — a flat table would lose
+// information the table format shows (#898).
+func TestRenderItemsGroupedByCollectionMarkdown_GroupsWithHeadings(t *testing.T) {
+	items := []models.Item{
+		{
+			CollectionSlug: "tasks", CollectionName: "Tasks", CollectionIcon: "✓",
+			CollectionPrefix: "TASK", ItemNumber: mdNum(1),
+			Title: "first task", Fields: `{"status":"ready"}`, UpdatedAt: time.Now(),
+		},
+		{
+			CollectionSlug: "ideas", CollectionName: "Ideas", CollectionIcon: "💡",
+			CollectionPrefix: "IDEA", ItemNumber: mdNum(7),
+			Title: "an idea", Fields: `{"status":"new"}`, UpdatedAt: time.Now(),
+		},
+		{
+			CollectionSlug: "tasks", CollectionName: "Tasks", CollectionIcon: "✓",
+			CollectionPrefix: "TASK", ItemNumber: mdNum(2),
+			Title: "second task", Fields: `{"status":"done"}`, UpdatedAt: time.Now(),
+		},
+	}
+
+	var buf bytes.Buffer
+	renderItemsGroupedByCollectionMarkdown(&buf, items)
+	out := buf.String()
+
+	if !strings.Contains(out, "## ✓ Tasks (2)") {
+		t.Errorf("missing Tasks heading with count:\n%s", out)
+	}
+	if !strings.Contains(out, "## 💡 Ideas (1)") {
+		t.Errorf("missing Ideas heading with count:\n%s", out)
+	}
+	// One table per group, so one header row per group.
+	if n := strings.Count(out, "| Ref | Title |"); n != 2 {
+		t.Errorf("got %d table headers, want 2 (one per group):\n%s", n, out)
+	}
+	// First-seen collection order is preserved (tasks before ideas).
+	if strings.Index(out, "Tasks (2)") > strings.Index(out, "Ideas (1)") {
+		t.Errorf("group order not preserved:\n%s", out)
+	}
+	if strings.Contains(out, "\x1b[") {
+		t.Errorf("markdown output contains ANSI escapes:\n%q", out)
+	}
+}
+
+func TestRenderItemsGroupedByCollectionMarkdown_Empty(t *testing.T) {
+	var buf bytes.Buffer
+	renderItemsGroupedByCollectionMarkdown(&buf, nil)
+	if got := buf.String(); got != "No items found.\n" {
+		t.Errorf("empty render = %q, want %q", got, "No items found.\n")
+	}
+}

--- a/cmd/pad/format_markdown_routing_test.go
+++ b/cmd/pad/format_markdown_routing_test.go
@@ -1,0 +1,178 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// End-to-end coverage of the --format routing itself, not just the render
+// helpers: the command is executed through cobra against an httptest server, so
+// a future edit that drops the markdown branch from a RunE fails here even
+// though the renderer tests still pass. Requested by @xarmian on PR #1070.
+//
+// Follows the house pattern from item_open_test.go (httptest + package flag
+// vars), with one addition: USERPROFILE is set alongside HOME because Go's
+// os.UserHomeDir reads USERPROFILE on Windows, and the credential store resolves
+// through it. Setting only HOME leaves the store pointed at the developer's real
+// ~/.pad on Windows.
+func setupFormatRoutingTest(t *testing.T, handler http.Handler) *httptest.Server {
+	t.Helper()
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	prevWorkspace, prevURL, prevFormat := workspaceFlag, urlFlag, formatFlag
+	workspaceFlag = "demo"
+	urlFlag = server.URL + "/"
+	t.Cleanup(func() {
+		workspaceFlag, urlFlag, formatFlag = prevWorkspace, prevURL, prevFormat
+	})
+
+	return server
+}
+
+// captureStdout runs fn with os.Stdout redirected and returns what it wrote.
+// The list commands print through fmt/os.Stdout rather than cmd.OutOrStdout,
+// so cobra's SetOut isn't enough here.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stdout = w
+	defer func() { os.Stdout = orig }()
+
+	fn()
+
+	_ = w.Close()
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(r); err != nil {
+		t.Fatalf("read captured stdout: %v", err)
+	}
+	return buf.String()
+}
+
+func routingTestItems() []models.Item {
+	one, two := 1, 2
+	return []models.Item{
+		{
+			Slug: "first-task", CollectionSlug: "tasks", CollectionName: "Tasks",
+			CollectionIcon: "✓", CollectionPrefix: "TASK", ItemNumber: &one,
+			Title: "first task", Fields: `{"status":"ready","priority":"high"}`,
+		},
+		{
+			Slug: "an-idea", CollectionSlug: "ideas", CollectionName: "Ideas",
+			CollectionIcon: "💡", CollectionPrefix: "IDEA", ItemNumber: &two,
+			Title: "an idea", Fields: `{"status":"new"}`,
+		},
+	}
+}
+
+func routingTestHandler(items []models.Item) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/items"):
+			_ = json.NewEncoder(w).Encode(items)
+		default:
+			http.NotFound(w, r)
+		}
+	})
+}
+
+func TestItemListRoutesToMarkdown(t *testing.T) {
+	setupFormatRoutingTest(t, routingTestHandler(routingTestItems()))
+	formatFlag = "markdown"
+
+	cmd := listCmd()
+	cmd.SetArgs(nil)
+
+	var execErr error
+	out := captureStdout(t, func() { execErr = cmd.Execute() })
+	if execErr != nil {
+		t.Fatalf("execute item list --format markdown: %v", execErr)
+	}
+
+	// Grouped markdown: a heading per collection, each with a markdown table.
+	for _, want := range []string{
+		"## ✓ Tasks (1)",
+		"## 💡 Ideas (1)",
+		"| Ref | Title | Status | Priority | Collection | Updated |",
+		"| TASK-1 |",
+		"| IDEA-2 |",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("markdown output missing %q:\n%s", want, out)
+		}
+	}
+	// The table renderer's column headers must not appear.
+	if strings.Contains(out, "PRIORITY") {
+		t.Errorf("table output leaked into the markdown path:\n%s", out)
+	}
+}
+
+func TestItemListRoutesToTableByDefault(t *testing.T) {
+	setupFormatRoutingTest(t, routingTestHandler(routingTestItems()))
+	formatFlag = "table"
+
+	cmd := listCmd()
+	cmd.SetArgs(nil)
+
+	var execErr error
+	out := captureStdout(t, func() { execErr = cmd.Execute() })
+	if execErr != nil {
+		t.Fatalf("execute item list: %v", execErr)
+	}
+
+	if strings.Contains(out, "| Ref | Title |") {
+		t.Errorf("markdown table leaked into the default table path:\n%s", out)
+	}
+	if !strings.Contains(out, "TASK-1") {
+		t.Errorf("table output missing the item ref:\n%s", out)
+	}
+}
+
+func TestCollectionListRoutesToMarkdown(t *testing.T) {
+	colls := []models.Collection{
+		{Name: "Tasks", Slug: "tasks", Icon: "✓", ItemCount: 3, IsDefault: true},
+	}
+	setupFormatRoutingTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/collections") {
+			_ = json.NewEncoder(w).Encode(colls)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	formatFlag = "markdown"
+
+	cmd := collectionsCmd()
+	cmd.SetArgs(nil)
+
+	var execErr error
+	out := captureStdout(t, func() { execErr = cmd.Execute() })
+	if execErr != nil {
+		t.Fatalf("execute collection list --format markdown: %v", execErr)
+	}
+
+	for _, want := range []string{"| Name | Slug | Items | Default |", "| ✓ Tasks | tasks | 3 | yes |"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("markdown output missing %q:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "NAME") {
+		t.Errorf("table output leaked into the markdown path:\n%s", out)
+	}
+}

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -124,7 +124,7 @@ func newRootCmd() *cobra.Command {
 	})
 
 	rootCmd.PersistentFlags().StringVar(&workspaceFlag, "workspace", "", "workspace slug override")
-	rootCmd.PersistentFlags().StringVar(&formatFlag, "format", "table", "output format: table, json (markdown on select commands, e.g. item show, project changelog)")
+	rootCmd.PersistentFlags().StringVar(&formatFlag, "format", "table", "output format: table, json, markdown (markdown on the list/show commands, e.g. item list, collection list, item show, project changelog)")
 	rootCmd.PersistentFlags().StringVar(&urlFlag, "url", "", "server URL override (e.g., https://app.getpad.dev)")
 
 	rootCmd.AddCommand(

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -124,7 +124,7 @@ func newRootCmd() *cobra.Command {
 	})
 
 	rootCmd.PersistentFlags().StringVar(&workspaceFlag, "workspace", "", "workspace slug override")
-	rootCmd.PersistentFlags().StringVar(&formatFlag, "format", "table", "output format: table, json, markdown (markdown on the list/show commands, e.g. item list, collection list, item show, project changelog)")
+	rootCmd.PersistentFlags().StringVar(&formatFlag, "format", "table", "output format: table, json, markdown (markdown on: item list/starred, collection list, item show, project changelog)")
 	rootCmd.PersistentFlags().StringVar(&urlFlag, "url", "", "server URL override (e.g., https://app.getpad.dev)")
 
 	rootCmd.AddCommand(

--- a/internal/cli/format_markdown.go
+++ b/internal/cli/format_markdown.go
@@ -1,0 +1,145 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// Markdown list rendering (#898).
+//
+// The `--format markdown` branch of the list commands writes a GitHub-flavored
+// markdown table. Two rules separate it from the table renderer:
+//
+//  1. No ANSI. Markdown output is destined for a file, a PR body, or an agent's
+//     context — never a terminal — so the colorized helpers (ColorizedStatus,
+//     PriorityColor, Dim) are deliberately NOT reused here. Raw field values go
+//     in and the reader's renderer does the styling.
+//  2. Every cell is escaped. An unescaped `|` in a title silently adds a column
+//     and corrupts the row; a newline ends the row early.
+//
+// Widths are not computed — markdown renderers lay the table out themselves, so
+// the width-aware column math in renderItemTable has no counterpart here.
+
+// escapeMarkdownCell makes an arbitrary string safe inside a table cell: ANSI
+// escapes are stripped, pipes are escaped so they can't start a new column, and
+// newlines collapse to spaces so they can't end the row.
+func escapeMarkdownCell(s string) string {
+	s = sgrPattern.ReplaceAllString(s, "")
+	s = strings.ReplaceAll(s, "|", `\|`)
+	s = strings.NewReplacer("\r\n", " ", "\n", " ", "\r", " ").Replace(s)
+	return strings.TrimSpace(s)
+}
+
+// writeMarkdownRow writes one pipe-delimited row. Cells are expected to be
+// pre-escaped.
+func writeMarkdownRow(w io.Writer, cells ...string) {
+	fmt.Fprintf(w, "| %s |\n", strings.Join(cells, " | "))
+}
+
+// writeMarkdownSeparator writes the header/body separator for n columns.
+func writeMarkdownSeparator(w io.Writer, n int) {
+	cells := make([]string, n)
+	for i := range cells {
+		cells[i] = "---"
+	}
+	writeMarkdownRow(w, cells...)
+}
+
+// PrintItemMarkdown prints items as a markdown table on stdout.
+func PrintItemMarkdown(items []models.Item) {
+	RenderItemMarkdown(os.Stdout, items)
+}
+
+// RenderItemMarkdown is the writer-taking core of PrintItemMarkdown. Columns
+// mirror the table renderer's — Ref · Title · Status · Priority · Collection ·
+// Updated — so switching format changes the styling, not the information.
+// Exported because cmd/pad composes it per collection group.
+func RenderItemMarkdown(w io.Writer, items []models.Item) {
+	if len(items) == 0 {
+		fmt.Fprintln(w, "No items found.")
+		return
+	}
+
+	writeMarkdownRow(w, "Ref", "Title", "Status", "Priority", "Collection", "Updated")
+	writeMarkdownSeparator(w, 6)
+
+	for _, item := range items {
+		// The ref is the item's handle for every other command, so fall back to
+		// the slug rather than emitting an unusable empty first cell.
+		ref := ItemRef(item)
+		if ref == "" {
+			ref = item.Slug
+		}
+		if item.Pinned {
+			// The table marks pins with a yellow "*"; colour is unavailable
+			// here, so the marker has to be a glyph.
+			ref = "📌 " + ref
+		}
+
+		title := item.Title
+		if item.DeletedAt != nil {
+			title += " (archived)"
+		}
+
+		status, priority := itemStatusPriority(item.Fields)
+		if status == "" {
+			status = "—"
+		}
+		if priority == "" {
+			priority = "—"
+		}
+
+		collection := item.CollectionName
+		if item.CollectionIcon != "" {
+			collection = item.CollectionIcon + " " + collection
+		}
+
+		writeMarkdownRow(w,
+			escapeMarkdownCell(ref),
+			escapeMarkdownCell(title),
+			escapeMarkdownCell(status),
+			escapeMarkdownCell(priority),
+			escapeMarkdownCell(collection),
+			escapeMarkdownCell(RelativeTime(item.UpdatedAt)),
+		)
+	}
+}
+
+// PrintCollectionMarkdown prints collections as a markdown table on stdout.
+func PrintCollectionMarkdown(collections []models.Collection) {
+	RenderCollectionMarkdown(os.Stdout, collections)
+}
+
+// RenderCollectionMarkdown is the writer-taking core of
+// PrintCollectionMarkdown. Columns mirror PrintCollectionTable's.
+func RenderCollectionMarkdown(w io.Writer, collections []models.Collection) {
+	if len(collections) == 0 {
+		fmt.Fprintln(w, "No collections found.")
+		return
+	}
+
+	writeMarkdownRow(w, "Name", "Slug", "Items", "Default")
+	writeMarkdownSeparator(w, 4)
+
+	for _, col := range collections {
+		name := col.Name
+		if col.Icon != "" {
+			name = col.Icon + " " + name
+		}
+		def := ""
+		if col.IsDefault {
+			def = "yes"
+		}
+		writeMarkdownRow(w,
+			escapeMarkdownCell(name),
+			escapeMarkdownCell(col.Slug),
+			strconv.Itoa(col.ItemCount),
+			def,
+		)
+	}
+}

--- a/internal/cli/format_markdown.go
+++ b/internal/cli/format_markdown.go
@@ -25,14 +25,31 @@ import (
 // Widths are not computed — markdown renderers lay the table out themselves, so
 // the width-aware column math in renderItemTable has no counterpart here.
 
-// escapeMarkdownCell makes an arbitrary string safe inside a table cell: ANSI
-// escapes are stripped, pipes are escaped so they can't start a new column, and
-// newlines collapse to spaces so they can't end the row.
-func escapeMarkdownCell(s string) string {
+// SanitizeMarkdownText makes an arbitrary string safe to interpolate into
+// markdown OUTSIDE a table cell — a heading, say. ANSI escapes are stripped and
+// newlines collapse to spaces, so a value carrying a line break can't inject
+// document structure. Pipes are left alone: they're only special inside a table.
+func SanitizeMarkdownText(s string) string {
 	s = sgrPattern.ReplaceAllString(s, "")
-	s = strings.ReplaceAll(s, "|", `\|`)
 	s = strings.NewReplacer("\r\n", " ", "\n", " ", "\r", " ").Replace(s)
 	return strings.TrimSpace(s)
+}
+
+// escapeMarkdownCell makes an arbitrary string safe INSIDE a table cell: it
+// sanitizes as above, then escapes backslashes and pipes.
+//
+// Order matters. Escaping the pipe alone is not enough: a title containing a
+// backslash immediately before a pipe ("…\|…") would become "…\\|…", which GFM
+// reads as an escaped backslash followed by a LIVE pipe, so the row still gains
+// a column. Escaping backslashes FIRST turns it into "…\\\|…" — an escaped
+// backslash then an escaped pipe — which renders back to the literal text.
+// Doing it the other way round would double-escape the backslashes we just
+// introduced. (Caught by @xarmian reviewing PR #1070.)
+func escapeMarkdownCell(s string) string {
+	s = SanitizeMarkdownText(s)
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, "|", `\|`)
+	return s
 }
 
 // writeMarkdownRow writes one pipe-delimited row. Cells are expected to be

--- a/internal/cli/format_markdown_test.go
+++ b/internal/cli/format_markdown_test.go
@@ -86,6 +86,44 @@ func TestRenderItemMarkdown_EscapesPipesInTitle(t *testing.T) {
 	}
 }
 
+// A title that already contains a backslash immediately before a pipe is the
+// case escaping the pipe alone can't survive: "\" + "|" becomes "\" + "\|",
+// which GFM reads as an escaped backslash followed by a LIVE pipe, so the row
+// still gains a column. The backslash has to be escaped first.
+// Reported by @xarmian in review of PR #1070.
+func TestRenderItemMarkdown_EscapesBackslashBeforePipe(t *testing.T) {
+	// Built by concatenation so the intent is unambiguous: a, space,
+	// backslash, pipe, space, b.
+	title := "a " + `\` + "|" + " b"
+
+	items := []models.Item{{
+		CollectionPrefix: "BUG",
+		ItemNumber:       num(10),
+		Title:            title,
+		Fields:           `{}`,
+		CollectionName:   "Bugs",
+		UpdatedAt:        time.Now(),
+	}}
+
+	var buf bytes.Buffer
+	RenderItemMarkdown(&buf, items)
+	row := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")[2]
+
+	// Want: escaped backslash (\\) then escaped pipe (\|) — three backslashes
+	// then a pipe. GFM renders that back to the literal "a \| b".
+	want := "a " + `\\\|` + " b"
+	if !strings.Contains(row, want) {
+		t.Errorf("backslash not escaped before pipe.\n got: %q\nwant substring: %q", row, want)
+	}
+
+	// Structural check: exactly 6 cells, so 7 delimiting pipes. Any live pipe
+	// from the title would push this higher.
+	delimiters := strings.Count(row, "|") - strings.Count(row, `\|`)
+	if delimiters != 7 {
+		t.Errorf("row has %d delimiting pipes, want 7 (6 cells): %q", delimiters, row)
+	}
+}
+
 func TestRenderItemMarkdown_NoANSIEscapes(t *testing.T) {
 	forceColor(t)
 

--- a/internal/cli/format_markdown_test.go
+++ b/internal/cli/format_markdown_test.go
@@ -1,0 +1,193 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+	"github.com/fatih/color"
+)
+
+// forceColor forces ANSI ON, so a renderer that leaks colorized helpers into
+// markdown output fails loudly instead of passing on a non-TTY test runner.
+func forceColor(t *testing.T) {
+	t.Helper()
+	prev := color.NoColor
+	color.NoColor = false
+	t.Cleanup(func() { color.NoColor = prev })
+}
+
+func num(n int) *int { return &n }
+
+func TestRenderItemMarkdown_Empty(t *testing.T) {
+	var buf bytes.Buffer
+	RenderItemMarkdown(&buf, nil)
+	if got := buf.String(); got != "No items found.\n" {
+		t.Errorf("empty render = %q, want %q", got, "No items found.\n")
+	}
+}
+
+func TestRenderItemMarkdown_TableShape(t *testing.T) {
+	items := []models.Item{{
+		CollectionPrefix: "TASK",
+		ItemNumber:       num(5),
+		Title:            "Wire up the widget",
+		Fields:           `{"status":"in-progress","priority":"high"}`,
+		CollectionName:   "Tasks",
+		CollectionIcon:   "✓",
+		UpdatedAt:        time.Now(),
+	}}
+
+	var buf bytes.Buffer
+	RenderItemMarkdown(&buf, items)
+	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+
+	if len(lines) != 3 {
+		t.Fatalf("got %d lines, want 3 (header, separator, one row):\n%s", len(lines), buf.String())
+	}
+	if want := "| Ref | Title | Status | Priority | Collection | Updated |"; lines[0] != want {
+		t.Errorf("header = %q, want %q", lines[0], want)
+	}
+	if want := "| --- | --- | --- | --- | --- | --- |"; lines[1] != want {
+		t.Errorf("separator = %q, want %q", lines[1], want)
+	}
+	for _, want := range []string{"TASK-5", "Wire up the widget", "in-progress", "high", "Tasks"} {
+		if !strings.Contains(lines[2], want) {
+			t.Errorf("row %q missing %q", lines[2], want)
+		}
+	}
+	if n := strings.Count(lines[2], "|"); n != 7 {
+		t.Errorf("row has %d pipes, want 7 (6 cells): %q", n, lines[2])
+	}
+}
+
+func TestRenderItemMarkdown_EscapesPipesInTitle(t *testing.T) {
+	items := []models.Item{{
+		CollectionPrefix: "BUG",
+		ItemNumber:       num(9),
+		Title:            "crash in a | b parser",
+		Fields:           `{}`,
+		CollectionName:   "Bugs",
+		UpdatedAt:        time.Now(),
+	}}
+
+	var buf bytes.Buffer
+	RenderItemMarkdown(&buf, items)
+	row := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")[2]
+
+	if !strings.Contains(row, `a \| b`) {
+		t.Errorf("row did not escape the pipe in the title: %q", row)
+	}
+	// An unescaped pipe would add a seventh cell and break the table.
+	if n := strings.Count(row, "|"); n != 8 {
+		t.Errorf("row has %d pipes, want 8 (6 cells + 1 escaped): %q", n, row)
+	}
+}
+
+func TestRenderItemMarkdown_NoANSIEscapes(t *testing.T) {
+	forceColor(t)
+
+	items := []models.Item{{
+		CollectionPrefix: "TASK",
+		ItemNumber:       num(1),
+		Title:            "colorful",
+		Fields:           `{"status":"done","priority":"critical"}`,
+		CollectionName:   "Tasks",
+		UpdatedAt:        time.Now(),
+		Pinned:           true,
+	}}
+
+	var buf bytes.Buffer
+	RenderItemMarkdown(&buf, items)
+
+	if strings.Contains(buf.String(), "\x1b[") {
+		t.Errorf("markdown output contains ANSI escapes: %q", buf.String())
+	}
+}
+
+func TestRenderItemMarkdown_MissingFieldsRenderDash(t *testing.T) {
+	items := []models.Item{{
+		CollectionPrefix: "IDEA",
+		ItemNumber:       num(2),
+		Title:            "no status or priority",
+		Fields:           `{}`,
+		CollectionName:   "Ideas",
+		UpdatedAt:        time.Now(),
+	}}
+
+	var buf bytes.Buffer
+	RenderItemMarkdown(&buf, items)
+	row := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")[2]
+
+	if strings.Count(row, "—") != 2 {
+		t.Errorf("want an em dash for both empty status and priority, got %q", row)
+	}
+}
+
+func TestRenderItemMarkdown_MarksArchived(t *testing.T) {
+	deleted := time.Now()
+	items := []models.Item{{
+		CollectionPrefix: "TASK",
+		ItemNumber:       num(3),
+		Title:            "gone",
+		Fields:           `{}`,
+		CollectionName:   "Tasks",
+		UpdatedAt:        time.Now(),
+		DeletedAt:        &deleted,
+	}}
+
+	var buf bytes.Buffer
+	RenderItemMarkdown(&buf, items)
+	row := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")[2]
+
+	if !strings.Contains(row, "(archived)") {
+		t.Errorf("archived item not marked: %q", row)
+	}
+}
+
+func TestRenderCollectionMarkdown_Empty(t *testing.T) {
+	var buf bytes.Buffer
+	RenderCollectionMarkdown(&buf, nil)
+	if got := buf.String(); got != "No collections found.\n" {
+		t.Errorf("empty render = %q, want %q", got, "No collections found.\n")
+	}
+}
+
+func TestRenderCollectionMarkdown_TableShape(t *testing.T) {
+	colls := []models.Collection{{
+		Name:      "Tasks",
+		Slug:      "tasks",
+		Icon:      "✓",
+		ItemCount: 12,
+		IsDefault: true,
+	}, {
+		Name:      "Ideas",
+		Slug:      "ideas",
+		ItemCount: 3,
+	}}
+
+	var buf bytes.Buffer
+	RenderCollectionMarkdown(&buf, colls)
+	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+
+	if len(lines) != 4 {
+		t.Fatalf("got %d lines, want 4 (header, separator, two rows):\n%s", len(lines), buf.String())
+	}
+	if want := "| Name | Slug | Items | Default |"; lines[0] != want {
+		t.Errorf("header = %q, want %q", lines[0], want)
+	}
+	if want := "| --- | --- | --- | --- |"; lines[1] != want {
+		t.Errorf("separator = %q, want %q", lines[1], want)
+	}
+	if !strings.Contains(lines[2], "tasks") || !strings.Contains(lines[2], "12") {
+		t.Errorf("first row missing slug/count: %q", lines[2])
+	}
+	if !strings.Contains(lines[2], "yes") {
+		t.Errorf("default collection not marked: %q", lines[2])
+	}
+	if strings.Contains(lines[3], "yes") {
+		t.Errorf("non-default collection wrongly marked: %q", lines[3])
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Implements #898: `--format markdown` on the list commands that lacked it.

- **`pad item list`** — grouped `## Icon Name (N)` sections with a markdown table each when listing across collections, mirroring the table format's grouping; a single table when scoped to one collection. Heading style matches `project changelog --format markdown`.
- **`pad item starred`** — single table.
- **`pad collection list`** — Name / Slug / Items / Default.
- **`--format` help** — drops the "markdown on select commands" caveat added in #893.

Renderers live in a new `internal/cli/format_markdown.go` (`RenderItemMarkdown`, `RenderCollectionMarkdown`, `escapeMarkdownCell`), so wiring the next command is two lines.

Two design notes:

1. **No ANSI, by design.** The markdown path deliberately does not reuse `ColorizedStatus` / `PriorityColor` / `Dim`. Markdown output is destined for a file, a PR body, or an agent's context, so raw field values go in and the reader's renderer does the styling. A test forces `color.NoColor = false` and asserts the output contains no escape sequences, so a future edit can't quietly leak colour into a markdown table.
2. **Every cell is escaped.** An unescaped `|` in an item title silently adds a column and corrupts the row; newlines end it early. `escapeMarkdownCell` strips SGR escapes, escapes pipes, and collapses newlines.

Item columns mirror the table renderer's (Ref, Title, Status, Priority, Collection, Updated) so switching format changes the styling, not the information. Where colour carried meaning and can't survive, a glyph stands in: pinned items get a `📌` prefix on the ref (the table uses a yellow `*`), and archived items keep the `(archived)` suffix.

## Empirical output

`pad item list tasks --format markdown`:

| Ref | Title | Status | Priority | Collection | Updated |
| --- | --- | --- | --- | --- | --- |
| 📌 TASK-314 | Push to fork, draft PR | done | high | ✓ Tasks | 2 hours ago |
| BUG-42 | parser chokes on a \| b input | ready | — | 🐛 Bugs | 1 day ago |
| IDEA-7 | retired idea (archived) | — | — | 💡 Ideas | 3 days ago |

`pad collection list --format markdown`:

| Name | Slug | Items | Default |
| --- | --- | --- | --- |
| ✓ Tasks | tasks | 208 | yes |
| 💡 Ideas | ideas | 159 | yes |
| Decisions | decisions | 4 |  |

Empty result sets print `No items found.` / `No collections found.`, matching the table renderers.

## How to test

1. `go test ./internal/cli/ -run Markdown -count=1` and `go test ./cmd/pad/ -run GroupedByCollectionMarkdown -count=1`
2. `pad item list --format markdown` (grouped), `pad item list tasks --format markdown` (single table), `pad collection list --format markdown`, `pad item starred --format markdown`
3. `pad --help | grep format` for the updated flag help
4. Corrupt-table check: create an item with a `|` in the title and confirm the row still renders as six cells

## Gate results

- `go build ./...` — PASS
- `go vet ./internal/cli ./cmd/pad` — PASS
- `golangci-lint run ./internal/cli/... ./cmd/pad/...` — PASS (0 issues)
- `gofmt -l` on the changed files — clean
- New tests — PASS (8 in `internal/cli/format_markdown_test.go`, 2 in `cmd/pad/format_markdown_list_test.go`), each written before the implementation and confirmed failing first

## Checklist

- [ ] `make build` — not run; needs the generated `web/build` embed assets. `go build ./...` passes.
- [ ] `make test` — the two touched packages have a red Windows baseline on clean `main` (7 credential/HOME failures in `internal/cli`, plus `TestWriteFileAtomic_WritesContent` and `TestHeadlessSetupNoTokenFileOK` in `cmd/pad`). I captured that baseline by stashing this branch and re-running; the failure set is identical with and without these changes. Same wall @cnYui hit on #910.
- [x] New features have tests
- [x] TypeScript types updated — N/A, CLI-only
- [x] CLI help text updated — yes, the `--format` flag help

There's an open question on #898 about whether the remaining table-printing surfaces (`item deps`, `item comments`, `project activity`, `attachment list`, `library list`, `role list`, `workspace members`) should come in here too, which would let the flag help drop the parenthetical entirely. Happy to extend this PR either way.