### PR TITLE
ci(nix): gate the Nix-built binary with govulncheck (BUG-2567)

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -36,3 +36,29 @@ jobs:
         run: |
           ./result/bin/pad --version
           ./result/bin/pad --help
+
+      # The Go toolchain here exists only to install govulncheck for the
+      # scan step below — the pad binary under test was built by Nix above.
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: "1.26"
+
+      - name: Scan Nix-built binary with govulncheck
+        # CI's main govulncheck job scans a `go build` binary, which honours
+        # go.mod's `toolchain go1.26.6` line — but nixpkgs pins
+        # GOTOOLCHAIN=local, so the Nix artifact is built with whatever Go
+        # patch the nixos-26.05 channel ships and can carry stdlib advisories
+        # the main gate can no longer see (BUG-2567). This scans the artifact
+        # that actually ships via Nix, against nix/accepted-advisories.txt:
+        # known-accepted advisories stay green and visible, any NEW advisory
+        # fails the job, and a warning fires when an accepted advisory clears
+        # (the signal to prune the list and eventually close BUG-2567).
+        #
+        # govulncheck pinned to the same release as ci.yml — bump the two
+        # together. GOTOOLCHAIN=auto on the install mirrors ci.yml's
+        # rationale: setup-go exports GOTOOLCHAIN=local, and if govulncheck's
+        # own go.mod ever requires a patch newer than setup-go's resolved
+        # one, `auto` lets Go fetch it instead of failing the install.
+        run: |
+          GOTOOLCHAIN=auto go install golang.org/x/vuln/cmd/govulncheck@v1.2.0
+          GOVULNCHECK="$(go env GOPATH)/bin/govulncheck" nix/vulnscan.sh result/bin/pad

--- a/nix/accepted-advisories.txt
+++ b/nix/accepted-advisories.txt
@@ -1,0 +1,37 @@
+# Advisories govulncheck reports against the Nix-built pad binary that are
+# KNOWN and ACCEPTED. nix/vulnscan.sh (run by .github/workflows/nix.yml)
+# fails only on advisories NOT listed here, so a new exposure in the Nix
+# artifact breaks CI while the known backlog below stays visible instead of
+# blocking every PR. See BUG-2567.
+#
+# Lines starting with '#' and blank lines are ignored. One GO-XXXX-NNNN per
+# line; anything after whitespace on the line is treated as a comment.
+#
+# ── Go 1.26.5 stdlib (8) ─────────────────────────────────────────────────
+# nixpkgs nixos-26.05 ships go 1.26.5 and its Go builder pins
+# GOTOOLCHAIN=local, so the `toolchain go1.26.6` line in go.mod (BUG-2565)
+# is ignored there by design. These clear as a group when nixos-26.05
+# backports go 1.26.6 and the flake input is updated — vulnscan.sh emits a
+# warning when a listed advisory stops being reported; when these 8 go
+# quiet, delete them here, verify `go version -m result/bin/pad` reads
+# go1.26.6, and close BUG-2567.
+GO-2026-5026  net/http: Punycode label validation
+GO-2026-5942  x/net/dns/dnsmessage via stdlib: SVCB/HTTPS RR panic
+GO-2026-5972  encoding/asn1: recursion depth
+GO-2026-6088  encoding/xml: recursion depth
+GO-2026-6089  net/http: ReadHeaderTimeout on unencrypted HTTP/2 check
+GO-2026-6090  crypto/tls: post-handshake message limit
+GO-2026-6091  html/template: JS regexp context tracking
+GO-2026-6218  net/url: quadratic resolvePath
+#
+# ── Module-level precision artifacts of the stripped binary (3) ──────────
+# nix/package.nix builds with ldflags "-s -w", which strips the symbol
+# table govulncheck needs for call-graph precision, so it degrades to
+# module-level reporting on this artifact. A symbol-precise scan of the
+# same source (unstripped build, 2026-08-15) shows all three UNCALLED —
+# these are import-only, not reachable. They do NOT clear with the Go
+# backport; they clear when the dependency is bumped past the advisory or
+# dropped.
+GO-2026-4985  otel OTLP exporter: oversized HTTP response bodies (uncalled)
+GO-2026-5932  x/crypto/openpgp: unmaintained (uncalled)
+GO-2026-6222  x/image VP8L decode: memory allocation (uncalled)

