### PR TITLE
feat(cli): markdown output on the remaining list surfaces; broaden ANSI stripping

### DIFF
--- a/cmd/pad/cmd_attachment.go
+++ b/cmd/pad/cmd_attachment.go
@@ -528,8 +528,13 @@ resolves it to a UUID before calling the API.`,
 				return nil
 			}
 
+			markdown := formatFlag == "markdown"
+			var mdRows [][]string
+
 			tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-			fmt.Fprintln(tw, "ID\tMIME\tSIZE\tFILENAME\tITEM\tCREATED")
+			if !markdown {
+				fmt.Fprintln(tw, "ID\tMIME\tSIZE\tFILENAME\tITEM\tCREATED")
+			}
 			for _, raw := range resp.Attachments {
 				var row struct {
 					ID             string  `json:"id"`
@@ -559,9 +564,25 @@ resolves it to a UUID before calling the API.`,
 				if t, err := time.Parse(time.RFC3339, row.CreatedAt); err == nil {
 					created = t.Format("2006-01-02 15:04")
 				}
+				if markdown {
+					mdRows = append(mdRows, []string{
+						short, row.MimeType, humanSize(row.SizeBytes), row.Filename, item, created,
+					})
+					continue
+				}
 				fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\n",
 					short, row.MimeType, humanSize(row.SizeBytes), row.Filename, item, created)
 			}
+
+			if markdown {
+				cli.RenderMarkdownTable(os.Stdout,
+					[]string{"ID", "MIME", "Size", "Filename", "Item", "Created"}, mdRows)
+				// Pagination footer as prose, so it can't be mistaken for a row.
+				fmt.Printf("\n_%d of %d (limit %d, offset %d)_\n",
+					len(resp.Attachments), resp.Total, resp.Limit, resp.Offset)
+				return nil
+			}
+
 			tw.Flush()
 			fmt.Printf("\n%d of %d (limit %d, offset %d)\n", len(resp.Attachments), resp.Total, resp.Limit, resp.Offset)
 			return nil

--- a/cmd/pad/cmd_item.go
+++ b/cmd/pad/cmd_item.go
@@ -2320,9 +2320,43 @@ func commentsCmd() *cobra.Command {
 				return cli.PrintJSON(comments)
 			}
 
+			if formatFlag == "markdown" {
+				renderCommentsMarkdown(os.Stdout, comments)
+				return nil
+			}
+
 			cli.PrintCommentTable(comments)
 			return nil
 		},
+	}
+}
+
+// renderCommentsMarkdown is the markdown counterpart of cli.PrintCommentTable.
+// Comments are not tabular — the terminal form prints an attribution line then
+// the body — so the markdown form keeps that shape rather than forcing a table.
+//
+// The body is written VERBATIM, not escaped: a comment body is authored as
+// markdown, so escaping it would turn its lists and code fences into literal
+// text. Only the attribution line, which we construct, is sanitized.
+func renderCommentsMarkdown(w io.Writer, comments []models.Comment) {
+	if len(comments) == 0 {
+		fmt.Fprintln(w, "No comments.")
+		return
+	}
+
+	for i, c := range comments {
+		badge := c.CreatedBy
+		if c.Author != "" && c.Author != c.CreatedBy {
+			badge = c.Author + " (" + c.CreatedBy + ")"
+		}
+		fmt.Fprintf(w, "**%s** · %s via %s\n\n",
+			cli.SanitizeMarkdownText(badge),
+			cli.SanitizeMarkdownText(cli.RelativeTime(c.CreatedAt)),
+			cli.SanitizeMarkdownText(c.Source))
+		fmt.Fprintln(w, c.Body)
+		if i < len(comments)-1 {
+			fmt.Fprintln(w)
+		}
 	}
 }
 
@@ -2579,6 +2613,12 @@ Example:
 			if ref != "" {
 				label = ref + " " + item.Title
 			}
+
+			if formatFlag == "markdown" {
+				renderDepsMarkdown(os.Stdout, label, blocks, blockedBy)
+				return nil
+			}
+
 			fmt.Printf("Dependencies for %s\n\n", cli.Bold.Sprint(label))
 
 			blocksHeader := color.New(color.FgYellow, color.Bold)
@@ -2609,6 +2649,38 @@ Example:
 			return nil
 		},
 	}
