### PR TITLE
fix(web): localIndex order-and-merge contract — tombstones, durable retag overlay, equal-seq merge (PLAN-2636 unit 2)

### DIFF
--- a/web/src/lib/stores/itemRowMerge.test.ts
+++ b/web/src/lib/stores/itemRowMerge.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect } from 'vitest';
+import {
+	resolveRowWrite,
+	preserveProjectionMetadata,
+	mergeEqualSeqProjection,
+	type Tombstone,
+} from './itemRowMerge';
+import type { ItemIndexRow } from '$lib/types';
+
+/**
+ * PLAN-2636 unit 2 — the pure write-decision + projection-merge logic shared by
+ * the in-RAM localIndex store and the IDB persistence layer. `resolveRowWrite`
+ * replaces the boolean `shouldWriteRow` at both persistence call sites and adds
+ * the tombstone gate (BUG-2633) and the equal-seq MERGE (BUG-2635); this file
+ * pins the DECISION. The interleaved-in-a-real-transaction OUTCOME is pinned by
+ * the `.idb.test.ts` siblings, which run against fake-indexeddb.
+ */
+
+function row(seq: number | undefined, extra: Record<string, unknown> = {}, id = 'item-1'): ItemIndexRow {
+	return { id, seq, ...extra } as unknown as ItemIndexRow;
+}
+
+function tomb(deletedAtSeq: number, id = 'item-1'): Tombstone {
+	return { id, deletedAtSeq };
+}
+
+function decide(
+	stored: ItemIndexRow | undefined,
+	tombstone: Tombstone | undefined,
+	incoming: ItemIndexRow,
+) {
+	return resolveRowWrite(stored, tombstone, incoming);
+}
+
+describe('resolveRowWrite — seq guard (the BUG-2609 policy, unchanged)', () => {
+	it('writes when nothing is stored yet', () => {
+		expect(decide(undefined, undefined, row(5))).toEqual({ action: 'write', row: row(5) });
+	});
+
+	it('writes over a stored row that carries no seq', () => {
+		// Stored has no ordering evidence — the incoming row wins regardless.
+		expect(decide(row(undefined), undefined, row(7)).action).toBe('write');
+		expect(decide(row(undefined), undefined, row(undefined)).action).toBe('write');
+	});
+
+	it('REFUSES a strictly older row', () => {
+		expect(decide(row(7), undefined, row(6))).toEqual({ action: 'skip' });
+		expect(decide(row(7), undefined, row(0))).toEqual({ action: 'skip' });
+	});
+
+	it('writes a strictly newer row', () => {
+		expect(decide(row(6), undefined, row(7)).action).toBe('write');
+	});
+
+	it('REFUSES a seq-less row over a stamped one (the asymmetry)', () => {
+		// The optimistic-reorder path clears seq to bypass the RAM guard; persisting
+		// it over an authoritative stamped row would strand an unorderable cache row.
+		expect(decide(row(7), undefined, row(undefined))).toEqual({ action: 'skip' });
+		expect(decide(row(0), undefined, row(undefined))).toEqual({ action: 'skip' });
+	});
+
+	it('treats seq 0 as a value, not as missing', () => {
+		expect(decide(row(0), undefined, row(1)).action).toBe('write');
+		expect(decide(row(1), undefined, row(0))).toEqual({ action: 'skip' });
+	});
+});
+
+describe('resolveRowWrite — equal seq MERGE (BUG-2635, replaces blind-accept)', () => {
+	it('writes the MERGED row when the incoming contributes a differing projection bit', () => {
+		const stored = row(7, { is_unparented: false });
+		const incoming = row(7, { is_unparented: true });
+		const d = decide(stored, undefined, incoming);
+		expect(d.action).toBe('write');
+		expect(d.action === 'write' && d.row.is_unparented).toBe(true);
+	});
+
+	it('SKIPS at equal seq when the incoming contributes nothing (no projection bit)', () => {
+		// A second tab's unmerged snapshot at the same seq must not clobber the
+		// merged row — the residual BUG-2635 closed by merging instead of accepting.
+		const stored = row(7, { is_unparented: true });
+		const incoming = row(7); // omits is_unparented
+		expect(decide(stored, undefined, incoming)).toEqual({ action: 'skip' });
+	});
+
+	it('SKIPS at equal seq when the projection bit matches (nothing to contribute)', () => {
+		const stored = row(7, { is_unparented: true });
+		const incoming = row(7, { is_unparented: true });
+		expect(decide(stored, undefined, incoming)).toEqual({ action: 'skip' });
+	});
+});
+
+describe('resolveRowWrite — projection preserve on write (unfiled 2635 sibling)', () => {
+	it('carries the stored is_unparented across a NEWER-seq write that omits it', () => {
+		// A mutation-response snapshot omits local-first projections; a newer-seq
+		// write must not drop the bit from IDB (mirrors RAM's mergeRow preserve).
+		const stored = row(5, { is_unparented: true });
+		const incoming = row(8); // newer, omits is_unparented
+		const d = decide(stored, undefined, incoming);
+		expect(d.action).toBe('write');
+		expect(d.action === 'write' && d.row.is_unparented).toBe(true);
+		expect(d.action === 'write' && d.row.seq).toBe(8);
+	});
+
+	it('does not invent a projection bit when neither side has one', () => {
+		const d = decide(row(5), undefined, row(8));
+		expect(d.action === 'write' && 'is_unparented' in d.row).toBe(false);
+	});
+});
+
+describe('resolveRowWrite — tombstone gate (BUG-2633)', () => {
+	it('REFUSES a seq-less snapshot when a tombstone exists (resurrection)', () => {
+		expect(decide(undefined, tomb(10), row(undefined))).toEqual({ action: 'skip' });
+	});
+
+	it('REFUSES a snapshot at or below the tombstone seq (stale resurrection)', () => {
+		expect(decide(undefined, tomb(10), row(9))).toEqual({ action: 'skip' });
+		expect(decide(undefined, tomb(10), row(10))).toEqual({ action: 'skip' });
+	});
+
+	it('WRITES a strictly-newer snapshot, superseding the tombstone', () => {
+		const d = decide(undefined, tomb(10), row(11));
+		expect(d).toEqual({ action: 'write', row: row(11) });
+		// The caller deletes the tombstone in the same tx; resolveRowWrite only
+		// decides the write — the supersession-delete is the persistence layer's.
+	});
+
+	it('a tombstone does not override a stored row that is even newer', () => {
+		// Defensive: if both a stored row and a tombstone exist for an id, the seq
+		// guard against the stored row still applies once the tombstone is passed.
+		const stored = row(20);
+		const incoming = row(15); // newer than tombstone, older than stored
+		expect(decide(stored, tomb(10), incoming)).toEqual({ action: 'skip' });
+	});
+});
+
+describe('preserveProjectionMetadata (moved verbatim from localIndex)', () => {
+	it('copies is_unparented from existing when next omits it', () => {
+		expect(preserveProjectionMetadata(row(1, { is_unparented: true }), row(2))).toMatchObject({
+			is_unparented: true,
+		});
+	});
+	it('leaves next untouched when it already carries the bit', () => {
+		const next = row(2, { is_unparented: false });
+		expect(preserveProjectionMetadata(row(1, { is_unparented: true }), next)).toBe(next);
+	});
+	it('no-ops when existing is undefined', () => {
+		const next = row(2);
+		expect(preserveProjectionMetadata(undefined, next)).toBe(next);
+	});
+});
+
+describe('mergeEqualSeqProjection (moved verbatim from localIndex)', () => {
+	it('returns a merged row when incoming changes the projection bit', () => {
+		expect(
+			mergeEqualSeqProjection(row(7, { is_unparented: false }), row(7, { is_unparented: true })),
+		).toMatchObject({ is_unparented: true });
+	});
+	it('returns null when incoming omits the bit', () => {
+		expect(mergeEqualSeqProjection(row(7, { is_unparented: true }), row(7))).toBeNull();
+	});
+	it('returns null when the bit is unchanged', () => {
+		expect(
+			mergeEqualSeqProjection(row(7, { is_unparented: true }), row(7, { is_unparented: true })),
+		).toBeNull();
+	});
+});