--- a/nix/accepted-advisories.txt
+++ b/nix/accepted-advisories.txt
@@ -24,14 +24,15 @@ GO-2026-6090  crypto/tls: post-handshake message limit
 GO-2026-6091  html/template: JS regexp context tracking
 GO-2026-6218  net/url: quadratic resolvePath
 #
-# ── Module-level precision artifacts of the stripped binary (3) ──────────
-# nix/package.nix builds with ldflags "-s -w", which strips the symbol
-# table govulncheck needs for call-graph precision, so it degrades to
-# module-level reporting on this artifact. A symbol-precise scan of the
-# same source (unstripped build, 2026-08-15) shows all three UNCALLED —
-# these are import-only, not reachable. They do NOT clear with the Go
-# backport; they clear when the dependency is bumped past the advisory or
-# dropped.
+# ── Precision artifacts of the stripped binary (3) ───────────────────────
+# nix/package.nix builds with ldflags "-s -w", which strips the symbols
+# govulncheck needs to prune its call graph, so on this artifact it
+# treats every vulnerable symbol of an imported package as potentially
+# called and reports these three as affected. A symbol-precise scan of
+# the same source (unstripped build, 2026-08-15) shows all three
+# UNCALLED — import-only, not reachable. They do NOT clear with the Go
+# backport; they clear when the dependency is bumped past the advisory
+# or dropped.
 GO-2026-4985  otel OTLP exporter: oversized HTTP response bodies (uncalled)
 GO-2026-5932  x/crypto/openpgp: unmaintained (uncalled)
 GO-2026-6222  x/image VP8L decode: memory allocation (uncalled)

