### PR TITLE
PLAN-2392 phase 3d: viewer touch gestures + mobile proof

### DIFF
--- a/web/e2e/attachment-viewer-sheet.spec.ts
+++ b/web/e2e/attachment-viewer-sheet.spec.ts
@@ -358,11 +358,11 @@ test.describe('attachment viewer — mobile phone-sheet layout (PLAN-2392 3c-ii 
 		expect(displays.length, 'the toolbar has labelled controls').toBeGreaterThan(0);
 		expect(displays.every((d) => d !== 'none'), 'every toolbar label is revealed on the phone').toBe(true);
 
-		// Native pinch preserved: neither the image NOR the stage restricts
-		// touch-action — both are `auto`, so the browser's own pinch-zoom stays live
-		// (a `none` OR a `pan-x`/`pan-y` would each block pinch before the 3d handler
-		// exists). The stage stays pointer-events:none so the letterbox still reaches
-		// the backdrop.
+		// The viewer OWNS touch now (3d / TASK-2518): the image AND the stage carry
+		// `touch-action: none`, so the browser's native pinch / scroll / double-tap-zoom
+		// don't compete with the pointer-driven pan / pinch / double-tap handlers. The
+		// stage stays pointer-events:none so a LETTERBOX touch still reaches the
+		// backdrop (which keeps touch-action:auto) and taps to close — the letterbox rule.
 		const facts = await page.evaluate((viewerSel) => {
 			const img = document.querySelector(`${viewerSel} .lightbox-image`) as HTMLElement | null;
 			const stage = document.querySelector(`${viewerSel} .lightbox-stage`) as HTMLElement | null;
@@ -372,8 +372,8 @@ test.describe('attachment viewer — mobile phone-sheet layout (PLAN-2392 3c-ii 
 				stagePointerEvents: stage ? getComputedStyle(stage).pointerEvents : null
 			};
 		}, '.attachment-viewer');
-		expect(facts.imgTouchAction, 'the image leaves touch-action auto (native pinch stays)').toBe('auto');
-		expect(facts.stageTouchAction, 'the stage leaves touch-action auto (native pinch stays)').toBe('auto');
+		expect(facts.imgTouchAction, 'the image takes touch-action none (the viewer owns touch)').toBe('none');
+		expect(facts.stageTouchAction, 'the stage takes touch-action none (the viewer owns touch)').toBe('none');
 		expect(facts.stagePointerEvents, 'the stage letterbox stays click-through to the backdrop').toBe('none');
 	});
 

--- a/web/e2e/attachment-viewer-touch.spec.ts
+++ b/web/e2e/attachment-viewer-touch.spec.ts
@@ -1,0 +1,541 @@
+import { test, expect } from './fixtures';
+import type { SuiteFixture } from './fixtures';
+import type { APIRequestContext, Page } from '@playwright/test';
+import { browserLogin, seedDoc } from './lib/collab-helpers';
+import {
+	BIG_PNG,
+	HUGE_PNG,
+	MID_PNG,
+	TILE,
+	VIEWER,
+	VIEWER_IMAGE,
+	VIEWER_STAGE,
+	WIDE_PNG,
+	CdpTouch,
+	imageRect,
+	itemUrl,
+	renderedScale,
+	settleScale,
+	transformOf,
+	uploadAttachment,
+	viewerTapLoad
+} from './lib/attachment-viewer';
+
+/**
+ * TOUCH GESTURES IN A REAL MOBILE BROWSER (PLAN-2392 phase 3d / TASK-2519, the
+ * V3 device proof).
+ *
+ * The unit suite (`Lightbox.svelte.test.ts`) dispatches synthesised
+ * `PointerEvent`s at the gesture state machine, and jsdom has no layout, no
+ * compositor and no genuine two-pointer sequencing. So it proves the arbitration
+ * LOGIC but never that REAL touch — injected through the compositor — reaches
+ * that logic, that two fingers actually pinch a painted bitmap, that the anchor
+ * math holds against live geometry, or that a `touchCancel` tears the gesture
+ * down. Each test here drives Chrome DevTools Protocol touch (see `CdpTouch`) and
+ * is written against "what mutation would this catch that the jsdom-equivalent
+ * survives?" — named per test.
+ *
+ * The `mobile-chromium` project (Pixel 7: `isMobile`, `hasTouch`) is the one
+ * place these run — the viewer only owns touch there, and CDP touch needs a
+ * Chromium session. Every leg skips on desktop.
+ *
+ * WHAT CDP CANNOT EXPRESS (recorded honestly, proven on hardware by the
+ * device-proof checklist DOC, not faked here):
+ *  • The 2→1 survivor-pan CONTINUATION. `degradeToPan` calls
+ *    `setPointerCapture(survivor)`, and CDP's synthetic touch releases the
+ *    survivor's IMPLICIT capture on the next move (a `lostpointercapture` the
+ *    handler reads as a teardown) — so the fresh single-finger pan dies before a
+ *    move lands. A real digitiser keeps the survivor's implicit capture, so the
+ *    pan continues. This leg therefore proves the lift is JUMP-FREE and the pan
+ *    ARMS (`.panning`, scale preserved); the continuation is checklist item 3.
+ *  • Per-pointer `touchCancel` (all-or-nothing in CDP — see `CdpTouch`).
+ */
+
+/** Open the viewer on `buffer` and wait until a bitmap has painted (naturalWidth
+ *  settles), so gestures ARM (`paintedGen === loadToken`) and geometry is stable. */
+async function openTouch(
+	page: Page,
+	fixture: SuiteFixture,
+	request: APIRequestContext,
+	title: string,
+	buffer: Buffer = BIG_PNG,
+	filename = 'touch.png'
+): Promise<void> {
+	await browserLogin(page);
+	const doc = await seedDoc(fixture, request, title);
+	await uploadAttachment(fixture, request, doc.id, filename, 'image/png', buffer);
+	await page.goto(itemUrl(fixture, doc.slug));
+	await expect(page.locator(TILE).first()).toBeVisible();
+	await page.locator(TILE).first().click();
+	await expect(page.locator(VIEWER_IMAGE)).toBeVisible();
+	await expect
+		.poll(() => page.locator(VIEWER_IMAGE).evaluate((el) => (el as HTMLImageElement).naturalWidth))
+		.toBeGreaterThan(0);
+	// Settle the FULL fit geometry before any gesture measures it: not just the
+	// image width but the STAGE box too — on the phone sheet the docked meta /
+	// toolbar resolve async (a late metadata HEAD populates the header, changing the
+	// dock height and so the shortened stage's y/height), which would leave gesture
+	// coordinates and the anchor oracle keyed to a stale rect. Poll every axis of
+	// both boxes to a fixpoint (two equal reads).
+	let prev = { iw: -1, ih: -1, sx: -1, sy: -1, sh: -1 };
+	await expect
+		.poll(async () => {
+			const r = await imageRect(page);
+			const s = await stageBox(page);
+			const cur = { iw: r.width, ih: r.height, sx: s.x, sy: s.y, sh: s.h };
+			const stable =
+				Math.abs(cur.iw - prev.iw) < 0.5 &&
+				Math.abs(cur.ih - prev.ih) < 0.5 &&
+				Math.abs(cur.sx - prev.sx) < 0.5 &&
+				Math.abs(cur.sy - prev.sy) < 0.5 &&
+				Math.abs(cur.sh - prev.sh) < 0.5;
+			prev = cur;
+			return stable;
+		})
+		.toBe(true);
+}
+
+/** The stage box in client coords (the shortened sheet stage on a phone). */
+function stageBox(page: Page): Promise<{ x: number; y: number; w: number; h: number }> {
+	return page.evaluate((sel) => {
+		const s = document.querySelector(sel)!.getBoundingClientRect();
+		return { x: s.x, y: s.y, w: s.width, h: s.height };
+	}, VIEWER_STAGE);
+}
+
+test.describe('attachment viewer — touch gestures (PLAN-2392 3d / TASK-2519)', () => {
+	test.beforeEach(async ({}, testInfo) => {
+		test.skip(
+			testInfo.project.name !== 'mobile-chromium',
+			'touch gestures are Pixel 7 (isMobile/hasTouch) + CDP only'
+		);
+	});
+
+	test('a two-finger spread zooms in and a converge zooms back out', async ({ page, fixture, request }) => {
+		// The bedrock pinch leg: a genuine two-finger spread must RAISE the rendered
+		// scale, and a converge must LOWER it. jsdom has no compositor, so the pinch
+		// distance→scale path has never driven a real painted matrix. Disabling the
+		// pinch handler leaves the scale pinned — this goes red.
+		await openTouch(page, fixture, request, 'Pinch spread/converge');
+		const touch = await CdpTouch.attach(page);
+		const r = await imageRect(page);
+		const cx = r.x + r.width / 2;
+		const cy = r.y + r.height / 2;
+
+		expect(await renderedScale(page), 'opens at fit').toBeCloseTo(1, 1);
+
+		// SPREAD: two fingers straddling the centre move apart in one-frame steps.
+		await touch.down(0, cx - 25, cy);
+		await touch.down(1, cx + 25, cy);
+		for (let i = 1; i <= 5; i++) {
+			await touch.moveAll([
+				{ id: 0, x: cx - 25 - i * 22, y: cy },
+				{ id: 1, x: cx + 25 + i * 22, y: cy }
+			]);
+		}
+		const spread = await settleScale(page);
+		expect(spread, 'a two-finger spread zoomed in').toBeGreaterThan(1.6);
+
+		// CONVERGE: bring them back together — the scale must shrink from the peak.
+		for (let i = 5; i >= 1; i--) {
+			await touch.moveAll([
+				{ id: 0, x: cx - 25 - i * 22, y: cy },
+				{ id: 1, x: cx + 25 + i * 22, y: cy }
+			]);
+		}
+		const converged = await settleScale(page);
+		expect(converged, 'a converge zoomed back out').toBeLessThan(spread - 0.3);
+		await touch.lift(0);
+		await touch.lift(1);
+	});
+
+	test('an off-centre pinch keeps the tracked image point under the moving midpoint (affine anchor oracle)', async ({
+		page,
+		fixture,
+		request
+	}) => {
+		// THE DISCRIMINATING ORACLE (round-2 P2). A pinch composes anchor-zoom around
+		// the previous midpoint PLUS the midpoint translation, so the IMAGE point under
+		// the midpoint stays under it as the midpoint both MOVES and the image SCALES.
+		// We fix a known image-local point (its fraction of the image rect) from the
+		// START midpoint, then drive a simultaneous translate+spread with an OFF-CENTRE
+		// midpoint and assert that same fraction, mapped through the FINAL rect, still
+		// lands under the final midpoint — within a tight px tolerance.
+		//
+		// A zoom-around-CENTRE mutant (anchoring to the stage centre) drifts the
+		// off-centre point away from the moving midpoint; a translation-ONLY mutant
+		// never grows the rect so the fraction can't track a moving midpoint AND the
+		// scale-climb assertion fails. jsdom computes no rect, so this has never run.
+		await openTouch(page, fixture, request, 'Pinch anchor oracle');
+		const touch = await CdpTouch.attach(page);
+		const stage = await stageBox(page);
+		const stageCx = stage.x + stage.w / 2;
+		const stageCy = stage.y + stage.h / 2;
+
+		// Pre-zoom past the vertical-room threshold. On the tall phone-sheet stage the
+		// fitted image fills the WIDTH but is letterboxed in HEIGHT, so vertical pan
+		// room (and thus vertical midpoint tracking) only exists once the scaled image
+		// height exceeds the stage — a few discrete zoom steps clear it, giving BOTH
+		// axes room so the oracle can assert X and Y.
+		for (let i = 0; i < 5; i++) await page.keyboard.press('+');
+		const preScale = await settleScale(page);
+		expect(preScale, 'pre-zoomed so both axes have pan room').toBeGreaterThan(2.3);
+
+		const r0 = await imageRect(page);
+		// An OFF-CENTRE start midpoint, well away from the stage centre (a centre-anchor
+		// mutant must visibly drift the tracked point away from it).
+		const M0 = { x: stageCx - 55, y: stageCy - 50 };
+		const fx = (M0.x - r0.x) / r0.width;
+		const fy = (M0.y - r0.y) / r0.height;
+		expect(Math.hypot(M0.x - stageCx, M0.y - stageCy), 'the midpoint is genuinely off-centre').toBeGreaterThan(60);
+
+		// Fingers straddle M0 diagonally (separation ~72).
+		const A0 = { id: 0, x: M0.x - 30, y: M0.y - 20 };
+		const B0 = { id: 1, x: M0.x + 30, y: M0.y + 20 };
+		await touch.down(A0.id, A0.x, A0.y);
+		await touch.down(B0.id, B0.x, B0.y);
+
+		// Target: midpoint MOVES by (+50, +45) while the separation grows ~72 → ~150
+		// (both a translate AND a spread, simultaneously — the composed invariant).
+		const M1 = { x: M0.x + 50, y: M0.y + 45 };
+		const A1 = { x: M1.x - 60, y: M1.y - 40 };
+		const B1 = { x: M1.x + 60, y: M1.y + 40 };
+		const N = 8;
+		for (let i = 1; i <= N; i++) {
+			const t = i / N;
+			await touch.moveAll([
+				{ id: 0, x: A0.x + (A1.x - A0.x) * t, y: A0.y + (A1.y - A0.y) * t },
+				{ id: 1, x: B0.x + (B1.x - B0.x) * t, y: B0.y + (B1.y - B0.y) * t }
+			]);
+		}
+		const finalScale = await settleScale(page);
+		expect(finalScale, 'the spread climbed the scale (rules out a translation-only mutant)').toBeGreaterThan(preScale + 0.6);
+
+		const r1 = await imageRect(page);
+		const predX = r1.x + fx * r1.width;
+		const predY = r1.y + fy * r1.height;
+		// TOL = 6px: the empirical residual is sub-pixel (~0.2px); 6px stays highly
+		// discriminating (a centre-anchor mutant drifts this point by >100px) while
+		// tolerating discrete-step + integer-touch-coord rounding.
+		const TOL = 6;
+		expect(Math.abs(predX - M1.x), 'the tracked point stays under the midpoint in X').toBeLessThan(TOL);
+		expect(Math.abs(predY - M1.y), 'the tracked point stays under the midpoint in Y').toBeLessThan(TOL);
+		await touch.lift(0);
+		await touch.lift(1);
+	});
+
+	test('a double-tap toggles fit↔actual; a single image tap is inert; a backdrop tap closes', async ({
+		page,
+		fixture,
+		request
+	}) => {
+		// The touch double-tap detector (pointerup-timing, DOUBLE_TAP_MS=300). Two taps
+		// on the image toggle fit↔actual; a lone tap on the image has NO action (it is
+		// only the pending first of a possible pair); a tap on the letterbox backdrop
+		// closes. jsdom can dispatch the pointers but proves none of the hit-testing —
+		// which surface a tap lands on, whether the toggle paints. The control legs
+		// (single-tap inert, backdrop tap closes) are what a jsdom-equivalent survives.
+		await openTouch(page, fixture, request, 'Double-tap toggle');
+		const touch = await CdpTouch.attach(page);
+		const r = await imageRect(page);
+		const cx = r.x + r.width / 2;
+		const cy = r.y + r.height / 2;
+
+		expect(await renderedScale(page), 'opens at fit').toBeCloseTo(1, 1);
+
+		// DOUBLE-TAP → actual (a jump well past fit).
+		await touch.tap(cx, cy);
+		await touch.tap(cx, cy);
+		const actual = await settleScale(page);
+		expect(actual, 'a double-tap jumped to actual size').toBeGreaterThan(1.3);
+
+		// DOUBLE-TAP again → back to fit.
+		await touch.tap(cx, cy);
+		await touch.tap(cx, cy);
+		expect(await settleScale(page), 'a second double-tap toggled back to fit').toBeCloseTo(1, 1);
+
+		// CONTROL: a LONE tap on the image is inert — no toggle, viewer stays open.
+		// Wait out the double-tap window first so it cannot pair with the toggle above.
+		await page.waitForTimeout(400);
+		await touch.tap(cx, cy);
+		expect(await renderedScale(page), 'a single image tap does not zoom').toBeCloseTo(1, 1);
+		await expect(page.locator(VIEWER), 'a single image tap does not close').toHaveCount(1);
+
+		// CONTROL: a tap on the LETTERBOX backdrop (above the fitted image, clear of the
+		// top-left counter) closes — a real touch tap, reaching the backdrop through the
+		// pointer-events:none stage.
+		const stage = await stageBox(page);
+		const img = await imageRect(page);
+		const bandY = (stage.y + img.top) / 2;
+		expect(bandY, 'there is a real letterbox band above the fitted image').toBeLessThan(img.top - 5);
+		await touch.tap(cx, bandY);
+		await expect(page.locator(VIEWER), 'a backdrop touch tap dismisses').toHaveCount(0);
+	});
+
+	test('lifting one finger of a pinch degrades to a pan with no transform jump (2→1)', async ({
+		page,
+		fixture,
+		request
+	}) => {
+		// The 2→1 degrade. Mid-pinch, lifting ONE finger must hand off to a single-
+		// finger pan on the survivor WITHOUT resetting or lurching the transform: the
+		// painted matrix is IDENTICAL across the lift, the scale is preserved (not
+		// snapped to fit), `.pinching` clears and `.panning` engages. A broken degrade
+		// (that clears the gesture, or resets the zoom) fails this.
+		//
+		// The survivor-pan CONTINUATION is NOT asserted here — CDP's synthetic touch
+		// releases the survivor's implicit pointer-capture on the next move, which the
+		// handler reads as a teardown, so the fresh pan dies before a move lands (a real
+		// digitiser keeps the capture). That continuation is device-checklist item 3;
+		// this leg proves everything the emulator CAN: the jump-free hand-off + arming.
+		await openTouch(page, fixture, request, 'Pinch 2 to 1 degrade');
+		const touch = await CdpTouch.attach(page);
+		const r = await imageRect(page);
+		const cx = r.x + r.width / 2;
+		const cy = r.y + r.height / 2;
+
+		await touch.down(0, cx - 25, cy);
+		await touch.down(1, cx + 25, cy);
+		for (let i = 1; i <= 3; i++) {
+			await touch.moveAll([
+				{ id: 0, x: cx - 25 - i * 14, y: cy },
+				{ id: 1, x: cx + 25 + i * 14, y: cy }
+			]);
+		}
+		const pinchScale = await settleScale(page);
+		expect(pinchScale, 'the two-finger pinch zoomed in').toBeGreaterThan(1.5);
+		await expect(page.locator(VIEWER_IMAGE)).toHaveClass(/pinching/);
+		const before = await transformOf(page);
+
+		// Lift finger A. The degrade must be seamless.
+		await touch.lift(0);
+
+		const after = await transformOf(page);
+		expect(after, 'the transform does not jump or reset across the lift').toBe(before);
+		expect(await renderedScale(page), 'the scale is preserved (not reset to fit)').toBeCloseTo(pinchScale, 1);
+		await expect(page.locator(VIEWER_IMAGE), 'the pinch class clears').not.toHaveClass(/pinching/);
+		await expect(page.locator(VIEWER_IMAGE), 'a single-finger pan is armed on the survivor').toHaveClass(/panning/);
+		await touch.lift(1);
+	});
+
+	test('pressing + mid-pinch rebases the baseline so continued spread does not snap back', async ({
+		page,
+		fixture,
+		request
+	}) => {
+		// The pinch's absolute scale is `startScale * curDist/startDist`. An EXTERNAL
+		// zoom mid-pinch (the `+` key) moves `zoom.scale` from outside the pinch, so the
+		// pinch must re-seed its baseline (`rebaseDrag`) or the next spread move snaps
+		// the scale back toward the pre-`+` value, ignoring the keypress. We spread a
+		// little, press `+` (scale jumps), then keep spreading and assert the scale
+		// climbs FURTHER from the post-`+` value — never dropping back below it.
+		await openTouch(page, fixture, request, 'Pinch plus rebase');
+		const touch = await CdpTouch.attach(page);
+		const r = await imageRect(page);
+		const cx = r.x + r.width / 2;
+		const cy = r.y + r.height / 2;
+
+		// Spread to a separation of ~114 (fingers at ±57), scale ~2.3.
+		await touch.down(0, cx - 25, cy);
+		await touch.down(1, cx + 25, cy);
+		for (let i = 1; i <= 2; i++) {
+			await touch.moveAll([
+				{ id: 0, x: cx - 25 - i * 16, y: cy },
+				{ id: 1, x: cx + 25 + i * 16, y: cy }
+			]);
+		}
+		const midPinch = await settleScale(page);
+
+		// External zoom mid-pinch (ZOOM_STEP = 1.25) — the scale jumps ~25%.
+		await page.keyboard.press('+');
+		const afterPlus = await settleScale(page);
+		expect(afterPlus, 'the + key raised the scale mid-pinch').toBeGreaterThan(midPinch + 0.1);
+
+		// THE DISCRIMINATOR (round-2 P2, Codex): a TINY continued spread (±57 → ±60, a
+		// separation barely wider than at the keypress). WITH the rebase, the pinch's
+		// baseline was re-seeded to (afterPlus, currentDist), so this near-zero-delta
+		// move holds the scale AT/ABOVE afterPlus. WITHOUT the rebase, the next move
+		// recomputes `startScale·curDist/startDist` from the ORIGINAL fit baseline —
+		// which SNAPS the scale back toward afterPlus/1.25 (~20% below), discarding the
+		// keypress. A big continued spread would let the stale baseline climb PAST
+		// afterPlus and mask the snap, so the sample must be taken on a tiny delta.
+		await touch.moveAll([
+			{ id: 0, x: cx - 60, y: cy },
+			{ id: 1, x: cx + 60, y: cy }
+		]);
+		const afterTiny = await settleScale(page);
+		expect(afterTiny, 'a tiny continued spread did NOT snap the scale back below the post-+ value').toBeGreaterThan(afterPlus - 0.15);
+
+		// And a larger continued spread climbs FURTHER from the rebased baseline.
+		for (let i = 4; i <= 7; i++) {
+			await touch.moveAll([
+				{ id: 0, x: cx - 25 - i * 18, y: cy },
+				{ id: 1, x: cx + 25 + i * 18, y: cy }
+			]);
+		}
+		const finalScale = await settleScale(page);
+		expect(finalScale, 'continued spread climbed further from the rebased baseline').toBeGreaterThan(afterPlus + 0.3);
+		await touch.lift(0);
+		await touch.lift(1);
+	});
+
+	test('a touchCancel tears the whole gesture down and the next gesture arms fresh (all-cancel)', async ({
+		page,
+		fixture,
+		request
+	}) => {
+		// CDP's `touchCancel` is all-or-nothing — it fires `pointercancel` for every
+		// active pointer at once (the per-pointer degrade stays a unit proof). A cancel
+		// mid-pinch must tear the gesture down cleanly: the transform is LEFT WHERE IT
+		// WAS (cancel does not undo the pan/zoom), `.pinching` clears, the viewer stays
+		// open — and, critically, the NEXT gesture arms from scratch (a stale founder or
+		// latched `pinching` would corrupt or block it). A leaked-state bug survives a
+		// jsdom check that only inspects the cancelled gesture.
+		await openTouch(page, fixture, request, 'Pinch cancel-all');
+		const touch = await CdpTouch.attach(page);
+		const r = await imageRect(page);
+		const cx = r.x + r.width / 2;
+		const cy = r.y + r.height / 2;
+
+		await touch.down(0, cx - 25, cy);
+		await touch.down(1, cx + 25, cy);
+		for (let i = 1; i <= 3; i++) {
+			await touch.moveAll([
+				{ id: 0, x: cx - 25 - i * 16, y: cy },
+				{ id: 1, x: cx + 25 + i * 16, y: cy }
+			]);
+		}
+		const cancelledScale = await settleScale(page);
+		expect(cancelledScale, 'the pinch zoomed in before the cancel').toBeGreaterThan(1.5);
+		const frozen = await transformOf(page);
+
+		await touch.cancelAll();
+
+		expect(await settleScale(page), 'the transform is stable across the cancel (no undo)').toBeCloseTo(cancelledScale, 1);
+		expect(await transformOf(page), 'the painted matrix is left where it was').toBe(frozen);
+		await expect(page.locator(VIEWER_IMAGE), 'the pinch class clears on cancel').not.toHaveClass(/pinching/);
+		await expect(page.locator(VIEWER), 'the viewer stays open').toHaveCount(1);
+
+		// ARMS FRESH: a brand-new pinch after the cancel must zoom again — proving no
+		// stale founder / latched pinch survived the teardown.
+		await touch.down(0, cx - 25, cy);
+		await touch.down(1, cx + 25, cy);
+		for (let i = 1; i <= 4; i++) {
+			await touch.moveAll([
+				{ id: 0, x: cx - 25 - i * 20, y: cy },
+				{ id: 1, x: cx + 25 + i * 20, y: cy }
+			]);
+		}
+		expect(await settleScale(page), 'a fresh pinch after the cancel arms and zooms again').toBeGreaterThan(cancelledScale + 0.3);
+		await touch.lift(0);
+		await touch.lift(1);
+	});
+
+	test('a letterbox touch never arms a pan, and a letterbox tap still closes', async ({ page, fixture, request }) => {
+		// The letterbox rule (V2 round-2 P2). A touch that lands on the STAGE letterbox
+		// — not the painted image — must NOT arm a pan (the stage is pointer-events:none
+		// so the target is the backdrop, and `touchOnImage` gates gesture arming); it
+		// stays a native tap-to-close. We zoom in (real pan room), then drag from the
+		// letterbox band: `.panning` must NEVER flip and the image transform must not
+		// move. Then a clean letterbox tap closes. Only a real hit-test proves this —
+		// jsdom can't tell the letterbox from the image.
+		await openTouch(page, fixture, request, 'Letterbox no-pan', WIDE_PNG, 'wide.png');
+		const touch = await CdpTouch.attach(page);
+		const stage = await stageBox(page);
+		const img = await imageRect(page);
+		const bandY = (stage.y + img.top) / 2; // clear letterbox band above the wide image
+		const cx = stage.x + stage.w / 2;
+		expect(bandY, 'there is a real letterbox band above the wide image').toBeLessThan(img.top - 5);
+
+		// Zoom in so a pan WOULD be visible if the letterbox wrongly armed one.
+		for (let i = 0; i < 3; i++) await page.keyboard.press('+');
+		await settleScale(page);
+		const before = await transformOf(page);
+
+		// A drag STARTING in the letterbox band, past the drag threshold.
+		let sawPanning = false;
+		await touch.down(0, cx, bandY);
+		for (let i = 1; i <= 6; i++) {
+			await touch.move(0, cx + i * 20, bandY);
+			if (await page.locator(VIEWER_IMAGE).evaluate((el) => el.classList.contains('panning'))) sawPanning = true;
+		}
+		await touch.lift(0);
+		expect(sawPanning, 'a letterbox drag never armed a pan').toBe(false);
+		expect(await transformOf(page), 'the image did not move under a letterbox drag').toBe(before);
+		await expect(page.locator(VIEWER), 'the letterbox drag did not close the viewer').toHaveCount(1);
+
+		// A clean letterbox TAP still closes.
+		await touch.tap(cx, bandY);
+		await expect(page.locator(VIEWER), 'a letterbox tap dismisses').toHaveCount(0);
+	});
+
+	test('the backdrop keeps touch-action:auto while the image and stage lock it to none', async ({
+		page,
+		fixture,
+		request
+	}) => {
+		// The touch-ownership split, on computed style. The image and stage take
+		// `touch-action: none` so the viewer's pointer handlers own pan/pinch/double-tap
+		// with no native gesture competing; the BACKDROP keeps `touch-action: auto` so a
+		// letterbox touch still reaches it as a native tap-to-close. The image/stage half
+		// is also asserted by the sheet spec; the backdrop:auto half is this leg's own
+		// (a regression locking the backdrop would silently kill the letterbox tap).
+		await openTouch(page, fixture, request, 'Touch-action split');
+		const facts = await page.evaluate((viewerSel) => {
+			const root = document.querySelector(viewerSel) as HTMLElement | null;
+			const img = document.querySelector(`${viewerSel} .lightbox-image`) as HTMLElement | null;
+			const stage = document.querySelector(`${viewerSel} .lightbox-stage`) as HTMLElement | null;
+			return {
+				backdrop: root ? getComputedStyle(root).touchAction : null,
+				img: img ? getComputedStyle(img).touchAction : null,
+				stage: stage ? getComputedStyle(stage).touchAction : null
+			};
+		}, VIEWER);
+		expect(facts.img, 'the image locks touch-action to none').toBe('none');
+		expect(facts.stage, 'the stage locks touch-action to none').toBe('none');
+		expect(facts.backdrop, 'the backdrop keeps touch-action auto for the native tap-to-close').toBe('auto');
+	});
+
+	test('tap-to-load takes first-tap priority over gesture arming (deferred cell)', async ({
+		page,
+		fixture,
+		request
+	}) => {
+		// DR-5b mobile deferral meets touch (TASK-2460 / TASK-2518). A large image shows
+		// the tap-to-load affordance and fetches NOTHING until tapped. The first touch on
+		// that button must LOAD the original (chrome-excluded, so it never arms a pan /
+		// double-tap) — first-tap priority. A regression that let the gesture machine
+		// swallow the tap would leave the original unfetched. Real touch + a real
+		// network count is the only proof.
+		let originalRequests = 0;
+		await page.route('**/attachments/*', async (route) => {
+			const url = new URL(route.request().url());
+			if (/\/attachments\/[^/?]+$/.test(url.pathname) && !url.searchParams.get('variant')) {
+				if (route.request().method() !== 'GET') return route.continue();
+				originalRequests++;
+				return route.fulfill({ contentType: 'image/png', body: HUGE_PNG });
+			}
+			if (url.searchParams.get('variant') === 'thumb-md')
+				return route.fulfill({ contentType: 'image/png', body: MID_PNG });
+			return route.continue();
+		});
+		await browserLogin(page);
+		const doc = await seedDoc(fixture, request, 'Tap-to-load first-tap');
+		// >8 MP so the mobile classifier defers it (tap affordance, no auto fetch).
+		await uploadAttachment(fixture, request, doc.id, 'deferred.png', 'image/png', HUGE_PNG);
+		await page.goto(itemUrl(fixture, doc.slug));
+		await page.locator(TILE).first().click();
+		await expect(page.locator(VIEWER)).toHaveCount(1);
+		await expect(viewerTapLoad(page)).toBeVisible();
+		expect(originalRequests, 'no original fetched before the tap').toBe(0);
+
+		// A REAL CDP touch tap on the affordance loads the original exactly once.
+		const touch = await CdpTouch.attach(page);
+		const b = (await viewerTapLoad(page).boundingBox())!;
+		await touch.tap(b.x + b.width / 2, b.y + b.height / 2);
+		await expect(page.locator(VIEWER_IMAGE)).toBeVisible();
+		await expect.poll(() => page.locator(VIEWER_IMAGE).evaluate((el) => (el as HTMLImageElement).naturalWidth)).toBeGreaterThan(0);
+		await expect(page.locator(`${VIEWER} .lightbox-error`)).toHaveCount(0);
+		expect(originalRequests, 'the tap issued exactly one original request').toBe(1);
+	});
+});

