### PR TITLE
PLAN-2392 phase 3c-iii: attachment lifecycle completeness

### DIFF
--- a/web/e2e/attachment-lifecycle.spec.ts
+++ b/web/e2e/attachment-lifecycle.spec.ts
@@ -1,0 +1,407 @@
+import { test, expect } from './fixtures';
+import { browserLogin, seedDoc } from './lib/collab-helpers';
+import {
+	DESKTOP,
+	REAL_PNG,
+	TILE,
+	STRIP_DELETE,
+	VIEWER,
+	VIEWER_IMAGE,
+	VIEWER_COUNTER,
+	VIEWER_MISSING,
+	archiveItem,
+	bulkItems,
+	createDoc,
+	createWorkspace,
+	deleteWorkspace,
+	itemUrl,
+	postComment,
+	uploadAttachment
+} from './lib/attachment-viewer';
+
+/**
+ * 3c-iii ATTACHMENT LIFECYCLE COMPLETENESS — the browser proof (PLAN-2392 U5 /
+ * TASK-2514, the final task in the serial spine).
+ *
+ * The falsifiable subset jsdom cannot see, one leg per lifecycle mechanism the
+ * chain built:
+ *
+ *  - U3 (navigation-step revalidation): arrowing to a sibling deleted from
+ *    ANOTHER context force-probes it no-store and tombstone-advances — a real
+ *    browser HTTP cache, a real cross-context delete, a real arrow. jsdom has no
+ *    HTTP cache to bypass and no network to 404.
+ *  - U2 (strip restore revalidation): the archive-no-op / restore-refetch
+ *    list-request choreography, driven through the REAL SSE bulk path
+ *    (`items_bulk_updated`, no `item_id`) that only a browser + server exercise.
+ *  - U1 (timeline lifecycle reconciliation): a comment thumbnail flipping to the
+ *    missing presentation off the process-local deletion bus, live, no reload.
+ *
+ * Desktop-chromium only: these drive keyboard navigation, the strip's delete
+ * control and multi-tab layout — the mobile sheet's own lifecycle is 3d.
+ */
+test.describe('attachment lifecycle completeness — 3c-iii browser proof (TASK-2514)', () => {
+	test.beforeEach(async ({ page }, testInfo) => {
+		test.skip(testInfo.project.name !== 'desktop-chromium', 'desktop legs only');
+		await page.setViewportSize(DESKTOP);
+	});
+
+	test('a navigation step force-probes the arrival no-store — a sibling deleted from another context tombstone-advances despite a primed 200 (PLAN-2392 3c-iii U5, U3 seam)', async ({
+		page,
+		fixture,
+		request
+	}) => {
+		// THE U3 BROWSER PROOF. T6 forced a no-store metadata probe of the OPENED
+		// entry only; U3 forces one per (open, entry) pair, so ARROWING to a
+		// not-yet-probed sibling revalidates it too — catching a delete the
+		// process-local bus never announced (another tab, a job, a direct API call).
+		// Observable here as: arrow onto a server-deleted sibling → its forced no-store
+		// HEAD 404s → the surface tombstones it and ADVANCES to a survivor, rather than
+		// presenting a live-looking stale row from its complete strip seed.
+		await browserLogin(page);
+		const doc = await seedDoc(fixture, request, 'U5 nav-step delete');
+		// Three attachments. The surface pages them in the strip's list order
+		// (`created_at DESC`), which is NOT derivable here — three uploads inside one
+		// second tie on `created_at`, so their order is the DB's tie-break, not the
+		// upload order. So DERIVE the viewer order at runtime rather than assume it (a
+		// hard-coded position would be a same-second coincidence that flips the moment
+		// the uploads straddle a second — Codex round 1).
+		const ids = [
+			await uploadAttachment(fixture, request, doc.id, 'nav-1.png'),
+			await uploadAttachment(fixture, request, doc.id, 'nav-2.png'),
+			await uploadAttachment(fixture, request, doc.id, 'nav-3.png')
+		];
+
+		const attPath = (id: string) =>
+			`/api/v1/workspaces/${fixture.workspaceSlug}/attachments/${id}`;
+		const shownId = async (): Promise<string> =>
+			(await page.locator(VIEWER_IMAGE).getAttribute('src'))!.match(/attachments\/([0-9a-f-]+)/)![1];
+
+		await page.goto(itemUrl(fixture, doc.slug));
+		await expect(page.locator(TILE)).toHaveCount(3);
+
+		// DISCOVERY PASS — learn the actual viewer order without assuming it. Open ANY
+		// of the three (identify it by its own shown id), then ArrowRight twice to read
+		// the two neighbours in `←/→` order. `arrival` is the entry a single ArrowRight
+		// from `opened` lands on; `advanceTarget` is the entry that FOLLOWS `arrival`,
+		// where a tombstone-advance off `arrival` lands. All three are distinct (a
+		// 3-set), so `advanceTarget !== opened` — the advance is observable. No
+		// deletions here, so the set order is stable across the pass.
+		await page.locator(TILE).first().click();
+		await expect(page.locator(VIEWER_IMAGE)).toBeVisible();
+		const opened = await shownId();
+		await page.keyboard.press('ArrowRight');
+		await expect
+			.poll(shownId, 'arrow lands on the right neighbour')
+			.not.toBe(opened);
+		const arrival = await shownId();
+		await page.keyboard.press('ArrowRight');
+		await expect.poll(shownId, 'second arrow lands on the third entry').not.toBe(arrival);
+		const advanceTarget = await shownId();
+		expect(new Set([opened, arrival, advanceTarget]).size, 'three distinct entries').toBe(3);
+		expect(ids).toContain(arrival);
+		await page.keyboard.press('Escape');
+		await expect(page.locator(VIEWER)).toHaveCount(0);
+
+		// Count 404 HEAD RESPONSES of `arrival`'s EXACT variant-less canonical URL. The
+		// metadata existence probe is a HEAD of the variant-less URL (no `?variant`), so
+		// anchor on an empty search AND the exact pathname — a thumb GET or a `?variant=`
+		// HEAD is never miscounted. Keyed on the RESPONSE, not `requestfinished`: a
+		// bodyless HEAD is reported as `net::ERR_ABORTED` after its headers arrive, so it
+		// fires `requestfailed`, never `requestfinished`.
+		//
+		// ONLY 404s are counted, deliberately: the discovery pass above already
+		// force-probed `arrival` once (a 200, while it was alive), and one such probe
+		// may still be in flight as we register this listener. Counting 200s would let
+		// that straggler pollute the count (Codex round 2); a 404 can ONLY come from a
+		// probe issued AFTER the API delete below — i.e. the post-reopen navigation
+		// probe this leg is proving. The priming's cacheability is asserted directly off
+		// the `page.evaluate` return value, not off a 200 counter.
+		let headArrival404 = 0;
+		page.on('response', (r) => {
+			const rq = r.request();
+			if (rq.method() !== 'HEAD') return;
+			const u = new URL(rq.url());
+			if (u.search !== '' || u.pathname !== attPath(arrival)) return;
+			if (r.status() === 404) headArrival404 += 1;
+		});
+
+		// PRIME `arrival`'s metadata in the PAGE context with a SUCCESSFUL, CACHEABLE
+		// response — while it is still alive. A page-side `fetch` (NOT the Playwright
+		// `request` fixture, whose separate API context Chromium's page cache never
+		// consults) warms the browser HTTP cache with the GET/HEAD handler's
+		// `Cache-Control: private, max-age=3600` 200. That warm 200 is exactly what a
+		// cache-RESPECTING probe would replay for the LATER 404 — so proving the
+		// navigation probe still sees the 404 is the cache-bypass proof. Assert the
+		// priming actually got a cacheable 200, or the leg's premise is silently vacuous.
+		const primed = await page.evaluate(async (url) => {
+			const r = await fetch(url, { method: 'HEAD', credentials: 'same-origin' });
+			return { status: r.status, cacheControl: r.headers.get('cache-control') };
+		}, attPath(arrival));
+		expect(primed.status, 'priming HEAD is a live 200').toBe(200);
+		expect(primed.cacheControl ?? '', 'the primed 200 is browser-cacheable').toContain('max-age');
+		// No 404 of `arrival` has been seen yet — it is still alive and, crucially,
+		// unprobed-since-reopen; the only 404 will come from the post-delete navigation.
+		expect(headArrival404, 'no 404 before the delete + reopen').toBe(0);
+
+		// Delete `arrival` via a SEPARATE request context (the API), NOT the same-page
+		// strip UI: a same-page delete fires `announceAttachmentDeleted` on the
+		// process-local bus and would tombstone it BEFORE the arrow — the leg would then
+		// pass WITHOUT U3's per-navigation probe existing. Deleted this way, the ONLY
+		// way the surface learns it is gone is the navigation-step probe. The strip is
+		// never re-listed (no bus, no SSE to it), so its tiles — and the surface set —
+		// still carry the row.
+		const del = await request.delete(attPath(arrival), {
+			headers: { Authorization: `Bearer ${fixture.apiToken}` }
+		});
+		expect(del.ok(), await del.text()).toBe(true);
+
+		// RE-OPEN `opened`. A fresh open mints a fresh nonce, so its own entry is
+		// force-probed once (200, alive); `arrival` stays UNPROBED until the arrow.
+		// (Re-open is REQUIRED: within the discovery open the arrival was already
+		// force-probed once for that nonce, so arrowing back would take the fast path —
+		// only a fresh nonce re-probes it, now against the 404.)
+		const openedFilename = `nav-${ids.indexOf(opened) + 1}.png`;
+		await page.locator(`${TILE}[aria-label*="${openedFilename}"]`).click();
+		await expect(page.locator(VIEWER_IMAGE)).toBeVisible();
+		await expect.poll(shownId, 'reopened on the opened entry').toBe(opened);
+		expect(headArrival404, 'reopening the opened entry does not probe the arrival').toBe(0);
+
+		// ARROW to `arrival`. U3 forces one no-store HEAD of the ARRIVAL; against the
+		// server-deleted row it 404s DESPITE the primed cacheable 200 (the cache-bypass
+		// proof). The 404 is a deletion by another door: the row tombstones and the
+		// surface ADVANCES to the entry that followed it — two survivors remain, so it
+		// does not close, and it is never a live-looking stale row.
+		//
+		// ARM the 404 response wait BEFORE the arrow so the observed 404 is causally the
+		// ARROW's probe, not a straggler (Codex round 3): armed after the delete + reopen
+		// and immediately before the keypress, it can only catch a HEAD 404 issued by the
+		// navigation that follows. The `headArrival404 === 0` guard above confirms none
+		// preceded it.
+		const arrowProbe404 = page.waitForResponse(
+			(r) => {
+				const rq = r.request();
+				if (rq.method() !== 'HEAD' || r.status() !== 404) return false;
+				const u = new URL(rq.url());
+				return u.search === '' && u.pathname === attPath(arrival);
+			},
+			{ timeout: 10_000 }
+		);
+		await page.keyboard.press('ArrowRight');
+		await arrowProbe404;
+		// The advance. Shown is `advanceTarget` (the arrival's follower), the viewer
+		// stays open, the counter recounts the two survivors, and no missing overlay
+		// shows (that is the single-item path, not a multi-set advance). `advanceTarget`
+		// is DISTINCT from `opened` and from the gone `arrival`, so BOTH failure modes
+		// fall here: a lost per-navigation probe (the arrival trusted from its complete
+		// seed, shown live) OR a cache-respecting probe (the primed 200 replayed, shown
+		// live).
+		await expect(page.locator(VIEWER)).toHaveCount(1);
+		await expect.poll(shownId, 'tombstone-advances to the arrival’s follower').toBe(advanceTarget);
+		await expect(page.locator(VIEWER_COUNTER)).toHaveText('2 / 2');
+		await expect(page.locator(VIEWER_MISSING)).toHaveCount(0);
+	});
+
+	test('restore revalidates the strip through the bulk SSE path: no list on archive, a fresh list after restore, tiles never blank (PLAN-2392 3c-iii U5, U2 seam)', async ({
+		page,
+		fixture,
+		request
+	}) => {
+		// THE U2 BROWSER PROOF. The strip has NO SSE subscription of its own — its
+		// only live inputs are the in-process delete/upload buses — so a restore that
+		// happened while this browser was elsewhere never reaches it without the
+		// `parentArchived` prop edge ItemDetail threads down. The RESTORE (the direction
+		// that actually fires `revalidateAfterRestore`) is driven through the BULK
+		// endpoint: `items_bulk_updated` carries NO `item_id` and routes only to
+		// `sync_required`, so it proves the PROP-driven mechanism covers exactly what a
+		// per-item SSE subscription would miss. The archive uses the per-item event —
+		// its only role here is to establish the archived level, and a reliable banner
+		// keeps the no-op assertion honest.
+		//
+		// The list-request choreography is three-step (round-9): ARCHIVE fires no
+		// `attachments.list` (the content no-op), then baseline the count immediately
+		// BEFORE the restore, then a NEW list must fire AFTER it. Baselining before the
+		// archive would let an incorrect archive-triggered reload false-satisfy the
+		// after-restore assertion.
+		//
+		// ISOLATED WORKSPACE: the `sync_required` → `/changes` delta path this leg
+		// depends on is starved on the shared suite workspace — every other parallel
+		// spec's mutation rides the same SSE stream, and a competing sync landing in the
+		// same second advances the RFC3339-second `/changes` cursor past this restore,
+		// dropping it (existing archived tests avoid the sync path for exactly this
+		// reason, using per-item events). A private workspace gives this leg an SSE
+		// stream nothing else touches.
+		await browserLogin(page);
+		// `ws` is captured OUTSIDE the try so the finally can always reclaim it; the
+		// try opens immediately after so a failure during doc/upload setup still cleans
+		// up (Codex round 2).
+		const ws = (await createWorkspace(fixture, request, 'U5 restore revalidate')).slug;
+		try {
+			const doc = await createDoc(fixture, request, ws, `U5 restore ${Date.now()}`);
+			await uploadAttachment(fixture, request, doc.id, 'restore-a.png', 'image/png', REAL_PNG, ws);
+			await uploadAttachment(fixture, request, doc.id, 'restore-b.png', 'image/png', REAL_PNG, ws);
+
+			// Count the STRIP's own list GETs — the item-scoped `attachments.list`
+			// (`?...item_id=<doc.id>`), never an unscoped page-1 listing (BUG-2504
+			// discipline). A GET of this workspace's attachments carrying THIS item's id.
+			// Used only for the ARCHIVE no-op (a dispatch count is right for "prove
+			// nothing fired"); the restore is proven by a settled RESPONSE below.
+			const listPath = `/api/v1/workspaces/${ws}/attachments`;
+			const isItemListReq = (u: URL) =>
+				u.pathname === listPath && u.searchParams.get('item_id') === doc.id;
+			const isItemListResp = (r: import('@playwright/test').Response) =>
+				r.request().method() === 'GET' && isItemListReq(new URL(r.url())) && r.status() === 200;
+			let listCalls = 0;
+			page.on('request', (r) => {
+				if (r.method() === 'GET' && isItemListReq(new URL(r.url()))) listCalls += 1;
+			});
+
+			// Arm the mount-load response BEFORE navigating so the settle is deterministic
+			// (no fixed-time sleep): the strip's first item-scoped list must land 200.
+			const mountList = page.waitForResponse(isItemListResp);
+			await page.goto(`/${fixture.adminUsername}/${ws}/docs/${doc.slug}`);
+			await expect(page.locator(TILE)).toHaveCount(2);
+			await mountList;
+			const afterMount = listCalls;
+
+			// ARCHIVE (per-item — a reliable banner; the archive is a strip content
+			// no-op either way). ItemDetail flips `parentArchived=true`; the strip's
+			// archive edge keeps the painted tiles and fires NO list.
+			await archiveItem(fixture, request, doc.slug, ws);
+			await expect(page.locator('.archived-banner')).toBeVisible({ timeout: 15_000 });
+			// Tiles are NOT blanked by the archive.
+			await expect(page.locator(TILE)).toHaveCount(2);
+			// Give any erroneous archive-triggered reload a window to fire, then assert
+			// it did not: the archive is a strip content no-op. A bounded wait is the
+			// right shape for proving ABSENCE — there is nothing to poll toward.
+			await page.waitForTimeout(500);
+			expect(listCalls, 'archiving fires no attachments.list — the content no-op').toBe(afterMount);
+
+			// Baseline immediately BEFORE the restore (round-9): the after-restore delta
+			// is measured from here, so an archive-time reload (were there one) could not
+			// pre-satisfy it.
+			const beforeRestore = listCalls;
+
+			// DELAY the restore's revalidation list so its IN-FLIGHT window is observable
+			// (Codex round 3): "never blank" is a claim about the interval WHILE the list
+			// is fetching, so hold that response open and assert the tiles stay painted
+			// during it. A blank-then-refill implementation would blank at fetch start and
+			// be caught here; a post-settle count alone could not tell the two apart. The
+			// route is registered only now — AFTER the mount load — and one-shot
+			// (`times: 1`), so it delays ONLY the restore's revalidation list.
+			let listHeld = false;
+			await page.route(
+				(u) => u.pathname === listPath && u.searchParams.get('item_id') === doc.id,
+				async (route) => {
+					listHeld = true; // the revalidation list reached the wire (held in flight)
+					await new Promise((r) => setTimeout(r, 1200));
+					await route.continue();
+				},
+				{ times: 1 }
+			);
+			// Arm the settled-200 wait BEFORE firing so what we assert is causally the
+			// restore's own list (Codex round 1), not a bare dispatch a failed/unrelated
+			// GET could satisfy.
+			const restoreList = page.waitForResponse(isItemListResp, { timeout: 15_000 });
+			// RESTORE through the BULK lane — `items_bulk_updated`, no `item_id`.
+			// `parentArchived` flips true→false and the strip's restore edge REVALIDATES.
+			await bulkItems(fixture, request, 'restore', [doc.slug], ws);
+			// The restore reaches the page through the bulk SSE → deltaSync round-trip,
+			// which is slower than a per-item event — give it room past the 5s default.
+			await expect(page.locator('.archived-banner')).toHaveCount(0, { timeout: 15_000 });
+			// The revalidation list has reached the wire and is HELD in flight by the
+			// route. Prove the strip did NOT blank while it fetches — the U2 contract.
+			await expect.poll(() => listHeld, 'the restore dispatched the revalidation list').toBe(true);
+			await expect(page.locator(TILE)).toHaveCount(2);
+			// Release + settle: the held response lands 200 and the merge keeps the tiles.
+			await restoreList;
+			await expect(page.locator(TILE)).toHaveCount(2);
+			// Corroborate against the dispatch counter: exactly the restore moved it off
+			// the pre-restore baseline (the archive did not).
+			expect(listCalls, 'the restore fired a fresh list; the archive did not').toBeGreaterThan(
+				beforeRestore
+			);
+		} finally {
+			await deleteWorkspace(fixture, request, ws);
+		}
+	});
+
+	test('deleting a strip attachment reconciles its comment thumbnail to the missing presentation, live, no reload (PLAN-2392 3c-iii U5, U1 seam)', async ({
+		page,
+		fixture,
+		request
+	}) => {
+		// THE U1 BROWSER PROOF. The deletion bus is process-local (`events.ts`), so the
+		// delete MUST go through the same-page strip UI for `announceAttachmentDeleted`
+		// to run — a direct API delete exercises nothing U1 built. The timeline's
+		// deletion listener then drops the cached metadata + probe mark and tombstones
+		// the id, so the comment's HTML re-renders the reference through the missing
+		// path — a live `<img>` becoming the `.attachment-missing` placeholder with no
+		// reload.
+		await browserLogin(page);
+		const doc = await seedDoc(fixture, request, 'U5 timeline reconcile');
+		// One attachment, bound to the item (so it lands in the strip — the delete
+		// surface) AND referenced by a comment (so the timeline renders its thumbnail).
+		const att = await uploadAttachment(fixture, request, doc.id, 'tl-shot.png');
+		await postComment(fixture, request, doc.slug, `shot\n\n![shot](pad-attachment:${att})\n`);
+
+		await page.goto(itemUrl(fixture, doc.slug));
+
+		// The timeline lives under the Activity tab. Open it and confirm the comment
+		// thumbnail resolved to a LIVE image first — the baseline the reconciliation
+		// flips away from. (The tab-panels are CSS-hidden, not `{#if}`-gated, so both
+		// the strip and the timeline stay MOUNTED across a switch — the timeline
+		// instance never remounts, which is what makes the reconciliation "live".)
+		const tlImg = `.timeline img[data-attachment-id="${att}"]`;
+		const tlMissing = `.timeline .attachment-missing[data-attachment-id="${att}"]`;
+		await page.getByRole('tab', { name: 'Activity' }).click();
+		await expect(page.locator('.timeline')).toBeVisible();
+		await expect(page.locator(tlImg)).toBeVisible();
+		await expect(page.locator(tlMissing)).toHaveCount(0);
+
+		// Stamp the document AND the timeline element: a full reload clears the window
+		// stamp, and a subtree remount replaces the stamped `.timeline` node. Both
+		// surviving proves the flip is the live bus reconciliation of the SAME mounted
+		// instance, not a reload or a remount.
+		await page.evaluate(() => {
+			(window as unknown as { __spa?: number }).__spa = 1;
+			const el = document.querySelector('.timeline') as (HTMLElement & { __tl?: number }) | null;
+			if (el) el.__tl = 2;
+		});
+
+		// Delete the attachment through the STRIP UI. Switch to the Details tab where
+		// the strip is visible (its `.att-delete` is display:none while Activity is
+		// shown, so unclickable there), open the confirm drill-down, and confirm — this
+		// is the same-page path that runs `announceAttachmentDeleted`.
+		await page.getByRole('tab', { name: 'Details' }).click();
+		// The delete control is CSS-revealed on hover / focus-within and sits over the
+		// tile, so focus it first (keyboard-reachable by contract) before clicking —
+		// the same handoff `item-attachment-strip.spec.ts` uses.
+		const del = page.locator(STRIP_DELETE).first();
+		await del.focus();
+		await expect(del).toBeFocused();
+		await del.click();
+		const confirmMenu = page.locator('[role="menu"]');
+		await expect(confirmMenu).toBeVisible();
+		await confirmMenu.getByRole('menuitem', { name: 'Delete file' }).click();
+		// The strip tile goes (the delete committed and reconciled its own surface).
+		await expect(page.locator(TILE)).toHaveCount(0);
+
+		// The mounted-but-hidden timeline already reconciled off the bus — its comment
+		// thumbnail is now the missing placeholder and the live `<img>` is gone, with
+		// NO tab switch and NO reload in between. Query the hidden panel directly (count
+		// assertions do not require visibility), then reveal it.
+		await expect(page.locator(tlMissing)).toHaveCount(1);
+		await expect(page.locator(tlImg)).toHaveCount(0);
+		expect(
+			await page.evaluate(() => {
+				const el = document.querySelector('.timeline') as (HTMLElement & { __tl?: number }) | null;
+				return (window as unknown as { __spa?: number }).__spa === 1 && el?.__tl === 2;
+			}),
+			'the reconciliation is the live bus reaching the mounted timeline — not a reload or a remount'
+		).toBe(true);
+
+		// And it renders correctly when the tab is shown again.
+		await page.getByRole('tab', { name: 'Activity' }).click();
+		await expect(page.locator(tlMissing)).toBeVisible();
+	});
+});

