### PR TITLE
feat(server,cli): watches, user-scoped event stream, plugin monitor command — PLAN-2469 Phase 1 (TASK-2533)

### DIFF
--- a/cmd/pad/cmd_server.go
+++ b/cmd/pad/cmd_server.go
@@ -35,6 +35,7 @@ import (
 	oauthpkg "github.com/PerpetualSoftware/pad/internal/oauth"
 	"github.com/PerpetualSoftware/pad/internal/server"
 	"github.com/PerpetualSoftware/pad/internal/store"
+	"github.com/PerpetualSoftware/pad/internal/watchevents"
 	"github.com/PerpetualSoftware/pad/internal/webhooks"
 	"github.com/google/uuid"
 	mcptransport "github.com/mark3labs/mcp-go/server"
@@ -653,6 +654,13 @@ func serveCmd() *cobra.Command {
 			// Wrap event bus with Prometheus instrumentation
 			eventBus = metrics.NewInstrumentedBus(eventBus, m)
 			srv.SetEventBus(eventBus)
+
+			// Watch/nudge notification bus (TASK-2533). In-process only —
+			// see internal/watchevents' package doc comment for the
+			// single-process/multi-instance limitation. No Redis-backed
+			// implementation exists yet, so this is unconditional (unlike
+			// eventBus above, which branches on PAD_REDIS_URL).
+			srv.SetWatchEventsBus(watchevents.New())
 
 			// Yjs collab room manager (PLAN-1248). Single-instance only
 			// today; multi-replica fanout via Redis is a deferred IDEA.

--- a/cmd/pad/cmd_session.go
+++ b/cmd/pad/cmd_session.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/PerpetualSoftware/pad/internal/cli"
+)
+
+// sessionCmd groups session-registry commands (TASK-2533).
+func sessionCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "session",
+		Short: "Manage this machine's on-disk pad session registry",
+		RunE:  unknownSubcommandRun,
+	}
+	cmd.AddCommand(sessionRegisterCmd())
+	return cmd
+}
+
+// sessionRegisterCmd registers the CURRENT process in the on-disk
+// session registry (~/.pad/sessions/<pid>.json). See
+// internal/cli/session_registry.go's package doc comment for what this
+// is for and — as important — what it is NOT for yet: Phase 1's nudge
+// delivery (the plugin monitor) needs no session registry at all; this
+// is forward-looking infra for Phase 3's live-sessions/presence surface
+// (IDEA-2464).
+func sessionRegisterCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "register",
+		Short: "Register this session in the local pad session registry",
+		Long: `Records this process's pid, working directory, and (when running inside a
+Claude Code session) the CLAUDE_CODE_MESSAGING_SOCKET path to
+~/.pad/sessions/<pid>.json.
+
+Safe to call from any directory — it does not require a linked
+workspace (.pad.toml) — and safe to call more than once per session
+(each call overwrites this pid's record with a fresh timestamp).`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cwd, err := os.Getwd()
+			if err != nil {
+				return fmt.Errorf("get working directory: %w", err)
+			}
+			socketPath := os.Getenv("CLAUDE_CODE_MESSAGING_SOCKET")
+
+			path, err := cli.RegisterSession(cwd, socketPath)
+			if err != nil {
+				return fmt.Errorf("register session: %w", err)
+			}
+
+			if formatFlag == "json" {
+				return cli.PrintJSON(map[string]string{
+					"path": path,
+					"cwd":  cwd,
+				})
+			}
+			fmt.Printf("Registered session (pid %d) at %s\n", os.Getpid(), path)
+			return nil
+		},
+	}
+}

--- a/cmd/pad/cmd_watch.go
+++ b/cmd/pad/cmd_watch.go
@@ -16,6 +16,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/PerpetualSoftware/pad/internal/cli"
+	"github.com/PerpetualSoftware/pad/internal/config"
 )
 
 // noPadTomlRetryInterval is how long `pad watch --stream --for-session`
@@ -233,20 +234,65 @@ func watchRemoveCmd() *cobra.Command {
 	}
 }
 
+// monitorClient builds a Client for the monitor loop WITHOUT any of
+// getClient()'s side effects that are fatal (or interactive) for an
+// unattended background process (codex round 1 finding 5):
+// getConfiguredConfig() calls os.Exit(1) when the client isn't
+// configured and stdin isn't a TTY, or — worse, when a TTY IS attached —
+// launches an INTERACTIVE configuration wizard that blocks on stdin and
+// prints prose to stdout. Either behavior directly violates DOC-2479's
+// silent-start contract, which requires "not ready yet" to be a silent
+// retry, never a crash or a prompt.
+//
+// This reads config.toml + the directory's .pad.toml override the same
+// way getConfiguredConfig does, but treats "not configured" as a plain
+// returned error the caller can retry on instead of exiting. EnsureServer
+// (local-mode auto-start of the background padd process — the same
+// thing every other `pad` command does transparently on first use) is
+// still called, but its failure is likewise a plain error, not an exit.
+//
+// The ONLY genuinely unrecoverable state left is config.Load() failing
+// (e.g. ~/.pad is unwritable/permission-denied) — that's a broken-
+// machine condition no retry will fix, and it is the ONE case this
+// function still surfaces as an actual Go error up to the loop below,
+// which folds it into the same silent backoff-and-retry as every other
+// failure rather than exiting even then: an unattended monitor should
+// never terminate itself over a condition an operator might fix without
+// restarting the whole Claude Code session.
+func monitorClient() (*cli.Client, error) {
+	cfg, err := config.Load()
+	if err != nil {
+		return nil, fmt.Errorf("load config: %w", err)
+	}
+	applyPadTomlOverride(cfg)
+	if !cfg.IsConfigured() {
+		return nil, fmt.Errorf("pad is not configured")
+	}
+	if err := cli.EnsureServer(cfg); err != nil {
+		return nil, fmt.Errorf("ensure server: %w", err)
+	}
+	return cli.NewClientFromURL(cfg.BaseURL()), nil
+}
+
 // runWatchMonitor is `pad watch --stream --for-session`'s main loop.
 // Implements DOC-2479's silent-start contract exactly:
 //   - no .pad.toml anywhere in the directory tree → sleep an hour,
 //     retry, print NOTHING (exiting would end the monitor process the
 //     plugin auto-started).
-//   - padd unreachable (dial failure, non-200, or the stream drops
-//     mid-read) → backoff-retry, print NOTHING.
+//   - client unconfigured, local server won't start, or padd otherwise
+//     unreachable (dial failure, non-200, or the stream drops mid-read)
+//     → backoff-retry, print NOTHING. See monitorClient's doc comment
+//     for exactly which conditions this folds into "unreachable" rather
+//     than treating as fatal.
 //   - a matching event → exactly one stdout line, formatMonitorLine.
 //
 // Runs until ctx is cancelled (Ctrl+C / SIGTERM) or, on the initial
-// call from Cobra's cmd.Context(), forever.
+// call from Cobra's cmd.Context(), forever. The .pad.toml check and
+// client construction both run INSIDE the loop, every iteration —
+// deliberately not hoisted above it — so a workspace linked or a padd
+// brought up mid-session is picked up on the next retry without a
+// process restart.
 func runWatchMonitor(ctx context.Context) error {
-	client, _ := getClient()
-
 	sigCtx, stop := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
@@ -264,6 +310,15 @@ func runWatchMonitor(ctx context.Context) error {
 			// directory can gain a .pad.toml later (pad workspace init
 			// run mid-session), so keep polling rather than exiting.
 			if !sleepOrDone(sigCtx, noPadTomlRetryInterval) {
+				return nil
+			}
+			continue
+		}
+
+		client, err := monitorClient()
+		if err != nil {
+			attempt++
+			if !sleepOrDone(sigCtx, padddBackoff(attempt)) {
 				return nil
 			}
 			continue
@@ -325,6 +380,17 @@ func runWatchMonitor(ctx context.Context) error {
 // formatMonitorLine for each "notification" event, until the body is
 // exhausted (connection closed) or a read error occurs. Returns the
 // last-seen event ID for Last-Event-ID resume on reconnect.
+//
+// On "sync_required" (the server's signal that the requested
+// Last-Event-ID has been evicted from its replay buffer — TASK-2533
+// codex round 1 finding 6), this CLEARS the returned cursor rather than
+// leaving it at the stale value. Without this, the caller's next
+// reconnect would resend the SAME stale Last-Event-ID, the server would
+// respond sync_required again, forever — an unrecoverable resume loop
+// that only a process restart could break. Clearing it makes the next
+// reconnect a fresh (non-resuming) subscription instead, which is
+// exactly what sync_required is telling the caller to do: the gap is
+// too large to replay, stop trying.
 func streamWatchEvents(resp *http.Response, lastEventID string) string {
 	scanner := bufio.NewScanner(resp.Body)
 	var eventType, data string
@@ -338,11 +404,16 @@ func streamWatchEvents(resp *http.Response, lastEventID string) string {
 		case strings.HasPrefix(line, "data: "):
 			data = strings.TrimPrefix(line, "data: ")
 		case line == "":
-			if eventType == "notification" && data != "" {
-				var payload watchStreamPayload
-				if err := json.Unmarshal([]byte(data), &payload); err == nil {
-					fmt.Println(formatMonitorLine(payload))
+			switch eventType {
+			case "notification":
+				if data != "" {
+					var payload watchStreamPayload
+					if err := json.Unmarshal([]byte(data), &payload); err == nil {
+						fmt.Println(formatMonitorLine(payload))
+					}
 				}
+			case "sync_required":
+				lastEventID = ""
 			}
 			eventType, data = "", ""
 		}

--- a/cmd/pad/cmd_watch.go
+++ b/cmd/pad/cmd_watch.go
@@ -1,0 +1,351 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"text/tabwriter"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/PerpetualSoftware/pad/internal/cli"
+)
+
+// noPadTomlRetryInterval is how long `pad watch --stream --for-session`
+// sleeps before re-checking for a .pad.toml when none was found in the
+// directory tree — DOC-2479's silent-start contract: "no .pad.toml in
+// tree → sleep-retry hourly, print nothing".
+const noPadTomlRetryInterval = time.Hour
+
+// padddBackoffBase / padddBackoffCap bound the retry delay when padd is
+// unreachable (connection refused, non-200, or the stream drops
+// mid-read). DOC-2479 distinguishes this from the no-workspace case
+// above ("padd unreachable → backoff retry, print nothing") — a
+// persistently-down padd shouldn't hot-loop, but shouldn't make the
+// caller wait a full hour either, unlike the no-.pad.toml case where an
+// hour is the right cadence for "nothing to do until a workspace shows
+// up".
+const (
+	padddBackoffBase = 5 * time.Second
+	padddBackoffCap  = 5 * time.Minute
+)
+
+// padddBackoff computes the delay before the Nth reconnect attempt
+// (attempt=1 is the first retry after an initial failed connection).
+// Linear and capped — extracted as a pure function so the retry math is
+// unit-testable without a real clock (per the dispatcher's ask: "unit-
+// test the decision logic, don't literally sleep").
+func padddBackoff(attempt int) time.Duration {
+	if attempt < 1 {
+		attempt = 1
+	}
+	d := time.Duration(attempt) * padddBackoffBase
+	if d > padddBackoffCap {
+		d = padddBackoffCap
+	}
+	return d
+}
+
+// watchStreamPayload mirrors server.watchEventPayload — the wire shape
+// of GET /api/v1/events/stream's "notification" events (DOC-2479):
+// {id, ts, workspace, item_ref, kind, actor, summary}.
+type watchStreamPayload struct {
+	ID        int64  `json:"id"`
+	Ts        int64  `json:"ts"`
+	Workspace string `json:"workspace"`
+	ItemRef   string `json:"item_ref"`
+	Kind      string `json:"kind"`
+	Actor     string `json:"actor"`
+	Summary   string `json:"summary"`
+}
+
+// formatMonitorLine renders one notification as the exact stdout-line
+// contract `pad watch --stream --for-session` promises (DOC-2479):
+// "PAD TASK-214 → done (Dave): fix verified" — one line, facts only, no
+// etiquette prose (that lives in the plugin skill per DR-4).
+//
+// TASK-2533 plan interpretation: DOC-2479's example names a target
+// STATUS VALUE and reads as though it combines two facts (a status
+// change AND an attached comment) into one line. This system publishes
+// one notification per fact (see server.publishWatchNotifications'
+// producer-coverage audit) rather than inventing a combining mechanism
+// DOC-2479 doesn't specify a wire shape for, so a
+// `pad item update --field status=done --comment "..."` call surfaces
+// as TWO lines here, and this formatter uses the notification's kind
+// (not a status value) as the arrow's target — it's the one thing every
+// kind (status-change / assignment / comment / the reserved ask) can
+// supply uniformly from the actual payload fields.
+func formatMonitorLine(p watchStreamPayload) string {
+	return fmt.Sprintf("PAD %s → %s (%s): %s", p.ItemRef, p.Kind, p.Actor, p.Summary)
+}
+
+// sleepOrDone waits for d or ctx cancellation, whichever comes first.
+// Returns false if ctx was cancelled — the caller should stop looping,
+// not schedule another retry, when that happens (Ctrl+C / SIGTERM
+// during a silent-retry wait must exit promptly, not after the full
+// interval).
+func sleepOrDone(ctx context.Context, d time.Duration) bool {
+	select {
+	case <-time.After(d):
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+// watchCmdGroup is `pad watch` (TASK-2533). Named ...Group, not watchCmd,
+// because that identifier is already taken by `pad project watch`
+// (cmd_project.go) — a different, pre-existing command that streams a
+// whole workspace's activity feed for a human terminal. This command is
+// per-item and user-scoped; the two are unrelated beyond sharing the
+// English verb "watch".
+func watchCmdGroup() *cobra.Command {
+	var untilPredicate string
+	var stream bool
+	var forSession bool
+
+	cmd := &cobra.Command{
+		Use:   "watch [ref]",
+		Short: "Create a durable watch on an item, or run the session-monitor stream",
+		Long: `pad watch <ref>
+    Create (or update) a durable, server-side watch on an item. Watches
+    survive monitor restarts and padd restarts — they are not client-side
+    state.
+
+pad watch <ref> --until status=X
+    Same, but the item only notifies once its status-equivalent field
+    reaches X (an unconditional watch, the default, notifies on every
+    status-change / assignment / comment on the item).
+
+pad watch list
+    List your active watches, across every workspace you belong to.
+
+pad watch remove <ref>
+    Stop watching an item.
+
+pad watch --stream --for-session
+    The plugin monitor command (see monitors/monitors.json). Prints one
+    line per matching event to stdout in a fixed, machine-readable
+    format. Silent on startup when no workspace is linked or padd is
+    unreachable — see the DOC-2479 behavior contract in this command's
+    source. Not meant to be run by hand; the pad plugin's monitor entry
+    invokes it.`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if stream || forSession {
+				if !stream || !forSession {
+					return fmt.Errorf("--stream and --for-session must be used together")
+				}
+				if len(args) > 0 {
+					return fmt.Errorf("--stream --for-session does not take a ref argument")
+				}
+				return runWatchMonitor(cmd.Context())
+			}
+			if len(args) != 1 {
+				return cmd.Help()
+			}
+			return runCreateWatch(args[0], untilPredicate)
+		},
+	}
+
+	cmd.Flags().StringVar(&untilPredicate, "until", "", `optional predicate, e.g. --until status=done`)
+	cmd.Flags().BoolVar(&stream, "stream", false, "run the session-monitor stream (requires --for-session)")
+	cmd.Flags().BoolVar(&forSession, "for-session", false, "format output for the Claude Code plugin monitor (requires --stream)")
+
+	cmd.AddCommand(watchListCmd(), watchRemoveCmd())
+	return cmd
+}
+
+func runCreateWatch(ref, predicate string) error {
+	client, _ := getClient()
+	ws := getWorkspace()
+
+	w, err := client.CreateWatch(ws, ref, predicate)
+	if err != nil {
+		return err
+	}
+
+	if formatFlag == "json" {
+		return cli.PrintJSON(w)
+	}
+	if predicate != "" {
+		fmt.Printf("Watching %s until %s\n", w.ItemRef, predicate)
+	} else {
+		fmt.Printf("Watching %s\n", w.ItemRef)
+	}
+	return nil
+}
+
+func watchListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List your active watches",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, _ := getClient()
+			watches, err := client.ListWatches()
+			if err != nil {
+				return err
+			}
+
+			if formatFlag == "json" {
+				return cli.PrintJSON(watches)
+			}
+			if len(watches) == 0 {
+				fmt.Println("No active watches.")
+				return nil
+			}
+
+			tw := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+			fmt.Fprintln(tw, "REF\tWORKSPACE\tTITLE\tPREDICATE")
+			for _, w := range watches {
+				predicate := w.Predicate
+				if predicate == "" {
+					predicate = "-"
+				}
+				fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", w.ItemRef, w.WorkspaceSlug, w.ItemTitle, predicate)
+			}
+			return tw.Flush()
+		},
+	}
+}
+
+func watchRemoveCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "remove <ref>",
+		Short: "Stop watching an item",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, _ := getClient()
+			ws := getWorkspace()
+			if err := client.DeleteWatch(ws, args[0]); err != nil {
+				return err
+			}
+			fmt.Printf("Stopped watching %s\n", args[0])
+			return nil
+		},
+	}
+}
+
+// runWatchMonitor is `pad watch --stream --for-session`'s main loop.
+// Implements DOC-2479's silent-start contract exactly:
+//   - no .pad.toml anywhere in the directory tree → sleep an hour,
+//     retry, print NOTHING (exiting would end the monitor process the
+//     plugin auto-started).
+//   - padd unreachable (dial failure, non-200, or the stream drops
+//     mid-read) → backoff-retry, print NOTHING.
+//   - a matching event → exactly one stdout line, formatMonitorLine.
+//
+// Runs until ctx is cancelled (Ctrl+C / SIGTERM) or, on the initial
+// call from Cobra's cmd.Context(), forever.
+func runWatchMonitor(ctx context.Context) error {
+	client, _ := getClient()
+
+	sigCtx, stop := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	var lastEventID string
+	attempt := 0
+
+	for {
+		if sigCtx.Err() != nil {
+			return nil
+		}
+
+		pt, _ := cli.LoadPadToml()
+		if pt == nil {
+			// Silent: no workspace linked anywhere above cwd. A
+			// directory can gain a .pad.toml later (pad workspace init
+			// run mid-session), so keep polling rather than exiting.
+			if !sleepOrDone(sigCtx, noPadTomlRetryInterval) {
+				return nil
+			}
+			continue
+		}
+
+		req, err := client.NewWatchEventsStreamRequest(sigCtx, lastEventID)
+		if err != nil {
+			attempt++
+			if !sleepOrDone(sigCtx, padddBackoff(attempt)) {
+				return nil
+			}
+			continue
+		}
+
+		// No timeout: an SSE connection is meant to stay open for the
+		// life of the monitor process. Deliberately a fresh client, not
+		// client.streamClient (1h cap) or the Client's default 10s
+		// client — see NewWatchEventsStreamRequest's doc comment.
+		httpClient := &http.Client{}
+		resp, err := httpClient.Do(req)
+		if err != nil {
+			if sigCtx.Err() != nil {
+				return nil
+			}
+			attempt++
+			if !sleepOrDone(sigCtx, padddBackoff(attempt)) {
+				return nil
+			}
+			continue
+		}
+		if resp.StatusCode != http.StatusOK {
+			resp.Body.Close()
+			attempt++
+			if !sleepOrDone(sigCtx, padddBackoff(attempt)) {
+				return nil
+			}
+			continue
+		}
+
+		attempt = 0 // connected — reset backoff for the NEXT disconnect
+		lastEventID = streamWatchEvents(resp, lastEventID)
+		resp.Body.Close()
+
+		if sigCtx.Err() != nil {
+			return nil
+		}
+		// The stream ended (server closed it, network blip, padd
+		// restart). Last-Event-ID (captured in streamWatchEvents)
+		// resumes from here — no re-delivery, no gap silently
+		// swallowed beyond the replay buffer's own bounds.
+		attempt++
+		if !sleepOrDone(sigCtx, padddBackoff(attempt)) {
+			return nil
+		}
+	}
+}
+
+// streamWatchEvents reads SSE lines from an open connection, printing
+// formatMonitorLine for each "notification" event, until the body is
+// exhausted (connection closed) or a read error occurs. Returns the
+// last-seen event ID for Last-Event-ID resume on reconnect.
+func streamWatchEvents(resp *http.Response, lastEventID string) string {
+	scanner := bufio.NewScanner(resp.Body)
+	var eventType, data string
+	for scanner.Scan() {
+		line := scanner.Text()
+		switch {
+		case strings.HasPrefix(line, "id: "):
+			lastEventID = strings.TrimPrefix(line, "id: ")
+		case strings.HasPrefix(line, "event: "):
+			eventType = strings.TrimPrefix(line, "event: ")
+		case strings.HasPrefix(line, "data: "):
+			data = strings.TrimPrefix(line, "data: ")
+		case line == "":
+			if eventType == "notification" && data != "" {
+				var payload watchStreamPayload
+				if err := json.Unmarshal([]byte(data), &payload); err == nil {
+					fmt.Println(formatMonitorLine(payload))
+				}
+			}
+			eventType, data = "", ""
+		}
+	}
+	return lastEventID
+}

--- a/cmd/pad/cmd_watch_test.go
+++ b/cmd/pad/cmd_watch_test.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fakeSSEResponse wraps a raw SSE body string in an *http.Response
+// shaped enough for streamWatchEvents to read (it only touches .Body).
+func fakeSSEResponse(body string) *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
+// TestPadddBackoff_MonotonicUntilCap asserts the backoff grows with each
+// attempt and is capped — the decision logic behind "padd unreachable →
+// backoff retry, print nothing" (DOC-2479), unit-tested per the
+// dispatcher's ask instead of literally sleeping.
+func TestPadddBackoff_MonotonicUntilCap(t *testing.T) {
+	prev := time.Duration(0)
+	for attempt := 1; attempt <= 200; attempt++ {
+		d := padddBackoff(attempt)
+		if d < prev {
+			t.Fatalf("attempt %d: backoff %v is less than previous %v — expected non-decreasing", attempt, d, prev)
+		}
+		if d > padddBackoffCap {
+			t.Fatalf("attempt %d: backoff %v exceeds cap %v", attempt, d, padddBackoffCap)
+		}
+		prev = d
+	}
+	if got := padddBackoff(1000); got != padddBackoffCap {
+		t.Fatalf("expected a large attempt count to saturate at the cap %v, got %v", padddBackoffCap, got)
+	}
+}
+
+func TestPadddBackoff_NonPositiveAttemptTreatedAsFirst(t *testing.T) {
+	if got, want := padddBackoff(0), padddBackoff(1); got != want {
+		t.Fatalf("padddBackoff(0) = %v, want padddBackoff(1) = %v", got, want)
+	}
+	if got, want := padddBackoff(-5), padddBackoff(1); got != want {
+		t.Fatalf("padddBackoff(-5) = %v, want padddBackoff(1) = %v", got, want)
+	}
+}
+
+func TestNoPadTomlRetryInterval_IsAnHour(t *testing.T) {
+	// Pinned as an explicit assertion (not just "compiles") so a future
+	// edit to the constant fails a test, not just silently changes
+	// DOC-2479's specified cadence.
+	if noPadTomlRetryInterval != time.Hour {
+		t.Fatalf("expected the no-.pad.toml retry interval to be exactly 1 hour (DOC-2479), got %v", noPadTomlRetryInterval)
+	}
+}
+
+func TestFormatMonitorLine(t *testing.T) {
+	cases := []struct {
+		name string
+		in   watchStreamPayload
+		want string
+	}{
+		{
+			name: "status change",
+			in:   watchStreamPayload{ItemRef: "TASK-214", Kind: "status-change", Actor: "Dave", Summary: "open → done"},
+			want: "PAD TASK-214 → status-change (Dave): open → done",
+		},
+		{
+			name: "assignment",
+			in:   watchStreamPayload{ItemRef: "BUG-5", Kind: "assignment", Actor: "Alice", Summary: "assigned to Alice"},
+			want: "PAD BUG-5 → assignment (Alice): assigned to Alice",
+		},
+		{
+			name: "comment",
+			in:   watchStreamPayload{ItemRef: "TASK-1", Kind: "comment", Actor: "Bob", Summary: "fix verified"},
+			want: "PAD TASK-1 → comment (Bob): fix verified",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := formatMonitorLine(c.in); got != c.want {
+				t.Errorf("formatMonitorLine(%+v) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+func TestSleepOrDone_ReturnsTrueWhenDurationElapses(t *testing.T) {
+	ctx := context.Background()
+	if !sleepOrDone(ctx, time.Millisecond) {
+		t.Fatal("expected sleepOrDone to return true when the duration elapses uninterrupted")
+	}
+}
+
+func TestSleepOrDone_ReturnsFalseWhenCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if sleepOrDone(ctx, time.Hour) {
+		t.Fatal("expected sleepOrDone to return false immediately for an already-cancelled context")
+	}
+}
+
+func TestStreamWatchEvents_ParsesNotificationsAndTracksLastEventID(t *testing.T) {
+	body := "id: 1\nevent: connected\ndata: {\"user_id\":\"u1\"}\n\n" +
+		"id: 2\nevent: notification\ndata: {\"item_ref\":\"TASK-1\",\"kind\":\"comment\",\"actor\":\"Dave\",\"summary\":\"looks good\"}\n\n" +
+		"id: 3\nevent: notification\ndata: {\"item_ref\":\"TASK-2\",\"kind\":\"status-change\",\"actor\":\"Dave\",\"summary\":\"open → done\"}\n\n"
+
+	resp := fakeSSEResponse(body)
+	lastID := streamWatchEvents(resp, "")
+	if lastID != "3" {
+		t.Fatalf("expected lastEventID to track the final id, got %q", lastID)
+	}
+}

--- a/cmd/pad/cmd_watch_test.go
+++ b/cmd/pad/cmd_watch_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/cli"
 )
 
 // fakeSSEResponse wraps a raw SSE body string in an *http.Response
@@ -103,6 +105,90 @@ func TestSleepOrDone_ReturnsFalseWhenCancelled(t *testing.T) {
 	}
 }
 
+// TestMonitorClient_UnconfiguredReturnsError covers codex round 1
+// finding 5's core regression: monitorClient must return a plain error
+// for an unconfigured environment, never call os.Exit (this test
+// process completing at all, rather than terminating early, is the
+// proof) and never block waiting for interactive input — unlike
+// getClient()/getConfiguredConfig(), which do both.
+func TestMonitorClient_UnconfiguredReturnsError(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("PAD_URL", "")
+	t.Setenv("PAD_MODE", "")
+	t.Chdir(t.TempDir()) // no .pad.toml above this directory
+
+	_, err := monitorClient()
+	if err == nil {
+		t.Fatal("expected an error for an unconfigured client, got nil")
+	}
+}
+
+// TestRunWatchMonitor_NoPadToml_RespectsCancellation verifies the
+// no-.pad.toml silent-retry path (which sleeps for
+// noPadTomlRetryInterval — an hour) still returns promptly when the
+// context is cancelled, WITHOUT ever reaching client construction
+// (there is no configured client in this test's environment at all —
+// if the loop attempted to build one before the .pad.toml check, per
+// finding 5, it would have to do so via a path that can only return an
+// error or block; since this test provably completes quickly, neither
+// happened).
+func TestRunWatchMonitor_NoPadToml_RespectsCancellation(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Chdir(t.TempDir()) // no .pad.toml above this directory
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- runWatchMonitor(ctx) }()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("expected nil error on cancellation, got %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("runWatchMonitor did not return within 3s of context cancellation (still waiting on the 1h no-.pad.toml sleep?)")
+	}
+}
+
+// TestRunWatchMonitor_PadTomlPresentButUnconfigured_RespectsCancellation
+// covers the ordering fix directly: a .pad.toml IS present (so the
+// no-workspace gate passes) but the client is unconfigured (no global
+// config.toml, no URL override in this .pad.toml) — monitorClient must
+// return a plain error that the loop folds into the backoff-retry path,
+// not an os.Exit or a blocked prompt. Proven the same way: the goroutine
+// returns promptly once the context is cancelled.
+func TestRunWatchMonitor_PadTomlPresentButUnconfigured_RespectsCancellation(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("PAD_URL", "")
+	t.Setenv("PAD_MODE", "")
+
+	workDir := t.TempDir()
+	t.Chdir(workDir)
+	if err := cli.WriteWorkspaceLink(workDir, "test-ws", ""); err != nil {
+		t.Fatalf("WriteWorkspaceLink: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- runWatchMonitor(ctx) }()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("expected nil error on cancellation, got %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("runWatchMonitor did not return within 3s of context cancellation")
+	}
+}
+
 func TestStreamWatchEvents_ParsesNotificationsAndTracksLastEventID(t *testing.T) {
 	body := "id: 1\nevent: connected\ndata: {\"user_id\":\"u1\"}\n\n" +
 		"id: 2\nevent: notification\ndata: {\"item_ref\":\"TASK-1\",\"kind\":\"comment\",\"actor\":\"Dave\",\"summary\":\"looks good\"}\n\n" +
@@ -112,5 +198,36 @@ func TestStreamWatchEvents_ParsesNotificationsAndTracksLastEventID(t *testing.T)
 	lastID := streamWatchEvents(resp, "")
 	if lastID != "3" {
 		t.Fatalf("expected lastEventID to track the final id, got %q", lastID)
+	}
+}
+
+// TestStreamWatchEvents_SyncRequiredClearsLastEventID covers codex
+// round 1 finding 6: without this, a stale Last-Event-ID would be
+// resent on every reconnect after the server's replay buffer evicted
+// it, producing sync_required forever. sync_required carries no "id:"
+// line (server writes it with eventID=0), matching real wire behavior.
+func TestStreamWatchEvents_SyncRequiredClearsLastEventID(t *testing.T) {
+	body := "event: sync_required\ndata: {\"reason\":\"gap too large\"}\n\n"
+
+	resp := fakeSSEResponse(body)
+	lastID := streamWatchEvents(resp, "42") // resuming from a stale cursor
+	if lastID != "" {
+		t.Fatalf("expected sync_required to clear the cursor, got %q", lastID)
+	}
+}
+
+// TestStreamWatchEvents_SyncRequiredThenFreshNotification verifies the
+// cursor stays cleared through sync_required but a notification
+// arriving afterward on the SAME connection still updates it normally —
+// sync_required only resets the resume point, it doesn't disable
+// tracking for the rest of the stream.
+func TestStreamWatchEvents_SyncRequiredThenFreshNotification(t *testing.T) {
+	body := "event: sync_required\ndata: {\"reason\":\"gap too large\"}\n\n" +
+		"id: 99\nevent: notification\ndata: {\"item_ref\":\"TASK-9\",\"kind\":\"comment\",\"actor\":\"Dave\",\"summary\":\"hi\"}\n\n"
+
+	resp := fakeSSEResponse(body)
+	lastID := streamWatchEvents(resp, "42")
+	if lastID != "99" {
+		t.Fatalf("expected the post-sync_required notification's id to be tracked, got %q", lastID)
 	}
 }

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -147,6 +147,8 @@ func newRootCmd() *cobra.Command {
 		mcpCmd(),
 		bootstrapCmd(),
 		playbookCmd(),
+		watchCmdGroup(),
+		sessionCmd(),
 	)
 
 	rootCmd.SetHelpCommand(helpCmd())

--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -313,6 +314,54 @@ func (c *Client) ListStarredItems(wsSlug string, includeTerminal bool) ([]models
 		path += "?include_terminal=true"
 	}
 	return result, c.get(path, &result)
+}
+
+// CreateWatch creates (or replaces the predicate on) a durable watch for
+// the current user on an item (TASK-2533). predicate is the raw
+// `--until field=value` string, or "" for an unconditional watch.
+func (c *Client) CreateWatch(wsSlug, itemSlug, predicate string) (*models.Watch, error) {
+	var body interface{}
+	if predicate != "" {
+		body = map[string]string{"predicate": predicate}
+	}
+	var result models.Watch
+	return &result, c.post("/workspaces/"+wsSlug+"/items/"+itemSlug+"/watch", body, &result)
+}
+
+// DeleteWatch removes the current user's watch on an item.
+func (c *Client) DeleteWatch(wsSlug, itemSlug string) error {
+	return c.delete("/workspaces/" + wsSlug + "/items/" + itemSlug + "/watch")
+}
+
+// ListWatches returns every watch the current user holds, across all
+// workspaces they belong to (TASK-2533 — a watch is personal, not
+// workspace-scoped; see Store.ListWatchesForUser's doc comment).
+func (c *Client) ListWatches() ([]models.Watch, error) {
+	var result []models.Watch
+	return result, c.get("/watches", &result)
+}
+
+// NewWatchEventsStreamRequest builds an authenticated GET request for
+// GET /api/v1/events/stream (TASK-2533), used by
+// `pad watch --stream --for-session`. Deliberately returns the request
+// rather than doing the round trip itself: an SSE connection is meant to
+// stay open for a whole session, and both c.httpClient (10s timeout) and
+// c.streamClient (1h timeout, sized for bundle transfers) would
+// eventually kill it — the caller must supply its own zero-timeout
+// http.Client. lastEventID, when non-empty, is sent as Last-Event-ID for
+// resume.
+func (c *Client) NewWatchEventsStreamRequest(ctx context.Context, lastEventID string) (*http.Request, error) {
+	req, err := c.newRequest("GET", "/events/stream", nil)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	req.Header.Set("Accept", "text/event-stream")
+	req.Header.Set("Cache-Control", "no-cache")
+	if lastEventID != "" {
+		req.Header.Set("Last-Event-ID", lastEventID)
+	}
+	return req, nil
 }
 
 func (c *Client) MoveItem(wsSlug, itemSlug string, input map[string]any) (*models.Item, error) {

--- a/internal/cli/session_registry.go
+++ b/internal/cli/session_registry.go
@@ -1,0 +1,85 @@
+package cli
+
+// On-disk session registry (TASK-2533, per IDEA-2465's recon comments).
+//
+// Forward-looking infra: Phase 1's nudge delivery ended up being plugin
+// monitors (stdout lines the Claude Code harness delivers directly to
+// the owning session), which need no session registry at all — the
+// earlier messaging-socket-based delivery path this registry was
+// originally scoped for was abandoned (see IDEA-2465's recon comments,
+// "socket path dead"). `pad session register` remains a PLAN-2469 Phase
+// 1 deliverable anyway: it's the discovery mechanism Phase 3's
+// live-sessions/presence surface (IDEA-2464) will need, and the recon
+// that found it (CLAUDE_CODE_MESSAGING_SOCKET + cwd passively available
+// to every `pad` invocation inside a Claude Code session) is cheap to
+// capture now rather than re-derive later. Nothing consumes this
+// registry yet.
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// SessionRegistration is one running CLI session's on-disk record.
+type SessionRegistration struct {
+	PID int `json:"pid"`
+	// Cwd is the directory the session was registered from — the same
+	// signal `pad watch --stream --for-session`'s silent-start logic
+	// uses to find (or fail to find) a .pad.toml.
+	Cwd string `json:"cwd"`
+	// MessagingSocketPath is CLAUDE_CODE_MESSAGING_SOCKET's value at
+	// registration time, or "" when the process isn't running inside a
+	// Claude Code session (or the harness hasn't exported it). Presence
+	// registration doesn't require it — a bare pid+cwd is still useful
+	// for Phase 3.
+	MessagingSocketPath string `json:"messaging_socket_path,omitempty"`
+	// RegisteredAt is RFC3339 UTC.
+	RegisteredAt string `json:"registered_at"`
+}
+
+// SessionsDir returns ~/.pad/sessions, creating it if it doesn't exist.
+func SessionsDir() (string, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("get home directory: %w", err)
+	}
+	dir := filepath.Join(homeDir, ".pad", "sessions")
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return "", fmt.Errorf("create sessions directory: %w", err)
+	}
+	return dir, nil
+}
+
+// RegisterSession writes a SessionRegistration for the CURRENT process
+// (os.Getpid()) to ~/.pad/sessions/<pid>.json, mode 0600 — mirroring
+// credentials.json's permissions (this file also names a filesystem
+// path, so it deserves the same care). Re-registering the same pid
+// (e.g. a second `pad session register` call in the same session)
+// simply overwrites the file with a fresh RegisteredAt. Returns the
+// path written.
+func RegisterSession(cwd, messagingSocketPath string) (string, error) {
+	dir, err := SessionsDir()
+	if err != nil {
+		return "", err
+	}
+
+	reg := SessionRegistration{
+		PID:                 os.Getpid(),
+		Cwd:                 cwd,
+		MessagingSocketPath: messagingSocketPath,
+		RegisteredAt:        time.Now().UTC().Format(time.RFC3339),
+	}
+	data, err := json.MarshalIndent(reg, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("marshal session registration: %w", err)
+	}
+
+	path := filepath.Join(dir, fmt.Sprintf("%d.json", reg.PID))
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		return "", fmt.Errorf("write session registration: %w", err)
+	}
+	return path, nil
+}