--- a/web/e2e/lib/attachment-viewer.ts
+++ b/web/e2e/lib/attachment-viewer.ts
@@ -1,4 +1,4 @@
-import { expect, type APIRequestContext, type Page } from '@playwright/test';
+import { expect, type APIRequestContext, type CDPSession, type Page } from '@playwright/test';
 import { crc32, deflateSync } from 'node:zlib';
 import type { SuiteFixture } from '../fixtures';
 
@@ -272,6 +272,116 @@ export function imageRect(page: Page, selector = VIEWER_IMAGE): Promise<DOMRect>
 		const r = el.getBoundingClientRect();
 		return { x: r.x, y: r.y, width: r.width, height: r.height, top: r.top, left: r.left, right: r.right, bottom: r.bottom } as DOMRect;
 	}, selector);
+}
+
+/** The RAW computed `transform` string on the frontmost viewer image — the exact
+ *  `translate(x,y) scale(s)` matrix the browser painted. Two reads being equal is
+ *  the "no jump" oracle (a degrade that reset or lurched changes the string). */
+export function transformOf(page: Page, selector = VIEWER_IMAGE): Promise<string> {
+	return page.evaluate((sel) => {
+		const all = document.querySelectorAll<HTMLElement>(sel);
+		const el = all[all.length - 1];
+		if (!el) throw new Error(`transformOf: no element for ${sel}`);
+		return getComputedStyle(el).transform;
+	}, selector);
+}
+
+/**
+ * The RENDERED scale once the CSS transition has settled (two equal reads). A
+ * pinch drops the transition (`.pinching`), but a discrete zoom / a toggle keeps
+ * the 0.15s ease, so measuring immediately after one samples a mid-animation
+ * matrix. Polls to a fixpoint (lifted from the zoom spec's `settledScale`).
+ */
+export async function settleScale(page: Page): Promise<number> {
+	let last = Number.NaN;
+	await expect
+		.poll(async () => {
+			const s = await renderedScale(page);
+			const stable = Math.abs(s - last) < 1e-3;
+			last = s;
+			return stable;
+		})
+		.toBe(true);
+	return renderedScale(page);
+}
+
+/**
+ * A real MULTI-TOUCH driver over the Chrome DevTools Protocol (PLAN-2392 3d /
+ * TASK-2519). Playwright's `page.touchscreen` is single-`tap` only, so genuine
+ * two-finger pinch / 2→1 degrade / all-cancel gestures — the whole point of the
+ * V3 device proof — need CDP's `Input.dispatchTouchEvent`, which injects real
+ * touch through the compositor into the Lightbox's pointer handlers (as opposed
+ * to synthesising `PointerEvent`s, which the unit suite already does).
+ *
+ * The semantics below are EMPIRICALLY PINNED to this Chromium (observed via
+ * `pointerdown/up/cancel` listeners, not assumed):
+ *
+ *  • `down` / `move` carry the FULL active-point set. Adding a point on a
+ *    `touchStart` promotes it (Chromium diffs the press against the prior frame);
+ *    `moveAll` moves several fingers in ONE frame, the way a real spread does.
+ *  • `lift(id)` sends `touchEnd` carrying the CHANGED (ending) point only —
+ *    Chromium fires `pointerup` for THAT id while the others stay down. VERIFIED
+ *    empirically against this Chromium (a `pointerup#<id>` listener fired for the
+ *    named point, and the 2→1 leg's degrade — which needs a SURVIVING co-founder —
+ *    arms green). Note this is the changed-touches convention, not the "remaining
+ *    active set" the CDP prose implies: an EMPTY `touchPoints` lifts a lone finger
+ *    (all-up), but a multi-touch lift MUST name the ending point, or `touchEnd:[]`
+ *    would release BOTH founders and there would be no survivor to degrade onto.
+ *  • `cancelAll()` is the ONLY cancel CDP exposes: `touchCancel` is
+ *    all-or-nothing and fires `pointercancel` for EVERY active pointer at once.
+ *    There is no per-pointer touchCancel, so the single-named-pointer
+ *    `pointercancel` degrade stays a UNIT-level proof (direct PointerEvent
+ *    dispatch); this class proves only the all-cancel teardown.
+ */
+export class CdpTouch {
+	private pts = new Map<number, { x: number; y: number }>();
+	private constructor(private readonly client: CDPSession) {}
+
+	static async attach(page: Page): Promise<CdpTouch> {
+		return new CdpTouch(await page.context().newCDPSession(page));
+	}
+
+	private frame(): Array<{ id: number; x: number; y: number }> {
+		return [...this.pts.entries()].map(([id, p]) => ({ id, x: p.x, y: p.y }));
+	}
+
+	/** Press a finger down at (x, y); sends `touchStart` with the full active set. */
+	async down(id: number, x: number, y: number): Promise<void> {
+		this.pts.set(id, { x, y });
+		await this.client.send('Input.dispatchTouchEvent', { type: 'touchStart', touchPoints: this.frame() });
+	}
+
+	/** Move one finger; sends `touchMove` with the full active set. */
+	async move(id: number, x: number, y: number): Promise<void> {
+		this.pts.set(id, { x, y });
+		await this.client.send('Input.dispatchTouchEvent', { type: 'touchMove', touchPoints: this.frame() });
+	}
+
+	/** Move several fingers in ONE frame — a genuine two-finger spread/converge. */
+	async moveAll(next: Array<{ id: number; x: number; y: number }>): Promise<void> {
+		for (const p of next) this.pts.set(p.id, { x: p.x, y: p.y });
+		await this.client.send('Input.dispatchTouchEvent', { type: 'touchMove', touchPoints: this.frame() });
+	}
+
+	/** Lift ONE finger (the others stay down): `touchEnd` of the ending point. */
+	async lift(id: number): Promise<void> {
+		const p = this.pts.get(id);
+		if (!p) return;
+		this.pts.delete(id);
+		await this.client.send('Input.dispatchTouchEvent', { type: 'touchEnd', touchPoints: [{ id, x: p.x, y: p.y }] });
+	}
+
+	/** A single-finger tap: down then up at the same point, no move. */
+	async tap(x: number, y: number, id = 0): Promise<void> {
+		await this.down(id, x, y);
+		await this.lift(id);
+	}
+
+	/** Cancel EVERY active pointer at once (CDP `touchCancel` is all-or-nothing). */
+	async cancelAll(): Promise<void> {
+		await this.client.send('Input.dispatchTouchEvent', { type: 'touchCancel', touchPoints: [] });
+		this.pts.clear();
+	}
 }
 
 export function itemUrl(fixture: SuiteFixture, slug: string): string {

--- a/web/src/lib/components/common/Lightbox.svelte
+++ b/web/src/lib/components/common/Lightbox.svelte
@@ -801,6 +801,21 @@
 	// otherwise engage or terminate an in-flight mouse drag (touch stays native
 	// until 3d).
 	let gesturePointerId: number | null = null;
+	// THE POINTER REGISTRY (PLAN-2392 phase 3d / TASK-2517). Every primary pointer
+	// that presses on the backdrop — mouse, pen AND touch — enters here keyed by
+	// `pointerId` with its down position + type; every up / cancel / capture-loss /
+	// teardown removes it. It is the multi-pointer plumbing V2's pinch needs (two
+	// live touch points at once), shipped INERT: V1 reads it for nothing, it only
+	// keeps the active-pointer set honest. The single-pointer drag still keys its
+	// OWNERSHIP off `gesturePointerId` above and its capture off `capturedPointerId`
+	// — the registry is their superset, and in the mouse-only case it holds exactly
+	// that one entry (the "1-entry case" the existing mouse suite pins byte-for-byte).
+	// A plain `let`, NOT `$state`: gesture internals are imperative, read/written
+	// only in pointer handlers + their teardowns, so no CONVE-1688 self-write; and
+	// instance-scoped (like every gesture scalar here) so stacked viewers never
+	// share a registry. V1 stores the DOWN position only — live position tracking is
+	// V2's (pinch) to add on move.
+	let registry = new Map<number, { x: number; y: number; type: string }>();
 	let dragStartClientX = 0;
 	let dragStartClientY = 0;
 	let dragOriginX = 0; // zoom.x at drag baseline
@@ -867,6 +882,7 @@
 	// moves), and — if a real pan was underway — still swallow the click it
 	// produces. The transform is LEFT WHERE IT WAS (the abort does not undo pan).
 	function abortGesture(e: PointerEvent): void {
+		registry.delete(e.pointerId); // reconcile the registry with the gesture teardown
 		const wasDragging = dragging;
 		maybeDrag = false;
 		dragging = false;
@@ -882,6 +898,14 @@
 	// `currentTarget` to hand `abortGesture`), so a stale gesture can neither pan
 	// the reloaded image after an A→unsafe→A flip nor leak into the next press.
 	function cancelGesture(): void {
+		// Registry hygiene runs UNCONDITIONALLY, BEFORE the no-gesture early return
+		// (round-2 P1): the bitmap has vanished, so no pointer can be gesturing over
+		// it. Drain the whole set — the mouse owner (if any) AND any touch pointers,
+		// which arm nothing in V1 but would otherwise leak here if the arm flip beats
+		// their pointerup/cancel, poisoning later pinch detection. Per-instance, so
+		// this never clears another viewer's registry. V2's pinch/tap-timer/baseline
+		// teardown joins this single path.
+		registry.clear();
 		if (!maybeDrag && !dragging) return;
 		const wasDragging = dragging;
 		maybeDrag = false;
@@ -898,9 +922,29 @@
 		if (wasDragging) armSuppressClear();
 	}
 
+	// TEST-ONLY (TASK-2517). The pointer registry is inert plumbing in V1, so a
+	// leak has NO V1-observable consequence — there is no indirect invariant that
+	// would catch it. This accessor lets the jsdom suite assert the drain invariant
+	// directly (registry empties on pointerup AND pointercancel, never leaks). Not
+	// used by production code. Exposed on the mount() result / `bind:this`.
+	export function __registrySize(): number {
+		return registry.size;
+	}
+
 	function onPointerDown(e: PointerEvent) {
 		if (e.button !== 0) return; // primary button only
-		if (e.pointerType === 'touch') return; // touch stays native until 3d
+		// EVERY primary pointer — mouse, pen AND touch — enters the registry FIRST,
+		// before any arm / gate / early-return below. `onPointerUp`/`onPointerCancel`
+		// delete by id before their own guards, so a press that never arms (touch,
+		// chrome, gated, no-bitmap) still drains cleanly (round-2 P1).
+		registry.set(e.pointerId, { x: e.clientX, y: e.clientY, type: e.pointerType });
+		// V1 (TASK-2517): a TOUCH press enters the registry but arms NO drag and takes
+		// NO capture — touch pan is arbitration-unsound under `touch-action: auto` (the
+		// browser can claim the gesture and `pointercancel` mid-stream), so it is V2's.
+		// Taps still work: arming nothing, this press falls through to backdrop
+		// `onclick` (close), the chrome exclusion, or the deferred tap-to-load button —
+		// none of which the registry entry disturbs.
+		if (e.pointerType === 'touch') return;
 		// A second pointer (a pen, say) pressing mid-drag must NOT seize the gesture:
 		// re-arming below would replace `gesturePointerId` and hand the pan to the
 		// interloper. An active drag is owned until its own pointer releases.
@@ -910,6 +954,18 @@
 		// Clear it before any early return below, or a later control / gated press
 		// leaves `maybeDrag` latched and the next move engages a phantom drag from a
 		// dead baseline. (We already returned above if a drag is live.)
+		//
+		// Reconcile the REGISTRY at the SAME point (round-2 P1 leak-freedom): that
+		// stale owner's missed off-root up never ran `registry.delete`, so its entry
+		// would linger. Drop it here — but only when it is a DIFFERENT id than this
+		// press (a same-id re-press, e.g. a mouse, already refreshed its own entry via
+		// the `registry.set` at the top; deleting it would drop the live one). This
+		// mirrors the owner-scalar cleanup: the registry is reconciled at every
+		// DELIVERED interaction (this press, the buttons-released move, cancel, lost),
+		// which is the strongest the event model allows without capture.
+		if (gesturePointerId !== null && gesturePointerId !== e.pointerId) {
+			registry.delete(gesturePointerId);
+		}
 		maybeDrag = false;
 		// A press ON a control (close / nav / the DR-10 retry) is that control's
 		// click, never a pan: arming here would let a drag OFF a button still fire
@@ -996,6 +1052,9 @@
 	}
 
 	function onPointerUp(e: PointerEvent) {
+		registry.delete(e.pointerId); // hygiene FIRST — before the owner guards below,
+		// so a foreign / never-armed pointer (touch, chrome, gated) still drains and
+		// never leaks (round-2 P1).
 		if (!maybeDrag && !dragging) return; // not a gesture we started
 		if (e.pointerId !== gesturePointerId) return; // a foreign pointer can't end ours
 		const el = rootEl;
@@ -1025,12 +1084,18 @@
 	}
 
 	function onPointerCancel(e: PointerEvent) {
+		registry.delete(e.pointerId); // hygiene FIRST — under `touch-action: auto` the
+		// browser claims and `pointercancel`s touches ROUTINELY in the V1 window; a
+		// literal owner-guarded early-return would leak every one of them (round-2 P1).
 		if (!maybeDrag && !dragging) return; // no gesture to cancel
 		if (e.pointerId !== gesturePointerId) return;
 		abortGesture(e);
 	}
 
 	function onLostPointerCapture(e: PointerEvent) {
+		registry.delete(e.pointerId); // reconcile the registry on capture loss too (a
+		// real pointerup already deleted it, so this is a no-op there; it matters for an
+		// OS/browser-stolen capture that arrives with no up).
 		if (!maybeDrag && !dragging) return; // no gesture; ignore a stray capture-loss
 		if (e.pointerId !== gesturePointerId) return;
 		// Capture taken away (OS/browser, or our own release) — the gesture is over.
@@ -1330,6 +1395,13 @@
 		// next wheel/keyboard zoom rebases via `rebaseDrag`. Re-seeding here would be
 		// unobservable — and calling `rebaseDrag` (which reads `zoom`) inside this
 		// `zoom`-writing effect would self-invalidate it (CONVE-1688).
+		//
+		// The POINTER REGISTRY is deliberately NOT reconciled here (TASK-2517): a
+		// shown-image change is nav / a set-shrink, not a pointer up/down, so the
+		// physical pointer set is unchanged — the registry must keep tracking exactly
+		// the pointers still down (clearing one still held would desync it, and its
+		// eventual up would drain nothing). The bitmap-vanish teardown (below) owns
+		// registry hygiene for the arm-flip case, via `cancelGesture`.
 	});
 
 	// (Re)load whenever the SHOWN image changes — nav, a dimension fill, or a set

--- a/web/src/lib/components/common/Lightbox.svelte
+++ b/web/src/lib/components/common/Lightbox.svelte
@@ -864,6 +864,15 @@
 	let pinchStartScale = 1; // zoom.scale at pinch start / re-entry rebase
 	let pinchPrevMidX = 0; // previous midpoint (stage-local px) for the translation term
 	let pinchPrevMidY = 0;
+	// The stage rect ORIGIN the midpoint baseline above was seeded against. The
+	// mobile sheet class flips synchronously with `viewport.isMobile` while the
+	// ResizeObserver re-clamp is async (TASK-2521): an immediate post-flip pinch move
+	// computes its midpoint against the NEW stage rect, but `pinchPrevMid{X,Y}` is
+	// still expressed against the OLD rect — mixing frames jumps the offset. Tracking
+	// the baseline's rect origin lets `onPinchMove` re-seed the baseline (zero delta
+	// that step) the moment the rect shifts, before the async re-clamp catches up.
+	let pinchPrevRectLeft = 0;
+	let pinchPrevRectTop = 0;
 	let pinchBelowMin = false; // true while curDist < PINCH_MIN_DIST (scale HELD)
 	// The pointer id whose capture we RELEASED on a 1→2 promotion — its
 	// `lostpointercapture` is our own surrender, not a browser theft, and must NOT
@@ -911,6 +920,8 @@
 					const rect = stageEl?.getBoundingClientRect();
 					pinchPrevMidX = (a.x + b.x) / 2 - (rect?.left ?? 0);
 					pinchPrevMidY = (a.y + b.y) / 2 - (rect?.top ?? 0);
+					pinchPrevRectLeft = rect?.left ?? 0;
+					pinchPrevRectTop = rect?.top ?? 0;
 					pinchBelowMin = false;
 				}
 			}
