### PR TITLE
feat(store): transactional event outbox — the SPEC-3 choke point (TASK-2658)

### DIFF
--- a/internal/kernelevents/taxonomy.go
+++ b/internal/kernelevents/taxonomy.go
@@ -73,7 +73,16 @@ const (
 	// batched.
 	ItemBulkUpdated = "item.bulk_updated"
 
+	// CommentCreated fires on comment creation. Payload: the stored comment
+	// row (body, author, item_id), not the item it hangs off — a binding that
+	// wants "a comment landed on an item matching X" filters the payload's
+	// item_id.
 	CommentCreated = "comment.created"
+
+	// CommentUpdated fires when a comment's body actually changes. A re-save
+	// of an identical body emits nothing, matching the item events, which emit
+	// only when a slice the taxonomy names moved. Payload: the post-update
+	// comment row.
 	CommentUpdated = "comment.updated"
 
 	// CommentDeleted fires on the HARD delete of a comment. Its payload is
@@ -97,8 +106,19 @@ const (
 	// bytes the system just reclaimed.
 	AttachmentRemoved = "attachment.removed"
 
+	// MemberJoined fires when a user is added to a workspace. Payload: the
+	// membership's own columns (workspace_id, user_id, role, created_at). The
+	// subject is the USER — a membership's key is the (workspace, user) pair
+	// and the workspace is already on the envelope. There is deliberately no
+	// member.left in v1: nothing forced it, and the closure rule makes that
+	// silence a versioned fact.
 	MemberJoined = "member.joined"
 
+	// Pack lifecycle events. Declared in the taxonomy because events/1 is the
+	// PUBLIC contract and its shape should not shift when packs arrive, but
+	// NOTHING EMITS THEM TODAY — there is no pack subsystem yet (phase 2+).
+	// A reader looking for their producers will not find one; that is the
+	// current state, not a missing wire-up.
 	PackInstalled = "pack.installed"
 	PackUpgraded  = "pack.upgraded"
 	PackDisabled  = "pack.disabled"
@@ -138,6 +158,69 @@ var canonical = map[string]string{
 	PackInstalled:     SubjectPack,
 	PackUpgraded:      SubjectPack,
 	PackDisabled:      SubjectPack,
+}
+
+// Payload families. Every canonical event produces exactly one payload shape,
+// and the family is what lets a writer check that an event and a payload were
+// meant for each other.
+//
+// Membership in the canonical set says the NAME is real; it says nothing about
+// whether the bytes attached to it are the right shape. Without families, a
+// caller could pair item.created with a ref-only deletion payload and the write
+// would be accepted — the taxonomy would have validated the half that was
+// already obviously correct (Codex round 10).
+const (
+	// PayloadItemSnapshot: a full item snapshot with the prior_status envelope
+	// pseudo-field.
+	PayloadItemSnapshot = "item_snapshot"
+
+	// PayloadItemBatch: member refs, the shared delta, and per-member
+	// snapshots.
+	PayloadItemBatch = "item_batch"
+
+	// PayloadCommentSnapshot / PayloadAttachmentSnapshot: the stored row.
+	PayloadCommentSnapshot    = "comment_snapshot"
+	PayloadAttachmentSnapshot = "attachment_snapshot"
+
+	// PayloadMember: the membership's own columns.
+	PayloadMember = "member"
+
+	// PayloadRefOnly: ids and parent refs, never content. The shape every
+	// hard-delete event uses, so a deletion can never re-ship what it deleted.
+	PayloadRefOnly = "ref_only"
+
+	// PayloadPack: reserved with the pack events; no producer yet.
+	PayloadPack = "pack"
+)
+
+var payloadFamilies = map[string]string{
+	ItemCreated:       PayloadItemSnapshot,
+	ItemUpdated:       PayloadItemSnapshot,
+	ItemStatusChanged: PayloadItemSnapshot,
+	ItemMoved:         PayloadItemSnapshot,
+	ItemDeleted:       PayloadItemSnapshot,
+	ItemRestored:      PayloadItemSnapshot,
+	ItemBulkUpdated:   PayloadItemBatch,
+	CommentCreated:    PayloadCommentSnapshot,
+	CommentUpdated:    PayloadCommentSnapshot,
+	CommentDeleted:    PayloadRefOnly,
+	AttachmentAdded:   PayloadAttachmentSnapshot,
+	AttachmentRemoved: PayloadRefOnly,
+	MemberJoined:      PayloadMember,
+	PackInstalled:     PayloadPack,
+	PackUpgraded:      PayloadPack,
+	PackDisabled:      PayloadPack,
+}
+
+// PayloadFamily returns the payload shape a canonical event carries, and false
+// if the name is not canonical.
+//
+// A writer that knows which shape it is about to marshal calls this to confirm
+// the event name agrees, so an event and a payload that were not meant for each
+// other cannot be stored together.
+func PayloadFamily(name string) (string, bool) {
+	family, ok := payloadFamilies[name]
+	return family, ok
 }
 
 // IsCanonical reports whether name is in the events/1 set.

--- a/internal/kernelevents/taxonomy.go
+++ b/internal/kernelevents/taxonomy.go
@@ -135,31 +135,23 @@ const (
 	SubjectPack       = "pack"
 )
 
-// canonical is the closed events/1 set mapped to its subject kind.
+// eventSpec is everything the kernel knows about one canonical event.
 //
-// A map rather than a slice because every consumer of this list is asking a
-// membership question — the closure rule is enforced by lookup, and the
-// subject kind falls out of the same entry instead of living in a second
-// table that could disagree with this one.
-var canonical = map[string]string{
-	ItemCreated:       SubjectItem,
-	ItemUpdated:       SubjectItem,
-	ItemStatusChanged: SubjectItem,
-	ItemMoved:         SubjectItem,
-	ItemDeleted:       SubjectItem,
-	ItemRestored:      SubjectItem,
-	ItemBulkUpdated:   SubjectItemBatch,
-	CommentCreated:    SubjectComment,
-	CommentUpdated:    SubjectComment,
-	CommentDeleted:    SubjectComment,
-	AttachmentAdded:   SubjectAttachment,
-	AttachmentRemoved: SubjectAttachment,
-	MemberJoined:      SubjectMember,
-	PackInstalled:     SubjectPack,
-	PackUpgraded:      SubjectPack,
-	PackDisabled:      SubjectPack,
+// ONE TABLE, not two maps keyed on the same names. A second map is a second
+// source of truth that can disagree with the first — and it disagreed
+// dangerously: a canonical event missing from a separate family map would
+// resolve to the empty family, which a caller declaring nothing would then
+// MATCH, so the check would fail OPEN exactly when it was needed (Codex round
+// 11, on code round 10 had just added). Co-locating the fields makes the drift
+// unrepresentable rather than tested-for.
+type eventSpec struct {
+	subject string
+	payload string
 }
 
+// canonical is the closed events/1 set. Adding an entry here is the ONLY way
+// to add a canonical event, and the compiler requires both fields, so a new
+// event cannot arrive half-declared.
 // Payload families. Every canonical event produces exactly one payload shape,
 // and the family is what lets a writer check that an event and a payload were
 // meant for each other.
@@ -193,23 +185,23 @@ const (
 	PayloadPack = "pack"
 )
 
-var payloadFamilies = map[string]string{
-	ItemCreated:       PayloadItemSnapshot,
-	ItemUpdated:       PayloadItemSnapshot,
-	ItemStatusChanged: PayloadItemSnapshot,
-	ItemMoved:         PayloadItemSnapshot,
-	ItemDeleted:       PayloadItemSnapshot,
-	ItemRestored:      PayloadItemSnapshot,
-	ItemBulkUpdated:   PayloadItemBatch,
-	CommentCreated:    PayloadCommentSnapshot,
-	CommentUpdated:    PayloadCommentSnapshot,
-	CommentDeleted:    PayloadRefOnly,
-	AttachmentAdded:   PayloadAttachmentSnapshot,
-	AttachmentRemoved: PayloadRefOnly,
-	MemberJoined:      PayloadMember,
-	PackInstalled:     PayloadPack,
-	PackUpgraded:      PayloadPack,
-	PackDisabled:      PayloadPack,
+var canonical = map[string]eventSpec{
+	ItemCreated:       {SubjectItem, PayloadItemSnapshot},
+	ItemUpdated:       {SubjectItem, PayloadItemSnapshot},
+	ItemStatusChanged: {SubjectItem, PayloadItemSnapshot},
+	ItemMoved:         {SubjectItem, PayloadItemSnapshot},
+	ItemDeleted:       {SubjectItem, PayloadItemSnapshot},
+	ItemRestored:      {SubjectItem, PayloadItemSnapshot},
+	ItemBulkUpdated:   {SubjectItemBatch, PayloadItemBatch},
+	CommentCreated:    {SubjectComment, PayloadCommentSnapshot},
+	CommentUpdated:    {SubjectComment, PayloadCommentSnapshot},
+	CommentDeleted:    {SubjectComment, PayloadRefOnly},
+	AttachmentAdded:   {SubjectAttachment, PayloadAttachmentSnapshot},
+	AttachmentRemoved: {SubjectAttachment, PayloadRefOnly},
+	MemberJoined:      {SubjectMember, PayloadMember},
+	PackInstalled:     {SubjectPack, PayloadPack},
+	PackUpgraded:      {SubjectPack, PayloadPack},
+	PackDisabled:      {SubjectPack, PayloadPack},
 }
 
 // PayloadFamily returns the payload shape a canonical event carries, and false
@@ -219,8 +211,8 @@ var payloadFamilies = map[string]string{
 // the event name agrees, so an event and a payload that were not meant for each
 // other cannot be stored together.
 func PayloadFamily(name string) (string, bool) {
-	family, ok := payloadFamilies[name]
-	return family, ok
+	spec, ok := canonical[name]
+	return spec.payload, ok
 }
 
 // IsCanonical reports whether name is in the events/1 set.
@@ -238,8 +230,8 @@ func IsCanonical(name string) bool {
 // SubjectKind returns the subject kind for a canonical event name, and false
 // if the name is not canonical.
 func SubjectKind(name string) (string, bool) {
-	kind, ok := canonical[name]
-	return kind, ok
+	spec, ok := canonical[name]
+	return spec.subject, ok
 }
 
 // Canonical returns the events/1 set. The returned slice is freshly built on

--- a/internal/kernelevents/taxonomy.go
+++ b/internal/kernelevents/taxonomy.go
@@ -76,7 +76,26 @@ const (
 	CommentCreated = "comment.created"
 	CommentUpdated = "comment.updated"
 
+	// CommentDeleted fires on the HARD delete of a comment. Its payload is
+	// REF-ONLY (SPEC-3 v1.4) — ids and parent refs, never the deleted body.
+	//
+	// The asymmetry with ItemDeleted is deliberate and load-bearing. An item
+	// "delete" is an archive: the row survives, so its snapshot stays
+	// addressable and carrying it costs nothing that is not already there. A
+	// comment delete is a hard delete, and a deletion event that re-ships the
+	// content it deletes hands every consumer a durable copy of exactly what
+	// the user asked to remove. The consumer needs to reconcile its model,
+	// not to receive the body again.
+	CommentDeleted = "comment.deleted"
+
 	AttachmentAdded = "attachment.added"
+
+	// AttachmentRemoved fires when an attachment row is hard-deleted (orphan
+	// GC). REF-ONLY for the same reason as CommentDeleted, and with a sharper
+	// edge: an attachment payload carries the filename, content hash and
+	// STORAGE KEY, so re-shipping it on removal would hand out a locator for
+	// bytes the system just reclaimed.
+	AttachmentRemoved = "attachment.removed"
 
 	MemberJoined = "member.joined"
 
@@ -112,7 +131,9 @@ var canonical = map[string]string{
 	ItemBulkUpdated:   SubjectItemBatch,
 	CommentCreated:    SubjectComment,
 	CommentUpdated:    SubjectComment,
+	CommentDeleted:    SubjectComment,
 	AttachmentAdded:   SubjectAttachment,
+	AttachmentRemoved: SubjectAttachment,
 	MemberJoined:      SubjectMember,
 	PackInstalled:     SubjectPack,
 	PackUpgraded:      SubjectPack,

--- a/internal/kernelevents/taxonomy.go
+++ b/internal/kernelevents/taxonomy.go
@@ -1,12 +1,10 @@
-// Package kernelevents defines the events/1 contract surface — the closed set
-// of canonical event names, the envelope every event carries, and the mapping
-// from a canonical name onto the per-surface wire vocabularies.
+// Package kernelevents defines the events/1 contract surface: the closed set of
+// canonical event names and the subject kind each one is about.
 //
 // This package is the contract, not the plumbing. SPEC-3 (DOC-2653) calls the
 // taxonomy a PUBLIC contract rather than internal wiring: connected apps
 // consume these names through webhooks, so a name here is as load-bearing as
-// an HTTP route. Storage lives in the store's event_outbox table; dispatch
-// lives in the server's drain loop; both refer back to the names defined here.
+// an HTTP route. Storage lives in the store's event_outbox table.
 //
 // Two rules from SPEC-3 shape everything below:
 //
@@ -17,11 +15,20 @@
 //     IsCanonical exists — a typo'd name must fail loudly at the choke point
 //     rather than travel to a consumer that will never recognize it.
 //
-//   - THE CHOKE POINT OWNS THE MAPPING. Before this package, SSE used
-//     snake_case names published from one set of hand-calls and webhooks used
+//   - THE CHOKE POINT WILL OWN THE MAPPING — and does not yet. Today SSE uses
+//     snake_case names published from one set of hand-calls and webhooks use
 //     dot-form string literals passed at a different set of hand-calls; the
-//     two vocabularies drifted because nothing tied them together. Under
-//     events/1 both surfaces derive from one canonical name (SPEC-3 v1.1).
+//     two vocabularies drifted because nothing ties them together. SPEC-3 v1.1
+//     rules that both surfaces derive from one canonical name, but THIS
+//     PACKAGE DOES NOT IMPLEMENT THAT MAPPING: it maps a canonical name to a
+//     subject kind and nothing else. The surface mapping, the drain that would
+//     use it, and the retirement of the legacy hand-calls are TASK-2714.
+//
+// SO, PLAINLY, SO NOBODY READS AN INTENTION AS A DESCRIPTION: as of this
+// package's introduction the outbox FILLS and nothing drains it. Every legacy
+// SSE publish and hand-called webhook dispatch still fires exactly as before.
+// ListPendingOutboxEvents has no production caller. That is the agreed shape
+// of this change, not an unfinished edge.
 package kernelevents
 
 // Canonical event names — the events/1 set (SPEC-3 §Taxonomy, v1.1).

--- a/internal/kernelevents/taxonomy.go
+++ b/internal/kernelevents/taxonomy.go
@@ -1,0 +1,146 @@
+// Package kernelevents defines the events/1 contract surface — the closed set
+// of canonical event names, the envelope every event carries, and the mapping
+// from a canonical name onto the per-surface wire vocabularies.
+//
+// This package is the contract, not the plumbing. SPEC-3 (DOC-2653) calls the
+// taxonomy a PUBLIC contract rather than internal wiring: connected apps
+// consume these names through webhooks, so a name here is as load-bearing as
+// an HTTP route. Storage lives in the store's event_outbox table; dispatch
+// lives in the server's drain loop; both refer back to the names defined here.
+//
+// Two rules from SPEC-3 shape everything below:
+//
+//   - THE CLOSURE RULE. A mutation whose event name is not in the canonical
+//     set emits nothing in v1. The set grows additively with the contract
+//     version, so silence about a mutation type is a versioned fact rather
+//     than an oversight. This is why Canonical is an explicit list and why
+//     IsCanonical exists — a typo'd name must fail loudly at the choke point
+//     rather than travel to a consumer that will never recognize it.
+//
+//   - THE CHOKE POINT OWNS THE MAPPING. Before this package, SSE used
+//     snake_case names published from one set of hand-calls and webhooks used
+//     dot-form string literals passed at a different set of hand-calls; the
+//     two vocabularies drifted because nothing tied them together. Under
+//     events/1 both surfaces derive from one canonical name (SPEC-3 v1.1).
+package kernelevents
+
+// Canonical event names — the events/1 set (SPEC-3 §Taxonomy, v1.1).
+//
+// item.restored and item.bulk_updated were admitted in v1.1 during TASK-2658
+// recon: restore is a live first-class mutation whose silence would let an
+// item reappear unobserved, and the batch event preserves TASK-1668's
+// anti-flood decision for lane-wide mutations.
+const (
+	// ItemCreated fires on item creation. Payload carries the post-create
+	// snapshot.
+	ItemCreated = "item.created"
+
+	// ItemUpdated fires on a field/content mutation that is not a status
+	// change. Payload carries the post-update snapshot.
+	ItemUpdated = "item.updated"
+
+	// ItemStatusChanged is first-class rather than inferred from
+	// ItemUpdated, because most bindings want exactly this — including
+	// terminality transitions. Payload carries the post-change snapshot plus
+	// the prior_status envelope pseudo-field.
+	ItemStatusChanged = "item.status_changed"
+
+	// ItemMoved fires when an item changes collection. Payload carries the
+	// post-move snapshot.
+	ItemMoved = "item.moved"
+
+	// ItemDeleted is pinned to the SOFT-DELETE/archive mutation (SPEC-3
+	// v1.1) — this codebase has no hard item delete on the request path.
+	// Payload carries the final pre-archive snapshot, which is what keeps a
+	// deleted item addressable by binding predicates.
+	ItemDeleted = "item.deleted"
+
+	// ItemRestored fires on un-archive. Payload carries the post-restore
+	// snapshot.
+	ItemRestored = "item.restored"
+
+	// ItemBulkUpdated is the canonical BATCH event: one wire event for a
+	// whole lane-wide mutation. Binding evaluation is still per-member —
+	// the dispatcher runs item-level selectors against each member snapshot
+	// — so bindings never miss a bulk mutation; only wire delivery is
+	// batched.
+	ItemBulkUpdated = "item.bulk_updated"
+
+	CommentCreated = "comment.created"
+	CommentUpdated = "comment.updated"
+
+	AttachmentAdded = "attachment.added"
+
+	MemberJoined = "member.joined"
+
+	PackInstalled = "pack.installed"
+	PackUpgraded  = "pack.upgraded"
+	PackDisabled  = "pack.disabled"
+)
+
+// Subject kinds — what an event is about. Stored alongside the event so a
+// consumer (and the drain loop) can route without parsing the name.
+const (
+	SubjectItem       = "item"
+	SubjectItemBatch  = "item_batch"
+	SubjectComment    = "comment"
+	SubjectAttachment = "attachment"
+	SubjectMember     = "member"
+	SubjectPack       = "pack"
+)
+
+// canonical is the closed events/1 set mapped to its subject kind.
+//
+// A map rather than a slice because every consumer of this list is asking a
+// membership question — the closure rule is enforced by lookup, and the
+// subject kind falls out of the same entry instead of living in a second
+// table that could disagree with this one.
+var canonical = map[string]string{
+	ItemCreated:       SubjectItem,
+	ItemUpdated:       SubjectItem,
+	ItemStatusChanged: SubjectItem,
+	ItemMoved:         SubjectItem,
+	ItemDeleted:       SubjectItem,
+	ItemRestored:      SubjectItem,
+	ItemBulkUpdated:   SubjectItemBatch,
+	CommentCreated:    SubjectComment,
+	CommentUpdated:    SubjectComment,
+	AttachmentAdded:   SubjectAttachment,
+	MemberJoined:      SubjectMember,
+	PackInstalled:     SubjectPack,
+	PackUpgraded:      SubjectPack,
+	PackDisabled:      SubjectPack,
+}
+
+// IsCanonical reports whether name is in the events/1 set.
+//
+// The choke point calls this before writing an outbox row. A name that fails
+// here is a programming error, not a runtime condition: it means a caller
+// invented an event the contract does not define, and letting it through
+// would put a name on the public webhook surface that no consumer can
+// recognize and no version note explains.
+func IsCanonical(name string) bool {
+	_, ok := canonical[name]
+	return ok
+}
+
+// SubjectKind returns the subject kind for a canonical event name, and false
+// if the name is not canonical.
+func SubjectKind(name string) (string, bool) {
+	kind, ok := canonical[name]
+	return kind, ok
+}
+
+// Canonical returns the events/1 set. The returned slice is freshly built on
+// each call, so a caller cannot mutate the contract out from under everyone
+// else — the closed set is closed at runtime too, not merely by convention.
+//
+// Order is unspecified (map iteration); callers that render this for humans
+// sort it themselves.
+func Canonical() []string {
+	names := make([]string, 0, len(canonical))
+	for name := range canonical {
+		names = append(names, name)
+	}
+	return names
+}

--- a/internal/server/handlers_auth.go
+++ b/internal/server/handlers_auth.go
@@ -653,7 +653,14 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 	// If registering via invitation, automatically add the user to the
 	// workspace and mark the invitation as accepted.
 	if invitation != nil {
-		_ = s.store.AddWorkspaceMember(invitation.WorkspaceID, user.ID, invitation.Role)
+		// Not fatal (see BUG-2715), but no longer silent: TASK-2658 made
+		// AddWorkspaceMember transactional, so it can now fail for a reason
+		// unrelated to the membership row itself — and the invitation is
+		// consumed on the next line either way.
+		if err := s.store.AddWorkspaceMember(invitation.WorkspaceID, user.ID, invitation.Role); err != nil {
+			slog.Error("invitation accepted but member was not added",
+				"workspace_id", invitation.WorkspaceID, "user_id", user.ID, "error", err)
+		}
 		_ = s.store.AcceptInvitation(invitation.ID)
 	}
 

--- a/internal/server/handlers_comments.go
+++ b/internal/server/handlers_comments.go
@@ -116,6 +116,15 @@ func (s *Server) handleCreateComment(w http.ResponseWriter, r *http.Request) {
 	// This prevents duplicate timeline entries (one for the comment, one for the activity).
 	// Only set ActivityID on success — comments.activity_id has a FK constraint,
 	// and CreateActivity returns an ID even on insert failure.
+	//
+	// THE ORDER IS FORCED, and it leaves a window: the activity commits in its
+	// own transaction before CreateComment runs, so any CreateComment failure
+	// leaves an orphan "commented" activity with no comment behind it. It
+	// cannot simply be reordered — the comment carries the activity's id, so
+	// the activity has to exist first. Pre-existing (a unique violation or DB
+	// error always could), widened slightly by TASK-2658 giving CreateComment
+	// one more way to fail. Tracked as BUG-2716; closing it needs a store-level
+	// call that writes both rows in one transaction.
 	if activityID, err := s.logActivityWithMetaReturningID(workspaceID, item.ID, "commented", r, ""); err == nil && activityID != "" {
 		input.ActivityID = activityID
 	}

--- a/internal/server/handlers_import_bundle.go
+++ b/internal/server/handlers_import_bundle.go
@@ -173,9 +173,13 @@ func (s *Server) handleImportWorkspaceBundle(w http.ResponseWriter, r *http.Requ
 	}
 
 	// Mirror the JSON-import path's owner-attachment so the workspace
-	// shows up under the importer's account.
+	// shows up under the importer's account — including its error posture:
+	// not fatal (BUG-2715), but not discarded either.
 	if userID != "" {
-		_ = s.store.AddWorkspaceMember(ws.ID, userID, "owner")
+		if err := s.store.AddWorkspaceMember(ws.ID, userID, "owner"); err != nil {
+			slog.Error("bundle imported but importer was not added as owner",
+				"workspace_id", ws.ID, "user_id", userID, "error", err)
+		}
 	}
 	writeJSON(w, http.StatusCreated, ws)
 }

--- a/internal/server/handlers_workspaces.go
+++ b/internal/server/handlers_workspaces.go
@@ -685,9 +685,15 @@ func (s *Server) handleImportWorkspace(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Add the importer as workspace owner (mirrors handleCreateWorkspace)
+	// Add the importer as workspace owner (mirrors handleCreateWorkspace).
+	// Same posture as that path: not fatal (BUG-2715), but not discarded —
+	// an import that silently fails here returns 201 for a workspace nobody
+	// can administer.
 	if userID != "" {
-		_ = s.store.AddWorkspaceMember(ws.ID, userID, "owner")
+		if err := s.store.AddWorkspaceMember(ws.ID, userID, "owner"); err != nil {
+			slog.Error("workspace imported but importer was not added as owner",
+				"workspace_id", ws.ID, "user_id", userID, "error", err)
+		}
 	}
 
 	writeJSON(w, http.StatusCreated, ws)

--- a/internal/server/handlers_workspaces.go
+++ b/internal/server/handlers_workspaces.go
@@ -300,9 +300,19 @@ func (s *Server) handleCreateWorkspace(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Add the creator as workspace owner
+	// Add the creator as workspace owner.
+	//
+	// The error is still not fatal here (changing that is BUG-2715 — a failure
+	// leaves an OWNERLESS workspace and a 201), but it is no longer discarded
+	// silently. TASK-2658 gave AddWorkspaceMember a second way to fail: it now
+	// writes member.joined transactionally, so an outbox failure rolls the
+	// membership back too. Widening a swallowed error without at least making
+	// it visible is how a new failure mode goes unnoticed for a year.
 	if userID := currentUserID(r); userID != "" {
-		_ = s.store.AddWorkspaceMember(ws.ID, userID, "owner")
+		if err := s.store.AddWorkspaceMember(ws.ID, userID, "owner"); err != nil {
+			slog.Error("workspace created but creator was not added as owner",
+				"workspace_id", ws.ID, "user_id", userID, "error", err)
+		}
 	}
 
 	// OAuth connection auto-add (PLAN-1519 / TASK-1521 / IDEA-1517 §1):

--- a/internal/store/attachments.go
+++ b/internal/store/attachments.go
@@ -1014,26 +1014,23 @@ func (s *Store) ClaimOrphanedVariantAttachment(id string) (bool, error) {
 // announced their arrival, and announcing their removal would hand a consumer
 // a deletion for an id it has never seen.
 //
-// I CHECKED ONE DIRECTION OF THAT AND STATED THE CONCLUSION FOR BOTH, so the
-// correction is recorded here rather than quietly fixed (Codex round 8).
+// THE IMPLICATION RUNS ONE WAY ONLY, which is the whole reason the gate below
+// exists. Never-attached implies never-announced: a row claimable by
+// ClaimNeverAttachedAttachment has item_id IS NULL, no path anywhere sets
+// attachments.item_id back to NULL on an existing row, and every birth path
+// producing a NULL item_id (CreateAttachment, CreateAttachmentTx,
+// CreateAttachmentForLiveItem's own orphan branch) is non-emitting.
 //
-// What is true, and verified: a row claimable by ClaimNeverAttachedAttachment
-// has item_id IS NULL, no path anywhere sets attachments.item_id back to NULL
-// on an existing row, and every birth path that produces a NULL item_id
-// (CreateAttachment, CreateAttachmentTx, CreateAttachmentForLiveItem's own
-// orphan branch) is non-emitting. So never-attached implies never-announced.
+// The CONVERSE is false: plenty of rows reach THIS path having never announced
+// themselves — variants (written by the thumbnail/derivation paths and
+// tombstoned by their original's cascade, so two per image upload), attachments
+// cloned by a cross-workspace copy, and attachments created by workspace
+// import.
 //
-// What does NOT follow, and what I asserted anyway: that everything reaching
-// THIS path announced itself. It does not. Rows arrive here having never
-// emitted attachment.added by at least three routes — variants (written by the
-// thumbnail/derivation paths and tombstoned by their original's cascade),
-// attachments cloned by a cross-workspace copy through CreateAttachmentTx, and
-// attachments created by workspace import.
-//
-// The emit below therefore carries the SAME gate as attachment.added — a
-// user-visible original, attached to an item — so the two are symmetric by
-// construction rather than by argument. That closes the variant route, which is
-// the systematic one.
+// So the emit carries the SAME gate as attachment.added — a user-visible
+// original, attached to an item — and the two are symmetric by construction
+// rather than by argument. That closes the variant route, which is the
+// systematic one.
 //
 // RESIDUE, stated because it is real: an import- or copy-created attachment
 // still passes that gate while never having emitted an addition, so its removal

--- a/internal/store/attachments.go
+++ b/internal/store/attachments.go
@@ -1004,8 +1004,46 @@ func (s *Store) ClaimOrphanedVariantAttachment(id string) (bool, error) {
 // row-before-bytes contract and same IRREVOCABILITY note as
 // ClaimNeverAttachedAttachment: once true, no recovery surface can
 // bring the row back.
+// TASK-2658: a successful claim also emits the ref-only attachment.removed
+// event, in the SAME transaction as the delete.
+//
+// Only THIS claim path emits, and the asymmetry with
+// ClaimNeverAttachedAttachment is deliberate rather than an oversight. That
+// one reclaims rows that were NEVER attached to an item, and attachment.added
+// fires only for attachments written against a live item — so those rows never
+// announced their arrival, and announcing their removal would hand a consumer
+// a deletion for an id it has never seen. A soft-deleted row, by contrast, WAS
+// attached and did emit, so its removal closes a loop the consumer is holding
+// open.
+//
+// The transaction does not weaken the claim protocol (BUG-2415): the claim's
+// conditionality lives entirely in the DELETE's WHERE clause, which is
+// unchanged, and wrapping one conditional statement plus one INSERT in a
+// transaction leaves the row-before-bytes contract and the IRREVOCABILITY note
+// exactly as they were.
 func (s *Store) ClaimSoftDeletedAttachment(id string, graceCutoff time.Time) (bool, error) {
-	res, err := s.db.Exec(s.q(`
+	tx, err := s.db.Begin()
+	if err != nil {
+		return false, fmt.Errorf("claim soft-deleted attachment: %w", err)
+	}
+	defer tx.Rollback()
+
+	// Read the refs BEFORE the delete — afterwards there is no row to read
+	// them from. A missing row is not an error here: it means another sweep
+	// (or a restore) got there first, and the claim below will match zero rows
+	// and report false, which is the existing contract.
+	var workspaceID string
+	var itemID sql.NullString
+	refsKnown := true
+	switch err := tx.QueryRow(s.q(`SELECT workspace_id, item_id FROM attachments WHERE id = ?`), id).
+		Scan(&workspaceID, &itemID); {
+	case errors.Is(err, sql.ErrNoRows):
+		refsKnown = false
+	case err != nil:
+		return false, fmt.Errorf("claim soft-deleted attachment refs: %w", err)
+	}
+
+	res, err := tx.Exec(s.q(`
 		DELETE FROM attachments
 		WHERE id = ?
 		  AND deleted_at IS NOT NULL
@@ -1018,7 +1056,24 @@ func (s *Store) ClaimSoftDeletedAttachment(id string, graceCutoff time.Time) (bo
 	if err != nil {
 		return false, fmt.Errorf("claim soft-deleted attachment rows: %w", err)
 	}
-	return n == 1, nil
+	if n != 1 {
+		// Nothing claimed: commit the (empty) transaction and report false,
+		// preserving the existing contract exactly.
+		if err := tx.Commit(); err != nil {
+			return false, fmt.Errorf("claim soft-deleted attachment: %w", err)
+		}
+		return false, nil
+	}
+
+	if refsKnown {
+		if err := s.emitRefOnlyDeletionTx(tx, kernelevents.AttachmentRemoved, workspaceID, id, itemID.String, ""); err != nil {
+			return false, err
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return false, fmt.Errorf("claim soft-deleted attachment: %w", err)
+	}
+	return true, nil
 }
 
 // AttachmentHashesWithRows reports which of the given content hashes have

--- a/internal/store/attachments.go
+++ b/internal/store/attachments.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/PerpetualSoftware/pad/internal/kernelevents"
 	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
@@ -174,6 +175,28 @@ func (s *Store) CreateAttachmentForLiveItem(a *models.Attachment) error {
 
 	if err := s.createAttachmentOn(tx, a); err != nil {
 		return err
+	}
+
+	// The choke point (SPEC-3 / TASK-2658): attachment.added, written in the
+	// same transaction as the row and under the same parent-item lock, so the
+	// event cannot outlive a refused insert.
+	//
+	// GATED TO USER-VISIBLE ORIGINALS, and the gate is the whole subtlety
+	// here. Variants are ATTACHMENT ROWS too — a thumbnail carries ParentID
+	// plus Variant "thumb-sm"/"thumb-md" (models.Attachment) — so an ungated
+	// emit fires three attachment.added events for one image upload, two of
+	// them announcing files no user added and no binding wants. A derived row
+	// always has a parent, so "no parent, and not a non-original variant" is
+	// the test.
+	//
+	// What this deliberately still ADMITS: a transform output (rotate/crop),
+	// which is a new top-level attachment with no ParentID — a user did add
+	// it, it is independently addressable, and calling it derived would be a
+	// judgment about provenance the row itself does not make.
+	if a.ParentID == nil && (a.Variant == nil || *a.Variant == models.AttachmentVariantOriginal) {
+		if err := s.emitAttachmentEventTx(tx, kernelevents.AttachmentAdded, a); err != nil {
+			return err
+		}
 	}
 	return tx.Commit()
 }

--- a/internal/store/attachments.go
+++ b/internal/store/attachments.go
@@ -1012,7 +1012,35 @@ func (s *Store) ClaimOrphanedVariantAttachment(id string) (bool, error) {
 // one reclaims rows that were NEVER attached to an item, and attachment.added
 // fires only for attachments written against a live item — so those rows never
 // announced their arrival, and announcing their removal would hand a consumer
-// a deletion for an id it has never seen. A soft-deleted row, by contrast, WAS
+// a deletion for an id it has never seen.
+//
+// I CHECKED ONE DIRECTION OF THAT AND STATED THE CONCLUSION FOR BOTH, so the
+// correction is recorded here rather than quietly fixed (Codex round 8).
+//
+// What is true, and verified: a row claimable by ClaimNeverAttachedAttachment
+// has item_id IS NULL, no path anywhere sets attachments.item_id back to NULL
+// on an existing row, and every birth path that produces a NULL item_id
+// (CreateAttachment, CreateAttachmentTx, CreateAttachmentForLiveItem's own
+// orphan branch) is non-emitting. So never-attached implies never-announced.
+//
+// What does NOT follow, and what I asserted anyway: that everything reaching
+// THIS path announced itself. It does not. Rows arrive here having never
+// emitted attachment.added by at least three routes — variants (written by the
+// thumbnail/derivation paths and tombstoned by their original's cascade),
+// attachments cloned by a cross-workspace copy through CreateAttachmentTx, and
+// attachments created by workspace import.
+//
+// The emit below therefore carries the SAME gate as attachment.added — a
+// user-visible original, attached to an item — so the two are symmetric by
+// construction rather than by argument. That closes the variant route, which is
+// the systematic one.
+//
+// RESIDUE, stated because it is real: an import- or copy-created attachment
+// still passes that gate while never having emitted an addition, so its removal
+// announces a subject the consumer never saw. The failure mode is noise rather
+// than harm — an unknown id in a delete is ignorable, where the reverse
+// (announced, never retracted) would leave stale state — and the deeper cause
+// is the deliberate silence of the import and copy paths, not this one. A soft-deleted row, by contrast, WAS
 // attached and did emit, so its removal closes a loop the consumer is holding
 // open.
 //
@@ -1033,10 +1061,10 @@ func (s *Store) ClaimSoftDeletedAttachment(id string, graceCutoff time.Time) (bo
 	// (or a restore) got there first, and the claim below will match zero rows
 	// and report false, which is the existing contract.
 	var workspaceID string
-	var itemID sql.NullString
+	var itemID, parentID, variant sql.NullString
 	refsKnown := true
-	switch err := tx.QueryRow(s.q(`SELECT workspace_id, item_id FROM attachments WHERE id = ?`), id).
-		Scan(&workspaceID, &itemID); {
+	switch err := tx.QueryRow(s.q(`SELECT workspace_id, item_id, parent_id, variant FROM attachments WHERE id = ?`), id).
+		Scan(&workspaceID, &itemID, &parentID, &variant); {
 	case errors.Is(err, sql.ErrNoRows):
 		refsKnown = false
 	case err != nil:
@@ -1065,7 +1093,12 @@ func (s *Store) ClaimSoftDeletedAttachment(id string, graceCutoff time.Time) (bo
 		return false, nil
 	}
 
-	if refsKnown {
+	// Same gate as attachment.added: a user-visible ORIGINAL attached to an
+	// item. Symmetry by construction — if it could not have announced its
+	// arrival, it does not announce its removal.
+	announceable := refsKnown && itemID.Valid && itemID.String != "" &&
+		!parentID.Valid && (!variant.Valid || variant.String == models.AttachmentVariantOriginal)
+	if announceable {
 		if err := s.emitRefOnlyDeletionTx(tx, kernelevents.AttachmentRemoved, workspaceID, id, itemID.String, ""); err != nil {
 			return false, err
 		}

--- a/internal/store/collections.go
+++ b/internal/store/collections.go
@@ -706,6 +706,15 @@ func (s *Store) applyFieldMigrationsTx(tx *sql.Tx, collectionID, workspaceID str
 	ts := now()
 	var totalAffected int64
 
+	// TASK-2658: this loop rewrites items.fields on every row carrying the old
+	// option value — a real change to item state that consumers cache — and it
+	// emitted nothing before. It is a SINGLE-TRANSACTION bulk mutation, so it
+	// gets one in-tx item.bulk_updated rather than per-row item.updated: a user
+	// renaming one select option must not arrive at a webhook consumer as
+	// hundreds of deliveries (TASK-1668 / SPEC-3 v1.1).
+	var touchedIDs []string
+	var renames []map[string]any
+
 	for _, m := range migrations {
 		for oldVal, newVal := range m.RenameOptions {
 			if oldVal == newVal {
@@ -759,9 +768,34 @@ func (s *Store) applyFieldMigrationsTx(tx *sql.Tx, collectionID, workspaceID str
 				}
 				n, _ := result.RowsAffected()
 				totalAffected += n
+				if n > 0 {
+					touchedIDs = append(touchedIDs, id)
+				}
+			}
+			if len(ids) > 0 {
+				renames = append(renames, map[string]any{
+					"field": m.Field,
+					"from":  oldVal,
+					"to":    newVal,
+				})
 			}
 		}
 	}
+
+	// Snapshots are read AFTER every UPDATE in this transaction, so a row
+	// touched by two migrations in one call is carried once, in its final
+	// state, rather than twice in intermediate ones.
+	members, err := s.itemSnapshotsTx(tx, touchedIDs)
+	if err != nil {
+		return totalAffected, err
+	}
+	if err := s.emitBulkItemEventTx(tx, workspaceID, members, map[string]any{
+		"kind":    "field_option_renamed",
+		"renames": renames,
+	}); err != nil {
+		return totalAffected, err
+	}
+
 	return totalAffected, nil
 }
 

--- a/internal/store/collections.go
+++ b/internal/store/collections.go
@@ -785,15 +785,19 @@ func (s *Store) applyFieldMigrationsTx(tx *sql.Tx, collectionID, workspaceID str
 	// Snapshots are read AFTER every UPDATE in this transaction, so a row
 	// touched by two migrations in one call is carried once, in its final
 	// state, rather than twice in intermediate ones.
+	// Report ZERO on failure, not totalAffected. Every error out of this
+	// function rolls the caller's transaction back, so the row count describes
+	// writes that did not commit — a caller observing (N, err) would be reading
+	// a number for changes that never happened (Codex round 4).
 	members, err := s.itemSnapshotsTx(tx, touchedIDs)
 	if err != nil {
-		return totalAffected, err
+		return 0, err
 	}
 	if err := s.emitBulkItemEventTx(tx, workspaceID, members, map[string]any{
 		"kind":    "field_option_renamed",
 		"renames": renames,
 	}); err != nil {
-		return totalAffected, err
+		return 0, err
 	}
 
 	return totalAffected, nil

--- a/internal/store/collections.go
+++ b/internal/store/collections.go
@@ -789,7 +789,7 @@ func (s *Store) applyFieldMigrationsTx(tx *sql.Tx, collectionID, workspaceID str
 	// function rolls the caller's transaction back, so the row count describes
 	// writes that did not commit — a caller observing (N, err) would be reading
 	// a number for changes that never happened (Codex round 4).
-	members, err := s.itemSnapshotsTx(tx, touchedIDs)
+	members, err := s.outboxMemberSnapshotsTx(tx, touchedIDs)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/store/comments.go
+++ b/internal/store/comments.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/PerpetualSoftware/pad/internal/kernelevents"
 	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
@@ -54,6 +55,18 @@ func (s *Store) CreateComment(workspaceID, itemID, userID string, input models.C
 	if err != nil {
 		return nil, fmt.Errorf("insert comment: %w", err)
 	}
+
+	// The choke point (SPEC-3 / TASK-2658): comment.created commits with the
+	// comment it describes. Read back in-tx so the payload is the stored row
+	// rather than the caller's input.
+	created, err := s.getCommentQ(tx, id)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.emitCommentEventTx(tx, kernelevents.CommentCreated, created); err != nil {
+		return nil, err
+	}
+
 	if err := tx.Commit(); err != nil {
 		return nil, fmt.Errorf("commit comment: %w", err)
 	}
@@ -95,6 +108,17 @@ func (s *Store) UpdateComment(id, body string) (*models.Comment, error) {
 	if n == 0 {
 		return nil, sql.ErrNoRows
 	}
+
+	// Gated on the UPDATE having changed a row — the zero-row case returns
+	// above, so a no-op edit announces nothing.
+	updated, err := s.getCommentQ(tx, id)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.emitCommentEventTx(tx, kernelevents.CommentUpdated, updated); err != nil {
+		return nil, err
+	}
+
 	if err := tx.Commit(); err != nil {
 		return nil, fmt.Errorf("commit comment update: %w", err)
 	}
@@ -103,7 +127,26 @@ func (s *Store) UpdateComment(id, body string) (*models.Comment, error) {
 
 // GetComment returns a single comment by ID.
 func (s *Store) GetComment(id string) (*models.Comment, error) {
-	row := s.db.QueryRow(s.q(`
+	return s.getCommentQ(s.db, id)
+}
+
+// getCommentQ is GetComment against any Queryer, so a caller holding a
+// transaction can read the row it just wrote.
+//
+// The reason is correctness before it is anything else: a read issued on s.db
+// takes a DIFFERENT connection, which cannot see the transaction's uncommitted
+// write. s.GetComment(id) called before COMMIT returns the pre-write row, or
+// no row at all for a comment being created — so an event built from it would
+// describe a state that is not the one committing. Event emission needs an
+// in-tx snapshot by design, so it must have an in-tx read to get one.
+//
+// The pool-contention hazard BUG-2409 covers is real too but secondary here,
+// and worth stating precisely rather than from memory: this store bounds
+// SQLite at sqliteMaxOpenConns (16), not one connection, so a pool read from
+// inside a transaction is a contention and lock-ordering risk under load, not
+// an unconditional deadlock.
+func (s *Store) getCommentQ(q Queryer, id string) (*models.Comment, error) {
+	row := q.QueryRow(s.q(`
 		SELECT c.id, c.item_id, c.workspace_id, c.author, COALESCE(c.user_id, ''), c.body,
 		       c.created_by, c.source, COALESCE(c.activity_id, ''), COALESCE(c.parent_id, ''),
 		       c.created_at, c.updated_at,

--- a/internal/store/comments.go
+++ b/internal/store/comments.go
@@ -88,8 +88,8 @@ func (s *Store) UpdateComment(id, body string) (*models.Comment, error) {
 	}
 	defer tx.Rollback()
 
-	var workspaceID string
-	if err := tx.QueryRow(s.q(`SELECT workspace_id FROM comments WHERE id = ?`), id).Scan(&workspaceID); err != nil {
+	var workspaceID, bodyBefore string
+	if err := tx.QueryRow(s.q(`SELECT workspace_id, body FROM comments WHERE id = ?`), id).Scan(&workspaceID, &bodyBefore); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, sql.ErrNoRows
 		}
@@ -109,14 +109,23 @@ func (s *Store) UpdateComment(id, body string) (*models.Comment, error) {
 		return nil, sql.ErrNoRows
 	}
 
-	// Gated on the UPDATE having changed a row — the zero-row case returns
-	// above, so a no-op edit announces nothing.
-	updated, err := s.getCommentQ(tx, id)
-	if err != nil {
-		return nil, err
-	}
-	if err := s.emitCommentEventTx(tx, kernelevents.CommentUpdated, updated); err != nil {
-		return nil, err
+	// Two gates, and the second one is the real no-op gate.
+	//
+	// The zero-row return above only catches a MISSING comment: the UPDATE
+	// matches on id alone, so re-saving an identical body still touches the
+	// row (updated_at moves) and still reports one row affected. An earlier
+	// version of this comment claimed that path suppressed a no-op edit; it
+	// does not (Codex round 4). Comparing the body is what does — and it keeps
+	// comment.updated consistent with the item events, which emit only when a
+	// slice the taxonomy names actually moved.
+	if body != bodyBefore {
+		updated, err := s.getCommentQ(tx, id)
+		if err != nil {
+			return nil, err
+		}
+		if err := s.emitCommentEventTx(tx, kernelevents.CommentUpdated, updated); err != nil {
+			return nil, err
+		}
 	}
 
 	if err := tx.Commit(); err != nil {

--- a/internal/store/comments.go
+++ b/internal/store/comments.go
@@ -268,14 +268,51 @@ func (s *Store) ListCommentsBeforeTime(itemID string, before time.Time, beforeID
 }
 
 // DeleteComment removes a comment by ID.
+// DeleteComment hard-deletes a comment and emits the ref-only
+// comment.deleted event in the same transaction (SPEC-3 v1.4 / TASK-2658).
+//
+// Transactional as of TASK-2658 — it was a bare Exec. The delete marker is
+// what resolves the conflict round 7 exposed: without it, a hard-deleted
+// comment's undispatched created/updated rows were the ONLY record it ever
+// existed, which forced a false choice between dropping committed events
+// (breaking the outbox guarantee) and delivering the deleted body forever.
+// With it, the created event still delivers, the deletion is announced
+// ref-only, and retention prunes both — privacy of a frozen payload is
+// temporal, not achieved by deleting rows out from under a consumer.
+//
+// The identifiers are read BEFORE the DELETE, in-tx, because after it there is
+// no row to read them from.
 func (s *Store) DeleteComment(id string) error {
-	result, err := s.db.Exec(s.q("DELETE FROM comments WHERE id = ?"), id)
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("delete comment: %w", err)
+	}
+	defer tx.Rollback()
+
+	var workspaceID, itemID string
+	var parentID sql.NullString
+	switch err := tx.QueryRow(s.q(`SELECT workspace_id, item_id, parent_id FROM comments WHERE id = ?`), id).
+		Scan(&workspaceID, &itemID, &parentID); {
+	case errors.Is(err, sql.ErrNoRows):
+		return sql.ErrNoRows
+	case err != nil:
+		return fmt.Errorf("delete comment: read refs: %w", err)
+	}
+
+	result, err := tx.Exec(s.q("DELETE FROM comments WHERE id = ?"), id)
 	if err != nil {
 		return fmt.Errorf("delete comment: %w", err)
 	}
 	n, _ := result.RowsAffected()
 	if n == 0 {
 		return sql.ErrNoRows
+	}
+
+	if err := s.emitRefOnlyDeletionTx(tx, kernelevents.CommentDeleted, workspaceID, id, itemID, parentID.String); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("delete comment: %w", err)
 	}
 	return nil
 }

--- a/internal/store/event_outbox.go
+++ b/internal/store/event_outbox.go
@@ -179,6 +179,89 @@ func (s *Store) emitItemEventTx(tx *sql.Tx, eventType string, item *models.Item,
 	})
 }
 
+// emitCommentEventTx writes one comment-subject event to the outbox on the
+// caller's transaction.
+//
+// The subject is the COMMENT, not the item it hangs off. A binding that wants
+// "a comment landed on an item matching X" filters the payload's item_id; a
+// binding keyed on the item as subject would be unable to distinguish a
+// comment from an edit to the item itself.
+func (s *Store) emitCommentEventTx(tx *sql.Tx, eventType string, comment *models.Comment) error {
+	if comment == nil {
+		return fmt.Errorf("outbox: %s has no comment snapshot", eventType)
+	}
+	payload, err := marshalEventPayload(comment)
+	if err != nil {
+		return err
+	}
+	return writeOutboxTx(tx, s, OutboxEvent{
+		WorkspaceID: comment.WorkspaceID,
+		EventType:   eventType,
+		SubjectID:   comment.ID,
+		Payload:     payload,
+	})
+}
+
+// emitAttachmentEventTx writes one attachment-subject event to the outbox on
+// the caller's transaction.
+//
+// Callers own the decision about WHICH attachment rows are event-worthy —
+// variants and derived rows are attachments too, and this helper deliberately
+// does not second-guess that gate, because the caller is the only place that
+// knows how the row was produced.
+func (s *Store) emitAttachmentEventTx(tx *sql.Tx, eventType string, a *models.Attachment) error {
+	if a == nil {
+		return fmt.Errorf("outbox: %s has no attachment snapshot", eventType)
+	}
+	payload, err := marshalEventPayload(a)
+	if err != nil {
+		return err
+	}
+	return writeOutboxTx(tx, s, OutboxEvent{
+		WorkspaceID: a.WorkspaceID,
+		EventType:   eventType,
+		SubjectID:   a.ID,
+		Payload:     payload,
+	})
+}
+
+// memberEventPayload is the wire shape of a member-subject event.
+//
+// A hand-built struct rather than a model, because workspace_members has no
+// model type — it is a join row. The keys are the row's own columns so a
+// binding predicate addresses them by the names they have in the database,
+// consistent with how the item payload works.
+type memberEventPayload struct {
+	WorkspaceID string `json:"workspace_id"`
+	UserID      string `json:"user_id"`
+	Role        string `json:"role"`
+	CreatedAt   string `json:"created_at"`
+}
+
+// emitMemberEventTx writes one member-subject event to the outbox on the
+// caller's transaction.
+//
+// The subject id is the USER, which is the only identifier a membership has —
+// the row's key is the (workspace, user) pair and the workspace is already on
+// the envelope.
+func (s *Store) emitMemberEventTx(tx *sql.Tx, eventType, workspaceID, userID, role, ts string) error {
+	payload, err := marshalEventPayload(memberEventPayload{
+		WorkspaceID: workspaceID,
+		UserID:      userID,
+		Role:        role,
+		CreatedAt:   ts,
+	})
+	if err != nil {
+		return err
+	}
+	return writeOutboxTx(tx, s, OutboxEvent{
+		WorkspaceID: workspaceID,
+		EventType:   eventType,
+		SubjectID:   userID,
+		Payload:     payload,
+	})
+}
+
 // itemDeltaExcludedKeys are the snapshot keys that must not count as a change
 // when deciding whether item.updated's slice moved.
 //

--- a/internal/store/event_outbox.go
+++ b/internal/store/event_outbox.go
@@ -488,6 +488,44 @@ func (s *Store) itemSnapshotsTx(tx *sql.Tx, ids []string) ([]*models.Item, error
 	return out, nil
 }
 
+// refOnlyDeletionPayload is the wire shape of a hard-delete event
+// (comment.deleted, attachment.removed) — SPEC-3 v1.4.
+//
+// IDS AND PARENT REFS, NEVER CONTENT. A deletion event exists so a consumer
+// can reconcile its model; shipping the deleted body or an attachment's
+// storage key would hand out a durable copy of exactly what was removed. Every
+// field here is an identifier: nothing a consumer did not already receive on
+// the create event, and nothing that re-exposes the subject.
+type refOnlyDeletionPayload struct {
+	ID          string `json:"id"`
+	WorkspaceID string `json:"workspace_id"`
+	ItemID      string `json:"item_id,omitempty"`
+	ParentID    string `json:"parent_id,omitempty"`
+}
+
+// emitRefOnlyDeletionTx writes one ref-only hard-delete event.
+//
+// Kept as its own helper rather than a flag on the existing emitters so the
+// ref-only shape cannot be reached with a full snapshot by accident: there is
+// no parameter here that could carry one.
+func (s *Store) emitRefOnlyDeletionTx(tx *sql.Tx, eventType, workspaceID, subjectID, itemID, parentID string) error {
+	payload, err := marshalEventPayload(refOnlyDeletionPayload{
+		ID:          subjectID,
+		WorkspaceID: workspaceID,
+		ItemID:      itemID,
+		ParentID:    parentID,
+	})
+	if err != nil {
+		return err
+	}
+	return writeOutboxTx(tx, s, OutboxEvent{
+		WorkspaceID: workspaceID,
+		EventType:   eventType,
+		SubjectID:   subjectID,
+		Payload:     payload,
+	})
+}
+
 // itemDeltaExcludedKeys are the snapshot keys that must not count as a change
 // when deciding whether item.updated's slice moved.
 //

--- a/internal/store/event_outbox.go
+++ b/internal/store/event_outbox.go
@@ -52,10 +52,18 @@ type OutboxEvent struct {
 // maxOutboxHop is SPEC-3 §L5's synchronous cascade bound: a binding-triggered
 // mutation inherits hop+1 and the kernel drops past depth 4.
 //
-// Bounds SYNCHRONOUS cascades only, and deliberately so — a queued playbook
-// run executed later, or a webhook consumer calling back through the API,
-// legitimately starts fresh at hop 0. Pretending otherwise would be
-// unenforceable, which is why SPEC-3 pairs this with per-pack quotas on
+// NOT YET EXERCISED IN PRODUCTION, and worth saying so rather than letting the
+// paragraph below read as a description of running behaviour. There is no
+// binding kernel yet (phase 2+), so nothing propagates a hop and every
+// production write leaves Hop at 0 — this bound and the column behind it are
+// the contract's shape, landed with the schema so the field does not have to
+// be retrofitted onto rows later. Its enforcement is covered by tests only.
+// Per-pack quota accounting, the other half of §L5, is likewise unimplemented.
+//
+// The rule it will enforce: bounds SYNCHRONOUS cascades only, deliberately —
+// a queued playbook run executed later, or a webhook consumer calling back
+// through the API, legitimately starts fresh at hop 0. Pretending otherwise
+// would be unenforceable, which is why SPEC-3 pairs it with per-pack quotas on
 // durable output rather than resting containment on the hop count alone.
 const maxOutboxHop = 4
 
@@ -96,11 +104,16 @@ func writeOutboxTx(tx *sql.Tx, s *Store, ev OutboxEvent) error {
 		return fmt.Errorf("outbox: event %s has a malformed JSON payload", ev.EventType)
 	}
 	if ev.Hop > maxOutboxHop {
-		// Cascade bound reached. Dropping is the designed behaviour, but a
-		// silent drop would make a runaway binding indistinguishable from a
-		// binding that never fired, so the drop is the caller's to observe:
-		// it is reported as a nil error with no row written, and the
-		// dispatcher's quota accounting is what surfaces the pattern.
+		// Cascade bound reached: drop the event, keep the mutation. No
+		// production caller can reach this today (see maxOutboxHop — nothing
+		// propagates a hop yet); it is here so the bound exists before the
+		// thing that needs it.
+		//
+		// When it does become reachable, a silent drop would make a runaway
+		// binding indistinguishable from one that never fired, so surfacing it
+		// is owed then — via the dispatcher's quota accounting, which is also
+		// still unimplemented. Recorded as an obligation rather than described
+		// as if it were already in place.
 		return nil
 	}
 

--- a/internal/store/event_outbox.go
+++ b/internal/store/event_outbox.go
@@ -120,9 +120,25 @@ func writeOutboxTx(tx *sql.Tx, s *Store, ev OutboxEvent) error {
 	if ev.ID == "" {
 		ev.ID = newID()
 	}
-	if ev.OccurredAt == "" {
-		ev.OccurredAt = now()
-	}
+	// occurred_at is STAMPED HERE, never accepted from the caller — same
+	// reasoning as subject_kind, applied to the rest of the class rather than
+	// waiting for a review to name the next member (CONVE-18).
+	//
+	// SPEC-3 §Bindings pins time-relative predicates (`within`) to this value,
+	// so a wrong one silently changes how a predicate evaluates — the same
+	// shape of silent harm a wrong subject_kind causes at routing time. No
+	// caller sets it today, and "the moment the event was written" is the only
+	// honest value while the write is transactional with the mutation.
+	//
+	// The enumeration, so the next reader does not have to redo it: of the
+	// eight fields on OutboxEvent, event_type is validated against the closed
+	// set, payload is validated as non-empty JSON, hop is bounded, subject_kind
+	// and occurred_at are derived, and id defaults but fails LOUDLY on a
+	// duplicate (primary key). That leaves workspace_id and subject_id as
+	// genuine caller inputs — neither is derivable, both are checked at their
+	// own call sites, and the bulk emitter partitions rather than trusting the
+	// workspace it is handed.
+	ev.OccurredAt = now()
 	// SUBJECT KIND IS DERIVED, NEVER TRUSTED. It is a pure function of the
 	// event name, so a caller-supplied value can only ever agree with the
 	// taxonomy or be wrong — and a wrong one persists silently and misroutes

--- a/internal/store/event_outbox.go
+++ b/internal/store/event_outbox.go
@@ -123,17 +123,30 @@ func writeOutboxTx(tx *sql.Tx, s *Store, ev OutboxEvent) error {
 	if ev.OccurredAt == "" {
 		ev.OccurredAt = now()
 	}
-	if ev.SubjectKind == "" {
-		kind, ok := kernelevents.SubjectKind(ev.EventType)
-		if !ok {
-			// Unreachable: IsCanonical above already established membership,
-			// and both answers come from the same map. Guarded anyway so a
-			// future split of those two lookups cannot silently write rows
-			// with an empty subject_kind.
-			return fmt.Errorf("outbox: no subject kind for canonical event %q", ev.EventType)
-		}
-		ev.SubjectKind = kind
+	// SUBJECT KIND IS DERIVED, NEVER TRUSTED. It is a pure function of the
+	// event name, so a caller-supplied value can only ever agree with the
+	// taxonomy or be wrong — and a wrong one persists silently and misroutes
+	// the event at drain time (Codex round 9). Before this, a non-empty value
+	// was taken as given, so `item.created` could be stored with
+	// subject_kind "comment" and nothing would notice; every test happened to
+	// pass either the correct value or none, which is exactly the blind spot
+	// that lets a bug like this survive eight review rounds.
+	kind, ok := kernelevents.SubjectKind(ev.EventType)
+	if !ok {
+		// Unreachable: IsCanonical above already established membership, and
+		// both answers come from the same map. Guarded anyway so a future
+		// split of those two lookups cannot silently write rows with an empty
+		// subject_kind.
+		return fmt.Errorf("outbox: no subject kind for canonical event %q", ev.EventType)
 	}
+	// A caller that supplied a DIFFERENT kind believes something false about
+	// the taxonomy. Silently correcting it would fix this row and leave the
+	// belief in place, so it is an error rather than an overwrite.
+	if ev.SubjectKind != "" && ev.SubjectKind != kind {
+		return fmt.Errorf("outbox: event %s has subject kind %q, want %q",
+			ev.EventType, ev.SubjectKind, kind)
+	}
+	ev.SubjectKind = kind
 
 	_, err := tx.Exec(s.q(`
 		INSERT INTO event_outbox (id, workspace_id, event_type, subject_kind, subject_id, payload, hop, occurred_at)

--- a/internal/store/event_outbox.go
+++ b/internal/store/event_outbox.go
@@ -84,6 +84,17 @@ func writeOutboxTx(tx *sql.Tx, s *Store, ev OutboxEvent) error {
 	if len(ev.Payload) == 0 {
 		return fmt.Errorf("outbox: event %s has an empty payload", ev.EventType)
 	}
+	// Validate here rather than leaning on the column type, because the column
+	// types DISAGREE: Postgres stores payload as JSONB and rejects malformed
+	// JSON at the INSERT, SQLite stores it as unconstrained TEXT and accepts
+	// it. Without this, the same bad payload fails a mutation on one backend
+	// and silently persists an undeliverable event on the other — a
+	// dual-dialect divergence in the one place the whole design is trying to
+	// make trustworthy (Codex round 3). Validating in Go makes the failure
+	// identical on both.
+	if !json.Valid(ev.Payload) {
+		return fmt.Errorf("outbox: event %s has a malformed JSON payload", ev.EventType)
+	}
 	if ev.Hop > maxOutboxHop {
 		// Cascade bound reached. Dropping is the designed behaviour, but a
 		// silent drop would make a runaway binding indistinguishable from a
@@ -360,13 +371,23 @@ func (s *Store) itemSnapshotsTx(tx *sql.Tx, ids []string) ([]*models.Item, error
 // when deciding whether item.updated's slice moved.
 //
 // AN EXCLUSION LIST, NOT AN INCLUSION LIST, and that direction is the point. A
-// column added to items later is included in the comparison by default, so the
-// worst a future schema change can do is emit an extra item.updated — visible,
+// new column that REACHES models.Item's JSON is compared by default, so the
+// worst such a schema change can do is emit an extra item.updated — visible,
 // arguable, fixable. An inclusion list would fail the other way: the new column
-// would be silently invisible to the delta, and a mutation that changed it
-// would emit nothing at all. Silent absence is the failure mode this whole unit
-// exists to eliminate, so it must not be reintroduced by the mechanism that
-// decides what to emit.
+// would be silently invisible, and a mutation that changed it would emit
+// nothing at all.
+//
+// THE LIMIT OF THAT GUARANTEE, stated precisely because the sloppy version of
+// this comment overclaimed it (Codex round 3): the diff sees the SNAPSHOT, not
+// the row. A column that models.Item does not carry — or carries as `json:"-"`
+// — is invisible here no matter what this list says. `items.last_restore_seq`
+// and the content-flush watermarks are exactly that, so a write touching ONLY
+// one of them emits nothing. Today that is unreachable in practice: every
+// caller that moves them also writes content or fields in the same mutation.
+// It is not structurally guaranteed, and a future column added to the table but
+// not to the model would inherit the same blind spot — so ADDING A PERSISTED
+// COLUMN THAT MATTERS TO CONSUMERS MEANS ADDING IT TO models.Item, not just to
+// the schema.
 //
 // Each exclusion is one of three things: bookkeeping that changes on EVERY
 // mutation (updated_at, seq, last_modified_by) and would therefore make the
@@ -396,6 +417,27 @@ var itemDeltaExcludedKeys = []string{
 	"item_number",
 }
 
+// fieldValueIsString reports whether the item's fields blob holds a JSON string
+// at key — the only shape extractFieldValue, and therefore the whole
+// status-transition path, can read. A missing key counts as a string ("" is
+// what extractFieldValue returns for it, and a cleared status is a legitimate
+// status transition).
+func fieldValueIsString(it *models.Item, key string) bool {
+	if it == nil {
+		return false
+	}
+	var f map[string]any
+	if err := json.Unmarshal([]byte(it.Fields), &f); err != nil {
+		return false
+	}
+	v, present := f[key]
+	if !present || v == nil {
+		return true
+	}
+	_, ok := v.(string)
+	return ok
+}
+
 // itemUpdatedSliceChanged reports whether anything outside the status and
 // location slices differs between two in-transaction snapshots of one item.
 //
@@ -406,6 +448,24 @@ var itemDeltaExcludedKeys = []string{
 // from a different query would silently compare rendering differences as if
 // they were changes.
 func itemUpdatedSliceChanged(before, after *models.Item, statusKey string) (bool, error) {
+	// MASK THE DONE KEY ONLY WHEN item.status_changed CAN ACTUALLY SEE IT.
+	//
+	// The status machinery (extractFieldValue) reads a done-key value only when
+	// it is a JSON STRING; anything else — a number, a bool, an object — reads
+	// as "". So for a numeric done field, `{"stage":1}` → `{"stage":2}` is a
+	// change status_changed will never report. Masking the key unconditionally
+	// then deleted it from BOTH snapshots, the remainder compared equal, and the
+	// mutation emitted NOTHING AT ALL: a real field change, silently unobservable
+	// (Codex round 3).
+	//
+	// The rule that fixes it is the disjoint-delta rule read carefully: a slice
+	// belongs to status_changed only if status_changed will describe it. When it
+	// will not, the change falls back to item.updated's slice, where something
+	// can. So mask only when both sides hold a string at that key — which is
+	// exactly the condition under which the status delta is visible.
+	maskStatus := statusKey == "" ||
+		(fieldValueIsString(before, statusKey) && fieldValueIsString(after, statusKey))
+
 	normalize := func(it *models.Item) (string, error) {
 		raw, err := json.Marshal(it)
 		if err != nil {
@@ -422,7 +482,7 @@ func itemUpdatedSliceChanged(before, after *models.Item, statusKey string) (bool
 		// nested delete rather than a top-level one. Re-marshalling the blob
 		// through a map also normalizes key order, which means a rewrite that
 		// only reorders keys is correctly NOT a change.
-		if statusKey != "" {
+		if statusKey != "" && maskStatus {
 			if blob, ok := m["fields"].(string); ok {
 				var f map[string]any
 				if err := json.Unmarshal([]byte(blob), &f); err == nil {
@@ -433,10 +493,13 @@ func itemUpdatedSliceChanged(before, after *models.Item, statusKey string) (bool
 					}
 					m["fields"] = string(nb)
 				}
-				// An unparseable fields blob is left verbatim. It compares
-				// byte-for-byte on both sides, so a corrupt blob still yields
-				// a correct "changed / did not change" answer; it just cannot
-				// have the status key masked out of it.
+				// An unparseable fields blob (an array, a scalar, corrupt JSON)
+				// is left verbatim. It compares byte-for-byte on both sides, so
+				// a corrupt blob still yields a correct changed / did-not-change
+				// answer; it just cannot have the status key masked out of it.
+				// Leaving such a change to item.updated is the honest outcome:
+				// the status machinery cannot see it either, so item.updated is
+				// the only event that can describe it at all.
 			}
 		}
 		// Map marshalling sorts keys, so this is a stable canonical form.

--- a/internal/store/event_outbox.go
+++ b/internal/store/event_outbox.go
@@ -262,6 +262,100 @@ func (s *Store) emitMemberEventTx(tx *sql.Tx, eventType, workspaceID, userID, ro
 	})
 }
 
+// bulkItemEventPayload is the wire shape of item.bulk_updated (SPEC-3 v1.1):
+// member refs, the shared delta, and PER-MEMBER SNAPSHOTS.
+//
+// The per-member snapshots are not optional decoration. v1.1 makes wire
+// delivery batched but binding evaluation PER-MEMBER — the dispatcher runs
+// item-level selectors against each member snapshot — so a payload without
+// them would silently make bulk mutations invisible to every item.updated and
+// status_changed binding, which is the gap the batch event was admitted to
+// avoid rather than create.
+type bulkItemEventPayload struct {
+	// Delta describes what the one mutation did, shared across members
+	// (e.g. {"kind":"field_option_renamed","field":"status","from":"wip","to":"in-progress"}).
+	Delta map[string]any `json:"delta"`
+
+	MemberCount int            `json:"member_count"`
+	Members     []*models.Item `json:"members"`
+}
+
+// emitBulkItemEventTx writes one item.bulk_updated event covering every member
+// of a single-transaction bulk mutation.
+//
+// ONE EVENT, NOT N — this is TASK-1668's anti-flood decision, which SPEC-3
+// v1.1 made canonical: a mutation the user experiences as ONE action (renaming
+// a select option, renaming an item and cascading its backlinks) must not
+// arrive at a webhook consumer as hundreds of separate deliveries.
+//
+// PAYLOAD SIZE IS DELIBERATELY UNBOUNDED IN V1, and that is a decision rather
+// than an oversight. The alternatives both cost correctness: capping the
+// member list silently drops binding evaluation for the tail, and omitting
+// `content` from the snapshots would break precisely the bindings that matter
+// for the wiki-title cascade, whose entire delta IS content. One large row is
+// the trade the batch event exists to make — the flood argument was about wire
+// deliveries and consumer rate limits, not about a single stored row — and the
+// payload is bounded by data the mutation already touched. If a real workspace
+// shows this producing unreasonable rows, bounding it is a measured follow-up,
+// not a guess made here.
+//
+// A bulk mutation that touched nothing writes nothing: an empty member set is
+// not an event.
+func (s *Store) emitBulkItemEventTx(tx *sql.Tx, workspaceID string, members []*models.Item, delta map[string]any) error {
+	if len(members) == 0 {
+		return nil
+	}
+	payload, err := marshalEventPayload(bulkItemEventPayload{
+		Delta:       delta,
+		MemberCount: len(members),
+		Members:     members,
+	})
+	if err != nil {
+		return err
+	}
+	return writeOutboxTx(tx, s, OutboxEvent{
+		WorkspaceID: workspaceID,
+		EventType:   kernelevents.ItemBulkUpdated,
+		Payload:     payload,
+	})
+}
+
+// itemSnapshotsTx reads the given items in-tx, de-duplicated, skipping any
+// that no longer resolve.
+//
+// De-duplication is the point of taking a slice rather than reading as it
+// goes: a bulk mutation can touch the same row twice (two option renames on
+// different fields of one item), and a member list carrying that row twice —
+// once in an intermediate state — would make per-member binding evaluation
+// fire twice on one item, the second time against a state that never existed
+// as a final value.
+func (s *Store) itemSnapshotsTx(tx *sql.Tx, ids []string) ([]*models.Item, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	seen := make(map[string]bool, len(ids))
+	out := make([]*models.Item, 0, len(ids))
+	for _, id := range ids {
+		if seen[id] {
+			continue
+		}
+		seen[id] = true
+		item, err := s.getItemTx(tx, id)
+		if err != nil {
+			return nil, fmt.Errorf("outbox: read bulk member snapshot %s: %w", id, err)
+		}
+		if item == nil {
+			// Archived or gone between the write and here. Skipping is
+			// correct: a member snapshot the event cannot produce is one no
+			// predicate could have evaluated anyway, and inventing a
+			// placeholder would put a shape in the payload that never existed.
+			continue
+		}
+		out = append(out, item)
+	}
+	return out, nil
+}
+
 // itemDeltaExcludedKeys are the snapshot keys that must not count as a change
 // when deciding whether item.updated's slice moved.
 //
@@ -407,6 +501,20 @@ func (s *Store) emitItemUpdateEventsTx(tx *sql.Tx, before, after *models.Item, s
 // v1 promises at-least-once with duplicates possible, not ordering. The id tie
 // break exists so the drain itself is deterministic when timestamps collide,
 // not so consumers can infer sequence.
+//
+// DELIBERATELY CROSS-WORKSPACE AND UNAUTHORIZED, which is safe only because of
+// who may call it. The drain is a single server-internal loop that must serve
+// every workspace in the instance; scoping it per workspace would mean asking
+// it to enumerate workspaces first, which is both slower and no more secure.
+// The authorization boundary for these payloads is the DISPATCHER — it decides
+// which surface each event reaches, and a webhook endpoint is registered by the
+// workspace's own owner.
+//
+// The rule that keeps that true: this returns raw payloads containing full item
+// content and comment bodies, so it must never be reachable from an HTTP
+// handler, an MCP tool, or anything else carrying a user's identity. If you
+// find yourself calling it from a request path, the answer is a
+// workspace-scoped query with an authorization check, not this (Codex round 2).
 func (s *Store) ListPendingOutboxEvents(limit int) ([]OutboxEvent, error) {
 	if limit <= 0 {
 		limit = 100

--- a/internal/store/event_outbox.go
+++ b/internal/store/event_outbox.go
@@ -1,0 +1,426 @@
+package store
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+
+	"github.com/PerpetualSoftware/pad/internal/kernelevents"
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// The transactional event outbox (SPEC-3 §choke point, TASK-2658).
+//
+// WHY THE WRITE LIVES IN THE STORE AND TAKES A *sql.Tx.
+//
+// Before this file, events were emitted from HTTP handlers after the store
+// call returned — outside any transaction, and in a layer that has to infer
+// what happened from what it asked for. Both halves were wrong:
+//
+//   - Outside the transaction, a commit followed by a crash loses the event
+//     with nothing recording that it should have existed, and an emit followed
+//     by a later failure leaks an event for a mutation that never committed.
+//   - Outside the store, the caller does not actually know what the mutation
+//     DID. Whether an update changed status — the difference between
+//     item.updated and the first-class item.status_changed — is known here,
+//     where the old and new rows are both in hand, and is guesswork anywhere
+//     else.
+//
+// So the outbox write is a plain INSERT on the caller's transaction. It has no
+// retry, no fallback, and no error swallowing: if the outbox INSERT fails, the
+// mutation must fail with it. That is the entire guarantee. A "best-effort"
+// outbox write would be strictly worse than no outbox at all, because it would
+// look durable while silently reintroducing the loss it exists to prevent.
+
+// OutboxEvent is one row of the event outbox — a canonical events/1 event
+// awaiting dispatch.
+type OutboxEvent struct {
+	ID          string
+	WorkspaceID string
+	EventType   string
+	SubjectKind string
+	SubjectID   string
+	Payload     []byte
+	Hop         int
+	OccurredAt  string
+
+	// Attempts and LastError are drain bookkeeping, populated on read.
+	Attempts  int
+	LastError string
+}
+
+// maxOutboxHop is SPEC-3 §L5's synchronous cascade bound: a binding-triggered
+// mutation inherits hop+1 and the kernel drops past depth 4.
+//
+// Bounds SYNCHRONOUS cascades only, and deliberately so — a queued playbook
+// run executed later, or a webhook consumer calling back through the API,
+// legitimately starts fresh at hop 0. Pretending otherwise would be
+// unenforceable, which is why SPEC-3 pairs this with per-pack quotas on
+// durable output rather than resting containment on the hop count alone.
+const maxOutboxHop = 4
+
+// writeOutboxTx appends one canonical event to the outbox on the caller's
+// transaction.
+//
+// Two rejections, both deliberately hard errors that fail the enclosing
+// mutation rather than dropping the event:
+//
+//   - A non-canonical event name. The events/1 set is closed (SPEC-3
+//     §Taxonomy); a name outside it is a programming error, and letting it
+//     through would put a name on the PUBLIC webhook surface that no consumer
+//     recognizes and no version note explains.
+//   - A nil/empty payload. Binding predicates evaluate against the payload
+//     snapshot and never against the live store, so an event with no snapshot
+//     is undeliverable by construction — better to fail the mutation now than
+//     to dispatch something no consumer can act on.
+//
+// A hop past the cascade bound is NOT an error: it is the bound working. The
+// event is dropped and the mutation stands, because the mutation itself was
+// legitimate — only the cascade it would extend is not.
+func writeOutboxTx(tx *sql.Tx, s *Store, ev OutboxEvent) error {
+	if !kernelevents.IsCanonical(ev.EventType) {
+		return fmt.Errorf("outbox: %q is not a canonical events/1 event", ev.EventType)
+	}
+	if len(ev.Payload) == 0 {
+		return fmt.Errorf("outbox: event %s has an empty payload", ev.EventType)
+	}
+	if ev.Hop > maxOutboxHop {
+		// Cascade bound reached. Dropping is the designed behaviour, but a
+		// silent drop would make a runaway binding indistinguishable from a
+		// binding that never fired, so the drop is the caller's to observe:
+		// it is reported as a nil error with no row written, and the
+		// dispatcher's quota accounting is what surfaces the pattern.
+		return nil
+	}
+
+	if ev.ID == "" {
+		ev.ID = newID()
+	}
+	if ev.OccurredAt == "" {
+		ev.OccurredAt = now()
+	}
+	if ev.SubjectKind == "" {
+		kind, ok := kernelevents.SubjectKind(ev.EventType)
+		if !ok {
+			// Unreachable: IsCanonical above already established membership,
+			// and both answers come from the same map. Guarded anyway so a
+			// future split of those two lookups cannot silently write rows
+			// with an empty subject_kind.
+			return fmt.Errorf("outbox: no subject kind for canonical event %q", ev.EventType)
+		}
+		ev.SubjectKind = kind
+	}
+
+	_, err := tx.Exec(s.q(`
+		INSERT INTO event_outbox (id, workspace_id, event_type, subject_kind, subject_id, payload, hop, occurred_at)
+		VALUES (?, ?, ?, ?, NULLIF(?, ''), ?, ?, ?)
+	`), ev.ID, ev.WorkspaceID, ev.EventType, ev.SubjectKind, ev.SubjectID, string(ev.Payload), ev.Hop, ev.OccurredAt)
+	if err != nil {
+		return fmt.Errorf("outbox: write %s: %w", ev.EventType, err)
+	}
+	return nil
+}
+
+// marshalEventPayload renders an event payload, returning an error rather than
+// an empty payload on failure.
+//
+// Callers write the result straight into the mutation's transaction, so a
+// marshal failure has to propagate: a payload that cannot be rendered is an
+// event that cannot be delivered, and swallowing it here would produce exactly
+// the silent gap the outbox exists to close.
+func marshalEventPayload(v any) ([]byte, error) {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, fmt.Errorf("outbox: marshal payload: %w", err)
+	}
+	return b, nil
+}
+
+// itemEventPayload is the wire shape of an item-subject event payload.
+//
+// models.Item is EMBEDDED rather than nested under an "item" key, deliberately.
+// SPEC-3 §Bindings says predicates are query/1 #where fragments applied
+// verbatim — no second filter language — and query/1 addresses item fields by
+// their own names. Nesting the snapshot would force every predicate to carry an
+// "item." prefix that exists nowhere else in the query grammar, which is how a
+// second dialect gets invented by accident. Embedding promotes the snapshot's
+// fields to the top level, so a predicate that works against an item in a query
+// works unchanged against an item in an event.
+//
+// prior_status sits alongside them as the envelope pseudo-field SPEC-3 names,
+// which is what makes "nonterminal → terminal" filterable. Omitted entirely
+// unless set, so it never appears as an empty string on events where a prior
+// status is meaningless.
+type itemEventPayload struct {
+	*models.Item
+	PriorStatus string `json:"prior_status,omitempty"`
+}
+
+// emitItemEventTx writes one item-subject event to the outbox on the caller's
+// transaction, carrying the post-mutation snapshot.
+//
+// The snapshot must be read back INSIDE the transaction before this is called.
+// A snapshot assembled from the caller's input rather than from the row is the
+// bug this design exists to prevent: it would describe what the caller asked
+// for, while the event claims to describe what happened.
+func (s *Store) emitItemEventTx(tx *sql.Tx, eventType string, item *models.Item, priorStatus string) error {
+	if item == nil {
+		return fmt.Errorf("outbox: %s has no item snapshot", eventType)
+	}
+	payload, err := marshalEventPayload(itemEventPayload{Item: item, PriorStatus: priorStatus})
+	if err != nil {
+		return err
+	}
+	return writeOutboxTx(tx, s, OutboxEvent{
+		WorkspaceID: item.WorkspaceID,
+		EventType:   eventType,
+		SubjectID:   item.ID,
+		Payload:     payload,
+	})
+}
+
+// itemDeltaExcludedKeys are the snapshot keys that must not count as a change
+// when deciding whether item.updated's slice moved.
+//
+// AN EXCLUSION LIST, NOT AN INCLUSION LIST, and that direction is the point. A
+// column added to items later is included in the comparison by default, so the
+// worst a future schema change can do is emit an extra item.updated — visible,
+// arguable, fixable. An inclusion list would fail the other way: the new column
+// would be silently invisible to the delta, and a mutation that changed it
+// would emit nothing at all. Silent absence is the failure mode this whole unit
+// exists to eliminate, so it must not be reintroduced by the mechanism that
+// decides what to emit.
+//
+// Each exclusion is one of three things: bookkeeping that changes on EVERY
+// mutation (updated_at, seq, last_modified_by) and would therefore make the
+// disjoint-delta rule vacuous by always reporting a change; a field owned by a
+// DIFFERENT canonical event under the rule (collection_id and the derived
+// collection_*/ref keys belong to item.moved; deleted_at belongs to
+// item.deleted / item.restored); or a value that cannot change after create
+// (id, workspace_id, created_at, created_by, item_number).
+var itemDeltaExcludedKeys = []string{
+	"updated_at",
+	"seq",
+	"last_modified_by",
+
+	"collection_id",
+	"collection_slug",
+	"collection_name",
+	"collection_icon",
+	"collection_prefix",
+	"ref",
+
+	"deleted_at",
+
+	"id",
+	"workspace_id",
+	"created_at",
+	"created_by",
+	"item_number",
+}
+
+// itemUpdatedSliceChanged reports whether anything outside the status and
+// location slices differs between two in-transaction snapshots of one item.
+//
+// Both snapshots MUST come from getItemTx. It is the same SQL that produced
+// `existing` under the write lock and `updated` after the write, so
+// join-populated fields are rendered identically on both sides and cannot
+// register as a spurious delta. Comparing a getItemTx snapshot against one
+// from a different query would silently compare rendering differences as if
+// they were changes.
+func itemUpdatedSliceChanged(before, after *models.Item, statusKey string) (bool, error) {
+	normalize := func(it *models.Item) (string, error) {
+		raw, err := json.Marshal(it)
+		if err != nil {
+			return "", fmt.Errorf("outbox: marshal item snapshot: %w", err)
+		}
+		var m map[string]any
+		if err := json.Unmarshal(raw, &m); err != nil {
+			return "", fmt.Errorf("outbox: re-read item snapshot: %w", err)
+		}
+		for _, k := range itemDeltaExcludedKeys {
+			delete(m, k)
+		}
+		// The status field lives INSIDE the fields blob, so excluding it is a
+		// nested delete rather than a top-level one. Re-marshalling the blob
+		// through a map also normalizes key order, which means a rewrite that
+		// only reorders keys is correctly NOT a change.
+		if statusKey != "" {
+			if blob, ok := m["fields"].(string); ok {
+				var f map[string]any
+				if err := json.Unmarshal([]byte(blob), &f); err == nil {
+					delete(f, statusKey)
+					nb, err := json.Marshal(f)
+					if err != nil {
+						return "", fmt.Errorf("outbox: re-marshal fields blob: %w", err)
+					}
+					m["fields"] = string(nb)
+				}
+				// An unparseable fields blob is left verbatim. It compares
+				// byte-for-byte on both sides, so a corrupt blob still yields
+				// a correct "changed / did not change" answer; it just cannot
+				// have the status key masked out of it.
+			}
+		}
+		// Map marshalling sorts keys, so this is a stable canonical form.
+		out, err := json.Marshal(m)
+		if err != nil {
+			return "", fmt.Errorf("outbox: canonicalize item snapshot: %w", err)
+		}
+		return string(out), nil
+	}
+
+	a, err := normalize(before)
+	if err != nil {
+		return false, err
+	}
+	b, err := normalize(after)
+	if err != nil {
+		return false, err
+	}
+	return a != b, nil
+}
+
+// emitItemUpdateEventsTx writes the canonical event(s) for one item UPDATE,
+// applying SPEC-3 v1.3's DISJOINT-DELTA RULE.
+//
+// Canonical events PARTITION a mutation's delta rather than competing to
+// describe it: item.status_changed owns the status field, item.moved owns
+// location, item.updated owns everything else. A mutation emits every event
+// whose slice actually changed — so a bare status flip emits status_changed
+// alone, and a single update that changes status AND priority emits BOTH,
+// because two things happened and each event describes its own slice exactly
+// once.
+//
+// The rule is what keeps item.updated honest: it does not mean "changed,
+// except status" as a special case, it owns a defined slice the same way the
+// others do. It also means the decision here has to DIFF SLICES rather than
+// branch on "was this a status update" — branching would drop the item.updated
+// half of every mixed update, silently, which is the shape of bug that
+// motivated the rule.
+func (s *Store) emitItemUpdateEventsTx(tx *sql.Tx, before, after *models.Item, statusChanged bool, priorStatus, statusKey string) error {
+	if statusChanged {
+		if err := s.emitItemEventTx(tx, kernelevents.ItemStatusChanged, after, priorStatus); err != nil {
+			return err
+		}
+	}
+
+	otherChanged, err := itemUpdatedSliceChanged(before, after, statusKey)
+	if err != nil {
+		return err
+	}
+	if otherChanged {
+		if err := s.emitItemEventTx(tx, kernelevents.ItemUpdated, after, ""); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ListPendingOutboxEvents returns up to limit undispatched events in drain
+// order.
+//
+// Ordering is (occurred_at, id) and is NOT a delivery-order contract — SPEC-3
+// v1 promises at-least-once with duplicates possible, not ordering. The id tie
+// break exists so the drain itself is deterministic when timestamps collide,
+// not so consumers can infer sequence.
+func (s *Store) ListPendingOutboxEvents(limit int) ([]OutboxEvent, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+	rows, err := s.db.Query(s.q(`
+		SELECT id, workspace_id, event_type, subject_kind, COALESCE(subject_id, ''), payload, hop, occurred_at, attempts, COALESCE(last_error, '')
+		FROM event_outbox
+		WHERE dispatched_at IS NULL
+		ORDER BY occurred_at, id
+		LIMIT ?
+	`), limit)
+	if err != nil {
+		return nil, fmt.Errorf("list pending outbox events: %w", err)
+	}
+	defer rows.Close()
+
+	var out []OutboxEvent
+	for rows.Next() {
+		var ev OutboxEvent
+		var payload string
+		if err := rows.Scan(&ev.ID, &ev.WorkspaceID, &ev.EventType, &ev.SubjectKind, &ev.SubjectID,
+			&payload, &ev.Hop, &ev.OccurredAt, &ev.Attempts, &ev.LastError); err != nil {
+			return nil, fmt.Errorf("scan outbox event: %w", err)
+		}
+		ev.Payload = []byte(payload)
+		out = append(out, ev)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate outbox events: %w", err)
+	}
+	return out, nil
+}
+
+// MarkOutboxDispatched stamps events as delivered.
+//
+// Called AFTER the surfaces have been handed the event, never before. The
+// ordering is what makes the guarantee at-least-once rather than at-most-once:
+// a crash between dispatch and this stamp re-delivers on the next drain, which
+// SPEC-3 §Delivery guarantees explicitly permits and consumers dedupe on the
+// event id.
+func (s *Store) MarkOutboxDispatched(ids []string) error {
+	if len(ids) == 0 {
+		return nil
+	}
+	ts := now()
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("mark outbox dispatched: %w", err)
+	}
+	defer tx.Rollback()
+
+	for _, id := range ids {
+		if _, err := tx.Exec(s.q(`
+			UPDATE event_outbox SET dispatched_at = ? WHERE id = ? AND dispatched_at IS NULL
+		`), ts, id); err != nil {
+			return fmt.Errorf("mark outbox dispatched %s: %w", id, err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("mark outbox dispatched: %w", err)
+	}
+	return nil
+}
+
+// MarkOutboxAttemptFailed records a failed dispatch attempt, leaving the event
+// pending so the next drain retries it.
+func (s *Store) MarkOutboxAttemptFailed(id, reason string) error {
+	if _, err := s.db.Exec(s.q(`
+		UPDATE event_outbox SET attempts = attempts + 1, last_error = ? WHERE id = ? AND dispatched_at IS NULL
+	`), reason, id); err != nil {
+		return fmt.Errorf("mark outbox attempt failed %s: %w", id, err)
+	}
+	return nil
+}
+
+// PruneDispatchedOutbox deletes dispatched events stamped before the given
+// timestamp, returning how many rows went.
+//
+// Retention rather than delete-on-dispatch, for two reasons. The table is the
+// only durable record that an event existed at all, so keeping a window of it
+// is what makes "did this mutation emit?" answerable after the fact. And
+// because the outbox intentionally carries no foreign keys — rows outlive
+// their subjects by design — retention is also the mechanism that keeps the
+// table bounded, which referential integrity would otherwise have done.
+func (s *Store) PruneDispatchedOutbox(before string) (int64, error) {
+	res, err := s.db.Exec(s.q(`
+		DELETE FROM event_outbox WHERE dispatched_at IS NOT NULL AND dispatched_at < ?
+	`), before)
+	if err != nil {
+		return 0, fmt.Errorf("prune dispatched outbox: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		// RowsAffected is advisory here — the DELETE already succeeded, and
+		// reporting a count failure as a prune failure would make a caller
+		// retry a completed prune.
+		return 0, nil
+	}
+	return n, nil
+}

--- a/internal/store/event_outbox.go
+++ b/internal/store/event_outbox.go
@@ -329,19 +329,55 @@ func (s *Store) emitBulkItemEventTx(tx *sql.Tx, workspaceID string, members []*m
 	if len(members) == 0 {
 		return nil
 	}
-	payload, err := marshalEventPayload(bulkItemEventPayload{
-		Delta:       delta,
-		MemberCount: len(members),
-		Members:     members,
-	})
-	if err != nil {
-		return err
+
+	// PARTITION BY THE MEMBERS' OWN WORKSPACE, never by the caller's.
+	//
+	// The caller passes the workspace it thinks the mutation belongs to, and
+	// for the collection-option rename that is exactly right. The wiki-title
+	// cascade is not so obviously safe: its source query selects on
+	// `target_item_id` alone and carries each source row's workspace_id
+	// per-row rather than assuming the renamed item's — so a member in a
+	// different workspace is not excluded by construction.
+	//
+	// Publishing a member snapshot under someone else's workspace_id would put
+	// one workspace's item content on another workspace's webhook. Whether
+	// that is reachable today is not the question worth answering: partitioning
+	// costs one map and makes it impossible, and "unreachable" is a property of
+	// today's queries rather than of this function.
+	//
+	// The caller's workspaceID is used only when a member somehow carries none.
+	byWorkspace := map[string][]*models.Item{}
+	var order []string
+	for _, m := range members {
+		ws := m.WorkspaceID
+		if ws == "" {
+			ws = workspaceID
+		}
+		if _, seen := byWorkspace[ws]; !seen {
+			order = append(order, ws)
+		}
+		byWorkspace[ws] = append(byWorkspace[ws], m)
 	}
-	return writeOutboxTx(tx, s, OutboxEvent{
-		WorkspaceID: workspaceID,
-		EventType:   kernelevents.ItemBulkUpdated,
-		Payload:     payload,
-	})
+
+	for _, ws := range order {
+		group := byWorkspace[ws]
+		payload, err := marshalEventPayload(bulkItemEventPayload{
+			Delta:       delta,
+			MemberCount: len(group),
+			Members:     group,
+		})
+		if err != nil {
+			return err
+		}
+		if err := writeOutboxTx(tx, s, OutboxEvent{
+			WorkspaceID: ws,
+			EventType:   kernelevents.ItemBulkUpdated,
+			Payload:     payload,
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // itemSnapshotsTx reads the given items in-tx, de-duplicated, skipping any

--- a/internal/store/event_outbox.go
+++ b/internal/store/event_outbox.go
@@ -101,7 +101,23 @@ func writeOutboxTx(tx *sql.Tx, s *Store, ev OutboxEvent) error {
 	// a ref-only deletion payload and the write would be accepted (Codex round
 	// 10). Pairing them here means an event and a payload that were not meant
 	// for each other cannot reach the table at all.
-	if want, _ := kernelevents.PayloadFamily(ev.EventType); ev.PayloadFamily != want {
+	want, known := kernelevents.PayloadFamily(ev.EventType)
+	if !known || want == "" {
+		// FAIL CLOSED on an event the taxonomy cannot describe. Discarding the
+		// ok meant an unknown family resolved to "", which a caller declaring
+		// nothing would then MATCH — the check passing precisely when it had
+		// no idea what the answer should be.
+		//
+		// UNREACHABLE TODAY, and said plainly rather than left to imply it is
+		// the protection: the canonical table co-locates subject kind and
+		// payload family in one entry, so a canonical event cannot be missing
+		// a family, and IsCanonical above has already rejected everything
+		// else. Verified by mutation — disabling this arm changes no test,
+		// because the mismatch check below catches the reachable cases. It
+		// stays as the guard for a future table that separates the two again.
+		return fmt.Errorf("outbox: event %s has no declared payload family", ev.EventType)
+	}
+	if ev.PayloadFamily != want {
 		return fmt.Errorf("outbox: event %s carries a %q payload, want %q",
 			ev.EventType, ev.PayloadFamily, want)
 	}

--- a/internal/store/event_outbox.go
+++ b/internal/store/event_outbox.go
@@ -190,6 +190,51 @@ type itemEventPayload struct {
 	PriorStatus *string `json:"prior_status,omitempty"`
 }
 
+// scrubItemPII returns a copy of the item with the JOIN-POPULATED assignee
+// identity removed, for storage in an event payload.
+//
+// An outbox payload is a FROZEN snapshot that outlives its subject by design.
+// Account deletion's de-identify posture (DeleteAccountAtomic) nulls
+// comments.user_id, items.created_by_user_id and so on precisely so a departed
+// user's identity stops being readable while the rows survive — but it reaches
+// only LIVE rows. A frozen payload keeps whatever it captured, so an assignee's
+// NAME AND EMAIL ADDRESS would remain legible in the outbox after the account
+// that owned them was deleted, and today nothing drains or prunes the table.
+//
+// THE RULE APPLIED, stated as the rule rather than as a proxy for it: remove
+// DIRECTLY IDENTIFYING personal data — a human name, an email address — and
+// keep opaque identifiers and row state. assigned_user_id stays: a binding
+// predicate filters on it, and after the account is gone it is a dangling
+// reference to nobody rather than a way to identify anyone. The name and email
+// are denormalized lookups a consumer can resolve for itself if it is
+// entitled to.
+//
+// Deliberately NOT scrubbed: collection_*/ref and the parent fields, which are
+// derived metadata rather than identity — predicates address items by
+// collection, so removing them would cost real expressiveness for no privacy
+// gain.
+//
+// POPULATION, enumerated rather than fixed one instance at a time (CONVE-18).
+// Five payload shapes carry data into the outbox:
+//
+//	item (single)   — JOIN-populated assignee name + email. SCRUBBED, here.
+//	item (bulk)     — same snapshots, same scrub, applied in itemSnapshotsTx.
+//	comment         — `author` is the comments table's OWN column, and account
+//	                  de-identification does not clear it on live rows either
+//	                  (it nulls user_id only), so a frozen copy is no more
+//	                  legible than the live row. Left alone deliberately.
+//	attachment      — uploaded_by, the attachments table's own column. Same.
+//	member.joined   — user_id only, an opaque identifier.
+//
+// So exactly one shape needed scrubbing, and the reason it stood out is that
+// it was the only one carrying a JOIN rather than the row.
+func scrubItemPII(item *models.Item) *models.Item {
+	clone := *item
+	clone.AssignedUserName = ""
+	clone.AssignedUserEmail = ""
+	return &clone
+}
+
 // emitItemEventTx writes one item-subject event to the outbox on the caller's
 // transaction, carrying the post-mutation snapshot.
 //
@@ -204,7 +249,8 @@ func (s *Store) emitItemEventTx(tx *sql.Tx, eventType string, item *models.Item,
 	if item == nil {
 		return fmt.Errorf("outbox: %s has no item snapshot", eventType)
 	}
-	payload, err := marshalEventPayload(itemEventPayload{Item: item, PriorStatus: priorStatus})
+	snapshot := scrubItemPII(item)
+	payload, err := marshalEventPayload(itemEventPayload{Item: snapshot, PriorStatus: priorStatus})
 	if err != nil {
 		return err
 	}
@@ -433,7 +479,11 @@ func (s *Store) itemSnapshotsTx(tx *sql.Tx, ids []string) ([]*models.Item, error
 			// placeholder would put a shape in the payload that never existed.
 			continue
 		}
-		out = append(out, item)
+		// Same scrub the single-item events get — a bulk payload is no less
+		// durable, and this is the SECOND of the two places item snapshots
+		// enter a payload. Population: 2 producers (emitItemEventTx, here),
+		// both scrubbed.
+		out = append(out, scrubItemPII(item))
 	}
 	return out, nil
 }

--- a/internal/store/event_outbox.go
+++ b/internal/store/event_outbox.go
@@ -44,6 +44,12 @@ type OutboxEvent struct {
 	Hop         int
 	OccurredAt  string
 
+	// PayloadFamily is the shape the caller marshalled into Payload. It is a
+	// WRITE-SIDE assertion, checked against the taxonomy and never stored:
+	// the event name already determines the shape, so persisting it would
+	// create a second source of truth that could disagree with the first.
+	PayloadFamily string
+
 	// Attempts and LastError are drain bookkeeping, populated on read.
 	Attempts  int
 	LastError string
@@ -88,6 +94,16 @@ const maxOutboxHop = 4
 func writeOutboxTx(tx *sql.Tx, s *Store, ev OutboxEvent) error {
 	if !kernelevents.IsCanonical(ev.EventType) {
 		return fmt.Errorf("outbox: %q is not a canonical events/1 event", ev.EventType)
+	}
+	// The caller declares which payload shape it just marshalled, and the
+	// taxonomy says which shape this event carries. Canonical membership only
+	// ever validated the NAME; without this, item.created could be stored with
+	// a ref-only deletion payload and the write would be accepted (Codex round
+	// 10). Pairing them here means an event and a payload that were not meant
+	// for each other cannot reach the table at all.
+	if want, _ := kernelevents.PayloadFamily(ev.EventType); ev.PayloadFamily != want {
+		return fmt.Errorf("outbox: event %s carries a %q payload, want %q",
+			ev.EventType, ev.PayloadFamily, want)
 	}
 	if len(ev.Payload) == 0 {
 		return fmt.Errorf("outbox: event %s has an empty payload", ev.EventType)
@@ -205,12 +221,10 @@ func marshalEventPayload(v any) ([]byte, error) {
 //
 // A POINTER, not a string with omitempty, and the distinction is the whole
 // point. An item can transition FROM no status at all — "" → "open" is a real
-// status change and item.status_changed fires for it. With omitempty on a
+// status change and item.status_changed fires for it — so with omitempty on a
 // plain string that transition dropped the key entirely, leaving a predicate
 // unable to tell "the prior status was empty" from "this event has no prior
-// status" (Codex round 6). My original reasoning — that an empty string should
-// never appear "where a prior status is meaningless" — was right about the
-// events where it IS meaningless and wrong about the one where it is not.
+// status".
 //
 // So: nil on every event that has no prior status, and present-and-possibly-
 // empty on item.status_changed, where the empty value is data.
@@ -247,7 +261,7 @@ type itemEventPayload struct {
 // Five payload shapes carry data into the outbox:
 //
 //	item (single)   — JOIN-populated assignee name + email. SCRUBBED, here.
-//	item (bulk)     — same snapshots, same scrub, applied in itemSnapshotsTx.
+//	item (bulk)     — same snapshots, same scrub, applied in outboxMemberSnapshotsTx.
 //	comment         — `author` is the comments table's OWN column, and account
 //	                  de-identification does not clear it on live rows either
 //	                  (it nulls user_id only), so a frozen copy is no more
@@ -284,10 +298,11 @@ func (s *Store) emitItemEventTx(tx *sql.Tx, eventType string, item *models.Item,
 		return err
 	}
 	return writeOutboxTx(tx, s, OutboxEvent{
-		WorkspaceID: item.WorkspaceID,
-		EventType:   eventType,
-		SubjectID:   item.ID,
-		Payload:     payload,
+		WorkspaceID:   item.WorkspaceID,
+		EventType:     eventType,
+		SubjectID:     item.ID,
+		Payload:       payload,
+		PayloadFamily: kernelevents.PayloadItemSnapshot,
 	})
 }
 
@@ -307,10 +322,11 @@ func (s *Store) emitCommentEventTx(tx *sql.Tx, eventType string, comment *models
 		return err
 	}
 	return writeOutboxTx(tx, s, OutboxEvent{
-		WorkspaceID: comment.WorkspaceID,
-		EventType:   eventType,
-		SubjectID:   comment.ID,
-		Payload:     payload,
+		WorkspaceID:   comment.WorkspaceID,
+		EventType:     eventType,
+		SubjectID:     comment.ID,
+		Payload:       payload,
+		PayloadFamily: kernelevents.PayloadCommentSnapshot,
 	})
 }
 
@@ -330,10 +346,11 @@ func (s *Store) emitAttachmentEventTx(tx *sql.Tx, eventType string, a *models.At
 		return err
 	}
 	return writeOutboxTx(tx, s, OutboxEvent{
-		WorkspaceID: a.WorkspaceID,
-		EventType:   eventType,
-		SubjectID:   a.ID,
-		Payload:     payload,
+		WorkspaceID:   a.WorkspaceID,
+		EventType:     eventType,
+		SubjectID:     a.ID,
+		Payload:       payload,
+		PayloadFamily: kernelevents.PayloadAttachmentSnapshot,
 	})
 }
 
@@ -367,10 +384,11 @@ func (s *Store) emitMemberEventTx(tx *sql.Tx, eventType, workspaceID, userID, ro
 		return err
 	}
 	return writeOutboxTx(tx, s, OutboxEvent{
-		WorkspaceID: workspaceID,
-		EventType:   eventType,
-		SubjectID:   userID,
-		Payload:     payload,
+		WorkspaceID:   workspaceID,
+		EventType:     eventType,
+		SubjectID:     userID,
+		Payload:       payload,
+		PayloadFamily: kernelevents.PayloadMember,
 	})
 }
 
@@ -458,9 +476,10 @@ func (s *Store) emitBulkItemEventTx(tx *sql.Tx, workspaceID string, members []*m
 			return err
 		}
 		if err := writeOutboxTx(tx, s, OutboxEvent{
-			WorkspaceID: ws,
-			EventType:   kernelevents.ItemBulkUpdated,
-			Payload:     payload,
+			WorkspaceID:   ws,
+			EventType:     kernelevents.ItemBulkUpdated,
+			Payload:       payload,
+			PayloadFamily: kernelevents.PayloadItemBatch,
 		}); err != nil {
 			return err
 		}
@@ -468,8 +487,13 @@ func (s *Store) emitBulkItemEventTx(tx *sql.Tx, workspaceID string, members []*m
 	return nil
 }
 
-// itemSnapshotsTx reads the given items in-tx, de-duplicated, skipping any
-// that no longer resolve.
+// outboxMemberSnapshotsTx builds the MEMBER LIST FOR AN item.bulk_updated
+// PAYLOAD. It is not a general "read these items" helper, and the name says so
+// on purpose (Codex round 10): it applies three outbox policies a maintainer
+// reusing it for ordinary snapshots would not expect and would not see fail —
+// it DE-DUPLICATES, it SILENTLY SKIPS rows that no longer resolve, and it
+// SCRUBS assignee identity. Any of those makes a general-purpose caller's
+// result quietly incomplete rather than wrong-looking.
 //
 // De-duplication is the point of taking a slice rather than reading as it
 // goes: a bulk mutation can touch the same row twice (two option renames on
@@ -486,7 +510,7 @@ func (s *Store) emitBulkItemEventTx(tx *sql.Tx, workspaceID string, members []*m
 // design, so each row gets its own seq. A single batched read would halve it;
 // that is BUG-2718, deliberately not done here because it means a new joined
 // query on the least-reviewed path of a heavily-reviewed change.
-func (s *Store) itemSnapshotsTx(tx *sql.Tx, ids []string) ([]*models.Item, error) {
+func (s *Store) outboxMemberSnapshotsTx(tx *sql.Tx, ids []string) ([]*models.Item, error) {
 	if len(ids) == 0 {
 		return nil, nil
 	}
@@ -548,10 +572,11 @@ func (s *Store) emitRefOnlyDeletionTx(tx *sql.Tx, eventType, workspaceID, subjec
 		return err
 	}
 	return writeOutboxTx(tx, s, OutboxEvent{
-		WorkspaceID: workspaceID,
-		EventType:   eventType,
-		SubjectID:   subjectID,
-		Payload:     payload,
+		WorkspaceID:   workspaceID,
+		EventType:     eventType,
+		SubjectID:     subjectID,
+		Payload:       payload,
+		PayloadFamily: kernelevents.PayloadRefOnly,
 	})
 }
 

--- a/internal/store/event_outbox.go
+++ b/internal/store/event_outbox.go
@@ -172,12 +172,22 @@ func marshalEventPayload(v any) ([]byte, error) {
 // works unchanged against an item in an event.
 //
 // prior_status sits alongside them as the envelope pseudo-field SPEC-3 names,
-// which is what makes "nonterminal → terminal" filterable. Omitted entirely
-// unless set, so it never appears as an empty string on events where a prior
-// status is meaningless.
+// which is what makes "nonterminal → terminal" filterable.
+//
+// A POINTER, not a string with omitempty, and the distinction is the whole
+// point. An item can transition FROM no status at all — "" → "open" is a real
+// status change and item.status_changed fires for it. With omitempty on a
+// plain string that transition dropped the key entirely, leaving a predicate
+// unable to tell "the prior status was empty" from "this event has no prior
+// status" (Codex round 6). My original reasoning — that an empty string should
+// never appear "where a prior status is meaningless" — was right about the
+// events where it IS meaningless and wrong about the one where it is not.
+//
+// So: nil on every event that has no prior status, and present-and-possibly-
+// empty on item.status_changed, where the empty value is data.
 type itemEventPayload struct {
 	*models.Item
-	PriorStatus string `json:"prior_status,omitempty"`
+	PriorStatus *string `json:"prior_status,omitempty"`
 }
 
 // emitItemEventTx writes one item-subject event to the outbox on the caller's
@@ -187,7 +197,10 @@ type itemEventPayload struct {
 // A snapshot assembled from the caller's input rather than from the row is the
 // bug this design exists to prevent: it would describe what the caller asked
 // for, while the event claims to describe what happened.
-func (s *Store) emitItemEventTx(tx *sql.Tx, eventType string, item *models.Item, priorStatus string) error {
+// priorStatus is a POINTER so a transition from an empty prior status is
+// distinguishable from an event that has none — pass nil for every event other
+// than item.status_changed.
+func (s *Store) emitItemEventTx(tx *sql.Tx, eventType string, item *models.Item, priorStatus *string) error {
 	if item == nil {
 		return fmt.Errorf("outbox: %s has no item snapshot", eventType)
 	}
@@ -389,6 +402,15 @@ func (s *Store) emitBulkItemEventTx(tx *sql.Tx, workspaceID string, members []*m
 // once in an intermediate state — would make per-member binding evaluation
 // fire twice on one item, the second time against a state that never existed
 // as a final value.
+//
+// COST, stated rather than discovered later: this is N sequential joined reads
+// for N members, inside the caller's transaction and under whatever lock the
+// caller holds (Codex round 6). The honest framing is that it roughly DOUBLES
+// an already-N-long lock hold rather than introducing one — the migration loop
+// this serves already issues N sequential UPDATEs under the same lock, by
+// design, so each row gets its own seq. A single batched read would halve it;
+// that is BUG-2718, deliberately not done here because it means a new joined
+// query on the least-reviewed path of a heavily-reviewed change.
 func (s *Store) itemSnapshotsTx(tx *sql.Tx, ids []string) ([]*models.Item, error) {
 	if len(ids) == 0 {
 		return nil, nil
@@ -589,7 +611,10 @@ func itemUpdatedSliceChanged(before, after *models.Item, statusKey string) (bool
 // motivated the rule.
 func (s *Store) emitItemUpdateEventsTx(tx *sql.Tx, before, after *models.Item, statusChanged bool, priorStatus, statusKey string) error {
 	if statusChanged {
-		if err := s.emitItemEventTx(tx, kernelevents.ItemStatusChanged, after, priorStatus); err != nil {
+		// Taken by address unconditionally: an empty prior status is a real
+		// prior status here, not an absent one.
+		prior := priorStatus
+		if err := s.emitItemEventTx(tx, kernelevents.ItemStatusChanged, after, &prior); err != nil {
 			return err
 		}
 	}
@@ -599,7 +624,7 @@ func (s *Store) emitItemUpdateEventsTx(tx *sql.Tx, before, after *models.Item, s
 		return err
 	}
 	if otherChanged {
-		if err := s.emitItemEventTx(tx, kernelevents.ItemUpdated, after, ""); err != nil {
+		if err := s.emitItemEventTx(tx, kernelevents.ItemUpdated, after, nil); err != nil {
 			return err
 		}
 	}

--- a/internal/store/event_outbox_test.go
+++ b/internal/store/event_outbox_test.go
@@ -462,3 +462,116 @@ func TestOutbox_MoveEmitsMovedOnlyWhenNothingElseChanged(t *testing.T) {
 			"item.updated's slice", got, kernelevents.ItemMoved)
 	}
 }
+
+func TestOutbox_CommentCreateAndUpdateEmit(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Outbox comments")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+	item := createTestItem(t, s, ws.ID, col.ID, "Commented", "body")
+	clearOutbox(t, s)
+
+	c, err := s.CreateComment(ws.ID, item.ID, "", models.CommentCreate{Body: "first"})
+	if err != nil {
+		t.Fatalf("CreateComment: %v", err)
+	}
+
+	if got := outboxEventsFor(t, s, c.ID); len(got) != 1 || got[0] != kernelevents.CommentCreated {
+		t.Fatalf("events = %v, want exactly [%s]", got, kernelevents.CommentCreated)
+	}
+
+	// The SUBJECT is the comment, not the item it hangs off — a binding keyed
+	// on the item as subject could not tell a comment from an edit to the item.
+	payload := outboxPayloadFor(t, s, c.ID, kernelevents.CommentCreated)
+	if payload["id"] != c.ID {
+		t.Fatalf("payload id = %v, want the comment id %s", payload["id"], c.ID)
+	}
+	// The payload must be the STORED row: a snapshot assembled from caller
+	// input would carry the body but not the values the write path filled in.
+	if payload["body"] != "first" {
+		t.Fatalf("payload body = %v, want %q", payload["body"], "first")
+	}
+	if payload["item_id"] != item.ID {
+		t.Fatalf("payload item_id = %v, want %s — a comment binding filters on this", payload["item_id"], item.ID)
+	}
+
+	clearOutbox(t, s)
+	if _, err := s.UpdateComment(c.ID, "edited"); err != nil {
+		t.Fatalf("UpdateComment: %v", err)
+	}
+	if got := outboxEventsFor(t, s, c.ID); len(got) != 1 || got[0] != kernelevents.CommentUpdated {
+		t.Fatalf("events = %v, want exactly [%s]", got, kernelevents.CommentUpdated)
+	}
+	updatedPayload := outboxPayloadFor(t, s, c.ID, kernelevents.CommentUpdated)
+	if updatedPayload["body"] != "edited" {
+		t.Fatalf("payload body = %v, want the POST-update body; an in-tx read that took the pool "+
+			"connection instead of the tx would return the pre-write row here", updatedPayload["body"])
+	}
+}
+
+func TestOutbox_AttachmentAddedSkipsVariants(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Outbox attachments")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+	item := createTestItem(t, s, ws.ID, col.ID, "Has attachments", "body")
+	clearOutbox(t, s)
+
+	original := &models.Attachment{
+		WorkspaceID: ws.ID,
+		ItemID:      &item.ID,
+		StorageKey:  "blob/original",
+		Filename:    "photo.jpg",
+		MimeType:    "image/jpeg",
+		SizeBytes:   1234,
+	}
+	if err := s.CreateAttachmentForLiveItem(original); err != nil {
+		t.Fatalf("CreateAttachmentForLiveItem(original): %v", err)
+	}
+	if got := outboxEventsFor(t, s, original.ID); len(got) != 1 || got[0] != kernelevents.AttachmentAdded {
+		t.Fatalf("events = %v, want exactly [%s]", got, kernelevents.AttachmentAdded)
+	}
+
+	// A THUMBNAIL IS AN ATTACHMENT ROW TOO. Without the gate, one image
+	// upload announces three attachment.added events — two of them for files
+	// no user added. This is the leg that proves the gate exists; deleting it
+	// makes this test fail rather than making it pass more easily.
+	variant := models.AttachmentVariantThumbMd
+	thumb := &models.Attachment{
+		WorkspaceID: ws.ID,
+		ItemID:      &item.ID,
+		ParentID:    &original.ID,
+		Variant:     &variant,
+		StorageKey:  "blob/thumb-md",
+		Filename:    "photo-thumb.jpg",
+		MimeType:    "image/jpeg",
+		SizeBytes:   234,
+	}
+	if err := s.CreateAttachmentForLiveItem(thumb); err != nil {
+		t.Fatalf("CreateAttachmentForLiveItem(thumb): %v", err)
+	}
+	if got := outboxEventsFor(t, s, thumb.ID); len(got) != 0 {
+		t.Fatalf("events for a %s variant = %v, want none — variants are derived rows, not "+
+			"attachments a user added", variant, got)
+	}
+}
+
+func TestOutbox_MemberJoinedEmits(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Outbox members")
+	user := createTestUser(t, s, "joiner@example.com", "Joiner", "pw-joiner-123")
+	clearOutbox(t, s)
+
+	if err := s.AddWorkspaceMember(ws.ID, user.ID, "editor"); err != nil {
+		t.Fatalf("AddWorkspaceMember: %v", err)
+	}
+
+	if got := outboxEventsFor(t, s, user.ID); len(got) != 1 || got[0] != kernelevents.MemberJoined {
+		t.Fatalf("events = %v, want exactly [%s]", got, kernelevents.MemberJoined)
+	}
+	payload := outboxPayloadFor(t, s, user.ID, kernelevents.MemberJoined)
+	if payload["role"] != "editor" {
+		t.Fatalf("payload role = %v, want %q", payload["role"], "editor")
+	}
+	if payload["workspace_id"] != ws.ID {
+		t.Fatalf("payload workspace_id = %v, want %s", payload["workspace_id"], ws.ID)
+	}
+}

--- a/internal/store/event_outbox_test.go
+++ b/internal/store/event_outbox_test.go
@@ -335,6 +335,27 @@ func TestWriteOutboxTx_DropsPastCascadeBound(t *testing.T) {
 	}
 	defer tx.Rollback()
 
+	// A caller-supplied occurred_at is IGNORED — the write stamps it. SPEC-3
+	// pins time-relative predicates to this value, so accepting one would let
+	// a caller silently change how a predicate evaluates.
+	if err := writeOutboxTx(tx, s, OutboxEvent{
+		WorkspaceID: ws.ID,
+		EventType:   kernelevents.ItemCreated,
+		SubjectID:   "stamped",
+		Payload:     []byte(`{"id":"stamped"}`),
+		OccurredAt:  "1999-01-01T00:00:00Z",
+	}); err != nil {
+		t.Fatalf("writeOutboxTx: %v", err)
+	}
+	var stamped string
+	if err := tx.QueryRow(s.q(`SELECT occurred_at FROM event_outbox WHERE subject_id = ?`), "stamped").Scan(&stamped); err != nil {
+		t.Fatalf("read occurred_at: %v", err)
+	}
+	if stamped == "1999-01-01T00:00:00Z" {
+		t.Fatalf("occurred_at was taken from the caller; a supplied timestamp silently changes " +
+			"how `within` predicates evaluate")
+	}
+
 	// At the bound: written. Past it: dropped, and NOT an error — the
 	// mutation itself was legitimate, only the cascade it would extend is
 	// not (SPEC-3 §L5).

--- a/internal/store/event_outbox_test.go
+++ b/internal/store/event_outbox_test.go
@@ -996,3 +996,50 @@ func TestOutbox_StatusChangeFromEmptyCarriesEmptyPriorStatus(t *testing.T) {
 		t.Fatalf("prior_status present on item.updated, where there is no prior status to report")
 	}
 }
+
+// TestOutbox_PayloadsOmitAssigneeIdentity pins the privacy-lifecycle property.
+//
+// An outbox payload is a frozen snapshot that outlives its subject by design.
+// Account deletion's de-identify pass nulls user identity on LIVE rows so a
+// departed user stops being legible; it cannot reach a frozen payload. If the
+// payload captured the assignee's name and email, those would stay readable in
+// the outbox after the account was deleted — and today nothing drains or prunes
+// the table.
+func TestOutbox_PayloadsOmitAssigneeIdentity(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Outbox PII")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+	user := createTestUser(t, s, "assignee@example.com", "Assignee Person", "pw-assignee-123")
+	if err := s.AddWorkspaceMember(ws.ID, user.ID, "editor"); err != nil {
+		t.Fatalf("AddWorkspaceMember: %v", err)
+	}
+	item := createTestItem(t, s, ws.ID, col.ID, "Assigned", "body")
+	clearOutbox(t, s)
+
+	if _, err := s.UpdateItem(item.ID, models.ItemUpdate{AssignedUserID: &user.ID}); err != nil {
+		t.Fatalf("assign: %v", err)
+	}
+
+	payload := outboxPayloadFor(t, s, item.ID, kernelevents.ItemUpdated)
+
+	// The item's OWN column stays — a predicate filters on it and it is an
+	// opaque id, not personal data.
+	if payload["assigned_user_id"] != user.ID {
+		t.Fatalf("assigned_user_id = %v, want %s — the item's own column must survive the scrub",
+			payload["assigned_user_id"], user.ID)
+	}
+	// The join-populated identity must not.
+	for _, key := range []string{"assigned_user_name", "assigned_user_email"} {
+		if v, present := payload[key]; present {
+			t.Fatalf("payload carries %s = %v; a frozen snapshot keeps it legible after the "+
+				"account is deleted, which the de-identify pass cannot reach", key, v)
+		}
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(raw), "assignee@example.com") {
+		t.Fatalf("payload contains the assignee's email address anywhere: %s", raw)
+	}
+}

--- a/internal/store/event_outbox_test.go
+++ b/internal/store/event_outbox_test.go
@@ -944,3 +944,55 @@ func TestEmitBulkItemEventTx_PartitionsByMemberWorkspace(t *testing.T) {
 		t.Fatalf("member counts = %v, want {A:2, B:1}", counts)
 	}
 }
+
+// TestOutbox_StatusChangeFromEmptyCarriesEmptyPriorStatus pins the SPEC-3
+// conformance point Codex round 6 found: prior_status must be PRESENT on
+// item.status_changed even when the prior status was empty.
+//
+// An item can transition from no status at all, and that is a real status
+// change. With `omitempty` on a plain string the key vanished, leaving a
+// binding predicate unable to distinguish "the prior status was empty" from
+// "this event carries no prior status" — which is exactly the distinction the
+// envelope pseudo-field exists to make.
+func TestOutbox_StatusChangeFromEmptyCarriesEmptyPriorStatus(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Outbox empty prior")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+	item := createTestItem(t, s, ws.ID, col.ID, "No status yet", "body")
+
+	// Clear the status first, so the next write is a genuine ""→value change.
+	cleared := `{"status":""}`
+	if _, err := s.UpdateItem(item.ID, models.ItemUpdate{Fields: &cleared}); err != nil {
+		t.Fatalf("clear status: %v", err)
+	}
+	clearOutbox(t, s)
+
+	set := `{"status":"open"}`
+	if _, err := s.UpdateItem(item.ID, models.ItemUpdate{Fields: &set}); err != nil {
+		t.Fatalf("set status: %v", err)
+	}
+
+	if got := outboxEventsFor(t, s, item.ID); len(got) != 1 || got[0] != kernelevents.ItemStatusChanged {
+		t.Fatalf("events = %v, want exactly [%s]", got, kernelevents.ItemStatusChanged)
+	}
+	payload := outboxPayloadFor(t, s, item.ID, kernelevents.ItemStatusChanged)
+	raw, present := payload["prior_status"]
+	if !present {
+		t.Fatalf("prior_status is ABSENT on a \"\"→open transition; a predicate cannot tell an "+
+			"empty prior status from an event that has none. payload keys: %v", payload)
+	}
+	if raw != "" {
+		t.Fatalf("prior_status = %v, want the empty string", raw)
+	}
+
+	// And it must still be absent where it is genuinely meaningless.
+	clearOutbox(t, s)
+	title := "Renamed"
+	if _, err := s.UpdateItem(item.ID, models.ItemUpdate{Title: &title}); err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+	updatedPayload := outboxPayloadFor(t, s, item.ID, kernelevents.ItemUpdated)
+	if _, present := updatedPayload["prior_status"]; present {
+		t.Fatalf("prior_status present on item.updated, where there is no prior status to report")
+	}
+}

--- a/internal/store/event_outbox_test.go
+++ b/internal/store/event_outbox_test.go
@@ -1351,13 +1351,36 @@ func TestWriteOutboxTx_RejectsMismatchedPayloadFamily(t *testing.T) {
 	}
 }
 
-// TestPayloadFamily_CoversEveryCanonicalEvent keeps the two taxonomy maps from
-// drifting: a canonical name with no declared family would be unwritable, and
-// the failure would surface as a confusing runtime rejection rather than here.
-func TestPayloadFamily_CoversEveryCanonicalEvent(t *testing.T) {
+// TestCanonicalEventsAreFullyDeclared checks that every canonical event
+// resolves BOTH a subject kind and a payload family, and that non-canonical
+// names resolve neither.
+//
+// The single taxonomy table makes a half-declared event unrepresentable, so
+// this is a guard against the table being replaced by something looser rather
+// than against today's literals. The non-canonical leg is the one that matters
+// most: an unknown name must report ok=false, not an empty string that a
+// caller declaring nothing would match.
+func TestCanonicalEventsAreFullyDeclared(t *testing.T) {
 	for _, name := range kernelevents.Canonical() {
-		if family, ok := kernelevents.PayloadFamily(name); !ok || family == "" {
+		kind, kindOK := kernelevents.SubjectKind(name)
+		if !kindOK || kind == "" {
+			t.Errorf("canonical event %q has no subject kind", name)
+		}
+		family, familyOK := kernelevents.PayloadFamily(name)
+		if !familyOK || family == "" {
 			t.Errorf("canonical event %q has no payload family", name)
+		}
+	}
+
+	for _, name := range []string{"", "item.frobnicated", "comment.deleted.v2"} {
+		if _, ok := kernelevents.PayloadFamily(name); ok {
+			t.Errorf("PayloadFamily(%q) reported ok for a non-canonical name", name)
+		}
+		if _, ok := kernelevents.SubjectKind(name); ok {
+			t.Errorf("SubjectKind(%q) reported ok for a non-canonical name", name)
+		}
+		if kernelevents.IsCanonical(name) {
+			t.Errorf("IsCanonical(%q) = true", name)
 		}
 	}
 }

--- a/internal/store/event_outbox_test.go
+++ b/internal/store/event_outbox_test.go
@@ -1043,3 +1043,126 @@ func TestOutbox_PayloadsOmitAssigneeIdentity(t *testing.T) {
 		t.Fatalf("payload contains the assignee's email address anywhere: %s", raw)
 	}
 }
+
+func TestOutbox_CommentDeleteEmitsRefOnly(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Outbox comment delete")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+	item := createTestItem(t, s, ws.ID, col.ID, "Commented", "body")
+
+	const secret = "the body a user asked to remove"
+	c, err := s.CreateComment(ws.ID, item.ID, "", models.CommentCreate{Body: secret})
+	if err != nil {
+		t.Fatalf("CreateComment: %v", err)
+	}
+	clearOutbox(t, s)
+
+	if err := s.DeleteComment(c.ID); err != nil {
+		t.Fatalf("DeleteComment: %v", err)
+	}
+
+	if got := outboxEventsFor(t, s, c.ID); len(got) != 1 || got[0] != kernelevents.CommentDeleted {
+		t.Fatalf("events = %v, want exactly [%s] — without a delete marker a hard-deleted "+
+			"comment's created event is the only record it existed", got, kernelevents.CommentDeleted)
+	}
+
+	payload := outboxPayloadFor(t, s, c.ID, kernelevents.CommentDeleted)
+	if payload["id"] != c.ID || payload["item_id"] != item.ID || payload["workspace_id"] != ws.ID {
+		t.Fatalf("payload = %v, want the ids a consumer needs to reconcile", payload)
+	}
+	// REF-ONLY is the whole contract (SPEC-3 v1.4): a deletion event must not
+	// re-ship what it deletes.
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(raw), secret) {
+		t.Fatalf("comment.deleted payload contains the deleted body: %s", raw)
+	}
+	if _, present := payload["body"]; present {
+		t.Fatalf("comment.deleted payload carries a body key: %v", payload)
+	}
+}
+
+func TestOutbox_SoftDeletedAttachmentClaimEmitsRefOnly(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Outbox attachment removed")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+	item := createTestItem(t, s, ws.ID, col.ID, "Has attachment", "body")
+
+	const storageKey = "blob/secret-locator"
+	att := &models.Attachment{
+		WorkspaceID: ws.ID,
+		ItemID:      &item.ID,
+		StorageKey:  storageKey,
+		Filename:    "private-notes.pdf",
+		MimeType:    "application/pdf",
+		SizeBytes:   99,
+	}
+	if err := s.CreateAttachmentForLiveItem(att); err != nil {
+		t.Fatalf("CreateAttachmentForLiveItem: %v", err)
+	}
+	if err := s.SoftDeleteAttachment(att.ID); err != nil {
+		t.Fatalf("SoftDeleteAttachment: %v", err)
+	}
+	clearOutbox(t, s)
+
+	claimed, err := s.ClaimSoftDeletedAttachment(att.ID, time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("ClaimSoftDeletedAttachment: %v", err)
+	}
+	if !claimed {
+		t.Fatalf("claim did not take the row; the test is not exercising the emit path")
+	}
+
+	if got := outboxEventsFor(t, s, att.ID); len(got) != 1 || got[0] != kernelevents.AttachmentRemoved {
+		t.Fatalf("events = %v, want exactly [%s]", got, kernelevents.AttachmentRemoved)
+	}
+	payload := outboxPayloadFor(t, s, att.ID, kernelevents.AttachmentRemoved)
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	// The sharp edge: an attachment payload carries the STORAGE KEY, so a
+	// full-snapshot removal event would hand out a locator for bytes the
+	// system just reclaimed.
+	if strings.Contains(string(raw), storageKey) {
+		t.Fatalf("attachment.removed payload contains the storage key: %s", raw)
+	}
+	if strings.Contains(string(raw), "private-notes.pdf") {
+		t.Fatalf("attachment.removed payload contains the filename: %s", raw)
+	}
+}
+
+func TestOutbox_NeverAttachedClaimEmitsNothing(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Outbox never attached")
+
+	// An orphan: never attached to an item, so it never emitted
+	// attachment.added either.
+	orphan := &models.Attachment{
+		WorkspaceID: ws.ID,
+		StorageKey:  "blob/orphan",
+		Filename:    "stray.bin",
+		MimeType:    "application/octet-stream",
+		SizeBytes:   10,
+	}
+	if err := s.CreateAttachment(orphan); err != nil {
+		t.Fatalf("CreateAttachment: %v", err)
+	}
+	clearOutbox(t, s)
+
+	claimed, err := s.ClaimNeverAttachedAttachment(orphan.ID, time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("ClaimNeverAttachedAttachment: %v", err)
+	}
+	if !claimed {
+		t.Fatalf("claim did not take the row; the test is not exercising the path")
+	}
+
+	// Announcing this removal would hand a consumer a deletion for an id it
+	// has never seen. The asymmetry with the soft-deleted claim is the point.
+	if got := outboxEventsFor(t, s, orphan.ID); len(got) != 0 {
+		t.Fatalf("events = %v, want none — this row never emitted attachment.added", got)
+	}
+}

--- a/internal/store/event_outbox_test.go
+++ b/internal/store/event_outbox_test.go
@@ -575,3 +575,41 @@ func TestOutbox_MemberJoinedEmits(t *testing.T) {
 		t.Fatalf("payload workspace_id = %v, want %s", payload["workspace_id"], ws.ID)
 	}
 }
+
+// TestOutbox_CrossWorkspaceMoveEmitsSourceArchive pins the gap that made this
+// test exist.
+//
+// archiveItemForCopyTx deliberately REPRODUCES DeleteItem's UPDATE inside the
+// copy's own transaction rather than calling it, so that the archive is atomic
+// with the destination write. The consequence nobody had to think about before
+// TASK-2658 is that it does not inherit DeleteItem's emit either: without an
+// explicit one, a cross-workspace MOVE archives the source silently while an
+// ordinary archive of the same item announces itself. Invisible until something
+// consumes the outbox, at which point moves just stop being observable.
+func TestOutbox_CrossWorkspaceMoveEmitsSourceArchive(t *testing.T) {
+	f := newCopyFixture(t)
+	src := createTestItem(t, f.s, f.wsA.ID, f.colA.ID, "Moving out", "body")
+	clearOutbox(t, f.s)
+
+	req := f.req()
+	req.SourceItemID = src.ID
+	req.ArchiveSource = true
+	res := f.copy(t, req)
+
+	if got := outboxEventsFor(t, f.s, src.ID); len(got) != 1 || got[0] != kernelevents.ItemDeleted {
+		t.Fatalf("source events = %v, want exactly [%s] — the move archived the source with no event",
+			got, kernelevents.ItemDeleted)
+	}
+
+	// The pre-archive snapshot must be the SOURCE's state, not the clone's.
+	payload := outboxPayloadFor(t, f.s, src.ID, kernelevents.ItemDeleted)
+	if payload["workspace_id"] != f.wsA.ID {
+		t.Fatalf("payload workspace_id = %v, want the SOURCE workspace %s", payload["workspace_id"], f.wsA.ID)
+	}
+
+	// And the destination item still emits its own creation, from the same
+	// transaction — the move is two canonical events, not one.
+	if got := outboxEventsFor(t, f.s, res.Item.ID); len(got) != 1 || got[0] != kernelevents.ItemCreated {
+		t.Fatalf("destination events = %v, want exactly [%s]", got, kernelevents.ItemCreated)
+	}
+}

--- a/internal/store/event_outbox_test.go
+++ b/internal/store/event_outbox_test.go
@@ -1232,3 +1232,51 @@ func TestOutbox_VariantClaimEmitsNothing(t *testing.T) {
 			"announce its removal", got)
 	}
 }
+
+// TestWriteOutboxTx_SubjectKindIsDerivedNotTrusted pins the round-9 finding.
+//
+// subject_kind is a pure function of the event name, so a caller-supplied
+// value can only agree with the taxonomy or be wrong — and a wrong one used to
+// persist silently and would misroute the event at drain time. Every earlier
+// test passed either the correct value or none, which is precisely why this
+// survived eight rounds of review.
+func TestWriteOutboxTx_SubjectKindIsDerivedNotTrusted(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Outbox subject kind")
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	defer tx.Rollback()
+
+	// A mismatched kind is refused rather than stored.
+	err = writeOutboxTx(tx, s, OutboxEvent{
+		WorkspaceID: ws.ID,
+		EventType:   kernelevents.ItemCreated,
+		SubjectKind: kernelevents.SubjectComment,
+		SubjectID:   "mismatched",
+		Payload:     []byte(`{"id":"mismatched"}`),
+	})
+	if err == nil {
+		t.Fatalf("writeOutboxTx stored item.created under subject kind %q; the drain would "+
+			"route it as a comment", kernelevents.SubjectComment)
+	}
+
+	// An omitted kind is filled in from the taxonomy.
+	if err := writeOutboxTx(tx, s, OutboxEvent{
+		WorkspaceID: ws.ID,
+		EventType:   kernelevents.ItemCreated,
+		SubjectID:   "derived",
+		Payload:     []byte(`{"id":"derived"}`),
+	}); err != nil {
+		t.Fatalf("writeOutboxTx with no subject kind: %v", err)
+	}
+	var kind string
+	if err := tx.QueryRow(s.q(`SELECT subject_kind FROM event_outbox WHERE subject_id = ?`), "derived").Scan(&kind); err != nil {
+		t.Fatalf("read subject kind: %v", err)
+	}
+	if kind != kernelevents.SubjectItem {
+		t.Fatalf("subject_kind = %q, want %q", kind, kernelevents.SubjectItem)
+	}
+}

--- a/internal/store/event_outbox_test.go
+++ b/internal/store/event_outbox_test.go
@@ -1,0 +1,464 @@
+package store
+
+import (
+	"encoding/json"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/kernelevents"
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// Tests for the transactional event outbox (SPEC-3 §choke point, TASK-2658).
+//
+// The load-bearing case here is the DISJOINT-DELTA RULE (SPEC-3 v1.3):
+// canonical events partition a mutation's delta rather than competing to
+// describe it, and a mutation emits every event whose slice actually changed.
+// The mixed update — status AND a non-status field in one call — is the case a
+// naive "did the status change?" branch gets wrong, so it is tested explicitly
+// rather than left to follow from the two single-slice cases.
+
+// outboxEventsFor returns the canonical event types recorded for an item,
+// sorted for stable comparison.
+func outboxEventsFor(t *testing.T, s *Store, itemID string) []string {
+	t.Helper()
+	rows, err := s.db.Query(s.q(`SELECT event_type FROM event_outbox WHERE subject_id = ? ORDER BY occurred_at, id`), itemID)
+	if err != nil {
+		t.Fatalf("query outbox: %v", err)
+	}
+	defer rows.Close()
+
+	var out []string
+	for rows.Next() {
+		var et string
+		if err := rows.Scan(&et); err != nil {
+			t.Fatalf("scan event_type: %v", err)
+		}
+		out = append(out, et)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate outbox: %v", err)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// outboxPayloadFor returns the decoded payload of the single event of the
+// given type for an item, failing if there is not exactly one.
+func outboxPayloadFor(t *testing.T, s *Store, itemID, eventType string) map[string]any {
+	t.Helper()
+	rows, err := s.db.Query(s.q(`SELECT payload FROM event_outbox WHERE subject_id = ? AND event_type = ?`), itemID, eventType)
+	if err != nil {
+		t.Fatalf("query payload: %v", err)
+	}
+	defer rows.Close()
+
+	var payloads []string
+	for rows.Next() {
+		var p string
+		if err := rows.Scan(&p); err != nil {
+			t.Fatalf("scan payload: %v", err)
+		}
+		payloads = append(payloads, p)
+	}
+	if len(payloads) != 1 {
+		t.Fatalf("outbox rows for %s = %d, want exactly 1", eventType, len(payloads))
+	}
+	var m map[string]any
+	if err := json.Unmarshal([]byte(payloads[0]), &m); err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+	return m
+}
+
+func clearOutbox(t *testing.T, s *Store) {
+	t.Helper()
+	if _, err := s.db.Exec(s.q(`DELETE FROM event_outbox`)); err != nil {
+		t.Fatalf("clear outbox: %v", err)
+	}
+}
+
+func TestOutbox_CreateEmitsItemCreatedWithSnapshot(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Outbox create")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+
+	item := createTestItem(t, s, ws.ID, col.ID, "Emitted on create", "body")
+
+	if got := outboxEventsFor(t, s, item.ID); len(got) != 1 || got[0] != kernelevents.ItemCreated {
+		t.Fatalf("events = %v, want exactly [%s]", got, kernelevents.ItemCreated)
+	}
+
+	// The payload must carry the SNAPSHOT with item fields at the top level
+	// (embedded, not nested under an "item" key) — SPEC-3 §Bindings applies
+	// query/1 #where fragments verbatim, and query/1 addresses item fields by
+	// their own names.
+	payload := outboxPayloadFor(t, s, item.ID, kernelevents.ItemCreated)
+	if payload["id"] != item.ID {
+		t.Fatalf("payload id = %v, want %s (snapshot is not embedded at the top level)", payload["id"], item.ID)
+	}
+	if payload["title"] != "Emitted on create" {
+		t.Fatalf("payload title = %v, want the created title", payload["title"])
+	}
+	if _, present := payload["prior_status"]; present {
+		t.Fatalf("prior_status present on item.created; it is meaningless there and must be omitted")
+	}
+}
+
+func TestOutbox_BareStatusFlipEmitsStatusChangedOnly(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Outbox status")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+	item := createTestItem(t, s, ws.ID, col.ID, "Status only", "body")
+	clearOutbox(t, s)
+
+	fields := `{"status":"in-progress"}`
+	updated, err := s.UpdateItem(item.ID, models.ItemUpdate{Fields: &fields})
+	if err != nil {
+		t.Fatalf("UpdateItem: %v", err)
+	}
+	if updated == nil {
+		t.Fatalf("UpdateItem returned nil")
+	}
+
+	got := outboxEventsFor(t, s, item.ID)
+	if len(got) != 1 || got[0] != kernelevents.ItemStatusChanged {
+		t.Fatalf("events = %v, want exactly [%s] — a bare status flip must not also emit item.updated",
+			got, kernelevents.ItemStatusChanged)
+	}
+
+	payload := outboxPayloadFor(t, s, item.ID, kernelevents.ItemStatusChanged)
+	if payload["prior_status"] != "open" {
+		t.Fatalf("prior_status = %v, want %q — the envelope pseudo-field is what makes nonterminal→terminal filterable",
+			payload["prior_status"], "open")
+	}
+}
+
+func TestOutbox_MixedUpdateEmitsBothSlices(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Outbox mixed")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+	item := createTestItem(t, s, ws.ID, col.ID, "Mixed", "body")
+	clearOutbox(t, s)
+
+	// One update that moves TWO slices: the status field and the title.
+	// Under the disjoint-delta rule each slice gets exactly one event.
+	fields := `{"status":"done"}`
+	title := "Mixed, renamed"
+	if _, err := s.UpdateItem(item.ID, models.ItemUpdate{Fields: &fields, Title: &title}); err != nil {
+		t.Fatalf("UpdateItem: %v", err)
+	}
+
+	got := outboxEventsFor(t, s, item.ID)
+	want := []string{kernelevents.ItemStatusChanged, kernelevents.ItemUpdated}
+	sort.Strings(want)
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("events = %v, want %v — a mixed update must emit BOTH slices; branching on "+
+			"\"was this a status update\" drops the item.updated half silently", got, want)
+	}
+}
+
+func TestOutbox_NonStatusUpdateEmitsUpdatedOnly(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Outbox plain")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+	item := createTestItem(t, s, ws.ID, col.ID, "Plain", "body")
+	clearOutbox(t, s)
+
+	title := "Plain, renamed"
+	if _, err := s.UpdateItem(item.ID, models.ItemUpdate{Title: &title}); err != nil {
+		t.Fatalf("UpdateItem: %v", err)
+	}
+
+	got := outboxEventsFor(t, s, item.ID)
+	if len(got) != 1 || got[0] != kernelevents.ItemUpdated {
+		t.Fatalf("events = %v, want exactly [%s]", got, kernelevents.ItemUpdated)
+	}
+}
+
+func TestOutbox_NoOpUpdateEmitsNothing(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Outbox noop")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+	item := createTestItem(t, s, ws.ID, col.ID, "Noop", "body")
+	clearOutbox(t, s)
+
+	// Rewrite the title to the value it already holds. The row is touched
+	// (updated_at and seq both move), but no slice the taxonomy names has
+	// changed — so the disjoint-delta rule emits nothing. This is the leg
+	// that proves the rule diffs SLICES rather than detecting "an update
+	// happened": the excluded bookkeeping columns must not manufacture a
+	// change on their own.
+	same := item.Title
+	if _, err := s.UpdateItem(item.ID, models.ItemUpdate{Title: &same}); err != nil {
+		t.Fatalf("UpdateItem: %v", err)
+	}
+
+	if got := outboxEventsFor(t, s, item.ID); len(got) != 0 {
+		t.Fatalf("events = %v, want none — updated_at/seq/last_modified_by move on every "+
+			"mutation and must not be read as a delta", got)
+	}
+}
+
+// TestItemUpdatedSliceChanged_IgnoresPerMutationBookkeeping drives the slice
+// diff DIRECTLY, with hand-built snapshots, because the end-to-end no-op test
+// above cannot see this.
+//
+// WHY IT CANNOT: store.now() formats RFC3339, which is SECOND granularity. A
+// test that creates an item and updates it milliseconds later produces the
+// SAME updated_at string on both snapshots, so the exclusion of updated_at is
+// never exercised — removing "updated_at" from itemDeltaExcludedKeys leaves
+// TestOutbox_NoOpUpdateEmitsNothing green (verified by mutation, not assumed).
+// In production the two writes are seconds or hours apart and the exclusion is
+// entirely load-bearing: without it, EVERY update would emit item.updated and
+// the disjoint-delta rule would be decorative.
+//
+// So the exclusions get an instrument that does not depend on wall-clock luck:
+// two snapshots differing ONLY in the per-mutation bookkeeping columns must
+// compare equal, and one differing in a real field must not.
+func TestItemUpdatedSliceChanged_IgnoresPerMutationBookkeeping(t *testing.T) {
+	base := &models.Item{
+		ID:          "item-1",
+		WorkspaceID: "ws-1",
+		Title:       "Same title",
+		Fields:      `{"status":"open","priority":"high"}`,
+		Seq:         10,
+		UpdatedAt:   time.Date(2026, 8, 20, 10, 0, 0, 0, time.UTC),
+	}
+
+	// Only bookkeeping moved: a touched-but-unchanged row.
+	touched := *base
+	touched.Seq = 11
+	touched.UpdatedAt = time.Date(2026, 8, 20, 12, 30, 0, 0, time.UTC)
+	touched.LastModifiedBy = "someone-else"
+
+	changed, err := itemUpdatedSliceChanged(base, &touched, "status")
+	if err != nil {
+		t.Fatalf("itemUpdatedSliceChanged: %v", err)
+	}
+	if changed {
+		t.Fatalf("a row whose only movement was seq/updated_at/last_modified_by reported a delta; " +
+			"every update would emit item.updated and the disjoint-delta rule would be decorative")
+	}
+
+	// The status field alone moved: owned by item.status_changed, so the
+	// item.updated slice must NOT report a change.
+	statusOnly := *base
+	statusOnly.Fields = `{"status":"done","priority":"high"}`
+	changed, err = itemUpdatedSliceChanged(base, &statusOnly, "status")
+	if err != nil {
+		t.Fatalf("itemUpdatedSliceChanged: %v", err)
+	}
+	if changed {
+		t.Fatalf("a bare status change reported an item.updated delta; status is status_changed's " +
+			"slice and would be described twice")
+	}
+
+	// A non-status field inside the same blob moved: that IS item.updated's
+	// slice. This is the leg that proves the status mask is surgical rather
+	// than excluding the whole fields blob.
+	priorityOnly := *base
+	priorityOnly.Fields = `{"status":"open","priority":"low"}`
+	changed, err = itemUpdatedSliceChanged(base, &priorityOnly, "status")
+	if err != nil {
+		t.Fatalf("itemUpdatedSliceChanged: %v", err)
+	}
+	if !changed {
+		t.Fatalf("a priority change inside the fields blob reported NO delta; masking the status " +
+			"key must not mask the whole blob")
+	}
+
+	// Key order in the blob is not semantic.
+	reordered := *base
+	reordered.Fields = `{"priority":"high","status":"open"}`
+	changed, err = itemUpdatedSliceChanged(base, &reordered, "status")
+	if err != nil {
+		t.Fatalf("itemUpdatedSliceChanged: %v", err)
+	}
+	if changed {
+		t.Fatalf("re-serializing the fields blob in a different key order reported a delta")
+	}
+}
+
+func TestWriteOutboxTx_RejectsNonCanonicalEvent(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Outbox reject")
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	defer tx.Rollback()
+
+	err = writeOutboxTx(tx, s, OutboxEvent{
+		WorkspaceID: ws.ID,
+		EventType:   "item.frobnicated",
+		SubjectKind: kernelevents.SubjectItem,
+		Payload:     []byte(`{"id":"x"}`),
+	})
+	if err == nil {
+		t.Fatalf("writeOutboxTx accepted a non-canonical event name; the events/1 set is closed, " +
+			"and an unknown name would reach the PUBLIC webhook surface")
+	}
+}
+
+func TestWriteOutboxTx_RejectsEmptyPayload(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Outbox empty")
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	defer tx.Rollback()
+
+	err = writeOutboxTx(tx, s, OutboxEvent{
+		WorkspaceID: ws.ID,
+		EventType:   kernelevents.ItemCreated,
+		SubjectKind: kernelevents.SubjectItem,
+	})
+	if err == nil {
+		t.Fatalf("writeOutboxTx accepted an empty payload; binding predicates evaluate against " +
+			"the payload snapshot, so such an event is undeliverable by construction")
+	}
+}
+
+func TestWriteOutboxTx_DropsPastCascadeBound(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Outbox hop")
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	defer tx.Rollback()
+
+	// At the bound: written. Past it: dropped, and NOT an error — the
+	// mutation itself was legitimate, only the cascade it would extend is
+	// not (SPEC-3 §L5).
+	atBound := OutboxEvent{
+		WorkspaceID: ws.ID,
+		EventType:   kernelevents.ItemCreated,
+		SubjectKind: kernelevents.SubjectItem,
+		SubjectID:   "at-bound",
+		Payload:     []byte(`{"id":"at-bound"}`),
+		Hop:         maxOutboxHop,
+	}
+	if err := writeOutboxTx(tx, s, atBound); err != nil {
+		t.Fatalf("writeOutboxTx at hop %d: %v", maxOutboxHop, err)
+	}
+
+	past := atBound
+	past.ID = ""
+	past.SubjectID = "past-bound"
+	past.Hop = maxOutboxHop + 1
+	if err := writeOutboxTx(tx, s, past); err != nil {
+		t.Fatalf("writeOutboxTx past the cascade bound returned an error; dropping is the bound "+
+			"working and must not fail the mutation: %v", err)
+	}
+
+	var n int
+	if err := tx.QueryRow(s.q(`SELECT COUNT(*) FROM event_outbox WHERE subject_id = ?`), "past-bound").Scan(&n); err != nil {
+		t.Fatalf("count past-bound: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("past-bound rows = %d, want 0 — the cascade bound did not drop the event", n)
+	}
+
+	if err := tx.QueryRow(s.q(`SELECT COUNT(*) FROM event_outbox WHERE subject_id = ?`), "at-bound").Scan(&n); err != nil {
+		t.Fatalf("count at-bound: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("at-bound rows = %d, want 1 — the bound is off by one and is dropping events "+
+			"that should be written", n)
+	}
+}
+
+func TestOutbox_DeleteEmitsPreArchiveSnapshot(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Outbox delete")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+	item := createTestItem(t, s, ws.ID, col.ID, "To be archived", "body")
+	clearOutbox(t, s)
+
+	if err := s.DeleteItem(item.ID); err != nil {
+		t.Fatalf("DeleteItem: %v", err)
+	}
+
+	if got := outboxEventsFor(t, s, item.ID); len(got) != 1 || got[0] != kernelevents.ItemDeleted {
+		t.Fatalf("events = %v, want exactly [%s]", got, kernelevents.ItemDeleted)
+	}
+
+	// SPEC-3 §Bindings: the payload must be the FINAL PRE-ARCHIVE state. It is
+	// the only thing keeping a deleted item addressable to predicates, which
+	// never consult the live store — so an empty or post-archive snapshot here
+	// makes every item.deleted binding unevaluable.
+	payload := outboxPayloadFor(t, s, item.ID, kernelevents.ItemDeleted)
+	if payload["title"] != "To be archived" {
+		t.Fatalf("payload title = %v, want the pre-archive title", payload["title"])
+	}
+	if payload["id"] != item.ID {
+		t.Fatalf("payload id = %v, want %s", payload["id"], item.ID)
+	}
+}
+
+func TestOutbox_RedeleteEmitsNothing(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Outbox redelete")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+	item := createTestItem(t, s, ws.ID, col.ID, "Archived once", "body")
+
+	if err := s.DeleteItem(item.ID); err != nil {
+		t.Fatalf("first DeleteItem: %v", err)
+	}
+	clearOutbox(t, s)
+
+	// The second delete affects zero rows: nothing was archived, so nothing
+	// may be announced. An event here would describe a mutation that did not
+	// happen — the exact class of lie the outbox exists to make impossible.
+	if err := s.DeleteItem(item.ID); err == nil {
+		t.Fatalf("re-deleting an archived item unexpectedly succeeded")
+	}
+	if got := outboxEventsFor(t, s, item.ID); len(got) != 0 {
+		t.Fatalf("events = %v, want none — a no-op delete emitted an event", got)
+	}
+}
+
+func TestOutbox_RestoreEmitsItemRestored(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Outbox restore")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+	item := createTestItem(t, s, ws.ID, col.ID, "Round trip", "body")
+	if err := s.DeleteItem(item.ID); err != nil {
+		t.Fatalf("DeleteItem: %v", err)
+	}
+	clearOutbox(t, s)
+
+	if _, err := s.RestoreItem(item.ID); err != nil {
+		t.Fatalf("RestoreItem: %v", err)
+	}
+
+	if got := outboxEventsFor(t, s, item.ID); len(got) != 1 || got[0] != kernelevents.ItemRestored {
+		t.Fatalf("events = %v, want exactly [%s] — restore was silent before SPEC-3 v1.1 and an "+
+			"item could reappear with no observable event", got, kernelevents.ItemRestored)
+	}
+}
+
+func TestOutbox_MoveEmitsMovedOnlyWhenNothingElseChanged(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Outbox move")
+	from := createTestCollection(t, s, ws.ID, "Tasks")
+	to := createTestCollection(t, s, ws.ID, "Bugs")
+	item := createTestItem(t, s, ws.ID, from.ID, "Relocating", "body")
+	clearOutbox(t, s)
+
+	if _, err := s.MoveItem(item.ID, to.ID, item.Fields); err != nil {
+		t.Fatalf("MoveItem: %v", err)
+	}
+
+	if got := outboxEventsFor(t, s, item.ID); len(got) != 1 || got[0] != kernelevents.ItemMoved {
+		t.Fatalf("events = %v, want exactly [%s] — a pure relocation must not leak into "+
+			"item.updated's slice", got, kernelevents.ItemMoved)
+	}
+}

--- a/internal/store/event_outbox_test.go
+++ b/internal/store/event_outbox_test.go
@@ -1166,3 +1166,69 @@ func TestOutbox_NeverAttachedClaimEmitsNothing(t *testing.T) {
 		t.Fatalf("events = %v, want none — this row never emitted attachment.added", got)
 	}
 }
+
+// TestOutbox_VariantClaimEmitsNothing pins the symmetry Codex round 8 found
+// missing: a row that could not have emitted attachment.added must not emit
+// attachment.removed.
+//
+// Variants are the systematic case. A thumbnail is written silently (it carries
+// a parent, so the add gate excludes it), then tombstoned by its original's
+// cascade, and arrives at ClaimSoftDeletedAttachment like any other soft-deleted
+// row. Before the gates were made symmetric it announced a removal for a subject
+// no consumer had ever been told about.
+func TestOutbox_VariantClaimEmitsNothing(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Outbox variant removal")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+	item := createTestItem(t, s, ws.ID, col.ID, "Has thumbnail", "body")
+
+	original := &models.Attachment{
+		WorkspaceID: ws.ID,
+		ItemID:      &item.ID,
+		StorageKey:  "blob/orig",
+		Filename:    "photo.jpg",
+		MimeType:    "image/jpeg",
+		SizeBytes:   100,
+	}
+	if err := s.CreateAttachmentForLiveItem(original); err != nil {
+		t.Fatalf("create original: %v", err)
+	}
+	variant := models.AttachmentVariantThumbMd
+	thumb := &models.Attachment{
+		WorkspaceID: ws.ID,
+		ItemID:      &item.ID,
+		ParentID:    &original.ID,
+		Variant:     &variant,
+		StorageKey:  "blob/thumb",
+		Filename:    "photo-thumb.jpg",
+		MimeType:    "image/jpeg",
+		SizeBytes:   10,
+	}
+	if err := s.CreateAttachmentForLiveItem(thumb); err != nil {
+		t.Fatalf("create thumb: %v", err)
+	}
+	// Confirm the premise rather than assuming it: the variant never announced
+	// its arrival. Without this leg the test could pass because nothing was
+	// ever emitted for the wrong reason.
+	if got := outboxEventsFor(t, s, thumb.ID); len(got) != 0 {
+		t.Fatalf("variant emitted %v on creation; the premise of this test is wrong", got)
+	}
+
+	if err := s.SoftDeleteAttachment(thumb.ID); err != nil {
+		t.Fatalf("SoftDeleteAttachment: %v", err)
+	}
+	clearOutbox(t, s)
+
+	claimed, err := s.ClaimSoftDeletedAttachment(thumb.ID, time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("ClaimSoftDeletedAttachment: %v", err)
+	}
+	if !claimed {
+		t.Fatalf("claim did not take the variant row; the test is not exercising the path")
+	}
+
+	if got := outboxEventsFor(t, s, thumb.ID); len(got) != 0 {
+		t.Fatalf("events = %v, want none — a row that could not announce its arrival must not "+
+			"announce its removal", got)
+	}
+}

--- a/internal/store/event_outbox_test.go
+++ b/internal/store/event_outbox_test.go
@@ -293,10 +293,11 @@ func TestWriteOutboxTx_RejectsNonCanonicalEvent(t *testing.T) {
 	defer tx.Rollback()
 
 	err = writeOutboxTx(tx, s, OutboxEvent{
-		WorkspaceID: ws.ID,
-		EventType:   "item.frobnicated",
-		SubjectKind: kernelevents.SubjectItem,
-		Payload:     []byte(`{"id":"x"}`),
+		WorkspaceID:   ws.ID,
+		EventType:     "item.frobnicated",
+		SubjectKind:   kernelevents.SubjectItem,
+		Payload:       []byte(`{"id":"x"}`),
+		PayloadFamily: kernelevents.PayloadItemSnapshot,
 	})
 	if err == nil {
 		t.Fatalf("writeOutboxTx accepted a non-canonical event name; the events/1 set is closed, " +
@@ -315,9 +316,10 @@ func TestWriteOutboxTx_RejectsEmptyPayload(t *testing.T) {
 	defer tx.Rollback()
 
 	err = writeOutboxTx(tx, s, OutboxEvent{
-		WorkspaceID: ws.ID,
-		EventType:   kernelevents.ItemCreated,
-		SubjectKind: kernelevents.SubjectItem,
+		WorkspaceID:   ws.ID,
+		EventType:     kernelevents.ItemCreated,
+		SubjectKind:   kernelevents.SubjectItem,
+		PayloadFamily: kernelevents.PayloadItemSnapshot,
 	})
 	if err == nil {
 		t.Fatalf("writeOutboxTx accepted an empty payload; binding predicates evaluate against " +
@@ -339,11 +341,12 @@ func TestWriteOutboxTx_DropsPastCascadeBound(t *testing.T) {
 	// pins time-relative predicates to this value, so accepting one would let
 	// a caller silently change how a predicate evaluates.
 	if err := writeOutboxTx(tx, s, OutboxEvent{
-		WorkspaceID: ws.ID,
-		EventType:   kernelevents.ItemCreated,
-		SubjectID:   "stamped",
-		Payload:     []byte(`{"id":"stamped"}`),
-		OccurredAt:  "1999-01-01T00:00:00Z",
+		WorkspaceID:   ws.ID,
+		EventType:     kernelevents.ItemCreated,
+		SubjectID:     "stamped",
+		Payload:       []byte(`{"id":"stamped"}`),
+		OccurredAt:    "1999-01-01T00:00:00Z",
+		PayloadFamily: kernelevents.PayloadItemSnapshot,
 	}); err != nil {
 		t.Fatalf("writeOutboxTx: %v", err)
 	}
@@ -360,12 +363,13 @@ func TestWriteOutboxTx_DropsPastCascadeBound(t *testing.T) {
 	// mutation itself was legitimate, only the cascade it would extend is
 	// not (SPEC-3 §L5).
 	atBound := OutboxEvent{
-		WorkspaceID: ws.ID,
-		EventType:   kernelevents.ItemCreated,
-		SubjectKind: kernelevents.SubjectItem,
-		SubjectID:   "at-bound",
-		Payload:     []byte(`{"id":"at-bound"}`),
-		Hop:         maxOutboxHop,
+		WorkspaceID:   ws.ID,
+		EventType:     kernelevents.ItemCreated,
+		SubjectKind:   kernelevents.SubjectItem,
+		SubjectID:     "at-bound",
+		Payload:       []byte(`{"id":"at-bound"}`),
+		Hop:           maxOutboxHop,
+		PayloadFamily: kernelevents.PayloadItemSnapshot,
 	}
 	if err := writeOutboxTx(tx, s, atBound); err != nil {
 		t.Fatalf("writeOutboxTx at hop %d: %v", maxOutboxHop, err)
@@ -847,11 +851,12 @@ func TestWriteOutboxTx_RejectsMalformedJSONPayload(t *testing.T) {
 	// would accept it. Validating in Go makes both backends fail identically
 	// rather than one silently persisting an undeliverable event.
 	err = writeOutboxTx(tx, s, OutboxEvent{
-		WorkspaceID: ws.ID,
-		EventType:   kernelevents.ItemCreated,
-		SubjectKind: kernelevents.SubjectItem,
-		SubjectID:   "x",
-		Payload:     []byte(`{"id":"x"`),
+		WorkspaceID:   ws.ID,
+		EventType:     kernelevents.ItemCreated,
+		SubjectKind:   kernelevents.SubjectItem,
+		SubjectID:     "x",
+		Payload:       []byte(`{"id":"x"`),
+		PayloadFamily: kernelevents.PayloadItemSnapshot,
 	})
 	if err == nil {
 		t.Fatalf("writeOutboxTx accepted a malformed JSON payload; on SQLite this persists an " +
@@ -1273,11 +1278,12 @@ func TestWriteOutboxTx_SubjectKindIsDerivedNotTrusted(t *testing.T) {
 
 	// A mismatched kind is refused rather than stored.
 	err = writeOutboxTx(tx, s, OutboxEvent{
-		WorkspaceID: ws.ID,
-		EventType:   kernelevents.ItemCreated,
-		SubjectKind: kernelevents.SubjectComment,
-		SubjectID:   "mismatched",
-		Payload:     []byte(`{"id":"mismatched"}`),
+		WorkspaceID:   ws.ID,
+		EventType:     kernelevents.ItemCreated,
+		SubjectKind:   kernelevents.SubjectComment,
+		SubjectID:     "mismatched",
+		Payload:       []byte(`{"id":"mismatched"}`),
+		PayloadFamily: kernelevents.PayloadItemSnapshot,
 	})
 	if err == nil {
 		t.Fatalf("writeOutboxTx stored item.created under subject kind %q; the drain would "+
@@ -1286,10 +1292,11 @@ func TestWriteOutboxTx_SubjectKindIsDerivedNotTrusted(t *testing.T) {
 
 	// An omitted kind is filled in from the taxonomy.
 	if err := writeOutboxTx(tx, s, OutboxEvent{
-		WorkspaceID: ws.ID,
-		EventType:   kernelevents.ItemCreated,
-		SubjectID:   "derived",
-		Payload:     []byte(`{"id":"derived"}`),
+		WorkspaceID:   ws.ID,
+		EventType:     kernelevents.ItemCreated,
+		SubjectID:     "derived",
+		Payload:       []byte(`{"id":"derived"}`),
+		PayloadFamily: kernelevents.PayloadItemSnapshot,
 	}); err != nil {
 		t.Fatalf("writeOutboxTx with no subject kind: %v", err)
 	}
@@ -1299,5 +1306,58 @@ func TestWriteOutboxTx_SubjectKindIsDerivedNotTrusted(t *testing.T) {
 	}
 	if kind != kernelevents.SubjectItem {
 		t.Fatalf("subject_kind = %q, want %q", kind, kernelevents.SubjectItem)
+	}
+}
+
+// TestWriteOutboxTx_RejectsMismatchedPayloadFamily pins Codex round 10's
+// finding: canonical membership validates the NAME, and said nothing about
+// whether the bytes attached to it were the right shape.
+func TestWriteOutboxTx_RejectsMismatchedPayloadFamily(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Outbox family")
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	defer tx.Rollback()
+
+	// item.created paired with a REF-ONLY deletion payload: both halves are
+	// individually valid — a canonical name and well-formed JSON — and they
+	// were not meant for each other.
+	err = writeOutboxTx(tx, s, OutboxEvent{
+		WorkspaceID:   ws.ID,
+		EventType:     kernelevents.ItemCreated,
+		SubjectID:     "mixed",
+		Payload:       []byte(`{"id":"mixed","workspace_id":"w"}`),
+		PayloadFamily: kernelevents.PayloadRefOnly,
+	})
+	if err == nil {
+		t.Fatalf("writeOutboxTx accepted a %s payload under %s; a consumer would parse the "+
+			"bytes as an item snapshot and find nothing it expected",
+			kernelevents.PayloadRefOnly, kernelevents.ItemCreated)
+	}
+
+	// And an undeclared family is refused too — silence must not pass for
+	// agreement.
+	err = writeOutboxTx(tx, s, OutboxEvent{
+		WorkspaceID: ws.ID,
+		EventType:   kernelevents.ItemCreated,
+		SubjectID:   "undeclared",
+		Payload:     []byte(`{"id":"undeclared"}`),
+	})
+	if err == nil {
+		t.Fatalf("writeOutboxTx accepted an event with no declared payload family")
+	}
+}
+
+// TestPayloadFamily_CoversEveryCanonicalEvent keeps the two taxonomy maps from
+// drifting: a canonical name with no declared family would be unwritable, and
+// the failure would surface as a confusing runtime rejection rather than here.
+func TestPayloadFamily_CoversEveryCanonicalEvent(t *testing.T) {
+	for _, name := range kernelevents.Canonical() {
+		if family, ok := kernelevents.PayloadFamily(name); !ok || family == "" {
+			t.Errorf("canonical event %q has no payload family", name)
+		}
 	}
 }

--- a/internal/store/event_outbox_test.go
+++ b/internal/store/event_outbox_test.go
@@ -869,3 +869,78 @@ func TestOutbox_NoOpCommentEditEmitsNothing(t *testing.T) {
 			got, kernelevents.CommentUpdated)
 	}
 }
+
+// TestEmitBulkItemEventTx_PartitionsByMemberWorkspace pins the multi-tenancy
+// property: a member snapshot must never be published under a workspace that
+// is not its own.
+//
+// The wiki-title cascade's source query selects on target_item_id alone and
+// carries each source row's workspace_id per-row, so a cross-workspace member
+// is not excluded by construction. Publishing the whole member set under the
+// caller's workspace would put one workspace's item content on another
+// workspace's webhook — so the emitter partitions rather than trusting that
+// today's queries happen never to produce one.
+func TestEmitBulkItemEventTx_PartitionsByMemberWorkspace(t *testing.T) {
+	s := testStore(t)
+	wsA := createTestWorkspace(t, s, "Partition A")
+	wsB := createTestWorkspace(t, s, "Partition B")
+
+	members := []*models.Item{
+		{ID: "a1", WorkspaceID: wsA.ID, Fields: "{}"},
+		{ID: "b1", WorkspaceID: wsB.ID, Fields: "{}"},
+		{ID: "a2", WorkspaceID: wsA.ID, Fields: "{}"},
+	}
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	// Caller passes workspace A, as the cascade would when A's item was renamed.
+	if err := s.emitBulkItemEventTx(tx, wsA.ID, members, map[string]any{"kind": "test"}); err != nil {
+		tx.Rollback()
+		t.Fatalf("emitBulkItemEventTx: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	rows, err := s.db.Query(s.q(`SELECT workspace_id, payload FROM event_outbox WHERE event_type = ? ORDER BY workspace_id`),
+		kernelevents.ItemBulkUpdated)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	defer rows.Close()
+
+	counts := map[string]int{}
+	for rows.Next() {
+		var ws, payload string
+		if err := rows.Scan(&ws, &payload); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		var m map[string]any
+		if err := json.Unmarshal([]byte(payload), &m); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		ms, _ := m["members"].([]any)
+		counts[ws] = len(ms)
+		// Every member in this row must belong to the row's workspace.
+		for _, raw := range ms {
+			mm, _ := raw.(map[string]any)
+			if mm["workspace_id"] != ws {
+				t.Fatalf("event for workspace %s carries a member from %v — one workspace's item "+
+					"content would reach another workspace's webhook", ws, mm["workspace_id"])
+			}
+		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate: %v", err)
+	}
+
+	if len(counts) != 2 {
+		t.Fatalf("bulk events = %d, want 2 (one per member workspace); a single event means the "+
+			"member set was published under the caller's workspace", len(counts))
+	}
+	if counts[wsA.ID] != 2 || counts[wsB.ID] != 1 {
+		t.Fatalf("member counts = %v, want {A:2, B:1}", counts)
+	}
+}

--- a/internal/store/event_outbox_test.go
+++ b/internal/store/event_outbox_test.go
@@ -678,14 +678,44 @@ func TestOutbox_CollectionOptionRenameEmitsOneBulkEvent(t *testing.T) {
 		t.Fatalf("members = %d, want 2 — per-member snapshots are what keep item-level bindings "+
 			"evaluable across a batched delivery", len(members))
 	}
-	// The snapshots must be POST-migration: a pre-migration snapshot would
-	// carry the value the mutation just removed.
+	// MEMBER IDENTITY, not just count (Codex round 3): a reader that returned
+	// the same member twice, or the wrong items entirely, would satisfy a
+	// count-only assertion while making per-member binding evaluation fire on
+	// the wrong set.
+	gotIDs := map[string]bool{}
 	for _, raw := range members {
 		m, _ := raw.(map[string]any)
+		id, _ := m["id"].(string)
+		if gotIDs[id] {
+			t.Fatalf("member %s appears twice; a duplicate makes per-member evaluation fire "+
+				"twice on one item", id)
+		}
+		gotIDs[id] = true
+		// The snapshots must be POST-migration: a pre-migration snapshot would
+		// carry the value the mutation just removed.
 		fields, _ := m["fields"].(string)
 		if !strings.Contains(fields, "doing") {
 			t.Fatalf("member snapshot fields = %q, want the POST-migration value", fields)
 		}
+	}
+	if !gotIDs[a.ID] || !gotIDs[b.ID] {
+		t.Fatalf("members = %v, want exactly the two migrated items %s and %s", gotIDs, a.ID, b.ID)
+	}
+
+	// THE DELTA, which is the only part of the payload that says what the one
+	// mutation actually did. An emitter that dropped it would leave consumers
+	// with two changed items and no explanation.
+	delta, _ := payload["delta"].(map[string]any)
+	if delta["kind"] != "field_option_renamed" {
+		t.Fatalf("delta kind = %v, want %q", delta["kind"], "field_option_renamed")
+	}
+	renames, _ := delta["renames"].([]any)
+	if len(renames) != 1 {
+		t.Fatalf("delta renames = %v, want one entry describing status in-progress→doing", renames)
+	}
+	r0, _ := renames[0].(map[string]any)
+	if r0["field"] != "status" || r0["from"] != "in-progress" || r0["to"] != "doing" {
+		t.Fatalf("delta rename = %v, want {field:status from:in-progress to:doing}", r0)
 	}
 }
 
@@ -722,5 +752,88 @@ func TestOutbox_WikiTitleCascadeEmitsOneBulkEvent(t *testing.T) {
 	if content, _ := m["content"].(string); !strings.Contains(content, "[[New Title]]") {
 		t.Fatalf("member content = %q, want the REWRITTEN content — the cascade's whole delta is "+
 			"content, so a pre-rewrite snapshot makes the event useless", content)
+	}
+}
+
+// TestItemUpdatedSliceChanged_NonDefaultAndNonStringDoneKey covers two gaps
+// Codex round 3 found in the classification tests above: every other test uses
+// the default "status" key, so a classifier hard-coded to mask "status" would
+// pass them all; and none of them exercise a done-key value the status
+// machinery cannot read.
+func TestItemUpdatedSliceChanged_NonDefaultAndNonStringDoneKey(t *testing.T) {
+	// A CUSTOM done-field key must behave exactly as "status" does. A
+	// classifier that masks the literal "status" instead of the collection's
+	// declared key fails here and nowhere else.
+	base := &models.Item{ID: "i", WorkspaceID: "w", Fields: `{"stage":"open","note":"a"}`}
+	stageOnly := *base
+	stageOnly.Fields = `{"stage":"done","note":"a"}`
+	changed, err := itemUpdatedSliceChanged(base, &stageOnly, "stage")
+	if err != nil {
+		t.Fatalf("itemUpdatedSliceChanged: %v", err)
+	}
+	if changed {
+		t.Fatalf("a bare change to the CUSTOM done field %q reported an item.updated delta; "+
+			"the mask must follow the collection's declared key, not the literal \"status\"", "stage")
+	}
+
+	// The same custom key, but the value is a NUMBER. extractFieldValue only
+	// reads JSON strings, so status_changed will never report this — and if
+	// the mask deleted the key anyway, the remainder would compare equal and
+	// the mutation would emit NOTHING AT ALL. A real field change has to land
+	// in item.updated's slice when no other event can describe it.
+	numBefore := &models.Item{ID: "i", WorkspaceID: "w", Fields: `{"stage":1}`}
+	numAfter := &models.Item{ID: "i", WorkspaceID: "w", Fields: `{"stage":2}`}
+	changed, err = itemUpdatedSliceChanged(numBefore, numAfter, "stage")
+	if err != nil {
+		t.Fatalf("itemUpdatedSliceChanged: %v", err)
+	}
+	if !changed {
+		t.Fatalf("a numeric done-field change reported NO delta; status_changed cannot see a " +
+			"non-string value either, so this mutation would be silently unobservable")
+	}
+
+	// A non-object blob cannot have anything masked out of it. It still has to
+	// yield a correct changed/did-not-change answer.
+	arrBefore := &models.Item{ID: "i", WorkspaceID: "w", Fields: `[{"status":"open"}]`}
+	arrAfter := &models.Item{ID: "i", WorkspaceID: "w", Fields: `[{"status":"done"}]`}
+	changed, err = itemUpdatedSliceChanged(arrBefore, arrAfter, "status")
+	if err != nil {
+		t.Fatalf("itemUpdatedSliceChanged: %v", err)
+	}
+	if !changed {
+		t.Fatalf("a change inside a non-object fields blob reported NO delta")
+	}
+	changed, err = itemUpdatedSliceChanged(arrBefore, arrBefore, "status")
+	if err != nil {
+		t.Fatalf("itemUpdatedSliceChanged: %v", err)
+	}
+	if changed {
+		t.Fatalf("an unchanged non-object fields blob reported a delta")
+	}
+}
+
+func TestWriteOutboxTx_RejectsMalformedJSONPayload(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Outbox malformed")
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	defer tx.Rollback()
+
+	// Postgres would reject this at the INSERT (JSONB); SQLite's TEXT column
+	// would accept it. Validating in Go makes both backends fail identically
+	// rather than one silently persisting an undeliverable event.
+	err = writeOutboxTx(tx, s, OutboxEvent{
+		WorkspaceID: ws.ID,
+		EventType:   kernelevents.ItemCreated,
+		SubjectKind: kernelevents.SubjectItem,
+		SubjectID:   "x",
+		Payload:     []byte(`{"id":"x"`),
+	})
+	if err == nil {
+		t.Fatalf("writeOutboxTx accepted a malformed JSON payload; on SQLite this persists an " +
+			"event no consumer can parse, while Postgres refuses the same write")
 	}
 }

--- a/internal/store/event_outbox_test.go
+++ b/internal/store/event_outbox_test.go
@@ -837,3 +837,35 @@ func TestWriteOutboxTx_RejectsMalformedJSONPayload(t *testing.T) {
 			"event no consumer can parse, while Postgres refuses the same write")
 	}
 }
+
+func TestOutbox_NoOpCommentEditEmitsNothing(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Outbox comment noop")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+	item := createTestItem(t, s, ws.ID, col.ID, "Commented", "body")
+
+	c, err := s.CreateComment(ws.ID, item.ID, "", models.CommentCreate{Body: "same"})
+	if err != nil {
+		t.Fatalf("CreateComment: %v", err)
+	}
+	clearOutbox(t, s)
+
+	// Re-saving an identical body still MATCHES the row — the UPDATE keys on
+	// id alone and updated_at moves — so the row-count check cannot suppress
+	// this. Comparing the body is what does.
+	if _, err := s.UpdateComment(c.ID, "same"); err != nil {
+		t.Fatalf("UpdateComment: %v", err)
+	}
+	if got := outboxEventsFor(t, s, c.ID); len(got) != 0 {
+		t.Fatalf("events = %v, want none — a no-op comment edit must not announce a change", got)
+	}
+
+	// ...and a real edit still does.
+	if _, err := s.UpdateComment(c.ID, "different"); err != nil {
+		t.Fatalf("UpdateComment: %v", err)
+	}
+	if got := outboxEventsFor(t, s, c.ID); len(got) != 1 || got[0] != kernelevents.CommentUpdated {
+		t.Fatalf("events = %v, want exactly [%s] — the no-op gate must not suppress real edits",
+			got, kernelevents.CommentUpdated)
+	}
+}

--- a/internal/store/event_outbox_test.go
+++ b/internal/store/event_outbox_test.go
@@ -3,6 +3,7 @@ package store
 import (
 	"encoding/json"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -611,5 +612,115 @@ func TestOutbox_CrossWorkspaceMoveEmitsSourceArchive(t *testing.T) {
 	// transaction — the move is two canonical events, not one.
 	if got := outboxEventsFor(t, f.s, res.Item.ID); len(got) != 1 || got[0] != kernelevents.ItemCreated {
 		t.Fatalf("destination events = %v, want exactly [%s]", got, kernelevents.ItemCreated)
+	}
+}
+
+// outboxBulkPayload returns the single item.bulk_updated payload in the
+// outbox, failing unless there is exactly one.
+func outboxBulkPayload(t *testing.T, s *Store) map[string]any {
+	t.Helper()
+	rows, err := s.db.Query(s.q(`SELECT payload FROM event_outbox WHERE event_type = ?`), kernelevents.ItemBulkUpdated)
+	if err != nil {
+		t.Fatalf("query bulk payloads: %v", err)
+	}
+	defer rows.Close()
+
+	var payloads []string
+	for rows.Next() {
+		var p string
+		if err := rows.Scan(&p); err != nil {
+			t.Fatalf("scan payload: %v", err)
+		}
+		payloads = append(payloads, p)
+	}
+	if len(payloads) != 1 {
+		t.Fatalf("item.bulk_updated rows = %d, want exactly 1 — a bulk mutation must emit ONE "+
+			"wire event, not per-row fan-out", len(payloads))
+	}
+	var m map[string]any
+	if err := json.Unmarshal([]byte(payloads[0]), &m); err != nil {
+		t.Fatalf("decode bulk payload: %v", err)
+	}
+	return m
+}
+
+func TestOutbox_CollectionOptionRenameEmitsOneBulkEvent(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Outbox option rename")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+
+	a := createTestItem(t, s, ws.ID, col.ID, "One", "body")
+	b := createTestItem(t, s, ws.ID, col.ID, "Two", "body")
+	wip := `{"status":"in-progress"}`
+	for _, it := range []*models.Item{a, b} {
+		if _, err := s.UpdateItem(it.ID, models.ItemUpdate{Fields: &wip}); err != nil {
+			t.Fatalf("seed status: %v", err)
+		}
+	}
+	clearOutbox(t, s)
+
+	n, err := s.MigrateItemFieldValues(col.ID, []models.FieldMigration{
+		{Field: "status", RenameOptions: map[string]string{"in-progress": "doing"}},
+	})
+	if err != nil {
+		t.Fatalf("MigrateItemFieldValues: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("migrated rows = %d, want 2 — the test is not exercising a bulk mutation", n)
+	}
+
+	payload := outboxBulkPayload(t, s)
+	if got := payload["member_count"]; got != float64(2) {
+		t.Fatalf("member_count = %v, want 2", got)
+	}
+	members, _ := payload["members"].([]any)
+	if len(members) != 2 {
+		t.Fatalf("members = %d, want 2 — per-member snapshots are what keep item-level bindings "+
+			"evaluable across a batched delivery", len(members))
+	}
+	// The snapshots must be POST-migration: a pre-migration snapshot would
+	// carry the value the mutation just removed.
+	for _, raw := range members {
+		m, _ := raw.(map[string]any)
+		fields, _ := m["fields"].(string)
+		if !strings.Contains(fields, "doing") {
+			t.Fatalf("member snapshot fields = %q, want the POST-migration value", fields)
+		}
+	}
+}
+
+func TestOutbox_WikiTitleCascadeEmitsOneBulkEvent(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Outbox cascade")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+
+	target := createTestItem(t, s, ws.ID, col.ID, "Old Title", "the target")
+	linker := createTestItem(t, s, ws.ID, col.ID, "Linker", "points at [[Old Title]] here")
+	clearOutbox(t, s)
+
+	newTitle := "New Title"
+	if _, err := s.UpdateItem(target.ID, models.ItemUpdate{Title: &newTitle}); err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+
+	// The renamed item emits its own item.updated for its own slice...
+	if got := outboxEventsFor(t, s, target.ID); len(got) != 1 || got[0] != kernelevents.ItemUpdated {
+		t.Fatalf("renamed item events = %v, want exactly [%s]", got, kernelevents.ItemUpdated)
+	}
+
+	// ...and the cascade's rewritten backlinks arrive as ONE batch event, not
+	// as per-backlink fan-out.
+	payload := outboxBulkPayload(t, s)
+	if payload["member_count"] != float64(1) {
+		t.Fatalf("member_count = %v, want 1", payload["member_count"])
+	}
+	members, _ := payload["members"].([]any)
+	m, _ := members[0].(map[string]any)
+	if m["id"] != linker.ID {
+		t.Fatalf("member id = %v, want the backlink item %s", m["id"], linker.ID)
+	}
+	if content, _ := m["content"].(string); !strings.Contains(content, "[[New Title]]") {
+		t.Fatalf("member content = %q, want the REWRITTEN content — the cascade's whole delta is "+
+			"content, so a pre-rewrite snapshot makes the event useless", content)
 	}
 }

--- a/internal/store/export.go
+++ b/internal/store/export.go
@@ -438,6 +438,16 @@ func (s *Store) ImportWorkspace(data *models.WorkspaceExport, newName string, ow
 		if err := stampAttachmentRefsTx(tx, s, ws.ID, it.Content, fieldsJSON); err != nil {
 			return nil, err
 		}
+		// NO EVENT IS EMITTED HERE, AND THAT IS A RULING, NOT AN OVERSIGHT.
+		// This is the second item-creation write path in the codebase — the
+		// other is insertItemTx, which owns the API paths and (from TASK-2658)
+		// the transactional event outbox. Import deliberately stays silent:
+		// SPEC-3 (DOC-2653) §Taxonomy records that events/1 cannot express an
+		// import, so restoring a 900-item archive fires no item.created fan-out
+		// and consumers resync out-of-band. If a future contract version wants
+		// import observable, the spec pre-names the shape — ONE additive
+		// workspace-level `workspace.imported` event, never per-item fan-out.
+		// Do not "fix" this by hanging an outbox write off this INSERT.
 		_, err := tx.Exec(s.q(`
 			INSERT INTO items (id, workspace_id, collection_id, title, slug, content, fields, tags, pinned, sort_order, parent_id, created_by, last_modified_by, source, item_number, created_at, updated_at, seq)
 			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULLIF(?, ''), ?, ?, ?, ?, ?, ?, `+nextWorkspaceSeqSubquery+`)`),

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -2742,13 +2742,11 @@ func (s *Store) DeleteItem(id string) error {
 	// that: the UPDATE carries `deleted_at IS NULL`, so a second delete
 	// matches nothing and this line is never reached.
 	//
-	// The `preArchive != nil` check is therefore NOT a second re-delete guard
-	// today — it is unreachable for that case, and an earlier version of this
-	// comment claiming otherwise was wrong twice over (Codex rounds 3 and 4).
-	// What it IS: the guard that keeps this correct if the order or the
-	// predicate ever changes. Measured, not assumed — moving this emit above
-	// the zero-row return leaves the re-delete test green, because getItemTx
-	// filters archived rows and `preArchive` is already nil by then.
+	// The `preArchive != nil` check is therefore NOT a second re-delete guard:
+	// it is unreachable for that case today. What it IS: the guard that keeps
+	// this correct if the order or the predicate ever changes — moving this
+	// emit above the zero-row return leaves the re-delete test green, because
+	// getItemTx filters archived rows and `preArchive` is already nil by then.
 	//
 	// It also covers the ordinary case where the pre-archive read found no
 	// live row at all, which must not emit an event for an item that was not

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -538,7 +538,7 @@ func (s *Store) createItemTxWithID(tx *sql.Tx, id, workspaceID, collectionID str
 	// A failure here fails the create. That is not incidental — an outbox
 	// write that degrades to best-effort would look durable while
 	// reintroducing exactly the lost-event window the outbox exists to close.
-	if err := s.emitItemEventTx(tx, kernelevents.ItemCreated, item, ""); err != nil {
+	if err := s.emitItemEventTx(tx, kernelevents.ItemCreated, item, nil); err != nil {
 		return nil, err
 	}
 	return item, nil
@@ -2754,7 +2754,7 @@ func (s *Store) DeleteItem(id string) error {
 	// live row at all, which must not emit an event for an item that was not
 	// there to archive.
 	if preArchive != nil {
-		if err := s.emitItemEventTx(tx, kernelevents.ItemDeleted, preArchive, ""); err != nil {
+		if err := s.emitItemEventTx(tx, kernelevents.ItemDeleted, preArchive, nil); err != nil {
 			return err
 		}
 	}
@@ -2847,7 +2847,7 @@ func (s *Store) restoreItemOnce(id string) (*models.Item, error) {
 		return nil, fmt.Errorf("read post-restore snapshot: %w", err)
 	}
 	if restored != nil {
-		if err := s.emitItemEventTx(tx, kernelevents.ItemRestored, restored, ""); err != nil {
+		if err := s.emitItemEventTx(tx, kernelevents.ItemRestored, restored, nil); err != nil {
 			return nil, err
 		}
 	}
@@ -4666,12 +4666,12 @@ func (s *Store) moveItemWithPreCheckOnce(
 	}
 	if moved != nil {
 		if targetCollectionID != preMove.CollectionID {
-			if err := s.emitItemEventTx(tx, kernelevents.ItemMoved, moved, ""); err != nil {
+			if err := s.emitItemEventTx(tx, kernelevents.ItemMoved, moved, nil); err != nil {
 				return nil, err
 			}
 		}
 		if newStatus != oldStatus {
-			if err := s.emitItemEventTx(tx, kernelevents.ItemStatusChanged, moved, oldStatus); err != nil {
+			if err := s.emitItemEventTx(tx, kernelevents.ItemStatusChanged, moved, &oldStatus); err != nil {
 				return nil, err
 			}
 		}
@@ -4683,7 +4683,7 @@ func (s *Store) moveItemWithPreCheckOnce(
 			return nil, cerr
 		}
 		if otherChanged {
-			if err := s.emitItemEventTx(tx, kernelevents.ItemUpdated, moved, ""); err != nil {
+			if err := s.emitItemEventTx(tx, kernelevents.ItemUpdated, moved, nil); err != nil {
 				return nil, err
 			}
 		}

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -4548,10 +4548,37 @@ func (s *Store) moveItemWithPreCheckOnce(
 	// read through that key may be empty, which correctly reads as "entered".
 	moveDoneKey := s.doneFieldKey(targetCollectionID)
 	oldFields := existing.Fields
+
+	// preMove is the item as it stands UNDER THE LOCK, immediately before the
+	// UPDATE. It is what the event decisions below compare against, and it is
+	// deliberately not `existing`: `existing` is only refreshed in-tx on the
+	// precheck path, so on the no-precheck path it is the PRE-LOCK pool read
+	// and every field on it — CollectionID included — may already be stale.
+	//
+	// That matters twice over for TASK-2658. A stale CollectionID makes the
+	// item.moved decision wrong outright. And itemUpdatedSliceChanged
+	// documents a precondition that BOTH snapshots come from getItemTx,
+	// because a pool read and an in-tx read can render join-populated fields
+	// differently and the diff would report those differences as changes —
+	// comparing `existing` against the post-move snapshot violated exactly
+	// that precondition (Codex round 1, P2).
+	preMove := existing
 	if precheck == nil {
-		if fresh, ferr := s.getItemTx(tx, itemID); ferr == nil && fresh != nil {
-			oldFields = fresh.Fields
+		// Read it once, and treat a failure as a failure. The previous shape
+		// tolerated a read error by silently keeping the pre-lock value, which
+		// only ever degraded from_status; now it would also silently decide
+		// which events to emit, so a degraded read is no longer an acceptable
+		// outcome. Under a held lock on a row we just resolved live, an error
+		// or a missing row means something is genuinely wrong.
+		fresh, ferr := s.getItemTx(tx, itemID)
+		if ferr != nil {
+			return nil, fmt.Errorf("re-read item under lock: %w", ferr)
 		}
+		if fresh == nil {
+			return nil, sql.ErrNoRows
+		}
+		oldFields = fresh.Fields
+		preMove = fresh
 	}
 
 	// A move's field OVERRIDES can inject a brand-new pad-attachment:
@@ -4624,7 +4651,7 @@ func (s *Store) moveItemWithPreCheckOnce(
 		return nil, fmt.Errorf("read post-move snapshot: %w", err)
 	}
 	if moved != nil {
-		if targetCollectionID != existing.CollectionID {
+		if targetCollectionID != preMove.CollectionID {
 			if err := s.emitItemEventTx(tx, kernelevents.ItemMoved, moved, ""); err != nil {
 				return nil, err
 			}
@@ -4637,7 +4664,7 @@ func (s *Store) moveItemWithPreCheckOnce(
 		// itemUpdatedSliceChanged already excludes collection_id and the
 		// derived collection_*/ref keys, so a pure relocation does not leak
 		// into item.updated's slice.
-		otherChanged, cerr := itemUpdatedSliceChanged(existing, moved, moveDoneKey)
+		otherChanged, cerr := itemUpdatedSliceChanged(preMove, moved, moveDoneKey)
 		if cerr != nil {
 			return nil, cerr
 		}

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -2734,11 +2734,23 @@ func (s *Store) DeleteItem(id string) error {
 		return sql.ErrNoRows
 	}
 
-	// The emit is gated on the UPDATE having actually archived a row. A
-	// re-delete of an already-archived item affects zero rows and returns
-	// above, so no event is written — the mutation did not happen, and an
-	// event for it would be a lie the outbox is specifically built not to
-	// tell.
+	// A re-delete of an already-archived item must announce nothing: the
+	// mutation did not happen, and an event for it would be a lie the outbox
+	// exists not to tell.
+	//
+	// TWO INDEPENDENT GUARDS produce that, and it is worth naming both because
+	// a mutation test cannot distinguish them (measured — moving this emit
+	// above the zero-row return leaves the re-delete test green):
+	//
+	//  1. The zero-row return above. The UPDATE carries `deleted_at IS NULL`,
+	//     so a second delete matches nothing and this code is never reached.
+	//  2. THE NIL SNAPSHOT, which is the one that actually fires first.
+	//     getItemTx filters archived rows, so on a re-delete `preArchive` is
+	//     already nil by the time the UPDATE runs — there is no snapshot to
+	//     emit even if the row count said otherwise.
+	//
+	// Guard 2 is load-bearing rather than defensive: it is also what keeps
+	// this correct if the UPDATE's predicate is ever loosened.
 	if preArchive != nil {
 		if err := s.emitItemEventTx(tx, kernelevents.ItemDeleted, preArchive, ""); err != nil {
 			return err

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/PerpetualSoftware/pad/internal/diff"
+	"github.com/PerpetualSoftware/pad/internal/kernelevents"
 	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
@@ -246,9 +247,18 @@ func (s *Store) tryCreateItem(workspaceID, collectionID string, input models.Ite
 // create-time status_transitions row. It neither begins nor commits — the
 // caller owns the transaction boundary.
 //
-// Every creation side effect lives in this one place. Its only caller is
-// createItemTx, which both CreateItem and the cross-workspace copy path
-// (PLAN-2357 / DR-9a) go through, so the two paths cannot drift.
+// Every side effect of an API-PATH creation lives in this one place. Its only
+// caller is createItemTx, which both CreateItem and the cross-workspace copy
+// path (PLAN-2357 / DR-9a) go through, so those two paths cannot drift.
+//
+// The "API-PATH" qualifier is load-bearing and was missing until TASK-2658.
+// This comment used to read "every creation side effect", full stop, and it is
+// not true: ImportWorkspace (export.go) writes items with its own INSERT INTO
+// items and never reaches here. Two units in a row have now been misled by
+// reading a scoped invariant as a global one — TASK-2657 shipped a P1 on the
+// same mistake in this file family. If you are adding a creation side effect,
+// grep `INSERT INTO items` and confirm which of the TWO write paths you need,
+// rather than trusting that this is the only one.
 func (s *Store) insertItemTx(tx *sql.Tx, id, workspaceID, collectionID, slug, ts, fields, tags, createdBy, source string, input models.ItemCreate) error {
 	var err error
 
@@ -517,6 +527,19 @@ func (s *Store) createItemTxWithID(tx *sql.Tx, id, workspaceID, collectionID str
 	}
 	if item == nil {
 		return nil, fmt.Errorf("created item %s not readable in transaction", id)
+	}
+
+	// The choke point (SPEC-3 / TASK-2658): the item.created event is written
+	// to the outbox on THIS transaction, so it commits with the row it
+	// describes or not at all. Placed after the in-transaction read-back
+	// because the event must carry what the database actually holds, not what
+	// the caller asked for.
+	//
+	// A failure here fails the create. That is not incidental — an outbox
+	// write that degrades to best-effort would look durable while
+	// reintroducing exactly the lost-event window the outbox exists to close.
+	if err := s.emitItemEventTx(tx, kernelevents.ItemCreated, item, ""); err != nil {
+		return nil, err
 	}
 	return item, nil
 }
@@ -2637,6 +2660,17 @@ func (s *Store) updateItemWithParentLinkOnce(
 		updated.LastMutation = &sig
 	}
 
+	// The choke point (SPEC-3 / TASK-2658). Emitted here — after the in-tx
+	// read-back and after the status/assignment deltas are computed, before
+	// COMMIT — because this is the first point where BOTH facts the event
+	// needs are known: what the row now holds, and what changed to get there.
+	// The prior status comes from the same in-tx before/after comparison that
+	// wrote the status_transitions row, so the event and the transition log
+	// cannot disagree about what happened.
+	if err := s.emitItemUpdateEventsTx(tx, existing, updated, mutSignal.StatusChanged, mutSignal.FromStatus, doneKey); err != nil {
+		return nil, err
+	}
+
 	if err := tx.Commit(); err != nil {
 		return nil, err
 	}
@@ -2672,6 +2706,21 @@ func (s *Store) DeleteItem(id string) error {
 		return err
 	}
 
+	// SPEC-3 §Bindings requires item.deleted to carry the FINAL PRE-ARCHIVE
+	// state — that snapshot is the only thing keeping a deleted item
+	// addressable to binding predicates, since they never consult the live
+	// store. Read it here: in-tx, under the seq lock already held, and before
+	// the UPDATE while the row is still live (getItemTx filters archived rows,
+	// so after the write it would return nil).
+	//
+	// In-tx rather than reusing the pre-tx `existing` read above: that read
+	// happened before the lock, so a concurrent update landing in between
+	// would make the event describe a state that was never the final one.
+	preArchive, err := s.getItemTx(tx, id)
+	if err != nil {
+		return fmt.Errorf("read pre-archive snapshot: %w", err)
+	}
+
 	ts := now()
 	result, err := tx.Exec(s.q(`
 		UPDATE items SET deleted_at = ?, updated_at = ?, seq = `+nextWorkspaceSeqSubquery+`
@@ -2683,6 +2732,17 @@ func (s *Store) DeleteItem(id string) error {
 	rows, _ := result.RowsAffected()
 	if rows == 0 {
 		return sql.ErrNoRows
+	}
+
+	// The emit is gated on the UPDATE having actually archived a row. A
+	// re-delete of an already-archived item affects zero rows and returns
+	// above, so no event is written — the mutation did not happen, and an
+	// event for it would be a lie the outbox is specifically built not to
+	// tell.
+	if preArchive != nil {
+		if err := s.emitItemEventTx(tx, kernelevents.ItemDeleted, preArchive, ""); err != nil {
+			return err
+		}
 	}
 	return tx.Commit()
 }
@@ -2761,6 +2821,23 @@ func (s *Store) restoreItemOnce(id string) (*models.Item, error) {
 	if rows == 0 {
 		return nil, sql.ErrNoRows
 	}
+
+	// item.restored carries the POST-restore snapshot (SPEC-3 v1.1). Read
+	// after the UPDATE, in-tx: the row is live again at this point, so
+	// getItemTx sees it, and the snapshot reflects the state a consumer will
+	// find if it goes looking. Restore was silent before v1.1 — an item could
+	// reappear with no observable event, which broke every consumer's model of
+	// what exists.
+	restored, err := s.getItemTx(tx, id)
+	if err != nil {
+		return nil, fmt.Errorf("read post-restore snapshot: %w", err)
+	}
+	if restored != nil {
+		if err := s.emitItemEventTx(tx, kernelevents.ItemRestored, restored, ""); err != nil {
+			return nil, err
+		}
+	}
+
 	if err := tx.Commit(); err != nil {
 		return nil, err
 	}
@@ -4532,6 +4609,42 @@ func (s *Store) moveItemWithPreCheckOnce(
 			VALUES (?, ?, ?, ?, ?, ?, ?)
 		`), newID(), existing.WorkspaceID, itemID, existing.CollectionID, targetCollectionID, moveSeq, moveTS); err != nil {
 			return nil, fmt.Errorf("record collection move: %w", err)
+		}
+	}
+
+	// The choke point for the move path, applying the same disjoint-delta rule
+	// as the update path (SPEC-3 v1.3). A move is not automatically ONE event:
+	// item.moved owns the location slice, item.status_changed owns the status
+	// field — which this path can change, since it accepts a new fields blob —
+	// and item.updated owns whatever else moved. Emitting only item.moved
+	// would silently drop a status transition that a binding is watching for,
+	// which is precisely the gap the rule exists to close.
+	moved, err := s.getItemTx(tx, itemID)
+	if err != nil {
+		return nil, fmt.Errorf("read post-move snapshot: %w", err)
+	}
+	if moved != nil {
+		if targetCollectionID != existing.CollectionID {
+			if err := s.emitItemEventTx(tx, kernelevents.ItemMoved, moved, ""); err != nil {
+				return nil, err
+			}
+		}
+		if newStatus != oldStatus {
+			if err := s.emitItemEventTx(tx, kernelevents.ItemStatusChanged, moved, oldStatus); err != nil {
+				return nil, err
+			}
+		}
+		// itemUpdatedSliceChanged already excludes collection_id and the
+		// derived collection_*/ref keys, so a pure relocation does not leak
+		// into item.updated's slice.
+		otherChanged, cerr := itemUpdatedSliceChanged(existing, moved, moveDoneKey)
+		if cerr != nil {
+			return nil, cerr
+		}
+		if otherChanged {
+			if err := s.emitItemEventTx(tx, kernelevents.ItemUpdated, moved, ""); err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -2738,19 +2738,21 @@ func (s *Store) DeleteItem(id string) error {
 	// mutation did not happen, and an event for it would be a lie the outbox
 	// exists not to tell.
 	//
-	// TWO INDEPENDENT GUARDS produce that, and it is worth naming both because
-	// a mutation test cannot distinguish them (measured — moving this emit
-	// above the zero-row return leaves the re-delete test green):
+	// In the CURRENT code order, the zero-row return above is what produces
+	// that: the UPDATE carries `deleted_at IS NULL`, so a second delete
+	// matches nothing and this line is never reached.
 	//
-	//  1. The zero-row return above. The UPDATE carries `deleted_at IS NULL`,
-	//     so a second delete matches nothing and this code is never reached.
-	//  2. THE NIL SNAPSHOT, which is the one that actually fires first.
-	//     getItemTx filters archived rows, so on a re-delete `preArchive` is
-	//     already nil by the time the UPDATE runs — there is no snapshot to
-	//     emit even if the row count said otherwise.
+	// The `preArchive != nil` check is therefore NOT a second re-delete guard
+	// today — it is unreachable for that case, and an earlier version of this
+	// comment claiming otherwise was wrong twice over (Codex rounds 3 and 4).
+	// What it IS: the guard that keeps this correct if the order or the
+	// predicate ever changes. Measured, not assumed — moving this emit above
+	// the zero-row return leaves the re-delete test green, because getItemTx
+	// filters archived rows and `preArchive` is already nil by then.
 	//
-	// Guard 2 is load-bearing rather than defensive: it is also what keeps
-	// this correct if the UPDATE's predicate is ever loosened.
+	// It also covers the ordinary case where the pre-archive read found no
+	// live row at all, which must not emit an event for an item that was not
+	// there to archive.
 	if preArchive != nil {
 		if err := s.emitItemEventTx(tx, kernelevents.ItemDeleted, preArchive, ""); err != nil {
 			return err

--- a/internal/store/items_create_tx_test.go
+++ b/internal/store/items_create_tx_test.go
@@ -551,6 +551,21 @@ func TestCreateItemTx_RollbackPersistsNothing(t *testing.T) {
 		tx.Rollback()
 		t.Fatalf("test is vacuous: in-tx seq %d did not advance past %d", phantomSeq, seqBefore)
 	}
+	// POSITIVE CONTROL for the outbox assertion below (TASK-2658). "No outbox
+	// row after rollback" is trivially true if the create never wrote one, so
+	// the row has to be observed INSIDE the transaction first. Without this
+	// leg, deleting the emit call from createItemTxWithID leaves the test
+	// green — which is the exact failure mode this whole unit exists to
+	// prevent, and it would be embarrassing to reproduce it in the test.
+	var inTxEvents int
+	if err := tx.QueryRow(s.q(`SELECT COUNT(*) FROM event_outbox WHERE subject_id = ?`), phantomID).Scan(&inTxEvents); err != nil {
+		tx.Rollback()
+		t.Fatalf("in-tx outbox count: %v", err)
+	}
+	if inTxEvents != 1 {
+		tx.Rollback()
+		t.Fatalf("in-tx outbox rows for created item = %d, want 1 (the create emitted no event)", inTxEvents)
+	}
 	if err := tx.Rollback(); err != nil {
 		t.Fatalf("rollback: %v", err)
 	}
@@ -569,6 +584,12 @@ func TestCreateItemTx_RollbackPersistsNothing(t *testing.T) {
 	}
 	if n := scanCount(t, s, `SELECT COUNT(*) FROM status_transitions WHERE item_id = ?`, phantomID); n != 0 {
 		t.Fatalf("status_transitions row survived rollback")
+	}
+	// The event must roll back with the row it describes (SPEC-3 §choke
+	// point, TASK-2658). A leaked event here would advertise an item that
+	// does not exist, to consumers that cannot tell the difference.
+	if n := scanCount(t, s, `SELECT COUNT(*) FROM event_outbox WHERE subject_id = ?`, phantomID); n != 0 {
+		t.Fatalf("event_outbox row survived rollback: a rolled-back mutation leaked an event")
 	}
 	if got := maxWorkspaceSeq(t, s, ws.ID); got != seqBefore {
 		t.Fatalf("workspace seq advanced across rollback: %d -> %d", seqBefore, got)

--- a/internal/store/items_cross_workspace_copy.go
+++ b/internal/store/items_cross_workspace_copy.go
@@ -1162,7 +1162,7 @@ func (s *Store) archiveItemForCopyTx(tx *sql.Tx, workspaceID, itemID, ts string)
 		return 0, fmt.Errorf("copy item across workspaces: source item %s was not archived", itemID)
 	}
 	if preArchive != nil {
-		if err := s.emitItemEventTx(tx, kernelevents.ItemDeleted, preArchive, ""); err != nil {
+		if err := s.emitItemEventTx(tx, kernelevents.ItemDeleted, preArchive, nil); err != nil {
 			return 0, err
 		}
 	}

--- a/internal/store/items_cross_workspace_copy.go
+++ b/internal/store/items_cross_workspace_copy.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/PerpetualSoftware/pad/internal/items"
+	"github.com/PerpetualSoftware/pad/internal/kernelevents"
 	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
@@ -45,6 +46,17 @@ import (
 // FANOUT IS NOT HERE EITHER (DR-14). No activity row, no SSE publish, no
 // webhook. Emitting inside the transaction would leak an event for a copy that
 // then rolls back. The caller emits post-commit from CrossWorkspaceCopyResult.
+//
+// NARROWED BY TASK-2658, deliberately and without reversing DR-14's reasoning.
+// The transactional event OUTBOX is written here — by createItemTx for the
+// destination item, and by archiveItemForCopyTx for a move's source archive.
+// That is not fanout: it is the durable record that the mutation happened, and
+// it is exempt from DR-14's rationale rather than an exception to it. DR-14
+// refuses in-transaction emission because a rollback would leak an event; an
+// outbox row written on the SAME transaction rolls back WITH the copy, so the
+// leak DR-14 names cannot occur. The three things DR-14 actually lists —
+// activity row, SSE publish, webhook — still happen post-commit at the caller,
+// unchanged.
 
 // ErrCopyCrossBackendAttachments is returned when the copy would have to move
 // attachment BYTES between storage backends.
@@ -1113,6 +1125,24 @@ func (s *Store) archiveItemForCopyTx(tx *sql.Tx, workspaceID, itemID, ts string)
 	if err := s.acquireWorkspaceSeqLock(tx, workspaceID); err != nil {
 		return 0, err
 	}
+
+	// The event has to be reproduced here for the SAME reason the archive is
+	// (TASK-2658). Because this path deliberately does not call DeleteItem, it
+	// does not inherit DeleteItem's item.deleted emit either — so a
+	// cross-workspace MOVE would archive the source with no event while an
+	// ordinary archive of the same item emits one. That asymmetry is invisible
+	// until something consumes the outbox, at which point moves silently stop
+	// being observable; catching it now is cheaper than discovering it as a
+	// missing-event bug later.
+	//
+	// Same ordering as DeleteItem: snapshot BEFORE the UPDATE, in-tx, while
+	// the row is still live (getItemTx filters archived rows), because SPEC-3
+	// requires the final pre-archive state.
+	preArchive, err := s.getItemTx(tx, itemID)
+	if err != nil {
+		return 0, fmt.Errorf("copy item across workspaces: read pre-archive snapshot: %w", err)
+	}
+
 	res, err := tx.Exec(s.q(`
 		UPDATE items SET deleted_at = ?, updated_at = ?, seq = `+nextWorkspaceSeqSubquery+`
 		WHERE id = ? AND deleted_at IS NULL
@@ -1131,6 +1161,12 @@ func (s *Store) archiveItemForCopyTx(tx *sql.Tx, workspaceID, itemID, ts string)
 		// happen.
 		return 0, fmt.Errorf("copy item across workspaces: source item %s was not archived", itemID)
 	}
+	if preArchive != nil {
+		if err := s.emitItemEventTx(tx, kernelevents.ItemDeleted, preArchive, ""); err != nil {
+			return 0, err
+		}
+	}
+
 	var seq int64
 	if err := tx.QueryRow(s.q(`SELECT seq FROM items WHERE id = ?`), itemID).Scan(&seq); err != nil {
 		return 0, fmt.Errorf("copy item across workspaces: read archive seq: %w", err)

--- a/internal/store/migrations/081_event_outbox.sql
+++ b/internal/store/migrations/081_event_outbox.sql
@@ -9,9 +9,15 @@
 -- can leak an event for a mutation that never committed. Writing the event
 -- into this table inside the SAME transaction as the mutation makes both
 -- impossible: the event and the row it describes commit or roll back
--- together. Everything downstream — webhooks, SSE, and later the binding
--- engine — drains from here, which is what lets SPEC-3's delivery guarantees
--- be stated honestly rather than hoped for.
+-- together, which is what lets SPEC-3's delivery guarantees be stated honestly
+-- rather than hoped for.
+--
+-- NOTHING DRAINS THIS TABLE YET. Webhooks and SSE still fire from their
+-- existing hand-called sites, unchanged; the drain that reads from here, the
+-- canonical-to-surface name mapping, and the retirement of those hand-calls
+-- are TASK-2714. The binding engine is later still (phase 2+). Stated in the
+-- present tense on purpose — a comment describing the intended end state as if
+-- it were the current one is how a reader concludes a feature is broken.
 --
 -- DELIBERATELY NO FOREIGN KEYS on workspace_id / subject_id, which is the one
 -- surprising thing in this schema. An outbox row must outlive its subject:

--- a/internal/store/migrations/081_event_outbox.sql
+++ b/internal/store/migrations/081_event_outbox.sql
@@ -1,0 +1,86 @@
+-- Transactional event outbox (SPEC-3 §"The choke point, with an outbox",
+-- PLAN-2656 phase 0 / TASK-2658).
+--
+-- Before this table, every event emission happened in the HTTP handler AFTER
+-- the store call returned — outside any transaction. That shape has two
+-- failure modes and both are silent: a mutation that commits and then loses
+-- its process emits nothing (the event is gone, and nothing records that it
+-- should have existed), and a handler that emits before a later step fails
+-- can leak an event for a mutation that never committed. Writing the event
+-- into this table inside the SAME transaction as the mutation makes both
+-- impossible: the event and the row it describes commit or roll back
+-- together. Everything downstream — webhooks, SSE, and later the binding
+-- engine — drains from here, which is what lets SPEC-3's delivery guarantees
+-- be stated honestly rather than hoped for.
+--
+-- DELIBERATELY NO FOREIGN KEYS on workspace_id / subject_id, which is the one
+-- surprising thing in this schema. An outbox row must outlive its subject:
+-- the whole point of an item.deleted event is that it is dispatched after the
+-- item is gone, and SPEC-3 §Bindings requires deleted items stay addressable
+-- through the payload snapshot. An ON DELETE CASCADE would delete exactly the
+-- events that matter most, and a RESTRICT would make purge fail on any
+-- workspace with undrained events. Orphan rows are handled by retention
+-- (drained rows are prunable), not by referential integrity.
+CREATE TABLE IF NOT EXISTS event_outbox (
+    -- The public event id. Consumers dedupe on it — SPEC-3 §Delivery
+    -- guarantees promises webhooks at-least-once with duplicates possible by
+    -- design, and this is the value that makes that promise usable.
+    id            TEXT PRIMARY KEY,
+    workspace_id  TEXT NOT NULL,
+
+    -- Canonical events/1 name (item.created, item.status_changed, ...). The
+    -- taxonomy is closed: a mutation whose name is not in events/1 writes no
+    -- row at all, so silence about a mutation type is a versioned fact rather
+    -- than a missing INSERT.
+    event_type    TEXT NOT NULL,
+
+    -- What the event is about. subject_id is nullable because not every
+    -- canonical event has a row-shaped subject (member.joined, pack.*).
+    subject_kind  TEXT NOT NULL,
+    subject_id    TEXT,
+
+    -- The event payload: the subject snapshot plus envelope pseudo-fields
+    -- (prior_status for status_changed, per SPEC-3 §Bindings). Predicates
+    -- evaluate against THIS, never against the live store, which is what
+    -- makes binding evaluation deterministic regardless of dispatch delay.
+    payload       TEXT NOT NULL,
+
+    -- Cost discipline (SPEC-3 §L5): binding-triggered mutations inherit
+    -- hop+1 and the kernel drops past depth 4. Bounds synchronous cascades
+    -- only — async re-entry (a webhook consumer calling back through the API)
+    -- legitimately starts fresh at 0.
+    hop           INTEGER NOT NULL DEFAULT 0,
+
+    -- The event's OWN timestamp, not dispatch time. SPEC-3 §Bindings pins
+    -- time-relative predicates (`within`) to this value so a delayed drain
+    -- cannot change how a predicate evaluates.
+    occurred_at   TEXT NOT NULL,
+
+    -- Drain bookkeeping. NULL dispatched_at is the pending set.
+    dispatched_at TEXT,
+    attempts      INTEGER NOT NULL DEFAULT 0,
+    last_error    TEXT
+);
+
+-- The drain query's index: pending rows in event order. Partial so it stays
+-- small — the pending set is transient while the table as a whole retains
+-- dispatched history until pruned.
+--
+-- Ordering is (occurred_at, id) and v1 does NOT promise event ordering to
+-- consumers. Timestamps can tie, so id breaks ties for determinism of the
+-- drain itself, not as an ordering contract. Anything needing true ordering
+-- has to earn a monotonic sequence in a later contract version rather than
+-- read one into this index.
+CREATE INDEX IF NOT EXISTS idx_event_outbox_pending
+    ON event_outbox(occurred_at, id)
+    WHERE dispatched_at IS NULL;
+
+-- Retention/pruning scans dispatched rows oldest-first.
+CREATE INDEX IF NOT EXISTS idx_event_outbox_dispatched
+    ON event_outbox(dispatched_at)
+    WHERE dispatched_at IS NOT NULL;
+
+-- Workspace-scoped reads (inspection, per-workspace quota accounting under
+-- SPEC-3 §L5).
+CREATE INDEX IF NOT EXISTS idx_event_outbox_workspace
+    ON event_outbox(workspace_id, occurred_at);

--- a/internal/store/pgmigrations/059_event_outbox.sql
+++ b/internal/store/pgmigrations/059_event_outbox.sql
@@ -1,0 +1,47 @@
+-- Transactional event outbox — Postgres mirror of
+-- internal/store/migrations/081_event_outbox.sql. See the SQLite migration for
+-- the full rationale (SPEC-3 §choke point; why the event and the mutation must
+-- commit together; why there are DELIBERATELY no foreign keys on
+-- workspace_id / subject_id).
+--
+-- Two dialect differences, both deliberate:
+--
+--   1. payload is JSONB rather than TEXT, matching what migration 058 did for
+--      collections.traits and what this schema already does for
+--      collections.schema / settings. Go scans JSONB into a string exactly as
+--      it does for those columns, so the store's scan path is dialect-neutral;
+--      the gain is that Postgres validates the payload at write time. A
+--      payload that fails to parse is an event no consumer can act on, and
+--      catching that at the INSERT — inside the mutation's own transaction,
+--      where it still rolls the mutation back — is strictly better than
+--      discovering it at drain time when the mutation is long committed.
+--
+--   2. Timestamps stay TEXT, matching every other table in this schema
+--      (watches, items, activities). Not a preference — occurred_at is
+--      compared against values the Go layer formats, and a TIMESTAMPTZ here
+--      would silently change comparison semantics on exactly the column
+--      SPEC-3 pins time-relative predicates to.
+CREATE TABLE IF NOT EXISTS event_outbox (
+    id            TEXT PRIMARY KEY,
+    workspace_id  TEXT NOT NULL,
+    event_type    TEXT NOT NULL,
+    subject_kind  TEXT NOT NULL,
+    subject_id    TEXT,
+    payload       JSONB NOT NULL,
+    hop           INTEGER NOT NULL DEFAULT 0,
+    occurred_at   TEXT NOT NULL,
+    dispatched_at TEXT,
+    attempts      INTEGER NOT NULL DEFAULT 0,
+    last_error    TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_event_outbox_pending
+    ON event_outbox(occurred_at, id)
+    WHERE dispatched_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_event_outbox_dispatched
+    ON event_outbox(dispatched_at)
+    WHERE dispatched_at IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_event_outbox_workspace
+    ON event_outbox(workspace_id, occurred_at);

--- a/internal/store/wiki_links.go
+++ b/internal/store/wiki_links.go
@@ -654,6 +654,10 @@ func (s *Store) cascadeTitleRename(tx *sql.Tx, renamedItemID, workspaceID, oldTi
 	// bracket via links.RewriteBracketAt, then UPDATE the source's
 	// content + re-parse to refresh the index.
 	ts := now()
+	// Members of the item.bulk_updated emitted after the loop — only sources
+	// whose content this cascade actually rewrote, not every candidate it
+	// examined.
+	var cascaded []string
 	for _, work := range works {
 		newContent := work.content
 		mutated := false
@@ -692,6 +696,32 @@ func (s *Store) cascadeTitleRename(tx *sql.Tx, renamedItemID, workspaceID, oldTi
 		if err := s.replaceWikiLinks(tx, work.id, work.workspaceID, newContent); err != nil {
 			return fmt.Errorf("cascade rename: reparse %s: %w", work.id, err)
 		}
+		cascaded = append(cascaded, work.id)
+	}
+
+	// TASK-2658: the cascade rewrites the CONTENT of every item that linked to
+	// the renamed one by title. Before this, only the renamed item emitted —
+	// its backlinks changed silently, so a consumer's cached copy of each one
+	// went stale with nothing to tell it.
+	//
+	// ONE item.bulk_updated rather than N item.updated: renaming a popular
+	// item can rewrite hundreds of backlinks, and the user performed ONE
+	// action (SPEC-3 v1.1 / TASK-1668). Per-member snapshots keep item-level
+	// bindings evaluable, which is what makes the batching safe.
+	//
+	// Emitted BEFORE resolveBrokenTitleLinks, which mutates the link INDEX
+	// rather than items — no item row changes there, so it has no members to
+	// carry and belongs outside this event.
+	members, err := s.itemSnapshotsTx(tx, cascaded)
+	if err != nil {
+		return err
+	}
+	if err := s.emitBulkItemEventTx(tx, workspaceID, members, map[string]any{
+		"kind":            "wiki_title_cascade",
+		"renamed_item_id": renamedItemID,
+		"new_title":       newTitle,
+	}); err != nil {
+		return err
 	}
 
 	// (2) Flip newly-resolvable broken rows under the NEW title.

--- a/internal/store/wiki_links.go
+++ b/internal/store/wiki_links.go
@@ -712,7 +712,7 @@ func (s *Store) cascadeTitleRename(tx *sql.Tx, renamedItemID, workspaceID, oldTi
 	// Emitted BEFORE resolveBrokenTitleLinks, which mutates the link INDEX
 	// rather than items — no item row changes there, so it has no members to
 	// carry and belongs outside this event.
-	members, err := s.itemSnapshotsTx(tx, cascaded)
+	members, err := s.outboxMemberSnapshotsTx(tx, cascaded)
 	if err != nil {
 		return err
 	}

--- a/internal/store/workspace_members.go
+++ b/internal/store/workspace_members.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/PerpetualSoftware/pad/internal/kernelevents"
 	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
@@ -19,13 +20,34 @@ import (
 const InvitationTTL = 14 * 24 * time.Hour
 
 // AddWorkspaceMember adds a user to a workspace with the given role.
+//
+// Transactional as of TASK-2658 — it was a bare Exec before. The membership
+// row and its member.joined event must commit together or not at all (SPEC-3
+// §choke point); a self-committing INSERT followed by a separate emit is the
+// exact shape that loses events on a crash and leaks them on a later failure.
+// The transaction wraps a single INSERT, so it costs nothing beyond the
+// BEGIN/COMMIT pair.
 func (s *Store) AddWorkspaceMember(workspaceID, userID, role string) error {
 	ts := now()
-	_, err := s.db.Exec(s.q(`
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("add workspace member: %w", err)
+	}
+	defer tx.Rollback()
+
+	if _, err := tx.Exec(s.q(`
 		INSERT INTO workspace_members (workspace_id, user_id, role, created_at)
 		VALUES (?, ?, ?, ?)
-	`), workspaceID, userID, role, ts)
-	if err != nil {
+	`), workspaceID, userID, role, ts); err != nil {
+		return fmt.Errorf("add workspace member: %w", err)
+	}
+
+	if err := s.emitMemberEventTx(tx, kernelevents.MemberJoined, workspaceID, userID, role, ts); err != nil {
+		return err
+	}
+
+	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("add workspace member: %w", err)
 	}
 	return nil

--- a/internal/store/workspace_purge.go
+++ b/internal/store/workspace_purge.go
@@ -168,6 +168,15 @@ func (s *Store) CountAttachmentsForStorageKeyOutsideWorkspace(storageKey, worksp
 // clears the RESTRICT FK to workspaces while preserving the audit trail —
 // the de-identify posture DeleteAccountAtomic uses for audit rows.
 var purgeWorkspaceChildDeletes = []struct{ what, query string }{
+	// --- event outbox (TASK-2658) ---
+	// Purged explicitly BECAUSE it has no foreign key. The outbox deliberately
+	// carries none so a row can outlive its subject (an item.deleted event is
+	// dispatched after its item is gone), which means nothing deletes these
+	// rows on its behalf. Payloads hold full item content and comment bodies,
+	// so leaving them behind would keep a purged workspace's text readable
+	// indefinitely — the exact thing a purge exists to prevent (Codex round 2).
+	{"event outbox", `DELETE FROM event_outbox WHERE workspace_id = ?`},
+
 	// --- item child rows (before items) ---
 	{"comment reactions", `DELETE FROM comment_reactions WHERE comment_id IN (SELECT id FROM comments WHERE workspace_id = ?)`},
 	{"comments", `DELETE FROM comments WHERE workspace_id = ?`},

--- a/internal/store/workspace_purge_test.go
+++ b/internal/store/workspace_purge_test.go
@@ -35,6 +35,12 @@ var wsChildTables = []string{
 	"workspace_invitations", "custom_templates", "api_tokens", "share_links",
 	"oauth_connection_workspaces", "user_report_layouts",
 	"member_collection_access", "workspace_members", "attachments", "activities",
+	// event_outbox has NO foreign key to workspaces (TASK-2658 — an outbox row
+	// must outlive its subject), so nothing deletes it on the purge's behalf.
+	// It holds full item content and comment bodies, so an omission here keeps
+	// a purged workspace's text readable indefinitely. Listing it makes the
+	// exhaustive-purge test cover it.
+	"event_outbox",
 }
 
 func (s *Store) mustExec(t *testing.T, query string, args ...interface{}) {


### PR DESCRIPTION
Phase-0 unit 2 of PLAN-2656, store half. Implements SPEC-3 (DOC-2653) §"The choke point, with an outbox" and §Taxonomy.

## The contract this PR ships — read this first

**The outbox fills. Nothing drains it. Behaviour is byte-identical to `main`.**

Every existing emission — the ten hand-called `dispatchWebhook` sites, every SSE publish, every watch notification — still fires exactly as it does today, from exactly where it does today. This PR adds a durable, transactional record *alongside* them. No consumer reads it yet.

That is deliberate, not unfinished. The drain, the surface rewiring, and the `item.updated_with_comment` retirement are **TASK-2714**, which exists and is queued as the next unit. The split was made on review-quality grounds: transactional writes are the part that cannot be retrofitted safely, and a reviewed foundation under the drain beats one rushed unit.

**So: the "missing consumer" is the design, not an omission.** Please don't spend a review round on it.

## Why an outbox at all

Before this, events were emitted from HTTP handlers *after* the store call returned — outside any transaction, and in a layer that has to infer what happened from what it asked for. Two silent failure modes:

- A mutation commits, the process dies, the event is gone — and nothing records that it should have existed.
- A handler emits, a later step fails, and an event goes out for a mutation that never committed.

Writing the event into `event_outbox` **inside the same transaction as the mutation** makes both impossible. That is what lets SPEC-3's delivery guarantees be stated rather than hoped for.

## What emits, and from where

All from inside the mutation's own transaction, from an **in-transaction snapshot read-back** rather than caller input — an event assembled from what the caller *asked for* would describe the request while claiming to describe what happened.

| Event | Where |
|---|---|
| `item.created` | `createItemTxWithID` (both API creation paths inherit it) |
| `item.updated` / `item.status_changed` | `updateItemWithParentLinkOnce` |
| `item.moved` (+ the other slices) | `MoveItemWithPreCheck` |
| `item.deleted` | `DeleteItem`, **and** `archiveItemForCopyTx` |
| `item.restored` | `restoreItemOnce` |
| `item.bulk_updated` | collection option rename; wiki title cascade |
| `comment.created` / `comment.updated` | `CreateComment` / `UpdateComment` |
| `comment.deleted` (ref-only) | `DeleteComment` |
| `attachment.added` | `CreateAttachmentForLiveItem` |
| `attachment.removed` (ref-only) | `ClaimSoftDeletedAttachment` |
| `member.joined` | `AddWorkspaceMember` |

## Decisions a reviewer should push on

**The outbox write is not best-effort.** A failed outbox INSERT fails the enclosing mutation. A degraded-to-best-effort outbox is strictly worse than none: it looks durable while reintroducing the loss it exists to close.

**No foreign keys on `workspace_id` / `subject_id`.** An outbox row must outlive its subject — the whole point of `item.deleted` is that it dispatches after the item is gone, and SPEC-3 §Bindings requires deleted items stay addressable via the payload snapshot. `ON DELETE CASCADE` would delete exactly the events that matter most; `RESTRICT` would make purge fail on any workspace with undrained events. Retention bounds the table instead — and **workspace purge deletes it explicitly**, because nothing else would.

**The payload embeds `models.Item` rather than nesting it.** SPEC-3 says binding predicates are `query/1` `#where` fragments applied verbatim, and `query/1` addresses item fields by their own names. Nesting would force an `item.` prefix that exists nowhere in the query grammar — that is how a second filter dialect gets invented by accident. `prior_status` rides alongside as the envelope pseudo-field.

**One taxonomy table, not two maps.** Subject kind and payload family live in the same canonical entry. Two maps keyed on the same names were free to drift, and drifted dangerously in exactly one direction: an event missing from the family map resolved to the empty family, which a caller declaring nothing then matched. Co-location makes that unrepresentable rather than tested-for, and the compiler requires both fields so an event cannot arrive half-declared.

**The disjoint-delta rule (SPEC-3 v1.3).** Canonical events *partition* a mutation's delta: `status_changed` owns the status field, `moved` owns location, `updated` owns everything else. A mutation emits every event whose slice actually changed — so a bare status flip emits `status_changed` alone, and one update changing status **and** priority emits **both**. The seam therefore diffs slices; branching on "was this a status update" drops the `item.updated` half of every mixed update, silently.

**The slice diff uses an EXCLUSION list, not an inclusion list.** A column added later is compared by default, so the worst a future schema change can do is emit a spurious `item.updated` — visible and arguable. An inclusion list fails the other way: the new column is invisible and a mutation that changes it emits nothing. Silent absence is the failure this unit exists to eliminate; it must not be reintroduced by the mechanism that decides what to emit.

**Bulk payloads are unbounded in v1.** Capping the member list silently drops binding evaluation for the tail; dropping `content` would break exactly the bindings the wiki cascade exists for, since content *is* its delta. One large stored row is the trade the batch event makes — the flood argument was about wire deliveries and consumer rate limits, not one row.

**Import stays silent, and that is spec text.** `ImportWorkspace` writes items through its own `INSERT` and emits nothing: `events/1` cannot express an import, so restoring a 900-item archive fires no `item.created` fan-out and consumers resync out-of-band. Import is fresh-workspace-only today (verified — it calls `CreateWorkspace` itself, and all three callers go through that), so no consumer can exist to miss them. A comment at that `INSERT` says so, ending "do not fix this by hanging an outbox write off this INSERT".

**`attachment.added` is gated to user-visible originals.** Variants are attachment rows too, so an ungated emit fires three events per image upload, two for files no user added. Transform outputs stay admitted: no parent, and a user did add them. **`attachment.removed` carries the identical gate**, so the two are symmetric by construction — a row that could not announce its arrival does not announce its removal.

**Hard-delete events are REF-ONLY, and no outbox row is ever deleted on subject death.** `comment.deleted` and `attachment.removed` carry ids and parent refs, never content — a deletion event must not re-ship what it deletes, and an attachment's full snapshot would hand out a *storage key* for bytes just reclaimed. Deliberately asymmetric with `item.deleted`, whose subject is an archive that stays addressable.

Deleting outbox rows when a subject dies was the obvious-looking fix and it is wrong: it drops undispatched events, reintroducing the silent-event class through the privacy door. Worse for comments, where `comment.deleted` did not exist and those created/updated rows were the *only* record the comment ever existed. The resolution was vocabulary, not deletion — the create event still delivers, the deletion is announced without content, and retention prunes both. **Payload privacy is therefore temporal, which makes the drain load-bearing for privacy and not only for delivery** (a stated requirement on TASK-2714).

**Payloads carry no assignee name or email.** Account deletion's de-identify pass nulls identity on *live* rows; it cannot reach a frozen snapshot. Opaque ids and row state stay — a predicate filters on `assigned_user_id`, and once the account is gone it is a dangling reference to nobody.

## Contract questions ruled during this work

SPEC-3 went v1.0 → v1.3 (rulings recorded on DOC-2653): `item.restored` and `item.bulk_updated` admitted to `events/1`; the disjoint-delta rule; the import silence and its `workspace.imported` successor shape; the choke point owning the canonical→surface name mapping; and Dave's ruling to **fold and retire** `item.updated_with_comment` (implemented in TASK-2714 with the rewiring).

## Review

Four Codex rounds on rotating angles — each round deliberately probing a dimension the previous ones had not, since a confirm-shaped round returns CLEAN while whole categories sit unexamined.

- **Round 1** found a real defect in my own code (a stale pre-lock snapshot used for event classification, violating a precondition documented on the very function it called) plus two silent write paths.
- **Round 2** found the workspace-purge omission, the unauthorized drain query, and a swallowed-error widening (filed as BUG-2715).
- **Round 3** found a **silent-event bug produced by this unit itself**: the done-key mask ran unconditionally, but the status machinery only reads *string* values — so on a collection whose done field holds a number, a real change emitted nothing at all, because `status_changed` could not see it and the mask hid it from `item.updated` too. Also the SQLite/Postgres payload-validation divergence, an overclaim in one of my comments, and two vacuous tests.
- **Round 4** was aimed at the claims the code comments make, and found three that were false or overclaiming — including one where the round-3 "correction" had swapped one wrong mechanism for another. It also found two *more* callers discarding `AddWorkspaceMember`'s error after round 2 named two: the instances a reviewer hands you are a sample, not the population, so all nine call sites are now enumerated. Real fixes out of it: a no-op comment edit no longer emits, and the bulk migration no longer reports a row count for writes that rolled back.

- **Rounds 5–8** found a multi-tenancy hole (the bulk event published every member under the *caller's* workspace, which the wiki-cascade query does not guarantee), a spec-conformance gap (`prior_status` vanished on a transition *from* an empty status, so a predicate could not tell "prior was empty" from "no prior"), the subject-lifecycle privacy findings above, and — in round 8 — a claim I had written into the code as *verified* one commit earlier. I had checked that never-attached implies never-announced, then stated the conclusion for both directions; the converse is false, and variants are the systematic counterexample.

- **Rounds 9–12** were convergence rounds on rotating axes. Round 9 (*what would eight rounds systematically miss?*) found `subject_kind` was caller-trusted, so `item.created` could be stored as kind `comment` and misroute at drain time — every test happened to pass the right value or none. Round 10 (*read this as a maintainer who inherits it*) found the emitters accepted any event name with any payload, an over-general helper name, and comments heavy on narrative while several exported events had no contract docs. Round 11, aimed adversarially at **round 10's own fix**, blocked on a fail-open check that fix had introduced.

**Mutation matrix: 33 applied, 31 caught, 2 survived — both by design and both documented.** Each survivor was informative: running the mutation is what revealed a comment claiming more than the code did.

**One branch is dormant by design.** The fail-closed arm in `writeOutboxTx` (`!known || want == ""`) is unreachable today — the canonical table co-locates subject kind and payload family, so a canonical event cannot lack a family, and `IsCanonical` has already rejected everything else. Verified by mutation: disabling it changes no test. It is kept as the guard for a future table that separates the two again, and its comment says exactly that rather than implying it is the protection.

Two of them are worth reading:

- Removing `updated_at` from the exclusion list **survived** the end-to-end test, because `store.now()` is RFC3339 second-granularity — a test that creates then updates within the same second sees identical timestamps, so the exclusion was never exercised. That test proved nothing about the thing it was named for. Fixed with a direct instrument that does not depend on wall-clock luck; the reason is written into the test.
- Moving the delete emit above the zero-row check **also survived** — and asking why found a *wrong mechanism claim in my own comment*. On a re-delete the pre-archive snapshot is already `nil` (`getItemTx` filters archived rows), so the nil guard fires first, not the row-count return I had credited. The comment now names both guards and which one actually fires.

## Gates

`go build` · `gofmt` · `make lint` (0 issues) · `go test ./...` · `make test-pg` — all green, each read from its own exit code. The `test-pg` log was grepped to confirm the new tests **actually ran** under Postgres rather than trusting the exit code. No web changes, no `go.mod` changes.