### PR TITLE
feat(server): outbox drain — webhooks delivered from the choke point (TASK-2714)

### DIFF
--- a/cmd/pad/cmd_server.go
+++ b/cmd/pad/cmd_server.go
@@ -746,6 +746,19 @@ func serveCmd() *cobra.Command {
 			// Attach webhook dispatcher for outgoing notifications
 			srv.SetWebhookDispatcher(webhooks.NewDispatcher(s))
 
+			// SPEC-3 event outbox drain (TASK-2714). Started AFTER the
+			// dispatcher is attached: a drain running without one acks its
+			// rows as having nowhere to go, which for the first few seconds
+			// of a boot would silently discard real events.
+			outboxInterval := parseDurationEnv("PAD_OUTBOX_DRAIN_INTERVAL", 0)
+			outboxLease := parseDurationEnv("PAD_OUTBOX_CLAIM_LEASE", 0)
+			outboxRetention := parseDurationEnv("PAD_OUTBOX_RETENTION", 0)
+			outboxMaxAge := parseDurationEnv("PAD_OUTBOX_MAX_AGE", 0)
+			if outboxInterval != 0 || outboxLease != 0 || outboxRetention != 0 || outboxMaxAge != 0 {
+				srv.SetOutboxDrainConfig(outboxInterval, outboxLease, outboxRetention, outboxMaxAge, 0)
+			}
+			srv.StartOutboxDrain()
+
 			// Attach email sender: env vars first, then platform settings overlay
 			if cfg.MailerooAPIKey != "" {
 				fromAddr := cfg.EmailFrom

--- a/internal/events/bus.go
+++ b/internal/events/bus.go
@@ -42,8 +42,12 @@ const (
 	ItemStarred   = "item_starred"
 	ItemUnstarred = "item_unstarred"
 
-	// Composite events
-	ItemUpdatedWithComment = "item_updated_with_comment"
+	// Composite events: NONE. item_updated_with_comment was declared here
+	// and never published by anything — its only producer was a hand-called
+	// webhook dispatch using the dot-form name, retired under SPEC-3 v1.2
+	// (Dave's ruling, day-48) because it folds into item.updated +
+	// comment.created. The constant went with it rather than being left as
+	// a name a future publisher could reach for.
 
 	// Batch events. Emitted once for a whole bulk mutation (TASK-1668)
 	// instead of one ItemUpdated/ItemArchived per row — the lane-header

--- a/internal/kernelevents/taxonomy.go
+++ b/internal/kernelevents/taxonomy.go
@@ -15,20 +15,21 @@
 //     IsCanonical exists — a typo'd name must fail loudly at the choke point
 //     rather than travel to a consumer that will never recognize it.
 //
-//   - THE CHOKE POINT WILL OWN THE MAPPING — and does not yet. Today SSE uses
-//     snake_case names published from one set of hand-calls and webhooks use
-//     dot-form string literals passed at a different set of hand-calls; the
-//     two vocabularies drifted because nothing ties them together. SPEC-3 v1.1
-//     rules that both surfaces derive from one canonical name, but THIS
-//     PACKAGE DOES NOT IMPLEMENT THAT MAPPING: it maps a canonical name to a
-//     subject kind and nothing else. The surface mapping, the drain that would
-//     use it, and the retirement of the legacy hand-calls are TASK-2714.
+//   - THE CHOKE POINT OWNS THE MAPPING. SSE's snake_case vocabulary and the
+//     webhook dot-form vocabulary drifted because each was hand-passed at its
+//     own call sites; the eventSpec.sse field is what ties them together now.
+//     What "derive" means is pinned by SPEC-3 v1.5: NAME derivation, not
+//     delivery path.
 //
-// SO, PLAINLY, SO NOBODY READS AN INTENTION AS A DESCRIPTION: as of this
-// package's introduction the outbox FILLS and nothing drains it. Every legacy
-// SSE publish and hand-called webhook dispatch still fires exactly as before.
-// ListPendingOutboxEvents has no production caller. That is the agreed shape
-// of this change, not an unfinished edge.
+// SO, PLAINLY, SO NOBODY READS AN INTENTION AS A DESCRIPTION — current as of
+// TASK-2714: the outbox is DRAINED, and the drain owns the WEBHOOK surface.
+// The hand-called webhook dispatches are gone. SSE is still published directly
+// at the mutation site, because it carries request-scoped attribution
+// (Actor/ActorName/Source) that a frozen payload deliberately does not hold;
+// it takes only its NAME from this package. Moving SSE behind the drain is
+// TASK-2722. The binding engine that SPEC-3 §Bindings describes does not exist
+// yet (phase 2+) — where a comment here says "bindings", it is naming the
+// contract's shape, not running code.
 package kernelevents
 
 // Canonical event names — the events/1 set (SPEC-3 §Taxonomy, v1.1).
@@ -67,10 +68,14 @@ const (
 	ItemRestored = "item.restored"
 
 	// ItemBulkUpdated is the canonical BATCH event: one wire event for a
-	// whole lane-wide mutation. Binding evaluation is still per-member —
-	// the dispatcher runs item-level selectors against each member snapshot
-	// — so bindings never miss a bulk mutation; only wire delivery is
-	// batched.
+	// whole lane-wide mutation, in the normal case (SPEC-3 v1.6 — a
+	// concurrent claim can split one operation across two events, which the
+	// payload's batch_id lets a consumer correlate).
+	//
+	// Per-member binding evaluation comes for free rather than from special
+	// handling: every member of a bulk mutation writes its OWN canonical
+	// event, so whatever binding engine arrives (phase 2+; none exists today)
+	// sees each member individually. Only wire delivery is batched.
 	ItemBulkUpdated = "item.bulk_updated"
 
 	// CommentCreated fires on comment creation. Payload: the stored comment
@@ -188,11 +193,13 @@ type eventSpec struct {
 }
 
 // canonical is the closed events/1 set. Adding an entry here is the ONLY way
-// to add a canonical event, and the compiler requires both fields, so a new
+// to add a canonical event, and the compiler requires every field, so a new
 // event cannot arrive half-declared.
-// Payload families. Every canonical event produces exactly one payload shape,
-// and the family is what lets a writer check that an event and a payload were
-// meant for each other.
+// Payload families. Every canonical event declares the payload shapes it may
+// carry — one for all of them except item.bulk_updated, which has two
+// producers with genuinely different write-time shapes (see eventSpec.payloads)
+// — and the family is what lets a writer check that an event and a payload
+// were meant for each other.
 //
 // Membership in the canonical set says the NAME is real; it says nothing about
 // whether the bytes attached to it are the right shape. Without families, a

--- a/internal/kernelevents/taxonomy.go
+++ b/internal/kernelevents/taxonomy.go
@@ -147,6 +147,26 @@ const (
 type eventSpec struct {
 	subject string
 	payload string
+
+	// sse is the snake_case name this event publishes under on the SSE
+	// surface, or "" when the event has no SSE surface at all.
+	//
+	// SPEC-3 §"The choke point owns the canonical→surface name mapping":
+	// SSE (snake_case) and webhooks (dot-form) drifted because nothing tied
+	// their vocabularies together. This field is the tie. SPEC-3 v1.5 pins
+	// what "derive" means — NAME derivation, not delivery path: webhooks
+	// deliver through the drain, SSE stays direct-published at the mutation
+	// site (it carries request-scoped Actor/ActorName/Source that a frozen
+	// payload deliberately does not hold) and takes only its NAME from here.
+	//
+	// The empty string is a real value, not a gap: attachment, member and
+	// pack events have no SSE surface, and SurfaceSSE reports false for them
+	// so a caller cannot mistake silence for a name. Several canonical events
+	// map onto ONE SSE name — status_changed and moved both surface as
+	// item_updated — because the SSE vocabulary is coarser than events/1 and
+	// the UI has never distinguished them. That is a mapping, not a loss:
+	// the fine-grained name is what the webhook wire and bindings receive.
+	sse string
 }
 
 // canonical is the closed events/1 set. Adding an entry here is the ONLY way
@@ -186,22 +206,22 @@ const (
 )
 
 var canonical = map[string]eventSpec{
-	ItemCreated:       {SubjectItem, PayloadItemSnapshot},
-	ItemUpdated:       {SubjectItem, PayloadItemSnapshot},
-	ItemStatusChanged: {SubjectItem, PayloadItemSnapshot},
-	ItemMoved:         {SubjectItem, PayloadItemSnapshot},
-	ItemDeleted:       {SubjectItem, PayloadItemSnapshot},
-	ItemRestored:      {SubjectItem, PayloadItemSnapshot},
-	ItemBulkUpdated:   {SubjectItemBatch, PayloadItemBatch},
-	CommentCreated:    {SubjectComment, PayloadCommentSnapshot},
-	CommentUpdated:    {SubjectComment, PayloadCommentSnapshot},
-	CommentDeleted:    {SubjectComment, PayloadRefOnly},
-	AttachmentAdded:   {SubjectAttachment, PayloadAttachmentSnapshot},
-	AttachmentRemoved: {SubjectAttachment, PayloadRefOnly},
-	MemberJoined:      {SubjectMember, PayloadMember},
-	PackInstalled:     {SubjectPack, PayloadPack},
-	PackUpgraded:      {SubjectPack, PayloadPack},
-	PackDisabled:      {SubjectPack, PayloadPack},
+	ItemCreated:       {SubjectItem, PayloadItemSnapshot, "item_created"},
+	ItemUpdated:       {SubjectItem, PayloadItemSnapshot, "item_updated"},
+	ItemStatusChanged: {SubjectItem, PayloadItemSnapshot, "item_updated"},
+	ItemMoved:         {SubjectItem, PayloadItemSnapshot, "item_updated"},
+	ItemDeleted:       {SubjectItem, PayloadItemSnapshot, "item_archived"},
+	ItemRestored:      {SubjectItem, PayloadItemSnapshot, "item_restored"},
+	ItemBulkUpdated:   {SubjectItemBatch, PayloadItemBatch, "items_bulk_updated"},
+	CommentCreated:    {SubjectComment, PayloadCommentSnapshot, "comment_created"},
+	CommentUpdated:    {SubjectComment, PayloadCommentSnapshot, "comment_updated"},
+	CommentDeleted:    {SubjectComment, PayloadRefOnly, "comment_deleted"},
+	AttachmentAdded:   {SubjectAttachment, PayloadAttachmentSnapshot, ""},
+	AttachmentRemoved: {SubjectAttachment, PayloadRefOnly, ""},
+	MemberJoined:      {SubjectMember, PayloadMember, ""},
+	PackInstalled:     {SubjectPack, PayloadPack, ""},
+	PackUpgraded:      {SubjectPack, PayloadPack, ""},
+	PackDisabled:      {SubjectPack, PayloadPack, ""},
 }
 
 // PayloadFamily returns the payload shape a canonical event carries, and false
@@ -246,4 +266,24 @@ func Canonical() []string {
 		names = append(names, name)
 	}
 	return names
+}
+
+// SurfaceSSE returns the SSE wire name a canonical event publishes under, and
+// false when it has none — either because the name is not canonical, or
+// because the event is deliberately absent from the SSE surface.
+//
+// ONE BOOL FOR BOTH CASES, deliberately. A caller has the same job either way:
+// do not publish. Splitting them would invite a caller to branch on
+// "canonical but unmapped" and invent a name, which is the drift this table
+// exists to end.
+//
+// The webhook wire name needs no accessor: it IS the canonical name. That
+// asymmetry is the point of SPEC-3's mapping sentence — the dot-form vocabulary
+// is the contract, and SSE's snake_case is a surface rendering of it.
+func SurfaceSSE(name string) (string, bool) {
+	spec, ok := canonical[name]
+	if !ok || spec.sse == "" {
+		return "", false
+	}
+	return spec.sse, true
 }

--- a/internal/kernelevents/taxonomy.go
+++ b/internal/kernelevents/taxonomy.go
@@ -72,10 +72,15 @@ const (
 	// concurrent claim can split one operation across two events, which the
 	// payload's batch_id lets a consumer correlate).
 	//
-	// Per-member binding evaluation comes for free rather than from special
-	// handling: every member of a bulk mutation writes its OWN canonical
-	// event, so whatever binding engine arrives (phase 2+; none exists today)
-	// sees each member individually. Only wire delivery is batched.
+	// Per-member binding evaluation is satisfied two different ways, and the
+	// distinction matters to anyone reading the payloads. The HANDLER path
+	// (bulk endpoint) loops over per-item store mutations, so every member
+	// writes its OWN canonical event and a future binding engine sees them
+	// individually; the header exists only to batch the WIRE delivery. The
+	// STORE-side single-transaction producers (a collection option rename, a
+	// wiki-title cascade) have no such loop — for those, the member snapshots
+	// carried INSIDE this event's payload are the only per-member view there
+	// is. Nothing evaluates selectors today; the binding engine is phase 2+.
 	ItemBulkUpdated = "item.bulk_updated"
 
 	// CommentCreated fires on comment creation. Payload: the stored comment

--- a/internal/kernelevents/taxonomy.go
+++ b/internal/kernelevents/taxonomy.go
@@ -146,7 +146,25 @@ const (
 // unrepresentable rather than tested-for.
 type eventSpec struct {
 	subject string
-	payload string
+
+	// payloads is every payload shape this event may legitimately carry —
+	// almost always exactly one.
+	//
+	// item.bulk_updated carries TWO, and they are genuinely different writes
+	// rather than one shape with optional fields. The store-side
+	// single-transaction producers (a collection option rename, a wiki-title
+	// cascade) know every member at write time and embed the snapshots. The
+	// handler-path producer is a batch HEADER written after a loop: it knows
+	// the operation, the shared delta and the member refs, and the snapshots
+	// live on the members'"'"' own rows until the drain folds them in.
+	//
+	// DECLARED RATHER THAN LOOSENED (SPEC-3 v1.6). The alternatives were
+	// stuffing placeholder snapshots into the header to satisfy a
+	// single-shape check — a lie in the durable record — or dropping the
+	// family gate for this event, which is the one event where two producers
+	// make the gate most useful. Two declared shapes is the honest reading:
+	// the contract says this name admits both.
+	payloads []string
 
 	// sse is the snake_case name this event publishes under on the SSE
 	// surface, or "" when the event has no SSE surface at all.
@@ -187,8 +205,15 @@ const (
 	PayloadItemSnapshot = "item_snapshot"
 
 	// PayloadItemBatch: member refs, the shared delta, and per-member
-	// snapshots.
+	// snapshots — the store-side single-transaction producers, which know
+	// every member at write time.
 	PayloadItemBatch = "item_batch"
+
+	// PayloadItemBatchHeader: the handler-path batch HEADER — operation,
+	// shared delta and member refs, with no snapshots. The members' own rows
+	// carry those until the drain folds them in. See eventSpec.payloads for
+	// why this is a declared second shape rather than a loosened check.
+	PayloadItemBatchHeader = "item_batch_header"
 
 	// PayloadCommentSnapshot / PayloadAttachmentSnapshot: the stored row.
 	PayloadCommentSnapshot    = "comment_snapshot"
@@ -206,33 +231,61 @@ const (
 )
 
 var canonical = map[string]eventSpec{
-	ItemCreated:       {SubjectItem, PayloadItemSnapshot, "item_created"},
-	ItemUpdated:       {SubjectItem, PayloadItemSnapshot, "item_updated"},
-	ItemStatusChanged: {SubjectItem, PayloadItemSnapshot, "item_updated"},
-	ItemMoved:         {SubjectItem, PayloadItemSnapshot, "item_updated"},
-	ItemDeleted:       {SubjectItem, PayloadItemSnapshot, "item_archived"},
-	ItemRestored:      {SubjectItem, PayloadItemSnapshot, "item_restored"},
-	ItemBulkUpdated:   {SubjectItemBatch, PayloadItemBatch, "items_bulk_updated"},
-	CommentCreated:    {SubjectComment, PayloadCommentSnapshot, "comment_created"},
-	CommentUpdated:    {SubjectComment, PayloadCommentSnapshot, "comment_updated"},
-	CommentDeleted:    {SubjectComment, PayloadRefOnly, "comment_deleted"},
-	AttachmentAdded:   {SubjectAttachment, PayloadAttachmentSnapshot, ""},
-	AttachmentRemoved: {SubjectAttachment, PayloadRefOnly, ""},
-	MemberJoined:      {SubjectMember, PayloadMember, ""},
-	PackInstalled:     {SubjectPack, PayloadPack, ""},
-	PackUpgraded:      {SubjectPack, PayloadPack, ""},
-	PackDisabled:      {SubjectPack, PayloadPack, ""},
+	ItemCreated:       {SubjectItem, []string{PayloadItemSnapshot}, "item_created"},
+	ItemUpdated:       {SubjectItem, []string{PayloadItemSnapshot}, "item_updated"},
+	ItemStatusChanged: {SubjectItem, []string{PayloadItemSnapshot}, "item_updated"},
+	ItemMoved:         {SubjectItem, []string{PayloadItemSnapshot}, "item_updated"},
+	ItemDeleted:       {SubjectItem, []string{PayloadItemSnapshot}, "item_archived"},
+	ItemRestored:      {SubjectItem, []string{PayloadItemSnapshot}, "item_restored"},
+	ItemBulkUpdated:   {SubjectItemBatch, []string{PayloadItemBatch, PayloadItemBatchHeader}, "items_bulk_updated"},
+	CommentCreated:    {SubjectComment, []string{PayloadCommentSnapshot}, "comment_created"},
+	CommentUpdated:    {SubjectComment, []string{PayloadCommentSnapshot}, "comment_updated"},
+	CommentDeleted:    {SubjectComment, []string{PayloadRefOnly}, "comment_deleted"},
+	AttachmentAdded:   {SubjectAttachment, []string{PayloadAttachmentSnapshot}, ""},
+	AttachmentRemoved: {SubjectAttachment, []string{PayloadRefOnly}, ""},
+	MemberJoined:      {SubjectMember, []string{PayloadMember}, ""},
+	PackInstalled:     {SubjectPack, []string{PayloadPack}, ""},
+	PackUpgraded:      {SubjectPack, []string{PayloadPack}, ""},
+	PackDisabled:      {SubjectPack, []string{PayloadPack}, ""},
 }
 
-// PayloadFamily returns the payload shape a canonical event carries, and false
-// if the name is not canonical.
+// PayloadFamilies returns every payload shape a canonical event may carry, and
+// false if the name is not canonical.
 //
-// A writer that knows which shape it is about to marshal calls this to confirm
-// the event name agrees, so an event and a payload that were not meant for each
-// other cannot be stored together.
-func PayloadFamily(name string) (string, bool) {
+// The returned slice is freshly built, so a caller cannot edit the contract in
+// place — same reason as Canonical().
+func PayloadFamilies(name string) ([]string, bool) {
 	spec, ok := canonical[name]
-	return spec.payload, ok
+	if !ok {
+		return nil, false
+	}
+	out := make([]string, len(spec.payloads))
+	copy(out, spec.payloads)
+	return out, true
+}
+
+// AllowsPayload reports whether a canonical event admits the given payload
+// shape.
+//
+// A writer that knows which shape it just marshalled calls this to confirm the
+// event name agrees, so an event and a payload that were not meant for each
+// other cannot be stored together. An empty family is never allowed: a caller
+// declaring nothing must not match, which was the fail-open shape Codex round
+// 10 found.
+func AllowsPayload(name, family string) bool {
+	if family == "" {
+		return false
+	}
+	spec, ok := canonical[name]
+	if !ok {
+		return false
+	}
+	for _, p := range spec.payloads {
+		if p == family {
+			return true
+		}
+	}
+	return false
 }
 
 // IsCanonical reports whether name is in the events/1 set.

--- a/internal/server/events_surface.go
+++ b/internal/server/events_surface.go
@@ -1,0 +1,58 @@
+package server
+
+import (
+	"fmt"
+
+	"github.com/PerpetualSoftware/pad/internal/kernelevents"
+)
+
+// The SSE wire names, DERIVED from the events/1 taxonomy rather than written
+// out again here.
+//
+// SPEC-3 §"The choke point owns the canonical→surface name mapping" is the
+// reason this file exists: SSE's snake_case vocabulary and the webhook
+// dot-form vocabulary drifted because nothing tied them together, each being
+// hand-passed at its own call sites. v1.5 pins what "derive" means — NAME
+// derivation, not delivery path. Webhooks deliver through the outbox drain;
+// SSE stays direct-published at the mutation site, because it carries
+// request-scoped attribution (Actor / ActorName / Source) that a frozen outbox
+// payload deliberately does not hold. What changes is only where the NAME
+// comes from.
+//
+// DERIVED AT INIT, not per publish, and that is the whole safety argument. A
+// canonical event with no SSE surface is a programming error at these call
+// sites — every one of them is a compile-time constant — so the check belongs
+// where a failure is impossible to miss and impossible to reach a user:
+// process start. A per-request lookup would have to decide what to do with the
+// "no surface" answer in a void helper, and every available answer (log and
+// drop, publish under an empty name) is worse than not starting.
+//
+// Several canonical events derive the SAME name: status_changed and moved both
+// surface as item_updated, because the SSE vocabulary is coarser than events/1
+// and the UI has never distinguished them. The finer name is what the webhook
+// wire and bindings receive.
+var (
+	sseItemCreated    = mustSurfaceSSE(kernelevents.ItemCreated)
+	sseItemUpdated    = mustSurfaceSSE(kernelevents.ItemUpdated)
+	sseItemMoved      = mustSurfaceSSE(kernelevents.ItemMoved)
+	sseItemArchived   = mustSurfaceSSE(kernelevents.ItemDeleted)
+	sseItemRestored   = mustSurfaceSSE(kernelevents.ItemRestored)
+	sseItemsBulk      = mustSurfaceSSE(kernelevents.ItemBulkUpdated)
+	sseCommentCreated = mustSurfaceSSE(kernelevents.CommentCreated)
+	sseCommentUpdated = mustSurfaceSSE(kernelevents.CommentUpdated)
+)
+
+// mustSurfaceSSE resolves a canonical event's SSE wire name or panics.
+//
+// The panic is deliberate and it fires at package init, before the server
+// listens: a canonical event that reaches here without an SSE surface means
+// the taxonomy and this file disagree, and the only honest outcomes are
+// "publish nothing" (silently breaking the live UI) or "refuse to start".
+// Refusing to start is the one a person notices.
+func mustSurfaceSSE(canonical string) string {
+	name, ok := kernelevents.SurfaceSSE(canonical)
+	if !ok {
+		panic(fmt.Sprintf("kernelevents: %q has no SSE surface name", canonical))
+	}
+	return name
+}

--- a/internal/server/events_surface_test.go
+++ b/internal/server/events_surface_test.go
@@ -15,30 +15,44 @@ import (
 // on these literals, so a derivation that quietly produced "item.created" or
 // "item_deleted" would break the UI while every Go test still passed.
 //
-// The assertion runs against events.* rather than against fresh literals on
-// purpose: those constants are what the CLIENTS are pinned to, so comparing
-// against them is comparing against the thing that actually has to hold.
+// THE EXPECTED SIDE IS A LITERAL COPY OF THE CLIENT'S STRINGS, not anything
+// the Go side derives, and that is the whole design of this test. Comparing
+// the derivation against events.* would pass for a coordinated rename of the
+// taxonomy AND the constants — which is exactly the change that breaks the
+// browser, because the client is pinned to the STRINGS.
+//
+// Source of truth for the wanted column: ITEM_EVENTS and the bulk listener in
+// web/src/lib/services/sse.svelte.ts (see also the `items_bulk_updated`
+// listener registered separately around line 270). Same disagree-with-the-
+// table principle as TestCanonicalEventsAreFullyDeclared, one layer out: this
+// file must be edited by hand when the wire vocabulary intentionally changes,
+// and that edit is the moment someone has to go change the client too.
+//
+// events.* is asserted alongside as a second leg, so a drift between the Go
+// constants and the client's strings is attributed rather than just reported.
 func TestDerivedSSENamesMatchTheLegacyWireVocabulary(t *testing.T) {
 	for _, tc := range []struct {
-		name    string
-		derived string
-		legacy  string
+		name       string
+		derived    string
+		clientWire string
+		legacy     string
 	}{
-		{"item created", sseItemCreated, events.ItemCreated},
-		{"item updated", sseItemUpdated, events.ItemUpdated},
-		{"item moved surfaces as updated", sseItemMoved, events.ItemUpdated},
-		{"item deleted surfaces as archived", sseItemArchived, events.ItemArchived},
-		{"item restored", sseItemRestored, events.ItemRestored},
-		{"bulk", sseItemsBulk, events.ItemsBulkUpdated},
-		{"comment created", sseCommentCreated, events.CommentCreated},
-		{"comment updated", sseCommentUpdated, events.CommentUpdated},
+		{"item created", sseItemCreated, "item_created", events.ItemCreated},
+		{"item updated", sseItemUpdated, "item_updated", events.ItemUpdated},
+		{"item moved surfaces as updated", sseItemMoved, "item_updated", events.ItemUpdated},
+		{"item deleted surfaces as archived", sseItemArchived, "item_archived", events.ItemArchived},
+		{"item restored", sseItemRestored, "item_restored", events.ItemRestored},
+		{"bulk", sseItemsBulk, "items_bulk_updated", events.ItemsBulkUpdated},
+		{"comment created", sseCommentCreated, "comment_created", events.CommentCreated},
+		{"comment updated", sseCommentUpdated, "comment_updated", events.CommentUpdated},
 	} {
-		if tc.derived != tc.legacy {
-			t.Errorf("%s: derived SSE name = %q, legacy wire name = %q — clients match the legacy string",
-				tc.name, tc.derived, tc.legacy)
+		if tc.derived != tc.clientWire {
+			t.Errorf("%s: derived SSE name = %q, but web/src/lib/services/sse.svelte.ts listens for %q — the browser would stop receiving this event",
+				tc.name, tc.derived, tc.clientWire)
 		}
-		if tc.derived == "" {
-			t.Errorf("%s: derived SSE name is empty", tc.name)
+		if tc.legacy != tc.clientWire {
+			t.Errorf("%s: events.* constant = %q, but the client listens for %q — the Go constants drifted from the client, independently of the derivation",
+				tc.name, tc.legacy, tc.clientWire)
 		}
 	}
 }

--- a/internal/server/events_surface_test.go
+++ b/internal/server/events_surface_test.go
@@ -1,0 +1,44 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/events"
+)
+
+// TestDerivedSSENamesMatchTheLegacyWireVocabulary is the compat guard for the
+// rewire: deriving the SSE names from the events/1 taxonomy must reproduce the
+// strings the bus already published, byte for byte.
+//
+// This is what makes the rewire a REFACTOR rather than a wire change. Every
+// live client — the web app's SSE handler, delta-sync's cursor logic — matches
+// on these literals, so a derivation that quietly produced "item.created" or
+// "item_deleted" would break the UI while every Go test still passed.
+//
+// The assertion runs against events.* rather than against fresh literals on
+// purpose: those constants are what the CLIENTS are pinned to, so comparing
+// against them is comparing against the thing that actually has to hold.
+func TestDerivedSSENamesMatchTheLegacyWireVocabulary(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		derived string
+		legacy  string
+	}{
+		{"item created", sseItemCreated, events.ItemCreated},
+		{"item updated", sseItemUpdated, events.ItemUpdated},
+		{"item moved surfaces as updated", sseItemMoved, events.ItemUpdated},
+		{"item deleted surfaces as archived", sseItemArchived, events.ItemArchived},
+		{"item restored", sseItemRestored, events.ItemRestored},
+		{"bulk", sseItemsBulk, events.ItemsBulkUpdated},
+		{"comment created", sseCommentCreated, events.CommentCreated},
+		{"comment updated", sseCommentUpdated, events.CommentUpdated},
+	} {
+		if tc.derived != tc.legacy {
+			t.Errorf("%s: derived SSE name = %q, legacy wire name = %q — clients match the legacy string",
+				tc.name, tc.derived, tc.legacy)
+		}
+		if tc.derived == "" {
+			t.Errorf("%s: derived SSE name is empty", tc.name)
+		}
+	}
+}

--- a/internal/server/handlers_comments.go
+++ b/internal/server/handlers_comments.go
@@ -137,7 +137,6 @@ func (s *Server) handleCreateComment(w http.ResponseWriter, r *http.Request) {
 
 	// Publish SSE event
 	s.publishCommentEvent(sseCommentCreated, workspaceID, item.ID, comment.ID, item.Title, item.CollectionSlug, actor, source)
-	s.dispatchWebhook(workspaceID, "comment.created", comment)
 
 	if s.watchEvents != nil {
 		s.watchEvents.Publish(watchevents.Notification{
@@ -264,7 +263,6 @@ func (s *Server) handleUpdateComment(w http.ResponseWriter, r *http.Request) {
 		collSlug = item.CollectionSlug
 	}
 	s.publishCommentEvent(sseCommentUpdated, workspaceID, updated.ItemID, updated.ID, title, collSlug, actor, source)
-	s.dispatchWebhook(workspaceID, "comment.updated", updated)
 
 	writeJSON(w, http.StatusOK, updated)
 }

--- a/internal/server/handlers_comments.go
+++ b/internal/server/handlers_comments.go
@@ -136,7 +136,7 @@ func (s *Server) handleCreateComment(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Publish SSE event
-	s.publishCommentEvent(events.CommentCreated, workspaceID, item.ID, comment.ID, item.Title, item.CollectionSlug, actor, source)
+	s.publishCommentEvent(sseCommentCreated, workspaceID, item.ID, comment.ID, item.Title, item.CollectionSlug, actor, source)
 	s.dispatchWebhook(workspaceID, "comment.created", comment)
 
 	if s.watchEvents != nil {
@@ -263,7 +263,7 @@ func (s *Server) handleUpdateComment(w http.ResponseWriter, r *http.Request) {
 		title = item.Title
 		collSlug = item.CollectionSlug
 	}
-	s.publishCommentEvent(events.CommentUpdated, workspaceID, updated.ItemID, updated.ID, title, collSlug, actor, source)
+	s.publishCommentEvent(sseCommentUpdated, workspaceID, updated.ItemID, updated.ID, title, collSlug, actor, source)
 	s.dispatchWebhook(workspaceID, "comment.updated", updated)
 
 	writeJSON(w, http.StatusOK, updated)
@@ -365,7 +365,7 @@ func (s *Server) handleCreateReply(w http.ResponseWriter, r *http.Request) {
 		replyItemRef = replyItem.Ref
 		replyCollID = replyItem.CollectionID
 	}
-	s.publishCommentEvent(events.CommentCreated, workspaceID, parentComment.ItemID, comment.ID, parentComment.ItemTitle, replyCollSlug, actor, source)
+	s.publishCommentEvent(sseCommentCreated, workspaceID, parentComment.ItemID, comment.ID, parentComment.ItemTitle, replyCollSlug, actor, source)
 
 	// TASK-2533 (codex round 1, finding 2): a reply is a SEPARATE code
 	// path from handleCreateComment — it calls store.CreateComment

--- a/internal/server/handlers_item_links.go
+++ b/internal/server/handlers_item_links.go
@@ -273,11 +273,18 @@ func (s *Server) publishStructuralLinkSourceEvent(r *http.Request, workspaceID, 
 	// that writes the ITEM'S OWN ROW emits item.updated; one that writes only
 	// the links table stays silent. A PARENT link crosses that line — it
 	// advances the child's seq — and emits from the store, inside
-	// setParentLinkOnce or the item-update transaction. Relationship-graph
-	// links (blocks / blocked-by) and `implements` do not, so events/1 says
-	// nothing about them and this publish stays a pure SSE nudge for the live
-	// UI. TASK-2723 carries the link.created / link.removed shape and this
-	// call site with it.
+	// setParentLinkOnce, DeleteItemLink, or the item-update transaction.
+	// blocks / blocked-by / supersedes write only the links table, so events/1
+	// says nothing about them.
+	//
+	// `implements` IS THE UNRESOLVED CASE, and this comment previously got it
+	// wrong by listing it with the silent ones (codex round 7). It DOES bump
+	// the source row — bumpStructuralLinkSourceTx treats it exactly like
+	// parent — so the mechanical criterion would have it emit, while v1.5's
+	// relationship-link silence would not. Deciding it inside a delivery
+	// refactor would put an event nobody ruled on onto a public wire, so it is
+	// raised with the lead and left as it was. TASK-2723 carries the
+	// link.created / link.removed shape and this call site with it.
 	//
 	// Consequence worth naming: this handler publishes SSE for BOTH kinds, so
 	// the SSE and events/1 pictures deliberately differ here. That is the

--- a/internal/server/handlers_item_links.go
+++ b/internal/server/handlers_item_links.go
@@ -267,12 +267,20 @@ func (s *Server) publishStructuralLinkSourceEvent(r *http.Request, workspaceID, 
 	}
 	actor, source := actorFromRequest(r)
 	// events.ItemUpdated LITERAL, not derived from the taxonomy, and that is
-	// the decision rather than an oversight. Item-link mutations are SILENT in
-	// events/1 (SPEC-3 v1.5): a link is plausibly its own subject kind, and
-	// faking item.updated would ship a snapshot in which nothing the consumer
-	// caches has changed. There is no canonical event to derive a name from
-	// here, so this publish stays a pure SSE nudge for the live UI. TASK-2723
-	// carries the link.created / link.removed shape and this call site with
-	// it.
+	// the decision rather than an oversight.
+	//
+	// THE LINE IS PER-LINK-TYPE, not per-handler (SPEC-3 v1.6): a mutation
+	// that writes the ITEM'S OWN ROW emits item.updated; one that writes only
+	// the links table stays silent. A PARENT link crosses that line — it
+	// advances the child's seq — and emits from the store, inside
+	// setParentLinkOnce or the item-update transaction. Relationship-graph
+	// links (blocks / blocked-by) and `implements` do not, so events/1 says
+	// nothing about them and this publish stays a pure SSE nudge for the live
+	// UI. TASK-2723 carries the link.created / link.removed shape and this
+	// call site with it.
+	//
+	// Consequence worth naming: this handler publishes SSE for BOTH kinds, so
+	// the SSE and events/1 pictures deliberately differ here. That is the
+	// v1.5 silence working, not drift.
 	s.publishItemEventWithName(events.ItemUpdated, workspaceID, item.ID, item.Title, item.CollectionSlug, actor, actorNameFromRequest(r), source, item.Seq)
 }

--- a/internal/server/handlers_item_links.go
+++ b/internal/server/handlers_item_links.go
@@ -266,5 +266,13 @@ func (s *Server) publishStructuralLinkSourceEvent(r *http.Request, workspaceID, 
 		return
 	}
 	actor, source := actorFromRequest(r)
+	// events.ItemUpdated LITERAL, not derived from the taxonomy, and that is
+	// the decision rather than an oversight. Item-link mutations are SILENT in
+	// events/1 (SPEC-3 v1.5): a link is plausibly its own subject kind, and
+	// faking item.updated would ship a snapshot in which nothing the consumer
+	// caches has changed. There is no canonical event to derive a name from
+	// here, so this publish stays a pure SSE nudge for the live UI. TASK-2723
+	// carries the link.created / link.removed shape and this call site with
+	// it.
 	s.publishItemEventWithName(events.ItemUpdated, workspaceID, item.ID, item.Title, item.CollectionSlug, actor, actorNameFromRequest(r), source, item.Seq)
 }

--- a/internal/server/handlers_item_links.go
+++ b/internal/server/handlers_item_links.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
-	"github.com/PerpetualSoftware/pad/internal/events"
 	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
@@ -266,8 +265,13 @@ func (s *Server) publishStructuralLinkSourceEvent(r *http.Request, workspaceID, 
 		return
 	}
 	actor, source := actorFromRequest(r)
-	// events.ItemUpdated LITERAL, not derived from the taxonomy, and that is
-	// the decision rather than an oversight.
+	// THE NAME DERIVES, THE EVENT DOES NOT EXIST — two separate facts, and
+	// keeping the first from following the second is the point of the central
+	// table. This publish takes sseItemUpdated like every other SSE site, so a
+	// future rename of the snake_case vocabulary reaches it; what it does NOT
+	// mean is that events/1 emits for this mutation (codex round 8 — the
+	// literal here would have quietly recreated exactly the drift the mapping
+	// exists to prevent).
 	//
 	// THE LINE IS PER-LINK-TYPE, not per-handler (SPEC-3 v1.6): a mutation
 	// that writes the ITEM'S OWN ROW emits item.updated; one that writes only
@@ -289,5 +293,5 @@ func (s *Server) publishStructuralLinkSourceEvent(r *http.Request, workspaceID, 
 	// Consequence worth naming: this handler publishes SSE for BOTH kinds, so
 	// the SSE and events/1 pictures deliberately differ here. That is the
 	// v1.5 silence working, not drift.
-	s.publishItemEventWithName(events.ItemUpdated, workspaceID, item.ID, item.Title, item.CollectionSlug, actor, actorNameFromRequest(r), source, item.Seq)
+	s.publishItemEventWithName(sseItemUpdated, workspaceID, item.ID, item.Title, item.CollectionSlug, actor, actorNameFromRequest(r), source, item.Seq)
 }

--- a/internal/server/handlers_item_versions.go
+++ b/internal/server/handlers_item_versions.go
@@ -382,7 +382,11 @@ func (s *Server) handleRestoreItemVersion(w http.ResponseWriter, r *http.Request
 	// to a generic /items-changes refetch.
 	if s.events != nil {
 		s.events.Publish(events.Event{
-			Type:        "item_updated",
+			// Derived, not a literal (codex round 9). A raw string here is a
+			// second source of SSE vocabulary — the exact drift the taxonomy's
+			// mapping exists to end, and the harder kind to find because it
+			// does not even reference the events package.
+			Type:        sseItemUpdated,
 			WorkspaceID: workspaceID,
 			Collection:  item.CollectionSlug,
 			ItemID:      item.ID,

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -808,7 +808,6 @@ func (s *Server) createItemChecked(r *http.Request, workspaceID string, coll *mo
 	actorNameForCreate := actorNameFromRequest(r)
 	s.logActivity(workspaceID, item.ID, "created", r)
 	s.publishItemEventWithName(sseItemCreated, workspaceID, item.ID, item.Title, coll.Slug, actor, actorNameForCreate, source, item.Seq)
-	s.dispatchWebhook(workspaceID, "item.created", item)
 
 	// Assignment-at-creation (TASK-2533): unlike an update, a freshly
 	// created item has no "before" state to diff — LastMutation doesn't
@@ -1695,7 +1694,6 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 	activityID, _ := s.logActivityWithMetaReturningID(workspaceID, updated.ID, "updated", r, meta)
 	actorNameForUpdate := actorNameFromRequest(r)
 	s.publishItemEventWithName(sseItemUpdated, workspaceID, updated.ID, updated.Title, updated.CollectionSlug, actor, actorNameForUpdate, source, updated.Seq)
-	s.dispatchWebhook(workspaceID, "item.updated", updated)
 	s.publishWatchNotifications(workspaceID, updated, actor, actorNameForUpdate)
 
 	// If a comment was attached to this update (e.g. explaining a status change),
@@ -1795,7 +1793,6 @@ func (s *Server) handleDeleteItem(w http.ResponseWriter, r *http.Request) {
 	actor, source := actorFromRequest(r)
 	s.logActivity(workspaceID, item.ID, "archived", r)
 	s.publishItemEventWithName(sseItemArchived, workspaceID, item.ID, item.Title, item.CollectionSlug, actor, actorNameFromRequest(r), source, deleteSeq)
-	s.dispatchWebhook(workspaceID, "item.deleted", item)
 
 	w.WriteHeader(http.StatusNoContent)
 }
@@ -2132,7 +2129,6 @@ func (s *Server) handleMoveItem(w http.ResponseWriter, r *http.Request) {
 	// Publish events for both old and new collections
 	actorNameForMove := actorNameFromRequest(r)
 	s.publishItemEventWithName(sseItemMoved, workspaceID, moved.ID, moved.Title, targetColl.Slug, actor, actorNameForMove, source, moved.Seq)
-	s.dispatchWebhook(workspaceID, "item.moved", moved)
 	s.publishWatchNotifications(workspaceID, moved, actor, actorNameForMove)
 
 	moveVisIDs, _ := s.visibleCollectionIDs(r, workspaceID)

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -1716,12 +1716,21 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 			s.publishCommentEvent(sseCommentCreated, workspaceID, updated.ID, comment.ID, updated.Title, updated.CollectionSlug, actor, source)
 			// item.updated_with_comment is RETIRED (SPEC-3 v1.2, Dave's
 			// ruling): a hand-rolled composite with no flood argument,
-			// which folds into item.updated + comment.created — both of
-			// which this path already emits, transactionally, from the
-			// store. It is never emitted under events/1, with no
-			// deprecation window, because webhooks are CLI-registered
-			// only today (no UI surface) and there were no known
-			// consumers at ruling time.
+			// which folds into the item event this update emitted plus
+			// comment.created.
+			//
+			// PRECISELY, because "item.updated + comment.created" would
+			// overstate it twice (codex round 1): the item half is whichever
+			// slice actually moved under the disjoint-delta rule — a
+			// status-only update emits item.status_changed, not item.updated
+			// — and the two events come from two SEPARATE transactions, since
+			// CreateComment runs after the update has committed. What holds
+			// is that each is written transactionally with ITS OWN mutation,
+			// which is all the composite was ever standing in for.
+			//
+			// No deprecation window: webhooks are CLI-registered only today
+			// (no UI surface) and there were no known consumers at ruling
+			// time.
 			// TASK-2533: this comment is created via a DIFFERENT code
 			// path than handleCreateComment (store.CreateComment called
 			// directly, not through POST .../comments) — a bypass Rider

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -807,7 +807,7 @@ func (s *Server) createItemChecked(r *http.Request, workspaceID string, coll *mo
 	actor, source := actorFromRequest(r)
 	actorNameForCreate := actorNameFromRequest(r)
 	s.logActivity(workspaceID, item.ID, "created", r)
-	s.publishItemEventWithName(events.ItemCreated, workspaceID, item.ID, item.Title, coll.Slug, actor, actorNameForCreate, source, item.Seq)
+	s.publishItemEventWithName(sseItemCreated, workspaceID, item.ID, item.Title, coll.Slug, actor, actorNameForCreate, source, item.Seq)
 	s.dispatchWebhook(workspaceID, "item.created", item)
 
 	// Assignment-at-creation (TASK-2533): unlike an update, a freshly
@@ -1694,7 +1694,7 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 	actor, source := actorFromRequest(r)
 	activityID, _ := s.logActivityWithMetaReturningID(workspaceID, updated.ID, "updated", r, meta)
 	actorNameForUpdate := actorNameFromRequest(r)
-	s.publishItemEventWithName(events.ItemUpdated, workspaceID, updated.ID, updated.Title, updated.CollectionSlug, actor, actorNameForUpdate, source, updated.Seq)
+	s.publishItemEventWithName(sseItemUpdated, workspaceID, updated.ID, updated.Title, updated.CollectionSlug, actor, actorNameForUpdate, source, updated.Seq)
 	s.dispatchWebhook(workspaceID, "item.updated", updated)
 	s.publishWatchNotifications(workspaceID, updated, actor, actorNameForUpdate)
 
@@ -1715,12 +1715,15 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 			slog.Warn("failed to create comment on item update", "item_id", updated.ID, "error", cerr)
 		}
 		if cerr == nil && comment != nil {
-			s.publishCommentEvent(events.CommentCreated, workspaceID, updated.ID, comment.ID, updated.Title, updated.CollectionSlug, actor, source)
-			s.dispatchWebhook(workspaceID, "item.updated_with_comment", map[string]interface{}{
-				"item":    updated,
-				"comment": comment,
-				"changes": meta,
-			})
+			s.publishCommentEvent(sseCommentCreated, workspaceID, updated.ID, comment.ID, updated.Title, updated.CollectionSlug, actor, source)
+			// item.updated_with_comment is RETIRED (SPEC-3 v1.2, Dave's
+			// ruling): a hand-rolled composite with no flood argument,
+			// which folds into item.updated + comment.created — both of
+			// which this path already emits, transactionally, from the
+			// store. It is never emitted under events/1, with no
+			// deprecation window, because webhooks are CLI-registered
+			// only today (no UI surface) and there were no known
+			// consumers at ruling time.
 			// TASK-2533: this comment is created via a DIFFERENT code
 			// path than handleCreateComment (store.CreateComment called
 			// directly, not through POST .../comments) — a bypass Rider
@@ -1791,7 +1794,7 @@ func (s *Server) handleDeleteItem(w http.ResponseWriter, r *http.Request) {
 
 	actor, source := actorFromRequest(r)
 	s.logActivity(workspaceID, item.ID, "archived", r)
-	s.publishItemEventWithName(events.ItemArchived, workspaceID, item.ID, item.Title, item.CollectionSlug, actor, actorNameFromRequest(r), source, deleteSeq)
+	s.publishItemEventWithName(sseItemArchived, workspaceID, item.ID, item.Title, item.CollectionSlug, actor, actorNameFromRequest(r), source, deleteSeq)
 	s.dispatchWebhook(workspaceID, "item.deleted", item)
 
 	w.WriteHeader(http.StatusNoContent)
@@ -1844,7 +1847,7 @@ func (s *Server) handleRestoreItem(w http.ResponseWriter, r *http.Request) {
 
 	actor, source := actorFromRequest(r)
 	s.logActivity(workspaceID, restored.ID, "restored", r)
-	s.publishItemEventWithName(events.ItemRestored, workspaceID, restored.ID, restored.Title, restored.CollectionSlug, actor, actorNameFromRequest(r), source, restored.Seq)
+	s.publishItemEventWithName(sseItemRestored, workspaceID, restored.ID, restored.Title, restored.CollectionSlug, actor, actorNameFromRequest(r), source, restored.Seq)
 
 	restoreVisIDs, _ := s.visibleCollectionIDs(r, workspaceID)
 	if err := s.enrichItemForResponse(restored, restoreVisIDs); err != nil {
@@ -2128,7 +2131,7 @@ func (s *Server) handleMoveItem(w http.ResponseWriter, r *http.Request) {
 
 	// Publish events for both old and new collections
 	actorNameForMove := actorNameFromRequest(r)
-	s.publishItemEventWithName(events.ItemUpdated, workspaceID, moved.ID, moved.Title, targetColl.Slug, actor, actorNameForMove, source, moved.Seq)
+	s.publishItemEventWithName(sseItemMoved, workspaceID, moved.ID, moved.Title, targetColl.Slug, actor, actorNameForMove, source, moved.Seq)
 	s.dispatchWebhook(workspaceID, "item.moved", moved)
 	s.publishWatchNotifications(workspaceID, moved, actor, actorNameForMove)
 

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -711,7 +711,9 @@ func (e *itemCreateError) Error() string { return e.message }
 
 // createItemChecked is the shared item-create core: schema-field validation →
 // workspace-unique-field precheck → persist → optional parent link → activity
-// log + SSE event + webhook dispatch. Both handleCreateItem and the
+// log + SSE event. (The webhook dispatch that used to close this list is gone
+// — TASK-2714 moved webhook delivery to the outbox drain, fed by the row the
+// persist step's own transaction writes.) Both handleCreateItem and the
 // artifact-import handler call it so neither path can drop straight to
 // store.CreateItem and skip validation, the uniqueness precheck, or the
 // create side effects.

--- a/internal/server/handlers_items_bulk.go
+++ b/internal/server/handlers_items_bulk.go
@@ -772,20 +772,26 @@ func bulkEventDelta(req *bulkItemsRequest) map[string]any {
 		// carrying "  " changed nothing while a raw delta would announce it.
 		// Untag matches on the raw value — it never trims — so only the add
 		// side normalizes here, exactly as in the mutation.
-		tags := req.Tags
-		if req.Op == "tag" {
-			// Trim AND de-duplicate, because bulkTagUpdate does both: it skips
-			// a tag already in `seen`, so ["foo", " foo "] adds one tag while
-			// a delta echoing the request advertised two (codex round 8).
-			tags = make([]string, 0, len(req.Tags))
-			seen := map[string]bool{}
-			for _, t := range req.Tags {
-				if t = strings.TrimSpace(t); t == "" || seen[t] {
+		// De-duplicate for BOTH verbs, and trim only for `tag` — which is
+		// exactly what the mutation does. bulkTagUpdate skips a tag already in
+		// its `seen` set and trims each ADDED tag, while untag builds a removal
+		// SET from the raw values, so duplicates and untrimmed strings behave
+		// differently on the two sides. A delta echoing the request advertised
+		// two changes where one happened (codex rounds 8-9).
+		tags := make([]string, 0, len(req.Tags))
+		seen := map[string]bool{}
+		for _, t := range req.Tags {
+			if req.Op == "tag" {
+				t = strings.TrimSpace(t)
+				if t == "" {
 					continue
 				}
-				seen[t] = true
-				tags = append(tags, t)
 			}
+			if seen[t] {
+				continue
+			}
+			seen[t] = true
+			tags = append(tags, t)
 		}
 		return map[string]any{"tags": tags}
 	case "move":

--- a/internal/server/handlers_items_bulk.go
+++ b/internal/server/handlers_items_bulk.go
@@ -774,11 +774,17 @@ func bulkEventDelta(req *bulkItemsRequest) map[string]any {
 		// side normalizes here, exactly as in the mutation.
 		tags := req.Tags
 		if req.Op == "tag" {
+			// Trim AND de-duplicate, because bulkTagUpdate does both: it skips
+			// a tag already in `seen`, so ["foo", " foo "] adds one tag while
+			// a delta echoing the request advertised two (codex round 8).
 			tags = make([]string, 0, len(req.Tags))
+			seen := map[string]bool{}
 			for _, t := range req.Tags {
-				if t = strings.TrimSpace(t); t != "" {
-					tags = append(tags, t)
+				if t = strings.TrimSpace(t); t == "" || seen[t] {
+					continue
 				}
+				seen[t] = true
+				tags = append(tags, t)
 			}
 		}
 		return map[string]any{"tags": tags}

--- a/internal/server/handlers_items_bulk.go
+++ b/internal/server/handlers_items_bulk.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"strings"
 
@@ -356,6 +357,21 @@ func (s *Server) handleBulkItems(w http.ResponseWriter, r *http.Request) {
 			"count":    len(affectedIDs),
 			"item_ids": affectedIDs,
 		})
+
+		// The batch HEADER for the outbox drain (SPEC-3 v1.6): the operation,
+		// the shared delta and the member refs — the three things the drain
+		// cannot work out from the member rows, which carry post-mutation
+		// snapshots rather than deltas.
+		//
+		// Written AFTER the loop, in its own transaction, because a handler
+		// bulk has no enclosing one. A failure here is logged and swallowed on
+		// purpose: the members' own events are already committed and will
+		// deliver individually, so the operation degrades to a flood rather
+		// than to a loss, and failing the request after every row has
+		// committed would be the worse answer.
+		if err := s.store.EmitBulkHeaderEvent(workspaceID, batchID, req.Op, affectedIDs, bulkEventDelta(&req)); err != nil {
+			slog.Error("failed to emit bulk batch header", "workspace_id", workspaceID, "batch_id", batchID, "error", err)
+		}
 	}
 
 	writeJSON(w, http.StatusOK, resp)
@@ -723,4 +739,43 @@ func (s *Server) publishBulkItemsEvent(workspaceID, op, collection string, count
 		Source:      source,
 		Seq:         maxSeq,
 	})
+}
+
+// bulkEventDelta is the SHARED delta of a bulk operation — the change every
+// member received, as opposed to each member's post-mutation snapshot.
+//
+// Only the handler knows this. By the time the drain sees the member rows they
+// carry full snapshots, and a diff of a snapshot against nothing is not a
+// delta. SPEC-3's item_batch payload names the shared delta as a field, which
+// is why it has to be captured here rather than reconstructed later.
+//
+// archive and restore return nil: the operation IS the delta, it is already on
+// the envelope as `op`, and inventing a {"deleted": true} field would put a
+// key on the public wire that no mutation actually wrote.
+func bulkEventDelta(req *bulkItemsRequest) map[string]any {
+	switch req.Op {
+	case "set-priority":
+		return map[string]any{"priority": req.Priority}
+	case "tag", "untag":
+		return map[string]any{"tags": req.Tags}
+	case "move":
+		if req.Collection != "" {
+			return map[string]any{"collection": req.Collection}
+		}
+		return map[string]any{"status": req.Status}
+	case "assign":
+		delta := map[string]any{}
+		if req.ClearAssignedUser {
+			delta["assigned_user_id"] = nil
+		} else if req.AssignedUserID != nil {
+			delta["assigned_user_id"] = *req.AssignedUserID
+		}
+		if req.ClearAgentRole {
+			delta["agent_role_id"] = nil
+		} else if req.AgentRoleID != nil {
+			delta["agent_role_id"] = *req.AgentRoleID
+		}
+		return delta
+	}
+	return nil
 }

--- a/internal/server/handlers_items_bulk.go
+++ b/internal/server/handlers_items_bulk.go
@@ -767,7 +767,21 @@ func bulkEventDelta(req *bulkItemsRequest) map[string]any {
 	case "set-priority":
 		return map[string]any{"priority": req.Priority}
 	case "tag", "untag":
-		return map[string]any{"tags": req.Tags}
+		// NORMALIZED THE SAME WAY THE MUTATION DOES (codex round 7). bulkTagUpdate
+		// trims each added tag and skips the ones that go empty, so a request
+		// carrying "  " changed nothing while a raw delta would announce it.
+		// Untag matches on the raw value — it never trims — so only the add
+		// side normalizes here, exactly as in the mutation.
+		tags := req.Tags
+		if req.Op == "tag" {
+			tags = make([]string, 0, len(req.Tags))
+			for _, t := range req.Tags {
+				if t = strings.TrimSpace(t); t != "" {
+					tags = append(tags, t)
+				}
+			}
+		}
+		return map[string]any{"tags": tags}
 	case "move":
 		// BOTH, when both were sent. bulkMoveCollection applies req.Status as
 		// a field override on the migrated set, so a move-with-status changes
@@ -782,16 +796,21 @@ func bulkEventDelta(req *bulkItemsRequest) map[string]any {
 		}
 		return delta
 	case "assign":
+		// SAME PRECEDENCE AS THE STORE (codex round 7): a non-empty id WINS
+		// over the clear flag, and an explicit empty string clears exactly as
+		// the flag does (see the assignment SET clauses in items.go — BUG-2566).
+		// The delta had the flag winning, so a request carrying both announced
+		// a clear while the row was assigned.
 		delta := map[string]any{}
-		if req.ClearAssignedUser {
+		if id := req.AssignedUserID; id != nil && *id != "" {
+			delta["assigned_user_id"] = *id
+		} else if req.ClearAssignedUser || (id != nil && *id == "") {
 			delta["assigned_user_id"] = nil
-		} else if req.AssignedUserID != nil {
-			delta["assigned_user_id"] = *req.AssignedUserID
 		}
-		if req.ClearAgentRole {
+		if id := req.AgentRoleID; id != nil && *id != "" {
+			delta["agent_role_id"] = *id
+		} else if req.ClearAgentRole || (id != nil && *id == "") {
 			delta["agent_role_id"] = nil
-		} else if req.AgentRoleID != nil {
-			delta["agent_role_id"] = *req.AgentRoleID
 		}
 		return delta
 	}

--- a/internal/server/handlers_items_bulk.go
+++ b/internal/server/handlers_items_bulk.go
@@ -340,11 +340,19 @@ func (s *Server) handleBulkItems(w http.ResponseWriter, r *http.Request) {
 
 	resp.Total = len(resp.Updated) + len(resp.Failed)
 
-	// One SSE batch event per affected collection + ONE webhook for the
-	// whole batch (only when something actually changed). The core of
-	// the task: a whole-lane bulk action must not emit N per-item events.
-	// Per-collection (not fully per-item) keeps SSE visibility routing
-	// correct while still collapsing a lane action to a single event.
+	// One SSE batch event per affected collection + ONE batch header for the
+	// drain. The core of the original task: a whole-lane bulk action must not
+	// emit N per-item events. Per-collection (not fully per-item) keeps SSE
+	// visibility routing correct while still collapsing a lane action to a
+	// single event.
+	//
+	// "when something actually changed" USED TO SAY MORE THAN IT MEANT, and is
+	// corrected here rather than left to be re-derived (codex rounds 1-2): the
+	// condition is that at least one row was TOUCHED without erroring, which
+	// is not the same as a semantic change. Untagging a tag nobody has
+	// succeeds on every row and changes nothing, so this fires with a count
+	// and the store — which emits only for real changes — writes no member
+	// events at all.
 	if len(affectedIDs) > 0 {
 		for collSlug, b := range batches {
 			s.publishBulkItemsEvent(workspaceID, req.Op, collSlug, b.count, actor, actorName, source, b.maxSeq)

--- a/internal/server/handlers_items_bulk.go
+++ b/internal/server/handlers_items_bulk.go
@@ -697,7 +697,7 @@ func (s *Server) publishBulkItemsEvent(workspaceID, op, collection string, count
 		return
 	}
 	s.events.Publish(events.Event{
-		Type:        events.ItemsBulkUpdated,
+		Type:        sseItemsBulk,
 		WorkspaceID: workspaceID,
 		Collection:  collection,
 		Op:          op,

--- a/internal/server/handlers_items_bulk.go
+++ b/internal/server/handlers_items_bulk.go
@@ -349,15 +349,6 @@ func (s *Server) handleBulkItems(w http.ResponseWriter, r *http.Request) {
 		for collSlug, b := range batches {
 			s.publishBulkItemsEvent(workspaceID, req.Op, collSlug, b.count, actor, actorName, source, b.maxSeq)
 		}
-		// The webhook is a trusted workspace integration (not
-		// visibility-scoped per subscriber), so it keeps the full id
-		// list for the whole batch.
-		s.dispatchWebhook(workspaceID, "item.bulk_updated", map[string]any{
-			"op":       req.Op,
-			"count":    len(affectedIDs),
-			"item_ids": affectedIDs,
-		})
-
 		// The batch HEADER for the outbox drain (SPEC-3 v1.6): the operation,
 		// the shared delta and the member refs — the three things the drain
 		// cannot work out from the member rows, which carry post-mutation

--- a/internal/server/handlers_items_bulk.go
+++ b/internal/server/handlers_items_bulk.go
@@ -354,6 +354,17 @@ func (s *Server) handleBulkItems(w http.ResponseWriter, r *http.Request) {
 		// cannot work out from the member rows, which carry post-mutation
 		// snapshots rather than deltas.
 		//
+		// affectedIDs counts rows the handler TOUCHED, not rows that
+		// semantically changed, so an operation whose members were all no-ops
+		// (untagging a tag nobody had) produces a header with a count and no
+		// members. That asymmetry is inherited, not introduced: the webhook
+		// this replaces fired on exactly the same condition with exactly the
+		// same count, and the store's "a mutation that changed nothing emits
+		// nothing" rule is the other half of it. Recorded rather than fixed
+		// here — narrowing the count to semantically-changed rows is a wire
+		// change to `count`/`item_ids` and belongs with a contract version,
+		// not inside a delivery refactor (codex round 1).
+		//
 		// Written AFTER the loop, in its own transaction, because a handler
 		// bulk has no enclosing one. A failure here is logged and swallowed on
 		// purpose: the members' own events are already committed and will
@@ -516,7 +527,7 @@ func (s *Server) bulkFieldUpdate(r *http.Request, workspaceID string, item *mode
 		Source:         source,
 	}
 
-	updated, err := s.store.UpdateItemWithPreCheck(item.ID, input, precheck)
+	updated, err := s.store.UpdateItemWithPreCheck(item.ID, input, precheck, store.WithEventBatch(batchID))
 	if err != nil {
 		if details, ok := asOpenChildrenGuardError(err); ok {
 			raw, _ := json.Marshal(details)
@@ -577,7 +588,7 @@ func (s *Server) bulkTagUpdate(item *models.Item, tags []string, add bool, actor
 		Tags:           &tagsStr,
 		LastModifiedBy: actor,
 		Source:         source,
-	})
+	}, store.WithEventBatch(batchID))
 	if err != nil {
 		return nil, &bulkOpError{message: err.Error()}
 	}
@@ -694,7 +705,7 @@ func (s *Server) bulkMoveCollection(r *http.Request, workspaceID string, item *m
 		}
 	}
 
-	moved, err := s.store.MoveItemWithPreCheck(item.ID, targetColl.ID, string(fieldsJSON), precheck)
+	moved, err := s.store.MoveItemWithPreCheck(item.ID, targetColl.ID, string(fieldsJSON), precheck, store.WithEventBatch(batchID))
 	if err != nil {
 		if details, ok := asOpenChildrenGuardError(err); ok {
 			raw, _ := json.Marshal(details)
@@ -750,10 +761,18 @@ func bulkEventDelta(req *bulkItemsRequest) map[string]any {
 	case "tag", "untag":
 		return map[string]any{"tags": req.Tags}
 	case "move":
+		// BOTH, when both were sent. bulkMoveCollection applies req.Status as
+		// a field override on the migrated set, so a move-with-status changes
+		// two things and a delta naming only the collection under-reports it
+		// (codex round 1).
+		delta := map[string]any{}
 		if req.Collection != "" {
-			return map[string]any{"collection": req.Collection}
+			delta["collection"] = req.Collection
 		}
-		return map[string]any{"status": req.Status}
+		if req.Status != "" {
+			delta["status"] = req.Status
+		}
+		return delta
 	case "assign":
 		delta := map[string]any{}
 		if req.ClearAssignedUser {

--- a/internal/server/handlers_items_bulk.go
+++ b/internal/server/handlers_items_bulk.go
@@ -7,9 +7,12 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/google/uuid"
+
 	"github.com/PerpetualSoftware/pad/internal/events"
 	"github.com/PerpetualSoftware/pad/internal/items"
 	"github.com/PerpetualSoftware/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/store"
 )
 
 // maxBulkItems caps how many items a single bulk request may touch.
@@ -221,6 +224,19 @@ func (s *Server) handleBulkItems(w http.ResponseWriter, r *http.Request) {
 	}
 	batches := map[string]*collBatch{}
 
+	// One id for the whole bulk OPERATION, stamped onto every canonical event
+	// its members emit (SPEC-3 v1.5, migration 082). Bulk is a handler loop
+	// over per-item store mutations with no enclosing transaction, so each
+	// member writes its own outbox row; without this correlation the drain
+	// would put N single-item events on the webhook wire for one lane action —
+	// the flood TASK-1668's batch event exists to prevent.
+	//
+	// Minted before the loop and unconditionally, including for the runs where
+	// every item fails: an unused batch id costs nothing, while deciding
+	// mid-loop whether this "counts as" a batch would make the correlation
+	// depend on how far the loop got.
+	batchID := uuid.NewString()
+
 	for _, ref := range req.IDs {
 		// `restore` operates on ARCHIVED items, which ResolveItem hides —
 		// resolve include-deleted for that op (used by undo, TASK-1674).
@@ -252,7 +268,7 @@ func (s *Server) handleBulkItems(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 
-		updated, opErr := s.applyBulkOp(r, workspaceID, item, &req, actor, source, visibleIDs, resolvedTarget)
+		updated, opErr := s.applyBulkOp(r, workspaceID, item, &req, actor, source, visibleIDs, resolvedTarget, batchID)
 		if opErr != nil {
 			resp.Failed = append(resp.Failed, bulkItemFailure{
 				Ref:     itemRefOrSlug(*item),
@@ -350,10 +366,10 @@ func (s *Server) handleBulkItems(w http.ResponseWriter, r *http.Request) {
 // item (for seq) on success, or a structured per-row error.
 // resolvedTarget carries the request-level collection resolution for `move`
 // (nil for every other op), so the per-item path never re-resolves.
-func (s *Server) applyBulkOp(r *http.Request, workspaceID string, item *models.Item, req *bulkItemsRequest, actor, source string, visibleIDs []string, resolvedTarget *models.Collection) (*models.Item, *bulkOpError) {
+func (s *Server) applyBulkOp(r *http.Request, workspaceID string, item *models.Item, req *bulkItemsRequest, actor, source string, visibleIDs []string, resolvedTarget *models.Collection, batchID string) (*models.Item, *bulkOpError) {
 	switch req.Op {
 	case "archive":
-		if err := s.store.DeleteItem(item.ID); err != nil {
+		if err := s.store.DeleteItem(item.ID, store.WithEventBatch(batchID)); err != nil {
 			return nil, &bulkOpError{message: err.Error()}
 		}
 		// DeleteItem bumps seq; re-read so the batch event carries the
@@ -367,7 +383,7 @@ func (s *Server) applyBulkOp(r *http.Request, workspaceID string, item *models.I
 	case "restore":
 		// Undo of a bulk archive (TASK-1674). RestoreItem clears
 		// deleted_at and bumps seq; returns the live row.
-		restored, err := s.store.RestoreItem(item.ID)
+		restored, err := s.store.RestoreItem(item.ID, store.WithEventBatch(batchID))
 		if err != nil {
 			if err == sql.ErrNoRows {
 				return nil, &bulkOpError{message: "item not found or not archived"}
@@ -384,19 +400,19 @@ func (s *Server) applyBulkOp(r *http.Request, workspaceID string, item *models.I
 
 	case "move":
 		if req.Collection != "" {
-			return s.bulkMoveCollection(r, workspaceID, item, req, visibleIDs, resolvedTarget)
+			return s.bulkMoveCollection(r, workspaceID, item, req, visibleIDs, resolvedTarget, batchID)
 		}
 		// Status-only move = a field update on the same collection.
-		return s.bulkFieldUpdate(r, workspaceID, item, map[string]any{"status": req.Status}, req.Force, visibleIDs, actor, source)
+		return s.bulkFieldUpdate(r, workspaceID, item, map[string]any{"status": req.Status}, req.Force, visibleIDs, actor, source, batchID)
 
 	case "set-priority":
-		return s.bulkFieldUpdate(r, workspaceID, item, map[string]any{"priority": req.Priority}, req.Force, visibleIDs, actor, source)
+		return s.bulkFieldUpdate(r, workspaceID, item, map[string]any{"priority": req.Priority}, req.Force, visibleIDs, actor, source, batchID)
 
 	case "tag":
-		return s.bulkTagUpdate(item, req.Tags, true, actor, source)
+		return s.bulkTagUpdate(item, req.Tags, true, actor, source, batchID)
 
 	case "untag":
-		return s.bulkTagUpdate(item, req.Tags, false, actor, source)
+		return s.bulkTagUpdate(item, req.Tags, false, actor, source, batchID)
 
 	case "assign":
 		input := models.ItemUpdate{
@@ -407,7 +423,7 @@ func (s *Server) applyBulkOp(r *http.Request, workspaceID string, item *models.I
 			LastModifiedBy:    actor,
 			Source:            source,
 		}
-		updated, err := s.store.UpdateItem(item.ID, input)
+		updated, err := s.store.UpdateItem(item.ID, input, store.WithEventBatch(batchID))
 		if err != nil {
 			return nil, &bulkOpError{message: err.Error()}
 		}
@@ -421,7 +437,7 @@ func (s *Server) applyBulkOp(r *http.Request, workspaceID string, item *models.I
 // validates against the collection schema, runs the open-children guard
 // (unless force), and writes via UpdateItemWithPreCheck — the same path
 // the single PATCH handler uses. Used by status moves and set-priority.
-func (s *Server) bulkFieldUpdate(r *http.Request, workspaceID string, item *models.Item, changes map[string]any, force bool, visibleIDs []string, actor, source string) (*models.Item, *bulkOpError) {
+func (s *Server) bulkFieldUpdate(r *http.Request, workspaceID string, item *models.Item, changes map[string]any, force bool, visibleIDs []string, actor, source, batchID string) (*models.Item, *bulkOpError) {
 	coll, err := s.store.GetCollection(item.CollectionID)
 	if err != nil || coll == nil {
 		return nil, &bulkOpError{message: "failed to load collection"}
@@ -513,7 +529,7 @@ func (s *Server) bulkFieldUpdate(r *http.Request, workspaceID string, item *mode
 
 // bulkTagUpdate adds (add=true) or removes (add=false) the given tags
 // from the item's tag set, preserving existing order and de-duplicating.
-func (s *Server) bulkTagUpdate(item *models.Item, tags []string, add bool, actor, source string) (*models.Item, *bulkOpError) {
+func (s *Server) bulkTagUpdate(item *models.Item, tags []string, add bool, actor, source, batchID string) (*models.Item, *bulkOpError) {
 	existing := []string{}
 	if item.Tags != "" && item.Tags != "[]" {
 		_ = json.Unmarshal([]byte(item.Tags), &existing)
@@ -571,7 +587,7 @@ func (s *Server) bulkTagUpdate(item *models.Item, tags []string, add bool, actor
 // resolves to nothing — deliberately, so that case and an existing-but-hidden
 // target fail identically here rather than at different HTTP statuses (the
 // existence oracle from codex round 4). Hence the nil check below.
-func (s *Server) bulkMoveCollection(r *http.Request, workspaceID string, item *models.Item, req *bulkItemsRequest, visibleIDs []string, targetColl *models.Collection) (*models.Item, *bulkOpError) {
+func (s *Server) bulkMoveCollection(r *http.Request, workspaceID string, item *models.Item, req *bulkItemsRequest, visibleIDs []string, targetColl *models.Collection, batchID string) (*models.Item, *bulkOpError) {
 	if targetColl == nil {
 		return nil, &bulkOpError{message: "target collection not found", code: "invalid_collection"}
 	}

--- a/internal/server/handlers_items_bulk_test.go
+++ b/internal/server/handlers_items_bulk_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/PerpetualSoftware/pad/internal/events"
+	"github.com/PerpetualSoftware/pad/internal/kernelevents"
 	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
@@ -572,4 +573,143 @@ func TestBulkItems_RouteRegistered(t *testing.T) {
 	if rr.Code != http.StatusOK {
 		t.Fatalf("bulk route: expected 200, got %d: %s", rr.Code, rr.Body.String())
 	}
+}
+
+// TestBulkItems_EveryVerbStampsOneBatchID drives ALL SIX bulk verbs through
+// the HTTP handler and asserts every event the operation produced shares one
+// batch id.
+//
+// This exists because the store-level test could not catch the bug codex round
+// 1 found. That test called the five store methods directly with the option,
+// so it proved the option WORKS; it said nothing about whether the handler
+// passes it. Three of the six verbs (set-priority, tag, untag, move) reached
+// their store calls without it, so their member rows stayed unbatched while
+// the header was still written — N individual wire deliveries plus a header
+// claiming they were a batch.
+//
+// The lesson underneath, for the third time in this unit: threading a
+// parameter into helper SIGNATURES is not the same work as passing it at every
+// CALL. Only a test at the layer that owns the call sites can tell them apart.
+func TestBulkItems_EveryVerbStampsOneBatchID(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		body map[string]any
+		// prep runs before the bulk request (e.g. archiving, so restore has
+		// something to restore).
+		prep func(t *testing.T, srv *Server, ws string, refs []string)
+	}{
+		{name: "set-priority", body: map[string]any{"op": "set-priority", "priority": "high"}},
+		{name: "tag", body: map[string]any{"op": "tag", "tags": []string{"batched"}}},
+		{
+			name: "untag",
+			body: map[string]any{"op": "untag", "tags": []string{"seed"}},
+			prep: func(t *testing.T, srv *Server, ws string, refs []string) {
+				// The tag has to EXIST for untag to change anything. Without
+				// this the operation is a no-op, no member events are written,
+				// and the leg asserts nothing about batching — which is how
+				// the first version of this test "passed" for two verbs.
+				rr := doRequest(srv, "POST", "/api/v1/workspaces/"+ws+"/items/bulk", map[string]any{
+					"ids": refs, "op": "tag", "tags": []string{"seed"},
+				})
+				if rr.Code != http.StatusOK {
+					t.Fatalf("prep tag: %d: %s", rr.Code, rr.Body.String())
+				}
+			},
+		},
+		{name: "move-status", body: map[string]any{"op": "move", "status": "done"}},
+		{name: "assign", body: map[string]any{"op": "assign"}},
+		{name: "archive", body: map[string]any{"op": "archive"}},
+		{
+			name: "restore",
+			body: map[string]any{"op": "restore"},
+			prep: func(t *testing.T, srv *Server, ws string, refs []string) {
+				rr := doRequest(srv, "POST", "/api/v1/workspaces/"+ws+"/items/bulk", map[string]any{
+					"ids": refs, "op": "archive",
+				})
+				if rr.Code != http.StatusOK {
+					t.Fatalf("prep archive: %d: %s", rr.Code, rr.Body.String())
+				}
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := testServer(t)
+			ws := createWSWithCollections(t, srv)
+
+			if tc.name == "assign" {
+				role, err := srv.store.CreateAgentRole(wsIDForSlug(t, srv, ws), models.AgentRoleCreate{Name: "Reviewer"})
+				if err != nil {
+					t.Fatalf("create role: %v", err)
+				}
+				tc.body["agent_role_id"] = role.ID
+			}
+
+			a := createBulkTestItem(t, srv, ws, "A", `{"status":"open","priority":"low"}`)
+			b := createBulkTestItem(t, srv, ws, "B", `{"status":"open","priority":"low"}`)
+			refs := []string{a.Ref, b.Ref}
+			if tc.prep != nil {
+				tc.prep(t, srv, ws, refs)
+			}
+
+			// Clear everything the setup emitted so the assertion sees only
+			// this operation's rows.
+			seeded, err := srv.store.ListPendingOutboxEvents(1000)
+			if err != nil {
+				t.Fatalf("list seeded outbox: %v", err)
+			}
+			var seededIDs []string
+			for _, ev := range seeded {
+				seededIDs = append(seededIDs, ev.ID)
+			}
+			if err := srv.store.MarkOutboxDispatched(seededIDs); err != nil {
+				t.Fatalf("clear outbox: %v", err)
+			}
+
+			body := map[string]any{"ids": refs}
+			for k, v := range tc.body {
+				body[k] = v
+			}
+			rr := doRequest(srv, "POST", "/api/v1/workspaces/"+ws+"/items/bulk", body)
+			if rr.Code != http.StatusOK {
+				t.Fatalf("bulk %s: %d: %s", tc.name, rr.Code, rr.Body.String())
+			}
+
+			pending, err := srv.store.ListPendingOutboxEvents(100)
+			if err != nil {
+				t.Fatalf("list pending: %v", err)
+			}
+			if len(pending) < 2 {
+				t.Fatalf("%s produced %d outbox rows; the batch assertion needs the members AND the header to prove anything", tc.name, len(pending))
+			}
+
+			var header int
+			batches := map[string]int{}
+			for _, ev := range pending {
+				batches[ev.BatchID]++
+				if ev.EventType == kernelevents.ItemBulkUpdated {
+					header++
+				}
+			}
+			if n := batches[""]; n != 0 {
+				t.Errorf("%s left %d event(s) unbatched — they would be delivered individually alongside a header claiming they were a batch", tc.name, n)
+			}
+			if len(batches) != 1 {
+				t.Errorf("%s produced %d distinct batch ids, want exactly 1: %v", tc.name, len(batches), batches)
+			}
+			if header != 1 {
+				t.Errorf("%s produced %d batch headers, want exactly 1", tc.name, header)
+			}
+		})
+	}
+}
+
+// wsIDForSlug resolves a workspace slug to its id for the store-level calls a
+// few fixtures need.
+func wsIDForSlug(t *testing.T, srv *Server, slug string) string {
+	t.Helper()
+	ws, err := srv.store.GetWorkspaceBySlug(slug)
+	if err != nil || ws == nil {
+		t.Fatalf("resolve workspace %q: %v", slug, err)
+	}
+	return ws.ID
 }

--- a/internal/server/handlers_items_bulk_test.go
+++ b/internal/server/handlers_items_bulk_test.go
@@ -575,17 +575,20 @@ func TestBulkItems_RouteRegistered(t *testing.T) {
 	}
 }
 
-// TestBulkItems_EveryVerbStampsOneBatchID drives ALL SIX bulk verbs through
-// the HTTP handler and asserts every event the operation produced shares one
-// batch id.
+// TestBulkItems_EveryVerbStampsOneBatchID drives all SEVEN bulk legs through
+// the HTTP handler — set-priority, tag, untag, move-status, assign, archive,
+// restore — and asserts every event the operation produced shares one batch
+// id. (Six OPS; move appears once as a status-only move, which is the field
+// path, and cross-collection move goes through the same helper.)
 //
 // This exists because the store-level test could not catch the bug codex round
 // 1 found. That test called the five store methods directly with the option,
 // so it proved the option WORKS; it said nothing about whether the handler
-// passes it. Three of the six verbs (set-priority, tag, untag, move) reached
-// their store calls without it, so their member rows stayed unbatched while
-// the header was still written — N individual wire deliveries plus a header
-// claiming they were a batch.
+// passes it. THREE CALL SITES were missing it, affecting FOUR verbs —
+// set-priority and move-status (bulkFieldUpdate), tag and untag
+// (bulkTagUpdate), and cross-collection move (bulkMoveCollection) — so those
+// member rows stayed unbatched while the header was still written: N
+// individual wire deliveries plus a header claiming they were a batch.
 //
 // The lesson underneath, for the third time in this unit: threading a
 // parameter into helper SIGNATURES is not the same work as passing it at every

--- a/internal/server/handlers_items_bulk_test.go
+++ b/internal/server/handlers_items_bulk_test.go
@@ -656,17 +656,7 @@ func TestBulkItems_EveryVerbStampsOneBatchID(t *testing.T) {
 
 			// Clear everything the setup emitted so the assertion sees only
 			// this operation's rows.
-			seeded, err := srv.store.ListPendingOutboxEvents(1000)
-			if err != nil {
-				t.Fatalf("list seeded outbox: %v", err)
-			}
-			var seededIDs []string
-			for _, ev := range seeded {
-				seededIDs = append(seededIDs, ev.ID)
-			}
-			if err := srv.store.MarkOutboxDispatched(seededIDs); err != nil {
-				t.Fatalf("clear outbox: %v", err)
-			}
+			clearSeededOutbox(t, srv)
 
 			body := map[string]any{"ids": refs}
 			for k, v := range tc.body {
@@ -715,4 +705,29 @@ func wsIDForSlug(t *testing.T, srv *Server, slug string) string {
 		t.Fatalf("resolve workspace %q: %v", slug, err)
 	}
 	return ws.ID
+}
+
+// clearSeededOutbox marks everything currently pending as dispatched, so a
+// test can assert on the rows one later operation produced.
+//
+// It claims first, because acking is conditioned on holding the claim (a stale
+// pass must not be able to stamp rows someone else owns). Claim-then-ack is
+// what the drain itself does.
+func clearSeededOutbox(t *testing.T, srv *Server) {
+	t.Helper()
+	future := time.Now().UTC().Add(time.Hour).Format(time.RFC3339)
+	claimed, err := srv.store.ClaimPendingOutboxEvents("test-clear", 1000, future)
+	if err != nil {
+		t.Fatalf("claim seeded outbox: %v", err)
+	}
+	if len(claimed) == 0 {
+		return
+	}
+	ids := make([]string, 0, len(claimed))
+	for _, ev := range claimed {
+		ids = append(ids, ev.ID)
+	}
+	if err := srv.store.MarkOutboxDispatched(claimed[0].ClaimToken, ids); err != nil {
+		t.Fatalf("clear seeded outbox: %v", err)
+	}
 }

--- a/internal/server/handlers_items_bulk_test.go
+++ b/internal/server/handlers_items_bulk_test.go
@@ -800,3 +800,15 @@ func TestBulkEventDelta_TagsAreDeduped(t *testing.T) {
 		t.Errorf("tags = %v, want [foo bar] — trimmed and de-duplicated, as the mutation applies them", tags)
 	}
 }
+
+// TestBulkEventDelta_UntagDedupsWithoutTrimming: untag builds a removal SET
+// from the RAW values, so duplicates collapse but whitespace is significant —
+// the mirror image of tag, and the delta has to match each side's own rule
+// (codex round 9).
+func TestBulkEventDelta_UntagDedupsWithoutTrimming(t *testing.T) {
+	got := bulkEventDelta(&bulkItemsRequest{Op: "untag", Tags: []string{"foo", "foo", " foo "}})
+	tags, _ := got["tags"].([]string)
+	if len(tags) != 2 || tags[0] != "foo" || tags[1] != " foo " {
+		t.Errorf("tags = %q, want [\"foo\" \" foo \"] — deduped, untrimmed", tags)
+	}
+}

--- a/internal/server/handlers_items_bulk_test.go
+++ b/internal/server/handlers_items_bulk_test.go
@@ -731,3 +731,61 @@ func clearSeededOutbox(t *testing.T, srv *Server) {
 		t.Fatalf("clear seeded outbox: %v", err)
 	}
 }
+
+// TestBulkEventDelta_MatchesTheMutation pins the batch header's delta to what
+// the mutation actually committed (codex round 7).
+//
+// The delta is the one field of the batch payload the drain cannot derive, so
+// nothing downstream can correct it: whatever this function says is what a
+// webhook consumer believes happened.
+func TestBulkEventDelta_MatchesTheMutation(t *testing.T) {
+	strptr := func(s string) *string { return &s }
+
+	t.Run("tag trims the way bulkTagUpdate does", func(t *testing.T) {
+		got := bulkEventDelta(&bulkItemsRequest{Op: "tag", Tags: []string{" spaced ", "   ", "plain"}})
+		tags, _ := got["tags"].([]string)
+		if len(tags) != 2 || tags[0] != "spaced" || tags[1] != "plain" {
+			t.Errorf("tags = %v, want the trimmed, non-empty set the mutation applies", tags)
+		}
+	})
+
+	t.Run("untag matches raw, because the mutation does", func(t *testing.T) {
+		got := bulkEventDelta(&bulkItemsRequest{Op: "untag", Tags: []string{" spaced "}})
+		tags, _ := got["tags"].([]string)
+		if len(tags) != 1 || tags[0] != " spaced " {
+			t.Errorf("tags = %v, want the raw value — untag removes by exact match", tags)
+		}
+	})
+
+	t.Run("a non-empty id beats the clear flag", func(t *testing.T) {
+		got := bulkEventDelta(&bulkItemsRequest{
+			Op:                "assign",
+			AssignedUserID:    strptr("user-1"),
+			ClearAssignedUser: true,
+		})
+		if got["assigned_user_id"] != "user-1" {
+			t.Errorf("assigned_user_id = %v, want user-1 — the store's SET clause gives the id precedence, so announcing a clear would describe the opposite of the committed row", got["assigned_user_id"])
+		}
+	})
+
+	t.Run("an explicit empty id clears, like the flag", func(t *testing.T) {
+		got := bulkEventDelta(&bulkItemsRequest{Op: "assign", AgentRoleID: strptr("")})
+		v, present := got["agent_role_id"]
+		if !present || v != nil {
+			t.Errorf("agent_role_id = %v (present %v), want an explicit null", v, present)
+		}
+	})
+
+	t.Run("move carries both when both were sent", func(t *testing.T) {
+		got := bulkEventDelta(&bulkItemsRequest{Op: "move", Collection: "done", Status: "closed"})
+		if got["collection"] != "done" || got["status"] != "closed" {
+			t.Errorf("delta = %v, want both halves of a move-with-status", got)
+		}
+	})
+
+	t.Run("archive has no delta", func(t *testing.T) {
+		if got := bulkEventDelta(&bulkItemsRequest{Op: "archive"}); got != nil {
+			t.Errorf("delta = %v, want nil — the operation IS the delta and it is on the envelope as op", got)
+		}
+	})
+}

--- a/internal/server/handlers_items_bulk_test.go
+++ b/internal/server/handlers_items_bulk_test.go
@@ -789,3 +789,14 @@ func TestBulkEventDelta_MatchesTheMutation(t *testing.T) {
 		}
 	})
 }
+
+// TestBulkEventDelta_TagsAreDeduped: bulkTagUpdate skips a tag already in its
+// `seen` set, so ["foo", " foo "] adds ONE tag. A delta echoing both would
+// advertise a change the mutation did not make (codex round 8).
+func TestBulkEventDelta_TagsAreDeduped(t *testing.T) {
+	got := bulkEventDelta(&bulkItemsRequest{Op: "tag", Tags: []string{"foo", " foo ", "bar"}})
+	tags, _ := got["tags"].([]string)
+	if len(tags) != 2 || tags[0] != "foo" || tags[1] != "bar" {
+		t.Errorf("tags = %v, want [foo bar] — trimmed and de-duplicated, as the mutation applies them", tags)
+	}
+}

--- a/internal/server/handlers_items_copy.go
+++ b/internal/server/handlers_items_copy.go
@@ -637,11 +637,14 @@ func (s *Server) afterCopyCommit(r *http.Request, res *store.CrossWorkspaceCopyR
 // the destination's next /items-changes poll surfaces the item regardless,
 // and the endpoint's 500 tells the user to go and look.
 //
-// SYNCHRONOUS, deliberately. logActivity writes a row, the SSE publish can
-// reach Redis, and dispatchWebhook lists and marshals before it spawns its
-// delivery goroutines — so this runs before the 201 and can add latency to
-// it. That is exactly what handleCreateItem, handleDeleteItem and
-// handleMoveItem already do (Codex round 3), and diverging would buy nothing:
+// SYNCHRONOUS, deliberately. logActivity writes a row and the SSE publish can
+// reach Redis — so this runs before the 201 and can add latency to it. That is
+// exactly what handleCreateItem, handleDeleteItem and handleMoveItem already
+// do (Codex round 3), and diverging would buy nothing:
+//
+// The webhook dispatch that used to be part of this list is gone (TASK-2714):
+// webhooks are delivered by the outbox drain now, from the row the copy's own
+// transaction wrote, so nothing webhook-shaped happens on this path at all.
 // moving it to a goroutine would make the emission ordering — which DR-14
 // specifies and these tests assert — unobservable, and would decouple the
 // "copy succeeded" response from the events that describe it for no
@@ -663,7 +666,6 @@ func (s *Server) emitCopyFanout(r *http.Request, res *store.CrossWorkspaceCopyRe
 	s.logActivity(targetWorkspaceID, res.Item.ID, "created", r)
 	s.publishItemEventWithName(sseItemCreated, targetWorkspaceID, res.Item.ID, res.Item.Title,
 		res.TargetCollection.Slug, actor, actorName, actorSource, res.Item.Seq)
-	s.dispatchWebhook(targetWorkspaceID, "item.created", res.Item)
 
 	// --- Source: only on a move, and SourceSeq is the discriminator. It is
 	// non-nil if and only if the archive ran, so this cannot emit an archive
@@ -675,7 +677,6 @@ func (s *Server) emitCopyFanout(r *http.Request, res *store.CrossWorkspaceCopyRe
 	s.logActivity(res.SourceWorkspaceID, res.Source.ID, "archived", r)
 	s.publishItemEventWithName(sseItemArchived, res.SourceWorkspaceID, res.Source.ID, res.Source.Title,
 		res.SourceCollection.Slug, actor, actorName, actorSource, *res.SourceSeq)
-	s.dispatchWebhook(res.SourceWorkspaceID, "item.deleted", res.Source)
 }
 
 // writeCopyError maps the store's typed errors onto the statuses the

--- a/internal/server/handlers_items_copy.go
+++ b/internal/server/handlers_items_copy.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"runtime/debug"
 
-	"github.com/PerpetualSoftware/pad/internal/events"
 	"github.com/PerpetualSoftware/pad/internal/models"
 	"github.com/PerpetualSoftware/pad/internal/store"
 )
@@ -662,7 +661,7 @@ func (s *Server) emitCopyFanout(r *http.Request, res *store.CrossWorkspaceCopyRe
 	// --- Destination: always all three. ---
 	targetWorkspaceID := res.Item.WorkspaceID
 	s.logActivity(targetWorkspaceID, res.Item.ID, "created", r)
-	s.publishItemEventWithName(events.ItemCreated, targetWorkspaceID, res.Item.ID, res.Item.Title,
+	s.publishItemEventWithName(sseItemCreated, targetWorkspaceID, res.Item.ID, res.Item.Title,
 		res.TargetCollection.Slug, actor, actorName, actorSource, res.Item.Seq)
 	s.dispatchWebhook(targetWorkspaceID, "item.created", res.Item)
 
@@ -674,7 +673,7 @@ func (s *Server) emitCopyFanout(r *http.Request, res *store.CrossWorkspaceCopyRe
 		return
 	}
 	s.logActivity(res.SourceWorkspaceID, res.Source.ID, "archived", r)
-	s.publishItemEventWithName(events.ItemArchived, res.SourceWorkspaceID, res.Source.ID, res.Source.Title,
+	s.publishItemEventWithName(sseItemArchived, res.SourceWorkspaceID, res.Source.ID, res.Source.Title,
 		res.SourceCollection.Slug, actor, actorName, actorSource, *res.SourceSeq)
 	s.dispatchWebhook(res.SourceWorkspaceID, "item.deleted", res.Source)
 }

--- a/internal/server/handlers_items_copy_preflight_test.go
+++ b/internal/server/handlers_items_copy_preflight_test.go
@@ -1003,7 +1003,7 @@ func TestCopyPreflight_NoWebhookDispatch(t *testing.T) {
 
 	// Positive control. Without it the silence above would also be
 	// consistent with a receiver that never works.
-	f.srv.dispatchWebhook(f.wsB.ID, "item.created", map[string]string{"probe": "1"})
+	f.srv.webhooks.Dispatch(f.wsB.ID, "item.created", map[string]string{"probe": "1"})
 	select {
 	case ev := <-received:
 		if ev != "item.created" {

--- a/internal/server/handlers_items_copy_test.go
+++ b/internal/server/handlers_items_copy_test.go
@@ -571,6 +571,15 @@ func newCopyFanoutObserver(t *testing.T, f *copyPreflightFixture) *copyFanoutObs
 	d.SkipSSRF = true // loopback httptest receivers
 	f.srv.SetWebhookDispatcher(d)
 
+	// Clear the outbox backlog the FIXTURE built — member joins, filler items,
+	// the source item itself — before the receivers are registered as
+	// webhooks. Since TASK-2714 webhooks are drained rather than hand-called,
+	// so without this the observer's first pass reports the whole setup as if
+	// the copy had produced it. Drained with no webhook rows yet, the backlog
+	// is acked and delivered nowhere, which is what "baseline" has always
+	// meant here.
+	f.srv.runOutboxDrainTick()
+
 	for _, side := range []struct {
 		label string
 		ws    *models.Workspace
@@ -646,7 +655,16 @@ func drainSSE(ch chan events.Event) []events.Event {
 // drainWebhooks collects deliveries over one quiet window. The window is a
 // wait for something that must NOT arrive in half these assertions, so it is
 // generous rather than tight; it only costs wall-clock time when passing.
+// drainWebhooks runs an outbox drain pass first, then collects what landed.
+//
+// Webhooks stopped being a post-commit hand-call in TASK-2714: the copy's own
+// transaction writes the outbox row and the drain delivers it. The assertions
+// these tests make about the DR-14 emission MATRIX — which workspace hears
+// what — are unchanged by that, but nothing arrives until a pass runs, and in
+// production that pass is the ticker rather than this call.
 func (o *copyFanoutObserver) drainWebhooks() []webhookDelivery {
+	o.f.srv.runOutboxDrainTick()
+
 	var out []webhookDelivery
 	deadline := time.After(fanoutQuietWindow)
 	for {
@@ -919,8 +937,8 @@ func TestCopyEndpoint_FanoutHarnessIsRealPositiveControl(t *testing.T) {
 	f := newCopyPreflightFixture(t)
 	o := newCopyFanoutObserver(t, f)
 
-	f.srv.dispatchWebhook(f.wsA.ID, "item.created", map[string]string{"probe": "A"})
-	f.srv.dispatchWebhook(f.wsB.ID, "item.created", map[string]string{"probe": "B"})
+	f.srv.webhooks.Dispatch(f.wsA.ID, "item.created", map[string]string{"probe": "A"})
+	f.srv.webhooks.Dispatch(f.wsB.ID, "item.created", map[string]string{"probe": "B"})
 
 	got := o.drainWebhooks()
 	if len(webhookEventsFor(got, "A")) == 0 || len(webhookEventsFor(got, "B")) == 0 {

--- a/internal/server/handlers_watch_notify.go
+++ b/internal/server/handlers_watch_notify.go
@@ -41,8 +41,9 @@ import (
 //     historical reconciliation, not a live mutation
 //   - workspace restore / purge — administrative, not a live human action
 //
-// Known limitation (flagged, not fixed, in Phase 1): unlike the existing
-// SSE/webhook bulk path (publishBulkItemsEvent), this does NOT collapse
+// Known limitation (flagged, not fixed, in Phase 1): unlike the SSE bulk path
+// (publishBulkItemsEvent) and the outbox drain's batch fold, this does NOT
+// collapse
 // N per-item bulk mutations into one batch notification. A bulk mutation
 // touching 50 watched items still surfaces 50 individual notifications
 // to the plugin monitor in a burst — in tension with PLAN-2469's noise-

--- a/internal/server/handlers_webhooks.go
+++ b/internal/server/handlers_webhooks.go
@@ -21,14 +21,6 @@ func maskWebhookSecret(hook models.Webhook) models.Webhook {
 	return hook
 }
 
-// dispatchWebhook fires a webhook event if a dispatcher is configured.
-func (s *Server) dispatchWebhook(workspaceID, event string, data interface{}) {
-	if s.webhooks == nil {
-		return
-	}
-	s.webhooks.Dispatch(workspaceID, event, data)
-}
-
 // handleCreateWebhook registers a new webhook for a workspace.
 func (s *Server) handleCreateWebhook(w http.ResponseWriter, r *http.Request) {
 	if !requireMinRole(w, r, "owner") {

--- a/internal/server/outbox_drain.go
+++ b/internal/server/outbox_drain.go
@@ -226,6 +226,7 @@ type outboxDelivery struct {
 	workspaceID string
 	eventType   string
 	eventID     string
+	batchID     string
 	occurredAt  string
 	payload     []byte
 	rowIDs      []string
@@ -289,6 +290,7 @@ func groupOutboxDeliveries(events []store.OutboxEvent) []outboxDelivery {
 			workspaceID: header.WorkspaceID,
 			eventType:   header.EventType,
 			eventID:     header.ID,
+			batchID:     header.BatchID,
 			occurredAt:  header.OccurredAt,
 			payload:     folded,
 			rowIDs:      rowIDs,
@@ -302,9 +304,13 @@ func singleOutboxDelivery(ev store.OutboxEvent) outboxDelivery {
 		workspaceID: ev.WorkspaceID,
 		eventType:   ev.EventType,
 		eventID:     ev.ID,
-		occurredAt:  ev.OccurredAt,
-		payload:     ev.Payload,
-		rowIDs:      []string{ev.ID},
+		// Carried even when this member is delivered ALONE: a consumer that
+		// receives members before their header needs the correlation on the
+		// singles, not only on the batch event.
+		batchID:    ev.BatchID,
+		occurredAt: ev.OccurredAt,
+		payload:    ev.Payload,
+		rowIDs:     []string{ev.ID},
 	}
 }
 
@@ -323,6 +329,7 @@ func (s *Server) deliverOutboxUnit(unit outboxDelivery) {
 	outcome, err := s.webhooks.DeliverEvent(webhooks.Delivery{
 		WorkspaceID: unit.workspaceID,
 		EventID:     unit.eventID,
+		BatchID:     unit.batchID,
 		Event:       unit.eventType,
 		OccurredAt:  unit.occurredAt,
 		Payload:     json.RawMessage(unit.payload),

--- a/internal/server/outbox_drain.go
+++ b/internal/server/outbox_drain.go
@@ -230,6 +230,10 @@ type outboxDelivery struct {
 	occurredAt  string
 	payload     []byte
 	rowIDs      []string
+	// claimToken is the claim these rows were taken under. Ack and release are
+	// conditioned on it, so a pass whose lease expired mid-delivery cannot
+	// stamp or free rows another instance now holds.
+	claimToken string
 }
 
 // groupOutboxDeliveries turns claimed rows into wire deliveries, folding each
@@ -294,6 +298,7 @@ func groupOutboxDeliveries(events []store.OutboxEvent) []outboxDelivery {
 			occurredAt:  header.OccurredAt,
 			payload:     folded,
 			rowIDs:      rowIDs,
+			claimToken:  header.ClaimToken,
 		})
 	}
 	return out
@@ -309,6 +314,7 @@ func singleOutboxDelivery(ev store.OutboxEvent) outboxDelivery {
 		// singles, not only on the batch event.
 		batchID:    ev.BatchID,
 		occurredAt: ev.OccurredAt,
+		claimToken: ev.ClaimToken,
 		payload:    ev.Payload,
 		rowIDs:     []string{ev.ID},
 	}
@@ -322,7 +328,7 @@ func (s *Server) deliverOutboxUnit(unit outboxDelivery) {
 		// tests). The event has nowhere to go and is not owed to anyone, so
 		// ack it — leaving it pending would grow the table forever and then
 		// hand the retention bound a queue of events nobody ever wanted.
-		s.ackOutboxRows(unit.rowIDs)
+		s.ackOutboxRows(unit.claimToken, unit.rowIDs)
 		return
 	}
 
@@ -337,26 +343,26 @@ func (s *Server) deliverOutboxUnit(unit outboxDelivery) {
 	if err != nil {
 		// The server's own failure: nothing was attempted, so the event is
 		// still owed in full.
-		s.failOutboxRows(unit.rowIDs, err.Error())
+		s.failOutboxRows(unit.claimToken, unit.rowIDs, err.Error())
 		return
 	}
 	if outcome.Retryable() {
-		s.failOutboxRows(unit.rowIDs, outcome.LastError)
+		s.failOutboxRows(unit.claimToken, unit.rowIDs, outcome.LastError)
 		return
 	}
-	s.ackOutboxRows(unit.rowIDs)
+	s.ackOutboxRows(unit.claimToken, unit.rowIDs)
 }
 
-func (s *Server) ackOutboxRows(ids []string) {
-	if err := s.store.MarkOutboxDispatched(ids); err != nil {
+func (s *Server) ackOutboxRows(claimToken string, ids []string) {
+	if err := s.store.MarkOutboxDispatched(claimToken, ids); err != nil {
 		// Not acking is safe — at-least-once means the next pass re-delivers.
 		slog.Error("outbox drain: ack failed", "error", err)
 	}
 }
 
-func (s *Server) failOutboxRows(ids []string, reason string) {
+func (s *Server) failOutboxRows(claimToken string, ids []string, reason string) {
 	for _, id := range ids {
-		if err := s.store.MarkOutboxAttemptFailed(id, reason); err != nil {
+		if err := s.store.MarkOutboxAttemptFailed(claimToken, id, reason); err != nil {
 			slog.Error("outbox drain: recording a failed attempt failed", "id", id, "error", err)
 		}
 	}

--- a/internal/server/outbox_drain.go
+++ b/internal/server/outbox_drain.go
@@ -212,7 +212,7 @@ func (s *Server) runOutboxDrainTick() {
 		s.deliverOutboxUnit(unit)
 	}
 
-	if err := s.runOutboxRetention(settings.dispatchedRetention, settings.undispatchedMaxAge); err != nil {
+	if err := s.runOutboxRetention(settings.dispatchedRetention, settings.undispatchedMaxAge, settings.lease); err != nil {
 		slog.Error("outbox drain: retention pass failed", "error", err)
 	}
 }
@@ -382,15 +382,15 @@ func (s *Server) failOutboxRows(claimToken string, ids []string, reason string) 
 // row written in the same second as the cutoff survives `occurred_at <
 // cutoff` either way). Returning the refusal makes the guard assert-able
 // without depending on the clock.
-func (s *Server) runOutboxRetention(dispatchedRetention, undispatchedMaxAge time.Duration) error {
+func (s *Server) runOutboxRetention(dispatchedRetention, undispatchedMaxAge, lease time.Duration) error {
 	// A non-positive window would make the cutoff `now` and delete the entire
 	// table — the pending set included. Refuse rather than normalize: reaching
 	// here with a zero means a caller bypassed resolveOutboxDrainSettings, and
 	// quietly substituting a default would hide that from whoever added the
 	// bypass.
-	if dispatchedRetention <= 0 || undispatchedMaxAge <= 0 {
-		err := fmt.Errorf("refusing to prune with a non-positive retention window (dispatched %s, undispatched %s)",
-			dispatchedRetention, undispatchedMaxAge)
+	if dispatchedRetention <= 0 || undispatchedMaxAge <= 0 || lease <= 0 {
+		err := fmt.Errorf("refusing to prune with a non-positive retention window (dispatched %s, undispatched %s, lease %s)",
+			dispatchedRetention, undispatchedMaxAge, lease)
 		slog.Error("outbox drain: " + err.Error())
 		return err
 	}
@@ -400,7 +400,10 @@ func (s *Server) runOutboxRetention(dispatchedRetention, undispatchedMaxAge time
 	}
 
 	undispatchedBefore := time.Now().UTC().Add(-undispatchedMaxAge).Format(time.RFC3339)
-	n, err := s.store.PruneUndispatchedOutbox(undispatchedBefore)
+	// The same lease cutoff the claim uses: a row another instance is
+	// currently delivering must survive this pass.
+	leaseCutoff := time.Now().UTC().Add(-lease).Format(time.RFC3339)
+	n, err := s.store.PruneUndispatchedOutbox(undispatchedBefore, leaseCutoff)
 	if err != nil {
 		slog.Error("outbox drain: pruning undispatched events failed", "error", err)
 		return err

--- a/internal/server/outbox_drain.go
+++ b/internal/server/outbox_drain.go
@@ -1,0 +1,403 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/PerpetualSoftware/pad/internal/kernelevents"
+	"github.com/PerpetualSoftware/pad/internal/store"
+	"github.com/PerpetualSoftware/pad/internal/webhooks"
+)
+
+// The outbox drain: the half of SPEC-3's choke point that turns stored events
+// into delivered ones.
+//
+// TASK-2658 built the fill side — every canonical mutation writes its event in
+// the same transaction as the row it describes, so a committed mutation cannot
+// lose its event. Until this file, nothing read those rows: the table filled
+// and webhooks still fired from hand-calls in the handlers. This drains it.
+//
+// SCOPE, because the other half is deliberately absent: the drain owns the
+// WEBHOOK surface only. SSE stays direct-published at the mutation site
+// (SPEC-3 v1.5) — it carries request-scoped attribution a frozen payload does
+// not hold, and putting the live UI behind a polling drain is a latency change
+// tracked as its own item. What both surfaces now share is the NAME, derived
+// from the taxonomy.
+const (
+	defaultOutboxDrainInterval = 5 * time.Second
+
+	// How many pending rows one pass claims. Whole batches are claimed past
+	// this bound (see ClaimPendingOutboxEvents) — it is a throughput knob, not
+	// a statement about what a bulk operation was.
+	defaultOutboxDrainLimit = 100
+
+	// How long a claim is honored before another instance may take the row.
+	// Generous relative to a delivery: three attempts with linear backoff and
+	// a 10s per-attempt timeout is well under a minute, and re-claiming early
+	// only buys a duplicate.
+	defaultOutboxClaimLease = 5 * time.Minute
+
+	// Retention. Dispatched rows are kept as the durable record that an event
+	// existed; undispatched rows are kept far longer because they are still
+	// owed, but NOT forever — see PruneUndispatchedOutbox for why the privacy
+	// claim is what makes this bound mandatory rather than tidy.
+	defaultOutboxDispatchedRetention = 24 * time.Hour
+	defaultOutboxUndispatchedMaxAge  = 7 * 24 * time.Hour
+)
+
+type outboxDrainConfig struct {
+	mu                  sync.Mutex
+	interval            time.Duration
+	limit               int
+	lease               time.Duration
+	dispatchedRetention time.Duration
+	undispatchedMaxAge  time.Duration
+	stop                chan struct{}
+	running             bool
+	drainerID           string
+	// tick, when non-nil, replaces the interval ticker so a test can pin
+	// assertions to a SPECIFIC pass instead of racing a free-running loop —
+	// the same affordance server.go's other sweepers expose.
+	tick <-chan time.Time
+}
+
+// SetOutboxDrainConfig overrides the drain's timings. Zero values keep the
+// defaults, so a caller can set one knob without restating the rest.
+func (s *Server) SetOutboxDrainConfig(interval, lease, dispatchedRetention, undispatchedMaxAge time.Duration, limit int) {
+	s.outboxDrain.mu.Lock()
+	defer s.outboxDrain.mu.Unlock()
+	if interval > 0 {
+		s.outboxDrain.interval = interval
+	}
+	if lease > 0 {
+		s.outboxDrain.lease = lease
+	}
+	if dispatchedRetention > 0 {
+		s.outboxDrain.dispatchedRetention = dispatchedRetention
+	}
+	if undispatchedMaxAge > 0 {
+		s.outboxDrain.undispatchedMaxAge = undispatchedMaxAge
+	}
+	if limit > 0 {
+		s.outboxDrain.limit = limit
+	}
+}
+
+// resolveOutboxDrainSettings fills every unset knob with its default and
+// stores the result, so the resolved values are identical no matter which
+// entry point ran first.
+//
+// ONE RESOLVER, NOT DEFAULTS-AT-START. When the defaults were applied only in
+// StartOutboxDrain, a tick reached directly — every test does this, and so
+// would any future admin-triggered drain — ran with a ZERO undispatched max
+// age, which made the retention cutoff `now` and deleted the entire pending
+// set on the first pass. A config whose zero value is catastrophic must not
+// depend on a particular caller having normalized it.
+func (s *Server) resolveOutboxDrainSettings() outboxDrainSettings {
+	s.outboxDrain.mu.Lock()
+	defer s.outboxDrain.mu.Unlock()
+	if s.outboxDrain.interval <= 0 {
+		s.outboxDrain.interval = defaultOutboxDrainInterval
+	}
+	if s.outboxDrain.limit <= 0 {
+		s.outboxDrain.limit = defaultOutboxDrainLimit
+	}
+	if s.outboxDrain.lease <= 0 {
+		s.outboxDrain.lease = defaultOutboxClaimLease
+	}
+	if s.outboxDrain.dispatchedRetention <= 0 {
+		s.outboxDrain.dispatchedRetention = defaultOutboxDispatchedRetention
+	}
+	if s.outboxDrain.undispatchedMaxAge <= 0 {
+		s.outboxDrain.undispatchedMaxAge = defaultOutboxUndispatchedMaxAge
+	}
+	if s.outboxDrain.drainerID == "" {
+		// Per-process identity. Not persisted deliberately: a restarted
+		// process must NOT inherit its predecessor's claims — those rows are
+		// exactly the ones whose lease should decide their fate.
+		s.outboxDrain.drainerID = uuid.NewString()
+	}
+	return outboxDrainSettings{
+		interval:            s.outboxDrain.interval,
+		limit:               s.outboxDrain.limit,
+		lease:               s.outboxDrain.lease,
+		dispatchedRetention: s.outboxDrain.dispatchedRetention,
+		undispatchedMaxAge:  s.outboxDrain.undispatchedMaxAge,
+		drainerID:           s.outboxDrain.drainerID,
+	}
+}
+
+type outboxDrainSettings struct {
+	interval            time.Duration
+	limit               int
+	lease               time.Duration
+	dispatchedRetention time.Duration
+	undispatchedMaxAge  time.Duration
+	drainerID           string
+}
+
+// StartOutboxDrain starts the periodic drain loop. Idempotent; tracked by
+// Server.bg so Stop() drains it before the process exits (the BUG-842
+// invariant every sweeper here observes).
+func (s *Server) StartOutboxDrain() {
+	settings := s.resolveOutboxDrainSettings()
+
+	s.outboxDrain.mu.Lock()
+	if s.outboxDrain.running {
+		s.outboxDrain.mu.Unlock()
+		return
+	}
+	s.outboxDrain.stop = make(chan struct{})
+	s.outboxDrain.running = true
+	interval := settings.interval
+	stop := s.outboxDrain.stop
+	tick := s.outboxDrain.tick
+	s.outboxDrain.mu.Unlock()
+
+	slog.Info("outbox drain started", "interval", interval.String())
+
+	s.bg.Add(1)
+	go func() {
+		defer s.bg.Done()
+		defer s.recoverSweeper("outbox-drain")
+		var c <-chan time.Time
+		if tick != nil {
+			c = tick
+		} else {
+			t := time.NewTicker(interval)
+			defer t.Stop()
+			c = t.C
+		}
+		for {
+			select {
+			case <-stop:
+				return
+			case <-c:
+				s.runOutboxDrainTick()
+			}
+		}
+	}()
+}
+
+// stopOutboxDrain signals the loop to exit. Safe when it never started.
+func (s *Server) stopOutboxDrain() {
+	s.outboxDrain.mu.Lock()
+	defer s.outboxDrain.mu.Unlock()
+	if !s.outboxDrain.running {
+		return
+	}
+	close(s.outboxDrain.stop)
+	s.outboxDrain.running = false
+}
+
+// runOutboxDrainTick is one pass: claim, deliver, ack, retain.
+func (s *Server) runOutboxDrainTick() {
+	if s.store == nil {
+		return
+	}
+	settings := s.resolveOutboxDrainSettings()
+
+	leaseCutoff := time.Now().UTC().Add(-settings.lease).Format(time.RFC3339)
+	events, err := s.store.ClaimPendingOutboxEvents(settings.drainerID, settings.limit, leaseCutoff)
+	if err != nil {
+		slog.Error("outbox drain: claim failed", "error", err)
+		return
+	}
+	for _, unit := range groupOutboxDeliveries(events) {
+		s.deliverOutboxUnit(unit)
+	}
+
+	if err := s.runOutboxRetention(settings.dispatchedRetention, settings.undispatchedMaxAge); err != nil {
+		slog.Error("outbox drain: retention pass failed", "error", err)
+	}
+}
+
+// outboxDelivery is one WIRE event and the rows it acks.
+//
+// The distinction the drain turns on: a folded batch is many rows and ONE
+// delivery, so acking has to be per-unit rather than per-row or a partially
+// acked batch would re-deliver on the next pass.
+type outboxDelivery struct {
+	workspaceID string
+	eventType   string
+	eventID     string
+	occurredAt  string
+	payload     []byte
+	rowIDs      []string
+}
+
+// groupOutboxDeliveries turns claimed rows into wire deliveries, folding each
+// batch that has a header into one.
+//
+// THE FOLD RULE (SPEC-3 v1.6): header PLUS whatever member rows of that batch
+// are still undispatched. Members of a batch whose header is not in this claim
+// deliver individually — that is not a fallback, it is the defined behaviour
+// for the window between the member loop committing and the header landing. A
+// consumer can therefore see singles and then a partial batch for one
+// operation, correlated by the batch_id both carry.
+func groupOutboxDeliveries(events []store.OutboxEvent) []outboxDelivery {
+	headers := map[string]store.OutboxEvent{}
+	members := map[string][]store.OutboxEvent{}
+	var singles []store.OutboxEvent
+
+	for _, ev := range events {
+		switch {
+		case ev.BatchID == "":
+			singles = append(singles, ev)
+		case ev.EventType == kernelevents.ItemBulkUpdated:
+			headers[ev.BatchID] = ev
+		default:
+			members[ev.BatchID] = append(members[ev.BatchID], ev)
+		}
+	}
+
+	var out []outboxDelivery
+	for _, ev := range singles {
+		out = append(out, singleOutboxDelivery(ev))
+	}
+	for batch, member := range members {
+		if _, folded := headers[batch]; folded {
+			continue
+		}
+		for _, ev := range member {
+			out = append(out, singleOutboxDelivery(ev))
+		}
+	}
+	for batch, header := range headers {
+		rowIDs := []string{header.ID}
+		var payloads [][]byte
+		for _, ev := range members[batch] {
+			rowIDs = append(rowIDs, ev.ID)
+			payloads = append(payloads, ev.Payload)
+		}
+		folded, err := store.FoldBulkHeader(header.Payload, payloads)
+		if err != nil {
+			// A header we cannot parse is not deliverable as a batch. Fall
+			// back to the header's own payload rather than dropping the
+			// event: the members are still acked with it, and a consumer
+			// receiving the unfolded header at least learns the operation
+			// happened.
+			slog.Error("outbox drain: fold failed", "batch", batch, "error", err)
+			folded = header.Payload
+		}
+		out = append(out, outboxDelivery{
+			workspaceID: header.WorkspaceID,
+			eventType:   header.EventType,
+			eventID:     header.ID,
+			occurredAt:  header.OccurredAt,
+			payload:     folded,
+			rowIDs:      rowIDs,
+		})
+	}
+	return out
+}
+
+func singleOutboxDelivery(ev store.OutboxEvent) outboxDelivery {
+	return outboxDelivery{
+		workspaceID: ev.WorkspaceID,
+		eventType:   ev.EventType,
+		eventID:     ev.ID,
+		occurredAt:  ev.OccurredAt,
+		payload:     ev.Payload,
+		rowIDs:      []string{ev.ID},
+	}
+}
+
+// deliverOutboxUnit puts one wire event on the webhook surface and acks or
+// releases its rows according to the outcome.
+func (s *Server) deliverOutboxUnit(unit outboxDelivery) {
+	if s.webhooks == nil {
+		// No dispatcher configured (self-hosted with webhooks off, most
+		// tests). The event has nowhere to go and is not owed to anyone, so
+		// ack it — leaving it pending would grow the table forever and then
+		// hand the retention bound a queue of events nobody ever wanted.
+		s.ackOutboxRows(unit.rowIDs)
+		return
+	}
+
+	outcome, err := s.webhooks.DeliverEvent(webhooks.Delivery{
+		WorkspaceID: unit.workspaceID,
+		EventID:     unit.eventID,
+		Event:       unit.eventType,
+		OccurredAt:  unit.occurredAt,
+		Payload:     json.RawMessage(unit.payload),
+	})
+	if err != nil {
+		// The server's own failure: nothing was attempted, so the event is
+		// still owed in full.
+		s.failOutboxRows(unit.rowIDs, err.Error())
+		return
+	}
+	if outcome.Retryable() {
+		s.failOutboxRows(unit.rowIDs, outcome.LastError)
+		return
+	}
+	s.ackOutboxRows(unit.rowIDs)
+}
+
+func (s *Server) ackOutboxRows(ids []string) {
+	if err := s.store.MarkOutboxDispatched(ids); err != nil {
+		// Not acking is safe — at-least-once means the next pass re-delivers.
+		slog.Error("outbox drain: ack failed", "error", err)
+	}
+}
+
+func (s *Server) failOutboxRows(ids []string, reason string) {
+	for _, id := range ids {
+		if err := s.store.MarkOutboxAttemptFailed(id, reason); err != nil {
+			slog.Error("outbox drain: recording a failed attempt failed", "id", id, "error", err)
+		}
+	}
+}
+
+// runOutboxRetention enforces both halves of the retention window.
+//
+// Both, on every tick, because they bound different things: dispatched rows
+// are history and undispatched rows are FROZEN PAYLOADS that de-identification
+// cannot reach. The second is the privacy bound SPEC-3 makes temporal, and it
+// is the one that would be easy to leave out — PruneDispatchedOutbox looks
+// like it covers retention until you notice which rows it can never see.
+// The error return exists FOR THE TEST, and is worth the signature: a refusal
+// that only logs is indistinguishable from a prune that happened to match no
+// rows, which is exactly how the first version of this guard's test passed
+// against a build with the guard removed (RFC3339 is second-granular, so a
+// row written in the same second as the cutoff survives `occurred_at <
+// cutoff` either way). Returning the refusal makes the guard assert-able
+// without depending on the clock.
+func (s *Server) runOutboxRetention(dispatchedRetention, undispatchedMaxAge time.Duration) error {
+	// A non-positive window would make the cutoff `now` and delete the entire
+	// table — the pending set included. Refuse rather than normalize: reaching
+	// here with a zero means a caller bypassed resolveOutboxDrainSettings, and
+	// quietly substituting a default would hide that from whoever added the
+	// bypass.
+	if dispatchedRetention <= 0 || undispatchedMaxAge <= 0 {
+		err := fmt.Errorf("refusing to prune with a non-positive retention window (dispatched %s, undispatched %s)",
+			dispatchedRetention, undispatchedMaxAge)
+		slog.Error("outbox drain: " + err.Error())
+		return err
+	}
+	dispatchedBefore := time.Now().UTC().Add(-dispatchedRetention).Format(time.RFC3339)
+	if _, err := s.store.PruneDispatchedOutbox(dispatchedBefore); err != nil {
+		slog.Error("outbox drain: pruning dispatched events failed", "error", err)
+	}
+
+	undispatchedBefore := time.Now().UTC().Add(-undispatchedMaxAge).Format(time.RFC3339)
+	n, err := s.store.PruneUndispatchedOutbox(undispatchedBefore)
+	if err != nil {
+		slog.Error("outbox drain: pruning undispatched events failed", "error", err)
+		return err
+	}
+	if n > 0 {
+		// Loud on purpose: these events were owed and never delivered. The
+		// count is the only place a delivery problem that has been failing for
+		// the whole window becomes visible.
+		slog.Warn("outbox drain: dropped undeliverable events at max age",
+			"count", n, "max_age", undispatchedMaxAge.String())
+	}
+	return nil
+}

--- a/internal/server/outbox_drain_test.go
+++ b/internal/server/outbox_drain_test.go
@@ -21,9 +21,10 @@ import (
 // assertion here a timing question.
 
 type capturedDelivery struct {
-	Event string          `json:"event"`
-	ID    string          `json:"id"`
-	Data  json.RawMessage `json:"data"`
+	Event   string          `json:"event"`
+	ID      string          `json:"id"`
+	BatchID string          `json:"batch_id"`
+	Data    json.RawMessage `json:"data"`
 }
 
 type webhookSink struct {
@@ -311,6 +312,16 @@ func TestOutboxDrain_MembersWithoutTheirHeaderDeliverIndividually(t *testing.T) 
 		if d.Event != kernelevents.ItemDeleted {
 			t.Errorf("event = %q, want %q — members deliver as their own canonical events", d.Event, kernelevents.ItemDeleted)
 		}
+		// THE ENVELOPE, not the payload: these are ordinary item.deleted
+		// events whose payload is an item snapshot with no batch anywhere in
+		// it. If the correlation is not on the envelope, a consumer receiving
+		// singles-then-partial-batch cannot tell they were one operation —
+		// which is the only reason batch_id is on the wire (codex round 2
+		// found this claimed in comments and reachable only from the folded
+		// half).
+		if d.BatchID != batch {
+			t.Errorf("member delivery carries batch_id %q, want %q", d.BatchID, batch)
+		}
 	}
 
 	// The header arrives and folds what is left, which is nothing: the members
@@ -332,7 +343,10 @@ func TestOutboxDrain_MembersWithoutTheirHeaderDeliverIndividually(t *testing.T) 
 		t.Fatalf("decode header payload: %v", err)
 	}
 	if payload.BatchID != batch {
-		t.Errorf("batch_id = %q, want %q — without it a consumer cannot tie the singles to this event", payload.BatchID, batch)
+		t.Errorf("payload batch_id = %q, want %q", payload.BatchID, batch)
+	}
+	if after[0].BatchID != batch {
+		t.Errorf("header envelope batch_id = %q, want %q — the singles carry it on the envelope, so the batch must too or they cannot be matched", after[0].BatchID, batch)
 	}
 	if len(payload.Members) != 0 {
 		t.Errorf("members = %d, want 0 — a fold must not re-include members a previous tick already delivered", len(payload.Members))

--- a/internal/server/outbox_drain_test.go
+++ b/internal/server/outbox_drain_test.go
@@ -381,12 +381,12 @@ func TestOutboxDrain_RetentionRefusesANonPositiveWindow(t *testing.T) {
 	// second as a zero-window cutoff survives `occurred_at < cutoff` whether
 	// or not anything refused to run. The end state was reachable by another
 	// mechanism (CONVE-12) — and worse, by a clock.
-	if err := srv.runOutboxRetention(0, 0); err == nil {
+	if err := srv.runOutboxRetention(0, 0, 0); err == nil {
 		t.Fatal("a zero retention window was accepted; its cutoff is `now`, which deletes every row including undelivered ones")
 	}
 
 	// The positive control: a sane window is not refused.
-	if err := srv.runOutboxRetention(time.Hour, 24*time.Hour); err != nil {
+	if err := srv.runOutboxRetention(time.Hour, 24*time.Hour, 5*time.Minute); err != nil {
 		t.Errorf("a positive window was refused: %v", err)
 	}
 	if after := pendingOutboxCount(t, srv); after != before {

--- a/internal/server/outbox_drain_test.go
+++ b/internal/server/outbox_drain_test.go
@@ -1,0 +1,406 @@
+package server
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/kernelevents"
+	"github.com/PerpetualSoftware/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/store"
+	"github.com/PerpetualSoftware/pad/internal/webhooks"
+)
+
+// Tests for the outbox drain (TASK-2714). They call runOutboxDrainTick
+// directly rather than starting the loop: the loop's ticker is not the
+// behaviour under test, and racing a free-running goroutine would make every
+// assertion here a timing question.
+
+type capturedDelivery struct {
+	Event string          `json:"event"`
+	ID    string          `json:"id"`
+	Data  json.RawMessage `json:"data"`
+}
+
+type webhookSink struct {
+	mu       sync.Mutex
+	got      []capturedDelivery
+	status   int
+	server   *httptest.Server
+	requests int
+}
+
+func newWebhookSink(t *testing.T) *webhookSink {
+	t.Helper()
+	sink := &webhookSink{status: http.StatusOK}
+	sink.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var d capturedDelivery
+		_ = json.Unmarshal(body, &d)
+		sink.mu.Lock()
+		sink.got = append(sink.got, d)
+		sink.requests++
+		status := sink.status
+		sink.mu.Unlock()
+		w.WriteHeader(status)
+	}))
+	t.Cleanup(sink.server.Close)
+	return sink
+}
+
+func (s *webhookSink) deliveries() []capturedDelivery {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]capturedDelivery, len(s.got))
+	copy(out, s.got)
+	return out
+}
+
+func (s *webhookSink) setStatus(code int) {
+	s.mu.Lock()
+	s.status = code
+	s.mu.Unlock()
+}
+
+// drainFixture wires a server to a webhook sink and returns the workspace the
+// events belong to.
+func drainFixture(t *testing.T) (*Server, *webhookSink, *models.Workspace) {
+	t.Helper()
+	srv := testServer(t)
+	sink := newWebhookSink(t)
+
+	ws, err := srv.store.CreateWorkspace(models.WorkspaceCreate{Name: "Drain", Slug: "drain"})
+	if err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	if _, err := srv.store.CreateWebhook(ws.ID, models.WebhookCreate{URL: sink.server.URL, Events: `["*"]`}); err != nil {
+		t.Fatalf("create webhook: %v", err)
+	}
+
+	d := webhooks.NewDispatcher(srv.store)
+	d.SkipSSRF = true
+	srv.SetWebhookDispatcher(d)
+	return srv, sink, ws
+}
+
+func pendingOutboxCount(t *testing.T, srv *Server) int {
+	t.Helper()
+	evs, err := srv.store.ListPendingOutboxEvents(1000)
+	if err != nil {
+		t.Fatalf("list pending: %v", err)
+	}
+	return len(evs)
+}
+
+// TestOutboxDrain_DeliversAndAcksASingleEvent is the base case: a stored event
+// reaches the wire once, carrying its row id as the dedupe key, and stops
+// being pending.
+func TestOutboxDrain_DeliversAndAcksASingleEvent(t *testing.T) {
+	srv, sink, ws := drainFixture(t)
+	col := createDrainCollection(t, srv, ws.ID)
+	item := createDrainItem(t, srv, ws.ID, col.ID, "Delivered once")
+
+	// Premise: the mutation actually wrote an event. Without this the
+	// assertions below would pass for a drain that delivered nothing.
+	if n := pendingOutboxCount(t, srv); n == 0 {
+		t.Fatal("no pending outbox events after creating an item")
+	}
+
+	srv.runOutboxDrainTick()
+
+	got := sink.deliveries()
+	if len(got) != 1 {
+		t.Fatalf("deliveries = %d, want exactly 1: %+v", len(got), got)
+	}
+	if got[0].Event != kernelevents.ItemCreated {
+		t.Errorf("event = %q, want %q", got[0].Event, kernelevents.ItemCreated)
+	}
+	if got[0].ID == "" {
+		t.Error("delivered envelope carries no id — consumers dedupe on it")
+	}
+	var snapshot map[string]any
+	if err := json.Unmarshal(got[0].Data, &snapshot); err != nil {
+		t.Fatalf("decode data: %v", err)
+	}
+	if snapshot["id"] != item.ID {
+		t.Errorf("payload id = %v, want the created item %s", snapshot["id"], item.ID)
+	}
+
+	if n := pendingOutboxCount(t, srv); n != 0 {
+		t.Errorf("pending after drain = %d, want 0 — a delivered event stayed pending and will re-deliver forever", n)
+	}
+
+	// And a second tick delivers nothing: the ack is what stops it.
+	srv.runOutboxDrainTick()
+	if got := sink.deliveries(); len(got) != 1 {
+		t.Errorf("deliveries after a second tick = %d, want still 1", len(got))
+	}
+}
+
+// TestOutboxDrain_TransientFailureLeavesTheEventPending: the durable retry is
+// the drain's, and it is the reason the outbox exists. A 5xx must not ack.
+func TestOutboxDrain_TransientFailureLeavesTheEventPending(t *testing.T) {
+	srv, sink, ws := drainFixture(t)
+	col := createDrainCollection(t, srv, ws.ID)
+	createDrainItem(t, srv, ws.ID, col.ID, "Retried")
+
+	sink.setStatus(http.StatusInternalServerError)
+	srv.runOutboxDrainTick()
+
+	if n := pendingOutboxCount(t, srv); n == 0 {
+		t.Fatal("event was acked despite a 5xx — the retry the outbox exists for cannot happen")
+	}
+
+	sink.setStatus(http.StatusOK)
+	srv.runOutboxDrainTick()
+
+	if n := pendingOutboxCount(t, srv); n != 0 {
+		t.Errorf("pending after the endpoint recovered = %d, want 0", n)
+	}
+}
+
+// TestOutboxDrain_PermanentFailureAcks: an endpoint that rejects the delivery
+// in a way no retry fixes must not hold the workspace's queue. The control leg
+// is the transient test above — same shape, opposite ack.
+func TestOutboxDrain_PermanentFailureAcks(t *testing.T) {
+	srv, sink, ws := drainFixture(t)
+	col := createDrainCollection(t, srv, ws.ID)
+	createDrainItem(t, srv, ws.ID, col.ID, "Rejected")
+
+	sink.setStatus(http.StatusBadRequest)
+	srv.runOutboxDrainTick()
+
+	if n := pendingOutboxCount(t, srv); n != 0 {
+		t.Errorf("pending after a 4xx = %d, want 0 — re-sending to an endpoint that rejects it costs the queue its progress", n)
+	}
+}
+
+func createDrainCollection(t *testing.T, srv *Server, workspaceID string) *models.Collection {
+	t.Helper()
+	col, err := srv.store.CreateCollection(workspaceID, models.CollectionCreate{
+		Name:   "Tasks",
+		Slug:   "tasks",
+		Prefix: "TASK",
+		Schema: `{"fields":[{"key":"status","type":"select","options":["open","done"],"default":"open"}]}`,
+	})
+	if err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	return col
+}
+
+func createDrainItem(t *testing.T, srv *Server, workspaceID, collectionID, title string) *models.Item {
+	t.Helper()
+	item, err := srv.store.CreateItem(workspaceID, collectionID, models.ItemCreate{
+		Title: title, Fields: `{"status":"open"}`,
+	})
+	if err != nil {
+		t.Fatalf("create item: %v", err)
+	}
+	return item
+}
+
+// TestOutboxDrain_FoldsABatchIntoOneWireEvent is the F2 payoff: a lane-wide
+// bulk action must reach a webhook consumer as ONE delivery carrying every
+// member, not as N single-item deliveries.
+func TestOutboxDrain_FoldsABatchIntoOneWireEvent(t *testing.T) {
+	srv, sink, ws := drainFixture(t)
+	col := createDrainCollection(t, srv, ws.ID)
+
+	const batch = "batch-fold"
+	var ids []string
+	for _, title := range []string{"One", "Two", "Three"} {
+		item := createDrainItem(t, srv, ws.ID, col.ID, title)
+		ids = append(ids, item.ID)
+	}
+	// Drain the creates so only the batch is left to assert on.
+	srv.runOutboxDrainTick()
+	sinkBefore := len(sink.deliveries())
+
+	for _, id := range ids {
+		if err := srv.store.DeleteItem(id, store.WithEventBatch(batch)); err != nil {
+			t.Fatalf("archive %s: %v", id, err)
+		}
+	}
+	if err := srv.store.EmitBulkHeaderEvent(ws.ID, batch, "archive", ids, nil); err != nil {
+		t.Fatalf("emit header: %v", err)
+	}
+	// Premise: four rows are pending — three members and the header. If the
+	// fold were tested against fewer, "one delivery" would prove nothing.
+	if n := pendingOutboxCount(t, srv); n != 4 {
+		t.Fatalf("pending = %d, want 3 members + 1 header", n)
+	}
+
+	srv.runOutboxDrainTick()
+
+	got := sink.deliveries()[sinkBefore:]
+	if len(got) != 1 {
+		t.Fatalf("deliveries = %d, want exactly 1 folded batch event: %+v", len(got), got)
+	}
+	if got[0].Event != kernelevents.ItemBulkUpdated {
+		t.Errorf("event = %q, want %q", got[0].Event, kernelevents.ItemBulkUpdated)
+	}
+
+	var payload struct {
+		BatchID string            `json:"batch_id"`
+		Op      string            `json:"op"`
+		Count   int               `json:"count"`
+		ItemIDs []string          `json:"item_ids"`
+		Members []json.RawMessage `json:"members"`
+	}
+	if err := json.Unmarshal(got[0].Data, &payload); err != nil {
+		t.Fatalf("decode folded payload: %v", err)
+	}
+	if payload.BatchID != batch {
+		t.Errorf("batch_id = %q, want %q — it is the consumer's correlation key when a batch splits", payload.BatchID, batch)
+	}
+	if payload.Op != "archive" {
+		t.Errorf("op = %q, want archive — the shared delta the drain cannot derive", payload.Op)
+	}
+	if payload.Count != 3 || len(payload.ItemIDs) != 3 {
+		t.Errorf("count/item_ids = %d/%v, want 3", payload.Count, payload.ItemIDs)
+	}
+	if len(payload.Members) != 3 {
+		t.Errorf("members = %d, want the three member snapshots folded in", len(payload.Members))
+	}
+
+	if n := pendingOutboxCount(t, srv); n != 0 {
+		t.Errorf("pending after the fold = %d, want 0 — the members must be acked with the header they were folded into", n)
+	}
+}
+
+// TestOutboxDrain_MembersWithoutTheirHeaderDeliverIndividually pins the window
+// SPEC-3 v1.6 defines rather than papers over: a tick can claim some members
+// before the header lands.
+//
+// The members deliver individually, and the header that arrives afterwards
+// folds whatever is LEFT. A consumer therefore sees singles plus a partial
+// batch for one operation — correlated by the batch id both carry, which is
+// why batch_id is on the wire at all.
+func TestOutboxDrain_MembersWithoutTheirHeaderDeliverIndividually(t *testing.T) {
+	srv, sink, ws := drainFixture(t)
+	col := createDrainCollection(t, srv, ws.ID)
+
+	const batch = "batch-split"
+	var ids []string
+	for _, title := range []string{"One", "Two"} {
+		item := createDrainItem(t, srv, ws.ID, col.ID, title)
+		ids = append(ids, item.ID)
+	}
+	srv.runOutboxDrainTick()
+	sinkBefore := len(sink.deliveries())
+
+	// The loop commits its members...
+	for _, id := range ids {
+		if err := srv.store.DeleteItem(id, store.WithEventBatch(batch)); err != nil {
+			t.Fatalf("archive %s: %v", id, err)
+		}
+	}
+	// ...and a drain tick lands before the header does.
+	srv.runOutboxDrainTick()
+
+	mid := sink.deliveries()[sinkBefore:]
+	if len(mid) != 2 {
+		t.Fatalf("deliveries before the header = %d, want the 2 members individually: %+v", len(mid), mid)
+	}
+	for _, d := range mid {
+		if d.Event != kernelevents.ItemDeleted {
+			t.Errorf("event = %q, want %q — members deliver as their own canonical events", d.Event, kernelevents.ItemDeleted)
+		}
+	}
+
+	// The header arrives and folds what is left, which is nothing: the members
+	// were already delivered and acked.
+	if err := srv.store.EmitBulkHeaderEvent(ws.ID, batch, "archive", ids, nil); err != nil {
+		t.Fatalf("emit header: %v", err)
+	}
+	srv.runOutboxDrainTick()
+
+	after := sink.deliveries()[sinkBefore+len(mid):]
+	if len(after) != 1 {
+		t.Fatalf("deliveries after the header = %d, want the header alone: %+v", len(after), after)
+	}
+	var payload struct {
+		BatchID string            `json:"batch_id"`
+		Members []json.RawMessage `json:"members"`
+	}
+	if err := json.Unmarshal(after[0].Data, &payload); err != nil {
+		t.Fatalf("decode header payload: %v", err)
+	}
+	if payload.BatchID != batch {
+		t.Errorf("batch_id = %q, want %q — without it a consumer cannot tie the singles to this event", payload.BatchID, batch)
+	}
+	if len(payload.Members) != 0 {
+		t.Errorf("members = %d, want 0 — a fold must not re-include members a previous tick already delivered", len(payload.Members))
+	}
+	if n := pendingOutboxCount(t, srv); n != 0 {
+		t.Errorf("pending = %d, want 0", n)
+	}
+}
+
+// TestOutboxDrain_RetentionRefusesANonPositiveWindow pins the guard on the one
+// configuration mistake that is unrecoverable.
+//
+// A zero window makes the retention cutoff `now`, which deletes every row —
+// including the PENDING ones that were never delivered. This is not
+// hypothetical: the drain's defaults were originally applied only in
+// StartOutboxDrain, so a tick reached directly ran with a zero max age and
+// wiped the pending set on its first pass. The defaults now live in one
+// resolver, and this asserts the second line of defence behind it.
+func TestOutboxDrain_RetentionRefusesANonPositiveWindow(t *testing.T) {
+	srv, _, ws := drainFixture(t)
+	col := createDrainCollection(t, srv, ws.ID)
+	createDrainItem(t, srv, ws.ID, col.ID, "Still owed")
+
+	before := pendingOutboxCount(t, srv)
+	if before == 0 {
+		t.Fatal("no pending events to protect — the assertion below would prove nothing")
+	}
+
+	// ASSERT THE REFUSAL, not the survival. The first version of this test
+	// checked that the pending row was still there, and it passed with the
+	// guard removed: RFC3339 is second-granular, so a row written in the same
+	// second as a zero-window cutoff survives `occurred_at < cutoff` whether
+	// or not anything refused to run. The end state was reachable by another
+	// mechanism (CONVE-12) — and worse, by a clock.
+	if err := srv.runOutboxRetention(0, 0); err == nil {
+		t.Fatal("a zero retention window was accepted; its cutoff is `now`, which deletes every row including undelivered ones")
+	}
+
+	// The positive control: a sane window is not refused.
+	if err := srv.runOutboxRetention(time.Hour, 24*time.Hour); err != nil {
+		t.Errorf("a positive window was refused: %v", err)
+	}
+	if after := pendingOutboxCount(t, srv); after != before {
+		t.Errorf("pending went from %d to %d — the recent event was pruned by a window it is well inside", before, after)
+	}
+}
+
+// TestOutboxDrain_SettingsResolveToPositiveDefaults is the primary defence the
+// guard above backs up: every knob has a usable value no matter which entry
+// point ran first. A zero max age is not a small misconfiguration — it makes
+// the retention cutoff `now`.
+func TestOutboxDrain_SettingsResolveToPositiveDefaults(t *testing.T) {
+	srv := testServer(t)
+	got := srv.resolveOutboxDrainSettings()
+
+	if got.interval <= 0 || got.limit <= 0 || got.lease <= 0 {
+		t.Errorf("interval/limit/lease = %v/%d/%v, want positive defaults", got.interval, got.limit, got.lease)
+	}
+	if got.dispatchedRetention <= 0 || got.undispatchedMaxAge <= 0 {
+		t.Errorf("retention windows = %v/%v, want positive defaults", got.dispatchedRetention, got.undispatchedMaxAge)
+	}
+	if got.drainerID == "" {
+		t.Error("drainer id is empty — every claim would be attributed to the same anonymous drainer")
+	}
+
+	// Resolution is stable: a second call must not mint a new drainer id, or
+	// an instance would lose track of its own claims between passes.
+	if again := srv.resolveOutboxDrainSettings(); again.drainerID != got.drainerID {
+		t.Errorf("drainer id changed between passes: %q then %q", got.drainerID, again.drainerID)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -213,6 +213,12 @@ type Server struct {
 	// Stop() signals the loop via stopWorkspacePurgeSweeper.
 	workspacePurge workspacePurgeConfig
 
+	// outboxDrain holds the periodic config + lifecycle for the SPEC-3 event
+	// outbox drain (TASK-2714). Mirrors orphanGC. Configured via
+	// SetOutboxDrainConfig + started via StartOutboxDrain; Stop() signals the
+	// loop via stopOutboxDrain.
+	outboxDrain outboxDrainConfig
+
 	// inFlightUploadHashes tracks content_hash values for uploads
 	// that have called AttachmentStore.Put but not yet inserted the
 	// attachments row. Without this, the orphan GC could delete a
@@ -403,6 +409,9 @@ func (s *Server) Stop() {
 	// Soft-deleted-workspace hard-purge sweeper (TASK-1966). Same
 	// lifecycle pattern; signal BEFORE Wait() so the goroutine exits.
 	s.stopWorkspacePurgeSweeper()
+	// SPEC-3 event outbox drain (TASK-2714). Same lifecycle pattern; an
+	// in-flight delivery is tracked on s.bg and awaited below.
+	s.stopOutboxDrain()
 	// MCP audit writer / sweeper run on s.bg too. Signal first so
 	// the workers see the close BEFORE Wait() blocks; without the
 	// signal Wait would hang forever on the writer's blocking

--- a/internal/store/event_outbox.go
+++ b/internal/store/event_outbox.go
@@ -922,9 +922,17 @@ func (s *Store) MarkOutboxDispatched(ids []string) error {
 
 // MarkOutboxAttemptFailed records a failed dispatch attempt, leaving the event
 // pending so the next drain retries it.
+//
+// The CLAIM IS RELEASED here, not left to expire. A transient failure means
+// the event is still owed and nothing is in flight for it; holding the claim
+// until the lease times out would idle the row for the whole lease window for
+// no reason, and on a single-instance deployment that is the only reason it
+// would ever wait at all.
 func (s *Store) MarkOutboxAttemptFailed(id, reason string) error {
 	if _, err := s.db.Exec(s.q(`
-		UPDATE event_outbox SET attempts = attempts + 1, last_error = ? WHERE id = ? AND dispatched_at IS NULL
+		UPDATE event_outbox
+		SET attempts = attempts + 1, last_error = ?, claimed_at = NULL, claimed_by = NULL
+		WHERE id = ? AND dispatched_at IS NULL
 	`), reason, id); err != nil {
 		return fmt.Errorf("mark outbox attempt failed %s: %w", id, err)
 	}
@@ -1004,4 +1012,194 @@ func (s *Store) PruneUndispatchedOutbox(before string) (int64, error) {
 		return 0, nil
 	}
 	return n, nil
+}
+
+// ClaimPendingOutboxEvents claims up to limit pending events for one drain
+// pass and returns them, oldest first.
+//
+// WHY A CLAIM AT ALL. Pad Cloud runs N instances against one database and each
+// runs the drain, so an unclaimed pending row is delivered N times BY
+// CONSTRUCTION. SPEC-3 permits duplicates — consumers dedupe on the event id —
+// but "occasionally, after a crash" and "always, once per instance" are
+// different promises, and only the first is one a consumer can budget for.
+//
+// The arbiter is the CONDITIONAL UPDATE, not the SELECT that finds candidates.
+// Two instances reading the same candidate list is expected and harmless: each
+// row's UPDATE carries its own claim-availability predicate, so one instance
+// writes it and the other matches zero rows. This is BUG-2415's orphan-GC
+// protocol, and it is dialect-uniform on purpose — Postgres FOR UPDATE SKIP
+// LOCKED plus a separate SQLite path would be two implementations of one
+// behaviour, only one of which ever runs where it matters.
+//
+// leaseCutoff is the claim expiry: a row claimed before it is claimable again,
+// because an instance that dies between claiming and dispatching must not
+// strand its events. At-least-once is exactly the promise that makes
+// re-claiming safe.
+//
+// BATCHES ARE CLAIMED WHOLE, past the limit if necessary. A batch split across
+// two passes would be folded into two wire events each reporting a partial
+// member count — the limit is a throughput knob, and letting it decide what a
+// bulk operation "was" would make the wire event's truth depend on queue depth.
+// Rows of a batch another instance already holds are simply not ours; the wire
+// payload carries the batch id so a consumer can correlate a split that a
+// concurrent claim did produce.
+func (s *Store) ClaimPendingOutboxEvents(drainer string, limit int, leaseCutoff string) ([]OutboxEvent, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+	// The token, not the drainer name, is what identifies THIS pass: a
+	// drainer that claims twice in the same second would otherwise read back
+	// its previous pass's rows as well.
+	token := drainer + ":" + newID()
+
+	ids, err := s.pendingClaimCandidates(limit, leaseCutoff)
+	if err != nil {
+		return nil, err
+	}
+	if len(ids) == 0 {
+		return nil, nil
+	}
+
+	if err := s.claimOutboxIDs(token, ids, leaseCutoff); err != nil {
+		return nil, err
+	}
+	return s.outboxEventsClaimedBy(token)
+}
+
+// claimOutboxIDs is the ARBITER: one conditional UPDATE per candidate, each
+// carrying its own claim-availability predicate.
+//
+// Split out from ClaimPendingOutboxEvents so a test can drive it with a
+// deliberately STALE candidate list — the race this exists for. Called with
+// ids the caller selected earlier, it must claim only those still available,
+// which is not observable through the public entry point (whose candidate
+// query has already filtered them).
+func (s *Store) claimOutboxIDs(token string, ids []string, leaseCutoff string) error {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("claim outbox events: %w", err)
+	}
+	defer tx.Rollback()
+	for _, id := range ids {
+		if _, err := tx.Exec(s.q(`
+			UPDATE event_outbox
+			SET claimed_at = ?, claimed_by = ?
+			WHERE id = ?
+			  AND dispatched_at IS NULL
+			  AND (claimed_at IS NULL OR claimed_at < ?)
+		`), now(), token, id, leaseCutoff); err != nil {
+			return fmt.Errorf("claim outbox event %s: %w", id, err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("claim outbox events: %w", err)
+	}
+	return nil
+}
+
+// pendingClaimCandidates returns the ids a claim pass should attempt: the
+// oldest claimable pending rows, plus every claimable sibling of any batch
+// they belong to.
+func (s *Store) pendingClaimCandidates(limit int, leaseCutoff string) ([]string, error) {
+	rows, err := s.db.Query(s.q(`
+		SELECT id, COALESCE(batch_id, '')
+		FROM event_outbox
+		WHERE dispatched_at IS NULL
+		  AND (claimed_at IS NULL OR claimed_at < ?)
+		ORDER BY occurred_at, id
+		LIMIT ?
+	`), leaseCutoff, limit)
+	if err != nil {
+		return nil, fmt.Errorf("list claimable outbox events: %w", err)
+	}
+	defer rows.Close()
+
+	seen := map[string]bool{}
+	var ids []string
+	var batches []string
+	for rows.Next() {
+		var id, batch string
+		if err := rows.Scan(&id, &batch); err != nil {
+			return nil, fmt.Errorf("scan claimable outbox event: %w", err)
+		}
+		if !seen[id] {
+			seen[id] = true
+			ids = append(ids, id)
+		}
+		if batch != "" {
+			batches = append(batches, batch)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate claimable outbox events: %w", err)
+	}
+
+	for _, batch := range batches {
+		siblings, err := s.claimableBatchSiblings(batch, leaseCutoff)
+		if err != nil {
+			return nil, err
+		}
+		for _, id := range siblings {
+			if !seen[id] {
+				seen[id] = true
+				ids = append(ids, id)
+			}
+		}
+	}
+	return ids, nil
+}
+
+func (s *Store) claimableBatchSiblings(batchID, leaseCutoff string) ([]string, error) {
+	rows, err := s.db.Query(s.q(`
+		SELECT id
+		FROM event_outbox
+		WHERE batch_id = ?
+		  AND dispatched_at IS NULL
+		  AND (claimed_at IS NULL OR claimed_at < ?)
+	`), batchID, leaseCutoff)
+	if err != nil {
+		return nil, fmt.Errorf("list batch siblings: %w", err)
+	}
+	defer rows.Close()
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("scan batch sibling: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate batch siblings: %w", err)
+	}
+	return ids, nil
+}
+
+func (s *Store) outboxEventsClaimedBy(token string) ([]OutboxEvent, error) {
+	rows, err := s.db.Query(s.q(`
+		SELECT id, workspace_id, event_type, subject_kind, COALESCE(subject_id, ''), payload, hop, occurred_at, attempts, COALESCE(last_error, ''), COALESCE(batch_id, '')
+		FROM event_outbox
+		WHERE claimed_by = ? AND dispatched_at IS NULL
+		ORDER BY occurred_at, id
+	`), token)
+	if err != nil {
+		return nil, fmt.Errorf("read claimed outbox events: %w", err)
+	}
+	defer rows.Close()
+
+	var out []OutboxEvent
+	for rows.Next() {
+		var ev OutboxEvent
+		var payload string
+		if err := rows.Scan(&ev.ID, &ev.WorkspaceID, &ev.EventType, &ev.SubjectKind, &ev.SubjectID,
+			&payload, &ev.Hop, &ev.OccurredAt, &ev.Attempts, &ev.LastError, &ev.BatchID); err != nil {
+			return nil, fmt.Errorf("scan claimed outbox event: %w", err)
+		}
+		ev.Payload = []byte(payload)
+		out = append(out, ev)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate claimed outbox events: %w", err)
+	}
+	return out, nil
 }

--- a/internal/store/event_outbox.go
+++ b/internal/store/event_outbox.go
@@ -64,6 +64,11 @@ type OutboxEvent struct {
 	// Attempts and LastError are drain bookkeeping, populated on read.
 	Attempts  int
 	LastError string
+
+	// ClaimToken identifies the claim pass that holds this row, populated by
+	// ClaimPendingOutboxEvents. Ack and release are conditioned on it — see
+	// MarkOutboxDispatched.
+	ClaimToken string
 }
 
 // MutationOption tunes the event side of a store mutation. Nothing about the
@@ -303,7 +308,10 @@ type itemEventPayload struct {
 // user's identity stops being readable while the rows survive — but it reaches
 // only LIVE rows. A frozen payload keeps whatever it captured, so an assignee's
 // NAME AND EMAIL ADDRESS would remain legible in the outbox after the account
-// that owned them was deleted, and today nothing drains or prunes the table.
+// that owned them was deleted. TASK-2714 added the drain and both prunes, so
+// the window is now BOUNDED rather than unbounded — but bounded is not zero,
+// and an undelivered row keeps its payload for the whole max-age window, which
+// is why the scrub is still the thing doing the work here.
 //
 // THE RULE APPLIED, stated as the rule rather than as a proxy for it: remove
 // DIRECTLY IDENTIFYING personal data — a human name, an email address — and
@@ -890,16 +898,30 @@ func (s *Store) ListPendingOutboxEvents(limit int) ([]OutboxEvent, error) {
 	return out, nil
 }
 
-// MarkOutboxDispatched stamps events as delivered.
+// MarkOutboxDispatched stamps events as delivered, for the claim that holds
+// them.
 //
 // Called AFTER the surfaces have been handed the event, never before. The
 // ordering is what makes the guarantee at-least-once rather than at-most-once:
 // a crash between dispatch and this stamp re-delivers on the next drain, which
 // SPEC-3 §Delivery guarantees explicitly permits and consumers dedupe on the
 // event id.
-func (s *Store) MarkOutboxDispatched(ids []string) error {
+//
+// CONDITIONED ON THE CLAIM TOKEN, not just on the id. Delivery can outrun the
+// lease — a workspace with many slow endpoints is delivered sequentially, and
+// the "well under a minute" estimate behind the lease default is an estimate,
+// not a bound. Once the lease expires another instance may legitimately claim
+// the row; without this condition the first instance's late ack would then
+// stamp a row the second instance is mid-delivery on, and its late RELEASE
+// would clear a live claim, handing the same event to a third pass (codex
+// round 3). A stale ack now matches zero rows, which is exactly right: the
+// event is the new claim's problem.
+func (s *Store) MarkOutboxDispatched(claimToken string, ids []string) error {
 	if len(ids) == 0 {
 		return nil
+	}
+	if claimToken == "" {
+		return fmt.Errorf("mark outbox dispatched: no claim token")
 	}
 	ts := now()
 	tx, err := s.db.Begin()
@@ -910,8 +932,9 @@ func (s *Store) MarkOutboxDispatched(ids []string) error {
 
 	for _, id := range ids {
 		if _, err := tx.Exec(s.q(`
-			UPDATE event_outbox SET dispatched_at = ? WHERE id = ? AND dispatched_at IS NULL
-		`), ts, id); err != nil {
+			UPDATE event_outbox SET dispatched_at = ?
+			WHERE id = ? AND dispatched_at IS NULL AND claimed_by = ?
+		`), ts, id, claimToken); err != nil {
 			return fmt.Errorf("mark outbox dispatched %s: %w", id, err)
 		}
 	}
@@ -929,12 +952,19 @@ func (s *Store) MarkOutboxDispatched(ids []string) error {
 // until the lease times out would idle the row for the whole lease window for
 // no reason, and on a single-instance deployment that is the only reason it
 // would ever wait at all.
-func (s *Store) MarkOutboxAttemptFailed(id, reason string) error {
+//
+// Conditioned on the claim token for the same reason as MarkOutboxDispatched:
+// releasing a claim that is no longer yours would hand a live delivery's row
+// to another pass.
+func (s *Store) MarkOutboxAttemptFailed(claimToken, id, reason string) error {
+	if claimToken == "" {
+		return fmt.Errorf("mark outbox attempt failed: no claim token")
+	}
 	if _, err := s.db.Exec(s.q(`
 		UPDATE event_outbox
 		SET attempts = attempts + 1, last_error = ?, claimed_at = NULL, claimed_by = NULL
-		WHERE id = ? AND dispatched_at IS NULL
-	`), reason, id); err != nil {
+		WHERE id = ? AND dispatched_at IS NULL AND claimed_by = ?
+	`), reason, id, claimToken); err != nil {
 		return fmt.Errorf("mark outbox attempt failed %s: %w", id, err)
 	}
 	return nil
@@ -1202,6 +1232,7 @@ func (s *Store) outboxEventsClaimedBy(token string) ([]OutboxEvent, error) {
 			return nil, fmt.Errorf("scan claimed outbox event: %w", err)
 		}
 		ev.Payload = []byte(payload)
+		ev.ClaimToken = token
 		out = append(out, ev)
 	}
 	if err := rows.Err(); err != nil {
@@ -1302,9 +1333,13 @@ func (s *Store) EmitBulkHeaderEvent(workspaceID, batchID, op string, itemIDs []s
 // drain holds IS the answer — re-reading would quietly re-include members a
 // previous tick already delivered individually.
 //
-// Member payloads are embedded VERBATIM. They are already the exact snapshots
-// the single-item events carry, and re-marshalling them through a Go type here
-// would let the batch and single views of one mutation drift apart.
+// Member payloads are embedded VERBATIM — with ONE exception, named because
+// "verbatim" is the kind of word a reader takes literally: when two rows
+// describe the same item, dedupeMemberSnapshots re-encodes the survivor to
+// carry prior_status across (see mergePriorStatus). Non-duplicate members are
+// untouched bytes. Re-marshalling them all through a Go type would let the
+// batch and single views of one mutation drift apart, which is what the rule
+// is protecting.
 func FoldBulkHeader(header []byte, members [][]byte) ([]byte, error) {
 	var h bulkHeaderPayload
 	if err := json.Unmarshal(header, &h); err != nil {

--- a/internal/store/event_outbox.go
+++ b/internal/store/event_outbox.go
@@ -458,11 +458,12 @@ func (s *Store) emitMemberEventTx(tx *sql.Tx, eventType, workspaceID, userID, ro
 // member refs, the shared delta, and PER-MEMBER SNAPSHOTS.
 //
 // The per-member snapshots are not optional decoration. v1.1 makes wire
-// delivery batched but binding evaluation PER-MEMBER — the dispatcher runs
-// item-level selectors against each member snapshot — so a payload without
-// them would silently make bulk mutations invisible to every item.updated and
-// status_changed binding, which is the gap the batch event was admitted to
-// avoid rather than create.
+// delivery batched but binding evaluation PER-MEMBER: a future binding engine
+// (phase 2+; none exists today — nothing evaluates selectors yet, and the
+// webhook dispatcher only filters on event NAME) must be able to see each
+// member, and for a SINGLE-TRANSACTION bulk producer this payload is the only
+// place they exist. The handler-path producer solves the same problem
+// differently, by leaving each member its own canonical row.
 type bulkItemEventPayload struct {
 	// Delta describes what the one mutation did, shared across members
 	// (e.g. {"kind":"field_option_renamed","field":"status","from":"wip","to":"in-progress"}).
@@ -1304,8 +1305,47 @@ func FoldBulkHeader(header []byte, members [][]byte) ([]byte, error) {
 	if err := json.Unmarshal(header, &h); err != nil {
 		return nil, fmt.Errorf("fold bulk header: %w", err)
 	}
-	for _, m := range members {
+	for _, m := range dedupeMemberSnapshots(members) {
 		h.MemberSet = append(h.MemberSet, json.RawMessage(m))
 	}
 	return marshalEventPayload(h)
+}
+
+// dedupeMemberSnapshots keeps ONE snapshot per item — the last, which is the
+// latest state — preserving input order otherwise.
+//
+// One bulk member can write several rows: the disjoint-delta rule means a move
+// that also changes status emits item.moved AND item.status_changed, and a
+// mixed update emits status_changed AND item.updated. Appending every row
+// would put the same item in `members` two or three times while `count` and
+// `item_ids` reported the number of ITEMS, so the payload would contradict
+// itself (codex round 1).
+//
+// The member list answers "what do these items look like now", so duplicates
+// are not extra information — they are the same item at two points inside one
+// operation. The per-event view is still available in full: each of those rows
+// is its own canonical event for bindings; only the WIRE aggregate collapses.
+//
+// A snapshot whose id cannot be read is kept rather than dropped: it is real
+// data the drain does not understand, and silently discarding it would be a
+// worse answer than a duplicate.
+func dedupeMemberSnapshots(members [][]byte) [][]byte {
+	lastAt := map[string]int{}
+	out := make([][]byte, 0, len(members))
+	for _, m := range members {
+		var probe struct {
+			ID string `json:"id"`
+		}
+		if err := json.Unmarshal(m, &probe); err != nil || probe.ID == "" {
+			out = append(out, m)
+			continue
+		}
+		if at, seen := lastAt[probe.ID]; seen {
+			out[at] = m
+			continue
+		}
+		lastAt[probe.ID] = len(out)
+		out = append(out, m)
+	}
+	return out
 }

--- a/internal/store/event_outbox.go
+++ b/internal/store/event_outbox.go
@@ -1117,6 +1117,10 @@ func (s *Store) pendingClaimCandidates(limit int, leaseCutoff string) ([]string,
 
 	seen := map[string]bool{}
 	var ids []string
+	// Batches are collected as a SET: a 100-row candidate slice drawn from one
+	// large batch would otherwise run the same sibling scan 100 times for the
+	// same answer (codex round 2).
+	seenBatch := map[string]bool{}
 	var batches []string
 	for rows.Next() {
 		var id, batch string
@@ -1127,7 +1131,8 @@ func (s *Store) pendingClaimCandidates(limit int, leaseCutoff string) ([]string,
 			seen[id] = true
 			ids = append(ids, id)
 		}
-		if batch != "" {
+		if batch != "" && !seenBatch[batch] {
+			seenBatch[batch] = true
 			batches = append(batches, batch)
 		}
 	}
@@ -1329,6 +1334,14 @@ func FoldBulkHeader(header []byte, members [][]byte) ([]byte, error) {
 // A snapshot whose id cannot be read is kept rather than dropped: it is real
 // data the drain does not understand, and silently discarding it would be a
 // worse answer than a duplicate.
+//
+// LAST-WINS ON THE SNAPSHOT, BUT prior_status IS CARRIED FORWARD. The rows
+// being collapsed are not interchangeable: item.status_changed carries the
+// envelope pseudo-field prior_status and item.updated does not, so plain
+// last-wins would keep the later row and silently drop the transition — the
+// one piece of information a "nonterminal → terminal" binding needs, lost
+// exactly in the mixed update that produces both (codex round 2, on round 1's
+// own fix).
 func dedupeMemberSnapshots(members [][]byte) [][]byte {
 	lastAt := map[string]int{}
 	out := make([][]byte, 0, len(members))
@@ -1341,11 +1354,45 @@ func dedupeMemberSnapshots(members [][]byte) [][]byte {
 			continue
 		}
 		if at, seen := lastAt[probe.ID]; seen {
-			out[at] = m
+			out[at] = mergePriorStatus(out[at], m)
 			continue
 		}
 		lastAt[probe.ID] = len(out)
 		out = append(out, m)
 	}
 	return out
+}
+
+// mergePriorStatus returns next, with prev's prior_status restored when next
+// has none.
+//
+// Deliberately one key. The snapshots describe the same row at two points in
+// one operation, so every FIELD is fresher on next; prior_status is not a
+// field of the row at all — it is envelope metadata that only one of the two
+// events carries, which is why it needs carrying and nothing else does.
+//
+// On any decode failure this returns next unchanged: the merge is an
+// enhancement, and failing the whole fold over it would trade a missing key
+// for a missing event.
+func mergePriorStatus(prev, next []byte) []byte {
+	var prevMap, nextMap map[string]json.RawMessage
+	if err := json.Unmarshal(prev, &prevMap); err != nil {
+		return next
+	}
+	prior, had := prevMap["prior_status"]
+	if !had {
+		return next
+	}
+	if err := json.Unmarshal(next, &nextMap); err != nil {
+		return next
+	}
+	if _, present := nextMap["prior_status"]; present {
+		return next
+	}
+	nextMap["prior_status"] = prior
+	merged, err := json.Marshal(nextMap)
+	if err != nil {
+		return next
+	}
+	return merged
 }

--- a/internal/store/event_outbox.go
+++ b/internal/store/event_outbox.go
@@ -910,3 +910,52 @@ func (s *Store) PruneDispatchedOutbox(before string) (int64, error) {
 	}
 	return n, nil
 }
+
+// PruneUndispatchedOutbox deletes events that were never dispatched and are
+// older than the given timestamp, returning how many rows went.
+//
+// This one DROPS COMMITTED EVENTS, which is the opposite of everything else in
+// this file, so the reason has to be explicit rather than inferred from the
+// name.
+//
+// SPEC-3 makes payload privacy TEMPORAL: an outbox payload is a frozen
+// snapshot, and account deletion's de-identify posture reaches only live rows,
+// so a payload that never drains keeps whatever it captured for as long as the
+// row survives. PruneDispatchedOutbox cannot reach these — it filters on
+// dispatched_at IS NOT NULL — so without this, a row that can never be
+// delivered (a workspace whose only webhook was deleted, an endpoint that 4xxs
+// forever, an event whose surfaces all reject it) keeps its frozen payload
+// indefinitely. The retention window is what makes the privacy claim finite,
+// and a window only one of its two halves can close is not a window.
+//
+// So the trade is stated plainly: at-least-once delivery holds WITHIN the
+// retention window and not past it. That is why the caller's max-age must be
+// far larger than any retry schedule — the rows this reaches are ones no
+// further attempt would help, and the alternative to dropping them is keeping
+// user content in a table nothing will ever read.
+//
+// Deleting is deliberate rather than stamping them dispatched: a dispatched
+// stamp would be a lie in the durable record, and this table is the only
+// evidence of what the kernel emitted. A row that leaves is honestly absent; a
+// row marked delivered that never was would corrupt every later answer to "did
+// this mutation emit?".
+//
+// Callers log the count — an undispatchable event reaching its max age is a
+// delivery problem that has been failing for the whole window, and the number
+// is the only place it becomes visible.
+func (s *Store) PruneUndispatchedOutbox(before string) (int64, error) {
+	res, err := s.db.Exec(s.q(`
+		DELETE FROM event_outbox WHERE dispatched_at IS NULL AND occurred_at < ?
+	`), before)
+	if err != nil {
+		return 0, fmt.Errorf("prune undispatched outbox: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		// Advisory, exactly as in PruneDispatchedOutbox: the DELETE already
+		// succeeded, and reporting a count failure as a prune failure would
+		// make a caller retry a completed prune.
+		return 0, nil
+	}
+	return n, nil
+}

--- a/internal/store/event_outbox.go
+++ b/internal/store/event_outbox.go
@@ -852,6 +852,13 @@ func (s *Store) emitItemUpdateEventsTx(tx *sql.Tx, before, after *models.Item, s
 // break exists so the drain itself is deterministic when timestamps collide,
 // not so consumers can infer sequence.
 //
+// NOT THE DRAIN'S QUERY. The drain claims (ClaimPendingOutboxEvents) so that
+// multi-instance deployments do not deliver every row once per instance; this
+// unclaimed read survives as the DIAGNOSTIC view — "what is still owed?" — and
+// is what tests assert against. Said plainly because a reader finding two
+// pending-row readers should not have to guess which one production uses
+// (codex round 4).
+//
 // DELIBERATELY CROSS-WORKSPACE AND UNAUTHORIZED, which is safe only because of
 // who may call it. The drain is a single server-internal loop that must serve
 // every workspace in the instance; scoping it per workspace would mean asking
@@ -917,11 +924,15 @@ func (s *Store) ListPendingOutboxEvents(limit int) ([]OutboxEvent, error) {
 // round 3). A stale ack now matches zero rows, which is exactly right: the
 // event is the new claim's problem.
 func (s *Store) MarkOutboxDispatched(claimToken string, ids []string) error {
-	if len(ids) == 0 {
-		return nil
-	}
+	// TOKEN FIRST, then the empty-id short-circuit. The other order makes the
+	// refusal conditional on there being work to do, so a caller with no token
+	// gets nil for an empty list and an error otherwise — a contract that
+	// depends on the argument it is not about (codex round 4).
 	if claimToken == "" {
 		return fmt.Errorf("mark outbox dispatched: no claim token")
+	}
+	if len(ids) == 0 {
+		return nil
 	}
 	ts := now()
 	tx, err := s.db.Begin()
@@ -1025,13 +1036,24 @@ func (s *Store) PruneDispatchedOutbox(before string) (int64, error) {
 // row marked delivered that never was would corrupt every later answer to "did
 // this mutation emit?".
 //
+// LIVE CLAIMS ARE EXEMPT. Every instance runs retention, so without the
+// leaseCutoff condition one instance's prune could delete a row another is
+// mid-delivery on: the delivery would then succeed while the ack matched zero
+// rows, and a crash in that window loses an event the outbox had committed
+// (codex round 4). A row whose claim has expired is fair game — that is what
+// expiry means — so this is the same predicate the claim uses, applied to
+// deletion.
+//
 // Callers log the count — an undispatchable event reaching its max age is a
 // delivery problem that has been failing for the whole window, and the number
 // is the only place it becomes visible.
-func (s *Store) PruneUndispatchedOutbox(before string) (int64, error) {
+func (s *Store) PruneUndispatchedOutbox(before, leaseCutoff string) (int64, error) {
 	res, err := s.db.Exec(s.q(`
-		DELETE FROM event_outbox WHERE dispatched_at IS NULL AND occurred_at < ?
-	`), before)
+		DELETE FROM event_outbox
+		WHERE dispatched_at IS NULL
+		  AND occurred_at < ?
+		  AND (claimed_at IS NULL OR claimed_at < ?)
+	`), before, leaseCutoff)
 	if err != nil {
 		return 0, fmt.Errorf("prune undispatched outbox: %w", err)
 	}

--- a/internal/store/event_outbox.go
+++ b/internal/store/event_outbox.go
@@ -44,6 +44,17 @@ type OutboxEvent struct {
 	Hop         int
 	OccurredAt  string
 
+	// BatchID correlates every event of ONE handler-path bulk operation.
+	// Empty on every single-item mutation, which is almost all of them.
+	//
+	// SPEC-3 v1.5: the drain folds a batch into one wire item.bulk_updated
+	// while the member rows stay individually addressable for bindings. The
+	// correlation is RECORDED here rather than inferred at delivery, because
+	// a wire event saying "these five items changed together" is only true if
+	// something recorded that they did — grouping pending rows by a time
+	// window would fold two unrelated updates into somebody's bulk event.
+	BatchID string
+
 	// PayloadFamily is the shape the caller marshalled into Payload. It is a
 	// WRITE-SIDE assertion, checked against the taxonomy and never stored:
 	// the event name already determines the shape, so persisting it would
@@ -53,6 +64,40 @@ type OutboxEvent struct {
 	// Attempts and LastError are drain bookkeeping, populated on read.
 	Attempts  int
 	LastError string
+}
+
+// MutationOption tunes the event side of a store mutation. Nothing about the
+// mutation itself changes — these options exist so a CALLER that knows
+// something the store cannot (that this write is one member of a bulk
+// operation) can say so.
+//
+// Variadic rather than new required parameters: every existing call site is a
+// single-item mutation that has nothing to declare, and making all of them
+// pass a zero value would bury the one case that matters.
+type MutationOption func(*mutationOptions)
+
+type mutationOptions struct {
+	batchID string
+}
+
+// WithEventBatch marks every canonical event this mutation emits as a member
+// of the named batch.
+//
+// The caller mints the id per bulk OPERATION, not per item — that is the whole
+// content of the correlation. See the batch_id column comment (migration 082)
+// for why the drain cannot work this out for itself.
+func WithEventBatch(batchID string) MutationOption {
+	return func(o *mutationOptions) { o.batchID = batchID }
+}
+
+func newMutationOptions(opts []MutationOption) mutationOptions {
+	var o mutationOptions
+	for _, fn := range opts {
+		if fn != nil {
+			fn(&o)
+		}
+	}
+	return o
 }
 
 // maxOutboxHop is SPEC-3 §L5's synchronous cascade bound: a binding-triggered
@@ -197,9 +242,9 @@ func writeOutboxTx(tx *sql.Tx, s *Store, ev OutboxEvent) error {
 	ev.SubjectKind = kind
 
 	_, err := tx.Exec(s.q(`
-		INSERT INTO event_outbox (id, workspace_id, event_type, subject_kind, subject_id, payload, hop, occurred_at)
-		VALUES (?, ?, ?, ?, NULLIF(?, ''), ?, ?, ?)
-	`), ev.ID, ev.WorkspaceID, ev.EventType, ev.SubjectKind, ev.SubjectID, string(ev.Payload), ev.Hop, ev.OccurredAt)
+		INSERT INTO event_outbox (id, workspace_id, event_type, subject_kind, subject_id, payload, hop, occurred_at, batch_id)
+		VALUES (?, ?, ?, ?, NULLIF(?, ''), ?, ?, ?, NULLIF(?, ''))
+	`), ev.ID, ev.WorkspaceID, ev.EventType, ev.SubjectKind, ev.SubjectID, string(ev.Payload), ev.Hop, ev.OccurredAt, ev.BatchID)
 	if err != nil {
 		return fmt.Errorf("outbox: write %s: %w", ev.EventType, err)
 	}
@@ -304,7 +349,7 @@ func scrubItemPII(item *models.Item) *models.Item {
 // priorStatus is a POINTER so a transition from an empty prior status is
 // distinguishable from an event that has none — pass nil for every event other
 // than item.status_changed.
-func (s *Store) emitItemEventTx(tx *sql.Tx, eventType string, item *models.Item, priorStatus *string) error {
+func (s *Store) emitItemEventTx(tx *sql.Tx, eventType string, item *models.Item, priorStatus *string, batchID string) error {
 	if item == nil {
 		return fmt.Errorf("outbox: %s has no item snapshot", eventType)
 	}
@@ -319,6 +364,7 @@ func (s *Store) emitItemEventTx(tx *sql.Tx, eventType string, item *models.Item,
 		SubjectID:     item.ID,
 		Payload:       payload,
 		PayloadFamily: kernelevents.PayloadItemSnapshot,
+		BatchID:       batchID,
 	})
 }
 
@@ -767,12 +813,12 @@ func itemUpdatedSliceChanged(before, after *models.Item, statusKey string) (bool
 // branch on "was this a status update" — branching would drop the item.updated
 // half of every mixed update, silently, which is the shape of bug that
 // motivated the rule.
-func (s *Store) emitItemUpdateEventsTx(tx *sql.Tx, before, after *models.Item, statusChanged bool, priorStatus, statusKey string) error {
+func (s *Store) emitItemUpdateEventsTx(tx *sql.Tx, before, after *models.Item, statusChanged bool, priorStatus, statusKey, batchID string) error {
 	if statusChanged {
 		// Taken by address unconditionally: an empty prior status is a real
 		// prior status here, not an absent one.
 		prior := priorStatus
-		if err := s.emitItemEventTx(tx, kernelevents.ItemStatusChanged, after, &prior); err != nil {
+		if err := s.emitItemEventTx(tx, kernelevents.ItemStatusChanged, after, &prior, batchID); err != nil {
 			return err
 		}
 	}
@@ -782,7 +828,7 @@ func (s *Store) emitItemUpdateEventsTx(tx *sql.Tx, before, after *models.Item, s
 		return err
 	}
 	if otherChanged {
-		if err := s.emitItemEventTx(tx, kernelevents.ItemUpdated, after, nil); err != nil {
+		if err := s.emitItemEventTx(tx, kernelevents.ItemUpdated, after, nil, batchID); err != nil {
 			return err
 		}
 	}
@@ -815,7 +861,7 @@ func (s *Store) ListPendingOutboxEvents(limit int) ([]OutboxEvent, error) {
 		limit = 100
 	}
 	rows, err := s.db.Query(s.q(`
-		SELECT id, workspace_id, event_type, subject_kind, COALESCE(subject_id, ''), payload, hop, occurred_at, attempts, COALESCE(last_error, '')
+		SELECT id, workspace_id, event_type, subject_kind, COALESCE(subject_id, ''), payload, hop, occurred_at, attempts, COALESCE(last_error, ''), COALESCE(batch_id, '')
 		FROM event_outbox
 		WHERE dispatched_at IS NULL
 		ORDER BY occurred_at, id
@@ -831,7 +877,7 @@ func (s *Store) ListPendingOutboxEvents(limit int) ([]OutboxEvent, error) {
 		var ev OutboxEvent
 		var payload string
 		if err := rows.Scan(&ev.ID, &ev.WorkspaceID, &ev.EventType, &ev.SubjectKind, &ev.SubjectID,
-			&payload, &ev.Hop, &ev.OccurredAt, &ev.Attempts, &ev.LastError); err != nil {
+			&payload, &ev.Hop, &ev.OccurredAt, &ev.Attempts, &ev.LastError, &ev.BatchID); err != nil {
 			return nil, fmt.Errorf("scan outbox event: %w", err)
 		}
 		ev.Payload = []byte(payload)

--- a/internal/store/event_outbox.go
+++ b/internal/store/event_outbox.go
@@ -822,7 +822,15 @@ func itemUpdatedSliceChanged(before, after *models.Item, statusKey string) (bool
 // branch on "was this a status update" — branching would drop the item.updated
 // half of every mixed update, silently, which is the shape of bug that
 // motivated the rule.
-func (s *Store) emitItemUpdateEventsTx(tx *sql.Tx, before, after *models.Item, statusChanged bool, priorStatus, statusKey, batchID string) error {
+//
+// hierarchyChanged forces the item.updated half. The disjoint-delta diff
+// compares two SNAPSHOTS, and a parent-link write leaves nothing in a snapshot
+// to compare: items.parent_id is legacy and untouched, the link lives in its
+// own table, and seq/updated_at are excluded from the diff as metadata. So a
+// fields_patch carrying only `parent` mutated the row and emitted NOTHING
+// (codex round 5). The caller knows it performed a hierarchy write; the diff
+// cannot see it, and it must not have to.
+func (s *Store) emitItemUpdateEventsTx(tx *sql.Tx, before, after *models.Item, statusChanged bool, priorStatus, statusKey, batchID string, hierarchyChanged bool) error {
 	if statusChanged {
 		// Taken by address unconditionally: an empty prior status is a real
 		// prior status here, not an absent one.
@@ -836,7 +844,7 @@ func (s *Store) emitItemUpdateEventsTx(tx *sql.Tx, before, after *models.Item, s
 	if err != nil {
 		return err
 	}
-	if otherChanged {
+	if otherChanged || hierarchyChanged {
 		if err := s.emitItemEventTx(tx, kernelevents.ItemUpdated, after, nil, batchID); err != nil {
 			return err
 		}
@@ -1308,8 +1316,19 @@ func (s *Store) EmitBulkHeaderEvent(workspaceID, batchID, op string, itemIDs []s
 	if batchID == "" {
 		return fmt.Errorf("outbox: bulk header has no batch id")
 	}
-	// A bulk operation that changed nothing is not an event, same rule as the
-	// transactional bulk emitter.
+	// A bulk operation that TOUCHED nothing is not an event. Note the verb:
+	// this is an empty-member-list guard, not a semantic-change guard, and the
+	// difference is visible on the wire (codex rounds 1, 2 and 5 each raised
+	// it). The caller passes every row it mutated without error, which
+	// includes rows where the mutation was a no-op — untagging a tag nobody
+	// has — and the store emits member events only for real changes. So a
+	// header can arrive with a count and no members.
+	//
+	// Left as-is deliberately: the hand-called webhook this replaced fired on
+	// exactly the same condition with exactly the same count (verified against
+	// origin/main), so narrowing it now would be a silent wire change to
+	// `count` and `item_ids` rather than a bug fix. It belongs with a contract
+	// version.
 	if len(itemIDs) == 0 {
 		return nil
 	}

--- a/internal/store/event_outbox.go
+++ b/internal/store/event_outbox.go
@@ -146,8 +146,8 @@ func writeOutboxTx(tx *sql.Tx, s *Store, ev OutboxEvent) error {
 	// a ref-only deletion payload and the write would be accepted (Codex round
 	// 10). Pairing them here means an event and a payload that were not meant
 	// for each other cannot reach the table at all.
-	want, known := kernelevents.PayloadFamily(ev.EventType)
-	if !known || want == "" {
+	want, known := kernelevents.PayloadFamilies(ev.EventType)
+	if !known || len(want) == 0 {
 		// FAIL CLOSED on an event the taxonomy cannot describe. Discarding the
 		// ok meant an unknown family resolved to "", which a caller declaring
 		// nothing would then MATCH — the check passing precisely when it had
@@ -162,8 +162,8 @@ func writeOutboxTx(tx *sql.Tx, s *Store, ev OutboxEvent) error {
 		// stays as the guard for a future table that separates the two again.
 		return fmt.Errorf("outbox: event %s has no declared payload family", ev.EventType)
 	}
-	if ev.PayloadFamily != want {
-		return fmt.Errorf("outbox: event %s carries a %q payload, want %q",
+	if !kernelevents.AllowsPayload(ev.EventType, ev.PayloadFamily) {
+		return fmt.Errorf("outbox: event %s carries a %q payload, want one of %v",
 			ev.EventType, ev.PayloadFamily, want)
 	}
 	if len(ev.Payload) == 0 {
@@ -1202,4 +1202,110 @@ func (s *Store) outboxEventsClaimedBy(token string) ([]OutboxEvent, error) {
 		return nil, fmt.Errorf("iterate claimed outbox events: %w", err)
 	}
 	return out, nil
+}
+
+// bulkHeaderPayload is the handler-path batch HEADER: what the operation was,
+// which items it touched, and the delta they share.
+//
+// The three legacy keys (op / count / item_ids) are the shape today's webhook
+// consumers already receive, kept verbatim so the drain's arrival is not also
+// a payload rename. batch_id and delta are additions: batch_id because
+// multi-instance claiming can in principle split one operation across two wire
+// events and a consumer needs to correlate them (SPEC-3 v1.6 demotes "one wire
+// event per batch" to the normal case for exactly this reason), and delta
+// because SPEC-3's item_batch payload names it and the handler is the only
+// place that knows it.
+//
+// NO SNAPSHOTS HERE. They live on the member rows until the drain folds them
+// in — which is the honest shape, not a gap: at header-write time the loop has
+// already committed each member's own event, and re-reading every row to
+// duplicate them into the header would double the storage for the same facts
+// and give the two copies a chance to disagree.
+type bulkHeaderPayload struct {
+	BatchID   string            `json:"batch_id"`
+	Op        string            `json:"op"`
+	Count     int               `json:"count"`
+	ItemIDs   []string          `json:"item_ids"`
+	Delta     map[string]any    `json:"delta,omitempty"`
+	MemberSet []json.RawMessage `json:"members,omitempty"`
+}
+
+// EmitBulkHeaderEvent writes the batch header for one handler-path bulk
+// operation, in its own transaction after the member loop.
+//
+// WHY THIS IS NOT A TRANSACTIONAL EMIT, said plainly because the rest of this
+// file argues the opposite for everything else: a handler-path bulk mutation
+// has no enclosing transaction to write it in. Each member committed
+// separately, carrying its own canonical event, and that is what keeps
+// per-member binding evaluation free. The header is delivery-side aggregation
+// (SPEC-3 v1.6), and its failure mode is bounded accordingly — if the process
+// dies between the members committing and this landing, the members simply
+// deliver individually. A flood in the crash case, never a loss.
+//
+// Single-workspace by construction: the bulk endpoint is workspace-scoped, so
+// unlike emitBulkItemEventTx there is no member set that could span workspaces
+// and nothing to partition.
+func (s *Store) EmitBulkHeaderEvent(workspaceID, batchID, op string, itemIDs []string, delta map[string]any) error {
+	if batchID == "" {
+		return fmt.Errorf("outbox: bulk header has no batch id")
+	}
+	// A bulk operation that changed nothing is not an event, same rule as the
+	// transactional bulk emitter.
+	if len(itemIDs) == 0 {
+		return nil
+	}
+	payload, err := marshalEventPayload(bulkHeaderPayload{
+		BatchID: batchID,
+		Op:      op,
+		Count:   len(itemIDs),
+		ItemIDs: itemIDs,
+		Delta:   delta,
+	})
+	if err != nil {
+		return err
+	}
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("emit bulk header: %w", err)
+	}
+	defer tx.Rollback()
+	if err := writeOutboxTx(tx, s, OutboxEvent{
+		WorkspaceID:   workspaceID,
+		EventType:     kernelevents.ItemBulkUpdated,
+		SubjectID:     batchID,
+		Payload:       payload,
+		PayloadFamily: kernelevents.PayloadItemBatchHeader,
+		BatchID:       batchID,
+	}); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("emit bulk header: %w", err)
+	}
+	return nil
+}
+
+// FoldBulkHeader returns the wire payload for a folded batch: the stored
+// header enriched with the member snapshots the drain claimed alongside it.
+//
+// The fold lives here, next to the shape it produces, so the drain does not
+// have to know how a header is spelled. It takes the members it was GIVEN
+// rather than reading them back: SPEC-3 v1.6 defines the fold as "header plus
+// whatever member rows of that batch are still undispatched", so the set the
+// drain holds IS the answer — re-reading would quietly re-include members a
+// previous tick already delivered individually.
+//
+// Member payloads are embedded VERBATIM. They are already the exact snapshots
+// the single-item events carry, and re-marshalling them through a Go type here
+// would let the batch and single views of one mutation drift apart.
+func FoldBulkHeader(header []byte, members [][]byte) ([]byte, error) {
+	var h bulkHeaderPayload
+	if err := json.Unmarshal(header, &h); err != nil {
+		return nil, fmt.Errorf("fold bulk header: %w", err)
+	}
+	for _, m := range members {
+		h.MemberSet = append(h.MemberSet, json.RawMessage(m))
+	}
+	return marshalEventPayload(h)
 }

--- a/internal/store/event_outbox_test.go
+++ b/internal/store/event_outbox_test.go
@@ -2255,3 +2255,90 @@ func TestOutbox_ParentOnlyUpdateStillEmits(t *testing.T) {
 		t.Errorf("a no-op update emitted %v, want nothing", got)
 	}
 }
+
+// TestOutbox_ParentDetachEmitsOnEveryRoute closes the loop codex round 6
+// opened: attach was observable on every route while DETACH was silent on two
+// of the three, so a consumer's model kept a parent the user had removed.
+//
+// The routes are enumerated rather than sampled (CONVE-18): ClearParentLink
+// (its own transaction), UpdateItemWithParentLink with an empty parent (the
+// item-update transaction), and DeleteItemLink on the parent link row (the
+// links handler's route).
+func TestOutbox_ParentDetachEmitsOnEveryRoute(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Outbox detach")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+
+	attach := func(t *testing.T, child, parent string) {
+		t.Helper()
+		if _, err := s.SetParentLink(ws.ID, child, parent, "user"); err != nil {
+			t.Fatalf("SetParentLink: %v", err)
+		}
+		clearOutbox(t, s)
+	}
+
+	t.Run("ClearParentLink", func(t *testing.T) {
+		parent := createTestItem(t, s, ws.ID, col.ID, "P1", "")
+		child := createTestItem(t, s, ws.ID, col.ID, "C1", "")
+		attach(t, child.ID, parent.ID)
+
+		if err := s.ClearParentLink(child.ID); err != nil {
+			t.Fatalf("ClearParentLink: %v", err)
+		}
+		if got := outboxEventsFor(t, s, child.ID); len(got) != 1 || got[0] != kernelevents.ItemUpdated {
+			t.Fatalf("events = %v, want exactly [%s]", got, kernelevents.ItemUpdated)
+		}
+
+		// A SECOND clear removes nothing, so it must emit nothing — the
+		// "provided is not changed" half of round 6.
+		clearOutbox(t, s)
+		if err := s.ClearParentLink(child.ID); err != nil {
+			t.Fatalf("ClearParentLink (already unparented): %v", err)
+		}
+		if got := outboxEventsFor(t, s, child.ID); len(got) != 0 {
+			t.Errorf("clearing an already-unparented item emitted %v — an event for a mutation that did not happen", got)
+		}
+	})
+
+	t.Run("UpdateItemWithParentLink clear", func(t *testing.T) {
+		parent := createTestItem(t, s, ws.ID, col.ID, "P2", "")
+		child := createTestItem(t, s, ws.ID, col.ID, "C2", "")
+		attach(t, child.ID, parent.ID)
+
+		if _, err := s.UpdateItemWithParentLink(child.ID, models.ItemUpdate{}, nil, &ParentLinkUpdate{
+			Provided: true, WorkspaceID: ws.ID, CreatedBy: "user",
+		}); err != nil {
+			t.Fatalf("UpdateItemWithParentLink: %v", err)
+		}
+		if got := outboxEventsFor(t, s, child.ID); len(got) != 1 || got[0] != kernelevents.ItemUpdated {
+			t.Fatalf("events = %v, want exactly [%s]", got, kernelevents.ItemUpdated)
+		}
+
+		clearOutbox(t, s)
+		if _, err := s.UpdateItemWithParentLink(child.ID, models.ItemUpdate{}, nil, &ParentLinkUpdate{
+			Provided: true, WorkspaceID: ws.ID, CreatedBy: "user",
+		}); err != nil {
+			t.Fatalf("UpdateItemWithParentLink (already unparented): %v", err)
+		}
+		if got := outboxEventsFor(t, s, child.ID); len(got) != 0 {
+			t.Errorf("a no-op clear through the update path emitted %v", got)
+		}
+	})
+
+	t.Run("DeleteItemLink on the parent row", func(t *testing.T) {
+		parent := createTestItem(t, s, ws.ID, col.ID, "P3", "")
+		child := createTestItem(t, s, ws.ID, col.ID, "C3", "")
+		link, err := s.SetParentLink(ws.ID, child.ID, parent.ID, "user")
+		if err != nil {
+			t.Fatalf("SetParentLink: %v", err)
+		}
+		clearOutbox(t, s)
+
+		if err := s.DeleteItemLink(link.ID); err != nil {
+			t.Fatalf("DeleteItemLink: %v", err)
+		}
+		if got := outboxEventsFor(t, s, child.ID); len(got) != 1 || got[0] != kernelevents.ItemUpdated {
+			t.Fatalf("events = %v, want exactly [%s]", got, kernelevents.ItemUpdated)
+		}
+	})
+}

--- a/internal/store/event_outbox_test.go
+++ b/internal/store/event_outbox_test.go
@@ -1375,23 +1375,23 @@ func TestCanonicalEventsAreFullyDeclared(t *testing.T) {
 	// The events/1 set at SPEC-3 v1.4. Adding, removing or re-homing an entry
 	// here is a CONTRACT CHANGE: update the spec version and the taxonomy's
 	// doc comment in the same commit.
-	want := map[string]struct{ subject, family string }{
-		"item.created":        {kernelevents.SubjectItem, kernelevents.PayloadItemSnapshot},
-		"item.updated":        {kernelevents.SubjectItem, kernelevents.PayloadItemSnapshot},
-		"item.status_changed": {kernelevents.SubjectItem, kernelevents.PayloadItemSnapshot},
-		"item.moved":          {kernelevents.SubjectItem, kernelevents.PayloadItemSnapshot},
-		"item.deleted":        {kernelevents.SubjectItem, kernelevents.PayloadItemSnapshot},
-		"item.restored":       {kernelevents.SubjectItem, kernelevents.PayloadItemSnapshot},
-		"item.bulk_updated":   {kernelevents.SubjectItemBatch, kernelevents.PayloadItemBatch},
-		"comment.created":     {kernelevents.SubjectComment, kernelevents.PayloadCommentSnapshot},
-		"comment.updated":     {kernelevents.SubjectComment, kernelevents.PayloadCommentSnapshot},
-		"comment.deleted":     {kernelevents.SubjectComment, kernelevents.PayloadRefOnly},
-		"attachment.added":    {kernelevents.SubjectAttachment, kernelevents.PayloadAttachmentSnapshot},
-		"attachment.removed":  {kernelevents.SubjectAttachment, kernelevents.PayloadRefOnly},
-		"member.joined":       {kernelevents.SubjectMember, kernelevents.PayloadMember},
-		"pack.installed":      {kernelevents.SubjectPack, kernelevents.PayloadPack},
-		"pack.upgraded":       {kernelevents.SubjectPack, kernelevents.PayloadPack},
-		"pack.disabled":       {kernelevents.SubjectPack, kernelevents.PayloadPack},
+	want := map[string]struct{ subject, family, sse string }{
+		"item.created":        {kernelevents.SubjectItem, kernelevents.PayloadItemSnapshot, "item_created"},
+		"item.updated":        {kernelevents.SubjectItem, kernelevents.PayloadItemSnapshot, "item_updated"},
+		"item.status_changed": {kernelevents.SubjectItem, kernelevents.PayloadItemSnapshot, "item_updated"},
+		"item.moved":          {kernelevents.SubjectItem, kernelevents.PayloadItemSnapshot, "item_updated"},
+		"item.deleted":        {kernelevents.SubjectItem, kernelevents.PayloadItemSnapshot, "item_archived"},
+		"item.restored":       {kernelevents.SubjectItem, kernelevents.PayloadItemSnapshot, "item_restored"},
+		"item.bulk_updated":   {kernelevents.SubjectItemBatch, kernelevents.PayloadItemBatch, "items_bulk_updated"},
+		"comment.created":     {kernelevents.SubjectComment, kernelevents.PayloadCommentSnapshot, "comment_created"},
+		"comment.updated":     {kernelevents.SubjectComment, kernelevents.PayloadCommentSnapshot, "comment_updated"},
+		"comment.deleted":     {kernelevents.SubjectComment, kernelevents.PayloadRefOnly, "comment_deleted"},
+		"attachment.added":    {kernelevents.SubjectAttachment, kernelevents.PayloadAttachmentSnapshot, ""},
+		"attachment.removed":  {kernelevents.SubjectAttachment, kernelevents.PayloadRefOnly, ""},
+		"member.joined":       {kernelevents.SubjectMember, kernelevents.PayloadMember, ""},
+		"pack.installed":      {kernelevents.SubjectPack, kernelevents.PayloadPack, ""},
+		"pack.upgraded":       {kernelevents.SubjectPack, kernelevents.PayloadPack, ""},
+		"pack.disabled":       {kernelevents.SubjectPack, kernelevents.PayloadPack, ""},
 	}
 
 	// The name constants are pinned to their wire strings separately, because
@@ -1444,6 +1444,17 @@ func TestCanonicalEventsAreFullyDeclared(t *testing.T) {
 		if !kernelevents.IsCanonical(name) {
 			t.Errorf("IsCanonical(%q) = false for an event Canonical() returned", name)
 		}
+		// The SSE surface name, including the events that deliberately have
+		// none. An empty want.sse asserts SILENCE — SurfaceSSE must report
+		// false rather than handing back a name a caller would publish under.
+		sse, sseOK := kernelevents.SurfaceSSE(name)
+		if expected.sse == "" {
+			if sseOK || sse != "" {
+				t.Errorf("SurfaceSSE(%q) = (%q, %v), want (\"\", false) — this event has no SSE surface", name, sse, sseOK)
+			}
+		} else if !sseOK || sse != expected.sse {
+			t.Errorf("SurfaceSSE(%q) = (%q, %v), want (%q, true)", name, sse, sseOK, expected.sse)
+		}
 	}
 	for name := range want {
 		if !seen[name] {
@@ -1463,6 +1474,9 @@ func TestCanonicalEventsAreFullyDeclared(t *testing.T) {
 		}
 		if kernelevents.IsCanonical(name) {
 			t.Errorf("IsCanonical(%q) = true", name)
+		}
+		if _, ok := kernelevents.SurfaceSSE(name); ok {
+			t.Errorf("SurfaceSSE(%q) reported ok for a non-canonical name", name)
 		}
 	}
 }

--- a/internal/store/event_outbox_test.go
+++ b/internal/store/event_outbox_test.go
@@ -1570,7 +1570,8 @@ func TestOutbox_PruneUndispatchedBoundsTheFrozenPayloadWindow(t *testing.T) {
 	}
 
 	cutoff := time.Now().UTC().Add(-24 * time.Hour).Format(time.RFC3339)
-	n, err := s.PruneUndispatchedOutbox(cutoff)
+	liveClaim := time.Now().UTC().Add(-5 * time.Minute).Format(time.RFC3339)
+	n, err := s.PruneUndispatchedOutbox(cutoff, liveClaim)
 	if err != nil {
 		t.Fatalf("PruneUndispatchedOutbox: %v", err)
 	}
@@ -2084,5 +2085,47 @@ func TestOutbox_StaleClaimCannotAckOrReleaseAnotherPass(t *testing.T) {
 	}
 	if pending, err := s.ListPendingOutboxEvents(10); err != nil || len(pending) != 0 {
 		t.Errorf("live ack left %d pending (err %v)", len(pending), err)
+	}
+}
+
+// TestOutbox_PruneUndispatchedSparesAClaimedRow: every instance runs
+// retention, so without a claim check one instance's prune deletes a row
+// another is mid-delivery on — the delivery then succeeds while the ack
+// matches zero rows, and a crash in that window loses an event the outbox had
+// already committed (codex round 4).
+func TestOutbox_PruneUndispatchedSparesAClaimedRow(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Outbox prune vs claim")
+	clearOutbox(t, s)
+
+	old := time.Now().UTC().Add(-72 * time.Hour).Format(time.RFC3339)
+	insertOutboxRow(t, s, "a-claimed", ws.ID, old, nil)
+	insertOutboxRow(t, s, "b-unclaimed", ws.ID, old, nil)
+
+	live := time.Now().UTC().Add(-5 * time.Minute).Format(time.RFC3339)
+	// Claim only the first row, by asking for exactly one.
+	claimed, err := s.ClaimPendingOutboxEvents("instance-1", 1, live)
+	if err != nil || len(claimed) != 1 || claimed[0].ID != "a-claimed" {
+		t.Fatalf("claim = %v, %v; want exactly a-claimed", claimedIDs(claimed), err)
+	}
+
+	cutoff := time.Now().UTC().Add(-24 * time.Hour).Format(time.RFC3339)
+	n, err := s.PruneUndispatchedOutbox(cutoff, live)
+	if err != nil {
+		t.Fatalf("PruneUndispatchedOutbox: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("pruned %d rows, want 1 — the claimed row must survive and the unclaimed one must not", n)
+	}
+	got := outboxRowIDs(t, s)
+	if len(got) != 1 || got[0] != "a-claimed" {
+		t.Fatalf("survivors = %v, want [a-claimed]", got)
+	}
+
+	// An EXPIRED claim is fair game — that is what expiry means — so the
+	// exemption is about live deliveries, not about claimed rows forever.
+	expired := time.Now().UTC().Add(time.Minute).Format(time.RFC3339)
+	if n, err := s.PruneUndispatchedOutbox(cutoff, expired); err != nil || n != 1 {
+		t.Errorf("prune with an expired lease removed %d rows (err %v), want 1", n, err)
 	}
 }

--- a/internal/store/event_outbox_test.go
+++ b/internal/store/event_outbox_test.go
@@ -1920,3 +1920,59 @@ func sameStrings(got, want []string) bool {
 	}
 	return true
 }
+
+// TestFoldBulkHeader_KeepsOneSnapshotPerItem pins the fold's answer to the
+// disjoint-delta rule: one bulk member can write several rows (a move that
+// also changes status emits item.moved AND item.status_changed), and the
+// folded payload reports `count` in ITEMS.
+//
+// Without dedup the members list disagrees with the count in the same
+// payload — the wire event contradicting itself (codex round 1).
+func TestFoldBulkHeader_KeepsOneSnapshotPerItem(t *testing.T) {
+	header := []byte(`{"batch_id":"b1","op":"move","count":2,"item_ids":["i1","i2"]}`)
+	members := [][]byte{
+		[]byte(`{"id":"i1","status":"open"}`),
+		[]byte(`{"id":"i2","status":"open"}`),
+		[]byte(`{"id":"i1","status":"done"}`),
+		[]byte(`{"id":"i2","status":"done"}`),
+	}
+
+	folded, err := FoldBulkHeader(header, members)
+	if err != nil {
+		t.Fatalf("FoldBulkHeader: %v", err)
+	}
+	var got struct {
+		Count   int `json:"count"`
+		Members []struct {
+			ID     string `json:"id"`
+			Status string `json:"status"`
+		} `json:"members"`
+	}
+	if err := json.Unmarshal(folded, &got); err != nil {
+		t.Fatalf("decode folded: %v", err)
+	}
+	if len(got.Members) != got.Count {
+		t.Fatalf("members = %d but count = %d — the payload contradicts itself", len(got.Members), got.Count)
+	}
+	for _, m := range got.Members {
+		if m.Status != "done" {
+			t.Errorf("member %s carries status %q, want the LAST snapshot (done)", m.ID, m.Status)
+		}
+	}
+
+	// A snapshot the drain cannot read is kept, not dropped: it is real data,
+	// and discarding it silently would be worse than a duplicate.
+	odd, err := FoldBulkHeader(header, [][]byte{[]byte(`"not an object"`), []byte(`{"id":"i1"}`)})
+	if err != nil {
+		t.Fatalf("FoldBulkHeader (unreadable member): %v", err)
+	}
+	var oddGot struct {
+		Members []json.RawMessage `json:"members"`
+	}
+	if err := json.Unmarshal(odd, &oddGot); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(oddGot.Members) != 2 {
+		t.Errorf("members = %d, want both kept", len(oddGot.Members))
+	}
+}

--- a/internal/store/event_outbox_test.go
+++ b/internal/store/event_outbox_test.go
@@ -2177,8 +2177,17 @@ func TestOutbox_SetParentLinkEmitsItemUpdated(t *testing.T) {
 	if int64(seq) <= createdSeq {
 		t.Errorf("event carries seq %d, want later than the create's %d — this is the pre-link snapshot", int64(seq), createdSeq)
 	}
-	if payload["is_unparented"] == true {
-		t.Error("event says the child is unparented, i.e. it describes the state before the link it is reporting")
+	// AND WHAT IT DOES NOT CARRY, asserted rather than left implied. Round 4's
+	// version of this test checked is_unparented and passed vacuously: that
+	// field is populated only by the local-first index queries, so it is
+	// absent from every event payload and "not true" was satisfied by nil.
+	// The parent EDGE is not in an item snapshot on any path — items.parent_id
+	// is legacy and untouched by SetParentLink — and it was not in the
+	// hand-called webhook this replaced either, which dispatched the same
+	// scan. The event's content is the ROW CHANGE; pinning that here stops the
+	// next reader inferring linkage data that has never been on this wire.
+	if _, present := payload["is_unparented"]; present {
+		t.Error("payload carries is_unparented; the assertions here assume item snapshots never do")
 	}
 
 	// The PARENT's row is untouched by this write, so it emits nothing — the
@@ -2186,5 +2195,63 @@ func TestOutbox_SetParentLinkEmitsItemUpdated(t *testing.T) {
 	// about "some event fired".
 	if got := outboxEventsFor(t, s, parent.ID); len(got) != 0 {
 		t.Errorf("parent emitted %v; the link does not write the parent's row", got)
+	}
+}
+
+// TestOutbox_ParentOnlyUpdateStillEmits covers the path SetParentLink's fix
+// did NOT reach (codex round 5): UpdateItemWithParentLink writes the hierarchy
+// inside the item-update transaction and emits from a SNAPSHOT DIFF, and a
+// parent write leaves nothing in a snapshot to diff — items.parent_id is
+// legacy and untouched, the link lives in its own table, and seq/updated_at
+// are excluded as metadata.
+//
+// So a fields_patch carrying only `parent` mutated the row and emitted
+// nothing. The same criterion that made SetParentLink emit applies here; the
+// difference is only which transaction does the write.
+func TestOutbox_ParentOnlyUpdateStillEmits(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Outbox parent-only update")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+
+	parent := createTestItem(t, s, ws.ID, col.ID, "Parent", "")
+	child := createTestItem(t, s, ws.ID, col.ID, "Child", "")
+	clearOutbox(t, s)
+
+	// No field changes at all — only the hierarchy.
+	if _, err := s.UpdateItemWithParentLink(child.ID, models.ItemUpdate{}, nil, &ParentLinkUpdate{
+		Provided:    true,
+		WorkspaceID: ws.ID,
+		ParentID:    parent.ID,
+		CreatedBy:   "user",
+	}); err != nil {
+		t.Fatalf("UpdateItemWithParentLink: %v", err)
+	}
+
+	if got := outboxEventsFor(t, s, child.ID); len(got) != 1 || got[0] != kernelevents.ItemUpdated {
+		t.Fatalf("events after a parent-only update = %v, want exactly [%s]", got, kernelevents.ItemUpdated)
+	}
+
+	// A CLEAR is the same mutation in the other direction and must also emit.
+	clearOutbox(t, s)
+	if _, err := s.UpdateItemWithParentLink(child.ID, models.ItemUpdate{}, nil, &ParentLinkUpdate{
+		Provided:    true,
+		WorkspaceID: ws.ID,
+		CreatedBy:   "user",
+	}); err != nil {
+		t.Fatalf("UpdateItemWithParentLink (clear): %v", err)
+	}
+	if got := outboxEventsFor(t, s, child.ID); len(got) != 1 || got[0] != kernelevents.ItemUpdated {
+		t.Fatalf("events after a parent CLEAR = %v, want exactly [%s]", got, kernelevents.ItemUpdated)
+	}
+
+	// CONTROL: an update with no hierarchy write and no field change still
+	// emits nothing. Without this the fix could be "always emit", which would
+	// undo the disjoint-delta rule's whole point.
+	clearOutbox(t, s)
+	if _, err := s.UpdateItemWithParentLink(child.ID, models.ItemUpdate{}, nil, nil); err != nil {
+		t.Fatalf("UpdateItemWithParentLink (no-op): %v", err)
+	}
+	if got := outboxEventsFor(t, s, child.ID); len(got) != 0 {
+		t.Errorf("a no-op update emitted %v, want nothing", got)
 	}
 }

--- a/internal/store/event_outbox_test.go
+++ b/internal/store/event_outbox_test.go
@@ -1565,3 +1565,127 @@ func TestOutbox_PruneUndispatchedBoundsTheFrozenPayloadWindow(t *testing.T) {
 		}
 	}
 }
+
+// outboxBatchIDsFor returns the batch_id of every event recorded for an item.
+func outboxBatchIDsFor(t *testing.T, s *Store, itemID string) []string {
+	t.Helper()
+	rows, err := s.db.Query(s.q(`SELECT COALESCE(batch_id, '') FROM event_outbox WHERE subject_id = ? ORDER BY occurred_at, id`), itemID)
+	if err != nil {
+		t.Fatalf("query batch ids: %v", err)
+	}
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var b string
+		if err := rows.Scan(&b); err != nil {
+			t.Fatalf("scan batch_id: %v", err)
+		}
+		out = append(out, b)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate batch ids: %v", err)
+	}
+	return out
+}
+
+// TestOutbox_WithEventBatchStampsEveryMutationPath drives ALL FIVE store entry
+// points the bulk handler reaches, because the failure this guards against is
+// per-method: a signature that accepts the option and never threads it to the
+// emit compiles, passes every other test, and silently un-batches one of the
+// six bulk verbs.
+//
+// The population is enumerated rather than sampled (CONVE-18): archive
+// (DeleteItem), restore (RestoreItem), move (MoveItemWithPreCheck), field
+// update (UpdateItemWithPreCheck) and assign (UpdateItem) are the complete set
+// of mutating store calls handlers_items_bulk.go makes. My own escalation said
+// four; it was five, and restore was the one missing.
+//
+// Each leg asserts the unstamped control too. Without it the test would pass
+// for an implementation that stamped every event ever written.
+func TestOutbox_WithEventBatchStampsEveryMutationPath(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Outbox batch")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+	other := createTestCollection(t, s, ws.ID, "Done")
+
+	const batch = "batch-42"
+
+	assertBatch := func(t *testing.T, itemID, want string) {
+		t.Helper()
+		got := outboxBatchIDsFor(t, s, itemID)
+		if len(got) == 0 {
+			t.Fatalf("no outbox rows for %s — the mutation emitted nothing, so the batch assertion proves nothing", itemID)
+		}
+		for _, b := range got {
+			if b != want {
+				t.Errorf("batch ids = %v, want every row stamped %q", got, want)
+				return
+			}
+		}
+	}
+
+	t.Run("DeleteItem", func(t *testing.T) {
+		batched := createTestItem(t, s, ws.ID, col.ID, "Archived in a batch", "")
+		clearOutbox(t, s)
+		if err := s.DeleteItem(batched.ID, WithEventBatch(batch)); err != nil {
+			t.Fatalf("DeleteItem: %v", err)
+		}
+		assertBatch(t, batched.ID, batch)
+
+		solo := createTestItem(t, s, ws.ID, col.ID, "Archived alone", "")
+		clearOutbox(t, s)
+		if err := s.DeleteItem(solo.ID); err != nil {
+			t.Fatalf("DeleteItem (control): %v", err)
+		}
+		assertBatch(t, solo.ID, "")
+	})
+
+	t.Run("RestoreItem", func(t *testing.T) {
+		item := createTestItem(t, s, ws.ID, col.ID, "Restored in a batch", "")
+		if err := s.DeleteItem(item.ID); err != nil {
+			t.Fatalf("DeleteItem: %v", err)
+		}
+		clearOutbox(t, s)
+		if _, err := s.RestoreItem(item.ID, WithEventBatch(batch)); err != nil {
+			t.Fatalf("RestoreItem: %v", err)
+		}
+		assertBatch(t, item.ID, batch)
+	})
+
+	t.Run("MoveItemWithPreCheck", func(t *testing.T) {
+		item := createTestItem(t, s, ws.ID, col.ID, "Moved in a batch", "")
+		clearOutbox(t, s)
+		if _, err := s.MoveItemWithPreCheck(item.ID, other.ID, "{}", nil, WithEventBatch(batch)); err != nil {
+			t.Fatalf("MoveItemWithPreCheck: %v", err)
+		}
+		assertBatch(t, item.ID, batch)
+	})
+
+	t.Run("UpdateItemWithPreCheck", func(t *testing.T) {
+		item := createTestItem(t, s, ws.ID, col.ID, "Field-updated in a batch", "")
+		clearOutbox(t, s)
+		title := "Field-updated in a batch, renamed"
+		if _, err := s.UpdateItemWithPreCheck(item.ID, models.ItemUpdate{Title: &title}, nil, WithEventBatch(batch)); err != nil {
+			t.Fatalf("UpdateItemWithPreCheck: %v", err)
+		}
+		assertBatch(t, item.ID, batch)
+	})
+
+	t.Run("UpdateItem", func(t *testing.T) {
+		item := createTestItem(t, s, ws.ID, col.ID, "Assigned in a batch", "")
+		clearOutbox(t, s)
+		title := "Assigned in a batch, renamed"
+		if _, err := s.UpdateItem(item.ID, models.ItemUpdate{Title: &title}, WithEventBatch(batch)); err != nil {
+			t.Fatalf("UpdateItem: %v", err)
+		}
+		assertBatch(t, item.ID, batch)
+
+		solo := createTestItem(t, s, ws.ID, col.ID, "Assigned alone", "")
+		clearOutbox(t, s)
+		soloTitle := "Assigned alone, renamed"
+		if _, err := s.UpdateItem(solo.ID, models.ItemUpdate{Title: &soloTitle}); err != nil {
+			t.Fatalf("UpdateItem (control): %v", err)
+		}
+		assertBatch(t, solo.ID, "")
+	})
+}

--- a/internal/store/event_outbox_test.go
+++ b/internal/store/event_outbox_test.go
@@ -1351,27 +1351,109 @@ func TestWriteOutboxTx_RejectsMismatchedPayloadFamily(t *testing.T) {
 	}
 }
 
-// TestCanonicalEventsAreFullyDeclared checks that every canonical event
-// resolves BOTH a subject kind and a payload family, and that non-canonical
-// names resolve neither.
+// TestCanonicalEventsAreFullyDeclared pins the events/1 contract surface as an
+// INDEPENDENT COPY: every canonical name, its subject kind and its payload
+// family, written out here as literals.
 //
-// The single taxonomy table makes a half-declared event unrepresentable, so
-// this is a guard against the table being replaced by something looser rather
-// than against today's literals. The non-canonical leg is the one that matters
-// most: an unknown name must report ok=false, not an empty string that a
-// caller declaring nothing would match.
+// The previous version of this test iterated kernelevents.Canonical() and
+// asserted each entry resolved SOMETHING non-empty. That check cannot fail for
+// any table the compiler accepts — eventSpec requires both fields, so a
+// corrupted table (a name deleted, a name added, item.deleted quietly rebased
+// onto the ref-only payload) passed its own validation. A test that agrees with
+// whatever the table says is not a test of the table.
+//
+// So the literals below must DISAGREE with the table when the table moves. That
+// is the point of the duplication, and the duplication is deliberate: this is a
+// PUBLIC contract (SPEC-3 §Taxonomy) where a rename is as breaking as an HTTP
+// route change, and the cost of restating sixteen triples is one edit per
+// intentional contract change — paid at exactly the moment a version note is
+// owed anyway.
+//
+// TASK-2714 edits this table (the handler-path bulk mapping), which is why the
+// independent copy lands as this unit's first commit.
 func TestCanonicalEventsAreFullyDeclared(t *testing.T) {
-	for _, name := range kernelevents.Canonical() {
-		kind, kindOK := kernelevents.SubjectKind(name)
-		if !kindOK || kind == "" {
-			t.Errorf("canonical event %q has no subject kind", name)
-		}
-		family, familyOK := kernelevents.PayloadFamily(name)
-		if !familyOK || family == "" {
-			t.Errorf("canonical event %q has no payload family", name)
+	// The events/1 set at SPEC-3 v1.4. Adding, removing or re-homing an entry
+	// here is a CONTRACT CHANGE: update the spec version and the taxonomy's
+	// doc comment in the same commit.
+	want := map[string]struct{ subject, family string }{
+		"item.created":        {kernelevents.SubjectItem, kernelevents.PayloadItemSnapshot},
+		"item.updated":        {kernelevents.SubjectItem, kernelevents.PayloadItemSnapshot},
+		"item.status_changed": {kernelevents.SubjectItem, kernelevents.PayloadItemSnapshot},
+		"item.moved":          {kernelevents.SubjectItem, kernelevents.PayloadItemSnapshot},
+		"item.deleted":        {kernelevents.SubjectItem, kernelevents.PayloadItemSnapshot},
+		"item.restored":       {kernelevents.SubjectItem, kernelevents.PayloadItemSnapshot},
+		"item.bulk_updated":   {kernelevents.SubjectItemBatch, kernelevents.PayloadItemBatch},
+		"comment.created":     {kernelevents.SubjectComment, kernelevents.PayloadCommentSnapshot},
+		"comment.updated":     {kernelevents.SubjectComment, kernelevents.PayloadCommentSnapshot},
+		"comment.deleted":     {kernelevents.SubjectComment, kernelevents.PayloadRefOnly},
+		"attachment.added":    {kernelevents.SubjectAttachment, kernelevents.PayloadAttachmentSnapshot},
+		"attachment.removed":  {kernelevents.SubjectAttachment, kernelevents.PayloadRefOnly},
+		"member.joined":       {kernelevents.SubjectMember, kernelevents.PayloadMember},
+		"pack.installed":      {kernelevents.SubjectPack, kernelevents.PayloadPack},
+		"pack.upgraded":       {kernelevents.SubjectPack, kernelevents.PayloadPack},
+		"pack.disabled":       {kernelevents.SubjectPack, kernelevents.PayloadPack},
+	}
+
+	// The name constants are pinned to their wire strings separately, because
+	// the map above is keyed on literals: a renamed constant would otherwise
+	// slip through as long as the table and the constant moved together.
+	for constant, wire := range map[string]string{
+		kernelevents.ItemCreated:       "item.created",
+		kernelevents.ItemUpdated:       "item.updated",
+		kernelevents.ItemStatusChanged: "item.status_changed",
+		kernelevents.ItemMoved:         "item.moved",
+		kernelevents.ItemDeleted:       "item.deleted",
+		kernelevents.ItemRestored:      "item.restored",
+		kernelevents.ItemBulkUpdated:   "item.bulk_updated",
+		kernelevents.CommentCreated:    "comment.created",
+		kernelevents.CommentUpdated:    "comment.updated",
+		kernelevents.CommentDeleted:    "comment.deleted",
+		kernelevents.AttachmentAdded:   "attachment.added",
+		kernelevents.AttachmentRemoved: "attachment.removed",
+		kernelevents.MemberJoined:      "member.joined",
+		kernelevents.PackInstalled:     "pack.installed",
+		kernelevents.PackUpgraded:      "pack.upgraded",
+		kernelevents.PackDisabled:      "pack.disabled",
+	} {
+		if constant != wire {
+			t.Errorf("event name constant = %q, want %q on the wire", constant, wire)
 		}
 	}
 
+	got := kernelevents.Canonical()
+	if len(got) != len(want) {
+		t.Errorf("Canonical() has %d events, want %d — the contract set changed", len(got), len(want))
+	}
+
+	seen := make(map[string]bool, len(got))
+	for _, name := range got {
+		seen[name] = true
+		expected, ok := want[name]
+		if !ok {
+			t.Errorf("Canonical() carries %q, which the events/1 contract does not declare", name)
+			continue
+		}
+		kind, kindOK := kernelevents.SubjectKind(name)
+		if !kindOK || kind != expected.subject {
+			t.Errorf("SubjectKind(%q) = (%q, %v), want (%q, true)", name, kind, kindOK, expected.subject)
+		}
+		family, familyOK := kernelevents.PayloadFamily(name)
+		if !familyOK || family != expected.family {
+			t.Errorf("PayloadFamily(%q) = (%q, %v), want (%q, true)", name, family, familyOK, expected.family)
+		}
+		if !kernelevents.IsCanonical(name) {
+			t.Errorf("IsCanonical(%q) = false for an event Canonical() returned", name)
+		}
+	}
+	for name := range want {
+		if !seen[name] {
+			t.Errorf("events/1 declares %q but Canonical() does not return it", name)
+		}
+	}
+
+	// Non-canonical names must report ok=false rather than an empty string a
+	// caller declaring nothing would match — the fail-open shape Codex round 11
+	// found in the two-map version.
 	for _, name := range []string{"", "item.frobnicated", "comment.deleted.v2"} {
 		if _, ok := kernelevents.PayloadFamily(name); ok {
 			t.Errorf("PayloadFamily(%q) reported ok for a non-canonical name", name)

--- a/internal/store/event_outbox_test.go
+++ b/internal/store/event_outbox_test.go
@@ -1466,3 +1466,88 @@ func TestCanonicalEventsAreFullyDeclared(t *testing.T) {
 		}
 	}
 }
+
+// insertOutboxRow writes one outbox row directly, so a retention test can pin
+// occurred_at / dispatched_at to values a real emit would never produce on
+// demand.
+func insertOutboxRow(t *testing.T, s *Store, id, workspaceID, occurredAt string, dispatchedAt *string) {
+	t.Helper()
+	if _, err := s.db.Exec(s.q(`
+		INSERT INTO event_outbox (id, workspace_id, event_type, subject_kind, subject_id, payload, hop, occurred_at, dispatched_at)
+		VALUES (?, ?, ?, ?, ?, ?, 0, ?, ?)
+	`), id, workspaceID, kernelevents.ItemCreated, kernelevents.SubjectItem, "subj-"+id,
+		`{"id":"subj-`+id+`","title":"frozen"}`, occurredAt, dispatchedAt); err != nil {
+		t.Fatalf("insert outbox row %s: %v", id, err)
+	}
+}
+
+func outboxRowIDs(t *testing.T, s *Store) []string {
+	t.Helper()
+	rows, err := s.db.Query(s.q(`SELECT id FROM event_outbox ORDER BY id`))
+	if err != nil {
+		t.Fatalf("query outbox ids: %v", err)
+	}
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			t.Fatalf("scan id: %v", err)
+		}
+		out = append(out, id)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate outbox ids: %v", err)
+	}
+	return out
+}
+
+// TestOutbox_PruneUndispatchedBoundsTheFrozenPayloadWindow pins the privacy
+// half of retention (TASK-2714 requirement 3).
+//
+// PruneDispatchedOutbox filters on dispatched_at IS NOT NULL, so a row that
+// can NEVER be delivered is unreachable by it and keeps its frozen payload
+// forever. Both legs below discriminate a plausible wrong implementation: a
+// prune that dropped the dispatched_at IS NULL clause would take the dispatched
+// row too (and hand that table's retention two owners with different windows),
+// and one that ignored the cutoff would take the young pending row that a
+// retry is still owed.
+func TestOutbox_PruneUndispatchedBoundsTheFrozenPayloadWindow(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Outbox retention")
+	clearOutbox(t, s)
+
+	old := time.Now().UTC().Add(-72 * time.Hour).Format(time.RFC3339)
+	recent := time.Now().UTC().Add(-1 * time.Hour).Format(time.RFC3339)
+	dispatchedAt := time.Now().UTC().Add(-71 * time.Hour).Format(time.RFC3339)
+
+	insertOutboxRow(t, s, "a-old-pending", ws.ID, old, nil)
+	insertOutboxRow(t, s, "b-old-dispatched", ws.ID, old, &dispatchedAt)
+	insertOutboxRow(t, s, "c-recent-pending", ws.ID, recent, nil)
+
+	// The test asserts its own premise: without all three rows present, the
+	// survivor checks below would pass for a reason unrelated to the prune.
+	if got := outboxRowIDs(t, s); len(got) != 3 {
+		t.Fatalf("seeded rows = %v, want 3", got)
+	}
+
+	cutoff := time.Now().UTC().Add(-24 * time.Hour).Format(time.RFC3339)
+	n, err := s.PruneUndispatchedOutbox(cutoff)
+	if err != nil {
+		t.Fatalf("PruneUndispatchedOutbox: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("pruned %d rows, want 1 (only the aged pending row)", n)
+	}
+
+	got := outboxRowIDs(t, s)
+	want := []string{"b-old-dispatched", "c-recent-pending"}
+	if len(got) != len(want) {
+		t.Fatalf("survivors = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("survivors = %v, want %v", got, want)
+		}
+	}
+}

--- a/internal/store/event_outbox_test.go
+++ b/internal/store/event_outbox_test.go
@@ -1614,8 +1614,13 @@ func outboxBatchIDsFor(t *testing.T, s *Store, itemID string) []string {
 // TestOutbox_WithEventBatchStampsEveryMutationPath drives ALL FIVE store entry
 // points the bulk handler reaches, because the failure this guards against is
 // per-method: a signature that accepts the option and never threads it to the
-// emit compiles, passes every other test, and silently un-batches one of the
-// six bulk verbs.
+// emit compiles, passes every other test, and silently un-batches whichever
+// bulk verbs route through it.
+//
+// THIS TEST IS NOT SUFFICIENT ON ITS OWN, and saying so is the point: it
+// proves the OPTION works, not that the handler passes it. Codex round 1 found
+// three handler call sites that never did.
+// TestBulkItems_EveryVerbStampsOneBatchID covers that layer.
 //
 // The population is enumerated rather than sampled (CONVE-18): archive
 // (DeleteItem), restore (RestoreItem), move (MoveItemWithPreCheck), field
@@ -1958,6 +1963,39 @@ func TestFoldBulkHeader_KeepsOneSnapshotPerItem(t *testing.T) {
 		if m.Status != "done" {
 			t.Errorf("member %s carries status %q, want the LAST snapshot (done)", m.ID, m.Status)
 		}
+	}
+
+	// prior_status survives the collapse. A mixed update writes
+	// item.status_changed (which carries it) AND item.updated (which does
+	// not); plain last-wins keeps the later row and drops the transition —
+	// the one field a "nonterminal -> terminal" binding needs, lost exactly
+	// in the case that produces both rows.
+	withPrior, err := FoldBulkHeader(
+		[]byte(`{"batch_id":"b1","op":"move","count":1,"item_ids":["i1"]}`),
+		[][]byte{
+			[]byte(`{"id":"i1","status":"done","prior_status":"open"}`),
+			[]byte(`{"id":"i1","status":"done","title":"later row, no prior_status"}`),
+		})
+	if err != nil {
+		t.Fatalf("FoldBulkHeader (prior_status): %v", err)
+	}
+	var priorGot struct {
+		Members []struct {
+			Title       string `json:"title"`
+			PriorStatus string `json:"prior_status"`
+		} `json:"members"`
+	}
+	if err := json.Unmarshal(withPrior, &priorGot); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(priorGot.Members) != 1 {
+		t.Fatalf("members = %d, want 1", len(priorGot.Members))
+	}
+	if priorGot.Members[0].PriorStatus != "open" {
+		t.Errorf("prior_status = %q, want it carried forward from the status_changed row", priorGot.Members[0].PriorStatus)
+	}
+	if priorGot.Members[0].Title != "later row, no prior_status" {
+		t.Errorf("member = %+v, want the LAST snapshot's fields kept", priorGot.Members[0])
 	}
 
 	// A snapshot the drain cannot read is kept, not dropped: it is real data,

--- a/internal/store/event_outbox_test.go
+++ b/internal/store/event_outbox_test.go
@@ -1486,11 +1486,16 @@ func TestCanonicalEventsAreFullyDeclared(t *testing.T) {
 // demand.
 func insertOutboxRow(t *testing.T, s *Store, id, workspaceID, occurredAt string, dispatchedAt *string) {
 	t.Helper()
+	insertOutboxRowBatch(t, s, id, workspaceID, occurredAt, dispatchedAt, "")
+}
+
+func insertOutboxRowBatch(t *testing.T, s *Store, id, workspaceID, occurredAt string, dispatchedAt *string, batchID string) {
+	t.Helper()
 	if _, err := s.db.Exec(s.q(`
-		INSERT INTO event_outbox (id, workspace_id, event_type, subject_kind, subject_id, payload, hop, occurred_at, dispatched_at)
-		VALUES (?, ?, ?, ?, ?, ?, 0, ?, ?)
+		INSERT INTO event_outbox (id, workspace_id, event_type, subject_kind, subject_id, payload, hop, occurred_at, dispatched_at, batch_id)
+		VALUES (?, ?, ?, ?, ?, ?, 0, ?, ?, NULLIF(?, ''))
 	`), id, workspaceID, kernelevents.ItemCreated, kernelevents.SubjectItem, "subj-"+id,
-		`{"id":"subj-`+id+`","title":"frozen"}`, occurredAt, dispatchedAt); err != nil {
+		`{"id":"subj-`+id+`","title":"frozen"}`, occurredAt, dispatchedAt, batchID); err != nil {
 		t.Fatalf("insert outbox row %s: %v", id, err)
 	}
 }
@@ -1688,4 +1693,193 @@ func TestOutbox_WithEventBatchStampsEveryMutationPath(t *testing.T) {
 		}
 		assertBatch(t, solo.ID, "")
 	})
+}
+
+func claimedIDs(evs []OutboxEvent) []string {
+	out := make([]string, 0, len(evs))
+	for _, e := range evs {
+		out = append(out, e.ID)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// TestOutbox_ClaimIsExclusiveUntilTheLeaseExpires is the multi-instance guard.
+// Every instance of a cloud deployment runs the drain, so without the claim
+// each pending row is delivered once PER INSTANCE — by construction, not by
+// accident.
+func TestOutbox_ClaimIsExclusiveUntilTheLeaseExpires(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Outbox claim")
+	clearOutbox(t, s)
+
+	occurred := time.Now().UTC().Add(-time.Minute).Format(time.RFC3339)
+	insertOutboxRow(t, s, "row-a", ws.ID, occurred, nil)
+	insertOutboxRow(t, s, "row-b", ws.ID, occurred, nil)
+
+	live := time.Now().UTC().Add(-5 * time.Minute).Format(time.RFC3339)
+
+	first, err := s.ClaimPendingOutboxEvents("instance-1", 10, live)
+	if err != nil {
+		t.Fatalf("first claim: %v", err)
+	}
+	if got := claimedIDs(first); len(got) != 2 {
+		t.Fatalf("instance-1 claimed %v, want both rows", got)
+	}
+
+	second, err := s.ClaimPendingOutboxEvents("instance-2", 10, live)
+	if err != nil {
+		t.Fatalf("second claim: %v", err)
+	}
+	if len(second) != 0 {
+		t.Fatalf("instance-2 claimed %v — every event would be delivered once per instance", claimedIDs(second))
+	}
+
+	// A drainer that died holding claims must not strand them: past the lease,
+	// the rows are claimable again. At-least-once is what makes that safe.
+	expired := time.Now().UTC().Add(time.Minute).Format(time.RFC3339)
+	third, err := s.ClaimPendingOutboxEvents("instance-2", 10, expired)
+	if err != nil {
+		t.Fatalf("post-lease claim: %v", err)
+	}
+	if got := claimedIDs(third); len(got) != 2 {
+		t.Fatalf("post-lease claim got %v, want both rows — a dead instance stranded them", got)
+	}
+}
+
+// TestOutbox_ClaimTakesWholeBatchesPastTheLimit pins the rule that keeps a
+// folded wire event true: the limit is a throughput knob, and letting it split
+// a batch would make one bulk operation arrive as two events each reporting a
+// partial member count.
+func TestOutbox_ClaimTakesWholeBatchesPastTheLimit(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Outbox batch claim")
+	clearOutbox(t, s)
+
+	occurred := time.Now().UTC().Add(-time.Minute).Format(time.RFC3339)
+	insertOutboxRowBatch(t, s, "b-1", ws.ID, occurred, nil, "batch-x")
+	insertOutboxRowBatch(t, s, "b-2", ws.ID, occurred, nil, "batch-x")
+	insertOutboxRowBatch(t, s, "b-3", ws.ID, occurred, nil, "batch-x")
+
+	live := time.Now().UTC().Add(-5 * time.Minute).Format(time.RFC3339)
+	claimed, err := s.ClaimPendingOutboxEvents("instance-1", 1, live)
+	if err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+	got := claimedIDs(claimed)
+	if len(got) != 3 {
+		t.Fatalf("claimed %v with limit=1, want all three members of batch-x", got)
+	}
+	for _, ev := range claimed {
+		if ev.BatchID != "batch-x" {
+			t.Errorf("claimed row %s carries batch %q, want batch-x", ev.ID, ev.BatchID)
+		}
+	}
+
+	// Control: an unbatched row is still bounded by the limit, so the
+	// expansion above is batch-specific rather than the limit being ignored.
+	clearOutbox(t, s)
+	insertOutboxRow(t, s, "s-1", ws.ID, occurred, nil)
+	insertOutboxRow(t, s, "s-2", ws.ID, occurred, nil)
+	single, err := s.ClaimPendingOutboxEvents("instance-1", 1, live)
+	if err != nil {
+		t.Fatalf("control claim: %v", err)
+	}
+	if len(single) != 1 {
+		t.Fatalf("control claimed %v with limit=1, want exactly one row", claimedIDs(single))
+	}
+}
+
+// TestOutbox_FailedAttemptReleasesTheClaim: a transient failure means the
+// event is still owed and nothing is in flight, so the next tick must be able
+// to take it. Holding the claim until the lease expired would idle the row for
+// the whole window — and on a single-instance deployment that is the only
+// reason it would ever wait at all.
+func TestOutbox_FailedAttemptReleasesTheClaim(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Outbox claim release")
+	clearOutbox(t, s)
+
+	occurred := time.Now().UTC().Add(-time.Minute).Format(time.RFC3339)
+	insertOutboxRow(t, s, "row-a", ws.ID, occurred, nil)
+	live := time.Now().UTC().Add(-5 * time.Minute).Format(time.RFC3339)
+
+	claimed, err := s.ClaimPendingOutboxEvents("instance-1", 10, live)
+	if err != nil || len(claimed) != 1 {
+		t.Fatalf("claim = %v, %v; want one row", claimedIDs(claimed), err)
+	}
+	// Premise: it really is unavailable while claimed, so the re-claim below
+	// proves the release rather than the claim never having applied.
+	if again, err := s.ClaimPendingOutboxEvents("instance-2", 10, live); err != nil || len(again) != 0 {
+		t.Fatalf("row was claimable while claimed (%v, %v)", claimedIDs(again), err)
+	}
+
+	if err := s.MarkOutboxAttemptFailed("row-a", "endpoint timed out"); err != nil {
+		t.Fatalf("MarkOutboxAttemptFailed: %v", err)
+	}
+
+	retry, err := s.ClaimPendingOutboxEvents("instance-2", 10, live)
+	if err != nil {
+		t.Fatalf("re-claim: %v", err)
+	}
+	if len(retry) != 1 {
+		t.Fatalf("re-claim got %v, want the released row", claimedIDs(retry))
+	}
+	if retry[0].Attempts != 1 {
+		t.Errorf("attempts = %d, want 1 — the failed attempt was not recorded", retry[0].Attempts)
+	}
+	if retry[0].LastError != "endpoint timed out" {
+		t.Errorf("last_error = %q, want the recorded reason", retry[0].LastError)
+	}
+}
+
+// TestOutbox_ClaimArbitratesTheRaceNotJustTheQuery drives the conditional
+// UPDATE with a STALE candidate list — the case the public entry point cannot
+// produce, because its own candidate query has already filtered held rows.
+//
+// Without this, the exclusivity test above passes for an implementation whose
+// UPDATE has no availability predicate at all: the candidate filter alone
+// produces the same end state single-threaded (CONVE-12 — name the other
+// mechanism that produces the end state, then assert against IT). Under real
+// concurrency that implementation double-claims every row two instances select
+// at the same moment, which is precisely the multi-instance bug the claim
+// exists to prevent.
+func TestOutbox_ClaimArbitratesTheRaceNotJustTheQuery(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Outbox claim race")
+	clearOutbox(t, s)
+
+	occurred := time.Now().UTC().Add(-time.Minute).Format(time.RFC3339)
+	insertOutboxRow(t, s, "row-a", ws.ID, occurred, nil)
+	live := time.Now().UTC().Add(-5 * time.Minute).Format(time.RFC3339)
+
+	// Instance 2 selects candidates FIRST — before instance 1 claims. This is
+	// the window: both instances have the row in their candidate list.
+	stale, err := s.pendingClaimCandidates(10, live)
+	if err != nil {
+		t.Fatalf("candidates: %v", err)
+	}
+	if len(stale) != 1 {
+		t.Fatalf("candidates = %v, want the one pending row", stale)
+	}
+
+	won, err := s.ClaimPendingOutboxEvents("instance-1", 10, live)
+	if err != nil || len(won) != 1 {
+		t.Fatalf("instance-1 claim = %v, %v; want the row", claimedIDs(won), err)
+	}
+
+	// Instance 2 now runs its UPDATE against the list it selected before the
+	// claim landed. The predicate on each statement is the only thing that can
+	// stop it.
+	const loser = "instance-2:stale-token"
+	if err := s.claimOutboxIDs(loser, stale, live); err != nil {
+		t.Fatalf("loser claim: %v", err)
+	}
+	got, err := s.outboxEventsClaimedBy(loser)
+	if err != nil {
+		t.Fatalf("read loser claims: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("instance-2 also claimed %v — both instances would deliver the same event", claimedIDs(got))
+	}
 }

--- a/internal/store/event_outbox_test.go
+++ b/internal/store/event_outbox_test.go
@@ -2129,3 +2129,62 @@ func TestOutbox_PruneUndispatchedSparesAClaimedRow(t *testing.T) {
 		t.Errorf("prune with an expired lease removed %d rows (err %v), want 1", n, err)
 	}
 }
+
+// TestOutbox_SetParentLinkEmitsItemUpdated pins the fix for the create-with-
+// parent regression (codex round 4).
+//
+// CreateItem commits item.created with a PRE-LINK snapshot, and the parent
+// link lands in a separate transaction afterwards. The hand-called webhook
+// that the drain replaced dispatched the handler's post-link re-read, so a
+// consumer saw the parent; without an event of its own, the frozen created row
+// would be the only thing on the wire.
+//
+// The criterion, per SPEC-3 v1.6: a parent link writes the item's OWN row
+// (seq, the unparented bit), so it emits. A relationship-graph link writes only
+// the links table and stays silent.
+func TestOutbox_SetParentLinkEmitsItemUpdated(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Outbox parent link")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+
+	parent := createTestItem(t, s, ws.ID, col.ID, "Parent", "")
+	child := createTestItem(t, s, ws.ID, col.ID, "Child", "")
+
+	// Premise: the create emitted item.created and nothing else, so the event
+	// asserted below is the LINK's rather than the create's.
+	if got := outboxEventsFor(t, s, child.ID); len(got) != 1 || got[0] != kernelevents.ItemCreated {
+		t.Fatalf("events after create = %v, want exactly [%s]", got, kernelevents.ItemCreated)
+	}
+	createdSeq := child.Seq
+	clearOutbox(t, s)
+
+	if _, err := s.SetParentLink(ws.ID, child.ID, parent.ID, "user"); err != nil {
+		t.Fatalf("SetParentLink: %v", err)
+	}
+
+	got := outboxEventsFor(t, s, child.ID)
+	if len(got) != 1 || got[0] != kernelevents.ItemUpdated {
+		t.Fatalf("events after linking = %v, want exactly [%s]", got, kernelevents.ItemUpdated)
+	}
+
+	// The payload must be the POST-link state, which is the whole point: a
+	// snapshot read outside the transaction would carry the pre-link row.
+	payload := outboxPayloadFor(t, s, child.ID, kernelevents.ItemUpdated)
+	seq, ok := payload["seq"].(float64)
+	if !ok {
+		t.Fatalf("payload has no seq: %v", payload["seq"])
+	}
+	if int64(seq) <= createdSeq {
+		t.Errorf("event carries seq %d, want later than the create's %d — this is the pre-link snapshot", int64(seq), createdSeq)
+	}
+	if payload["is_unparented"] == true {
+		t.Error("event says the child is unparented, i.e. it describes the state before the link it is reporting")
+	}
+
+	// The PARENT's row is untouched by this write, so it emits nothing — the
+	// control that keeps the assertion above about the child's row rather than
+	// about "some event fired".
+	if got := outboxEventsFor(t, s, parent.ID); len(got) != 0 {
+		t.Errorf("parent emitted %v; the link does not write the parent's row", got)
+	}
+}

--- a/internal/store/event_outbox_test.go
+++ b/internal/store/event_outbox_test.go
@@ -1029,8 +1029,9 @@ func TestOutbox_StatusChangeFromEmptyCarriesEmptyPriorStatus(t *testing.T) {
 // Account deletion's de-identify pass nulls user identity on LIVE rows so a
 // departed user stops being legible; it cannot reach a frozen payload. If the
 // payload captured the assignee's name and email, those would stay readable in
-// the outbox after the account was deleted — and today nothing drains or prunes
-// the table.
+// the outbox after the account was deleted for as long as the row survived.
+// TASK-2714 bounded that window with the drain and its two prunes; bounded is
+// not zero, so the scrub is still what does the work.
 func TestOutbox_PayloadsOmitAssigneeIdentity(t *testing.T) {
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Outbox PII")
@@ -1837,7 +1838,7 @@ func TestOutbox_FailedAttemptReleasesTheClaim(t *testing.T) {
 		t.Fatalf("row was claimable while claimed (%v, %v)", claimedIDs(again), err)
 	}
 
-	if err := s.MarkOutboxAttemptFailed("row-a", "endpoint timed out"); err != nil {
+	if err := s.MarkOutboxAttemptFailed(claimed[0].ClaimToken, "row-a", "endpoint timed out"); err != nil {
 		t.Fatalf("MarkOutboxAttemptFailed: %v", err)
 	}
 
@@ -2012,5 +2013,76 @@ func TestFoldBulkHeader_KeepsOneSnapshotPerItem(t *testing.T) {
 	}
 	if len(oddGot.Members) != 2 {
 		t.Errorf("members = %d, want both kept", len(oddGot.Members))
+	}
+}
+
+// TestOutbox_StaleClaimCannotAckOrReleaseAnotherPass pins the lease's other
+// half. Delivery can outrun the lease — a workspace with many slow endpoints
+// is delivered sequentially — and the estimate behind the default is an
+// estimate, not a bound.
+//
+// So the question is what a LATE pass may still do to rows a newer pass now
+// owns. The answer has to be nothing: a late ack would stamp a row the new
+// holder is mid-delivery on, and a late release would clear a live claim and
+// hand the event to a third pass.
+func TestOutbox_StaleClaimCannotAckOrReleaseAnotherPass(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Outbox stale claim")
+	clearOutbox(t, s)
+
+	occurred := time.Now().UTC().Add(-time.Minute).Format(time.RFC3339)
+	insertOutboxRow(t, s, "row-a", ws.ID, occurred, nil)
+
+	live := time.Now().UTC().Add(-5 * time.Minute).Format(time.RFC3339)
+	first, err := s.ClaimPendingOutboxEvents("instance-1", 10, live)
+	if err != nil || len(first) != 1 {
+		t.Fatalf("first claim = %v, %v", claimedIDs(first), err)
+	}
+	staleToken := first[0].ClaimToken
+	if staleToken == "" {
+		t.Fatal("claim returned no token; ack and release have nothing to condition on")
+	}
+
+	// The lease expires and a second instance legitimately takes the row.
+	expired := time.Now().UTC().Add(time.Minute).Format(time.RFC3339)
+	second, err := s.ClaimPendingOutboxEvents("instance-2", 10, expired)
+	if err != nil || len(second) != 1 {
+		t.Fatalf("second claim = %v, %v — the premise of this test is that the row moved on", claimedIDs(second), err)
+	}
+	if second[0].ClaimToken == staleToken {
+		t.Fatal("both passes share a claim token; the tokens do not identify a pass")
+	}
+
+	// Instance 1 finally finishes and acks. It must reach nothing.
+	if err := s.MarkOutboxDispatched(staleToken, []string{"row-a"}); err != nil {
+		t.Fatalf("stale ack: %v", err)
+	}
+	pending, err := s.ListPendingOutboxEvents(10)
+	if err != nil {
+		t.Fatalf("list pending: %v", err)
+	}
+	if len(pending) != 1 {
+		t.Fatalf("stale ack marked the row dispatched while instance-2 holds it; pending = %d", len(pending))
+	}
+
+	// ...and its release must not free instance-2's claim either.
+	if err := s.MarkOutboxAttemptFailed(staleToken, "row-a", "late failure"); err != nil {
+		t.Fatalf("stale release: %v", err)
+	}
+	third, err := s.ClaimPendingOutboxEvents("instance-3", 10, live)
+	if err != nil {
+		t.Fatalf("third claim: %v", err)
+	}
+	if len(third) != 0 {
+		t.Errorf("a stale release freed a live claim; instance-3 took %v", claimedIDs(third))
+	}
+
+	// Positive control: the CURRENT holder's ack does work, so the assertions
+	// above are about staleness rather than about acking being broken.
+	if err := s.MarkOutboxDispatched(second[0].ClaimToken, []string{"row-a"}); err != nil {
+		t.Fatalf("live ack: %v", err)
+	}
+	if pending, err := s.ListPendingOutboxEvents(10); err != nil || len(pending) != 0 {
+		t.Errorf("live ack left %d pending (err %v)", len(pending), err)
 	}
 }

--- a/internal/store/event_outbox_test.go
+++ b/internal/store/event_outbox_test.go
@@ -1375,23 +1375,27 @@ func TestCanonicalEventsAreFullyDeclared(t *testing.T) {
 	// The events/1 set at SPEC-3 v1.4. Adding, removing or re-homing an entry
 	// here is a CONTRACT CHANGE: update the spec version and the taxonomy's
 	// doc comment in the same commit.
-	want := map[string]struct{ subject, family, sse string }{
-		"item.created":        {kernelevents.SubjectItem, kernelevents.PayloadItemSnapshot, "item_created"},
-		"item.updated":        {kernelevents.SubjectItem, kernelevents.PayloadItemSnapshot, "item_updated"},
-		"item.status_changed": {kernelevents.SubjectItem, kernelevents.PayloadItemSnapshot, "item_updated"},
-		"item.moved":          {kernelevents.SubjectItem, kernelevents.PayloadItemSnapshot, "item_updated"},
-		"item.deleted":        {kernelevents.SubjectItem, kernelevents.PayloadItemSnapshot, "item_archived"},
-		"item.restored":       {kernelevents.SubjectItem, kernelevents.PayloadItemSnapshot, "item_restored"},
-		"item.bulk_updated":   {kernelevents.SubjectItemBatch, kernelevents.PayloadItemBatch, "items_bulk_updated"},
-		"comment.created":     {kernelevents.SubjectComment, kernelevents.PayloadCommentSnapshot, "comment_created"},
-		"comment.updated":     {kernelevents.SubjectComment, kernelevents.PayloadCommentSnapshot, "comment_updated"},
-		"comment.deleted":     {kernelevents.SubjectComment, kernelevents.PayloadRefOnly, "comment_deleted"},
-		"attachment.added":    {kernelevents.SubjectAttachment, kernelevents.PayloadAttachmentSnapshot, ""},
-		"attachment.removed":  {kernelevents.SubjectAttachment, kernelevents.PayloadRefOnly, ""},
-		"member.joined":       {kernelevents.SubjectMember, kernelevents.PayloadMember, ""},
-		"pack.installed":      {kernelevents.SubjectPack, kernelevents.PayloadPack, ""},
-		"pack.upgraded":       {kernelevents.SubjectPack, kernelevents.PayloadPack, ""},
-		"pack.disabled":       {kernelevents.SubjectPack, kernelevents.PayloadPack, ""},
+	want := map[string]struct {
+		subject string
+		family  []string
+		sse     string
+	}{
+		"item.created":        {kernelevents.SubjectItem, []string{kernelevents.PayloadItemSnapshot}, "item_created"},
+		"item.updated":        {kernelevents.SubjectItem, []string{kernelevents.PayloadItemSnapshot}, "item_updated"},
+		"item.status_changed": {kernelevents.SubjectItem, []string{kernelevents.PayloadItemSnapshot}, "item_updated"},
+		"item.moved":          {kernelevents.SubjectItem, []string{kernelevents.PayloadItemSnapshot}, "item_updated"},
+		"item.deleted":        {kernelevents.SubjectItem, []string{kernelevents.PayloadItemSnapshot}, "item_archived"},
+		"item.restored":       {kernelevents.SubjectItem, []string{kernelevents.PayloadItemSnapshot}, "item_restored"},
+		"item.bulk_updated":   {kernelevents.SubjectItemBatch, []string{kernelevents.PayloadItemBatch, kernelevents.PayloadItemBatchHeader}, "items_bulk_updated"},
+		"comment.created":     {kernelevents.SubjectComment, []string{kernelevents.PayloadCommentSnapshot}, "comment_created"},
+		"comment.updated":     {kernelevents.SubjectComment, []string{kernelevents.PayloadCommentSnapshot}, "comment_updated"},
+		"comment.deleted":     {kernelevents.SubjectComment, []string{kernelevents.PayloadRefOnly}, "comment_deleted"},
+		"attachment.added":    {kernelevents.SubjectAttachment, []string{kernelevents.PayloadAttachmentSnapshot}, ""},
+		"attachment.removed":  {kernelevents.SubjectAttachment, []string{kernelevents.PayloadRefOnly}, ""},
+		"member.joined":       {kernelevents.SubjectMember, []string{kernelevents.PayloadMember}, ""},
+		"pack.installed":      {kernelevents.SubjectPack, []string{kernelevents.PayloadPack}, ""},
+		"pack.upgraded":       {kernelevents.SubjectPack, []string{kernelevents.PayloadPack}, ""},
+		"pack.disabled":       {kernelevents.SubjectPack, []string{kernelevents.PayloadPack}, ""},
 	}
 
 	// The name constants are pinned to their wire strings separately, because
@@ -1437,9 +1441,20 @@ func TestCanonicalEventsAreFullyDeclared(t *testing.T) {
 		if !kindOK || kind != expected.subject {
 			t.Errorf("SubjectKind(%q) = (%q, %v), want (%q, true)", name, kind, kindOK, expected.subject)
 		}
-		family, familyOK := kernelevents.PayloadFamily(name)
-		if !familyOK || family != expected.family {
-			t.Errorf("PayloadFamily(%q) = (%q, %v), want (%q, true)", name, family, familyOK, expected.family)
+		families, familiesOK := kernelevents.PayloadFamilies(name)
+		if !familiesOK || !sameStrings(families, expected.family) {
+			t.Errorf("PayloadFamilies(%q) = (%v, %v), want (%v, true)", name, families, familiesOK, expected.family)
+		}
+		for _, family := range expected.family {
+			if !kernelevents.AllowsPayload(name, family) {
+				t.Errorf("AllowsPayload(%q, %q) = false for a declared shape", name, family)
+			}
+		}
+		if kernelevents.AllowsPayload(name, "") {
+			t.Errorf("AllowsPayload(%q, \"\") = true — a caller declaring nothing must not match", name)
+		}
+		if kernelevents.AllowsPayload(name, "not_a_family") {
+			t.Errorf("AllowsPayload(%q, \"not_a_family\") = true", name)
 		}
 		if !kernelevents.IsCanonical(name) {
 			t.Errorf("IsCanonical(%q) = false for an event Canonical() returned", name)
@@ -1466,8 +1481,11 @@ func TestCanonicalEventsAreFullyDeclared(t *testing.T) {
 	// caller declaring nothing would match — the fail-open shape Codex round 11
 	// found in the two-map version.
 	for _, name := range []string{"", "item.frobnicated", "comment.deleted.v2"} {
-		if _, ok := kernelevents.PayloadFamily(name); ok {
-			t.Errorf("PayloadFamily(%q) reported ok for a non-canonical name", name)
+		if _, ok := kernelevents.PayloadFamilies(name); ok {
+			t.Errorf("PayloadFamilies(%q) reported ok for a non-canonical name", name)
+		}
+		if kernelevents.AllowsPayload(name, kernelevents.PayloadItemSnapshot) {
+			t.Errorf("AllowsPayload(%q, ...) = true for a non-canonical name", name)
 		}
 		if _, ok := kernelevents.SubjectKind(name); ok {
 			t.Errorf("SubjectKind(%q) reported ok for a non-canonical name", name)
@@ -1882,4 +1900,23 @@ func TestOutbox_ClaimArbitratesTheRaceNotJustTheQuery(t *testing.T) {
 	if len(got) != 0 {
 		t.Fatalf("instance-2 also claimed %v — both instances would deliver the same event", claimedIDs(got))
 	}
+}
+
+// sameStrings compares two payload-family lists order-independently: the
+// taxonomy declares a SET, and pinning its order would make the test fail on a
+// reordering that changes nothing.
+func sameStrings(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	g := append([]string(nil), got...)
+	w := append([]string(nil), want...)
+	sort.Strings(g)
+	sort.Strings(w)
+	for i := range g {
+		if g[i] != w[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -3286,12 +3286,14 @@ func (s *Store) DeleteItemLink(id string) error {
 	// every attach route was observable.
 	//
 	// IMPLEMENTS IS DELIBERATELY NOT INCLUDED HERE, and the asymmetry is
-	// flagged rather than resolved: it bumps the same row (so the mechanical
-	// criterion would include it) but it is a relationship-graph link (so
-	// v1.5's silence would exclude it). The contract does not currently
-	// decide that case, and inventing an answer inside a delivery refactor is
-	// how a public wire acquires an event nobody ruled on. Raised with the
-	// lead; tracked separately.
+	// flagged rather than resolved: it bumps the same row two lines above (so
+	// the mechanical criterion would include it) but it is a
+	// relationship-graph link (so v1.5's silence would exclude it). The
+	// contract does not currently decide that case, and inventing an answer
+	// inside a delivery refactor is how a public wire acquires an event nobody
+	// ruled on. Raised with the lead; tracked separately. The same note is on
+	// handlers_item_links.go, which is where a reader is likely to hit it
+	// first.
 	if linkType == models.ItemLinkTypeParent {
 		child, err := s.getItemTx(tx, sourceID)
 		if err != nil {

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -2613,7 +2613,8 @@ func (s *Store) updateItemWithParentLinkOnce(
 	// update committed while the parent link write failed. The new
 	// parent's advisory lock was already folded into the acquisition
 	// above, so setParentLinkTx's re-lock is a no-op.
-	if parentLink != nil && parentLink.Provided {
+	hierarchyChanged := parentLink != nil && parentLink.Provided
+	if hierarchyChanged {
 		if parentLink.ParentID != "" {
 			if _, err := s.setParentLinkTx(tx, parentLink.WorkspaceID, id, parentLink.ParentID, parentLink.CreatedBy); err != nil {
 				return nil, err
@@ -2671,7 +2672,7 @@ func (s *Store) updateItemWithParentLinkOnce(
 	// The prior status comes from the same in-tx before/after comparison that
 	// wrote the status_transitions row, so the event and the transition log
 	// cannot disagree about what happened.
-	if err := s.emitItemUpdateEventsTx(tx, existing, updated, mutSignal.StatusChanged, mutSignal.FromStatus, doneKey, opt.batchID); err != nil {
+	if err := s.emitItemUpdateEventsTx(tx, existing, updated, mutSignal.StatusChanged, mutSignal.FromStatus, doneKey, opt.batchID, hierarchyChanged); err != nil {
 		return nil, err
 	}
 
@@ -3315,26 +3316,34 @@ func (s *Store) setParentLinkOnce(workspaceID, itemID, parentID, createdBy strin
 		return nil, err
 	}
 
-	// item.updated for the CHILD, on this transaction (TASK-2714, codex round
-	// 4; SPEC-3 v1.6 clarification).
+	// item.updated for the CHILD, on this transaction (TASK-2714, codex rounds
+	// 4-5; SPEC-3 v1.6 clarification).
 	//
-	// A parent link writes the item's OWN row — it advances seq and flips the
-	// is_unparented bit — and that is the criterion the contract uses to
-	// divide these two rulings: a mutation that touches the item's row emits
-	// item.updated, and a relationship-graph link (blocks / blocked-by), which
-	// writes only the links table, stays silent under v1.5.
+	// A parent link writes the item's OWN row — it advances seq — and that is
+	// the criterion the contract uses to divide two rulings that look
+	// adjacent: a mutation touching the item's row emits item.updated, while a
+	// relationship-graph link (blocks / blocked-by), which writes only the
+	// links table, stays silent under v1.5.
 	//
-	// The regression that forced it: createItemChecked calls this AFTER
-	// CreateItem has already committed item.created with a pre-link snapshot,
-	// then re-reads the item for its own response. The hand-called webhook
-	// this replaced dispatched that re-read, so a consumer saw the parent;
-	// under the drain, the frozen created row is all there was. created
-	// (pre-link) then updated (post-link) is a true history — a frozen
-	// pre-link snapshot with no correction is not.
+	// WHAT THE PAYLOAD DOES AND DOES NOT CARRY, stated because round 4's
+	// version of this comment claimed more than the code delivers (round 5
+	// caught it): the snapshot is the ITEM ROW, and the parent EDGE is not on
+	// it. items.parent_id is legacy and untouched here, and IsUnparented is
+	// populated only by the local-first index queries. So this event reports
+	// that the row changed — a fresh seq and updated_at — not the linkage
+	// itself. That is not a shortfall against the behaviour it restores: the
+	// hand-called webhook this replaced dispatched the handler's post-link
+	// re-read, which is the SAME scan and carried the same fields. A consumer
+	// wanting the edge reads the item, exactly as before.
+	//
+	// The regression it closes: createItemChecked calls this AFTER CreateItem
+	// has committed item.created with a pre-link snapshot. Without an event
+	// here the frozen created row — with the stale seq — was the only thing on
+	// the wire, and nothing corrected it.
 	//
 	// The snapshot MUST come from getItemTx: a pool read takes a different
 	// connection, cannot see this uncommitted write, and would emit the
-	// pre-link state under a post-link event.
+	// pre-link seq under a post-link event.
 	//
 	// EMITTED HERE RATHER THAN IN setParentLinkTx, which is the shared core.
 	// UpdateItemWithParentLink reuses that core inside the item-update

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -2613,16 +2613,23 @@ func (s *Store) updateItemWithParentLinkOnce(
 	// update committed while the parent link write failed. The new
 	// parent's advisory lock was already folded into the acquisition
 	// above, so setParentLinkTx's re-lock is a no-op.
-	hierarchyChanged := parentLink != nil && parentLink.Provided
-	if hierarchyChanged {
+	// PROVIDED IS NOT CHANGED (codex round 6). Clearing an already-unparented
+	// item deletes zero rows; forcing item.updated for it would describe a
+	// mutation that did not happen. The set branch always writes — it is a
+	// DELETE-then-INSERT that bumps the row either way.
+	var hierarchyChanged bool
+	if parentLink != nil && parentLink.Provided {
 		if parentLink.ParentID != "" {
 			if _, err := s.setParentLinkTx(tx, parentLink.WorkspaceID, id, parentLink.ParentID, parentLink.CreatedBy); err != nil {
 				return nil, err
 			}
+			hierarchyChanged = true
 		} else {
-			if err := s.clearParentLinkTx(tx, id, existing.WorkspaceID); err != nil {
+			removed, err := s.clearParentLinkTx(tx, id, existing.WorkspaceID)
+			if err != nil {
 				return nil, err
 			}
+			hierarchyChanged = removed
 		}
 	}
 
@@ -3269,6 +3276,33 @@ func (s *Store) DeleteItemLink(id string) error {
 			return err
 		}
 	}
+
+	// item.updated for a PARENT detach, on this transaction (codex round 6).
+	//
+	// Same criterion as SetParentLink and the update path (SPEC-3 v1.6): the
+	// parent edge writes the source item's own row. Without this, DELETE
+	// /links/{id} on a parent link was the one detach route that stayed
+	// silent, so a consumer's model kept a parent the user had removed while
+	// every attach route was observable.
+	//
+	// IMPLEMENTS IS DELIBERATELY NOT INCLUDED HERE, and the asymmetry is
+	// flagged rather than resolved: it bumps the same row (so the mechanical
+	// criterion would include it) but it is a relationship-graph link (so
+	// v1.5's silence would exclude it). The contract does not currently
+	// decide that case, and inventing an answer inside a delivery refactor is
+	// how a public wire acquires an event nobody ruled on. Raised with the
+	// lead; tracked separately.
+	if linkType == models.ItemLinkTypeParent {
+		child, err := s.getItemTx(tx, sourceID)
+		if err != nil {
+			return err
+		}
+		if child != nil {
+			if err := s.emitItemEventTx(tx, kernelevents.ItemUpdated, child, nil, ""); err != nil {
+				return err
+			}
+		}
+	}
 	return tx.Commit()
 }
 
@@ -3552,8 +3586,24 @@ func (s *Store) clearParentLinkOnce(itemID string) error {
 		return err
 	}
 
-	if err := s.clearParentLinkTx(tx, itemID, workspaceID); err != nil {
+	removed, err := s.clearParentLinkTx(tx, itemID, workspaceID)
+	if err != nil {
 		return err
+	}
+	// Same criterion as SetParentLink (SPEC-3 v1.6): a parent DETACH writes
+	// the item's own row, so it emits. Removing this half would leave the
+	// attach observable and the detach silent — a consumer's model would keep
+	// a parent the user removed (codex round 6).
+	if removed {
+		child, err := s.getItemTx(tx, itemID)
+		if err != nil {
+			return err
+		}
+		if child != nil {
+			if err := s.emitItemEventTx(tx, kernelevents.ItemUpdated, child, nil, ""); err != nil {
+				return err
+			}
+		}
 	}
 	return tx.Commit()
 }
@@ -3562,11 +3612,15 @@ func (s *Store) clearParentLinkOnce(itemID string) error {
 // transaction. Shared by the public ClearParentLink (own tx) and
 // UpdateItemWithParentLink (item-update tx), so a cleared parent commits
 // atomically with the field write it accompanied (BUG-2013).
-func (s *Store) clearParentLinkTx(tx *sql.Tx, itemID, workspaceID string) error {
+// Returns whether a link was actually REMOVED. Callers need the distinction:
+// clearing an already-unparented item deletes zero rows and changes nothing, so
+// forcing an item.updated for it would put an event on the wire describing a
+// mutation that did not happen (codex round 6).
+func (s *Store) clearParentLinkTx(tx *sql.Tx, itemID, workspaceID string) (bool, error) {
 	// Best-effort pre-lock read of the current parent, re-verified under lock.
 	oldParentID, err := s.readParentLinkTarget(tx, itemID)
 	if err != nil {
-		return fmt.Errorf("lookup parent for clear: %w", err)
+		return false, fmt.Errorf("lookup parent for clear: %w", err)
 	}
 
 	// BUG-2073: fold the CHILD's own (itemID) lock into the batch alongside
@@ -3574,7 +3628,7 @@ func (s *Store) clearParentLinkTx(tx *sql.Tx, itemID, workspaceID string) error 
 	// concurrent parent mutations of this item (SetParentLink/ClearParentLink/
 	// UpdateItemWithParentLink all take it), so a detach can't race a reparent.
 	if err := s.AcquireParentChildrenLocks(tx, itemID, oldParentID); err != nil {
-		return err
+		return false, err
 	}
 
 	// Re-read the parent under the child lock (BUG-2073 race 2): a concurrent
@@ -3585,26 +3639,26 @@ func (s *Store) clearParentLinkTx(tx *sql.Tx, itemID, workspaceID string) error 
 	// moved key here would risk an out-of-order grab).
 	reOldParentID, err := s.readParentLinkTarget(tx, itemID)
 	if err != nil {
-		return fmt.Errorf("lookup parent for clear: %w", err)
+		return false, fmt.Errorf("lookup parent for clear: %w", err)
 	}
 	if reOldParentID != oldParentID {
-		return errParentSetChanged
+		return false, errParentSetChanged
 	}
 
 	result, err := tx.Exec(s.q(`DELETE FROM item_links WHERE source_id = ? AND link_type = 'parent'`), itemID)
 	if err != nil {
-		return fmt.Errorf("clear parent link: %w", err)
+		return false, fmt.Errorf("clear parent link: %w", err)
 	}
 	rows, err := result.RowsAffected()
 	if err != nil {
-		return fmt.Errorf("clear parent link rows affected: %w", err)
+		return false, fmt.Errorf("clear parent link rows affected: %w", err)
 	}
 	if rows > 0 {
 		if err := s.bumpStructuralLinkSourceTx(tx, workspaceID, itemID); err != nil {
-			return err
+			return false, err
 		}
 	}
-	return nil
+	return rows > 0, nil
 }
 
 // bumpStructuralLinkSourceTx advances the source row whenever a parent or

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -538,7 +538,7 @@ func (s *Store) createItemTxWithID(tx *sql.Tx, id, workspaceID, collectionID str
 	// A failure here fails the create. That is not incidental — an outbox
 	// write that degrades to best-effort would look durable while
 	// reintroducing exactly the lost-event window the outbox exists to close.
-	if err := s.emitItemEventTx(tx, kernelevents.ItemCreated, item, nil); err != nil {
+	if err := s.emitItemEventTx(tx, kernelevents.ItemCreated, item, nil, ""); err != nil {
 		return nil, err
 	}
 	return item, nil
@@ -1953,8 +1953,8 @@ func (s *Store) listItemsFTS(workspaceID string, params models.ItemListParams) (
 	return scanItems(rows)
 }
 
-func (s *Store) UpdateItem(id string, input models.ItemUpdate) (*models.Item, error) {
-	return s.UpdateItemWithPreCheck(id, input, nil)
+func (s *Store) UpdateItem(id string, input models.ItemUpdate, opts ...MutationOption) (*models.Item, error) {
+	return s.UpdateItemWithPreCheck(id, input, nil, opts...)
 }
 
 // UpdateConflictError is returned by UpdateItem when the caller supplied
@@ -2044,8 +2044,9 @@ func (s *Store) UpdateItemWithPreCheck(
 	id string,
 	input models.ItemUpdate,
 	precheck func(tx *sql.Tx, existing *models.Item) error,
+	opts ...MutationOption,
 ) (*models.Item, error) {
-	return s.UpdateItemWithParentLink(id, input, precheck, nil)
+	return s.UpdateItemWithParentLink(id, input, precheck, nil, opts...)
 }
 
 // UpdateItemWithParentLink is UpdateItemWithPreCheck plus an OPTIONAL
@@ -2069,9 +2070,11 @@ func (s *Store) UpdateItemWithParentLink(
 	input models.ItemUpdate,
 	precheck func(tx *sql.Tx, existing *models.Item) error,
 	parentLink *ParentLinkUpdate,
+	opts ...MutationOption,
 ) (*models.Item, error) {
+	opt := newMutationOptions(opts)
 	return retryOnParentSetChanged(func() (*models.Item, error) {
-		return s.updateItemWithParentLinkOnce(id, input, precheck, parentLink)
+		return s.updateItemWithParentLinkOnce(id, input, precheck, parentLink, opt)
 	})
 }
 
@@ -2080,6 +2083,7 @@ func (s *Store) updateItemWithParentLinkOnce(
 	input models.ItemUpdate,
 	precheck func(tx *sql.Tx, existing *models.Item) error,
 	parentLink *ParentLinkUpdate,
+	opt mutationOptions,
 ) (*models.Item, error) {
 	existing, err := s.GetItem(id)
 	if err != nil {
@@ -2667,7 +2671,7 @@ func (s *Store) updateItemWithParentLinkOnce(
 	// The prior status comes from the same in-tx before/after comparison that
 	// wrote the status_transitions row, so the event and the transition log
 	// cannot disagree about what happened.
-	if err := s.emitItemUpdateEventsTx(tx, existing, updated, mutSignal.StatusChanged, mutSignal.FromStatus, doneKey); err != nil {
+	if err := s.emitItemUpdateEventsTx(tx, existing, updated, mutSignal.StatusChanged, mutSignal.FromStatus, doneKey, opt.batchID); err != nil {
 		return nil, err
 	}
 
@@ -2683,7 +2687,8 @@ func (s *Store) updateItemWithParentLinkOnce(
 // The seq bump uses the same MAX(seq)+1 subquery the other mutations
 // rely on; the advisory lock keeps concurrent Postgres writes from
 // racing on it.
-func (s *Store) DeleteItem(id string) error {
+func (s *Store) DeleteItem(id string, opts ...MutationOption) error {
+	opt := newMutationOptions(opts)
 	// Look up the workspace before the write so we can key the
 	// advisory lock and the seq subquery. The lookup tolerates
 	// already-deleted items (we still need to short-circuit cleanly
@@ -2752,7 +2757,7 @@ func (s *Store) DeleteItem(id string) error {
 	// live row at all, which must not emit an event for an item that was not
 	// there to archive.
 	if preArchive != nil {
-		if err := s.emitItemEventTx(tx, kernelevents.ItemDeleted, preArchive, nil); err != nil {
+		if err := s.emitItemEventTx(tx, kernelevents.ItemDeleted, preArchive, nil, opt.batchID); err != nil {
 			return err
 		}
 	}
@@ -2762,14 +2767,15 @@ func (s *Store) DeleteItem(id string) error {
 // RestoreItem un-archives a soft-deleted item and bumps the
 // workspace-scoped seq so delta-sync clients re-materialize the row.
 // Same lock + subquery shape as DeleteItem.
-func (s *Store) RestoreItem(id string) (*models.Item, error) {
+func (s *Store) RestoreItem(id string, opts ...MutationOption) (*models.Item, error) {
+	opt := newMutationOptions(opts)
 	// BUG-2073: retry if the item's parent set moves during lock acquisition.
 	return retryOnParentSetChanged(func() (*models.Item, error) {
-		return s.restoreItemOnce(id)
+		return s.restoreItemOnce(id, opt)
 	})
 }
 
-func (s *Store) restoreItemOnce(id string) (*models.Item, error) {
+func (s *Store) restoreItemOnce(id string, opt mutationOptions) (*models.Item, error) {
 	existing, err := s.GetItemIncludeDeleted(id)
 	if err != nil {
 		return nil, err
@@ -2845,7 +2851,7 @@ func (s *Store) restoreItemOnce(id string) (*models.Item, error) {
 		return nil, fmt.Errorf("read post-restore snapshot: %w", err)
 	}
 	if restored != nil {
-		if err := s.emitItemEventTx(tx, kernelevents.ItemRestored, restored, nil); err != nil {
+		if err := s.emitItemEventTx(tx, kernelevents.ItemRestored, restored, nil, opt.batchID); err != nil {
 			return nil, err
 		}
 	}
@@ -4504,16 +4510,19 @@ func (s *Store) MoveItem(itemID, targetCollectionID, newFieldsJSON string) (*mod
 func (s *Store) MoveItemWithPreCheck(
 	itemID, targetCollectionID, newFieldsJSON string,
 	precheck func(tx *sql.Tx, existing *models.Item) error,
+	opts ...MutationOption,
 ) (*models.Item, error) {
+	opt := newMutationOptions(opts)
 	// BUG-2073: retry if the item's parent set moves during lock acquisition.
 	return retryOnParentSetChanged(func() (*models.Item, error) {
-		return s.moveItemWithPreCheckOnce(itemID, targetCollectionID, newFieldsJSON, precheck)
+		return s.moveItemWithPreCheckOnce(itemID, targetCollectionID, newFieldsJSON, precheck, opt)
 	})
 }
 
 func (s *Store) moveItemWithPreCheckOnce(
 	itemID, targetCollectionID, newFieldsJSON string,
 	precheck func(tx *sql.Tx, existing *models.Item) error,
+	opt mutationOptions,
 ) (*models.Item, error) {
 	existing, err := s.GetItem(itemID)
 	if err != nil {
@@ -4664,12 +4673,12 @@ func (s *Store) moveItemWithPreCheckOnce(
 	}
 	if moved != nil {
 		if targetCollectionID != preMove.CollectionID {
-			if err := s.emitItemEventTx(tx, kernelevents.ItemMoved, moved, nil); err != nil {
+			if err := s.emitItemEventTx(tx, kernelevents.ItemMoved, moved, nil, opt.batchID); err != nil {
 				return nil, err
 			}
 		}
 		if newStatus != oldStatus {
-			if err := s.emitItemEventTx(tx, kernelevents.ItemStatusChanged, moved, &oldStatus); err != nil {
+			if err := s.emitItemEventTx(tx, kernelevents.ItemStatusChanged, moved, &oldStatus, opt.batchID); err != nil {
 				return nil, err
 			}
 		}
@@ -4681,7 +4690,7 @@ func (s *Store) moveItemWithPreCheckOnce(
 			return nil, cerr
 		}
 		if otherChanged {
-			if err := s.emitItemEventTx(tx, kernelevents.ItemUpdated, moved, nil); err != nil {
+			if err := s.emitItemEventTx(tx, kernelevents.ItemUpdated, moved, nil, opt.batchID); err != nil {
 				return nil, err
 			}
 		}

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -3315,6 +3315,41 @@ func (s *Store) setParentLinkOnce(workspaceID, itemID, parentID, createdBy strin
 		return nil, err
 	}
 
+	// item.updated for the CHILD, on this transaction (TASK-2714, codex round
+	// 4; SPEC-3 v1.6 clarification).
+	//
+	// A parent link writes the item's OWN row — it advances seq and flips the
+	// is_unparented bit — and that is the criterion the contract uses to
+	// divide these two rulings: a mutation that touches the item's row emits
+	// item.updated, and a relationship-graph link (blocks / blocked-by), which
+	// writes only the links table, stays silent under v1.5.
+	//
+	// The regression that forced it: createItemChecked calls this AFTER
+	// CreateItem has already committed item.created with a pre-link snapshot,
+	// then re-reads the item for its own response. The hand-called webhook
+	// this replaced dispatched that re-read, so a consumer saw the parent;
+	// under the drain, the frozen created row is all there was. created
+	// (pre-link) then updated (post-link) is a true history — a frozen
+	// pre-link snapshot with no correction is not.
+	//
+	// The snapshot MUST come from getItemTx: a pool read takes a different
+	// connection, cannot see this uncommitted write, and would emit the
+	// pre-link state under a post-link event.
+	//
+	// EMITTED HERE RATHER THAN IN setParentLinkTx, which is the shared core.
+	// UpdateItemWithParentLink reuses that core inside the item-update
+	// transaction and already emits its own item events from the field diff;
+	// putting the emit in the shared function would double-emit on that path.
+	child, err := s.getItemTx(tx, itemID)
+	if err != nil {
+		return nil, err
+	}
+	if child != nil {
+		if err := s.emitItemEventTx(tx, kernelevents.ItemUpdated, child, nil, ""); err != nil {
+			return nil, err
+		}
+	}
+
 	if err := tx.Commit(); err != nil {
 		return nil, fmt.Errorf("commit parent link: %w", err)
 	}

--- a/internal/store/items_cross_workspace_copy.go
+++ b/internal/store/items_cross_workspace_copy.go
@@ -1162,7 +1162,7 @@ func (s *Store) archiveItemForCopyTx(tx *sql.Tx, workspaceID, itemID, ts string)
 		return 0, fmt.Errorf("copy item across workspaces: source item %s was not archived", itemID)
 	}
 	if preArchive != nil {
-		if err := s.emitItemEventTx(tx, kernelevents.ItemDeleted, preArchive, nil); err != nil {
+		if err := s.emitItemEventTx(tx, kernelevents.ItemDeleted, preArchive, nil, ""); err != nil {
 			return 0, err
 		}
 	}

--- a/internal/store/migrations/081_event_outbox.sql
+++ b/internal/store/migrations/081_event_outbox.sql
@@ -12,12 +12,16 @@
 -- together, which is what lets SPEC-3's delivery guarantees be stated honestly
 -- rather than hoped for.
 --
--- NOTHING DRAINS THIS TABLE YET. Webhooks and SSE still fire from their
--- existing hand-called sites, unchanged; the drain that reads from here, the
--- canonical-to-surface name mapping, and the retirement of those hand-calls
--- are TASK-2714. The binding engine is later still (phase 2+). Stated in the
--- present tense on purpose — a comment describing the intended end state as if
--- it were the current one is how a reader concludes a feature is broken.
+-- SUPERSEDED BY TASK-2714, amended rather than left standing: this migration
+-- shipped saying nothing drained the table and that webhooks still fired from
+-- hand-called sites. The drain exists now and OWNS the webhook surface; the
+-- hand-calls are gone; the canonical-to-surface name mapping lives in
+-- internal/kernelevents. SSE is still published directly at the mutation site
+-- (SPEC-3 v1.5) and takes only its NAME from the taxonomy. The binding engine
+-- is later still (phase 2+) — nothing evaluates selectors today. Kept in the
+-- present tense on purpose, because a comment describing the intended end
+-- state as if it were the current one is how a reader concludes a feature is
+-- broken.
 --
 -- DELIBERATELY NO FOREIGN KEYS on workspace_id / subject_id, which is the one
 -- surprising thing in this schema. An outbox row must outlive its subject:

--- a/internal/store/migrations/082_event_outbox_batch.sql
+++ b/internal/store/migrations/082_event_outbox_batch.sql
@@ -1,0 +1,32 @@
+-- Migration 082: event_outbox.batch_id (TASK-2714, SPEC-3 v1.5).
+--
+-- The correlation key for handler-path bulk mutations. A lane-wide bulk action
+-- is a HANDLER LOOP over per-item store mutations — there is no bulk
+-- transaction — so each member writes its own canonical outbox row from its
+-- own transaction. That is what keeps SPEC-3's per-member binding evaluation
+-- free. It also means that without a marker, the drain would put 200
+-- item.deleted events on the webhook wire for a 200-item lane archive, which
+-- is precisely the flood TASK-1668's batch event exists to prevent.
+--
+-- So the handler stamps one id across every row of one bulk operation, and the
+-- drain folds a batch into ONE wire item.bulk_updated while the member rows
+-- stay individually addressable for bindings.
+--
+-- RECORDED, NEVER INFERRED (SPEC-3 v1.5). The alternative was grouping pending
+-- rows by workspace and a time window, which needs no schema — and would fold
+-- two unrelated single updates into somebody's bulk event whenever they landed
+-- in the same tick. A wire event that says "these five items changed together"
+-- is only true if something recorded that they did.
+--
+-- Nullable, and NULL is the overwhelmingly common case: every single-item
+-- mutation leaves it unset and delivers individually. No foreign key, matching
+-- the rest of this table — a batch is not a row anywhere, it is a name the
+-- handler minted for one operation.
+ALTER TABLE event_outbox ADD COLUMN batch_id TEXT;
+
+-- The drain's grouping index. Partial on the pending set, since a dispatched
+-- batch is never re-grouped, and NULL batch_ids are excluded because the
+-- single-item path never looks them up by batch.
+CREATE INDEX IF NOT EXISTS idx_event_outbox_batch
+    ON event_outbox(batch_id)
+    WHERE dispatched_at IS NULL AND batch_id IS NOT NULL;

--- a/internal/store/migrations/083_event_outbox_claim.sql
+++ b/internal/store/migrations/083_event_outbox_claim.sql
@@ -8,9 +8,12 @@
 -- consumer can budget for.
 --
 -- The claim is a conditional UPDATE (see ClaimPendingOutboxEvents), the same
--- protocol BUG-2415 established for orphan GC: one statement that both selects
--- and marks, so two instances racing on the same row produce one winner and
--- one no-op rather than two winners. Dialect-uniform on purpose — the
+-- protocol BUG-2415 established for orphan GC. Candidate rows are SELECTed
+-- first and then claimed one conditional UPDATE at a time; the select is only
+-- discovery, and the predicate ON THE UPDATE is the arbiter, so two instances
+-- racing on the same row produce one winner and one no-op rather than two
+-- winners. (Codex round 1 flagged an earlier version of this comment for
+-- describing it as a single statement doing both.) Dialect-uniform on purpose — the
 -- alternative, Postgres FOR UPDATE SKIP LOCKED with a separate SQLite path,
 -- is two implementations of one behaviour and only one of them ever runs in
 -- the environment where it matters.

--- a/internal/store/migrations/083_event_outbox_claim.sql
+++ b/internal/store/migrations/083_event_outbox_claim.sql
@@ -1,0 +1,30 @@
+-- Migration 083: event_outbox claim columns (TASK-2714).
+--
+-- Pad Cloud runs N instances against one database, and every one of them runs
+-- the drain. Without a claim, each pending row is delivered N times BY
+-- CONSTRUCTION. SPEC-3 §Delivery guarantees permits duplicates — consumers
+-- dedupe on the event id — but "occasionally, after a crash" and "always,
+-- once per instance" are different promises, and only the first is one a
+-- consumer can budget for.
+--
+-- The claim is a conditional UPDATE (see ClaimPendingOutboxEvents), the same
+-- protocol BUG-2415 established for orphan GC: one statement that both selects
+-- and marks, so two instances racing on the same row produce one winner and
+-- one no-op rather than two winners. Dialect-uniform on purpose — the
+-- alternative, Postgres FOR UPDATE SKIP LOCKED with a separate SQLite path,
+-- is two implementations of one behaviour and only one of them ever runs in
+-- the environment where it matters.
+--
+-- claimed_at doubles as the LEASE. A claimed row whose claim has aged past the
+-- lease window is re-claimable: an instance that dies between claiming and
+-- dispatching must not strand its rows, and at-least-once is exactly the
+-- promise that makes re-claiming safe.
+ALTER TABLE event_outbox ADD COLUMN claimed_at TEXT;
+ALTER TABLE event_outbox ADD COLUMN claimed_by TEXT;
+
+-- The claim query scans pending rows whose claim is absent or expired. The
+-- existing pending index orders by (occurred_at, id); this one narrows to the
+-- claim state so an instance does not walk rows another instance holds.
+CREATE INDEX IF NOT EXISTS idx_event_outbox_claim
+    ON event_outbox(claimed_at, occurred_at)
+    WHERE dispatched_at IS NULL;

--- a/internal/store/pgmigrations/060_event_outbox_batch.sql
+++ b/internal/store/pgmigrations/060_event_outbox_batch.sql
@@ -1,0 +1,32 @@
+-- Migration 060: event_outbox.batch_id (TASK-2714, SPEC-3 v1.5).
+--
+-- The correlation key for handler-path bulk mutations. A lane-wide bulk action
+-- is a HANDLER LOOP over per-item store mutations — there is no bulk
+-- transaction — so each member writes its own canonical outbox row from its
+-- own transaction. That is what keeps SPEC-3's per-member binding evaluation
+-- free. It also means that without a marker, the drain would put 200
+-- item.deleted events on the webhook wire for a 200-item lane archive, which
+-- is precisely the flood TASK-1668's batch event exists to prevent.
+--
+-- So the handler stamps one id across every row of one bulk operation, and the
+-- drain folds a batch into ONE wire item.bulk_updated while the member rows
+-- stay individually addressable for bindings.
+--
+-- RECORDED, NEVER INFERRED (SPEC-3 v1.5). The alternative was grouping pending
+-- rows by workspace and a time window, which needs no schema — and would fold
+-- two unrelated single updates into somebody's bulk event whenever they landed
+-- in the same tick. A wire event that says "these five items changed together"
+-- is only true if something recorded that they did.
+--
+-- Nullable, and NULL is the overwhelmingly common case: every single-item
+-- mutation leaves it unset and delivers individually. No foreign key, matching
+-- the rest of this table — a batch is not a row anywhere, it is a name the
+-- handler minted for one operation.
+ALTER TABLE event_outbox ADD COLUMN IF NOT EXISTS batch_id TEXT;
+
+-- The drain's grouping index. Partial on the pending set, since a dispatched
+-- batch is never re-grouped, and NULL batch_ids are excluded because the
+-- single-item path never looks them up by batch.
+CREATE INDEX IF NOT EXISTS idx_event_outbox_batch
+    ON event_outbox(batch_id)
+    WHERE dispatched_at IS NULL AND batch_id IS NOT NULL;

--- a/internal/store/pgmigrations/061_event_outbox_claim.sql
+++ b/internal/store/pgmigrations/061_event_outbox_claim.sql
@@ -8,9 +8,12 @@
 -- consumer can budget for.
 --
 -- The claim is a conditional UPDATE (see ClaimPendingOutboxEvents), the same
--- protocol BUG-2415 established for orphan GC: one statement that both selects
--- and marks, so two instances racing on the same row produce one winner and
--- one no-op rather than two winners. Dialect-uniform on purpose — the
+-- protocol BUG-2415 established for orphan GC. Candidate rows are SELECTed
+-- first and then claimed one conditional UPDATE at a time; the select is only
+-- discovery, and the predicate ON THE UPDATE is the arbiter, so two instances
+-- racing on the same row produce one winner and one no-op rather than two
+-- winners. (Codex round 1 flagged an earlier version of this comment for
+-- describing it as a single statement doing both.) Dialect-uniform on purpose — the
 -- alternative, Postgres FOR UPDATE SKIP LOCKED with a separate SQLite path,
 -- is two implementations of one behaviour and only one of them ever runs in
 -- the environment where it matters.

--- a/internal/store/pgmigrations/061_event_outbox_claim.sql
+++ b/internal/store/pgmigrations/061_event_outbox_claim.sql
@@ -1,0 +1,30 @@
+-- Migration 061: event_outbox claim columns (TASK-2714).
+--
+-- Pad Cloud runs N instances against one database, and every one of them runs
+-- the drain. Without a claim, each pending row is delivered N times BY
+-- CONSTRUCTION. SPEC-3 §Delivery guarantees permits duplicates — consumers
+-- dedupe on the event id — but "occasionally, after a crash" and "always,
+-- once per instance" are different promises, and only the first is one a
+-- consumer can budget for.
+--
+-- The claim is a conditional UPDATE (see ClaimPendingOutboxEvents), the same
+-- protocol BUG-2415 established for orphan GC: one statement that both selects
+-- and marks, so two instances racing on the same row produce one winner and
+-- one no-op rather than two winners. Dialect-uniform on purpose — the
+-- alternative, Postgres FOR UPDATE SKIP LOCKED with a separate SQLite path,
+-- is two implementations of one behaviour and only one of them ever runs in
+-- the environment where it matters.
+--
+-- claimed_at doubles as the LEASE. A claimed row whose claim has aged past the
+-- lease window is re-claimable: an instance that dies between claiming and
+-- dispatching must not strand its rows, and at-least-once is exactly the
+-- promise that makes re-claiming safe.
+ALTER TABLE event_outbox ADD COLUMN IF NOT EXISTS claimed_at TEXT;
+ALTER TABLE event_outbox ADD COLUMN IF NOT EXISTS claimed_by TEXT;
+
+-- The claim query scans pending rows whose claim is absent or expired. The
+-- existing pending index orders by (occurred_at, id); this one narrows to the
+-- claim state so an instance does not walk rows another instance holds.
+CREATE INDEX IF NOT EXISTS idx_event_outbox_claim
+    ON event_outbox(claimed_at, occurred_at)
+    WHERE dispatched_at IS NULL;

--- a/internal/webhooks/dispatcher.go
+++ b/internal/webhooks/dispatcher.go
@@ -74,7 +74,19 @@ type WebhookPayload struct {
 	// "webhook.test" ping a user fires from the CLI is not a kernel event,
 	// has no outbox row, and must not invent an id a consumer would dedupe
 	// against.
-	ID        string      `json:"id,omitempty"`
+	ID string `json:"id,omitempty"`
+
+	// BatchID correlates deliveries that belong to ONE bulk operation.
+	//
+	// Present on the folded item.bulk_updated event AND on any member
+	// delivered individually — which happens when a drain pass claims members
+	// before their header lands (SPEC-3 v1.6 makes "one wire event per batch"
+	// the normal case rather than an invariant). Without it on BOTH, a
+	// consumer receiving singles-then-partial-batch has no way to tell they
+	// were one operation, which is the entire reason the field exists (codex
+	// round 2 — the correlation was claimed in comments and reachable only
+	// from the folded half).
+	BatchID   string      `json:"batch_id,omitempty"`
 	Event     string      `json:"event"`
 	Workspace string      `json:"workspace"`
 	Timestamp string      `json:"timestamp"`
@@ -90,6 +102,9 @@ type Delivery struct {
 	WorkspaceID string
 	// EventID is the outbox row id, reaching the consumer as the dedupe key.
 	EventID string
+	// BatchID is the bulk operation this event belongs to, empty for the
+	// single-item mutations that are almost all of them.
+	BatchID string
 	// Event is the canonical events/1 name. The webhook wire name IS the
 	// canonical name — no mapping, unlike SSE's snake_case surface.
 	Event string
@@ -304,6 +319,7 @@ func (d *Dispatcher) DeliverEvent(dv Delivery) (DeliveryOutcome, error) {
 
 	body, err := json.Marshal(WebhookPayload{
 		ID:        dv.EventID,
+		BatchID:   dv.BatchID,
 		Event:     dv.Event,
 		Workspace: dv.WorkspaceID,
 		Timestamp: dv.OccurredAt,

--- a/internal/webhooks/dispatcher.go
+++ b/internal/webhooks/dispatcher.go
@@ -64,11 +64,76 @@ type WebhookStore interface {
 
 // WebhookPayload is the JSON body sent to each webhook endpoint.
 type WebhookPayload struct {
+	// ID is the outbox row id — the CONSUMER DEDUPE KEY. SPEC-3 §Delivery
+	// guarantees promises webhooks at-least-once with duplicates possible by
+	// design, and tells consumers to dedupe on the event id; before the drain
+	// existed, no id reached the wire at all, so that instruction named a
+	// field nobody could see.
+	//
+	// omitempty because one caller legitimately has no event: the
+	// "webhook.test" ping a user fires from the CLI is not a kernel event,
+	// has no outbox row, and must not invent an id a consumer would dedupe
+	// against.
+	ID        string      `json:"id,omitempty"`
 	Event     string      `json:"event"`
 	Workspace string      `json:"workspace"`
 	Timestamp string      `json:"timestamp"`
 	Data      interface{} `json:"data"`
 }
+
+// Delivery is one canonical event to put on the wire.
+//
+// A struct rather than four positional strings because three of them are
+// strings that would silently transpose, and the one that matters most
+// (OccurredAt vs dispatch time) is the one a reader would least suspect.
+type Delivery struct {
+	WorkspaceID string
+	// EventID is the outbox row id, reaching the consumer as the dedupe key.
+	EventID string
+	// Event is the canonical events/1 name. The webhook wire name IS the
+	// canonical name — no mapping, unlike SSE's snake_case surface.
+	Event string
+	// OccurredAt is the EVENT'S OWN timestamp, not dispatch time. SPEC-3
+	// §Bindings pins time-relative predicates to it precisely so a delayed
+	// drain cannot change how a predicate evaluates; stamping time.Now() here
+	// would make every consumer's notion of when the mutation happened depend
+	// on how backed up the queue was.
+	OccurredAt string
+	// Payload is the stored outbox payload, embedded VERBATIM under "data".
+	// json.RawMessage rather than []byte: []byte would base64-encode the
+	// snapshot into a string, which is valid JSON and completely unusable.
+	Payload json.RawMessage
+}
+
+// DeliveryOutcome is what the drain acks on.
+//
+// Counts rather than a single status because one event fans out to N
+// endpoints, and the answers can differ: an endpoint that 404s permanently and
+// one that times out transiently are the same "not delivered" to a boolean and
+// opposite decisions to a retry loop.
+type DeliveryOutcome struct {
+	// Matched is how many active webhooks selected this event. ZERO IS A
+	// SUCCESS, not a failure — a workspace with no webhooks has nothing owed
+	// to it, and treating it as undelivered would leave every event in every
+	// webhook-less workspace pending until the retention bound deleted it.
+	Matched   int
+	Succeeded int
+	// Permanent counts endpoints that rejected the delivery in a way no retry
+	// fixes (4xx, SSRF block, malformed URL). They do NOT hold the event
+	// pending: re-delivering to an endpoint that will reject it again buys
+	// nothing and costs the whole workspace's queue its progress.
+	Permanent int
+	// Transient counts endpoints whose retries were exhausted (network error,
+	// timeout, 5xx). These DO hold the event pending — the durable retry is
+	// the drain's, and it is the reason the outbox exists.
+	Transient int
+	LastError string
+}
+
+// Retryable reports whether any endpoint's failure is worth another drain
+// pass. It is the ack decision, stated once here rather than re-derived by
+// every caller from the counts.
+func (o DeliveryOutcome) Retryable() bool { return o.Transient > 0 }
 
 // Dispatcher sends webhook HTTP POST notifications for workspace events.
 type Dispatcher struct {
@@ -175,8 +240,16 @@ func screenDialAddr(address string) error {
 	return nil
 }
 
-// Dispatch sends the event payload to all matching active webhooks for the workspace.
-// Each delivery runs in its own goroutine so the caller is never blocked.
+// Dispatch sends the event payload to all matching active webhooks for the
+// workspace. Each delivery runs in its own goroutine so the caller is never
+// blocked, and NOTHING IS REPORTED BACK — by design, for the one caller that
+// remains: the "webhook.test" ping, which is a user pressing a button and
+// reading the result on the webhook row, not a kernel event with an outbox
+// row to ack.
+//
+// Canonical events do not come through here. They go through DeliverEvent,
+// because a drain cannot mark a row dispatched on the strength of having
+// SPAWNED some goroutines.
 func (d *Dispatcher) Dispatch(workspaceID, event string, data interface{}) {
 	hooks, err := d.store.ListWebhooks(workspaceID)
 	if err != nil {
@@ -184,14 +257,12 @@ func (d *Dispatcher) Dispatch(workspaceID, event string, data interface{}) {
 		return
 	}
 
-	payload := WebhookPayload{
+	body, err := json.Marshal(WebhookPayload{
 		Event:     event,
 		Workspace: workspaceID,
 		Timestamp: time.Now().UTC().Format(time.RFC3339),
 		Data:      data,
-	}
-
-	body, err := json.Marshal(payload)
+	})
 	if err != nil {
 		slog.Error("failed to marshal webhook payload", "error", err)
 		return
@@ -208,11 +279,68 @@ func (d *Dispatcher) Dispatch(workspaceID, event string, data interface{}) {
 	}
 }
 
+// DeliverEvent puts one canonical event on the wire SYNCHRONOUSLY and reports
+// what happened to each matching endpoint.
+//
+// This exists because acking is only honest if the ack follows the delivery.
+// Dispatch returns once its goroutines are spawned, so a drain built on it
+// would stamp rows dispatched while the HTTP requests were still in flight —
+// and a crash in that window loses exactly the events the outbox was built to
+// make unlosable. Blocking is the point, and the caller is a background drain
+// that has nothing better to do.
+//
+// The returned error is reserved for failures that are the SERVER's, not an
+// endpoint's — listing webhooks, marshalling the envelope. Those must not ack:
+// nothing was attempted, so the event is still owed. Per-endpoint failures
+// come back in the outcome instead, where the retry decision can see the
+// difference between "rejected us" and "did not answer".
+func (d *Dispatcher) DeliverEvent(dv Delivery) (DeliveryOutcome, error) {
+	var out DeliveryOutcome
+
+	hooks, err := d.store.ListWebhooks(dv.WorkspaceID)
+	if err != nil {
+		return out, fmt.Errorf("list webhooks: %w", err)
+	}
+
+	body, err := json.Marshal(WebhookPayload{
+		ID:        dv.EventID,
+		Event:     dv.Event,
+		Workspace: dv.WorkspaceID,
+		Timestamp: dv.OccurredAt,
+		Data:      dv.Payload,
+	})
+	if err != nil {
+		return out, fmt.Errorf("marshal webhook payload: %w", err)
+	}
+
+	for _, hook := range hooks {
+		if !hook.Active {
+			continue
+		}
+		if !matchesEvent(hook.Events, dv.Event) {
+			continue
+		}
+		out.Matched++
+		switch d.deliver(hook, body) {
+		case deliverySuccess:
+			out.Succeeded++
+		case deliveryPermanent:
+			out.Permanent++
+			out.LastError = "permanent delivery failure to " + hook.ID
+		default:
+			out.Transient++
+			out.LastError = "transient delivery failure to " + hook.ID
+		}
+	}
+	return out, nil
+}
+
 // deliver sends a webhook, retrying transient failures up to
-// maxDeliveryAttempts with linear backoff, and records the final outcome
-// once via the store. Permanent failures (4xx, SSRF block, malformed URL)
+// maxDeliveryAttempts with linear backoff, records the final outcome once via
+// the store, and RETURNS that outcome. The async Dispatch path discards the
+// return; DeliverEvent tallies it, which is the whole of requirement 2. Permanent failures (4xx, SSRF block, malformed URL)
 // stop immediately without consuming retries.
-func (d *Dispatcher) deliver(hook models.Webhook, body []byte) {
+func (d *Dispatcher) deliver(hook models.Webhook, body []byte) deliveryResult {
 	result := deliveryPermanent
 	for attempt := 1; attempt <= maxDeliveryAttempts; attempt++ {
 		result = d.attemptDeliver(hook, body)
@@ -226,6 +354,7 @@ func (d *Dispatcher) deliver(hook models.Webhook, body []byte) {
 		}
 	}
 	d.store.UpdateWebhookFailure(hook.ID, result != deliverySuccess)
+	return result
 }
 
 // attemptDeliver performs a single HTTP POST to the webhook URL and

--- a/internal/webhooks/dispatcher_test.go
+++ b/internal/webhooks/dispatcher_test.go
@@ -20,6 +20,7 @@ type mockStore struct {
 	hooks    []models.Webhook
 	failures map[string]bool // id -> last failed state
 	updated  chan string     // signals when UpdateWebhookFailure is called
+	listErr  error           // when set, ListWebhooks fails
 }
 
 func newMockStore(hooks []models.Webhook) *mockStore {
@@ -32,6 +33,9 @@ func newMockStore(hooks []models.Webhook) *mockStore {
 func (m *mockStore) ListWebhooks(workspaceID string) ([]models.Webhook, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	if m.listErr != nil {
+		return nil, m.listErr
+	}
 	var result []models.Webhook
 	for _, h := range m.hooks {
 		if h.WorkspaceID == workspaceID {
@@ -507,5 +511,206 @@ func TestDispatcher_RedirectBlockIsPermanent(t *testing.T) {
 	defer store.mu.Unlock()
 	if !store.failures["hook-1"] {
 		t.Error("expected failure recorded for blocked redirect")
+	}
+}
+
+// Tests for DeliverEvent — the synchronous delivery seam the outbox drain acks
+// on (TASK-2714 requirements 1 and 2).
+
+func deliverTestHook(url, events string) *mockStore {
+	return newMockStore([]models.Webhook{{
+		ID:          "hook-1",
+		WorkspaceID: "ws-1",
+		URL:         url,
+		Events:      events,
+		Active:      true,
+	}})
+}
+
+// TestDeliverEvent_EnvelopeCarriesIDAndEventTime pins requirement 1 and the
+// envelope's two easy-to-get-wrong fields.
+//
+// The dedupe key is the point: SPEC-3 tells consumers to dedupe on the event
+// id, and before the drain nothing put one on the wire. The timestamp is the
+// subtle one — it must be the event's OWN occurred_at, because SPEC-3 pins
+// time-relative binding predicates to it, so stamping dispatch time would make
+// every consumer's notion of when a mutation happened depend on how backed up
+// the queue was.
+func TestDeliverEvent_EnvelopeCarriesIDAndEventTime(t *testing.T) {
+	bodies := make(chan []byte, 1)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		bodies <- b
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	d := NewDispatcher(deliverTestHook(ts.URL, `["*"]`))
+	d.SkipSSRF = true
+
+	occurred := "2026-01-02T03:04:05Z"
+	out, err := d.DeliverEvent(Delivery{
+		WorkspaceID: "ws-1",
+		EventID:     "outbox-row-42",
+		Event:       "item.created",
+		OccurredAt:  occurred,
+		Payload:     json.RawMessage(`{"id":"item-9","title":"Embedded verbatim"}`),
+	})
+	if err != nil {
+		t.Fatalf("DeliverEvent: %v", err)
+	}
+	if out.Matched != 1 || out.Succeeded != 1 {
+		t.Fatalf("outcome = %+v, want one matched and one succeeded", out)
+	}
+
+	// The body must already be here: DeliverEvent returning before its HTTP
+	// request completed is the async shape the drain cannot ack on.
+	var raw []byte
+	select {
+	case raw = <-bodies:
+	default:
+		t.Fatal("DeliverEvent returned before the endpoint was called — delivery is not synchronous")
+	}
+
+	var got WebhookPayload
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("decode delivered body: %v", err)
+	}
+	if got.ID != "outbox-row-42" {
+		t.Errorf("envelope id = %q, want the outbox row id — consumers dedupe on it", got.ID)
+	}
+	if got.Event != "item.created" {
+		t.Errorf("envelope event = %q, want the canonical name", got.Event)
+	}
+	if got.Timestamp != occurred {
+		t.Errorf("envelope timestamp = %q, want the event's occurred_at %q (not dispatch time)", got.Timestamp, occurred)
+	}
+
+	// The payload must be embedded as JSON, not base64'd (what []byte would
+	// do) and not double-encoded into a string.
+	var envelope struct {
+		Data map[string]any `json:"data"`
+	}
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		t.Fatalf("decode envelope data: %v", err)
+	}
+	if envelope.Data["title"] != "Embedded verbatim" {
+		t.Errorf("data = %v, want the outbox payload embedded verbatim", envelope.Data)
+	}
+}
+
+// TestDeliverEvent_OutcomeDrivesTheAckDecision is the requirement-2 test: the
+// drain must be able to tell "rejected us" from "did not answer", because they
+// are opposite retry decisions.
+//
+// Each leg asserts Retryable() rather than just the counts, since that is the
+// value the drain actually branches on.
+func TestDeliverEvent_OutcomeDrivesTheAckDecision(t *testing.T) {
+	t.Run("permanent rejection does not hold the event pending", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		defer ts.Close()
+
+		d := NewDispatcher(deliverTestHook(ts.URL, `["*"]`))
+		d.SkipSSRF = true
+		d.retryBackoff = 0
+
+		out, err := d.DeliverEvent(Delivery{WorkspaceID: "ws-1", Event: "item.created", Payload: json.RawMessage(`{}`)})
+		if err != nil {
+			t.Fatalf("DeliverEvent: %v", err)
+		}
+		if out.Permanent != 1 || out.Transient != 0 {
+			t.Fatalf("outcome = %+v, want one permanent failure and no transient", out)
+		}
+		if out.Retryable() {
+			t.Error("Retryable() = true for a 404 — re-delivering to an endpoint that will reject it again holds up the whole queue")
+		}
+	})
+
+	t.Run("transient failure holds the event pending", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer ts.Close()
+
+		d := NewDispatcher(deliverTestHook(ts.URL, `["*"]`))
+		d.SkipSSRF = true
+		d.retryBackoff = 0
+
+		out, err := d.DeliverEvent(Delivery{WorkspaceID: "ws-1", Event: "item.created", Payload: json.RawMessage(`{}`)})
+		if err != nil {
+			t.Fatalf("DeliverEvent: %v", err)
+		}
+		if out.Transient != 1 || out.Permanent != 0 {
+			t.Fatalf("outcome = %+v, want one transient failure and no permanent", out)
+		}
+		if !out.Retryable() {
+			t.Error("Retryable() = false for a 5xx — the durable retry is the drain's, and it is why the outbox exists")
+		}
+	})
+}
+
+// TestDeliverEvent_NoMatchingHooksIsSuccess pins the case that would otherwise
+// wedge every webhook-less workspace.
+//
+// Zero matched endpoints means nothing is owed, so the event is done. A drain
+// that read "nothing succeeded" as "not delivered" would leave every event in
+// every workspace without webhooks pending until the retention bound deleted
+// it — turning the common case into a permanent backlog.
+func TestDeliverEvent_NoMatchingHooksIsSuccess(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("endpoint was called for an event it does not subscribe to")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	for _, tc := range []struct {
+		name  string
+		store *mockStore
+	}{
+		{"workspace has no webhooks at all", newMockStore(nil)},
+		{"webhook subscribes to other events", deliverTestHook(ts.URL, `["comment.created"]`)},
+		{"webhook is inactive", newMockStore([]models.Webhook{{
+			ID: "hook-1", WorkspaceID: "ws-1", URL: ts.URL, Events: `["*"]`, Active: false,
+		}})},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			d := NewDispatcher(tc.store)
+			d.SkipSSRF = true
+
+			out, err := d.DeliverEvent(Delivery{WorkspaceID: "ws-1", Event: "item.created", Payload: json.RawMessage(`{}`)})
+			if err != nil {
+				t.Fatalf("DeliverEvent: %v", err)
+			}
+			if out.Matched != 0 {
+				t.Fatalf("Matched = %d, want 0", out.Matched)
+			}
+			if out.Retryable() {
+				t.Error("Retryable() = true with nothing to deliver to — every event in this workspace would back up forever")
+			}
+		})
+	}
+}
+
+// TestDeliverEvent_ServerSideFailureIsAnError separates the failure the drain
+// must NOT ack from the ones it may.
+//
+// Listing webhooks failing means nothing was attempted, so the event is still
+// owed in full. Returning it in the outcome instead of as an error would let a
+// database blip look like "delivered to zero endpoints", which acks.
+func TestDeliverEvent_ServerSideFailureIsAnError(t *testing.T) {
+	store := newMockStore(nil)
+	store.listErr = fmt.Errorf("database unavailable")
+
+	d := NewDispatcher(store)
+	d.SkipSSRF = true
+
+	out, err := d.DeliverEvent(Delivery{WorkspaceID: "ws-1", Event: "item.created", Payload: json.RawMessage(`{}`)})
+	if err == nil {
+		t.Fatalf("DeliverEvent returned nil error on a store failure; outcome %+v would ack an undelivered event", out)
+	}
+	if !strings.Contains(err.Error(), "database unavailable") {
+		t.Errorf("error = %v, want it to carry the store's cause", err)
 	}
 }


### PR DESCRIPTION
Phase-0 unit 2b of PLAN-2656 (TASK-2714). TASK-2658 made the outbox FILL; this makes it DRAIN, and moves webhook delivery off the handlers onto it.

## What changes on the wire

Stated first, because "no behaviour change" would be false here.

- **Timing.** Deliveries were post-commit and inline; they are now up to one drain interval (5s default) later. In exchange a delivery survives a crash — the event commits with the mutation it describes.
- **The disjoint-delta rule arrives** (SPEC-3 v1.3, ruled during 2a). A bare status flip now emits `item.status_changed` ONLY, where the hand-call always emitted `item.updated`. A mixed update emits both.
- **Envelopes** gain `id` (the dedupe key SPEC-3 already told consumers to use, which nothing put on the wire before) and `batch_id`; `timestamp` is the event's `occurred_at` rather than dispatch time, so a backed-up queue cannot change how a time-relative binding predicate evaluates.
- **Item payloads** come from the in-transaction read-back and are PII-scrubbed — the joined assignee name and email are gone, deliberately: a frozen payload outlives account de-identification.
- **`item.updated_with_comment` is retired** (SPEC-3 v1.2, Dave's ruling). One producer deleted; the dead `events.ItemUpdatedWithComment` constant went with it.
- **`item.bulk_updated`** carries `batch_id`, the shared delta, and the member snapshots folded in from the member rows.

## Surface inventory

Enumerated before scoping, per CONVE-18, and both counts corrected during the unit:

- **Webhook emission: 12 sites, not 10.** The 10 hand-called `dispatchWebhook` sites, plus two `s.webhooks.Dispatch` DIRECT calls the count missed — the `webhook.test` ping (deliberately not a kernel event; it stays a direct call) and the helper definition. Nine were deleted here; the composite was retired earlier in the branch; the helper itself went as dead code.
- **SSE emission: 12 canonical-corresponding sites** out of a ~55-site publish-helper family. The other ~43 (documents, stars, reactions, collections, workspaces, versions, watch-notify) stay hand-called — the closure rule makes their events/1 silence a versioned fact, not a gap.
- **Five store entry points** carry the bulk path, not four as my own escalation said: archive, restore, move, field update, assign. Restore was the one I missed.

## Design decisions, all ruled rather than assumed

Four forks went to the lead before implementation and became SPEC-3 v1.5/v1.6 text:

1. **The drain owns webhooks only.** "Both surfaces derive from one canonical name" means NAME derivation, not delivery path. SSE stays direct-published — it carries request-scoped attribution (Actor/ActorName/Source) that a frozen payload deliberately does not hold — and takes only its name from the taxonomy. Moving SSE behind the drain is TASK-2722.
2. **Handler-path bulk correlates via a recorded `batch_id`**, never an inferred one. Time-window grouping would fold two unrelated updates into somebody's bulk event.
3. **Multi-instance claiming** is a dialect-uniform conditional UPDATE (BUG-2415's protocol), with `claimed_at` doubling as the lease.
4. **Item-link mutations** are silent in events/1 — with the boundary made mechanical during review: a mutation that writes the ITEM'S OWN ROW emits `item.updated`; one that writes only the links table does not. Parent hierarchy crosses that line, blocks/blocked-by do not. `implements` bumps the row AND is a relationship link, so the contract does not decide it; flagged at both call sites and left alone rather than putting an event nobody ruled on onto a public wire.

## Review loop

**Ten Codex rounds, CLEAN at round 10.** Rounds 1-9 each found something real; every round after the first was aimed at the previous round's own fix, and that angle produced the P1 five times running.

- **R1**: `batchID` was threaded into the bulk helpers' signatures but not passed at three of six store calls — four verbs' member rows stayed unbatched while the header still claimed them as a batch. The store-level test could not see it: it called the store methods directly, proving the option works and saying nothing about the handler. Also: fold dedup, move delta, five comment overclaims.
- **R2**: `batch_id` reached only the folded half, so individually-delivered members carried no correlation while three comments claimed they did; and R1's dedup could drop `prior_status`.
- **R3**: claim tokens were minted and never checked — a late pass could ack or RELEASE rows a newer pass owned.
- **R4**: retention could delete a row another instance was mid-delivery on; create-with-parent webhooks carried a pre-link snapshot (a genuine regression against main, escalated and ruled).
- **R5**: the parent-only update path still emitted nothing; my own R4 comment and test overclaimed what the payload carries (the test's `is_unparented` assertion passed vacuously against an absent field).
- **R6**: parent DETACH was silent on two of three routes; `hierarchyChanged` meant "provided", not "changed".
- **R7-R9**: the batch delta reported the request rather than the commit (tag trimming, tag/untag dedup, assignment precedence), and two more raw SSE-name literals.

## Verification

**Mutation matrix: 47 applied, 47 caught.** Notably, four results initially read as SURVIVORS and were not — two had failed to BUILD, one met a vacuous test, one was a script that never applied and reported green. Each was caught by grepping the file rather than trusting the exit line; all four are recorded in the commits that contain them.

Two vacuous tests of my own were found by the matrix and rewritten to assert what the WRONG behaviour would DO: the claim-exclusivity test (the candidate query produced the same end state, so the arbiter's predicate could be deleted) and the retention guard's test (RFC3339 is second-granular, so the end state was produced by the CLOCK).

## Gates, on the exact tip

- `go build ./...` — clean
- `gofmt -l` — clean
- `make lint` — exit 0, **0 issues**
- `go test ./...` — exit 0, all packages
- `make test-pg` — exit 0, **3448 PASS / 0 FAIL**, with 152 lines of this unit's own test legs verified PRESENT in the Postgres output
- No `go.mod`, `web/`, or `nix/` changes, so no vendorHash exposure; no MCP surface change, so no `ToolSurfaceVersion` bump

**Worktree note for the next seat:** `go build ./...` and `make lint` cannot run in a fresh worktree — `embed.go` wants `all:web/build`, which is gitignored and absent. `cp -r ../docapp/web/build web/build` is the fix (go:embed does not follow symlinks); skipping the leg is not.
