### PR TITLE
fix(store): include the cursor's own second in /changes deltas (BUG-2539)

### DIFF
--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -4784,10 +4784,14 @@ func scanItems(rows *sql.Rows) ([]models.Item, error) {
 // second and no later query reaches back for it: a bulk archive ~450ms after a
 // page seeded its cursor left the item rendering as live indefinitely.
 //
-// `>=` against the truncated second may re-deliver changes from the boundary
-// second that the caller already has. That is the cheap direction to be wrong
-// in — every consumer of this endpoint applies server state idempotently — and
-// it is bounded to one second of changes per sync. Sub-second storage would be
+// `>=` against the truncated second makes the endpoint AT-LEAST-ONCE at the
+// second boundary: rows written inside the cursor's second come back again, and
+// come back on every sync whose cursor stays inside that second, so a burst of
+// rapid syncs can repeat them more than once. That is the cheap direction to be
+// wrong in, because the payload is server STATE rather than a delta to apply on
+// top of what the caller has — every in-tree consumer overwrites its row from
+// it, so a repeat is a no-op rather than a double-apply. A future consumer that
+// treats these rows as increments would not be safe here. Sub-second storage would be
 // the other fix, but items timestamps are second-precision throughout and
 // mixing formats in one column breaks the lexicographic ordering these string
 // comparisons rely on ("…20.451Z" sorts BEFORE "…20Z"), so precision is a

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -4770,11 +4770,30 @@ func scanItems(rows *sql.Rows) ([]models.Item, error) {
 // items that were deleted (hard-deleted or archived) since the timestamp.
 //
 // The updated list includes both active AND recently archived items (those with
-// deleted_at > since). This lets the frontend update archived views correctly —
-// an item that was just archived needs its full data to appear in archived views,
-// not just its ID in the deleted list.
+// deleted_at at/after since). This lets the frontend update archived views
+// correctly — an item that was just archived needs its full data to appear in
+// archived views, not just its ID in the deleted list.
+//
+// The cursor comparison is INCLUSIVE of its own second, deliberately (BUG-2539).
+// items.updated_at / items.deleted_at are written at RFC3339 whole-second
+// precision (store.now()), while the caller's cursor is a unix-MILLISECOND value
+// — normally the previous response's server_time. Formatting that cursor for
+// comparison truncates it DOWN to the second, so with a strict `>` every change
+// that landed in the cursor's own second compares equal and is dropped. It is
+// dropped PERMANENTLY, because the caller then advances its cursor past that
+// second and no later query reaches back for it: a bulk archive ~450ms after a
+// page seeded its cursor left the item rendering as live indefinitely.
+//
+// `>=` against the truncated second may re-deliver changes from the boundary
+// second that the caller already has. That is the cheap direction to be wrong
+// in — every consumer of this endpoint applies server state idempotently — and
+// it is bounded to one second of changes per sync. Sub-second storage would be
+// the other fix, but items timestamps are second-precision throughout and
+// mixing formats in one column breaks the lexicographic ordering these string
+// comparisons rely on ("…20.451Z" sorts BEFORE "…20Z"), so precision is a
+// migration, not a one-line change.
 func (s *Store) ItemsModifiedSince(workspaceID string, since time.Time) (updated []models.Item, deletedIDs []string, err error) {
-	sinceStr := since.UTC().Format(time.RFC3339)
+	sinceStr := since.UTC().Truncate(time.Second).Format(time.RFC3339)
 
 	// Fetch updated items: active items modified since the timestamp,
 	// PLUS items archived since the timestamp (so archived views can update).
@@ -4791,8 +4810,8 @@ func (s *Store) ItemsModifiedSince(workspaceID string, since time.Time) (updated
 		LEFT JOIN users au ON au.id = i.assigned_user_id
 		LEFT JOIN agent_roles ar ON ar.id = i.agent_role_id
 		WHERE i.workspace_id = ?
-		  AND i.updated_at > ?
-		  AND (i.deleted_at IS NULL OR i.deleted_at > ?)
+		  AND i.updated_at >= ?
+		  AND (i.deleted_at IS NULL OR i.deleted_at >= ?)
 		ORDER BY i.updated_at ASC
 	`)
 
@@ -4811,7 +4830,7 @@ func (s *Store) ItemsModifiedSince(workspaceID string, since time.Time) (updated
 		SELECT id FROM items
 		WHERE workspace_id = ?
 		  AND deleted_at IS NOT NULL
-		  AND deleted_at > ?
+		  AND deleted_at >= ?
 	`)
 	delRows, err := s.db.Query(delQuery, workspaceID, sinceStr)
 	if err != nil {

--- a/internal/store/items_changes_cursor_test.go
+++ b/internal/store/items_changes_cursor_test.go
@@ -14,81 +14,139 @@ import (
 // equal and vanish — permanently, since the caller advances its cursor past
 // that second afterwards.
 //
-// Both cases below use a cursor that is strictly EARLIER than the mutation in
-// real time, so a correct implementation returns the change in BOTH. They
-// differ only in whether the cursor truncates to the same second as the write,
-// which is exactly the axis the bug lives on: the second leg is the control,
-// and it passed before the fix as well as after.
+// Both legs use a cursor that is strictly EARLIER than the mutation in real
+// time, so a correct implementation returns the change in BOTH. They differ
+// only in whether the cursor truncates to the same second as the write, which
+// is exactly the axis the bug lives on: the second leg is the control, and it
+// passed before the fix as well as after.
+//
+// The same-second claim is checked against the timestamps the writes ACTUALLY
+// stored, not against a wall-clock reading taken before them — a leg whose
+// writes drifted into the next second would otherwise pass under the unfixed
+// query and be counted as evidence (Codex P2). Alignment is retried rather than
+// skipped so the leg cannot silently stop testing anything.
 func TestItemsModifiedSince_SameSecondCursor(t *testing.T) {
 	for _, tc := range []struct {
 		name string
 		// how far before the mutation the cursor sits
 		cursorLead time.Duration
-		// whether that lands the cursor inside the mutation's own second
+		// whether that should land the cursor inside the mutation's own second
 		sameSecond bool
 	}{
 		{name: "cursor inside the mutation's own second", cursorLead: 200 * time.Millisecond, sameSecond: true},
 		{name: "cursor in the previous second (control)", cursorLead: 1200 * time.Millisecond, sameSecond: false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			s := testStore(t)
-			ws := createTestWorkspace(t, s, "ChangesCursor")
-			coll := createTestCollection(t, s, ws.ID, "Tasks")
-
-			// Park the mutation ~500ms into a wall-clock second so a 200ms lead
-			// stays inside that second and a 1200ms lead cannot.
-			for {
-				if frac := time.Now().UnixMilli() % 1000; frac > 450 && frac < 550 {
-					break
+			const attempts = 8
+			for attempt := 1; ; attempt++ {
+				aligned := runSameSecondCursorLeg(t, tc.cursorLead, tc.sameSecond, attempt == attempts)
+				if aligned {
+					return
 				}
-				time.Sleep(2 * time.Millisecond)
-			}
-
-			archived := createTestItem(t, s, ws.ID, coll.ID, "archived in-window", "")
-			updatedItem := createTestItem(t, s, ws.ID, coll.ID, "updated in-window", "")
-
-			mutateAt := time.Now()
-			cursor := mutateAt.Add(-tc.cursorLead)
-			if inSameSecond := cursor.UTC().Truncate(time.Second).Equal(mutateAt.UTC().Truncate(time.Second)); inSameSecond != tc.sameSecond {
-				t.Skipf("timing raced the second boundary (cursor same-second=%v, wanted %v)", inSameSecond, tc.sameSecond)
-			}
-
-			if err := s.DeleteItem(archived.ID); err != nil {
-				t.Fatalf("archive: %v", err)
-			}
-			newTitle := "updated in-window (touched)"
-			if _, err := s.UpdateItem(updatedItem.ID, models.ItemUpdate{Title: &newTitle}); err != nil {
-				t.Fatalf("update: %v", err)
-			}
-
-			updated, deletedIDs, err := s.ItemsModifiedSince(ws.ID, cursor)
-			if err != nil {
-				t.Fatalf("ItemsModifiedSince: %v", err)
-			}
-
-			var sawDeleted bool
-			for _, id := range deletedIDs {
-				if id == archived.ID {
-					sawDeleted = true
+				if attempt == attempts {
+					t.Fatalf("could not land the writes in the intended second after %d attempts", attempts)
 				}
-			}
-			if !sawDeleted {
-				t.Errorf("archive at %s is missing from the deleted list for cursor %s (%v earlier, same-second=%v)",
-					mutateAt.UTC().Format(time.RFC3339Nano), cursor.UTC().Format(time.RFC3339Nano),
-					tc.cursorLead, tc.sameSecond)
-			}
-
-			var sawUpdated bool
-			for _, it := range updated {
-				if it.ID == updatedItem.ID {
-					sawUpdated = true
-				}
-			}
-			if !sawUpdated {
-				t.Errorf("update at %s is missing from the updated list for cursor %s (%v earlier, same-second=%v)",
-					mutateAt.UTC().Format(time.RFC3339Nano), cursor.UTC().Format(time.RFC3339Nano),
-					tc.cursorLead, tc.sameSecond)
 			}
 		})
 	}
+}
+
+// runSameSecondCursorLeg runs one attempt. It reports whether the writes landed
+// in the intended second relative to the cursor; when they did, it asserts the
+// delta. `strict` makes a misalignment fatal rather than a retry signal.
+func runSameSecondCursorLeg(t *testing.T, cursorLead time.Duration, wantSameSecond, strict bool) bool {
+	t.Helper()
+
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "ChangesCursor")
+	coll := createTestCollection(t, s, ws.ID, "Tasks")
+
+	// Park the mutations ~500ms into a wall-clock second so a 200ms lead stays
+	// inside that second and a 1200ms lead cannot.
+	for {
+		if frac := time.Now().UnixMilli() % 1000; frac > 450 && frac < 550 {
+			break
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	archived := createTestItem(t, s, ws.ID, coll.ID, "archived in-window", "")
+	updatedItem := createTestItem(t, s, ws.ID, coll.ID, "updated in-window", "")
+
+	cursor := time.Now().Add(-cursorLead)
+
+	if err := s.DeleteItem(archived.ID); err != nil {
+		t.Fatalf("archive: %v", err)
+	}
+	newTitle := "updated in-window (touched)"
+	if _, err := s.UpdateItem(updatedItem.ID, models.ItemUpdate{Title: &newTitle}); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+
+	// The alignment that matters is between the cursor and what was STORED.
+	storedDeletedAt := scalarString(t, s, `SELECT deleted_at FROM items WHERE id = `+s.dialect.Placeholder(1), archived.ID)
+	storedUpdatedAt := scalarString(t, s, `SELECT updated_at FROM items WHERE id = `+s.dialect.Placeholder(1), updatedItem.ID)
+	cursorSecond := cursor.UTC().Truncate(time.Second).Format(time.RFC3339)
+	gotSameSecond := storedDeletedAt == cursorSecond && storedUpdatedAt == cursorSecond
+	if gotSameSecond != wantSameSecond {
+		if !strict {
+			return false
+		}
+		t.Fatalf("writes landed at deleted_at=%s updated_at=%s against cursor second %s (same-second=%v, wanted %v)",
+			storedDeletedAt, storedUpdatedAt, cursorSecond, gotSameSecond, wantSameSecond)
+	}
+	if cursor.After(time.Now()) {
+		t.Fatalf("cursor %s is not earlier than the mutations", cursor)
+	}
+
+	updated, deletedIDs, err := s.ItemsModifiedSince(ws.ID, cursor)
+	if err != nil {
+		t.Fatalf("ItemsModifiedSince: %v", err)
+	}
+
+	if !containsID(deletedIDs, archived.ID) {
+		t.Errorf("archive stored at %s is missing from the deleted list for cursor second %s (same-second=%v)",
+			storedDeletedAt, cursorSecond, wantSameSecond)
+	}
+
+	// The archived row must ALSO come back in `updated` — that is the only
+	// coverage of the `(deleted_at IS NULL OR deleted_at >= ?)` arm, which
+	// could otherwise regress to `>` unnoticed (Codex P2). Archived views need
+	// the full row, not just the id.
+	var sawArchivedInUpdated, sawUpdated bool
+	for _, it := range updated {
+		switch it.ID {
+		case archived.ID:
+			sawArchivedInUpdated = true
+		case updatedItem.ID:
+			sawUpdated = true
+		}
+	}
+	if !sawArchivedInUpdated {
+		t.Errorf("archived row stored at %s is missing from the updated list for cursor second %s (same-second=%v)",
+			storedDeletedAt, cursorSecond, wantSameSecond)
+	}
+	if !sawUpdated {
+		t.Errorf("update stored at %s is missing from the updated list for cursor second %s (same-second=%v)",
+			storedUpdatedAt, cursorSecond, wantSameSecond)
+	}
+	return true
+}
+
+func containsID(ids []string, want string) bool {
+	for _, id := range ids {
+		if id == want {
+			return true
+		}
+	}
+	return false
+}
+
+func scalarString(t *testing.T, s *Store, query string, args ...any) string {
+	t.Helper()
+	var v string
+	if err := s.db.QueryRow(query, args...).Scan(&v); err != nil {
+		t.Fatalf("scalar query %q: %v", query, err)
+	}
+	return v
 }

--- a/internal/store/items_changes_cursor_test.go
+++ b/internal/store/items_changes_cursor_test.go
@@ -1,0 +1,94 @@
+package store
+
+import (
+	"testing"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// BUG-2539. items.updated_at / items.deleted_at are RFC3339 whole-second
+// strings; the /changes cursor is a unix-millisecond value that gets formatted
+// with the same second precision, i.e. truncated DOWN. Under the original
+// strict `>` that made every change landing in the cursor's own second compare
+// equal and vanish — permanently, since the caller advances its cursor past
+// that second afterwards.
+//
+// Both cases below use a cursor that is strictly EARLIER than the mutation in
+// real time, so a correct implementation returns the change in BOTH. They
+// differ only in whether the cursor truncates to the same second as the write,
+// which is exactly the axis the bug lives on: the second leg is the control,
+// and it passed before the fix as well as after.
+func TestItemsModifiedSince_SameSecondCursor(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		// how far before the mutation the cursor sits
+		cursorLead time.Duration
+		// whether that lands the cursor inside the mutation's own second
+		sameSecond bool
+	}{
+		{name: "cursor inside the mutation's own second", cursorLead: 200 * time.Millisecond, sameSecond: true},
+		{name: "cursor in the previous second (control)", cursorLead: 1200 * time.Millisecond, sameSecond: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := testStore(t)
+			ws := createTestWorkspace(t, s, "ChangesCursor")
+			coll := createTestCollection(t, s, ws.ID, "Tasks")
+
+			// Park the mutation ~500ms into a wall-clock second so a 200ms lead
+			// stays inside that second and a 1200ms lead cannot.
+			for {
+				if frac := time.Now().UnixMilli() % 1000; frac > 450 && frac < 550 {
+					break
+				}
+				time.Sleep(2 * time.Millisecond)
+			}
+
+			archived := createTestItem(t, s, ws.ID, coll.ID, "archived in-window", "")
+			updatedItem := createTestItem(t, s, ws.ID, coll.ID, "updated in-window", "")
+
+			mutateAt := time.Now()
+			cursor := mutateAt.Add(-tc.cursorLead)
+			if inSameSecond := cursor.UTC().Truncate(time.Second).Equal(mutateAt.UTC().Truncate(time.Second)); inSameSecond != tc.sameSecond {
+				t.Skipf("timing raced the second boundary (cursor same-second=%v, wanted %v)", inSameSecond, tc.sameSecond)
+			}
+
+			if err := s.DeleteItem(archived.ID); err != nil {
+				t.Fatalf("archive: %v", err)
+			}
+			newTitle := "updated in-window (touched)"
+			if _, err := s.UpdateItem(updatedItem.ID, models.ItemUpdate{Title: &newTitle}); err != nil {
+				t.Fatalf("update: %v", err)
+			}
+
+			updated, deletedIDs, err := s.ItemsModifiedSince(ws.ID, cursor)
+			if err != nil {
+				t.Fatalf("ItemsModifiedSince: %v", err)
+			}
+
+			var sawDeleted bool
+			for _, id := range deletedIDs {
+				if id == archived.ID {
+					sawDeleted = true
+				}
+			}
+			if !sawDeleted {
+				t.Errorf("archive at %s is missing from the deleted list for cursor %s (%v earlier, same-second=%v)",
+					mutateAt.UTC().Format(time.RFC3339Nano), cursor.UTC().Format(time.RFC3339Nano),
+					tc.cursorLead, tc.sameSecond)
+			}
+
+			var sawUpdated bool
+			for _, it := range updated {
+				if it.ID == updatedItem.ID {
+					sawUpdated = true
+				}
+			}
+			if !sawUpdated {
+				t.Errorf("update at %s is missing from the updated list for cursor %s (%v earlier, same-second=%v)",
+					mutateAt.UTC().Format(time.RFC3339Nano), cursor.UTC().Format(time.RFC3339Nano),
+					tc.cursorLead, tc.sameSecond)
+			}
+		})
+	}
+}

--- a/web/e2e/bug-2539-sync-window.spec.ts
+++ b/web/e2e/bug-2539-sync-window.spec.ts
@@ -1,5 +1,5 @@
-import { expect, type Request } from '@playwright/test';
-import { test, quietCrossActorToasts } from './fixtures';
+import { expect, type APIRequestContext, type Page, type Request } from '@playwright/test';
+import { test, quietCrossActorToasts, type SuiteFixture } from './fixtures';
 
 /**
  * BUG-2539 — a bulk archive landing in the same wall-clock second as the page's
@@ -11,28 +11,36 @@ import { test, quietCrossActorToasts } from './fixtures';
  * end: the archived banner appears in the page that was already open, without a
  * reload.
  *
- * The two legs are named after the MECHANISM, not a millisecond offset. An
- * earlier version fired the archive at a fixed delay after navigation start;
- * that reproduced on an idle machine and stopped reproducing under parallel
- * workers, because a slow load put the page's own item read AFTER the archive —
- * at which point the page renders an archived row from the start and the sync
- * path is never exercised. The legs now wait for the preconditions instead:
+ * The legs are named after the MECHANISM, and — this is the part that took
+ * three tries to get right — each one PROVES it hit that mechanism using
+ * server-attested values, then retries if it did not:
  *
- *   - the page has READ a live row (server-attested, `deleted_at: null`), and
- *   - its EventSource is subscribed (the /events response headers have
- *     arrived — the handler subscribes before writing them),
+ *   - the cursor second is the `server_time` of the page's FIRST `/changes`
+ *     (the seed `setWorkspace` fires on mount, which is what `lastSyncTime`
+ *     becomes);
+ *   - the archive second is the `deleted_at` the server stored.
  *
- * and only then archive: immediately (same second as the page's sync cursor —
- * the reproducing case) or after crossing the next second boundary (the control
- * that behaved even before the fix).
+ * The same-second leg requires those to be equal, the boundary leg requires
+ * them to differ, and a misaligned attempt is retried on a fresh workspace
+ * rather than asserted on. Without that check the reproducing leg can drift
+ * across a second boundary on a slow machine, quietly become a second control,
+ * and pass against the very query it is supposed to convict.
  *
- * The oracle requires all three of:
+ * Preconditions before archiving, so the leg exercises the sync path at all:
+ * the page has READ a live row (a GET whose body carries no `deleted_at`) and
+ * its EventSource is subscribed (the /events response headers have arrived —
+ * the handler subscribes before writing them). An earlier revision fired at a
+ * fixed offset from navigation start instead; under parallel workers a slow
+ * load put the page's read AFTER the archive, so it rendered an already-
+ * archived row and no sync was involved.
+ *
+ * The oracle then requires:
  *   1. the page read a live row — otherwise no sync was involved;
- *   2. the deletion arrived on a `/changes` that is neither the cursor-seeding
- *      one (ordinal 0, fired by setWorkspace on mount) nor issued before the
- *      archive. Both checks are kept so a RETRIED seed cannot pass on ordinal
- *      alone. The URL match is anchored so `/items-changes` — a different,
- *      seq-based endpoint — cannot consume ordinals;
+ *   2. the deletion arrived on a `/changes` that is neither the seed (ordinal
+ *      0) nor issued before the archive. Both are checked so a RETRIED seed
+ *      cannot pass on ordinal alone. The URL match is anchored so
+ *      `/items-changes` — a different, seq-based endpoint — cannot consume
+ *      ordinals;
  *   3. the banner rendered.
  *
  * Ground truth for archived-ness is the server's `deleted_at`, never the UI:
@@ -42,17 +50,21 @@ import { test, quietCrossActorToasts } from './fixtures';
 
 const CHANGES_RE = /\/api\/v1\/workspaces\/[^/]+\/changes(\?|$)/;
 const ITEM_GET_RE = /\/api\/v1\/workspaces\/[^/]+\/items\/[^/?]+$/;
+const ALIGNMENT_ATTEMPTS = 6;
 
 const LEGS = [
-	{
-		name: 'in the same second as the page cursor (the reproducing case)',
-		crossSecondBoundary: false
-	},
-	{
-		name: 'after the next second boundary (control)',
-		crossSecondBoundary: true
-	}
+	{ name: 'in the same second as the page cursor (the reproducing case)', crossSecondBoundary: false },
+	{ name: 'after the next second boundary (control)', crossSecondBoundary: true }
 ] as const;
+
+/** RFC3339 whole-second string, the shape the server stores and returns. */
+function secondOf(unixMs: number): string {
+	return new Date(Math.floor(unixMs / 1000) * 1000).toISOString().replace('.000Z', 'Z');
+}
+
+type Attempt =
+	| { outcome: 'misaligned'; cursorSecond: string | null; archiveSecond: string | null }
+	| { outcome: 'checked' };
 
 LEGS.forEach((leg, idx) => {
 	test(`BUG-2539: a bulk archive ${leg.name} reaches the open item`, async ({
@@ -63,80 +75,112 @@ LEGS.forEach((leg, idx) => {
 	}) => {
 		await quietCrossActorToasts(context);
 
-		const auth = { Authorization: `Bearer ${fixture.apiToken}` };
-		let createdSlug: string | null = null;
-		let cleanup: { ok: boolean; body: string } | null = null;
+		let last: Attempt = { outcome: 'misaligned', cursorSecond: null, archiveSecond: null };
+		for (let attempt = 1; attempt <= ALIGNMENT_ATTEMPTS; attempt++) {
+			last = await runLeg({ page, request, fixture, idx, attempt, crossSecondBoundary: leg.crossSecondBoundary });
+			if (last.outcome === 'checked') return;
+		}
+		throw new Error(
+			`could not land the archive ${leg.crossSecondBoundary ? 'past' : 'inside'} the cursor's second ` +
+				`after ${ALIGNMENT_ATTEMPTS} attempts (last: cursor=${last.cursorSecond} archive=${last.archiveSecond})`
+		);
+	});
+});
+
+async function runLeg(opts: {
+	page: Page;
+	request: APIRequestContext;
+	fixture: SuiteFixture;
+	idx: number;
+	attempt: number;
+	crossSecondBoundary: boolean;
+}): Promise<Attempt> {
+	const { page, request, fixture, idx, attempt, crossSecondBoundary } = opts;
+	const auth = { Authorization: `Bearer ${fixture.apiToken}` };
+	// Assigned from the slug we ASKED for, before any parse, so a malformed
+	// success response cannot leak the workspace. Overwritten with the server's
+	// slug (it uniquifies on collision) as soon as that is known.
+	let createdSlug: string | null = null;
+
+	try {
+		// Own workspace: the shared suite workspace carries cross-spec mutation
+		// traffic that muddies a cursor-sensitive leg.
+		const slug = `b2539-${idx}-${attempt}-${Date.now().toString(36)}`;
+		createdSlug = slug;
+		const wsResp = await request.post('/api/v1/workspaces', {
+			headers: auth,
+			data: { name: `BUG-2539 ${idx}`, slug, template: 'startup' }
+		});
+		expect(wsResp.ok(), await wsResp.text()).toBeTruthy();
+		const ws = (await wsResp.json()) as { slug: string };
+		createdSlug = ws.slug;
+
+		const itemResp = await request.post(`/api/v1/workspaces/${ws.slug}/collections/tasks/items`, {
+			headers: auth,
+			data: { title: `sync-window probe ${idx}` }
+		});
+		expect(itemResp.ok(), await itemResp.text()).toBeTruthy();
+		const item = (await itemResp.json()) as { id: string; slug: string };
+
+		// `archiveSentAt` is stamped before the POST is issued, so "issued after
+		// the archive went out" needs nothing to have resolved.
+		let archiveSentAt = Number.POSITIVE_INFINITY;
+		let seedServerTime: number | null = null;
+		const changesOrder = new Map<Request, number>();
+		const changesIssuedAt = new Map<Request, number>();
+		let changesSeen = 0;
+
+		const onRequest = (r: Request) => {
+			if (CHANGES_RE.test(r.url())) {
+				changesOrder.set(r, changesSeen++);
+				changesIssuedAt.set(r, Date.now());
+			}
+		};
+		page.on('request', onRequest);
+
+		let readLiveRow = false;
+		let incrementalCarriedDeletion = false;
+		const inFlight: Promise<void>[] = [];
+		const onResponse = (resp: import('@playwright/test').Response) => {
+			inFlight.push(
+				(async () => {
+					try {
+						if (CHANGES_RE.test(resp.url())) {
+							const order = changesOrder.get(resp.request());
+							const issued = changesIssuedAt.get(resp.request());
+							const body = (await resp.json()) as { deleted?: string[]; server_time?: number };
+							// The seed's server_time is what the client keeps as
+							// lastSyncTime — the cursor the failing sync used.
+							if (order === 0 && typeof body.server_time === 'number') {
+								seedServerTime = body.server_time;
+							}
+							if (
+								order !== undefined &&
+								order > 0 &&
+								issued !== undefined &&
+								issued >= archiveSentAt &&
+								body.deleted?.includes(item.id)
+							) {
+								incrementalCarriedDeletion = true;
+							}
+						} else if (ITEM_GET_RE.test(resp.url()) && resp.request().method() === 'GET') {
+							// A live row omits deleted_at entirely (omitempty), so
+							// this is a falsy check, not a null check.
+							const body = (await resp.json()) as { id?: string; deleted_at?: string | null };
+							if (body.id === item.id && !body.deleted_at) readLiveRow = true;
+						}
+					} catch {
+						/* non-JSON body — ignore */
+					}
+				})()
+			);
+		};
+		page.on('response', onResponse);
 
 		try {
-			// Own workspace: the shared suite workspace carries cross-spec
-			// mutation traffic that muddies a cursor-sensitive leg.
-			const slug = `b2539-${idx}-${Date.now().toString(36)}`;
-			const wsResp = await request.post('/api/v1/workspaces', {
-				headers: auth,
-				data: { name: `BUG-2539 ${idx}`, slug, template: 'startup' }
-			});
-			expect(wsResp.ok(), await wsResp.text()).toBeTruthy();
-			const ws = (await wsResp.json()) as { slug: string };
-			createdSlug = ws.slug;
-
-			const itemResp = await request.post(
-				`/api/v1/workspaces/${ws.slug}/collections/tasks/items`,
-				{ headers: auth, data: { title: `sync-window probe ${idx}` } }
-			);
-			expect(itemResp.ok(), await itemResp.text()).toBeTruthy();
-			const item = (await itemResp.json()) as { id: string; slug: string };
-
-			// `archiveSentAt` is stamped before the POST is issued, so "issued
-			// after the archive went out" needs nothing to have resolved.
-			let archiveSentAt = Number.POSITIVE_INFINITY;
-			const changesOrder = new Map<Request, number>();
-			const changesIssuedAt = new Map<Request, number>();
-			let changesSeen = 0;
-
-			page.on('request', (r) => {
-				if (CHANGES_RE.test(r.url())) {
-					changesOrder.set(r, changesSeen++);
-					changesIssuedAt.set(r, Date.now());
-				}
-			});
-
-			let readLiveRow = false;
-			let incrementalCarriedDeletion = false;
-			const inFlight: Promise<void>[] = [];
-			page.on('response', (resp) => {
-				inFlight.push(
-					(async () => {
-						try {
-							if (CHANGES_RE.test(resp.url())) {
-								const order = changesOrder.get(resp.request());
-								const issued = changesIssuedAt.get(resp.request());
-								const body = (await resp.json()) as { deleted?: string[] };
-								if (
-									order !== undefined &&
-									order > 0 &&
-									issued !== undefined &&
-									issued >= archiveSentAt &&
-									body.deleted?.includes(item.id)
-								) {
-									incrementalCarriedDeletion = true;
-								}
-							} else if (ITEM_GET_RE.test(resp.url()) && resp.request().method() === 'GET') {
-								const body = (await resp.json()) as { id?: string; deleted_at?: string | null };
-								if (body.id === item.id && !body.deleted_at) readLiveRow = true;
-							}
-						} catch {
-							/* non-JSON body — ignore */
-						}
-					})()
-				);
-			});
-
 			// The SSE handler subscribes BEFORE writing its response headers, so
-			// this resolving means the server is ready to deliver the archive
-			// event to this page.
+			// this resolving means the server can deliver the archive event here.
 			const sseSubscribed = page.waitForResponse((r) => r.url().includes('/api/v1/events'));
-			// A GET of this item whose body carries deleted_at null — the page
-			// has a live row on screen.
 			const liveRowRead = page.waitForResponse(async (r) => {
 				if (!ITEM_GET_RE.test(r.url()) || r.request().method() !== 'GET') return false;
 				try {
@@ -147,13 +191,14 @@ LEGS.forEach((leg, idx) => {
 				}
 			});
 
-			const itemUrl = `/${fixture.adminUsername}/${ws.slug}/tasks/${item.id}`;
-			await page.goto(itemUrl, { waitUntil: 'domcontentloaded' });
+			await page.goto(`/${fixture.adminUsername}/${ws.slug}/tasks/${item.id}`, {
+				waitUntil: 'domcontentloaded'
+			});
 			await Promise.all([sseSubscribed, liveRowRead]);
 
-			if (leg.crossSecondBoundary) {
-				// Push the archive past the second the page's cursor sits in,
-				// plus a small margin so a clock tick can't land it back inside.
+			if (crossSecondBoundary) {
+				// Push past the second the cursor sits in, plus a margin so a
+				// clock tick cannot land the archive back inside it.
 				await page.waitForTimeout(1000 - (Date.now() % 1000) + 120);
 			}
 
@@ -172,6 +217,16 @@ LEGS.forEach((leg, idx) => {
 			const checked = (await check.json()) as { deleted_at: string | null };
 			expect(checked.deleted_at, 'archive must land server-side').not.toBeNull();
 
+			// Did this attempt actually hit the mechanism it is named after?
+			// Both sides are server values: the cursor the client kept, and the
+			// timestamp the server stored.
+			const cursorSecond = seedServerTime === null ? null : secondOf(seedServerTime);
+			const archiveSecond = checked.deleted_at;
+			const sameSecond = cursorSecond !== null && cursorSecond === archiveSecond;
+			if (sameSecond === crossSecondBoundary) {
+				return { outcome: 'misaligned', cursorSecond, archiveSecond };
+			}
+
 			// The open page must learn about it without a reload.
 			await expect(page.locator('.archived-banner')).toBeVisible({ timeout: 10_000 });
 			// Drain until no new handler was queued while awaiting.
@@ -180,14 +235,16 @@ LEGS.forEach((leg, idx) => {
 				await Promise.all(inFlight);
 			}
 
-			// Both messages carry the recorded state. This leg has flaked rarely
-			// (twice in ~70 local runs) and both times the artifacts were gone
-			// before they could be read, so a recurrence has to explain itself
-			// from the failure text alone.
+			// Messages carry the recorded state: this leg flaked twice in ~70
+			// runs of an earlier revision and the artifacts were cleared by the
+			// next run before they could be read, so a recurrence has to explain
+			// itself from the failure text alone.
 			const diag = JSON.stringify({
+				attempt,
+				cursorSecond,
+				archiveSecond,
 				changesSeen,
 				changesAfterArchive: [...changesIssuedAt.values()].filter((t) => t >= archiveSentAt).length,
-				archiveSentAt,
 				readLiveRow,
 				incrementalCarriedDeletion,
 				responsesObserved: inFlight.length
@@ -200,15 +257,18 @@ LEGS.forEach((leg, idx) => {
 				incrementalCarriedDeletion,
 				`the deletion must arrive on a /changes issued after the archive and after the page's cursor-seeding one — not the seed, and not a reload — ${diag}`
 			).toBeTruthy();
+			return { outcome: 'checked' };
 		} finally {
-			if (createdSlug) {
-				const del = await request.delete(`/api/v1/workspaces/${createdSlug}`, { headers: auth });
-				// Recorded, not asserted here: throwing from `finally` would
-				// replace the real failure with a cleanup one.
-				cleanup = { ok: del.ok(), body: await del.text() };
-			}
+			page.off('request', onRequest);
+			page.off('response', onResponse);
 		}
-
-		expect(cleanup?.ok, `scratch workspace cleanup failed: ${cleanup?.body}`).toBeTruthy();
-	});
-});
+	} finally {
+		if (createdSlug) {
+			// Swallowed on purpose: throwing from here would replace the real
+			// failure with a cleanup one.
+			await request
+				.delete(`/api/v1/workspaces/${createdSlug}`, { headers: auth })
+				.catch(() => undefined);
+		}
+	}
+}

--- a/web/e2e/bug-2539-sync-window.spec.ts
+++ b/web/e2e/bug-2539-sync-window.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from '@playwright/test';
+import { expect, type Request } from '@playwright/test';
 import { test, quietCrossActorToasts } from './fixtures';
 
 /**
@@ -11,16 +11,23 @@ import { test, quietCrossActorToasts } from './fixtures';
  * end of the same defect: the archived banner appears in the page that was
  * already open, without a reload.
  *
- * Three things have to hold together, or the assertion is satisfiable by a
- * mechanism that is not the one under test (Codex P2):
+ * Three things must hold together, or the banner is satisfiable by a mechanism
+ * that is not the one under test:
  *
- *   1. the page must have loaded a LIVE row — otherwise it simply rendered an
- *      already-archived item and no sync was involved;
- *   2. the deletion must arrive on a `/changes` response that resolved AFTER
- *      the archive POST completed — the cursor-seeding request `setWorkspace`
- *      fires during load can also carry it once the fix is in, and that one
- *      proves nothing about the incremental path;
+ *   1. the page must have loaded a LIVE row, on a request it issued BEFORE the
+ *      archive — otherwise it simply rendered an already-archived item;
+ *   2. the deletion must arrive on a `/changes` that is NOT the page's first
+ *      one — the first is the cursor seed `setWorkspace` fires on mount, which
+ *      can carry the deletion once the fix is in and proves nothing about the
+ *      incremental path;
  *   3. only then does the banner count.
+ *
+ * Both (1) and (2) are decided by REQUEST ORDER, not by response timing.
+ * Response-arrival ordering is genuinely racy here: the server publishes the
+ * SSE event before the bulk handler finishes writing its own HTTP response, so
+ * the incremental `/changes` can resolve before the archive call returns
+ * (Codex P2 on the first attempt at this oracle, which timed responses against
+ * archive completion and could both flake and false-pass).
  *
  * Ground truth for archived-ness is the server's `deleted_at`, never the UI:
  * asserting on the UI alone cannot distinguish "not archived" from "archived
@@ -56,72 +63,103 @@ DELAYS.forEach((delay, idx) => {
 		});
 		expect(wsResp.ok(), await wsResp.text()).toBeTruthy();
 		const ws = (await wsResp.json()) as { slug: string };
-		test.info().annotations.push({ type: 'workspace', description: ws.slug });
 
-		const itemResp = await request.post(
-			`/api/v1/workspaces/${ws.slug}/collections/tasks/items`,
-			{ headers: auth, data: { title: `sync-window probe ${delay}` } }
-		);
-		expect(itemResp.ok(), await itemResp.text()).toBeTruthy();
-		const item = (await itemResp.json()) as { id: string; slug: string };
+		try {
+			const itemResp = await request.post(
+				`/api/v1/workspaces/${ws.slug}/collections/tasks/items`,
+				{ headers: auth, data: { title: `sync-window probe ${delay}` } }
+			);
+			expect(itemResp.ok(), await itemResp.text()).toBeTruthy();
+			const item = (await itemResp.json()) as { id: string; slug: string };
 
-		let archiveDoneAt = Number.POSITIVE_INFINITY;
-		// (1) did the page's own item load see a LIVE row?
-		let loadedLive = false;
-		// (2) did a /changes that resolved AFTER the archive carry the deletion?
-		let incrementalCarriedDeletion = false;
-		const itemGetRe = /\/api\/v1\/workspaces\/[^/]+\/items\/[^/?]+$/;
-		page.on('response', async (resp) => {
-			const at = Date.now();
-			try {
-				if (resp.url().includes('/changes')) {
-					const body = (await resp.json()) as { deleted?: string[] };
-					if (body.deleted?.includes(item.id) && at > archiveDoneAt) {
-						incrementalCarriedDeletion = true;
-					}
-				} else if (itemGetRe.test(resp.url()) && resp.request().method() === 'GET') {
-					const body = (await resp.json()) as { id?: string; deleted_at?: string | null };
-					if (body.id === item.id && !body.deleted_at) loadedLive = true;
+			// Request-side bookkeeping. `archiveSentAt` is stamped before the POST
+			// is issued, so "issued before the archive" is decidable without
+			// depending on when anything resolved.
+			let archiveSentAt = Number.POSITIVE_INFINITY;
+			const changesOrder = new Map<Request, number>();
+			const itemGetIssuedAt = new Map<Request, number>();
+			let changesSeen = 0;
+			const itemGetRe = /\/api\/v1\/workspaces\/[^/]+\/items\/[^/?]+$/;
+
+			page.on('request', (r) => {
+				if (r.url().includes('/changes')) {
+					changesOrder.set(r, changesSeen++);
+				} else if (itemGetRe.test(r.url()) && r.method() === 'GET') {
+					itemGetIssuedAt.set(r, Date.now());
 				}
-			} catch {
-				/* non-JSON body — ignore */
-			}
-		});
-
-		const itemUrl = `/${fixture.adminUsername}/${ws.slug}/tasks/${item.id}`;
-		// Fire the archive on a timer started at navigation start WITHOUT
-		// awaiting the page — awaiting first paint moves the archive out of the
-		// window under test.
-		const archivePromise = (async () => {
-			await new Promise((r) => setTimeout(r, delay));
-			const resp = await request.post(`/api/v1/workspaces/${ws.slug}/items/bulk`, {
-				headers: auth,
-				data: { op: 'archive', ids: [item.id] }
 			});
-			const body = await resp.text();
-			archiveDoneAt = Date.now();
-			return { ok: resp.ok(), body };
-		})();
-		await page.goto(itemUrl, { waitUntil: 'domcontentloaded' });
-		const bulk = await archivePromise;
-		expect(bulk.ok, bulk.body).toBeTruthy();
 
-		// Premise: the archive really landed server-side.
-		const check = await request.get(`/api/v1/workspaces/${ws.slug}/items/${item.slug}`, {
-			headers: auth
-		});
-		expect(check.ok(), await check.text()).toBeTruthy();
-		const checked = (await check.json()) as { deleted_at: string | null };
-		expect(checked.deleted_at, 'archive must land server-side').not.toBeNull();
+			// (1) the page's own pre-archive item load saw a LIVE row
+			let loadedLiveBeforeArchive = false;
+			// (2) a NON-SEED /changes carried the deletion
+			let incrementalCarriedDeletion = false;
+			// Response handlers are async; collect them so the assertions below
+			// can await the ones already in flight instead of racing them.
+			const inFlight: Promise<void>[] = [];
+			page.on('response', (resp) => {
+				inFlight.push(
+					(async () => {
+						try {
+							if (resp.url().includes('/changes')) {
+								const order = changesOrder.get(resp.request());
+								const body = (await resp.json()) as { deleted?: string[] };
+								if (order !== undefined && order > 0 && body.deleted?.includes(item.id)) {
+									incrementalCarriedDeletion = true;
+								}
+							} else if (itemGetRe.test(resp.url()) && resp.request().method() === 'GET') {
+								const issued = itemGetIssuedAt.get(resp.request());
+								const body = (await resp.json()) as { id?: string; deleted_at?: string | null };
+								if (body.id === item.id && !body.deleted_at && issued !== undefined && issued < archiveSentAt) {
+									loadedLiveBeforeArchive = true;
+								}
+							}
+						} catch {
+							/* non-JSON body — ignore */
+						}
+					})()
+				);
+			});
 
-		// The open page must learn about it without a reload.
-		await expect(page.locator('.archived-banner')).toBeVisible({ timeout: 10_000 });
-		expect(loadedLive, 'the page must have loaded a LIVE row for a sync to be what corrected it').toBeTruthy();
-		expect(
-			incrementalCarriedDeletion,
-			'the banner must follow a /changes that resolved AFTER the archive and carried the deletion — not the cursor-seeding request, and not a reload'
-		).toBeTruthy();
+			const itemUrl = `/${fixture.adminUsername}/${ws.slug}/tasks/${item.id}`;
+			// Fire the archive on a timer started at navigation start WITHOUT
+			// awaiting the page — awaiting first paint moves the archive out of
+			// the window under test.
+			const archivePromise = (async () => {
+				await new Promise((r) => setTimeout(r, delay));
+				archiveSentAt = Date.now();
+				const resp = await request.post(`/api/v1/workspaces/${ws.slug}/items/bulk`, {
+					headers: auth,
+					data: { op: 'archive', ids: [item.id] }
+				});
+				return { ok: resp.ok(), body: await resp.text() };
+			})();
+			await page.goto(itemUrl, { waitUntil: 'domcontentloaded' });
+			const bulk = await archivePromise;
+			expect(bulk.ok, bulk.body).toBeTruthy();
 
-		await request.delete(`/api/v1/workspaces/${ws.slug}`, { headers: auth });
+			// Premise: the archive really landed server-side.
+			const check = await request.get(`/api/v1/workspaces/${ws.slug}/items/${item.slug}`, {
+				headers: auth
+			});
+			expect(check.ok(), await check.text()).toBeTruthy();
+			const checked = (await check.json()) as { deleted_at: string | null };
+			expect(checked.deleted_at, 'archive must land server-side').not.toBeNull();
+
+			// The open page must learn about it without a reload.
+			await expect(page.locator('.archived-banner')).toBeVisible({ timeout: 10_000 });
+			await Promise.all(inFlight);
+
+			expect(
+				loadedLiveBeforeArchive,
+				'the page must have loaded a LIVE row before the archive for a sync to be what corrected it'
+			).toBeTruthy();
+			expect(
+				incrementalCarriedDeletion,
+				'the deletion must arrive on a /changes AFTER the page\'s cursor-seeding one — not the seed, and not a reload'
+			).toBeTruthy();
+		} finally {
+			const del = await request.delete(`/api/v1/workspaces/${ws.slug}`, { headers: auth });
+			expect(del.ok(), `scratch workspace cleanup failed: ${await del.text()}`).toBeTruthy();
+		}
 	});
 });

--- a/web/e2e/bug-2539-sync-window.spec.ts
+++ b/web/e2e/bug-2539-sync-window.spec.ts
@@ -48,8 +48,15 @@ import { test, quietCrossActorToasts, type SuiteFixture } from './fixtures';
  * but not shown", which is the failure mode under test.
  */
 
-const CHANGES_RE = /\/api\/v1\/workspaces\/[^/]+\/changes(\?|$)/;
-const ITEM_GET_RE = /\/api\/v1\/workspaces\/[^/]+\/items\/[^/?]+$/;
+// Matchers are built PER ATTEMPT and scoped to that attempt's workspace. A
+// retry reuses the page, which is still showing the previous attempt's
+// workspace when the listeners go on — an in-flight /changes from that one
+// would otherwise take ordinal 0 and be mistaken for the new seed (Codex P2).
+const changesReFor = (wsSlug: string) =>
+	new RegExp(`/api/v1/workspaces/${wsSlug}/changes(\\?|$)`);
+const itemGetReFor = (wsSlug: string) =>
+	new RegExp(`/api/v1/workspaces/${wsSlug}/items/[^/?]+$`);
+const eventsUrlFor = (wsSlug: string) => `/api/v1/events?workspace=${wsSlug}`;
 const ALIGNMENT_ATTEMPTS = 6;
 
 const LEGS = [
@@ -130,6 +137,8 @@ async function runLeg(opts: {
 		const changesIssuedAt = new Map<Request, number>();
 		let changesSeen = 0;
 
+		const CHANGES_RE = changesReFor(ws.slug);
+		const ITEM_GET_RE = itemGetReFor(ws.slug);
 		const onRequest = (r: Request) => {
 			if (CHANGES_RE.test(r.url())) {
 				changesOrder.set(r, changesSeen++);
@@ -180,7 +189,7 @@ async function runLeg(opts: {
 		try {
 			// The SSE handler subscribes BEFORE writing its response headers, so
 			// this resolving means the server can deliver the archive event here.
-			const sseSubscribed = page.waitForResponse((r) => r.url().includes('/api/v1/events'));
+			const sseSubscribed = page.waitForResponse((r) => r.url().includes(eventsUrlFor(ws.slug)));
 			const liveRowRead = page.waitForResponse(async (r) => {
 				if (!ITEM_GET_RE.test(r.url()) || r.request().method() !== 'GET') return false;
 				try {
@@ -222,7 +231,12 @@ async function runLeg(opts: {
 			// timestamp the server stored.
 			const cursorSecond = seedServerTime === null ? null : secondOf(seedServerTime);
 			const archiveSecond = checked.deleted_at;
-			const sameSecond = cursorSecond !== null && cursorSecond === archiveSecond;
+			// A seed we never observed proves NEITHER equality nor difference —
+			// retry rather than let the control leg pass on an unknown (Codex P2).
+			if (cursorSecond === null) {
+				return { outcome: 'misaligned', cursorSecond, archiveSecond };
+			}
+			const sameSecond = cursorSecond === archiveSecond;
 			if (sameSecond === crossSecondBoundary) {
 				return { outcome: 'misaligned', cursorSecond, archiveSecond };
 			}

--- a/web/e2e/bug-2539-sync-window.spec.ts
+++ b/web/e2e/bug-2539-sync-window.spec.ts
@@ -1,0 +1,102 @@
+import { expect } from '@playwright/test';
+import { test, quietCrossActorToasts } from './fixtures';
+
+/**
+ * BUG-2539 — a bulk archive landing in the same wall-clock second as the page's
+ * sync cursor was invisible to `/changes`, leaving the item rendered LIVE
+ * indefinitely (see internal/store/items.go::ItemsModifiedSince).
+ *
+ * The deterministic pin for the cursor arithmetic is the store-level
+ * `TestItemsModifiedSince_SameSecondCursor`. This spec covers the user-visible
+ * end of the same defect: the archived banner appears in the page that was
+ * already open, without a reload.
+ *
+ * Two legs. 450ms after navigation start is the offset that reproduced 7/8
+ * times before the fix (the archive lands just after the SSE connects and
+ * inside the cursor's own second); 1200ms is the control that always behaved.
+ * Both are deterministic AFTER the fix — the comparison no longer depends on
+ * where inside a second the mutation fell.
+ *
+ * Ground truth for archived-ness is the server's `deleted_at`, never the UI:
+ * asserting on the UI alone cannot distinguish "not archived" from "archived
+ * but not shown", which is the failure mode under test.
+ */
+
+// Offsets are measured from NAVIGATION START, not first paint — anchoring to
+// paint pushes the archive clear of the window and the bug does not reproduce.
+const DELAYS = [450, 1200];
+
+DELAYS.forEach((delay, idx) => {
+	test(`BUG-2539: bulk archive ${delay}ms after navigation start reaches the open item`, async ({
+		page,
+		context,
+		request,
+		fixture
+	}) => {
+		await quietCrossActorToasts(context);
+
+		// Own workspace: the shared suite workspace carries cross-spec mutation
+		// traffic that muddies a cursor-sensitive leg.
+		const slug = `b2539-${idx}-${Date.now().toString(36)}`;
+		const auth = { Authorization: `Bearer ${fixture.apiToken}` };
+		const wsResp = await request.post('/api/v1/workspaces', {
+			headers: auth,
+			data: { name: `BUG-2539 ${delay}`, slug, template: 'startup' }
+		});
+		expect(wsResp.ok(), await wsResp.text()).toBeTruthy();
+		const ws = (await wsResp.json()) as { slug: string };
+
+		const itemResp = await request.post(
+			`/api/v1/workspaces/${ws.slug}/collections/tasks/items`,
+			{ headers: auth, data: { title: `sync-window probe ${delay}` } }
+		);
+		expect(itemResp.ok(), await itemResp.text()).toBeTruthy();
+		const item = (await itemResp.json()) as { id: string; slug: string };
+
+		// Record whether the delta the page fetched actually carried the
+		// deletion. The banner assertion alone would also be satisfied by an
+		// unrelated mechanism (a full reload renders it too), so this is the
+		// leg that ties the banner to the sync path under test.
+		let deltaCarriedDeletion = false;
+		page.on('response', async (resp) => {
+			if (!resp.url().includes('/changes')) return;
+			try {
+				const body = (await resp.json()) as { deleted?: string[] };
+				if (body.deleted?.includes(item.id)) deltaCarriedDeletion = true;
+			} catch {
+				/* non-JSON body — ignore */
+			}
+		});
+
+		const itemUrl = `/${fixture.adminUsername}/${ws.slug}/tasks/${item.id}`;
+		// Fire the archive on a timer started at navigation start WITHOUT
+		// awaiting the page — awaiting first paint moves the archive out of the
+		// window under test.
+		const navStart = Date.now();
+		const archivePromise = (async () => {
+			await new Promise((r) => setTimeout(r, delay));
+			const resp = await request.post(`/api/v1/workspaces/${ws.slug}/items/bulk`, {
+				headers: auth,
+				data: { op: 'archive', ids: [item.id] }
+			});
+			return { ok: resp.ok(), body: await resp.text(), at: Date.now() - navStart };
+		})();
+		await page.goto(itemUrl, { waitUntil: 'domcontentloaded' });
+		const bulk = await archivePromise;
+		expect(bulk.ok, bulk.body).toBeTruthy();
+
+		// Premise: the archive really landed server-side.
+		const check = await request.get(`/api/v1/workspaces/${ws.slug}/items/${item.slug}`, {
+			headers: auth
+		});
+		const checked = (await check.json()) as { deleted_at: string | null };
+		expect(checked.deleted_at, 'archive must land server-side').not.toBeNull();
+
+		// The open page must learn about it without a reload.
+		await expect(page.locator('.archived-banner')).toBeVisible({ timeout: 10_000 });
+		expect(
+			deltaCarriedDeletion,
+			'the banner must follow a /changes delta carrying the deletion, not an unrelated reload'
+		).toBeTruthy();
+	});
+});

--- a/web/e2e/bug-2539-sync-window.spec.ts
+++ b/web/e2e/bug-2539-sync-window.spec.ts
@@ -8,44 +8,54 @@ import { test, quietCrossActorToasts } from './fixtures';
  *
  * The deterministic pin for the cursor arithmetic is the store-level
  * `TestItemsModifiedSince_SameSecondCursor`. This spec covers the user-visible
- * end of the same defect: the archived banner appears in the page that was
- * already open, without a reload.
+ * end: the archived banner appears in the page that was already open, without a
+ * reload.
  *
- * Three things must hold together, or the banner is satisfiable by a mechanism
- * that is not the one under test:
+ * The two legs are named after the MECHANISM, not a millisecond offset. An
+ * earlier version fired the archive at a fixed delay after navigation start;
+ * that reproduced on an idle machine and stopped reproducing under parallel
+ * workers, because a slow load put the page's own item read AFTER the archive —
+ * at which point the page renders an archived row from the start and the sync
+ * path is never exercised. The legs now wait for the preconditions instead:
  *
- *   1. the page must have loaded a LIVE row, on a request it issued BEFORE the
- *      archive — otherwise it simply rendered an already-archived item;
- *   2. the deletion must arrive on a `/changes` that is NOT the page's first
- *      one — the first is the cursor seed `setWorkspace` fires on mount, which
- *      can carry the deletion once the fix is in and proves nothing about the
- *      incremental path;
- *   3. only then does the banner count.
+ *   - the page has READ a live row (server-attested, `deleted_at: null`), and
+ *   - its EventSource is subscribed (the /events response headers have
+ *     arrived — the handler subscribes before writing them),
  *
- * Both (1) and (2) are decided by REQUEST ORDER, not by response timing.
- * Response-arrival ordering is genuinely racy here: the server publishes the
- * SSE event before the bulk handler finishes writing its own HTTP response, so
- * the incremental `/changes` can resolve before the archive call returns
- * (Codex P2 on the first attempt at this oracle, which timed responses against
- * archive completion and could both flake and false-pass).
+ * and only then archive: immediately (same second as the page's sync cursor —
+ * the reproducing case) or after crossing the next second boundary (the control
+ * that behaved even before the fix).
+ *
+ * The oracle requires all three of:
+ *   1. the page read a live row — otherwise no sync was involved;
+ *   2. the deletion arrived on a `/changes` that is neither the cursor-seeding
+ *      one (ordinal 0, fired by setWorkspace on mount) nor issued before the
+ *      archive. Both checks are kept so a RETRIED seed cannot pass on ordinal
+ *      alone. The URL match is anchored so `/items-changes` — a different,
+ *      seq-based endpoint — cannot consume ordinals;
+ *   3. the banner rendered.
  *
  * Ground truth for archived-ness is the server's `deleted_at`, never the UI:
  * asserting on the UI alone cannot distinguish "not archived" from "archived
  * but not shown", which is the failure mode under test.
- *
- * Two legs. 450ms after navigation start is the offset that reproduced 7/8
- * times before the fix (the archive lands just after the SSE connects and
- * inside the cursor's own second); 1200ms is the control that always behaved.
- * Both are deterministic AFTER the fix — the comparison no longer depends on
- * where inside a second the mutation fell.
  */
 
-// Offsets are measured from NAVIGATION START, not first paint — anchoring to
-// paint pushes the archive clear of the window and the bug does not reproduce.
-const DELAYS = [450, 1200];
+const CHANGES_RE = /\/api\/v1\/workspaces\/[^/]+\/changes(\?|$)/;
+const ITEM_GET_RE = /\/api\/v1\/workspaces\/[^/]+\/items\/[^/?]+$/;
 
-DELAYS.forEach((delay, idx) => {
-	test(`BUG-2539: bulk archive ${delay}ms after navigation start reaches the open item`, async ({
+const LEGS = [
+	{
+		name: 'in the same second as the page cursor (the reproducing case)',
+		crossSecondBoundary: false
+	},
+	{
+		name: 'after the next second boundary (control)',
+		crossSecondBoundary: true
+	}
+] as const;
+
+LEGS.forEach((leg, idx) => {
+	test(`BUG-2539: a bulk archive ${leg.name} reaches the open item`, async ({
 		page,
 		context,
 		request,
@@ -53,65 +63,66 @@ DELAYS.forEach((delay, idx) => {
 	}) => {
 		await quietCrossActorToasts(context);
 
-		// Own workspace: the shared suite workspace carries cross-spec mutation
-		// traffic that muddies a cursor-sensitive leg.
-		const slug = `b2539-${idx}-${Date.now().toString(36)}`;
 		const auth = { Authorization: `Bearer ${fixture.apiToken}` };
-		const wsResp = await request.post('/api/v1/workspaces', {
-			headers: auth,
-			data: { name: `BUG-2539 ${delay}`, slug, template: 'startup' }
-		});
-		expect(wsResp.ok(), await wsResp.text()).toBeTruthy();
-		const ws = (await wsResp.json()) as { slug: string };
+		let createdSlug: string | null = null;
+		let cleanup: { ok: boolean; body: string } | null = null;
 
 		try {
+			// Own workspace: the shared suite workspace carries cross-spec
+			// mutation traffic that muddies a cursor-sensitive leg.
+			const slug = `b2539-${idx}-${Date.now().toString(36)}`;
+			const wsResp = await request.post('/api/v1/workspaces', {
+				headers: auth,
+				data: { name: `BUG-2539 ${idx}`, slug, template: 'startup' }
+			});
+			expect(wsResp.ok(), await wsResp.text()).toBeTruthy();
+			const ws = (await wsResp.json()) as { slug: string };
+			createdSlug = ws.slug;
+
 			const itemResp = await request.post(
 				`/api/v1/workspaces/${ws.slug}/collections/tasks/items`,
-				{ headers: auth, data: { title: `sync-window probe ${delay}` } }
+				{ headers: auth, data: { title: `sync-window probe ${idx}` } }
 			);
 			expect(itemResp.ok(), await itemResp.text()).toBeTruthy();
 			const item = (await itemResp.json()) as { id: string; slug: string };
 
-			// Request-side bookkeeping. `archiveSentAt` is stamped before the POST
-			// is issued, so "issued before the archive" is decidable without
-			// depending on when anything resolved.
+			// `archiveSentAt` is stamped before the POST is issued, so "issued
+			// after the archive went out" needs nothing to have resolved.
 			let archiveSentAt = Number.POSITIVE_INFINITY;
 			const changesOrder = new Map<Request, number>();
-			const itemGetIssuedAt = new Map<Request, number>();
+			const changesIssuedAt = new Map<Request, number>();
 			let changesSeen = 0;
-			const itemGetRe = /\/api\/v1\/workspaces\/[^/]+\/items\/[^/?]+$/;
 
 			page.on('request', (r) => {
-				if (r.url().includes('/changes')) {
+				if (CHANGES_RE.test(r.url())) {
 					changesOrder.set(r, changesSeen++);
-				} else if (itemGetRe.test(r.url()) && r.method() === 'GET') {
-					itemGetIssuedAt.set(r, Date.now());
+					changesIssuedAt.set(r, Date.now());
 				}
 			});
 
-			// (1) the page's own pre-archive item load saw a LIVE row
-			let loadedLiveBeforeArchive = false;
-			// (2) a NON-SEED /changes carried the deletion
+			let readLiveRow = false;
 			let incrementalCarriedDeletion = false;
-			// Response handlers are async; collect them so the assertions below
-			// can await the ones already in flight instead of racing them.
 			const inFlight: Promise<void>[] = [];
 			page.on('response', (resp) => {
 				inFlight.push(
 					(async () => {
 						try {
-							if (resp.url().includes('/changes')) {
+							if (CHANGES_RE.test(resp.url())) {
 								const order = changesOrder.get(resp.request());
+								const issued = changesIssuedAt.get(resp.request());
 								const body = (await resp.json()) as { deleted?: string[] };
-								if (order !== undefined && order > 0 && body.deleted?.includes(item.id)) {
+								if (
+									order !== undefined &&
+									order > 0 &&
+									issued !== undefined &&
+									issued >= archiveSentAt &&
+									body.deleted?.includes(item.id)
+								) {
 									incrementalCarriedDeletion = true;
 								}
-							} else if (itemGetRe.test(resp.url()) && resp.request().method() === 'GET') {
-								const issued = itemGetIssuedAt.get(resp.request());
+							} else if (ITEM_GET_RE.test(resp.url()) && resp.request().method() === 'GET') {
 								const body = (await resp.json()) as { id?: string; deleted_at?: string | null };
-								if (body.id === item.id && !body.deleted_at && issued !== undefined && issued < archiveSentAt) {
-									loadedLiveBeforeArchive = true;
-								}
+								if (body.id === item.id && !body.deleted_at) readLiveRow = true;
 							}
 						} catch {
 							/* non-JSON body — ignore */
@@ -120,22 +131,38 @@ DELAYS.forEach((delay, idx) => {
 				);
 			});
 
+			// The SSE handler subscribes BEFORE writing its response headers, so
+			// this resolving means the server is ready to deliver the archive
+			// event to this page.
+			const sseSubscribed = page.waitForResponse((r) => r.url().includes('/api/v1/events'));
+			// A GET of this item whose body carries deleted_at null — the page
+			// has a live row on screen.
+			const liveRowRead = page.waitForResponse(async (r) => {
+				if (!ITEM_GET_RE.test(r.url()) || r.request().method() !== 'GET') return false;
+				try {
+					const body = (await r.json()) as { id?: string; deleted_at?: string | null };
+					return body.id === item.id && !body.deleted_at;
+				} catch {
+					return false;
+				}
+			});
+
 			const itemUrl = `/${fixture.adminUsername}/${ws.slug}/tasks/${item.id}`;
-			// Fire the archive on a timer started at navigation start WITHOUT
-			// awaiting the page — awaiting first paint moves the archive out of
-			// the window under test.
-			const archivePromise = (async () => {
-				await new Promise((r) => setTimeout(r, delay));
-				archiveSentAt = Date.now();
-				const resp = await request.post(`/api/v1/workspaces/${ws.slug}/items/bulk`, {
-					headers: auth,
-					data: { op: 'archive', ids: [item.id] }
-				});
-				return { ok: resp.ok(), body: await resp.text() };
-			})();
 			await page.goto(itemUrl, { waitUntil: 'domcontentloaded' });
-			const bulk = await archivePromise;
-			expect(bulk.ok, bulk.body).toBeTruthy();
+			await Promise.all([sseSubscribed, liveRowRead]);
+
+			if (leg.crossSecondBoundary) {
+				// Push the archive past the second the page's cursor sits in,
+				// plus a small margin so a clock tick can't land it back inside.
+				await page.waitForTimeout(1000 - (Date.now() % 1000) + 120);
+			}
+
+			archiveSentAt = Date.now();
+			const bulk = await request.post(`/api/v1/workspaces/${ws.slug}/items/bulk`, {
+				headers: auth,
+				data: { op: 'archive', ids: [item.id] }
+			});
+			expect(bulk.ok(), await bulk.text()).toBeTruthy();
 
 			// Premise: the archive really landed server-side.
 			const check = await request.get(`/api/v1/workspaces/${ws.slug}/items/${item.slug}`, {
@@ -147,19 +174,41 @@ DELAYS.forEach((delay, idx) => {
 
 			// The open page must learn about it without a reload.
 			await expect(page.locator('.archived-banner')).toBeVisible({ timeout: 10_000 });
-			await Promise.all(inFlight);
+			// Drain until no new handler was queued while awaiting.
+			for (let drained = 0; drained < inFlight.length; ) {
+				drained = inFlight.length;
+				await Promise.all(inFlight);
+			}
 
+			// Both messages carry the recorded state. This leg has flaked rarely
+			// (twice in ~70 local runs) and both times the artifacts were gone
+			// before they could be read, so a recurrence has to explain itself
+			// from the failure text alone.
+			const diag = JSON.stringify({
+				changesSeen,
+				changesAfterArchive: [...changesIssuedAt.values()].filter((t) => t >= archiveSentAt).length,
+				archiveSentAt,
+				readLiveRow,
+				incrementalCarriedDeletion,
+				responsesObserved: inFlight.length
+			});
 			expect(
-				loadedLiveBeforeArchive,
-				'the page must have loaded a LIVE row before the archive for a sync to be what corrected it'
+				readLiveRow,
+				`the page must have read a LIVE row for a sync to be what corrected it — ${diag}`
 			).toBeTruthy();
 			expect(
 				incrementalCarriedDeletion,
-				'the deletion must arrive on a /changes AFTER the page\'s cursor-seeding one — not the seed, and not a reload'
+				`the deletion must arrive on a /changes issued after the archive and after the page's cursor-seeding one — not the seed, and not a reload — ${diag}`
 			).toBeTruthy();
 		} finally {
-			const del = await request.delete(`/api/v1/workspaces/${ws.slug}`, { headers: auth });
-			expect(del.ok(), `scratch workspace cleanup failed: ${await del.text()}`).toBeTruthy();
+			if (createdSlug) {
+				const del = await request.delete(`/api/v1/workspaces/${createdSlug}`, { headers: auth });
+				// Recorded, not asserted here: throwing from `finally` would
+				// replace the real failure with a cleanup one.
+				cleanup = { ok: del.ok(), body: await del.text() };
+			}
 		}
+
+		expect(cleanup?.ok, `scratch workspace cleanup failed: ${cleanup?.body}`).toBeTruthy();
 	});
 });

--- a/web/e2e/bug-2539-sync-window.spec.ts
+++ b/web/e2e/bug-2539-sync-window.spec.ts
@@ -11,15 +11,26 @@ import { test, quietCrossActorToasts } from './fixtures';
  * end of the same defect: the archived banner appears in the page that was
  * already open, without a reload.
  *
+ * Three things have to hold together, or the assertion is satisfiable by a
+ * mechanism that is not the one under test (Codex P2):
+ *
+ *   1. the page must have loaded a LIVE row — otherwise it simply rendered an
+ *      already-archived item and no sync was involved;
+ *   2. the deletion must arrive on a `/changes` response that resolved AFTER
+ *      the archive POST completed — the cursor-seeding request `setWorkspace`
+ *      fires during load can also carry it once the fix is in, and that one
+ *      proves nothing about the incremental path;
+ *   3. only then does the banner count.
+ *
+ * Ground truth for archived-ness is the server's `deleted_at`, never the UI:
+ * asserting on the UI alone cannot distinguish "not archived" from "archived
+ * but not shown", which is the failure mode under test.
+ *
  * Two legs. 450ms after navigation start is the offset that reproduced 7/8
  * times before the fix (the archive lands just after the SSE connects and
  * inside the cursor's own second); 1200ms is the control that always behaved.
  * Both are deterministic AFTER the fix — the comparison no longer depends on
  * where inside a second the mutation fell.
- *
- * Ground truth for archived-ness is the server's `deleted_at`, never the UI:
- * asserting on the UI alone cannot distinguish "not archived" from "archived
- * but not shown", which is the failure mode under test.
  */
 
 // Offsets are measured from NAVIGATION START, not first paint — anchoring to
@@ -45,6 +56,7 @@ DELAYS.forEach((delay, idx) => {
 		});
 		expect(wsResp.ok(), await wsResp.text()).toBeTruthy();
 		const ws = (await wsResp.json()) as { slug: string };
+		test.info().annotations.push({ type: 'workspace', description: ws.slug });
 
 		const itemResp = await request.post(
 			`/api/v1/workspaces/${ws.slug}/collections/tasks/items`,
@@ -53,16 +65,24 @@ DELAYS.forEach((delay, idx) => {
 		expect(itemResp.ok(), await itemResp.text()).toBeTruthy();
 		const item = (await itemResp.json()) as { id: string; slug: string };
 
-		// Record whether the delta the page fetched actually carried the
-		// deletion. The banner assertion alone would also be satisfied by an
-		// unrelated mechanism (a full reload renders it too), so this is the
-		// leg that ties the banner to the sync path under test.
-		let deltaCarriedDeletion = false;
+		let archiveDoneAt = Number.POSITIVE_INFINITY;
+		// (1) did the page's own item load see a LIVE row?
+		let loadedLive = false;
+		// (2) did a /changes that resolved AFTER the archive carry the deletion?
+		let incrementalCarriedDeletion = false;
+		const itemGetRe = /\/api\/v1\/workspaces\/[^/]+\/items\/[^/?]+$/;
 		page.on('response', async (resp) => {
-			if (!resp.url().includes('/changes')) return;
+			const at = Date.now();
 			try {
-				const body = (await resp.json()) as { deleted?: string[] };
-				if (body.deleted?.includes(item.id)) deltaCarriedDeletion = true;
+				if (resp.url().includes('/changes')) {
+					const body = (await resp.json()) as { deleted?: string[] };
+					if (body.deleted?.includes(item.id) && at > archiveDoneAt) {
+						incrementalCarriedDeletion = true;
+					}
+				} else if (itemGetRe.test(resp.url()) && resp.request().method() === 'GET') {
+					const body = (await resp.json()) as { id?: string; deleted_at?: string | null };
+					if (body.id === item.id && !body.deleted_at) loadedLive = true;
+				}
 			} catch {
 				/* non-JSON body — ignore */
 			}
@@ -72,14 +92,15 @@ DELAYS.forEach((delay, idx) => {
 		// Fire the archive on a timer started at navigation start WITHOUT
 		// awaiting the page — awaiting first paint moves the archive out of the
 		// window under test.
-		const navStart = Date.now();
 		const archivePromise = (async () => {
 			await new Promise((r) => setTimeout(r, delay));
 			const resp = await request.post(`/api/v1/workspaces/${ws.slug}/items/bulk`, {
 				headers: auth,
 				data: { op: 'archive', ids: [item.id] }
 			});
-			return { ok: resp.ok(), body: await resp.text(), at: Date.now() - navStart };
+			const body = await resp.text();
+			archiveDoneAt = Date.now();
+			return { ok: resp.ok(), body };
 		})();
 		await page.goto(itemUrl, { waitUntil: 'domcontentloaded' });
 		const bulk = await archivePromise;
@@ -89,14 +110,18 @@ DELAYS.forEach((delay, idx) => {
 		const check = await request.get(`/api/v1/workspaces/${ws.slug}/items/${item.slug}`, {
 			headers: auth
 		});
+		expect(check.ok(), await check.text()).toBeTruthy();
 		const checked = (await check.json()) as { deleted_at: string | null };
 		expect(checked.deleted_at, 'archive must land server-side').not.toBeNull();
 
 		// The open page must learn about it without a reload.
 		await expect(page.locator('.archived-banner')).toBeVisible({ timeout: 10_000 });
+		expect(loadedLive, 'the page must have loaded a LIVE row for a sync to be what corrected it').toBeTruthy();
 		expect(
-			deltaCarriedDeletion,
-			'the banner must follow a /changes delta carrying the deletion, not an unrelated reload'
+			incrementalCarriedDeletion,
+			'the banner must follow a /changes that resolved AFTER the archive and carried the deletion — not the cursor-seeding request, and not a reload'
 		).toBeTruthy();
+
+		await request.delete(`/api/v1/workspaces/${ws.slug}`, { headers: auth });
 	});
 });


### PR DESCRIPTION
Fixes BUG-2539.

## The defect

`items.updated_at` / `items.deleted_at` are TEXT columns holding RFC3339 **whole-second** strings (`store.now()`). The `/changes` cursor is a unix-**millisecond** value — normally the previous response's `server_time`. `ItemsModifiedSince` formatted that cursor with the same second precision, truncating it DOWN, then compared with a strict `>`. Every change landing in the cursor's own second compared equal and was dropped — **permanently**, because the caller then advances its cursor to `server_time` and nothing reaches back.

User-visible symptom: bulk-archive an item ~450ms after a page seeded its cursor and the page keeps rendering it as LIVE indefinitely — no banner, no redirect — while the server has `deleted_at` set.

It was never archive-specific. Updates were dropped identically; a missed update is usually re-delivered by the next event, a missed deletion never is.

## Evidence for the mechanism

Four cursors against a live instance, **all strictly earlier than the archive in real time**, so a correct implementation returns it in all four:

```
archive at epoch_ms 1786630404453 (453ms into its second)
  since = sec_start +   1ms  (same second)      -> MISS   updated=0
  since = sec_start + 400ms  (same second)      -> MISS   updated=0
  since = sec_start -   1ms  (previous second)  -> HIT    updated=9
  since = sec_start -1001ms  (two secs earlier) -> HIT    updated=9
```

Two cursors 1ms and 400ms into the same second miss; one 1ms earlier hits. That is truncation, not a race.

## The fix

Truncate the cursor to its second explicitly and compare **inclusively** on all three comparisons.

This makes the endpoint at-least-once at the second boundary — rows written inside the cursor's second come back again, on every sync whose cursor stays inside that second. That is safe here because the payload is server **state**, not a delta to apply on top of what the caller has: every in-tree consumer overwrites its row from it, so a repeat is a no-op. The code comment says so, and says that a future consumer treating these rows as increments would not be safe.

Sub-second storage is the other fix and is a migration, not a one-liner: these comparisons are lexicographic on TEXT, and mixing precisions inverts them (`…20.451Z` sorts BEFORE `…20Z`), so a partial move to nanosecond timestamps would break this more quietly than it fixes it.

## Tests

Both are mutation-tested against a genuinely reverted query, and both carry a control leg that passes either way — so what is being measured is the fix, not the harness.

- **`TestItemsModifiedSince_SameSecondCursor`** — same-second leg + previous-second control. Alignment is checked against the timestamps the writes actually STORED (not a wall-clock reading taken before them) and a misaligned attempt is retried, so the leg cannot silently stop testing anything. Fails 3/3 unfixed with all three assertions firing; passes 3/3 fixed.
- **`web/e2e/bug-2539-sync-window.spec.ts`** — the user-visible end. Each attempt proves it hit the mechanism it is named after by comparing two server values (the seed `/changes` `server_time`, which is what the client keeps as `lastSyncTime`, against the stored `deleted_at`) and retries if it did not. The banner only counts if the page read a LIVE row first and the deletion arrived on a `/changes` that was neither the cursor seed nor issued before the archive. Same-second leg fails 4/4 unfixed; control passes 4/4.

## Gates

- `go test ./...` — pass
- `make test-pg` (full suite on Postgres) — pass. The columns are TEXT on both engines, so the defect and the fix behave identically; worth running because SQLite-green has hidden PG bugs here before.
- `npm run check` — 0 errors; web unit suite — 1511 passed
- Full desktop e2e — 159 passed, 0 failed. New spec also green on `mobile-chromium`.
- Codex CLI review to CLEAN (six passes; no P1 at any point — every finding was on whether the tests actually measure the fix, and each round tightened them)

## Not fixed here, and worth its own item

A mutation landing between the page's initial item read and its SSE subscription (~30ms) is delivered to nobody and triggers no sync, so the page never learns. `pendingSyncOnConnect` exists for exactly that shape but is armed only on leader promotion, not on first connect. Separate defect, deliberately out of scope.

Not exercised: the BroadcastChannel leader/peer fan-out path (single tab only), and `/items-changes`, which is seq-based and should not share this defect — but I did not test it and am not claiming it is clean.

https://claude.ai/code/session_01QGbUKZBAZoWdEgiTNWsXag
