### PR TITLE
fix(server): serve RFC 9728 PRM at path-aware well-known (BUG-2266)

### DIFF
--- a/internal/server/handlers_mcp.go
+++ b/internal/server/handlers_mcp.go
@@ -174,5 +174,19 @@ func (s *Server) registerMCPRoutes(r chi.Router) {
 	// (protected-resource) gets the real metadata; RFC 8414 (auth-server)
 	// is the 501 stub TASK-951 fills in.
 	r.With(s.requireCloudMode).Get("/.well-known/oauth-protected-resource", s.handleOAuthProtectedResource)
+	// Path-aware RFC 9728 §3.1 variant (BUG-2266). A client configured
+	// with the path-suffixed transport URL (https://mcp.getpad.dev/mcp —
+	// the shape every FastMCP example uses) constructs its metadata URL
+	// by inserting the well-known segment BEFORE the path:
+	// /.well-known/oauth-protected-resource/mcp. Without this route the
+	// request fell through to the SPA catch-all and discovery died
+	// JSON-parsing HTML. Bounded to the two shapes a pasted transport
+	// URL actually produces (/mcp and a trailing-slash /mcp/) rather
+	// than a wildcard: the handler sets Cache-Control public max-age,
+	// and a wildcard would hand a CDN one cacheable object per
+	// attacker-chosen suffix (codex round 2). /mcp is the only
+	// path-mounted resource, so nothing else needs the variant.
+	r.With(s.requireCloudMode).Get("/.well-known/oauth-protected-resource/mcp", s.handleOAuthProtectedResource)
+	r.With(s.requireCloudMode).Get("/.well-known/oauth-protected-resource/mcp/", s.handleOAuthProtectedResource)
 	r.With(s.requireCloudMode).Get("/.well-known/oauth-authorization-server", s.handleOAuthAuthorizationServer)
 }

