### PR TITLE
fix(web): give the IDB write path the seq guard RAM already had (BUG-2609)

### DIFF
--- a/web/src/lib/stores/localIndex.svelte.ts
+++ b/web/src/lib/stores/localIndex.svelte.ts
@@ -197,6 +197,7 @@ function applyRetag(ws: string, state: WorkspaceState, collectionId: string, new
 		persistRetag(
 			state.userId,
 			ws,
+			collectionId,
 			retagged.map((r) => r.id),
 			newSlug,
 		).catch(() => undefined);

--- a/web/src/lib/stores/localIndex.svelte.ts
+++ b/web/src/lib/stores/localIndex.svelte.ts
@@ -63,6 +63,7 @@ import {
 	persistDelta,
 	persistRemovals,
 	persistReplace,
+	persistRetag,
 	persistUpserts,
 	wipe as persistWipe,
 } from './localIndexPersistence';
@@ -188,7 +189,17 @@ function applyRetag(ws: string, state: WorkspaceState, collectionId: string, new
 		retagged.push(next);
 	}
 	if (retagged.length > 0) {
-		persistUpserts(state.userId, ws, retagged).catch(() => undefined);
+		// persistRetag, NOT persistUpserts: a rename is a field-level intent,
+		// and persisting it as a whole-row snapshot would be refused by the
+		// IDB seq guard whenever a newer delta has already landed — dropping
+		// the rename with nothing left to reapply it, since a rename produces
+		// no item delta and pendingRetags is in-memory only (BUG-2609).
+		persistRetag(
+			state.userId,
+			ws,
+			retagged.map((r) => r.id),
+			newSlug,
+		).catch(() => undefined);
 	}
 }
 

--- a/web/src/lib/stores/localIndexPersistence.test.ts
+++ b/web/src/lib/stores/localIndexPersistence.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { shouldWriteRow } from './localIndexPersistence';
+import { shouldApplyRetag, shouldWriteRow } from './localIndexPersistence';
 import type { ItemIndexRow } from '$lib/types';
 
 /**
@@ -17,6 +17,10 @@ import type { ItemIndexRow } from '$lib/types';
 
 function row(seq: number | undefined, id = 'item-1'): ItemIndexRow {
 	return { id, seq } as unknown as ItemIndexRow;
+}
+
+function collRow(collectionId: string, slug: string, id = 'item-1'): ItemIndexRow {
+	return { id, collection_id: collectionId, collection_slug: slug } as unknown as ItemIndexRow;
 }
 
 describe('shouldWriteRow', () => {
@@ -79,6 +83,33 @@ describe('shouldWriteRow', () => {
 		const storedByDelta = row(101);
 		const staleSnapshot = row(100);
 		expect(shouldWriteRow(storedByDelta, staleSnapshot)).toBe(false);
+	});
+});
+
+/**
+ * shouldApplyRetag is the decision persistRetag makes per row INSIDE its
+ * transaction. Unlike the transaction itself, it is reachable here.
+ */
+describe('shouldApplyRetag', () => {
+	it('renames a row that is still in the renamed collection', () => {
+		expect(shouldApplyRetag(collRow('coll-a', 'old'), 'coll-a', 'new')).toBe(true);
+	});
+
+	// The row moved between the RAM retag and this write. Applying the renamed
+	// collection's slug would persist a row whose collection_id and
+	// collection_slug disagree — behind the cursor, so no delta repairs it.
+	it('REFUSES a row that has moved to another collection', () => {
+		expect(shouldApplyRetag(collRow('coll-b', 'b-slug'), 'coll-a', 'new')).toBe(false);
+	});
+
+	it('skips a row already carrying the new slug (idempotent)', () => {
+		expect(shouldApplyRetag(collRow('coll-a', 'new'), 'coll-a', 'new')).toBe(false);
+	});
+
+	// Absent means the row is not cached — or was removed by a delta. Inserting
+	// it here would resurrect it behind the cursor (the BUG-2633 shape).
+	it('REFUSES an absent row rather than inserting one', () => {
+		expect(shouldApplyRetag(undefined, 'coll-a', 'new')).toBe(false);
 	});
 });
 

--- a/web/src/lib/stores/localIndexPersistence.test.ts
+++ b/web/src/lib/stores/localIndexPersistence.test.ts
@@ -138,10 +138,15 @@ describe('the premise behind persistRetag (guard behaviour, not persistRetag its
  *
  * That the guard runs INSIDE the IDB transaction — i.e. compares against what
  * is stored at write time rather than at snapshot time — is not asserted by any
- * test, because this harness has no IndexedDB at all: jsdom does not implement
- * it, `fake-indexeddb` is not a dependency, and `isSupported()` therefore
- * returns false, making every function in the persistence module a no-op under
- * vitest.
+ * test, because there is no IndexedDB to run it against. A plain `.test.ts`
+ * file belongs to vitest's `node` project (environment: 'node', see
+ * vitest.config.ts) rather than the jsdom one, which takes the
+ * browser-suite glob. Node provides no `indexedDB` global, the
+ * jsdom project does not implement one either, and `fake-indexeddb` is not a
+ * dependency. `isSupported()` therefore returns false, so every function in
+ * the persistence module that TOUCHES IDB is a no-op here — the exported
+ * decision helpers tested above are pure and unaffected, which is precisely
+ * why they were extracted.
  *
  * So the interleaving rests on reading the call sites (the `await store.get`
  * immediately before each `put`, both within the transaction) rather than on a

