### PR TITLE
fix(store): re-stamp attachment refs on item/document restore so a racing GC claim is refused (BUG-2629)

### DIFF
--- a/internal/store/attachments_restore_stamp_test.go
+++ b/internal/store/attachments_restore_stamp_test.go
@@ -1,0 +1,154 @@
+package store
+
+import (
+	"testing"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// BUG-2629 — RestoreItem / RestoreDocument must re-stamp the attachment
+// references in the restored content, so an orphan-GC claim racing the
+// restore is refused. The claim (ClaimNeverAttachedAttachment) bypasses the
+// live AttachmentReferenced scan and keys on last_referenced_at; if that has
+// gone stale during the archive window and the restore does not refresh it,
+// the claim reclaims a now-referenced attachment.
+//
+// ARMED FOR THE RIGHT REASON: last_referenced_at is aged to BEFORE the
+// claim's refCutoff, so the ONLY thing that can refuse the claim is a fresh
+// stamp written BY the restore. A full post-restore sweep would be vacuous
+// here — its live AttachmentReferenced scan protects the now-live content
+// regardless of the fix — so these drive ClaimNeverAttachedAttachment
+// directly, which is the claim half the restore actually races. The aged
+// stamp is the counterfactual arm: without it, CreateDocument/CreateItem's
+// own fresh stamp would refuse the claim and the test would pass for the
+// wrong reason.
+
+// stampAged forces an attachment's last_referenced_at to `when`, standing in
+// for time elapsing while the referencing content sat archived.
+func stampAged(t *testing.T, f *gcClaimFixture, id string, when time.Time) {
+	t.Helper()
+	ts := when.UTC().Format(time.RFC3339)
+	if _, err := f.s.db.Exec(f.s.q(`UPDATE attachments SET last_referenced_at = ? WHERE id = ?`), ts, id); err != nil {
+		t.Fatalf("age last_referenced_at: %v", err)
+	}
+}
+
+const restoreStaleWindow = 15 * time.Minute
+
+func TestRestoreDocument_ReStampsAttachmentRefs(t *testing.T) {
+	f := newGCClaimFixture(t)
+	att := f.seedNeverAttached(t)
+
+	doc, err := f.s.CreateDocument(f.wsID, models.DocumentCreate{
+		Title:   "spec",
+		Content: "diagram ![d](pad-attachment:" + att.ID + ")",
+	})
+	if err != nil {
+		t.Fatalf("CreateDocument: %v", err)
+	}
+	if f.lastReferencedAt(t, att.ID) == nil {
+		t.Fatalf("precondition: CreateDocument did not stamp the reference")
+	}
+
+	// Simulate the archive window: the create-time stamp goes stale.
+	stale := time.Now().Add(-restoreStaleWindow - time.Hour)
+	stampAged(t, f, att.ID, stale)
+
+	if err := f.s.DeleteDocument(doc.ID); err != nil {
+		t.Fatalf("DeleteDocument (soft): %v", err)
+	}
+	if _, err := f.s.RestoreDocument(doc.ID); err != nil {
+		t.Fatalf("RestoreDocument: %v", err)
+	}
+
+	// The claim the sweep would run while racing this restore. A fresh
+	// restore-stamp (>= refCutoff) refuses it; the aged stamp does not.
+	refCutoff := time.Now().Add(-restoreStaleWindow)
+	claimed, err := f.s.ClaimNeverAttachedAttachment(att.ID, refCutoff)
+	if err != nil {
+		t.Fatalf("ClaimNeverAttachedAttachment: %v", err)
+	}
+	if claimed {
+		t.Error("attachment claimed after RestoreDocument — restore did not re-stamp the reference (BUG-2629)")
+	}
+	if !f.rowExists(t, att.ID) {
+		t.Error("attachment row gone after restore+claim — reference not protected")
+	}
+}
+
+func TestRestoreItem_ReStampsAttachmentRefs(t *testing.T) {
+	f := newGCClaimFixture(t)
+	// Unattached upload (item_id NULL) referenced only from an item's content
+	// — the reachable item-leg case (an item-attached row carries item_id and
+	// is refused by the claim's own predicate).
+	att := f.seedNeverAttached(t)
+
+	item, err := f.s.CreateItem(f.wsID, f.collID, models.ItemCreate{
+		Title:   "host",
+		Content: "shot ![s](pad-attachment:" + att.ID + ")",
+	})
+	if err != nil {
+		t.Fatalf("CreateItem: %v", err)
+	}
+	if f.lastReferencedAt(t, att.ID) == nil {
+		t.Fatalf("precondition: CreateItem did not stamp the reference")
+	}
+
+	stale := time.Now().Add(-restoreStaleWindow - time.Hour)
+	stampAged(t, f, att.ID, stale)
+
+	if err := f.s.DeleteItem(item.ID); err != nil {
+		t.Fatalf("DeleteItem (soft): %v", err)
+	}
+	if _, err := f.s.RestoreItem(item.ID); err != nil {
+		t.Fatalf("RestoreItem: %v", err)
+	}
+
+	refCutoff := time.Now().Add(-restoreStaleWindow)
+	claimed, err := f.s.ClaimNeverAttachedAttachment(att.ID, refCutoff)
+	if err != nil {
+		t.Fatalf("ClaimNeverAttachedAttachment: %v", err)
+	}
+	if claimed {
+		t.Error("attachment claimed after RestoreItem — restore did not re-stamp the reference (BUG-2629)")
+	}
+	if !f.rowExists(t, att.ID) {
+		t.Error("attachment row gone after restore+claim — reference not protected")
+	}
+}
+
+// TestRestoreItem_ReStampsFieldsRefs covers the item fields JSON channel — an
+// attachment referenced only from a field value (e.g. a cover image) must be
+// re-stamped on restore too, since RestoreItem stamps content AND fields.
+func TestRestoreItem_ReStampsFieldsRefs(t *testing.T) {
+	f := newGCClaimFixture(t)
+	att := f.seedNeverAttached(t)
+
+	item, err := f.s.CreateItem(f.wsID, f.collID, models.ItemCreate{
+		Title:  "host",
+		Fields: `{"status":"open","cover":"pad-attachment:` + att.ID + `"}`,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem: %v", err)
+	}
+	if f.lastReferencedAt(t, att.ID) == nil {
+		t.Fatalf("precondition: CreateItem did not stamp the fields reference")
+	}
+
+	stampAged(t, f, att.ID, time.Now().Add(-restoreStaleWindow-time.Hour))
+	if err := f.s.DeleteItem(item.ID); err != nil {
+		t.Fatalf("DeleteItem (soft): %v", err)
+	}
+	if _, err := f.s.RestoreItem(item.ID); err != nil {
+		t.Fatalf("RestoreItem: %v", err)
+	}
+
+	claimed, err := f.s.ClaimNeverAttachedAttachment(att.ID, time.Now().Add(-restoreStaleWindow))
+	if err != nil {
+		t.Fatalf("ClaimNeverAttachedAttachment: %v", err)
+	}
+	if claimed {
+		t.Error("fields-referenced attachment claimed after RestoreItem — restore did not stamp fields (BUG-2629)")
+	}
+}

--- a/internal/store/documents.go
+++ b/internal/store/documents.go
@@ -455,8 +455,43 @@ func (s *Store) DeleteDocument(id string) error {
 }
 
 func (s *Store) RestoreDocument(id string) (*models.Document, error) {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+
+	// Read the soft-deleted document's content + workspace inside the tx so
+	// we can re-stamp its attachment references before it becomes live again.
+	// GetDocument filters deleted_at IS NULL, so it can't see this row yet.
+	var content, workspaceID string
+	if err := tx.QueryRow(s.q(`
+		SELECT content, workspace_id FROM documents WHERE id = ? AND deleted_at IS NOT NULL
+	`), id).Scan(&content, &workspaceID); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, sql.ErrNoRows
+		}
+		return nil, err
+	}
+
+	// BUG-2629: re-assert the document's attachment references at the moment
+	// it becomes live again. While archived, the live AttachmentReferenced
+	// scan can't see this document's refs (BUG-2614 only scans live docs), so
+	// the orphan GC may have let their last_referenced_at go stale; a claim
+	// racing this restore keys on that stamp, not the live scan. Stamp BEFORE
+	// the deleted_at clear, in this tx, per stampAttachmentRefsTx's ORDERING
+	// note: the stamp's row-lock makes a concurrent claim block until commit
+	// and re-evaluate against the fresh stamp — refusing. Document refs are
+	// necessarily never-attached (no document_id column on attachments), so
+	// this is the leg with nothing else standing between it and the claim.
+	// Prevention only: an already-reclaimed blob is gone (stamp matches zero
+	// rows).
+	if err := stampAttachmentRefsTx(tx, s, workspaceID, content); err != nil {
+		return nil, err
+	}
+
 	ts := now()
-	result, err := s.db.Exec(s.q(`
+	result, err := tx.Exec(s.q(`
 		UPDATE documents SET deleted_at = NULL, updated_at = ?, status = 'draft'
 		WHERE id = ? AND deleted_at IS NOT NULL
 	`), ts, id)
@@ -466,6 +501,9 @@ func (s *Store) RestoreDocument(id string) (*models.Document, error) {
 	rows, _ := result.RowsAffected()
 	if rows == 0 {
 		return nil, sql.ErrNoRows
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, err
 	}
 	return s.GetDocument(id)
 }

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -2736,6 +2736,19 @@ func (s *Store) restoreItemOnce(id string) (*models.Item, error) {
 		return nil, err
 	}
 
+	// BUG-2629: re-assert the item's attachment references at the moment it
+	// becomes live again. While archived, the live AttachmentReferenced scan
+	// can't see this item's refs, so the orphan GC may have let their
+	// last_referenced_at go stale; a claim racing this restore keys on that
+	// stamp (not the live scan). Stamp BEFORE the deleted_at clear, in this
+	// tx, per stampAttachmentRefsTx's ORDERING note: the stamp's row-lock
+	// makes a concurrent claim block until commit and then re-evaluate
+	// against the fresh stamp — refusing. (Prevention only: a blob already
+	// reclaimed is gone, and the stamp matches zero rows — see BUG-2629.)
+	if err := stampAttachmentRefsTx(tx, s, existing.WorkspaceID, existing.Content, existing.Fields); err != nil {
+		return nil, err
+	}
+
 	ts := now()
 	result, err := tx.Exec(s.q(`
 		UPDATE items SET deleted_at = NULL, updated_at = ?, seq = `+nextWorkspaceSeqSubquery+`


### PR DESCRIPTION
Fixes BUG-2629. An attachment referenced only from soft-deleted content was reclaimable by the orphan GC: `AttachmentReferenced` scans **live** rows only, so an archived reference is invisible to the sweep and the claim reclaims the blob past the grace period; on restore the reference is live again and dangles.

## Reachable case
A never-attached upload (`item_id IS NULL`) referenced from a **document** (no `document_id` column exists, so such a row is necessarily never-attached and `ClaimNeverAttachedAttachment` applies with nothing else in its way), or from an item's content where the attachment was uploaded unattached.

## Fix
`RestoreItem` and `RestoreDocument` call `stampAttachmentRefsTx` **before** clearing `deleted_at`, inside the restoring transaction, per that helper's ORDERING contract: the stamp row-locks the attachment, so a GC claim racing the restore blocks until commit and re-evaluates `last_referenced_at` against the fresh stamp — refusing. `RestoreItem` stamps content + fields; `RestoreDocument` (previously a bare `Exec`) is wrapped in a transaction that reads the soft-deleted content + workspace and stamps content.

**Prevention only:** a blob already reclaimed before the restore is gone (the claim is irrevocable by design) and the restore-time stamp matches zero rows. Surfacing an already-dangling reference on restore is tracked separately as **IDEA-2646**.

## Tests
Three legs (document content, item content, item fields). Each archives content holding the only reference, ages `last_referenced_at` past the claim's stale window, restores, then runs `ClaimNeverAttachedAttachment` directly — **not** the full sweep, whose live `AttachmentReferenced` scan would protect the now-live content and pass for the wrong reason. All three **fail on unfixed code**; a mutation neutering only `RestoreItem`'s stamp turns both item legs red while the document leg stays green (independently load-bearing).

## Verification
`make test` ✓ (25 pkgs) · `make test-pg` ✓ (25 pkgs — the restore tests ran under Postgres, which matters since the fix leans on the PG row-lock ordering) · `make lint` 0 issues.

https://claude.ai/code/session_017jD6t1zjxGSq47SQpZfp1V