### PR TITLE
feat(web): composer + quick actions target armed sessions with honest counts (PLAN-2613 S4, TASK-2619)

### DIFF
--- a/web/src/lib/components/collections/QuickActionsEditor.svelte
+++ b/web/src/lib/components/collections/QuickActionsEditor.svelte
@@ -76,9 +76,9 @@
      template laid out over paragraphs arrives collapsed. Better learned while
      authoring than by reading it back in a terminal. -->
 <p class="qa-hint">
-	Item actions push the resolved prompt to your connected agent session — as a
-	single line, so line breaks collapse — and copy it to your clipboard when no
-	session is connected. Collection actions always copy. Template variables:
+	Item actions push the resolved prompt to an agent session that's accepting
+	pushes — as a single line, so line breaks collapse — and copy it to your
+	clipboard when none is. Collection actions always copy. Template variables:
 	<code class="qa-var-help">{variableHelp}</code>
 </p>
 

--- a/web/src/lib/components/common/QuickActionsMenu.svelte
+++ b/web/src/lib/components/common/QuickActionsMenu.svelte
@@ -188,7 +188,11 @@
 			// nothing accepting, the action copies instead. The array (not
 			// `count`) is what the server enumerated; the two can only disagree
 			// if something is wrong, in which case enumeration is the honest one.
-			presence = { state: 'known', count: resp.sessions?.filter((s) => s.armed).length ?? 0 };
+			presence = {
+				state: 'known',
+				count: resp.sessions?.filter((s) => s.armed).length ?? 0,
+				connected: resp.sessions?.length ?? 0
+			};
 		} catch {
 			if (!stillCurrent()) return;
 			presenceAppliedSeq = seq;
@@ -370,15 +374,20 @@
 		if (presence.state === 'unknown') {
 			return 'Can’t tell if an agent is connected — actions copy to your clipboard';
 		}
-		if (presence.count === 0) {
-			// "accepting", not "connected": a session may be connected but not
-			// armed, in which case a push is dropped and the action copies
-			// (PLAN-2613 S4). The count above is already the accepting subset.
-			return 'No agent session accepting pushes — actions copy to your clipboard';
+		// Honest split (PLAN-2613 S4, D3): `count` is the ACCEPTING subset that
+		// decides push-vs-copy; `connected` is the total, shown so a
+		// connected-but-unarmed session isn't hidden behind a bare zero.
+		const accepting = presence.count;
+		const connected = presence.connected ?? accepting;
+		if (accepting === 0) {
+			return connected > 0
+				? `${connected} connected, 0 accepting pushes — actions copy; run /pad:connect to enable`
+				: 'No agent session connected — actions copy to your clipboard';
 		}
-		return presence.count === 1
-			? 'Pushes to your agent session'
-			: `Pushes to your ${presence.count} agent sessions accepting pushes`;
+		const ofConnected = connected > accepting ? ` (of ${connected} connected)` : '';
+		return accepting === 1
+			? `Pushes to 1 accepting session${ofConnected}`
+			: `Pushes to ${accepting} accepting sessions${ofConnected}`;
 	});
 
 	function resetCreateForm() {

--- a/web/src/lib/components/common/QuickActionsMenu.svelte
+++ b/web/src/lib/components/common/QuickActionsMenu.svelte
@@ -180,10 +180,15 @@
 			presenceAppliedSeq = seq;
 			lastAnsweredAt = Date.now();
 			armExpiry();
-			// `sessions.length` over `count`: the array is what the server
-			// actually enumerated, and the two can only disagree if something is
-			// wrong — in which case the enumeration is the honest one.
-			presence = { state: 'known', count: resp.sessions?.length ?? 0 };
+			// Count ACCEPTING sessions, not merely connected ones (PLAN-2613
+			// S4): only an armed session receives a push, so a quick action
+			// that routes to push based on the raw connected count would
+			// fire-and-forget into a connected-but-unarmed session and lose the
+			// prompt. Filtering to armed here makes push-vs-copy honest — with
+			// nothing accepting, the action copies instead. The array (not
+			// `count`) is what the server enumerated; the two can only disagree
+			// if something is wrong, in which case enumeration is the honest one.
+			presence = { state: 'known', count: resp.sessions?.filter((s) => s.armed).length ?? 0 };
 		} catch {
 			if (!stillCurrent()) return;
 			presenceAppliedSeq = seq;
@@ -366,11 +371,14 @@
 			return 'Can’t tell if an agent is connected — actions copy to your clipboard';
 		}
 		if (presence.count === 0) {
-			return 'No agent session connected — actions copy to your clipboard';
+			// "accepting", not "connected": a session may be connected but not
+			// armed, in which case a push is dropped and the action copies
+			// (PLAN-2613 S4). The count above is already the accepting subset.
+			return 'No agent session accepting pushes — actions copy to your clipboard';
 		}
 		return presence.count === 1