--- a/internal/server/handlers_mcp_test.go
+++ b/internal/server/handlers_mcp_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -25,6 +26,7 @@ func TestMCP_CloudModeOff_RoutesAbsent(t *testing.T) {
 	}{
 		{"POST", "/mcp"},
 		{"GET", "/.well-known/oauth-protected-resource"},
+		{"GET", "/.well-known/oauth-protected-resource/mcp"},
 		{"GET", "/.well-known/oauth-authorization-server"},
 	}
 	for _, tc := range cases {
@@ -87,6 +89,111 @@ func TestMCP_DiscoveryDoc_PopulatedFromConfig(t *testing.T) {
 	}
 	if !sliceEqual(doc.BearerMethodsSupported, []string{"header"}) {
 		t.Errorf("BearerMethodsSupported: got %v, want [header]", doc.BearerMethodsSupported)
+	}
+}
+
+// TestMCP_DiscoveryDoc_PathAwareWellKnown pins the RFC 9728 §3.1
+// path-aware metadata URL (BUG-2266). A client configured with the
+// path-suffixed transport URL (https://mcp.getpad.dev/mcp — the shape
+// every FastMCP example uses) inserts the well-known segment BEFORE
+// the path, requesting /.well-known/oauth-protected-resource/mcp.
+// Before the fix that request fell through to the SPA catch-all and
+// the client died JSON-parsing HTML. The assertions decode into the
+// typed doc and compare field-by-field against the root variant, so
+// neither an HTML shell nor a 404 body can ever satisfy them
+// (CONVE-12: the catch-all cannot produce this end state).
+func TestMCP_DiscoveryDoc_PathAwareWellKnown(t *testing.T) {
+	t.Parallel()
+	srv := mcpEnabledTestServer(t)
+
+	rrRoot := doRequest(srv, "GET", "/.well-known/oauth-protected-resource", nil)
+	if rrRoot.Code != http.StatusOK {
+		t.Fatalf("root variant: expected 200, got %d (body: %s)", rrRoot.Code, rrRoot.Body.String())
+	}
+	var rootDoc protectedResourceMetadata
+	parseJSON(t, rrRoot, &rootDoc)
+
+	// /mcp and a trailing-slash /mcp/ — both shapes a pasted transport
+	// URL produces under §3.1 construction.
+	for _, path := range []string{
+		"/.well-known/oauth-protected-resource/mcp",
+		"/.well-known/oauth-protected-resource/mcp/",
+	} {
+		rr := doRequest(srv, "GET", path, nil)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("%s: expected 200, got %d (body: %s)", path, rr.Code, rr.Body.String())
+		}
+		if ct := rr.Header().Get("Content-Type"); ct != "application/json" {
+			t.Errorf("%s: expected Content-Type application/json, got %q", path, ct)
+		}
+		var doc protectedResourceMetadata
+		parseJSON(t, rr, &doc)
+		if doc.Resource != rootDoc.Resource {
+			t.Errorf("%s: Resource: got %q, want %q (same doc as root variant)", path, doc.Resource, rootDoc.Resource)
+		}
+		if !sliceEqual(doc.AuthorizationServers, rootDoc.AuthorizationServers) {
+			t.Errorf("%s: AuthorizationServers: got %v, want %v", path, doc.AuthorizationServers, rootDoc.AuthorizationServers)
+		}
+		if !sliceEqual(doc.ScopesSupported, rootDoc.ScopesSupported) {
+			t.Errorf("%s: ScopesSupported: got %v, want %v", path, doc.ScopesSupported, rootDoc.ScopesSupported)
+		}
+		if !sliceEqual(doc.BearerMethodsSupported, rootDoc.BearerMethodsSupported) {
+			t.Errorf("%s: BearerMethodsSupported: got %v, want %v", path, doc.BearerMethodsSupported, rootDoc.BearerMethodsSupported)
+		}
+	}
+
+	// The route is deliberately bounded to /mcp and /mcp/ — NOT a
+	// wildcard. The handler emits Cache-Control: public max-age, so a
+	// wildcard would hand a CDN one cacheable object per attacker-
+	// chosen suffix (codex round 2). Pin that an arbitrary suffix does
+	// not get the doc.
+	rrBogus := doRequest(srv, "GET", "/.well-known/oauth-protected-resource/bogus", nil)
+	if ct := rrBogus.Header().Get("Content-Type"); rrBogus.Code == http.StatusOK && ct == "application/json" {
+		t.Errorf("arbitrary suffix served the metadata doc (status %d, CT %q) — route must stay bounded to /mcp", rrBogus.Code, ct)
+	}
+}
+
+// TestMCP_DiscoveryRoutes_RequireCloudModePerRoute exercises the
+// requireCloudMode middleware ON each mounted discovery route — which
+// TestMCP_CloudModeOff_RoutesAbsent structurally cannot (it never
+// wires the transport, so registerMCPRoutes bails at its nil-guard and
+// the routes are absent for a different reason; stripping the
+// middleware from a route would still pass that test — codex round 3).
+// Here the routes ARE mounted (cloud on at router build), then the
+// cloud flag is flipped off in-place; only the per-route middleware
+// can refuse from there.
+func TestMCP_DiscoveryRoutes_RequireCloudModePerRoute(t *testing.T) {
+	t.Parallel()
+	srv := mcpEnabledTestServer(t)
+
+	paths := []string{
+		"/.well-known/oauth-protected-resource",
+		"/.well-known/oauth-protected-resource/mcp",
+		"/.well-known/oauth-protected-resource/mcp/",
+	}
+	// Force router build + prove the routes are live first, so the
+	// refusals below can only come from the per-route middleware.
+	for _, p := range paths {
+		if rr := doRequest(srv, "GET", p, nil); rr.Code != http.StatusOK {
+			t.Fatalf("%s: expected 200 with cloud mode on, got %d", p, rr.Code)
+		}
+	}
+
+	// In-package flip of the flag requireCloudMode reads. The routes
+	// stay mounted (chi trees are immutable post-build) — that's the
+	// point: only the middleware stands between the request and the
+	// handler now.
+	srv.cloudMode = false
+
+	for _, p := range paths {
+		rr := doRequest(srv, "GET", p, nil)
+		if rr.Code != http.StatusNotFound {
+			t.Errorf("%s: expected 404 from requireCloudMode after cloud flag cleared, got %d (body: %s)", p, rr.Code, rr.Body.String())
+		}
+		var doc protectedResourceMetadata
+		if err := json.Unmarshal(rr.Body.Bytes(), &doc); err == nil && doc.Resource != "" {
+			t.Errorf("%s: metadata doc leaked past requireCloudMode: %+v", p, doc)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Serves the RFC 9728 protected-resource metadata document at the path-aware well-known URLs (`/.well-known/oauth-protected-resource/mcp` and trailing-slash `/mcp/`) in addition to the existing exact-match root. Fixes OAuth discovery for MCP clients configured with the path-suffixed transport URL (`https://mcp.getpad.dev/mcp` — the shape every FastMCP example uses, e.g. Kimi CLI): per RFC 9728 §3.1 such clients insert the well-known segment *before* the path, and that URL previously fell through to the SPA catch-all, so discovery died JSON-parsing an HTML shell.

Bounded to the two real shapes rather than a wildcard: the handler emits `Cache-Control: public, max-age=3600`, and a wildcard would hand a CDN one cacheable object per attacker-chosen suffix (codex round 2 finding, fixed).

Scope: PRIMARY fix from BUG-2266 only. The audience-widening secondary (`NormalizeAudience` / `audienceMatchingStrategy`) is deliberately untouched — separate security-boundary item. For the same reason the suffixed doc keeps the canonical bare-host `resource`: echoing `.../mcp` would steer compliant clients into an audience the AS still rejects (codex round 1 P1, declined with reasoning — doc-following clients converge on the canonical audience and work end-to-end; strict §3.3 validators fail cleanly at discovery exactly as before, until the audience item lands).

## Test plan

- New `TestMCP_DiscoveryDoc_PathAwareWellKnown`: decodes `/mcp` and `/mcp/` variants into the typed doc and compares field-by-field against the root response (SPA HTML or a 404 body cannot satisfy it); pins that an arbitrary suffix (`/bogus`) does NOT get the doc. `t.Parallel` per CONVE-2086.
- Path-aware URL added to `TestMCP_CloudModeOff_RoutesAbsent`'s 404 list (cloud-mode gate preserved).
- Mutation-verified: with the route lines removed, the new test fails `expected 200, got 404`.
- Live-verified on the real binary (cloud-mode boot, temp HOME/DB): suffixed paths return `200 application/json` with the full doc; root unchanged; control leg confirms an unmatched well-known path still serves the SPA shell — the pre-fix behavior at the suffixed path.
- Codex: round 1 FINDINGS (P1 declined on coupling grounds, recorded above), round 2 fresh-angle sweep — middleware/auth ordering, WWW-Authenticate pointer consistency, route shadowing all CLEAN; cache P2 fixed by bounding. Round 3 confirm pending below.

Closes BUG-2266.

https://claude.ai/code/session_018qREYgDd6Ag1X1SDmqhyFM