### PR TITLE
feat(sessions): session-presence registry + GET /api/v1/sessions (PLAN-2558 S1)

### DIFF
--- a/cmd/pad/cmd_server.go
+++ b/cmd/pad/cmd_server.go
@@ -662,6 +662,17 @@ func serveCmd() *cobra.Command {
 			// eventBus above, which branches on PAD_REDIS_URL).
 			srv.SetWatchEventsBus(watchevents.New())
 
+			// Live-session presence registry (PLAN-2558 S1). Wired
+			// unconditionally for the same reason and with the same
+			// caveat as the watch bus directly above: in-process only,
+			// no Redis-backed implementation yet. It reports on the
+			// same connections that bus feeds, so the two share a
+			// lifetime and a limitation — see
+			// internal/server/session_presence.go's SINGLE-PROCESS
+			// LIMITATION note before putting the web-UI push surface
+			// (PLAN-2558 S3) in front of a multi-process deployment.
+			srv.SetSessionPresence(server.NewMemorySessionPresence())
+
 			// Yjs collab room manager (PLAN-1248). Single-instance only
 			// today; multi-replica fanout via Redis is a deferred IDEA.
 			// MemoryOpBus is in-process; the OpBus interface keeps the

--- a/internal/server/handlers_sessions.go
+++ b/internal/server/handlers_sessions.go
@@ -1,0 +1,55 @@
+package server
+
+import "net/http"
+
+// sessionsResponse is the body of GET /api/v1/sessions.
+//
+// Count is redundant with len(Sessions) and is included anyway: the
+// primary consumer is a UI that only needs "is anything listening?" to
+// decide whether the push button is honest (PLAN-2558 S3), and making
+// that the cheapest possible read keeps the common case from having to
+// reason about the array at all.
+type sessionsResponse struct {
+	Sessions []LiveSession `json:"sessions"`
+	Count    int           `json:"count"`
+}
+
+// handleListSessions returns the caller's OWN live event-stream
+// connections (PLAN-2558 S1). It is the read side of the presence
+// registry described in session_presence.go.
+//
+// SELF-SCOPED, WITH NO ADMIN VIEW. There is deliberately no
+// ?user_id= parameter and no admin bypass, even though most list
+// endpoints in this server have one. Who has an agent session open, and
+// when, is a presence signal about a person rather than a fact about
+// workspace content — the same reasoning that made `pad push`
+// self-addressed only (handlers_push.go: "pushing into someone else's
+// session is a consent question, not a code question"). If a
+// cross-user view is ever wanted, it is a product decision with a
+// consent design attached, not a query parameter.
+//
+// GET /api/v1/sessions
+func (s *Server) handleListSessions(w http.ResponseWriter, r *http.Request) {
+	if s.sessionPresence == nil {
+		// Mirrors handleWatchEventsStream's own nil-bus stance: a server
+		// built without the presence registry doesn't have a degraded
+		// answer to give, and answering 200 with an empty list would be
+		// a LIE in exactly the direction this feature exists to prevent
+		// (the UI would report "nobody is listening" when it simply
+		// cannot tell).
+		writeError(w, http.StatusServiceUnavailable, "unavailable", "Session presence is not available")
+		return
+	}
+
+	user := currentUser(r)
+	if user == nil {
+		// Same stance as the stream this endpoint reports on: there is
+		// no coherent "my sessions" for a workspace-scoped token or the
+		// fresh-install no-auth window. Resolved user identity or 401.
+		writeError(w, http.StatusUnauthorized, "unauthorized", "Authentication required")
+		return
+	}
+
+	sessions := s.sessionPresence.ListForUser(user.ID)
+	writeJSON(w, http.StatusOK, sessionsResponse{Sessions: sessions, Count: len(sessions)})
+}

--- a/internal/server/handlers_sessions.go
+++ b/internal/server/handlers_sessions.go
@@ -50,6 +50,22 @@ func (s *Server) handleListSessions(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Codex round 2, P2. writeJSON sets no Cache-Control and the
+	// jsonContentType middleware only sets Content-Type, so without
+	// this the response is heuristically cacheable. Two reasons that's
+	// wrong here, beyond matching the house pattern for per-user
+	// sensitive responses (handlers_attachments.go:585):
+	//
+	//  1. Cross-context staleness. This body is scoped to ONE user; a
+	//     shared cache serving it to another is a presence leak about a
+	//     person, which is the same boundary this endpoint's missing
+	//     admin view exists to hold.
+	//  2. It is a liveness answer with a short shelf life (see
+	//     LiveSession's staleness note). A cached "1 session connected"
+	//     is precisely the confident-but-wrong answer the whole slice
+	//     exists to prevent.
+	w.Header().Set("Cache-Control", "private, no-store")
+
 	sessions := s.sessionPresence.ListForUser(user.ID)
 	writeJSON(w, http.StatusOK, sessionsResponse{Sessions: sessions, Count: len(sessions)})
 }

--- a/internal/server/handlers_sessions_test.go
+++ b/internal/server/handlers_sessions_test.go
@@ -1,0 +1,182 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// testServerWithPresence gives a server both the watch bus and the
+// presence registry — the production pairing (cmd_server.go wires them
+// on adjacent lines), since presence only ever fills from stream
+// connections.
+func testServerWithPresence(t *testing.T) *Server {
+	t.Helper()
+	srv := testServerWithWatchEvents(t)
+	srv.SetSessionPresence(NewMemorySessionPresence())
+	return srv
+}
+
+func getSessions(t *testing.T, baseURL, token string) (int, sessionsResponse) {
+	t.Helper()
+	req, _ := http.NewRequest("GET", baseURL+"/api/v1/sessions", nil)
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var out sessionsResponse
+	if resp.StatusCode == http.StatusOK {
+		if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+			t.Fatalf("decode sessions response: %v", err)
+		}
+	}
+	return resp.StatusCode, out
+}
+
+func TestListSessions_RequiresAuth(t *testing.T) {
+	t.Parallel()
+	srv := testServerWithPresence(t)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	if status, _ := getSessions(t, ts.URL, ""); status != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", status)
+	}
+}
+
+// TestListSessions_UnavailableWithoutRegistry pins the deliberate
+// choice in handleListSessions: a server with no registry answers 503,
+// NOT 200-with-an-empty-list. "I can't tell" and "nobody is listening"
+// must not look the same to the UI — collapsing them is precisely the
+// dishonesty this feature exists to remove.
+func TestListSessions_UnavailableWithoutRegistry(t *testing.T) {
+	t.Parallel()
+	srv := testServerWithWatchEvents(t) // no SetSessionPresence
+	_, _, tok, _ := setupWatchTestUser(t, srv)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	if status, _ := getSessions(t, ts.URL, tok.Token); status != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503 without a presence registry, got %d", status)
+	}
+}
+
+func TestListSessions_EmptyWhenNothingConnected(t *testing.T) {
+	t.Parallel()
+	srv := testServerWithPresence(t)
+	_, _, tok, _ := setupWatchTestUser(t, srv)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	status, body := getSessions(t, ts.URL, tok.Token)
+	if status != http.StatusOK {
+		t.Fatalf("expected 200, got %d", status)
+	}
+	if body.Count != 0 || len(body.Sessions) != 0 {
+		t.Fatalf("expected an empty session list, got count=%d sessions=%+v", body.Count, body.Sessions)
+	}
+}
+
+// TestListSessions_ReflectsAnOpenStream is the end-to-end shape of the
+// slice: open a stream, see it; drop the stream, stop seeing it. The
+// disconnect half is the one that matters — a leaked entry makes the UI
+// promise a listener that is gone.
+func TestListSessions_ReflectsAnOpenStream(t *testing.T) {
+	t.Parallel()
+	srv := testServerWithPresence(t)
+	_, _, tok, _ := setupWatchTestUser(t, srv)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch := connectWatchStream(ctx, t, ts.URL, tok.Token)
+	// Wait for "connected" rather than polling blind: it proves the
+	// handler reached the point where registration has happened, so the
+	// assertion below isn't racing the handshake.
+	if ev := waitForWatchEvent(t, ch, 3*time.Second); ev.Type != "connected" {
+		t.Fatalf("expected 'connected', got %q", ev.Type)
+	}
+
+	status, body := getSessions(t, ts.URL, tok.Token)
+	if status != http.StatusOK {
+		t.Fatalf("expected 200, got %d", status)
+	}
+	if body.Count != 1 || len(body.Sessions) != 1 {
+		t.Fatalf("expected exactly 1 live session, got count=%d sessions=%+v", body.Count, body.Sessions)
+	}
+	if body.Sessions[0].ID == "" {
+		t.Fatal("live session has an empty id")
+	}
+	if body.Sessions[0].ConnectedAt.IsZero() {
+		t.Fatal("live session has a zero connected_at")
+	}
+
+	cancel()
+	// The deregistration happens in the handler's defer once it notices
+	// ctx.Done, which is asynchronous with the client-side cancel.
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		_, body = getSessions(t, ts.URL, tok.Token)
+		if body.Count == 0 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("session still listed %v after disconnect: %+v", 3*time.Second, body.Sessions)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+// TestListSessions_IsSelfScoped guards the consent boundary: one user's
+// open stream must never appear in another user's list. There is no
+// admin view and no ?user_id= for the same reason.
+func TestListSessions_IsSelfScoped(t *testing.T) {
+	t.Parallel()
+	srv := testServerWithPresence(t)
+	_, _, tokA, _ := setupWatchTestUser(t, srv)
+	// Not a second setupWatchTestUser call: that helper hardcodes
+	// watch-test@example.com, so calling it twice on one server collides
+	// on the unique email. User B needs no workspace membership here —
+	// the presence list is user-scoped and never consults workspaces.
+	userB, err := srv.store.CreateUser(models.UserCreate{
+		Email:    "sessions-test-b@example.com",
+		Name:     "Sessions Tester B",
+		Password: "pw-test-12345",
+	})
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	tokB, err := srv.store.CreateAPIToken(userB.ID, models.APITokenCreate{Name: "sessions-test-b"}, 0, 0)
+	if err != nil {
+		t.Fatalf("CreateAPIToken: %v", err)
+	}
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch := connectWatchStream(ctx, t, ts.URL, tokA.Token)
+	if ev := waitForWatchEvent(t, ch, 3*time.Second); ev.Type != "connected" {
+		t.Fatalf("expected 'connected', got %q", ev.Type)
+	}
+
+	if _, body := getSessions(t, ts.URL, tokA.Token); body.Count != 1 {
+		t.Fatalf("user A should see their own session, got count=%d", body.Count)
+	}
+	if _, body := getSessions(t, ts.URL, tokB.Token); body.Count != 0 {
+		t.Fatalf("user B must not see user A's session, got count=%d sessions=%+v", body.Count, body.Sessions)
+	}
+}

--- a/internal/server/handlers_sessions_test.go
+++ b/internal/server/handlers_sessions_test.go
@@ -87,6 +87,33 @@ func TestListSessions_EmptyWhenNothingConnected(t *testing.T) {
 	}
 }
 
