### PR TITLE
feat(web): push-to-agent composer in the item view (TASK-2561)

### DIFF
--- a/internal/server/push_message_collapse_test.go
+++ b/internal/server/push_message_collapse_test.go
@@ -2,11 +2,40 @@ package server
 
 import (
 	"encoding/json"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 )
+
+type pushCollapseCase struct {
+	Name      string `json:"name"`
+	Raw       string `json:"raw"`
+	Collapsed string `json:"collapsed"`
+	Runes     int    `json:"runes"`
+}
+
+func loadPushCollapseCases(t *testing.T) []pushCollapseCase {
+	t.Helper()
+	var fixture struct {
+		Cases []pushCollapseCase `json:"cases"`
+	}
+	raw, err := os.ReadFile(filepath.Join("testdata", "push_message_cases.json"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	if err := json.Unmarshal(raw, &fixture); err != nil {
+		t.Fatalf("parse fixture: %v", err)
+	}
+	// Guard against a fixture that silently empties out (a bad merge, a
+	// rewritten generator): an empty table would make these tests pass while
+	// proving nothing, which is the exact false-green shape CONVE-12 names.
+	if len(fixture.Cases) < 20 {
+		t.Fatalf("fixture has %d cases, expected the full table — did it get truncated?", len(fixture.Cases))
+	}
+	return fixture.Cases
+}
 
 // This file is one half of a cross-language contract test (PLAN-2558 S3).
 //
@@ -23,32 +52,7 @@ import (
 // table. If either implementation drifts, exactly one of the two goes red and
 // names the case.
 func TestPushMessageCollapseFixture(t *testing.T) {
-	type collapseCase struct {
-		Name      string `json:"name"`
-		Raw       string `json:"raw"`
-		Collapsed string `json:"collapsed"`
-		Runes     int    `json:"runes"`
-	}
-	var fixture struct {
-		Cases []collapseCase `json:"cases"`
-	}
-
-	path := filepath.Join("testdata", "push_message_cases.json")
-	raw, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("read fixture: %v", err)
-	}
-	if err := json.Unmarshal(raw, &fixture); err != nil {
-		t.Fatalf("parse fixture: %v", err)
-	}
-	// Guard against a fixture that silently empties out (a bad merge, a
-	// rewritten generator): an empty table would make this test pass while
-	// proving nothing, which is the exact false-green shape CONVE-12 names.
-	if len(fixture.Cases) < 20 {
-		t.Fatalf("fixture has %d cases, expected the full table — did it get truncated?", len(fixture.Cases))
-	}
-
-	for _, tc := range fixture.Cases {
+	for _, tc := range loadPushCollapseCases(t) {
 		t.Run(tc.Name, func(t *testing.T) {
 			// The exact expression handlePushToItem applies to input.Message.
 			got := strings.Join(strings.Fields(tc.Raw), " ")
@@ -63,15 +67,80 @@ func TestPushMessageCollapseFixture(t *testing.T) {
 	}
 }
 
+// The test above asserts the EXPRESSION handlePushToItem uses, copied into the
+// test — which cannot notice the handler switching to a different
+// normalization (codex review). This one drives the real endpoint for every
+// fixture case and reads the collapsed form back off the response, so the
+// table is pinned to the code path a client actually talks to.
+//
+// The two are kept separate rather than merged: this one needs a server, a
+// user and a workspace per case, while the expression-level test is instant
+// and pinpoints WHICH of collapse-vs-count disagrees when one does.
+func TestPushMessageCollapseThroughTheHandler(t *testing.T) {
+	t.Parallel()
+	srv := testServerWithWatchEvents(t)
+	slug, item, tok, _ := setupWatchTestUser(t, srv)
+	path := "/api/v1/workspaces/" + slug + "/items/" + item.Slug + "/push"
+
+	for _, tc := range loadPushCollapseCases(t) {
+		t.Run(tc.Name, func(t *testing.T) {
+			rr := bearerJSON(t, srv, "POST", path, tok.Token,
+				map[string]interface{}{"message": tc.Raw})
+
+			// A case that collapses to nothing is the handler's own 400
+			// condition — and the 400 IS the assertion that the collapse
+			// emptied it, so it is evidence rather than an exempted case.
+			if tc.Collapsed == "" {
+				if rr.Code != http.StatusBadRequest {
+					t.Fatalf("expected 400 for a message that collapses to empty, got %d (%s)", rr.Code, rr.Body.String())
+				}
+				return
+			}
+
+			if rr.Code != http.StatusOK {
+				t.Fatalf("push: %d %s", rr.Code, rr.Body.String())
+			}
+			var resp pushResponse
+			if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+				t.Fatalf("parse response: %v", err)
+			}
+			// pushResponse.Message echoes the post-collapse text — the exact
+			// bytes that went onto the bus as Notification.Summary.
+			if resp.Message != tc.Collapsed {
+				t.Errorf("handler collapsed %q to %q, fixture says %q", tc.Raw, resp.Message, tc.Collapsed)
+			}
+			if n := len([]rune(resp.Message)); n != tc.Runes {
+				t.Errorf("handler produced %d runes for %q, fixture says %d", n, tc.Raw, tc.Runes)
+			}
+		})
+	}
+}
+
 // The fixture's whitespace cases are only meaningful if they agree with the
-// constant the handler actually enforces. A composer that bounds at a
-// hard-coded 4096 while the server moved on is wrong in whichever direction
-// the constant went, so pin the number the web client mirrors
-// (PUSH_MESSAGE_MAX_LEN in web/src/lib/push/message.ts).
-func TestMaxPushMessageLenIsMirroredByTheWebComposer(t *testing.T) {
+// bound the handler actually enforces. Asserted THROUGH the endpoint at the
+// boundary — 4096 collapsed runes accepted, 4097 refused — rather than by
+// comparing the constant to a copy of itself, so the web composer's
+// PUSH_MESSAGE_MAX_LEN is pinned to observed behaviour.
+func TestPushMessageBoundIsWhatTheWebComposerMirrors(t *testing.T) {
+	t.Parallel()
+	// The number hard-coded in web/src/lib/push/message.ts.
 	const mirroredInWebClient = 4096
-	if maxPushMessageLen != mirroredInWebClient {
-		t.Fatalf("maxPushMessageLen = %d but web/src/lib/push/message.ts still says %d — update PUSH_MESSAGE_MAX_LEN in lockstep",
-			maxPushMessageLen, mirroredInWebClient)
+
+	srv := testServerWithWatchEvents(t)
+	slug, item, tok, _ := setupWatchTestUser(t, srv)
+	path := "/api/v1/workspaces/" + slug + "/items/" + item.Slug + "/push"
+
+	atLimit := strings.Repeat("a", mirroredInWebClient)
+	if rr := bearerJSON(t, srv, "POST", path, tok.Token,
+		map[string]interface{}{"message": atLimit}); rr.Code != http.StatusOK {
+		t.Fatalf("a %d-rune message was refused (%d %s) — the server bounds lower than the web composer, which will refuse text users are entitled to send",
+			mirroredInWebClient, rr.Code, rr.Body.String())
+	}
+
+	overLimit := strings.Repeat("a", mirroredInWebClient+1)
+	if rr := bearerJSON(t, srv, "POST", path, tok.Token,
+		map[string]interface{}{"message": overLimit}); rr.Code != http.StatusBadRequest {
+		t.Fatalf("a %d-rune message was accepted (%d) — the server bounds higher than the web composer, which will block text the server would take",
+			mirroredInWebClient+1, rr.Code)
 	}
 }

--- a/internal/server/push_message_collapse_test.go
+++ b/internal/server/push_message_collapse_test.go
@@ -1,0 +1,77 @@
+package server
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// This file is one half of a cross-language contract test (PLAN-2558 S3).
+//
+// handlePushToItem measures a push message in runes AFTER whitespace collapse
+// and REJECTS an over-length one with a 400 rather than truncating it. The web
+// composer has to apply the same accounting to warn the user before they
+// submit — but "the same" is a claim about Go's unicode.IsSpace vs
+// JavaScript's \s, and those two genuinely differ (U+0085 is whitespace to Go
+// only; U+FEFF to JS only). A TypeScript-only test would assert the author's
+// BELIEF about Go, not Go's behaviour.
+//
+// So both suites read one fixture. This test pins it to what the server
+// actually does; web/src/lib/push/message.test.ts pins the client to the same
+// table. If either implementation drifts, exactly one of the two goes red and
+// names the case.
+func TestPushMessageCollapseFixture(t *testing.T) {
+	type collapseCase struct {
+		Name      string `json:"name"`
+		Raw       string `json:"raw"`
+		Collapsed string `json:"collapsed"`
+		Runes     int    `json:"runes"`
+	}
+	var fixture struct {
+		Cases []collapseCase `json:"cases"`
+	}
+
+	path := filepath.Join("testdata", "push_message_cases.json")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	if err := json.Unmarshal(raw, &fixture); err != nil {
+		t.Fatalf("parse fixture: %v", err)
+	}
+	// Guard against a fixture that silently empties out (a bad merge, a
+	// rewritten generator): an empty table would make this test pass while
+	// proving nothing, which is the exact false-green shape CONVE-12 names.
+	if len(fixture.Cases) < 20 {
+		t.Fatalf("fixture has %d cases, expected the full table — did it get truncated?", len(fixture.Cases))
+	}
+
+	for _, tc := range fixture.Cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			// The exact expression handlePushToItem applies to input.Message.
+			got := strings.Join(strings.Fields(tc.Raw), " ")
+			if got != tc.Collapsed {
+				t.Errorf("collapse(%q) = %q, fixture says %q", tc.Raw, got, tc.Collapsed)
+			}
+			// The exact expression its length check applies to the result.
+			if n := len([]rune(got)); n != tc.Runes {
+				t.Errorf("len([]rune(collapse(%q))) = %d, fixture says %d", tc.Raw, n, tc.Runes)
+			}
+		})
+	}
+}
+
+// The fixture's whitespace cases are only meaningful if they agree with the
+// constant the handler actually enforces. A composer that bounds at a
+// hard-coded 4096 while the server moved on is wrong in whichever direction
+// the constant went, so pin the number the web client mirrors
+// (PUSH_MESSAGE_MAX_LEN in web/src/lib/push/message.ts).
+func TestMaxPushMessageLenIsMirroredByTheWebComposer(t *testing.T) {
+	const mirroredInWebClient = 4096
+	if maxPushMessageLen != mirroredInWebClient {
+		t.Fatalf("maxPushMessageLen = %d but web/src/lib/push/message.ts still says %d — update PUSH_MESSAGE_MAX_LEN in lockstep",
+			maxPushMessageLen, mirroredInWebClient)
+	}
+}

--- a/internal/server/testdata/push_message_cases.json
+++ b/internal/server/testdata/push_message_cases.json
@@ -1,0 +1,172 @@
+{
+  "_comment": [
+    "Shared fixture for the push-message whitespace-collapse contract (PLAN-2558 S3).",
+    "Consumed by TWO suites that must agree:",
+    "",
+    "  - internal/server/push_message_collapse_test.go asserts these are what the",
+    "    SERVER actually does: strings.Join(strings.Fields(s), \" \") plus",
+    "    len([]rune(...)), the exact pair handlePushToItem applies before its",
+    "    empty check and its maxPushMessageLen check. That test is the authority;",
+    "    this table is only true because it passes.",
+    "  - web/src/lib/push/message.test.ts asserts the composer's client-side",
+    "    accounting produces the same answers, so an over-length message is caught",
+    "    in the UI instead of coming back as a 400.",
+    "",
+    "The interesting cases pin the places Go's unicode.IsSpace and JavaScript's",
+    "\\s DISAGREE: U+0085 (Go: space, JS: not) and U+FEFF (JS: space, Go: not).",
+    "A client written against \\s is wrong in BOTH directions there, and both",
+    "characters arrive routinely via paste."
+  ],
+  "cases": [
+    {
+      "name": "plain text is unchanged",
+      "raw": "hello world",
+      "collapsed": "hello world",
+      "runes": 11
+    },
+    {
+      "name": "empty stays empty",
+      "raw": "",
+      "collapsed": "",
+      "runes": 0
+    },
+    {
+      "name": "whitespace-only collapses to empty (the server's 400 condition)",
+      "raw": "   \n\t ",
+      "collapsed": "",
+      "runes": 0
+    },
+    {
+      "name": "newline becomes a single space",
+      "raw": "a\nb",
+      "collapsed": "a b",
+      "runes": 3
+    },
+    {
+      "name": "CRLF is one separator, not two",
+      "raw": "a\r\nb",
+      "collapsed": "a b",
+      "runes": 3
+    },
+    {
+      "name": "a run of spaces becomes one",
+      "raw": "a   b",
+      "collapsed": "a b",
+      "runes": 3
+    },
+    {
+      "name": "mixed run of tab/newline/space becomes one",
+      "raw": "a \t\n  b",
+      "collapsed": "a b",
+      "runes": 3
+    },
+    {
+      "name": "leading and trailing whitespace is trimmed",
+      "raw": "   a  ",
+      "collapsed": "a",
+      "runes": 1
+    },
+    {
+      "name": "U+000B vertical tab is whitespace",
+      "raw": "a\u000bb",
+      "collapsed": "a b",
+      "runes": 3
+    },
+    {
+      "name": "U+000C form feed is whitespace",
+      "raw": "a\fb",
+      "collapsed": "a b",
+      "runes": 3
+    },
+    {
+      "name": "U+0085 NEL is whitespace to Go but NOT to JS backslash-s",
+      "raw": "a\u0085b",
+      "collapsed": "a b",
+      "runes": 3
+    },
+    {
+      "name": "U+00A0 NBSP is whitespace to both",
+      "raw": "a\u00a0b",
+      "collapsed": "a b",
+      "runes": 3
+    },
+    {
+      "name": "U+1680 OGHAM SPACE MARK is whitespace",
+      "raw": "a\u1680b",
+      "collapsed": "a b",
+      "runes": 3
+    },
+    {
+      "name": "U+2003 EM SPACE is whitespace",
+      "raw": "a\u2003b",
+      "collapsed": "a b",
+      "runes": 3
+    },
+    {
+      "name": "U+2028 LINE SEPARATOR is whitespace",
+      "raw": "a\u2028b",
+      "collapsed": "a b",
+      "runes": 3
+    },
+    {
+      "name": "U+2029 PARAGRAPH SEPARATOR is whitespace",
+      "raw": "a\u2029b",
+      "collapsed": "a b",
+      "runes": 3
+    },
+    {
+      "name": "U+202F NARROW NO-BREAK SPACE is whitespace",
+      "raw": "a\u202fb",
+      "collapsed": "a b",
+      "runes": 3
+    },
+    {
+      "name": "U+205F MEDIUM MATHEMATICAL SPACE is whitespace",
+      "raw": "a\u205fb",
+      "collapsed": "a b",
+      "runes": 3
+    },
+    {
+      "name": "U+3000 IDEOGRAPHIC SPACE is whitespace",
+      "raw": "a\u3000b",
+      "collapsed": "a b",
+      "runes": 3
+    },
+    {
+      "name": "U+FEFF BOM is NOT whitespace to Go, though JS backslash-s says it is",
+      "raw": "a\ufeffb",
+      "collapsed": "a\ufeffb",
+      "runes": 3
+    },
+    {
+      "name": "U+200B ZWSP is whitespace to neither",
+      "raw": "a\u200bb",
+      "collapsed": "a\u200bb",
+      "runes": 3
+    },
+    {
+      "name": "U+180E MONGOLIAN VOWEL SEPARATOR is not whitespace in current Unicode",
+      "raw": "a\u180eb",
+      "collapsed": "a\u180eb",
+      "runes": 3
+    },
+    {
+      "name": "an astral emoji is ONE rune, not two UTF-16 units",
+      "raw": "a \ud83d\udc4d b",
+      "collapsed": "a \ud83d\udc4d b",
+      "runes": 5
+    },
+    {
+      "name": "a combining sequence counts as two runes",
+      "raw": "e\u0301",
+      "collapsed": "e\u0301",
+      "runes": 2
+    },
+    {
+      "name": "a realistic multi-line instruction arrives as one line",
+      "raw": "Fix the bug.\n\n  Steps:\n   1. repro\n   2. patch\n",
+      "collapsed": "Fix the bug. Steps: 1. repro 2. patch",
+      "runes": 37
+    }
+  ]
+}

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -67,6 +67,8 @@ import type {
 	AttachmentTransformRequest,
 	AttachmentTransformResult,
 	ServerCapabilities,
+	LiveSessionsResponse,
+	ItemPushResult,
 	WorkspaceStorageInfo,
 	AttachmentListFilters,
 	AttachmentListResponse,
@@ -1417,7 +1419,55 @@ export const api = {
 
 		/** List all starred items in a workspace for the current user */
 		starred: (ws: string, params?: {include_terminal?: boolean}) =>
-			request<Item[]>(`/workspaces/${ws}/starred${qs(params)}`)
+			request<Item[]>(`/workspaces/${ws}/starred${qs(params)}`),
+
+		/**
+		 * Push an instruction about this item to the caller's OWN connected
+		 * agent sessions (IDEA-2544 Phase 1 / PLAN-2558 S3).
+		 *
+		 * Fire-and-forget: there is no durable inbox and no ack, so a
+		 * resolved promise means "published to the bus", never "an agent read
+		 * it". Pair the call site with `api.sessions.list()` so the user
+		 * knows whether anything is listening BEFORE they click — that pairing
+		 * is the entire reason this endpoint has a web surface.
+		 *
+		 * Self-addressed only; there is no target parameter, by design (see
+		 * handlePushToItem). `message` is collapsed and bounded server-side —
+		 * use `$lib/push/message` to apply the same rules in the composer so
+		 * over-length text is caught before it becomes a 400.
+		 *
+		 * NEVER auto-retry this. Like the copy endpoint it carries no
+		 * idempotency key, so a retry after an ambiguous failure can deliver
+		 * the same instruction twice.
+		 */
+		push: (ws: string, itemSlug: string, message: string) =>
+			request<ItemPushResult>(`/workspaces/${ws}/items/${itemSlug}/push`, {
+				method: 'POST',
+				body: JSON.stringify({ message })
+			})
+	},
+
+	// ── Agent session presence (PLAN-2558 S1) ────────────────────────────────
+
+	sessions: {
+		/**
+		 * The caller's own live event-stream connections.
+		 *
+		 * Deliberately NOT workspace-scoped: the stream is user-scoped across
+		 * every workspace the caller belongs to, so presence is too.
+		 *
+		 * Failure modes a caller must distinguish rather than flatten:
+		 *  - 503 `unavailable` — the server has no presence registry wired.
+		 *    That is "cannot tell", NOT "nobody is listening"; rendering it as
+		 *    zero is the exact lie this endpoint exists to prevent.
+		 *  - 401 — no resolved user (workspace token, or the fresh-install
+		 *    no-auth window). Also "cannot tell".
+		 *
+		 * The response is `Cache-Control: private, no-store` server-side; it
+		 * is a liveness answer with a short shelf life, so callers should
+		 * re-read it rather than hold one.
+		 */
+		list: () => request<LiveSessionsResponse>('/sessions')
 	},
 
 	// ── Versions ──────────────────────────────────────────────────────────────

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -1537,6 +1537,10 @@
 		// re-open a fresh one pointed at B, silently retargeting a mutation the
 		// user set up for A.
 		copyDialogOpen = false;
+		// Same ownership story for the push composer, and the same failure if
+		// it is skipped: the dialog is {#key itemSlug}-remounted, so a stale
+		// `true` silently reopens it pointed at B carrying A's typed message.
+		pushDialogOpen = false;
 		editCollectionOpen = false;
 		showGraph = false;
 		backlinksCount = 0;

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -41,6 +41,7 @@
 	import EditCollectionModal from '$lib/components/collections/EditCollectionModal.svelte';
 	import ShareDialog from '$lib/components/ShareDialog.svelte';
 	import CopyItemDialog from '$lib/components/items/CopyItemDialog.svelte';
+	import PushToAgentDialog from '$lib/components/items/PushToAgentDialog.svelte';
 	import ItemAttachmentStrip from '$lib/components/items/ItemAttachmentStrip.svelte';
 	import AttachmentSurfaceHost from '$lib/components/attachments/AttachmentSurfaceHost.svelte';
 	import {
@@ -3851,6 +3852,29 @@
 		paneMenuTrigger?.focus();
 	}
 
+	// ── Push to agent (PLAN-2558 S3 / IDEA-2544 Phase 3) ────────────────────
+
+	let pushDialogOpen = $state(false);
+
+	/**
+	 * Whether to offer "Push to agent…" at all. Push is SELF-ADDRESSED — the
+	 * server always targets the caller's own user id, never a request-supplied
+	 * one — so the gate is "is there a resolved user", not `canEdit`: a viewer
+	 * pushing an item into their own session is reading, not writing. Without a
+	 * resolved user (a workspace-scoped token, a share-link guest, the
+	 * fresh-install no-auth window) the endpoint 401s, so the row would be a
+	 * button that cannot work.
+	 */
+	let canPush = $derived(authStore.authenticated);
+
+	/** Same focus-restore contract as `closeCopyDialog` — see its doc comment
+	 *  for why the ⋯ trigger, and why the `tick()` is load-bearing. */
+	async function closePushDialog() {
+		pushDialogOpen = false;
+		await tick();
+		paneMenuTrigger?.focus();
+	}
+
 	/**
 	 * Foreground-flush whatever the user has typed into `items.content` before a
 	 * copy previews or commits. Resolves false when the flush FAILED, which
@@ -4828,6 +4852,22 @@
 								Copy or move to workspace…
 							</MenuItem>
 						{/if}
+						{#if canPush}
+							<!-- Launcher only; the composer is a Modal. Gated on a
+							     resolved user rather than `canEdit` — the push is
+							     addressed to the caller's OWN sessions, so a viewer
+							     qualifies (see `canPush`). -->
+							<MenuItem
+								icon="➤"
+								onclick={() => {
+									paneMenuOpen = false;
+									paneMenuView = 'root';
+									pushDialogOpen = true;
+								}}
+							>
+								Push to agent…
+							</MenuItem>
+						{/if}
 						{#if isOwner}
 							<MenuItem icon="⇗" onclick={() => { paneMenuOpen = false; shareDialogOpen = true; }}>
 								Share…
@@ -5698,6 +5738,27 @@
 				flushContent={flushContentBeforeCopy}
 				onmove={handleMove}
 				oncopied={handleCopied}
+			/>
+		{/key}
+	{/if}
+
+	{#if canPush && item}
+		<!--
+			Push-to-agent composer (PLAN-2558 S3).
+
+			{#key itemSlug}: same reasoning as the copy dialog above — this pane is
+			persistent, and the composed message belongs to ONE item. Remounting on
+			switch also drops the presence poll's interval with the old instance.
+			Not wrapped in {#if open}: Modal's consumer contract.
+		-->
+		{#key itemSlug}
+			<PushToAgentDialog
+				open={pushDialogOpen}
+				onclose={closePushDialog}
+				{wsSlug}
+				itemSlug={item.slug}
+				itemRef={formatItemRef(item) || item.slug}
+				itemTitle={item.title}
 			/>
 		{/key}
 	{/if}

--- a/web/src/lib/components/items/PushToAgentDialog.svelte
+++ b/web/src/lib/components/items/PushToAgentDialog.svelte
@@ -1,0 +1,501 @@
+<!--
+@component
+PushToAgentDialog — compose an instruction about an item and push it to the
+user's own connected agent sessions (PLAN-2558 S3, IDEA-2544 Phase 3).
+
+Built on the shared `Modal` primitive, same as CopyItemDialog: the composer
+needs more room than the pane menu's drill-down affords, and the native
+`<dialog>` supplies focus trap + Escape + top-layer. Consumer obligations from
+Modal's docs are honored — it is NOT wrapped in `{#if open}`, and `labelledby`
+points at the heading.
+
+THE POINT OF THIS DIALOG IS THE PRESENCE LINE, NOT THE TEXTAREA. `pad push` is
+fire-and-forget: no durable inbox, no ack, no "nobody was listening" warning
+(handlers_push.go — Dave's product call, and defensible for a CLI verb typed by
+someone who knows their own session is running). A button in a web UI has no
+such user. So this dialog answers "is anything listening?" BEFORE the click, and
+words the answer at exactly the confidence the server can support:
+
+  - N > 0        → "N session connected". NOT "this will be delivered". The
+                   registry can name a session that died up to ~30s ago (an
+                   ungraceful disconnect is invisible until the next keepalive
+                   write fails), and even a live session gets no delivery
+                   receipt. Send is enabled; the caveat is stated, not implied.
+  - N == 0       → send is DISABLED. With nothing listening, a push is not
+                   "probably lost" — it is definitively lost, because there is
+                   no inbox to land in. Offering the button anyway would make
+                   this surface worse than the clipboard ferry it replaces, so
+                   the empty state offers the clipboard instead (the same
+                   fallback PLAN-2558 S4 rules for quick actions).
+  - can't tell   → send is ENABLED, with the uncertainty stated. A 503 (no
+                   presence registry wired) or a network failure means the
+                   server cannot answer, and rendering that as zero is the
+                   precise lie handleListSessions refuses to tell by returning
+                   503 rather than an empty list. Blocking the user on our own
+                   inability to check would inherit the same false confidence
+                   in the other direction.
+
+The bound is enforced client-side (`$lib/push/message`) against the server's
+own rune-after-collapse accounting, so an over-length message is caught in the
+composer rather than coming back as a 400.
+-->
+<script lang="ts">
+	import { untrack } from 'svelte';
+	import Modal from '$lib/components/common/Modal.svelte';
+	import Button from '$lib/components/common/Button.svelte';
+	import { api, PadApiError } from '$lib/api/client';
+	import { toastStore } from '$lib/stores/toast.svelte';
+	import { relativeTime } from '$lib/utils/markdown';
+	import {
+		PUSH_MESSAGE_MAX_LEN,
+		collapsePushMessage,
+		defaultPushMessage,
+		isPushMessageEmpty,
+		isPushMessageTooLong,
+		pushMessageLength
+	} from '$lib/push/message';
+	import type { LiveSession } from '$lib/types';
+
+	interface Props {
+		open: boolean;
+		/** Dismissal request from Escape / backdrop / Cancel / a completed send.
+		 *  The parent flips `open` and restores focus to the ⋯ trigger. */
+		onclose: () => void;
+		wsSlug: string;
+		/** The item's slug, used to address the endpoint. */
+		itemSlug: string;
+		/** Human ref for the heading and the prefill, e.g. "TASK-14". */
+		itemRef: string;
+		itemTitle: string;
+	}
+
+	let { open, onclose, wsSlug, itemSlug, itemRef, itemTitle }: Props = $props();
+
+	const uid = $props.id();
+	const titleId = `push-dialog-title-${uid}`;
+	const textareaId = `push-dialog-message-${uid}`;
+	const counterId = `push-dialog-counter-${uid}`;
+
+	/**
+	 * Presence re-read cadence while the dialog is open. A session can connect
+	 * or drop mid-compose, and the whole value of this surface is that the
+	 * count is true at the moment of the click rather than at mount.
+	 *
+	 * 10s is affordable: GET /api/v1/sessions falls through to the general API
+	 * limiter (600 req/min per user, burst 60) and is in no strict per-path
+	 * bucket, so a poll open for an hour costs 360 of a 36,000-request budget.
+	 * It is also the right ORDER of magnitude for the underlying signal — the
+	 * registry's own worst-case staleness is ~30s (keepalive interval), so
+	 * polling much faster would buy precision the data doesn't have.
+	 */
+	const PRESENCE_POLL_MS = 10_000;
+
+	/**
+	 * What we know about who is listening.
+	 *  - 'checking': first read of this opening is in flight, no answer yet.
+	 *  - 'known':    a 200 answered; `count` is authoritative (modulo the ~30s
+	 *                staleness every consumer of this data carries).
+	 *  - 'unknown':  the server could not answer (503 / 401) or the request
+	 *                failed. NOT zero — see this component's header.
+	 */
+	type PresenceState = 'checking' | 'known' | 'unknown';
+	let presenceState = $state<PresenceState>('checking');
+	let sessions = $state<LiveSession[]>([]);
+	let presenceReason = $state('');
+
+	let message = $state('');
+	let sending = $state(false);
+	let sendError = $state('');
+
+	/**
+	 * Fence for async presence writes. Plain `let`, never $state: it is read and
+	 * written only inside the loader and the open effect, never in reactive
+	 * position. Incremented on every open so a response in flight when the user
+	 * closes and reopens (or the parent remounts on an item switch) cannot write
+	 * a stale count into the new opening — the no-`{#key}` late-continuation
+	 * class this codebase keeps hitting.
+	 */
+	let presenceGen = 0;
+
+	const sessionCount = $derived(sessions.length);
+	const collapsed = $derived(collapsePushMessage(message));
+	const messageLength = $derived(pushMessageLength(message));
+	const tooLong = $derived(isPushMessageTooLong(message));
+	const empty = $derived(isPushMessageEmpty(message));
+
+	/**
+	 * True when the collapse will visibly change what the user typed. Surfaced
+	 * because `Notification.Summary` is a single-line wire contract — a composer
+	 * that silently reflows three paragraphs into one line misrepresents the
+	 * channel, and the user should find that out here rather than by reading
+	 * their own message in a terminal.
+	 */
+	const willCollapse = $derived(message.trim() !== '' && collapsed !== message.trim());
+
+	/** Nothing is listening, and we are sure of it. The only state that blocks
+	 *  send on presence grounds — 'unknown' deliberately does not. */
+	const noListeners = $derived(presenceState === 'known' && sessionCount === 0);
+
+	const canSend = $derived(
+		!sending && !empty && !tooLong && !noListeners && presenceState !== 'checking'
+	);
+
+	async function refreshPresence(gen: number): Promise<void> {
+		try {
+			const resp = await api.sessions.list();
+			if (gen !== presenceGen) return;
+			sessions = resp.sessions ?? [];
+			presenceState = 'known';
+			presenceReason = '';
+		} catch (err) {
+			if (gen !== presenceGen) return;
+			// Every failure lands here as 'unknown', never as zero. The message
+			// distinguishes the one case a self-hosted user can act on (the
+			// server has no presence registry) from a transient read failure.
+			sessions = [];
+			presenceState = 'unknown';
+			presenceReason =
+				err instanceof PadApiError && err.code === 'unavailable'
+					? 'This server has no session presence registry.'
+					: 'Could not reach the server to check.';
+		}
+	}
+
+	// Fresh-on-open reset + presence polling.
+	//
+	// CONVE-1688: the tracked scope reads `open` (a prop) and nothing else. Every
+	// $state write — and every prop read that must NOT re-trigger this effect —
+	// is inside `untrack`, so the effect cannot self-invalidate, and a title edit
+	// arriving over SSE mid-compose cannot clobber what the user has typed.
+	$effect(() => {
+		if (!open) return;
+
+		const gen = untrack(() => {
+			presenceGen += 1;
+			message = defaultPushMessage(itemRef, itemTitle);
+			sending = false;
+			sendError = '';
+			sessions = [];
+			presenceState = 'checking';
+			presenceReason = '';
+			return presenceGen;
+		});
+
+		void refreshPresence(gen);
+		const timer = setInterval(() => void refreshPresence(gen), PRESENCE_POLL_MS);
+		return () => clearInterval(timer);
+	});
+
+	function handleDismiss() {
+		if (sending) return;
+		// Invalidate any in-flight presence read so it cannot write after close.
+		presenceGen += 1;
+		onclose();
+	}
+
+	async function handleSend() {
+		if (!canSend) return;
+		sending = true;
+		sendError = '';
+		try {
+			// NEVER retried, at this call site or any other: the endpoint carries
+			// no idempotency key, so a retry on an ambiguous failure can deliver
+			// the same instruction twice.
+			await api.items.push(wsSlug, itemSlug, collapsed);
+			// Honest past tense: the notification was published. Whether an agent
+			// read it is not something the server can tell us, so the toast does
+			// not claim it.
+			toastStore.show(`Pushed to ${itemRef} — delivery isn’t confirmed`, 'success');
+			sending = false;
+			handleDismiss();
+		} catch (err) {
+			sending = false;
+			sendError =
+				err instanceof PadApiError || err instanceof Error
+					? err.message
+					: 'Failed to push the message.';
+		}
+	}
+
+	/** Clipboard fallback for the no-listeners state — the same escape hatch
+	 *  PLAN-2558 S4 rules for quick actions, so the surface is never a dead end. */
+	async function handleCopyInstead() {
+		try {
+			await navigator.clipboard.writeText(collapsed);
+			toastStore.show('Copied to clipboard', 'success');
+			handleDismiss();
+		} catch {
+			toastStore.show('Failed to copy to clipboard', 'error');
+		}
+	}
+
+	function sessionName(session: LiveSession): string {
+		// An unlabelled session is shown by a short id rather than hidden: the
+		// list's job is to account for every listener, and "unlabelled" is not
+		// the same as "not there".
+		const base = session.label || `session ${session.id.slice(0, 8)}`;
+		return session.pid ? `${base} (pid ${session.pid})` : base;
+	}
+</script>
+
+<Modal
+	{open}
+	onclose={handleDismiss}
+	labelledby={titleId}
+	maxWidth="560px"
+	closeOnBackdrop={!sending}
+	class="push-dialog"
+>
+	<div class="modal-header">
+		<h2 id={titleId}>Push {itemRef} to an agent</h2>
+		<button
+			class="close-btn"
+			type="button"
+			aria-label="Close"
+			disabled={sending}
+			onclick={handleDismiss}>&#10005;</button
+		>
+	</div>
+
+	<div class="modal-body">
+		<!-- ── Who is listening ──────────────────────────────────────────────
+		     role="status" so a count that changes under the user (a session
+		     drops mid-compose) is announced rather than silently flipping the
+		     Send button's disabled state. -->
+		<section class="presence" role="status">
+			{#if presenceState === 'checking'}
+				<p class="muted">Checking for connected agent sessions…</p>
+			{:else if presenceState === 'unknown'}
+				<p class="notice notice-warn">
+					<strong>Can’t tell whether any agent session is connected.</strong>
+					{presenceReason} You can still send — but nothing here knows whether it will
+					land anywhere.
+				</p>
+			{:else if sessionCount === 0}
+				<p class="notice notice-warn">
+					<strong>No agent session is connected.</strong>
+					A push isn’t stored anywhere — with nothing listening it would be lost, not
+					queued. Start a session (<code>pad watch --stream</code>) and it will appear
+					here, or copy the message and paste it yourself.
+				</p>
+			{:else}
+				<p class="presence-ok">
+					<strong
+						>{sessionCount}
+						{sessionCount === 1 ? 'session' : 'sessions'} connected</strong
+					>
+					— Pad can’t confirm delivery, only that something is listening.
+				</p>
+				<ul class="session-list">
+					{#each sessions as session (session.id)}
+						<li>
+							<span class="session-name">{sessionName(session)}</span>
+							<span class="muted">connected {relativeTime(session.connected_at)}</span>
+						</li>
+					{/each}
+				</ul>
+			{/if}
+		</section>
+
+		<!-- ── Message ───────────────────────────────────────────────────── -->
+		<section class="section">
+			<label class="field-label" for={textareaId}>Message</label>
+			<textarea
+				id={textareaId}
+				class="composer"
+				rows="4"
+				bind:value={message}
+				disabled={sending}
+				aria-describedby={counterId}
+				placeholder="What should the agent do with this item?"
+			></textarea>
+
+			<div class="composer-meta">
+				<span id={counterId} class="counter" class:over={tooLong}>
+					{messageLength} / {PUSH_MESSAGE_MAX_LEN}
+				</span>
+				{#if tooLong}
+					<span class="notice-inline" role="alert">
+						Too long — trim {messageLength - PUSH_MESSAGE_MAX_LEN} character{messageLength -
+							PUSH_MESSAGE_MAX_LEN ===
+						1
+							? ''
+							: 's'} before sending.
+					</span>
+				{:else if willCollapse}
+					<span class="muted">
+						Line breaks and repeated spaces are collapsed — this arrives as one line.
+					</span>
+				{/if}
+			</div>
+		</section>
+
+		{#if sendError}
+			<p class="notice notice-error" role="alert">{sendError}</p>
+		{/if}
+	</div>
+
+	<div class="modal-footer">
+		{#if sending}
+			<span class="muted footer-status" role="status">Sending…</span>
+		{/if}
+		<Button variant="secondary" disabled={sending} onclick={handleDismiss}>Cancel</Button>
+		{#if noListeners}
+			<Button variant="secondary" disabled={empty || tooLong} onclick={handleCopyInstead}>
+				Copy instead
+			</Button>
+		{/if}
+		<Button variant="primary" disabled={!canSend} onclick={handleSend}>
+			{sending ? 'Sending…' : 'Push'}
+		</Button>
+	</div>
+</Modal>
+
+<style>
+	.modal-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: var(--space-3);
+		padding: var(--space-4);
+		border-bottom: 1px solid var(--border);
+		flex-shrink: 0;
+	}
+	.modal-header h2 {
+		margin: 0;
+		font-size: 1rem;
+		font-weight: 600;
+	}
+	.close-btn {
+		background: none;
+		border: none;
+		color: var(--text-muted);
+		cursor: pointer;
+		font-size: 1rem;
+		line-height: 1;
+		padding: var(--space-1);
+	}
+	.close-btn:disabled {
+		opacity: 0.4;
+		cursor: not-allowed;
+	}
+
+	.modal-body {
+		padding: var(--space-4);
+		overflow-y: auto;
+		flex: 1 1 auto;
+		min-height: 0;
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-4);
+	}
+
+	.modal-footer {
+		display: flex;
+		align-items: center;
+		justify-content: flex-end;
+		gap: var(--space-2);
+		padding: var(--space-3) var(--space-4);
+		border-top: 1px solid var(--border);
+		flex-shrink: 0;
+	}
+	.footer-status {
+		margin-right: auto;
+	}
+
+	.section,
+	.presence {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-2);
+	}
+
+	.field-label {
+		font-size: 0.8125rem;
+		font-weight: 600;
+		color: var(--text-muted);
+	}
+
+	/* Border / background / padding come from app.css's global
+	   `input, textarea, select` rule — only the box behaviour is local. */
+	.composer {
+		width: 100%;
+		box-sizing: border-box;
+		resize: vertical;
+	}
+	.composer:disabled {
+		opacity: 0.6;
+	}
+
+	.composer-meta {
+		display: flex;
+		align-items: baseline;
+		justify-content: space-between;
+		gap: var(--space-3);
+		font-size: 0.8125rem;
+		flex-wrap: wrap;
+	}
+	.counter {
+		color: var(--text-muted);
+		font-variant-numeric: tabular-nums;
+		flex-shrink: 0;
+	}
+	.counter.over {
+		color: var(--accent-red);
+		font-weight: 600;
+	}
+	.notice-inline {
+		color: var(--accent-red);
+	}
+
+	.presence-ok {
+		margin: 0;
+		font-size: 0.875rem;
+	}
+
+	.session-list {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-1);
+		font-size: 0.8125rem;
+	}
+	.session-list li {
+		display: flex;
+		gap: var(--space-2);
+		align-items: baseline;
+		flex-wrap: wrap;
+	}
+	.session-name {
+		font-weight: 600;
+	}
+
+	/* Same notice treatment as CopyItemDialog, so the two dialogs in this
+	   pane's ⋯ menu read as one surface. */
+	.notice {
+		margin: 0;
+		padding: var(--space-2) var(--space-3);
+		border-radius: var(--radius);
+		font-size: 0.85rem;
+		line-height: 1.5;
+		border: 1px solid var(--border);
+		background: var(--bg-secondary);
+	}
+	.notice-warn {
+		border-left: 3px solid var(--accent-orange);
+	}
+	.notice-error {
+		border-left: 3px solid var(--accent-red);
+	}
+	.notice code {
+		font-size: 0.8125em;
+	}
+
+	.muted {
+		color: var(--text-muted);
+		font-size: 0.8125rem;
+		margin: 0;
+	}
+</style>

--- a/web/src/lib/components/items/PushToAgentDialog.svelte
+++ b/web/src/lib/components/items/PushToAgentDialog.svelte
@@ -290,6 +290,12 @@ server tells you not to run would cost honesty in the case that actually ships.
 				sessions = [];
 				presenceState = 'unknown';
 				presenceReason = 'The last check was a while ago and hasn’t refreshed.';
+				// Retire every request already in flight (codex round 3). Those
+				// were issued BEFORE the expiry, so their answers describe the
+				// server as it was back then — letting one land now would restore
+				// the very count we just declared too old to trust. The poll
+				// issued immediately below carries a newer seq and still applies.
+				presenceAppliedSeq = presenceSeq;
 			}
 			void refreshPresence(gen);
 		}, PRESENCE_POLL_MS);
@@ -339,7 +345,11 @@ server tells you not to run would cost honesty in the case that actually ships.
 		'permission_denied', // workspace-access middleware
 		'unavailable', // the bus isn't wired — nothing to publish TO
 		'rate_limited', // the client's own 429 shape; the handler never ran
-		'plan_limit_exceeded'
+		'plan_limit_exceeded',
+		// Middleware, so strictly before the handler: nothing can have been
+		// published by the time either of these is written.
+		'csrf_error',
+		'email_not_verified'
 	]);
 
 	async function handleSend() {

--- a/web/src/lib/components/items/PushToAgentDialog.svelte
+++ b/web/src/lib/components/items/PushToAgentDialog.svelte
@@ -38,6 +38,17 @@ words the answer at exactly the confidence the server can support:
 The bound is enforced client-side (`$lib/push/message`) against the server's
 own rune-after-collapse accounting, so an over-length message is caught in the
 composer rather than coming back as a 400.
+
+DEPLOYMENT CONSTRAINT, inherited not created. Both the presence registry and
+the event bus are per-PROCESS (`internal/server/session_presence.go`'s
+SINGLE-PROCESS LIMITATION note). Behind more than one padd process a load
+balancer can route the presence GET and the push POST to different instances,
+and then every claim on this surface — including "No agent session is
+connected" — can be wrong. That file already states the rule ("Do not put the
+web-UI push surface in front of a multi-process deployment until both exist");
+this dialog is the surface it means. The copy below is written for the
+single-process case ON PURPOSE: hedging every sentence for a deployment the
+server tells you not to run would cost honesty in the case that actually ships.
 -->
 <script lang="ts">
 	import { untrack } from 'svelte';
@@ -52,7 +63,8 @@ composer rather than coming back as a 400.
 		defaultPushMessage,
 		isPushMessageEmpty,
 		isPushMessageTooLong,
-		pushMessageLength
+		pushMessageLength,
+		trimPushMessage
 	} from '$lib/push/message';
 	import type { LiveSession } from '$lib/types';
 
@@ -75,6 +87,7 @@ composer rather than coming back as a 400.
 	const titleId = `push-dialog-title-${uid}`;
 	const textareaId = `push-dialog-message-${uid}`;
 	const counterId = `push-dialog-counter-${uid}`;
+	const noteId = `push-dialog-note-${uid}`;
 
 	/**
 	 * Presence re-read cadence while the dialog is open. A session can connect
@@ -89,6 +102,11 @@ composer rather than coming back as a 400.
 	 * polling much faster would buy precision the data doesn't have.
 	 */
 	const PRESENCE_POLL_MS = 10_000;
+
+	/** How long to stay in 'checking' before admitting we cannot tell. Shorter
+	 *  than one poll interval, so a stalled first read never leaves Push dead
+	 *  and unexplained while the user waits for a beat that may not help. */
+	const PRESENCE_STALL_MS = 5_000;
 
 	/**
 	 * What we know about who is listening.
@@ -106,16 +124,33 @@ composer rather than coming back as a 400.
 	let message = $state('');
 	let sending = $state(false);
 	let sendError = $state('');
+	/**
+	 * Set when a send failed in a way that leaves the OUTCOME UNKNOWN — the
+	 * request was dispatched but the server never told us what happened to it.
+	 * Push is not re-armed in that state: the endpoint has no idempotency key,
+	 * so a second click can publish the same instruction twice. Same rule
+	 * CopyItemDialog applies for the same reason (DR-13), and drawn at the same
+	 * line — "was the mutation dispatched?", not "did the server say it failed?".
+	 */
+	let outcomeUnknown = $state(false);
 
 	/**
-	 * Fence for async presence writes. Plain `let`, never $state: it is read and
-	 * written only inside the loader and the open effect, never in reactive
-	 * position. Incremented on every open so a response in flight when the user
-	 * closes and reopens (or the parent remounts on an item switch) cannot write
-	 * a stale count into the new opening — the no-`{#key}` late-continuation
-	 * class this codebase keeps hitting.
+	 * Fences for async writes. Plain `let`s, never $state: read and written only
+	 * inside handlers, never in reactive position.
+	 *
+	 * TWO counters, because they fence different things:
+	 *  - `presenceGen` identifies one OPENING of the dialog. A response in
+	 *    flight when the user closes and reopens (or the parent remounts on an
+	 *    item switch) must not write into the new opening.
+	 *  - `presenceSeq` identifies one REQUEST. Polls are 10s apart but nothing
+	 *    bounds how long one takes, so a stalled poll can resolve AFTER a later
+	 *    one and overwrite a fresher count with an older one — re-enabling Push
+	 *    against a session list that is already gone. Only a strictly newer
+	 *    response is applied.
 	 */
 	let presenceGen = 0;
+	let presenceSeq = 0;
+	let presenceAppliedSeq = 0;
 
 	const sessionCount = $derived(sessions.length);
 	const collapsed = $derived(collapsePushMessage(message));
@@ -130,25 +165,41 @@ composer rather than coming back as a 400.
 	 * channel, and the user should find that out here rather than by reading
 	 * their own message in a terminal.
 	 */
-	const willCollapse = $derived(message.trim() !== '' && collapsed !== message.trim());
+	// Compared against the GO-trimmed message, not `String.trim()`. The two
+	// disagree on exactly the characters `$lib/push/message` exists to get right
+	// (JS trims a leading U+FEFF that the server keeps; it leaves a U+0085 the
+	// server strips), so using `trim()` here would warn about a collapse that
+	// isn't going to happen — and stay silent about one that is.
+	const willCollapse = $derived(collapsed !== '' && collapsed !== trimPushMessage(message));
 
 	/** Nothing is listening, and we are sure of it. The only state that blocks
 	 *  send on presence grounds — 'unknown' deliberately does not. */
 	const noListeners = $derived(presenceState === 'known' && sessionCount === 0);
 
 	const canSend = $derived(
-		!sending && !empty && !tooLong && !noListeners && presenceState !== 'checking'
+		!sending &&
+			!outcomeUnknown &&
+			!empty &&
+			!tooLong &&
+			!noListeners &&
+			presenceState !== 'checking'
 	);
 
 	async function refreshPresence(gen: number): Promise<void> {
+		const seq = ++presenceSeq;
+		/** Apply only if this opening is still current AND no newer response
+		 *  has already landed. */
+		const stillCurrent = () => gen === presenceGen && seq > presenceAppliedSeq;
 		try {
 			const resp = await api.sessions.list();
-			if (gen !== presenceGen) return;
+			if (!stillCurrent()) return;
+			presenceAppliedSeq = seq;
 			sessions = resp.sessions ?? [];
 			presenceState = 'known';
 			presenceReason = '';
 		} catch (err) {
-			if (gen !== presenceGen) return;
+			if (!stillCurrent()) return;
+			presenceAppliedSeq = seq;
 			// Every failure lands here as 'unknown', never as zero. The message
 			// distinguishes the one case a self-hosted user can act on (the
 			// server has no presence registry) from a transient read failure.
@@ -172,9 +223,11 @@ composer rather than coming back as a 400.
 
 		const gen = untrack(() => {
 			presenceGen += 1;
+			presenceAppliedSeq = 0;
 			message = defaultPushMessage(itemRef, itemTitle);
 			sending = false;
 			sendError = '';
+			outcomeUnknown = false;
 			sessions = [];
 			presenceState = 'checking';
 			presenceReason = '';
@@ -183,7 +236,20 @@ composer rather than coming back as a 400.
 
 		void refreshPresence(gen);
 		const timer = setInterval(() => void refreshPresence(gen), PRESENCE_POLL_MS);
-		return () => clearInterval(timer);
+		// Nothing bounds how long `/sessions` may take, and 'checking' disables
+		// Push — so a request that never settles would strand the composer with
+		// a dead button and no explanation. After this long, stop waiting and
+		// say what is true: we cannot tell. A later response still lands (the
+		// sequence fence lets it) and upgrades the answer.
+		const stall = setTimeout(() => {
+			if (gen !== presenceGen || presenceState !== 'checking') return;
+			presenceState = 'unknown';
+			presenceReason = 'The server hasn’t answered.';
+		}, PRESENCE_STALL_MS);
+		return () => {
+			clearInterval(timer);
+			clearTimeout(stall);
+		};
 	});
 
 	function handleDismiss() {
@@ -195,34 +261,55 @@ composer rather than coming back as a 400.
 
 	async function handleSend() {
 		if (!canSend) return;
+		// Fence the continuation against the parent switching items mid-flight:
+		// the dialog is {#key itemSlug}-remounted, so a late `onclose()` from
+		// item A's send would close the composer the user just opened for B.
+		const gen = presenceGen;
 		sending = true;
 		sendError = '';
 		try {
-			// NEVER retried, at this call site or any other: the endpoint carries
-			// no idempotency key, so a retry on an ambiguous failure can deliver
-			// the same instruction twice.
+			// NEVER retried automatically, at this call site or any other: the
+			// endpoint carries no idempotency key.
 			await api.items.push(wsSlug, itemSlug, collapsed);
-			// Honest past tense: the notification was published. Whether an agent
-			// read it is not something the server can tell us, so the toast does
-			// not claim it.
-			toastStore.show(`Pushed to ${itemRef} — delivery isn’t confirmed`, 'success');
 			sending = false;
+			// The toast fires regardless of a switch — the push really happened,
+			// and suppressing the confirmation would be the dishonest half.
+			// Honest past tense: the notification was PUBLISHED. Whether an agent
+			// read it is not something the server can tell us.
+			toastStore.show(`Pushed to ${itemRef} — delivery isn’t confirmed`, 'success');
+			if (gen !== presenceGen) return;
 			handleDismiss();
 		} catch (err) {
 			sending = false;
-			sendError =
-				err instanceof PadApiError || err instanceof Error
-					? err.message
-					: 'Failed to push the message.';
+			if (gen !== presenceGen) return;
+			// Ambiguity rule, drawn where CopyItemDialog draws it: a STRUCTURED
+			// error means the server responded and therefore refused before
+			// publishing (`bad_request` on empty/over-length, `not_found`,
+			// `forbidden`, `unavailable` when the bus is unwired) — safe to fix
+			// and send again. An UNSTRUCTURED failure (rejected fetch, non-JSON
+			// 502, timeout) means the request went out and we never learned its
+			// fate; the handler publishes BEFORE it writes the response, so the
+			// message may well have been delivered. Re-arming Push there offers
+			// the user a duplicate, so we don't.
+			if (err instanceof PadApiError) {
+				sendError = err.message;
+			} else {
+				outcomeUnknown = true;
+				sendError =
+					'The server didn’t answer, so we can’t tell whether this was sent. ' +
+					'Check your agent session before sending it again — pushing twice would deliver it twice.';
+			}
 		}
 	}
 
 	/** Clipboard fallback for the no-listeners state — the same escape hatch
 	 *  PLAN-2558 S4 rules for quick actions, so the surface is never a dead end. */
 	async function handleCopyInstead() {
+		const gen = presenceGen;
 		try {
 			await navigator.clipboard.writeText(collapsed);
 			toastStore.show('Copied to clipboard', 'success');
+			if (gen !== presenceGen) return;
 			handleDismiss();
 		} catch {
 			toastStore.show('Failed to copy to clipboard', 'error');
@@ -284,7 +371,12 @@ composer rather than coming back as a 400.
 						>{sessionCount}
 						{sessionCount === 1 ? 'session' : 'sessions'} connected</strong
 					>
-					— Pad can’t confirm delivery, only that something is listening.
+					<!-- Two separate hedges, both load-bearing. The registry can name a
+					     session that dropped ungracefully up to ~30s ago, so even
+					     "was listening" is past tense; and nothing acknowledges a
+					     push, so delivery is never confirmable. -->
+					— as of the last check. Pad can’t confirm delivery, and a session
+					that dropped in the last ~30 seconds can still be listed here.
 				</p>
 				<ul class="session-list">
 					{#each sessions as session (session.id)}
@@ -306,7 +398,8 @@ composer rather than coming back as a 400.
 				rows="4"
 				bind:value={message}
 				disabled={sending}
-				aria-describedby={counterId}
+				aria-invalid={tooLong ? 'true' : undefined}
+				aria-describedby="{counterId} {noteId}"
 				placeholder="What should the agent do with this item?"
 			></textarea>
 
@@ -314,19 +407,36 @@ composer rather than coming back as a 400.
 				<span id={counterId} class="counter" class:over={tooLong}>
 					{messageLength} / {PUSH_MESSAGE_MAX_LEN}
 				</span>
-				{#if tooLong}
-					<span class="notice-inline" role="alert">
+				<!--
+					One stable node for BOTH the over-length error and the
+					collapse note, always present and always referenced by the
+					textarea's aria-describedby.
+
+					Two reasons it isn't two conditionally-rendered spans: an
+					`aria-describedby` pointing at an id that isn't in the
+					document resolves to nothing (so a note that appears only
+					when relevant is announced by nobody), and swapping the
+					referenced node in and out is what makes assistive tech miss
+					the change. `role="status"` announces politely as the text
+					swaps; the over-length case escalates to `alert` because it
+					is a blocking condition, not an aside.
+				-->
+				<span
+					id={noteId}
+					class:notice-inline={tooLong}
+					class:muted={!tooLong}
+					role={tooLong ? 'alert' : 'status'}
+				>
+					{#if tooLong}
 						Too long — trim {messageLength - PUSH_MESSAGE_MAX_LEN} character{messageLength -
 							PUSH_MESSAGE_MAX_LEN ===
 						1
 							? ''
 							: 's'} before sending.
-					</span>
-				{:else if willCollapse}
-					<span class="muted">
+					{:else if willCollapse}
 						Line breaks and repeated spaces are collapsed — this arrives as one line.
-					</span>
-				{/if}
+					{/if}
+				</span>
 			</div>
 		</section>
 

--- a/web/src/lib/components/items/PushToAgentDialog.svelte
+++ b/web/src/lib/components/items/PushToAgentDialog.svelte
@@ -109,6 +109,18 @@ server tells you not to run would cost honesty in the case that actually ships.
 	const PRESENCE_STALL_MS = 5_000;
 
 	/**
+	 * How stale a 'known' answer may get before it degrades to 'can't tell'.
+	 *
+	 * 30s is not arbitrary: it is the server's own worst-case presence
+	 * staleness (watchEventsKeepaliveInterval — an ungraceful disconnect is
+	 * invisible until the next keepalive write fails). Past that, an
+	 * un-refreshed count is no more informative than no count, so continuing to
+	 * render it as fact would be the same overclaim in slow motion. Three poll
+	 * intervals must fail in a row to reach it.
+	 */
+	const PRESENCE_MAX_AGE_MS = 30_000;
+
+	/**
 	 * What we know about who is listening.
 	 *  - 'checking': first read of this opening is in flight, no answer yet.
 	 *  - 'known':    a 200 answered; `count` is authoritative (modulo the ~30s
@@ -151,6 +163,25 @@ server tells you not to run would cost honesty in the case that actually ships.
 	let presenceGen = 0;
 	let presenceSeq = 0;
 	let presenceAppliedSeq = 0;
+	/** Wall-clock of the last SUCCESSFUL presence read, for the staleness
+	 *  expiry in the poll below. */
+	let lastAnsweredAt = 0;
+
+	/**
+	 * True once this component instance has been torn down.
+	 *
+	 * `presenceGen` cannot cover this case, and assuming it could was the bug
+	 * (codex round 2): the parent remounts this dialog under `{#key itemSlug}`,
+	 * so item B gets a NEW instance with its OWN counters. A's in-flight send
+	 * therefore still sees `gen === presenceGen` — A's own, untouched — and
+	 * calls the SHARED parent `onclose`, closing the composer the user just
+	 * opened for B. A per-instance liveness flag is the thing that actually
+	 * distinguishes "still mine to close" from "I no longer exist".
+	 */
+	let destroyed = false;
+	$effect(() => () => {
+		destroyed = true;
+	});
 
 	const sessionCount = $derived(sessions.length);
 	const collapsed = $derived(collapsePushMessage(message));
@@ -187,13 +218,26 @@ server tells you not to run would cost honesty in the case that actually ships.
 
 	async function refreshPresence(gen: number): Promise<void> {
 		const seq = ++presenceSeq;
-		/** Apply only if this opening is still current AND no newer response
-		 *  has already landed. */
+		/**
+		 * Apply only if this opening is still current AND no newer response has
+		 * already landed.
+		 *
+		 * Deliberately "latest ARRIVED", not "latest ISSUED" (codex round 2).
+		 * If request 1 stalls and request 2 is issued, a late-but-first arrival
+		 * from request 1 IS applied — because the alternative, dropping it
+		 * because a newer request exists, leaves the UI holding older data when
+		 * that newer request is the one that never settles. Any answer beats no
+		 * answer; what must never happen is an OLDER answer overwriting a newer
+		 * one, and that is what the `>` fence prevents. `presenceAppliedSeq`
+		 * resets to 0 per opening, which is safe because `gen` already rejects
+		 * responses from a previous one.
+		 */
 		const stillCurrent = () => gen === presenceGen && seq > presenceAppliedSeq;
 		try {
 			const resp = await api.sessions.list();
 			if (!stillCurrent()) return;
 			presenceAppliedSeq = seq;
+			lastAnsweredAt = Date.now();
 			sessions = resp.sessions ?? [];
 			presenceState = 'known';
 			presenceReason = '';
@@ -235,7 +279,20 @@ server tells you not to run would cost honesty in the case that actually ships.
 		});
 
 		void refreshPresence(gen);
-		const timer = setInterval(() => void refreshPresence(gen), PRESENCE_POLL_MS);
+		const timer = setInterval(() => {
+			// Expire a 'known' answer that has stopped being refreshed (codex
+			// round 2). The stall timeout below only rescues the FIRST read; a
+			// later poll that hangs would otherwise freeze the count at its last
+			// value forever, leaving Push armed against a session list nobody has
+			// confirmed in minutes. Past PRESENCE_MAX_AGE_MS our answer carries no
+			// more authority than "can't tell", so we say that instead.
+			if (presenceState === 'known' && Date.now() - lastAnsweredAt > PRESENCE_MAX_AGE_MS) {
+				sessions = [];
+				presenceState = 'unknown';
+				presenceReason = 'The last check was a while ago and hasn’t refreshed.';
+			}
+			void refreshPresence(gen);
+		}, PRESENCE_POLL_MS);
 		// Nothing bounds how long `/sessions` may take, and 'checking' disables
 		// Push — so a request that never settles would strand the composer with
 		// a dead button and no explanation. After this long, stop waiting and
@@ -259,12 +316,40 @@ server tells you not to run would cost honesty in the case that actually ships.
 		onclose();
 	}
 
+	/**
+	 * Error codes handlePushToItem (and the middleware in front of it) can
+	 * return WITHOUT having published — the request provably never reached the
+	 * bus, so a corrected resend cannot duplicate anything.
+	 *
+	 * A whitelist, not `err instanceof PadApiError`, and the difference is
+	 * load-bearing (codex round 2): the API client turns ANY JSON error
+	 * envelope into a PadApiError, including one a proxy or gateway invented
+	 * AFTER the handler had already published. Treating "structured" as
+	 * "definitely not published" would re-arm Push on exactly that case. So the
+	 * rule is inverted — enumerate what we know is safe, and treat every
+	 * unrecognised failure as ambiguous. The cost of the wrong answer is
+	 * asymmetric: an unnecessary "we can't tell" makes the user check, while a
+	 * wrong re-arm delivers the instruction twice.
+	 */
+	const PRE_PUBLISH_ERROR_CODES = new Set([
+		'bad_request', // empty / whitespace-only / over-length / undecodable body
+		'unauthorized', // no resolved user
+		'not_found', // item or workspace doesn't resolve
+		'forbidden',
+		'permission_denied', // workspace-access middleware
+		'unavailable', // the bus isn't wired — nothing to publish TO
+		'rate_limited', // the client's own 429 shape; the handler never ran
+		'plan_limit_exceeded'
+	]);
+
 	async function handleSend() {
 		if (!canSend) return;
-		// Fence the continuation against the parent switching items mid-flight:
-		// the dialog is {#key itemSlug}-remounted, so a late `onclose()` from
-		// item A's send would close the composer the user just opened for B.
+		// Fence the continuation two ways. `gen` catches a close-and-reopen
+		// within THIS instance; `destroyed` catches the parent remounting the
+		// dialog for a different item, where a new instance has its own `gen`
+		// and only liveness distinguishes A's stale continuation from B's.
 		const gen = presenceGen;
+		const stillMine = () => !destroyed && gen === presenceGen;
 		sending = true;
 		sendError = '';
 		try {
@@ -272,31 +357,29 @@ server tells you not to run would cost honesty in the case that actually ships.
 			// endpoint carries no idempotency key.
 			await api.items.push(wsSlug, itemSlug, collapsed);
 			sending = false;
-			// The toast fires regardless of a switch — the push really happened,
-			// and suppressing the confirmation would be the dishonest half.
-			// Honest past tense: the notification was PUBLISHED. Whether an agent
-			// read it is not something the server can tell us.
+			// The toast fires even if this instance is gone — the push really
+			// happened, and suppressing the confirmation would be the dishonest
+			// half. Honest past tense: the notification was PUBLISHED. Whether an
+			// agent read it is not something the server can tell us.
 			toastStore.show(`Pushed to ${itemRef} — delivery isn’t confirmed`, 'success');
-			if (gen !== presenceGen) return;
+			if (!stillMine()) return;
 			handleDismiss();
 		} catch (err) {
 			sending = false;
-			if (gen !== presenceGen) return;
-			// Ambiguity rule, drawn where CopyItemDialog draws it: a STRUCTURED
-			// error means the server responded and therefore refused before
-			// publishing (`bad_request` on empty/over-length, `not_found`,
-			// `forbidden`, `unavailable` when the bus is unwired) — safe to fix
-			// and send again. An UNSTRUCTURED failure (rejected fetch, non-JSON
-			// 502, timeout) means the request went out and we never learned its
-			// fate; the handler publishes BEFORE it writes the response, so the
-			// message may well have been delivered. Re-arming Push there offers
-			// the user a duplicate, so we don't.
-			if (err instanceof PadApiError) {
-				sendError = err.message;
+			if (!stillMine()) return;
+			// See PRE_PUBLISH_ERROR_CODES: a recognised pre-publish refusal is
+			// safe to correct and resend. Everything else — a rejected fetch, a
+			// non-JSON 502, a gateway envelope we don't recognise — means the
+			// request went out and we never learned its fate. The handler
+			// publishes BEFORE it writes the response, so the message may well
+			// have been delivered; re-arming Push would offer a duplicate.
+			const code = err instanceof PadApiError ? err.code : '';
+			if (code && PRE_PUBLISH_ERROR_CODES.has(code)) {
+				sendError = err instanceof Error ? err.message : 'Failed to push the message.';
 			} else {
 				outcomeUnknown = true;
 				sendError =
-					'The server didn’t answer, so we can’t tell whether this was sent. ' +
+					'The server didn’t give a clear answer, so we can’t tell whether this was sent. ' +
 					'Check your agent session before sending it again — pushing twice would deliver it twice.';
 			}
 		}
@@ -309,7 +392,9 @@ server tells you not to run would cost honesty in the case that actually ships.
 		try {
 			await navigator.clipboard.writeText(collapsed);
 			toastStore.show('Copied to clipboard', 'success');
-			if (gen !== presenceGen) return;
+			// Same two-part fence as handleSend — a late dismiss from a
+			// destroyed instance would close the NEXT item's composer.
+			if (destroyed || gen !== presenceGen) return;
 			handleDismiss();
 		} catch {
 			toastStore.show('Failed to copy to clipboard', 'error');
@@ -412,21 +497,20 @@ server tells you not to run would cost honesty in the case that actually ships.
 					collapse note, always present and always referenced by the
 					textarea's aria-describedby.
 
-					Two reasons it isn't two conditionally-rendered spans: an
-					`aria-describedby` pointing at an id that isn't in the
-					document resolves to nothing (so a note that appears only
-					when relevant is announced by nobody), and swapping the
-					referenced node in and out is what makes assistive tech miss
-					the change. `role="status"` announces politely as the text
-					swaps; the over-length case escalates to `alert` because it
-					is a blocking condition, not an aside.
+					Not two conditionally-rendered spans: an `aria-describedby`
+					pointing at an id that isn't in the document resolves to
+					nothing, so a note that only exists when relevant is
+					announced by nobody.
+
+					And a FIXED `role="status"`, not one that escalates to
+					`alert` when the message is too long — swapping the role on
+					a live region while also changing its text is not reliably
+					honoured across screen readers, so the escalation would be a
+					promise the markup can't keep. The blocking condition is
+					carried where it is unambiguous instead: `aria-invalid` on
+					the textarea plus a disabled Push.
 				-->
-				<span
-					id={noteId}
-					class:notice-inline={tooLong}
-					class:muted={!tooLong}
-					role={tooLong ? 'alert' : 'status'}
-				>
+				<span id={noteId} class:notice-inline={tooLong} class:muted={!tooLong} role="status">
 					{#if tooLong}
 						Too long — trim {messageLength - PUSH_MESSAGE_MAX_LEN} character{messageLength -
 							PUSH_MESSAGE_MAX_LEN ===

--- a/web/src/lib/components/items/PushToAgentDialog.svelte.test.ts
+++ b/web/src/lib/components/items/PushToAgentDialog.svelte.test.ts
@@ -1,0 +1,302 @@
+// Runs in the jsdom vitest project (see vitest.config.ts). `setup-jsdom.ts`
+// polyfills the native <dialog> top-layer methods Modal.svelte drives.
+//
+// WHAT THESE TESTS ARE FOR. The composer's textarea is not the deliverable —
+// the presence line is (PLAN-2558's "Honesty" rationale). So the assertions
+// below are about the three-way distinction the surface has to keep straight:
+//
+//     N > 0        → send, with the caveat that connected ≠ delivered
+//     N == 0       → do NOT send; a push with nothing listening is lost, not queued
+//     can't tell   → send anyway, and SAY it is a guess
+//
+// Two of those three are easy to get wrong in the same direction — flattening
+// "can't tell" into "nobody is there" — and a test that only asserted the
+// rendered copy would not notice, because both states render a warning box.
+// So every gating test asserts the MECHANISM (did `api.items.push` get called?)
+// and not just the button's `disabled` attribute: a disabled attribute is an
+// end state that a second, unrelated bug could also produce (CONVE-12).
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, cleanup, fireEvent } from '@testing-library/svelte';
+import { tick, flushSync } from 'svelte';
+
+const pushMock = vi.fn();
+const sessionsListMock = vi.fn();
+const toastMock = vi.fn();
+
+vi.mock('$lib/api/client', async () => {
+	// Keep the REAL PadApiError: the component branches on `instanceof`, and a
+	// stand-in class would make the 503 test pass for the wrong reason.
+	const actual = await vi.importActual<typeof import('$lib/api/client')>('$lib/api/client');
+	return {
+		...actual,
+		api: {
+			items: { push: (...args: unknown[]) => pushMock(...args) },
+			sessions: { list: () => sessionsListMock() }
+		}
+	};
+});
+
+vi.mock('$lib/stores/toast.svelte', () => ({
+	toastStore: { show: (...args: unknown[]) => toastMock(...args) }
+}));
+
+const { PadApiError } = await import('$lib/api/client');
+const PushToAgentDialog = (await import('./PushToAgentDialog.svelte')).default;
+
+function baseProps(overrides: Record<string, unknown> = {}) {
+	return {
+		open: true,
+		onclose: vi.fn(),
+		wsSlug: 'docapp',
+		itemSlug: 'fix-the-thing',
+		itemRef: 'TASK-5',
+		itemTitle: 'Fix the thing',
+		...overrides
+	};
+}
+
+/** Sessions payload with `n` live entries. */
+function sessions(n: number) {
+	return {
+		count: n,
+		sessions: Array.from({ length: n }, (_, i) => ({
+			id: `session-id-${i}`,
+			label: `docapp-${i}`,
+			pid: 1000 + i,
+			connected_at: new Date(Date.now() - 60_000).toISOString()
+		}))
+	};
+}
+
+function button(name: string): HTMLButtonElement {
+	const match = Array.from(document.querySelectorAll('button')).find(
+		(b) => b.textContent?.trim().toLowerCase() === name.toLowerCase()
+	);
+	if (!match) {
+		throw new Error(
+			`no button named "${name}"; present: ${Array.from(document.querySelectorAll('button'))
+				.map((b) => JSON.stringify(b.textContent?.trim()))
+				.join(', ')}`
+		);
+	}
+	return match as HTMLButtonElement;
+}
+
+/** The dialog's rendered text with HTML whitespace collapsed — the same
+ *  normalization a browser applies when laying it out, so an assertion reads
+ *  the sentence the user sees rather than the source's indentation. */
+function bodyText(): string {
+	return (document.body.textContent ?? '').replace(/\s+/g, ' ').trim();
+}
+
+function textarea(): HTMLTextAreaElement {
+	const el = document.querySelector('textarea');
+	if (!el) throw new Error('composer textarea not found');
+	return el as HTMLTextAreaElement;
+}
+
+/** Mount, then let the initial presence read settle. */
+async function mountSettled(props: Record<string, unknown> = {}) {
+	const result = render(PushToAgentDialog, { props: baseProps(props) });
+	await tick();
+	flushSync();
+	// Two flushes: one for the fetch promise, one for the effect it re-triggers.
+	await tick();
+	await tick();
+	flushSync();
+	return result;
+}
+
+beforeEach(() => {
+	pushMock.mockReset().mockResolvedValue({
+		ref: 'TASK-5',
+		workspace: 'docapp',
+		pushed: true,
+		message: 'ok'
+	});
+	sessionsListMock.mockReset().mockResolvedValue(sessions(1));
+	toastMock.mockReset();
+});
+
+afterEach(() => {
+	cleanup();
+	vi.useRealTimers();
+	document.body.innerHTML = '';
+});
+
+describe('PushToAgentDialog — presence honesty', () => {
+	it('with a live session: enables Push and does not promise delivery', async () => {
+		await mountSettled();
+
+		const body = bodyText();
+		expect(body).toContain('1 session connected');
+		// The whole point. If this ever starts asserting delivery, the surface
+		// has begun claiming something the server has no way to know.
+		expect(body).toMatch(/can’t confirm delivery|cannot confirm delivery/i);
+		expect(body).not.toMatch(/will be delivered/i);
+
+		expect(button('Push').disabled).toBe(false);
+	});
+
+	it('with zero sessions: refuses to send, and the click really does nothing', async () => {
+		sessionsListMock.mockResolvedValue(sessions(0));
+		await mountSettled();
+
+		expect(bodyText()).toContain('No agent session is connected');
+		expect(button('Push').disabled).toBe(true);
+
+		// The `disabled` assertion above is the load-bearing one — it is what
+		// fails if `noListeners` ever drops out of `canSend`. The click below is
+		// a belt-and-braces check that no other path reaches the endpoint; being
+		// honest about it, a disabled <button> also refuses to dispatch, so this
+		// line on its own would pass for that reason too.
+		await fireEvent.click(button('Push'));
+		await tick();
+		expect(pushMock).not.toHaveBeenCalled();
+	});
+
+	it('offers the clipboard instead when nothing is listening', async () => {
+		sessionsListMock.mockResolvedValue(sessions(0));
+		const writeText = vi.fn().mockResolvedValue(undefined);
+		Object.defineProperty(navigator, 'clipboard', {
+			value: { writeText },
+			configurable: true
+		});
+
+		await mountSettled();
+		await fireEvent.click(button('Copy instead'));
+		await tick();
+
+		expect(writeText).toHaveBeenCalledWith('Take a look at TASK-5 — Fix the thing');
+		expect(pushMock).not.toHaveBeenCalled();
+	});
+
+	it('when presence is UNAVAILABLE (503) it says so and still allows sending', async () => {
+		sessionsListMock.mockRejectedValue(
+			new PadApiError({ code: 'unavailable', message: 'Session presence is not available' })
+		);
+		await mountSettled();
+
+		const body = bodyText();
+		// Must NOT render as "nobody is listening" — that is the lie
+		// handleListSessions returns a 503 (rather than an empty list) to avoid.
+		expect(body).toContain('Can’t tell whether any agent session is connected');
+		expect(body).not.toContain('No agent session is connected');
+
+		// The counterfactual leg: this state must behave DIFFERENTLY from the
+		// zero-sessions state above. If 'unknown' ever gets flattened into
+		// 'known zero', this is what catches it — the copy test alone would not,
+		// since both states render a warning box.
+		expect(button('Push').disabled).toBe(false);
+		await fireEvent.click(button('Push'));
+		await tick();
+		expect(pushMock).toHaveBeenCalledTimes(1);
+	});
+
+	it('treats a transient network failure as unknown, not as zero', async () => {
+		sessionsListMock.mockRejectedValue(new Error('network down'));
+		await mountSettled();
+
+		expect(bodyText()).toContain('Could not reach the server to check');
+		expect(button('Push').disabled).toBe(false);
+	});
+
+	it('re-reads presence while open, so a session that drops mid-compose disarms Push', async () => {
+		vi.useFakeTimers();
+		sessionsListMock.mockResolvedValue(sessions(1));
+		render(PushToAgentDialog, { props: baseProps() });
+		await vi.advanceTimersByTimeAsync(0);
+		flushSync();
+		expect(button('Push').disabled).toBe(false);
+
+		// The session goes away; the next poll must notice.
+		sessionsListMock.mockResolvedValue(sessions(0));
+		await vi.advanceTimersByTimeAsync(10_000);
+		flushSync();
+
+		expect(button('Push').disabled).toBe(true);
+		expect(bodyText()).toContain('No agent session is connected');
+	});
+});
+
+describe('PushToAgentDialog — message handling', () => {
+	it('sends the COLLAPSED message, not the raw textarea value', async () => {
+		await mountSettled();
+
+		await fireEvent.input(textarea(), { target: { value: 'line one\n\n   line two  ' } });
+		await tick();
+		await fireEvent.click(button('Push'));
+		await tick();
+
+		// Whitespace-collapsed exactly as the server would collapse it — so what
+		// the user sees in the counter is what actually goes on the wire.
+		expect(pushMock).toHaveBeenCalledWith('docapp', 'fix-the-thing', 'line one line two');
+	});
+
+	it('blocks an over-length message client-side rather than letting it 400', async () => {
+		await mountSettled();
+
+		await fireEvent.input(textarea(), { target: { value: 'a'.repeat(4097) } });
+		await tick();
+
+		expect(button('Push').disabled).toBe(true);
+		expect(bodyText()).toContain('4097 / 4096');
+		await fireEvent.click(button('Push'));
+		await tick();
+		expect(pushMock).not.toHaveBeenCalled();
+	});
+
+	it('blocks a whitespace-only message, matching the server empty check', async () => {
+		await mountSettled();
+
+		await fireEvent.input(textarea(), { target: { value: '   \n\t  ' } });
+		await tick();
+
+		expect(button('Push').disabled).toBe(true);
+		await fireEvent.click(button('Push'));
+		await tick();
+		expect(pushMock).not.toHaveBeenCalled();
+	});
+
+	it('warns that a multi-line message arrives as one line', async () => {
+		await mountSettled();
+
+		await fireEvent.input(textarea(), { target: { value: 'first\nsecond' } });
+		await tick();
+		expect(bodyText()).toContain('arrives as one line');
+	});
+
+	it('prefills from the item and closes with an unconfirmed-delivery toast on success', async () => {
+		const onclose = vi.fn();
+		await mountSettled({ onclose });
+
+		expect(textarea().value).toBe('Take a look at TASK-5 — Fix the thing');
+
+		await fireEvent.click(button('Push'));
+		await tick();
+		await tick();
+
+		expect(pushMock).toHaveBeenCalledTimes(1);
+		expect(onclose).toHaveBeenCalled();
+		const [msg] = toastMock.mock.calls[0] ?? [];
+		expect(String(msg)).toMatch(/isn’t confirmed|is not confirmed/);
+	});
+
+	it('surfaces a failed push in the dialog and does NOT retry it', async () => {
+		pushMock.mockRejectedValue(
+			new PadApiError({ code: 'bad_request', message: 'message must not be empty' })
+		);
+		const onclose = vi.fn();
+		await mountSettled({ onclose });
+
+		await fireEvent.click(button('Push'));
+		await tick();
+		await tick();
+
+		expect(bodyText()).toContain('message must not be empty');
+		// Stays open so the user can fix it, and — the endpoint having no
+		// idempotency key — exactly one dispatch happened.
+		expect(onclose).not.toHaveBeenCalled();
+		expect(pushMock).toHaveBeenCalledTimes(1);
+	});
+});

--- a/web/src/lib/components/items/PushToAgentDialog.svelte.test.ts
+++ b/web/src/lib/components/items/PushToAgentDialog.svelte.test.ts
@@ -439,6 +439,53 @@ describe('PushToAgentDialog — message handling', () => {
 		expect(button('Push').disabled).toBe(false);
 	});
 
+	it('re-arms Push on a middleware refusal (CSRF), which is strictly pre-publish', async () => {
+		pushMock.mockRejectedValueOnce(
+			new PadApiError({ code: 'csrf_error', message: 'CSRF token mismatch' })
+		);
+		await mountSettled();
+
+		await fireEvent.click(button('Push'));
+		await tick();
+		await tick();
+
+		expect(button('Push').disabled).toBe(false);
+		expect(bodyText()).toContain('CSRF token mismatch');
+		expect(bodyText()).not.toContain('can’t tell whether this was sent');
+	});
+
+	it('does not let a pre-expiry poll restore the count it just declared too old', async () => {
+		vi.useFakeTimers();
+		// First read answers "one". The poll issued at t=10s hangs long enough
+		// to outlive the expiry, then finally answers — with the state as it was
+		// at t=10s.
+		let releaseStalled: (v: unknown) => void = () => {};
+		sessionsListMock.mockResolvedValueOnce(sessions(1));
+		sessionsListMock.mockImplementationOnce(
+			() => new Promise((resolve) => (releaseStalled = resolve))
+		);
+		sessionsListMock.mockImplementation(() => new Promise(() => {}));
+
+		render(PushToAgentDialog, { props: baseProps() });
+		await vi.advanceTimersByTimeAsync(0);
+		flushSync();
+		expect(bodyText()).toContain('1 session connected');
+
+		await vi.advanceTimersByTimeAsync(40_000);
+		flushSync();
+		expect(bodyText()).toContain('Can’t tell whether any agent session is connected');
+
+		// The stalled pre-expiry poll finally lands. Its data is older than the
+		// expiry we just applied, so it must be dropped rather than reinstating
+		// "1 session connected".
+		releaseStalled(sessions(1));
+		await vi.advanceTimersByTimeAsync(0);
+		flushSync();
+
+		expect(bodyText()).not.toContain('1 session connected');
+		expect(bodyText()).toContain('Can’t tell whether any agent session is connected');
+	});
+
 	it('surfaces a failed push in the dialog and does NOT retry it', async () => {
 		pushMock.mockRejectedValue(
 			new PadApiError({ code: 'bad_request', message: 'message must not be empty' })

--- a/web/src/lib/components/items/PushToAgentDialog.svelte.test.ts
+++ b/web/src/lib/components/items/PushToAgentDialog.svelte.test.ts
@@ -364,6 +364,81 @@ describe('PushToAgentDialog — message handling', () => {
 		expect(button('Push').disabled).toBe(false);
 	});
 
+	it('latches outcome-unknown on an UNRECOGNISED structured error, not just an unstructured one', async () => {
+		// A gateway/proxy that returns a JSON envelope becomes a PadApiError
+		// just like a handler refusal does — but it can be produced AFTER the
+		// handler published. Treating "structured" as "definitely not
+		// published" would re-arm Push on exactly this case, so the rule is a
+		// whitelist of known pre-publish codes and everything else is ambiguous.
+		pushMock.mockRejectedValue(
+			new PadApiError({ code: 'bad_gateway', message: 'upstream exploded' })
+		);
+		await mountSettled();
+
+		await fireEvent.click(button('Push'));
+		await tick();
+		await tick();
+
+		expect(button('Push').disabled).toBe(true);
+		expect(bodyText()).toContain('can’t tell whether this was sent');
+	});
+
+	it('does not close a NEW item’s composer when a destroyed instance’s send resolves', async () => {
+		// The dialog is {#key itemSlug}-remounted, so item B gets a fresh
+		// instance with its own generation counter — A's in-flight send would
+		// still see its own `gen` unchanged and call the SHARED parent onclose,
+		// closing B's composer. Only per-instance liveness distinguishes them.
+		let releasePush: (v: unknown) => void = () => {};
+		pushMock.mockImplementationOnce(() => new Promise((resolve) => (releasePush = resolve)));
+
+		const onclose = vi.fn();
+		const { unmount } = render(PushToAgentDialog, { props: baseProps({ onclose }) });
+		await tick();
+		await tick();
+		flushSync();
+
+		await fireEvent.click(button('Push'));
+		await tick();
+
+		// The parent switches items: this instance is destroyed.
+		unmount();
+		await tick();
+
+		// A's push now completes.
+		releasePush({ ref: 'TASK-5', workspace: 'docapp', pushed: true, message: 'ok' });
+		await tick();
+		await tick();
+
+		// The toast still fires — the push really happened — but the dead
+		// instance must not reach for the shared close callback.
+		expect(toastMock).toHaveBeenCalled();
+		expect(onclose).not.toHaveBeenCalled();
+	});
+
+	it('expires a known count that stops refreshing rather than holding it as fact', async () => {
+		vi.useFakeTimers();
+		// First read succeeds; every later poll hangs forever.
+		sessionsListMock.mockResolvedValueOnce(sessions(1));
+		sessionsListMock.mockImplementation(() => new Promise(() => {}));
+
+		render(PushToAgentDialog, { props: baseProps() });
+		await vi.advanceTimersByTimeAsync(0);
+		flushSync();
+		expect(bodyText()).toContain('1 session connected');
+		expect(button('Push').disabled).toBe(false);
+
+		// Three poll intervals with no answer takes us past the server's own
+		// ~30s presence staleness bound. Past that, "1 session connected" is a
+		// claim nothing supports.
+		await vi.advanceTimersByTimeAsync(40_000);
+		flushSync();
+
+		expect(bodyText()).not.toContain('1 session connected');
+		expect(bodyText()).toContain('Can’t tell whether any agent session is connected');
+		// Still sendable — "can't tell" never blocks, only "known zero" does.
+		expect(button('Push').disabled).toBe(false);
+	});
+
 	it('surfaces a failed push in the dialog and does NOT retry it', async () => {
 		pushMock.mockRejectedValue(
 			new PadApiError({ code: 'bad_request', message: 'message must not be empty' })

--- a/web/src/lib/components/items/PushToAgentDialog.svelte.test.ts
+++ b/web/src/lib/components/items/PushToAgentDialog.svelte.test.ts
@@ -282,6 +282,88 @@ describe('PushToAgentDialog — message handling', () => {
 		expect(String(msg)).toMatch(/isn’t confirmed|is not confirmed/);
 	});
 
+	it('re-arms Push after a STRUCTURED refusal — the server answered, so nothing was published', async () => {
+		pushMock.mockRejectedValueOnce(
+			new PadApiError({ code: 'bad_request', message: 'message must not be empty' })
+		);
+		await mountSettled();
+
+		await fireEvent.click(button('Push'));
+		await tick();
+		await tick();
+
+		// A 400 means the handler refused BEFORE publishing, so a corrected
+		// resend is safe and the button must come back.
+		expect(button('Push').disabled).toBe(false);
+		expect(bodyText()).toContain('message must not be empty');
+	});
+
+	it('does NOT re-arm Push after an UNSTRUCTURED failure — the push may already have landed', async () => {
+		// A rejected fetch / non-JSON 502: the request went out and we never
+		// learned its fate. The handler publishes before writing its response,
+		// so re-arming would offer the user a duplicate delivery on an endpoint
+		// with no idempotency key.
+		pushMock.mockRejectedValue(new TypeError('Failed to fetch'));
+		await mountSettled();
+
+		await fireEvent.click(button('Push'));
+		await tick();
+		await tick();
+
+		expect(button('Push').disabled).toBe(true);
+		expect(bodyText()).toContain('can’t tell whether this was sent');
+		expect(pushMock).toHaveBeenCalledTimes(1);
+
+		// And the state is genuinely latched, not merely rendered: a second
+		// click cannot get through.
+		await fireEvent.click(button('Push'));
+		await tick();
+		expect(pushMock).toHaveBeenCalledTimes(1);
+	});
+
+	it('ignores a stale presence response that resolves after a newer one', async () => {
+		vi.useFakeTimers();
+		// First poll stalls; the second answers "zero" and lands first.
+		let releaseFirst: (v: unknown) => void = () => {};
+		sessionsListMock.mockImplementationOnce(
+			() => new Promise((resolve) => (releaseFirst = resolve))
+		);
+		sessionsListMock.mockResolvedValue(sessions(0));
+
+		render(PushToAgentDialog, { props: baseProps() });
+		await vi.advanceTimersByTimeAsync(10_000); // second poll fires and resolves zero
+		flushSync();
+		expect(button('Push').disabled).toBe(true);
+
+		// Now the STALE first poll finally answers with one session. Applying it
+		// would re-enable Push against a session list already known to be empty.
+		releaseFirst(sessions(1));
+		await vi.advanceTimersByTimeAsync(0);
+		flushSync();
+
+		expect(button('Push').disabled).toBe(true);
+		expect(bodyText()).toContain('No agent session is connected');
+	});
+
+	it('stops waiting on a presence read that never settles, rather than leaving Push dead', async () => {
+		vi.useFakeTimers();
+		sessionsListMock.mockImplementation(() => new Promise(() => {})); // never settles
+		render(PushToAgentDialog, { props: baseProps() });
+		await vi.advanceTimersByTimeAsync(0);
+		flushSync();
+
+		// While checking, Push is held — that part is deliberate.
+		expect(button('Push').disabled).toBe(true);
+
+		await vi.advanceTimersByTimeAsync(5_000);
+		flushSync();
+
+		// …but not forever, and not silently: it degrades to the honest
+		// "can't tell" state, which allows sending.
+		expect(bodyText()).toContain('Can’t tell whether any agent session is connected');
+		expect(button('Push').disabled).toBe(false);
+	});
+
 	it('surfaces a failed push in the dialog and does NOT retry it', async () => {
 		pushMock.mockRejectedValue(
 			new PadApiError({ code: 'bad_request', message: 'message must not be empty' })

--- a/web/src/lib/push/message.test.ts
+++ b/web/src/lib/push/message.test.ts
@@ -7,7 +7,8 @@ import {
 	defaultPushMessage,
 	isPushMessageEmpty,
 	isPushMessageTooLong,
-	pushMessageLength
+	pushMessageLength,
+	trimPushMessage
 } from './message';
 
 /**
@@ -62,8 +63,9 @@ describe('push message collapse — server contract fixture', () => {
 
 describe('push message bounds', () => {
 	it('mirrors the server constant', () => {
-		// Pinned on the Go side too (TestMaxPushMessageLenIsMirroredByTheWebComposer),
-		// so a change to either without the other goes red.
+		// Pinned on the Go side too, through the real endpoint at the boundary
+		// (TestPushMessageBoundIsWhatTheWebComposerMirrors), so a change to
+		// either without the other goes red.
 		expect(PUSH_MESSAGE_MAX_LEN).toBe(4096);
 	});
 
@@ -108,6 +110,34 @@ describe('push message bounds', () => {
 		const emoji = '👍'.repeat(100);
 		expect(emoji.length).toBe(200);
 		expect(pushMessageLength(emoji)).toBe(100);
+	});
+});
+
+describe('trimPushMessage', () => {
+	/**
+	 * The composer compares `collapsePushMessage(x)` against
+	 * `trimPushMessage(x)` to decide whether to warn "this arrives as one
+	 * line". Using `String.prototype.trim` for that comparison is wrong on
+	 * exactly the two characters this module exists for, in both directions —
+	 * which is what these cases pin.
+	 */
+	it('trims the edges using Go’s whitespace class', () => {
+		expect(trimPushMessage('  a  ')).toBe('a');
+		expect(trimPushMessage('\na\t')).toBe('a');
+		// Interior whitespace is untouched — that is collapse's job, not trim's.
+		expect(trimPushMessage(' a  b ')).toBe('a  b');
+	});
+
+	it('keeps a leading U+FEFF that JS trim() would strip', () => {
+		// JS: ''.trim() removes the BOM, so a `trim()`-based comparison would
+		// see a difference the server will never produce and warn falsely.
+		expect('﻿abc'.trim()).toBe('abc');
+		expect(trimPushMessage('﻿abc')).toBe('﻿abc');
+	});
+
+	it('strips a leading U+0085 that JS trim() would keep', () => {
+		expect('abc'.trim()).toBe('abc');
+		expect(trimPushMessage('abc')).toBe('abc');
 	});
 });
 

--- a/web/src/lib/push/message.test.ts
+++ b/web/src/lib/push/message.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import {
+	PUSH_MESSAGE_MAX_LEN,
+	collapsePushMessage,
+	defaultPushMessage,
+	isPushMessageEmpty,
+	isPushMessageTooLong,
+	pushMessageLength
+} from './message';
+
+/**
+ * The other half of the cross-language contract test described in
+ * internal/server/push_message_collapse_test.go.
+ *
+ * The fixture is shared deliberately. The claim this module makes — "the
+ * composer counts a message the way the server will" — is a claim about Go's
+ * `unicode.IsSpace` versus JavaScript's `\s`, and those two disagree in BOTH
+ * directions (U+0085 is whitespace to Go only, U+FEFF to JS only). Asserting
+ * against a table written here would only pin what the author BELIEVED Go
+ * does; the Go test pins the same table to what Go actually does, so a drift
+ * on either side turns exactly one suite red.
+ */
+const fixture = JSON.parse(
+	readFileSync(
+		fileURLToPath(new URL('../../../../internal/server/testdata/push_message_cases.json', import.meta.url)),
+		'utf8'
+	)
+) as { cases: { name: string; raw: string; collapsed: string; runes: number }[] };
+
+describe('push message collapse — server contract fixture', () => {
+	// Same false-green guard as the Go side: an empty (or truncated) fixture
+	// would make every it() below vacuous while the suite reported green.
+	it('loads the full shared fixture', () => {
+		expect(fixture.cases.length).toBeGreaterThanOrEqual(20);
+	});
+
+	for (const tc of fixture.cases) {
+		it(tc.name, () => {
+			expect(collapsePushMessage(tc.raw)).toBe(tc.collapsed);
+			expect(pushMessageLength(tc.raw)).toBe(tc.runes);
+		});
+	}
+
+	// The two divergence cases are the reason this file exists, so assert the
+	// mechanism directly rather than trusting that the table above still
+	// contains them. Written as a counterfactual: these are precisely the
+	// inputs on which a naive `\s`-based implementation would differ, so if
+	// someone "simplifies" the whitespace class back to `\s`, these fail while
+	// the ASCII cases keep passing.
+	it('collapses U+0085 NEL, which JS \\s does not treat as whitespace', () => {
+		expect('ab'.replace(/\s+/g, ' ')).toBe('ab'); // what \s would do: nothing
+		expect(collapsePushMessage('ab')).toBe('a b'); // what Go does
+	});
+
+	it('preserves U+FEFF BOM, which JS \\s does treat as whitespace', () => {
+		expect('a﻿b'.replace(/\s+/g, ' ')).toBe('a b'); // what \s would do: collapse
+		expect(collapsePushMessage('a﻿b')).toBe('a﻿b'); // what Go does
+	});
+});
+
+describe('push message bounds', () => {
+	it('mirrors the server constant', () => {
+		// Pinned on the Go side too (TestMaxPushMessageLenIsMirroredByTheWebComposer),
+		// so a change to either without the other goes red.
+		expect(PUSH_MESSAGE_MAX_LEN).toBe(4096);
+	});
+
+	it('treats whitespace-only as empty, matching the server 400', () => {
+		expect(isPushMessageEmpty('')).toBe(true);
+		expect(isPushMessageEmpty('   \n\t  ')).toBe(true);
+		expect(isPushMessageEmpty(' 　')).toBe(true);
+		expect(isPushMessageEmpty(' x ')).toBe(false);
+	});
+
+	it('accepts a message at exactly the bound', () => {
+		const atLimit = 'a'.repeat(PUSH_MESSAGE_MAX_LEN);
+		expect(pushMessageLength(atLimit)).toBe(PUSH_MESSAGE_MAX_LEN);
+		expect(isPushMessageTooLong(atLimit)).toBe(false);
+	});
+
+	it('rejects one rune over the bound', () => {
+		expect(isPushMessageTooLong('a'.repeat(PUSH_MESSAGE_MAX_LEN + 1))).toBe(true);
+	});
+
+	/**
+	 * The regression this module exists to prevent, stated as its own case: a
+	 * message whose RAW length is over the bound but whose collapsed length is
+	 * under it. A composer counting the textarea value would refuse to send
+	 * this; the server accepts it happily.
+	 */
+	it('counts the collapsed form, so whitespace padding does not eat the budget', () => {
+		const padded = 'word' + '\n'.repeat(PUSH_MESSAGE_MAX_LEN + 100) + 'word';
+		// The raw value is over the bound; only the collapse brings it under.
+		expect(padded.length).toBeGreaterThan(PUSH_MESSAGE_MAX_LEN);
+		expect(pushMessageLength(padded)).toBe(9); // "word word"
+		expect(isPushMessageTooLong(padded)).toBe(false);
+	});
+
+	/**
+	 * The mirror-image regression: astral characters. `String.length` counts
+	 * UTF-16 units, so a message of emoji would look twice as long as the
+	 * server measures it — a composer using `.length` would block at half the
+	 * real budget.
+	 */
+	it('counts an astral character as one rune, not two UTF-16 units', () => {
+		const emoji = '👍'.repeat(100);
+		expect(emoji.length).toBe(200);
+		expect(pushMessageLength(emoji)).toBe(100);
+	});
+});
+
+describe('defaultPushMessage', () => {
+	it('names the item and stays on one line', () => {
+		const msg = defaultPushMessage('TASK-5', 'Fix the thing');
+		expect(msg).toContain('TASK-5');
+		expect(msg).toContain('Fix the thing');
+		// Single-line: the channel collapses newlines, so a prefill that
+		// contained one would misrepresent what gets sent.
+		expect(collapsePushMessage(msg)).toBe(msg);
+	});
+
+	it('degrades to whichever half it has', () => {
+		expect(defaultPushMessage('TASK-5', '')).toContain('TASK-5');
+		expect(defaultPushMessage('', 'Fix the thing')).toContain('Fix the thing');
+		expect(defaultPushMessage('', '')).toBe('');
+	});
+});

--- a/web/src/lib/push/message.ts
+++ b/web/src/lib/push/message.ts
@@ -1,0 +1,105 @@
+/**
+ * Push-message accounting, shared by every surface that composes a push
+ * (PLAN-2558 S3 today; S4's quick-action dispatch next).
+ *
+ * WHY THIS EXISTS AT ALL. The server bounds a push message at
+ * `maxPushMessageLen` runes measured AFTER whitespace collapse
+ * (`internal/server/handlers_push.go`), and rejects an over-length message
+ * with a 400 rather than truncating it. So a client that counts the raw
+ * textarea value is wrong in BOTH directions:
+ *
+ *   - It OVER-counts a message with newlines or runs of spaces — the server
+ *     collapses those away, so text the server would happily accept gets
+ *     refused before it is ever sent.
+ *   - It UNDER-counts nothing today, but would the moment the two
+ *     definitions of "whitespace" drifted apart (see below), which is the
+ *     failure the task explicitly asks to avoid: the user finding out from a
+ *     400 instead of from the composer.
+ *
+ * So the collapse is reproduced here rather than approximated, and the count
+ * is taken on the collapsed string.
+ */
+
+/**
+ * Whitespace, defined to match Go's `unicode.IsSpace` — which is what
+ * `strings.Fields` splits on server-side — and NOT JavaScript's `\s`.
+ *
+ * The two classes genuinely differ, in both directions:
+ *   - Go treats U+0085 (NEL) as space; JS `\s` does not.
+ *   - JS `\s` treats U+FEFF (BOM / ZWNBSP) as space; Go does not.
+ *
+ * Using `\s` would therefore collapse a BOM the server keeps (under-count,
+ * → surprise 400) and preserve a NEL the server collapses (over-count, →
+ * refusing an acceptable message). Both are reachable from a paste, which is
+ * how text arrives in this composer more often than not.
+ *
+ * The set below is Go's exactly: the Latin-1 cases enumerated in
+ * `unicode.IsSpace`, plus the non-Latin-1 members of the Unicode White_Space
+ * property. Note U+200B (ZWSP) is deliberately absent — it is not white space
+ * in either implementation.
+ */
+const GO_WHITESPACE_CLASS = '\\t\\n\\v\\f\\r \\u0085\\u00A0\\u1680\\u2000-\\u200A\\u2028\\u2029\\u202F\\u205F\\u3000';
+const GO_WHITESPACE_RUN = new RegExp(`[${GO_WHITESPACE_CLASS}]+`, 'g');
+const GO_WHITESPACE_EDGE = new RegExp(`^[${GO_WHITESPACE_CLASS}]+|[${GO_WHITESPACE_CLASS}]+$`, 'g');
+
+/**
+ * Maximum push-message length in runes, AFTER `collapsePushMessage`.
+ *
+ * Mirrors `maxPushMessageLen` in `internal/server/handlers_push.go`. The two
+ * must move together; a client bound that drifts BELOW the server's silently
+ * removes headroom the user is entitled to, and one that drifts ABOVE
+ * reintroduces the 400 this module exists to pre-empt.
+ */
+export const PUSH_MESSAGE_MAX_LEN = 4096;
+
+/**
+ * Collapse a message the way the server does before it measures or publishes
+ * it: every run of whitespace becomes a single space, and the result is
+ * trimmed. Equivalent to Go's `strings.Join(strings.Fields(s), " ")`.
+ *
+ * This is not only a length concern — it is what the user's message will
+ * ACTUALLY look like on the wire, because `Notification.Summary` rides a
+ * single stdout line into the monitor session. A composer that lets someone
+ * lay out three paragraphs without saying they will arrive as one line is
+ * lying about the medium, so callers surface this (see PushToAgentDialog's
+ * multi-line note).
+ */
+export function collapsePushMessage(raw: string): string {
+	return raw.replace(GO_WHITESPACE_EDGE, '').replace(GO_WHITESPACE_RUN, ' ');
+}
+
+/**
+ * Length of `raw` in the units the server bounds: runes of the collapsed
+ * message. `[...s]` iterates by code point, matching Go's `len([]rune(s))`.
+ * (`s.length` would count UTF-16 units and double-count every astral
+ * character — an emoji in a push message is not hypothetical.)
+ */
+export function pushMessageLength(raw: string): number {
+	return [...collapsePushMessage(raw)].length;
+}
+
+/** True when the collapsed message is empty — the server's own 400 condition
+ *  (it trims before the empty check, so a whitespace-only message is empty). */
+export function isPushMessageEmpty(raw: string): boolean {
+	return collapsePushMessage(raw) === '';
+}
+
+/** True when the collapsed message exceeds the server's bound. */
+export function isPushMessageTooLong(raw: string): boolean {
+	return pushMessageLength(raw) > PUSH_MESSAGE_MAX_LEN;
+}
+
+/**
+ * The composer's prefill. Deliberately a single line — see
+ * `collapsePushMessage`: multi-line prefill would arrive collapsed anyway, so
+ * offering it would misrepresent the channel.
+ *
+ * It names the item and states the ask in the imperative, because the
+ * receiving end is an agent session reading one stdout line, not a person
+ * reading a form. Users are expected to edit it; the value of a prefill here
+ * is a starting shape, not a finished instruction.
+ */
+export function defaultPushMessage(ref: string, title: string): string {
+	const subject = ref && title ? `${ref} — ${title}` : ref || title;
+	return subject ? `Take a look at ${subject}` : '';
+}

--- a/web/src/lib/push/message.ts
+++ b/web/src/lib/push/message.ts
@@ -69,6 +69,21 @@ export function collapsePushMessage(raw: string): string {
 }
 
 /**
+ * Trim `raw` using Go's whitespace class rather than JavaScript's — the
+ * leading/trailing half of what `strings.Fields` does, without the interior
+ * collapse.
+ *
+ * Exists so callers can ask "will the interior of this message change on the
+ * wire?" without reintroducing the very `\s` mismatch `collapsePushMessage`
+ * avoids. `String.prototype.trim` uses the JS class, so comparing against it
+ * reports a phantom collapse for a leading U+FEFF (JS trims it, Go keeps it)
+ * and misses a real one around U+0085.
+ */
+export function trimPushMessage(raw: string): string {
+	return raw.replace(GO_WHITESPACE_EDGE, '');
+}
+
+/**
  * Length of `raw` in the units the server bounds: runes of the collapsed
  * message. `[...s]` iterates by code point, matching Go's `len([]rune(s))`.
  * (`s.length` would count UTF-16 units and double-count every astral

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -1786,6 +1786,63 @@ export interface ServerCapabilities {
 }
 
 /**
+ * One currently-connected agent session — a `GET /api/v1/events/stream`
+ * connection the server is holding open for the calling user (PLAN-2558 S1,
+ * `internal/server/session_presence.go`).
+ *
+ * STALENESS, restated here because this is the type a UI holds: an entry
+ * means "connected as of the last time the server could tell", not
+ * "connected now". A clean disconnect deregisters immediately; an ungraceful
+ * one (closed laptop, dropped network) is invisible until the next keepalive
+ * write fails, up to ~30s later. Fine for a fire-and-forget push; NOT a
+ * delivery guarantee, and consumers must not word it as one — "one session
+ * connected" is honest, "this will be delivered" is not.
+ *
+ * `label` and `pid` are SELF-DECLARED by the connecting client (S2) and
+ * verified against nothing. That is safe only because the list is self-scoped
+ * — a lying client corrupts nobody's list but its own. Never build anything
+ * on them that needs them to be true.
+ */
+export interface LiveSession {
+	/** Server-generated per CONNECTION, not per client: a reconnect (including
+	 *  a Last-Event-ID resume) gets a new id. Not a stable client identity. */
+	id: string;
+	/** Human-meaningful name, from the client's working-directory basename.
+	 *  Absent means "unlabelled" — fall back to the id, never hide the row. */
+	label?: string;
+	/** The client process's own pid, absent when it didn't say. Disambiguates
+	 *  two sessions sharing a label; not a process the server can act on. */
+	pid?: number;
+	/** When the stream opened (UTC, ISO-8601). */
+	connected_at: string;
+}
+
+/** Body of GET /api/v1/sessions. `count` is redundant with `sessions.length`
+ *  and is sent anyway so "is anything listening?" is a one-field read. */
+export interface LiveSessionsResponse {
+	sessions: LiveSession[];
+	count: number;
+}
+
+/**
+ * Result of POST /workspaces/{ws}/items/{slug}/push (IDEA-2544 Phase 1).
+ *
+ * `pushed: true` means the notification was PUBLISHED to the event bus — not
+ * that any session received it. A push has no durable backing and no ack, so
+ * there is nothing here that could report delivery, and callers must not
+ * present this as confirmation that an agent saw it.
+ *
+ * `message` echoes the server's whitespace-collapsed form, which is what
+ * actually went on the wire — it may differ from what the user typed.
+ */
+export interface ItemPushResult {
+	ref: string;
+	workspace: string;
+	pushed: boolean;
+	message: string;
+}
+
+/**
  * Consolidated quota summary returned by
  * GET /api/v1/workspaces/{ws}/storage/usage.
  *


### PR DESCRIPTION
PLAN-2558 **S3** — the web half of IDEA-2544's push-to-harness. Closes TASK-2561.

Adds `api.items.push`, a new `api.sessions.list`, and a **Push to agent…** row in the item pane's ⋯ menu that opens a small composer.

## The deliverable is the presence line, not the textarea

`pad push` is fire-and-forget: no durable inbox, no ack, no "nobody was listening" warning. That's defensible for a CLI verb typed by someone who knows their own session is running; it is not defensible for a button. So the dialog answers *is anything listening?* **before** the click, and keeps **three** states apart rather than two:

| state | Push | wording |
|---|---|---|
| `N > 0` | enabled | "N session connected — as of the last check", plus the ~30s window and "can't confirm delivery". Never "will be delivered". |
| `N == 0` | **disabled** | Nothing listening means the message is *lost*, not queued. The empty state offers the clipboard instead — the fallback S4 rules for quick actions. |
| can't tell | enabled | A 503 / 401 / network failure is **not** zero. Rendering it as zero is the exact lie `handleListSessions` returns a 503 rather than an empty list to avoid. |

Flattening "can't tell" into "known zero" is the easy wrong move, and both render a warning box — so the tests assert the *mechanism* (was `api.items.push` called?), not just the rendered copy.

The menu row is gated on a **resolved user**, not `canEdit`: push is self-addressed, so a viewer pushing an item into their own session is a read.

## Client/server message accounting

`$lib/push/message` mirrors the server's rune-after-collapse bound so an over-length message is caught in the composer instead of coming back as a 400. It deliberately does **not** use JS `\s` — Go's `unicode.IsSpace` and `\s` disagree in both directions (U+0085 is whitespace to Go only, U+FEFF to JS only), so a `\s` client under-counts a pasted BOM and over-counts a pasted NEL.

That agreement is pinned by a **shared fixture** (`internal/server/testdata/push_message_cases.json`, 25 cases) read by *both* `internal/server/push_message_collapse_test.go` and the web unit test. A TS-only table would only assert a belief about Go.

## Verification

- `go build` · `make lint` 0 issues · `go test ./...` exit 0 · web `vitest` 1571 passed · `svelte-check` 0 errors. `make test-pg` **N/A** — no store SQL touched.
- **Live, end-to-end in a real browser**: clicked Push in the web UI with a real `GET /api/v1/events/stream` held open, and the message arrived on the stream. Both presence states verified against a running server, plus the item-switch regression with its counterfactual (reverting the fix reopens the dialog on item B).
- Three adversarial Codex rounds; every fix mutation-tested 1:1 against its own test, with restores grep-verified rather than trusted to a re-run.

## Known gaps, stated rather than left to be found

- **Multi-process deployments.** Both the presence registry and the event bus are per-process; `session_presence.go` already says not to put this surface in front of a multi-process deployment. The copy is written for the single-process case on purpose — hedging every sentence for a deployment the server tells you not to run would cost honesty in the case that ships. Noted in the component header.
- **The ItemDetail switch-reset has no unit test.** It's parent state in a 7.5k-line component; it was verified live with a counterfactual instead, matching the (also untested) sibling resets for `copyDialogOpen` / `shareDialogOpen`.
- One Codex finding was **refuted**: push on an archived item returns 200 (`requireItemVisible` admits archived items, and the handler has no archived gate), so there's no `archived` code to whitelist and hiding the launcher would remove a capability that works.

https://claude.ai/code/session_01QCMLhHQBrMHVML3YKdm4Cd
