### PR TITLE
ci: make the go test timeout explicit everywhere (TASK-2545)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,16 @@ jobs:
           "$(go env GOPATH)/bin/govulncheck" -mode binary pad-vulnscan
 
       - name: Run tests
-        run: go test ./...
+        # -timeout is EXPLICIT here on purpose. `go test` without it uses a
+        # 10m per-test-binary default that nobody chose, and the two race
+        # steps in this file were raised to 45m twice (BUG-1371, BUG-1913)
+        # while their non-race siblings silently kept the default — which is
+        # how the PostgreSQL leg below panicked at 10m on the v0.13.0 release
+        # commit and cost the cut ~40 minutes (TASK-2545). Matching the race
+        # legs keeps ONE number in this file. It is a hang-catcher, not a
+        # performance budget: the signal for "the suite got slow" is job
+        # wall-clock, not this value.
+        run: go test -timeout=45m ./...
 
       - name: Run tests with race detector
         # Runs on both push-to-main AND pull_request. Previously gated to
@@ -237,7 +246,14 @@ jobs:
       - name: Run tests against PostgreSQL
         env:
           PAD_TEST_POSTGRES_URL: "postgres://pad:pad@localhost:5432/pad?sslmode=disable"
-        run: go test ./... -count=1
+        # Explicit -timeout: see the SQLite "Run tests" step. This is the
+        # binary that actually blew the 10m default — internal/store creates a
+        # fresh database AND replays the full migration chain per test
+        # (~0.43s each locally), so the package's runtime grows linearly with
+        # the test count. Measured on a dev box at 212d59e7: internal/store
+        # 280s, whole PG suite 4m43s wall; CI runners are ~2x slower, which
+        # put store over 10m.
+        run: go test -timeout=45m ./... -count=1
 
       - name: Run tests with race detector against PostgreSQL
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,14 @@ permissions:
 
 jobs:
   go:
+    # Backstop only. A hung TEST is caught by -timeout=45m on the steps
+    # below, which fails fast AND prints the goroutine dump that tells
+    # you which test hung; this cap exists because a job with no
+    # timeout-minutes inherits GitHub's 6-HOUR default, so a runaway
+    # that isn't a single test (a wedged service container, a stuck
+    # download) would otherwise sit there. Deliberately well above the
+    # two 45m test steps so it never fires before they do (TASK-2545).
+    timeout-minutes: 100
     name: Go
     runs-on: ubuntu-latest
     steps:
@@ -212,6 +220,14 @@ jobs:
           }
 
   go-postgres:
+    # Backstop only. A hung TEST is caught by -timeout=45m on the steps
+    # below, which fails fast AND prints the goroutine dump that tells
+    # you which test hung; this cap exists because a job with no
+    # timeout-minutes inherits GitHub's 6-HOUR default, so a runaway
+    # that isn't a single test (a wedged service container, a stuck
+    # download) would otherwise sit there. Deliberately well above the
+    # two 45m test steps so it never fires before they do (TASK-2545).
+    timeout-minutes: 100
     name: Go (PostgreSQL)
     runs-on: ubuntu-latest
     services:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,10 @@ jobs:
     # you which test hung; this cap exists because a job with no
     # timeout-minutes inherits GitHub's 6-HOUR default, so a runaway
     # that isn't a single test (a wedged service container, a stuck
-    # download) would otherwise sit there. Deliberately well above the
-    # two 45m test steps so it never fires before they do (TASK-2545).
+    # download) would otherwise sit there. Set well above the two 45m test
+    # steps so that in practice the per-binary timeout is what fires — not a
+    # guarantee, since this cap covers setup and every step, not just those
+    # two (TASK-2545).
     timeout-minutes: 100
     name: Go
     runs-on: ubuntu-latest
@@ -105,11 +107,13 @@ jobs:
 
       - name: Run tests
         # -timeout is EXPLICIT here on purpose. `go test` without it uses a
-        # 10m per-test-binary default that nobody chose, and the two race
-        # steps in this file were raised to 45m twice (BUG-1371, BUG-1913)
-        # while their non-race siblings silently kept the default — which is
-        # how the PostgreSQL leg below panicked at 10m on the v0.13.0 release
-        # commit and cost the cut ~40 minutes (TASK-2545). Matching the race
+        # 10m per-test-binary default that nobody chose. The two race steps
+        # in this file were raised to 45m when the suite outgrew 30m
+        # (BUG-1913) while their non-race siblings silently kept the
+        # default — which is how the PostgreSQL leg below panicked at 10m on
+        # the v0.13.0 release commit (TASK-2545, which also found the ~40
+        # minutes it cost the cut and the goroutine dump showing nothing
+        # actually hung). Matching the race
         # legs keeps ONE number in this file. It is a hang-catcher, not a
         # performance budget: the signal for "the suite got slow" is job
         # wall-clock, not this value.