--- a/nix/vulnscan.sh
+++ b/nix/vulnscan.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Scan a built pad binary with govulncheck and compare the advisories it
+# reports against nix/accepted-advisories.txt. Closes the gap BUG-2567
+# documents: CI's govulncheck job scans a `go build` binary, so the
+# Nix-built artifact (different toolchain, different ldflags) ships with no
+# gate over it at all.
+#
+# Usage: nix/vulnscan.sh <path-to-binary>
+#
+# Exit 0: every reported advisory is in the accepted list. Advisories in
+#         the accepted list that are NO LONGER reported produce a warning
+#         (GitHub annotation when running in Actions) — that is the signal
+#         to prune the list and, once the stdlib group is quiet, close
+#         BUG-2567.
+# Exit 1: an advisory NOT in the accepted list was reported — new exposure
+#         in this artifact. Fails the job.
+# Exit 2: operational error (missing tool, scan failure, missing file).
+#
+# Requires govulncheck and jq on PATH. GOVULNCHECK overrides the
+# govulncheck executable (the workflow installs a pinned version).
+set -euo pipefail
+
+BINARY="${1:?usage: nix/vulnscan.sh <path-to-binary>}"
+ACCEPTED_FILE="$(dirname "$0")/accepted-advisories.txt"
+GOVULNCHECK="${GOVULNCHECK:-govulncheck}"
+
+[ -f "$BINARY" ] || { echo "vulnscan: binary not found: $BINARY" >&2; exit 2; }
+[ -f "$ACCEPTED_FILE" ] || { echo "vulnscan: accepted list not found: $ACCEPTED_FILE" >&2; exit 2; }
+command -v "$GOVULNCHECK" >/dev/null || { echo "vulnscan: govulncheck not on PATH" >&2; exit 2; }
+command -v jq >/dev/null || { echo "vulnscan: jq not on PATH" >&2; exit 2; }
+
+# JSON mode exits 0 even when findings exist (unlike text mode's exit 3),
+# which is what lets us do the comparison ourselves. A non-zero exit here
+# is an operational failure (bad binary, no network to vuln.go.dev, ...).
+scan_json="$(mktemp)"
+trap 'rm -f "$scan_json"' EXIT
+if ! "$GOVULNCHECK" -mode binary -format json "$BINARY" > "$scan_json"; then
+  echo "vulnscan: govulncheck failed (operational error, not a finding)" >&2
+  exit 2
+fi
+
+# A finding whose top trace frame carries a function is one govulncheck
+# considers reachable — the same criterion that drives text mode's
+# "Your code is affected" list and its failing exit code. On this stripped
+# binary (-s -w) precision degrades to module level, which is why the
+# accepted list carries module-level entries; see the comments there.
+reported="$(jq -r 'select(.finding != null)
+                   | select(.finding.trace[0].function != null)
+                   | .finding.osv' "$scan_json" | sort -u)"
+
+accepted="$(sed -e 's/#.*//' -e 's/[[:space:]].*//' -e '/^$/d' "$ACCEPTED_FILE" | sort -u)"
+
+new="$(comm -23 <(printf '%s' "$reported") <(printf '%s' "$accepted"))"
+resolved="$(comm -13 <(printf '%s' "$reported") <(printf '%s' "$accepted"))"
+
+echo "vulnscan: $(printf '%s' "$reported" | grep -c . || true) advisories reported, $(printf '%s' "$accepted" | grep -c . || true) accepted"
+
+if [ -n "$resolved" ]; then
+  while IFS= read -r id; do
+    msg="accepted advisory $id is no longer reported against $BINARY — remove it from nix/accepted-advisories.txt (when the stdlib group clears, close BUG-2567)"
+    if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
+      echo "::warning file=nix/accepted-advisories.txt::$msg"
+    else
+      echo "vulnscan: WARNING: $msg" >&2
+    fi
+  done <<< "$resolved"
+fi
+
+if [ -n "$new" ]; then
+  echo "vulnscan: NEW advisories in the Nix-built artifact (not in $ACCEPTED_FILE):" >&2
+  echo "$new" | sed 's/^/  /' >&2
+  echo "vulnscan: investigate; only add to the accepted list with a dated comment explaining why." >&2
+  exit 1
+fi
+
+echo "vulnscan: OK — no unaccepted advisories"

--- a/nix/vulnscan.sh
+++ b/nix/vulnscan.sh
@@ -39,14 +39,30 @@ if ! "$GOVULNCHECK" -mode binary -format json "$BINARY" > "$scan_json"; then
   exit 2
 fi
 
-# A finding whose top trace frame carries a function is one govulncheck
-# considers reachable — the same criterion that drives text mode's
-# "Your code is affected" list and its failing exit code. On this stripped
-# binary (-s -w) precision degrades to module level, which is why the
-# accepted list carries module-level entries; see the comments there.
+# Integrity guard: govulncheck's JSON stream opens with a config message
+# stating the scan mode. Its absence means empty/garbled output — a scan
+# that never ran can't be allowed to read as a clean pass — and a mode
+# other than "binary" means govulncheck silently did something other than
+# what this gate is asserting about the artifact.
+scan_mode="$(jq -r 'select(.config != null) | .config.scan_mode' "$scan_json" | head -1)" \
+  || { echo "vulnscan: could not parse govulncheck JSON output" >&2; exit 2; }
+if [ "$scan_mode" != "binary" ]; then
+  echo "vulnscan: govulncheck output has no binary-mode config message (scan_mode='${scan_mode}') — refusing to treat as a clean scan" >&2
+  exit 2
+fi
+
+# Govulncheck emits progressive findings per advisory (module-level, then
+# package, then symbol). One whose top trace frame carries a function is
+# one govulncheck considers reachable — the same criterion that drives
+# text mode's "Your code is affected" list and its failing exit code.
+# Advisories with ONLY functionless findings are govulncheck's
+# informational tier (imported/required but not called); text mode does
+# not fail on those and neither does this gate — matching ci.yml's
+# govulncheck job semantics.
 reported="$(jq -r 'select(.finding != null)
                    | select(.finding.trace[0].function != null)
