### PR TITLE
fix(cli): give the CLI auth poll loop its own wall-clock timeout (BUG-2572)

### DIFF
--- a/cmd/pad/cmd_auth.go
+++ b/cmd/pad/cmd_auth.go
@@ -429,6 +429,33 @@ func doBrowserLogin(client *cli.Client, cfg *config.Config) error {
 	return pollAndSaveCLIAuth(ctx, client, cfg, sess)
 }
 
+// cliAuthPollInterval is how often pollAndSaveCLIAuth re-checks the CLI auth
+// session. var (not const) so tests can shrink it. Matches
+// bootstrapPollInterval's cadence (internal/cli/bootstrap.go).
+var cliAuthPollInterval = 2 * time.Second
+
+// cliAuthPollTimeout caps how long pollAndSaveCLIAuth waits for approval on
+// its own, independent of the server-side session TTL (BUG-2572: without
+// this, an unreachable server after session creation left the loop with no
+// exit but Ctrl-C). Sized to the LONGER of the two server TTLs
+// (cliAuthSetupSessionTTL, 20m in internal/store/cli_auth_sessions.go) —
+// this helper is shared by the plain 5m login flow and the 20m first-run
+// setup handoff, and the caller doesn't tell it which one it got, so a
+// single conservative bound avoids falsely cutting the setup flow short.
+// The login flow's server-side "expired" status fires well before this in
+// the common case; this timer only matters once the server has gone
+// unreachable, same as bootstrapPollTimeout. var (not const) so tests can
+// shrink it.
+var cliAuthPollTimeout = 20 * time.Minute
+
+// cliAuthMaxConsecutivePollErrs bounds consecutive transient poll errors
+// before pollAndSaveCLIAuth gives up with a network-shaped error, so a
+// permanently unreachable server fails fast instead of waiting out the full
+// cliAuthPollTimeout for a generic timeout message. Resets on any successful
+// poll (including "pending"), so an isolated blip doesn't count against it.
+// var (not const) so tests can shrink it.
+var cliAuthMaxConsecutivePollErrs = 5
+
 // pollAndSaveCLIAuth polls a pending CLI auth session until it is approved,
 // then persists the issued token as credentials for cfg.BaseURL(). It is the
 // shared tail of every browser auth flow: doBrowserLogin (which prints its