--- a/web/src/lib/stores/itemRowMerge.ts
+++ b/web/src/lib/stores/itemRowMerge.ts
@@ -1,0 +1,145 @@
+// itemRowMerge — pure row-merge + write-decision logic shared by the in-RAM
+// localIndex store and the IDB persistence layer (PLAN-2636 unit 2).
+//
+// WHY A SHARED MODULE. The persisted localIndex cache and the in-RAM store had
+// drifted into three separate decisions about whether an incoming row may
+// overwrite a stored one: RAM's `mergeRow`, the persistence layer's boolean
+// `shouldWriteRow`, and — nowhere — any memory of deletes or out-of-band
+// fields. BUG-2633 / BUG-2634 / BUG-2635 are that one gap seen three ways. The
+// fix is a single pure decision function (`resolveRowWrite`) plus the two
+// projection-merge helpers RAM already had, lifted here so both layers import
+// one implementation. The persistence layer must NOT import the Svelte store
+// (reactivity + import cycle); these helpers are pure, so this is a move.
+//
+// `preserveProjectionMetadata` and `mergeEqualSeqProjection` are moved VERBATIM
+// from `localIndex.svelte.ts` — RAM behaviour must be bit-identical after the
+// move, pinned by the existing localIndex tests.
+
+import type { ItemIndexRow } from '$lib/types';
+
+/**
+ * A hard-delete tombstone: the id that was removed and the `seq` (cursor) the
+ * removal was durable at. A tombstone IS ordering evidence — a delayed snapshot
+ * for the same id at an equal-or-older seq must not resurrect the row
+ * (BUG-2633). Persisted in its own IDB object store; see localIndexPersistence.
+ */
+export interface Tombstone {
+	id: string;
+	deletedAtSeq: number;
+}
+
+/**
+ * The outcome of `resolveRowWrite`: either write `row` (which may be a merged
+ * projection, not the raw incoming row) or skip the write entirely.
+ */
+export type RowWriteDecision =
+	| { action: 'write'; row: ItemIndexRow }
+	| { action: 'skip' };
+
+/**
+ * Full mutation responses intentionally omit local-first-only projections
+ * (e.g. `is_unparented`). Carry the existing value across optimistic
+ * replacements until the authoritative index/delta row for that seq arrives.
+ *
+ * Moved verbatim from localIndex.svelte.ts (PLAN-2636 unit 2).
+ */
+export function preserveProjectionMetadata(
+	existing: ItemIndexRow | undefined,
+	next: ItemIndexRow,
+): ItemIndexRow {
+	if (existing && !('is_unparented' in next) && 'is_unparented' in existing) {
+		return { ...next, is_unparented: existing.is_unparented };
+	}
+	return next;
+}
+
+/**
+ * An index/delta row with the SAME seq as an optimistic mutation response is
+ * not stale when it contributes projection metadata that response omitted.
+ * Returns the merged row when the incoming row adds/changes a projection bit,
+ * or null when it contributes nothing (so the caller skips the write).
+ *
+ * Moved verbatim from localIndex.svelte.ts (PLAN-2636 unit 2).
+ */
+export function mergeEqualSeqProjection(
+	existing: ItemIndexRow,
+	incoming: ItemIndexRow,
+): ItemIndexRow | null {
+	if ('is_unparented' in incoming && incoming.is_unparented !== existing.is_unparented) {
+		return { ...existing, is_unparented: incoming.is_unparented };
+	}
+	return null;
+}
+
+/**
+ * Decide whether `incoming` may overwrite the persisted row for its id, given
+ * the currently stored row and any tombstone. This is the persistence layer's
+ * write policy for `persistUpserts` / `persistDelta` — the single function that
+ * replaces the boolean `shouldWriteRow`, now aware of deletes (BUG-2633) and
+ * equal-seq projection merges (BUG-2635).
+ *
+ * Check order (the contract on the PLAN-2636 trail):
+ *
+ *   1. TOMBSTONE (BUG-2633). A tombstone is ordering evidence, so the same
+ *      no-seq asymmetry a stored row gets applies to it: a seq-less incoming,
+ *      or one at seq <= the tombstone's, is a stale resurrection → skip. A
+ *      strictly-newer incoming supersedes the delete → fall through to write;
+ *      the caller deletes the tombstone in the SAME transaction.
+ *
+ *   2. SEQ (unchanged from BUG-2609, including the no-seq asymmetry): a stored
+ *      stamped row is never overwritten by a strictly-older incoming, nor by a
+ *      seq-less one (the optimistic-reorder path clears seq to bypass the RAM
+ *      guard and paint immediately — persisting it over an authoritative row
+ *      would strand the cache with an unorderable row while the cursor sits
+ *      past the correcting delta; see shouldWriteRow's original note).
+ *
+ *   3. EQUAL SEQ (BUG-2635): MERGE, not blind-accept. This is exactly RAM's
+ *      `mergeRow` equal-seq branch, now cross-tab-safe — a second tab that
+ *      lacks the row in RAM can no longer persist an unmerged snapshot over
+ *      another tab's merged row.
+ *
+ *   4. ON WRITE: `preserveProjectionMetadata` first, mirroring RAM. This also
+ *      closes the unfiled cross-tab sibling of 2635 — a tab persisting a
+ *      mutation-response snapshot that omits `is_unparented` no longer drops
+ *      the projection field from IDB on a newer-seq write.
+ *
+ * Pure: no IDB, no store, no side effects. The caller owns the transaction and
+ * the tombstone delete.
+ */
+export function resolveRowWrite(
+	stored: ItemIndexRow | undefined,
+	tombstone: Tombstone | undefined,
+	incoming: ItemIndexRow,
+): RowWriteDecision {
+	// 1. Tombstone check (BUG-2633). Same no-seq asymmetry as a stored row: a
+	//    tombstone carries ordering evidence the incoming seq-less snapshot
+	//    lacks, so it cannot resurrect the row.
+	if (tombstone) {
+		if (incoming.seq === undefined || incoming.seq <= tombstone.deletedAtSeq) {
+			return { action: 'skip' };
+		}
+		// incoming.seq > tombstone.deletedAtSeq — authoritative supersession.
+		// A tombstoned id has no stored row (the delete removed it), so the seq
+		// block below is a no-op and we fall through to the write.
+	}
+
+	// 2 & 3. Seq guard, mirroring shouldWriteRow but merging (not accepting) at
+	//        equal seq.
+	if (stored && stored.seq !== undefined) {
+		// Stored row is stamped and the incoming one is not: no claim to be newer.
+		if (incoming.seq === undefined) return { action: 'skip' };
+		if (incoming.seq < stored.seq) return { action: 'skip' };
+		if (incoming.seq === stored.seq) {
+			const merged = mergeEqualSeqProjection(stored, incoming);
+			if (!merged) return { action: 'skip' };
+			return { action: 'write', row: merged };
+		}
+		// incoming.seq > stored.seq — newer; fall through to the write.
+	}
+
+	// 4. Preserve projection metadata on write (mirrors RAM's mergeRow, which
+	//    runs preserve before the seq compare; at equal seq the branch above
+	//    already handled the merge, so this covers the fresh-insert / stored-
+	//    seq-less / strictly-newer paths).
+	return { action: 'write', row: preserveProjectionMetadata(stored, incoming) };
+}

--- a/web/src/lib/stores/localIndex.svelte.ts
+++ b/web/src/lib/stores/localIndex.svelte.ts
@@ -67,6 +67,7 @@ import {
 	persistUpserts,
 	wipe as persistWipe,
 } from './localIndexPersistence';
+import { preserveProjectionMetadata, mergeEqualSeqProjection } from './itemRowMerge';
 import { localSearch } from './localSearch.svelte';
 import type { Item, ItemChangeRow, ItemIndexRow } from '$lib/types';
 
@@ -218,30 +219,11 @@ function toSkinny(row: ItemIndexRow | Item): ItemIndexRow {
 	return row;
 }
 
-// Full mutation responses intentionally omit local-first-only projections.
-// Carry the existing value across optimistic replacements until the
-// authoritative index/delta row for that seq arrives.
-function preserveProjectionMetadata(
-	existing: ItemIndexRow | undefined,
-	next: ItemIndexRow,
-): ItemIndexRow {
-	if (existing && !('is_unparented' in next) && 'is_unparented' in existing) {
-		return { ...next, is_unparented: existing.is_unparented };
-	}
-	return next;
-}
-
-// An index/delta row with the same seq as an optimistic mutation response is
-// not stale when it contributes projection metadata that response omitted.
-function mergeEqualSeqProjection(
-	existing: ItemIndexRow,
-	incoming: ItemIndexRow,
-): ItemIndexRow | null {
-	if ('is_unparented' in incoming && incoming.is_unparented !== existing.is_unparented) {
-		return { ...existing, is_unparented: incoming.is_unparented };
-	}
-	return null;
-}
+// `preserveProjectionMetadata` and `mergeEqualSeqProjection` moved to the pure
+// shared module `itemRowMerge.ts` (PLAN-2636 unit 2) so the IDB persistence
+// layer can apply the same equal-seq merge without importing this Svelte store.
+// Imported at the top of this file; RAM behaviour is unchanged (bit-identical
+// move, pinned by the localIndex tests).
 
 /**
  * Cursors are decimal-encoded `seq` values as opaque strings — but
@@ -538,6 +520,7 @@ export const localIndex = {
 							items: [],
 							cursor: state.cursor,
 							includesUnparentedMetadata: state.includesUnparentedMetadata,
+							retags: {},
 						}
 					: await persistHydrate(userId, ws);
 				if (isStale()) return;

--- a/web/src/lib/stores/localIndexPersistence.test.ts
+++ b/web/src/lib/stores/localIndexPersistence.test.ts
@@ -1,90 +1,20 @@
 import { describe, it, expect } from 'vitest';
-import { shouldApplyRetag, shouldWriteRow } from './localIndexPersistence';
+import { shouldApplyRetag } from './localIndexPersistence';
 import type { ItemIndexRow } from '$lib/types';
 
 /**
- * BUG-2609 — the IDB write path had no seq guard, so a snapshot taken from RAM
- * and persisted fire-and-forget could land AFTER a newer delta's atomic
- * rows+cursor transaction. The cache then held a pre-delta row while the
- * persisted cursor sat past that delta: warm boot hydrates the stale row and
- * `/items-changes?since=cursor` never returns it, so it stays stale until the
- * item happens to change again.
- *
- * These cover the DECISION. The interleaving itself is not covered — see the
- * note at the bottom of this file, which says so rather than leaving a reader
- * to assume otherwise.
+ * Pure-decision coverage for the persistence layer. The write policy itself
+ * (seq guard, no-seq asymmetry, tombstone gate, equal-seq merge) moved to
+ * `resolveRowWrite` in `itemRowMerge.ts` (PLAN-2636 unit 2) and is pinned by
+ * `itemRowMerge.test.ts`; the interleaved-in-a-real-transaction OUTCOME is
+ * pinned by the `.idb.test.ts` siblings against fake-indexeddb. What remains
+ * pure and persistence-owned here is `shouldApplyRetag` — the per-row decision
+ * `persistRetag` makes inside its transaction.
  */
