### PR TITLE
fix(web): full-page pane host gets its own navigate-away handling (BUG-2178)

### DIFF
--- a/web/e2e/pane-full-page-capstone.spec.ts
+++ b/web/e2e/pane-full-page-capstone.spec.ts
@@ -43,8 +43,12 @@ import type { SuiteFixture } from './fixtures';
  *      the master route).
  *
  * DEFERRED / out of scope (do NOT assert): BUG-2177 (an editor-bound
- * upload/crop orphaned by the peeking editor remount — accepted) and BUG-2178
- * (collection-rename/move-from-pane URL shaping on this host — deferred).
+ * upload/crop orphaned by the peeking editor remount — accepted). BUG-2178
+ * (collection-rename/move-from-pane URL shaping on this host) is now FIXED
+ * and covered below: the move-from-pane case is asserted end-to-end; the
+ * rename case is a host-side IGNORE whose decision table lives in
+ * planFullPageNavigateAway's unit tests (paneController.test.ts) and whose
+ * route self-heal is BUG-2272's separately-tested SSE machinery.
  *
  * The pane is a desktop-split concern, so the desktop project alone covers it.
  */
@@ -936,4 +940,50 @@ test.describe('full-page pane host CAPSTONE (PLAN-2154 Phase 2 / TASK-2175)', ()
 		// The master is EDITABLE again (un-peeked) — a clean single unwind.
 		await expect(masterCol(page).locator('button.title', { hasText: 'FP dblclose master' })).toBeVisible();
 	});
+
+	test('BUG-2178: moving the PANE item to another collection re-targets the pane and never abandons the master route', async ({
+		page,
+		request,
+		fixture,
+	}) => {
+		await browserLogin(page);
+		const coll = await seedNoteCollection(fixture, request, 'FP move src', 'FPMS');
+		const target = await seedNoteCollection(fixture, request, 'FP move target', 'FPMT');
+		const master = await seedNoteItem(fixture, request, coll.slug, `FP move master ${Date.now()}`, 'm', '');
+		const paneItem = await seedNoteItem(fixture, request, coll.slug, `FP move pane ${Date.now()}`, 'p', '');
+		// Open with the REF-shaped `?item=` a row-click / relationship first-open
+		// mints (openItemPaneByRef → itemUrlId). This is the realistic shape, and
+		// it also makes the post-move retarget a REAL drill: the moved item's
+		// SLUG (which a same-workspace move preserves) differs from the ref, so
+		// the pane remounts onto the fresh item.
+		const paneRef = await itemRef(fixture, request, paneItem.slug);
+		await page.goto(fullPageUrl(fixture, coll.slug, master.slug, `?item=${paneRef}`), {
+			waitUntil: 'domcontentloaded',
+		});
+
+		const pane = page.locator('aside.item-pane');
+		await expect(pane).toBeVisible();
+		await expect(pane.locator('button.title', { hasText: 'FP move pane' })).toBeVisible();
+		const masterPath = pathname(page);
+
+		// Activate the peeking pane FIRST (a click on a peeking side is spent
+		// on activation), THEN open the pane-scoped ⋯ menu.
+		await pane.locator('button.title', { hasText: 'FP move pane' }).click();
+		await page.keyboard.press('Escape'); // close the title editor the activation click opened
+		await pane.locator('button.pane-more-btn').click();
+		// MenuItem hints are not aria-hidden, so match non-exact (harness memory).
+		await pane.getByRole('menuitem', { name: 'Move to collection…' }).click();
+		await pane.getByRole('menuitem', { name: /FP move target/ }).click();
+
+		// The retarget lands as a drill: `?item=` flips from the ref to the moved
+		// item's slug, and the PATHNAME NEVER LEAVES the master route. The broken
+		// build instead `goto`s /{user}/{ws}/{target}/{movedSlug} — pathname
+		// change is exactly what discriminates (CONVE-12).
+		await expect.poll(() => openItemParam(page), { timeout: 10_000 }).toBe(paneItem.slug);
+		expect(pathname(page)).toBe(masterPath);
+		// Pane still shows the (now-moved) item; master column intact.
+		await expect(pane.locator('button.title', { hasText: 'FP move pane' })).toBeVisible();
+		await expect(masterCol(page).locator('button.title', { hasText: 'FP move master' })).toBeVisible();
+	});
 });
