### PR TITLE
fix(web): heal collection renames missed by SSE — sync-pass route reconcile + localIndex retag (BUG-2601)

### DIFF
--- a/web/e2e/bug-2601-sse-rename-retag.spec.ts
+++ b/web/e2e/bug-2601-sse-rename-retag.spec.ts
@@ -1,0 +1,48 @@
+import { expect } from '@playwright/test';
+import { test } from './fixtures';
+
+/**
+ * BUG-2601 (retag half) — the LIVE SSE rename path. BUG-2272 re-targets
+ * the route, but cached localIndex rows keep the OLD `collection_slug`
+ * (rows are only re-stamped when the item itself changes, and a rename
+ * touches no items), so the healed route rendered an EMPTY board while
+ * the sidebar still counted the items. Discovered by this spec's
+ * pre-fix run during BUG-2601; fixed by `localIndex.retagCollection`
+ * called from the workspace layout's global `collection_updated`
+ * subscriber. The sibling spec (bug-2601-sync-rename-heal) covers the
+ * missed-SSE path, which retags at the sync-heal site instead.
+ */
+test('BUG-2601: live SSE rename re-targets the route AND the board still renders its items', async ({ page, request, fixture }) => {
+	const auth = { Authorization: `Bearer ${fixture.apiToken}` };
+	const slug = `b2601p-${Date.now().toString(36)}`;
+	const wsResp = await request.post('/api/v1/workspaces', {
+		headers: auth,
+		data: { name: 'BUG-2601 probe', slug, template: 'startup' },
+	});
+	expect(wsResp.ok(), await wsResp.text()).toBeTruthy();
+	const ws = (await wsResp.json()) as { slug: string };
+	try {
+		const itemResp = await request.post(`/api/v1/workspaces/${ws.slug}/collections/tasks/items`, {
+			headers: auth,
+			data: { title: 'probe item' },
+		});
+		expect(itemResp.ok()).toBeTruthy();
+
+		await page.goto(`/${fixture.adminUsername}/${ws.slug}/tasks`);
+		await expect(page.getByText('probe item').first()).toBeVisible();
+
+		const renameResp = await request.patch(`/api/v1/workspaces/${ws.slug}/collections/tasks`, {
+			headers: auth,
+			data: { name: 'Chores' },
+		});
+		expect(renameResp.ok()).toBeTruthy();
+		const renamed = (await renameResp.json()) as { slug: string };
+
+		await page.waitForURL((u) => new URL(u).pathname.endsWith(`/${renamed.slug}`), {
+			timeout: 10_000,
+		});
+		await expect(page.getByText('probe item').first()).toBeVisible({ timeout: 5000 });
+	} finally {
+		await request.delete(`/api/v1/workspaces/${ws.slug}`, { headers: auth }).catch(() => {});
+	}
+});

