### PR TITLE
fix(store): treat empty assignment IDs as clear-to-NULL (BUG-2566)

### DIFF
--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -295,7 +295,7 @@ func (s *Store) insertItemTx(tx *sql.Tx, id, workspaceID, collectionID, slug, ts
 		        (SELECT COALESCE(MAX(item_number), 0) + 1 FROM items WHERE workspace_id = ?),
 		        ?, ?, ?, ?, `+nextWorkspaceSeqSubquery+`)
 	`), id, workspaceID, collectionID, input.Title, slug, input.Content, fields, tags,
-		s.dialect.BoolToInt(input.Pinned), input.ParentID, input.AssignedUserID, input.AgentRoleID,
+		s.dialect.BoolToInt(input.Pinned), input.ParentID, nullIfEmptyID(input.AssignedUserID), nullIfEmptyID(input.AgentRoleID),
 		createdBy, createdBy, source, workspaceID, ts, ts, contentFlushedAt, contentFlushedOpLogID, workspaceID)
 	if err != nil {
 		return err
@@ -409,6 +409,18 @@ func (s *Store) insertItemTx(tx *sql.Tx, id, workspaceID, collectionID, slug, ts
 // Returns the created item read back inside the tx, so the caller can consume
 // its committed slug / item_number / seq (DR-14 fanout) without a second
 // round-trip after COMMIT.
+// nullIfEmptyID maps a nil-or-empty ID pointer to SQL NULL. Nullable FK
+// columns (assigned_user_id, agent_role_id) need this at bind time: a JSON
+// client that blanks the field sends "", which validateAssignmentScope
+// deliberately skips, and binding "" verbatim fails the FK instead of
+// clearing the column (BUG-2566).
+func nullIfEmptyID(p *string) any {
+	if p == nil || *p == "" {
+		return nil
+	}
+	return *p
+}
+
 func (s *Store) createItemTx(tx *sql.Tx, workspaceID, collectionID string, input models.ItemCreate) (*models.Item, error) {
 	return s.createItemTxWithID(tx, newID(), workspaceID, collectionID, input)
 }
@@ -2443,16 +2455,21 @@ func (s *Store) updateItemWithParentLinkOnce(
 		sets = append(sets, "parent_id = ?")
 		args = append(args, *input.ParentID)
 	}
-	if input.AssignedUserID != nil {
+	// An explicit empty string clears the assignment, same as
+	// ClearAssignedUser / ClearAgentRole: it's what a JSON client sends
+	// when a user blanks the field, validateAssignmentScope already
+	// treats "" as "nothing to validate", and binding it verbatim would
+	// hit the FK instead of writing NULL (BUG-2566).
+	if input.AssignedUserID != nil && *input.AssignedUserID != "" {
 		sets = append(sets, "assigned_user_id = ?")
 		args = append(args, *input.AssignedUserID)
-	} else if input.ClearAssignedUser {
+	} else if input.ClearAssignedUser || (input.AssignedUserID != nil && *input.AssignedUserID == "") {
 		sets = append(sets, "assigned_user_id = NULL")
 	}
-	if input.AgentRoleID != nil {
+	if input.AgentRoleID != nil && *input.AgentRoleID != "" {
 		sets = append(sets, "agent_role_id = ?")
 		args = append(args, *input.AgentRoleID)
-	} else if input.ClearAgentRole {
+	} else if input.ClearAgentRole || (input.AgentRoleID != nil && *input.AgentRoleID == "") {
 		sets = append(sets, "agent_role_id = NULL")
 	}
 	if input.LastModifiedBy != "" {

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -362,6 +362,18 @@ func (s *Store) insertItemTx(tx *sql.Tx, id, workspaceID, collectionID, slug, ts
 	return nil
 }
 
+// nullIfEmptyID maps a nil-or-empty ID pointer to SQL NULL. Nullable FK
+// columns (assigned_user_id, agent_role_id) need this at bind time: a JSON
+// client that blanks the field sends "", which validateAssignmentScope
+// deliberately skips, and binding "" verbatim fails the FK instead of
+// clearing the column (BUG-2566).
+func nullIfEmptyID(p *string) any {
+	if p == nil || *p == "" {
+		return nil
+	}
+	return *p
+}
+
 // createItemTx is the tx-taking form of item creation (PLAN-2357 / DR-9a) and
 // the single implementation behind BOTH CreateItem and the cross-workspace
 // copy path. It performs the ENTIRE create pipeline — defaults,
@@ -409,18 +421,6 @@ func (s *Store) insertItemTx(tx *sql.Tx, id, workspaceID, collectionID, slug, ts
 // Returns the created item read back inside the tx, so the caller can consume
 // its committed slug / item_number / seq (DR-14 fanout) without a second
 // round-trip after COMMIT.
-// nullIfEmptyID maps a nil-or-empty ID pointer to SQL NULL. Nullable FK
-// columns (assigned_user_id, agent_role_id) need this at bind time: a JSON
-// client that blanks the field sends "", which validateAssignmentScope
-// deliberately skips, and binding "" verbatim fails the FK instead of
-// clearing the column (BUG-2566).
-func nullIfEmptyID(p *string) any {
-	if p == nil || *p == "" {
-		return nil
-	}
-	return *p
-}
-
 func (s *Store) createItemTx(tx *sql.Tx, workspaceID, collectionID string, input models.ItemCreate) (*models.Item, error) {
 	return s.createItemTxWithID(tx, newID(), workspaceID, collectionID, input)
 }

--- a/internal/store/items_empty_assignment_test.go
+++ b/internal/store/items_empty_assignment_test.go
@@ -1,0 +1,92 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// BUG-2566: an explicit empty string for assigned_user_id / agent_role_id
+// is what a JSON client sends when a user blanks the field. It must clear
+// the assignment (write NULL) exactly like ClearAssignedUser /
+// ClearAgentRole — before the fix it was bound verbatim and failed the FK
+// with a driver-specific 500.
+
+func TestUpdateItem_EmptyAssignedUserIDClearsAssignment(t *testing.T) {
+	t.Parallel()
+	s := testStore(t)
+	wsID, colID := newTransitionTestWorkspace(t, s)
+	item := createTestItem(t, s, wsID, colID, "Assign then blank", "")
+
+	assignee := createTestUser(t, s, "blankme@example.com", "BlankMe", "pw")
+	if err := s.AddWorkspaceMember(wsID, assignee.ID, "editor"); err != nil {
+		t.Fatalf("add member: %v", err)
+	}
+	if _, err := s.UpdateItem(item.ID, models.ItemUpdate{AssignedUserID: &assignee.ID}); err != nil {
+		t.Fatalf("assign item: %v", err)
+	}
+
+	empty := ""
+	cleared, err := s.UpdateItem(item.ID, models.ItemUpdate{AssignedUserID: &empty})
+	if err != nil {
+		t.Fatalf("update with empty assigned_user_id: %v", err)
+	}
+	if cleared.AssignedUserID != nil {
+		t.Fatalf("expected assignment cleared, got %q", *cleared.AssignedUserID)
+	}
+	// The mutation signal must match the ClearAssignedUser shape — the
+	// notification pipeline keys off it.
+	if cleared.LastMutation == nil || !cleared.LastMutation.AssignmentChanged {
+		t.Fatalf("expected AssignmentChanged=true, got %+v", cleared.LastMutation)
+	}
+	if cleared.LastMutation.FromAssignedUserID != assignee.ID || cleared.LastMutation.ToAssignedUserID != "" {
+		t.Fatalf("expected %q -> '', got %q -> %q", assignee.ID,
+			cleared.LastMutation.FromAssignedUserID, cleared.LastMutation.ToAssignedUserID)
+	}
+}
+
+func TestUpdateItem_EmptyAgentRoleIDClearsRole(t *testing.T) {
+	t.Parallel()
+	s := testStore(t)
+	wsID, colID := newTransitionTestWorkspace(t, s)
+	item := createTestItem(t, s, wsID, colID, "Role then blank", "")
+
+	role, err := s.CreateAgentRole(wsID, models.AgentRoleCreate{Name: "Blanker"})
+	if err != nil {
+		t.Fatalf("CreateAgentRole: %v", err)
+	}
+	if _, err := s.UpdateItem(item.ID, models.ItemUpdate{AgentRoleID: &role.ID}); err != nil {
+		t.Fatalf("set role: %v", err)
+	}
+
+	empty := ""
+	cleared, err := s.UpdateItem(item.ID, models.ItemUpdate{AgentRoleID: &empty})
+	if err != nil {
+		t.Fatalf("update with empty agent_role_id: %v", err)
+	}
+	if cleared.AgentRoleID != nil {
+		t.Fatalf("expected role cleared, got %q", *cleared.AgentRoleID)
+	}
+}
+
+func TestCreateItem_EmptyAssignmentIDsAreNull(t *testing.T) {
+	t.Parallel()
+	s := testStore(t)
+	wsID, colID := newTransitionTestWorkspace(t, s)
+
+	empty := ""
+	item, err := s.CreateItem(wsID, colID, models.ItemCreate{
+		Title:          "Born unassigned",
+		AssignedUserID: &empty,
+		AgentRoleID:    &empty,
+	})
+	if err != nil {
+		t.Fatalf("create with empty assignment ids: %v", err)
+	}
+	if item.AssignedUserID != nil {
+		t.Fatalf("expected nil assigned_user_id, got %q", *item.AssignedUserID)
+	}
+	if item.AgentRoleID != nil {
+		t.Fatalf("expected nil agent_role_id, got %q", *item.AgentRoleID)
+	}
+}


### PR DESCRIPTION
## Summary

`PATCH` with `{"assigned_user_id": ""}` returned a 500 with a raw FK constraint string and left the item assigned. An explicit empty string is the natural clear payload for a JSON client (JSON `null` on a `*string` decodes to nil = "don't change", so it cannot express clearing), and `validateAssignmentScope` already skips `""` as nothing-to-validate — the SQL builder just bound it verbatim into the FK column.

Fix is store-level so HTTP, bulk, and CLI all inherit it: `""` now clears `assigned_user_id` / `agent_role_id` exactly like `ClearAssignedUser` / `ClearAgentRole` on update, and binds NULL on create (`nullIfEmptyID`). The mutation signal keeps the ClearAssignedUser shape, so watch notifications behave identically.

## Scope decisions

- **`parent_id` deliberately excluded**: it shares the FK shape but parent relations also live in `item_links`; coercing the column alone would desync them.
- **MCP path deliberately excluded**: codex R1 found the MCP dispatch layer drops empty-string assignment IDs before the store (and exposes no `clear_*` flags at all, so MCP agents cannot unassign, period). That's a behavior change on a separate surface with its own compat posture — filed as TASK-2571.
- Web UI unaffected: it already sends `clear_assigned_user: true`.

## Test plan

- [x] New tests reproduce the exact FK failure pre-fix (verified by stash-run: `constraint failed: FOREIGN KEY constraint failed (787)`)
- [x] Update-clear for both fields + mutation-signal parity + create-path, green on SQLite AND PostgreSQL (targeted run against the compose PG at :5445)
- [x] Full `go test ./...` (SQLite) green; `make lint` 0 issues
- [ ] CI matrix incl. the full Go (PostgreSQL) leg

## Review

3 codex rounds: R1 — MCP-path unreachability (dispositioned as TASK-2571) → R2 — branch logic and NULL binding confirmed clean on both drivers, one doc-comment placement P3 (fixed) → R3 convergence CLEAN.

Refs: BUG-2566.

https://claude.ai/code/session_01BhQoeaWXxJbvw86ezzK8dt