+}
+
+// renderDepsMarkdown is the markdown counterpart of `pad item deps`. The
+// terminal form is two coloured sections rather than a table, so markdown keeps
+// the sections and uses lists — colour is what carried the direction (yellow ->
+// out, red <- in), and headings carry it instead.
+func renderDepsMarkdown(w io.Writer, label string, blocks, blockedBy []models.ItemLink) {
+	fmt.Fprintf(w, "# Dependencies for %s\n\n", cli.SanitizeMarkdownText(label))
+
+	section := func(heading string, titles []string) {
+		fmt.Fprintf(w, "## %s\n\n", heading)
+		if len(titles) == 0 {
+			fmt.Fprint(w, "_none_\n\n")
+			return
+		}
+		for _, t := range titles {
+			fmt.Fprintf(w, "- %s\n", cli.SanitizeMarkdownText(t))
+		}
+		fmt.Fprintln(w)
+	}
+
+	outgoing := make([]string, 0, len(blocks))
+	for _, l := range blocks {
+		outgoing = append(outgoing, l.TargetTitle)
+	}
+	incoming := make([]string, 0, len(blockedBy))
+	for _, l := range blockedBy {
+		incoming = append(incoming, l.SourceTitle)
+	}
+
+	section("Blocks", outgoing)
+	section("Blocked by", incoming)
 }
 
 func unblockCmd() *cobra.Command {

--- a/cmd/pad/cmd_library.go
+++ b/cmd/pad/cmd_library.go
@@ -79,6 +79,63 @@ Examples:
 				}
 			}
 