@@ -1116,14 +1127,20 @@
 		const el = rootEl;
 		const gatesOpen = !!el && pointerGatesOpen(el);
 		const armable = !chromeExcluded(e) && touchOnImage(e) && gesturesArmable && gatesOpen;
+		const ownerEntry = gesturePointerId !== null ? registry.get(gesturePointerId) : undefined;
 
 		// A live NON-touch (mouse/pen) gesture owns the surface — a touch is
 		// registry-only and must not disturb it (the existing "touch can't move/end a
-		// mouse drag" contract).
+		// mouse drag" contract). Require the owner entry PRESENT (TASK-2521): a stale
+		// owner whose entry was reconciled out has no live point — undefined `.type` is
+		// NOT a non-touch owner, and treating it as one would swallow this press and
+		// strand the stale arm; it falls through to the promotion/first-touch supersede
+		// instead.
 		if (
 			(maybeDrag || dragging) &&
 			gesturePointerId !== null &&
-			registry.get(gesturePointerId)?.type !== 'touch'
+			ownerEntry &&
+			ownerEntry.type !== 'touch'
 		) {
 			disarmDoubleTap();
 			return;
@@ -1133,12 +1150,16 @@
 			disarmDoubleTap();
 			return;
 		}
-		// A second touch over an existing single-touch pan → maybe PROMOTE to pinch.
+		// A second touch over an existing single-touch pan → maybe PROMOTE to pinch. A
+		// live non-touch owner already returned above, so the owner here is a touch owner
+		// (entry present) OR a stale owner whose founder point was reconciled out (entry
+		// absent). Both route through `tryPromoteToPinch`, which seeds the pinch from the
+		// two live points OR — on the missing founder — disarms the stale pan and
+		// supersedes it with THIS touch as a fresh first touch (TASK-2521).
 		if (
 			(maybeDrag || dragging) &&
 			gesturePointerId !== null &&
-			gesturePointerId !== e.pointerId &&
-			registry.get(gesturePointerId)?.type === 'touch'
+			gesturePointerId !== e.pointerId
 		) {
 			if (armable) tryPromoteToPinch(e);
 			else disarmDoubleTap(); // second finger on letterbox/chrome — stays a pan
@@ -1169,7 +1190,31 @@
 		const a = registry.get(ownerId);
 		const b = registry.get(e.pointerId);
 		if (!a || !b) {
+			// FAILED PROMOTION (TASK-2521): the owner's founder point is gone — a stale
+			// owner whose off-root pointerup was missed and whose entry was later
+			// reconciled out, so its pan scalars linger with no live point. The old
+			// `return` left `maybeDrag`/`dragging`/`gesturePointerId` set — a phantom pan
+			// that ate every later gesture. Fully disarm it the way a cancel does (release
+			// the capture, clear the scalars, drop the stale entry, disarm the tap), then
+			// treat THIS touch as a fresh first touch — superseding the stale owner exactly
+			// as the first-touch reconcile does. `cancelGesture` is not used: it clears the
+			// WHOLE registry, dropping this live incoming touch's own entry.
+			if (capturedPointerId !== null) {
+				try {
+					rootEl?.releasePointerCapture(capturedPointerId);
+				} catch {
+					// already released — ignore.
+				}
+				capturedPointerId = null;
+			}
+			maybeDrag = false;
+			dragging = false;
+			swallowLostCapture = null;
+			if (ownerId !== e.pointerId) registry.delete(ownerId);
+			gesturePointerId = null;
 			disarmDoubleTap();
+			armPan(e);
+			armTapCandidate();
 			return;
 		}
 		// Below the pinch threshold the two touches never become a pinch (the second
@@ -1211,6 +1256,8 @@
 		const rt = rect?.top ?? 0;
 		pinchPrevMidX = (a.x + b.x) / 2 - rl;
 		pinchPrevMidY = (a.y + b.y) / 2 - rt;
+		pinchPrevRectLeft = rl;
+		pinchPrevRectTop = rt;
 		pinchBelowMin = false;
 		pinching = true;
 		suppressClick = true; // a pinch is not a tap-to-close
@@ -1240,6 +1287,20 @@
 		const curDist = Math.hypot(b.x - a.x, b.y - a.y);
 		const midX = (a.x + b.x) / 2 - rect.left;
 		const midY = (a.y + b.y) / 2 - rect.top;
+		// FLIP-MID-PINCH rebase (TASK-2521): if the stage rect ORIGIN moved since the
+		// midpoint baseline was seeded — the mobile sheet class flips synchronously with
+		// the breakpoint while the ResizeObserver re-clamp is async — `pinchPrevMid{X,Y}`
+		// is expressed against the OLD rect and the fresh `mid{X,Y}` against the NEW one,
+		// so the translation term below would mix frames and jump. Re-seed the baseline
+		// from the CURRENT live points (zero translation this step; scale, which is
+		// rect-independent, still applies), then tracking resumes next move. Distance /
+		// scale need no rebase — they cancel the rect offset.
+		if (rect.left !== pinchPrevRectLeft || rect.top !== pinchPrevRectTop) {
+			pinchPrevMidX = midX;
+			pinchPrevMidY = midY;
+			pinchPrevRectLeft = rect.left;
+			pinchPrevRectTop = rect.top;
+		}
 		// Scale: ABSOLUTE from the baseline (startScale * curDist/startDist), with the
 		// PINCH_MIN_DIST guard. Below the threshold the ratio update is SKIPPED (scale
 		// HELD; the midpoint translation still applies), preventing a degenerate
@@ -1276,6 +1337,8 @@
 		zoom = clampState({ scale: nextScale, x, y }, g);
 		pinchPrevMidX = midX;
 		pinchPrevMidY = midY;
+		pinchPrevRectLeft = rect.left;
+		pinchPrevRectTop = rect.top;
 	}
 
 	// 2→1 DEGRADE: a founder ended while its co-founder is still down. Continue as a