--- a/web/e2e/attachment-surface-chrome.spec.ts
+++ b/web/e2e/attachment-surface-chrome.spec.ts
@@ -386,16 +386,21 @@ test.describe('attachment viewer — 3c-i surface chrome (TASK-2484)', () => {
 		// `heads` counts DISPATCHED probes; `headsDone` counts COMPLETED ones. The
 		// count barriers below poll on COMPLETION rather than dispatch so every earlier
 		// probe has fully landed before the next exact count is read — a settled-state
-		// sync point, not a timing crutch. `requestfinished` fires when the response is
-		// fully received.
+		// sync point, not a timing crutch.
+		//
+		// COMPLETION is keyed on the RESPONSE, not `requestfinished` (PLAN-2392 3c-iii
+		// U5): a bodyless HEAD gets its 200 headers and is then reported by Chromium as
+		// `net::ERR_ABORTED` — it fires `requestfailed`, NOT `requestfinished`, so a
+		// `requestfinished` barrier for a HEAD never completes. The `response` event
+		// fires with the arrived status, which is the true settle point for a HEAD.
 		const heads: Record<string, number> = { [a]: 0, [b]: 0 };
 		const headsDone: Record<string, number> = { [a]: 0, [b]: 0 };
 		page.on('request', (r) => {
 			const id = isCanonicalHead(r);
 			if (id) heads[id] += 1;
 		});
-		page.on('requestfinished', (r) => {
-			const id = isCanonicalHead(r);
+		page.on('response', (r) => {
+			const id = isCanonicalHead(r.request());
 			if (id) headsDone[id] += 1;
 		});
 

--- a/web/e2e/attachment-surface-chrome.spec.ts
+++ b/web/e2e/attachment-surface-chrome.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from './fixtures';
-import type { Page } from '@playwright/test';
+import type { Page, Request } from '@playwright/test';
 import { browserLogin, seedDoc } from './lib/collab-helpers';
 import {
 	BIG_PNG,
@@ -346,19 +346,22 @@ test.describe('attachment viewer — 3c-i surface chrome (TASK-2484)', () => {
 		await expect(viewerDownloadAnchor(page)).toHaveAttribute('download', 'logs.zip');
 	});
 
-	test('every open forces exactly one no-store HEAD of the opened entry; arrowing forces none; a reopen forces another (PLAN-2392 3c-ii T6)', async ({
+	test('every open AND every navigation step forces one no-store HEAD per (open, entry); a reopen forces another (PLAN-2392 3c-iii U3)', async ({
 		page,
 		fixture,
 		request
 	}) => {
-		// T6 always-revalidate-on-open, in a browser. The strip's list rows carry a
-		// COMPLETE seed (filename + MIME + size), so before T6 a strip open issued
-		// ZERO metadata HEADs — the machine short-circuits a complete seed. T6 mints
-		// a per-open nonce that joins the metadata subject identity, forcing exactly
-		// one `no-store` revalidating HEAD of the OPENED entry so a cross-tab /
-		// background delete the browser's `max-age` HEAD cache would hide is caught.
-		// Observable as the HEAD count: one per open, NONE while arrowing within an
-		// open (the nonce is constant), and another on a reopen (a fresh nonce).
+		// 3c-iii U3 generalizes T6's always-revalidate-on-open to per navigation step,
+		// in a browser. The strip's list rows carry a COMPLETE seed (filename + MIME +
+		// size), so before T6 a strip open issued ZERO metadata HEADs. T6 forced one
+		// `no-store` HEAD of the OPENED entry; U3 forces one per (open, attachment)
+		// pair, so ARROWING to a not-yet-probed sibling revalidates it too — catching a
+		// cross-tab / background delete the browser's `max-age` HEAD cache would hide.
+		// Observable as the HEAD count: one on the open, one MORE when arrowing to a
+		// fresh entry, and a fresh probe on a reopen (a fresh nonce). (The complementary
+		// "arrowing BACK to an already-probed pair does NOT re-probe" is proven
+		// deterministically in surfaceMetadata.svelte.test.ts — it turns on a JS-internal
+		// mark with no race-free browser observable, so it is not asserted here.)
 		await browserLogin(page);
 		const doc = await seedDoc(fixture, request, 'No-store reopen');
 		const a = await uploadAttachment(fixture, request, doc.id, 'ns-a.png');
@@ -371,14 +374,29 @@ test.describe('attachment viewer — 3c-i surface chrome (TASK-2484)', () => {
 		// The EXACT canonical API path per id — a full-path compare, not a suffix, so a
 		// different workspace or a prefixed route can never be miscounted.
 		const attPath = (id: string) => `/api/v1/workspaces/${fixture.workspaceSlug}/attachments/${id}`;
-		const heads: Record<string, number> = { [a]: 0, [b]: 0 };
-		page.on('request', (r) => {
-			if (r.method() !== 'HEAD') return;
+		const isCanonicalHead = (r: Request) => {
+			if (r.method() !== 'HEAD') return null;
 			const u = new URL(r.url());
 			// EXACT variant-less canonical URL: no query at all (a `?variant=` HEAD, were
 			// one ever issued, must not be miscounted as the canonical existence probe).
-			if (u.search !== '') return;
-			for (const id of [a, b]) if (u.pathname === attPath(id)) heads[id] += 1;
+			if (u.search !== '') return null;
+			for (const id of [a, b]) if (u.pathname === attPath(id)) return id;
+			return null;
+		};
+		// `heads` counts DISPATCHED probes; `headsDone` counts COMPLETED ones. The
+		// count barriers below poll on COMPLETION rather than dispatch so every earlier
+		// probe has fully landed before the next exact count is read — a settled-state
+		// sync point, not a timing crutch. `requestfinished` fires when the response is
+		// fully received.
+		const heads: Record<string, number> = { [a]: 0, [b]: 0 };
+		const headsDone: Record<string, number> = { [a]: 0, [b]: 0 };
+		page.on('request', (r) => {
+			const id = isCanonicalHead(r);
+			if (id) heads[id] += 1;
+		});
+		page.on('requestfinished', (r) => {
+			const id = isCanonicalHead(r);
+			if (id) headsDone[id] += 1;
 		});
 
 		await page.goto(itemUrl(fixture, doc.slug));
@@ -390,41 +408,36 @@ test.describe('attachment viewer — 3c-i surface chrome (TASK-2484)', () => {
 		expect(heads[b]).toBe(0);
 
 		// OPEN ns-a: exactly one forced HEAD of ns-a, and none of ns-b (only the
-		// opened entry is probed, not the whole set).
+		// opened entry is probed at open, not the whole set). Barrier on COMPLETION so
+		// every earlier probe has landed before the next count is read.
 		await page.locator(`${TILE}[aria-label*="ns-a.png"]`).click();
 		await expect(page.locator(VIEWER_IMAGE)).toBeVisible();
-		await expect.poll(() => heads[a], 'the opened entry gets one no-store HEAD').toBe(1);
+		await expect.poll(() => headsDone[a], 'ns-a open probe completes').toBe(1);
+		expect(heads[a], 'the opened entry gets one no-store HEAD').toBe(1);
 		expect(heads[b], 'a non-opened sibling is NOT probed at open').toBe(0);
 
-		// ARROW to ns-b within the SAME open: the nonce is constant across
-		// navigation, so no NEW forced HEAD fires for the arrival (3c-iii owns
-		// navigation-step revalidation).
+		// ARROW to ns-b within the SAME open: THE U3 INVERSION. T6 forced only the
+		// opened entry, so arrowing here forced NOTHING and ns-b stayed at 0; U3 forces
+		// one no-store HEAD of the ARRIVAL (a fresh (nonce, entry) pair), so ns-b is now
+		// probed exactly once by the navigation step. ns-a is untouched by the arrow —
+		// it stays at 1, quiescent (no arrow-back is issued, so no count can transiently
+		// inflate; the reopen below is the only thing that moves ns-a again).
 		await page.keyboard.press('ArrowRight');
 		await expect(page.locator(VIEWER_COUNTER)).toHaveText('2 / 2');
+		await expect.poll(() => headsDone[b], 'arrowing to a fresh entry forces one no-store HEAD (U3)').toBe(1);
+		expect(heads[b]).toBe(1);
+		expect(heads[a], 'the arrow does not re-probe the departed entry').toBe(1);
 		await page.keyboard.press('Escape');
 		await expect(page.locator(VIEWER)).toHaveCount(0);
 
-		// Now OPEN ns-b directly from its tile. This forces exactly one probe of ns-b
-		// — a DETERMINISTIC positive barrier that also proves the arrow above forced
-		// NONE: if arrowing had (wrongly) probed the arrival, ns-b's count would land
-		// on 2 here, not 1. The poll is the sync point; no timing crutch.
-		await page.locator(`${TILE}[aria-label*="ns-b.png"]`).click();
-		await expect(page.locator(VIEWER_IMAGE)).toBeVisible();
-		await expect.poll(() => heads[b], 'ns-b probed once — by its own open, not the earlier arrow').toBe(1);
-		await page.keyboard.press('Escape');
-		await expect(page.locator(VIEWER)).toHaveCount(0);
-
-		// REOPEN ns-a: a fresh open mints a fresh nonce → another forced HEAD, so its
-		// count reaches exactly 2 (its two opens), not more from the arrow-back. This
-		// poll is the final sync barrier; by the time it settles every earlier probe
-		// has landed, so the settled exact counts below are quiescent — heads[a] is
-		// its two opens (no arrow re-force) and heads[b] is its one direct open.
+		// REOPEN ns-a: a fresh open mints a fresh nonce → every entry is unseen again,
+		// so ns-a is force-probed once more, reaching exactly 2 (its two opens). ns-a
+		// climbs 1→2 with no intervening probe, so this exact poll cannot false-green on
+		// a transient. ns-b remains at its single arrow-forced probe.
 		await page.locator(`${TILE}[aria-label*="ns-a.png"]`).click();
 		await expect(page.locator(VIEWER_IMAGE)).toBeVisible();
-		// Poll the PAIR to the settled exact state — ns-a its two opens (no arrow
-		// re-force), ns-b its one direct open (the arrow forced none).
 		await expect
-			.poll(() => `${heads[a]},${heads[b]}`, 'exactly {a:2, b:1} — no arrow re-force of either')
+			.poll(() => `${heads[a]},${heads[b]}`, 'exactly {a:2, b:1} — reopen re-forces ns-a; the arrow forced ns-b once')
 			.toBe('2,1');
 	});
 

--- a/web/e2e/lib/attachment-viewer.ts
+++ b/web/e2e/lib/attachment-viewer.ts
@@ -119,6 +119,14 @@ export const MOBILE = { width: 390, height: 844 };
 const STRIP = '.attachment-strip';
 export const TILE = `${STRIP} .att-tile`;
 /**
+ * The strip tile's per-tile delete control (PLAN-2392 3c-iii U5 / TASK-2514).
+ * Class-qualified inside the strip, mirroring `item-attachment-strip.spec.ts`'s
+ * local `DELETE_BTN` — lifted here because the U5 lifecycle proof deletes a
+ * strip attachment to fire `announceAttachmentDeleted` on the process-local bus,
+ * and a selector that drifted between the two specs would silently retarget one.
+ */
+export const STRIP_DELETE = `${STRIP} .att-delete`;
+/**
  * The viewer root. Class-qualified on PURPOSE (see the selector rule above);
  * `VIEWER_ROOT_CLASS` in `$lib/a11y/viewerBackdrop` is the same string, and
  * the manager's arbitration keys on it, so a rename that broke this locator
@@ -274,16 +282,56 @@ export function collectionUrl(fixture: SuiteFixture, query = ''): string {
 	return `/${fixture.adminUsername}/${fixture.workspaceSlug}/docs${query}`;
 }
 
-/** Upload a file bound to `itemId` so it lands in that item's strip. */
+/**
+ * Create a fresh, isolated workspace owned by the admin (PLAN-2392 3c-iii U5).
+ * The suite runs fully parallel against ONE server on ONE shared workspace, so
+ * its SSE stream carries every other spec's mutations — which starves the
+ * delta-sync cursor (a competing sync landing in the same second advances it
+ * past your own change, and the RFC3339-second `since` then drops it). A test
+ * that depends on the `items_bulk_updated` → `sync_required` → `/changes` path
+ * (the strip restore revalidation) must run on a stream NOTHING else touches.
+ * `startup` seeds a `docs` collection so the doc + strip have a home.
+ */
+export async function createWorkspace(
+	fixture: SuiteFixture,
+	request: APIRequestContext,
+	label: string
+): Promise<{ slug: string }> {
+	const resp = await request.post('/api/v1/workspaces', {
+		headers: authJson(fixture),
+		data: { name: `${label} ${Date.now()}`, template: 'startup' }
+	});
+	if (!resp.ok()) throw new Error(`workspace create failed (${resp.status()}): ${await resp.text()}`);
+	return (await resp.json()) as { slug: string };
+}
+
+/** Seed a doc item in an explicit workspace (the isolated-workspace analogue of
+ *  `seedDoc`, which is pinned to the shared suite workspace). */
+export async function createDoc(
+	fixture: SuiteFixture,
+	request: APIRequestContext,
+	wsSlug: string,
+	title: string
+): Promise<{ id: string; slug: string }> {
+	const resp = await request.post(`/api/v1/workspaces/${wsSlug}/collections/docs/items`, {
+		headers: authJson(fixture),
+		data: { title, fields: '{}', content: '' }
+	});
+	if (!resp.ok()) throw new Error(`doc create failed (${resp.status()}): ${await resp.text()}`);
+	return (await resp.json()) as { id: string; slug: string };
+}
+
+/** Upload a file bound to `itemId` so it lands in that item's strip. `ws`
+ *  defaults to the shared suite workspace; pass it for an isolated workspace. */
 export async function uploadAttachment(
 	fixture: SuiteFixture,
 	request: APIRequestContext,
 	itemId: string,
 	filename: string,
 	mimeType = 'image/png',
-	buffer: Buffer = REAL_PNG
+	buffer: Buffer = REAL_PNG,
+	ws: string = fixture.workspaceSlug
 ): Promise<string> {
-	const ws = fixture.workspaceSlug;
 	const resp = await request.post(
 		`/api/v1/workspaces/${ws}/attachments?item_id=${encodeURIComponent(itemId)}`,
 		{
@@ -403,6 +451,63 @@ export function authJson(fixture: SuiteFixture): Record<string, string> {
 		Authorization: `Bearer ${fixture.apiToken}`,
 		'Content-Type': 'application/json'
 	};
+}
+
+/**
+ * Archive (soft-delete) an item via the SINGLE-item endpoint (PLAN-2392 3c-iii
+ * U5). `DELETE /items/{slug}` sets `deleted_at`; the item GET still returns it,
+ * so the page stays up with its archived banner. Emits the per-item
+ * `item_archived` SSE.
+ */
+export async function archiveItem(
+	fixture: SuiteFixture,
+	request: APIRequestContext,
+	slug: string,
+	ws: string = fixture.workspaceSlug
+): Promise<void> {
+	const resp = await request.delete(`/api/v1/workspaces/${ws}/items/${slug}`, {
+		headers: { Authorization: `Bearer ${fixture.apiToken}` }
+	});
+	if (!resp.ok()) throw new Error(`archive failed (${resp.status()}): ${await resp.text()}`);
+}
+
+/**
+ * Restore an archived item via the SINGLE-item endpoint (PLAN-2392 3c-iii U5).
+ * `POST /items/{slug}/restore` clears `deleted_at`. Emits the per-item
+ * `item_restored` SSE.
+ */
+export async function restoreItem(
+	fixture: SuiteFixture,
+	request: APIRequestContext,
+	slug: string,
+	ws: string = fixture.workspaceSlug
+): Promise<void> {
+	const resp = await request.post(`/api/v1/workspaces/${ws}/items/${slug}/restore`, {
+		headers: { Authorization: `Bearer ${fixture.apiToken}` }
+	});
+	if (!resp.ok()) throw new Error(`restore failed (${resp.status()}): ${await resp.text()}`);
+}
+
+/**
+ * Bulk archive / restore via the LANE endpoint (PLAN-2392 3c-iii U5 / TASK-2511
+ * seam). `POST /items/bulk` emits ONE `items_bulk_updated` SSE per affected
+ * collection — carrying NO `item_id` (it routes only to `sync_required`). That
+ * is the exact path the prop-driven strip/timeline reconciliation must cover
+ * that a per-item `item_archived`/`item_restored` subscription would miss, so
+ * the U5 restore leg drives at least one transition through here.
+ */
+export async function bulkItems(
+	fixture: SuiteFixture,
+	request: APIRequestContext,
+	op: 'archive' | 'restore',
+	ids: string[],
+	ws: string = fixture.workspaceSlug
+): Promise<void> {
+	const resp = await request.post(`/api/v1/workspaces/${ws}/items/bulk`, {
+		headers: authJson(fixture),
+		data: { op, ids }
+	});
+	if (!resp.ok()) throw new Error(`bulk ${op} failed (${resp.status()}): ${await resp.text()}`);
 }
 
 /**

--- a/web/src/lib/attachments/events.ts
+++ b/web/src/lib/attachments/events.ts
@@ -225,6 +225,39 @@ export interface LightboxImage {
  * or a record inside it — after calling must not be able to reach into an open
  * surface, so the array AND each record are copied here. A shallow array copy is
  * not enough: the records stay shared references until each is spread.
+ *
+ * MUTATION INTO AN OPEN SET IS OUT OF SCOPE, BY CONTRACT (PLAN-2392 3c-iii U4 /
+ * TASK-2513). Scoped to THIS channel — the set as delivered by an emit: this
+ * channel adds no NEW member to an already-open set after emit, and no snapshotted
+ * record is mutated in place. (Downstream, a member's nullable display metadata may
+ * still be COMPLETED by probing — `surfaceMetadata` fills a null `mime_type` /
+ * `size_bytes` from a HEAD, the Lightbox normalizes a blank filename — augmenting
+ * what an already-present member shows, not adding or swapping one.) The one
+ * post-emit change to the set is member REMOVAL via DELETION reconciliation, which
+ * reaches the surface two ways — the separate delete channel
+ * (`registerAttachmentDeletionListener`) and the surface's own authoritative HEAD
+ * 404 while probing — and can only RETIRE a member, never add one; how the Lightbox
+ * then renders that (advance, close, or a sole-member missing state) is its own
+ * concern, documented there. Two consequences, both deliberate and pinned rather
+ * than assumed:
+ *   - UPLOAD during an open surface does NOT join that surface's set. The strip's
+ *     own tile list gains the row (its upload subscription), but the open surface
+ *     keeps the emit-time set — proven end-to-end in
+ *     `ItemAttachmentStrip.svelte.test.ts` ("upload during an open surface"). The
+ *     complementary half — a producer mutating its OWN array/records in place
+ *     after emit can't reach the surface — is the deep copy above, pinned directly
+ *     by this module's deep-snapshot test.
+ *   - A RENAME / metadata-change to a member cannot reach an open surface either,
+ *     because THE CHANNEL FOR IT DOES NOT EXIST YET. `api.attachments` has no
+ *     rename / update-in-place op — nothing edits an existing attachment's
+ *     metadata; its closest operation, `transform`, mints a NEW peer attachment
+ *     row rather than editing the source's metadata in place — and attachment
+ *     metadata is otherwise treated as immutable. So there is no in-process channel
+ *     by which a rename could reach an open surface; a member's caption could go
+ *     stale only via an out-of-band DB change nothing observes. There is no test for
+ *     this: nothing in the current tree can exercise it. If a rename op ever ships
+ *     it needs its own bus channel plus open-set reconciliation rules — routed to
+ *     IDEA-2515.
  */
 export interface AttachmentSurfaceOpenEvent {
 	/** UUID of the attachment the surface opens ON. */

--- a/web/src/lib/attachments/surfaceMetadata.svelte.test.ts
+++ b/web/src/lib/attachments/surfaceMetadata.svelte.test.ts
@@ -20,6 +20,8 @@ vi.mock('$lib/components/editor/attachment-metadata', () => ({
 	invalidateAttachmentMetadata: vi.fn(),
 }));
 
+import type { SurfaceMetadata } from './surfaceMetadata.svelte';
+
 const { createSurfaceMetadata } = await import('./surfaceMetadata.svelte');
 
 const ATT_A = 'aaaaaaaa-1111-4111-8111-aaaaaaaaaaaa';
@@ -57,8 +59,9 @@ function harness(initial: Partial<Addr> = {}) {
 		open: true,
 		...initial,
 	});
+	let meta!: SurfaceMetadata;
 	const dispose = $effect.root(() => {
-		createSurfaceMetadata(() => ({
+		meta = createSurfaceMetadata(() => ({
 			ws: addr.ws,
 			attachmentId: addr.att,
 			seed: { filename: null, mime_type: addr.seedMime, size_bytes: addr.seedSize },
@@ -70,7 +73,15 @@ function harness(initial: Partial<Addr> = {}) {
 	});
 	roots.push(dispose);
 	flushSync();
-	return addr;
+	return { addr, meta };
+}
+
+/** Drain the metadata machine's async probe continuations, flushing effects between. */
+async function settle() {
+	for (let i = 0; i < 6; i++) {
+		await Promise.resolve();
+		flushSync();
+	}
 }
 
 beforeEach(() => {
@@ -84,7 +95,7 @@ afterEach(() => {
 	while (roots.length) roots.pop()!();
 });
 
-describe('surfaceMetadata — always-revalidate-on-open nonce (T6)', () => {
+describe('surfaceMetadata — always-revalidate-per-(open, entry) nonce (T6 + 3c-iii U3)', () => {
 	it('a complete-seed open forces exactly ONE no-store revalidation (never the plain fetch)', () => {
 		harness();
 		// The old fast path would have short-circuited a complete seed with zero
@@ -95,7 +106,7 @@ describe('surfaceMetadata — always-revalidate-on-open nonce (T6)', () => {
 	});
 
 	it('a fresh nonce on the SAME (ws, att) forces a SECOND no-store revalidation — WITHOUT a remount', () => {
-		const addr = harness();
+		const { addr } = harness();
 		expect(metaRevalidate).toHaveBeenCalledTimes(1);
 
 		// The host mints a new nonce on reopen. There is NO remount here — the same
@@ -109,41 +120,139 @@ describe('surfaceMetadata — always-revalidate-on-open nonce (T6)', () => {
 		expect(metaFetch).not.toHaveBeenCalled();
 	});
 
-	it('navigating to another attachment keeps the nonce → NO additional forced probe (a complete sibling probes not at all)', () => {
-		const addr = harness();
+	it('navigating to a fresh sibling forces a SECOND no-store revalidation (U3: per navigation step, even a complete seed)', async () => {
+		// INVERTS the T6-era expectation. T6 forced only the OPENED entry; U3
+		// generalizes to one forced probe per (nonce, attachment) pair, so arrowing to
+		// a not-yet-probed sibling revalidates it too — a complete seed no longer
+		// short-circuits a navigated-to entry, and the probe is the no-store
+		// revalidation, never the plain (cacheable) fetch.
+		const { addr } = harness();
+		await settle();
 		expect(metaRevalidate).toHaveBeenCalledTimes(1);
 
-		// Arrow to a complete-seed sibling: a subject change, but the nonce is
-		// unchanged, so nothing forces and the complete seed short-circuits — zero
-		// new probes of either kind.
 		addr.att = ATT_B;
 		flushSync();
-		expect(metaRevalidate).toHaveBeenCalledTimes(1);
+		expect(metaRevalidate).toHaveBeenCalledTimes(2);
+		expect(metaRevalidate.mock.calls[1][3]).toEqual({ cache: 'no-store' });
 		expect(metaFetch).not.toHaveBeenCalled();
 	});
 
-	it('navigating to an INCOMPLETE sibling uses the plain fetch, not a forced revalidation', () => {
-		const addr = harness();
+	it('navigating to an INCOMPLETE sibling ALSO takes the forced revalidation, not the plain fetch (U3)', async () => {
+		// INVERTS the T6-era expectation that a navigated-to entry took the plain
+		// seed-fill fetch. Under U3 an unseen pair forces regardless of seed
+		// completeness: the reachability question owns the step, so it is the no-store
+		// revalidation. A null-size seed does not downgrade it to the cacheable HEAD.
+		const { addr } = harness();
+		await settle();
 		expect(metaRevalidate).toHaveBeenCalledTimes(1);
 
-		// The sibling has a null size → it needs a seed-fill, but navigation does NOT
-		// force: it takes the plain (cacheable) HEAD, and the forced-probe count stays
-		// at the single open. This is what proves the nonce is not consumed per step.
 		addr.att = ATT_B;
 		addr.seedSize = null;
 		flushSync();
-		expect(metaFetch).toHaveBeenCalledTimes(1);
-		expect(metaRevalidate).toHaveBeenCalledTimes(1); // still just the open's
+		expect(metaRevalidate).toHaveBeenCalledTimes(2);
+		expect(metaFetch).not.toHaveBeenCalled();
+	});
+
+	it('arrowing BACK to an already-probed entry within the same open does NOT re-probe (one automatic probe per pair)', async () => {
+		// The complement of the two inversions above: a pair is probed once per open.
+		// A→B→A: A and B each force once on first sight; arrowing back to A (already
+		// recorded under this nonce) takes the fast path — no third probe.
+		const { addr } = harness();
+		await settle(); // A's open probe completes → A recorded
+		expect(metaRevalidate).toHaveBeenCalledTimes(1);
+
+		addr.att = ATT_B;
+		flushSync();
+		await settle(); // B's probe completes → B recorded
+		expect(metaRevalidate).toHaveBeenCalledTimes(2);
+
+		addr.att = ATT_A;
+		flushSync();
+		await settle();
+		// A was already recorded → its complete seed short-circuits. No re-probe.
+		expect(metaRevalidate).toHaveBeenCalledTimes(2);
+		expect(metaFetch).not.toHaveBeenCalled();
+	});
+
+	it('records the pair on COMPLETION, not dispatch: a delayed probe discarded stale leaves it unseen → arrow-back re-probes', async () => {
+		// round-2 P1. Marking at dispatch would let A→B, arrow-away-before-B-resolves,
+		// arrow-back-to-B take B's complete-seed fast path — painting a maybe-deleted B
+		// live. B is recorded ONLY when its forced probe resolves non-stale; a
+		// stale-discarded probe leaves B unseen so a later arrow-back re-forces.
+		const { addr } = harness();
+		await settle(); // A recorded
+		expect(metaRevalidate).toHaveBeenCalledTimes(1);
+
+		// Arrow to B, holding B's probe on a DEFERRED we resolve only after navigating
+		// away — so its continuation runs against a moved-on subject and hits the
+		// `req.stale()` guard at the mark site (exercising it, not just skipping it).
+		let resolveB!: (v: { status: 'ok'; mime: string; size: number }) => void;
+		metaRevalidate.mockReturnValueOnce(new Promise((r) => (resolveB = r)));
+		addr.att = ATT_B;
+		flushSync();
+		expect(metaRevalidate).toHaveBeenCalledTimes(2); // B forced (U3), unresolved
+
+		// Arrow back to A before B resolved.
+		addr.att = ATT_A;
+		flushSync();
+		// NOW resolve B's probe: its continuation runs but the subject is A, so
+		// `req.stale()` is true and the pair must NOT be recorded. A mark-before-the-
+		// stale-guard regression would record B here and the final re-probe would vanish.
+		resolveB({ status: 'ok', mime: 'image/png', size: 2048 });
+		await settle();
+		expect(metaRevalidate).toHaveBeenCalledTimes(2); // A already recorded → no probe
+
+		// Arrow to B again: B is STILL unseen (its earlier probe was stale-discarded), so
+		// a fresh automatic probe fires. Mark-at-dispatch — or marking before the stale
+		// guard — would suppress this (stay at 2).
+		metaRevalidate.mockResolvedValue({ status: 'ok', mime: 'image/png', size: 2048 });
+		addr.att = ATT_B;
+		flushSync();
+		expect(metaRevalidate).toHaveBeenCalledTimes(3);
+	});
+
+	it('a completed Retry probe does NOT record the pair → a later arrow-back still gets its one automatic probe (round-4 P2)', async () => {
+		// forcedFor records AUTOMATIC probes only. B's automatic probe is held pending
+		// (never records B); a Retry on B then completes but, being the reload path,
+		// must NOT record B either — so arrowing back to B still fires the automatic
+		// probe. If Retry (wrongly) recorded B, the final arrow-back would find B seen
+		// and skip, leaving the count one short.
+		const { addr, meta } = harness();
+		await settle(); // A recorded
+		metaRevalidate.mockReset();
+
+		// Arrow to B; hold its AUTOMATIC probe pending so it cannot record B.
+		metaRevalidate.mockReturnValueOnce(new Promise<never>(() => {}));
+		addr.att = ATT_B;
+		flushSync();
+		expect(metaRevalidate).toHaveBeenCalledTimes(1); // B automatic (pending)
+
+		// Retry on B resolves via the reload path — records nothing (automatic-only).
+		metaRevalidate.mockResolvedValue({ status: 'ok', mime: 'image/png', size: 2048 });
+		meta.retry();
+		flushSync();
+		await settle();
+		expect(metaRevalidate).toHaveBeenCalledTimes(2); // the Retry probe
+
+		// Arrow away to A (recorded → no probe), then back to B: B is still unseen
+		// (only a Retry ever completed for it), so the automatic probe fires.
+		addr.att = ATT_A;
+		flushSync();
+		await settle();
+		addr.att = ATT_B;
+		flushSync();
+		await settle();
+		expect(metaRevalidate).toHaveBeenCalledTimes(3);
 	});
 
 	it('does not burn the nonce while CLOSED even with an addressable attachment — forces once it opens', () => {
 		// The dangerous case: `open` is false but the attachment id is already set, so
-		// the subject IS addressable (a non-null key). The nonce must NOT be consumed
+		// the subject IS addressable (a non-null key). The pair must NOT be recorded
 		// here — no probe runs while closed — or a later real open on the SAME nonce
 		// would take the complete-seed fast path and skip the always-revalidate probe.
 		// (Reachable only if a consumer decouples `open` from a present attachment; the
 		// gate is `isOpen && req.key !== null`, matching the probe's own precondition.)
-		const addr = harness({ att: ATT_A, open: false, openNonce: 7 });
+		const { addr } = harness({ att: ATT_A, open: false, openNonce: 7 });
 		expect(metaRevalidate).not.toHaveBeenCalled();
 		expect(metaFetch).not.toHaveBeenCalled();
 
@@ -157,7 +266,7 @@ describe('surfaceMetadata — always-revalidate-on-open nonce (T6)', () => {
 	it('also does not burn the nonce while the subject is UN-addressable (no attachment yet)', () => {
 		// The sibling case: neither open nor addressable. Resolving the entry forces
 		// the opened entry on the same nonce.
-		const addr = harness({ att: '', open: false, openNonce: 3 });
+		const { addr } = harness({ att: '', open: false, openNonce: 3 });
 		expect(metaRevalidate).not.toHaveBeenCalled();
 
 		addr.att = ATT_A;

--- a/web/src/lib/attachments/surfaceMetadata.svelte.ts
+++ b/web/src/lib/attachments/surfaceMetadata.svelte.ts
@@ -71,12 +71,14 @@ export interface SurfaceMetadataAddress {
 	/** Host revalidate signal — a bump forces an invalidate-then-fetch (DR-14). */
 	revalidateToken: number;
 	/**
-	 * Per-OPEN nonce (PLAN-2392 3c-ii T6). The host mints a fresh value each time
-	 * it accepts an open request; it joins the SUBJECT identity below (not the
-	 * reload stamp), so a reopen of the same (ws, att) is a new subject and the
-	 * OPENED entry gets exactly one forced `no-store` probe. Constant across the
-	 * navigations within one open, so arrowing does not force (3c-iii owns
-	 * navigation-step revalidation).
+	 * Per-OPEN nonce (PLAN-2392 3c-ii T6, generalized by 3c-iii U3). The host mints
+	 * a fresh value each time it accepts an open request; it joins the SUBJECT
+	 * identity below (not the reload stamp), so a reopen of the same (ws, att) is a
+	 * new subject. Constant across the navigations WITHIN one open — but the machine
+	 * now forces one `no-store` probe per `(openNonce, attachment)` pair (U3), so the
+	 * opened entry AND every entry navigated to gets exactly one automatic
+	 * revalidation, while arrowing BACK to an already-probed entry within the same
+	 * open does not re-probe.
 	 */
 	openNonce: number;
 }
@@ -136,19 +138,29 @@ export function createSurfaceMetadata(
 	// Seeded from the incoming token so a host that already bumped its counter
 	// doesn't read as a pending reload on the first render.
 	let seenReload = untrack(() => `${address().revalidateToken}:0`);
-	// The open-nonce this machine has already forced a probe for (T6). A nonce it
-	// has NOT seen is a fresh open, and the opened entry gets exactly one forced
-	// `no-store` probe; arrowing keeps the nonce, so navigation does not force.
+	// The `(openNonce, attachment)` pairs this machine has already AUTOMATICALLY
+	// force-probed (T6, generalized to per-navigation-step by 3c-iii U3). Within one
+	// open the opened entry AND every entry navigated to gets exactly one forced
+	// `no-store` probe; the set records which pairs are done so arrowing BACK to an
+	// already-probed entry takes the fast path. Scoped to the live nonce — a REOPEN
+	// mints a fresh nonce, so the same (ws, att) is unseen again and re-probes.
+	//
+	// COMPLETION, NOT DISPATCH (round-2 P1). An id is recorded only when its forced
+	// probe RESOLVES non-stale (see the async continuation), never at dispatch: a
+	// probe discarded stale (arrow away before it resolves) leaves the pair unseen,
+	// so arrow-back re-probes rather than trusting the seed for a maybe-deleted entry.
+	// AUTOMATIC ONLY (round-4 P2): a Retry- or restore-driven forced probe (the
+	// reload path) does NOT record its id — the two mechanisms stay independent, so
+	// an arrow-back after a Retry still gets its one automatic probe if it never had one.
 	//
 	// Deliberately NOT seeded from the incoming value, UNLIKE `seenReload` above:
 	// the reload stamp seeds to SWALLOW a pre-mount host bump (so an
 	// already-bumped revalidateToken doesn't read as a pending reload on first
 	// render — the trap documented at the retired AttachmentPanelHost.svelte:128);
-	// the nonce must do the OPPOSITE — always force on the first nonce it sees —
-	// because always-revalidate-on-open is the guarantee. The {#key request} host
-	// remounts this machine per open, so `null` here reliably forces the opened
-	// entry.
-	let forcedNonce: number | null = null;
+	// this must do the OPPOSITE — always force on the first sight of each pair —
+	// because always-revalidate is the guarantee. The {#key request} host remounts
+	// this machine per open, so `null` here reliably forces the opened entry.
+	let forcedFor: { nonce: number; ids: Set<string> } | null = null;
 
 	// What the server told us, filling the gaps the event left.
 	let fetchedMime = $state<string | null>(null);
@@ -180,8 +192,12 @@ export function createSurfaceMetadata(
 		const reloadStamp = `${a.revalidateToken}:${forceReload}`;
 		const archivedParent = a.parentArchived;
 		const nonce = a.openNonce;
+		const att = a.attachmentId;
 
 		let forced = false;
+		// Whether THIS run's force is the automatic per-(nonce, att) revalidation —
+		// the only trigger that records the pair as seen when its probe completes.
+		let automaticForce = false;
 		untrack(() => {
 			// A genuine subject change: drop everything the previous attachment left
 			// behind, stop any in-flight continuation from reconciling, and abandon a
@@ -202,7 +218,8 @@ export function createSurfaceMetadata(
 			// can hold an `ok` observed before the archive — force it, routing through
 			// invalidate-then-fetch instead of replaying a stale success.
 			if (archivedParent) forced = true;
-			if (reloadStamp !== seenReload) {
+			const reloadForce = reloadStamp !== seenReload;
+			if (reloadForce) {
 				seenReload = reloadStamp;
 				forced = true;
 				// A forced revalidation exists because the previous answer may no
@@ -211,18 +228,26 @@ export function createSurfaceMetadata(
 				// to the retryable error, not sit on "no longer available" (DR-10).
 				missing = false;
 			}
-			// Always-revalidate-on-open (T6): a nonce this machine has not forced for
-			// yet is a fresh open — force one `no-store` probe of the OPENED entry.
-			// Gated on exactly the probe's own precondition (`isOpen && req.key !==
-			// null`, the early-return below), so the nonce is consumed only when a probe
-			// will actually run: a not-yet-open or not-yet-addressable subject must not
-			// burn the nonce and leave a later real open (same nonce) taking the
-			// fast-path with no forced probe. Navigation keeps the nonce, so this lands
-			// once per open. Same `missing` reset as the reload path, for the same reason.
-			if (isOpen && req.key !== null && nonce !== forcedNonce) {
-				forcedNonce = nonce;
+			// Always-revalidate-per-(open, entry) (T6, generalized by 3c-iii U3): scope
+			// the forced-set to the live nonce (a fresh open resets it), then force one
+			// `no-store` probe for a pair this machine has not yet AUTOMATICALLY probed
+			// to completion — the OPENED entry AND every entry navigated to. Gated on
+			// exactly the probe's own precondition (`isOpen && req.key !== null`, the
+			// early-return below), so a not-yet-open / not-yet-addressable subject
+			// neither probes nor records. Same `missing` reset as the reload path, for
+			// the same reason.
+			if (!forcedFor || forcedFor.nonce !== nonce) {
+				forcedFor = { nonce, ids: new Set() };
+			}
+			if (isOpen && req.key !== null && !forcedFor.ids.has(att)) {
 				forced = true;
 				missing = false;
+				// This run's forced probe is the pair's AUTOMATIC one only when it is not
+				// ALSO a reload (Retry/restore): those stay independent and never record,
+				// so an arrow-back after a Retry still gets its automatic probe. Recording
+				// happens on COMPLETION (the continuation), not here — a stale-discarded
+				// probe must leave the pair unseen.
+				if (!reloadForce) automaticForce = true;
 			}
 		});
 
@@ -255,6 +280,15 @@ export function createSurfaceMetadata(
 				: await fetchAttachmentMetadata(req.value.ws, req.value.att, downloadUrl);
 			clearTimeout(slowTimer);
 			if (req.stale()) return;
+			// Record this pair's AUTOMATIC probe as COMPLETE, now that it resolved for
+			// the still-current subject. Keyed to the pair THIS run dispatched for (`att`
+			// / `nonce` closed over), guarded on the live forced-set still belonging to
+			// that nonce — a stale-discarded probe returned above, leaving the pair
+			// unseen so arrow-back re-probes. `forcedFor` is a plain object, so this
+			// write starts no reactive dependency.
+			if (automaticForce && forcedFor && forcedFor.nonce === nonce) {
+				forcedFor.ids.add(att);
+			}
 			loading = false;
 			if (result.status === 'ok') {
 				fetchedMime = result.mime;

--- a/web/src/lib/components/attachments/AttachmentSurfaceHost.svelte.test.ts
+++ b/web/src/lib/components/attachments/AttachmentSurfaceHost.svelte.test.ts
@@ -226,12 +226,12 @@ describe('AttachmentSurfaceHost — the surface channel (TASK-2487 / TASK-2490)'
 		expect(metaFetch).not.toHaveBeenCalled();
 	});
 
-	it('arrowing between entries issues NO additional forced probe (only the open does)', async () => {
-		// The guarantee covers the OPENED entry, not each navigation step (3c-iii owns
-		// that). Opening force-revalidates the first entry once; arrowing keeps the
-		// nonce, so it never forces again — the sibling here has an INCOMPLETE seed
-		// (null size), so it takes the PLAIN (cacheable) HEAD, proving navigation is on
-		// the non-forced path rather than simply not probing.
+	it('arrowing to a fresh entry forces one no-store probe of the arrival (3c-iii U3), while arrowing back does not re-probe', async () => {
+		// INVERTS the T6-era expectation. T6 forced only the OPENED entry; 3c-iii U3
+		// forces one `no-store` probe per (open, entry) pair, so arrowing to a
+		// not-yet-probed sibling revalidates it too (never the plain seed-fill fetch,
+		// even though the sibling here has an INCOMPLETE seed). Arrowing BACK to the
+		// already-probed first entry takes the fast path — no third probe.
 		mountHost(propsA);
 		notifyAttachmentSurfaceOpen(
 			surfaceEvent({ images: [img(ATT_A), img(ATT_B, { alt: 'second', size_bytes: null })] })
@@ -240,12 +240,18 @@ describe('AttachmentSurfaceHost — the surface channel (TASK-2487 / TASK-2490)'
 		expect(metaRevalidate).toHaveBeenCalledTimes(1);
 		expect(metaFetch).not.toHaveBeenCalled();
 
-		// Arrow to the incomplete sibling — a plain seed-fill fetch, NOT a forced
-		// revalidation: the forced-probe count stays at the single open.
+		// Arrow to the sibling — a forced no-store revalidation of the arrival, NOT the
+		// plain cacheable HEAD.
 		document.body.querySelector<HTMLButtonElement>('.lightbox-nav.next')!.click();
 		await settle();
-		expect(metaRevalidate).toHaveBeenCalledTimes(1); // still just the open's
-		expect(metaFetch).toHaveBeenCalledTimes(1); // the sibling's plain HEAD
+		expect(metaRevalidate).toHaveBeenCalledTimes(2); // the arrival's forced probe
+		expect(metaRevalidate.mock.calls[1][3]).toEqual({ cache: 'no-store' });
+		expect(metaFetch).not.toHaveBeenCalled(); // never the plain seed-fill HEAD
+
+		// Arrow BACK to the first entry — already probed under this nonce → no re-probe.
+		document.body.querySelector<HTMLButtonElement>('.lightbox-nav.prev')!.click();
+		await settle();
+		expect(metaRevalidate).toHaveBeenCalledTimes(2);
 	});
 
 	it('keeps the CAPTURED workspace from the event, not any host default', async () => {

--- a/web/src/lib/components/common/Lightbox.svelte.test.ts
+++ b/web/src/lib/components/common/Lightbox.svelte.test.ts
@@ -4045,9 +4045,10 @@ describe('Lightbox — deletion subscription (DR-5c / TASK-2477)', () => {
 	}
 
 	it('an authoritative metadata 404 (missing) for the shown image advances to a survivor', async () => {
-		// A (the OPENED entry) is probed via the forced revalidation (T6); B (reached by
-		// the advance) via the plain fetch. Both mocks return the same per-uuid answer
-		// so A 404s wherever its probe is dispatched from.
+		// A (the OPENED entry) and B (reached by the advance) are BOTH probed via the
+		// forced revalidation — 3c-iii U3 forces one no-store probe per (open, entry)
+		// pair, advances included. Both mocks return the same per-uuid answer anyway, so
+		// A 404s wherever its probe is dispatched from.
 		const perUuid = (_ws: unknown, uuid: string) =>
 			Promise.resolve(
 				uuid === IMG_A
@@ -4086,8 +4087,8 @@ describe('Lightbox — deletion subscription (DR-5c / TASK-2477)', () => {
 		// Every image 404s: A advances to B, B's own probe 404s and advances to C,
 		// C's 404 empties the set → close. The effect re-runs once per subject change
 		// (each HEAD is async), so the cascade settles rather than looping. A (opened)
-		// probes via the forced revalidation, B/C (advanced-to) via the plain fetch —
-		// both mocks 404.
+		// AND B/C (advanced-to) all probe via the forced revalidation (3c-iii U3 forces
+		// per (open, entry) pair) — both mocks 404 regardless.
 		metaFetch.mockResolvedValue({ status: 'missing' });
 		metaRevalidate.mockResolvedValue({ status: 'missing' });
 		mountViewer({

--- a/web/src/lib/components/items/ItemAttachmentStrip.svelte
+++ b/web/src/lib/components/items/ItemAttachmentStrip.svelte
@@ -104,6 +104,26 @@
 		 * broadcasting to every host.
 		 */
 		hostToken?: string;
+		/**
+		 * The archive LEVEL of the item whose `ItemDetail` owns this strip
+		 * (PLAN-2392 3c-iii U2 / TASK-2511), threaded from `ItemDetail` exactly as
+		 * the timeline (U1) and the attachment surface host (DR-14) take it. The
+		 * strip has NO SSE subscription — its only live inputs are the in-process
+		 * delete/upload buses — so a restore that happened while this browser was
+		 * elsewhere never reaches it, and its rows keep rendering from the
+		 * pre-archive fetch (thumb URLs work again by accident, metadata may be
+		 * stale). This prop is the missing signal:
+		 *  - RESTORE (true→false edge): revalidate — re-fetch the attachment list
+		 *    and MERGE it over the current rows WITHOUT blanking them, preserving
+		 *    tombstones / pending uploads / in-flight deletes / expanded state.
+		 *  - ARCHIVE (false→true edge): a NO-OP on strip CONTENT. Tiles keep their
+		 *    painted bytes; the interaction paths already fail server-side (DR-14's
+		 *    404 correction). Deliberately not blanked.
+		 * Item scoping is inherent to the prop — no SSE filter — which is what lets
+		 * it cover BULK archive/restore (whose `items_bulk_updated` carries no
+		 * item_id). Defaults false → byte-identical for every existing caller.
+		 */
+		parentArchived?: boolean;
 	}
 	let {
 		wsSlug,
@@ -113,6 +133,7 @@
 		itemContent = null,
 		liveContent = null,
 		hostToken = '',
+		parentArchived = false,
 	}: Props = $props();
 
 	// Hard bound on what the strip will ever hold (DR-9 / DR-11). Past this the
@@ -282,6 +303,57 @@
 	// showed (Codex review of TASK-2385). Merged back on top of every response.
 	let pendingUploads: StripAttachment[] = [];
 
+	// list() requests currently fetching, counted PER VIEW KEY. A restore
+	// revalidation consults this to DEFER to a load already fetching THIS view
+	// rather than supersede it (PLAN-2392 3c-iii U2 / TASK-2511 — see
+	// `revalidateAfterRestore`). Per-view, not a single counter: the api client
+	// has no abort, so a superseded prior-view load lingers in flight after an
+	// A→B switch, and a global counter would let that stale A-load suppress B's
+	// genuine restore revalidation with nothing left to refetch B (Codex round 3).
+	const loadsInFlightByView = new Map<string, number>();
+	function viewLoadsInFlight(key: string | null): number {
+		return key === null ? 0 : (loadsInFlightByView.get(key) ?? 0);
+	}
+	function noteLoadStart(key: string | null) {
+		if (key === null) return;
+		loadsInFlightByView.set(key, (loadsInFlightByView.get(key) ?? 0) + 1);
+	}
+	function noteLoadEnd(key: string | null) {
+		if (key === null) return;
+		const n = (loadsInFlightByView.get(key) ?? 0) - 1;
+		if (n <= 0) loadsInFlightByView.delete(key);
+		else loadsInFlightByView.set(key, n);
+	}
+
+	// Ids with a DELETE request outstanding — the optimistic-removal window
+	// (PLAN-2392 3c-iii U2 / TASK-2511). `deletedIds` is only latched AFTER the
+	// delete's API await (via the deletion bus's self-broadcast in
+	// `performDelete`), so in the gap between the optimistic removal and that
+	// broadcast a row is gone from `attachments` but NOT yet tombstoned. The
+	// RESTORE revalidation re-fetches the list in exactly that window, and its
+	// response can still carry the row (its own DELETE hasn't committed, or the
+	// GET predates it) — repainting the tile the user just removed. The restore
+	// reload therefore excludes these ids too, not only tombstones.
+	//
+	// REF-COUNTED, not a bare Set: the same id can have two deletes outstanding
+	// (a load repaints an optimistically-removed-but-not-yet-tombstoned row and
+	// the user deletes it again), and the first to settle must not clear the
+	// marker while the second is still in flight (Codex round 2). Not bounded
+	// like `deletedIds`: it drains per delete, holding at most the handful of
+	// concurrently in-flight deletes, never a workspace-wide backlog.
+	const inFlightDeletes = new Map<string, number>();
+	function isDeleting(id: string): boolean {
+		return inFlightDeletes.has(id);
+	}
+	function markDeleting(id: string) {
+		inFlightDeletes.set(id, (inFlightDeletes.get(id) ?? 0) + 1);
+	}
+	function unmarkDeleting(id: string) {
+		const n = (inFlightDeletes.get(id) ?? 0) - 1;
+		if (n <= 0) inFlightDeletes.delete(id);
+		else inFlightDeletes.set(id, n);
+	}
+
 	$effect(() => {
 		// Restarting the request fence supersedes any response still in flight
 		// AND captures the identity this run belongs to. Reading the identity
@@ -351,6 +423,14 @@
 		}
 
 		void (async () => {
+			// Count this load as in flight for its view for the whole fetch
+			// (PLAN-2392 3c-iii U2 / TASK-2511). A restore revalidation DEFERS to a
+			// load already fetching THIS view — that load returns fresh-enough data
+			// (archive doesn't delete attachments), and superseding it would strand
+			// the strip empty if the revalidation then failed (Codex round 2). Keyed
+			// by `req.key` so a stale prior-view load can't suppress a genuine
+			// restore of the current view (Codex round 3).
+			noteLoadStart(req.key);
 			// Ids the pending buffer ALREADY held when this request went out. A
 			// response can be authoritative about exactly these — the row existed
 			// before the GET, so its absence is proof the row is gone (deleted by
@@ -459,6 +539,7 @@
 				attachments = capped(pendingUploads.filter((a) => !deletedIds.has(a.id)));
 				loadFailed = true;
 			} finally {
+				noteLoadEnd(req.key);
 				stopLoadingMarker();
 				if (!req.stale()) showLoading = false;
 			}
@@ -520,6 +601,141 @@
 		retryRequestedFor = painted.key;
 		retryNonce++;
 	}
+
+	/**
+	 * Re-fetch and reconcile the list after the parent item is RESTORED
+	 * (PLAN-2392 3c-iii U2 / TASK-2511). Deliberately a SEPARATE, gentler path
+	 * from the load effect's non-retry rerun, which blanks `attachments`,
+	 * `expanded`, `pendingDelete`, `deletedIds`, `pendingUploads` synchronously
+	 * before its fetch. A restore is a refresh of the SAME view, not a switch, so
+	 * this one:
+	 *   - never blanks: the current tiles stay painted until (and unless) the
+	 *     response replaces them, so a restore of an item with a slow list never
+	 *     flashes empty;
+	 *   - preserves the mutation state the reset path would wipe — deletion
+	 *     tombstones (`deletedIds`), pending uploads, the expanded/overflow state
+	 *     — and merges the response over them exactly as the load path's SUCCESS
+	 *     arm does, so a just-uploaded row isn't dropped and a just-deleted one
+	 *     isn't resurrected;
+	 *   - honours `inFlightDeletes`: a delete whose optimistic removal has run but
+	 *     whose tombstone broadcast hasn't yet must not be repainted by this
+	 *     refetch (round-3 P1).
+	 *
+	 * Fenced on `loadFence.restart()` like every other request: it SUPERSEDES an
+	 * in-flight load (and is superseded by a later switch / Retry / another
+	 * restore), and its captured token goes stale on a view change, so a response
+	 * that lands after the user moved on is discarded. A FAILED revalidation is
+	 * NOT authoritative and NOT surfaced as the error row: the strip already holds
+	 * a good list from before the archive, and degrading a refresh into a blocking
+	 * "Couldn't load" would be worse than keeping the slightly-stale-but-present
+	 * tiles. The next real load corrects it.
+	 */
+	async function revalidateAfterRestore() {
+		// DEFER to a load already fetching THIS view (Codex rounds 2-3). A restore
+		// is a refresh, and an in-flight load for this view — the mount fetch, a
+		// Retry — already returns the current list (archive doesn't delete
+		// attachments), so superseding it buys nothing and, if this revalidation
+		// then failed, would strand the strip empty with no rows and no
+		// error/retry. Keyed on the live view so a lingering stale prior-view load
+		// (no request abort) can't wrongly suppress this. Skip; that load paints.
+		if (viewLoadsInFlight(view.key()) > 0) return;
+		const req = loadFence.restart();
+		const { ws: reqWsSlug, item: reqItemId } = req.value;
+		if (!reqItemId || !reqWsSlug) return;
+		try {
+			const res = await api.attachments.list(reqWsSlug, {
+				item_id: reqItemId,
+				limit: MAX_FETCH,
+			});
+			if (req.stale()) return;
+			const raw = res.attachments ?? [];
+			// Exclude BOTH the tombstoned ids AND the ids with a delete still in
+			// flight: neither may be repainted (round-3 P1). This is the only
+			// difference from the load path's response filter, which sees just
+			// `deletedIds` because a fresh load runs with no optimistic delete
+			// outstanding against its own results.
+			const rows = raw
+				.filter((a) => !deletedIds.has(a.id) && !isDeleting(a.id))
+				.map(toStripAttachment);
+			const seen = new Set(rows.map((a) => a.id));
+			// Pending uploads the response did NOT return ride back on top, same as
+			// the load path — a drop announced while archived is otherwise lost.
+			// Deliberately NOT consumed here (unlike the load path's retention
+			// pass): a restore is a one-shot refresh, not the mount-time load whose
+			// buffer would grow forever, and "preserve pending uploads" is the U2
+			// contract.
+			const missed = pendingUploads.filter(
+				(a) => !seen.has(a.id) && !deletedIds.has(a.id) && !isDeleting(a.id)
+			);
+			const merged = [...missed, ...rows];
+			attachments = capped(merged);
+			// Continuation count recomputed off `total`, corrected the same three
+			// ways as the load path (deleted-in-page, uploads-not-returned, floor).
+			const reportedTotal = Math.max(
+				0,
+				(res.total ?? raw.length) - (raw.length - rows.length)
+			);
+			const trueTotal = Math.max(reportedTotal + missed.length, merged.length);
+			beyondStripCount = Math.max(0, trueTotal - attachments.length);
+			// A successful revalidation is an authoritative fresh listing, so it
+			// also clears a stale error left from an EARLIER failed load: without
+			// this the restored rows would render UNDER a lingering "Couldn't load"
+			// row (Codex round 1). The failure arm deliberately does NOT set it —
+			// a refresh failure is not authoritative (see the header).
+			loadFailed = false;
+		} catch {
+			// Swallowed by design (see the header): keep the pre-restore rows.
+		} finally {
+			// A settled revalidation is, by definition, not loading. The defer guard
+			// above means no same-view load was in flight when this ran, so
+			// `showLoading` is already false — this is a defensive invariant, not a
+			// live fix, and it self-suppresses if a later switch/Retry has since
+			// superseded us (that run owns its own marker). Symmetric with the load
+			// effect's finally.
+			if (!req.stale()) showLoading = false;
+		}
+	}
+
+	// Archive/restore LIFECYCLE edge (PLAN-2392 3c-iii U2 / TASK-2511). Threaded
+	// as a PROP from ItemDetail — the same signal the timeline (U1) and the
+	// surface host (DR-14) take — rather than an SSE subscription, so it covers
+	// BULK archive/restore (whose `items_bulk_updated` carries no item_id).
+	//
+	// Edge-triggered off a LATCHED previous value that is KEYED TO THE VIEW
+	// IDENTITY, not just the boolean: the strip persists across item switches (it
+	// lives outside ItemDetail's `{#key itemSlug}`), so an archived item A → an
+	// active item B is ALSO a true→false transition in the raw prop — but it is a
+	// SWITCH, not a restore, and honouring it would fire a duplicate racing load
+	// on top of the switch's own (round-3 P2). Reseeding the latch whenever the
+	// view key changes makes a switch reseed-not-fire. Only the true→false edge
+	// WITHIN one identity revalidates; the archive edge is a content no-op.
+	//
+	// Plain `let` latches read/written under `untrack` — a $state read+written in
+	// one tracked scope aborts its own flush (the Svelte self-write trap). Seeded
+	// from the initial props so a mount on an already-archived item is a LEVEL,
+	// not an edge.
+	let archivedLatchKey: string | null = untrack(() => view.key());
+	let prevArchived = untrack(() => parentArchived === true);
+	$effect(() => {
+		const archived = parentArchived === true;
+		// Tracked reads: the effect must re-run on a lifecycle flip AND on a view
+		// switch (so it can reseed the latch before the flip is misread as a
+		// restore).
+		const key = view.key();
+		untrack(() => {
+			if (key !== archivedLatchKey) {
+				// A switch (or an id becoming known/unknown). Reseed to the incoming
+				// item's level; do NOT treat the cross-item boolean change as an edge.
+				archivedLatchKey = key;
+				prevArchived = archived;
+				return;
+			}
+			if (archived === prevArchived) return;
+			prevArchived = archived;
+			// Only restore (true→false) reconciles content; archive is a no-op.
+			if (!archived) void revalidateAfterRestore();
+		});
+	});
 
 	// Deletions broadcast on the shared registry — from Settings → Storage, or
 	// from ANOTHER strip (the split-pane host mounts two ItemDetails, so two
@@ -881,6 +1097,16 @@
 		const reqWsSlug = req.value.ws;
 		const index = attachments.findIndex((a) => a.id === att.id);
 
+		// Mark the delete in-flight BEFORE the optimistic removal (PLAN-2392
+		// 3c-iii U2 / TASK-2511). The tombstone (`deletedIds`) is only latched
+		// AFTER the await — via the deletion bus's self-broadcast below — so
+		// between here and then the row is gone from `attachments` but not yet
+		// tombstoned. A restore revalidation refetching in that window would
+		// otherwise repaint it; `revalidateAfterRestore` excludes this set. Cleared
+		// when the call settles, by which point success/404 has handed off to the
+		// tombstone.
+		markDeleting(att.id);
+
 		// Optimistic removal.
 		attachments = attachments.filter((a) => a.id !== att.id);
 
@@ -952,6 +1178,14 @@
 					: `Couldn't delete ${displayFilename(att.filename)}.`,
 				'error'
 			);
+		} finally {
+			// Every exit path — 204, 404, stale, tombstoned, rollback — passes
+			// through here, so the in-flight marker never leaks. On success/404 the
+			// tombstone latched by the broadcast above already covers the id; on a
+			// genuine failure the row is back and must be repaintable again. Ref-
+			// counted, so a concurrent second delete of the same id keeps the marker
+			// until IT settles too.
+			unmarkDeleting(att.id);
 		}
 	}
 </script>

--- a/web/src/lib/components/items/ItemAttachmentStrip.svelte
+++ b/web/src/lib/components/items/ItemAttachmentStrip.svelte
@@ -450,7 +450,16 @@
 				});
 				if (req.stale()) return;
 				const raw = res.attachments ?? [];
-				const rows = raw.filter((a) => !deletedIds.has(a.id)).map(toStripAttachment);
+				// Exclude BOTH tombstoned ids AND ids with a delete still in flight
+				// (PLAN-2392 3c-iii — load-path fence). `deletedIds` is only latched
+				// AFTER a delete's API await, so between an optimistic removal and that
+				// broadcast a row is gone from `attachments` but not yet tombstoned. An
+				// ordinary list() response issued (or in flight) across that window can
+				// still carry the row and repaint the tile the user just removed — the
+				// same hole `revalidateAfterRestore` already fences on the restore path.
+				const rows = raw
+					.filter((a) => !deletedIds.has(a.id) && !isDeleting(a.id))
+					.map(toStripAttachment);
 				const seen = new Set(rows.map((a) => a.id));
 				// ...but only a COMPLETE page is authoritative about absence. The
 				// request is bounded at MAX_FETCH, so a truncated page may simply
@@ -466,7 +475,8 @@
 					typeof res.total === 'number' ? res.total <= raw.length : raw.length < MAX_FETCH;
 				const covered = pageIsComplete ? pendingAtRequest : new Set<string>();
 				const missed = pendingUploads.filter(
-					(a) => !seen.has(a.id) && !deletedIds.has(a.id) && !covered.has(a.id)
+					(a) =>
+						!seen.has(a.id) && !deletedIds.has(a.id) && !isDeleting(a.id) && !covered.has(a.id)
 				);
 				// Consume what this response covered. The exclusion above already
 				// makes every LATER load ignore these ids (a later request's own
@@ -536,7 +546,12 @@
 				// Keep anything uploaded while this request was in flight: the
 				// upload SUCCEEDED, so dropping it would hide a row the editor
 				// and server both have, until a remount (Codex review round 2).
-				attachments = capped(pendingUploads.filter((a) => !deletedIds.has(a.id)));
+				// A row with a delete still in flight is excluded here too — the
+				// failure arm repaints from the pending buffer, and an optimistically
+				// removed row must not ride back in on that repaint (load-path fence).
+				attachments = capped(
+					pendingUploads.filter((a) => !deletedIds.has(a.id) && !isDeleting(a.id))
+				);
 				loadFailed = true;
 			} finally {
 				noteLoadEnd(req.key);

--- a/web/src/lib/components/items/ItemAttachmentStrip.svelte.test.ts
+++ b/web/src/lib/components/items/ItemAttachmentStrip.svelte.test.ts
@@ -2494,4 +2494,177 @@ describe('ItemAttachmentStrip', () => {
 		expect(final.some((n) => n.includes('a1'))).toBe(false);
 		expect(final.some((n) => n.includes('a2'))).toBe(true);
 	});
+
+	// ── ORDINARY-LOAD in-flight-delete fence (PLAN-2392 3c-iii — load-path) ────
+	//
+	// U2 (TASK-2511) added the `inFlightDeletes` marker but applied it ONLY to the
+	// restore revalidation's merge. The ORDINARY load paths — the mount/retry
+	// response row filter, the pending-upload merge, and the load-FAILURE repaint —
+	// filtered on `deletedIds` alone. `deletedIds` is latched only AFTER a delete's
+	// API await (the deletion bus self-broadcast), so between an optimistic removal
+	// and that broadcast a row is gone from `attachments` but not yet tombstoned. An
+	// ordinary load whose response was issued (or is in flight) across that window
+	// can still carry the row and repaint the just-removed tile — the same hole the
+	// restore path already fences. These cover the three ordinary paths + the
+	// rollback discipline that must still repaint a genuinely failed delete.
+
+	it('does not repaint an in-flight-deleted row that an ordinary (retry) load returns', async () => {
+		// Path 1 — the response ROW filter (~:453). a1 is painted from a server load
+		// (surviving a failure as a pending upload → visible with a Retry), then a
+		// retry load returns a1 while a1's delete is in flight. `pendingAtRequest`
+		// already holds a1 at retry time, so the pending-upload merge excludes it via
+		// `covered` — leaving the response row filter as the ONLY thing between a1 and
+		// a repaint. That isolates path 1: dropping its `!isDeleting` guard resurrects
+		// a1 even though the merge leg's guard is untouched.
+		props.canDelete = true;
+		let rejectLoad1!: (e: Error) => void;
+		listMock.mockReturnValueOnce(
+			new Promise<AttachmentListResponse>((_, reject) => (rejectLoad1 = reject))
+		);
+		mountStrip('item-a');
+		flushSync();
+		broadcastUpload('item-a', uploaded('a1'));
+		flushSync();
+		rejectLoad1(new Error('offline'));
+		await settle();
+		expect(tiles()).toHaveLength(1); // a1 kept as a pending upload
+		expect(errorRow()).not.toBeNull();
+
+		// Retry: a1 stays painted while the retry load is in flight (isRetry never blanks).
+		const load2 = deferred<AttachmentListResponse>();
+		listMock.mockReturnValueOnce(load2.promise);
+		target.querySelector<HTMLElement>('.att-retry')!.click();
+		flushSync();
+
+		// Delete a1 — deferred, so its tombstone broadcast hasn't fired.
+		const del = deferred<void>();
+		deleteMock.mockReturnValueOnce(del.promise);
+		openConfirm(0);
+		clickConfirm();
+		expect(tiles()).toHaveLength(0); // optimistic removal
+
+		// The retry load lands mid-delete, still listing a1: the in-flight marker
+		// filters it out of the response rows, so a1 does NOT resurrect.
+		load2.resolve(response([att({ id: 'a1' })]));
+		await settle();
+		expect(tiles()).toHaveLength(0);
+
+		// The delete resolves: still gone, now tombstoned too — the durable filter
+		// takes over from the transient marker.
+		del.resolve();
+		await settle();
+		expect(tiles()).toHaveLength(0);
+		expect(deleteMock).toHaveBeenCalledWith('ws', 'a1');
+	});
+
+	it('does not resurrect an in-flight-deleted upload row through the pending-upload merge', async () => {
+		// Path 2 — the pending-upload MERGE (~:468). a1 is a pending upload the mount
+		// load's response does NOT return (the GET predates the upload), so a1 rides
+		// back only via `missed`. The mount load's `pendingAtRequest` snapshot was
+		// captured empty (before the upload), so `covered` is empty and cannot mask
+		// the effect — this isolates path 2: dropping its `!isDeleting` guard
+		// resurrects a1, while the response-row filter (raw is empty) is irrelevant.
+		props.canDelete = true;
+		const load1 = deferred<AttachmentListResponse>();
+		listMock.mockReturnValueOnce(load1.promise);
+		mountStrip('item-a');
+		flushSync();
+		broadcastUpload('item-a', uploaded('a1'));
+		flushSync();
+		expect(tiles()).toHaveLength(1);
+
+		const del = deferred<void>();
+		deleteMock.mockReturnValueOnce(del.promise);
+		openConfirm(0);
+		clickConfirm();
+		expect(tiles()).toHaveLength(0); // optimistic removal
+
+		// The mount load resolves WITHOUT a1. a1 now lives only in the pending-upload
+		// buffer; the merge must not ride it back in while its delete is in flight.
+		load1.resolve(response([]));
+		await settle();
+		expect(tiles()).toHaveLength(0);
+
+		del.resolve();
+		await settle();
+		expect(tiles()).toHaveLength(0);
+	});
+
+	it('does not resurrect an in-flight-deleted upload row through the load-failure repaint', async () => {
+		// Path 3 — the load-FAILURE repaint (~:539). The catch arm repaints from the
+		// pending-upload buffer, which still holds a1. The in-flight marker must keep
+		// a1 out; dropping its `!isDeleting` guard resurrects a1 under the error row.
+		props.canDelete = true;
+		let rejectLoad1!: (e: Error) => void;
+		listMock.mockReturnValueOnce(
+			new Promise<AttachmentListResponse>((_, reject) => (rejectLoad1 = reject))
+		);
+		mountStrip('item-a');
+		flushSync();
+		broadcastUpload('item-a', uploaded('a1'));
+		flushSync();
+		expect(tiles()).toHaveLength(1);
+
+		const del = deferred<void>();
+		deleteMock.mockReturnValueOnce(del.promise);
+		openConfirm(0);
+		clickConfirm();
+		expect(tiles()).toHaveLength(0); // optimistic removal
+
+		// The mount load now FAILS: its catch repaints from the pending buffer, but
+		// the in-flight marker keeps a1 out — no resurrection, just the error row.
+		rejectLoad1(new Error('offline'));
+		await settle();
+		expect(errorRow()).not.toBeNull();
+		expect(tiles()).toHaveLength(0);
+
+		del.resolve();
+		await settle();
+		expect(tiles()).toHaveLength(0);
+	});
+
+	it('rolls a row back into view when its delete fails, even though a list response landed mid-delete', async () => {
+		// The rollback discipline is a SETTLE-TIME correction and must survive the new
+		// filter: a genuinely failed delete re-inserts the row DIRECTLY into
+		// `attachments` (not through the filtered load paths), and the marker is
+		// cleared in performDelete's `finally` — which runs AFTER the catch re-inserts
+		// the row, so ordering never lets the filter swallow the rollback.
+		props.canDelete = true;
+		let rejectLoad1!: (e: Error) => void;
+		listMock.mockReturnValueOnce(
+			new Promise<AttachmentListResponse>((_, reject) => (rejectLoad1 = reject))
+		);
+		mountStrip('item-a');
+		flushSync();
+		broadcastUpload('item-a', uploaded('a1'));
+		flushSync();
+		rejectLoad1(new Error('offline'));
+		await settle();
+		expect(tiles()).toHaveLength(1);
+
+		const load2 = deferred<AttachmentListResponse>();
+		listMock.mockReturnValueOnce(load2.promise);
+		target.querySelector<HTMLElement>('.att-retry')!.click();
+		flushSync();
+
+		// Delete a1 — the DELETE will fail.
+		let rejectDel!: (e: Error) => void;
+		deleteMock.mockReturnValueOnce(new Promise<void>((_, reject) => (rejectDel = reject)));
+		openConfirm(0);
+		clickConfirm();
+		expect(tiles()).toHaveLength(0); // optimistic removal
+
+		// The retry load lands mid-delete, still listing a1: the marker hides it, so
+		// the tile does NOT come back on the load.
+		load2.resolve(response([att({ id: 'a1' })]));
+		await settle();
+		expect(tiles()).toHaveLength(0);
+
+		// The delete now FAILS: the row must roll back into view and toast.
+		rejectDel(new Error('500'));
+		await settle();
+		expect(tiles()).toHaveLength(1);
+		expect(tiles()[0].getAttribute('aria-label')).toContain('a1.png');
+		expect(toastMock).toHaveBeenCalled();
+	});
 });

--- a/web/src/lib/components/items/ItemAttachmentStrip.svelte.test.ts
+++ b/web/src/lib/components/items/ItemAttachmentStrip.svelte.test.ts
@@ -148,6 +148,7 @@ const props = $state<{
 	itemContent: string | null;
 	liveContent: (() => string | null) | null;
 	hostToken: string;
+	parentArchived: boolean;
 	mutationsEnabled?: boolean;
 	getItemContent?: () => string | null;
 	getLiveContent?: () => string | null;
@@ -159,6 +160,7 @@ const props = $state<{
 	itemContent: null,
 	liveContent: null,
 	hostToken: 'host-1',
+	parentArchived: false,
 	mutationsEnabled: false,
 	getItemContent: undefined,
 	getLiveContent: undefined,
@@ -186,6 +188,7 @@ describe('ItemAttachmentStrip', () => {
 		props.canDelete = false;
 		props.itemContent = null;
 		props.liveContent = null;
+		props.parentArchived = false;
 		props.mutationsEnabled = false;
 		props.getItemContent = undefined;
 		props.getLiveContent = undefined;
@@ -2055,5 +2058,395 @@ describe('ItemAttachmentStrip', () => {
 		expect(document.querySelector<HTMLImageElement>('.lightbox-image')?.getAttribute('alt')).toBe(
 			'img2.png'
 		);
+	});
+
+	// ── Archive / restore revalidation (PLAN-2392 3c-iii U2 / TASK-2511) ──────
+	//
+	// The strip has NO SSE subscription: its only live inputs are the in-process
+	// delete/upload buses, so a restore that happened while this browser was
+	// elsewhere never reaches it and its rows keep rendering from the pre-archive
+	// fetch. `parentArchived` — threaded from ItemDetail, the same signal the
+	// timeline and surface host take — is the missing edge. Restore (true→false)
+	// re-fetches and MERGES over the current rows WITHOUT blanking, preserving
+	// tombstones / pending uploads / in-flight deletes / expanded state. Archive
+	// (false→true) is a content no-op. The latch is keyed to VIEW IDENTITY, so an
+	// archived→active item SWITCH is not misread as a restore.
+
+	it('treats a mount on an already-archived item as a level, not a restore edge', async () => {
+		// The latch is seeded from the initial prop, so an already-archived mount
+		// is a LEVEL — one fetch (the mount load), no spurious restore refetch.
+		props.parentArchived = true;
+		listMock.mockResolvedValue(response([att({ id: 'a1' })]));
+		mountStrip('item-a');
+		await settle();
+
+		expect(listMock).toHaveBeenCalledTimes(1);
+		expect(tiles()).toHaveLength(1);
+	});
+
+	it('revalidates on restore (archived true→false), merging fresh rows without blanking', async () => {
+		// Mount already-archived: the tiles are the pre-archive snapshot.
+		props.parentArchived = true;
+		listMock.mockResolvedValueOnce(response([att({ id: 'a1' })]));
+		mountStrip('item-a');
+		await settle();
+		expect(tiles()).toHaveLength(1);
+		expect(listMock).toHaveBeenCalledTimes(1);
+
+		// The restore refetch is DEFERRED so the pre-restore tile can be observed
+		// still on screen while it is in flight — the gentle path never blanks.
+		const revalidate = deferred<AttachmentListResponse>();
+		listMock.mockReturnValueOnce(revalidate.promise);
+		props.parentArchived = false;
+		flushSync();
+		expect(listMock).toHaveBeenCalledTimes(2);
+		expect(tiles()).toHaveLength(1);
+		expect(tiles()[0].getAttribute('aria-label')).toContain('a1.png');
+
+		// The response carries an attachment that appeared while archived.
+		revalidate.resolve(response([att({ id: 'a1' }), att({ id: 'a2' })]));
+		await settle();
+		const names = tiles().map((el) => el.getAttribute('aria-label') ?? '');
+		expect(names).toHaveLength(2);
+		expect(names.some((n) => n.includes('a2.png'))).toBe(true);
+	});
+
+	it('does not refetch or blank on archive (false→true) — the content no-op contract', async () => {
+		props.parentArchived = false;
+		listMock.mockResolvedValueOnce(response([att({ id: 'a1' }), att({ id: 'a2' })]));
+		mountStrip('item-a');
+		await settle();
+		expect(tiles()).toHaveLength(2);
+		expect(listMock).toHaveBeenCalledTimes(1);
+
+		props.parentArchived = true;
+		flushSync();
+		await settle();
+
+		// Tiles keep their painted bytes; the archive edge issues no list() at all.
+		expect(tiles()).toHaveLength(2);
+		expect(listMock).toHaveBeenCalledTimes(1);
+	});
+
+	it('does not double-load when an archived item switches to an active one', async () => {
+		// A(archived) → B(active) is a true→false transition in the raw prop, but a
+		// SWITCH, not a restore (round-3 P2). The switch's own load is the ONLY
+		// fetch; a value-only latch would fire a duplicate restore revalidation on
+		// top of it. The identity-keyed latch reseeds to B instead.
+		props.parentArchived = true;
+		listMock.mockResolvedValueOnce(response([att({ id: 'a1' })]));
+		mountStrip('item-a');
+		await settle();
+		expect(listMock).toHaveBeenCalledTimes(1);
+
+		listMock.mockResolvedValueOnce(response([att({ id: 'b1' })]));
+		props.itemId = 'item-b';
+		props.parentArchived = false;
+		flushSync();
+		await settle();
+
+		// Exactly TWO fetches: mount-A and switch-B. A third is the bug.
+		expect(listMock).toHaveBeenCalledTimes(2);
+		expect(tiles()).toHaveLength(1);
+		expect(tiles()[0].getAttribute('aria-label')).toContain('b1.png');
+	});
+
+	it('does not repaint an in-flight-deleted row when a restore revalidation lands first', async () => {
+		// round-3 P1: `deletedIds` is only tombstoned AFTER the delete's await, so
+		// a restore refetch in the optimistic-removal window would otherwise
+		// repaint the just-removed tile. The in-flight-delete marker excludes it.
+		props.parentArchived = true;
+		props.canDelete = true;
+		listMock.mockResolvedValueOnce(response([att({ id: 'a1' }), att({ id: 'a2' })]));
+		mountStrip('item-a');
+		await settle();
+		expect(tiles()).toHaveLength(2);
+
+		// Delete a1 with a DEFERRED delete, so its tombstone broadcast hasn't
+		// fired when the restore refetch resolves.
+		const del = deferred<void>();
+		deleteMock.mockReturnValueOnce(del.promise);
+		openConfirm(0); // a1 is the first tile's ×
+		clickConfirm();
+		expect(tiles()).toHaveLength(1); // optimistic removal of a1
+
+		// Restore. The refetch still lists a1 — its own DELETE hasn't committed —
+		// but a1 must NOT come back.
+		listMock.mockResolvedValueOnce(response([att({ id: 'a1' }), att({ id: 'a2' })]));
+		props.parentArchived = false;
+		flushSync();
+		await settle();
+
+		let names = tiles().map((el) => el.getAttribute('aria-label') ?? '');
+		expect(names.some((n) => n.includes('a1.png'))).toBe(false);
+		expect(names.some((n) => n.includes('a2.png'))).toBe(true);
+
+		// The delete now resolves successfully: still gone, now tombstoned too.
+		del.resolve();
+		await settle();
+		names = tiles().map((el) => el.getAttribute('aria-label') ?? '');
+		expect(names.some((n) => n.includes('a1.png'))).toBe(false);
+		expect(deleteMock).toHaveBeenCalledWith('ws', 'a1');
+	});
+
+	it('preserves a pending upload through a restore revalidation', async () => {
+		props.parentArchived = true;
+		listMock.mockResolvedValueOnce(response([att({ id: 'a1' })]));
+		mountStrip('item-a');
+		await settle();
+
+		// A drop announced while archived — in `attachments` AND `pendingUploads`.
+		broadcastUpload('item-a', uploaded('fresh'));
+		flushSync();
+		expect(tiles()).toHaveLength(2);
+
+		// The restore refetch does NOT return `fresh` (the server doesn't know it
+		// yet). The gentle path must merge it back on top, not drop it.
+		listMock.mockResolvedValueOnce(response([att({ id: 'a1' })]));
+		props.parentArchived = false;
+		flushSync();
+		await settle();
+
+		const names = tiles().map((el) => el.getAttribute('aria-label') ?? '');
+		expect(names.some((n) => n.includes('fresh.png'))).toBe(true);
+		expect(names.some((n) => n.includes('a1.png'))).toBe(true);
+	});
+
+	it('does not resurrect a tombstoned row on a restore revalidation', async () => {
+		props.parentArchived = true;
+		listMock.mockResolvedValueOnce(response([att({ id: 'a1' }), att({ id: 'a2' })]));
+		mountStrip('item-a');
+		await settle();
+
+		// Another surface deleted a2 while archived.
+		broadcastDeletion('a2');
+		flushSync();
+		expect(tiles()).toHaveLength(1);
+
+		// The restore refetch still lists a2 (its delete raced the server, or this
+		// GET predates it). The tombstone must win.
+		listMock.mockResolvedValueOnce(response([att({ id: 'a1' }), att({ id: 'a2' })]));
+		props.parentArchived = false;
+		flushSync();
+		await settle();
+
+		const names = tiles().map((el) => el.getAttribute('aria-label') ?? '');
+		expect(names.some((n) => n.includes('a2.png'))).toBe(false);
+		expect(names).toHaveLength(1);
+	});
+
+	it('preserves the expanded state across a restore revalidation', async () => {
+		props.parentArchived = true;
+		const rows = Array.from({ length: 12 }, (_, i) => att({ id: `a${i}` }));
+		listMock.mockResolvedValueOnce(response(rows));
+		mountStrip('item-a');
+		await settle();
+		expect(tiles()).toHaveLength(8);
+
+		// Expand — the non-retry load path would reset this to false.
+		target.querySelector<HTMLElement>('.att-more-expand')?.click();
+		flushSync();
+		expect(tiles()).toHaveLength(12);
+
+		listMock.mockResolvedValueOnce(response(rows));
+		props.parentArchived = false;
+		flushSync();
+		await settle();
+
+		// Still expanded: the gentle path never touched `expanded`.
+		expect(tiles()).toHaveLength(12);
+		expect(target.querySelector('.att-more-expand')).toBeNull();
+	});
+
+	it('keeps the pre-restore rows when the restore revalidation fails', async () => {
+		props.parentArchived = true;
+		listMock.mockResolvedValueOnce(response([att({ id: 'a1' })]));
+		mountStrip('item-a');
+		await settle();
+		expect(tiles()).toHaveLength(1);
+
+		listMock.mockRejectedValueOnce(new Error('offline'));
+		props.parentArchived = false;
+		flushSync();
+		await settle();
+
+		// A refresh failure is not authoritative: keep the good rows, and do NOT
+		// degrade to the blocking error row.
+		expect(tiles()).toHaveLength(1);
+		expect(tiles()[0].getAttribute('aria-label')).toContain('a1.png');
+		expect(errorRow()).toBeNull();
+	});
+
+	it('clears a stale load error when a restore revalidation succeeds', async () => {
+		// The initial load failed, leaving the error row up. A restore then fires a
+		// SUCCESSFUL revalidation, which must clear the stale error — otherwise the
+		// restored tiles render UNDER a lingering "Couldn't load" row.
+		props.parentArchived = true;
+		listMock.mockRejectedValueOnce(new Error('offline'));
+		mountStrip('item-a');
+		await settle();
+		expect(errorRow()).not.toBeNull();
+
+		listMock.mockResolvedValueOnce(response([att({ id: 'a1' })]));
+		props.parentArchived = false;
+		flushSync();
+		await settle();
+
+		expect(errorRow()).toBeNull();
+		expect(tiles()).toHaveLength(1);
+	});
+
+	it('defers to a load still in flight instead of superseding it (no strand on failure)', async () => {
+		// A restore that superseded a still-pending mount load would strand the
+		// strip empty with no error/retry if the revalidation then failed (Codex
+		// round 2). The revalidation instead DEFERS: the in-flight load already
+		// returns the current list (archive doesn't delete attachments), so no
+		// second fetch is issued, and that load remains responsible for the outcome.
+		props.parentArchived = true;
+		const pending = deferred<AttachmentListResponse>();
+		listMock.mockReturnValueOnce(pending.promise);
+		mountStrip('item-a');
+		flushSync();
+		expect(listMock).toHaveBeenCalledTimes(1);
+
+		// Restore while the mount load is still in flight: no new fetch.
+		props.parentArchived = false;
+		flushSync();
+		await settle();
+		expect(listMock).toHaveBeenCalledTimes(1);
+
+		// The original load completes and paints; nothing was stranded.
+		pending.resolve(response([att({ id: 'a1' })]));
+		await settle();
+		expect(tiles()).toHaveLength(1);
+		expect(tiles()[0].getAttribute('aria-label')).toContain('a1.png');
+	});
+
+	it('is not suppressed by a lingering stale prior-view load (per-view defer)', async () => {
+		// The defer guard is keyed PER VIEW. The api client has no request abort, so
+		// item A's load lingers in flight after a switch to B; a GLOBAL guard would
+		// let that stale A-load suppress B's genuine restore revalidation, leaving B
+		// stale with nothing to refetch it (Codex round 3).
+		props.parentArchived = true;
+		const aPending = deferred<AttachmentListResponse>(); // A's load never resolves
+		listMock.mockReturnValueOnce(aPending.promise);
+		mountStrip('item-a');
+		flushSync();
+		expect(listMock).toHaveBeenCalledTimes(1);
+
+		// Switch to B (still archived): B's load resolves; A's is still in flight.
+		listMock.mockResolvedValueOnce(response([att({ id: 'b1' })]));
+		props.itemId = 'item-b';
+		flushSync();
+		await settle();
+		expect(listMock).toHaveBeenCalledTimes(2);
+		expect(tiles()).toHaveLength(1);
+
+		// Restore B. B's own load is done; only A's stale load lingers. The restore
+		// revalidation must still run (per-view key), not defer to A's load.
+		listMock.mockResolvedValueOnce(response([att({ id: 'b1' }), att({ id: 'b2' })]));
+		props.parentArchived = false;
+		flushSync();
+		await settle();
+
+		expect(listMock).toHaveBeenCalledTimes(3);
+		const names = tiles().map((el) => el.getAttribute('aria-label') ?? '');
+		expect(names.some((n) => n.includes('b2.png'))).toBe(true);
+	});
+
+	it('recomputes the continuation count from the restore response', async () => {
+		props.parentArchived = true;
+		const rows = Array.from({ length: 50 }, (_, i) => att({ id: `a${i}` }));
+		listMock.mockResolvedValueOnce({ attachments: rows, total: 120, limit: 50, offset: 0 });
+		mountStrip('item-a');
+		await settle();
+		expect(target.querySelector('a.att-more-link')?.textContent?.trim()).toBe('View all (120)');
+
+		// While archived, some were deleted elsewhere: the restore's total is lower.
+		// The continuation must track the fresh response, not stay frozen at 120.
+		listMock.mockResolvedValueOnce({ attachments: rows, total: 80, limit: 50, offset: 0 });
+		props.parentArchived = false;
+		flushSync();
+		await settle();
+
+		expect(target.querySelector('a.att-more-link')?.textContent?.trim()).toBe('View all (80)');
+	});
+
+	it('keeps an open delete confirmation across a restore revalidation', async () => {
+		// The non-retry load path nulls `pendingDelete`; the gentle restore path
+		// must not — the confirmation is anchored to a row that still exists.
+		props.parentArchived = true;
+		props.canDelete = true;
+		listMock.mockResolvedValueOnce(response([att({ id: 'a1' }), att({ id: 'a2' })]));
+		mountStrip('item-a');
+		await settle();
+
+		openConfirm(0); // a1
+		expect(confirmPanel()).not.toBeNull();
+
+		listMock.mockResolvedValueOnce(response([att({ id: 'a1' }), att({ id: 'a2' })]));
+		props.parentArchived = false;
+		flushSync();
+		await settle();
+
+		// Still open, and nothing sent: the restore reload preserved it.
+		expect(confirmPanel()).not.toBeNull();
+		expect(deleteMock).not.toHaveBeenCalled();
+	});
+
+	it('keeps a row excluded while a SECOND delete of the same id is still pending (ref-count)', async () => {
+		// A bare Set marker would let the FIRST delete's settle clear the id while a
+		// SECOND delete of the same id is still outstanding, so a restore refetch
+		// could repaint a row that is still being deleted (Codex round 2). The
+		// in-flight-delete marker is ref-counted.
+		props.parentArchived = true;
+		props.canDelete = true;
+		listMock.mockResolvedValueOnce(response([att({ id: 'a1' }), att({ id: 'a2' })]));
+		mountStrip('item-a');
+		await settle();
+		expect(tiles()).toHaveLength(2);
+
+		// First delete of a1 — deferred, and it will FAIL (so no tombstone latches;
+		// only the in-flight marker stands between a1 and a repaint).
+		let failFirst!: (e: Error) => void;
+		deleteMock.mockReturnValueOnce(new Promise<void>((_, reject) => (failFirst = reject)));
+		openConfirm(0); // a1
+		clickConfirm();
+		expect(tiles()).toHaveLength(1); // a1 optimistically removed
+
+		// a1 reappears while its delete is still in flight (a re-announced upload —
+		// it isn't tombstoned yet, so the row comes back), and the user deletes it
+		// again: a SECOND outstanding delete of the same id.
+		broadcastUpload('item-a', uploaded('a1'));
+		flushSync();
+		const del2 = deferred<void>();
+		deleteMock.mockReturnValueOnce(del2.promise);
+		openConfirm(0); // a1 again (newest-first, it is the first tile)
+		clickConfirm();
+
+		// The FIRST delete now fails and decrements ITS count — but the second is
+		// still pending, so a1 must stay marked in-flight.
+		failFirst(new Error('500'));
+		await settle();
+
+		// Restore: the refetch still lists a1. A bare Set (cleared by delete #1)
+		// would repaint it; the ref-count keeps it excluded because delete #2 is
+		// still outstanding.
+		listMock.mockResolvedValueOnce(response([att({ id: 'a1' }), att({ id: 'a2' })]));
+		props.parentArchived = false;
+		flushSync();
+		await settle();
+
+		const names = tiles().map((el) => el.getAttribute('aria-label') ?? '');
+		expect(names.some((n) => n.includes('a1'))).toBe(false);
+		expect(names.some((n) => n.includes('a2'))).toBe(true);
+
+		// Drain: the second delete now succeeds; the marker fully releases and a1
+		// stays gone (now tombstoned). No leaked marker, no resurrection.
+		del2.resolve();
+		await settle();
+		const final = tiles().map((el) => el.getAttribute('aria-label') ?? '');
+		expect(final.some((n) => n.includes('a1'))).toBe(false);
+		expect(final.some((n) => n.includes('a2'))).toBe(true);
 	});
 });

--- a/web/src/lib/components/items/ItemAttachmentStrip.svelte.test.ts
+++ b/web/src/lib/components/items/ItemAttachmentStrip.svelte.test.ts
@@ -1622,6 +1622,51 @@ describe('ItemAttachmentStrip', () => {
 		expect(listMock).toHaveBeenCalledOnce(); // no refetch
 	});
 
+	it('an upload during an open surface joins the STRIP but NOT the open set (PLAN-2392 3c-iii U4 / TASK-2513)', async () => {
+		// The open-set mutation contract, pinned end-to-end (DR-15 style) rather
+		// than assumed. An upload that lands while the surface is open must NOT
+		// retro-join its set, while the strip's own tile list — which subscribes to
+		// the upload bus — MUST gain the row. What THIS test pins is the NO-LIVE-FOLLOW
+		// half: the plausible wrong design is a host that synced new uploads into the
+		// open request, and the surface leg falsifies exactly that. (The other half of
+		// the snapshot contract — a producer mutating its OWN array/records in place
+		// after emit can't reach the surface — is the deep copy in
+		// notifyAttachmentSurfaceOpen, pinned directly at the module level by
+		// events.test.ts's deep-snapshot test.) The two legs here are independent: a
+		// dead upload bus fails the strip leg while leaving the surface leg green, and
+		// a live-following surface fails the surface leg while leaving the strip leg
+		// green — neither mechanism can mask the other.
+		listMock.mockResolvedValue(response([att({ id: 'img1' }), att({ id: 'img2' })]));
+		mountStrip('item-a');
+		await settle();
+		mountViewerHost();
+
+		// Open the surface on the strip's 2-image set, at image 1 of 2. The counter
+		// reads `position / total`, so its DENOMINATOR is the set size.
+		tiles()[0].click();
+		await settle();
+		expect(document.querySelector('.lightbox-backdrop')).not.toBeNull();
+		expect(document.querySelector('.lightbox-counter')?.textContent).toBe('1 / 2');
+
+		// A THIRD image is uploaded while the surface is open. It is viewer-eligible
+		// (image/png), so a live-following surface would grow the denominator to
+		// "1 / 3" — which is exactly the wrong behavior this asserts against.
+		broadcastUpload('item-a', uploaded('img3'));
+		flushSync();
+
+		// Surface set UNCHANGED: still a 2-member set, still paging the emit-time
+		// snapshot.
+		expect(document.querySelector('.lightbox-counter')?.textContent).toBe('1 / 2');
+		expect(
+			document.querySelector<HTMLImageElement>('.lightbox-image')?.getAttribute('alt')
+		).toBe('img1.png');
+
+		// Strip DID gain the upload — its own tile list follows the bus.
+		const names = tiles().map((el) => el.getAttribute('aria-label') ?? '');
+		expect(names).toHaveLength(3);
+		expect(names.some((n) => n.includes('img3.png'))).toBe(true);
+	});
+
 	it('renders the strip from empty when the first upload lands', async () => {
 		// The strip renders nothing at all when empty, so this covers the
 		// transition from no-element to mounted.

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -5097,6 +5097,7 @@
 				canDelete={mutationsEnabled}
 				itemContent={itemMatchesRef ? item?.content : null}
 				liveContent={liveEditorMarkdown}
+				parentArchived={itemMatchesRef && isArchived}
 			/>
 
 			<!-- The unified attachment surface host is mounted at the TOP LEVEL, not

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -5617,6 +5617,7 @@
 				collectionId={item.collection_id}
 				frozen={false}
 				restoreFrozen={peeking}
+				parentArchived={itemMatchesRef && isArchived}
 				visibleKinds={activeTab === 'versions' ? ['version'] : ['comment', 'activity']}
 			/>
 		</div>

--- a/web/src/lib/components/timeline/ItemTimeline.lifecycle.svelte.test.ts
+++ b/web/src/lib/components/timeline/ItemTimeline.lifecycle.svelte.test.ts
@@ -1,0 +1,620 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { flushSync, mount, unmount, tick } from 'svelte';
+import type { Comment, TimelineEntry, TimelineResponse } from '$lib/types';
+
+/**
+ * Timeline attMeta LIFECYCLE reconciliation (PLAN-2392 3c-iii U1 / TASK-2510).
+ *
+ * The timeline caches HEAD-probe results in `attMeta` and — before this task —
+ * had NO invalidation path: it subscribed to neither the deletion bus nor any
+ * archive/restore signal, so a deleted attachment stayed rendered as a live
+ * `<img>`, an archived parent kept painting a soon-to-be-broken image, and a
+ * restore never escaped a `missing` cached while archived.
+ *
+ * These tests drive the three reconciliation surfaces directly:
+ *  - the deletion bus (REAL, so the announce genuinely fans out to the
+ *    timeline's newly-registered listener — the TASK-2477 lesson),
+ *  - the `parentArchived` PROP edges (false→true archive, true→false restore),
+ *  - and the shared module cache, whose cached-vs-no-store behaviour is the
+ *    whole point of several assertions.
+ *
+ * The metadata module is MOCKED with two distinct fns so a test can prove WHICH
+ * path a probe took: `fetchAttachmentMetadata` is the cache-sharing HEAD and
+ * `revalidateAttachmentMetadata` is the no-store existence probe. Making them
+ * answer differently is what makes "used no-store" / "used cache" falsifiable.
+ *
+ * The markdown pipeline is REAL: a resolved id renders an `<img
+ * data-attachment-id>`, a dropped/absent one renders a `.attachment-missing`
+ * span. That rendered difference is the observable for every attMeta assertion.
+ */
+
+const PNG_A = '11111111-1111-4111-8111-111111111111';
+const PNG_B = '33333333-3333-4333-8333-333333333333';
+
+type Result =
+	| { status: 'ok'; mime: string; size: number }
+	| { status: 'missing' }
+	| { status: 'transient' };
+
+const OK: Result = { status: 'ok', mime: 'image/png', size: 4096 };
+const MISSING: Result = { status: 'missing' };
+
+/**
+ * The cache-sharing HEAD (`fetchAttachmentMetadata`) and the no-store existence
+ * probe (`revalidateAttachmentMetadata`). Separate spies so a test can assert
+ * which one a probe went through, and mock their results independently.
+ */
+const fetchImpl = vi.fn<(ws: string, uuid: string) => Promise<Result>>();
+const revalidateImpl =
+	vi.fn<
+		(ws: string, uuid: string, url: unknown, opts: unknown) => Promise<Result>
+	>();
+const invalidateSpy = vi.fn<(ws: string, uuid: string) => void>();
+
+vi.mock('$lib/components/editor/attachment-metadata', () => ({
+	fetchAttachmentMetadata: (ws: string, uuid: string, _url: unknown) => fetchImpl(ws, uuid),
+	revalidateAttachmentMetadata: (ws: string, uuid: string, url: unknown, opts: unknown) =>
+		revalidateImpl(ws, uuid, url, opts),
+	invalidateAttachmentMetadata: (ws: string, uuid: string) => invalidateSpy(ws, uuid),
+}));
+
+const timelineListMock = vi.fn<(ws: string, slug: string) => Promise<TimelineResponse>>();
+
+vi.mock('$lib/api/client', () => ({
+	api: {
+		timeline: { list: (ws: string, slug: string) => timelineListMock(ws, slug) },
+		comments: {
+			create: vi.fn(),
+			update: vi.fn(),
+			delete: vi.fn(),
+			addReaction: vi.fn(),
+			removeReaction: vi.fn(),
+		},
+	},
+}));
+
+// A controllable SSE seam: capture the timeline's handler so a test can fire a
+// comment event that drives its (debounced) reload — the realistic way the
+// referenced-attachment set churns without a user editing comments by hand.
+const sseBox = vi.hoisted(() => ({ handler: null as null | ((e: { type: string }) => void) }));
+vi.mock('$lib/services/sse.svelte', () => ({
+	sseService: {
+		onItemEvent: (fn: (e: { type: string }) => void) => {
+			sseBox.handler = fn;
+			return () => {
+				if (sseBox.handler === fn) sseBox.handler = null;
+			};
+		},
+	},
+}));
+
+vi.mock('$lib/stores/auth.svelte', () => ({
+	authStore: { userId: 'user-1', user: { id: 'user-1', role: 'member' } },
+}));
+
+vi.mock('$lib/stores/workspace.svelte', () => ({
+	workspaceStore: { canEditItem: () => false },
+}));
+
+// Tiptap in jsdom is not what these tests are about; the composer is inert.
+vi.mock('$lib/components/CommentEditor.svelte', async () => ({
+	default: (await import('./fixtures/InertCommentEditor.svelte')).default,
+}));
+
+// The deletion bus is REAL — the announce must genuinely reach the timeline's
+// registered listener (a spy-only mock would prove nothing about the wiring).
+const { notifyAttachmentDeleted } = await import('$lib/attachments/events');
+const { default: ItemTimeline } = await import('./ItemTimeline.svelte');
+
+function deferred<T>() {
+	let resolve!: (v: T) => void;
+	const promise = new Promise<T>((r) => {
+		resolve = r;
+	});
+	return { promise, resolve };
+}
+
+function comment(body: string, id = 'c1'): Comment {
+	return {
+		id,
+		item_id: 'item-a',
+		workspace_id: 'ws-1',
+		author: 'alice',
+		body,
+		created_by: 'alice',
+		source: 'web',
+		created_at: '2026-01-01T00:00:00Z',
+		updated_at: '2026-01-01T00:00:00Z',
+	};
+}
+
+function entry(c: Comment): TimelineEntry {
+	return {
+		id: `e-${c.id}`,
+		kind: 'comment',
+		created_at: c.created_at,
+		actor: 'alice',
+		source: 'web',
+		comment: c,
+	};
+}
+
+function bodyWith(ids: string[]): string {
+	return ids.map((id, i) => `![image ${i}](pad-attachment:${id})`).join('\n\n');
+}
+
+function respond(ids: string[]): TimelineResponse {
+	return { entries: [entry(comment(bodyWith(ids)))], has_more: false };
+}
+
+let host: HTMLElement;
+let app: Record<string, unknown> | null = null;
+
+const props = $state<{
+	wsSlug: string;
+	username: string;
+	itemSlug: string;
+	currentContent: string;
+	itemId: string;
+	collectionId: string;
+	hostToken: string;
+	parentArchived: boolean;
+}>({
+	wsSlug: 'ws',
+	username: 'alice',
+	itemSlug: 'TASK-1',
+	currentContent: '',
+	itemId: 'item-a',
+	collectionId: 'coll-1',
+	hostToken: 'host-1',
+	parentArchived: false,
+});
+
+function resetProps() {
+	props.wsSlug = 'ws';
+	props.username = 'alice';
+	props.itemSlug = 'TASK-1';
+	props.currentContent = '';
+	props.itemId = 'item-a';
+	props.collectionId = 'coll-1';
+	props.hostToken = 'host-1';
+	props.parentArchived = false;
+}
+
+function render() {
+	app = mount(ItemTimeline, { target: host, props }) as Record<string, unknown>;
+	return app;
+}
+
+/** Several microtask hops: list() → entries → probe → attMeta → re-render. */
+async function settle() {
+	for (let i = 0; i < 10; i++) {
+		await tick();
+		flushSync();
+	}
+}
+
+function imgFor(id: string): HTMLElement | null {
+	return host.querySelector<HTMLElement>(`img[data-attachment-id="${id}"]`);
+}
+
+function missingFor(id: string): HTMLElement | null {
+	return host.querySelector<HTMLElement>(`span.attachment-missing[data-attachment-id="${id}"]`);
+}
+
+beforeEach(() => {
+	host = document.createElement('div');
+	document.body.appendChild(host);
+	resetProps();
+	fetchImpl.mockReset();
+	revalidateImpl.mockReset();
+	invalidateSpy.mockReset();
+	timelineListMock.mockReset();
+	fetchImpl.mockResolvedValue(OK);
+	revalidateImpl.mockResolvedValue(OK);
+	timelineListMock.mockResolvedValue({ entries: [], has_more: false });
+	sseBox.handler = null;
+});
+
+afterEach(() => {
+	if (app) unmount(app);
+	app = null;
+	host.remove();
+});
+
+describe('ItemTimeline — attMeta lifecycle reconciliation (TASK-2510)', () => {
+	it('renders a resolved image, and a missing placeholder when unresolved (observable baseline)', async () => {
+		timelineListMock.mockResolvedValue(respond([PNG_A, PNG_B]));
+		fetchImpl.mockImplementation(async (_ws, uuid) => (uuid === PNG_A ? OK : MISSING));
+		render();
+		await settle();
+
+		// The whole suite reads attMeta state off this render difference; if this
+		// ever stops holding the assertions below are vacuous.
+		expect(imgFor(PNG_A)).not.toBeNull();
+		expect(imgFor(PNG_B)).toBeNull();
+		expect(missingFor(PNG_B)).not.toBeNull();
+	});
+
+	describe('deletion bus', () => {
+		it('drops a rendered attachment when the app-wide bus announces its deletion', async () => {
+			// The bus is real: notifyAttachmentDeleted fans out to the timeline's
+			// registered listener (TASK-2477 — a spy-only mock would never fire it).
+			timelineListMock.mockResolvedValue(respond([PNG_A]));
+			render();
+			await settle();
+			expect(imgFor(PNG_A)).not.toBeNull();
+
+			notifyAttachmentDeleted(PNG_A);
+			await settle();
+
+			// COULD FAIL: without the deletion listener the <img> stays; the drop of
+			// the attMeta entry re-renders the reference through the missing path.
+			expect(imgFor(PNG_A)).toBeNull();
+			expect(missingFor(PNG_A)).not.toBeNull();
+		});
+
+		it('a HEAD that resolves ok AFTER the delete does not repopulate attMeta (tombstone fence)', async () => {
+			// The delete clears the caches, but it does NOT cancel the in-flight HEAD
+			// (the probe writes its result unconditionally otherwise). The tombstone
+			// covers the id even though it was never populated.
+			const d = deferred<Result>();
+			timelineListMock.mockResolvedValue(respond([PNG_A]));
+			fetchImpl.mockReturnValue(d.promise);
+			render();
+			await settle();
+			// The probe MUST have been dispatched — otherwise this test would pass
+			// against a no-op probe effect for the wrong reason (Codex round-1).
+			expect(fetchImpl).toHaveBeenCalledWith('ws', PNG_A);
+			// Not yet resolved → still unresolved.
+			expect(imgFor(PNG_A)).toBeNull();
+
+			notifyAttachmentDeleted(PNG_A);
+			await settle();
+
+			// The delayed HEAD lands ok, post-delete.
+			d.resolve(OK);
+			await settle();
+
+			// COULD FAIL: without the tombstone the delayed ok writes attMeta and the
+			// <img> appears for a row the server no longer has.
+			expect(imgFor(PNG_A)).toBeNull();
+			expect(missingFor(PNG_A)).not.toBeNull();
+		});
+
+		it('deleting A does not fence B’s in-flight probe (tombstone is per-id, not a global epoch)', async () => {
+			// The linchpin distinguishing the per-id tombstone from a blunt epoch: a
+			// single deletion must NOT refuse the OTHER attachments' in-flight writes.
+			// An implementation that bumped a shared epoch on delete would fence B and
+			// pass every other test in this suite — only this one catches it.
+			const dA = deferred<Result>();
+			const dB = deferred<Result>();
+			timelineListMock.mockResolvedValue(respond([PNG_A, PNG_B]));
+			fetchImpl.mockImplementation(async (_ws, uuid) =>
+				uuid === PNG_A ? dA.promise : dB.promise
+			);
+			render();
+			await settle();
+			expect(fetchImpl).toHaveBeenCalledWith('ws', PNG_A);
+			expect(fetchImpl).toHaveBeenCalledWith('ws', PNG_B);
+
+			// Delete A while BOTH probes are still in flight.
+			notifyAttachmentDeleted(PNG_A);
+
+			// B resolves ok AFTER the delete of A.
+			dB.resolve(OK);
+			await settle();
+			// COULD FAIL: a global-epoch delete would fence B here.
+			expect(imgFor(PNG_B)).not.toBeNull();
+
+			// A resolves ok too — but A is tombstoned, so it stays suppressed.
+			dA.resolve(OK);
+			await settle();
+			expect(imgFor(PNG_A)).toBeNull();
+			expect(missingFor(PNG_A)).not.toBeNull();
+		});
+	});
+
+	describe('archive edge (false→true)', () => {
+		it('drops this item’s cached metadata and invalidates the shared cache', async () => {
+			timelineListMock.mockResolvedValue(respond([PNG_A]));
+			fetchImpl.mockResolvedValue(OK);
+			render();
+			await settle();
+			expect(imgFor(PNG_A)).not.toBeNull();
+
+			props.parentArchived = true;
+			await settle();
+
+			// A cached `ok` renders a plain <img> with no error bridge to the missing
+			// presentation — so the archive edge drops the entry (→ missing) and
+			// invalidates the shared cache so a re-render cannot rehydrate a stale ok.
+			expect(imgFor(PNG_A)).toBeNull();
+			expect(missingFor(PNG_A)).not.toBeNull();
+			expect(invalidateSpy).toHaveBeenCalledWith('ws', PNG_A);
+		});
+
+		it('drops a resolved-then-unreferenced id so re-referencing it while archived shows missing, not a broken <img>', async () => {
+			// Codex round-2, symmetric to P2 on the ARCHIVE side: an attachment
+			// resolved `ok`, then unreferenced BEFORE the archive, keeps its cached
+			// `ok` + probe mark. If the archive edge cleaned only the currently-
+			// referenced ids, re-adding it while archived would skip the probe and
+			// replay the stale `ok` as a broken <img>. The whole-tracked-set cleanup
+			// drops it so the re-reference probes no-store → missing.
+			vi.useFakeTimers();
+			try {
+				const fireReload = async (resp: TimelineResponse) => {
+					timelineListMock.mockResolvedValue(resp);
+					sseBox.handler?.({ type: 'comment_updated' });
+					vi.advanceTimersByTime(600);
+					for (let i = 0; i < 12; i++) {
+						await Promise.resolve();
+						flushSync();
+					}
+				};
+				const settleFake = async () => {
+					for (let i = 0; i < 12; i++) {
+						await Promise.resolve();
+						flushSync();
+					}
+				};
+
+				// Live: PNG_A referenced and resolved ok.
+				timelineListMock.mockResolvedValue(respond([PNG_A]));
+				fetchImpl.mockResolvedValue(OK);
+				render();
+				await settleFake();
+				expect(imgFor(PNG_A)).not.toBeNull();
+
+				// Edited to DROP the reference, still live. attMeta[PNG_A]=ok lingers.
+				await fireReload({
+					entries: [entry(comment('no attachments now', 'c1'))],
+					has_more: false,
+				});
+				expect(imgFor(PNG_A)).toBeNull();
+
+				// ARCHIVE. PNG_A is not referenced at this instant, but its cached ok
+				// must be dropped AND its probe mark cleared / cache invalidated so it
+				// can't repaint as a broken image later.
+				invalidateSpy.mockClear();
+				revalidateImpl.mockResolvedValue(MISSING); // archived → 404
+				props.parentArchived = true;
+				await settleFake();
+				// The archive edge reconciled the historical (unreferenced) id, not only
+				// the on-screen ones — proves whole-tracked-set cleanup rather than a
+				// bare wholesale attMeta clear that leaves `probed` set.
+				expect(invalidateSpy).toHaveBeenCalledWith('ws', PNG_A);
+
+				// Re-add PNG_A while archived.
+				await fireReload(respond([PNG_A]));
+
+				// COULD FAIL (pre-fix): the lingering cached ok + probe mark would
+				// render a broken <img>; the whole-set archive cleanup shows missing.
+				expect(imgFor(PNG_A)).toBeNull();
+				expect(missingFor(PNG_A)).not.toBeNull();
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+
+		it('a pre-archive ok that resolves after the edge refuses to write (epoch fence)', async () => {
+			// The in-flight HEAD captured the pre-archive epoch; revalidate invalidates
+			// the cache but can't cancel the promise, so the epoch fence is what stops
+			// a pre-archive ok from repainting after the parent went archived.
+			const d = deferred<Result>();
+			timelineListMock.mockResolvedValue(respond([PNG_A]));
+			fetchImpl.mockReturnValue(d.promise);
+			render();
+			await settle();
+			expect(imgFor(PNG_A)).toBeNull();
+
+			props.parentArchived = true;
+			await settle();
+
+			d.resolve(OK); // lands post-archive
+			await settle();
+
+			// COULD FAIL: without the epoch fence the delayed ok writes attMeta and
+			// paints a broken <img> against the archived parent.
+			expect(imgFor(PNG_A)).toBeNull();
+			expect(missingFor(PNG_A)).not.toBeNull();
+		});
+
+		it('a re-render against the now-archived parent does not rehydrate a stale ok (no-store)', async () => {
+			// archive→remount: the parent is archived, the shared cache would still
+			// answer `ok` (fetch), but a genuine probe must go no-store and see the
+			// 404. Simulated by fetch→ok (stale cache) vs revalidate→missing (server).
+			timelineListMock.mockResolvedValue(respond([PNG_A]));
+			fetchImpl.mockResolvedValue(OK);
+			revalidateImpl.mockResolvedValue(MISSING);
+			render();
+			await settle();
+			expect(imgFor(PNG_A)).not.toBeNull(); // live: cached ok painted it
+
+			props.parentArchived = true;
+			await settle();
+			expect(imgFor(PNG_A)).toBeNull(); // archive edge dropped it
+
+			// Remount the timeline against the archived parent (a card/pane remount).
+			unmount(app!);
+			revalidateImpl.mockClear();
+			fetchImpl.mockClear();
+			app = mount(ItemTimeline, { target: host, props }) as Record<string, unknown>;
+			await settle();
+
+			// COULD FAIL: a cached fetch would rehydrate the stale ok and paint a
+			// broken <img>; the LEVEL no-store probe sees the 404 → missing.
+			expect(imgFor(PNG_A)).toBeNull();
+			expect(missingFor(PNG_A)).not.toBeNull();
+			expect(revalidateImpl).toHaveBeenCalledWith('ws', PNG_A, expect.anything(), {
+				cache: 'no-store',
+			});
+			expect(fetchImpl).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('archived is a LEVEL, not only an edge', () => {
+		it('mounting archived with a stale cached ok presents missing, not a broken <img>', async () => {
+			// No edge fires on a mount that is already archived — the LEVEL rule is
+			// what routes the probe through no-store so the stale cached ok can't
+			// repaint. fetch→ok (stale cache), revalidate→missing (archived 404).
+			props.parentArchived = true;
+			timelineListMock.mockResolvedValue(respond([PNG_A]));
+			fetchImpl.mockResolvedValue(OK);
+			revalidateImpl.mockResolvedValue(MISSING);
+			render();
+			await settle();
+
+			expect(imgFor(PNG_A)).toBeNull();
+			expect(missingFor(PNG_A)).not.toBeNull();
+			expect(revalidateImpl).toHaveBeenCalledWith('ws', PNG_A, expect.anything(), {
+				cache: 'no-store',
+			});
+			// The cached HEAD must never be consulted while archived.
+			expect(fetchImpl).not.toHaveBeenCalled();
+			// ...and NO archive EDGE fired: a mount that is already archived is a
+			// LEVEL, so the edge-only shared-cache invalidation must not run.
+			expect(invalidateSpy).not.toHaveBeenCalled();
+		});
+
+		it('an entry arriving while archived probes no-store', async () => {
+			// The entry arrives via the post-mount async load while parentArchived is
+			// already true — the probe that fires in response must be no-store.
+			props.parentArchived = true;
+			timelineListMock.mockResolvedValue(respond([PNG_A]));
+			fetchImpl.mockResolvedValue(OK);
+			revalidateImpl.mockResolvedValue(MISSING);
+			render();
+			await settle();
+
+			expect(revalidateImpl).toHaveBeenCalledWith('ws', PNG_A, expect.anything(), {
+				cache: 'no-store',
+			});
+			expect(fetchImpl).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('restore edge (true→false)', () => {
+		it('re-probes no-store so a restore escapes a missing cached while archived', async () => {
+			// Mount archived: the row reads missing (server 404s the archived parent),
+			// and that missing is what the shared cache would hold. fetch (cached)
+			// stays missing to model the stale cache; revalidate (no-store) tracks the
+			// live server, which returns ok once restored.
+			props.parentArchived = true;
+			timelineListMock.mockResolvedValue(respond([PNG_A]));
+			fetchImpl.mockResolvedValue(MISSING);
+			revalidateImpl.mockResolvedValueOnce(MISSING); // archived probe
+			revalidateImpl.mockResolvedValue(OK); // restored server
+			render();
+			await settle();
+			expect(imgFor(PNG_A)).toBeNull();
+			expect(missingFor(PNG_A)).not.toBeNull();
+
+			props.parentArchived = false;
+			await settle();
+
+			// COULD FAIL: a restore that re-probed through the cache would keep seeing
+			// the cached missing (fetch→MISSING) and the image would never come back;
+			// the no-store re-probe escapes it.
+			expect(imgFor(PNG_A)).not.toBeNull();
+			expect(fetchImpl).not.toHaveBeenCalled();
+			expect(revalidateImpl).toHaveBeenLastCalledWith('ws', PNG_A, expect.anything(), {
+				cache: 'no-store',
+			});
+		});
+
+		it('a pre-restore missing that resolves after the edge refuses to overwrite the restored ok (epoch fence)', async () => {
+			// A probe dispatched while archived (→ missing) can land AFTER the restore
+			// re-probe already wrote ok. Without the epoch fence its authoritative
+			// missing would clear the now-correct attMeta entry.
+			const archivedProbe = deferred<Result>();
+			props.parentArchived = true;
+			timelineListMock.mockResolvedValue(respond([PNG_A]));
+			fetchImpl.mockResolvedValue(MISSING);
+			revalidateImpl.mockReturnValueOnce(archivedProbe.promise); // archived, deferred
+			revalidateImpl.mockResolvedValue(OK); // restore re-probe, immediate
+			render();
+			await settle();
+			expect(imgFor(PNG_A)).toBeNull();
+
+			props.parentArchived = false;
+			await settle();
+			// The restore re-probe resolved ok first.
+			expect(imgFor(PNG_A)).not.toBeNull();
+
+			// Now the stale archived probe lands missing, post-restore.
+			archivedProbe.resolve(MISSING);
+			await settle();
+
+			// COULD FAIL: without the epoch fence the delayed missing clears attMeta
+			// and the restored image vanishes again.
+			expect(imgFor(PNG_A)).not.toBeNull();
+			expect(missingFor(PNG_A)).toBeNull();
+		});
+
+		it('re-probes an id that went missing while archived, was unreferenced, then re-referenced after restore (P2)', async () => {
+			// Codex round-1 P2: `probed` is cleared on restore only for the WHOLE
+			// unresolved set, not just the currently-referenced ids. Otherwise an id
+			// that probed `missing` while archived, then lost its reference before the
+			// restore, keeps a stale `probed` mark and SKIPS the probe when re-added
+			// afterward — stuck missing forever.
+			vi.useFakeTimers();
+			try {
+				// Reload arrives via the timeline's own (debounced) SSE refresh.
+				const fireReload = async (resp: TimelineResponse) => {
+					timelineListMock.mockResolvedValue(resp);
+					sseBox.handler?.({ type: 'comment_updated' });
+					vi.advanceTimersByTime(600);
+					for (let i = 0; i < 12; i++) {
+						await Promise.resolve();
+						flushSync();
+					}
+				};
+				const settleFake = async () => {
+					for (let i = 0; i < 12; i++) {
+						await Promise.resolve();
+						flushSync();
+					}
+				};
+
+				props.parentArchived = true;
+				timelineListMock.mockResolvedValue(respond([PNG_A]));
+				revalidateImpl.mockResolvedValue(MISSING); // archived → 404
+				render();
+				await settleFake();
+				expect(missingFor(PNG_A)).not.toBeNull();
+
+				// The comment is edited to DROP the PNG_A reference, while still archived.
+				await fireReload({
+					entries: [entry(comment('no attachments now', 'c1'))],
+					has_more: false,
+				});
+				expect(imgFor(PNG_A)).toBeNull();
+				expect(missingFor(PNG_A)).toBeNull(); // not referenced at all
+
+				// RESTORE. PNG_A is not referenced right now — but its probe mark must
+				// still be cleared AND its shared-cache entry invalidated so a later
+				// re-reference re-probes fresh rather than replaying a cached `missing`.
+				invalidateSpy.mockClear();
+				revalidateImpl.mockResolvedValue(OK);
+				fetchImpl.mockResolvedValue(OK);
+				props.parentArchived = false;
+				await settleFake();
+				// The restore reconciled the unreferenced id's cache, not only the
+				// on-screen ones (proves whole-tracked-set invalidation, not just the
+				// stale-mark clear).
+				expect(invalidateSpy).toHaveBeenCalledWith('ws', PNG_A);
+
+				// The comment is edited AGAIN to RE-ADD the PNG_A reference.
+				await fireReload(respond([PNG_A]));
+
+				// COULD FAIL (pre-P2-fix): the stale `probed` mark skips the re-probe and
+				// PNG_A renders missing forever; the broadened restore clearing re-probes
+				// it and the image returns.
+				expect(imgFor(PNG_A)).not.toBeNull();
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+	});
+});

--- a/web/src/lib/components/timeline/ItemTimeline.svelte
+++ b/web/src/lib/components/timeline/ItemTimeline.svelte
@@ -9,12 +9,20 @@
 	import TimelineActivityCard from './TimelineActivityCard.svelte';
 	import TimelineVersionCard from './TimelineVersionCard.svelte';
 	import { attachmentRefsIn } from '$lib/utils/commentAttachments';
-	import { fetchAttachmentMetadata } from '$lib/components/editor/attachment-metadata';
+	import {
+		fetchAttachmentMetadata,
+		revalidateAttachmentMetadata,
+		invalidateAttachmentMetadata
+	} from '$lib/components/editor/attachment-metadata';
 	import { attachmentDownloadUrl, type AttachmentMeta } from '$lib/markdown/attachments';
 	import { canOpenInViewer } from '$lib/attachments/display';
 	import { isEditorOwnedImage } from '$lib/attachments/editorOwnedImage';
 	// One declaration of the surface set's image shape, on the channel (TASK-2431).
-	import { notifyAttachmentSurfaceOpen, type LightboxImage } from '$lib/attachments/events';
+	import {
+		notifyAttachmentSurfaceOpen,
+		registerAttachmentDeletionListener,
+		type LightboxImage
+	} from '$lib/attachments/events';
 	import { viewIdentity, createPaintFence } from '$lib/attachments/viewFence';
 	import CommentEditor from '$lib/components/CommentEditor.svelte';
 
@@ -83,9 +91,25 @@
 		 * callers outside an ItemDetail) disables addressing.
 		 */
 		hostToken?: string;
+		/**
+		 * PLAN-2392 3c-iii U1 (TASK-2510). The archive LEVEL of the item whose
+		 * `ItemDetail` owns this timeline, threaded from `ItemDetail` exactly as the
+		 * attachment surface host takes it (DR-14). Two jobs:
+		 *  - LEVEL: while true, every attachment probe goes through the no-store
+		 *    revalidation primitive, so an archived parent's genuine 404 lands as
+		 *    "missing" and a stale cached `ok` cannot repaint a broken `<img>`.
+		 *  - EDGES: false→true drops this item's cached attachment metadata + probe
+		 *    marks (so a re-render degrades to the missing path, not a broken image)
+		 *    and bumps the lifecycle epoch; true→false re-probes the unresolved set
+		 *    no-store so a restore escapes a `missing` cached while archived.
+		 * Item scoping is inherent to the prop — no SSE filter changes here, which is
+		 * what lets it cover BULK archive/restore (whose `items_bulk_updated` carries
+		 * no item_id). Defaults false → byte-identical for every existing caller.
+		 */
+		parentArchived?: boolean;
 	}
 
-	let { wsSlug, username = '', itemSlug, currentContent, items = [], onRestore, itemId, collectionId, frozen = false, restoreFrozen = false, flushBeforeRestore, visibleKinds, hostToken = '' }: Props = $props();
+	let { wsSlug, username = '', itemSlug, currentContent, items = [], onRestore, itemId, collectionId, frozen = false, restoreFrozen = false, flushBeforeRestore, visibleKinds, hostToken = '', parentArchived = false }: Props = $props();
 
 	// Resolve canEditItem reactively; falls to false if itemId/collectionId
 	// aren't supplied (e.g. an older caller). Folds in the master-freeze gate
@@ -123,36 +147,107 @@
 	// fires one HEAD per attachment without re-triggering on attMeta writes.
 	const probed = new Set<string>();
 
-	function probeAttachment(uuid: string) {
+	// UUIDs whose last probe did NOT yield metadata — a genuine `missing` (404)
+	// or a `transient` failure. Tracked EXPLICITLY because `probed` is
+	// non-reactive and a `missing` writes nothing to `attMeta`, so "clear a Set"
+	// alone would re-probe nothing on restore (PLAN-2392 3c-iii U1). The restore
+	// edge re-probes exactly this set.
+	const unresolved = new Set<string>();
+
+	// Deleted UUIDs — the deletion bus's authoritative, latched fact. A HEAD
+	// that resolves `ok` AFTER the delete must not repopulate `attMeta`, and the
+	// tombstone covers EVERY deleted id, not only ones already cached: a delayed
+	// probe for a not-yet-populated id must refuse to write too. Per-id, NOT the
+	// epoch — a single deletion must not fence the OTHER attachments' in-flight
+	// probes (PLAN-2392 3c-iii U1).
+	const tombstoned = new Set<string>();
+
+	// The per-timeline LIFECYCLE epoch — a plain `let` (non-reactive: read at
+	// probe dispatch, checked before write). Bumped by BOTH archive/restore prop
+	// edges. `revalidateAttachmentMetadata` invalidates the shared cache map but
+	// cannot cancel an already-dispatched promise, so a pre-archive `ok` or a
+	// pre-restore `missing` could otherwise overwrite the post-edge state — the
+	// epoch fence refuses any authoritative result whose dispatch epoch is stale.
+	let lifecycleEpoch = 0;
+
+	// Reactive re-probe trigger. The probe effect tracks this; the restore edge
+	// bumps it so the effect re-runs for exactly the unresolved set (clearing the
+	// non-reactive `probed` Set alone re-probes nothing — the effect tracks only
+	// `entries`).
+	let probeNonce = $state(0);
+
+	// Set true by the restore edge just before it bumps `probeNonce`, consumed
+	// (and reset) by the probe effect's next run: the restore re-probe must be
+	// no-store to ESCAPE a `missing` cached while the parent was archived, even
+	// though `parentArchived` is already false again by then. Plain `let`,
+	// read/written only under `untrack` — never a tracked-scope self-write.
+	let pendingRestoreNoStore = false;
+
+	// The attachment UUIDs referenced by the current comment/reply bodies. One
+	// definition, shared by the probe effect and the archive/restore edges so
+	// each targets exactly this item's attachments.
+	function referencedAttachmentIds(): Set<string> {
+		const ids = new Set<string>();
+		for (const entry of entries) {
+			if (entry.kind !== 'comment' || !entry.comment) continue;
+			for (const id of attachmentRefsIn(entry.comment.body)) ids.add(id);
+			for (const reply of entry.comment.replies ?? []) {
+				for (const id of attachmentRefsIn(reply.body)) ids.add(id);
+			}
+		}
+		return ids;
+	}
+
+	function probeAttachment(uuid: string, noStore: boolean) {
 		if (probed.has(uuid)) return;
 		probed.add(uuid);
-		// Capture the workspace identity before the HEAD probe. `attMeta` is a
-		// workspace-scoped attachment cache; ItemDetail reuses this panel across
-		// a no-{#key} item switch (its wsSlug/itemSlug props just change), so a
-		// probe resolving after a workspace switch must NOT write the old
-		// workspace's attachment metadata into the new item's cache (TASK-2112).
+		// Capture the workspace identity AND the lifecycle epoch before the HEAD.
+		// `attMeta` is a workspace-scoped attachment cache; ItemDetail reuses this
+		// panel across a no-{#key} item switch (its wsSlug/itemSlug props just
+		// change), so a probe resolving after a workspace switch must NOT write the
+		// old workspace's metadata into the new item's cache (TASK-2112). The epoch
+		// is the same discipline for archive/restore (PLAN-2392 3c-iii U1).
 		const reqWs = wsSlug;
-		fetchAttachmentMetadata(wsSlug, uuid, (id, variant) =>
-			attachmentDownloadUrl(wsSlug, id, variant)
-		).then((m) => {
-			// A transient failure (5xx / network) is not evidence about the
-			// row, and the helper deliberately doesn't cache it — so drop the
-			// probed mark too, or this panel could never ask again for the
-			// rest of the mount (PLAN-2392 DR-17). Note what this does and
-			// does not buy: clearing the mark makes the attachment eligible
-			// again on the NEXT run of the probe effect (a new comment, an
-			// edit, a remount), it does not schedule a retry of its own. A
-			// proactive retry belongs with the timeline's deletion
-			// subscription in phase 3c, not here. A `missing` result IS
-			// authoritative: leave the mark set and leave `attMeta` without an
-			// entry, which is what the renderer already degrades to a missing
-			// placeholder on.
+		const reqEpoch = lifecycleEpoch;
+		// LEVEL rule: while the parent is archived (or forced by a restore edge),
+		// bypass the shared module cache with a no-store revalidation so a stale
+		// cached `ok` cannot repaint a broken `<img>` and a genuine 404 lands as
+		// missing honestly. Otherwise the plain, cache-sharing HEAD.
+		const urlFor = (id: string, variant?: 'thumb-sm' | 'thumb-md' | 'original') =>
+			attachmentDownloadUrl(wsSlug, id, variant);
+		const probe = noStore
+			? revalidateAttachmentMetadata(wsSlug, uuid, urlFor, { cache: 'no-store' })
+			: fetchAttachmentMetadata(wsSlug, uuid, urlFor);
+		probe.then((m) => {
+			// A delete (tombstone) or a workspace switch makes this answer
+			// irrelevant — ignore it entirely.
+			if (tombstoned.has(uuid)) return;
+			if (reqWs !== wsSlug) return;
+			// A transient failure (5xx / network) is not evidence about the row,
+			// and the helper deliberately doesn't cache it — so drop the probed
+			// mark, leaving the attachment eligible again on the NEXT run of the
+			// probe effect (a new comment, an edit, a remount, a restore bump). It
+			// does not schedule a retry of its own (PLAN-2392 DR-17).
 			if (m.status === 'transient') {
 				probed.delete(uuid);
+				unresolved.add(uuid);
 				return;
 			}
-			if (m.status !== 'ok') return;
-			if (reqWs !== wsSlug) return;
+			// An authoritative ok/missing that lands AFTER a lifecycle edge must
+			// not overwrite the post-edge state (the epoch fence).
+			if (reqEpoch !== lifecycleEpoch) return;
+			if (m.status !== 'ok') {
+				// `missing` is authoritative: latch it unresolved and clear any
+				// stale entry so the renderer degrades to the missing placeholder.
+				unresolved.add(uuid);
+				if (attMeta.has(uuid)) {
+					const next = new Map(attMeta);
+					next.delete(uuid);
+					attMeta = next;
+				}
+				return;
+			}
+			unresolved.delete(uuid);
 			const next = new Map(attMeta);
 			// filename is left empty — the markdown alt text is the chip/img
 			// label, and renderAttachmentImage only falls back to filename
@@ -162,16 +257,120 @@
 		});
 	}
 
-	// Probe every attachment referenced by a comment or reply as the
-	// timeline loads / changes. Depends only on `entries`.
+	// Probe every attachment referenced by a comment or reply as the timeline
+	// loads / changes. Tracks `entries` (new/edited comments) and `probeNonce`
+	// (the restore re-probe trigger). `parentArchived` is read NON-reactively:
+	// the LEVEL is a dispatch-time decision, and the archive/restore EDGES are
+	// owned by the dedicated edge effect below — reading it reactively here would
+	// re-run (and needlessly re-probe) on every lifecycle flip.
 	$effect(() => {
-		for (const entry of entries) {
-			if (entry.kind !== 'comment' || !entry.comment) continue;
-			for (const id of attachmentRefsIn(entry.comment.body)) probeAttachment(id);
-			for (const reply of entry.comment.replies ?? []) {
-				for (const id of attachmentRefsIn(reply.body)) probeAttachment(id);
+		void probeNonce;
+		const ids = referencedAttachmentIds();
+		untrack(() => {
+			const noStore = parentArchived === true || pendingRestoreNoStore;
+			pendingRestoreNoStore = false;
+			for (const id of ids) probeAttachment(id, noStore);
+		});
+	});
+
+	// External attachment deletion (the app-wide bus, PLAN-2382). Drop the cached
+	// entry AND its probe mark so the comment-HTML renderer re-renders the
+	// reference through the missing path, and TOMBSTONE the id so an in-flight
+	// HEAD that resolves `ok` after the delete can't repopulate it. Self-broadcast
+	// is idempotent (the deleting surface already reconciled).
+	$effect(() => {
+		return registerAttachmentDeletionListener((uuid) => {
+			if (!uuid) return;
+			tombstoned.add(uuid);
+			probed.delete(uuid);
+			unresolved.delete(uuid);
+			if (attMeta.has(uuid)) {
+				const next = new Map(attMeta);
+				next.delete(uuid);
+				attMeta = next;
 			}
-		}
+		});
+	});
+
+	// Archive/restore LIFECYCLE edges (PLAN-2392 3c-iii U1 / DR-14). Threaded as a
+	// PROP from ItemDetail rather than an SSE subscription: the bulk
+	// archive/restore endpoints emit `items_bulk_updated` with NO item_id (routed
+	// only to sync_required), which a timeline-side item_archived/item_restored
+	// filter would miss — but ItemDetail reconciles `deleted_at` through BOTH the
+	// per-item events and the bulk sync path, and passes the settled level down.
+	// Edge-triggered off a LATCHED previous value (plain `let` + untrack — a
+	// $state read+written in one effect aborts its flush, CONVE-1688). Seeded from
+	// the initial prop so a mount on an already-archived item is a LEVEL, not an
+	// edge (the LEVEL rule in the probe effect covers it).
+	let prevArchived = untrack(() => parentArchived === true);
+	$effect(() => {
+		const archived = parentArchived === true;
+		untrack(() => {
+			if (archived === prevArchived) return;
+			prevArchived = archived;
+			lifecycleEpoch += 1;
+			// Every id this timeline holds ANY state for — referenced by the current
+			// comments, cached in `attMeta`, probed, or latched unresolved. BOTH edges
+			// reconcile over this whole set, not just the currently-referenced ids: an
+			// attachment resolved-then-unreferenced (or a probe still in flight) keeps
+			// `attMeta`/`probed` state that a later re-reference would otherwise replay
+			// — a stale `ok` painting a broken `<img>` against an archived parent, or a
+			// stale probe mark skipping the restore re-probe (Codex rounds 1-2, the
+			// symmetric P2). All of `attMeta`/`probed`/`unresolved` describe THIS
+			// timeline instance's own probes (UUIDs are globally unique), so the union
+			// never misattributes an entry to another item. After a no-{#key} workspace
+			// switch the union may still carry a PRIOR workspace's id (attMeta persists
+			// across the switch by design); discarding it from THIS instance's caches is
+			// benign (it re-probes on switch-back), and the shared-cache invalidate below
+			// keys on the CURRENT `wsSlug`, so a foreign id hits a `wsSlug:id` key that
+			// never exists — a no-op that correctly leaves the other workspace's (still
+			// valid) cache entry untouched.
+			const referenced = referencedAttachmentIds();
+			const tracked = new Set<string>(referenced);
+			for (const id of attMeta.keys()) tracked.add(id);
+			for (const id of probed) tracked.add(id);
+			for (const id of unresolved) tracked.add(id);
+			if (archived) {
+				// false→true: a cached `ok` renders a plain `<img>` with no error bridge
+				// to the missing presentation, so ANY tracked entry against the archived
+				// parent would show a BROKEN image on (re-)render. Drop every cached
+				// entry + probe mark and invalidate the shared cache so a re-render /
+				// re-reference goes through the no-store probe → missing path honestly.
+				// Already-painted thumbs keep their decoded bytes until re-render (the
+				// DR-14 posture); no eager re-probe.
+				for (const id of tracked) {
+					probed.delete(id);
+					unresolved.add(id);
+					invalidateAttachmentMetadata(wsSlug, id);
+				}
+				// `tracked` ⊇ every `attMeta` key, so this drops exactly the tracked
+				// cached entries — i.e. all of them.
+				if (attMeta.size) attMeta = new Map();
+			} else {
+				// true→false: re-probe every NOT-yet-resolved tracked id NO-STORE so a
+				// `missing` cached while archived is escaped; leave resolved `ok` entries
+				// alone (they survive archive, and re-probing them would be a redundant
+				// HEAD). Clearing the probe mark + invalidating for a not-currently-
+				// referenced id too is what lets a re-reference AFTER the restore
+				// re-probe instead of skipping on a stale probe mark / stale cached
+				// `missing` (Codex rounds 1-2). The probe effect iterates only
+				// CURRENTLY-referenced ids, so bump the reactive nonce (which forces this
+				// run no-store) when a referenced id needs re-probing; the rest re-probe
+				// when they are next referenced.
+				let bump = false;
+				for (const id of tracked) {
+					if (attMeta.has(id)) continue;
+					probed.delete(id);
+					unresolved.add(id);
+					invalidateAttachmentMetadata(wsSlug, id);
+					if (referenced.has(id)) bump = true;
+				}
+				if (bump) {
+					pendingRestoreNoStore = true;
+					probeNonce += 1;
+				}
+			}
+		});
 	});
 
 	let entryListEl: HTMLElement | undefined = $state();


### PR DESCRIPTION
PLAN-2392 phase 3c-iii: attachment lifecycle completeness. Serial spine from the converged decomposition (12 Codex rounds, final CLEAN) — see the amendment comment on PLAN-2392.

- [x] TASK-2510 — U1: timeline attMeta lifecycle reconciliation
- [x] TASK-2511 — U2: strip content-level restore revalidation
- [x] TASK-2512 — U3: navigation-step revalidation per (openNonce, attachment)
- [x] TASK-2513 — U4: open-set mutation contracts pinned
- [x] TASK-2514 — U5: browser proof

https://claude.ai/code/session_01WFBYxdBuSZs2tjipATxAZu
