### PR TITLE
fix(server): rowless-blob GC sweep — reclaim blobs no attachments row references (BUG-2406)

### DIFF
--- a/internal/attachments/fs_store.go
+++ b/internal/attachments/fs_store.go
@@ -230,3 +230,58 @@ func (s *FSStore) Delete(_ context.Context, key string) error {
 	}
 	return nil
 }
+
+// ListBlobs enumerates every blob under the store's sharded tree,
+// satisfying the optional Lister capability (BUG-2406 — the rowless-blob
+// GC sweep). One full WalkDir per call: O(blobs) readdir+stat, affordable
+// because its only caller runs on the orphan-GC cadence, not on any
+// request path.
+//
+// Only entries whose BASE NAME is a canonical 64-hex sha256 are returned.
+// That single gate excludes everything else the tree can legitimately
+// contain: Put's in-progress temp files (".<hash>.*.tmp" — dot-prefixed
+// and suffixed, so never hash-shaped), the shard directories themselves,
+// and any stray operator artifact. A file that isn't hash-shaped was not
+// written by Put, and this store must not offer to delete what it did not
+// write.
+func (s *FSStore) ListBlobs(ctx context.Context) ([]BlobInfo, error) {
+	var out []BlobInfo
+	err := filepath.WalkDir(s.baseDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			// A shard directory vanishing mid-walk (concurrent Delete
+			// pruning) is normal churn, not a failed listing.
+			if errors.Is(err, os.ErrNotExist) {
+				return nil
+			}
+			return err
+		}
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		hash := filepath.Base(path)
+		if !validHash(hash) {
+			return nil
+		}
+		fi, err := d.Info()
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				return nil
+			}
+			return err
+		}
+		out = append(out, BlobInfo{
+			Key:     FSPrefix + ":" + hash,
+			Hash:    hash,
+			Size:    fi.Size(),
+			ModTime: fi.ModTime(),
+		})
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("attachments: FSStore list blobs: %w", err)
+	}
+	return out, nil
+}

--- a/internal/attachments/fs_store_test.go
+++ b/internal/attachments/fs_store_test.go
@@ -284,3 +284,73 @@ func TestNewFSStore_EmptyBaseDirRejected(t *testing.T) {
 		t.Fatal("expected error for empty baseDir")
 	}
 }