--- a/web/e2e/bug-2601-sse-rename-retag.spec.ts
+++ b/web/e2e/bug-2601-sse-rename-retag.spec.ts
@@ -14,7 +14,10 @@ import { test } from './fixtures';
  */
 test('BUG-2601: live SSE rename re-targets the route AND the board still renders its items', async ({ page, request, fixture }) => {
 	const auth = { Authorization: `Bearer ${fixture.apiToken}` };
-	const slug = `b2601p-${Date.now().toString(36)}`;
+	// Worker-unique: desktop + mobile projects run this spec in
+	// parallel, and Date.now() alone can collide across workers
+	// (codex round 1 P2).
+	const slug = `b2601p-${test.info().workerIndex}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
 	const wsResp = await request.post('/api/v1/workspaces', {
 		headers: auth,
 		data: { name: 'BUG-2601 probe', slug, template: 'startup' },

--- a/web/e2e/bug-2601-sync-rename-heal.spec.ts
+++ b/web/e2e/bug-2601-sync-rename-heal.spec.ts
@@ -39,7 +39,10 @@ test('BUG-2601: a missed collection-rename SSE is healed by the next sync pass',
 	try {
 		// Own workspace — the shared suite workspace carries cross-spec SSE
 		// and mutation traffic that could mask or confound the strand.
-		const slug = `b2601-${Date.now().toString(36)}`;
+		// Worker-unique: desktop + mobile projects run this spec in
+		// parallel, and Date.now() alone can collide across workers
+		// (codex round 1 P2).
+		const slug = `b2601-${test.info().workerIndex}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
 		createdSlug = slug;
 		const wsResp = await request.post('/api/v1/workspaces', {
 			headers: auth,

--- a/web/e2e/bug-2601-sync-rename-heal.spec.ts
+++ b/web/e2e/bug-2601-sync-rename-heal.spec.ts
@@ -89,6 +89,11 @@ test('BUG-2601: a missed collection-rename SSE is healed by the next sync pass',
 			document.dispatchEvent(new Event('visibilitychange'));
 		});
 		await page.waitForTimeout(2200);
+		// Still stranded INSIDE the hidden window: pins the heal to the
+		// RESUME signal specifically — a broken implementation healing on
+		// the hidden event or a free-running timer fails here (codex
+		// round 7 P2).
+		expect(new URL(page.url()).pathname.endsWith('/tasks')).toBeTruthy();
 		await page.evaluate(() => {
 			Object.defineProperty(document, 'hidden', { configurable: true, get: () => false });
 			document.dispatchEvent(new Event('visibilitychange'));
@@ -163,6 +168,9 @@ test('BUG-2601: a missed rename heals the full-page item route too', async ({
 			document.dispatchEvent(new Event('visibilitychange'));
 		});
 		await page.waitForTimeout(2200);
+		// Still stranded inside the hidden window (same vacuity pin as the
+		// list-route leg above).
+		expect(new URL(page.url()).pathname).toContain('/tasks/');
 		await page.evaluate(() => {
 			Object.defineProperty(document, 'hidden', { configurable: true, get: () => false });
 			document.dispatchEvent(new Event('visibilitychange'));

--- a/web/e2e/bug-2601-sync-rename-heal.spec.ts
+++ b/web/e2e/bug-2601-sync-rename-heal.spec.ts
@@ -1,0 +1,108 @@
+import { expect } from '@playwright/test';
+import { test } from './fixtures';
+
+/**
+ * BUG-2601 — a collection rename only travels over the `collection_updated`
+ * SSE. A client that misses that event (replay-buffer gap, disconnect) is
+ * stranded on the dead slug: delta-sync reconciles ITEM changes only, and
+ * `/changes` says nothing about renames — a rename-only gap even reports
+ * `caught_up` — so every slug-keyed fetch 404s until a manual navigation.
+ *
+ * The fix reconciles the route slug against the live collections list by
+ * STABLE collection id on every sync pass (resolveSyncRenameTarget +
+ * reconcileRouteCollectionSlug in the collection route), mirroring the
+ * BUG-2272 SSE/reorder-404 heals.
+ *
+ * The missed-SSE condition is made DETERMINISTIC here by aborting the
+ * page's `/api/v1/events` requests — the EventSource never connects, so
+ * the rename event cannot arrive by the primary path.
+ *
+ * Vacuity guard: before triggering the sync pass, the spec asserts the
+ * route is STILL on the dead slug after a settle — proving no other
+ * mechanism (an SSE leak, a router side-effect) healed it, so the heal
+ * observed afterwards is attributable to the sync pass. The heal is then
+ * triggered by a real tab-resume (hidden → 2s+ → visible), the exact
+ * signal the sync service acts on in production.
+ *
+ * The rename-detection oracle is server-attested: the PATCH response's
+ * regenerated slug is what the URL must converge to.
+ */
+
+test('BUG-2601: a missed collection-rename SSE is healed by the next sync pass', async ({
+	page,
+	request,
+	fixture,
+}) => {
+	const auth = { Authorization: `Bearer ${fixture.apiToken}` };
+	let createdSlug: string | null = null;
+
+	try {
+		// Own workspace — the shared suite workspace carries cross-spec SSE
+		// and mutation traffic that could mask or confound the strand.
+		const slug = `b2601-${Date.now().toString(36)}`;
+		createdSlug = slug;
+		const wsResp = await request.post('/api/v1/workspaces', {
+			headers: auth,
+			data: { name: 'BUG-2601 heal', slug, template: 'startup' },
+		});
+		expect(wsResp.ok(), await wsResp.text()).toBeTruthy();
+		const ws = (await wsResp.json()) as { slug: string };
+		createdSlug = ws.slug;
+
+		// A probe item so "the page still works on the new slug" is
+		// observable content, not just a URL.
+		const itemResp = await request.post(
+			`/api/v1/workspaces/${ws.slug}/collections/tasks/items`,
+			{ headers: auth, data: { title: 'rename-heal probe' } },
+		);
+		expect(itemResp.ok(), await itemResp.text()).toBeTruthy();
+
+		// THE MISSED-SSE CONDITION: the EventSource never connects, so the
+		// collection_updated rename event cannot arrive on the primary path.
+		await page.route('**/api/v1/events**', (route) => route.abort());
+
+		await page.goto(`/${fixture.adminUsername}/${ws.slug}/tasks`);
+		await expect(page.getByText('rename-heal probe').first()).toBeVisible();
+
+		// Rename server-side. A name change regenerates the slug
+		// (store.UpdateCollection), which is what kills the route's slug.
+		const renameResp = await request.patch(
+			`/api/v1/workspaces/${ws.slug}/collections/tasks`,
+			{ headers: auth, data: { name: 'Chores' } },
+		);
+		expect(renameResp.ok(), await renameResp.text()).toBeTruthy();
+		const renamed = (await renameResp.json()) as { slug: string };
+		expect(renamed.slug).not.toBe('tasks');
+
+		// VACUITY GUARD: with SSE dead, nothing re-targets the route on its
+		// own. If this fails, the "heal" below would not be the sync pass's.
+		await page.waitForTimeout(700);
+		expect(new URL(page.url()).pathname.endsWith('/tasks')).toBeTruthy();
+
+		// Tab-resume: hidden long enough to clear the sync service's
+		// MIN_ABSENCE_MS (2s), then visible — the production trigger.
+		await page.evaluate(() => {
+			Object.defineProperty(document, 'hidden', { configurable: true, get: () => true });
+			document.dispatchEvent(new Event('visibilitychange'));
+		});
+		await page.waitForTimeout(2200);
+		await page.evaluate(() => {
+			Object.defineProperty(document, 'hidden', { configurable: true, get: () => false });
+			document.dispatchEvent(new Event('visibilitychange'));
+		});
+
+		// THE HEAL: the sync pass reconciles the dead slug by stable id and
+		// re-targets the route to the server-attested new slug.
+		await page.waitForURL((u) => new URL(u).pathname.endsWith(`/${renamed.slug}`), {
+			timeout: 15_000,
+		});
+		// And the page is functional there — the probe item renders.
+		await expect(page.getByText('rename-heal probe').first()).toBeVisible();
+	} finally {
+		if (createdSlug) {
+			await request
+				.delete(`/api/v1/workspaces/${createdSlug}`, { headers: auth })
+				.catch(() => {});
+		}
+	}
+});

--- a/web/e2e/bug-2601-sync-rename-heal.spec.ts
+++ b/web/e2e/bug-2601-sync-rename-heal.spec.ts
@@ -109,3 +109,75 @@ test('BUG-2601: a missed collection-rename SSE is healed by the next sync pass',
 		}
 	}
 });
+
+// The bug body's own example is the FULL-PAGE ITEM route
+// (`/user/ws/OLDSLUG/item-slug`) — its collection segment goes just as
+// dead, and a reload 404s the collection fetch. ItemDetail's
+// reconcileCollectionSegment heals it on the same sync pass (codex
+// round 3 finding 1); the goto is replaceState, so the dead URL also
+// leaves the history.
+test('BUG-2601: a missed rename heals the full-page item route too', async ({
+	page,
+	request,
+	fixture,
+}) => {
+	const auth = { Authorization: `Bearer ${fixture.apiToken}` };
+	let createdSlug: string | null = null;
+
+	try {
+		const slug = `b2601i-${test.info().workerIndex}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
+		createdSlug = slug;
+		const wsResp = await request.post('/api/v1/workspaces', {
+			headers: auth,
+			data: { name: 'BUG-2601 item heal', slug, template: 'startup' },
+		});
+		expect(wsResp.ok(), await wsResp.text()).toBeTruthy();
+		const ws = (await wsResp.json()) as { slug: string };
+		createdSlug = ws.slug;
+
+		const itemResp = await request.post(
+			`/api/v1/workspaces/${ws.slug}/collections/tasks/items`,
+			{ headers: auth, data: { title: 'item-route heal probe' } },
+		);
+		expect(itemResp.ok(), await itemResp.text()).toBeTruthy();
+		const item = (await itemResp.json()) as { slug: string };
+
+		await page.route('**/api/v1/events**', (route) => route.abort());
+		await page.goto(`/${fixture.adminUsername}/${ws.slug}/tasks/${item.slug}`);
+		await expect(page.getByText('item-route heal probe').first()).toBeVisible();
+
+		const renameResp = await request.patch(
+			`/api/v1/workspaces/${ws.slug}/collections/tasks`,
+			{ headers: auth, data: { name: 'Chores' } },
+		);
+		expect(renameResp.ok(), await renameResp.text()).toBeTruthy();
+		const renamed = (await renameResp.json()) as { slug: string };
+		expect(renamed.slug).not.toBe('tasks');
+
+		// Vacuity guard: still on the dead segment before the sync pass.
+		await page.waitForTimeout(700);
+		expect(new URL(page.url()).pathname).toContain('/tasks/');
+
+		await page.evaluate(() => {
+			Object.defineProperty(document, 'hidden', { configurable: true, get: () => true });
+			document.dispatchEvent(new Event('visibilitychange'));
+		});
+		await page.waitForTimeout(2200);
+		await page.evaluate(() => {
+			Object.defineProperty(document, 'hidden', { configurable: true, get: () => false });
+			document.dispatchEvent(new Event('visibilitychange'));
+		});
+
+		await page.waitForURL(
+			(u) => new URL(u).pathname.endsWith(`/${renamed.slug}/${item.slug}`),
+			{ timeout: 15_000 },
+		);
+		await expect(page.getByText('item-route heal probe').first()).toBeVisible();
+	} finally {
+		if (createdSlug) {
+			await request
+				.delete(`/api/v1/workspaces/${createdSlug}`, { headers: auth })
+				.catch(() => {});
+		}
+	}
+});

--- a/web/src/lib/collections/renameNav.test.ts
+++ b/web/src/lib/collections/renameNav.test.ts
@@ -110,6 +110,7 @@ describe('resolveRenameNavTarget', () => {
 function syncInput(over: Partial<SyncRenameInput>): SyncRenameInput {
 	return {
 		collectionId: 'id-1',
+		loadedCollectionSlug: 'old',
 		routeSlug: 'old',
 		collections: [{ id: 'id-1', slug: 'new' }],
 		renameNav: null,
@@ -148,6 +149,20 @@ describe('resolveSyncRenameTarget', () => {
 	it('skips a DELETED collection — dead slug, id absent from the list', () => {
 		expect(
 			resolveSyncRenameTarget(syncInput({ collections: [{ id: 'id-9', slug: 'other' }] })),
+		).toBeNull();
+	});
+
+	it('skips a mid-navigation foreign snapshot — loaded slug belongs to the PREVIOUS route', () => {
+		// Navigating A→B while A's snapshot is still loaded: B's route must
+		// not be steered by A's id, even when B's slug is dead (codex P1).
+		expect(
+			resolveSyncRenameTarget(
+				syncInput({
+					loadedCollectionSlug: 'a',
+					routeSlug: 'b-dead',
+					collections: [{ id: 'id-1', slug: 'a' }],
+				}),
+			),
 		).toBeNull();
 	});
 

--- a/web/src/lib/collections/renameNav.test.ts
+++ b/web/src/lib/collections/renameNav.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { resolveRenameNavTarget, type RenameNavInput } from './renameNav';
+import {
+	resolveRenameNavTarget,
+	resolveSyncRenameTarget,
+	type RenameNavInput,
+	type SyncRenameInput,
+} from './renameNav';
 
 // Convenience builder — every field is named so each scenario reads as the
 // concrete route/snapshot/tracker state at the moment the SSE event arrives.
@@ -97,5 +102,72 @@ describe('resolveRenameNavTarget', () => {
 				input({ eventOldSlug: 'z', eventNewSlug: 'q', loadedCollectionSlug: 'a', routeSlug: 'a', renameNav: null }),
 			),
 		).toBeNull();
+	});
+});
+
+// --- Sync-side reconciliation (BUG-2601) ---
+
+function syncInput(over: Partial<SyncRenameInput>): SyncRenameInput {
+	return {
+		collectionId: 'id-1',
+		routeSlug: 'old',
+		collections: [{ id: 'id-1', slug: 'new' }],
+		renameNav: null,
+		...over,
+	};
+}
+
+describe('resolveSyncRenameTarget', () => {
+	it('heals a dead route slug whose stable id lives under a new slug (the missed-SSE strand)', () => {
+		expect(resolveSyncRenameTarget(syncInput({}))).toBe('new');
+	});
+
+	it('does nothing when the route slug is still live (no rename happened)', () => {
+		expect(
+			resolveSyncRenameTarget(
+				syncInput({ collections: [{ id: 'id-1', slug: 'old' }] }),
+			),
+		).toBeNull();
+	});
+
+	it('skips a REUSED slug — the route slug is live but names a different collection', () => {
+		// Ambiguous: our collection renamed away AND another took the slug.
+		// Yanking the user off a live route is worse; the SSE path owns it.
+		expect(
+			resolveSyncRenameTarget(
+				syncInput({
+					collections: [
+						{ id: 'id-2', slug: 'old' },
+						{ id: 'id-1', slug: 'new' },
+					],
+				}),
+			),
+		).toBeNull();
+	});
+
+	it('skips a DELETED collection — dead slug, id absent from the list', () => {
+		expect(
+			resolveSyncRenameTarget(syncInput({ collections: [{ id: 'id-9', slug: 'other' }] })),
+		).toBeNull();
+	});
+
+	it('skips when nothing is loaded (no stable id to reconcile by)', () => {
+		expect(resolveSyncRenameTarget(syncInput({ collectionId: null }))).toBeNull();
+	});
+
+	it('skips while a rename goto to a DIFFERENT slug is in flight (no dueling navigations)', () => {
+		expect(resolveSyncRenameTarget(syncInput({ renameNav: 'elsewhere' }))).toBeNull();
+	});
+
+	it('still heals in the continuation window (renameNav caught up to the route)', () => {
+		// We goto'd `old` earlier (renameNav === routeSlug), then a rename we
+		// never saw moved it again — same admit rule as the SSE helper's
+		// continuation case.
+		expect(resolveSyncRenameTarget(syncInput({ renameNav: 'old' }))).toBe('new');
+	});
+
+	it('empty collections list: treated as dead-slug + missing id → skip (not a heal)', () => {
+		// A failed/empty list must never navigate anywhere.
+		expect(resolveSyncRenameTarget(syncInput({ collections: [] }))).toBeNull();
 	});
 });

--- a/web/src/lib/collections/renameNav.ts
+++ b/web/src/lib/collections/renameNav.ts
@@ -71,3 +71,53 @@ export function resolveRenameNavTarget(input: RenameNavInput): string | null {
 	if (eventOldSlug === believed && eventNewSlug !== believed) return eventNewSlug;
 	return null;
 }
+
+// --- Sync-side rename reconciliation (BUG-2601) ---
+//
+// The SSE handler above is the PRIMARY rename recovery, but it only fires if
+// the `collection_updated` event actually arrives. A client that missed it
+// (replay-buffer gap, disconnect) is stranded: delta-sync reconciles ITEM
+// changes only, `/changes` says nothing about collection renames — a
+// rename-only gap even reports `caught_up` — and every slug-keyed fetch on
+// the route 404s until a manual navigation. This helper is the pure decision
+// for the sync-pass fallback: given the freshly fetched collections list,
+// heal the route iff its slug is DEAD and the loaded collection's STABLE id
+// maps to a live entry under a new slug.
+
+export interface SyncRenameInput {
+	/** The mounted collection snapshot's stable id (null → nothing loaded, skip). */
+	collectionId: string | null;
+	/** The live route slug (`page.params.collection`). */
+	routeSlug: string;
+	/** The freshly fetched workspace collections (only id + slug are read). */
+	collections: Array<{ id: string; slug: string }>;
+	/** The synchronous pending-rename tracker (slug we last goto'd), or null. */
+	renameNav: string | null;
+}
+
+/**
+ * Decide the slug a sync pass should heal the route to, or `null` to skip.
+ *
+ * Deliberately conservative — it only acts when every one of these holds:
+ *
+ *   - Something is loaded (`collectionId` non-null): a cold route with no
+ *     snapshot has no stable id to reconcile by; nothing to do client-side.
+ *   - No rename goto is already in flight (`renameNav` null or caught up to
+ *     the route): the SSE / reorder-404 paths own their own navigation, and
+ *     dueling gotos must not race.
+ *   - The route slug is ABSENT from the live list: a present slug is either
+ *     our own collection (nothing to heal) or a REUSED slug now naming a
+ *     different collection — ambiguous, and yanking the user off a live
+ *     route is worse than leaving the SSE path to sort it out.
+ *   - The stable id maps to a live entry with a different slug: a missing id
+ *     means DELETED, not renamed — the not-found flows own that.
+ */
+export function resolveSyncRenameTarget(input: SyncRenameInput): string | null {
+	const { collectionId, routeSlug, collections, renameNav } = input;
+	if (!collectionId) return null;
+	if (renameNav !== null && renameNav !== routeSlug) return null;
+	if (collections.some((c) => c.slug === routeSlug)) return null;
+	const fresh = collections.find((c) => c.id === collectionId);
+	if (!fresh || fresh.slug === routeSlug) return null;
+	return fresh.slug;
+}

--- a/web/src/lib/collections/renameNav.ts
+++ b/web/src/lib/collections/renameNav.ts
@@ -87,6 +87,14 @@ export function resolveRenameNavTarget(input: RenameNavInput): string | null {
 export interface SyncRenameInput {
 	/** The mounted collection snapshot's stable id (null → nothing loaded, skip). */
 	collectionId: string | null;
+	/**
+	 * The mounted collection snapshot's slug. Must match `routeSlug` for a
+	 * heal to fire — during an A→B navigation the snapshot briefly still
+	 * belongs to A, and reconciling B's route against A's id would goto A,
+	 * hijacking the navigation (codex round 1 P1; the SSE helper's
+	 * loadedCollectionSlug gate guards the same window).
+	 */
+	loadedCollectionSlug: string;
 	/** The live route slug (`page.params.collection`). */
 	routeSlug: string;
 	/** The freshly fetched workspace collections (only id + slug are read). */
@@ -102,6 +110,10 @@ export interface SyncRenameInput {
  *
  *   - Something is loaded (`collectionId` non-null): a cold route with no
  *     snapshot has no stable id to reconcile by; nothing to do client-side.
+ *   - The snapshot belongs to THIS route (`loadedCollectionSlug ===
+ *     routeSlug`): mid-navigation the snapshot is briefly the previous
+ *     collection's, and its id must not steer this route. The legitimate
+ *     missed-SSE strand satisfies this — both slugs are the dead one.
  *   - No rename goto is already in flight (`renameNav` null or caught up to
  *     the route): the SSE / reorder-404 paths own their own navigation, and
  *     dueling gotos must not race.
@@ -113,8 +125,9 @@ export interface SyncRenameInput {
  *     means DELETED, not renamed — the not-found flows own that.
  */
 export function resolveSyncRenameTarget(input: SyncRenameInput): string | null {
-	const { collectionId, routeSlug, collections, renameNav } = input;
+	const { collectionId, loadedCollectionSlug, routeSlug, collections, renameNav } = input;
 	if (!collectionId) return null;
+	if (loadedCollectionSlug !== routeSlug) return null;
 	if (renameNav !== null && renameNav !== routeSlug) return null;
 	if (collections.some((c) => c.slug === routeSlug)) return null;
 	const fresh = collections.find((c) => c.id === collectionId);

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -7,6 +7,7 @@
 	import { collectionStore } from '$lib/stores/collections.svelte';
 	import { pushEscapeHandler, ESCAPE_PRIORITY } from '$lib/stores/escapeStack';
 	import { localIndex } from '$lib/stores/localIndex.svelte';
+	import { resolveSyncRenameTarget } from '$lib/collections/renameNav';
 	import { syncService } from '$lib/services/sync.svelte';
 	import { sseService } from '$lib/services/sse.svelte';
 	import Editor from '$lib/components/editor/Editor.svelte';
@@ -367,6 +368,64 @@
 			renameOverride = null;
 		}
 	});
+
+	/**
+	 * BUG-2601: sync-pass fallback for a MISSED collection-rename SSE on
+	 * the FULL-PAGE item route — the bug body's own example
+	 * (`/user/ws/OLDSLUG/item-slug`). The SSE branch above is the primary
+	 * recovery; when the event never arrived, the route keeps the dead
+	 * collection segment and a reload 404s the collection fetch. Same
+	 * pure decision as the collection page's sync heal; on a hit, mirror
+	 * the SSE branch exactly: renameOverride bridge, row retag, sidebar
+	 * refresh, replaceState goto preserving item slug + query. Full-page
+	 * only — callers gate on `!embedded`.
+	 */
+	async function reconcileCollectionSegment() {
+		const ws = wsSlug;
+		const routeColl = collSlug;
+		const itemRef = itemSlug;
+		const snap = collection;
+		const believed = effectiveCollSlug;
+		if (!ws || !routeColl || !itemRef || !snap) return;
+		try {
+			const list = await api.collections.list(ws);
+			// Route or snapshot moved while the list was in flight.
+			if (ws !== wsSlug || routeColl !== collSlug || itemRef !== itemSlug) return;
+			if (!collection || collection.id !== snap.id) return;
+			const target = resolveSyncRenameTarget({
+				collectionId: snap.id,
+				loadedCollectionSlug: snap.slug,
+				// `believed` folds in a pending renameOverride: mid-goto the
+				// target slug is live in the list, so the helper skips —
+				// same no-dueling property renameNav gives the list route.
+				routeSlug: believed,
+				collections: list,
+				renameNav: null,
+			});
+			if (!target) return;
+			renameOverride = { collectionId: snap.id, from: routeColl, to: target };
+			// The missed SSE also means the layout's global retag never ran.
+			localIndex.retagCollection(ws, snap.id, target, authStore.user?.id ?? null);
+			void collectionStore.loadCollections(ws);
+			const collGen = ++collectionGen;
+			const fresh = list.find((c) => c.id === snap.id);
+			if (fresh && collGen === collectionGen) {
+				collection = fresh;
+			}
+			const search = typeof window !== 'undefined' ? window.location.search : '';
+			goto(`/${username}/${ws}/${target}/${itemRef}${search}`, {
+				replaceState: true,
+				noScroll: true,
+			}).catch(() => {
+				// A failed/cancelled navigation must not leave the override
+				// bridging to a URL we never reached (same posture as the
+				// list route's renameNav reset).
+				if (renameOverride?.to === target) renameOverride = null;
+			});
+		} catch {
+			// Best-effort heal — the next sync pass retries.
+		}
+	}
 
 	// ── Scroll position restoration readiness (BUG-1425) ───────────────
 	// The route wrapper (`[slug]/+page.svelte`) owns `createScrollRestoration`
@@ -1283,6 +1342,16 @@
 			if (!itemMatchesRef) return;
 			// Item writes below are ordered via the dedicated itemGen (round 9),
 			// bumped per-refetch; a switch is caught by the item-id check.
+
+			// BUG-2601: reconcile the FULL-PAGE route's collection segment
+			// BEFORE the caught_up short-circuit — renames don't appear in
+			// /changes, so a rename-only gap reports caught_up and the dead
+			// segment would never heal (the bug body's own example is this
+			// route). Embedded panes retarget via item.collection_slug
+			// (PLAN-2154), never a goto.
+			if (!embedded) {
+				await reconcileCollectionSegment();
+			}
 
 			if (result.type === 'caught_up') return;
 

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -410,8 +410,13 @@
 				renameNav: null,
 			});
 			if (!target) return;
-			const bridge = { collectionId: snap.id, from: routeColl, to: target };
-			renameOverride = bridge;
+			renameOverride = { collectionId: snap.id, from: routeColl, to: target };
+			// Read back the installed value: `renameOverride` is $state, so
+			// the assignment wraps the literal in a reactive proxy — the raw
+			// object would never compare === to it (codex round 5 P2). The
+			// proxy identity is stable across reads, so this is the token
+			// the rejection cleanup below can safely compare.
+			const bridge = renameOverride;
 			// The missed SSE also means the layout's global retag never ran.
 			localIndex.retagCollection(ws, snap.id, target, authStore.user?.id ?? null);
 			void collectionStore.loadCollections(ws);

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { page } from '$app/state';
+	import { page, navigating } from '$app/state';
 	import { tick, onMount, onDestroy, untrack } from 'svelte';
 	import { api, PadApiError, isUpdateConflictError, type ImportURLResponse } from '$lib/api/client';
 	import { confirmOpenChildrenOrThrow, isOpenChildrenError } from '$lib/items/openChildrenError';
@@ -410,6 +410,9 @@
 				renameNav: null,
 			});
 			if (!target) return;
+			// A user navigation already in flight would be ABORTED by our
+			// goto (route props lag until commit — codex round 7 P1).
+			if (navigating.to) return;
 			renameOverride = { collectionId: snap.id, from: routeColl, to: target };
 			// Read back the installed value: `renameOverride` is $state, so
 			// the assignment wraps the literal in a reactive proxy — the raw

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -387,9 +387,16 @@
 		const snap = collection;
 		const believed = effectiveCollSlug;
 		if (!ws || !routeColl || !itemRef || !snap) return;
+		// Fence captured BEFORE the await (codex round 4 P1 — bumping after
+		// it made the check tautological): a newer collection write during
+		// the list fetch supersedes this heal's snapshot refresh.
+		const collGen = ++collectionGen;
 		try {
 			const list = await api.collections.list(ws);
-			// Route or snapshot moved while the list was in flight.
+			// Persistent-host discipline: the instance may have unmounted
+			// (destroyed), the route or snapshot may have moved — a stale
+			// continuation must not retag, refresh, or goto (round 4 P1).
+			if (destroyed) return;
 			if (ws !== wsSlug || routeColl !== collSlug || itemRef !== itemSlug) return;
 			if (!collection || collection.id !== snap.id) return;
 			const target = resolveSyncRenameTarget({
@@ -403,11 +410,11 @@
 				renameNav: null,
 			});
 			if (!target) return;
-			renameOverride = { collectionId: snap.id, from: routeColl, to: target };
+			const bridge = { collectionId: snap.id, from: routeColl, to: target };
+			renameOverride = bridge;
 			// The missed SSE also means the layout's global retag never ran.
 			localIndex.retagCollection(ws, snap.id, target, authStore.user?.id ?? null);
 			void collectionStore.loadCollections(ws);
-			const collGen = ++collectionGen;
 			const fresh = list.find((c) => c.id === snap.id);
 			if (fresh && collGen === collectionGen) {
 				collection = fresh;
@@ -418,9 +425,10 @@
 				noScroll: true,
 			}).catch(() => {
 				// A failed/cancelled navigation must not leave the override
-				// bridging to a URL we never reached (same posture as the
-				// list route's renameNav reset).
-				if (renameOverride?.to === target) renameOverride = null;
+				// bridging to a URL we never reached. Identity compare (this
+				// heal's own bridge object, round 4 P2) so a cancelled older
+				// navigation can't clear a newer bridge to the same slug.
+				if (renameOverride === bridge) renameOverride = null;
 			});
 		} catch {
 			// Best-effort heal — the next sync pass retries.

--- a/web/src/lib/stores/localIndex.svelte.ts
+++ b/web/src/lib/stores/localIndex.svelte.ts
@@ -140,6 +140,15 @@ class WorkspaceState {
 	// could regress a newer slug. Latest-wins per collection id; not
 	// persisted (the window it guards is within a single session).
 	pendingRetags = new Map<string, string>();
+
+	// The auth identity the pendingRetags were recorded under (codex round 2
+	// P2): a cold state survives the bootstrap user-mismatch reset (that
+	// check deliberately skips cold states), so a rename recorded pre-
+	// bootstrap by user A could otherwise be applied to user B's warm cache
+	// after a console logout + login. Recorded at retag time from the
+	// caller's auth view; the warm-hydrate apply discards the intent when
+	// it doesn't match the bootstrapping user.
+	pendingRetagsUser: string | null = null;
 }
 
 // Outer map: reactive (SvelteMap) so consumers re-render when a fresh
@@ -544,9 +553,14 @@ export const localIndex = {
 					// delta below will ever re-stamp them. Applied then
 					// cleared — a one-shot repair for the pre-hydration
 					// window. Runs before the search rebuild so the
-					// rebuilt index sees the live slugs.
-					for (const [collectionId, newSlug] of state.pendingRetags) {
-						applyRetag(ws, state, collectionId, newSlug);
+					// rebuilt index sees the live slugs. Intent recorded
+					// under a DIFFERENT auth identity is discarded, not
+					// applied (codex round 2 P2 — a cold state survives
+					// the logout path, so this is the cross-user gate).
+					if (state.pendingRetagsUser === userId) {
+						for (const [collectionId, newSlug] of state.pendingRetags) {
+							applyRetag(ws, state, collectionId, newSlug);
+						}
 					}
 					state.pendingRetags.clear();
 					// Rebuild the search index from the warm snapshot so
@@ -1140,12 +1154,20 @@ export const localIndex = {
 	 * the rename. Idempotent; rows already carrying `newSlug` are
 	 * skipped. Mirrors the upsert write-through (search + IDB).
 	 */
-	retagCollection(ws: string, collectionId: string, newSlug: string): void {
+	retagCollection(ws: string, collectionId: string, newSlug: string, userId: string | null): void {
 		// ensureState (not a bare get): a rename that lands before this
 		// workspace ever hydrated must still be RECORDED, or the warm
 		// hydrate restores rows under the dead slug with nothing left to
 		// fix them (codex round 1 P1 — see pendingRetags on WorkspaceState).
 		const state = ensureState(ws);
+		// Ownership stamp (codex round 2 P2): intent recorded under a
+		// different auth identity is dropped, never mixed — a cold state
+		// survives logout, and user A's rename intent must not steer user
+		// B's warm cache. Same-user re-records just refresh the stamp.
+		if (state.pendingRetagsUser !== userId) {
+			state.pendingRetags.clear();
+			state.pendingRetagsUser = userId;
+		}
 		state.pendingRetags.set(collectionId, newSlug);
 		applyRetag(ws, state, collectionId, newSlug);
 	},

--- a/web/src/lib/stores/localIndex.svelte.ts
+++ b/web/src/lib/stores/localIndex.svelte.ts
@@ -557,7 +557,9 @@ export const localIndex = {
 					// under a DIFFERENT auth identity is discarded, not
 					// applied (codex round 2 P2 — a cold state survives
 					// the logout path, so this is the cross-user gate).
-					if (state.pendingRetagsUser === userId) {
+					// A null stamp = recorded before this session's auth
+					// resolved — same session, so apply (codex round 7 P2).
+					if (state.pendingRetagsUser === null || state.pendingRetagsUser === userId) {
 						for (const [collectionId, newSlug] of state.pendingRetags) {
 							applyRetag(ws, state, collectionId, newSlug);
 						}
@@ -1161,11 +1163,17 @@ export const localIndex = {
 		// fix them (codex round 1 P1 — see pendingRetags on WorkspaceState).
 		const state = ensureState(ws);
 		// Ownership stamp (codex round 2 P2): intent recorded under a
-		// different auth identity is dropped, never mixed — a cold state
-		// survives logout, and user A's rename intent must not steer user
-		// B's warm cache. Same-user re-records just refresh the stamp.
+		// DIFFERENT resolved auth identity is dropped, never mixed — a cold
+		// state survives logout, and user A's rename intent must not steer
+		// user B's warm cache. A null stamp means "recorded before this
+		// session's auth resolved" and is ADOPTED by the first resolved
+		// identity rather than discarded (codex round 7 P2): the SSE
+		// connection that delivered the event was authenticated as this
+		// session's user, so the intent is theirs.
 		if (state.pendingRetagsUser !== userId) {
-			state.pendingRetags.clear();
+			if (state.pendingRetagsUser !== null) {
+				state.pendingRetags.clear();
+			}
 			state.pendingRetagsUser = userId;
 		}
 		state.pendingRetags.set(collectionId, newSlug);

--- a/web/src/lib/stores/localIndex.svelte.ts
+++ b/web/src/lib/stores/localIndex.svelte.ts
@@ -1074,6 +1074,36 @@ export const localIndex = {
 	},
 
 	/**
+	 * Re-stamp `collection_slug` on every cached row of a collection
+	 * after a RENAME (BUG-2601). Rows are ingested with the slug the
+	 * server denormalized at fetch time; a rename changes the slug
+	 * without touching the items, so no `/items-changes` delta will
+	 * ever re-ingest them — `getByCollection(newSlug)` returns [] and
+	 * every rename-healed route (SSE and sync-pass alike) renders an
+	 * empty board while the sidebar still counts the items.
+	 *
+	 * Matches by STABLE `collection_id` — never by old slug, which a
+	 * different collection may have re-owned by the time we hear about
+	 * the rename. Idempotent; rows already carrying `newSlug` are
+	 * skipped. Mirrors the upsert write-through (search + IDB).
+	 */
+	retagCollection(ws: string, collectionId: string, newSlug: string): void {
+		const state = workspaces.get(ws);
+		if (!state) return;
+		const retagged: ItemIndexRow[] = [];
+		for (const [id, row] of state.items.entries()) {
+			if (row.collection_id !== collectionId || row.collection_slug === newSlug) continue;
+			const next = { ...row, collection_slug: newSlug };
+			state.items.set(id, next);
+			localSearch.upsert(ws, next);
+			retagged.push(next);
+		}
+		if (retagged.length > 0) {
+			persistUpserts(state.userId, ws, retagged).catch(() => undefined);
+		}
+	},
+
+	/**
 	 * Look up an item by EITHER id OR slug within a workspace. Used
 	 * by the 403-purge path so a 403 on `/items/{slug}` can resolve
 	 * the slug to the in-RAM id (the SvelteMap is keyed by id) and

--- a/web/src/lib/stores/localIndex.svelte.ts
+++ b/web/src/lib/stores/localIndex.svelte.ts
@@ -127,6 +127,19 @@ class WorkspaceState {
 	// recomputes the set from scratch, so a re-upgrade clears it. Not persisted;
 	// the race it guards is within a single session.
 	fencedIds = new Set<string>();
+
+	// `pendingRetags` records collection renames (collection id → latest new
+	// slug) seen via `retagCollection` (BUG-2601). A rename event can land
+	// BEFORE this workspace's rows exist (SSE connects fast; bootstrap's warm
+	// IDB hydrate hasn't run), and the hydrated rows then arrive carrying the
+	// dead slug with nothing left to re-stamp them — a rename touches no
+	// items, so no delta ever will. The warm-hydrate path applies (then
+	// clears) these; authoritative server snapshots (cold /items-index,
+	// projection resync) clear them unapplied — server rows already carry the
+	// live slug, and re-applying a recorded rename over fresher server truth
+	// could regress a newer slug. Latest-wins per collection id; not
+	// persisted (the window it guards is within a single session).
+	pendingRetags = new Map<string, string>();
 }
 
 // Outer map: reactive (SvelteMap) so consumers re-render when a fresh
@@ -147,6 +160,27 @@ function ensureState(ws: string): WorkspaceState {
 		workspaces.set(ws, state);
 	}
 	return state;
+}
+
+/**
+ * Re-stamp `collection_slug` on every cached row of one collection
+ * (BUG-2601). Matches by STABLE `collection_id` — never by old slug,
+ * which a different collection may have re-owned by the time we hear
+ * about the rename. Idempotent; rows already carrying `newSlug` are
+ * skipped. Mirrors the `upsert` write-through (search + IDB).
+ */
+function applyRetag(ws: string, state: WorkspaceState, collectionId: string, newSlug: string): void {
+	const retagged: ItemIndexRow[] = [];
+	for (const [id, row] of state.items.entries()) {
+		if (row.collection_id !== collectionId || row.collection_slug === newSlug) continue;
+		const next = { ...row, collection_slug: newSlug };
+		state.items.set(id, next);
+		localSearch.upsert(ws, next);
+		retagged.push(next);
+	}
+	if (retagged.length > 0) {
+		persistUpserts(state.userId, ws, retagged).catch(() => undefined);
+	}
 }
 
 /**
@@ -344,6 +378,10 @@ async function resyncProjectionScope(ws: string, state: WorkspaceState): Promise
 		}
 		state.cursor = resp.cursor;
 		state.bootstrapState = 'ready';
+		// Server rows carry the live collection slug — a rename recorded
+		// pre-snapshot is already reflected, and re-applying it later could
+		// regress a newer slug (BUG-2601).
+		state.pendingRetags.clear();
 		// NOTE: deliberately do NOT clear pendingResync here. This resync only
 		// installs the authoritative snapshot and pins the cursor for replay;
 		// the post-snapshot mutations aren't caught up until the caller's delta
@@ -500,6 +538,17 @@ export const localIndex = {
 					if (cursorAsNum(cached.cursor) > cursorAsNum(state.cursor)) {
 						state.cursor = cached.cursor;
 					}
+					// Apply renames recorded BEFORE these rows existed
+					// (BUG-2601): hydrated rows carry the slug they were
+					// cached under, and a rename touches no items, so no
+					// delta below will ever re-stamp them. Applied then
+					// cleared — a one-shot repair for the pre-hydration
+					// window. Runs before the search rebuild so the
+					// rebuilt index sees the live slugs.
+					for (const [collectionId, newSlug] of state.pendingRetags) {
+						applyRetag(ws, state, collectionId, newSlug);
+					}
+					state.pendingRetags.clear();
 					// Rebuild the search index from the warm snapshot so
 					// the collection page and CommandPalette can serve
 					// results immediately on first paint — TASK-1363.
@@ -652,6 +701,10 @@ export const localIndex = {
 					state.bootstrapState = 'ready';
 					// Cold path is a full snapshot — nothing pending.
 					state.pendingResync = false;
+					// Server rows carry the live collection slug — drop any
+					// rename recorded pre-snapshot rather than re-applying
+					// it over fresher server truth (BUG-2601).
+					state.pendingRetags.clear();
 					// Rebuild the search index from the cold snapshot —
 					// TASK-1363. Bulk rebuild is cheaper than N per-row
 					// upserts and keeps the index hot for the first
@@ -1088,19 +1141,13 @@ export const localIndex = {
 	 * skipped. Mirrors the upsert write-through (search + IDB).
 	 */
 	retagCollection(ws: string, collectionId: string, newSlug: string): void {
-		const state = workspaces.get(ws);
-		if (!state) return;
-		const retagged: ItemIndexRow[] = [];
-		for (const [id, row] of state.items.entries()) {
-			if (row.collection_id !== collectionId || row.collection_slug === newSlug) continue;
-			const next = { ...row, collection_slug: newSlug };
-			state.items.set(id, next);
-			localSearch.upsert(ws, next);
-			retagged.push(next);
-		}
-		if (retagged.length > 0) {
-			persistUpserts(state.userId, ws, retagged).catch(() => undefined);
-		}
+		// ensureState (not a bare get): a rename that lands before this
+		// workspace ever hydrated must still be RECORDED, or the warm
+		// hydrate restores rows under the dead slug with nothing left to
+		// fix them (codex round 1 P1 — see pendingRetags on WorkspaceState).
+		const state = ensureState(ws);
+		state.pendingRetags.set(collectionId, newSlug);
+		applyRetag(ws, state, collectionId, newSlug);
 	},
 
 	/**

--- a/web/src/routes/[username]/[workspace]/+layout.svelte
+++ b/web/src/routes/[username]/[workspace]/+layout.svelte
@@ -9,6 +9,7 @@
 	import { api } from '$lib/api/client';
 	import { toastStore, quietExternalToasts } from '$lib/stores/toast.svelte';
 	import { starredStore } from '$lib/stores/starred.svelte';
+	import { localIndex } from '$lib/stores/localIndex.svelte';
 	import { titleStore } from '$lib/stores/title.svelte';
 	import { authStore } from '$lib/stores/auth.svelte';
 	import { registerWorkspaceTools, type WebMcpHandle } from '$lib/webmcp/register';
@@ -224,6 +225,26 @@
 
 				case 'item_restored': {
 					collectionStore.loadCollections(wsSlug);
+					break;
+				}
+
+				case 'collection_updated': {
+					// BUG-2601: a RENAME changes the collection's slug without
+					// touching its items, so no /items-changes delta ever
+					// re-stamps the cached rows' `collection_slug` — after any
+					// rename, `getByCollection(newSlug)` returns [] and the
+					// renamed collection renders an empty board (sidebar still
+					// counts the items) until each item is individually
+					// modified. Retag the rows by STABLE collection id here,
+					// on the workspace-global subscriber, so the heal applies
+					// regardless of which route is open when the event lands.
+					// Route re-targeting stays with the per-page handlers
+					// (collection page + ItemDetail); this case owns the DATA.
+					if (event.new_slug && event.collection_id) {
+						localIndex.retagCollection(wsSlug, event.collection_id, event.new_slug);
+						// Sidebar/pickers pick up the new slug + counts.
+						collectionStore.loadCollections(wsSlug);
+					}
 					break;
 				}
 			}

--- a/web/src/routes/[username]/[workspace]/+layout.svelte
+++ b/web/src/routes/[username]/[workspace]/+layout.svelte
@@ -242,9 +242,11 @@
 					// (collection page + ItemDetail); this case owns the DATA.
 					if (event.new_slug && event.collection_id) {
 						localIndex.retagCollection(wsSlug, event.collection_id, event.new_slug);
-						// Sidebar/pickers pick up the new slug + counts.
-						collectionStore.loadCollections(wsSlug);
 					}
+					// Refresh sidebar/pickers for EVERY collection_updated —
+					// icon / name / sort-order changes matter to the nav
+					// even without a rename (codex round 1 P2).
+					collectionStore.loadCollections(wsSlug);
 					break;
 				}
 			}

--- a/web/src/routes/[username]/[workspace]/+layout.svelte
+++ b/web/src/routes/[username]/[workspace]/+layout.svelte
@@ -241,7 +241,12 @@
 					// Route re-targeting stays with the per-page handlers
 					// (collection page + ItemDetail); this case owns the DATA.
 					if (event.new_slug && event.collection_id) {
-						localIndex.retagCollection(wsSlug, event.collection_id, event.new_slug);
+						localIndex.retagCollection(
+							wsSlug,
+							event.collection_id,
+							event.new_slug,
+							authStore.user?.id ?? null,
+						);
 					}
 					// Refresh sidebar/pickers for EVERY collection_updated —
 					// icon / name / sort-order changes matter to the nav

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -1024,6 +1024,7 @@
 		const ws = wsSlug;
 		const slug = collSlug;
 		const baseId = collection?.id ?? null;
+		const baseSlug = collection?.slug ?? '';
 		if (!ws || !slug || !baseId) return;
 		try {
 			const list = await api.collections.list(ws);
@@ -1033,6 +1034,7 @@
 			if (collection?.id !== baseId) return;
 			const target = resolveSyncRenameTarget({
 				collectionId: baseId,
+				loadedCollectionSlug: baseSlug,
 				routeSlug: slug,
 				collections: list,
 				renameNav,
@@ -1048,7 +1050,14 @@
 			// side-effect as the SSE + reorder-404 rename paths.
 			void collectionStore.loadCollections(ws);
 			const search = typeof window !== 'undefined' ? window.location.search : '';
-			void goto(`/${username}/${ws}/${target}${search}`);
+			goto(`/${username}/${ws}/${target}${search}`).catch(() => {
+				// A cancelled/failed navigation (navigate-away guard, a
+				// racing nav) must not leave renameNav pointing at a slug
+				// we never reached — a poisoned tracker would veto every
+				// future sync heal (codex round 1 P2). Reset only if it is
+				// still ours; a newer rename may have re-aimed it.
+				if (renameNav === target) renameNav = null;
+			});
 		} catch {
 			// Best-effort heal — the next sync pass retries.
 		}

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -1045,7 +1045,7 @@
 			// ran — re-stamp the cached rows' collection_slug by stable id
 			// or the healed route renders an empty board (the rows still
 			// carry the dead slug and no item delta will ever fix them).
-			localIndex.retagCollection(ws, baseId, target);
+			localIndex.retagCollection(ws, baseId, target, authStore.user?.id ?? null);
 			// Refresh the sidebar/pickers off the dead slug too — same
 			// side-effect as the SSE + reorder-404 rename paths.
 			void collectionStore.loadCollections(ws);

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { page } from '$app/state';
+	import { page, navigating } from '$app/state';
 	import { browser } from '$app/environment';
 	import { goto, beforeNavigate, afterNavigate } from '$app/navigation';
 	import { api, PadApiError, isPlanLimitError, planLimitMessage, isConflictOrNotFound } from '$lib/api/client';
@@ -1040,6 +1040,11 @@
 				renameNav,
 			});
 			if (!target) return;
+			// A user navigation already in flight would be ABORTED by our
+			// goto — route props don't update until commit, so the checks
+			// above can't see it (codex round 7 P1). Yield; the next sync
+			// pass retries if the strand persists.
+			if (navigating.to) return;
 			renameNav = target;
 			// The missed SSE also means the layout's global retag never
 			// ran — re-stamp the cached rows' collection_slug by stable id
@@ -1050,7 +1055,10 @@
 			// side-effect as the SSE + reorder-404 rename paths.
 			void collectionStore.loadCollections(ws);
 			const search = typeof window !== 'undefined' ? window.location.search : '';
-			goto(`/${username}/${ws}/${target}${search}`).catch(() => {
+			// replaceState: the healed-away slug is DEAD — Back must not
+			// return to a URL that 404s (codex round 7 P2; the item-route
+			// healer already replaces).
+			goto(`/${username}/${ws}/${target}${search}`, { replaceState: true }).catch(() => {
 				// A cancelled/failed navigation (navigate-away guard, a
 				// racing nav) must not leave renameNav pointing at a slug
 				// we never reached — a poisoned tracker would veto every

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -6,7 +6,7 @@
 	import type { BulkItemsRequest, Collection, Item, PaneTarget, QuickAction, View, ViewConfig } from '$lib/types';
 	import { parseSettings, parseFields, parseSchema, parseTags, getStatusOptions, itemUrlId, formatItemRef } from '$lib/types';
 	import { plansProgressToMap, fetchCollectionProgress } from '$lib/collections/progressMerge';
-	import { resolveRenameNavTarget } from '$lib/collections/renameNav';
+	import { resolveRenameNavTarget, resolveSyncRenameTarget } from '$lib/collections/renameNav';
 	import BoardView from '$lib/components/collections/BoardView.svelte';
 	import ListView from '$lib/components/collections/ListView.svelte';
 	import TableView from '$lib/components/collections/TableView.svelte';
@@ -976,6 +976,13 @@
 				// it is so the next tab-resume retries.
 				syncService.markSynced();
 			}
+			// BUG-2601: renames only travel over the collection_updated
+			// SSE; a missed event strands this route on the dead slug and
+			// NOTHING above notices — /changes says nothing about
+			// collection renames, so a rename-only gap even reports
+			// caught_up. Reconcile the route slug by stable id on every
+			// sync pass (caught_up included, for exactly that reason).
+			await reconcileRouteCollectionSlug();
 		});
 	});
 
@@ -996,6 +1003,56 @@
 		// (snapshot.capture fires on navigate-away; the helper's $effect
 		// teardown cancels any in-flight RAF).
 	});
+
+	/**
+	 * BUG-2601: sync-pass fallback for a MISSED collection-rename SSE.
+	 * The collection_updated handler is the primary rename recovery, but
+	 * it only fires if the event arrives; a client that missed it
+	 * (replay-buffer gap, disconnect) keeps a dead route slug — reloads
+	 * and slug-keyed fetches 404 until a manual navigation. After each
+	 * sync pass, reconcile the route slug against the live collections
+	 * list by STABLE id and re-target exactly like the SSE path —
+	 * mirroring the BUG-2272 reorder-404 heal and sharing the same
+	 * `renameNav` intent tracker. The decision itself is the pure
+	 * `resolveSyncRenameTarget` (renameNav.ts) — see its doc for the
+	 * deliberate skips (reused slug, deleted id, rename already in
+	 * flight, nothing loaded).
+	 */
+	async function reconcileRouteCollectionSlug() {
+		// Capture identity BEFORE the await (no {#key} on this route — a
+		// switch mid-await must not navigate the wrong collection).
+		const ws = wsSlug;
+		const slug = collSlug;
+		const baseId = collection?.id ?? null;
+		if (!ws || !slug || !baseId) return;
+		try {
+			const list = await api.collections.list(ws);
+			// Route or snapshot moved while the list was in flight — a
+			// heal computed for the old identity must not fire now.
+			if (ws !== wsSlug || slug !== collSlug) return;
+			if (collection?.id !== baseId) return;
+			const target = resolveSyncRenameTarget({
+				collectionId: baseId,
+				routeSlug: slug,
+				collections: list,
+				renameNav,
+			});
+			if (!target) return;
+			renameNav = target;
+			// The missed SSE also means the layout's global retag never
+			// ran — re-stamp the cached rows' collection_slug by stable id
+			// or the healed route renders an empty board (the rows still
+			// carry the dead slug and no item delta will ever fix them).
+			localIndex.retagCollection(ws, baseId, target);
+			// Refresh the sidebar/pickers off the dead slug too — same
+			// side-effect as the SSE + reorder-404 rename paths.
+			void collectionStore.loadCollections(ws);
+			const search = typeof window !== 'undefined' ? window.location.search : '';
+			void goto(`/${username}/${ws}/${target}${search}`);
+		} catch {
+			// Best-effort heal — the next sync pass retries.
+		}
+	}
 
 	/**
 	 * Drive a /items-changes delta apply against the local store. Used


### PR DESCRIPTION
## Root cause

A collection rename changes the slug without touching items, so nothing item-shaped ever re-announces it. Three stranding layers fell out of that one fact:

1. **List route:** delta-sync catch-up covers item changes only, and `/changes` says nothing about renames — a rename-only gap even reports `caught_up`. A client that missed the `collection_updated` SSE kept the dead route slug; slug-keyed fetches 404'd until a manual navigation.
2. **Data (discovered by this fix's own e2e — present on the LIVE SSE path too):** cached `localIndex` rows keep the old `collection_slug` (rows only re-stamp when the item itself changes), so *every* rename-healed route — the existing BUG-2272 SSE heal included — rendered an **empty board** while the sidebar still counted the items.
3. **Full-page item route** (the bug body's own example, `/user/ws/OLDSLUG/item-slug`): same missed-SSE strand, no reconciliation.

## Change

- **Pure decision** `resolveSyncRenameTarget` (renameNav.ts, 9 unit tests): heal iff the route slug is DEAD in the live collections list and the loaded snapshot's stable id maps to a new slug; skips foreign mid-navigation snapshots, reused slugs, deleted ids, in-flight rename gotos, empty lists.
- **List route:** `reconcileRouteCollectionSlug` on every sync pass (`caught_up` included — that silence IS the bug), sharing the `renameNav` tracker; `replaceState` goto; `navigating.to` guard so a heal can never abort an in-flight user navigation; goto-rejection resets the tracker.
- **Item route:** `reconcileCollectionSegment` in ItemDetail (full-page only), mirroring its SSE branch — `renameOverride` bridge, `replaceState`+`noScroll` goto preserving item slug + query, pre-await `collectionGen` fence, `destroyed` guard, `$state`-proxy-identity cleanup token.
- **Rows:** `localIndex.retagCollection(ws, collectionId, newSlug, userId)` re-stamps rows by stable collection id (search + IDB write-through, `upsert` pattern), called from a new workspace-layout global `collection_updated` subscriber (live SSE, any route) and from both sync heals (missed SSE). Renames arriving before hydration are recorded as `pendingRetags` and applied after the warm IDB hydrate — stamped with the recording user's identity so a cold state surviving logout can't steer the next user's cache (null stamp = pre-auth-resolution, adopted by the session's first resolved identity); authoritative server snapshots clear them unapplied.

## Verification

- Three e2e specs, each **verified failing on a control build** of the unfixed sources: missed-SSE list route (aborted `/events` + strand asserted *inside* the hidden window, so a heal firing on the wrong signal fails), missed-SSE item route, live-SSE retag (route heals AND board renders — the leg that exposed layer 2, screenshot ground truth: sidebar `Chores (1)`, board "No chores yet").
- 17 renameNav unit tests; full vitest 1638 passed; svelte-check 0 errors; 6/6 e2e across desktop+mobile projects. Web-only diff.

## Review

8 codex rounds. Notables: the tautological post-await fence, the `$state` raw-vs-proxy identity trap, the navigating-abort hazard. Declined with recorded reasoning: retag O(rows) scan (rare human event, `removeByCollection` precedent), duplicate `loadCollections` (layout-wide pattern, seq-guarded store), IDB fire-and-forget persist race (pre-existing pattern shared with `upsert()` — filed as **BUG-2609** with a fix sketch).