### PR TITLE
feat(web): quick actions push to a connected agent session (TASK-2562)

### DIFF
--- a/web/src/lib/components/collections/QuickActionsEditor.svelte
+++ b/web/src/lib/components/collections/QuickActionsEditor.svelte
@@ -70,8 +70,15 @@
 	const variableHelp = TEMPLATE_VARIABLES.map((v) => `{${v}}`).join(' · ');
 </script>
 
+<!-- PLAN-2558 S4: item actions push rather than copy, so the hint has to say
+     which surface does what. The one-line note is not pedantry — a pushed
+     prompt rides `Notification.Summary`, a single-line wire contract, so a
+     template laid out over paragraphs arrives collapsed. Better learned while
+     authoring than by reading it back in a terminal. -->
 <p class="qa-hint">
-	Quick actions copy agent prompts to your clipboard. Template variables:
+	Item actions push the resolved prompt to your connected agent session — as a
+	single line, so line breaks collapse — and copy it to your clipboard when no
+	session is connected. Collection actions always copy. Template variables:
 	<code class="qa-var-help">{variableHelp}</code>
 </p>
 

--- a/web/src/lib/components/common/QuickActionsMenu.svelte
+++ b/web/src/lib/components/common/QuickActionsMenu.svelte
@@ -179,6 +179,7 @@
 			if (!stillCurrent()) return;
 			presenceAppliedSeq = seq;
 			lastAnsweredAt = Date.now();
+			armExpiry();
 			// `sessions.length` over `count`: the array is what the server
 			// actually enumerated, and the two can only disagree if something is
 			// wrong — in which case the enumeration is the honest one.
@@ -186,6 +187,8 @@
 		} catch {
 			if (!stillCurrent()) return;
 			presenceAppliedSeq = seq;
+			// Already the state expiry would produce; nothing left to expire.
+			clearTimeout(expiryTimer);
 			// Every failure lands here as 'unknown', NEVER as zero — a 503 (no
 			// presence registry), a 401 (no resolved user, which is also the
 			// answer for a logged-out viewer) and a dead network are all "we
@@ -202,11 +205,40 @@
 	}
 
 	/**
+	 * Expire the displayed answer, and retire every read already in flight —
+	 * those were issued BEFORE the expiry, so their answers describe the server
+	 * as it was back then, and letting one land now would restore the very count
+	 * we just declared too old to trust. The next poll carries a newer seq and
+	 * still applies.
+	 */
+	function expirePresence() {
+		presence = { state: 'unknown' };
+		presenceAppliedSeq = presenceSeq;
+	}
+
+	/**
+	 * Fire the expiry at the moment it comes due, rather than waiting for the
+	 * next poll tick to notice (codex round 3).
+	 *
+	 * Without this the footer line kept saying "Pushes to your connected agent
+	 * session" for up to a full poll interval after the routing had already
+	 * switched to the clipboard — the menu contradicting itself, on the one line
+	 * whose entire job is to say what the next click will do.
+	 */
+	function armExpiry() {
+		clearTimeout(expiryTimer);
+		expiryTimer = setTimeout(expirePresence, PRESENCE_MAX_AGE_MS);
+	}
+	let expiryTimer: ReturnType<typeof setTimeout> | undefined;
+
+	/**
 	 * `presence`, downgraded to 'unknown' if it has gone stale.
 	 *
-	 * Read at CLICK time as well as on the poll tick, because a click can land
-	 * up to one whole poll interval after the answer expires — and routing is
-	 * the decision that actually costs something when it uses a dead count.
+	 * Belt AND braces with `armExpiry`, deliberately: a timer is a request, not
+	 * a guarantee. Browsers throttle timers hard in a backgrounded tab, so the
+	 * expiry can fire arbitrarily late — long after a user has returned to the
+	 * tab and clicked. The timer is what keeps the DISPLAY honest; this check is
+	 * what keeps the DECISION correct, and only the decision can lose a message.
 	 */
 	function currentPresence(): PushPresence | null {
 		return presenceExpired() ? { state: 'unknown' } : presence;
@@ -224,19 +256,15 @@
 		});
 		void readPresence(gen);
 		const timer = setInterval(() => {
-			if (presenceExpired()) {
-				presence = { state: 'unknown' };
-				// Retire every request already in flight. Those were issued BEFORE
-				// the expiry, so their answers describe the server as it was back
-				// then — letting one land now would restore the very count we just
-				// declared too old to trust. The read issued immediately below
-				// carries a newer seq and still applies.
-				presenceAppliedSeq = presenceSeq;
-			}
+			// Catches the throttled-timer case: if `expiryTimer` ran late, the
+			// answer is already past its bound and must not survive to the next
+			// tick just because a timeout was delayed.
+			if (presenceExpired()) expirePresence();
 			void readPresence(gen);
 		}, PRESENCE_POLL_MS);
 		return () => {
 			clearInterval(timer);
+			clearTimeout(expiryTimer);
 			// Retire in-flight reads so a late answer can't write into the next
 			// opening (or into a closed menu's stale `presence`).
 			presenceGen += 1;

--- a/web/src/lib/components/common/QuickActionsMenu.svelte
+++ b/web/src/lib/components/common/QuickActionsMenu.svelte
@@ -1,9 +1,19 @@
 <script lang="ts">
-	import { tick } from 'svelte';
+	import { tick, untrack } from 'svelte';
 	import type { QuickAction, Item, Collection } from '$lib/types';
 	import { parseFields, formatItemRef, parseSettings } from '$lib/types';
 	import { api, isConflictOrNotFound } from '$lib/api/client';
 	import { toastStore } from '$lib/stores/toast.svelte';
+	import { copyToClipboard } from '$lib/utils/clipboard';
+	import { collapsePushMessage } from '$lib/push/message';
+	import {
+		describeDispatch,
+		isPrePublishRefusal,
+		routePrompt,
+		type ClipboardReason,
+		type DispatchOutcome,
+		type PushPresence
+	} from '$lib/push/dispatch';
 	import Menu from '$lib/components/common/Menu.svelte';
 	import MenuItem from '$lib/components/common/MenuItem.svelte';
 	import EmojiPickerButton from '$lib/components/common/EmojiPickerButton.svelte';
@@ -86,38 +96,192 @@
 		return prompt;
 	}
 
