### PR TITLE
fix(watchevents): make the subscribe/replay overlap test deterministic (BUG-2707)

### DIFF
--- a/internal/watchevents/redis_bus.go
+++ b/internal/watchevents/redis_bus.go
@@ -182,6 +182,30 @@ type RedisBus struct {
 	replaySize  int
 	closed      bool
 
+	// afterSubscribeRegister is a test-only seam, nil in production and thus
+	// zero-cost there. SubscribeAndReplaySince calls it, while still holding
+	// mu, at the exact instant AFTER the subscriber is registered and BEFORE
+	// the replay buffer is read — the boundary that the single mutex
+	// collapses into one atomic step, and the boundary a reintroduced
+	// split-lock layout (events.RedisBus's template; see the type comment
+	// (3)) would place its unlock/relock around.
+	//
+	// TestRedisBusSubscribeAndReplayNeverDoubleDelivers uses it to force a
+	// concurrent fanOutLocally to attempt the lock right here, on every
+	// attempt, instead of racing an unsynchronized goroutine and hoping for a
+	// microsecond of overlap (which is what made that test flake — see its
+	// comment). Because the hook fires while mu is still held, the forced
+	// fan-out is provably blocked until the read+return completes; that is
+	// what the test is asserting still holds.
+	//
+	// The seam's value is tied to its POSITION, not its mere existence: if
+	// SubscribeAndReplaySince is ever restructured — e.g. split into two
+	// critical sections — this call must move with the register/read
+	// boundary, or the test starts exercising a spot that no longer
+	// corresponds to where a real regression would open a window, and passes
+	// while proving nothing.
+	afterSubscribeRegister func()
+
 	// knownFrom / lastAppendedID bound what this instance can HONESTLY
 	// replay — a failure mode MemoryBus structurally cannot have and this
 	// one can (codex rounds 3 and 4).
@@ -379,6 +403,9 @@ func (b *RedisBus) SubscribeAndReplaySince(sinceID int64) (chan Notification, []
 		return ch, nil
 	}
 	b.subscribers[ch] = struct{}{}
+	if b.afterSubscribeRegister != nil {
+		b.afterSubscribeRegister()
+	}
 	if forceGap {
 		return ch, nil
 	}

--- a/internal/watchevents/redis_bus_test.go
+++ b/internal/watchevents/redis_bus_test.go
@@ -208,53 +208,75 @@ drain:
 // a window a few nanoseconds wide, so a test built on one subscribe is a
 // coin-flip dressed as an assertion.
 //
-// This takes many chances instead: a producer runs continuously while
-// subscribers join over and over, and each join checks the ONE signature the
-// defect leaves — an id that appears in the replay slice AND then arrives on
-// the channel. No accounting of the whole id space, no timing assumptions
-// beyond "drain briefly"; just the intersection, which must be empty every
-// time.
+// BUG-2707: "many chances" turned out to be the same coin flip repeated —
+// an unsynchronized producer looping every 5 microseconds against 600
+// independent subscribes, hoping OS scheduling would occasionally interleave
+// them. On this environment it stopped landing at all (0-2 of 600), which
+// tripped the anti-vacuity guard below and made main red. Raising the
+// attempt count or loosening that guard would have papered over exactly the
+// silent-false-pass risk it exists to catch.
+//
+// So this drives the interleaving instead of hoping for it, via
+// RedisBus.afterSubscribeRegister — a seam at the one boundary the single
+// mutex collapses into an atomic step (see that field's comment). Each
+// attempt arms the hook to release a producer goroutine that calls
+// fanOutLocally the instant this subscribe call has registered its channel
+// but before it reads the replay buffer. Because the hook fires while mu is
+// still held, the producer's Lock() is provably forced to wait for the
+// read+return to finish — reproducing the register/read boundary on EVERY
+// attempt, not just the lucky ones. The assertion is unchanged: an id that
+// shows up in the replay slice AND arrives on the channel is the defect's one
+// signature, and it must never happen.
 func TestRedisBusSubscribeAndReplayNeverDoubleDelivers(t *testing.T) {
-	const attempts = 600
+	const attempts = 30
 
 	b := newLocalOnlyBus(4096)
 	defer b.Close()
 
-	stop := make(chan struct{})
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		for i := int64(1); ; i++ {
-			select {
-			case <-stop:
-				return
-			default:
-			}
-			b.fanOutLocally(Notification{ID: i, Kind: KindStatusChange, ItemRef: "TASK-1"})
-			time.Sleep(5 * time.Microsecond)
-		}
-	}()
-	defer func() {
-		close(stop)
-		wg.Wait()
-	}()
+	// A small backlog before the first subscribe, so `missed` is non-empty
+	// from attempt 0 — the notifications each attempt forces live (below)
+	// grow it further for every later attempt.
+	nextID := int64(1)
+	for ; nextID <= 5; nextID++ {
+		b.fanOutLocally(Notification{ID: nextID, Kind: KindStatusChange, ItemRef: "TASK-1"})
+	}
 
 	straddled := 0
 	for i := 0; i < attempts; i++ {
+		liveID := nextID
+		nextID++
+
+		producerDone := make(chan struct{})
+		b.afterSubscribeRegister = func() {
+			// Runs on the SAME goroutine as SubscribeAndReplaySince, while it
+			// still holds mu. Starting the producer here (rather than
+			// waiting for it) is what avoids deadlocking against the lock
+			// this goroutine is holding — see afterSubscribeRegister's
+			// comment.
+			go func() {
+				b.fanOutLocally(Notification{ID: liveID, Kind: KindStatusChange, ItemRef: "TASK-1"})
+				close(producerDone)
+			}()
+		}
+
 		ch, missed := b.SubscribeAndReplaySince(0)
+		b.afterSubscribeRegister = nil
+
+		// Block until the forced fan-out has actually completed before
+		// draining, so the drain is not itself racing the producer — it
+		// only needs to observe a send that has already happened.
+		select {
+		case <-producerDone:
+		case <-time.After(time.Second):
+			b.Unsubscribe(ch)
+			t.Fatalf("attempt %d: forced fan-out for id=%d never completed", i, liveID)
+		}
 
 		replayed := make(map[int64]struct{}, len(missed))
 		for _, n := range missed {
 			replayed[n.ID] = struct{}{}
 		}
 
-		// NON-BLOCKING drain, and the reason is what makes this test both
-		// fast and exact. In the split-lock layout the duplicate is SENT
-		// before the buffer is read — register, unlock, [fan-out sends],
-		// lock, read — so by the time this call has returned, the duplicate
-		// is already sitting in the channel's buffer. Waiting on a timer
-		// bought nothing but 11 seconds of CI time.
 		got := 0
 	drain:
 		for {
@@ -279,12 +301,16 @@ func TestRedisBusSubscribeAndReplayNeverDoubleDelivers(t *testing.T) {
 		b.Unsubscribe(ch)
 	}
 
-	// Same anti-vacuity guard as above, applied to the whole run: if no
-	// attempt ever saw both a replay and a live delivery, this test spun
-	// without ever approaching the boundary and its silence means nothing.
-	if straddled == 0 {
-		t.Fatalf("none of %d attempts saw both replayed and live notifications; "+
-			"the producer and the subscriber never overlapped", attempts)
+	// The forced interleaving above makes every attempt straddle by
+	// construction, so this is no longer "did we get lucky at least once" —
+	// it is a seam-health check. Anything less than every attempt means the
+	// forced fan-out is landing somewhere other than register-then-read
+	// (afterSubscribeRegister has drifted from that boundary, or the
+	// synchronization above is wrong), and the run is back to proving
+	// nothing about the window.
+	if straddled != attempts {
+		t.Fatalf("only %d/%d attempts straddled the subscribe boundary; the forced interleaving "+
+			"is not landing where it should — see afterSubscribeRegister's comment", straddled, attempts)
 	}
 	t.Logf("%d/%d attempts straddled the subscribe boundary", straddled, attempts)
 }


### PR DESCRIPTION
Main is red on TestRedisBusSubscribeAndReplayNeverDoubleDelivers: its anti-vacuity guard (from #1167) requires an overlap the test could only reach probabilistically, and scheduling on the dev box stopped cooperating (0-2/600 straddles).

Fix: a nil-checked test seam (afterSubscribeRegister) at the register/replay-read boundary forces the interleaving deterministically — every attempt straddles by construction — and the guard inverts from 'at least one straddle' to 'every attempt straddles', so a relocated seam announces itself. The seam's comment carries the contract: its detection power depends on staying at that boundary.

Verified: 30/30 straddles at -count=20 and -race -count=10; un-fix check resurfaces the original flake (0-1/30); a simulated split-lock at the seam trips the duplicate detector 5/5 with the invariant named in the failure message. watchevents green under SQLite and Postgres; lint clean.

https://claude.ai/code/session_01BhQoeaWXxJbvw86ezzK8dt