+// TestListSessions_IsNotCacheable pins the Cache-Control header (codex
+// round 2, P2). The response is both per-user sensitive and short-lived
+// by nature, so a cached copy is wrong in two independent ways — see
+// handleListSessions.
+func TestListSessions_IsNotCacheable(t *testing.T) {
+	t.Parallel()
+	srv := testServerWithPresence(t)
+	_, _, tok, _ := setupWatchTestUser(t, srv)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	req, _ := http.NewRequest("GET", ts.URL+"/api/v1/sessions", nil)
+	req.Header.Set("Authorization", "Bearer "+tok.Token)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	if got := resp.Header.Get("Cache-Control"); got != "private, no-store" {
+		t.Fatalf("expected Cache-Control %q, got %q", "private, no-store", got)
+	}
+}
+
 // TestListSessions_ReflectsAnOpenStream is the end-to-end shape of the
 // slice: open a stream, see it; drop the stream, stop seeing it. The
 // disconnect half is the one that matters — a leaked entry makes the UI

--- a/internal/server/handlers_watch_events.go
+++ b/internal/server/handlers_watch_events.go
@@ -122,6 +122,26 @@ func (s *Server) handleWatchEventsStream(w http.ResponseWriter, r *http.Request)
 	}
 	defer s.watchEvents.Unsubscribe(ch)
 
