### PR TITLE
fix(cli): gate promptAndBootstrap on canPromptForConfig() (BUG-2597)

### DIFF
--- a/cmd/pad/cmd_auth.go
+++ b/cmd/pad/cmd_auth.go
@@ -654,9 +654,18 @@ func promptAndBootstrap(client *cli.Client) (*cli.LoginResponse, error) {
 	// reaches this path without a TTY would hang indefinitely on
 	// reader.ReadString('\n'). Fail fast with a hint pointing at the
 	// headless flags instead (BUG-988).
-	if !term.IsTerminal(int(os.Stdin.Fd())) {
+	//
+	// BUG-2597: gate on canPromptForConfig() (stdin AND stdout are
+	// terminals), not stdin alone — a pty-backed harness can make stdin
+	// look like a char device with nobody able to answer, which sent
+	// "  Email: " into a redirected stdout and blocked on the read.
+	// Same swap as offerSkillInstall (BUG-2577, PR #1111) and
+	// installInteractive (BUG-2593, PR #1116); as there, a caller with
+	// BOTH fds on an undriven pty is indistinguishable from a real
+	// terminal and still prompts.
+	if !canPromptForConfig() {
 		return nil, fmt.Errorf(
-			"stdin is not a terminal — cannot prompt for admin credentials.\n" +
+			"not running in an interactive terminal — cannot prompt for admin credentials.\n" +
 				"Run with --email, --name, and --password for non-interactive bootstrap:\n" +
 				"  pad auth setup --email you@example.com --name \"Your Name\" --password <pass>")
 	}

--- a/cmd/pad/setup_headless_test.go
+++ b/cmd/pad/setup_headless_test.go
@@ -281,8 +281,8 @@ func TestHeadlessSetupNonTTYWithoutFlags(t *testing.T) {
 	if gotErr == nil {
 		t.Fatal("expected error when stdin is not a terminal, got nil")
 	}
-	if !strings.Contains(gotErr.Error(), "stdin is not a terminal") {
-		t.Errorf("error %q should mention 'stdin is not a terminal'", gotErr.Error())
+	if !strings.Contains(gotErr.Error(), "not running in an interactive terminal") {
+		t.Errorf("error %q should mention not running in an interactive terminal (BUG-2597 widened the gate past stdin-only, so the message no longer blames stdin specifically)", gotErr.Error())
 	}
 	// Must also point at the headless flags so the agent knows what to use
 	if !strings.Contains(gotErr.Error(), "--email") {


### PR DESCRIPTION
## Summary

Third and final member of the BUG-2577 gate family (offerSkillInstall #1111, installInteractive #1116): `promptAndBootstrap` — the legacy `--cli-prompt` admin bootstrap — guarded its prompts on stdin-only `term.IsTerminal`, so a pty-backed harness with redirected stdout got `  Email: ` printed into the pipe and then blocked on the read. Swapped to `canPromptForConfig()` (stdin AND stdout) with the family's boundary comment; the BUG-988 refuse-fast-with-headless-hint contract is unchanged.

The error message no longer blames stdin specifically ("not running in an interactive terminal") — under the widened gate it can fire when stdin IS a terminal and stdout isn't. Only the existing test consumed the old wording; its assertion is updated with the why.

## Verification

- **Live discriminating legs** (pty-stdin + piped stdout, fresh setup-required sandbox): fixed binary refuses fast with the new message + headless hint; pre-fix control (origin/main) prints `Email:` into the pipe and hangs to the 10s kill — the reported defect exactly.
- **Remedy leg**: the message's suggested command (`pad auth setup --email/--name/--password`) ran to success in the same environment.
- Codex r1 CLEAN, including the sweep: no remaining active stdin-only `IsTerminal` prompt gates in `cmd/pad` or `internal/cli`; the family is closed. It also confirmed `pad init --cli-prompt` is pre-gated at init.go:205, so this message is reachable only via `pad auth setup --cli-prompt` — where its remedy is exactly right.

## Test plan

- [x] go build clean · make lint 0 issues
- [x] go test ./... exit 0, zero FAIL lines (existing non-TTY test updated, still pins the refuse-fast contract)
- [x] make test-pg N/A (no store SQL) · web checks N/A

Refs: BUG-2597, BUG-2577 (#1111), BUG-2593 (#1116), BUG-988.

https://claude.ai/code/session_018qREYgDd6Ag1X1SDmqhyFM