### PR TITLE
fix(web): portal the pane action-bar menus — anchored panels clipped against the pane's scroll container (BUG-2610)

### DIFF
--- a/web/e2e/bug-2610-pane-menu-clip.spec.ts
+++ b/web/e2e/bug-2610-pane-menu-clip.spec.ts
@@ -1,0 +1,82 @@
+import { expect, type Page } from '@playwright/test';
+import { test, type SuiteFixture } from './fixtures';
+
+/**
+ * BUG-2610 — in split view the pane's quick-actions (⚡) and ⋯ menus were
+ * ANCHORED panels inside `.item-pane`, an `overflow-y:auto` scroll
+ * container (which computes `overflow-x:auto` too). A right-aligned panel
+ * opening from the pane's action bar extends LEFT past the pane's left
+ * edge, so the container clipped it mid-text (Dave's screenshots on the
+ * item: "age actions" for "Manage actions"). Both menus now use the Menu
+ * component's portal mode, which exists precisely to escape overflow
+ * containment.
+ *
+ * The oracle is a PAINT-level probe, because clipping doesn't shrink
+ * getBoundingClientRect: `document.elementFromPoint` just inside the
+ * panel's LEFT edge must resolve to the panel itself. On the anchored
+ * control build the panel's left region lies outside the pane's clip, so
+ * the probe hits whatever is underneath (the board) — which is exactly
+ * what a user's click there did.
+ */
+
+function authHeaders(fixture: SuiteFixture) {
+	return { Authorization: `Bearer ${fixture.apiToken}` };
+}
+
+/** Probe: does the point just inside the panel's left edge actually hit
+ *  the panel (i.e. is it painted / clickable there)? */
+async function leftEdgeHitsMenu(page: Page): Promise<boolean> {
+	const panel = page.getByRole('menu');
+	await expect(panel).toBeVisible();
+	const box = await panel.boundingBox();
+	if (!box) return false;
+	return page.evaluate(
+		([x, y]) => {
+			const el = document.elementFromPoint(x, y);
+			return !!el && !!el.closest('[role="menu"]');
+		},
+		[box.x + 6, box.y + box.height / 2] as [number, number],
+	);
+}
+
+test('BUG-2610: pane quick-actions and ⋯ menus are not clipped by the pane container in split view', async ({
+	page,
+	request,
+	fixture,
+}, testInfo) => {
+	test.skip(
+		testInfo.project.name !== 'desktop-chromium',
+		'split view is a desktop layout; the mobile path renders a BottomSheet',
+	);
+
+	const uniq = `${test.info().workerIndex}-${Date.now().toString(36)}`;
+	const itemResp = await request.post(
+		`/api/v1/workspaces/${fixture.workspaceSlug}/collections/tasks/items`,
+		{ headers: authHeaders(fixture), data: { title: `b2610 probe ${uniq}` } },
+	);
+	expect(itemResp.ok(), await itemResp.text()).toBeTruthy();
+	const item = (await itemResp.json()) as { slug: string };
+
+	await page.goto(`/${fixture.adminUsername}/${fixture.workspaceSlug}/tasks?item=${item.slug}`);
+	const pane = page.locator('.item-pane');
+	await expect(pane.locator('.title', { hasText: /b2610 probe/ })).toBeVisible();
+
+	// GEOMETRY PRECONDITION (keeps the probe non-vacuous): the trigger
+	// sits close enough to the pane's left edge that a right-aligned
+	// panel MUST extend past it — otherwise both builds pass trivially.
+	const paneBox = await pane.boundingBox();
+	const qaTrigger = pane.locator('button.trigger-btn[title="Quick actions"]');
+	const qaBox = await qaTrigger.boundingBox();
+	expect(paneBox && qaBox && qaBox.x + qaBox.width - 260 < paneBox.x).toBeTruthy();
+
+	// ⚡ quick-actions menu.
+	await qaTrigger.click();
+	expect(await leftEdgeHitsMenu(page), 'quick-actions panel clipped at its left edge').toBe(true);
+	await page.keyboard.press('Escape');
+	await expect(page.getByRole('menu')).not.toBeVisible();
+
+	// ⋯ overflow menu.
+	await pane.locator('button.pane-more-btn').click();
+	expect(await leftEdgeHitsMenu(page), '⋯ panel clipped at its left edge').toBe(true);
+	await page.keyboard.press('Escape');
+});