+			if formatFlag == "markdown" {
+				// The library is category-nested, so markdown mirrors that with a
+				// heading per section and per category, then one table each. The
+				// terminal form packs enforcement and surfaces into bracket tags
+				// beside the trigger; a table gives them their own columns instead.
+				if showConventions {
+					fmt.Println("# Conventions")
+					for _, cat := range lib.Categories {
+						fmt.Printf("\n## %s\n\n", cli.SanitizeMarkdownText(cat.Name))
+						if cat.Description != "" {
+							fmt.Printf("%s\n\n", cli.SanitizeMarkdownText(cat.Description))
+						}
+						rows := make([][]string, 0, len(cat.Conventions))
+						for _, conv := range cat.Conventions {
+							rows = append(rows, []string{
+								conv.Title, conv.Trigger, conv.Enforcement,
+								strings.Join(conv.Surfaces, ", "),
+							})
+						}
+						cli.RenderMarkdownTable(os.Stdout,
+							[]string{"Title", "Trigger", "Enforcement", "Surfaces"}, rows)
+					}
+				}
+
+				if showPlaybooks {
+					if showConventions {
+						fmt.Println()
+					}
+					fmt.Println("# Playbooks")
+					for _, cat := range plib.Categories {
+						fmt.Printf("\n## %s\n\n", cli.SanitizeMarkdownText(cat.Name))
+						if cat.Description != "" {
+							fmt.Printf("%s\n\n", cli.SanitizeMarkdownText(cat.Description))
+						}
+						rows := make([][]string, 0, len(cat.Playbooks))
+						for _, pb := range cat.Playbooks {
+							invocation := ""
+							if pb.InvocationSlug != "" {
+								invocation = "/pad " + pb.InvocationSlug
+							}
+							// Summaries are not truncated here: markdown output
+							// isn't width-bound the way the terminal table is.
+							summary := ""
+							if !fullFlag {
+								summary = pb.Summary
+							}
+							rows = append(rows, []string{
+								pb.Title, pb.Trigger, pb.Scope, invocation, summary,
+							})
+						}
+						cli.RenderMarkdownTable(os.Stdout,
+							[]string{"Title", "Trigger", "Scope", "Invocation", "Summary"}, rows)
+					}
+				}
+				return nil
+			}
+
 			// Table output.
 			if showConventions {
 				fmt.Printf("\n=== CONVENTIONS ===\n")

--- a/cmd/pad/cmd_project.go
+++ b/cmd/pad/cmd_project.go
@@ -936,6 +936,50 @@ enriched activity feed the web UI uses (item refs, titles, change details).`,
 				return nil
 			}
 
+			if formatFlag == "markdown" {
+				// Columns mirror what the terminal form shows: timestamp, actor,
+				// action, the item it touched, and the field-level changes.
+				rows := make([][]string, 0, len(activities))
+				for _, a := range activities {
+					actorName := a.ActorName
+					if actorName == "" {
+						actorName = a.Actor
+					}
+					if actorName == "" {
+						actorName = "unknown"
+					}
+
+					target := a.ItemTitle
+					if a.ItemRef != "" {
+						target = a.ItemRef
+						if a.ItemTitle != "" {
+							target += " " + a.ItemTitle
+						}
+					}
+
+					changes := ""
+					if a.Metadata != "" {
+						var meta struct {
+							Changes string `json:"changes"`
+						}
+						if json.Unmarshal([]byte(a.Metadata), &meta) == nil {
+							changes = meta.Changes
+						}
+					}
+
+					rows = append(rows, []string{
+						a.CreatedAt.Format("2006-01-02 15:04"),
+						actorName,
+						a.Action,
+						target,
+						changes,
+					})
+				}
+				cli.RenderMarkdownTable(os.Stdout,
+					[]string{"When", "Actor", "Action", "Item", "Changes"}, rows)
+				return nil
+			}
+
 			dim := color.New(color.Faint)
 			bold := color.New(color.Bold)
 			cyan := color.New(color.FgCyan)

--- a/cmd/pad/cmd_role.go
+++ b/cmd/pad/cmd_role.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"strconv"
 	"text/tabwriter"
 
 	"github.com/spf13/cobra"
@@ -42,6 +43,22 @@ func roleListCmd() *cobra.Command {
 				fmt.Println("Create one with: pad role create 'Implementer' --description 'Writes code, builds features'")
 				return nil
 			}
+			if formatFlag == "markdown" {
+				rows := make([][]string, 0, len(roles))
+				for _, r := range roles {
+					name := r.Name
+					if r.Icon != "" {
+						name = r.Icon + " " + name
+					}
+					rows = append(rows, []string{
+						r.Slug, name, r.Description, r.Tools, strconv.Itoa(r.ItemCount),
+					})
+				}
+				cli.RenderMarkdownTable(os.Stdout,
+					[]string{"Slug", "Name", "Description", "Tools", "Items"}, rows)
+				return nil
+			}
+
 			w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 			fmt.Fprintln(w, "SLUG\tNAME\tDESCRIPTION\tTOOLS\tITEMS")
 			for _, r := range roles {

--- a/cmd/pad/cmd_workspace.go
+++ b/cmd/pad/cmd_workspace.go
@@ -123,6 +123,34 @@ func membersCmd() *cobra.Command {
 				return nil
 			}
 
+			var invitations []struct {
+				Email string `json:"email"`
+				Role  string `json:"role"`
+				Code  string `json:"code"`
+			}
+
+			if formatFlag == "markdown" {
+				rows := make([][]string, 0, len(members))
+				for _, m := range members {
+					rows = append(rows, []string{m.UserName, m.UserEmail, m.Role})
+				}
+				cli.RenderMarkdownTable(os.Stdout, []string{"Name", "Email", "Role"}, rows)
+
+				json.Unmarshal(result.Invitations, &invitations)
+				if len(invitations) > 0 {
+					fmt.Println()
+					fmt.Println("## Pending invitations")
+					fmt.Println()
+					inviteRows := make([][]string, 0, len(invitations))
+					for _, inv := range invitations {
+						inviteRows = append(inviteRows, []string{inv.Email, inv.Role, inv.Code})
+					}
+					cli.RenderMarkdownTable(os.Stdout,
+						[]string{"Email", "Role", "Join code"}, inviteRows)
+				}
+				return nil
+			}
+
 			w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 			fmt.Fprintln(w, "NAME\tEMAIL\tROLE")
 			for _, m := range members {
@@ -130,11 +158,6 @@ func membersCmd() *cobra.Command {
 			}
 			w.Flush()
 
-			var invitations []struct {
-				Email string `json:"email"`
-				Role  string `json:"role"`
-				Code  string `json:"code"`
-			}
 			json.Unmarshal(result.Invitations, &invitations)
 
 			if len(invitations) > 0 {

--- a/cmd/pad/format_markdown_surfaces_test.go
+++ b/cmd/pad/format_markdown_surfaces_test.go
@@ -1,0 +1,265 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+	"github.com/spf13/cobra"
+)
+
+// --- renderer unit tests for the two non-tabular surfaces ---
+
+// A comment body is authored as markdown, so it must be emitted verbatim.
+// Escaping it would turn its lists, links, and code fences into literal text —
+// the opposite of what --format markdown is for.
+func TestRenderCommentsMarkdown_BodyIsVerbatim(t *testing.T) {
+	comments := []models.Comment{{
+		Author:    "Dave",
+		CreatedBy: "dave@example.com",
+		Source:    "cli",
+		CreatedAt: time.Now(),
+		Body:      "- a list item\n- another\n\n`code | with a pipe`",
+	}}
+
+	var buf bytes.Buffer
+	renderCommentsMarkdown(&buf, comments)
+	out := buf.String()
+
+	if !strings.Contains(out, "- a list item\n- another") {
+		t.Errorf("list markup did not survive verbatim:\n%s", out)
+	}
+	if strings.Contains(out, `\|`) {
+		t.Errorf("body was table-escaped; it should be verbatim:\n%s", out)
+	}
+	if !strings.Contains(out, "**Dave (dave@example.com)**") {
+		t.Errorf("attribution line missing or unformatted:\n%s", out)
+	}
+}
+
+// The attribution line IS constructed by us, so it gets sanitized.
+func TestRenderCommentsMarkdown_SanitizesAttribution(t *testing.T) {
+	comments := []models.Comment{{
+		Author:    "Dave\n# Injected",
+		CreatedBy: "dave@example.com",
+		Source:    "\x1b[2Kcli",
+		CreatedAt: time.Now(),
+		Body:      "body",
+	}}
+
+	var buf bytes.Buffer
+	renderCommentsMarkdown(&buf, comments)
+	out := buf.String()
+
+	if strings.Contains(out, "\n# Injected") {
+		t.Errorf("newline in author injected a heading:\n%s", out)
+	}
+	if strings.ContainsRune(out, 0x1b) {
+		t.Errorf("escape byte survived in attribution: %q", out)
+	}
+}
+
+func TestRenderCommentsMarkdown_Empty(t *testing.T) {
+	var buf bytes.Buffer
+	renderCommentsMarkdown(&buf, nil)
+	if got := buf.String(); got != "No comments.\n" {
+		t.Errorf("empty render = %q, want %q", got, "No comments.\n")
+	}
+}
+
+func TestRenderDepsMarkdown_SectionsAndEmptyState(t *testing.T) {
+	var buf bytes.Buffer
+	renderDepsMarkdown(&buf, "TASK-5 the item",
+		[]models.ItemLink{{TargetTitle: "blocks this"}},
+		nil)
+	out := buf.String()
+
+	for _, want := range []string{
+		"# Dependencies for TASK-5 the item",
+		"## Blocks",
+		"- blocks this",
+		"## Blocked by",
+		"_none_",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("deps markdown missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestRenderDepsMarkdown_SanitizesTitles(t *testing.T) {
+	var buf bytes.Buffer
+	renderDepsMarkdown(&buf, "label", []models.ItemLink{{TargetTitle: "evil\n## Injected"}}, nil)
+
+	headings := 0
+	for _, line := range strings.Split(buf.String(), "\n") {
+		if strings.HasPrefix(line, "## ") {
+			headings++
+		}
+	}
+	// Exactly the two section headings we emit.
+	if headings != 2 {
+		t.Errorf("got %d headings, want 2 — a link title injected structure:\n%s", headings, buf.String())
+	}
+}
+
+// --- end-to-end routing, one case per surface ---
+
+// jsonHandler serves canned JSON per URL-path suffix so each command's client
+// call is satisfied without knowing the full route.
+func jsonHandler(t *testing.T, bySuffix map[string]any) http.Handler {
+	t.Helper()
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		for suffix, payload := range bySuffix {
+			if strings.HasSuffix(r.URL.Path, suffix) {
+				if raw, ok := payload.(string); ok {
+					_, _ = w.Write([]byte(raw))
+					return
+				}
+				_ = json.NewEncoder(w).Encode(payload)
+				return
+			}
+		}
+		http.NotFound(w, r)
+	})
+}
+
+func TestMarkdownRoutingAcrossSurfaces(t *testing.T) {
+	now := time.Now()
+	five := 5
+
+	cases := []struct {
+		name    string
+		routes  map[string]any
+		cmd     func() *cobra.Command
+		args    []string
+		want    []string
+		notWant []string
+	}{
+		{
+			name: "item starred",
+			routes: map[string]any{"/starred": []models.Item{{
+				CollectionPrefix: "TASK", ItemNumber: &five, Title: "starred one",
+				CollectionName: "Tasks", Fields: `{"status":"ready"}`, UpdatedAt: now,
+			}}},
+			cmd:     starredCmd,
+			want:    []string{"| Ref | Title | Status | Priority | Collection | Updated |", "| TASK-5 |"},
+			notWant: []string{"PRIORITY"},
+		},
+		{
+			name: "item list scoped to one collection",
+			routes: map[string]any{"/items": []models.Item{{
+				CollectionPrefix: "TASK", ItemNumber: &five, Title: "scoped one",
+				CollectionSlug: "tasks", CollectionName: "Tasks",
+				Fields: `{"status":"ready"}`, UpdatedAt: now,
+			}}},
+			cmd:  listCmd,
+			args: []string{"tasks"},
+			want: []string{"| Ref | Title | Status | Priority | Collection | Updated |", "| TASK-5 |"},
+			// Scoped listing is a single table, so no grouping heading.
+			notWant: []string{"## ", "PRIORITY"},
+		},
+		{
+			name: "item comments",
+			routes: map[string]any{
+				"/comments": []models.Comment{{
+					Author: "Dave", CreatedBy: "dave@example.com", Source: "cli",
+					CreatedAt: now, Body: "the body",
+				}},
+				"/items/TASK-5": models.Item{Slug: "task-5"},
+			},
+			cmd:  commentsCmd,
+			args: []string{"TASK-5"},
+			want: []string{"**Dave (dave@example.com)**", "the body"},
+		},
+		{
+			name: "project activity",
+			routes: map[string]any{"/activity": []models.Activity{{
+				Action: "updated", Actor: "user", ActorName: "Claude",
+				ItemRef: "TASK-5", ItemTitle: "a task", CreatedAt: now,
+				Metadata: `{"changes":"status: ready → done"}`,
+			}}},
+			cmd:  activityCmd,
+			want: []string{"| When | Actor | Action | Item | Changes |", "TASK-5 a task", "status: ready → done"},
+		},
+		{
+			name: "role list",
+			routes: map[string]any{"/agent-roles": []models.AgentRole{{
+				Slug: "implementer", Name: "Implementer", Icon: "🔧",
+				Description: "writes code", Tools: "edit", ItemCount: 3,
+			}}},
+			cmd:     roleListCmd,
+			want:    []string{"| Slug | Name | Description | Tools | Items |", "| implementer | 🔧 Implementer | writes code | edit | 3 |"},
+			notWant: []string{"SLUG\t", "DESCRIPTION"},
+		},
+		{
+			name: "attachment list",
+			routes: map[string]any{"/attachments": `{"attachments":[` +
+				`{"id":"0123456789abcdef","mime_type":"image/png","size_bytes":2048,` +
+				`"filename":"shot.png","item_title":"a task","created_at":"2026-08-11T10:00:00Z"}],` +
+				`"total":1,"limit":50,"offset":0}`},
+			cmd:  attachmentListCmd,
+			want: []string{"| ID | MIME | Size | Filename | Item | Created |", "| 01234567 | image/png |", "shot.png", "_1 of 1 (limit 50, offset 0)_"},
+		},
+		{
+			name: "library list",
+			routes: map[string]any{
+				"/convention-library": `{"categories":[{"name":"git","description":"version control",` +
+					`"conventions":[{"title":"Conventional commits","trigger":"on-commit",` +
+					`"enforcement":"must","surfaces":["cli","web"]}]}]}`,
+				"/playbook-library": `{"categories":[{"name":"agent-workflows","description":"agent flows",` +
+					`"playbooks":[{"title":"Ship tasks","trigger":"manual","scope":"all",` +
+					`"invocation_slug":"ship","summary":"work a list of tasks"}]}]}`,
+			},
+			cmd: libraryCmd,
+			want: []string{
+				"# Conventions", "## git", "| Title | Trigger | Enforcement | Surfaces |",
+				"| Conventional commits | on-commit | must | cli, web |",
+				"# Playbooks", "## agent-workflows", "| Title | Trigger | Scope | Invocation | Summary |",
+				"/pad ship",
+			},
+			notWant: []string{"=== CONVENTIONS ===", "────"},
+		},
+		{
+			name: "workspace members",
+			routes: map[string]any{"/members": `{"members":[{"user_name":"Dave","user_email":"dave@example.com","role":"owner"}],` +
+				`"invitations":[{"email":"new@example.com","role":"editor","code":"ABC123"}]}`},
+			cmd:  membersCmd,
+			want: []string{"| Name | Email | Role |", "| Dave | dave@example.com | owner |", "## Pending invitations", "| new@example.com | editor | ABC123 |"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			setupFormatRoutingTest(t, jsonHandler(t, tc.routes))
+			formatFlag = "markdown"
+
+			cmd := tc.cmd()
+			cmd.SetArgs(tc.args)
+
+			var execErr error
+			out := captureStdout(t, func() { execErr = cmd.Execute() })
+			if execErr != nil {
+				t.Fatalf("execute: %v\noutput:\n%s", execErr, out)
+			}
+
+			for _, want := range tc.want {
+				if !strings.Contains(out, want) {
+					t.Errorf("output missing %q:\n%s", want, out)
+				}
+			}
+			for _, notWant := range tc.notWant {
+				if strings.Contains(out, notWant) {
+					t.Errorf("output should not contain %q (table path leaked?):\n%s", notWant, out)
+				}
+			}
+			if strings.ContainsRune(out, 0x1b) {
+				t.Errorf("ANSI escape leaked into markdown output: %q", out)
+			}
+		})
+	}
+}

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -124,7 +124,7 @@ func newRootCmd() *cobra.Command {
 	})
 
 	rootCmd.PersistentFlags().StringVar(&workspaceFlag, "workspace", "", "workspace slug override")
-	rootCmd.PersistentFlags().StringVar(&formatFlag, "format", "table", "output format: table, json, markdown (markdown on: item list/starred, collection list, item show, project changelog)")
+	rootCmd.PersistentFlags().StringVar(&formatFlag, "format", "table", "output format: table, json, markdown")
 	rootCmd.PersistentFlags().StringVar(&urlFlag, "url", "", "server URL override (e.g., https://app.getpad.dev)")
 
 	rootCmd.AddCommand(

--- a/internal/cli/format.go
+++ b/internal/cli/format.go
@@ -133,20 +133,41 @@ func RelativeTime(t time.Time) string {
 	}
 }
 
-// sgrPattern matches ANSI SGR (Select Graphic Rendition) escape sequences —
-// the color/reset codes fatih/color emits on a TTY. Compiled once and reused
-// to measure the visible width of a colorized string. Declared at package
-// scope so the compile cost is paid a single time.
-var sgrPattern = regexp.MustCompile("\x1b\\[[0-9;]*m")
+// ansiPattern matches the zero-width escape and control sequences that can
+// appear in a string we are about to measure or render. Compiled once at package
+// scope so the cost is paid a single time.
+//
+// It deliberately covers more than SGR (#1076). The original pattern matched
+// only `ESC [ … m` — the colour codes fatih/color emits — so a non-SGR CSI
+// sequence, an OSC-8 hyperlink, or a stray control byte carried in stored data
+// survived "ANSI stripping" and either miscounted a table column or leaked into
+// markdown output that promised to be escape-free.
+//
+// The alternation is ordered: OSC first (it ends at BEL or ST and may contain
+// bytes the later alternatives would otherwise claim), then CSI, then the
+// two-character Fe escapes, then any remaining stray C0 control or DEL. TAB, LF,
+// and CR are excluded — they are meaningful whitespace, and callers that need
+// them normalized (SanitizeMarkdownText) handle them explicitly.
+var ansiPattern = regexp.MustCompile(
+	"\x1b\\][^\x07\x1b]*(?:\x07|\x1b\\\\)" + // OSC … BEL | ST  (e.g. OSC-8 hyperlinks)
+		"|\x1b\\[[0-9;?:<=>]*[ -/]*[@-~]" + // CSI … final byte (SGR, cursor moves, erases)
+		"|\x1b[@-Z\\\\-_]" + // two-character Fe escapes
+		"|[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]") // stray C0 controls + DEL (includes bare ESC)
 
-// displayWidth returns the visible column width of s: ANSI SGR escape
+// stripANSI removes escape and control sequences from s, leaving the visible
+// text. TAB, LF, and CR are preserved.
+func stripANSI(s string) string {
+	return ansiPattern.ReplaceAllString(s, "")
+}
+
+// displayWidth returns the visible column width of s: escape and control
 // sequences are stripped, then the remaining runes are counted. Every rune is
 // approximated as one column — emoji and other wide runes therefore
 // under-count. That is a pre-existing limitation of the CLI's table rendering
 // (matching the old tabwriter behavior) and is intentionally out of scope; the
 // alternative is a new go-runewidth dependency we don't want to add.
 func displayWidth(s string) int {
-	return utf8.RuneCountInString(sgrPattern.ReplaceAllString(s, ""))
+	return utf8.RuneCountInString(stripANSI(s))
 }
 
 // padCell left-aligns s in a column of the given visible width by appending
@@ -251,7 +272,7 @@ func renderItemTable(w io.Writer, items []models.Item, maxWidth int) {
 		// styling). This keeps displayWidth == rune count for the title, so
 		// truncateTitle can slice by runes without ever cutting mid-escape or
 		// mis-accounting the width budget.
-		r.title = sgrPattern.ReplaceAllString(item.Title, "")
+		r.title = stripANSI(item.Title)
 		r.archived = item.DeletedAt != nil
 
 		status, priority := itemStatusPriority(item.Fields)

--- a/internal/cli/format_ansi_test.go
+++ b/internal/cli/format_ansi_test.go
@@ -1,0 +1,82 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+// #1076: "ANSI stripping" covered only SGR (ESC[…m), so non-SGR CSI sequences,
+// OSC-8 hyperlinks, and stray C0 controls survived — including through the
+// markdown renderers, whose doc comments promise ANSI is stripped.
+
+func TestStripANSI_NonSGRSequences(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"SGR colour", "\x1b[1;31mred\x1b[0m", "red"},
+		{"CSI erase line", "before\x1b[2Kafter", "beforeafter"},
+		{"CSI cursor move", "a\x1b[10;20Hb", "ab"},
+		{"CSI private mode", "a\x1b[?25lb", "ab"},
+		{"OSC-8 hyperlink", "\x1b]8;;http://example.com\x07label\x1b]8;;\x07", "label"},
+		{"OSC window title with ST", "a\x1b]0;title\x1b\\b", "ab"},
+		{"stray C0 control", "a\x01b\x7fc", "abc"},
+		{"vertical tab and form feed", "a\x0bb\x0cc", "abc"},
+		{"bare ESC", "a\x1bb", "ab"},
+		{"plain text untouched", "nothing to strip", "nothing to strip"},
+		{"newlines preserved for the caller to handle", "a\nb", "a\nb"},
+		{"tabs preserved", "a\tb", "a\tb"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := stripANSI(tc.in); got != tc.want {
+				t.Errorf("stripANSI(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// displayWidth drives the table column maths, so a zero-width control sequence
+// must not be counted as visible columns.
+func TestDisplayWidth_IgnoresNonSGRSequences(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want int
+	}{
+		{"CSI erase line", "abc\x1b[2K", 3},
+		{"OSC-8 hyperlink", "\x1b]8;;http://example.com\x07abc\x1b]8;;\x07", 3},
+		{"stray C0", "ab\x01c", 3},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := displayWidth(tc.in); got != tc.want {
+				t.Errorf("displayWidth(%q) = %d, want %d", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// The markdown path promises no ANSI in its output; that promise has to hold for
+// non-SGR sequences too.
+func TestSanitizeMarkdownText_StripsNonSGRSequences(t *testing.T) {
+	in := "Tasks\x1b[2K\x1b]8;;http://example.com\x07"
+	got := SanitizeMarkdownText(in)
+
+	if strings.ContainsRune(got, 0x1b) {
+		t.Errorf("escape byte survived: %q", got)
+	}
+	if got != "Tasks" {
+		t.Errorf("SanitizeMarkdownText(%q) = %q, want %q", in, got, "Tasks")
+	}
+}
+
+func TestEscapeMarkdownCell_StripsNonSGRSequences(t *testing.T) {
+	got := escapeMarkdownCell("a\x1b[2Kb")
+	if got != "ab" {
+		t.Errorf("escapeMarkdownCell = %q, want %q", got, "ab")
+	}
+}

--- a/internal/cli/format_markdown.go
+++ b/internal/cli/format_markdown.go
@@ -30,7 +30,7 @@ import (
 // newlines collapse to spaces, so a value carrying a line break can't inject
 // document structure. Pipes are left alone: they're only special inside a table.
 func SanitizeMarkdownText(s string) string {
-	s = sgrPattern.ReplaceAllString(s, "")
+	s = stripANSI(s)
 	s = strings.NewReplacer("\r\n", " ", "\n", " ", "\r", " ").Replace(s)
 	return strings.TrimSpace(s)
 }
@@ -65,6 +65,37 @@ func writeMarkdownSeparator(w io.Writer, n int) {
 		cells[i] = "---"
 	}
 	writeMarkdownRow(w, cells...)
+}
+
+// RenderMarkdownTable writes headers, a separator, and one row per entry as a
+// GitHub-flavored markdown table. Every cell is escaped, so callers pass raw
+// values and never pre-format. Rows shorter than the header are padded with
+// empty cells and longer ones are truncated, so a ragged row can't shift the
+// column count and corrupt the table.
+//
+// This is the shared spine for the list commands' markdown output; a command
+// only has to name its columns and map its rows.
+func RenderMarkdownTable(w io.Writer, headers []string, rows [][]string) {
+	if len(headers) == 0 {
+		return
+	}
+
+	escaped := make([]string, len(headers))
+	for i, h := range headers {
+		escaped[i] = escapeMarkdownCell(h)
+	}
+	writeMarkdownRow(w, escaped...)
+	writeMarkdownSeparator(w, len(headers))
+
+	for _, row := range rows {
+		cells := make([]string, len(headers))
+		for i := range cells {
+			if i < len(row) {
+				cells[i] = escapeMarkdownCell(row[i])
+			}
+		}
+		writeMarkdownRow(w, cells...)
+	}
 }
 
 // PrintItemMarkdown prints items as a markdown table on stdout.

--- a/internal/cli/format_markdown_table_test.go
+++ b/internal/cli/format_markdown_table_test.go
@@ -1,0 +1,75 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestRenderMarkdownTable_Shape(t *testing.T) {
+	var buf bytes.Buffer
+	RenderMarkdownTable(&buf, []string{"A", "B"}, [][]string{{"1", "2"}, {"3", "4"}})
+
+	want := strings.Join([]string{
+		"| A | B |",
+		"| --- | --- |",
+		"| 1 | 2 |",
+		"| 3 | 4 |",
+		"",
+	}, "\n")
+	if got := buf.String(); got != want {
+		t.Errorf("table =\n%q\nwant\n%q", got, want)
+	}
+}
+
+func TestRenderMarkdownTable_EscapesCells(t *testing.T) {
+	var buf bytes.Buffer
+	RenderMarkdownTable(&buf, []string{"A"}, [][]string{
+		{"pipe | here"},
+		{"line\nbreak"},
+		{"ansi \x1b[2K here"},
+	})
+	out := buf.String()
+
+	if !strings.Contains(out, `pipe \| here`) {
+		t.Errorf("pipe not escaped:\n%s", out)
+	}
+	if strings.Contains(out, "line\nbreak") {
+		t.Errorf("newline not collapsed:\n%q", out)
+	}
+	if strings.ContainsRune(out, 0x1b) {
+		t.Errorf("escape byte survived:\n%q", out)
+	}
+	// Header + separator + three rows, and nothing extra from the newline cell.
+	if n := len(strings.Split(strings.TrimRight(out, "\n"), "\n")); n != 5 {
+		t.Errorf("got %d lines, want 5:\n%s", n, out)
+	}
+}
+
+// A row with the wrong number of cells must not change the column count, or the
+// whole table stops parsing as a table.
+func TestRenderMarkdownTable_NormalizesRaggedRows(t *testing.T) {
+	var buf bytes.Buffer
+	RenderMarkdownTable(&buf, []string{"A", "B", "C"}, [][]string{
+		{"only-one"},
+		{"one", "two", "three", "four-is-too-many"},
+	})
+
+	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+	for i, line := range lines {
+		if n := strings.Count(line, "|"); n != 4 {
+			t.Errorf("line %d has %d pipes, want 4 (3 cells): %q", i, n, line)
+		}
+	}
+	if strings.Contains(buf.String(), "four-is-too-many") {
+		t.Errorf("overflow cell was not dropped:\n%s", buf.String())
+	}
+}
+
+func TestRenderMarkdownTable_NoHeadersWritesNothing(t *testing.T) {
+	var buf bytes.Buffer
+	RenderMarkdownTable(&buf, nil, [][]string{{"x"}})
+	if buf.Len() != 0 {
+		t.Errorf("expected no output without headers, got %q", buf.String())
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Completes #898 and fixes #1076.

**The seven surfaces left out of #1070** now support `--format markdown`, so the format is honestly global and the flag help collapses to `output format: table, json, markdown`:

`item comments`, `item deps`, `project activity`, `attachment list`, `library list`, `role list`, `workspace members`.

Two of those aren't tabular, and markdown follows the terminal shape rather than forcing a table onto them:

- **`item comments`** keeps the attribution-line-then-body form, and the body is emitted **verbatim**. A comment body is authored as markdown, so escaping it would turn its lists and code fences into literal text — the opposite of what the format is for. Only the attribution line, which we construct, is sanitized.
- **`item deps`** keeps its two sections as `## Blocks` / `## Blocked by` lists. Colour carried the direction in the terminal (yellow `->` out, red `<-` in); headings carry it here.

**New shared spine:** `cli.RenderMarkdownTable(w, headers, rows)`. Every cell is escaped, and a row shorter or longer than the header is padded or truncated to the header width, so a ragged row can't shift the column count and stop the whole block parsing as a table. Wiring a surface is now naming columns and mapping rows, which is what made this diff mostly mechanical.

**#1076 — ANSI stripping.** `sgrPattern` matched only `ESC[…m`, so non-SGR CSI sequences, OSC-8 hyperlinks, and stray C0 controls survived. Replaced with `ansiPattern` + `stripANSI` covering OSC (to BEL or ST), CSI, two-character Fe escapes, and stray C0/DEL. TAB, LF, and CR are deliberately preserved — they're meaningful whitespace, and the callers that need them normalized (`SanitizeMarkdownText`) handle them explicitly.

One judgement call worth flagging: **`displayWidth` now uses the broader pattern too.** The issue framed this around the markdown renderers, but a control sequence is zero-width, so counting it as visible columns was a table-alignment bug of the same family. It only bites on data-borne sequences, same as the markdown case. Happy to split that back out if you'd rather keep this PR to the markdown surface.

## Empirical output

`pad item deps TASK-5 --format markdown`:

```markdown
# Dependencies for TASK-5 Ship the follow-up

## Blocks

- TASK-9 Docs refresh

## Blocked by

_none_
```

`pad item comments TASK-5 --format markdown` (note the body's own markdown surviving intact):

```markdown
**Dave (dave@example.com)** · just now via cli

Confirmed on Linux:

- build green
- `role list | wc -l` unchanged
```

`pad role list --format markdown`:

| Slug | Name | Description | Tools | Items |
| --- | --- | --- | --- | --- |
| implementer | 🔧 Implementer | Writes code, builds features | edit,bash | 12 |

`pad project activity --format markdown`:

| When | Actor | Action | Item | Changes |
| --- | --- | --- | --- | --- |
| 2026-08-11 09:14 | Claude | updated | TASK-440 Markdown follow-up | status: ready → done |

`library list` gets a `# Conventions` / `# Playbooks` heading with a `## category` heading and table per category; `workspace members` gets the member table plus a `## Pending invitations` table when there are any.

## How to test

1. `go test ./internal/cli/ ./cmd/pad/ -run 'Markdown|StripANSI|DisplayWidth' -count=1`
2. `pad item comments <ref> --format markdown` — confirm a body containing a list or a fenced block renders as markdown, not escaped text
3. `pad item deps <ref> --format markdown`, `pad project activity --format markdown`, `pad role list --format markdown`, `pad workspace members --format markdown`, `pad attachment list --format markdown`, `pad library list --format markdown`
4. `pad --help | grep format` — now just `table, json, markdown`
5. Non-SGR check: store a title containing `ESC[2K` and confirm it neither appears in markdown output nor misaligns the table

## Gate results

- `go build ./...` — PASS
- `go vet ./cmd/pad ./internal/cli` — PASS
- `gofmt -l` — clean
- `golangci-lint run ./internal/cli/... ./cmd/pad/...` — PASS (0 issues)
- New tests — 12 ANSI-stripping cases, 4 table-helper cases (including ragged rows), 4 renderer cases for the two non-tabular surfaces, and the routing test extended to **8 subtests, one per surface**, each driven through cobra against an httptest server. That covers the two gaps you named in #1076: `item starred` and the scoped `item list <collection>` path.
- Every new guard was proven by mutating the source and watching it fail, rather than trusting a test that passed first time.

## Checklist

- [ ] `make build` — not run; needs the generated `web/build` embed assets. `go build ./...` passes.
- [ ] `make test` — both touched packages show the same 6+2 pre-existing Windows failures as clean `main` under an identical sandboxed run (6 credential/HOME in `internal/cli`, `TestWriteFileAtomic_WritesContent` + `TestHeadlessSetupNoTokenFileOK` in `cmd/pad`).
- [x] New features have tests
- [x] TypeScript types updated — N/A, CLI-only
- [x] CLI help text updated — the `--format` flag help

Closes #898. Closes #1076.