### PR TITLE
feat(watch): drop assignment from the addressed-to-you stream (IDEA-2544 Phase 2, TASK-2551)

### DIFF
--- a/internal/server/handlers_watch_access.go
+++ b/internal/server/handlers_watch_access.go
@@ -60,7 +60,7 @@ func (s *Server) filterWatchesByCurrentAccess(r *http.Request, userID string, wa
 }
 
 // watchAccessVisibility is filterWatchesByCurrentAccess's (and, as of
-// codex round 2 finding 2, the addressed-to-you check's) per-workspace
+// codex round 2 finding 2, the addressed-delivery check's) per-workspace
 // visibility snapshot. Deliberately keyed by ID (collection ID / item
 // ID), unlike handlers_events.go's sseVisibility, which is keyed by
 // collection SLUG because it routes live workspace-scoped events that
@@ -130,12 +130,12 @@ func (v watchAccessVisibility) allows(collectionID, itemID string) bool {
 // "every call site filters a caller's OWN watches, so this can't leak
 // another user's data." That reasoning held for watch-matched
 // notifications, but finding 2 is exactly the case where it doesn't:
-// the addressed-to-you/assignment path is now ALSO gated by this
-// function (handlers_watch_events.go), and an addressed-to-you
-// notification is, by definition, about something that happened TO the
+// the addressed-delivery path is now ALSO gated by this
+// function (handlers_watch_events.go), and an addressed
+// notification is, by definition, about something aimed AT the
 // connected user in a workspace — a bearer-borne admin token (a leaked
 // PAT, a compromised CI credential) being unconditionally trusted to see
-// EVERY workspace's assignment activity for "themselves" is exactly the
+// EVERY workspace's addressed traffic for "themselves" is exactly the
 // blast-radius BUG-1616 exists to bound. There is no watch-specific
 // exemption from that reasoning; this now mirrors computeSSEVisibility's
 // bearer-vs-cookie distinction exactly, so admin access to watch/nudge

--- a/internal/server/handlers_watch_events.go
+++ b/internal/server/handlers_watch_events.go
@@ -416,6 +416,14 @@ func watchNotificationVisible(watches map[string]string, vis watchAccessVisibili
 	// populated; only the addressed DELIVERY is gone, so a watcher's line
 	// is unchanged and re-introducing an opt-in later needs no producer
 	// work.
+	//
+	// KNOWN STALE, deliberately: plugin/monitors/monitors.json and
+	// plugin/skills/pad/SKILL.md still describe assignment as
+	// addressed-to-you traffic. Fixing them here would ship nothing —
+	// installed plugins are version-pinned at install (live-proven
+	// day-33), so plugin-visible text only reaches users with a version
+	// bump. TASK-2564 owns both the wording and the bump; this task is
+	// server-side only.
 
 	// Push (IDEA-2544 Phase 1) is semantically DIFFERENT from assignment,
 	// not just a same-shaped variant, and that difference is why this

--- a/internal/server/handlers_watch_events.go
+++ b/internal/server/handlers_watch_events.go
@@ -58,21 +58,24 @@ type watchEventPayload struct {
 //
 // Unlike handleSSE (GET /api/v1/events, workspace-scoped), this stream is
 // USER-scoped and spans every workspace the caller belongs to — a watch
-// or an assignment can land in any of them. It is filtered, server-side,
+// or a push can land in any of them. It is filtered, server-side,
 // to exactly two things (DR-2: no firehose, no wildcard subscriptions):
 //
 //  1. Notifications on an item the caller has an explicit watch on
 //     (internal/store's watches table), gated by that watch's optional
 //     `--until field=value` predicate.
-//  2. "Addressed to you": the item was JUST assigned to the caller.
-//     (Phase 1 narrowing, confirmed with the dispatcher: DOC-2479 also
-//     describes a "human-gate-shaped collection targets your ... active
-//     role" half of addressed-to-you, but this codebase has neither a
-//     Collection.Kind field nor any user→active-role binding to ground
-//     that mechanically — `pad session register` is the natural future
-//     hook for a session-carried role identity, see cmd_session.go. Only
-//     the assignment half is implemented; watchevents.KindAsk stays in
-//     the wire-contract enum with no producer until that exists.)
+//  2. "Addressed to you": traffic a user deliberately aimed at their own
+//     harness — today exactly KindPush (IDEA-2544 Phase 1). Assignment
+//     USED to qualify; IDEA-2544 Phase 2 (TASK-2551) removed it, because
+//     assignment is bookkeeping and push is dispatch — see
+//     watchNotificationVisible. watchevents.KindAsk is addressed traffic
+//     in the other direction (harness→human) and stays in the
+//     wire-contract enum with no producer: grounding DOC-2479's
+//     "human-gate-shaped collection targets your ... active role" half
+//     mechanically needs either a Collection.Kind field or a
+//     user→active-role binding, and this codebase has neither today
+//     (`pad session register` is the natural future hook for a
+//     session-carried role identity, see cmd_session.go).
 func (s *Server) handleWatchEventsStream(w http.ResponseWriter, r *http.Request) {
 	if s.watchEvents == nil {
 		writeError(w, http.StatusServiceUnavailable, "unavailable", "Watch event streaming is not available")
@@ -133,7 +136,7 @@ func (s *Server) handleWatchEventsStream(w http.ResponseWriter, r *http.Request)
 	// codex round 5 finding 1).
 	consecutiveWatchReloadFailures := 0
 	// TASK-2533 codex round 2 finding 2: EVERY notification — watch-
-	// matched or addressed-to-you — must pass the same current-access
+	// matched or addressed (KindPush) — must pass the same current-access
 	// check before delivery, not just watch-matched ones. visCache
 	// resolves per-workspace visibility lazily (a notification's
 	// workspace isn't known in advance the way `watches`' workspaces
@@ -233,13 +236,14 @@ func (s *Server) handleWatchEventsStream(w http.ResponseWriter, r *http.Request)
 				// exists. After maxConsecutiveWatchReloadFailures ticks
 				// of failure, fail closed on watch-matched delivery
 				// specifically: clear the set so it can no longer match
-				// anything stale. Addressed-to-you delivery is
-				// unaffected either way — it depends only on visCache,
-				// which was already refreshed above regardless of this
+				// anything stale. Addressed delivery (KindPush — see
+				// watchNotificationVisible) is unaffected either way:
+				// it depends only on TargetUserID and visCache, which
+				// was already refreshed above regardless of this
 				// failure.
 				if consecutiveWatchReloadFailures >= maxConsecutiveWatchReloadFailures {
 					if len(watches) > 0 {
-						slog.Warn("watch-events: watch-list reload failed repeatedly, clearing stale watch set (addressed-to-you delivery continues)",
+						slog.Warn("watch-events: watch-list reload failed repeatedly, clearing stale watch set (addressed push delivery continues)",
 							"user_id", user.ID, "consecutive_failures", consecutiveWatchReloadFailures, "error", ferr)
 						watches = map[string]string{}
 					}
@@ -396,14 +400,22 @@ func watchNotificationVisible(watches map[string]string, vis watchAccessVisibili
 		return false
 	}
 
-	// Addressed-to-you: the item was just assigned to the caller. Fires
-	// regardless of whether the caller also holds an explicit watch on
-	// the item (a watch and an addressed-to-you event are independent
-	// reasons to be told) — gated above by the SAME access check a
-	// watch-matched notification gets, not a bespoke one.
-	if n.Kind == watchevents.KindAssignment && n.AssignedUserID != "" && n.AssignedUserID == userID {
-		return true
-	}
+	// IDEA-2544 Phase 2 (TASK-2551): assignment is NOT addressed traffic.
+	// There used to be a branch here delivering a KindAssignment
+	// notification to its new assignee whether or not they watched the
+	// item. Dave's product call (day-33) removed it outright — no opt-in
+	// flag, no config key: assignment is bookkeeping (who owns this),
+	// push is dispatch (where attention goes now), and conflating them
+	// meant one triage session assigning N items sprayed N notifications
+	// into every open session of the assignee. KindAssignment now reaches
+	// a caller only the way any other item-level fact does — via an
+	// explicit watch, matched below — which is what `pad watch --help`
+	// already promises an unconditional watch delivers. Producers still
+	// publish assignment notifications onto the bus (handlers_items.go,
+	// handlers_watch_notify.go) and Notification.AssignedUserID is still
+	// populated; only the addressed DELIVERY is gone, so a watcher's line
+	// is unchanged and re-introducing an opt-in later needs no producer
+	// work.
 
 	// Push (IDEA-2544 Phase 1) is semantically DIFFERENT from assignment,
 	// not just a same-shaped variant, and that difference is why this

--- a/internal/server/handlers_watch_events_test.go
+++ b/internal/server/handlers_watch_events_test.go
@@ -247,23 +247,61 @@ func TestWatchEventsStream_SuppressesUnwatchedItem(t *testing.T) {
 	}
 }
 
-func TestWatchEventsStream_AddressedToYou_Assignment(t *testing.T) {
+// TestWatchEventsStream_AssignmentIsNotAddressedToYou is the inverted
+// successor of TASK-2533's TestWatchEventsStream_AddressedToYou_Assignment,
+// which asserted the opposite: that assigning an UNWATCHED item to the
+// connected user surfaced on their stream. IDEA-2544 Phase 2 (TASK-2551)
+// removed that delivery path outright — assignment is bookkeeping, push
+// is dispatch — so the same setup must now stay silent.
+//
+// Structured so a silent stream can't pass it by accident (team CONVE-12:
+// an end-state assertion is only evidence when no OTHER mechanism
+// produces the same end state). Both legs are published on the SAME bus
+// in order, so receiving the WATCHED item's assignment proves the
+// unwatched one was filtered rather than merely slow — no sleep, no
+// timing window. The control leg also pins the half of the rule that
+// SURVIVED: an unconditional watch still delivers assignment
+// notifications, exactly as `pad watch --help` promises.
+func TestWatchEventsStream_AssignmentIsNotAddressedToYou(t *testing.T) {
 	t.Parallel()
 	srv := testServerWithWatchEvents(t)
 	slug, item, tok, user := setupWatchTestUser(t, srv)
 	ts := httptest.NewServer(srv)
 	defer ts.Close()
 
-	// No explicit watch — this must fire purely via addressed-to-you.
+	// The control item, watched BEFORE connecting (the watches map is
+	// loaded once at connect time — same rationale as the other
+	// watch-before-connect setups in this file).
+	rr := bearerJSON(t, srv, "POST", "/api/v1/workspaces/"+slug+"/collections/tasks/items", tok.Token,
+		map[string]interface{}{"title": "Watched control", "fields": `{"status":"open"}`})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("seed watched item: %d %s", rr.Code, rr.Body.String())
+	}
+	var watched models.Item
+	parseJSON(t, rr, &watched)
+	rr = bearerCall(t, srv, "POST", "/api/v1/workspaces/"+slug+"/items/"+watched.Slug+"/watch", tok.Token, nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("create watch: %d %s", rr.Code, rr.Body.String())
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	ch := connectWatchStream(ctx, t, ts.URL, tok.Token)
 	waitForWatchEvent(t, ch, 3*time.Second) // connected
 
-	rr := bearerJSON(t, srv, "PATCH", "/api/v1/workspaces/"+slug+"/items/"+item.Slug, tok.Token,
+	// Leg 1: assign the UNWATCHED item to the connected user. Pre-Phase-2
+	// this fired via addressed-to-you; it must now be silent.
+	rr = bearerJSON(t, srv, "PATCH", "/api/v1/workspaces/"+slug+"/items/"+item.Slug, tok.Token,
 		map[string]interface{}{"assigned_user_id": user.ID})
 	if rr.Code != http.StatusOK {
-		t.Fatalf("assign item: %d %s", rr.Code, rr.Body.String())
+		t.Fatalf("assign unwatched item: %d %s", rr.Code, rr.Body.String())
+	}
+	// Leg 2: assign the WATCHED item — must surface, proving the stream is
+	// live and leg 1's absence isn't just "nothing happened yet".
+	rr = bearerJSON(t, srv, "PATCH", "/api/v1/workspaces/"+slug+"/items/"+watched.Slug, tok.Token,
+		map[string]interface{}{"assigned_user_id": user.ID})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("assign watched item: %d %s", rr.Code, rr.Body.String())
 	}
 
 	ev := waitForWatchEvent(t, ch, 3*time.Second)
@@ -271,11 +309,11 @@ func TestWatchEventsStream_AddressedToYou_Assignment(t *testing.T) {
 	if err := json.Unmarshal([]byte(ev.Data), &payload); err != nil {
 		t.Fatalf("parse payload: %v", err)
 	}
+	if payload.ItemRef != watched.Ref {
+		t.Fatalf("expected the WATCHED item's ref %q first, got %q — assignment is still being delivered addressed-to-you", watched.Ref, payload.ItemRef)
+	}
 	if payload.Kind != watchevents.KindAssignment {
 		t.Fatalf("expected kind %q, got %q", watchevents.KindAssignment, payload.Kind)
-	}
-	if payload.ItemRef != item.Ref {
-		t.Fatalf("expected item_ref %q, got %q", item.Ref, payload.ItemRef)
 	}
 }
 
@@ -414,15 +452,26 @@ func TestWatchEventsStream_ReplyNotification(t *testing.T) {
 // TestWatchEventsStream_BulkAssignFires exercises the producer-coverage
 // claim in publishWatchNotifications' doc comment (TASK-2533 audit): a
 // bulk "assign" op (which calls store.UpdateItem directly, bypassing
-// handleUpdateItem entirely) must still surface an addressed-to-you
-// assignment notification — proving the fix belongs at the store layer
+// handleUpdateItem entirely) must still surface an assignment
+// notification — proving the fix belongs at the store layer
 // (LastMutation), not in each individual HTTP handler.
+//
+// The delivery vehicle is an explicit WATCH on the item, not the
+// caller's own assignment: IDEA-2544 Phase 2 (TASK-2551) dropped
+// addressed-to-you assignment delivery, which is what this test used to
+// ride on. The producer claim under test is unchanged — only the reason
+// the notification reaches this stream is.
 func TestWatchEventsStream_BulkAssignFires(t *testing.T) {
 	t.Parallel()
 	srv := testServerWithWatchEvents(t)
 	slug, item, tok, user := setupWatchTestUser(t, srv)
 	ts := httptest.NewServer(srv)
 	defer ts.Close()
+
+	rr0 := bearerCall(t, srv, "POST", "/api/v1/workspaces/"+slug+"/items/"+item.Slug+"/watch", tok.Token, nil)
+	if rr0.Code != http.StatusOK {
+		t.Fatalf("create watch: %d %s", rr0.Code, rr0.Body.String())
+	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -553,12 +602,21 @@ func TestWatchNotificationVisible_PredicateMatchesOnlyTargetValue(t *testing.T) 
 	}
 }
 
-func TestWatchNotificationVisible_AddressedToYouIgnoresWatchList(t *testing.T) {
+// TestWatchNotificationVisible_AssignmentToYouNeedsAWatch replaces
+// TASK-2533's TestWatchNotificationVisible_AddressedToYouIgnoresWatchList,
+// which asserted the exact opposite. IDEA-2544 Phase 2 (TASK-2551):
+// assignment is no longer addressed traffic, so being the new assignee
+// buys nothing — a watch is now the ONLY way a KindAssignment
+// notification reaches a caller. Both legs run against the same
+// notification so the watch map is provably the only variable.
+func TestWatchNotificationVisible_AssignmentToYouNeedsAWatch(t *testing.T) {
 	t.Parallel()
-	watches := map[string]string{} // no watches at all
 	n := watchevents.Notification{ItemID: "item-1", Kind: watchevents.KindAssignment, AssignedUserID: "user-1"}
-	if !watchNotificationVisible(watches, watchAccessVisibility{fullAccess: true}, "user-1", n) {
-		t.Fatal("expected an assignment-to-you notification to be visible with no watch")
+	if watchNotificationVisible(map[string]string{}, watchAccessVisibility{fullAccess: true}, "user-1", n) {
+		t.Fatal("expected an assignment-to-you notification to be denied with no watch on the item")
+	}
+	if !watchNotificationVisible(map[string]string{"item-1": ""}, watchAccessVisibility{fullAccess: true}, "user-1", n) {
+		t.Fatal("expected the same assignment to be visible to a caller holding an unconditional watch")
 	}
 }
 
@@ -568,6 +626,25 @@ func TestWatchNotificationVisible_AssignmentToSomeoneElseDenied(t *testing.T) {
 	n := watchevents.Notification{ItemID: "item-1", Kind: watchevents.KindAssignment, AssignedUserID: "user-2"}
 	if watchNotificationVisible(watches, watchAccessVisibility{fullAccess: true}, "user-1", n) {
 		t.Fatal("expected an assignment to someone else to be denied")
+	}
+}
+
+// TestWatchNotificationVisible_AssignmentToSomeoneElseVisibleToWatcher
+// pins the deliberate asymmetry between assignment and push after
+// IDEA-2544 Phase 2. Push is private dispatch and is EXCLUSIVE of
+// watch-matched delivery (see the Push* tests below): an unconditional
+// watch must not leak a push addressed to someone else. An assignment is
+// an ordinary item-level fact, so the opposite is true — a watcher is
+// entitled to see who the item got assigned to, whoever that is. Without
+// this test, deleting the KindAssignment fall-through in favour of a
+// push-style `return n.AssignedUserID == userID` would look correct: the
+// Phase 2 tests above would all still pass.
+func TestWatchNotificationVisible_AssignmentToSomeoneElseVisibleToWatcher(t *testing.T) {
+	t.Parallel()
+	watches := map[string]string{"item-1": ""} // unconditional watch
+	n := watchevents.Notification{ItemID: "item-1", Kind: watchevents.KindAssignment, AssignedUserID: "user-2"}
+	if !watchNotificationVisible(watches, watchAccessVisibility{fullAccess: true}, "user-1", n) {
+		t.Fatal("expected an unconditional watcher to see an assignment to someone else — an assignment is an item-level fact, not private dispatch")
 	}
 }
 
@@ -653,25 +730,33 @@ func TestWatchNotificationVisible_PushStillGatedByAccess(t *testing.T) {
 	}
 }
 
-// TestWatchNotificationVisible_AddressedToYouStillGatedByAccess covers
+// TestWatchNotificationVisible_AssignmentStillGatedByAccess covers
 // TASK-2533 codex round 2 finding 2: the addressed-to-you branch used to
 // return true unconditionally, with NO access check — an item assigned
 // to a "specific"-access member whose granted collections don't include
 // it (validateAssignmentScope only checks workspace membership, never
 // collection access — a completely ordinary, no-revocation-needed
 // scenario) would still leak. A zero-value watchAccessVisibility (no
-// full access, no granted collections/items) must deny an
-// assignment-to-you notification just as it would a watch-matched one.
-func TestWatchNotificationVisible_AddressedToYouStillGatedByAccess(t *testing.T) {
+// full access, no granted collections/items) must deny an assignment
+// notification just as it would any other kind.
+//
+// IDEA-2544 Phase 2 (TASK-2551) deleted that branch, so the specific
+// leak is now structurally impossible — but the ordering rule it taught
+// (access is checked FIRST, uniformly, before any per-kind logic) is
+// still live and still worth pinning. The caller therefore holds an
+// unconditional WATCH here: without it the denial leg would pass for the
+// uninteresting reason that nothing matches at all (team CONVE-12), and
+// the access check would never be the thing under test.
+func TestWatchNotificationVisible_AssignmentStillGatedByAccess(t *testing.T) {
 	t.Parallel()
-	watches := map[string]string{}
+	watches := map[string]string{"item-1": ""}
 	deny := watchAccessVisibility{} // zero value: nothing visible
 	n := watchevents.Notification{
 		ItemID: "item-1", CollectionID: "coll-1",
 		Kind: watchevents.KindAssignment, AssignedUserID: "user-1",
 	}
 	if watchNotificationVisible(watches, deny, "user-1", n) {
-		t.Fatal("expected an assignment-to-you notification to be denied when the caller has no current access to the item's collection")
+		t.Fatal("expected a watch-matched assignment notification to be denied when the caller has no current access to the item's collection")
 	}
 
 	allow := watchAccessVisibility{visibleCollIDs: map[string]bool{"coll-1": true}}
@@ -688,6 +773,19 @@ func TestWatchNotificationVisible_AddressedToYouStillGatedByAccess(t *testing.T)
 // collection access, so this needs no revocation timing at all, just an
 // ordinary assignment. The addressed-to-you path used to deliver it
 // anyway with zero access check.
+//
+// Honest limitation after IDEA-2544 Phase 2 (TASK-2551), stated rather
+// than left for a reader to assume otherwise (team CONVE-12): the
+// restricted member now has TWO independent reasons not to receive this
+// assignment — no access to "tasks" AND no watch on the item — and this
+// test cannot separate them, because loadWatchPredicates drops watches
+// on inaccessible items before the visibility check ever runs, so the
+// setup that would isolate the access gate is unreachable over HTTP. It
+// is kept as an end-to-end guard that the leak stays closed, not as
+// evidence of WHICH gate closes it; the discriminating coverage for that
+// is TestWatchNotificationVisible_AssignmentStillGatedByAccess (unit,
+// watch present) and the mid-stream revocation tests in
+// handlers_watch_vis_cache_test.go.
 func TestWatchEventsStream_AssignmentOutsideMemberCollectionAccessDenied(t *testing.T) {
 	t.Parallel()
 	srv := testServerWithWatchEvents(t)

--- a/internal/server/handlers_watch_notify.go
+++ b/internal/server/handlers_watch_notify.go
@@ -43,15 +43,21 @@ import (
 //
 // Known limitation (flagged, not fixed, in Phase 1): unlike the existing
 // SSE/webhook bulk path (publishBulkItemsEvent), this does NOT collapse
-// N per-item bulk mutations into one batch notification. A "bulk-assign
-// 50 items to me" would surface 50 individual assignment notifications
+// N per-item bulk mutations into one batch notification. A bulk mutation
+// touching 50 watched items still surfaces 50 individual notifications
 // to the plugin monitor in a burst — in tension with PLAN-2469's noise-
 // discipline principle. Each notification is still correctly scoped by
-// the caller's own watches/addressed-to-you filter (a fundamentally
-// narrower audience than the workspace-wide SSE firehose the existing
-// batching was built to protect), so this is a burst-noise concern, not
-// a leak — deferred rather than building ad-hoc coalescing beyond what
-// DOC-2479 specs.
+// the caller's own watch filter (a fundamentally narrower audience than
+// the workspace-wide SSE firehose the existing batching was built to
+// protect), so this is a burst-noise concern, not a leak — deferred
+// rather than building ad-hoc coalescing beyond what DOC-2479 specs.
+//
+// IDEA-2544 Phase 2 (TASK-2551) shrank the worst case: the motivating
+// example was "bulk-assign 50 items to me", which sprayed 50
+// addressed-to-you notifications at someone who had asked for none of
+// them. Assignment no longer delivers that way, so the remaining burst
+// requires 50 items the caller explicitly watched — noise they opted
+// into, one notification per fact they asked to hear about.
 func (s *Server) publishWatchNotifications(workspaceID string, updated *models.Item, actor, actorName string) {
 	if s.watchEvents == nil || updated == nil || updated.LastMutation == nil {
 		return

--- a/internal/server/handlers_watch_vis_cache_test.go
+++ b/internal/server/handlers_watch_vis_cache_test.go
@@ -208,29 +208,81 @@ func TestWatchEventsStream_StopsDeliveringAfterUserDisabled(t *testing.T) {
 // user kept receiving previously-visible content through the whole
 // error window. Reproduces this with a forced, persistent watch-list
 // reload fault (via the watchPredicatesLoadFault test seam) active
-// across the SAME tick the connected user is disabled on, and asserts
-// the addressed-to-you delivery path (which depends only on visCache,
-// never on the watch list) is denied anyway — proving reset() now runs
-// unconditionally rather than being coupled to the reload's success.
+// across the SAME tick the connected user's access is narrowed, and
+// asserts delivery for the now-invisible item is denied anyway —
+// proving reset() runs unconditionally rather than being coupled to the
+// reload's success.
 //
-// Uses "disabled" rather than "demoted admin" for the actor under test:
-// the admin-bypass path requires cookie-session auth (BUG-1616 is
-// bearer-vs-cookie gated), which this bearer-token HTTP/SSE test
-// harness doesn't exercise — round 3's TestWatchVisCache_DeniesAfterAdminDemotion
-// already covers visCache's OWN demotion handling directly at the unit
-// level. This test is about the CALLER's ordering bug in
-// handleWatchEventsStream's reval branch, not about re-proving
-// refreshUser's per-condition correctness, and "disabled" exercises the
-// identical reset()-must-run-unconditionally code path.
+// Two things this test has to keep true at once, and how it does it:
+//
+//   - The probe must ride WATCH-MATCHED delivery. It used to ride
+//     addressed-to-you assignment, which IDEA-2544 Phase 2 (TASK-2551)
+//     deleted; push, the surviving addressed path, is self-addressed
+//     only, so there is no way for a second actor to publish addressed
+//     traffic at a user whose access is being revoked underneath them.
+//   - A watch-matched probe brings a SECOND mechanism that produces the
+//     same silence: once maxConsecutiveWatchReloadFailures is crossed,
+//     the handler clears the watch set wholesale (round 5 finding 1,
+//     covered by the test below). A bare "nothing arrived" assertion
+//     would pass on that alone (team CONVE-12). The control leg closes
+//     it: a watch on an item in a STILL-granted collection must keep
+//     delivering in the same window, which is only possible while the
+//     watch set is still live — so the revoked item's silence can only
+//     be visCache.
+//
+// Uses collection-access revocation rather than "disabled" (round 4's
+// original vehicle) because a disabled user denies everything, control
+// leg included. Same reset()-must-run-unconditionally code path:
+// visCache.reset() re-derives per-workspace visibility AND re-fetches
+// the user. TestWatchEventsStream_StopsDeliveringAfterUserDisabled above
+// keeps the disabled-user path covered end to end, and
+// TestWatchVisCache_DeniesAfterUserDisabled covers refreshUser directly.
 func TestWatchEventsStream_RevalStillDeniesWhenWatchListReloadErrors(t *testing.T) {
 	// Deliberately NOT t.Parallel() — mutates watchListRevalInterval,
 	// same rationale as TestWatchEventsStream_StopsDeliveringAfterUserDisabled above.
 	srv := testServerWithWatchEvents(t)
-	slug, item, tok, user := setupWatchTestUser(t, srv)
+	slug := createWSWithCollections(t, srv)
 
+	// 200ms rather than the 50ms its siblings use, deliberately: the
+	// control leg below is only meaningful while the watch set is still
+	// live, and the handler clears it after maxConsecutiveWatchReloadFailures
+	// consecutive faulting ticks. One tick (300ms sleep) is enough to
+	// prove reset() ran; the bound needs three (600ms+), leaving a wide
+	// margin before the second mechanism could start producing the same
+	// silence. At 50ms the two were ~30ms apart and the control leg lost
+	// the race under ordinary scheduling.
 	origInterval := watchListRevalInterval
-	watchListRevalInterval = 50 * time.Millisecond
+	watchListRevalInterval = 200 * time.Millisecond
 	t.Cleanup(func() { watchListRevalInterval = origInterval })
+
+	// A second collection, which the member KEEPS access to when
+	// "tasks" is revoked below — it hosts the control item.
+	rr := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections", map[string]interface{}{
+		"name": "Still Granted", "icon": "doc",
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create second collection: %d %s", rr.Code, rr.Body.String())
+	}
+	var grantedColl models.Collection
+	parseJSON(t, rr, &grantedColl)
+
+	// Both items seeded BEFORE any user exists, while doRequest's
+	// fresh-install auth bypass still applies.
+	rr = doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections/tasks/items",
+		map[string]interface{}{"title": "Soon invisible", "fields": `{"status":"open"}`})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("seed revoked-collection item: %d %s", rr.Code, rr.Body.String())
+	}
+	var revokedItem models.Item
+	parseJSON(t, rr, &revokedItem)
+
+	rr = doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections/"+grantedColl.Slug+"/items",
+		map[string]interface{}{"title": "Stays visible", "fields": "{}"})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("seed granted-collection item: %d %s", rr.Code, rr.Body.String())
+	}
+	var controlItem models.Item
+	parseJSON(t, rr, &controlItem)
 
 	ws, err := srv.store.GetWorkspaceBySlug(slug)
 	if err != nil {
@@ -243,25 +295,49 @@ func TestWatchEventsStream_RevalStillDeniesWhenWatchListReloadErrors(t *testing.
 		t.Fatalf("create actor: %v", err)
 	}
 	if err := srv.store.AddWorkspaceMember(ws.ID, actor.ID, "owner"); err != nil {
-		t.Fatalf("AddWorkspaceMember: %v", err)
+		t.Fatalf("AddWorkspaceMember (actor): %v", err)
 	}
 	actorTok, err := srv.store.CreateAPIToken(actor.ID, models.APITokenCreate{Name: "reval-fault-actor-test"}, 0, 0)
 	if err != nil {
-		t.Fatalf("CreateAPIToken: %v", err)
+		t.Fatalf("CreateAPIToken (actor): %v", err)
+	}
+
+	// The connected user: an ordinary member (no collection_access row,
+	// so full workspace access) until the revocation below.
+	member, err := srv.store.CreateUser(models.UserCreate{
+		Email: "reval-fault-member@example.com", Name: "Member", Password: "pw-test-12345",
+	})
+	if err != nil {
+		t.Fatalf("create member: %v", err)
+	}
+	if err := srv.store.AddWorkspaceMember(ws.ID, member.ID, "editor"); err != nil {
+		t.Fatalf("AddWorkspaceMember (member): %v", err)
+	}
+	memberTok, err := srv.store.CreateAPIToken(member.ID, models.APITokenCreate{Name: "reval-fault-member-test"}, 0, 0)
+	if err != nil {
+		t.Fatalf("CreateAPIToken (member): %v", err)
+	}
+	// Watches created before connecting — the map is loaded once at
+	// connect time, and the forced fault below stops it reloading.
+	if _, err := srv.store.CreateWatch(ws.ID, member.ID, revokedItem.ID, ""); err != nil {
+		t.Fatalf("CreateWatch (revoked item): %v", err)
+	}
+	if _, err := srv.store.CreateWatch(ws.ID, member.ID, controlItem.ID, ""); err != nil {
+		t.Fatalf("CreateWatch (control item): %v", err)
 	}
 
 	ts := httptest.NewServer(srv)
 	defer ts.Close()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	ch := connectWatchStream(ctx, t, ts.URL, tok.Token)
+	ch := connectWatchStream(ctx, t, ts.URL, memberTok.Token)
 	waitForWatchEvent(t, ch, 3*time.Second) // connected
 
-	// Baseline: addressed-to-you delivery works before any of this.
-	rr := bearerJSON(t, srv, "PATCH", "/api/v1/workspaces/"+slug+"/items/"+item.Slug, actorTok.Token,
-		map[string]interface{}{"assigned_user_id": user.ID})
+	// Baseline: watch-matched delivery works before any of this.
+	rr = bearerJSON(t, srv, "PATCH", "/api/v1/workspaces/"+slug+"/items/"+revokedItem.Slug, actorTok.Token,
+		map[string]interface{}{"fields": `{"status":"done"}`})
 	if rr.Code != http.StatusOK {
-		t.Fatalf("assign item (baseline): %d %s", rr.Code, rr.Body.String())
+		t.Fatalf("update revoked-collection item (baseline): %d %s", rr.Code, rr.Body.String())
 	}
 	waitForWatchEvent(t, ch, 3*time.Second)
 
@@ -272,31 +348,38 @@ func TestWatchEventsStream_RevalStillDeniesWhenWatchListReloadErrors(t *testing.
 	// field here would race.
 	loadFault := func() error { return errFakeWatchListReload }
 	srv.watchPredicatesLoadFault.Store(&loadFault)
-	// ...AND disable the connected user, in the SAME window.
-	if err := srv.store.DisableUser(user.ID); err != nil {
-		t.Fatalf("DisableUser: %v", err)
+	// ...AND narrow the connected member's access, in the SAME window:
+	// everything except the collection holding the control item.
+	if err := srv.store.SetMemberCollectionAccess(ws.ID, member.ID, "specific", []string{grantedColl.ID}); err != nil {
+		t.Fatalf("SetMemberCollectionAccess: %v", err)
 	}
-	time.Sleep(150 * time.Millisecond) // several reval ticks, all with the forced fault active
+	time.Sleep(300 * time.Millisecond) // one reval tick with the forced fault active, well short of the clear-the-watch-set bound
 
-	rr = bearerJSON(t, srv, "PATCH", "/api/v1/workspaces/"+slug+"/items/"+item.Slug, actorTok.Token,
-		map[string]interface{}{"assigned_user_id": actor.ID})
+	// Must NOT deliver: the collection is no longer visible to the
+	// member, and reset() has to have run despite the reload fault for
+	// the handler to know that.
+	rr = bearerJSON(t, srv, "PATCH", "/api/v1/workspaces/"+slug+"/items/"+revokedItem.Slug, actorTok.Token,
+		map[string]interface{}{"fields": `{"status":"in-progress"}`})
 	if rr.Code != http.StatusOK {
-		t.Fatalf("reassign away: %d %s", rr.Code, rr.Body.String())
+		t.Fatalf("update revoked-collection item (post-revocation): %d %s", rr.Code, rr.Body.String())
 	}
-	rr = bearerJSON(t, srv, "PATCH", "/api/v1/workspaces/"+slug+"/items/"+item.Slug, actorTok.Token,
-		map[string]interface{}{"assigned_user_id": user.ID})
-	if rr.Code != http.StatusOK {
-		t.Fatalf("re-assign (post-disable): %d %s", rr.Code, rr.Body.String())
+	// Control: still-granted collection, same stream, same window — must
+	// deliver, proving the watch set is still live and the silence above
+	// is visCache's doing rather than a cleared watch map.
+	rr = bearerJSON(t, srv, "POST", "/api/v1/workspaces/"+slug+"/items/"+controlItem.Slug+"/comments", actorTok.Token,
+		map[string]interface{}{"body": "control nudge"})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("comment on control item: %d %s", rr.Code, rr.Body.String())
 	}
 
-	select {
-	case ev, ok := <-ch:
-		if ok {
-			t.Fatalf("expected no delivery for a disabled user even though the watch-list reload is also failing every tick, got %+v (data: %s)", ev, ev.Data)
-		}
-	case <-time.After(1 * time.Second):
-		// No event arrived — correct: visCache.reset() (and its
-		// fail-closed refreshUser) ran despite the reload fault.
+	ev := waitForWatchEvent(t, ch, 3*time.Second)
+	var payload watchEventPayload
+	if err := json.Unmarshal([]byte(ev.Data), &payload); err != nil {
+		t.Fatalf("parse payload: %v", err)
+	}
+	if payload.ItemRef != controlItem.Ref {
+		t.Fatalf("expected the still-granted item's notification %q, got %q — the revoked collection's item leaked despite the access change (visCache.reset() did not run on the faulting reval tick)",
+			controlItem.Ref, payload.ItemRef)
 	}
 }
 
@@ -317,15 +400,21 @@ func (*testWatchListReloadError) Error() string { return "forced watch-list relo
 // visCache gates current ACCESS, not whether a watch still legitimately
 // exists. Forces maxConsecutiveWatchReloadFailures+1 consecutive
 // failures via the fault seam and asserts: watch-matched delivery stops
-// once the bound is crossed, addressed-to-you delivery is unaffected
-// throughout (it never depended on the watch list), and watch-matched
-// delivery RESUMES once the fault is cleared and a reload succeeds
-// again — this is a bounded outage response, not a one-way ratchet.
+// once the bound is crossed, ADDRESSED delivery is unaffected throughout
+// (it never depended on the watch list), and watch-matched delivery
+// RESUMES once the fault is cleared and a reload succeeds again — this
+// is a bounded outage response, not a one-way ratchet.
+//
+// The addressed leg is a PUSH. It was an assignment-to-self until
+// IDEA-2544 Phase 2 (TASK-2551) dropped assignment from the addressed
+// stream; KindPush is now the only addressed kind, and it carries the
+// same property the leg is here to prove — delivery gated by
+// TargetUserID and visCache alone, never by the watch map.
 func TestWatchEventsStream_WatchSetClearedAfterPersistentReloadFailures(t *testing.T) {
 	// Deliberately NOT t.Parallel() — mutates watchListRevalInterval,
 	// same rationale as the other reval-interval tests in this file.
 	srv := testServerWithWatchEvents(t)
-	slug, item, tok, user := setupWatchTestUser(t, srv)
+	slug, item, tok, _ := setupWatchTestUser(t, srv)
 
 	origInterval := watchListRevalInterval
 	watchListRevalInterval = 30 * time.Millisecond
@@ -364,12 +453,13 @@ func TestWatchEventsStream_WatchSetClearedAfterPersistentReloadFailures(t *testi
 		t.Fatalf("update item (during outage): %d %s", rr.Code, rr.Body.String())
 	}
 
-	// Addressed-to-you: MUST still deliver — it depends only on
-	// visCache, which round 4 already decoupled from the reload outcome.
-	rr = bearerJSON(t, srv, "PATCH", "/api/v1/workspaces/"+slug+"/items/"+item.Slug, tok.Token,
-		map[string]interface{}{"assigned_user_id": user.ID})
+	// Addressed (push): MUST still deliver — it depends only on
+	// TargetUserID and visCache, which round 4 already decoupled from
+	// the reload outcome.
+	rr = bearerJSON(t, srv, "POST", "/api/v1/workspaces/"+slug+"/items/"+item.Slug+"/push", tok.Token,
+		map[string]interface{}{"message": "still addressed during the outage"})
 	if rr.Code != http.StatusOK {
-		t.Fatalf("assign item (during outage): %d %s", rr.Code, rr.Body.String())
+		t.Fatalf("push item (during outage): %d %s", rr.Code, rr.Body.String())
 	}
 
 	ev := waitForWatchEvent(t, ch, 3*time.Second)
@@ -377,8 +467,8 @@ func TestWatchEventsStream_WatchSetClearedAfterPersistentReloadFailures(t *testi
 	if err := json.Unmarshal([]byte(ev.Data), &payload); err != nil {
 		t.Fatalf("parse payload: %v", err)
 	}
-	if payload.Kind != watchevents.KindAssignment {
-		t.Fatalf("expected the assignment notification (watch-matched delivery should have been suppressed by the outage), got kind %q: %+v", payload.Kind, payload)
+	if payload.Kind != watchevents.KindPush {
+		t.Fatalf("expected the push notification (watch-matched delivery should have been suppressed by the outage), got kind %q: %+v", payload.Kind, payload)
 	}
 
 	// Recovery: clear the fault, let a reload succeed, and confirm

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1147,7 +1147,7 @@ func (s *Server) setupRouter() {
 
 		// User-scoped watch/nudge event stream (TASK-2533, DOC-2479).
 		// Unlike /api/v1/events above, this is NOT workspace-scoped — a
-		// caller's watches and addressed-to-you assignments can span
+		// caller's watches and addressed pushes can span
 		// every workspace they belong to. Lives alongside the other SSE
 		// endpoint for the same "outside jsonContentType, inherits auth"
 		// reason.

--- a/internal/watchevents/watchevents.go
+++ b/internal/watchevents/watchevents.go
@@ -79,9 +79,15 @@ type Notification struct {
 	ActorName string
 	Summary   string
 	// AssignedUserID is populated on Kind == KindAssignment with the
-	// item's NEW assignee (empty string = unassigned). The
-	// addressed-to-you check compares this directly against the
-	// connected caller's user ID — see server.sseWatchVisible.
+	// item's NEW assignee (empty string = unassigned). It no longer gates
+	// delivery: IDEA-2544 Phase 2 (TASK-2551) dropped assignment from the
+	// addressed-to-you stream entirely — assignment is bookkeeping, push
+	// is dispatch — so a KindAssignment notification now reaches a caller
+	// only via an explicit watch on the item, exactly like every other
+	// item-level fact (see server.watchNotificationVisible). Producers
+	// keep populating it: it's the assignment's payload, it costs
+	// nothing, and any future opt-in re-addressing (a per-watch flag, a
+	// config key) needs it in place to be a consumer-side change only.
 	AssignedUserID string
 	// TargetUserID is IDEA-2544's generalized addressed-to field:
 	// populated on Kind == KindPush with the user the push is addressed


### PR DESCRIPTION
Phase 2 of IDEA-2544 (push-to-harness). Server-side only; no plugin change (plugin-visible text belongs to Phase 3 + a version bump, since installed plugins are version-pinned at install).

## What changes

`watchNotificationVisible` loses its `KindAssignment` addressed-to-you early-return. An assignment notification now falls through to the watch-map check like any other item-level fact, so it reaches a caller only via an explicit watch — which is exactly what an unconditional watch already promises.

Decided by Dave (day-33): drop entirely, no opt-in flag, no config key. Assignment is bookkeeping (who owns this); push is dispatch (where attention goes now). The old behaviour meant one triage session assigning N items sprayed N notifications into every open session of the assignee.

Producers are untouched (`handlers_items.go`, `handlers_watch_notify.go` still publish) and `Notification.AssignedUserID` is still populated, so re-introducing an opt-in later is a consumer-side change only. `KindPush` is now the only addressed kind.

## Tests

Six tests rode the deleted path. All reworked, none deleted:

- `AddressedToYou_Assignment` -> `AssignmentIsNotAddressedToYou`, inverted, with a watched control item so a merely-silent stream cannot pass it (both legs publish on the same bus in order, so no sleep and no timing window).
- `BulkAssignFires` keeps its producer-coverage claim; only the delivery vehicle changes to an explicit watch.
- `AddressedToYouIgnoresWatchList` -> `AssignmentToYouNeedsAWatch` (deny with no watch, deliver with one, same notification both legs).
- `AddressedToYouStillGatedByAccess` -> `AssignmentStillGatedByAccess`, now with a watch present so the access gate is actually the variable under test.
- `WatchSetClearedAfterPersistentReloadFailures`: addressed leg swapped from assignment-to-self to a push (same watch-map-independent property).
- `RevalStillDeniesWhenWatchListReloadErrors`: rebuilt on collection-access revocation with a still-granted control item. Push could not be the vehicle (self-addressed only, and the test's subject is a user losing access), and a bare watch-matched probe has a second mechanism producing the same silence once the clear-the-watch-set bound is crossed — the control leg is what discriminates. Reval interval 50ms -> 200ms; at 50ms the bound landed ~30ms behind the assertion and the control leg lost the race.

New: `AssignmentToSomeoneElseVisibleToWatcher`, pinning the asymmetry this change creates — a push stays exclusive of watch-matched delivery, an assignment does not.

Recorded honestly in-code: `AssignmentOutsideMemberCollectionAccessDenied` now has two independent reasons to deny and cannot separate them (loadWatchPredicates drops watches on inaccessible items, so the isolating setup is unreachable over HTTP). Kept as an end-to-end guard, not as access-gate evidence.

## Verification

Gate matrix:

- build: green
- make lint: 0 issues
- go test ./...: green
- make test-pg: green (exit 0, zero FAIL lines) — run despite no store SQL change, because the reworked tests are timing-sensitive
- web: not applicable, no web changes
- Codex review: pending

Mutation-tested three ways, each revert grep-verified:

1. restore the old addressed branch -> `AssignmentToYouNeedsAWatch` + `AssignmentIsNotAddressedToYou` fail
2. make assignment exclusive addressed-only (push-style return) -> those two plus `AssignmentToSomeoneElseVisibleToWatcher` fail
3. couple `visCache.reset()` to reload success -> `RevalStillDeniesWhenWatchListReloadErrors` fails with the leak message, not a timeout

Live, against a sandboxed server on an alternate port with its own HOME/DB, through the real `pad watch --stream --for-session` monitor:

- assign a fresh, unwatched item to the connected user -> monitor silent
- push the same item -> exactly one line, kind push
- assign a WATCHED item -> assignment notification delivered (so the producer still fires and only addressed delivery is gone)

## Found while verifying, not fixed here

`PATCH .../items/{slug}` with `{"assigned_user_id": ""}` returns 500 (`FOREIGN KEY constraint failed`) instead of unassigning. Pre-existing, unrelated to this change; filed separately.


Filed as BUG-2566.

## Deferred by scope

Codex round 1's only finding (P2): `plugin/monitors/monitors.json:5` and `plugin/skills/pad/SKILL.md:331,336` still describe assignment as addressed-to-you traffic, which this change makes untrue. Deliberately not fixed here — installed plugins are version-pinned at install (live-proven day-33), so plugin-visible text reaches nobody without a version bump, and TASK-2564 (PLAN-2558 S6) owns the wording and the bump together. Now noted in code beside the deleted branch, and recorded on TASK-2564 with the exact line refs.

Codex round 2: CLEAN.

## CI note

`CI / Go` is expected to fail on `Run govulncheck` — 8 Go standard-library advisories (`net@go1.26.5`, fixed in `go1.26.6`) that turned main red at `da6ce642`, before this branch existed. Pre-existing and not this PR's; tracked as BUG-2565. Judge this branch on Go tests, Web, Smoke, and Nix.