+

--- a/web/src/lib/collections/paneController.test.ts
+++ b/web/src/lib/collections/paneController.test.ts
@@ -4,6 +4,7 @@ import {
 	planPaneDrill,
 	planLateralOpen,
 	planPaneClose,
+	planFullPageNavigateAway,
 	PANE_DEPTH_SOFT_CAP,
 	type ResolvedPaneState,
 } from './paneController';
@@ -239,6 +240,61 @@ describe('integration — full open/drill/close round-trips', () => {
 		expect(planPaneClose((reset as { resetState: ResolvedPaneState }).resetState)).toEqual({
 			kind: 'owned-go',
 			goDelta: -1,
+		});
+	});
+});
+
+describe('planFullPageNavigateAway (BUG-2178)', () => {
+	// The two REAL emit shapes, verbatim from ItemDetail.svelte:
+	//  - collection rename (embedded): `/${user}/${ws}/${newColl}?item=${slug}`
+	//  - item move: `/${user}/${ws}/${targetColl}/${movedSlug}`
+
+	it('IGNOREs a collection-rename emit (keeps-pane, ?item= present)', () => {
+		expect(planFullPageNavigateAway('/dave/docapp/new-tasks?item=my-item')).toEqual({
+			kind: 'ignore',
+		});
+	});
+
+	it('IGNOREs a rename emit even when the ?item value is empty or strange', () => {
+		expect(planFullPageNavigateAway('/dave/docapp/new-tasks?item=')).toEqual({ kind: 'ignore' });
+		expect(planFullPageNavigateAway('/dave/docapp/new-tasks?item=%2F%2F')).toEqual({
+			kind: 'ignore',
+		});
+	});
+
+	it('RETARGETs an item-move emit to the moved slug (last path segment)', () => {
+		expect(planFullPageNavigateAway('/dave/docapp/ideas/moved-item-slug')).toEqual({
+			kind: 'retarget',
+			target: 'moved-item-slug',
+		});
+	});
+
+	it('decodes a percent-encoded moved slug', () => {
+		expect(planFullPageNavigateAway('/dave/docapp/ideas/caf%C3%A9-item')).toEqual({
+			kind: 'retarget',
+			target: 'café-item',
+		});
+	});
+
+	it('tolerates a trailing slash on the move URL', () => {
+		expect(planFullPageNavigateAway('/dave/docapp/ideas/moved-item-slug/')).toEqual({
+			kind: 'retarget',
+			target: 'moved-item-slug',
+		});
+	});
+
+	// Input-domain edges (the type admits any string): never navigate on
+	// something unparseable — staying on the master is the safe floor.
+	it('IGNOREs malformed, empty, and pathless inputs', () => {
+		expect(planFullPageNavigateAway('')).toEqual({ kind: 'ignore' });
+		expect(planFullPageNavigateAway('/')).toEqual({ kind: 'ignore' });
+		expect(planFullPageNavigateAway('http://')).toEqual({ kind: 'ignore' });
+		expect(planFullPageNavigateAway('%%%')).toEqual({ kind: 'ignore' });
+	});
+
+	it('IGNOREs an absolute URL to a foreign origin carrying ?item=', () => {
+		expect(planFullPageNavigateAway('https://evil.example/x/y?item=z')).toEqual({
+			kind: 'ignore',
 		});
 	});
 });

--- a/web/src/lib/collections/paneController.ts
+++ b/web/src/lib/collections/paneController.ts
@@ -135,6 +135,67 @@ export function planPaneDrill(
 	return { kind: 'push', state: { paneDepth: current.paneDepth + 1, paneOwned: current.paneOwned } };
 }
 