-
-function row(seq: number | undefined, id = 'item-1'): ItemIndexRow {
-	return { id, seq } as unknown as ItemIndexRow;
-}
 
 function collRow(collectionId: string, slug: string, id = 'item-1'): ItemIndexRow {
 	return { id, collection_id: collectionId, collection_slug: slug } as unknown as ItemIndexRow;
 }
-
-describe('shouldWriteRow', () => {
-	it('writes when nothing is stored yet', () => {
-		expect(shouldWriteRow(undefined, row(5))).toBe(true);
-	});
-
-	it('REFUSES a strictly older row — the whole point of the guard', () => {
-		expect(shouldWriteRow(row(7), row(6))).toBe(false);
-		expect(shouldWriteRow(row(7), row(0))).toBe(false);
-	});
-
-	it('writes a newer row', () => {
-		expect(shouldWriteRow(row(6), row(7))).toBe(true);
-	});
-
-	// Equal seq must still write. RAM merges same-seq projections before
-	// persisting (localIndex's mergeRow), so the incoming row IS the merged
-	// one; refusing it would drop that merge and leave the cache behind RAM
-	// with no seq difference to ever correct it.
-	// Within a tab this is right: upsert returns early on equal seq, and any
-	// row that does reach here has been through RAM's projection merge.
-	// Across tabs it leaves a residual (BUG-2635) — accept-or-refuse is the
-	// wrong axis at equal seq, and a merge is what this layer lacks.
-	it('writes on equal seq, because RAM has already merged the projection', () => {
-		expect(shouldWriteRow(row(7), row(7))).toBe(true);
-	});
-
-	// Missing seq is ASYMMETRIC. An incoming row that carries ordering
-	// evidence beats a stored row that has none, and two unstamped rows have
-	// nothing to arbitrate — but a stored STAMPED row must not be overwritten
-	// by a snapshot with no seq at all.
-	it('writes when the incoming row has the only seq, or neither does', () => {
-		expect(shouldWriteRow(row(undefined), row(7))).toBe(true);
-		expect(shouldWriteRow(row(undefined), row(undefined))).toBe(true);
-	});
-
-	// The optimistic reorder path clears seq deliberately, to bypass the RAM
-	// guard so the drag paints immediately (TASK-1357). Persisting that copy
-	// is incidental to the intent, and letting it overwrite a stamped row
-	// leaves the cache holding a row with NO seq while the cursor sits past
-	// the delta that would have fixed it — unorderable by either guard on the
-	// next warm boot. Codex round 4; the previous version of this file
-	// asserted the opposite and enshrined the bug.
-	it('REFUSES a seq-less row over a stamped one', () => {
-		expect(shouldWriteRow(row(7), row(undefined))).toBe(false);
-		expect(shouldWriteRow(row(0), row(undefined))).toBe(false);
-	});
-
-	// seq 0 is a real value; treating it as absent would let a stale row
-	// through on the falsy check that `!existing.seq` would perform.
-	it('treats seq 0 as a value, not as missing', () => {
-		expect(shouldWriteRow(row(0), row(1))).toBe(true);
-		expect(shouldWriteRow(row(1), row(0))).toBe(false);
-	});
-
-	// The filed race, expressed as the decision the guard has to make:
-	// a retag snapshot at seq N arriving after a delta at seq N+1.
-	it('refuses the BUG-2609 sequence: an un-bumped snapshot behind a landed delta', () => {
-		const storedByDelta = row(101);
-		const staleSnapshot = row(100);
-		expect(shouldWriteRow(storedByDelta, staleSnapshot)).toBe(false);
-	});
-});
 
 /**
  * shouldApplyRetag is the decision persistRetag makes per row INSIDE its
@@ -107,60 +37,23 @@ describe('shouldApplyRetag', () => {
 	});
 
 	// Absent means the row is not cached — or was removed by a delta. Inserting
-	// it here would resurrect it behind the cursor (the BUG-2633 shape).
+	// it here would resurrect it behind the cursor (the BUG-2633 shape, now also
+	// guarded durably by the tombstone store).
 	it('REFUSES an absent row rather than inserting one', () => {
 		expect(shouldApplyRetag(undefined, 'coll-a', 'new')).toBe(false);
 	});
 });
 
 /**
- * NOT a test of persistRetag — that function is unreachable in this harness
- * (see the note at the bottom), and a no-op implementation of it would pass
- * everything in this file. Codex asked for that to be said plainly rather than
- * left for a reader to work out from the imports.
+ * WHAT THIS FILE DOES NOT COVER, stated so nobody reads it as more than it is.
  *
- * What IS asserted is the premise that made a separate function necessary: had
- * retags kept going through persistUpserts, the seq guard would have dropped
- * them. That premise is checkable here; persistRetag's own behaviour is not.
- */
-describe('the premise behind persistRetag (guard behaviour, not persistRetag itself)', () => {
-	it('would refuse an un-bumped retag snapshot once a newer delta has landed', () => {
-		const storedByDelta = row(200);
-		// applyRetag copies the row and changes collection_slug WITHOUT
-		// bumping seq — this is the value it would have persisted.
-		const retagSnapshot = row(199);
-		expect(shouldWriteRow(storedByDelta, retagSnapshot)).toBe(false);
-	});
-});
-
-/**
- * NOT COVERED HERE, stated so nobody reads these as more than they are.
- *
- * That the guard runs INSIDE the IDB transaction — i.e. compares against what
- * is stored at write time rather than at snapshot time — is not asserted by any
- * test, because there is no IndexedDB to run it against. A plain `.test.ts`
- * file belongs to vitest's `node` project (environment: 'node', see
- * vitest.config.ts) rather than the jsdom one, which takes the
- * browser-suite glob. Node provides no `indexedDB` global, the
- * jsdom project does not implement one either, and `fake-indexeddb` is not a
- * dependency. `isSupported()` therefore returns false, so every function in
- * the persistence module that TOUCHES IDB is a no-op here — the exported
- * decision helpers tested above are pure and unaffected, which is precisely
- * why they were extracted.
- *
- * So the interleaving rests on reading the call sites (the `await store.get`
- * immediately before each `put`, both within the transaction) rather than on a
- * deterministic hook. The same gap covers persistRetag entirely: nothing here
- * exercises it, and a no-op version would pass this file.
- *
- * What DID verify the transaction actually commits is a live browser run
- * against a real server — 2625 rows persisted with the fix, and 0 rows with a
- * control build whose guard refuses every write, which also reproduced the
- * cursor-ahead-of-rows shape this bug is about. That is evidence the write
- * path works; it is not a regression test, and it will not run again on its
- * own.
- *
- * Closing the gap properly means adding `fake-indexeddb` as a dev dependency,
- * which is a project decision and cannot be done from a worktree whose
- * node_modules is a symlink — raised rather than assumed.
+ * The transactional behaviour of every IDB-touching function — the write policy
+ * running INSIDE the transaction, tombstone writes/supersession, the durable
+ * retag overlay, the v1→v2 migration — is NOT exercised here. A plain
+ * `.test.ts` file belongs to vitest's `node` project (environment: 'node'),
+ * which has no `indexedDB`, so `isSupported()` returns false and every such
+ * function is a no-op. Those outcomes are covered by the `*.idb.test.ts`
+ * siblings, which run under the dedicated `idb` project against fake-indexeddb
+ * (PLAN-2636 unit 1's harness). This file keeps only the pure decisions that
+ * are reachable in the node env.
  */

--- a/web/src/lib/stores/localIndexPersistence.ts
+++ b/web/src/lib/stores/localIndexPersistence.ts
@@ -35,6 +35,25 @@
 
 import { openDB, type IDBPDatabase } from 'idb';
 import type { ItemIndexRow } from '$lib/types';
+import { resolveRowWrite, type Tombstone } from './itemRowMerge';
+
+/**
+ * IDB FORMAT version — the argument to `openDB`, used by the library to drive
+ * store-creation migrations. Bumped 1 → 2 in PLAN-2636 unit 2 to add the
+ * `tombstones` object store (BUG-2633). Distinct from
+ * `LOCAL_INDEX_SCHEMA_VERSION`, which versions the ROW SHAPE: the row shape did
+ * not change, so that constant stays 3. A v1 DB reopening under v2 gets the
+ * upgrade callback with `oldVersion === 1`; `items`/`meta` data is RETAINED and
+ * only the new store is created (empty — old exposure until first resync, not
+ * corruption). An OLD build reopening a v2 DB at version 1 gets a VersionError,
+ * which `open()` catches → returns null → that tab degrades to memory-only.
+ * Fail-safe and transient during a deploy.
+ *
+ * Exported so the test harness opens second connections / raw readers at the
+ * SAME format version the module creates — a drift there would VersionError
+ * every raw read once the module owns a higher-versioned DB.
+ */
+export const IDB_FORMAT_VERSION = 2;
 
 /**
  * SCHEMA_VERSION is the cache-shape contract. Bump it whenever the
@@ -51,15 +70,41 @@ export interface HydrateResult {
 	items: ItemIndexRow[];
 	cursor: string;
 	includesUnparentedMetadata: boolean | null;
+	/**
+	 * The durable retag overlay applied to `items` before return (BUG-2634):
+	 * `collection_id → newSlug`. Returned for inspection; `items` already
+	 * reflect it, so the warm-boot caller needs no further action. Empty when
+	 * no rename has been persisted. See `persistRetag`.
+	 */
+	retags: Record<string, string>;
 }
 
-/** Shape of the single row stored in the `meta` store. */
+/** Shape of the sync row stored in the `meta` store (keyed by `key: 'sync'`). */
 interface MetaRow {
 	key: 'sync';
 	cursor: string;
 	schemaVersion: number;
 	includesUnparentedMetadata: boolean;
 }