--- a/web/src/lib/stores/localIndexPersistence.test.ts
+++ b/web/src/lib/stores/localIndexPersistence.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { shouldWriteRow } from './localIndexPersistence';
+import type { ItemIndexRow } from '$lib/types';
+
+/**
+ * BUG-2609 — the IDB write path had no seq guard, so a snapshot taken from RAM
+ * and persisted fire-and-forget could land AFTER a newer delta's atomic
+ * rows+cursor transaction. The cache then held a pre-delta row while the
+ * persisted cursor sat past that delta: warm boot hydrates the stale row and
+ * `/items-changes?since=cursor` never returns it, so it stays stale until the
+ * item happens to change again.
+ *
+ * These cover the DECISION. The interleaving itself is not covered — see the
+ * note at the bottom of this file, which says so rather than leaving a reader
+ * to assume otherwise.
+ */
+
+function row(seq: number | undefined, id = 'item-1'): ItemIndexRow {
+	return { id, seq } as unknown as ItemIndexRow;
+}
+
+describe('shouldWriteRow', () => {
+	it('writes when nothing is stored yet', () => {
+		expect(shouldWriteRow(undefined, row(5))).toBe(true);
+	});
+
+	it('REFUSES a strictly older row — the whole point of the guard', () => {
+		expect(shouldWriteRow(row(7), row(6))).toBe(false);
+		expect(shouldWriteRow(row(7), row(0))).toBe(false);
+	});
+
+	it('writes a newer row', () => {
+		expect(shouldWriteRow(row(6), row(7))).toBe(true);
+	});
+
+	// Equal seq must still write. RAM merges same-seq projections before
+	// persisting (localIndex's mergeRow), so the incoming row IS the merged
+	// one; refusing it would drop that merge and leave the cache behind RAM
+	// with no seq difference to ever correct it.
+	it('writes on equal seq, because RAM has already merged the projection', () => {
+		expect(shouldWriteRow(row(7), row(7))).toBe(true);
+	});
+
+	// A missing seq is not evidence of being older. Refusing would silently
+	// disable the cache for any row the server has not stamped.
+	it('writes when either side has no seq', () => {
+		expect(shouldWriteRow(row(undefined), row(7))).toBe(true);
+		expect(shouldWriteRow(row(7), row(undefined))).toBe(true);
+		expect(shouldWriteRow(row(undefined), row(undefined))).toBe(true);
+	});
+
+	// seq 0 is a real value; treating it as absent would let a stale row
+	// through on the falsy check that `!existing.seq` would perform.
+	it('treats seq 0 as a value, not as missing', () => {
+		expect(shouldWriteRow(row(0), row(1))).toBe(true);
+		expect(shouldWriteRow(row(1), row(0))).toBe(false);
+	});
+
+	// The filed race, expressed as the decision the guard has to make:
+	// a retag snapshot at seq N arriving after a delta at seq N+1.
+	it('refuses the BUG-2609 sequence: an un-bumped snapshot behind a landed delta', () => {
+		const storedByDelta = row(101);
+		const staleSnapshot = row(100);
+		expect(shouldWriteRow(storedByDelta, staleSnapshot)).toBe(false);
+	});
+});
+
+/**
+ * NOT COVERED HERE, stated so nobody reads these as more than they are.
+ *
+ * That the guard runs INSIDE the IDB transaction — i.e. compares against what
+ * is stored at write time rather than at snapshot time — is not asserted by any
+ * test, because this harness has no IndexedDB at all: jsdom does not implement
+ * it, `fake-indexeddb` is not a dependency, and `isSupported()` therefore
+ * returns false, making every function in the persistence module a no-op under
+ * vitest.
+ *
+ * So the interleaving rests on reading two call sites (the `await store.get`
+ * immediately before each `put`, both within the transaction) rather than on a
+ * deterministic hook. Closing that gap means adding `fake-indexeddb` as a dev
+ * dependency, which is a project decision and cannot be done from a worktree
+ * whose node_modules is a symlink — raised rather than assumed.
+ */

--- a/web/src/lib/stores/localIndexPersistence.test.ts
+++ b/web/src/lib/stores/localIndexPersistence.test.ts
@@ -45,12 +45,25 @@ describe('shouldWriteRow', () => {
 		expect(shouldWriteRow(row(7), row(7))).toBe(true);
 	});
 
