### PR TITLE
fix(models): refuse an append that would destroy an unreadable structured field (BUG-2627, part 3)

### DIFF
--- a/internal/models/item.go
+++ b/internal/models/item.go
@@ -464,14 +464,23 @@ var ErrStructuredFieldUnreadable = errors.New("structured field is present but u
 //
 //  1. the key is absent          — the first append on an item. Must proceed.
 //  2. the key holds an empty array — well-formed, just empty. Must proceed.
-//  3. the key holds a value that does not decode — the defect. Must REFUSE,
+//  3. the key holds an explicit JSON null — carries no entries. Must proceed.
+//  4. the key holds a value that does not decode — the defect. Must REFUSE,
 //     because the unconditional assign would overwrite that value with a
 //     one-element slice and report success. Observed live: an item whose
 //     implementation_notes was a JSON-ENCODED STRING lost its stored note to a
 //     single `pad item note` call, with no warning on any surface.
 //
 // So this checks decodability directly against the raw value instead of reusing
-// Extract*'s nil, which cannot distinguish (3) from (1) or (2).
+// Extract*'s nil, which cannot distinguish (4) from (1), (2) or (3).
+//
+// T must be the entry type the MATCHING Extract* decodes into. A wrong-but-
+// compiling instantiation is silently destructive rather than merely wrong:
+// encoding/json ignores unknown fields, so ItemImplementationNote ACCEPTS
+// `{"decision":{...}}` while ExtractItemDecisionLog rejects it — the guard would
+// permit an append that the extractor then reads as empty, which is the exact
+// divergence this function exists to prevent. Both directions are pinned by
+// tests; see TestAppendDecisionLogRefusesEntriesOnlyItsOwnTypeRejects.
 func assertStructuredFieldAppendable[T any](fieldsMap map[string]any, key string) error {
 	raw, ok := fieldsMap[key]
 	if !ok {

--- a/internal/models/item.go
+++ b/internal/models/item.go
@@ -448,9 +448,65 @@ func ExtractItemDecisionLog(fieldsJSON string) []ItemDecisionLogEntry {
 	return entries
 }
 
+// ErrStructuredFieldUnreadable is returned by the Append* helpers when the item
+// already carries a structured-entry field whose stored value cannot be decoded
+// into its entry slice. Callers should surface it rather than retry: the append
+// is refused precisely because completing it would destroy the stored value.
+var ErrStructuredFieldUnreadable = errors.New("structured field is present but unreadable")
+
+// assertStructuredFieldAppendable refuses an append when key holds a value that
+// does not decode into []T.
+//
+// BUG-2627. The Append* helpers below build the new slice from Extract*, then
+// assign it over the key unconditionally. Extract* returns nil for THREE
+// different reasons and only one of them is a defect, so the nil itself cannot
+// be the refusal condition:
+//
+//  1. the key is absent          — the first append on an item. Must proceed.
+//  2. the key holds an empty array — well-formed, just empty. Must proceed.
+//  3. the key holds a value that does not decode — the defect. Must REFUSE,
+//     because the unconditional assign would overwrite that value with a
+//     one-element slice and report success. Observed live: an item whose
+//     implementation_notes was a JSON-ENCODED STRING lost its stored note to a
+//     single `pad item note` call, with no warning on any surface.
+//
+// So this checks decodability directly against the raw value instead of reusing
+// Extract*'s nil, which cannot distinguish (3) from (1) or (2).
+func assertStructuredFieldAppendable[T any](fieldsMap map[string]any, key string) error {
+	raw, ok := fieldsMap[key]
+	if !ok {
+		return nil // case 1 — absent, nothing to lose.
+	}
+	if raw == nil {
+		return nil // an explicit JSON null carries no entries either.
+	}
+
+	payload, err := json.Marshal(raw)
+	if err != nil {
+		return fmt.Errorf("%w: %q could not be re-encoded for inspection: %w", ErrStructuredFieldUnreadable, key, err)
+	}
+
+	var entries []T
+	if err := json.Unmarshal(payload, &entries); err != nil {
+		// Deliberately does NOT name a repair command. The remedy has to be
+		// one that works in THIS state, and every append path is exactly what
+		// is being refused here; `pad item show --format json` is read-only
+		// and does surface the raw value, so it is the one action safe to
+		// suggest.
+		return fmt.Errorf(
+			"%w: %q holds a value that is not a list of entries, so appending would overwrite and destroy it; "+
+				"inspect the stored value with `pad item show <ref> --format json` and repair it before appending (BUG-2627)",
+			ErrStructuredFieldUnreadable, key)
+	}
+	return nil
+}
+
 func AppendImplementationNote(fieldsJSON string, note ItemImplementationNote) (string, error) {
 	fieldsMap, err := parseMutableItemFields(fieldsJSON)
 	if err != nil {
+		return "", err
+	}
+	if err := assertStructuredFieldAppendable[ItemImplementationNote](fieldsMap, ItemFieldImplementationNotes); err != nil {
 		return "", err
 	}
 
@@ -463,6 +519,9 @@ func AppendImplementationNote(fieldsJSON string, note ItemImplementationNote) (s
 func AppendDecisionLogEntry(fieldsJSON string, entry ItemDecisionLogEntry) (string, error) {
 	fieldsMap, err := parseMutableItemFields(fieldsJSON)
 	if err != nil {
+		return "", err
+	}
+	if err := assertStructuredFieldAppendable[ItemDecisionLogEntry](fieldsMap, ItemFieldDecisionLog); err != nil {
 		return "", err
 	}
 

--- a/internal/models/item_test.go
+++ b/internal/models/item_test.go
@@ -243,12 +243,29 @@ func TestAppendRefusesWhenStructuredFieldIsUnreadable(t *testing.T) {
 		}
 	})
 
-	t.Run("object instead of list", func(t *testing.T) {
-		_, err := AppendImplementationNote(`{"implementation_notes":{"summary":"not a list"}}`, ItemImplementationNote{ID: "note-new"})
-		if !errors.Is(err, ErrStructuredFieldUnreadable) {
-			t.Fatalf("expected ErrStructuredFieldUnreadable, got %v", err)
-		}
-	})
+	// Shapes other than the double-encoded string that must also refuse. Each
+	// asserts the empty fields return too, not just the error — the refusal is
+	// only useful if the caller is left with nothing to write.
+	for _, tc := range []struct {
+		name   string
+		fields string
+	}{
+		{"object instead of list", `{"implementation_notes":{"summary":"not a list"}}`},
+		{"list of wrong element type", `{"implementation_notes":[1,2,3]}`},
+		{"list of strings", `{"implementation_notes":["a note"]}`},
+		{"bare number", `{"implementation_notes":42}`},
+		{"known key holding an incompatible nested value", `{"implementation_notes":[{"summary":{"nested":"object"}}]}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fields, err := AppendImplementationNote(tc.fields, ItemImplementationNote{ID: "note-new"})
+			if !errors.Is(err, ErrStructuredFieldUnreadable) {
+				t.Fatalf("expected ErrStructuredFieldUnreadable, got %v", err)
+			}
+			if fields != "" {
+				t.Fatalf("refused append must return no fields to write, got %q", fields)
+			}
+		})
+	}
 
 	// The message is the only thing a human sees at the moment of refusal, and
 	// PATTE-135 requires its suggested remedy to work in THIS state. It names a
@@ -299,6 +316,68 @@ func TestAppendProceedsWhenStructuredFieldIsAbsentEmptyOrValid(t *testing.T) {
 				t.Fatalf("new note should be appended last, got %#v", got)
 			}
 		})
+	}
+}
+
+// decision_log gets its own control legs rather than riding on the notes ones.
+// The two helpers carry independent guard calls, so coverage on one says
+// nothing about the other — a guard omitted from AppendDecisionLogEntry, or
+// pointed at the wrong field key, would pass every implementation_notes test.
+func TestAppendDecisionLogProceedsWhenFieldIsAbsentEmptyOrValid(t *testing.T) {
+	cases := []struct {
+		name        string
+		fields      string
+		wantEntries int
+	}{
+		{"absent key", `{"status":"open"}`, 1},
+		{"empty list", `{"decision_log":[]}`, 1},
+		{"explicit null", `{"decision_log":null}`, 1},
+		{"existing entry is preserved", `{"decision_log":[{"id":"decision-1","decision":"stored"}]}`, 2},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fields, err := AppendDecisionLogEntry(tc.fields, ItemDecisionLogEntry{ID: "decision-new", Decision: "new"})
+			if err != nil {
+				t.Fatalf("append must proceed, got %v", err)
+			}
+			got := ExtractItemDecisionLog(fields)
+			if len(got) != tc.wantEntries {
+				t.Fatalf("expected %d entr(y|ies), got %#v", tc.wantEntries, got)
+			}
+			// Ordering, not just count: a helper that PREPENDED would satisfy
+			// the length assertion on every leg above.
+			if got[len(got)-1].ID != "decision-new" {
+				t.Fatalf("new entry should be appended last, got %#v", got)
+			}
+		})
+	}
+}
+
+// A successful append must not disturb the item's other reserved metadata.
+// github_pr lives in the same fields blob and is rebuilt from the same map, so
+// a helper that assigned a fresh map instead of mutating the parsed one would
+// drop it while every notes assertion stayed green.
+func TestAppendPreservesSiblingReservedFields(t *testing.T) {
+	const withPR = `{"github_pr":{"number":42,"url":"https://github.com/PerpetualSoftware/pad/pull/42","state":"OPEN"},"status":"open"}`
+
+	fields, err := AppendImplementationNote(withPR, ItemImplementationNote{ID: "note-new", Summary: "new"})
+	if err != nil {
+		t.Fatalf("AppendImplementationNote error: %v", err)
+	}
+	if ctx := ExtractItemCodeContext(fields); ctx == nil {
+		t.Fatalf("github_pr must survive an implementation-note append, got %q", fields)
+	}
+
+	fields, err = AppendDecisionLogEntry(fields, ItemDecisionLogEntry{ID: "decision-new", Decision: "new"})
+	if err != nil {
+		t.Fatalf("AppendDecisionLogEntry error: %v", err)
+	}
+	if ctx := ExtractItemCodeContext(fields); ctx == nil {
+		t.Fatalf("github_pr must survive a decision-log append, got %q", fields)
+	}
+	if got := ExtractItemImplementationNotes(fields); len(got) != 1 {
+		t.Fatalf("notes must survive a decision-log append, got %#v", got)
 	}
 }
 

--- a/internal/models/item_test.go
+++ b/internal/models/item_test.go
@@ -209,6 +209,99 @@ func TestAppendDecisionLogEntryPreservesExistingNotes(t *testing.T) {
 	}
 }
 
+// BUG-2627. The Append* helpers assigned the rebuilt slice over the key
+// unconditionally, so an existing value that Extract* could not decode was
+// overwritten and destroyed while the call reported success. Reproduced live: an
+// item whose implementation_notes held a JSON-ENCODED STRING lost its stored
+// note to one `pad item note` call, silently.
+//
+// The refusal is asserted on the ERROR *and* on the returned fields being empty
+// — "returns an error" alone would still pass if the helper handed back a
+// mutated fields blob that a caller then wrote (CONVE-12: assert what the wrong
+// behaviour would DO, not what the right one leaves looking unchanged).
+func TestAppendRefusesWhenStructuredFieldIsUnreadable(t *testing.T) {
+	const encodedNotes = `{"implementation_notes":"[{\"summary\":\"stored note\"}]","status":"done"}`
+	const encodedDecisions = `{"decision_log":"[{\"decision\":\"stored decision\"}]"}`
+
+	t.Run("implementation notes", func(t *testing.T) {
+		fields, err := AppendImplementationNote(encodedNotes, ItemImplementationNote{ID: "note-new", Summary: "new"})
+		if !errors.Is(err, ErrStructuredFieldUnreadable) {
+			t.Fatalf("expected ErrStructuredFieldUnreadable, got %v", err)
+		}
+		if fields != "" {
+			t.Fatalf("refused append must return no fields to write, got %q", fields)
+		}
+	})
+
+	t.Run("decision log", func(t *testing.T) {
+		fields, err := AppendDecisionLogEntry(encodedDecisions, ItemDecisionLogEntry{ID: "decision-new", Decision: "new"})
+		if !errors.Is(err, ErrStructuredFieldUnreadable) {
+			t.Fatalf("expected ErrStructuredFieldUnreadable, got %v", err)
+		}
+		if fields != "" {
+			t.Fatalf("refused append must return no fields to write, got %q", fields)
+		}
+	})
+
+	t.Run("object instead of list", func(t *testing.T) {
+		_, err := AppendImplementationNote(`{"implementation_notes":{"summary":"not a list"}}`, ItemImplementationNote{ID: "note-new"})
+		if !errors.Is(err, ErrStructuredFieldUnreadable) {
+			t.Fatalf("expected ErrStructuredFieldUnreadable, got %v", err)
+		}
+	})
+
+	// The message is the only thing a human sees at the moment of refusal, and
+	// PATTE-135 requires its suggested remedy to work in THIS state. It names a
+	// read-only inspection command deliberately — every append path is what is
+	// being refused, so none of them is a safe suggestion here.
+	t.Run("message names the field and a remedy that is not an append", func(t *testing.T) {
+		_, err := AppendImplementationNote(encodedNotes, ItemImplementationNote{ID: "note-new"})
+		msg := err.Error()
+		for _, want := range []string{"implementation_notes", "pad item show", "BUG-2627"} {
+			if !strings.Contains(msg, want) {
+				t.Errorf("refusal message missing %q: %s", want, msg)
+			}
+		}
+		if strings.Contains(msg, "pad item note") {
+			t.Errorf("refusal must not suggest an append path — it is destructive in this state: %s", msg)
+		}
+	})
+}
+
+// The guard must key on "present and undecodable", NOT on Extract* returning
+// nil — Extract* also returns nil for an absent key and for a well-formed empty
+// list, and refusing either would break every first append. These are the
+// control legs: without them a guard of the form `if Extract(...) == nil` would
+// pass the refusal test above and still be wrong.
+func TestAppendProceedsWhenStructuredFieldIsAbsentEmptyOrValid(t *testing.T) {
+	cases := []struct {
+		name      string
+		fields    string
+		wantNotes int
+	}{
+		{"absent key", `{"status":"open"}`, 1},
+		{"empty list", `{"implementation_notes":[]}`, 1},
+		{"explicit null", `{"implementation_notes":null}`, 1},
+		{"existing entry is preserved", `{"implementation_notes":[{"id":"note-1","summary":"stored"}]}`, 2},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fields, err := AppendImplementationNote(tc.fields, ItemImplementationNote{ID: "note-new", Summary: "new"})
+			if err != nil {
+				t.Fatalf("append must proceed, got %v", err)
+			}
+			got := ExtractItemImplementationNotes(fields)
+			if len(got) != tc.wantNotes {
+				t.Fatalf("expected %d note(s), got %#v", tc.wantNotes, got)
+			}
+			if got[len(got)-1].ID != "note-new" {
+				t.Fatalf("new note should be appended last, got %#v", got)
+			}
+		})
+	}
+}
+
 func TestApplyItemConventionMetadataPreservesStatusAndWritesAliases(t *testing.T) {
 	fields, err := ApplyItemConventionMetadata(`{"status":"active"}`, &ItemConventionMetadata{
 		Category:    "pm",

--- a/internal/models/item_test.go
+++ b/internal/models/item_test.go
@@ -354,6 +354,60 @@ func TestAppendDecisionLogProceedsWhenFieldIsAbsentEmptyOrValid(t *testing.T) {
 	}
 }
 
+// The decision-log guard must be instantiated with ItemDecisionLogEntry, not
+// merely with SOME entry type. A wrong-but-compiling type parameter passes every
+// other decision test, because the two structs disagree only on shapes that no
+// other case exercises: `{"decision":{...}}` is ACCEPTED by the notes struct
+// (unknown key, ignored) and REJECTED by the log struct (Decision is a string).
+// The guard would then permit an append that ExtractItemDecisionLog reads as
+// empty — which is the exact guard/extractor divergence this whole change exists
+// to prevent, reintroduced one type parameter away. Codex round 2.
+func TestAppendDecisionLogRefusesEntriesOnlyItsOwnTypeRejects(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		fields string
+	}{
+		{"decision holding an object", `{"decision_log":[{"decision":{"nested":"object"}}]}`},
+		{"rationale holding a list", `{"decision_log":[{"decision":"ok","rationale":["a","b"]}]}`},
+		{"double-encoded string", `{"decision_log":"[{\"decision\":\"stored\"}]"}`},
+		{"list of wrong element type", `{"decision_log":[1,2,3]}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fields, err := AppendDecisionLogEntry(tc.fields, ItemDecisionLogEntry{ID: "decision-new", Decision: "new"})
+			if !errors.Is(err, ErrStructuredFieldUnreadable) {
+				t.Fatalf("expected ErrStructuredFieldUnreadable, got %v", err)
+			}
+			if fields != "" {
+				t.Fatalf("refused append must return no fields to write, got %q", fields)
+			}
+		})
+	}
+}
+
+// The mirror of the above: shapes only the NOTES struct rejects, so a
+// decision-log type parameter on the notes guard is caught too. `{"summary":{}}`
+// is rejected by ItemImplementationNote (Summary is a string) and accepted by
+// ItemDecisionLogEntry (unknown key, ignored).
+func TestAppendImplementationNoteRefusesEntriesOnlyItsOwnTypeRejects(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		fields string
+	}{
+		{"summary holding an object", `{"implementation_notes":[{"summary":{"nested":"object"}}]}`},
+		{"details holding a list", `{"implementation_notes":[{"summary":"ok","details":["a","b"]}]}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fields, err := AppendImplementationNote(tc.fields, ItemImplementationNote{ID: "note-new", Summary: "new"})
+			if !errors.Is(err, ErrStructuredFieldUnreadable) {
+				t.Fatalf("expected ErrStructuredFieldUnreadable, got %v", err)
+			}
+			if fields != "" {
+				t.Fatalf("refused append must return no fields to write, got %q", fields)
+			}
+		})
+	}
+}
+
 // A successful append must not disturb the item's other reserved metadata.
 // github_pr lives in the same fields blob and is rebuilt from the same map, so
 // a helper that assigned a fresh map instead of mutating the parsed one would


### PR DESCRIPTION
Part 3 of BUG-2627. **Ships first by design** — see Ordering below.

## The defect

`AppendImplementationNote` / `AppendDecisionLogEntry` rebuilt their entry slice from `Extract*`, then assigned it over the field key **unconditionally**. When the stored value was something `Extract*` could not decode, `Extract*` returned `nil` and the assign overwrote that value with a one-element slice — reporting success.

Observed live, not hypothesised. A scratch item corrupted to the real-world shape, carrying two notes:

```
pad item note TASK-2668 "third note appended via the remedy path"
→ "Added implementation note to TASK-2668"     ← success

read back → one note. note-A and note-B are GONE.
```

## The design point

**The guard cannot key on `Extract*` returning nil** — the obvious shape, and the wrong one. `Extract*` returns nil for four different reasons and only one is a defect:

| | stored value | correct behaviour |
|---|---|---|
| 1 | key absent | proceed — the first append on an item |
| 2 | empty array | proceed — well-formed, just empty |
| 3 | explicit JSON `null` | proceed — carries no entries |
| 4 | **undecodable value** | **refuse** |

`if Extract(...) == nil { refuse }` passes every refusal test and breaks *every first append*. So `assertStructuredFieldAppendable` tests decodability against the raw value in the fields map, which is the only check separating (4) from (1)–(3).

## The error message

Deliberately does **not** name an append path. Per PATTE-135 a suggested remedy has to work in the state where the message appears, and every append path is precisely what's being refused. `pad item show --format json` is read-only and does surface the raw value, so it's the one action safe to suggest. A test asserts the message never names `pad item note`.

That requirement came from *running* the trace rather than reasoning about it — which is also what produced the ordering below.

## Ordering

**3 → 1 → 2.** Load-bearing, not stylistic: part 2's error message names a remedy that destroys affected rows until this guard exists. Shipping part 2 first would weaponize its own error message.

## Verification

Every mutant was **run**, and the killing assertion recorded:

| mutant | killed by |
|---|---|
| guard removed | the refusal legs |
| `present && Extract(...) == nil` — the plausible-wrong guard | the `empty_list` / `explicit_null` **control** legs (it passes all refusal tests) |
| returns mutated fields alongside the error | the `fields != ""` assertion (an `errors.Is` check alone passes it) |
| message names `pad item note` | the message assertion |
| prepend instead of append | the ordering assertion |
| rebuild `fieldsMap` fresh | the sibling-field (`github_pr`) test |
| wrong-but-compiling type parameter, both directions | the type-discriminating cases |

All mutants removed afterwards, verified by grep.

**End-to-end against a binary built from this branch:** the trace that destroyed two notes now exits non-zero and both notes read back byte-identical; a healthy item still takes a first note and appends onto an existing one.

## Gates

- `make lint` — 0 issues
- `go test ./...` — exit 0, 25 packages
- `make test-pg` — exit 0, 3276 tests. **Run, not waived**: no SQL changed, but this is a shared writer the server handlers reach
- web checks — **not applicable**, zero web files
- Codex CLI — **CLEAN at round 3** (3 rounds, findings below)

## Codex rounds

- **R1** — P1: item moves drop the reserved arrays entirely. Independently verified and reproduced live, then filed as **BUG-2674** rather than fixed here: different mechanism, different door, and it destroys *valid* data. P2: generic `--field` writers remain a bypass — that is part 2. Nit: test coverage didn't support the claimed matrix → fixed.
- **R2** — a real hole, not a coverage complaint: the guard is generic, so a wrong-but-compiling type parameter passes every test while permitting an append the extractor reads as empty. Both directions now pinned.
- **R3** — CLEAN. Three nit-level accuracy notes on my commit messages; the one that mattered (an undercount that also sat in the *code* comment) is fixed where a maintainer reads it.

## Known, deliberate non-goals

`--field implementation_notes=...` still reaches the fields patch and overwrites — that's part 2. Item moves still drop these fields — that's BUG-2674.

https://claude.ai/code/session_017jD6t1zjxGSq47SQpZfp1V
