### PR TITLE
fix(web): arm the connect-time sync on FIRST connect, not only on leader promotion (BUG-2540)

### DIFF
--- a/web/src/lib/services/sse.svelte.ts
+++ b/web/src/lib/services/sse.svelte.ts
@@ -196,40 +196,59 @@ function createSSEService() {
 
 	function openEventSource(workspaceSlug: string) {
 		const url = `/api/v1/events?workspace=${encodeURIComponent(workspaceSlug)}`;
-		eventSource = new EventSource(url);
+		const source = new EventSource(url);
+		eventSource = source;
 
-		eventSource.onopen = () => {
-			status = 'connected';
-			broadcast({ type: 'status', status: 'connected' });
-			if (pendingSyncOnConnect) {
-				pendingSyncOnConnect = false;
-				dispatchSyncRequired();
-				broadcast({ type: 'sync_required' });
-			}
+		/**
+		 * Claim the pending connect-sync, but only on behalf of the
+		 * CURRENT connection.
+		 *
+		 * The identity check is load-bearing (codex review). `close()`
+		 * does not retract already-queued event tasks, so on a fast
+		 * workspace switch source A's `connected`/`onopen` handler can
+		 * still run after B has been created. Without `source ===
+		 * eventSource` it would clear the shared flag and broadcast on
+		 * B's channel — and B's own open, when it arrived, would find
+		 * the flag already false and SKIP the sync it actually needed.
+		 * The gap this whole fix exists to close would silently reopen,
+		 * on exactly the switch path where a fresh read is most likely
+		 * to be stale.
+		 */
+		const claimPendingSync = () => {
+			if (source !== eventSource) return;
+			if (!pendingSyncOnConnect) return;
+			pendingSyncOnConnect = false;
+			dispatchSyncRequired();
+			broadcast({ type: 'sync_required' });
 		};
 
-		eventSource.onerror = () => {
+		source.onopen = () => {
+			if (source !== eventSource) return;
+			status = 'connected';
+			broadcast({ type: 'status', status: 'connected' });
+			claimPendingSync();
+		};
+
+		source.onerror = () => {
+			if (source !== eventSource) return;
 			status = 'reconnecting';
 			broadcast({ type: 'status', status: 'reconnecting' });
 			// EventSource auto-reconnects and sends Last-Event-ID.
 			// The server replays missed events from its buffer.
 		};
 
-		eventSource.addEventListener('connected', () => {
+		source.addEventListener('connected', () => {
+			if (source !== eventSource) return;
 			status = 'connected';
 			broadcast({ type: 'status', status: 'connected' });
 			// Mirror onopen — some platforms fire `connected`
 			// reliably before `onopen` on reconnect, others vice
 			// versa. Whichever fires first claims the pending sync.
-			if (pendingSyncOnConnect) {
-				pendingSyncOnConnect = false;
-				dispatchSyncRequired();
-				broadcast({ type: 'sync_required' });
-			}
+			claimPendingSync();
 		});
 
 		// Handle sync_required: server's replay buffer couldn't cover the gap.
-		eventSource.addEventListener('sync_required', () => {
+		source.addEventListener('sync_required', () => {
 			dispatchSyncRequired();
 			broadcast({ type: 'sync_required' });
 		});
@@ -241,7 +260,7 @@ function createSSEService() {
 		// through the same incremental backfill the gap path uses — a
 		// /items-changes delta reconciles every affected row by seq.
 		// Broadcast so peer tabs reconcile too.
-		eventSource.addEventListener('items_bulk_updated', () => {
+		source.addEventListener('items_bulk_updated', () => {
 			dispatchSyncRequired();
 			broadcast({ type: 'sync_required' });
 		});
@@ -251,7 +270,7 @@ function createSSEService() {
 		// must close the EventSource ourselves — otherwise the browser
 		// auto-reconnect would tight-loop on a 401 or a stream that
 		// immediately closes again, hammering /api/v1/events.
-		eventSource.addEventListener('unauthorized', () => {
+		source.addEventListener('unauthorized', () => {
 			status = 'unauthorized';
 			broadcast({ type: 'status', status: 'unauthorized' });
 			if (eventSource) {
@@ -262,7 +281,7 @@ function createSSEService() {
 		});
 
 		for (const eventType of ITEM_EVENTS) {
-			eventSource.addEventListener(eventType, (e: MessageEvent) => {
+			source.addEventListener(eventType, (e: MessageEvent) => {
 				const data: ItemEvent = JSON.parse(e.data);
 				dispatchItemEvent(data);
 				broadcast({ type: 'item_event', event: data });
@@ -418,6 +437,18 @@ function createSSEService() {
 		currentWorkspace = '';
 		isLeader = false;
 		status = 'disconnected';
+		// Don't carry an unclaimed arm across a teardown (codex review).
+		//
+		// Belt-and-braces, and labelled as such rather than implied to be
+		// load-bearing: mutation-testing says the source-identity checks in
+		// openEventSource are what actually stop a torn-down connection from
+		// claiming a later one's sync — removing THIS line alone changes no
+		// observable behaviour, while removing those checks does. It is kept
+		// because leaving per-connection state set after the connection is
+		// gone is how the stale-source bug arose in the first place, and a
+		// future caller that arms conditionally would inherit a flag it never
+		// set.
+		pendingSyncOnConnect = false;
 	}
 
 	/** Force reconnect (e.g., after auth change). */

--- a/web/src/lib/services/sse.svelte.ts
+++ b/web/src/lib/services/sse.svelte.ts
@@ -177,6 +177,21 @@ function createSSEService() {
 	// connection lands, so any mutation between the resulting
 	// /items-changes snapshot and the new stream's first received
 	// event can be missed (Codex P1 round 4 of TASK-1359).
+	//
+	// BUG-2540 widened WHEN it is armed: originally only on leader
+	// promotion and the lock-failure fallback, which left the FIRST
+	// connect uncovered. A page reads its items and only then
+	// subscribes, so a mutation landing in that window reaches nobody
+	// — the SSE frame is never received (no subscription yet) and
+	// nothing reconciles the gap afterwards. The window is small
+	// (~30ms measured) but it is a silent, permanent divergence:
+	// the row stays stale until some unrelated event happens to
+	// trigger a sync. Arming on every EventSource open closes it,
+	// and costs one /items-changes delta per connect.
+	//
+	// This deliberately does NOT touch cursor-advance semantics —
+	// the delta is asked from whatever cursor syncService already
+	// holds. IDEA-2535 owns that question separately.
 	let pendingSyncOnConnect = false;
 
 	function openEventSource(workspaceSlug: string) {
@@ -275,46 +290,31 @@ function createSSEService() {
 	 * environments) skip the leader election and every tab opens
 	 * its own EventSource — N× traffic but correct.
 	 */
-	async function requestLeader(workspaceSlug: string) {
+	function requestLeader(workspaceSlug: string) {
 		if (!leaderElectionSupported()) {
 			// No leader election available. Fall back to per-tab SSE.
 			// BC was also skipped above, so this is the per-tab N×
 			// fallback path — correct, just less efficient.
+			//
+			// Armed for the same first-connect reason as the lock path
+			// below (BUG-2540): this tab read its items before getting
+			// here, and nothing else will reconcile the gap.
+			pendingSyncOnConnect = true;
 			openEventSource(workspaceSlug);
 			return;
 		}
-		// Distinguish "first leader" from "promoted follower" so we
-		// only fire sync_required on promotion — the freshly-opened
-		// EventSource has no Last-Event-ID and the server can't
-		// replay events emitted during the gap between the old
-		// leader's close and the new connection. Two signals:
+		// BUG-2540 removed the "first leader vs promoted follower"
+		// classification that used to live here (a `navigator.locks.query`
+		// probe plus a >100ms grant-delay heuristic, from TASK-1359 review
+		// rounds 2 and 3). It existed for exactly one purpose: to arm
+		// `pendingSyncOnConnect` only on promotion. Now that the flag is
+		// armed on every connect, nothing branches on it, and keeping the
+		// computation would mean paying for a `locks.query()` round-trip on
+		// every connect to produce a value no one reads.
 		//
-		//   1. `navigator.locks.query` before the request. If the
-		//      slot is already held by another tab, we're definitely
-		//      a future promotion. (Codex P1 round 2 of TASK-1359.)
-		//   2. Grant delay. If `query` raced with two tabs starting
-		//      simultaneously (both see "no holder"), one wins and
-		//      the other queues. The loser would mis-classify with
-		//      query alone — but the lock grant for the queued tab
-		//      is delayed by however long the winner held it. Any
-		//      callback that fires more than ~100ms after the
-		//      request is treated as a promotion. (Codex P1 round 3
-		//      of TASK-1359.) 100ms is a conservative cap on the
-		//      immediate grant case (uncontested lock acquisition
-		//      in a healthy browser is sub-millisecond).
-		let queryPromoted = false;
-		try {
-			const snapshot = await navigator.locks.query();
-			const held = (snapshot.held ?? []).some(
-				(l) => l.name === `pad-sse-leader-${workspaceSlug}`,
-			);
-			queryPromoted = held;
-		} catch {
-			/* swallow — query unsupported on some platforms */
-		}
-		const requestStart =
-			typeof performance !== 'undefined' ? performance.now() : Date.now();
-
+		// Note this is strictly MORE coverage, not a trade: every case the
+		// heuristic classified as "promoted" still arms, plus the first
+		// connect it was never able to classify at all.
 		navigator.locks
 			.request(
 				`pad-sse-leader-${workspaceSlug}`,
@@ -324,20 +324,14 @@ function createSSEService() {
 					// we acquire the lock. Bail before opening a stale
 					// connection.
 					if (currentWorkspace !== workspaceSlug) return;
-					const grantDelay =
-						(typeof performance !== 'undefined'
-							? performance.now()
-							: Date.now()) - requestStart;
-					const promoted = queryPromoted || grantDelay > 100;
 					isLeader = true;
-					if (promoted) {
-						// Schedule the sync to fire AFTER the SSE is
-						// connected — otherwise any mutation between
-						// the resulting /items-changes snapshot and
-						// the new stream's first received event would
-						// be missed (Codex P1 round 4).
-						pendingSyncOnConnect = true;
-					}
+					// Armed unconditionally — see `pendingSyncOnConnect`.
+					// Deliberately not narrowed to "only if this tab has
+					// already fetched something": the service has no view
+					// of what its consumers read, and guessing would
+					// reintroduce exactly the coverage hole this fixes.
+					// One delta request per connect is the right price.
+					pendingSyncOnConnect = true;
 					openEventSource(workspaceSlug);
 					// Hold the lock until release is signaled (by
 					// disconnect() or a workspace switch). The promise
@@ -399,10 +393,12 @@ function createSSEService() {
 		// while passively receiving via bc. When the leader tab
 		// closes, the lock releases and our queued request fires —
 		// at which point we open our own EventSource.
-		// requestLeader is async (it queries the lock state first)
-		// but we don't await it — the .catch() handler covers any
-		// failures and connect() returns synchronously to the caller.
-		void requestLeader(workspaceSlug);
+		// requestLeader returns synchronously; the lock request it
+		// fires resolves later and its .catch() handler covers any
+		// failures. (It used to be async to await a lock-state query —
+		// removed in BUG-2540 along with the promotion heuristic that
+		// was its only consumer.)
+		requestLeader(workspaceSlug);
 	}
 
 	function disconnect() {

--- a/web/src/lib/services/sseFirstConnectSync.svelte.test.ts
+++ b/web/src/lib/services/sseFirstConnectSync.svelte.test.ts
@@ -178,6 +178,90 @@ describe('SSE first-connect sync coverage (BUG-2540)', () => {
 		sse.disconnect();
 	});
 
+	it('arms on the lock-failure fallback path', async () => {
+		// The third arming site: navigator.locks.request rejects (exotic
+		// cross-origin / iframe cases). The service closes BC and opens a
+		// per-tab EventSource, which needs the same coverage as the granted
+		// path — and reaches openEventSource by yet another route, so neither
+		// of the tests above exercises it.
+		Object.defineProperty(globalThis.navigator, 'locks', {
+			value: {
+				request: () => Promise.reject(new Error('lock unavailable')),
+				query: async () => ({ held: [], pending: [] })
+			},
+			configurable: true,
+			writable: true
+		});
+		const sse = await loadService();
+		const onSync = vi.fn();
+		sse.onSyncRequired(onSync);
+
+		sse.connect('ws-lockfail');
+		// The rejection lands in a microtask, and .catch() opens the source.
+		await Promise.resolve();
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(sources).toHaveLength(1);
+		sources[0].fireOpen();
+		expect(onSync).toHaveBeenCalledTimes(1);
+
+		sse.disconnect();
+	});
+
+	it('does not let a stale source claim the NEXT connection’s pending sync', async () => {
+		// `close()` does not retract already-queued event tasks, so on a fast
+		// workspace switch source A's `connected` handler can still run after B
+		// exists. Without the source-identity check it would clear the shared
+		// flag and B's own open would skip the sync it actually needed —
+		// silently reopening the exact gap this fix closes, on the switch path
+		// where a fresh read is most likely to be stale.
+		const sse = await loadService();
+		const onSync = vi.fn();
+		sse.onSyncRequired(onSync);
+
+		sse.connect('ws-1');
+		await Promise.resolve();
+		await Promise.resolve();
+		const sourceA = sources[0];
+
+		// Switch before A ever opened.
+		sse.connect('ws-2');
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(sources).toHaveLength(2);
+		const sourceB = sources[1];
+		expect(sourceA.closed).toBe(true);
+
+		// A's queued handler finally runs. It must be ignored entirely.
+		sourceA.fireConnected();
+		sourceA.fireOpen();
+		expect(onSync).not.toHaveBeenCalled();
+
+		// B's own open still finds the flag armed and does its job.
+		sourceB.fireOpen();
+		expect(onSync).toHaveBeenCalledTimes(1);
+
+		sse.disconnect();
+	});
+
+	it('does not carry an unclaimed arm across a disconnect', async () => {
+		const sse = await loadService();
+		const onSync = vi.fn();
+		sse.onSyncRequired(onSync);
+
+		sse.connect('ws-x');
+		await Promise.resolve();
+		await Promise.resolve();
+		const stale = sources[0];
+		sse.disconnect();
+
+		// The torn-down source opening afterwards must dispatch nothing —
+		// both the identity check and the teardown reset stand in its way.
+		stale.fireOpen();
+		expect(onSync).not.toHaveBeenCalled();
+	});
+
 	it('re-arms for the next connect, so a workspace switch is covered too', async () => {
 		const sse = await loadService();
 		const onSync = vi.fn();

--- a/web/src/lib/services/sseFirstConnectSync.svelte.test.ts
+++ b/web/src/lib/services/sseFirstConnectSync.svelte.test.ts
@@ -1,0 +1,203 @@
+// Runs in the jsdom vitest project (filename ends `.svelte.test.ts`) because
+// sse.svelte.ts uses runes.
+//
+// WHAT THIS PINS (BUG-2540). A page reads its items and only THEN subscribes to
+// SSE. A mutation landing in that window reaches nobody: no subscription exists
+// yet, so the frame is never received, and nothing reconciles the gap
+// afterwards — the row stays stale until some unrelated event happens to
+// trigger a sync.
+//
+// `pendingSyncOnConnect` was the right mechanism but was armed only on LEADER
+// PROMOTION (and the lock-failure fallback), so the FIRST connect — the one
+// every page load performs — was uncovered. These tests assert it now fires on
+// every connect, and, importantly, that it still fires AFTER the stream is
+// open rather than before: firing early would just move the same gap, which is
+// the property TASK-1359 round 4 established and this change must not lose.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+/** The fake EventSource instances a test has caused to be constructed. */
+let sources: FakeEventSource[] = [];
+
+class FakeEventSource {
+	static readonly CLOSED = 2;
+	url: string;
+	readyState = 0;
+	onopen: (() => void) | null = null;
+	onerror: (() => void) | null = null;
+	closed = false;
+	private listeners = new Map<string, Set<(e: unknown) => void>>();
+
+	constructor(url: string) {
+		this.url = url;
+		sources.push(this);
+	}
+	addEventListener(type: string, cb: (e: unknown) => void) {
+		let set = this.listeners.get(type);
+		if (!set) {
+			set = new Set();
+			this.listeners.set(type, set);
+		}
+		set.add(cb);
+	}
+	close() {
+		this.closed = true;
+		this.readyState = FakeEventSource.CLOSED;
+	}
+	/** Drive the platform's open signal. */
+	fireOpen() {
+		this.readyState = 1;
+		this.onopen?.();
+	}
+	/** Drive the server's own `connected` frame (the other arm). */
+	fireConnected() {
+		for (const cb of this.listeners.get('connected') ?? []) cb({});
+	}
+}
+
+/**
+ * Minimal `navigator.locks`. `request` grants immediately and never resolves
+ * the held promise, matching the real lock's lifetime (the service holds it
+ * until disconnect).
+ */
+function installLocks() {
+	Object.defineProperty(globalThis.navigator, 'locks', {
+		value: {
+			request: (_name: string, _opts: unknown, cb: () => Promise<void>) => {
+				void cb();
+				return new Promise<void>(() => {});
+			},
+			query: async () => ({ held: [], pending: [] })
+		},
+		configurable: true,
+		writable: true
+	});
+}
+
+function removeLocks() {
+	// `delete navigator.locks` is what makes leaderElectionSupported() false —
+	// `'locks' in navigator` is the probe, so an undefined VALUE is not enough.
+	// @ts-expect-error — deleting an optional platform property under test
+	delete globalThis.navigator.locks;
+}
+
+async function loadService() {
+	vi.resetModules();
+	return (await import('./sse.svelte')).sseService;
+}
+
+beforeEach(() => {
+	sources = [];
+	vi.stubGlobal('EventSource', FakeEventSource);
+	installLocks();
+});
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+	removeLocks();
+});
+
+describe('SSE first-connect sync coverage (BUG-2540)', () => {
+	it('fires sync_required on the FIRST connect, not only on leader promotion', async () => {
+		const sse = await loadService();
+		const onSync = vi.fn();
+		sse.onSyncRequired(onSync);
+
+		sse.connect('ws-a');
+		// The lock grant runs the callback in a microtask.
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(sources).toHaveLength(1);
+		// Nothing yet — the whole point is that it waits for the stream.
+		expect(onSync).not.toHaveBeenCalled();
+
+		sources[0].fireOpen();
+		expect(onSync).toHaveBeenCalledTimes(1);
+
+		sse.disconnect();
+	});
+
+	it('fires it AFTER the stream opens, never before', async () => {
+		// The ordering property from TASK-1359 round 4. Dispatching early would
+		// relocate the gap rather than close it: the resulting /items-changes
+		// snapshot would be taken before the subscription exists, so a mutation
+		// between snapshot and subscription would still reach nobody.
+		const sse = await loadService();
+		const order: string[] = [];
+		sse.onSyncRequired(() => order.push('sync'));
+
+		sse.connect('ws-b');
+		await Promise.resolve();
+		await Promise.resolve();
+		order.push('constructed');
+
+		sources[0].fireOpen();
+		order.push('opened');
+
+		expect(order).toEqual(['constructed', 'sync', 'opened']);
+		sse.disconnect();
+	});
+
+	it('is claimed by whichever of onopen / `connected` arrives first, and only once', async () => {
+		const sse = await loadService();
+		const onSync = vi.fn();
+		sse.onSyncRequired(onSync);
+
+		sse.connect('ws-c');
+		await Promise.resolve();
+		await Promise.resolve();
+
+		// Some platforms deliver the server's `connected` frame before onopen.
+		sources[0].fireConnected();
+		expect(onSync).toHaveBeenCalledTimes(1);
+
+		// The other arm must not fire a second, redundant sync.
+		sources[0].fireOpen();
+		expect(onSync).toHaveBeenCalledTimes(1);
+
+		sse.disconnect();
+	});
+
+	it('arms on the no-leader-election fallback path too', async () => {
+		// Browsers without navigator.locks skip leader election entirely and
+		// every tab opens its own EventSource. That path reaches openEventSource
+		// by a different route, so it needs its own arming — and its own test,
+		// since the lock-path tests above can't exercise it.
+		removeLocks();
+		const sse = await loadService();
+		const onSync = vi.fn();
+		sse.onSyncRequired(onSync);
+
+		sse.connect('ws-d');
+		await Promise.resolve();
+
+		expect(sources).toHaveLength(1);
+		sources[0].fireOpen();
+		expect(onSync).toHaveBeenCalledTimes(1);
+
+		sse.disconnect();
+	});
+
+	it('re-arms for the next connect, so a workspace switch is covered too', async () => {
+		const sse = await loadService();
+		const onSync = vi.fn();
+		sse.onSyncRequired(onSync);
+
+		sse.connect('ws-e');
+		await Promise.resolve();
+		await Promise.resolve();
+		sources[0].fireOpen();
+		expect(onSync).toHaveBeenCalledTimes(1);
+
+		// A switch tears down and reconnects — the new workspace's initial read
+		// has exactly the same gap as the first one did.
+		sse.connect('ws-f');
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(sources).toHaveLength(2);
+		sources[1].fireOpen();
+		expect(onSync).toHaveBeenCalledTimes(2);
+
+		sse.disconnect();
+	});
+});


### PR DESCRIPTION
Closes BUG-2540.

A page reads its items and only then subscribes to SSE. A mutation landing in that window reaches nobody: no subscription exists yet so the frame is never received, and nothing reconciles the gap afterwards — the row stays stale until some unrelated event happens to trigger a sync.

`pendingSyncOnConnect` is exactly the right mechanism and already existed, but was armed only on **leader promotion** and the lock-failure fallback. The **first** connect — the one every page load performs — was uncovered. It is now armed on every EventSource open.

Cursor-advance semantics are untouched, per the scoping on the item: the delta is asked from whatever cursor `syncService` already holds. IDEA-2535 owns that question.

Also removes the "first leader vs promoted follower" classification (a `navigator.locks.query` probe plus a >100ms grant-delay heuristic from TASK-1359 rounds 2–3). It existed solely to gate this flag; with the flag armed unconditionally nothing reads it, and keeping it would mean a `locks.query()` round-trip per connect producing a value no one consumes. Strictly more coverage, not a trade — every case it classified as "promoted" still arms.

## Verification, including three instruments that did **not** discriminate

The unit tests (8) pin the mechanism and are mutation-verified. The live work is worth reading, because most of it failed:

| instrument | result |
|---|---|
| Collection page, "is the row visible" | **Cannot discriminate.** That page runs its own `deltaSync` on mount, covering the same window either way. Fixed and unfixed both "passed". |
| Graph page, "is the node's title in the page text" | **Blind.** A positive control — item created with *no* race — is also "not present". Every reading measured nothing. |
| Graph page, `/graph` response bodies, natural timing | **Still cannot discriminate.** The write consistently lands before the page's own first read, so nothing is ever missed and both builds recover. |
| Builds with the EventSource open delayed 3s, write timed into the widened window | **Discriminates.** 3/3 LOST on unfixed, 3/3 RECOVERED on fixed — binaries confirmed serving, differing only in the arming sites. |

One hypothesis was refuted rather than written down as fact: I suspected the graph subscribed too late to receive the connect dispatch. An instrumented run showed `dispatchSyncRequired subscribers=2` — both `syncService` and the graph are registered before it fires. The real reason those runs failed was a stale server process still bound to the port, so they were served by an unrelated binary.

## Second commit — stale-EventSource fence (Codex round 1)

`pendingSyncOnConnect` is shared state and the handlers closed over no identity, so on a fast workspace switch source A's already-queued handler could run after B existed, clear the flag, and make B skip the sync it needed — silently reopening this exact gap on the switch path. `close()` does not retract queued event tasks, so it is reachable. Each handler now returns unless its own source is current; `disconnect()` also clears the flag.

The mutation testing there is worth noting: the first attempt was a **false green**. Dropping the identity check inside `claimPendingSync` reddened nothing, because the handler-level guards still caught it. Only removing every guard isolates which layer acts — the guards are load-bearing, the teardown reset is belt-and-braces, and the code now says so rather than implying both are proven.

## Verification summary

`go build` clean · `make lint` 0 issues · `go test ./...` exit 0 · web `vitest` 1519 passed / 84 files · `svelte-check` 0 errors · `make test-pg` N/A (no store SQL) · two Codex rounds, converged CLEAN.

## Filed, not folded in

**BUG-2576** — follower tabs have the same uncovered initial-read window and cannot use this mechanism (they never open an EventSource), plus the adjacent non-sync listeners that still carry no source-identity guard.

https://claude.ai/code/session_01QCMLhHQBrMHVML3YKdm4Cd
