### PR TITLE
fix(web): route ItemDetail collection writes through a semantic adopt gate (BUG-2602)

### DIFF
--- a/web/e2e/bug-2602-collection-adopt-race.spec.ts
+++ b/web/e2e/bug-2602-collection-adopt-race.spec.ts
@@ -1,0 +1,170 @@
+import { expect, type APIRequestContext } from '@playwright/test';
+import { test, type SuiteFixture } from './fixtures';
+
+/**
+ * BUG-2602 — ItemDetail's collection writes raced under fences that
+ * ordered STARTS, and loadData's cross-collection escape hatch admitted
+ * any generation-stale write that fetched a different collection. A
+ * loadData continuation spanning a cross-collection MOVE could therefore
+ * restore the SOURCE collection over the freshly adopted TARGET — the
+ * live item (itemGen-fenced) kept the move, so the pane rendered the
+ * item against the WRONG collection's schema.
+ *
+ * Deterministic construction (route-hold, same technique as
+ * pane-collection-migration-race.spec.ts):
+ *
+ *   1. An embedded pane is opened via a cross-collection `?item=` — the
+ *      route is the suite workspace's `tasks`, the item lives in SRC —
+ *      which sends loadData down its realColl branch: `GET
+ *      /collections/<src>`. That GET is HELD by route interception.
+ *   2. While held, the item is MOVED src → tgt via the API. The pane's
+ *      live SSE delivers item_updated; refreshCollectionIfMoved fetches
+ *      TGT (not held) and adopts it — the pane renders TGT's schema
+ *      (its marker field label).
+ *   3. The held SRC fetch is released. The continuation is generation-
+ *      stale AND cross-collection: the old hatch admitted it (pane
+ *      reverts to SRC's schema — the control build fails here); the
+ *      adoptCollection semantic veto rejects it (live item's
+ *      collection_id is TGT).
+ *
+ * The observable is the fields panel, which renders the COLLECTION
+ * schema's field labels — src and tgt carry distinct marker fields.
+ */
+
+function authHeaders(fixture: SuiteFixture) {
+	return { Authorization: `Bearer ${fixture.apiToken}` };
+}
+
+async function seedCollection(
+	fixture: SuiteFixture,
+	request: APIRequestContext,
+	name: string,
+	prefix: string,
+	markerLabel: string,
+) {
+	const schema = JSON.stringify({
+		fields: [
+			{ key: 'status', type: 'select', options: ['open', 'done'], default: 'open' },
+			{ key: 'marker', label: markerLabel, type: 'text' },
+		],
+	});
+	const resp = await request.post(`/api/v1/workspaces/${fixture.workspaceSlug}/collections`, {
+		headers: authHeaders(fixture),
+		data: { name, prefix, schema },
+	});
+	if (!resp.ok()) throw new Error(`collection create failed (${resp.status()}): ${await resp.text()}`);
+	return (await resp.json()) as { id: string; slug: string };
+}
+
+test('BUG-2602: a held cross-collection load released after a move cannot revert the adopted target collection', async ({
+	page,
+	fixture,
+	request,
+}, testInfo) => {
+	test.skip(
+		testInfo.project.name !== 'desktop-chromium',
+		'switch-safety is viewport-agnostic; one project is enough',
+	);
+	test.setTimeout(60_000);
+
+	const uniq = `${test.info().workerIndex}${Date.now().toString(36)}`;
+	const src = await seedCollection(fixture, request, `b2602src${uniq}`, 'BSRC', 'SrcMarkerField');
+	const tgt = await seedCollection(fixture, request, `b2602tgt${uniq}`, 'BTGT', 'TgtMarkerField');
+
+	const itemResp = await request.post(
+		`/api/v1/workspaces/${fixture.workspaceSlug}/collections/${src.slug}/items`,
+		{
+			headers: authHeaders(fixture),
+			data: { title: `b2602 race probe ${uniq}`, fields: JSON.stringify({ status: 'open' }), content: '' },
+		},
+	);
+	expect(itemResp.ok(), await itemResp.text()).toBeTruthy();
+	const item = (await itemResp.json()) as { id: string; slug: string };
+
+	// A warm-up item IN the route collection: refreshCollectionIfMoved
+	// (and the real-world race) requires the pane to already hold a
+	// collection snapshot — a cold pane with `collection === null` bails
+	// out of the move handling before the fetch this spec gates on.
+	const warmResp = await request.post(
+		`/api/v1/workspaces/${fixture.workspaceSlug}/collections/tasks/items`,
+		{
+			headers: authHeaders(fixture),
+			data: { title: `b2602 warmup ${uniq}`, fields: JSON.stringify({}), content: '' },
+		},
+	);
+	expect(warmResp.ok(), await warmResp.text()).toBeTruthy();
+	const warm = (await warmResp.json()) as { slug: string };
+
+	// Hold loadData's realColl fetch for SRC. GETs only; the move below
+	// must still be able to touch anything else.
+	let releaseSrc = () => {};
+	const srcGate = new Promise<void>((resolve) => {
+		releaseSrc = resolve;
+	});
+	let heldCount = 0;
+	await page.route(`**/api/v1/workspaces/${fixture.workspaceSlug}/collections/${src.slug}`, async (route) => {
+		if (route.request().method() !== 'GET') {
+			await route.continue();
+			return;
+		}
+		heldCount++;
+		await srcGate;
+		await route.continue();
+	});
+
+	// Warm the pane on the route collection's own item so `collection`
+	// is loaded (tasks), then switch to the cross-collection SRC item —
+	// loadData(src item) takes the realColl branch (the held GET) while
+	// the pane keeps its persistent (no {#key}) state.
+	await page.goto(`/${fixture.adminUsername}/${fixture.workspaceSlug}/tasks?item=${warm.slug}`);
+	const pane = page.locator('.item-pane');
+	await expect(pane.locator('.title', { hasText: /b2602 warmup/ })).toBeVisible();
+
+	// The switch: same route, new ?item= — no remount.
+	// NOTE: from here until release, the pane shows a loading state, so
+	// the mid-hold oracles below are network-level.
+	await page.goto(`/${fixture.adminUsername}/${fixture.workspaceSlug}/tasks?item=${item.slug}`);
+
+	// PRECONDITION: the hold actually caught loadData's realColl fetch —
+	// otherwise the race below is vacuous. Reaching that fetch also
+	// means loadData already adopted the item (item precedes collection
+	// in loadData), so the SSE move handling below has an item to match.
+	await expect.poll(() => heldCount, { timeout: 15_000 }).toBeGreaterThan(0);
+
+	// The MOVE, while the SRC fetch is held. The pane's live SSE delivers
+	// item_updated and the pane refetches the item by slug — that
+	// response (carrying the moved item) is the deterministic "move
+	// processed" oracle; the pane UI can't serve as one while loading.
+	// (On this freshly-switched pane `collection` is still null, so
+	// refreshCollectionIfMoved's `!collection` guard self-skips — the
+	// convergence happens on the veto path after release.)
+	const paneRefetch = page.waitForResponse(
+		(r) =>
+			r.url().endsWith(`/items/${item.slug}`) &&
+			r.request().method() === 'GET' &&
+			r.ok(),
+		{ timeout: 15_000 },
+	);
+	const moveResp = await request.post(
+		`/api/v1/workspaces/${fixture.workspaceSlug}/items/${item.slug}/move`,
+		{ headers: authHeaders(fixture), data: { target_collection: tgt.slug, source: 'cli' } },
+	);
+	expect(moveResp.ok(), await moveResp.text()).toBeTruthy();
+	await paneRefetch;
+	// Small settle: the item adopt happens just after the response body
+	// is consumed.
+	await page.waitForTimeout(300);
+
+	// RELEASE the stale SRC continuation — the race under test. loadData
+	// then completes and the pane renders with whichever collection won.
+	releaseSrc();
+
+	// The veto must hold: the pane renders the live item's collection
+	// (TGT). On the control build the released continuation wins via the
+	// old escape hatch and SrcMarkerField renders instead.
+	await expect(pane.locator('.title', { hasText: /b2602 race probe/ })).toBeVisible({
+		timeout: 15_000,
+	});
+	await expect(pane.getByText('TgtMarkerField')).toBeVisible({ timeout: 10_000 });
+	await expect(pane.getByText('SrcMarkerField')).not.toBeVisible();
+});

