### PR TITLE
fix(store): cover documents and comment bodies in the attachment reference walks (BUG-2614, BUG-2615)

### DIFF
--- a/internal/server/handlers_import_bundle_comment_refs_test.go
+++ b/internal/server/handlers_import_bundle_comment_refs_test.go
@@ -1,0 +1,149 @@
+package server
+
+// BUG-2615 end to end. TestImportBundle_RoundTrip proves the remap for a
+// reference living in ITEM CONTENT. The remap walked items only, so a bundle
+// whose reference lives in a COMMENT imported with the source workspace's id
+// intact — a reference that resolves to nothing in the destination, while the
+// freshly-rehydrated attachment row it should point at ends up referenced by
+// nothing and eventually reclaimed by the orphan GC.
+//
+// Driven through the real export → import path rather than the store helper,
+// because that is where the bug was reachable and because the filing asked for
+// exactly this fixture: a bundle whose ONLY reference to an attachment lives
+// in a comment.
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+func TestImportBundle_RemapsCommentOnlyAttachmentRefs(t *testing.T) {
+	src, srcSlug := testServerWithAttachments(t)
+
+	body := realPNG()
+	rr := doMultipartUpload(src, srcSlug, "in-comment.png", body)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("upload: %d %s", rr.Code, rr.Body.String())
+	}
+	var upload struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &upload); err != nil {
+		t.Fatalf("decode upload: %v", err)
+	}
+
+	// The item deliberately carries NO reference. If it did, the items walk
+	// alone would remap the id and this test would pass on the unfixed code —
+	// the reference has to live ONLY in the comment for the fixture to arm.
+	rr = doRequest(src, "POST", "/api/v1/workspaces/"+srcSlug+"/collections/docs/items",
+		map[string]any{"title": "Comment Carrier", "content": "no reference in this body\n"})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create item: %d %s", rr.Code, rr.Body.String())
+	}
+	var item models.Item
+	if err := json.Unmarshal(rr.Body.Bytes(), &item); err != nil {
+		t.Fatalf("decode item: %v", err)
+	}
+
+	commentBody := fmt.Sprintf("see ![shot](pad-attachment:%s) for context\n", upload.ID)
+	rr = doRequest(src, "POST",
+		"/api/v1/workspaces/"+srcSlug+"/items/"+item.Slug+"/comments",
+		map[string]any{"body": commentBody, "author": "alice", "source": "web"})
+	if rr.Code != http.StatusCreated && rr.Code != http.StatusOK {
+		t.Fatalf("create comment: %d %s", rr.Code, rr.Body.String())
+	}
+
+	rr = doRequest(src, "GET", "/api/v1/workspaces/"+srcSlug+"/export?format=tar", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("export: %d %s", rr.Code, rr.Body.String())
+	}
+	bundle := rr.Body.Bytes()
+
+	// A separate server, as the round-trip test does: a same-server import can
+	// pass with the remap broken, because the old ids still resolve there.
+	dest, _ := testServerWithAttachments(t)
+	req := httptest.NewRequest("POST", "/api/v1/workspaces/import?name=CommentImported",
+		bytes.NewReader(bundle))
+	req.Header.Set("Content-Type", "application/gzip")
+	req.RemoteAddr = "127.0.0.1:1234"
+	rr = httptest.NewRecorder()
+	dest.ServeHTTP(rr, req)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("import: status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	var newWS models.Workspace
+	if err := json.Unmarshal(rr.Body.Bytes(), &newWS); err != nil {
+		t.Fatalf("decode new ws: %v", err)
+	}
+
+	rr = doRequest(dest, "GET", "/api/v1/workspaces/"+newWS.Slug+"/attachments", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("list attachments: %d %s", rr.Code, rr.Body.String())
+	}
+	var attResp struct {
+		Attachments []struct {
+			ID string `json:"id"`
+		} `json:"attachments"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &attResp); err != nil {
+		t.Fatalf("decode att list: %v", err)
+	}
+	if len(attResp.Attachments) != 1 {
+		t.Fatalf("imported attachments: got %d, want 1", len(attResp.Attachments))
+	}
+	newAttID := attResp.Attachments[0].ID
+	if newAttID == upload.ID {
+		t.Fatalf("attachment id was not remapped at all (got %s) — the fixture proves "+
+			"nothing about comment bodies if the import reused the source id", newAttID)
+	}
+
+	// Find the imported item, then read its comments.
+	rr = doRequest(dest, "GET", "/api/v1/workspaces/"+newWS.Slug+"/collections/docs/items", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("list items: %d %s", rr.Code, rr.Body.String())
+	}
+	var items []models.Item
+	if err := json.Unmarshal(rr.Body.Bytes(), &items); err != nil {
+		t.Fatalf("decode items: %v", err)
+	}
+	var imported *models.Item
+	for i := range items {
+		if items[i].Title == "Comment Carrier" {
+			imported = &items[i]
+			break
+		}
+	}
+	if imported == nil {
+		t.Fatalf("imported item not found; got %d items", len(items))
+	}
+
+	rr = doRequest(dest, "GET",
+		"/api/v1/workspaces/"+newWS.Slug+"/items/"+imported.Slug+"/comments", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("list comments: %d %s", rr.Code, rr.Body.String())
+	}
+	var comments []models.Comment
+	if err := json.Unmarshal(rr.Body.Bytes(), &comments); err != nil {
+		t.Fatalf("decode comments: %v body=%s", err, rr.Body.String())
+	}
+	if len(comments) != 1 {
+		t.Fatalf("imported comments: got %d, want 1 — without the comment the rest "+
+			"of this test asserts nothing", len(comments))
+	}
+
+	if !strings.Contains(comments[0].Body, "pad-attachment:"+newAttID) {
+		t.Errorf("imported comment does not reference the rehydrated attachment %s; body=%q",
+			newAttID, comments[0].Body)
+	}
+	if strings.Contains(comments[0].Body, "pad-attachment:"+upload.ID) {
+		t.Errorf("imported comment still carries the SOURCE workspace's id %s; body=%q",
+			upload.ID, comments[0].Body)
+	}
+}

--- a/internal/server/orphan_gc.go
+++ b/internal/server/orphan_gc.go
@@ -151,9 +151,11 @@ func (s *Server) runOrphanGCSweep(ctx context.Context, graceCutoff time.Time) (*
 				continue
 			}
 			if referenced {
-				// Item content references the attachment — leave it
-				// alone. Bonus side effect: the row will be picked
-				// up next sweep if the reference goes away.
+				// Some live content — item content or fields, a comment
+				// body, or a document body (BUG-2614) — references the
+				// attachment, so leave it alone. Bonus side effect: the
+				// row will be picked up next sweep if the reference goes
+				// away.
 				continue
 			}
 		}

--- a/internal/store/attachments.go
+++ b/internal/store/attachments.go
@@ -1337,14 +1337,30 @@ func (s *Store) WorkspaceItemSlugMap(workspaceID string) (map[string]string, err
 
 // RemapAttachmentReferencesInWorkspace rewrites every
 // "pad-attachment:OLD" reference in items.content + items.fields
-// to "pad-attachment:NEW" for every (old, new) pair in the map.
-// Run after a bundle import has rehydrated attachments so item
-// content points at the new attachment ids instead of the source
-// workspace's ids.
+// AND in comment bodies (BUG-2615) to "pad-attachment:NEW" for
+// every (old, new) pair in the map. Run after a bundle import has
+// rehydrated attachments so the imported content points at the new
+// attachment ids instead of the source workspace's ids.
+//
+// CALLER PRECONDITION — read this before adding a second caller.
+// Every surface here is read-modify-write across a scan and a later
+// UPDATE, with no row locks and no old-value predicate, and the whole
+// population is loaded inside one transaction. That is safe for the
+// ONE existing caller (the bundle import) for a reason that is about
+// the caller, not this function: it runs against a workspace the
+// import itself just created, which no other session can reach yet,
+// so there are no concurrent writers to lose an edit to and no
+// contention to hold up. Called against a LIVE workspace it would
+// clobber a concurrent edit committed between the scan and the write,
+// and would hold a long transaction across the entire item and
+// comment population. Both would need fixing first — the pre-existing
+// items walk has the same shape, so this is a property of the
+// function, not of the comment leg added for BUG-2615.
 //
 // Implementation: a single transaction that loads every item's
-// content+fields, runs remapAttachmentRefs over each, and writes
-// back only when something changed. That helper tokenizes with
+// content+fields and every comment body, runs remapAttachmentRefs
+// over each, stamps the attachment rows the rewrites will point at,
+// then writes back only what changed. That helper tokenizes with
 // attachmentRefRE and matches whole ids — NOT strings.ReplaceAll,
 // which used to rewrite a mapped id sitting as the PREFIX of a
 // longer one (Codex round 26). See its doc.
@@ -1422,19 +1438,6 @@ func (s *Store) RemapAttachmentReferencesInWorkspace(workspaceID string, oldToNe
 	}
 	crows.Close()
 
-	for _, u := range updates {
-		if _, err := tx.Exec(s.q(`UPDATE items SET content = ?, fields = ? WHERE id = ?`),
-			u.content, u.fields, u.id); err != nil {
-			return fmt.Errorf("update item %s: %w", u.id, err)
-		}
-	}
-	for _, u := range commentUpdates {
-		if _, err := tx.Exec(s.q(`UPDATE comments SET body = ? WHERE id = ?`),
-			u.body, u.id); err != nil {
-			return fmt.Errorf("update comment %s: %w", u.id, err)
-		}
-	}
-
 	// Stamp what the rewrites now point AT, inside this same transaction.
 	// The import stamped each comment body at insert time, but the body still
 	// held the SOURCE ids then, so those stamps landed on nothing that ends up
@@ -1442,6 +1445,20 @@ func (s *Store) RemapAttachmentReferencesInWorkspace(workspaceID string, oldToNe
 	// created, referenced only by text this transaction just wrote, and
 	// carrying no stamp — the exact shape the orphan GC's never-attached claim
 	// reclaims (BUG-2615).
+	//
+	// ORDERING: this runs BEFORE the content UPDATEs, per
+	// stampAttachmentRefsTx's own contract and for the same two reasons every
+	// other writer follows it. On Postgres the stamp row-locks the attachment
+	// rows for the rest of the transaction, so a concurrent GC claim blocks
+	// and re-evaluates against the fresh stamp; stamping last would let a
+	// claim delete the target while the rewritten text sat uncommitted, and
+	// the stamp would then match zero rows and commit a dangling reference.
+	// It also keeps this path's lock order identical to the item and comment
+	// writers (attachments first, then content rows) — the reverse order
+	// deadlocks against them (codex round 2 P1).
+	//
+	// The texts are already known here: both scans have run and produced the
+	// exact strings the UPDATEs below will write.
 	//
 	// The REWRITTEN TEXTS are passed rather than every id in oldToNew, so only
 	// ids something actually references get stamped. Stamping the whole map
@@ -1456,6 +1473,19 @@ func (s *Store) RemapAttachmentReferencesInWorkspace(workspaceID string, oldToNe
 	}
 	if err := stampAttachmentRefsTx(tx, s, workspaceID, stampTexts...); err != nil {
 		return fmt.Errorf("stamp remapped refs: %w", err)
+	}
+
+	for _, u := range updates {
+		if _, err := tx.Exec(s.q(`UPDATE items SET content = ?, fields = ? WHERE id = ?`),
+			u.content, u.fields, u.id); err != nil {
+			return fmt.Errorf("update item %s: %w", u.id, err)
+		}
+	}
+	for _, u := range commentUpdates {
+		if _, err := tx.Exec(s.q(`UPDATE comments SET body = ? WHERE id = ?`),
+			u.body, u.id); err != nil {
+			return fmt.Errorf("update comment %s: %w", u.id, err)
+		}
 	}
 
 	if err := tx.Commit(); err != nil {

--- a/internal/store/attachments.go
+++ b/internal/store/attachments.go
@@ -1119,6 +1119,14 @@ func (s *Store) AttachmentReferenced(workspaceID, attachmentID string) (bool, er
 		fieldsExpr = "fields::text"
 	}
 
+	// The documents leg covers the legacy v1 `/workspaces/{ws}/documents`
+	// surface (BUG-2614). It has no first-party client left — nothing in the
+	// web API client or the CLI calls it — but the CRUD routes are mounted and
+	// authenticated, so a direct API consumer can still put a
+	// `pad-attachment:` reference in a document body. Scanning items and
+	// comments only made such an attachment reclaimable while genuinely
+	// referenced. Live rows only, mirroring items; comments carry no
+	// deleted_at at all, which is why that leg has no such filter.
 	var n int
 	err := s.db.QueryRow(s.q(`
 		SELECT
@@ -1127,7 +1135,9 @@ func (s *Store) AttachmentReferenced(workspaceID, attachmentID string) (bool, er
 		       AND (content LIKE ? OR `+fieldsExpr+` LIKE ?))
 		+ (SELECT COUNT(*) FROM comments
 		     WHERE workspace_id = ? AND body LIKE ?)
-	`), workspaceID, pattern, pattern, workspaceID, pattern).Scan(&n)
+		+ (SELECT COUNT(*) FROM documents
+		     WHERE workspace_id = ? AND deleted_at IS NULL AND content LIKE ?)
+	`), workspaceID, pattern, pattern, workspaceID, pattern, workspaceID, pattern).Scan(&n)
 	if err != nil {
 		return false, fmt.Errorf("attachment referenced: %w", err)
 	}
