### PR TITLE
fix(server): refuse a PATCH carrying both a fields hierarchy key and top-level parent_id (BUG-2594)

### DIFF
--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -956,6 +956,19 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 		if !extractOK {
 			return
 		}
+		if parentProvided && input.ParentID != nil {
+			// BUG-2594: a hierarchy write in fields ("parent"/"plan" — the
+			// canonical item_links surface) and a top-level "parent_id"
+			// (a raw column stamp no first-party client sends on update)
+			// in one request are two competing hierarchy writes. The old
+			// behavior applied BOTH — clearing the link while stamping
+			// the column, leaving silently inconsistent state. Refused,
+			// not silently resolved, per the clear_parent contract
+			// family's standing rule (v0.19).
+			writeError(w, http.StatusBadRequest, "validation_error",
+				`Request carries both a "parent"/"plan" key in fields and a top-level "parent_id" — two competing hierarchy writes. Send exactly one.`)
+			return
+		}
 
 		if err := items.ValidateFields(fieldMap, schema); err != nil {
 			writeError(w, http.StatusBadRequest, "validation_error", err.Error())
@@ -1097,6 +1110,19 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 		var extractOK bool
 		parentValue, parentProvided, extractOK = s.extractParentLink(w, r, workspaceID, schema, patchMap)
 		if !extractOK {
+			return
+		}
+		if parentProvided && input.ParentID != nil {
+			// BUG-2594: a hierarchy write in fields_patch ("parent"/"plan" — the
+			// canonical item_links surface) and a top-level "parent_id"
+			// (a raw column stamp no first-party client sends on update)
+			// in one request are two competing hierarchy writes. The old
+			// behavior applied BOTH — clearing the link while stamping
+			// the column, leaving silently inconsistent state. Refused,
+			// not silently resolved, per the clear_parent contract
+			// family's standing rule (v0.19).
+			writeError(w, http.StatusBadRequest, "validation_error",
+				`Request carries both a "parent"/"plan" key in fields_patch and a top-level "parent_id" — two competing hierarchy writes. Send exactly one.`)
 			return
 		}
 

--- a/internal/server/handlers_items_parent_ambiguity_test.go
+++ b/internal/server/handlers_items_parent_ambiguity_test.go
@@ -33,11 +33,17 @@ func assertAmbiguityRefused(t *testing.T, rr interface {
 	if code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d: %s", code, body)
 	}
-	// The error must NAME both competing keys so a raw-HTTP client can
-	// fix its request without spelunking. (The body is JSON-encoded, so
-	// the quoted key arrives as \"parent\".)
-	if !strings.Contains(body, "parent_id") || !strings.Contains(body, `\"parent\"`) {
-		t.Errorf("refusal should name both competing keys, got: %s", body)
+	// The refusal is the standard validation envelope and must NAME the
+	// competing keys — both the canonical "parent" and its "plan" alias —
+	// so a raw-HTTP client can fix its request without spelunking. (The
+	// body is JSON-encoded, so quoted keys arrive as \"parent\".)
+	if !strings.Contains(body, `"code":"validation_error"`) {
+		t.Errorf("refusal should use the validation_error code, got: %s", body)
+	}
+	if !strings.Contains(body, "parent_id") ||
+		!strings.Contains(body, `\"parent\"`) ||
+		!strings.Contains(body, `\"plan\"`) {
+		t.Errorf("refusal should name both competing keys (and the plan alias), got: %s", body)
 	}
 }
 

--- a/internal/server/handlers_items_parent_ambiguity_test.go
+++ b/internal/server/handlers_items_parent_ambiguity_test.go
@@ -1,0 +1,125 @@
+package server
+
+// BUG-2594 — one PATCH carrying BOTH a hierarchy write in fields /
+// fields_patch ("parent" or its "plan" alias, any value including the
+// empty-string clear) AND a top-level "parent_id" used to apply both:
+// extractParentLink staged the item_links write while ItemUpdate.ParentID
+// stamped the column unconditionally in the same transaction — clearing
+// the link while re-parenting the column, silently inconsistent. The
+// shape is raw-HTTP-only (no first-party client sends top-level
+// parent_id on update), and it is now REFUSED, not silently resolved,
+// per the clear_parent contract family's standing rule (v0.19).
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+func seedParentAndChild(t *testing.T, srv *Server, slug string) (parent, child models.Item) {
+	t.Helper()
+	parent = createTaskWithFields(t, srv, slug, "Ambiguity parent", `{"status":"open"}`)
+	child = createTaskWithFields(t, srv, slug, "Ambiguity child", `{"status":"open"}`)
+	return parent, child
+}
+
+func assertAmbiguityRefused(t *testing.T, rr interface {
+	// httptest.ResponseRecorder shape without importing it here
+	Result() *http.Response
+}, code int, body string) {
+	t.Helper()
+	if code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", code, body)
+	}
+	// The error must NAME both competing keys so a raw-HTTP client can
+	// fix its request without spelunking. (The body is JSON-encoded, so
+	// the quoted key arrives as \"parent\".)
+	if !strings.Contains(body, "parent_id") || !strings.Contains(body, `\"parent\"`) {
+		t.Errorf("refusal should name both competing keys, got: %s", body)
+	}
+}
+
+func TestPatchItem_ParentClearPlusParentID_Refused(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+	parent, child := seedParentAndChild(t, srv, slug)
+
+	// The filed shape: fields_patch clears the link while parent_id
+	// re-stamps the column.
+	rr := doRequest(srv, "PATCH", "/api/v1/workspaces/"+slug+"/items/"+child.Slug, map[string]interface{}{
+		"fields_patch": map[string]interface{}{"parent": ""},
+		"parent_id":    parent.ID,
+	})
+	assertAmbiguityRefused(t, rr, rr.Code, rr.Body.String())
+}
+
+func TestPatchItem_ParentSetPlusParentID_Refused(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+	parent, child := seedParentAndChild(t, srv, slug)
+
+	rr := doRequest(srv, "PATCH", "/api/v1/workspaces/"+slug+"/items/"+child.Slug, map[string]interface{}{
+		"fields_patch": map[string]interface{}{"parent": parent.ID},
+		"parent_id":    parent.ID,
+	})
+	assertAmbiguityRefused(t, rr, rr.Code, rr.Body.String())
+}
+
+func TestPatchItem_PlanAliasPlusParentID_Refused(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+	parent, child := seedParentAndChild(t, srv, slug)
+
+	rr := doRequest(srv, "PATCH", "/api/v1/workspaces/"+slug+"/items/"+child.Slug, map[string]interface{}{
+		"fields_patch": map[string]interface{}{"plan": parent.ID},
+		"parent_id":    parent.ID,
+	})
+	assertAmbiguityRefused(t, rr, rr.Code, rr.Body.String())
+}
+
+func TestPatchItem_FullFieldsParentPlusParentID_Refused(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+	parent, child := seedParentAndChild(t, srv, slug)
+
+	// The full-`fields` sibling path shares extractParentLink and gets
+	// the same refusal.
+	rr := doRequest(srv, "PATCH", "/api/v1/workspaces/"+slug+"/items/"+child.Slug, map[string]interface{}{
+		"fields":    `{"status":"open","parent":"` + parent.ID + `"}`,
+		"parent_id": parent.ID,
+	})
+	assertAmbiguityRefused(t, rr, rr.Code, rr.Body.String())
+}
+
+// Controls: each hierarchy write ALONE keeps working exactly as before —
+// the guard must refuse the pair, not either member.
+func TestPatchItem_ParentViaFieldsPatchAlone_StillWorks(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+	parent, child := seedParentAndChild(t, srv, slug)
+
+	rr := doRequest(srv, "PATCH", "/api/v1/workspaces/"+slug+"/items/"+child.Slug, map[string]interface{}{
+		"fields_patch": map[string]interface{}{"parent": parent.ID},
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("fields_patch parent alone: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestPatchItem_TopLevelParentIDAlone_StillWorks(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+	parent, child := seedParentAndChild(t, srv, slug)
+
+	// Pre-existing raw-HTTP behavior deliberately unchanged (the audit
+	// found no first-party sender; solo parent_id is out of this bug's
+	// scope — see BUG-2379 for the adjacent undeclared-override family).
+	rr := doRequest(srv, "PATCH", "/api/v1/workspaces/"+slug+"/items/"+child.Slug, map[string]interface{}{
+		"parent_id": parent.ID,
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("parent_id alone: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+}


### PR DESCRIPTION
## Root cause

`{"fields_patch": {"parent": ""}, "parent_id": "<id>"}` in one PATCH applied **both** hierarchy writes: `extractParentLink` staged the `item_links` write (including the empty-string clear) while `ItemUpdate.ParentID` stamped the `parent_id` column unconditionally in the same transaction — link cleared, column re-parented, `unparentedItemPredicate` still saw a parent. Silent inconsistent state, no error. Pre-existing since the `parent_id` column landed on `ItemUpdate` (2026-07-08); surfaced by BUG-2078's review.

## Change

Both update paths (full `fields` + `fields_patch`) refuse the pair with a `validation_error` naming both keys — **refused, not silently resolved**, per the clear_parent contract family's standing rule (v0.19). The audit found the shape is raw-HTTP-only: no first-party client sends top-level `parent_id` on item update (CLI resolves `--parent` into the patch; web client and MCP catalog never carry it) — confirmed independently by review across bulk/restore/move/import/MCP dispatchers. Solo `parent_id` and solo fields-hierarchy writes are deliberately unchanged (BUG-2379 tracks the adjacent undeclared-override family); the schema-declared `parent`-field case stays an ordinary field write per the v0.19 shadowing rule.

## Verification

Six handler tests: refusal on clear+id, set+id, the `plan` alias, and the full-`fields` sibling path — **each verified failing (200) on the unguarded control build** — plus both solo-write controls, envelope-code and both-keys-named assertions. Full `internal/server` suite green. Codex round 1: clean on caller audit, guard placement, and the schema-shadowed precedence; its test-tightening note applied.