### PR TITLE
fix: surface implementation notes + decision log in the item timeline (BUG-2301)

### DIFF
--- a/internal/models/activity.go
+++ b/internal/models/activity.go
@@ -121,17 +121,26 @@ type AuditLogParams struct {
 }
 
 // TimelineEntry represents a single entry in the unified item timeline.
-// It wraps one of: a comment, an activity, or a version.
+// It wraps one of: a comment, an activity, a version, an implementation
+// note, or a decision-log entry.
+//
+// Notes and decisions differ from the other three kinds in where they live:
+// they are elements of the item's own fields blob, not rows in a table, so
+// they arrive already-loaded on the item rather than through a cursor query
+// (BUG-2301). The handler still runs them through the same (created_at, id)
+// cursor predicate the SQL uses, so paging behaves identically for all five.
 type TimelineEntry struct {
-	ID        string    `json:"id"`
-	Kind      string    `json:"kind"` // "comment", "activity", "version"
-	CreatedAt time.Time `json:"created_at"`
-	Actor     string    `json:"actor"`
-	ActorName string    `json:"actor_name,omitempty"`
-	Source    string    `json:"source"`
-	Comment   *Comment  `json:"comment,omitempty"`
-	Activity  *Activity `json:"activity,omitempty"`
-	Version   *Version  `json:"version,omitempty"`
+	ID        string                  `json:"id"`
+	Kind      string                  `json:"kind"` // "comment", "activity", "version", "note", "decision"
+	CreatedAt time.Time               `json:"created_at"`
+	Actor     string                  `json:"actor"`
+	ActorName string                  `json:"actor_name,omitempty"`
+	Source    string                  `json:"source"`
+	Comment   *Comment                `json:"comment,omitempty"`
+	Activity  *Activity               `json:"activity,omitempty"`
+	Version   *Version                `json:"version,omitempty"`
+	Note      *ItemImplementationNote `json:"note,omitempty"`
+	Decision  *ItemDecisionLogEntry   `json:"decision,omitempty"`
 }
 
 // TimelineResponse is the paginated response from the timeline endpoint.

--- a/internal/models/activity.go
+++ b/internal/models/activity.go
@@ -128,7 +128,14 @@ type AuditLogParams struct {
 // they are elements of the item's own fields blob, not rows in a table, so
 // they arrive already-loaded on the item rather than through a cursor query
 // (BUG-2301). The handler still runs them through the same (created_at, id)
-// cursor predicate the SQL uses, so paging behaves identically for all five.
+// cursor predicate the SQL uses, so paging behaves identically for all five —
+// over a STABLE dataset. The five sources are read at five instants with no
+// shared snapshot, so a write landing mid-request can put one page slightly
+// out of step with another (an `updated` activity present while the note that
+// caused it is not, or the reverse). That predates this type and is not
+// specific to the structured kinds — the three SQL sources were already read
+// one after another. Nothing is lost: the blob is authoritative and the next
+// fetch is consistent.
 type TimelineEntry struct {
 	ID        string                  `json:"id"`
 	Kind      string                  `json:"kind"` // "comment", "activity", "version", "note", "decision"

--- a/internal/server/handlers_timeline.go
+++ b/internal/server/handlers_timeline.go
@@ -50,6 +50,15 @@ func (s *Server) handleListItemTimeline(w http.ResponseWriter, r *http.Request) 
 	//      lowercase-hex UUID character in every reasonable collation) so
 	//      same-second entries aren't silently dropped.
 	//
+	// Case 3 carries an ASSUMPTION, not a guarantee: "g" keeps same-second
+	// entries only for ids drawn from the lowercase-hex UUID alphabet. Any
+	// source whose ids can sort ABOVE "g" is silently dropped at the cursor
+	// instant instead — and a source with ids on BOTH sides is split in half
+	// on their first character. That is not hypothetical: the structured
+	// kinds' `note-…` / `decision-…` ids straddle it exactly that way
+	// (BUG-2301), which is what `sentinelBeforeID` below exists to handle.
+	// If you add a source whose ids are not UUIDs, this is the line to check.
+	//
 	// The previous code defaulted beforeID to "\xff" in all three cases.
 	// That worked on SQLite but Postgres rejects "\xff" as an invalid UTF-8
 	// byte sequence (SQLSTATE 22021), causing every timeline load to 500.
@@ -75,7 +84,9 @@ func (s *Server) handleListItemTimeline(w http.ResponseWriter, r *http.Request) 
 		beforeID = v
 	}
 	if hasBefore && beforeID == "" {
-		beforeID = "g" // > any UUID character lex-wise; valid UTF-8
+		// > any UUID character lex-wise; valid UTF-8. Non-UUID ids are NOT
+		// covered by that — see the assumption note above.
+		beforeID = "g"
 		sentinelBeforeID = true
 	}
 

--- a/internal/server/handlers_timeline.go
+++ b/internal/server/handlers_timeline.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"fmt"
 	"net/http"
 	"sort"
 	"strconv"
@@ -110,7 +111,15 @@ func (s *Server) handleListItemTimeline(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	entries := buildTimeline(comments, activities, versions)
+	// Implementation notes and decision-log entries live inside the item's
+	// own fields blob (hydrated by the store on resolve), not in a table, so
+	// there is no cursor query to run — every entry is already in hand. They
+	// still have to be filtered through the SAME (created_at, id) predicate
+	// the SQL above uses, or paging would show them on every page instead of
+	// exactly one (BUG-2301).
+	notes, decisions := structuredTimelineEntries(item, before, beforeID)
+
+	entries := buildTimeline(comments, activities, versions, notes, decisions)
 
 	// Determine if there are more entries beyond this page.
 	hasMore := false
@@ -129,9 +138,99 @@ func (s *Server) handleListItemTimeline(w http.ResponseWriter, r *http.Request) 
 	})
 }
 