+	// Presence registration (PLAN-2558 S1). Deliberately bracketed to
+	// the SUBSCRIPTION's lifetime rather than the request's: a session
+	// counts as "listening" for exactly as long as it can actually
+	// receive a notification, which is what a push's honesty check is
+	// really asking about. Registering here also means the defer pairs
+	// with Unsubscribe's on the adjacent line, so every exit path below
+	// — client disconnect via ctx.Done, a failed SSE write, the
+	// replay-loop returns, the reval-tick paths — releases both or
+	// neither. A leaked entry is the one failure that matters: it makes
+	// the UI claim a listener that is gone, i.e. exactly the silent-
+	// nowhere-push this feature exists to prevent, but with a
+	// confident label on it.
+	//
+	// The label is empty until S2 (TASK-2560) teaches the client to
+	// carry its `pad session register` identity; a count needs no name.
+	if s.sessionPresence != nil {
+		sessionID := s.sessionPresence.Add(user.ID, "")
+		defer s.sessionPresence.Remove(user.ID, sessionID)
+	}
+
 	watches, werr := s.loadWatchPredicates(r, user.ID)
 	if werr != nil {
 		slog.Warn("watch-events: failed to load caller's watches, denying watch-scoped matches",

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -47,6 +47,7 @@ type Server struct {
 	webFS                 fs.FS                // embedded web UI static files (optional)
 	events                events.EventBus      // real-time event bus (optional)
 	watchEvents           watchevents.Bus      // watch/nudge notification bus (optional, TASK-2533)
+	sessionPresence       SessionPresence      // live event-stream connections per user (optional, PLAN-2558 S1)
 	collab                *collab.RoomManager  // Yjs collab room manager (PLAN-1248); optional
 	webhooks              *webhooks.Dispatcher // webhook dispatcher (optional)
 	email                 *email.Sender        // transactional email sender (optional)
@@ -728,6 +729,16 @@ func (s *Server) SetWatchEventsBus(bus watchevents.Bus) {
 	s.watchEvents = bus
 }
 
+// SetSessionPresence attaches the live-session registry read by
+// GET /api/v1/sessions and written by GET /api/v1/events/stream
+// (PLAN-2558 S1). Nil-checked at both ends, so a server constructed
+// without one still streams events — it just can't answer "who is
+// listening?", and says so with a 503 rather than an empty list (see
+// handleListSessions).
+func (s *Server) SetSessionPresence(p SessionPresence) {
+	s.sessionPresence = p
+}
+
 // SetCollabRoomManager attaches a Yjs collab RoomManager (PLAN-1248).
 // When set, the /api/v1/collab/{itemID} WebSocket endpoint hands new
 // connections to the manager for op-log replay + fan-out. When nil,
@@ -1152,6 +1163,15 @@ func (s *Server) setupRouter() {
 		// endpoint for the same "outside jsonContentType, inherits auth"
 		// reason.
 		r.Get("/api/v1/events/stream", s.handleWatchEventsStream)
+
+		// Live-session presence (PLAN-2558 S1) — the READ side of the
+		// registry the stream above writes. Mounted here beside the
+		// endpoint it reports on rather than in the /api/v1 Route block
+		// below: the two are one feature, and a reader asking "what
+		// fills this list?" should find the answer on the adjacent
+		// line. Self-scoped; see handleListSessions on why there is
+		// deliberately no admin view.
+		r.Get("/api/v1/sessions", s.handleListSessions)
 
 		// WebSocket endpoint for Yjs-based collaborative editing on a
 		// single item (PLAN-1248). Lives outside jsonContentType for

--- a/internal/server/session_presence.go
+++ b/internal/server/session_presence.go
@@ -1,0 +1,173 @@
+package server
+
+import (
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// This file implements the session-presence registry (PLAN-2558 S1,
+// TASK-2559): the server's answer to "is anything actually listening
+// right now?"
+//
+// WHY IT EXISTS. `pad push` (IDEA-2544 Phase 1, handlers_push.go) is
+// fire-and-forget by design — no durable inbox, no "no session
+// connected" warning. That is a defensible contract for a CLI verb
+// typed by someone who knows whether their own session is running. It
+// is NOT a defensible contract for a web-UI button: "Push to Claude"
+// that silently goes nowhere is worse than the clipboard ferry it
+// replaces, because the user has no way to tell the two outcomes
+// apart. The presence registry lets the UI answer the question BEFORE
+// the click (PLAN-2558's "Honesty" rationale), and — once sessions
+// carry a label (S2, TASK-2560) — turns the same data into the target
+// picker S5 needs.
+//
+// SINGLE-PROCESS LIMITATION, stated up front for the same reason
+// internal/watchevents states its own: MemorySessionPresence tracks
+// connections held open by THIS process only. In a multi-process padd
+// deployment (Pad Cloud) a session connected to instance A is invisible
+// to instance B, so /api/v1/sessions under-reports.
+//
+// The precise shape of that matters, because the obvious reading —
+// "presence lies about delivery" — is not quite it. watchevents.Bus has
+// the SAME per-process boundary: a push published on instance A never
+// reaches a stream held on instance B either. So presence and delivery
+// are blind in the same direction, and a request pair that lands on one
+// instance gets a presence answer that correctly predicts what a push
+// would do. What is NOT guaranteed is that the pair lands together — a
+// load balancer is free to route the POST and the GET to different
+// instances, and then the two disagree. So the honest statement is:
+// per-instance presence is as accurate as per-instance delivery, and
+// both stop being trustworthy at the same boundary, for the same
+// reason, and only a shared-state implementation fixes either.
+//
+// Hence SessionPresence is an interface from day one: a Redis-backed
+// implementation must be able to slot in without touching the stream
+// handler or the endpoint — and it should land alongside the Redis
+// watchevents.Bus that package's doc comment already anticipates, not
+// separately, since fixing one without the other just moves the
+// disagreement. Do not put the web-UI push surface (PLAN-2558 S3) in
+// front of a multi-process deployment until both exist.
+
+// LiveSession is one currently-connected user-scoped event stream —
+// i.e. one `GET /api/v1/events/stream` connection being held open.
+//
+// The identity fields are deliberately thin in S1. Label is empty until
+// S2 teaches the stream connection to carry the `pad session register`
+// payload (cwd basename, pid) it already writes to
+// ~/.pad/sessions/<pid>.json; until then a session is an opaque id and
+// a connect time, which is all a COUNT needs. Note that S2 must send
+// the label only — never messaging_socket_path, which is local-machine
+// state with no business crossing the wire.
+type LiveSession struct {
+	// ID is server-generated per connection, not per client. A client
+	// that reconnects (including the Last-Event-ID resume path) gets a
+	// NEW id, because from the presence registry's point of view a
+	// resumed stream is a different open connection. Callers must not
+	// treat this as a stable client identity.
+	ID string `json:"id"`
+	// Label is a human-meaningful name for the session ("docapp"),
+	// populated in S2. Empty means "unlabelled", not "unknown user" —
+	// consumers should fall back to the id, never hide the session.
+	Label string `json:"label,omitempty"`
+	// ConnectedAt is when the stream opened, UTC.
+	ConnectedAt time.Time `json:"connected_at"`
+}
+
+// SessionPresence tracks which of a user's event streams are open right
+// now. Implementations must be safe for concurrent use: Add/Remove are
+// called from each stream connection's own goroutine while ListForUser
+// is served from unrelated request goroutines.
+type SessionPresence interface {
+	// Add registers a newly-opened stream for userID and returns the
+	// session's generated id, which the caller MUST pass to Remove.
+	Add(userID string, label string) string
+	// Remove deregisters a session. It must be idempotent and must not
+	// panic on an unknown id — the stream handler calls it from a defer
+	// that also runs on paths where Add may not have been reached.
+	Remove(userID string, sessionID string)
+	// ListForUser returns userID's live sessions, oldest connection
+	// first. The returned slice is a copy and is safe to retain.
+	ListForUser(userID string) []LiveSession
+}
+
+// MemorySessionPresence is the in-process SessionPresence — see this
+// file's SINGLE-PROCESS LIMITATION note before deploying it behind more
+// than one padd process.
+type MemorySessionPresence struct {
+	mu sync.RWMutex
+	// byUser is userID -> sessionID -> session. Two levels rather than a
+	// flat map keyed by session id because every read is user-scoped
+	// (there is no "list all sessions on this server" consumer, and
+	// there should not be one — see handleListSessions' doc comment on
+	// why this endpoint is not admin-visible).
+	byUser map[string]map[string]LiveSession
+}
+
+// NewMemorySessionPresence returns an empty in-process registry.
+func NewMemorySessionPresence() *MemorySessionPresence {
+	return &MemorySessionPresence{byUser: make(map[string]map[string]LiveSession)}
+}
+
+// Add implements SessionPresence.
+func (p *MemorySessionPresence) Add(userID string, label string) string {
+	id := uuid.NewString()
+	// Stamp the time OUTSIDE the lock — time.Now can be comparatively
+	// slow on some platforms and there is no correctness reason to hold
+	// writers behind it.
+	sess := LiveSession{ID: id, Label: label, ConnectedAt: time.Now().UTC()}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	sessions, ok := p.byUser[userID]
+	if !ok {
+		sessions = make(map[string]LiveSession)
+		p.byUser[userID] = sessions
+	}
+	sessions[id] = sess
+	return id
+}
+
+// Remove implements SessionPresence. Removing the user's last session
+// deletes the user's bucket too, so an idle server doesn't accumulate
+// an empty map per user who has ever connected.
+func (p *MemorySessionPresence) Remove(userID string, sessionID string) {
+	if sessionID == "" {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	sessions, ok := p.byUser[userID]
+	if !ok {
+		return
+	}
+	delete(sessions, sessionID)
+	if len(sessions) == 0 {
+		delete(p.byUser, userID)
+	}
+}
+
+// ListForUser implements SessionPresence, oldest connection first with
+// the session id as a tiebreaker so the order is deterministic even for
+// two connections that opened within the same clock tick (a real case
+// under a coarse monotonic clock, and an unstable list order would make
+// the S5 target picker jump around under the user's cursor).
+func (p *MemorySessionPresence) ListForUser(userID string) []LiveSession {
+	p.mu.RLock()
+	sessions := p.byUser[userID]
+	out := make([]LiveSession, 0, len(sessions))
+	for _, sess := range sessions {
+		out = append(out, sess)
+	}
+	p.mu.RUnlock()
+
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].ConnectedAt.Equal(out[j].ConnectedAt) {
+			return out[i].ID < out[j].ID
+		}
+		return out[i].ConnectedAt.Before(out[j].ConnectedAt)
+	})
+	return out
+}

--- a/internal/server/session_presence.go
+++ b/internal/server/session_presence.go
@@ -68,6 +68,27 @@ type LiveSession struct {
 	// resumed stream is a different open connection. Callers must not
 	// treat this as a stable client identity.
 	ID string `json:"id"`
+	// STALENESS. A session in this list is "connected" as of the last
+	// time the server could tell, which is not the same as "connected
+	// now". A CLEAN disconnect deregisters immediately (the stream
+	// handler's ctx.Done fires and its defer runs). An UNGRACEFUL one
+	// — half-open TCP, closed laptop, dropped network — is invisible
+	// to the server until the next keepalive write fails, and
+	// watchEventsKeepaliveInterval is 30s. So this list can name a
+	// listener that is already gone, for up to ~30 seconds.
+	//
+	// That bound is acceptable for push, which is fire-and-forget
+	// either way: a push to a session that died 5 seconds ago costs a
+	// message that would have been lost regardless. It is NOT
+	// acceptable as a delivery guarantee, and consumers must not
+	// upgrade it into one — "one session connected" is honest, "this
+	// will be delivered" is not (PLAN-2558 S3).
+	//
+	// Shortening the window means shortening the keepalive, which
+	// costs every idle connection real traffic. Not worth it for a
+	// fire-and-forget channel; revisit only if a consumer appears that
+	// genuinely needs delivery confidence, and give that consumer an
+	// ack rather than a faster heartbeat.
 	// Label is a human-meaningful name for the session ("docapp"),
 	// populated in S2. Empty means "unlabelled", not "unknown user" —
 	// consumers should fall back to the id, never hide the session.
@@ -80,6 +101,27 @@ type LiveSession struct {
 // now. Implementations must be safe for concurrent use: Add/Remove are
 // called from each stream connection's own goroutine while ListForUser
 // is served from unrelated request goroutines.
+//
+// CONSTRAINT ON ANY OUT-OF-PROCESS IMPLEMENTATION (codex round 2, P2,
+// refined). Server.Shutdown delegates to http.Server.Shutdown, and Go's
+// stdlib does NOT cancel an in-flight handler's request context there —
+// it waits for the handler to return. SSE handlers only return on their
+// own ctx.Done or a failed write, so a shutdown leaves stream handlers
+// (and their presence entries) hanging until something else knocks them
+// loose.
+//
+// For MemorySessionPresence this is harmless, and saying so is the
+// point: the registry lives in the process that is going away, so its
+// entries die with it. There is nothing to reap.
+//
+// A Redis-backed implementation does NOT inherit that mercy. Its
+// entries outlive the process that wrote them, so a hard shutdown or a
+// crash strands them, and the list starts naming sessions belonging to
+// an instance that no longer exists — permanently, not for 30 seconds.
+// Such an implementation MUST carry its own reaping story (TTL with
+// heartbeat renewal, or ownership keyed by instance id and swept on
+// startup). Do not port MemorySessionPresence's lifecycle assumptions
+// across; they are load-bearing on the in-process case only.
 type SessionPresence interface {
 	// Add registers a newly-opened stream for userID and returns the
 	// session's generated id, which the caller MUST pass to Remove.

--- a/internal/server/session_presence_test.go
+++ b/internal/server/session_presence_test.go
@@ -1,0 +1,154 @@
+package server
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestMemorySessionPresence_AddListRemove(t *testing.T) {
+	t.Parallel()
+	p := NewMemorySessionPresence()
+
+	if got := p.ListForUser("u1"); len(got) != 0 {
+		t.Fatalf("expected no sessions for an unknown user, got %d", len(got))
+	}
+
+	a := p.Add("u1", "docapp")
+	b := p.Add("u1", "voiapp")
+	other := p.Add("u2", "poker")
+
+	if a == b {
+		t.Fatal("two connections for the same user must get distinct ids")
+	}
+
+	got := p.ListForUser("u1")
+	if len(got) != 2 {
+		t.Fatalf("expected 2 sessions for u1, got %d", len(got))
+	}
+	// u2's session must not leak into u1's list — the whole endpoint is
+	// self-scoped, so cross-user bleed here is the bug that matters.
+	for _, s := range got {
+		if s.ID == other {
+			t.Fatal("u2's session appeared in u1's list")
+		}
+		if s.ConnectedAt.IsZero() {
+			t.Fatalf("session %s has a zero ConnectedAt", s.ID)
+		}
+	}
+
+	p.Remove("u1", a)
+	got = p.ListForUser("u1")
+	if len(got) != 1 || got[0].ID != b {
+		t.Fatalf("expected only session %s to remain, got %+v", b, got)
+	}
+	if len(p.ListForUser("u2")) != 1 {
+		t.Fatal("removing u1's session disturbed u2's list")
+	}
+}
+
+// TestMemorySessionPresence_RemoveIsForgiving pins the contract the
+// stream handler's defer depends on: Remove runs on exit paths where
+// Add may never have happened, and must not panic or corrupt state.
+func TestMemorySessionPresence_RemoveIsForgiving(t *testing.T) {
+	t.Parallel()
+	p := NewMemorySessionPresence()
+
+	p.Remove("nobody", "no-such-session") // unknown user
+	p.Remove("u1", "")                    // empty id (Add never ran)
+
+	id := p.Add("u1", "")
+	p.Remove("u1", id)
+	p.Remove("u1", id) // double-remove: idempotent, not a panic
+
+	if got := p.ListForUser("u1"); len(got) != 0 {
+		t.Fatalf("expected u1 to have no sessions, got %d", len(got))
+	}
+}
+
+// TestMemorySessionPresence_ListIsOldestFirstAndStable covers the
+// ordering the S5 target picker relies on. Two sessions can share a
+// ConnectedAt under a coarse clock, so the id tiebreaker — not the map
+// iteration order — has to decide, or the rendered list jumps around
+// under the user's cursor between polls.
+func TestMemorySessionPresence_ListIsOldestFirstAndStable(t *testing.T) {
+	t.Parallel()
+	p := NewMemorySessionPresence()
+
+	now := time.Now().UTC()
+	p.mu.Lock()
+	p.byUser["u1"] = map[string]LiveSession{
+		"ccc": {ID: "ccc", ConnectedAt: now},
+		"aaa": {ID: "aaa", ConnectedAt: now},
+		"bbb": {ID: "bbb", ConnectedAt: now.Add(-time.Minute)},
+	}
+	p.mu.Unlock()
+
+	// Same input, repeated reads: the order must not depend on Go's
+	// randomized map iteration.
+	for i := 0; i < 20; i++ {
+		got := p.ListForUser("u1")
+		if len(got) != 3 {
+			t.Fatalf("expected 3 sessions, got %d", len(got))
+		}
+		if got[0].ID != "bbb" {
+			t.Fatalf("expected the oldest connection first, got %q", got[0].ID)
+		}
+		if got[1].ID != "aaa" || got[2].ID != "ccc" {
+			t.Fatalf("expected the id tiebreaker to order the same-timestamp pair aaa,ccc; got %q,%q", got[1].ID, got[2].ID)
+		}
+	}
+}
+
+// TestMemorySessionPresence_ListReturnsACopy pins the doc-comment
+// promise that a caller may retain the returned slice: mutating it must
+// not reach back into the registry.
+func TestMemorySessionPresence_ListReturnsACopy(t *testing.T) {
+	t.Parallel()
+	p := NewMemorySessionPresence()
+	id := p.Add("u1", "docapp")
+
+	got := p.ListForUser("u1")
+	got[0].Label = "tampered"
+
+	fresh := p.ListForUser("u1")
+	if fresh[0].Label != "docapp" {
+		t.Fatalf("mutating the returned slice changed the registry: label is now %q", fresh[0].Label)
+	}
+	if fresh[0].ID != id {
+		t.Fatalf("expected id %q, got %q", id, fresh[0].ID)
+	}
+}
+
+// TestMemorySessionPresence_ConcurrentAccess is the race-detector's
+// entry point for the connect/disconnect-vs-read pattern the stream
+// handler produces in production.
+func TestMemorySessionPresence_ConcurrentAccess(t *testing.T) {
+	t.Parallel()
+	p := NewMemorySessionPresence()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 50; j++ {
+				id := p.Add("u1", "")
+				p.ListForUser("u1")
+				p.Remove("u1", id)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if got := p.ListForUser("u1"); len(got) != 0 {
+		t.Fatalf("every Add was paired with a Remove, expected 0 sessions, got %d", len(got))
+	}
+	// The user's bucket should be reclaimed too, not left as an empty map.
+	p.mu.RLock()
+	_, stillThere := p.byUser["u1"]
+	p.mu.RUnlock()
+	if stillThere {
+		t.Fatal("expected the empty user bucket to be reclaimed")
+	}
+}


### PR DESCRIPTION
Slice 1 of **PLAN-2558** (IDEA-2544 Phase 3 — web-UI push). Unblocks S2/S3; S3 is the demo money-shot PLAN-2469's campaign is waiting on.

## Why

`pad push` (Phase 1, `da6ce642`) is fire-and-forget with no "no session connected" warning. That is a defensible contract for a CLI verb typed by someone who knows whether their own session is running. It is **not** defensible for a web-UI button: "Push to Claude" that silently goes nowhere is *worse* than the clipboard ferry it replaces, because the user cannot tell the two outcomes apart. Presence lets the UI answer the question before the click, and — once sessions carry a label (S2) — turns the same data into the target picker S5 needs.

It also closes the substrate half of **PLAN-2469 Phase 3** ("presence surface: SessionStart hook → live-sessions view", IDEA-2464). The two Phase 3s turned out to be the same work.

## What

- `internal/server/session_presence.go` — `SessionPresence` interface + `MemorySessionPresence`.
- `handleWatchEventsStream` registers on connect, deregisters in a defer **paired with `Unsubscribe`'s on the adjacent line**, so presence is bracketed to the subscription's lifetime and every exit path (`ctx.Done`, a failed SSE write, the replay-loop returns, the reval-tick paths) releases both or neither. A leaked entry is the failure that matters — it makes the UI promise a listener that is gone.
- `internal/server/handlers_sessions.go` — `GET /api/v1/sessions`.

## Two decisions worth a reviewer's eye

**Self-scoped, no admin view.** No `?user_id=`, no admin bypass, unlike most list endpoints here. Who has an agent session open is a presence signal about a person, not a fact about workspace content — the same reasoning that made push self-addressed only. A cross-user view is a product decision with a consent design attached, not a query parameter.

**503, not 200-with-an-empty-list**, when no registry is wired. "I can't tell" and "nobody is listening" must not look the same to the UI; collapsing them is precisely the dishonesty this slice exists to remove.

## Multi-process boundary

`MemorySessionPresence` is per-process, so it is an interface from day one. The doc comment states the boundary precisely rather than hand-waving it: `watchevents.Bus` is blind in the **same** direction (a push published on instance A never reaches a stream on instance B), so per-instance presence is as accurate as per-instance delivery and both stop being trustworthy at the same boundary — *except* that a load balancer may route a POST and a GET to different instances, at which point the two disagree. A Redis-backed presence must therefore land **with** the Redis `watchevents.Bus` that package already anticipates, not separately. Fixing one alone just moves the disagreement.

**Do not put the web-UI push surface (S3) in front of a multi-process deployment until both exist.**

## pad-cloud

No change required — checked, not assumed. `/api/v1/sessions` is a plain JSON GET served by `nginx-router.conf`'s default `location /` pass-through; the special long-lived-connection blocks are for `/api/v1/events` and `/api/v1/collab/` only.

## Verification

- `make test` (SQLite) clean
- `make test-pg` clean — 25 packages, exit 0
- `make lint` — 0 issues
- New tests pass under `-race` (including a concurrent Add/List/Remove hammer)
- **Live, on the installed binary:** 0 sessions with nothing connected → 1 with one stream open → 2 with two, oldest-first → back to 0 after both disconnect, with a second user's list staying empty throughout.