### PR TITLE
fix(web): search Enter go-to accepts full refs like TASK-1345 (BUG-2128)

### DIFF
--- a/web/src/lib/components/search/CommandPalette.svelte
+++ b/web/src/lib/components/search/CommandPalette.svelte
@@ -6,7 +6,7 @@
 	import { workspaceStore } from '$lib/stores/workspace.svelte';
 	import { collectionStore } from '$lib/stores/collections.svelte';
 	import { localIndex } from '$lib/stores/localIndex.svelte';
-	import { localSearch, parseSearchQuery } from '$lib/stores/localSearch.svelte';
+	import { localSearch, parseSearchQuery, parseGoToTarget } from '$lib/stores/localSearch.svelte';
 	import { uiStore } from '$lib/stores/ui.svelte';
 	import type {
 		SearchResult,
@@ -654,24 +654,35 @@
 			scrollSelectedIntoView();
 		} else if (e.key === 'Enter') {
 			e.preventDefault();
-			// Numeric go-to mode: typing a bare number + Enter jumps directly
-			// to the item with that item_number — the search palette doubles
-			// as a quick "go to item N" jump. See BUG-910 + BUG-864.
-			const trimmed = query.trim();
-			if (/^\d+$/.test(trimmed)) {
-				const targetNum = parseInt(trimmed, 10);
+			// Go-to mode: a bare number (BUG-910) or a full `TASK-1345`-style
+			// ref (BUG-2128) + Enter jumps directly to that item — the search
+			// palette doubles as a quick "go to item" jump. See BUG-864 for
+			// why everything else requires an explicit arrow-selection.
+			const target = parseGoToTarget(query);
+			if (target) {
+				// Ref form must match prefix AND number (a typo'd prefix is a
+				// no-op, never a cross-collection jump); bare number matches
+				// any collection, as before.
+				const matches = (r: AugmentedSearchResult) =>
+					target.ref
+						? formatItemRef(r.item)?.toUpperCase() === target.ref
+						: r.item.item_number === target.num;
 				// Flush any pending debounced search so Enter feels instant
 				// even if the user beats the 200ms debounce.
 				clearTimeout(searchTimeout);
-				let item = results.find((r) => r.item.item_number === targetNum);
+				let item = results.find(matches);
 				if (!item) {
 					loading = true;
 					try {
-						const resp = await api.search(trimmed, buildFilters(0));
+						// Query the bare number for both forms: that's the
+						// query shape the item_number go-to path has always
+						// relied on server-side, and the ref filter above
+						// narrows by prefix client-side.
+						const resp = await api.search(String(target.num), buildFilters(0));
 						results = resp.results ?? [];
 						total = resp.total ?? 0;
 						facets = resp.facets;
-						item = results.find((r) => r.item.item_number === targetNum);
+						item = results.find(matches);
 					} catch {
 						// ignore — falls through to no-op below
 					} finally {

--- a/web/src/lib/components/search/CommandPalette.svelte
+++ b/web/src/lib/components/search/CommandPalette.svelte
@@ -670,19 +670,38 @@
 				// Flush any pending debounced search so Enter feels instant
 				// even if the user beats the 200ms debounce.
 				clearTimeout(searchTimeout);
+				const typedAtEnter = query.trim();
 				let item = results.find(matches);
 				if (!item) {
 					loading = true;
 					try {
-						// Query the bare number for both forms: that's the
-						// query shape the item_number go-to path has always
-						// relied on server-side, and the ref filter above
-						// narrows by prefix client-side.
-						const resp = await api.search(String(target.num), buildFilters(0));
-						results = resp.results ?? [];
-						total = resp.total ?? 0;
-						facets = resp.facets;
-						item = results.find(matches);
+						// Ref form probes the bare number (the query shape
+						// the item_number path has always relied on
+						// server-side) and filters by prefix client-side;
+						// bare-number form keeps its pre-existing behavior
+						// of searching exactly what was typed.
+						const resp = await api.search(
+							target.ref ? String(target.num) : typedAtEnter,
+							buildFilters(0)
+						);
+						// Stale-query fence: if the user kept typing while
+						// the probe was in flight, discard it — don't
+						// navigate to (or render) a target they've moved
+						// past.
+						if (query.trim() !== typedAtEnter) return;
+						if (target.ref) {
+							// Probe only: on a miss, the displayed results
+							// must not be clobbered with a different
+							// query's result set (the palette still shows
+							// the typed ref, and loadMore() pages by the
+							// typed query).
+							item = (resp.results ?? []).find(matches);
+						} else {
+							results = resp.results ?? [];
+							total = resp.total ?? 0;
+							facets = resp.facets;
+							item = results.find(matches);
+						}
 					} catch {
 						// ignore — falls through to no-op below
 					} finally {

--- a/web/src/lib/stores/localSearch.goto.svelte.test.ts
+++ b/web/src/lib/stores/localSearch.goto.svelte.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { parseGoToTarget } from './localSearch.svelte';
+
+// BUG-2128: the palette's Enter fast-path must treat a full ref
+// (`TASK-1345`) as a direct go-to, same as a bare number (BUG-910).
+// parseGoToTarget is the pure core of that routing decision.
+describe('parseGoToTarget', () => {
+	it('parses a bare number with no ref constraint', () => {
+		expect(parseGoToTarget('1345')).toEqual({ num: 1345, ref: null });
+	});
+
+	it('trims whitespace around either form', () => {
+		expect(parseGoToTarget('  42 ')).toEqual({ num: 42, ref: null });
+		expect(parseGoToTarget(' task-7 ')).toEqual({ num: 7, ref: 'TASK-7' });
+	});
+
+	it('parses a full ref and normalizes the prefix to upper-case', () => {
+		expect(parseGoToTarget('TASK-1345')).toEqual({ num: 1345, ref: 'TASK-1345' });
+		expect(parseGoToTarget('task-1345')).toEqual({ num: 1345, ref: 'TASK-1345' });
+		expect(parseGoToTarget('Bug-8')).toEqual({ num: 8, ref: 'BUG-8' });
+	});
+
+	it('preserves the typed digits in the ref while parsing the number', () => {
+		// Leading zeros: the number is 7, the ref keeps the typed form —
+		// the caller matches on formatItemRef output, which never carries
+		// leading zeros, so `TASK-007` deliberately matches nothing
+		// rather than jumping to TASK-7 on a guess.
+		expect(parseGoToTarget('TASK-007')).toEqual({ num: 7, ref: 'TASK-007' });
+	});
+
+	it('rejects everything that is not go-to-shaped', () => {
+		expect(parseGoToTarget('')).toBeNull();
+		expect(parseGoToTarget('fix the parser')).toBeNull();
+		expect(parseGoToTarget('TASK-1345 extra words')).toBeNull();
+		expect(parseGoToTarget('TASK-')).toBeNull();
+		expect(parseGoToTarget('-1345')).toBeNull();
+		expect(parseGoToTarget('TASK-13a5')).toBeNull();
+		expect(parseGoToTarget('1345x')).toBeNull();
+		expect(parseGoToTarget('#1345')).toBeNull(); // item:/# prefixes are search syntax, not go-to
+		expect(parseGoToTarget('TA SK-5')).toBeNull();
+	});
+});

--- a/web/src/lib/stores/localSearch.svelte.ts
+++ b/web/src/lib/stores/localSearch.svelte.ts
@@ -95,6 +95,30 @@ const PREFIX_ITEM_NUMBER_RE = /^(?:#|item:)(\d+)$/i;
 const REF_PATTERN_RE = /^([A-Za-z]+)-(\d+)$/;
 
 /**
+ * Parse a whole search query as a direct "go to item" target — the
+ * palette's Enter fast-path (BUG-910: bare digits; BUG-2128: a full
+ * `TASK-1345`-style ref, case-insensitive). Returns null when the query
+ * isn't go-to-shaped. `ref` is null for the bare-number form (matches
+ * any collection) and the normalized upper-case ref otherwise (the
+ * caller must match prefix AND number — a wrong prefix is an honest
+ * no-op, never a cross-collection jump).
+ */
+export function parseGoToTarget(query: string): { num: number; ref: string | null } | null {
+	const trimmed = query.trim();
+	if (/^\d+$/.test(trimmed)) {
+		const num = Number(trimmed);
+		return Number.isFinite(num) ? { num, ref: null } : null;
+	}
+	const m = trimmed.match(REF_PATTERN_RE);
+	if (m) {
+		const num = Number(m[2]);
+		if (!Number.isFinite(num)) return null;
+		return { num, ref: `${m[1].toUpperCase()}-${m[2]}` };
+	}
+	return null;
+}
+
+/**
  * Parse a free-form search query into structured prefixes + residual
  * text. Unknown / malformed prefixes pass through as part of `text` so
  * the user always sees something happen.


### PR DESCRIPTION
## Summary

Typing a bare item number + Enter in the search palette jumps straight to the item (BUG-910), but a full ref — `TASK-1345` — fell through to the arrow-selection guard and did nothing. The routing decision is now `parseGoToTarget()` (pure, exported beside `REF_PATTERN_RE`): bare numbers keep match-any-collection semantics; a `PREFIX-N` ref (case-insensitive) must match prefix AND number via `formatItemRef`, so a typo'd prefix is an honest no-op rather than a cross-collection jump, and `TASK-007` deliberately matches nothing rather than guessing `TASK-7`.

Review hardenings (codex r1, all live-verified): a ref-form miss probes the server without clobbering the palette's displayed `results/total/facets` (the query box and result list never diverge, and `loadMore()` keeps paging the typed query); a stale-query fence discards a probe the user typed past (pre-existing race on the numeric path, newly exposed for refs); the numeric miss fallback searches exactly what was typed again.

## Verification

- 5 vitest cases on the parser (case normalization, whitespace, leading zeros, nine reject shapes).
- **Live playwright legs against a sandboxed build** (alt port, own HOME/DB): `TASK-9` → navigates to `/tasks/TASK-9`; `task-9` → same; bare `9` → still navigates (regression leg); `TASH-9` → stays put (control leg — the instrument detects non-navigation, which is the pre-fix behavior on any full ref); miss-display leg → after a `TASH-9` miss the input still shows the typed ref and the result list is not the bare-number set.
- Codex ×2: r1 three findings (above), r2 CLEAN with each fix's placement re-verified.

## Test plan

- [x] svelte-check 0 errors · production build clean
- [x] vitest full suite green (1623, incl. 5 new)
- [x] Go untouched (web-only) · test-pg N/A

Refs: BUG-2128, BUG-910, BUG-864.

https://claude.ai/code/session_018qREYgDd6Ag1X1SDmqhyFM