### PR TITLE
feat(cli): PAD_TOKEN environment override for stored credentials (#879)

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,7 +513,7 @@ Set `PAD_TOKEN` to a Pad API token (minted under **Settings → API tokens** in 
 PAD_TOKEN=pad_xxxxxxxx pad item list
 ```
 
-`PAD_TOKEN` takes precedence over credentials saved by `pad auth login` — the same convention as `gh`'s `GH_TOKEN`. This is useful for CI, scripts, and machines where several AI agents share one CLI install but should act as different Pad users: give each agent its own token in its process environment, and the credential store is never touched. `pad auth whoami` reports the token's identity (with an `Auth: PAD_TOKEN environment override` line), and `pad auth login`/`logout` warn when the override is active — they manage the stored credentials, which the override bypasses.
+`PAD_TOKEN` takes precedence over credentials saved by `pad auth login` — the same convention as `gh`'s `GH_TOKEN`. This is useful for CI, scripts, and machines where several AI agents share one CLI install but should act as different Pad users: give each agent its own token in its process environment, and the credential store is never touched. `pad auth whoami` reports the token's identity (with an `Auth: PAD_TOKEN environment override` line), and `pad auth login`/`logout` warn when the override is active — they manage the stored credentials, which the override bypasses. Deliberately, `pad auth logout` never invalidates the `PAD_TOKEN` session itself: it signs out the *stored* session only, and the env token's lifecycle belongs to wherever it was minted (revoke it under **Settings → API tokens**).
 
 ```bash
 pad workspace members               # List workspace members

--- a/README.md
+++ b/README.md
@@ -505,6 +505,16 @@ pad auth logout        # Sign out
 
 Once a user exists, all API requests and web UI access require authentication. Credentials are stored in `~/.pad/credentials.json`. Multiple users can be invited to workspaces with role-based access control (`owner`, `editor`, `viewer`).
 
+#### Authenticating with an environment token
+
+Set `PAD_TOKEN` to a Pad API token (minted under **Settings → API tokens** in the web UI) to authenticate without `pad auth login`:
+
+```bash
+PAD_TOKEN=pad_xxxxxxxx pad item list
+```
+
+`PAD_TOKEN` takes precedence over credentials saved by `pad auth login` — the same convention as `gh`'s `GH_TOKEN`. This is useful for CI, scripts, and machines where several AI agents share one CLI install but should act as different Pad users: give each agent its own token in its process environment, and the credential store is never touched. `pad auth whoami` reports the token's identity (with an `Auth: PAD_TOKEN environment override` line), and `pad auth login`/`logout` warn when the override is active — they manage the stored credentials, which the override bypasses.
+
 ```bash
 pad workspace members               # List workspace members
 pad workspace invite user@example.com

--- a/cmd/pad/cmd_auth.go
+++ b/cmd/pad/cmd_auth.go
@@ -342,6 +342,9 @@ func loginCmd() *cobra.Command {
 			}()
 
 			cfg := getConfiguredConfig()
+			if n := envTokenNotice(); n != "" {
+				fmt.Fprintln(os.Stderr, n)
+			}
 			if err := cli.EnsureServer(cfg); err != nil {
 				return err
 			}
@@ -801,29 +804,56 @@ func readPasswordFrom(fallback *bufio.Reader) (string, error) {
 	return string(pw), nil
 }
 
+// envTokenNotice returns a one-line warning when PAD_TOKEN is set, or ""
+// when it isn't. login/logout print it to stderr (gh-style) so users
+// aren't surprised that managing stored credentials doesn't change the
+// identity API calls use while the override is active (#879).
+func envTokenNotice() string {
+	if cli.EnvToken() == "" {
+		return ""
+	}
+	return "Note: PAD_TOKEN is set and overrides stored credentials for all API calls."
+}
+
 func logoutCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "logout",
 		Short: "Log out of Pad",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg := getConfiguredConfig()
+			if n := envTokenNotice(); n != "" {
+				fmt.Fprintln(os.Stderr, n)
+			}
 			if err := cli.EnsureServer(cfg); err != nil {
 				return err
 			}
 			client := cli.NewClientFromURL(cfg.BaseURL())
 
-			// Try to invalidate server-side session
-			_ = client.Logout()
+			store, err := cli.LoadStore()
+			if err != nil {
+				return fmt.Errorf("load credentials: %w", err)
+			}
+
+			// Try to invalidate the STORED server-side session. Under
+			// PAD_TOKEN the constructor resolved the env token (#879),
+			// so an unpinned Logout() would invalidate the env token's
+			// session instead of the stored one — pin to the stored
+			// token, and skip the server call entirely when there is no
+			// stored session to invalidate.
+			if cli.EnvToken() != "" {
+				if creds := store.Get(cfg.BaseURL()); creds != nil && creds.Token != "" {
+					client.SetAuthToken(creds.Token)
+					_ = client.Logout()
+				}
+			} else {
+				_ = client.Logout()
+			}
 
 			// Delete only the entry for THIS server. Other servers'
 			// credentials stay intact (TASK-1228 — pre-fix behavior wiped
 			// the whole file). If the entry isn't present, Delete is a
 			// silent no-op which matches what the user expects from
 			// `pad auth logout` against an unauthed server.
-			store, err := cli.LoadStore()
-			if err != nil {
-				return fmt.Errorf("load credentials: %w", err)
-			}
 			store.Delete(cfg.BaseURL())
 			if err := store.Save(); err != nil {
 				return fmt.Errorf("save credentials: %w", err)
@@ -843,26 +873,45 @@ func whoamiCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg := getConfiguredConfig()
 
-			// Per-server lookup (TASK-1228). The store may have entries
-			// for other servers — we only care about the configured one.
-			store, err := cli.LoadStore()
-			if err != nil {
-				return fmt.Errorf("load credentials: %w", err)
-			}
-			creds := store.Get(cfg.BaseURL())
-			if creds == nil || creds.Token == "" {
-				fmt.Println("Not logged in. Run 'pad auth login'.")
-				return nil
+			// PAD_TOKEN overrides stored credentials (issue #879): when
+			// set, report the identity the token resolves to via a real
+			// /me fetch — the store may be empty or hold a different
+			// user, and every other command authenticates as the env
+			// token's user, so the store short-circuit below would make
+			// whoami lie.
+			envToken := cli.EnvToken()
+
+			var creds *cli.Credentials
+			if envToken == "" {
+				// Per-server lookup (TASK-1228). The store may have entries
+				// for other servers — we only care about the configured one.
+				store, err := cli.LoadStore()
+				if err != nil {
+					return fmt.Errorf("load credentials: %w", err)
+				}
+				creds = store.Get(cfg.BaseURL())
+				if creds == nil || creds.Token == "" {
+					fmt.Println("Not logged in. Run 'pad auth login'.")
+					return nil
+				}
 			}
 
 			if err := cli.EnsureServer(cfg); err != nil {
 				return err
 			}
+			// NewClientFromURL already resolves PAD_TOKEN; only pin the
+			// token explicitly on the stored-credential path.
 			client := cli.NewClientFromURL(cfg.BaseURL())
-			client.SetAuthToken(creds.Token)
+			if creds != nil {
+				client.SetAuthToken(creds.Token)
+			}
 
 			user, err := client.GetCurrentUser()
 			if err != nil {
+				if envToken != "" {
+					fmt.Println("PAD_TOKEN is set but the server rejected it.")
+					return nil
+				}
 				fmt.Println("Session expired. Run 'pad auth login'.")
 				return nil
 			}
@@ -873,6 +922,9 @@ func whoamiCmd() *cobra.Command {
 				fmt.Printf("Name:  %s\n", user.Name)
 				fmt.Printf("Email: %s\n", user.Email)
 				fmt.Printf("Role:  %s\n", user.Role)
+				if envToken != "" {
+					fmt.Println("Auth:  PAD_TOKEN environment override")
+				}
 			}
 			return nil
 		},

--- a/cmd/pad/cmd_auth.go
+++ b/cmd/pad/cmd_auth.go
@@ -353,14 +353,22 @@ func loginCmd() *cobra.Command {
 			// Check if already logged in with valid session for THIS
 			// server. Per-server lookup (TASK-1228) — saved credentials
 			// for other servers don't short-circuit this login.
-			store, _ := cli.LoadStore()
-			creds := store.Get(cfg.BaseURL())
-			if creds != nil && creds.Token != "" {
-				client.SetAuthToken(creds.Token)
-				user, err := client.GetCurrentUser()
-				if err == nil && user != nil {
-					fmt.Printf("Already logged in as %s (%s)\n", user.Name, user.Email)
-					return nil
+			//
+			// Skipped under PAD_TOKEN (#879): the shortcut reads the
+			// STORE, and printing "Already logged in as <stored user>"
+			// right after the override notice would contradict it —
+			// API calls run as the env token's user regardless. login
+			// manages stored credentials, so proceed to the real flow.
+			if cli.EnvToken() == "" {
+				store, _ := cli.LoadStore()
+				creds := store.Get(cfg.BaseURL())
+				if creds != nil && creds.Token != "" {
+					client.SetAuthToken(creds.Token)
+					user, err := client.GetCurrentUser()
+					if err == nil && user != nil {
+						fmt.Printf("Already logged in as %s (%s)\n", user.Name, user.Email)
+						return nil
+					}
 				}
 			}
 

--- a/cmd/pad/env_token_override_test.go
+++ b/cmd/pad/env_token_override_test.go
@@ -1,0 +1,189 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Tests for the PAD_TOKEN override's command-level behaviour (issue
+// #879, layer 1): whoami reports the effective identity, and logout
+// never invalidates the env token's session.
+//
+// HOME and USERPROFILE are both set because CredentialsPath resolves
+// via os.UserHomeDir (HOME on Unix, USERPROFILE on Windows).
+
+func setTempHomeMain(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("PAD_MODE", "")
+	// Escape any ancestor .pad.toml: applyPadTomlOverride walks up from
+	// CWD and its URL pin would override the PAD_URL these tests set
+	// (same pattern as TestMonitorClient_UnconfiguredReturnsError).
+	t.Chdir(t.TempDir())
+	return home
+}
+
+func writeCredStore(t *testing.T, home, serverURL, token string) {
+	t.Helper()
+	dir := filepath.Join(home, ".pad")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	body := `{"version": 2, "credentials": {"` + serverURL + `": {
+		"server_url": "` + serverURL + `", "token": "` + token + `",
+		"user_id": "u-1", "email": "stored@example.com", "name": "Stored User"}}}`
+	if err := os.WriteFile(filepath.Join(dir, "credentials.json"), []byte(body), 0600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}
+
+// stubAuthServer serves /api/v1/auth/me for exactly one bearer token and
+// records the Authorization header of any /api/v1/auth/logout call.
+type stubAuthServer struct {
+	*httptest.Server
+	meHits       int
+	logoutTokens []string
+}
+
+func newStubAuthServer(t *testing.T, wantToken string) *stubAuthServer {
+	t.Helper()
+	s := &stubAuthServer{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/auth/me", func(w http.ResponseWriter, r *http.Request) {
+		s.meHits++
+		if r.Header.Get("Authorization") != "Bearer "+wantToken {
+			w.WriteHeader(http.StatusUnauthorized)
+			_ = json.NewEncoder(w).Encode(map[string]any{"error": "unauthorized"})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id": "u-agent", "email": "agent@example.com",
+			"name": "Agent User", "role": "member",
+		})
+	})
+	mux.HandleFunc("/api/v1/auth/logout", func(w http.ResponseWriter, r *http.Request) {
+		s.logoutTokens = append(s.logoutTokens, r.Header.Get("Authorization"))
+		w.WriteHeader(http.StatusOK)
+	})
+	s.Server = httptest.NewServer(mux)
+	t.Cleanup(s.Close)
+	return s
+}
+
+// With PAD_TOKEN set and NO stored credentials, whoami must authenticate
+// with the env token instead of printing "Not logged in." — the store
+// short-circuit would make whoami lie about the identity every other
+// command uses.
+func TestWhoami_UsesEnvToken(t *testing.T) {
+	setTempHomeMain(t) // empty credential store
+	srv := newStubAuthServer(t, "pad_envtoken")
+	t.Setenv("PAD_URL", srv.URL)
+	t.Setenv("PAD_TOKEN", "pad_envtoken")
+
+	cmd := whoamiCmd()
+	if err := cmd.RunE(cmd, nil); err != nil {
+		t.Fatalf("whoami with PAD_TOKEN: %v", err)
+	}
+	if srv.meHits == 0 {
+		t.Error("stub /auth/me never contacted — whoami short-circuited on the store lookup")
+	}
+}
+
+// Without PAD_TOKEN and without credentials, whoami keeps its existing
+// "Not logged in" behaviour and never contacts the server.
+func TestWhoami_NoTokenNoStoreUnchanged(t *testing.T) {
+	setTempHomeMain(t)
+	srv := newStubAuthServer(t, "unused")
+	t.Setenv("PAD_URL", srv.URL)
+	t.Setenv("PAD_TOKEN", "")
+
+	cmd := whoamiCmd()
+	if err := cmd.RunE(cmd, nil); err != nil {
+		t.Fatalf("whoami: %v", err)
+	}
+	if srv.meHits != 0 {
+		t.Errorf("expected no server contact when unauthenticated, got %d /auth/me hits", srv.meHits)
+	}
+}
+
+// logout manages the STORED session. Under PAD_TOKEN, the client
+// constructor resolves the env token, so an unpinned client.Logout()
+// would invalidate the env token's server-side session — the one thing
+// `pad auth logout` must never do (#879 grounding note 2: identity
+// switching is where the concurrency pain lives).
+func TestLogout_UnderEnvTokenInvalidatesStoredSessionOnly(t *testing.T) {
+	home := setTempHomeMain(t)
+	srv := newStubAuthServer(t, "unused")
+	writeCredStore(t, home, srv.URL, "padsess_stored")
+	t.Setenv("PAD_URL", srv.URL)
+	t.Setenv("PAD_TOKEN", "pad_envtoken")
+
+	cmd := logoutCmd()
+	if err := cmd.RunE(cmd, nil); err != nil {
+		t.Fatalf("logout: %v", err)
+	}
+	for _, tok := range srv.logoutTokens {
+		if tok == "Bearer pad_envtoken" {
+			t.Fatal("logout invalidated the PAD_TOKEN session — must pin to the stored session")
+		}
+	}
+	if len(srv.logoutTokens) != 1 || srv.logoutTokens[0] != "Bearer padsess_stored" {
+		t.Errorf("logout tokens = %v, want exactly the stored session", srv.logoutTokens)
+	}
+	// The stored entry itself is still deleted — that part is unchanged.
+	data, err := os.ReadFile(filepath.Join(home, ".pad", "credentials.json"))
+	if err != nil {
+		t.Fatalf("read store: %v", err)
+	}
+	if got := string(data); got != "" && containsToken(got, "padsess_stored") {
+		t.Errorf("stored credential survived logout: %s", got)
+	}
+}
+
+// Under PAD_TOKEN with NO stored session there is nothing server-side
+// for logout to invalidate — it must not fire /auth/logout with the env
+// token.
+func TestLogout_UnderEnvTokenNoStoreSkipsServerCall(t *testing.T) {
+	setTempHomeMain(t)
+	srv := newStubAuthServer(t, "unused")
+	t.Setenv("PAD_URL", srv.URL)
+	t.Setenv("PAD_TOKEN", "pad_envtoken")
+
+	cmd := logoutCmd()
+	if err := cmd.RunE(cmd, nil); err != nil {
+		t.Fatalf("logout: %v", err)
+	}
+	if len(srv.logoutTokens) != 0 {
+		t.Errorf("expected no /auth/logout call, got tokens %v", srv.logoutTokens)
+	}
+}
+
+func containsToken(haystack, needle string) bool {
+	return len(needle) > 0 && len(haystack) >= len(needle) && (func() bool {
+		for i := 0; i+len(needle) <= len(haystack); i++ {
+			if haystack[i:i+len(needle)] == needle {
+				return true
+			}
+		}
+		return false
+	})()
+}
+
+// envTokenNotice is the login/logout disclosure line (gh-style): present
+// exactly when PAD_TOKEN is set.
+func TestEnvTokenNotice(t *testing.T) {
+	t.Setenv("PAD_TOKEN", "pad_x")
+	if got := envTokenNotice(); got == "" {
+		t.Fatal("expected a notice when PAD_TOKEN is set")
+	}
+	t.Setenv("PAD_TOKEN", "")
+	if got := envTokenNotice(); got != "" {
+		t.Errorf("expected empty notice when unset, got %q", got)
+	}
+}

--- a/cmd/pad/env_token_override_test.go
+++ b/cmd/pad/env_token_override_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -185,5 +186,133 @@ func TestEnvTokenNotice(t *testing.T) {
 	t.Setenv("PAD_TOKEN", "")
 	if got := envTokenNotice(); got != "" {
 		t.Errorf("expected empty notice when unset, got %q", got)
+	}
+}
+
+// stubSessionServer extends the auth stub with /api/v1/auth/session
+// control, for driving init/login flows. meTokens records every
+// Authorization header /auth/me saw, so a test can prove which
+// identity a command actually consulted.
+type stubSessionServer struct {
+	*httptest.Server
+	meTokens      []string
+	meAccept      string // bearer token /auth/me accepts
+	sessionStatus int    // HTTP status for /auth/session
+}
+
+func newStubSessionServer(t *testing.T, meAccept string, sessionStatus int) *stubSessionServer {
+	t.Helper()
+	s := &stubSessionServer{meAccept: meAccept, sessionStatus: sessionStatus}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/auth/session", func(w http.ResponseWriter, r *http.Request) {
+		if s.sessionStatus != http.StatusOK {
+			w.WriteHeader(s.sessionStatus)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"authenticated": false, "setup_required": false,
+		})
+	})
+	mux.HandleFunc("/api/v1/auth/me", func(w http.ResponseWriter, r *http.Request) {
+		tok := r.Header.Get("Authorization")
+		s.meTokens = append(s.meTokens, tok)
+		if tok != "Bearer "+s.meAccept {
+			w.WriteHeader(http.StatusUnauthorized)
+			_ = json.NewEncoder(w).Encode(map[string]any{"error": "unauthorized"})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id": "u-stored", "email": "stored@example.com",
+			"name": "Stored User", "role": "member",
+		})
+	})
+	s.Server = httptest.NewServer(mux)
+	t.Cleanup(s.Close)
+	return s
+}
+
+// TestInit_RejectedEnvTokenFailsInsteadOfStoredFallback covers PR #1160
+// round-1 bug 1: with PAD_TOKEN set to a token the server rejects,
+// `pad init`'s auth step used to fall back to valid stored credentials
+// and silently run as that user — then report the override as active.
+// Under the override, an unauthenticated session must fail with the
+// distinct rejected-token message and never consult the stored
+// identity.
+func TestInit_RejectedEnvTokenFailsInsteadOfStoredFallback(t *testing.T) {
+	home := setTempHomeMain(t)
+	// /auth/me accepts ONLY the stored token — the env token is rejected.
+	srv := newStubSessionServer(t, "padsess_stored", http.StatusOK)
+	writeCredStore(t, home, srv.URL, "padsess_stored")
+	t.Setenv("PAD_URL", srv.URL)
+	t.Setenv("PAD_TOKEN", "pad_rejected")
+
+	cmd := padInitCmd()
+	var runErr error
+	out := captureStdout(t, func() {
+		runErr = cmd.RunE(cmd, nil)
+	})
+	if runErr == nil {
+		t.Fatalf("expected init to fail under a rejected PAD_TOKEN; stdout:\n%s", out)
+	}
+	if !strings.Contains(runErr.Error(), "PAD_TOKEN") {
+		t.Errorf("error %q should name PAD_TOKEN as the cause", runErr.Error())
+	}
+	for _, tok := range srv.meTokens {
+		if tok == "Bearer padsess_stored" {
+			t.Error("init consulted the stored identity under a rejected PAD_TOKEN — the silent-fallback bug")
+		}
+	}
+	if strings.Contains(out, "PAD_TOKEN environment override") {
+		t.Errorf("status output claims the override was active on a failed init:\n%s", out)
+	}
+}
+
+// TestLogin_UnderEnvTokenSkipsStoredShortcut covers PR #1160 round-1
+// bug 2: `login` printed "Already logged in as <stored user>" off the
+// credential store even while PAD_TOKEN was overriding every API call —
+// directly contradicting the envTokenNotice printed above it. Under the
+// override the shortcut must not fire; login proceeds to the real flow
+// (which in this test fails fast at CheckSession — the stub 500s — and
+// that error is the proof the shortcut was skipped).
+func TestLogin_UnderEnvTokenSkipsStoredShortcut(t *testing.T) {
+	home := setTempHomeMain(t)
+	srv := newStubSessionServer(t, "padsess_stored", http.StatusInternalServerError)
+	writeCredStore(t, home, srv.URL, "padsess_stored")
+	t.Setenv("PAD_URL", srv.URL)
+	t.Setenv("PAD_TOKEN", "pad_envtoken")
+
+	cmd := loginCmd()
+	var runErr error
+	out := captureStdout(t, func() {
+		runErr = cmd.RunE(cmd, nil)
+	})
+	if strings.Contains(out, "Already logged in") {
+		t.Errorf("stored-credential shortcut fired under PAD_TOKEN:\n%s", out)
+	}
+	if runErr == nil {
+		t.Error("expected login to proceed past the shortcut and fail at the stubbed session check")
+	}
+}
+
+// TestLogin_NoEnvTokenShortcutUnchanged pins the pre-existing behaviour:
+// without PAD_TOKEN, valid stored credentials still short-circuit login
+// with the "Already logged in" message.
+func TestLogin_NoEnvTokenShortcutUnchanged(t *testing.T) {
+	home := setTempHomeMain(t)
+	srv := newStubSessionServer(t, "padsess_stored", http.StatusInternalServerError)
+	writeCredStore(t, home, srv.URL, "padsess_stored")
+	t.Setenv("PAD_URL", srv.URL)
+	t.Setenv("PAD_TOKEN", "")
+
+	cmd := loginCmd()
+	var runErr error
+	out := captureStdout(t, func() {
+		runErr = cmd.RunE(cmd, nil)
+	})
+	if runErr != nil {
+		t.Fatalf("login with valid stored creds should short-circuit cleanly: %v", runErr)
+	}
+	if !strings.Contains(out, "Already logged in") {
+		t.Errorf("expected the stored-credential shortcut without PAD_TOKEN:\n%s", out)
 	}
 }

--- a/cmd/pad/init.go
+++ b/cmd/pad/init.go
@@ -611,12 +611,19 @@ func printInitStatus(client *cli.Client, cfg *config.Config, ws *models.Workspac
 	}
 	fmt.Println(serverAddr)
 
-	// Auth — entry for the configured server only
-	store, _ := cli.LoadStore()
-	creds := store.Get(cfg.BaseURL())
-	if creds != nil && creds.Email != "" {
-		green.Print("  ✓ Logged in  ")
-		fmt.Println(creds.Email)
+	// Auth — entry for the configured server only. Under the PAD_TOKEN
+	// override (#879) the stored entry is not what API calls use, so
+	// disclose the override instead of implying the stored identity.
+	if cli.EnvToken() != "" {
+		green.Print("  ✓ Auth       ")
+		fmt.Println("PAD_TOKEN environment override")
+	} else {
+		store, _ := cli.LoadStore()
+		creds := store.Get(cfg.BaseURL())
+		if creds != nil && creds.Email != "" {
+			green.Print("  ✓ Logged in  ")
+			fmt.Println(creds.Email)
+		}
 	}
 
 	// Workspace

--- a/cmd/pad/init.go
+++ b/cmd/pad/init.go
@@ -258,6 +258,17 @@ Examples:
 
 			// ── Step 4: Authentication ────────────────────────────────
 			if !session.Authenticated && !session.SetupRequired {
+				// PAD_TOKEN overrides stored credentials (#879). The client
+				// above already carried the env token into CheckSession, so
+				// landing here means the server REJECTED it. Falling back to
+				// stored credentials would silently run init as a different
+				// user — and the final status line would still claim the
+				// override was active. Fail with the distinct message
+				// instead, mirroring whoami's treatment.
+				if cli.EnvToken() != "" {
+					return fmt.Errorf("PAD_TOKEN is set but the server rejected it — fix or unset PAD_TOKEN, then re-run 'pad init'")
+				}
+
 				// Check if we have saved credentials for THIS server that
 				// still work. Per-server lookup (TASK-1228) — credentials
 				// for other servers are silently ignored here.

--- a/cmd/pad/server_info.go
+++ b/cmd/pad/server_info.go
@@ -41,15 +41,21 @@ type serverInfoConnection struct {
 }
 
 type serverInfoAuth struct {
-	CredentialsPath        string         `json:"credentials_path"`
-	CredentialsPresent     bool           `json:"credentials_present"`
-	CredentialsServerURL   string         `json:"credentials_server_url,omitempty"`
-	CredentialsMatchServer bool           `json:"credentials_match_server"`
-	Authenticated          bool           `json:"authenticated"`
-	SessionValid           bool           `json:"session_valid"`
-	SetupRequired          bool           `json:"setup_required"`
-	SetupMethod            string         `json:"setup_method,omitempty"`
-	User                   *cli.LoginUser `json:"user,omitempty"`
+	CredentialsPath        string `json:"credentials_path"`
+	CredentialsPresent     bool   `json:"credentials_present"`
+	CredentialsServerURL   string `json:"credentials_server_url,omitempty"`
+	CredentialsMatchServer bool   `json:"credentials_match_server"`
+	// EnvTokenOverride reports whether PAD_TOKEN is set (#879). When
+	// true, the Authenticated/SessionValid/User fields below describe
+	// the ENV token's identity, not the stored credential's — without
+	// this flag a consumer reading credentials_present=false would
+	// wrongly conclude the CLI is unauthenticated.
+	EnvTokenOverride bool           `json:"env_token_override,omitempty"`
+	Authenticated    bool           `json:"authenticated"`
+	SessionValid     bool           `json:"session_valid"`
+	SetupRequired    bool           `json:"setup_required"`
+	SetupMethod      string         `json:"setup_method,omitempty"`
+	User             *cli.LoginUser `json:"user,omitempty"`
 }
 
 type serverInfoWorkspace struct {
@@ -136,6 +142,8 @@ func collectServerInfo(cfg *config.Config) (*serverInfoReport, error) {
 		report.Auth.CredentialsMatchServer = true
 	}
 
+	report.Auth.EnvTokenOverride = cli.EnvToken() != ""
+
 	client := cli.NewClientFromURL(cfg.BaseURL())
 	client.SetAuthToken("")
 
@@ -143,7 +151,12 @@ func collectServerInfo(cfg *config.Config) (*serverInfoReport, error) {
 		report.Connection.Error = err.Error()
 	} else {
 		report.Connection.Reachable = true
-		if creds != nil && creds.Token != "" && report.Auth.CredentialsMatchServer {
+		// Probe with the token every other command would use: the
+		// PAD_TOKEN override when set (#879), else the stored
+		// credential for this server.
+		if report.Auth.EnvTokenOverride {
+			client.SetAuthToken(cli.EnvToken())
+		} else if creds != nil && creds.Token != "" && report.Auth.CredentialsMatchServer {
 			client.SetAuthToken(creds.Token)
 		}
 		session, err := client.CheckSession()
@@ -245,6 +258,9 @@ func printServerInfo(report *serverInfoReport) {
 	if report.Auth.CredentialsPresent {
 		fmt.Fprintf(w, "Credentials server:\t%s\n", report.Auth.CredentialsServerURL)
 		fmt.Fprintf(w, "Credentials match current server:\t%s\n", yesNo(report.Auth.CredentialsMatchServer))
+	}
+	if report.Auth.EnvTokenOverride {
+		fmt.Fprintf(w, "Auth source:\tPAD_TOKEN environment override\n")
 	}
 	fmt.Fprintf(w, "Session valid:\t%s\n", yesNo(report.Auth.SessionValid))
 	fmt.Fprintf(w, "Authenticated:\t%s\n", yesNo(report.Auth.Authenticated))

--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -59,12 +59,16 @@ func NewClientFromURL(baseURL string) *Client {
 		},
 	}
 
-	// Auto-load credentials for THIS server URL if any are saved. We use
-	// the original baseURL (without the /api/v1 suffix added below) so
-	// the lookup matches what login/save commands key on. Credentials
-	// for other servers are left untouched in the store — see TASK-1228
-	// / IDEA-1226 for the per-server design.
-	if store, err := LoadStore(); err == nil {
+	// Auth resolution order: PAD_TOKEN env override first (explicit,
+	// per-process — lets concurrent agents on one machine act as
+	// different users, issue #879), then the saved credential for THIS
+	// server URL. We use the original baseURL (without the /api/v1
+	// suffix added below) so the lookup matches what login/save
+	// commands key on. Credentials for other servers are left untouched
+	// in the store — see TASK-1228 / IDEA-1226 for the per-server design.
+	if tok := EnvToken(); tok != "" {
+		c.authToken = tok
+	} else if store, err := LoadStore(); err == nil {
 		if creds := store.Get(baseURL); creds != nil {
 			c.authToken = creds.Token
 		}

--- a/internal/cli/env_token.go
+++ b/internal/cli/env_token.go
@@ -1,0 +1,26 @@
+package cli
+
+import (
+	"os"
+	"strings"
+)
+
+// EnvToken returns the value of the PAD_TOKEN environment variable,
+// trimmed of surrounding whitespace. When non-empty, it overrides any
+// credential stored in ~/.pad/credentials.json — the same convention as
+// gh's GH_TOKEN (issue #879, layer 1).
+//
+// Why an env override at all: the credential store is per-server, not
+// per-process, so several agent processes on one machine cannot act as
+// different Pad users without contending over the file. Reads never
+// write credentials.json (only login/setup/logout do), so a read-only
+// override sidesteps the identity-switching contention completely —
+// each process carries its own token in its environment and the store
+// is never touched.
+//
+// Accepts either token type the server takes (padsess_ session or
+// pad_ API token); API tokens are the intended fit (mint under
+// Settings → API tokens in the web UI).
+func EnvToken() string {
+	return strings.TrimSpace(os.Getenv("PAD_TOKEN"))
+}

--- a/internal/cli/env_token.go
+++ b/internal/cli/env_token.go
@@ -21,6 +21,13 @@ import (
 // Accepts either token type the server takes (padsess_ session or
 // pad_ API token); API tokens are the intended fit (mint under
 // Settings → API tokens in the web UI).
+//
+// Lifecycle asymmetry, deliberate: `pad auth logout` never invalidates
+// the env token's own server-side session — it pins its Logout() call
+// to the STORED token and only deletes the stored entry. The env
+// token's lifecycle belongs to whoever minted it (revoke it where it
+// was minted), exactly gh's GH_TOKEN posture. This is the read-only
+// contract applied to logout, not an oversight.
 func EnvToken() string {
 	return strings.TrimSpace(os.Getenv("PAD_TOKEN"))
 }

--- a/internal/cli/env_token_test.go
+++ b/internal/cli/env_token_test.go
@@ -1,0 +1,106 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Tests for the PAD_TOKEN environment override (issue #879, layer 1).
+//
+// Environment isolation sets BOTH HOME and USERPROFILE: CredentialsPath
+// resolves through os.UserHomeDir, which reads HOME on Unix and
+// USERPROFILE on Windows — setting only HOME (the older convention in
+// this package) leaves Windows runs pointed at the developer's real
+// ~/.pad.
+
+func setTempHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	return home
+}
+
+// PAD_TOKEN is an explicit per-process override, so it must win exactly
+// when set to something non-blank and be invisible otherwise.
+func TestEnvToken_SetReturnsTrimmed(t *testing.T) {
+	t.Setenv("PAD_TOKEN", "  pad_abc123  ")
+	if got := EnvToken(); got != "pad_abc123" {
+		t.Errorf("EnvToken() = %q, want %q", got, "pad_abc123")
+	}
+}
+
+func TestEnvToken_UnsetReturnsEmpty(t *testing.T) {
+	t.Setenv("PAD_TOKEN", "")
+	if got := EnvToken(); got != "" {
+		t.Errorf("EnvToken() = %q, want empty", got)
+	}
+}
+
+func TestEnvToken_WhitespaceOnlyReturnsEmpty(t *testing.T) {
+	t.Setenv("PAD_TOKEN", "   ")
+	if got := EnvToken(); got != "" {
+		t.Errorf("EnvToken() = %q, want empty", got)
+	}
+}
+
+func writeStoreForClientTest(t *testing.T) {
+	t.Helper()
+	home := setTempHome(t)
+	dir := filepath.Join(home, ".pad")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	body := `{"version": 2, "credentials": {"http://127.0.0.1:7777": {
+		"server_url": "http://127.0.0.1:7777", "token": "padsess_fromstore",
+		"user_id": "u-1", "email": "a@b.c", "name": "A"}}}`
+	if err := os.WriteFile(filepath.Join(dir, "credentials.json"), []byte(body), 0600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}
+
+// PAD_TOKEN must beat the stored credential: the env var is the caller's
+// explicit, per-process choice; the file is ambient machine state.
+func TestNewClientFromURL_EnvTokenOverridesStore(t *testing.T) {
+	writeStoreForClientTest(t)
+	t.Setenv("PAD_TOKEN", "pad_envtoken")
+
+	c := NewClientFromURL("http://127.0.0.1:7777")
+	if c.authToken != "pad_envtoken" {
+		t.Errorf("authToken = %q, want env token to win over store", c.authToken)
+	}
+}
+
+func TestNewClientFromURL_NoEnvFallsBackToStore(t *testing.T) {
+	writeStoreForClientTest(t)
+	t.Setenv("PAD_TOKEN", "")
+
+	c := NewClientFromURL("http://127.0.0.1:7777")
+	if c.authToken != "padsess_fromstore" {
+		t.Errorf("authToken = %q, want stored token when PAD_TOKEN unset", c.authToken)
+	}
+}
+
+// The override must not touch the store: reads stay side-effect-free
+// (the invariant the v2 store documents), so a process running under
+// PAD_TOKEN never contends over credentials.json.
+func TestNewClientFromURL_EnvTokenLeavesStoreUntouched(t *testing.T) {
+	writeStoreForClientTest(t)
+	t.Setenv("PAD_TOKEN", "pad_envtoken")
+
+	home, _ := os.UserHomeDir()
+	path := filepath.Join(home, ".pad", "credentials.json")
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read before: %v", err)
+	}
+	_ = NewClientFromURL("http://127.0.0.1:7777")
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read after: %v", err)
+	}
+	if string(before) != string(after) {
+		t.Error("credentials.json changed during client construction under PAD_TOKEN")
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Layer 1 of #879, in the order you accepted: `PAD_TOKEN` as a per-process bearer-token override, `gh`'s `GH_TOKEN` convention. Named profiles (v3 store) come separately as layer 2.

Part of #879 (layer 1 of 2 — please don't auto-close the issue on merge).

Your three grounding notes, taken as contract:

1. **The store short-circuits get honest.** `whoami` under `PAD_TOKEN` skips the store lookup and reports the effective identity via a real `/me` fetch, adding an `Auth: PAD_TOKEN environment override` line (and a distinct message when the server rejects the env token). `pad init`'s status output and `pad server info` disclose the override too — `server info` gains an additive `env_token_override` JSON field, and its auth probe now uses the token every other command would use.
2. **Reads stay reads.** The override never touches `credentials.json` — pinned by a test asserting the file is byte-identical across client construction under `PAD_TOKEN`.
3. **`auth login`/`logout` warn** (one stderr line, gh-style) when the override is active. One behaviour I want your eyes on: `logout` now pins its server-side session invalidation to the **stored** token — after the constructor change, an unpinned `client.Logout()` would have invalidated the *env token's* session, which is the one thing logout must never do — and skips the server call entirely when there's no stored session. Unset-`PAD_TOKEN` behaviour is unchanged.

The override lands at the `NewClientFromURL` chokepoint you identified: env token first, then the per-server store lookup. Zero behaviour change when the variable is unset.

**Out of scope, as flagged on the issue:** the minimal `pad token create/list/revoke` CLI — immediate follow-up PR unless you'd rather have it here.

## How to test

1. `go test ./internal/cli/ ./cmd/pad/ -run 'EnvToken|Whoami_|Logout_UnderEnv|NewClientFromURL_' -count=1` — the new suite (written first, watched fail). The command-level tests drive real `whoamiCmd`/`logoutCmd` against an `httptest` stub and assert which bearer token each request carried.
2. Manually: `pad auth whoami` → stored user; `PAD_TOKEN=<other user's API token> pad auth whoami` → that user + the `Auth:` line; `PAD_TOKEN=... pad item list --workspace <slug>` → acts as the token's user; `PAD_TOKEN=... pad auth logout` → warns, deletes the stored entry, env identity keeps working.
3. A test-environment note: the new tests set `USERPROFILE` alongside `HOME` — `os.UserHomeDir` reads `USERPROFILE` on Windows, so `HOME`-only isolation (the existing convention) points Windows runs at the developer's real `~/.pad`. Happy to file that separately for the existing tests if useful.

## Checklist

- [x] `make build` passes (`go build ./...`; web unchanged)
- [x] `make test` passes — same caveat as #1159: the Windows dev box has a pre-existing red baseline; name-level failure comparison before/after this change is identical, zero new failures
- [x] New features have tests (TDD)
- [ ] TypeScript types updated — n/a, no API change
- [ ] CLI help text updated — n/a, no new command (README auth section documents `PAD_TOKEN`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)