### PR TITLE
fix(e2e): silence cross-actor SSE creation toasts suite-wide (BUG-2334)

### DIFF
--- a/web/e2e/collab-persistence.spec.ts
+++ b/web/e2e/collab-persistence.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type SuiteFixture } from './fixtures';
+import { test, expect, type SuiteFixture, quietCrossActorToasts } from './fixtures';
 import type { Browser, Page } from '@playwright/test';
 import { browserLogin, seedDoc } from './lib/collab-helpers';
 
@@ -124,6 +124,10 @@ async function openSyncedEditor(
 		baseURL: fixture.baseURL,
 		extraHTTPHeaders: { Authorization: `Bearer ${fixture.apiToken}` }
 	});
+	// Self-built context: the shared fixture's cross-actor toast silence
+	// (BUG-2334) doesn't apply automatically — install it explicitly, this
+	// page lives inside the workspace and receives other specs' SSE traffic.
+	await quietCrossActorToasts(context);
 	const page = await context.newPage();
 	await browserLogin(page);
 	await page.goto(path);

--- a/web/e2e/fixtures.ts
+++ b/web/e2e/fixtures.ts
@@ -39,6 +39,26 @@ async function applyTokenAuth(context: BrowserContext, fixture: SuiteFixture) {
 	});
 }
 
