### PR TITLE
feat(cli): pad session arm/disarm/status + consent config resolution (PLAN-2613 S2, TASK-2617)

### DIFF
--- a/cmd/pad/cmd_session.go
+++ b/cmd/pad/cmd_session.go
@@ -169,6 +169,11 @@ type sessionStatusJSON struct {
 	AutoArm     bool `json:"auto_arm"`
 	AutoArmRepo bool `json:"auto_arm_repo"`
 	AutoArmVeto bool `json:"auto_arm_user_veto"`
+	// AutoArmConfigError is true when the per-user config.toml exists but
+	// couldn't be read; auto-arm then resolves off (fail closed) and this
+	// says so, so the off state reads as "couldn't confirm" rather than
+	// "not opted in".
+	AutoArmConfigError bool `json:"auto_arm_config_error"`
 	// Announced is what a stream this session opens now would declare:
 	// LocalArmed OR AutoArm.
 	Announced bool `json:"announced_armed"`
@@ -197,11 +202,12 @@ func sessionStatusCmd() *cobra.Command {
 			localArmed := cli.SessionArmedLocally()
 
 			st := sessionStatusJSON{
-				LocalArmed:  localArmed,
-				AutoArm:     decision.Armed,
-				AutoArmRepo: decision.RepoAutoArm,
-				AutoArmVeto: decision.UserVeto,
-				Announced:   localArmed || decision.Armed,
+				LocalArmed:         localArmed,
+				AutoArm:            decision.Armed,
+				AutoArmRepo:        decision.RepoAutoArm,
+				AutoArmVeto:        decision.UserVeto,
+				AutoArmConfigError: decision.ConfigUnreadable,
+				Announced:          localArmed || decision.Armed,
 			}
 			if ws, err := cli.DetectWorkspace(workspaceFlag); err == nil {
 				st.Workspace = ws
@@ -233,7 +239,18 @@ type sessionCounts struct{ connected, accepting int }
 // misleading zero.
 func serverSessionCounts() (sessionCounts, bool) {
 	cfg, err := config.Load()
-	if err != nil || !cfg.IsConfigured() {
+	if err != nil {
+		return sessionCounts{}, false
+	}
+	// Apply the directory's .pad.toml `url` override exactly as the
+	// monitor does (cmd_watch.go's monitorClient), so status queries the
+	// SAME server the monitor connects to. Without this, a repo whose
+	// .pad.toml points at server B would report server A's sessions — or,
+	// with only a repo URL set, wrongly report the server unreachable
+	// (Codex R1 MED-2). The override can also flip Mode to remote, which
+	// makes an otherwise-"not configured" global config usable.
+	applyPadTomlOverride(cfg)
+	if !cfg.IsConfigured() {
 		return sessionCounts{}, false
 	}
 	if err := cli.EnsureServer(cfg); err != nil {
@@ -272,6 +289,8 @@ func printSessionStatus(st sessionStatusJSON) {
 	switch {
 	case st.AutoArm:
 		auto = "on (.pad.toml push.auto_arm)"
+	case st.AutoArmConfigError:
+		auto = "off (user config unreadable — failing closed)"
 	case st.AutoArmVeto:
 		auto = "off (vetoed by per-user config)"
 	}

--- a/cmd/pad/cmd_session.go
+++ b/cmd/pad/cmd_session.go
@@ -3,20 +3,28 @@ package main
 import (
 	"fmt"
 	"os"
+	"text/tabwriter"
 
 	"github.com/spf13/cobra"
 
 	"github.com/PerpetualSoftware/pad/internal/cli"
+	"github.com/PerpetualSoftware/pad/internal/config"
 )
 
-// sessionCmd groups session-registry commands (TASK-2533).
+// sessionCmd groups session-registry commands (TASK-2533) and the
+// arm/disarm/status consent verbs (PLAN-2613 S2, TASK-2617).
 func sessionCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "session",
-		Short: "Manage this machine's on-disk pad session registry",
+		Short: "Manage this session's pad registry entry and push-arming",
 		RunE:  unknownSubcommandRun,
 	}
-	cmd.AddCommand(sessionRegisterCmd())
+	cmd.AddCommand(
+		sessionRegisterCmd(),
+		sessionArmCmd(),
+		sessionDisarmCmd(),
+		sessionStatusCmd(),
+	)
 	return cmd
 }
 
@@ -60,4 +68,225 @@ workspace (.pad.toml) — and safe to call more than once per session
 			return nil
 		},
 	}
+}
+
+// sessionArmCmd is `pad session arm` (PLAN-2613 S2, TASK-2617): the
+// explicit in-session consent verb. It declares that THIS session accepts
+// `pad push` notifications by writing the local arm-state file
+// (internal/cli/session_arm_state.go) that a monitor reads to decide
+// whether the stream it opens announces armed=true.
+//
+// Idempotent (D7): re-running it just refreshes the file. The effect
+// reaches the server the next time this session's stream connects, since
+// arming is declared at connect (the server bit from S1 is the delivery
+// authority, D3); a monitor already streaming before the arm re-reads on
+// its next reconnect — mid-session re-arm of a live monitor is the S3
+// lockfile's job, not this verb's.
+func sessionArmCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "arm",
+		Short: "Declare that this session accepts pad push notifications",
+		Long: `Arm this session: declare consent to receive 'pad push' notifications.
+
+Writes a local, session-scoped arm-state file. A push monitor for this
+session announces armed=true to the server on its next stream connect,
+and only armed sessions receive pushes (the consent gate). Run
+'pad session disarm' to withdraw consent, or 'pad session status' to see
+the current state.
+
+Arming is per-session and transient. To opt a whole REPOSITORY in without
+arming each session by hand, set 'push.auto_arm = true' under a [push]
+table in the repo's .pad.toml (a deliberate, committed choice).`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			path, err := cli.WriteArmState()
+			if err != nil {
+				return err
+			}
+			if formatFlag == "json" {
+				return cli.PrintJSON(map[string]any{
+					"armed": true,
+					"path":  path,
+				})
+			}
+			fmt.Println("Armed this session — it will accept pad push notifications.")
+			fmt.Println("Takes effect when the session's push monitor next connects.")
+			fmt.Println("Run 'pad session disarm' to withdraw, or 'pad session status' to check.")
+			return nil
+		},
+	}
+}
+
+// sessionDisarmCmd is `pad session disarm` (PLAN-2613 S2, TASK-2617): the
+// withdrawal verb. It removes this session's arm-state file, so a monitor
+// stops announcing armed on its next connect. Idempotent — disarming a
+// session that was never armed is a success, not an error.
+func sessionDisarmCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "disarm",
+		Short: "Withdraw this session's consent to pad push notifications",
+		Long: `Disarm this session: remove its local arm-state file so it stops
+accepting 'pad push' notifications.
+
+Idempotent — disarming a session that was not armed still succeeds.
+
+Note: this withdraws an EXPLICIT 'pad session arm'. If the repository
+opted in via .pad.toml 'push.auto_arm = true', the session still auto-arms
+by policy; remove that setting to stop it.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			removed, path, err := cli.RemoveArmState()
+			if err != nil {
+				return err
+			}
+			if formatFlag == "json" {
+				return cli.PrintJSON(map[string]any{
+					"armed":     false,
+					"was_armed": removed,
+					"path":      path,
+				})
+			}
+			if removed {
+				fmt.Println("Disarmed this session — it no longer accepts pad push notifications.")
+			} else {
+				fmt.Println("This session was not armed; nothing to disarm.")
+			}
+			return nil
+		},
+	}
+}
+
+// sessionStatusJSON is the JSON shape of `pad session status` (a stable
+// contract S4's composer and other tooling can read).
+type sessionStatusJSON struct {
+	Workspace string `json:"workspace,omitempty"`
+	// LocalArmed is whether THIS session has a live local arm declaration
+	// (the explicit `pad session arm` path). It reflects intent on this
+	// machine, not server state.
+	LocalArmed bool `json:"local_armed"`
+	// AutoArm is the resolved .pad.toml + per-user config decision (the
+	// auto path).
+	AutoArm     bool `json:"auto_arm"`
+	AutoArmRepo bool `json:"auto_arm_repo"`
+	AutoArmVeto bool `json:"auto_arm_user_veto"`
+	// Announced is what a stream this session opens now would declare:
+	// LocalArmed OR AutoArm.
+	Announced bool `json:"announced_armed"`
+	// ServerReachable reports whether the server answered; when false the
+	// session counts are unknown, not zero.
+	ServerReachable bool `json:"server_reachable"`
+	Connected       int  `json:"connected_sessions"`
+	Accepting       int  `json:"accepting_sessions"`
+}
+
+// sessionStatusCmd is `pad session status` (PLAN-2613 S2, TASK-2617):
+// reports this session's arming — the resolved local/auto decision and
+// what a stream would announce — plus the server's own view of how many
+// of the user's sessions are connected and accepting pushes.
+//
+// Deliberately resilient: an unreachable server degrades the session
+// counts to "unknown" rather than failing the command, because the local
+// arm/config half is still worth reporting when padd is down.
+func sessionStatusCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "status",
+		Short: "Show this session's push-arming state and the server's session view",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			decision := cli.ResolveAutoArmFromDisk()
+			localArmed := cli.SessionArmedLocally()
+
+			st := sessionStatusJSON{
+				LocalArmed:  localArmed,
+				AutoArm:     decision.Armed,
+				AutoArmRepo: decision.RepoAutoArm,
+				AutoArmVeto: decision.UserVeto,
+				Announced:   localArmed || decision.Armed,
+			}
+			if ws, err := cli.DetectWorkspace(workspaceFlag); err == nil {
+				st.Workspace = ws
+			}
+
+			// Server view — best effort. Build the client without
+			// getClient()'s os.Exit-on-failure so a down server degrades
+			// gracefully (see this command's doc comment).
+			if counts, ok := serverSessionCounts(); ok {
+				st.ServerReachable = true
+				st.Connected = counts.connected
+				st.Accepting = counts.accepting
+			}
+
+			if formatFlag == "json" {
+				return cli.PrintJSON(st)
+			}
+			printSessionStatus(st)
+			return nil
+		},
+	}
+}
+
+type sessionCounts struct{ connected, accepting int }
+
+// serverSessionCounts fetches the caller's live sessions from the server,
+// returning ok=false (not an error) when the server can't be reached or
+// the client isn't configured — the caller reports "unknown", never a
+// misleading zero.
+func serverSessionCounts() (sessionCounts, bool) {
+	cfg, err := config.Load()
+	if err != nil || !cfg.IsConfigured() {
+		return sessionCounts{}, false
+	}
+	if err := cli.EnsureServer(cfg); err != nil {
+		return sessionCounts{}, false
+	}
+	client := cli.NewClientFromURL(cfg.BaseURL())
+	resp, err := client.ListSessions()
+	if err != nil || resp == nil {
+		return sessionCounts{}, false
+	}
+	var counts sessionCounts
+	counts.connected = resp.Count
+	for _, s := range resp.Sessions {
+		if s.Armed {
+			counts.accepting++
+		}
+	}
+	return counts, true
+}
+
+func printSessionStatus(st sessionStatusJSON) {
+	tw := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+	ws := st.Workspace
+	if ws == "" {
+		ws = "(not linked)"
+	}
+	fmt.Fprintf(tw, "Workspace:\t%s\n", ws)
+
+	local := "not armed"
+	if st.LocalArmed {
+		local = "armed (pad session arm)"
+	}
+	fmt.Fprintf(tw, "Local arm:\t%s\n", local)
+
+	auto := "off"
+	switch {
+	case st.AutoArm:
+		auto = "on (.pad.toml push.auto_arm)"
+	case st.AutoArmVeto:
+		auto = "off (vetoed by per-user config)"
+	}
+	fmt.Fprintf(tw, "Auto-arm:\t%s\n", auto)
+
+	announced := "no — this session will NOT receive pushes"
+	if st.Announced {
+		announced = "yes — this session declares consent on connect"
+	}
+	fmt.Fprintf(tw, "Announced:\t%s\n", announced)
+
+	if st.ServerReachable {
+		fmt.Fprintf(tw, "Server sees:\t%d connected, %d accepting pushes\n", st.Connected, st.Accepting)
+	} else {
+		fmt.Fprintf(tw, "Server sees:\t(unreachable — session counts unknown)\n")
+	}
+	tw.Flush()
 }

--- a/cmd/pad/cmd_session.go
+++ b/cmd/pad/cmd_session.go
@@ -242,14 +242,20 @@ func serverSessionCounts() (sessionCounts, bool) {
 	if err != nil {
 		return sessionCounts{}, false
 	}
-	// Apply the directory's .pad.toml `url` override exactly as the
-	// monitor does (cmd_watch.go's monitorClient), so status queries the
-	// SAME server the monitor connects to. Without this, a repo whose
-	// .pad.toml points at server B would report server A's sessions — or,
-	// with only a repo URL set, wrongly report the server unreachable
-	// (Codex R1 MED-2). The override can also flip Mode to remote, which
-	// makes an otherwise-"not configured" global config usable.
-	applyPadTomlOverride(cfg)
+	// Resolve the target server exactly as the client entry points do: an
+	// explicit --url wins (and promotes Mode to remote), otherwise the
+	// directory's .pad.toml `url` override applies. Without this, status
+	// would query the global config's server while the monitor connects to
+	// the repo's (Codex R1 MED-2), and `--url B` would be ignored entirely
+	// (Codex R2 finding 5).
+	if urlFlag != "" {
+		cfg.URL = urlFlag
+		cfg.LoadedFromFlags = true
+		if cfg.Mode == "" || cfg.Mode == config.ModeLocal {
+			cfg.Mode = config.ModeRemote
+		}
+	}
+	applyPadTomlOverride(cfg) // no-op when --url set (LoadedFromFlags)
 	if !cfg.IsConfigured() {
 		return sessionCounts{}, false
 	}

--- a/cmd/pad/cmd_session_test.go
+++ b/cmd/pad/cmd_session_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestMonitorSessionIdentity_ArmedFromAutoArm is the S2 end-to-end wiring
+// check (PLAN-2613 D4): a repository that opted in via .pad.toml [push]
+// auto_arm makes the monitor announce armed=true, and a repository that
+// did not stays unarmed. This is what carries the whole auto path from
+// config to the ?armed=true the client sends — without it, S1's server
+// gate would have nothing declaring consent.
+func TestMonitorSessionIdentity_ArmedFromAutoArm(t *testing.T) {
+	tests := []struct {
+		name        string
+		padTomlBody string
+		wantArmed   bool
+	}{
+		{"auto_arm repo announces armed", "workspace = \"demo\"\n[push]\nauto_arm = true\n", true},
+		{"no auto_arm stays unarmed (safe default)", "workspace = \"demo\"\n", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			// No socket and a fresh HOME → no local arm-state file, so
+			// Armed is decided purely by the auto_arm config resolution.
+			t.Setenv("CLAUDE_CODE_MESSAGING_SOCKET", "")
+			dataDir := filepath.Join(home, ".pad")
+			if err := os.MkdirAll(dataDir, 0700); err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv("PAD_DATA_DIR", dataDir)
+
+			repo := t.TempDir()
+			if err := os.WriteFile(filepath.Join(repo, ".pad.toml"), []byte(tc.padTomlBody), 0600); err != nil {
+				t.Fatal(err)
+			}
+			orig, _ := os.Getwd()
+			if err := os.Chdir(repo); err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { _ = os.Chdir(orig) })
+
+			if got := monitorSessionIdentity().Armed; got != tc.wantArmed {
+				t.Fatalf("monitorSessionIdentity().Armed = %v, want %v", got, tc.wantArmed)
+			}
+		})
+	}
+}

--- a/cmd/pad/cmd_watch.go
+++ b/cmd/pad/cmd_watch.go
@@ -355,6 +355,15 @@ func monitorSessionIdentity() cli.StreamSessionIdentity {
 	// S2→S3 rollout, before the plugin's on-skill-invoke arming exists.
 	// The server's own armed bit (D3/S1) remains the delivery authority;
 	// this only decides what the client ANNOUNCES.
+	//
+	// This value is snapshotted here, at connect. A `pad session disarm`
+	// that lands AFTER this read but before the stream request is sent
+	// leaves the just-opened connection announcing armed=true until its
+	// next reconnect (Codex R2 finding 4) — an inherent check-then-connect
+	// TOCTOU, bounded to one reconnect window and re-evaluated every
+	// reconnect (the monitor re-reads on each loop iteration). Fully
+	// closing it needs a server-side disarm signal on an already-open
+	// connection, which is S3's reconnect/heal job, not this snapshot's.
 	ident.Armed = cli.SessionArmedLocally() || cli.ResolveAutoArmFromDisk().Armed
 	return ident
 }

--- a/cmd/pad/cmd_watch.go
+++ b/cmd/pad/cmd_watch.go
@@ -347,6 +347,15 @@ func monitorSessionIdentity() cli.StreamSessionIdentity {
 			ident.Label = base
 		}
 	}
+	// PLAN-2613 S2: announce consent. A session arms when EITHER it has a
+	// live local arm declaration (`pad session arm`, the explicit path) OR
+	// its repository opted in via .pad.toml [push] auto_arm with no
+	// per-user veto (the auto path, D4). Both default to off, so a monitor
+	// on a repo that did neither stays unarmed — the safe skew during the
+	// S2→S3 rollout, before the plugin's on-skill-invoke arming exists.
+	// The server's own armed bit (D3/S1) remains the delivery authority;
+	// this only decides what the client ANNOUNCES.
+	ident.Armed = cli.SessionArmedLocally() || cli.ResolveAutoArmFromDisk().Armed
 	return ident
 }
 

--- a/internal/cli/arm_consent.go
+++ b/internal/cli/arm_consent.go
@@ -1,0 +1,92 @@
+package cli
+
+import "github.com/PerpetualSoftware/pad/internal/config"
+
+// Arm-consent resolution (PLAN-2613 S2, D4).
+//
+// "Arming" is a session's declaration that it consents to receive `pad
+// push` notifications — the security gate S1 built server-side (a stream
+// declares armed=true at connect and only armed streams receive
+// KindPush; see internal/server/session_identity.go). Nothing decided
+// WHETHER to arm yet. This file is that decision for the AUTO path: a
+// repository opts its sessions in through .pad.toml, a user can veto it
+// globally, and the default everywhere is off.
+//
+// The EXPLICIT path — an in-session `pad session arm` toggle — layers on
+// top of this (its state overrides the resolved value); the running
+// plugin monitor's mid-session re-arm is the S3 lockfile's job. This
+// resolver is the piece both paths and the status verb share, so it is a
+// pure function of its two inputs with a separate loader for the IO.
+
+// ResolveAutoArm decides whether a session should auto-arm at connect,
+// from the two config sources, with default OFF (PLAN-2613 D4).
+//
+// The full table (repoAutoArm = .pad.toml [push] auto_arm; userAutoArm =
+// ~/.pad/config.toml [push] auto_arm):
+//
+//	repo=false, user=nil    → false  (default: not opted in)
+//	repo=false, user=&true  → false  (a per-user true is NOT an enabler —
+//	                                   D4 forbids a machine-global
+//	                                   always-on, so it cannot arm a repo
+//	                                   that didn't opt in itself)
+//	repo=false, user=&false → false
+//	repo=true,  user=nil    → true   (repo opted in, user has no opinion)
+//	repo=true,  user=&true  → true
+//	repo=true,  user=&false → false  (VETO — deny-wins: a per-user
+//	                                   explicit false forces off even over
+//	                                   a repo opt-in)
+//
+// The last row is the one decision the design under-specified ("deny-
+// wins: .pad.toml over per-user"). It is resolved deny-wins — the
+// security-conservative reading for a consent gate: a user who has said
+// "never auto-arm me" must not be re-armed by a committed .pad.toml they
+// pulled from someone else's opt-in. The alternative (repo overrides the
+// user's global off) is exactly the surprise a consent gate exists to
+// prevent, so a per-repo enable cannot override a per-user disable.
+func ResolveAutoArm(repoAutoArm bool, userAutoArm *bool) bool {
+	if userAutoArm != nil && !*userAutoArm {
+		return false // per-user veto — deny-wins
+	}
+	return repoAutoArm
+}
+
+// ArmDecision is the resolved arm state plus the inputs that produced it,
+// so callers (notably `pad session status`) can explain WHY a session is
+// or isn't arming rather than just reporting the bit.
+type ArmDecision struct {
+	// Armed is the resolved auto-arm value — the same bool a connecting
+	// stream would declare for this repo, absent an explicit in-session
+	// override.
+	Armed bool
+	// RepoAutoArm is the .pad.toml [push] auto_arm value (false when no
+	// workspace is linked).
+	RepoAutoArm bool
+	// UserVeto is true when the per-user config explicitly set auto_arm
+	// to false — the one thing that forces Armed off over a repo opt-in.
+	UserVeto bool
+}
+
+// ResolveAutoArmFromDisk loads both config sources (the nearest .pad.toml
+// and the user's config.toml) and returns the resolved auto-arm
+// decision. Failures degrade to the safe default: an unreadable or
+// missing source contributes "not opted in" / "no veto" rather than an
+// error, because a consent gate must fail CLOSED (off), and a torn config
+// file should never silently arm a session — nor block one path of a CLI
+// verb that has other useful things to report.
+func ResolveAutoArmFromDisk() ArmDecision {
+	repoAutoArm := false
+	if pt, err := LoadPadToml(); err == nil {
+		repoAutoArm = pt.PadTomlAutoArm()
+	}
+
+	var userAutoArm *bool
+	if cfg, err := config.Load(); err == nil {
+		userAutoArm = cfg.PushAutoArm()
+	}
+
+	return ArmDecision{
+		Armed:       ResolveAutoArm(repoAutoArm, userAutoArm),
+		RepoAutoArm: repoAutoArm,
+		UserVeto:    userAutoArm != nil && !*userAutoArm,
+	}
+}