@@ -1380,12 +1390,74 @@ func (s *Store) RemapAttachmentReferencesInWorkspace(workspaceID string, oldToNe
 	}
 	rows.Close()
 
+	// Comment bodies carry `pad-attachment:` references exactly as item
+	// content does, and a bundle import re-inserts them (export.go's comment
+	// import), so walking items alone left every comment pointing at the
+	// SOURCE workspace's ids — which resolve to nothing in the destination,
+	// while the freshly-cloned rows they should have pointed at end up
+	// referenced by nothing and eventually reclaimed (BUG-2615). Comments have
+	// no deleted_at column, hence no filter here.
+	crows, err := tx.Query(s.q(`SELECT id, body FROM comments WHERE workspace_id = ?`), workspaceID)
+	if err != nil {
+		return fmt.Errorf("scan comments for remap: %w", err)
+	}
+	type commentUpdate struct {
+		id   string
+		body string
+	}
+	var commentUpdates []commentUpdate
+	for crows.Next() {
+		var id, body string
+		if err := crows.Scan(&id, &body); err != nil {
+			crows.Close()
+			return fmt.Errorf("scan comment: %w", err)
+		}
+		if newBody := remapAttachmentRefs(body, oldToNew); newBody != body {
+			commentUpdates = append(commentUpdates, commentUpdate{id: id, body: newBody})
+		}
+	}
+	if err := crows.Err(); err != nil {
+		crows.Close()
+		return fmt.Errorf("iterate comments for remap: %w", err)
+	}
+	crows.Close()
+
 	for _, u := range updates {
 		if _, err := tx.Exec(s.q(`UPDATE items SET content = ?, fields = ? WHERE id = ?`),
 			u.content, u.fields, u.id); err != nil {
 			return fmt.Errorf("update item %s: %w", u.id, err)
 		}
 	}