--- a/web/e2e/bug-2610-pane-menu-clip.spec.ts
+++ b/web/e2e/bug-2610-pane-menu-clip.spec.ts
@@ -61,13 +61,15 @@ test('BUG-2610: pane quick-actions and ⋯ menus are not clipped by the pane con
 	const pane = page.locator('.item-pane');
 	await expect(pane.locator('.title', { hasText: /b2610 probe/ })).toBeVisible();
 
-	// GEOMETRY PRECONDITION (keeps the probe non-vacuous): the trigger
-	// sits close enough to the pane's left edge that a right-aligned
-	// panel MUST extend past it — otherwise both builds pass trivially.
+	// GEOMETRY PRECONDITIONS (keep the probe non-vacuous): each trigger
+	// sits close enough to the pane's left edge that its right-aligned
+	// panel — at ITS configured width — MUST extend past the edge;
+	// otherwise both builds pass trivially. Widths mirror the component
+	// props (QA 288, ⋯ 260).
 	const paneBox = await pane.boundingBox();
 	const qaTrigger = pane.locator('button.trigger-btn[title="Quick actions"]');
 	const qaBox = await qaTrigger.boundingBox();
-	expect(paneBox && qaBox && qaBox.x + qaBox.width - 260 < paneBox.x).toBeTruthy();
+	expect(paneBox && qaBox && qaBox.x + qaBox.width - 288 < paneBox.x).toBeTruthy();
 
 	// ⚡ quick-actions menu.
 	await qaTrigger.click();
@@ -75,8 +77,11 @@ test('BUG-2610: pane quick-actions and ⋯ menus are not clipped by the pane con
 	await page.keyboard.press('Escape');
 	await expect(page.getByRole('menu')).not.toBeVisible();
 
-	// ⋯ overflow menu.
-	await pane.locator('button.pane-more-btn').click();
+	// ⋯ overflow menu — its own precondition at its own width.
+	const moreTrigger = pane.locator('button.pane-more-btn');
+	const moreBox = await moreTrigger.boundingBox();
+	expect(paneBox && moreBox && moreBox.x + moreBox.width - 260 < paneBox.x).toBeTruthy();
+	await moreTrigger.click();
 	expect(await leftEdgeHitsMenu(page), '⋯ panel clipped at its left edge').toBe(true);
 	await page.keyboard.press('Escape');
 });

