### PR TITLE
docs: worktree web-tooling rules in CLAUDE.md; fix vitest.config.ts's dangling pointer (TASK-2590)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,16 @@ make dev-web    # Run SvelteKit dev server (hot reload on :5173)
 - **Frontend only:** `make web && make install` or use `make dev-web` for hot reload during development
 - **Full rebuild:** `make install`
 
+### Working in a git worktree
+
+Agent sessions take a `git worktree` per task rather than sharing the main checkout (a shared checkout means a shared stash stack, branch state, and dirty files across sessions). Three rules keep web tooling working there:
+
+- **Symlinking `web/node_modules` to the main checkout's copy is fine** (and fast). Vitest, `vite build`, and `npm run check` all work through the symlink.
+- **A fresh worktree has no `web/.svelte-kit`** (gitignored, generated). Run `npx svelte-kit sync` in `web/` before any vitest/vite command — or `npm run check`, which syncs first. Without it, vitest fails with `Failed to load tsconfig '.svelte-kit/tsconfig.json': Tsconfig not found` regardless of how `node_modules` was set up. (This missing generated dir was historically misdiagnosed as a symlink problem — `npm ci` "fixed" it only because its `prepare` script runs `svelte-kit sync`.)
+- **Never run `npm ci` in a worktree whose `web/node_modules` is a symlink — including via make.** `npm ci` lives in the `web` target, so every target whose dependency chain reaches it is off-limits too: currently `web`, `build`, `install`, `serve`, `web-check`, and `check` (via `web-check`). Everything else — `build-go`, `dev`, `restart`, `test`, `test-pg`, `lint`, `vuln`, `web-test`, `dev-web`, `clean` — never reaches `npm ci`. `npm ci` deletes through the symlink into the shared tree, breaking every other worktree and session at once with a confusing `vitest: not found`. If you want a real, isolated `node_modules` instead of a symlink, `npm ci` in an un-symlinked `web/` is ~5s on a warm cache and regenerates `.svelte-kit` as a side effect.
+
+`web/vitest.config.ts`'s `server.fs.allow` note covers the other worktree wrinkle (symlink realpaths vs the dev-server file-serving guard) and points back at this section.
+
 ## Key Directories
 
 ```

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -39,8 +39,10 @@ const appStateMock = fileURLToPath(new URL('./src/test/mocks/app-state.ts', impo
 const appNavigationMock = fileURLToPath(new URL('./src/test/mocks/app-navigation.ts', import.meta.url));
 
 // Agent worktrees symlink `web/node_modules` to the main checkout's
-// node_modules rather than `npm install`-ing a copy (installing clobbers a
-// worktree; see CLAUDE.md). Vite's dev-server fs-access guard checks a
+// node_modules rather than `npm ci`-ing a copy (running npm ci THROUGH the
+// symlink deletes the shared tree — see CLAUDE.md's "Working in a git
+// worktree" section, which also covers the svelte-kit sync prerequisite).
+// Vite's dev-server fs-access guard checks a
 // requested file's REALPATH against `server.fs.allow`, which defaults to the
 // project root and its ancestors — a node_modules symlink that resolves
 // outside that root (the worktree lives under a sibling directory tree) gets


### PR DESCRIPTION
## Summary

CLAUDE.md gains the "Working in a git worktree" section that `web/vitest.config.ts`'s `fs.allow` comment has pointed at since it shipped — it never existed. Content follows the **corrected** day-38 ruling on TASK-2590, not the task's original body (whose "npm ci, never symlink" rule was refuted by the 2×2 on the trail — the missing generated `web/.svelte-kit` was the variable, not the symlink, and `npm ci` only "fixed" it because its `prepare` script runs `svelte-kit sync`):

- Symlinking `web/node_modules` stays fine and stays the recommendation.
- A fresh worktree needs `npx svelte-kit sync` in `web/` (or `npm run check`) before any vitest/vite command.
- Never `npm ci` through a symlinked `node_modules` — it deletes the shared tree and stalls every session. The section names the mechanism (`npm ci` lives in the `web` make target) and enumerates every target whose chain reaches it: `web`, `build`, `install`, `serve`, `web-check`, `check`; `build-go` and `web-test` are the safe ones (codex r1's finding — the original list missed `web-check` and `serve`).

The `vitest.config.ts` comment (comment-only, no config values) now states the real hazard and points at the section that now exists.

## Verification

- Both documented legs executed **as written, in this PR's own fresh worktree**: symlink + no `.svelte-kit` → vitest fails with the exact quoted `TSCONFIG_ERROR`; `npx svelte-kit sync` → same test passes through the symlink and through the edited config file.
- Make-target enumeration verified directly against the Makefile (chains: `build→web`, `install→build`, `serve→build`, `web-check→web`, `check→web-check`; `web-test` runs `npm run test` only).
- Codex: r1 found the target-list gap (fixed); r2 convergence attempts wedged twice (service degraded tonight — 5 wedges total, pattern recorded in harness memory), so convergence rests on the direct Makefile verification above rather than a CLEAN stamp.

## Test plan

- [x] Docs + comment only; vitest ran green through the edited config (leg 2)
- [x] Go untouched · store untouched · no behavior changes

Refs: TASK-2590, TASK-2588 (origin), the day-38 correction ruling on the item trail.

https://claude.ai/code/session_018qREYgDd6Ag1X1SDmqhyFM