--- a/internal/cli/session_registry_test.go
+++ b/internal/cli/session_registry_test.go
@@ -1,0 +1,108 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRegisterSession_WritesExpectedShape(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	path, err := RegisterSession("/some/project/dir", "/run/user/1000/cc-socks/123.sock")
+	if err != nil {
+		t.Fatalf("RegisterSession: %v", err)
+	}
+
+	wantPath := filepath.Join(home, ".pad", "sessions", fmt.Sprintf("%d.json", os.Getpid()))
+	if path != wantPath {
+		t.Fatalf("expected path %q, got %q", wantPath, path)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read registration file: %v", err)
+	}
+	var reg SessionRegistration
+	if err := json.Unmarshal(data, &reg); err != nil {
+		t.Fatalf("parse registration: %v", err)
+	}
+	if reg.PID != os.Getpid() {
+		t.Errorf("expected pid %d, got %d", os.Getpid(), reg.PID)
+	}
+	if reg.Cwd != "/some/project/dir" {
+		t.Errorf("expected cwd '/some/project/dir', got %q", reg.Cwd)
+	}
+	if reg.MessagingSocketPath != "/run/user/1000/cc-socks/123.sock" {
+		t.Errorf("expected messaging socket path to round-trip, got %q", reg.MessagingSocketPath)
+	}
+	if reg.RegisteredAt == "" {
+		t.Error("expected a non-empty RegisteredAt")
+	}
+}
+
+func TestRegisterSession_EmptySocketPathOmitted(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	path, err := RegisterSession("/some/dir", "")
+	if err != nil {
+		t.Fatalf("RegisterSession: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if _, ok := raw["messaging_socket_path"]; ok {
+		t.Error("expected messaging_socket_path key to be omitted when empty")
+	}
+}
+
+func TestRegisterSession_FilePermissions(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	path, err := RegisterSession("/some/dir", "")
+	if err != nil {
+		t.Fatalf("RegisterSession: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if info.Mode().Perm() != 0600 {
+		t.Errorf("expected mode 0600, got %o", info.Mode().Perm())
+	}
+}
+
+func TestRegisterSession_ReRegisterOverwrites(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	if _, err := RegisterSession("/first/dir", ""); err != nil {
+		t.Fatalf("first RegisterSession: %v", err)
+	}
+	path, err := RegisterSession("/second/dir", "")
+	if err != nil {
+		t.Fatalf("second RegisterSession: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var reg SessionRegistration
+	if err := json.Unmarshal(data, &reg); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if reg.Cwd != "/second/dir" {
+		t.Fatalf("expected re-registration to overwrite cwd, got %q", reg.Cwd)
+	}
+}

--- a/internal/models/item.go
+++ b/internal/models/item.go
@@ -99,6 +99,37 @@ type Item struct {
 	Convention          *ItemConventionMetadata  `json:"convention,omitempty"`
 	ImplementationNotes []ItemImplementationNote `json:"implementation_notes,omitempty"`
 	DecisionLog         []ItemDecisionLogEntry   `json:"decision_log,omitempty"`
+
+	// LastMutation carries the status/assignment delta that THIS specific
+	// store call (UpdateItemWithParentLink / MoveItemWithPreCheck) produced,
+	// computed synchronously inside the same transaction that already writes
+	// the canonical status_transitions row (TASK-2533). It exists so the
+	// watch-notification pipeline can classify an update's kind
+	// (status-change / assignment) from a race-free, in-tx source of truth
+	// instead of a separate before/after snapshot pair racing against
+	// concurrent writers of the same item.
+	//
+	// Nil when the update touched neither the collection's done-field nor
+	// assigned_user_id. Never persisted, never populated by GetItem or any
+	// list/search path — only the two store functions above set it, and
+	// only on the *models.Item they hand back to their caller. `json:"-"`
+	// is deliberate: this is an internal signal for one in-process
+	// consumer, not a wire contract the API is committing to.
+	LastMutation *ItemMutationSignal `json:"-"`
+}
+
+// ItemMutationSignal is the race-free status/assignment delta attached to
+// models.Item.LastMutation. See that field's doc comment for why it exists
+// and who populates it.
+type ItemMutationSignal struct {
+	StatusChanged  bool
+	StatusFieldKey string
+	FromStatus     string
+	ToStatus       string
+
+	AssignmentChanged  bool
+	FromAssignedUserID string // "" = was unassigned
+	ToAssignedUserID   string // "" = now unassigned
 }
 
 // ComputeRef sets the Ref field from CollectionPrefix and ItemNumber.

--- a/internal/models/watch.go
+++ b/internal/models/watch.go
@@ -26,4 +26,14 @@ type Watch struct {
 	ItemTitle     string `json:"item_title,omitempty"`
 	ItemSlug      string `json:"item_slug,omitempty"`
 	WorkspaceSlug string `json:"workspace_slug,omitempty"`
+	// ItemCollectionID is the watched item's collection ID (populated by
+	// the same join as the fields above). Internal-only (`json:"-"`,
+	// like models.Item.LastMutation) — not part of the wire contract,
+	// consumed only by server.filterWatchesByCurrentAccess (TASK-2533,
+	// codex round 1 finding 1) to re-check the caller's CURRENT
+	// visibility into the watched item's collection before delivering or
+	// listing a watch, so a workspace membership or grant revoked after
+	// the watch was created can't keep leaking item metadata/events
+	// through a stale row.
+	ItemCollectionID string `json:"-"`
 }

--- a/internal/models/watch.go
+++ b/internal/models/watch.go
@@ -1,0 +1,29 @@
+package models
+
+import "time"
+
+// Watch is a durable, server-side subscription created by `pad watch <ref>`
+// (TASK-2533, per DOC-2479's subscription-table design). Unlike an SSE
+// connection or a plugin-monitor process, a Watch survives both — it is the
+// thing that makes "the monitor restarts every session" not lose track of
+// what a user asked to be told about.
+type Watch struct {
+	ID          string `json:"id"`
+	WorkspaceID string `json:"workspace_id"`
+	UserID      string `json:"user_id"`
+	ItemID      string `json:"item_id"`
+	// Predicate is the raw `--until field=value` string (e.g. "status=done"),
+	// or "" for an unconditional watch that fires on any matching
+	// notification for this item. DOC-2479 specs only this single
+	// field=value grammar — no boolean combinators.
+	Predicate string    `json:"predicate,omitempty"`
+	CreatedAt time.Time `json:"created_at"`
+
+	// Populated by joins (not stored) — the CLI's `pad watch list` and
+	// the event-stream handler's summary text both want the item's
+	// human-facing identity without a second lookup.
+	ItemRef       string `json:"item_ref,omitempty"`
+	ItemTitle     string `json:"item_title,omitempty"`
+	ItemSlug      string `json:"item_slug,omitempty"`
+	WorkspaceSlug string `json:"workspace_slug,omitempty"`
+}

--- a/internal/server/handlers_comments.go
+++ b/internal/server/handlers_comments.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/PerpetualSoftware/pad/internal/events"
 	"github.com/PerpetualSoftware/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/watchevents"
 )
 
 // handleListComments returns all comments for an item.
@@ -129,7 +130,33 @@ func (s *Server) handleCreateComment(w http.ResponseWriter, r *http.Request) {
 	s.publishCommentEvent(events.CommentCreated, workspaceID, item.ID, comment.ID, item.Title, item.CollectionSlug, actor, source)
 	s.dispatchWebhook(workspaceID, "comment.created", comment)
 
+	if s.watchEvents != nil {
+		s.watchEvents.Publish(watchevents.Notification{
+			WorkspaceID: workspaceID,
+			ItemID:      item.ID,
+			ItemRef:     item.Ref,
+			Kind:        watchevents.KindComment,
+			Actor:       actor,
+			ActorName:   actorNameFromRequest(r),
+			Summary:     truncateForSummary(comment.Body, 120),
+		})
+	}
+
 	writeJSON(w, http.StatusCreated, comment)
+}
+
+// truncateForSummary shortens a comment body (or any free-text field) to
+// a single-line notification summary. Collapses newlines to spaces first
+// so a multi-paragraph comment doesn't produce a multi-line CLI nudge
+// line — `pad watch --stream --for-session`'s contract is exactly one
+// stdout line per event.
+func truncateForSummary(body string, maxLen int) string {
+	body = strings.Join(strings.Fields(body), " ")
+	r := []rune(body)
+	if len(r) <= maxLen {
+		return body
+	}
+	return string(r[:maxLen]) + "…"
 }
 
 // handleDeleteComment removes a comment.

--- a/internal/server/handlers_comments.go
+++ b/internal/server/handlers_comments.go
@@ -132,13 +132,14 @@ func (s *Server) handleCreateComment(w http.ResponseWriter, r *http.Request) {
 
 	if s.watchEvents != nil {
 		s.watchEvents.Publish(watchevents.Notification{
-			WorkspaceID: workspaceID,
-			ItemID:      item.ID,
-			ItemRef:     item.Ref,
-			Kind:        watchevents.KindComment,
-			Actor:       actor,
-			ActorName:   actorNameFromRequest(r),
-			Summary:     truncateForSummary(comment.Body, 120),
+			WorkspaceID:  workspaceID,
+			ItemID:       item.ID,
+			CollectionID: item.CollectionID,
+			ItemRef:      item.Ref,
+			Kind:         watchevents.KindComment,
+			Actor:        actor,
+			ActorName:    actorNameFromRequest(r),
+			Summary:      truncateForSummary(comment.Body, 120),
 		})
 	}
 
@@ -349,9 +350,11 @@ func (s *Server) handleCreateReply(w http.ResponseWriter, r *http.Request) {
 	// Resolve the item's collection slug for SSE filtering
 	replyCollSlug := ""
 	replyItemRef := ""
+	replyCollID := ""
 	if replyItem, err := s.store.GetItem(parentComment.ItemID); err == nil && replyItem != nil {
 		replyCollSlug = replyItem.CollectionSlug
 		replyItemRef = replyItem.Ref
+		replyCollID = replyItem.CollectionID
 	}
 	s.publishCommentEvent(events.CommentCreated, workspaceID, parentComment.ItemID, comment.ID, parentComment.ItemTitle, replyCollSlug, actor, source)
 
@@ -363,13 +366,14 @@ func (s *Server) handleCreateReply(w http.ResponseWriter, r *http.Request) {
 	// one level deeper in the thread.
 	if s.watchEvents != nil {
 		s.watchEvents.Publish(watchevents.Notification{
-			WorkspaceID: workspaceID,
-			ItemID:      parentComment.ItemID,
-			ItemRef:     replyItemRef,
-			Kind:        watchevents.KindComment,
-			Actor:       actor,
-			ActorName:   actorNameFromRequest(r),
-			Summary:     truncateForSummary(comment.Body, 120),
+			WorkspaceID:  workspaceID,
+			ItemID:       parentComment.ItemID,
+			CollectionID: replyCollID,
+			ItemRef:      replyItemRef,
+			Kind:         watchevents.KindComment,
+			Actor:        actor,
+			ActorName:    actorNameFromRequest(r),
+			Summary:      truncateForSummary(comment.Body, 120),
 		})
 	}
 

--- a/internal/server/handlers_comments.go
+++ b/internal/server/handlers_comments.go
@@ -348,10 +348,30 @@ func (s *Server) handleCreateReply(w http.ResponseWriter, r *http.Request) {
 
 	// Resolve the item's collection slug for SSE filtering
 	replyCollSlug := ""
+	replyItemRef := ""
 	if replyItem, err := s.store.GetItem(parentComment.ItemID); err == nil && replyItem != nil {
 		replyCollSlug = replyItem.CollectionSlug
+		replyItemRef = replyItem.Ref
 	}
 	s.publishCommentEvent(events.CommentCreated, workspaceID, parentComment.ItemID, comment.ID, parentComment.ItemTitle, replyCollSlug, actor, source)
+
+	// TASK-2533 (codex round 1, finding 2): a reply is a SEPARATE code
+	// path from handleCreateComment — it calls store.CreateComment
+	// directly here, not via POST .../comments — and was missing this
+	// hook entirely. Same kind=comment notification as a top-level
+	// comment; a watcher shouldn't lose replies just because they landed
+	// one level deeper in the thread.
+	if s.watchEvents != nil {
+		s.watchEvents.Publish(watchevents.Notification{
+			WorkspaceID: workspaceID,
+			ItemID:      parentComment.ItemID,
+			ItemRef:     replyItemRef,
+			Kind:        watchevents.KindComment,
+			Actor:       actor,
+			ActorName:   actorNameFromRequest(r),
+			Summary:     truncateForSummary(comment.Body, 120),
+		})
+	}
 
 	writeJSON(w, http.StatusCreated, comment)
 }

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -767,6 +767,7 @@ func (s *Server) createItemChecked(r *http.Request, workspaceID string, coll *mo
 		s.watchEvents.Publish(watchevents.Notification{
 			WorkspaceID:    workspaceID,
 			ItemID:         item.ID,
+			CollectionID:   item.CollectionID,
 			ItemRef:        item.Ref,
 			Kind:           watchevents.KindAssignment,
 			Actor:          actor,
@@ -1600,13 +1601,14 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 			// kind=comment notification as the standalone endpoint.
 			if s.watchEvents != nil {
 				s.watchEvents.Publish(watchevents.Notification{
-					WorkspaceID: workspaceID,
-					ItemID:      updated.ID,
-					ItemRef:     updated.Ref,
-					Kind:        watchevents.KindComment,
-					Actor:       actor,
-					ActorName:   actorNameForUpdate,
-					Summary:     truncateForSummary(comment.Body, 120),
+					WorkspaceID:  workspaceID,
+					ItemID:       updated.ID,
+					CollectionID: updated.CollectionID,
+					ItemRef:      updated.Ref,
+					Kind:         watchevents.KindComment,
+					Actor:        actor,
+					ActorName:    actorNameForUpdate,
+					Summary:      truncateForSummary(comment.Body, 120),
 				})
 			}
 		}

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -19,6 +19,7 @@ import (
 	"github.com/PerpetualSoftware/pad/internal/items"
 	"github.com/PerpetualSoftware/pad/internal/models"
 	"github.com/PerpetualSoftware/pad/internal/store"
+	"github.com/PerpetualSoftware/pad/internal/watchevents"
 )
 
 // errStaleCollabSnapshot signals an UnderItemLock-wrapped
@@ -749,9 +750,31 @@ func (s *Server) createItemChecked(r *http.Request, workspaceID string, coll *mo
 	}
 
 	actor, source := actorFromRequest(r)
+	actorNameForCreate := actorNameFromRequest(r)
 	s.logActivity(workspaceID, item.ID, "created", r)
-	s.publishItemEventWithName(events.ItemCreated, workspaceID, item.ID, item.Title, coll.Slug, actor, actorNameFromRequest(r), source, item.Seq)
+	s.publishItemEventWithName(events.ItemCreated, workspaceID, item.ID, item.Title, coll.Slug, actor, actorNameForCreate, source, item.Seq)
 	s.dispatchWebhook(workspaceID, "item.created", item)
+
+	// Assignment-at-creation (TASK-2533): unlike an update, a freshly
+	// created item has no "before" state to diff — LastMutation doesn't
+	// apply here — so this is a direct, unconditional check rather than
+	// a call to publishWatchNotifications.
+	if s.watchEvents != nil && item.AssignedUserID != nil && *item.AssignedUserID != "" {
+		name := item.AssignedUserName
+		if name == "" {
+			name = *item.AssignedUserID
+		}
+		s.watchEvents.Publish(watchevents.Notification{
+			WorkspaceID:    workspaceID,
+			ItemID:         item.ID,
+			ItemRef:        item.Ref,
+			Kind:           watchevents.KindAssignment,
+			Actor:          actor,
+			ActorName:      actorNameForCreate,
+			Summary:        fmt.Sprintf("assigned to %s on creation", name),
+			AssignedUserID: *item.AssignedUserID,
+		})
+	}
 
 	return item, nil
 }
@@ -1542,8 +1565,10 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 	}
 	actor, source := actorFromRequest(r)
 	activityID, _ := s.logActivityWithMetaReturningID(workspaceID, updated.ID, "updated", r, meta)
-	s.publishItemEventWithName(events.ItemUpdated, workspaceID, updated.ID, updated.Title, updated.CollectionSlug, actor, actorNameFromRequest(r), source, updated.Seq)
+	actorNameForUpdate := actorNameFromRequest(r)
+	s.publishItemEventWithName(events.ItemUpdated, workspaceID, updated.ID, updated.Title, updated.CollectionSlug, actor, actorNameForUpdate, source, updated.Seq)
 	s.dispatchWebhook(workspaceID, "item.updated", updated)
+	s.publishWatchNotifications(workspaceID, updated, actor, actorNameForUpdate)
 
 	// If a comment was attached to this update (e.g. explaining a status change),
 	// create a comment linked to the activity entry.
@@ -1568,6 +1593,22 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 				"comment": comment,
 				"changes": meta,
 			})
+			// TASK-2533: this comment is created via a DIFFERENT code
+			// path than handleCreateComment (store.CreateComment called
+			// directly, not through POST .../comments) — a bypass Rider
+			// 1's producer audit would otherwise miss. Same
+			// kind=comment notification as the standalone endpoint.
+			if s.watchEvents != nil {
+				s.watchEvents.Publish(watchevents.Notification{
+					WorkspaceID: workspaceID,
+					ItemID:      updated.ID,
+					ItemRef:     updated.Ref,
+					Kind:        watchevents.KindComment,
+					Actor:       actor,
+					ActorName:   actorNameForUpdate,
+					Summary:     truncateForSummary(comment.Body, 120),
+				})
+			}
 		}
 	}
 
@@ -1906,8 +1947,10 @@ func (s *Server) handleMoveItem(w http.ResponseWriter, r *http.Request) {
 	s.logActivityWithMeta(workspaceID, moved.ID, "moved", r, moveMeta)
 
 	// Publish events for both old and new collections
-	s.publishItemEventWithName(events.ItemUpdated, workspaceID, moved.ID, moved.Title, targetColl.Slug, actor, actorNameFromRequest(r), source, moved.Seq)
+	actorNameForMove := actorNameFromRequest(r)
+	s.publishItemEventWithName(events.ItemUpdated, workspaceID, moved.ID, moved.Title, targetColl.Slug, actor, actorNameForMove, source, moved.Seq)
 	s.dispatchWebhook(workspaceID, "item.moved", moved)
+	s.publishWatchNotifications(workspaceID, moved, actor, actorNameForMove)
 
 	moveVisIDs, _ := s.visibleCollectionIDs(r, workspaceID)
 	if err := s.enrichItemForResponse(moved, moveVisIDs); err != nil {

--- a/internal/server/handlers_items_bulk.go
+++ b/internal/server/handlers_items_bulk.go
@@ -228,6 +228,13 @@ func (s *Server) handleBulkItems(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 
+		// TASK-2533: per-item, NOT batched like publishBulkItemsEvent
+		// below — see publishWatchNotifications' doc comment for why
+		// that's an accepted noise-discipline tradeoff for Phase 1.
+		// No-op when updated.LastMutation is nil (most bulk ops:
+		// archive/restore/tag/untag never touch status or assignment).
+		s.publishWatchNotifications(workspaceID, updated, actor, actorName)
+
 		// Per-row activity log keeps the audit trail intact — it's a
 		// DB write, not the SSE/webhook fan-out the task is avoiding.
 		// A cross-collection move logs action="moved" with from/to

--- a/internal/server/handlers_watch_access.go
+++ b/internal/server/handlers_watch_access.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"log/slog"
+	"net/http"
 
 	"github.com/PerpetualSoftware/pad/internal/models"
 )
@@ -24,7 +25,12 @@ import (
 // legitimately span many workspaces, unlike a single SSE connection
 // (handlers_events.go's computeSSEVisibility), which only ever resolves
 // visibility for the ONE workspace it's subscribed to.
-func (s *Server) filterWatchesByCurrentAccess(userID string, watches []models.Watch) []models.Watch {
+//
+// r is threaded through to computeWatchAccessVisibility for the
+// bearer-vs-cookie admin check (TASK-2533 codex round 2 finding 2) —
+// see that function's doc comment for why this call site can no longer
+// treat "userID is always the caller" as a reason to skip it.
+func (s *Server) filterWatchesByCurrentAccess(r *http.Request, userID string, watches []models.Watch) []models.Watch {
 	if len(watches) == 0 {
 		return watches
 	}
@@ -43,7 +49,7 @@ func (s *Server) filterWatchesByCurrentAccess(userID string, watches []models.Wa
 
 	out := make([]models.Watch, 0, len(watches))
 	for workspaceID, wsWatches := range byWorkspace {
-		vis := s.computeWatchAccessVisibility(user, workspaceID)
+		vis := s.computeWatchAccessVisibility(r, user, workspaceID)
 		for _, w := range wsWatches {
 			if vis.allows(w.ItemCollectionID, w.ItemID) {
 				out = append(out, w)
@@ -53,20 +59,32 @@ func (s *Server) filterWatchesByCurrentAccess(userID string, watches []models.Wa
 	return out
 }
 
-// watchAccessVisibility is filterWatchesByCurrentAccess's per-workspace
+// watchAccessVisibility is filterWatchesByCurrentAccess's (and, as of
+// codex round 2 finding 2, the addressed-to-you check's) per-workspace
 // visibility snapshot. Deliberately keyed by ID (collection ID / item
 // ID), unlike handlers_events.go's sseVisibility, which is keyed by
 // collection SLUG because it routes live workspace-scoped events that
-// only carry a slug — models.Watch already carries ItemCollectionID and
-// ItemID directly, so ID-keying here avoids an extra slug round trip per
-// collection.
+// only carry a slug — models.Watch and watchevents.Notification both
+// carry collection/item IDs directly, so ID-keying here avoids an extra
+// slug round trip per collection.
 type watchAccessVisibility struct {
-	// fullAccess is true for admin or a member with unrestricted
+	// fullAccess is true for admin (bearer-vs-cookie gated, see
+	// computeWatchAccessVisibility) or a member with unrestricted
 	// collection access (CollectionAccess != "specific"). true means "no
-	// filtering" — every watch in this workspace passes.
+	// filtering" — every notification in this workspace passes.
 	fullAccess bool
-	// visibleCollIDs is the set of collection IDs the caller can see in
-	// full (nil/empty when fullAccess is true or the caller has none).
+	// visibleCollIDs is the set of collection IDs the caller GENUINELY has
+	// full access to — a member's own assigned collections, system
+	// collections, or a guest's direct collection_grants (nil/empty when
+	// fullAccess is true or the caller has none). Deliberately NOT built
+	// from VisibleCollectionIDs/GuestVisibleCollectionIDs (TASK-2533
+	// codex round 2 finding 1) — those over-widen for navigation,
+	// including a collection ID merely because the caller has an item
+	// grant somewhere inside it, which is exactly the leak this field
+	// must not reproduce. Built from GuestVisibleResources'
+	// fullCollectionIDs (+ GetMemberCollectionAccess/
+	// ListSystemCollectionIDs for a member) instead — see
+	// computeWatchAccessVisibility.
 	visibleCollIDs map[string]bool
 	// grantedItemIDs are individually-granted items (guest item grants,
 	// or a "specific"-access member's item-level grants) — visible
@@ -86,61 +104,102 @@ func (v watchAccessVisibility) allows(collectionID, itemID string) bool {
 }
 
 // computeWatchAccessVisibility resolves a user's current access within
-// one workspace. Built from the same two store primitives
-// computeSSEVisibility uses (VisibleCollectionIDs + GuestVisibleResources)
-// rather than reimplementing membership/grant SQL here — see that
-// function (handlers_events.go) for the underlying RBAC shape this
-// mirrors, minus the slug translation this call site doesn't need.
+// one workspace, built from the SAME primitives computeSSEVisibility
+// uses (handlers_events.go) and the SAME two-tier construction, not an
+// approximation of it.
 //
-// Admin bypass note: unlike computeSSEVisibility's BUG-1616 carve-out
-// (cookie-session admin only, bearer-borne admin gets the real grant-
-// based check), this treats ANY admin as full-access regardless of auth
-// transport. That's deliberately simpler and still safe: every call site
-// filters a caller's OWN watches (userID is always the authenticated
-// requester, never a caller-supplied target), so the only thing this
-// bypass affects is whether an admin's OWN watches stay visible to
-// themselves — not a cross-user visibility leak the way the SSE
-// carve-out has to guard against.
-func (s *Server) computeWatchAccessVisibility(user *models.User, workspaceID string) watchAccessVisibility {
-	if user.Role == "admin" {
+// TASK-2533 codex round 2 finding 1 (confirmed real, fixed): the
+// previous version used VisibleCollectionIDs/GuestVisibleCollectionIDs
+// directly as the "fully visible" gate. Those functions deliberately
+// OVER-WIDEN for navigation purposes — GuestVisibleCollectionIDs' own
+// query adds a collection's ID to the result if the caller has an item
+// grant on ANY item inside it (so a guest's sidebar can show the
+// collection at all), explicitly leaving item-level narrowing to the
+// caller. allows() never did that narrowing: a guest granted item A got
+// treated as having full access to A's whole collection, including
+// sibling item B they were never granted. Fixed by using
+// GuestVisibleResources' fullCollectionIDs return (populated ONLY from
+// direct collection_grants — never widened by an item grant) as the
+// "genuinely full access" set, exactly like computeSSEVisibility's own
+// fullCollSet construction, with GetMemberCollectionAccess +
+// ListSystemCollectionIDs layered on for an actual workspace member.
+//
+// Admin bypass (TASK-2533 codex round 2 finding 2 — the argument below
+// REPLACES a now-falsified one, not just a code fix): this used to treat
+// ANY admin as full-access regardless of auth transport, reasoned as
+// "every call site filters a caller's OWN watches, so this can't leak
+// another user's data." That reasoning held for watch-matched
+// notifications, but finding 2 is exactly the case where it doesn't:
+// the addressed-to-you/assignment path is now ALSO gated by this
+// function (handlers_watch_events.go), and an addressed-to-you
+// notification is, by definition, about something that happened TO the
+// connected user in a workspace — a bearer-borne admin token (a leaked
+// PAT, a compromised CI credential) being unconditionally trusted to see
+// EVERY workspace's assignment activity for "themselves" is exactly the
+// blast-radius BUG-1616 exists to bound. There is no watch-specific
+// exemption from that reasoning; this now mirrors computeSSEVisibility's
+// bearer-vs-cookie distinction exactly, so admin access to watch/nudge
+// delivery has no bespoke ACL argument of its own left to defend.
+func (s *Server) computeWatchAccessVisibility(r *http.Request, user *models.User, workspaceID string) watchAccessVisibility {
+	if user.Role == "admin" && !isBearerAuth(r) {
 		return watchAccessVisibility{fullAccess: true}
 	}
 
-	visibleIDs, err := s.store.VisibleCollectionIDs(workspaceID, user.ID)
+	member, err := s.store.GetWorkspaceMember(workspaceID, user.ID)
 	if err != nil {
-		slog.Warn("watch-access: failed to resolve visible collections, denying all in workspace",
+		slog.Warn("watch-access: failed to resolve workspace membership, denying all in workspace",
 			"workspace_id", workspaceID, "user_id", user.ID, "error", err)
-		return watchAccessVisibility{} // fail closed: no collections, no items
+		return watchAccessVisibility{} // fail closed
 	}
-	if visibleIDs == nil {
-		// nil is VisibleCollectionIDs' sentinel for "unrestricted" —
-		// full workspace member with CollectionAccess == "all"/"".
+	if member != nil && member.CollectionAccess != "specific" {
+		// "all" access (or the legacy "" default) — unrestricted. Note
+		// this fires for a bearer-borne admin too, exactly like
+		// computeSSEVisibility: a bearer admin who is ALSO a genuine full
+		// member of this specific workspace legitimately sees it in
+		// full; the gate above only denies the platform-wide, not-a-
+		// member-here bypass.
 		return watchAccessVisibility{fullAccess: true}
 	}
 
-	v := watchAccessVisibility{
-		visibleCollIDs: make(map[string]bool, len(visibleIDs)),
-	}
-	for _, id := range visibleIDs {
-		v.visibleCollIDs[id] = true
+	// From here: either a "specific"-access member, a non-member guest,
+	// or a bearer-borne admin with no membership/grants in this
+	// workspace at all — all three need the fullCollSet/grantedItemSet
+	// distinction GuestVisibleResources provides, unlike
+	// VisibleCollectionIDs.
+	fullCollIDs, grantedItemIDs, gerr := s.store.GuestVisibleResources(workspaceID, user.ID)
+	if gerr != nil {
+		slog.Warn("watch-access: failed to resolve grants, denying all in workspace",
+			"workspace_id", workspaceID, "user_id", user.ID, "error", gerr)
+		return watchAccessVisibility{} // fail closed
 	}
 
-	// Item-level grants layer on top of the collection set — a guest or
-	// a "specific"-access member may see individual items outside it
-	// (mirrors computeSSEVisibility's needsItemFilter / grantedItemSet).
-	// A failure here does NOT widen or narrow the collection-level
-	// result above; it only means no item-level grants get layered on.
-	_, grantedItemIDs, gerr := s.store.GuestVisibleResources(workspaceID, user.ID)
-	if gerr != nil {
-		slog.Warn("watch-access: failed to resolve item grants, no item-level widening",
-			"workspace_id", workspaceID, "user_id", user.ID, "error", gerr)
-		return v
+	fullCollSet := make(map[string]bool, len(fullCollIDs))
+	for _, id := range fullCollIDs {
+		fullCollSet[id] = true
 	}
-	if len(grantedItemIDs) > 0 {
-		v.grantedItemIDs = make(map[string]bool, len(grantedItemIDs))
-		for _, id := range grantedItemIDs {
-			v.grantedItemIDs[id] = true
+	if member != nil {
+		// A "specific"-access member's OWN assigned collections + system
+		// collections are genuinely fully visible — mirrors
+		// computeSSEVisibility exactly. A pure guest (member == nil) has
+		// no such assignment; fullCollSet stays limited to their direct
+		// collection_grants from GuestVisibleResources above.
+		memberColls, _ := s.store.GetMemberCollectionAccess(workspaceID, user.ID)
+		sysColls, _ := s.store.ListSystemCollectionIDs(workspaceID)
+		for _, id := range memberColls {
+			fullCollSet[id] = true
+		}
+		for _, id := range sysColls {
+			fullCollSet[id] = true
 		}
 	}
-	return v
+
+	grantedSet := make(map[string]bool, len(grantedItemIDs))
+	for _, id := range grantedItemIDs {
+		grantedSet[id] = true
+	}
+
+	return watchAccessVisibility{
+		visibleCollIDs: fullCollSet,
+		grantedItemIDs: grantedSet,
+	}
 }

--- a/internal/server/handlers_watch_access.go
+++ b/internal/server/handlers_watch_access.go
@@ -1,0 +1,146 @@
+package server
+
+import (
+	"log/slog"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// filterWatchesByCurrentAccess re-checks each watch's CURRENT visibility
+// (workspace membership / role / collection access / item grants)
+// before it is used to gate SSE delivery or returned from
+// GET /api/v1/watches (TASK-2533, codex round 1 finding 1).
+//
+// Store.ListWatchesForUser's doc comment explains why this exists: the
+// watches table durably outlives a workspace membership or grant
+// revocation — nothing deletes a watch row when access is pulled — so
+// without this step a caller removed from a workspace (or whose guest
+// grant was revoked) would keep receiving live nudges and keep seeing
+// the watch in `pad watch list`, leaking item title/ref, workspace slug,
+// actor, and summary for a workspace they can no longer see.
+//
+// Grouped by workspace (one RBAC resolution per DISTINCT workspace among
+// the caller's watches, not one per watch): a caller's watches can
+// legitimately span many workspaces, unlike a single SSE connection
+// (handlers_events.go's computeSSEVisibility), which only ever resolves
+// visibility for the ONE workspace it's subscribed to.
+func (s *Server) filterWatchesByCurrentAccess(userID string, watches []models.Watch) []models.Watch {
+	if len(watches) == 0 {
+		return watches
+	}
+
+	user, err := s.store.GetUser(userID)
+	if err != nil || user == nil {
+		// Can't resolve the caller at all — fail closed.
+		slog.Warn("watch-access: failed to resolve user, denying all watches", "user_id", userID, "error", err)
+		return nil
+	}
+
+	byWorkspace := make(map[string][]models.Watch)
+	for _, w := range watches {
+		byWorkspace[w.WorkspaceID] = append(byWorkspace[w.WorkspaceID], w)
+	}
+
+	out := make([]models.Watch, 0, len(watches))
+	for workspaceID, wsWatches := range byWorkspace {
+		vis := s.computeWatchAccessVisibility(user, workspaceID)
+		for _, w := range wsWatches {
+			if vis.allows(w.ItemCollectionID, w.ItemID) {
+				out = append(out, w)
+			}
+		}
+	}
+	return out
+}
+
+// watchAccessVisibility is filterWatchesByCurrentAccess's per-workspace
+// visibility snapshot. Deliberately keyed by ID (collection ID / item
+// ID), unlike handlers_events.go's sseVisibility, which is keyed by
+// collection SLUG because it routes live workspace-scoped events that
+// only carry a slug — models.Watch already carries ItemCollectionID and
+// ItemID directly, so ID-keying here avoids an extra slug round trip per
+// collection.
+type watchAccessVisibility struct {
+	// fullAccess is true for admin or a member with unrestricted
+	// collection access (CollectionAccess != "specific"). true means "no
+	// filtering" — every watch in this workspace passes.
+	fullAccess bool
+	// visibleCollIDs is the set of collection IDs the caller can see in
+	// full (nil/empty when fullAccess is true or the caller has none).
+	visibleCollIDs map[string]bool
+	// grantedItemIDs are individually-granted items (guest item grants,
+	// or a "specific"-access member's item-level grants) — visible
+	// regardless of visibleCollIDs. nil when the caller has no
+	// item-level grants (the common case).
+	grantedItemIDs map[string]bool
+}
+
+func (v watchAccessVisibility) allows(collectionID, itemID string) bool {
+	if v.fullAccess {
+		return true
+	}
+	if v.visibleCollIDs[collectionID] {
+		return true
+	}
+	return v.grantedItemIDs[itemID]
+}
+
+// computeWatchAccessVisibility resolves a user's current access within
+// one workspace. Built from the same two store primitives
+// computeSSEVisibility uses (VisibleCollectionIDs + GuestVisibleResources)
+// rather than reimplementing membership/grant SQL here — see that
+// function (handlers_events.go) for the underlying RBAC shape this
+// mirrors, minus the slug translation this call site doesn't need.
+//
+// Admin bypass note: unlike computeSSEVisibility's BUG-1616 carve-out
+// (cookie-session admin only, bearer-borne admin gets the real grant-
+// based check), this treats ANY admin as full-access regardless of auth
+// transport. That's deliberately simpler and still safe: every call site
+// filters a caller's OWN watches (userID is always the authenticated
+// requester, never a caller-supplied target), so the only thing this
+// bypass affects is whether an admin's OWN watches stay visible to
+// themselves — not a cross-user visibility leak the way the SSE
+// carve-out has to guard against.
+func (s *Server) computeWatchAccessVisibility(user *models.User, workspaceID string) watchAccessVisibility {
+	if user.Role == "admin" {
+		return watchAccessVisibility{fullAccess: true}
+	}
+
+	visibleIDs, err := s.store.VisibleCollectionIDs(workspaceID, user.ID)
+	if err != nil {
+		slog.Warn("watch-access: failed to resolve visible collections, denying all in workspace",
+			"workspace_id", workspaceID, "user_id", user.ID, "error", err)
+		return watchAccessVisibility{} // fail closed: no collections, no items
+	}
+	if visibleIDs == nil {
+		// nil is VisibleCollectionIDs' sentinel for "unrestricted" —
+		// full workspace member with CollectionAccess == "all"/"".
+		return watchAccessVisibility{fullAccess: true}
+	}
+
+	v := watchAccessVisibility{
+		visibleCollIDs: make(map[string]bool, len(visibleIDs)),
+	}
+	for _, id := range visibleIDs {
+		v.visibleCollIDs[id] = true
+	}
+
+	// Item-level grants layer on top of the collection set — a guest or
+	// a "specific"-access member may see individual items outside it
+	// (mirrors computeSSEVisibility's needsItemFilter / grantedItemSet).
+	// A failure here does NOT widen or narrow the collection-level
+	// result above; it only means no item-level grants get layered on.
+	_, grantedItemIDs, gerr := s.store.GuestVisibleResources(workspaceID, user.ID)
+	if gerr != nil {
+		slog.Warn("watch-access: failed to resolve item grants, no item-level widening",
+			"workspace_id", workspaceID, "user_id", user.ID, "error", gerr)
+		return v
+	}
+	if len(grantedItemIDs) > 0 {
+		v.grantedItemIDs = make(map[string]bool, len(grantedItemIDs))
+		for _, id := range grantedItemIDs {
+			v.grantedItemIDs[id] = true
+		}
+	}
+	return v
+}

--- a/internal/server/handlers_watch_access_test.go
+++ b/internal/server/handlers_watch_access_test.go
@@ -2,10 +2,21 @@ package server
 
 import (
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/PerpetualSoftware/pad/internal/models"
 )
+
+// noBearerRequest returns a bare request with no Authorization header —
+// isBearerAuth(r) reports false for it, matching a cookie-session-style
+// caller. None of this file's tests exercise an admin user, so the
+// bearer-vs-cookie distinction (TASK-2533 codex round 2 finding 2) is
+// inert for them either way; this just satisfies
+// computeWatchAccessVisibility's signature.
+func noBearerRequest() *http.Request {
+	return httptest.NewRequest(http.MethodGet, "/api/v1/watches", nil)
+}
 
 // TestFilterWatchesByCurrentAccess_ExcludesRevokedMembership covers
 // codex round-1 finding 1: a watch row survives a workspace membership
@@ -29,7 +40,7 @@ func TestFilterWatchesByCurrentAccess_ExcludesRevokedMembership(t *testing.T) {
 	if len(watches) != 1 {
 		t.Fatalf("expected 1 watch before revocation, got %d", len(watches))
 	}
-	if got := srv.filterWatchesByCurrentAccess(user.ID, watches); len(got) != 1 {
+	if got := srv.filterWatchesByCurrentAccess(noBearerRequest(), user.ID, watches); len(got) != 1 {
 		t.Fatalf("expected the watch to remain visible while still a member, got %d", len(got))
 	}
 
@@ -41,7 +52,7 @@ func TestFilterWatchesByCurrentAccess_ExcludesRevokedMembership(t *testing.T) {
 		t.Fatalf("RemoveWorkspaceMember: %v", err)
 	}
 
-	filtered := srv.filterWatchesByCurrentAccess(user.ID, watches)
+	filtered := srv.filterWatchesByCurrentAccess(noBearerRequest(), user.ID, watches)
 	if len(filtered) != 0 {
 		t.Fatalf("expected the watch to be excluded after membership removal, got %+v", filtered)
 	}
@@ -55,7 +66,7 @@ func TestFilterWatchesByCurrentAccess_KeepsActiveMembership(t *testing.T) {
 	_, item, _, user := setupWatchTestUser(t, srv)
 
 	watches := []models.Watch{{UserID: user.ID, ItemID: item.ID, ItemCollectionID: item.CollectionID, WorkspaceID: item.WorkspaceID}}
-	got := srv.filterWatchesByCurrentAccess(user.ID, watches)
+	got := srv.filterWatchesByCurrentAccess(noBearerRequest(), user.ID, watches)
 	if len(got) != 1 {
 		t.Fatalf("expected the active member's watch to remain visible, got %d", len(got))
 	}
@@ -93,7 +104,7 @@ func TestFilterWatchesByCurrentAccess_GuestItemGrantKeepsWatch(t *testing.T) {
 	}
 
 	watches := []models.Watch{{UserID: guest.ID, ItemID: item.ID, ItemCollectionID: item.CollectionID, WorkspaceID: ws.ID}}
-	got := srv.filterWatchesByCurrentAccess(guest.ID, watches)
+	got := srv.filterWatchesByCurrentAccess(noBearerRequest(), guest.ID, watches)
 	if len(got) != 1 {
 		t.Fatalf("expected the item-granted guest's watch to remain visible, got %d", len(got))
 	}
@@ -106,7 +117,7 @@ func TestFilterWatchesByCurrentAccess_GuestItemGrantKeepsWatch(t *testing.T) {
 		t.Fatalf("CreateUser (stranger): %v", err)
 	}
 	strangerWatches := []models.Watch{{UserID: stranger.ID, ItemID: item.ID, ItemCollectionID: item.CollectionID, WorkspaceID: ws.ID}}
-	if got := srv.filterWatchesByCurrentAccess(stranger.ID, strangerWatches); len(got) != 0 {
+	if got := srv.filterWatchesByCurrentAccess(noBearerRequest(), stranger.ID, strangerWatches); len(got) != 0 {
 		t.Fatalf("expected a stranger with no membership or grant to be denied, got %d", len(got))
 	}
 }
@@ -147,5 +158,77 @@ func TestListWatches_ExcludesRevokedAccess(t *testing.T) {
 	parseJSON(t, rr, &after)
 	if len(after) != 0 {
 		t.Fatalf("expected 0 watches after membership removal, got %+v", after)
+	}
+}
+
+// TestFilterWatchesByCurrentAccess_ItemGrantDoesNotWidenToSiblingItem
+// covers TASK-2533 codex round 2 finding 1: VisibleCollectionIDs /
+// GuestVisibleCollectionIDs deliberately over-widen for navigation — a
+// collection ID is included in their result if the caller has an item
+// grant on ANY item inside it, explicitly leaving item-level narrowing
+// to the caller (their own doc comments say so). The previous
+// computeWatchAccessVisibility used that over-wide set directly as the
+// "fully visible" gate, so a guest granted item A was treated as having
+// full access to A's WHOLE collection — including a sibling item B they
+// were never granted. This asserts the fix: item A's watch stays
+// visible, a hypothetical watch on sibling item B does not.
+func TestFilterWatchesByCurrentAccess_ItemGrantDoesNotWidenToSiblingItem(t *testing.T) {
+	t.Parallel()
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	rrA := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections/tasks/items",
+		map[string]interface{}{"title": "Granted item", "fields": `{"status":"open"}`})
+	if rrA.Code != http.StatusCreated {
+		t.Fatalf("seed item A: %d %s", rrA.Code, rrA.Body.String())
+	}
+	var itemA models.Item
+	parseJSON(t, rrA, &itemA)
+
+	rrB := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections/tasks/items",
+		map[string]interface{}{"title": "Sibling item", "fields": `{"status":"open"}`})
+	if rrB.Code != http.StatusCreated {
+		t.Fatalf("seed item B: %d %s", rrB.Code, rrB.Body.String())
+	}
+	var itemB models.Item
+	parseJSON(t, rrB, &itemB)
+
+	if itemA.CollectionID != itemB.CollectionID {
+		t.Fatalf("test setup bug: items must share a collection, got %q and %q", itemA.CollectionID, itemB.CollectionID)
+	}
+
+	ws, err := srv.store.GetWorkspaceBySlug(slug)
+	if err != nil {
+		t.Fatalf("GetWorkspaceBySlug: %v", err)
+	}
+	guest, err := srv.store.CreateUser(models.UserCreate{
+		Email: "sibling-guest@example.com", Name: "Sibling Guest", Password: "pw-test-12345",
+	})
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	// Grant ONLY item A — item B is an ungranted sibling in the SAME collection.
+	if _, err := srv.store.CreateItemGrant(ws.ID, itemA.ID, guest.ID, "view", guest.ID); err != nil {
+		t.Fatalf("CreateItemGrant: %v", err)
+	}
+
+	watches := []models.Watch{
+		{UserID: guest.ID, ItemID: itemA.ID, ItemCollectionID: itemA.CollectionID, WorkspaceID: ws.ID},
+		{UserID: guest.ID, ItemID: itemB.ID, ItemCollectionID: itemB.CollectionID, WorkspaceID: ws.ID},
+	}
+	got := srv.filterWatchesByCurrentAccess(noBearerRequest(), guest.ID, watches)
+
+	visible := make(map[string]bool, len(got))
+	for _, w := range got {
+		visible[w.ItemID] = true
+	}
+	if !visible[itemA.ID] {
+		t.Errorf("expected the granted item A's watch to remain visible")
+	}
+	if visible[itemB.ID] {
+		t.Errorf("expected the UNGRANTED sibling item B's watch to be denied — item grant must not widen to the whole collection")
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected exactly 1 visible watch (item A only), got %d: %+v", len(got), got)
 	}
 }

--- a/internal/server/handlers_watch_access_test.go
+++ b/internal/server/handlers_watch_access_test.go
@@ -1,0 +1,151 @@
+package server
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// TestFilterWatchesByCurrentAccess_ExcludesRevokedMembership covers
+// codex round-1 finding 1: a watch row survives a workspace membership
+// removal (nothing deletes it), so without this filter a removed user
+// would keep seeing / receiving nudges for a workspace they can no
+// longer access.
+func TestFilterWatchesByCurrentAccess_ExcludesRevokedMembership(t *testing.T) {
+	t.Parallel()
+	srv := testServer(t)
+	slug, item, tok, user := setupWatchTestUser(t, srv)
+
+	rr := bearerCall(t, srv, "POST", "/api/v1/workspaces/"+slug+"/items/"+item.Slug+"/watch", tok.Token, nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("create watch: %d %s", rr.Code, rr.Body.String())
+	}
+
+	watches, err := srv.store.ListWatchesForUser(user.ID)
+	if err != nil {
+		t.Fatalf("ListWatchesForUser: %v", err)
+	}
+	if len(watches) != 1 {
+		t.Fatalf("expected 1 watch before revocation, got %d", len(watches))
+	}
+	if got := srv.filterWatchesByCurrentAccess(user.ID, watches); len(got) != 1 {
+		t.Fatalf("expected the watch to remain visible while still a member, got %d", len(got))
+	}
+
+	ws, err := srv.store.GetWorkspaceBySlug(slug)
+	if err != nil {
+		t.Fatalf("GetWorkspaceBySlug: %v", err)
+	}
+	if err := srv.store.RemoveWorkspaceMember(ws.ID, user.ID); err != nil {
+		t.Fatalf("RemoveWorkspaceMember: %v", err)
+	}
+
+	filtered := srv.filterWatchesByCurrentAccess(user.ID, watches)
+	if len(filtered) != 0 {
+		t.Fatalf("expected the watch to be excluded after membership removal, got %+v", filtered)
+	}
+}
+
+// TestFilterWatchesByCurrentAccess_KeepsActiveMembership is the happy-path
+// sanity check alongside the revocation test above.
+func TestFilterWatchesByCurrentAccess_KeepsActiveMembership(t *testing.T) {
+	t.Parallel()
+	srv := testServer(t)
+	_, item, _, user := setupWatchTestUser(t, srv)
+
+	watches := []models.Watch{{UserID: user.ID, ItemID: item.ID, ItemCollectionID: item.CollectionID, WorkspaceID: item.WorkspaceID}}
+	got := srv.filterWatchesByCurrentAccess(user.ID, watches)
+	if len(got) != 1 {
+		t.Fatalf("expected the active member's watch to remain visible, got %d", len(got))
+	}
+}
+
+// TestFilterWatchesByCurrentAccess_GuestItemGrantKeepsWatch exercises the
+// item-level-grant branch: a non-member guest with an explicit item
+// grant (not a full collection grant) must still see their watch on
+// that specific item.
+func TestFilterWatchesByCurrentAccess_GuestItemGrantKeepsWatch(t *testing.T) {
+	t.Parallel()
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+	rr := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections/tasks/items",
+		map[string]interface{}{"title": "Grant target", "fields": `{"status":"open"}`})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("seed item: %d %s", rr.Code, rr.Body.String())
+	}
+	var item models.Item
+	parseJSON(t, rr, &item)
+
+	ws, err := srv.store.GetWorkspaceBySlug(slug)
+	if err != nil {
+		t.Fatalf("GetWorkspaceBySlug: %v", err)
+	}
+	guest, err := srv.store.CreateUser(models.UserCreate{
+		Email: "guest@example.com", Name: "Guest", Password: "pw-test-12345",
+	})
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	// Deliberately NOT added as a workspace member — item-grant-only guest.
+	if _, err := srv.store.CreateItemGrant(ws.ID, item.ID, guest.ID, "view", guest.ID); err != nil {
+		t.Fatalf("CreateItemGrant: %v", err)
+	}
+
+	watches := []models.Watch{{UserID: guest.ID, ItemID: item.ID, ItemCollectionID: item.CollectionID, WorkspaceID: ws.ID}}
+	got := srv.filterWatchesByCurrentAccess(guest.ID, watches)
+	if len(got) != 1 {
+		t.Fatalf("expected the item-granted guest's watch to remain visible, got %d", len(got))
+	}
+
+	// A DIFFERENT unrelated user (no membership, no grant) must be denied.
+	stranger, err := srv.store.CreateUser(models.UserCreate{
+		Email: "stranger@example.com", Name: "Stranger", Password: "pw-test-12345",
+	})
+	if err != nil {
+		t.Fatalf("CreateUser (stranger): %v", err)
+	}
+	strangerWatches := []models.Watch{{UserID: stranger.ID, ItemID: item.ID, ItemCollectionID: item.CollectionID, WorkspaceID: ws.ID}}
+	if got := srv.filterWatchesByCurrentAccess(stranger.ID, strangerWatches); len(got) != 0 {
+		t.Fatalf("expected a stranger with no membership or grant to be denied, got %d", len(got))
+	}
+}
+
+// TestListWatches_ExcludesRevokedAccess is the HTTP-level regression
+// test: GET /api/v1/watches must not return a watch on a workspace the
+// caller has since been removed from.
+func TestListWatches_ExcludesRevokedAccess(t *testing.T) {
+	t.Parallel()
+	srv := testServer(t)
+	slug, item, tok, user := setupWatchTestUser(t, srv)
+
+	rr := bearerCall(t, srv, "POST", "/api/v1/workspaces/"+slug+"/items/"+item.Slug+"/watch", tok.Token, nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("create watch: %d %s", rr.Code, rr.Body.String())
+	}
+
+	rr = bearerCall(t, srv, "GET", "/api/v1/watches", tok.Token, nil)
+	var before []models.Watch
+	parseJSON(t, rr, &before)
+	if len(before) != 1 {
+		t.Fatalf("expected 1 watch before revocation, got %d", len(before))
+	}
+
+	ws, err := srv.store.GetWorkspaceBySlug(slug)
+	if err != nil {
+		t.Fatalf("GetWorkspaceBySlug: %v", err)
+	}
+	if err := srv.store.RemoveWorkspaceMember(ws.ID, user.ID); err != nil {
+		t.Fatalf("RemoveWorkspaceMember: %v", err)
+	}
+
+	rr = bearerCall(t, srv, "GET", "/api/v1/watches", tok.Token, nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("list watches after revocation: expected 200, got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+	var after []models.Watch
+	parseJSON(t, rr, &after)
+	if len(after) != 0 {
+		t.Fatalf("expected 0 watches after membership removal, got %+v", after)
+	}
+}

--- a/internal/server/handlers_watch_events.go
+++ b/internal/server/handlers_watch_events.go
@@ -183,17 +183,37 @@ func (s *Server) handleWatchEventsStream(w http.ResponseWriter, r *http.Request)
 			flusher.Flush()
 
 		case <-reval.C:
+			// TASK-2533 codex round 4: reset the identity/visibility
+			// cache FIRST, unconditionally, BEFORE attempting the watch-
+			// list reload — the two used to be coupled (visCache.reset()
+			// only ran on the reload's success path), so a
+			// ListWatchesForUser error skipped the reset via `continue`
+			// and kept the STALE user/visibility live for exactly as
+			// long as that unrelated query kept failing. A demoted or
+			// disabled user would keep being treated as admin-visible
+			// through the whole error window. refreshUser (inside
+			// reset()) has its own fail-closed handling for ITS OWN
+			// fetch failures, so this can never make things WORSE than
+			// before — it can only stop tying an unrelated failure mode
+			// to it.
+			visCache.reset()
+
 			fresh, ferr := s.loadWatchPredicates(r, user.ID)
 			if ferr != nil {
-				slog.Warn("watch-events: watch-list reload failed, keeping previous snapshot",
+				// Keep the STALE watch list rather than dropping all
+				// delivery for the tick: the list itself being one tick
+				// behind is a narrower, already-bounded staleness
+				// (mirrors watchListRevalInterval's own "eventually
+				// consistent" contract), and it's now gated by the
+				// FRESH visCache above regardless — a demoted/disabled
+				// user is denied via visCache even while watches stays
+				// stale. Dropping everything here would tie stream
+				// availability to an unrelated query's transient health.
+				slog.Warn("watch-events: watch-list reload failed, keeping previous watch snapshot (visibility was still refreshed)",
 					"user_id", user.ID, "error", ferr)
 				continue
 			}
 			watches = fresh
-			// Same cadence as the watches reload above: a revoked grant
-			// or membership must stop widening EITHER visibility source
-			// within one tick, not just the watch-matched one.
-			visCache.reset()
 		}
 	}
 }
@@ -302,6 +322,11 @@ func (c *watchVisCache) refreshUser() {
 // or grant revoked after the watch was created — doesn't keep delivering
 // live nudges for it.
 func (s *Server) loadWatchPredicates(r *http.Request, userID string) (map[string]string, error) {
+	if s.watchPredicatesLoadFault != nil {
+		if fe := s.watchPredicatesLoadFault(); fe != nil {
+			return nil, fe
+		}
+	}
 	list, err := s.store.ListWatchesForUser(userID)
 	if err != nil {
 		return nil, err

--- a/internal/server/handlers_watch_events.go
+++ b/internal/server/handlers_watch_events.go
@@ -1,0 +1,267 @@
+package server
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/watchevents"
+)
+
+// watchEventsKeepaliveInterval mirrors sseKeepaliveInterval
+// (handlers_events.go) — same rationale, same httpIdleTimeout invariant,
+// already enforced by that file's init() guard.
+const watchEventsKeepaliveInterval = sseKeepaliveInterval
+
+// watchListRevalInterval is how often an open watch-events stream
+// reloads the caller's watch list from the store, mirroring
+// sseMembershipRevalInterval's role in handlers_events.go: a watch
+// created or removed after the stream connected takes effect within one
+// tick instead of requiring a reconnect.
+var watchListRevalInterval = 60 * time.Second
+
+// watchEventPayload is the wire shape GET /api/v1/events/stream emits,
+// per DOC-2479's contract exactly: {id, ts, workspace, item_ref, kind,
+// actor, summary}.
+type watchEventPayload struct {
+	ID        int64  `json:"id"`
+	Ts        int64  `json:"ts"`
+	Workspace string `json:"workspace"`
+	ItemRef   string `json:"item_ref"`
+	Kind      string `json:"kind"`
+	Actor     string `json:"actor"`
+	Summary   string `json:"summary"`
+}
+
+// handleWatchEventsStream streams the caller's watch/nudge notifications.
+// GET /api/v1/events/stream (TASK-2533, per DOC-2479's SSE-endpoint
+// design).
+//
+// Unlike handleSSE (GET /api/v1/events, workspace-scoped), this stream is
+// USER-scoped and spans every workspace the caller belongs to — a watch
+// or an assignment can land in any of them. It is filtered, server-side,
+// to exactly two things (DR-2: no firehose, no wildcard subscriptions):
+//
+//  1. Notifications on an item the caller has an explicit watch on
+//     (internal/store's watches table), gated by that watch's optional
+//     `--until field=value` predicate.
+//  2. "Addressed to you": the item was JUST assigned to the caller.
+//     (Phase 1 narrowing, confirmed with the dispatcher: DOC-2479 also
+//     describes a "human-gate-shaped collection targets your ... active
+//     role" half of addressed-to-you, but this codebase has neither a
+//     Collection.Kind field nor any user→active-role binding to ground
+//     that mechanically — `pad session register` is the natural future
+//     hook for a session-carried role identity, see cmd_session.go. Only
+//     the assignment half is implemented; watchevents.KindAsk stays in
+//     the wire-contract enum with no producer until that exists.)
+func (s *Server) handleWatchEventsStream(w http.ResponseWriter, r *http.Request) {
+	if s.watchEvents == nil {
+		writeError(w, http.StatusServiceUnavailable, "unavailable", "Watch event streaming is not available")
+		return
+	}
+
+	user := currentUser(r)
+	if user == nil {
+		// Unlike the workspace-scoped SSE stream, there is no coherent
+		// "my watches" concept for a legacy workspace-scoped token or the
+		// fresh-install no-auth window — this endpoint requires a
+		// resolved user identity, full stop.
+		writeError(w, http.StatusUnauthorized, "unauthorized", "Authentication required")
+		return
+	}
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		writeError(w, http.StatusInternalServerError, "internal_error", "Streaming not supported")
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
+
+	ch := s.watchEvents.Subscribe()
+	defer s.watchEvents.Unsubscribe(ch)
+
+	watches, werr := s.loadWatchPredicates(user.ID)
+	if werr != nil {
+		slog.Warn("watch-events: failed to load caller's watches, denying watch-scoped matches",
+			"user_id", user.ID, "error", werr)
+		watches = map[string]string{} // fail closed, not open
+	}
+
+	if err := writeSSEEvent(w, "connected", 0, map[string]string{"user_id": user.ID}); err != nil {
+		slog.Debug("watch-events: initial connected write failed, closing", "user_id", user.ID, "error", err)
+		return
+	}
+	flusher.Flush()
+
+	if lastIDStr := r.Header.Get("Last-Event-ID"); lastIDStr != "" {
+		if lastID, perr := strconv.ParseInt(lastIDStr, 10, 64); perr == nil && lastID > 0 {
+			missed := s.watchEvents.EventsSince(lastID)
+			if missed == nil {
+				if err := writeSSEEvent(w, "sync_required", 0, map[string]string{
+					"reason": "Notification buffer exceeded. Reconnect without Last-Event-ID to resync.",
+				}); err != nil {
+					slog.Debug("watch-events: sync_required write failed, closing", "user_id", user.ID, "error", err)
+					return
+				}
+				flusher.Flush()
+			} else {
+				for _, n := range missed {
+					if !watchNotificationVisible(watches, user.ID, n) {
+						continue
+					}
+					if err := writeSSEEvent(w, "notification", n.ID, watchEventPayloadFor(s, n)); err != nil {
+						slog.Debug("watch-events: replay write failed, closing", "user_id", user.ID, "error", err)
+						return
+					}
+					flusher.Flush()
+				}
+			}
+		}
+	}
+
+	keepalive := time.NewTicker(watchEventsKeepaliveInterval)
+	defer keepalive.Stop()
+	reval := time.NewTicker(watchListRevalInterval)
+	defer reval.Stop()
+
+	ctx := r.Context()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+
+		case n, ok := <-ch:
+			if !ok {
+				return
+			}
+			if !watchNotificationVisible(watches, user.ID, n) {
+				continue
+			}
+			if err := writeSSEEvent(w, "notification", n.ID, watchEventPayloadFor(s, n)); err != nil {
+				slog.Debug("watch-events: notification write failed, closing", "user_id", user.ID, "error", err)
+				return
+			}
+			flusher.Flush()
+
+		case <-keepalive.C:
+			if _, err := fmt.Fprintf(w, ": keepalive\n\n"); err != nil {
+				slog.Debug("watch-events: keepalive write failed, closing", "user_id", user.ID, "error", err)
+				return
+			}
+			flusher.Flush()
+
+		case <-reval.C:
+			fresh, ferr := s.loadWatchPredicates(user.ID)
+			if ferr != nil {
+				slog.Warn("watch-events: watch-list reload failed, keeping previous snapshot",
+					"user_id", user.ID, "error", ferr)
+				continue
+			}
+			watches = fresh
+		}
+	}
+}
+
+// loadWatchPredicates returns the caller's active watches as
+// itemID -> predicate ("" = unconditional).
+func (s *Server) loadWatchPredicates(userID string) (map[string]string, error) {
+	list, err := s.store.ListWatchesForUser(userID)
+	if err != nil {
+		return nil, err
+	}
+	m := make(map[string]string, len(list))
+	for _, w := range list {
+		m[w.ItemID] = w.Predicate
+	}
+	return m, nil
+}
+
+// watchNotificationVisible decides whether a Notification should be
+// delivered to a caller holding the given watch map. Extracted from the
+// handler so the DR-2 filtering rules are unit-testable without a live
+// SSE connection — mirrors sseEventVisibleFor's role in
+// handlers_events.go.
+func watchNotificationVisible(watches map[string]string, userID string, n watchevents.Notification) bool {
+	// Addressed-to-you: the item was just assigned to the caller. Fires
+	// regardless of whether the caller also holds an explicit watch on
+	// the item (a watch and an addressed-to-you event are independent
+	// reasons to be told).
+	if n.Kind == watchevents.KindAssignment && n.AssignedUserID != "" && n.AssignedUserID == userID {
+		return true
+	}
+
+	predicate, watched := watches[n.ItemID]
+	if !watched {
+		return false
+	}
+	if predicate == "" {
+		return true // unconditional watch: any notification on this item
+	}
+
+	// A `--until field=value` predicate (TASK-2533 plan interpretation,
+	// confirmed with the dispatcher): "watch this item UNTIL <condition>"
+	// reads as a threshold, not "notify me of everything AND also flag
+	// this condition" — so a predicated watch fires ONLY on the matching
+	// status-change, not on every comment/assignment touching the item.
+	field, value, ok := parseWatchPredicate(predicate)
+	if !ok {
+		// Malformed predicate should never reach here — CreateWatch
+		// validates at write time. Fail open to "unconditional" rather
+		// than silently dropping a watch the user believes is active.
+		return true
+	}
+	return n.Kind == watchevents.KindStatusChange && n.StatusFieldKey == field && n.ToStatus == value
+}
+
+// parseWatchPredicate splits a `field=value` predicate string. DOC-2479
+// specs only this single-pair grammar — no boolean combinators.
+func parseWatchPredicate(raw string) (field, value string, ok bool) {
+	raw = strings.TrimSpace(raw)
+	idx := strings.IndexByte(raw, '=')
+	if idx <= 0 {
+		return "", "", false
+	}
+	return raw[:idx], raw[idx+1:], true
+}
+
+// watchEventPayloadFor resolves a Notification's WorkspaceID to its
+// slug (DOC-2479's payload carries a human-facing "workspace", matching
+// item_ref's human-facing shape rather than an internal UUID). A
+// resolution failure degrades to the raw ID rather than dropping the
+// event — the caller still gets everything else in the payload.
+//
+// Actor mapping (TASK-2533 plan interpretation): DOC-2479's payload
+// lists a single `actor` field, but the monitor's own example output —
+// `PAD TASK-214 → done (Dave): fix verified` — names a PERSON, not a
+// source category ("web"/"cli"/"agent"). Notification carries both
+// (Actor = category, ActorName = display name, mirroring the existing
+// events.Event shape); this maps the wire `actor` field to ActorName
+// with a fallback to the category for actors that have no display name
+// (e.g. a webhook or system-sourced mutation), rather than adding a
+// second field DOC-2479 doesn't specify.
+func watchEventPayloadFor(s *Server, n watchevents.Notification) watchEventPayload {
+	workspaceSlug := n.WorkspaceID
+	if ws, err := s.store.GetWorkspaceByID(n.WorkspaceID); err == nil && ws != nil {
+		workspaceSlug = ws.Slug
+	}
+	actor := n.ActorName
+	if actor == "" {
+		actor = n.Actor
+	}
+	return watchEventPayload{
+		ID:        n.ID,
+		Ts:        n.Timestamp,
+		Workspace: workspaceSlug,
+		ItemRef:   n.ItemRef,
+		Kind:      n.Kind,
+		Actor:     actor,
+		Summary:   n.Summary,
+	}
+}

--- a/internal/server/handlers_watch_events.go
+++ b/internal/server/handlers_watch_events.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/PerpetualSoftware/pad/internal/models"
 	"github.com/PerpetualSoftware/pad/internal/watchevents"
 )
 
@@ -106,12 +107,20 @@ func (s *Server) handleWatchEventsStream(w http.ResponseWriter, r *http.Request)
 	}
 	defer s.watchEvents.Unsubscribe(ch)
 
-	watches, werr := s.loadWatchPredicates(user.ID)
+	watches, werr := s.loadWatchPredicates(r, user.ID)
 	if werr != nil {
 		slog.Warn("watch-events: failed to load caller's watches, denying watch-scoped matches",
 			"user_id", user.ID, "error", werr)
 		watches = map[string]string{} // fail closed, not open
 	}
+	// TASK-2533 codex round 2 finding 2: EVERY notification — watch-
+	// matched or addressed-to-you — must pass the same current-access
+	// check before delivery, not just watch-matched ones. visCache
+	// resolves per-workspace visibility lazily (a notification's
+	// workspace isn't known in advance the way `watches`' workspaces
+	// are) and is cleared on the same reval tick as `watches` below, so
+	// revoked access takes effect within one tick without a reconnect.
+	visCache := newWatchVisCache(s, r, user)
 
 	if err := writeSSEEvent(w, "connected", 0, map[string]string{"user_id": user.ID}); err != nil {
 		slog.Debug("watch-events: initial connected write failed, closing", "user_id", user.ID, "error", err)
@@ -130,7 +139,7 @@ func (s *Server) handleWatchEventsStream(w http.ResponseWriter, r *http.Request)
 			flusher.Flush()
 		} else {
 			for _, n := range missed {
-				if !watchNotificationVisible(watches, user.ID, n) {
+				if !watchNotificationVisible(watches, visCache.forWorkspace(n.WorkspaceID), user.ID, n) {
 					continue
 				}
 				if err := writeSSEEvent(w, "notification", n.ID, watchEventPayloadFor(s, n)); err != nil {
@@ -157,7 +166,7 @@ func (s *Server) handleWatchEventsStream(w http.ResponseWriter, r *http.Request)
 			if !ok {
 				return
 			}
-			if !watchNotificationVisible(watches, user.ID, n) {
+			if !watchNotificationVisible(watches, visCache.forWorkspace(n.WorkspaceID), user.ID, n) {
 				continue
 			}
 			if err := writeSSEEvent(w, "notification", n.ID, watchEventPayloadFor(s, n)); err != nil {
@@ -174,15 +183,52 @@ func (s *Server) handleWatchEventsStream(w http.ResponseWriter, r *http.Request)
 			flusher.Flush()
 
 		case <-reval.C:
-			fresh, ferr := s.loadWatchPredicates(user.ID)
+			fresh, ferr := s.loadWatchPredicates(r, user.ID)
 			if ferr != nil {
 				slog.Warn("watch-events: watch-list reload failed, keeping previous snapshot",
 					"user_id", user.ID, "error", ferr)
 				continue
 			}
 			watches = fresh
+			// Same cadence as the watches reload above: a revoked grant
+			// or membership must stop widening EITHER visibility source
+			// within one tick, not just the watch-matched one.
+			visCache.reset()
 		}
 	}
+}
+
+// watchVisCache resolves per-workspace watchAccessVisibility snapshots
+// lazily and caches them for the lifetime of one connection between
+// reval ticks (TASK-2533 codex round 2 finding 2). A notification's
+// workspace isn't known in advance the way the watches map's workspaces
+// are — an addressed-to-you assignment can arrive from ANY workspace the
+// caller has ever touched — so visibility is resolved on first sight of
+// each workspace rather than precomputed. reset() is called on the same
+// reval tick that reloads `watches`, so a revoked grant or membership
+// takes effect within one tick without requiring a reconnect.
+type watchVisCache struct {
+	s    *Server
+	r    *http.Request
+	user *models.User
+	m    map[string]watchAccessVisibility
+}
+
+func newWatchVisCache(s *Server, r *http.Request, user *models.User) *watchVisCache {
+	return &watchVisCache{s: s, r: r, user: user, m: make(map[string]watchAccessVisibility)}
+}
+
+func (c *watchVisCache) forWorkspace(workspaceID string) watchAccessVisibility {
+	if v, ok := c.m[workspaceID]; ok {
+		return v
+	}
+	v := c.s.computeWatchAccessVisibility(c.r, c.user, workspaceID)
+	c.m[workspaceID] = v
+	return v
+}
+
+func (c *watchVisCache) reset() {
+	c.m = make(map[string]watchAccessVisibility)
 }
 
 // loadWatchPredicates returns the caller's active watches as
@@ -191,12 +237,12 @@ func (s *Server) handleWatchEventsStream(w http.ResponseWriter, r *http.Request)
 // watch on an item the caller can no longer see — workspace membership
 // or grant revoked after the watch was created — doesn't keep delivering
 // live nudges for it.
-func (s *Server) loadWatchPredicates(userID string) (map[string]string, error) {
+func (s *Server) loadWatchPredicates(r *http.Request, userID string) (map[string]string, error) {
 	list, err := s.store.ListWatchesForUser(userID)
 	if err != nil {
 		return nil, err
 	}
-	list = s.filterWatchesByCurrentAccess(userID, list)
+	list = s.filterWatchesByCurrentAccess(r, userID, list)
 	m := make(map[string]string, len(list))
 	for _, w := range list {
 		m[w.ItemID] = w.Predicate
@@ -209,11 +255,26 @@ func (s *Server) loadWatchPredicates(userID string) (map[string]string, error) {
 // handler so the DR-2 filtering rules are unit-testable without a live
 // SSE connection — mirrors sseEventVisibleFor's role in
 // handlers_events.go.
-func watchNotificationVisible(watches map[string]string, userID string, n watchevents.Notification) bool {
+func watchNotificationVisible(watches map[string]string, vis watchAccessVisibility, userID string, n watchevents.Notification) bool {
+	// TASK-2533 codex round 2 finding 2: the caller's CURRENT access to
+	// the notification's collection/item is checked FIRST and applies
+	// UNIFORMLY to every kind below — watch-matched and addressed-to-you
+	// alike. The addressed-to-you branch used to skip this entirely: an
+	// item can be assigned to a "specific"-access member whose granted
+	// collections don't include it at all (validateAssignmentScope only
+	// checks WORKSPACE membership, never collection access), and nothing
+	// clears an existing assignment when membership is later revoked —
+	// both are live, no-timing-required paths to leaking item_ref/
+	// workspace/summary via a bare "you were assigned" fact.
+	if !vis.allows(n.CollectionID, n.ItemID) {
+		return false
+	}
+
 	// Addressed-to-you: the item was just assigned to the caller. Fires
 	// regardless of whether the caller also holds an explicit watch on
 	// the item (a watch and an addressed-to-you event are independent
-	// reasons to be told).
+	// reasons to be told) — gated above by the SAME access check a
+	// watch-matched notification gets, not a bespoke one.
 	if n.Kind == watchevents.KindAssignment && n.AssignedUserID != "" && n.AssignedUserID == userID {
 		return true
 	}

--- a/internal/server/handlers_watch_events.go
+++ b/internal/server/handlers_watch_events.go
@@ -24,6 +24,21 @@ const watchEventsKeepaliveInterval = sseKeepaliveInterval
 // tick instead of requiring a reconnect.
 var watchListRevalInterval = 60 * time.Second
 
+// maxConsecutiveWatchReloadFailures bounds how many reval ticks in a row
+// a stale watch list is tolerated before it's cleared (TASK-2533 codex
+// round 5 finding 1). A single failed reload is ordinary, bounded
+// staleness — one tick behind, same as watchListRevalInterval's normal
+// "eventually consistent" contract — but an unbounded run of failures
+// would leave a DEAD watch set live indefinitely (a removed watch or a
+// deleted item keeps matching forever; a watch created during the outage
+// is silently missed forever), since visCache gates current ACCESS, not
+// whether a watch still legitimately exists. 3 ticks (a few reval
+// intervals) is long enough to ride out a transient blip without going
+// silent on watch-matched delivery for something genuinely temporary,
+// short enough that a real outage doesn't leave stale matches live
+// indefinitely.
+const maxConsecutiveWatchReloadFailures = 3
+
 // watchEventPayload is the wire shape GET /api/v1/events/stream emits,
 // per DOC-2479's contract exactly: {id, ts, workspace, item_ref, kind,
 // actor, summary}.
@@ -113,6 +128,10 @@ func (s *Server) handleWatchEventsStream(w http.ResponseWriter, r *http.Request)
 			"user_id", user.ID, "error", werr)
 		watches = map[string]string{} // fail closed, not open
 	}
+	// consecutiveWatchReloadFailures tracks reval ticks in a row where
+	// loadWatchPredicates errored — see the reval.C case below (TASK-2533
+	// codex round 5 finding 1).
+	consecutiveWatchReloadFailures := 0
 	// TASK-2533 codex round 2 finding 2: EVERY notification — watch-
 	// matched or addressed-to-you — must pass the same current-access
 	// check before delivery, not just watch-matched ones. visCache
@@ -200,19 +219,37 @@ func (s *Server) handleWatchEventsStream(w http.ResponseWriter, r *http.Request)
 
 			fresh, ferr := s.loadWatchPredicates(r, user.ID)
 			if ferr != nil {
-				// Keep the STALE watch list rather than dropping all
-				// delivery for the tick: the list itself being one tick
-				// behind is a narrower, already-bounded staleness
-				// (mirrors watchListRevalInterval's own "eventually
-				// consistent" contract), and it's now gated by the
-				// FRESH visCache above regardless — a demoted/disabled
-				// user is denied via visCache even while watches stays
-				// stale. Dropping everything here would tie stream
-				// availability to an unrelated query's transient health.
-				slog.Warn("watch-events: watch-list reload failed, keeping previous watch snapshot (visibility was still refreshed)",
-					"user_id", user.ID, "error", ferr)
+				consecutiveWatchReloadFailures++
+				// TASK-2533 codex round 5 finding 1: keeping the stale
+				// watch list across a SINGLE reload failure is bounded
+				// staleness (one tick behind, matching
+				// watchListRevalInterval's normal "eventually
+				// consistent" contract) — but keeping it across an
+				// UNBOUNDED run of consecutive failures is not: a dead
+				// watch (removed, item deleted) keeps matching forever,
+				// and a watch created while every reload keeps failing
+				// is silently missed forever, since visCache gates
+				// CURRENT ACCESS, not whether a watch still legitimately
+				// exists. After maxConsecutiveWatchReloadFailures ticks
+				// of failure, fail closed on watch-matched delivery
+				// specifically: clear the set so it can no longer match
+				// anything stale. Addressed-to-you delivery is
+				// unaffected either way — it depends only on visCache,
+				// which was already refreshed above regardless of this
+				// failure.
+				if consecutiveWatchReloadFailures >= maxConsecutiveWatchReloadFailures {
+					if len(watches) > 0 {
+						slog.Warn("watch-events: watch-list reload failed repeatedly, clearing stale watch set (addressed-to-you delivery continues)",
+							"user_id", user.ID, "consecutive_failures", consecutiveWatchReloadFailures, "error", ferr)
+						watches = map[string]string{}
+					}
+				} else {
+					slog.Warn("watch-events: watch-list reload failed, keeping previous watch snapshot for now (visibility was still refreshed)",
+						"user_id", user.ID, "consecutive_failures", consecutiveWatchReloadFailures, "error", ferr)
+				}
 				continue
 			}
+			consecutiveWatchReloadFailures = 0
 			watches = fresh
 		}
 	}
@@ -322,8 +359,8 @@ func (c *watchVisCache) refreshUser() {
 // or grant revoked after the watch was created — doesn't keep delivering
 // live nudges for it.
 func (s *Server) loadWatchPredicates(r *http.Request, userID string) (map[string]string, error) {
-	if s.watchPredicatesLoadFault != nil {
-		if fe := s.watchPredicatesLoadFault(); fe != nil {
+	if fault := s.watchPredicatesLoadFault.Load(); fault != nil {
+		if fe := (*fault)(); fe != nil {
 			return nil, fe
 		}
 	}

--- a/internal/server/handlers_watch_events.go
+++ b/internal/server/handlers_watch_events.go
@@ -84,7 +84,26 @@ func (s *Server) handleWatchEventsStream(w http.ResponseWriter, r *http.Request)
 	w.Header().Set("Connection", "keep-alive")
 	w.Header().Set("X-Accel-Buffering", "no")
 
-	ch := s.watchEvents.Subscribe()
+	// Subscribe FIRST, replay (if resuming) as part of the SAME atomic
+	// call when a Last-Event-ID was supplied (codex round 1 finding 3):
+	// subscribing and separately reading the replay buffer left a window
+	// where a Notification published in between would be delivered
+	// TWICE — once from the replay loop below, once again from the live
+	// channel in the main select loop. SubscribeAndReplaySince closes
+	// that window structurally; see its doc comment in
+	// internal/watchevents.
+	var ch chan watchevents.Notification
+	var missed []watchevents.Notification
+	var lastID int64
+	if lastIDStr := r.Header.Get("Last-Event-ID"); lastIDStr != "" {
+		if parsed, perr := strconv.ParseInt(lastIDStr, 10, 64); perr == nil && parsed > 0 {
+			lastID = parsed
+			ch, missed = s.watchEvents.SubscribeAndReplaySince(lastID)
+		}
+	}
+	if ch == nil {
+		ch = s.watchEvents.Subscribe()
+	}
 	defer s.watchEvents.Unsubscribe(ch)
 
 	watches, werr := s.loadWatchPredicates(user.ID)
@@ -100,28 +119,25 @@ func (s *Server) handleWatchEventsStream(w http.ResponseWriter, r *http.Request)
 	}
 	flusher.Flush()
 
-	if lastIDStr := r.Header.Get("Last-Event-ID"); lastIDStr != "" {
-		if lastID, perr := strconv.ParseInt(lastIDStr, 10, 64); perr == nil && lastID > 0 {
-			missed := s.watchEvents.EventsSince(lastID)
-			if missed == nil {
-				if err := writeSSEEvent(w, "sync_required", 0, map[string]string{
-					"reason": "Notification buffer exceeded. Reconnect without Last-Event-ID to resync.",
-				}); err != nil {
-					slog.Debug("watch-events: sync_required write failed, closing", "user_id", user.ID, "error", err)
+	if lastID > 0 {
+		if missed == nil {
+			if err := writeSSEEvent(w, "sync_required", 0, map[string]string{
+				"reason": "Notification buffer exceeded. Reconnect without Last-Event-ID to resync.",
+			}); err != nil {
+				slog.Debug("watch-events: sync_required write failed, closing", "user_id", user.ID, "error", err)
+				return
+			}
+			flusher.Flush()
+		} else {
+			for _, n := range missed {
+				if !watchNotificationVisible(watches, user.ID, n) {
+					continue
+				}
+				if err := writeSSEEvent(w, "notification", n.ID, watchEventPayloadFor(s, n)); err != nil {
+					slog.Debug("watch-events: replay write failed, closing", "user_id", user.ID, "error", err)
 					return
 				}
 				flusher.Flush()
-			} else {
-				for _, n := range missed {
-					if !watchNotificationVisible(watches, user.ID, n) {
-						continue
-					}
-					if err := writeSSEEvent(w, "notification", n.ID, watchEventPayloadFor(s, n)); err != nil {
-						slog.Debug("watch-events: replay write failed, closing", "user_id", user.ID, "error", err)
-						return
-					}
-					flusher.Flush()
-				}
 			}
 		}
 	}
@@ -170,12 +186,17 @@ func (s *Server) handleWatchEventsStream(w http.ResponseWriter, r *http.Request)
 }
 
 // loadWatchPredicates returns the caller's active watches as
-// itemID -> predicate ("" = unconditional).
+// itemID -> predicate ("" = unconditional). Filtered through
+// filterWatchesByCurrentAccess (TASK-2533 codex round 1 finding 1) so a
+// watch on an item the caller can no longer see — workspace membership
+// or grant revoked after the watch was created — doesn't keep delivering
+// live nudges for it.
 func (s *Server) loadWatchPredicates(userID string) (map[string]string, error) {
 	list, err := s.store.ListWatchesForUser(userID)
 	if err != nil {
 		return nil, err
 	}
+	list = s.filterWatchesByCurrentAccess(userID, list)
 	m := make(map[string]string, len(list))
 	for _, w := range list {
 		m[w.ItemID] = w.Predicate

--- a/internal/server/handlers_watch_events.go
+++ b/internal/server/handlers_watch_events.go
@@ -207,18 +207,46 @@ func (s *Server) handleWatchEventsStream(w http.ResponseWriter, r *http.Request)
 // each workspace rather than precomputed. reset() is called on the same
 // reval tick that reloads `watches`, so a revoked grant or membership
 // takes effect within one tick without requiring a reconnect.
+//
+// TASK-2533 codex round 3: the round-2 version's reset() cleared only
+// the per-workspace map — the cached *models.User itself was captured
+// ONCE at connect time and never re-fetched, so a mid-stream admin
+// demotion or disable left computeWatchAccessVisibility's admin bypass
+// running on stale Role/disabled data until reconnect, on BOTH delivery
+// paths (watch-matched and addressed-to-you alike, since both go through
+// this same cache). refreshUser (called by both the constructor and
+// reset, so the cadence matches computeSSEVisibility's own — see below)
+// closes that: it re-fetches the user fresh from the store every reval
+// tick, exactly like computeSSEVisibility does on ITS revalidation tick
+// in handlers_events.go (that function is invoked once at connect and
+// again only on each membershipCheck tick — never per event — so "per
+// cache reset" here IS "per tick" there; this is not a narrower cadence
+// than the thing it mirrors).
 type watchVisCache struct {
 	s    *Server
 	r    *http.Request
 	user *models.User
+	// deny, once true, makes forWorkspace return a deny-all
+	// watchAccessVisibility{} for every workspace without even calling
+	// computeWatchAccessVisibility — set by refreshUser when the user
+	// can't be confirmed live and unrestricted. Re-checked (and cleared,
+	// if the user becomes valid again) on every subsequent reset(), so a
+	// re-enabled or un-demoted user recovers on the next tick rather than
+	// staying stuck for the rest of the connection.
+	deny bool
 	m    map[string]watchAccessVisibility
 }
 
 func newWatchVisCache(s *Server, r *http.Request, user *models.User) *watchVisCache {
-	return &watchVisCache{s: s, r: r, user: user, m: make(map[string]watchAccessVisibility)}
+	c := &watchVisCache{s: s, r: r, user: user, m: make(map[string]watchAccessVisibility)}
+	c.refreshUser()
+	return c
 }
 
 func (c *watchVisCache) forWorkspace(workspaceID string) watchAccessVisibility {
+	if c.deny {
+		return watchAccessVisibility{}
+	}
 	if v, ok := c.m[workspaceID]; ok {
 		return v
 	}
@@ -229,6 +257,42 @@ func (c *watchVisCache) forWorkspace(workspaceID string) watchAccessVisibility {
 
 func (c *watchVisCache) reset() {
 	c.m = make(map[string]watchAccessVisibility)
+	c.refreshUser()
+}
+
+// refreshUser re-fetches c.user fresh from the store, mirroring
+// computeSSEVisibility's re-fetch (handlers_events.go) with ONE
+// deliberate, documented difference: computeSSEVisibility falls back to
+// the STALE cached user on a transient GetUser error or a deleted user,
+// reasoned as "a stale-but-previously-valid snapshot can't widen
+// visibility beyond what it already had, so don't punish a DB blip."
+// This function fails CLOSED instead (sets deny = true) on any of
+// {fetch error, user gone, user disabled} — not a blanket "mirror
+// exactly" claim, and it shouldn't be described as one. A nudge
+// stream's wrong failure mode is different from a browser SSE tab's:
+// delivering a fact (an assignment, a watched status change) to someone
+// who shouldn't see it is worse here than the stream going briefly
+// silent until the next successful tick, so this trades the SSE
+// handler's availability-leaning fallback for a stricter one.
+func (c *watchVisCache) refreshUser() {
+	fresh, err := c.s.store.GetUser(c.user.ID)
+	if err != nil {
+		slog.Warn("watch-events: GetUser failed during visibility recompute, denying until next tick",
+			"user_id", c.user.ID, "error", err)
+		c.deny = true
+		return
+	}
+	if fresh == nil {
+		// Deleted mid-connection.
+		c.deny = true
+		return
+	}
+	if fresh.IsDisabled() {
+		c.deny = true
+		return
+	}
+	c.user = fresh
+	c.deny = false
 }
 
 // loadWatchPredicates returns the caller's active watches as

--- a/internal/server/handlers_watch_events_test.go
+++ b/internal/server/handlers_watch_events_test.go
@@ -517,7 +517,7 @@ func TestWatchNotificationVisible_UnconditionalWatch(t *testing.T) {
 	t.Parallel()
 	watches := map[string]string{"item-1": ""}
 	n := watchevents.Notification{ItemID: "item-1", Kind: watchevents.KindComment}
-	if !watchNotificationVisible(watches, "user-1", n) {
+	if !watchNotificationVisible(watches, watchAccessVisibility{fullAccess: true}, "user-1", n) {
 		t.Fatal("expected an unconditional watch to match any notification on the item")
 	}
 }
@@ -526,7 +526,7 @@ func TestWatchNotificationVisible_UnwatchedItemDenied(t *testing.T) {
 	t.Parallel()
 	watches := map[string]string{"item-1": ""}
 	n := watchevents.Notification{ItemID: "item-2", Kind: watchevents.KindComment}
-	if watchNotificationVisible(watches, "user-1", n) {
+	if watchNotificationVisible(watches, watchAccessVisibility{fullAccess: true}, "user-1", n) {
 		t.Fatal("expected an unwatched item's notification to be denied")
 	}
 }
@@ -535,7 +535,7 @@ func TestWatchNotificationVisible_PredicateGatesNonStatusKinds(t *testing.T) {
 	t.Parallel()
 	watches := map[string]string{"item-1": "status=done"}
 	n := watchevents.Notification{ItemID: "item-1", Kind: watchevents.KindComment}
-	if watchNotificationVisible(watches, "user-1", n) {
+	if watchNotificationVisible(watches, watchAccessVisibility{fullAccess: true}, "user-1", n) {
 		t.Fatal("expected a predicated watch to suppress a comment notification")
 	}
 }
@@ -545,10 +545,10 @@ func TestWatchNotificationVisible_PredicateMatchesOnlyTargetValue(t *testing.T) 
 	watches := map[string]string{"item-1": "status=done"}
 	wrong := watchevents.Notification{ItemID: "item-1", Kind: watchevents.KindStatusChange, StatusFieldKey: "status", ToStatus: "in-progress"}
 	right := watchevents.Notification{ItemID: "item-1", Kind: watchevents.KindStatusChange, StatusFieldKey: "status", ToStatus: "done"}
-	if watchNotificationVisible(watches, "user-1", wrong) {
+	if watchNotificationVisible(watches, watchAccessVisibility{fullAccess: true}, "user-1", wrong) {
 		t.Fatal("expected the non-matching status transition to be denied")
 	}
-	if !watchNotificationVisible(watches, "user-1", right) {
+	if !watchNotificationVisible(watches, watchAccessVisibility{fullAccess: true}, "user-1", right) {
 		t.Fatal("expected the matching status transition to be visible")
 	}
 }
@@ -557,7 +557,7 @@ func TestWatchNotificationVisible_AddressedToYouIgnoresWatchList(t *testing.T) {
 	t.Parallel()
 	watches := map[string]string{} // no watches at all
 	n := watchevents.Notification{ItemID: "item-1", Kind: watchevents.KindAssignment, AssignedUserID: "user-1"}
-	if !watchNotificationVisible(watches, "user-1", n) {
+	if !watchNotificationVisible(watches, watchAccessVisibility{fullAccess: true}, "user-1", n) {
 		t.Fatal("expected an assignment-to-you notification to be visible with no watch")
 	}
 }
@@ -566,8 +566,270 @@ func TestWatchNotificationVisible_AssignmentToSomeoneElseDenied(t *testing.T) {
 	t.Parallel()
 	watches := map[string]string{}
 	n := watchevents.Notification{ItemID: "item-1", Kind: watchevents.KindAssignment, AssignedUserID: "user-2"}
-	if watchNotificationVisible(watches, "user-1", n) {
+	if watchNotificationVisible(watches, watchAccessVisibility{fullAccess: true}, "user-1", n) {
 		t.Fatal("expected an assignment to someone else to be denied")
+	}
+}
+
+// TestWatchNotificationVisible_AddressedToYouStillGatedByAccess covers
+// TASK-2533 codex round 2 finding 2: the addressed-to-you branch used to
+// return true unconditionally, with NO access check — an item assigned
+// to a "specific"-access member whose granted collections don't include
+// it (validateAssignmentScope only checks workspace membership, never
+// collection access — a completely ordinary, no-revocation-needed
+// scenario) would still leak. A zero-value watchAccessVisibility (no
+// full access, no granted collections/items) must deny an
+// assignment-to-you notification just as it would a watch-matched one.
+func TestWatchNotificationVisible_AddressedToYouStillGatedByAccess(t *testing.T) {
+	t.Parallel()
+	watches := map[string]string{}
+	deny := watchAccessVisibility{} // zero value: nothing visible
+	n := watchevents.Notification{
+		ItemID: "item-1", CollectionID: "coll-1",
+		Kind: watchevents.KindAssignment, AssignedUserID: "user-1",
+	}
+	if watchNotificationVisible(watches, deny, "user-1", n) {
+		t.Fatal("expected an assignment-to-you notification to be denied when the caller has no current access to the item's collection")
+	}
+
+	allow := watchAccessVisibility{visibleCollIDs: map[string]bool{"coll-1": true}}
+	if !watchNotificationVisible(watches, allow, "user-1", n) {
+		t.Fatal("expected the same notification to be visible once the collection is in the caller's current access")
+	}
+}
+
+// TestWatchEventsStream_AssignmentOutsideMemberCollectionAccessDenied is
+// the HTTP/SSE-level regression for TASK-2533 codex round 2 finding 2:
+// an item can be assigned to a "specific"-access member whose granted
+// collections do NOT include it — validateAssignmentScope
+// (internal/store/items.go) only checks WORKSPACE membership, never
+// collection access, so this needs no revocation timing at all, just an
+// ordinary assignment. The addressed-to-you path used to deliver it
+// anyway with zero access check.
+func TestWatchEventsStream_AssignmentOutsideMemberCollectionAccessDenied(t *testing.T) {
+	t.Parallel()
+	srv := testServerWithWatchEvents(t)
+	slug := createWSWithCollections(t, srv)
+
+	// A second collection the restricted member WILL be granted, distinct
+	// from "tasks" where the assigned item actually lives.
+	rr := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections", map[string]interface{}{
+		"name": "Docs Only", "icon": "doc",
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create second collection: %d %s", rr.Code, rr.Body.String())
+	}
+	var otherColl models.Collection
+	parseJSON(t, rr, &otherColl)
+
+	rr = doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections/tasks/items",
+		map[string]interface{}{"title": "Assign me", "fields": `{"status":"open"}`})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("seed item: %d %s", rr.Code, rr.Body.String())
+	}
+	var item models.Item
+	parseJSON(t, rr, &item)
+
+	ws, err := srv.store.GetWorkspaceBySlug(slug)
+	if err != nil {
+		t.Fatalf("GetWorkspaceBySlug: %v", err)
+	}
+	owner, err := srv.store.CreateUser(models.UserCreate{
+		Email: "assign-owner@example.com", Name: "Owner", Password: "pw-test-12345",
+	})
+	if err != nil {
+		t.Fatalf("CreateUser (owner): %v", err)
+	}
+	if err := srv.store.AddWorkspaceMember(ws.ID, owner.ID, "owner"); err != nil {
+		t.Fatalf("AddWorkspaceMember (owner): %v", err)
+	}
+	ownerTok, err := srv.store.CreateAPIToken(owner.ID, models.APITokenCreate{Name: "assign-owner-test"}, 0, 0)
+	if err != nil {
+		t.Fatalf("CreateAPIToken (owner): %v", err)
+	}
+
+	restricted, err := srv.store.CreateUser(models.UserCreate{
+		Email: "assign-restricted@example.com", Name: "Restricted", Password: "pw-test-12345",
+	})
+	if err != nil {
+		t.Fatalf("CreateUser (restricted): %v", err)
+	}
+	if err := srv.store.AddWorkspaceMember(ws.ID, restricted.ID, "editor"); err != nil {
+		t.Fatalf("AddWorkspaceMember (restricted): %v", err)
+	}
+	// Granted ONLY the "Docs Only" collection — NOT "tasks", where the
+	// item being assigned actually lives.
+	if err := srv.store.SetMemberCollectionAccess(ws.ID, restricted.ID, "specific", []string{otherColl.ID}); err != nil {
+		t.Fatalf("SetMemberCollectionAccess: %v", err)
+	}
+	restrictedTok, err := srv.store.CreateAPIToken(restricted.ID, models.APITokenCreate{Name: "assign-restricted-test"}, 0, 0)
+	if err != nil {
+		t.Fatalf("CreateAPIToken (restricted): %v", err)
+	}
+
+	// An item in the GRANTED collection, watched BEFORE connecting (the
+	// watches map is loaded once at connect time and only reloaded on
+	// the 60s reval tick — creating this after connecting would make the
+	// "prove liveness" step below flaky/slow rather than deterministic).
+	rr = bearerJSON(t, srv, "POST", "/api/v1/workspaces/"+slug+"/collections/"+otherColl.Slug+"/items", ownerTok.Token,
+		map[string]interface{}{"title": "Visible item", "fields": "{}"})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("seed visible item: %d %s", rr.Code, rr.Body.String())
+	}
+	var visibleItem models.Item
+	parseJSON(t, rr, &visibleItem)
+	if _, err := srv.store.CreateWatch(ws.ID, restricted.ID, visibleItem.ID, ""); err != nil {
+		t.Fatalf("CreateWatch: %v", err)
+	}
+
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ch := connectWatchStream(ctx, t, ts.URL, restrictedTok.Token)
+	waitForWatchEvent(t, ch, 3*time.Second) // connected
+
+	// Owner assigns the item (in "tasks") to the restricted member.
+	// validateAssignmentScope only checks workspace membership, so this
+	// succeeds even though the assignee can't see "tasks" at all.
+	rr = bearerJSON(t, srv, "PATCH", "/api/v1/workspaces/"+slug+"/items/"+item.Slug, ownerTok.Token,
+		map[string]interface{}{"assigned_user_id": restricted.ID})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("assign item: %d %s", rr.Code, rr.Body.String())
+	}
+
+	// Prove the stream is live and would have surfaced something: comment
+	// on the watched, GRANTED item, then assert THAT arrives instead of
+	// the assignment leaking first.
+	rr = bearerJSON(t, srv, "POST", "/api/v1/workspaces/"+slug+"/items/"+visibleItem.Slug+"/comments", ownerTok.Token,
+		map[string]interface{}{"body": "visible nudge"})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("comment on visible item: %d %s", rr.Code, rr.Body.String())
+	}
+
+	ev := waitForWatchEvent(t, ch, 3*time.Second)
+	var payload watchEventPayload
+	if err := json.Unmarshal([]byte(ev.Data), &payload); err != nil {
+		t.Fatalf("parse payload: %v", err)
+	}
+	if payload.ItemRef != visibleItem.Ref {
+		t.Fatalf("expected the VISIBLE item's ref %q first, got %q (kind %q) — the out-of-scope assignment leaked",
+			visibleItem.Ref, payload.ItemRef, payload.Kind)
+	}
+	if payload.Kind == watchevents.KindAssignment {
+		t.Fatalf("assignment notification leaked to a member with no access to the item's collection: %+v", payload)
+	}
+}
+
+// TestWatchEventsStream_ItemGrantGuestDoesNotSeeSiblingItem is the
+// HTTP/SSE-level regression for TASK-2533 codex round 2 finding 1: a
+// guest granted only item A must not receive stream notifications for
+// an ungranted sibling item B in the SAME collection, even if a watch
+// row exists on B (simulating access narrowed after the watch was
+// created — the exact scenario the delivery-time filter, not the
+// creation-time gate, has to catch).
+func TestWatchEventsStream_ItemGrantGuestDoesNotSeeSiblingItem(t *testing.T) {
+	t.Parallel()
+	srv := testServerWithWatchEvents(t)
+	slug := createWSWithCollections(t, srv)
+
+	rrA := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections/tasks/items",
+		map[string]interface{}{"title": "Granted item", "fields": `{"status":"open"}`})
+	if rrA.Code != http.StatusCreated {
+		t.Fatalf("seed item A: %d %s", rrA.Code, rrA.Body.String())
+	}
+	var itemA models.Item
+	parseJSON(t, rrA, &itemA)
+
+	rrB := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections/tasks/items",
+		map[string]interface{}{"title": "Sibling item", "fields": `{"status":"open"}`})
+	if rrB.Code != http.StatusCreated {
+		t.Fatalf("seed item B: %d %s", rrB.Code, rrB.Body.String())
+	}
+	var itemB models.Item
+	parseJSON(t, rrB, &itemB)
+	if itemA.CollectionID != itemB.CollectionID {
+		t.Fatalf("test setup bug: items must share a collection")
+	}
+
+	ws, err := srv.store.GetWorkspaceBySlug(slug)
+	if err != nil {
+		t.Fatalf("GetWorkspaceBySlug: %v", err)
+	}
+
+	// Owner performs the mutations below — the guest below is deliberately
+	// NOT granted edit access to item B, so it must not be the guest's
+	// own token making that PATCH (it would be correctly rejected before
+	// ever reaching the notification pipeline, which is not what this
+	// test is exercising).
+	owner, err := srv.store.CreateUser(models.UserCreate{
+		Email: "sibling-stream-owner@example.com", Name: "Owner", Password: "pw-test-12345",
+	})
+	if err != nil {
+		t.Fatalf("CreateUser (owner): %v", err)
+	}
+	if err := srv.store.AddWorkspaceMember(ws.ID, owner.ID, "owner"); err != nil {
+		t.Fatalf("AddWorkspaceMember (owner): %v", err)
+	}
+	ownerTok, err := srv.store.CreateAPIToken(owner.ID, models.APITokenCreate{Name: "sibling-owner-test"}, 0, 0)
+	if err != nil {
+		t.Fatalf("CreateAPIToken (owner): %v", err)
+	}
+
+	guest, err := srv.store.CreateUser(models.UserCreate{
+		Email: "sibling-stream-guest@example.com", Name: "Sibling Stream Guest", Password: "pw-test-12345",
+	})
+	if err != nil {
+		t.Fatalf("CreateUser (guest): %v", err)
+	}
+	if _, err := srv.store.CreateItemGrant(ws.ID, itemA.ID, guest.ID, "view", guest.ID); err != nil {
+		t.Fatalf("CreateItemGrant: %v", err)
+	}
+	guestTok, err := srv.store.CreateAPIToken(guest.ID, models.APITokenCreate{Name: "sibling-guest-test"}, 0, 0)
+	if err != nil {
+		t.Fatalf("CreateAPIToken (guest): %v", err)
+	}
+
+	// Watches on BOTH items, created directly at the store layer —
+	// simulating a watch on B that predates a since-narrowed grant
+	// (the API's creation-time requireItemVisible gate would correctly
+	// refuse to let the guest create this watch on B today; the
+	// delivery-time filter is what has to catch a STALE one).
+	if _, err := srv.store.CreateWatch(ws.ID, guest.ID, itemA.ID, ""); err != nil {
+		t.Fatalf("CreateWatch(A): %v", err)
+	}
+	if _, err := srv.store.CreateWatch(ws.ID, guest.ID, itemB.ID, ""); err != nil {
+		t.Fatalf("CreateWatch(B): %v", err)
+	}
+
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ch := connectWatchStream(ctx, t, ts.URL, guestTok.Token)
+	waitForWatchEvent(t, ch, 3*time.Second) // connected
+
+	// Mutate the UNGRANTED sibling B first — must not surface.
+	rr := bearerJSON(t, srv, "PATCH", "/api/v1/workspaces/"+slug+"/items/"+itemB.Slug, ownerTok.Token,
+		map[string]interface{}{"fields": `{"status":"done"}`})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("update item B: %d %s", rr.Code, rr.Body.String())
+	}
+	// Then mutate the GRANTED item A — must surface, proving the stream
+	// is live and B's absence above wasn't just "nothing happened yet".
+	rr = bearerJSON(t, srv, "PATCH", "/api/v1/workspaces/"+slug+"/items/"+itemA.Slug, ownerTok.Token,
+		map[string]interface{}{"fields": `{"status":"done"}`})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("update item A: %d %s", rr.Code, rr.Body.String())
+	}
+
+	ev := waitForWatchEvent(t, ch, 3*time.Second)
+	var payload watchEventPayload
+	if err := json.Unmarshal([]byte(ev.Data), &payload); err != nil {
+		t.Fatalf("parse payload: %v", err)
+	}
+	if payload.ItemRef != itemA.Ref {
+		t.Fatalf("expected the GRANTED item A's ref %q first, got %q — ungranted sibling B leaked", itemA.Ref, payload.ItemRef)
 	}
 }
 

--- a/internal/server/handlers_watch_events_test.go
+++ b/internal/server/handlers_watch_events_test.go
@@ -1,0 +1,541 @@
+package server
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/watchevents"
+)
+
+func testServerWithWatchEvents(t *testing.T) *Server {
+	t.Helper()
+	srv := testServer(t)
+	srv.SetWatchEventsBus(watchevents.New())
+	return srv
+}
+
+// watchSSEEvent mirrors sseEvent (handlers_events_test.go) for the
+// watch-events stream.
+type watchSSEEvent struct {
+	Type string
+	Data string
+}
+
+// connectWatchStream connects to GET /api/v1/events/stream with a Bearer
+// token and returns a channel of parsed SSE events.
+func connectWatchStream(ctx context.Context, t *testing.T, baseURL, token string) <-chan watchSSEEvent {
+	t.Helper()
+	ch := make(chan watchSSEEvent, 32)
+
+	req, err := http.NewRequestWithContext(ctx, "GET", baseURL+"/api/v1/events/stream", nil)
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("failed to connect: %v", err)
+	}
+
+	go func() {
+		defer resp.Body.Close()
+		defer close(ch)
+		scanner := bufio.NewScanner(resp.Body)
+		var eventType, data string
+		for scanner.Scan() {
+			line := scanner.Text()
+			switch {
+			case strings.HasPrefix(line, "event: "):
+				eventType = strings.TrimPrefix(line, "event: ")
+			case strings.HasPrefix(line, "data: "):
+				data = strings.TrimPrefix(line, "data: ")
+			case line == "":
+				if eventType != "" && data != "" {
+					ch <- watchSSEEvent{Type: eventType, Data: data}
+					eventType, data = "", ""
+				}
+			}
+		}
+	}()
+
+	return ch
+}
+
+func waitForWatchEvent(t *testing.T, ch <-chan watchSSEEvent, timeout time.Duration) watchSSEEvent {
+	t.Helper()
+	select {
+	case ev, ok := <-ch:
+		if !ok {
+			t.Fatal("event channel closed unexpectedly")
+		}
+		return ev
+	case <-time.After(timeout):
+		t.Fatal("timed out waiting for watch stream event")
+		return watchSSEEvent{}
+	}
+}
+
+// assertNoWatchEvent drains ch for `d` and fails if a "notification"
+// event with the given item_ref shows up — used to assert an unwatched
+// item's mutation does NOT reach the stream.
+func assertNoWatchEventForRef(t *testing.T, ch <-chan watchSSEEvent, ref string, d time.Duration) {
+	t.Helper()
+	deadline := time.After(d)
+	for {
+		select {
+		case ev, ok := <-ch:
+			if !ok {
+				return
+			}
+			if ev.Type != "notification" {
+				continue
+			}
+			var payload watchEventPayload
+			if err := json.Unmarshal([]byte(ev.Data), &payload); err == nil && payload.ItemRef == ref {
+				t.Fatalf("unexpected notification for unwatched item %q: %+v", ref, payload)
+			}
+		case <-deadline:
+			return
+		}
+	}
+}
+
+func TestWatchEventsStream_RequiresAuth(t *testing.T) {
+	t.Parallel()
+	srv := testServerWithWatchEvents(t)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	req, _ := http.NewRequest("GET", ts.URL+"/api/v1/events/stream", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", resp.StatusCode)
+	}
+}
+
+func TestWatchEventsStream_ConnectedEvent(t *testing.T) {
+	t.Parallel()
+	srv := testServerWithWatchEvents(t)
+	_, _, tok, user := setupWatchTestUser(t, srv)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch := connectWatchStream(ctx, t, ts.URL, tok.Token)
+	ev := waitForWatchEvent(t, ch, 3*time.Second)
+	if ev.Type != "connected" {
+		t.Fatalf("expected 'connected' event, got %q (data: %s)", ev.Type, ev.Data)
+	}
+	var data map[string]string
+	if err := json.Unmarshal([]byte(ev.Data), &data); err != nil {
+		t.Fatalf("parse connected data: %v", err)
+	}
+	if data["user_id"] != user.ID {
+		t.Fatalf("expected user_id %q, got %q", user.ID, data["user_id"])
+	}
+}
+
+func TestWatchEventsStream_DeliversWatchedStatusChange(t *testing.T) {
+	t.Parallel()
+	srv := testServerWithWatchEvents(t)
+	slug, item, tok, _ := setupWatchTestUser(t, srv)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	// Unconditional watch.
+	rr := bearerCall(t, srv, "POST", "/api/v1/workspaces/"+slug+"/items/"+item.Slug+"/watch", tok.Token, nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("create watch: %d %s", rr.Code, rr.Body.String())
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ch := connectWatchStream(ctx, t, ts.URL, tok.Token)
+	waitForWatchEvent(t, ch, 3*time.Second) // connected
+
+	rr = bearerJSON(t, srv, "PATCH", "/api/v1/workspaces/"+slug+"/items/"+item.Slug, tok.Token,
+		map[string]interface{}{"fields": `{"status":"done"}`})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("update item: %d %s", rr.Code, rr.Body.String())
+	}
+
+	ev := waitForWatchEvent(t, ch, 3*time.Second)
+	if ev.Type != "notification" {
+		t.Fatalf("expected 'notification', got %q (data: %s)", ev.Type, ev.Data)
+	}
+	var payload watchEventPayload
+	if err := json.Unmarshal([]byte(ev.Data), &payload); err != nil {
+		t.Fatalf("parse payload: %v", err)
+	}
+	if payload.ItemRef != item.Ref {
+		t.Fatalf("expected item_ref %q, got %q", item.Ref, payload.ItemRef)
+	}
+	if payload.Kind != watchevents.KindStatusChange {
+		t.Fatalf("expected kind %q, got %q", watchevents.KindStatusChange, payload.Kind)
+	}
+	if payload.Workspace != slug {
+		t.Fatalf("expected workspace %q, got %q", slug, payload.Workspace)
+	}
+	if payload.Summary != "open → done" {
+		t.Fatalf("expected summary 'open → done', got %q", payload.Summary)
+	}
+}
+
+func TestWatchEventsStream_SuppressesUnwatchedItem(t *testing.T) {
+	t.Parallel()
+	srv := testServerWithWatchEvents(t)
+	slug, watchedItem, tok, _ := setupWatchTestUser(t, srv)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	// Seed a second, unwatched item in the same collection.
+	rr := bearerJSON(t, srv, "POST", "/api/v1/workspaces/"+slug+"/collections/tasks/items", tok.Token,
+		map[string]interface{}{"title": "Not watched", "fields": `{"status":"open"}`})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("seed second item: %d %s", rr.Code, rr.Body.String())
+	}
+	var otherItem models.Item
+	parseJSON(t, rr, &otherItem)
+
+	rr = bearerCall(t, srv, "POST", "/api/v1/workspaces/"+slug+"/items/"+watchedItem.Slug+"/watch", tok.Token, nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("create watch: %d %s", rr.Code, rr.Body.String())
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ch := connectWatchStream(ctx, t, ts.URL, tok.Token)
+	waitForWatchEvent(t, ch, 3*time.Second) // connected
+
+	// Mutate the UNWATCHED item — must not surface.
+	rr = bearerJSON(t, srv, "PATCH", "/api/v1/workspaces/"+slug+"/items/"+otherItem.Slug, tok.Token,
+		map[string]interface{}{"fields": `{"status":"done"}`})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("update other item: %d %s", rr.Code, rr.Body.String())
+	}
+	// Then mutate the WATCHED item — must surface, proving the stream is
+	// live and the absence above wasn't just "nothing happened yet".
+	rr = bearerJSON(t, srv, "PATCH", "/api/v1/workspaces/"+slug+"/items/"+watchedItem.Slug, tok.Token,
+		map[string]interface{}{"fields": `{"status":"done"}`})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("update watched item: %d %s", rr.Code, rr.Body.String())
+	}
+
+	ev := waitForWatchEvent(t, ch, 3*time.Second)
+	var payload watchEventPayload
+	if err := json.Unmarshal([]byte(ev.Data), &payload); err != nil {
+		t.Fatalf("parse payload: %v", err)
+	}
+	if payload.ItemRef != watchedItem.Ref {
+		t.Fatalf("expected the WATCHED item's ref %q first, got %q — unwatched item leaked", watchedItem.Ref, payload.ItemRef)
+	}
+}
+
+func TestWatchEventsStream_AddressedToYou_Assignment(t *testing.T) {
+	t.Parallel()
+	srv := testServerWithWatchEvents(t)
+	slug, item, tok, user := setupWatchTestUser(t, srv)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	// No explicit watch — this must fire purely via addressed-to-you.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ch := connectWatchStream(ctx, t, ts.URL, tok.Token)
+	waitForWatchEvent(t, ch, 3*time.Second) // connected
+
+	rr := bearerJSON(t, srv, "PATCH", "/api/v1/workspaces/"+slug+"/items/"+item.Slug, tok.Token,
+		map[string]interface{}{"assigned_user_id": user.ID})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("assign item: %d %s", rr.Code, rr.Body.String())
+	}
+
+	ev := waitForWatchEvent(t, ch, 3*time.Second)
+	var payload watchEventPayload
+	if err := json.Unmarshal([]byte(ev.Data), &payload); err != nil {
+		t.Fatalf("parse payload: %v", err)
+	}
+	if payload.Kind != watchevents.KindAssignment {
+		t.Fatalf("expected kind %q, got %q", watchevents.KindAssignment, payload.Kind)
+	}
+	if payload.ItemRef != item.Ref {
+		t.Fatalf("expected item_ref %q, got %q", item.Ref, payload.ItemRef)
+	}
+}
+
+func TestWatchEventsStream_PredicateOnlyFiresOnMatch(t *testing.T) {
+	t.Parallel()
+	srv := testServerWithWatchEvents(t)
+	slug, item, tok, _ := setupWatchTestUser(t, srv)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	rr := bearerCall(t, srv, "POST", "/api/v1/workspaces/"+slug+"/items/"+item.Slug+"/watch", tok.Token,
+		[]byte(`{"predicate":"status=done"}`))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("create watch: %d %s", rr.Code, rr.Body.String())
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ch := connectWatchStream(ctx, t, ts.URL, tok.Token)
+	waitForWatchEvent(t, ch, 3*time.Second) // connected
+
+	// Transition to a non-matching status first — must NOT fire.
+	rr = bearerJSON(t, srv, "PATCH", "/api/v1/workspaces/"+slug+"/items/"+item.Slug, tok.Token,
+		map[string]interface{}{"fields": `{"status":"in-progress"}`})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("update to in-progress: %d %s", rr.Code, rr.Body.String())
+	}
+	assertNoWatchEventForRef(t, ch, item.Ref, 300*time.Millisecond)
+
+	// Now transition to the matching status — must fire.
+	rr = bearerJSON(t, srv, "PATCH", "/api/v1/workspaces/"+slug+"/items/"+item.Slug, tok.Token,
+		map[string]interface{}{"fields": `{"status":"done"}`})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("update to done: %d %s", rr.Code, rr.Body.String())
+	}
+
+	ev := waitForWatchEvent(t, ch, 3*time.Second)
+	var payload watchEventPayload
+	if err := json.Unmarshal([]byte(ev.Data), &payload); err != nil {
+		t.Fatalf("parse payload: %v", err)
+	}
+	if payload.Summary != "in-progress → done" {
+		t.Fatalf("expected summary 'in-progress → done', got %q", payload.Summary)
+	}
+}
+
+func TestWatchEventsStream_CommentNotification(t *testing.T) {
+	t.Parallel()
+	srv := testServerWithWatchEvents(t)
+	slug, item, tok, _ := setupWatchTestUser(t, srv)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	rr := bearerCall(t, srv, "POST", "/api/v1/workspaces/"+slug+"/items/"+item.Slug+"/watch", tok.Token, nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("create watch: %d %s", rr.Code, rr.Body.String())
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ch := connectWatchStream(ctx, t, ts.URL, tok.Token)
+	waitForWatchEvent(t, ch, 3*time.Second) // connected
+
+	rr = bearerJSON(t, srv, "POST", "/api/v1/workspaces/"+slug+"/items/"+item.Slug+"/comments", tok.Token,
+		map[string]interface{}{"body": "fix verified, looks good"})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create comment: %d %s", rr.Code, rr.Body.String())
+	}
+
+	ev := waitForWatchEvent(t, ch, 3*time.Second)
+	var payload watchEventPayload
+	if err := json.Unmarshal([]byte(ev.Data), &payload); err != nil {
+		t.Fatalf("parse payload: %v", err)
+	}
+	if payload.Kind != watchevents.KindComment {
+		t.Fatalf("expected kind %q, got %q", watchevents.KindComment, payload.Kind)
+	}
+	if payload.Summary != "fix verified, looks good" {
+		t.Fatalf("expected summary to be the comment body, got %q", payload.Summary)
+	}
+}
+
+// TestWatchEventsStream_BulkAssignFires exercises the producer-coverage
+// claim in publishWatchNotifications' doc comment (TASK-2533 audit): a
+// bulk "assign" op (which calls store.UpdateItem directly, bypassing
+// handleUpdateItem entirely) must still surface an addressed-to-you
+// assignment notification — proving the fix belongs at the store layer
+// (LastMutation), not in each individual HTTP handler.
+func TestWatchEventsStream_BulkAssignFires(t *testing.T) {
+	t.Parallel()
+	srv := testServerWithWatchEvents(t)
+	slug, item, tok, user := setupWatchTestUser(t, srv)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ch := connectWatchStream(ctx, t, ts.URL, tok.Token)
+	waitForWatchEvent(t, ch, 3*time.Second) // connected
+
+	rr := bearerJSON(t, srv, "POST", "/api/v1/workspaces/"+slug+"/items/bulk", tok.Token,
+		map[string]interface{}{
+			"ids":              []string{item.ID},
+			"op":               "assign",
+			"assigned_user_id": user.ID,
+		})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("bulk assign: %d %s", rr.Code, rr.Body.String())
+	}
+
+	ev := waitForWatchEvent(t, ch, 3*time.Second)
+	var payload watchEventPayload
+	if err := json.Unmarshal([]byte(ev.Data), &payload); err != nil {
+		t.Fatalf("parse payload: %v", err)
+	}
+	if payload.Kind != watchevents.KindAssignment {
+		t.Fatalf("expected kind %q from a bulk assign, got %q", watchevents.KindAssignment, payload.Kind)
+	}
+	if payload.ItemRef != item.Ref {
+		t.Fatalf("expected item_ref %q, got %q", item.Ref, payload.ItemRef)
+	}
+}
+
+// TestWatchEventsStream_UpdateWithAttachedComment covers the bypass
+// named in publishWatchNotifications' audit: `PATCH .../items/{slug}`
+// with a `comment` field creates that comment via store.CreateComment
+// directly, not through handleCreateComment. Both the status-change and
+// the comment notification must surface (as two separate notifications
+// — TASK-2533 plan note: this system does not combine a field change and
+// its attached comment into one nudge line, unlike DOC-2479's single
+// combined example).
+func TestWatchEventsStream_UpdateWithAttachedComment(t *testing.T) {
+	t.Parallel()
+	srv := testServerWithWatchEvents(t)
+	slug, item, tok, _ := setupWatchTestUser(t, srv)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	rr := bearerCall(t, srv, "POST", "/api/v1/workspaces/"+slug+"/items/"+item.Slug+"/watch", tok.Token, nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("create watch: %d %s", rr.Code, rr.Body.String())
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ch := connectWatchStream(ctx, t, ts.URL, tok.Token)
+	waitForWatchEvent(t, ch, 3*time.Second) // connected
+
+	rr = bearerJSON(t, srv, "PATCH", "/api/v1/workspaces/"+slug+"/items/"+item.Slug, tok.Token,
+		map[string]interface{}{
+			"fields":  `{"status":"done"}`,
+			"comment": "fix verified",
+		})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("update with comment: %d %s", rr.Code, rr.Body.String())
+	}
+
+	kinds := map[string]watchEventPayload{}
+	for i := 0; i < 2; i++ {
+		ev := waitForWatchEvent(t, ch, 3*time.Second)
+		var payload watchEventPayload
+		if err := json.Unmarshal([]byte(ev.Data), &payload); err != nil {
+			t.Fatalf("parse payload: %v", err)
+		}
+		kinds[payload.Kind] = payload
+	}
+	sc, ok := kinds[watchevents.KindStatusChange]
+	if !ok {
+		t.Fatalf("expected a status-change notification, got %+v", kinds)
+	}
+	if sc.Summary != "open → done" {
+		t.Fatalf("expected status summary 'open → done', got %q", sc.Summary)
+	}
+	c, ok := kinds[watchevents.KindComment]
+	if !ok {
+		t.Fatalf("expected a comment notification, got %+v", kinds)
+	}
+	if c.Summary != "fix verified" {
+		t.Fatalf("expected comment summary 'fix verified', got %q", c.Summary)
+	}
+}
+
+// --- Pure unit tests for the visibility/predicate logic (no HTTP) ---
+
+func TestWatchNotificationVisible_UnconditionalWatch(t *testing.T) {
+	t.Parallel()
+	watches := map[string]string{"item-1": ""}
+	n := watchevents.Notification{ItemID: "item-1", Kind: watchevents.KindComment}
+	if !watchNotificationVisible(watches, "user-1", n) {
+		t.Fatal("expected an unconditional watch to match any notification on the item")
+	}
+}
+
+func TestWatchNotificationVisible_UnwatchedItemDenied(t *testing.T) {
+	t.Parallel()
+	watches := map[string]string{"item-1": ""}
+	n := watchevents.Notification{ItemID: "item-2", Kind: watchevents.KindComment}
+	if watchNotificationVisible(watches, "user-1", n) {
+		t.Fatal("expected an unwatched item's notification to be denied")
+	}
+}
+
+func TestWatchNotificationVisible_PredicateGatesNonStatusKinds(t *testing.T) {
+	t.Parallel()
+	watches := map[string]string{"item-1": "status=done"}
+	n := watchevents.Notification{ItemID: "item-1", Kind: watchevents.KindComment}
+	if watchNotificationVisible(watches, "user-1", n) {
+		t.Fatal("expected a predicated watch to suppress a comment notification")
+	}
+}
+
+func TestWatchNotificationVisible_PredicateMatchesOnlyTargetValue(t *testing.T) {
+	t.Parallel()
+	watches := map[string]string{"item-1": "status=done"}
+	wrong := watchevents.Notification{ItemID: "item-1", Kind: watchevents.KindStatusChange, StatusFieldKey: "status", ToStatus: "in-progress"}
+	right := watchevents.Notification{ItemID: "item-1", Kind: watchevents.KindStatusChange, StatusFieldKey: "status", ToStatus: "done"}
+	if watchNotificationVisible(watches, "user-1", wrong) {
+		t.Fatal("expected the non-matching status transition to be denied")
+	}
+	if !watchNotificationVisible(watches, "user-1", right) {
+		t.Fatal("expected the matching status transition to be visible")
+	}
+}
+
+func TestWatchNotificationVisible_AddressedToYouIgnoresWatchList(t *testing.T) {
+	t.Parallel()
+	watches := map[string]string{} // no watches at all
+	n := watchevents.Notification{ItemID: "item-1", Kind: watchevents.KindAssignment, AssignedUserID: "user-1"}
+	if !watchNotificationVisible(watches, "user-1", n) {
+		t.Fatal("expected an assignment-to-you notification to be visible with no watch")
+	}
+}
+
+func TestWatchNotificationVisible_AssignmentToSomeoneElseDenied(t *testing.T) {
+	t.Parallel()
+	watches := map[string]string{}
+	n := watchevents.Notification{ItemID: "item-1", Kind: watchevents.KindAssignment, AssignedUserID: "user-2"}
+	if watchNotificationVisible(watches, "user-1", n) {
+		t.Fatal("expected an assignment to someone else to be denied")
+	}
+}
+
+func TestParseWatchPredicate(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		raw        string
+		field, val string
+		ok         bool
+	}{
+		{"status=done", "status", "done", true},
+		{"status=", "status", "", true},
+		{"=done", "", "", false},
+		{"nopair", "", "", false},
+		{"", "", "", false},
+	}
+	for _, c := range cases {
+		field, val, ok := parseWatchPredicate(c.raw)
+		if ok != c.ok || field != c.field || val != c.val {
+			t.Errorf("parseWatchPredicate(%q) = (%q, %q, %v), want (%q, %q, %v)",
+				c.raw, field, val, ok, c.field, c.val, c.ok)
+		}
+	}
+}

--- a/internal/server/handlers_watch_events_test.go
+++ b/internal/server/handlers_watch_events_test.go
@@ -358,6 +358,59 @@ func TestWatchEventsStream_CommentNotification(t *testing.T) {
 	}
 }
 
+// TestWatchEventsStream_ReplyNotification covers codex round-1 finding 2:
+// handleCreateReply is a SEPARATE code path from handleCreateComment (it
+// calls store.CreateComment directly via POST .../comments/{id}/replies,
+// not POST .../comments) and was missing the watch-notification hook
+// entirely — a reply to a comment on a watched item produced zero
+// notification. Verifies the fix.
+func TestWatchEventsStream_ReplyNotification(t *testing.T) {
+	t.Parallel()
+	srv := testServerWithWatchEvents(t)
+	slug, item, tok, _ := setupWatchTestUser(t, srv)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	rr := bearerCall(t, srv, "POST", "/api/v1/workspaces/"+slug+"/items/"+item.Slug+"/watch", tok.Token, nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("create watch: %d %s", rr.Code, rr.Body.String())
+	}
+
+	rr = bearerJSON(t, srv, "POST", "/api/v1/workspaces/"+slug+"/items/"+item.Slug+"/comments", tok.Token,
+		map[string]interface{}{"body": "top-level comment"})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create comment: %d %s", rr.Code, rr.Body.String())
+	}
+	var parent models.Comment
+	parseJSON(t, rr, &parent)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ch := connectWatchStream(ctx, t, ts.URL, tok.Token)
+	waitForWatchEvent(t, ch, 3*time.Second) // connected
+
+	rr = bearerJSON(t, srv, "POST", "/api/v1/workspaces/"+slug+"/comments/"+parent.ID+"/replies", tok.Token,
+		map[string]interface{}{"body": "a reply worth nudging about"})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create reply: %d %s", rr.Code, rr.Body.String())
+	}
+
+	ev := waitForWatchEvent(t, ch, 3*time.Second)
+	var payload watchEventPayload
+	if err := json.Unmarshal([]byte(ev.Data), &payload); err != nil {
+		t.Fatalf("parse payload: %v", err)
+	}
+	if payload.Kind != watchevents.KindComment {
+		t.Fatalf("expected kind %q, got %q", watchevents.KindComment, payload.Kind)
+	}
+	if payload.Summary != "a reply worth nudging about" {
+		t.Fatalf("expected summary to be the reply body, got %q", payload.Summary)
+	}
+	if payload.ItemRef != item.Ref {
+		t.Fatalf("expected item_ref %q, got %q", item.Ref, payload.ItemRef)
+	}
+}
+
 // TestWatchEventsStream_BulkAssignFires exercises the producer-coverage
 // claim in publishWatchNotifications' doc comment (TASK-2533 audit): a
 // bulk "assign" op (which calls store.UpdateItem directly, bypassing

--- a/internal/server/handlers_watch_notify.go
+++ b/internal/server/handlers_watch_notify.go
@@ -1,0 +1,104 @@
+package server
+
+import (
+	"fmt"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/watchevents"
+)
+
+// publishWatchNotifications inspects updated.LastMutation (TASK-2533,
+// models.ItemMutationSignal — set race-free inside the SAME transaction
+// that writes status_transitions / assigned_user_id, see
+// internal/store/items.go) and publishes the corresponding
+// watchevents.Notification(s): at most one status-change and one
+// assignment notification, matching the two independent facets a single
+// mutation signal can carry.
+//
+// No-op when s.watchEvents is nil (feature disabled) or LastMutation is
+// nil (this particular mutation touched neither the done-field nor
+// assigned_user_id — e.g. a title rename, a tag change, a content edit).
+//
+// Producer coverage (TASK-2533 audit — call this from every path that can
+// produce a LastMutation signal):
+//   - handleUpdateItem (single-item PATCH, including its collab sub-paths —
+//     they all funnel through the same `updated` variable at the point
+//     this is called)
+//   - handleMoveItem (single-item move, status-override case)
+//   - the bulk-items loop in handleBulkItems (covers every bulk op
+//     variant — archive/restore/move/set-priority/tag/untag/assign — via
+//     one call site, since LastMutation is simply nil for the ops that
+//     don't touch status/assignment)
+//   - version restore (handlers_item_versions.go) — called for
+//     completeness; LastMutation is nil in practice there because restore
+//     only ever rewrites content, never fields/assignment
+//
+// NOT called from (named bypasses, not silent gaps):
+//   - import bundle (handlers_import_bundle.go) — bulk import writes
+//     items directly via store.CreateItem, not through UpdateItem; a
+//     freshly-imported item can't have a pre-existing watch anyway
+//   - status_transitions backfill (BackfillStatusTransitions) — a one-time
+//     historical reconciliation, not a live mutation
+//   - workspace restore / purge — administrative, not a live human action
+//
+// Known limitation (flagged, not fixed, in Phase 1): unlike the existing
+// SSE/webhook bulk path (publishBulkItemsEvent), this does NOT collapse
+// N per-item bulk mutations into one batch notification. A "bulk-assign
+// 50 items to me" would surface 50 individual assignment notifications
+// to the plugin monitor in a burst — in tension with PLAN-2469's noise-
+// discipline principle. Each notification is still correctly scoped by
+// the caller's own watches/addressed-to-you filter (a fundamentally
+// narrower audience than the workspace-wide SSE firehose the existing
+// batching was built to protect), so this is a burst-noise concern, not
+// a leak — deferred rather than building ad-hoc coalescing beyond what
+// DOC-2479 specs.
+func (s *Server) publishWatchNotifications(workspaceID string, updated *models.Item, actor, actorName string) {
+	if s.watchEvents == nil || updated == nil || updated.LastMutation == nil {
+		return
+	}
+	sig := updated.LastMutation
+
+	if sig.StatusChanged {
+		s.watchEvents.Publish(watchevents.Notification{
+			WorkspaceID:    workspaceID,
+			ItemID:         updated.ID,
+			ItemRef:        updated.Ref,
+			Kind:           watchevents.KindStatusChange,
+			Actor:          actor,
+			ActorName:      actorName,
+			Summary:        fmt.Sprintf("%s → %s", orNoneLabel(sig.FromStatus), orNoneLabel(sig.ToStatus)),
+			StatusFieldKey: sig.StatusFieldKey,
+			ToStatus:       sig.ToStatus,
+		})
+	}
+
+	if sig.AssignmentChanged {
+		summary := "unassigned"
+		if sig.ToAssignedUserID != "" {
+			name := updated.AssignedUserName
+			if name == "" {
+				name = sig.ToAssignedUserID
+			}
+			summary = fmt.Sprintf("assigned to %s", name)
+		}
+		s.watchEvents.Publish(watchevents.Notification{
+			WorkspaceID:    workspaceID,
+			ItemID:         updated.ID,
+			ItemRef:        updated.Ref,
+			Kind:           watchevents.KindAssignment,
+			Actor:          actor,
+			ActorName:      actorName,
+			Summary:        summary,
+			AssignedUserID: sig.ToAssignedUserID,
+		})
+	}
+}
+
+// orNoneLabel renders an empty done-field value as "(none)" for a
+// notification summary line, rather than an ugly bare arrow ("→ done").
+func orNoneLabel(status string) string {
+	if status == "" {
+		return "(none)"
+	}
+	return status
+}

--- a/internal/server/handlers_watch_notify.go
+++ b/internal/server/handlers_watch_notify.go
@@ -62,6 +62,7 @@ func (s *Server) publishWatchNotifications(workspaceID string, updated *models.I
 		s.watchEvents.Publish(watchevents.Notification{
 			WorkspaceID:    workspaceID,
 			ItemID:         updated.ID,
+			CollectionID:   updated.CollectionID,
 			ItemRef:        updated.Ref,
 			Kind:           watchevents.KindStatusChange,
 			Actor:          actor,
@@ -84,6 +85,7 @@ func (s *Server) publishWatchNotifications(workspaceID string, updated *models.I
 		s.watchEvents.Publish(watchevents.Notification{
 			WorkspaceID:    workspaceID,
 			ItemID:         updated.ID,
+			CollectionID:   updated.CollectionID,
 			ItemRef:        updated.Ref,
 			Kind:           watchevents.KindAssignment,
 			Actor:          actor,

--- a/internal/server/handlers_watch_vis_cache_test.go
+++ b/internal/server/handlers_watch_vis_cache_test.go
@@ -198,3 +198,108 @@ func TestWatchEventsStream_StopsDeliveringAfterUserDisabled(t *testing.T) {
 		// No event arrived — correct.
 	}
 }
+
+// TestWatchEventsStream_RevalStillDeniesWhenWatchListReloadErrors covers
+// TASK-2533 codex round 4: on a reval tick, if ListWatchesForUser
+// errored, the handler's `continue` used to skip visCache.reset()
+// entirely — the STALE identity/visibility stayed live for exactly as
+// long as that unrelated query kept failing, so a demoted or disabled
+// user kept receiving previously-visible content through the whole
+// error window. Reproduces this with a forced, persistent watch-list
+// reload fault (via the watchPredicatesLoadFault test seam) active
+// across the SAME tick the connected user is disabled on, and asserts
+// the addressed-to-you delivery path (which depends only on visCache,
+// never on the watch list) is denied anyway — proving reset() now runs
+// unconditionally rather than being coupled to the reload's success.
+//
+// Uses "disabled" rather than "demoted admin" for the actor under test:
+// the admin-bypass path requires cookie-session auth (BUG-1616 is
+// bearer-vs-cookie gated), which this bearer-token HTTP/SSE test
+// harness doesn't exercise — round 3's TestWatchVisCache_DeniesAfterAdminDemotion
+// already covers visCache's OWN demotion handling directly at the unit
+// level. This test is about the CALLER's ordering bug in
+// handleWatchEventsStream's reval branch, not about re-proving
+// refreshUser's per-condition correctness, and "disabled" exercises the
+// identical reset()-must-run-unconditionally code path.
+func TestWatchEventsStream_RevalStillDeniesWhenWatchListReloadErrors(t *testing.T) {
+	// Deliberately NOT t.Parallel() — mutates watchListRevalInterval,
+	// same rationale as TestWatchEventsStream_StopsDeliveringAfterUserDisabled above.
+	srv := testServerWithWatchEvents(t)
+	slug, item, tok, user := setupWatchTestUser(t, srv)
+
+	origInterval := watchListRevalInterval
+	watchListRevalInterval = 50 * time.Millisecond
+	t.Cleanup(func() { watchListRevalInterval = origInterval })
+
+	ws, err := srv.store.GetWorkspaceBySlug(slug)
+	if err != nil {
+		t.Fatalf("GetWorkspaceBySlug: %v", err)
+	}
+	actor, err := srv.store.CreateUser(models.UserCreate{
+		Email: "reval-fault-actor@example.com", Name: "Actor", Password: "pw-test-12345",
+	})
+	if err != nil {
+		t.Fatalf("create actor: %v", err)
+	}
+	if err := srv.store.AddWorkspaceMember(ws.ID, actor.ID, "owner"); err != nil {
+		t.Fatalf("AddWorkspaceMember: %v", err)
+	}
+	actorTok, err := srv.store.CreateAPIToken(actor.ID, models.APITokenCreate{Name: "reval-fault-actor-test"}, 0, 0)
+	if err != nil {
+		t.Fatalf("CreateAPIToken: %v", err)
+	}
+
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ch := connectWatchStream(ctx, t, ts.URL, tok.Token)
+	waitForWatchEvent(t, ch, 3*time.Second) // connected
+
+	// Baseline: addressed-to-you delivery works before any of this.
+	rr := bearerJSON(t, srv, "PATCH", "/api/v1/workspaces/"+slug+"/items/"+item.Slug, actorTok.Token,
+		map[string]interface{}{"assigned_user_id": user.ID})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("assign item (baseline): %d %s", rr.Code, rr.Body.String())
+	}
+	waitForWatchEvent(t, ch, 3*time.Second)
+
+	// Force every subsequent reval tick's watch-list reload to fail...
+	srv.watchPredicatesLoadFault = func() error {
+		return errFakeWatchListReload
+	}
+	// ...AND disable the connected user, in the SAME window.
+	if err := srv.store.DisableUser(user.ID); err != nil {
+		t.Fatalf("DisableUser: %v", err)
+	}
+	time.Sleep(150 * time.Millisecond) // several reval ticks, all with the forced fault active
+
+	rr = bearerJSON(t, srv, "PATCH", "/api/v1/workspaces/"+slug+"/items/"+item.Slug, actorTok.Token,
+		map[string]interface{}{"assigned_user_id": actor.ID})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("reassign away: %d %s", rr.Code, rr.Body.String())
+	}
+	rr = bearerJSON(t, srv, "PATCH", "/api/v1/workspaces/"+slug+"/items/"+item.Slug, actorTok.Token,
+		map[string]interface{}{"assigned_user_id": user.ID})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("re-assign (post-disable): %d %s", rr.Code, rr.Body.String())
+	}
+
+	select {
+	case ev, ok := <-ch:
+		if ok {
+			t.Fatalf("expected no delivery for a disabled user even though the watch-list reload is also failing every tick, got %+v (data: %s)", ev, ev.Data)
+		}
+	case <-time.After(1 * time.Second):
+		// No event arrived — correct: visCache.reset() (and its
+		// fail-closed refreshUser) ran despite the reload fault.
+	}
+}
+
+// errFakeWatchListReload is the sentinel error the
+// watchPredicatesLoadFault test seam returns.
+var errFakeWatchListReload = &testWatchListReloadError{}
+
+type testWatchListReloadError struct{}
+
+func (*testWatchListReloadError) Error() string { return "forced watch-list reload failure (test)" }

--- a/internal/server/handlers_watch_vis_cache_test.go
+++ b/internal/server/handlers_watch_vis_cache_test.go
@@ -1,0 +1,200 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// TestWatchVisCache_DeniesAfterAdminDemotion covers TASK-2533 codex
+// round 3: the round-2 watchVisCache captured *models.User ONCE at
+// connect time and never re-fetched it — reset() cleared only the
+// per-workspace map — so an admin demoted mid-connection kept
+// fullAccess (via computeWatchAccessVisibility's admin bypass) until
+// reconnect. Mirrors handlers_events_revalidation_test.go's
+// TestSSESubscriberStillHasAccess_AdminDemotion / TestComputeSSEVisibility_DemotedAdminGetsFilter
+// exactly: the request context holds the STALE pre-demotion snapshot
+// (Role="admin"), the store holds the post-demotion truth, and the
+// fix under test is what makes the SECOND call see the truth.
+func TestWatchVisCache_DeniesAfterAdminDemotion(t *testing.T) {
+	t.Parallel()
+	srv := testServer(t)
+
+	admin, err := srv.store.CreateUser(models.UserCreate{
+		Email: "vis-cache-admin@example.com", Name: "Admin", Password: "correct-horse-battery-staple", Role: "admin",
+	})
+	if err != nil {
+		t.Fatalf("create admin: %v", err)
+	}
+	// A second admin so SetUserRole's last-admin guard doesn't block the
+	// demotion below.
+	if _, err := srv.store.CreateUser(models.UserCreate{
+		Email: "vis-cache-admin2@example.com", Name: "Admin2", Password: "correct-horse-battery-staple", Role: "admin",
+	}); err != nil {
+		t.Fatalf("create second admin: %v", err)
+	}
+	ws, err := srv.store.CreateWorkspace(models.WorkspaceCreate{Name: "VisCacheDemotion"})
+	if err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	// admin is deliberately NOT a member of ws — their only access is
+	// the platform-admin bypass.
+
+	// Cookie-session-style request: no Authorization header, so
+	// isBearerAuth(r) is false and the admin bypass (cookie-session only,
+	// BUG-1616) is reachable — this is the SAME auth-transport
+	// precondition the analogous existing SSE tests use.
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/events/stream", nil)
+
+	cache := newWatchVisCache(srv, req, admin)
+	before := cache.forWorkspace(ws.ID)
+	if !before.fullAccess {
+		t.Fatalf("expected the admin to have full access before demotion, got %+v", before)
+	}
+
+	if err := srv.store.SetUserRole(admin.ID, "member"); err != nil {
+		t.Fatalf("demote admin: %v", err)
+	}
+
+	// SAME cache instance (same request context, same originally-cached
+	// user) — reset() is what a reval tick calls.
+	cache.reset()
+	after := cache.forWorkspace(ws.ID)
+	if after.fullAccess {
+		t.Fatal("demoted admin without workspace membership must NOT keep full access after reset() — the cached user was not refreshed")
+	}
+}
+
+// TestWatchVisCache_DeniesAfterUserDisabled covers the same gap for a
+// disabled user: refreshUser must deny outright (not just narrow
+// collection access) once the user is confirmed disabled.
+func TestWatchVisCache_DeniesAfterUserDisabled(t *testing.T) {
+	t.Parallel()
+	srv := testServer(t)
+
+	user, err := srv.store.CreateUser(models.UserCreate{
+		Email: "vis-cache-disabled@example.com", Name: "ToDisable", Password: "correct-horse-battery-staple",
+	})
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	ws, err := srv.store.CreateWorkspace(models.WorkspaceCreate{Name: "VisCacheDisable"})
+	if err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	if err := srv.store.AddWorkspaceMember(ws.ID, user.ID, "owner"); err != nil {
+		t.Fatalf("add member: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/events/stream", nil)
+	cache := newWatchVisCache(srv, req, user)
+
+	before := cache.forWorkspace(ws.ID)
+	if !before.fullAccess {
+		t.Fatalf("expected the active owner-member to have full access before disable, got %+v", before)
+	}
+
+	if err := srv.store.DisableUser(user.ID); err != nil {
+		t.Fatalf("disable user: %v", err)
+	}
+
+	cache.reset()
+	after := cache.forWorkspace(ws.ID)
+	if after.fullAccess || len(after.visibleCollIDs) != 0 || len(after.grantedItemIDs) != 0 {
+		t.Fatalf("expected a disabled user to be denied outright after reset(), got %+v", after)
+	}
+}
+
+// TestWatchEventsStream_StopsDeliveringAfterUserDisabled is the
+// HTTP/SSE-level regression: a live stream for a user who gets disabled
+// mid-connection must stop delivering entirely once the next reval tick
+// runs, not just narrow to a smaller visible set.
+func TestWatchEventsStream_StopsDeliveringAfterUserDisabled(t *testing.T) {
+	// Deliberately NOT t.Parallel(): this test mutates the PACKAGE-LEVEL
+	// watchListRevalInterval var below. Every other watch-stream test in
+	// this package reads that same var (via time.NewTicker(...) when it
+	// opens its own SSE connection) and DOES run t.Parallel() — writing
+	// to a shared package var from a parallel test while sibling
+	// parallel tests concurrently read it is a genuine data race
+	// (caught by go test -race, which attributed the failure to a whole
+	// cluster of unrelated concurrently-running tests, not just this
+	// one). Running serially means this test's mutate-then-restore
+	// window never overlaps with another test's read of the same var.
+	srv := testServerWithWatchEvents(t)
+	slug, item, tok, user := setupWatchTestUser(t, srv)
+
+	// Shrink the reval interval so the test doesn't wait 60 real
+	// seconds — mirrors the package-level var override pattern this
+	// codebase already uses for the analogous SSE membership interval.
+	origInterval := watchListRevalInterval
+	watchListRevalInterval = 50 * time.Millisecond
+	t.Cleanup(func() { watchListRevalInterval = origInterval })
+
+	rr := bearerCall(t, srv, "POST", "/api/v1/workspaces/"+slug+"/items/"+item.Slug+"/watch", tok.Token, nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("create watch: %d %s", rr.Code, rr.Body.String())
+	}
+
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ch := connectWatchStream(ctx, t, ts.URL, tok.Token)
+	waitForWatchEvent(t, ch, 3*time.Second) // connected
+
+	// Sanity: the stream delivers before disabling.
+	admin2, err := srv.store.CreateUser(models.UserCreate{
+		Email: "disable-owner@example.com", Name: "Owner2", Password: "pw-test-12345", Role: "admin",
+	})
+	if err != nil {
+		t.Fatalf("create actor: %v", err)
+	}
+	ws, err := srv.store.GetWorkspaceBySlug(slug)
+	if err != nil {
+		t.Fatalf("GetWorkspaceBySlug: %v", err)
+	}
+	if err := srv.store.AddWorkspaceMember(ws.ID, admin2.ID, "owner"); err != nil {
+		t.Fatalf("AddWorkspaceMember: %v", err)
+	}
+	actorTok, err := srv.store.CreateAPIToken(admin2.ID, models.APITokenCreate{Name: "disable-actor"}, 0, 0)
+	if err != nil {
+		t.Fatalf("CreateAPIToken: %v", err)
+	}
+
+	rr = bearerJSON(t, srv, "PATCH", "/api/v1/workspaces/"+slug+"/items/"+item.Slug, actorTok.Token,
+		map[string]interface{}{"fields": `{"status":"done"}`})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("update item: %d %s", rr.Code, rr.Body.String())
+	}
+	waitForWatchEvent(t, ch, 3*time.Second) // the pre-disable notification
+
+	// Disable the connected user and wait past a reval tick.
+	if err := srv.store.DisableUser(user.ID); err != nil {
+		t.Fatalf("DisableUser: %v", err)
+	}
+	time.Sleep(150 * time.Millisecond) // several reval ticks
+
+	rr = bearerJSON(t, srv, "PATCH", "/api/v1/workspaces/"+slug+"/items/"+item.Slug, actorTok.Token,
+		map[string]interface{}{"fields": `{"status":"in-progress"}`})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("update item (post-disable): %d %s", rr.Code, rr.Body.String())
+	}
+
+	select {
+	case ev, ok := <-ch:
+		if ok {
+			var payload watchEventPayload
+			_ = json.Unmarshal([]byte(ev.Data), &payload)
+			t.Fatalf("expected no further notifications after the connected user was disabled, got %+v (data: %s)", ev, ev.Data)
+		}
+		// Channel closed is also an acceptable outcome (server dropped
+		// the connection outright).
+	case <-time.After(1 * time.Second):
+		// No event arrived — correct.
+	}
+}

--- a/internal/server/handlers_watch_vis_cache_test.go
+++ b/internal/server/handlers_watch_vis_cache_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/PerpetualSoftware/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/watchevents"
 )
 
 // TestWatchVisCache_DeniesAfterAdminDemotion covers TASK-2533 codex
@@ -264,10 +265,13 @@ func TestWatchEventsStream_RevalStillDeniesWhenWatchListReloadErrors(t *testing.
 	}
 	waitForWatchEvent(t, ch, 3*time.Second)
 
-	// Force every subsequent reval tick's watch-list reload to fail...
-	srv.watchPredicatesLoadFault = func() error {
-		return errFakeWatchListReload
-	}
+	// Force every subsequent reval tick's watch-list reload to fail —
+	// via the atomic seam (TASK-2533 codex round 5 finding 2): this
+	// write happens AFTER the stream's background goroutine is already
+	// running and reading the seam on its own reval ticks, so a plain
+	// field here would race.
+	loadFault := func() error { return errFakeWatchListReload }
+	srv.watchPredicatesLoadFault.Store(&loadFault)
 	// ...AND disable the connected user, in the SAME window.
 	if err := srv.store.DisableUser(user.ID); err != nil {
 		t.Fatalf("DisableUser: %v", err)
@@ -303,3 +307,96 @@ var errFakeWatchListReload = &testWatchListReloadError{}
 type testWatchListReloadError struct{}
 
 func (*testWatchListReloadError) Error() string { return "forced watch-list reload failure (test)" }
+
+// TestWatchEventsStream_WatchSetClearedAfterPersistentReloadFailures
+// covers TASK-2533 codex round 5 finding 1: `watches = fresh` only ran
+// on the reload's success path, so under a PERSISTENT (not single-tick)
+// reload failure the watch set stayed live indefinitely — a dead watch
+// (removed, item deleted) would keep matching forever, and a watch
+// created during the outage would be silently missed forever, since
+// visCache gates current ACCESS, not whether a watch still legitimately
+// exists. Forces maxConsecutiveWatchReloadFailures+1 consecutive
+// failures via the fault seam and asserts: watch-matched delivery stops
+// once the bound is crossed, addressed-to-you delivery is unaffected
+// throughout (it never depended on the watch list), and watch-matched
+// delivery RESUMES once the fault is cleared and a reload succeeds
+// again — this is a bounded outage response, not a one-way ratchet.
+func TestWatchEventsStream_WatchSetClearedAfterPersistentReloadFailures(t *testing.T) {
+	// Deliberately NOT t.Parallel() — mutates watchListRevalInterval,
+	// same rationale as the other reval-interval tests in this file.
+	srv := testServerWithWatchEvents(t)
+	slug, item, tok, user := setupWatchTestUser(t, srv)
+
+	origInterval := watchListRevalInterval
+	watchListRevalInterval = 30 * time.Millisecond
+	t.Cleanup(func() { watchListRevalInterval = origInterval })
+
+	rr := bearerCall(t, srv, "POST", "/api/v1/workspaces/"+slug+"/items/"+item.Slug+"/watch", tok.Token, nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("create watch: %d %s", rr.Code, rr.Body.String())
+	}
+
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ch := connectWatchStream(ctx, t, ts.URL, tok.Token)
+	waitForWatchEvent(t, ch, 3*time.Second) // connected
+
+	// Baseline: watch-matched delivery works before any of this.
+	rr = bearerJSON(t, srv, "PATCH", "/api/v1/workspaces/"+slug+"/items/"+item.Slug, tok.Token,
+		map[string]interface{}{"fields": `{"status":"done"}`})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("update item (baseline): %d %s", rr.Code, rr.Body.String())
+	}
+	waitForWatchEvent(t, ch, 3*time.Second)
+
+	// Force every reload to fail, for MORE than the bound.
+	loadFault := func() error { return errFakeWatchListReload }
+	srv.watchPredicatesLoadFault.Store(&loadFault)
+	time.Sleep(time.Duration(maxConsecutiveWatchReloadFailures+2) * watchListRevalInterval)
+
+	// Watch-matched: must NOT deliver — the watch set was cleared once
+	// the failure bound was crossed.
+	rr = bearerJSON(t, srv, "PATCH", "/api/v1/workspaces/"+slug+"/items/"+item.Slug, tok.Token,
+		map[string]interface{}{"fields": `{"status":"in-progress"}`})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("update item (during outage): %d %s", rr.Code, rr.Body.String())
+	}
+
+	// Addressed-to-you: MUST still deliver — it depends only on
+	// visCache, which round 4 already decoupled from the reload outcome.
+	rr = bearerJSON(t, srv, "PATCH", "/api/v1/workspaces/"+slug+"/items/"+item.Slug, tok.Token,
+		map[string]interface{}{"assigned_user_id": user.ID})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("assign item (during outage): %d %s", rr.Code, rr.Body.String())
+	}
+
+	ev := waitForWatchEvent(t, ch, 3*time.Second)
+	var payload watchEventPayload
+	if err := json.Unmarshal([]byte(ev.Data), &payload); err != nil {
+		t.Fatalf("parse payload: %v", err)
+	}
+	if payload.Kind != watchevents.KindAssignment {
+		t.Fatalf("expected the assignment notification (watch-matched delivery should have been suppressed by the outage), got kind %q: %+v", payload.Kind, payload)
+	}
+
+	// Recovery: clear the fault, let a reload succeed, and confirm
+	// watch-matched delivery resumes — this is a bounded response to an
+	// outage, not a permanent one-way ratchet.
+	srv.watchPredicatesLoadFault.Store(nil)
+	time.Sleep(2 * watchListRevalInterval)
+
+	rr = bearerJSON(t, srv, "PATCH", "/api/v1/workspaces/"+slug+"/items/"+item.Slug, tok.Token,
+		map[string]interface{}{"fields": `{"status":"done"}`})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("update item (post-recovery): %d %s", rr.Code, rr.Body.String())
+	}
+	ev = waitForWatchEvent(t, ch, 3*time.Second)
+	if err := json.Unmarshal([]byte(ev.Data), &payload); err != nil {
+		t.Fatalf("parse payload: %v", err)
+	}
+	if payload.Kind != watchevents.KindStatusChange {
+		t.Fatalf("expected watch-matched delivery to resume after the reload recovers, got kind %q: %+v", payload.Kind, payload)
+	}
+}

--- a/internal/server/handlers_watches.go
+++ b/internal/server/handlers_watches.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 // watchCreateRequest is the body of POST .../items/{itemSlug}/watch.
@@ -134,6 +136,14 @@ func (s *Server) handleListWatches(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		writeInternalError(w, err)
 		return
+	}
+	// TASK-2533 codex round 1 finding 1: re-check current access before
+	// listing — a watch row survives a revoked workspace membership or
+	// grant, so without this a caller could see item/workspace metadata
+	// for access they no longer have. See filterWatchesByCurrentAccess.
+	watches = s.filterWatchesByCurrentAccess(userID, watches)
+	if watches == nil {
+		watches = []models.Watch{}
 	}
 
 	writeJSON(w, http.StatusOK, watches)

--- a/internal/server/handlers_watches.go
+++ b/internal/server/handlers_watches.go
@@ -141,7 +141,7 @@ func (s *Server) handleListWatches(w http.ResponseWriter, r *http.Request) {
 	// listing — a watch row survives a revoked workspace membership or
 	// grant, so without this a caller could see item/workspace metadata
 	// for access they no longer have. See filterWatchesByCurrentAccess.
-	watches = s.filterWatchesByCurrentAccess(userID, watches)
+	watches = s.filterWatchesByCurrentAccess(r, userID, watches)
 	if watches == nil {
 		watches = []models.Watch{}
 	}

--- a/internal/server/handlers_watches.go
+++ b/internal/server/handlers_watches.go
@@ -1,0 +1,140 @@
+package server
+
+import (
+	"database/sql"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// watchCreateRequest is the body of POST .../items/{itemSlug}/watch.
+// Predicate is optional — DOC-2479's `--until field=value` grammar
+// (e.g. "status=done"). Empty means an unconditional watch: any
+// status-change/assignment/comment on the item notifies the caller.
+type watchCreateRequest struct {
+	Predicate string `json:"predicate,omitempty"`
+}
+
+// handleCreateWatch creates (or replaces the predicate on) a durable
+// watch for the authenticated user on this item (TASK-2533). Re-running
+// this on an already-watched item is an upsert — see
+// Store.CreateWatch's doc comment.
+// POST /api/v1/workspaces/{slug}/items/{itemSlug}/watch
+func (s *Server) handleCreateWatch(w http.ResponseWriter, r *http.Request) {
+	workspaceID, ok := s.getWorkspaceID(w, r)
+	if !ok {
+		return
+	}
+
+	itemSlug := chi.URLParam(r, "itemSlug")
+	item, err := s.store.ResolveItem(workspaceID, itemSlug)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	if item == nil {
+		s.writeItemResolveError(w, r, workspaceID, itemSlug)
+		return
+	}
+	if !s.requireItemVisible(w, r, workspaceID, item) {
+		return
+	}
+
+	userID := currentUserID(r)
+	if userID == "" {
+		writeError(w, http.StatusUnauthorized, "unauthorized", "Authentication required")
+		return
+	}
+
+	var input watchCreateRequest
+	// A watch with no body is valid (unconditional watch) — only reject
+	// a body that's present but malformed JSON, mirroring the tolerant-
+	// empty-body pattern other optional-body endpoints use.
+	if r.ContentLength > 0 {
+		if err := decodeJSON(r, &input); err != nil {
+			writeError(w, http.StatusBadRequest, "bad_request", err.Error())
+			return
+		}
+	}
+	if input.Predicate != "" {
+		if _, _, ok := parseWatchPredicate(input.Predicate); !ok {
+			writeError(w, http.StatusBadRequest, "bad_request",
+				`predicate must be in "field=value" form, e.g. "status=done"`)
+			return
+		}
+	}
+
+	watch, err := s.store.CreateWatch(workspaceID, userID, item.ID, input.Predicate)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	watch.ItemRef = item.Ref
+	watch.ItemTitle = item.Title
+	watch.ItemSlug = item.Slug
+
+	writeJSON(w, http.StatusOK, watch)
+}
+
+// handleDeleteWatch removes the authenticated user's watch on an item.
+// DELETE /api/v1/workspaces/{slug}/items/{itemSlug}/watch
+func (s *Server) handleDeleteWatch(w http.ResponseWriter, r *http.Request) {
+	workspaceID, ok := s.getWorkspaceID(w, r)
+	if !ok {
+		return
+	}
+
+	itemSlug := chi.URLParam(r, "itemSlug")
+	item, err := s.store.ResolveItem(workspaceID, itemSlug)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	if item == nil {
+		s.writeItemResolveError(w, r, workspaceID, itemSlug)
+		return
+	}
+	if !s.requireItemVisible(w, r, workspaceID, item) {
+		return
+	}
+
+	userID := currentUserID(r)
+	if userID == "" {
+		writeError(w, http.StatusUnauthorized, "unauthorized", "Authentication required")
+		return
+	}
+
+	if err := s.store.DeleteWatch(userID, item.ID); err != nil {
+		if err == sql.ErrNoRows {
+			writeError(w, http.StatusNotFound, "not_found", "No watch on this item")
+			return
+		}
+		writeInternalError(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"ref":     item.Ref,
+		"watched": false,
+	})
+}
+
+// handleListWatches lists every watch the authenticated user holds,
+// across all workspaces they belong to (TASK-2533 — a watch is personal,
+// not workspace-scoped; see Store.ListWatchesForUser's doc comment).
+// GET /api/v1/watches
+func (s *Server) handleListWatches(w http.ResponseWriter, r *http.Request) {
+	userID := currentUserID(r)
+	if userID == "" {
+		writeError(w, http.StatusUnauthorized, "unauthorized", "Authentication required")
+		return
+	}
+
+	watches, err := s.store.ListWatchesForUser(userID)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, watches)
+}

--- a/internal/server/handlers_watches_test.go
+++ b/internal/server/handlers_watches_test.go
@@ -1,0 +1,179 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// setupWatchTestUser seeds a workspace + item, mints a real user +
+// user-scoped Bearer token (mirrors handlers_stars_test.go's pattern),
+// and returns everything a watch CRUD test needs.
+func setupWatchTestUser(t *testing.T, srv *Server) (slug string, item models.Item, tok *models.APITokenWithSecret, user *models.User) {
+	t.Helper()
+	slug = createWSWithCollections(t, srv)
+	rr := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections/tasks/items",
+		map[string]interface{}{"title": "Watch me", "fields": `{"status":"open"}`})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("seed item: %d %s", rr.Code, rr.Body.String())
+	}
+	parseJSON(t, rr, &item)
+
+	u, err := srv.store.CreateUser(models.UserCreate{
+		Email:    "watch-test@example.com",
+		Name:     "Watch Tester",
+		Password: "pw-test-12345",
+	})
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	ws, err := srv.store.GetWorkspaceBySlug(slug)
+	if err != nil {
+		t.Fatalf("GetWorkspaceBySlug: %v", err)
+	}
+	if err := srv.store.AddWorkspaceMember(ws.ID, u.ID, "owner"); err != nil {
+		t.Fatalf("AddWorkspaceMember: %v", err)
+	}
+	tok, err = srv.store.CreateAPIToken(u.ID, models.APITokenCreate{Name: "watch-test"}, 0, 0)
+	if err != nil {
+		t.Fatalf("CreateAPIToken: %v", err)
+	}
+	return slug, item, tok, u
+}
+
+// bearerJSON marshals body and issues a Bearer-authenticated request.
+// Needed for any mutation issued AFTER a real user has been created in
+// the test's store: creating a user ends the fresh-install "no users
+// exist" auth bypass that doRequest relies on, so further mutations must
+// carry a token (Bearer auth also bypasses CSRF — middleware_csrf.go).
+func bearerJSON(t *testing.T, srv *Server, method, path, token string, body interface{}) *httptest.ResponseRecorder {
+	t.Helper()
+	data, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal body: %v", err)
+	}
+	return bearerCall(t, srv, method, path, token, data)
+}
+
+func bearerCall(t *testing.T, srv *Server, method, path, token string, body []byte) *httptest.ResponseRecorder {
+	t.Helper()
+	var req *http.Request
+	if body != nil {
+		req = httptest.NewRequest(method, path, bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+	} else {
+		req = httptest.NewRequest(method, path, nil)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.RemoteAddr = "127.0.0.1:0"
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestCreateWatch_AndList(t *testing.T) {
+	t.Parallel()
+	srv := testServer(t)
+	slug, item, tok, _ := setupWatchTestUser(t, srv)
+
+	rr := bearerCall(t, srv, "POST", "/api/v1/workspaces/"+slug+"/items/"+item.Slug+"/watch", tok.Token, nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("create watch: expected 200, got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+	var w models.Watch
+	parseJSON(t, rr, &w)
+	if w.ItemID != item.ID || w.Predicate != "" {
+		t.Fatalf("unexpected watch: %+v", w)
+	}
+
+	rr = bearerCall(t, srv, "GET", "/api/v1/watches", tok.Token, nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("list watches: expected 200, got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+	var list []models.Watch
+	parseJSON(t, rr, &list)
+	if len(list) != 1 || list[0].ItemRef != item.Ref {
+		t.Fatalf("expected 1 watch with ref %q, got %+v", item.Ref, list)
+	}
+}
+
+func TestCreateWatch_WithPredicate(t *testing.T) {
+	t.Parallel()
+	srv := testServer(t)
+	slug, item, tok, _ := setupWatchTestUser(t, srv)
+
+	rr := bearerCall(t, srv, "POST", "/api/v1/workspaces/"+slug+"/items/"+item.Slug+"/watch", tok.Token,
+		[]byte(`{"predicate":"status=done"}`))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("create watch: expected 200, got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+	var w models.Watch
+	parseJSON(t, rr, &w)
+	if w.Predicate != "status=done" {
+		t.Fatalf("expected predicate 'status=done', got %q", w.Predicate)
+	}
+}
+
+func TestCreateWatch_MalformedPredicateRejected(t *testing.T) {
+	t.Parallel()
+	srv := testServer(t)
+	slug, item, tok, _ := setupWatchTestUser(t, srv)
+
+	rr := bearerCall(t, srv, "POST", "/api/v1/workspaces/"+slug+"/items/"+item.Slug+"/watch", tok.Token,
+		[]byte(`{"predicate":"not-a-pair"}`))
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for malformed predicate, got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+}
+
+func TestDeleteWatch(t *testing.T) {
+	t.Parallel()
+	srv := testServer(t)
+	slug, item, tok, _ := setupWatchTestUser(t, srv)
+
+	rr := bearerCall(t, srv, "POST", "/api/v1/workspaces/"+slug+"/items/"+item.Slug+"/watch", tok.Token, nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("create watch: %d %s", rr.Code, rr.Body.String())
+	}
+
+	rr = bearerCall(t, srv, "DELETE", "/api/v1/workspaces/"+slug+"/items/"+item.Slug+"/watch", tok.Token, nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("delete watch: expected 200, got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+
+	rr = bearerCall(t, srv, "DELETE", "/api/v1/workspaces/"+slug+"/items/"+item.Slug+"/watch", tok.Token, nil)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("delete watch (again): expected 404, got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+
+	rr = bearerCall(t, srv, "GET", "/api/v1/watches", tok.Token, nil)
+	var list []models.Watch
+	parseJSON(t, rr, &list)
+	if len(list) != 0 {
+		t.Fatalf("expected 0 watches after delete, got %d", len(list))
+	}
+}
+
+func TestListWatches_RequiresAuth(t *testing.T) {
+	t.Parallel()
+	srv := testServer(t)
+	// No workspace member exists, no bearer token — this exercises the
+	// currentUserID(r) == "" branch even in the fresh-install no-auth
+	// window (a request with a bearer header pointing at nothing valid
+	// still resolves no user).
+	req := httptest.NewRequest("GET", "/api/v1/watches", nil)
+	req.RemoteAddr = "127.0.0.1:0"
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	// Fresh-install (no users exist) bypasses auth entirely, so this can
+	// legitimately be 200 with an empty list in that mode — assert the
+	// weaker, still-meaningful invariant: it never 500s and never
+	// requires currentUserID to be non-empty to avoid crashing.
+	if rec.Code == http.StatusInternalServerError {
+		t.Fatalf("unexpected 500: %s", rec.Body.String())
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -34,6 +34,7 @@ import (
 	"github.com/PerpetualSoftware/pad/internal/models"
 	"github.com/PerpetualSoftware/pad/internal/oauth"
 	"github.com/PerpetualSoftware/pad/internal/store"
+	"github.com/PerpetualSoftware/pad/internal/watchevents"
 	"github.com/PerpetualSoftware/pad/internal/webhooks"
 )
 
@@ -44,6 +45,7 @@ type Server struct {
 	httpServer            *http.Server         // underlying HTTP server (set during ListenAndServe)
 	webFS                 fs.FS                // embedded web UI static files (optional)
 	events                events.EventBus      // real-time event bus (optional)
+	watchEvents           watchevents.Bus      // watch/nudge notification bus (optional, TASK-2533)
 	collab                *collab.RoomManager  // Yjs collab room manager (PLAN-1248); optional
 	webhooks              *webhooks.Dispatcher // webhook dispatcher (optional)
 	email                 *email.Sender        // transactional email sender (optional)
@@ -694,6 +696,14 @@ func (s *Server) SetEventBus(bus events.EventBus) {
 	s.events = bus
 }
 
+// SetWatchEventsBus attaches the watch/nudge notification bus consumed by
+// GET /api/v1/events/stream (TASK-2533). Nil-checked by every producer and
+// by the stream handler, so a server constructed without one (e.g. a test
+// that doesn't exercise watches) still serves every other endpoint.
+func (s *Server) SetWatchEventsBus(bus watchevents.Bus) {
+	s.watchEvents = bus
+}
+
 // SetCollabRoomManager attaches a Yjs collab RoomManager (PLAN-1248).
 // When set, the /api/v1/collab/{itemID} WebSocket endpoint hands new
 // connections to the manager for op-log replay + fan-out. When nil,
@@ -1111,6 +1121,14 @@ func (s *Server) setupRouter() {
 		// SSE endpoint (outside jsonContentType middleware — but inherits auth)
 		r.Get("/api/v1/events", s.handleSSE)
 
+		// User-scoped watch/nudge event stream (TASK-2533, DOC-2479).
+		// Unlike /api/v1/events above, this is NOT workspace-scoped — a
+		// caller's watches and addressed-to-you assignments can span
+		// every workspace they belong to. Lives alongside the other SSE
+		// endpoint for the same "outside jsonContentType, inherits auth"
+		// reason.
+		r.Get("/api/v1/events/stream", s.handleWatchEventsStream)
+
 		// WebSocket endpoint for Yjs-based collaborative editing on a
 		// single item (PLAN-1248). Lives outside jsonContentType for
 		// the same reason as SSE: the response is a WS upgrade, not
@@ -1514,6 +1532,11 @@ func (s *Server) setupRouter() {
 						r.Get("/star", s.handleGetItemStarStatus)
 						r.Post("/star", s.handleStarItem)
 						r.Delete("/star", s.handleUnstarItem)
+						// Watches (TASK-2533): durable per-item subscriptions
+						// for the padd event-stream / plugin-monitor nudge
+						// pipeline. `pad watch <ref>` / `pad watch remove <ref>`.
+						r.Post("/watch", s.handleCreateWatch)
+						r.Delete("/watch", s.handleDeleteWatch)
 					})
 
 					// Links (v2)
@@ -1658,6 +1681,14 @@ func (s *Server) setupRouter() {
 
 			// Search
 			r.Get("/search", s.handleSearch)
+
+			// My watches (TASK-2533), cross-workspace — mirrors
+			// /auth/tokens' shape for a user-scoped-not-workspace-scoped
+			// resource. `pad watch list`. Create/delete are per-item and
+			// live under /workspaces/{ws}/items/{itemSlug}/watch instead
+			// (they need the item's workspace context to resolve the
+			// ref/slug the CLI's positional arg names).
+			r.Get("/watches", s.handleListWatches)
 
 			// MCP tool-surface descriptor (PLAN-1888 / TASK-1891). Serves
 			// the catalog JSON (the nine env.Catalog tools + per-action

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -275,6 +275,16 @@ type Server struct {
 	// the driver surfaces an error), exercising BUG-2276 residual 1's commit-outcome
 	// reconciliation end-to-end through the real handler.
 	restoreAckFault func() error
+
+	// watchPredicatesLoadFault is a TEST SEAM (always nil in production,
+	// TASK-2533). When non-nil, loadWatchPredicates calls it before
+	// touching the store; a non-nil return short-circuits the real
+	// ListWatchesForUser call and is returned as the reload error —
+	// exercising GET /api/v1/events/stream's reval-tick error path
+	// (codex round 4: a watch-list reload failure must not also skip
+	// the identity/visibility refresh) deterministically, without
+	// needing to actually break the DB connection mid-test.
+	watchPredicatesLoadFault func() error
 }
 
 // goAsync spawns fn in a goroutine that's tracked by s.bg, so Stop() can

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -18,6 +18,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -284,7 +285,20 @@ type Server struct {
 	// (codex round 4: a watch-list reload failure must not also skip
 	// the identity/visibility refresh) deterministically, without
 	// needing to actually break the DB connection mid-test.
-	watchPredicatesLoadFault func() error
+	//
+	// atomic.Pointer, not a plain func field (codex round 5 finding 2):
+	// unlike restoreAckFault — set once, synchronously, before the single
+	// HTTP request that will read it, so goroutine-creation's own
+	// happens-before edge makes a plain field safe there — this seam is
+	// set by a test AFTER the SSE stream's background goroutine is
+	// already running and reading it on every reval tick. A plain field
+	// written from the test's goroutine while that goroutine reads it
+	// concurrently is a genuine, if timing-dependent, data race
+	// (verified: restoreAckFault's OWN usage doesn't share this flaw,
+	// since it's never touched after the goroutine that reads it starts,
+	// so it was intentionally left as a plain field rather than changed
+	// too).
+	watchPredicatesLoadFault atomic.Pointer[func() error]
 }
 
 // goAsync spawns fn in a goroutine that's tracked by s.bg, so Stop() can

--- a/internal/store/item_mutation_signal_test.go
+++ b/internal/store/item_mutation_signal_test.go
@@ -1,0 +1,138 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// TestLastMutation_StatusChange asserts UpdateItem attaches a
+// race-free ItemMutationSignal (TASK-2533) when the done-field changes,
+// carrying the same from/to values the status_transitions row records.
+func TestLastMutation_StatusChange(t *testing.T) {
+	t.Parallel()
+	s := testStore(t)
+	wsID, colID := newTransitionTestWorkspace(t, s)
+	item := createTestItem(t, s, wsID, colID, "Do a thing", "")
+
+	updated, err := s.UpdateItem(item.ID, models.ItemUpdate{Fields: strPtr(`{"status":"done"}`)})
+	if err != nil {
+		t.Fatalf("update item: %v", err)
+	}
+	if updated.LastMutation == nil {
+		t.Fatalf("expected LastMutation to be set")
+	}
+	if !updated.LastMutation.StatusChanged {
+		t.Fatalf("expected StatusChanged=true")
+	}
+	if updated.LastMutation.FromStatus != "open" || updated.LastMutation.ToStatus != "done" {
+		t.Fatalf("expected open -> done, got %q -> %q", updated.LastMutation.FromStatus, updated.LastMutation.ToStatus)
+	}
+	if updated.LastMutation.StatusFieldKey != "status" {
+		t.Fatalf("expected field key 'status', got %q", updated.LastMutation.StatusFieldKey)
+	}
+	if updated.LastMutation.AssignmentChanged {
+		t.Fatalf("expected AssignmentChanged=false")
+	}
+}
+
+// TestLastMutation_NoOpWhenNothingChanges asserts that an update touching
+// neither the done-field nor assignment leaves LastMutation nil — the
+// notification pipeline must not fire on unrelated field edits (e.g. a
+// title rename).
+func TestLastMutation_NoOpWhenNothingChanges(t *testing.T) {
+	t.Parallel()
+	s := testStore(t)
+	wsID, colID := newTransitionTestWorkspace(t, s)
+	item := createTestItem(t, s, wsID, colID, "Do a thing", "")
+
+	newTitle := "Do a different thing"
+	updated, err := s.UpdateItem(item.ID, models.ItemUpdate{Title: &newTitle})
+	if err != nil {
+		t.Fatalf("update item: %v", err)
+	}
+	if updated.LastMutation != nil {
+		t.Fatalf("expected LastMutation to stay nil, got %+v", updated.LastMutation)
+	}
+}
+
+// TestLastMutation_AssignmentChange asserts assignment (set, then clear)
+// is captured, and that it is independent of status.
+func TestLastMutation_AssignmentChange(t *testing.T) {
+	t.Parallel()
+	s := testStore(t)
+	wsID, colID := newTransitionTestWorkspace(t, s)
+	item := createTestItem(t, s, wsID, colID, "Assign me", "")
+
+	assignee := createTestUser(t, s, "assignee@example.com", "Assignee", "pw")
+	if err := s.AddWorkspaceMember(wsID, assignee.ID, "editor"); err != nil {
+		t.Fatalf("add member: %v", err)
+	}
+
+	updated, err := s.UpdateItem(item.ID, models.ItemUpdate{AssignedUserID: &assignee.ID})
+	if err != nil {
+		t.Fatalf("assign item: %v", err)
+	}
+	if updated.LastMutation == nil || !updated.LastMutation.AssignmentChanged {
+		t.Fatalf("expected AssignmentChanged=true, got %+v", updated.LastMutation)
+	}
+	if updated.LastMutation.FromAssignedUserID != "" || updated.LastMutation.ToAssignedUserID != assignee.ID {
+		t.Fatalf("expected '' -> %q, got %q -> %q", assignee.ID,
+			updated.LastMutation.FromAssignedUserID, updated.LastMutation.ToAssignedUserID)
+	}
+	if updated.LastMutation.StatusChanged {
+		t.Fatalf("expected StatusChanged=false for an assignment-only update")
+	}
+
+	cleared, err := s.UpdateItem(item.ID, models.ItemUpdate{ClearAssignedUser: true})
+	if err != nil {
+		t.Fatalf("clear assignment: %v", err)
+	}
+	if cleared.LastMutation == nil || !cleared.LastMutation.AssignmentChanged {
+		t.Fatalf("expected AssignmentChanged=true on clear, got %+v", cleared.LastMutation)
+	}
+	if cleared.LastMutation.FromAssignedUserID != assignee.ID || cleared.LastMutation.ToAssignedUserID != "" {
+		t.Fatalf("expected %q -> '', got %q -> %q", assignee.ID,
+			cleared.LastMutation.FromAssignedUserID, cleared.LastMutation.ToAssignedUserID)
+	}
+}
+
+// TestLastMutation_OnMove mirrors TestStatusTransition_CapturedOnMoveWithStatusOverride
+// but asserts the LastMutation signal MoveItemWithPreCheck attaches.
+func TestLastMutation_OnMove(t *testing.T) {
+	t.Parallel()
+	s := testStore(t)
+	wsID, colID := newTransitionTestWorkspace(t, s)
+	targetCol := createTestCollection(t, s, wsID, "Done Tasks")
+	item := createTestItem(t, s, wsID, colID, "Move me", "")
+
+	moved, err := s.MoveItem(item.ID, targetCol.ID, `{"status":"done"}`)
+	if err != nil {
+		t.Fatalf("move item: %v", err)
+	}
+	if moved.LastMutation == nil || !moved.LastMutation.StatusChanged {
+		t.Fatalf("expected StatusChanged=true on move, got %+v", moved.LastMutation)
+	}
+	if moved.LastMutation.FromStatus != "open" || moved.LastMutation.ToStatus != "done" {
+		t.Fatalf("expected open -> done, got %q -> %q", moved.LastMutation.FromStatus, moved.LastMutation.ToStatus)
+	}
+}
+
+// TestLastMutation_NoOpOnMoveWithoutStatusChange mirrors the sibling
+// status_transitions test: a move that doesn't touch the done-field must
+// not attach a LastMutation signal.
+func TestLastMutation_NoOpOnMoveWithoutStatusChange(t *testing.T) {
+	t.Parallel()
+	s := testStore(t)
+	wsID, colID := newTransitionTestWorkspace(t, s)
+	targetCol := createTestCollection(t, s, wsID, "Other Tasks")
+	item := createTestItem(t, s, wsID, colID, "Move me quietly", "")
+
+	moved, err := s.MoveItem(item.ID, targetCol.ID, item.Fields)
+	if err != nil {
+		t.Fatalf("move item: %v", err)
+	}
+	if moved.LastMutation != nil {
+		t.Fatalf("expected LastMutation to stay nil, got %+v", moved.LastMutation)
+	}
+}

--- a/internal/store/item_mutation_signal_test.go
+++ b/internal/store/item_mutation_signal_test.go
@@ -213,7 +213,23 @@ func TestLastMutation_AssignmentDelta_NotMisattributedUnderConcurrentWrite(t *te
 	time.Sleep(50 * time.Millisecond)
 	close(releaseTx2)
 
-	wg.Wait()
+	// Bounded wait, not an unconditional wg.Wait(): TX2 is released
+	// unconditionally above regardless of scheduler contention, so both
+	// goroutines are guaranteed to make progress — but a bare wg.Wait()
+	// still has no ceiling on how long that progress can legitimately take
+	// under real DB lock contention. 10s is generous for a two-row update
+	// even on a slow, shared runner; if it's ever exceeded, fail fast with
+	// a clear diagnostic instead of silently eating test-binary budget.
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for TX1/TX2 to complete — synchronization assumption broke down under contention")
+	}
 
 	if tx2Err != nil {
 		t.Fatalf("TX2 (assignment): %v", tx2Err)

--- a/internal/store/item_mutation_signal_test.go
+++ b/internal/store/item_mutation_signal_test.go
@@ -1,7 +1,10 @@
 package store
 
 import (
+	"database/sql"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/PerpetualSoftware/pad/internal/models"
 )
@@ -134,5 +137,102 @@ func TestLastMutation_NoOpOnMoveWithoutStatusChange(t *testing.T) {
 	}
 	if moved.LastMutation != nil {
 		t.Fatalf("expected LastMutation to stay nil, got %+v", moved.LastMutation)
+	}
+}
+
+// TestLastMutation_AssignmentDelta_NotMisattributedUnderConcurrentWrite
+// covers TASK-2533 codex round 2 finding 4: the assignment-delta capture
+// used to compare against `existing`, which stayed the STALE pre-tx
+// snapshot for any update that triggered none of {precheck,
+// ExpectedUpdatedAt, FieldsPatch} — including a plain title-only update.
+// A concurrent OTHER transaction's assignment change landing between
+// this transaction's pre-tx read and its lock acquisition would get
+// misattributed to THIS transaction: a title-only update would report a
+// spurious AssignmentChanged for a change it never made, duplicating the
+// real one the OTHER transaction already reported correctly.
+//
+// Reproduces the exact interleaving using UpdateItemWithPreCheck's
+// precheck hook as a synchronization point: TX2 (the real assignment
+// change) blocks INSIDE its precheck — after acquiring the write lock,
+// before its own UPDATE statement runs — while TX1 (a concurrent
+// title-only update, no precheck) runs its pre-tx GetItem (WAL mode: not
+// blocked by TX2's held write lock) and then blocks on its own
+// tx.Begin() (BEGIN IMMEDIATE) until TX2 commits and releases the lock.
+func TestLastMutation_AssignmentDelta_NotMisattributedUnderConcurrentWrite(t *testing.T) {
+	t.Parallel()
+	s := testStore(t)
+	wsID, colID := newTransitionTestWorkspace(t, s)
+	item := createTestItem(t, s, wsID, colID, "Contested", "")
+	assignee := createTestUser(t, s, "assignee2@example.com", "Assignee Two", "pw")
+	if err := s.AddWorkspaceMember(wsID, assignee.ID, "editor"); err != nil {
+		t.Fatalf("add member: %v", err)
+	}
+
+	tx2InPrecheck := make(chan struct{})
+	releaseTx2 := make(chan struct{})
+	tx1Started := make(chan struct{})
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	var tx2Result *models.Item
+	var tx2Err error
+	go func() {
+		defer wg.Done()
+		precheck := func(tx *sql.Tx, existing *models.Item) error {
+			close(tx2InPrecheck)
+			<-releaseTx2
+			return nil
+		}
+		tx2Result, tx2Err = s.UpdateItemWithPreCheck(item.ID,
+			models.ItemUpdate{AssignedUserID: &assignee.ID}, precheck)
+	}()
+
+	var tx1Result *models.Item
+	var tx1Err error
+	go func() {
+		defer wg.Done()
+		<-tx2InPrecheck // wait until TX2 holds the write lock but hasn't committed
+		close(tx1Started)
+		newTitle := "Contested (renamed)"
+		// TX1's own pre-tx GetItem (inside UpdateItem) runs here, racing
+		// ahead of TX2's held write lock (WAL mode: a plain SELECT isn't
+		// blocked by it) — it must see the PRE-TX2 assignee (nil), which
+		// is the whole point: this is the stale snapshot that must NOT
+		// leak into TX1's delta once TX2 has committed by the time TX1
+		// actually acquires the lock and writes. TX1's own tx.Begin()
+		// (BEGIN IMMEDIATE) blocks right after, until TX2 releases the
+		// lock below.
+		tx1Result, tx1Err = s.UpdateItem(item.ID, models.ItemUpdate{Title: &newTitle})
+	}()
+
+	<-tx1Started
+	// Give TX1's pre-tx GetItem (fast, non-blocking SELECT) time to
+	// actually complete and TX1's tx.Begin() time to actually block on
+	// TX2's held lock, before letting TX2 proceed to commit.
+	time.Sleep(50 * time.Millisecond)
+	close(releaseTx2)
+
+	wg.Wait()
+
+	if tx2Err != nil {
+		t.Fatalf("TX2 (assignment): %v", tx2Err)
+	}
+	if tx1Err != nil {
+		t.Fatalf("TX1 (title-only): %v", tx1Err)
+	}
+
+	if tx2Result.LastMutation == nil || !tx2Result.LastMutation.AssignmentChanged {
+		t.Fatalf("expected TX2 to correctly report AssignmentChanged, got %+v", tx2Result.LastMutation)
+	}
+	if tx2Result.LastMutation.ToAssignedUserID != assignee.ID {
+		t.Fatalf("expected TX2's ToAssignedUserID to be %q, got %q", assignee.ID, tx2Result.LastMutation.ToAssignedUserID)
+	}
+
+	// The bug: TX1 never touched assignment, but with a stale `existing`
+	// it would see (pre-TX2 nil) vs (post-TX2 assignee.ID) and wrongly
+	// report AssignmentChanged for a transition it didn't make.
+	if tx1Result.LastMutation != nil && tx1Result.LastMutation.AssignmentChanged {
+		t.Fatalf("TX1 (title-only update) must NOT report AssignmentChanged — that transition belongs to TX2 alone, got %+v", tx1Result.LastMutation)
 	}
 }

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -2096,6 +2096,13 @@ func (s *Store) updateItemWithParentLinkOnce(
 		return nil, err
 	}
 
+	// mutSignal accumulates the race-free status/assignment delta this call
+	// produces (TASK-2533 / models.ItemMutationSignal). Populated below,
+	// right alongside the status_transitions write and the final in-tx
+	// re-read, then attached to the returned item only if something
+	// actually changed.
+	var mutSignal models.ItemMutationSignal
+
 	tx, err := s.db.Begin()
 	if err != nil {
 		return nil, err
@@ -2499,6 +2506,10 @@ func (s *Store) updateItemWithParentLinkOnce(
 			`), newID(), id, existing.WorkspaceID, existing.CollectionID, doneKey, statusBefore, newStatus, ts); err != nil {
 				return nil, fmt.Errorf("record status transition: %w", err)
 			}
+			mutSignal.StatusChanged = true
+			mutSignal.StatusFieldKey = doneKey
+			mutSignal.FromStatus = statusBefore
+			mutSignal.ToStatus = newStatus
 		}
 	}
 
@@ -2585,6 +2596,30 @@ func (s *Store) updateItemWithParentLinkOnce(
 	}
 	if updated == nil {
 		return nil, nil
+	}
+
+	// Assignment delta, read from the same in-tx before/after snapshots
+	// used for the status delta above — `existing` is this transaction's
+	// pre-write view (either the pre-tx read or the post-lock re-read at
+	// line ~2189), `updated` is this transaction's own committed write.
+	// Comparing the two committed values (rather than re-deriving "after"
+	// from input.AssignedUserID / ClearAssignedUser) sidesteps having to
+	// duplicate that tri-state set/clear/untouched logic here.
+	beforeAssignee, afterAssignee := "", ""
+	if existing.AssignedUserID != nil {
+		beforeAssignee = *existing.AssignedUserID
+	}
+	if updated.AssignedUserID != nil {
+		afterAssignee = *updated.AssignedUserID
+	}
+	if beforeAssignee != afterAssignee {
+		mutSignal.AssignmentChanged = true
+		mutSignal.FromAssignedUserID = beforeAssignee
+		mutSignal.ToAssignedUserID = afterAssignee
+	}
+	if mutSignal.StatusChanged || mutSignal.AssignmentChanged {
+		sig := mutSignal
+		updated.LastMutation = &sig
 	}
 
 	if err := tx.Commit(); err != nil {
@@ -4467,7 +4502,22 @@ func (s *Store) moveItemWithPreCheckOnce(
 		return nil, err
 	}
 
-	return s.GetItem(itemID)
+	result, err := s.GetItem(itemID)
+	if err != nil || result == nil {
+		return result, err
+	}
+	// Same race-free-delta rationale as updateItemWithParentLinkOnce
+	// (TASK-2533): oldStatus/newStatus were captured under the write lock
+	// above, so this is safe to attach post-commit.
+	if newStatus != oldStatus {
+		result.LastMutation = &models.ItemMutationSignal{
+			StatusChanged:  true,
+			StatusFieldKey: moveDoneKey,
+			FromStatus:     oldStatus,
+			ToStatus:       newStatus,
+		}
+	}
+	return result, nil
 }
 
 // --- Helpers ---

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -2181,9 +2181,28 @@ func (s *Store) updateItemWithParentLinkOnce(
 	// open-children precheck, and the field-level merge all need the item's
 	// state as seen UNDER the write lock — the pre-tx `existing` was read
 	// before the locks, so a concurrent writer could have superseded it.
-	// Re-read ONCE, in-tx, when any of those is active and reuse the snapshot
-	// for all three (plus the status-transition capture below).
-	if precheck != nil || input.ExpectedUpdatedAt != "" || input.FieldsPatch != nil {
+	//
+	// TASK-2533 codex round 2 finding 4: this used to be conditional
+	// (precheck != nil || ExpectedUpdatedAt != "" || FieldsPatch != nil),
+	// which left `existing` as the STALE pre-tx snapshot for any update
+	// that touched none of those three — including a plain assignment
+	// change. The status-transition capture below defended against this
+	// itself with its OWN separate re-read (conditional on precheck ==
+	// nil), but the LastMutation assignment-delta capture (further down)
+	// used `existing.AssignedUserID` directly with no such guard: a
+	// concurrent OTHER transaction's assignment change landing between
+	// this transaction's pre-tx read and its lock acquisition could get
+	// misattributed to THIS transaction (spurious/duplicate
+	// AssignmentChanged for an update that never touched assignment at
+	// all), or the reverse (a real change this transaction DID make
+	// compared against the wrong prior value). Re-reading UNCONDITIONALLY
+	// here — once, right after the locks are held and before any SET-
+	// clause building or the UPDATE itself — closes that for every
+	// existing.* comparison in this function at once, not just the ones
+	// that happen to remember to guard themselves. The extra SELECT is
+	// one row, under locks this function already holds; correctness here
+	// is worth more than skipping it in the common case.
+	{
 		fresh, ferr := s.getItemTx(tx, id)
 		if ferr != nil {
 			return nil, fmt.Errorf("re-read item under lock: %w", ferr)
@@ -2446,23 +2465,17 @@ func (s *Store) updateItemWithParentLinkOnce(
 	}
 
 	// Capture the pre-update status BEFORE the UPDATE runs, so the
-	// transition log below records an accurate from_status. It must reflect
-	// the locked, in-tx state: when a precheck ran, `existing` was already
-	// replaced with the fresh in-tx snapshot above; otherwise `existing` is
-	// the pre-tx read, which a concurrent update (now serialized behind the
-	// workspace/parent locks we hold) could have superseded — re-read in-tx
-	// in that case. Reading here, before the UPDATE, is essential: a re-read
-	// after the UPDATE would see the new status and the hop would vanish.
+	// transition log below records an accurate from_status. `existing` is
+	// now UNCONDITIONALLY the locked, in-tx snapshot (see the re-read
+	// above, widened by TASK-2533 codex round 2 finding 4 to cover every
+	// existing.* comparison in this function, not just this one) — no
+	// separate defensive re-read needed here anymore. Reading here,
+	// before the UPDATE, is essential: a re-read after the UPDATE would
+	// see the new status and the hop would vanish.
 	var statusBefore, doneKey string
 	if input.Fields != nil {
 		doneKey = s.doneFieldKey(existing.CollectionID)
-		oldFields := existing.Fields
-		if precheck == nil {
-			if fresh, ferr := s.getItemTx(tx, id); ferr == nil && fresh != nil {
-				oldFields = fresh.Fields
-			}
-		}
-		statusBefore = extractFieldValue(oldFields, doneKey)
+		statusBefore = extractFieldValue(existing.Fields, doneKey)
 	}
 
 	args = append(args, id)
@@ -2599,12 +2612,12 @@ func (s *Store) updateItemWithParentLinkOnce(
 	}
 
 	// Assignment delta, read from the same in-tx before/after snapshots
-	// used for the status delta above — `existing` is this transaction's
-	// pre-write view (either the pre-tx read or the post-lock re-read at
-	// line ~2189), `updated` is this transaction's own committed write.
-	// Comparing the two committed values (rather than re-deriving "after"
-	// from input.AssignedUserID / ClearAssignedUser) sidesteps having to
-	// duplicate that tri-state set/clear/untouched logic here.
+	// used for the status delta above — `existing` is now UNCONDITIONALLY
+	// this transaction's locked, in-tx pre-write view (TASK-2533 codex
+	// round 2 finding 4), `updated` is this transaction's own committed
+	// write. Comparing the two committed values (rather than re-deriving
+	// "after" from input.AssignedUserID / ClearAssignedUser) sidesteps
+	// having to duplicate that tri-state set/clear/untouched logic here.
 	beforeAssignee, afterAssignee := "", ""
 	if existing.AssignedUserID != nil {
 		beforeAssignee = *existing.AssignedUserID

--- a/internal/store/migrations/078_watches.sql
+++ b/internal/store/migrations/078_watches.sql
@@ -1,0 +1,37 @@
+-- Migration 078: watches — durable, server-side subscriptions for the
+-- padd event-stream / plugin-monitor nudge pipeline (TASK-2533, per
+-- DOC-2479's subscription-table design).
+--
+-- A watch is created by `pad watch <ref>` (optionally with a `--until
+-- field=value` predicate) and lives independently of any client process:
+-- the plugin monitor that consumes it restarts every Claude Code session,
+-- so the subscription itself cannot be in-memory state — it must survive
+-- both the monitor process and a padd restart.
+--
+-- Columns match DOC-2479's schema literally: id, workspace_id, user_id,
+-- item_id, predicate, created_at. `predicate` is a nullable TEXT holding
+-- the raw `--until field=value` string (or empty for an unconditional
+-- watch); DOC-2479 specs no boolean-combinator grammar, so this
+-- deliberately stores at most one `field=value` pair rather than
+-- inventing one.
+CREATE TABLE IF NOT EXISTS watches (
+    -- NOT NULL is explicit: SQLite doesn't imply it for a TEXT PRIMARY
+    -- KEY, unlike Postgres (see item_workspace_moves/077 for the same
+    -- note).
+    id           TEXT NOT NULL PRIMARY KEY,
+    workspace_id TEXT NOT NULL REFERENCES workspaces(id),
+    user_id      TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    item_id      TEXT NOT NULL REFERENCES items(id) ON DELETE CASCADE,
+    predicate    TEXT,
+    created_at   TEXT NOT NULL
+);
+
+-- `pad watch <ref>` re-run on an already-watched item is an upsert (new
+-- predicate replaces the old one), not a duplicate subscription — one
+-- watch per (user, item). Also the index the event-stream handler's
+-- per-notification lookup uses.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_watches_user_item ON watches(user_id, item_id);
+
+-- `pad watch list` / the event-stream handler's "load my active watches"
+-- query, both keyed by user_id alone.
+CREATE INDEX IF NOT EXISTS idx_watches_user ON watches(user_id);

--- a/internal/store/pgmigrations/056_watches.sql
+++ b/internal/store/pgmigrations/056_watches.sql
@@ -1,0 +1,17 @@
+-- Migration 056 (Postgres): watches — durable, server-side subscriptions
+-- for the padd event-stream / plugin-monitor nudge pipeline (TASK-2533).
+-- Postgres counterpart to internal/store/migrations/078_watches.sql — same
+-- intent, same columns, same indexes; see that file for the full rationale.
+-- No dialect differences: every column here is TEXT, so there is nothing
+-- for BoolToInt-style translation to do.
+CREATE TABLE IF NOT EXISTS watches (
+    id           TEXT PRIMARY KEY,
+    workspace_id TEXT NOT NULL REFERENCES workspaces(id),
+    user_id      TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    item_id      TEXT NOT NULL REFERENCES items(id) ON DELETE CASCADE,
+    predicate    TEXT,
+    created_at   TEXT NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_watches_user_item ON watches(user_id, item_id);
+CREATE INDEX IF NOT EXISTS idx_watches_user ON watches(user_id);

--- a/internal/store/watches.go
+++ b/internal/store/watches.go
@@ -1,0 +1,114 @@
+package store
+
+import (
+	"database/sql"
+	"fmt"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// CreateWatch creates a durable watch, or replaces the predicate on an
+// existing one for the same (user, item) pair (TASK-2533). Re-running
+// `pad watch <ref>` on an already-watched item is an upsert, not a
+// duplicate subscription — uq_watches_user_item (migrations 078/056)
+// enforces one watch per (user, item) at the DB level; this mirrors that
+// with an explicit ON CONFLICT so a repeat call updates the predicate in
+// place instead of erroring.
+func (s *Store) CreateWatch(workspaceID, userID, itemID, predicate string) (*models.Watch, error) {
+	id := newID()
+	ts := now()
+	_, err := s.db.Exec(s.q(`
+		INSERT INTO watches (id, workspace_id, user_id, item_id, predicate, created_at)
+		VALUES (?, ?, ?, ?, ?, ?)
+		ON CONFLICT (user_id, item_id) DO UPDATE SET predicate = excluded.predicate, created_at = excluded.created_at
+	`), id, workspaceID, userID, itemID, predicate, ts)
+	if err != nil {
+		return nil, fmt.Errorf("create watch: %w", err)
+	}
+	return s.GetWatchByUserItem(userID, itemID)
+}
+
+// GetWatchByUserItem returns the (at most one) watch a user holds on a
+// specific item, or (nil, nil) if none exists.
+func (s *Store) GetWatchByUserItem(userID, itemID string) (*models.Watch, error) {
+	var w models.Watch
+	var predicate sql.NullString
+	var createdAt string
+	err := s.db.QueryRow(s.q(`
+		SELECT id, workspace_id, user_id, item_id, predicate, created_at
+		FROM watches WHERE user_id = ? AND item_id = ?
+	`), userID, itemID).Scan(&w.ID, &w.WorkspaceID, &w.UserID, &w.ItemID, &predicate, &createdAt)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get watch: %w", err)
+	}
+	w.Predicate = predicate.String
+	w.CreatedAt = parseTime(createdAt)
+	return &w, nil
+}
+
+// ListWatchesForUser returns every watch a user holds, across ALL
+// workspaces they're a member of, newest first — enriched with the
+// watched item's ref/title/slug and its workspace's slug so both
+// `pad watch list` and the event-stream handler's per-connection watch
+// map can use it directly without a second round trip per row.
+//
+// Deliberately unscoped by workspace (unlike most list methods in this
+// file): a watch is a personal subscription, not a workspace resource,
+// and the event-stream handler is inherently cross-workspace — it needs
+// every watch a caller holds to filter one global notification stream.
+func (s *Store) ListWatchesForUser(userID string) ([]models.Watch, error) {
+	rows, err := s.db.Query(s.q(`
+		SELECT w.id, w.workspace_id, w.user_id, w.item_id, w.predicate, w.created_at,
+		       i.title, i.slug, i.item_number, c.prefix, ws.slug
+		FROM watches w
+		JOIN items i ON i.id = w.item_id
+		JOIN collections c ON c.id = i.collection_id
+		JOIN workspaces ws ON ws.id = w.workspace_id
+		WHERE w.user_id = ?
+		ORDER BY w.created_at DESC
+	`), userID)
+	if err != nil {
+		return nil, fmt.Errorf("list watches: %w", err)
+	}
+	defer rows.Close()
+
+	var out []models.Watch
+	for rows.Next() {
+		var w models.Watch
+		var predicate sql.NullString
+		var createdAt string
+		var itemNumber sql.NullInt64
+		var prefix string
+		if err := rows.Scan(&w.ID, &w.WorkspaceID, &w.UserID, &w.ItemID, &predicate, &createdAt,
+			&w.ItemTitle, &w.ItemSlug, &itemNumber, &prefix, &w.WorkspaceSlug); err != nil {
+			return nil, fmt.Errorf("scan watch: %w", err)
+		}
+		w.Predicate = predicate.String
+		w.CreatedAt = parseTime(createdAt)
+		if prefix != "" && itemNumber.Valid {
+			w.ItemRef = fmt.Sprintf("%s-%d", prefix, itemNumber.Int64)
+		}
+		out = append(out, w)
+	}
+	if out == nil {
+		out = []models.Watch{}
+	}
+	return out, rows.Err()
+}
+
+// DeleteWatch removes a user's watch on an item. Returns sql.ErrNoRows if
+// no such watch exists — mirrors UnstarItem's contract.
+func (s *Store) DeleteWatch(userID, itemID string) error {
+	result, err := s.db.Exec(s.q(`DELETE FROM watches WHERE user_id = ? AND item_id = ?`), userID, itemID)
+	if err != nil {
+		return fmt.Errorf("delete watch: %w", err)
+	}
+	n, _ := result.RowsAffected()
+	if n == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
+}

--- a/internal/store/watches.go
+++ b/internal/store/watches.go
@@ -51,18 +51,26 @@ func (s *Store) GetWatchByUserItem(userID, itemID string) (*models.Watch, error)
 
 // ListWatchesForUser returns every watch a user holds, across ALL
 // workspaces they're a member of, newest first — enriched with the
-// watched item's ref/title/slug and its workspace's slug so both
-// `pad watch list` and the event-stream handler's per-connection watch
-// map can use it directly without a second round trip per row.
+// watched item's ref/title/slug/collection ID and its workspace's slug
+// so both `pad watch list` and the event-stream handler's per-connection
+// watch map can use it directly without a second round trip per row.
 //
 // Deliberately unscoped by workspace (unlike most list methods in this
 // file): a watch is a personal subscription, not a workspace resource,
 // and the event-stream handler is inherently cross-workspace — it needs
 // every watch a caller holds to filter one global notification stream.
+//
+// IMPORTANT: this does NOT re-check the caller's CURRENT access to the
+// watched item — it only reflects the watches table, which durably
+// outlives a workspace membership or grant revocation. Callers MUST run
+// the result through server.filterWatchesByCurrentAccess (or an
+// equivalent live-access check) before using it to gate delivery or a
+// listing response; not doing so leaks item/workspace metadata for
+// access the caller no longer has (TASK-2533, codex round 1 finding 1).
 func (s *Store) ListWatchesForUser(userID string) ([]models.Watch, error) {
 	rows, err := s.db.Query(s.q(`
 		SELECT w.id, w.workspace_id, w.user_id, w.item_id, w.predicate, w.created_at,
-		       i.title, i.slug, i.item_number, c.prefix, ws.slug
+		       i.title, i.slug, i.collection_id, i.item_number, c.prefix, ws.slug
 		FROM watches w
 		JOIN items i ON i.id = w.item_id
 		JOIN collections c ON c.id = i.collection_id
@@ -83,7 +91,7 @@ func (s *Store) ListWatchesForUser(userID string) ([]models.Watch, error) {
 		var itemNumber sql.NullInt64
 		var prefix string
 		if err := rows.Scan(&w.ID, &w.WorkspaceID, &w.UserID, &w.ItemID, &predicate, &createdAt,
-			&w.ItemTitle, &w.ItemSlug, &itemNumber, &prefix, &w.WorkspaceSlug); err != nil {
+			&w.ItemTitle, &w.ItemSlug, &w.ItemCollectionID, &itemNumber, &prefix, &w.WorkspaceSlug); err != nil {
 			return nil, fmt.Errorf("scan watch: %w", err)
 		}
 		w.Predicate = predicate.String

--- a/internal/store/watches_test.go
+++ b/internal/store/watches_test.go
@@ -1,0 +1,204 @@
+package store
+
+import (
+	"database/sql"
+	"errors"
+	"testing"
+)
+
+func TestCreateWatch_AndGet(t *testing.T) {
+	t.Parallel()
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+	user := createTestUser(t, s, "alice@test.com", "Alice", "password123")
+	item := createTestItem(t, s, ws.ID, col.ID, "Fix bug", "")
+
+	w, err := s.CreateWatch(ws.ID, user.ID, item.ID, "status=done")
+	if err != nil {
+		t.Fatalf("CreateWatch: %v", err)
+	}
+	if w.WorkspaceID != ws.ID || w.UserID != user.ID || w.ItemID != item.ID {
+		t.Fatalf("unexpected watch: %+v", w)
+	}
+	if w.Predicate != "status=done" {
+		t.Fatalf("expected predicate 'status=done', got %q", w.Predicate)
+	}
+
+	got, err := s.GetWatchByUserItem(user.ID, item.ID)
+	if err != nil {
+		t.Fatalf("GetWatchByUserItem: %v", err)
+	}
+	if got == nil || got.ID != w.ID {
+		t.Fatalf("expected to find the created watch, got %+v", got)
+	}
+}
+
+func TestCreateWatch_RepeatUpsertsPredicate(t *testing.T) {
+	t.Parallel()
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+	user := createTestUser(t, s, "alice@test.com", "Alice", "password123")
+	item := createTestItem(t, s, ws.ID, col.ID, "Fix bug", "")
+
+	first, err := s.CreateWatch(ws.ID, user.ID, item.ID, "")
+	if err != nil {
+		t.Fatalf("CreateWatch: %v", err)
+	}
+
+	second, err := s.CreateWatch(ws.ID, user.ID, item.ID, "status=done")
+	if err != nil {
+		t.Fatalf("CreateWatch (repeat): %v", err)
+	}
+	if second.ID != first.ID {
+		t.Fatalf("expected the same watch row (upsert), got a new ID: %q vs %q", first.ID, second.ID)
+	}
+	if second.Predicate != "status=done" {
+		t.Fatalf("expected predicate to be replaced, got %q", second.Predicate)
+	}
+
+	all, err := s.ListWatchesForUser(user.ID)
+	if err != nil {
+		t.Fatalf("ListWatchesForUser: %v", err)
+	}
+	if len(all) != 1 {
+		t.Fatalf("expected exactly 1 watch row (no duplicate), got %d", len(all))
+	}
+}
+
+func TestGetWatchByUserItem_NotFound(t *testing.T) {
+	t.Parallel()
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+	user := createTestUser(t, s, "alice@test.com", "Alice", "password123")
+	item := createTestItem(t, s, ws.ID, col.ID, "Fix bug", "")
+
+	got, err := s.GetWatchByUserItem(user.ID, item.ID)
+	if err != nil {
+		t.Fatalf("GetWatchByUserItem: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil, got %+v", got)
+	}
+}
+
+func TestListWatchesForUser_EnrichedAndScopedToUser(t *testing.T) {
+	t.Parallel()
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+	alice := createTestUser(t, s, "alice@test.com", "Alice", "password123")
+	bob := createTestUser(t, s, "bob@test.com", "Bob", "password123")
+	item := createTestItem(t, s, ws.ID, col.ID, "Fix bug", "")
+
+	if _, err := s.CreateWatch(ws.ID, alice.ID, item.ID, ""); err != nil {
+		t.Fatalf("CreateWatch(alice): %v", err)
+	}
+	if _, err := s.CreateWatch(ws.ID, bob.ID, item.ID, ""); err != nil {
+		t.Fatalf("CreateWatch(bob): %v", err)
+	}
+
+	aliceWatches, err := s.ListWatchesForUser(alice.ID)
+	if err != nil {
+		t.Fatalf("ListWatchesForUser(alice): %v", err)
+	}
+	if len(aliceWatches) != 1 {
+		t.Fatalf("expected alice to see exactly her own watch, got %d", len(aliceWatches))
+	}
+	got := aliceWatches[0]
+	if got.ItemTitle != "Fix bug" || got.ItemSlug != item.Slug || got.WorkspaceSlug != ws.Slug {
+		t.Fatalf("expected enriched item/workspace fields, got %+v", got)
+	}
+	if got.ItemRef == "" {
+		t.Fatalf("expected a computed item ref, got empty string")
+	}
+}
+
+func TestListWatchesForUser_EmptyIsNotNil(t *testing.T) {
+	t.Parallel()
+	s := testStore(t)
+	user := createTestUser(t, s, "alice@test.com", "Alice", "password123")
+
+	got, err := s.ListWatchesForUser(user.ID)
+	if err != nil {
+		t.Fatalf("ListWatchesForUser: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected an empty (non-nil) slice")
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected 0 watches, got %d", len(got))
+	}
+}
+
+func TestDeleteWatch(t *testing.T) {
+	t.Parallel()
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+	user := createTestUser(t, s, "alice@test.com", "Alice", "password123")
+	item := createTestItem(t, s, ws.ID, col.ID, "Fix bug", "")
+
+	if _, err := s.CreateWatch(ws.ID, user.ID, item.ID, ""); err != nil {
+		t.Fatalf("CreateWatch: %v", err)
+	}
+	if err := s.DeleteWatch(user.ID, item.ID); err != nil {
+		t.Fatalf("DeleteWatch: %v", err)
+	}
+
+	got, err := s.GetWatchByUserItem(user.ID, item.ID)
+	if err != nil {
+		t.Fatalf("GetWatchByUserItem: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected watch to be gone, got %+v", got)
+	}
+}
+
+func TestDeleteWatch_NotFoundReturnsErrNoRows(t *testing.T) {
+	t.Parallel()
+	s := testStore(t)
+	user := createTestUser(t, s, "alice@test.com", "Alice", "password123")
+
+	err := s.DeleteWatch(user.ID, "nonexistent-item")
+	if !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("expected sql.ErrNoRows, got %v", err)
+	}
+}
+
+func TestWatch_CascadesOnItemDelete(t *testing.T) {
+	t.Parallel()
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+	user := createTestUser(t, s, "alice@test.com", "Alice", "password123")
+	item := createTestItem(t, s, ws.ID, col.ID, "Fix bug", "")
+
+	if _, err := s.CreateWatch(ws.ID, user.ID, item.ID, ""); err != nil {
+		t.Fatalf("CreateWatch: %v", err)
+	}
+
+	// Workspace purge hard-deletes items; watches must not survive as
+	// dangling rows (see workspace_purge.go's explicit "watches" delete,
+	// and the item_id ON DELETE CASCADE FK as a backstop for any future
+	// single-item hard-delete path).
+	if err := s.PurgeWorkspaceData(ws.ID); err == nil {
+		t.Fatalf("expected PurgeWorkspaceData to refuse a live (non-soft-deleted) workspace")
+	}
+	if err := s.DeleteWorkspace(ws.Slug); err != nil {
+		t.Fatalf("DeleteWorkspace: %v", err)
+	}
+	if err := s.PurgeWorkspaceData(ws.ID); err != nil {
+		t.Fatalf("PurgeWorkspaceData: %v", err)
+	}
+
+	got, err := s.GetWatchByUserItem(user.ID, item.ID)
+	if err != nil {
+		t.Fatalf("GetWatchByUserItem: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected watch to be purged with its workspace, got %+v", got)
+	}
+}

--- a/internal/store/workspace_purge.go
+++ b/internal/store/workspace_purge.go
@@ -148,8 +148,8 @@ func (s *Store) CountAttachmentsForStorageKeyOutsideWorkspace(storageKey, worksp
 // takes a single workspace_id placeholder. Ordering rules (both SQLite
 // with foreign_keys=ON and Postgres enforce these):
 //
-//   - Item child rows (comments, item_versions, item_links, ...) before
-//     items — several carry RESTRICT FKs to items.
+//   - Item child rows (comments, item_versions, item_links, watches, ...)
+//     before items — several carry RESTRICT FKs to items.
 //   - Collection child rows (views, collection_grants,
 //     member_collection_access) before collections; items before
 //     collections (items.collection_id is RESTRICT).
@@ -188,6 +188,7 @@ var purgeWorkspaceChildDeletes = []struct{ what, query string }{
 	{"item workspace moves (target side)", `DELETE FROM item_workspace_moves WHERE target_workspace_id = ?`},
 	{"item grants", `DELETE FROM item_grants WHERE workspace_id = ?`},
 	{"status transitions", `DELETE FROM status_transitions WHERE workspace_id = ?`},
+	{"watches", `DELETE FROM watches WHERE workspace_id = ?`},
 	// --- items (self-ref parent_id NULLed by PurgeWorkspaceData first) ---
 	{"items", `DELETE FROM items WHERE workspace_id = ?`},
 	// --- collection child rows (before collections) ---

--- a/internal/watchevents/watchevents.go
+++ b/internal/watchevents/watchevents.go
@@ -83,18 +83,40 @@ type Notification struct {
 type Bus interface {
 	// Publish assigns the Notification a monotonic ID, stores it in the
 	// replay buffer, and fans it out to every live Subscribe channel.
+	// ID assignment and buffer insertion are atomic under one lock
+	// (codex round 1 finding 4): two concurrent Publish calls that got
+	// their IDs from separate critical sections could otherwise append
+	// to the replay buffer out of ID order, corrupting since()'s
+	// ordering assumptions.
 	Publish(n Notification)
 	// Subscribe returns a channel that receives every future
-	// Notification. There is exactly one logical stream (unlike
-	// internal/events.EventBus, which is workspace-scoped) — per-caller
-	// filtering happens in the consumer, not the bus, per DR-2.
+	// Notification, with NO replay. There is exactly one logical stream
+	// (unlike internal/events.EventBus, which is workspace-scoped) —
+	// per-caller filtering happens in the consumer, not the bus, per
+	// DR-2. Use this for a fresh (non-resuming) connection; use
+	// SubscribeAndReplaySince for a Last-Event-ID resume.
 	Subscribe() chan Notification
+	// SubscribeAndReplaySince atomically subscribes AND captures every
+	// buffered notification with ID > sinceID, under the SAME lock
+	// (codex round 1 finding 3). Subscribing and reading the replay
+	// buffer as two separate calls leaves a window where a Notification
+	// published in between lands in BOTH the replay set and the live
+	// channel — this closes that window structurally rather than
+	// requiring the consumer to dedupe by ID. Returns (ch, nil) if
+	// sinceID has been evicted from the buffer (gap too large — caller
+	// should treat this like the SSE handler's sync_required signal);
+	// the subscription is still valid in that case, only the replay is
+	// unavailable.
+	SubscribeAndReplaySince(sinceID int64) (chan Notification, []Notification)
 	// Unsubscribe removes a subscriber and closes its channel.
 	Unsubscribe(ch chan Notification)
 	// EventsSince returns buffered notifications with ID > sinceID, for
 	// Last-Event-ID resume. Returns nil if sinceID has been evicted from
 	// the buffer (gap too large — caller should treat this like the SSE
-	// handler's sync_required signal).
+	// handler's sync_required signal). Exposed as a standalone primitive
+	// for tests and any future caller that doesn't need the atomic
+	// subscribe-and-replay guarantee; GET /api/v1/events/stream uses
+	// SubscribeAndReplaySince instead, precisely to avoid that gap.
 	EventsSince(sinceID int64) []Notification
 	// Close shuts the bus down, closing every subscriber channel.
 	Close()
@@ -167,13 +189,23 @@ func (rb *replayBuffer) since(sinceID int64) []Notification {
 
 // MemoryBus is an in-process implementation of Bus. See the package doc
 // comment for its single-process limitation.
+//
+// A SINGLE mutex guards subscriber membership, sequence assignment, and
+// the replay buffer together (codex round 1 findings 3 + 4 — the two
+// were separate locks before, which allowed both out-of-ID-order buffer
+// insertion under concurrent Publish AND a subscribe-then-replay window
+// where a Notification could be delivered twice). This serializes
+// Publish/Subscribe/EventsSince with respect to each other, which is the
+// correct semantics for a monotonic sequence + ordered ring buffer
+// anyway — genuinely concurrent publishes cannot both proceed and still
+// yield a strictly-ordered buffer. Expected volume (status/assignment/
+// comment notifications, not a firehose) makes the lack of reader
+// concurrency a non-issue in practice.
 type MemoryBus struct {
-	mu          sync.RWMutex
+	mu          sync.Mutex
 	subscribers map[chan Notification]struct{}
 	seq         int64
-
-	replayMu sync.RWMutex
-	replay   *replayBuffer
+	replay      *replayBuffer
 }
 
 // New creates a MemoryBus with the default replay buffer size.
@@ -198,15 +230,20 @@ func (b *MemoryBus) Publish(n Notification) {
 	b.mu.Lock()
 	b.seq++
 	n.ID = b.seq
+	b.replay.append(n)
+	// Snapshot subscriber channels while still holding the lock so the
+	// fan-out below sees a membership consistent with this publish's
+	// position in the sequence, then release before the (potentially
+	// blocking-on-full-channel) sends — Publish must never hold the
+	// lock while sending, or a slow subscriber would stall every other
+	// Publish/Subscribe/EventsSince call, not just its own delivery.
+	subs := make([]chan Notification, 0, len(b.subscribers))
+	for ch := range b.subscribers {
+		subs = append(subs, ch)
+	}
 	b.mu.Unlock()
 
-	b.replayMu.Lock()
-	b.replay.append(n)
-	b.replayMu.Unlock()
-
-	b.mu.RLock()
-	defer b.mu.RUnlock()
-	for ch := range b.subscribers {
+	for _, ch := range subs {
 		select {
 		case ch <- n:
 		default:
@@ -223,6 +260,21 @@ func (b *MemoryBus) Subscribe() chan Notification {
 	return ch
 }
 
+// SubscribeAndReplaySince — see the Bus interface doc comment for why
+// this exists (codex round 1 finding 3). Subscribing and reading the
+// replay buffer under the SAME critical section that Publish also uses
+// means a Notification is either: published before this call (and thus
+// only in the returned replay slice), or published after (and thus only
+// delivered on the returned channel) — never both.
+func (b *MemoryBus) SubscribeAndReplaySince(sinceID int64) (chan Notification, []Notification) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	ch := make(chan Notification, 64)
+	b.subscribers[ch] = struct{}{}
+	missed := b.replay.since(sinceID)
+	return ch, missed
+}
+
 func (b *MemoryBus) Unsubscribe(ch chan Notification) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -233,8 +285,8 @@ func (b *MemoryBus) Unsubscribe(ch chan Notification) {
 }
 
 func (b *MemoryBus) EventsSince(sinceID int64) []Notification {
-	b.replayMu.RLock()
-	defer b.replayMu.RUnlock()
+	b.mu.Lock()
+	defer b.mu.Unlock()
 	return b.replay.since(sinceID)
 }
 

--- a/internal/watchevents/watchevents.go
+++ b/internal/watchevents/watchevents.go
@@ -55,6 +55,12 @@ type Notification struct {
 	ID          int64
 	WorkspaceID string
 	ItemID      string
+	// CollectionID is the watched/assigned item's collection, needed so
+	// the stream handler can apply the SAME current-access visibility
+	// check to EVERY notification kind — watch-matched and
+	// addressed-to-you alike (TASK-2533 codex round 2 finding 2: the
+	// addressed-to-you branch used to skip this check entirely).
+	CollectionID string
 	// ItemRef is the human-facing issue ID ("TASK-214"), pre-resolved by
 	// the producer so the stream handler and the CLI's --for-session
 	// formatter never need a second lookup.

--- a/internal/watchevents/watchevents.go
+++ b/internal/watchevents/watchevents.go
@@ -207,6 +207,10 @@ func (rb *replayBuffer) since(sinceID int64) []Notification {
 // yield a strictly-ordered buffer. Expected volume (status/assignment/
 // comment notifications, not a firehose) makes the lack of reader
 // concurrency a non-issue in practice.
+//
+// Publish also sends to every subscriber channel WHILE HOLDING mu
+// (codex round 2 finding 3 — see Publish's doc comment for why an
+// earlier "send after releasing the lock" version could panic).
 type MemoryBus struct {
 	mu          sync.Mutex
 	subscribers map[chan Notification]struct{}
@@ -228,28 +232,38 @@ func NewWithReplaySize(size int) *MemoryBus {
 	}
 }
 
+// Publish assigns a sequence ID, appends to the replay buffer, and sends
+// to every live subscriber — ALL under the same lock Unsubscribe/Close
+// use to remove-and-close a channel (codex round 2 finding 3, fixing a
+// send-on-closed-channel panic).
+//
+// The earlier version snapshotted subscriber channels under the lock,
+// released it, and sent afterward — reasoning that holding the lock
+// through a send would let a slow subscriber stall every other
+// Publish/Subscribe/EventsSince call. That reasoning didn't hold up: the
+// send below is already non-blocking (select/default — a full channel
+// is dropped-and-logged, never awaited), so it can't stall anything
+// regardless of the lock. What the released-lock version actually did
+// was open a window between the snapshot and the send where
+// Unsubscribe/Close could close a channel THIS call was about to send
+// to — a send on a closed channel panics in Go, crashing the whole
+// process (not a single subscriber's connection). Sending under the
+// lock costs nothing (the send is O(1) and non-blocking either way) and
+// closes that window structurally: Unsubscribe/Close can no longer run
+// between "this channel is still a live subscriber" and "send to it".
 func (b *MemoryBus) Publish(n Notification) {
 	if n.Timestamp == 0 {
 		n.Timestamp = time.Now().UnixMilli()
 	}
 
 	b.mu.Lock()
+	defer b.mu.Unlock()
+
 	b.seq++
 	n.ID = b.seq
 	b.replay.append(n)
-	// Snapshot subscriber channels while still holding the lock so the
-	// fan-out below sees a membership consistent with this publish's
-	// position in the sequence, then release before the (potentially
-	// blocking-on-full-channel) sends — Publish must never hold the
-	// lock while sending, or a slow subscriber would stall every other
-	// Publish/Subscribe/EventsSince call, not just its own delivery.
-	subs := make([]chan Notification, 0, len(b.subscribers))
-	for ch := range b.subscribers {
-		subs = append(subs, ch)
-	}
-	b.mu.Unlock()
 
-	for _, ch := range subs {
+	for ch := range b.subscribers {
 		select {
 		case ch <- n:
 		default:

--- a/internal/watchevents/watchevents.go
+++ b/internal/watchevents/watchevents.go
@@ -1,0 +1,248 @@
+// Package watchevents is the internal notification pipeline behind the
+// padd watch / nudge feature (TASK-2533, per DOC-2479's event-model
+// design). Producers (item update, item move, comment creation, ...)
+// publish a Notification whenever something watch-worthy happens;
+// GET /api/v1/events/stream is the single consumer, filtering the raw
+// stream down to each caller's own watches plus the addressed-to-you
+// predicate before anything reaches a client (DR-2: no firehose, no
+// wildcard subscriptions).
+//
+// SINGLE-PROCESS LIMITATION. Bus here is an in-process pub/sub, exactly
+// like internal/events.MemoryBus — and it has the same blind spot: in a
+// multi-process padd deployment, a Notification published on one
+// process is never seen by a stream connection held open on a
+// different process, and is silently dropped for that connection. This
+// is precisely why internal/events also ships a RedisBus for
+// multi-instance deployments (Pad Cloud runs that shape). Bus is
+// defined as an interface specifically so a Redis-backed implementation
+// can slot in later without changing any producer or the stream
+// handler; only MemoryBus is implemented in Phase 1. Do not point this
+// package at a multi-process deployment without that follow-up — the
+// local plugin monitor talking to a local, single-process padd is the
+// only supported Phase 1 consumer.
+package watchevents
+
+import (
+	"log/slog"
+	"sync"
+	"time"
+)
+
+// Notification kinds, matching DOC-2479's event payload contract
+// (kind ∈ {status-change, assignment, comment, ask}) exactly.
+const (
+	KindStatusChange = "status-change"
+	KindAssignment   = "assignment"
+	KindComment      = "comment"
+	// KindAsk is contract-reserved: DOC-2479 specs it as part of the kind
+	// enum, but no Phase 1 producer emits it. Grounding "human-gate-shaped
+	// collection" mechanically requires either a collection `kind` field
+	// or a user→active-role binding, and this codebase has neither today
+	// (TASK-2533 plan review, confirmed with the dispatcher). Left in the
+	// enum so the wire contract doesn't have to change when a producer
+	// eventually exists.
+	KindAsk = "ask"
+)
+
+// Notification is one watch-worthy fact: an item's status changed, it was
+// (re)assigned, or a comment landed on it. Consumed only by the
+// GET /api/v1/events/stream handler, which filters and reshapes it per
+// connected caller before anything is serialized to an HTTP response —
+// this type itself is never sent to a client as-is.
+type Notification struct {
+	// ID is a monotonic sequence number assigned by the Bus on Publish,
+	// used for Last-Event-ID resume. Zero until Publish assigns it.
+	ID          int64
+	WorkspaceID string
+	ItemID      string
+	// ItemRef is the human-facing issue ID ("TASK-214"), pre-resolved by
+	// the producer so the stream handler and the CLI's --for-session
+	// formatter never need a second lookup.
+	ItemRef   string
+	Kind      string
+	Actor     string
+	ActorName string
+	Summary   string
+	// AssignedUserID is populated on Kind == KindAssignment with the
+	// item's NEW assignee (empty string = unassigned). The
+	// addressed-to-you check compares this directly against the
+	// connected caller's user ID — see server.sseWatchVisible.
+	AssignedUserID string
+	// StatusFieldKey / ToStatus are populated on Kind == KindStatusChange,
+	// mirroring models.ItemMutationSignal, so the `--until field=value`
+	// watch predicate can be evaluated against a Notification directly
+	// without a second lookup back into the item.
+	StatusFieldKey string
+	ToStatus       string
+	Timestamp      int64
+}
+
+// Bus is the pub/sub surface the watch pipeline's producers and the
+// GET /api/v1/events/stream consumer share. See the package doc comment
+// for why only an in-process MemoryBus exists in Phase 1.
+type Bus interface {
+	// Publish assigns the Notification a monotonic ID, stores it in the
+	// replay buffer, and fans it out to every live Subscribe channel.
+	Publish(n Notification)
+	// Subscribe returns a channel that receives every future
+	// Notification. There is exactly one logical stream (unlike
+	// internal/events.EventBus, which is workspace-scoped) — per-caller
+	// filtering happens in the consumer, not the bus, per DR-2.
+	Subscribe() chan Notification
+	// Unsubscribe removes a subscriber and closes its channel.
+	Unsubscribe(ch chan Notification)
+	// EventsSince returns buffered notifications with ID > sinceID, for
+	// Last-Event-ID resume. Returns nil if sinceID has been evicted from
+	// the buffer (gap too large — caller should treat this like the SSE
+	// handler's sync_required signal).
+	EventsSince(sinceID int64) []Notification
+	// Close shuts the bus down, closing every subscriber channel.
+	Close()
+}
+
+// DefaultReplayBufferSize and DefaultReplayMaxAge mirror
+// internal/events' defaults. The watch stream is lower-volume than the
+// per-workspace activity firehose (only status/assignment/comment
+// notifications that matter for *someone's* watch or addressed-to-you
+// state), so the same sizing is a reasonable starting point without
+// needing independent tuning.
+const (
+	DefaultReplayBufferSize = 1024
+	DefaultReplayMaxAge     = 5 * time.Minute
+)
+
+// replayEntry pairs a Notification with the time it was published, so
+// the ring buffer can also enforce DefaultReplayMaxAge (unused for now —
+// eviction is purely capacity-driven, exactly like internal/events —
+// but kept alongside the Notification for parity/future use).
+type replayBuffer struct {
+	items []Notification
+	size  int
+	head  int
+	count int
+}
+
+func newReplayBuffer(size int) *replayBuffer {
+	return &replayBuffer{items: make([]Notification, size), size: size}
+}
+
+func (rb *replayBuffer) append(n Notification) {
+	rb.items[rb.head] = n
+	rb.head = (rb.head + 1) % rb.size
+	if rb.count < rb.size {
+		rb.count++
+	}
+}
+
+// since mirrors internal/events.replayBuffer.since exactly (same gap /
+// eviction semantics), scoped to this package's Notification type.
+func (rb *replayBuffer) since(sinceID int64) []Notification {
+	if rb.count == 0 {
+		return []Notification{}
+	}
+	oldest := (rb.head - rb.count + rb.size) % rb.size
+	oldestID := rb.items[oldest].ID
+	newest := (rb.head - 1 + rb.size) % rb.size
+	newestID := rb.items[newest].ID
+
+	if sinceID > newestID {
+		return nil
+	}
+	if sinceID > 0 && sinceID < oldestID && rb.count == rb.size {
+		return nil
+	}
+
+	var result []Notification
+	for i := 0; i < rb.count; i++ {
+		idx := (oldest + i) % rb.size
+		if rb.items[idx].ID > sinceID {
+			result = append(result, rb.items[idx])
+		}
+	}
+	if result == nil {
+		result = []Notification{}
+	}
+	return result
+}
+
+// MemoryBus is an in-process implementation of Bus. See the package doc
+// comment for its single-process limitation.
+type MemoryBus struct {
+	mu          sync.RWMutex
+	subscribers map[chan Notification]struct{}
+	seq         int64
+
+	replayMu sync.RWMutex
+	replay   *replayBuffer
+}
+
+// New creates a MemoryBus with the default replay buffer size.
+func New() *MemoryBus {
+	return NewWithReplaySize(DefaultReplayBufferSize)
+}
+
+// NewWithReplaySize creates a MemoryBus with a custom replay buffer
+// capacity (tests use a small one).
+func NewWithReplaySize(size int) *MemoryBus {
+	return &MemoryBus{
+		subscribers: make(map[chan Notification]struct{}),
+		replay:      newReplayBuffer(size),
+	}
+}
+
+func (b *MemoryBus) Publish(n Notification) {
+	if n.Timestamp == 0 {
+		n.Timestamp = time.Now().UnixMilli()
+	}
+
+	b.mu.Lock()
+	b.seq++
+	n.ID = b.seq
+	b.mu.Unlock()
+
+	b.replayMu.Lock()
+	b.replay.append(n)
+	b.replayMu.Unlock()
+
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	for ch := range b.subscribers {
+		select {
+		case ch <- n:
+		default:
+			slog.Warn("watchevents: dropping notification for slow subscriber", "kind", n.Kind, "item_ref", n.ItemRef)
+		}
+	}
+}
+
+func (b *MemoryBus) Subscribe() chan Notification {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	ch := make(chan Notification, 64)
+	b.subscribers[ch] = struct{}{}
+	return ch
+}
+
+func (b *MemoryBus) Unsubscribe(ch chan Notification) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if _, ok := b.subscribers[ch]; ok {
+		delete(b.subscribers, ch)
+		close(ch)
+	}
+}
+
+func (b *MemoryBus) EventsSince(sinceID int64) []Notification {
+	b.replayMu.RLock()
+	defer b.replayMu.RUnlock()
+	return b.replay.since(sinceID)
+}
+
+func (b *MemoryBus) Close() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for ch := range b.subscribers {
+		delete(b.subscribers, ch)
+		close(ch)
+	}
+}

--- a/internal/watchevents/watchevents_test.go
+++ b/internal/watchevents/watchevents_test.go
@@ -1,6 +1,8 @@
 package watchevents
 
 import (
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 )
@@ -138,5 +140,119 @@ func TestMemoryBus_SlowSubscriberDoesNotBlockPublish(t *testing.T) {
 	case <-done:
 	case <-time.After(2 * time.Second):
 		t.Fatal("Publish blocked on a full subscriber channel")
+	}
+}
+
+// TestMemoryBus_ConcurrentPublish_MaintainsIDOrderInReplayBuffer covers
+// codex round 1 finding 4: sequence assignment and replay-buffer
+// insertion used to happen under SEPARATE locks, so two concurrent
+// Publish calls could append to the ring buffer out of ID order —
+// corrupting since()'s ordering assumptions (it walks the ring
+// oldest→newest and compares IDs, assuming monotonic order). Run with
+// -race; this also catches any residual lock-ordering issue in the
+// unified-lock fix.
+func TestMemoryBus_ConcurrentPublish_MaintainsIDOrderInReplayBuffer(t *testing.T) {
+	t.Parallel()
+	b := New()
+	defer b.Close()
+
+	const n = 200
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			b.Publish(Notification{Kind: KindComment, ItemRef: fmt.Sprintf("TASK-%d", i)})
+		}(i)
+	}
+	wg.Wait()
+
+	all := b.EventsSince(0)
+	if len(all) != n {
+		t.Fatalf("expected %d buffered events, got %d", n, len(all))
+	}
+	for i := 1; i < len(all); i++ {
+		if all[i].ID <= all[i-1].ID {
+			t.Fatalf("replay buffer out of ID order at index %d: %d then %d", i, all[i-1].ID, all[i].ID)
+		}
+	}
+	// IDs must be a dense, unique 1..n set — every concurrent Publish
+	// got its own sequence number with no duplicates and no gaps.
+	seenIDs := make(map[int64]bool, n)
+	for _, e := range all {
+		seenIDs[e.ID] = true
+	}
+	for id := int64(1); id <= n; id++ {
+		if !seenIDs[id] {
+			t.Fatalf("missing sequence ID %d after %d concurrent publishes", id, n)
+		}
+	}
+}
+
+// TestMemoryBus_SubscribeAndReplaySince_NoDuplicateUnderConcurrentPublish
+// covers codex round 1 finding 3: Subscribe() and EventsSince() used to
+// be two separate calls, leaving a window where a Notification published
+// in between would be delivered TWICE (once via replay, once via the
+// live channel). Publishes a batch of notifications immediately after
+// the atomic subscribe-and-replay call — the exact timing that was
+// racy under the old two-step sequence — and asserts every notification
+// ID is observed EXACTLY once across {replay result, live channel}.
+func TestMemoryBus_SubscribeAndReplaySince_NoDuplicateUnderConcurrentPublish(t *testing.T) {
+	t.Parallel()
+	b := New()
+	defer b.Close()
+
+	// Seed some history so there's a real replay window to resume into.
+	for i := 0; i < 5; i++ {
+		b.Publish(Notification{Kind: KindComment})
+	}
+	seeded := b.EventsSince(0)
+	sinceID := seeded[2].ID // resume from partway through history
+
+	ch, missed := b.SubscribeAndReplaySince(sinceID)
+	defer b.Unsubscribe(ch)
+
+	const concurrentPublishes = 20
+	var wg sync.WaitGroup
+	for i := 0; i < concurrentPublishes; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			b.Publish(Notification{Kind: KindStatusChange})
+		}()
+	}
+	wg.Wait()
+
+	seen := make(map[int64]int)
+	for _, n := range missed {
+		seen[n.ID]++
+	}
+	deadline := time.After(500 * time.Millisecond)
+drain:
+	for {
+		select {
+		case n := <-ch:
+			seen[n.ID]++
+		case <-deadline:
+			break drain
+		}
+	}
+
+	for id, count := range seen {
+		if count != 1 {
+			t.Errorf("notification ID %d delivered %d times, want exactly 1", id, count)
+		}
+	}
+	// None of the 20 concurrently-published notifications should be
+	// missing (they must all land on the live channel, since they were
+	// published strictly after the atomic subscribe returned).
+	concurrentSeen := 0
+	for id := range seen {
+		if id > seeded[len(seeded)-1].ID {
+			concurrentSeen++
+		}
+	}
+	if concurrentSeen != concurrentPublishes {
+		t.Fatalf("expected all %d concurrently-published notifications to be observed exactly once, got %d", concurrentPublishes, concurrentSeen)
 	}
 }

--- a/internal/watchevents/watchevents_test.go
+++ b/internal/watchevents/watchevents_test.go
@@ -1,0 +1,142 @@
+package watchevents
+
+import (
+	"testing"
+	"time"
+)
+
+func TestMemoryBus_PublishDeliversToSubscriber(t *testing.T) {
+	t.Parallel()
+	b := New()
+	defer b.Close()
+
+	ch := b.Subscribe()
+	defer b.Unsubscribe(ch)
+
+	b.Publish(Notification{WorkspaceID: "ws1", ItemID: "item1", Kind: KindStatusChange})
+
+	select {
+	case n := <-ch:
+		if n.WorkspaceID != "ws1" || n.Kind != KindStatusChange {
+			t.Fatalf("unexpected notification: %+v", n)
+		}
+		if n.ID == 0 {
+			t.Fatalf("expected a non-zero assigned ID")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for notification")
+	}
+}
+
+func TestMemoryBus_UnsubscribeClosesChannel(t *testing.T) {
+	t.Parallel()
+	b := New()
+	defer b.Close()
+
+	ch := b.Subscribe()
+	b.Unsubscribe(ch)
+
+	if _, ok := <-ch; ok {
+		t.Fatal("expected channel to be closed after Unsubscribe")
+	}
+}
+
+func TestMemoryBus_MultipleSubscribersAllReceive(t *testing.T) {
+	t.Parallel()
+	b := New()
+	defer b.Close()
+
+	ch1 := b.Subscribe()
+	ch2 := b.Subscribe()
+	defer b.Unsubscribe(ch1)
+	defer b.Unsubscribe(ch2)
+
+	b.Publish(Notification{Kind: KindComment})
+
+	for _, ch := range []chan Notification{ch1, ch2} {
+		select {
+		case <-ch:
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for notification on one of the subscribers")
+		}
+	}
+}
+
+func TestMemoryBus_EventsSince_ReplaysNewerOnly(t *testing.T) {
+	t.Parallel()
+	b := New()
+	defer b.Close()
+
+	b.Publish(Notification{Kind: KindStatusChange, ItemRef: "TASK-1"})
+	b.Publish(Notification{Kind: KindComment, ItemRef: "TASK-2"})
+	b.Publish(Notification{Kind: KindAssignment, ItemRef: "TASK-3"})
+
+	all := b.EventsSince(0)
+	if len(all) != 3 {
+		t.Fatalf("expected 3 events since 0, got %d", len(all))
+	}
+
+	sinceFirst := b.EventsSince(all[0].ID)
+	if len(sinceFirst) != 2 {
+		t.Fatalf("expected 2 events since the first, got %d", len(sinceFirst))
+	}
+	if sinceFirst[0].ItemRef != "TASK-2" || sinceFirst[1].ItemRef != "TASK-3" {
+		t.Fatalf("unexpected replay order: %+v", sinceFirst)
+	}
+}
+
+func TestMemoryBus_EventsSince_CaughtUpReturnsEmptyNotNil(t *testing.T) {
+	t.Parallel()
+	b := New()
+	defer b.Close()
+
+	b.Publish(Notification{Kind: KindComment})
+	all := b.EventsSince(0)
+	latest := all[len(all)-1].ID
+
+	got := b.EventsSince(latest)
+	if got == nil {
+		t.Fatal("expected an empty (non-nil) slice, got nil (nil means 'gap, resync')")
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected 0 events, got %d", len(got))
+	}
+}
+
+func TestMemoryBus_EventsSince_EvictedGapReturnsNil(t *testing.T) {
+	t.Parallel()
+	b := NewWithReplaySize(2)
+	defer b.Close()
+
+	b.Publish(Notification{Kind: KindComment, ItemRef: "TASK-1"})
+	b.Publish(Notification{Kind: KindComment, ItemRef: "TASK-2"})
+	b.Publish(Notification{Kind: KindComment, ItemRef: "TASK-3"}) // evicts TASK-1's slot
+
+	got := b.EventsSince(1) // TASK-1's ID, now evicted
+	if got != nil {
+		t.Fatalf("expected nil (gap too large), got %+v", got)
+	}
+}
+
+func TestMemoryBus_SlowSubscriberDoesNotBlockPublish(t *testing.T) {
+	t.Parallel()
+	b := New()
+	defer b.Close()
+
+	ch := b.Subscribe() // never drained
+	defer b.Unsubscribe(ch)
+
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < 100; i++ {
+			b.Publish(Notification{Kind: KindComment})
+		}
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Publish blocked on a full subscriber channel")
+	}
+}

--- a/internal/watchevents/watchevents_test.go
+++ b/internal/watchevents/watchevents_test.go
@@ -256,3 +256,93 @@ drain:
 		t.Fatalf("expected all %d concurrently-published notifications to be observed exactly once, got %d", concurrentPublishes, concurrentSeen)
 	}
 }
+
+// TestMemoryBus_ConcurrentPublishUnsubscribeClose_NoPanic covers codex
+// round 2 finding 3: Publish used to snapshot subscriber channels under
+// the lock, release it, and send afterward — a window where a
+// concurrent Unsubscribe or Close could close a channel Publish was
+// about to send to. A send on a closed channel PANICS in Go, which
+// would have crashed the whole padd process (not just dropped one
+// subscriber's message), and the timing-dependent nature of the race
+// means -race alone does not reliably surface it — this test hammers
+// concurrent publish / subscribe / unsubscribe / close across many
+// iterations and short-lived channels specifically to provoke it, with
+// a recover() so a regression fails this test cleanly instead of
+// crashing the whole `go test` run.
+func TestMemoryBus_ConcurrentPublishUnsubscribeClose_NoPanic(t *testing.T) {
+	t.Parallel()
+
+	for iter := 0; iter < 30; iter++ {
+		b := New()
+
+		const numChannels = 20
+		chs := make([]chan Notification, numChannels)
+		for i := range chs {
+			chs[i] = b.Subscribe()
+		}
+
+		var wg sync.WaitGroup
+		wg.Add(3)
+
+		// Publisher: hammers Publish continuously while channels are
+		// being torn down concurrently below.
+		go func() {
+			defer wg.Done()
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("Publish panicked (iter %d): %v", iter, r)
+				}
+			}()
+			for i := 0; i < 200; i++ {
+				b.Publish(Notification{Kind: KindComment})
+			}
+		}()
+
+		// Unsubscriber: closes every channel while Publish is mid-flight.
+		go func() {
+			defer wg.Done()
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("Unsubscribe panicked (iter %d): %v", iter, r)
+				}
+			}()
+			for _, ch := range chs {
+				b.Unsubscribe(ch)
+			}
+		}()
+
+		// Churner: subscribes and immediately unsubscribes fresh
+		// channels throughout, maximizing the window a stale Publish
+		// snapshot (under the old code) could race against.
+		go func() {
+			defer wg.Done()
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("churn panicked (iter %d): %v", iter, r)
+				}
+			}()
+			for i := 0; i < 200; i++ {
+				ch := b.Subscribe()
+				b.Unsubscribe(ch)
+			}
+		}()
+
+		// Drain the original channels concurrently so Publish's
+		// non-blocking sends don't just fall through to "channel full"
+		// for the whole run (irrelevant to the race being tested, but
+		// keeps the scenario realistic).
+		var drainWg sync.WaitGroup
+		for _, ch := range chs {
+			drainWg.Add(1)
+			go func(ch chan Notification) {
+				defer drainWg.Done()
+				for range ch {
+				}
+			}(ch)
+		}
+
+		wg.Wait()
+		b.Close()
+		drainWg.Wait()
+	}
+}


### PR DESCRIPTION
## Summary

Phase 1 of PLAN-2469 (the Claude Code plugin / event-delivery plan): the server and CLI machinery the plugin's monitor will consume. Design doc: DOC-2479 (amended day-31 with the v1 narrowing recorded below).

- **`watches` table** (SQLite + Postgres migrations): durable server-side subscriptions — `watches(id, workspace_id, user_id, item_id, predicate, created_at)`; survive monitor restarts. Store CRUD + workspace-purge cascade.
- **`internal/watchevents`**: a small in-process notification bus (interface shaped so a Redis-backed impl can slot in later; MemoryBus only for now — **single-process limitation documented**: multi-process deployments need that impl before this feature works there). Atomic ID assignment; `SubscribeAndReplaySince` closes the replay/live duplication window; sends happen under the same lock Unsubscribe/Close use (send is select/default non-blocking), eliminating a send-on-closed-channel panic race.
- **`GET /api/v1/events/stream`**: user-scoped SSE with `Last-Event-ID` ring-buffer resume and `sync_required` on gap. Server-side filtering only — the client never sees a firehose (DR-2). Every notification, watch-matched or addressed-to-you, passes a uniform current-access gate mirroring `computeSSEVisibility` (incl. the BUG-1616 cookie-vs-bearer admin distinction), with item-grant collections narrowed to the granted items. The visibility cache re-fetches the user each reval tick and **fails closed** on fetch error/disabled — a deliberate departure from SSE's stale-fallback, reasoned in-code: a notification stream's wrong failure mode is delivering a fact to someone unentitled. The reset runs unconditionally per tick, decoupled from watch-list reload success.
- **Publish sites** driven by an in-transaction `models.Item.LastMutation` signal (computed where the authoritative diff already happens — race-free vs handler-level snapshots, and it covers every caller including bulk ops). Producer coverage audited: single/bulk item updates, moves, creates-with-assignee, comments, replies, and comment-attached-to-update all emit; named non-emitting paths (import bundle, transitions backfill, workspace restore/purge, version restore) documented.
- **CLI**: `pad watch <ref> [--until status=X]` / `list` / `remove`; `pad watch --stream --for-session` — the plugin monitor: one plain fact line per event (`PAD TASK-214 → done (Dave): fix verified`), silent-start contract per DOC-2479 (no `.pad.toml` → hourly silent retry; server unreachable → silent backoff; never exits, never prompts — the old getClient path could launch an interactive wizard); `sync_required` clears the resume cursor. `pad session register` writes the on-disk session registry (`~/.pad/sessions/`).

## Scope decisions (recorded in DOC-2479)

- **Addressed-to-you = assignment-only in v1.** The data model has no collection "kind" and no server-side session→role binding, so the design's "ask/decision targets your role" half has no mechanical hook; collection-name sniffing rejected as silently wrong. `ask` stays in the wire enum with no producer. Human-gate items are reachable via explicit `pad watch`. `pad session register` is the natural future hook for session identity.
- **Bulk mutations emit per-item notifications** (not batched like the workspace SSE path) — each is scoped by the recipient's own filter; noted as a noise tradeoff, not a leak.
- Monitor line format is one-notification-per-fact; a combined field-change+comment update surfaces as two lines.

## Review trail

Five codex (gpt-5.6-luna) rounds; every finding fixed with a revert-verified regression test (each test shown to fail against the reverted fix):
- R1 (6 findings): watches ACL re-checked against *current* access; reply comments publish; replay/live dedupe via atomic subscribe-and-replay; atomic ID ordering; monitor silent-start ordering (the getClient wizard trap); `sync_required` cursor clear.
- R2 (4): item-grant collections no longer widen to full collection access (sibling-item leak closed); addressed-to-you delivery gated by the same uniform access check — this falsified the original "only filters the caller's own watches" argument, so the bespoke ACL reasoning was replaced with computeSSEVisibility parity; Publish close-then-send panic race fixed; assignment delta re-read under lock (no stale pre-tx snapshot).
- R3 (1): the vis cache re-fetches the user each tick (demotion/disablement take effect mid-connection), fail-closed.
- R4 (1): the reset is unconditional per tick — no longer skipped when the watch-list reload errors.
- R5 (2): watch-set staleness bounded — after 3 consecutive reload failures the set clears (watch-matched delivery fails closed; addressed-to-you continues; recovers on next successful reload); the reload-fault test seam made properly atomic (the sibling `restoreAckFault` seam checked and found safe by happens-before, documented).
- R6: convergence re-verify of the final commit.

## Test plan

- [x] `go test ./...` (SQLite, count=1) — all packages
- [x] `go test ./... -race` — full suite, clean
- [x] Postgres suite (`PAD_TEST_POSTGRES_URL`) — all packages, incl. both migrations and lock-model-sensitive concurrency tests
- [x] `golangci-lint run ./...` — 0 issues
- [x] Concurrency: hammer test provokes the pre-fix send-on-closed-channel panic; deterministic two-transaction race test for the mutation signal; demotion/disable mid-connection stream tests; reval-tick fault-injection test (watch-list reload failing while user is disabled)

Refs: TASK-2533, PLAN-2469, DOC-2479 (+ day-31 amendment)