+	for _, u := range commentUpdates {
+		if _, err := tx.Exec(s.q(`UPDATE comments SET body = ? WHERE id = ?`),
+			u.body, u.id); err != nil {
+			return fmt.Errorf("update comment %s: %w", u.id, err)
+		}
+	}
+
+	// Stamp what the rewrites now point AT, inside this same transaction.
+	// The import stamped each comment body at insert time, but the body still
+	// held the SOURCE ids then, so those stamps landed on nothing that ends up
+	// referenced here. Without this the destination's clones are freshly
+	// created, referenced only by text this transaction just wrote, and
+	// carrying no stamp — the exact shape the orphan GC's never-attached claim
+	// reclaims (BUG-2615).
+	//
+	// The REWRITTEN TEXTS are passed rather than every id in oldToNew, so only
+	// ids something actually references get stamped. Stamping the whole map
+	// would also refresh clones nothing points at, keeping genuinely
+	// unreferenced rows alive for an extra GC window.
+	stampTexts := make([]string, 0, len(updates)*2+len(commentUpdates))
+	for _, u := range updates {
+		stampTexts = append(stampTexts, u.content, u.fields)
+	}
+	for _, u := range commentUpdates {
+		stampTexts = append(stampTexts, u.body)
+	}
+	if err := stampAttachmentRefsTx(tx, s, workspaceID, stampTexts...); err != nil {
+		return fmt.Errorf("stamp remapped refs: %w", err)
+	}
+
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("commit remap: %w", err)
 	}