+
+// TestFSStore_ListBlobs pins the Lister capability (BUG-2406): every
+// Put blob is enumerated with its routable key, hash, and size — and
+// NOTHING else is. Temp files (dot-prefixed, never hash-shaped), the
+// shard directories, and stray non-hash files must all be excluded: a
+// file the store didn't write is not a file the rowless sweep may
+// offer to delete.
+func TestFSStore_ListBlobs(t *testing.T) {
+	dir := t.TempDir()
+	s, err := NewFSStore(dir)
+	if err != nil {
+		t.Fatalf("NewFSStore: %v", err)
+	}
+	ctx := context.Background()
+
+	put := func(content string) (hash, key string) {
+		t.Helper()
+		sum := sha256.Sum256([]byte(content))
+		hash = hex.EncodeToString(sum[:])
+		key, err := s.Put(ctx, hash, "text/plain", strings.NewReader(content))
+		if err != nil {
+			t.Fatalf("Put: %v", err)
+		}
+		return hash, key
+	}
+	hashA, keyA := put("blob-a")
+	hashB, keyB := put("blob-b-longer")
+
+	// Plant impostors: a stray operator file at the root, a non-hash
+	// file inside a real shard dir, and a synthetic Put temp file.
+	if err := os.WriteFile(filepath.Join(dir, "README.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("write junk: %v", err)
+	}
+	shardDir := filepath.Join(dir, hashA[0:2], hashA[2:4])
+	if err := os.WriteFile(filepath.Join(shardDir, "not-a-hash"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("write shard junk: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(shardDir, "."+hashA+".123.tmp"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("write temp impostor: %v", err)
+	}
+
+	blobs, err := s.ListBlobs(ctx)
+	if err != nil {
+		t.Fatalf("ListBlobs: %v", err)
+	}
+	if len(blobs) != 2 {
+		t.Fatalf("ListBlobs returned %d entries, want 2: %+v", len(blobs), blobs)
+	}
+	byHash := map[string]BlobInfo{}
+	for _, b := range blobs {
+		byHash[b.Hash] = b
+	}
+	a, ok := byHash[hashA]
+	if !ok || a.Key != keyA || a.Size != int64(len("blob-a")) {
+		t.Errorf("blob A = %+v (ok=%v), want key %s size %d", a, ok, keyA, len("blob-a"))
+	}
+	b, ok := byHash[hashB]
+	if !ok || b.Key != keyB || b.Size != int64(len("blob-b-longer")) {
+		t.Errorf("blob B = %+v (ok=%v), want key %s size %d", b, ok, keyB, len("blob-b-longer"))
+	}
+	for _, blob := range blobs {
+		if blob.ModTime.IsZero() {
+			t.Errorf("blob %s has zero ModTime", blob.Hash)
+		}
+		// The returned key must round-trip through the ordinary surface.
+		if _, err := s.Stat(ctx, blob.Key); err != nil {
+			t.Errorf("Stat(%s): %v", blob.Key, err)
+		}
+	}
+}

--- a/internal/attachments/registry.go
+++ b/internal/attachments/registry.go
@@ -43,6 +43,21 @@ func (r *Registry) Register(prefix string, store AttachmentStore) {
 	r.stores[prefix] = store
 }
 
+// Backends returns a snapshot of every registered backend, keyed by
+// prefix. The rowless-blob GC sweep iterates it and type-asserts each
+// store against Lister; a snapshot (rather than holding the lock across
+// the caller's walk) because a sweep over a large backend is long-lived
+// and registration is a startup-time affair anyway.
+func (r *Registry) Backends() map[string]AttachmentStore {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make(map[string]AttachmentStore, len(r.stores))
+	for prefix, store := range r.stores {
+		out[prefix] = store
+	}
+	return out
+}
+
 // Resolve returns the store responsible for key, or an error if no
 // matching backend is registered. The key format is "<prefix>:<rest>".
 func (r *Registry) Resolve(key string) (AttachmentStore, error) {

--- a/internal/attachments/store.go
+++ b/internal/attachments/store.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"time"
 )
 
 // AttachmentStore is the backend abstraction every storage implementation
@@ -57,3 +58,37 @@ type AttachmentStore interface {
 // ErrNotFound is returned (or wrapped) by Get/Stat when the requested key
 // is not present in the backend. Callers can compare with errors.Is.
 var ErrNotFound = errors.New("attachment not found")
+
+// BlobInfo describes one stored blob as enumerated by a Lister.
+type BlobInfo struct {
+	// Key is the routable "<backend>:<...>" form, exactly what Put
+	// returned when the blob was written — valid input to Get/Stat/Delete.
+	Key string
+	// Hash is the content sha256 the blob is addressed by.
+	Hash string
+	// Size in bytes.
+	Size int64
+	// ModTime is when the blob landed in the backend (filesystem mtime,
+	// object-store LastModified). The rowless-blob sweep uses it as the
+	// age gate: a blob younger than the GC grace period may simply be a
+	// row insert that has not happened yet.
+	ModTime time.Time
+}
+
+// Lister is an OPTIONAL capability of an AttachmentStore: enumerating
+// every blob it holds. The rowless-blob GC sweep (BUG-2406) needs it to
+// find blobs that no attachments row references — a leak class the
+// row-driven orphan sweep cannot see, produced when anything fails
+// between AttachmentStore.Put and the row insert (or the process dies
+// there). Kept separate from AttachmentStore rather than added to it so
+// a backend without an affordable enumeration (or one not yet wired for
+// it) still satisfies the core interface; the sweep detects the
+// capability by type assertion and skips — with a logged notice — any
+// backend that lacks it.
+//
+// ListBlobs walks the ENTIRE backend: cost is O(blobs) per call, which
+// is why its only caller runs on the orphan-GC cadence (default 24h),
+// never on a request path.
+type Lister interface {
+	ListBlobs(ctx context.Context) ([]BlobInfo, error)
+}

--- a/internal/server/handlers_attachments.go
+++ b/internal/server/handlers_attachments.go
@@ -440,11 +440,15 @@ func (s *Server) handleUploadAttachment(w http.ResponseWriter, r *http.Request) 
 			writeAttachmentNotFound(w)
 			return
 		}
-		// Note: the blob is now an orphan on disk. Orphan GC (TASK-886)
-		// will reclaim it past the grace period; we do NOT delete it
-		// here because the same hash may still be used by a concurrent
-		// upload that succeeded its DB insert. The refusal above lands in
-		// the same shape — BUG-2406 tracks the rowless-blob reclaim.
+		// Note: the blob is now ROWLESS on disk — no attachments row
+		// references it, so the row-driven orphan GC (TASK-886) cannot
+		// see it. The rowless-blob sweep (runRowlessBlobSweep, BUG-2406)
+		// reclaims it once its mtime ages past the GC grace period. We
+		// deliberately do NOT delete it here: the same hash may back a
+		// concurrent upload that succeeded its DB insert, and the sweep
+		// already owns the guards (any-state row check, in-flight fence,
+		// age gate) that make the delete safe. The refusal above lands
+		// in the same shape.
 		writeInternalError(w, fmt.Errorf("create attachment row: %w", err))
 		return
 	}

--- a/internal/server/orphan_gc.go
+++ b/internal/server/orphan_gc.go
@@ -288,6 +288,141 @@ func (s *Server) runOrphanGCSweep(ctx context.Context, graceCutoff time.Time) (*
 	return res, nil
 }
 
+// rowlessBlobSweepResult records what one rowless-blob sweep (BUG-2406)
+// accomplished, mirroring orphanGCResult's role for the row-driven sweep.
+type rowlessBlobSweepResult struct {
+	Listed         int   // blobs enumerated across all Lister-capable backends
+	Reclaimed      int   // blobs deleted (no row in any state, past grace, not in flight)
+	BytesReclaimed int64 // sum of reclaimed blob sizes
+	Skipped        int   // candidates skipped due to mid-sweep errors
+	Failures       int   // backends whose listing failed outright
+}
+
+// runRowlessBlobSweep reclaims blobs that NO attachments row references —
+// the leak class the row-driven sweep above cannot see (BUG-2406). Every
+// write path calls AttachmentStore.Put BEFORE inserting the row, so a
+// failure (or crash) between the two leaves a blob on disk with nothing
+// pointing at it; being row-driven, runOrphanGCSweep never scans it.
+//
+// Candidate = enumerated blob whose content hash has ZERO rows in ANY
+// state AND whose ModTime predates blobCutoff. Both halves matter:
+//
+//   - ANY state: a soft-deleted row — even one already past its own
+//     grace — still owns its bytes under the row sweep's row-before-bytes
+//     claim protocol (BUG-2415); reaching around it here would recreate
+//     the stranded-row-without-bytes state that protocol prevents. Rows
+//     and their blobs are the row sweep's business; this sweep takes only
+//     what no row claims.
+//   - ModTime age: a young rowless blob is indistinguishable from an
+//     upload whose row insert hasn't happened yet — rowlessness is the
+//     NORMAL transient state of every in-progress upload. The cutoff is
+//     the same operator-configured GC grace the row sweep uses (30d
+//     default), orders of magnitude beyond any plausible Put-to-insert
+//     gap; the in-flight guard below covers the active window, age is
+//     the backstop for windows the process didn't live to observe.
+//
+// TOCTOU at delete time: a writer could commit a row for a candidate
+// hash after the batched subtraction ran. Every Put-then-insert path
+// runs inside markUploadInFlight (its documented contract), and the copy
+// path's row clones only reference hashes that already have a live
+// source row (so they were never candidates) — which leaves exactly two
+// interleavings for a fresh writer, both closed under inFlightHashesMu:
+// it marked before we locked (in-flight check skips), or it marks after
+// we delete (its Put finds the file missing and rewrites it — Put is
+// create-if-absent by contract). Between those sits the writer that
+// marked, inserted, and RELEASED entirely inside our check-to-lock gap:
+// in-flight is zero again but its row exists, which is what the row
+// RE-CHECK inside the critical section catches. The mutex is held across
+// re-check + Delete, same ms-class discipline the row sweep documents.
+//
+// Backends without the Lister capability are skipped, with a
+// once-per-process notice (silent skipping would hide that this leak
+// class is unguarded there). Cost on capable backends: one full listing
+// + chunked hash-subtraction queries per sweep, O(blobs) — bounded by
+// the GC cadence (24h default), never on a request path.
+func (s *Server) runRowlessBlobSweep(ctx context.Context, blobCutoff time.Time) (*rowlessBlobSweepResult, error) {
+	if s.attachments == nil {
+		return nil, errors.New("attachments registry not configured")
+	}
+	res := &rowlessBlobSweepResult{}
+
+	for prefix, backend := range s.attachments.Backends() {
+		lister, ok := backend.(attachments.Lister)
+		if !ok {
+			s.rowlessNoListerOnce.Do(func() {
+				slog.Info("rowless-blob sweep: backend has no Lister capability; rowless blobs on it are not reclaimed",
+					"backend", prefix)
+			})
+			continue
+		}
+		blobs, err := lister.ListBlobs(ctx)
+		if err != nil {
+			slog.Warn("rowless-blob sweep: listing failed", "backend", prefix, "error", err)
+			res.Failures++
+			continue
+		}
+		res.Listed += len(blobs)
+
+		const chunkSize = 400
+		for start := 0; start < len(blobs); start += chunkSize {
+			if err := ctx.Err(); err != nil {
+				return res, err
+			}
+			chunk := blobs[start:min(start+chunkSize, len(blobs))]
+			hashes := make([]string, len(chunk))
+			for i, b := range chunk {
+				hashes[i] = b.Hash
+			}
+			withRows, err := s.store.AttachmentHashesWithRows(hashes)
+			if err != nil {
+				slog.Warn("rowless-blob sweep: hash subtraction failed", "backend", prefix, "error", err)
+				res.Skipped += len(chunk)
+				continue
+			}
+			for _, b := range chunk {
+				if err := ctx.Err(); err != nil {
+					return res, err
+				}
+				if withRows[b.Hash] || !b.ModTime.Before(blobCutoff) {
+					continue
+				}
+
+				s.inFlightHashesMu.Lock()
+				if s.inFlightHashes[b.Hash] > 0 {
+					s.inFlightHashesMu.Unlock()
+					continue
+				}
+				if s.rowlessPreDeleteHook != nil {
+					s.rowlessPreDeleteHook(b.Hash)
+				}
+				exists, err := s.store.AttachmentRowsExistForHash(b.Hash)
+				if err != nil {
+					s.inFlightHashesMu.Unlock()
+					slog.Warn("rowless-blob sweep: delete-time row re-check failed",
+						"backend", prefix, "hash", b.Hash, "error", err)
+					res.Skipped++
+					continue
+				}
+				if exists {
+					s.inFlightHashesMu.Unlock()
+					continue
+				}
+				delErr := backend.Delete(ctx, b.Key)
+				s.inFlightHashesMu.Unlock()
+				if delErr != nil {
+					slog.Warn("rowless-blob sweep: blob delete failed",
+						"backend", prefix, "storage_key", b.Key, "error", delErr)
+					res.Skipped++
+					continue
+				}
+				res.Reclaimed++
+				res.BytesReclaimed += b.Size
+			}
+		}
+	}
+	return res, nil
+}
+
 // orphanGCConfig captures runtime knobs for the periodic loop.
 // Stored on Server via SetOrphanGCConfig so tests + cmd/pad can
 // override defaults independently.
@@ -408,6 +543,22 @@ func (s *Server) runOrphanGCTick(grace time.Duration) {
 		"bytes_reclaimed", res.BytesReclaimed,
 		"skipped", res.Skipped,
 		"blob_delete_failures", res.BlobDeleteFailures)
+
+	// The rowless-blob sweep runs AFTER the row sweep, same tick and same
+	// grace cutoff: rows the row sweep just claimed are gone, so their
+	// now-unreferenced blobs age normally into the NEXT tick's rowless
+	// candidates rather than racing this one.
+	rres, err := s.runRowlessBlobSweep(ctx, cutoff)
+	if err != nil {
+		slog.Warn("rowless-blob sweep failed", "error", err)
+		return
+	}
+	slog.Info("rowless-blob sweep",
+		"listed", rres.Listed,
+		"reclaimed", rres.Reclaimed,
+		"bytes_reclaimed", rres.BytesReclaimed,
+		"skipped", rres.Skipped,
+		"backend_failures", rres.Failures)
 }
 
 // _ keeps the attachments import alive even if every callsite ends

--- a/internal/server/orphan_gc_test.go
+++ b/internal/server/orphan_gc_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -726,5 +727,221 @@ func TestOrphanGC_VariantProtectedByReferencedParent(t *testing.T) {
 	}
 	if att, _ := srv.store.GetAttachment(thumbID); att == nil {
 		t.Errorf("referenced original's VARIANT reclaimed — parent-aware scan failed")
+	}
+}
+
+// --- Rowless-blob sweep (BUG-2406) -------------------------------------
+
+// putRowlessBlob writes bytes straight into the fs backend with no
+// attachments row — the artifact of a Put-then-insert failure (or a
+// crash between the two), which the row-driven sweep cannot see.
+func putRowlessBlob(t *testing.T, srv *Server, content []byte) (hash, key string) {
+	t.Helper()
+	backend, ok := srv.attachments.Backends()[attachments.FSPrefix]
+	if !ok {
+		t.Fatal("no fs backend registered")
+	}
+	hash = sha256Hex(content)
+	key, err := backend.Put(context.Background(), hash, "application/octet-stream", bytes.NewReader(content))
+	if err != nil {
+		t.Fatalf("direct Put: %v", err)
+	}
+	return hash, key
+}
+
+func statBlob(t *testing.T, srv *Server, key string) error {
+	t.Helper()
+	backend, err := srv.attachments.Resolve(key)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	_, statErr := backend.Stat(context.Background(), key)
+	return statErr
+}
+
+// TestRowlessBlobSweep_ReclaimsAgedRowlessBlob pins the core: a blob no
+// row references, older than the grace cutoff, is deleted — bytes,
+// counters, and all. This is the leak the row-driven sweep can never
+// reclaim, verified by the companion counterfactual below.
+func TestRowlessBlobSweep_ReclaimsAgedRowlessBlob(t *testing.T) {
+	srv, _ := testServerWithAttachments(t)
+	content := []byte("leaked-by-failed-insert")
+	_, key := putRowlessBlob(t, srv, content)
+
+	// Counterfactual: the ROW sweep, given the same permissive cutoff,
+	// walks zero rows and leaves the blob exactly where it is — proving
+	// the class needs its own sweep rather than being covered already.
+	rowRes, err := srv.runOrphanGCSweep(context.Background(), time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("row sweep: %v", err)
+	}
+	if rowRes.BlobsReclaimed != 0 {
+		t.Fatalf("row sweep reclaimed %d blobs; rowless blob should be invisible to it", rowRes.BlobsReclaimed)
+	}
+	if err := statBlob(t, srv, key); err != nil {
+		t.Fatalf("blob missing after row sweep already: %v", err)
+	}
+
+	res, err := srv.runRowlessBlobSweep(context.Background(), time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("rowless sweep: %v", err)
+	}
+	if res.Listed < 1 {
+		t.Errorf("Listed=%d, want >= 1", res.Listed)
+	}
+	if res.Reclaimed != 1 {
+		t.Errorf("Reclaimed=%d, want 1", res.Reclaimed)
+	}
+	if res.BytesReclaimed != int64(len(content)) {
+		t.Errorf("BytesReclaimed=%d, want %d", res.BytesReclaimed, len(content))
+	}
+	if err := statBlob(t, srv, key); !errors.Is(err, attachments.ErrNotFound) {
+		t.Errorf("blob still present after rowless sweep; Stat err=%v", err)
+	}
+}
+
+// TestRowlessBlobSweep_KeepsYoungBlob pins the age gate: a rowless blob
+// younger than the cutoff is the normal transient state of an upload
+// whose row insert hasn't happened yet, and must survive.
+func TestRowlessBlobSweep_KeepsYoungBlob(t *testing.T) {
+	srv, _ := testServerWithAttachments(t)
+	_, key := putRowlessBlob(t, srv, []byte("mid-upload"))
+
+	res, err := srv.runRowlessBlobSweep(context.Background(), time.Now().Add(-time.Hour))
+	if err != nil {
+		t.Fatalf("rowless sweep: %v", err)
+	}
+	if res.Reclaimed != 0 {
+		t.Errorf("Reclaimed=%d, want 0 (blob younger than cutoff)", res.Reclaimed)
+	}
+	if err := statBlob(t, srv, key); err != nil {
+		t.Errorf("young rowless blob was deleted: %v", err)
+	}
+}
+
+// TestRowlessBlobSweep_KeepsRowBackedBlobs pins the subtraction: a blob
+// with a LIVE row and a blob whose only row is SOFT-DELETED both
+// survive — any row in any state owns its bytes via the row sweep's
+// claim protocol, and the rowless sweep must not reach around it.
+func TestRowlessBlobSweep_KeepsRowBackedBlobs(t *testing.T) {
+	srv, slug := testServerWithAttachments(t)
+	wsID := workspaceIDForSlug(t, srv, slug)
+
+	// Live row via the real upload endpoint.
+	if rr := doMultipartUpload(srv, slug, "live.png", realPNG()); rr.Code != 201 {
+		t.Fatalf("upload: %d %s", rr.Code, rr.Body.String())
+	}
+	liveKey := "fs:" + sha256Hex(realPNG())
+
+	// Soft-deleted-only row, planted directly.
+	content := []byte("soft-deleted-owner")
+	hash, sdKey := putRowlessBlob(t, srv, content)
+	att := &models.Attachment{
+		WorkspaceID: wsID,
+		UploadedBy:  "someone",
+		StorageKey:  sdKey,
+		ContentHash: hash,
+		MimeType:    "application/octet-stream",
+		SizeBytes:   int64(len(content)),
+		Filename:    "soon-deleted.bin",
+	}
+	if err := srv.store.CreateAttachment(att); err != nil {
+		t.Fatalf("CreateAttachment: %v", err)
+	}
+	if err := srv.store.SoftDeleteAttachment(att.ID); err != nil {
+		t.Fatalf("SoftDeleteAttachment: %v", err)
+	}
+
+	res, err := srv.runRowlessBlobSweep(context.Background(), time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("rowless sweep: %v", err)
+	}
+	if res.Reclaimed != 0 {
+		t.Errorf("Reclaimed=%d, want 0 (both blobs are row-backed)", res.Reclaimed)
+	}
+	for _, key := range []string{liveKey, sdKey} {
+		if err := statBlob(t, srv, key); err != nil {
+			t.Errorf("row-backed blob %s deleted by rowless sweep: %v", key, err)
+		}
+	}
+}
+
+// TestRowlessBlobSweep_RespectsInFlightUploads pins the in-flight fence,
+// with the counterfactual leg: the same blob IS reclaimed once the
+// registration releases, so the fence — not something else — is what
+// held it.
+func TestRowlessBlobSweep_RespectsInFlightUploads(t *testing.T) {
+	srv, _ := testServerWithAttachments(t)
+	hash, key := putRowlessBlob(t, srv, []byte("in-flight-window"))
+
+	release := srv.markUploadInFlight(hash)
+	res, err := srv.runRowlessBlobSweep(context.Background(), time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("rowless sweep (in flight): %v", err)
+	}
+	if res.Reclaimed != 0 {
+		t.Errorf("Reclaimed=%d, want 0 while upload in flight", res.Reclaimed)
+	}
+	if err := statBlob(t, srv, key); err != nil {
+		t.Fatalf("in-flight blob deleted: %v", err)
+	}
+
+	release()
+	res, err = srv.runRowlessBlobSweep(context.Background(), time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("rowless sweep (released): %v", err)
+	}
+	if res.Reclaimed != 1 {
+		t.Errorf("Reclaimed=%d after release, want 1", res.Reclaimed)
+	}
+	if err := statBlob(t, srv, key); !errors.Is(err, attachments.ErrNotFound) {
+		t.Errorf("blob survived after release; Stat err=%v", err)
+	}
+}
+
+// TestRowlessBlobSweep_DeleteTimeRowRecheck pins the TOCTOU guard: a row
+// committed AFTER the batched hash subtraction but BEFORE the delete —
+// the fully-completed writer whose in-flight registration has already
+// released — must still protect its bytes. The pre-delete hook commits
+// the row at exactly that point.
+func TestRowlessBlobSweep_DeleteTimeRowRecheck(t *testing.T) {
+	srv, slug := testServerWithAttachments(t)
+	wsID := workspaceIDForSlug(t, srv, slug)
+	content := []byte("late-row-writer")
+	hash, key := putRowlessBlob(t, srv, content)
+
+	hookRan := false
+	srv.rowlessPreDeleteHook = func(h string) {
+		if h != hash {
+			return
+		}
+		hookRan = true
+		att := &models.Attachment{
+			WorkspaceID: wsID,
+			UploadedBy:  "late-writer",
+			StorageKey:  key,
+			ContentHash: hash,
+			MimeType:    "application/octet-stream",
+			SizeBytes:   int64(len(content)),
+			Filename:    "late.bin",
+		}
+		if err := srv.store.CreateAttachment(att); err != nil {
+			t.Errorf("hook CreateAttachment: %v", err)
+		}
+	}
+	defer func() { srv.rowlessPreDeleteHook = nil }()
+
+	res, err := srv.runRowlessBlobSweep(context.Background(), time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("rowless sweep: %v", err)
+	}
+	if !hookRan {
+		t.Fatal("pre-delete hook never ran — the TOCTOU leg was not exercised")
+	}
+	if res.Reclaimed != 0 {
+		t.Errorf("Reclaimed=%d, want 0 (row committed before delete)", res.Reclaimed)
+	}
+	if err := statBlob(t, srv, key); err != nil {
+		t.Errorf("blob deleted despite delete-time row: %v", err)
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -228,6 +228,22 @@ type Server struct {
 	inFlightHashesMu sync.Mutex
 	inFlightHashes   map[string]int64
 
+	// rowlessNoListerOnce gates the once-per-process notice that a
+	// registered attachment backend lacks the Lister capability, leaving
+	// the rowless-blob sweep (BUG-2406) inert for it. Logged rather than
+	// silently skipped so an operator can tell the leak class is
+	// unguarded on that backend; once, so a 24h-cadence sweep doesn't
+	// turn it into log spam.
+	rowlessNoListerOnce sync.Once
+
+	// rowlessPreDeleteHook, when non-nil, runs inside the rowless
+	// sweep's in-flight critical section immediately BEFORE the
+	// delete-time row re-check. Test seam only (injectedStageFailure
+	// precedent): it lets a test commit a row for the hash at exactly
+	// the point that distinguishes the batched subtraction from the
+	// re-check, making the TOCTOU leg deterministic.
+	rowlessPreDeleteHook func(hash string)
+
 	// bg tracks fire-and-forget goroutines spawned by request handlers
 	// (TouchUserActivity in middleware_auth, async email sends, etc.) so
 	// the server can drain them before shutdown / test cleanup. Without

--- a/internal/store/attachments.go
+++ b/internal/store/attachments.go
@@ -986,6 +986,61 @@ func (s *Store) ClaimSoftDeletedAttachment(id string, graceCutoff time.Time) (bo
 	return n == 1, nil
 }
 
+// AttachmentHashesWithRows reports which of the given content hashes have
+// at least one attachments row — in ANY state. Soft-deleted rows count,
+// including ones already past the GC grace: as long as a row exists, its
+// bytes belong to the ROW-driven sweep's claim protocol (row before
+// bytes, BUG-2415), and the rowless-blob sweep must not reach around it —
+// deleting the blob from under a still-existing row recreates exactly the
+// stranded-row-without-bytes state that protocol exists to prevent. The
+// rowless sweep (BUG-2406) only reclaims blobs NO row references.
+//
+// Chunked like the copy planner's lookups so a large listing cannot blow
+// the host-parameter limit.
+func (s *Store) AttachmentHashesWithRows(hashes []string) (map[string]bool, error) {
+	out := make(map[string]bool, len(hashes))
+	for _, chunk := range chunkStrings(hashes, attachmentPlanChunk) {
+		args := make([]any, 0, len(chunk))
+		for _, h := range chunk {
+			args = append(args, h)
+		}
+		query := `SELECT DISTINCT content_hash FROM attachments
+			WHERE content_hash IN (` + sqlPlaceholderList(len(chunk)) + `)`
+		rows, err := s.db.Query(s.q(query), args...)
+		if err != nil {
+			return nil, fmt.Errorf("attachment hashes with rows: %w", err)
+		}
+		for rows.Next() {
+			var h string
+			if err := rows.Scan(&h); err != nil {
+				rows.Close()
+				return nil, fmt.Errorf("attachment hashes with rows: %w", err)
+			}
+			out[h] = true
+		}
+		if err := rows.Err(); err != nil {
+			rows.Close()
+			return nil, fmt.Errorf("attachment hashes with rows: %w", err)
+		}
+		rows.Close()
+	}
+	return out, nil
+}
+
+// AttachmentRowsExistForHash is the single-hash form of
+// AttachmentHashesWithRows — the rowless-blob sweep's delete-time
+// re-check, run under the in-flight mutex immediately before a blob
+// delete so a row inserted after the batched subtraction still protects
+// its bytes (see runRowlessBlobSweep's TOCTOU note).
+func (s *Store) AttachmentRowsExistForHash(hash string) (bool, error) {
+	var n int
+	err := s.db.QueryRow(s.q(`SELECT COUNT(*) FROM attachments WHERE content_hash = ?`), hash).Scan(&n)
+	if err != nil {
+		return false, fmt.Errorf("attachment rows exist for hash: %w", err)
+	}
+	return n > 0, nil
+}
+
 // CountProtectingAttachmentsForHash returns the number of rows
 // pointing at the given content_hash whose presence requires the
 // on-disk blob to stay. A row protects the blob when it is either:

--- a/internal/store/attachments.go
+++ b/internal/store/attachments.go
@@ -988,12 +988,15 @@ func (s *Store) ClaimSoftDeletedAttachment(id string, graceCutoff time.Time) (bo
 
 // AttachmentHashesWithRows reports which of the given content hashes have
 // at least one attachments row — in ANY state. Soft-deleted rows count,
-// including ones already past the GC grace: as long as a row exists, its
-// bytes belong to the ROW-driven sweep's claim protocol (row before
-// bytes, BUG-2415), and the rowless-blob sweep must not reach around it —
-// deleting the blob from under a still-existing row recreates exactly the
-// stranded-row-without-bytes state that protocol exists to prevent. The
-// rowless sweep (BUG-2406) only reclaims blobs NO row references.
+// including ones already past the GC grace. That is deliberately BROADER
+// than CountProtectingAttachmentsForHash, whose grace-window semantics end
+// a row's protection when its own grace expires: the row-driven machinery
+// may do that because its claim protocol (row before bytes, BUG-2415)
+// coordinates row and blob fates within one sweep. The rowless sweep has
+// no claim on any row and no such coordination, so it draws the simplest
+// safe line instead — a hash with ANY row is that row's business, handled
+// by the row sweep's own claim path within a tick; the rowless sweep
+// (BUG-2406) takes only blobs NO row references.
 //
 // Chunked like the copy planner's lookups so a large listing cannot blow
 // the host-parameter limit.

--- a/internal/store/attachments_test.go
+++ b/internal/store/attachments_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -709,5 +710,67 @@ func TestWorkspaceStorageInfo_TracksLiveAttachments(t *testing.T) {
 	}
 	if info.UsedBytes != 3072 {
 		t.Errorf("used_bytes = %d, want 3072 (1024 + 2048; soft-deleted excluded)", info.UsedBytes)
+	}
+}
+
+// TestAttachmentHashesWithRows pins the rowless-sweep subtraction's
+// contract (BUG-2406): a hash is "row-backed" when ANY row exists —
+// soft-deleted included, because a still-existing row owns its bytes
+// under the row sweep's claim protocol regardless of its state. The
+// delete-time re-check enforces the same rule independently; this pins
+// the batched form at its own layer so the two cannot drift apart
+// silently.
+func TestAttachmentHashesWithRows(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Hash Rows")
+
+	mk := func(hash string) *models.Attachment {
+		t.Helper()
+		a := &models.Attachment{
+			WorkspaceID: ws.ID,
+			UploadedBy:  "u",
+			StorageKey:  "fs:" + hash,
+			ContentHash: hash,
+			MimeType:    "application/octet-stream",
+			SizeBytes:   1,
+			Filename:    hash[:8] + ".bin",
+		}
+		if err := s.CreateAttachment(a); err != nil {
+			t.Fatalf("CreateAttachment: %v", err)
+		}
+		return a
+	}
+	liveHash := strings.Repeat("a", 64)
+	softHash := strings.Repeat("b", 64)
+	goneHash := strings.Repeat("c", 64)
+	mk(liveHash)
+	soft := mk(softHash)
+	if err := s.SoftDeleteAttachment(soft.ID); err != nil {
+		t.Fatalf("SoftDeleteAttachment: %v", err)
+	}
+
+	got, err := s.AttachmentHashesWithRows([]string{liveHash, softHash, goneHash})
+	if err != nil {
+		t.Fatalf("AttachmentHashesWithRows: %v", err)
+	}
+	if !got[liveHash] {
+		t.Error("live-row hash not reported as row-backed")
+	}
+	if !got[softHash] {
+		t.Error("soft-deleted-row hash not reported as row-backed — the sweep would reach around the row sweep's claim protocol")
+	}
+	if got[goneHash] {
+		t.Error("rowless hash reported as row-backed")
+	}
+
+	// Single-hash re-check agrees on all three.
+	for hash, want := range map[string]bool{liveHash: true, softHash: true, goneHash: false} {
+		exists, err := s.AttachmentRowsExistForHash(hash)
+		if err != nil {
+			t.Fatalf("AttachmentRowsExistForHash(%s): %v", hash, err)
+		}
+		if exists != want {
+			t.Errorf("AttachmentRowsExistForHash(%s) = %v, want %v", hash[:8], exists, want)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Every attachment write path calls `AttachmentStore.Put` **before** inserting the `attachments` row; a failure or crash between the two leaves a blob on disk that nothing references. The orphan GC is row-driven (`Store.OrphanedAttachments`), so a rowless blob is invisible to every claim class — disk that is never returned (BUG-2406, found by two independent Codex passes during TASK-2402 review).

Fix: a **rowless-blob sweep** running after the row sweep on the same GC tick.

- `attachments.Lister` — new **optional** backend capability (`ListBlobs` → key/hash/size/mtime). `FSStore` implements it with one `WalkDir` of the sharded tree; the base-name `validHash` gate excludes Put's temp files and anything the store didn't write. Non-Lister backends are skipped with a once-per-process notice (silent skip would hide that the leak class is unguarded there).
- Candidate = blob whose hash has **zero rows in any state** (a soft-deleted row — even past grace — still owns its bytes under BUG-2415's row-before-bytes claim protocol) **and** whose mtime predates the same operator-configured GC grace the row sweep uses (30d default; a young rowless blob is just an upload whose insert hasn't landed).
- Delete-time guards under `inFlightHashesMu`: in-flight fence + a single-hash row **re-check** closing the subtraction→delete TOCTOU (the writer that marked, inserted, and released entirely inside the gap). Same ms-class mutex discipline the row sweep documents.
- Cost: O(blobs) walk + chunked IN subtraction per tick, 24h cadence, never on a request path. Bonus: retro-reclaims blobs stranded by past row-sweep `BlobDeleteFailures`.
- The upload handler's failure comment claiming "Orphan GC will reclaim it" (false) is corrected.

Failure-site best-effort deletes deliberately left out — redundant once the sweep exists (lead concurred on the trail).

## Context

Fixes BUG-2406. Sibling of the BUG-2415/BUG-2388 claim-protocol work; the sweep takes only what no row claims and never reaches around the row sweep.

## Test plan

- [x] `FSStore.ListBlobs`: enumerates Put blobs exactly; impostors (stray root file, non-hash shard file, temp-file lookalike) excluded; keys round-trip through Stat
- [x] Sweep legs: aged rowless reclaimed (with a row-sweep-cannot-see-it counterfactual), young kept, live-row + soft-deleted-only-row kept, in-flight kept then reclaimed after release (counterfactual), hook-injected delete-time row kept (deterministic TOCTOU leg)
- [x] Mutation-verified instrument: removing the re-check / age gate / in-flight fence each fails its leg; live-only subtraction is masked by the re-check (defense in depth) and its contract is pinned by a store-level unit instead
- [x] `go test ./...` (SQLite) green; `make lint` 0 issues
- [ ] `make test-pg` (running)
- [ ] Codex review loop → CLEAN

https://claude.ai/code/session_017jD6t1zjxGSq47SQpZfp1V