--- a/web/e2e/bug-2602-collection-adopt-race.spec.ts
+++ b/web/e2e/bug-2602-collection-adopt-race.spec.ts
@@ -150,7 +150,12 @@ test('BUG-2602: a held cross-collection load released after a move cannot revert
 		{ headers: authHeaders(fixture), data: { target_collection: tgt.slug, source: 'cli' } },
 	);
 	expect(moveResp.ok(), await moveResp.text()).toBeTruthy();
-	await paneRefetch;
+	const refetched = await paneRefetch;
+	// Hard oracle (codex round 1 #4): the refetch the pane consumed must
+	// actually carry the MOVED item — collection_id === tgt.id — or the
+	// race below would be constructed against pre-move data.
+	const refetchedBody = (await refetched.json()) as { collection_id: string };
+	expect(refetchedBody.collection_id).toBe(tgt.id);
 	// Small settle: the item adopt happens just after the response body
 	// is consumed.
 	await page.waitForTimeout(300);

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -264,7 +264,9 @@
 	 * panes converge on the live item's collection (the same policy
 	 * refreshCollectionIfMoved implements for the steady-state case);
 	 * non-embedded masters stay route-authoritative (see the policy note
-	 * on refreshCollectionIfMoved) and simply keep what they show.
+	 * on refreshCollectionIfMoved) and keep what they show — except a
+	 * COLD mount with nothing shown, where the caller surfaces the
+	 * schema-less outcome as a load error rather than a blank pane.
 	 */
 	async function adoptOrConvergeToLiveCollection(
 		fetched: Collection,
@@ -4973,9 +4975,10 @@
 							//   2. On a SAME-collection switch the callback DOES fire,
 							//      but `updated` is that same collection, so assigning it
 							//      is correct; and loadData's collection write
-							//      (`collGen === collectionGen || collection?.id !==
-							//      collData.id`) forces the right collection regardless
-							//      of the collectionGen bump below.
+							//      (adoptCollection — BUG-2602 replaced the old
+							//      gen/id escape hatch) still lands the right
+							//      collection regardless of the collectionGen
+							//      bump below, since the live item agrees with it.
 							// Bump the unified fence so an in-flight stale load/refresh
 							// can't revert this fresh write (Codex). adoptCollection adds
 							// the live-item semantic veto on top (BUG-2602).

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -241,7 +241,10 @@
 	function adoptCollection(fetched: Collection, collGen: number): boolean {
 		const ok = shouldAdoptCollection({
 			fetchedId: fetched.id,
-			liveItemCollectionId: item?.collection_id ?? null,
+			// `|| null`, not `?? null`: an empty-string collection_id (a
+			// malformed row) must read as "no anchor", not as a real id
+			// that vetoes every collection (codex round 3 P2).
+			liveItemCollectionId: item?.collection_id || null,
 			currentCollectionId: collection?.id ?? null,
 			genFresh: collGen === collectionGen,
 		});
@@ -1833,6 +1836,13 @@
 				// Same hatch shape, same fix (BUG-2602) — see above.
 				await adoptOrConvergeToLiveCollection(collData, collGen, myGen);
 				if (myGen !== loadGeneration) return;
+				// Same schema-less surfacing as the realColl branch (codex
+				// round 3): a veto + failed/skipped convergence on a cold
+				// mount must not report a successful load with no fields.
+				if (!collection) {
+					error = 'Failed to load this item’s collection';
+					return;
+				}
 			}
 			// A FROZEN (peeking) instance must NOT write the SINGLETON global stores
 			// the ACTIVE side owns (PLAN-2179 DR-2 / TASK-2181). Both are module
@@ -1852,7 +1862,12 @@
 			// collection-route pane included — it never peeks). The per-instance
 			// `localDirty` shadow (below) resets unconditionally — it's what THIS
 			// instance's own SSE guards read (TASK-2156).
-			if (!peeking) {
+			if (!peeking && myItemGen === itemGen) {
+				// itemGen re-check (codex round 3 P1): the collection adoption
+				// above AWAITS (realColl fetch, possibly the convergence
+				// fallback), and an SSE item write during that window bumps
+				// itemGen — this load's itemData is then stale and must not
+				// claim the singletons with it.
 				collectionStore.setActiveItem(itemData);
 				activeItemOwnedId = itemData.id;
 				editorStore.resetForDoc();

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -8,6 +8,7 @@
 	import { pushEscapeHandler, ESCAPE_PRIORITY } from '$lib/stores/escapeStack';
 	import { localIndex } from '$lib/stores/localIndex.svelte';
 	import { resolveSyncRenameTarget } from '$lib/collections/renameNav';
+	import { shouldAdoptCollection } from '$lib/items/adoptCollection';
 	import { syncService } from '$lib/services/sync.svelte';
 	import { sseService } from '$lib/services/sse.svelte';
 	import Editor from '$lib/components/editor/Editor.svelte';
@@ -224,6 +225,62 @@
 	// Plain counter — not reactive; it only fences writes.
 	let collectionGen = 0;
 
+	/**
+	 * Single write path for the `collection` snapshot (BUG-2602). Every
+	 * assignment routes through here so the SEMANTIC invariant — the pane
+	 * renders the LIVE item's collection — is asserted at write time, not
+	 * left to per-site generation ordering. `shouldAdoptCollection`
+	 * (pure, unit-tested) folds in the generation order for
+	 * same-collection refreshes and the legitimate cross-collection
+	 * correction the old loadData escape hatch existed for, minus its
+	 * defect: a continuation spanning a cross-collection move can no
+	 * longer restore the source collection over the adopted target, and
+	 * a reused-slug fetch that returned a FOREIGN collection is vetoed
+	 * outright. Returns whether the snapshot was adopted.
+	 */
+	function adoptCollection(fetched: Collection, collGen: number): boolean {
+		const ok = shouldAdoptCollection({
+			fetchedId: fetched.id,
+			liveItemCollectionId: item?.collection_id ?? null,
+			currentCollectionId: collection?.id ?? null,
+			genFresh: collGen === collectionGen,
+		});
+		if (ok) collection = fetched;
+		return ok;
+	}
+
+	/**
+	 * loadData's collection adoption + the veto's convergence fallback
+	 * (BUG-2602). When adoptCollection rejects the load's fetched
+	 * collection, the usual cause is a cross-collection MOVE that landed
+	 * while the load was in flight: the live item (itemGen-fenced) is on
+	 * the target, the fetched collection is the pre-move location, and —
+	 * on a freshly (re)mounted pane — `collection` is still null, so
+	 * refreshCollectionIfMoved's `!collection` guard skipped too. Without
+	 * a fallback the veto would leave the pane schema-less. EMBEDDED
+	 * panes converge on the live item's collection (the same policy
+	 * refreshCollectionIfMoved implements for the steady-state case);
+	 * non-embedded masters stay route-authoritative (see the policy note
+	 * on refreshCollectionIfMoved) and simply keep what they show.
+	 */
+	async function adoptOrConvergeToLiveCollection(
+		fetched: Collection,
+		collGen: number,
+		myGen: number,
+	) {
+		if (adoptCollection(fetched, collGen)) return;
+		if (!embedded) return;
+		const liveSlug = item?.collection_slug;
+		if (!liveSlug || liveSlug === fetched.slug) return;
+		try {
+			const liveColl = await api.collections.get(wsSlug, liveSlug);
+			if (myGen !== loadGeneration) return;
+			adoptCollection(liveColl, ++collectionGen);
+		} catch {
+			// Best-effort — the next event / reload catches up.
+		}
+	}
+
 	// UNIFIED item-snapshot generation (BUG-2265 Codex round 9): bumped by EVERY
 	// async operation that assigns `item` from a fetch — loadData's item load,
 	// the SSE item_updated/archived/restored refetches, the onSync refetches,
@@ -424,8 +481,8 @@
 			localIndex.retagCollection(ws, snap.id, target, authStore.user?.id ?? null);
 			void collectionStore.loadCollections(ws);
 			const fresh = list.find((c) => c.id === snap.id);
-			if (fresh && collGen === collectionGen) {
-				collection = fresh;
+			if (fresh) {
+				adoptCollection(fresh, collGen);
 			}
 			const search = typeof window !== 'undefined' ? window.location.search : '';
 			goto(`/${username}/${ws}/${target}/${itemRef}${search}`, {
@@ -1186,13 +1243,15 @@
 				const collGen = ++collectionGen;
 				try {
 					const fresh = await api.collections.get(wsSlug, targetSlug);
-					// Persistent pane host has no {#key} remount — fence the write
-					// against a switch during the fetch (PLAN-2105 discipline):
-					// drop if a newer collection write superseded us or the loaded
-					// collection changed IDENTITY. Compare by stable id, not slug,
-					// so a rename (same id, new slug) still applies (Codex round 9).
-					if (collGen === collectionGen && collection && collection.id === snap.id) {
-						collection = fresh;
+					// Persistent pane host has no {#key} remount — drop if the
+					// loaded collection changed IDENTITY during the fetch (compare
+					// by stable id, not slug, so a rename still applies — Codex
+					// round 9); adoptCollection folds in the generation order AND
+					// the live-item semantic veto, which also covers the fetched
+					// snapshot itself being foreign (a reused targetSlug after a
+					// rename returns a different collection — BUG-2602).
+					if (collection && collection.id === snap.id) {
+						adoptCollection(fresh, collGen);
 					}
 				} catch {
 					// Best-effort — a stale snapshot just means the next save
@@ -1732,14 +1791,16 @@
 				try {
 					const realColl = await api.collections.get(wsSlug, itemData.collection_slug);
 					if (myGen !== loadGeneration) return;
-					// Gate the collection SNAPSHOT on the unified generation so a
-					// newer SSE refresh (bumps collectionGen, not loadGeneration)
-					// isn't reverted by this in-flight load.
-					// Apply when this is the freshest same-collection write OR when it's
-					// a switch to a DIFFERENT collection (a stale refresh for the old
-					// collection must not block loading the new one).
-					if (collGen === collectionGen || collection?.id !== realColl.id)
-						collection = realColl;
+					// adoptOrConvergeToLiveCollection replaces the old escape
+					// hatch (`collGen === collectionGen || collection?.id !==
+					// realColl.id`), which admitted ANY generation-stale
+					// cross-collection write — including a pre-move continuation
+					// restoring the SOURCE collection over the move target
+					// (BUG-2602). The live item (written above, itemGen-fenced)
+					// is the anchor: the legitimate correction still lands, the
+					// stale revert is vetoed, and a vetoed embedded pane
+					// converges on the live item's collection instead.
+					await adoptOrConvergeToLiveCollection(realColl, collGen, myGen);
 				} catch {
 					if (myGen !== loadGeneration) return;
 					// Can't resolve the item's REAL collection. Surface the
@@ -1750,8 +1811,9 @@
 					error = 'Failed to load this item’s collection';
 					return;
 				}
-			} else if (collGen === collectionGen || collection?.id !== collData.id) {
-				collection = collData;
+			} else {
+				// Same hatch shape, same fix (BUG-2602) — see above.
+				await adoptOrConvergeToLiveCollection(collData, collGen, myGen);
 			}
 			// A FROZEN (peeking) instance must NOT write the SINGLETON global stores
 			// the ACTIVE side owns (PLAN-2179 DR-2 / TASK-2181). Both are module
@@ -2973,13 +3035,12 @@
 		const collGen = ++collectionGen;
 		try {
 			const fresh = await api.collections.get(wsSlug, newSlug);
-			if (collGen !== collectionGen) return;
-			// Semantic fence on top of the generation fence: only write while
-			// the LIVE item still agrees this is its collection — a
-			// chained-move burst (X→Y→Z) can leave an older refresh both
-			// newest-started-for-its-slug and wrong (codex round 2 P1).
-			if (item?.collection_slug !== newSlug) return;
-			collection = fresh;
+			// adoptCollection carries BOTH fences this site pioneered
+			// (BUG-2178 codex round 2): generation order for same-collection
+			// refreshes, and the live-item semantic check — now anchored on
+			// stable collection_id rather than slug, so a reused slug can't
+			// satisfy it (BUG-2602).
+			adoptCollection(fresh, collGen);
 		} catch {
 			// Ignore — the next event / reload catches up.
 		}
@@ -4882,9 +4943,9 @@
 							//      collData.id`) forces the right collection regardless
 							//      of the collectionGen bump below.
 							// Bump the unified fence so an in-flight stale load/refresh
-							// can't revert this fresh write (Codex).
-							collectionGen++;
-							collection = updated;
+							// can't revert this fresh write (Codex). adoptCollection adds
+							// the live-item semantic veto on top (BUG-2602).
+							adoptCollection(updated, ++collectionGen);
 						}}
 					/>
 				{/key}
@@ -6038,9 +6099,9 @@
 					return;
 				}
 				// Bump the unified fence so an in-flight stale load/refresh can't
-				// revert this fresh edit-modal write (Codex).
-				collectionGen++;
-				collection = updated;
+				// revert this fresh edit-modal write (Codex). adoptCollection adds
+				// the live-item semantic veto on top (BUG-2602).
+				adoptCollection(updated, ++collectionGen);
 				// If the owner renamed the collection, its slug may have
 				// changed. The current `/[collection]/[slug]` URL still
 				// points at the old slug and subsequent loadData() calls

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -272,12 +272,18 @@
 		if (!embedded) return;
 		const liveSlug = item?.collection_slug;
 		if (!liveSlug || liveSlug === fetched.slug) return;
+		// Ordering: capture the generation BEFORE the fetch (codex round 1
+		// #3) — a fresher collection write landing during it must win, and
+		// bumping on completion would have overwritten it with this older
+		// snapshot.
+		const convergeGen = ++collectionGen;
 		try {
 			const liveColl = await api.collections.get(wsSlug, liveSlug);
 			if (myGen !== loadGeneration) return;
-			adoptCollection(liveColl, ++collectionGen);
+			adoptCollection(liveColl, convergeGen);
 		} catch {
-			// Best-effort — the next event / reload catches up.
+			// Best-effort here; the caller surfaces the schema-less outcome
+			// (codex round 1 #2).
 		}
 	}
 
@@ -1801,6 +1807,18 @@
 					// stale revert is vetoed, and a vetoed embedded pane
 					// converges on the live item's collection instead.
 					await adoptOrConvergeToLiveCollection(realColl, collGen, myGen);
+					// The converge fallback awaited — a route switch during it
+					// must stop this load before the global writes below
+					// (codex round 1 #1).
+					if (myGen !== loadGeneration) return;
+					// Veto + failed convergence = a schema-less pane. Surface
+					// it like the old fetch-failure path did instead of
+					// reporting a successful load with no fields (codex
+					// round 1 #2).
+					if (!collection) {
+						error = 'Failed to load this item’s collection';
+						return;
+					}
 				} catch {
 					if (myGen !== loadGeneration) return;
 					// Can't resolve the item's REAL collection. Surface the
@@ -1814,6 +1832,7 @@
 			} else {
 				// Same hatch shape, same fix (BUG-2602) — see above.
 				await adoptOrConvergeToLiveCollection(collData, collGen, myGen);
+				if (myGen !== loadGeneration) return;
 			}
 			// A FROZEN (peeking) instance must NOT write the SINGLETON global stores
 			// the ACTIVE side owns (PLAN-2179 DR-2 / TASK-2181). Both are module

--- a/web/src/lib/items/adoptCollection.test.ts
+++ b/web/src/lib/items/adoptCollection.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest';
+import { shouldAdoptCollection, type AdoptCollectionInput } from './adoptCollection';
+
+function input(over: Partial<AdoptCollectionInput>): AdoptCollectionInput {
+	return {
+		fetchedId: 'coll-x',
+		liveItemCollectionId: 'coll-x',
+		currentCollectionId: 'coll-x',
+		genFresh: true,
+		...over,
+	};
+}
+
+describe('shouldAdoptCollection', () => {
+	it('admits a fresh same-collection refresh (the common case)', () => {
+		expect(shouldAdoptCollection(input({}))).toBe(true);
+	});
+
+	it('rejects a generation-stale same-collection refresh (newest-started wins)', () => {
+		expect(shouldAdoptCollection(input({ genFresh: false }))).toBe(false);
+	});
+
+	it('THE FILED RACE: vetoes a pre-move source-collection snapshot after the live item moved', () => {
+		// loadData(X) was in flight; an SSE move adopted the item into Y
+		// (itemGen fences the item, so the live item stays moved). The
+		// continuation resolves with X — generation-stale, and the old
+		// escape hatch (currentCollectionId !== fetchedId) would have
+		// admitted it. The semantic veto must fire.
+		expect(
+			shouldAdoptCollection(
+				input({
+					fetchedId: 'coll-x',
+					liveItemCollectionId: 'coll-y',
+					currentCollectionId: 'coll-y',
+					genFresh: false,
+				}),
+			),
+		).toBe(false);
+	});
+
+	it('vetoes even a generation-FRESH snapshot that disagrees with the live item', () => {
+		// Freshness cannot make a semantically wrong snapshot right —
+		// e.g. the reused-slug hazard: an SSE refresh fetched by slug got
+		// a FOREIGN collection because the slug was re-owned post-rename.
+		expect(
+			shouldAdoptCollection(
+				input({
+					fetchedId: 'coll-foreign',
+					liveItemCollectionId: 'coll-x',
+					currentCollectionId: 'coll-x',
+					genFresh: true,
+				}),
+			),
+		).toBe(false);
+	});
+
+	it('admits the legitimate cross-collection correction even when generation-stale', () => {
+		// The old escape hatch's valid half: loadData resolved the item's
+		// REAL collection while a stale refresh for the previously shown
+		// collection had bumped the generation. The live item agrees with
+		// the fetched collection, so the correction lands.
+		expect(
+			shouldAdoptCollection(
+				input({
+					fetchedId: 'coll-y',
+					liveItemCollectionId: 'coll-y',
+					currentCollectionId: 'coll-x',
+					genFresh: false,
+				}),
+			),
+		).toBe(true);
+	});
+
+	it('first load (no collection shown yet): live item agreement admits', () => {
+		expect(
+			shouldAdoptCollection(
+				input({ currentCollectionId: null, liveItemCollectionId: 'coll-x', genFresh: false }),
+			),
+		).toBe(true);
+	});
+
+	it('no live item: generation order is the only signal (fresh admits)', () => {
+		expect(
+			shouldAdoptCollection(
+				input({ liveItemCollectionId: null, currentCollectionId: 'coll-w', fetchedId: 'coll-x', genFresh: true }),
+			),
+		).toBe(true);
+	});
+
+	it('no live item: generation-stale cross-collection write is rejected', () => {
+		// Without an item to anchor on there is no semantic basis to
+		// override ordering — the hatch's blanket admit was the defect.
+		expect(
+			shouldAdoptCollection(
+				input({ liveItemCollectionId: null, currentCollectionId: 'coll-w', fetchedId: 'coll-x', genFresh: false }),
+			),
+		).toBe(false);
+	});
+
+	it('chained-move burst: an older refresh for an intermediate collection is vetoed', () => {
+		// X→Y→Z: the Y refresh resolves last while the live item is on Z.
+		expect(
+			shouldAdoptCollection(
+				input({
+					fetchedId: 'coll-y',
+					liveItemCollectionId: 'coll-z',
+					currentCollectionId: 'coll-z',
+					genFresh: false,
+				}),
+			),
+		).toBe(false);
+	});
+});

--- a/web/src/lib/items/adoptCollection.ts
+++ b/web/src/lib/items/adoptCollection.ts
@@ -1,0 +1,54 @@
+// ItemDetail collection-snapshot adoption decision (BUG-2602).
+//
+// ItemDetail has seven sites that assign the `collection` snapshot, racing
+// under a generation fence (`collectionGen`) that orders STARTS — and one
+// site (loadData's cross-collection escape hatch) that deliberately admitted
+// a generation-stale write when it fetched a different collection. That
+// disjunct made the fences compose wrongly: a loadData continuation spanning
+// a cross-collection move could restore the SOURCE collection over the
+// freshly adopted TARGET (the live item, itemGen-fenced, keeps the move —
+// so the pane rendered item and collection from different collections).
+//
+// This helper is the single pure decision every write routes through. The
+// invariant it enforces is SEMANTIC, not ordinal: the pane renders the LIVE
+// item's collection. `collection_id` is the anchor — stable across renames
+// (where slugs lie) and changed by moves (where slugs can be reused).
+//
+// Decision:
+//   1. Semantic veto — if a live item is loaded and carries a collection id,
+//      a snapshot for any OTHER collection is wrong NOW, regardless of how
+//      fresh its fetch was. This also closes a latent reused-slug hazard:
+//      an SSE-refresh fetch by slug can return a FOREIGN collection when
+//      the slug was re-owned after a rename.
+//   2. Generation order — among semantically-valid snapshots of the SAME
+//      collection (schema edits, refreshes), newest-started wins, exactly
+//      what `collectionGen` always meant.
+//   3. Cross-collection correction — a semantically-valid snapshot for a
+//      DIFFERENT collection than currently shown is admitted even when
+//      generation-stale: this is the legitimate half of the old escape
+//      hatch (a stale refresh for the old collection must not block
+//      correcting to the live item's collection).
+export interface AdoptCollectionInput {
+	/** The fetched snapshot's collection id. */
+	fetchedId: string;
+	/** The LIVE item's collection_id at write time (null → no item loaded / not carried). */
+	liveItemCollectionId: string | null;
+	/** The currently shown collection's id (null → none loaded yet). */
+	currentCollectionId: string | null;
+	/** Whether the writer's captured generation is still the latest. */
+	genFresh: boolean;
+}
+
+export function shouldAdoptCollection(input: AdoptCollectionInput): boolean {
+	const { fetchedId, liveItemCollectionId, currentCollectionId, genFresh } = input;
+	// 1. Semantic veto: disagreeing with the live item is wrong regardless
+	//    of freshness.
+	if (liveItemCollectionId !== null && liveItemCollectionId !== fetchedId) return false;
+	// 2. Same-collection refreshes: newest-started wins.
+	if (currentCollectionId === fetchedId) return genFresh;
+	// 3. Cross-collection correction toward the live item's collection (or
+	//    first load with nothing to disagree with): admit. When no item is
+	//    loaded, generation order is the only signal left.
+	if (liveItemCollectionId === null) return genFresh;
+	return true;
+}


### PR DESCRIPTION
## Root cause

Seven sites assign ItemDetail's `collection` snapshot under fences that order *starts* (`collectionGen`), and loadData's cross-collection escape hatch (`collGen === collectionGen || collection?.id !== fetched.id`) deliberately admitted any generation-stale write that fetched a different collection. A loadData continuation spanning a cross-collection **move** could therefore restore the SOURCE collection over the freshly adopted TARGET — the live item (itemGen-fenced) kept the move, so the pane rendered the item against the wrong collection's schema. Filed from BUG-2178's codex review; the shape predates it.

## Change

- **`shouldAdoptCollection`** (pure, 9 unit tests, mutation-resistant per review): a snapshot disagreeing with the **live item's `collection_id`** is vetoed regardless of freshness — id, not slug, so renames still apply and a reused slug can't satisfy it (this also closes a latent foreign-write in the SSE `collection_updated` refresh, which fetches by slug); same-collection refreshes keep newest-started-wins; the legitimate cross-collection correction the old hatch existed for still lands when the live item agrees.
- **`adoptCollection`** routes all seven write sites (loadData ×2, SSE refresh, refreshCollectionIfMoved, the BUG-2601 rename heal, quick-action + edit-modal callbacks). Empty-string `collection_id` normalizes to no-anchor.
- **`adoptOrConvergeToLiveCollection`**: on the veto path an embedded pane whose `collection` was still null (fresh mount — `refreshCollectionIfMoved`'s `!collection` guard skips there too, found by runtime instrumentation) converges on the live item's collection instead of being left schema-less; both loadData branches surface a schema-less outcome as the load error and re-check `myGen` after the new await before any singleton writes; the singleton claim (`setActiveItem`/editor reset) now also requires `myItemGen === itemGen`.

## Verification

e2e reproduces the filed race deterministically (route-hold on the realColl fetch, API move mid-hold with a hard `collection_id === tgt.id` oracle on the pane's refetch, release): the **control build renders the moved item against `SrcMarkerField`'s schema** — the filed bug verbatim, screenshot-verified; the fixed build converges on `TgtMarkerField`. Full vitest 1647; svelte-check 0 errors.

## Review

5 codex rounds (R2/R4 confirm CLEAN, R5 fresh-angle only doc nits + a stale-local-main scope false-positive). Substantive catches folded in: post-converge `myGen` re-checks before global writes, schema-less error surfacing on both branches, `convergeGen` captured pre-fetch, itemGen gate on singleton claims, empty-string anchor normalization, hard e2e oracle.