-			? 'Pushes to your connected agent session'
-			: `Pushes to your ${presence.count} connected agent sessions`;
+			? 'Pushes to your agent session'
+			: `Pushes to your ${presence.count} agent sessions accepting pushes`;
 	});
 
 	function resetCreateForm() {
@@ -535,8 +543,8 @@
 			Template variables: {'{ref}'} {'{title}'} {'{status}'} {'{priority}'} {'{collection}'} {'{content}'} {'{fields}'}
 			{#if scope === 'item'}
 				<br />
-				Pushes to your connected agent session as a single line; copies to your
-				clipboard when none is connected.
+				Pushes to your agent session as a single line when one is accepting pushes;
+				copies to your clipboard otherwise.
 			{/if}
 		</div>
 		<div class="qa-actions">

--- a/web/src/lib/components/common/QuickActionsMenu.svelte.test.ts
+++ b/web/src/lib/components/common/QuickActionsMenu.svelte.test.ts
@@ -255,7 +255,7 @@ describe('QuickActionsMenu push dispatch (PLAN-2558 S4)', () => {
 	});
 
 	it('pushes the resolved prompt when a session is connected, and leaves the clipboard alone', async () => {
-		sessionsListMock.mockResolvedValue({ sessions: [{ id: 's1' }], count: 1 });
+		sessionsListMock.mockResolvedValue({ sessions: [{ id: 's1', armed: true }], count: 1 });
 		pushMock.mockResolvedValue({ pushed: true });
 
 		const { host, component } = mountMenu();
@@ -287,7 +287,34 @@ describe('QuickActionsMenu push dispatch (PLAN-2558 S4)', () => {
 		expect(pushMock).not.toHaveBeenCalled();
 		expect(copyMock).toHaveBeenCalledWith('Ship TASK-14');
 		expect(toastShow.mock.calls[0][0]).toBe(
-			'No agent session connected — copied to clipboard instead'
+			'No agent session accepting pushes — copied to clipboard instead'
+		);
+
+		unmount(component);
+		host.remove();
+	});
+
+	it('copies when sessions are connected but NONE are armed (PLAN-2613 S4), never pushing', async () => {
+		// Two sessions connected, neither accepting pushes. A push would be
+		// dropped server-side, so the action must copy — the same routing as
+		// zero sessions, decided on the ACCEPTING count not the connected one.
+		sessionsListMock.mockResolvedValue({
+			sessions: [
+				{ id: 's1', armed: false },
+				{ id: 's2', armed: false }
+			],
+			count: 2
+		});
+
+		const { host, component } = mountMenu();
+		await openMenu(host);
+		actionRow(host, 'Ship it').click();
+		await vi.waitFor(() => expect(toastShow).toHaveBeenCalled());
+
+		expect(pushMock).not.toHaveBeenCalled();
+		expect(copyMock).toHaveBeenCalledWith('Ship TASK-14');
+		expect(toastShow.mock.calls[0][0]).toBe(
+			'No agent session accepting pushes — copied to clipboard instead'
 		);
 
 		unmount(component);
@@ -345,7 +372,7 @@ describe('QuickActionsMenu push dispatch (PLAN-2558 S4)', () => {
 			scope: 'item',
 		};
 
-		sessionsListMock.mockResolvedValue({ sessions: [{ id: 's1' }], count: 1 });
+		sessionsListMock.mockResolvedValue({ sessions: [{ id: 's1', armed: true }], count: 1 });
 		pushMock.mockResolvedValue({ pushed: true });
 		const pushed = mountMenu({ actions: [multiline] });
 		await openMenu(pushed.host);
@@ -398,7 +425,7 @@ describe('QuickActionsMenu push dispatch (PLAN-2558 S4)', () => {
 		// text over cannot deliver it twice. It is OFFERED rather than done
 		// because the original gesture is spent by now; the toast button is a
 		// fresh one, which is what makes the clipboard write work.
-		sessionsListMock.mockResolvedValue({ sessions: [{ id: 's1' }], count: 1 });
+		sessionsListMock.mockResolvedValue({ sessions: [{ id: 's1', armed: true }], count: 1 });
 		pushMock.mockRejectedValue(
 			new MockPadApiError({ code: 'unavailable', message: 'Push is not available' })
 		);
@@ -431,7 +458,7 @@ describe('QuickActionsMenu push dispatch (PLAN-2558 S4)', () => {
 		// result would leave a failed copy completely silent — and this is the
 		// one path where that silence means the instruction was neither sent NOR
 		// copied, the worst state the surface can be in.
-		sessionsListMock.mockResolvedValue({ sessions: [{ id: 's1' }], count: 1 });
+		sessionsListMock.mockResolvedValue({ sessions: [{ id: 's1', armed: true }], count: 1 });
 		pushMock.mockRejectedValue(
 			new MockPadApiError({ code: 'rate_limited', message: 'Too many requests' })
 		);
@@ -457,7 +484,7 @@ describe('QuickActionsMenu push dispatch (PLAN-2558 S4)', () => {
 		// unrecognised failure leaves the instruction possibly delivered. A
 		// "Copy instead" button here would invite exactly the duplicate the
 		// message warns about — the endpoint has no idempotency key.
-		sessionsListMock.mockResolvedValue({ sessions: [{ id: 's1' }], count: 1 });
+		sessionsListMock.mockResolvedValue({ sessions: [{ id: 's1', armed: true }], count: 1 });
 		pushMock.mockRejectedValue(new TypeError('Failed to fetch'));
 
 		const { host, component } = mountMenu();
@@ -482,16 +509,16 @@ describe('QuickActionsMenu push dispatch (PLAN-2558 S4)', () => {
 		const { host, component } = mountMenu();
 		await openMenu(host);
 		expect(document.querySelector('.dropdown-tagline')?.textContent?.trim()).toBe(
-			'No agent session connected — actions copy to your clipboard'
+			'No agent session accepting pushes — actions copy to your clipboard'
 		);
 		unmount(component);
 		host.remove();
 
-		sessionsListMock.mockResolvedValue({ sessions: [{ id: 's1' }, { id: 's2' }], count: 2 });
+		sessionsListMock.mockResolvedValue({ sessions: [{ id: 's1', armed: true }, { id: 's2', armed: true }], count: 2 });
 		const live = mountMenu();
 		await openMenu(live.host);
 		expect(document.querySelector('.dropdown-tagline')?.textContent?.trim()).toBe(
-			'Pushes to your 2 connected agent sessions'
+			'Pushes to your 2 agent sessions accepting pushes'
 		);
 		unmount(live.component);
 		live.host.remove();
@@ -514,7 +541,7 @@ describe('QuickActionsMenu presence staleness (codex round 1)', () => {
 		// one direction that loses the user's instruction.
 		vi.useFakeTimers();
 		try {
-			sessionsListMock.mockResolvedValueOnce({ sessions: [{ id: 's1' }], count: 1 });
+			sessionsListMock.mockResolvedValueOnce({ sessions: [{ id: 's1', armed: true }], count: 1 });
 			// Every poll after the first hangs forever.
 			sessionsListMock.mockReturnValue(new Promise(() => {}));
 
@@ -526,7 +553,7 @@ describe('QuickActionsMenu presence staleness (codex round 1)', () => {
 
 			// The first read landed: the menu is armed to push.
 			expect(document.querySelector('.dropdown-tagline')?.textContent?.trim()).toBe(
-				'Pushes to your connected agent session'
+				'Pushes to your agent session'
 			);
 
 			// Four poll intervals later — nothing has refreshed it. (The TAGLINE
@@ -559,7 +586,7 @@ describe('QuickActionsMenu presence staleness (codex round 1)', () => {
 		// looks like from the component's point of view.
 		vi.useFakeTimers();
 		try {
-			sessionsListMock.mockResolvedValueOnce({ sessions: [{ id: 's1' }], count: 1 });
+			sessionsListMock.mockResolvedValueOnce({ sessions: [{ id: 's1', armed: true }], count: 1 });
 			sessionsListMock.mockReturnValue(new Promise(() => {}));
 
 			const { host, component } = mountMenu();
@@ -573,7 +600,7 @@ describe('QuickActionsMenu presence staleness (codex round 1)', () => {
 			vi.setSystemTime(Date.now() + 5 * 60_000);
 			flushSync();
 			expect(document.querySelector('.dropdown-tagline')?.textContent?.trim()).toBe(
-				'Pushes to your connected agent session'
+				'Pushes to your agent session'
 			);
 
 			// The decision must not inherit that staleness.
@@ -595,7 +622,7 @@ describe('QuickActionsMenu presence staleness (codex round 1)', () => {
 		// routing has already switched to the clipboard.
 		vi.useFakeTimers();
 		try {
-			sessionsListMock.mockResolvedValueOnce({ sessions: [{ id: 's1' }], count: 1 });
+			sessionsListMock.mockResolvedValueOnce({ sessions: [{ id: 's1', armed: true }], count: 1 });
 			sessionsListMock.mockReturnValue(new Promise(() => {}));
 
 			const { host, component } = mountMenu();
@@ -608,7 +635,7 @@ describe('QuickActionsMenu presence staleness (codex round 1)', () => {
 			await vi.advanceTimersByTimeAsync(29_000);
 			flushSync();
 			expect(document.querySelector('.dropdown-tagline')?.textContent?.trim()).toBe(
-				'Pushes to your connected agent session'
+				'Pushes to your agent session'
 			);
 
 			// Just past it — and well before the next 10s poll tick at t=40s.
@@ -631,7 +658,7 @@ describe('QuickActionsMenu presence staleness (codex round 1)', () => {
 		// would silently retire the whole feature.
 		vi.useFakeTimers();
 		try {
-			sessionsListMock.mockResolvedValue({ sessions: [{ id: 's1' }], count: 1 });
+			sessionsListMock.mockResolvedValue({ sessions: [{ id: 's1', armed: true }], count: 1 });
 
 			const { host, component } = mountMenu();
 			(host.querySelector('.trigger-btn') as HTMLButtonElement).click();
@@ -640,7 +667,7 @@ describe('QuickActionsMenu presence staleness (codex round 1)', () => {
 			flushSync();
 
 			expect(document.querySelector('.dropdown-tagline')?.textContent?.trim()).toBe(
-				'Pushes to your connected agent session'
+				'Pushes to your agent session'
 			);
 			actionRow(host, 'Ship it').click();
 			await vi.advanceTimersByTimeAsync(0);

--- a/web/src/lib/components/common/QuickActionsMenu.svelte.test.ts
+++ b/web/src/lib/components/common/QuickActionsMenu.svelte.test.ts
@@ -509,7 +509,7 @@ describe('QuickActionsMenu push dispatch (PLAN-2558 S4)', () => {
 		const { host, component } = mountMenu();
 		await openMenu(host);
 		expect(document.querySelector('.dropdown-tagline')?.textContent?.trim()).toBe(
-			'No agent session accepting pushes — actions copy to your clipboard'
+			'No agent session connected — actions copy to your clipboard'
 		);
 		unmount(component);
 		host.remove();
@@ -518,10 +518,46 @@ describe('QuickActionsMenu push dispatch (PLAN-2558 S4)', () => {
 		const live = mountMenu();
 		await openMenu(live.host);
 		expect(document.querySelector('.dropdown-tagline')?.textContent?.trim()).toBe(
-			'Pushes to your 2 agent sessions accepting pushes'
+			'Pushes to 2 accepting sessions'
 		);
 		unmount(live.component);
 		live.host.remove();
+	});
+
+	it('shows the accepting-of-connected split when some sessions are unarmed (PLAN-2613 S4)', async () => {
+		// 3 connected, 1 accepting — the honest split D3 wants, not a bare "1".
+		sessionsListMock.mockResolvedValue({
+			sessions: [
+				{ id: 's1', armed: true },
+				{ id: 's2', armed: false },
+				{ id: 's3', armed: false }
+			],
+			count: 3
+		});
+		const { host, component } = mountMenu();
+		await openMenu(host);
+		expect(document.querySelector('.dropdown-tagline')?.textContent?.trim()).toBe(
+			'Pushes to 1 accepting session (of 3 connected)'
+		);
+		unmount(component);
+		host.remove();
+
+		// Connected but none accepting: the tagline names both and points at
+		// the enable path rather than reading as "nobody there".
+		sessionsListMock.mockResolvedValue({
+			sessions: [
+				{ id: 's1', armed: false },
+				{ id: 's2', armed: false }
+			],
+			count: 2
+		});
+		const none = mountMenu();
+		await openMenu(none.host);
+		expect(document.querySelector('.dropdown-tagline')?.textContent?.trim()).toBe(
+			'2 connected, 0 accepting pushes — actions copy; run /pad:connect to enable'
+		);
+		unmount(none.component);
+		none.host.remove();
 	});
 });
 
@@ -553,7 +589,7 @@ describe('QuickActionsMenu presence staleness (codex round 1)', () => {
 
 			// The first read landed: the menu is armed to push.
 			expect(document.querySelector('.dropdown-tagline')?.textContent?.trim()).toBe(
-				'Pushes to your agent session'
+				'Pushes to 1 accepting session'
 			);
 
 			// Four poll intervals later — nothing has refreshed it. (The TAGLINE
@@ -600,7 +636,7 @@ describe('QuickActionsMenu presence staleness (codex round 1)', () => {
 			vi.setSystemTime(Date.now() + 5 * 60_000);
 			flushSync();
 			expect(document.querySelector('.dropdown-tagline')?.textContent?.trim()).toBe(
-				'Pushes to your agent session'
+				'Pushes to 1 accepting session'
 			);
 
 			// The decision must not inherit that staleness.
@@ -635,7 +671,7 @@ describe('QuickActionsMenu presence staleness (codex round 1)', () => {
 			await vi.advanceTimersByTimeAsync(29_000);
 			flushSync();
 			expect(document.querySelector('.dropdown-tagline')?.textContent?.trim()).toBe(
-				'Pushes to your agent session'
+				'Pushes to 1 accepting session'
 			);
 
 			// Just past it — and well before the next 10s poll tick at t=40s.
@@ -667,7 +703,7 @@ describe('QuickActionsMenu presence staleness (codex round 1)', () => {
 			flushSync();
 
 			expect(document.querySelector('.dropdown-tagline')?.textContent?.trim()).toBe(
-				'Pushes to your agent session'
+				'Pushes to 1 accepting session'
 			);
 			actionRow(host, 'Ship it').click();
 			await vi.advanceTimersByTimeAsync(0);

--- a/web/src/lib/components/items/PushToAgentDialog.svelte
+++ b/web/src/lib/components/items/PushToAgentDialog.svelte
@@ -25,20 +25,30 @@ THE POINT OF THIS DIALOG IS THE PRESENCE LINE, NOT THE TEXTAREA. `pad push` is
 fire-and-forget: no durable inbox, no ack, no "nobody was listening" warning
 (handlers_push.go — Dave's product call, and defensible for a CLI verb typed by
 someone who knows their own session is running). A button in a web UI has no
-such user. So this dialog answers "is anything listening?" BEFORE the click, and
-words the answer at exactly the confidence the server can support:
+such user. So this dialog answers "is anything ACCEPTING?" BEFORE the click, and
+words the answer at exactly the confidence the server can support.
 
-  - N > 0        → "N session connected". NOT "this will be delivered". The
-                   registry can name a session that died up to ~30s ago (an
-                   ungraceful disconnect is invisible until the next keepalive
-                   write fails), and even a live session gets no delivery
-                   receipt. Send is enabled; the caveat is stated, not implied.
-  - N == 0       → send is DISABLED. With nothing listening, a push is not
-                   "probably lost" — it is definitively lost, because there is
-                   no inbox to land in. Offering the button anyway would make
-                   this surface worse than the clipboard ferry it replaces, so
-                   the empty state offers the clipboard instead (the same
-                   fallback PLAN-2558 S4 rules for quick actions).
+CONNECTED IS NOT ACCEPTING (PLAN-2613 S4, D3). Only an armed session receives a
+push — the server filters delivery to armed sessions — so every count and gate
+below keys on the ACCEPTING (armed) subset, not the raw connected list, and the
+line shows the split honestly rather than hiding the difference:
+
+  - accepting > 0 → "M sessions accepting pushes" (and "of N connected" when
+                   some are connected-but-unarmed). NOT "this will be
+                   delivered": the registry can name a session that died up to
+                   ~30s ago (an ungraceful disconnect is invisible until the
+                   next keepalive write fails), and even a live armed session
+                   gets no delivery receipt. Send is enabled; the caveat is
+                   stated, not implied.
+  - accepting == 0 → send is DISABLED, because a push to no armed session is
+                   definitively lost (no inbox), and a push to a connected-but-
+                   unarmed session is dropped server-side — sending either way
+                   would be the silent fire-and-forget D3 forbids. Two empty
+                   states: nobody connected at all ("start a session"), or
+                   sessions connected but none opted in ("run /pad:connect to
+                   enable"). Both offer the clipboard instead (the same fallback
+                   PLAN-2558 S4 rules for quick actions), so the surface is
+                   never a dead end.
   - can't tell   → send is ENABLED, with the uncertainty stated. A 503 (no
                    presence registry wired) or a network failure means the
                    server cannot answer, and rendering that as zero is the
@@ -207,7 +217,19 @@ server tells you not to run would cost honesty in the case that actually ships.
 		destroyed = true;
 	});
 
-	const sessionCount = $derived(sessions.length);
+	/**
+	 * PLAN-2613 S4 (D3): connected is not the same as ACCEPTING. Only an
+	 * armed session actually receives a push (the server filters delivery to
+	 * armed sessions), so `acceptingSessions` — not the full `sessions` list —
+	 * is what the picker targets, what the count promises, and what enables
+	 * Send. Showing the split ("N connected, M accepting") is the honest
+	 * form: a connected-but-unarmed session is real and worth surfacing so
+	 * the user can enable it (/pad:connect), not hidden so a push silently
+	 * goes nowhere. `count` on the wire is redundant; derive from the array.
+	 */
+	const connectedCount = $derived(sessions.length);
+	const acceptingSessions = $derived(sessions.filter((s) => s.armed));
+	const acceptingCount = $derived(acceptingSessions.length);
 	const collapsed = $derived(collapsePushMessage(message));
 	const messageLength = $derived(pushMessageLength(message));
 	const tooLong = $derived(isPushMessageTooLong(message));
@@ -227,16 +249,20 @@ server tells you not to run would cost honesty in the case that actually ships.
 	// isn't going to happen — and stay silent about one that is.
 	const willCollapse = $derived(collapsed !== '' && collapsed !== trimPushMessage(message));
 
-	/** Nothing is listening, and we are sure of it. The only state that blocks
-	 *  send on presence grounds — 'unknown' deliberately does not. */
-	const noListeners = $derived(presenceState === 'known' && sessionCount === 0);
+	/** Nothing is ACCEPTING pushes, and we are sure of it. The only state that
+	 *  blocks send on presence grounds — 'unknown' deliberately does not.
+	 *  Gated on acceptingCount, not connectedCount (PLAN-2613 S4): a push to a
+	 *  connected-but-unarmed session is silently dropped by the server, so
+	 *  sending with zero accepting would be the fire-and-forget D3 forbids,
+	 *  even when other sessions are connected. */
+	const noAccepting = $derived(presenceState === 'known' && acceptingCount === 0);
 
 	const canSend = $derived(
 		!sending &&
 			!outcomeUnknown &&
 			!empty &&
 			!tooLong &&
-			!noListeners &&
+			!noAccepting &&
 			presenceState !== 'checking'
 	);
 
@@ -258,7 +284,13 @@ server tells you not to run would cost honesty in the case that actually ships.
 	 * path below that clears `sessions` directly.
 	 */
 	function reconcileSelectedSession() {
-		if (selectedSessionId && !sessions.some((s) => s.id === selectedSessionId)) {
+		// The target must be an ARMED session (PLAN-2613 S4) — an unarmed one
+		// can't receive the push. Reads `sessions` directly (freshly assigned
+		// by the caller) rather than the acceptingSessions derived, so it
+		// doesn't depend on derived recompute timing, and never in reactive
+		// position (CONVE-1688). A selection that dropped OR lost its armed
+		// bit falls back to broadcast.
+		if (selectedSessionId && !sessions.some((s) => s.id === selectedSessionId && s.armed)) {
 			selectedSessionId = '';
 		}
 	}
@@ -520,19 +552,36 @@ server tells you not to run would cost honesty in the case that actually ships.
 					{presenceReason} You can still send — but nothing here knows whether it will
 					land anywhere.
 				</p>
-			{:else if sessionCount === 0}
-				<p class="notice notice-warn">
-					<strong>No agent session is connected.</strong>
-					A push isn’t stored anywhere — with nothing listening it would be lost, not
-					queued. Start a session (<code>pad watch --stream</code>) and it will appear
-					here, or copy the message and paste it yourself.
-				</p>
+			{:else if acceptingCount === 0}
+				<!-- Nothing accepting. Two distinct empty states (PLAN-2613 S4):
+				     nobody connected at all, vs. sessions connected but none opted
+				     in — the second is the honest-counts case D3 exists for. -->
+				{#if connectedCount === 0}
+					<p class="notice notice-warn">
+						<strong>No agent session is connected.</strong>
+						A push isn’t stored anywhere — with nothing listening it would be lost, not
+						queued. Start a session (<code>pad watch --stream</code>) and connect it
+						(<code>/pad:connect</code>) so it accepts pushes, or copy the message and
+						paste it yourself.
+					</p>
+				{:else}
+					<p class="notice notice-warn">
+						<strong
+							>{connectedCount}
+							{connectedCount === 1 ? 'session' : 'sessions'} connected, 0 accepting pushes.</strong
+						>
+						A push only reaches a session that has opted in. Run
+						<code>/pad:connect</code> (or <code>pad session arm</code>) in a connected
+						session to enable it, or copy the message and paste it yourself.
+					</p>
+				{/if}
 			{:else}
 				<p class="presence-ok">
 					<strong
-						>{sessionCount}
-						{sessionCount === 1 ? 'session' : 'sessions'} connected</strong
-					>
+						>{acceptingCount}
+						{acceptingCount === 1 ? 'session' : 'sessions'} accepting pushes</strong
+					>{#if connectedCount > acceptingCount}
+						<span class="muted"> (of {connectedCount} connected)</span>{/if}
 					<!-- Two separate hedges, both load-bearing. The registry can name a
 					     session that dropped ungracefully up to ~30s ago, so even
 					     "was listening" is past tense; and nothing acknowledges a
@@ -541,7 +590,7 @@ server tells you not to run would cost honesty in the case that actually ships.
 					that dropped in the last ~30 seconds can still be listed here.
 				</p>
 				<ul class="session-list">
-					{#each sessions as session (session.id)}
+					{#each acceptingSessions as session (session.id)}
 						<li>
 							<span class="session-name">{sessionName(session)}</span>
 							<span class="muted">connected {relativeTime(session.connected_at)}</span>
@@ -557,14 +606,19 @@ server tells you not to run would cost honesty in the case that actually ships.
 		     `noListeners`, so a picker here would offer a choice that can't be
 		     acted on. Broadcast is the default on every fresh open (Fresh-on-
 		     open reset above), never a remembered previous target. -->
-		{#if sessionCount > 0}
+		{#if acceptingCount > 0}
 			<section class="section">
 				<label class="field-label" for={targetId}>Send to</label>
+				<!-- Only ARMED sessions are targetable (PLAN-2613 S4): a push to
+				     an unarmed session is dropped server-side, so offering one as
+				     a target would be offering a guaranteed miss. Broadcast, too,
+				     reaches only accepting sessions (the server filters), so its
+				     count is the accepting count, not the connected one. -->
 				<select id={targetId} class="target-picker" bind:value={selectedSessionId} disabled={sending}>
 					<option value=""
-						>All connected sessions ({sessionCount})</option
+						>All accepting sessions ({acceptingCount})</option
 					>
-					{#each sessions as session (session.id)}
+					{#each acceptingSessions as session (session.id)}
 						<option value={session.id}>{sessionName(session)}</option>
 					{/each}
 				</select>
@@ -631,7 +685,7 @@ server tells you not to run would cost honesty in the case that actually ships.
 			<span class="muted footer-status" role="status">Sending…</span>
 		{/if}
 		<Button variant="secondary" disabled={sending} onclick={handleDismiss}>Cancel</Button>
-		{#if noListeners}
+		{#if noAccepting}
 			<Button variant="secondary" disabled={empty || tooLong} onclick={handleCopyInstead}>
 				Copy instead
 			</Button>

--- a/web/src/lib/components/items/PushToAgentDialog.svelte.test.ts
+++ b/web/src/lib/components/items/PushToAgentDialog.svelte.test.ts
@@ -55,17 +55,28 @@ function baseProps(overrides: Record<string, unknown> = {}) {
 	};
 }
 
-/** Sessions payload with `n` live entries. */
+/** Sessions payload with `n` live entries, all ARMED (accepting pushes) by
+ *  default — the common case the pre-PLAN-2613 tests assumed. */
 function sessions(n: number) {
-	return {
-		count: n,
-		sessions: Array.from({ length: n }, (_, i) => ({
-			id: `session-id-${i}`,
-			label: `docapp-${i}`,
-			pid: 1000 + i,
-			connected_at: new Date(Date.now() - 60_000).toISOString()
-		}))
-	};
+	return armedSessions(n, 0);
+}
+
+/** Sessions payload with `armed` accepting entries and `unarmed`
+ *  connected-but-not-accepting entries (PLAN-2613 S4). Armed ones come first
+ *  so their ids are stable (`session-id-0`…) across the tests that target one. */
+function armedSessions(armed: number, unarmed: number) {
+	const make = (i: number, isArmed: boolean) => ({
+		id: `session-id-${i}`,
+		label: `docapp-${i}`,
+		pid: 1000 + i,
+		armed: isArmed,
+		connected_at: new Date(Date.now() - 60_000).toISOString()
+	});
+	const list = [
+		...Array.from({ length: armed }, (_, i) => make(i, true)),
+		...Array.from({ length: unarmed }, (_, i) => make(armed + i, false))
+	];
+	return { count: list.length, sessions: list };
 }
 
 function button(name: string): HTMLButtonElement {
@@ -136,7 +147,7 @@ describe('PushToAgentDialog — presence honesty', () => {
 		await mountSettled();
 
 		const body = bodyText();
-		expect(body).toContain('1 session connected');
+		expect(body).toContain('1 session accepting pushes');
 		// The whole point. If this ever starts asserting delivery, the surface
 		// has begun claiming something the server has no way to know.
 		expect(body).toMatch(/can’t confirm delivery|cannot confirm delivery/i);
@@ -431,16 +442,16 @@ describe('PushToAgentDialog — message handling', () => {
 		render(PushToAgentDialog, { props: baseProps() });
 		await vi.advanceTimersByTimeAsync(0);
 		flushSync();
-		expect(bodyText()).toContain('1 session connected');
+		expect(bodyText()).toContain('1 session accepting pushes');
 		expect(button('Push').disabled).toBe(false);
 
 		// Three poll intervals with no answer takes us past the server's own
-		// ~30s presence staleness bound. Past that, "1 session connected" is a
+		// ~30s presence staleness bound. Past that, "1 session accepting pushes" is a
 		// claim nothing supports.
 		await vi.advanceTimersByTimeAsync(40_000);
 		flushSync();
 
-		expect(bodyText()).not.toContain('1 session connected');
+		expect(bodyText()).not.toContain('1 session accepting pushes');
 		expect(bodyText()).toContain('Can’t tell whether any agent session is connected');
 		// Still sendable — "can't tell" never blocks, only "known zero" does.
 		expect(button('Push').disabled).toBe(false);
@@ -476,7 +487,7 @@ describe('PushToAgentDialog — message handling', () => {
 		render(PushToAgentDialog, { props: baseProps() });
 		await vi.advanceTimersByTimeAsync(0);
 		flushSync();
-		expect(bodyText()).toContain('1 session connected');
+		expect(bodyText()).toContain('1 session accepting pushes');
 
 		await vi.advanceTimersByTimeAsync(40_000);
 		flushSync();
@@ -484,12 +495,12 @@ describe('PushToAgentDialog — message handling', () => {
 
 		// The stalled pre-expiry poll finally lands. Its data is older than the
 		// expiry we just applied, so it must be dropped rather than reinstating
-		// "1 session connected".
+		// "1 session accepting pushes".
 		releaseStalled(sessions(1));
 		await vi.advanceTimersByTimeAsync(0);
 		flushSync();
 
-		expect(bodyText()).not.toContain('1 session connected');
+		expect(bodyText()).not.toContain('1 session accepting pushes');
 		expect(bodyText()).toContain('Can’t tell whether any agent session is connected');
 	});
 
@@ -513,14 +524,14 @@ describe('PushToAgentDialog — message handling', () => {
 });
 
 describe('PushToAgentDialog — session targeting (PLAN-2558 S5, TASK-2588)', () => {
-	it('renders a broadcast default plus one option per connected session', async () => {
+	it('renders a broadcast default plus one option per accepting session', async () => {
 		sessionsListMock.mockResolvedValue(sessions(2));
 		await mountSettled();
 
 		const picker = targetPicker();
 		if (!picker) throw new Error('expected a target picker with 2 live sessions');
 		const options = Array.from(picker.options).map((o) => ({ value: o.value, text: o.textContent }));
-		expect(options[0]).toEqual({ value: '', text: expect.stringContaining('All connected sessions (2)') });
+		expect(options[0]).toEqual({ value: '', text: expect.stringContaining('All accepting sessions (2)') });
 		expect(options[1]).toEqual({ value: 'session-id-0', text: 'docapp-0 (pid 1000)' });
 		expect(options[2]).toEqual({ value: 'session-id-1', text: 'docapp-1 (pid 1001)' });
 	});
@@ -646,6 +657,7 @@ describe('PushToAgentDialog — session targeting (PLAN-2558 S5, TASK-2588)', ()
 					id: 'session-id-1',
 					label: 'docapp-1',
 					pid: 1001,
+					armed: true,
 					connected_at: new Date(Date.now() - 60_000).toISOString()
 				}
 			]
@@ -735,5 +747,66 @@ describe('PushToAgentDialog — session targeting (PLAN-2558 S5, TASK-2588)', ()
 		// Dismissed like a normal success, not re-armed like a miss —
 		// "no auto-resend enablement" (dispatcher round 2).
 		expect(onclose).toHaveBeenCalled();
+	});
+});
+
+describe('PushToAgentDialog — connected vs accepting (PLAN-2613 S4)', () => {
+	it('sessions connected but NONE armed: refuses to send, shows the split, offers enable + clipboard', async () => {
+		sessionsListMock.mockResolvedValue(armedSessions(0, 2)); // 2 connected, 0 accepting
+		await mountSettled();
+
+		const body = bodyText();
+		// The honest-counts state D3 exists for — the two connected sessions
+		// are surfaced, not hidden behind a bare "0".
+		expect(body).toContain('2 sessions connected, 0 accepting pushes');
+		expect(body).toContain('/pad:connect');
+		// NOT the "nobody connected" copy — that would be a different lie.
+		expect(body).not.toContain('No agent session is connected');
+
+		// Send is DISABLED — a push to a connected-but-unarmed session is
+		// dropped server-side, so sending would be the silent fire-and-forget
+		// D3 forbids. Asserted at the mechanism, not just the attribute
+		// (CONVE-12).
+		expect(button('Push').disabled).toBe(true);
+		await fireEvent.click(button('Push'));
+		await tick();
+		expect(pushMock).not.toHaveBeenCalled();
+
+		// The picker offers no target (nothing accepting), and the clipboard
+		// escape hatch is present so the surface isn't a dead end.
+		expect(targetPicker()).toBeNull();
+		expect(() => button('Copy instead')).not.toThrow();
+	});
+
+	it('a mix of armed and unarmed: counts and targets only the accepting subset', async () => {
+		sessionsListMock.mockResolvedValue(armedSessions(1, 2)); // 1 accepting, 3 connected
+		await mountSettled();
+
+		const body = bodyText();
+		expect(body).toContain('1 session accepting pushes');
+		expect(body).toContain('(of 3 connected)');
+		expect(button('Push').disabled).toBe(false);
+
+		// The picker offers ONLY the armed session (+ broadcast), never the
+		// unarmed ones — targeting an unarmed session is a guaranteed miss.
+		const picker = targetPicker();
+		if (!picker) throw new Error('expected a target picker');
+		const optionValues = Array.from(picker.querySelectorAll('option')).map((o) => o.value);
+		expect(optionValues).toEqual(['', 'session-id-0']); // broadcast + the one armed
+		expect(bodyText()).toContain('All accepting sessions (1)');
+	});
+
+	it('broadcast to a mixed set carries no target (server filters to accepting)', async () => {
+		sessionsListMock.mockResolvedValue(armedSessions(2, 1));
+		await mountSettled();
+
+		// Default is broadcast; send carries the pre-S5 3-arg shape.
+		await fireEvent.click(button('Push'));
+		await tick();
+		expect(pushMock).toHaveBeenCalledWith(
+			'docapp',
+			'fix-the-thing',
+			'Take a look at TASK-5 — Fix the thing'
+		);
 	});
 });

--- a/web/src/lib/push/dispatch.test.ts
+++ b/web/src/lib/push/dispatch.test.ts
@@ -117,7 +117,7 @@ describe('describeDispatch', () => {
 
 	it('names the fallback AND its reason, so a copy never reads as a push', () => {
 		expect(describeDispatch({ kind: 'copied', because: 'no-sessions' }).message).toBe(
-			'No agent session connected — copied to clipboard instead'
+			'No agent session accepting pushes — copied to clipboard instead'
 		);
 		expect(describeDispatch({ kind: 'copied', because: 'presence-unknown' }).message).toContain(
 			'Couldn’t check for agent sessions'

--- a/web/src/lib/push/dispatch.ts
+++ b/web/src/lib/push/dispatch.ts
@@ -192,7 +192,11 @@ export function describeDispatch(outcome: DispatchOutcome): DispatchMessage {
 function copiedMessage(because: ClipboardReason): string {
 	switch (because) {
 		case 'no-sessions':
-			return 'No agent session connected — copied to clipboard instead';
+			// "accepting", not "connected": the caller counts only armed
+			// sessions (PLAN-2613 S4), so this fires when nothing is ACCEPTING
+			// pushes — which includes the case where sessions are connected but
+			// none has opted in.
+			return 'No agent session accepting pushes — copied to clipboard instead';
 		case 'presence-unknown':
 			return 'Couldn’t check for agent sessions — copied to clipboard instead';
 		case 'too-long':

--- a/web/src/lib/push/dispatch.ts
+++ b/web/src/lib/push/dispatch.ts
@@ -79,7 +79,12 @@ export function isPrePublishRefusal(err: unknown): boolean {
  * `handleListSessions` returns 503 rather than an empty list to avoid.
  */
 export type PushPresence =
-	| { state: 'known'; count: number }
+	// `count` is the ACCEPTING (armed) count — the routing gate: only an armed
+	// session receives a push (PLAN-2613 S4). `connected` is the total live
+	// count, carried alongside so a tagline can show the honest split
+	// ("M accepting of N connected") without a second read; optional so
+	// routing-only consumers need not supply it.
+	| { state: 'known'; count: number; connected?: number }
 	| { state: 'unknown' };
 
 /** Why a prompt went to the clipboard instead of an agent session. */

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -1820,6 +1820,13 @@ export interface LiveSession {
 	/** The client process's own pid, absent when it didn't say. Disambiguates
 	 *  two sessions sharing a label; not a process the server can act on. */
 	pid?: number;
+	/** Whether this session declared consent to receive `pad push`
+	 *  notifications (PLAN-2613). Only armed sessions actually RECEIVE a
+	 *  push — the server filters delivery to them — so this is the field the
+	 *  composer targets and counts. Always present (`false` for an unarmed
+	 *  session), never omitted, so "connected but not accepting" is a state
+	 *  the UI can show rather than infer from absence. */
+	armed: boolean;
 	/** When the stream opened (UTC, ISO-8601). */
 	connected_at: string;
 }


### PR DESCRIPTION
## What

PLAN-2613 **S4** — the web presentation layer, and the final stage of the push-consent gate. Presentation truthfulness only, **no new server state**: it consumes S1's per-session `armed` bit from `GET /api/v1/sessions` and reflects S3's rule that **only armed sessions receive pushes**.

**Connected is not accepting.** Surfaces that decided push-vs-copy or enabled Send on the raw connected count would fire-and-forget into a connected-but-unarmed session and lose the instruction (D3: no silent fire-and-forget).

- **`LiveSession` TS type** gains `armed` (S1 shipped it server-side; the web type hadn't caught up).
- **PushToAgentDialog** counts and targets the **accepting (armed)** subset. The presence line shows the honest split — *"M sessions accepting pushes (of N connected)"*, and the *"N connected, 0 accepting pushes — run `/pad:connect` to enable"* empty state rather than hiding connected-but-unarmed sessions behind a bare zero. Send is gated on `accepting > 0`; the picker offers only armed sessions; broadcast reaches only accepting (server-filtered). Degrades to N == M once the S3 rollout completes — the honest telemetry of D6's flip landing.
- **QuickActionsMenu** routes push-vs-copy on the accepting count (so it copies, never silently pushes, when nothing's accepting) and its tagline shows the same *"M accepting (of N connected)"* split.

## Review

Codex CLI to **CLEAN in 2 rounds** (R1 flagged the quick-actions tagline hiding the split; fixed). The consent-honesty gates (Send, picker, routing) are mutation-verified.

## Gates

`npm run check` ✓ (0 errors) · `npm run test` ✓ (1690 tests) · `npm run build` ✓ · Codex ✓ CLEAN. No Go changes (server-side `armed` shipped in S1).

## Note

Supersedes an S1-era trail note on TASK-2619 that called for an armed-only count; its premise ("unarmed sessions are structurally invisible") is contradicted by the merged code — `sessionPresence.Add` runs for every connection and `LiveSession` carries the armed bit — so the split is buildable and, per D3, more honest. The plan's own D3 text specifies the split.

https://claude.ai/code/session_017jD6t1zjxGSq47SQpZfp1V