### PR TITLE
fix(store): attachment delete vs thumbnail derivation race — atomic cascade, locked conditional insert, orphaned-variant GC class (BUG-2388)

### DIFF
--- a/internal/server/handlers_attachments_thumbnails.go
+++ b/internal/server/handlers_attachments_thumbnails.go
@@ -275,16 +275,31 @@ func (s *Server) persistThumbnail(
 		// The parent was deleted between the derivation's early liveness
 		// check and this insert (BUG-2388) — the conditional insert is
 		// the fix for the race that used to mint a live variant row
-		// under a tombstoned parent. Clean up the just-Put blob while we
-		// still hold the in-flight hash fence, unless another live/
-		// in-grace row shares the hash (same dedupe protection as the
-		// GC sweep). A cleanup failure only strands bytes — never a row.
-		others, cErr := s.store.CountProtectingAttachmentsForHash(hash, "", time.Now().Add(-defaultOrphanGCGrace))
-		if cErr == nil && others == 0 {
-			if dErr := store.Delete(ctx, storageKey); dErr != nil {
-				slog.Warn("thumbnails: orphan blob cleanup failed",
-					"storage_key", storageKey, "error", dErr)
+		// under a tombstoned parent. Clean up the just-Put blob, unless
+		// another live/in-grace row shares the hash (same dedupe
+		// protection as the GC sweep, using the CONFIGURED grace — a
+		// longer operator grace must keep a still-restorable peer's
+		// bytes). The count runs first; the in-flight re-check + Delete
+		// then hold inFlightHashesMu, mirroring the sweep's fence, so a
+		// concurrent upload registering this hash between our check and
+		// the Delete cannot lose its bytes (codex round 1 P1). We hold
+		// one registration ourselves — > 1 means someone else does too.
+		// A cleanup failure or skipped count only strands bytes — never
+		// a row — and is logged so it isn't silent (codex round 1 P2).
+		graceCutoff := time.Now().Add(-s.orphanGCGraceConfigured())
+		others, cErr := s.store.CountProtectingAttachmentsForHash(hash, "", graceCutoff)
+		if cErr != nil {
+			slog.Warn("thumbnails: refusal cleanup count failed — blob stranded for manual cleanup",
+				"storage_key", storageKey, "error", cErr)
+		} else if others == 0 {
+			s.inFlightHashesMu.Lock()
+			if s.inFlightHashes[hash] <= 1 {
+				if dErr := store.Delete(ctx, storageKey); dErr != nil {
+					slog.Warn("thumbnails: orphan blob cleanup failed",
+						"storage_key", storageKey, "error", dErr)
+				}
 			}
+			s.inFlightHashesMu.Unlock()
 		}
 		slog.Info("thumbnails: skipped, parent deleted during derivation",
 			"parent_id", parent.ID, "variant", variant)

--- a/internal/server/handlers_attachments_thumbnails.go
+++ b/internal/server/handlers_attachments_thumbnails.go
@@ -286,21 +286,27 @@ func (s *Server) persistThumbnail(
 		// one registration ourselves — > 1 means someone else does too.
 		// A cleanup failure or skipped count only strands bytes — never
 		// a row — and is logged so it isn't silent (codex round 1 P2).
+		// Count INSIDE the fence (codex round 2): a full upload
+		// lifecycle — register, Put, insert row, release — can complete
+		// between an outside-the-mutex count and the delete, so the
+		// count must observe the world the delete will act on. The
+		// sweep holds this mutex across a backend resolve + FS delete
+		// already; one bounded DB count under it is the same class.
 		graceCutoff := time.Now().Add(-s.orphanGCGraceConfigured())
-		others, cErr := s.store.CountProtectingAttachmentsForHash(hash, "", graceCutoff)
-		if cErr != nil {
-			slog.Warn("thumbnails: refusal cleanup count failed — blob stranded for manual cleanup",
-				"storage_key", storageKey, "error", cErr)
-		} else if others == 0 {
-			s.inFlightHashesMu.Lock()
-			if s.inFlightHashes[hash] <= 1 {
+		s.inFlightHashesMu.Lock()
+		if s.inFlightHashes[hash] <= 1 {
+			others, cErr := s.store.CountProtectingAttachmentsForHash(hash, "", graceCutoff)
+			if cErr != nil {
+				slog.Warn("thumbnails: refusal cleanup count failed — blob stranded for manual cleanup",
+					"storage_key", storageKey, "error", cErr)
+			} else if others == 0 {
 				if dErr := store.Delete(ctx, storageKey); dErr != nil {
 					slog.Warn("thumbnails: orphan blob cleanup failed",
 						"storage_key", storageKey, "error", dErr)
 				}
 			}
-			s.inFlightHashesMu.Unlock()
 		}
+		s.inFlightHashesMu.Unlock()
 		slog.Info("thumbnails: skipped, parent deleted during derivation",
 			"parent_id", parent.ID, "variant", variant)
 		return nil

--- a/internal/server/handlers_attachments_thumbnails.go
+++ b/internal/server/handlers_attachments_thumbnails.go
@@ -12,6 +12,7 @@ import (
 	"log/slog"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/PerpetualSoftware/pad/internal/attachments"
 	"github.com/PerpetualSoftware/pad/internal/models"
@@ -266,8 +267,28 @@ func (s *Server) persistThumbnail(
 		ParentID:    &parentRef,
 		Variant:     &variantRef,
 	}
-	if err := s.store.CreateAttachment(row); err != nil {
+	inserted, err := s.store.CreateAttachmentVariantIfParentLive(row)
+	if err != nil {
 		return fmt.Errorf("create thumbnail row: %w", err)
+	}
+	if !inserted {
+		// The parent was deleted between the derivation's early liveness
+		// check and this insert (BUG-2388) — the conditional insert is
+		// the fix for the race that used to mint a live variant row
+		// under a tombstoned parent. Clean up the just-Put blob while we
+		// still hold the in-flight hash fence, unless another live/
+		// in-grace row shares the hash (same dedupe protection as the
+		// GC sweep). A cleanup failure only strands bytes — never a row.
+		others, cErr := s.store.CountProtectingAttachmentsForHash(hash, "", time.Now().Add(-defaultOrphanGCGrace))
+		if cErr == nil && others == 0 {
+			if dErr := store.Delete(ctx, storageKey); dErr != nil {
+				slog.Warn("thumbnails: orphan blob cleanup failed",
+					"storage_key", storageKey, "error", dErr)
+			}
+		}
+		slog.Info("thumbnails: skipped, parent deleted during derivation",
+			"parent_id", parent.ID, "variant", variant)
+		return nil
 	}
 	return nil
 }

--- a/internal/server/handlers_attachments_thumbnails_test.go
+++ b/internal/server/handlers_attachments_thumbnails_test.go
@@ -388,6 +388,25 @@ func TestThumbnails_PersistRefusedWhenParentDeleted(t *testing.T) {
 	if n != 0 {
 		t.Fatalf("race minted %d live variant row(s) under a tombstoned parent", n)
 	}
+	// And the refused thumbnail's just-Put blob was cleaned up (codex
+	// round 1: without this assertion the cleanup branch was untested).
+	// The thumb bytes are a deterministic function of the 8x8 RGBA +
+	// encoder, so recompute the storage key the same way persistThumbnail
+	// did and Stat it.
+	{
+		var buf bytes.Buffer
+		if err := srv.imageProcessor.Encode(img, "png", &buf); err != nil {
+			t.Fatalf("re-encode: %v", err)
+		}
+		thumbHash := sha256Hex(buf.Bytes())
+		bstore, err := srv.attachments.Resolve(attachments.FSPrefix + ":" + thumbHash)
+		if err != nil {
+			t.Fatalf("resolve: %v", err)
+		}
+		if _, err := bstore.Stat(context.Background(), attachments.FSPrefix+":"+thumbHash); err == nil {
+			t.Errorf("refused thumbnail's blob still on disk — cleanup branch did not run")
+		}
+	}
 
 	// CONTROL: the same call against a LIVE parent inserts.
 	rr = doMultipartUpload(srv, slug, "tiny2.png", realPNG())

--- a/internal/server/handlers_attachments_thumbnails_test.go
+++ b/internal/server/handlers_attachments_thumbnails_test.go
@@ -4,6 +4,7 @@ package server
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"image"
 	"image/color"
@@ -13,6 +14,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/PerpetualSoftware/pad/internal/attachments"
 	"github.com/PerpetualSoftware/pad/internal/models"
@@ -339,5 +341,161 @@ func TestServerCapabilities_PublicAfterBootstrap(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("unauthenticated capabilities fetch returned %d (want 200); body = %s",
 			w.Code, w.Body.String())
+	}
+}
+
+// TestThumbnails_PersistRefusedWhenParentDeleted pins BUG-2388's race
+// deterministically: persistThumbnail is called with a parent SNAPSHOT
+// taken before a delete (exactly what the async derivation holds after
+// its early liveness check), the delete cascade lands, and the
+// conditional variant INSERT must refuse — no live variant row under a
+// tombstoned parent, and the just-Put blob is cleaned up under the
+// in-flight fence.
+func TestThumbnails_PersistRefusedWhenParentDeleted(t *testing.T) {
+	srv, slug := testServerWithAttachments(t)
+	if srv.imageProcessor == nil {
+		t.Skip("no image processor in this build")
+	}
+
+	rr := doMultipartUpload(srv, slug, "tiny.png", realPNG())
+	if rr.Code != 201 {
+		t.Fatalf("upload: %d %s", rr.Code, rr.Body.String())
+	}
+	wsID := workspaceIDForSlug(t, srv, slug)
+	id := getOnlyAttachmentID(t, srv, wsID)
+	parent, err := srv.store.GetAttachment(id)
+	if err != nil || parent == nil {
+		t.Fatalf("GetAttachment: %v %v", parent, err)
+	}
+
+	// The delete cascade lands AFTER the derivation captured its parent
+	// snapshot (the filed interleaving).
+	if err := srv.store.SoftDeleteAttachment(parent.ID); err != nil {
+		t.Fatalf("SoftDeleteAttachment: %v", err)
+	}
+
+	img := image.NewRGBA(image.Rect(0, 0, 8, 8))
+	if err := srv.persistThumbnail(context.Background(), parent, img, "thumb-md", "png"); err != nil {
+		t.Fatalf("persistThumbnail should skip, not error: %v", err)
+	}
+
+	// No live variant row was minted.
+	var n int
+	if err := srv.store.DB().QueryRow(srv.store.D().Rebind(
+		`SELECT COUNT(*) FROM attachments WHERE parent_id = ? AND deleted_at IS NULL`), parent.ID).Scan(&n); err != nil {
+		t.Fatalf("count variants: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("race minted %d live variant row(s) under a tombstoned parent", n)
+	}
+
+	// CONTROL: the same call against a LIVE parent inserts.
+	rr = doMultipartUpload(srv, slug, "tiny2.png", realPNG())
+	if rr.Code != 201 {
+		t.Fatalf("upload 2: %d %s", rr.Code, rr.Body.String())
+	}
+	var liveID string
+	if err := srv.store.DB().QueryRow(srv.store.D().Rebind(
+		`SELECT id FROM attachments WHERE workspace_id = ? AND deleted_at IS NULL AND parent_id IS NULL ORDER BY created_at DESC LIMIT 1`), wsID).Scan(&liveID); err != nil {
+		t.Fatalf("find live upload: %v", err)
+	}
+	liveParent, err := srv.store.GetAttachment(liveID)
+	if err != nil || liveParent == nil {
+		t.Fatalf("GetAttachment live: %v %v", liveParent, err)
+	}
+	if err := srv.persistThumbnail(context.Background(), liveParent, img, "thumb-md", "png"); err != nil {
+		t.Fatalf("persistThumbnail live: %v", err)
+	}
+	if err := srv.store.DB().QueryRow(srv.store.D().Rebind(
+		`SELECT COUNT(*) FROM attachments WHERE parent_id = ? AND deleted_at IS NULL`), liveParent.ID).Scan(&n); err != nil {
+		t.Fatalf("count live variants: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("control: expected 1 variant under live parent, got %d", n)
+	}
+}
+
+// TestOrphanGC_ReclaimsLeakedLiveVariant pins the retro-cleanup class:
+// a LIVE variant row under a tombstoned parent (the pre-fix leak
+// artifact — inserted directly, as the old code path would have left
+// it) is claimed by the sweep; and the claim refuses when the parent
+// is restored first.
+func TestOrphanGC_ReclaimsLeakedLiveVariant(t *testing.T) {
+	srv, slug := testServerWithAttachments(t)
+
+	rr := doMultipartUpload(srv, slug, "leaked.png", realPNG())
+	if rr.Code != 201 {
+		t.Fatalf("upload: %d %s", rr.Code, rr.Body.String())
+	}
+	wsID := workspaceIDForSlug(t, srv, slug)
+	parentID := getOnlyAttachmentID(t, srv, wsID)
+
+	// Leak artifact: live variant row inserted the OLD unconditional way,
+	// then the parent tombstoned without the (now-atomic) cascade seeing
+	// it. item_id is SET (an attached upload's thumbnail — the common
+	// case): that keeps the row out of BOTH pre-existing GC classes, so
+	// only the new orphaned-variant class can reclaim it — which is what
+	// makes this test discriminate against the old sweep.
+	var anyItemID string
+	if err := srv.store.DB().QueryRow(srv.store.D().Rebind(
+		`SELECT id FROM items WHERE workspace_id = ? LIMIT 1`), wsID).Scan(&anyItemID); err != nil {
+		// No seeded items in this workspace — create one directly.
+		anyItemID = ""
+	}
+	leakID := parentID + "-leak"
+	if anyItemID == "" {
+		var collID string
+		if err := srv.store.DB().QueryRow(srv.store.D().Rebind(
+			`SELECT id FROM collections WHERE workspace_id = ? ORDER BY sort_order, slug LIMIT 1`), wsID).Scan(&collID); err != nil {
+			t.Fatalf("pick collection: %v", err)
+		}
+		item, err := srv.store.CreateItem(wsID, collID, models.ItemCreate{Title: "leak host"})
+		if err != nil {
+			t.Fatalf("CreateItem: %v", err)
+		}
+		anyItemID = item.ID
+	}
+	if _, err := srv.store.DB().Exec(srv.store.D().Rebind(
+		`INSERT INTO attachments (id, workspace_id, item_id, uploaded_by, storage_key, content_hash, mime_type, size_bytes, filename, parent_id, variant, created_at)
+		 VALUES (?, ?, ?, '', ?, ?, 'image/png', 10, 'leak.png', ?, 'thumb-md', ?)`),
+		leakID, wsID, anyItemID, "fs:leak-"+leakID, "hash-leak-"+leakID, parentID,
+		time.Now().UTC().Format(time.RFC3339)); err != nil {
+		t.Fatalf("insert leak: %v", err)
+	}
+	if _, err := srv.store.DB().Exec(srv.store.D().Rebind(
+		`UPDATE attachments SET deleted_at = ? WHERE id = ?`),
+		time.Now().UTC().Format(time.RFC3339), parentID); err != nil {
+		t.Fatalf("tombstone parent only: %v", err)
+	}
+
+	// RESTORE-WINS leg first: un-tombstone the parent, sweep — the
+	// leaked row must survive (claim predicate re-asserts at delete
+	// time; a restored original keeps its thumbnails).
+	if _, err := srv.store.DB().Exec(srv.store.D().Rebind(
+		`UPDATE attachments SET deleted_at = NULL WHERE id = ?`), parentID); err != nil {
+		t.Fatalf("restore parent: %v", err)
+	}
+	if _, err := srv.runOrphanGCSweep(context.Background(), time.Now().Add(-24*time.Hour)); err != nil {
+		t.Fatalf("sweep 1: %v", err)
+	}
+	if att, _ := srv.store.GetAttachment(leakID); att == nil {
+		t.Fatalf("variant of RESTORED parent reclaimed")
+	}
+
+	// Now genuinely orphan it and sweep again — reclaimed.
+	if _, err := srv.store.DB().Exec(srv.store.D().Rebind(
+		`UPDATE attachments SET deleted_at = ? WHERE id = ?`),
+		time.Now().Add(-40*24*time.Hour).UTC().Format(time.RFC3339), parentID); err != nil {
+		t.Fatalf("re-tombstone parent: %v", err)
+	}
+	res, err := srv.runOrphanGCSweep(context.Background(), time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("sweep 2: %v", err)
+	}
+	if res.Deleted < 1 {
+		t.Errorf("sweep 2 Deleted=%d, want >= 1", res.Deleted)
+	}
+	if att, _ := srv.store.GetAttachment(leakID); att != nil {
+		t.Errorf("leaked live variant survived the sweep")
 	}
 }

--- a/internal/server/orphan_gc.go
+++ b/internal/server/orphan_gc.go
@@ -299,6 +299,19 @@ type orphanGCConfig struct {
 	running  bool
 }
 
+// orphanGCGraceConfigured returns the effective grace period —
+// operator-configured when set, the default otherwise. Read under the
+// config mutex; used by the thumbnail refusal cleanup so its hash-
+// protection window honors SetOrphanGCConfig (BUG-2388 codex round 1).
+func (s *Server) orphanGCGraceConfigured() time.Duration {
+	s.orphanGC.mu.Lock()
+	defer s.orphanGC.mu.Unlock()
+	if s.orphanGC.grace > 0 {
+		return s.orphanGC.grace
+	}
+	return defaultOrphanGCGrace
+}
+
 // SetOrphanGCConfig overrides the default sweep interval (24h) and
 // grace period (30d). Pass 0 for either to keep the package default.
 // Must be called before StartOrphanGC.

--- a/internal/server/orphan_gc.go
+++ b/internal/server/orphan_gc.go
@@ -108,8 +108,32 @@ func (s *Server) runOrphanGCSweep(ctx context.Context, graceCutoff time.Time) (*
 		// + comment bodies before reclaiming so the GC doesn't destroy
 		// a legitimate reference. Codex P1 on PR #307 round 1;
 		// comment-body coverage added for IDEA-1650.
+		// LIVE variant whose parent is tombstoned/gone (BUG-2388): the
+		// leak artifact of the old non-transactional delete cascade, and
+		// the retro-cleanup class for rows already leaked. Tried FIRST
+		// for live parented rows — an item_id-NULL variant of a DEAD
+		// parent would otherwise fall into the never-attached scan,
+		// where a lingering content reference to that dead parent could
+		// keep the leaked row alive forever. The claim's own predicate
+		// re-asserts parent-not-live at delete time, so a concurrent
+		// parent restore refuses it — and a refusal simply means the
+		// parent is live, in which case the row falls through to the
+		// ordinary classes below (e.g. a live orphan upload's thumbnail
+		// stays governed by the parent-aware never-attached path).
+		claimedAsOrphanedVariant := false
+		if a.DeletedAt == nil && a.ParentID != nil && *a.ParentID != "" {
+			var claimErr error
+			claimedAsOrphanedVariant, claimErr = s.store.ClaimOrphanedVariantAttachment(a.ID)
+			if claimErr != nil {
+				slog.Warn("orphan GC: orphaned-variant claim failed",
+					"attachment_id", a.ID, "error", claimErr)
+				res.Skipped++
+				continue
+			}
+		}
+
 		neverAttached := a.ItemID == nil && a.DeletedAt == nil
-		if neverAttached {
+		if !claimedAsOrphanedVariant && neverAttached {
 			// Variants (thumbnails) are never text-referenced by their
 			// OWN id — content references the original. Scan the parent's
 			// id for them, or a referenced upload would keep its original
@@ -157,11 +181,20 @@ func (s *Server) runOrphanGCSweep(ctx context.Context, graceCutoff time.Time) (*
 		// was already destroyed — the worst failure mode of the race.)
 		var claimed bool
 		var claimErr error
-		if neverAttached {
+		switch {
+		case claimedAsOrphanedVariant:
+			claimed = true
+		case neverAttached:
 			claimed, claimErr = s.store.ClaimNeverAttachedAttachment(
 				a.ID, time.Now().Add(-orphanGCRefStaleWindow))
-		} else {
+		case a.DeletedAt != nil:
 			claimed, claimErr = s.store.ClaimSoftDeletedAttachment(a.ID, graceCutoff)
+		default:
+			// Live, parented, parent turned out to be LIVE (restored
+			// between the candidate SELECT and the variant claim), and
+			// attached (non-nil item_id) — nothing reclaimable about it.
+			res.Skipped++
+			continue
 		}
 		if claimErr != nil {
 			slog.Warn("orphan GC: claim failed",

--- a/internal/store/attachments.go
+++ b/internal/store/attachments.go
@@ -901,14 +901,51 @@ func (s *Store) ClaimNeverAttachedAttachment(id string, refCutoff time.Time) (bo
 // Same row-before-bytes and irrevocability contract as the other
 // Claim methods.
 func (s *Store) ClaimOrphanedVariantAttachment(id string) (bool, error) {
-	res, err := s.db.Exec(s.q(`
+	// Transaction + parent row-lock so a concurrent RESTORE (clearing
+	// the parent's deleted_at) serializes with this claim instead of
+	// racing its NOT EXISTS snapshot (codex round 1 P1): restore commits
+	// first → the locked re-read sees a live parent and the claim
+	// refuses; claim commits first → the restore proceeds against a
+	// parent whose thumbnail is gone (regenerable state, consistent
+	// order). SQLite serializes writers via _txlock=immediate; the lock
+	// clause is Postgres-only, same dialect gate as its siblings.
+	tx, err := s.db.Begin()
+	if err != nil {
+		return false, fmt.Errorf("begin variant claim tx: %w", err)
+	}
+	defer tx.Rollback()
+
+	var parentID *string
+	if err := tx.QueryRow(s.q(`SELECT parent_id FROM attachments WHERE id = ? AND deleted_at IS NULL`), id).Scan(&parentID); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false, nil // already gone / tombstoned
+		}
+		return false, fmt.Errorf("read variant row: %w", err)
+	}
+	if parentID == nil || *parentID == "" {
+		return false, nil // not a variant
+	}
+	lockQ := `SELECT deleted_at FROM attachments WHERE id = ?`
+	if s.dialect.Driver() == DriverPostgres {
+		lockQ += ` FOR NO KEY UPDATE`
+	}
+	var parentDeletedAt *string
+	switch err := tx.QueryRow(s.q(lockQ), *parentID).Scan(&parentDeletedAt); {
+	case errors.Is(err, sql.ErrNoRows):
+		// Parent hard-gone — the variant is orphaned; claim below.
+	case err != nil:
+		return false, fmt.Errorf("lock variant parent: %w", err)
+	default:
+		if parentDeletedAt == nil {
+			// Parent is LIVE (e.g. restored between the candidate
+			// SELECT and this claim) — refuse.
+			return false, nil
+		}
+	}
+
+	res, err := tx.Exec(s.q(`
 		DELETE FROM attachments
-		WHERE id = ?
-		  AND deleted_at IS NULL
-		  AND parent_id IS NOT NULL
-		  AND NOT EXISTS (
-		    SELECT 1 FROM attachments p WHERE p.id = attachments.parent_id AND p.deleted_at IS NULL
-		  )
+		WHERE id = ? AND deleted_at IS NULL
 	`), id)
 	if err != nil {
 		return false, fmt.Errorf("claim orphaned variant attachment: %w", err)
@@ -916,6 +953,9 @@ func (s *Store) ClaimOrphanedVariantAttachment(id string) (bool, error) {
 	n, err := res.RowsAffected()
 	if err != nil {
 		return false, fmt.Errorf("claim orphaned variant rows: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return false, fmt.Errorf("commit variant claim: %w", err)
 	}
 	return n == 1, nil
 }
@@ -1136,31 +1176,52 @@ func (s *Store) CreateAttachmentVariantIfParentLive(a *models.Attachment) (bool,
 	if a.ID == "" {
 		a.ID = newID()
 	}
-	// Same column list + timestamp idiom as createAttachmentOn so the
-	// two insert paths can never drift on shape.
 	ts := now()
 	if a.CreatedAt.IsZero() {
 		a.CreatedAt = parseTime(ts)
 	} else {
 		ts = a.CreatedAt.UTC().Format("2006-01-02T15:04:05Z07:00")
 	}
-	res, err := s.db.Exec(s.q(`
+
+	// Same transaction + row-lock shape as CreateAttachmentForLiveItem
+	// (which closed the identical check-then-insert race against ITEM
+	// deletion, PLAN-2391 DR-14): on Postgres a plain WHERE EXISTS reads
+	// a snapshot and a concurrent SoftDeleteAttachment can commit under
+	// it — the lock makes the delete cascade wait, and whichever commits
+	// first, the other observes it (codex round 1 P1). SQLite's
+	// _txlock=immediate already serializes writers, and the lock clause
+	// is a syntax error there — the dialect gate is not an optimization.
+	tx, err := s.db.Begin()
+	if err != nil {
+		return false, fmt.Errorf("begin variant insert tx: %w", err)
+	}
+	defer tx.Rollback()
+
+	query := `SELECT 1 FROM attachments WHERE id = ? AND deleted_at IS NULL`
+	if s.dialect.Driver() == DriverPostgres {
+		query += ` FOR NO KEY UPDATE`
+	}
+	var one int
+	switch err := tx.QueryRow(s.q(query), *a.ParentID).Scan(&one); {
+	case errors.Is(err, sql.ErrNoRows):
+		// Parent gone or tombstoned — refuse, no row minted.
+		return false, nil
+	case err != nil:
+		return false, fmt.Errorf("lock variant parent: %w", err)
+	}
+
+	if _, err := tx.Exec(s.q(`
 		INSERT INTO attachments (`+attachmentColumns+`)
-		SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
-		WHERE EXISTS (
-			SELECT 1 FROM attachments p WHERE p.id = ? AND p.deleted_at IS NULL
-		)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`), a.ID, a.WorkspaceID, a.ItemID, a.UploadedBy, a.StorageKey, a.ContentHash,
 		a.MimeType, a.SizeBytes, a.Filename, a.Width, a.Height, a.ParentID, a.Variant,
-		ts, nil, *a.ParentID)
-	if err != nil {
-		return false, fmt.Errorf("create variant if parent live: %w", err)
+		ts, nil); err != nil {
+		return false, fmt.Errorf("create variant row: %w", err)
 	}
-	n, err := res.RowsAffected()
-	if err != nil {
-		return false, fmt.Errorf("create variant rows affected: %w", err)
+	if err := tx.Commit(); err != nil {
+		return false, fmt.Errorf("commit variant insert: %w", err)
 	}
-	return n == 1, nil
+	return true, nil
 }
 
 // WorkspaceItemSlugMap returns slug → id for every live item in a

--- a/internal/store/attachments.go
+++ b/internal/store/attachments.go
@@ -707,6 +707,10 @@ func (s *Store) OrphanedAttachments(graceCutoff time.Time) ([]models.Attachment,
 		  (item_id IS NULL AND deleted_at IS NULL AND created_at < ?)
 		  OR
 		  (deleted_at IS NOT NULL AND deleted_at < ?)
+		  OR
+		  (deleted_at IS NULL AND parent_id IS NOT NULL AND NOT EXISTS (
+		    SELECT 1 FROM attachments p WHERE p.id = attachments.parent_id AND p.deleted_at IS NULL
+		  ))
 		ORDER BY created_at, id
 	`), cutoffStr, cutoffStr)
 	if err != nil {
@@ -886,6 +890,36 @@ func (s *Store) ClaimNeverAttachedAttachment(id string, refCutoff time.Time) (bo
 	return n == 1, nil
 }
 
+// ClaimOrphanedVariantAttachment is the orphan GC's atomic claim for a
+// LIVE variant row whose parent original is tombstoned or gone
+// (BUG-2388) — the leak artifact of the old non-transactional delete
+// cascade racing thumbnail derivation, and the retro-cleanup for rows
+// already leaked. The DELETE re-asserts the whole shape at delete
+// time: still live, still a variant, and the parent still NOT live —
+// so a parent restore committing first makes this match zero rows and
+// the variant survives (a restored original keeps its thumbnails).
+// Same row-before-bytes and irrevocability contract as the other
+// Claim methods.
+func (s *Store) ClaimOrphanedVariantAttachment(id string) (bool, error) {
+	res, err := s.db.Exec(s.q(`
+		DELETE FROM attachments
+		WHERE id = ?
+		  AND deleted_at IS NULL
+		  AND parent_id IS NOT NULL
+		  AND NOT EXISTS (
+		    SELECT 1 FROM attachments p WHERE p.id = attachments.parent_id AND p.deleted_at IS NULL
+		  )
+	`), id)
+	if err != nil {
+		return false, fmt.Errorf("claim orphaned variant attachment: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("claim orphaned variant rows: %w", err)
+	}
+	return n == 1, nil
+}
+
 // ClaimSoftDeletedAttachment is the orphan GC's atomic claim for a
 // soft-deleted row past its grace window (BUG-2415): the DELETE
 // re-asserts deleted_at is still set and still past the cutoff at
@@ -1038,7 +1072,20 @@ func (s *Store) SoftDeleteWorkspaceAttachments(workspaceID string) (int64, error
 // is the GC's job once it can prove no live row references the hash.
 func (s *Store) SoftDeleteAttachment(id string) error {
 	ts := now()
-	res, err := s.db.Exec(s.q(`
+	// One TRANSACTION for original + variants (BUG-2388): the old two
+	// separate statements let a crash — or a concurrent thumbnail
+	// derivation — land between them, leaving half-tombstoned families.
+	// (The old comment claimed orphan GC would reach stragglers "via the
+	// deleted-parent path"; no such path existed — that is exactly the
+	// leak this bug fixes, and the sweep now has a real orphaned-variant
+	// class as the belt.)
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin soft delete tx: %w", err)
+	}
+	defer tx.Rollback()
+
+	res, err := tx.Exec(s.q(`
 		UPDATE attachments
 		SET deleted_at = ?
 		WHERE id = ? AND deleted_at IS NULL
@@ -1053,20 +1100,67 @@ func (s *Store) SoftDeleteAttachment(id string) error {
 	if n == 0 {
 		return sql.ErrNoRows
 	}
-	// Also tombstone any thumbnail variants. They're synthetic rows
-	// derived from the original; without the original they have no
-	// reason to exist. Errors here are non-fatal — orphan GC will
-	// still reach them eventually via the deleted-parent path.
-	if _, err := s.db.Exec(s.q(`
+	// Tombstone the thumbnail variants atomically with the original —
+	// synthetic rows with no reason to outlive it.
+	if _, err := tx.Exec(s.q(`
 		UPDATE attachments
 		SET deleted_at = ?
 		WHERE parent_id = ? AND deleted_at IS NULL
 	`), ts, id); err != nil {
-		// Log via the caller; we don't have a logger here. The row
-		// went through, so don't fail the request.
-		return nil
+		return fmt.Errorf("soft delete attachment variants: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit soft delete: %w", err)
 	}
 	return nil
+}
+
+// CreateAttachmentVariantIfParentLive inserts a derived-variant row
+// ONLY while its parent original is still live — the liveness check is
+// part of the INSERT statement itself (BUG-2388, the same
+// claim-by-statement discipline as the orphan-GC claims): a delete
+// cascade committing between the derivation's early parent check and
+// this insert makes the WHERE EXISTS fail and the insert report false,
+// instead of minting a live variant row under a tombstoned parent.
+//
+// Returns whether the row was inserted. The caller owns the just-Put
+// blob on a false return (clean it up under the in-flight hash fence
+// it already holds).
+func (s *Store) CreateAttachmentVariantIfParentLive(a *models.Attachment) (bool, error) {
+	if a.ParentID == nil || *a.ParentID == "" {
+		return false, fmt.Errorf("variant insert requires parent_id")
+	}
+	if a.StorageKey == "" {
+		return false, fmt.Errorf("attachment storage_key must not be empty")
+	}
+	if a.ID == "" {
+		a.ID = newID()
+	}
+	// Same column list + timestamp idiom as createAttachmentOn so the
+	// two insert paths can never drift on shape.
+	ts := now()
+	if a.CreatedAt.IsZero() {
+		a.CreatedAt = parseTime(ts)
+	} else {
+		ts = a.CreatedAt.UTC().Format("2006-01-02T15:04:05Z07:00")
+	}
+	res, err := s.db.Exec(s.q(`
+		INSERT INTO attachments (`+attachmentColumns+`)
+		SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+		WHERE EXISTS (
+			SELECT 1 FROM attachments p WHERE p.id = ? AND p.deleted_at IS NULL
+		)
+	`), a.ID, a.WorkspaceID, a.ItemID, a.UploadedBy, a.StorageKey, a.ContentHash,
+		a.MimeType, a.SizeBytes, a.Filename, a.Width, a.Height, a.ParentID, a.Variant,
+		ts, nil, *a.ParentID)
+	if err != nil {
+		return false, fmt.Errorf("create variant if parent live: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("create variant rows affected: %w", err)
+	}
+	return n == 1, nil
 }
 
 // WorkspaceItemSlugMap returns slug → id for every live item in a

--- a/internal/store/attachments_gc_claim_test.go
+++ b/internal/store/attachments_gc_claim_test.go
@@ -343,3 +343,65 @@ func TestStampAttachmentRefs_StampsVariantsOfReferencedOriginal(t *testing.T) {
 		t.Fatalf("fresh-own-stamp variant claim = (%v, %v), want (false, nil)", claimed, err)
 	}
 }
+
+// TestClaimOrphanedVariant_RestoreRefusesAtClaimTime pins the codex-
+// round-1 gap in BUG-2388's restore-wins e2e leg (which only proved the
+// restored row never became a CANDIDATE): the claim itself, called
+// directly against a variant whose parent was restored after candidate
+// selection, must refuse — the parent-liveness re-read happens inside
+// the claim's own transaction, under a Postgres row lock.
+func TestClaimOrphanedVariant_RestoreRefusesAtClaimTime(t *testing.T) {
+	f := newGCClaimFixture(t)
+	parent := f.seedNeverAttached(t)
+
+	variantID := parent.ID + "-v"
+	if _, err := f.s.db.Exec(f.s.q(
+		`INSERT INTO attachments (id, workspace_id, item_id, uploaded_by, storage_key, content_hash, mime_type, size_bytes, filename, parent_id, variant, created_at)
+		 VALUES (?, ?, NULL, '', ?, ?, 'image/png', 10, 'v.png', ?, 'thumb-md', ?)`),
+		variantID, f.wsID, "fs:v-"+variantID, "h-v-"+variantID, parent.ID,
+		time.Now().UTC().Format(time.RFC3339)); err != nil {
+		t.Fatalf("insert variant: %v", err)
+	}
+
+	// Tombstone the parent (candidate state), then RESTORE it — the
+	// interleaving the claim must observe at delete time.
+	nowTS := time.Now().UTC().Format(time.RFC3339)
+	if _, err := f.s.db.Exec(f.s.q(`UPDATE attachments SET deleted_at = ? WHERE id = ?`), nowTS, parent.ID); err != nil {
+		t.Fatalf("tombstone parent: %v", err)
+	}
+	if _, err := f.s.db.Exec(f.s.q(`UPDATE attachments SET deleted_at = NULL WHERE id = ?`), parent.ID); err != nil {
+		t.Fatalf("restore parent: %v", err)
+	}
+
+	claimed, err := f.s.ClaimOrphanedVariantAttachment(variantID)
+	if err != nil || claimed {
+		t.Fatalf("restored-parent variant claim = (%v, %v), want (false, nil)", claimed, err)
+	}
+	if !f.rowExists(t, variantID) {
+		t.Errorf("variant of restored parent deleted anyway")
+	}
+
+	// Counterfactual: re-tombstone the parent → the same claim succeeds.
+	if _, err := f.s.db.Exec(f.s.q(`UPDATE attachments SET deleted_at = ? WHERE id = ?`), nowTS, parent.ID); err != nil {
+		t.Fatalf("re-tombstone parent: %v", err)
+	}
+	claimed, err = f.s.ClaimOrphanedVariantAttachment(variantID)
+	if err != nil || !claimed {
+		t.Fatalf("dead-parent variant claim = (%v, %v), want (true, nil)", claimed, err)
+	}
+
+	// Hard-gone parent leg: a variant whose parent row does not exist at
+	// all is likewise claimable.
+	orphanVar := "no-parent-v"
+	if _, err := f.s.db.Exec(f.s.q(
+		`INSERT INTO attachments (id, workspace_id, item_id, uploaded_by, storage_key, content_hash, mime_type, size_bytes, filename, parent_id, variant, created_at)
+		 VALUES (?, ?, NULL, '', ?, ?, 'image/png', 10, 'v2.png', 'gone-parent-id', 'thumb-md', ?)`),
+		orphanVar, f.wsID, "fs:v2", "h-v2",
+		time.Now().UTC().Format(time.RFC3339)); err != nil {
+		t.Fatalf("insert hard-orphan variant: %v", err)
+	}
+	claimed, err = f.s.ClaimOrphanedVariantAttachment(orphanVar)
+	if err != nil || !claimed {
+		t.Fatalf("hard-gone-parent variant claim = (%v, %v), want (true, nil)", claimed, err)
+	}
+}


### PR DESCRIPTION
## Root cause

Deleting an attachment mid-derivation could mint a live, unreachable variant row under a tombstoned parent: the delete cascade tombstoned original and variants in **separate statements**, and derivation checked parent liveness once, then inserted unconditionally. The leaked row was UI-invisible, counted toward quota forever, and **no GC class could reclaim it** — the old code's comment claimed a "deleted-parent path" existed; it did not.

## Change (the BUG-2415 claim-by-statement family)

- **Atomic cascade** — `SoftDeleteAttachment` tombstones original + variants in one transaction; a variant-tombstone failure now rolls back rather than leaving a partial family.
- **`CreateAttachmentVariantIfParentLive`** — transaction + dialect-gated `FOR NO KEY UPDATE` parent lock + insert, the `CreateAttachmentForLiveItem` precedent (review round 1 showed a plain `WHERE EXISTS` still races on Postgres — snapshot reads don't wait for a committing cascade; the lock makes whichever transaction commits first observable to the other). `persistThumbnail` cleans up the just-Put blob on refusal with the count, self-registration check, and `Delete` all held under `inFlightHashesMu` (round 2: a complete upload lifecycle could otherwise stale an outside-the-fence count), honoring the operator-configured GC grace.
- **Orphaned-variant GC class** — live variant whose parent is tombstoned/gone; candidate branch + `ClaimOrphanedVariantAttachment`, tried first for live parented rows (an `item_id`-NULL leak would otherwise hide behind a content reference to its dead parent in the never-attached scan). The claim re-reads the variant and **locks the parent** in its own transaction, so a concurrent restore refuses it — a restored original keeps its thumbnails. Retro-reclaims rows already leaked. Lock ordering between the insert tx and the cascade tx reviewed: both take parent before children — no deadlock surface.

## Verification

- The filed race pinned **deterministically**: `persistThumbnail` called with a pre-delete parent snapshot (exactly what the async goroutine holds) — the control build mints the leaked row with the test's own message; the fixed build refuses, mints nothing, and the blob-cleanup assertion (deterministic hash recompute + `Stat`) proves the bytes went too.
- Retro-reclaim sweep test with a deliberately **attached** leak fixture so only the new class can reclaim it (control build: "leaked live variant survived the sweep"), plus a restore-wins leg.
- Store-level restore-refusal-**at-claim-time** test with tombstoned-counterfactual and hard-gone-parent legs (round 2 observed the e2e restore leg only proved candidate non-selection).
- `go test ./...` 0 / `make lint` 0 / `make test-pg` 0 at both round tips. Codex rounds: R1 four findings fixed, R2 one, R3 confirm CLEAN.