@@ -438,9 +465,16 @@ func doBrowserLogin(client *cli.Client, cfg *config.Config) error {
 // cancellation this returns errCancelled so the standard "Cancelled." +
 // exit-130 path fires.
 func pollAndSaveCLIAuth(ctx context.Context, client *cli.Client, cfg *config.Config, sess *cli.CLIAuthSessionResponse) error {
-	// Poll until approved, expired, or cancelled
-	ticker := time.NewTicker(2 * time.Second)
+	// Poll until approved, expired, timed out, cancelled, or the server has
+	// been unreachable for too many consecutive polls.
+	ticker := time.NewTicker(cliAuthPollInterval)
 	defer ticker.Stop()
+
+	timeout := time.NewTimer(cliAuthPollTimeout)
+	defer timeout.Stop()
+
+	var consecutiveErrs int
+	var lastErr error
 
 	for {
 		select {
@@ -455,12 +489,29 @@ func pollAndSaveCLIAuth(ctx context.Context, client *cli.Client, cfg *config.Con
 			// 130 instead of falling back to cobra's generic error
 			// path.
 			return errCancelled
+		case <-timeout.C:
+			// No remedy suggested here: this helper is shared by login,
+			// first-run setup, and pad init's linking path, each of which
+			// has its own idea of what to retry — let the caller's own
+			// context guide the user instead of misdirecting a setup-flow
+			// user toward "pad auth login".
+			return fmt.Errorf("timed out waiting for approval after %s", cliAuthPollTimeout)
 		case <-ticker.C:
 			status, err := client.PollCLIAuthSession(sess.SessionCode)
 			if err != nil {
-				// Transient network errors — keep polling
+				// Transient network errors — keep polling, but only up to
+				// cliAuthMaxConsecutivePollErrs in a row. Beyond that the
+				// server is almost certainly gone, and a network-shaped
+				// error surfaces the real cause faster than waiting out
+				// cliAuthPollTimeout for a generic timeout message.
+				consecutiveErrs++
+				lastErr = err
+				if consecutiveErrs >= cliAuthMaxConsecutivePollErrs {
+					return fmt.Errorf("could not reach server while waiting for approval (%d consecutive failures): %w", consecutiveErrs, lastErr)
+				}
 				continue
 			}
+			consecutiveErrs = 0
 
 			switch status.Status {
 			case "approved":

--- a/cmd/pad/cmd_auth.go
+++ b/cmd/pad/cmd_auth.go
@@ -448,12 +448,13 @@ var cliAuthPollInterval = 2 * time.Second
 // shrink it.
 var cliAuthPollTimeout = 20 * time.Minute
 
-// cliAuthMaxConsecutivePollErrs bounds consecutive transient poll errors
-// before pollAndSaveCLIAuth gives up with a network-shaped error, so a
-// permanently unreachable server fails fast instead of waiting out the full
-// cliAuthPollTimeout for a generic timeout message. Resets on any successful
-// poll (including "pending"), so an isolated blip doesn't count against it.
-// var (not const) so tests can shrink it.
+// cliAuthMaxConsecutivePollErrs bounds consecutive poll failures before
+// pollAndSaveCLIAuth gives up, so a persistently failing server — whether
+// unreachable or reachable-but-erroring (client.get returns an error for
+// both transport failures and non-2xx responses) — fails fast instead of
+// waiting out the full cliAuthPollTimeout for a generic timeout message.
+// Resets on any successful poll (including "pending"), so an isolated blip
+// doesn't count against it. var (not const) so tests can shrink it.
 var cliAuthMaxConsecutivePollErrs = 5
 
 // pollAndSaveCLIAuth polls a pending CLI auth session until it is approved,
@@ -499,15 +500,19 @@ func pollAndSaveCLIAuth(ctx context.Context, client *cli.Client, cfg *config.Con
 		case <-ticker.C:
 			status, err := client.PollCLIAuthSession(sess.SessionCode)
 			if err != nil {
-				// Transient network errors — keep polling, but only up to
-				// cliAuthMaxConsecutivePollErrs in a row. Beyond that the
-				// server is almost certainly gone, and a network-shaped
-				// error surfaces the real cause faster than waiting out
-				// cliAuthPollTimeout for a generic timeout message.
+				// Transient poll errors — keep polling, but only up to
+				// cliAuthMaxConsecutivePollErrs in a row. Beyond that,
+				// something is persistently wrong (unreachable server or a
+				// server that keeps erroring), and bailing out surfaces the
+				// wrapped cause faster than waiting out cliAuthPollTimeout
+				// for a generic timeout message. Avoid claiming a specific
+				// cause ("could not reach server") in the headline: err can
+				// be either a transport failure or a non-2xx HTTP response,
+				// and %w already carries the real one.
 				consecutiveErrs++
 				lastErr = err
 				if consecutiveErrs >= cliAuthMaxConsecutivePollErrs {
-					return fmt.Errorf("could not reach server while waiting for approval (%d consecutive failures): %w", consecutiveErrs, lastErr)
+					return fmt.Errorf("polling for approval failed %d times in a row: %w", consecutiveErrs, lastErr)
 				}
 				continue
 			}

--- a/cmd/pad/cmd_auth_poll_test.go
+++ b/cmd/pad/cmd_auth_poll_test.go
@@ -88,9 +88,10 @@ func TestPollAndSaveCLIAuth_TimeoutFires(t *testing.T) {
 }
 
 // TestPollAndSaveCLIAuth_ConsecutiveErrorsBound asserts a server that only
-// ever errors trips the consecutive-error bound with a network-shaped error
-// well before the (much larger) wall-clock timeout would fire, and that the
-// error wraps the last poll failure.
+// ever errors (here, persistent HTTP 500s — client.get returns an error for
+// non-2xx responses too, not just transport failures) trips the
+// consecutive-error bound well before the (much larger) wall-clock timeout
+// would fire, and that the error wraps the last poll failure.
 func TestPollAndSaveCLIAuth_ConsecutiveErrorsBound(t *testing.T) {
 	withFastCLIAuthPolling(t, 5*time.Millisecond, 5*time.Second, 3)
 
@@ -109,8 +110,11 @@ func TestPollAndSaveCLIAuth_ConsecutiveErrorsBound(t *testing.T) {
 	if err == nil {
 		t.Fatal("pollAndSaveCLIAuth returned nil after repeated poll errors, want error")
 	}
-	if !strings.Contains(err.Error(), "could not reach server") {
-		t.Errorf("error %q should mention the server being unreachable", err.Error())
+	if !strings.Contains(err.Error(), "polling for approval failed") {
+		t.Errorf("error %q should mention the poll failures", err.Error())
+	}
+	if !strings.Contains(err.Error(), "500") {
+		t.Errorf("error %q should wrap the underlying poll error", err.Error())
 	}
 	if elapsed >= 5*time.Second {
 		t.Errorf("took %s — consecutive-error bound should fire well before the wall-clock timeout", elapsed)

--- a/cmd/pad/cmd_auth_poll_test.go
+++ b/cmd/pad/cmd_auth_poll_test.go
@@ -1,0 +1,160 @@
+package main
+
+// Tests for pollAndSaveCLIAuth's exit paths introduced by BUG-2572: the
+// wall-clock timeout and the consecutive-transient-poll-error bound. These
+// deliberately run serially (no t.Parallel) — withFastCLIAuthPolling mutates
+// the package-level cliAuthPollInterval / cliAuthPollTimeout /
+// cliAuthMaxConsecutivePollErrs vars for the duration of the test, so
+// parallel execution would race across tests in this file.
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/cli"
+)
+
+// withFastCLIAuthPolling shrinks pollAndSaveCLIAuth's interval/timeout/error
+// bound for the duration of the test, then restores them. Mirrors
+// internal/cli/bootstrap_test.go's withFastPolling.
+func withFastCLIAuthPolling(t *testing.T, interval, timeout time.Duration, maxErrs int) {
+	t.Helper()
+	prevInterval := cliAuthPollInterval
+	prevTimeout := cliAuthPollTimeout
+	prevMaxErrs := cliAuthMaxConsecutivePollErrs
+	cliAuthPollInterval = interval
+	cliAuthPollTimeout = timeout
+	cliAuthMaxConsecutivePollErrs = maxErrs
+	t.Cleanup(func() {
+		cliAuthPollInterval = prevInterval
+		cliAuthPollTimeout = prevTimeout
+		cliAuthMaxConsecutivePollErrs = prevMaxErrs
+	})
+}
+
+// cliAuthPollServer builds an httptest.Server serving GET
+// /api/v1/auth/cli/sessions/{code}, delegating each request to handle so
+// tests can script status sequences or failures.
+func cliAuthPollServer(t *testing.T, handle func(w http.ResponseWriter, r *http.Request)) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasPrefix(r.URL.Path, "/api/v1/auth/cli/sessions/") {
+			http.NotFound(w, r)
+			return
+		}
+		handle(w, r)
+	}))
+}
+
+func testSession() *cli.CLIAuthSessionResponse {
+	return &cli.CLIAuthSessionResponse{SessionCode: "test-code"}
+}
+
+// TestPollAndSaveCLIAuth_TimeoutFires asserts the new wall-clock timer ends
+// the loop with a distinct, remedy-neutral error when the server never
+// reports anything but "pending" — the scenario an unreachable-but-still-
+// responding server can't distinguish from a slow human, and the case a
+// permanently-unresponsive server degrades to once its consecutive-error
+// bound would otherwise not apply (server IS reachable here, just stuck).
+func TestPollAndSaveCLIAuth_TimeoutFires(t *testing.T) {
+	withFastCLIAuthPolling(t, 5*time.Millisecond, 50*time.Millisecond, 1000)
+
+	srv := cliAuthPollServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(cli.CLIAuthSessionStatus{Status: "pending"})
+	})
+	defer srv.Close()
+
+	client := cli.NewClientFromURL(srv.URL)
+	cfg := remoteHeadlessCfg(srv.URL)
+
+	err := pollAndSaveCLIAuth(t.Context(), client, cfg, testSession())
+	if err == nil {
+		t.Fatal("pollAndSaveCLIAuth returned nil after the wall-clock timeout, want error")
+	}
+	if !strings.Contains(err.Error(), "timed out waiting for approval") {
+		t.Errorf("error %q should mention the timeout", err.Error())
+	}
+	// Remedy-neutral: this helper is shared by login, setup, and pad init's
+	// linking path, so it must not steer everyone toward "pad auth login".
+	if strings.Contains(err.Error(), "pad auth login") {
+		t.Errorf("error %q should not suggest a specific remedy — callers add their own", err.Error())
+	}
+}
+
+// TestPollAndSaveCLIAuth_ConsecutiveErrorsBound asserts a server that only
+// ever errors trips the consecutive-error bound with a network-shaped error
+// well before the (much larger) wall-clock timeout would fire, and that the
+// error wraps the last poll failure.
+func TestPollAndSaveCLIAuth_ConsecutiveErrorsBound(t *testing.T) {
+	withFastCLIAuthPolling(t, 5*time.Millisecond, 5*time.Second, 3)
+
+	srv := cliAuthPollServer(t, func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "server error", http.StatusInternalServerError)
+	})
+	defer srv.Close()
+
+	client := cli.NewClientFromURL(srv.URL)
+	cfg := remoteHeadlessCfg(srv.URL)
+
+	start := time.Now()
+	err := pollAndSaveCLIAuth(t.Context(), client, cfg, testSession())
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("pollAndSaveCLIAuth returned nil after repeated poll errors, want error")
+	}
+	if !strings.Contains(err.Error(), "could not reach server") {
+		t.Errorf("error %q should mention the server being unreachable", err.Error())
+	}
+	if elapsed >= 5*time.Second {
+		t.Errorf("took %s — consecutive-error bound should fire well before the wall-clock timeout", elapsed)
+	}
+}
+
+// TestPollAndSaveCLIAuth_TransientErrorsRecover asserts the consecutive-error
+// counter resets on any successful poll rather than accumulating across the
+// whole run, so isolated blips don't eventually trip the bound.
+func TestPollAndSaveCLIAuth_TransientErrorsRecover(t *testing.T) {
+	isolateHome(t) // approval saves credentials via $HOME/.pad/credentials.json
+	withFastCLIAuthPolling(t, 5*time.Millisecond, 5*time.Second, 2)
+
+	var reqs atomic.Int32
+	srv := cliAuthPollServer(t, func(w http.ResponseWriter, r *http.Request) {
+		// Single errors at n=1 and n=3, each followed by a success (n=2
+		// "pending", n=4 "approved") that should reset the counter. With
+		// maxErrs=2, a single consecutive run never reaches the bound — but
+		// a counter that accumulated across the whole run instead of
+		// resetting on success would hit 2 total errors by n=3 and fail
+		// this test, which is exactly the bug this test guards against.
+		n := reqs.Add(1)
+		if n == 1 || n == 3 {
+			http.Error(w, "server error", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if n == 2 {
+			_ = json.NewEncoder(w).Encode(cli.CLIAuthSessionStatus{Status: "pending"})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(cli.CLIAuthSessionStatus{
+			Status: "approved",
+			Token:  "padsess_test",
+			User:   cli.LoginUser{ID: "user-1", Email: "admin@example.com", Name: "Test Admin"},
+		})
+	})
+	defer srv.Close()
+
+	client := cli.NewClientFromURL(srv.URL)
+	cfg := remoteHeadlessCfg(srv.URL)
+
+	err := pollAndSaveCLIAuth(t.Context(), client, cfg, testSession())
+	if err != nil {
+		t.Fatalf("pollAndSaveCLIAuth: unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

`pollAndSaveCLIAuth` — the shared tail of every CLI browser-auth flow (`pad auth login`, first-run setup handoff, `pad init`'s linking path) — had no wall-clock bound of its own. The ~5-minute limit users observe is entirely the server-side session TTL answering `expired`; if the server becomes unreachable *after* session creation, every poll error was swallowed by `continue` and nothing ended the loop but Ctrl-C. Fixes BUG-2572.

Two new exits, mirroring the shape `RunBrowserBootstrap` already has:

- **Wall-clock timeout** (`cliAuthPollTimeout`, 20m): a `time.NewTimer` arm in the `select`. Sized to the longer of the two server TTLs (`cliAuthSetupSessionTTL`, 20m) because the helper is shared by both flows and the CLI-side session object doesn't say which TTL it got — a single conservative bound never falsely cuts the setup flow short, and the login flow's server-side 5m `expired` still fires first whenever the server is reachable.
- **Consecutive-error bound** (`cliAuthMaxConsecutivePollErrs`, 5): persistent poll failures bail out in ~10s with `polling for approval failed N times in a row: <cause>` instead of waiting out the full 20m. The counter resets on any successful poll (including `pending`), so isolated blips don't accumulate. The headline is deliberately cause-neutral — `client.get` errors on both transport failures and non-2xx responses, so the wrapped error carries the real cause (dial error vs server 500).

## Plus (architectural decisions)

- **No `ExpiresAt` parsing / per-flow bound**: plumbing flow identity (or parsing the server-returned `ExpiresAt`) buys precision only in the unreachable-server case the fixed bound already covers, at the cost of parsing/fallback error surface. Deliberately skipped.
- **Timeout error is remedy-neutral** ("timed out waiting for approval after %s"): the helper is shared by three flows with three different retry commands; each caller's own context guides the user.
- **Per-poll blocking is bounded upstream**: the shared `cli.Client` `httpClient` has `Timeout: 10s`, so a hung request can delay observation of `ctx.Done()`/the timer by at most ~10s — it cannot bypass them. (Raised and ruled in review; context-plumbing `PollCLIAuthSession` would be a contract change out of this item's scope.)
- **Caller audit**: all four call sites (`loginCmd`, `setupCmd`, `cmd_workspace.go` linking, `init.go` browser-setup branch) propagate errors verbatim; only `isCancellation()` pattern-matches, and neither new error is `errCancelled`.

## Observable behavior changes

- A CLI auth wait against a server that dies after session creation now ends with a clear error (~10s if the server stays down, 20m worst case if it keeps answering `pending`) instead of spinning until Ctrl-C.
- New error texts: `timed out waiting for approval after 20m0s` and `polling for approval failed 5 times in a row: <underlying error>`.

## Test plan

- [x] `TestPollAndSaveCLIAuth_TimeoutFires` — always-`pending` server; timeout error fires, remedy-neutral text asserted
- [x] `TestPollAndSaveCLIAuth_ConsecutiveErrorsBound` — always-500 server; bail-out fires well before the wall clock, wrapped `500` present in text
- [x] `TestPollAndSaveCLIAuth_TransientErrorsRecover` — errors at requests 1 and 3 with `maxErrs=2`; success proves the counter resets per-success (a cumulative counter would trip at request 3)
- [x] Tests are deliberately serial (fast-polling helper mutates package vars; documented in-file)
- [x] `go test ./...` green; `golangci-lint run ./...` clean
- [ ] CI (Postgres matrix + Web job) — N/A to this diff (no SQL, no web/), but gates the merge as always

Review: codex ×3 with framing rotation — r1 CLEAN, r2 two findings (one fixed in `bd617480`, one refuted), r3 (contract blast radius) CLEAN, converged.

Refs: BUG-2572. Related: BUG-2541 (skill-docs wording, separate item, unchanged here).

https://claude.ai/code/session_01BhQoeaWXxJbvw86ezzK8dt
