### PR TITLE
feat(sessions): announce session identity on the event stream (PLAN-2558 S2, TASK-2560)

### DIFF
--- a/cmd/pad/cmd_watch.go
+++ b/cmd/pad/cmd_watch.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strings"
 	"syscall"
 	"text/tabwriter"
@@ -310,6 +311,45 @@ func monitorClient() (*cli.Client, error) {
 // deliberately not hoisted above it — so a workspace linked or a padd
 // brought up mid-session is picked up on the next retry without a
 // process restart.
+// monitorSessionIdentity describes THIS monitor process to the server's
+// presence registry (PLAN-2558 S2, TASK-2560): the working directory's
+// basename as a human-readable label, plus this process's own pid.
+//
+// WHY NOT READ ~/.pad/sessions/, given that this slice exists to give
+// `pad session register` a consumer. Because the monitor cannot tell
+// WHICH registry entry is its own session without guessing. The entries
+// are written by whatever process ran `pad session register` — an agent
+// harness, a different pid — and the only fields available to match on
+// are pid and cwd. Two agent sessions in the same checkout produce two
+// entries with identical cwd, and picking "the newest" would be a
+// coin flip that puts a wrong-but-confident name in the S5 target
+// picker. Process ancestry would settle it exactly, and is
+// platform-specific (this binary ships for macOS and Windows too), so
+// it is not a slice-S2 shape.
+//
+// The monitor's own cwd + pid are never wrong, and they answer the
+// question the label exists to answer: which project is this session
+// working in. The registry's remaining value — correlating a stream to
+// the agent session that spawned it — needs an identifier the harness
+// passes down, not a heuristic; that is worth doing when something
+// actually needs it, and worth NOT faking until then.
+//
+// Failures are silent by construction: os.Getwd can fail (a deleted
+// cwd), and the answer is an unlabelled session, not a dead monitor.
+// This whole file's contract is "print nothing, keep running" (see
+// runWatchMonitor's doc comment).
+func monitorSessionIdentity() cli.StreamSessionIdentity {
+	ident := cli.StreamSessionIdentity{PID: os.Getpid()}
+	if cwd, err := os.Getwd(); err == nil {
+		// filepath.Base("/") is "/" and Base("") is "." — neither names
+		// anything, so drop them rather than labelling a session "/".
+		if base := filepath.Base(cwd); base != "" && base != "." && base != string(filepath.Separator) {
+			ident.Label = base
+		}
+	}
+	return ident
+}
+
 func runWatchMonitor(ctx context.Context) error {
 	sigCtx, stop := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
 	defer stop()
@@ -342,7 +382,7 @@ func runWatchMonitor(ctx context.Context) error {
 			continue
 		}
 
-		req, err := client.NewWatchEventsStreamRequest(sigCtx, lastEventID)
+		req, err := client.NewWatchEventsStreamRequest(sigCtx, lastEventID, monitorSessionIdentity())
 		if err != nil {
 			attempt++
 			if !sleepOrDone(sigCtx, padddBackoff(attempt)) {

--- a/cmd/pad/cmd_watch_test.go
+++ b/cmd/pad/cmd_watch_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"io"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -239,5 +241,48 @@ func TestStreamWatchEvents_SyncRequiredThenFreshNotification(t *testing.T) {
 	lastID := streamWatchEvents(resp, "42")
 	if lastID != "99" {
 		t.Fatalf("expected the post-sync_required notification's id to be tracked, got %q", lastID)
+	}
+}
+
+// TestMonitorSessionIdentity_UsesCwdBasename is the privacy regression
+// for PLAN-2558 S2. The promise is that a session announces "docapp",
+// never "/home/someone/Dev/docapp" — the basename is what a picker
+// needs, while the full path additionally hands the server (and its
+// logs, and every consumer of GET /api/v1/sessions) a home directory
+// and usually an account name. That failure would be invisible until
+// somebody read a session list, which is exactly why it is pinned here
+// rather than trusted to the one-line implementation.
+func TestMonitorSessionIdentity_UsesCwdBasename(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "docapp")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	t.Chdir(dir)
+
+	ident := monitorSessionIdentity()
+	if ident.Label != "docapp" {
+		t.Fatalf("label = %q, want %q", ident.Label, "docapp")
+	}
+	if strings.ContainsRune(ident.Label, filepath.Separator) {
+		t.Fatalf("label must never contain a path separator, got %q", ident.Label)
+	}
+	if ident.PID != os.Getpid() {
+		t.Fatalf("pid = %d, want this process's own pid %d", ident.PID, os.Getpid())
+	}
+}
+
+// TestMonitorSessionIdentity_RootCwdIsUnlabelled covers the degenerate
+// directory: filepath.Base("/") is "/", which names nothing and would
+// put a bare separator in the picker. An unlabelled session is the
+// honest answer there — consumers already fall back to the id.
+func TestMonitorSessionIdentity_RootCwdIsUnlabelled(t *testing.T) {
+	t.Chdir(string(filepath.Separator))
+
+	ident := monitorSessionIdentity()
+	if ident.Label != "" {
+		t.Fatalf("expected no label at the filesystem root, got %q", ident.Label)
+	}
+	if ident.PID != os.Getpid() {
+		t.Fatalf("pid = %d, want %d — the pid is still worth sending", ident.PID, os.Getpid())
 	}
 }

--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -365,6 +365,29 @@ func (c *Client) ListWatches() ([]models.Watch, error) {
 	return result, c.get("/watches", &result)
 }
 
+// StreamSessionIdentity is what a monitor tells the server about itself
+// when it opens the event stream (PLAN-2558 S2, TASK-2560), so the
+// server's presence registry can name the session instead of showing an
+// opaque uuid.
+//
+// The two fields are the wire-safe half of what `pad session register`
+// records locally (internal/cli/session_registry.go). What is missing
+// is the point: MessagingSocketPath never leaves this machine, and the
+// cwd travels as a BASENAME, because "docapp" is what a session picker
+// needs while "/home/dave/Dev/docapp" additionally hands over a home
+// directory and an account name.
+//
+// Both fields are optional. A zero value produces the pre-S2 behaviour:
+// an unlabelled session that still receives every event.
+type StreamSessionIdentity struct {
+	// Label names the session for a human — the working directory's
+	// basename ("docapp"). The server sanitizes and truncates it.
+	Label string
+	// PID is this process's own pid, for telling two sessions with the
+	// same label apart.
+	PID int
+}
+
 // NewWatchEventsStreamRequest builds an authenticated GET request for
 // GET /api/v1/events/stream (TASK-2533), used by
 // `pad watch --stream --for-session`. Deliberately returns the request
@@ -373,8 +396,8 @@ func (c *Client) ListWatches() ([]models.Watch, error) {
 // c.streamClient (1h timeout, sized for bundle transfers) would
 // eventually kill it — the caller must supply its own zero-timeout
 // http.Client. lastEventID, when non-empty, is sent as Last-Event-ID for
-// resume.
-func (c *Client) NewWatchEventsStreamRequest(ctx context.Context, lastEventID string) (*http.Request, error) {
+// resume; ident, when non-zero, announces the session (S2).
+func (c *Client) NewWatchEventsStreamRequest(ctx context.Context, lastEventID string, ident StreamSessionIdentity) (*http.Request, error) {
 	req, err := c.newRequest("GET", "/events/stream", nil)
 	if err != nil {
 		return nil, err
@@ -384,6 +407,12 @@ func (c *Client) NewWatchEventsStreamRequest(ctx context.Context, lastEventID st
 	req.Header.Set("Cache-Control", "no-cache")
 	if lastEventID != "" {
 		req.Header.Set("Last-Event-ID", lastEventID)
+	}
+	if ident.Label != "" {
+		req.Header.Set("X-Pad-Session-Label", ident.Label)
+	}
+	if ident.PID > 0 {
+		req.Header.Set("X-Pad-Session-Pid", strconv.Itoa(ident.PID))
 	}
 	return req, nil
 }

--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -15,6 +15,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/PerpetualSoftware/pad/internal/models"
 )
@@ -408,13 +409,61 @@ func (c *Client) NewWatchEventsStreamRequest(ctx context.Context, lastEventID st
 	if lastEventID != "" {
 		req.Header.Set("Last-Event-ID", lastEventID)
 	}
-	if ident.Label != "" {
-		req.Header.Set("X-Pad-Session-Label", ident.Label)
+	if label := headerSafeLabel(ident.Label); label != "" {
+		req.Header.Set("X-Pad-Session-Label", label)
 	}
 	if ident.PID > 0 {
 		req.Header.Set("X-Pad-Session-Pid", strconv.Itoa(ident.PID))
 	}
 	return req, nil
+}
+
+// maxHeaderLabelLen bounds the label the client is willing to put on
+// the wire, in runes. It is deliberately looser than the server's own
+// cap (server.maxSessionLabelLen, 64): the server decides what a label
+// should LOOK like, while this only has to keep the request from being
+// absurd. Leaving the two independent means neither has to be kept in
+// sync with the other to stay correct.
+const maxHeaderLabelLen = 256
+
+// headerSafeLabel makes a label safe to put in an HTTP header value, or
+// returns "" if nothing usable survives.
+//
+// This is not belt-and-braces for the server's sanitizer — it fixes a
+// failure the server can never see. Unix directory names may contain
+// newlines, tabs and other control bytes ("doc\napp" is a legal
+// directory), and Go's http.Client REFUSES to send a request whose
+// header value contains one: Do returns "invalid header field value"
+// and the request never leaves. In the monitor that surfaces as a
+// connection error, which its retry loop treats like an unreachable
+// padd — so a user who happened to name a directory with a newline
+// would get no notifications at all, forever, silently, because the
+// monitor prints nothing by contract. Losing the label is a cosmetic
+// problem; losing the stream is not, and the cause would be invisible.
+//
+// Reproduced before fixing (a real directory, a real client) rather
+// than reasoned about: the client-side refusal is what makes this
+// unfixable server-side.
+func headerSafeLabel(label string) string {
+	if label == "" {
+		return ""
+	}
+	var b strings.Builder
+	b.Grow(len(label))
+	for _, r := range label {
+		// The server collapses whitespace and trims; the client's only
+		// job is to not build an unsendable request, so anything
+		// non-printable is simply dropped. Space itself is printable
+		// and legal in a header value, so it survives.
+		if unicode.IsPrint(r) {
+			b.WriteRune(r)
+		}
+	}
+	out := strings.TrimSpace(b.String())
+	if runes := []rune(out); len(runes) > maxHeaderLabelLen {
+		out = strings.TrimSpace(string(runes[:maxHeaderLabelLen]))
+	}
+	return out
 }
 
 func (c *Client) MoveItem(wsSlug, itemSlug string, input map[string]any) (*models.Item, error) {

--- a/internal/cli/client_stream_identity_test.go
+++ b/internal/cli/client_stream_identity_test.go
@@ -2,6 +2,9 @@ package cli
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -53,5 +56,94 @@ func TestNewWatchEventsStreamRequest_OmitsUnsetIdentity(t *testing.T) {
 	}
 	if _, ok := req.Header["X-Pad-Session-Pid"]; ok {
 		t.Fatal("expected no pid header at all for a zero identity")
+	}
+}
+
+// TestNewWatchEventsStreamRequest_UnsendableLabelStillConnects is the
+// regression for the failure Codex round 1 found on this PR, and the
+// reason it is asserted by DOING THE ROUND TRIP rather than by
+// inspecting the header: the bug was never about the header's contents.
+// Unix directory names may contain newlines ("doc\napp" is a legal
+// directory), Go's http.Client refuses to SEND a header value holding
+// one, and Do returns an error before anything reaches the server. In
+// the monitor that looks exactly like an unreachable padd, so its retry
+// loop backs off and tries again — forever, printing nothing, with the
+// user simply never receiving notifications. The server cannot defend
+// against a request that was never transmitted.
+//
+// A test that only checked the header value would pass against the
+// broken version too, since http.Header.Set stores anything; only
+// attempting the request distinguishes them.
+func TestNewWatchEventsStreamRequest_UnsendableLabelStillConnects(t *testing.T) {
+	t.Parallel()
+
+	var gotLabel string
+	var sawRequest bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawRequest = true
+		gotLabel = r.Header.Get("X-Pad-Session-Label")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := NewClientFromURL(srv.URL)
+	req, err := c.NewWatchEventsStreamRequest(context.Background(), "", StreamSessionIdentity{
+		Label: "doc\napp",
+		PID:   4242,
+	})
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request was not sendable — the monitor would retry forever and deliver nothing: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if !sawRequest {
+		t.Fatal("server never saw the request")
+	}
+	if gotLabel != "docapp" {
+		t.Fatalf("label = %q, want the control byte dropped (%q)", gotLabel, "docapp")
+	}
+}
+
+// TestHeaderSafeLabel covers the pieces the round trip above can't show
+// individually.
+func TestHeaderSafeLabel(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"ordinary", "docapp", "docapp"},
+		{"newline dropped", "doc\napp", "docapp"},
+		{"carriage return dropped", "doc\rapp", "docapp"},
+		{"tab dropped", "doc\tapp", "docapp"},
+		{"spaces survive — legal in a header value", "my project", "my project"},
+		{"surrounding space trimmed", "  docapp  ", "docapp"},
+		{"control-only becomes empty, so no header is sent at all", "\n\t\x00", ""},
+		{"non-ascii printable survives", "проект", "проект"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := headerSafeLabel(tc.in); got != tc.want {
+				t.Fatalf("headerSafeLabel(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestHeaderSafeLabel_BoundsLength(t *testing.T) {
+	t.Parallel()
+
+	got := headerSafeLabel(strings.Repeat("é", maxHeaderLabelLen+50))
+	if n := len([]rune(got)); n != maxHeaderLabelLen {
+		t.Fatalf("got %d runes, want %d", n, maxHeaderLabelLen)
 	}
 }

--- a/internal/cli/client_stream_identity_test.go
+++ b/internal/cli/client_stream_identity_test.go
@@ -1,0 +1,57 @@
+package cli
+
+import (
+	"context"
+	"testing"
+)
+
+// TestNewWatchEventsStreamRequest_AnnouncesIdentity covers PLAN-2558
+// S2's client half: the session identity has to reach the server as
+// request headers, because the presence registry fills from the stream
+// connection itself.
+func TestNewWatchEventsStreamRequest_AnnouncesIdentity(t *testing.T) {
+	t.Parallel()
+
+	c := NewClientFromURL("http://127.0.0.1:0")
+	req, err := c.NewWatchEventsStreamRequest(context.Background(), "", StreamSessionIdentity{
+		Label: "docapp",
+		PID:   4242,
+	})
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+
+	if got := req.Header.Get("X-Pad-Session-Label"); got != "docapp" {
+		t.Fatalf("label header = %q, want %q", got, "docapp")
+	}
+	if got := req.Header.Get("X-Pad-Session-Pid"); got != "4242" {
+		t.Fatalf("pid header = %q, want %q", got, "4242")
+	}
+	// The stream's pre-existing contract must survive the new parameter.
+	if got := req.Header.Get("Accept"); got != "text/event-stream" {
+		t.Fatalf("Accept header = %q, want text/event-stream", got)
+	}
+}
+
+// TestNewWatchEventsStreamRequest_OmitsUnsetIdentity pins absence
+// rather than emptiness. Sending `X-Pad-Session-Label: ""` would make
+// every unannounced client look like a client that announced nothing
+// useful — indistinguishable at the server, but noise on the wire and
+// an invitation for a future reader to treat "present but empty" as a
+// meaningful state.
+func TestNewWatchEventsStreamRequest_OmitsUnsetIdentity(t *testing.T) {
+	t.Parallel()
+
+	c := NewClientFromURL("http://127.0.0.1:0")
+	req, err := c.NewWatchEventsStreamRequest(context.Background(), "", StreamSessionIdentity{})
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+
+	if _, ok := req.Header["X-Pad-Session-Label"]; ok {
+		t.Fatal("expected no label header at all for a zero identity")
+	}
+	if _, ok := req.Header["X-Pad-Session-Pid"]; ok {
+		t.Fatal("expected no pid header at all for a zero identity")
+	}
+}

--- a/internal/server/handlers_sessions_test.go
+++ b/internal/server/handlers_sessions_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -205,5 +206,134 @@ func TestListSessions_IsSelfScoped(t *testing.T) {
 	}
 	if _, body := getSessions(t, ts.URL, tokB.Token); body.Count != 0 {
 		t.Fatalf("user B must not see user A's session, got count=%d sessions=%+v", body.Count, body.Sessions)
+	}
+}
+
+// TestListSessions_CarriesClientDeclaredIdentity is PLAN-2558 S2's
+// end-to-end leg: the label and pid a client announces on the stream
+// request come back on its own session row. Without this, S1's registry
+// is a count and S5's picker has nothing to show.
+//
+// The no-headers leg is not decoration. It is the compatibility
+// contract — a pre-S2 client (or any client that declines to say) must
+// still register, unlabelled, and still stream. Asserting only the
+// labelled case would pass equally well if the handler had started
+// REQUIRING the headers, which would silently drop every older monitor
+// out of presence.
+func TestListSessions_CarriesClientDeclaredIdentity(t *testing.T) {
+	t.Parallel()
+	srv := testServerWithPresence(t)
+	_, _, tok, _ := setupWatchTestUser(t, srv)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch := connectWatchStreamWithHeaders(ctx, t, ts.URL, tok.Token, map[string]string{
+		sessionLabelHeader: "docapp",
+		sessionPIDHeader:   "4242",
+	})
+	if ev := waitForWatchEvent(t, ch, 3*time.Second); ev.Type != "connected" {
+		t.Fatalf("expected 'connected', got %q", ev.Type)
+	}
+
+	status, body := getSessions(t, ts.URL, tok.Token)
+	if status != http.StatusOK {
+		t.Fatalf("expected 200, got %d", status)
+	}
+	if len(body.Sessions) != 1 {
+		t.Fatalf("expected exactly 1 live session, got %+v", body.Sessions)
+	}
+	if body.Sessions[0].Label != "docapp" {
+		t.Fatalf("label = %q, want %q — the client's announcement never reached the registry", body.Sessions[0].Label, "docapp")
+	}
+	if body.Sessions[0].PID != 4242 {
+		t.Fatalf("pid = %d, want 4242", body.Sessions[0].PID)
+	}
+}
+
+func TestListSessions_UnannouncedSessionStillRegisters(t *testing.T) {
+	t.Parallel()
+	srv := testServerWithPresence(t)
+	_, _, tok, _ := setupWatchTestUser(t, srv)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch := connectWatchStream(ctx, t, ts.URL, tok.Token) // no identity headers
+	if ev := waitForWatchEvent(t, ch, 3*time.Second); ev.Type != "connected" {
+		t.Fatalf("expected 'connected', got %q", ev.Type)
+	}
+
+	status, body := getSessions(t, ts.URL, tok.Token)
+	if status != http.StatusOK {
+		t.Fatalf("expected 200, got %d", status)
+	}
+	if len(body.Sessions) != 1 {
+		t.Fatalf("a client that announces nothing must still be listed, got %+v", body.Sessions)
+	}
+	if body.Sessions[0].Label != "" || body.Sessions[0].PID != 0 {
+		t.Fatalf("expected an unlabelled session, got label=%q pid=%d", body.Sessions[0].Label, body.Sessions[0].PID)
+	}
+	if body.Sessions[0].ID == "" {
+		t.Fatal("an unlabelled session still needs its server-generated id — that is what consumers fall back to")
+	}
+}
+
+// TestListSessions_HostileIdentityIsSanitizedOnTheWire checks the
+// sanitizer where it matters to a consumer: in the response body, not
+// just at the unit boundary. An unbounded label is a UI problem nobody
+// planned for, and a negative pid is a nonsense number in a picker.
+//
+// What this test deliberately does NOT try to send is a control
+// character. Go's server answers 400 Bad Request to a header value
+// containing one, before any handler runs (verified with a raw socket,
+// because Go's client refuses to send one so a normal client test
+// cannot tell the two refusals apart). So that arm of the sanitizer is
+// unreachable over HTTP and belongs to the unit tests in
+// session_identity_test.go, where it is covered as the defence in
+// depth it actually is. Asserting it here would have been a test that
+// passes because the transport refused the input, while reading as
+// though the sanitizer did the work.
+func TestListSessions_HostileIdentityIsSanitizedOnTheWire(t *testing.T) {
+	t.Parallel()
+	srv := testServerWithPresence(t)
+	_, _, tok, _ := setupWatchTestUser(t, srv)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// A tab (legal in a header value) plus a label far over the cap —
+	// both things a real client can genuinely put on the wire.
+	hostile := "evil\tproject" + strings.Repeat("x", maxSessionLabelLen*2)
+	ch := connectWatchStreamWithHeaders(ctx, t, ts.URL, tok.Token, map[string]string{
+		sessionLabelHeader: hostile,
+		sessionPIDHeader:   "-1",
+	})
+	if ev := waitForWatchEvent(t, ch, 3*time.Second); ev.Type != "connected" {
+		t.Fatalf("expected 'connected', got %q", ev.Type)
+	}
+
+	_, body := getSessions(t, ts.URL, tok.Token)
+	if len(body.Sessions) != 1 {
+		t.Fatalf("expected 1 session, got %+v", body.Sessions)
+	}
+	got := body.Sessions[0]
+	if strings.ContainsRune(got.Label, '\t') {
+		t.Fatalf("raw tab survived to the response body: %q", got.Label)
+	}
+	if !strings.HasPrefix(got.Label, "evil project") {
+		t.Fatalf("expected the tab collapsed to a single space, got %q", got.Label)
+	}
+	if len([]rune(got.Label)) > maxSessionLabelLen {
+		t.Fatalf("label of %d runes exceeded the %d cap: %q", len([]rune(got.Label)), maxSessionLabelLen, got.Label)
+	}
+	if got.PID != 0 {
+		t.Fatalf("a negative pid must land on the not-stated sentinel, got %d", got.PID)
 	}
 }

--- a/internal/server/handlers_watch_events.go
+++ b/internal/server/handlers_watch_events.go
@@ -138,10 +138,11 @@ func (s *Server) handleWatchEventsStream(w http.ResponseWriter, r *http.Request)
 	// nowhere-push this feature exists to prevent, but with a
 	// confident label on it.
 	//
-	// The label is empty until S2 (TASK-2560) teaches the client to
-	// carry its `pad session register` identity; a count needs no name.
+	// The identity is whatever the client claimed in its request
+	// headers (S2, TASK-2560) — sanitized, never verified, and empty
+	// for any client that doesn't say. See SessionIdentity.
 	if s.sessionPresence != nil {
-		sessionID := s.sessionPresence.Add(user.ID, "")
+		sessionID := s.sessionPresence.Add(user.ID, parseSessionIdentity(r))
 		defer s.sessionPresence.Remove(user.ID, sessionID)
 	}
 

--- a/internal/server/handlers_watch_events_test.go
+++ b/internal/server/handlers_watch_events_test.go
@@ -32,6 +32,15 @@ type watchSSEEvent struct {
 // token and returns a channel of parsed SSE events.
 func connectWatchStream(ctx context.Context, t *testing.T, baseURL, token string) <-chan watchSSEEvent {
 	t.Helper()
+	return connectWatchStreamWithHeaders(ctx, t, baseURL, token, nil)
+}
+
+// connectWatchStreamWithHeaders is connectWatchStream plus arbitrary
+// request headers — the seam the session-identity headers need
+// (PLAN-2558 S2, TASK-2560), since those ride the stream request
+// itself.
+func connectWatchStreamWithHeaders(ctx context.Context, t *testing.T, baseURL, token string, headers map[string]string) <-chan watchSSEEvent {
+	t.Helper()
 	ch := make(chan watchSSEEvent, 32)
 
 	req, err := http.NewRequestWithContext(ctx, "GET", baseURL+"/api/v1/events/stream", nil)
@@ -40,6 +49,9 @@ func connectWatchStream(ctx context.Context, t *testing.T, baseURL, token string
 	}
 	if token != "" {
 		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	for k, v := range headers {
+		req.Header.Set(k, v)
 	}
 
 	resp, err := http.DefaultClient.Do(req)

--- a/internal/server/session_identity.go
+++ b/internal/server/session_identity.go
@@ -1,0 +1,142 @@
+package server
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+	"unicode"
+)
+
+// Session-identity headers on GET /api/v1/events/stream (PLAN-2558 S2,
+// TASK-2560). A connecting client uses them to say what it is, so the
+// presence registry holds nameable sessions ("docapp") rather than
+// opaque uuids — which is what turns S1's count into S5's target picker.
+//
+// WHY HEADERS AND NOT A QUERY STRING. The task body sketched "the
+// stream connect carries it" without picking a transport; three were
+// on the table (query param, header, separate registration POST) and
+// this is the reasoning, recorded because the choice is otherwise
+// invisible:
+//
+//   - A query param would put the label and pid in every access log
+//     line — this server logs `path=` for each request — and in any
+//     proxy log in front of it. The whole point of the privacy line
+//     here (basename, never the full cwd; never the socket path) is to
+//     stop local-machine detail from travelling further than it needs
+//     to, and a durable log entry is exactly travelling further.
+//   - A separate registration POST would need its own correlation to
+//     the connection it describes, and a lifecycle to match — the
+//     registry entry lives and dies with the stream, so anything that
+//     can arrive independently of the stream can also fail to.
+//   - A header rides the request that already exists, is trivially set
+//     by the one client that has this data (the Go CLI monitor), and
+//     sits alongside Last-Event-ID, which is already doing exactly this
+//     job on exactly this endpoint.
+//
+// The known cost, stated so the next person doesn't discover it as a
+// surprise: a browser EventSource cannot set request headers. Nothing
+// in the web UI opens this stream today (it uses the workspace-scoped
+// /api/v1/events), but if a browser tab ever wants to appear in
+// presence, it will need either a query-param fallback added
+// deliberately — with the logging consequence above accepted — or a
+// fetch-based SSE reader.
+const (
+	sessionLabelHeader = "X-Pad-Session-Label"
+	sessionPIDHeader   = "X-Pad-Session-Pid"
+)
+
+// maxSessionLabelLen bounds a label in RUNES, not bytes: the value is a
+// directory basename, which is user-controlled text that ends up
+// rendered in a picker. 64 is far more than any real project directory
+// needs and short enough that no UI has to plan for it. Over-long
+// labels are TRUNCATED rather than rejected — a session that shows up
+// with a clipped name is strictly better than one that silently doesn't
+// show up at all, which is the failure this whole slice exists to
+// prevent.
+const maxSessionLabelLen = 64
+
+// parseSessionIdentity reads the self-declared session identity off a
+// stream request. It never fails: every malformed input degrades to the
+// S1 behaviour (an unlabelled session) rather than rejecting the
+// connection, because presence is a convenience and event delivery is
+// not — a client with a garbled header still deserves its events.
+func parseSessionIdentity(r *http.Request) SessionIdentity {
+	return SessionIdentity{
+		Label: sanitizeSessionLabel(r.Header.Get(sessionLabelHeader)),
+		PID:   parseSessionPID(r.Header.Get(sessionPIDHeader)),
+	}
+}
+
+// sanitizeSessionLabel makes a client-supplied label safe to store and
+// hand to a UI: printable characters only, collapsed whitespace,
+// truncated to maxSessionLabelLen runes.
+//
+// Control characters are dropped rather than escaped — a label is
+// destined for terminal output (`pad` listing sessions) as much as for
+// a browser, and an escape sequence there rewrites what the reader
+// sees rather than merely looking ugly.
+//
+// Measured, not assumed: that particular arm is UNREACHABLE over HTTP
+// today. Go's server rejects a request whose header value contains a
+// control byte with 400 Bad Request before any handler runs (verified
+// with a raw socket against httptest, since Go's own client refuses to
+// send one either — neither behaviour is something to take on faith).
+// It is kept as defence in depth for the next caller in: a WebSocket
+// frame, a registration POST body, or a non-Go client on a laxer stack
+// would all reach this function without that protection. The
+// whitespace and length arms, by contrast, are reachable right now —
+// tabs are legal in header values and nothing bounds their length.
+//
+// Either way this is hygiene, not a security boundary: the label is
+// self-declared and only ever appears in its own owner's session list
+// (see SessionIdentity).
+func sanitizeSessionLabel(raw string) string {
+	if raw == "" {
+		return ""
+	}
+
+	var b strings.Builder
+	b.Grow(len(raw))
+	lastWasSpace := false
+	for _, r := range raw {
+		switch {
+		case r == ' ' || r == '\t' || r == '\n' || r == '\r':
+			// Collapse any run of whitespace to a single space; leading
+			// runs are dropped by the lastWasSpace seed below.
+			if b.Len() > 0 && !lastWasSpace {
+				b.WriteRune(' ')
+				lastWasSpace = true
+			}
+		case !unicode.IsPrint(r):
+			// Dropped entirely, and deliberately NOT treated as a word
+			// boundary: "do\x00capp" is far likelier to be a mangled
+			// "docapp" than two words.
+			continue
+		default:
+			b.WriteRune(r)
+			lastWasSpace = false
+		}
+	}
+
+	label := strings.TrimRight(b.String(), " ")
+	runes := []rune(label)
+	if len(runes) > maxSessionLabelLen {
+		label = strings.TrimRight(string(runes[:maxSessionLabelLen]), " ")
+	}
+	return label
+}
+
+// parseSessionPID parses the pid header, returning 0 for anything that
+// isn't a plausible process id. 0 is the sentinel for "not stated"
+// (LiveSession omits it from JSON), so every rejection path lands
+// there rather than propagating a nonsense number into a picker.
+func parseSessionPID(raw string) int {
+	if raw == "" {
+		return 0
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(raw))
+	if err != nil || pid <= 0 {
+		return 0
+	}
+	return pid
+}

--- a/internal/server/session_identity_test.go
+++ b/internal/server/session_identity_test.go
@@ -1,0 +1,156 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestSanitizeSessionLabel(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"ordinary basename", "docapp", "docapp"},
+		{"empty", "", ""},
+		{"surrounding whitespace trimmed", "  docapp  ", "docapp"},
+		{"inner whitespace collapsed", "my   project", "my project"},
+		{"tabs and newlines are whitespace", "my\tproject\nhere", "my project here"},
+		{
+			// The reason control characters are dropped rather than
+			// escaped: this label is printed in a terminal (`pad`
+			// listing sessions) as well as a browser, and an escape
+			// sequence there rewrites what the reader sees.
+			"ansi escape stripped to its printable residue",
+			"doc\x1b[31mapp",
+			"doc[31mapp",
+		},
+		{"nul and bell dropped without splitting the word", "do\x00cap\ap", "docapp"},
+		{"control-only input yields empty, not garbage", "\x00\x01\x02", ""},
+		{"non-ascii printable is kept — a directory can be named anything", "проект", "проект"},
+		{"emoji is printable and kept", "docapp 🪶", "docapp 🪶"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := sanitizeSessionLabel(tc.in); got != tc.want {
+				t.Fatalf("sanitizeSessionLabel(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSanitizeSessionLabel_TruncatesByRunes pins the bound as RUNES,
+// not bytes. A byte-based cap would slice a multibyte character in half
+// and emit invalid UTF-8 into a JSON response — the kind of thing that
+// surfaces as a broken UI far from here.
+func TestSanitizeSessionLabel_TruncatesByRunes(t *testing.T) {
+	t.Parallel()
+
+	long := strings.Repeat("a", maxSessionLabelLen+10)
+	got := sanitizeSessionLabel(long)
+	if len([]rune(got)) != maxSessionLabelLen {
+		t.Fatalf("expected %d runes, got %d", maxSessionLabelLen, len([]rune(got)))
+	}
+
+	// Each 'é' is 2 bytes: a byte-based cap would cut one in half.
+	multi := strings.Repeat("é", maxSessionLabelLen+10)
+	got = sanitizeSessionLabel(multi)
+	if len([]rune(got)) != maxSessionLabelLen {
+		t.Fatalf("expected %d runes for multibyte input, got %d", maxSessionLabelLen, len([]rune(got)))
+	}
+	if !isValidUTF8(got) {
+		t.Fatalf("truncation produced invalid UTF-8: %q", got)
+	}
+}
+
+func isValidUTF8(s string) bool {
+	for _, r := range s {
+		if r == '�' {
+			return false
+		}
+	}
+	return true
+}
+
+func TestParseSessionPID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		in   string
+		want int
+	}{
+		{"1234", 1234},
+		{" 1234 ", 1234},
+		{"", 0},
+		{"0", 0},
+		{"-5", 0},
+		{"not-a-pid", 0},
+		{"12.5", 0},
+		{"1234abc", 0},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.in, func(t *testing.T) {
+			t.Parallel()
+			if got := parseSessionPID(tc.in); got != tc.want {
+				t.Fatalf("parseSessionPID(%q) = %d, want %d", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestParseSessionIdentity_ReadsBothHeaders is the wiring check: the
+// right header feeds the right field. Cheap, and it is what catches a
+// copy-paste that reads the label header into the pid slot — a mistake
+// no amount of sanitizer testing would find.
+func TestParseSessionIdentity_ReadsBothHeaders(t *testing.T) {
+	t.Parallel()
+
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/events/stream", nil)
+	r.Header.Set(sessionLabelHeader, " docapp\x00 ")
+	r.Header.Set(sessionPIDHeader, "4242")
+
+	ident := parseSessionIdentity(r)
+	if ident.Label != "docapp" {
+		t.Fatalf("label = %q, want %q", ident.Label, "docapp")
+	}
+	if ident.PID != 4242 {
+		t.Fatalf("pid = %d, want 4242", ident.PID)
+	}
+}
+
+// TestParseSessionIdentity_AbsentHeadersAreTheS1Shape covers the
+// compatibility leg that matters most: a pre-S2 client (or any client
+// that just doesn't say) must produce exactly the zero identity, which
+// is the unlabelled session S1 registered. Presence is a convenience;
+// nothing about a missing header may affect the connection.
+func TestParseSessionIdentity_AbsentHeadersAreTheS1Shape(t *testing.T) {
+	t.Parallel()
+
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/events/stream", nil)
+	if ident := parseSessionIdentity(r); ident != (SessionIdentity{}) {
+		t.Fatalf("expected the zero identity for a client that sends no headers, got %+v", ident)
+	}
+}
+
+// TestParseSessionIdentity_GarbageDegradesRatherThanRejects pins the
+// no-fail contract. There is no error return by design: a client with a
+// mangled header still deserves its events, so every bad input has to
+// land on the unlabelled shape rather than anywhere else.
+func TestParseSessionIdentity_GarbageDegradesRatherThanRejects(t *testing.T) {
+	t.Parallel()
+
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/events/stream", nil)
+	r.Header.Set(sessionLabelHeader, "\x00\x01")
+	r.Header.Set(sessionPIDHeader, "definitely-not-a-pid")
+
+	if ident := parseSessionIdentity(r); ident != (SessionIdentity{}) {
+		t.Fatalf("expected garbage to degrade to the zero identity, got %+v", ident)
+	}
+}

--- a/internal/server/session_presence.go
+++ b/internal/server/session_presence.go
@@ -54,13 +54,31 @@ import (
 // LiveSession is one currently-connected user-scoped event stream —
 // i.e. one `GET /api/v1/events/stream` connection being held open.
 //
-// The identity fields are deliberately thin in S1. Label is empty until
-// S2 teaches the stream connection to carry the `pad session register`
-// payload (cwd basename, pid) it already writes to
-// ~/.pad/sessions/<pid>.json; until then a session is an opaque id and
-// a connect time, which is all a COUNT needs. Note that S2 must send
-// the label only — never messaging_socket_path, which is local-machine
-// state with no business crossing the wire.
+// STALENESS (moved here in S2 from where S1 left it, wedged above
+// Label, where it read as documenting the name rather than the entry —
+// it is a property of every field below). A session in this list is
+// "connected" as of the last time the server could tell, which is not
+// the same as "connected now". A CLEAN disconnect deregisters
+// immediately (the stream handler's ctx.Done fires and its defer runs).
+// An UNGRACEFUL one — half-open TCP, closed laptop, dropped network —
+// is invisible to the server until the next keepalive write fails, and
+// watchEventsKeepaliveInterval is 30s. So this list can name a listener
+// that is already gone, for up to ~30 seconds.
+//
+// That bound is acceptable for push, which is fire-and-forget either
+// way: a push to a session that died 5 seconds ago costs a message that
+// would have been lost regardless. It is NOT acceptable as a delivery
+// guarantee, and consumers must not upgrade it into one — "one session
+// connected" is honest, "this will be delivered" is not (PLAN-2558 S3).
+//
+// Shortening the window means shortening the keepalive, which costs
+// every idle connection real traffic. Not worth it for a
+// fire-and-forget channel; revisit only if a consumer appears that
+// genuinely needs delivery confidence, and give that consumer an ack
+// rather than a faster heartbeat.
+//
+// Label and PID arrive from the client (S2) and are self-declared —
+// see SessionIdentity.
 type LiveSession struct {
 	// ID is server-generated per connection, not per client. A client
 	// that reconnects (including the Last-Event-ID resume path) gets a
@@ -68,33 +86,46 @@ type LiveSession struct {
 	// resumed stream is a different open connection. Callers must not
 	// treat this as a stable client identity.
 	ID string `json:"id"`
-	// STALENESS. A session in this list is "connected" as of the last
-	// time the server could tell, which is not the same as "connected
-	// now". A CLEAN disconnect deregisters immediately (the stream
-	// handler's ctx.Done fires and its defer runs). An UNGRACEFUL one
-	// — half-open TCP, closed laptop, dropped network — is invisible
-	// to the server until the next keepalive write fails, and
-	// watchEventsKeepaliveInterval is 30s. So this list can name a
-	// listener that is already gone, for up to ~30 seconds.
-	//
-	// That bound is acceptable for push, which is fire-and-forget
-	// either way: a push to a session that died 5 seconds ago costs a
-	// message that would have been lost regardless. It is NOT
-	// acceptable as a delivery guarantee, and consumers must not
-	// upgrade it into one — "one session connected" is honest, "this
-	// will be delivered" is not (PLAN-2558 S3).
-	//
-	// Shortening the window means shortening the keepalive, which
-	// costs every idle connection real traffic. Not worth it for a
-	// fire-and-forget channel; revisit only if a consumer appears that
-	// genuinely needs delivery confidence, and give that consumer an
-	// ack rather than a faster heartbeat.
 	// Label is a human-meaningful name for the session ("docapp"),
-	// populated in S2. Empty means "unlabelled", not "unknown user" —
+	// populated in S2 from the connecting client's working-directory
+	// basename. Empty means "unlabelled", not "unknown user" —
 	// consumers should fall back to the id, never hide the session.
 	Label string `json:"label,omitempty"`
+	// PID is the connecting client process's own pid, or 0 when it
+	// didn't say (S2). It exists to disambiguate two sessions that
+	// share a label — two agents in the same checkout both report
+	// "docapp" — not to identify a process the server can act on.
+	PID int `json:"pid,omitempty"`
 	// ConnectedAt is when the stream opened, UTC.
 	ConnectedAt time.Time `json:"connected_at"`
+}
+
+// SessionIdentity is what a connecting client tells the server about
+// itself when it opens a stream (PLAN-2558 S2, TASK-2560).
+//
+// SELF-DECLARED, NOT VERIFIED — the same honesty-not-verification line
+// BUG-2542 drew for actor attribution. Nothing here is checked against
+// anything: a client can claim any label and any pid. That is
+// acceptable precisely because the blast radius is the caller's own
+// row — GET /api/v1/sessions is self-scoped with no admin view
+// (handlers_sessions.go), so the only list a lying client corrupts is
+// its own. Do not build anything on these fields that would need them
+// to be trustworthy; if that day comes, the fix is a server-side
+// identity, not tighter validation of a claim.
+//
+// What is deliberately NOT here: messaging_socket_path. `pad session
+// register` records it locally (internal/cli/session_registry.go) and
+// it must not cross the wire — a filesystem path on the user's machine
+// is of no use to the server and every use to anyone who shouldn't
+// have it. Nor does the full cwd cross: the basename is what a picker
+// needs, while the absolute path leaks the home directory (and usually
+// the account name) for no gain.
+type SessionIdentity struct {
+	// Label is a short human-meaningful name, already sanitized by
+	// parseSessionIdentity before it reaches the registry.
+	Label string
+	// PID is the client's own process id, or 0 for "not stated".
+	PID int
 }
 
 // SessionPresence tracks which of a user's event streams are open right
@@ -125,7 +156,9 @@ type LiveSession struct {
 type SessionPresence interface {
 	// Add registers a newly-opened stream for userID and returns the
 	// session's generated id, which the caller MUST pass to Remove.
-	Add(userID string, label string) string
+	// The identity is whatever the client claimed about itself, already
+	// sanitized — see SessionIdentity on why it is never trusted.
+	Add(userID string, ident SessionIdentity) string
 	// Remove deregisters a session. It must be idempotent and must not
 	// panic on an unknown id — the stream handler calls it from a defer
 	// that also runs on paths where Add may not have been reached.
@@ -154,12 +187,17 @@ func NewMemorySessionPresence() *MemorySessionPresence {
 }
 
 // Add implements SessionPresence.
-func (p *MemorySessionPresence) Add(userID string, label string) string {
+func (p *MemorySessionPresence) Add(userID string, ident SessionIdentity) string {
 	id := uuid.NewString()
 	// Stamp the time OUTSIDE the lock — time.Now can be comparatively
 	// slow on some platforms and there is no correctness reason to hold
 	// writers behind it.
-	sess := LiveSession{ID: id, Label: label, ConnectedAt: time.Now().UTC()}
+	sess := LiveSession{
+		ID:          id,
+		Label:       ident.Label,
+		PID:         ident.PID,
+		ConnectedAt: time.Now().UTC(),
+	}
 
 	p.mu.Lock()
 	defer p.mu.Unlock()

--- a/internal/server/session_presence_test.go
+++ b/internal/server/session_presence_test.go
@@ -14,9 +14,9 @@ func TestMemorySessionPresence_AddListRemove(t *testing.T) {
 		t.Fatalf("expected no sessions for an unknown user, got %d", len(got))
 	}
 
-	a := p.Add("u1", "docapp")
-	b := p.Add("u1", "voiapp")
-	other := p.Add("u2", "poker")
+	a := p.Add("u1", SessionIdentity{Label: "docapp"})
+	b := p.Add("u1", SessionIdentity{Label: "voiapp"})
+	other := p.Add("u2", SessionIdentity{Label: "poker"})
 
 	if a == b {
 		t.Fatal("two connections for the same user must get distinct ids")
@@ -57,7 +57,7 @@ func TestMemorySessionPresence_RemoveIsForgiving(t *testing.T) {
 	p.Remove("nobody", "no-such-session") // unknown user
 	p.Remove("u1", "")                    // empty id (Add never ran)
 
-	id := p.Add("u1", "")
+	id := p.Add("u1", SessionIdentity{})
 	p.Remove("u1", id)
 	p.Remove("u1", id) // double-remove: idempotent, not a panic
 
@@ -106,7 +106,7 @@ func TestMemorySessionPresence_ListIsOldestFirstAndStable(t *testing.T) {
 func TestMemorySessionPresence_ListReturnsACopy(t *testing.T) {
 	t.Parallel()
 	p := NewMemorySessionPresence()
-	id := p.Add("u1", "docapp")
+	id := p.Add("u1", SessionIdentity{Label: "docapp"})
 
 	got := p.ListForUser("u1")
 	got[0].Label = "tampered"
@@ -133,7 +133,7 @@ func TestMemorySessionPresence_ConcurrentAccess(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			for j := 0; j < 50; j++ {
-				id := p.Add("u1", "")
+				id := p.Add("u1", SessionIdentity{})
 				p.ListForUser("u1")
 				p.Remove("u1", id)
 			}


### PR DESCRIPTION
PLAN-2558 S2, branched from main (S1 landed as `21001bc4`). S1 gave the presence registry a count of anonymous uuids; this makes each row nameable, which is what S3 needs for an honest empty state and S5 needs for a target picker.

A monitor announces itself when it opens the stream — `X-Pad-Session-Label` (working-directory basename) and `X-Pad-Session-Pid`. The server sanitizes both, stores them on the `LiveSession`, and `GET /api/v1/sessions` returns them.

## The transport call

The task body sketched "the stream connect carries it" without picking a mechanism and said explicitly it was a proposal, not a ruling. Headers, for two reasons:

- **A query param would log the payload.** This server logs `path=` for every request, and any proxy in front does too. Putting a directory name and pid into durable log lines is exactly the "local-machine detail travelling further than it needs to" that the privacy line below exists to prevent. Verified in the live run: the logged line is a bare `/api/v1/events/stream`.
- **A separate registration POST would need its own correlation and lifecycle.** The registry entry lives and dies with the stream connection; anything that can arrive independently of the stream can also fail to.

Headers ride the request that already exists and sit next to `Last-Event-ID`, which is already doing this job on this endpoint.

Cost, written into the code rather than left to be discovered: a browser `EventSource` cannot set request headers. Nothing in the web UI opens this stream today, but a future browser-tab consumer needs either a deliberate query-param fallback (accepting the logging) or a fetch-based SSE reader.

## Privacy

Basename only — `/home/dave/Dev/docapp` would additionally hand over a home directory and usually an account name for no gain — and `messaging_socket_path` never leaves the machine. Pinned by a test, not by the implementation happening to be one line.

## What this deliberately does not do

Read `~/.pad/sessions/`. The task framed S2 as giving `pad session register` its first consumer, and the monitor cannot honestly be one: registry entries are written by whatever process ran that command (a different pid), and the only matchable fields are pid and cwd — so two agent sessions in one checkout are indistinguishable, and "pick the newest" is a coin flip that puts a confident wrong name in the S5 picker. Process ancestry would settle it exactly and is platform-specific (this binary ships for macOS and Windows).

The monitor's own cwd basename and pid are never wrong and answer the question the label exists to answer. Correlating a stream to the agent session that spawned it needs an identifier the harness passes down; worth doing when something needs it, worth not faking until then.

## Verification

Gate matrix:

- build green · `make lint` 0 issues · `go test ./...` green
- `make test-pg` — running; result reported before this leaves draft
- web: not applicable, no web changes
- Codex review: pending

Mutation-tested four ways, each revert grep-verified:

1. handler ignores the parsed identity → the labelled-session test and the hostile-input test fail; the no-headers control still passes
2. monitor sends the full cwd → the basename test fails
3. drop the rune truncation → the truncation test and the wire test fail
4. client always sets the headers, even empty → the omit-when-unset test fails

Live, against a sandboxed server on an alternate port with its own HOME/DB, through the real `pad watch --stream --for-session`:

- session appears as `label=my-project`, `pid=<the monitor's pid>`
- it disappears when the monitor exits (S1 deregistration intact)
- the logged request line carries no label or pid — the payoff of the header choice, checked rather than asserted
- two monitors in the same directory produce two rows sharing a label and differing by pid, which is what the `PID` field is documented to be for

**Measured rather than assumed:** Go's server answers 400 Bad Request to a header value containing a control byte, before any handler runs — verified with a raw socket, since Go's own client refuses to send one and the two refusals are indistinguishable from a normal client test. So the control-character arm of the sanitizer is unreachable over HTTP. It stays as defence in depth for the next caller in (a WebSocket frame, a POST body, a non-Go client), and both the code comment and the wire test say so, instead of a test that passes because the transport refused the input while reading as though the sanitizer did the work.

Also moves S1's STALENESS doc block, which sat above `LiveSession.Label` where it read as documenting the name rather than the whole entry.
