### PR TITLE
fix(release): keep RC tags off brew and docker :latest (BUG-2524)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -141,6 +141,10 @@ homebrew_casks:
     homepage: "https://getpad.dev"
     description: "Project Management for the agent era"
     license: "Apache-2.0"
+    # Prerelease tags (vX.Y.Z-rc.N) must not reach the tap: without this,
+    # goreleaser uploads the cask for RCs too and `brew install` serves a
+    # prerelease to the public until the stable tag overwrites it (BUG-2524).
+    skip_upload: auto
 
 # dockers_v2 replaces the legacy `dockers:` + `docker_manifests:` blocks.
 # A single declaration handles multi-platform builds via buildx; goreleaser
@@ -151,7 +155,10 @@ dockers_v2:
       - "ghcr.io/perpetualsoftware/pad"
     tags:
       - "{{ .Version }}"
-      - "latest"
+      # Only stable tags move the floating :latest tag — a template that
+      # evaluates empty is skipped, so RCs publish only their own
+      # :X.Y.Z-rc.N tag and never overwrite :latest (BUG-2524).
+      - "{{ if not .Prerelease }}latest{{ end }}"
     dockerfile: Dockerfile.goreleaser
     extra_files:
       - web/build


### PR DESCRIPTION
## Summary

Cutting a prerelease tag (`vX.Y.Z-rc.N`) published the RC to both mainstream install channels (verified during the v0.12.0 cut: brew served `0.12.0-rc.1` and `ghcr :latest` matched the rc digest). Two independent causes in `.goreleaser.yaml`, two one-line fixes:

- `homebrew_casks`: add `skip_upload: auto` — goreleaser skips cask upload for prereleases.
- `dockers_v2.tags`: `latest` becomes `{{ if not .Prerelease }}latest{{ end }}` — `.Prerelease` is the semver prerelease part (empty on stable), goreleaser ignores empty-evaluating tags (documented; the docs' conditional-tag example uses this exact shape), so RCs publish only their own `:X.Y.Z-rc.N` tag.

## Verification

- [x] `goreleaser check` passes
- [x] Template semantics verified against goreleaser docs (empty tags ignored; `.Prerelease` string var)
- [ ] Real-world confirmation lands at the next RC cut — release playbook step 5e gets a prerelease-aware branch as follow-up (playbook edit, not repo code)

Refs: BUG-2524.

https://claude.ai/code/session_01BhQoeaWXxJbvw86ezzK8dt