--- a/internal/store/attachments.go
+++ b/internal/store/attachments.go
@@ -1095,7 +1095,16 @@ func (s *Store) CountProtectingAttachmentsForHash(hash, excludeID string, graceC
 //
 // Comments are covered because a pasted screenshot (IDEA-1650) may be
 // referenced ONLY from a comment body; without the comments scan the GC
-// would reclaim it after the grace period and break the embed.
+// would reclaim it after the grace period and break the embed. Documents
+// are covered for the same reason (BUG-2614) — the legacy v1 documents
+// API is still mounted, so a direct API consumer can put the only
+// reference to an attachment in a document body.
+//
+// THE SET OF SCANNED SURFACES IS THE CONTRACT. Anything that persists
+// user-authored text which can contain a `pad-attachment:` token belongs
+// here, and adding such a surface without adding it here silently makes
+// its references invisible to the GC. Both of the additions above were
+// found that way, after the fact.
 //
 // Scoped to one workspace because a "pad-attachment:UUID" reference
 // only resolves within the workspace where the attachment lives;

--- a/internal/store/attachments_document_refs_test.go
+++ b/internal/store/attachments_document_refs_test.go
@@ -1,0 +1,292 @@
+package store
+
+// BUG-2614 — the orphan GC's reference scan and the writer-side reference
+// stamp both ignored the legacy v1 documents surface, so an attachment
+// referenced ONLY from a document body was reclaimable while genuinely
+// referenced. BUG-2615 — the bundle import's attachment remap rewrote item
+// content and fields but not comment bodies, so imported comments kept the
+// source workspace's ids.
+//
+// Both defects have the same shape: a content surface that carries
+// `pad-attachment:` references was missing from a walk that is supposed to
+// cover every such surface.
+
+import (
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+func (f *gcClaimFixture) createDocument(t *testing.T, content string) *models.Document {
+	t.Helper()
+	doc, err := f.s.CreateDocument(f.wsID, models.DocumentCreate{
+		Title:   "Ref carrier",
+		Content: content,
+	})
+	if err != nil {
+		t.Fatalf("CreateDocument: %v", err)
+	}
+	if doc == nil {
+		t.Fatal("CreateDocument returned nil")
+	}
+	return doc
+}
+
+// The headline: an attachment referenced only from a document body must read
+// as referenced. Before the fix the scan covered items and comments only, so
+// this returned false and the GC was free to reclaim a live reference.
+func TestAttachmentReferenced_SeesDocumentContent(t *testing.T) {
+	f := newGCClaimFixture(t)
+	a := f.seedNeverAttached(t)
+
+	// Control first: nothing references it yet, on any surface.
+	referenced, err := f.s.AttachmentReferenced(f.wsID, a.ID)
+	if err != nil {
+		t.Fatalf("AttachmentReferenced (pre): %v", err)
+	}
+	if referenced {
+		t.Fatal("attachment read as referenced before anything referenced it — " +
+			"the assertion below would be vacuous")
+	}
+
+	f.createDocument(t, "before ![img](pad-attachment:"+a.ID+") after")
+
+	referenced, err = f.s.AttachmentReferenced(f.wsID, a.ID)
+	if err != nil {
+		t.Fatalf("AttachmentReferenced (post): %v", err)
+	}
+	if !referenced {
+		t.Error("attachment referenced from a document body read as UNreferenced — " +
+			"the orphan GC would reclaim it while the reference is live")
+	}
+}
+
+// A soft-deleted document must NOT hold a reference, mirroring items. Without
+// this the scan would pin blobs behind deleted content forever.
+func TestAttachmentReferenced_IgnoresDeletedDocument(t *testing.T) {
+	f := newGCClaimFixture(t)
+	a := f.seedNeverAttached(t)
+	doc := f.createDocument(t, "![img](pad-attachment:"+a.ID+")")
+
+	// Armed: live document, reference visible. Without this leg a broken
+	// scan that never sees documents at all would satisfy the assertion below.
+	referenced, err := f.s.AttachmentReferenced(f.wsID, a.ID)
+	if err != nil {
+		t.Fatalf("AttachmentReferenced (live): %v", err)
+	}
+	if !referenced {
+		t.Fatal("fixture never armed: live document's reference was not seen")
+	}
+
+	if err := f.s.DeleteDocument(doc.ID); err != nil {
+		t.Fatalf("DeleteDocument: %v", err)
+	}
+
+	referenced, err = f.s.AttachmentReferenced(f.wsID, a.ID)
+	if err != nil {
+		t.Fatalf("AttachmentReferenced (deleted): %v", err)
+	}
+	if referenced {
+		t.Error("a soft-deleted document still held the attachment reference; " +
+			"items are scanned live-only and documents must match")
+	}
+}
+
+// A document in ANOTHER workspace must not hold the reference — the scan is
+// workspace-scoped, and a pasted foreign id must not pin someone else's rows.
+func TestAttachmentReferenced_DocumentScanIsWorkspaceScoped(t *testing.T) {
+	f := newGCClaimFixture(t)
+	a := f.seedNeverAttached(t)
+
+	other, err := f.s.CreateWorkspace(models.WorkspaceCreate{Name: "Other WS"})
+	if err != nil {
+		t.Fatalf("CreateWorkspace: %v", err)
+	}
+	if _, err := f.s.CreateDocument(other.ID, models.DocumentCreate{
+		Title:   "Foreign carrier",
+		Content: "![img](pad-attachment:" + a.ID + ")",
+	}); err != nil {
+		t.Fatalf("CreateDocument (other ws): %v", err)
+	}
+
+	referenced, err := f.s.AttachmentReferenced(f.wsID, a.ID)
+	if err != nil {
+		t.Fatalf("AttachmentReferenced: %v", err)
+	}
+	if referenced {
+		t.Error("a document in another workspace held the reference — the scan " +
+			"must stay workspace-scoped")
+	}
+}
+
+// The write half. The scan protects references that exist when the sweep runs;
+// the stamp is what covers a reference landing DURING a sweep, and it only
+// works if the document writers call it. Both write paths are covered because
+// they were differently shaped: UpdateDocument already had a transaction,
+// CreateDocument had none and needed one.
+func TestDocumentWrites_StampAttachmentRefs(t *testing.T) {
+	t.Run("create stamps", func(t *testing.T) {
+		f := newGCClaimFixture(t)
+		a := f.seedNeverAttached(t)
+
+		if stamp := f.lastReferencedAt(t, a.ID); stamp != nil {
+			t.Fatalf("attachment already stamped before any write: %v", *stamp)
+		}
+
+		f.createDocument(t, "![img](pad-attachment:"+a.ID+")")
+
+		if stamp := f.lastReferencedAt(t, a.ID); stamp == nil {
+			t.Error("CreateDocument did not stamp the reference it wrote — a claim " +
+				"racing the insert cannot observe it")
+		}
+	})
+
+	t.Run("update stamps", func(t *testing.T) {
+		f := newGCClaimFixture(t)
+		a := f.seedNeverAttached(t)
+
+		// Create with NO reference, so the stamp under test can only come
+		// from the update.
+		doc := f.createDocument(t, "nothing here yet")
+		if stamp := f.lastReferencedAt(t, a.ID); stamp != nil {
+			t.Fatalf("stamped by a document that never referenced it: %v", *stamp)
+		}
+
+		body := "![img](pad-attachment:" + a.ID + ")"
+		if _, err := f.s.UpdateDocument(doc.ID, models.DocumentUpdate{Content: &body}); err != nil {
+			t.Fatalf("UpdateDocument: %v", err)
+		}
+
+		if stamp := f.lastReferencedAt(t, a.ID); stamp == nil {
+			t.Error("UpdateDocument did not stamp the reference it wrote")
+		}
+	})
+
+	t.Run("a metadata-only update stamps nothing", func(t *testing.T) {
+		f := newGCClaimFixture(t)
+		a := f.seedNeverAttached(t)
+		doc := f.createDocument(t, "![img](pad-attachment:"+a.ID+")")
+
+		// Clear the create-time stamp so the assertion is about THIS update.
+		if _, err := f.s.db.Exec(f.s.q(
+			`UPDATE attachments SET last_referenced_at = NULL WHERE id = ?`), a.ID); err != nil {
+			t.Fatalf("clear stamp: %v", err)
+		}
+
+		title := "Renamed, content untouched"
+		if _, err := f.s.UpdateDocument(doc.ID, models.DocumentUpdate{Title: &title}); err != nil {
+			t.Fatalf("UpdateDocument: %v", err)
+		}
+
+		if stamp := f.lastReferencedAt(t, a.ID); stamp != nil {
+			t.Errorf("a metadata-only update refreshed the reference stamp (%v) — it "+
+				"neither adds nor keeps a reference and must not vouch for one", *stamp)
+		}
+	})
+}
+
+// BUG-2615. The remap is what makes an imported bundle's references point at
+// the destination's cloned attachment rows. It walked items only, so a
+// reference living in a COMMENT kept the source workspace's id: broken in the
+// destination, and the clone it should have pointed at ends up referenced by
+// nothing.
+func TestRemapAttachmentReferences_RewritesCommentBodies(t *testing.T) {
+	f := newGCClaimFixture(t)
+	oldID, newID := "11111111-1111-4111-8111-111111111111", "22222222-2222-4222-8222-222222222222"
+
+	item, err := f.s.CreateItem(f.wsID, f.collID, models.ItemCreate{Title: "Carrier"})
+	if err != nil {
+		t.Fatalf("CreateItem: %v", err)
+	}
+	comment, err := f.s.CreateComment(f.wsID, item.ID, "", models.CommentCreate{
+		Author: "alice",
+		Body:   "see ![img](pad-attachment:" + oldID + ") above",
+	})
+	if err != nil {
+		t.Fatalf("CreateComment: %v", err)
+	}
+
+	if err := f.s.RemapAttachmentReferencesInWorkspace(f.wsID, map[string]string{oldID: newID}); err != nil {
+		t.Fatalf("RemapAttachmentReferencesInWorkspace: %v", err)
+	}
+
+	var body string
+	if err := f.s.db.QueryRow(f.s.q(`SELECT body FROM comments WHERE id = ?`), comment.ID).Scan(&body); err != nil {
+		t.Fatalf("read comment body: %v", err)
+	}
+	if want := "pad-attachment:" + newID; !contains(body, want) {
+		t.Errorf("comment body was not remapped: %q — an imported comment keeps the "+
+			"SOURCE workspace's id, which resolves to nothing here", body)
+	}
+	if stale := "pad-attachment:" + oldID; contains(body, stale) {
+		t.Errorf("comment body still carries the source id: %q", body)
+	}
+}
+
+// The remap must leave the destination's stamps correct, not just its text.
+// The import stamps each comment body at insert, but the body still holds the
+// SOURCE ids then — so the clone the rewrite now points at carries no stamp
+// unless the remap adds one, which is exactly the never-attached shape the GC
+// claims.
+func TestRemapAttachmentReferences_StampsTheRewrittenTarget(t *testing.T) {
+	f := newGCClaimFixture(t)
+	target := f.seedNeverAttached(t)
+	oldID := "33333333-3333-4333-8333-333333333333"
+
+	item, err := f.s.CreateItem(f.wsID, f.collID, models.ItemCreate{Title: "Carrier"})
+	if err != nil {
+		t.Fatalf("CreateItem: %v", err)
+	}
+	if _, err := f.s.CreateComment(f.wsID, item.ID, "", models.CommentCreate{
+		Author: "alice",
+		Body:   "![img](pad-attachment:" + oldID + ")",
+	}); err != nil {
+		t.Fatalf("CreateComment: %v", err)
+	}
+	// The comment referenced the SOURCE id, so nothing stamped the clone.
+	if stamp := f.lastReferencedAt(t, target.ID); stamp != nil {
+		t.Fatalf("fixture never armed: clone was already stamped (%v)", *stamp)
+	}
+
+	if err := f.s.RemapAttachmentReferencesInWorkspace(f.wsID, map[string]string{oldID: target.ID}); err != nil {
+		t.Fatalf("RemapAttachmentReferencesInWorkspace: %v", err)
+	}
+
+	if stamp := f.lastReferencedAt(t, target.ID); stamp == nil {
+		t.Error("the remap rewrote a reference onto the clone without stamping it — " +
+			"a GC sweep between the import and the next write reclaims it")
+	}
+}
+
+// A clone that nothing ends up referencing must NOT be stamped. Stamping the
+// whole id map would vouch for rows no text points at, keeping genuinely
+// unreferenced clones alive for an extra GC window.
+func TestRemapAttachmentReferences_DoesNotStampUnreferencedClones(t *testing.T) {
+	f := newGCClaimFixture(t)
+	unreferenced := f.seedNeverAttached(t)
+
+	if err := f.s.RemapAttachmentReferencesInWorkspace(f.wsID, map[string]string{
+		"44444444-4444-4444-8444-444444444444": unreferenced.ID,
+	}); err != nil {
+		t.Fatalf("RemapAttachmentReferencesInWorkspace: %v", err)
+	}
+
+	if stamp := f.lastReferencedAt(t, unreferenced.ID); stamp != nil {
+		t.Errorf("stamped a clone that no content references (%v)", *stamp)
+	}
+}
+
+// strings.Contains by another name would be simpler; kept local only because
+// the package already imports strings for other purposes and a helper name
+// collision is cheaper to avoid than to debug.
+func contains(haystack, needle string) bool {
+	return len(needle) > 0 && len(haystack) >= len(needle) &&
+		func() bool {
+			for i := 0; i+len(needle) <= len(haystack); i++ {
+				if haystack[i:i+len(needle)] == needle {
+					return true
+				}
+			}
+			return false
+		}()
+}

--- a/internal/store/documents.go
+++ b/internal/store/documents.go
@@ -316,7 +316,17 @@ func (s *Store) UpdateDocument(id string, input models.DocumentUpdate) (*models.
 		}
 	}
 
-	// Update [[link]] references if title is changing
+	// Update [[link]] references if title is changing.
+	//
+	// KNOWN GAP, filed as BUG-2629, deliberately not fixed here: this cascade
+	// rewrites OTHER documents' bodies without stamping the attachment
+	// references in the text it writes, and wiki_links.go::cascadeTitleRename
+	// does the same on the items side. Uniform across both surfaces, so fixing
+	// only this one would leave the larger hole open. It is also the weakest
+	// member of that family — the cascade rewrites link text in content whose
+	// references were already stamped when written and are still visible to
+	// the scan, so a NEW reference requires a title that literally contains a
+	// `pad-attachment:` token.
 	if input.Title != nil && *input.Title != existing.Title {
 		err = s.updateLinksInTx(tx, existing.WorkspaceID, existing.Title, *input.Title)
 		if err != nil {

--- a/internal/store/documents.go
+++ b/internal/store/documents.go
@@ -177,7 +177,26 @@ func (s *Store) CreateDocument(workspaceID string, input models.DocumentCreate) 
 		return nil, err
 	}
 
-	_, err = s.db.Exec(s.q(`
+	// Transactional so the attachment-reference stamp commits atomically with
+	// the content that carries the reference (BUG-2415's protocol, extended to
+	// documents by BUG-2614). Without the transaction the stamp and the insert
+	// could not serialize against a concurrent orphan-GC claim, which is the
+	// entire point of stamping.
+	tx, err := s.db.Begin()
+	if err != nil {
+		return nil, fmt.Errorf("begin create document: %w", err)
+	}
+	defer tx.Rollback()
+
+	// BEFORE the insert, per stampAttachmentRefsTx's ORDERING note: on
+	// Postgres the stamp row-locks the attachment rows for the rest of the
+	// transaction, so a concurrent claim blocks and then re-evaluates against
+	// the fresh stamp. Stamping after the write would leave a gap.
+	if err := stampAttachmentRefsTx(tx, s, workspaceID, input.Content); err != nil {
+		return nil, err
+	}
+
+	_, err = tx.Exec(s.q(`
 		INSERT INTO documents (id, workspace_id, title, slug, content, doc_type, status, tags,
 		                       pinned, sort_order, created_by, last_modified_by, source, created_at, updated_at)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?, ?, ?, ?)
@@ -185,6 +204,10 @@ func (s *Store) CreateDocument(workspaceID string, input models.DocumentCreate) 
 		s.dialect.BoolToInt(input.Pinned), createdBy, createdBy, source, ts, ts)
 	if err != nil {
 		return nil, fmt.Errorf("insert document: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit create document: %w", err)
 	}
 
 	return s.GetDocument(id)
@@ -235,6 +258,17 @@ func (s *Store) UpdateDocument(id string, input models.DocumentUpdate) (*models.
 		return nil, err
 	}
 	defer tx.Rollback()
+
+	// Stamp the incoming content's attachment references first (BUG-2614,
+	// same protocol and ordering as items and comments). Only when content is
+	// actually being written — a metadata-only PATCH neither adds nor keeps a
+	// reference, and stamping on one would refresh rows this write has no
+	// opinion about.
+	if input.Content != nil {
+		if err := stampAttachmentRefsTx(tx, s, existing.WorkspaceID, *input.Content); err != nil {
+			return nil, err
+		}
+	}
 
 	ts := now()
 

--- a/internal/store/wiki_links.go
+++ b/internal/store/wiki_links.go
@@ -549,6 +549,11 @@ func resolveWorkspaceSlugTx(tx *sql.Tx, s *Store, slug string) sql.NullString {
 //     If their new content contains `[[Old Title]]`, the trailing
 //     replaceWikiLinks correctly stores it as broken — same as the
 //     renderer would render it.
+//
+// KNOWN GAP, filed as BUG-2629: like documents.go::updateLinksInTx, this
+// cascade writes other rows' content without stamping the attachment
+// references in the text it writes (BUG-2415's protocol). Both surfaces have
+// it, so they are fixed together or not at all.
 func (s *Store) cascadeTitleRename(tx *sql.Tx, renamedItemID, workspaceID, oldTitle, newTitle string, excludeSelf bool) error {
 	if oldTitle == newTitle {
 		return nil


### PR DESCRIPTION
Fixes BUG-2614 and BUG-2615, shipped as one unit — same file, same harness, same underlying shape.

Both were found by Codex during BUG-2415 and both predate it. **A content surface that carries `pad-attachment:` references was missing from a walk meant to cover every such surface.**

## BUG-2614 — the orphan GC could reclaim a live reference

`AttachmentReferenced` counted items and comments; `documents.content` was never scanned, and neither document write path stamped. An attachment referenced only from a document was therefore invisible to the sweep's scan *and* unprotected by the stamp that covers references landing mid-sweep.

**The filing asked whether the documents surface is dead enough to delete instead. Evidence says widen the scan, and I did not make the deletion call inside a bug fix:**

- Not dead: `/workspaces/{ws}/documents` has full CRUD mounted and authenticated today — list/create/get/patch/delete, plus restore, versions, activity. A direct API consumer can still write one.
- Legacy: the route block says *"v1 — will be replaced by items in Phase 2"*, and no first-party client reaches it (zero references in `web/src/lib/api/client.ts`, zero in `cmd/pad`).
- Production data: **4 document rows, all soft-deleted, none referencing an attachment, newest touched 2026-04-27.**

"Reachable but unused by us" is not dead. Retiring the surface belongs with the Phase 2 migration, deliberately — and the conservative fix is a few lines.

`CreateDocument` had no transaction and gains one, because the stamp must commit atomically with the content carrying the reference or it cannot serialize against a concurrent claim. `UpdateDocument` already had one and needed only the call — and only when content is actually written, since a metadata-only PATCH neither adds nor keeps a reference and must not vouch for one.

## BUG-2615 — imported comments kept the source workspace's ids

The bundle import's remap rewrote item content and fields but not comment bodies, so an imported comment pointed at ids that resolve to nothing in the destination, while the rehydrated rows they should reference were left referenced by nothing. Bundles do carry comments; they carry no documents, so this stays scoped to comments.

The remap now also **stamps what the rewrites point at**. `ImportWorkspace` already stamps each comment body at insert, but the body still holds the source ids then and the remap runs later, so those stamps land on nothing that ends up referenced — leaving a fresh clone referenced only by text the transaction just wrote and carrying no stamp, which is exactly the shape the never-attached claim reclaims. The **rewritten texts** are passed rather than every id in the map, so a clone nothing references is not vouched for.

## Review — 6 Codex rounds

Round 2 found a **P1 that was mine**: I stamped *after* the content UPDATEs, violating the ordering contract of the very helper I was mirroring. On Postgres the stamp row-locks the attachment rows, so a concurrent GC claim blocks and re-evaluates; stamping last instead lets a claim delete the target while the rewritten text is uncommitted, after which the stamp matches zero rows and the transaction commits a dangling reference. It also inverted lock order against every other writer. The stamp now runs before both write loops.

Declined, with reasoning put in the **code** rather than only here:

- The remap's scan-then-write has no row lock, so a concurrent edit is clobbered — real as a shape, unreachable at the only call site, which runs against a workspace the import just created and nobody else can reach. The pre-existing items walk is identical. That argument depends on a property of the *caller*, and the next caller is exactly who would break it, so the precondition is now stated at the top of the function.
- The one-transaction scan of the whole population, and document slug allocation outside the create transaction (predates the transaction existing at all; yields a spurious unique violation, not partial state).
- The widened scan's cost: already `O(candidates × content rows)` via unindexable leading-wildcard LIKE, so documents add a constant to a pre-existing shape; narrowed by `idx_documents_workspace`; 4 rows in production.

Two findings were verified as **uniform with their items-side equivalents and filed as BUG-2629** rather than half-fixed: restore paths don't re-stamp, and title-rename cascades don't stamp. The honest framing on that item: BUG-2415 established a protocol and four call sites were never brought into it. Both sites now carry a comment naming it in place — Codex raised the cascade twice, which is the signal that a disposition living only in a tracker is not where a reader meets the problem.

## Verification

**Eight negative controls, one mutation at a time, each failing exactly the test that covers it**: the documents scan leg, each of the two document stamps, the comment write-back (at store level *and* end-to-end), the remap stamp, an over-broad stamp-the-whole-map variant caught by the precision test, and the stamp guard re-confirmed after the reordering.

Per the standing bar from BUG-2301, **every regression test here was run against the unfixed code and observed to fail** — including the end-to-end bundle fixture the filing asked for, whose item deliberately carries *no* reference so the items walk alone cannot rescue it.

**Not covered by a test, stated rather than implied:** the stamp *ordering*. The guard asserts the stamp is present and fails without it, but it reads end state, so it cannot distinguish before-the-writes from after. Proving order needs a concurrent-session Postgres instrument of the kind BUG-2409 used; that is not built here. The ordering rests on the documented contract and the reasoning above.

## Gates

| gate | result |
|---|---|
| `go build ./internal/...` | pass |
| `make lint` | 0 issues |
| `go test ./...` (SQLite) | pass |
| `go test ./...` (Postgres, :5445) | pass — full suite, required for a store change |
| `make vuln` | 0 affecting vulnerabilities |
| Codex | 6 rounds |

Web unchanged, so no web gates apply.