-                   | .finding.osv' "$scan_json" | sort -u)"
+                   | .finding.osv' "$scan_json" | sort -u)" \
+  || { echo "vulnscan: could not parse govulncheck JSON output" >&2; exit 2; }
 
 accepted="$(sed -e 's/#.*//' -e 's/[[:space:]].*//' -e '/^$/d' "$ACCEPTED_FILE" | sort -u)"
 


### PR DESCRIPTION
## Summary

The Nix-built pad binary ships with **no vulnerability gate over it**: CI's govulncheck job scans a `go build` binary, which honours go.mod's `toolchain go1.26.6` line — but nixpkgs pins `GOTOOLCHAIN=local`, so the Nix artifact is built with the channel's go 1.26.5 and carries the 8 reachable stdlib advisories BUG-2565 cleared everywhere else. Nothing in the pipeline could ever notice (BUG-2567).

This adds a scan of the artifact that actually ships:

- **`nix/vulnscan.sh`** — binary-mode govulncheck (JSON) against a built binary, comparing reachable advisories to an in-repo baseline. New advisory → job fails. Accepted advisory clears → GitHub warning annotation telling you to prune the list. Empty/garbled/non-binary-mode scanner output → fail closed (exit 2), never a silent pass.
- **`nix/accepted-advisories.txt`** — the 11 currently-reported advisories, split and documented: 8 stdlib (clear as a group when nixos-26.05 backports go 1.26.6 — checked 2026-08-15, still 1.26.5) + 3 module-level entries that only appear because `-s -w` strips the symbols govulncheck needs for call-graph precision (a symbol-precise scan shows all three uncalled; they clear on dependency bumps, not the Go backport).
- **`.github/workflows/nix.yml`** — installs govulncheck pinned to the same release as ci.yml and runs the script against `result/bin/pad` after the smoke test.

## Plus (design decisions)

- **Baseline over `continue-on-error`**: a permanently-yellow step rots; a baseline keeps the job green today, makes any NEW exposure red, and turns the backport landing into an explicit, annotated cleanup signal that closes BUG-2567.
- **Called-only criterion**: the jq filter keeps advisories govulncheck considers reachable (top trace frame has a function) — the same line that drives text mode's failing exit code, so this gate's semantics match ci.yml's existing govulncheck job.
- Measured against a build-faithful proxy (`GOTOOLCHAIN=go1.26.5`, `CGO_ENABLED=0`, `-s -w`): stripping degrades govulncheck's precision, which is why the artifact reports 11 advisories where the unstripped scan reports 8 — the baseline matches the artifact, not the item's original count.

## Test plan

- [x] Current stripped 1.26.5 proxy → `11 reported, 11 accepted`, exit 0, no warnings
- [x] Stripped 1.26.6 proxy → exit 0 + 8 prune warnings (backport-landed signal)
- [x] Baseline entry removed → exit 1 listing the new advisory
- [x] go1.26.2 binary (13 unlisted stdlib advisories) → exit 1
- [x] Zero-finding binary → `0 reported`, exit 0 + prune warnings
- [x] Missing binary / empty scanner output / garbled JSON → exit 2 (operational, fail closed)
- [x] `bash -n` clean; `::warning` annotation shape verified under `GITHUB_ACTIONS=true`
- [ ] The `Nix build & check` job on THIS PR runs the new step against the real Nix artifact — that run is the end-to-end verification

## Review

3 codex rounds (framing rotation): R1 CLEAN → R2 two findings — silent-pass on empty/garbled scanner output (fixed, fail-closed guard) and a dead-baseline-entries claim (refuted against the actual JSON stream; documented in the script instead) → R3 convergence CLEAN.

Refs: BUG-2567, follow-up to BUG-2565 (#1093).

https://claude.ai/code/session_01BhQoeaWXxJbvw86ezzK8dt