-	// A missing seq is not evidence of being older. Refusing would silently
-	// disable the cache for any row the server has not stamped.
-	it('writes when either side has no seq', () => {
+	// Missing seq is ASYMMETRIC. An incoming row that carries ordering
+	// evidence beats a stored row that has none, and two unstamped rows have
+	// nothing to arbitrate — but a stored STAMPED row must not be overwritten
+	// by a snapshot with no seq at all.
+	it('writes when the incoming row has the only seq, or neither does', () => {
 		expect(shouldWriteRow(row(undefined), row(7))).toBe(true);
-		expect(shouldWriteRow(row(7), row(undefined))).toBe(true);
 		expect(shouldWriteRow(row(undefined), row(undefined))).toBe(true);
+	});
+
+	// The optimistic reorder path clears seq deliberately, to bypass the RAM
+	// guard so the drag paints immediately (TASK-1357). Persisting that copy
+	// is incidental to the intent, and letting it overwrite a stamped row
+	// leaves the cache holding a row with NO seq while the cursor sits past
+	// the delta that would have fixed it — unorderable by either guard on the
+	// next warm boot. Codex round 4; the previous version of this file
+	// asserted the opposite and enshrined the bug.
+	it('REFUSES a seq-less row over a stamped one', () => {
+		expect(shouldWriteRow(row(7), row(undefined))).toBe(false);
+		expect(shouldWriteRow(row(0), row(undefined))).toBe(false);
 	});
 
 	// seq 0 is a real value; treating it as absent would let a stale row

--- a/web/src/lib/stores/localIndexPersistence.test.ts
+++ b/web/src/lib/stores/localIndexPersistence.test.ts
@@ -66,17 +66,16 @@ describe('shouldWriteRow', () => {
 });
 
 /**
- * persistRetag exists because a rename cannot be expressed as a whole-row
- * snapshot without also asserting every other field, which the seq guard then
- * refuses whenever a newer delta has landed. Losing a rename that way is
- * PERMANENT — a rename touches no items so no delta re-stamps it, and
- * localIndex's pendingRetags repair is in-memory and single-session.
+ * NOT a test of persistRetag — that function is unreachable in this harness
+ * (see the note at the bottom), and a no-op implementation of it would pass
+ * everything in this file. Codex asked for that to be said plainly rather than
+ * left for a reader to work out from the imports.
  *
- * The IDB call itself is not reachable in this harness (see the note below),
- * so what is asserted here is the property that made a separate function
- * necessary: the guard would have dropped the retag.
+ * What IS asserted is the premise that made a separate function necessary: had
+ * retags kept going through persistUpserts, the seq guard would have dropped
+ * them. That premise is checkable here; persistRetag's own behaviour is not.
  */
-describe('why retags cannot go through shouldWriteRow', () => {
+describe('the premise behind persistRetag (guard behaviour, not persistRetag itself)', () => {
 	it('would refuse an un-bumped retag snapshot once a newer delta has landed', () => {
 		const storedByDelta = row(200);
 		// applyRetag copies the row and changes collection_slug WITHOUT
@@ -96,9 +95,19 @@ describe('why retags cannot go through shouldWriteRow', () => {
  * returns false, making every function in the persistence module a no-op under
  * vitest.
  *
- * So the interleaving rests on reading two call sites (the `await store.get`
+ * So the interleaving rests on reading the call sites (the `await store.get`
  * immediately before each `put`, both within the transaction) rather than on a
- * deterministic hook. Closing that gap means adding `fake-indexeddb` as a dev
- * dependency, which is a project decision and cannot be done from a worktree
- * whose node_modules is a symlink — raised rather than assumed.
+ * deterministic hook. The same gap covers persistRetag entirely: nothing here
+ * exercises it, and a no-op version would pass this file.
+ *
+ * What DID verify the transaction actually commits is a live browser run
+ * against a real server — 2625 rows persisted with the fix, and 0 rows with a
+ * control build whose guard refuses every write, which also reproduced the
+ * cursor-ahead-of-rows shape this bug is about. That is evidence the write
+ * path works; it is not a regression test, and it will not run again on its
+ * own.
+ *
+ * Closing the gap properly means adding `fake-indexeddb` as a dev dependency,
+ * which is a project decision and cannot be done from a worktree whose
+ * node_modules is a symlink — raised rather than assumed.
  */

--- a/web/src/lib/stores/localIndexPersistence.test.ts
+++ b/web/src/lib/stores/localIndexPersistence.test.ts
@@ -66,6 +66,27 @@ describe('shouldWriteRow', () => {
 });
 
 /**
+ * persistRetag exists because a rename cannot be expressed as a whole-row
+ * snapshot without also asserting every other field, which the seq guard then
+ * refuses whenever a newer delta has landed. Losing a rename that way is
+ * PERMANENT — a rename touches no items so no delta re-stamps it, and
+ * localIndex's pendingRetags repair is in-memory and single-session.
+ *
+ * The IDB call itself is not reachable in this harness (see the note below),
+ * so what is asserted here is the property that made a separate function
+ * necessary: the guard would have dropped the retag.
+ */
+describe('why retags cannot go through shouldWriteRow', () => {
+	it('would refuse an un-bumped retag snapshot once a newer delta has landed', () => {
+		const storedByDelta = row(200);
+		// applyRetag copies the row and changes collection_slug WITHOUT
+		// bumping seq — this is the value it would have persisted.
+		const retagSnapshot = row(199);
+		expect(shouldWriteRow(storedByDelta, retagSnapshot)).toBe(false);
+	});
+});
+
+/**
  * NOT COVERED HERE, stated so nobody reads these as more than they are.
  *
  * That the guard runs INSIDE the IDB transaction — i.e. compares against what

--- a/web/src/lib/stores/localIndexPersistence.test.ts
+++ b/web/src/lib/stores/localIndexPersistence.test.ts
@@ -37,6 +37,10 @@ describe('shouldWriteRow', () => {
 	// persisting (localIndex's mergeRow), so the incoming row IS the merged
 	// one; refusing it would drop that merge and leave the cache behind RAM
 	// with no seq difference to ever correct it.
+	// Within a tab this is right: upsert returns early on equal seq, and any
+	// row that does reach here has been through RAM's projection merge.
+	// Across tabs it leaves a residual (BUG-2635) — accept-or-refuse is the
+	// wrong axis at equal seq, and a merge is what this layer lacks.
 	it('writes on equal seq, because RAM has already merged the projection', () => {
 		expect(shouldWriteRow(row(7), row(7))).toBe(true);
 	});

--- a/web/src/lib/stores/localIndexPersistence.ts
+++ b/web/src/lib/stores/localIndexPersistence.ts
@@ -318,6 +318,15 @@ export async function persistUpserts(
  * inserting a snapshot here would resurrect rows a delta may have removed.
  * Rows that have MOVED to another collection are skipped too; see
  * shouldApplyRetag.
+ *
+ * LIMIT: this is still a best-effort WRITE, like everything else in this
+ * module, so a rename is lost outright if the transaction aborts (quota,
+ * eviction, tab freeze) — the catch below swallows it and nothing retries.
+ * A lost rename does not self-heal for the same reason it cannot be reordered:
+ * no item delta re-stamps those rows, and pendingRetags is in-memory. That is
+ * the same gap as BUG-2634, reached by failure rather than by racing, and the
+ * fix it proposes — persist the retag INTENT and reapply it on hydrate —
+ * closes both, which is why this is not a separate patch.
  */
 export function shouldApplyRetag(
 	existing: ItemIndexRow | undefined,

--- a/web/src/lib/stores/localIndexPersistence.ts
+++ b/web/src/lib/stores/localIndexPersistence.ts
@@ -315,10 +315,29 @@ export async function persistUpserts(
  * keeps both properties: the newer row's fields survive, and the rename lands.
  * Rows absent from the cache are skipped — there is nothing to rename, and
  * inserting a snapshot here would resurrect rows a delta may have removed.
+ * Rows that have MOVED to another collection are skipped too; see
+ * shouldApplyRetag.
  */
+export function shouldApplyRetag(
+	existing: ItemIndexRow | undefined,
+	collectionId: string,
+	newSlug: string,
+): boolean {
+	if (!existing) return false;
+	// Membership is re-checked HERE, not trusted from the snapshot. A row can
+	// move to another collection between the RAM retag and this transaction,
+	// and applying the renamed collection's slug to it would persist a row
+	// whose collection_id and collection_slug disagree — behind the cursor,
+	// so no delta repairs it (codex round 5).
+	if (existing.collection_id !== collectionId) return false;
+	if (existing.collection_slug === newSlug) return false;
+	return true;
+}
+
 export async function persistRetag(
 	userId: string | null,
 	ws: string,
+	collectionId: string,
 	ids: string[],
 	newSlug: string,
 ): Promise<void> {
@@ -330,9 +349,8 @@ export async function persistRetag(
 		const store = tx.objectStore('items');
 		for (const id of ids) {
 			const existing = (await store.get(id)) as ItemIndexRow | undefined;
-			if (!existing) continue;
-			if (existing.collection_slug === newSlug) continue;
-			store.put({ ...existing, collection_slug: newSlug }).catch(() => undefined);
+			if (!shouldApplyRetag(existing, collectionId, newSlug)) continue;
+			store.put({ ...existing!, collection_slug: newSlug }).catch(() => undefined);
 		}
 		await tx.done;
 	} catch {

--- a/web/src/lib/stores/localIndexPersistence.ts
+++ b/web/src/lib/stores/localIndexPersistence.ts
@@ -196,13 +196,22 @@ export async function hydrate(
  * item happens to change. RAM is unaffected (single-threaded and seq-guarded);
  * only the warm-boot cache can regress.
  *
- * The retag case is worth stating because the outcome looks lossy and is not.
- * `applyRetag` rewrites collection_slug WITHOUT bumping seq, so a delta at a
- * higher seq will now SKIP the retag write. That leaves IDB agreeing with the
- * persisted cursor while its slug lags RAM — which self-heals through the
- * sync-pass reconcile (BUG-2601). The alternative it replaces does not
- * self-heal: a row behind the cursor is invisible to delta sync by
- * construction.
+ * WHAT THIS GUARD DOES NOT COVER, so nobody reads it as covering more:
+ *
+ *   - RETAGS do not come through here at all. `applyRetag` changes
+ *     collection_slug WITHOUT bumping seq, so a whole-row retag snapshot would
+ *     be refused whenever a newer delta had landed — and losing a rename is
+ *     permanent, not self-healing (no item delta re-stamps it, and
+ *     pendingRetags is in-memory and single-session). Renames go through
+ *     persistRetag, which rewrites the one field in place.
+ *
+ *   - HARD DELETES can still be resurrected. If persistDelta removes a row and
+ *     advances the cursor, a delayed snapshot for that id finds nothing stored,
+ *     passes this guard, and reinserts it behind the cursor — the same
+ *     invisible-to-delta-sync shape this bug is about, in the delete direction.
+ *     Refusing it needs a tombstone with its own seq, i.e. an IDB schema
+ *     change; filed as BUG-2633 rather than half-built here. Pre-existing: a
+ *     blind put resurrected it too.
  */
 export function shouldWriteRow(
 	existing: ItemIndexRow | undefined,
@@ -240,6 +249,54 @@ export async function persistUpserts(
 			const existing = (await store.get(row.id)) as ItemIndexRow | undefined;
 			if (!shouldWriteRow(existing, row)) continue;
 			store.put(row).catch(() => undefined);
+		}
+		await tx.done;
+	} catch {
+		/* swallow — best-effort cache */
+	}
+}
+
+/**
+ * Persist a collection RENAME by rewriting `collection_slug` on the given rows
+ * IN PLACE, rather than putting whole snapshots (BUG-2609).
+ *
+ * A retag is a field-level intent — "these rows are in a collection that got
+ * renamed" — and expressing it as a whole-row put makes it two claims at once,
+ * the second of which is false: it also asserts every other field still looks
+ * like the snapshot taken from RAM. That second claim is what the seq guard in
+ * shouldWriteRow has to refuse when a newer delta has landed, and refusing it
+ * drops the rename with it.
+ *
+ * Dropping the rename is NOT self-healing, which is the reason this function
+ * exists instead of an exemption from the guard. `applyRetag` does not bump
+ * seq, a collection rename touches no items so no item delta ever re-stamps
+ * them, and localIndex's `pendingRetags` repair is explicitly in-memory and
+ * scoped to a single session's pre-hydration window. A persisted slug that
+ * loses its rename therefore stays wrong across reloads with nothing left to
+ * correct it.
+ *
+ * Reading each row inside the transaction and changing only the one field
+ * keeps both properties: the newer row's fields survive, and the rename lands.
+ * Rows absent from the cache are skipped — there is nothing to rename, and
+ * inserting a snapshot here would resurrect rows a delta may have removed.
+ */
+export async function persistRetag(
+	userId: string | null,
+	ws: string,
+	ids: string[],
+	newSlug: string,
+): Promise<void> {
+	if (!isSupported() || ids.length === 0) return;
+	const db = await open(userId, ws);
+	if (!db) return;
+	try {
+		const tx = db.transaction('items', 'readwrite');
+		const store = tx.objectStore('items');
+		for (const id of ids) {
+			const existing = (await store.get(id)) as ItemIndexRow | undefined;
+			if (!existing) continue;
+			if (existing.collection_slug === newSlug) continue;
+			store.put({ ...existing, collection_slug: newSlug }).catch(() => undefined);
 		}
 		await tx.done;
 	} catch {

--- a/web/src/lib/stores/localIndexPersistence.ts
+++ b/web/src/lib/stores/localIndexPersistence.ts
@@ -189,9 +189,27 @@ export async function hydrate(
  * correct semantics are a MERGE, which this layer does not have. That leaves a
  * narrow cross-tab residual (BUG-2635): a tab without the row in RAM can
  * persist an unmerged snapshot over another tab's merged one at the same seq.
- * A missing seq on either side writes too — absence is not evidence of being
- * older, and refusing would silently disable the cache for rows the server has
- * not stamped.
+ * A missing seq is treated ASYMMETRICALLY, which is the part worth reading:
+ *
+ *   - stored row has no seq, incoming does  -> WRITE. The incoming row carries
+ *     ordering evidence the stored one lacks.
+ *   - neither has a seq                     -> WRITE. No evidence either way,
+ *     and refusing would disable the cache for rows the server never stamped.
+ *   - stored row HAS a seq, incoming does not -> REFUSE.
+ *
+ * That last case is not symmetry-breaking for its own sake. The optimistic
+ * reorder path deliberately clears `seq` so the row bypasses localIndex's RAM
+ * guard and paints immediately (TASK-1357); persisting it is incidental to
+ * that intent. Allowing it here lets a delayed optimistic snapshot overwrite an
+ * authoritative row that already landed at a real seq, and the result is worse
+ * than an ordinary stale row: the persisted row then has NO seq at all, so
+ * neither this guard nor the RAM guard can order it on the next warm boot,
+ * while the cursor sits past the delta that would have corrected it.
+ *
+ * Refusing costs nothing the reorder needs. RAM still shows the optimistic
+ * order, and the authoritative response persists with a real seq moments later
+ * — and because the cursor has not advanced past that response, a warm boot in
+ * the meantime simply refetches it.
  *
  * WHY THIS EXISTS. `upsert` hands persistUpserts a snapshot taken from RAM and
  * does not await it. (`applyRetag` used to as well; it now goes through
@@ -234,7 +252,9 @@ export function shouldWriteRow(
 	next: ItemIndexRow,
 ): boolean {
 	if (!existing) return true;
-	if (existing.seq === undefined || next.seq === undefined) return true;
+	if (existing.seq === undefined) return true;
+	// Stored row is stamped and the incoming one is not: no claim to be newer.
+	if (next.seq === undefined) return false;
 	return next.seq >= existing.seq;
 }
 

--- a/web/src/lib/stores/localIndexPersistence.ts
+++ b/web/src/lib/stores/localIndexPersistence.ts
@@ -180,8 +180,9 @@ export async function hydrate(
  * id. The IDB analogue of localIndex's in-RAM `mergeRow` seq guard, which the
  * persistence layer never had (BUG-2609).
  *
- * Returns false ONLY when `next` is strictly older than what is stored. Equal
- * seq still writes: RAM merges same-seq projections before persisting, so the
+ * Returns false in exactly two cases: `next` is strictly older than what is
+ * stored, or `next` carries no seq while the stored row does (see the
+ * asymmetry note below). Equal seq still writes: RAM merges same-seq projections before persisting, so the
  * incoming row is the merged one, and refusing it would drop that merge.
  * Refusing would also mirror the bug onto persistDelta, where a re-delivered
  * same-seq row carrying computed projection fields would be skipped. The

--- a/web/src/lib/stores/localIndexPersistence.ts
+++ b/web/src/lib/stores/localIndexPersistence.ts
@@ -183,6 +183,12 @@ export async function hydrate(
  * Returns false ONLY when `next` is strictly older than what is stored. Equal
  * seq still writes: RAM merges same-seq projections before persisting, so the
  * incoming row is the merged one, and refusing it would drop that merge.
+ * Refusing would also mirror the bug onto persistDelta, where a re-delivered
+ * same-seq row carrying computed projection fields would be skipped. The
+ * honest reading is that accept-or-refuse is the wrong axis at equal seq — the
+ * correct semantics are a MERGE, which this layer does not have. That leaves a
+ * narrow cross-tab residual (BUG-2635): a tab without the row in RAM can
+ * persist an unmerged snapshot over another tab's merged one at the same seq.
  * A missing seq on either side writes too — absence is not evidence of being
  * older, and refusing would silently disable the cache for rows the server has
  * not stamped.

--- a/web/src/lib/stores/localIndexPersistence.ts
+++ b/web/src/lib/stores/localIndexPersistence.ts
@@ -176,6 +176,44 @@ export async function hydrate(
 }
 
 /**
+ * Decide whether `next` may overwrite the row already stored under the same
+ * id. The IDB analogue of localIndex's in-RAM `mergeRow` seq guard, which the
+ * persistence layer never had (BUG-2609).
+ *
+ * Returns false ONLY when `next` is strictly older than what is stored. Equal
+ * seq still writes: RAM merges same-seq projections before persisting, so the
+ * incoming row is the merged one, and refusing it would drop that merge.
+ * A missing seq on either side writes too — absence is not evidence of being
+ * older, and refusing would silently disable the cache for rows the server has
+ * not stamped.
+ *
+ * WHY THIS EXISTS. `upsert` and `applyRetag` hand persistUpserts a snapshot
+ * taken from RAM and do not await it. An SSE delta for the same row can commit
+ * its own atomic rows+cursor transaction in between, after which the older
+ * snapshot lands LAST and leaves IDB holding a pre-delta row while the
+ * persisted cursor sits past that delta. Warm boot then hydrates the stale row
+ * and `/items-changes?since=cursor` never returns it again — stale until the
+ * item happens to change. RAM is unaffected (single-threaded and seq-guarded);
+ * only the warm-boot cache can regress.
+ *
+ * The retag case is worth stating because the outcome looks lossy and is not.
+ * `applyRetag` rewrites collection_slug WITHOUT bumping seq, so a delta at a
+ * higher seq will now SKIP the retag write. That leaves IDB agreeing with the
+ * persisted cursor while its slug lags RAM — which self-heals through the
+ * sync-pass reconcile (BUG-2601). The alternative it replaces does not
+ * self-heal: a row behind the cursor is invisible to delta sync by
+ * construction.
+ */
+export function shouldWriteRow(
+	existing: ItemIndexRow | undefined,
+	next: ItemIndexRow,
+): boolean {
+	if (!existing) return true;
+	if (existing.seq === undefined || next.seq === undefined) return true;
+	return next.seq >= existing.seq;
+}
+
+/**
  * Upsert a batch of rows in a single transaction. Used by
  * `applyDelta`/`bootstrap` write-through. Batching matters when an
  * SSE flurry arrives — a single tx is much cheaper than N
@@ -192,8 +230,15 @@ export async function persistUpserts(
 	try {
 		const tx = db.transaction('items', 'readwrite');
 		const store = tx.objectStore('items');
-		// Fire-and-forget per-row put; the .done promise waits for them all.
+		// Read-modify-write per row, INSIDE the transaction, so the comparison
+		// is against what is stored at write time rather than at snapshot
+		// time. A blind put here is what let an older snapshot land after a
+		// newer delta (BUG-2609). The extra get doubles the operations on a
+		// cache write-through, which is cheap next to a row that goes stale
+		// until the item next changes.
 		for (const row of rows) {
+			const existing = (await store.get(row.id)) as ItemIndexRow | undefined;
+			if (!shouldWriteRow(existing, row)) continue;
 			store.put(row).catch(() => undefined);
 		}
 		await tx.done;
@@ -231,7 +276,13 @@ export async function persistDelta(
 	try {
 		const tx = db.transaction(['items', 'meta'], 'readwrite');
 		const itemsStore = tx.objectStore('items');
+		// Same guard as persistUpserts: the race runs in both directions, so a
+		// delta must not overwrite a row that is already NEWER in the cache
+		// either. Skipping a row here is safe with the cursor advance below —
+		// a newer stored row already reflects state past this delta.
 		for (const row of rows) {
+			const existing = (await itemsStore.get(row.id)) as ItemIndexRow | undefined;
+			if (!shouldWriteRow(existing, row)) continue;
 			itemsStore.put(row).catch(() => undefined);
 		}
 		for (const id of removeIds) {

--- a/web/src/lib/stores/localIndexPersistence.ts
+++ b/web/src/lib/stores/localIndexPersistence.ts
@@ -187,8 +187,9 @@ export async function hydrate(
  * older, and refusing would silently disable the cache for rows the server has
  * not stamped.
  *
- * WHY THIS EXISTS. `upsert` and `applyRetag` hand persistUpserts a snapshot
- * taken from RAM and do not await it. An SSE delta for the same row can commit
+ * WHY THIS EXISTS. `upsert` hands persistUpserts a snapshot taken from RAM and
+ * does not await it. (`applyRetag` used to as well; it now goes through
+ * persistRetag, for the reason in the exclusion list below.) An SSE delta for the same row can commit
  * its own atomic rows+cursor transaction in between, after which the older
  * snapshot lands LAST and leaves IDB holding a pre-delta row while the
  * persisted cursor sits past that delta. Warm boot then hydrates the stale row
@@ -204,6 +205,15 @@ export async function hydrate(
  *     permanent, not self-healing (no item delta re-stamps it, and
  *     pendingRetags is in-memory and single-session). Renames go through
  *     persistRetag, which rewrites the one field in place.
+ *
+ *     That closes the direction where the RETAG is the late write. It does not
+ *     close the reverse: a delta captured before the rename can commit after
+ *     it, whole-row put an older collection_slug at a NEWER seq, and pass this
+ *     guard legitimately. collection_slug simply is not ordered by seq — it is
+ *     out-of-band relative to the item's own version — so no seq comparison
+ *     can arbitrate it. Fixing that means making the rename DURABLE (persisted
+ *     retag intent, reapplied on hydrate) rather than a racing write; filed as
+ *     BUG-2634. Pre-existing — a blind put lost the same race.
  *
  *   - HARD DELETES can still be resurrected. If persistDelta removes a row and
  *     advances the cursor, a delayed snapshot for that id finds nothing stored,


### PR DESCRIPTION
Fixes BUG-2609.

`upsert` hands `persistUpserts` a snapshot taken from RAM and does not await it. An SSE delta for the same row can commit its own atomic rows+cursor transaction in between, after which the older snapshot lands **last**: IndexedDB holds a pre-delta row while the persisted cursor sits past that delta. Warm boot hydrates the stale row and `/items-changes?since=cursor` never returns it again — stale until the item happens to change. RAM is unaffected (single-threaded, already seq-guarded by `mergeRow`), which is why this only ever surfaced as a warm-boot regression.

## The fix

The guard localIndex has had in RAM all along, applied at the layer that lacked it: a **read-modify-write inside the transaction**, comparing against what is *stored* at write time rather than what was in RAM at snapshot time. Both writers get it, because the race runs in both directions.

The missing-seq rule is **asymmetric**, and that took a review round to get right. An incoming row carrying ordering evidence beats a stored row with none; two unstamped rows have nothing to arbitrate; but a stored **stamped** row refuses a snapshot with no seq. The optimistic reorder path deliberately clears `seq` to bypass the RAM guard so a drag paints immediately (TASK-1357) — persisting that copy is incidental, and allowing it let a delayed optimistic snapshot overwrite an authoritative row, leaving a persisted row with *no seq at all*: unorderable by either guard on the next warm boot, behind an advanced cursor.

**Renames get their own path.** A retag is a field-level intent — "these rows are in a collection that got renamed" — and expressing it as a whole-row put makes a second claim (that every other field still matches the snapshot) which the guard then has to refuse, dropping the rename with it. `persistRetag` reads each row in the transaction and changes only `collection_slug`, re-checking collection membership there rather than trusting the snapshot: a row that moved between the RAM retag and the write would otherwise be persisted with a `collection_id` and `collection_slug` that disagree.

## Verification

The failure mode of getting the transaction wrong is **silent** — awaiting inside an `idb` transaction risks it auto-closing mid-loop, after which the remaining puts throw into a swallowed catch and the cache quietly stops being written, which is worse than the bug. In-repo precedent said it was safe (`hydrate` already awaits a get and keeps using the same tx); a **live browser run** confirmed it: **2625 rows persisted, all seq-stamped, cursor advanced, zero page errors**.

That check was itself validated against a **control build** whose guard refuses every write: **0 rows, cursor still advanced** — which also reproduces the cursor-ahead-of-rows shape this bug is about, so the instrument demonstrably reads the thing it claims to.

Six mutations on the decision helpers, each failing only its own assertion.

**What is NOT covered, stated in the test file rather than left to inference:** there is no IndexedDB in this harness — a plain `.test.ts` runs in vitest's `node` project, Node has no `indexedDB`, the jsdom project doesn't implement one, and `fake-indexeddb` is not a dependency. So the transaction interleaving and `persistRetag` itself are unreachable by test; a no-op `persistRetag` would pass the whole file. The live run is evidence the write path works, **not** a regression test — it will not run again on its own. Closing that gap means adding `fake-indexeddb`, which is a project decision and cannot be done from a worktree whose `node_modules` is a symlink.

## Three residuals, filed rather than half-built

They are one family — the persisted cache has no total order and no merge semantics of its own — and each has a distinct fix, so **BUG-2635 carries the cross-links and suggests triaging them as a batch**; one pass giving the cache real order-and-merge semantics beats three patches.

- **BUG-2633** — a hard-deleted row leaves no `existing` to compare against, so a delayed snapshot resurrects it behind the cursor. Needs tombstones carrying the removal seq (IDB schema change).
- **BUG-2634** — `collection_slug` is out-of-band relative to `seq`, so a rename loses to any delta captured before it, *and* is lost outright if the retag transaction aborts. Needs durable retag intent reapplied on hydrate. Both triggers recorded on the item.
- **BUG-2635** — equal seq needs a **merge**, not accept-or-refuse; a cross-tab unmerged snapshot can regress projection metadata. Narrow: `persistUpserts` now has one caller, which returns early on equal seq when it has the row in RAM.

Each is named at the point in the code where the decision is made, so a reader meets the limit rather than inferring the guard covers more than it does.

## Review — 10 Codex rounds

Two findings were defects in my own work rather than pre-existing gaps: the missing-seq symmetry (my test **enshrined** it), and `persistRetag` trusting snapshot membership — in a function that exists *because* trusting a snapshot at write time is unsafe.

One was a correction to a claim I had already shipped in a commit message: I wrote that a skipped retag "self-heals through the sync-pass reconcile", and the code says the opposite where I should have read it — *"a rename touches no items, so no delta ever will"*, and pendingRetags is *"not persisted"*. Fixed by design (persistRetag) rather than by rewording.

## Gates

| gate | result |
|---|---|
| `npx vitest run` | 94 files, 1685 tests pass |
| `svelte-check` | 0 errors (6 pre-existing warnings) |
| `make lint` | 0 issues |
| `go test ./...` | pass |
| live browser | 2625 rows persisted, 0 page errors; control build 0 rows |
| Codex | CLEAN after 10 rounds, two consecutive fresh-angle |