-	function copyToClipboard(text: string): boolean {
-		// Try navigator.clipboard first
-		if (navigator.clipboard?.writeText) {
-			navigator.clipboard.writeText(text).catch(() => {});
-			return true;
-		}
-		// Fallback: temporary textarea + execCommand
-		const textarea = document.createElement('textarea');
-		textarea.value = text;
-		textarea.style.position = 'fixed';
-		textarea.style.opacity = '0';
-		document.body.appendChild(textarea);
-		textarea.select();
+	// ── Push dispatch (PLAN-2558 S4) ─────────────────────────────────────
+	//
+	// A quick action used to be a clipboard ferry: resolve the template, copy,
+	// let the user paste it into their agent. The templating was always the
+	// hard part and it already worked; only the last hop was manual. So the
+	// action now PUSHES the resolved prompt to the user's connected agent
+	// session, and the clipboard becomes the fallback rather than the
+	// mechanism.
+	//
+	// WHY PRESENCE IS READ WHEN THE MENU OPENS, NOT WHEN A ROW IS CLICKED.
+	// Both clipboard APIs — `navigator.clipboard.writeText` and the legacy
+	// `execCommand('copy')` — want the user gesture that is still live during
+	// the click handler and is gone after a network round-trip (Safari is
+	// strictest, but Firefox refuses too). Deciding push-vs-copy from a read
+	// issued on the CLICK would therefore put an await in front of the very
+	// fallback this slice promises, and the ruling is that nothing silently
+	// vanishes. Reading on OPEN keeps the copy synchronous inside the gesture.
+	//
+	// The cost is a small window: click a row before the first read lands and
+	// presence is null, which routes to the clipboard with an honest toast
+	// rather than to a push. That is the right way round — a needless paste
+	// costs the user one action, a push into nothing loses their instruction —
+	// and the window is bounded by how fast a mouse can reach a menu row.
+
+	/** Only item-scope actions can push: the endpoint is
+	 *  `POST .../items/{slug}/push`, and a collection-scope action has no item
+	 *  to address. Those keep the pre-S4 clipboard behavior exactly. */
+	const pushable = $derived(scope === 'item' && !!item);
+
+	/**
+	 * Presence re-read cadence while the menu is open. Same 10s as
+	 * PushToAgentDialog, and for the same reason: the registry's own worst-case
+	 * staleness is ~30s (an ungraceful disconnect is invisible until the next
+	 * keepalive write fails), so polling faster would buy precision the data
+	 * does not have.
+	 */
+	const PRESENCE_POLL_MS = 10_000;
+
+	/** What we know about who is listening; null until the first read of this
+	 *  opening lands. Null is treated as 'unknown' by `routePrompt` — "haven't
+	 *  heard" and "couldn't hear" license the same conclusion. */
+	let presence = $state<PushPresence | null>(null);
+	/** True while a push is in flight. The endpoint has NO idempotency key, so
+	 *  a second dispatch would deliver the instruction twice. */
+	let dispatching = $state(false);
+
+	// Fences for the presence reads. Plain `let`s, never $state: read and
+	// written only inside handlers, never in reactive position.
+	//  - `presenceGen` identifies one OPENING; a response in flight when the
+	//    menu closes must not write into the next one.
+	//  - `presenceSeq` identifies one REQUEST; nothing bounds how long one
+	//    takes, so a stalled poll can resolve after a later one and overwrite a
+	//    fresh count with an older one. Only a strictly newer response applies.
+	let presenceGen = 0;
+	let presenceSeq = 0;
+	let presenceAppliedSeq = 0;
+
+	async function readPresence(gen: number): Promise<void> {
+		const seq = ++presenceSeq;
+		const stillCurrent = () => gen === presenceGen && seq > presenceAppliedSeq;
 		try {
-			document.execCommand('copy');
-			return true;
+			const resp = await api.sessions.list();
+			if (!stillCurrent()) return;
+			presenceAppliedSeq = seq;
+			// `sessions.length` over `count`: the array is what the server
+			// actually enumerated, and the two can only disagree if something is
+			// wrong — in which case the enumeration is the honest one.
+			presence = { state: 'known', count: resp.sessions?.length ?? 0 };
 		} catch {
-			return false;
-		} finally {
-			document.body.removeChild(textarea);
+			if (!stillCurrent()) return;
+			presenceAppliedSeq = seq;
+			// Every failure lands here as 'unknown', NEVER as zero — a 503 (no
+			// presence registry), a 401 (no resolved user, which is also the
+			// answer for a logged-out viewer) and a dead network are all "we
+			// can't tell", and rendering them as zero is the exact lie
+			// handleListSessions returns 503 rather than an empty list to avoid.
+			presence = { state: 'unknown' };
 		}
 	}
 
-	function handleAction(action: QuickAction) {
-		const resolved = resolvePrompt(action);
-		if (copyToClipboard(resolved)) {
-			toastStore.show('Copied to clipboard', 'success');
-		} else {
-			toastStore.show('Failed to copy to clipboard', 'error');
-		}
-		open = false;
+	// CONVE-1688: the tracked scope reads only `open` and `pushable`; every
+	// $state write is inside `untrack`, so the effect cannot self-invalidate.
+	$effect(() => {
+		if (!open || !pushable) return;
+		const gen = untrack(() => {
+			presenceAppliedSeq = 0;
+			presence = null;
+			return ++presenceGen;
+		});
+		void readPresence(gen);
+		const timer = setInterval(() => void readPresence(gen), PRESENCE_POLL_MS);
+		return () => {
+			clearInterval(timer);
+			// Retire in-flight reads so a late answer can't write into the next
+			// opening (or into a closed menu's stale `presence`).
+			presenceGen += 1;
+		};
+	});
+
+	function announce(outcome: DispatchOutcome, copyOffer?: string) {
+		const { message, tone } = describeDispatch(outcome);
+		// The two push-failure messages carry an instruction ("check your agent
+		// session before sending it again") that nobody can read in 3s.
+		const longLived = outcome.kind === 'push-refused' || outcome.kind === 'push-unconfirmed';
+		toastStore.show(
+			message,
+			tone,
+			longLived ? 9000 : undefined,
+			undefined,
+			// Offered ONLY where a copy cannot duplicate anything — see the call
+			// sites. The click is also a fresh user gesture, which is what makes
+			// a clipboard write work this long after the original one.
+			copyOffer ? { label: 'Copy instead', onAction: () => void copyToClipboard(copyOffer) } : undefined
+		);
 	}
+
+	async function copyAndAnnounce(text: string, because: ClipboardReason): Promise<void> {
+		// The RAW prompt, not the collapsed one: the clipboard has no
+		// single-line constraint, so an action whose template spans paragraphs
+		// should paste as the author wrote it. Only the push is collapsed, and
+		// only because `Notification.Summary` is a one-line wire contract.
+		const ok = await copyToClipboard(text);
+		announce(ok ? { kind: 'copied', because } : { kind: 'copy-failed', because });
+	}
+
+	async function handleAction(action: QuickAction) {
+		if (dispatching) return;
+		// Capture everything BEFORE any await (BUG-2265 switch-safety): this
+		// component is reused across items and collections without a guaranteed
+		// remount, so reading a live prop after the await could address the
+		// WRONG item.
+		const prompt = resolvePrompt(action);
+		const ws = wsSlug;
+		const target = pushable && item ? item.slug : null;
+		const knownCount = presence?.state === 'known' ? presence.count : 0;
+		const route = routePrompt(prompt, target, presence);
+		open = false;
+		resetCreateForm();
+
+		if (route.via === 'clipboard' || !target) {
+			// Still inside the click's user gesture — see the note above.
+			await copyAndAnnounce(prompt, route.via === 'clipboard' ? route.because : 'not-addressable');
+			return;
+		}
+
+		dispatching = true;
+		try {
+			// NEVER retried automatically, here or anywhere else: the endpoint
+			// carries no idempotency key.
+			await api.items.push(ws, target, collapsePushMessage(prompt));
+			announce({ kind: 'pushed', count: knownCount });
+		} catch (err) {
+			if (isPrePublishRefusal(err)) {
+				// The server refused before publishing, so nothing went out and
+				// handing the text over cannot deliver it twice — offer the copy.
+				announce(
+					{ kind: 'push-refused', detail: err instanceof Error ? err.message : '' },
+					prompt
+				);
+			} else {
+				// Outcome genuinely unknown: the handler publishes BEFORE it
+				// writes its response, so the instruction may already have
+				// landed. No copy offer here — a paste would be the duplicate the
+				// message is warning about.
+				announce({ kind: 'push-unconfirmed' });
+			}
+		} finally {
+			dispatching = false;
+		}
+	}
+
+	/** The menu footer line. Says what the NEXT click will do, so the routing
+	 *  is visible before it happens rather than only in the toast after. */
+	const tagline = $derived.by(() => {
+		if (!pushable) return 'Copy a prompt to your agent';
+		if (!presence) return 'Checking for connected agent sessions…';
+		if (presence.state === 'unknown') {
+			return 'Can’t tell if an agent is connected — actions copy to your clipboard';
+		}
+		if (presence.count === 0) {
+			return 'No agent session connected — actions copy to your clipboard';
+		}
+		return presence.count === 1
+			? 'Pushes to your connected agent session'
+			: `Pushes to your ${presence.count} connected agent sessions`;
+	});
 
 	function resetCreateForm() {
 		showCreateForm = false;
@@ -279,6 +443,11 @@
 		></textarea>
 		<div class="qa-help">
 			Template variables: {'{ref}'} {'{title}'} {'{status}'} {'{priority}'} {'{collection}'} {'{content}'} {'{fields}'}
+			{#if scope === 'item'}
+				<br />
+				Pushes to your connected agent session as a single line; copies to your
+				clipboard when none is connected.
+			{/if}
 		</div>
 		<div class="qa-actions">
 			<button class="qa-btn qa-btn-cancel" type="button" onclick={resetCreateForm}>
@@ -305,7 +474,12 @@
 				{action.label}
 			</MenuItem>
 		{/each}
-		<div class="dropdown-tagline">Copy a prompt to your agent</div>
+		<!-- Plain div, deliberately not role="status": the panel is role="menu",
+		     whose children must be menuitem/group/separator, and a live region
+		     nested in a menu is unreliably announced anyway. The routing reaches
+		     assistive tech through the menu's own accessible name instead (see
+		     `ariaLabel` below), which is read when focus enters the panel. -->
+		<div class="dropdown-tagline">{tagline}</div>
 		{#if canEdit}
 			<div class="footer-divider"></div>
 			<MenuItem icon="+" onclick={() => (showCreateForm = true)}>New quick action</MenuItem>
@@ -334,7 +508,7 @@
 			align={alignLeft ? 'left' : 'right'}
 			sheetOnMobile
 			sheetTitle="Quick actions"
-			ariaLabel="Quick actions"
+			ariaLabel={pushable ? `Quick actions. ${tagline}` : 'Quick actions'}
 			exempt={emojiPickerContainers}
 		>
 			<div class="qa-body">

--- a/web/src/lib/components/common/QuickActionsMenu.svelte
+++ b/web/src/lib/components/common/QuickActionsMenu.svelte
@@ -134,10 +134,28 @@
 	 */
 	const PRESENCE_POLL_MS = 10_000;
 
+	/**
+	 * How stale a 'known' answer may get before it degrades to "can't tell".
+	 *
+	 * A FAILED poll already lands as 'unknown'. A poll that HANGS does not — it
+	 * simply never writes, leaving the last count in place indefinitely while
+	 * the menu goes on offering a push into a session that may be long gone.
+	 * That is the losing direction, so a known answer expires.
+	 *
+	 * 30s is not arbitrary: it is the server's own worst-case presence staleness
+	 * (`watchEventsKeepaliveInterval` — an ungraceful disconnect is invisible
+	 * until the next keepalive write fails). Past it an un-refreshed count is no
+	 * more informative than no count. Three poll intervals must fail in a row to
+	 * reach it. Same bound and same reasoning as PushToAgentDialog.
+	 */
+	const PRESENCE_MAX_AGE_MS = 30_000;
+
 	/** What we know about who is listening; null until the first read of this
 	 *  opening lands. Null is treated as 'unknown' by `routePrompt` — "haven't
 	 *  heard" and "couldn't hear" license the same conclusion. */
 	let presence = $state<PushPresence | null>(null);
+	/** Wall-clock of the last SUCCESSFUL presence read, for the expiry above. */
+	let lastAnsweredAt = 0;
 	/** True while a push is in flight. The endpoint has NO idempotency key, so
 	 *  a second dispatch would deliver the instruction twice. */
 	let dispatching = $state(false);
@@ -160,6 +178,7 @@
 			const resp = await api.sessions.list();
 			if (!stillCurrent()) return;
 			presenceAppliedSeq = seq;
+			lastAnsweredAt = Date.now();
 			// `sessions.length` over `count`: the array is what the server
 			// actually enumerated, and the two can only disagree if something is
 			// wrong — in which case the enumeration is the honest one.
@@ -176,6 +195,23 @@
 		}
 	}
 
+	/** True when a 'known' answer has stopped being refreshed for longer than
+	 *  the server's own presence staleness bound. */
+	function presenceExpired(): boolean {
+		return presence?.state === 'known' && Date.now() - lastAnsweredAt > PRESENCE_MAX_AGE_MS;
+	}
+
+	/**
+	 * `presence`, downgraded to 'unknown' if it has gone stale.
+	 *
+	 * Read at CLICK time as well as on the poll tick, because a click can land
+	 * up to one whole poll interval after the answer expires — and routing is
+	 * the decision that actually costs something when it uses a dead count.
+	 */
+	function currentPresence(): PushPresence | null {
+		return presenceExpired() ? { state: 'unknown' } : presence;
+	}
+
 	// CONVE-1688: the tracked scope reads only `open` and `pushable`; every
 	// $state write is inside `untrack`, so the effect cannot self-invalidate.
 	$effect(() => {
@@ -183,10 +219,22 @@
 		const gen = untrack(() => {
 			presenceAppliedSeq = 0;
 			presence = null;
+			lastAnsweredAt = 0;
 			return ++presenceGen;
 		});
 		void readPresence(gen);
-		const timer = setInterval(() => void readPresence(gen), PRESENCE_POLL_MS);
+		const timer = setInterval(() => {
+			if (presenceExpired()) {
+				presence = { state: 'unknown' };
+				// Retire every request already in flight. Those were issued BEFORE
+				// the expiry, so their answers describe the server as it was back
+				// then — letting one land now would restore the very count we just
+				// declared too old to trust. The read issued immediately below
+				// carries a newer seq and still applies.
+				presenceAppliedSeq = presenceSeq;
+			}
+			void readPresence(gen);
+		}, PRESENCE_POLL_MS);
 		return () => {
 			clearInterval(timer);
 			// Retire in-flight reads so a late answer can't write into the next
@@ -230,8 +278,11 @@
 		const prompt = resolvePrompt(action);
 		const ws = wsSlug;
 		const target = pushable && item ? item.slug : null;
-		const knownCount = presence?.state === 'known' ? presence.count : 0;
-		const route = routePrompt(prompt, target, presence);
+		// The staleness-aware read, not the raw state: a click can land a whole
+		// poll interval after a 'known' answer expired.
+		const known = currentPresence();
+		const knownCount = known?.state === 'known' ? known.count : 0;
+		const route = routePrompt(prompt, target, known);
 		open = false;
 		resetCreateForm();
 

--- a/web/src/lib/components/common/QuickActionsMenu.svelte
+++ b/web/src/lib/components/common/QuickActionsMenu.svelte
@@ -256,7 +256,18 @@
 			// Offered ONLY where a copy cannot duplicate anything — see the call
 			// sites. The click is also a fresh user gesture, which is what makes
 			// a clipboard write work this long after the original one.
-			copyOffer ? { label: 'Copy instead', onAction: () => void copyToClipboard(copyOffer) } : undefined
+			//
+			// The offer reports its own outcome (codex round 2). Taking it
+			// dismisses the toast that carried it, so discarding the result would
+			// leave a failed copy completely silent — and this is the one path
+			// where that silence means the instruction was neither sent NOR
+			// copied, which is the worst state the surface can be in.
+			copyOffer
+				? {
+						label: 'Copy instead',
+						onAction: () => void copyAndAnnounce(copyOffer, 'offered')
+					}
+				: undefined
 		);
 	}
 

--- a/web/src/lib/components/common/QuickActionsMenu.svelte.test.ts
+++ b/web/src/lib/components/common/QuickActionsMenu.svelte.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { flushSync, mount, unmount } from 'svelte';
 import { tick } from 'svelte';
-import type { Collection } from '$lib/types';
+import type { Collection, Item, QuickAction } from '$lib/types';
 
 // BUG-2265 Pattern C: QuickActionsMenu's save must recover from a competing
 // RENAME (404 not_found) — not just a 409 — by resolving the collection by its
@@ -11,6 +11,20 @@ import type { Collection } from '$lib/types';
 
 const updateMock = vi.fn();
 const listMock = vi.fn();
+const sessionsListMock = vi.fn();
+const pushMock = vi.fn();
+
+// Stand-in for the real PadApiError. `$lib/push/dispatch` classifies failures
+// with `err instanceof PadApiError`, and it imports the class from THIS mocked
+// module — so the class the component sees and the class a test throws must be
+// the same object, which is only true if both come from here.
+class MockPadApiError extends Error {
+	code: string;
+	constructor(init: { code: string; message: string }) {
+		super(init.message);
+		this.code = init.code;
+	}
+}
 
 vi.mock('$lib/api/client', () => ({
 	api: {
@@ -18,12 +32,24 @@ vi.mock('$lib/api/client', () => ({
 			update: (...args: unknown[]) => updateMock(...args),
 			list: (...args: unknown[]) => listMock(...args),
 		},
+		sessions: {
+			list: (...args: unknown[]) => sessionsListMock(...args),
+		},
+		items: {
+			push: (...args: unknown[]) => pushMock(...args),
+		},
 	},
+	PadApiError: MockPadApiError,
 	// Real-ish classifier so the component's branch fires for 404/409.
 	isConflictOrNotFound: (err: unknown) =>
 		err instanceof Error &&
 		((err as { code?: string }).code === 'not_found' ||
 			(err as { code?: string }).code === 'update_conflict'),
+}));
+
+const copyMock = vi.fn();
+vi.mock('$lib/utils/clipboard', () => ({
+	copyToClipboard: (...args: unknown[]) => copyMock(...args),
 }));
 
 const toastShow = vi.fn();
@@ -141,5 +167,303 @@ describe('QuickActionsMenu save retry (BUG-2265 Pattern C)', () => {
 
 		unmount(component);
 		host.remove();
+	});
+});
+
+// ── PLAN-2558 S4: quick actions push, clipboard is the fallback ─────────────
+//
+// The behavior under test is a ROUTING decision plus what the user is told
+// about it. Both halves matter: a fallback that silently reports "Copied to
+// clipboard" on a surface the user believes pushes is the failure this slice
+// exists to prevent, and so is a push that claims a delivery nobody can
+// confirm. Each case therefore asserts BOTH which call was made and which was
+// not — an assertion on the push alone would stay green if the component also
+// clobbered the clipboard every time.
+
+const PUSH_ACTION: QuickAction = {
+	label: 'Ship it',
+	prompt: 'Ship {ref}',
+	scope: 'item',
+};
+
+function makeItem(): Item {
+	return {
+		id: 'i1',
+		workspace_id: 'ws-1',
+		collection_id: 'c1',
+		slug: 'ship-the-thing',
+		title: 'Ship the thing',
+		content: '',
+		fields: '{"status":"open"}',
+		item_number: 14,
+		collection_prefix: 'TASK',
+		created_at: '2026-01-01T00:00:00Z',
+		updated_at: '2026-01-01T00:00:00Z',
+	} as unknown as Item;
+}
+
+interface MountOpts {
+	scope?: 'item' | 'collection';
+	item?: Item | null;
+	actions?: QuickAction[];
+}
+
+function mountMenu(opts: MountOpts = {}) {
+	const host = document.createElement('div');
+	document.body.appendChild(host);
+	const component = mount(QuickActionsMenu, {
+		target: host,
+		props: {
+			actions: opts.actions ?? [PUSH_ACTION],
+			item: opts.item === undefined ? makeItem() : opts.item,
+			collection: makeCollection('c1', 'tasks'),
+			scope: opts.scope ?? 'item',
+			wsSlug: 'ws-1',
+			canEdit: false,
+		},
+	});
+	flushSync();
+	return { host, component };
+}
+
+/** Open the menu and let the presence read (if any) settle. */
+async function openMenu(host: HTMLElement) {
+	(host.querySelector('.trigger-btn') as HTMLButtonElement).click();
+	flushSync();
+	await tick();
+	await tick();
+	flushSync();
+}
+
+function actionRow(host: HTMLElement, label: string): HTMLButtonElement {
+	const row = [...host.querySelectorAll('button')].find(
+		(b) => b.textContent?.trim() === label
+	);
+	if (!row) throw new Error(`no action row labelled ${label}`);
+	return row as HTMLButtonElement;
+}
+
+describe('QuickActionsMenu push dispatch (PLAN-2558 S4)', () => {
+	beforeEach(() => {
+		updateMock.mockReset();
+		listMock.mockReset();
+		toastShow.mockReset();
+		sessionsListMock.mockReset();
+		pushMock.mockReset();
+		copyMock.mockReset();
+		copyMock.mockResolvedValue(true);
+	});
+
+	it('pushes the resolved prompt when a session is connected, and leaves the clipboard alone', async () => {
+		sessionsListMock.mockResolvedValue({ sessions: [{ id: 's1' }], count: 1 });
+		pushMock.mockResolvedValue({ pushed: true });
+
+		const { host, component } = mountMenu();
+		await openMenu(host);
+		actionRow(host, 'Ship it').click();
+		await vi.waitFor(() => expect(pushMock).toHaveBeenCalledTimes(1));
+
+		// Template resolved (TASK-14, not the literal {ref}) and addressed by
+		// the item's slug against the workspace it was mounted for.
+		expect(pushMock.mock.calls[0]).toEqual(['ws-1', 'ship-the-thing', 'Ship TASK-14']);
+		// The clipboard is NOT a belt-and-braces second delivery: clobbering it
+		// on the happy path would take the user's clipboard for nothing.
+		expect(copyMock).not.toHaveBeenCalled();
+		expect(toastShow.mock.calls[0][0]).toContain('Pushed to your agent session');
+		expect(toastShow.mock.calls[0][0]).toContain('delivery isn’t confirmed');
+
+		unmount(component);
+		host.remove();
+	});
+
+	it('copies with the ruled wording when nothing is listening, and never pushes', async () => {
+		sessionsListMock.mockResolvedValue({ sessions: [], count: 0 });
+
+		const { host, component } = mountMenu();
+		await openMenu(host);
+		actionRow(host, 'Ship it').click();
+		await vi.waitFor(() => expect(toastShow).toHaveBeenCalled());
+
+		expect(pushMock).not.toHaveBeenCalled();
+		expect(copyMock).toHaveBeenCalledWith('Ship TASK-14');
+		expect(toastShow.mock.calls[0][0]).toBe(
+			'No agent session connected — copied to clipboard instead'
+		);
+
+		unmount(component);
+		host.remove();
+	});
+
+	it('copies rather than pushing when presence cannot be read', async () => {
+		// A failed read is NOT zero sessions — but here it routes the same way,
+		// because the surface has no dialog in which to state the uncertainty
+		// and the lossless branch is the one to take blind.
+		sessionsListMock.mockRejectedValue(new Error('network down'));
+
+		const { host, component } = mountMenu();
+		await openMenu(host);
+		actionRow(host, 'Ship it').click();
+		await vi.waitFor(() => expect(toastShow).toHaveBeenCalled());
+
+		expect(pushMock).not.toHaveBeenCalled();
+		expect(copyMock).toHaveBeenCalledWith('Ship TASK-14');
+		expect(toastShow.mock.calls[0][0]).toContain('Couldn’t check for agent sessions');
+
+		unmount(component);
+		host.remove();
+	});
+
+	it('issues the clipboard fallback synchronously inside the click', async () => {
+		// The load-bearing timing property, and the reason presence is read when
+		// the MENU OPENS rather than on the click. Both clipboard APIs want the
+		// user gesture that is live during the handler and gone after a network
+		// round-trip, so the copy must be dispatched before ANY await.
+		//
+		// Counterfactual: move the presence read into handleAction (await it
+		// before deciding) and this assertion fails while every other test in
+		// this block still passes — the copy still happens, just a microtask
+		// too late to be inside the gesture.
+		sessionsListMock.mockResolvedValue({ sessions: [], count: 0 });
+
+		const { host, component } = mountMenu();
+		await openMenu(host);
+		actionRow(host, 'Ship it').click();
+		// No await, no tick: the call must already have been made.
+		expect(copyMock).toHaveBeenCalledWith('Ship TASK-14');
+
+		unmount(component);
+		host.remove();
+	});
+
+	it('copies the RAW prompt but pushes the collapsed one', async () => {
+		// Two different constraints. `Notification.Summary` is a single-line wire
+		// contract, so a push is collapsed; the clipboard has no such bound, so a
+		// paste should look like what the author wrote.
+		const multiline: QuickAction = {
+			label: 'Review',
+			prompt: 'Review {ref}\n\nCheck the tests too.',
+			scope: 'item',
+		};
+
+		sessionsListMock.mockResolvedValue({ sessions: [{ id: 's1' }], count: 1 });
+		pushMock.mockResolvedValue({ pushed: true });
+		const pushed = mountMenu({ actions: [multiline] });
+		await openMenu(pushed.host);
+		actionRow(pushed.host, 'Review').click();
+		await vi.waitFor(() => expect(pushMock).toHaveBeenCalledTimes(1));
+		expect(pushMock.mock.calls[0][2]).toBe('Review TASK-14 Check the tests too.');
+		unmount(pushed.component);
+		pushed.host.remove();
+
+		sessionsListMock.mockResolvedValue({ sessions: [], count: 0 });
+		const copied = mountMenu({ actions: [multiline] });
+		await openMenu(copied.host);
+		actionRow(copied.host, 'Review').click();
+		await vi.waitFor(() => expect(copyMock).toHaveBeenCalled());
+		expect(copyMock.mock.calls[0][0]).toBe('Review TASK-14\n\nCheck the tests too.');
+		unmount(copied.component);
+		copied.host.remove();
+	});
+
+	it('never reads presence or pushes for a collection-scope action', async () => {
+		// The endpoint is POST .../items/{slug}/push. A collection-scope action
+		// has no item to address, so it keeps the pre-S4 behavior exactly — and
+		// must not spend a presence read finding that out.
+		const collectionAction: QuickAction = {
+			label: 'Triage',
+			prompt: 'Triage {collection}',
+			scope: 'collection',
+		};
+		const { host, component } = mountMenu({
+			scope: 'collection',
+			item: null,
+			actions: [collectionAction],
+		});
+		await openMenu(host);
+
+		expect(sessionsListMock).not.toHaveBeenCalled();
+		actionRow(host, 'Triage').click();
+		await vi.waitFor(() => expect(toastShow).toHaveBeenCalled());
+
+		expect(pushMock).not.toHaveBeenCalled();
+		expect(copyMock).toHaveBeenCalledWith('Triage Tasks');
+		expect(toastShow.mock.calls[0][0]).toBe('Copied to clipboard');
+
+		unmount(component);
+		host.remove();
+	});
+
+	it('offers a copy — but does not take one — when the server refuses before publishing', async () => {
+		// A recognised pre-publish refusal means nothing went out, so handing the
+		// text over cannot deliver it twice. It is OFFERED rather than done
+		// because the original gesture is spent by now; the toast button is a
+		// fresh one, which is what makes the clipboard write work.
+		sessionsListMock.mockResolvedValue({ sessions: [{ id: 's1' }], count: 1 });
+		pushMock.mockRejectedValue(
+			new MockPadApiError({ code: 'unavailable', message: 'Push is not available' })
+		);
+
+		const { host, component } = mountMenu();
+		await openMenu(host);
+		actionRow(host, 'Ship it').click();
+		await vi.waitFor(() => expect(toastShow).toHaveBeenCalled());
+
+		const [message, tone, , , action] = toastShow.mock.calls[0];
+		expect(tone).toBe('error');
+		expect(message).toContain('Push is not available');
+		expect(action?.label).toBe('Copy instead');
+		// Offered, not taken.
+		expect(copyMock).not.toHaveBeenCalled();
+
+		action.onAction();
+		await vi.waitFor(() => expect(copyMock).toHaveBeenCalledWith('Ship TASK-14'));
+
+		unmount(component);
+		host.remove();
+	});
+
+	it('offers nothing when the push outcome is unknown', async () => {
+		// The handler publishes BEFORE it writes its response, so an
+		// unrecognised failure leaves the instruction possibly delivered. A
+		// "Copy instead" button here would invite exactly the duplicate the
+		// message warns about — the endpoint has no idempotency key.
+		sessionsListMock.mockResolvedValue({ sessions: [{ id: 's1' }], count: 1 });
+		pushMock.mockRejectedValue(new TypeError('Failed to fetch'));
+
+		const { host, component } = mountMenu();
+		await openMenu(host);
+		actionRow(host, 'Ship it').click();
+		await vi.waitFor(() => expect(toastShow).toHaveBeenCalled());
+
+		const [message, tone, , , action] = toastShow.mock.calls[0];
+		expect(tone).toBe('info');
+		expect(message).toContain('didn’t say whether the push went through');
+		expect(action).toBeUndefined();
+		expect(copyMock).not.toHaveBeenCalled();
+
+		unmount(component);
+		host.remove();
+	});
+
+	it('tells the user which way the next click will go, before they click', async () => {
+		// The S3 principle applied to a surface with no dialog: the routing is
+		// visible in the menu itself, not only in the toast afterwards.
+		sessionsListMock.mockResolvedValue({ sessions: [], count: 0 });
+		const { host, component } = mountMenu();
+		await openMenu(host);
+		expect(host.querySelector('.dropdown-tagline')?.textContent?.trim()).toBe(
+			'No agent session connected — actions copy to your clipboard'
+		);
+		unmount(component);
+		host.remove();
+
+		sessionsListMock.mockResolvedValue({ sessions: [{ id: 's1' }, { id: 's2' }], count: 2 });
+		const live = mountMenu();
+		await openMenu(live.host);
+		expect(live.host.querySelector('.dropdown-tagline')?.textContent?.trim()).toBe(
+			'Pushes to your 2 connected agent sessions'
+		);
+		unmount(live.component);
+		live.host.remove();
 	});
 });

--- a/web/src/lib/components/common/QuickActionsMenu.svelte.test.ts
+++ b/web/src/lib/components/common/QuickActionsMenu.svelte.test.ts
@@ -467,3 +467,121 @@ describe('QuickActionsMenu push dispatch (PLAN-2558 S4)', () => {
 		live.host.remove();
 	});
 });
+
+describe('QuickActionsMenu presence staleness (codex round 1)', () => {
+	beforeEach(() => {
+		toastShow.mockReset();
+		sessionsListMock.mockReset();
+		pushMock.mockReset();
+		copyMock.mockReset();
+		copyMock.mockResolvedValue(true);
+	});
+
+	it('stops trusting a count whose refreshes have stopped landing', async () => {
+		// A FAILED poll already degrades to 'unknown'. A poll that HANGS does
+		// not — it just never writes, so without an expiry the menu goes on
+		// offering a push against a session that may be long gone, which is the
+		// one direction that loses the user's instruction.
+		vi.useFakeTimers();
+		try {
+			sessionsListMock.mockResolvedValueOnce({ sessions: [{ id: 's1' }], count: 1 });
+			// Every poll after the first hangs forever.
+			sessionsListMock.mockReturnValue(new Promise(() => {}));
+
+			const { host, component } = mountMenu();
+			(host.querySelector('.trigger-btn') as HTMLButtonElement).click();
+			flushSync();
+			await vi.advanceTimersByTimeAsync(0);
+			flushSync();
+
+			// The first read landed: the menu is armed to push.
+			expect(host.querySelector('.dropdown-tagline')?.textContent?.trim()).toBe(
+				'Pushes to your connected agent session'
+			);
+
+			// Four poll intervals later — nothing has refreshed it. (The TAGLINE
+			// can lag the expiry by up to one interval, since only a tick
+			// rewrites it; the routing decision does not — see the next test.)
+			await vi.advanceTimersByTimeAsync(41_000);
+			flushSync();
+			expect(host.querySelector('.dropdown-tagline')?.textContent?.trim()).toBe(
+				'Can’t tell if an agent is connected — actions copy to your clipboard'
+			);
+
+			actionRow(host, 'Ship it').click();
+			await vi.advanceTimersByTimeAsync(0);
+			expect(pushMock).not.toHaveBeenCalled();
+			expect(copyMock).toHaveBeenCalledWith('Ship TASK-14');
+			expect(toastShow.mock.calls[0][0]).toContain('Couldn’t check for agent sessions');
+
+			unmount(component);
+			host.remove();
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it('refuses a stale count at click time, between poll ticks', async () => {
+		// The expiry must be checked where the DECISION is made, not only on
+		// the poll tick. A tick-only expiry leaves a window of up to one whole
+		// interval in which the menu still pushes against a count it has
+		// already outlived — and this is exactly the window a click lands in.
+		vi.useFakeTimers();
+		try {
+			sessionsListMock.mockResolvedValueOnce({ sessions: [{ id: 's1' }], count: 1 });
+			sessionsListMock.mockReturnValue(new Promise(() => {}));
+
+			const { host, component } = mountMenu();
+			(host.querySelector('.trigger-btn') as HTMLButtonElement).click();
+			flushSync();
+			await vi.advanceTimersByTimeAsync(0);
+			flushSync();
+
+			// Past the bound, but BEFORE the tick that would rewrite the tagline.
+			await vi.advanceTimersByTimeAsync(31_000);
+			flushSync();
+			expect(host.querySelector('.dropdown-tagline')?.textContent?.trim()).toBe(
+				'Pushes to your connected agent session'
+			);
+
+			actionRow(host, 'Ship it').click();
+			await vi.advanceTimersByTimeAsync(0);
+			expect(pushMock).not.toHaveBeenCalled();
+			expect(copyMock).toHaveBeenCalledWith('Ship TASK-14');
+
+			unmount(component);
+			host.remove();
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it('does not expire an answer that is still being refreshed', async () => {
+		// The control leg: with polls landing, the same elapsed time must NOT
+		// downgrade the answer — an expiry that fires on a healthy connection
+		// would silently retire the whole feature.
+		vi.useFakeTimers();
+		try {
+			sessionsListMock.mockResolvedValue({ sessions: [{ id: 's1' }], count: 1 });
+
+			const { host, component } = mountMenu();
+			(host.querySelector('.trigger-btn') as HTMLButtonElement).click();
+			flushSync();
+			await vi.advanceTimersByTimeAsync(31_000);
+			flushSync();
+
+			expect(host.querySelector('.dropdown-tagline')?.textContent?.trim()).toBe(
+				'Pushes to your connected agent session'
+			);
+			actionRow(host, 'Ship it').click();
+			await vi.advanceTimersByTimeAsync(0);
+			expect(pushMock).toHaveBeenCalledTimes(1);
+			expect(copyMock).not.toHaveBeenCalled();
+
+			unmount(component);
+			host.remove();
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+});

--- a/web/src/lib/components/common/QuickActionsMenu.svelte.test.ts
+++ b/web/src/lib/components/common/QuickActionsMenu.svelte.test.ts
@@ -417,6 +417,36 @@ describe('QuickActionsMenu push dispatch (PLAN-2558 S4)', () => {
 
 		action.onAction();
 		await vi.waitFor(() => expect(copyMock).toHaveBeenCalledWith('Ship TASK-14'));
+		// Taking the offer reports its own outcome, plainly — the user asked for
+		// the copy, so there is no absent push to explain.
+		await vi.waitFor(() => expect(toastShow).toHaveBeenCalledTimes(2));
+		expect(toastShow.mock.calls[1][0]).toBe('Copied to clipboard');
+
+		unmount(component);
+		host.remove();
+	});
+
+	it('does not swallow a failure in the offered copy', async () => {
+		// Taking the offer dismisses the toast that carried it, so a discarded
+		// result would leave a failed copy completely silent — and this is the
+		// one path where that silence means the instruction was neither sent NOR
+		// copied, the worst state the surface can be in.
+		sessionsListMock.mockResolvedValue({ sessions: [{ id: 's1' }], count: 1 });
+		pushMock.mockRejectedValue(
+			new MockPadApiError({ code: 'rate_limited', message: 'Too many requests' })
+		);
+		copyMock.mockResolvedValue(false);
+
+		const { host, component } = mountMenu();
+		await openMenu(host);
+		actionRow(host, 'Ship it').click();
+		await vi.waitFor(() => expect(toastShow).toHaveBeenCalled());
+
+		const action = toastShow.mock.calls[0][4];
+		action.onAction();
+		await vi.waitFor(() => expect(toastShow).toHaveBeenCalledTimes(2));
+		expect(toastShow.mock.calls[1][0]).toBe('Failed to copy to clipboard');
+		expect(toastShow.mock.calls[1][1]).toBe('error');
 
 		unmount(component);
 		host.remove();

--- a/web/src/lib/components/common/QuickActionsMenu.svelte.test.ts
+++ b/web/src/lib/components/common/QuickActionsMenu.svelte.test.ts
@@ -551,11 +551,12 @@ describe('QuickActionsMenu presence staleness (codex round 1)', () => {
 		}
 	});
 
-	it('refuses a stale count at click time, between poll ticks', async () => {
-		// The expiry must be checked where the DECISION is made, not only on
-		// the poll tick. A tick-only expiry leaves a window of up to one whole
-		// interval in which the menu still pushes against a count it has
-		// already outlived — and this is exactly the window a click lands in.
+	it('refuses a stale count at click time even if the expiry timer never ran', async () => {
+		// A timer is a request, not a guarantee: browsers throttle timers hard
+		// in a backgrounded tab, so the expiry can fire long after it came due —
+		// including after the user has come back and clicked. Modelled by moving
+		// the CLOCK without running any timer, which is exactly what throttling
+		// looks like from the component's point of view.
 		vi.useFakeTimers();
 		try {
 			sessionsListMock.mockResolvedValueOnce({ sessions: [{ id: 's1' }], count: 1 });
@@ -567,17 +568,55 @@ describe('QuickActionsMenu presence staleness (codex round 1)', () => {
 			await vi.advanceTimersByTimeAsync(0);
 			flushSync();
 
-			// Past the bound, but BEFORE the tick that would rewrite the tagline.
-			await vi.advanceTimersByTimeAsync(31_000);
+			// Clock jumps well past the bound; NO timer fires, so the display
+			// still shows what the last successful read said.
+			vi.setSystemTime(Date.now() + 5 * 60_000);
 			flushSync();
 			expect(host.querySelector('.dropdown-tagline')?.textContent?.trim()).toBe(
 				'Pushes to your connected agent session'
 			);
 
+			// The decision must not inherit that staleness.
 			actionRow(host, 'Ship it').click();
 			await vi.advanceTimersByTimeAsync(0);
 			expect(pushMock).not.toHaveBeenCalled();
 			expect(copyMock).toHaveBeenCalledWith('Ship TASK-14');
+
+			unmount(component);
+			host.remove();
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it('flips the footer line the moment the answer comes due, not a poll later', async () => {
+		// The line's whole job is to say what the next click will do, so it must
+		// not go on advertising a push for up to a full poll interval after the
+		// routing has already switched to the clipboard.
+		vi.useFakeTimers();
+		try {
+			sessionsListMock.mockResolvedValueOnce({ sessions: [{ id: 's1' }], count: 1 });
+			sessionsListMock.mockReturnValue(new Promise(() => {}));
+
+			const { host, component } = mountMenu();
+			(host.querySelector('.trigger-btn') as HTMLButtonElement).click();
+			flushSync();
+			await vi.advanceTimersByTimeAsync(0);
+			flushSync();
+
+			// Just before the bound: still armed.
+			await vi.advanceTimersByTimeAsync(29_000);
+			flushSync();
+			expect(host.querySelector('.dropdown-tagline')?.textContent?.trim()).toBe(
+				'Pushes to your connected agent session'
+			);
+
+			// Just past it — and well before the next 10s poll tick at t=40s.
+			await vi.advanceTimersByTimeAsync(1_500);
+			flushSync();
+			expect(host.querySelector('.dropdown-tagline')?.textContent?.trim()).toBe(
+				'Can’t tell if an agent is connected — actions copy to your clipboard'
+			);
 
 			unmount(component);
 			host.remove();

--- a/web/src/lib/components/items/PushToAgentDialog.svelte
+++ b/web/src/lib/components/items/PushToAgentDialog.svelte
@@ -66,6 +66,9 @@ server tells you not to run would cost honesty in the case that actually ships.
 		pushMessageLength,
 		trimPushMessage
 	} from '$lib/push/message';
+	// Shared with the quick-action dispatch (PLAN-2558 S4) — one whitelist, so
+	// the two surfaces can't drift on which failures are safe to re-offer.
+	import { isPrePublishRefusal } from '$lib/push/dispatch';
 	import type { LiveSession } from '$lib/types';
 
 	interface Props {
@@ -322,36 +325,6 @@ server tells you not to run would cost honesty in the case that actually ships.
 		onclose();
 	}
 
-	/**
-	 * Error codes handlePushToItem (and the middleware in front of it) can
-	 * return WITHOUT having published — the request provably never reached the
-	 * bus, so a corrected resend cannot duplicate anything.
-	 *
-	 * A whitelist, not `err instanceof PadApiError`, and the difference is
-	 * load-bearing (codex round 2): the API client turns ANY JSON error
-	 * envelope into a PadApiError, including one a proxy or gateway invented
-	 * AFTER the handler had already published. Treating "structured" as
-	 * "definitely not published" would re-arm Push on exactly that case. So the
-	 * rule is inverted — enumerate what we know is safe, and treat every
-	 * unrecognised failure as ambiguous. The cost of the wrong answer is
-	 * asymmetric: an unnecessary "we can't tell" makes the user check, while a
-	 * wrong re-arm delivers the instruction twice.
-	 */
-	const PRE_PUBLISH_ERROR_CODES = new Set([
-		'bad_request', // empty / whitespace-only / over-length / undecodable body
-		'unauthorized', // no resolved user
-		'not_found', // item or workspace doesn't resolve
-		'forbidden',
-		'permission_denied', // workspace-access middleware
-		'unavailable', // the bus isn't wired — nothing to publish TO
-		'rate_limited', // the client's own 429 shape; the handler never ran
-		'plan_limit_exceeded',
-		// Middleware, so strictly before the handler: nothing can have been
-		// published by the time either of these is written.
-		'csrf_error',
-		'email_not_verified'
-	]);
-
 	async function handleSend() {
 		if (!canSend) return;
 		// Fence the continuation two ways. `gen` catches a close-and-reopen
@@ -377,14 +350,13 @@ server tells you not to run would cost honesty in the case that actually ships.
 		} catch (err) {
 			sending = false;
 			if (!stillMine()) return;
-			// See PRE_PUBLISH_ERROR_CODES: a recognised pre-publish refusal is
-			// safe to correct and resend. Everything else — a rejected fetch, a
-			// non-JSON 502, a gateway envelope we don't recognise — means the
+			// See PUSH_PRE_PUBLISH_ERROR_CODES: a recognised pre-publish refusal
+			// is safe to correct and resend. Everything else — a rejected fetch,
+			// a non-JSON 502, a gateway envelope we don't recognise — means the
 			// request went out and we never learned its fate. The handler
 			// publishes BEFORE it writes the response, so the message may well
 			// have been delivered; re-arming Push would offer a duplicate.
-			const code = err instanceof PadApiError ? err.code : '';
-			if (code && PRE_PUBLISH_ERROR_CODES.has(code)) {
+			if (isPrePublishRefusal(err)) {
 				sendError = err instanceof Error ? err.message : 'Failed to push the message.';
 			} else {
 				outcomeUnknown = true;

--- a/web/src/lib/push/dispatch.test.ts
+++ b/web/src/lib/push/dispatch.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from 'vitest';
+import { PadApiError } from '$lib/api/client';
+import { PUSH_MESSAGE_MAX_LEN } from './message';
+import {
+	PUSH_PRE_PUBLISH_ERROR_CODES,
+	describeDispatch,
+	isPrePublishRefusal,
+	routePrompt,
+	type PushPresence
+} from './dispatch';
+
+const KNOWN = (count: number): PushPresence => ({ state: 'known', count });
+const UNKNOWN: PushPresence = { state: 'unknown' };
+
+describe('routePrompt', () => {
+	it('pushes when an item is addressable and a session is connected', () => {
+		expect(routePrompt('do the thing', 'task-1', KNOWN(1))).toEqual({ via: 'push' });
+		expect(routePrompt('do the thing', 'task-1', KNOWN(4))).toEqual({ via: 'push' });
+	});
+
+	it('falls back to the clipboard when nothing is listening', () => {
+		// The ruled case (PLAN-2558 S4). Not a hard error, not a queue.
+		expect(routePrompt('do the thing', 'task-1', KNOWN(0))).toEqual({
+			via: 'clipboard',
+			because: 'no-sessions'
+		});
+	});
+
+	it('treats an unreadable presence answer as clipboard, NOT as a push', () => {
+		// The asymmetry this module exists for: copying when we could have
+		// pushed costs a paste; pushing into nothing loses the instruction.
+		expect(routePrompt('do the thing', 'task-1', UNKNOWN)).toEqual({
+			via: 'clipboard',
+			because: 'presence-unknown'
+		});
+	});
+
+	it('treats "no answer yet" the same as "could not get an answer"', () => {
+		expect(routePrompt('do the thing', 'task-1', null)).toEqual({
+			via: 'clipboard',
+			because: 'presence-unknown'
+		});
+	});
+
+	it('cannot push without an item to address, however many sessions are live', () => {
+		// Collection-scope quick actions: the endpoint is item-scoped.
+		expect(routePrompt('do the thing', null, KNOWN(3))).toEqual({
+			via: 'clipboard',
+			because: 'not-addressable'
+		});
+	});
+
+	it('refuses to push a message the server would reject', () => {
+		// Both are 400s at the endpoint, so pushing them would trade a working
+		// clipboard copy for an error. Checked BEFORE presence, so a live
+		// session doesn't route an unpushable message into a failure.
+		expect(routePrompt('   \n\t  ', 'task-1', KNOWN(2))).toEqual({
+			via: 'clipboard',
+			because: 'empty'
+		});
+		expect(routePrompt('x'.repeat(PUSH_MESSAGE_MAX_LEN + 1), 'task-1', KNOWN(2))).toEqual({
+			via: 'clipboard',
+			because: 'too-long'
+		});
+		// Exactly at the bound is pushable — the check is `>`, matching the
+		// server's own comparison.
+		expect(routePrompt('x'.repeat(PUSH_MESSAGE_MAX_LEN), 'task-1', KNOWN(2))).toEqual({
+			via: 'push'
+		});
+	});
+
+	it('measures length after collapse, like the server does', () => {
+		// Raw length is over the bound; collapsed length is exactly at it. A
+		// client counting the raw string would refuse a message the server
+		// accepts — the failure `$lib/push/message` exists to prevent, asserted
+		// here at the routing layer that consumes it.
+		const raw = 'x'.repeat(PUSH_MESSAGE_MAX_LEN) + '\n'.repeat(200);
+		expect(raw.length).toBeGreaterThan(PUSH_MESSAGE_MAX_LEN);
+		expect(routePrompt(raw, 'task-1', KNOWN(1))).toEqual({ via: 'push' });
+	});
+});
+
+describe('isPrePublishRefusal', () => {
+	it('recognises the codes the handler and its middleware write before publishing', () => {
+		for (const code of PUSH_PRE_PUBLISH_ERROR_CODES) {
+			expect(isPrePublishRefusal(new PadApiError({ code, message: 'nope' }))).toBe(true);
+		}
+	});
+
+	it('treats an unrecognised structured error as ambiguous', () => {
+		// The load-bearing case: the API client turns ANY JSON error envelope
+		// into a PadApiError, including one a gateway invented AFTER the
+		// handler published. "Structured" is not proof of "never sent".
+		expect(isPrePublishRefusal(new PadApiError({ code: 'upstream_error', message: 'bad gateway' }))).toBe(
+			false
+		);
+		expect(isPrePublishRefusal(new PadApiError({ code: '', message: 'boom' }))).toBe(false);
+	});
+
+	it('treats a non-API failure as ambiguous', () => {
+		expect(isPrePublishRefusal(new TypeError('Failed to fetch'))).toBe(false);
+		expect(isPrePublishRefusal(undefined)).toBe(false);
+	});
+});
+
+describe('describeDispatch', () => {
+	it('never claims delivery on a successful push', () => {
+		const one = describeDispatch({ kind: 'pushed', count: 1 });
+		expect(one.tone).toBe('success');
+		expect(one.message).toContain('delivery isn’t confirmed');
+		expect(one.message).not.toMatch(/delivered|received/i);
+
+		const many = describeDispatch({ kind: 'pushed', count: 3 });
+		expect(many.message).toContain('3 agent sessions');
+		expect(many.message).toContain('delivery isn’t confirmed');
+	});
+
+	it('names the fallback AND its reason, so a copy never reads as a push', () => {
+		expect(describeDispatch({ kind: 'copied', because: 'no-sessions' }).message).toBe(
+			'No agent session connected — copied to clipboard instead'
+		);
+		expect(describeDispatch({ kind: 'copied', because: 'presence-unknown' }).message).toContain(
+			'Couldn’t check for agent sessions'
+		);
+		expect(describeDispatch({ kind: 'copied', because: 'too-long' }).message).toContain(
+			String(PUSH_MESSAGE_MAX_LEN)
+		);
+	});
+
+	it('says only "copied" where the user never expected a push', () => {
+		// A collection-scope action has no push behavior to explain the absence
+		// of, so explaining it would be noise.
+		expect(describeDispatch({ kind: 'copied', because: 'not-addressable' }).message).toBe(
+			'Copied to clipboard'
+		);
+		expect(describeDispatch({ kind: 'copied', because: 'empty' }).message).toBe(
+			'Copied to clipboard'
+		);
+	});
+
+	it('reports a refusal as a failure and carries the server’s reason', () => {
+		const d = describeDispatch({ kind: 'push-refused', detail: 'Push is not available' });
+		expect(d.tone).toBe('error');
+		expect(d.message).toContain('Push is not available');
+	});
+
+	it('reports an unconfirmed push as neither success nor failure', () => {
+		const d = describeDispatch({ kind: 'push-unconfirmed' });
+		// Not 'error': the message may well have landed. Not 'success' either.
+		expect(d.tone).toBe('info');
+		expect(d.message).toMatch(/didn’t say|check your agent session/i);
+		// It must NOT claim a copy happened — nothing was copied, precisely
+		// because a paste could deliver the same instruction a second time.
+		expect(d.message).not.toMatch(/clipboard|copied/i);
+	});
+
+	it('reports a failed copy as an error whatever sent it there', () => {
+		for (const because of ['no-sessions', 'presence-unknown', 'not-addressable'] as const) {
+			const d = describeDispatch({ kind: 'copy-failed', because });
+			expect(d.tone).toBe('error');
+			expect(d.message).toContain('Failed to copy');
+		}
+	});
+});

--- a/web/src/lib/push/dispatch.ts
+++ b/web/src/lib/push/dispatch.ts
@@ -96,7 +96,10 @@ export type ClipboardReason =
 	| 'no-sessions'
 	/** Presence could not be read. See this module's header for why that goes
 	 *  to the clipboard here and not in the dialog. */
-	| 'presence-unknown';
+	| 'presence-unknown'
+	/** The user asked for the copy explicitly, by taking the offer on a
+	 *  push-failure toast. Nothing to explain — they chose it. */
+	| 'offered';
 
 export type PushRoute = { via: 'push' } | { via: 'clipboard'; because: ClipboardReason };
 
@@ -196,6 +199,7 @@ function copiedMessage(because: ClipboardReason): string {
 			return `Too long to push (over ${PUSH_MESSAGE_MAX_LEN} characters) — copied to clipboard instead`;
 		case 'not-addressable':
 		case 'empty':
+		case 'offered':
 			// Nothing surprising happened: these surfaces never push, so
 			// explaining an absence the user never expected would be noise.
 			return 'Copied to clipboard';

--- a/web/src/lib/push/dispatch.ts
+++ b/web/src/lib/push/dispatch.ts
@@ -1,0 +1,203 @@
+/**
+ * Routing a resolved prompt to a connected agent session — or to the clipboard
+ * when it can't go to one (PLAN-2558 S4).
+ *
+ * S3 gave the item view a composer that answers "is anything listening?" before
+ * the click, in a dialog with room to state the answer. A quick action has no
+ * such moment: it is one click that must decide for the user and then report
+ * what it did. This module is that decision, split into pure pieces so the
+ * wording — which is the actual deliverable, since the whole plan exists to
+ * stop a button claiming a delivery it can't make — is unit-testable without a
+ * browser.
+ *
+ * WHY THE UNCERTAIN CASE GOES TO THE CLIPBOARD, WHERE S3'S DIALOG SENDS.
+ * PushToAgentDialog leaves Send ENABLED when presence can't be read, and that
+ * is right there: the warning is on screen, and the user chooses with the
+ * uncertainty in front of them. Here nobody is asked. So the tie is broken by
+ * which wrong answer costs more:
+ *
+ *   - copy when we could have pushed → the user pastes once. Exactly today's
+ *     behavior, nothing lost.
+ *   - push when nothing is listening → the message is gone. There is no inbox,
+ *     no ack, no replay a user can reach, and the toast has already claimed
+ *     success. That is the precise failure PLAN-2558 exists to prevent.
+ *
+ * Asymmetric, so the uncertain case takes the lossless branch.
+ */
+
+import { PadApiError } from '$lib/api/client';
+import {
+	PUSH_MESSAGE_MAX_LEN,
+	isPushMessageEmpty,
+	isPushMessageTooLong
+} from './message';
+
+/**
+ * Error codes `handlePushToItem` (and the middleware in front of it) can return
+ * WITHOUT having published — the request provably never reached the bus, so a
+ * corrected resend cannot duplicate anything.
+ *
+ * A whitelist, not `err instanceof PadApiError`, and the difference is
+ * load-bearing (PR #1099 codex round 2): the API client turns ANY JSON error
+ * envelope into a PadApiError, including one a proxy or gateway invented AFTER
+ * the handler had already published. Treating "structured" as "definitely not
+ * published" would offer a duplicate on exactly that case. So the rule is
+ * inverted — enumerate what is known safe, and treat every unrecognised failure
+ * as ambiguous. The cost of the wrong answer is asymmetric: an unnecessary "we
+ * can't tell" makes the user check, a wrong re-arm delivers twice.
+ *
+ * Lives here rather than in the dialog because S4 is the second consumer, and
+ * two copies of a security-shaped whitelist drift.
+ */
+export const PUSH_PRE_PUBLISH_ERROR_CODES: ReadonlySet<string> = new Set([
+	'bad_request', // empty / whitespace-only / over-length / undecodable body
+	'unauthorized', // no resolved user
+	'not_found', // item or workspace doesn't resolve
+	'forbidden',
+	'permission_denied', // workspace-access middleware
+	'unavailable', // the bus isn't wired — nothing to publish TO
+	'rate_limited', // the client's own 429 shape; the handler never ran
+	'plan_limit_exceeded',
+	// Middleware, so strictly before the handler: nothing can have been
+	// published by the time either of these is written.
+	'csrf_error',
+	'email_not_verified'
+]);
+
+/** True when `err` is a failure the push endpoint provably wrote BEFORE
+ *  publishing, so the message did not go out and re-offering it is safe. */
+export function isPrePublishRefusal(err: unknown): boolean {
+	const code = err instanceof PadApiError ? err.code : '';
+	return code !== '' && PUSH_PRE_PUBLISH_ERROR_CODES.has(code);
+}
+
+/**
+ * What a surface knows about who is listening.
+ *
+ * There is deliberately no `count: 0` inside `unknown` — a failed presence read
+ * is not zero sessions, and collapsing the two is the exact lie
+ * `handleListSessions` returns 503 rather than an empty list to avoid.
+ */
+export type PushPresence =
+	| { state: 'known'; count: number }
+	| { state: 'unknown' };
+
+/** Why a prompt went to the clipboard instead of an agent session. */
+export type ClipboardReason =
+	/** The surface has no item to address — the push endpoint is item-scoped,
+	 *  and a collection-scope quick action has nothing to point it at. */
+	| 'not-addressable'
+	/** The resolved prompt collapses to nothing; the server would 400. */
+	| 'empty'
+	/** Over the server's rune bound. The clipboard has no such bound, so the
+	 *  text survives there — this is a downgrade, not a failure. */
+	| 'too-long'
+	/** The ruled case (PLAN-2558 S4): nothing is listening. */
+	| 'no-sessions'
+	/** Presence could not be read. See this module's header for why that goes
+	 *  to the clipboard here and not in the dialog. */
+	| 'presence-unknown';
+
+export type PushRoute = { via: 'push' } | { via: 'clipboard'; because: ClipboardReason };
+
+/**
+ * Decide where a resolved prompt goes. Pure: no I/O, no clock, no DOM.
+ *
+ * `presence` is null when the surface hasn't got an answer yet (the read is
+ * still in flight). That is treated as `unknown` rather than given its own
+ * branch — "haven't heard" and "couldn't hear" license exactly the same
+ * conclusion, and a third state would only invite a fourth wording.
+ */
+export function routePrompt(
+	prompt: string,
+	itemSlug: string | null,
+	presence: PushPresence | null
+): PushRoute {
+	if (!itemSlug) return { via: 'clipboard', because: 'not-addressable' };
+	if (isPushMessageEmpty(prompt)) return { via: 'clipboard', because: 'empty' };
+	if (isPushMessageTooLong(prompt)) return { via: 'clipboard', because: 'too-long' };
+	if (!presence || presence.state === 'unknown') {
+		return { via: 'clipboard', because: 'presence-unknown' };
+	}
+	if (presence.count === 0) return { via: 'clipboard', because: 'no-sessions' };
+	return { via: 'push' };
+}
+
+/** What actually happened, once the route was taken. */
+export type DispatchOutcome =
+	| { kind: 'pushed'; count: number }
+	| { kind: 'copied'; because: ClipboardReason }
+	| { kind: 'copy-failed'; because: ClipboardReason }
+	/** The server refused before publishing — nothing was sent, and offering
+	 *  the text again is safe. */
+	| { kind: 'push-refused'; detail: string }
+	/** The request went out and we never learned its fate. The handler
+	 *  publishes BEFORE it writes its response, so the message may well have
+	 *  been delivered — the user must be told that, not told it failed. */
+	| { kind: 'push-unconfirmed' };
+
+export interface DispatchMessage {
+	message: string;
+	tone: 'success' | 'error' | 'info';
+}
+
+/**
+ * The toast for an outcome.
+ *
+ * Two rules run through every string here:
+ *  1. Never claim delivery. A push is published to a bus with no ack, so the
+ *     honest past tense is "pushed", hedged — never "delivered" or "sent to
+ *     your agent".
+ *  2. Always name the fallback and why. "Copied to clipboard" alone, on a
+ *     surface the user believes pushes, reads as the push having happened.
+ */
+export function describeDispatch(outcome: DispatchOutcome): DispatchMessage {
+	switch (outcome.kind) {
+		case 'pushed':
+			return {
+				message:
+					outcome.count === 1
+						? 'Pushed to your agent session — delivery isn’t confirmed'
+						: `Pushed to ${outcome.count} agent sessions — delivery isn’t confirmed`,
+				tone: 'success'
+			};
+		case 'copied':
+			return { message: copiedMessage(outcome.because), tone: 'success' };
+		case 'copy-failed':
+			return { message: 'Failed to copy to clipboard', tone: 'error' };
+		case 'push-refused':
+			return {
+				message: outcome.detail
+					? `Couldn’t push: ${outcome.detail}`
+					: 'Couldn’t push to your agent session',
+				tone: 'error'
+			};
+		case 'push-unconfirmed':
+			// Not an error and not a success: the server gave no clear answer, so
+			// the only true thing to say is that we don't know. Copying for the
+			// user here would be worse than useless — if the push DID land, a
+			// paste delivers the same instruction twice, and the endpoint has no
+			// idempotency key to absorb it. So the copy is offered, not taken.
+			return {
+				message:
+					'The server didn’t say whether the push went through. Check your agent session before sending it again.',
+				tone: 'info'
+			};
+	}
+}
+
+function copiedMessage(because: ClipboardReason): string {
+	switch (because) {
+		case 'no-sessions':
+			return 'No agent session connected — copied to clipboard instead';
+		case 'presence-unknown':
+			return 'Couldn’t check for agent sessions — copied to clipboard instead';
+		case 'too-long':
+			return `Too long to push (over ${PUSH_MESSAGE_MAX_LEN} characters) — copied to clipboard instead`;
+		case 'not-addressable':
+		case 'empty':
+			// Nothing surprising happened: these surfaces never push, so
+			// explaining an absence the user never expected would be noise.
+			return 'Copied to clipboard';
+	}
+}


### PR DESCRIPTION
PLAN-2558 S4. Quick actions stop being a clipboard ferry: the resolved prompt
now goes to the user's connected agent session, and the clipboard becomes the
fallback rather than the mechanism.

`resolvePrompt()` already did the templating push needed. Only the last hop
was manual, and this changes that hop.

**Zero-touch migration**, as the task required: quick actions are still
`{label, prompt, scope, icon}` in collection settings. No settings rewrite, no
schema change, no per-action opt-in.

## Routing

Per the plan's ruling — with zero live sessions, fall back to the clipboard
with an honest toast, never a hard error and never a queue.

| presence | behaviour |
|---|---|
| session(s) live | push the collapsed prompt; the toast hedges ("delivery isn't confirmed") because a push gets no ack |
| zero sessions | copy — *"No agent session connected — copied to clipboard instead"* |
| can't tell | **copy** — see below |
| no item to address | collection-scope actions keep the pre-S4 behaviour exactly, and don't even spend a presence read finding that out |

**The uncertain case is where S4 deliberately diverges from S3's dialog**,
which leaves Send *enabled* on an unreadable presence answer. The dialog is
right to: the warning is on screen and the user chooses with it in front of
them. A quick action asks nobody, so the tie goes to the lossless branch —
copying when we could have pushed costs one paste; pushing into nothing loses
the instruction outright, and the toast has already claimed success.

## Presence is read when the MENU OPENS, not on the click

The one non-obvious thing in the diff. Both clipboard APIs want the user
gesture that is live during the click handler and gone after a network
round-trip (Safari strictest, Firefox too). Deciding from a read issued on the
click would put an await in front of the very fallback this slice promises.

The cost is a small window — click a row before the first read lands and
presence is null, which routes to the clipboard with an honest toast rather
than to a push — and that is the right way round.

The menu footer now says which way the next click will go, so the routing is
visible *before* it happens rather than only in the toast after. A logged-out
or workspace-token viewer gets a 401 from `/sessions`, which is "can't tell",
which is the clipboard — today's behaviour, no extra gating needed.

## Push failure

Splits on the same line `CopyItemDialog` and the S3 composer draw (DR-13). A
recognised pre-publish refusal means nothing went out, so the copy is
**offered** as a toast action — a fresh gesture, which is what makes a
clipboard write work this long after the original one. An unrecognised failure
leaves the outcome unknown (the handler publishes *before* it writes its
response), so nothing is offered: a paste would be the duplicate the message is
warning about, on an endpoint with no idempotency key.

`PRE_PUBLISH_ERROR_CODES` moved out of `PushToAgentDialog` into
`$lib/push/dispatch` so the two surfaces can't drift on it.

## Drive-by fix

The local `copyToClipboard` returned `true` from the promise path *without
awaiting it*, so a rejected write reported success and never reached the
`execCommand` fallback. Replaced with `$lib/utils/clipboard`'s. Harmless when
copying was a convenience; not harmless now that "we copied instead" is a
load-bearing claim.

## Verification

Live against a throwaway instance (built binary, real browser), three legs,
with the SSE stream as the receipt:

| leg | result |
|---|---|
| no session | tagline *"No agent session connected — actions copy to your clipboard"*; toast matches the ruling; clipboard holds `Implement TASK-9: Ship the thing (status open)` |
| one session | tagline *"Pushes to your connected agent session"*; the connected stream **received** `{"kind":"push","item_ref":"TASK-9","summary":"Implement TASK-9: ..."}`; clipboard untouched |
| presence 503 | same live session still connected, `/sessions` aborted: copies instead — and the stream's push count did **not** increase. The counterfactual, not just the end state |

Each of the five behaviours is mutation-tested 1:1 against its test: an await
before the copy fails ONLY the synchronous-gesture test; routing `unknown` to
push fails only the two uncertainty tests; dropping the collapse fails only the
raw-vs-collapsed test; offering a copy on an unconfirmed push fails only that
test; copying on the happy path fails three.

`npm run check` 0 errors · full web unit suite 1604 passed.

Closes TASK-2562.

https://claude.ai/code/session_01QCMLhHQBrMHVML3YKdm4Cd

---

## Review rounds

**Round 1 — presence staleness (real).** A *failed* poll already degraded to
"unknown"; a poll that *hung* did not — it simply never wrote, so the last
count stayed in place indefinitely while the menu went on offering a push into
a session that may have dropped minutes earlier. A known answer now expires
after 30s without a refresh (the server's own `watchEventsKeepaliveInterval`
bound, same as `PushToAgentDialog`'s round-2 fix), and reads already in flight
at the moment of expiry are retired so one issued *before* it can't land after
and restore the count.

**Round 2 — the offered copy swallowed its outcome (real).** `Copy instead`
discarded the `copyToClipboard()` result, and taking the offer dismisses the
toast that carried it, so a failed copy said nothing. Worst on exactly this
path: a pre-publish refusal means the instruction was never sent, so a
silently-failed copy leaves it neither sent nor copied while the user believes
they rescued it. It now routes through the same `copyAndAnnounce` as every
other clipboard path.

**Round 3 — the footer line lagged the routing (real, introduced by round 1).**
The click-time expiry check made the routing correct immediately, but the
tagline read raw `presence` until the next poll tick — so for up to 10s the
menu said "Pushes to your connected agent session" while the next click would
copy. A successful read now arms a one-shot timeout at the exact expiry.

`currentPresence()` stays, and the redundancy is deliberate: a timer is a
request, not a guarantee — browsers throttle timers hard in a backgrounded tab,
so the expiry can fire long after it came due, including after the user returns
and clicks. The timer keeps the **display** honest; the click-time check keeps
the **decision** correct, and only the decision can lose a message. The two are
mutation-tested against *different* tests, and the throttling one models it by
moving the clock without running any timer — not reachable with
`advanceTimersByTime`.

**Round 4 — CLEAN.**

Live legs re-run against the final HEAD (rebuilt binary): no session → ruled
toast + clipboard holds the resolved prompt; one session → the connected stream
received `{"kind":"push","item_ref":"TASK-9","summary":"Implement TASK-9: ..."}`
with the clipboard untouched.

Final gates: `npm run check` 0 errors · web unit suite **1609 passed**.