+/**
+ * BUG-2334: silence CROSS-ACTOR "X created: …" SSE toasts in a context.
+ * Specs share one workspace, so other specs' seeding otherwise stacks
+ * toasts over bottom-right UI and races unrelated clicks. Page-own toasts
+ * are unaffected (see quietExternalToasts in the toast store). Applied to
+ * every built-in `context`; specs that build their OWN workspace-visiting
+ * contexts (browser.newContext) must call this too —
+ * sse-toast-quiet.spec.ts's control leg is the one deliberate exception,
+ * pinning the flag-off product behavior.
+ */
+export async function quietCrossActorToasts(context: BrowserContext): Promise<void> {
+	await context.addInitScript(() => {
+		try {
+			localStorage.setItem('pad:e2e-quiet-external-toasts', '1');
+		} catch {
+			// storage unavailable — fall through to prod behavior
+		}
+	});
+}
+
 // Standalone helper for the occasional spec that wants to build its
 // own isolated context (e.g. to assert unauthed behaviour).
 export function suiteFixture(): SuiteFixture {
@@ -52,6 +72,7 @@ export const test = base.extend<{ fixture: SuiteFixture }>({
 	context: async ({ context }, run) => {
 		const fixture = loadSuiteFixture();
 		await applyTokenAuth(context, fixture);
+		await quietCrossActorToasts(context);
 		await run(context);
 	},
 	fixture: async ({}, run) => {

--- a/web/e2e/sse-toast-quiet.spec.ts
+++ b/web/e2e/sse-toast-quiet.spec.ts
@@ -1,0 +1,133 @@
+import { test, expect, suiteFixture } from './fixtures';
+import type { APIRequestContext, Page } from '@playwright/test';
+
+/**
+ * BUG-2334 — the cross-actor SSE toast kill switch, pinned from BOTH sides.
+ *
+ * The shared e2e fixture sets `pad:e2e-quiet-external-toasts` on every
+ * context, silencing the "X created: …" info toasts that OTHER specs'
+ * seeding used to stack over bottom-right UI (the graph drawer's detail
+ * card), racing unrelated clicks suite-wide.
+ *
+ * Leg 1 proves the flag works where the suite relies on it. Leg 2 is the
+ * CONTROL: a context WITHOUT the flag still shows the toast — the real
+ * product behavior cannot silently regress behind the suite-wide silence.
+ *
+ * The quiet leg's anchor is the layout handler's OWN observable: its
+ * `item_created` branch fetches the item BY EVENT UUID (`api.items.get`,
+ * +layout.svelte) before the toast line runs, and on a bare list URL
+ * nothing else issues that exact by-uuid GET (deltaSync uses /changes and
+ * slug routes). A pre-attached response LOG (no arm-order race) is polled
+ * for that pathname, the SSE stream's own response gates the create (the
+ * heading doesn't prove connectedness), and a bounded settle covers the
+ * fetch→toast continuation — so a missing toast is real suppression, never
+ * a not-yet-arrived event or a row painted by the page's own sync.
+ */
+
+const DESKTOP = { width: 1280, height: 900 };
+
+function authHeaders(token: string) {
+	return { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' };
+}
+
+async function createTask(
+	request: APIRequestContext,
+	token: string,
+	ws: string,
+	title: string,
+): Promise<{ id: string }> {
+	const resp = await request.post(`/api/v1/workspaces/${ws}/collections/tasks/items`, {
+		headers: authHeaders(token),
+		data: { title, fields: { status: 'open' } },
+	});
+	if (!resp.ok()) throw new Error(`task create failed (${resp.status()}): ${await resp.text()}`);
+	return (await resp.json()) as { id: string };
+}
+
+/** The list row for an item title, in the tasks list view. */
+function rowFor(page: Page, title: string) {
+	return page.getByText(title, { exact: true }).first();
+}
+
+/** Any live cross-actor creation toast mentioning the title. */
+function creationToast(page: Page, title: string) {
+	return page.locator('.toast-container .toast-message', { hasText: `created: ${title}` });
+}
+
+test.beforeEach(async ({}, testInfo) => {
+	test.skip(testInfo.project.name !== 'desktop-chromium', 'one project is enough — DOM-level behavior');
+});
+
+test('the shared-fixture flag silences another actor\'s creation toast (row arrives, toast does not)', async ({
+	page,
+	request,
+	fixture,
+}) => {
+	await page.setViewportSize(DESKTOP);
+	// A LISTENER LOG, attached before navigation, is the anchor mechanism:
+	// unlike an armed waitForResponse it has no arm-order race — every
+	// response is recorded whenever it lands, and we poll the log afterwards.
+	const responseLog: string[] = [];
+	page.on('response', (r) => {
+		if (r.request().method() === 'GET') responseLog.push(new URL(r.url()).pathname);
+	});
+	await page.goto(`/${fixture.adminUsername}/${fixture.workspaceSlug}/tasks`, {
+		waitUntil: 'domcontentloaded',
+	});
+	await expect(page.getByRole('heading', { name: /tasks/i }).first()).toBeVisible();
+	// SSE must actually be CONNECTED before the external create — the heading
+	// alone doesn't prove it. The stream's response headers land in the log
+	// the moment the EventSource opens.
+	await expect
+		.poll(() => responseLog.some((u) => u.startsWith('/api/v1/events')), { timeout: 15_000 })
+		.toBe(true);
+
+	const title = `Quiet toast probe ${Date.now()}`;
+	const { id } = await createTask(request, fixture.apiToken, fixture.workspaceSlug, title);
+	// The layout's item_created branch fetches the item by EVENT UUID before
+	// its toast line; on a bare /tasks list URL nothing else issues that GET
+	// (exact-pathname match — /children, /progress etc. don't count).
+	await expect
+		.poll(() => responseLog.some((u) => u.endsWith(`/items/${id}`)), { timeout: 15_000 })
+		.toBe(true);
+	// The response landing is not the toast line running — give the branch's
+	// json+microtask continuation a bounded, generous settle, then assert the
+	// suppression for real.
+	await expect(rowFor(page, title)).toBeVisible({ timeout: 15_000 });
+	await page.waitForTimeout(1000);
+	await expect(creationToast(page, title)).toHaveCount(0);
+});
+
+test('CONTROL: an unflagged context still shows the creation toast — the product surface stays pinned', async ({
+	browser,
+	request,
+}) => {
+	const fixture = suiteFixture();
+	// A context built OUTSIDE the shared fixture: token auth applied the same
+	// way, but NO init script — localStorage stays empty, prod behavior.
+	const context = await browser.newContext({ viewport: DESKTOP });
+	await context.setExtraHTTPHeaders({ Authorization: `Bearer ${fixture.apiToken}` });
+	const page = await context.newPage();
+	try {
+		const responseLog: string[] = [];
+		page.on('response', (r) => {
+			if (r.request().method() === 'GET') responseLog.push(new URL(r.url()).pathname);
+		});
+		await page.goto(
+			`${fixture.baseURL}/${fixture.adminUsername}/${fixture.workspaceSlug}/tasks`,
+			{ waitUntil: 'domcontentloaded' },
+		);
+		await expect(page.getByRole('heading', { name: /tasks/i }).first()).toBeVisible();
+		await expect
+			.poll(() => responseLog.some((u) => u.startsWith('/api/v1/events')), { timeout: 15_000 })
+			.toBe(true);
+
+		const title = `Loud toast control ${Date.now()}`;
+		await createTask(request, fixture.apiToken, fixture.workspaceSlug, title);
+
+		await expect(rowFor(page, title)).toBeVisible({ timeout: 15_000 });
+		await expect(creationToast(page, title)).toBeVisible({ timeout: 5_000 });
+	} finally {
+		await context.close();
+	}
+});

--- a/web/src/lib/stores/toast.quiet.svelte.test.ts
+++ b/web/src/lib/stores/toast.quiet.svelte.test.ts
@@ -1,0 +1,43 @@
+// Runs in the jsdom vitest project (filename ends `.svelte.test.ts`). jsdom's
+// own localStorage is non-functional in this setup, so each case stubs
+// `globalThis.localStorage` explicitly — which is also exactly the contract
+// under test: the helper must never throw, whatever storage does (BUG-2334).
+import { describe, it, expect, afterEach } from 'vitest';
+import { quietExternalToasts } from './toast.svelte';
+
+const original = Object.getOwnPropertyDescriptor(globalThis, 'localStorage');
+
+function stubStorage(value: Pick<Storage, 'getItem'> | undefined) {
+	Object.defineProperty(globalThis, 'localStorage', {
+		configurable: true,
+		value,
+	});
+}
+
+afterEach(() => {
+	if (original) Object.defineProperty(globalThis, 'localStorage', original);
+	else delete (globalThis as Record<string, unknown>).localStorage;
+});
+
+describe('quietExternalToasts (BUG-2334 e2e kill switch)', () => {
+	it('is true only when the flag is the literal "1"', () => {
+		stubStorage({ getItem: (k) => (k === 'pad:e2e-quiet-external-toasts' ? '1' : null) });
+		expect(quietExternalToasts()).toBe(true);
+	});
+
+	it('is false when the flag is absent — the production default', () => {
+		stubStorage({ getItem: () => null });
+		expect(quietExternalToasts()).toBe(false);
+	});
+
+	it('is false, not a throw, when storage itself is unavailable or hostile', () => {
+		stubStorage(undefined);
+		expect(quietExternalToasts()).toBe(false);
+		stubStorage({
+			getItem: () => {
+				throw new Error('denied');
+			},
+		});
+		expect(quietExternalToasts()).toBe(false);
+	});
+});

--- a/web/src/lib/stores/toast.svelte.ts
+++ b/web/src/lib/stores/toast.svelte.ts
@@ -27,6 +27,31 @@ const MAX_TOASTS = 5;
 const MAX_HISTORY = 20;
 const DEFAULT_DURATION = 3000;
 
+/**
+ * Test-surface kill switch for CROSS-ACTOR notification toasts (BUG-2334).
+ *
+ * The e2e suite shares one pad instance and one workspace, so items seeded by
+ * OTHER concurrently-running specs arrive over SSE and stack "X created: …"
+ * info toasts bottom-right — directly over bottom-right UI (the graph drawer's
+ * detail card), turning unrelated specs' clicks into a race. The shared e2e
+ * fixture sets this flag via addInitScript; the ONE call site that shows a
+ * toast for another actor's SSE event checks it.
+ *
+ * Scope is deliberately narrow: only toasts announcing ANOTHER actor's work is
+ * gated. Toasts the page earns with its own actions (copy results, errors,
+ * undo) are untouched, so specs still exercise — and can still be broken by —
+ * the real toast surface. Production never sets the flag; the e2e control leg
+ * pins the flag-off behavior so the product toast can't silently regress.
+ */
+export function quietExternalToasts(): boolean {
+	try {
+		return globalThis.localStorage?.getItem('pad:e2e-quiet-external-toasts') === '1';
+	} catch {
+		// Storage unavailable (privacy mode, sandboxed iframe): behave like prod.
+		return false;
+	}
+}
+
 let toasts = $state<Toast[]>([]);
 let history = $state<HistoryEntry[]>([]);
 let unreadCount = $state(0);

--- a/web/src/routes/[username]/[workspace]/+layout.svelte
+++ b/web/src/routes/[username]/[workspace]/+layout.svelte
@@ -7,7 +7,7 @@
 	import { sseService } from '$lib/services/sse.svelte';
 	import { syncService } from '$lib/services/sync.svelte';
 	import { api } from '$lib/api/client';
-	import { toastStore } from '$lib/stores/toast.svelte';
+	import { toastStore, quietExternalToasts } from '$lib/stores/toast.svelte';
 	import { starredStore } from '$lib/stores/starred.svelte';
 	import { titleStore } from '$lib/stores/title.svelte';
 	import { authStore } from '$lib/stores/auth.svelte';
@@ -162,7 +162,10 @@
 					} catch {
 						// Item might not be fetchable by event ID, refresh collection
 					}
-					if (isExternal) {
+					// `quietExternalToasts` is the BUG-2334 e2e kill switch for exactly
+					// this toast — the one place another actor's SSE traffic becomes a
+					// click-intercepting surface. See its doc in the toast store.
+					if (isExternal && !quietExternalToasts()) {
 						const who = event.actor === 'agent' ? 'Agent' : (event.actor_name || 'CLI');
 						const link = event.collection ? `/${username}/${wsSlug}/${event.collection}/${event.item_id}` : undefined;
 						toastStore.show(`${who} created: ${event.title}`, 'info', 4000, link);


### PR DESCRIPTION
Fixes the suite-wide SSE-toast click-interception flake (BUG-2334) with a narrowly-scoped test-surface kill switch — not retries. See the commit body for the full mechanism and evidence (three consecutive zero-failure full suite runs; both sides pinned by sse-toast-quiet.spec.ts incl. an unflagged control context).

https://claude.ai/code/session_01WFBYxdBuSZs2tjipATxAZu
