### PR TITLE
feat(watchevents): Redis-backed bus so watch notifications cross instances (BUG-2651)

### DIFF
--- a/cmd/pad/cmd_push.go
+++ b/cmd/pad/cmd_push.go
@@ -36,9 +36,15 @@ func pushCmd() *cobra.Command {
 		Long: fmt.Sprintf(`pad push <ref> -m "message"
     Publish a self-addressed push notification on an item. Every one of
     your OWN connected plugin-monitor sessions (pad watch --stream
-    --for-session) receives it — this is fire-and-forget over the
-    in-memory watch-events bus, with no durable inbox: a push with no
-    connected session listening is simply not seen (Phase 1 scope).
+    --for-session) receives it — fire-and-forget over the watch-events
+    bus, with no durable inbox: a push with no connected session
+    listening is simply not seen (Phase 1 scope).
+
+    On a multi-instance deployment (PAD_REDIS_URL set) a BROADCAST push
+    reaches your sessions on every instance. A push naming one session
+    is still resolved against the server that handles the request, so
+    targeting a session connected to a different instance finds nothing
+    and sends nothing — see BUG-2651.
 
     -m/--message is required and must not be blank; it is the
     instruction text the receiving agent acts on (load the item first,

--- a/cmd/pad/cmd_push.go
+++ b/cmd/pad/cmd_push.go
@@ -44,7 +44,7 @@ func pushCmd() *cobra.Command {
     reaches your sessions on every instance. A push naming one session
     is still resolved against the server that handles the request, so
     targeting a session connected to a different instance finds nothing
-    and sends nothing — see BUG-2651.
+    and sends nothing — see BUG-2698.
 
     -m/--message is required and must not be blank; it is the
     instruction text the receiving agent acts on (load the item first,

--- a/cmd/pad/cmd_server.go
+++ b/cmd/pad/cmd_server.go
@@ -634,8 +634,11 @@ func serveCmd() *cobra.Command {
 			srv.SetMetrics(m)
 			slog.Info("Prometheus metrics enabled at /metrics")
 
-			// Attach event bus for real-time SSE
+			// Attach event bus for real-time SSE. The client built here is
+			// shared with the watch bus below (BUG-2651) — nil when this is
+			// a single-instance deployment.
 			var eventBus events.EventBus
+			var watchRedis *redis.Client
 			if redisURL := os.Getenv("PAD_REDIS_URL"); redisURL != "" {
 				opts, err := redis.ParseURL(redisURL)
 				if err != nil {
@@ -646,6 +649,7 @@ func serveCmd() *cobra.Command {
 					return fmt.Errorf("redis connection failed: %w", err)
 				}
 				eventBus = events.NewRedisBus(rc)
+				watchRedis = rc
 				slog.Info("Event bus using Redis pub/sub", "addr", opts.Addr, "db", opts.DB)
 			} else {
 				eventBus = events.New()
@@ -655,12 +659,23 @@ func serveCmd() *cobra.Command {
 			eventBus = metrics.NewInstrumentedBus(eventBus, m)
 			srv.SetEventBus(eventBus)
 
-			// Watch/nudge notification bus (TASK-2533). In-process only —
-			// see internal/watchevents' package doc comment for the
-			// single-process/multi-instance limitation. No Redis-backed
-			// implementation exists yet, so this is unconditional (unlike
-			// eventBus above, which branches on PAD_REDIS_URL).
-			srv.SetWatchEventsBus(watchevents.New())
+			// Watch/nudge notification bus (TASK-2533), on the SAME
+			// PAD_REDIS_URL switch as the event bus above (BUG-2651).
+			// Reusing that client rather than dialing a second one: they
+			// address the same server, and one connection pool with two
+			// logical channels is the shape events already assumes.
+			//
+			// The branch is here rather than inside the package because a
+			// self-hosted single-process binary should keep MemoryBus and
+			// never touch Redis at all — see internal/watchevents' package
+			// doc for what each implementation does and does not fix.
+			if watchRedis != nil {
+				srv.SetWatchEventsBus(watchevents.NewRedisBus(watchRedis))
+				slog.Info("Watch notification bus using Redis pub/sub")
+			} else {
+				srv.SetWatchEventsBus(watchevents.New())
+				slog.Info("Watch notification bus using in-memory (single instance)")
+			}
 
 			// Live-session presence registry (PLAN-2558 S1). Wired
 			// unconditionally for the same reason and with the same

--- a/cmd/pad/cmd_server.go
+++ b/cmd/pad/cmd_server.go
@@ -875,6 +875,19 @@ func serveCmd() *cobra.Command {
 				// subscription down promptly instead of at the very end.
 				// Both Close implementations are idempotent, so the second
 				// call inside srv.Stop() is a no-op.
+				//
+				// THE TRADE, which is the same one eventBus above already
+				// makes and is worth naming (codex round 10): closing BEFORE
+				// Shutdown drains handlers means a push already in flight can
+				// Publish into a closed bus, be dropped, and still return
+				// HTTP 200 with pushed:true. Closing AFTER instead would hold
+				// Shutdown for its full 30s deadline on any open stream,
+				// every time. Neither is free; this side loses a message in a
+				// window measured in milliseconds during a deliberate
+				// shutdown, the other side delays every shutdown by half a
+				// minute. Making the handler actually LEARN the publish was
+				// dropped needs Bus.Publish to report it, which is an
+				// interface change and a different unit.
 				watchBus.Close()
 				slog.Info("Watch notification bus closed")
 

--- a/cmd/pad/cmd_server.go
+++ b/cmd/pad/cmd_server.go
@@ -669,13 +669,15 @@ func serveCmd() *cobra.Command {
 			// self-hosted single-process binary should keep MemoryBus and
 			// never touch Redis at all — see internal/watchevents' package
 			// doc for what each implementation does and does not fix.
+			var watchBus watchevents.Bus
 			if watchRedis != nil {
-				srv.SetWatchEventsBus(watchevents.NewRedisBus(watchRedis))
+				watchBus = watchevents.NewRedisBus(watchRedis)
 				slog.Info("Watch notification bus using Redis pub/sub")
 			} else {
-				srv.SetWatchEventsBus(watchevents.New())
+				watchBus = watchevents.New()
 				slog.Info("Watch notification bus using in-memory (single instance)")
 			}
+			srv.SetWatchEventsBus(watchBus)
 
 			// Live-session presence registry (PLAN-2558 S1). Wired
 			// unconditionally, and it is now the ONLY in-process piece
@@ -863,6 +865,18 @@ func serveCmd() *cobra.Command {
 				// above to a concrete *metrics.InstrumentedBus return value.
 				eventBus.Close()
 				slog.Info("Event bus closed")
+
+				// Same reasoning for the watch bus, and it matters for the
+				// same reason: GET /api/v1/events/stream is a long-lived
+				// handler blocked on this bus's channel, so leaving it open
+				// keeps http.Server.Shutdown waiting out its full 30s
+				// deadline (codex round 2 on BUG-2651). Closing here rather
+				// than only in srv.Stop() below also tears the Redis
+				// subscription down promptly instead of at the very end.
+				// Both Close implementations are idempotent, so the second
+				// call inside srv.Stop() is a no-op.
+				watchBus.Close()
+				slog.Info("Watch notification bus closed")
 
 				shutdownCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 				defer cancel()

--- a/cmd/pad/cmd_server.go
+++ b/cmd/pad/cmd_server.go
@@ -678,14 +678,18 @@ func serveCmd() *cobra.Command {
 			}
 
 			// Live-session presence registry (PLAN-2558 S1). Wired
-			// unconditionally for the same reason and with the same
-			// caveat as the watch bus directly above: in-process only,
-			// no Redis-backed implementation yet. It reports on the
-			// same connections that bus feeds, so the two share a
-			// lifetime and a limitation — see
-			// internal/server/session_presence.go's SINGLE-PROCESS
-			// LIMITATION note before putting the web-UI push surface
-			// (PLAN-2558 S3) in front of a multi-process deployment.
+			// unconditionally, and it is now the ONLY in-process piece
+			// of this pair — the watch bus above stopped being one when
+			// PAD_REDIS_URL is set (BUG-2651). So the old "same caveat
+			// as the bus directly above" reading no longer holds: the
+			// bus delivers across instances, while this registry still
+			// reports only the answering instance's connections.
+			//
+			// See internal/server/session_presence.go's note for what
+			// that costs (a session picker that under-reports, rather
+			// than a push that lies) before putting the web-UI push
+			// surface (PLAN-2558 S3) in front of a multi-process
+			// deployment.
 			srv.SetSessionPresence(server.NewMemorySessionPresence())
 
 			// Yjs collab room manager (PLAN-1248). Single-instance only

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ toolchain go1.26.6
 require (
 	github.com/BurntSushi/toml v1.6.0
 	github.com/JohannesKaufmann/html-to-markdown/v2 v2.5.2
+	github.com/alicebob/miniredis/v2 v2.38.0
 	github.com/disintegration/imaging v1.6.2
 	github.com/fatih/color v1.19.0
 	github.com/go-chi/chi/v5 v5.3.1
@@ -112,6 +113,7 @@ require (
 	github.com/subosito/gotenv v1.4.2 // indirect
 	github.com/test-go/testify v1.1.4 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
+	github.com/yuin/gopher-lua v1.1.1 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace v0.46.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -45,6 +45,8 @@ github.com/JohannesKaufmann/dom v0.3.1/go.mod h1:BZPkf8ZeYrBgABjwJn9iiKt8aiCtkxp
 github.com/JohannesKaufmann/html-to-markdown/v2 v2.5.2 h1:XFJZFWESIWlUEHHjzBuv8RvrtCWnSGlimEX17ysSDb8=
 github.com/JohannesKaufmann/html-to-markdown/v2 v2.5.2/go.mod h1:BHWO8lJzttJLqwuV8Rb1B3OG2OSzLbssZDI1FRg2eAA=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
+github.com/alicebob/miniredis/v2 v2.38.0 h1:nZAzCR+Lj+Vxk4ZXzm2NuKq2O33RXj1XxJ2e2uP9jiw=
+github.com/alicebob/miniredis/v2 v2.38.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/andybalholm/cascadia v1.3.4 h1:vM2lgh0Vru9Vwyfm4cQqWP2HHMW0u0+2PAW7Q38Qufg=
 github.com/andybalholm/cascadia v1.3.4/go.mod h1:BLRmbRjpEtNKieZOCCvYj4RqN+KRA41GBe/5O+G93kM=
 github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de h1:FxWPpzIjnTlhPwqqXc4/vE0f7GvRjuAsbW+HOIe8KnA=
@@ -507,6 +509,8 @@ github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/yuin/goldmark v1.8.2 h1:kEGpgqJXdgbkhcOgBxkC0X0PmoPG1ZyoZ117rDVp4zE=
 github.com/yuin/goldmark v1.8.2/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
+github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
+github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 github.com/zeebo/xxh3 v1.1.0 h1:s7DLGDK45Dyfg7++yxI0khrfwq9661w9EN78eP/UZVs=
 github.com/zeebo/xxh3 v1.1.0/go.mod h1:IisAie1LELR4xhVinxWS5+zf1lA4p0MW4T+w+W07F5s=
 github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxtB1Q=

--- a/internal/server/handlers_push.go
+++ b/internal/server/handlers_push.go
@@ -67,6 +67,21 @@ type pushResponse struct {
 	// and, for a targeted push, skips the publish entirely when the
 	// target isn't in that snapshot — see its doc comment — so a 0 here
 	// is never a race, it's a guarantee: nothing was sent.
+	//
+	// THAT GUARANTEE IS PER-PROCESS, and in a Redis-backed deployment
+	// that makes this count wrong in BOTH directions for a BROADCAST push
+	// (BUG-2651, codex round 3). The count comes from the local presence
+	// registry while the bus now delivers everywhere: with one armed
+	// session on each of two replicas, the replica handling the POST
+	// reports 1 and two sessions receive it; with none of its own, it
+	// reports 0 while a remote session receives it anyway.
+	//
+	// Not corrected here, because the fix is not a better count — it is
+	// the shared-state SessionPresence that PLAN-2558 S3 already gates
+	// on. Any local arithmetic would just be a more elaborate way of
+	// asking one replica what all of them are doing. Targeted pushes do
+	// not have the over-report half of this problem, for the unhappy
+	// reason that the same locality stops them being published at all.
 	DeliveredSessions int `json:"delivered_sessions"`
 }
 

--- a/internal/server/handlers_push.go
+++ b/internal/server/handlers_push.go
@@ -76,9 +76,9 @@ type pushResponse struct {
 	// reports 1 and two sessions receive it; with none of its own, it
 	// reports 0 while a remote session receives it anyway.
 	//
-	// Not corrected here, because the fix is not a better count — it is
-	// the shared-state SessionPresence that PLAN-2558 S3 already gates
-	// on. Any local arithmetic would just be a more elaborate way of
+	// Filed as BUG-2698 alongside the targeted-push half. Not corrected
+	// here, because the fix is not a better count — it is the shared-state
+	// SessionPresence that PLAN-2558 S3 already gates on. Any local arithmetic would just be a more elaborate way of
 	// asking one replica what all of them are doing. Targeted pushes do
 	// not have the over-report half of this problem, for the unhappy
 	// reason that the same locality stops them being published at all.

--- a/internal/server/handlers_push.go
+++ b/internal/server/handlers_push.go
@@ -218,6 +218,24 @@ func (s *Server) handlePushToItem(w http.ResponseWriter, r *http.Request) {
 	// who's connected, not a promise that count still holds by the time
 	// delivery happens, which is the same staleness every presence
 	// answer on this surface already carries.
+	//
+	// THE "GUARANTEED NO-OP" PREMISE IS NOW MEMORYBUS-ONLY (BUG-2651,
+	// codex round 2). It rested on the bus being in-process: a target
+	// this instance cannot see was, by construction, a target nobody
+	// could deliver to. With watchevents.RedisBus the notification would
+	// reach every instance, so a session held on another one WOULD match
+	// it — and this skip is what stops that, turning a deliverable push
+	// into the no-op the comment describes rather than merely declining
+	// to record one.
+	//
+	// Deliberately NOT changed here. Publishing unconditionally would fix
+	// targeted cross-instance delivery and immediately make the
+	// delivered_sessions=0 in the response a lie in the other direction,
+	// which is a question about what that field promises rather than a
+	// bug in this line. It belongs with the shared-state SessionPresence
+	// that PLAN-2558 S3 already gates on — fixing the registry makes the
+	// snapshot right, and then this skip is correct again for the same
+	// reason it was originally.
 	deliveredSessions := deliveredSessionCount(s.sessionPresence, userID, targetSessionID)
 	if targetSessionID == "" || deliveredSessions > 0 {
 		s.watchEvents.Publish(watchevents.Notification{

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -426,6 +426,19 @@ func (s *Server) Stop() {
 		s.collab.Close()
 	}
 	s.bg.Wait()
+	// Watch/nudge bus (BUG-2651). Closed AFTER bg.Wait() so a background
+	// producer cannot publish into a bus that is already tearing down; both
+	// implementations are safe if one does anyway (MemoryBus finds no
+	// subscribers, RedisBus finds a cancelled context and fails closed).
+	//
+	// This matters more than it did for MemoryBus, whose Close only dropped
+	// channels: RedisBus holds a receive goroutine and a Redis subscription
+	// from construction, so skipping it leaks both for the process's life
+	// (Codex round 1 P2). Closing also closes every subscriber channel, which
+	// is how a still-open SSE stream learns to unwind.
+	if s.watchEvents != nil {
+		s.watchEvents.Close()
+	}
 	s.rateLimiters.Stop() // nil-safe via the RateLimiters receiver guard
 }
 

--- a/internal/server/session_presence.go
+++ b/internal/server/session_presence.go
@@ -57,8 +57,8 @@ import (
 //     asks A sees nothing to target. Unchanged by BUG-2651 — neither
 //     better nor worse — so nothing regressed.
 //
-// The two open halves are the same defect wearing different clothes, and
-// one implementation closes both: a shared-state SessionPresence makes
+// The two open halves are the same defect wearing different clothes (filed
+// together as BUG-2698), and one implementation closes both: a shared-state SessionPresence makes
 // the snapshot right, which makes the picker complete AND makes the
 // push gate's premise true again. Do not put the web-UI push surface
 // (PLAN-2558 S3) in front of a multi-process deployment until it exists.

--- a/internal/server/session_presence.go
+++ b/internal/server/session_presence.go
@@ -33,11 +33,14 @@ import (
 // THIS NOTE USED TO SAY presence and delivery were blind in the same
 // direction, and that the two had to be fixed together or not at all.
 // That was true when written and is no longer: BUG-2651 shipped
-// watchevents.RedisBus, so DELIVERY is now cross-instance — a push
-// published on A reaches a stream held on B, and B matches it against
-// its own live sessions, which is the only set B needs. What remains
-// per-process is exactly this registry, and it is worth being precise
-// about what that costs, because the two halves fail differently:
+// watchevents.RedisBus, so DELIVERY is now cross-instance WHEN
+// PAD_REDIS_URL IS SET — a push published on A reaches a stream held on
+// B, and B matches it against its own live sessions, which is the only
+// set B needs. Without that env var the deployment is single-process by
+// definition and none of this applies. What remains per-process in a
+// Redis-backed deployment is exactly this registry, and it is worth
+// being precise about what that costs, because the two halves fail
+// differently:
 //
 //   - DELIVERY (fixed): a broadcast push — TargetUserID with no session
 //     id — used to reach only the sessions on whichever instance handled

--- a/internal/server/session_presence.go
+++ b/internal/server/session_presence.go
@@ -42,26 +42,33 @@ import (
 // being precise about what that costs, because the two halves fail
 // differently:
 //
-//   - DELIVERY (fixed): a broadcast push — TargetUserID with no session
-//     id — used to reach only the sessions on whichever instance handled
-//     the POST. It now reaches all of that user's sessions. A
-//     session-targeted push likewise reaches the instance holding that
-//     session, wherever it is.
+//   - BROADCAST DELIVERY (fixed): a push with TargetUserID and no
+//     session id used to reach only the sessions on whichever instance
+//     handled the POST. It now reaches all of that user's sessions,
+//     wherever they are held.
+//   - TARGETED DELIVERY (still open, and NOT fixed by the bus): a push
+//     naming a specific session id is gated on THIS registry before it
+//     is published at all — see handlers_push.go, which skips the
+//     publish when the id is absent from the local snapshot. So a POST
+//     landing on A for a session held on B still delivers nothing. The
+//     bus would carry it; the gate means it is never put on the bus.
 //   - VISIBILITY (still open): GET /api/v1/sessions answers from ONE
 //     instance's registry, so a user whose session is held on B and who
-//     asks A sees nothing to target. That under-report is unchanged by
-//     BUG-2651 — it is neither better nor worse — so nothing regressed;
-//     a session a caller can SEE is by construction on the instance that
-//     listed it, and pushing to it works.
+//     asks A sees nothing to target. Unchanged by BUG-2651 — neither
+//     better nor worse — so nothing regressed.
 //
-// So the remaining defect is a picker that under-reports, not a push
-// that lies. Do not put the web-UI push surface (PLAN-2558 S3) in front
-// of a multi-process deployment until a shared-state SessionPresence
-// exists: a picker that silently omits half a user's sessions is its own
-// kind of dishonest, even though every session it DOES list is real and
-// reachable. SessionPresence is an interface from day one so that
-// implementation can slot in without touching the stream handler or the
-// endpoint.
+// The two open halves are the same defect wearing different clothes, and
+// one implementation closes both: a shared-state SessionPresence makes
+// the snapshot right, which makes the picker complete AND makes the
+// push gate's premise true again. Do not put the web-UI push surface
+// (PLAN-2558 S3) in front of a multi-process deployment until it exists.
+// SessionPresence is an interface from day one so it can slot in without
+// touching the stream handler or the endpoint.
+//
+// (An earlier version of this note, written with BUG-2651, claimed
+// targeted delivery was fixed too. It was not: that claim was made from
+// reading the bus and this file without reading the push handler's gate,
+// and codex round 2 caught it.)
 
 // LiveSession is one currently-connected user-scoped event stream —
 // i.e. one `GET /api/v1/events/stream` connection being held open.

--- a/internal/server/session_presence.go
+++ b/internal/server/session_presence.go
@@ -30,26 +30,35 @@ import (
 // deployment (Pad Cloud) a session connected to instance A is invisible
 // to instance B, so /api/v1/sessions under-reports.
 //
-// The precise shape of that matters, because the obvious reading —
-// "presence lies about delivery" — is not quite it. watchevents.Bus has
-// the SAME per-process boundary: a push published on instance A never
-// reaches a stream held on instance B either. So presence and delivery
-// are blind in the same direction, and a request pair that lands on one
-// instance gets a presence answer that correctly predicts what a push
-// would do. What is NOT guaranteed is that the pair lands together — a
-// load balancer is free to route the POST and the GET to different
-// instances, and then the two disagree. So the honest statement is:
-// per-instance presence is as accurate as per-instance delivery, and
-// both stop being trustworthy at the same boundary, for the same
-// reason, and only a shared-state implementation fixes either.
+// THIS NOTE USED TO SAY presence and delivery were blind in the same
+// direction, and that the two had to be fixed together or not at all.
+// That was true when written and is no longer: BUG-2651 shipped
+// watchevents.RedisBus, so DELIVERY is now cross-instance — a push
+// published on A reaches a stream held on B, and B matches it against
+// its own live sessions, which is the only set B needs. What remains
+// per-process is exactly this registry, and it is worth being precise
+// about what that costs, because the two halves fail differently:
 //
-// Hence SessionPresence is an interface from day one: a Redis-backed
-// implementation must be able to slot in without touching the stream
-// handler or the endpoint — and it should land alongside the Redis
-// watchevents.Bus that package's doc comment already anticipates, not
-// separately, since fixing one without the other just moves the
-// disagreement. Do not put the web-UI push surface (PLAN-2558 S3) in
-// front of a multi-process deployment until both exist.
+//   - DELIVERY (fixed): a broadcast push — TargetUserID with no session
+//     id — used to reach only the sessions on whichever instance handled
+//     the POST. It now reaches all of that user's sessions. A
+//     session-targeted push likewise reaches the instance holding that
+//     session, wherever it is.
+//   - VISIBILITY (still open): GET /api/v1/sessions answers from ONE
+//     instance's registry, so a user whose session is held on B and who
+//     asks A sees nothing to target. That under-report is unchanged by
+//     BUG-2651 — it is neither better nor worse — so nothing regressed;
+//     a session a caller can SEE is by construction on the instance that
+//     listed it, and pushing to it works.
+//
+// So the remaining defect is a picker that under-reports, not a push
+// that lies. Do not put the web-UI push surface (PLAN-2558 S3) in front
+// of a multi-process deployment until a shared-state SessionPresence
+// exists: a picker that silently omits half a user's sessions is its own
+// kind of dishonest, even though every session it DOES list is real and
+// reachable. SessionPresence is an interface from day one so that
+// implementation can slot in without touching the stream handler or the
+// endpoint.
 
 // LiveSession is one currently-connected user-scoped event stream —
 // i.e. one `GET /api/v1/events/stream` connection being held open.

--- a/internal/watchevents/redis_bus.go
+++ b/internal/watchevents/redis_bus.go
@@ -389,12 +389,70 @@ const settleWindow = 250 * time.Millisecond
 // A failed read answers false — proceed on local knowledge. Turning a Redis
 // hiccup into a resync for every reconnecting client would be a worse failure
 // than the one this is guarding against.
+//
+// CHATTINESS BOUND, stated because it is the cost side of the lead's ruling
+// (chatty-but-correct beats quiet-but-lossy): the condition is agreement
+// between the two reads, so a resume that happens while publishing is
+// CONTINUOUS across the whole settle window can find them disagreeing every
+// time and resync. That is bounded by this stream being low-volume by design
+// (status changes, comments and pushes — the package's own sizing note calls
+// out that it is not the per-workspace firehose) and by resumes only
+// happening on reconnect. If a workload ever makes this chatty in practice,
+// the fix is a longer settle window, not a magnitude threshold.
 func (b *RedisBus) resumeOutrunsLocalView(sinceID int64) bool {
 	if sinceID <= 0 || b.client == nil {
 		return false
 	}
 
-	remote, err := b.client.Get(b.ctx, redisWatchSeqKey).Int64()
+	remote, ok := b.sharedCounter()
+	if !ok {
+		return false
+	}
+	if remote == b.highestSeen() {
+		return false
+	}
+
+	// Give propagation its beat, then re-read BOTH SIDES.
+	//
+	// Re-reading only the local side was the first version of this and it was
+	// wrong in both directions (codex round 11). The captured counter is a
+	// SNAPSHOT: if id 101 lands during the beat while 102 is published and
+	// missed, comparing against the stale 101 says "converged" and loses 102;
+	// and a GET that raced just before a publish can report a value BELOW
+	// what we already hold, which then never matches and resyncs a client
+	// that missed nothing.
+	//
+	// Agreement between the authority and this instance is the condition, and
+	// it has to be evaluated on two fresh reads or it is not agreement at all.
+	select {
+	case <-b.ctx.Done():
+		return false
+	case <-time.After(settleWindow):
+	}
+
+	remote, ok = b.sharedCounter()
+	if !ok {
+		return false
+	}
+	held := b.highestSeen()
+	if remote == held {
+		return false
+	}
+
+	// Any remaining disagreement is a gap, in either direction: still BEHIND
+	// means ids exist that never reached us, still AHEAD means the counter
+	// was reset under us and our buffer belongs to a dead id space. Both make
+	// this instance's replay untrustworthy for this cursor.
+	slog.Warn("watchevents: resume cannot be served from this instance's view; reporting a gap",
+		"since_id", sinceID, "highest_seen", held, "shared_counter", remote)
+	return true
+}
+
+// sharedCounter reads the authoritative sequence value. The bool is false when
+// it could not be read, which callers treat as "answer from local knowledge" —
+// see resumeOutrunsLocalView for why failing closed here would be worse.
+func (b *RedisBus) sharedCounter() (int64, bool) {
+	v, err := b.client.Get(b.ctx, redisWatchSeqKey).Int64()
 	if err != nil {
 		if err != redis.Nil {
 			slog.Warn("watchevents: could not read the sequence counter to validate a resume; "+
@@ -402,33 +460,15 @@ func (b *RedisBus) resumeOutrunsLocalView(sinceID int64) bool {
 		}
 		// redis.Nil means nothing has ever been published, so there is
 		// nothing this instance could have missed.
-		return false
+		return 0, false
 	}
+	return v, true
+}
 
+func (b *RedisBus) highestSeen() int64 {
 	b.mu.Lock()
-	held := b.lastAppendedID
-	b.mu.Unlock()
-	if remote == held {
-		return false
-	}
-
-	// Give propagation its beat before calling it a miss.
-	select {
-	case <-b.ctx.Done():
-		return false
-	case <-time.After(settleWindow):
-	}
-
-	b.mu.Lock()
-	held = b.lastAppendedID
-	b.mu.Unlock()
-	if remote == held {
-		return false
-	}
-
-	slog.Warn("watchevents: resume cannot be served from this instance's view; reporting a gap",
-		"since_id", sinceID, "highest_seen", held, "shared_counter", remote)
-	return true
+	defer b.mu.Unlock()
+	return b.lastAppendedID
 }
 
 // replaySince is replayBuffer.since plus the hole check. Callers must hold mu.

--- a/internal/watchevents/redis_bus.go
+++ b/internal/watchevents/redis_bus.go
@@ -366,6 +366,30 @@ func (b *RedisBus) replaySince(sinceID int64) []Notification {
 			return nil
 		}
 	}
+
+	// THE TRAILING GAP, known and open (codex round 10). Everything above
+	// reasons about what this instance HAS received. It cannot see a
+	// notification it missed at the END of the sequence: if we hold up to
+	// 100, miss 101 to a disconnect, and a client resumes from 100 before
+	// 102 arrives, there is nothing above 100 in the buffer and this
+	// answers "caught up". The hole only becomes visible when 102 lands,
+	// which is too late for the connection that already resumed.
+	//
+	// The one thing that WOULD reveal it is Redis itself: a GET of
+	// redisWatchSeqKey higher than lastAppendedID means ids exist that we
+	// have not seen. That same read also reveals a counter reset (a value
+	// BELOW ours), so one mechanism closes both open windows.
+	//
+	// Not done here because it is a genuine trade rather than an omission,
+	// and it is product-visible: INCR happens before the message
+	// propagates, so the counter legitimately runs ahead of any instance
+	// for microseconds after every publish. A strict comparison would turn
+	// normal in-flight traffic into spurious sync_required responses, and
+	// there is no principled tolerance to pick. Spurious resyncs are
+	// recoverable and a lost nudge is not — which is the argument FOR doing
+	// it — but that is a call about how chatty the resync path should be,
+	// so it goes to the plan rather than being settled here. Raised on
+	// BUG-2651's trail with both halves.
 	return b.replay.since(sinceID)
 }
 

--- a/internal/watchevents/redis_bus.go
+++ b/internal/watchevents/redis_bus.go
@@ -37,6 +37,24 @@ const (
 	// turn every replay-gap diagnosis into a question about the other bus.
 	redisWatchSeqKey = "pad:watchevents_seq"
 
+	// redisWatchEpochKey identifies the CURRENT id space, and exists because
+	// numeric detection alone cannot see a reset that has caught back up
+	// (codex round 13).
+	//
+	// The counter resetting is detectable when an id arrives BELOW our
+	// high-water mark. It is invisible when the new space has already climbed
+	// past it: hold 100, lose the connection, the counter resets and ids 1-101
+	// are published, and the only one that reaches us is 101 — which looks
+	// exactly like the contiguous successor of 100. The buffer then mixes two
+	// id spaces and a client resuming from OLD 100 is handed NEW 101, having
+	// silently missed the new space's 1-100.
+	//
+	// An epoch is the only thing that distinguishes them, because the
+	// question is not "is this number bigger" but "is this the same
+	// sequence". Minted once per id space by the publish script and carried
+	// on every message.
+	redisWatchEpochKey = "pad:watchevents_epoch"
+
 	// DEPLOYMENT SCOPING, or rather the lack of it (codex round 3). Both
 	// names above are fixed, so two Pad installations pointed at the SAME
 	// Redis endpoint cross-feed each other's notifications and share one id
@@ -88,8 +106,10 @@ var publishScript = redis.NewScript(`
 if redis.call('SET', KEYS[3], '1', 'NX', 'EX', ARGV[2]) == false then
   return 0
 end
+redis.call('SET', KEYS[4], ARGV[3], 'NX')
+local epoch = redis.call('GET', KEYS[4])
 local id = redis.call('INCR', KEYS[1])
-redis.call('PUBLISH', KEYS[2], id .. '|' .. ARGV[1])
+redis.call('PUBLISH', KEYS[2], epoch .. '|' .. id .. '|' .. ARGV[1])
 return id
 `)
 
@@ -185,6 +205,15 @@ type RedisBus struct {
 	// readable as MISSED rather than merely reordered.
 	knownFrom      int64
 	lastAppendedID int64
+
+	// epoch identifies the id space these ids belong to. A change means the
+	// counter was reset and the buffer describes a sequence that no longer
+	// exists — see redisWatchEpochKey and fanOutFromRedis.
+	epoch string
+	// epochJustChanged makes the next cold start refuse the
+	// contiguous-with-our-view cursor, because across an epoch boundary that
+	// cursor is ambiguous rather than contiguous. See fanOutLocally.
+	epochJustChanged bool
 
 	pubsub *redis.PubSub
 	ctx    context.Context
@@ -288,9 +317,11 @@ func (b *RedisBus) Publish(n Notification) {
 	// second run of the script sees the same token and declines.
 	dedupeKey := redisWatchDedupePrefix + uuid.NewString()
 
+	// The candidate epoch is only adopted when none exists (SET NX inside the
+	// script), so every publisher can offer one and exactly the first wins.
 	if err := publishScript.Run(b.ctx, b.client,
-		[]string{redisWatchSeqKey, redisWatchChannel, dedupeKey},
-		string(data), redisWatchDedupeTTLSeconds).Err(); err != nil {
+		[]string{redisWatchSeqKey, redisWatchChannel, dedupeKey, redisWatchEpochKey},
+		string(data), redisWatchDedupeTTLSeconds, uuid.NewString()).Err(); err != nil {
 		slog.Error("watchevents: dropping notification — Redis publish failed, so no globally ordered ID was assigned",
 			"error", err, "kind", n.Kind, "item_ref", n.ItemRef)
 	}
@@ -600,38 +631,46 @@ func (b *RedisBus) receiveMessages() {
 			if !ok {
 				return
 			}
-			n, err := decodePayload(msg.Payload)
+			epoch, n, err := decodePayload(msg.Payload)
 			if err != nil {
 				slog.Error("watchevents: failed to decode notification from Redis",
 					"error", err, "channel", msg.Channel)
 				continue
 			}
-			b.fanOutLocally(n)
+			b.fanOutFromRedis(epoch, n)
 		}
 	}
 }
 
-// decodePayload parses the "<id>|<json>" wire form publishScript emits.
+// decodePayload parses the "<epoch>|<id>|<json>" wire form publishScript emits.
+//
+// Splitting into exactly three parts on the FIRST two separators is what keeps
+// a '|' inside the JSON body harmless: the epoch is a uuid and the id is
+// digits, so neither can contain one.
 //
 // The id lives outside the JSON because it is assigned inside the Lua script,
 // atomically with the publish (see publishScript). Whatever ID the publisher
 // had in the struct is overwritten by the authoritative one — the publisher
 // never knows it, since the script assigns it after the marshal.
-func decodePayload(payload string) (Notification, error) {
-	sep := strings.IndexByte(payload, '|')
-	if sep < 0 {
-		return Notification{}, fmt.Errorf("payload has no id prefix")
+func decodePayload(payload string) (string, Notification, error) {
+	parts := strings.SplitN(payload, "|", 3)
+	if len(parts) != 3 {
+		return "", Notification{}, fmt.Errorf("payload is not <epoch>|<id>|<json>")
 	}
-	id, err := strconv.ParseInt(payload[:sep], 10, 64)
+	epoch, idPart, body := parts[0], parts[1], parts[2]
+	if epoch == "" {
+		return "", Notification{}, fmt.Errorf("payload has an empty epoch prefix")
+	}
+	id, err := strconv.ParseInt(idPart, 10, 64)
 	if err != nil {
-		return Notification{}, fmt.Errorf("payload id prefix %q is not an integer: %w", payload[:sep], err)
+		return "", Notification{}, fmt.Errorf("payload id prefix %q is not an integer: %w", idPart, err)
 	}
 	var n Notification
-	if err := json.Unmarshal([]byte(payload[sep+1:]), &n); err != nil {
-		return Notification{}, fmt.Errorf("payload body is not a Notification: %w", err)
+	if err := json.Unmarshal([]byte(body), &n); err != nil {
+		return "", Notification{}, fmt.Errorf("payload body is not a Notification: %w", err)
 	}
 	n.ID = id
-	return n, nil
+	return epoch, n, nil
 }
 
 // fanOutLocally appends to the replay buffer and sends to every live local
@@ -641,6 +680,34 @@ func decodePayload(payload string) (Notification, error) {
 // The notification already carries its globally assigned ID from the
 // publishing instance; nothing is renumbered here, which is what keeps
 // Last-Event-ID meaningful across instances.
+// fanOutFromRedis is the receive path's entry point: it applies the EPOCH
+// check, then hands off to fanOutLocally for the id-level bookkeeping.
+//
+// The two are separate because they answer different questions. The epoch asks
+// "is this the same id sequence I have been tracking" — a string comparison
+// that no arithmetic on ids can substitute for. fanOutLocally then asks "am I
+// contiguous within it". Numeric detection alone is blind to a reset that has
+// already climbed past our high-water mark (codex round 13), which is exactly
+// the case the epoch exists for.
+func (b *RedisBus) fanOutFromRedis(epoch string, n Notification) {
+	b.mu.Lock()
+	if b.epoch == "" {
+		b.epoch = epoch
+	} else if b.epoch != epoch {
+		slog.Warn("watchevents: the notification id space changed; dropping the replay buffer — "+
+			"resumes from the previous epoch will report sync_required",
+			"previous_epoch", b.epoch, "new_epoch", epoch, "id", n.ID)
+		b.epoch = epoch
+		b.replay = newReplayBuffer(b.replaySize)
+		b.lastAppendedID = 0
+		b.knownFrom = 0
+		b.epochJustChanged = true
+	}
+	b.mu.Unlock()
+
+	b.fanOutLocally(n)
+}
+
 func (b *RedisBus) fanOutLocally(n Notification) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -648,8 +715,24 @@ func (b *RedisBus) fanOutLocally(n Notification) {
 	// Coverage bookkeeping before the append — see knownFrom's comment.
 	switch {
 	case b.lastAppendedID == 0:
-		// Cold start: this instance knows nothing before this id.
+		// Cold start: this instance knows nothing before this id, so a client
+		// resuming from the id JUST BELOW it is contiguous with our view and
+		// can be served — knownFrom = n.ID admits exactly that cursor.
+		//
+		// UNLESS we just crossed an epoch, in which case that cursor is
+		// ambiguous rather than contiguous: id spaces can overlap, so a
+		// client presenting n.ID-1 might be holding the OLD sequence's
+		// n.ID-1, which was a different notification entirely. Admitting it
+		// would hand them the new epoch's id as though it followed theirs —
+		// which is the precise failure the epoch check exists to prevent, so
+		// letting it back in one line later would be a poor joke. One higher
+		// refuses it while still serving anyone genuinely inside the new
+		// space.
 		b.knownFrom = n.ID
+		if b.epochJustChanged {
+			b.knownFrom = n.ID + 1
+			b.epochJustChanged = false
+		}
 
 	case n.ID <= b.lastAppendedID:
 		// THE COUNTER WENT BACKWARDS, which means the id space itself

--- a/internal/watchevents/redis_bus.go
+++ b/internal/watchevents/redis_bus.go
@@ -34,6 +34,20 @@ const (
 	// whenever the other published — harmless for ordering, but it would
 	// turn every replay-gap diagnosis into a question about the other bus.
 	redisWatchSeqKey = "pad:watchevents_seq"
+
+	// DEPLOYMENT SCOPING, or rather the lack of it (codex round 3). Both
+	// names above are fixed, so two Pad installations pointed at the SAME
+	// Redis endpoint cross-feed each other's notifications and share one id
+	// counter — and selecting different logical DBs does not help, because
+	// Redis pub/sub is not namespaced by DB at all.
+	//
+	// Left unscoped deliberately: internal/events has used flat `pad:events:`
+	// / `pad:event_seq` names since it shipped, and giving one of the two
+	// buses a prefix the other lacks would make the operational rule harder
+	// to state, not easier. The rule for now is the simple one — one Redis
+	// endpoint per Pad installation — and if that ever needs relaxing it
+	// should be relaxed for both buses at once, from shared config, rather
+	// than growing here first.
 )
 
 // publishScript assigns the next id and publishes, ATOMICALLY.
@@ -113,6 +127,27 @@ type RedisBus struct {
 	subscribers map[chan Notification]struct{}
 	replay      *replayBuffer
 	closed      bool
+
+	// lastAppendedID / contiguousFrom detect a HOLE in the received
+	// sequence, which is a failure mode MemoryBus structurally cannot have
+	// and this one can (codex round 3).
+	//
+	// MemoryBus assigns every id itself, so its buffer is contiguous by
+	// construction and replayBuffer.since()'s only gap case is eviction —
+	// the buffer being full and the caller asking for something older than
+	// the oldest entry. Here the ids come from Redis and the delivery is
+	// at-most-once: a subscription that blips can miss 101 and receive 102.
+	// The buffer then holds a hole, is NOT full, and since() happily answers
+	// a resume from 100 with just [102] — 101 silently lost, no
+	// sync_required, and the consumer never learns it missed a nudge.
+	//
+	// contiguousFrom records the id at which the sequence resumed after the
+	// most recent hole (0 = none seen). A resume that would have to span it
+	// is answered as a gap instead. The atomic publish script is what makes
+	// this readable: publish order equals id order globally, so a
+	// non-consecutive id means a message was MISSED rather than reordered.
+	lastAppendedID int64
+	contiguousFrom int64
 
 	pubsub *redis.PubSub
 	ctx    context.Context
@@ -225,7 +260,22 @@ func (b *RedisBus) SubscribeAndReplaySince(sinceID int64) (chan Notification, []
 		return ch, nil
 	}
 	b.subscribers[ch] = struct{}{}
-	return ch, b.replay.since(sinceID)
+	return ch, b.replaySince(sinceID)
+}
+
+// replaySince is replayBuffer.since plus the hole check. Callers must hold mu.
+//
+// Returning nil is the same signal eviction already produces, and the SSE
+// handler already treats it as sync_required — so a missed notification
+// becomes a resync rather than a silent loss, which is the behaviour a
+// consumer of MemoryBus would expect and get.
+func (b *RedisBus) replaySince(sinceID int64) []Notification {
+	// sinceID == 0 is a fresh subscriber asking for everything buffered; it
+	// is not resuming from a position, so there is no position to span.
+	if sinceID > 0 && b.contiguousFrom > 0 && sinceID+1 < b.contiguousFrom {
+		return nil
+	}
+	return b.replay.since(sinceID)
 }
 
 func (b *RedisBus) Unsubscribe(ch chan Notification) {
@@ -240,7 +290,7 @@ func (b *RedisBus) Unsubscribe(ch chan Notification) {
 func (b *RedisBus) EventsSince(sinceID int64) []Notification {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	return b.replay.since(sinceID)
+	return b.replaySince(sinceID)
 }
 
 // Close stops the receive loop, closes the Redis subscription, and closes every
@@ -328,6 +378,16 @@ func decodePayload(payload string) (Notification, error) {
 func (b *RedisBus) fanOutLocally(n Notification) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
+
+	// Hole detection before the append — see lastAppendedID's comment.
+	if b.lastAppendedID != 0 && n.ID != b.lastAppendedID+1 {
+		slog.Warn("watchevents: gap in the received notification sequence; resumes across it will report sync_required",
+			"expected", b.lastAppendedID+1, "got", n.ID)
+		b.contiguousFrom = n.ID
+	}
+	if n.ID > b.lastAppendedID {
+		b.lastAppendedID = n.ID
+	}
 
 	b.replay.append(n)
 

--- a/internal/watchevents/redis_bus.go
+++ b/internal/watchevents/redis_bus.go
@@ -329,6 +329,11 @@ func (b *RedisBus) Subscribe() chan Notification {
 // only the replay is unavailable, and the caller should treat it like the SSE
 // handler's sync_required signal.
 func (b *RedisBus) SubscribeAndReplaySince(sinceID int64) (chan Notification, []Notification) {
+	// Consulted BEFORE the lock: it sleeps and does network I/O. See its
+	// comment for why that ordering is also the only one that preserves the
+	// subscribe-and-replay guarantee.
+	forceGap := b.resumeOutrunsLocalView(sinceID)
+
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	ch := make(chan Notification, 64)
@@ -337,7 +342,93 @@ func (b *RedisBus) SubscribeAndReplaySince(sinceID int64) (chan Notification, []
 		return ch, nil
 	}
 	b.subscribers[ch] = struct{}{}
+	if forceGap {
+		return ch, nil
+	}
 	return ch, b.replaySince(sinceID)
+}
+
+// settleWindow is how long resumeOutrunsLocalView waits before deciding that
+// ids it has not seen are MISSED rather than merely in flight.
+//
+// The counter is incremented inside the publish script, and the message then
+// has to reach this instance — so a counter running ahead of our high-water
+// mark is the NORMAL state for a moment after every publish. That window is
+// bounded by propagation time (a local network hop), while a genuinely missed
+// message never arrives at all. So the discriminator is TIME, not magnitude:
+// wait out the propagation window and re-read. This is the lead's ruling on
+// BUG-2651, and it is what avoids inventing an unprincipled "how many ids
+// behind is too many" threshold.
+const settleWindow = 250 * time.Millisecond
+
+// resumeOutrunsLocalView reports whether a resume from sinceID is asking about
+// ids this instance cannot vouch for, by asking the one authority that knows:
+// the shared counter.
+//
+// WHY THIS EXISTS. The local coverage bookkeeping (knownFrom) detects a hole
+// once a LATER id arrives to reveal it. It is blind to the trailing case —
+// hold 100, miss 101, client resumes from 100 before 102 lands — where the
+// buffer simply has nothing above the cursor and "caught up" is
+// indistinguishable from "nothing happened". A silently lost nudge is
+// unbounded staleness; a spurious resync costs one redundant fetch. That
+// asymmetry is why this is worth a network read on a path that only runs on
+// reconnect.
+//
+// It also catches the counter having gone BACKWARDS — a reset this instance
+// has not yet observed — because any DISAGREEMENT between the authority and
+// our high-water mark means our replay cannot be trusted for this cursor.
+//
+// Called WITHOUT the mutex held, and deliberately: it sleeps and does network
+// I/O, neither of which may happen inside the lock the fan-out needs. It is
+// also called BEFORE subscribing rather than between subscribe and replay,
+// which would reopen the double-delivery window SubscribeAndReplaySince
+// exists to close. Nothing is lost by waiting first: fanOutLocally appends to
+// the replay buffer regardless of who is subscribed, so anything arriving
+// during the settle beat is picked up by the replay read afterwards.
+//
+// A failed read answers false — proceed on local knowledge. Turning a Redis
+// hiccup into a resync for every reconnecting client would be a worse failure
+// than the one this is guarding against.
+func (b *RedisBus) resumeOutrunsLocalView(sinceID int64) bool {
+	if sinceID <= 0 || b.client == nil {
+		return false
+	}
+
+	remote, err := b.client.Get(b.ctx, redisWatchSeqKey).Int64()
+	if err != nil {
+		if err != redis.Nil {
+			slog.Warn("watchevents: could not read the sequence counter to validate a resume; "+
+				"answering from local knowledge only", "error", err)
+		}
+		// redis.Nil means nothing has ever been published, so there is
+		// nothing this instance could have missed.
+		return false
+	}
+
+	b.mu.Lock()
+	held := b.lastAppendedID
+	b.mu.Unlock()
+	if remote == held {
+		return false
+	}
+
+	// Give propagation its beat before calling it a miss.
+	select {
+	case <-b.ctx.Done():
+		return false
+	case <-time.After(settleWindow):
+	}
+
+	b.mu.Lock()
+	held = b.lastAppendedID
+	b.mu.Unlock()
+	if remote == held {
+		return false
+	}
+
+	slog.Warn("watchevents: resume cannot be served from this instance's view; reporting a gap",
+		"since_id", sinceID, "highest_seen", held, "shared_counter", remote)
+	return true
 }
 
 // replaySince is replayBuffer.since plus the hole check. Callers must hold mu.
@@ -367,29 +458,10 @@ func (b *RedisBus) replaySince(sinceID int64) []Notification {
 		}
 	}
 
-	// THE TRAILING GAP, known and open (codex round 10). Everything above
-	// reasons about what this instance HAS received. It cannot see a
-	// notification it missed at the END of the sequence: if we hold up to
-	// 100, miss 101 to a disconnect, and a client resumes from 100 before
-	// 102 arrives, there is nothing above 100 in the buffer and this
-	// answers "caught up". The hole only becomes visible when 102 lands,
-	// which is too late for the connection that already resumed.
-	//
-	// The one thing that WOULD reveal it is Redis itself: a GET of
-	// redisWatchSeqKey higher than lastAppendedID means ids exist that we
-	// have not seen. That same read also reveals a counter reset (a value
-	// BELOW ours), so one mechanism closes both open windows.
-	//
-	// Not done here because it is a genuine trade rather than an omission,
-	// and it is product-visible: INCR happens before the message
-	// propagates, so the counter legitimately runs ahead of any instance
-	// for microseconds after every publish. A strict comparison would turn
-	// normal in-flight traffic into spurious sync_required responses, and
-	// there is no principled tolerance to pick. Spurious resyncs are
-	// recoverable and a lost nudge is not — which is the argument FOR doing
-	// it — but that is a call about how chatty the resync path should be,
-	// so it goes to the plan rather than being settled here. Raised on
-	// BUG-2651's trail with both halves.
+	// NOTE: everything above reasons about what this instance HAS received,
+	// which cannot see a notification missed at the END of the sequence.
+	// That half is handled before the lock is taken — see
+	// resumeOutrunsLocalView, which the resume path consults.
 	return b.replay.since(sinceID)
 }
 
@@ -402,6 +474,20 @@ func (b *RedisBus) Unsubscribe(ch chan Notification) {
 	}
 }
 
+// EventsSince answers from THIS INSTANCE'S LOCAL VIEW ONLY, and deliberately
+// does not run resumeOutrunsLocalView's authority check.
+//
+// The asymmetry with SubscribeAndReplaySince is intentional rather than an
+// oversight. The Bus interface already documents EventsSince as the standalone
+// primitive "for tests and any future caller that doesn't need the atomic
+// subscribe-and-replay guarantee"; the SSE handler — the one caller whose
+// answer a user depends on — uses SubscribeAndReplaySince. Teaching this method
+// to sleep for a settle window and make a network call would surprise every one
+// of those callers for no benefit they asked for.
+//
+// If a future caller DOES need a trustworthy resume without subscribing, the
+// honest move is to give it the check explicitly, not to make this one
+// silently expensive.
 func (b *RedisBus) EventsSince(sinceID int64) []Notification {
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -524,14 +610,14 @@ func (b *RedisBus) fanOutLocally(n Notification) {
 		// in Redis and this instance only learns about it by receiving
 		// something.
 		//
-		// Not closed, deliberately. The shapes that would are a GET of the
-		// counter on every resume (network I/O on a latency-sensitive path,
-		// and it must not happen under this mutex — a Redis call inside the
-		// lock that fan-out needs is its own hazard) or a background poller
-		// (a goroutine and a Redis round trip per tick, forever, against a
-		// condition measured in years). The exposure is redelivery of
-		// notifications the client already has, bounded by the window and
-		// self-healing on the next publish.
+		// CLOSED, as of the trailing-gap work: resumeOutrunsLocalView reads
+		// the shared counter on every resume, and a value BELOW our
+		// high-water mark is exactly this reset seen from the other side. So
+		// a client reconnecting inside this window is told to resync rather
+		// than handed stale ids. This arm still matters — it is what repairs
+		// the instance's own state when the first post-reset message
+		// arrives, and it is the only thing that fixes a bus with no
+		// reconnecting clients at all.
 		slog.Warn("watchevents: notification id went backwards; the Redis sequence counter was reset. "+
 			"Dropping the replay buffer — resumes from the previous id space will report sync_required",
 			"previous", b.lastAppendedID, "got", n.ID)

--- a/internal/watchevents/redis_bus.go
+++ b/internal/watchevents/redis_bus.go
@@ -1,0 +1,283 @@
+package watchevents
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+const (
+	// redisWatchChannel is the single Redis pub/sub channel every instance
+	// publishes to and subscribes to.
+	//
+	// SINGLE, not per-workspace, unlike internal/events' pad:events:<wsID>.
+	// That is not a simplification of the template — it is this package's
+	// contract: there is exactly one logical watch stream and ALL per-caller
+	// filtering happens in the consumer (DOC-2479 DR-2, "no firehose, no
+	// wildcard subscriptions"). Subscribe() takes no workspace precisely
+	// because a subscriber is not scoped to one, so there is nothing to key a
+	// channel by.
+	redisWatchChannel = "pad:watchevents"
+
+	// redisWatchSeqKey is the shared counter behind Notification.ID.
+	//
+	// Deliberately distinct from internal/events' pad:event_seq: the two
+	// buses carry different streams with independent Last-Event-ID spaces,
+	// and sharing a counter would make each one's ids jump unpredictably
+	// whenever the other published — harmless for ordering, but it would
+	// turn every replay-gap diagnosis into a question about the other bus.
+	redisWatchSeqKey = "pad:watchevents_seq"
+)
+
+// RedisBus is the multi-instance implementation of Bus (BUG-2651). Every
+// instance publishes to one shared Redis channel and receives from it, so a
+// Notification produced on instance A reaches a stream held open on instance B
+// — the gap MemoryBus's package doc has flagged since this package existed.
+//
+// THREE THINGS DIFFER FROM internal/events.RedisBus, which is otherwise the
+// template. Each is deliberate, and each would look like a mistake to someone
+// diffing the two:
+//
+//  1. One channel and one replay buffer (see redisWatchChannel).
+//
+//  2. The Redis subscription is opened EAGERLY in NewRedisBus and lives for
+//     the bus's lifetime, rather than being started on the first local
+//     subscriber and torn down after the last. The replay buffer is filled by
+//     the RECEIVE path, so a lazily-torn-down subscription stops filling it at
+//     exactly the moment before a Last-Event-ID resume is attempted — for the
+//     common shape here (one harness monitor holding one stream, reconnecting)
+//     that would make resume structurally useless. events.RedisBus can afford
+//     lazy because per-workspace means N idle subscriptions; here it is one per
+//     instance, forever, which is the whole trade.
+//
+//  3. ONE mutex guards subscriber membership and the replay buffer together,
+//     and it is held across the entire local fan-out. events.RedisBus uses two
+//     (mu + replayMu) and exposes only separate Subscribe + EventsSince — a
+//     structure that cannot provide SubscribeAndReplaySince's guarantee. See
+//     that method's comment; reproducing the template's locking here would
+//     hand back a double-delivery window this package's interface exists to
+//     close.
+//
+// A publisher's OWN subscribers are served through the Redis round trip like
+// everyone else's — Publish never fans out locally. That costs a round trip of
+// latency and buys exactly-once delivery: a local send plus the echo back from
+// Redis would deliver twice to the publishing instance's own streams.
+type RedisBus struct {
+	client *redis.Client
+
+	// mu guards subscribers AND replay together — see the type comment (3)
+	// and SubscribeAndReplaySince.
+	mu          sync.Mutex
+	subscribers map[chan Notification]struct{}
+	replay      *replayBuffer
+	closed      bool
+
+	pubsub *redis.PubSub
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+}
+
+// NewRedisBus creates a Redis-backed Bus with the default replay buffer size
+// and opens the shared subscription immediately. The client should already be
+// configured; the caller is expected to have pinged it (cmd/pad/cmd_server.go
+// does, before either bus is constructed).
+func NewRedisBus(client *redis.Client) *RedisBus {
+	return NewRedisBusWithReplaySize(client, DefaultReplayBufferSize)
+}
+
+// NewRedisBusWithReplaySize is NewRedisBus with a custom replay capacity
+// (tests use a small one, exactly like NewWithReplaySize).
+func NewRedisBusWithReplaySize(client *redis.Client, size int) *RedisBus {
+	ctx, cancel := context.WithCancel(context.Background())
+	b := &RedisBus{
+		client:      client,
+		subscribers: make(map[chan Notification]struct{}),
+		replay:      newReplayBuffer(size),
+		ctx:         ctx,
+		cancel:      cancel,
+	}
+	// Eager subscription — see the type comment (2).
+	b.pubsub = client.Subscribe(ctx, redisWatchChannel)
+	b.wg.Add(1)
+	go b.receiveMessages()
+	return b
+}
+
+// Publish assigns a globally ordered ID via Redis INCR and publishes to the
+// shared channel. It does NOT deliver locally; the receive path does that for
+// every instance including this one.
+//
+// FAIL-CLOSED ON INCR FAILURE, and this is the one place this implementation
+// refuses to follow internal/events.RedisBus, which falls back to a local
+// counter. Two instances falling back at once mint ids from independent
+// counters into a SHARED stream, and replayBuffer.since() reasons on
+// monotonicity to detect gaps — so a disordered id does not degrade replay, it
+// corrupts it silently for every consumer until the buffer rolls over. Note
+// also what the fallback would actually buy: INCR and PUBLISH travel the same
+// connection, so an INCR failure almost always precedes a PUBLISH failure, and
+// the fallback mostly lets a doomed publish proceed carrying a poisoned id.
+// Dropping the notification loses a nudge in a deployment that is already
+// degraded; keeping it breaks resume for everyone.
+func (b *RedisBus) Publish(n Notification) {
+	if n.Timestamp == 0 {
+		n.Timestamp = time.Now().UnixMilli()
+	}
+
+	id, err := b.client.Incr(b.ctx, redisWatchSeqKey).Result()
+	if err != nil {
+		slog.Error("watchevents: dropping notification — Redis INCR failed, so no globally ordered ID is available",
+			"error", err, "kind", n.Kind, "item_ref", n.ItemRef)
+		return
+	}
+	n.ID = id
+
+	data, err := json.Marshal(n)
+	if err != nil {
+		slog.Error("watchevents: failed to marshal notification for Redis", "error", err, "kind", n.Kind)
+		return
+	}
+	if err := b.client.Publish(b.ctx, redisWatchChannel, data).Err(); err != nil {
+		slog.Error("watchevents: failed to publish notification to Redis",
+			"error", err, "channel", redisWatchChannel, "kind", n.Kind, "item_ref", n.ItemRef)
+	}
+}
+
+// Subscribe returns a channel receiving every future Notification, with no
+// replay — same contract as MemoryBus.Subscribe.
+func (b *RedisBus) Subscribe() chan Notification {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	ch := make(chan Notification, 64)
+	if b.closed {
+		// A subscriber registered after Close would never be closed by
+		// anyone. Hand back an already-closed channel so the consumer's
+		// range/select terminates instead of blocking forever.
+		close(ch)
+		return ch
+	}
+	b.subscribers[ch] = struct{}{}
+	return ch
+}
+
+// SubscribeAndReplaySince atomically registers the subscriber and captures the
+// buffered notifications above sinceID, under the SAME lock the local fan-out
+// holds.
+//
+// That shared lock is the whole mechanism, and it is why this type cannot
+// borrow events.RedisBus's two-lock layout. For any notification n and any
+// call to this method, one of two things is true: n's fan-out completed first,
+// so n is in the replay buffer and the channel it would have been sent to did
+// not yet exist; or the fan-out begins after, so n arrives on the channel and
+// the buffer read has already happened. Never both, never neither — the same
+// argument MemoryBus makes, one layer further out, with fan-out standing in
+// for Publish because that is where delivery happens here.
+//
+// Returns (ch, nil) when sinceID has been evicted; the subscription is valid,
+// only the replay is unavailable, and the caller should treat it like the SSE
+// handler's sync_required signal.
+func (b *RedisBus) SubscribeAndReplaySince(sinceID int64) (chan Notification, []Notification) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	ch := make(chan Notification, 64)
+	if b.closed {
+		close(ch)
+		return ch, nil
+	}
+	b.subscribers[ch] = struct{}{}
+	return ch, b.replay.since(sinceID)
+}
+
+func (b *RedisBus) Unsubscribe(ch chan Notification) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if _, ok := b.subscribers[ch]; ok {
+		delete(b.subscribers, ch)
+		close(ch)
+	}
+}
+
+func (b *RedisBus) EventsSince(sinceID int64) []Notification {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.replay.since(sinceID)
+}
+
+// Close stops the receive loop, closes the Redis subscription, and closes every
+// subscriber channel.
+//
+// The `closed` flag exists because this bus, unlike MemoryBus, has a goroutine
+// that can be mid-fan-out when Close runs: it takes the same mutex, so the two
+// serialize, but a Subscribe racing in afterwards would otherwise register a
+// channel nobody will ever close.
+func (b *RedisBus) Close() {
+	b.mu.Lock()
+	if b.closed {
+		b.mu.Unlock()
+		return
+	}
+	b.closed = true
+	for ch := range b.subscribers {
+		delete(b.subscribers, ch)
+		close(ch)
+	}
+	b.mu.Unlock()
+
+	b.cancel()
+	if b.pubsub != nil {
+		_ = b.pubsub.Close()
+	}
+	b.wg.Wait()
+}
+
+// receiveMessages is the single consumer of the shared Redis channel. Every
+// delivery on this instance — including for notifications this instance itself
+// published — comes through here.
+func (b *RedisBus) receiveMessages() {
+	defer b.wg.Done()
+	ch := b.pubsub.Channel()
+	for {
+		select {
+		case <-b.ctx.Done():
+			return
+		case msg, ok := <-ch:
+			if !ok {
+				return
+			}
+			var n Notification
+			if err := json.Unmarshal([]byte(msg.Payload), &n); err != nil {
+				slog.Error("watchevents: failed to unmarshal notification from Redis",
+					"error", err, "channel", msg.Channel)
+				continue
+			}
+			b.fanOutLocally(n)
+		}
+	}
+}
+
+// fanOutLocally appends to the replay buffer and sends to every live local
+// subscriber, under the single mutex — see SubscribeAndReplaySince for why
+// those two steps may not be separated.
+//
+// The notification already carries its globally assigned ID from the
+// publishing instance; nothing is renumbered here, which is what keeps
+// Last-Event-ID meaningful across instances.
+func (b *RedisBus) fanOutLocally(n Notification) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	b.replay.append(n)
+
+	for ch := range b.subscribers {
+		select {
+		case ch <- n:
+		default:
+			slog.Warn("watchevents: dropping notification for slow subscriber",
+				"kind", n.Kind, "item_ref", n.ItemRef)
+		}
+	}
+}

--- a/internal/watchevents/redis_bus.go
+++ b/internal/watchevents/redis_bus.go
@@ -86,10 +86,15 @@ const (
 // for one instance both complete before another instance's script begins:
 // publish order equals id order, globally, with no coordination on our side.
 //
-// The id is prepended to the payload as "<id>|<json>" rather than being
-// injected into the JSON, because string-editing JSON inside Lua is a fragile
-// way to save one split. The id is digits and the separator is the FIRST '|',
-// so a '|' anywhere in the payload is unambiguous.
+// The epoch and id are PREPENDED as "<epoch>|<id>|<json>" rather than injected
+// into the JSON, because string-editing JSON inside Lua is a fragile way to
+// save a split. The epoch is a uuid and the id is digits, so neither can
+// contain a '|' and splitting on the first two is unambiguous however the body
+// is punctuated.
+//
+// The epoch is not decoration: it is what distinguishes a reset id space from a
+// continuing one when the new space has already climbed past an instance's
+// high-water mark. See redisWatchEpochKey before considering it removable.
 // The dedupe key makes the script IDEMPOTENT UNDER RETRY, which it needs to be
 // because go-redis retries a command when the reply is lost to a network error
 // (codex round 5). Without it, a script that ran and whose reply never came
@@ -304,8 +309,8 @@ func (b *RedisBus) Publish(n Notification) {
 	}
 
 	// n.ID is assigned by the script, so it is marshalled zero and filled in
-	// by the receiver from the "<id>|" prefix. Serializing before the call is
-	// what lets the id assignment and the publish be one atomic step.
+	// by the receiver from the "<epoch>|<id>|" prefix. Serializing before the
+	// call is what lets the id assignment and the publish be one atomic step.
 	data, err := json.Marshal(n)
 	if err != nil {
 		slog.Error("watchevents: failed to marshal notification for Redis", "error", err, "kind", n.Kind)

--- a/internal/watchevents/redis_bus.go
+++ b/internal/watchevents/redis_bus.go
@@ -153,6 +153,7 @@ type RedisBus struct {
 	mu          sync.Mutex
 	subscribers map[chan Notification]struct{}
 	replay      *replayBuffer
+	replaySize  int
 	closed      bool
 
 	// knownFrom / lastAppendedID bound what this instance can HONESTLY
@@ -201,11 +202,22 @@ func NewRedisBus(client *redis.Client) *RedisBus {
 // NewRedisBusWithReplaySize is NewRedisBus with a custom replay capacity
 // (tests use a small one, exactly like NewWithReplaySize).
 func NewRedisBusWithReplaySize(client *redis.Client, size int) *RedisBus {
+	if size <= 0 {
+		// newReplayBuffer(0) returns a buffer whose first append panics on a
+		// zero-length backing slice. That was reachable here in a way it is
+		// not for MemoryBus, because the epoch-reset path REBUILDS the buffer
+		// at runtime — a bad size would turn a Redis counter reset into a
+		// crash rather than a resync. (MemoryBus's NewWithReplaySize has the
+		// same trap for a caller passing 0; left alone as pre-existing and
+		// off this bug's path, but it is the same trap.)
+		size = DefaultReplayBufferSize
+	}
 	ctx, cancel := context.WithCancel(context.Background())
 	b := &RedisBus{
 		client:      client,
 		subscribers: make(map[chan Notification]struct{}),
 		replay:      newReplayBuffer(size),
+		replaySize:  size,
 		ctx:         ctx,
 		cancel:      cancel,
 	}
@@ -449,14 +461,33 @@ func (b *RedisBus) fanOutLocally(n Notification) {
 	case b.lastAppendedID == 0:
 		// Cold start: this instance knows nothing before this id.
 		b.knownFrom = n.ID
+
+	case n.ID <= b.lastAppendedID:
+		// THE COUNTER WENT BACKWARDS, which means the id space itself
+		// restarted — pad:watchevents_seq evicted under maxmemory, lost to a
+		// FLUSHDB, or restored from an older snapshot (codex round 6). Ids
+		// are no longer comparable across that boundary, so KEEPING the old
+		// entries is what does the damage: the ring would hold 99,100,101
+		// alongside a fresh 1,2,3, and a resume from 2 would replay the
+		// stale hundreds as though they were newer.
+		//
+		// Dropping the buffer makes every resume from the old space answer
+		// nil instead — replayBuffer.since() returns nil once sinceID
+		// exceeds the newest id it holds, which after the reset is a small
+		// number — so those clients resync, which is the only honest
+		// outcome. Clients in the NEW space keep working immediately.
+		slog.Warn("watchevents: notification id went backwards; the Redis sequence counter was reset. "+
+			"Dropping the replay buffer — resumes from the previous id space will report sync_required",
+			"previous", b.lastAppendedID, "got", n.ID)
+		b.replay = newReplayBuffer(b.replaySize)
+		b.knownFrom = n.ID
+
 	case n.ID != b.lastAppendedID+1:
 		slog.Warn("watchevents: gap in the received notification sequence; resumes across it will report sync_required",
 			"expected", b.lastAppendedID+1, "got", n.ID)
 		b.knownFrom = n.ID
 	}
-	if n.ID > b.lastAppendedID {
-		b.lastAppendedID = n.ID
-	}
+	b.lastAppendedID = n.ID
 
 	b.replay.append(n)
 

--- a/internal/watchevents/redis_bus.go
+++ b/internal/watchevents/redis_bus.go
@@ -349,8 +349,22 @@ func (b *RedisBus) SubscribeAndReplaySince(sinceID int64) (chan Notification, []
 func (b *RedisBus) replaySince(sinceID int64) []Notification {
 	// sinceID == 0 is a fresh subscriber asking for everything buffered; it
 	// is not resuming from a position, so there is no position to span.
-	if sinceID > 0 && b.knownFrom > 0 && sinceID+1 < b.knownFrom {
-		return nil
+	if sinceID > 0 {
+		// knownFrom == 0 means this instance has received NOTHING yet, which
+		// is strictly LESS knowledge than "contiguous from X" and must
+		// therefore produce at least as strong a signal (codex round 9). The
+		// earlier version skipped the check entirely in that state, so an
+		// empty buffer answered any cursor with an empty-but-non-nil slice —
+		// which the SSE handler reads as "caught up".
+		//
+		// The scenario is a restart, not an exotic one: replica B comes up
+		// while Redis is at 100, id 101 is published before B's subscription
+		// is live, and a client reconnects to B with Last-Event-ID 100 before
+		// 102 arrives. B says caught-up, then delivers 102, and 101 is gone
+		// with nothing to tell anyone.
+		if b.knownFrom == 0 || sinceID+1 < b.knownFrom {
+			return nil
+		}
 	}
 	return b.replay.since(sinceID)
 }

--- a/internal/watchevents/redis_bus.go
+++ b/internal/watchevents/redis_bus.go
@@ -3,6 +3,7 @@ package watchevents
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strconv"
@@ -409,6 +410,17 @@ func (b *RedisBus) resumeOutrunsLocalView(sinceID int64) bool {
 		return false
 	}
 	if remote == b.highestSeen() {
+		// Agreed as of this instant, so there is nothing to settle for.
+		//
+		// WHAT THIS DOES NOT COVER, and cannot (codex round 12): a
+		// notification published AFTER this read and missed by this instance
+		// is invisible to any check made here — and shrinking the window by
+		// settling anyway would not close it, since the same race exists in
+		// the instant after this function returns. The check's honest scope
+		// is "what was missed BEFORE the resume"; a message missed after it
+		// is a property of at-most-once pub/sub with no per-connection ack,
+		// and the only real answer to that is a durable stream (Redis
+		// Streams with consumer groups) rather than a longer wait here.
 		return false
 	}
 
@@ -453,16 +465,29 @@ func (b *RedisBus) resumeOutrunsLocalView(sinceID int64) bool {
 // see resumeOutrunsLocalView for why failing closed here would be worse.
 func (b *RedisBus) sharedCounter() (int64, bool) {
 	v, err := b.client.Get(b.ctx, redisWatchSeqKey).Int64()
-	if err != nil {
-		if err != redis.Nil {
-			slog.Warn("watchevents: could not read the sequence counter to validate a resume; "+
-				"answering from local knowledge only", "error", err)
-		}
-		// redis.Nil means nothing has ever been published, so there is
-		// nothing this instance could have missed.
+	switch {
+	case err == nil:
+		return v, true
+	case errors.Is(err, redis.Nil):
+		// ABSENT IS A VALUE, NOT A FAILURE, and reading it as the latter was
+		// a bug (codex round 12). "No counter" legitimately means zero — on a
+		// fresh deployment nothing has been published, so there is nothing to
+		// have missed and 0 == 0 agrees with an instance that has seen
+		// nothing. But the key can also DISAPPEAR after this bus has seen
+		// ids, via FLUSHDB or eviction, and treating that as unreadable meant
+		// falling back to local knowledge and cheerfully replaying an id
+		// space the authority no longer has — while the next publish starts
+		// again at 1.
+		//
+		// Returning 0-and-readable makes that case fall out of the ordinary
+		// comparison: an instance holding 101 disagrees with an authority at
+		// 0, does not converge, and the resume is answered with a gap.
+		return 0, true
+	default:
+		slog.Warn("watchevents: could not read the sequence counter to validate a resume; "+
+			"answering from local knowledge only", "error", err)
 		return 0, false
 	}
-	return v, true
 }
 
 func (b *RedisBus) highestSeen() int64 {

--- a/internal/watchevents/redis_bus.go
+++ b/internal/watchevents/redis_bus.go
@@ -476,6 +476,24 @@ func (b *RedisBus) fanOutLocally(n Notification) {
 		// exceeds the newest id it holds, which after the reset is a small
 		// number — so those clients resync, which is the only honest
 		// outcome. Clients in the NEW space keep working immediately.
+		//
+		// RESIDUAL WINDOW, accepted (codex round 8). This fires when the
+		// first post-reset notification ARRIVES, so between the counter
+		// resetting and the next publish, this instance still holds and will
+		// still replay the old ids. A client reconnecting inside that window
+		// with a low Last-Event-ID gets buffered entries it has already
+		// seen. Nothing here can detect the reset earlier: the counter lives
+		// in Redis and this instance only learns about it by receiving
+		// something.
+		//
+		// Not closed, deliberately. The shapes that would are a GET of the
+		// counter on every resume (network I/O on a latency-sensitive path,
+		// and it must not happen under this mutex — a Redis call inside the
+		// lock that fan-out needs is its own hazard) or a background poller
+		// (a goroutine and a Redis round trip per tick, forever, against a
+		// condition measured in years). The exposure is redelivery of
+		// notifications the client already has, bounded by the window and
+		// self-healing on the next publish.
 		slog.Warn("watchevents: notification id went backwards; the Redis sequence counter was reset. "+
 			"Dropping the replay buffer — resumes from the previous id space will report sync_required",
 			"previous", b.lastAppendedID, "got", n.ID)

--- a/internal/watchevents/redis_bus.go
+++ b/internal/watchevents/redis_bus.go
@@ -3,7 +3,10 @@ package watchevents
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -32,6 +35,32 @@ const (
 	// turn every replay-gap diagnosis into a question about the other bus.
 	redisWatchSeqKey = "pad:watchevents_seq"
 )
+
+// publishScript assigns the next id and publishes, ATOMICALLY.
+//
+// Doing those as two client calls is not merely unlocked, it is actively
+// order-breaking, and the failure is not theoretical (Codex round 1 P1):
+// instance A runs INCR and gets 1, is descheduled; instance B runs INCR, gets
+// 2, and publishes; A then publishes 1. Every subscriber receives 2 before 1.
+// The replay buffer appends in ARRIVAL order, so it now holds a non-monotonic
+// sequence, and replayBuffer.since() reasons on monotonicity: a resume from 2
+// takes the `sinceID > newestID` branch and answers "gap too large", turning a
+// perfectly healthy reconnect into a spurious sync_required, while a resume
+// from 1 silently skips the notification that arrived late.
+//
+// Redis executes a script atomically on its single thread, so INCR and PUBLISH
+// for one instance both complete before another instance's script begins:
+// publish order equals id order, globally, with no coordination on our side.
+//
+// The id is prepended to the payload as "<id>|<json>" rather than being
+// injected into the JSON, because string-editing JSON inside Lua is a fragile
+// way to save one split. The id is digits and the separator is the FIRST '|',
+// so a '|' anywhere in the payload is unambiguous.
+var publishScript = redis.NewScript(`
+local id = redis.call('INCR', KEYS[1])
+redis.call('PUBLISH', KEYS[2], id .. '|' .. ARGV[1])
+return id
+`)
 
 // RedisBus is the multi-instance implementation of Bus (BUG-2651). Every
 // instance publishes to one shared Redis channel and receives from it, so a
@@ -64,8 +93,17 @@ const (
 //
 // A publisher's OWN subscribers are served through the Redis round trip like
 // everyone else's — Publish never fans out locally. That costs a round trip of
-// latency and buys exactly-once delivery: a local send plus the echo back from
+// latency and buys NO-DOUBLE-DELIVERY: a local send plus the echo back from
 // Redis would deliver twice to the publishing instance's own streams.
+//
+// Not "exactly-once", which an earlier draft of this comment claimed and which
+// is not on offer at any layer here (Codex round 1). Redis pub/sub is
+// at-most-once — a subscriber that is disconnected when a message is published
+// never sees it — and the local send is deliberately non-blocking, so a slow
+// subscriber's notification is dropped and logged rather than awaited. The
+// replay buffer plus Last-Event-ID is the recovery mechanism for both, and it
+// is bounded: DefaultReplayBufferSize entries, after which a resume answers
+// "gap too large" and the consumer resyncs.
 type RedisBus struct {
 	client *redis.Client
 
@@ -108,42 +146,40 @@ func NewRedisBusWithReplaySize(client *redis.Client, size int) *RedisBus {
 	return b
 }
 
-// Publish assigns a globally ordered ID via Redis INCR and publishes to the
-// shared channel. It does NOT deliver locally; the receive path does that for
-// every instance including this one.
+// Publish hands the notification to publishScript, which assigns its globally
+// ordered ID and publishes it in one atomic step. It does NOT deliver locally;
+// the receive path does that for every instance including this one.
 //
-// FAIL-CLOSED ON INCR FAILURE, and this is the one place this implementation
-// refuses to follow internal/events.RedisBus, which falls back to a local
-// counter. Two instances falling back at once mint ids from independent
-// counters into a SHARED stream, and replayBuffer.since() reasons on
-// monotonicity to detect gaps — so a disordered id does not degrade replay, it
-// corrupts it silently for every consumer until the buffer rolls over. Note
-// also what the fallback would actually buy: INCR and PUBLISH travel the same
-// connection, so an INCR failure almost always precedes a PUBLISH failure, and
-// the fallback mostly lets a doomed publish proceed carrying a poisoned id.
+// FAIL-CLOSED, where internal/events.RedisBus falls back to a local counter
+// when its id lookup fails. Two instances falling back at once mint ids from
+// independent counters into a SHARED stream, and replayBuffer.since() reasons
+// on monotonicity to detect gaps — so a disordered id does not degrade replay,
+// it corrupts it silently for every consumer until the buffer rolls over.
 // Dropping the notification loses a nudge in a deployment that is already
 // degraded; keeping it breaks resume for everyone.
+//
+// Folding the id assignment INTO the publish also removed the only case where
+// that fallback could have applied: there is no longer a window in which an id
+// exists but the publish has not happened, so "assign or don't" and "publish
+// or don't" are the same decision.
 func (b *RedisBus) Publish(n Notification) {
 	if n.Timestamp == 0 {
 		n.Timestamp = time.Now().UnixMilli()
 	}
 
-	id, err := b.client.Incr(b.ctx, redisWatchSeqKey).Result()
-	if err != nil {
-		slog.Error("watchevents: dropping notification — Redis INCR failed, so no globally ordered ID is available",
-			"error", err, "kind", n.Kind, "item_ref", n.ItemRef)
-		return
-	}
-	n.ID = id
-
+	// n.ID is assigned by the script, so it is marshalled zero and filled in
+	// by the receiver from the "<id>|" prefix. Serializing before the call is
+	// what lets the id assignment and the publish be one atomic step.
 	data, err := json.Marshal(n)
 	if err != nil {
 		slog.Error("watchevents: failed to marshal notification for Redis", "error", err, "kind", n.Kind)
 		return
 	}
-	if err := b.client.Publish(b.ctx, redisWatchChannel, data).Err(); err != nil {
-		slog.Error("watchevents: failed to publish notification to Redis",
-			"error", err, "channel", redisWatchChannel, "kind", n.Kind, "item_ref", n.ItemRef)
+
+	if err := publishScript.Run(b.ctx, b.client,
+		[]string{redisWatchSeqKey, redisWatchChannel}, string(data)).Err(); err != nil {
+		slog.Error("watchevents: dropping notification — Redis publish failed, so no globally ordered ID was assigned",
+			"error", err, "kind", n.Kind, "item_ref", n.ItemRef)
 	}
 }
 
@@ -248,15 +284,38 @@ func (b *RedisBus) receiveMessages() {
 			if !ok {
 				return
 			}
-			var n Notification
-			if err := json.Unmarshal([]byte(msg.Payload), &n); err != nil {
-				slog.Error("watchevents: failed to unmarshal notification from Redis",
+			n, err := decodePayload(msg.Payload)
+			if err != nil {
+				slog.Error("watchevents: failed to decode notification from Redis",
 					"error", err, "channel", msg.Channel)
 				continue
 			}
 			b.fanOutLocally(n)
 		}
 	}
+}
+
+// decodePayload parses the "<id>|<json>" wire form publishScript emits.
+//
+// The id lives outside the JSON because it is assigned inside the Lua script,
+// atomically with the publish (see publishScript). Whatever ID the publisher
+// had in the struct is overwritten by the authoritative one — the publisher
+// never knows it, since the script assigns it after the marshal.
+func decodePayload(payload string) (Notification, error) {
+	sep := strings.IndexByte(payload, '|')
+	if sep < 0 {
+		return Notification{}, fmt.Errorf("payload has no id prefix")
+	}
+	id, err := strconv.ParseInt(payload[:sep], 10, 64)
+	if err != nil {
+		return Notification{}, fmt.Errorf("payload id prefix %q is not an integer: %w", payload[:sep], err)
+	}
+	var n Notification
+	if err := json.Unmarshal([]byte(payload[sep+1:]), &n); err != nil {
+		return Notification{}, fmt.Errorf("payload body is not a Notification: %w", err)
+	}
+	n.ID = id
+	return n, nil
 }
 
 // fanOutLocally appends to the replay buffer and sends to every live local

--- a/internal/watchevents/redis_bus.go
+++ b/internal/watchevents/redis_bus.go
@@ -128,26 +128,34 @@ type RedisBus struct {
 	replay      *replayBuffer
 	closed      bool
 
-	// lastAppendedID / contiguousFrom detect a HOLE in the received
-	// sequence, which is a failure mode MemoryBus structurally cannot have
-	// and this one can (codex round 3).
+	// knownFrom / lastAppendedID bound what this instance can HONESTLY
+	// replay — a failure mode MemoryBus structurally cannot have and this
+	// one can (codex rounds 3 and 4).
 	//
 	// MemoryBus assigns every id itself, so its buffer is contiguous by
 	// construction and replayBuffer.since()'s only gap case is eviction —
 	// the buffer being full and the caller asking for something older than
-	// the oldest entry. Here the ids come from Redis and the delivery is
-	// at-most-once: a subscription that blips can miss 101 and receive 102.
-	// The buffer then holds a hole, is NOT full, and since() happily answers
-	// a resume from 100 with just [102] — 101 silently lost, no
-	// sync_required, and the consumer never learns it missed a nudge.
+	// the oldest entry. Here the ids come from Redis, and this instance's
+	// view has TWO ways of not covering what a client asks for:
 	//
-	// contiguousFrom records the id at which the sequence resumed after the
-	// most recent hole (0 = none seen). A resume that would have to span it
-	// is answered as a gap instead. The atomic publish script is what makes
-	// this readable: publish order equals id order globally, so a
-	// non-consecutive id means a message was MISSED rather than reordered.
+	//  1. A HOLE. Delivery is at-most-once, so a subscription that blips can
+	//     miss 101 and receive 102. The buffer then holds a hole, is nowhere
+	//     near full, and since() would answer a resume from 100 with just
+	//     [102] — 101 silently lost, no sync_required.
+	//  2. A COLD START, which the first version of this missed. A replica
+	//     that restarts while Redis is at 101 has an EMPTY buffer and no
+	//     lastAppendedID, so its first received message (say 102) recorded no
+	//     hole at all. A client reconnecting to it with Last-Event-ID 100
+	//     silently skipped 101 by exactly the same route.
+	//
+	// knownFrom collapses both: it is the lowest id from which this
+	// instance's buffer is contiguous. It is SET on the first append (before
+	// which we know nothing) and RESET on every hole (before which we no
+	// longer know anything usable). A resume from below it is answered as a
+	// gap. The atomic publish script is what makes a non-consecutive id
+	// readable as MISSED rather than merely reordered.
+	knownFrom      int64
 	lastAppendedID int64
-	contiguousFrom int64
 
 	pubsub *redis.PubSub
 	ctx    context.Context
@@ -272,7 +280,7 @@ func (b *RedisBus) SubscribeAndReplaySince(sinceID int64) (chan Notification, []
 func (b *RedisBus) replaySince(sinceID int64) []Notification {
 	// sinceID == 0 is a fresh subscriber asking for everything buffered; it
 	// is not resuming from a position, so there is no position to span.
-	if sinceID > 0 && b.contiguousFrom > 0 && sinceID+1 < b.contiguousFrom {
+	if sinceID > 0 && b.knownFrom > 0 && sinceID+1 < b.knownFrom {
 		return nil
 	}
 	return b.replay.since(sinceID)
@@ -379,11 +387,15 @@ func (b *RedisBus) fanOutLocally(n Notification) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	// Hole detection before the append — see lastAppendedID's comment.
-	if b.lastAppendedID != 0 && n.ID != b.lastAppendedID+1 {
+	// Coverage bookkeeping before the append — see knownFrom's comment.
+	switch {
+	case b.lastAppendedID == 0:
+		// Cold start: this instance knows nothing before this id.
+		b.knownFrom = n.ID
+	case n.ID != b.lastAppendedID+1:
 		slog.Warn("watchevents: gap in the received notification sequence; resumes across it will report sync_required",
 			"expected", b.lastAppendedID+1, "got", n.ID)
-		b.contiguousFrom = n.ID
+		b.knownFrom = n.ID
 	}
 	if n.ID > b.lastAppendedID {
 		b.lastAppendedID = n.ID

--- a/internal/watchevents/redis_bus.go
+++ b/internal/watchevents/redis_bus.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/redis/go-redis/v9"
 )
 
@@ -70,11 +71,37 @@ const (
 // injected into the JSON, because string-editing JSON inside Lua is a fragile
 // way to save one split. The id is digits and the separator is the FIRST '|',
 // so a '|' anywhere in the payload is unambiguous.
+// The dedupe key makes the script IDEMPOTENT UNDER RETRY, which it needs to be
+// because go-redis retries a command when the reply is lost to a network error
+// (codex round 5). Without it, a script that ran and whose reply never came
+// back would run AGAIN on retry: the same notification published twice under
+// two different ids. Both copies look perfectly valid — correct ordering,
+// distinct ids — so nothing downstream could tell them apart, and on the push
+// path a duplicate is a duplicate DISPATCH into an agent harness, not just a
+// repeated line in a feed.
+//
+// SET NX on a caller-generated token turns the retry into a no-op: the retry
+// carries the same KEYS[3], the SET fails, and the script returns 0 without
+// publishing. The TTL only has to outlive a retry burst, not a session.
 var publishScript = redis.NewScript(`
+if redis.call('SET', KEYS[3], '1', 'NX', 'EX', ARGV[2]) == false then
+  return 0
+end
 local id = redis.call('INCR', KEYS[1])
 redis.call('PUBLISH', KEYS[2], id .. '|' .. ARGV[1])
 return id
 `)
+
+const (
+	// redisWatchDedupePrefix namespaces the per-publish idempotency tokens.
+	redisWatchDedupePrefix = "pad:watchevents:pub:"
+
+	// redisWatchDedupeTTLSeconds bounds how long a token is remembered. It
+	// only has to cover a client-side retry burst — go-redis gives up after
+	// MaxRetries with backoff measured in milliseconds — so a minute is
+	// generous, and the keys are small and expire on their own.
+	redisWatchDedupeTTLSeconds = 60
+)
 
 // RedisBus is the multi-instance implementation of Bus (BUG-2651). Every
 // instance publishes to one shared Redis channel and receives from it, so a
@@ -184,6 +211,30 @@ func NewRedisBusWithReplaySize(client *redis.Client, size int) *RedisBus {
 	}
 	// Eager subscription — see the type comment (2).
 	b.pubsub = client.Subscribe(ctx, redisWatchChannel)
+
+	// WAIT FOR THE SUBSCRIBE TO BE CONFIRMED before returning. go-redis
+	// establishes the subscription asynchronously, so without this the
+	// constructor hands back a bus that is not yet listening — and Redis
+	// pub/sub is at-most-once, so everything published in that window is
+	// lost to this instance, silently.
+	//
+	// Found as a test flake (a second bus constructed and published to
+	// immediately received nothing), which is exactly the shape a rolling
+	// deploy has: a replica comes up, and traffic reaches it before its
+	// subscription is live. The window is small and entirely real.
+	//
+	// A failure here is logged rather than fatal: the receive loop's
+	// Channel() re-subscribes on reconnect, so a bus that missed its first
+	// confirmation still recovers — it just cannot promise it was listening
+	// from the moment it was constructed.
+	subCtx, subCancel := context.WithTimeout(ctx, 5*time.Second)
+	defer subCancel()
+	if _, err := b.pubsub.Receive(subCtx); err != nil {
+		slog.Warn("watchevents: Redis subscription not confirmed at construction; "+
+			"notifications published before it establishes will be missed by this instance",
+			"error", err, "channel", redisWatchChannel)
+	}
+
 	b.wg.Add(1)
 	go b.receiveMessages()
 	return b
@@ -219,8 +270,14 @@ func (b *RedisBus) Publish(n Notification) {
 		return
 	}
 
+	// A fresh token per logical publish — NOT per attempt, which is the
+	// point: go-redis reuses the same arguments on its own retries, so the
+	// second run of the script sees the same token and declines.
+	dedupeKey := redisWatchDedupePrefix + uuid.NewString()
+
 	if err := publishScript.Run(b.ctx, b.client,
-		[]string{redisWatchSeqKey, redisWatchChannel}, string(data)).Err(); err != nil {
+		[]string{redisWatchSeqKey, redisWatchChannel, dedupeKey},
+		string(data), redisWatchDedupeTTLSeconds).Err(); err != nil {
 		slog.Error("watchevents: dropping notification — Redis publish failed, so no globally ordered ID was assigned",
 			"error", err, "kind", n.Kind, "item_ref", n.ItemRef)
 	}

--- a/internal/watchevents/redis_bus_integration_test.go
+++ b/internal/watchevents/redis_bus_integration_test.go
@@ -1,0 +1,210 @@
+package watchevents
+
+// BUG-2651 — the half the hermetic tests structurally cannot reach: the actual
+// Redis round trip.
+//
+// Codex raised the gap three times, and it was right to: the publish path is a
+// Lua script with KEYS/ARGV indexing, a wire format with an id prefix, a
+// channel name, and a subscription lifecycle — none of which a test that calls
+// fanOutLocally directly can exercise. The argument became concrete when the
+// idempotency script shipped with `ARGV[3]` while Publish passed two arguments.
+// That bug was caught by re-reading, which is not a control I want to rely on
+// for the next one.
+//
+// miniredis is a test-only dependency (an in-process Redis with a Lua
+// interpreter). It is not a substitute for a real server — it is an
+// implementation of the same protocol — so a failure here is meaningful and a
+// pass is good evidence rather than proof.
+
+import (
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+)
+
+func newMiniredisBus(t *testing.T, size int) (*RedisBus, *miniredis.Miniredis) {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+
+	b := NewRedisBusWithReplaySize(client, size)
+	t.Cleanup(b.Close)
+	return b, mr
+}
+
+// waitFor polls until cond holds or the deadline passes. Delivery crosses a
+// goroutine and a socket, so a bare read after Publish is a race.
+func waitFor(t *testing.T, what string, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", what)
+}
+
+// TestRedisBusRoundTripDeliversToTheSameInstance is the end-to-end path: a
+// notification published here goes out to Redis, comes back through the
+// subscription, and lands on a local subscriber with an id assigned by the
+// script.
+//
+// It is also the only test that would catch a wrong channel name, a broken
+// KEYS/ARGV mapping, or a receive goroutine that never started.
+func TestRedisBusRoundTripDeliversToTheSameInstance(t *testing.T) {
+	b, _ := newMiniredisBus(t, 64)
+
+	ch := b.Subscribe()
+	b.Publish(Notification{Kind: KindComment, ItemRef: "TASK-1", Summary: "hello"})
+
+	select {
+	case n := <-ch:
+		if n.ItemRef != "TASK-1" || n.Summary != "hello" {
+			t.Errorf("payload did not survive the round trip: %+v", n)
+		}
+		if n.ID != 1 {
+			t.Errorf("id: got %d, want 1 — the script assigns it from the shared counter", n.ID)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("notification never came back through Redis; check the channel name and the receive goroutine")
+	}
+}
+
+// TestRedisBusRoundTripCrossInstance is the actual bug being fixed: two buses
+// on one Redis, one publishes, the OTHER receives. This is the case MemoryBus
+// cannot do at all.
+func TestRedisBusRoundTripCrossInstance(t *testing.T) {
+	a, mr := newMiniredisBus(t, 64)
+
+	clientB := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = clientB.Close() })
+	busB := NewRedisBusWithReplaySize(clientB, 64)
+	t.Cleanup(busB.Close)
+
+	chB := busB.Subscribe()
+
+	// Published on A.
+	a.Publish(Notification{Kind: KindPush, ItemRef: "TASK-9", Summary: "from A"})
+
+	select {
+	case n := <-chB:
+		if n.ItemRef != "TASK-9" || n.Summary != "from A" {
+			t.Errorf("instance B received the wrong payload: %+v", n)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("a notification published on instance A never reached instance B — " +
+			"this is the entire point of BUG-2651")
+	}
+}
+
+// TestRedisBusIDsAreSharedAcrossInstances pins the shared counter: ids come
+// from one Redis key, so two instances publishing interleaved do not both
+// start at 1.
+func TestRedisBusIDsAreSharedAcrossInstances(t *testing.T) {
+	a, mr := newMiniredisBus(t, 64)
+
+	clientB := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = clientB.Close() })
+	busB := NewRedisBusWithReplaySize(clientB, 64)
+	t.Cleanup(busB.Close)
+
+	ch := a.Subscribe()
+
+	a.Publish(Notification{Kind: KindComment, ItemRef: "TASK-1"})
+	busB.Publish(Notification{Kind: KindComment, ItemRef: "TASK-2"})
+	a.Publish(Notification{Kind: KindComment, ItemRef: "TASK-3"})
+
+	var ids []int64
+	for i := 0; i < 3; i++ {
+		select {
+		case n := <-ch:
+			ids = append(ids, n.ID)
+		case <-time.After(3 * time.Second):
+			t.Fatalf("only received %d of 3 notifications: %v", len(ids), ids)
+		}
+	}
+	for i, want := range []int64{1, 2, 3} {
+		if ids[i] != want {
+			t.Fatalf("ids %v — want 1,2,3 in order; a per-instance counter would repeat, "+
+				"and a non-atomic assign could reorder", ids)
+		}
+	}
+}
+
+// TestRedisBusPublishIsIdempotentUnderRetry drives the dedupe token directly:
+// running the SAME script arguments twice is what go-redis does when a reply is
+// lost, and the second run must publish nothing.
+//
+// Calling the script twice by hand is the honest way to test this — provoking a
+// real lost-reply retry is not something miniredis can be asked for, and a test
+// that pretended to would be testing its own mock.
+func TestRedisBusPublishIsIdempotentUnderRetry(t *testing.T) {
+	b, _ := newMiniredisBus(t, 64)
+	ch := b.Subscribe()
+
+	const token = redisWatchDedupePrefix + "fixed-token-for-this-test"
+	keys := []string{redisWatchSeqKey, redisWatchChannel, token}
+	payload := `{"ItemRef":"TASK-1","Kind":"comment"}`
+
+	first, err := publishScript.Run(b.ctx, b.client, keys, payload, redisWatchDedupeTTLSeconds).Int64()
+	if err != nil {
+		t.Fatalf("first run: %v", err)
+	}
+	if first != 1 {
+		t.Fatalf("first run returned id %d, want 1", first)
+	}
+
+	second, err := publishScript.Run(b.ctx, b.client, keys, payload, redisWatchDedupeTTLSeconds).Int64()
+	if err != nil {
+		t.Fatalf("second run: %v", err)
+	}
+	if second != 0 {
+		t.Fatalf("second run with the same token returned id %d, want 0 — a retried script must not "+
+			"publish the notification a second time under a new id", second)
+	}
+
+	// Exactly one delivery, and the counter moved exactly once.
+	waitFor(t, "the first notification", func() bool { return len(ch) == 1 })
+	<-ch
+	time.Sleep(50 * time.Millisecond)
+	if got := len(ch); got != 0 {
+		t.Fatalf("a second notification arrived (%d queued); the dedupe token did not hold", got)
+	}
+}
+
+// TestRedisBusCloseStopsReceiving — Close must actually tear the subscription
+// down, not merely close the local channels. A leaked subscription keeps a
+// goroutine and a connection alive for the process's life.
+func TestRedisBusCloseStopsReceiving(t *testing.T) {
+	b, mr := newMiniredisBus(t, 64)
+
+	ch := b.Subscribe()
+	b.Publish(Notification{Kind: KindComment, ItemRef: "TASK-1"})
+	select {
+	case <-ch:
+	case <-time.After(3 * time.Second):
+		t.Fatal("precondition failed: the bus never received its first notification")
+	}
+
+	b.Close()
+
+	// The SERVER's view of who is subscribed is the half Close is responsible
+	// for — asserting only that the local channel closed would pass on a
+	// build that leaked the subscription and the goroutine behind it.
+	waitFor(t, "Redis to report no subscribers on the channel", func() bool {
+		for _, c := range mr.PubSubChannels("") {
+			if c == redisWatchChannel {
+				return false
+			}
+		}
+		return true
+	})
+	if n := mr.Publish(redisWatchChannel, "probe"); n != 0 {
+		t.Fatalf("Redis still reports %d subscriber(s) after Close", n)
+	}
+}

--- a/internal/watchevents/redis_bus_integration_test.go
+++ b/internal/watchevents/redis_bus_integration_test.go
@@ -148,10 +148,11 @@ func TestRedisBusPublishIsIdempotentUnderRetry(t *testing.T) {
 	ch := b.Subscribe()
 
 	const token = redisWatchDedupePrefix + "fixed-token-for-this-test"
-	keys := []string{redisWatchSeqKey, redisWatchChannel, token}
+	keys := []string{redisWatchSeqKey, redisWatchChannel, token, redisWatchEpochKey}
 	payload := `{"ItemRef":"TASK-1","Kind":"comment"}`
+	const epochCandidate = "epoch-for-this-test"
 
-	first, err := publishScript.Run(b.ctx, b.client, keys, payload, redisWatchDedupeTTLSeconds).Int64()
+	first, err := publishScript.Run(b.ctx, b.client, keys, payload, redisWatchDedupeTTLSeconds, epochCandidate).Int64()
 	if err != nil {
 		t.Fatalf("first run: %v", err)
 	}
@@ -159,7 +160,7 @@ func TestRedisBusPublishIsIdempotentUnderRetry(t *testing.T) {
 		t.Fatalf("first run returned id %d, want 1", first)
 	}
 
-	second, err := publishScript.Run(b.ctx, b.client, keys, payload, redisWatchDedupeTTLSeconds).Int64()
+	second, err := publishScript.Run(b.ctx, b.client, keys, payload, redisWatchDedupeTTLSeconds, epochCandidate).Int64()
 	if err != nil {
 		t.Fatalf("second run: %v", err)
 	}

--- a/internal/watchevents/redis_bus_resume_test.go
+++ b/internal/watchevents/redis_bus_resume_test.go
@@ -223,6 +223,50 @@ func TestResumeFallsBackToLocalKnowledgeWhenTheCounterIsUnreadable(t *testing.T)
 	}
 }
 
+// TestResumeReportsAGapWhenTheCounterKeyDisappears — codex round 12, P2.
+//
+// The sequence key can vanish after this bus has seen ids (FLUSHDB, eviction).
+// Reading redis.Nil as "unreadable" meant falling back to local knowledge and
+// replaying an id space the authority no longer has, while the next publish
+// starts again at 1. Absent is a VALUE — zero — and an instance holding ids
+// disagrees with it.
+func TestResumeReportsAGapWhenTheCounterKeyDisappears(t *testing.T) {
+	b, mr := newMiniredisBus(t, 64)
+
+	ch := b.Subscribe()
+	b.Publish(Notification{Kind: KindComment, ItemRef: "TASK-1"})
+	b.Publish(Notification{Kind: KindComment, ItemRef: "TASK-2"})
+	for i := 0; i < 2; i++ {
+		select {
+		case <-ch:
+		case <-time.After(3 * time.Second):
+			t.Fatalf("precondition: only %d of 2 notifications arrived", i)
+		}
+	}
+	b.Unsubscribe(ch)
+
+	mr.Del(redisWatchSeqKey)
+
+	_, missed := b.SubscribeAndReplaySince(1)
+	if missed != nil {
+		t.Fatalf("the counter is gone while this instance holds ids 1-2; replaying a dead id space "+
+			"is exactly what the next publish (starting again at 1) will collide with; got %+v", missed)
+	}
+}
+
+// TestResumeOnAVirginDeploymentDoesNotReportAGap is the control for the case
+// above: an absent counter on a bus that has seen nothing is genuine agreement
+// at zero, not a gap. Without this leg, "absent means gap" would pass the test
+// above while resyncing every first connection on a fresh deployment.
+func TestResumeOnAVirginDeploymentDoesNotReportAGap(t *testing.T) {
+	b, _ := newMiniredisBus(t, 64)
+
+	if b.resumeOutrunsLocalView(5) {
+		t.Error("nothing has ever been published and this instance has seen nothing; " +
+			"there is no gap to report")
+	}
+}
+
 // TestResumeIsUnaffectedForAFreshSubscriber — sinceID 0 is not a resume, so it
 // must not pay the settle window or be handed a gap.
 func TestResumeIsUnaffectedForAFreshSubscriber(t *testing.T) {

--- a/internal/watchevents/redis_bus_resume_test.go
+++ b/internal/watchevents/redis_bus_resume_test.go
@@ -112,6 +112,81 @@ func TestResumeToleratesAnInFlightCounter(t *testing.T) {
 	}
 }
 
+// TestResumeReportsAGapWhenTheCounterAdvancesAgainDuringTheSettle — codex
+// round 11, P1. The first version of the check re-read only the LOCAL side, so
+// it compared against a stale counter snapshot: id 2 arrives during the beat,
+// the captured remote was 2, and it declared convergence — while id 3 had been
+// published and missed in the meantime.
+func TestResumeReportsAGapWhenTheCounterAdvancesAgainDuringTheSettle(t *testing.T) {
+	b, mr := newMiniredisBus(t, 64)
+
+	ch := b.Subscribe()
+	b.Publish(Notification{Kind: KindComment, ItemRef: "TASK-1"})
+	select {
+	case <-ch:
+	case <-time.After(3 * time.Second):
+		t.Fatal("precondition: the first notification never arrived")
+	}
+	b.Unsubscribe(ch)
+
+	if err := mr.Set(redisWatchSeqKey, "2"); err != nil {
+		t.Fatalf("set counter: %v", err)
+	}
+	go func() {
+		time.Sleep(settleWindow / 4)
+		// The id the first read was waiting for lands...
+		b.fanOutLocally(Notification{ID: 2, Kind: KindComment, ItemRef: "TASK-2"})
+		// ...while a THIRD is published elsewhere and never reaches us.
+		_ = mr.Set(redisWatchSeqKey, "3")
+	}()
+
+	_, missed := b.SubscribeAndReplaySince(1)
+	if missed != nil {
+		t.Fatalf("id 3 exists and never reached this instance; the resume must report a gap "+
+			"rather than converge against a stale counter snapshot; got %+v", missed)
+	}
+}
+
+// TestResumeDoesNotResyncWhenTheCounterReadRacedAPublish — codex round 11, P2,
+// the other direction. A GET can land just before a publish completes and
+// return a value BELOW what this instance already holds. Comparing against
+// that stale snapshot forever meant an unnecessary full resync for a client
+// that had missed nothing.
+func TestResumeDoesNotResyncWhenTheCounterReadRacedAPublish(t *testing.T) {
+	b, mr := newMiniredisBus(t, 64)
+
+	ch := b.Subscribe()
+	b.Publish(Notification{Kind: KindComment, ItemRef: "TASK-1"})
+	b.Publish(Notification{Kind: KindComment, ItemRef: "TASK-2"})
+	for i := 0; i < 2; i++ {
+		select {
+		case <-ch:
+		case <-time.After(3 * time.Second):
+			t.Fatalf("precondition: only %d of 2 notifications arrived", i)
+		}
+	}
+	b.Unsubscribe(ch)
+
+	// The counter reads BEHIND what we hold — the shape a read racing a
+	// publish produces. It catches up during the settle window.
+	if err := mr.Set(redisWatchSeqKey, "1"); err != nil {
+		t.Fatalf("set counter: %v", err)
+	}
+	go func() {
+		time.Sleep(settleWindow / 4)
+		_ = mr.Set(redisWatchSeqKey, "2")
+	}()
+
+	_, missed := b.SubscribeAndReplaySince(1)
+	if missed == nil {
+		t.Fatal("this instance holds everything the counter ends up reporting; resyncing here " +
+			"would punish a client that missed nothing")
+	}
+	if len(missed) != 1 || missed[0].ID != 2 {
+		t.Errorf("resume from 1: got %+v, want just id 2", missed)
+	}
+}
+
 // TestResumeFallsBackToLocalKnowledgeWhenTheCounterIsUnreadable — a Redis
 // hiccup must not turn every reconnect into a resync. Failing closed here would
 // be a worse failure than the one the check guards against, because it fires on

--- a/internal/watchevents/redis_bus_resume_test.go
+++ b/internal/watchevents/redis_bus_resume_test.go
@@ -1,0 +1,172 @@
+package watchevents
+
+// BUG-2651, the trailing gap — lead ruling: a silently lost nudge is unbounded
+// staleness, a spurious resync costs one redundant fetch, so the gap must not
+// survive. These run against miniredis because the check's whole mechanism is
+// asking the shared counter, which is not a thing a hermetic fixture has.
+//
+// The settle window is the interesting part. The counter legitimately runs
+// ahead of any instance for a moment after every publish (INCR happens inside
+// the script; the message still has to propagate), so a strict comparison would
+// resync on ordinary traffic. Waiting out propagation and re-reading turns an
+// unprincipled "how many ids behind is too many" threshold into a time bound:
+// in-flight ids arrive, missed ones never do.
+
+import (
+	"testing"
+	"time"
+)
+
+// TestResumeReportsAGapWhenThisInstanceMissedTheTail is the case the local
+// bookkeeping structurally cannot see: a hole at the END of the sequence, with
+// no later id to reveal it.
+//
+// Simulated by advancing the shared counter WITHOUT publishing — which is
+// exactly what a message this instance missed looks like from here: the
+// authority has moved on and nothing arrived.
+func TestResumeReportsAGapWhenThisInstanceMissedTheTail(t *testing.T) {
+	b, mr := newMiniredisBus(t, 64)
+
+	ch := b.Subscribe()
+	b.Publish(Notification{Kind: KindComment, ItemRef: "TASK-1"})
+	select {
+	case <-ch:
+	case <-time.After(3 * time.Second):
+		t.Fatal("precondition: the first notification never arrived")
+	}
+	b.Unsubscribe(ch)
+
+	// Id 2 exists as far as Redis is concerned, and never reached us.
+	if err := mr.Set(redisWatchSeqKey, "2"); err != nil {
+		t.Fatalf("set counter: %v", err)
+	}
+
+	_, missed := b.SubscribeAndReplaySince(1)
+	if missed != nil {
+		t.Fatalf("a resume from 1 must report a gap when id 2 exists and we never saw it; got %+v", missed)
+	}
+}
+
+// TestResumeDoesNotReportAGapWhenTheInstanceIsCurrent is the control leg, and
+// the one that stops the check being "always resync". Without it, a build that
+// reported a gap on every reconnect would pass the test above.
+func TestResumeDoesNotReportAGapWhenTheInstanceIsCurrent(t *testing.T) {
+	b, _ := newMiniredisBus(t, 64)
+
+	ch := b.Subscribe()
+	for i := 0; i < 3; i++ {
+		b.Publish(Notification{Kind: KindComment, ItemRef: "TASK-1"})
+	}
+	for i := 0; i < 3; i++ {
+		select {
+		case <-ch:
+		case <-time.After(3 * time.Second):
+			t.Fatalf("precondition: only %d of 3 notifications arrived", i)
+		}
+	}
+	b.Unsubscribe(ch)
+
+	_, missed := b.SubscribeAndReplaySince(1)
+	if missed == nil {
+		t.Fatal("this instance has seen everything the counter knows about; a resume must replay, not resync")
+	}
+	if len(missed) != 2 {
+		t.Errorf("resume from 1: got %d entries, want ids 2 and 3: %+v", len(missed), missed)
+	}
+}
+
+// TestResumeToleratesAnInFlightCounter is the settle window doing its job.
+//
+// The counter is ahead when the resume starts and the "missing" notification
+// arrives DURING the settle beat — which is what ordinary propagation looks
+// like. A strict comparison would call that a gap and resync a client that
+// missed nothing.
+func TestResumeToleratesAnInFlightCounter(t *testing.T) {
+	b, mr := newMiniredisBus(t, 64)
+
+	ch := b.Subscribe()
+	b.Publish(Notification{Kind: KindComment, ItemRef: "TASK-1"})
+	select {
+	case <-ch:
+	case <-time.After(3 * time.Second):
+		t.Fatal("precondition: the first notification never arrived")
+	}
+	b.Unsubscribe(ch)
+
+	// Counter says 2 exists; the message is "in flight" and lands mid-settle.
+	if err := mr.Set(redisWatchSeqKey, "2"); err != nil {
+		t.Fatalf("set counter: %v", err)
+	}
+	go func() {
+		time.Sleep(settleWindow / 4)
+		b.fanOutLocally(Notification{ID: 2, Kind: KindComment, ItemRef: "TASK-2"})
+	}()
+
+	_, missed := b.SubscribeAndReplaySince(1)
+	if missed == nil {
+		t.Fatal("the id arrived during the settle window, so nothing was missed; " +
+			"reporting a gap here would resync on ordinary in-flight traffic")
+	}
+	if len(missed) != 1 || missed[0].ID != 2 {
+		t.Errorf("resume from 1: got %+v, want just id 2", missed)
+	}
+}
+
+// TestResumeFallsBackToLocalKnowledgeWhenTheCounterIsUnreadable — a Redis
+// hiccup must not turn every reconnect into a resync. Failing closed here would
+// be a worse failure than the one the check guards against, because it fires on
+// every client at once.
+func TestResumeFallsBackToLocalKnowledgeWhenTheCounterIsUnreadable(t *testing.T) {
+	b, mr := newMiniredisBus(t, 64)
+
+	ch := b.Subscribe()
+	b.Publish(Notification{Kind: KindComment, ItemRef: "TASK-1"})
+	b.Publish(Notification{Kind: KindComment, ItemRef: "TASK-2"})
+	for i := 0; i < 2; i++ {
+		select {
+		case <-ch:
+		case <-time.After(3 * time.Second):
+			t.Fatalf("precondition: only %d of 2 notifications arrived", i)
+		}
+	}
+	b.Unsubscribe(ch)
+
+	// The counter becomes unreadable — a WRONGTYPE error rather than a
+	// connection failure, so the rest of the bus keeps working and only the
+	// validating read fails.
+	mr.Del(redisWatchSeqKey)
+	if _, err := mr.Lpush(redisWatchSeqKey, "not-an-integer"); err != nil {
+		t.Fatalf("seed a wrong-typed key: %v", err)
+	}
+
+	_, missed := b.SubscribeAndReplaySince(1)
+	if missed == nil {
+		t.Fatal("an unreadable counter must fall back to local knowledge, not resync every reconnect")
+	}
+	if len(missed) != 1 || missed[0].ID != 2 {
+		t.Errorf("resume from 1: got %+v, want just id 2", missed)
+	}
+}
+
+// TestResumeIsUnaffectedForAFreshSubscriber — sinceID 0 is not a resume, so it
+// must not pay the settle window or be handed a gap.
+func TestResumeIsUnaffectedForAFreshSubscriber(t *testing.T) {
+	b, mr := newMiniredisBus(t, 64)
+
+	b.Publish(Notification{Kind: KindComment, ItemRef: "TASK-1"})
+	waitFor(t, "the notification to be buffered", func() bool { return len(b.EventsSince(0)) == 1 })
+
+	// Counter deliberately ahead, which would trip the check for a resume.
+	if err := mr.Set(redisWatchSeqKey, "99"); err != nil {
+		t.Fatalf("set counter: %v", err)
+	}
+
+	start := time.Now()
+	_, missed := b.SubscribeAndReplaySince(0)
+	if elapsed := time.Since(start); elapsed >= settleWindow {
+		t.Errorf("a fresh subscriber waited %v — it should not pay the settle window at all", elapsed)
+	}
+	if missed == nil {
+		t.Fatal("sinceID=0 is not a resume and must not be answered with a gap")
+	}
+}

--- a/internal/watchevents/redis_bus_test.go
+++ b/internal/watchevents/redis_bus_test.go
@@ -460,6 +460,41 @@ func TestRedisBusReplayReportsAHoleAsAGap(t *testing.T) {
 	}
 }
 
+// TestRedisBusColdStartReplayReportsAGap — codex round 4, the case the first
+// version of the hole check missed entirely.
+//
+// A replica that restarts while Redis is already at 101 has an empty buffer.
+// Its first received message might be 102, and because there is no previous id
+// to compare against, nothing looks like a hole. A client reconnecting to THAT
+// replica with Last-Event-ID 100 would have been handed [102] — skipping 101
+// as silently as the hole case, by a different route.
+func TestRedisBusColdStartReplayReportsAGap(t *testing.T) {
+	b := newLocalOnlyBus(64)
+	defer b.Close()
+
+	// This instance's first sight of the stream is id 102.
+	b.fanOutLocally(Notification{ID: 102, Kind: KindComment, ItemRef: "TASK-1"})
+	b.fanOutLocally(Notification{ID: 103, Kind: KindComment, ItemRef: "TASK-1"})
+
+	if got := b.EventsSince(100); got != nil {
+		t.Errorf("a resume from 100 asks for 101, which this instance never saw; want a gap, got %+v", got)
+	}
+
+	// A resume from exactly the id before the first one we saw is contiguous
+	// with our view, so it must replay rather than resync — the boundary that
+	// separates this from an over-broad "always gap after a cold start".
+	if got := b.EventsSince(101); got == nil {
+		t.Fatal("a resume from 101 is contiguous with the first id we saw (102) and must replay")
+	} else if len(got) != 2 {
+		t.Errorf("resume from 101: got %d entries, want 102 and 103: %+v", len(got), got)
+	}
+
+	// And a fresh subscriber still gets what is buffered.
+	if fresh := b.EventsSince(0); len(fresh) != 2 {
+		t.Errorf("fresh subscriber: got %d entries, want 2: %+v", len(fresh), fresh)
+	}
+}
+
 // TestRedisBusDecodePayloadRoundTrip covers the wire format publishScript
 // introduced (Codex round 1 P1): the id is assigned inside the Lua script and
 // prepended as "<id>|<json>", so the publisher never knows it and the receiver

--- a/internal/watchevents/redis_bus_test.go
+++ b/internal/watchevents/redis_bus_test.go
@@ -610,9 +610,10 @@ func TestRedisBusCounterResetDropsTheStaleReplayBuffer(t *testing.T) {
 }
 
 // TestRedisBusDecodePayloadRoundTrip covers the wire format publishScript
-// introduced (Codex round 1 P1): the id is assigned inside the Lua script and
-// prepended as "<id>|<json>", so the publisher never knows it and the receiver
-// is the only place the two halves are rejoined.
+// introduced (Codex round 1 P1) and extended in round 13: the epoch and id are
+// both assigned inside the Lua script and prepended as "<epoch>|<id>|<json>",
+// so the publisher never knows either and the receiver is the only place the
+// three parts are rejoined.
 //
 // The malformed cases are here because this decoder consumes bytes from a
 // shared channel that any process with the Redis credentials can publish to; a

--- a/internal/watchevents/redis_bus_test.go
+++ b/internal/watchevents/redis_bus_test.go
@@ -412,6 +412,54 @@ func TestRedisBusNotificationSurvivesTheJSONRoundTrip(t *testing.T) {
 	}
 }
 
+// TestRedisBusReplayReportsAHoleAsAGap — codex round 3.
+//
+// MemoryBus assigns every id itself, so its replay buffer is contiguous by
+// construction and the ONLY gap it can report is eviction. RedisBus receives
+// ids over at-most-once pub/sub, so it can miss one: buffer holds 100 and 102,
+// is nowhere near full, and the underlying replayBuffer.since() would answer a
+// resume from 100 with just [102] — losing 101 silently, with no sync_required
+// for the consumer to act on.
+//
+// The assertion is on the RESUME THAT SPANS THE HOLE returning nil, and — the
+// part that keeps it from being over-broad — on the resumes that do NOT span
+// it still working. A bus that answered nil to everything after one hole would
+// satisfy the first half alone.
+func TestRedisBusReplayReportsAHoleAsAGap(t *testing.T) {
+	b := newLocalOnlyBus(64)
+	defer b.Close()
+
+	b.fanOutLocally(Notification{ID: 99, Kind: KindComment, ItemRef: "TASK-1"})
+	b.fanOutLocally(Notification{ID: 100, Kind: KindComment, ItemRef: "TASK-1"})
+	// 101 is never received — the subscription blipped.
+	b.fanOutLocally(Notification{ID: 102, Kind: KindComment, ItemRef: "TASK-1"})
+
+	if got := b.EventsSince(100); got != nil {
+		t.Errorf("a resume from 100 must span the missing 101 and report a gap; got %+v", got)
+	}
+	if got := b.EventsSince(99); got != nil {
+		t.Errorf("a resume from 99 also spans the hole; got %+v", got)
+	}
+
+	// Resumes that do not span the hole still work.
+	after := b.EventsSince(101)
+	if after == nil {
+		t.Fatal("a resume from 101 does not span the hole and must replay normally, not report a gap")
+	}
+	if len(after) != 1 || after[0].ID != 102 {
+		t.Errorf("resume from 101: got %+v, want just id 102", after)
+	}
+	if latest := b.EventsSince(102); len(latest) != 0 {
+		t.Errorf("resume from the newest id should be caught-up-empty, got %+v", latest)
+	}
+
+	// And a fresh subscriber (sinceID 0) is not resuming from a position, so
+	// it must not be handed a gap signal for a hole it never spanned.
+	if fresh := b.EventsSince(0); fresh == nil {
+		t.Error("sinceID=0 is a fresh subscriber, not a resume; it must not report a gap")
+	}
+}
+
 // TestRedisBusDecodePayloadRoundTrip covers the wire format publishScript
 // introduced (Codex round 1 P1): the id is assigned inside the Lua script and
 // prepended as "<id>|<json>", so the publisher never knows it and the receiver

--- a/internal/watchevents/redis_bus_test.go
+++ b/internal/watchevents/redis_bus_test.go
@@ -56,8 +56,12 @@ func newLocalOnlyBus(size int) *RedisBus {
 	return &RedisBus{
 		subscribers: make(map[chan Notification]struct{}),
 		replay:      newReplayBuffer(size),
-		ctx:         ctx,
-		cancel:      cancel,
+		// replaySize matters: the epoch-reset path rebuilds the buffer from
+		// it, and a fixture that left it zero turned a counter reset into a
+		// panic rather than a resync.
+		replaySize: size,
+		ctx:        ctx,
+		cancel:     cancel,
 	}
 }
 
@@ -492,6 +496,48 @@ func TestRedisBusColdStartReplayReportsAGap(t *testing.T) {
 	// And a fresh subscriber still gets what is buffered.
 	if fresh := b.EventsSince(0); len(fresh) != 2 {
 		t.Errorf("fresh subscriber: got %d entries, want 2: %+v", len(fresh), fresh)
+	}
+}
+
+// TestRedisBusCounterResetDropsTheStaleReplayBuffer — codex round 6.
+//
+// pad:watchevents_seq has no TTL, but it can still vanish: evicted under
+// maxmemory, dropped by a FLUSHDB, or restored from an older snapshot. Ids then
+// restart at 1 while this instance's ring still holds the hundreds. Keeping
+// both is what corrupts replay — a resume from 2 in the NEW space would be
+// handed the stale 99/100/101 as though they were newer.
+func TestRedisBusCounterResetDropsTheStaleReplayBuffer(t *testing.T) {
+	b := newLocalOnlyBus(64)
+	defer b.Close()
+
+	for _, id := range []int64{99, 100, 101} {
+		b.fanOutLocally(Notification{ID: id, Kind: KindComment, ItemRef: "TASK-old"})
+	}
+
+	// Redis counter reset: ids restart.
+	b.fanOutLocally(Notification{ID: 1, Kind: KindComment, ItemRef: "TASK-new"})
+	b.fanOutLocally(Notification{ID: 2, Kind: KindComment, ItemRef: "TASK-new"})
+
+	// A client from the OLD id space must be told to resync, not handed
+	// entries from the new one (or, worse, the stale ones it already saw).
+	if got := b.EventsSince(100); got != nil {
+		t.Errorf("a resume from the pre-reset id space must report a gap; got %+v", got)
+	}
+
+	// A client in the NEW space works normally, and must never see a stale
+	// entry — which is the assertion a build that merely logged the reset
+	// and kept the buffer would fail.
+	after := b.EventsSince(1)
+	if after == nil {
+		t.Fatal("a resume from 1 is inside the new id space and must replay")
+	}
+	for _, n := range after {
+		if n.ItemRef != "TASK-new" {
+			t.Fatalf("replay after a counter reset returned a pre-reset entry: %+v", n)
+		}
+	}
+	if len(after) != 1 || after[0].ID != 2 {
+		t.Errorf("resume from 1: got %+v, want just id 2", after)
 	}
 }
 

--- a/internal/watchevents/redis_bus_test.go
+++ b/internal/watchevents/redis_bus_test.go
@@ -525,6 +525,48 @@ func TestRedisBusColdStartReplayReportsAGap(t *testing.T) {
 	}
 }
 
+// TestRedisBusEpochChangeDropsTheStaleReplayBuffer — codex round 13, and the
+// case pure arithmetic cannot see.
+//
+// Hold 100. Lose the connection. The counter resets and ids 1-101 are
+// published in the NEW space; the only one that reaches us is 101 — which
+// looks exactly like the contiguous successor of 100. Every numeric check
+// passes, the buffer quietly mixes two id spaces, and a client resuming from
+// OLD 100 is handed NEW 101 having silently missed the new space's 1-100.
+//
+// The epoch is the only thing that distinguishes them, because the question is
+// not "is this number bigger" but "is this the same sequence".
+func TestRedisBusEpochChangeDropsTheStaleReplayBuffer(t *testing.T) {
+	b := newLocalOnlyBus(64)
+	defer b.Close()
+
+	for _, id := range []int64{99, 100} {
+		b.fanOutFromRedis("epoch-one", Notification{ID: id, Kind: KindComment, ItemRef: "TASK-old"})
+	}
+
+	// New id space, and its first id we see happens to be 100+1.
+	b.fanOutFromRedis("epoch-two", Notification{ID: 101, Kind: KindComment, ItemRef: "TASK-new"})
+
+	// A client from the OLD epoch must resync rather than be handed an id
+	// from a sequence it was never part of.
+	if got := b.EventsSince(100); got != nil {
+		t.Errorf("a resume from the previous epoch must report a gap; got %+v", got)
+	}
+
+	// A client genuinely INSIDE the new epoch is still served — the control
+	// that stops this becoming "resync everyone forever after any reset".
+	if got := b.EventsSince(101); got == nil {
+		t.Error("a cursor at the new epoch's own id must be servable, not answered with a gap")
+	}
+
+	// And the buffer holds only the new space — the assertion a build that
+	// merely logged the change would fail.
+	fresh := b.EventsSince(0)
+	if len(fresh) != 1 || fresh[0].ItemRef != "TASK-new" {
+		t.Fatalf("after an epoch change the buffer must hold only the new space; got %+v", fresh)
+	}
+}
+
 // TestRedisBusCounterResetDropsTheStaleReplayBuffer — codex round 6.
 //
 // pad:watchevents_seq has no TTL, but it can still vanish: evicted under
@@ -589,9 +631,12 @@ func TestRedisBusDecodePayloadRoundTrip(t *testing.T) {
 		t.Fatalf("marshal: %v", err)
 	}
 
-	got, err := decodePayload("77|" + string(body))
+	epoch, got, err := decodePayload("epoch-a|77|" + string(body))
 	if err != nil {
 		t.Fatalf("decode: %v", err)
+	}
+	if epoch != "epoch-a" {
+		t.Errorf("epoch: got %q, want epoch-a", epoch)
 	}
 	if got.ID != 77 {
 		t.Errorf("id: got %d, want 77 — the id lives in the prefix, not the JSON", got.ID)
@@ -608,7 +653,7 @@ func TestRedisBusDecodePayloadRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
-	gotPipe, err := decodePayload("5|" + string(pipeBody))
+	_, gotPipe, err := decodePayload("epoch-a|5|" + string(pipeBody))
 	if err != nil {
 		t.Fatalf("decode with a pipe in the body: %v", err)
 	}
@@ -620,13 +665,15 @@ func TestRedisBusDecodePayloadRoundTrip(t *testing.T) {
 		name    string
 		payload string
 	}{
-		{"no separator", `{"ItemRef":"TASK-1"}`},
-		{"non-numeric id", `abc|{"ItemRef":"TASK-1"}`},
-		{"body is not JSON", `1|not json`},
+		{"no separators", `{"ItemRef":"TASK-1"}`},
+		{"only one separator", `1|{"ItemRef":"TASK-1"}`},
+		{"non-numeric id", `epoch-a|abc|{"ItemRef":"TASK-1"}`},
+		{"empty epoch", `|1|{"ItemRef":"TASK-1"}`},
+		{"body is not JSON", `epoch-a|1|not json`},
 		{"empty", ``},
 	} {
 		t.Run("malformed/"+bad.name, func(t *testing.T) {
-			if _, err := decodePayload(bad.payload); err == nil {
+			if _, _, err := decodePayload(bad.payload); err == nil {
 				t.Fatalf("decodePayload(%q) returned no error; a malformed payload from the shared "+
 					"channel must be rejected, not fanned out with a zero id", bad.payload)
 			}

--- a/internal/watchevents/redis_bus_test.go
+++ b/internal/watchevents/redis_bus_test.go
@@ -1,0 +1,445 @@
+package watchevents
+
+// BUG-2651 — RedisBus.
+//
+// WHAT IS AND IS NOT COVERED HERE, stated up front because the gap is real:
+// there is no Redis in CI and no miniredis/redismock in go.mod (internal/events'
+// RedisBus has no tests at all for the same reason). So these tests drive the
+// two halves that do not need a server —
+//
+//   - the LOCAL half (fanOutLocally + Subscribe/SubscribeAndReplaySince/
+//     Unsubscribe/Close), which is where the concurrency contract lives and
+//     where a port of events.RedisBus's two-lock layout would break;
+//   - Publish's fail-closed branch, driven with a client pointed at a closed
+//     port, which is a real INCR failure rather than a simulated one;
+//   - the JSON round trip a notification takes through Redis.
+//
+// NOT covered: the actual pub/sub round trip (channel name, subscription
+// lifecycle against a live server). That needs a Redis, and adding one is a
+// dependency decision rather than a test-writing one.
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// deadClient returns a Redis client pointed at a closed port on loopback.
+// Every command against it fails immediately — a genuine connection error, not
+// a stub — which is exactly the condition Publish's fail-closed branch is for.
+func deadClient(t *testing.T) *redis.Client {
+	t.Helper()
+	return redis.NewClient(&redis.Options{
+		Addr:        "127.0.0.1:1",
+		DialTimeout: 200 * time.Millisecond,
+		MaxRetries:  -1,
+	})
+}
+
+// newLocalOnlyBus builds a RedisBus without starting its subscription, for the
+// tests that exercise the local fan-out path directly. Constructing through
+// NewRedisBus would spawn a receive goroutine dialing a dead server, which adds
+// noise and nothing else — the receive loop's only job is to call
+// fanOutLocally, which these tests call themselves.
+//
+// ctx/cancel are populated even though nothing here uses the context, because
+// Close legitimately assumes the constructor set them. Making Close nil-safe
+// instead would have been the wrong fix: a zero-value RedisBus is not a
+// supported construction, and a defensive nil check there would mask real
+// misuse to spare a test fixture.
+func newLocalOnlyBus(size int) *RedisBus {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &RedisBus{
+		subscribers: make(map[chan Notification]struct{}),
+		replay:      newReplayBuffer(size),
+		ctx:         ctx,
+		cancel:      cancel,
+	}
+}
+
+// TestRedisBusSubscribeAndReplayIsAtomic is the load-bearing test.
+//
+// The contract (inherited from MemoryBus, and the reason Bus has this method
+// at all) is that a notification is EITHER in the replay slice OR delivered on
+// the channel — never both, never neither. events.RedisBus cannot provide it:
+// it guards subscribers and replay with different locks. So a future
+// "simplification" that aligns this type with that template must fail here.
+//
+// Asserting the exclusion rather than the presence is the point: a build that
+// delivered every notification twice would satisfy "the resume worked".
+func TestRedisBusSubscribeAndReplayIsAtomic(t *testing.T) {
+	b := newLocalOnlyBus(64)
+	defer b.Close()
+
+	// Three notifications land before anyone subscribes.
+	for i := int64(1); i <= 3; i++ {
+		b.fanOutLocally(Notification{ID: i, Kind: KindComment, ItemRef: "TASK-1"})
+	}
+
+	ch, missed := b.SubscribeAndReplaySince(1)
+
+	if len(missed) != 2 {
+		t.Fatalf("replay since 1 should carry ids 2,3; got %d entries: %+v", len(missed), missed)
+	}
+	for _, n := range missed {
+		if n.ID <= 1 {
+			t.Errorf("replay carried id %d, which is not above sinceID=1", n.ID)
+		}
+	}
+
+	// Nothing already-replayed may ALSO be sitting on the channel.
+	select {
+	case n := <-ch:
+		t.Fatalf("notification id=%d was replayed AND delivered on the channel — "+
+			"the subscribe and the buffer read did not share a critical section", n.ID)
+	default:
+	}
+
+	// A notification fanned out after the subscribe goes to the channel and
+	// must NOT be something the caller already had.
+	b.fanOutLocally(Notification{ID: 4, Kind: KindComment, ItemRef: "TASK-1"})
+	select {
+	case n := <-ch:
+		if n.ID != 4 {
+			t.Errorf("expected id 4 on the channel, got %d", n.ID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("notification fanned out after subscribe never arrived on the channel")
+	}
+}
+
+// TestRedisBusSubscribeAndReplayHasNoWindowUnderConcurrency is the same
+// contract driven by a race rather than by a fixed ordering: a fan-out loop
+// runs while a subscriber joins, and every id must appear exactly once across
+// (replay ∪ channel).
+//
+// Run this with -race; without the shared lock it fails on the duplicate long
+// before the race detector has anything to say.
+func TestRedisBusSubscribeAndReplayHasNoWindowUnderConcurrency(t *testing.T) {
+	// Buffer > total so nothing is evicted and every id is accounted for.
+	const total = 1000
+	b := newLocalOnlyBus(4096)
+	defer b.Close()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := int64(1); i <= total; i++ {
+			b.fanOutLocally(Notification{ID: i, Kind: KindStatusChange, ItemRef: "TASK-1"})
+			// Deliberately paced. The first version of this test fired all
+			// of them as fast as a map iteration allows and then slept 1ms
+			// before subscribing — so the producer was always FINISHED by
+			// the time the subscriber joined, the channel leg received
+			// nothing, and the test passed on the replay slice alone. It
+			// was vacuous for the defect it names, and a split-lock mutant
+			// survived 50 runs of it before this was noticed.
+			time.Sleep(10 * time.Microsecond)
+		}
+	}()
+
+	// Join mid-flight.
+	time.Sleep(2 * time.Millisecond)
+	ch, missed := b.SubscribeAndReplaySince(0)
+
+	wg.Wait()
+
+	seen := make(map[int64]int, total)
+	for _, n := range missed {
+		seen[n.ID]++
+	}
+	// Drain on a QUIET deadline rather than `default`: sends happen on the
+	// producer goroutine, so a non-blocking drain can declare the channel
+	// empty while a send is still in flight — another way to be vacuous.
+	deadline := time.NewTimer(200 * time.Millisecond)
+	defer deadline.Stop()
+	fromChannel := 0
+drain:
+	for {
+		select {
+		case n, ok := <-ch:
+			if !ok {
+				break drain
+			}
+			seen[n.ID]++
+			fromChannel++
+			if !deadline.Stop() {
+				<-deadline.C
+			}
+			deadline.Reset(50 * time.Millisecond)
+		case <-deadline.C:
+			break drain
+		}
+	}
+
+	for id, count := range seen {
+		if count != 1 {
+			t.Fatalf("notification id=%d appeared %d times across replay+channel; "+
+				"exactly-once is the contract SubscribeAndReplaySince exists to provide", id, count)
+		}
+	}
+
+	// THE PRECONDITION THAT MAKES THE ASSERTION ABOVE MEAN ANYTHING. If the
+	// subscriber joined before the first fan-out or after the last, there was
+	// no window to test and "no duplicates" is trivially true. Both legs must
+	// be non-empty for this run to have exercised the boundary at all.
+	if len(missed) == 0 || fromChannel == 0 {
+		t.Fatalf("fixture did not straddle the subscribe: %d replayed, %d on the channel — "+
+			"the run proves nothing about the window", len(missed), fromChannel)
+	}
+}
+
+// TestRedisBusSubscribeAndReplayNeverDoubleDelivers is the DETECTOR for the
+// split-lock defect, and it exists because the test above turned out not to be
+// one.
+//
+// Measured: with subscribe and replay in two separate critical sections (the
+// events.RedisBus layout), the test above killed the mutant in roughly 1 run
+// in 20 — 0 of 5 independent invocations. A single subscribe is one chance at
+// a window a few nanoseconds wide, so a test built on one subscribe is a
+// coin-flip dressed as an assertion.
+//
+// This takes many chances instead: a producer runs continuously while
+// subscribers join over and over, and each join checks the ONE signature the
+// defect leaves — an id that appears in the replay slice AND then arrives on
+// the channel. No accounting of the whole id space, no timing assumptions
+// beyond "drain briefly"; just the intersection, which must be empty every
+// time.
+func TestRedisBusSubscribeAndReplayNeverDoubleDelivers(t *testing.T) {
+	const attempts = 600
+
+	b := newLocalOnlyBus(4096)
+	defer b.Close()
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := int64(1); ; i++ {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			b.fanOutLocally(Notification{ID: i, Kind: KindStatusChange, ItemRef: "TASK-1"})
+			time.Sleep(5 * time.Microsecond)
+		}
+	}()
+	defer func() {
+		close(stop)
+		wg.Wait()
+	}()
+
+	straddled := 0
+	for i := 0; i < attempts; i++ {
+		ch, missed := b.SubscribeAndReplaySince(0)
+
+		replayed := make(map[int64]struct{}, len(missed))
+		for _, n := range missed {
+			replayed[n.ID] = struct{}{}
+		}
+
+		// NON-BLOCKING drain, and the reason is what makes this test both
+		// fast and exact. In the split-lock layout the duplicate is SENT
+		// before the buffer is read — register, unlock, [fan-out sends],
+		// lock, read — so by the time this call has returned, the duplicate
+		// is already sitting in the channel's buffer. Waiting on a timer
+		// bought nothing but 11 seconds of CI time.
+		got := 0
+	drain:
+		for {
+			select {
+			case n, ok := <-ch:
+				if !ok {
+					break drain
+				}
+				got++
+				if _, dup := replayed[n.ID]; dup {
+					b.Unsubscribe(ch)
+					t.Fatalf("attempt %d: notification id=%d was in the replay slice AND arrived on the "+
+						"channel — subscribe and the buffer read did not share one critical section", i, n.ID)
+				}
+			default:
+				break drain
+			}
+		}
+		if len(missed) > 0 && got > 0 {
+			straddled++
+		}
+		b.Unsubscribe(ch)
+	}
+
+	// Same anti-vacuity guard as above, applied to the whole run: if no
+	// attempt ever saw both a replay and a live delivery, this test spun
+	// without ever approaching the boundary and its silence means nothing.
+	if straddled == 0 {
+		t.Fatalf("none of %d attempts saw both replayed and live notifications; "+
+			"the producer and the subscriber never overlapped", attempts)
+	}
+	t.Logf("%d/%d attempts straddled the subscribe boundary", straddled, attempts)
+}
+
+// commandRecorder is a go-redis Hook that records every command NAME the
+// client attempts, whether or not it succeeds. It is the seam that makes the
+// fail-closed decision observable without a live server: the policy difference
+// is not "was anything delivered" (with Redis down, nothing is delivered under
+// either policy — the first version of this test asserted exactly that and a
+// local-counter mutant sailed through it), it is WHICH COMMANDS Publish
+// issues.
+type commandRecorder struct {
+	mu   sync.Mutex
+	cmds []string
+}
+
+func (r *commandRecorder) DialHook(next redis.DialHook) redis.DialHook { return next }
+func (r *commandRecorder) ProcessPipelineHook(next redis.ProcessPipelineHook) redis.ProcessPipelineHook {
+	return next
+}
+func (r *commandRecorder) ProcessHook(next redis.ProcessHook) redis.ProcessHook {
+	return func(ctx context.Context, cmd redis.Cmder) error {
+		r.mu.Lock()
+		r.cmds = append(r.cmds, cmd.Name())
+		r.mu.Unlock()
+		return next(ctx, cmd)
+	}
+}
+
+func (r *commandRecorder) names() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string(nil), r.cmds...)
+}
+
+// TestRedisBusPublishFailsClosedWhenIDsAreUnavailable pins the one place this
+// implementation deliberately diverges from events.RedisBus, which falls back
+// to a local counter when INCR fails.
+//
+// WHAT IT ASSERTS AND WHY IT IS SHAPED THIS WAY. A local-counter fallback
+// would mint an id from a counter another instance is also using, and
+// replayBuffer.since() reasons on monotonicity, so the damage is silent replay
+// corruption rather than a visible error. But "nothing was delivered" cannot
+// detect that: Publish never delivers locally (the receive path does), so with
+// Redis down NOTHING is delivered under either policy. Asserting delivery was
+// the first version of this test, and a fallback mutant survived it.
+//
+// So the assertion is on the COMMANDS ISSUED — fail-closed attempts INCR and
+// then stops; a fallback would go on to attempt PUBLISH with the locally
+// minted id. That is the observable difference between the two policies, and
+// it is observable without a server.
+func TestRedisBusPublishFailsClosedWhenIDsAreUnavailable(t *testing.T) {
+	rec := &commandRecorder{}
+	client := deadClient(t)
+	client.AddHook(rec)
+
+	b := newLocalOnlyBus(16)
+	b.client = client
+	defer b.Close()
+
+	ch := b.Subscribe()
+	b.Publish(Notification{Kind: KindPush, ItemRef: "TASK-1", Summary: "should not be published"})
+
+	cmds := rec.names()
+	if len(cmds) == 0 {
+		t.Fatal("no Redis command was attempted at all; the fixture is not exercising Publish")
+	}
+	for _, name := range cmds {
+		if name == "publish" {
+			t.Fatalf("Publish issued PUBLISH after INCR failed (commands: %v) — the notification would "+
+				"carry an id minted outside the shared counter, which corrupts replay ordering for "+
+				"every instance rather than failing visibly", cmds)
+		}
+	}
+	if cmds[0] != "incr" {
+		t.Errorf("expected INCR to be attempted first, got %v", cmds)
+	}
+
+	// Belt and braces: nothing may have leaked into local state either.
+	select {
+	case n, ok := <-ch:
+		if ok {
+			t.Fatalf("a notification was delivered (id=%d) despite INCR failing", n.ID)
+		}
+	default:
+	}
+	if got := b.EventsSince(0); len(got) != 0 {
+		t.Fatalf("replay buffer holds %d entries after a failed publish: %+v", len(got), got)
+	}
+}
+
+// TestRedisBusNotificationSurvivesTheJSONRoundTrip covers the half of the
+// Redis hop that does not need Redis: every field a consumer gates on has to
+// survive marshal/unmarshal, because the receive path rebuilds the struct from
+// bytes rather than sharing memory with the publisher.
+//
+// The fields chosen are the ones watchNotificationVisible actually branches on
+// — a silently-dropped TargetSessionID would route a push to every session of
+// a user instead of one, which no test of the bus's plumbing would notice.
+func TestRedisBusNotificationSurvivesTheJSONRoundTrip(t *testing.T) {
+	want := Notification{
+		ID:              42,
+		WorkspaceID:     "ws-1",
+		ItemID:          "item-1",
+		CollectionID:    "coll-1",
+		ItemRef:         "TASK-214",
+		Kind:            KindPush,
+		Actor:           "agent",
+		ActorName:       "Wren",
+		Summary:         "look at this",
+		AssignedUserID:  "user-1",
+		TargetUserID:    "user-2",
+		TargetSessionID: "sess-9",
+		StatusFieldKey:  "status",
+		ToStatus:        "done",
+		Timestamp:       1755000000000,
+	}
+
+	data, err := json.Marshal(want)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got Notification
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got != want {
+		t.Fatalf("notification did not survive the round trip:\n got: %+v\nwant: %+v", got, want)
+	}
+}
+
+// TestRedisBusCloseIsIdempotentAndClosesSubscribers — Close runs from server
+// shutdown while a receive goroutine may be mid-fan-out, so it has to be safe
+// to call twice and must not leave a subscriber holding a channel nobody will
+// close.
+func TestRedisBusCloseIsIdempotentAndClosesSubscribers(t *testing.T) {
+	b := newLocalOnlyBus(16)
+	ch := b.Subscribe()
+
+	b.Close()
+	b.Close() // must not panic on a double close of the same channels
+
+	select {
+	case _, ok := <-ch:
+		if ok {
+			t.Fatal("subscriber channel yielded a value after Close; expected it closed")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("subscriber channel was not closed by Close — the consumer would block forever")
+	}
+
+	// A subscriber arriving after Close must get a closed channel rather than
+	// registering into a bus that will never close it.
+	late := b.Subscribe()
+	select {
+	case _, ok := <-late:
+		if ok {
+			t.Fatal("post-Close Subscribe yielded a value; expected an already-closed channel")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("post-Close Subscribe returned a live channel nobody will ever close")
+	}
+}

--- a/internal/watchevents/redis_bus_test.go
+++ b/internal/watchevents/redis_bus_test.go
@@ -465,6 +465,31 @@ func TestRedisBusReplayReportsAHoleAsAGap(t *testing.T) {
 	}
 }
 
+// TestRedisBusResumeAgainstAnEmptyBusReportsAGap — codex round 9, P1.
+//
+// A replica that has received NOTHING knows nothing, which is strictly less
+// than "contiguous from X" — so it must answer a resume at least as
+// conservatively. It did the opposite: with knownFrom still 0 the coverage
+// check was skipped entirely, an empty buffer returned an empty-but-non-nil
+// slice, and the SSE handler read that as "caught up". The client then
+// silently lost everything published while the replica was down.
+func TestRedisBusResumeAgainstAnEmptyBusReportsAGap(t *testing.T) {
+	b := newLocalOnlyBus(64)
+	defer b.Close()
+
+	if got := b.EventsSince(100); got != nil {
+		t.Errorf("a bus that has received nothing cannot vouch for a cursor at 100; "+
+			"want a gap, got %#v", got)
+	}
+
+	// A FRESH subscriber presents no cursor and must not be handed a resync
+	// just because the buffer is empty — that would turn every cold start
+	// into a spurious sync_required for every new connection.
+	if fresh := b.EventsSince(0); fresh == nil {
+		t.Error("sinceID=0 is not a resume; an empty bus must answer it with an empty replay, not a gap")
+	}
+}
+
 // TestRedisBusColdStartReplayReportsAGap — codex round 4, the case the first
 // version of the hole check missed entirely.
 //

--- a/internal/watchevents/redis_bus_test.go
+++ b/internal/watchevents/redis_bus_test.go
@@ -347,15 +347,16 @@ func TestRedisBusPublishFailsClosedWhenIDsAreUnavailable(t *testing.T) {
 	if len(cmds) == 0 {
 		t.Fatal("no Redis command was attempted at all; the fixture is not exercising Publish")
 	}
+	// The id assignment and the publish must be ONE round trip (publishScript),
+	// not a bare INCR followed by a bare PUBLISH. Two calls are what let two
+	// instances interleave and publish their ids out of order — see
+	// publishScript's comment. Seeing either bare command here means the
+	// atomicity fix was undone.
 	for _, name := range cmds {
-		if name == "publish" {
-			t.Fatalf("Publish issued PUBLISH after INCR failed (commands: %v) — the notification would "+
-				"carry an id minted outside the shared counter, which corrupts replay ordering for "+
-				"every instance rather than failing visibly", cmds)
+		if name == "incr" || name == "publish" {
+			t.Fatalf("Publish issued a bare %q (commands: %v) — id assignment and publication must be "+
+				"one atomic script, or two instances can publish their ids out of order", name, cmds)
 		}
-	}
-	if cmds[0] != "incr" {
-		t.Errorf("expected INCR to be attempted first, got %v", cmds)
 	}
 
 	// Belt and braces: nothing may have leaked into local state either.
@@ -408,6 +409,73 @@ func TestRedisBusNotificationSurvivesTheJSONRoundTrip(t *testing.T) {
 	}
 	if got != want {
 		t.Fatalf("notification did not survive the round trip:\n got: %+v\nwant: %+v", got, want)
+	}
+}
+
+// TestRedisBusDecodePayloadRoundTrip covers the wire format publishScript
+// introduced (Codex round 1 P1): the id is assigned inside the Lua script and
+// prepended as "<id>|<json>", so the publisher never knows it and the receiver
+// is the only place the two halves are rejoined.
+//
+// The malformed cases are here because this decoder consumes bytes from a
+// shared channel that any process with the Redis credentials can publish to; a
+// panic or a silently-zero id would both be worse than a logged error.
+func TestRedisBusDecodePayloadRoundTrip(t *testing.T) {
+	want := Notification{
+		WorkspaceID:     "ws-1",
+		ItemRef:         "TASK-214",
+		Kind:            KindPush,
+		TargetUserID:    "user-2",
+		TargetSessionID: "sess-9",
+		Timestamp:       1755000000000,
+	}
+	body, err := json.Marshal(want)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	got, err := decodePayload("77|" + string(body))
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.ID != 77 {
+		t.Errorf("id: got %d, want 77 — the id lives in the prefix, not the JSON", got.ID)
+	}
+	want.ID = 77
+	if got != want {
+		t.Errorf("payload did not survive the round trip:\n got: %+v\nwant: %+v", got, want)
+	}
+
+	// A '|' inside the body must not confuse the split: only the FIRST one
+	// separates, which is what makes the format unambiguous.
+	withPipe := Notification{ItemRef: "TASK-1", Summary: "a|b|c"}
+	pipeBody, err := json.Marshal(withPipe)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	gotPipe, err := decodePayload("5|" + string(pipeBody))
+	if err != nil {
+		t.Fatalf("decode with a pipe in the body: %v", err)
+	}
+	if gotPipe.Summary != "a|b|c" || gotPipe.ID != 5 {
+		t.Errorf("pipe in the body broke the split: id=%d summary=%q", gotPipe.ID, gotPipe.Summary)
+	}
+
+	for _, bad := range []struct {
+		name    string
+		payload string
+	}{
+		{"no separator", `{"ItemRef":"TASK-1"}`},
+		{"non-numeric id", `abc|{"ItemRef":"TASK-1"}`},
+		{"body is not JSON", `1|not json`},
+		{"empty", ``},
+	} {
+		t.Run("malformed/"+bad.name, func(t *testing.T) {
+			if _, err := decodePayload(bad.payload); err == nil {
+				t.Fatalf("decodePayload(%q) returned no error; a malformed payload from the shared "+
+					"channel must be rejected, not fanned out with a zero id", bad.payload)
+			}
+		})
 	}
 }
 

--- a/internal/watchevents/redis_bus_test.go
+++ b/internal/watchevents/redis_bus_test.go
@@ -2,21 +2,22 @@ package watchevents
 
 // BUG-2651 — RedisBus.
 //
-// WHAT IS AND IS NOT COVERED HERE, stated up front because the gap is real:
-// there is no Redis in CI and no miniredis/redismock in go.mod (internal/events'
-// RedisBus has no tests at all for the same reason). So these tests drive the
-// two halves that do not need a server —
+// THIS FILE drives the parts that need no server:
 //
 //   - the LOCAL half (fanOutLocally + Subscribe/SubscribeAndReplaySince/
 //     Unsubscribe/Close), which is where the concurrency contract lives and
 //     where a port of events.RedisBus's two-lock layout would break;
-//   - Publish's fail-closed branch, driven with a client pointed at a closed
-//     port, which is a real INCR failure rather than a simulated one;
-//   - the JSON round trip a notification takes through Redis.
+//   - the coverage bookkeeping that turns a hole, a cold start, or a Redis
+//     counter reset into an honest resync;
+//   - Publish's behaviour when Redis is unreachable, driven with a client
+//     pointed at a closed port — a real failure rather than a simulated one;
+//   - the payload codec.
 //
-// NOT covered: the actual pub/sub round trip (channel name, subscription
-// lifecycle against a live server). That needs a Redis, and adding one is a
-// dependency decision rather than a test-writing one.
+// The Redis ROUND TRIP — channel name, Lua KEYS/ARGV mapping, shared counter,
+// cross-instance delivery, dedupe, subscription teardown — lives in
+// redis_bus_integration_test.go against miniredis. An earlier version of this
+// header said that coverage did not exist and could not without a dependency
+// decision. The decision was made; see that file's header for what forced it.
 
 import (
 	"context"

--- a/internal/watchevents/watchevents.go
+++ b/internal/watchevents/watchevents.go
@@ -23,12 +23,16 @@
 // held: RedisBus changed neither.
 //
 // STILL PER-PROCESS, and worth knowing before assuming multi-instance is
-// finished: internal/server's SessionPresence registry. RedisBus makes
-// DELIVERY cross-instance — a push published on A now reaches a stream on
-// B, and B matches it against its own live sessions — but the
-// GET /api/v1/sessions listing still reports only the answering
-// instance's connections. See session_presence.go's own note for which
-// half that leaves open.
+// finished: internal/server's SessionPresence registry. What RedisBus
+// fixes is delivery of what is actually PUBLISHED — a broadcast push, a
+// status change, a comment — which now reaches a stream on any instance.
+// What it does not fix is a SESSION-TARGETED push, because
+// handlers_push.go consults that per-process registry and skips the
+// publish entirely when the named session is not local; the bus would
+// carry it, but it is never put on the bus. The
+// GET /api/v1/sessions listing is per-process for the same reason.
+// See session_presence.go's own note — one shared-state implementation
+// closes both.
 package watchevents
 
 import (
@@ -58,9 +62,12 @@ const (
 	// right now rather than waiting on assignment/watch semantics. NOT
 	// "publishes exactly one" unconditionally as of PLAN-2558 S5
 	// (TASK-2588): handlePushToItem decides whether to publish at all —
-	// a session-targeted request whose id matches no live session skips
-	// the publish entirely (a guaranteed no-op; see TargetSessionID and
-	// pushResponse.DeliveredSessions' doc comments in handlers_push.go).
+	// a session-targeted request whose id matches no LOCAL live session
+	// skips the publish entirely. That was a guaranteed no-op under
+	// MemoryBus and is merely a skip under RedisBus, where the session
+	// might be live on another instance; see handlers_push.go's own
+	// comment on that gate, plus TargetSessionID and
+	// pushResponse.DeliveredSessions there.
 	// KindAsk is push's reserved sibling in the other direction
 	// (harness→human) — see TargetUserID's doc comment for the shared
 	// envelope shape the two are meant to converge on.
@@ -275,6 +282,9 @@ type MemoryBus struct {
 	subscribers map[chan Notification]struct{}
 	seq         int64
 	replay      *replayBuffer
+	// closed makes a post-Close Subscribe hand back an already-closed
+	// channel rather than one nobody will ever close — see Subscribe.
+	closed bool
 }
 
 // New creates a MemoryBus with the default replay buffer size.
@@ -335,6 +345,16 @@ func (b *MemoryBus) Subscribe() chan Notification {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	ch := make(chan Notification, 64)
+	if b.closed {
+		// Subscribing after Close used to register a channel that nobody
+		// would ever close, so a consumer ranging over it blocked forever —
+		// reachable during shutdown, where Stop closes the bus while a
+		// stream handler is still running. RedisBus guarded this from the
+		// start and the two implementations must not differ in a way a
+		// consumer can feel (codex round 2 on BUG-2651).
+		close(ch)
+		return ch
+	}
 	b.subscribers[ch] = struct{}{}
 	return ch
 }
@@ -349,6 +369,11 @@ func (b *MemoryBus) SubscribeAndReplaySince(sinceID int64) (chan Notification, [
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	ch := make(chan Notification, 64)
+	if b.closed {
+		// Same post-Close guard as Subscribe.
+		close(ch)
+		return ch, nil
+	}
 	b.subscribers[ch] = struct{}{}
 	missed := b.replay.since(sinceID)
 	return ch, missed
@@ -372,6 +397,10 @@ func (b *MemoryBus) EventsSince(sinceID int64) []Notification {
 func (b *MemoryBus) Close() {
 	b.mu.Lock()
 	defer b.mu.Unlock()
+	if b.closed {
+		return
+	}
+	b.closed = true
 	for ch := range b.subscribers {
 		delete(b.subscribers, ch)
 		close(ch)

--- a/internal/watchevents/watchevents.go
+++ b/internal/watchevents/watchevents.go
@@ -7,19 +7,28 @@
 // predicate before anything reaches a client (DR-2: no firehose, no
 // wildcard subscriptions).
 //
-// SINGLE-PROCESS LIMITATION. Bus here is an in-process pub/sub, exactly
-// like internal/events.MemoryBus — and it has the same blind spot: in a
-// multi-process padd deployment, a Notification published on one
-// process is never seen by a stream connection held open on a
-// different process, and is silently dropped for that connection. This
-// is precisely why internal/events also ships a RedisBus for
-// multi-instance deployments (Pad Cloud runs that shape). Bus is
-// defined as an interface specifically so a Redis-backed implementation
-// can slot in later without changing any producer or the stream
-// handler; only MemoryBus is implemented in Phase 1. Do not point this
-// package at a multi-process deployment without that follow-up — the
-// local plugin monitor talking to a local, single-process padd is the
-// only supported Phase 1 consumer.
+// TWO IMPLEMENTATIONS, PICKED BY DEPLOYMENT SHAPE. MemoryBus is an
+// in-process pub/sub, exactly like internal/events.MemoryBus, and it has
+// the same blind spot: a Notification published on one process is never
+// seen by a stream connection held open on a different process, and is
+// silently dropped for that connection. RedisBus (BUG-2651, redis_bus.go)
+// closes that by routing every notification through one shared Redis
+// channel. cmd/pad/cmd_server.go picks between them on PAD_REDIS_URL,
+// the same switch the event bus already uses — so a self-hosted
+// single-process binary keeps MemoryBus and never grows a Redis
+// dependency.
+//
+// Bus was defined as an interface from Phase 1 precisely so this could
+// slot in without touching any producer or the stream handler, and that
+// held: RedisBus changed neither.
+//
+// STILL PER-PROCESS, and worth knowing before assuming multi-instance is
+// finished: internal/server's SessionPresence registry. RedisBus makes
+// DELIVERY cross-instance — a push published on A now reaches a stream on
+// B, and B matches it against its own live sessions — but the
+// GET /api/v1/sessions listing still reports only the answering
+// instance's connections. See session_presence.go's own note for which
+// half that leaves open.
 package watchevents
 
 import (

--- a/internal/watchevents/watchevents.go
+++ b/internal/watchevents/watchevents.go
@@ -144,7 +144,7 @@ type Notification struct {
 
 // Bus is the pub/sub surface the watch pipeline's producers and the
 // GET /api/v1/events/stream consumer share. See the package doc comment
-// for why only an in-process MemoryBus exists in Phase 1.
+// for which implementation serves which deployment shape.
 type Bus interface {
 	// Publish assigns the Notification a monotonic ID, stores it in the
 	// replay buffer, and fans it out to every live Subscribe channel.

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -61,7 +61,7 @@ buildGoModule {
 
   # Update alongside go.sum. Regenerate via:
   #   nix build .#default 2>&1 | grep -A2 'got:'
-  vendorHash = "sha256-sxEvWbpdJIk5OJJFGPrewI1mgzNkpPr1tgM+16RRiwk=";
+  vendorHash = "sha256-3eAP+zJQ3MJzCGjKcFOzI5k+YvcwXuRyaF3dXK9P1AA=";
 
   subPackages = [ "cmd/pad" ];
 


### PR DESCRIPTION
Closes BUG-2651. Phase-0 unit of PLAN-2656; also a live correctness gap independent of that plan.

## What was broken

`internal/watchevents` shipped an in-process `MemoryBus` only. In a multi-instance deployment a notification published on instance A never reached a stream held open on instance B — watches *appeared* to work and silently dropped cross-instance. `Bus` was defined as an interface from Phase 1 for exactly this, and that held: adding `RedisBus` changed no producer and no consumer.

## Not a port of `internal/events.RedisBus`

That file is the obvious template and copying its structure would have reintroduced a bug this package already fixed. Three deliberate divergences, each documented where someone diffing the two would call it a mistake:

- **One channel, one replay buffer.** This package has exactly one logical stream by contract (DOC-2479 DR-2: all per-caller filtering happens in the consumer). Most of the template's per-workspace bookkeeping has nothing to key on.
- **Eager subscription for the bus's lifetime.** The replay buffer is filled by the *receive* path, so a lazily torn-down subscription stops filling it precisely before a `Last-Event-ID` resume. The template can afford lazy because per-workspace means N idle subscriptions; here it is one.
- **One mutex across subscriber membership and the replay buffer, held through the fan-out.** The template uses two and offers only separate `Subscribe` + `EventsSince`, which cannot provide `SubscribeAndReplaySince`'s guarantee. Copying its locking would have handed back the double-delivery window this package's interface exists to close.

## Fifteen Codex rounds

Every round through 13 found something real. 14 was clean but for stale comments; 15 was CLEAN.

| Round | Finding |
|---|---|
| 1 | **P1** `INCR`+`PUBLISH` as two calls is order-breaking (A gets 1, is descheduled, B gets 2 and publishes, A publishes 1). Fixed with an atomic Lua script. Also: the bus was never closed on shutdown; "exactly-once delivery" was a false claim in my own comment. |
| 2 | **P2** I claimed cross-instance delivery was fixed. Half true — see below. |
| 3, 4, 9 | Replay holes `MemoryBus` structurally cannot have, found in three shapes (mid-stream, cold start, empty bus). One variable (`knownFrom`) now covers all three. |
| 5 | **P2** go-redis retries made publish non-idempotent — on the push path a duplicate *dispatch* into an agent harness. Fixed with a `SET NX` token. |
| 6 | **P2** A counter reset would replay stale ids into the new id space. |
| 10, 11, 12 | The resume-time authority check: added, then fixed for comparing against a *stale* counter snapshot (both directions), then for treating an absent key as unreadable rather than as zero. |
| 13 | **P2** A reset that has already climbed *past* our high-water mark is invisible to arithmetic. Added an epoch marker. |

## Two things I got wrong

Recording these because the review record is the useful artifact, not the clean diff.

**I told the lead cross-instance delivery was fixed. It is half fixed.** `handlers_push.go` gates a session-targeted push on the *local* presence registry and skips the publish entirely, so a POST on A for a session held on B still delivers nothing. Broadcast and every non-push kind *are* fixed. I asserted the push path's behaviour from reading the bus and `session_presence.go` without reading the push handler. Corrected in all three artifacts that carried the claim, and filed as **BUG-2698**.

**Both load-bearing tests were vacuous as written**, and only the mutation matrix caught it:

- the "concurrency" test's producer finished before the subscriber joined, so the channel leg was never exercised — a split-lock mutant survived 50 iterations, then 0/5 independent runs. Rebuilt as a detector taking 600 subscribe attempts against a live producer: 8/8 kills, 0.02s.
- the fail-closed test asserted "nothing was delivered", which is equally true of the policy it existed to exclude (`Publish` never delivers locally, so with Redis down neither policy delivers). Rewritten around a go-redis hook recording *attempted commands*, which is where the policies actually differ.

## `miniredis` as a test dependency

Codex raised the untested-round-trip gap three times; I deferred twice. The argument became concrete when the idempotency script shipped indexing `ARGV[3]` while `Publish` passed two arguments — invisible to every hermetic test, caught by re-reading, which is not a control worth relying on for the next Lua edit.

It earned its place immediately: adding it surfaced a **real production race** where `NewRedisBus` returned before its subscription was live, so anything published in that window was lost to that instance — precisely a rolling deploy's shape. The constructor now waits for the confirmation.

`make vuln`: 0 vulnerabilities in imported packages.

## Deliberate residuals, each filed and cited in the code

- **BUG-2698** — targeted push resolved against local presence, plus `delivered_sessions` being wrong in both directions for a broadcast. Both are consequences of the per-process `SessionPresence`; one shared-state implementation closes both, and PLAN-2558 S3 already gates the web-UI push surface on it.
- **BUG-2699** — `push` returns `200 pushed:true` for a dropped publish, because `Bus.Publish` reports nothing. Fixing it is an interface change across two implementations and six call sites.
- **Unnamespaced Redis keys** — flat names matching `internal/events`' existing convention. The operational rule is one Redis endpoint per installation; relaxing it should cover both buses at once, from shared config.
- **The post-resume window** — a notification missed *after* a resume is invisible to any check made during it, and settling longer would not close it. The honest answer is a durable stream (Redis Streams with consumer groups), not a longer wait.

## Verification

**Gate matrix**, stated in full including what did not apply:

- `go build ./...` — clean
- `make lint` — 0 issues
- `go test ./internal/... ./cmd/...` — green
- `internal/watchevents` under `-race` at `-count=10` — green
- `make vuln` — 0 in imported packages
- `make test-pg` — 25 packages ok, exit 0, run on this exact tip. No store SQL changed in this unit, so it was arguably N/A; run anyway because the bus is wired into `Server.Stop`.
- web checks — **N/A**, no `web/` files changed
- Codex — CLEAN at round 15

**Mutation matrix.** 13 mutations, counted from this unit's run log (an earlier draft of this paragraph said 12 and had silently folded in three from the previous unit's matrix — recounted):

1. split lock — the `events.RedisBus` two-critical-section layout
2. settle window removed
3. re-read only the local side, not the counter
4. resume authority check disabled entirely
5. empty-coverage arm disabled
6. cold-start arm disabled
7. hole detection removed
8. stale buffer kept across a counter reset
9. epoch change ignored
10. `redis.Nil` back to "unreadable"
11. non-atomic `INCR`+`PUBLISH`
12. local-counter fallback instead of fail-closed
13. the `ARGV[3]` index bug restored — verifying the integration tests catch what justified adding miniredis

All 13 are killed by an assertion in the current tree. **Two of them survived their first run**, and that is the load-bearing fact rather than the final score: #1 survived 50 iterations and then 0/5 independent runs, and #12 passed outright. Both were tests, not implementation — see the vacuous-tests section above. A third was rewritten because its first form was killed by a *compile* error, which says nothing about the test.

---

https://claude.ai/code/session_017jD6t1zjxGSq47SQpZfp1V