--- a/web/e2e/pane-collection-migration-race.spec.ts
+++ b/web/e2e/pane-collection-migration-race.spec.ts
@@ -226,7 +226,9 @@ test('a collection migration completing after a rapid A->B pane switch refreshes
 
 	// Open Quick Actions -> Manage actions -> Edit Collection modal, Fields tab.
 	await pane.locator('button.trigger-btn[title="Quick actions"]').click();
-	await pane.getByRole('menuitem', { name: 'Manage actions' }).click();
+	// Portaled panel (BUG-2610) — page-scoped lookup; the pane-scoped
+	// trigger click ties the menu to this pane.
+	await page.getByRole('menuitem', { name: 'Manage actions' }).click();
 	await expect(page.locator('#edit-collection-title')).toBeVisible();
 	await page.locator('button.tab', { hasText: 'Fields' }).click();
 

--- a/web/e2e/pane-content-link-anchors.spec.ts
+++ b/web/e2e/pane-content-link-anchors.spec.ts
@@ -254,7 +254,8 @@ test.describe('content-link anchor interception (PLAN-2154 / TASK-2159)', () => 
 
 		// Graph opens from the pane ⋯ overflow now (PLAN-2290 Phase 4 PR B).
 		await pane.locator('button.pane-more-btn').click();
-		await pane.getByRole('menuitem', { name: 'Dependency graph' }).click();
+		// Portaled panel (BUG-2610) — page-scoped row lookup.
+		await page.getByRole('menuitem', { name: 'Dependency graph' }).click();
 		const drawer = pane.locator('.graph-drawer');
 		await expect(drawer).toBeVisible();
 		const childNode = drawer.locator('.node', { hasText: childRef });
@@ -292,7 +293,8 @@ test.describe('content-link anchor interception (PLAN-2154 / TASK-2159)', () => 
 
 		// Graph opens from the pane ⋯ overflow now (PLAN-2290 Phase 4 PR B).
 		await pane.locator('button.pane-more-btn').click();
-		await pane.getByRole('menuitem', { name: 'Dependency graph' }).click();
+		// Portaled panel (BUG-2610) — page-scoped row lookup.
+		await page.getByRole('menuitem', { name: 'Dependency graph' }).click();
 		const drawer = pane.locator('.graph-drawer');
 		await expect(drawer).toBeVisible();
 

--- a/web/e2e/pane-controller.spec.ts
+++ b/web/e2e/pane-controller.spec.ts
@@ -417,7 +417,11 @@ test.describe('pane controller: depth/ownership state machine (PLAN-2154 / TASK-
 		// (old→new slug) while preserving `?item=` — routed through
 		// onNavigateAway (must replaceState + rebase ownership).
 		await pane.locator('button.trigger-btn[title="Quick actions"]').click();
-		await pane.getByRole('menuitem', { name: 'Manage actions' }).click();
+		// Menu panels are PORTALED to <body> since BUG-2610 (the pane's
+		// overflow container clipped anchored panels), so menuitem lookups
+		// are page-scoped; the pane-scoped trigger click above is what ties
+		// the open menu to this pane.
+		await page.getByRole('menuitem', { name: 'Manage actions' }).click();
 		await expect(page.locator('#edit-collection-title')).toBeVisible();
 		// "Manage actions" opens the modal on the Actions tab — switch to General
 		// to reach the collection-name field.

--- a/web/e2e/pane-full-page-capstone.spec.ts
+++ b/web/e2e/pane-full-page-capstone.spec.ts
@@ -317,9 +317,12 @@ test.describe('full-page pane host CAPSTONE (PLAN-2154 Phase 2 / TASK-2175)', ()
 		await expect(col.locator('button.star-btn')).toBeEnabled();
 		await expect(col.locator('button.trigger-btn[title="Quick actions"]')).toBeVisible();
 		await col.locator('button.pane-more-btn').click();
-		await expect(col.getByRole('menuitem', { name: 'Share…' })).toBeVisible();
-		await expect(col.getByRole('menuitem', { name: 'Move to collection…' })).toBeVisible();
-		await expect(col.getByRole('menuitem', { name: 'Delete…' })).toBeVisible();
+		// Menu panels are PORTALED to <body> since BUG-2610; only one menu
+		// is ever open, and the col-scoped trigger click above is what ties
+		// it to this column — page-scope the row lookups.
+		await expect(page.getByRole('menuitem', { name: 'Share…' })).toBeVisible();
+		await expect(page.getByRole('menuitem', { name: 'Move to collection…' })).toBeVisible();
+		await expect(page.getByRole('menuitem', { name: 'Delete…' })).toBeVisible();
 		await page.keyboard.press('Escape');
 		// Relationships tab: the per-link remove button (rendered but `display:none`
 		// until row-hover, so assert DOM presence) and the "+ Add relationship" opener.
@@ -447,9 +450,11 @@ test.describe('full-page pane host CAPSTONE (PLAN-2154 Phase 2 / TASK-2175)', ()
 		// owner write controls are all present.
 		await expect(trigger).toBeVisible();
 		await trigger.click();
-		await expect(col.getByRole('menuitem', { name: 'Summarize' })).toBeVisible();
-		await expect(col.getByRole('menuitem', { name: 'New quick action' })).toBeVisible();
-		await expect(col.getByRole('menuitem', { name: 'Manage actions' })).toBeVisible();
+		// Portaled panel (BUG-2610) — page-scoped rows; the col-scoped
+		// trigger is what ties the open menu to the master column.
+		await expect(page.getByRole('menuitem', { name: 'Summarize' })).toBeVisible();
+		await expect(page.getByRole('menuitem', { name: 'New quick action' })).toBeVisible();
+		await expect(page.getByRole('menuitem', { name: 'Manage actions' })).toBeVisible();
 		await trigger.click(); // close
 
 		// Open the pane and activate it → the master becomes the peeking side.
@@ -972,8 +977,9 @@ test.describe('full-page pane host CAPSTONE (PLAN-2154 Phase 2 / TASK-2175)', ()
 		await page.keyboard.press('Escape'); // close the title editor the activation click opened
 		await pane.locator('button.pane-more-btn').click();
 		// MenuItem hints are not aria-hidden, so match non-exact (harness memory).
-		await pane.getByRole('menuitem', { name: 'Move to collection…' }).click();
-		await pane.getByRole('menuitem', { name: /FP move target/ }).click();
+		// Portaled panel (BUG-2610) — page-scoped rows.
+		await page.getByRole('menuitem', { name: 'Move to collection…' }).click();
+		await page.getByRole('menuitem', { name: /FP move target/ }).click();
 
 		// The retarget lands as a drill: `?item=` flips from the ref to the moved
 		// item's slug, and the PATHNAME NEVER LEAVES the master route. The broken

--- a/web/src/lib/components/common/Menu.svelte
+++ b/web/src/lib/components/common/Menu.svelte
@@ -108,12 +108,26 @@
 		return unregister;
 	});
 
-	// Portal mode: any scroll or resize closes (coords would go stale).
-	// Deliberately onclose() and NOT close(): refocusing the trigger here
-	// would scroll the card back into view and fight the user's scroll.
+	// Portal mode: a scroll that can MOVE THE ANCHOR closes the menu
+	// (fixed coords would go stale). Scoped to containers that contain
+	// the trigger (BUG-2610): the old any-scroll dismissal also fired for
+	// scrolls in UNRELATED containers — under live SSE churn a foreign
+	// list re-layout scrolling its own column closed an open pane menu
+	// mid-interaction (and flaked the capstone move e2e the same way).
+	// A container that doesn't contain the trigger cannot move it, so
+	// its scrolling never stales the coords. The panel's own internal
+	// overflow scroll is likewise exempt. Deliberately onclose() and NOT
+	// close(): refocusing the trigger here would scroll the card back
+	// into view and fight the user's scroll.
 	$effect(() => {
 		if (!open || useSheet || mode !== 'portal') return;
-		const dismiss = () => onclose();
+		const dismiss = (e?: Event) => {
+			if (e && e.target instanceof Node) {
+				if (panelEl?.contains(e.target)) return;
+				if (trigger && e.target !== document && !e.target.contains(trigger)) return;
+			}
+			onclose();
+		};
 		window.addEventListener('scroll', dismiss, { capture: true, passive: true });
 		window.addEventListener('resize', dismiss, { passive: true });
 		return () => {

--- a/web/src/lib/components/common/Menu.svelte
+++ b/web/src/lib/components/common/Menu.svelte
@@ -123,8 +123,13 @@
 		if (!open || useSheet || mode !== 'portal') return;
 		const dismiss = (e?: Event) => {
 			if (e && e.target instanceof Node) {
-				if (panelEl?.contains(e.target)) return;
-				if (trigger && e.target !== document && !e.target.contains(trigger)) return;
+				const t = e.target;
+				if (panelEl?.contains(t)) return;
+				// A scrolling exempt surface (e.g. a nested portaled emoji
+				// picker) is part of the menu interaction, not a stale-coords
+				// signal (codex round 1 #2).
+				if (exempt?.().some((el) => el && (el === t || el.contains(t)))) return;
+				if (trigger && t !== document && !t.contains(trigger)) return;
 			}
 			onclose();
 		};
@@ -168,6 +173,10 @@
 		else if (e.key === 'End') next = list.length - 1;
 		if (next >= 0) {
 			e.preventDefault();
+			// Portaled panels bubble to <svelte:window> handlers that
+			// location-filter on containers the panel no longer lives in —
+			// a handled key must not double as a page hotkey (BUG-2610).
+			e.stopPropagation();
 			list[next].focus();
 		}
 	}

--- a/web/src/lib/components/common/QuickActionsMenu.svelte
+++ b/web/src/lib/components/common/QuickActionsMenu.svelte
@@ -591,11 +591,20 @@
 			&#9889;
 		</button>
 
+		<!-- mode=portal (BUG-2610): the split-view pane is an
+		     overflow-y:auto scroll container, which computes
+		     overflow-x:auto too — an anchored right-aligned panel opening
+		     from the pane's action bar extended past the pane's left edge
+		     and was CLIPPED mid-text. Portal escapes overflow containment
+		     and viewport-clamps/flips when cramped. width covers the
+		     .qa-body min-width (230) plus panel chrome. -->
 		<Menu
 			{open}
 			onclose={closeMenu}
 			trigger={triggerEl}
 			align={alignLeft ? 'left' : 'right'}
+			mode="portal"
+			width={288}
 			sheetOnMobile
 			sheetTitle="Quick actions"
 			ariaLabel={pushable ? `Quick actions. ${tagline}` : 'Quick actions'}

--- a/web/src/lib/components/common/QuickActionsMenu.svelte.test.ts
+++ b/web/src/lib/components/common/QuickActionsMenu.svelte.test.ts
@@ -133,15 +133,15 @@ describe('QuickActionsMenu save retry (BUG-2265 Pattern C)', () => {
 		// Open the menu, then the inline create form.
 		(host.querySelector('.trigger-btn') as HTMLButtonElement).click();
 		flushSync();
-		const openFormBtn = [...host.querySelectorAll('button')].find((b) =>
+		const openFormBtn = [...document.querySelectorAll('button')].find((b) =>
 			b.textContent?.includes('New quick action')
 		) as HTMLButtonElement;
 		openFormBtn.click();
 		flushSync();
 
 		// Fill label + prompt.
-		const label = host.querySelector('.qa-label-input') as HTMLInputElement;
-		const prompt = host.querySelector('.qa-prompt-input') as HTMLTextAreaElement;
+		const label = document.querySelector('.qa-label-input') as HTMLInputElement;
+		const prompt = document.querySelector('.qa-prompt-input') as HTMLTextAreaElement;
 		label.value = 'Ship';
 		label.dispatchEvent(new Event('input', { bubbles: true }));
 		prompt.value = '/pad ship';
@@ -149,7 +149,7 @@ describe('QuickActionsMenu save retry (BUG-2265 Pattern C)', () => {
 		flushSync();
 
 		// Click Save.
-		const saveBtn = [...host.querySelectorAll('button')].find(
+		const saveBtn = [...document.querySelectorAll('button')].find(
 			(b) => b.textContent?.trim() === 'Save'
 		) as HTMLButtonElement;
 		saveBtn.click();
@@ -236,7 +236,7 @@ async function openMenu(host: HTMLElement) {
 }
 
 function actionRow(host: HTMLElement, label: string): HTMLButtonElement {
-	const row = [...host.querySelectorAll('button')].find(
+	const row = [...document.querySelectorAll('button')].find(
 		(b) => b.textContent?.trim() === label
 	);
 	if (!row) throw new Error(`no action row labelled ${label}`);
@@ -481,7 +481,7 @@ describe('QuickActionsMenu push dispatch (PLAN-2558 S4)', () => {
 		sessionsListMock.mockResolvedValue({ sessions: [], count: 0 });
 		const { host, component } = mountMenu();
 		await openMenu(host);
-		expect(host.querySelector('.dropdown-tagline')?.textContent?.trim()).toBe(
+		expect(document.querySelector('.dropdown-tagline')?.textContent?.trim()).toBe(
 			'No agent session connected — actions copy to your clipboard'
 		);
 		unmount(component);
@@ -490,7 +490,7 @@ describe('QuickActionsMenu push dispatch (PLAN-2558 S4)', () => {
 		sessionsListMock.mockResolvedValue({ sessions: [{ id: 's1' }, { id: 's2' }], count: 2 });
 		const live = mountMenu();
 		await openMenu(live.host);
-		expect(live.host.querySelector('.dropdown-tagline')?.textContent?.trim()).toBe(
+		expect(document.querySelector('.dropdown-tagline')?.textContent?.trim()).toBe(
 			'Pushes to your 2 connected agent sessions'
 		);
 		unmount(live.component);
@@ -525,7 +525,7 @@ describe('QuickActionsMenu presence staleness (codex round 1)', () => {
 			flushSync();
 
 			// The first read landed: the menu is armed to push.
-			expect(host.querySelector('.dropdown-tagline')?.textContent?.trim()).toBe(
+			expect(document.querySelector('.dropdown-tagline')?.textContent?.trim()).toBe(
 				'Pushes to your connected agent session'
 			);
 
@@ -534,7 +534,7 @@ describe('QuickActionsMenu presence staleness (codex round 1)', () => {
 			// rewrites it; the routing decision does not — see the next test.)
 			await vi.advanceTimersByTimeAsync(41_000);
 			flushSync();
-			expect(host.querySelector('.dropdown-tagline')?.textContent?.trim()).toBe(
+			expect(document.querySelector('.dropdown-tagline')?.textContent?.trim()).toBe(
 				'Can’t tell if an agent is connected — actions copy to your clipboard'
 			);
 
@@ -572,7 +572,7 @@ describe('QuickActionsMenu presence staleness (codex round 1)', () => {
 			// still shows what the last successful read said.
 			vi.setSystemTime(Date.now() + 5 * 60_000);
 			flushSync();
-			expect(host.querySelector('.dropdown-tagline')?.textContent?.trim()).toBe(
+			expect(document.querySelector('.dropdown-tagline')?.textContent?.trim()).toBe(
 				'Pushes to your connected agent session'
 			);
 
@@ -607,14 +607,14 @@ describe('QuickActionsMenu presence staleness (codex round 1)', () => {
 			// Just before the bound: still armed.
 			await vi.advanceTimersByTimeAsync(29_000);
 			flushSync();
-			expect(host.querySelector('.dropdown-tagline')?.textContent?.trim()).toBe(
+			expect(document.querySelector('.dropdown-tagline')?.textContent?.trim()).toBe(
 				'Pushes to your connected agent session'
 			);
 
 			// Just past it — and well before the next 10s poll tick at t=40s.
 			await vi.advanceTimersByTimeAsync(1_500);
 			flushSync();
-			expect(host.querySelector('.dropdown-tagline')?.textContent?.trim()).toBe(
+			expect(document.querySelector('.dropdown-tagline')?.textContent?.trim()).toBe(
 				'Can’t tell if an agent is connected — actions copy to your clipboard'
 			);
 
@@ -639,7 +639,7 @@ describe('QuickActionsMenu presence staleness (codex round 1)', () => {
 			await vi.advanceTimersByTimeAsync(31_000);
 			flushSync();
 
-			expect(host.querySelector('.dropdown-tagline')?.textContent?.trim()).toBe(
+			expect(document.querySelector('.dropdown-tagline')?.textContent?.trim()).toBe(
 				'Pushes to your connected agent session'
 			);
 			actionRow(host, 'Ship it').click();

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -5044,11 +5044,15 @@
 						paneMenuOpen = !paneMenuOpen;
 					}}
 				>⋯</button>
+				<!-- mode=portal (BUG-2610): anchored panels clip against the
+				     pane's overflow-y:auto scroll container in split view —
+				     see QuickActionsMenu's matching note. -->
 				<Menu
 					open={paneMenuOpen}
 					onclose={() => { paneMenuOpen = false; paneMenuView = 'root'; }}
 					trigger={paneMenuTrigger}
-					mode="anchored"
+					mode="portal"
+					width={260}
 					sheetOnMobile
 					sheetTitle="Item actions"
 					ariaLabel="Item actions"

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -2428,7 +2428,11 @@
 		// resizable pane divider — otherwise j/k/arrows/Enter typed there (the
 		// divider owns ArrowLeft/ArrowRight for width nudging, TASK-2114) would
 		// drive list/board navigation instead (PLAN-2105 / TASK-2111 / -2119).
-		if (target?.closest?.('[contenteditable="true"], .item-pane, .pane-divider')) return;
+		// `[role="menu"]` (BUG-2610): portaled menu panels live in <body>,
+		// outside `.item-pane` — while one has focus, j/k/Enter belong to
+		// the menu, not list navigation. Covers every portal-mode menu
+		// (board card ⋮ menus had this leak before the pane menus joined).
+		if (target?.closest?.('[contenteditable="true"], .item-pane, .pane-divider, [role="menu"]')) return;
 		if (quickCreateOpen || saveViewOpen) return;
 		// On the MOBILE overlay the list is hidden behind the full-screen pane, so
 		// list nav is meaningless — bail even if focus has escaped to <body> (e.g.


### PR DESCRIPTION
## Root cause

In split view `.item-pane` is an `overflow-y:auto` scroll container — which computes `overflow-x:auto` too — and the quick-actions (⚡) and ⋯ menus were **anchored** panels inside it. A right-aligned panel opening from the pane's action bar extends left past the pane's edge, so the container paint-clipped it mid-text (Dave's screenshots: "age actions" for "Manage actions", truncated tagline).

## Change

- Both menus flip to the Menu component's **portal mode** — built precisely to escape overflow containment (fixed coords portaled to `<body>`, viewport clamping, flip-when-cramped), and already the mode of every board-card menu. Widths mirror content (QA 288 / ⋯ 260).
- **Portal scroll-dismiss scoped to anchor-moving containers** — the any-scroll dismissal closed open menus whenever *unrelated* containers scrolled (live SSE re-layout churn). Found because the capstone move e2e went parallel-unstable on this branch while a control build ran clean — treated as signal, not flake. Dismiss now fires only when the scrolled container contains the trigger; panel-internal and `exempt` surfaces (nested emoji picker) are exempt.
- **Portaled-menu key leak closed** (codex): the collection route's nav-key bail checks `target.closest('.item-pane')`, which a portaled row no longer matches — j/k/Enter drove list navigation under an open menu. `[role="menu"]` joins the bail (also closing the same **pre-existing** leak for board-card portal menus), plus `stopPropagation` on Menu-handled arrow keys.

## Verification

- Regression e2e with a **paint-level oracle**: clipping doesn't shrink `getBoundingClientRect`, so `elementFromPoint` just inside the panel's left edge must resolve to the panel; per-menu geometry preconditions keep it non-vacuous. Verified failing on the anchored control build with the exact reported symptom.
- Blast radius swept: 14 e2e menu-row lookups page-scoped (portaled panels live in `<body>`; the scoped trigger click ties each menu to its column), QA unit-test queries re-scoped to document. Targeted pane suites 34/34 ×3 under parallel load; vitest 1651; svelte-check 0.
- **Full-suite flake transparency**: five full-suite runs (3 branch / 1 control / 1 branch) each flaked 1-2 tests from the documented parallel-load family (content-link popups, capstone move — the latter also on **control**, a11y j/k, viewer-owners), always passing isolated and in groups; tally + triage method recorded on BUG-2447. The one genuinely diff-caused parallel failure found this session was the scroll-dismiss regression above — fixed, not excused.

## Review

Codex R1: key-leak (fixed route-side), exempt-scroll gap (fixed), per-menu e2e preconditions (fixed); R2 confirm caught two remaining pane-scoped graph lookups (fixed). Shadow-DOM `contains()` awareness declined — no shadow DOM in the app.