@@ -120,8 +124,10 @@ jobs:
         # main only because GitHub Actions minutes were billed on private
         # repos; the repo is public now, so PR minutes are free and we'd
         # rather catch race regressions on the contributing branch than
-        # after merge. See BUG-1371 (also dropped test-only bcrypt cost
-        # via TestMain so this step stays well under the 30m budget).
+        # after merge. See BUG-1371 (also dropped test-only bcrypt cost via
+        # TestMain, which brought this step back under the then-30m budget —
+        # it did NOT raise the budget; BUG-1913 later did, 30m→45m, when the
+        # suite outgrew it again).
         #
         # Default 10m is tight: the full server-package suite under -race
         # measures ~13m locally on a developer laptop after BUG-851 (the
@@ -225,8 +231,10 @@ jobs:
     # you which test hung; this cap exists because a job with no
     # timeout-minutes inherits GitHub's 6-HOUR default, so a runaway
     # that isn't a single test (a wedged service container, a stuck
-    # download) would otherwise sit there. Deliberately well above the
-    # two 45m test steps so it never fires before they do (TASK-2545).
+    # download) would otherwise sit there. Set well above the two 45m test
+    # steps so that in practice the per-binary timeout is what fires — not a
+    # guarantee, since this cap covers setup and every step, not just those
+    # two (TASK-2545).
     timeout-minutes: 100
     name: Go (PostgreSQL)
     runs-on: ubuntu-latest
@@ -267,8 +275,11 @@ jobs:
         # fresh database AND replays the full migration chain per test
         # (~0.43s each locally), so the package's runtime grows linearly with
         # the test count. Measured on a dev box at 212d59e7: internal/store
-        # 280s, whole PG suite 4m43s wall; CI runners are ~2x slower, which
-        # put store over 10m.
+        # 280s, whole PG suite 4m43s wall. CI's own runtime is UNMEASURED
+        # here; all that follows from the panic is that its store binary
+        # exceeded 10m, i.e. >2.14x this box on that package. (An earlier
+        # version of this comment said "~2x slower, which put store over
+        # 10m" — 280s x 2 is 9m20s, so that explained nothing.)
         run: go test -timeout=45m ./... -count=1
 
       - name: Run tests with race detector against PostgreSQL

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,12 @@ jobs:
         run: mkdir -p web/build && echo "placeholder" > web/build/.gitkeep
 
       - name: Run tests
-        run: go test ./...
+        # Explicit -timeout, same reasoning as ci.yml's steps (TASK-2545):
+        # `go test` defaults to 10m per test binary, and this is the RELEASE
+        # gate — the one place an unchosen default is most expensive. SQLite
+        # only here (no PAD_TEST_POSTGRES_URL), so it is the faster driver,
+        # but it grows on the same curve.
+        run: go test -timeout=45m ./...
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0

--- a/Makefile
+++ b/Makefile
@@ -51,14 +51,17 @@ install: build
 	@$(INSTALL_DIR)/$(BINARY) auth whoami 2>/dev/null || true
 	@echo "Server restarted."
 
+# -timeout matches CI (see .github/workflows/ci.yml). Without it `go test`
+# uses a 10m per-test-binary default nobody chose — the shape that killed
+# the v0.13.0 release pre-flight (TASK-2545).
 test:
-	go test ./... -v
+	go test -timeout=45m ./... -v
 
 # Run tests against PostgreSQL (starts a container automatically).
 # Uses port 5445 to avoid conflicts with any local PostgreSQL.
 test-pg:
 	docker compose -f docker-compose.test.yml up -d --wait
-	PAD_TEST_POSTGRES_URL="postgres://pad:pad@localhost:5445/pad?sslmode=disable" go test ./... -v -count=1; \
+	PAD_TEST_POSTGRES_URL="postgres://pad:pad@localhost:5445/pad?sslmode=disable" go test -timeout=45m ./... -v -count=1; \
 		EXIT_CODE=$$?; \
 		docker compose -f docker-compose.test.yml down -v; \
 		exit $$EXIT_CODE
@@ -164,7 +167,7 @@ web-test:
 # `make install` stays lightweight (build + restart only) so the inner
 # dev loop is fast; opt into `check` when you're ready to push.
 check: lint