+/** Plan for a pane `onNavigateAway` on the FULL-PAGE item host (BUG-2178). */
+export type FullPageNavigateAwayPlan =
+	/** No navigation. The master route is never invalidated FOR THE HOST by a
+	 *  keeps-pane emit, so the host stays put. */
+	| { kind: 'ignore' }
+	/** Item move: re-target the pane (a drill via `navigatePaneTo`) to the
+	 *  moved item, keeping the master route. */
+	| { kind: 'retarget'; target: string };
+
+/**
+ * Plan a pane `onNavigateAway` for the FULL-PAGE item host (BUG-2178).
+ *
+ * ItemDetail's two emits are collection-host-shaped (see
+ * `handlePaneNavigateAway`'s comment in paneHostController.ts), so the
+ * full-page host must not `goto` them — both abandon the master. Instead:
+ *
+ *  - COLLECTION RENAME (`/user/ws/NEWSLUG?item=X`, keeps-pane): IGNORE.
+ *    Nothing the host owns is invalidated by this emit alone: if the
+ *    renamed collection is the MASTER's, the master ItemDetail's own SSE
+ *    rename handler (BUG-2272) already `goto`s the new-slug URL with the
+ *    full search string — `?item=` included — so the route self-heals with
+ *    the pane intact; if it's a DIFFERENT collection, the master route
+ *    never referenced the old slug at all. The embedded pane needs no URL
+ *    change either — it trusts `item.collection_slug`
+ *    (`effectiveCollSlug`), not the route. Known degradation, accepted
+ *    deliberately: if the `collection_updated` SSE is LOST (replay gap),
+ *    the route stays on the dead old slug — the same exposure BUG-2272's
+ *    model already accepts for remote renames, since delta-sync doesn't
+ *    recover collection renames either (BUG-2601 tracks closing that).
+ *  - ITEM MOVE (`/user/ws/COLL/MOVEDSLUG`, no `?item=`): RETARGET the pane
+ *    to the moved item's slug (the emitted URL's last path segment) via the
+ *    drill machinery, which preserves the master pathname by construction
+ *    and handles depth/ownership/focus. The in-pane Back may land on the
+ *    pre-move `?item=` value; if that was a ref the move re-prefixed, the
+ *    pane's gone-state close handles it.
+ *  - Malformed / empty URLs: IGNORE — staying on the master beats
+ *    navigating somewhere unparseable.
+ */
+export function planFullPageNavigateAway(url: string): FullPageNavigateAwayPlan {
+	let parsed: URL | null = null;
+	try {
+		parsed = new URL(url, 'http://pad.invalid');
+	} catch {
+		parsed = null;
+	}
+	if (!parsed || parsed.searchParams.has('item')) return { kind: 'ignore' };
+	const segments = parsed.pathname.split('/').filter(Boolean);
+	if (segments.length === 0) return { kind: 'ignore' };
+	let target = '';
+	try {
+		// decodeURIComponent THROWS on a malformed percent sequence (e.g. a
+		// literal '%' in a slug that never round-tripped through encoding) —
+		// treat that as unparseable, same as the URL-constructor failures.
+		target = decodeURIComponent(segments[segments.length - 1]);
+	} catch {
+		return { kind: 'ignore' };
+	}
+	if (!target) return { kind: 'ignore' };
+	return { kind: 'retarget', target };
+}
+
 /**
  * Plan a LATERAL open (`openItemPane` — a list/board/table row click, Enter,
  * or a j/k pane-follow settle). Three cases:

--- a/web/src/lib/collections/paneHostController.ts
+++ b/web/src/lib/collections/paneHostController.ts
@@ -342,6 +342,12 @@ export function createPaneController(deps: PaneControllerDeps): PaneController {
 		}
 	}
 
+	// COLLECTION-HOST-ONLY (BUG-2178): the URLs ItemDetail emits here are
+	// collection-host-shaped (the base route IS the collection page), so the
+	// full-page item host must NOT wire this handler — it navigates off the
+	// master. That host wires planFullPageNavigateAway (paneController.ts)
+	// instead.
+	//
 	// The pane's ItemDetail fires `onNavigateAway` for TWO distinct cases, which
 	// we tell apart by whether the target URL still carries `?item=` (i.e. keeps
 	// the pane open):

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -1252,6 +1252,7 @@
 						// mid-keystroke with no save yet pending would
 						// still lose chars without this branch.
 						item = adoptServerItem(updated);
+						void refreshCollectionIfMoved(updated);
 						const links = await api.links.list(reqWsSlug, updated.slug).catch(() => []);
 						if (!item || item.id !== reqItemId || myItemGen !== itemGen) return;
 						itemLinks = links;
@@ -1344,6 +1345,7 @@
 					// Bump the item-snapshot gen so an in-flight refetch drops (round 9).
 					const myItemGen = ++itemGen;
 					item = adoptServerItem(updated);
+					void refreshCollectionIfMoved(updated);
 					const links = await api.links.list(reqWsSlug, updated.slug).catch(() => []);
 					if (!item || item.id !== reqItemId || myItemGen !== itemGen) return;
 					itemLinks = links;
@@ -1357,6 +1359,10 @@
 				const updated = await api.items.get(reqWsSlug, reqItemSlug);
 				if (!item || item.id !== reqItemId || myItemGen !== itemGen) return;
 				item = adoptServerItem(updated);
+				// Same collection-moved handling as the SSE + incremental
+				// adoptions above — a long tab absence can span a move too
+				// (codex round 2 P1).
+				void refreshCollectionIfMoved(updated);
 				const links = await api.links.list(reqWsSlug, updated.slug).catch(() => []);
 				if (!item || item.id !== reqItemId || myItemGen !== itemGen) return;
 				itemLinks = links;
@@ -2857,6 +2863,41 @@
 		return withInflightTags(
 			collabProvider ? updated : { ...updated, content: item?.content ?? updated.content }
 		);
+	}
+
+	// BUG-2178 (codex R1): an SSE / delta-sync adoption can change the item's
+	// COLLECTION — a cross-collection move by another user/tab, or this pane's
+	// own move when the full-page host's retarget same-ref-guards to a noop
+	// (a same-workspace move keeps the slug). `collection` — and the schema
+	// derived from it — would silently keep the OLD collection's shape, so
+	// fields rendered/validated against the wrong schema. Refetch by the
+	// adopted slug when it diverges, fenced with the same collectionGen every
+	// other collection write uses (last-started wins).
+	async function refreshCollectionIfMoved(adopted: Item) {
+		// EMBEDDED only: the pane derives its collection context from
+		// item.collection_slug (effectiveCollSlug), so a moved item must get
+		// the target collection's schema. A NON-embedded master keeps the
+		// route-authoritative collSlug on a remote move (the route itself is
+		// stale — a bigger, separately-tracked problem), and refreshing its
+		// collection object there would render the target collection's
+		// name/icon under the source route's URL — mixed state worse than
+		// consistently stale (codex round 2 P2).
+		if (!embedded) return;
+		const newSlug = adopted.collection_slug;
+		if (!newSlug || !collection || collection.slug === newSlug) return;
+		const collGen = ++collectionGen;
+		try {
+			const fresh = await api.collections.get(wsSlug, newSlug);
+			if (collGen !== collectionGen) return;
+			// Semantic fence on top of the generation fence: only write while
+			// the LIVE item still agrees this is its collection — a
+			// chained-move burst (X→Y→Z) can leave an older refresh both
+			// newest-started-for-its-slug and wrong (codex round 2 P1).
+			if (item?.collection_slug !== newSlug) return;
+			collection = fresh;
+		} catch {
+			// Ignore — the next event / reload catches up.
+		}
 	}
 
 	// Load the workspace's distinct tags for autocomplete. Pure data-fetch

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -7,7 +7,10 @@
 	import PaneHost from '$lib/components/collections/PaneHost.svelte';
 	import { createScrollRestoration } from '$lib/scroll/restore.svelte';
 	import { createPaneController } from '$lib/collections/paneHostController';
-	import { type ResolvedPaneState } from '$lib/collections/paneController';
+	import {
+		planFullPageNavigateAway,
+		type ResolvedPaneState,
+	} from '$lib/collections/paneController';
 	import { createPaneMintSettle, PANE_MINT_SETTLE_MS } from '$lib/collections/paneMintSettle';
 	import { resolvePaneTarget, isSamePaneTarget, type PaneGuardItem } from '$lib/collections/paneTarget';
 	import { inExemptSurface } from '$lib/collections/paneFocus';
@@ -170,12 +173,23 @@
 		openItemPaneByRef,
 		navigatePaneTo,
 		handlePaneBack,
-		handlePaneNavigateAway,
 		closeItemPane,
 		currentPaneState,
 		paneNavInFlight,
 		clearPaneGo,
 	} = paneController;
+
+	// BUG-2178: the controller's handlePaneNavigateAway is COLLECTION-host
+	// shaped (its goto targets assume the base route is the collection page),
+	// so this host must not wire it — a pane collection-rename would land on
+	// the collection page and a pane item-move on the moved item's full page,
+	// both abandoning the master. planFullPageNavigateAway (pure, unit-tested)
+	// decides per emit; the only action this host ever takes is a pane drill,
+	// which preserves the master pathname by construction.
+	function handleFullPageNavigateAway(url: string) {
+		const plan = planFullPageNavigateAway(url);
+		if (plan.kind === 'retarget') navigatePaneTo(plan.target);
+	}
 
 	// Parse a ref-shaped candidate's item NUMBER (mirrors paneTarget's private
 	// `parseRefNumber`) — used only to derive `masterItem.item_number` from the
@@ -575,7 +589,7 @@
 			{activePane}
 			onClose={closeItemPane}
 			onGone={closeItemPane}
-			onNavigateAway={handlePaneNavigateAway}
+			onNavigateAway={handleFullPageNavigateAway}
 			onOpenTarget={guardedDrill}
 			onBack={handlePaneBack}
 		/>


### PR DESCRIPTION
## Summary

The full-page item host reused the pane controller's collection-host-shaped `handlePaneNavigateAway`, so a collection rename or item move performed from within the docked pane abandoned the master route. The host now wires `planFullPageNavigateAway` — a new pure planner beside `planPaneDrill`:

- **Collection rename** (keeps-pane emit): **ignore**. The master's own BUG-2272 SSE handler self-heals the shared-collection case with `?item=` preserved; a foreign collection never touched the master route; the embedded pane trusts `item.collection_slug`. Known degradation (lost SSE → dead route) is BUG-2272's existing exposure class, documented in the planner comment and routed to **BUG-2601** (delta-sync doesn't recover collection renames).
- **Item move** (no `?item=`): **retarget** the pane to the moved item via the existing drill machinery — preserves the master pathname by construction. The same-slug noop edge self-heals via SSE adoption, which now also refreshes the collection object: new `refreshCollectionIfMoved` (embedded-only, gen-fenced + write-time semantic recheck) at all three adoption sites (SSE, incremental, full-refresh) — fixes stale-schema rendering for remote moves too (codex R1/R2).
- **Malformed URLs**: ignore — the hostile-input unit test caught a `decodeURIComponent` crash pre-ship.

The controller's `handlePaneNavigateAway` behavior is byte-identical for the collection host (comment-only diff there). Pre-existing semantic-fencing gaps at other collection write sites are filed as **BUG-2602** with the class analysis.

## Test plan

- `planFullPageNavigateAway` unit table (both real emit shapes verbatim; encoded slugs; trailing slash; malformed/empty/foreign-origin inputs).
- E2E: move the pane item to another collection from the docked pane on the full-page host — asserts the pathname never leaves the master route and `?item=` retargets. **Mutation-verified against a control binary with the old wiring: fails with the master abandoned, the reported bug verbatim.**
- Gates: `svelte-check` 0 errors · vitest 33/33 (planner) + full suite green pre-amend · `go test ./...` exit 0 · `make lint` 0 issues · web build OK.
- Codex: R1 FINDINGS (2 P1s — one accepted as existing exposure + filed, one folded in), R2 FINDINGS (semantic fence, full-refresh gap, non-embedded mixed state — fixed/filed per disposition), R3 CLEAN (fresh angle: drill depth/ownership arithmetic).

Closes BUG-2178.

https://claude.ai/code/session_018qREYgDd6Ag1X1SDmqhyFM