### PR TITLE
fix(cli): suppress pad agent install's dangling (Y/n) prompt in non-interactive contexts (BUG-2593)

### DIFF
--- a/cmd/pad/agent_install_noninteractive_test.go
+++ b/cmd/pad/agent_install_noninteractive_test.go
@@ -1,0 +1,76 @@
+package main
+
+// Test for BUG-2593: installInteractive (pad agent install) must not print
+// the dangling "(Y/n): " prompt in non-interactive contexts — the same
+// IsTerminal()→canPromptForConfig() swap offerSkillInstall got for
+// BUG-2577 (PR #1111), whose test this mirrors.
+//
+// Scope note (same limitation as #1111's test): with a closed-stdin pipe,
+// the old stdin-only guard and the new stdin+stdout guard agree, so this
+// test pins the non-interactive no-prompt behavior but cannot discriminate
+// the pty-backed-stdin case that motivates the swap — canPromptForConfig()
+// reads the real process fds and the repo carries no direct pty dep. The
+// discriminating case is covered by the live verification recorded on
+// BUG-2593's trail: stdin on an undriven pty + stdout on a pipe, where the
+// pre-fix binary prints the prompt and hangs at readChoice while the fixed
+// binary installs silently and exits.
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/cli"
+)
+
+func TestAgentInstallNonInteractiveNoPrompt(t *testing.T) {
+	isolateHome(t)
+	withClosedStdin(t)
+
+	origStdout := os.Stdout
+	pr, pw, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = pw
+	t.Cleanup(func() { os.Stdout = origStdout })
+
+	done := make(chan string, 1)
+	go func() {
+		buf := make([]byte, 0, 4096)
+		tmp := make([]byte, 4096)
+		for {
+			n, err := pr.Read(tmp)
+			if n > 0 {
+				buf = append(buf, tmp[:n]...)
+			}
+			if err != nil {
+				break
+			}
+		}
+		done <- string(buf)
+	}()
+
+	instErr := installInteractive()
+
+	pw.Close()
+	os.Stdout = origStdout
+	output := <-done
+
+	if instErr != nil {
+		t.Fatalf("installInteractive: %v", instErr)
+	}
+	if strings.Contains(output, "(Y/n)") {
+		t.Errorf("non-interactive pad agent install printed a dangling prompt: %q", output)
+	}
+
+	// Claude is always in the detected set (installInteractive's hardcoded
+	// fallback), so the skill should have been installed silently.
+	path := cli.ToolSkillPath(cli.SupportedTools[0])
+	if path == "" {
+		t.Fatal("expected a skill path for the Claude tool")
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("expected /pad skill to be installed at %s, got: %v", path, err)
+	}
+}

--- a/cmd/pad/cmd_agent.go
+++ b/cmd/pad/cmd_agent.go
@@ -267,7 +267,16 @@ func installInteractive() error {
 		detected = append([]cli.AgentTool{cli.SupportedTools[0]}, detected...)
 	}
 
-	if !cli.IsTerminal() {
+	// BUG-2593: gate on canPromptForConfig() (stdin AND stdout are
+	// terminals) rather than cli.IsTerminal() (stdin only) — the same
+	// swap offerSkillInstall got for BUG-2577 (PR #1111, which see for
+	// the boundary): a pty-backed harness can make stdin look like a
+	// char device with nobody able to answer, which left the "(Y/n): "
+	// prompt printed even though the choice auto-defaults. A caller with
+	// BOTH stdin and stdout attached to a pty but nothing driving it
+	// still reads as promptable — that case can't be distinguished from
+	// a real interactive terminal by any check available here.
+	if !canPromptForConfig() {
 		// Non-interactive: install for all detected tools
 		for _, tool := range detected {
 			content := cli.FormatForTool(tool, pad.PadSkill)


### PR DESCRIPTION
## Summary

Same shape and same fix as offerSkillInstall's BUG-2577 (#1111), on the `pad agent install` path #1111 didn't reach: `installInteractive` gated its prompt on `cli.IsTerminal()` (stdin only), so a pty-backed harness — stdin looks like a char device, nobody able to answer — got `Install /pad skill for all N? (Y/n): ` printed and then hung at `readChoice`. Swapped to `canPromptForConfig()` (stdin AND stdout), with #1111's both-pty undetectable-boundary comment. Auto-install behavior unchanged.

## Verification

- Test mirrors #1111's `TestOfferSkillInstallNonInteractiveNoPrompt`, with an honest scope note: closed-stdin cannot discriminate the pty case (both guards agree there), so it pins the non-interactive no-prompt path and the silent install.
- **Live discriminating legs** (undriven-pty stdin + pipe stdout, identical harness): fixed binary installs silently and exits 0 with no prompt; pre-fix control binary (origin/main) prints the dangling `(Y/n):` and hangs to the 10s kill — the reported defect, reproduced.
- Codex ×2: r1 sound except one P2 — the same stdin-only gate in `promptAndBootstrap` (cmd_auth.go), a separate legacy `--cli-prompt` path — **filed as BUG-2597** rather than folded in (consistent with how 2592/2593 were themselves filed as #1111 siblings); r2 CLEAN and ratified the defer. Codex's sweep cleared every other remaining `IsTerminal` call site (config/template gates check both FDs; workspace export's stdout-only check is deliberate binary-output safety).

## Test plan

- [x] go build clean · make lint 0 issues
- [x] go test ./... exit 0, zero FAIL lines
- [x] make test-pg N/A (no store SQL) · web checks N/A (no web changes)

Refs: BUG-2593, BUG-2577 (#1111), BUG-2597 (filed follow-up).

https://claude.ai/code/session_018qREYgDd6Ag1X1SDmqhyFM