### PR TITLE
fix(oauth): keep zero-workspace consent authorizable via the wildcard path (BUG-2303)

### DIFF
--- a/internal/server/handlers_oauth.go
+++ b/internal/server/handlers_oauth.go
@@ -1426,7 +1426,6 @@ button:disabled { opacity: 0.5; cursor: not-allowed; }
 button.primary:hover:not(:disabled) { background: #1e54d4; }
 .footer { margin-top: 2em; font-size: .85em; color: #888; }
 .footer a { color: inherit; }
-.no-ws { color: #b00; }
 .allow-helper {
   color: #b00; font-size: .85em; margin-top: .35em;
   display: none;
@@ -1490,11 +1489,16 @@ button.primary:hover:not(:disabled) { background: #1e54d4; }
 
   <fieldset>
     <legend>Which workspaces</legend>
+    {{/* The wildcard radio renders even with zero memberships — the server
+         accepts a zero-workspace "all" consent (parseConsentPayload wildcard
+         path), and hiding it dead-ended those users on a permanently disabled
+         Authorize button (BUG-2303). Force-checked in that case: it is the
+         only option, and an unchecked radio group would re-disable the button. */}}
+    <label class="access-row">
+      <input type="radio" name="workspace_access" value="all" id="access-all"{{if or .DefaultWildcard (not .Workspaces)}} checked{{end}}>
+      <span><strong>All my workspaces</strong><span class="desc">— includes workspaces you join or create later.</span></span>
+    </label>
     {{if .Workspaces}}
-      <label class="access-row">
-        <input type="radio" name="workspace_access" value="all" id="access-all"{{if .DefaultWildcard}} checked{{end}}>
-        <span><strong>All my workspaces</strong><span class="desc">— includes workspaces you join or create later.</span></span>
-      </label>
       <label class="access-row">
         <input type="radio" name="workspace_access" value="specific" id="access-specific"{{if not .DefaultWildcard}} checked{{end}}>
         <span><strong>Only specific workspaces</strong><span class="desc">— you'll pick them next.</span></span>
@@ -1523,7 +1527,7 @@ button.primary:hover:not(:disabled) { background: #1e54d4; }
         asking again. Pick "Only specific workspaces" to restrict.
       </div>
     {{else}}
-      <p class="no-ws">You are not a member of any workspaces yet. Create or join one to authorize this app.</p>
+      <p class="field-helper">You don't have any workspaces yet — with workspace creation allowed below, {{.ClientName}} can create your first one.</p>
     {{end}}
   </fieldset>
 
@@ -1609,9 +1613,10 @@ button.primary:hover:not(:disabled) { background: #1e54d4; }
     });
   }
 
-  // Initial paint.
+  // Initial paint. The access-all radio always renders (BUG-2303), so the
+  // missing-radio branch is defensive: if a template regression removes it
+  // again, fail closed (disabled) rather than half-initialized.
   if (!accessAll) {
-    // No workspaces at all — leave Authorize disabled.
     allowBtn.disabled = true;
   } else {
     refresh();

--- a/internal/server/handlers_oauth_test.go
+++ b/internal/server/handlers_oauth_test.go
@@ -1077,16 +1077,21 @@ func TestConsent_RendersUserWorkspaces(t *testing.T) {
 	}
 }
 
-// TestConsent_NoWorkspaces_ShowsEmptyState confirms the consent UI
-// renders cleanly for a user with zero workspace memberships. The
-// Allow button stays disabled (server-side validation enforces this
-// regardless of JS state).
+// TestConsent_NoWorkspaces_WildcardStaysAuthorizable confirms the
+// consent UI keeps the wildcard path open for a user with zero
+// workspace memberships (BUG-2303). The server accepts a zero-workspace
+// workspace_access=all consent (parseConsentPayload's wildcard path
+// skips membership validation), so the template must render the
+// pre-checked "All my workspaces" radio — before the fix the radio was
+// gated on .Workspaces and its absence made the inline script disable
+// Authorize permanently, dead-ending the user. The specific-workspaces
+// radio and picker stay hidden (there is nothing to pick), and the old
+// dead-end copy is replaced by a pointer at workspace creation.
 //
-// In production cloud-mode signup creates a default workspace, so
-// this case is rare — but worth pinning so a future regression
-// (e.g. autoCreateWorkspace failing silently) doesn't leave users
-// with a broken consent screen.
-func TestConsent_NoWorkspaces_ShowsEmptyState(t *testing.T) {
+// Cloud signup auto-creates a workspace on every path, so this state is
+// reached via auto-create failure or a user who deleted/left their only
+// workspace — rare, but it gates the zero-CLI funnel (PLAN-2309).
+func TestConsent_NoWorkspaces_WildcardStaysAuthorizable(t *testing.T) {
 	t.Parallel()
 	srv, _ := oauthEnabledTestServer(t)
 	_, sessionToken := loginTestUser(t, srv)
@@ -1109,9 +1114,98 @@ func TestConsent_NoWorkspaces_ShowsEmptyState(t *testing.T) {
 		t.Fatalf("expected 200, got %d (body: %s)", rr.Code, rr.Body.String())
 	}
 	body := rr.Body.String()
-	// The empty-state message must mention how to recover.
-	if !strings.Contains(body, "not a member of any workspaces") {
-		t.Errorf("expected empty-state message; got body: %s", body[:min(400, len(body))])
+	// The wildcard radio must render pre-checked: it is the only access
+	// option, and an unchecked radio group would leave Authorize disabled.
+	// Locate the tag then check the attribute inside it, so a benign
+	// attribute insertion or reorder doesn't false-fail.
+	allTag := regexp.MustCompile(`<input[^>]*id="access-all"[^>]*>`).FindString(body)
+	if allTag == "" || !strings.Contains(allTag, "checked") {
+		t.Errorf("wildcard radio must render pre-checked for a zero-workspace user; tag=%q", allTag)
+	}
+	// Nothing to pick — the specific-workspaces alternative stays hidden.
+	if strings.Contains(body, `id="access-specific"`) {
+		t.Errorf("specific-workspaces radio should not render with zero memberships")
+	}
+	if strings.Contains(body, `name="allowed_workspaces"`) {
+		t.Errorf("workspace picker should not render with zero memberships")
+	}
+	// The pre-fix dead-end copy must be gone, replaced by copy that
+	// points at the workspace-creation checkbox as the way forward.
+	if strings.Contains(body, "not a member of any workspaces") {
+		t.Errorf("dead-end empty-state copy should be gone (BUG-2303)")
+	}
+	if !strings.Contains(body, "can create your first one") {
+		t.Errorf("zero-workspace copy should point at workspace creation")
+	}
+	createTag := regexp.MustCompile(`<input[^>]*name="may_create_workspaces"[^>]*>`).FindString(body)
+	if createTag == "" || !strings.Contains(createTag, "checked") {
+		t.Errorf("may_create_workspaces checkbox must render checked; tag=%q", createTag)
+	}
+}
+
+// TestConsent_ApproveWildcard_ZeroWorkspaces pins the end-to-end path
+// the zero-workspace consent UI posts after BUG-2303: workspace_access=all
+// + may_create_workspaces from a user with no memberships must mint an
+// auth code, and the connection row must carry the wildcard + may-create
+// shape so the resulting token can create the user's first workspace.
+func TestConsent_ApproveWildcard_ZeroWorkspaces(t *testing.T) {
+	t.Parallel()
+	srv, _ := oauthEnabledTestServer(t)
+	user, sessionToken := loginTestUser(t, srv)
+	clientID := registerTestClient(t, srv, "https://app.test/cb")
+	csrfTok := readCSRFFromCookie(t, srv, sessionToken)
+
+	verifier := "verifier-zero-ws-wildcard-quick-brown-fox-1234567"
+	challenge := s256Challenge(verifier)
+	form := url.Values{
+		"client_id":             {clientID},
+		"response_type":         {"code"},
+		"redirect_uri":          {"https://app.test/cb"},
+		"code_challenge":        {challenge},
+		"code_challenge_method": {"S256"},
+		"scope":                 {"pad:read pad:write"},
+		"audience":              {testCanonicalAudience},
+		"state":                 {"zero-ws-wildcard-state"},
+		"decision":              {"approve"},
+		"csrf_token":            {csrfTok},
+		"capability_tier":       {"write"},
+		"connection_name":       {"Claude Code"},
+		"workspace_access":      {"all"},
+		"may_create_workspaces": {"1"},
+	}
+	rr := postFormWithCookie(srv, "/oauth/authorize/decide", form, sessionToken, csrfTok)
+	if rr.Code != http.StatusSeeOther && rr.Code != http.StatusFound {
+		t.Fatalf("decide: expected 303/302, got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+	cbURL, _ := url.Parse(rr.Header().Get("Location"))
+	if cbURL.Query().Get("code") == "" {
+		t.Fatalf("decide redirect missing code: %s", rr.Header().Get("Location"))
+	}
+
+	// Same connection-row assertion strategy as
+	// TestConsent_ApproveWithNewShape: the code hasn't been exchanged,
+	// so query the authorization code's request_id directly.
+	var requestID string
+	row := srv.store.DB().QueryRow(srv.store.D().Rebind(
+		`SELECT request_id FROM oauth_authorization_codes ORDER BY requested_at DESC LIMIT 1`))
+	if err := row.Scan(&requestID); err != nil {
+		t.Fatalf("scan request_id: %v", err)
+	}
+	conn, err := srv.store.GetOAuthConnection(requestID)
+	if err != nil {
+		t.Fatalf("GetOAuthConnection: %v", err)
+	}
+	if conn.UserID != user.ID {
+		t.Errorf("connection.UserID = %q, want %q", conn.UserID, user.ID)
+	}
+	if !conn.AllCurrentWorkspaces {
+		t.Errorf("AllCurrentWorkspaces = false, want true (workspace_access=all)")
+	}
+	if !conn.IncludeFutureWorkspaces {
+		t.Errorf("IncludeFutureWorkspaces = false, want true (workspace_access=all)")
+	}
+	if !conn.MayCreateWorkspaces {
+		t.Errorf("MayCreateWorkspaces = false, want true (checkbox checked)")
 	}
 }
 


### PR DESCRIPTION
## Root cause

The consent template gated the entire workspace fieldset on `.Workspaces` being non-empty. For a user with zero memberships no `workspace_access` radio rendered at all, so the inline script's initial paint hit the missing-radio branch and permanently disabled Authorize — a hard dead end. The server was never the blocker: `parseConsentPayload`'s wildcard path accepts a zero-workspace `workspace_access=all` consent with no membership validation, and `may_create_workspaces` defaults on.

Zero-workspace users are rarer than the bug body claimed (all three cloud signup paths auto-create a workspace; the state is reached via auto-create failure or deleting/leaving your only workspace — severity re-rated on the item), but the state is a real dead end and gates the zero-CLI funnel (PLAN-2309): the fixed page is what lets an MCP client mint a token that can create the user's first workspace.

## Change

- Render the "All my workspaces" radio unconditionally; force-checked when memberships are zero (it is the only option — an unchecked radio group would re-disable the button).
- Keep the "Only specific workspaces" radio + picker gated on `.Workspaces` (nothing to pick).
- Replace the dead-end red copy with helper copy pointing at the workspace-creation checkbox; drop the now-unused `.no-ws` CSS.
- Keep the JS missing-radio branch as a fail-closed guard (comment updated).

Template-only; no server logic changed.

## Tests

- `TestConsent_NoWorkspaces_ShowsEmptyState` (which pinned the buggy dead-end) rewritten as `TestConsent_NoWorkspaces_WildcardStaysAuthorizable`: pre-checked wildcard radio, no specific radio/picker, dead-end copy gone, creation checkbox checked. Assertions locate the `<input>` tag then check attributes inside it (Codex round-2 finding: attribute-order brittleness).
- New `TestConsent_ApproveWildcard_ZeroWorkspaces`: new-shape approve (`workspace_access=all` + `may_create_workspaces`) from a zero-workspace user mints a code and the connection row carries AllCurrent + IncludeFuture + MayCreate.

## Verification

- Negative control: render test against the pre-fix template (via `git show HEAD~1:`) fails on exactly the fixed behaviors; approve test passes pre-fix, confirming the bug was UI-only.
- Browser leg (JS behavior Go tests can't see): rendered the real handler output for a zero-workspace user (control + fixed), drove both in Playwright. Control: Authorize disabled, no radio, form posts NO `workspace_access`. Fixed: Authorize enabled, radio checked, form posts `workspace_access=all` + `may_create_workspaces=1`, zero JS errors.
- `go test ./...` exit 0; `make lint` 0 issues; Codex rounds R1 CLEAN, R2 one P2 (fixed), R3 confirm CLEAN. `make test-pg` result to follow on BUG-2303.