--- a/internal/cli/arm_consent.go
+++ b/internal/cli/arm_consent.go
@@ -64,6 +64,12 @@ type ArmDecision struct {
 	// UserVeto is true when the per-user config explicitly set auto_arm
 	// to false — the one thing that forces Armed off over a repo opt-in.
 	UserVeto bool
+	// ConfigUnreadable is true when the user's config.toml exists but
+	// could not be read or parsed. The decision fails CLOSED (Armed
+	// false) in that case, because a veto that cannot be read must be
+	// assumed present; the flag lets `pad session status` explain the
+	// off state honestly rather than as an ordinary "not opted in".
+	ConfigUnreadable bool
 }
 
 // ResolveAutoArmFromDisk loads both config sources (the nearest .pad.toml
@@ -74,14 +80,26 @@ type ArmDecision struct {
 // file should never silently arm a session — nor block one path of a CLI
 // verb that has other useful things to report.
 func ResolveAutoArmFromDisk() ArmDecision {
+	// A .pad.toml that exists but can't be parsed leaves repoAutoArm
+	// false — a repo can't opt in through a file we can't read, which is
+	// already the fail-closed direction.
 	repoAutoArm := false
 	if pt, err := LoadPadToml(); err == nil {
 		repoAutoArm = pt.PadTomlAutoArm()
 	}
 
-	var userAutoArm *bool
-	if cfg, err := config.Load(); err == nil {
-		userAutoArm = cfg.PushAutoArm()
+	// The per-user config is read STRICTLY (config.LoadPushConfigAutoArm,
+	// not the lenient config.Load): an existing-but-unreadable config.toml
+	// means we cannot confirm the user hasn't vetoed, so the auto path
+	// must NOT arm (Codex R1 HIGH-1). Local explicit arm is a separate
+	// signal and is unaffected.
+	userAutoArm, err := config.LoadPushConfigAutoArm()
+	if err != nil {
+		return ArmDecision{
+			Armed:            false,
+			RepoAutoArm:      repoAutoArm,
+			ConfigUnreadable: true,
+		}
 	}
 
 	return ArmDecision{

--- a/internal/cli/arm_consent_test.go
+++ b/internal/cli/arm_consent_test.go
@@ -116,3 +116,35 @@ func TestResolveAutoArmFromDisk_ReadsBothSources(t *testing.T) {
 		})
 	}
 }
+
+// TestResolveAutoArmFromDisk_UnreadableConfigFailsClosed is the Codex R1
+// HIGH-1 regression: a repo that opted into auto_arm must NOT arm when the
+// per-user config.toml exists but can't be parsed — a veto we can't read
+// must be assumed present (fail closed), and the decision must say why.
+func TestResolveAutoArmFromDisk_UnreadableConfigFailsClosed(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	dataDir := filepath.Join(home, ".pad")
+	if err := os.MkdirAll(dataDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PAD_DATA_DIR", dataDir)
+	// A config.toml that exists but is not valid TOML.
+	if err := os.WriteFile(filepath.Join(dataDir, "config.toml"), []byte("this is [not valid"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	repoDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(repoDir, ".pad.toml"), []byte("workspace = \"demo\"\n[push]\nauto_arm = true\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	chdir(t, repoDir)
+
+	got := ResolveAutoArmFromDisk()
+	if got.Armed {
+		t.Fatal("repo opt-in + unreadable user config must fail closed (not armed)")
+	}
+	if !got.ConfigUnreadable {
+		t.Fatal("ConfigUnreadable must be set so status can explain the off state")
+	}
+}

--- a/internal/cli/arm_consent_test.go
+++ b/internal/cli/arm_consent_test.go
@@ -1,0 +1,118 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func boolPtr(b bool) *bool { return &b }
+
+// TestResolveAutoArm is the full consent truth table (PLAN-2613 S2, D4).
+// Every row is a distinct assertion so a mutation that flips one cell —
+// dropping the veto, making a per-user true an enabler, defaulting on —
+// fails on exactly that row and names it.
+func TestResolveAutoArm(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		repoAutoArm bool
+		userAutoArm *bool
+		want        bool
+	}{
+		{"default: neither set", false, nil, false},
+		{"per-user true is NOT an enabler (no machine-global always-on)", false, boolPtr(true), false},
+		{"per-user false with no repo opt-in stays off", false, boolPtr(false), false},
+		{"repo opt-in, user no opinion", true, nil, true},
+		{"repo opt-in, user also true", true, boolPtr(true), true},
+		{"repo opt-in VETOED by per-user false (deny-wins)", true, boolPtr(false), false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := ResolveAutoArm(tc.repoAutoArm, tc.userAutoArm); got != tc.want {
+				t.Fatalf("ResolveAutoArm(%v, %v) = %v, want %v", tc.repoAutoArm, tc.userAutoArm, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestResolveAutoArmFromDisk_ReadsBothSources wires the resolver to the
+// two real config files: a repo .pad.toml and the per-user config.toml.
+// It exercises the enable path and the veto path end to end, so a
+// regression in either loader (wrong toml key, wrong nil-handling) shows
+// up here and not just in the pure resolver.
+func TestResolveAutoArmFromDisk_ReadsBothSources(t *testing.T) {
+	// Not parallel: mutates HOME and the working directory.
+	tests := []struct {
+		name        string
+		padTomlBody string
+		configBody  string
+		wantArmed   bool
+		wantRepo    bool
+		wantVeto    bool
+	}{
+		{
+			name:        "repo opt-in, no user config → armed",
+			padTomlBody: "workspace = \"demo\"\n[push]\nauto_arm = true\n",
+			configBody:  "",
+			wantArmed:   true,
+			wantRepo:    true,
+			wantVeto:    false,
+		},
+		{
+			name:        "repo opt-in vetoed by per-user false → not armed",
+			padTomlBody: "workspace = \"demo\"\n[push]\nauto_arm = true\n",
+			configBody:  "[push]\nauto_arm = false\n",
+			wantArmed:   false,
+			wantRepo:    true,
+			wantVeto:    true,
+		},
+		{
+			name:        "no [push] table anywhere → default off",
+			padTomlBody: "workspace = \"demo\"\n",
+			configBody:  "",
+			wantArmed:   false,
+			wantRepo:    false,
+			wantVeto:    false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			// config.Load keys the user config off PAD_DATA_DIR when set;
+			// point it at HOME/.pad so the per-user config.toml is found.
+			dataDir := filepath.Join(home, ".pad")
+			if err := os.MkdirAll(dataDir, 0700); err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv("PAD_DATA_DIR", dataDir)
+			if tc.configBody != "" {
+				if err := os.WriteFile(filepath.Join(dataDir, "config.toml"), []byte(tc.configBody), 0600); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			repoDir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(repoDir, ".pad.toml"), []byte(tc.padTomlBody), 0600); err != nil {
+				t.Fatal(err)
+			}
+			chdir(t, repoDir)
+
+			got := ResolveAutoArmFromDisk()
+			if got.Armed != tc.wantArmed {
+				t.Errorf("Armed = %v, want %v", got.Armed, tc.wantArmed)
+			}
+			if got.RepoAutoArm != tc.wantRepo {
+				t.Errorf("RepoAutoArm = %v, want %v", got.RepoAutoArm, tc.wantRepo)
+			}
+			if got.UserVeto != tc.wantVeto {
+				t.Errorf("UserVeto = %v, want %v", got.UserVeto, tc.wantVeto)
+			}
+		})
+	}
+}

--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -411,6 +411,14 @@ type StreamSessionIdentity struct {
 	// PID is this process's own pid, for telling two sessions with the
 	// same label apart.
 	PID int
+	// Armed is PLAN-2613 S2's consent declaration: when true, the stream
+	// request carries ?armed=true and the server admits this connection to
+	// KindPush delivery (the gate S1 built). False — the zero value — is
+	// the legacy/unarmed shape and receives ordinary watch-matched events
+	// only. Unlike Label/PID this rides a query param, not a header: see
+	// server.sessionArmedQueryParam for why (audit-visible by design, and
+	// reachable by a future non-CLI client that can't set headers).
+	Armed bool
 }
 
 // NewWatchEventsStreamRequest builds an authenticated GET request for
@@ -438,6 +446,18 @@ func (c *Client) NewWatchEventsStreamRequest(ctx context.Context, lastEventID st
 	}
 	if ident.PID > 0 {
 		req.Header.Set("X-Pad-Session-Pid", strconv.Itoa(ident.PID))
+	}
+	if ident.Armed {
+		// The consent declaration is a QUERY PARAM, not a header —
+		// server.sessionArmedQueryParam documents why (a plain audit-safe
+		// boolean, and reachable by a browser EventSource that can't set
+		// headers). The literal "armed" and the exact value "true" are the
+		// wire contract that side matches; only "true" counts as armed
+		// there, so an unarmed session sends nothing rather than
+		// armed=false.
+		q := req.URL.Query()
+		q.Set("armed", "true")
+		req.URL.RawQuery = q.Encode()
 	}
 	return req, nil
 }

--- a/internal/cli/client_sessions.go
+++ b/internal/cli/client_sessions.go
@@ -1,0 +1,37 @@
+package cli
+
+// Client access to the caller's live event-stream sessions (PLAN-2613
+// S2). GET /api/v1/sessions is self-scoped — it returns only the
+// authenticated user's own connections (handlers_sessions.go) — so `pad
+// session status` can report how many of THIS user's sessions the server
+// currently sees, and how many of those are armed.
+
+// LiveSession mirrors server.LiveSession's JSON shape (the wire contract
+// of GET /api/v1/sessions). Only the fields `pad session status` reads
+// are declared; extra fields in the response are ignored.
+type LiveSession struct {
+	ID          string `json:"id"`
+	Label       string `json:"label,omitempty"`
+	PID         int    `json:"pid,omitempty"`
+	Armed       bool   `json:"armed"`
+	ConnectedAt string `json:"connected_at"`
+}
+
+// SessionsResponse is the body of GET /api/v1/sessions.
+type SessionsResponse struct {
+	Sessions []LiveSession `json:"sessions"`
+	Count    int           `json:"count"`
+}
+
+// ListSessions returns the caller's currently-connected event-stream
+// sessions as the server sees them. This is authoritative for delivery
+// (the server's armed bit is the sole authority — PLAN-2613 D3/S1),
+// unlike the LOCAL arm-state file, which only reflects a session's
+// declared intent on this machine.
+func (c *Client) ListSessions() (*SessionsResponse, error) {
+	var resp SessionsResponse
+	if err := c.get("/sessions", &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}

--- a/internal/cli/client_stream_identity_test.go
+++ b/internal/cli/client_stream_identity_test.go
@@ -109,6 +109,58 @@ func TestNewWatchEventsStreamRequest_UnsendableLabelStillConnects(t *testing.T) 
 	}
 }
 
+// TestNewWatchEventsStreamRequest_ArmedSendsQueryParam is PLAN-2613 S2's
+// client half: an armed identity must reach the server as ?armed=true (a
+// query param, not a header — see StreamSessionIdentity.Armed). Asserted
+// by the round trip, matching the label test's stance: the value only
+// matters if it actually arrives, and it is what admits the connection to
+// push delivery, so a broken wiring is a silent consent failure.
+func TestNewWatchEventsStreamRequest_ArmedSendsQueryParam(t *testing.T) {
+	t.Parallel()
+
+	var gotArmed string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotArmed = r.URL.Query().Get("armed")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := NewClientFromURL(srv.URL)
+	req, err := c.NewWatchEventsStreamRequest(context.Background(), "", StreamSessionIdentity{Armed: true})
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request not sendable: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// Exactly "true" — the server treats only that value as armed, so
+	// anything else would be a silent no-consent.
+	if gotArmed != "true" {
+		t.Fatalf("armed query param = %q, want %q", gotArmed, "true")
+	}
+}
+
+// TestNewWatchEventsStreamRequest_UnarmedOmitsQueryParam pins absence, not
+// armed=false. Sending armed=false would be indistinguishable at the
+// server (only "true" counts) but invites a reader to treat "present but
+// false" as meaningful, and it must never look like a partially-armed
+// state. A zero identity carries no armed param at all.
+func TestNewWatchEventsStreamRequest_UnarmedOmitsQueryParam(t *testing.T) {
+	t.Parallel()
+
+	c := NewClientFromURL("http://127.0.0.1:0")
+	req, err := c.NewWatchEventsStreamRequest(context.Background(), "", StreamSessionIdentity{Label: "docapp"})
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	if _, ok := req.URL.Query()["armed"]; ok {
+		t.Fatalf("expected no armed query param for an unarmed identity, got %q", req.URL.RawQuery)
+	}
+}
+
 // TestHeaderSafeLabel covers the pieces the round trip above can't show
 // individually.
 func TestHeaderSafeLabel(t *testing.T) {

--- a/internal/cli/pid_alive.go
+++ b/internal/cli/pid_alive.go
@@ -1,0 +1,34 @@
+package cli
+
+import (
+	"errors"
+	"os"
+	"syscall"
+)
+
+// pidAlive reports whether a process with the given pid is currently
+// running. It is used only by the headless (no-socket) arm-state liveness
+// fallback (see armStateOwnerAlive) and errs toward "dead" on any
+// uncertainty, because that is the fail-closed direction for a consent
+// gate: a session wrongly judged dead simply doesn't arm.
+//
+// On Unix, os.FindProcess never fails, so liveness is probed with signal
+// 0: a nil error means the process exists, EPERM means it exists but is
+// owned by another user (still alive), and ESRCH (or anything else) means
+// it is gone. On platforms where signalling is unsupported (Windows), the
+// probe returns an error and this reports dead — acceptable, since the
+// headless fallback is explicitly secondary to auto_arm there.
+func pidAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	err = proc.Signal(syscall.Signal(0))
+	if err == nil {
+		return true
+	}
+	return errors.Is(err, syscall.EPERM)
+}

--- a/internal/cli/proc_start_linux.go
+++ b/internal/cli/proc_start_linux.go
@@ -1,0 +1,39 @@
+//go:build linux
+
+package cli
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// procStartToken returns a stable owner-identity token for a pid on
+// Linux: the process's start time (field 22 of /proc/<pid>/stat, in clock
+// ticks since boot). It is constant for the life of a process and differs
+// for a reused pid, so comparing it defeats the pid-reuse hazard the
+// headless arm-state fallback would otherwise have (Codex R1 HIGH-2). ok
+// is false when the value can't be read, in which case the caller falls
+// back to bare pid-liveness.
+//
+// The comm field (2) is wrapped in parentheses and may itself contain
+// spaces or parentheses, so parsing starts after the LAST ')': the fields
+// that follow are space-separated, and starttime is the 22nd overall —
+// index 19 once pid and comm are dropped.
+func procStartToken(pid int) (string, bool) {
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid))
+	if err != nil {
+		return "", false
+	}
+	s := string(data)
+	rparen := strings.LastIndexByte(s, ')')
+	if rparen < 0 || rparen+1 >= len(s) {
+		return "", false
+	}
+	fields := strings.Fields(s[rparen+1:])
+	const startTimeIndexAfterComm = 19 // field 22 minus pid(1) and comm(2)
+	if len(fields) <= startTimeIndexAfterComm {
+		return "", false
+	}
+	return fields[startTimeIndexAfterComm], true
+}

--- a/internal/cli/proc_start_linux.go
+++ b/internal/cli/proc_start_linux.go
@@ -13,13 +13,19 @@ import (
 // ticks since boot). It is constant for the life of a process and differs
 // for a reused pid, so comparing it defeats the pid-reuse hazard the
 // headless arm-state fallback would otherwise have (Codex R1 HIGH-2). ok
-// is false when the value can't be read, in which case the caller falls
-// back to bare pid-liveness.
+// is false when the value can't be read, in which case the caller treats
+// the owner as unverifiable and fails closed.
+//
+// A ZOMBIE (state 'Z') reports ok=false even though its /proc entry and
+// start time still exist: the arming process has exited and is only
+// awaiting reap, so its consent is dead. Without this a defunct arm
+// command would keep a headless session armed until its parent reaped it
+// (Codex R2 finding 3).
 //
 // The comm field (2) is wrapped in parentheses and may itself contain
 // spaces or parentheses, so parsing starts after the LAST ')': the fields
-// that follow are space-separated, and starttime is the 22nd overall —
-// index 19 once pid and comm are dropped.
+// that follow are space-separated. State is the 3rd field overall (index
+// 0 after comm) and starttime is the 22nd (index 19 after comm).
 func procStartToken(pid int) (string, bool) {
 	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid))
 	if err != nil {
@@ -31,9 +37,15 @@ func procStartToken(pid int) (string, bool) {
 		return "", false
 	}
 	fields := strings.Fields(s[rparen+1:])
-	const startTimeIndexAfterComm = 19 // field 22 minus pid(1) and comm(2)
+	const (
+		stateIndexAfterComm     = 0  // field 3
+		startTimeIndexAfterComm = 19 // field 22, minus pid(1) and comm(2)
+	)
 	if len(fields) <= startTimeIndexAfterComm {
 		return "", false
+	}
+	if fields[stateIndexAfterComm] == "Z" {
+		return "", false // zombie: the arming process has exited
 	}
 	return fields[startTimeIndexAfterComm], true
 }

--- a/internal/cli/proc_start_linux_test.go
+++ b/internal/cli/proc_start_linux_test.go
@@ -1,0 +1,55 @@
+//go:build linux
+
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+)
+
+// TestProcStartToken_CurrentProcess: on Linux the token is readable and
+// stable for a live process (a sanity check that the /proc parsing works).
+func TestProcStartToken_CurrentProcess(t *testing.T) {
+	tok, ok := procStartToken(os.Getpid())
+	if !ok || tok == "" {
+		t.Fatalf("expected a proc-start token for the current pid, got ok=%v tok=%q", ok, tok)
+	}
+	tok2, _ := procStartToken(os.Getpid())
+	if tok != tok2 {
+		t.Fatalf("proc-start token must be stable: %q != %q", tok, tok2)
+	}
+}
+
+// TestArmState_HeadlessPidReuseRejected is the Codex R1 HIGH-2 regression
+// for the headless path on Linux: a live pid whose recorded owner-identity
+// token does NOT match (a reused pid belonging to an unrelated process)
+// must read as disarmed, not armed.
+func TestArmState_HeadlessPidReuseRejected(t *testing.T) {
+	repo := armStateTestEnv(t, "") // headless, cwd-keyed, pid liveness
+
+	path, err := armStatePath("", repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A file owned by THIS (alive) pid but stamped with a different
+	// proc-start token — the shape of a reused pid.
+	st := ArmState{
+		Armed:     true,
+		PID:       os.Getpid(),
+		ProcStart: "0", // guaranteed not to match this process's real start
+		Cwd:       repo,
+		StartedAt: "2026-08-18T00:00:00Z",
+	}
+	data, _ := json.MarshalIndent(st, "", "  ")
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if SessionArmedLocally() {
+		t.Fatal("a live pid with a mismatched owner-identity token must NOT arm (pid reuse)")
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("reused-pid file must be reaped; stat err = %v", err)
+	}
+}

--- a/internal/cli/proc_start_other.go
+++ b/internal/cli/proc_start_other.go
@@ -1,0 +1,13 @@
+//go:build !linux
+
+package cli
+
+// procStartToken has no portable non-Linux implementation, so it returns
+// ok=false and the headless arm-state liveness check falls back to bare
+// pid-liveness. This is the documented residual on the secondary
+// (headless, cwd-keyed) arming path — the sanctioned headless path is
+// .pad.toml auto_arm, which carries no pid identity at all. See
+// armStateOwnerAlive.
+func procStartToken(pid int) (string, bool) {
+	return "", false
+}

--- a/internal/cli/session_arm_state.go
+++ b/internal/cli/session_arm_state.go
@@ -81,6 +81,15 @@ type ArmState struct {
 	// with a different mtime; the reader requires an exact match, which
 	// ties the file to the specific socket instance it was armed for.
 	SocketMtimeUnixNano int64 `json:"socket_mtime_unix_nano,omitempty"`
+	// SocketIno / SocketDev are the socket node's inode and device at arm
+	// time (0 on platforms where they can't be read). They are the
+	// STRONGEST identity signal: a socket rebound at the same path gets a
+	// new inode, so this rejects both a lingering stale node reused as-is
+	// and an mtime collision on a coarse-resolution filesystem (Codex R2
+	// finding 2). Where unavailable (non-unix), the reader falls back to
+	// the mtime check alone — the documented residual on those platforms.
+	SocketIno uint64 `json:"socket_ino,omitempty"`
+	SocketDev uint64 `json:"socket_dev,omitempty"`
 	// ProcStart is an opaque owner-identity token for the HEADLESS
 	// fallback (empty when socket-keyed, or when the platform can't supply
 	// one). It disambiguates PID reuse: a bare "is this pid alive" check
@@ -158,10 +167,15 @@ func WriteArmState() (path string, err error) {
 		StartedAt: time.Now().UTC().Format(time.RFC3339),
 	}
 	if socket != "" {
-		// Bind the file to this specific socket instance (its mtime), not
-		// just the path, so a reused path can't revive it (HIGH-2).
+		// Bind the file to this specific socket instance — its mtime plus,
+		// where available, its inode+device — not just the path, so a
+		// reused path (or a lingering stale node) can't revive it (HIGH-2,
+		// R2 finding 2).
 		if info, statErr := os.Stat(socket); statErr == nil {
 			st.SocketMtimeUnixNano = info.ModTime().UnixNano()
+			if ino, dev, ok := statIdentity(info); ok {
+				st.SocketIno, st.SocketDev = ino, dev
+			}
 		}
 	} else {
 		// Headless: record an owner-identity token so pid reuse can't
@@ -256,18 +270,20 @@ func readArmState() (st *ArmState, path string, err error) {
 // armed file must never arm a future monitor, so "alive" means the
 // recorded owner is not merely present but the SAME owner:
 //
-//   - Socket-keyed: the socket path must still exist AND its mtime must
-//     match the one recorded at arm time. A reused path is a different
-//     socket instance with a different bind time, so the mtime mismatch
-//     rejects it. A file that recorded no mtime (only possible if the
-//     socket had vanished at arm time) can't prove identity and is dead.
+//   - Socket-keyed: the socket path must still exist AND its recorded
+//     identity must match — inode+device where available (the strongest
+//     signal: a rebound socket gets a new inode), else the socket's
+//     mtime. A reused path, a lingering stale node, or an mtime collision
+//     are all rejected. A file that recorded no mtime (only possible if
+//     the socket had vanished at arm time) can't prove identity and is
+//     dead.
 //   - Headless: the pid must be alive AND, when an owner-identity token
-//     was recorded and can be re-read now, it must match — so a reused
-//     pid belonging to an unrelated process is rejected. Where the
-//     platform supplies no token (ProcStart empty, or unreadable now),
-//     this falls back to bare pid-liveness: the documented residual on
-//     the secondary path (the sanctioned headless arming path is
-//     auto_arm, not this file).
+//     was RECORDED, it must be re-readable now AND match — so a reused pid
+//     (or one whose /proc entry we can no longer verify) is rejected
+//     rather than trusted. Only a file that recorded NO token (a non-Linux
+//     arm) falls back to bare pid-liveness: the documented residual on the
+//     secondary path (the sanctioned headless arming path is auto_arm, not
+//     this file).
 //
 // Anything uncertain is dead (fail closed).
 func armStateOwnerAlive(st *ArmState) bool {
@@ -282,6 +298,15 @@ func armStateOwnerAlive(st *ArmState) bool {
 		if st.SocketMtimeUnixNano == 0 {
 			return false // no identity recorded — can't prove it's ours
 		}
+		// Prefer inode+device when both the file recorded them and the
+		// current node exposes them: it distinguishes a rebound socket at
+		// the same path from the original. Fall back to mtime only when
+		// identity isn't available on this platform.
+		if st.SocketIno != 0 {
+			if ino, dev, ok := statIdentity(info); ok {
+				return ino == st.SocketIno && dev == st.SocketDev
+			}
+		}
 		return info.ModTime().UnixNano() == st.SocketMtimeUnixNano
 	}
 	// Headless fallback: the pid is the owner we have. A pid <= 0 is never
@@ -292,9 +317,13 @@ func armStateOwnerAlive(st *ArmState) bool {
 		return false
 	}
 	if st.ProcStart != "" {
-		if now, ok := procStartToken(st.PID); ok {
-			return now == st.ProcStart // reject a reused pid
-		}
+		// A token was recorded (a Linux arm), so it must be re-readable and
+		// match. If it can't be read now (pid gone from /proc, or a zombie —
+		// procStartToken reports not-ok for state 'Z'), fail closed rather
+		// than trusting bare pid-liveness, which a reused pid would pass
+		// (Codex R2 finding 3).
+		now, ok := procStartToken(st.PID)
+		return ok && now == st.ProcStart
 	}
 	return true
 }

--- a/internal/cli/session_arm_state.go
+++ b/internal/cli/session_arm_state.go
@@ -68,10 +68,28 @@ type ArmState struct {
 	// headless fallback it IS the liveness signal.
 	PID int `json:"pid"`
 	// Socket is CLAUDE_CODE_MESSAGING_SOCKET at arm time, or "" for the
-	// headless fallback. When set, its continued existence on disk is the
-	// authoritative liveness signal — it outlives the short-lived arm
-	// command and vanishes with the Claude Code session.
+	// headless fallback. When set, its continued existence on disk is a
+	// necessary liveness signal — it outlives the short-lived arm command
+	// and vanishes with the Claude Code session.
 	Socket string `json:"socket,omitempty"`
+	// SocketMtimeUnixNano is the socket file's modification time at arm
+	// time (0 when headless). Existence alone is not enough: a socket
+	// PATH can be reused by a later, unrelated Claude Code session, and a
+	// stale arm file keyed on that path would then arm the new session —
+	// consent-grandfathering (Codex R1 HIGH-2). The socket file's mtime is
+	// its bind (creation) time, so a reused path is a DIFFERENT socket
+	// with a different mtime; the reader requires an exact match, which
+	// ties the file to the specific socket instance it was armed for.
+	SocketMtimeUnixNano int64 `json:"socket_mtime_unix_nano,omitempty"`
+	// ProcStart is an opaque owner-identity token for the HEADLESS
+	// fallback (empty when socket-keyed, or when the platform can't supply
+	// one). It disambiguates PID reuse: a bare "is this pid alive" check
+	// can't tell the original arming process from an unrelated later
+	// process that happens to reuse its pid. On Linux this is the
+	// process's start time from /proc; where unavailable it is empty and
+	// the reader falls back to bare pid-liveness (the documented residual
+	// on the secondary path — see armStateOwnerAlive).
+	ProcStart string `json:"proc_start,omitempty"`
 	// Cwd is the working directory at arm time — the fallback key's source
 	// and useful human context when inspecting the file.
 	Cwd string `json:"cwd"`
@@ -139,14 +157,55 @@ func WriteArmState() (path string, err error) {
 		Cwd:       cwd,
 		StartedAt: time.Now().UTC().Format(time.RFC3339),
 	}
+	if socket != "" {
+		// Bind the file to this specific socket instance (its mtime), not
+		// just the path, so a reused path can't revive it (HIGH-2).
+		if info, statErr := os.Stat(socket); statErr == nil {
+			st.SocketMtimeUnixNano = info.ModTime().UnixNano()
+		}
+	} else {
+		// Headless: record an owner-identity token so pid reuse can't
+		// revive this file (best effort — empty where unsupported).
+		st.ProcStart, _ = procStartToken(st.PID)
+	}
 	data, err := json.MarshalIndent(st, "", "  ")
 	if err != nil {
 		return "", fmt.Errorf("marshal arm state: %w", err)
 	}
-	if err := os.WriteFile(p, data, 0600); err != nil {
+	// Atomic write: a reader must never observe a half-written file (a
+	// partial file would be an unparseable "malformed" state, and now that
+	// readers reap malformed files, a torn write could be reaped mid-arm).
+	// Write to a temp file in the same directory, then rename — rename is
+	// atomic within a filesystem.
+	if err := atomicWriteFile(p, data, 0600); err != nil {
 		return "", fmt.Errorf("write arm state: %w", err)
 	}
 	return p, nil
+}
+
+// atomicWriteFile writes data to a temp file in path's directory and
+// renames it into place, so a concurrent reader sees either the old file
+// or the complete new one, never a partial write.
+func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".arm-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName) // no-op after a successful rename
+	if err := tmp.Chmod(perm); err != nil {
+		tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, path)
 }
 
 // RemoveArmState disarms the current session by removing its arm-state
@@ -193,29 +252,51 @@ func readArmState() (st *ArmState, path string, err error) {
 }
 
 // armStateOwnerAlive implements the mandatory liveness check (constraint
-// 2). A socket-keyed file is alive iff its recorded socket still exists on
-// disk — that outlives the short-lived arm command and disappears with
-// the Claude Code session. A headless (no-socket) file is alive iff its
-// recorded pid is still running. Anything uncertain is dead (fail
-// closed): a stale armed file must never arm a future monitor.
+// 2), hardened against owner-identity reuse (Codex R1 HIGH-2). A stale
+// armed file must never arm a future monitor, so "alive" means the
+// recorded owner is not merely present but the SAME owner:
+//
+//   - Socket-keyed: the socket path must still exist AND its mtime must
+//     match the one recorded at arm time. A reused path is a different
+//     socket instance with a different bind time, so the mtime mismatch
+//     rejects it. A file that recorded no mtime (only possible if the
+//     socket had vanished at arm time) can't prove identity and is dead.
+//   - Headless: the pid must be alive AND, when an owner-identity token
+//     was recorded and can be re-read now, it must match — so a reused
+//     pid belonging to an unrelated process is rejected. Where the
+//     platform supplies no token (ProcStart empty, or unreadable now),
+//     this falls back to bare pid-liveness: the documented residual on
+//     the secondary path (the sanctioned headless arming path is
+//     auto_arm, not this file).
+//
+// Anything uncertain is dead (fail closed).
 func armStateOwnerAlive(st *ArmState) bool {
 	if st == nil {
 		return false
 	}
 	if st.Socket != "" {
-		if _, err := os.Stat(st.Socket); err != nil {
-			return false
+		info, err := os.Stat(st.Socket)
+		if err != nil {
+			return false // socket vanished — session gone
 		}
-		return true
+		if st.SocketMtimeUnixNano == 0 {
+			return false // no identity recorded — can't prove it's ours
+		}
+		return info.ModTime().UnixNano() == st.SocketMtimeUnixNano
 	}
-	// Headless fallback: the pid is the only owner we have. A pid <= 0 is
-	// never a live owner; a short-lived arm command's pid will usually be
-	// gone by the time a reader looks, which is exactly why this path is
-	// documented as secondary to auto_arm.
-	if st.PID <= 0 {
+	// Headless fallback: the pid is the owner we have. A pid <= 0 is never
+	// a live owner; a short-lived arm command's pid will usually be gone
+	// by the time a reader looks, which is why this path is documented as
+	// secondary to auto_arm.
+	if st.PID <= 0 || !pidAlive(st.PID) {
 		return false
 	}
-	return pidAlive(st.PID)
+	if st.ProcStart != "" {
+		if now, ok := procStartToken(st.PID); ok {
+			return now == st.ProcStart // reject a reused pid
+		}
+	}
+	return true
 }
 
 // SessionArmedLocally reports whether THIS session has a live local arm
@@ -232,15 +313,40 @@ func armStateOwnerAlive(st *ArmState) bool {
 // see cmd/pad's monitor wiring.
 func SessionArmedLocally() bool {
 	st, path, err := readArmState()
-	if err != nil || st == nil {
+	if err != nil {
+		// A file that exists but can't be parsed is corrupt. With atomic
+		// writes it can't be a torn in-progress arm, so reap it (best
+		// effort) rather than leaving it to linger against the reaping
+		// rule (Codex R1 LOW). Fail closed regardless.
+		if path != "" {
+			reapArmFile(path)
+		}
+		return false
+	}
+	if st == nil {
 		return false
 	}
 	if !armStateOwnerAlive(st) {
-		// Dead owner: reap the stale file (best effort — a failed removal
-		// still yields "not armed", which is the safe answer) so it can't
-		// arm a future reader.
-		_ = os.Remove(path)
+		// Dead owner: reap the stale file so it can't arm a future reader
+		// (constraint 2). A failed removal still yields "not armed", the
+		// safe answer.
+		reapArmFile(path)
 		return false
 	}
 	return true
+}
+
+// reapArmFile removes a stale arm file, but only after RE-READING it and
+// confirming it is still stale — so a concurrent `pad session arm` that
+// rewrote a fresh, live file between our first read and now is not
+// destroyed (a non-destructive reap; Codex R1 MED-1). A tiny window
+// remains between this re-check and the removal, but both outcomes are
+// safe: at worst a just-armed session is disarmed and must re-arm (fail
+// closed), never the reverse. Best effort throughout — a lingering file
+// is simply re-evaluated on the next read.
+func reapArmFile(path string) {
+	if st, _, err := readArmState(); err == nil && st != nil && armStateOwnerAlive(st) {
+		return // someone re-armed with a live owner — leave it
+	}
+	_ = os.Remove(path)
 }

--- a/internal/cli/session_arm_state.go
+++ b/internal/cli/session_arm_state.go
@@ -1,0 +1,246 @@
+package cli
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// Local arm-state file (PLAN-2613 S2, D4; lead ruling "OPTION 2" on the
+// TASK-2617 trail). This is the concrete file contract S3's plugin
+// monitor builds against, so its rules are load-bearing and stated in
+// full here (and mirrored in the S2 evidence package):
+//
+//   - WHAT IT IS. One file per SESSION recording that the session has
+//     armed — declared consent to receive `pad push` notifications. A
+//     separate process (S3's monitor) reads it to decide whether the
+//     stream it opens should announce armed=true. It is how a short-lived
+//     `pad session arm` command hands its intent to the long-lived
+//     monitor that actually holds the stream.
+//
+//   - IT IS LOCAL CLIENT STATE, NOT SERVER STATE (constraint 4). It feeds
+//     exactly one thing: the ?armed=true query param the client sends at
+//     connect. The SERVER's per-connection armed bit (PLAN-2613 D3, built
+//     in S1) remains the SOLE authority for whether a push is delivered.
+//     No reader may treat this file as proof that any server-side session
+//     is armed — the server never sees it.
+//
+//   - LIVENESS IS MANDATORY (constraint 2, non-negotiable). A file whose
+//     OWNER is dead is treated as DISARMED and may be removed by any
+//     reader. "Owner dead" means: the recorded messaging socket has
+//     vanished (the Claude Code session it belonged to is gone), or — for
+//     the headless fallback with no socket — the recorded pid is no
+//     longer running. This is the whole reason the file carries owner
+//     identity rather than a bare bit: a crashed session's stale armed
+//     file must NEVER arm a future monitor. That would be consent-
+//     grandfathering through the filesystem, exactly the silent re-arm
+//     PLAN-2613 D6 forbids. When in doubt the check fails CLOSED (treats
+//     the owner as dead / the session as disarmed).
+//
+//   - KEYED PER SESSION (constraint 1). The key is derived from
+//     CLAUDE_CODE_MESSAGING_SOCKET, which both the arming command and the
+//     monitor see because they run in the same Claude Code session. With
+//     no socket (a headless agent), the key falls back to the working
+//     directory — PER-REPO semantics, documented as secondary: the
+//     sanctioned headless arming path is .pad.toml auto_arm (D4), not
+//     this file, because a short-lived `pad session arm` in a headless
+//     shell owns nothing long-lived for liveness to track (its own pid
+//     dies with the command). See armStateOwnerAlive.
+//
+//   - LIFECYCLE (constraint 3). arm writes/overwrites the file
+//     (idempotent). disarm and a clean monitor exit remove it. Both are
+//     ordinary CLI actions visible in the session transcript (D7).
+
+// ArmState is one session's on-disk arm declaration. Presence of the file
+// (with a live owner) is what "armed" means; the fields exist to prove
+// the owner is still alive, not to carry a mutable armed bit. Armed is
+// serialized as a constant true purely so a human inspecting this
+// security artifact reads intent at a glance — a file that exists always
+// means armed, and disarm removes it rather than flipping it.
+type ArmState struct {
+	Armed bool `json:"armed"`
+	// PID is the process that wrote the file. For a socket-keyed session
+	// it is informational (the socket is the liveness signal); for the
+	// headless fallback it IS the liveness signal.
+	PID int `json:"pid"`
+	// Socket is CLAUDE_CODE_MESSAGING_SOCKET at arm time, or "" for the
+	// headless fallback. When set, its continued existence on disk is the
+	// authoritative liveness signal — it outlives the short-lived arm
+	// command and vanishes with the Claude Code session.
+	Socket string `json:"socket,omitempty"`
+	// Cwd is the working directory at arm time — the fallback key's source
+	// and useful human context when inspecting the file.
+	Cwd string `json:"cwd"`
+	// StartedAt is RFC3339 UTC.
+	StartedAt string `json:"started_at"`
+}
+
+// armStateKey derives the per-session key and reports whether the
+// headless (per-repo) fallback was used. socket wins when present; cwd is
+// the fallback. Both are hashed so the filename is filesystem-safe and
+// leaks neither the socket path nor the absolute cwd into a directory
+// listing.
+func armStateKey(socket, cwd string) (key string, headless bool) {
+	if socket != "" {
+		return "sess-" + shortHash(socket), false
+	}
+	return "repo-" + shortHash(cwd), true
+}
+
+func shortHash(s string) string {
+	sum := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(sum[:])[:16]
+}
+
+// armStatePath returns the on-disk path for this session's arm-state
+// file, creating ~/.pad/sessions if needed.
+func armStatePath(socket, cwd string) (string, error) {
+	dir, err := SessionsDir()
+	if err != nil {
+		return "", err
+	}
+	key, _ := armStateKey(socket, cwd)
+	return filepath.Join(dir, "arm-"+key+".json"), nil
+}
+
+// currentSessionArmKey returns the (socket, cwd) pair identifying THIS
+// process's session, read from the environment and the working directory.
+// A cwd error degrades to "" — the arm file just loses its human-readable
+// cwd and, in the headless case, its key; callers that need cwd for
+// keying handle the empty case by refusing (see WriteArmState).
+func currentSessionArmKey() (socket, cwd string) {
+	socket = os.Getenv("CLAUDE_CODE_MESSAGING_SOCKET")
+	cwd, _ = os.Getwd()
+	return socket, cwd
+}
+
+// WriteArmState arms the current session: it writes (or idempotently
+// overwrites) this session's arm-state file, mode 0600, and returns the
+// path. It refuses only when there is no key to write under at all — no
+// messaging socket AND no working directory — because a file with neither
+// could never be matched to a session or a repo by a reader.
+func WriteArmState() (path string, err error) {
+	socket, cwd := currentSessionArmKey()
+	if socket == "" && cwd == "" {
+		return "", fmt.Errorf("cannot arm: no messaging socket and no working directory to key the session on")
+	}
+	p, err := armStatePath(socket, cwd)
+	if err != nil {
+		return "", err
+	}
+	st := ArmState{
+		Armed:     true,
+		PID:       os.Getpid(),
+		Socket:    socket,
+		Cwd:       cwd,
+		StartedAt: time.Now().UTC().Format(time.RFC3339),
+	}
+	data, err := json.MarshalIndent(st, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("marshal arm state: %w", err)
+	}
+	if err := os.WriteFile(p, data, 0600); err != nil {
+		return "", fmt.Errorf("write arm state: %w", err)
+	}
+	return p, nil
+}
+
+// RemoveArmState disarms the current session by removing its arm-state
+// file. It reports whether a file was actually present (so `pad session
+// disarm` can tell the user "disarmed" vs "was not armed") and never
+// treats a missing file as an error — disarm is idempotent.
+func RemoveArmState() (removed bool, path string, err error) {
+	socket, cwd := currentSessionArmKey()
+	p, err := armStatePath(socket, cwd)
+	if err != nil {
+		return false, "", err
+	}
+	if err := os.Remove(p); err != nil {
+		if os.IsNotExist(err) {
+			return false, p, nil
+		}
+		return false, p, fmt.Errorf("remove arm state: %w", err)
+	}
+	return true, p, nil
+}
+
+// readArmState reads and unmarshals the current session's arm-state file.
+// A missing file returns (nil, path, nil) — the common "not armed" case,
+// not an error. A malformed file returns an error the caller folds into
+// "not armed" (fail closed).
+func readArmState() (st *ArmState, path string, err error) {
+	socket, cwd := currentSessionArmKey()
+	p, err := armStatePath(socket, cwd)
+	if err != nil {
+		return nil, "", err
+	}
+	data, err := os.ReadFile(p)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, p, nil
+		}
+		return nil, p, err
+	}
+	var parsed ArmState
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		return nil, p, fmt.Errorf("parse arm state %s: %w", p, err)
+	}
+	return &parsed, p, nil
+}
+
+// armStateOwnerAlive implements the mandatory liveness check (constraint
+// 2). A socket-keyed file is alive iff its recorded socket still exists on
+// disk — that outlives the short-lived arm command and disappears with
+// the Claude Code session. A headless (no-socket) file is alive iff its
+// recorded pid is still running. Anything uncertain is dead (fail
+// closed): a stale armed file must never arm a future monitor.
+func armStateOwnerAlive(st *ArmState) bool {
+	if st == nil {
+		return false
+	}
+	if st.Socket != "" {
+		if _, err := os.Stat(st.Socket); err != nil {
+			return false
+		}
+		return true
+	}
+	// Headless fallback: the pid is the only owner we have. A pid <= 0 is
+	// never a live owner; a short-lived arm command's pid will usually be
+	// gone by the time a reader looks, which is exactly why this path is
+	// documented as secondary to auto_arm.
+	if st.PID <= 0 {
+		return false
+	}
+	return pidAlive(st.PID)
+}
+
+// SessionArmedLocally reports whether THIS session has a live local arm
+// declaration. It is the reader half of the file contract: it returns
+// true only for a present file whose owner is still alive, and it
+// opportunistically removes a file whose owner is dead so a crashed
+// session's consent cannot linger (constraint 2). It never errors — every
+// failure path is "not armed", because this gates a security-relevant
+// declaration and must fail closed.
+//
+// This answers "should the stream I am about to open announce armed?" for
+// the EXPLICIT path only. The caller ORs it with the auto_arm config
+// resolution (ResolveAutoArmFromDisk) to get the full announced value —
+// see cmd/pad's monitor wiring.
+func SessionArmedLocally() bool {
+	st, path, err := readArmState()
+	if err != nil || st == nil {
+		return false
+	}
+	if !armStateOwnerAlive(st) {
+		// Dead owner: reap the stale file (best effort — a failed removal
+		// still yields "not armed", which is the safe answer) so it can't
+		// arm a future reader.
+		_ = os.Remove(path)
+		return false
+	}
+	return true
+}

--- a/internal/cli/session_arm_state_test.go
+++ b/internal/cli/session_arm_state_test.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 )
 
 // armStateTestEnv points HOME (and thus ~/.pad/sessions) at a temp dir and
@@ -184,12 +183,15 @@ func TestArmState_MalformedFailsClosedAndReaped(t *testing.T) {
 	}
 }
 
-// TestArmState_SocketPathReuseRejected is the Codex R1 HIGH-2 regression:
-// a stale arm file must not arm a session that merely REUSES the socket
-// path. The socket file's mtime binds the arm file to a specific socket
-// instance; a recreated socket at the same path has a different mtime and
-// must read as disarmed (and be reaped).
-func TestArmState_SocketPathReuseRejected(t *testing.T) {
+// TestArmState_SocketIdentityMismatchRejected is the Codex R1 HIGH-2 / R2
+// finding-2 regression: a stale arm file must not arm a session that
+// merely reuses the socket PATH. On unix the file records the socket's
+// inode; a different node at the same path (a rebind, or a lingering stale
+// node reused as-is) has a different inode and must read as disarmed. The
+// tamper is deterministic — it forces the recorded identity to not match
+// the live socket — where a remove+recreate could coincidentally reuse the
+// inode.
+func TestArmState_SocketIdentityMismatchRejected(t *testing.T) {
 	socketFile := filepath.Join(t.TempDir(), "msg.sock")
 	if err := os.WriteFile(socketFile, nil, 0600); err != nil {
 		t.Fatal(err)
@@ -204,18 +206,60 @@ func TestArmState_SocketPathReuseRejected(t *testing.T) {
 		t.Fatal("freshly armed session must read as armed")
 	}
 
-	// Simulate the path being reused by a DIFFERENT socket instance: same
-	// path, different mtime. os.Chtimes to a distinct time is deterministic
-	// where a remove+recreate might land on the same coarse timestamp.
-	future := time.Now().Add(time.Hour)
-	if err := os.Chtimes(socketFile, future, future); err != nil {
+	// Read the recorded state and corrupt ONLY the inode, leaving the
+	// mtime correct, so this isolates the inode-identity check: mtime-only
+	// logic would wrongly still match. Skip where inode identity isn't
+	// recorded (non-unix), which uses the mtime fallback covered separately.
+	st, _, err := readArmState()
+	if err != nil || st == nil {
+		t.Fatalf("read state: %v", err)
+	}
+	if st.SocketIno == 0 {
+		t.Skip("no inode identity on this platform; mtime fallback covered separately")
+	}
+	st.SocketIno++
+	data, _ := json.MarshalIndent(st, "", "  ")
+	if err := os.WriteFile(path, data, 0600); err != nil {
 		t.Fatal(err)
 	}
+
 	if SessionArmedLocally() {
-		t.Fatal("a reused socket path (different mtime) must NOT arm the stale file")
+		t.Fatal("a socket-identity mismatch (reused path) must NOT arm the stale file")
 	}
 	if _, err := os.Stat(path); !os.IsNotExist(err) {
 		t.Fatalf("stale-identity file must be reaped; stat err = %v", err)
+	}
+}
+
+// TestArmState_SocketMtimeFallbackMismatch exercises the non-unix fallback
+// branch (no inode identity available): with SocketIno=0 the reader
+// compares the socket's mtime, and a mismatch must read as disarmed.
+func TestArmState_SocketMtimeFallbackMismatch(t *testing.T) {
+	socketFile := filepath.Join(t.TempDir(), "msg.sock")
+	if err := os.WriteFile(socketFile, nil, 0600); err != nil {
+		t.Fatal(err)
+	}
+	armStateTestEnv(t, socketFile)
+	path, err := armStatePath(socketFile, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A state with no inode identity (SocketIno=0) and a wrong mtime —
+	// the shape a non-unix arm would produce for a reused path.
+	st := ArmState{
+		Armed:               true,
+		PID:                 os.Getpid(),
+		Socket:              socketFile,
+		SocketMtimeUnixNano: 1, // will not match the real socket
+		Cwd:                 "",
+		StartedAt:           "2026-08-18T00:00:00Z",
+	}
+	data, _ := json.MarshalIndent(st, "", "  ")
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		t.Fatal(err)
+	}
+	if SessionArmedLocally() {
+		t.Fatal("mtime-fallback mismatch must NOT arm the stale file")
 	}
 }
 

--- a/internal/cli/session_arm_state_test.go
+++ b/internal/cli/session_arm_state_test.go
@@ -1,0 +1,197 @@
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// armStateTestEnv points HOME (and thus ~/.pad/sessions) at a temp dir and
+// sets the messaging socket env to socket ("" for the headless case),
+// then chdirs to a fresh repo dir so the cwd fallback key is stable.
+// Returns the repo dir.
+func armStateTestEnv(t *testing.T, socket string) string {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("CLAUDE_CODE_MESSAGING_SOCKET", socket)
+	repo := t.TempDir()
+	chdir(t, repo)
+	return repo
+}
+
+func TestArmStateKey(t *testing.T) {
+	t.Parallel()
+
+	sessKey, headless := armStateKey("/run/user/1000/msg.sock", "/home/x/repo")
+	if headless {
+		t.Fatal("socket present must NOT be headless")
+	}
+	if !strings.HasPrefix(sessKey, "sess-") {
+		t.Fatalf("socket key = %q, want sess- prefix", sessKey)
+	}
+
+	repoKey, headless := armStateKey("", "/home/x/repo")
+	if !headless {
+		t.Fatal("no socket must be headless (cwd fallback)")
+	}
+	if !strings.HasPrefix(repoKey, "repo-") {
+		t.Fatalf("cwd key = %q, want repo- prefix", repoKey)
+	}
+
+	// A socket wins over cwd, and different sockets key differently while
+	// the same socket is stable (so arm and monitor in one session agree).
+	if sessKey == repoKey {
+		t.Fatal("socket and cwd keys must differ")
+	}
+	other, _ := armStateKey("/run/user/1000/other.sock", "/home/x/repo")
+	if other == sessKey {
+		t.Fatal("different sockets must produce different keys")
+	}
+	again, _ := armStateKey("/run/user/1000/msg.sock", "/different/cwd")
+	if again != sessKey {
+		t.Fatal("same socket must produce the same key regardless of cwd")
+	}
+}
+
+// TestArmState_SocketLivenessRoundTrip is the core happy path AND the
+// non-negotiable liveness rule (constraint 2): a socket-keyed session is
+// armed while its socket exists and DISARMED the instant the socket
+// vanishes (the Claude Code session ended), with the stale file reaped so
+// it can never arm a future monitor.
+func TestArmState_SocketLivenessRoundTrip(t *testing.T) {
+	socketFile := filepath.Join(t.TempDir(), "msg.sock")
+	if err := os.WriteFile(socketFile, nil, 0600); err != nil {
+		t.Fatal(err)
+	}
+	armStateTestEnv(t, socketFile)
+
+	path, err := WriteArmState()
+	if err != nil {
+		t.Fatalf("WriteArmState: %v", err)
+	}
+	if !SessionArmedLocally() {
+		t.Fatal("armed session with a live socket must read as armed")
+	}
+
+	// Socket vanishes → owner is dead → disarmed, and the file is reaped.
+	if err := os.Remove(socketFile); err != nil {
+		t.Fatal(err)
+	}
+	if SessionArmedLocally() {
+		t.Fatal("a session whose socket vanished must NOT read as armed (consent-grandfathering)")
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("stale arm-state file must be reaped by the reader; stat err = %v", err)
+	}
+}
+
+// TestArmState_DisarmRemovesAndIsIdempotent covers constraint 3: disarm
+// removes the file and reports whether one was there; a second disarm is a
+// success, not an error.
+func TestArmState_DisarmRemovesAndIsIdempotent(t *testing.T) {
+	socketFile := filepath.Join(t.TempDir(), "msg.sock")
+	if err := os.WriteFile(socketFile, nil, 0600); err != nil {
+		t.Fatal(err)
+	}
+	armStateTestEnv(t, socketFile)
+
+	if _, err := WriteArmState(); err != nil {
+		t.Fatalf("WriteArmState: %v", err)
+	}
+	removed, _, err := RemoveArmState()
+	if err != nil {
+		t.Fatalf("RemoveArmState: %v", err)
+	}
+	if !removed {
+		t.Fatal("first disarm should report a file was removed")
+	}
+	if SessionArmedLocally() {
+		t.Fatal("session must not read as armed after disarm")
+	}
+
+	removed, _, err = RemoveArmState()
+	if err != nil {
+		t.Fatalf("idempotent disarm must not error: %v", err)
+	}
+	if removed {
+		t.Fatal("second disarm should report nothing was removed")
+	}
+}
+
+// TestArmState_HeadlessLivePid: the cwd-fallback path with no socket reads
+// as armed while its owner pid (this process) is alive.
+func TestArmState_HeadlessLivePid(t *testing.T) {
+	armStateTestEnv(t, "") // no socket → headless, cwd-keyed, pid liveness
+
+	if _, err := WriteArmState(); err != nil {
+		t.Fatalf("WriteArmState: %v", err)
+	}
+	if !SessionArmedLocally() {
+		t.Fatal("headless arm owned by this live process must read as armed")
+	}
+}
+
+// TestArmState_HeadlessDeadPidReaped: the liveness rule for the headless
+// fallback — a file whose owner pid is gone reads as DISARMED and is
+// reaped. Uses a genuinely-exited process's pid rather than a guessed
+// number, so the test doesn't depend on a pid being coincidentally free.
+func TestArmState_HeadlessDeadPidReaped(t *testing.T) {
+	repo := armStateTestEnv(t, "")
+
+	deadPID := exitedProcessPID(t)
+
+	// Write a headless arm-state file by hand with the dead owner pid.
+	path, err := armStatePath("", repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	st := ArmState{Armed: true, PID: deadPID, Cwd: repo, StartedAt: "2026-08-18T00:00:00Z"}
+	data, _ := json.MarshalIndent(st, "", "  ")
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if SessionArmedLocally() {
+		t.Fatal("headless arm owned by a dead pid must NOT read as armed")
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("dead-owner headless file must be reaped; stat err = %v", err)
+	}
+}
+
+// TestArmState_MalformedFailsClosed: an unparseable arm-state file reads
+// as not-armed rather than erroring or arming — a consent gate fails
+// closed.
+func TestArmState_MalformedFailsClosed(t *testing.T) {
+	armStateTestEnv(t, filepath.Join(t.TempDir(), "msg.sock"))
+	path, err := armStatePath(os.Getenv("CLAUDE_CODE_MESSAGING_SOCKET"), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("{not json"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if SessionArmedLocally() {
+		t.Fatal("a malformed arm-state file must fail closed (not armed)")
+	}
+}
+
+// exitedProcessPID starts and reaps a trivial process, returning its pid,
+// which is then dead. Skips on platforms without a shell.
+func exitedProcessPID(t *testing.T) int {
+	t.Helper()
+	sh, err := exec.LookPath("sh")
+	if err != nil {
+		t.Skip("no shell to spawn a dead process from")
+	}
+	cmd := exec.Command(sh, "-c", "exit 0")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start throwaway process: %v", err)
+	}
+	pid := cmd.Process.Pid
+	_ = cmd.Wait() // reap — pid is now dead
+	return pid
+}

--- a/internal/cli/session_arm_state_test.go
+++ b/internal/cli/session_arm_state_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 // armStateTestEnv points HOME (and thus ~/.pad/sessions) at a temp dir and
@@ -162,10 +163,11 @@ func TestArmState_HeadlessDeadPidReaped(t *testing.T) {
 	}
 }
 
-// TestArmState_MalformedFailsClosed: an unparseable arm-state file reads
-// as not-armed rather than erroring or arming — a consent gate fails
-// closed.
-func TestArmState_MalformedFailsClosed(t *testing.T) {
+// TestArmState_MalformedFailsClosedAndReaped: an unparseable arm-state
+// file reads as not-armed (fail closed) AND is reaped — atomic writes
+// mean a malformed file is genuinely corrupt, not a torn in-progress arm
+// (Codex R1 LOW).
+func TestArmState_MalformedFailsClosedAndReaped(t *testing.T) {
 	armStateTestEnv(t, filepath.Join(t.TempDir(), "msg.sock"))
 	path, err := armStatePath(os.Getenv("CLAUDE_CODE_MESSAGING_SOCKET"), "")
 	if err != nil {
@@ -176,6 +178,70 @@ func TestArmState_MalformedFailsClosed(t *testing.T) {
 	}
 	if SessionArmedLocally() {
 		t.Fatal("a malformed arm-state file must fail closed (not armed)")
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("malformed arm-state file must be reaped; stat err = %v", err)
+	}
+}
+
+// TestArmState_SocketPathReuseRejected is the Codex R1 HIGH-2 regression:
+// a stale arm file must not arm a session that merely REUSES the socket
+// path. The socket file's mtime binds the arm file to a specific socket
+// instance; a recreated socket at the same path has a different mtime and
+// must read as disarmed (and be reaped).
+func TestArmState_SocketPathReuseRejected(t *testing.T) {
+	socketFile := filepath.Join(t.TempDir(), "msg.sock")
+	if err := os.WriteFile(socketFile, nil, 0600); err != nil {
+		t.Fatal(err)
+	}
+	armStateTestEnv(t, socketFile)
+
+	path, err := WriteArmState()
+	if err != nil {
+		t.Fatalf("WriteArmState: %v", err)
+	}
+	if !SessionArmedLocally() {
+		t.Fatal("freshly armed session must read as armed")
+	}
+
+	// Simulate the path being reused by a DIFFERENT socket instance: same
+	// path, different mtime. os.Chtimes to a distinct time is deterministic
+	// where a remove+recreate might land on the same coarse timestamp.
+	future := time.Now().Add(time.Hour)
+	if err := os.Chtimes(socketFile, future, future); err != nil {
+		t.Fatal(err)
+	}
+	if SessionArmedLocally() {
+		t.Fatal("a reused socket path (different mtime) must NOT arm the stale file")
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("stale-identity file must be reaped; stat err = %v", err)
+	}
+}
+
+// TestReapArmFile_NonDestructive: reap must NOT delete a file that was
+// re-armed with a live owner between the read and the reap (Codex R1
+// MED-1). Simulated by pointing reap at a path that currently holds a
+// live arm.
+func TestReapArmFile_NonDestructive(t *testing.T) {
+	socketFile := filepath.Join(t.TempDir(), "msg.sock")
+	if err := os.WriteFile(socketFile, nil, 0600); err != nil {
+		t.Fatal(err)
+	}
+	armStateTestEnv(t, socketFile)
+
+	path, err := WriteArmState()
+	if err != nil {
+		t.Fatalf("WriteArmState: %v", err)
+	}
+	// The file at `path` is live. A reap attempt must leave it alone
+	// because the re-read shows a live owner.
+	reapArmFile(path)
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("non-destructive reap must not delete a live arm file: %v", err)
+	}
+	if !SessionArmedLocally() {
+		t.Fatal("session must still be armed after a no-op reap")
 	}
 }
 

--- a/internal/cli/stat_identity_other.go
+++ b/internal/cli/stat_identity_other.go
@@ -1,0 +1,13 @@
+//go:build !unix
+
+package cli
+
+import "os"
+
+// statIdentity has no portable inode/device on non-unix platforms, so it
+// reports ok=false and the socket liveness check falls back to the mtime
+// comparison alone (the documented residual on those platforms). See
+// armStateOwnerAlive.
+func statIdentity(info os.FileInfo) (ino, dev uint64, ok bool) {
+	return 0, 0, false
+}

--- a/internal/cli/stat_identity_unix.go
+++ b/internal/cli/stat_identity_unix.go
@@ -1,0 +1,21 @@
+//go:build unix
+
+package cli
+
+import (
+	"os"
+	"syscall"
+)
+
+// statIdentity returns the inode and device of a stat'd file on unix,
+// which together identify a specific filesystem node — a recreated node
+// at the same path gets a new inode. Used to bind an arm-state file to
+// the exact socket instance it was armed for (see armStateOwnerAlive).
+// ok is false when the underlying stat isn't a *syscall.Stat_t.
+func statIdentity(info os.FileInfo) (ino, dev uint64, ok bool) {
+	st, ok := info.Sys().(*syscall.Stat_t)
+	if !ok || st == nil {
+		return 0, 0, false
+	}
+	return st.Ino, uint64(st.Dev), true
+}

--- a/internal/cli/workspace.go
+++ b/internal/cli/workspace.go
@@ -19,6 +19,34 @@ type PadToml struct {
 	// default loopback server is implied). See BUG-1535.
 	URL       string `toml:"url,omitempty"`
 	AgentName string `toml:"agent_name,omitempty"` // optional: identifies which AI agent is acting
+	// Push carries per-repository push/consent settings (PLAN-2613 S2).
+	// A pointer so an absent `[push]` table is distinguishable from one
+	// written with every field at its zero value — though for AutoArm the
+	// two mean the same thing (not opted in), the distinction keeps the
+	// door open for future push settings where it would matter, and lets
+	// PadTomlAutoArm answer without a second nil check leaking out.
+	Push *PadTomlPush `toml:"push,omitempty"`
+}
+
+// PadTomlPush is the `[push]` table in a repository's .pad.toml
+// (PLAN-2613 S2, D4).
+type PadTomlPush struct {
+	// AutoArm, when true, opts THIS repository's sessions into arming at
+	// connect — declaring consent to receive `pad push` notifications
+	// without an explicit in-session `pad session arm` (D4). It is the
+	// ONLY per-repo enabler, and it lives in a committed file on purpose:
+	// D4's "explicit file edit = deliberate act" is the whole consent
+	// story for the auto path. Default (absent/false) is not opted in —
+	// see ResolveAutoArm for how a per-user setting can veto a true here
+	// but nothing can turn arming on machine-wide.
+	AutoArm bool `toml:"auto_arm"`
+}
+
+// PadTomlAutoArm reports whether this .pad.toml opts the repository into
+// auto-arm. Nil-safe: a nil *PadToml (no workspace linked) or a missing
+// `[push]` table both read as "not opted in", so callers need no guard.
+func (p *PadToml) PadTomlAutoArm() bool {
+	return p != nil && p.Push != nil && p.Push.AutoArm
 }
 
 // DetectWorkspace walks up the directory tree from cwd looking for .pad.toml.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -338,13 +338,31 @@ func (c *Config) Save() error {
 		return err
 	}
 
-	f, err := os.OpenFile(c.ConfigPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
+	// Write atomically: encode into a temp file in the same directory and
+	// rename it into place, so a concurrent reader never observes a
+	// truncated or partially-written config.toml. This matters beyond
+	// tidiness for the push-consent gate (PLAN-2613 S2): a monitor
+	// reconnecting while `pad configure` rewrites the file could otherwise
+	// read an empty/partial config, miss a [push] auto_arm=false veto, and
+	// arm despite it (Codex R2 HIGH-1).
+	tmp, err := os.CreateTemp(c.DataDir, ".config-*.toml.tmp")
 	if err != nil {
 		return err
 	}
-	defer f.Close()
-
-	if err := toml.NewEncoder(f).Encode(c); err != nil {
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName) // no-op after a successful rename
+	if err := tmp.Chmod(0600); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := toml.NewEncoder(tmp).Encode(c); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpName, c.ConfigPath); err != nil {
 		return err
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -116,6 +116,56 @@ func (c *Config) PushAutoArm() *bool {
 	return c.Push.AutoArm
 }
 
+// userConfigPath resolves the user's config.toml path with the SAME
+// precedence Load() uses (PAD_DATA_DIR, then PAD_DB_PATH's directory,
+// overriding), so a strict reader lands on exactly the file Load would.
+func userConfigPath() string {
+	home, _ := os.UserHomeDir()
+	path := filepath.Join(home, ".pad", "config.toml")
+	if v := os.Getenv("PAD_DATA_DIR"); v != "" {
+		path = filepath.Join(v, "config.toml")
+	}
+	if v := os.Getenv("PAD_DB_PATH"); v != "" {
+		path = filepath.Join(filepath.Dir(v), "config.toml")
+	}
+	return path
+}
+
+// LoadPushConfigAutoArm reads ONLY the [push] auto_arm value from the
+// user's config.toml with STRICT fail-closed semantics for the consent
+// gate (PLAN-2613 S2). Unlike Load(), which is deliberately lenient — an
+// unreadable or unparseable config.toml degrades to defaults so the whole
+// CLI doesn't die — this distinguishes the three states a consent
+// decision must not conflate:
+//
+//   - file ABSENT            → (nil, nil): the user has no opinion.
+//   - file present, no [push] → (nil, nil): same.
+//   - file present but UNREADABLE or UNPARSEABLE → (nil, err): the caller
+//     CANNOT confirm the user's veto and must fail closed (not arm),
+//     rather than silently proceeding as if no veto existed.
+//
+// The last case is the fix for Codex round-1 HIGH-1: a malformed
+// config.toml in a repo that opted into auto_arm must not arm.
+func LoadPushConfigAutoArm() (*bool, error) {
+	path := userConfigPath()
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil // genuinely absent — no opinion
+		}
+		return nil, fmt.Errorf("stat user config %s: %w", path, err)
+	}
+	var wrapper struct {
+		Push *PushConfig `toml:"push"`
+	}
+	if _, err := toml.DecodeFile(path, &wrapper); err != nil {
+		return nil, fmt.Errorf("read user push config %s: %w", path, err)
+	}
+	if wrapper.Push == nil {
+		return nil, nil
+	}
+	return wrapper.Push.AutoArm, nil
+}
+
 func DefaultConfig() *Config {
 	homeDir, _ := os.UserHomeDir()
 	dataDir := filepath.Join(homeDir, ".pad")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -84,6 +84,36 @@ type Config struct {
 	// SSE limits
 	SSEMaxConnections  int `toml:"sse_max_connections"`   // Global max SSE connections (0 = unlimited)
 	SSEMaxPerWorkspace int `toml:"sse_max_per_workspace"` // Per-workspace max SSE connections (0 = unlimited)
+
+	// Push carries per-USER push/consent preferences (PLAN-2613 S2). A
+	// pointer so an absent `[push]` table stays nil and Save() (via the
+	// omitempty tag) never writes an empty table into everyone's
+	// config.toml on the next `pad init` / `pad configure`.
+	Push *PushConfig `toml:"push,omitempty"`
+}
+
+// PushConfig is the `[push]` table in ~/.pad/config.toml — the per-user
+// half of the arm-consent resolution (PLAN-2613 S2, D4).
+type PushConfig struct {
+	// AutoArm is the per-USER auto-arm setting, and it is a pointer for a
+	// reason the resolution depends on: unset (nil) must be
+	// distinguishable from an explicit false. Only an explicit false acts
+	// as a veto — it forces auto-arm OFF even in a repository whose
+	// .pad.toml opted in (deny-wins). Nil means "no opinion" and lets the
+	// repository decide. A true here is deliberately INERT as an enabler:
+	// D4 forbids a machine-global always-on, so a per-user true can never
+	// turn arming on for a repo that didn't opt in itself. See
+	// cli.ResolveAutoArm for the full table.
+	AutoArm *bool `toml:"auto_arm"`
+}
+
+// PushAutoArm returns the per-user auto-arm veto value, nil-safe: a nil
+// *Config or a missing `[push]` table both read as "no opinion" (nil).
+func (c *Config) PushAutoArm() *bool {
+	if c == nil || c.Push == nil {
+		return nil
+	}
+	return c.Push.AutoArm
 }
 
 func DefaultConfig() *Config {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -51,6 +51,52 @@ func TestSaveAndLoadRoundTrip(t *testing.T) {
 	}
 }
 
+// TestSavePreservesPushVetoForStrictLoader guards PLAN-2613 S2's consent
+// path: a per-user auto_arm=false veto written by Save() must survive an
+// atomic write intact and be read back by the STRICT loader
+// (LoadPushConfigAutoArm), which is what fails a repo's auto_arm opt-in
+// closed. A Save that dropped or corrupted the [push] table would silently
+// re-open the veto.
+func TestSavePreservesPushVetoForStrictLoader(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	veto := false
+	cfg.Push = &PushConfig{AutoArm: &veto}
+	if err := cfg.Save(); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	got, err := LoadPushConfigAutoArm()
+	if err != nil {
+		t.Fatalf("strict load: %v", err)
+	}
+	if got == nil || *got != false {
+		t.Fatalf("expected the auto_arm=false veto to survive Save(), got %v", got)
+	}
+}
+
+// TestLoadPushConfigAutoArmAbsentIsNoOpinion: with no config.toml the
+// strict loader returns (nil, nil) — no opinion, not an error — so an
+// unconfigured machine doesn't fail every consent read.
+func TestLoadPushConfigAutoArmAbsentIsNoOpinion(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("PAD_DATA_DIR", filepath.Join(home, ".pad"))
+
+	got, err := LoadPushConfigAutoArm()
+	if err != nil {
+		t.Fatalf("absent config must not error: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("absent config must read as no opinion (nil), got %v", got)
+	}
+}
+
 func TestLoadWithPadURLMarksConfigConfigured(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)


### PR DESCRIPTION
## What

PLAN-2613 **S2** — the CLI push-consent surface, the contract S3's plugin skills and S4's web composer build against. S1 (already on main) gated push delivery on a server-side `armed` bit a stream declares at connect; nothing decided WHETHER to arm or sent the declaration. S2 adds both, **defaulting off everywhere**.

## The verb + config contract (for S3/S4)

- **`ResolveAutoArm(repoAutoArm, *userAutoArm)`** — pure consent resolver. `.pad.toml [push] auto_arm=true` is the **only** per-repo enabler (D4); a per-user `config.toml [push] auto_arm=false` **vetoes** it (deny-wins); a per-user `true` is **not** a global enabler; default **off**. Reads fail **closed**.
- **Wire:** `StreamSessionIdentity.Armed` → `?armed=true` on the event stream (S1's server gate finally has a sender). The monitor announces `armed = live local arm OR resolved auto_arm`, so a repo opt-in works end-to-end with a safe default-off skew.
- **`pad session arm` / `disarm` / `status`** — arm/disarm manage a per-session local arm-state file; `status` reports the resolved local/auto decision plus the server's own armed/connected counts (new `Client.ListSessions`), degrading gracefully when padd is unreachable.

## Arm-state file (the S3 contract — lead "Option 2" ruling, 5 constraints)

`~/.pad/sessions/arm-<key>.json`, keyed **per session by `CLAUDE_CODE_MESSAGING_SOCKET`** (cwd fallback = per-repo-for-headless, secondary to `auto_arm`). Records owner **pid + socket + inode/dev + started_at**; presence = armed. **Liveness is mandatory**: a dead-owner file (socket vanished / rebound to a new inode / pid gone) reads as **disarmed and is reaped** — a crashed session can never arm a future monitor. disarm/exit remove it; arm is idempotent; writes are atomic. It is **local client state only**: S1's server armed bit stays the sole delivery authority.

## Review

Codex CLI review to **CLEAN** in 3 rounds (fail-closed config reads, socket inode/device + Linux /proc owner identity, atomic config writes, zombie handling, `--url` precedence). Every security guard is **mutation-verified** (each guarding test observed failing on the injected defect).

## Tests / gates

- build ✓ · gofmt ✓ · `make lint` ✓ (0 issues) · `go test ./...` ✓ · Codex ✓ CLEAN
- `make test-pg` N/A (no store SQL) · web checks N/A (no web changes)

## One flagged interaction (for lead/S3, not a blocker)

In an `auto_arm=true` repo, `pad session disarm` removes the local file but the session falls back to `auto_arm=true` (re-armed). If `/pad:disconnect` must beat `auto_arm` for a session, S3 needs a persisted explicit-OFF — the lead's "disarm removes the file" constraint deliberately doesn't provide it. Implemented exactly as ruled; surfacing the seam.

https://claude.ai/code/session_017jD6t1zjxGSq47SQpZfp1V