-	go test ./...
+	go test -timeout=45m ./...
 	$(MAKE) vuln
 	$(MAKE) web-check
 	$(MAKE) web-test

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -79,7 +79,10 @@ buildGoModule {
     # needs DNS/network the Nix build sandbox deliberately doesn't have.
     # Everything else in the package (invalid schemes, private-IP
     # rejection, etc.) needs no network and still runs.
-    go test -skip 'TestValidateWebhookURL/valid_(https|http|with_port|with_path)$' ./...
+    # -timeout is explicit for the same reason as CI and the Makefile: the
+    # 10m default is a budget nobody chose (TASK-2545). This runs in the
+    # Nix sandbox via .github/workflows/nix.yml.
+    go test -timeout=45m -skip 'TestValidateWebhookURL/valid_(https|http|with_port|with_path)$' ./...
     runHook postCheck
   '';
 


### PR DESCRIPTION
Fixes TASK-2545.

The v0.13.0 pre-flight died on `panic: test timed out after 10m0s` in `internal/store`, on a commit whose Go tree was identical to a green run an hour earlier. Nothing hung — the package simply crossed a budget nobody had chosen.

## Root cause

`go test` without `-timeout` uses a **10m per-test-binary** default. The two race steps were raised to 45m when the suite outgrew 30m (BUG-1913) — with careful comments — and their non-race siblings were left on the silent default. Seven invocations were still on it, found by sweeping every `go test` in the repo rather than only the file the failure pointed at:

| File | Invocation |
|---|---|
| `ci.yml` | SQLite `Run tests` |
| `ci.yml` | `Run tests against PostgreSQL` — **the one that panicked** |
| `release.yml` | `Run tests` — **the release gate itself** |
| `Makefile` | `test`, `test-pg`, `check` |
| `nix/package.nix` | checkPhase, run by `nix.yml` |

All now carry `-timeout=45m`, matching the race legs so the repo has one number. The comments say what it is: a **hang-catcher, not a performance budget** — the signal for "the suite got slow" is job wall-clock.

## Job caps, which turned out to be the bigger hole

Codex objected that 45m lets a hung binary burn a release-gating job. Investigating that found worse: `go` and `go-postgres` had **no `timeout-minutes` at all**, so they inherit GitHub's **6-hour** default. Both capped at 100m — above the two 45m steps, so in practice the per-binary timeout fires first, and that is the one that prints the goroutine dump naming the hung test.

## Measured, both drivers, at 212d59e7

| | PostgreSQL | SQLite |
|---|---|---|
| whole suite, wall | 4m43s | 1m52s |
| `internal/store` | **280s** | 64s |
| `internal/server` | 103s | 107s |

Verified by running the exact post-change commands: PG green in 4m42s, SQLite green in 1m52s, 25 packages each. `make lint` 0 issues.

## This raises the ceiling; it does not change the slope

`internal/store` on PG costs **~0.43s per test in database setup alone** — `CREATE DATABASE` plus a full migration replay, per test, where the SQLite harness copies a pre-migrated template (IDEA-1914). 598 tests x that ≈ the whole 280s, and the package is 99% of the PG job's critical path. Every test anyone adds costs PG CI ~0.43s forever.

Measured and filed as **IDEA-2550** (with the sharp edges: Postgres refuses a template with open connections; parallel `CREATE DATABASE ... TEMPLATE` serializes server-side) rather than fixed here — it changes shared test infrastructure gating every merge and deserves its own review, and this task was scoped to the cheapest durable fix for a release-gating flake.

## Two claims of mine that didn't survive review

Recorded because the branch corrects them in the files, not just in git log:

- I wrote that CI runners are "~2x slower, which is what put store over 10m". Its own arithmetic refutes it: 280s x 2 is 9m20s, under the budget. What the failure supports is a **lower bound** — CI's store binary exceeded 10m, so >2.14x this box — not an explanation. I hadn't measured CI and shouldn't have written a factor as if I had.
- I attributed the 30m→45m raise to two bugs; BUG-1913 did it once, and BUG-1371 kept 30m while removing the bcrypt cost that had blown past it. The pre-existing race-step comment asserting BUG-1371 kept things "well under" 30m is corrected too — not my text, but wrong in a file I'm editing.

Both corrections live in the workflow comments, because a retraction that exists only in a commit message is one almost nobody receives.

https://claude.ai/code/session_01QGbUKZBAZoWdEgiTNWsXag