@@ -1284,6 +1347,18 @@
 	// point (the next move is a pure delta from here).
 	function degradeToPan(survivorId: number): void {
 		const s = registry.get(survivorId);
+		const el = rootEl;
+		// GATE the degrade arm like every START path (TASK-2521): the pinch START (1094 /
+		// 1227 / onPinchMove) all check `pointerGatesOpen`, but the 2→1 degrade armed a
+		// survivor PAN unconditionally — so a native modal or a stacked viewer that
+		// became frontmost mid-pinch left a pan that would resume when that layer closed.
+		// Gates closed (or the survivor is gone) → full clear instead, exactly as
+		// `onPinchMove` aborts. Run BEFORE clearing `pinching` so `cancelGesture` sees the
+		// live pinch and drops the held `suppressClick` (its `wasPinching` arm).
+		if (!s || !el || !pointerGatesOpen(el)) {
+			cancelGesture();
+			return;
+		}
 		pinching = false;
 		pinchA = null;
 		pinchB = null;
@@ -1293,10 +1368,6 @@
 		// `lostpointercapture` would otherwise tear down this fresh pan. It is one-shot
 		// (cleared when swallowed) and reset by `armPan` / `cancelGesture` on the next
 		// gesture, so leaving it set across the degrade is safe.
-		if (!s) {
-			cancelGesture();
-			return;
-		}
 		gesturePointerId = survivorId;
 		maybeDrag = true;
 		dragging = true; // already past threshold — it was a pinch
@@ -1332,6 +1403,16 @@
 	// used by production code. Exposed on the mount() result / `bind:this`.
 	export function __registrySize(): number {
 		return registry.size;
+	}
+	// TEST-ONLY (TASK-2521). Drops the current gesture owner's registry entry WITHOUT
+	// touching its pan scalars — the one state a normal teardown never leaves, because
+	// every up/cancel/lost drains the entry AND clears the scalars in the same handler.
+	// It models a stale owner whose founder point was reconciled out from under a
+	// lingering arm, so the jsdom suite can drive the missing-founder promotion path
+	// (which is V1-unobservable otherwise, like `__registrySize`). Not used by
+	// production code.
+	export function __dropGestureOwnerEntry(): void {
+		if (gesturePointerId !== null) registry.delete(gesturePointerId);
 	}
 
 	function onPointerDown(e: PointerEvent) {

--- a/web/src/lib/components/common/Lightbox.svelte
+++ b/web/src/lib/components/common/Lightbox.svelte
@@ -42,6 +42,7 @@
 	import {
 		reset as resetZoom,
 		clampState,
+		clampScale,
 		clampPan,
 		zoomTo,
 		toggleFitOrActual,
@@ -657,6 +658,30 @@
 		shownRenderer === 'raster-image' && !!img && !!loader.displaySrc && loader.phase !== 'error'
 	);
 
+	// THE PAINT-GENERATION SIGNAL (PLAN-2392 phase 3d / TASK-2518). The generation
+	// (`loader.loadToken`) whose CURRENTLY-MOUNTED <img> element has decoded its own
+	// bitmap. Set in the image's `onload` (below) to the live element's `data-gen`.
+	// A plain arm on `loader.painted` is NOT enough: `retry()` re-mounts the image in
+	// `phase: 'loading'` at a FRESH token WITHOUT resetting `painted`, so the module
+	// flag is stale for the new (blank) element — an upgrade-error → retry leaves
+	// `painted` true while the retried element's pixels are blank. Keying off the
+	// per-element generation makes retry-loading inert (gen !== loadToken) while the
+	// thumb→original UPGRADE stays live (same element, same token, already painted).
+	// `$state` (read by the derived below); written only in an event handler, so no
+	// CONVE-1688 self-write.
+	let paintedGen = $state(-1);
+	// Whether TOUCH gestures (pan / pinch / double-tap) may ARM: a decoded bitmap is
+	// on screen for the CURRENT element (round-1/3/4/6 P2). Stricter than
+	// `bitmapPresent` (which is true mid-load and mid-retry): the painted rule is
+	// PRE-FIRST-PAINT-only, so it stays true across a thumb→original upgrade (element
+	// reused, token unchanged) but false during initial-load and retry-loading (the
+	// re-mounted element has not decoded at the new token yet). Over the error overlay
+	// it is false via `bitmapPresent`'s `phase !== 'error'` leg. Mouse/pen keep the
+	// looser `bitmapPresent` arm (their existing behaviour); only touch tightens here.
+	let gesturesArmable = $derived(
+		bitmapPresent && loader.painted && paintedGen === loader.loadToken
+	);
+
 	// RELEASE THE BYTES AT UNMOUNT (TASK-2476). Disposing the loader clears its
 	// state, but the `<img>` Svelte is about to remove keeps its `src` — and thus a
 	// possibly in-flight native request and its decoded bitmap — alive on the
@@ -823,6 +848,45 @@
 	let lastClientX = 0; // last pointer position seen during the gesture
 	let lastClientY = 0;
 
+	// ── Touch pinch + double-tap (PLAN-2392 phase 3d / TASK-2518) ─────────────
+	//
+	// TWO-FINGER PINCH state, keyed to its two FOUNDING pointers. A third-and-beyond
+	// touch is registry-only (its down/up changes nothing here); only a FOUNDER
+	// ending routes the 2→1 degrade. Plain `lets` (imperative gesture internals,
+	// read/written only in the pointer handlers) except `pinching`, which is `$state`
+	// so the template can drop the transform transition during a pinch (as `.panning`
+	// does for a drag).
+	const PINCH_MIN_DIST = 12; // CSS px; below this the two touches are not a pinch
+	let pinching = $state(false);
+	let pinchA: number | null = null; // first founding pointer id
+	let pinchB: number | null = null; // second founding pointer id
+	let pinchStartDist = 0; // founder separation at pinch start / re-entry rebase
+	let pinchStartScale = 1; // zoom.scale at pinch start / re-entry rebase
+	let pinchPrevMidX = 0; // previous midpoint (stage-local px) for the translation term
+	let pinchPrevMidY = 0;
+	let pinchBelowMin = false; // true while curDist < PINCH_MIN_DIST (scale HELD)
+	// The pointer id whose capture we RELEASED on a 1→2 promotion — its
+	// `lostpointercapture` is our own surrender, not a browser theft, and must NOT
+	// tear down the new pinch. Cleared the instant that event is swallowed.
+	let swallowLostCapture: number | null = null;
+
+	// DOUBLE-TAP detector (touch-only, pointerup-timing). `DOUBLE_TAP_MS` /
+	// `DOUBLE_TAP_SLOP_PX` are named + boundary-tested. `lastTap*` records the FIRST
+	// qualifying tap (image-only); a second within the window+slop toggles fit↔actual
+	// at the tap anchor. The detector DISARMS (clears the pending first tap) on drag
+	// arming, pinch arming, a chrome/letterbox target, or a second pointer joining.
+	const DOUBLE_TAP_MS = 300;
+	const DOUBLE_TAP_SLOP_PX = 24;
+	let tapArmed = false; // the current touch press is still a tap candidate
+	let lastTapTime = -1; // timeStamp of the pending first tap; -1 = none (a real
+	// `timeStamp` can legitimately be 0, so 0 cannot be the sentinel)
+	let lastTapX = 0;
+	let lastTapY = 0;
+	// The last pointer type seen on pointerdown — the compat-dblclick dedup reads it:
+	// a browser may synthesize `dblclick` from a touch double-tap, and our own
+	// detector already handled that gesture, so `onDoubleClick` ignores a touch source.
+	let lastPointerType = '';
+
 	// Re-baseline the gesture to the CURRENT zoom + last pointer position. The drag
 	// computes `origin + total delta`, so anything that moves `zoom.{x,y}` from
 	// OUTSIDE the drag — wheel, `+`/`-`/`0` keys, a resize re-clamp — must rebase,
@@ -831,6 +895,27 @@
 	// between pointerdown and the drag threshold would otherwise leave the engage
 	// baseline stale. A no-op when no gesture is in flight.
 	function rebaseDrag(): void {
+		// A live PINCH re-seeds its OWN baseline to the current zoom + live founder
+		// distance / midpoint (TASK-2518): the same external zooms (keys / wheel / a
+		// resize re-clamp) that desync a pan's origin desync a pinch's absolute
+		// startScale and midpoint too, jumping the next pinch move. Skip while converged
+		// below the min-distance (the scale is intentionally HELD there).
+		if (pinching) {
+			const a = pinchA !== null ? registry.get(pinchA) : undefined;
+			const b = pinchB !== null ? registry.get(pinchB) : undefined;
+			if (a && b) {
+				const d = Math.hypot(b.x - a.x, b.y - a.y);
+				if (d >= PINCH_MIN_DIST) {
+					pinchStartDist = d;
+					pinchStartScale = zoom.scale;
+					const rect = stageEl?.getBoundingClientRect();
+					pinchPrevMidX = (a.x + b.x) / 2 - (rect?.left ?? 0);
+					pinchPrevMidY = (a.y + b.y) / 2 - (rect?.top ?? 0);
+					pinchBelowMin = false;
+				}
+			}
+			return;
+		}
 		if (!maybeDrag && !dragging) return;
 		dragOriginX = zoom.x;
 		dragOriginY = zoom.y;
@@ -887,6 +972,7 @@
 		maybeDrag = false;
 		dragging = false;
 		gesturePointerId = null;
+		disarmDoubleTap(); // an aborted gesture is not a tap
 		releaseCapture(e);
 		if (wasDragging) armSuppressClear();
 	}
@@ -906,11 +992,26 @@
 		// this never clears another viewer's registry. V2's pinch/tap-timer/baseline
 		// teardown joins this single path.
 		registry.clear();
-		if (!maybeDrag && !dragging) return;
+		// Drain the double-tap detector UNCONDITIONALLY too, before the no-gesture early
+		// return: a pending first tap must not survive a bitmap loss / navigation and
+		// pair with a tap on the NEXT image (round-1 P2, follow-up). It is cheap and
+		// idempotent when there is nothing pending.
+		disarmDoubleTap();
+		if (!maybeDrag && !dragging && !pinching) return;
 		const wasDragging = dragging;
+		const wasPinching = pinching;
 		maybeDrag = false;
 		dragging = false;
 		gesturePointerId = null;
+		// V2's pinch / double-tap / promotion state joins this ONE canonical full-clear
+		// (TASK-2518): the reactive bitmap-loss teardown, a nav / image change, and a
+		// cancel of the LAST pointer all reach it. Per-pointer degrade (2→1) is the only
+		// path that does NOT full-clear — it rebases to the survivor instead.
+		pinching = false;
+		pinchA = null;
+		pinchB = null;
+		pinchBelowMin = false;
+		swallowLostCapture = null;
 		if (capturedPointerId !== null) {
 			try {
 				rootEl?.releasePointerCapture(capturedPointerId);
@@ -919,7 +1020,309 @@
 			}
 			capturedPointerId = null;
 		}
-		if (wasDragging) armSuppressClear();
+		// Clear a stuck `suppressClick` for a torn-down PINCH too, not only a drag:
+		// `beginPinch` sets it, but a pinch never sets `dragging`, so `wasDragging`
+		// alone would leave it latched — swallowing the next genuine backdrop tap.
+		if (wasDragging || wasPinching) armSuppressClear();
+	}
+
+	// ── shared gesture predicates (TASK-2518) ────────────────────────────────
+	// The chrome/control exclusion carried by pointerdown AND double-click: a press
+	// on a control is that control's, never a pan / zoom. (Wheel uses a NARROWER
+	// list — toolbar+meta only — so it is not folded in here.)
+	function chromeExcluded(e: PointerEvent | MouseEvent): boolean {
+		return !!(e.target as Element | null)?.closest?.(
+			'.lightbox-close, .lightbox-nav, .lightbox-retry, .lightbox-tap-load, .lightbox-toolbar, .lightbox-meta'
+		);
+	}
+	// Whether a live gesture is a TOUCH one (a pinch, or a single-touch pan) — used by
+	// the reactive teardown to tear a touch gesture down when the paint arm is lost mid
+	// gesture (a same-id reload / nav remounts a blank element while `bitmapPresent`
+	// stays true). A mouse/pen pan tolerates the looser `bitmapPresent` arm, so it is
+	// excluded here.
+	function touchGestureLive(): boolean {
+		if (pinching) return true;
+		if ((maybeDrag || dragging) && gesturePointerId !== null) {
+			return registry.get(gesturePointerId)?.type === 'touch';
+		}
+		return false;
+	}
+	// A TOUCH gesture begins only on a PAINTED-IMAGE hit (round-2 / round-5 P2): the
+	// stage letterbox is `pointer-events: none`, so a letterbox touch lands on the
+	// backdrop (target is the root, not the image) and stays a native tap-to-close —
+	// only a touch whose target is the image itself arms pan / joins a pinch.
+	function touchOnImage(e: PointerEvent): boolean {
+		return (e.target as Element | null)?.closest?.('.lightbox-image') != null;
+	}
+
+	// Arm a single-pointer PAN from `e` — the shared body for the mouse/pen path and
+	// a first touch. Sets the owner + drag baseline; capture waits for the threshold.
+	function armPan(e: PointerEvent): void {
+		maybeDrag = true;
+		dragging = false;
+		gesturePointerId = e.pointerId;
+		suppressClick = false;
+		cancelSuppressClear(); // a fresh gesture — drop any prior pan's pending clear
+		swallowLostCapture = null;
+		// Capture the pan origin from the state at pointer-down, so every move computes
+		// origin + TOTAL delta — never delta-of-delta (the zoom module's "not
+		// associative" note). No `setPointerCapture` yet: capturing here would swallow
+		// dblclick.
+		dragStartClientX = e.clientX;
+		dragStartClientY = e.clientY;
+		lastClientX = e.clientX;
+		lastClientY = e.clientY;
+		dragOriginX = zoom.x;
+		dragOriginY = zoom.y;
+	}
+
+	// ── double-tap detector (touch-only) ──
+	function armTapCandidate(): void {
+		tapArmed = true;
+	}
+	// DISARM: this press is no longer a tap AND any pending first tap is dropped (a
+	// drag, pinch, chrome hit, or second pointer cancels a double-tap in progress).
+	function disarmDoubleTap(): void {
+		tapArmed = false;
+		lastTapTime = -1;
+	}
+	// Evaluate a completed TOUCH tap (a press+up on the image with no drag / pinch).
+	// A second qualifying tap within the window + slop toggles fit↔actual at the tap
+	// anchor; otherwise this tap becomes the pending first one.
+	function evalDoubleTap(e: PointerEvent): void {
+		const el = rootEl;
+		if (!el || !pointerGatesOpen(el) || !gesturesArmable) return;
+		const rect = stageEl?.getBoundingClientRect();
+		const g = readGeometry();
+		if (!rect || !g) return;
+		const t = e.timeStamp;
+		if (
+			lastTapTime >= 0 &&
+			t - lastTapTime <= DOUBLE_TAP_MS &&
+			Math.hypot(e.clientX - lastTapX, e.clientY - lastTapY) <= DOUBLE_TAP_SLOP_PX
+		) {
+			const anchor = { x: e.clientX - rect.left, y: e.clientY - rect.top };
+			zoom = toggleFitOrActual(zoom, anchor, g);
+			lastTapTime = -1; // consumed — the pair is spent, not a founder for a third tap
+		} else {
+			lastTapTime = t;
+			lastTapX = e.clientX;
+			lastTapY = e.clientY;
+		}
+	}
+
+	// ── touch pointerdown: pan arm / pinch promotion / third-and-beyond ──
+	function onTouchDown(e: PointerEvent): void {
+		const el = rootEl;
+		const gatesOpen = !!el && pointerGatesOpen(el);
+		const armable = !chromeExcluded(e) && touchOnImage(e) && gesturesArmable && gatesOpen;
+
+		// A live NON-touch (mouse/pen) gesture owns the surface — a touch is
+		// registry-only and must not disturb it (the existing "touch can't move/end a
+		// mouse drag" contract).
+		if (
+			(maybeDrag || dragging) &&
+			gesturePointerId !== null &&
+			registry.get(gesturePointerId)?.type !== 'touch'
+		) {
+			disarmDoubleTap();
+			return;
+		}
+		// Already a two-founder pinch → third-and-beyond: registry-only, no effect.
+		if (pinching) {
+			disarmDoubleTap();
+			return;
+		}
+		// A second touch over an existing single-touch pan → maybe PROMOTE to pinch.
+		if (
+			(maybeDrag || dragging) &&
+			gesturePointerId !== null &&
+			gesturePointerId !== e.pointerId &&
+			registry.get(gesturePointerId)?.type === 'touch'
+		) {
+			if (armable) tryPromoteToPinch(e);
+			else disarmDoubleTap(); // second finger on letterbox/chrome — stays a pan
+			return;
+		}
+		// First touch.
+		if (!armable) {
+			// Letterbox / chrome / not-yet-painted: arm nothing (the press falls through
+			// to backdrop close, a control, or the tap-to-load button). Not a tap either.
+			disarmDoubleTap();
+			return;
+		}
+		// Supersede a stale armed owner (its off-root up was never delivered) — mirrors
+		// the mouse reconcile.
+		if (gesturePointerId !== null && gesturePointerId !== e.pointerId) {
+			registry.delete(gesturePointerId);
+		}
+		armPan(e);
+		armTapCandidate();
+	}
+
+	// 1→2 PROMOTION: a second image touch joins a single-touch pan. Surrender the
+	// pan's capture (swallowing its own lostpointercapture) and seed the pinch from
+	// BOTH live points — never A's origin, or the pinch would jump.
+	function tryPromoteToPinch(e: PointerEvent): void {
+		const ownerId = gesturePointerId;
+		if (ownerId === null) return;
+		const a = registry.get(ownerId);
+		const b = registry.get(e.pointerId);
+		if (!a || !b) {
+			disarmDoubleTap();
+			return;
+		}
+		// Below the pinch threshold the two touches never become a pinch (the second
+		// stays registry-only; the owner keeps its single-touch pan).
+		if (Math.hypot(b.x - a.x, b.y - a.y) < PINCH_MIN_DIST) {
+			disarmDoubleTap();
+			return;
+		}
+		if (capturedPointerId !== null) {
+			swallowLostCapture = capturedPointerId;
+			try {
+				rootEl?.releasePointerCapture(capturedPointerId);
+			} catch {
+				// already released — ignore.
+			}
+			capturedPointerId = null;
+		}
+		maybeDrag = false;
+		dragging = false;
+		gesturePointerId = null;
+		disarmDoubleTap(); // a second pointer joined
+		beginPinch(ownerId, e.pointerId, a, b);
+	}
+
+	// Seed the pinch baseline from two live points (a promotion, above). Callers
+	// guarantee the separation is >= PINCH_MIN_DIST.
+	function beginPinch(
+		idA: number,
+		idB: number,
+		a: { x: number; y: number },
+		b: { x: number; y: number }
+	): void {
+		pinchA = idA;
+		pinchB = idB;
+		pinchStartDist = Math.hypot(b.x - a.x, b.y - a.y);
+		pinchStartScale = zoom.scale;
+		const rect = stageEl?.getBoundingClientRect();
+		const rl = rect?.left ?? 0;
+		const rt = rect?.top ?? 0;
+		pinchPrevMidX = (a.x + b.x) / 2 - rl;
+		pinchPrevMidY = (a.y + b.y) / 2 - rt;
+		pinchBelowMin = false;
+		pinching = true;
+		suppressClick = true; // a pinch is not a tap-to-close
+		cancelSuppressClear();
+	}
+
+	// A pinch move — one of the two founders moved (its live position is already in
+	// the registry). Compose ONE candidate state at the FINAL scale and clamp ONCE
+	// (round-3 P1): the anchor-zoom offset around the PREVIOUS midpoint PLUS the
+	// midpoint translation, so the image point under the midpoint stays under it.
+	function onPinchMove(e: PointerEvent): void {
+		if (e.pointerId !== pinchA && e.pointerId !== pinchB) return; // extra: registry only
+		const el = rootEl;
+		if (!el || !pointerGatesOpen(el) || !bitmapPresent) {
+			cancelGesture();
+			return;
+		}
+		const a = pinchA !== null ? registry.get(pinchA) : undefined;
+		const b = pinchB !== null ? registry.get(pinchB) : undefined;
+		if (!a || !b) {
+			cancelGesture();
+			return;
+		}
+		const g = readGeometry();
+		const rect = stageEl?.getBoundingClientRect();
+		if (!g || !rect) return;
+		const curDist = Math.hypot(b.x - a.x, b.y - a.y);
+		const midX = (a.x + b.x) / 2 - rect.left;
+		const midY = (a.y + b.y) / 2 - rect.top;
+		// Scale: ABSOLUTE from the baseline (startScale * curDist/startDist), with the
+		// PINCH_MIN_DIST guard. Below the threshold the ratio update is SKIPPED (scale
+		// HELD; the midpoint translation still applies), preventing a degenerate
+		// near-zero distance from jumping the scale. On re-crossing upward, REBASE the
+		// baseline to the current distance + HELD scale so the absolute ratio does not
+		// snap back toward the original.
+		let targetScale = zoom.scale;
+		if (curDist < PINCH_MIN_DIST) {
+			pinchBelowMin = true;
+		} else {
+			if (pinchBelowMin) {
+				pinchStartDist = curDist;
+				pinchStartScale = zoom.scale;
+				pinchBelowMin = false;
+			}
+			targetScale = pinchStartScale * (curDist / pinchStartDist);
+		}
+		// Clamp the SCALE first, then build the offset from the CLAMPED scale (as
+		// `zoomTo` does): `k` must be the ratio actually applied, or spreading further
+		// once max scale is reached would keep translating `x/y` while the visible scale
+		// is pinned — a drift at the ceiling.
+		const nextScale = clampScale(targetScale, g);
+		// Offset: anchor-zoom around the PREVIOUS midpoint (keeping its image point
+		// fixed as we scale) PLUS the midpoint delta (moving that point to the CURRENT
+		// midpoint). `zoom.scale` is >= FIT, never a zero divide. Clamp PAN once at the
+		// new scale — clamping at the OLD scale would zero the translation at fit and
+		// lose midpoint tracking.
+		const centre = stageCenter(g);
+		const ux = pinchPrevMidX - centre.x;
+		const uy = pinchPrevMidY - centre.y;
+		const k = nextScale / zoom.scale;
+		const x = ux - k * (ux - zoom.x) + (midX - pinchPrevMidX);
+		const y = uy - k * (uy - zoom.y) + (midY - pinchPrevMidY);
+		zoom = clampState({ scale: nextScale, x, y }, g);
+		pinchPrevMidX = midX;
+		pinchPrevMidY = midY;
+	}
+
+	// 2→1 DEGRADE: a founder ended while its co-founder is still down. Continue as a
+	// single-touch pan rebased to the SURVIVOR's current position — no offset jump,
+	// because the drag origin is the CURRENT zoom and the baseline the survivor's live
+	// point (the next move is a pure delta from here).
+	function degradeToPan(survivorId: number): void {
+		const s = registry.get(survivorId);
+		pinching = false;
+		pinchA = null;
+		pinchB = null;
+		pinchBelowMin = false;
+		// Do NOT clear `swallowLostCapture` here: the promotion's deliberate release may
+		// still be in flight, and if that founder is now the SURVIVOR its delayed
+		// `lostpointercapture` would otherwise tear down this fresh pan. It is one-shot
+		// (cleared when swallowed) and reset by `armPan` / `cancelGesture` on the next
+		// gesture, so leaving it set across the degrade is safe.
+		if (!s) {
+			cancelGesture();
+			return;
+		}
+		gesturePointerId = survivorId;
+		maybeDrag = true;
+		dragging = true; // already past threshold — it was a pinch
+		suppressClick = true;
+		cancelSuppressClear();
+		dragStartClientX = s.x;
+		dragStartClientY = s.y;
+		lastClientX = s.x;
+		lastClientY = s.y;
+		dragOriginX = zoom.x;
+		dragOriginY = zoom.y;
+		try {
+			rootEl?.setPointerCapture(survivorId);
+			capturedPointerId = survivorId;
+		} catch {
+			capturedPointerId = null; // capture unsupported/failed — pan still works
+		}
+	}
+
+	// A founder's up/cancel during a pinch: degrade to the surviving FOUNDER if it is
+	// still down (extras never route this), else full-clear. The ending pointer was
+	// already removed from the registry by the caller.
+	function endPinchPointer(e: PointerEvent): void {
+		const other = e.pointerId === pinchA ? pinchB : pinchA;
+		if (other !== null && registry.has(other)) degradeToPan(other);
+		else cancelGesture();
 	}
 
 	// TEST-ONLY (TASK-2517). The pointer registry is inert plumbing in V1, so a
@@ -938,13 +1341,25 @@
 		// delete by id before their own guards, so a press that never arms (touch,
 		// chrome, gated, no-bitmap) still drains cleanly (round-2 P1).
 		registry.set(e.pointerId, { x: e.clientX, y: e.clientY, type: e.pointerType });
-		// V1 (TASK-2517): a TOUCH press enters the registry but arms NO drag and takes
-		// NO capture — touch pan is arbitration-unsound under `touch-action: auto` (the
-		// browser can claim the gesture and `pointercancel` mid-stream), so it is V2's.
-		// Taps still work: arming nothing, this press falls through to backdrop
-		// `onclick` (close), the chrome exclusion, or the deferred tap-to-load button —
-		// none of which the registry entry disturbs.
-		if (e.pointerType === 'touch') return;
+		lastPointerType = e.pointerType;
+		// TOUCH now has a full gesture surface (TASK-2518): pan on the painted image,
+		// two-finger pinch, and double-tap — all routed through `onTouchDown`, which
+		// arms only on painted-image hits (a letterbox touch stays a native tap-to-close)
+		// and owns the pinch promotion / third-and-beyond policy. The mouse/pen path
+		// below is UNCHANGED.
+		if (e.pointerType === 'touch') {
+			onTouchDown(e);
+			return;
+		}
+		// A live TOUCH gesture (a pinch, or an armed / engaged single-touch pan) OWNS the
+		// surface — a mouse/pen press is registry-only and must not seize it (the mirror
+		// of `onTouchDown`'s non-touch-owner guard, and stronger than the `dragging`-only
+		// guard below, which would miss an armed-but-not-yet-dragging touch or a pinch).
+		if (touchGestureLive()) return;
+		// A mouse/pen press ends any pending touch double-tap (TASK-2518): the user
+		// switched input device, so a touch tap before it must not pair with one after
+		// across the interleaving click.
+		disarmDoubleTap();
 		// A second pointer (a pen, say) pressing mid-drag must NOT seize the gesture:
 		// re-arming below would replace `gesturePointerId` and hand the pan to the
 		// interloper. An active drag is owned until its own pointer releases.
@@ -973,7 +1388,7 @@
 		// (the house pattern in ItemGraph excludes its interactive overlays the same
 		// way). Retry sits over the (broken) stage in the error state, so it needs
 		// the same exclusion as the always-present chrome.
-		if ((e.target as Element | null)?.closest?.('.lightbox-close, .lightbox-nav, .lightbox-retry, .lightbox-tap-load, .lightbox-toolbar, .lightbox-meta')) return;
+		if (chromeExcluded(e)) return;
 		// No decoded bitmap to pan (the mobile `deferred` placeholder shows no
 		// `<img>`) — do NOT arm a drag, so the gesture stays fully inert instead of
 		// capturing the pointer and latching `dragging` for a pan that can never
@@ -981,24 +1396,23 @@
 		if (!bitmapPresent) return;
 		const el = rootEl;
 		if (!el || !pointerGatesOpen(el)) return; // START gate
-		maybeDrag = true;
-		dragging = false;
-		gesturePointerId = e.pointerId;
-		suppressClick = false;
-		cancelSuppressClear(); // a fresh gesture — drop any prior pan's pending clear
-		dragStartClientX = e.clientX;
-		dragStartClientY = e.clientY;
-		lastClientX = e.clientX;
-		lastClientY = e.clientY;
-		// Capture the pan origin from the state at pointer-down, so every move
-		// computes origin + TOTAL delta — never delta-of-delta, which the zoom
-		// module warns loses the slack at a bound (its "gesture is not associative"
-		// note). No `setPointerCapture` yet: capturing here would swallow dblclick.
-		dragOriginX = zoom.x;
-		dragOriginY = zoom.y;
+		armPan(e);
 	}
 
 	function onPointerMove(e: PointerEvent) {
+		// Keep the live registry position current for ANY tracked pointer — pinch reads
+		// both founders' live positions from here, and a 2→1 degrade rebases to the
+		// survivor's registry position (TASK-2518).
+		const entry = registry.get(e.pointerId);
+		if (entry) {
+			entry.x = e.clientX;
+			entry.y = e.clientY;
+		}
+		// A live pinch: a founder move recomputes; an extra touch is registry-only.
+		if (pinching) {
+			onPinchMove(e);
+			return;
+		}
 		if (!maybeDrag) return;
 		if (e.pointerId !== gesturePointerId) return; // only the owning pointer drives
 		const el = rootEl;
@@ -1036,6 +1450,7 @@
 			// can't fire mid-pan and unsuppress us.
 			suppressClick = true;
 			cancelSuppressClear();
+			disarmDoubleTap(); // a drag is not a tap — cancel any pending double-tap
 			capturedPointerId = e.pointerId;
 			try {
 				(e.currentTarget as Element).setPointerCapture(e.pointerId);
@@ -1055,6 +1470,12 @@
 		registry.delete(e.pointerId); // hygiene FIRST — before the owner guards below,
 		// so a foreign / never-armed pointer (touch, chrome, gated) still drains and
 		// never leaks (round-2 P1).
+		// A founder lifting during a pinch DEGRADES to the survivor (2→1); an extra
+		// touch's up is registry-only (already drained above). Not a tap, either.
+		if (pinching) {
+			if (e.pointerId === pinchA || e.pointerId === pinchB) endPinchPointer(e);
+			return;
+		}
 		if (!maybeDrag && !dragging) return; // not a gesture we started
 		if (e.pointerId !== gesturePointerId) return; // a foreign pointer can't end ours
 		const el = rootEl;
@@ -1072,6 +1493,7 @@
 			abortGesture(e);
 			return;
 		}
+		const wasTap = !dragging && e.pointerType === 'touch' && tapArmed;
 		maybeDrag = false;
 		gesturePointerId = null;
 		if (dragging) {
@@ -1080,22 +1502,47 @@
 			// Keep the click this pan produces swallowed, then clear on the next tick
 			// so a later genuine click is unaffected.
 			armSuppressClear();
+		} else if (wasTap) {
+			// A touch TAP on the image (armed a pan, never dragged) — the double-tap
+			// detector. A single tap on the image has no action, so this introduces no
+			// close-delay; a second qualifying tap toggles fit↔actual (TASK-2518).
+			evalDoubleTap(e);
 		}
+		tapArmed = false;
 	}
 
 	function onPointerCancel(e: PointerEvent) {
-		registry.delete(e.pointerId); // hygiene FIRST — under `touch-action: auto` the
-		// browser claims and `pointercancel`s touches ROUTINELY in the V1 window; a
-		// literal owner-guarded early-return would leak every one of them (round-2 P1).
-		if (!maybeDrag && !dragging) return; // no gesture to cancel
+		registry.delete(e.pointerId); // hygiene FIRST — the browser claims and
+		// `pointercancel`s touches ROUTINELY; a literal owner-guarded early-return would
+		// leak every one of them (round-2 P1).
+		// PER-POINTER routing (round-3 P1): a founder cancel with a surviving co-founder
+		// is the 2→1 DEGRADE; an extra touch's cancel is registry-only.
+		if (pinching) {
+			if (e.pointerId === pinchA || e.pointerId === pinchB) endPinchPointer(e);
+			return;
+		}
+		if (!maybeDrag && !dragging) {
+			tapArmed = false; // a lone touch tap canceled — drop the candidate
+			return;
+		}
 		if (e.pointerId !== gesturePointerId) return;
 		abortGesture(e);
 	}
 
 	function onLostPointerCapture(e: PointerEvent) {
+		// A 1→2 promotion RELEASED the pan owner's capture deliberately — swallow that
+		// self-surrender so it does not tear down the new pinch, and KEEP the founder in
+		// the registry (deleting it would break the pinch, which reads its live position).
+		if (swallowLostCapture !== null && e.pointerId === swallowLostCapture) {
+			swallowLostCapture = null;
+			return;
+		}
 		registry.delete(e.pointerId); // reconcile the registry on capture loss too (a
 		// real pointerup already deleted it, so this is a no-op there; it matters for an
 		// OS/browser-stolen capture that arrives with no up).
+		// Pinch founders are not captured, so a capture-loss during a pinch is nothing to
+		// us (the only capture in flight was the just-swallowed promotion release).
+		if (pinching) return;
 		if (!maybeDrag && !dragging) return; // no gesture; ignore a stray capture-loss
 		if (e.pointerId !== gesturePointerId) return;
 		// Capture taken away (OS/browser, or our own release) — the gesture is over.
@@ -1118,10 +1565,15 @@
 		// gesture is either a drag or a double-click, never both. Same swallow the
 		// backdrop click consults.
 		if (suppressClick) return;
+		// COMPAT-DBLCLICK DEDUP (TASK-2518): a browser may synthesize `dblclick` from a
+		// touch double-tap, which our own pointerup-timing detector already handled — so
+		// a touch-sourced dblclick would toggle a SECOND time. Ignore it; only a genuine
+		// mouse/pen double-click reaches the toggle here.
+		if (lastPointerType === 'touch') return;
 		// A double-click ON a control (close / nav / retry) is that control's, not a
 		// zoom toggle — without this, double-clicking Next navigates twice AND
 		// toggles, or a double-click on Retry toggles zoom on the broken stage.
-		if ((e.target as Element | null)?.closest?.('.lightbox-close, .lightbox-nav, .lightbox-retry, .lightbox-tap-load, .lightbox-toolbar, .lightbox-meta')) return;
+		if (chromeExcluded(e)) return;
 		// Inert with no decoded bitmap (deferred placeholder / error UI) — the same
 		// guard the keys and wheel use (TASK-2461).
 		if (!bitmapPresent) return;
@@ -1389,6 +1841,10 @@
 		// image. Both are `$state` this effect never reads, so no self-invalidation.
 		toolbarBusy = false;
 		toolbarError = null;
+		// Drop any pending FIRST double-tap too (TASK-2518): the shown image changed, so
+		// a tap on the PREVIOUS image must not pair with one on this new image into a
+		// spurious toggle. A plain-let write, so no self-invalidation.
+		disarmDoubleTap();
 		// A drag live ACROSS the image change (arrow-nav mid-drag) is left with a
 		// stale baseline, and deliberately so: `resetZoom` is fit, where `clampPan`
 		// pins the pan to 0 for ANY baseline, so the next move can't jump; and the
@@ -1439,15 +1895,26 @@
 	// Drop the load on unmount (close) — one teardown, no dependencies.
 	$effect(() => () => loader.dispose());
 
-	// Reactively abort a live gesture the instant the bitmap goes away (TASK-2476).
-	// The pointer handlers catch a flip that arrives WITH an event (move / up), but
-	// the arm can flip to fallback from a PROP change while the pointer is held
-	// still — no event to carry the abort. Reads `bitmapPresent` (tracked) and
-	// tears the gesture down in `untrack` (it writes `dragging` etc., never read
-	// here), so it cannot self-invalidate (CONVE-1688).
+	// Reactively abort a live gesture the instant the bitmap goes away (TASK-2476), or
+	// the instant a TOUCH gesture's paint arm is lost (TASK-2518). The pointer handlers
+	// catch a flip that arrives WITH an event (move / up), but the arm can flip from a
+	// PROP change while the pointer is held still — no event to carry the abort. Two
+	// triggers: `!bitmapPresent` tears down ANY gesture (mouse included), and — when the
+	// bitmap is still present but `gesturesArmable` is false (a same-id reload / nav
+	// remounted a blank element mid-gesture) — a live TOUCH gesture too, since touch
+	// requires the painted element while a mouse pan tolerates the looser arm. Reads
+	// `bitmapPresent` + `gesturesArmable` (tracked) and tears down in `untrack` (it
+	// writes `dragging` etc., never read here), so it cannot self-invalidate (CONVE-1688).
 	$effect(() => {
-		if (bitmapPresent) return;
-		untrack(() => cancelGesture());
+		if (bitmapPresent && gesturesArmable) return;
+		untrack(() => {
+			if (!bitmapPresent || touchGestureLive()) cancelGesture();
+			// The paint arm is lost with no live gesture to tear down (e.g. a SAME-ID
+			// reload — dimension fill — which keeps `bitmapPresent` true so cancelGesture
+			// does not run): drop any pending FIRST tap, so a tap before the reload cannot
+			// pair with one after the element repaints into a spurious toggle (TASK-2518).
+			else disarmDoubleTap();
+		});
 	});
 
 	// Zoom-past-fit is the mobile THUMB cell's trigger to fetch the original
@@ -1858,13 +2325,22 @@
 					use:releaseImg
 					class="lightbox-image"
 					class:panning={dragging}
+					class:pinching={pinching}
 					src={loader.displaySrc}
 					data-gen={loader.loadToken}
 					alt={img.alt || 'Attachment'}
 					draggable="false"
 					onload={(e) => {
 						const el = e.currentTarget as HTMLImageElement;
-						loader.decoded(el.naturalWidth, el.naturalHeight, el.getAttribute('src') ?? '', Number(el.dataset.gen));
+						const decodedSrc = el.getAttribute('src') ?? '';
+						const gen = Number(el.dataset.gen);
+						// Snapshot the loader's fence inputs BEFORE `decoded()` runs — it
+						// MUTATES `displaySrc`/`loadToken` (the desktop thumb→original upgrade
+						// repoints `displaySrc` to the original), so comparing against them
+						// afterwards would reject the very thumb it just accepted.
+						const srcBefore = loader.displaySrc;
+						const tokenBefore = loader.loadToken;
+						loader.decoded(el.naturalWidth, el.naturalHeight, decodedSrc, gen);
 						// RE-CLAMP on a fresh bitmap. A same-id reload can change the geometry
 						// (an async dimension fill swaps a large original for a smaller thumb,
 						// lowering actualScale and MAX_SCALE), stranding the current scale above
@@ -1877,6 +2353,16 @@
 						// drive the current zoom. Event handler, so the `zoom` read/write is not a
 						// CONVE-1688 self-write.
 						if (el === imgEl) {
+							// Mark the paint generation ONLY when this decode was ACCEPTED — the
+							// SAME fence `decoded` applies, evaluated against the PRE-decode
+							// snapshot (round-3 P1). A stale / superseded-src load on the live
+							// element (a mid-swap retry race) must not arm touch gestures on pixels
+							// that are not the current request's; but a legitimately-accepted thumb
+							// MUST arm (gestures live on the thumb→original upgrade), which the
+							// snapshot preserves even though `decoded` repointed `displaySrc`.
+							if (decodedSrc !== '' && decodedSrc === srcBefore && gen === tokenBefore) {
+								paintedGen = gen;
+							}
 							const g = readGeometry();
 							if (g) {
 								zoom = clampState(zoom, g);
@@ -2084,11 +2570,19 @@
 		/*
 		 * The empty letterbox around the image is transparent to pointer events, so
 		 * a click there reaches the backdrop and closes — the pre-zoom behaviour.
-		 * The image below re-enables them. Deliberately NOT `touch-action: none`
-		 * here: that would kill native pinch before 3d's handler exists, leaving
-		 * phone users no zoom at all in the interval (out of TASK-2455's scope).
+		 * The image below re-enables them.
+		 *
+		 * `touch-action: none` NOW (PLAN-2392 phase 3d / TASK-2518): the viewer owns
+		 * touch pan / pinch / double-tap through pointer handlers, so native touch
+		 * behaviours (scroll, pinch-zoom, double-tap-zoom) must not also fire. The
+		 * LETTERBOX RULE: because the stage is `pointer-events: none`, a letterbox
+		 * touch lands on the BACKDROP — which keeps `touch-action: auto` — so a
+		 * letterbox touch stays a native tap-to-close and never pans; touch GESTURES
+		 * begin only on painted-image hits. A blanket `none` on the backdrop would
+		 * kill scroll arbitration for the whole layer with no gesture to serve it.
 		 */
 		pointer-events: none;
+		touch-action: none;
 	}
 
 	.lightbox-image {
@@ -2101,12 +2595,16 @@
 		pointer-events: auto;
 		transform-origin: center;
 		transition: transform 0.15s ease-out;
+		/* The viewer owns touch on the image — pan / pinch / double-tap via pointer
+		   handlers (TASK-2518); native touch behaviours must not compete. */
+		touch-action: none;
 	}
 
-	/* While DRAGGING, the image must track the pointer 1:1 — the easing transition
-	   would make it lag behind the cursor (TASK-2458). Discrete zoom (keys / wheel /
-	   double-click) keeps the transition. */
-	.lightbox-image.panning {
+	/* While DRAGGING or PINCHING, the image must track the pointer(s) 1:1 — the
+	   easing transition would make it lag behind (TASK-2458 / TASK-2518). Discrete
+	   zoom (keys / wheel / double-click / double-tap) keeps the transition. */
+	.lightbox-image.panning,
+	.lightbox-image.pinching {
 		transition: none;
 	}
 

--- a/web/src/lib/components/common/Lightbox.svelte.test.ts
+++ b/web/src/lib/components/common/Lightbox.svelte.test.ts
@@ -1967,18 +1967,32 @@ function pointerEvent(
 	type: string,
 	x: number,
 	y: number,
-	opts: { buttons?: number; pointerType?: string; button?: number; pointerId?: number } = {}
+	opts: {
+		buttons?: number;
+		pointerType?: string;
+		button?: number;
+		pointerId?: number;
+		timeStamp?: number;
+	} = {}
 ): Event {
 	const e = new MouseEvent(type, { bubbles: true, cancelable: true, clientX: x, clientY: y });
 	Object.defineProperty(e, 'pointerId', { value: opts.pointerId ?? 1 });
 	Object.defineProperty(e, 'buttons', { value: opts.buttons ?? 1 });
 	Object.defineProperty(e, 'button', { value: opts.button ?? 0 });
 	Object.defineProperty(e, 'pointerType', { value: opts.pointerType ?? 'mouse' });
+	// The double-tap detector times off `timeStamp` (TASK-2518); overridable so the
+	// boundary at DOUBLE_TAP_MS is deterministic. Left as the auto value otherwise.
+	if (opts.timeStamp !== undefined) Object.defineProperty(e, 'timeStamp', { value: opts.timeStamp });
 	return e;
 }
 
 function panX(scope: HTMLElement = root()): number {
 	const m = /translate\(([-\d.]+)px,/.exec(transformOf(scope));
+	return m ? Number(m[1]) : NaN;
+}
+
+function panY(scope: HTMLElement = root()): number {
+	const m = /translate\([-\d.]+px,\s*([-\d.]+)px\)/.exec(transformOf(scope));
 	return m ? Number(m[1]) : NaN;
 }
 
@@ -2245,20 +2259,19 @@ describe('Lightbox — drag-to-pan and double-click (TASK-2458)', () => {
 		expect(root().querySelector('.lightbox-image')?.getAttribute('draggable')).toBe('false');
 	});
 
-	// DELIBERATELY INVERTED from the pre-3d contract (TASK-2517, falsify-don't-
-	// contort). The former test here pinned "a touch pointerdown is IGNORED — no
-	// registry, no anything". V1 replaces it with the V1 touch contract, split into
-	// two honest halves: (a) a touch press+MOVE arms nothing (no capture, no pan) and
-	// the mouse path stays byte-identical; (b) a real touch TAP (press+up, NO move)
-	// still closes via the backdrop. Keeping them separate avoids conflating "no pan"
-	// with "tap closes" by injecting a click after an unrealistic 100px touch move.
-	it('V1: a TOUCH press+move arms nothing (no capture, no pan); the mouse path is byte-identical', () => {
+	// These dispatch on `root()` — the backdrop LETTERBOX. Touch gestures shipped in
+	// V2 (TASK-2518) but arm only on a PAINTED-IMAGE hit, so a letterbox touch STILL
+	// arms nothing: (a) a letterbox touch press+MOVE never pans (touch pan requires an
+	// image target; the mouse path — which arms over the backdrop — is byte-identical);
+	// (b) a real letterbox TAP (press+up, NO move) still closes via the backdrop. The
+	// V2 touch pan / pinch / double-tap tests dispatch on the IMAGE element instead.
+	it('a TOUCH press+move on the backdrop arms nothing (no capture, no pan); the mouse path is byte-identical', () => {
 		mountViewer();
 		mockGeometry(root(), OVERFLOW_G);
 		zoomToActual();
 
-		// Touch press + move: no capture taken, the transform does not move (V1 arms
-		// no touch drag — touch pan is V2's).
+		// Touch press + move on the letterbox: no capture taken, the transform does not
+		// move (touch pan arms only on a painted-image hit — the letterbox is not one).
 		root().dispatchEvent(pointerEvent('pointerdown', 500, 500, { pointerType: 'touch' }));
 		root().dispatchEvent(pointerEvent('pointermove', 600, 500, { pointerType: 'touch' }));
 		flushSync();
@@ -2273,12 +2286,12 @@ describe('Lightbox — drag-to-pan and double-click (TASK-2458)', () => {
 		expect(panX()).toBeCloseTo(100);
 	});
 
-	it('V1: a real TOUCH TAP (press+up, no move) still closes via the backdrop', () => {
+	it('a real backdrop TOUCH TAP (press+up, no move) still closes via the backdrop', () => {
 		const onClose = vi.fn();
 		mountViewer({ onClose });
-		// A genuine tap — down + up at the SAME point, no drag. Touch arms nothing, so
-		// `suppressClick` stays false and the tap's synthesized backdrop click closes,
-		// exactly as a plain backdrop click does (the V1 touch surface: taps).
+		// A genuine letterbox tap — down + up at the SAME point, no drag. A backdrop touch
+		// arms nothing, so `suppressClick` stays false and the tap's synthesized backdrop
+		// click closes, exactly as a plain backdrop click does.
 		root().dispatchEvent(pointerEvent('pointerdown', 500, 500, { pointerType: 'touch' }));
 		root().dispatchEvent(pointerEvent('pointerup', 500, 500, { pointerType: 'touch', buttons: 0 }));
 		root().dispatchEvent(new MouseEvent('click', { bubbles: true }));
@@ -2650,6 +2663,655 @@ describe('Lightbox — drag-to-pan and double-click (TASK-2458)', () => {
 		front.dispatchEvent(new MouseEvent('dblclick', { bubbles: true, clientX: 500, clientY: 500 }));
 		flushSync();
 		expect(scaleOf(front)).toBeCloseTo(2000 / 900); // frontmost did
+	});
+});
+
+// ── TASK-2518 — touch pan + pinch + double-tap (3d-V2) ───────────────────────
+//
+// The V1 touch suite above dispatches on `root()` (the backdrop letterbox), where
+// touch STILL arms nothing — V2 touch gestures begin only on a PAINTED-IMAGE hit,
+// so those pins stay green byte-for-byte. This suite dispatches on the IMAGE
+// element (so `e.target` passes the painted-image gate) and paints first (so
+// `gesturesArmable` is true — the painted rule).
+const ACTUAL_SCALE = 2000 / 900; // actualScale for OVERFLOW_G — the toggle target
+describe('Lightbox — touch pan, pinch, double-tap (TASK-2518)', () => {
+	beforeEach(() => {
+		captured = [];
+		released = [];
+		(Element.prototype as unknown as Record<string, unknown>).setPointerCapture = function (id: number) {
+			captured.push(id);
+		};
+		(Element.prototype as unknown as Record<string, unknown>).releasePointerCapture = function (id: number) {
+			released.push(id);
+		};
+	});
+	afterEach(() => {
+		if (REAL_PC.setPointerCapture === undefined)
+			delete (Element.prototype as unknown as Record<string, unknown>).setPointerCapture;
+		else Element.prototype.setPointerCapture = REAL_PC.setPointerCapture;
+		if (REAL_PC.releasePointerCapture === undefined)
+			delete (Element.prototype as unknown as Record<string, unknown>).releasePointerCapture;
+		else Element.prototype.releasePointerCapture = REAL_PC.releasePointerCapture;
+	});
+
+	function imageEl(): HTMLElement {
+		return root().querySelector<HTMLElement>('.lightbox-image')!;
+	}
+	/** Mount, mock OVERFLOW_G geometry, and DECODE — so `gesturesArmable` is true. */
+	function mountPainted(props: Partial<Props> = {}): ReturnType<typeof mount> {
+		const app = mountViewer(props);
+		mockGeometry(root(), OVERFLOW_G);
+		fireLoad(2000, 2000); // paints → painted + paintedGen === loadToken
+		return app;
+	}
+	/** A touch pointer event, dispatched on the IMAGE by default (the painted-image hit). */
+	function tp(
+		type: string,
+		x: number,
+		y: number,
+		id: number,
+		opts: { ts?: number; buttons?: number; target?: HTMLElement } = {}
+	): void {
+		const target = opts.target ?? imageEl();
+		target.dispatchEvent(
+			pointerEvent(type, x, y, {
+				pointerType: 'touch',
+				pointerId: id,
+				buttons: opts.buttons,
+				timeStamp: opts.ts,
+			})
+		);
+		flushSync();
+	}
+	const tdown = (x: number, y: number, id: number, o: { ts?: number; target?: HTMLElement } = {}) =>
+		tp('pointerdown', x, y, id, { ...o, buttons: 1 });
+	const tmove = (x: number, y: number, id: number) => tp('pointermove', x, y, id, { buttons: 1 });
+	const tup = (x: number, y: number, id: number, o: { ts?: number; target?: HTMLElement } = {}) =>
+		tp('pointerup', x, y, id, { ...o, buttons: 0 });
+	const tcancel = (x: number, y: number, id: number) => tp('pointercancel', x, y, id, { buttons: 0 });
+	type RS = { __registrySize: () => number };
+
+	// ── touch pan ──
+	it('a FRESH single-touch drag on a zoomed image pans (registry size 1 — the direct leg)', () => {
+		const app = mountPainted() as unknown as RS;
+		zoomToActual(); // scale ~2.22, real pan room
+		expect(scaleOf()).toBeCloseTo(ACTUAL_SCALE);
+
+		tdown(500, 500, 1);
+		expect(app.__registrySize()).toBe(1); // one live touch — not a post-degrade artefact
+		tmove(600, 500, 1); // past threshold on the image → engages + captures
+		expect(captured).toContain(1);
+		expect(panX()).toBeCloseTo(100);
+		tup(600, 500, 1);
+	});
+
+	it('at FIT scale a touch drag ARMS + suppresses the click but applies NO offset', () => {
+		const onClose = vi.fn();
+		mountPainted({ onClose }); // fit — pan bound is zero
+		tdown(500, 500, 1);
+		tmove(560, 500, 1); // well past threshold
+		expect(captured).toContain(1); // armed + captured (click-suppression engaged)
+		expect(panX()).toBeCloseTo(0); // ...but no pan applied at fit
+		tup(560, 500, 1);
+		// The pan's synthesized click is swallowed — a pan attempt never closes.
+		root().dispatchEvent(new MouseEvent('click', { bubbles: true }));
+		expect(onClose).not.toHaveBeenCalled();
+	});
+
+	// ── pinch ──
+	it('a two-finger spread zooms; the .pinching class disables the transform transition', () => {
+		mountPainted(); // fit
+		const image = imageEl();
+		tdown(400, 500, 1); // first finger → pan owner
+		tdown(600, 500, 2); // second finger on the image → promote (dist 200 ≥ 12)
+		expect(image.classList.contains('pinching')).toBe(true);
+		tmove(700, 500, 2); // widen: 200 → 300 → scale ×1.5
+		expect(scaleOf()).toBeCloseTo(1.5);
+		expect(panX()).toBeCloseTo(50); // midpoint 500→550 tracked
+		tup(700, 500, 2);
+		expect(imageEl().classList.contains('pinching')).toBe(false);
+	});
+
+	it('composed pinch keeps the image point under the midpoint (fit-start, off-centre, move+spread)', () => {
+		mountPainted(); // fit, centred: s0 = 1, t0 = 0
+		// The feature under the INITIAL midpoint (480,500), relative to stage centre.
+		const fx = 480 - 500;
+		const fy = 500 - 500;
+		tdown(400, 480, 1);
+		tdown(560, 520, 2); // pinch seeded from these — off-centre
+		// A simultaneous MOVE + SPREAD.
+		tmove(380, 470, 1);
+		tmove(620, 540, 2);
+		const s = scaleOf();
+		const finalMidX = (380 + 620) / 2;
+		const finalMidY = (470 + 540) / 2;
+		// The feature that was under the midpoint is STILL under the (moved) midpoint.
+		expect(500 + panX() + s * fx).toBeCloseTo(finalMidX);
+		expect(500 + panY() + s * fy).toBeCloseTo(finalMidY);
+	});
+
+	it('PINCH_MIN_DIST: founders exactly 12px apart ARM a pinch; 11.999px do NOT', () => {
+		mountPainted(); // fit
+		tdown(500, 500, 1);
+		tdown(512, 500, 2); // exactly 12 apart → arms
+		tmove(524, 500, 2); // widen 12 → 24 → ×2
+		expect(scaleOf()).toBeCloseTo(2);
+		tup(524, 500, 2);
+		tup(500, 500, 1);
+
+		mountPainted(); // fresh viewer, fit
+		tdown(500, 500, 3);
+		tdown(511.999, 500, 4); // below 12 → NOT a pinch; stays single-touch pan
+		tmove(524, 500, 4); // registry-only (not the owner) → nothing
+		tmove(400, 500, 3); // the owner pans (at fit → 0), never zooms
+		expect(scaleOf()).toBe(1); // no pinch ever armed
+	});
+
+	it('a degenerate converge below PINCH_MIN_DIST HOLDS the scale; re-crossing REBASES (no snap)', () => {
+		mountPainted(); // fit
+		tdown(480, 500, 1);
+		tdown(520, 500, 2); // startDist 40, startScale 1
+		tmove(600, 500, 2); // curDist 120 → ×3
+		expect(scaleOf()).toBeCloseTo(3);
+		// A FAST converge that crosses far→near in one move: curDist 5 < 12, so the ratio
+		// update is SKIPPED and the scale HOLDS at 3 (not the near-zero-distance jump to
+		// fit that recomputing 5/40 would produce).
+		tmove(485, 500, 2); // curDist 5 < 12
+		expect(scaleOf()).toBeCloseTo(3);
+		// Re-cross upward: REBASE startDist/startScale to (curDist, held=3), so the
+		// absolute ratio continues from 3 — WITHOUT the rebase it would be
+		// startScale(1)·25/startDist(40) = 0.625 → clamped to fit (1), a snap.
+		tmove(505, 500, 2); // curDist 25 ≥ 12
+		expect(scaleOf()).toBeCloseTo(3);
+		// And the rebase produced a LIVE baseline, not a permanent hold: widening further
+		// GROWS the scale from the held 3 (rebased startDist 25, startScale 3).
+		tmove(530, 500, 2); // curDist 50 → 3 · 50/25 = 6
+		expect(scaleOf()).toBeCloseTo(6);
+	});
+
+	it('pinch admission requires BOTH pointers on the image (image + letterbox does not zoom)', () => {
+		mountPainted(); // fit
+		tdown(400, 500, 1); // image finger → pan owner
+		// Second finger on the LETTERBOX (dispatched on the backdrop root) — not on the
+		// image, so no promotion; it stays a single-touch pan.
+		tdown(600, 500, 2, { target: root() });
+		tmove(700, 500, 2); // registry-only
+		tmove(300, 500, 1); // owner pans (fit → 0), never zooms
+		expect(scaleOf()).toBe(1); // no pinch
+	});
+
+	it('a THIRD touch mid-pinch is registry-only (scale + offset untouched)', () => {
+		const app = mountPainted() as unknown as RS;
+		tdown(400, 500, 1);
+		tdown(600, 500, 2);
+		tmove(700, 500, 2); // zoomed
+		const scaleBefore = scaleOf();
+		const panBefore = panX();
+		tdown(500, 300, 3); // a third finger
+		expect(app.__registrySize()).toBe(3);
+		expect(scaleOf()).toBeCloseTo(scaleBefore); // untouched
+		expect(panX()).toBeCloseTo(panBefore);
+		tup(500, 300, 3); // its up only drains it — never the 2→1 degrade
+		expect(app.__registrySize()).toBe(2);
+		expect(scaleOf()).toBeCloseTo(scaleBefore);
+		// The two FOUNDERS still drive the pinch (the third neither rebased nor stole it):
+		// widening founder 2 scales per the founders' baseline (startDist 200), unaffected.
+		tmove(750, 500, 2); // founders 400 & 750 → dist 350 → 1 · 350/200 = 1.75
+		expect(scaleOf()).toBeCloseTo(1.75);
+		// A third pointer's CANCEL (not just up) is likewise registry-only — no degrade.
+		tdown(500, 400, 4);
+		tcancel(500, 400, 4);
+		expect(app.__registrySize()).toBe(2);
+		expect(scaleOf()).toBeCloseTo(1.75);
+	});
+
+	// ── 1→2 promotion, 2→1 degrade, cancel routing ──
+	it('1→2 promotion: a pan past threshold + a second finger becomes a pinch (capture surrendered, no teardown)', () => {
+		mountPainted(); // fit
+		tdown(500, 500, 1);
+		tmove(520, 500, 1); // engages the pan → captures id 1
+		expect(captured).toContain(1);
+		released = [];
+		tdown(560, 500, 2); // second image finger → PROMOTE
+		expect(released).toContain(1); // the pan's capture is deliberately surrendered
+		// No teardown — the pinch is live: widening now zooms (seeded from BOTH points).
+		tmove(600, 500, 2); // 40 → 80 → ×2
+		expect(scaleOf()).toBeCloseTo(2);
+	});
+
+	it("the promoted owner's lostpointercapture is SWALLOWED (the new pinch survives)", () => {
+		const app = mountPainted() as unknown as RS;
+		tdown(500, 500, 1);
+		tmove(520, 500, 1); // capture id 1
+		tdown(560, 500, 2); // promote → releases id 1's capture
+		// The browser now delivers id 1's lostpointercapture (our own surrender): it must
+		// NOT tear the pinch down, and id 1 must stay in the registry.
+		root().dispatchEvent(pointerEvent('lostpointercapture', 520, 500, { pointerId: 1, pointerType: 'touch' }));
+		flushSync();
+		expect(app.__registrySize()).toBe(2); // founder kept
+		tmove(600, 500, 2); // still a pinch → zooms
+		expect(scaleOf()).toBeCloseTo(2);
+	});
+
+	it('2→1 degrade: a founder lifting continues as a pan on the SURVIVOR with no offset jump', () => {
+		mountPainted();
+		tdown(300, 500, 1);
+		tdown(700, 500, 2); // startDist 400
+		tmove(900, 500, 2); // curDist 600 → ×1.5, ample pan room (bound ±175)
+		const scaleAfterPinch = scaleOf();
+		const panAfterPinch = panX();
+		// Lift founder 1 → degrade to a pan on the survivor (id 2), rebased to its
+		// current position. No jump: the transform is unchanged until the survivor moves.
+		tup(300, 500, 1);
+		expect(scaleOf()).toBeCloseTo(scaleAfterPinch);
+		expect(panX()).toBeCloseTo(panAfterPinch);
+		expect(captured).toContain(2); // the survivor is captured as the pan owner
+		// Now the survivor pans by exactly its delta (no scale change, in-bounds).
+		tmove(850, 500, 2); // 900 → 850 = −50
+		expect(scaleOf()).toBeCloseTo(scaleAfterPinch); // pan, not zoom
+		expect(panX()).toBeCloseTo(panAfterPinch - 50);
+	});
+
+	it('cancel of ONE founder degrades; cancel of the LAST clears everything', () => {
+		const app = mountPainted() as unknown as RS;
+		tdown(300, 500, 1);
+		tdown(700, 500, 2);
+		tmove(760, 500, 2);
+		const scaleAfterPinch = scaleOf();
+		// Cancel a founder with a surviving co-founder → 2→1 degrade (pan continues).
+		tcancel(760, 500, 2);
+		expect(app.__registrySize()).toBe(1); // survivor still down
+		// The survivor (id 1) is now the pan owner — its move pans, does not zoom.
+		tmove(340, 500, 1);
+		expect(scaleOf()).toBeCloseTo(scaleAfterPinch);
+		// Cancel the LAST pointer → full clear (registry drained, gesture gone).
+		tcancel(340, 500, 1);
+		expect(app.__registrySize()).toBe(0);
+	});
+
+	// ── double-tap ──
+	it('a double-tap on the image toggles fit↔actual at the anchor; a single tap does nothing', () => {
+		const onClose = vi.fn();
+		mountPainted({ onClose });
+		// One tap: no toggle, no close (a single image tap has no action).
+		tdown(500, 500, 1, { ts: 1000 });
+		tup(500, 500, 1, { ts: 1000 });
+		expect(scaleOf()).toBe(1);
+		expect(onClose).not.toHaveBeenCalled();
+		// Second qualifying tap at an OFF-CENTRE anchor (505,505): toggles to actual size
+		// ANCHORED there — the image point under the tap stays under the tap — still no close.
+		tdown(505, 505, 1, { ts: 1200 });
+		tup(505, 505, 1, { ts: 1200 });
+		expect(scaleOf()).toBeCloseTo(ACTUAL_SCALE);
+		// Anchor invariance: centre (500,500), tap 5px off → the feature under the tap
+		// (fx=fy=5 at fit) is still under (505,505). Wrong anchor arithmetic would fail here.
+		expect(500 + panX() + scaleOf() * 5).toBeCloseTo(505);
+		expect(500 + panY() + scaleOf() * 5).toBeCloseTo(505);
+		expect(onClose).not.toHaveBeenCalled();
+	});
+
+	it('DOUBLE_TAP_MS boundary: 300ms apart toggles, 301ms does not', () => {
+		mountPainted();
+		tdown(500, 500, 1, { ts: 1000 });
+		tup(500, 500, 1, { ts: 1000 });
+		tdown(500, 500, 1, { ts: 1300 });
+		tup(500, 500, 1, { ts: 1300 }); // dt = 300 ≤ 300 → toggles
+		expect(scaleOf()).toBeCloseTo(ACTUAL_SCALE);
+
+		mountPainted();
+		tdown(500, 500, 2, { ts: 1000 });
+		tup(500, 500, 2, { ts: 1000 });
+		tdown(500, 500, 2, { ts: 1301 });
+		tup(500, 500, 2, { ts: 1301 }); // dt = 301 > 300 → does NOT toggle
+		expect(scaleOf()).toBe(1);
+	});
+
+	it('DOUBLE_TAP_SLOP_PX boundary: 24px apart toggles, 25px does not', () => {
+		mountPainted();
+		tdown(500, 500, 1, { ts: 1000 });
+		tup(500, 500, 1, { ts: 1000 });
+		tdown(524, 500, 1, { ts: 1100 });
+		tup(524, 500, 1, { ts: 1100 }); // dist 24 ≤ 24 → toggles
+		expect(scaleOf()).toBeCloseTo(ACTUAL_SCALE);
+
+		mountPainted();
+		tdown(500, 500, 2, { ts: 1000 });
+		tup(500, 500, 2, { ts: 1000 });
+		tdown(525, 500, 2, { ts: 1100 });
+		tup(525, 500, 2, { ts: 1100 }); // dist 25 > 24 → does NOT toggle
+		expect(scaleOf()).toBe(1);
+	});
+
+	it('the detector DISARMS on a drag between taps', () => {
+		mountPainted();
+		tdown(500, 500, 1, { ts: 1000 });
+		tup(500, 500, 1, { ts: 1000 }); // pending first tap
+		// A drag: engages past threshold → disarms the pending double-tap.
+		tdown(500, 500, 1, { ts: 1050 });
+		tmove(560, 500, 1);
+		tup(560, 500, 1, { ts: 1050 });
+		// A tap that WOULD have paired with the first now only starts a new one.
+		tdown(500, 500, 1, { ts: 1100 });
+		tup(500, 500, 1, { ts: 1100 });
+		expect(scaleOf()).toBe(1); // no toggle — the drag disarmed the detector
+	});
+
+	it('the detector DISARMS on a pinch between taps', () => {
+		mountPainted();
+		tdown(500, 500, 1, { ts: 1000 });
+		tup(500, 500, 1, { ts: 1000 });
+		// A pinch (second pointer joins) disarms.
+		tdown(400, 500, 1, { ts: 1050 });
+		tdown(600, 500, 2);
+		tup(600, 500, 2);
+		tup(400, 500, 1, { ts: 1050 });
+		tdown(500, 500, 1, { ts: 1100 });
+		tup(500, 500, 1, { ts: 1100 });
+		expect(scaleOf()).toBe(1); // no toggle — the pinch disarmed the detector
+	});
+
+	it('the detector DISARMS on a chrome tap between taps', () => {
+		mountPainted();
+		const close = closeButton();
+		tdown(500, 500, 1, { ts: 1000 });
+		tup(500, 500, 1, { ts: 1000 });
+		// A touch on chrome (no click dispatched → no close) disarms.
+		tdown(20, 20, 1, { ts: 1050, target: close });
+		tup(20, 20, 1, { ts: 1050, target: close });
+		tdown(500, 500, 1, { ts: 1100 });
+		tup(500, 500, 1, { ts: 1100 });
+		expect(scaleOf()).toBe(1); // no toggle — the chrome tap disarmed the detector
+	});
+
+	it('a backdrop single-tap closes with NO delay; an image tap does not close', () => {
+		const onClose = vi.fn();
+		mountPainted({ onClose });
+		// Image tap: no close (target is the image, not the backdrop), no delay machinery.
+		tdown(500, 500, 1, { ts: 1000 });
+		tup(500, 500, 1, { ts: 1000 });
+		imageEl().dispatchEvent(new MouseEvent('click', { bubbles: true }));
+		expect(onClose).not.toHaveBeenCalled();
+		// Backdrop tap: closes immediately via the synthesized click (unchanged).
+		tp('pointerdown', 50, 50, 5, { buttons: 1, target: root() });
+		tp('pointerup', 50, 50, 5, { buttons: 0, target: root() });
+		root().dispatchEvent(new MouseEvent('click', { bubbles: true }));
+		expect(onClose).toHaveBeenCalledTimes(1);
+	});
+
+	it('compat dedup: a synthesized dblclick after a touch double-tap does not toggle twice', () => {
+		mountPainted();
+		tdown(500, 500, 1, { ts: 1000 });
+		tup(500, 500, 1, { ts: 1000 });
+		tdown(500, 500, 1, { ts: 1100 });
+		tup(500, 500, 1, { ts: 1100 }); // our detector toggled → actual size
+		expect(scaleOf()).toBeCloseTo(ACTUAL_SCALE);
+		// The browser now synthesizes a dblclick from the double-tap — it must be
+		// IGNORED (last pointer was touch), or it would toggle back to fit.
+		imageEl().dispatchEvent(new MouseEvent('dblclick', { bubbles: true, clientX: 500, clientY: 500 }));
+		flushSync();
+		expect(scaleOf()).toBeCloseTo(ACTUAL_SCALE); // still actual — not toggled a second time
+	});
+
+	// ── the painted rule + retry generation gate ──
+	it('touch gestures are INERT until the bitmap PAINTS (no arm pre-decode)', () => {
+		mountViewer(); // NOT painted — img is loading (bitmapPresent, but painted false)
+		mockGeometry(root(), OVERFLOW_G);
+		// Two image fingers + a spread before any decode: nothing arms, nothing zooms.
+		tdown(400, 500, 1);
+		tdown(600, 500, 2);
+		tmove(700, 500, 2);
+		expect(scaleOf()).toBe(1); // inert — the painted rule
+		// After it paints, the SAME gesture zooms.
+		fireLoad(2000, 2000);
+		tdown(400, 500, 3);
+		tdown(600, 500, 4);
+		tmove(700, 500, 4);
+		expect(scaleOf()).toBeCloseTo(1.5);
+	});
+
+	it('touch gestures are INERT during retry-loading (stale module painted, fresh blank element)', () => {
+		// A large image: thumb paints, desktop auto-upgrades, the UPGRADE errors, retry
+		// re-mounts a blank element at a fresh generation. `loader.painted` is still true
+		// (stale), but the per-element paint generation is not — so gestures stay inert
+		// until the retried element decodes (round-6 P2).
+		mountViewer({ images: [sized(IMG_A, 'big', 5000, 5000)] });
+		mockGeometry(root(), OVERFLOW_G);
+		fireLoad(1024, 768); // thumb decodes → painted; desktop requests the original
+		expect(imageSrc()).not.toContain('variant='); // upgrading to the original
+		// The original fails.
+		imageEl().dispatchEvent(new Event('error'));
+		flushSync();
+		expect(root().querySelector('.lightbox-retry')).not.toBeNull();
+		// Retry: a fresh, blank element at a NEW generation (still phase loading).
+		root().querySelector<HTMLButtonElement>('.lightbox-retry')!.click();
+		flushSync();
+		mockGeometry(root(), OVERFLOW_G);
+		// A double-tap during retry-loading is INERT (paintedGen ≠ loadToken).
+		tdown(500, 500, 1, { ts: 1000 });
+		tup(500, 500, 1, { ts: 1000 });
+		tdown(500, 500, 1, { ts: 1100 });
+		tup(500, 500, 1, { ts: 1100 });
+		expect(scaleOf()).toBe(1); // inert during retry-loading
+		// Once the retried element decodes, gestures come back.
+		fireLoad(4000, 4000);
+		tdown(500, 500, 2, { ts: 2000 });
+		tup(500, 500, 2, { ts: 2000 });
+		tdown(500, 500, 2, { ts: 2100 });
+		tup(500, 500, 2, { ts: 2100 });
+		expect(scaleOf()).toBeGreaterThan(1); // armed again after the fresh decode
+	});
+
+	// ── regressions from the Codex review (round 1) ──
+	it('at MAX scale, spreading further does NOT drift the pan (k uses the clamped scale)', () => {
+		mountPainted(); // fit
+		const MAX = ACTUAL_SCALE * 4; // maxScale for OVERFLOW_G
+		// Pinch OUT to max, midpoint held OFF-CENTRE (600) so any k error is visible.
+		tdown(580, 500, 1);
+		tdown(620, 500, 2); // startDist 40, mid 600
+		tmove(420, 500, 1); // symmetric around 600
+		tmove(780, 500, 2); // curDist 360 → ×9 → clamped to MAX
+		expect(scaleOf()).toBeCloseTo(MAX);
+		const panAtMax = panX();
+		// Spread FURTHER, midpoint still 600: scale stays pinned at MAX, so the pan must
+		// NOT move — with the pre-fix raw-scale `k` it would drift.
+		tmove(400, 500, 1);
+		tmove(800, 500, 2); // curDist 400 → raw ×10, clamped MAX
+		expect(scaleOf()).toBeCloseTo(MAX);
+		expect(panX()).toBeCloseTo(panAtMax);
+	});
+
+	it("a delayed surrender lostpointercapture after a degrade does NOT kill the survivor pan", () => {
+		const app = mountPainted() as unknown as RS;
+		tdown(500, 500, 1);
+		tmove(520, 500, 1); // capture id 1
+		tdown(560, 500, 2); // promote → id 1's capture surrendered (swallow armed)
+		tmove(700, 500, 2); // zoom in so there is pan room
+		const scaleAfterPinch = scaleOf();
+		const panAfterPinch = panX();
+		// Founder 2 ends BEFORE id 1's deliberate lostpointercapture arrives → degrade to
+		// the survivor (id 1, at x=520). The swallow must remain armed for the in-flight loss.
+		tup(700, 500, 2);
+		expect(captured).toContain(1); // survivor (id 1) is captured as the pan owner
+		// The delayed loss for id 1 now arrives — it must be SWALLOWED, not tear the pan
+		// down, and id 1 must stay in the registry.
+		root().dispatchEvent(pointerEvent('lostpointercapture', 520, 500, { pointerId: 1, pointerType: 'touch' }));
+		flushSync();
+		expect(app.__registrySize()).toBe(1); // survivor kept
+		// Still the pan owner → the survivor pans by its EXACT delta (520 → 480 = −40), no
+		// zoom. A teardown that left the registry entry but stopped panning would fail here.
+		tmove(480, 500, 1);
+		expect(scaleOf()).toBeCloseTo(scaleAfterPinch);
+		expect(panX()).toBeCloseTo(panAfterPinch - 40);
+	});
+
+	it('a pinch torn down by bitmap loss does not leave suppressClick stuck (next backdrop tap closes)', async () => {
+		const onClose = vi.fn();
+		mountPainted({ onClose });
+		tdown(400, 500, 1);
+		tdown(600, 500, 2);
+		tmove(700, 500, 2); // pinch active → suppressClick is held true
+		// The bitmap vanishes: the reactive teardown FULL-CLEARS the pinch. A pinch never
+		// set `dragging`, so the fix clears the held `suppressClick` on `wasPinching`.
+		imageEl().dispatchEvent(new Event('error'));
+		flushSync();
+		await new Promise((r) => setTimeout(r, 0)); // let the suppress-clear timer fire
+		root().dispatchEvent(new MouseEvent('click', { bubbles: true }));
+		expect(onClose).toHaveBeenCalledTimes(1); // not swallowed by a stuck suppressClick
+	});
+
+	it('a double-tap whose first tap timeStamp is 0 still toggles (the sentinel is not 0)', () => {
+		mountPainted();
+		tdown(500, 500, 1, { ts: 0 });
+		tup(500, 500, 1, { ts: 0 }); // first tap at t=0 — a legitimate timeStamp
+		tdown(500, 500, 1, { ts: 100 });
+		tup(500, 500, 1, { ts: 100 }); // dt = 100 → toggles
+		expect(scaleOf()).toBeCloseTo(ACTUAL_SCALE);
+	});
+
+	it('a pending touch tap does NOT pair across an interleaving MOUSE interaction', () => {
+		mountPainted();
+		tdown(500, 500, 1, { ts: 1000 });
+		tup(500, 500, 1, { ts: 1000 }); // pending first touch tap
+		// A mouse press between the taps disarms the detector (input device switched).
+		root().dispatchEvent(pointerEvent('pointerdown', 500, 500, { pointerType: 'mouse', pointerId: 9 }));
+		root().dispatchEvent(pointerEvent('pointerup', 500, 500, { pointerType: 'mouse', pointerId: 9, buttons: 0 }));
+		flushSync();
+		tdown(500, 500, 1, { ts: 1100 });
+		tup(500, 500, 1, { ts: 1100 }); // would-be second tap
+		expect(scaleOf()).toBe(1); // no toggle — the mouse press disarmed the pending tap
+	});
+
+	it('a live touch pinch is torn down when a same-id reload remounts a blank element (arm lost)', () => {
+		liveProps.images = [image(IMG_A, 'a')];
+		const app = mount(Lightbox, { target: appRoot, props: liveProps });
+		mounted.push(app);
+		flushSync();
+		mockGeometry(root(), OVERFLOW_G);
+		fireLoad(2000, 2000); // painted
+		// Start a pinch.
+		imageEl().dispatchEvent(pointerEvent('pointerdown', 400, 500, { pointerType: 'touch', pointerId: 1 }));
+		flushSync();
+		imageEl().dispatchEvent(pointerEvent('pointerdown', 600, 500, { pointerType: 'touch', pointerId: 2 }));
+		flushSync();
+		imageEl().dispatchEvent(pointerEvent('pointermove', 700, 500, { pointerType: 'touch', pointerId: 2 }));
+		flushSync();
+		expect(scaleOf()).toBeGreaterThan(1);
+		expect(root().querySelector('.lightbox-image')!.classList.contains('pinching')).toBe(true);
+		// A same-id re-emit with dimensions flips loadKey → reload → a fresh BLANK element
+		// (loadToken bumps). bitmapPresent stays true (loading), but gesturesArmable goes
+		// false — so the live TOUCH pinch is torn down (the paint arm is lost).
+		liveProps.images = [sized(IMG_A, 'a', 5000, 5000)];
+		flushSync();
+		expect(root().querySelector('.lightbox-image')?.classList.contains('pinching') ?? false).toBe(false);
+		void app;
+	});
+
+	it('a pending first tap does NOT survive a navigation (no cross-image double-tap)', () => {
+		mountPainted({
+			images: [image(IMG_A, 'a'), image(IMG_B, 'b')],
+		});
+		// First tap on image A.
+		tdown(500, 500, 1, { ts: 1000 });
+		tup(500, 500, 1, { ts: 1000 });
+		// Navigate to B — the reset-on-image-change disarms the pending tap.
+		root().querySelector<HTMLButtonElement>('.lightbox-nav.next')!.click();
+		flushSync();
+		fireLoad(2000, 2000); // B paints
+		mockGeometry(root(), OVERFLOW_G);
+		// A single tap on B within the window must NOT pair with A's tap into a toggle.
+		tdown(500, 500, 1, { ts: 1100 });
+		tup(500, 500, 1, { ts: 1100 });
+		expect(scaleOf()).toBe(1);
+	});
+
+	it('touch gestures stay LIVE on a painted thumb during the thumb→original upgrade', () => {
+		// Desktop large image: the thumb decodes and PAINTS (arming gestures), then the
+		// original auto-upgrades in the background (SAME element, SAME token). Gestures
+		// must stay live on the thumb — the accept-gate arms on the thumb decode even
+		// though `decoded` repointed `displaySrc` to the original (the round-2 regression).
+		mountViewer({ images: [sized(IMG_A, 'big', 5000, 5000)] });
+		mockGeometry(root(), OVERFLOW_G);
+		expect(imageSrc()).toContain('variant=thumb-md');
+		fireLoad(1024, 768); // thumb decodes → painted; the original is now requested
+		expect(imageSrc()).not.toContain('variant='); // upgrading (phase loading, same element)
+		// A double-tap DURING the upgrade toggles — gestures are LIVE on the painted thumb.
+		tdown(500, 500, 1, { ts: 1000 });
+		tup(500, 500, 1, { ts: 1000 });
+		tdown(500, 500, 1, { ts: 1100 });
+		tup(500, 500, 1, { ts: 1100 });
+		expect(scaleOf()).toBeGreaterThan(1);
+	});
+
+	it('a mouse press does NOT seize an armed (not-yet-dragging) touch pan', () => {
+		mountPainted();
+		zoomToActual(); // pan room
+		tdown(500, 500, 1); // touch pan ARMED (maybeDrag), not yet dragging, uncaptured
+		// A mouse press mid-arm must be registry-only — not steal ownership onto itself.
+		imageEl().dispatchEvent(pointerEvent('pointerdown', 300, 300, { pointerType: 'mouse', pointerId: 9 }));
+		flushSync();
+		// The touch still owns the pan: its move past threshold pans by its delta.
+		tmove(600, 500, 1);
+		expect(panX()).toBeCloseTo(100);
+	});
+
+	it('a MOUSE pan tolerates the looser bitmapPresent arm (not torn down pre-paint)', () => {
+		mountViewer(); // NOT painted: bitmapPresent true (loading), gesturesArmable false
+		mockGeometry(root(), OVERFLOW_G);
+		const image = imageEl();
+		// A mouse drag engages over the loading (unpainted) image — mouse uses the looser
+		// `bitmapPresent` arm, so it arms where touch would not.
+		root().dispatchEvent(pointerEvent('pointerdown', 500, 500));
+		root().dispatchEvent(pointerEvent('pointermove', 560, 500));
+		flushSync();
+		// The reactive teardown must NOT abort it: only a live TOUCH gesture requires the
+		// paint arm; a mouse pan is left alone (`touchGestureLive()` is false for it).
+		expect(image.classList.contains('panning')).toBe(true);
+	});
+
+	it('a keyboard zoom mid-pinch REBASES the pinch baseline (the next move keeps it)', () => {
+		mountPainted(); // fit
+		tdown(400, 500, 1);
+		tdown(600, 500, 2); // startDist 200, startScale 1
+		tmove(700, 500, 2); // dist 300 → ×1.5
+		expect(scaleOf()).toBeCloseTo(1.5);
+		// A keyboard `+` zooms mid-pinch (hybrid input): `stepZoom` writes `zoom` AND
+		// rebases the pinch baseline to the current scale + founder distance.
+		expect(press('+')).toBe(true);
+		expect(scaleOf()).toBeCloseTo(1.875); // 1.5 × 1.25
+		// The next pinch move continues from the REBASED baseline (startScale 1.875,
+		// startDist 300): widening to 400 → 1.875 · 400/300 = 2.5. Without the rebase it
+		// would recompute from the stale pinch-start baseline (1 · 400/200 = 2.0),
+		// discarding the keyboard zoom.
+		tmove(800, 500, 2);
+		expect(scaleOf()).toBeCloseTo(2.5);
+	});
+
+	it('a pending first tap does NOT survive a same-id reload (no spurious toggle after repaint)', () => {
+		liveProps.images = [image(IMG_A, 'a')];
+		const app = mount(Lightbox, { target: appRoot, props: liveProps });
+		mounted.push(app);
+		flushSync();
+		mockGeometry(root(), OVERFLOW_G);
+		fireLoad(2000, 2000); // painted
+		// First tap.
+		imageEl().dispatchEvent(pointerEvent('pointerdown', 500, 500, { pointerType: 'touch', pointerId: 1, timeStamp: 1000 }));
+		flushSync();
+		imageEl().dispatchEvent(pointerEvent('pointerup', 500, 500, { pointerType: 'touch', pointerId: 1, buttons: 0, timeStamp: 1000 }));
+		flushSync();
+		// A SAME-ID reload (dimension fill) flips gesturesArmable false with no live
+		// gesture — cancelGesture does not run (bitmapPresent stays true), so the effect's
+		// else-branch must drop the pending tap.
+		liveProps.images = [sized(IMG_A, 'a', 5000, 5000)];
+		flushSync();
+		fireLoad(1024, 768); // repaint
+		mockGeometry(root(), OVERFLOW_G);
+		// A tap now must NOT pair with the pre-reload tap.
+		imageEl().dispatchEvent(pointerEvent('pointerdown', 500, 500, { pointerType: 'touch', pointerId: 1, timeStamp: 1100 }));
+		flushSync();
+		imageEl().dispatchEvent(pointerEvent('pointerup', 500, 500, { pointerType: 'touch', pointerId: 1, buttons: 0, timeStamp: 1100 }));
+		flushSync();
+		expect(scaleOf()).toBe(1);
+		void app;
 	});
 });
 
@@ -3077,9 +3739,11 @@ describe('Lightbox — mobile tap-to-load and zoom-past-fit (TASK-2460)', () => 
 //    over the resized box).
 //  • The `@media (forced-colors: active)` sheet-chrome fill/border being visible.
 //  • The DR-18 `@media (max-width: 768px)` label reveal on the phone.
-//  • Real TOUCH: native pinch still available (no `touch-action` change), no
-//    pointer capture on the sheet chrome, two-pointer input not swallowed — the
-//    3d handoff criterion.
+//  • Real TOUCH (3d / TASK-2518): the image + stage carry `touch-action: none` and
+//    the viewer OWNS pan / pinch / double-tap through pointer handlers — native
+//    pinch is replaced, not preserved. A letterbox touch (the backdrop keeps
+//    `touch-action: auto`) still taps to close, and the sheet chrome is excluded
+//    from the gestures. A real browser (T7 / V3) proves the two-pointer geometry.
 // The class is the SELECTION mechanism (a DOM fact) and the whole assertable
 // surface here: jsdom's getComputedStyle does NOT apply `<style>`-element rules
 // (the existing tap-to-load `pointer-events` assertions only ever assert

--- a/web/src/lib/components/common/Lightbox.svelte.test.ts
+++ b/web/src/lib/components/common/Lightbox.svelte.test.ts
@@ -2692,6 +2692,9 @@ describe('Lightbox — touch pan, pinch, double-tap (TASK-2518)', () => {
 		if (REAL_PC.releasePointerCapture === undefined)
 			delete (Element.prototype as unknown as Record<string, unknown>).releasePointerCapture;
 		else Element.prototype.releasePointerCapture = REAL_PC.releasePointerCapture;
+		// The flip-mid-pinch test (TASK-2521) drives `mobileFlag`; never let it leak.
+		mobileFlag = false;
+		flushSync();
 	});
 
 	function imageEl(): HTMLElement {
@@ -2927,6 +2930,104 @@ describe('Lightbox — touch pan, pinch, double-tap (TASK-2518)', () => {
 		// Cancel the LAST pointer → full clear (registry drained, gesture gone).
 		tcancel(340, 500, 1);
 		expect(app.__registrySize()).toBe(0);
+	});
+
+	// ── failed-promotion / stale-owner disarm + gate-on-degrade (TASK-2521) ──
+	type Drop = RS & { __dropGestureOwnerEntry: () => void };
+
+	it('missing-founder promotion DISARMS the stale pan; the incoming touch arms fresh', () => {
+		const app = mountPainted() as unknown as Drop;
+		zoomToActual(); // pan room so a fresh arm is observable
+		tdown(500, 500, 1); // a touch pan owner — registry entry present
+		expect(app.__registrySize()).toBe(1);
+		// Model a stale owner whose founder point was reconciled out from under its
+		// lingering arm — the exact state the promotion's missing-founder guard exists
+		// for. `maybeDrag`/`gesturePointerId` still claim ownership; the live point is gone.
+		app.__dropGestureOwnerEntry();
+		// A second image touch reaches the promotion, finds the founder missing, and must
+		// fully disarm the stale pan and treat THIS touch as a fresh first touch — NOT
+		// strand a phantom pan (which the pre-fix `return` left, eating every later
+		// gesture) and NOT seed a pinch from the dead point.
+		tdown(560, 500, 2);
+		expect(imageEl().classList.contains('pinching')).toBe(false);
+		// The incoming touch OWNS the pan now: past threshold it pans by its own delta.
+		// A stranded stale owner would have swallowed this move (id 2 ≠ the stale owner).
+		tmove(660, 500, 2);
+		expect(panX()).toBeCloseTo(100);
+		expect(captured).toContain(2);
+		expect(app.__registrySize()).toBe(1); // only the live touch — the stale entry dropped
+	});
+
+	it('a stale owner reconciled out of the registry is SUPERSEDED, never a phantom pinch', () => {
+		const app = mountPainted() as unknown as Drop;
+		zoomToActual(); // pan room
+		const scaleBefore = scaleOf();
+		const panBefore = panX();
+		tdown(400, 500, 1); // arm owner 1
+		app.__dropGestureOwnerEntry(); // its founder point is gone — stale, no live pointer
+		// A new touch 200px away WOULD pinch from a live owner. From the DEAD founder it
+		// must not: the promotion supersedes the stale owner with this fresh single touch.
+		tdown(600, 500, 2);
+		expect(imageEl().classList.contains('pinching')).toBe(false);
+		// It is a genuine single-touch PAN, not a two-finger zoom: the lone live finger
+		// pans by its delta and the scale never moves (a phantom pinch would have zoomed).
+		tmove(700, 500, 2);
+		expect(scaleOf()).toBeCloseTo(scaleBefore); // no zoom — no phantom pinch
+		expect(panX()).toBeCloseTo(panBefore + 100); // superseded → the live finger pans
+		expect(app.__registrySize()).toBe(1);
+	});
+
+	it('a native modal opening MID-PINCH degrades to a full clear, not a survivor pan', () => {
+		const dialog = document.body.appendChild(document.createElement('dialog'));
+		mockOpenModals([]); // establish :modal support with nothing open
+		const app = mountPainted() as unknown as RS;
+		tdown(300, 500, 1);
+		tdown(700, 500, 2); // pinch seeded
+		tmove(900, 500, 2); // zoomed
+		expect(imageEl().classList.contains('pinching')).toBe(true);
+		const scaleAfterPinch = scaleOf();
+		captured = [];
+		// A showModal() dialog opens above the viewer mid-pinch — the gates close.
+		mockOpenModals([dialog]);
+		// Lift one founder: the 2→1 degrade must GATE like every START path. Gates closed
+		// → full clear, NOT a survivor pan that would resume when the dialog later closes.
+		tup(300, 500, 1);
+		expect(imageEl().classList.contains('pinching')).toBe(false);
+		expect(imageEl().classList.contains('panning')).toBe(false); // no survivor pan armed
+		expect(app.__registrySize()).toBe(0); // full clear — the registry is drained
+		expect(captured).not.toContain(2); // the survivor was NOT captured as a pan owner
+		// Gates reopen; a fresh gesture arms cleanly from the post-clear scale.
+		mockOpenModals([]);
+		tdown(400, 500, 3);
+		tdown(600, 500, 4);
+		tmove(700, 500, 4);
+		expect(scaleOf()).toBeGreaterThan(scaleAfterPinch);
+	});
+
+	it('a viewport flip MID-PINCH does not jump the offset (rect-origin rebased midpoint)', () => {
+		mountPainted(); // desktop; stage rect mocked at origin (0,0)
+		tdown(400, 500, 1);
+		tdown(600, 500, 2); // startDist 200, midpoint 500
+		tmove(700, 500, 2); // curDist 300 → ×1.5, midpoint 500→550 tracked
+		expect(scaleOf()).toBeCloseTo(1.5);
+		const panBefore = panX();
+		const panYBefore = panY();
+		// The phone-sheet breakpoint flips: the sheet class toggles synchronously and the
+		// stage docks to the bottom, SHIFTING the stage rect ORIGIN — while the async
+		// ResizeObserver re-clamp has NOT fired. Re-mock the geometry with the shifted
+		// origin to model that synchronous layout move.
+		mobileFlag = true;
+		flushSync();
+		mockGeometry(root(), OVERFLOW_G, 100, 40);
+		// Continue the pinch in the SAME flush without moving the fingers: the midpoint
+		// baseline was seeded against the OLD rect origin, the fresh midpoint against the
+		// NEW one — mixing them would jump the pan by the origin shift. The rebase re-seeds
+		// the baseline (zero delta this step), so the offset holds and the scale
+		// (rect-independent) is unchanged. Without the fix panX jumps by −100 here.
+		tmove(700, 500, 2);
+		expect(scaleOf()).toBeCloseTo(1.5);
+		expect(panX()).toBeCloseTo(panBefore);
+		expect(panY()).toBeCloseTo(panYBefore);
 	});
 
 	// ── double-tap ──

--- a/web/src/lib/components/common/Lightbox.svelte.test.ts
+++ b/web/src/lib/components/common/Lightbox.svelte.test.ts
@@ -2245,21 +2245,44 @@ describe('Lightbox — drag-to-pan and double-click (TASK-2458)', () => {
 		expect(root().querySelector('.lightbox-image')?.getAttribute('draggable')).toBe('false');
 	});
 
-	it('ignores a TOUCH pointer (native until 3d); a mouse pointer pans', () => {
+	// DELIBERATELY INVERTED from the pre-3d contract (TASK-2517, falsify-don't-
+	// contort). The former test here pinned "a touch pointerdown is IGNORED — no
+	// registry, no anything". V1 replaces it with the V1 touch contract, split into
+	// two honest halves: (a) a touch press+MOVE arms nothing (no capture, no pan) and
+	// the mouse path stays byte-identical; (b) a real touch TAP (press+up, NO move)
+	// still closes via the backdrop. Keeping them separate avoids conflating "no pan"
+	// with "tap closes" by injecting a click after an unrealistic 100px touch move.
+	it('V1: a TOUCH press+move arms nothing (no capture, no pan); the mouse path is byte-identical', () => {
 		mountViewer();
 		mockGeometry(root(), OVERFLOW_G);
 		zoomToActual();
 
+		// Touch press + move: no capture taken, the transform does not move (V1 arms
+		// no touch drag — touch pan is V2's).
 		root().dispatchEvent(pointerEvent('pointerdown', 500, 500, { pointerType: 'touch' }));
 		root().dispatchEvent(pointerEvent('pointermove', 600, 500, { pointerType: 'touch' }));
 		flushSync();
 		expect(captured).toEqual([]);
+		expect(panX()).toBeCloseTo(0); // unmoved — no pan
 
+		// The mouse path is byte-identical: it still captures and pans.
 		root().dispatchEvent(pointerEvent('pointerdown', 500, 500));
 		root().dispatchEvent(pointerEvent('pointermove', 600, 500));
 		flushSync();
 		expect(captured).toContain(1);
 		expect(panX()).toBeCloseTo(100);
+	});
+
+	it('V1: a real TOUCH TAP (press+up, no move) still closes via the backdrop', () => {
+		const onClose = vi.fn();
+		mountViewer({ onClose });
+		// A genuine tap — down + up at the SAME point, no drag. Touch arms nothing, so
+		// `suppressClick` stays false and the tap's synthesized backdrop click closes,
+		// exactly as a plain backdrop click does (the V1 touch surface: taps).
+		root().dispatchEvent(pointerEvent('pointerdown', 500, 500, { pointerType: 'touch' }));
+		root().dispatchEvent(pointerEvent('pointerup', 500, 500, { pointerType: 'touch', buttons: 0 }));
+		root().dispatchEvent(new MouseEvent('click', { bubbles: true }));
+		expect(onClose).toHaveBeenCalledTimes(1);
 	});
 
 	it('drops the transform transition while dragging (image tracks the pointer), restoring it after', () => {
@@ -2347,6 +2370,92 @@ describe('Lightbox — drag-to-pan and double-click (TASK-2458)', () => {
 		expect(captured).toContain(1);
 		root().dispatchEvent(pointerEvent('pointercancel', 600, 500));
 		expect(released).toContain(1);
+	});
+
+	// ── registry hygiene: the pointer set drains, never leaks (round-2 P1) ──
+	//
+	// The registry is inert plumbing in V1, so a leak has no other observable
+	// consequence — assert the drain invariant directly via the test-only accessor.
+	type RegistrySized = { __registrySize: () => number };
+
+	it('drains the registry on pointerup AND on pointercancel — a touch leaves no entry', () => {
+		const app = mountViewer() as unknown as RegistrySized;
+		// A touch enters the registry...
+		root().dispatchEvent(pointerEvent('pointerdown', 300, 300, { pointerType: 'touch', pointerId: 7 }));
+		expect(app.__registrySize()).toBe(1);
+		// ...and its pointerup drains it (deleted BEFORE the owner guard — the touch
+		// never owned a gesture, so an owner-guarded early return would have leaked it).
+		root().dispatchEvent(
+			pointerEvent('pointerup', 300, 300, { pointerType: 'touch', pointerId: 7, buttons: 0 })
+		);
+		expect(app.__registrySize()).toBe(0);
+
+		// A browser-claimed touch (pointercancel under touch-action:auto) also drains.
+		root().dispatchEvent(pointerEvent('pointerdown', 300, 300, { pointerType: 'touch', pointerId: 8 }));
+		expect(app.__registrySize()).toBe(1);
+		root().dispatchEvent(pointerEvent('pointercancel', 300, 300, { pointerType: 'touch', pointerId: 8 }));
+		expect(app.__registrySize()).toBe(0);
+	});
+
+	it('a pointercancel STORM during a mouse drag leaves no leak and never ends the mouse gesture', () => {
+		const app = mountViewer() as unknown as RegistrySized;
+		mockGeometry(root(), OVERFLOW_G);
+		zoomToActual();
+		// The mouse (id 1) owns the drag.
+		root().dispatchEvent(pointerEvent('pointerdown', 500, 500, { pointerId: 1 }));
+		root().dispatchEvent(pointerEvent('pointermove', 600, 500, { pointerId: 1 }));
+		flushSync();
+		expect(panX()).toBeCloseTo(100);
+
+		// A storm of browser-claimed touches arrive and each cancels. Every delete runs
+		// FIRST, before the owner guard, so none leaks AND none ends the mouse drag.
+		for (const id of [2, 3, 4, 5]) {
+			root().dispatchEvent(pointerEvent('pointerdown', 200, 200, { pointerType: 'touch', pointerId: id }));
+		}
+		expect(app.__registrySize()).toBe(5); // the mouse owner + four live touches
+		for (const id of [2, 3, 4, 5]) {
+			root().dispatchEvent(pointerEvent('pointercancel', 200, 200, { pointerType: 'touch', pointerId: id }));
+		}
+		// The foreign touches drained; only the mouse owner remains.
+		expect(app.__registrySize()).toBe(1);
+		// The mouse drag is intact — its next move still pans...
+		root().dispatchEvent(pointerEvent('pointermove', 700, 500, { pointerId: 1 }));
+		flushSync();
+		expect(panX()).toBeCloseTo(200);
+		// ...and the mouse up drains the last entry.
+		root().dispatchEvent(pointerEvent('pointerup', 700, 500, { pointerId: 1, buttons: 0 }));
+		expect(app.__registrySize()).toBe(0);
+	});
+
+	it('a TOUCH tap on chrome arms nothing (no capture, no pan) and drains', () => {
+		const app = mountViewer() as unknown as RegistrySized;
+		mockGeometry(root(), OVERFLOW_G);
+		zoomToActual();
+		const closeBtn = root().querySelector<HTMLButtonElement>('.lightbox-close')!;
+		// A touch press on the close chrome bubbles to the backdrop handler: it enters
+		// the registry, arms no drag, takes no capture, and the up drains it — the
+		// chrome's own click is left free to fire.
+		closeBtn.dispatchEvent(pointerEvent('pointerdown', 20, 20, { pointerType: 'touch', pointerId: 3 }));
+		expect(app.__registrySize()).toBe(1);
+		closeBtn.dispatchEvent(pointerEvent('pointerup', 20, 20, { pointerType: 'touch', pointerId: 3, buttons: 0 }));
+		flushSync();
+		expect(captured).toEqual([]);
+		expect(panX()).toBeCloseTo(0); // the chrome press engaged no pan on the stage
+		expect(app.__registrySize()).toBe(0);
+	});
+
+	it("a stale armed owner's missed off-root pointerup is reconciled out by the next press", () => {
+		const app = mountViewer() as unknown as RegistrySized;
+		mockGeometry(root(), OVERFLOW_G);
+		zoomToActual();
+		// A pen arms a drag (id 2) but its pointerup fires OFF-ROOT before capture — no
+		// up is ever delivered, so it can't self-delete. The entry is now in the registry.
+		root().dispatchEvent(pointerEvent('pointerdown', 500, 500, { pointerType: 'pen', pointerId: 2 }));
+		expect(app.__registrySize()).toBe(1);
+		// A fresh mouse press (id 1) supersedes the stale armed gesture and reconciles
+		// the phantom pen entry out — leaving only the live pointer, not two.
+		root().dispatchEvent(pointerEvent('pointerdown', 500, 500, { pointerId: 1 }));
+		expect(app.__registrySize()).toBe(1);
 	});
 
 	// ── gesture-state hygiene (round 1) ──
@@ -2926,6 +3035,24 @@ describe('Lightbox — mobile tap-to-load and zoom-past-fit (TASK-2460)', () => 
 		tapButton().click();
 		flushSync();
 		expect(imageSrc()).toContain(IMG_A);
+	});
+
+	it('V1: a TOUCH tap on the deferred affordance keeps first-tap priority (it loads)', () => {
+		mountViewer({ images: [sized(IMG_A, 'big', 5000, 5000)] });
+		const tap = tapButton();
+		expect(tap).not.toBeNull();
+		// A touch press on the affordance bubbles to the backdrop handler: in V1 it
+		// enters the registry but arms NOTHING and takes NO capture (the deferred cell
+		// has no bitmap anyway), so it does not swallow or pre-empt the tap. The tap's
+		// own click then issues the request — first-tap priority preserved.
+		tap.dispatchEvent(pointerEvent('pointerdown', 100, 100, { pointerType: 'touch', pointerId: 9 }));
+		tap.dispatchEvent(pointerEvent('pointerup', 100, 100, { pointerType: 'touch', pointerId: 9, buttons: 0 }));
+		flushSync();
+		expect(root().querySelector('.lightbox-image')).toBeNull(); // the tap-move alone loaded nothing
+		tap.click(); // the synthesized click the tap produces
+		flushSync();
+		expect(imageSrc()).toContain(IMG_A);
+		expect(root().querySelector('.lightbox-tap-load')).toBeNull(); // replaced by the image it loaded
 	});
 
 	it('mobile→desktop breakpoint flip does NOT retro-fetch: the affordance stays', () => {

--- a/web/src/lib/scroll/restore.svelte.test.ts
+++ b/web/src/lib/scroll/restore.svelte.test.ts
@@ -168,7 +168,8 @@ describe('scroll restoration — ignores frontmost-viewer and handled input (TAS
 		).toBe(false);
 	});
 
-	// ── touch (still native until 3d, so NOT defaultPrevented — only the origin check catches it) ──
+	// ── touch (the viewer owns touch via POINTER handlers since 3d, but a touchmove is
+	//    still NOT defaultPrevented — only the origin check catches it) ──
 	it('a TOUCHMOVE originating in the frontmost viewer does NOT abort the restore', () => {
 		expect(
 			driveRestore(() => frontmostViewer().dispatchEvent(new Event('touchmove', { bubbles: true })))

--- a/web/src/lib/scroll/restore.svelte.ts
+++ b/web/src/lib/scroll/restore.svelte.ts
@@ -60,11 +60,13 @@ import { isViewerFrontmost, VIEWER_ROOT_CLASS } from '$lib/a11y/viewerBackdrop';
  *    wheel / key / touch while open (the page behind is inert), so its own zoom
  *    / arrow-nav must not count as the user driving the page underneath it.
  *
- * Generalized across wheel / key / touch on purpose, not wheel-only: touch stays
- * native until phase 3d, so a viewer `touchmove` is NOT `defaultPrevented` and
- * only the origin check catches it; the viewer's arrow-nav (shipped 3a) IS
- * `defaultPrevented`, so either branch catches that. A genuine, non-viewer,
- * un-handled scroll passes both checks and still aborts the restore, as before.
+ * Generalized across wheel / key / touch on purpose, not wheel-only: the viewer now
+ * OWNS touch via pointer handlers + `touch-action: none` on the image (phase 3d /
+ * TASK-2518), but it handles POINTER events, not `touchmove` — so a viewer
+ * `touchmove` is still NOT `defaultPrevented`, and only the origin check catches it;
+ * the viewer's arrow-nav (shipped 3a) IS `defaultPrevented`, so either branch catches
+ * that. A genuine, non-viewer, un-handled scroll passes both checks and still aborts
+ * the restore, as before.
  */
 export function isModalViewerScrollInput(e: Event): boolean {
 	if (e.defaultPrevented) return true;


### PR DESCRIPTION
PLAN-2392 phase 3d: touch gestures + mobile proof for the unified viewer. Serial spine from the converged decomposition (7 Codex rounds, final CLEAN) — see the amendment comment on PLAN-2392. FINAL phase of the plan.

- [x] TASK-2517 — V1: pointer registry + touch tap semantics
- [x] TASK-2518 — V2: touch pan + pinch + double-tap + touch-action none
- [x] TASK-2519 — V3: mobile browser proof + device checklist

https://claude.ai/code/session_01WFBYxdBuSZs2tjipATxAZu
