### PR TITLE
test(web): capture pristine DOM probes at module load in mockOpenModals helpers

### DIFF
--- a/web/src/lib/a11y/viewerBackdrop.svelte.test.ts
+++ b/web/src/lib/a11y/viewerBackdrop.svelte.test.ts
@@ -16,6 +16,13 @@ import {
 // selection path instead of always seeing an empty candidate list.
 const realGetClientRects = HTMLElement.prototype.getClientRects;
 
+// `mockOpenModals` can run more than once per test; `vi.spyOn` on an already-
+// spied method hands back the SAME spy, so a "real function" captured at that
+// point is the spy itself and the pass-through branch recurses. Capture the
+// pristine probes before any spy exists — at module load.
+const REAL_QUERY_ALL = document.querySelectorAll.bind(document);
+const REAL_MATCHES = Element.prototype.matches;
+
 /** A direct child of `<body>` — the shape a portaled viewer root has. */
 function bodyChild(id: string, html = ''): HTMLElement {
 	const el = document.createElement('div');
@@ -46,7 +53,7 @@ function mockOpenModals(
 ): void {
 	const isModal = (el: Element) =>
 		typeof oracle === 'function' ? oracle(el) : oracle.includes(el);
-	const realQueryAll = document.querySelectorAll.bind(document);
+	const realQueryAll = REAL_QUERY_ALL;
 	vi.spyOn(document, 'querySelectorAll').mockImplementation((selector: string) => {
 		selectorLog?.push(selector);
 		if (selector !== 'dialog:modal') return realQueryAll(selector);
@@ -54,7 +61,7 @@ function mockOpenModals(
 		// opens mid-lease) is reflected the way a real engine would.
 		return Array.from(realQueryAll('dialog')).filter(isModal) as unknown as NodeListOf<Element>;
 	});
-	const realMatches = Element.prototype.matches;
+	const realMatches = REAL_MATCHES;
 	vi.spyOn(Element.prototype, 'matches').mockImplementation(function (
 		this: Element,
 		selector: string,
@@ -687,7 +694,7 @@ describe('isBlockedByModal', () => {
 			const dialog = openModal('<button id="d">d</button>');
 			dialog.setAttribute('open', '');
 
-			const realQueryAll = document.querySelectorAll.bind(document);
+			const realQueryAll = REAL_QUERY_ALL;
 			const probe = vi
 				.spyOn(document, 'querySelectorAll')
 				.mockImplementation((selector: string) => {

--- a/web/src/lib/components/common/Lightbox.svelte.test.ts
+++ b/web/src/lib/components/common/Lightbox.svelte.test.ts
@@ -71,6 +71,14 @@ vi.mock('$lib/components/editor/attachment-metadata', () => ({
 	invalidateAttachmentMetadata: vi.fn(),
 }));
 
+// The `mockOpenModals` helpers below re-spy `querySelectorAll` / `matches`
+// mid-test; `vi.spyOn` on an already-spied method hands back the SAME spy, so
+// a "real function" captured at that point is the spy itself and the pass-
+// through branch recurses. The pristine probes must be captured before any
+// spy exists — here, at module load.
+const REAL_QUERY_ALL = document.querySelectorAll.bind(document);
+const REAL_MATCHES = Element.prototype.matches;
+
 // TASK-2429 — the DR-4b modal contract on the attachment viewer.
 //
 // WHAT JSDOM CANNOT PROVE, and is therefore TASK-2436's browser suite (DR-9):
@@ -1194,14 +1202,14 @@ describe('Lightbox — a native modal opened OVER the viewer', () => {
 	 * the module makes (`querySelectorAll` and `Element.matches`) are covered.
 	 */
 	function mockOpenModals(modals: Element[]): void {
-		const realQueryAll = document.querySelectorAll.bind(document);
+		const realQueryAll = REAL_QUERY_ALL;
 		vi.spyOn(document, 'querySelectorAll').mockImplementation((selector: string) => {
 			if (selector !== 'dialog:modal') return realQueryAll(selector);
 			return Array.from(realQueryAll('dialog')).filter((d) =>
 				modals.includes(d)
 			) as unknown as NodeListOf<Element>;
 		});
-		const realMatches = Element.prototype.matches;
+		const realMatches = REAL_MATCHES;
 		vi.spyOn(Element.prototype, 'matches').mockImplementation(function (
 			this: Element,
 			selector: string
@@ -1429,14 +1437,14 @@ describe('Lightbox — zoom keys are ARBITRATED, not just handled', () => {
 	// gets its own leg with a positive control.
 
 	function mockOpenModals(modals: Element[]): void {
-		const realQueryAll = document.querySelectorAll.bind(document);
+		const realQueryAll = REAL_QUERY_ALL;
 		vi.spyOn(document, 'querySelectorAll').mockImplementation((selector: string) => {
 			if (selector !== 'dialog:modal') return realQueryAll(selector);
 			return Array.from(realQueryAll('dialog')).filter((d) =>
 				modals.includes(d)
 			) as unknown as NodeListOf<Element>;
 		});
-		const realMatches = Element.prototype.matches;
+		const realMatches = REAL_MATCHES;
 		vi.spyOn(Element.prototype, 'matches').mockImplementation(function (
 			this: Element,
 			selector: string
@@ -1798,14 +1806,14 @@ function mockGeometry(scope: HTMLElement, g: Geometry, rectLeft = 0, rectTop = 0
 
 describe('Lightbox — wheel zoom (TASK-2457)', () => {
 	function mockOpenModals(modals: Element[]): void {
-		const realQueryAll = document.querySelectorAll.bind(document);
+		const realQueryAll = REAL_QUERY_ALL;
 		vi.spyOn(document, 'querySelectorAll').mockImplementation((selector: string) => {
 			if (selector !== 'dialog:modal') return realQueryAll(selector);
 			return Array.from(realQueryAll('dialog')).filter((d) =>
 				modals.includes(d)
 			) as unknown as NodeListOf<Element>;
 		});
-		const realMatches = Element.prototype.matches;
+		const realMatches = REAL_MATCHES;
 		vi.spyOn(Element.prototype, 'matches').mockImplementation(function (
 			this: Element,
 			selector: string
@@ -2014,14 +2022,14 @@ function zoomToActual(scope: HTMLElement = root()): void {
 const ACTUAL_BOUND = (OVERFLOW_G.fittedW * (OVERFLOW_G.naturalW / OVERFLOW_G.fittedW) - OVERFLOW_G.stageW) / 2;
 
 function mockOpenModals(modals: Element[]): void {
-	const realQueryAll = document.querySelectorAll.bind(document);
+	const realQueryAll = REAL_QUERY_ALL;
 	vi.spyOn(document, 'querySelectorAll').mockImplementation((selector: string) => {
 		if (selector !== 'dialog:modal') return realQueryAll(selector);
 		return Array.from(realQueryAll('dialog')).filter((d) =>
 			modals.includes(d)
 		) as unknown as NodeListOf<Element>;
 	});
-	const realMatches = Element.prototype.matches;
+	const realMatches = REAL_MATCHES;
 	vi.spyOn(Element.prototype, 'matches').mockImplementation(function (this: Element, selector: string) {
 		if (selector !== 'dialog:modal') return realMatches.call(this, selector);
 		return realMatches.call(this, 'dialog') && modals.includes(this);


### PR DESCRIPTION
## What

Test-only change: the `mockOpenModals` helpers in `Lightbox.svelte.test.ts` (4 copies) and `viewerBackdrop.svelte.test.ts` re-captured "the real" `document.querySelectorAll` / `Element.prototype.matches` on every call, from inside a test that may already have spied them.

## Why

vitest 4 returns the SAME spy when `vi.spyOn` targets an already-spied method, so the second `mockOpenModals` call in a test captures the spy itself as the pass-through and recurses (RangeError). The component's guarded `:modal` probe swallows that as ":modal unsupported", so the modal never registers — 3 Lightbox drag-abort tests (TASK-2458) fail on a merged tree with vitest 4 (#1045).

Capturing the pristine probes once at module load is correct under both majors.

## Evidence

- vitest 3.2.6 (current pin): 1609/1609 before and after this change.
- vitest 4.1.10: 3 failed → 1609/1609 with this change.
- Mechanism confirmed with an isolated re-spy probe (recursion → RangeError under v4).

Unblocks dependabot #1045; part of the TASK-2585 dependabot triage.

https://claude.ai/code/session_01BhQoeaWXxJbvw86ezzK8dt