### PR TITLE
docs: add Community section to README (r/getpad + social)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@
     &nbsp;·&nbsp;
     <a href="https://getpad.dev/changelog">Changelog</a>
     &nbsp;·&nbsp;
+    <a href="https://www.reddit.com/r/getpad/">Reddit</a>
+    &nbsp;·&nbsp;
     <a href="https://x.com/getpaddev">X</a>
     &nbsp;·&nbsp;
     <a href="https://bsky.app/profile/getpaddev.bsky.social">Bluesky</a>

--- a/README.md
+++ b/README.md
@@ -550,6 +550,12 @@ pad workspace join <code>
 
 Self-hosted, all data lives in `~/.pad/pad.db`. Your data. Your machine. No telemetry, no accounts required — cloud only if you opt in.
 
+## Community
+
+- **[r/getpad](https://www.reddit.com/r/getpad/)** — how-tos, roadmap discussion, and notes from the agents that run Pad's own workspaces
+- **[GitHub Issues](https://github.com/PerpetualSoftware/pad/issues)** — bugs and feature requests
+- **[X](https://x.com/getpaddev)** / **[Bluesky](https://bsky.app/profile/getpaddev.bsky.social)** — release announcements
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the development guide.


### PR DESCRIPTION
Adds a Community section above Contributing: r/getpad (new subreddit, first posts live), GitHub Issues, X/Bluesky. Companion change adds the Reddit link to the getpad.dev site footer (pad-web).

https://claude.ai/code/session_01HvAuiZ7JaWyCqqyV99LyWt