### PR TITLE
WIP: feat(cli): named credential profiles + --profile (#879 layer 2)

### DIFF
--- a/cmd/pad/cmd_auth.go
+++ b/cmd/pad/cmd_auth.go
@@ -351,7 +351,7 @@ func loginCmd() *cobra.Command {
 			// server. Per-server lookup (TASK-1228) — saved credentials
 			// for other servers don't short-circuit this login.
 			store, _ := cli.LoadStore()
-			creds := store.Get(cfg.BaseURL())
+			creds := store.GetProfile(cfg.BaseURL(), cli.ResolveProfile())
 			if creds != nil && creds.Token != "" {
 				client.SetAuthToken(creds.Token)
 				user, err := client.GetCurrentUser()
@@ -526,7 +526,7 @@ func pollAndSaveCLIAuth(ctx context.Context, client *cli.Client, cfg *config.Con
 				if err != nil {
 					return fmt.Errorf("load credentials: %w", err)
 				}
-				store.Set(cfg.BaseURL(), &cli.Credentials{
+				store.SetProfile(cfg.BaseURL(), cli.ResolveProfile(), &cli.Credentials{
 					Token:  status.Token,
 					UserID: status.User.ID,
 					Email:  status.User.Email,
@@ -743,7 +743,7 @@ func saveCredentials(cfg *config.Config, resp *cli.LoginResponse) error {
 	if err != nil {
 		return fmt.Errorf("load credentials: %w", err)
 	}
-	store.Set(cfg.BaseURL(), &cli.Credentials{
+	store.SetProfile(cfg.BaseURL(), cli.ResolveProfile(), &cli.Credentials{
 		Token:  resp.Token,
 		UserID: resp.User.ID,
 		Email:  resp.User.Email,
@@ -824,7 +824,7 @@ func logoutCmd() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("load credentials: %w", err)
 			}
-			store.Delete(cfg.BaseURL())
+			store.DeleteProfile(cfg.BaseURL(), cli.ResolveProfile())
 			if err := store.Save(); err != nil {
 				return fmt.Errorf("save credentials: %w", err)
 			}
@@ -849,7 +849,8 @@ func whoamiCmd() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("load credentials: %w", err)
 			}
-			creds := store.Get(cfg.BaseURL())
+			profile := cli.ResolveProfile()
+			creds := store.GetProfile(cfg.BaseURL(), profile)
 			if creds == nil || creds.Token == "" {
 				fmt.Println("Not logged in. Run 'pad auth login'.")
 				return nil
@@ -873,6 +874,9 @@ func whoamiCmd() *cobra.Command {
 				fmt.Printf("Name:  %s\n", user.Name)
 				fmt.Printf("Email: %s\n", user.Email)
 				fmt.Printf("Role:  %s\n", user.Role)
+				if profile != "default" {
+					fmt.Printf("Profile: %s\n", profile)
+				}
 			}
 			return nil
 		},

--- a/cmd/pad/cmd_auth_profile_test.go
+++ b/cmd/pad/cmd_auth_profile_test.go
@@ -1,0 +1,228 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/cli"
+)
+
+// profileAuthServer stubs the endpoints whoami and logout hit:
+// GET /api/v1/health, GET /api/v1/auth/me, POST /api/v1/auth/logout.
+// meByToken maps bearer token → user payload so we can assert the
+// command attached the active profile, not always default.
+func profileAuthServer(t *testing.T, meByToken map[string]map[string]string, logoutTokens *[]string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/health":
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/auth/me":
+			token := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+			user, ok := meByToken[token]
+			if !ok {
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(user)
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/auth/logout":
+			token := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+			if logoutTokens != nil {
+				*logoutTokens = append(*logoutTokens, token)
+			}
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			t.Logf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+}
+
+func writeV3Creds(t *testing.T, serverURL string) {
+	t.Helper()
+	home := os.Getenv("HOME")
+	dir := filepath.Join(home, ".pad")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("mkdir ~/.pad: %v", err)
+	}
+	doc := map[string]any{
+		"version": 3,
+		"credentials": map[string]any{
+			serverURL: map[string]any{
+				"profiles": map[string]any{
+					"default": map[string]string{
+						"token":   "padsess_default",
+						"user_id": "u-default",
+						"email":   "dave@example.com",
+						"name":    "Dave",
+					},
+					"cursor": map[string]string{
+						"token":   "padsess_cursor",
+						"user_id": "u-cursor",
+						"email":   "cursor@example.com",
+						"name":    "Cursor",
+					},
+				},
+			},
+		},
+	}
+	data, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal credentials: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "credentials.json"), data, 0600); err != nil {
+		t.Fatalf("write credentials: %v", err)
+	}
+}
+
+func runAuthCmd(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	t.Cleanup(func() { cli.SetProfileOverride("") })
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(io.Discard)
+	root.SetArgs(args)
+	// Capture fmt.Print* which whoami/logout use instead of cmd.Print.
+	orig := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	err := root.Execute()
+	_ = w.Close()
+	os.Stdout = orig
+	piped, _ := io.ReadAll(r)
+	_ = r.Close()
+	return string(piped) + stdout.String(), err
+}
+
+func TestWhoami_PrintsProfileWhenNonDefault(t *testing.T) {
+	isolateHome(t)
+	srv := profileAuthServer(t, map[string]map[string]string{
+		"padsess_cursor": {
+			"id":    "u-cursor",
+			"email": "cursor@example.com",
+			"name":  "Cursor",
+			"role":  "member",
+		},
+	}, nil)
+	defer srv.Close()
+	t.Setenv("PAD_URL", srv.URL)
+	writeV3Creds(t, srv.URL)
+
+	out, err := runAuthCmd(t, "auth", "whoami", "--profile", "cursor")
+	if err != nil {
+		t.Fatalf("whoami --profile cursor: %v\nout=%s", err, out)
+	}
+	if !strings.Contains(out, "cursor@example.com") {
+		t.Errorf("whoami should report the cursor identity, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Profile:") || !strings.Contains(out, "cursor") {
+		t.Errorf("whoami should print the active non-default profile, got:\n%s", out)
+	}
+}
+
+func TestWhoami_OmitsProfileLineWhenDefault(t *testing.T) {
+	isolateHome(t)
+	srv := profileAuthServer(t, map[string]map[string]string{
+		"padsess_default": {
+			"id":    "u-default",
+			"email": "dave@example.com",
+			"name":  "Dave",
+			"role":  "owner",
+		},
+	}, nil)
+	defer srv.Close()
+	t.Setenv("PAD_URL", srv.URL)
+	writeV3Creds(t, srv.URL)
+
+	out, err := runAuthCmd(t, "auth", "whoami")
+	if err != nil {
+		t.Fatalf("whoami: %v\nout=%s", err, out)
+	}
+	if !strings.Contains(out, "dave@example.com") {
+		t.Errorf("whoami should report the default identity, got:\n%s", out)
+	}
+	if strings.Contains(out, "Profile:") {
+		t.Errorf("whoami should omit Profile when default, got:\n%s", out)
+	}
+}
+
+func TestWhoami_PAD_PROFILESelectsNamedProfile(t *testing.T) {
+	isolateHome(t)
+	srv := profileAuthServer(t, map[string]map[string]string{
+		"padsess_cursor": {
+			"id":    "u-cursor",
+			"email": "cursor@example.com",
+			"name":  "Cursor",
+			"role":  "member",
+		},
+	}, nil)
+	defer srv.Close()
+	t.Setenv("PAD_URL", srv.URL)
+	t.Setenv("PAD_PROFILE", "cursor")
+	writeV3Creds(t, srv.URL)
+
+	out, err := runAuthCmd(t, "auth", "whoami")
+	if err != nil {
+		t.Fatalf("whoami with PAD_PROFILE: %v\nout=%s", err, out)
+	}
+	if !strings.Contains(out, "cursor@example.com") {
+		t.Errorf("PAD_PROFILE=cursor should report cursor identity, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Profile:") {
+		t.Errorf("PAD_PROFILE=cursor should print Profile line, got:\n%s", out)
+	}
+}
+
+func TestLogout_ProfileOnlyRemovesNamedProfile(t *testing.T) {
+	isolateHome(t)
+	var loggedOut []string
+	srv := profileAuthServer(t, map[string]map[string]string{
+		"padsess_cursor": {
+			"id":    "u-cursor",
+			"email": "cursor@example.com",
+			"name":  "Cursor",
+			"role":  "member",
+		},
+	}, &loggedOut)
+	defer srv.Close()
+	t.Setenv("PAD_URL", srv.URL)
+	writeV3Creds(t, srv.URL)
+
+	out, err := runAuthCmd(t, "auth", "logout", "--profile", "cursor")
+	if err != nil {
+		t.Fatalf("logout --profile cursor: %v\nout=%s", err, out)
+	}
+	if !strings.Contains(out, "Logged out") {
+		t.Errorf("logout output = %q, want Logged out", out)
+	}
+	if len(loggedOut) != 1 || loggedOut[0] != "padsess_cursor" {
+		t.Errorf("logout should invalidate the cursor token, got %v", loggedOut)
+	}
+
+	store, err := cli.LoadStore()
+	if err != nil {
+		t.Fatalf("LoadStore: %v", err)
+	}
+	if store.GetProfile(srv.URL, "cursor") != nil {
+		t.Error("cursor profile should be gone after logout --profile cursor")
+	}
+	if got := store.GetProfile(srv.URL, "default"); got == nil || got.Token != "padsess_default" {
+		t.Errorf("default profile must survive logout --profile cursor: %+v", got)
+	}
+}
+
+func TestRootPersistentFlag_ProfileExists(t *testing.T) {
+	root := newRootCmd()
+	if root.PersistentFlags().Lookup("profile") == nil {
+		t.Fatal("expected persistent --profile flag on root")
+	}
+}

--- a/cmd/pad/init.go
+++ b/cmd/pad/init.go
@@ -262,7 +262,7 @@ Examples:
 				// still work. Per-server lookup (TASK-1228) — credentials
 				// for other servers are silently ignored here.
 				store, _ := cli.LoadStore()
-				creds := store.Get(cfg.BaseURL())
+				creds := store.GetProfile(cfg.BaseURL(), cli.ResolveProfile())
 				if creds != nil && creds.Token != "" {
 					client.SetAuthToken(creds.Token)
 					user, err := client.GetCurrentUser()
@@ -613,7 +613,7 @@ func printInitStatus(client *cli.Client, cfg *config.Config, ws *models.Workspac
 
 	// Auth — entry for the configured server only
 	store, _ := cli.LoadStore()
-	creds := store.Get(cfg.BaseURL())
+	creds := store.GetProfile(cfg.BaseURL(), cli.ResolveProfile())
 	if creds != nil && creds.Email != "" {
 		green.Print("  ✓ Logged in  ")
 		fmt.Println(creds.Email)

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -20,6 +20,7 @@ var (
 	workspaceFlag string
 	formatFlag    string
 	urlFlag       string
+	profileFlag   string
 )
 
 // truthyEnv reports whether an environment-variable value means "on".
@@ -104,6 +105,11 @@ func newRootCmd() *cobra.Command {
 		// --format, which shadows this persistent flag, so `pad help … --format md`
 		// leaves formatFlag at its "table" default and still passes.
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			// Stateless profile selection (#879 layer 2): --profile wins
+			// over PAD_PROFILE over "default". Always push the flag value
+			// (including "") so a leftover override from a previous
+			// Execute in the same process cannot leak.
+			cli.SetProfileOverride(profileFlag)
 			switch formatFlag {
 			case "table", "json", "markdown":
 				return nil
@@ -126,6 +132,7 @@ func newRootCmd() *cobra.Command {
 	rootCmd.PersistentFlags().StringVar(&workspaceFlag, "workspace", "", "workspace slug override")
 	rootCmd.PersistentFlags().StringVar(&formatFlag, "format", "table", "output format: table, json, markdown")
 	rootCmd.PersistentFlags().StringVar(&urlFlag, "url", "", "server URL override (e.g., https://app.getpad.dev)")
+	rootCmd.PersistentFlags().StringVar(&profileFlag, "profile", "", "named credential profile (overrides PAD_PROFILE; default: default)")
 
 	rootCmd.AddCommand(
 		padInitCmd(),

--- a/cmd/pad/server_info.go
+++ b/cmd/pad/server_info.go
@@ -129,7 +129,7 @@ func collectServerInfo(cfg *config.Config) (*serverInfoReport, error) {
 	if err != nil {
 		return nil, fmt.Errorf("load credentials: %w", err)
 	}
-	creds := store.Get(cfg.BaseURL())
+	creds := store.GetProfile(cfg.BaseURL(), cli.ResolveProfile())
 	if creds != nil {
 		report.Auth.CredentialsPresent = true
 		report.Auth.CredentialsServerURL = creds.ServerURL

--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -64,8 +64,13 @@ func NewClientFromURL(baseURL string) *Client {
 	// the lookup matches what login/save commands key on. Credentials
 	// for other servers are left untouched in the store — see TASK-1228
 	// / IDEA-1226 for the per-server design.
+	//
+	// The active named profile is resolved per invocation (#879 layer 2):
+	// --profile > PAD_PROFILE > "default". PAD_TOKEN (layer 1, #1160)
+	// is a separate override and will sit above this lookup when it
+	// lands — do not reimplement it here.
 	if store, err := LoadStore(); err == nil {
-		if creds := store.Get(baseURL); creds != nil {
+		if creds := store.GetProfile(baseURL, ResolveProfile()); creds != nil {
 			c.authToken = creds.Token
 		}
 	}

--- a/internal/cli/credentials.go
+++ b/internal/cli/credentials.go
@@ -1,6 +1,6 @@
 package cli
 
-// Per-server credentials store (TASK-1228 / IDEA-1226).
+// Per-server credentials store (TASK-1228 / IDEA-1226, extended by #879).
 //
 // `~/.pad/credentials.json` previously held a single login blob:
 //
@@ -18,24 +18,38 @@ package cli
 //     "version": 2,
 //     "credentials": {
 //       "https://app.getpad.dev":      {"token": "...", "user_id": "...", ...},
-//       "http://127.0.0.1:7777":       {"token": "...", "user_id": "...", ...},
-//       "https://pad-staging:7777":    {"token": "...", "user_id": "...", ...}
+//       "http://127.0.0.1:7777":       {"token": "...", "user_id": "...", ...}
 //     }
 //   }
 //
-// Reads transparently migrate v1 → v2 in memory; the next Save writes v2.
-// We deliberately do NOT save-on-read so reads stay side-effect free —
-// the migration becomes durable on the first login/logout/setup.
+// v3 (#879 layer 2) nests named profiles under each server so multiple
+// identities can share one CLI install without logout/login cycling:
 //
-// Single-server users see no behavior change: one entry, same shape per
-// entry, identical UX.
+//   {
+//     "version": 3,
+//     "credentials": {
+//       "https://app.getpad.dev": {
+//         "profiles": {
+//           "default": { "token": "...", "user_id": "..." },
+//           "cursor":  { "token": "...", "user_id": "..." }
+//         }
+//       }
+//     }
+//   }
 //
-// No top-level `default` field. The configured server URL
-// (cfg.BaseURL() from ~/.pad/config.toml or --url) is always the
-// authoritative answer for "which server am I targeting" — a separate
-// `default` would create a second source of truth and the split-brain
-// bugs that follow. The v2 schema can be extended later if a use case
-// shows up; the current map shape is forward compatible.
+// Reads transparently migrate v1 → v3 and v2 → v3 in memory; the next
+// Save writes v3. We deliberately do NOT save-on-read so reads stay
+// side-effect free — the migration becomes durable on the first
+// login/logout/setup.
+//
+// Single-profile users see no behavior change: one entry under
+// profiles.default, Get(url) still returns it, identical UX.
+//
+// No persisted "current profile" and no top-level default pointer.
+// Selection is stateless per invocation: --profile > PAD_PROFILE >
+// "default". The configured server URL (cfg.BaseURL() from
+// ~/.pad/config.toml or --url) remains the authoritative answer for
+// "which server am I targeting."
 
 import (
 	"encoding/json"
@@ -43,17 +57,22 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 )
 
 // credentialsVersion is what new saves write. Bump and add a migration
 // branch in LoadStore when the on-disk shape changes.
-const credentialsVersion = 2
+const credentialsVersion = 3
 
-// Credentials is the per-server login blob. The `server_url` JSON tag is
-// kept (with omitempty) so v1 files still parse during the migration
-// path; in v2 the URL is the map key and the field is redundant — Set
-// mirrors the key into the field so consumers reading the value alone
-// still see a consistent ServerURL.
+// defaultProfileName is the implicit profile. v2 single-user entries
+// migrate here so existing Get(url) call sites stay valid.
+const defaultProfileName = "default"
+
+// Credentials is the per-server (and, in v3, per-profile) login blob.
+// The `server_url` JSON tag is kept (with omitempty) so v1 files still
+// parse during the migration path; in v2/v3 the URL is the map key and
+// the field is redundant — Set mirrors the key into the field so
+// consumers reading the value alone still see a consistent ServerURL.
 type Credentials struct {
 	ServerURL string `json:"server_url,omitempty"`
 	Token     string `json:"token"`
@@ -62,10 +81,23 @@ type Credentials struct {
 	Name      string `json:"name"`
 }
 
-// CredentialStore is the on-disk shape of `~/.pad/credentials.json` (v2).
+// ServerCredentials is the v3 per-server bucket: a map of named profiles.
+type ServerCredentials struct {
+	Profiles map[string]*Credentials `json:"profiles"`
+}
+
+// CredentialStore is the on-disk shape of `~/.pad/credentials.json` (v3).
 // Keyed by canonical server URL (trailing slash + surrounding whitespace
-// stripped — see normalizeServerURL).
+// stripped — see normalizeServerURL). Each server holds named profiles;
+// "default" is the implicit one.
 type CredentialStore struct {
+	Version     int                           `json:"version"`
+	Credentials map[string]*ServerCredentials `json:"credentials"`
+}
+
+// v2CredentialStore is the on-disk shape of a v2 file, used only as the
+// source of the in-memory v2 → v3 migration.
+type v2CredentialStore struct {
 	Version     int                     `json:"version"`
 	Credentials map[string]*Credentials `json:"credentials"`
 }
@@ -87,12 +119,14 @@ func credentialsPath() (string, error) {
 // LoadStore reads the credentials file and returns a usable
 // CredentialStore. Returns an empty (but non-nil) store if the file
 // doesn't exist — that's not an error, just "nothing logged in
-// anywhere." Migrates v1 single-blob format to v2 in memory; v1 files
-// stay v1 on disk until the first Save (which always writes v2).
+// anywhere." Migrates v1 single-blob and v2 per-URL formats to v3 in
+// memory; older files stay as-is on disk until the first Save (which
+// always writes v3).
 //
 // LoadStore is the only intended way to read credentials. Internal
-// callers that need a single server's entry should call
-// LoadStore().Get(url).
+// callers that need a single server's default entry should call
+// LoadStore().Get(url). Callers that need a named profile should call
+// LoadStore().GetProfile(url, name).
 func LoadStore() (*CredentialStore, error) {
 	path, err := credentialsPath()
 	if err != nil {
@@ -112,9 +146,10 @@ func LoadStore() (*CredentialStore, error) {
 	}
 
 	// Detect format. v1 has a top-level `token` string; v2 has a
-	// top-level `credentials` object. Probe with a generic map so a
+	// top-level `credentials` object whose values are login blobs; v3
+	// values are `{profiles: {...}}`. Probe with a generic map so a
 	// garbage file fails loudly here rather than silently parsing as
-	// "empty v2."
+	// "empty v3."
 	var probe map[string]json.RawMessage
 	if err := json.Unmarshal(data, &probe); err != nil {
 		return nil, fmt.Errorf("parse credentials: %w", err)
@@ -122,15 +157,58 @@ func LoadStore() (*CredentialStore, error) {
 	if _, hasToken := probe["token"]; hasToken {
 		return migrateV1(data)
 	}
-	return parseV2(data)
+	if isV3Store(probe) {
+		return parseV3(data)
+	}
+	return migrateV2(data)
 }
 
-// migrateV1 reads a v1 single-blob file and returns an in-memory v2 store
-// keyed by the legacy ServerURL. A v1 file with an empty server_url is
-// treated as "no usable credentials" (returns an empty store) — that's
-// the only safe interpretation, since we have no key to file the entry
-// under. The on-disk file is unchanged; callers triggering Save (login,
-// logout, setup) will write v2.
+// isV3Store reports whether the probed file is already v3: either the
+// version field is >= 3, or a credentials entry has a `profiles` object.
+// An empty credentials map with version 2 is treated as v2 (migrate);
+// the same shape with version 3 is v3.
+func isV3Store(probe map[string]json.RawMessage) bool {
+	if versionFromProbe(probe) >= 3 {
+		return true
+	}
+	raw, ok := probe["credentials"]
+	if !ok || len(raw) == 0 {
+		return false
+	}
+	var creds map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &creds); err != nil {
+		return false
+	}
+	for _, entry := range creds {
+		var keys map[string]json.RawMessage
+		if err := json.Unmarshal(entry, &keys); err != nil {
+			continue
+		}
+		if _, hasProfiles := keys["profiles"]; hasProfiles {
+			return true
+		}
+	}
+	return false
+}
+
+func versionFromProbe(probe map[string]json.RawMessage) int {
+	raw, ok := probe["version"]
+	if !ok {
+		return 0
+	}
+	var version int
+	if err := json.Unmarshal(raw, &version); err != nil {
+		return 0
+	}
+	return version
+}
+
+// migrateV1 reads a v1 single-blob file and returns an in-memory v3 store
+// keyed by the legacy ServerURL under the default profile. A v1 file with
+// an empty server_url is treated as "no usable credentials" (returns an
+// empty store) — that's the only safe interpretation, since we have no
+// key to file the entry under. The on-disk file is unchanged; callers
+// triggering Save (login, logout, setup) will write v3.
 func migrateV1(data []byte) (*CredentialStore, error) {
 	var legacy Credentials
 	if err := json.Unmarshal(data, &legacy); err != nil {
@@ -143,16 +221,38 @@ func migrateV1(data []byte) (*CredentialStore, error) {
 	return store, nil
 }
 
-// parseV2 unmarshals a v2 file. Tolerates a missing or zero version
-// field and a nil credentials map by normalizing both — anything else
-// (malformed JSON, wrong types) surfaces as an error.
-func parseV2(data []byte) (*CredentialStore, error) {
-	var store CredentialStore
-	if err := json.Unmarshal(data, &store); err != nil {
+// migrateV2 reads a v2 per-URL file and wraps each login blob as
+// profiles.default. In-memory only; disk stays v2 until Save.
+func migrateV2(data []byte) (*CredentialStore, error) {
+	var legacy v2CredentialStore
+	if err := json.Unmarshal(data, &legacy); err != nil {
 		return nil, fmt.Errorf("parse v2 credentials: %w", err)
 	}
+	store := newEmptyStore()
+	for url, creds := range legacy.Credentials {
+		if creds == nil {
+			continue
+		}
+		store.Set(url, creds)
+	}
+	return store, nil
+}
+
+// parseV3 unmarshals a v3 file. Tolerates a missing or zero version
+// field and a nil credentials/profiles map by normalizing both —
+// anything else (malformed JSON, wrong types) surfaces as an error.
+func parseV3(data []byte) (*CredentialStore, error) {
+	var store CredentialStore
+	if err := json.Unmarshal(data, &store); err != nil {
+		return nil, fmt.Errorf("parse v3 credentials: %w", err)
+	}
 	if store.Credentials == nil {
-		store.Credentials = map[string]*Credentials{}
+		store.Credentials = map[string]*ServerCredentials{}
+	}
+	for _, sc := range store.Credentials {
+		if sc != nil && sc.Profiles == nil {
+			sc.Profiles = map[string]*Credentials{}
+		}
 	}
 	if store.Version == 0 {
 		store.Version = credentialsVersion
@@ -163,49 +263,92 @@ func parseV2(data []byte) (*CredentialStore, error) {
 func newEmptyStore() *CredentialStore {
 	return &CredentialStore{
 		Version:     credentialsVersion,
-		Credentials: map[string]*Credentials{},
+		Credentials: map[string]*ServerCredentials{},
 	}
 }
 
-// Get returns the credential for the given server URL, or nil if none
-// exists. URL is canonicalized (trailing slash + whitespace stripped)
-// before lookup. Nil-receiver safe — callers can write
-// `store.Get(url)` without a prior nil check on store.
+// Get returns the default-profile credential for the given server URL,
+// or nil if none exists. Delegates to GetProfile(url, "default") so
+// existing call sites stay valid. URL is canonicalized (trailing slash
+// + whitespace stripped) before lookup. Nil-receiver safe.
 func (s *CredentialStore) Get(serverURL string) *Credentials {
+	return s.GetProfile(serverURL, defaultProfileName)
+}
+
+// GetProfile returns the named profile for the given server URL, or nil
+// if none exists. Empty / whitespace names resolve to "default".
+// Nil-receiver safe.
+func (s *CredentialStore) GetProfile(serverURL, name string) *Credentials {
 	if s == nil || s.Credentials == nil {
 		return nil
 	}
-	return s.Credentials[normalizeServerURL(serverURL)]
+	sc := s.Credentials[normalizeServerURL(serverURL)]
+	if sc == nil || sc.Profiles == nil {
+		return nil
+	}
+	return sc.Profiles[normalizeProfileName(name)]
 }
 
-// Set adds or replaces the credential for the given server URL. The
-// canonical URL is mirrored into the value's ServerURL field so a
-// caller reading the credential standalone still sees a consistent
-// URL. Passing a nil credential is a no-op (use Delete to remove).
+// Set adds or replaces the default-profile credential for the given
+// server URL. Delegates to SetProfile(url, "default", c).
 func (s *CredentialStore) Set(serverURL string, c *Credentials) {
+	s.SetProfile(serverURL, defaultProfileName, c)
+}
+
+// SetProfile adds or replaces the named profile for the given server
+// URL. The canonical URL is mirrored into the value's ServerURL field
+// so a caller reading the credential standalone still sees a consistent
+// URL. Passing a nil credential is a no-op (use DeleteProfile to remove).
+func (s *CredentialStore) SetProfile(serverURL, name string, c *Credentials) {
 	if c == nil {
 		return
 	}
 	if s.Credentials == nil {
-		s.Credentials = map[string]*Credentials{}
+		s.Credentials = map[string]*ServerCredentials{}
 	}
 	key := normalizeServerURL(serverURL)
+	name = normalizeProfileName(name)
+	sc := s.Credentials[key]
+	if sc == nil {
+		sc = &ServerCredentials{Profiles: map[string]*Credentials{}}
+		s.Credentials[key] = sc
+	}
+	if sc.Profiles == nil {
+		sc.Profiles = map[string]*Credentials{}
+	}
 	c.ServerURL = key
-	s.Credentials[key] = c
+	sc.Profiles[name] = c
 }
 
-// Delete removes the credential for the given server URL. No-op if the
-// entry isn't present, or if the receiver is nil.
+// Delete removes the default-profile credential for the given server
+// URL. Other named profiles on the same server are left intact.
+// Delegates to DeleteProfile(url, "default").
 func (s *CredentialStore) Delete(serverURL string) {
+	s.DeleteProfile(serverURL, defaultProfileName)
+}
+
+// DeleteProfile removes the named profile for the given server URL.
+// No-op if the entry isn't present, or if the receiver is nil. When
+// the last profile for a server is removed, the server key itself is
+// dropped so we don't persist an empty profiles object.
+func (s *CredentialStore) DeleteProfile(serverURL, name string) {
 	if s == nil || s.Credentials == nil {
 		return
 	}
-	delete(s.Credentials, normalizeServerURL(serverURL))
+	key := normalizeServerURL(serverURL)
+	sc := s.Credentials[key]
+	if sc == nil || sc.Profiles == nil {
+		return
+	}
+	delete(sc.Profiles, normalizeProfileName(name))
+	if len(sc.Profiles) == 0 {
+		delete(s.Credentials, key)
+	}
 }
 
-// Save writes the store to disk in v2 format with mode 0600. Always
+// Save writes the store to disk in v3 format with mode 0600. Always
 // writes the current version constant — even if the store was loaded
-// from v1, this is the migration moment.
+// from v1 or v2, this is the migration moment.
 func (s *CredentialStore) Save() error {
 	path, err := credentialsPath()
 	if err != nil {
@@ -218,7 +361,7 @@ func (s *CredentialStore) Save() error {
 
 	s.Version = credentialsVersion
 	if s.Credentials == nil {
-		s.Credentials = map[string]*Credentials{}
+		s.Credentials = map[string]*ServerCredentials{}
 	}
 
 	data, err := json.MarshalIndent(s, "", "  ")
@@ -233,9 +376,9 @@ func (s *CredentialStore) Save() error {
 }
 
 // WipeCredentialsFile removes ~/.pad/credentials.json entirely. Distinct
-// from CredentialStore.Delete (which removes a single server's entry)
-// — used by tests and any future "pad auth wipe" that wants a clean
-// slate. Silently succeeds if the file is already absent.
+// from CredentialStore.Delete (which removes a single server's default
+// profile) — used by tests and any future "pad auth wipe" that wants a
+// clean slate. Silently succeeds if the file is already absent.
 func WipeCredentialsFile() error {
 	path, err := credentialsPath()
 	if err != nil {
@@ -255,4 +398,51 @@ func WipeCredentialsFile() error {
 // so the two stay consistent.
 func normalizeServerURL(u string) string {
 	return strings.TrimRight(strings.TrimSpace(u), "/")
+}
+
+// normalizeProfileName trims whitespace and treats an empty name as the
+// implicit default profile.
+func normalizeProfileName(name string) string {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return defaultProfileName
+	}
+	return name
+}
+
+// profileOverride is the --profile flag value, set once per invocation
+// from cmd/pad's PersistentPreRunE. Empty means "not set" so PAD_PROFILE
+// and the implicit default can still win. Guarded by a mutex because
+// tests in this package construct clients from multiple goroutines in
+// other suites; CLI use is single-threaded.
+var (
+	profileOverrideMu sync.Mutex
+	profileOverride   string
+)
+
+// SetProfileOverride records the --profile flag for this process. Pass
+// "" to clear (so subsequent ResolveProfile calls fall through to
+// PAD_PROFILE / default). Callers should invoke this from PersistentPreRunE
+// on every command so a leftover value from a previous Execute in the
+// same test process cannot leak.
+func SetProfileOverride(name string) {
+	profileOverrideMu.Lock()
+	defer profileOverrideMu.Unlock()
+	profileOverride = strings.TrimSpace(name)
+}
+
+// ResolveProfile returns the active credential profile for this
+// invocation: --profile (SetProfileOverride) > PAD_PROFILE > "default".
+// Selection is stateless; nothing is persisted.
+func ResolveProfile() string {
+	profileOverrideMu.Lock()
+	override := profileOverride
+	profileOverrideMu.Unlock()
+	if override != "" {
+		return override
+	}
+	if env := strings.TrimSpace(os.Getenv("PAD_PROFILE")); env != "" {
+		return env
+	}
+	return defaultProfileName
 }

--- a/internal/cli/credentials_profile_test.go
+++ b/internal/cli/credentials_profile_test.go
@@ -1,0 +1,375 @@
+package cli
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+)
+
+const profileServerURL = "https://app.getpad.dev"
+
+func v2SingleUserBody() string {
+	return `{
+		"version": 2,
+		"credentials": {
+			"https://app.getpad.dev": {
+				"server_url": "https://app.getpad.dev",
+				"token": "padsess_default",
+				"user_id": "u-default",
+				"email": "dave@example.com",
+				"name": "Dave"
+			}
+		}
+	}`
+}
+
+func v3TwoProfileBody() string {
+	return `{
+		"version": 3,
+		"credentials": {
+			"https://app.getpad.dev": {
+				"profiles": {
+					"default": {
+						"token": "padsess_default",
+						"user_id": "u-default",
+						"email": "dave@example.com",
+						"name": "Dave"
+					},
+					"cursor": {
+						"token": "padsess_cursor",
+						"user_id": "u-cursor",
+						"email": "cursor@example.com",
+						"name": "Cursor"
+					}
+				}
+			}
+		}
+	}`
+}
+
+// TestLoadStore_V2MigratesToDefaultProfileInMemory — a v2 single-blob-per-URL
+// file becomes an in-memory v3 store with the legacy entry under "default".
+// Read is side-effect-free: the on-disk file stays v2 until Save.
+func TestLoadStore_V2MigratesToDefaultProfileInMemory(t *testing.T) {
+	home := withTempHome(t)
+	path := writeCredsFile(t, home, v2SingleUserBody())
+
+	store, err := LoadStore()
+	if err != nil {
+		t.Fatalf("LoadStore: %v", err)
+	}
+	got := store.GetProfile(profileServerURL, "default")
+	if got == nil {
+		t.Fatal("expected v2 entry to migrate into profiles.default; got nil")
+	}
+	if got.Token != "padsess_default" {
+		t.Errorf("default profile token = %q, want padsess_default", got.Token)
+	}
+	// Get still delegates to the default profile so existing call sites
+	// keep working through the migration.
+	if viaGet := store.Get(profileServerURL); viaGet == nil || viaGet.Token != "padsess_default" {
+		t.Errorf("Get after v2 migrate = %+v, want default token", viaGet)
+	}
+
+	onDisk, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("re-read credentials.json: %v", err)
+	}
+	if strings.Contains(string(onDisk), `"profiles"`) {
+		t.Errorf("read should not rewrite v2 file to v3; got: %s", onDisk)
+	}
+	if !strings.Contains(string(onDisk), `"version": 2`) {
+		t.Errorf("expected v2 file to remain on disk after read, got: %s", onDisk)
+	}
+}
+
+// TestLoadStore_V2MigrationDurableOnSave — the in-memory v2→v3 migration
+// becomes durable on Save. Single-user files land as profiles.default
+// with no extra profiles invented.
+func TestLoadStore_V2MigrationDurableOnSave(t *testing.T) {
+	home := withTempHome(t)
+	writeCredsFile(t, home, v2SingleUserBody())
+
+	store, err := LoadStore()
+	if err != nil {
+		t.Fatalf("LoadStore: %v", err)
+	}
+	if err := store.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	body := readCredsFile(t, home)
+	if !strings.Contains(body, `"version": 3`) {
+		t.Errorf("post-save missing version 3 marker: %s", body)
+	}
+	if !strings.Contains(body, `"profiles"`) {
+		t.Errorf("post-save missing profiles map: %s", body)
+	}
+	if !strings.Contains(body, `"default"`) {
+		t.Errorf("post-save missing default profile: %s", body)
+	}
+
+	var roundTrip struct {
+		Version     int `json:"version"`
+		Credentials map[string]struct {
+			Profiles map[string]*Credentials `json:"profiles"`
+		} `json:"credentials"`
+	}
+	if err := json.Unmarshal([]byte(body), &roundTrip); err != nil {
+		t.Fatalf("post-save parse: %v\nbody: %s", err, body)
+	}
+	if roundTrip.Version != 3 {
+		t.Errorf("post-save version = %d, want 3", roundTrip.Version)
+	}
+	entry := roundTrip.Credentials[profileServerURL]
+	if entry.Profiles == nil || entry.Profiles["default"] == nil {
+		t.Fatalf("post-save missing profiles.default; body: %s", body)
+	}
+	if entry.Profiles["default"].Token != "padsess_default" {
+		t.Errorf("default token = %q, want padsess_default", entry.Profiles["default"].Token)
+	}
+	if len(entry.Profiles) != 1 {
+		t.Errorf("expected only the default profile after v2 migrate, got %d", len(entry.Profiles))
+	}
+}
+
+// TestLoadStore_V3RoundTrip — a v3 file written by an earlier session
+// reads back both the default and a named profile.
+func TestLoadStore_V3RoundTrip(t *testing.T) {
+	home := withTempHome(t)
+	writeCredsFile(t, home, v3TwoProfileBody())
+
+	store, err := LoadStore()
+	if err != nil {
+		t.Fatalf("LoadStore: %v", err)
+	}
+	def := store.GetProfile(profileServerURL, "default")
+	if def == nil || def.Token != "padsess_default" {
+		t.Errorf("default profile: got %+v, want token=padsess_default", def)
+	}
+	cur := store.GetProfile(profileServerURL, "cursor")
+	if cur == nil || cur.Token != "padsess_cursor" {
+		t.Errorf("cursor profile: got %+v, want token=padsess_cursor", cur)
+	}
+	if got := store.GetProfile(profileServerURL, "missing"); got != nil {
+		t.Errorf("GetProfile missing name returned %+v, want nil", got)
+	}
+}
+
+// TestGet_DelegatesToDefaultProfile — Get(url) is GetProfile(url, "default")
+// even when PAD_PROFILE names another profile. Existing call sites stay on
+// the implicit profile; selection is the caller's job.
+func TestGet_DelegatesToDefaultProfile(t *testing.T) {
+	t.Setenv("PAD_PROFILE", "cursor")
+	store := newEmptyStore()
+	store.SetProfile(profileServerURL, "default", &Credentials{Token: "def"})
+	store.SetProfile(profileServerURL, "cursor", &Credentials{Token: "cur"})
+
+	got := store.Get(profileServerURL)
+	if got == nil || got.Token != "def" {
+		t.Errorf("Get = %+v, want default token (must ignore PAD_PROFILE)", got)
+	}
+}
+
+// TestStore_SetProfile_KeepsSiblings — writing one named profile must not
+// clobber another on the same server.
+func TestStore_SetProfile_KeepsSiblings(t *testing.T) {
+	store := newEmptyStore()
+	store.SetProfile(profileServerURL, "default", &Credentials{Token: "def"})
+	store.SetProfile(profileServerURL, "cursor", &Credentials{Token: "cur"})
+
+	if got := store.GetProfile(profileServerURL, "default"); got == nil || got.Token != "def" {
+		t.Errorf("default after sibling Set: %+v", got)
+	}
+	if got := store.GetProfile(profileServerURL, "cursor"); got == nil || got.Token != "cur" {
+		t.Errorf("cursor after sibling Set: %+v", got)
+	}
+}
+
+// TestStore_DeleteProfile_KeepsSiblings — logout --profile cursor must not
+// drop the default (or any other) profile on the same server.
+func TestStore_DeleteProfile_KeepsSiblings(t *testing.T) {
+	store := newEmptyStore()
+	store.SetProfile(profileServerURL, "default", &Credentials{Token: "def"})
+	store.SetProfile(profileServerURL, "cursor", &Credentials{Token: "cur"})
+
+	store.DeleteProfile(profileServerURL, "cursor")
+
+	if store.GetProfile(profileServerURL, "cursor") != nil {
+		t.Error("expected cursor profile to be deleted")
+	}
+	if got := store.GetProfile(profileServerURL, "default"); got == nil || got.Token != "def" {
+		t.Errorf("DeleteProfile cursor removed default: %+v", got)
+	}
+}
+
+// TestStore_DeleteProfile_DropsEmptyServer — when the last profile for a
+// server is removed, the server key itself goes away so we don't leave an
+// empty profiles object in the file.
+func TestStore_DeleteProfile_DropsEmptyServer(t *testing.T) {
+	store := newEmptyStore()
+	store.SetProfile(profileServerURL, "cursor", &Credentials{Token: "cur"})
+	store.DeleteProfile(profileServerURL, "cursor")
+
+	if got := len(store.Credentials); got != 0 {
+		t.Errorf("expected empty server map after last profile delete, got %d", got)
+	}
+}
+
+// TestStore_Delete_OnlyRemovesDefault — Delete(url) stays the default-profile
+// operation so existing logout call sites don't wipe every named profile.
+func TestStore_Delete_OnlyRemovesDefault(t *testing.T) {
+	store := newEmptyStore()
+	store.SetProfile(profileServerURL, "default", &Credentials{Token: "def"})
+	store.SetProfile(profileServerURL, "cursor", &Credentials{Token: "cur"})
+
+	store.Delete(profileServerURL)
+
+	if store.Get(profileServerURL) != nil {
+		t.Error("expected default profile to be deleted")
+	}
+	if got := store.GetProfile(profileServerURL, "cursor"); got == nil || got.Token != "cur" {
+		t.Errorf("Delete(url) must not drop cursor: %+v", got)
+	}
+}
+
+// TestStore_GetProfile_NilReceiverSafe — same contract as Get.
+func TestStore_GetProfile_NilReceiverSafe(t *testing.T) {
+	var store *CredentialStore
+	if got := store.GetProfile(profileServerURL, "cursor"); got != nil {
+		t.Errorf("nil-receiver GetProfile returned %+v, want nil", got)
+	}
+	store.DeleteProfile(profileServerURL, "cursor")
+}
+
+// TestStore_EmptyProfileNameIsDefault — blank / whitespace profile names
+// collapse to the implicit default so `--profile ""` and an empty
+// PAD_PROFILE don't invent a nameless bucket.
+func TestStore_EmptyProfileNameIsDefault(t *testing.T) {
+	store := newEmptyStore()
+	store.SetProfile(profileServerURL, "  ", &Credentials{Token: "def"})
+	if got := store.GetProfile(profileServerURL, ""); got == nil || got.Token != "def" {
+		t.Errorf("empty name should resolve to default, got %+v", got)
+	}
+}
+
+// TestResolveProfile_Precedence — --profile (SetProfileOverride) beats
+// PAD_PROFILE beats the implicit default. Stateless: no persisted current
+// profile.
+func TestResolveProfile_Precedence(t *testing.T) {
+	t.Cleanup(func() { SetProfileOverride("") })
+
+	t.Setenv("PAD_PROFILE", "")
+	SetProfileOverride("")
+	if got := ResolveProfile(); got != "default" {
+		t.Errorf("no flag/env: got %q, want default", got)
+	}
+
+	t.Setenv("PAD_PROFILE", "from-env")
+	if got := ResolveProfile(); got != "from-env" {
+		t.Errorf("env only: got %q, want from-env", got)
+	}
+
+	SetProfileOverride("from-flag")
+	if got := ResolveProfile(); got != "from-flag" {
+		t.Errorf("flag+env: got %q, want from-flag (flag wins)", got)
+	}
+
+	SetProfileOverride("")
+	if got := ResolveProfile(); got != "from-env" {
+		t.Errorf("cleared flag: got %q, want from-env", got)
+	}
+}
+
+// TestNewClientFromURL_UsesResolvedProfile — the constructor chokepoint
+// attaches the active profile's token, not always default. Pins the
+// selection contract for every command that goes through NewClientFromURL.
+func TestNewClientFromURL_UsesResolvedProfile(t *testing.T) {
+	home := withTempHome(t)
+	writeCredsFile(t, home, v3TwoProfileBody())
+	t.Cleanup(func() { SetProfileOverride("") })
+
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/auth/me" {
+			http.NotFound(w, r)
+			return
+		}
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"u-cursor","email":"cursor@example.com","name":"Cursor","role":"member"}`))
+	}))
+	defer srv.Close()
+
+	store, err := LoadStore()
+	if err != nil {
+		t.Fatalf("LoadStore: %v", err)
+	}
+	store.SetProfile(srv.URL, "default", &Credentials{Token: "padsess_default"})
+	store.SetProfile(srv.URL, "cursor", &Credentials{Token: "padsess_cursor"})
+	if err := store.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	t.Setenv("PAD_PROFILE", "cursor")
+	SetProfileOverride("")
+	client := NewClientFromURL(srv.URL)
+	if _, err := client.GetCurrentUser(); err != nil {
+		t.Fatalf("GetCurrentUser: %v", err)
+	}
+	if gotAuth != "Bearer padsess_cursor" {
+		t.Errorf("PAD_PROFILE=cursor attached %q, want Bearer padsess_cursor", gotAuth)
+	}
+
+	SetProfileOverride("default")
+	client = NewClientFromURL(srv.URL)
+	if _, err := client.GetCurrentUser(); err != nil {
+		t.Fatalf("GetCurrentUser (flag default): %v", err)
+	}
+	if gotAuth != "Bearer padsess_default" {
+		t.Errorf("--profile default attached %q, want Bearer padsess_default", gotAuth)
+	}
+}
+
+// TestNewClientFromURL_DefaultWhenUnset — single-profile users see zero
+// behavior change: no flag, no env, constructor still picks default.
+func TestNewClientFromURL_DefaultWhenUnset(t *testing.T) {
+	home := withTempHome(t)
+	writeCredsFile(t, home, v3TwoProfileBody())
+	t.Cleanup(func() { SetProfileOverride("") })
+	t.Setenv("PAD_PROFILE", "")
+	SetProfileOverride("")
+
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/auth/me" {
+			http.NotFound(w, r)
+			return
+		}
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"u-default","email":"dave@example.com","name":"Dave","role":"owner"}`))
+	}))
+	defer srv.Close()
+
+	store, err := LoadStore()
+	if err != nil {
+		t.Fatalf("LoadStore: %v", err)
+	}
+	store.SetProfile(srv.URL, "default", &Credentials{Token: "padsess_default"})
+	store.SetProfile(srv.URL, "cursor", &Credentials{Token: "padsess_cursor"})
+	if err := store.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	client := NewClientFromURL(srv.URL)
+	if _, err := client.GetCurrentUser(); err != nil {
+		t.Fatalf("GetCurrentUser: %v", err)
+	}
+	if gotAuth != "Bearer padsess_default" {
+		t.Errorf("unset profile attached %q, want Bearer padsess_default", gotAuth)
+	}
+}

--- a/internal/cli/credentials_test.go
+++ b/internal/cli/credentials_test.go
@@ -172,7 +172,7 @@ func TestLoadStore_V1MigrationDurableOnSave(t *testing.T) {
 	if roundTrip.Version != credentialsVersion {
 		t.Errorf("post-save version = %d, want %d", roundTrip.Version, credentialsVersion)
 	}
-	if got := roundTrip.Credentials["http://127.0.0.1:7777"]; got == nil {
+	if got := roundTrip.Get("http://127.0.0.1:7777"); got == nil {
 		t.Fatalf("post-save missing entry for original server URL; body: %s", body)
 	} else if got.Token != "padsess_v1token" {
 		t.Errorf("post-save token = %q, want padsess_v1token", got.Token)
@@ -182,8 +182,8 @@ func TestLoadStore_V1MigrationDurableOnSave(t *testing.T) {
 	if strings.Contains(body, `"token": "padsess_v1token"`) && !strings.Contains(body, `"credentials"`) {
 		t.Errorf("v2 file unexpectedly retained legacy top-level token: %s", body)
 	}
-	if !strings.Contains(body, `"version": 2`) {
-		t.Errorf("v2 file missing version marker: %s", body)
+	if !strings.Contains(body, `"version": 3`) {
+		t.Errorf("v3 file missing version marker: %s", body)
 	}
 }
 


### PR DESCRIPTION
## What does this PR do?

Layer 2 of #879: named credential profiles in a v3 store, plus a stateless `--profile` / `PAD_PROFILE` selector.

**This is a draft / WIP.** asjdf will review it before it is ready. Please do not merge yet.

Part of #879 (layer 2 of 2). Layer 1 is #1160 (`PAD_TOKEN` env override) and is **not** included here — this branch is independent of #1160 so the two can land in either order. When #1160 merges, `PAD_TOKEN` should sit above the store lookup in `NewClientFromURL` (commented at that chokepoint).

### Store

Bump `~/.pad/credentials.json` to v3. Each server key holds a map of named profiles; `default` is the implicit profile so single-user v2 files migrate transparently (same probe-and-migrate pattern `LoadStore()` already uses for v1 → v2). Reads stay side-effect-free; Save writes v3.

```json
{
  "version": 3,
  "credentials": {
    "https://app.getpad.dev": {
      "profiles": {
        "default": { "token": "...", "user_id": "..." },
        "cursor":  { "token": "...", "user_id": "..." }
      }
    }
  }
}
```

### Selection (stateless, per invocation)

`--profile` persistent flag > `PAD_PROFILE` env > `default`

No persisted "current profile", no `pad auth switch`.

- `pad auth login --profile cursor` / `pad auth logout --profile cursor`
- `whoami` prints `Profile: <name>` only when the active profile is not `default`
- Store API: `GetProfile(url, name)`; `Get(url)` delegates to `GetProfile(url, "default")` so existing call sites stay
- `NewClientFromURL` uses the resolved profile so every command that goes through the constructor picks the right token
- `init` and `server info` use the same resolved profile (they short-circuit the store before the client, same trap xarmian called out for layer 1)

Single-profile users see zero behavior change.

## How to test

```
go test ./internal/cli/ ./cmd/pad/ -count=1
```

TDD: profile tests were written first and failed on the v2 store (`GetProfile` undefined), then the v3 implementation went green. Existing `./internal/cli/` and `./cmd/pad/` suites stay green.

Manual:

1. `pad auth login` — still writes `profiles.default`; `pad auth whoami` has no Profile line
2. `pad auth login --profile cursor` — adds a sibling profile; default is untouched
3. `pad --profile cursor auth whoami` / `PAD_PROFILE=cursor pad auth whoami` — reports the cursor identity and prints `Profile: cursor`
4. `pad auth logout --profile cursor` — drops only cursor; default remains

## Test plan

- [ ] `go test ./internal/cli/ ./cmd/pad/ -count=1`
- [ ] v2 file still loads (default profile) and is not rewritten until Save
- [ ] `--profile` beats `PAD_PROFILE` beats default
- [ ] `whoami` omits Profile on default, prints it otherwise
- [ ] logout `--profile` does not wipe sibling profiles

Refs #879. Layer 1 is #1160.