### PR TITLE
fix(e2e): resolve imported attachment via content reference, not list page 1 (BUG-2504)

### DIFF
--- a/web/e2e/workspace-bundle-roundtrip.spec.ts
+++ b/web/e2e/workspace-bundle-roundtrip.spec.ts
@@ -259,32 +259,33 @@ test('workspace export → import round-trip via web UI', async ({ page, fixture
 	expect(importedItem.content).not.toContain(`pad-attachment:${seeded.attachmentID}`);
 	expect(importedItem.content).toMatch(/pad-attachment:[0-9a-f-]{36}/);
 
-	// 5c. The rehydrated attachment row must be downloadable and
-	// the bytes must match the original PNG. This is the strongest
-	// possible round-trip assertion — every layer (export tar →
-	// import dispatch → rehydrate → storage backend → download)
-	// must work or the bytes won't match.
-	const attListResp = await request.get(`/api/v1/workspaces/${newSlug}/attachments`, {
-		headers: auth
-	});
-	if (!attListResp.ok()) {
-		throw new Error(
-			`imported attachments list failed (${attListResp.status()}): ${await attListResp.text()}`
-		);
-	}
-	const attList = (await attListResp.json()) as { attachments: { id: string; filename: string }[] };
-	expect(attList.attachments.length).toBeGreaterThan(0);
-	const newAtt = attList.attachments.find((a) => a.filename === 'roundtrip-logo.png');
-	expect(newAtt, 'imported attachment with the seeded filename should exist').toBeTruthy();
-	expect(newAtt!.id).not.toBe(seeded.attachmentID);
+	// 5c. Resolve the REWRITTEN reference straight from the imported
+	// content. The seeded attachment is a workspace-level row that the
+	// item references only through its markdown (item_id is NULL by
+	// design), so an item_id-scoped list can't see it — and the
+	// workspace-wide list defaults to limit 50 / created_at_desc,
+	// which silently drops the logo once the shared e2e workspace
+	// outgrows one page (sibling specs' fixtures did exactly that:
+	// BUG-2504 held main's CI red from 2026-08-06). The content URI is
+	// the contract the UI actually follows, so assert through it: the
+	// rewritten id must resolve, carry the seeded filename, and serve
+	// back the original bytes — every layer (export tar → import
+	// dispatch → rehydrate → storage backend → download) must work or
+	// the bytes won't match.
+	const newID = importedItem.content.match(/pad-attachment:([0-9a-f-]{36})/)![1];
+	expect(newID).not.toBe(seeded.attachmentID);
 
 	const blobResp = await request.get(
-		`/api/v1/workspaces/${newSlug}/attachments/${newAtt!.id}`,
+		`/api/v1/workspaces/${newSlug}/attachments/${newID}`,
 		{ headers: auth }
 	);
 	if (!blobResp.ok()) {
 		throw new Error(`download imported blob failed (${blobResp.status()})`);
 	}
+	expect(
+		blobResp.headers()['content-disposition'] ?? '',
+		'imported attachment should keep the seeded filename'
+	).toContain('filename="roundtrip-logo.png"');
 	const downloadedBytes = await blobResp.body();
 	expect(downloadedBytes.length).toBe(REAL_PNG.length);
 	expect(downloadedBytes.equals(REAL_PNG)).toBe(true);


### PR DESCRIPTION
## What

Fixes the `workspace-bundle-roundtrip` E2E failure that has held main's CI red since 2026-08-06 (BUG-2504).

## Root cause

The spec's final assertion fished the imported workspace's **unscoped** attachment list, which defaults to `limit 50 / created_at_desc`. The suite's newer browser-proof specs (PLAN-2392) grew the shared `e2e` workspace past one page (73 attachments in the failing run's trace), so the seeded `roundtrip-logo.png` — old in the sort — fell off page 1 and the `find()` returned nothing. The regression window on main contained only dependabot CI-action bumps: the race was latent and runner-timing shifts made it deterministic. Verified from the failed run's Playwright trace: list response `total: 73`, page of 50, no logo.

An `item_id`-scoped list can't work either — the seed uploads at workspace level and references the attachment only through the item's markdown, so `item_id` is NULL by design (confirmed by a scoped query returning `total: 0`).

## Fix

Resolve the **rewritten `pad-attachment:` UUID straight from the imported item's content** — the contract the UI actually follows — then assert the blob GET returns the seeded filename (via `Content-Disposition`) and byte-identical PNG. Immune to suite growth by construction; the filename and bytes assertions are strictly stronger than the old list-fishing.

## Verification

- Single spec: green locally.
- **Full Playwright suite locally (the actual failure condition, 70+ attachments in the shared workspace): 148 passed**, roundtrip green; one unrelated known-flaky spec passed on retry.
- `npm run check`: 0 errors.

https://claude.ai/code/session_01VxyZv1g6W6rGx7nuaGcH3i