+
+/**
+ * The durable retag overlay row in the `meta` store (BUG-2634), keyed by
+ * `key: 'retags'`. `map` is `collection_id → latest new slug`; last rename per
+ * collection wins, mirroring RAM's `pendingRetags`. Written in the same tx as
+ * the row rewrites by `persistRetag`, applied at read time by `hydrate`, and
+ * dropped by `persistReplace` (authoritative snapshot supersedes).
+ */
+interface RetagsRow {
+	key: 'retags';
+	map: Record<string, string>;
+}
+
+/**
+ * A hard-delete tombstone row in the `tombstones` store (BUG-2633). Structural
+ * alias of `Tombstone` from itemRowMerge — kept as the persisted shape's name
+ * at the store boundary.
+ */
+type TombstoneRow = Tombstone;
 
 // Open IDB connections are cached per (user, workspace) pair. The
 // map key matches `dbName()` so cache slots can't collide across
@@ -90,6 +135,36 @@ function key(userId: string | null, ws: string): string {
 }
 
 /**
+ * Decode a cursor string to its numeric `seq` for tombstone stamping. Cursors
+ * are decimal-encoded seq values; a non-numeric / empty cursor decodes to 0,
+ * matching localIndex's `cursorAsNum`. A tombstone stamped 0 is the weakest
+ * possible ordering evidence — it refuses only seq-less and seq-0 resurrections
+ * — which is the correct floor when no real cursor is in hand.
+ */
+function seqFromCursor(cursor: string): number {
+	const n = Number(cursor);
+	return Number.isFinite(n) ? n : 0;
+}
+
+/**
+ * Write a tombstone for `id` at `deletedAtSeq`, but NEVER lower an existing
+ * tombstone's stamp (codex F4). Tombstone puts are otherwise last-write-wins,
+ * so an out-of-order cross-tab eviction (a lower-cursor delta arriving after a
+ * higher one) could weaken the gate and let a stale row between the two stamps
+ * resurrect. Keeping the max makes the stamp monotonic. Best-effort like every
+ * other write here — a failed put is swallowed so `tx.done` still resolves.
+ */
+async function raiseTombstone(
+	store: { get(key: string): Promise<unknown>; put(value: TombstoneRow): Promise<unknown> },
+	id: string,
+	deletedAtSeq: number,
+): Promise<void> {
+	const prior = (await store.get(id)) as TombstoneRow | undefined;
+	const seq = prior ? Math.max(prior.deletedAtSeq, deletedAtSeq) : deletedAtSeq;
+	store.put({ id, deletedAtSeq: seq } satisfies TombstoneRow).catch(() => undefined);
+}
+
+/**
  * Open the workspace's IDB database for the given user, creating
  * object stores on first run. Cached so subsequent calls reuse the
  * connection. Returns null on any storage failure — callers must
@@ -105,17 +180,24 @@ async function open(
 	if (cached) return cached;
 
 	try {
-		// The version arg to openDB is the IDB-format version (used
-		// for migrations). We pin it to 1 and use our own
-		// `schemaVersion` row in `meta` for content-shape versioning.
-		// That keeps schema bumps decoupled from idb library quirks.
-		const db = await openDB(dbName(userId, ws), 1, {
+		// The version arg to openDB is the IDB-FORMAT version, used by the
+		// library to drive store-creation migrations. It is now 2 (was 1) to
+		// add the `tombstones` store — see IDB_FORMAT_VERSION. Content-shape
+		// versioning stays decoupled in the `schemaVersion` row in `meta`
+		// (LOCAL_INDEX_SCHEMA_VERSION), so a row-shape bump and a format bump
+		// remain independent. The upgrade callback is idempotent per store, so
+		// it serves both a fresh v2 create (all three stores) and a v1 → v2
+		// upgrade (only `tombstones` is missing; `items`/`meta` are retained).
+		const db = await openDB(dbName(userId, ws), IDB_FORMAT_VERSION, {
 			upgrade(db) {
 				if (!db.objectStoreNames.contains('items')) {
 					db.createObjectStore('items', { keyPath: 'id' });
 				}
 				if (!db.objectStoreNames.contains('meta')) {
 					db.createObjectStore('meta', { keyPath: 'key' });
+				}
+				if (!db.objectStoreNames.contains('tombstones')) {
+					db.createObjectStore('tombstones', { keyPath: 'id' });
 				}
 			},
 		});
@@ -142,7 +224,12 @@ export async function hydrate(
 	userId: string | null,
 	ws: string,
 ): Promise<HydrateResult> {
-	const empty: HydrateResult = { items: [], cursor: '0', includesUnparentedMetadata: null };
+	const empty: HydrateResult = {
+		items: [],
+		cursor: '0',
+		includesUnparentedMetadata: null,
+		retags: {},
+	};
 	if (!isSupported()) return empty;
 
 	const db = await open(userId, ws);
@@ -150,9 +237,8 @@ export async function hydrate(
 
 	try {
 		const tx = db.transaction(['items', 'meta'], 'readonly');
-		const meta = (await tx.objectStore('meta').get('sync')) as
-			| MetaRow
-			| undefined;
+		const metaStore = tx.objectStore('meta');
+		const meta = (await metaStore.get('sync')) as MetaRow | undefined;
 
 		// Schema-version mismatch is the "your local cache is from a
 		// previous incompatible build" case. Drop everything and
@@ -163,12 +249,50 @@ export async function hydrate(
 			return empty;
 		}
 
-		const items = (await tx.objectStore('items').getAll()) as ItemIndexRow[];
+		const retagsRow = (await metaStore.get('retags')) as RetagsRow | undefined;
+		const retags = retagsRow?.map ?? {};
+		const rawRows = (await tx.objectStore('items').getAll()) as ItemIndexRow[];
 		await tx.done.catch(() => undefined);
+
+		// Apply the durable retag overlay (BUG-2634) AFTER the read: a collection
+		// rename touches no items, so no delta re-stamps a persisted row cached
+		// under the dead slug, and RAM's `pendingRetags` repair is in-memory /
+		// single-session. Reapplying the persisted intent on every hydrate is what
+		// makes a rename survive a reload. Membership + already-current checks
+		// mirror `shouldApplyRetag`: only rows whose `collection_id` matches the
+		// renamed collection are touched, and a row already carrying the new slug
+		// is left alone (also skips a row that has since MOVED to another
+		// collection — its `collection_id` no longer matches).
+		//
+		// RESIDUAL (codex F3, lead-accepted option (a)). This ALWAYS trusts the
+		// recorded rename, so it can revert a NEWER authoritative slug. TRIGGER: a
+		// tab records rename coll-a v0->v1 (overlay {coll-a:v1}), MISSES the later
+		// v1->v2 rename SSE (reconnect gap), then receives an item-delta carrying
+		// collection_slug=v2 — hydrate rewrites v2 back to v1. There is no LOCAL
+		// fix: `collection_slug` is out-of-band, renames carry no item seq, so the
+		// 2634 racing OLD-slug delta and this F3 NEWER-slug delta are
+		// indistinguishable (both arrive with seq > the rename cursor, slug !=
+		// overlay). Clearing the overlay on a divergent-slug delta only flips which
+		// case loses — it sacrifices the common 2634 race to protect the missed-SSE
+		// rarity. HEAL PATHS: (1) the next rename event for coll-a overwrites the
+		// overlay (latest-wins); (2) the BUG-2601 SSE-heal / sync-pass reconcile
+		// re-stamps the live slug; (3) any full resync -> persistReplace drops the
+		// overlay. The true disambiguator is server-side collection-slug versioning
+		// (not built here). Net strictly better than main, where the rename is lost
+		// across every reload.
+		const items = (rawRows ?? []).map((row) => {
+			const newSlug = row.collection_id ? retags[row.collection_id] : undefined;
+			if (newSlug !== undefined && row.collection_slug !== newSlug) {
+				return { ...row, collection_slug: newSlug };
+			}
+			return row;
+		});
+
 		return {
-			items: items ?? [],
+			items,
 			cursor: meta?.cursor ?? '0',
 			includesUnparentedMetadata: meta?.includesUnparentedMetadata ?? null,
+			retags,
 		};
 	} catch {
 		return empty;
@@ -176,88 +300,25 @@ export async function hydrate(
 }
 
 /**
- * Decide whether `next` may overwrite the row already stored under the same
- * id. The IDB analogue of localIndex's in-RAM `mergeRow` seq guard, which the
- * persistence layer never had (BUG-2609).
+ * WHY THE WRITE POLICY EXISTS (the race resolveRowWrite arbitrates). `upsert`
+ * hands persistUpserts a snapshot taken from RAM and does not await it. An SSE
+ * delta for the same row can commit its own atomic rows+cursor transaction in
+ * between, after which the older snapshot lands LAST and would leave IDB
+ * holding a pre-delta row while the persisted cursor sits past that delta —
+ * warm boot then hydrates the stale row and `/items-changes?since=cursor` never
+ * returns it again (BUG-2609). RAM is unaffected (single-threaded and
+ * seq-guarded); only the warm-boot cache can regress. The read-modify-write is
+ * done INSIDE the transaction so the decision compares against committed state
+ * at write time, not snapshot time — IDB serializes overlapping readwrite
+ * transactions on a store, so the `get` always sees a competing tx's committed
+ * `put`.
  *
- * Returns false in exactly two cases: `next` is strictly older than what is
- * stored, or `next` carries no seq while the stored row does (see the
- * asymmetry note below). Equal seq still writes: RAM merges same-seq projections before persisting, so the
- * incoming row is the merged one, and refusing it would drop that merge.
- * Refusing would also mirror the bug onto persistDelta, where a re-delivered
- * same-seq row carrying computed projection fields would be skipped. The
- * honest reading is that accept-or-refuse is the wrong axis at equal seq — the
- * correct semantics are a MERGE, which this layer does not have. That leaves a
- * narrow cross-tab residual (BUG-2635): a tab without the row in RAM can
- * persist an unmerged snapshot over another tab's merged one at the same seq.
- * A missing seq is treated ASYMMETRICALLY, which is the part worth reading:
- *
- *   - stored row has no seq, incoming does  -> WRITE. The incoming row carries
- *     ordering evidence the stored one lacks.
- *   - neither has a seq                     -> WRITE. No evidence either way,
- *     and refusing would disable the cache for rows the server never stamped.
- *   - stored row HAS a seq, incoming does not -> REFUSE.
- *
- * That last case is not symmetry-breaking for its own sake. The optimistic
- * reorder path deliberately clears `seq` so the row bypasses localIndex's RAM
- * guard and paints immediately (TASK-1357); persisting it is incidental to
- * that intent. Allowing it here lets a delayed optimistic snapshot overwrite an
- * authoritative row that already landed at a real seq, and the result is worse
- * than an ordinary stale row: the persisted row then has NO seq at all, so
- * neither this guard nor the RAM guard can order it on the next warm boot,
- * while the cursor sits past the delta that would have corrected it.
- *
- * Refusing costs nothing the reorder needs. RAM still shows the optimistic
- * order, and the authoritative response persists with a real seq moments later
- * — and because the cursor has not advanced past that response, a warm boot in
- * the meantime simply refetches it.
- *
- * WHY THIS EXISTS. `upsert` hands persistUpserts a snapshot taken from RAM and
- * does not await it. (`applyRetag` used to as well; it now goes through
- * persistRetag, for the reason in the exclusion list below.) An SSE delta for the same row can commit
- * its own atomic rows+cursor transaction in between, after which the older
- * snapshot lands LAST and leaves IDB holding a pre-delta row while the
- * persisted cursor sits past that delta. Warm boot then hydrates the stale row
- * and `/items-changes?since=cursor` never returns it again — stale until the
- * item happens to change. RAM is unaffected (single-threaded and seq-guarded);
- * only the warm-boot cache can regress.
- *
- * WHAT THIS GUARD DOES NOT COVER, so nobody reads it as covering more:
- *
- *   - RETAGS do not come through here at all. `applyRetag` changes
- *     collection_slug WITHOUT bumping seq, so a whole-row retag snapshot would
- *     be refused whenever a newer delta had landed — and losing a rename is
- *     permanent, not self-healing (no item delta re-stamps it, and
- *     pendingRetags is in-memory and single-session). Renames go through
- *     persistRetag, which rewrites the one field in place.
- *
- *     That closes the direction where the RETAG is the late write. It does not
- *     close the reverse: a delta captured before the rename can commit after
- *     it, whole-row put an older collection_slug at a NEWER seq, and pass this
- *     guard legitimately. collection_slug simply is not ordered by seq — it is
- *     out-of-band relative to the item's own version — so no seq comparison
- *     can arbitrate it. Fixing that means making the rename DURABLE (persisted
- *     retag intent, reapplied on hydrate) rather than a racing write; filed as
- *     BUG-2634. Pre-existing — a blind put lost the same race.
- *
- *   - HARD DELETES can still be resurrected. If persistDelta removes a row and
- *     advances the cursor, a delayed snapshot for that id finds nothing stored,
- *     passes this guard, and reinserts it behind the cursor — the same
- *     invisible-to-delta-sync shape this bug is about, in the delete direction.
- *     Refusing it needs a tombstone with its own seq, i.e. an IDB schema
- *     change; filed as BUG-2633 rather than half-built here. Pre-existing: a
- *     blind put resurrected it too.
+ * The decision itself — seq guard + no-seq asymmetry (BUG-2609), tombstone gate
+ * (BUG-2633), equal-seq projection MERGE (BUG-2635), and projection preserve on
+ * write — is the pure `resolveRowWrite` in `itemRowMerge.ts`, shared with RAM's
+ * `mergeRow`. This module owns only the transaction and the tombstone delete on
+ * supersession.
  */
