### PR TITLE
fix(store): route cross-workspace copy's lock-held reads through the copy transaction (BUG-2409)

### DIFF
--- a/internal/server/attachments_authz.go
+++ b/internal/server/attachments_authz.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/PerpetualSoftware/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/store"
 )
 
 // attachmentParentOutcome classifies the result of resolving an attachment
@@ -71,6 +72,15 @@ const (
 // store.CreateAttachmentForLiveItem; derivation deliberately does not (see the
 // comment on deriveThumbnails). Do not read a passing check here as a lock.
 func (s *Server) resolveAttachmentParentItem(att *models.Attachment, includeArchived bool) (*models.Item, attachmentParentOutcome, error) {
+	return s.resolveAttachmentParentItemQ(s.store.Q(), att, includeArchived)
+}
+
+// resolveAttachmentParentItemQ is resolveAttachmentParentItem parameterized
+// over its executor — the cross-workspace copy's attachment authorizer runs
+// it on the copy transaction's connection (BUG-2409); every other caller
+// uses the pool wrapper above. One body, two executors, so the invariant
+// stays in one place.
+func (s *Server) resolveAttachmentParentItemQ(q store.Queryer, att *models.Attachment, includeArchived bool) (*models.Item, attachmentParentOutcome, error) {
 	if att.ItemID == nil || *att.ItemID == "" {
 		return nil, attachmentParentOrphan, nil
 	}
@@ -80,9 +90,9 @@ func (s *Server) resolveAttachmentParentItem(att *models.Attachment, includeArch
 		err  error
 	)
 	if includeArchived {
-		item, err = s.store.GetItemIncludeDeleted(*att.ItemID)
+		item, err = s.store.GetItemIncludeDeletedQ(q, *att.ItemID)
 	} else {
-		item, err = s.store.GetItem(*att.ItemID)
+		item, err = s.store.GetItemQ(q, *att.ItemID)
 	}
 	if err != nil {
 		return nil, attachmentParentGone, err
@@ -116,7 +126,13 @@ func (s *Server) resolveAttachmentParentItem(att *models.Attachment, includeArch
 // Callers MUST apply it AHEAD of any role gate that would answer 403: a 403
 // reached only for rows that exist is itself the oracle.
 func (s *Server) attachmentCallerIsRestricted(r *http.Request, workspaceID string) (bool, error) {
-	fullCollIDs, grantedItemIDs, err := s.guestResourceFilter(r, workspaceID)
+	return s.attachmentCallerIsRestrictedQ(s.store.Q(), r, workspaceID)
+}
+
+// attachmentCallerIsRestrictedQ is attachmentCallerIsRestricted
+// parameterized over its executor (see resolveAttachmentParentItemQ).
+func (s *Server) attachmentCallerIsRestrictedQ(q store.Queryer, r *http.Request, workspaceID string) (bool, error) {
+	fullCollIDs, grantedItemIDs, err := s.guestResourceFilterCoreQ(q, r, workspaceID, false)
 	if err != nil {
 		return false, err
 	}
@@ -170,20 +186,20 @@ func (s *Server) attachmentCallerIsRestricted(r *http.Request, workspaceID strin
 // practice by the attachments that actually exist in the source workspace,
 // since an unresolvable reference never reaches this function at all.
 //
-// RESIDUAL, and the more consequential one: these queries go through the
-// connection POOL, and on the mutating path the planner runs inside a
-// transaction holding advisory locks on BOTH workspaces. Enough concurrent
-// copies could therefore occupy every pooled connection with lock-waiters
-// while the lock HOLDER waits for a spare — starvation presenting as a
-// hang. The memo above is what keeps this bounded rather than per-row. The
-// hazard is not new (PlanAttachmentCopy already reads through the pool
-// under the same locks, attachments_copy_plan.go) and the real fix is to
-// make the lock-held reads transaction-bound, which means threading the
-// *sql.Tx through the planner and giving this callback a tx-aware form.
-// Tracked as BUG-2409; deliberately NOT done here, because it is a change
-// to the store's transaction plumbing rather than to this authorization
-// rule.
-func (s *Server) attachmentCopyAuthorizer(r *http.Request, workspaceID string) func(models.Attachment) (bool, error) {
+// TRANSACTION-BOUND READS (BUG-2409). Every read below runs on the Queryer
+// the PLANNER passes in — the pool on the preflight path, the copy's own
+// in-flight transaction on the mutating path. That matters because the
+// mutating planner runs inside a transaction holding advisory locks on
+// BOTH workspaces: a read routed through the connection pool there could
+// wait for a free connection while every pooled connection is itself
+// occupied by a copy waiting on those locks — starvation presenting as a
+// hang. On the transaction's own connection the reads cannot wait on the
+// pool at all. The memo is what keeps the read count bounded rather than
+// per-row; the q-threading is what keeps the bounded reads off the pool.
+// NOTE the memo is keyed per parent item, not per (q, item) — sound
+// because one closure only ever sees one executor: it is built per
+// resolveAuthorizedCopy call and consumed by exactly one planner pass.
+func (s *Server) attachmentCopyAuthorizer(r *http.Request, workspaceID string) store.AttachmentAuthorizer {
 	type verdict struct {
 		allowed bool
 		err     error
@@ -194,14 +210,14 @@ func (s *Server) attachmentCopyAuthorizer(r *http.Request, workspaceID string) f
 		byParentItem    = map[string]verdict{}
 	)
 
-	decide := func(att models.Attachment) (bool, error) {
-		item, outcome, err := s.resolveAttachmentParentItem(&att, false)
+	decide := func(q store.Queryer, att models.Attachment) (bool, error) {
+		item, outcome, err := s.resolveAttachmentParentItemQ(q, &att, false)
 		if err != nil {
 			return false, err
 		}
 		switch outcome {
 		case attachmentParentOK:
-			return s.checkItemVisible(workspaceID, item, currentUser(r), workspaceRole(r), isBearerAuth(r))
+			return s.checkItemVisibleQ(q, workspaceID, item, currentUser(r), workspaceRole(r), isBearerAuth(r))
 		case attachmentParentOrphan:
 			// The orphan rule (PLAN-2382 DR-4), and the restriction check
 			// BEFORE the role check for the reason every sibling path
@@ -210,7 +226,7 @@ func (s *Server) attachmentCopyAuthorizer(r *http.Request, workspaceID string) f
 			// "unresolvable" count anyway, but keeping the order identical
 			// to the read path is what makes the two comparable.
 			if !restrictedKnown {
-				isRestricted, err := s.attachmentCallerIsRestricted(r, workspaceID)
+				isRestricted, err := s.attachmentCallerIsRestrictedQ(q, r, workspaceID)
 				if err != nil {
 					return false, err
 				}
@@ -226,7 +242,7 @@ func (s *Server) attachmentCopyAuthorizer(r *http.Request, workspaceID string) f
 		}
 	}
 
-	return func(att models.Attachment) (bool, error) {
+	return func(q store.Queryer, att models.Attachment) (bool, error) {
 		// Defense in depth: the planner scopes every query to the source
 		// workspace already, so this cannot fire today. It costs nothing
 		// and means the authorizer is safe to hand to any future caller
@@ -241,12 +257,12 @@ func (s *Server) attachmentCopyAuthorizer(r *http.Request, workspaceID string) f
 		// Orphans are not memoized: they have no item_id to key on, and
 		// their branch runs no per-row query anyway.
 		if att.ItemID == nil || *att.ItemID == "" {
-			return decide(att)
+			return decide(q, att)
 		}
 		if v, ok := byParentItem[*att.ItemID]; ok {
 			return v.allowed, v.err
 		}
-		allowed, err := decide(att)
+		allowed, err := decide(q, att)
 		byParentItem[*att.ItemID] = verdict{allowed: allowed, err: err}
 		return allowed, err
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2172,6 +2172,16 @@ func (s *Server) requireItemVisible(w http.ResponseWriter, r *http.Request, work
 //     because the item-grants branch only checked direct grants + the
 //     member's explicit collection-access list).
 func (s *Server) checkItemVisible(workspaceID string, item *models.Item, user *models.User, role string, isBearer bool) (bool, error) {
+	return s.checkItemVisibleQ(s.store.Q(), workspaceID, item, user, role, isBearer)
+}
+
+// checkItemVisibleQ is checkItemVisible parameterized over its executor, so
+// the cross-workspace copy's attachment authorizer can run the same
+// visibility rule on the copy transaction's own connection instead of the
+// pool while the transaction holds both workspace advisory locks
+// (BUG-2409). Every other caller goes through the pool wrapper above; the
+// decision logic is identical by construction — one body, two executors.
+func (s *Server) checkItemVisibleQ(q store.Queryer, workspaceID string, item *models.Item, user *models.User, role string, isBearer bool) (bool, error) {
 	// Tokenized-nil-user bypass. RequireWorkspaceAccess synthesizes
 	// "owner" on fresh installs (UserCount == 0, currentUser == nil) and
 	// "editor" for legacy workspace-scoped API tokens (currentUser ==
@@ -2198,7 +2208,7 @@ func (s *Server) checkItemVisible(workspaceID string, item *models.Item, user *m
 	}
 
 	// Visibility filter: nil = unrestricted; non-nil = restricted to the slice.
-	visibleIDs, err := s.store.VisibleCollectionIDs(workspaceID, user.ID)
+	visibleIDs, err := s.store.VisibleCollectionIDsQ(q, workspaceID, user.ID)
 	if err != nil {
 		return false, err
 	}
@@ -2210,7 +2220,7 @@ func (s *Server) checkItemVisible(workspaceID string, item *models.Item, user *m
 	// dependency. Member-with-all-access short-circuits to "no item-level
 	// filter"; guests + restricted members get the grant filter.
 	if role != "guest" {
-		member, err := s.store.GetWorkspaceMember(workspaceID, user.ID)
+		member, err := s.store.GetWorkspaceMemberQ(q, workspaceID, user.ID)
 		if err != nil {
 			return false, err
 		}
@@ -2220,7 +2230,7 @@ func (s *Server) checkItemVisible(workspaceID string, item *models.Item, user *m
 		}
 	}
 
-	grantCollIDs, grantedItemIDs, err := s.store.GuestVisibleResources(workspaceID, user.ID)
+	grantCollIDs, grantedItemIDs, err := s.store.GuestVisibleResourcesQ(q, workspaceID, user.ID)
 	if err != nil {
 		return false, err
 	}
@@ -2250,7 +2260,7 @@ func (s *Server) checkItemVisible(workspaceID string, item *models.Item, user *m
 		// member_collection_access path — restricted members see their
 		// explicit collection-access list as full grants alongside any
 		// item-level grants.
-		memberColls, err := s.store.GetMemberCollectionAccess(workspaceID, user.ID)
+		memberColls, err := s.store.GetMemberCollectionAccessQ(q, workspaceID, user.ID)
 		if err != nil {
 			return false, err
 		}
@@ -2263,7 +2273,7 @@ func (s *Server) checkItemVisible(workspaceID string, item *models.Item, user *m
 		// pre-round-2 behavior. ListSystemCollectionIDs is a workspace-
 		// scoped lookup (no per-user filter), so the same call is correct
 		// for every restricted member in the workspace.
-		sysColls, err := s.store.ListSystemCollectionIDs(workspaceID)
+		sysColls, err := s.store.ListSystemCollectionIDsQ(q, workspaceID)
 		if err != nil {
 			return false, err
 		}
@@ -2354,6 +2364,14 @@ func (s *Server) guestResourceFilterIncludeDeletedItems(r *http.Request, workspa
 //
 // The includeDeletedItems flag swaps the underlying grant query.
 func (s *Server) guestResourceFilterCore(r *http.Request, workspaceID string, includeDeletedItems bool) (fullCollIDs, grantedItemIDs []string, err error) {
+	return s.guestResourceFilterCoreQ(s.store.Q(), r, workspaceID, includeDeletedItems)
+}
+
+// guestResourceFilterCoreQ is guestResourceFilterCore parameterized over its
+// executor — the cross-workspace copy's attachment authorizer runs it on the
+// copy transaction's connection (BUG-2409); everything else uses the pool
+// wrapper above.
+func (s *Server) guestResourceFilterCoreQ(q store.Queryer, r *http.Request, workspaceID string, includeDeletedItems bool) (fullCollIDs, grantedItemIDs []string, err error) {
 	user := currentUser(r)
 	if user == nil {
 		return nil, nil, nil
@@ -2366,7 +2384,7 @@ func (s *Server) guestResourceFilterCore(r *http.Request, workspaceID string, in
 	// helper duplicates the admin check via GetUser, but for the
 	// request hot path we short-circuit above (cookie admin only)
 	// so the duplicate lookup never fires for the common case.
-	return s.store.ResolveBacklinksVisibility(user.ID, workspaceID, includeDeletedItems, authIsBearer)
+	return s.store.ResolveBacklinksVisibilityQ(q, user.ID, workspaceID, includeDeletedItems, authIsBearer)
 }
 
 // isCollectionVisible checks if a collection ID is in the visible set.

--- a/internal/store/attachments_copy_plan.go
+++ b/internal/store/attachments_copy_plan.go
@@ -31,12 +31,17 @@ import (
 // RecordItemWorkspaceMoveTx is the shape to follow. That belongs to the
 // caller; it is not something this planner can or should provide.
 //
-// The planner takes no *sql.Tx and holds no lock. It reads in three
-// bounded passes — referenced ids, any missing parents, then variants —
-// each chunked, so the query count is proportional to the number of
-// chunks, not to the number of references. It mutates nothing. If a future
-// change appears to need a transaction here, the boundary has been drawn
-// wrong: the writes belong to the caller.
+// The planner takes no lock of its own and mutates nothing. It reads in
+// three bounded passes — referenced ids, any missing parents, then
+// variants — each chunked, so the query count is proportional to the
+// number of chunks, not to the number of references. It is parameterized
+// over a Queryer (planAttachmentCopyQ) rather than owning a transaction:
+// the dry-run reads through the pool, and the mutating copy passes its own
+// in-flight transaction so the reads run on the connection that already
+// holds the workspace advisory locks instead of waiting on the pool
+// (BUG-2409). If a future change appears to need the planner to BEGIN a
+// transaction here, the boundary has been drawn wrong: the writes belong
+// to the caller.
 //
 // STALENESS CONTRACT — a plan is a snapshot, and it is only valid inside
 // the critical section that produced it. Because the planner holds no
@@ -219,7 +224,19 @@ type AttachmentCopyRequest struct {
 // preflight and the copy, set it from the one place their shared
 // authorization ladder runs (server.resolveAuthorizedCopy), so a new
 // endpoint cannot reach the planner without going past it.
-type AttachmentAuthorizer func(models.Attachment) (bool, error)
+//
+// THE QUERYER PARAMETER IS THE PLANNER'S OWN EXECUTOR (BUG-2409). The
+// verdict requires reads — the parent item, the caller's grants — and on
+// the mutating path the planner runs inside a transaction holding BOTH
+// workspace advisory locks. An authorizer that read through the connection
+// pool there could wait on a free connection while every pooled connection
+// waits on the locks this transaction holds: starvation presenting as a
+// hang. Running the reads on q — the pool on the preflight path, the
+// copy's own transaction on the mutating path — makes them free of pool
+// waits exactly when it matters. Implementations must route every read
+// through q (the store's *Q variants exist for this) and must not reach
+// for the pool directly.
+type AttachmentAuthorizer func(q Queryer, att models.Attachment) (bool, error)
 
 // AttachmentCopyRow is one attachment row to create in workspace B, plus
 // the source-side facts the caller needs in order to move bytes if it has
@@ -354,6 +371,16 @@ type AttachmentCopyPlan struct {
 // Dropping the scope from the variant query runs the same escalation one
 // level down.
 func (s *Store) PlanAttachmentCopy(req AttachmentCopyRequest) (*AttachmentCopyPlan, error) {
+	return s.planAttachmentCopyQ(s.db, req)
+}
+
+// planAttachmentCopyQ is PlanAttachmentCopy parameterized over its executor.
+// The preflight plans through the pool (no locks held); the mutating copy
+// plans on its own transaction, which holds both workspace advisory locks —
+// routing these reads (and the authorizer callback's, which receives the
+// same q) through that transaction is what keeps the lock-held critical
+// section free of pool waits (BUG-2409).
+func (s *Store) planAttachmentCopyQ(q Queryer, req AttachmentCopyRequest) (*AttachmentCopyPlan, error) {
 	for _, required := range []struct{ name, value string }{
 		{"source_workspace_id", req.SourceWorkspaceID},
 		{"target_workspace_id", req.TargetWorkspaceID},
@@ -385,11 +412,11 @@ func (s *Store) PlanAttachmentCopy(req AttachmentCopyRequest) (*AttachmentCopyPl
 	// not exist" are the same fact, expressed the same way, and every
 	// downstream classification treats them identically without knowing
 	// the difference exists (TASK-2408).
-	resolved, err := s.attachmentsByIDInWorkspace(req.SourceWorkspaceID, refs)
+	resolved, err := s.attachmentsByIDInWorkspace(q, req.SourceWorkspaceID, refs)
 	if err != nil {
 		return nil, err
 	}
-	if err := filterAuthorizedAttachments(resolved, req.Authorize); err != nil {
+	if err := filterAuthorizedAttachments(q, resolved, req.Authorize); err != nil {
 		return nil, err
 	}
 
@@ -418,14 +445,14 @@ func (s *Store) PlanAttachmentCopy(req AttachmentCopyRequest) (*AttachmentCopyPl
 		missingParents = append(missingParents, *a.ParentID)
 	}
 	if len(missingParents) > 0 {
-		parents, err := s.attachmentsByIDInWorkspace(req.SourceWorkspaceID, missingParents)
+		parents, err := s.attachmentsByIDInWorkspace(q, req.SourceWorkspaceID, missingParents)
 		if err != nil {
 			return nil, err
 		}
 		// A parent the caller cannot see is not a clone root, exactly as a
 		// parent in another workspace is not: the reference below finds no
 		// entry and becomes unresolvable.
-		if err := filterAuthorizedAttachments(parents, req.Authorize); err != nil {
+		if err := filterAuthorizedAttachments(q, parents, req.Authorize); err != nil {
 			return nil, err
 		}
 		for id, a := range parents {
@@ -476,7 +503,7 @@ func (s *Store) PlanAttachmentCopy(req AttachmentCopyRequest) (*AttachmentCopyPl
 	for i, r := range roots {
 		rootIDs[i] = r.ID
 	}
-	variantsByParent, err := s.attachmentVariantsInWorkspace(req.SourceWorkspaceID, rootIDs)
+	variantsByParent, err := s.attachmentVariantsInWorkspace(q, req.SourceWorkspaceID, rootIDs)
 	if err != nil {
 		return nil, err
 	}
@@ -492,7 +519,7 @@ func (s *Store) PlanAttachmentCopy(req AttachmentCopyRequest) (*AttachmentCopyPl
 		for parentID, variants := range variantsByParent {
 			kept := variants[:0]
 			for _, v := range variants {
-				ok, err := req.Authorize(v)
+				ok, err := req.Authorize(q, v)
 				if err != nil {
 					return nil, fmt.Errorf("plan attachment copy: authorize variant: %w", err)
 				}
@@ -521,12 +548,12 @@ func (s *Store) PlanAttachmentCopy(req AttachmentCopyRequest) (*AttachmentCopyPl
 // unobservable: the planner's classification asks only whether an id is
 // present in the map, so the denied reference takes the identical branch a
 // dangling one takes and produces identical counts.
-func filterAuthorizedAttachments(rows map[string]models.Attachment, authorize AttachmentAuthorizer) error {
+func filterAuthorizedAttachments(q Queryer, rows map[string]models.Attachment, authorize AttachmentAuthorizer) error {
 	if authorize == nil {
 		return nil
 	}
 	for id, a := range rows {
-		ok, err := authorize(a)
+		ok, err := authorize(q, a)
 		if err != nil {
 			return fmt.Errorf("plan attachment copy: authorize %s: %w", id, err)
 		}
@@ -636,7 +663,7 @@ func attachmentRefsIn(content string, fields map[string]any) ([]string, error) {
 // are simply absent from the result — the caller treats absence as
 // "unresolvable", so a foreign id and a dangling id are indistinguishable
 // by design.
-func (s *Store) attachmentsByIDInWorkspace(workspaceID string, ids []string) (map[string]models.Attachment, error) {
+func (s *Store) attachmentsByIDInWorkspace(q Queryer, workspaceID string, ids []string) (map[string]models.Attachment, error) {
 	out := make(map[string]models.Attachment, len(ids))
 	for _, chunk := range chunkStrings(ids, attachmentPlanChunk) {
 		args := make([]any, 0, len(chunk)+1)
@@ -647,7 +674,7 @@ func (s *Store) attachmentsByIDInWorkspace(workspaceID string, ids []string) (ma
 		query := `SELECT ` + attachmentColumns + ` FROM attachments
 			WHERE workspace_id = ? AND deleted_at IS NULL
 			  AND id IN (` + sqlPlaceholderList(len(chunk)) + `)`
-		if err := s.scanAttachmentsInto(query, args, func(a models.Attachment) {
+		if err := s.scanAttachmentsInto(q, query, args, func(a models.Attachment) {
 			out[a.ID] = a
 		}); err != nil {
 			return nil, fmt.Errorf("plan attachment copy: resolve refs: %w", err)
@@ -667,7 +694,7 @@ func (s *Store) attachmentsByIDInWorkspace(workspaceID string, ids []string) (ma
 // same reason itemWorkspaceMoveOrder coalesces source_seq. Real thumbnails
 // always set variant, but a NULL one must not reorder the plan depending
 // on which database is underneath.
-func (s *Store) attachmentVariantsInWorkspace(workspaceID string, parentIDs []string) (map[string][]models.Attachment, error) {
+func (s *Store) attachmentVariantsInWorkspace(q Queryer, workspaceID string, parentIDs []string) (map[string][]models.Attachment, error) {
 	out := map[string][]models.Attachment{}
 	for _, chunk := range chunkStrings(parentIDs, attachmentPlanChunk) {
 		args := make([]any, 0, len(chunk)+1)
@@ -679,7 +706,7 @@ func (s *Store) attachmentVariantsInWorkspace(workspaceID string, parentIDs []st
 			WHERE workspace_id = ? AND deleted_at IS NULL
 			  AND parent_id IN (` + sqlPlaceholderList(len(chunk)) + `)
 			ORDER BY COALESCE(variant, ''), id`
-		if err := s.scanAttachmentsInto(query, args, func(a models.Attachment) {
+		if err := s.scanAttachmentsInto(q, query, args, func(a models.Attachment) {
 			if a.ParentID == nil {
 				return
 			}
@@ -693,8 +720,8 @@ func (s *Store) attachmentVariantsInWorkspace(workspaceID string, parentIDs []st
 
 // scanAttachmentsInto runs a query returning attachmentColumns and hands
 // each row to visit.
-func (s *Store) scanAttachmentsInto(query string, args []any, visit func(models.Attachment)) error {
-	rows, err := s.db.Query(s.q(query), args...)
+func (s *Store) scanAttachmentsInto(q Queryer, query string, args []any, visit func(models.Attachment)) error {
+	rows, err := q.Query(s.q(query), args...)
 	if err != nil {
 		return err
 	}

--- a/internal/store/attachments_copy_plan_test.go
+++ b/internal/store/attachments_copy_plan_test.go
@@ -1001,7 +1001,7 @@ func TestPlanAttachmentCopy_DeniedParentSinksTheVariantRef(t *testing.T) {
 	thumb := f.variant(t, f.wsA, orig, models.AttachmentVariantThumbSm, 10)
 
 	// Everything is visible EXCEPT the original.
-	req := withAuthorizer(f.req(imageRef(thumb.ID), nil), func(a models.Attachment) (bool, error) {
+	req := withAuthorizer(f.req(imageRef(thumb.ID), nil), func(_ Queryer, a models.Attachment) (bool, error) {
 		return a.ID != orig.ID, nil
 	})
 	plan := f.plan(t, req)
@@ -1026,7 +1026,7 @@ func TestPlanAttachmentCopy_DeniedVariantDropsOnlyItself(t *testing.T) {
 	sm := f.variant(t, f.wsA, orig, models.AttachmentVariantThumbSm, 10)
 	md := f.variant(t, f.wsA, orig, models.AttachmentVariantThumbMd, 20)
 
-	req := withAuthorizer(f.req(imageRef(orig.ID), nil), func(a models.Attachment) (bool, error) {
+	req := withAuthorizer(f.req(imageRef(orig.ID), nil), func(_ Queryer, a models.Attachment) (bool, error) {
 		return a.ID != md.ID, nil
 	})
 	plan := f.plan(t, req)
@@ -1048,7 +1048,7 @@ func TestPlanAttachmentCopy_AuthorizerErrorIsFatal(t *testing.T) {
 	f := newPlanFixture(t)
 	a := f.attach(t, f.wsA, "shot.png", 10)
 
-	req := withAuthorizer(f.req(imageRef(a.ID), nil), func(models.Attachment) (bool, error) {
+	req := withAuthorizer(f.req(imageRef(a.ID), nil), func(Queryer, models.Attachment) (bool, error) {
 		return false, fmt.Errorf("membership lookup exploded")
 	})
 	if _, err := f.s.PlanAttachmentCopy(req); err == nil {
@@ -1066,7 +1066,7 @@ func TestPlanAttachmentCopy_AuthorizerSeesEveryClonedRow(t *testing.T) {
 	other := f.attach(t, f.wsA, "spec.pdf", 50)
 
 	seen := map[string]bool{}
-	req := withAuthorizer(f.req(imageRef(sm.ID)+fileRef(other.ID), nil), func(a models.Attachment) (bool, error) {
+	req := withAuthorizer(f.req(imageRef(sm.ID)+fileRef(other.ID), nil), func(_ Queryer, a models.Attachment) (bool, error) {
 		seen[a.ID] = true
 		return true, nil
 	})
@@ -1089,4 +1089,4 @@ func withAuthorizer(req AttachmentCopyRequest, auth AttachmentAuthorizer) Attach
 	return req
 }
 
-func denyAll(models.Attachment) (bool, error) { return false, nil }
+func denyAll(Queryer, models.Attachment) (bool, error) { return false, nil }

--- a/internal/store/backlinks_visibility.go
+++ b/internal/store/backlinks_visibility.go
@@ -57,7 +57,14 @@ package store
 // surfaces, "user not found" returns an empty result rather than
 // erroring so the cross-ws traversal can keep going).
 func (s *Store) ResolveBacklinksVisibility(userID, workspaceID string, includeDeletedItems, authIsBearer bool) (fullCollIDs, grantedItemIDs []string, err error) {
-	user, err := s.GetUser(userID)
+	return s.ResolveBacklinksVisibilityQ(s.db, userID, workspaceID, includeDeletedItems, authIsBearer)
+}
+
+// ResolveBacklinksVisibilityQ is ResolveBacklinksVisibility parameterized
+// over its executor (see Queryer). The cross-workspace copy's attachment
+// authorizer runs it on the copy transaction's connection.
+func (s *Store) ResolveBacklinksVisibilityQ(q Queryer, userID, workspaceID string, includeDeletedItems, authIsBearer bool) (fullCollIDs, grantedItemIDs []string, err error) {
+	user, err := s.GetUserQ(q, userID)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -79,7 +86,7 @@ func (s *Store) ResolveBacklinksVisibility(userID, workspaceID string, includeDe
 	// Member lookup determines whether we treat this as a guest (no
 	// member row but has grants) or a member (with full or specific
 	// access).
-	member, err := s.GetWorkspaceMember(workspaceID, userID)
+	member, err := s.GetWorkspaceMemberQ(q, workspaceID, userID)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -95,9 +102,9 @@ func (s *Store) ResolveBacklinksVisibility(userID, workspaceID string, includeDe
 	// member-specific collections below if applicable.
 	var grantCollIDs []string
 	if includeDeletedItems {
-		grantCollIDs, grantedItemIDs, err = s.GuestVisibleResourcesIncludeDeleted(workspaceID, userID)
+		grantCollIDs, grantedItemIDs, err = s.GuestVisibleResourcesIncludeDeletedQ(q, workspaceID, userID)
 	} else {
-		grantCollIDs, grantedItemIDs, err = s.GuestVisibleResources(workspaceID, userID)
+		grantCollIDs, grantedItemIDs, err = s.GuestVisibleResourcesQ(q, workspaceID, userID)
 	}
 	if err != nil {
 		return nil, nil, err
@@ -136,14 +143,14 @@ func (s *Store) ResolveBacklinksVisibility(userID, workspaceID string, includeDe
 	for _, id := range grantCollIDs {
 		fullCollSet[id] = true
 	}
-	memberColls, err := s.GetMemberCollectionAccess(workspaceID, userID)
+	memberColls, err := s.GetMemberCollectionAccessQ(q, workspaceID, userID)
 	if err != nil {
 		return nil, nil, err
 	}
 	for _, id := range memberColls {
 		fullCollSet[id] = true
 	}
-	sysColls, err := s.ListSystemCollectionIDs(workspaceID)
+	sysColls, err := s.ListSystemCollectionIDsQ(q, workspaceID)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/store/grants.go
+++ b/internal/store/grants.go
@@ -390,10 +390,16 @@ func (s *Store) UserHasGrantsInWorkspace(workspaceID, userID string) (bool, erro
 // grants) can see. Includes collections with direct collection_grants and
 // collections that contain items the user has item_grants on.
 func (s *Store) GuestVisibleCollectionIDs(workspaceID, userID string) ([]string, error) {
+	return s.GuestVisibleCollectionIDsQ(s.db, workspaceID, userID)
+}
+
+// GuestVisibleCollectionIDsQ is GuestVisibleCollectionIDs parameterized over
+// its executor (see Queryer).
+func (s *Store) GuestVisibleCollectionIDsQ(q Queryer, workspaceID, userID string) ([]string, error) {
 	ids := make(map[string]bool)
 
 	// Collections with direct grants (excluding soft-deleted collections)
-	rows, err := s.db.Query(s.q(`
+	rows, err := q.Query(s.q(`
 		SELECT DISTINCT cg.collection_id FROM collection_grants cg
 		JOIN collections c ON c.id = cg.collection_id
 		WHERE cg.workspace_id = ? AND cg.user_id = ? AND c.deleted_at IS NULL
@@ -411,7 +417,7 @@ func (s *Store) GuestVisibleCollectionIDs(workspaceID, userID string) ([]string,
 	}
 
 	// Collections containing items with direct grants (excluding soft-deleted)
-	itemRows, err := s.db.Query(s.q(`
+	itemRows, err := q.Query(s.q(`
 		SELECT DISTINCT i.collection_id
 		FROM item_grants ig
 		JOIN items i ON i.id = ig.item_id
@@ -451,10 +457,16 @@ func (s *Store) GuestVisibleCollectionIDs(workspaceID, userID string) ([]string,
 // in/out depending on whether the endpoint needs live-state or
 // tombstone-bearing visibility.
 func (s *Store) GuestVisibleResourcesIncludeDeleted(workspaceID, userID string) (fullCollectionIDs []string, grantedItemIDs []string, err error) {
+	return s.GuestVisibleResourcesIncludeDeletedQ(s.db, workspaceID, userID)
+}
+
+// GuestVisibleResourcesIncludeDeletedQ is GuestVisibleResourcesIncludeDeleted
+// parameterized over its executor (see Queryer).
+func (s *Store) GuestVisibleResourcesIncludeDeletedQ(q Queryer, workspaceID, userID string) (fullCollectionIDs []string, grantedItemIDs []string, err error) {
 	// Collections with direct grants — include soft-deleted
 	// collections so the client can flush their items from its
 	// local index via the items query below.
-	rows, err := s.db.Query(s.q(`
+	rows, err := q.Query(s.q(`
 		SELECT DISTINCT cg.collection_id FROM collection_grants cg
 		WHERE cg.workspace_id = ? AND cg.user_id = ?
 	`), workspaceID, userID)
@@ -478,7 +490,7 @@ func (s *Store) GuestVisibleResourcesIncludeDeleted(workspaceID, userID string) 
 	// is the source of truth for visibility; the item's
 	// deleted_at is what the delta endpoint USES to mark
 	// `deleted:true` on the wire.
-	itemRows, err := s.db.Query(s.q(`
+	itemRows, err := q.Query(s.q(`
 		SELECT DISTINCT ig.item_id
 		FROM item_grants ig
 		WHERE ig.workspace_id = ? AND ig.user_id = ?
@@ -506,8 +518,14 @@ func (s *Store) GuestVisibleResourcesIncludeDeleted(workspaceID, userID string) 
 // - grantedItemIDs: specific item IDs the user has item-level grants on
 // This allows callers to distinguish between full-collection access and item-only access.
 func (s *Store) GuestVisibleResources(workspaceID, userID string) (fullCollectionIDs []string, grantedItemIDs []string, err error) {
+	return s.GuestVisibleResourcesQ(s.db, workspaceID, userID)
+}
+
+// GuestVisibleResourcesQ is GuestVisibleResources parameterized over its
+// executor (see Queryer).
+func (s *Store) GuestVisibleResourcesQ(q Queryer, workspaceID, userID string) (fullCollectionIDs []string, grantedItemIDs []string, err error) {
 	// Collections with direct grants (full collection access, excluding soft-deleted)
-	rows, err := s.db.Query(s.q(`
+	rows, err := q.Query(s.q(`
 		SELECT DISTINCT cg.collection_id FROM collection_grants cg
 		JOIN collections c ON c.id = cg.collection_id
 		WHERE cg.workspace_id = ? AND cg.user_id = ? AND c.deleted_at IS NULL
@@ -528,7 +546,7 @@ func (s *Store) GuestVisibleResources(workspaceID, userID string) (fullCollectio
 	}
 
 	// Individual item IDs with direct grants (excluding soft-deleted items/collections)
-	itemRows, err := s.db.Query(s.q(`
+	itemRows, err := q.Query(s.q(`
 		SELECT DISTINCT ig.item_id
 		FROM item_grants ig
 		JOIN items i ON i.id = ig.item_id

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -556,47 +556,19 @@ func isUniqueViolation(err error) bool {
 }
 
 func (s *Store) GetItem(id string) (*models.Item, error) {
-	var item models.Item
-	var createdAt, updatedAt string
-	var deletedAt *string
-	var pinned bool
+	return s.GetItemQ(s.db, id)
+}
 
-	err := s.db.QueryRow(s.q(`
-		SELECT i.id, i.workspace_id, i.collection_id, i.title, i.slug, i.content, i.fields, i.tags,
-		       i.pinned, i.sort_order, i.parent_id, i.assigned_user_id, i.agent_role_id, i.role_sort_order,
-		       i.created_by, i.last_modified_by, i.source,
-		       i.item_number, i.seq, i.created_at, i.updated_at, i.deleted_at,
-		       c.slug, c.name, c.icon, c.prefix,
-		       COALESCE(au.name, ''), COALESCE(au.email, ''),
-		       COALESCE(ar.name, ''), COALESCE(ar.slug, ''), COALESCE(ar.icon, '')
-		FROM items i
-		JOIN collections c ON c.id = i.collection_id
-		LEFT JOIN users au ON au.id = i.assigned_user_id
-		LEFT JOIN agent_roles ar ON ar.id = i.agent_role_id
-		WHERE i.id = ? AND i.deleted_at IS NULL
-	`), id).Scan(
-		&item.ID, &item.WorkspaceID, &item.CollectionID, &item.Title, &item.Slug,
-		&item.Content, &item.Fields, &item.Tags,
-		&pinned, &item.SortOrder, &item.ParentID, &item.AssignedUserID, &item.AgentRoleID, &item.RoleSortOrder,
-		&item.CreatedBy, &item.LastModifiedBy, &item.Source,
-		&item.ItemNumber, &item.Seq, &createdAt, &updatedAt, &deletedAt,
-		&item.CollectionSlug, &item.CollectionName, &item.CollectionIcon, &item.CollectionPrefix,
-		&item.AssignedUserName, &item.AssignedUserEmail,
-		&item.AgentRoleName, &item.AgentRoleSlug, &item.AgentRoleIcon,
-	)
-	if err == sql.ErrNoRows {
-		return nil, nil
-	}
+// GetItemQ is GetItem parameterized over its executor, so the same read can
+// run against the pool or on an in-flight transaction's connection (see
+// Queryer). getItemTx and the cross-workspace copy's authorization callback
+// are the transaction-side callers.
+func (s *Store) GetItemQ(q Queryer, id string) (*models.Item, error) {
+	item, err := s.getItemScanQ(q, id, false)
 	if err != nil {
 		return nil, fmt.Errorf("get item: %w", err)
 	}
-
-	item.Pinned = pinned
-	item.CreatedAt = parseTime(createdAt)
-	item.UpdatedAt = parseTime(updatedAt)
-	item.DeletedAt = parseTimePtr(deletedAt)
-	hydrateItemComputedMetadata(&item)
-	return &item, nil
+	return item, nil
 }
 
 // getItemTx is the in-transaction variant of GetItem. Used by
@@ -606,12 +578,23 @@ func (s *Store) GetItem(id string) (*models.Item, error) {
 // (Codex round-3 P2). Soft-deleted items are excluded, matching
 // GetItem's contract.
 func (s *Store) getItemTx(tx *sql.Tx, id string) (*models.Item, error) {
+	item, err := s.getItemScanQ(tx, id, false)
+	if err != nil {
+		return nil, fmt.Errorf("get item (tx): %w", err)
+	}
+	return item, nil
+}
+
+// getItemScanQ is the one item-row scan behind GetItem, getItemTx and
+// GetItemIncludeDeleted — identical SELECT and hydration, differing only in
+// executor and in whether soft-deleted rows are visible. (nil, nil) on no row.
+func (s *Store) getItemScanQ(q Queryer, id string, includeDeleted bool) (*models.Item, error) {
 	var item models.Item
 	var createdAt, updatedAt string
 	var deletedAt *string
 	var pinned bool
 
-	err := tx.QueryRow(s.q(`
+	query := `
 		SELECT i.id, i.workspace_id, i.collection_id, i.title, i.slug, i.content, i.fields, i.tags,
 		       i.pinned, i.sort_order, i.parent_id, i.assigned_user_id, i.agent_role_id, i.role_sort_order,
 		       i.created_by, i.last_modified_by, i.source,
@@ -623,8 +606,11 @@ func (s *Store) getItemTx(tx *sql.Tx, id string) (*models.Item, error) {
 		JOIN collections c ON c.id = i.collection_id
 		LEFT JOIN users au ON au.id = i.assigned_user_id
 		LEFT JOIN agent_roles ar ON ar.id = i.agent_role_id
-		WHERE i.id = ? AND i.deleted_at IS NULL
-	`), id).Scan(
+		WHERE i.id = ?`
+	if !includeDeleted {
+		query += ` AND i.deleted_at IS NULL`
+	}
+	err := q.QueryRow(s.q(query), id).Scan(
 		&item.ID, &item.WorkspaceID, &item.CollectionID, &item.Title, &item.Slug,
 		&item.Content, &item.Fields, &item.Tags,
 		&pinned, &item.SortOrder, &item.ParentID, &item.AssignedUserID, &item.AgentRoleID, &item.RoleSortOrder,
@@ -638,7 +624,7 @@ func (s *Store) getItemTx(tx *sql.Tx, id string) (*models.Item, error) {
 		return nil, nil
 	}
 	if err != nil {
-		return nil, fmt.Errorf("get item (tx): %w", err)
+		return nil, err
 	}
 
 	item.Pinned = pinned
@@ -870,47 +856,17 @@ func parseItemNumber(s string) (int, bool) {
 // blob). The visibility check still keys off the (still-set)
 // collection_id, so soft-deleting an item doesn't escalate access.
 func (s *Store) GetItemIncludeDeleted(id string) (*models.Item, error) {
-	var item models.Item
-	var createdAt, updatedAt string
-	var deletedAt *string
-	var pinned bool
+	return s.GetItemIncludeDeletedQ(s.db, id)
+}
 
-	err := s.db.QueryRow(s.q(`
-		SELECT i.id, i.workspace_id, i.collection_id, i.title, i.slug, i.content, i.fields, i.tags,
-		       i.pinned, i.sort_order, i.parent_id, i.assigned_user_id, i.agent_role_id, i.role_sort_order,
-		       i.created_by, i.last_modified_by, i.source,
-		       i.item_number, i.seq, i.created_at, i.updated_at, i.deleted_at,
-		       c.slug, c.name, c.icon, c.prefix,
-		       COALESCE(au.name, ''), COALESCE(au.email, ''),
-		       COALESCE(ar.name, ''), COALESCE(ar.slug, ''), COALESCE(ar.icon, '')
-		FROM items i
-		JOIN collections c ON c.id = i.collection_id
-		LEFT JOIN users au ON au.id = i.assigned_user_id
-		LEFT JOIN agent_roles ar ON ar.id = i.agent_role_id
-		WHERE i.id = ?
-	`), id).Scan(
-		&item.ID, &item.WorkspaceID, &item.CollectionID, &item.Title, &item.Slug,
-		&item.Content, &item.Fields, &item.Tags,
-		&pinned, &item.SortOrder, &item.ParentID, &item.AssignedUserID, &item.AgentRoleID, &item.RoleSortOrder,
-		&item.CreatedBy, &item.LastModifiedBy, &item.Source,
-		&item.ItemNumber, &item.Seq, &createdAt, &updatedAt, &deletedAt,
-		&item.CollectionSlug, &item.CollectionName, &item.CollectionIcon, &item.CollectionPrefix,
-		&item.AssignedUserName, &item.AssignedUserEmail,
-		&item.AgentRoleName, &item.AgentRoleSlug, &item.AgentRoleIcon,
-	)
-	if err == sql.ErrNoRows {
-		return nil, nil
-	}
+// GetItemIncludeDeletedQ is GetItemIncludeDeleted parameterized over its
+// executor (see Queryer).
+func (s *Store) GetItemIncludeDeletedQ(q Queryer, id string) (*models.Item, error) {
+	item, err := s.getItemScanQ(q, id, true)
 	if err != nil {
 		return nil, fmt.Errorf("get item (include deleted): %w", err)
 	}
-
-	item.Pinned = pinned
-	item.CreatedAt = parseTime(createdAt)
-	item.UpdatedAt = parseTime(updatedAt)
-	item.DeletedAt = parseTimePtr(deletedAt)
-	hydrateItemComputedMetadata(&item)
-	return &item, nil
+	return item, nil
 }
 
 // GetItemsByIDsIncludeDeleted fetches items (soft-deleted included) for the

--- a/internal/store/items_cross_workspace_copy.go
+++ b/internal/store/items_cross_workspace_copy.go
@@ -636,22 +636,30 @@ func (s *Store) copyItemAcrossWorkspacesTx(req CrossWorkspaceCopyRequest, source
 	// it; caching one across the lock would let a soft-delete, an orphan-GC
 	// reclaim or a revoked membership slip between planning and inserting.
 	//
-	// The planner reads through s.db rather than this tx, and holds no lock on
-	// the attachment rows — its documented, deliberate shape (TASK-2354), so
-	// that the dry-run and the copy share ONE implementation and cannot drift.
-	// The residual window that leaves is bounded and harmless, and it is worth
-	// writing down why rather than re-litigating it:
+	// The planner reads ON THIS TRANSACTION, not through the pool (BUG-2409).
+	// This transaction holds both workspace advisory locks, and a pool read
+	// here can wait for a free connection while every pooled connection is
+	// itself occupied by another copy waiting on these locks — starvation
+	// presenting as a hang. Running the reads (the planner's passes AND the
+	// Authorize callback's, which receives the same executor) on the
+	// transaction's own connection removes the pool from the critical
+	// section entirely. The dry-run still plans through the pool via
+	// PlanAttachmentCopy — one implementation, two executors, so the shared
+	// no-drift shape TASK-2354 established survives.
+	//
+	// What tx-routing deliberately does NOT change is the attachment-row
+	// staleness window, which remains bounded and harmless (TASK-2354):
 	//
 	//   - On SQLite there is no window at all. BEGIN IMMEDIATE means this
 	//     transaction holds the database's write lock, so a concurrent
 	//     SoftDeleteAttachment / HardDeleteAttachment simply blocks until the
 	//     copy commits.
 	//   - On Postgres a concurrent soft-delete CAN land between planning and
-	//     inserting. Routing the planner's reads through this tx would not
-	//     change that: READ COMMITTED takes a fresh snapshot per statement, so
-	//     the same committed delete would be just as visible. Only making every
-	//     attachment writer take the workspace advisory lock would close it,
-	//     which means putting a lock on the upload hot path for this.
+	//     inserting, tx or no tx: READ COMMITTED takes a fresh snapshot per
+	//     statement, so the same committed delete is just as visible either
+	//     way. Only making every attachment writer take the workspace
+	//     advisory lock would close it, which means putting a lock on the
+	//     upload hot path for this.
 	//   - And the outcome of losing that race is benign. Soft-delete never
 	//     removes bytes, and the clone this transaction commits carries the
 	//     same content_hash — so it is itself a protecting row for
@@ -665,7 +673,7 @@ func (s *Store) copyItemAcrossWorkspacesTx(req CrossWorkspaceCopyRequest, source
 	// NULL-item_id row that the copied body then references is a permanent,
 	// un-reclaimable orphan (see AttachmentCopyRequest.DryRun).
 	targetItemID := newID()
-	plan, err := s.PlanAttachmentCopy(AttachmentCopyRequest{
+	plan, err := s.planAttachmentCopyQ(tx, AttachmentCopyRequest{
 		SourceWorkspaceID: sourceWorkspaceID,
 		TargetWorkspaceID: req.TargetWorkspaceID,
 		TargetItemID:      targetItemID,

--- a/internal/store/items_cross_workspace_copy_test.go
+++ b/internal/store/items_cross_workspace_copy_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/PerpetualSoftware/pad/internal/models"
 )
@@ -125,6 +126,7 @@ func attachmentsIn(t *testing.T, s *Store, workspaceID string) []models.Attachme
 	t.Helper()
 	var out []models.Attachment
 	if err := s.scanAttachmentsInto(
+		s.db,
 		`SELECT `+attachmentColumns+` FROM attachments WHERE workspace_id = ? ORDER BY created_at, id`,
 		[]any{workspaceID},
 		func(a models.Attachment) { out = append(out, a) },
@@ -1425,5 +1427,71 @@ func TestCopyRollbackErrorClassification(t *testing.T) {
 				t.Error("an error classified as BOTH deadlock and lock timeout")
 			}
 		})
+	}
+}
+
+// TestCopyItemAcrossWorkspaces_NoPoolIOUnderLocks pins BUG-2409: while the
+// copy transaction holds both workspace advisory locks, every read — the
+// attachment planner's resolution passes AND the caller's Authorize
+// callback — must run on the transaction's own connection, never through
+// the connection pool. A pool read there can wait for a free connection
+// while every pooled connection is occupied by other copies waiting on the
+// same locks: starvation presenting as a hang.
+//
+// The instrument makes the hazard deterministic instead of probabilistic:
+// with MaxOpenConns(1), the transaction owns the ONLY connection, so any
+// pool read inside the critical section blocks forever rather than only
+// under concurrent load. The pre-fix build fails this test by timeout
+// (verified — the planner read through s.db); the fixed build completes in
+// milliseconds. The Authorize callback below performs a real read through
+// the Queryer it is handed, mirroring the server's authorizer
+// (GetItemQ-backed parent resolution), so the callback's executor is
+// pinned too — not just the planner's own passes.
+func TestCopyItemAcrossWorkspaces_NoPoolIOUnderLocks(t *testing.T) {
+	f := newCopyFixture(t)
+	orig := f.attachIn(t, f.wsA.ID, "shot.png", 100)
+	f.variantOf(t, f.wsA.ID, orig, "thumb-md", 10)
+	src := createTestItem(t, f.s, f.wsA.ID, f.colA.ID, "Locked reads", "body\n\n"+imageRef(orig.ID))
+
+	req := f.req()
+	req.SourceItemID = src.ID
+	authorizerReads := 0
+	req.AttachmentAuthorizer = func(q Queryer, att models.Attachment) (bool, error) {
+		// A real read through the planner's executor. On the fixed build q
+		// is the copy transaction; on a regressed build it would be the
+		// pool and this line deadlocks under MaxOpenConns(1).
+		if _, err := f.s.GetItemQ(q, src.ID); err != nil {
+			return false, err
+		}
+		authorizerReads++
+		return true, nil
+	}
+
+	// From here on the pool has exactly one connection: the transaction's.
+	f.s.db.SetMaxOpenConns(1)
+
+	type outcome struct {
+		res *CrossWorkspaceCopyResult
+		err error
+	}
+	done := make(chan outcome, 1)
+	go func() {
+		res, err := f.s.CopyItemAcrossWorkspaces(req)
+		done <- outcome{res, err}
+	}()
+
+	select {
+	case out := <-done:
+		if out.err != nil {
+			t.Fatalf("CopyItemAcrossWorkspaces: %v", out.err)
+		}
+		if out.res.AttachmentsCopied != 2 {
+			t.Fatalf("AttachmentsCopied = %d, want 2 (original + variant)", out.res.AttachmentsCopied)
+		}
+		if authorizerReads == 0 {
+			t.Fatal("Authorize callback never ran — the executor pin was not exercised")
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("copy deadlocked with MaxOpenConns(1): pool I/O while holding the workspace advisory locks (BUG-2409)")
 	}
 }

--- a/internal/store/items_cross_workspace_copy_test.go
+++ b/internal/store/items_cross_workspace_copy_test.go
@@ -1448,13 +1448,41 @@ func TestCopyRollbackErrorClassification(t *testing.T) {
 // (GetItemQ-backed parent resolution), so the callback's executor is
 // pinned too — not just the planner's own passes.
 func TestCopyItemAcrossWorkspaces_NoPoolIOUnderLocks(t *testing.T) {
-	f := newCopyFixture(t)
+	// Quota-shaped fixture rather than the plain one, deliberately: with a
+	// FREE-plan owner and EnforceItemLimit set, the in-transaction quota
+	// check runs its full read chain (workspace owner → user → platform
+	// plan-limit setting → count), which was the second lock-held pool-read
+	// leg Codex found after the planner/authorizer leg — the plain fixture
+	// never armed it (round 2). No plan override, so resolveLimit reaches
+	// the platform-settings read instead of returning early.
+	s := testStore(t)
+	owner := createTestUser(t, s, "no-pool-io-owner@example.com", "Owner", "s3cret")
+	if err := s.SetUserPlan(owner.ID, "free", ""); err != nil {
+		t.Fatalf("SetUserPlan: %v", err)
+	}
+	wsA, err := s.CreateWorkspace(models.WorkspaceCreate{Name: "Locked Source", OwnerID: owner.ID})
+	if err != nil {
+		t.Fatalf("CreateWorkspace(A): %v", err)
+	}
+	wsB, err := s.CreateWorkspace(models.WorkspaceCreate{Name: "Locked Dest", OwnerID: owner.ID})
+	if err != nil {
+		t.Fatalf("CreateWorkspace(B): %v", err)
+	}
+	f := copyFixture{
+		s:     s,
+		wsA:   wsA,
+		wsB:   wsB,
+		colA:  createTestCollection(t, s, wsA.ID, "Tasks A"),
+		colB:  createTestCollection(t, s, wsB.ID, "Tasks B"),
+		actor: owner.ID,
+	}
 	orig := f.attachIn(t, f.wsA.ID, "shot.png", 100)
 	f.variantOf(t, f.wsA.ID, orig, "thumb-md", 10)
 	src := createTestItem(t, f.s, f.wsA.ID, f.colA.ID, "Locked reads", "body\n\n"+imageRef(orig.ID))
 
 	req := f.req()
 	req.SourceItemID = src.ID
+	req.EnforceItemLimit = true
 	authorizerReads := 0
 	req.AttachmentAuthorizer = func(q Queryer, att models.Attachment) (bool, error) {
 		// A real read through the planner's executor. On the fixed build q

--- a/internal/store/limits.go
+++ b/internal/store/limits.go
@@ -65,36 +65,41 @@ func (s *Store) CheckLimit(workspaceID, feature string) (*LimitResult, error) {
 	return s.checkLimitOn(s.db, workspaceID, feature)
 }
 
-// CheckLimitTx is CheckLimit with the usage count read through the caller's
+// CheckLimitTx is CheckLimit with every read routed through the caller's
 // transaction instead of an independent connection (PLAN-2357 / DR-16).
 //
-// The distinction is the whole point: a limit check that counts on the pool
-// cannot see the caller's own uncommitted inserts, and — more importantly —
-// it is not serialized with a concurrent transaction holding the workspace's
-// advisory lock. Two copies into a workspace one item below its cap would then
-// both read "under the limit" and both commit. Counting inside the transaction,
-// after the destination workspace lock is held, makes the second copy's COUNT
-// wait for the first to commit and observe it.
+// The COUNT is where the routing is a correctness matter: a limit check that
+// counts on the pool cannot see the caller's own uncommitted inserts, and —
+// more importantly — it is not serialized with a concurrent transaction
+// holding the workspace's advisory lock. Two copies into a workspace one item
+// below its cap would then both read "under the limit" and both commit.
+// Counting inside the transaction, after the destination workspace lock is
+// held, makes the second copy's COUNT wait for the first to commit and
+// observe it.
 //
-// Only the COUNT moves onto the tx. The workspace-owner and user lookups stay
-// on the pool: neither is written by the copy path, and routing them through
-// the tx would only widen what a failed probe poisons.
+// The workspace-owner, user and plan-limit lookups originally stayed on the
+// pool (they are not written by the copy path), but that put pool waits
+// inside a critical section that holds both workspace advisory locks — the
+// BUG-2409 starvation shape, same as the attachment planner's reads. They now
+// run on the transaction too. Visibility is unchanged (READ COMMITTED takes a
+// fresh snapshot per statement either way), and every error here aborts the
+// copy regardless of which connection the failed read used.
 func (s *Store) CheckLimitTx(tx *sql.Tx, workspaceID, feature string) (*LimitResult, error) {
 	return s.checkLimitOn(tx, workspaceID, feature)
 }
 
 // checkLimitOn is the shared body of CheckLimit / CheckLimitTx, parameterized
-// over the surface the feature COUNT runs on.
-func (s *Store) checkLimitOn(counter rowQueryer, workspaceID, feature string) (*LimitResult, error) {
+// over the executor EVERY read runs on (BUG-2409 — see CheckLimitTx).
+func (s *Store) checkLimitOn(q Queryer, workspaceID, feature string) (*LimitResult, error) {
 	// 1. Look up workspace → owner_id
 	var ownerID string
-	err := s.db.QueryRow(s.q(`SELECT owner_id FROM workspaces WHERE id = ?`), workspaceID).Scan(&ownerID)
+	err := q.QueryRow(s.q(`SELECT owner_id FROM workspaces WHERE id = ?`), workspaceID).Scan(&ownerID)
 	if err != nil {
 		return nil, fmt.Errorf("check limit: get workspace owner: %w", err)
 	}
 
 	// 2. Look up user → plan, plan_overrides
-	user, err := s.GetUser(ownerID)
+	user, err := s.GetUserQ(q, ownerID)
 	if err != nil {
 		return nil, fmt.Errorf("check limit: get user: %w", err)
 	}
@@ -112,7 +117,7 @@ func (s *Store) checkLimitOn(counter rowQueryer, workspaceID, feature string) (*
 	}
 
 	// 3. Resolve the limit for this feature
-	limit := s.resolveLimit(plan, feature, user.PlanOverrides)
+	limit := s.resolveLimitQ(q, plan, feature, user.PlanOverrides)
 
 	// -1 = unlimited
 	if limit < 0 {
@@ -120,7 +125,7 @@ func (s *Store) checkLimitOn(counter rowQueryer, workspaceID, feature string) (*
 	}
 
 	// 4. Get current count for the feature
-	current, err := s.featureCountOn(counter, workspaceID, ownerID, feature)
+	current, err := s.featureCountOn(q, workspaceID, ownerID, feature)
 	if err != nil {
 		return nil, fmt.Errorf("check limit: count %s: %w", feature, err)
 	}
@@ -175,6 +180,13 @@ func (s *Store) CheckUserLimit(userID, feature string) (*LimitResult, error) {
 // resolveLimit resolves the limit for a feature using the three-tier resolution:
 // user overrides → DB-stored plan defaults → hardcoded fallback.
 func (s *Store) resolveLimit(plan, feature, overridesJSON string) int {
+	return s.resolveLimitQ(s.db, plan, feature, overridesJSON)
+}
+
+// resolveLimitQ is resolveLimit parameterized over its executor (see
+// Queryer) — the plan-limit platform setting is a read, and CheckLimitTx
+// must not touch the pool (BUG-2409).
+func (s *Store) resolveLimitQ(q Queryer, plan, feature, overridesJSON string) int {
 	// 1. Check per-user overrides
 	if overridesJSON != "" {
 		var overrides map[string]int
@@ -187,7 +199,7 @@ func (s *Store) resolveLimit(plan, feature, overridesJSON string) int {
 
 	// 2. Check DB-stored plan defaults
 	settingKey := "plan_limits_" + plan + "_" + feature
-	if val, err := s.GetPlatformSetting(settingKey); err == nil && val != "" {
+	if val, err := s.GetPlatformSettingQ(q, settingKey); err == nil && val != "" {
 		if v, err := strconv.Atoi(val); err == nil {
 			return v
 		}

--- a/internal/store/platform_settings.go
+++ b/internal/store/platform_settings.go
@@ -4,8 +4,14 @@ import "database/sql"
 
 // GetPlatformSetting returns a single platform setting value, or empty string if not set.
 func (s *Store) GetPlatformSetting(key string) (string, error) {
+	return s.GetPlatformSettingQ(s.db, key)
+}
+
+// GetPlatformSettingQ is GetPlatformSetting parameterized over its executor
+// (see Queryer).
+func (s *Store) GetPlatformSettingQ(q Queryer, key string) (string, error) {
 	var value string
-	err := s.db.QueryRow(s.q("SELECT value FROM platform_settings WHERE key = ?"), key).Scan(&value)
+	err := q.QueryRow(s.q("SELECT value FROM platform_settings WHERE key = ?"), key).Scan(&value)
 	if err == sql.ErrNoRows {
 		return "", nil
 	}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -469,6 +469,31 @@ type sqlExecer interface {
 	Exec(query string, args ...any) (sql.Result, error)
 }
 
+// Queryer is the read-only subset of *sql.DB / *sql.Tx a store read needs.
+// It exists so a read can run either against the pool or on an in-flight
+// transaction's own connection. The distinction matters most inside
+// transactions that hold locks: a read routed through the POOL while the
+// transaction's connection is held can wait on a free connection, and if
+// every pooled connection is itself occupied by a transaction waiting on
+// those locks, the system deadlocks by starvation (BUG-2409 — the
+// cross-workspace copy held both workspace advisory locks while the
+// attachment planner and its authorization callback read through the pool).
+// A read routed through the transaction's Queryer cannot wait on the pool,
+// because the transaction already owns its connection.
+//
+// Exported because the callback boundary crosses packages: the copy
+// planner hands ITS executor to the server-side AttachmentAuthorizer, so
+// the server's authorization reads run wherever the planner runs.
+type Queryer interface {
+	Query(query string, args ...any) (*sql.Rows, error)
+	QueryRow(query string, args ...any) *sql.Row
+}
+
+// Q returns the store's pool as a Queryer — the executor for reads that run
+// outside any transaction. Server code uses it to call the *Q read variants
+// through the same signature the in-transaction path uses.
+func (s *Store) Q() Queryer { return s.db }
+
 // execMulti executes multiple SQL statements by iteratively using
 // database/sql's Exec which processes one statement at a time,
 // then advancing past it using the driver's awareness of statement boundaries.

--- a/internal/store/users.go
+++ b/internal/store/users.go
@@ -119,7 +119,12 @@ func (s *Store) CreateUser(input models.UserCreate) (*models.User, error) {
 
 // GetUser retrieves a user by ID.
 func (s *Store) GetUser(id string) (*models.User, error) {
-	u, err := scanUser(s.db.QueryRow(s.q(`SELECT `+userColumns+` FROM users WHERE id = ?`), id))
+	return s.GetUserQ(s.db, id)
+}
+
+// GetUserQ is GetUser parameterized over its executor (see Queryer).
+func (s *Store) GetUserQ(q Queryer, id string) (*models.User, error) {
+	u, err := scanUser(q.QueryRow(s.q(`SELECT `+userColumns+` FROM users WHERE id = ?`), id))
 	if err != nil {
 		return nil, fmt.Errorf("get user: %w", err)
 	}

--- a/internal/store/workspace_members.go
+++ b/internal/store/workspace_members.go
@@ -80,10 +80,16 @@ func (s *Store) RemoveWorkspaceMemberAndRevokeGrants(workspaceID, userID string)
 
 // GetWorkspaceMember retrieves a single membership record.
 func (s *Store) GetWorkspaceMember(workspaceID, userID string) (*models.WorkspaceMember, error) {
+	return s.GetWorkspaceMemberQ(s.db, workspaceID, userID)
+}
+
+// GetWorkspaceMemberQ is GetWorkspaceMember parameterized over its executor
+// (see Queryer).
+func (s *Store) GetWorkspaceMemberQ(q Queryer, workspaceID, userID string) (*models.WorkspaceMember, error) {
 	var m models.WorkspaceMember
 	var createdAt string
 
-	err := s.db.QueryRow(s.q(`
+	err := q.QueryRow(s.q(`
 		SELECT workspace_id, user_id, role, collection_access, created_at
 		FROM workspace_members
 		WHERE workspace_id = ? AND user_id = ?
@@ -137,13 +143,19 @@ func (s *Store) ListWorkspaceMembers(workspaceID string) ([]models.WorkspaceMemb
 // Returns nil if the member has "all" access (meaning no filtering needed).
 // System collections (conventions, playbooks) are always included for members.
 func (s *Store) VisibleCollectionIDs(workspaceID, userID string) ([]string, error) {
-	member, err := s.GetWorkspaceMember(workspaceID, userID)
+	return s.VisibleCollectionIDsQ(s.db, workspaceID, userID)
+}
+
+// VisibleCollectionIDsQ is VisibleCollectionIDs parameterized over its
+// executor (see Queryer).
+func (s *Store) VisibleCollectionIDsQ(q Queryer, workspaceID, userID string) ([]string, error) {
+	member, err := s.GetWorkspaceMemberQ(q, workspaceID, userID)
 	if err != nil {
 		return nil, err
 	}
 	if member == nil {
 		// Not a member — check for guest access via grants
-		return s.GuestVisibleCollectionIDs(workspaceID, userID)
+		return s.GuestVisibleCollectionIDsQ(q, workspaceID, userID)
 	}
 
 	// "all" access — return nil to indicate no filtering needed
@@ -152,7 +164,7 @@ func (s *Store) VisibleCollectionIDs(workspaceID, userID string) ([]string, erro
 	}
 
 	// "specific" access — get the granted collection IDs + system collections
-	rows, err := s.db.Query(s.q(`
+	rows, err := q.Query(s.q(`
 		SELECT collection_id FROM member_collection_access
 		WHERE workspace_id = ? AND user_id = ?
 	`), workspaceID, userID)
@@ -174,7 +186,7 @@ func (s *Store) VisibleCollectionIDs(workspaceID, userID string) ([]string, erro
 	}
 
 	// Always include system collections for members
-	sysRows, err := s.db.Query(s.q(`
+	sysRows, err := q.Query(s.q(`
 		SELECT id FROM collections
 		WHERE workspace_id = ? AND is_system = ? AND deleted_at IS NULL
 	`), workspaceID, s.dialect.BoolToInt(true))
@@ -197,7 +209,7 @@ func (s *Store) VisibleCollectionIDs(workspaceID, userID string) ([]string, erro
 	// Note: we only merge full collection grants here, NOT collections derived
 	// from item grants. Item grants should not promote to collection-wide
 	// visibility for members — the item-level filtering in handlers handles that.
-	collGrantRows, err := s.db.Query(s.q(`
+	collGrantRows, err := q.Query(s.q(`
 		SELECT DISTINCT collection_id FROM collection_grants
 		WHERE workspace_id = ? AND user_id = ?
 	`), workspaceID, userID)
@@ -219,7 +231,7 @@ func (s *Store) VisibleCollectionIDs(workspaceID, userID string) ([]string, erro
 	// Also include collections that contain items with item grants, so the
 	// collection appears in navigation. The actual item-level filtering is
 	// handled by the request handlers for members who also have item grants.
-	itemCollRows, err := s.db.Query(s.q(`
+	itemCollRows, err := q.Query(s.q(`
 		SELECT DISTINCT i.collection_id
 		FROM item_grants ig
 		JOIN items i ON i.id = ig.item_id
@@ -308,7 +320,13 @@ func (s *Store) SetMemberCollectionAccess(workspaceID, userID, mode string, coll
 // GetMemberCollectionAccess returns the collection IDs a member has been
 // explicitly granted access to (only meaningful when collection_access = "specific").
 func (s *Store) GetMemberCollectionAccess(workspaceID, userID string) ([]string, error) {
-	rows, err := s.db.Query(s.q(`
+	return s.GetMemberCollectionAccessQ(s.db, workspaceID, userID)
+}
+
+// GetMemberCollectionAccessQ is GetMemberCollectionAccess parameterized over
+// its executor (see Queryer).
+func (s *Store) GetMemberCollectionAccessQ(q Queryer, workspaceID, userID string) ([]string, error) {
+	rows, err := q.Query(s.q(`
 		SELECT collection_id FROM member_collection_access
 		WHERE workspace_id = ? AND user_id = ?
 	`), workspaceID, userID)
@@ -331,7 +349,13 @@ func (s *Store) GetMemberCollectionAccess(workspaceID, userID string) ([]string,
 // ListSystemCollectionIDs returns the IDs of system collections in a workspace.
 // System collections are always visible to members regardless of collection_access mode.
 func (s *Store) ListSystemCollectionIDs(workspaceID string) ([]string, error) {
-	rows, err := s.db.Query(s.q(`
+	return s.ListSystemCollectionIDsQ(s.db, workspaceID)
+}
+
+// ListSystemCollectionIDsQ is ListSystemCollectionIDs parameterized over its
+// executor (see Queryer).
+func (s *Store) ListSystemCollectionIDsQ(q Queryer, workspaceID string) ([]string, error) {
+	rows, err := q.Query(s.q(`
 		SELECT id FROM collections
 		WHERE workspace_id = ? AND is_system = ? AND deleted_at IS NULL
 	`), workspaceID, s.dialect.BoolToInt(true))


### PR DESCRIPTION
## Summary

The cross-workspace copy transaction holds advisory locks on BOTH workspaces, but the attachment planner (`PlanAttachmentCopy`) and the server's per-row attachment authorizer read through the connection pool. Under enough concurrent copies, every pooled connection can be occupied by a lock-waiter while the lock holder waits for a spare connection — pool starvation presenting as a hang (BUG-2409, found by the Codex review of TASK-2408).

Fix: a `store.Queryer` interface (satisfied by `*sql.DB` and `*sql.Tx`) threaded through the planner and the `AttachmentAuthorizer` callback. The mutating copy now plans and authorizes on its own transaction's connection; the preflight keeps planning through the pool — one implementation, two executors, preserving TASK-2354's dry-run/copy no-drift shape. Zero pool I/O remains inside the copy's critical section.

Mechanical `*Q` executor variants for the store reads the authorizer transitively needs (GetItem, GetUser, GetWorkspaceMember, VisibleCollectionIDs, GetMemberCollectionAccess, ListSystemCollectionIDs, GuestVisibleCollectionIDs, GuestVisibleResources(+IncludeDeleted), ResolveBacklinksVisibility), and Q-cores behind existing-signature server wrappers (checkItemVisible, guestResourceFilterCore, resolveAttachmentParentItem, attachmentCallerIsRestricted). **No decision logic changed anywhere** — executor threading only. A side dedupe: GetItem / getItemTx / GetItemIncludeDeleted's three duplicate scan bodies collapse into one `getItemScanQ`.

## Context

Fixes BUG-2409. The TASK-2354 comment block defending the planner's pool reads argued from staleness only (and itself conceded tx-routing changes no staleness semantics — READ COMMITTED takes per-statement snapshots; SQLite's BEGIN IMMEDIATE has no window); it has been rewritten to document the tx-bound shape while retaining the staleness rationale, which this PR deliberately does not change.

## Test plan

- [x] New `TestCopyItemAcrossWorkspaces_NoPoolIOUnderLocks` — with `MaxOpenConns(1)` the transaction owns the ONLY connection, so any pool read under the advisory locks deadlocks deterministically. **Negative control verified:** fails by 30s timeout on the pre-fix executor; passes in 0.16s fixed. The test's authorizer performs a real read through the handed Queryer, pinning the callback leg too.
- [x] `go test ./...` (SQLite) — green
- [x] `make test-pg` (Postgres, full suite) — green, exit 0
- [x] `make lint` — 0 issues
- [ ] Codex review loop → CLEAN

https://claude.ai/code/session_017jD6t1zjxGSq47SQpZfp1V