### PR TITLE
fix(store): orphan GC claim protocol — writer reference stamps + conditional row-first deletes (BUG-2415)

### DIFF
--- a/internal/server/orphan_gc.go
+++ b/internal/server/orphan_gc.go
@@ -15,6 +15,27 @@ import (
 const (
 	defaultOrphanGCInterval = 24 * time.Hour
 	defaultOrphanGCGrace    = 30 * 24 * time.Hour
+
+	// orphanGCRefStaleWindow is a CORRECTNESS parameter, not a tuning
+	// knob (BUG-2415). A never-attached row is only claimable when its
+	// last_referenced_at stamp is older than this window.
+	//
+	// What it must cover: the stamp is NOT a lease on long-lived
+	// references — those are caught by the content LIKE scan
+	// (AttachmentReferenced) that runs immediately before the claim.
+	// The stamp only has to cover references that commit AFTER that
+	// scan, i.e. within the scan→claim gap of a single sweep iteration
+	// (milliseconds) PLUS the full duration of the writer transaction
+	// that carries the stamp — including a pathologically stalled one
+	// (lock waits, an operator-paused Postgres, a laptop suspending
+	// mid-commit). 15 minutes exceeds any plausible single write
+	// transaction by orders of magnitude while delaying reclamation of
+	// a genuinely-orphaned row by at most one extra sweep against a
+	// 30-day grace period — the asymmetry is entirely in favor of
+	// generosity. If you are tempted to lower this for faster tests,
+	// inject the cutoff in the test instead; the constant guards
+	// production correctness.
+	orphanGCRefStaleWindow = 15 * time.Minute
 )
 
 // orphanGCResult records what one sweep accomplished. Returned from
@@ -77,7 +98,8 @@ func (s *Server) runOrphanGCSweep(ctx context.Context, graceCutoff time.Time) (*
 		// + comment bodies before reclaiming so the GC doesn't destroy
 		// a legitimate reference. Codex P1 on PR #307 round 1;
 		// comment-body coverage added for IDEA-1650.
-		if a.ItemID == nil && a.DeletedAt == nil {
+		neverAttached := a.ItemID == nil && a.DeletedAt == nil
+		if neverAttached {
 			referenced, err := s.store.AttachmentReferenced(a.WorkspaceID, a.ID)
 			if err != nil {
 				slog.Warn("orphan GC: ref-scan failed",
@@ -93,8 +115,55 @@ func (s *Server) runOrphanGCSweep(ctx context.Context, graceCutoff time.Time) (*
 			}
 		}
 
-		// Decide whether the on-disk blob can also be reclaimed.
-		// Two protections to consider:
+		// CLAIM — row BEFORE bytes (BUG-2415). The row deletion is a
+		// conditional DELETE that re-asserts the row's reclaimable
+		// state inside the statement itself, so it serializes at the
+		// database against every writer:
+		//
+		//   - never-attached: still unattached, still live, and no
+		//     reference stamp fresher than the stale window. A writer
+		//     committing a `pad-attachment:` reference stamps the row
+		//     in the SAME transaction as the content
+		//     (stampAttachmentRefsTx), so either the stamp lands first
+		//     and this claim matches zero rows, or the claim lands
+		//     first and the writer's stamp matches zero rows — no
+		//     interleaving destroys a referenced row.
+		//   - soft-deleted: deleted_at still set and still past grace
+		//     at delete time, so a mid-sweep restore survives.
+		//
+		// Row-first ordering is what makes a surviving row imply
+		// surviving bytes: the blob is only reclaimed after the row is
+		// provably gone. (The old order deleted the blob first, so a
+		// reference landing mid-sweep could keep a row whose content
+		// was already destroyed — the worst failure mode of the race.)
+		var claimed bool
+		var claimErr error
+		if neverAttached {
+			claimed, claimErr = s.store.ClaimNeverAttachedAttachment(
+				a.ID, time.Now().Add(-orphanGCRefStaleWindow))
+		} else {
+			claimed, claimErr = s.store.ClaimSoftDeletedAttachment(a.ID, graceCutoff)
+		}
+		if claimErr != nil {
+			slog.Warn("orphan GC: claim failed",
+				"attachment_id", a.ID, "error", claimErr)
+			res.Skipped++
+			continue
+		}
+		if !claimed {
+			// The row's state changed since the candidate SELECT — a
+			// writer referenced it, an upload attached it, or a restore
+			// revived it. That is the claim protocol WORKING, not a
+			// failure; the next sweep takes a fresh look.
+			slog.Debug("orphan GC: claim refused — row state changed mid-sweep",
+				"attachment_id", a.ID)
+			res.Skipped++
+			continue
+		}
+		res.Deleted++
+
+		// Row is gone — decide whether the on-disk blob can also be
+		// reclaimed. Two protections to consider:
 		//
 		//   1. content-addressed dedupe: another row at the same
 		//      hash may still need the blob. CountProtecting includes
@@ -141,10 +210,13 @@ func (s *Server) runOrphanGCSweep(ctx context.Context, graceCutoff time.Time) (*
 			if delErr := store.Delete(ctx, a.StorageKey); delErr != nil {
 				// AttachmentStore.Delete documents that deleting a
 				// missing key is NOT an error, so anything reaching
-				// here is a real failure (permission, IO, etc.).
-				// Still drop the DB row — keeping it strands the
-				// row indefinitely; the operator will have to clean
-				// the disk by hand either way.
+				// here is a real failure (permission, IO, etc.). The
+				// row is already claimed (deleted), so this strands
+				// the blob on disk for the operator to clean by hand
+				// — the inverse of the old order's failure mode, and
+				// the safe direction: a stranded blob wastes disk, a
+				// stranded row without bytes lied about data that no
+				// longer existed (BUG-2415).
 				slog.Warn("orphan GC: blob delete failed",
 					"attachment_id", a.ID, "storage_key", a.StorageKey, "error", delErr)
 			} else {
@@ -158,14 +230,6 @@ func (s *Server) runOrphanGCSweep(ctx context.Context, graceCutoff time.Time) (*
 			res.BytesReclaimed += a.SizeBytes
 			reclaimedThisSweep[a.ContentHash] = true
 		}
-
-		if err := s.store.HardDeleteAttachment(a.ID); err != nil {
-			slog.Warn("orphan GC: hard delete failed",
-				"attachment_id", a.ID, "error", err)
-			res.Skipped++
-			continue
-		}
-		res.Deleted++
 	}
 
 	return res, nil

--- a/internal/server/orphan_gc.go
+++ b/internal/server/orphan_gc.go
@@ -32,9 +32,13 @@ const (
 	// transaction by orders of magnitude while delaying reclamation of
 	// a genuinely-orphaned row by at most one extra sweep against a
 	// 30-day grace period — the asymmetry is entirely in favor of
-	// generosity. If you are tempted to lower this for faster tests,
-	// inject the cutoff in the test instead; the constant guards
-	// production correctness.
+	// generosity. The window is also the bound on residual (2) in
+	// stampAttachmentRefsTx's ORDERING note: a writer transaction whose
+	// stamp-to-commit span exceeds it loses protection, which is why
+	// "longest plausible stalled writer transaction" is the sizing
+	// criterion and not a soft target. If you are tempted to lower this
+	// for faster tests, inject the cutoff in the test instead; the
+	// constant guards production correctness.
 	orphanGCRefStaleWindow = 15 * time.Minute
 )
 

--- a/internal/server/orphan_gc.go
+++ b/internal/server/orphan_gc.go
@@ -47,6 +47,12 @@ type orphanGCResult struct {
 	BlobsReclaimed int   // on-disk blobs Delete'd through the storage backend
 	BytesReclaimed int64 // sum of size_bytes for reclaimed blobs
 	Skipped        int   // rows skipped due to mid-sweep errors
+	// BlobDeleteFailures counts rows whose DB row was claimed but whose
+	// blob delete then failed — stranded bytes an operator must clean by
+	// hand. Surfaced as its own counter so a sweep summary can't read
+	// "deleted=N, blobs_reclaimed=0, skipped=0" as if nothing went wrong
+	// (BUG-2415 codex round 3).
+	BlobDeleteFailures int
 }
 
 // runOrphanGCSweep walks the orphaned-attachments query and reclaims
@@ -228,6 +234,7 @@ func (s *Server) runOrphanGCSweep(ctx context.Context, graceCutoff time.Time) (*
 				// longer existed (BUG-2415).
 				slog.Warn("orphan GC: blob delete failed",
 					"attachment_id", a.ID, "storage_key", a.StorageKey, "error", delErr)
+				res.BlobDeleteFailures++
 			} else {
 				blobDeleted = true
 			}
@@ -349,7 +356,8 @@ func (s *Server) runOrphanGCTick(grace time.Duration) {
 		"deleted", res.Deleted,
 		"blobs_reclaimed", res.BlobsReclaimed,
 		"bytes_reclaimed", res.BytesReclaimed,
-		"skipped", res.Skipped)
+		"skipped", res.Skipped,
+		"blob_delete_failures", res.BlobDeleteFailures)
 }
 
 // _ keeps the attachments import alive even if every callsite ends

--- a/internal/server/orphan_gc.go
+++ b/internal/server/orphan_gc.go
@@ -100,7 +100,16 @@ func (s *Server) runOrphanGCSweep(ctx context.Context, graceCutoff time.Time) (*
 		// comment-body coverage added for IDEA-1650.
 		neverAttached := a.ItemID == nil && a.DeletedAt == nil
 		if neverAttached {
-			referenced, err := s.store.AttachmentReferenced(a.WorkspaceID, a.ID)
+			// Variants (thumbnails) are never text-referenced by their
+			// OWN id — content references the original. Scan the parent's
+			// id for them, or a referenced upload would keep its original
+			// while the sweep destroyed its thumbnails (codex round 1 #4;
+			// pre-existing hole, closed alongside the claim protocol).
+			scanID := a.ID
+			if a.ParentID != nil && *a.ParentID != "" {
+				scanID = *a.ParentID
+			}
+			referenced, err := s.store.AttachmentReferenced(a.WorkspaceID, scanID)
 			if err != nil {
 				slog.Warn("orphan GC: ref-scan failed",
 					"attachment_id", a.ID, "workspace_id", a.WorkspaceID, "error", err)

--- a/internal/server/orphan_gc_test.go
+++ b/internal/server/orphan_gc_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/PerpetualSoftware/pad/internal/attachments"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 // TestOrphanGC_ReclaimsSoftDeleted pins TASK-886's main case: a
@@ -671,5 +672,59 @@ func TestOrphanGC_ClaimRefusesFreshlyReferencedRow(t *testing.T) {
 	}
 	if att3 != nil {
 		t.Errorf("stale-stamped row survived the second sweep")
+	}
+}
+
+// TestOrphanGC_VariantProtectedByReferencedParent pins the parent-aware
+// half of BUG-2415: content references an ORIGINAL's id, never a
+// thumbnail's, so a referenced never-attached upload must keep its
+// variants too — the scan consults the parent id for variant rows, and
+// the claim refuses on a fresh PARENT stamp.
+func TestOrphanGC_VariantProtectedByReferencedParent(t *testing.T) {
+	srv, slug := testServerWithAttachments(t)
+
+	rr := doMultipartUpload(srv, slug, "with-thumb.png", realPNG())
+	if rr.Code != 201 {
+		t.Fatalf("upload: %d %s", rr.Code, rr.Body.String())
+	}
+	wsID := workspaceIDForSlug(t, srv, slug)
+	origID := getOnlyAttachmentID(t, srv, wsID)
+
+	// Seed a variant row hanging off the original. Direct insert keeps
+	// the test independent of the thumbnail pipeline's async behavior.
+	thumbID := origID + "-thumb"
+	if _, err := srv.store.DB().Exec(srv.store.D().Rebind(
+		`INSERT INTO attachments (id, workspace_id, item_id, uploaded_by, storage_key, content_hash, mime_type, size_bytes, filename, parent_id, variant, created_at)
+		 VALUES (?, ?, NULL, '', ?, ?, 'image/png', 10, 'thumb.png', ?, 'thumb-md', ?)`),
+		thumbID, wsID, "fs:thumb-"+thumbID, "hash-thumb-"+thumbID, origID,
+		time.Now().Add(-40*24*time.Hour).UTC().Format(time.RFC3339)); err != nil {
+		t.Fatalf("insert variant: %v", err)
+	}
+
+	// Reference the ORIGINAL from item content — the only id content
+	// ever carries.
+	var collID string
+	if err := srv.store.DB().QueryRow(srv.store.D().Rebind(
+		`SELECT id FROM collections WHERE workspace_id = ? ORDER BY sort_order, slug LIMIT 1`), wsID).Scan(&collID); err != nil {
+		t.Fatalf("pick collection: %v", err)
+	}
+	if _, err := srv.store.CreateItem(wsID, collID, models.ItemCreate{
+		Title:   "holder",
+		Content: "see ![x](pad-attachment:" + origID + ")",
+	}); err != nil {
+		t.Fatalf("CreateItem: %v", err)
+	}
+
+	res, err := srv.runOrphanGCSweep(context.Background(), time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	_ = res
+
+	if att, _ := srv.store.GetAttachment(origID); att == nil {
+		t.Fatalf("referenced original reclaimed")
+	}
+	if att, _ := srv.store.GetAttachment(thumbID); att == nil {
+		t.Errorf("referenced original's VARIANT reclaimed — parent-aware scan failed")
 	}
 }

--- a/internal/server/orphan_gc_test.go
+++ b/internal/server/orphan_gc_test.go
@@ -590,3 +590,86 @@ func TestOrphanGC_StartStop(t *testing.T) {
 	// If we got here without deadlocking on Stop, the loop drains
 	// correctly. testServer's t.Cleanup will exercise Stop.
 }
+
+// TestOrphanGC_ClaimRefusesFreshlyReferencedRow pins BUG-2415 at the
+// sweep level: a never-attached row whose last_referenced_at stamp is
+// FRESH (a writer referenced it after the sweep's content scan would
+// have run) survives the sweep — row AND blob — because the row
+// deletion is a conditional claim and the blob is only reclaimed after
+// a successful claim. The stamped row deliberately has NO content
+// reference, so the LIKE scan passes it and the claim predicate is the
+// only thing standing between it and deletion — exactly the filed
+// mid-sweep window.
+func TestOrphanGC_ClaimRefusesFreshlyReferencedRow(t *testing.T) {
+	srv, slug := testServerWithAttachments(t)
+
+	body := realPNG()
+	rr := doMultipartUpload(srv, slug, "raced.png", body)
+	if rr.Code != 201 {
+		t.Fatalf("upload: %d %s", rr.Code, rr.Body.String())
+	}
+	wsID := workspaceIDForSlug(t, srv, slug)
+	id := getOnlyAttachmentID(t, srv, wsID)
+
+	// Fresh stamp, no content reference — the post-scan writer's trace.
+	nowTS := time.Now().UTC().Format(time.RFC3339)
+	if _, err := srv.store.DB().Exec(srv.store.D().Rebind(
+		`UPDATE attachments SET last_referenced_at = ? WHERE id = ?`), nowTS, id); err != nil {
+		t.Fatalf("stamp: %v", err)
+	}
+
+	att, err := srv.store.GetAttachment(id)
+	if err != nil || att == nil {
+		t.Fatalf("GetAttachment: %v %v", att, err)
+	}
+	store, err := srv.attachments.Resolve(att.StorageKey)
+	if err != nil {
+		t.Fatalf("resolve backend: %v", err)
+	}
+
+	res, err := srv.runOrphanGCSweep(context.Background(), time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	if res.Deleted != 0 {
+		t.Errorf("Deleted=%d, want 0 — fresh-stamped row was reclaimed", res.Deleted)
+	}
+
+	// Row survives.
+	att2, err := srv.store.GetAttachment(id)
+	if err != nil {
+		t.Fatalf("post-sweep GetAttachment: %v", err)
+	}
+	if att2 == nil {
+		t.Fatalf("fresh-stamped row deleted by sweep — the filed data-loss race")
+	}
+	// Blob survives (row-before-bytes: an unclaimed row's bytes are
+	// never touched).
+	if _, err := store.Stat(context.Background(), att.StorageKey); err != nil {
+		t.Errorf("blob missing after refused claim: %v", err)
+	}
+
+	// COUNTERFACTUAL ARM: age the stamp past the stale window and sweep
+	// again — the same row must now be reclaimed, proving the stamp
+	// condition (not the scan, not the grace cutoff) is what protected
+	// it above.
+	staleTS := time.Now().Add(-2 * orphanGCRefStaleWindow).UTC().Format(time.RFC3339)
+	if _, err := srv.store.DB().Exec(srv.store.D().Rebind(
+		`UPDATE attachments SET last_referenced_at = ? WHERE id = ?`), staleTS, id); err != nil {
+		t.Fatalf("age stamp: %v", err)
+	}
+	res, err = srv.runOrphanGCSweep(context.Background(), time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("second sweep: %v", err)
+	}
+	if res.Deleted < 1 {
+		t.Errorf("second sweep Deleted=%d, want >= 1 — stale stamp should not protect", res.Deleted)
+	}
+	att3, err := srv.store.GetAttachment(id)
+	if err != nil {
+		t.Fatalf("final GetAttachment: %v", err)
+	}
+	if att3 != nil {
+		t.Errorf("stale-stamped row survived the second sweep")
+	}
+}

--- a/internal/store/attachments.go
+++ b/internal/store/attachments.go
@@ -754,6 +754,19 @@ func (s *Store) HardDeleteAttachment(id string) error {
 // failed statement poisons the transaction anyway, and a save whose
 // stamp did not commit would not be protected — failing the save is the
 // honest outcome.
+//
+// ORDERING (codex round 3): call this BEFORE the content statement, as
+// early in the writer transaction as the texts are known. On Postgres
+// the stamp UPDATE row-locks the attachment rows for the rest of the
+// transaction, so a concurrent GC claim DELETE blocks until commit and
+// then re-evaluates its predicate against the fresh stamp — refusing.
+// Stamping late would leave a window where the claim slips between the
+// content write and the stamp. The irreducible residual is the claim
+// COMMITTING before the writer's stamp executes at all: the row is
+// gone, the stamp matches zero rows, and the committed text carries a
+// dangling ref — the same outcome as referencing any already-deleted
+// attachment, and deliberately NOT turned into a save failure because
+// zero-rows also describes legitimate unknown / foreign / typo ids.
 func stampAttachmentRefsTx(tx *sql.Tx, s *Store, workspaceID string, texts ...string) error {
 	if workspaceID == "" {
 		return nil
@@ -776,19 +789,30 @@ func stampAttachmentRefsTx(tx *sql.Tx, s *Store, workspaceID string, texts ...st
 	if len(ids) == 0 {
 		return nil
 	}
-	placeholders := make([]string, len(ids))
-	args := make([]interface{}, 0, len(ids)+2)
-	args = append(args, time.Now().UTC().Format(time.RFC3339))
-	args = append(args, workspaceID)
-	for i, id := range ids {
-		placeholders[i] = "?"
-		args = append(args, id)
-	}
-	_, err := tx.Exec(s.q(
-		`UPDATE attachments SET last_referenced_at = ? WHERE workspace_id = ? AND id IN (`+
-			strings.Join(placeholders, ",")+`)`), args...)
-	if err != nil {
-		return fmt.Errorf("stamp attachment refs: %w", err)
+	// Chunked like the attachment-copy planner's id walks: a hostile
+	// payload can carry thousands of refs, and an unbounded IN list
+	// would blow the bind-parameter limit and roll back the whole
+	// write (codex round 3 P2).
+	const stampChunk = 400
+	ts := time.Now().UTC().Format(time.RFC3339)
+	for start := 0; start < len(ids); start += stampChunk {
+		end := start + stampChunk
+		if end > len(ids) {
+			end = len(ids)
+		}
+		chunk := ids[start:end]
+		placeholders := make([]string, len(chunk))
+		args := make([]interface{}, 0, len(chunk)+2)
+		args = append(args, ts, workspaceID)
+		for i, id := range chunk {
+			placeholders[i] = "?"
+			args = append(args, id)
+		}
+		if _, err := tx.Exec(s.q(
+			`UPDATE attachments SET last_referenced_at = ? WHERE workspace_id = ? AND id IN (`+
+				strings.Join(placeholders, ",")+`)`), args...); err != nil {
+			return fmt.Errorf("stamp attachment refs: %w", err)
+		}
 	}
 	return nil
 }

--- a/internal/store/attachments.go
+++ b/internal/store/attachments.go
@@ -728,15 +728,129 @@ func (s *Store) OrphanedAttachments(graceCutoff time.Time) ([]models.Attachment,
 	return out, nil
 }
 
-// HardDeleteAttachment removes the attachments row outright. Used by
-// orphan GC after the grace period; never call from a request
-// handler — soft-delete is the safe default for user-facing flows.
+// HardDeleteAttachment removes the attachments row outright. Never call
+// from a request handler — soft-delete is the safe default for
+// user-facing flows. The orphan GC no longer uses it (BUG-2415): its
+// row deletions go through the conditional Claim* methods below so the
+// delete itself is the atomic claim.
 func (s *Store) HardDeleteAttachment(id string) error {
 	_, err := s.db.Exec(s.q(`DELETE FROM attachments WHERE id = ?`), id)
 	if err != nil {
 		return fmt.Errorf("hard delete attachment: %w", err)
 	}
 	return nil
+}
+
+// stampAttachmentRefsTx bumps attachments.last_referenced_at for every
+// `pad-attachment:<id>` reference found in the given texts, inside the
+// caller's transaction (BUG-2415). Content writers call this alongside
+// their content/fields/body write so the stamp commits atomically with
+// the reference: either both are visible to the GC sweep's conditional
+// claim, or neither is.
+//
+// Scoped to the workspace so a pasted foreign-workspace reference can't
+// refresh another workspace's rows. Unknown / already-deleted ids simply
+// match zero rows. Errors are returned, not swallowed: on Postgres any
+// failed statement poisons the transaction anyway, and a save whose
+// stamp did not commit would not be protected — failing the save is the
+// honest outcome.
+func stampAttachmentRefsTx(tx *sql.Tx, s *Store, workspaceID string, texts ...string) error {
+	if workspaceID == "" {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	ids := make([]string, 0, 4)
+	for _, text := range texts {
+		if text == "" || !strings.Contains(text, attachmentRefPrefix) {
+			continue
+		}
+		for _, m := range attachmentRefRE.FindAllStringSubmatch(text, -1) {
+			id := m[1]
+			if _, dup := seen[id]; dup {
+				continue
+			}
+			seen[id] = struct{}{}
+			ids = append(ids, id)
+		}
+	}
+	if len(ids) == 0 {
+		return nil
+	}
+	placeholders := make([]string, len(ids))
+	args := make([]interface{}, 0, len(ids)+2)
+	args = append(args, time.Now().UTC().Format(time.RFC3339))
+	args = append(args, workspaceID)
+	for i, id := range ids {
+		placeholders[i] = "?"
+		args = append(args, id)
+	}
+	_, err := tx.Exec(s.q(
+		`UPDATE attachments SET last_referenced_at = ? WHERE workspace_id = ? AND id IN (`+
+			strings.Join(placeholders, ",")+`)`), args...)
+	if err != nil {
+		return fmt.Errorf("stamp attachment refs: %w", err)
+	}
+	return nil
+}
+
+// ClaimNeverAttachedAttachment is the orphan GC's atomic claim for a
+// never-attached row (BUG-2415): a conditional DELETE that re-asserts
+// the row is still unattached, still live, and has no FRESH reference
+// stamp — all inside the delete statement itself, so a writer's
+// in-transaction stamp (stampAttachmentRefsTx) and this delete
+// serialize at the database: whichever commits first wins, and the
+// loser observes it (the writer's stamp matches zero rows, or this
+// claim deletes zero rows).
+//
+// Returns whether the row was claimed (deleted). The caller must
+// reclaim the blob ONLY on a true return — row-before-bytes is the
+// ordering that makes a surviving row imply surviving bytes.
+//
+// refCutoff bounds stamp freshness: a stamp at-or-after it refuses the
+// claim. The content LIKE scan (AttachmentReferenced) still runs before
+// this in the sweep, so the stamp only needs to cover references that
+// landed AFTER that scan — the window is sized in orphan_gc.go, not
+// here.
+func (s *Store) ClaimNeverAttachedAttachment(id string, refCutoff time.Time) (bool, error) {
+	res, err := s.db.Exec(s.q(`
+		DELETE FROM attachments
+		WHERE id = ?
+		  AND item_id IS NULL
+		  AND deleted_at IS NULL
+		  AND (last_referenced_at IS NULL OR last_referenced_at < ?)
+	`), id, refCutoff.UTC().Format(time.RFC3339))
+	if err != nil {
+		return false, fmt.Errorf("claim never-attached attachment: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("claim never-attached attachment rows: %w", err)
+	}
+	return n == 1, nil
+}
+
+// ClaimSoftDeletedAttachment is the orphan GC's atomic claim for a
+// soft-deleted row past its grace window (BUG-2415): the DELETE
+// re-asserts deleted_at is still set and still past the cutoff at
+// delete time, so a concurrent restore (which clears deleted_at)
+// commits either before this — claim matches zero rows, row survives —
+// or after — the restore's own predicate sees the row gone. Same
+// row-before-bytes contract as ClaimNeverAttachedAttachment.
+func (s *Store) ClaimSoftDeletedAttachment(id string, graceCutoff time.Time) (bool, error) {
+	res, err := s.db.Exec(s.q(`
+		DELETE FROM attachments
+		WHERE id = ?
+		  AND deleted_at IS NOT NULL
+		  AND deleted_at < ?
+	`), id, graceCutoff.UTC().Format(time.RFC3339))
+	if err != nil {
+		return false, fmt.Errorf("claim soft-deleted attachment: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("claim soft-deleted attachment rows: %w", err)
+	}
+	return n == 1, nil
 }
 
 // CountProtectingAttachmentsForHash returns the number of rows

--- a/internal/store/attachments.go
+++ b/internal/store/attachments.go
@@ -761,12 +761,17 @@ func (s *Store) HardDeleteAttachment(id string) error {
 // transaction, so a concurrent GC claim DELETE blocks until commit and
 // then re-evaluates its predicate against the fresh stamp — refusing.
 // Stamping late would leave a window where the claim slips between the
-// content write and the stamp. The irreducible residual is the claim
-// COMMITTING before the writer's stamp executes at all: the row is
-// gone, the stamp matches zero rows, and the committed text carries a
-// dangling ref — the same outcome as referencing any already-deleted
-// attachment, and deliberately NOT turned into a save failure because
-// zero-rows also describes legitimate unknown / foreign / typo ids.
+// content write and the stamp. Two residuals, both accepted and
+// bounded: (1) the claim COMMITTING before the writer's stamp executes
+// at all — the row is gone, the stamp matches zero rows, and the
+// committed text carries a dangling ref, the same outcome as
+// referencing any already-deleted attachment; deliberately NOT turned
+// into a save failure because zero-rows also describes legitimate
+// unknown / foreign / typo ids. (2) a writer transaction whose
+// stamp-to-commit span EXCEEDS orphanGCRefStaleWindow — the stamp is
+// already stale when a blocked claim re-evaluates, so the window's
+// sizing (see its comment) is what bounds this case, not the lock
+// (codex round 4 P2).
 func stampAttachmentRefsTx(tx *sql.Tx, s *Store, workspaceID string, texts ...string) error {
 	if workspaceID == "" {
 		return nil
@@ -802,15 +807,26 @@ func stampAttachmentRefsTx(tx *sql.Tx, s *Store, workspaceID string, texts ...st
 		}
 		chunk := ids[start:end]
 		placeholders := make([]string, len(chunk))
-		args := make([]interface{}, 0, len(chunk)+2)
+		args := make([]interface{}, 0, 2*len(chunk)+2)
 		args = append(args, ts, workspaceID)
 		for i, id := range chunk {
 			placeholders[i] = "?"
 			args = append(args, id)
 		}
+		for _, id := range chunk {
+			args = append(args, id)
+		}
+		in := strings.Join(placeholders, ",")
+		// `parent_id IN (...)` stamps (and on Postgres, ROW-LOCKS) the
+		// referenced originals' VARIANTS too: a variant's claim DELETE
+		// only re-evaluates predicates on the row it deletes, so a
+		// fresh stamp on the parent alone cannot make a concurrently
+		// claimed thumbnail wait — locking the variant row itself does
+		// (codex round 4 P1). The claim's parent NOT EXISTS stays as
+		// the belt for variants created AFTER the stamp landed.
 		if _, err := tx.Exec(s.q(
-			`UPDATE attachments SET last_referenced_at = ? WHERE workspace_id = ? AND id IN (`+
-				strings.Join(placeholders, ",")+`)`), args...); err != nil {
+			`UPDATE attachments SET last_referenced_at = ? WHERE workspace_id = ? AND (id IN (`+
+				in+`) OR parent_id IN (`+in+`))`), args...); err != nil {
 			return fmt.Errorf("stamp attachment refs: %w", err)
 		}
 	}
@@ -829,6 +845,11 @@ func stampAttachmentRefsTx(tx *sql.Tx, s *Store, workspaceID string, texts ...st
 // Returns whether the row was claimed (deleted). The caller must
 // reclaim the blob ONLY on a true return — row-before-bytes is the
 // ordering that makes a surviving row imply surviving bytes.
+//
+// A true return is IRREVOCABLE: the row and its metadata are gone, so
+// no later recovery surface (PLAN-2411/PLAN-2416) can restore this
+// attachment or retry a failed blob delete — the caller's retained
+// StorageKey is the only remaining handle for operator cleanup.
 //
 // refCutoff bounds stamp freshness: a stamp at-or-after it refuses the
 // claim. The content LIKE scan (AttachmentReferenced) still runs before
@@ -871,7 +892,9 @@ func (s *Store) ClaimNeverAttachedAttachment(id string, refCutoff time.Time) (bo
 // delete time, so a concurrent restore (which clears deleted_at)
 // commits either before this — claim matches zero rows, row survives —
 // or after — the restore's own predicate sees the row gone. Same
-// row-before-bytes contract as ClaimNeverAttachedAttachment.
+// row-before-bytes contract and same IRREVOCABILITY note as
+// ClaimNeverAttachedAttachment: once true, no recovery surface can
+// bring the row back.
 func (s *Store) ClaimSoftDeletedAttachment(id string, graceCutoff time.Time) (bool, error) {
 	res, err := s.db.Exec(s.q(`
 		DELETE FROM attachments

--- a/internal/store/attachments.go
+++ b/internal/store/attachments.go
@@ -811,14 +811,26 @@ func stampAttachmentRefsTx(tx *sql.Tx, s *Store, workspaceID string, texts ...st
 // this in the sweep, so the stamp only needs to cover references that
 // landed AFTER that scan — the window is sized in orphan_gc.go, not
 // here.
+//
+// Variants: content references an ORIGINAL's id, so stamps land on the
+// parent row — a fresh PARENT stamp refuses the variant's claim too
+// (the NOT EXISTS below). A parent already claimed in the same sweep
+// has no row, so its variants claim normally, which is correct: a
+// legitimately reclaimed original takes its thumbnails with it.
 func (s *Store) ClaimNeverAttachedAttachment(id string, refCutoff time.Time) (bool, error) {
+	cutoff := refCutoff.UTC().Format(time.RFC3339)
 	res, err := s.db.Exec(s.q(`
 		DELETE FROM attachments
 		WHERE id = ?
 		  AND item_id IS NULL
 		  AND deleted_at IS NULL
 		  AND (last_referenced_at IS NULL OR last_referenced_at < ?)
-	`), id, refCutoff.UTC().Format(time.RFC3339))
+		  AND NOT EXISTS (
+		    SELECT 1 FROM attachments p
+		    WHERE p.id = attachments.parent_id
+		      AND p.last_referenced_at >= ?
+		  )
+	`), id, cutoff, cutoff)
 	if err != nil {
 		return false, fmt.Errorf("claim never-attached attachment: %w", err)
 	}

--- a/internal/store/attachments_gc_claim_test.go
+++ b/internal/store/attachments_gc_claim_test.go
@@ -303,3 +303,43 @@ func TestClaimProtocol_FiledRaceSequence(t *testing.T) {
 		t.Errorf("row destroyed despite live reference")
 	}
 }
+
+// TestStampAttachmentRefs_StampsVariantsOfReferencedOriginal pins the
+// codex-round-4 half of the variant story: stamping a referenced
+// ORIGINAL also stamps rows whose parent_id points at it, so a
+// concurrently-claimed thumbnail is protected by its OWN row's stamp
+// (and, on Postgres, its own row lock) — not just the claim's parent
+// NOT EXISTS belt.
+func TestStampAttachmentRefs_StampsVariantsOfReferencedOriginal(t *testing.T) {
+	f := newGCClaimFixture(t)
+	orig := f.seedNeverAttached(t)
+
+	// A variant hanging off the original.
+	thumbID := orig.ID + "-thumb"
+	if _, err := f.s.db.Exec(f.s.q(
+		`INSERT INTO attachments (id, workspace_id, item_id, uploaded_by, storage_key, content_hash, mime_type, size_bytes, filename, parent_id, variant, created_at)
+		 VALUES (?, ?, NULL, '', ?, ?, 'image/png', 10, 't.png', ?, 'thumb-md', ?)`),
+		thumbID, f.wsID, "fs:t-"+thumbID, "h-t-"+thumbID, orig.ID,
+		time.Now().Add(-40*24*time.Hour).UTC().Format(time.RFC3339)); err != nil {
+		t.Fatalf("insert variant: %v", err)
+	}
+
+	if _, err := f.s.CreateItem(f.wsID, f.collID, models.ItemCreate{
+		Title:   "ref holder",
+		Content: "ref ![x](pad-attachment:" + orig.ID + ")",
+	}); err != nil {
+		t.Fatalf("CreateItem: %v", err)
+	}
+
+	if f.lastReferencedAt(t, orig.ID) == nil {
+		t.Errorf("original not stamped")
+	}
+	if f.lastReferencedAt(t, thumbID) == nil {
+		t.Errorf("variant of referenced original not stamped")
+	}
+	// And the variant's own fresh stamp refuses its claim directly.
+	claimed, err := f.s.ClaimNeverAttachedAttachment(thumbID, time.Now().Add(-15*time.Minute))
+	if err != nil || claimed {
+		t.Fatalf("fresh-own-stamp variant claim = (%v, %v), want (false, nil)", claimed, err)
+	}
+}

--- a/internal/store/attachments_gc_claim_test.go
+++ b/internal/store/attachments_gc_claim_test.go
@@ -1,0 +1,305 @@
+package store
+
+// BUG-2415 — the orphan-GC claim protocol at the store layer: writer-side
+// pad-attachment: reference stamps (stampAttachmentRefsTx via the content
+// writers) and the conditional Claim* deletes whose predicates ARE the
+// serialization. The filed race is pinned as an explicit sequence test,
+// plus a counterfactual arm proving the stamp condition — not something
+// else — is what refuses the claim.
+
+import (
+	"testing"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+type gcClaimFixture struct {
+	s      *Store
+	wsID   string
+	collID string
+}
+
+func newGCClaimFixture(t *testing.T) *gcClaimFixture {
+	t.Helper()
+	s := testStore(t)
+	ws, err := s.CreateWorkspace(models.WorkspaceCreate{Name: "GC Claim WS"})
+	if err != nil {
+		t.Fatalf("CreateWorkspace: %v", err)
+	}
+	coll, err := s.CreateCollection(ws.ID, models.CollectionCreate{
+		Name: "Tasks", Slug: "tasks", Prefix: "TASK",
+		Schema: `{"fields":[{"key":"status","type":"select","options":["open","done"],"default":"open"}]}`,
+	})
+	if err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	return &gcClaimFixture{s: s, wsID: ws.ID, collID: coll.ID}
+}
+
+// seedNeverAttached inserts a never-attached attachment row aged past any
+// grace cutoff a test will use.
+func (f *gcClaimFixture) seedNeverAttached(t *testing.T) *models.Attachment {
+	t.Helper()
+	variant := "original"
+	a := &models.Attachment{
+		ID:          newID(),
+		WorkspaceID: f.wsID,
+		StorageKey:  "fs:deadbeef" + newID()[:8],
+		ContentHash: "hash-" + newID()[:8],
+		Filename:    "orphan.png",
+		MimeType:    "image/png",
+		SizeBytes:   42,
+		Variant:     &variant,
+	}
+	if err := f.s.CreateAttachment(a); err != nil {
+		t.Fatalf("CreateAttachment: %v", err)
+	}
+	// Age it so a candidate SELECT with a now-ish cutoff matches.
+	old := time.Now().Add(-40 * 24 * time.Hour).UTC().Format(time.RFC3339)
+	if _, err := f.s.db.Exec(f.s.q(`UPDATE attachments SET created_at = ? WHERE id = ?`), old, a.ID); err != nil {
+		t.Fatalf("age attachment: %v", err)
+	}
+	return a
+}
+
+func (f *gcClaimFixture) lastReferencedAt(t *testing.T, id string) *string {
+	t.Helper()
+	var v *string
+	if err := f.s.db.QueryRow(f.s.q(`SELECT last_referenced_at FROM attachments WHERE id = ?`), id).Scan(&v); err != nil {
+		t.Fatalf("read last_referenced_at: %v", err)
+	}
+	return v
+}
+
+func (f *gcClaimFixture) rowExists(t *testing.T, id string) bool {
+	t.Helper()
+	var n int
+	if err := f.s.db.QueryRow(f.s.q(`SELECT COUNT(*) FROM attachments WHERE id = ?`), id).Scan(&n); err != nil {
+		t.Fatalf("count row: %v", err)
+	}
+	return n == 1
+}
+
+func TestStampAttachmentRefs_ItemContentAndFields(t *testing.T) {
+	f := newGCClaimFixture(t)
+	inContent := f.seedNeverAttached(t)
+	inFields := f.seedNeverAttached(t)
+	unrelated := f.seedNeverAttached(t)
+
+	item, err := f.s.CreateItem(f.wsID, f.collID, models.ItemCreate{
+		Title:   "stamps",
+		Content: "see ![img](pad-attachment:" + inContent.ID + ")",
+		Fields:  `{"status":"open","cover":"pad-attachment:` + inFields.ID + `"}`,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem: %v", err)
+	}
+	if f.lastReferencedAt(t, inContent.ID) == nil {
+		t.Errorf("content-referenced attachment not stamped on create")
+	}
+	if f.lastReferencedAt(t, inFields.ID) == nil {
+		t.Errorf("fields-referenced attachment not stamped on create")
+	}
+	if f.lastReferencedAt(t, unrelated.ID) != nil {
+		t.Errorf("unreferenced attachment stamped spuriously")
+	}
+
+	// Update path: a new reference arriving via UpdateItem stamps too.
+	late := f.seedNeverAttached(t)
+	newContent := "now also [f](pad-attachment:" + late.ID + ")"
+	if _, err := f.s.UpdateItem(item.ID, models.ItemUpdate{Content: &newContent}); err != nil {
+		t.Fatalf("UpdateItem: %v", err)
+	}
+	if f.lastReferencedAt(t, late.ID) == nil {
+		t.Errorf("attachment referenced via UpdateItem not stamped")
+	}
+}
+
+func TestStampAttachmentRefs_Comments(t *testing.T) {
+	f := newGCClaimFixture(t)
+	inCreate := f.seedNeverAttached(t)
+	inEdit := f.seedNeverAttached(t)
+
+	item, err := f.s.CreateItem(f.wsID, f.collID, models.ItemCreate{Title: "host"})
+	if err != nil {
+		t.Fatalf("CreateItem: %v", err)
+	}
+	c, err := f.s.CreateComment(f.wsID, item.ID, "", models.CommentCreate{
+		Body: "look: ![x](pad-attachment:" + inCreate.ID + ")",
+	})
+	if err != nil {
+		t.Fatalf("CreateComment: %v", err)
+	}
+	if f.lastReferencedAt(t, inCreate.ID) == nil {
+		t.Errorf("comment-create reference not stamped")
+	}
+	if _, err := f.s.UpdateComment(c.ID, "edited: pad-attachment:"+inEdit.ID); err != nil {
+		t.Fatalf("UpdateComment: %v", err)
+	}
+	if f.lastReferencedAt(t, inEdit.ID) == nil {
+		t.Errorf("comment-edit reference not stamped")
+	}
+}
+
+func TestStampAttachmentRefs_WorkspaceScoped(t *testing.T) {
+	f := newGCClaimFixture(t)
+	foreign := f.seedNeverAttached(t)
+
+	// A second workspace pastes a reference to the first workspace's
+	// attachment id — it must NOT refresh the foreign row.
+	ws2, err := f.s.CreateWorkspace(models.WorkspaceCreate{Name: "Other WS"})
+	if err != nil {
+		t.Fatalf("CreateWorkspace: %v", err)
+	}
+	coll2, err := f.s.CreateCollection(ws2.ID, models.CollectionCreate{
+		Name: "Tasks", Slug: "tasks", Prefix: "TASK",
+		Schema: `{"fields":[{"key":"status","type":"select","options":["open"],"default":"open"}]}`,
+	})
+	if err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	if _, err := f.s.CreateItem(ws2.ID, coll2.ID, models.ItemCreate{
+		Title:   "foreign paste",
+		Content: "stolen ref pad-attachment:" + foreign.ID,
+	}); err != nil {
+		t.Fatalf("CreateItem: %v", err)
+	}
+	if f.lastReferencedAt(t, foreign.ID) != nil {
+		t.Errorf("foreign-workspace paste refreshed another workspace's attachment")
+	}
+}
+
+func TestClaimNeverAttached_PredicateLegs(t *testing.T) {
+	f := newGCClaimFixture(t)
+	cutoff := time.Now().Add(-15 * time.Minute)
+
+	// Leg 1: unstamped row → claimable.
+	plain := f.seedNeverAttached(t)
+	claimed, err := f.s.ClaimNeverAttachedAttachment(plain.ID, cutoff)
+	if err != nil || !claimed {
+		t.Fatalf("unstamped claim = (%v, %v), want (true, nil)", claimed, err)
+	}
+	if f.rowExists(t, plain.ID) {
+		t.Errorf("claimed row still present")
+	}
+
+	// Leg 2: fresh stamp → refused, row survives.
+	fresh := f.seedNeverAttached(t)
+	nowTS := time.Now().UTC().Format(time.RFC3339)
+	if _, err := f.s.db.Exec(f.s.q(`UPDATE attachments SET last_referenced_at = ? WHERE id = ?`), nowTS, fresh.ID); err != nil {
+		t.Fatalf("stamp: %v", err)
+	}
+	claimed, err = f.s.ClaimNeverAttachedAttachment(fresh.ID, cutoff)
+	if err != nil || claimed {
+		t.Fatalf("fresh-stamp claim = (%v, %v), want (false, nil)", claimed, err)
+	}
+	if !f.rowExists(t, fresh.ID) {
+		t.Errorf("refused claim deleted the row anyway")
+	}
+
+	// Leg 3 (counterfactual for leg 2): the SAME row claims fine once
+	// the cutoff moves past its stamp — proving the stamp condition,
+	// not some other predicate, is what refused above.
+	claimed, err = f.s.ClaimNeverAttachedAttachment(fresh.ID, time.Now().Add(time.Minute))
+	if err != nil || !claimed {
+		t.Fatalf("stale-stamp claim = (%v, %v), want (true, nil)", claimed, err)
+	}
+
+	// Leg 4: attached row → refused regardless of stamp.
+	attached := f.seedNeverAttached(t)
+	item, err := f.s.CreateItem(f.wsID, f.collID, models.ItemCreate{Title: "owner"})
+	if err != nil {
+		t.Fatalf("CreateItem: %v", err)
+	}
+	if _, err := f.s.db.Exec(f.s.q(`UPDATE attachments SET item_id = ? WHERE id = ?`), item.ID, attached.ID); err != nil {
+		t.Fatalf("attach: %v", err)
+	}
+	claimed, err = f.s.ClaimNeverAttachedAttachment(attached.ID, cutoff)
+	if err != nil || claimed {
+		t.Fatalf("attached claim = (%v, %v), want (false, nil)", claimed, err)
+	}
+
+	// Leg 5: soft-deleted row → wrong class, refused.
+	soft := f.seedNeverAttached(t)
+	if _, err := f.s.db.Exec(f.s.q(`UPDATE attachments SET deleted_at = ? WHERE id = ?`), nowTS, soft.ID); err != nil {
+		t.Fatalf("soft delete: %v", err)
+	}
+	claimed, err = f.s.ClaimNeverAttachedAttachment(soft.ID, cutoff)
+	if err != nil || claimed {
+		t.Fatalf("soft-deleted claim via never-attached = (%v, %v), want (false, nil)", claimed, err)
+	}
+}
+
+func TestClaimSoftDeleted_RefusesRestoredRow(t *testing.T) {
+	f := newGCClaimFixture(t)
+	a := f.seedNeverAttached(t)
+	oldTS := time.Now().Add(-40 * 24 * time.Hour).UTC().Format(time.RFC3339)
+	if _, err := f.s.db.Exec(f.s.q(`UPDATE attachments SET deleted_at = ? WHERE id = ?`), oldTS, a.ID); err != nil {
+		t.Fatalf("soft delete: %v", err)
+	}
+
+	// Restore between the candidate SELECT and the claim: clear
+	// deleted_at, then claim with a cutoff that WOULD have reclaimed it.
+	if _, err := f.s.db.Exec(f.s.q(`UPDATE attachments SET deleted_at = NULL WHERE id = ?`), a.ID); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+	claimed, err := f.s.ClaimSoftDeletedAttachment(a.ID, time.Now())
+	if err != nil || claimed {
+		t.Fatalf("restored-row claim = (%v, %v), want (false, nil)", claimed, err)
+	}
+	if !f.rowExists(t, a.ID) {
+		t.Errorf("restored row deleted anyway")
+	}
+
+	// Counterfactual: re-soft-delete past grace → claims.
+	if _, err := f.s.db.Exec(f.s.q(`UPDATE attachments SET deleted_at = ? WHERE id = ?`), oldTS, a.ID); err != nil {
+		t.Fatalf("re-soft-delete: %v", err)
+	}
+	claimed, err = f.s.ClaimSoftDeletedAttachment(a.ID, time.Now())
+	if err != nil || !claimed {
+		t.Fatalf("past-grace claim = (%v, %v), want (true, nil)", claimed, err)
+	}
+}
+
+// TestClaimProtocol_FiledRaceSequence pins BUG-2415's exact interleaving
+// at the store layer: the sweep's content scan finds no reference, a
+// writer then commits a reference (whose transaction stamps the row),
+// and the claim that follows must refuse — row survives, and since the
+// blob is only reclaimed after a successful claim (row-before-bytes in
+// the sweep), the bytes survive by construction.
+func TestClaimProtocol_FiledRaceSequence(t *testing.T) {
+	f := newGCClaimFixture(t)
+	a := f.seedNeverAttached(t)
+
+	// Step 1 — the sweep's scan: no reference anywhere.
+	referenced, err := f.s.AttachmentReferenced(f.wsID, a.ID)
+	if err != nil {
+		t.Fatalf("AttachmentReferenced: %v", err)
+	}
+	if referenced {
+		t.Fatalf("precondition: attachment unexpectedly referenced")
+	}
+
+	// Step 2 — a writer commits a reference AFTER the scan. The stamp
+	// rides the same transaction as the content write.
+	if _, err := f.s.CreateItem(f.wsID, f.collID, models.ItemCreate{
+		Title:   "late reference",
+		Content: "raced: ![x](pad-attachment:" + a.ID + ")",
+	}); err != nil {
+		t.Fatalf("CreateItem: %v", err)
+	}
+
+	// Step 3 — the sweep's claim runs with the production-shaped cutoff
+	// (now - stale window). The fresh stamp must refuse it.
+	claimed, err := f.s.ClaimNeverAttachedAttachment(a.ID, time.Now().Add(-15*time.Minute))
+	if err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+	if claimed {
+		t.Fatalf("claim succeeded against a just-referenced attachment — the filed data-loss race")
+	}
+	if !f.rowExists(t, a.ID) {
+		t.Errorf("row destroyed despite live reference")
+	}
+}

--- a/internal/store/comments.go
+++ b/internal/store/comments.go
@@ -40,6 +40,11 @@ func (s *Store) CreateComment(workspaceID, itemID, userID string, input models.C
 	}
 	defer tx.Rollback()
 
+	// Stamp BEFORE the INSERT — see the ORDERING note on
+	// stampAttachmentRefsTx (BUG-2415, codex round 3).
+	if err := stampAttachmentRefsTx(tx, s, workspaceID, input.Body); err != nil {
+		return nil, err
+	}
 	_, err = tx.Exec(s.q(`
 		INSERT INTO comments (id, item_id, workspace_id, author, user_id, body, created_by, source, activity_id, parent_id, created_at, updated_at)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`),
@@ -48,9 +53,6 @@ func (s *Store) CreateComment(workspaceID, itemID, userID string, input models.C
 	)
 	if err != nil {
 		return nil, fmt.Errorf("insert comment: %w", err)
-	}
-	if err := stampAttachmentRefsTx(tx, s, workspaceID, input.Body); err != nil {
-		return nil, err
 	}
 	if err := tx.Commit(); err != nil {
 		return nil, fmt.Errorf("commit comment: %w", err)
@@ -80,6 +82,11 @@ func (s *Store) UpdateComment(id, body string) (*models.Comment, error) {
 		}
 		return nil, fmt.Errorf("resolve comment workspace: %w", err)
 	}
+	// Stamp BEFORE the UPDATE — see the ORDERING note on
+	// stampAttachmentRefsTx (BUG-2415, codex round 3).
+	if err := stampAttachmentRefsTx(tx, s, workspaceID, body); err != nil {
+		return nil, err
+	}
 	res, err := tx.Exec(s.q(`UPDATE comments SET body = ?, updated_at = ? WHERE id = ?`), body, ts, id)
 	if err != nil {
 		return nil, fmt.Errorf("update comment: %w", err)
@@ -87,9 +94,6 @@ func (s *Store) UpdateComment(id, body string) (*models.Comment, error) {
 	n, _ := res.RowsAffected()
 	if n == 0 {
 		return nil, sql.ErrNoRows
-	}
-	if err := stampAttachmentRefsTx(tx, s, workspaceID, body); err != nil {
-		return nil, err
 	}
 	if err := tx.Commit(); err != nil {
 		return nil, fmt.Errorf("commit comment update: %w", err)

--- a/internal/store/comments.go
+++ b/internal/store/comments.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"time"
 
@@ -30,7 +31,16 @@ func (s *Store) CreateComment(workspaceID, itemID, userID string, input models.C
 		author = createdBy
 	}
 
-	_, err := s.db.Exec(s.q(`
+	// Transactional so the pad-attachment: reference stamp (BUG-2415)
+	// commits atomically with the body that carries the reference —
+	// the orphan-GC claim must never observe one without the other.
+	tx, err := s.db.Begin()
+	if err != nil {
+		return nil, fmt.Errorf("begin comment tx: %w", err)
+	}
+	defer tx.Rollback()
+
+	_, err = tx.Exec(s.q(`
 		INSERT INTO comments (id, item_id, workspace_id, author, user_id, body, created_by, source, activity_id, parent_id, created_at, updated_at)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`),
 		id, itemID, workspaceID, author, nilIfEmpty(userID), input.Body, createdBy, source,
@@ -38,6 +48,12 @@ func (s *Store) CreateComment(workspaceID, itemID, userID string, input models.C
 	)
 	if err != nil {
 		return nil, fmt.Errorf("insert comment: %w", err)
+	}
+	if err := stampAttachmentRefsTx(tx, s, workspaceID, input.Body); err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit comment: %w", err)
 	}
 
 	return s.GetComment(id)
@@ -49,13 +65,34 @@ func (s *Store) CreateComment(workspaceID, itemID, userID string, input models.C
 // admin) is enforced by the handler, not here.
 func (s *Store) UpdateComment(id, body string) (*models.Comment, error) {
 	ts := now()
-	res, err := s.db.Exec(s.q(`UPDATE comments SET body = ?, updated_at = ? WHERE id = ?`), body, ts, id)
+	// Transactional for the same BUG-2415 reason as CreateComment: the
+	// new body and its pad-attachment: reference stamp commit together.
+	tx, err := s.db.Begin()
+	if err != nil {
+		return nil, fmt.Errorf("begin comment tx: %w", err)
+	}
+	defer tx.Rollback()
+
+	var workspaceID string
+	if err := tx.QueryRow(s.q(`SELECT workspace_id FROM comments WHERE id = ?`), id).Scan(&workspaceID); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, sql.ErrNoRows
+		}
+		return nil, fmt.Errorf("resolve comment workspace: %w", err)
+	}
+	res, err := tx.Exec(s.q(`UPDATE comments SET body = ?, updated_at = ? WHERE id = ?`), body, ts, id)
 	if err != nil {
 		return nil, fmt.Errorf("update comment: %w", err)
 	}
 	n, _ := res.RowsAffected()
 	if n == 0 {
 		return nil, sql.ErrNoRows
+	}
+	if err := stampAttachmentRefsTx(tx, s, workspaceID, body); err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit comment update: %w", err)
 	}
 	return s.GetComment(id)
 }

--- a/internal/store/export.go
+++ b/internal/store/export.go
@@ -323,6 +323,11 @@ func (s *Store) ImportWorkspace(data *models.WorkspaceExport, newName string, ow
 		// per-workspace seqs — clients post-import see them on the next
 		// /items-index fetch, and any subsequent mutation keeps bumping
 		// from a sensible floor instead of a flat MAX(seq)=0.
+		// Stamp BEFORE the INSERT — see the ORDERING note on
+		// stampAttachmentRefsTx (BUG-2415).
+		if err := stampAttachmentRefsTx(tx, s, ws.ID, it.Content, fieldsJSON); err != nil {
+			return nil, err
+		}
 		_, err := tx.Exec(s.q(`
 			INSERT INTO items (id, workspace_id, collection_id, title, slug, content, fields, tags, pinned, sort_order, parent_id, created_by, last_modified_by, source, item_number, created_at, updated_at, seq)
 			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULLIF(?, ''), ?, ?, ?, ?, ?, ?, `+nextWorkspaceSeqSubquery+`)`),
@@ -331,14 +336,6 @@ func (s *Store) ImportWorkspace(data *models.WorkspaceExport, newName string, ow
 			it.CreatedAt, it.UpdatedAt, ws.ID)
 		if err != nil {
 			return nil, fmt.Errorf("import item %s: %w", it.Title, err)
-		}
-		// Imported content can carry pad-attachment: references to rows
-		// this same import (or a prior state) created as never-attached —
-		// stamp them inside the import tx so a sweep racing the import
-		// can't claim a row the arriving content references (BUG-2415,
-		// codex round 1 #2).
-		if err := stampAttachmentRefsTx(tx, s, ws.ID, it.Content, fieldsJSON); err != nil {
-			return nil, err
 		}
 	}
 
@@ -377,6 +374,10 @@ func (s *Store) ImportWorkspace(data *models.WorkspaceExport, newName string, ow
 		if newItemID == "" {
 			continue
 		}
+		// Stamp BEFORE the INSERT (BUG-2415).
+		if err := stampAttachmentRefsTx(tx, s, ws.ID, cm.Body); err != nil {
+			return nil, err
+		}
 		_, err := tx.Exec(s.q(`
 			INSERT INTO comments (id, item_id, workspace_id, author, body, created_by, source, created_at, updated_at)
 			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`),
@@ -384,10 +385,6 @@ func (s *Store) ImportWorkspace(data *models.WorkspaceExport, newName string, ow
 			cm.CreatedAt, cm.UpdatedAt)
 		if err != nil {
 			return nil, fmt.Errorf("import comment: %w", err)
-		}
-		// Same BUG-2415 stamp as the item-import loop above.
-		if err := stampAttachmentRefsTx(tx, s, ws.ID, cm.Body); err != nil {
-			return nil, err
 		}
 	}
 

--- a/internal/store/export.go
+++ b/internal/store/export.go
@@ -332,6 +332,14 @@ func (s *Store) ImportWorkspace(data *models.WorkspaceExport, newName string, ow
 		if err != nil {
 			return nil, fmt.Errorf("import item %s: %w", it.Title, err)
 		}
+		// Imported content can carry pad-attachment: references to rows
+		// this same import (or a prior state) created as never-attached —
+		// stamp them inside the import tx so a sweep racing the import
+		// can't claim a row the arriving content references (BUG-2415,
+		// codex round 1 #2).
+		if err := stampAttachmentRefsTx(tx, s, ws.ID, it.Content, fieldsJSON); err != nil {
+			return nil, err
+		}
 	}
 
 	// Second pass: remap parent_id and relation fields (now all items exist).
@@ -376,6 +384,10 @@ func (s *Store) ImportWorkspace(data *models.WorkspaceExport, newName string, ow
 			cm.CreatedAt, cm.UpdatedAt)
 		if err != nil {
 			return nil, fmt.Errorf("import comment: %w", err)
+		}
+		// Same BUG-2415 stamp as the item-import loop above.
+		if err := stampAttachmentRefsTx(tx, s, ws.ID, cm.Body); err != nil {
+			return nil, err
 		}
 	}
 

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -4517,6 +4517,13 @@ func (s *Store) moveItemWithPreCheckOnce(
 		return nil, fmt.Errorf("move item: %w", err)
 	}
 
+	// A move's field OVERRIDES can inject a brand-new pad-attachment:
+	// reference into the rewritten fields blob — this write bypasses the
+	// UpdateItem core, so stamp here too (BUG-2415, codex round 1 #2).
+	if err := stampAttachmentRefsTx(tx, s, existing.WorkspaceID, newFieldsJSON); err != nil {
+		return nil, err
+	}
+
 	// A move can carry a status-changing field override (e.g.
 	// `pad item move ... --field status=done`), which rewrites `fields`
 	// outside the UpdateItemWithPreCheck path. Record the transition here

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -283,6 +283,13 @@ func (s *Store) insertItemTx(tx *sql.Tx, id, workspaceID, collectionID, slug, ts
 		contentFlushedAt = ts
 		contentFlushedOpLogID = int64(0)
 	}
+	// Stamp any pad-attachment: references BEFORE the INSERT (see the
+	// ORDERING note on stampAttachmentRefsTx): the stamp's row locks
+	// make a concurrent GC claim block until this tx commits.
+	if err := stampAttachmentRefsTx(tx, s, workspaceID, input.Content, fields); err != nil {
+		return err
+	}
+
 	// The workspace advisory lock acquired above for item_number
 	// assignment ALSO serializes the seq subquery below — both read
 	// MAX(...) per workspace and would otherwise race in Postgres.
@@ -314,13 +321,6 @@ func (s *Store) insertItemTx(tx *sql.Tx, id, workspaceID, collectionID, slug, ts
 		if err != nil {
 			return fmt.Errorf("create initial version: %w", err)
 		}
-	}
-
-	// Stamp any pad-attachment: references in the new content/fields so
-	// the orphan-GC claim sees them (BUG-2415). Same tx as the INSERT —
-	// the stamp and the reference commit atomically.
-	if err := stampAttachmentRefsTx(tx, s, workspaceID, input.Content, fields); err != nil {
-		return err
 	}
 
 	// Index [[...]] wiki-links from the new content. Lives inside the
@@ -2502,19 +2502,13 @@ func (s *Store) updateItemWithParentLinkOnce(
 		statusBefore = extractFieldValue(existing.Fields, doneKey)
 	}
 
-	args = append(args, id)
-	query := fmt.Sprintf("UPDATE items SET %s WHERE id = ?", strings.Join(sets, ", "))
-	_, err = tx.Exec(s.q(query), args...)
-	if err != nil {
-		return nil, fmt.Errorf("update item: %w", err)
-	}
-
 	// Stamp pad-attachment: references carried by the new content /
-	// fields so the orphan-GC claim sees them (BUG-2415). Same tx as
-	// the UPDATE — reference and stamp commit atomically. Covers every
-	// funnel into this core: item PATCH, the collab-snapshot flush,
-	// version restore, and bulk updates. input.Fields is already the
-	// RESOLVED blob here (a fields_patch was merged into it above).
+	// fields BEFORE the UPDATE (see the ORDERING note on
+	// stampAttachmentRefsTx — the stamp's row locks make a concurrent
+	// GC claim wait out this tx). Covers every funnel into this core:
+	// item PATCH, the collab-snapshot flush, version restore, and bulk
+	// updates. input.Fields is already the RESOLVED blob here (a
+	// fields_patch was merged into it above).
 	{
 		var refTexts []string
 		if input.Content != nil {
@@ -2528,6 +2522,13 @@ func (s *Store) updateItemWithParentLinkOnce(
 				return nil, err
 			}
 		}
+	}
+
+	args = append(args, id)
+	query := fmt.Sprintf("UPDATE items SET %s WHERE id = ?", strings.Join(sets, ", "))
+	_, err = tx.Exec(s.q(query), args...)
+	if err != nil {
+		return nil, fmt.Errorf("update item: %w", err)
 	}
 
 	// Durable restore boundary (BUG-2264): stamp last_restore_seq with the seq
@@ -4507,6 +4508,15 @@ func (s *Store) moveItemWithPreCheckOnce(
 		}
 	}
 
+	// A move's field OVERRIDES can inject a brand-new pad-attachment:
+	// reference into the rewritten fields blob — this write bypasses the
+	// UpdateItem core, so stamp here too, BEFORE the UPDATE (BUG-2415,
+	// codex rounds 1 #2 and 3; see the ORDERING note on
+	// stampAttachmentRefsTx).
+	if err := stampAttachmentRefsTx(tx, s, existing.WorkspaceID, newFieldsJSON); err != nil {
+		return nil, err
+	}
+
 	moveTS := time.Now().UTC().Format(time.RFC3339)
 	_, err = tx.Exec(s.q(`
 		UPDATE items
@@ -4515,13 +4525,6 @@ func (s *Store) moveItemWithPreCheckOnce(
 		targetCollectionID, newFieldsJSON, moveTS, existing.WorkspaceID, itemID)
 	if err != nil {
 		return nil, fmt.Errorf("move item: %w", err)
-	}
-
-	// A move's field OVERRIDES can inject a brand-new pad-attachment:
-	// reference into the rewritten fields blob — this write bypasses the
-	// UpdateItem core, so stamp here too (BUG-2415, codex round 1 #2).
-	if err := stampAttachmentRefsTx(tx, s, existing.WorkspaceID, newFieldsJSON); err != nil {
-		return nil, err
 	}
 
 	// A move can carry a status-changing field override (e.g.

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -316,6 +316,13 @@ func (s *Store) insertItemTx(tx *sql.Tx, id, workspaceID, collectionID, slug, ts
 		}
 	}
 
+	// Stamp any pad-attachment: references in the new content/fields so
+	// the orphan-GC claim sees them (BUG-2415). Same tx as the INSERT —
+	// the stamp and the reference commit atomically.
+	if err := stampAttachmentRefsTx(tx, s, workspaceID, input.Content, fields); err != nil {
+		return err
+	}
+
 	// Index [[...]] wiki-links from the new content. Lives inside the
 	// same tx as the items INSERT so partial state never lands and a
 	// content rollback also rolls back the index rows. Empty content
@@ -2500,6 +2507,27 @@ func (s *Store) updateItemWithParentLinkOnce(
 	_, err = tx.Exec(s.q(query), args...)
 	if err != nil {
 		return nil, fmt.Errorf("update item: %w", err)
+	}
+
+	// Stamp pad-attachment: references carried by the new content /
+	// fields so the orphan-GC claim sees them (BUG-2415). Same tx as
+	// the UPDATE — reference and stamp commit atomically. Covers every
+	// funnel into this core: item PATCH, the collab-snapshot flush,
+	// version restore, and bulk updates. input.Fields is already the
+	// RESOLVED blob here (a fields_patch was merged into it above).
+	{
+		var refTexts []string
+		if input.Content != nil {
+			refTexts = append(refTexts, *input.Content)
+		}
+		if input.Fields != nil {
+			refTexts = append(refTexts, *input.Fields)
+		}
+		if len(refTexts) > 0 {
+			if err := stampAttachmentRefsTx(tx, s, existing.WorkspaceID, refTexts...); err != nil {
+				return nil, err
+			}
+		}
 	}
 
 	// Durable restore boundary (BUG-2264): stamp last_restore_seq with the seq

--- a/internal/store/migrations/079_attachment_last_referenced.sql
+++ b/internal/store/migrations/079_attachment_last_referenced.sql
@@ -1,0 +1,17 @@
+-- Migration 079: attachments.last_referenced_at (BUG-2415).
+--
+-- Writer-side reference stamp for the orphan-GC claim protocol. Every
+-- content writer that persists text containing a `pad-attachment:<id>`
+-- reference (item create/update — including the collab-snapshot flush,
+-- version restore, and artifact import, which all funnel through the
+-- same store methods — and comment create/update) bumps this column
+-- inside its own write transaction. The GC sweep's row deletion is a
+-- conditional DELETE that refuses when the stamp is fresh, closing the
+-- race where a reference commits between the sweep's content scan and
+-- its reclaim.
+--
+-- TEXT ISO-8601 UTC like every other timestamp on this table —
+-- lexicographic compare equals chronological compare. Nullable: NULL
+-- means "never stamped", which the claim treats as claimable (the
+-- content LIKE scan already ran and found nothing).
+ALTER TABLE attachments ADD COLUMN last_referenced_at TEXT;

--- a/internal/store/pgmigrations/057_attachment_last_referenced.sql
+++ b/internal/store/pgmigrations/057_attachment_last_referenced.sql
@@ -1,0 +1,5 @@
+-- Migration 057: attachments.last_referenced_at (BUG-2415).
+-- Postgres mirror of SQLite migration 079 — see that file for the full
+-- rationale (writer-side reference stamp backing the orphan-GC claim
+-- protocol). TEXT ISO-8601 UTC to match the table's other timestamps.
+ALTER TABLE attachments ADD COLUMN IF NOT EXISTS last_referenced_at TEXT;


### PR DESCRIPTION
## Root cause

`runOrphanGCSweep` scanned content for `pad-attachment:` references, then deleted the **blob**, then the row — with nothing serializing it against content writers. A reference committing between scan and reclaim left a dangling id or, worse, a surviving row whose bytes were already gone.

## The claim protocol (lead-approved A+B)

- **B — writer-side stamp.** New `attachments.last_referenced_at` (dual-dialect migration 079/057, TEXT RFC3339). `stampAttachmentRefsTx` parses `pad-attachment:` refs (chunked at 400 ids) and stamps the rows **and their variants** (`parent_id IN`) inside the writer's own transaction, executed **before** the content statement — on Postgres the stamp's row locks make a concurrent claim DELETE block until the writer commits, then re-evaluate against the fresh stamp.
- **A — claim-by-delete, row before bytes.** The sweep's row deletion is a conditional DELETE re-asserting reclaimable state in the statement itself: `ClaimNeverAttachedAttachment` (unattached + live + no fresh own-stamp + no fresh **parent** stamp) and `ClaimSoftDeletedAttachment` (still deleted + still past grace — a mid-sweep restore now survives too). The blob is reclaimed **only** after a successful claim, so a surviving row implies surviving bytes; a `BlobDeleteFailures` counter surfaces the inverted failure mode.
- **`orphanGCRefStaleWindow` (15 m)** is documented as a correctness parameter: the LIKE scan still guards long-lived references, so the stamp only covers refs landing after the scan — the window bounds scan-to-claim latency plus a maximally stalled writer transaction, and is explicitly the bound on the >window stamp-to-commit residual.

## Coverage enumeration (constraint 2 — sites, not prose)

Every persistence path that can write a `pad-attachment:` ref, mapped to its stamp call:

| Path | Funnel | Stamp site |
|---|---|---|
| Item create (web/CLI/MCP), artifact import (`createItemChecked`), template seeds | `store.CreateItem` | pre-INSERT, items.go |
| Item PATCH, collab-snapshot flush (`?source=collab-snapshot`), version restore, bulk update | `UpdateItemWithPreCheck/WithParentLink` core | pre-UPDATE, items.go (fields_patch already resolved) |
| Move with `--field` overrides | `MoveItemWithPreCheck` | pre-UPDATE, items.go |
| Comment create / edit | `CreateComment` / `UpdateComment` (both now transactional) | pre-INSERT/UPDATE, comments.go |
| Workspace import | `ImportWorkspace` item + comment loops | pre-INSERT ×2, export.go |
| Cross-workspace copy | clones are inserted **attached** (`item_id` set) → not orphan-eligible | n/a by construction |
| Documents table (legacy) | invisible to scan AND stamp — **pre-existing**, filed **BUG-2614** | out of scope |
| Bundle remap skips comment bodies | **pre-existing**, filed **BUG-2615** | out of scope |

## Accepted residuals (documented at `stampAttachmentRefsTx`)

1. Claim **commits first** → the writer's stamp matches zero rows and the committed text carries a dangling ref — identical to referencing any already-deleted attachment; deliberately not a save failure (zero-rows also describes legitimate unknown/foreign/typo ids).
2. A writer transaction whose stamp-to-commit span exceeds the window — which is why the window is sized to a pathologically stalled transaction.

## Verification

- Sweep-level: fresh-stamp row survives (row **and** blob) with an aged-stamp counterfactual arm — **verified discriminating against a compiling control build of the old sweep order** (control reclaims the fresh-stamped row). Variant test with a both-guards-disabled total-loss control (single-guard mutations pass by design — belt and suspenders proven separately).
- Store-level: every claim predicate leg with counterfactuals, the filed-race sequence, stamp wiring on all sites incl. workspace scoping and variant stamping.
- `go test ./...`, `make lint`, `make test-pg` green at every round; 5 codex rounds (R2/R5 confirm CLEAN; substantive catches folded: coverage gaps → move+import stamps, variant hole → parent-aware scan + claim + variant stamping, stamp ordering → pre-content, chunking, observability counter).

## For PLAN-2411 / PLAN-2416

A true claim is irrevocable (noted on both Claim methods): recovery surfaces can restore only rows the claim hasn't taken — restores that clear `deleted_at` before the claim commits now survive the sweep by predicate.