-export function shouldWriteRow(
-	existing: ItemIndexRow | undefined,
-	next: ItemIndexRow,
-): boolean {
-	if (!existing) return true;
-	if (existing.seq === undefined) return true;
-	// Stored row is stamped and the incoming one is not: no claim to be newer.
-	if (next.seq === undefined) return false;
-	return next.seq >= existing.seq;
-}
 
 /**
  * Upsert a batch of rows in a single transaction. Used by
@@ -274,18 +335,19 @@ export async function persistUpserts(
 	const db = await open(userId, ws);
 	if (!db) return;
 	try {
-		const tx = db.transaction('items', 'readwrite');
-		const store = tx.objectStore('items');
-		// Read-modify-write per row, INSIDE the transaction, so the comparison
-		// is against what is stored at write time rather than at snapshot
-		// time. A blind put here is what let an older snapshot land after a
-		// newer delta (BUG-2609). The extra get doubles the operations on a
-		// cache write-through, which is cheap next to a row that goes stale
-		// until the item next changes.
+		const tx = db.transaction(['items', 'tombstones'], 'readwrite');
+		const itemsStore = tx.objectStore('items');
+		const tombstones = tx.objectStore('tombstones');
 		for (const row of rows) {
-			const existing = (await store.get(row.id)) as ItemIndexRow | undefined;
-			if (!shouldWriteRow(existing, row)) continue;
-			store.put(row).catch(() => undefined);
+			const stored = (await itemsStore.get(row.id)) as ItemIndexRow | undefined;
+			const tombstone = (await tombstones.get(row.id)) as TombstoneRow | undefined;
+			const decision = resolveRowWrite(stored, tombstone, row);
+			if (decision.action === 'skip') continue;
+			itemsStore.put(decision.row).catch(() => undefined);
+			// The write is authoritative supersession of a hard delete (rule 1):
+			// clear the tombstone in the SAME tx so it can't re-refuse a later
+			// legitimate write for this id.
+			if (tombstone) tombstones.delete(row.id).catch(() => undefined);
 		}
 		await tx.done;
 	} catch {
@@ -301,8 +363,8 @@ export async function persistUpserts(
  * renamed" — and expressing it as a whole-row put makes it two claims at once,
  * the second of which is false: it also asserts every other field still looks
  * like the snapshot taken from RAM. That second claim is what the seq guard in
- * shouldWriteRow has to refuse when a newer delta has landed, and refusing it
- * drops the rename with it.
+ * `resolveRowWrite` has to refuse when a newer delta has landed, and refusing
+ * it drops the rename with it.
  *
  * Dropping the rename is NOT self-healing, which is the reason this function
  * exists instead of an exemption from the guard. `applyRetag` does not bump
@@ -319,14 +381,19 @@ export async function persistUpserts(
  * Rows that have MOVED to another collection are skipped too; see
  * shouldApplyRetag.
  *
- * LIMIT: this is still a best-effort WRITE, like everything else in this
- * module, so a rename is lost outright if the transaction aborts (quota,
- * eviction, tab freeze) — the catch below swallows it and nothing retries.
- * A lost rename does not self-heal for the same reason it cannot be reordered:
- * no item delta re-stamps those rows, and pendingRetags is in-memory. That is
- * the same gap as BUG-2634, reached by failure rather than by racing, and the
- * fix it proposes — persist the retag INTENT and reapply it on hydrate —
- * closes both, which is why this is not a separate patch.
+ * DURABLE OVERLAY (BUG-2634, PLAN-2636 unit 2). Rewriting the rows in place is
+ * still racy in the other direction: a delta captured BEFORE the rename can
+ * commit AFTER it and whole-row put an older `collection_slug` at a newer seq,
+ * which no seq compare can arbitrate (the slug is out-of-band relative to the
+ * item's version). And a lost write (tx abort) drops the rename with nothing to
+ * retry it. Both are closed by ALSO persisting the retag INTENT: `persistRetag`
+ * upserts `{key:'retags', map:{[collectionId]: newSlug}}` in the `meta` store,
+ * in the SAME tx as the row rewrites, and `hydrate` reapplies the overlay to
+ * every matching row after the read. A racing older-slug delta is then
+ * corrected on the next hydrate rather than surviving. Latest rename per
+ * collection wins (read-modify-write the map). `persistReplace` drops the key —
+ * an authoritative snapshot already carries the live slug (BUG-2601), so a
+ * stale overlay reapplied over it could regress a newer rename.
  */
 export function shouldApplyRetag(
 	existing: ItemIndexRow | undefined,
@@ -355,13 +422,21 @@ export async function persistRetag(
 	const db = await open(userId, ws);
 	if (!db) return;
 	try {
-		const tx = db.transaction('items', 'readwrite');
+		const tx = db.transaction(['items', 'meta'], 'readwrite');
 		const store = tx.objectStore('items');
 		for (const id of ids) {
 			const existing = (await store.get(id)) as ItemIndexRow | undefined;
 			if (!shouldApplyRetag(existing, collectionId, newSlug)) continue;
 			store.put({ ...existing!, collection_slug: newSlug }).catch(() => undefined);
 		}
+		// Persist the retag INTENT (BUG-2634) in the same tx: read-modify-write
+		// the `retags` overlay map so hydrate can reapply the rename to rows a
+		// racing older-slug delta or a lost in-place write left wrong. Latest
+		// rename per collection wins.
+		const metaStore = tx.objectStore('meta');
+		const existingOverlay = (await metaStore.get('retags')) as RetagsRow | undefined;
+		const map = { ...(existingOverlay?.map ?? {}), [collectionId]: newSlug };
+		metaStore.put({ key: 'retags', map } satisfies RetagsRow).catch(() => undefined);
 		await tx.done;
 	} catch {
 		/* swallow — best-effort cache */
@@ -381,7 +456,9 @@ export async function persistRetag(
  * populated). Hard removals are either passed as `removeIds` (so a
  * moved-out eviction lands in the SAME tx as the cursor advance and
  * can't resurrect on warm boot — BUG-1675) or, for paths without a
- * cursor advance, go through `persistRemovals`.
+ * cursor advance, go through `persistRemovals`. Each hard removal also
+ * writes a tombstone stamped with this delta's cursor so a delayed stale
+ * snapshot can't reinsert the id behind the cursor (BUG-2633).
  */
 export async function persistDelta(
 	userId: string | null,
@@ -395,19 +472,32 @@ export async function persistDelta(
 	const db = await open(userId, ws);
 	if (!db) return;
 	try {
-		const tx = db.transaction(['items', 'meta'], 'readwrite');
+		const tx = db.transaction(['items', 'meta', 'tombstones'], 'readwrite');
 		const itemsStore = tx.objectStore('items');
-		// Same guard as persistUpserts: the race runs in both directions, so a
-		// delta must not overwrite a row that is already NEWER in the cache
-		// either. Skipping a row here is safe with the cursor advance below —
-		// a newer stored row already reflects state past this delta.
+		const tombstones = tx.objectStore('tombstones');
+		// Same policy as persistUpserts (resolveRowWrite): the race runs in both
+		// directions, so a delta must not overwrite a row that is already NEWER
+		// in the cache, and a tombstone must refuse a stale resurrection.
+		// Skipping a row here is safe with the cursor advance below — a newer
+		// stored row already reflects state past this delta.
 		for (const row of rows) {
-			const existing = (await itemsStore.get(row.id)) as ItemIndexRow | undefined;
-			if (!shouldWriteRow(existing, row)) continue;
-			itemsStore.put(row).catch(() => undefined);
+			const stored = (await itemsStore.get(row.id)) as ItemIndexRow | undefined;
+			const tombstone = (await tombstones.get(row.id)) as TombstoneRow | undefined;
+			const decision = resolveRowWrite(stored, tombstone, row);
+			if (decision.action === 'skip') continue;
+			itemsStore.put(decision.row).catch(() => undefined);
+			if (tombstone) tombstones.delete(row.id).catch(() => undefined);
 		}
+		// Hard removals (moved-out evictions — BUG-1675) land a TOMBSTONE stamped
+		// with this delta's cursor in the SAME tx (BUG-2633). The resurrect
+		// window is exactly "behind the persisted cursor", so the cursor is the
+		// right stamp: a delayed snapshot for this id at seq <= cursor is stale
+		// and resolveRowWrite refuses it; a genuinely newer one (seq > cursor)
+		// supersedes and clears the tombstone.
+		const deletedAtSeq = seqFromCursor(cursor);
 		for (const id of removeIds) {
 			itemsStore.delete(id).catch(() => undefined);
+			await raiseTombstone(tombstones, id, deletedAtSeq);
 		}
 		tx.objectStore('meta')
 			.put({
@@ -434,6 +524,18 @@ export async function persistDelta(
  * behind it indefinitely. A single transaction over the still-open
  * connection sidesteps that — the clear and the puts commit together (or not
  * at all), and no connection is ever torn down.
+ *
+ * RESIDUAL (codex F2, lead-accepted). Clearing `tombstones` for ids the
+ * snapshot omits reopens, for those ids, the cross-tab resurrection window a
+ * tombstone otherwise closes: a stale `persistUpserts` from ANOTHER tab — one
+ * that did not run this resync, so its RAM `fencedIds` does not cover the id —
+ * can land after the clear and reinsert an omitted row behind the replacement
+ * cursor. This is PRE-EXISTING to the item-clear below: before unit 2 the same
+ * tab could resurrect the same row with no tombstone in the picture at all, so
+ * tombstones only ever ADDED protection and this clear does not widen the
+ * hazard. Within one tab the `fencedIds` guard refuses the stale upsert before
+ * it reaches persistence. Self-healing: the next resync recomputes the fence
+ * and re-drops the row. Not worth a key-diff in this tx to close.
  */
 export async function persistReplace(
 	userId: string | null,
@@ -446,15 +548,23 @@ export async function persistReplace(
 	const db = await open(userId, ws);
 	if (!db) return;
 	try {
-		const tx = db.transaction(['items', 'meta'], 'readwrite');
+		const tx = db.transaction(['items', 'meta', 'tombstones'], 'readwrite');
 		const itemsStore = tx.objectStore('items');
 		// Queued before the puts; IDB executes requests against a store in
 		// issue order, so the clear always lands first.
 		itemsStore.clear().catch(() => undefined);
+		// The authoritative snapshot supersedes every tombstone and every
+		// pending rename: its rows ARE the current truth under the (possibly
+		// downgraded) scope, and its slugs are already live (BUG-2601). Drop
+		// both overlays so a stale tombstone can't refuse a legitimate row and a
+		// stale retag can't regress a newer slug on the next hydrate.
+		tx.objectStore('tombstones').clear().catch(() => undefined);
+		const metaStore = tx.objectStore('meta');
+		metaStore.delete('retags').catch(() => undefined);
 		for (const row of rows) {
 			itemsStore.put(row).catch(() => undefined);
 		}
-		tx.objectStore('meta')
+		metaStore
 			.put({
 				key: 'sync',
 				cursor,
@@ -473,6 +583,14 @@ export async function persistReplace(
  * 403 purge (TASK-1360) and any other hard-delete path. Soft deletes
  * stay in the cache as upserts with `deleted_at` populated — they
  * flow through `persistUpserts`.
+ *
+ * Like `persistDelta`'s `removeIds`, a removal lands a TOMBSTONE so a delayed
+ * snapshot can't resurrect the id (BUG-2633). This path has no cursor advance
+ * in hand, so it stamps the strongest floor available: the PERSISTED cursor
+ * (`meta.sync`) when a sync has happened, else the removed row's OWN seq (codex
+ * F1 — an `upsert` can persist a row before any sync writes meta.sync, and that
+ * row must still be un-resurrectable after removal), else 0. `raiseTombstone`
+ * never lowers an existing stamp.
  */
 export async function persistRemovals(
 	userId: string | null,
@@ -483,10 +601,22 @@ export async function persistRemovals(
 	const db = await open(userId, ws);
 	if (!db) return;
 	try {
-		const tx = db.transaction('items', 'readwrite');
+		const tx = db.transaction(['items', 'meta', 'tombstones'], 'readwrite');
 		const store = tx.objectStore('items');
+		const meta = (await tx.objectStore('meta').get('sync')) as MetaRow | undefined;
+		const tombstones = tx.objectStore('tombstones');
+		const cursorSeq = meta ? seqFromCursor(meta.cursor) : undefined;
 		for (const id of ids) {
+			const stored = (await store.get(id)) as ItemIndexRow | undefined;
 			store.delete(id).catch(() => undefined);
+			// ALWAYS tombstone, even with no persisted cursor (codex F1): an upsert
+			// can write a row before any sync stamps meta.sync, and without a
+			// tombstone a delayed snapshot would resurrect that removed row. Stamp
+			// the strongest floor available — the persisted cursor if we have one,
+			// else the removed row's OWN seq (a snapshot at <= that seq is the same
+			// row or older; a genuinely newer create still supersedes), else 0.
+			const stamp = cursorSeq ?? (typeof stored?.seq === 'number' ? stored.seq : 0);
+			await raiseTombstone(tombstones, id, stamp);
 		}
 		await tx.done;
 	} catch {

--- a/web/src/lib/stores/localIndexPersistence.unit2.idb.test.ts
+++ b/web/src/lib/stores/localIndexPersistence.unit2.idb.test.ts
@@ -1,0 +1,300 @@
+import { describe, it, expect } from 'vitest';
+import type { ItemIndexRow } from '$lib/types';
+import {
+	loadPersistence,
+	rawItem,
+	rawItems,
+	rawTombstone,
+	rawTombstones,
+	rawRetags,
+	seedV1Database,
+} from '../../test/idbHarness';
+
+/**
+ * PLAN-2636 unit 2 — the cache's order-and-merge contract, end-to-end through a
+ * real (fake-indexeddb) database. The pure decision is pinned by
+ * itemRowMerge.test.ts; this file pins the TRANSACTIONAL outcomes the contract
+ * on the PLAN-2636 trail specifies:
+ *
+ *   - BUG-2633: tombstones for hard-deletes — a stale snapshot can't resurrect
+ *     an evicted id behind the cursor; a genuinely newer write supersedes.
+ *   - BUG-2634: durable retag overlay — a rename survives a racing older-slug
+ *     delta and a reload, reapplied at hydrate.
+ *   - BUG-2635: equal-seq merge — a second tab's unmerged snapshot can't clobber
+ *     a merged row's projection at the same seq.
+ *
+ * Per the lead's ruling these are SNAPSHOT-staleness races: plain SEQUENTIAL
+ * calls through the module reproduce them (IDB serializes the transactions), so
+ * there is no interleaving hook.
+ */
+
+function row(
+	id: string,
+	seq: number | undefined,
+	extra: Record<string, unknown> = {},
+): ItemIndexRow {
+	return { id, seq, ...extra } as unknown as ItemIndexRow;
+}
+
+describe('BUG-2633 — tombstones stop a stale snapshot resurrecting an evicted row', () => {
+	it('an eviction tombstones the id; a later stale snapshot is refused and hydrate agrees', async () => {
+		const { persistUpserts, persistDelta, hydrate } = await loadPersistence();
+		const U = null;
+		const WS = 'ws-2633-evict';
+
+		await persistUpserts(U, WS, [row('x', 5)]);
+		// A delta evicts x (moved-out) and advances the cursor to 10 — atomic.
+		await persistDelta(U, WS, [], '10', false, ['x']);
+		// The stale RAM snapshot for x (seq 5, behind the cursor) lands last.
+		await persistUpserts(U, WS, [row('x', 5)]);
+
+		expect(await rawItem(U, WS, 'x')).toBeUndefined();
+		expect((await hydrate(U, WS)).items.find((i) => i.id === 'x')).toBeUndefined();
+		// The tombstone is stamped with the evicting delta's cursor.
+		expect((await rawTombstone(U, WS, 'x'))?.deletedAtSeq).toBe(10);
+	});
+
+	it('a seq-less stale snapshot cannot resurrect a tombstoned id', async () => {
+		const { persistUpserts, persistDelta } = await loadPersistence();
+		const U = null;
+		const WS = 'ws-2633-seqless';
+
+		await persistUpserts(U, WS, [row('x', 5)]);
+		await persistDelta(U, WS, [], '10', false, ['x']);
+		await persistUpserts(U, WS, [row('x', undefined)]); // optimistic seq-less snapshot
+
+		expect(await rawItem(U, WS, 'x')).toBeUndefined();
+	});
+
+	it('a genuinely newer write supersedes the tombstone AND clears it', async () => {
+		const { persistUpserts, persistDelta } = await loadPersistence();
+		const U = null;
+		const WS = 'ws-2633-supersede';
+
+		await persistUpserts(U, WS, [row('x', 5)]);
+		await persistDelta(U, WS, [], '10', false, ['x']); // tombstone x @ 10
+		await persistUpserts(U, WS, [row('x', 11)]); // newer than the tombstone
+
+		expect((await rawItem(U, WS, 'x'))?.seq).toBe(11);
+		expect(await rawTombstone(U, WS, 'x')).toBeUndefined(); // supersession cleared it
+	});
+
+	it('403-purge (persistRemovals) tombstones with the PERSISTED cursor', async () => {
+		const { persistDelta, persistRemovals, persistUpserts } = await loadPersistence();
+		const U = null;
+		const WS = 'ws-2633-purge';
+
+		// A prior sync established rows + a persisted cursor of 20.
+		await persistDelta(U, WS, [row('y', 15)], '20', false);
+		await persistRemovals(U, WS, ['y']); // no cursor in hand → reads meta.sync (20)
+
+		expect((await rawTombstone(U, WS, 'y'))?.deletedAtSeq).toBe(20);
+		// An in-flight stale upsert behind that cursor cannot bring y back.
+		await persistUpserts(U, WS, [row('y', 15)]);
+		expect(await rawItem(U, WS, 'y')).toBeUndefined();
+	});
+
+	it('tombstones an upsert-then-removed row even before any sync (codex F1)', async () => {
+		const { persistUpserts, persistRemovals, hydrate } = await loadPersistence();
+		const U = null;
+		const WS = 'ws-2633-presync';
+
+		// A row is optimistically upserted before any sync writes meta.sync, then
+		// removed. With no persisted cursor the tombstone stamps the row's own seq.
+		await persistUpserts(U, WS, [row('z', 5)]);
+		await persistRemovals(U, WS, ['z']);
+		expect((await rawTombstone(U, WS, 'z'))?.deletedAtSeq).toBe(5);
+
+		// A delayed stale snapshot of the same row cannot bring it back...
+		await persistUpserts(U, WS, [row('z', 5)]);
+		expect(await rawItem(U, WS, 'z')).toBeUndefined();
+		expect((await hydrate(U, WS)).items.find((i) => i.id === 'z')).toBeUndefined();
+
+		// ...but a genuinely newer create still supersedes the tombstone.
+		await persistUpserts(U, WS, [row('z', 9)]);
+		expect((await rawItem(U, WS, 'z'))?.seq).toBe(9);
+	});
+
+	it('a lower-cursor eviction does not weaken a higher tombstone stamp (codex F4)', async () => {
+		const { persistUpserts, persistDelta } = await loadPersistence();
+		const U = null;
+		const WS = 'ws-2633-f4';
+
+		await persistUpserts(U, WS, [row('x', 5)]);
+		await persistDelta(U, WS, [], '20', false, ['x']); // tombstone x @ 20
+		// An out-of-order lower-cursor eviction for the same id must not lower it.
+		await persistDelta(U, WS, [], '10', false, ['x']);
+		expect((await rawTombstone(U, WS, 'x'))?.deletedAtSeq).toBe(20);
+
+		// A snapshot at a seq between the two stamps is still refused.
+		await persistUpserts(U, WS, [row('x', 15)]);
+		expect(await rawItem(U, WS, 'x')).toBeUndefined();
+	});
+});
+
+describe('BUG-2634 — durable retag overlay survives a racing delta and a reload', () => {
+	function collRow(id: string, seq: number, collectionId: string, slug: string): ItemIndexRow {
+		return { id, seq, collection_id: collectionId, collection_slug: slug } as unknown as ItemIndexRow;
+	}
+
+	it('a rename is reapplied at hydrate even after a racing older-slug delta wins the stored row', async () => {
+		const { persistUpserts, persistRetag, persistDelta, hydrate } = await loadPersistence();
+		const U = null;
+		const WS = 'ws-2634-race';
+
+		await persistUpserts(U, WS, [collRow('a1', 1, 'coll-a', 'old-a')]);
+		// Collection renamed old-a → new-a: rows rewritten in place + overlay persisted.
+		await persistRetag(U, WS, 'coll-a', ['a1'], 'new-a');
+		expect((await rawItem(U, WS, 'a1'))?.collection_slug).toBe('new-a');
+		expect(await rawRetags(U, WS)).toEqual({ 'coll-a': 'new-a' });
+
+		// A delta captured BEFORE the rename commits AFTER it, at a newer seq,
+		// carrying the dead slug — no seq compare can arbitrate an out-of-band field.
+		await persistDelta(U, WS, [collRow('a1', 2, 'coll-a', 'old-a')], '2', false);
+		expect((await rawItem(U, WS, 'a1'))?.collection_slug).toBe('old-a'); // stored row regressed...
+
+		// ...but hydrate reapplies the overlay, so the reader sees the rename.
+		const h = await hydrate(U, WS);
+		expect(h.items.find((i) => i.id === 'a1')?.collection_slug).toBe('new-a');
+		expect(h.retags).toEqual({ 'coll-a': 'new-a' });
+	});
+
+	it('the overlay does not chase a row that has since MOVED out of the renamed collection (codex F5)', async () => {
+		const { persistUpserts, persistRetag, persistDelta, hydrate } = await loadPersistence();
+		const U = null;
+		const WS = 'ws-2634-moved';
+
+		await persistUpserts(U, WS, [collRow('a1', 1, 'coll-a', 'old-a')]);
+		// Rename coll-a → new-a: a1 rewritten in place + overlay persisted.
+		await persistRetag(U, WS, 'coll-a', ['a1'], 'new-a');
+		// a1 then genuinely MOVES to coll-b via an authoritative delta at a newer seq.
+		await persistDelta(U, WS, [collRow('a1', 2, 'coll-b', 'b-slug')], '2', false);
+		expect((await rawItem(U, WS, 'a1'))?.collection_id).toBe('coll-b');
+
+		// Membership is by collection_id: the coll-a overlay must NOT rewrite a1's
+		// slug now that a1 lives in coll-b. (This discriminates the membership rule —
+		// a blanket overlay-apply would wrongly stamp a1 with new-a.)
+		const h = await hydrate(U, WS);
+		const a1 = h.items.find((i) => i.id === 'a1');
+		expect(a1?.collection_id).toBe('coll-b');
+		expect(a1?.collection_slug).toBe('b-slug');
+	});
+
+	it('latest rename per collection wins the overlay', async () => {
+		const { persistUpserts, persistRetag } = await loadPersistence();
+		const U = null;
+		const WS = 'ws-2634-latest';
+
+		await persistUpserts(U, WS, [collRow('a1', 1, 'coll-a', 'v0')]);
+		await persistRetag(U, WS, 'coll-a', ['a1'], 'v1');
+		await persistRetag(U, WS, 'coll-a', ['a1'], 'v2');
+		expect(await rawRetags(U, WS)).toEqual({ 'coll-a': 'v2' });
+	});
+
+	it('persistReplace drops the overlay (authoritative snapshot carries live slugs)', async () => {
+		const { persistUpserts, persistRetag, persistReplace, hydrate } = await loadPersistence();
+		const U = null;
+		const WS = 'ws-2634-replace';
+
+		await persistUpserts(U, WS, [collRow('a1', 1, 'coll-a', 'old-a')]);
+		await persistRetag(U, WS, 'coll-a', ['a1'], 'new-a');
+		expect(await rawRetags(U, WS)).toEqual({ 'coll-a': 'new-a' });
+
+		// A projection resync installs an authoritative snapshot (live slugs).
+		await persistReplace(U, WS, [collRow('a1', 3, 'coll-a', 'authoritative')], '3', true);
+		expect(await rawRetags(U, WS)).toBeUndefined();
+		// Hydrate no longer rewrites the slug — the overlay is gone.
+		expect((await hydrate(U, WS)).items.find((i) => i.id === 'a1')?.collection_slug).toBe(
+			'authoritative',
+		);
+	});
+});
+
+describe('BUG-2635 — equal-seq merge keeps a merged projection cross-tab', () => {
+	it('an unmerged equal-seq snapshot does NOT clobber a merged rows projection bit', async () => {
+		const { persistUpserts } = await loadPersistence();
+		const U = null;
+		const WS = 'ws-2635-merge';
+
+		// Tab B has the merged row: is_unparented projected in at seq 7.
+		await persistUpserts(U, WS, [row('x', 7, { is_unparented: true })]);
+		// Tab A holds a stale RAM snapshot at the SAME seq that never merged the
+		// projection, and persists it. Under the old blind-accept-at-equal-seq it
+		// would drop is_unparented; the merge refuses it.
+		await persistUpserts(U, WS, [row('x', 7)]);
+
+		expect((await rawItem(U, WS, 'x'))?.is_unparented).toBe(true);
+	});
+
+	it('a newer-seq write that omits the projection preserves the stored bit', async () => {
+		const { persistUpserts } = await loadPersistence();
+		const U = null;
+		const WS = 'ws-2635-preserve';
+
+		await persistUpserts(U, WS, [row('x', 5, { is_unparented: true })]);
+		await persistUpserts(U, WS, [row('x', 8)]); // mutation snapshot omits the projection
+
+		const stored = await rawItem(U, WS, 'x');
+		expect(stored?.seq).toBe(8);
+		expect(stored?.is_unparented).toBe(true);
+	});
+});
+
+describe('persistReplace clears the tombstone store too', () => {
+	it('an authoritative snapshot supersedes every tombstone', async () => {
+		const { persistUpserts, persistDelta, persistReplace } = await loadPersistence();
+		const U = null;
+		const WS = 'ws-replace-tombstones';
+
+		await persistUpserts(U, WS, [row('x', 5)]);
+		await persistDelta(U, WS, [], '10', false, ['x']); // tombstone x
+		expect(await rawTombstones(U, WS)).toHaveLength(1);
+
+		await persistReplace(U, WS, [row('y', 1)], '10', false);
+		expect(await rawTombstones(U, WS)).toHaveLength(0);
+	});
+});
+
+describe('v1 → v2 migration through the real module', () => {
+	it('a v1 database migrates on the module open, retaining items and starting tombstones empty', async () => {
+		const U = null;
+		const WS = 'ws-migrate-module';
+		// Seed a pre-unit-2 (format v1) database with an item + meta.
+		await seedV1Database(U, WS, [row('keep', 3)], {
+			cursor: '3',
+			schemaVersion: 3,
+			includesUnparentedMetadata: true,
+		});
+
+		// The module opens at IDB_FORMAT_VERSION (2) → upgrade runs, tombstones
+		// store is created, existing data retained.
+		const { persistUpserts, hydrate } = await loadPersistence();
+		await persistUpserts(U, WS, [row('fresh', 4)]);
+
+		expect((await rawItem(U, WS, 'keep'))?.seq).toBe(3); // survived the format bump
+		expect(await rawTombstones(U, WS)).toHaveLength(0); // new store, empty
+		const items = (await hydrate(U, WS)).items;
+		expect(items.map((i) => i.id).sort()).toEqual(['fresh', 'keep']);
+	});
+});
+
+// Guard the vacuous-read failure mode for the new stores: assert the module
+// actually writes what the raw readers claim to read, under the module's own
+// namespace, not an empty sibling.
+describe('raw readers address the module database', () => {
+	it('a persisted tombstone + retag are readable back under the module name', async () => {
+		const { persistUpserts, persistDelta, persistRetag } = await loadPersistence();
+		const U = 'user-9';
+		const WS = 'Name With Spaces';
+
+		await persistUpserts(U, WS, [
+			{ id: 'r', seq: 1, collection_id: 'c', collection_slug: 's' } as unknown as ItemIndexRow,
+		]);
+		await persistRetag(U, WS, 'c', ['r'], 's2');
+		await persistDelta(U, WS, [], '9', false, ['r']);
+
+		expect(await rawRetags(U, WS)).toEqual({ c: 's2' });
+		expect((await rawTombstone(U, WS, 'r'))?.deletedAtSeq).toBe(9);
+		expect(await rawItems(U, WS)).toHaveLength(0);
+	});
+});

--- a/web/src/test/idbHarness.ts
+++ b/web/src/test/idbHarness.ts
@@ -16,6 +16,8 @@
 import { openDB, type IDBPDatabase } from 'idb';
 import { vi } from 'vitest';
 import type { ItemIndexRow } from '$lib/types';
+import type { Tombstone } from '$lib/stores/itemRowMerge';
+import { IDB_FORMAT_VERSION } from '$lib/stores/localIndexPersistence';
 
 /**
  * Mirrors localIndexPersistence.dbName EXACTLY so the harness addresses the
@@ -52,14 +54,16 @@ export async function loadPersistence(): Promise<
  * (verified in the unit-1 spike), so writes through one are visible to the
  * other, exactly like two browser tabs.
  *
- * Opens at IDB format version 1 with the same stores localIndexPersistence
- * creates, so it never triggers an unexpected upgrade.
+ * Opens at the module's CURRENT IDB format version (IDB_FORMAT_VERSION) with
+ * the same stores localIndexPersistence creates, so it never triggers an
+ * unexpected upgrade and never VersionErrors against a module-owned DB at that
+ * version. Imported from the module so the two can't drift.
  */
 export async function openSecondConnection(
 	userId: string | null,
 	ws: string,
 ): Promise<IDBPDatabase> {
-	return openDB(harnessDbName(userId, ws), 1, {
+	return openDB(harnessDbName(userId, ws), IDB_FORMAT_VERSION, {
 		upgrade(db) {
 			if (!db.objectStoreNames.contains('items')) {
 				db.createObjectStore('items', { keyPath: 'id' });
@@ -67,8 +71,49 @@ export async function openSecondConnection(
 			if (!db.objectStoreNames.contains('meta')) {
 				db.createObjectStore('meta', { keyPath: 'key' });
 			}
+			if (!db.objectStoreNames.contains('tombstones')) {
+				db.createObjectStore('tombstones', { keyPath: 'id' });
+			}
 		},
 	});
+}
+
+/** Raw read of a single persisted tombstone by id (BUG-2633) — ground truth. */
+export async function rawTombstone(
+	userId: string | null,
+	ws: string,
+	id: string,
+): Promise<Tombstone | undefined> {
+	const db = await openSecondConnection(userId, ws);
+	try {
+		return (await db.get('tombstones', id)) as Tombstone | undefined;
+	} finally {
+		db.close();
+	}
+}
+
+/** Raw read of every persisted tombstone — ground truth for the store's size. */
+export async function rawTombstones(userId: string | null, ws: string): Promise<Tombstone[]> {
+	const db = await openSecondConnection(userId, ws);
+	try {
+		return (await db.getAll('tombstones')) as Tombstone[];
+	} finally {
+		db.close();
+	}
+}
+
+/** Raw read of the durable retag overlay map (BUG-2634), or undefined if unset. */
+export async function rawRetags(
+	userId: string | null,
+	ws: string,
+): Promise<Record<string, string> | undefined> {
+	const db = await openSecondConnection(userId, ws);
+	try {
+		const row = (await db.get('meta', 'retags')) as { map?: Record<string, string> } | undefined;
+		return row?.map;
+	} finally {
+		db.close();
+	}
 }
 
 /**


### PR DESCRIPTION
PLAN-2636 unit 2 — the localIndex cache's order-and-merge contract. Follows unit 1 (#1156, the fake-indexeddb harness). Implements the design checkpoint on the PLAN-2636 trail.

## What
The persisted localIndex cache decided writes with a bare seq compare that (a) had no memory of hard deletes, (b) couldn't arbitrate out-of-band `collection_slug`, and (c) blind-accepted at equal seq — BUG-2633 / BUG-2634 / BUG-2635, one gap seen three ways. This lands a single write policy + read overlay.

- **`itemRowMerge.ts` (new, pure):** `resolveRowWrite(stored, tombstone, incoming)` replaces boolean `shouldWriteRow` at both persistence call sites. Order: tombstone gate (2633) → seq guard + no-seq asymmetry (unchanged from 2609) → equal-seq MERGE (2635) → `preserveProjectionMetadata` on write. The two projection helpers move here verbatim from `localIndex.svelte.ts` so the IDB layer shares them without importing the Svelte store; RAM stays bit-identical.
- **Tombstones (2633):** new `tombstones` store, IDB format v1→v2 (row shape unchanged, `LOCAL_INDEX_SCHEMA_VERSION` stays 3). Hard removals stamp `deletedAtSeq`; a stale/seq-less snapshot behind the cursor can't resurrect an evicted id; a newer write supersedes + clears the tombstone. `persistReplace` clears the store. Old build on a v2 DB → VersionError → memory-only degrade.
- **Durable retag overlay (2634):** `persistRetag` also persists `{key:'retags', map}`; `hydrate` reapplies it after the read, so a rename survives a racing older-slug delta and a reload. `persistReplace` drops it (server rows carry live slugs — BUG-2601).

## Tests / gates
- `itemRowMerge.test.ts` (pure decision matrix) + `localIndexPersistence.unit2.idb.test.ts` (tombstone/overlay/cross-tab/migration outcomes through fake-indexeddb) + harness raw-readers.
- Every regression **mutation-verified discriminating**: neuter tombstone gate / blind-accept equal seq / skip overlay-apply / drop preserve / break the shared helper — each reddens exactly the matching test, across BOTH RAM and persistence suites.
- `npm run test` 1729 passed (98 files, +26); `npm run check` 0 errors; `check:tiptap-pins` OK; `vite build` clean. **WEB-ONLY, zero Go, no dep churn** (fake-indexeddb already on main from unit 1).

Draft pending Codex-to-CLEAN + lead GO (CONVE-11).

https://claude.ai/code/session_017jD6t1zjxGSq47SQpZfp1V

---
**Codex round 1:** F1 (pre-sync tombstone), F4 (tombstone stamp monotonic), F5 (real "moved" membership test) fixed in-lane and mutation-verified. **F2** (persistReplace clears tombstones for omitted ids — pre-existing to its item-clear) and **F3** (durable overlay has no local way to disambiguate a pre-rename old-slug delta from a newer authoritative slug — can revert v2→v1 after a missed rename SSE) are contract-level and held on the PLAN-2636 trail for a lead ruling before merge. Gates: 1730 tests / check 0 errors / build clean.