-// buildTimeline merges comments, activities, and versions into a single chronological
-// stream, applying deduplication and collapsing logic.
-func buildTimeline(comments []models.Comment, activities []models.Activity, versions []models.Version) []models.TimelineEntry {
+// structuredTimelineEntries turns the item's implementation notes and
+// decision-log entries into timeline entries, applying the same cursor
+// predicate the SQL sources use: keep an entry strictly older than the
+// cursor, or at the cursor instant with a lower id.
+//
+// The two structured kinds are stored as JSON inside items.fields rather than
+// as rows, which makes three things representable that a table would not:
+//
+//   - a missing created_at (both structs mark it omitempty). Such an entry has
+//     no place of its own in a chronological feed, so it is anchored at the
+//     item's creation instant — the earliest moment it could have existed.
+//     Anchoring at the zero time instead would render as 1970 in the UI.
+//   - a missing id. The id is the sort tie-breaker and the cursor's second
+//     term, so a blank one gets a positional fallback, keeping the ordering
+//     total and paging stable.
+//   - a field that is not an array at all. models.ExtractItem* returns nil for
+//     those, so they arrive here as an empty slice and simply contribute
+//     nothing. See BUG-2627 for a live instance.
+func structuredTimelineEntries(item *models.Item, before time.Time, beforeID string) ([]models.TimelineEntry, []models.TimelineEntry) {
+	if item == nil {
+		return nil, nil
+	}
+
+	keep := func(at time.Time, id string) bool {
+		if at.Before(before) {
+			return true
+		}
+		return at.Equal(before) && beforeID != "" && id < beforeID
+	}
+
+	// Parse an entry timestamp, falling back to the item's own creation
+	// instant when it is absent or malformed.
+	stamp := func(raw string) time.Time {
+		if raw != "" {
+			if t, err := time.Parse(time.RFC3339Nano, raw); err == nil {
+				return t.UTC()
+			}
+			if t, err := time.Parse(time.RFC3339, raw); err == nil {
+				return t.UTC()
+			}
+		}
+		return item.CreatedAt.UTC()
+	}
+
+	var notes []models.TimelineEntry
+	for i := range item.ImplementationNotes {
+		n := item.ImplementationNotes[i]
+		id := n.ID
+		if id == "" {
+			id = fmt.Sprintf("note-idx-%d", i)
+		}
+		at := stamp(n.CreatedAt)
+		if !keep(at, id) {
+			continue
+		}
+		notes = append(notes, models.TimelineEntry{
+			ID:        id,
+			Kind:      "note",
+			CreatedAt: at,
+			Actor:     n.CreatedBy,
+			Source:    "structured",
+			Note:      &item.ImplementationNotes[i],
+		})
+	}
+
+	var decisions []models.TimelineEntry
+	for i := range item.DecisionLog {
+		d := item.DecisionLog[i]
+		id := d.ID
+		if id == "" {
+			id = fmt.Sprintf("decision-idx-%d", i)
+		}
+		at := stamp(d.CreatedAt)
+		if !keep(at, id) {
+			continue
+		}
+		decisions = append(decisions, models.TimelineEntry{
+			ID:        id,
+			Kind:      "decision",
+			CreatedAt: at,
+			Actor:     d.CreatedBy,
+			Source:    "structured",
+			Decision:  &item.DecisionLog[i],
+		})
+	}
+
+	return notes, decisions
+}
+
+// buildTimeline merges comments, activities, versions, implementation notes,
+// and decision-log entries into a single chronological stream, applying
+// deduplication and collapsing logic.
+func buildTimeline(comments []models.Comment, activities []models.Activity, versions []models.Version, notes, decisions []models.TimelineEntry) []models.TimelineEntry {
 	// Build a set of version timestamps (rounded to the second) for dedup.
 	versionTimes := make(map[int64]bool, len(versions))
 	for _, v := range versions {
@@ -227,6 +326,11 @@ func buildTimeline(comments []models.Comment, activities []models.Activity, vers
 		}
 		entries = append(entries, entry)
 	}
+
+	// Add the structured kinds. They are already TimelineEntry-shaped and
+	// cursor-filtered; the sort below is what places them in the stream.
+	entries = append(entries, notes...)
+	entries = append(entries, decisions...)
 
 	// Sort chronologically (newest first), with ID as tie-breaker for same-second entries.
 	// This must match the SQL ORDER BY (created_at DESC, id DESC) used by the cursor queries.

--- a/internal/server/handlers_timeline.go
+++ b/internal/server/handlers_timeline.go
@@ -227,17 +227,30 @@ func structuredTimelineEntries(item *models.Item, before time.Time, beforeID str
 	}
 
 	// Parse an entry timestamp, falling back to the item's own creation
-	// instant when it is absent or malformed.
+	// instant when it is absent or malformed, and TRUNCATE to whole seconds.
+	//
+	// Truncation is not cosmetic. The SQL sources store and compare
+	// second-precision RFC3339 text, so a structured entry that kept
+	// sub-second precision would be in a different space than every other
+	// entry in the merged stream, in three places at once: the sort would
+	// interleave it against same-second rows by a component they do not have;
+	// the client echoes the last entry's created_at back as the next cursor,
+	// where the store formats it down to the second and would then EXCLUDE
+	// same-second rows that were still owed; and the filter's own comparison
+	// would disagree with the SQL one. Landing the entry in the shared space
+	// at the point it is built fixes all three at once — filtering in the
+	// formatted space alone (which is what the first pass at this did) leaves
+	// the sort and the emitted cursor wrong.
 	stamp := func(raw string) time.Time {
+		parsed := item.CreatedAt
 		if raw != "" {
 			if t, err := time.Parse(time.RFC3339Nano, raw); err == nil {
-				return t.UTC()
-			}
-			if t, err := time.Parse(time.RFC3339, raw); err == nil {
-				return t.UTC()
+				parsed = t
+			} else if t, err := time.Parse(time.RFC3339, raw); err == nil {
+				parsed = t
 			}
 		}
-		return item.CreatedAt.UTC()
+		return parsed.UTC().Truncate(time.Second)
 	}
 
 	var notes []models.TimelineEntry

--- a/internal/server/handlers_timeline.go
+++ b/internal/server/handlers_timeline.go
@@ -155,7 +155,8 @@ func (s *Server) handleListItemTimeline(w http.ResponseWriter, r *http.Request) 
 //   - a missing created_at (both structs mark it omitempty). Such an entry has
 //     no place of its own in a chronological feed, so it is anchored at the
 //     item's creation instant — the earliest moment it could have existed.
-//     Anchoring at the zero time instead would render as 1970 in the UI.
+//     Anchoring at Go's zero time instead would date the entry to year 1 and
+//     sort it below everything real.
 //   - a missing id. The id is the sort tie-breaker and the cursor's second
 //     term, so a blank one gets a positional fallback, keeping the ordering
 //     total and paging stable.

--- a/internal/server/handlers_timeline.go
+++ b/internal/server/handlers_timeline.go
@@ -57,6 +57,11 @@ func (s *Server) handleListItemTimeline(w http.ResponseWriter, r *http.Request) 
 	before := time.Now().UTC().Add(time.Minute)
 	beforeID := ""
 	hasBefore := false
+	// Whether beforeID below is the synthetic sentinel rather than a real id
+	// the client sent. The structured sources need to know, because the
+	// sentinel encodes "keep every entry at this instant" and only does so by
+	// accident for ids drawn from the lowercase-hex UUID alphabet.
+	sentinelBeforeID := false
 	if v := r.URL.Query().Get("before"); v != "" {
 		if t, err := time.Parse(time.RFC3339Nano, v); err == nil {
 			before = t
@@ -71,6 +76,7 @@ func (s *Server) handleListItemTimeline(w http.ResponseWriter, r *http.Request) 
 	}
 	if hasBefore && beforeID == "" {
 		beforeID = "g" // > any UUID character lex-wise; valid UTF-8
+		sentinelBeforeID = true
 	}
 
 	// Over-fetch per source (3x limit) to compensate for entries removed by
@@ -117,7 +123,7 @@ func (s *Server) handleListItemTimeline(w http.ResponseWriter, r *http.Request) 
 	// still have to be filtered through the SAME (created_at, id) predicate
 	// the SQL above uses, or paging would show them on every page instead of
 	// exactly one (BUG-2301).
-	notes, decisions := structuredTimelineEntries(item, before, beforeID)
+	notes, decisions := structuredTimelineEntries(item, before, beforeID, sentinelBeforeID)
 
 	entries := buildTimeline(comments, activities, versions, notes, decisions)
 
@@ -156,16 +162,68 @@ func (s *Server) handleListItemTimeline(w http.ResponseWriter, r *http.Request) 
 //   - a field that is not an array at all. models.ExtractItem* returns nil for
 //     those, so they arrive here as an empty slice and simply contribute
 //     nothing. See BUG-2627 for a live instance.
-func structuredTimelineEntries(item *models.Item, before time.Time, beforeID string) ([]models.TimelineEntry, []models.TimelineEntry) {
+//   - duplicate ids. Nothing validates them on write, and a duplicate id is
+//     not merely untidy: it collides in the client's keyed {#each}, and the
+//     cursor cannot page past a pair of entries it cannot tell apart. Repeats
+//     get the same positional suffix an absent id gets.
+//
+// `sentinelBeforeID` says the caller synthesized beforeID rather than
+// receiving it, which means "keep every entry at this instant" — see the
+// comparison note inside.
+func structuredTimelineEntries(item *models.Item, before time.Time, beforeID string, sentinelBeforeID bool) ([]models.TimelineEntry, []models.TimelineEntry) {
 	if item == nil {
 		return nil, nil
 	}
 
+	// Compare in the SAME space the SQL sources do: RFC3339 text, whole
+	// seconds. The store formats the cursor with time.Format(time.RFC3339)
+	// and compares it against the stored text column, so a Go-side comparison
+	// on full-precision time.Time is a DIFFERENT predicate — a structured
+	// entry carrying sub-second precision (a hand-written created_at, or the
+	// item's own createdAt used as the undated fallback) could then sit on a
+	// page boundary that the SQL sources resolve the other way, dropping or
+	// repeating entries around it. Formatting both sides removes the seam
+	// instead of trying to compensate for it.
+	beforeText := before.Format(time.RFC3339)
+
 	keep := func(at time.Time, id string) bool {
-		if at.Before(before) {
+		atText := at.Format(time.RFC3339)
+		if atText < beforeText {
 			return true
 		}
-		return at.Equal(before) && beforeID != "" && id < beforeID
+		if atText != beforeText {
+			return false
+		}
+		// At the cursor instant the id decides. The sentinel is not a real
+		// id: it exists so same-second entries are NOT dropped, and it
+		// achieves that for UUIDs only because every lowercase-hex character
+		// sorts below "g". Structured ids are `note-…` / `decision-…`, so
+		// comparing against it would drop every note ("n" > "g") while
+		// keeping every decision ("d" < "g") — an arbitrary split. Honour
+		// what the sentinel MEANS rather than how it happens to sort.
+		if sentinelBeforeID {
+			return true
+		}
+		return beforeID != "" && id < beforeID
+	}
+
+	// Assign a stable, unique entry id: the entry's own id when it has one
+	// and no earlier entry claimed it, otherwise a positional fallback.
+	// Notes and decisions share this map — they land in one merged stream and
+	// a collision ACROSS the two kinds breaks the client exactly as one
+	// within a kind does.
+	usedIDs := make(map[string]bool, len(item.ImplementationNotes)+len(item.DecisionLog))
+	entryID := func(raw, prefix string, i int) string {
+		if raw != "" && !usedIDs[raw] {
+			usedIDs[raw] = true
+			return raw
+		}
+		id := fmt.Sprintf("%s-idx-%d", prefix, i)
+		for usedIDs[id] {
+			id += "x"
+		}
+		usedIDs[id] = true
+		return id
 	}
 
 	// Parse an entry timestamp, falling back to the item's own creation
@@ -185,10 +243,7 @@ func structuredTimelineEntries(item *models.Item, before time.Time, beforeID str
 	var notes []models.TimelineEntry
 	for i := range item.ImplementationNotes {
 		n := item.ImplementationNotes[i]
-		id := n.ID
-		if id == "" {
-			id = fmt.Sprintf("note-idx-%d", i)
-		}
+		id := entryID(n.ID, "note", i)
 		at := stamp(n.CreatedAt)
 		if !keep(at, id) {
 			continue
@@ -206,10 +261,7 @@ func structuredTimelineEntries(item *models.Item, before time.Time, beforeID str
 	var decisions []models.TimelineEntry
 	for i := range item.DecisionLog {
 		d := item.DecisionLog[i]
-		id := d.ID
-		if id == "" {
-			id = fmt.Sprintf("decision-idx-%d", i)
-		}
+		id := entryID(d.ID, "decision", i)
 		at := stamp(d.CreatedAt)
 		if !keep(at, id) {
 			continue

--- a/internal/server/handlers_timeline_structured_test.go
+++ b/internal/server/handlers_timeline_structured_test.go
@@ -1,0 +1,381 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// BUG-2301: `pad item note` / `pad item decide` wrote structured entries that
+// no web surface rendered — the renderer shipped in c61f4cda and was deleted
+// the next day as collateral of the unified-timeline PR (998716ae). These
+// tests cover the replacement: the two kinds are merged server-side by the
+// timeline endpoint, so the existing cursor pagination carries them.
+
+// timelineItemWithStructured creates an item whose fields blob carries the
+// given raw implementation_notes / decision_log JSON, going through the real
+// HTTP create path so the entries are hydrated exactly as production does it.
+// Pass raw JSON so a test can express shapes the Go structs allow but the CLI
+// never writes (missing ids, missing timestamps, a non-array field).
+func timelineItemWithStructured(t *testing.T, srv *Server, wsSlug, notesJSON, decisionsJSON string) *models.Item {
+	t.Helper()
+
+	fields := `{"status":"open"`
+	if notesJSON != "" {
+		fields += `,"implementation_notes":` + notesJSON
+	}
+	if decisionsJSON != "" {
+		fields += `,"decision_log":` + decisionsJSON
+	}
+	fields += `}`
+
+	rr := doRequest(srv, "POST", "/api/v1/workspaces/"+wsSlug+"/collections/tasks/items", map[string]any{
+		"title":  "structured subject",
+		"source": "cli",
+		"fields": fields,
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create item = %d: %s", rr.Code, rr.Body.String())
+	}
+	var it models.Item
+	parseJSON(t, rr, &it)
+	return &it
+}
+
+func fetchTimeline(t *testing.T, srv *Server, wsSlug, itemSlug, query string) models.TimelineResponse {
+	t.Helper()
+	path := "/api/v1/workspaces/" + wsSlug + "/items/" + itemSlug + "/timeline"
+	if query != "" {
+		path += "?" + query
+	}
+	rr := doRequest(srv, "GET", path, nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("GET timeline = %d: %s", rr.Code, rr.Body.String())
+	}
+	var resp models.TimelineResponse
+	parseJSON(t, rr, &resp)
+	return resp
+}
+
+func kindsOf(entries []models.TimelineEntry) map[string]int {
+	out := map[string]int{}
+	for _, e := range entries {
+		out[e.Kind]++
+	}
+	return out
+}
+
+// The headline regression: notes and decisions written into the fields blob
+// must reach the timeline endpoint's response. Before this fix the endpoint
+// merged only comments, activities and versions, so the response carried zero
+// entries for either kind no matter how many the item held.
+func TestItemTimeline_SurfacesNotesAndDecisions(t *testing.T) {
+	srv := testServer(t)
+	ws := createTestWorkspaceViaAPI(t, srv)
+
+	item := timelineItemWithStructured(t, srv, ws,
+		`[{"id":"note-1","summary":"first note","details":"body one","created_at":"2026-04-02T10:00:00Z","created_by":"agent"},
+		  {"id":"note-2","summary":"second note","created_at":"2026-04-02T12:00:00Z","created_by":"user"}]`,
+		`[{"id":"decision-1","decision":"use reserved field keys","rationale":"no new table","created_at":"2026-04-02T11:00:00Z","created_by":"user"}]`)
+
+	resp := fetchTimeline(t, srv, ws, item.Slug, "")
+	counts := kindsOf(resp.Entries)
+	if counts["note"] != 2 {
+		t.Errorf("expected 2 note entries in the timeline, got %d (kinds: %v)", counts["note"], counts)
+	}
+	if counts["decision"] != 1 {
+		t.Errorf("expected 1 decision entry in the timeline, got %d (kinds: %v)", counts["decision"], counts)
+	}
+
+	// The payload has to travel, not just the kind label — the card renders
+	// summary/details/decision/rationale, so an entry with a nil body would
+	// render blank and still satisfy a count-only assertion.
+	var sawNoteBody, sawDecisionBody bool
+	for _, e := range resp.Entries {
+		if e.Kind == "note" && e.Note != nil && e.Note.Summary == "first note" && e.Note.Details == "body one" {
+			sawNoteBody = true
+		}
+		if e.Kind == "decision" && e.Decision != nil && e.Decision.Decision == "use reserved field keys" &&
+			e.Decision.Rationale == "no new table" {
+			sawDecisionBody = true
+		}
+	}
+	if !sawNoteBody {
+		t.Error("note entry reached the timeline without its summary/details payload")
+	}
+	if !sawDecisionBody {
+		t.Error("decision entry reached the timeline without its decision/rationale payload")
+	}
+
+	// Chronological placement among the other kinds is the point of merging
+	// server-side rather than appending client-side: newest first.
+	var order []string
+	for _, e := range resp.Entries {
+		if e.Kind == "note" || e.Kind == "decision" {
+			order = append(order, e.ID)
+		}
+	}
+	want := []string{"note-2", "decision-1", "note-1"}
+	if len(order) != len(want) {
+		t.Fatalf("structured entry order = %v, want %v", order, want)
+	}
+	for i := range want {
+		if order[i] != want[i] {
+			t.Fatalf("structured entry order = %v, want %v (newest first)", order, want)
+		}
+	}
+}
+
+// Actor attribution has to survive the trip, because these entries are the one
+// place created_by is client-declared (BUG-2542) and the UI labels them with it.
+func TestItemTimeline_StructuredEntriesCarryActor(t *testing.T) {
+	srv := testServer(t)
+	ws := createTestWorkspaceViaAPI(t, srv)
+
+	item := timelineItemWithStructured(t, srv, ws,
+		`[{"id":"note-1","summary":"agent wrote this","created_at":"2026-04-02T10:00:00Z","created_by":"agent"}]`,
+		`[{"id":"decision-1","decision":"human decided this","created_at":"2026-04-02T11:00:00Z","created_by":"user"}]`)
+
+	resp := fetchTimeline(t, srv, ws, item.Slug, "")
+	// Count as well as check: a loop that only asserts on entries it finds
+	// passes vacuously when the merge drops them, which is the very failure
+	// this file exists to catch (CONVE-12).
+	var checked int
+	for _, e := range resp.Entries {
+		switch e.Kind {
+		case "note":
+			checked++
+			if e.Actor != "agent" {
+				t.Errorf("note actor = %q, want %q", e.Actor, "agent")
+			}
+		case "decision":
+			checked++
+			if e.Actor != "user" {
+				t.Errorf("decision actor = %q, want %q", e.Actor, "user")
+			}
+		}
+	}
+	if checked != 2 {
+		t.Fatalf("asserted on %d structured entries, want 2 — the assertions above "+
+			"are vacuous unless both entries are present", checked)
+	}
+}
+
+// Paging correctness. Notes and decisions do not come from a cursor query —
+// they arrive whole on the item — so without an explicit filter they would
+// reappear on EVERY page. This drives the same (created_at, id) predicate the
+// SQL sources use, through the real handler.
+func TestItemTimeline_StructuredEntriesRespectCursor(t *testing.T) {
+	srv := testServer(t)
+	ws := createTestWorkspaceViaAPI(t, srv)
+
+	item := timelineItemWithStructured(t, srv, ws,
+		`[{"id":"note-old","summary":"older","created_at":"2026-04-02T10:00:00Z","created_by":"user"},
+		  {"id":"note-new","summary":"newer","created_at":"2026-04-02T12:00:00Z","created_by":"user"}]`, "")
+
+	// Cursor at 11:00 — strictly between the two notes.
+	resp := fetchTimeline(t, srv, ws, item.Slug, "before=2026-04-02T11:00:00Z")
+	var got []string
+	for _, e := range resp.Entries {
+		if e.Kind == "note" {
+			got = append(got, e.ID)
+		}
+	}
+	if len(got) != 1 || got[0] != "note-old" {
+		t.Fatalf("notes past a 11:00 cursor = %v, want [note-old] — an unfiltered "+
+			"structured source repeats every entry on every page", got)
+	}
+}
+
+// The same-instant half of the cursor predicate: at the cursor timestamp, the
+// id decides. An entry whose id sorts at or above before_id was already shown
+// on the previous page and must not repeat; one below it is still owed.
+func TestItemTimeline_StructuredCursorTieBreaksOnID(t *testing.T) {
+	srv := testServer(t)
+	ws := createTestWorkspaceViaAPI(t, srv)
+
+	item := timelineItemWithStructured(t, srv, ws,
+		`[{"id":"note-a","summary":"sorts below the cursor id","created_at":"2026-04-02T10:00:00Z","created_by":"user"},
+		  {"id":"note-z","summary":"sorts above the cursor id","created_at":"2026-04-02T10:00:00Z","created_by":"user"}]`, "")
+
+	resp := fetchTimeline(t, srv, ws, item.Slug,
+		"before=2026-04-02T10:00:00Z&before_id=note-m")
+	var got []string
+	for _, e := range resp.Entries {
+		if e.Kind == "note" {
+			got = append(got, e.ID)
+		}
+	}
+	if len(got) != 1 || got[0] != "note-a" {
+		t.Fatalf("same-instant cursor with before_id=note-m returned %v, want [note-a]", got)
+	}
+}
+
+// Hostile shapes. Both entry structs mark id and created_at omitempty, and the
+// fields blob is writable by hand (`pad item update --field`), so absence is
+// representable even though today's live data has none of it. A live workspace
+// does carry the third case — a double-encoded implementation_notes STRING
+// rather than an array (BUG-2627) — which must contribute nothing rather than
+// erroring the whole timeline.
+func TestItemTimeline_StructuredEntriesTolerateHostileShapes(t *testing.T) {
+	t.Run("missing created_at anchors at the item, not 1970", func(t *testing.T) {
+		srv := testServer(t)
+		ws := createTestWorkspaceViaAPI(t, srv)
+		item := timelineItemWithStructured(t, srv, ws,
+			`[{"id":"note-undated","summary":"no timestamp","created_by":"user"}]`, "")
+
+		resp := fetchTimeline(t, srv, ws, item.Slug, "")
+		var found *models.TimelineEntry
+		for i := range resp.Entries {
+			if resp.Entries[i].ID == "note-undated" {
+				found = &resp.Entries[i]
+			}
+		}
+		if found == nil {
+			t.Fatal("undated note dropped from the timeline entirely")
+		}
+		if found.CreatedAt.Year() < 2000 {
+			t.Errorf("undated note anchored at %s — a zero-time fallback renders as 1970 "+
+				"and sorts below every real entry", found.CreatedAt)
+		}
+		if !found.CreatedAt.Equal(item.CreatedAt.UTC()) {
+			t.Errorf("undated note anchored at %s, want the item's own created_at %s",
+				found.CreatedAt, item.CreatedAt.UTC())
+		}
+	})
+
+	t.Run("unparseable created_at falls back the same way", func(t *testing.T) {
+		srv := testServer(t)
+		ws := createTestWorkspaceViaAPI(t, srv)
+		item := timelineItemWithStructured(t, srv, ws,
+			`[{"id":"note-bad-ts","summary":"garbage timestamp","created_at":"not-a-timestamp","created_by":"user"}]`, "")
+
+		resp := fetchTimeline(t, srv, ws, item.Slug, "")
+		var found bool
+		for _, e := range resp.Entries {
+			if e.ID == "note-bad-ts" {
+				found = true
+				if e.CreatedAt.Year() < 2000 {
+					t.Errorf("note with an unparseable timestamp anchored at %s", e.CreatedAt)
+				}
+			}
+		}
+		if !found {
+			t.Error("note with an unparseable timestamp dropped from the timeline")
+		}
+	})
+
+	t.Run("missing id still yields a distinct, stable entry id", func(t *testing.T) {
+		srv := testServer(t)
+		ws := createTestWorkspaceViaAPI(t, srv)
+		item := timelineItemWithStructured(t, srv, ws,
+			`[{"summary":"first idless","created_at":"2026-04-02T10:00:00Z","created_by":"user"},
+			  {"summary":"second idless","created_at":"2026-04-02T11:00:00Z","created_by":"user"}]`, "")
+
+		resp := fetchTimeline(t, srv, ws, item.Slug, "")
+		seen := map[string]bool{}
+		notes := 0
+		for _, e := range resp.Entries {
+			if e.Kind != "note" {
+				continue
+			}
+			notes++
+			if e.ID == "" {
+				t.Error("id-less note produced a blank timeline entry id — the sort " +
+					"tie-breaker and the paging cursor both key on it")
+			}
+			if seen[e.ID] {
+				t.Errorf("two notes collided on timeline entry id %q", e.ID)
+			}
+			seen[e.ID] = true
+		}
+		if notes != 2 {
+			t.Errorf("expected both id-less notes, got %d", notes)
+		}
+	})
+
+	t.Run("non-array field contributes nothing and does not break the timeline", func(t *testing.T) {
+		srv := testServer(t)
+		ws := createTestWorkspaceViaAPI(t, srv)
+		// A JSON-encoded string holding the array, i.e. double-encoded —
+		// the exact live shape found on one docapp item (BUG-2627).
+		doubled, err := json.Marshal(`[{"id":"note-1","summary":"invisible","created_at":"2026-04-02T10:00:00Z"}]`)
+		if err != nil {
+			t.Fatalf("marshal doubled payload: %v", err)
+		}
+		item := timelineItemWithStructured(t, srv, ws, string(doubled), "")
+
+		resp := fetchTimeline(t, srv, ws, item.Slug, "")
+		if n := kindsOf(resp.Entries)["note"]; n != 0 {
+			t.Errorf("double-encoded implementation_notes produced %d note entries, want 0", n)
+		}
+	})
+}
+
+// An item with neither field must produce exactly the timeline it produced
+// before this change — the control leg for "the new sources are additive".
+func TestItemTimeline_NoStructuredEntriesIsUnchanged(t *testing.T) {
+	srv := testServer(t)
+	ws := createTestWorkspaceViaAPI(t, srv)
+	item := timelineItemWithStructured(t, srv, ws, "", "")
+
+	resp := fetchTimeline(t, srv, ws, item.Slug, "")
+	counts := kindsOf(resp.Entries)
+	if counts["note"] != 0 || counts["decision"] != 0 {
+		t.Errorf("item with no structured fields produced %d notes / %d decisions",
+			counts["note"], counts["decision"])
+	}
+	if len(resp.Entries) == 0 {
+		t.Error("expected the pre-existing kinds (creation activity/version) to still be there")
+	}
+}
+
+// Unit-level coverage of the cursor predicate itself, including the nil-item
+// guard the handler can't reach but callers could.
+func TestStructuredTimelineEntries_CursorPredicate(t *testing.T) {
+	at := func(s string) time.Time {
+		ts, err := time.Parse(time.RFC3339, s)
+		if err != nil {
+			t.Fatalf("parse %q: %v", s, err)
+		}
+		return ts
+	}
+
+	item := &models.Item{
+		CreatedAt: at("2026-04-01T00:00:00Z"),
+		ImplementationNotes: []models.ItemImplementationNote{
+			{ID: "note-1", Summary: "older", CreatedAt: "2026-04-02T10:00:00Z"},
+			{ID: "note-2", Summary: "newer", CreatedAt: "2026-04-02T12:00:00Z"},
+		},
+		DecisionLog: []models.ItemDecisionLogEntry{
+			{ID: "decision-1", Decision: "mid", CreatedAt: "2026-04-02T11:00:00Z"},
+		},
+	}
+
+	t.Run("first page keeps everything older than now", func(t *testing.T) {
+		notes, decisions := structuredTimelineEntries(item, at("2026-05-01T00:00:00Z"), "")
+		if len(notes) != 2 || len(decisions) != 1 {
+			t.Fatalf("got %d notes / %d decisions, want 2 / 1", len(notes), len(decisions))
+		}
+	})
+
+	t.Run("cursor drops everything at or newer than it", func(t *testing.T) {
+		notes, decisions := structuredTimelineEntries(item, at("2026-04-02T11:00:00Z"), "")
+		if len(notes) != 1 || notes[0].ID != "note-1" {
+			t.Errorf("notes = %+v, want only note-1", notes)
+		}
+		if len(decisions) != 0 {
+			t.Errorf("decision at exactly the cursor with no before_id should be excluded, got %+v", decisions)
+		}
+	})
+
+	t.Run("nil item is not a panic", func(t *testing.T) {
+		notes, decisions := structuredTimelineEntries(nil, at("2026-05-01T00:00:00Z"), "")
+		if notes != nil || decisions != nil {
+			t.Errorf("nil item returned %v / %v", notes, decisions)
+		}
+	})
+}

--- a/internal/server/handlers_timeline_structured_test.go
+++ b/internal/server/handlers_timeline_structured_test.go
@@ -381,6 +381,17 @@ func assertEachEntryOnce(t *testing.T, seen []string, want ...string) {
 			t.Errorf("%q appeared %d times across the paged walk (saw %v)", id, counts[id], seen)
 		}
 	}
+	// The named ids are the ones this change introduces, but the invariant is
+	// about the whole feed: the structured entries are interleaved with the
+	// SQL-sourced ones, so a boundary this filter resolves differently from
+	// the SQL predicate would repeat a COMMENT or a VERSION, not a note.
+	// Checking only the named ids would miss exactly that.
+	for id, n := range counts {
+		if n > 1 {
+			t.Errorf("entry %q appeared %d times across the paged walk — some entry "+
+				"repeats across a page boundary (saw %v)", id, n, seen)
+		}
+	}
 }
 
 // The structured entries are filtered in Go against a parsed time, while the
@@ -417,6 +428,104 @@ func TestItemTimeline_StructuredPagingIsExactlyOnce(t *testing.T) {
 	})
 }
 
+// Codex round 2, finding 2. When a client sends `before` WITHOUT `before_id`,
+// the handler substitutes the sentinel "g" — an upper bound whose whole job is
+// to keep same-second entries rather than drop them, and which does that job
+// only because every lowercase-hex UUID character sorts below "g". Structured
+// ids are not UUIDs: `note-…` sorts above "g" and `decision-…` below it, so
+// comparing against the sentinel literally would drop every note at the cursor
+// instant while keeping every decision — an arbitrary split with no rationale.
+func TestItemTimeline_StructuredSentinelCursorKeepsBothKinds(t *testing.T) {
+	srv := testServer(t)
+	ws := createTestWorkspaceViaAPI(t, srv)
+
+	// Both entries sit at EXACTLY the cursor instant, which is the only case
+	// the sentinel decides.
+	item := timelineItemWithStructured(t, srv, ws,
+		`[{"id":"note-1","summary":"at the cursor","created_at":"2026-04-02T10:00:00Z","created_by":"user"}]`,
+		`[{"id":"decision-1","decision":"also at the cursor","created_at":"2026-04-02T10:00:00Z","created_by":"user"}]`)
+
+	resp := fetchTimeline(t, srv, ws, item.Slug, "before=2026-04-02T10:00:00Z")
+	counts := kindsOf(resp.Entries)
+	if counts["note"] != 1 || counts["decision"] != 1 {
+		t.Fatalf("sentinel cursor kept %d notes / %d decisions, want 1 / 1 — comparing "+
+			"structured ids against the \"g\" sentinel splits the kinds on their "+
+			"first letter", counts["note"], counts["decision"])
+	}
+}
+
+// Codex round 2, finding 1. The SQL sources format the cursor to whole-second
+// RFC3339 text before comparing; a structured entry can carry sub-second
+// precision (a hand-written created_at, or the item's createdAt standing in
+// for an absent one). Comparing full-precision Go times against a truncated
+// SQL cursor is two different predicates on one page boundary.
+func TestItemTimeline_StructuredCursorMatchesSQLTruncation(t *testing.T) {
+	srv := testServer(t)
+	ws := createTestWorkspaceViaAPI(t, srv)
+
+	// Sub-second timestamp inside the cursor's second.
+	item := timelineItemWithStructured(t, srv, ws,
+		`[{"id":"note-frac","summary":"sub-second","created_at":"2026-04-02T10:00:00.500Z","created_by":"user"}]`, "")
+
+	// A cursor at the same whole second, with a real before_id above the
+	// note's id so the id predicate would keep it. Under whole-second
+	// comparison — what the SQL sources do — the entry is AT the cursor
+	// second, so the id decides and it is kept.
+	resp := fetchTimeline(t, srv, ws, item.Slug,
+		"before=2026-04-02T10:00:00Z&before_id=zzz")
+	if n := kindsOf(resp.Entries)["note"]; n != 1 {
+		t.Fatalf("sub-second note at the cursor second: got %d note entries, want 1 — "+
+			"the Go filter must compare in the same whole-second text space the "+
+			"SQL sources do", n)
+	}
+
+	// The mirror: a cursor one second earlier excludes it under either
+	// reading, so this leg fails if the filter simply stopped filtering.
+	resp = fetchTimeline(t, srv, ws, item.Slug,
+		"before=2026-04-02T09:59:59Z&before_id=zzz")
+	if n := kindsOf(resp.Entries)["note"]; n != 0 {
+		t.Fatalf("note newer than the cursor was returned (%d) — the control leg for "+
+			"the truncation assertion above", n)
+	}
+}
+
+// Codex round 2, finding 3. Nothing validates ids on write, so a hand-written
+// fields blob can repeat one. A duplicate is not cosmetic: it collides in the
+// client's keyed {#each} (a hard render error in Svelte 5), the client's
+// loadMore dedupes by id and would drop the older entry, and the cursor cannot
+// page past two entries it cannot tell apart.
+func TestItemTimeline_StructuredDuplicateIDsAreDisambiguated(t *testing.T) {
+	srv := testServer(t)
+	ws := createTestWorkspaceViaAPI(t, srv)
+
+	item := timelineItemWithStructured(t, srv, ws,
+		`[{"id":"dup","summary":"first","created_at":"2026-04-02T10:00:00Z","created_by":"user"},
+		  {"id":"dup","summary":"second","created_at":"2026-04-02T11:00:00Z","created_by":"user"}]`,
+		// Same id again on the OTHER kind — they share one merged stream, so a
+		// cross-kind collision breaks the client exactly as a within-kind one does.
+		`[{"id":"dup","decision":"third","created_at":"2026-04-02T12:00:00Z","created_by":"user"}]`)
+
+	resp := fetchTimeline(t, srv, ws, item.Slug, "")
+	seen := map[string]int{}
+	structured := 0
+	for _, e := range resp.Entries {
+		if e.Kind != "note" && e.Kind != "decision" {
+			continue
+		}
+		structured++
+		seen[e.ID]++
+	}
+	if structured != 3 {
+		t.Fatalf("got %d structured entries, want all 3 — a duplicate id must not "+
+			"cost an entry", structured)
+	}
+	for id, n := range seen {
+		if n > 1 {
+			t.Errorf("entry id %q was emitted %d times; ids must be unique within a page", id, n)
+		}
+	}
+}
+
 // Unit-level coverage of the cursor predicate itself, including the nil-item
 // guard the handler can't reach but callers could.
 func TestStructuredTimelineEntries_CursorPredicate(t *testing.T) {
@@ -440,14 +549,14 @@ func TestStructuredTimelineEntries_CursorPredicate(t *testing.T) {
 	}
 
 	t.Run("first page keeps everything older than now", func(t *testing.T) {
-		notes, decisions := structuredTimelineEntries(item, at("2026-05-01T00:00:00Z"), "")
+		notes, decisions := structuredTimelineEntries(item, at("2026-05-01T00:00:00Z"), "", false)
 		if len(notes) != 2 || len(decisions) != 1 {
 			t.Fatalf("got %d notes / %d decisions, want 2 / 1", len(notes), len(decisions))
 		}
 	})
 
 	t.Run("cursor drops everything at or newer than it", func(t *testing.T) {
-		notes, decisions := structuredTimelineEntries(item, at("2026-04-02T11:00:00Z"), "")
+		notes, decisions := structuredTimelineEntries(item, at("2026-04-02T11:00:00Z"), "", false)
 		if len(notes) != 1 || notes[0].ID != "note-1" {
 			t.Errorf("notes = %+v, want only note-1", notes)
 		}
@@ -457,7 +566,7 @@ func TestStructuredTimelineEntries_CursorPredicate(t *testing.T) {
 	})
 
 	t.Run("nil item is not a panic", func(t *testing.T) {
-		notes, decisions := structuredTimelineEntries(nil, at("2026-05-01T00:00:00Z"), "")
+		notes, decisions := structuredTimelineEntries(nil, at("2026-05-01T00:00:00Z"), "", false)
 		if notes != nil || decisions != nil {
 			t.Errorf("nil item returned %v / %v", notes, decisions)
 		}

--- a/internal/server/handlers_timeline_structured_test.go
+++ b/internal/server/handlers_timeline_structured_test.go
@@ -487,6 +487,45 @@ func TestItemTimeline_StructuredCursorMatchesSQLTruncation(t *testing.T) {
 		t.Fatalf("note newer than the cursor was returned (%d) — the control leg for "+
 			"the truncation assertion above", n)
 	}
+
+	// The entry's OWN timestamp must land in the shared whole-second space
+	// too, not just the comparison. The client echoes this value back as the
+	// next page's `before`, where the store formats it down to the second: a
+	// cursor of 10:00:00.5 becomes 10:00:00Z and excludes same-second rows
+	// that were still owed. It is also what the merge sorts on.
+	resp = fetchTimeline(t, srv, ws, item.Slug, "")
+	var found bool
+	for _, e := range resp.Entries {
+		if e.ID != "note-frac" {
+			continue
+		}
+		found = true
+		if e.CreatedAt.Nanosecond() != 0 {
+			t.Errorf("structured entry created_at = %s, want whole seconds — the client "+
+				"echoes this back as the next cursor and the store truncates it there",
+				e.CreatedAt.Format(time.RFC3339Nano))
+		}
+	}
+	if !found {
+		t.Fatal("note-frac missing from the unfiltered page")
+	}
+}
+
+// The consequence of a fractional structured timestamp, driven end to end: the
+// entry sits at a page boundary and the client pages on its created_at. If
+// that value carries sub-second precision the store truncates it, and a
+// same-second COMMENT that was still owed is skipped — data loss in a source
+// this change never touches.
+func TestItemTimeline_FractionalStructuredEntryDoesNotSkipSameSecondRows(t *testing.T) {
+	srv := testServer(t)
+	ws := createTestWorkspaceViaAPI(t, srv)
+
+	item := timelineItemWithStructured(t, srv, ws,
+		`[{"id":"note-frac","summary":"boundary","created_at":"2026-04-02T10:00:00.500Z","created_by":"user"},
+		  {"id":"note-older","summary":"older","created_at":"2026-04-02T09:00:00Z","created_by":"user"}]`, "")
+
+	seen := walkTimelinePages(t, srv, ws, item.Slug)
+	assertEachEntryOnce(t, seen, "note-frac", "note-older")
 }
 
 // Codex round 2, finding 3. Nothing validates ids on write, so a hand-written

--- a/internal/server/handlers_timeline_structured_test.go
+++ b/internal/server/handlers_timeline_structured_test.go
@@ -222,7 +222,7 @@ func TestItemTimeline_StructuredCursorTieBreaksOnID(t *testing.T) {
 // rather than an array (BUG-2627) — which must contribute nothing rather than
 // erroring the whole timeline.
 func TestItemTimeline_StructuredEntriesTolerateHostileShapes(t *testing.T) {
-	t.Run("missing created_at anchors at the item, not 1970", func(t *testing.T) {
+	t.Run("missing created_at anchors at the item, not the zero time", func(t *testing.T) {
 		srv := testServer(t)
 		ws := createTestWorkspaceViaAPI(t, srv)
 		item := timelineItemWithStructured(t, srv, ws,
@@ -239,8 +239,8 @@ func TestItemTimeline_StructuredEntriesTolerateHostileShapes(t *testing.T) {
 			t.Fatal("undated note dropped from the timeline entirely")
 		}
 		if found.CreatedAt.Year() < 2000 {
-			t.Errorf("undated note anchored at %s — a zero-time fallback renders as 1970 "+
-				"and sorts below every real entry", found.CreatedAt)
+			t.Errorf("undated note anchored at %s — a zero-time fallback dates the entry "+
+				"to year 1 and sorts it below every real entry", found.CreatedAt)
 		}
 		if !found.CreatedAt.Equal(item.CreatedAt.UTC()) {
 			t.Errorf("undated note anchored at %s, want the item's own created_at %s",
@@ -516,16 +516,63 @@ func TestItemTimeline_StructuredCursorMatchesSQLTruncation(t *testing.T) {
 // that value carries sub-second precision the store truncates it, and a
 // same-second COMMENT that was still owed is skipped — data loss in a source
 // this change never touches.
+//
+// Two fixture choices are load-bearing, and the test is vacuous without both.
+//
+// The comment must be REAL and share the note's second: a walk over structured
+// entries alone stays green with the truncation removed, because nothing in it
+// crosses the Go/SQL boundary. So a comment is created first and its
+// server-stamped second is read back.
+//
+// The note's ID must sort BELOW every UUID — hence `0-frac` rather than a
+// realistic `note-<nanos>`. The cursor's second term is the id, and the SQL
+// sources keep same-second rows with `id < before_id`. A `note-…` id sorts
+// above every lowercase-hex UUID, so the sibling row survives the truncated
+// cursor no matter what, and the test passes on broken code. That is exactly
+// how the first version of this test read: correct-looking, and unable to fail.
+// With an id below the UUID space, a cursor that keeps sub-second precision
+// drops the same-second comment for real.
 func TestItemTimeline_FractionalStructuredEntryDoesNotSkipSameSecondRows(t *testing.T) {
 	srv := testServer(t)
 	ws := createTestWorkspaceViaAPI(t, srv)
 
-	item := timelineItemWithStructured(t, srv, ws,
-		`[{"id":"note-frac","summary":"boundary","created_at":"2026-04-02T10:00:00.500Z","created_by":"user"},
-		  {"id":"note-older","summary":"older","created_at":"2026-04-02T09:00:00Z","created_by":"user"}]`, "")
+	item := timelineItemWithStructured(t, srv, ws, "", "")
+
+	rr := doRequest(srv, "POST",
+		"/api/v1/workspaces/"+ws+"/items/"+item.Slug+"/comments",
+		map[string]any{"body": "same-second sibling", "author": "alice", "source": "web"})
+	if rr.Code != http.StatusCreated && rr.Code != http.StatusOK {
+		t.Fatalf("create comment = %d: %s", rr.Code, rr.Body.String())
+	}
+
+	// Read the comment's server-stamped second back out of the feed.
+	var commentID string
+	var commentSecond time.Time
+	for _, e := range fetchTimeline(t, srv, ws, item.Slug, "").Entries {
+		if e.Kind == "comment" {
+			commentID = e.ID
+			commentSecond = e.CreatedAt.UTC().Truncate(time.Second)
+		}
+	}
+	if commentID == "" {
+		t.Fatal("no comment entry in the feed — the fixture never armed")
+	}
+
+	// Plant the note half a second INTO the comment's second, so the note
+	// sorts above the comment and becomes the page boundary the client pages
+	// from. A cursor carrying that .5 truncates to the comment's own second
+	// and excludes it.
+	notesJSON := `[{"id":"0-frac","summary":"boundary","created_at":"` +
+		commentSecond.Add(500*time.Millisecond).Format(time.RFC3339Nano) +
+		`","created_by":"user"}]`
+	rr = doRequest(srv, "PATCH", "/api/v1/workspaces/"+ws+"/items/"+item.Slug,
+		map[string]any{"fields": `{"status":"open","implementation_notes":` + notesJSON + `}`, "source": "cli"})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("patch notes = %d: %s", rr.Code, rr.Body.String())
+	}
 
 	seen := walkTimelinePages(t, srv, ws, item.Slug)
-	assertEachEntryOnce(t, seen, "note-frac", "note-older")
+	assertEachEntryOnce(t, seen, "0-frac", commentID)
 }
 
 // Codex round 2, finding 3. Nothing validates ids on write, so a hand-written

--- a/internal/server/handlers_timeline_structured_test.go
+++ b/internal/server/handlers_timeline_structured_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/PerpetualSoftware/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/store"
 )
 
 // BUG-2301: `pad item note` / `pad item decide` wrote structured entries that
@@ -331,6 +332,89 @@ func TestItemTimeline_NoStructuredEntriesIsUnchanged(t *testing.T) {
 	if len(resp.Entries) == 0 {
 		t.Error("expected the pre-existing kinds (creation activity/version) to still be there")
 	}
+}
+
+// walkTimelinePages pages the whole feed one entry at a time, following the
+// (created_at, before_id) cursor exactly as the web client does, and returns
+// the ids it saw in order.
+//
+// This is the end-to-end statement about the structured filter: every entry
+// must appear EXACTLY once across the full walk. A too-loose predicate repeats
+// the in-blob entries on every page; a too-tight one drops them at a boundary.
+// Neither is visible from a single-page assertion.
+func walkTimelinePages(t *testing.T, srv *Server, wsSlug, itemSlug string) []string {
+	t.Helper()
+	var seen []string
+	query := "limit=1"
+	for range 40 { // bounded: the fixtures below are far smaller
+		resp := fetchTimeline(t, srv, wsSlug, itemSlug, query)
+		if len(resp.Entries) == 0 {
+			return seen
+		}
+		last := resp.Entries[len(resp.Entries)-1]
+		for _, e := range resp.Entries {
+			seen = append(seen, e.ID)
+		}
+		if !resp.HasMore {
+			return seen
+		}
+		query = "limit=1&before=" + last.CreatedAt.UTC().Format(time.RFC3339Nano) +
+			"&before_id=" + last.ID
+	}
+	t.Fatal("timeline paging did not terminate within 40 pages — a cursor that " +
+		"fails to advance repeats a page forever")
+	return nil
+}
+
+func assertEachEntryOnce(t *testing.T, seen []string, want ...string) {
+	t.Helper()
+	counts := map[string]int{}
+	for _, id := range seen {
+		counts[id]++
+	}
+	for _, id := range want {
+		switch counts[id] {
+		case 1: // exactly once, as required
+		case 0:
+			t.Errorf("%q never appeared across the paged walk (saw %v)", id, seen)
+		default:
+			t.Errorf("%q appeared %d times across the paged walk (saw %v)", id, counts[id], seen)
+		}
+	}
+}
+
+// The structured entries are filtered in Go against a parsed time, while the
+// comment/activity/version sources are filtered in SQL against a FORMATTED
+// STRING. That is a real seam between two comparison semantics, and the
+// timeline endpoint has a Postgres-specific paging history (BUG-1086), so the
+// paging invariant is asserted on both drivers rather than assumed portable.
+func TestItemTimeline_StructuredPagingIsExactlyOnce(t *testing.T) {
+	run := func(t *testing.T, srv *Server, wsSlug string) {
+		t.Helper()
+		item := timelineItemWithStructured(t, srv, wsSlug,
+			`[{"id":"note-1","summary":"n1","created_at":"2026-04-02T10:00:00Z","created_by":"user"},
+			  {"id":"note-2","summary":"n2","created_at":"2026-04-02T12:00:00Z","created_by":"user"}]`,
+			`[{"id":"decision-1","decision":"d1","created_at":"2026-04-02T11:00:00Z","created_by":"user"}]`)
+
+		seen := walkTimelinePages(t, srv, wsSlug, item.Slug)
+		assertEachEntryOnce(t, seen, "note-1", "note-2", "decision-1")
+	}
+
+	t.Run("sqlite", func(t *testing.T) {
+		srv := testServer(t)
+		run(t, srv, createTestWorkspaceViaAPI(t, srv))
+	})
+
+	t.Run("postgres", func(t *testing.T) {
+		// Skips unless PAD_TEST_POSTGRES_URL is set (make test-pg).
+		srv, _ := testServerPostgres(t)
+		// Assert the driver rather than trusting the helper: without this the
+		// leg would silently re-run the SQLite case and report a PG pass.
+		if got := srv.store.D().Driver(); got != store.DriverPostgres {
+			t.Fatalf("expected a Postgres store, got %s", got)
+		}
+		run(t, srv, createTestWorkspaceViaAPI(t, srv))
+	})
 }
 
 // Unit-level coverage of the cursor predicate itself, including the nil-item

--- a/skills/pad/SKILL.md
+++ b/skills/pad/SKILL.md
@@ -193,10 +193,14 @@ pad item delete TASK-5
 pad item search "query"
 pad item comment TASK-5 "..." [--reply-to <comment-id>]
 pad item comments TASK-5
+pad item note TASK-5 "what you did" [--details "..." | --stdin]
+pad item decide TASK-5 "what you chose" [--rationale "..." | --stdin]
 pad item bulk-update --status X TASK-5 TASK-8 ...
 ```
 
 `--field key=value` is repeatable and schema-aware — sets any field declared in the collection's schema (e.g. `--field trigger=always --field priority=must` for a convention; `--field 'arguments=[...]'` JSON literal for a playbook). `--comment "..."` on update writes an audit note explaining *why* status changed.
+
+`note` and `decide` append structured entries to the item — an implementation note (what you did) and a decision-log entry (what you chose, and why). They differ from a comment: a comment is addressed to a person, these are addressed to the record, and they carry no reply or reaction affordances. Both show up in the item's Activity timeline in the web UI alongside comments and versions, and in `pad item show`. Reach for `decide` when a choice would otherwise only survive in a chat log.
 
 ### Dependencies
 ```bash

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -5925,7 +5925,14 @@
 			     different: it REST-writes this item's `items.content` directly (not via
 			     the Y.Doc applier), so on a peeking side whose Y.Doc is retained-alive a
 			     later collab flush could overwrite it — a same-item collision. So it
-			     stays frozen: `restoreFrozen={peeking}` (Codex P1). -->
+			     stays frozen: `restoreFrozen={peeking}` (Codex P1).
+
+			     `note` / `decision` in visibleKinds below are the structured entries
+			     `pad item note` / `pad item decide` write into the item's fields blob.
+			     They belong to Activity, not Versions — things that happened to the
+			     record, not restore points. That whitelist is the ONLY gate on them:
+			     omitting them there renders them on NEITHER tab, which is exactly how
+			     the feature shipped invisible the first time (BUG-2301). -->
 			<ItemTimeline
 				{wsSlug}
 				{username}
@@ -5940,7 +5947,9 @@
 				frozen={false}
 				restoreFrozen={peeking}
 				parentArchived={itemMatchesRef && isArchived}
-				visibleKinds={activeTab === 'versions' ? ['version'] : ['comment', 'activity']}
+				visibleKinds={activeTab === 'versions'
+					? ['version']
+					: ['comment', 'activity', 'note', 'decision']}
 			/>
 		</div>
 		</div><!-- /tab-panel Activity/Versions -->

--- a/web/src/lib/components/timeline/ItemTimeline.svelte
+++ b/web/src/lib/components/timeline/ItemTimeline.svelte
@@ -8,6 +8,7 @@
 	import TimelineCommentCard from './TimelineCommentCard.svelte';
 	import TimelineActivityCard from './TimelineActivityCard.svelte';
 	import TimelineVersionCard from './TimelineVersionCard.svelte';
+	import TimelineStructuredCard from './TimelineStructuredCard.svelte';
 	import { attachmentRefsIn } from '$lib/utils/commentAttachments';
 	import {
 		fetchAttachmentMetadata,
@@ -52,7 +53,7 @@
 		 * Which entry kinds render (undefined = all). Filter-only: the merged
 		 * feed still fetches every kind, so switching kinds never refetches.
 		 */
-		visibleKinds?: Array<'comment' | 'activity' | 'version'>;
+		visibleKinds?: Array<'comment' | 'activity' | 'version' | 'note' | 'decision'>;
 		/**
 		 * `frozen` freezes the COMMENT/REACTION surfaces (composer, reply, edit,
 		 * delete, reaction). These are per-item / per-user REST entities, so under
@@ -893,6 +894,8 @@
 	function dotClass(kind: TimelineEntry['kind']): string {
 		if (kind === 'comment') return 'dot-comment';
 		if (kind === 'version') return 'dot-version';
+		if (kind === 'note') return 'dot-note';
+		if (kind === 'decision') return 'dot-decision';
 		return 'dot-activity';
 	}
 </script>
@@ -976,6 +979,20 @@
 								{onRestore}
 								{flushBeforeRestore}
 								frozen={frozen || restoreFrozen}
+							/>
+						{:else if entry.kind === 'note' && entry.note}
+							<TimelineStructuredCard
+								kind="note"
+								note={entry.note}
+								actor={entry.actor}
+								createdAt={entry.created_at}
+							/>
+						{:else if entry.kind === 'decision' && entry.decision}
+							<TimelineStructuredCard
+								kind="decision"
+								decision={entry.decision}
+								actor={entry.actor}
+								createdAt={entry.created_at}
 							/>
 						{/if}
 					</div>
@@ -1123,6 +1140,14 @@
 
 	.dot-version {
 		background: var(--accent-green);
+	}
+
+	.dot-note {
+		background: var(--accent-cyan);
+	}
+
+	.dot-decision {
+		background: var(--accent-orange);
 	}
 
 	.line {

--- a/web/src/lib/components/timeline/ItemTimeline.svelte
+++ b/web/src/lib/components/timeline/ItemTimeline.svelte
@@ -696,6 +696,16 @@
 	// Content saves create version-diff entries that appear on next natural
 	// refresh (new comment, page load). Refreshing on every content save caused
 	// visible shakiness and rate-limit errors from rapid SSE replay.
+	//
+	// The `note` / `decision` kinds (BUG-2301) inherit this deliberately. They
+	// are written by `pad item note` / `pad item decide`, which PATCH the item
+	// and so emit `item_updated` — an open Activity tab will not show a new one
+	// until the next natural refresh. That is the same staleness version
+	// entries have always had, and these kinds have no web writer at all, so no
+	// user performs the action and then waits on this view. Flagged twice in
+	// review and declined twice: admitting `item_updated` here would trade a
+	// bounded, documented staleness for the shakiness and rate-limit errors
+	// this exclusion exists to prevent.
 	const relevantEvents = new Set([
 		'comment_created',
 		'comment_updated',

--- a/web/src/lib/components/timeline/ItemTimeline.svelte
+++ b/web/src/lib/components/timeline/ItemTimeline.svelte
@@ -980,14 +980,18 @@
 								{flushBeforeRestore}
 								frozen={frozen || restoreFrozen}
 							/>
-						{:else if entry.kind === 'note' && entry.note}
+						<!-- No `&& entry.note` guard, unlike the kinds above: the card is
+						     null-safe, and a payload-less entry still occupies a rail. Requiring
+						     the payload turns a partial entry into a blank rail with no card at
+						     all, which reads as a rendering fault rather than as a thin entry. -->
+						{:else if entry.kind === 'note'}
 							<TimelineStructuredCard
 								kind="note"
 								note={entry.note}
 								actor={entry.actor}
 								createdAt={entry.created_at}
 							/>
-						{:else if entry.kind === 'decision' && entry.decision}
+						{:else if entry.kind === 'decision'}
 							<TimelineStructuredCard
 								kind="decision"
 								decision={entry.decision}

--- a/web/src/lib/components/timeline/TimelineStructuredCard.svelte
+++ b/web/src/lib/components/timeline/TimelineStructuredCard.svelte
@@ -1,0 +1,120 @@
+<script lang="ts">
+	import type { ItemImplementationNote, ItemDecisionLogEntry } from '$lib/types';
+	import { relativeTime } from '$lib/utils/markdown';
+	import Chip from '$lib/components/common/Chip.svelte';
+
+	// One card for both structured kinds (BUG-2301). They share a shape —
+	// headline + optional body + actor + timestamp — and differ only in
+	// label, accent and weight, so a variant keeps them from drifting apart
+	// the way two near-identical components would.
+	let {
+		kind,
+		note,
+		decision,
+		actor,
+		createdAt
+	}: {
+		kind: 'note' | 'decision';
+		note?: ItemImplementationNote;
+		decision?: ItemDecisionLogEntry;
+		actor: string;
+		createdAt: string;
+	} = $props();
+
+	const headline = $derived(kind === 'note' ? (note?.summary ?? '') : (decision?.decision ?? ''));
+	const body = $derived(kind === 'note' ? (note?.details ?? '') : (decision?.rationale ?? ''));
+	const label = $derived(kind === 'note' ? 'Note' : 'Decision');
+
+	// `actor` is self-declared by whichever client wrote the entry — it lives
+	// inside the item's fields blob and the server never stamps it (BUG-2542).
+	// Older entries predate that fix and claim "user" regardless of who wrote
+	// them, so this labels the claim, not a verified author.
+	const actorLabel = $derived(actor === 'agent' ? 'Agent' : actor === 'user' ? 'User' : actor);
+</script>
+
+<div class="card" class:decision={kind === 'decision'}>
+	<div class="row">
+		<Chip size="sm" color={kind === 'decision' ? 'var(--accent-orange)' : 'var(--accent-cyan)'}
+			>{label}</Chip
+		>
+		{#if actorLabel}
+			<span class="actor">{actorLabel}</span>
+		{/if}
+		<span class="spacer"></span>
+		<span class="timestamp" title={new Date(createdAt).toLocaleString()}
+			>{relativeTime(createdAt)}</span
+		>
+	</div>
+	{#if headline}
+		<p class="headline">{headline}</p>
+	{/if}
+	{#if body}
+		<p class="body">{body}</p>
+	{/if}
+</div>
+
+<style>
+	.card {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-1);
+		padding: var(--space-2) var(--space-3);
+		background: var(--bg-secondary);
+		border: 1px solid var(--border);
+		border-left: 3px solid var(--accent-cyan);
+		border-radius: var(--radius);
+	}
+
+	/* A decision log is the thing you go back looking for; it earns more
+	   weight than a note, per the BUG-2301 design note. */
+	.card.decision {
+		border-left-color: var(--accent-orange);
+		background: var(--bg-tertiary);
+	}
+
+	.row {
+		display: flex;
+		align-items: center;
+		gap: var(--space-2);
+		flex-wrap: wrap;
+		min-width: 0;
+	}
+
+	.actor {
+		font-size: 0.85em;
+		color: var(--text-muted);
+	}
+
+	.spacer {
+		flex: 1;
+	}
+
+	.timestamp {
+		font-size: 0.8em;
+		color: var(--text-muted);
+		white-space: nowrap;
+	}
+
+	.headline {
+		margin: 0;
+		font-size: 0.9em;
+		color: var(--text-primary);
+		/* Entries are written as plain text by `pad item note` / `pad item
+		   decide` — no markdown pass — so preserve the author's line breaks
+		   rather than reflowing them. */
+		white-space: pre-wrap;
+		overflow-wrap: anywhere;
+	}
+
+	.card.decision .headline {
+		font-weight: 600;
+	}
+
+	.body {
+		margin: 0;
+		font-size: 0.85em;
+		color: var(--text-muted);
+		white-space: pre-wrap;
+		overflow-wrap: anywhere;
+	}
+</style>

--- a/web/src/lib/components/timeline/timelineStructuredEntries.svelte.test.ts
+++ b/web/src/lib/components/timeline/timelineStructuredEntries.svelte.test.ts
@@ -1,0 +1,273 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { flushSync, mount, unmount, tick } from 'svelte';
+import type { TimelineEntry, TimelineResponse } from '$lib/types';
+
+/**
+ * BUG-2301 — implementation notes and decision-log entries render in the item
+ * timeline.
+ *
+ * The regression these guard against is a rendering hole with two independent
+ * halves, either of which alone makes the feature invisible:
+ *
+ *   1. `ItemTimeline` has no branch for the `note` / `decision` kinds, so the
+ *      entry falls through the {#if} chain and renders an empty rail.
+ *   2. `visibleKinds` — a WHITELIST — omits them, so they never reach the
+ *      render at all. This is how the original renderer's replacement would
+ *      have shipped dead: the server can merge them perfectly and the tab
+ *      still shows nothing.
+ *
+ * Half 2 is covered here rather than only in ItemDetail because the filter
+ * lives on this component; the ItemDetail call site is asserted separately.
+ */
+
+const timelineListMock = vi.fn<(ws: string, slug: string) => Promise<TimelineResponse>>();
+
+vi.mock('$lib/api/client', () => ({
+	api: {
+		timeline: {
+			list: (ws: string, slug: string) => timelineListMock(ws, slug),
+		},
+		comments: {
+			create: vi.fn(),
+			update: vi.fn(),
+			delete: vi.fn(),
+			addReaction: vi.fn(),
+			removeReaction: vi.fn(),
+		},
+		attachments: {
+			downloadUrl: (ws: string, id: string) => `/api/v1/workspaces/${ws}/attachments/${id}`,
+		},
+	},
+}));
+
+vi.mock('$lib/services/sse.svelte', () => ({
+	sseService: {
+		onItemEvent: () => () => {},
+	},
+}));
+
+vi.mock('$lib/stores/auth.svelte', () => ({
+	authStore: { userId: 'user-1', user: { id: 'user-1', role: 'member' } },
+}));
+
+vi.mock('$lib/stores/workspace.svelte', () => ({
+	workspaceStore: { canEditItem: () => false },
+}));
+
+vi.mock('$lib/components/editor/attachment-metadata', () => ({
+	fetchAttachmentMetadata: () => Promise.resolve({ status: 'transient' as const }),
+	revalidateAttachmentMetadata: () => Promise.resolve({ status: 'transient' as const }),
+	invalidateAttachmentMetadata: vi.fn(),
+}));
+
+vi.mock('$lib/components/CommentEditor.svelte', async () => ({
+	default: (await import('./fixtures/InertCommentEditor.svelte')).default,
+}));
+
+const { default: ItemTimeline } = await import('./ItemTimeline.svelte');
+
+function noteEntry(overrides: Partial<TimelineEntry> = {}): TimelineEntry {
+	return {
+		id: 'note-1',
+		kind: 'note',
+		created_at: '2026-04-02T10:00:00Z',
+		actor: 'agent',
+		source: 'structured',
+		note: { id: 'note-1', summary: 'ensureWorkspace gained a slug-aware attach path', details: 'Refactored the init command.' },
+		...overrides,
+	};
+}
+
+function decisionEntry(overrides: Partial<TimelineEntry> = {}): TimelineEntry {
+	return {
+		id: 'decision-1',
+		kind: 'decision',
+		created_at: '2026-04-02T11:00:00Z',
+		actor: 'user',
+		source: 'structured',
+		decision: {
+			id: 'decision-1',
+			decision: 'Store notes in reserved field keys',
+			rationale: 'Avoids a new table for the first cut.',
+		},
+		...overrides,
+	};
+}
+
+let host: HTMLElement;
+let app: Record<string, unknown> | null = null;
+
+const props = $state<{
+	wsSlug: string;
+	username: string;
+	itemSlug: string;
+	currentContent: string;
+	itemId: string;
+	collectionId: string;
+	hostToken: string;
+	visibleKinds: Array<'comment' | 'activity' | 'version' | 'note' | 'decision'> | undefined;
+}>({
+	wsSlug: 'ws',
+	username: 'alice',
+	itemSlug: 'TASK-1',
+	currentContent: '',
+	itemId: 'item-a',
+	collectionId: 'coll-1',
+	hostToken: 'host-1',
+	visibleKinds: undefined,
+});
+
+async function settle() {
+	for (let i = 0; i < 8; i++) {
+		await tick();
+		flushSync();
+	}
+}
+
+function cards(): HTMLElement[] {
+	return Array.from(host.querySelectorAll<HTMLElement>('.entry-content > div.card'));
+}
+
+function renderedText(): string {
+	return host.textContent ?? '';
+}
+
+beforeEach(() => {
+	host = document.createElement('div');
+	document.body.appendChild(host);
+	props.visibleKinds = undefined;
+	timelineListMock.mockReset();
+});
+
+afterEach(() => {
+	if (app) {
+		unmount(app);
+		app = null;
+	}
+	host.remove();
+});
+
+describe('structured timeline entries', () => {
+	it('renders a note entry with its summary and details', async () => {
+		timelineListMock.mockResolvedValue({ entries: [noteEntry()], has_more: false });
+		app = mount(ItemTimeline, { target: host, props }) as Record<string, unknown>;
+		await settle();
+
+		const text = renderedText();
+		expect(text).toContain('ensureWorkspace gained a slug-aware attach path');
+		expect(text).toContain('Refactored the init command.');
+		// The kind has to be legible as a note, not indistinguishable from a comment.
+		expect(text).toContain('Note');
+	});
+
+	it('renders a decision entry with its decision and rationale', async () => {
+		timelineListMock.mockResolvedValue({ entries: [decisionEntry()], has_more: false });
+		app = mount(ItemTimeline, { target: host, props }) as Record<string, unknown>;
+		await settle();
+
+		const text = renderedText();
+		expect(text).toContain('Store notes in reserved field keys');
+		expect(text).toContain('Avoids a new table for the first cut.');
+		expect(text).toContain('Decision');
+	});
+
+	it('gives a decision more visual weight than a note', async () => {
+		timelineListMock.mockResolvedValue({
+			entries: [decisionEntry(), noteEntry()],
+			has_more: false,
+		});
+		app = mount(ItemTimeline, { target: host, props }) as Record<string, unknown>;
+		await settle();
+
+		const rendered = cards();
+		expect(rendered).toHaveLength(2);
+		const decisionCard = rendered.find((c) => c.textContent?.includes('Store notes'));
+		const noteCard = rendered.find((c) => c.textContent?.includes('ensureWorkspace'));
+		expect(decisionCard?.classList.contains('decision')).toBe(true);
+		expect(noteCard?.classList.contains('decision')).toBe(false);
+	});
+
+	it('labels the writer, so an agent note is not read as a human one', async () => {
+		timelineListMock.mockResolvedValue({
+			entries: [noteEntry(), decisionEntry()],
+			has_more: false,
+		});
+		app = mount(ItemTimeline, { target: host, props }) as Record<string, unknown>;
+		await settle();
+
+		const rendered = cards();
+		const noteCard = rendered.find((c) => c.textContent?.includes('ensureWorkspace'));
+		const decisionCard = rendered.find((c) => c.textContent?.includes('Store notes'));
+		expect(noteCard?.textContent).toContain('Agent');
+		expect(decisionCard?.textContent).toContain('User');
+	});
+
+	it('renders an entry whose optional body is absent', async () => {
+		timelineListMock.mockResolvedValue({
+			entries: [
+				noteEntry({ note: { id: 'note-1', summary: 'summary only' } }),
+				decisionEntry({ decision: { id: 'decision-1', decision: 'decision only' } }),
+			],
+			has_more: false,
+		});
+		app = mount(ItemTimeline, { target: host, props }) as Record<string, unknown>;
+		await settle();
+
+		expect(renderedText()).toContain('summary only');
+		expect(renderedText()).toContain('decision only');
+		expect(cards()).toHaveLength(2);
+	});
+
+	// The whitelist half of the hole. A kind the filter omits renders nowhere,
+	// no matter how correct the server merge is.
+	it('honours visibleKinds — the Activity set shows them, the Versions set does not', async () => {
+		timelineListMock.mockResolvedValue({
+			entries: [noteEntry(), decisionEntry()],
+			has_more: false,
+		});
+		props.visibleKinds = ['comment', 'activity', 'note', 'decision'];
+		app = mount(ItemTimeline, { target: host, props }) as Record<string, unknown>;
+		await settle();
+		expect(cards()).toHaveLength(2);
+
+		props.visibleKinds = ['version'];
+		await settle();
+		expect(cards()).toHaveLength(0);
+	});
+
+	// The exact configuration that shipped the feature invisible the first
+	// time: server merges the kinds, whitelist predates them.
+	it('a whitelist that predates the kinds hides them entirely', async () => {
+		timelineListMock.mockResolvedValue({
+			entries: [noteEntry(), decisionEntry()],
+			has_more: false,
+		});
+		props.visibleKinds = ['comment', 'activity'];
+		app = mount(ItemTimeline, { target: host, props }) as Record<string, unknown>;
+		await settle();
+		expect(cards()).toHaveLength(0);
+	});
+
+	// Body text is written as plain text by the CLI, never through a markdown
+	// pass, so it must not be interpreted as markup.
+	it('does not interpret entry text as HTML', async () => {
+		timelineListMock.mockResolvedValue({
+			entries: [
+				noteEntry({
+					note: {
+						id: 'note-1',
+						summary: 'a <script>alert(1)</script> summary',
+						details: '<img src=x onerror="alert(2)">',
+					},
+				}),
+			],
+			has_more: false,
+		});
+		app = mount(ItemTimeline, { target: host, props }) as Record<string, unknown>;
+		await settle();
+
+		expect(host.querySelector('script')).toBeNull();
+		expect(host.querySelector('img')).toBeNull();
+		expect(renderedText()).toContain('<script>alert(1)</script>');
+	});
+});

--- a/web/src/lib/components/timeline/timelineStructuredEntries.svelte.test.ts
+++ b/web/src/lib/components/timeline/timelineStructuredEntries.svelte.test.ts
@@ -218,6 +218,27 @@ describe('structured timeline entries', () => {
 		expect(cards()).toHaveLength(2);
 	});
 
+	// A partial entry — kind set, payload missing — must still produce a card.
+	// Guarding the branch on the payload leaves the rail dot and connector
+	// drawn with nothing beside them, which reads as a broken render rather
+	// than as a thin entry.
+	it('renders a card for an entry whose payload is missing entirely', async () => {
+		timelineListMock.mockResolvedValue({
+			entries: [
+				noteEntry({ note: undefined }),
+				decisionEntry({ decision: undefined }),
+			],
+			has_more: false,
+		});
+		app = mount(ItemTimeline, { target: host, props }) as Record<string, unknown>;
+		await settle();
+
+		expect(cards()).toHaveLength(2);
+		// The kind label still identifies what the entry is.
+		expect(renderedText()).toContain('Note');
+		expect(renderedText()).toContain('Decision');
+	});
+
 	// The whitelist half of the hole. A kind the filter omits renders nowhere,
 	// no matter how correct the server merge is.
 	it('honours visibleKinds — the Activity set shows them, the Versions set does not', async () => {

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -1215,7 +1215,7 @@ export interface Reaction {
 
 export interface TimelineEntry {
 	id: string;
-	kind: 'comment' | 'activity' | 'version';
+	kind: 'comment' | 'activity' | 'version' | 'note' | 'decision';
 	created_at: string;
 	actor: string;
 	actor_name?: string;
@@ -1223,6 +1223,13 @@ export interface TimelineEntry {
 	comment?: Comment;
 	activity?: Activity;
 	version?: Version;
+	// `note` / `decision` entries are elements of the item's fields blob that
+	// the server merges into the same paginated stream (BUG-2301). Their
+	// `created_at` is server-normalized: an entry whose stored timestamp is
+	// missing or malformed is anchored at the item's own creation instant, so
+	// this is always a usable date.
+	note?: ItemImplementationNote;
+	decision?: ItemDecisionLogEntry;
 }
 
 export interface TimelineResponse {


### PR DESCRIPTION
Fixes BUG-2301.

`pad item note` and `pad item decide` have written structured entries since `c61f4cda`. `998716ae` deleted their renderer the next day as collateral of the unified-timeline PR, and nothing replaced it — the feature had a UI for one day. The write paths kept working on CLI and MCP, so entries kept accumulating with no read surface outside `pad item show`: **185 notes and 33 decisions across 7 workspaces**, measured against a copy of the live DB, written by people and agents who found the commands unaided.

## Shape

Two more timeline **kinds**, merged server-side, rather than a separate renderer. The endpoint already merges comments, activities and versions under cursor pagination, and these carry the same timestamp/actor/body shape.

They differ from the other three in one way that drove most of the review: they are elements of the item's fields blob, not rows, so they arrive whole on the already-resolved item instead of through a cursor query. Without an explicit filter they would repeat on every page.

**The frontend half is not optional.** `visibleKinds` is a whitelist with one live call site; a kind `ItemDetail` does not list renders on *neither* tab. The server change alone would have shipped this invisible a second time.

The blob is hand-writable, so several shapes are representable that a table would not allow — a missing `created_at` (anchored at the item's own creation instant), a missing id (positional fallback), a value that is not an array at all (contributes nothing), and duplicate ids (disambiguated). One live item is in that third state and is filed separately as BUG-2627.

## Review — 7 Codex rounds

Round 2 found three defects in the cursor path, all real and all mine:

- **The `"g"` sentinel split the kinds on their first letter.** When a client sends `before` without `before_id`, the handler substitutes `"g"` — an upper bound that keeps same-second entries only because every lowercase-hex UUID character sorts below it. `note-…` sorts above and `decision-…` below, so every note at the cursor instant was dropped and every decision kept.
- **Two comparison spaces met on one page boundary.** The SQL sources compare whole-second RFC3339 text; the new filter compared full-precision `time.Time`.
- **Duplicate ids were trusted.** A repeat collides in the client's keyed `{#each}`, and the cursor cannot page past two entries it cannot tell apart.

Round 3 caught that the second fix was incomplete: aligning the *comparison* left the entry's own timestamp full-precision, so the sort and the cursor the client echoes back still diverged — which silently drops same-second **comments and versions**, sources this change never touched. Fixed by truncating where the entry is built.

Round 4 caught a bad test of mine, twice over. The fractional-boundary regression test could not fail: it walked only structured entries, and after adding a real same-second comment it *still* could not fail, because a realistic `note-<nanos>` id sorts above every hex UUID and the cursor's id tie-break rescued the sibling row regardless. It now uses an id below the UUID space and drops the comment outright on unfixed code.

Declined, with reasoning recorded in the code rather than only here:

- **Live refresh.** The SSE filter excludes `item_updated` deliberately (refreshing on every content save caused shakiness and rate-limit errors). Version entries already carry the identical staleness, and these kinds have no web writer, so no user acts and then waits on this view. Raised twice, declined twice — which is why the reasoning now lives in that comment.
- **`has_more` heuristic** and the **absence of a cross-source snapshot** — both pre-existing, neither caused nor worsened here, neither reproduced. The paging claim in the type's doc comment is now qualified to the static-dataset case rather than left overstated.

Rounds 6 and 7 returned clean on fresh angles (theming, a11y, dead branches, share-page and guest visibility, scope creep, other read surfaces).

## Verification

Every guard is mutation-verified — 11 mutations, one at a time: dropping the merge, neutering the cursor predicate, removing each fallback, removing the sentinel branch, reverting the truncation, trusting raw ids, removing each render branch, restoring the payload guard. Each fails exactly the tests that cover it. That pass caught a vacuous assertion of my own (CONVE-12) which now counts what it asserted on.

Live, against a copy of the production DB rather than a fixture:

- Real notes from April/May/July 2026 now reach the API. `TASK-312` → `{note:2, activity:3, version:2, decision:1}`; `PLAN-1496` surfaces a note it never showed.
- **Control binary** (`origin/main`, same DB, same request, same token): `TASK-312` → `{activity:3, version:1}`, `PLAN-1496` → no note. The delta is attributable to this change.
- Browser render on the Activity tab: 6 cards, zero page errors, Note and Decision cards distinct.
- BUG-2627's double-encoded live row: HTTP 200, other kinds intact, zero note entries — degrades exactly as designed.

## Gates

| gate | result |
|---|---|
| `go build ./internal/...` | pass |
| `make lint` | 0 issues |
| `go test ./...` (SQLite) | pass |
| `go test ./...` (Postgres, :5445) | pass — full suite, not just the timeline tests |
| `npx vitest run` | 93 files, 1672 tests pass |
| `svelte-check` | 0 errors (6 pre-existing warnings) |
| `make vuln` | 0 affecting vulnerabilities |
| Codex | CLEAN after 7 rounds |

Postgres was run because the paging invariant crosses a Go/SQL seam and this endpoint has Postgres-specific paging history (BUG-1086); the new paging test has a PG leg that asserts its driver so it cannot pass by silently re-running SQLite.

## Spin-offs filed

- **BUG-2627** — one live item stores `implementation_notes` as a JSON-encoded string containing the array, so its notes are invisible on every surface including the CLI. Different defect (bad write, not missing renderer).
- **BUG-2628** — legacy April-2026 activity rows render the whole notes array as a raw Go map. Verified as legacy-only: a note written through the current path summarizes cleanly to `(1 note)`.
