### PR TITLE
fix(ci): build with go1.26.6 to clear the govulncheck gate (BUG-2565)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,24 +179,25 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        # No GOTOOLCHAIN=auto step here, unlike every other Go job in this
+        # file, and the reason is worth stating because the asymmetry looks
+        # like an oversight: `go-version-file` makes setup-go PARSE go.mod
+        # itself, and v7's parser prefers the `toolchain` directive over the
+        # `go` directive, so it installs go1.26.6 (BUG-2565) directly. The
+        # GOTOOLCHAIN=local it then exports is satisfied by that install —
+        # nothing left to fetch. The other jobs pass `go-version: "1.26"`,
+        # which never reads go.mod at all, so they genuinely need `auto` to
+        # pick the toolchain line up at build time.
+        #
+        # The one way this silently regresses: setup-go's parser falls back
+        # to the `go` directive when GOTOOLCHAIN is ALREADY `local` in the
+        # environment at parse time (installer.ts parseGoVersionFile). So if
+        # a job- or workflow-level `env: GOTOOLCHAIN: local` is ever added
+        # above this step, these smoke binaries drop to the 1.26.5 floor
+        # while everything else ships 1.26.6 — no red, just coverage that
+        # quietly stops matching the artifact.
         with:
           go-version-file: go.mod
-
-      - name: Allow Go to fetch the toolchain go.mod pins
-        # This job never needed the override before: `go-version-file` reads
-        # go.mod's `go` directive, so setup-go installed exactly the floor and
-        # GOTOOLCHAIN=local had nothing to block. BUG-2565's `toolchain
-        # go1.26.6` changes that — under `local` this job would keep smoke-
-        # testing a 1.26.5 binary while every other job (and every release
-        # artifact) moved to 1.26.6, which is the pins-disagree failure mode
-        # rather than a gate failure: nothing here goes red, the platform
-        # smoke coverage just silently stops matching what ships.
-        #
-        # pwsh, not bash, in this job (see `defaults.run.shell` above), so
-        # this uses the documented Out-File form with an explicit encoding
-        # rather than `>>` — PowerShell's redirection encoding is version-
-        # dependent and a UTF-16 $GITHUB_ENV line is silently ignored.
-        run: '"GOTOOLCHAIN=auto" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8'
 
       - name: Create web build placeholder
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,15 @@ jobs:
         # its manifest (1.26.4 here), so every `go` command fails with
         # "go.mod requires go >= 1.26.5 (running go 1.26.4)". Written AFTER
         # setup-go so it wins the $GITHUB_ENV last-write; `auto` lets Go pull
-        # 1.26.5 on demand. Added after #896 raised the go.mod floor.
+        # what go.mod asks for on demand. Added after #896 raised the go.mod
+        # floor.
+        #
+        # Load-bearing for the govulncheck step below as of BUG-2565: go.mod
+        # also carries `toolchain go1.26.6`, which is what actually gets
+        # stamped into the scanned binary and clears 8 reachable stdlib
+        # advisories. `auto` is what honours that line — under `local` the
+        # build silently falls back to whatever patch setup-go installed and
+        # the gate goes red again.
         run: echo "GOTOOLCHAIN=auto" >> "$GITHUB_ENV"
 
       - name: Create web build placeholder for embed
@@ -261,7 +269,8 @@ jobs:
 
       - name: Allow Go to fetch the toolchain go.mod pins
         # See the identical step in the `go` job — setup-go pins
-        # GOTOOLCHAIN=local, blocking the 1.26.5 fetch go.mod requires.
+        # GOTOOLCHAIN=local, blocking the toolchain fetch go.mod requires
+        # (`go 1.26.5` floor, `toolchain go1.26.6` per BUG-2565).
         run: echo "GOTOOLCHAIN=auto" >> "$GITHUB_ENV"
 
       - name: Create web build placeholder for embed
@@ -358,8 +367,9 @@ jobs:
 
       - name: Allow Go to fetch the toolchain go.mod pins
         # See the identical step in the `go` job — setup-go pins
-        # GOTOOLCHAIN=local, blocking the 1.26.5 fetch go.mod requires
-        # (the "Build pad binary" step below fails without this).
+        # GOTOOLCHAIN=local, blocking the toolchain fetch go.mod requires
+        # (`go 1.26.5` floor, `toolchain go1.26.6` per BUG-2565; the
+        # "Build pad binary" step below fails without this).
         run: echo "GOTOOLCHAIN=auto" >> "$GITHUB_ENV"
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,6 +182,22 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Allow Go to fetch the toolchain go.mod pins
+        # This job never needed the override before: `go-version-file` reads
+        # go.mod's `go` directive, so setup-go installed exactly the floor and
+        # GOTOOLCHAIN=local had nothing to block. BUG-2565's `toolchain
+        # go1.26.6` changes that — under `local` this job would keep smoke-
+        # testing a 1.26.5 binary while every other job (and every release
+        # artifact) moved to 1.26.6, which is the pins-disagree failure mode
+        # rather than a gate failure: nothing here goes red, the platform
+        # smoke coverage just silently stops matching what ships.
+        #
+        # pwsh, not bash, in this job (see `defaults.run.shell` above), so
+        # this uses the documented Out-File form with an explicit encoding
+        # rather than `>>` — PowerShell's redirection encoding is version-
+        # dependent and a UTF-16 $GITHUB_ENV line is silently ignored.
+        run: '"GOTOOLCHAIN=auto" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8'
+
       - name: Create web build placeholder
         run: |
           New-Item -ItemType Directory -Force web/build | Out-Null

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,9 +51,12 @@ jobs:
 
       - name: Allow Go to fetch the toolchain go.mod pins
         # actions/setup-go pins GOTOOLCHAIN=local, which blocks the toolchain
-        # go.mod requires (`go 1.26.5`) from being fetched. `auto`, written
-        # after setup-go so it wins the $GITHUB_ENV last-write, lets Go pull
-        # it on demand. Mirrors the CI workflow; see #896.
+        # go.mod requires (`go 1.26.5` floor, `toolchain go1.26.6`) from being
+        # fetched. `auto`, written after setup-go so it wins the $GITHUB_ENV
+        # last-write, lets Go pull it on demand. Mirrors the CI workflow; see
+        # #896. As of BUG-2565 this also decides which stdlib the RELEASED
+        # binaries carry — under `local` they would ship the 1.26.5 stdlib and
+        # its 8 reachable advisories.
         run: echo "GOTOOLCHAIN=auto" >> "$GITHUB_ENV"
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,19 @@ module github.com/PerpetualSoftware/pad
 
 go 1.26.5
 
+// BUG-2565: build with go1.26.6, which fixes 8 reachable standard-library
+// advisories (GO-2026-5942 and friends — net.Resolver.LookupCNAME,
+// http.Client.Do) that turned CI's govulncheck gate red on 2026-08-13
+// without any commit causing it. A `toolchain` line, not a raise of the
+// `go` directive above, on purpose: GOTOOLCHAIN=auto (every GitHub
+// Actions job sets it) fetches 1.26.6 and stamps it into the binary,
+// while builders pinned to GOTOOLCHAIN=local ignore this line and keep
+// satisfying the 1.26.5 floor. nixpkgs nixos-26.05 still ships go 1.26.5,
+// so raising the floor would break the Nix build outright; see BUG-2567
+// for the Nix-packaged binary, which stays on 1.26.5 until nixpkgs
+// catches up.
+toolchain go1.26.6
+
 require (
 	github.com/BurntSushi/toml v1.6.0
 	github.com/JohannesKaufmann/html-to-markdown/v2 v2.5.2


### PR DESCRIPTION
main has been red since `da6ce642` (2026-08-13 22:41Z) on `CI / Go` → `Run govulncheck`. Not a test, lint or build failure, and not that commit's doing — it touches no dependency and no toolchain pin. A vuln-DB entry published in the window turned the gate red with nobody committing anything, which is the failure mode a govulncheck gate has by design.

8 reachable Go standard-library advisories, all the same shape: `Found in: net@go1.26.5` / `Fixed in: net@go1.26.6` — GO-2026-5942 via `net.Resolver.LookupCNAME`, GO-2026-5026 via `http.Client.Do`, and friends. No dependency bump fixes a stdlib advisory; the toolchain has to move.

## Why a `toolchain` line and not a higher `go` directive

```
go 1.26.5
toolchain go1.26.6
```

Every GitHub Actions job in this repo exports `GOTOOLCHAIN=auto` explicitly (added in #896), so all of them fetch 1.26.6 and stamp it into the binary govulncheck scans. Builders pinned to `GOTOOLCHAIN=local` ignore the `toolchain` line and keep satisfying the unchanged 1.26.5 floor.

That matters because nixpkgs `nixos-26.05` — the channel this flake tracks — still ships go 1.26.5 (verified against the channel's `pkgs/development/compilers/go/1.26.nix`). Raising the floor to 1.26.6 would have failed the Nix build outright, in exchange for nothing govulncheck can see.

## What this deliberately leaves standing

The Nix-packaged binary still carries the 1.26.5 stdlib. Tracked as BUG-2567, with the two heavier options written down (point the flake at a channel that has 1.26.6, or override `go` in `nix/package.nix`) and deliberately not taken here — both are bigger than the advisory warrants inside a gate-unblocking fix.

Nothing currently scans the Nix artifact, so that gap is invisible to the gate that found the original problem. Said out loud rather than left implicit.

## Verification

- `make vuln` before: `Your code is affected by 8 vulnerabilities from the Go standard library.` (exit 3)
- `make vuln` after: `No vulnerabilities found.` (exit 0)
- Mechanism confirmed rather than inferred: `go version -m` on the built binary reads `go1.26.6`, so the fix is the stamp, not a scanner quirk. The unchanged tail — 1 vulnerability in an imported package, 2 in required modules, none called — is identical before and after, as predicted before running.
- `go build ./...` green · `make lint` 0 issues · `go test ./...` green, all on 1.26.6.
- Not verifiable locally (no nix on this box): the `Nix build & check` job. The expectation is that it is unaffected because nixpkgs' Go builder pins `GOTOOLCHAIN=local` — this PR's Nix job is the actual evidence for that claim.

Also updates the `GOTOOLCHAIN=auto` comments in both workflows to say what they are now protecting: under `local`, the build silently falls back to setup-go's patch and the gate goes red again, and released binaries would ship the vulnerable stdlib.

Fixes BUG-2565. Refs BUG-2567.
