### PR TITLE
fix(events): a resume must not be answered from coverage we never had (BUG-2731)

### DIFF
--- a/cmd/pad/cmd_server.go
+++ b/cmd/pad/cmd_server.go
@@ -687,12 +687,12 @@ func serveCmd() *cobra.Command {
 				// only trace was a line nobody's log aggregator was
 				// shaped to catch.
 				redis.SetLogger(redisSlogLogger{})
-				eventBus = events.NewRedisBusWithKeys(rc, redisKeys)
+				eventBus = newObservedEventBus(rc, redisKeys, m)
 				watchRedis = rc
 				slog.Info("Event bus using Redis pub/sub", "addr", opts.Addr, "db", opts.DB,
 					"namespace", redisKeys.Namespace())
 			} else {
-				eventBus = events.New()
+				eventBus = newObservedEventBus(nil, redisKeys, m)
 				slog.Info("Event bus using in-memory (single instance)")
 			}
 			// Wrap event bus with Prometheus instrumentation
@@ -1297,4 +1297,36 @@ func humanBytes(n int64) string {
 		exp = len(suffixes) - 1
 	}
 	return fmt.Sprintf("%.1f %s", float64(n)/float64(div), suffixes[exp])
+}
+
+// newObservedEventBus builds the event bus for this deployment shape with its
+// operational observer already attached (BUG-2731). A nil client selects the
+// in-process bus.
+//
+// EXTRACTED SO THE WIRING IS TESTABLE, which is the whole point (CONVE-19:
+// wiring is a claim). Inline in the command's RunE, the SetObserver call was a
+// claim no test could reach: an events-package test proves the bus calls its
+// observer and a metrics-package test proves the adapter maps it, and both
+// pass with that line deleted.
+//
+// The observer attaches to the CONCRETE bus because SetObserver is not part of
+// the EventBus interface the wrapper implements, so it has to happen before
+// the value is widened — a typing constraint, not a subtle ordering
+// requirement. What the wrapper genuinely cannot do is REPLACE this: the
+// conditions reported here are detected inside the bus, on the receive path
+// and inside the coverage rules, not at the interface it wraps.
+//
+// The in-process bus is wired too, deliberately: a single-process deployment
+// restarts, and the cold-buffer resume gap is exactly as real there. Its reset
+// counter stays at zero by construction — MemoryBus owns its own IDs and has
+// no shared counter to lose.
+func newObservedEventBus(rc *redis.Client, redisKeys redisns.Keys, m *metrics.Metrics) events.EventBus {
+	if rc != nil {
+		bus := events.NewRedisBusWithKeys(rc, redisKeys)
+		bus.SetObserver(metrics.NewEventsObserver(m))
+		return bus
+	}
+	bus := events.New()
+	bus.SetObserver(metrics.NewEventsObserver(m))
+	return bus
 }

--- a/cmd/pad/event_bus_wiring_test.go
+++ b/cmd/pad/event_bus_wiring_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+
+	"github.com/PerpetualSoftware/pad/internal/events"
+	"github.com/PerpetualSoftware/pad/internal/metrics"
+	"github.com/PerpetualSoftware/pad/internal/redisns"
+)
+
+// CONVE-19: wiring is a claim. internal/events proves the bus calls its
+// observer and internal/metrics proves the adapter maps it to a counter —
+// and BOTH pass with the SetObserver call in this package deleted, because
+// each of those tests attaches the observer itself. This is the only test
+// that fails when the production wiring goes missing.
+//
+// Both deployment shapes, because they are two separate call sites and only
+// one of them is exercised by any given deployment.
+func TestBothEventBusShapesReportToMetrics(t *testing.T) {
+	t.Run("in-process", func(t *testing.T) {
+		m := metrics.New()
+		bus := newObservedEventBus(nil, redisns.Default, m)
+		t.Cleanup(bus.Close)
+
+		// Negative control first: a served resume must not move the counter,
+		// so a non-zero reading cannot be mistaken for this test's work.
+		bus.Publish(events.Event{Type: events.ItemCreated, WorkspaceID: "ws-1"})
+		if got := bus.EventsSince("ws-1", 1); got == nil {
+			t.Fatal("a caught-up cursor must be served")
+		}
+		assertResumeGaps(t, m, 0)
+
+		if got := bus.EventsSince("ws-never-seen", 4200); got != nil {
+			t.Fatalf("expected a gap, got %d events", len(got))
+		}
+		assertResumeGaps(t, m, 1)
+	})
+
+	t.Run("redis", func(t *testing.T) {
+		mr := miniredis.RunT(t)
+		client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+		t.Cleanup(func() { _ = client.Close() })
+
+		m := metrics.New()
+		bus := newObservedEventBus(client, redisns.Default, m)
+		t.Cleanup(bus.Close)
+
+		assertResumeGaps(t, m, 0)
+
+		if got := bus.EventsSince("ws-never-seen", 4200); got != nil {
+			t.Fatalf("expected a gap, got %d events", len(got))
+		}
+		assertResumeGaps(t, m, 1)
+	})
+}
+
+// Reads the counter straight off the registry rather than through a helper
+// exported from internal/metrics: this is the only consumer outside that
+// package's own tests, and widening a production API to serve one test is a
+// worse trade than eight lines here.
+func assertResumeGaps(t *testing.T, m *metrics.Metrics, want float64) {
+	t.Helper()
+	families, err := m.Registry.Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+	var got float64
+	for _, f := range families {
+		if f.GetName() != "pad_event_resume_gaps_total" {
+			continue
+		}
+		for _, metric := range f.GetMetric() {
+			got += metric.GetCounter().GetValue()
+		}
+	}
+	if got != want {
+		t.Fatalf("pad_event_resume_gaps_total = %v, want %v", got, want)
+	}
+}

--- a/cmd/pad/redis_keyspace_wiring_test.go
+++ b/cmd/pad/redis_keyspace_wiring_test.go
@@ -66,6 +66,41 @@ func TestAllRedisKeyspacesShareOneNamespace(t *testing.T) {
 		}
 	}
 
+	// ONE LEVEL OF INDIRECTION IS ALLOWED AND CHECKED. The event bus is
+	// built by newObservedEventBus so its observer wiring is testable
+	// (BUG-2731), which means the constructor above receives that helper's
+	// PARAMETER rather than the outer variable. Naming the parameter
+	// redisKeys keeps the check above meaningful only if every CALL to the
+	// helper also passes the shared value — otherwise the identifier check
+	// is satisfied by a shadowed name and proves nothing.
+	//
+	// The `func ` exclusion and the EXACT count both matter (codex round 8):
+	// the naive pattern also matches the helper's own DECLARATION, so a
+	// version accepting "at least 2" would be satisfied by the declaration
+	// plus a single call site — passing while one deployment shape went
+	// unchecked.
+	helperCall := regexp.MustCompile(`(?:^|[^c])(?:\bfunc\s+)?newObservedEventBus\(([^)]*)\)`)
+	var helperCalls [][]string
+	for _, m := range helperCall.FindAllStringSubmatch(text, -1) {
+		if strings.Contains(m[0], "func ") {
+			continue // the declaration, not a call
+		}
+		helperCalls = append(helperCalls, m)
+	}
+	const wantHelperCalls = 2 // the Redis shape and the in-process shape
+	if len(helperCalls) != wantHelperCalls {
+		t.Fatalf("found %d newObservedEventBus CALL sites in cmd_server.go, want %d (the Redis and in-process shapes) — "+
+			"either a shape was dropped, a third was added without this guard being updated, or the helper "+
+			"was renamed and this half of the guard is now inert",
+			len(helperCalls), wantHelperCalls)
+	}
+	for _, m := range helperCalls {
+		if !argsContainIdentifier(m[1], sharedVar) {
+			t.Errorf("helper call %q does not pass %s — the namespace must reach the bus constructor "+
+				"from the shared value, not from a locally assembled one", strings.TrimSpace(m[0]), sharedVar)
+		}
+	}
+
 	// And that variable must come from the validated parser, not be
 	// assembled locally.
 	if !strings.Contains(text, sharedVar+", err := redisns.Parse(") {

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -165,21 +165,95 @@ cross-tenant leak.
 > 2. **Rolling BACK re-creates the split** unless the namespace is unset at the
 >    same time. The env var and the binary version have to move together in both
 >    directions.
-> 3. **Client resync is honest on the watch stream and silent on the activity
->    stream.** The notification stream answers resumes with `sync_required` —
->    by way of its cold replay-buffer coverage check rather than the epoch
->    comparison, since a freshly namespaced bus has no old epoch to compare
->    against. The workspace
->    activity stream (`/api/v1/events`) has no equivalent: a client reconnecting
->    with a `Last-Event-ID` from the old keyspace against a fresh replay buffer
->    is treated as caught up, so it silently misses whatever happened during the
->    cutover until its next full page load. That is a pre-existing property of
->    any cold replay buffer (a replica restart does the same), not something the
->    namespace introduced — it is called out here because a namespace change is
->    the one case an operator triggers deliberately.
+> 3. **Client resync is honest on both streams**, with one documented edge.
+>    Each answers a resume whose cursor belongs to the old keyspace with
+>    `sync_required`, by way of its cold replay-buffer coverage check rather
+>    than an epoch comparison — a freshly namespaced bus has no old epoch to
+>    compare against. Expect a burst of full re-fetches as clients reconnect;
+>    that is the cutover being paid for, and it is bounded by the number of
+>    reconnecting clients — each RESUME is counted, so a client that
+>    reconnects several times counts several times.
+>
+>    The edge: a cursor that lands exactly one below the first ID a replica
+>    sees in the new keyspace is served rather than refused, because nothing in
+>    an integer cursor distinguishes the two keyspaces. It is narrow — that one
+>    value, on a client that reconnects before the replica has seen anything
+>    else — and closing it needs the ID space's identity on the wire, which the
+>    SSE `id:` field has no room for. Tracked as BUG-2736. A maintenance window
+>    narrows it — clients reconnect against an already-cut-over instance rather
+>    than racing the cutover — but does not remove it, since their stored
+>    `Last-Event-ID` values still belong to the old keyspace and the wire
+>    format still cannot say which one they came from.
+>
+>    Before BUG-2731 the activity stream (`/api/v1/events`) was the silent one:
+>    a client reconnecting with a `Last-Event-ID` from the old keyspace against
+>    a fresh replay buffer was treated as caught up and silently missed
+>    everything that happened during the cutover, until its next full page
+>    load. If you are running a build older than that fix, the old behaviour
+>    still applies and a namespace change wants a maintenance window rather
+>    than a live cutover.
 >
 > Session-presence entries are transient — 90s TTL — and cost nothing either
 > way.
+
+**Upgrading ACROSS the BUG-2731 fix partitions the activity stream for the
+duration of the roll.** The activity channel's payload gained an
+`<epoch>|<id>|` prefix so the ID can be assigned atomically with the publish;
+receivers on the new build understand both the prefixed and the old bare-JSON
+form, so **new instances handle old publishers fine**. The reverse does not
+hold: an instance still running the old build cannot parse a prefixed payload
+and **drops that event for its own connected clients**, logging
+`failed to unmarshal Redis event` each time.
+
+What that means in practice:
+
+- The asymmetry lasts only as long as mixed versions are running. Roll all
+  replicas promptly rather than parking a partial rollout.
+- Clients connected to old-build replicas miss activity events published by
+  new-build replicas during the window. **They heal when they reconnect to a
+  NEW-build replica**, which answers the resume with `sync_required` — or,
+  if that replica happens to hold coverage spanning the client's cursor,
+  replays the missed events directly.
+  A reconnect that lands on another old-build replica is served by the old code
+  and can still be told it is caught up, so the stale window lasts until the
+  client's connection happens to land on an upgraded replica — which is the
+  practical reason to roll promptly rather than park a half-finished rollout.
+
+  **One case does not self-heal on the stream at all**, and it is worth
+  understanding before deciding how much the window matters: if a client's
+  cursor is advanced PAST a dropped event by a later one it did receive, no
+  replica will ever replay the dropped event, because from every replica's
+  point of view that client is up to date. Nothing on the stream is wrong
+  after that — it is a specific missing row in a live view. It is corrected by
+  any full reconciliation (a page load, a navigation that refetches the
+  collection), not by reconnecting. Data at rest is never affected; the store
+  is the source of truth and the stream is a notification channel.
+- The error log is a signal that the window is OPEN; it going quiet is **not**
+  proof the roll finished. On an idle workspace there is nothing to publish and
+  nothing to fail to parse. Confirm from the rollout itself — every replica on
+  the new build — not from the absence of errors.
+- **An old build restarting the counter mid-roll produces a visible resume-gap
+  loop.** If the Redis sequence key is lost while old-build replicas are still
+  publishing, cursors at or below the dead sequence's high-water mark are
+  refused until the new sequence climbs past it, so affected clients resync
+  repeatedly. It is loud by design — `pad_event_resume_gaps_total` climbs and
+  every drop logs a warning — and it ends when the roll does, because on the
+  new build a counter restart rotates the epoch instead, which clears the
+  floor. The remedy is to finish the roll, not to wait it out.
+- **ID ordering is also mixed during the window**, and it is handled rather
+  than merely tolerated. An old-build publisher still assigns its ID and
+  publishes as two separate steps, so a new-build instance can receive a
+  higher ID before a lower one. It reads that as the sequence having been
+  reset, drops its replay buffers, and — the part that matters — refuses
+  resumes from the cursors whose successors it just discarded, so an affected
+  client resyncs instead of being told it is current. Expect
+  `pad_event_sequence_resets_total{reason="counter_backwards"}` to move during
+  a roll for this reason; it should stop once every replica is on the new
+  build.
+
+The alternative — wrapping the epoch in a JSON envelope — was rejected because
+an old instance would unmarshal it into an empty event with **no error at
+all**, turning a loud, self-announcing window into a silent one.
 
 Pad's Redis integration assumes a **single Redis node** — `redis://…`, not a
 cluster. Key names carry no hash tags and Pad dials a non-cluster client, so a
@@ -211,6 +285,9 @@ Alert on these instead:
 | `pad_watchevents_notifications_dropped_total` | Received but not delivered to a local subscriber |
 | `pad_watchevents_sequence_resets_total` | The Redis counter or epoch changed; replay buffers dropped |
 | `pad_watchevents_receive_loop_exits_total` | Non-zero outside shutdown means an instance publishes but receives nothing |
+| `pad_event_resume_gaps_total` | The ACTIVITY stream's (`/api/v1/events`) twin of the watch counter above. **Expect a step around a deploy that settles back to baseline** — each instance starts with no replay coverage, so an early resume against a workspace it has not seen yet is a warranted resync. It counts RESUMES, not clients: a deploy with no reconnects does not move it at all, and a client that reconnects several times is counted several times. A rate that does not settle is the thing to alert on |
+| `pad_event_sequence_resets_total` | Activity replay coverage dropped, by reason. **Read the label.** `epoch_change` / `counter_backwards` mean the shared ID space changed under a RUNNING instance and every buffer was dropped — no benign baseline: a flushed counter key or two installations on one endpoint. `subscription_resumed` means a pub/sub connection dropped and resubscribed, dropping one workspace's buffer — expect it during a Redis failover and expect it to stop afterwards. Note a `PAD_REDIS_NAMESPACE` change does **not** show up here, because it takes a restart, and a freshly started instance has no coverage to lose |
+| `pad_event_receive_loop_exits_total` | A workspace's activity subscription loop stopped. Unlike the watch stream's twin this does **not** stay at zero — it is expected at shutdown and whenever a workspace's last local subscriber leaves. Read it as a rate against a stable subscriber count |
 | `pad_session_presence_failures_total` | Presence operations failing — **read the `op` label**, the risks differ and run in opposite directions: `register`/`renew` may under-report (a live session unlisted and untargetable), `deregister` may over-report (a dead session left listed, and a push aimed at it reaches nobody), `list` returns a 503, `prune` is benign. A failure means the operation reported an error — Redis can fail a pipeline after applying it, so the write may have landed anyway |
 
 **Avoid an evicting `maxmemory-policy` for Pad's Redis.**
@@ -574,7 +651,8 @@ curl -s http://localhost:7777/api/v1/health   # {"status":"ok"}
 - [ ] **Redis:** Connected for multi-instance events, notifications, and session presence (`PAD_REDIS_URL`), on a non-evicting `maxmemory-policy`, single node (not a cluster)
 - [ ] **Redis namespace:** `PAD_REDIS_NAMESPACE` set if this endpoint is shared with another Pad installation
 - [ ] **Streaming limits:** `PAD_SSE_MAX_CONNECTIONS` / `PAD_SSE_MAX_PER_USER` sized for your fleet (both cover *both* SSE endpoints)
-- [ ] **Redis alerting:** `pad_redis_up` and `pad_watchevents_sequence_gaps_total` wired to alerts
+- [ ] **Redis alerting:** `pad_redis_up`, `pad_watchevents_sequence_gaps_total` and `pad_event_sequence_resets_total` wired to alerts
+- [ ] **Stream-honesty alerting:** `pad_event_resume_gaps_total` alerting on a rate that does NOT settle after a deploy (a step around one is expected — cold replay buffers), and `pad_event_receive_loop_exits_total` read as a rate against a stable subscriber count. See the metrics table above for what each label means
 - [ ] **TLS:** Reverse proxy with valid certificates
 - [ ] **Secure cookies:** `PAD_SECURE_COOKIES=true` (requires TLS)
 - [ ] **Public URL:** `PAD_URL` set to your public-facing domain

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -169,7 +169,8 @@ cross-tenant leak.
 >    Each answers a resume whose cursor belongs to the old keyspace with
 >    `sync_required`, by way of its cold replay-buffer coverage check rather
 >    than an epoch comparison — a freshly namespaced bus has no old epoch to
->    compare against. Expect a burst of full re-fetches as clients reconnect;
+>    compare against. Expect a burst of client reconciliation as they reconnect
+>    — an incremental `/changes` delta each, not a full page load;
 >    that is the cutover being paid for, and it is bounded by the number of
 >    reconnecting clients — each RESUME is counted, so a client that
 >    reconnects several times counts several times.
@@ -178,8 +179,10 @@ cross-tenant leak.
 >    sees in the new keyspace is served rather than refused, because nothing in
 >    an integer cursor distinguishes the two keyspaces. It is narrow — that one
 >    value, on a client that reconnects before the replica has seen anything
->    else — and closing it needs the ID space's identity on the wire, which the
->    SSE `id:` field has no room for. Tracked as BUG-2736. A maintenance window
+>    else — and closing it needs the ID space's identity to reach the client.
+>    The SSE spec would allow that (an event ID is arbitrary UTF-8); what
+>    excludes it is Pad's own `id:` contract, an int64 that every deployed
+>    client already parses. Tracked as BUG-2736. A maintenance window
 >    narrows it — clients reconnect against an already-cut-over instance rather
 >    than racing the cutover — but does not remove it, since their stored
 >    `Last-Event-ID` values still belong to the old keyspace and the wire
@@ -226,7 +229,7 @@ Alert on these instead:
 | `pad_watchevents_notifications_dropped_total` | Received but not delivered to a local subscriber |
 | `pad_watchevents_sequence_resets_total` | The Redis counter or epoch changed; replay buffers dropped |
 | `pad_watchevents_receive_loop_exits_total` | Non-zero outside shutdown means an instance publishes but receives nothing |
-| `pad_event_resume_gaps_total` | The ACTIVITY stream's (`/api/v1/events`) twin of the watch counter above. **Expect a step around a deploy that settles back to baseline** — each instance starts with no replay coverage, so an early resume against a workspace it has not seen yet is a warranted resync. It counts RESUMES, not clients: a deploy with no reconnects does not move it at all, and a client that reconnects several times is counted several times. A rate that does not settle is the thing to alert on |
+| `pad_event_resume_gaps_total` | The ACTIVITY stream's (`/api/v1/events`) twin of the watch counter above. **Expect a step around a deploy, with the RATE settling back to baseline** (the counter itself only ever increases) — each instance starts with no replay coverage, so an early resume against a workspace it has not seen yet is a warranted resync. It counts RESUMES, not clients: a deploy with no reconnects does not move it at all, and a client that reconnects several times is counted several times. A rate that does not settle is the thing to alert on |
 | `pad_event_sequence_resets_total` | Activity replay coverage dropped, by reason. Today one reason: `subscription_resumed`, a pub/sub connection that dropped and resubscribed, dropping that workspace's buffer — expect it during a Redis failover and expect it to stop afterwards |
 | `pad_event_receive_loop_exits_total` | A workspace's activity subscription loop stopped. Unlike the watch stream's twin this does **not** stay at zero — it is expected at shutdown and whenever a workspace's last local subscriber leaves. Read it as a rate against a stable subscriber count |
 | `pad_session_presence_failures_total` | Presence operations failing — **read the `op` label**, the risks differ and run in opposite directions: `register`/`renew` may under-report (a live session unlisted and untargetable), `deregister` may over-report (a dead session left listed, and a push aimed at it reaches nobody), `list` returns a 503, `prune` is benign. A failure means the operation reported an error — Redis can fail a pipeline after applying it, so the write may have landed anyway |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -196,65 +196,6 @@ cross-tenant leak.
 > Session-presence entries are transient — 90s TTL — and cost nothing either
 > way.
 
-**Upgrading ACROSS the BUG-2731 fix partitions the activity stream for the
-duration of the roll.** The activity channel's payload gained an
-`<epoch>|<id>|` prefix so the ID can be assigned atomically with the publish;
-receivers on the new build understand both the prefixed and the old bare-JSON
-form, so **new instances handle old publishers fine**. The reverse does not
-hold: an instance still running the old build cannot parse a prefixed payload
-and **drops that event for its own connected clients**, logging
-`failed to unmarshal Redis event` each time.
-
-What that means in practice:
-
-- The asymmetry lasts only as long as mixed versions are running. Roll all
-  replicas promptly rather than parking a partial rollout.
-- Clients connected to old-build replicas miss activity events published by
-  new-build replicas during the window. **They heal when they reconnect to a
-  NEW-build replica**, which answers the resume with `sync_required` — or,
-  if that replica happens to hold coverage spanning the client's cursor,
-  replays the missed events directly.
-  A reconnect that lands on another old-build replica is served by the old code
-  and can still be told it is caught up, so the stale window lasts until the
-  client's connection happens to land on an upgraded replica — which is the
-  practical reason to roll promptly rather than park a half-finished rollout.
-
-  **One case does not self-heal on the stream at all**, and it is worth
-  understanding before deciding how much the window matters: if a client's
-  cursor is advanced PAST a dropped event by a later one it did receive, no
-  replica will ever replay the dropped event, because from every replica's
-  point of view that client is up to date. Nothing on the stream is wrong
-  after that — it is a specific missing row in a live view. It is corrected by
-  any full reconciliation (a page load, a navigation that refetches the
-  collection), not by reconnecting. Data at rest is never affected; the store
-  is the source of truth and the stream is a notification channel.
-- The error log is a signal that the window is OPEN; it going quiet is **not**
-  proof the roll finished. On an idle workspace there is nothing to publish and
-  nothing to fail to parse. Confirm from the rollout itself — every replica on
-  the new build — not from the absence of errors.
-- **An old build restarting the counter mid-roll produces a visible resume-gap
-  loop.** If the Redis sequence key is lost while old-build replicas are still
-  publishing, cursors at or below the dead sequence's high-water mark are
-  refused until the new sequence climbs past it, so affected clients resync
-  repeatedly. It is loud by design — `pad_event_resume_gaps_total` climbs and
-  every drop logs a warning — and it ends when the roll does, because on the
-  new build a counter restart rotates the epoch instead, which clears the
-  floor. The remedy is to finish the roll, not to wait it out.
-- **ID ordering is also mixed during the window**, and it is handled rather
-  than merely tolerated. An old-build publisher still assigns its ID and
-  publishes as two separate steps, so a new-build instance can receive a
-  higher ID before a lower one. It reads that as the sequence having been
-  reset, drops its replay buffers, and — the part that matters — refuses
-  resumes from the cursors whose successors it just discarded, so an affected
-  client resyncs instead of being told it is current. Expect
-  `pad_event_sequence_resets_total{reason="counter_backwards"}` to move during
-  a roll for this reason; it should stop once every replica is on the new
-  build.
-
-The alternative — wrapping the epoch in a JSON envelope — was rejected because
-an old instance would unmarshal it into an empty event with **no error at
-all**, turning a loud, self-announcing window into a silent one.
-
 Pad's Redis integration assumes a **single Redis node** — `redis://…`, not a
 cluster. Key names carry no hash tags and Pad dials a non-cluster client, so a
 user's presence index and their session entries would hash to different slots
@@ -286,7 +227,7 @@ Alert on these instead:
 | `pad_watchevents_sequence_resets_total` | The Redis counter or epoch changed; replay buffers dropped |
 | `pad_watchevents_receive_loop_exits_total` | Non-zero outside shutdown means an instance publishes but receives nothing |
 | `pad_event_resume_gaps_total` | The ACTIVITY stream's (`/api/v1/events`) twin of the watch counter above. **Expect a step around a deploy that settles back to baseline** — each instance starts with no replay coverage, so an early resume against a workspace it has not seen yet is a warranted resync. It counts RESUMES, not clients: a deploy with no reconnects does not move it at all, and a client that reconnects several times is counted several times. A rate that does not settle is the thing to alert on |
-| `pad_event_sequence_resets_total` | Activity replay coverage dropped, by reason. **Read the label.** `epoch_change` / `counter_backwards` mean the shared ID space changed under a RUNNING instance and every buffer was dropped — no benign baseline: a flushed counter key or two installations on one endpoint. `subscription_resumed` means a pub/sub connection dropped and resubscribed, dropping one workspace's buffer — expect it during a Redis failover and expect it to stop afterwards. Note a `PAD_REDIS_NAMESPACE` change does **not** show up here, because it takes a restart, and a freshly started instance has no coverage to lose |
+| `pad_event_sequence_resets_total` | Activity replay coverage dropped, by reason. Today one reason: `subscription_resumed`, a pub/sub connection that dropped and resubscribed, dropping that workspace's buffer — expect it during a Redis failover and expect it to stop afterwards |
 | `pad_event_receive_loop_exits_total` | A workspace's activity subscription loop stopped. Unlike the watch stream's twin this does **not** stay at zero — it is expected at shutdown and whenever a workspace's last local subscriber leaves. Read it as a rate against a stable subscriber count |
 | `pad_session_presence_failures_total` | Presence operations failing — **read the `op` label**, the risks differ and run in opposite directions: `register`/`renew` may under-report (a live session unlisted and untargetable), `deregister` may over-report (a dead session left listed, and a push aimed at it reaches nobody), `list` returns a 503, `prune` is benign. A failure means the operation reported an error — Redis can fail a pipeline after applying it, so the write may have landed anyway |
 
@@ -651,7 +592,7 @@ curl -s http://localhost:7777/api/v1/health   # {"status":"ok"}
 - [ ] **Redis:** Connected for multi-instance events, notifications, and session presence (`PAD_REDIS_URL`), on a non-evicting `maxmemory-policy`, single node (not a cluster)
 - [ ] **Redis namespace:** `PAD_REDIS_NAMESPACE` set if this endpoint is shared with another Pad installation
 - [ ] **Streaming limits:** `PAD_SSE_MAX_CONNECTIONS` / `PAD_SSE_MAX_PER_USER` sized for your fleet (both cover *both* SSE endpoints)
-- [ ] **Redis alerting:** `pad_redis_up`, `pad_watchevents_sequence_gaps_total` and `pad_event_sequence_resets_total` wired to alerts
+- [ ] **Redis alerting:** `pad_redis_up` and `pad_watchevents_sequence_gaps_total` wired to alerts
 - [ ] **Stream-honesty alerting:** `pad_event_resume_gaps_total` alerting on a rate that does NOT settle after a deploy (a step around one is expected — cold replay buffers), and `pad_event_receive_loop_exits_total` read as a rate against a stable subscriber count. See the metrics table above for what each label means
 - [ ] **TLS:** Reverse proxy with valid certificates
 - [ ] **Secure cookies:** `PAD_SECURE_COOKIES=true` (requires TLS)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -99,14 +99,16 @@ type Config struct {
 	// dump. For that case it is a genuine cross-tenant leak.
 	//
 	// Changing it on a running deployment is a cutover, not a tweak, and
-	// the two streams behave DIFFERENTLY across it. The watch stream
-	// detects the changed id space through its epoch key and answers
-	// resumes with sync_required. The workspace activity stream does not:
-	// a client resuming against a fresh replay buffer is treated as
-	// caught up and silently misses the cutover window (BUG-2731,
-	// pre-existing — a replica restart does the same). Presence entries
-	// are transient and cost nothing either way. It also partitions a
-	// rolling upgrade in both directions; see docs/deployment.md.
+	// BOTH streams now answer resumes across it with sync_required — the
+	// watch stream through its epoch key, the workspace activity stream
+	// through the replay coverage check BUG-2731 added. Expect a burst of
+	// client re-fetches as they reconnect — one per RESUME, so a client that
+	// reconnects several times re-fetches several times.
+	// (Before BUG-2731 the activity stream was the silent one: a client
+	// resuming against a fresh replay buffer was treated as caught up and
+	// missed the cutover window.) Presence entries are transient and cost
+	// nothing either way. It also partitions a rolling upgrade in both
+	// directions; see docs/deployment.md.
 	RedisNamespace string `toml:"redis_namespace"`
 
 	// Push carries per-USER push/consent preferences (PLAN-2613 S2). A

--- a/internal/events/bus.go
+++ b/internal/events/bus.go
@@ -217,8 +217,14 @@ type replayBuffer struct {
 	// rollout, which is a migration rather than a bug fix.
 	//
 	// Invalidated only by lifecycle facts this instance can actually
-	// observe — losing the workspace's subscription, or the ID space
-	// resetting underneath it — never by a gap between IDs.
+	// observe — today, losing the workspace's subscription (it stopping, or
+	// a pub/sub reconnect) — never by a gap between IDs.
+	//
+	// AN ID-SPACE RESET IS NOT ON THAT LIST, deliberately. Detecting one
+	// needs the identity this buffer does not carry, so a reset Redis counter
+	// can still leave two incarnations' IDs in one buffer. That is BUG-2736's
+	// unit, and this comment names the omission rather than letting a reader
+	// assume the coverage rule covers more than it does.
 	//
 	// IT BOUNDS THE START OF COVERAGE, NOT ITS CONTINUITY, and that limit is
 	// structural rather than an omission: a message lost mid-subscription

--- a/internal/events/bus.go
+++ b/internal/events/bus.go
@@ -156,7 +156,15 @@ type EventBus interface {
 
 	// EventsSince returns events for a workspace with IDs greater than sinceID.
 	// Used to replay missed events on SSE reconnect (Last-Event-ID).
-	// Returns nil if sinceID is too old and has been evicted from the buffer.
+	//
+	// Returns nil whenever this instance CANNOT VOUCH for the span the caller
+	// is asking about, which the SSE handler turns into sync_required. That
+	// covers eviction (the historical meaning), and since BUG-2731 also a
+	// buffer whose coverage starts above the caller's cursor — including the
+	// buffer not existing at all, which is a cold start, a restart, a
+	// scale-up, or the first connection to a workspace on this instance.
+	// Returns an empty (non-nil) slice only when the caller is genuinely
+	// caught up.
 	EventsSince(workspaceID string, sinceID int64) []Event
 
 	// Close shuts down the event bus and cleans up resources.
@@ -177,6 +185,50 @@ type replayBuffer struct {
 	size   int // max capacity
 	head   int // next write position
 	count  int // current number of events
+
+	// knownFrom is the lowest event ID from which this buffer's coverage of
+	// its workspace can be VOUCHED FOR: the first ID appended since this
+	// instance began continuously receiving the workspace. Zero means
+	// nothing has been appended, which is strictly less knowledge than any
+	// non-zero value and must produce at least as strong a signal.
+	//
+	// CONTINUITY HERE MEANS RECEIVING-CONTINUITY, NEVER ID-CONTIGUITY, and
+	// that is the one thing to understand before changing this (BUG-2731).
+	// internal/watchevents has a field of the same name that ALSO detects
+	// holes, by noticing a non-consecutive ID — and porting that here would
+	// be a serious regression, because this bus has a GLOBAL counter and
+	// PER-WORKSPACE buffers. Four publishes alternating across two
+	// workspaces give W=[1 4] and X=[2 3]: a workspace's buffer holds
+	// non-consecutive IDs BY CONSTRUCTION, so an id-contiguity check would
+	// fire on nearly every append, reset knownFrom every time, and turn
+	// every resume into sync_required — the false-positive inversion of the
+	// bug this field exists to fix. The watch bus can do it because it has
+	// one logical stream whose IDs are consecutive by construction; we
+	// cannot, and no cleverer local check recovers it — see BUG-2735, which
+	// carries the two real options (a per-workspace counter, or an authority
+	// read against the shared counter) and the load arithmetic that ruled
+	// the second one out.
+	//
+	// THE ID SPACE'S IDENTITY IS ALSO NOT HERE. This buffer can say where its
+	// coverage started; it cannot say which INCARNATION of the counter that
+	// ID belongs to, so a restarted process reusing low IDs can still answer
+	// an old low cursor. That is BUG-2736, and it is deliberately a separate
+	// unit: closing it changes the Redis wire format and needs a two-phase
+	// rollout, which is a migration rather than a bug fix.
+	//
+	// Invalidated only by lifecycle facts this instance can actually
+	// observe — losing the workspace's subscription, or the ID space
+	// resetting underneath it — never by a gap between IDs.
+	//
+	// IT BOUNDS THE START OF COVERAGE, NOT ITS CONTINUITY, and that limit is
+	// structural rather than an omission: a message lost mid-subscription
+	// (hold 100, miss 101, receive 102) leaves NO local trace here, because
+	// per-workspace IDs are non-consecutive by construction and 101 may
+	// simply have belonged to another workspace. BUG-2735 carries that case,
+	// the two non-local options for detecting it, and why one of them was
+	// ruled out on load. Do not try to recover it with a cleverer local
+	// check; there isn't one.
+	knownFrom int64
 }
 
 func newReplayBuffer(size int) *replayBuffer {
@@ -193,14 +245,39 @@ func (rb *replayBuffer) append(e Event) {
 	if rb.count < rb.size {
 		rb.count++
 	}
+	if rb.knownFrom == 0 {
+		// First append since this buffer started (or restarted) covering
+		// the workspace. From this ID forward we can answer honestly.
+		rb.knownFrom = e.ID
+	}
 }
 
 // since returns all buffered events with ID > sinceID, in chronological order.
-// Returns nil if sinceID is older than the oldest buffered event AND the buffer
-// is full (i.e. events have been evicted), meaning we can't guarantee completeness.
-// Returns an empty (non-nil) slice if sinceID is current (no missed events).
-// A sinceID of 0 means "give me everything in the buffer".
+// Returns nil when this buffer cannot vouch for completeness across the
+// requested span — the caller turns that into sync_required. Returns an empty
+// (non-nil) slice if sinceID is current (no missed events). A sinceID of 0
+// means "give me everything in the buffer" and is never a coverage question:
+// a fresh client is not resuming from a position, so there is no span to span.
 func (rb *replayBuffer) since(sinceID int64) []Event {
+	// COVERAGE CHECK (BUG-2731). A resume asking about IDs at or below what
+	// this buffer started covering cannot be answered honestly, and the
+	// pre-BUG-2731 code answered it anyway — with an empty-but-non-nil slice,
+	// which the SSE handler reads as "caught up". An empty buffer cannot
+	// prove a client is current, and neither can a partial one whose first
+	// event is above the client's cursor.
+	//
+	// sinceID+1 == knownFrom PASSES THIS CHECK: there is no ID strictly
+	// between the cursor and our first event, so no workspace event can have
+	// been missed in that span. (It may still be refused further down by the
+	// eviction or newest-ID checks — this one check is not the whole answer.)
+	// sinceID+1 < knownFrom leaves room for a missed event, and because the
+	// ID space is shared across workspaces (see knownFrom) we cannot tell
+	// whether the IDs in that room were ours. Refusing is the conservative
+	// direction and the only honest one.
+	if sinceID > 0 && (rb.knownFrom == 0 || sinceID+1 < rb.knownFrom) {
+		return nil
+	}
+
 	if rb.count == 0 {
 		return []Event{}
 	}
@@ -250,6 +327,13 @@ type subscriber struct {
 // MemoryBus is an in-process pub/sub event bus that fans out events
 // to all subscribers for a given workspace. Suitable for single-instance deployments.
 type MemoryBus struct {
+	// observable carries the optional operational-event seam (BUG-2731).
+	// Wired here as well as on RedisBus, and deliberately: a single-process
+	// deployment restarts too, and the cold-buffer resume gap is exactly as
+	// real there. The reset counters stay at zero here by construction —
+	// MemoryBus assigns its own IDs and has no shared counter to lose.
+	observable
+
 	mu          sync.RWMutex
 	subscribers map[chan Event]*subscriber
 
@@ -367,18 +451,46 @@ func (b *MemoryBus) Publish(event Event) {
 }
 
 // EventsSince returns buffered events for a workspace with IDs greater than sinceID.
-// Returns nil if sinceID has been evicted from the buffer (gap too large).
+// Returns nil when this instance cannot vouch for the requested span (gap too
+// large, or coverage that never reached back that far — see replayBuffer.since).
 // Returns an empty slice if the caller is fully caught up.
 func (b *MemoryBus) EventsSince(workspaceID string, sinceID int64) []Event {
+	// Counted in ONE place, on the way out, so both ways of failing to serve
+	// a resume land on the same counter: the workspace having no buffer at
+	// all, and since() refusing the span. Counting at each `return nil`
+	// instead is how a gap metric ends up measuring one of its two halves —
+	// the failure BUG-2699's own metric shipped with, and the reason this is
+	// structural rather than remembered.
+	var missed []Event
+	defer func() {
+		if missed == nil {
+			b.reportResumeGap(workspaceID)
+		}
+	}()
+
 	b.replayMu.RLock()
 	defer b.replayMu.RUnlock()
 
 	rb, ok := b.replayBuffers[workspaceID]
 	if !ok {
-		// No events ever published for this workspace.
-		return []Event{}
+		// Nothing has been published for this workspace IN THIS PROCESS.
+		//
+		// For a fresh client (sinceID == 0) that is honestly "nothing to
+		// replay". For a RESUMING client it is the strongest form of "cannot
+		// vouch" there is (BUG-2731): this bus assigns its own IDs starting
+		// from 1 on every start, so a non-zero cursor for a workspace we have
+		// never published to belongs to a previous incarnation of the process
+		// — or to another instance — and the events between it and now are
+		// unrecoverable here. Answering []Event{} told that client it was
+		// caught up and silently dropped everything it had missed.
+		if sinceID > 0 {
+			return nil
+		}
+		missed = []Event{}
+		return missed
 	}
-	return rb.since(sinceID)
+	missed = rb.since(sinceID)
+	return missed
 }
 
 // Close shuts down the event bus by closing all subscriber channels.

--- a/internal/events/observer.go
+++ b/internal/events/observer.go
@@ -15,11 +15,11 @@ import "sync"
 // because those conditions are detected INSIDE the bus and are invisible from
 // outside it:
 //
-//   - A resume this instance could not serve is a nil return from EventsSince.
-//     A wrapper CAN see that nil — the point is that it cannot see WHY, or
-//     that it happened at all without reimplementing the coverage rules it is
-//     wrapping, and the reason (cold start vs eviction vs reset) is what an
-//     operator needs. Instrumenting it outside would duplicate the decision.
+//   - A resume this instance could not serve is a nil return from EventsSince,
+//     and a wrapper CAN see that nil. What it cannot see is WHY — cold start,
+//     eviction, a stopped subscription — which is the part an operator acts
+//     on, and recovering it outside means reimplementing the coverage rules
+//     being wrapped.
 //   - A sequence reset is detected on the RECEIVE path, in fanOut, which no
 //     caller ever invokes and no wrapper can observe.
 //
@@ -35,11 +35,14 @@ type Observer interface {
 	// ResumeGap reports that a Last-Event-ID resume could not be served from
 	// this instance's view, so the client is told sync_required and re-fetches.
 	//
-	// This is the user-visible one: every increment is one client doing a
-	// full resync. It is also the metric that makes this fix falsifiable in
-	// production — the fix's whole claim is that the syncs it adds are the
-	// WARRANTED ones, and a rate that does not settle after a deploy is the
-	// evidence against it.
+	// Every increment is one client being told to reconcile. NOT necessarily a
+	// full re-fetch: the web client answers sync_required with an incremental
+	// /changes delta and only falls back to a full refresh after a long
+	// absence or a failure (web/src/lib/services/sync.svelte.ts).
+	//
+	// It is the metric that makes this fix falsifiable in production — the
+	// claim is that the syncs it adds are the WARRANTED ones, and a RATE that
+	// does not settle after a deploy is the evidence against it.
 	ResumeGap(workspaceID string)
 
 	// SequenceReset reports that this instance's replay coverage was thrown

--- a/internal/events/observer.go
+++ b/internal/events/observer.go
@@ -1,0 +1,118 @@
+package events
+
+import "sync"
+
+// Observer receives OPERATIONAL events from an EventBus — the conditions an
+// operator would want to alert on, as opposed to the events the bus exists to
+// deliver.
+//
+// WHY THIS EXISTS ALONGSIDE metrics.InstrumentedBus, WHICH ALREADY WRAPS THIS
+// BUS. Read this before "fixing" the duplication back into the wrapper.
+//
+// A wrapper can instrument anything visible at the EventBus interface:
+// publishes, subscriptions, subscriber counts. That covered everything this
+// package reported before BUG-2731. It cannot cover what BUG-2731 added,
+// because those conditions are detected INSIDE the bus and are invisible from
+// outside it:
+//
+//   - A resume this instance could not serve is a nil return from EventsSince.
+//     A wrapper CAN see that nil — the point is that it cannot see WHY, or
+//     that it happened at all without reimplementing the coverage rules it is
+//     wrapping, and the reason (cold start vs eviction vs reset) is what an
+//     operator needs. Instrumenting it outside would duplicate the decision.
+//   - A sequence reset is detected on the RECEIVE path, in fanOut, which no
+//     caller ever invokes and no wrapper can observe.
+//
+// So the two coexist deliberately, split by what each can actually see, which
+// is the same split internal/watchevents made for the same reason. Both keep
+// Prometheus out of this package.
+//
+// Implementations must be safe for concurrent use and must not block. Every
+// report fires with no bus lock held, so an observer may call back into the
+// bus — except into a method that itself REPORTS (EventsSince can), which
+// would be unbounded mutual recursion no lock discipline can prevent.
+type Observer interface {
+	// ResumeGap reports that a Last-Event-ID resume could not be served from
+	// this instance's view, so the client is told sync_required and re-fetches.
+	//
+	// This is the user-visible one: every increment is one client doing a
+	// full resync. It is also the metric that makes this fix falsifiable in
+	// production — the fix's whole claim is that the syncs it adds are the
+	// WARRANTED ones, and a rate that does not settle after a deploy is the
+	// evidence against it.
+	ResumeGap(workspaceID string)
+
+	// SequenceReset reports that this instance's replay coverage was thrown
+	// away because something happened it cannot account for. reason is bounded
+	// so it can be a metric label:
+	//
+	//   "subscription_resumed" — a pub/sub connection dropped and resubscribed,
+	//                             so this instance cannot account for whatever
+	//                             was published while it was away.
+	//
+	// A bounded label rather than a bare counter because the reason is what an
+	// operator acts on, and because BUG-2736's ID-space work adds reasons here
+	// (a changed epoch, a restarted counter) that are diagnosed differently
+	// from a connection flap.
+	SequenceReset(reason string)
+
+	// ReceiveLoopExited reports that a workspace's Redis subscription loop
+	// has stopped. After this the instance receives nothing for that
+	// workspace — including its own publishes, which come back through Redis
+	// like everyone else's.
+	//
+	// Expected at shutdown and whenever the last local subscriber for a
+	// workspace leaves. It earns its counter as a RATE: a steady trickle with
+	// stable subscriber counts means loops are dying under something other
+	// than those two causes, which is otherwise invisible from outside the
+	// process.
+	ReceiveLoopExited()
+}
+
+// Reset reasons. Bounded by construction so they are safe as metric labels.
+const (
+	// ResetReasonSubscriptionResumed is scoped to ONE workspace: a dropped
+	// subscription says nothing about any other channel. See Observer.
+	ResetReasonSubscriptionResumed = "subscription_resumed"
+)
+
+// observable is the shared, nil-safe Observer holder both bus implementations
+// embed. Reporting before SetObserver is called — every bus in every test that
+// does not opt in — is a no-op.
+type observable struct {
+	obsMu sync.RWMutex
+	obs   Observer
+}
+
+// SetObserver attaches an Observer. Passing nil detaches. Safe to call after
+// the bus is running; cmd/pad/cmd_server.go calls it at wiring time.
+func (o *observable) SetObserver(obs Observer) {
+	o.obsMu.Lock()
+	o.obs = obs
+	o.obsMu.Unlock()
+}
+
+func (o *observable) observer() Observer {
+	o.obsMu.RLock()
+	obs := o.obs
+	o.obsMu.RUnlock()
+	return obs
+}
+
+func (o *observable) reportResumeGap(workspaceID string) {
+	if obs := o.observer(); obs != nil {
+		obs.ResumeGap(workspaceID)
+	}
+}
+
+func (o *observable) reportReset(reason string) {
+	if obs := o.observer(); obs != nil {
+		obs.SequenceReset(reason)
+	}
+}
+
+func (o *observable) reportReceiveLoopExited() {
+	if obs := o.observer(); obs != nil {
+		obs.ReceiveLoopExited()
+	}
+}

--- a/internal/events/observer_test.go
+++ b/internal/events/observer_test.go
@@ -1,0 +1,140 @@
+package events
+
+import (
+	"sync"
+	"testing"
+)
+
+type recordingObserver struct {
+	mu         sync.Mutex
+	resumeGaps []string
+	resets     []string
+	loopExits  int
+}
+
+func (o *recordingObserver) ResumeGap(workspaceID string) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.resumeGaps = append(o.resumeGaps, workspaceID)
+}
+
+func (o *recordingObserver) SequenceReset(reason string) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.resets = append(o.resets, reason)
+}
+
+func (o *recordingObserver) ReceiveLoopExited() {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.loopExits++
+}
+
+func (o *recordingObserver) exits() int {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return o.loopExits
+}
+
+func (o *recordingObserver) snapshot() ([]string, []string) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return append([]string(nil), o.resumeGaps...), append([]string(nil), o.resets...)
+}
+
+// BOTH WAYS OF FAILING TO SERVE A RESUME MUST REACH THE COUNTER. This is the
+// specific shape that went wrong on the watch bus's own gap metric, where one
+// of two conditions producing sync_required reported nothing — a metric gap
+// that prose claimed did not exist. Here the two are "the workspace has no
+// buffer" and "the buffer refused the span", and they are structurally
+// different branches, so a suite that exercises one proves nothing about the
+// other.
+func TestResumeGapIsReportedForBothWaysOfNotServing(t *testing.T) {
+	obs := &recordingObserver{}
+	bus := New()
+	bus.SetObserver(obs)
+
+	// Half one: no buffer for this workspace at all.
+	if got := bus.EventsSince("ws-cold", 4200); got != nil {
+		t.Fatalf("expected a gap, got %d events", len(got))
+	}
+
+	// Half two: a buffer exists, and refuses the span.
+	for i := 0; i < 49; i++ {
+		bus.Publish(Event{Type: ItemUpdated, WorkspaceID: "ws-other"})
+	}
+	bus.Publish(Event{Type: ItemCreated, WorkspaceID: "ws-warm"})
+	if got := bus.EventsSince("ws-warm", 30); got != nil {
+		t.Fatalf("expected a gap, got %d events", len(got))
+	}
+
+	gaps, _ := obs.snapshot()
+	if len(gaps) != 2 {
+		t.Fatalf("expected 2 resume gaps (no-buffer AND refused-span), got %d: %v", len(gaps), gaps)
+	}
+	if gaps[0] != "ws-cold" || gaps[1] != "ws-warm" {
+		t.Fatalf("resume gaps carry the wrong workspace: %v", gaps)
+	}
+}
+
+// The negative control, and the one that matters for the load posture: a
+// resume this instance CAN serve must not be counted. Without it, a bus that
+// reported unconditionally would satisfy the test above and make the metric
+// useless for exactly the question it exists to answer.
+func TestServedResumesAreNotReportedAsGaps(t *testing.T) {
+	obs := &recordingObserver{}
+	bus := New()
+	bus.SetObserver(obs)
+
+	for i := 0; i < 5; i++ {
+		bus.Publish(Event{Type: ItemUpdated, WorkspaceID: "ws-1"})
+	}
+
+	if got := bus.EventsSince("ws-1", 3); got == nil {
+		t.Fatal("a cursor inside the buffer must be served")
+	}
+	if got := bus.EventsSince("ws-1", 5); got == nil {
+		t.Fatal("a caught-up cursor must be served")
+	}
+	// A fresh client on a workspace with no events is not resuming at all.
+	if got := bus.EventsSince("ws-empty", 0); got == nil {
+		t.Fatal("sinceID=0 must never be a gap")
+	}
+
+	gaps, _ := obs.snapshot()
+	if len(gaps) != 0 {
+		t.Fatalf("served resumes must not be counted as gaps, got %v", gaps)
+	}
+}
+
+// An observer may call back into the bus: every report fires with no bus lock
+// held. Asserted rather than documented, because the property is invisible
+// until it deadlocks a production receive loop.
+func TestAnObserverMayCallBackIntoTheBus(t *testing.T) {
+	bus := New()
+	done := make(chan struct{})
+	bus.SetObserver(callbackObserver{bus: bus, done: done})
+
+	// Triggers a resume gap, whose report calls Publish from inside.
+	_ = bus.EventsSince("ws-1", 99)
+
+	select {
+	case <-done:
+	default:
+		t.Fatal("the observer's call back into the bus did not complete")
+	}
+}
+
+type callbackObserver struct {
+	bus  *MemoryBus
+	done chan struct{}
+}
+
+func (o callbackObserver) ResumeGap(string) {
+	o.bus.Publish(Event{Type: ItemUpdated, WorkspaceID: "ws-callback"})
+	close(o.done)
+}
+
+func (o callbackObserver) SequenceReset(string) {}
+
+func (o callbackObserver) ReceiveLoopExited() {}

--- a/internal/events/redis_bus.go
+++ b/internal/events/redis_bus.go
@@ -3,7 +3,6 @@ package events
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"log/slog"
 	"sync"
 	"time"
@@ -370,93 +369,74 @@ func (b *RedisBus) stopRedisSubscription(workspaceID string) {
 // receiveMessages consumes one workspace's Redis channel until the context is
 // cancelled.
 //
-// IT USES Receive RATHER THAN Channel, AND THAT IS THE POINT (codex round 6).
-// PubSub.Channel resubscribes transparently on a dropped connection — a Redis
-// failover, a network blip, a server restart — and hands back the messages
-// that arrive AFTER it recovers, saying nothing about the ones published while
-// it was down. The replay buffer then carries a hole it has no idea about, and
-// a resume across it is answered "caught up".
+// IT USES ChannelWithSubscriptions, AND BOTH HALVES OF THAT CHOICE MATTER.
 //
-// A resubscription is the one form of mid-stream loss this process can
-// actually OBSERVE (contrast BUG-2735, which stays open precisely because a
-// message lost in transit leaves no local trace on a bus whose per-workspace
-// IDs are non-consecutive by construction). Receive surfaces each
-// *redis.Subscription, so every one after the first is treated exactly like a
-// stopped subscription: the workspace's coverage ends there.
+// Against Channel: a plain message channel hides RESUBSCRIPTIONS. go-redis
+// reconnects transparently on a dropped connection — a Redis failover, a
+// network blip, a server restart — and hands back the messages that arrive
+// AFTER it recovers, saying nothing about the ones published while it was
+// down. The replay buffer then carries a hole it has no idea about, and a
+// resume across it is answered "caught up". A resubscription is the one form
+// of mid-stream loss this process can actually OBSERVE (contrast BUG-2735,
+// which stays open precisely because a message lost in transit leaves no local
+// trace on a bus whose per-workspace IDs are non-consecutive by construction),
+// so every subscription confirmation after the first ends that workspace's
+// coverage, exactly like a stopped subscription.
+//
+// Against a bare Receive loop, which is what this was first written as: only
+// the Channel* constructors start go-redis's health check (newChannel →
+// initHealthCheck), and go-redis owns the redial and backoff, so a hand-rolled
+// retry loop here is machinery this package does not need to maintain.
+//
+// WHAT NEITHER FORM DETECTS, measured rather than assumed: a HALF-OPEN
+// connection — no FIN, no RST, just a route that stopped working. The health
+// check's PubSub.Ping only WRITES the command and never reads a reply
+// (go-redis v9.22.0, pubsub.go), so it succeeds for as long as the socket
+// accepts writes, and the channel path sets no read deadline. A proxy that
+// silently stops forwarding produced no reconnect in 24 seconds of probing.
+// So an instance behind a wedged route still sits there receiving nothing
+// while its buffer keeps looking valid; detecting that needs application-level
+// idle tracking, which is BUG-2730's family and its own decision. Do not
+// assume the health check covers it.
 func (b *RedisBus) receiveMessages(ctx context.Context, pubsub *redis.PubSub, workspaceID string, gen int64) {
 	defer b.reportReceiveLoopExited()
 
+	ch := pubsub.ChannelWithSubscriptions()
 	var subscribed bool
 	for {
-		if ctx.Err() != nil {
+		select {
+		case <-ctx.Done():
 			return
-		}
-		raw, err := pubsub.Receive(ctx)
-		if err != nil {
-			if ctx.Err() != nil {
+		case raw, ok := <-ch:
+			if !ok {
 				return
 			}
-			if errors.Is(err, redis.ErrClosed) {
-				// The client or the PubSub was closed: nothing will redial,
-				// so continuing would spin.
-				slog.Debug("events: pub/sub closed", "workspace", workspaceID, "error", err)
-				return
-			}
-			// A TRANSIENT FAILURE, AND THE HONEST SIGNAL FOR ONE (codex round
-			// 6). Unlike PubSub.Channel, Receive surfaces the error instead of
-			// hiding a reconnect, and this loop must NOT exit on it — doing so
-			// would leave the instance publishing fine and receiving nothing.
-			// go-redis releases the failed connection and redials as part of
-			// serving the next Receive, so continuing the loop is what makes
-			// the reconnection happen.
-			//
-			// The error IS the coverage break: whatever was published while we
-			// were disconnected did not reach us, and we cannot know what. The
-			// resubscription confirmation below is the same fact arriving by a
-			// second route, and the drop is idempotent, so keying on both
-			// costs nothing and neither one alone is reliable.
-			slog.Warn("events: pub/sub receive failed; dropping this workspace's replay buffer, resumes across the gap will report sync_required",
-				"workspace", workspaceID, "error", err)
-			b.dropWorkspaceCoverage(workspaceID, ResetReasonSubscriptionResumed, gen)
-			subscribed = false
-			select {
-			case <-ctx.Done():
-				return
-			case <-time.After(receiveRetryDelay):
-			}
-			continue
-		}
+			switch msg := raw.(type) {
+			case *redis.Subscription:
+				if msg.Kind != "subscribe" && msg.Kind != "psubscribe" {
+					continue
+				}
+				if !subscribed {
+					subscribed = true
+					continue
+				}
+				// A RESUBSCRIPTION: the connection dropped and came back, and
+				// whatever was published in between never reached us.
+				slog.Warn("events: pub/sub resubscribed; dropping this workspace's replay buffer, resumes across the gap will report sync_required",
+					"workspace", workspaceID, "channel", msg.Channel)
+				b.dropWorkspaceCoverage(workspaceID, ResetReasonSubscriptionResumed, gen)
 
-		switch msg := raw.(type) {
-		case *redis.Subscription:
-			if msg.Kind != "subscribe" && msg.Kind != "psubscribe" {
-				continue
+			case *redis.Message:
+				var event Event
+				if err := json.Unmarshal([]byte(msg.Payload), &event); err != nil {
+					slog.Error("failed to unmarshal Redis event", "channel", msg.Channel, "error", err)
+					continue
+				}
+				b.fanOutFromRedis(gen, event)
 			}
-			if !subscribed {
-				subscribed = true
-				continue
-			}
-			// A RESUBSCRIPTION: the connection dropped and came back, and
-			// whatever was published in between never reached us.
-			slog.Warn("events: pub/sub resubscribed; dropping this workspace's replay buffer, resumes across the gap will report sync_required",
-				"workspace", workspaceID, "channel", msg.Channel)
-			b.dropWorkspaceCoverage(workspaceID, ResetReasonSubscriptionResumed, gen)
-
-		case *redis.Message:
-			var event Event
-			if err := json.Unmarshal([]byte(msg.Payload), &event); err != nil {
-				slog.Error("failed to unmarshal Redis event", "channel", msg.Channel, "error", err)
-				continue
-			}
-			b.fanOutFromRedis(gen, event)
 		}
 	}
 }
-
-// receiveRetryDelay paces redial attempts after a pub/sub receive failure. It
-// is not a timeout on anything — go-redis does the redialing — only a bound on
-// how fast this loop spins while Redis is unreachable.
-const receiveRetryDelay = 200 * time.Millisecond
 
 // dropWorkspaceCoverage ends this instance's coverage of one workspace,
 // because something happened that its buffer cannot account for. The next

--- a/internal/events/redis_bus.go
+++ b/internal/events/redis_bus.go
@@ -3,9 +3,9 @@ package events
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/PerpetualSoftware/pad/internal/redisns"
@@ -28,25 +28,13 @@ const (
 	redisSeqSuffix = "event_seq"
 )
 
-// DEPLOYMENT SCOPING (BUG-2724). Both names above carry the installation's
-// PAD_REDIS_NAMESPACE when one is set — see internal/redisns — and are
-// byte-identical to the historical flat names when it is not.
-//
-// The rule, stated the same way in internal/watchevents and
-// internal/server's presence registry because it belongs to all three at
-// once: scoping comes from ONE shared config value built in
-// cmd/pad/cmd_server.go, never from one package growing a prefix the
-// others lack. Two installations sharing a Redis endpoint without distinct
-// namespaces cross-feed; different logical DBs do not help, since pub/sub
-// is not namespaced by DB at all.
-//
-// Redis CLUSTER remains unsupported across all three keyspaces: no hash
-// tags, and a non-cluster client. Deferred as one unit on BUG-2724.
-
 // RedisBus distributes events across multiple Pad instances via Redis pub/sub.
 // Each instance subscribes to Redis channels for its locally-connected SSE clients,
 // and publishes events to Redis so all instances see them.
 type RedisBus struct {
+	// observable carries the optional operational-event seam (BUG-2731).
+	observable
+
 	client *redis.Client
 
 	// keys builds this installation's Redis names (BUG-2724). The zero
@@ -54,20 +42,51 @@ type RedisBus struct {
 	// without one behaves exactly as it always did.
 	keys redisns.Keys
 
-	mu          sync.RWMutex
-	subscribers map[chan Event]*subscriber
+	// mu guards subscriber membership, the per-workspace subscription
+	// bookkeeping, AND the replay buffers TOGETHER.
+	//
+	// The buffers used to have their own RWMutex, and that separation is
+	// what made BUG-2731's case 4 unfixable in isolation. stopRedisSubscription
+	// does not JOIN the receive goroutine — sub.cancel() only signals it — so a
+	// straggler already inside fanOutLocally could re-create a buffer we had
+	// just dropped, with knownFrom set to its own ID, and the resulting
+	// one-entry buffer would then vouch for coverage it never had. One lock
+	// makes "is this workspace still being received?" and "append to its
+	// buffer" a single atomic decision.
+	//
+	// Holding a write lock through the fan-out cannot STALL anyone, for the
+	// reason internal/watchevents records for its own single-mutex design: the
+	// sends are already non-blocking (select/default — a full channel is
+	// dropped-and-logged, never awaited). It does serialize fan-outs, resumes
+	// and map work against each other, which is a real cost — and is why the
+	// subscriber map is indexed by workspace: the critical section is then
+	// proportional to one workspace's subscribers rather than to all of them.
+	mu sync.Mutex
+	// subscribers is indexed BY WORKSPACE, not a flat set (codex round 6).
+	// Fan-out runs under the same lock as everything else here, so scanning
+	// every local subscriber to filter by workspace would make one hot
+	// workspace's publish rate the serialization point for every other
+	// workspace's fan-out AND for every resume. The index makes the critical
+	// section O(subscribers in THIS workspace) with non-blocking sends.
+	//
+	// MemoryBus keeps its flat map deliberately: it has an RWMutex and a
+	// separate replay lock, so its fan-out does not exclude anyone.
+	subscribers map[string]map[chan Event]*subscriber
+	// workspaceOf resolves a channel back to its workspace on Unsubscribe,
+	// which is the one operation that has only the channel to go on.
+	workspaceOf map[chan Event]string
 
 	// Track which workspace channels we're subscribed to in Redis,
 	// so we subscribe/unsubscribe as local SSE clients come and go.
 	wsCounts map[string]int       // workspace → local subscriber count
 	wsSubs   map[string]*redisSub // workspace → active Redis subscription
 
-	// Monotonic sequence counter for event IDs (local to this instance).
-	seq atomic.Int64
+	// subGen numbers subscriptions so a message can be matched to the one it
+	// arrived on. See fanOut for the race it closes.
+	subGen int64
 
 	// Per-workspace replay buffers for Last-Event-ID support.
-	// Populated from events received via Redis pub/sub.
-	replayMu      sync.RWMutex
+	// Populated from events received via Redis pub/sub. Guarded by mu.
 	replayBuffers map[string]*replayBuffer
 	replaySize    int
 
@@ -79,6 +98,10 @@ type RedisBus struct {
 type redisSub struct {
 	pubsub *redis.PubSub
 	cancel context.CancelFunc
+	// gen identifies this subscription among all subscriptions this bus has
+	// opened for the workspace, so a message carrying a stale gen can be
+	// recognised as belonging to a subscription that has already ended.
+	gen int64
 }
 
 // NewRedisBus creates a new Redis-backed EventBus.
@@ -96,7 +119,8 @@ func NewRedisBusWithKeys(client *redis.Client, keys redisns.Keys) *RedisBus {
 	return &RedisBus{
 		client:        client,
 		keys:          keys,
-		subscribers:   make(map[chan Event]*subscriber),
+		subscribers:   make(map[string]map[chan Event]*subscriber),
+		workspaceOf:   make(map[chan Event]string),
 		wsCounts:      make(map[string]int),
 		wsSubs:        make(map[string]*redisSub),
 		replayBuffers: make(map[string]*replayBuffer),
@@ -112,18 +136,27 @@ func (b *RedisBus) Subscribe(workspaceID string) chan Event {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	ch := make(chan Event, 64)
-	b.subscribers[ch] = &subscriber{
-		ch:          ch,
-		workspaceID: workspaceID,
-	}
-
-	b.wsCounts[workspaceID]++
+	ch := b.addSubscriberLocked(workspaceID)
 	if b.wsCounts[workspaceID] == 1 {
 		// First local subscriber for this workspace — subscribe to Redis channel
 		b.startRedisSubscription(workspaceID)
 	}
 
+	return ch
+}
+
+// addSubscriberLocked registers a channel for a workspace and bumps its local
+// count. Callers must hold mu.
+func (b *RedisBus) addSubscriberLocked(workspaceID string) chan Event {
+	ch := make(chan Event, 64)
+	byWorkspace, ok := b.subscribers[workspaceID]
+	if !ok {
+		byWorkspace = make(map[chan Event]*subscriber)
+		b.subscribers[workspaceID] = byWorkspace
+	}
+	byWorkspace[ch] = &subscriber{ch: ch, workspaceID: workspaceID}
+	b.workspaceOf[ch] = workspaceID
+	b.wsCounts[workspaceID]++
 	return ch
 }
 
@@ -142,13 +175,7 @@ func (b *RedisBus) SubscribeIfAllowed(workspaceID string, maxPerWorkspace int) (
 		return nil, false
 	}
 
-	ch := make(chan Event, 64)
-	b.subscribers[ch] = &subscriber{
-		ch:          ch,
-		workspaceID: workspaceID,
-	}
-
-	b.wsCounts[workspaceID]++
+	ch := b.addSubscriberLocked(workspaceID)
 	if b.wsCounts[workspaceID] == 1 {
 		b.startRedisSubscription(workspaceID)
 	}
@@ -162,15 +189,19 @@ func (b *RedisBus) Unsubscribe(ch chan Event) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	sub, ok := b.subscribers[ch]
+	wsID, ok := b.workspaceOf[ch]
 	if !ok {
 		return
 	}
-
-	delete(b.subscribers, ch)
+	delete(b.workspaceOf, ch)
+	if byWorkspace, ok := b.subscribers[wsID]; ok {
+		delete(byWorkspace, ch)
+		if len(byWorkspace) == 0 {
+			delete(b.subscribers, wsID)
+		}
+	}
 	close(ch)
 
-	wsID := sub.workspaceID
 	b.wsCounts[wsID]--
 	if b.wsCounts[wsID] <= 0 {
 		delete(b.wsCounts, wsID)
@@ -186,14 +217,22 @@ func (b *RedisBus) Publish(event Event) {
 		event.Timestamp = time.Now().UnixMilli()
 	}
 
-	// Assign a globally ordered sequence ID via Redis atomic counter.
-	// This ensures all instances share the same ID space, so Last-Event-ID
-	// from one instance is meaningful on any other instance.
+	channel := b.keys.Name(redisChannelSuffix) + event.WorkspaceID
+	// Assign a globally ordered sequence ID via Redis atomic counter, so all
+	// instances share one ID space and Last-Event-ID from one instance is
+	// meaningful on any other.
 	id, err := b.client.Incr(b.ctx, b.keys.Name(redisSeqSuffix)).Result()
 	if err != nil {
-		// Fall back to local counter if Redis INCR fails (degraded mode).
-		slog.Warn("failed to get global event ID from Redis, falling back to local", "error", err)
-		id = b.seq.Add(1)
+		// NO LOCAL-COUNTER FALLBACK, and its removal is a fix rather than a
+		// regression (BUG-2731). The previous version answered a failed INCR
+		// by minting an id from a process-local counter starting at zero and
+		// publishing it anyway — an id from a different space, which every
+		// receiving instance reads as the counter having been reset. It also
+		// bought nothing: this bus has no local fan-out path, so an event
+		// that does not reach Redis reaches no subscriber on this instance
+		// either, fallback id or not. Failing loudly is the honest outcome.
+		slog.Error("failed to assign an event ID from Redis; dropping the publish", "error", err)
+		return
 	}
 	event.ID = id
 
@@ -203,23 +242,49 @@ func (b *RedisBus) Publish(event Event) {
 		return
 	}
 
-	channel := b.keys.Name(redisChannelSuffix) + event.WorkspaceID
 	if err := b.client.Publish(b.ctx, channel, data).Err(); err != nil {
 		slog.Error("failed to publish event to Redis", "channel", channel, "error", err)
 	}
 }
 
-// EventsSince returns buffered events for a workspace with IDs greater than sinceID.
-// Returns nil if sinceID has been evicted from the buffer (gap too large).
+// EventsSince returns buffered events for a workspace with IDs greater than
+// sinceID. Returns nil when this instance cannot vouch for the requested span
+// — see the EventBus interface and replayBuffer.since.
 func (b *RedisBus) EventsSince(workspaceID string, sinceID int64) []Event {
-	b.replayMu.RLock()
-	defer b.replayMu.RUnlock()
+	// Reported once, on the way out, and with the lock released — see the
+	// MemoryBus twin for why both no-buffer and refused-span must reach the
+	// same counter.
+	var missed []Event
+	defer func() {
+		if missed == nil {
+			b.reportResumeGap(workspaceID)
+		}
+	}()
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
 
 	rb, ok := b.replayBuffers[workspaceID]
 	if !ok {
-		return []Event{}
+		// No buffer means this instance is not currently covering the
+		// workspace, or has only just started to. For a fresh client
+		// (sinceID == 0) that is honestly "nothing to replay"; for a
+		// resuming one it is the strongest form of "cannot vouch" there
+		// is, and answering []Event{} told it that it was caught up
+		// (BUG-2731).
+		//
+		// This is the NORMAL state for the first connection to a given
+		// workspace on a given replica, because buffers are built lazily
+		// in fanOutLocally — so a restart, a scale-up, or a namespace
+		// cutover all land here, not just an exotic failure.
+		if sinceID > 0 {
+			return nil
+		}
+		missed = []Event{}
+		return missed
 	}
-	return rb.since(sinceID)
+	missed = rb.since(sinceID)
+	return missed
 }
 
 // Close shuts down all Redis subscriptions and closes local subscriber channels.
@@ -235,23 +300,26 @@ func (b *RedisBus) Close() {
 		delete(b.wsSubs, wsID)
 	}
 
-	for ch := range b.subscribers {
-		delete(b.subscribers, ch)
-		close(ch)
+	for wsID, byWorkspace := range b.subscribers {
+		for ch := range byWorkspace {
+			delete(b.workspaceOf, ch)
+			close(ch)
+		}
+		delete(b.subscribers, wsID)
 	}
 }
 
 // SubscriberCount returns the number of active local subscribers.
 func (b *RedisBus) SubscriberCount() int {
-	b.mu.RLock()
-	defer b.mu.RUnlock()
-	return len(b.subscribers)
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return len(b.workspaceOf)
 }
 
 // WorkspaceSubscriberCount returns the number of active local subscribers for a workspace.
 func (b *RedisBus) WorkspaceSubscriberCount(workspaceID string) int {
-	b.mu.RLock()
-	defer b.mu.RUnlock()
+	b.mu.Lock()
+	defer b.mu.Unlock()
 	return b.wsCounts[workspaceID]
 }
 
@@ -262,12 +330,15 @@ func (b *RedisBus) startRedisSubscription(workspaceID string) {
 	pubsub := b.client.Subscribe(b.ctx, channel)
 
 	subCtx, subCancel := context.WithCancel(b.ctx)
+	b.subGen++
+	gen := b.subGen
 	b.wsSubs[workspaceID] = &redisSub{
 		pubsub: pubsub,
 		cancel: subCancel,
+		gen:    gen,
 	}
 
-	go b.receiveMessages(subCtx, pubsub, workspaceID)
+	go b.receiveMessages(subCtx, pubsub, workspaceID, gen)
 }
 
 // stopRedisSubscription cancels and cleans up the Redis subscription for a workspace.
@@ -280,56 +351,253 @@ func (b *RedisBus) stopRedisSubscription(workspaceID string) {
 	sub.cancel()
 	sub.pubsub.Close()
 	delete(b.wsSubs, workspaceID)
+
+	// WHEN WE STOP RECEIVING, THE HONEST STATE IS NO BUFFER, NOT A STALE
+	// CONTIGUOUS ONE (BUG-2731). This is the invariant a future optimization
+	// will be tempted to violate — keeping the buffer "in case they come
+	// back" looks like a free win and is the bug.
+	//
+	// From here until the workspace is subscribed again, events published on
+	// other instances never enter this buffer, while the buffer itself goes
+	// on LOOKING complete: same IDs, no eviction, nothing to distinguish it
+	// from a live one. A later client resuming with a cursor at or below the
+	// stale newest ID would be replayed the stale tail and told nothing about
+	// the hole. Dropping it makes the next resume answer nil, which is true.
+	delete(b.replayBuffers, workspaceID)
 }
 
 // receiveMessages reads from a Redis pub/sub channel and fans out to local subscribers.
-func (b *RedisBus) receiveMessages(ctx context.Context, pubsub *redis.PubSub, workspaceID string) {
-	ch := pubsub.Channel()
+// receiveMessages consumes one workspace's Redis channel until the context is
+// cancelled.
+//
+// IT USES Receive RATHER THAN Channel, AND THAT IS THE POINT (codex round 6).
+// PubSub.Channel resubscribes transparently on a dropped connection — a Redis
+// failover, a network blip, a server restart — and hands back the messages
+// that arrive AFTER it recovers, saying nothing about the ones published while
+// it was down. The replay buffer then carries a hole it has no idea about, and
+// a resume across it is answered "caught up".
+//
+// A resubscription is the one form of mid-stream loss this process can
+// actually OBSERVE (contrast BUG-2735, which stays open precisely because a
+// message lost in transit leaves no local trace on a bus whose per-workspace
+// IDs are non-consecutive by construction). Receive surfaces each
+// *redis.Subscription, so every one after the first is treated exactly like a
+// stopped subscription: the workspace's coverage ends there.
+func (b *RedisBus) receiveMessages(ctx context.Context, pubsub *redis.PubSub, workspaceID string, gen int64) {
+	defer b.reportReceiveLoopExited()
+
+	var subscribed bool
 	for {
-		select {
-		case <-ctx.Done():
+		if ctx.Err() != nil {
 			return
-		case msg, ok := <-ch:
-			if !ok {
+		}
+		raw, err := pubsub.Receive(ctx)
+		if err != nil {
+			if ctx.Err() != nil {
 				return
 			}
+			if errors.Is(err, redis.ErrClosed) {
+				// The client or the PubSub was closed: nothing will redial,
+				// so continuing would spin.
+				slog.Debug("events: pub/sub closed", "workspace", workspaceID, "error", err)
+				return
+			}
+			// A TRANSIENT FAILURE, AND THE HONEST SIGNAL FOR ONE (codex round
+			// 6). Unlike PubSub.Channel, Receive surfaces the error instead of
+			// hiding a reconnect, and this loop must NOT exit on it — doing so
+			// would leave the instance publishing fine and receiving nothing.
+			// go-redis releases the failed connection and redials as part of
+			// serving the next Receive, so continuing the loop is what makes
+			// the reconnection happen.
+			//
+			// The error IS the coverage break: whatever was published while we
+			// were disconnected did not reach us, and we cannot know what. The
+			// resubscription confirmation below is the same fact arriving by a
+			// second route, and the drop is idempotent, so keying on both
+			// costs nothing and neither one alone is reliable.
+			slog.Warn("events: pub/sub receive failed; dropping this workspace's replay buffer, resumes across the gap will report sync_required",
+				"workspace", workspaceID, "error", err)
+			b.dropWorkspaceCoverage(workspaceID, ResetReasonSubscriptionResumed, gen)
+			subscribed = false
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(receiveRetryDelay):
+			}
+			continue
+		}
+
+		switch msg := raw.(type) {
+		case *redis.Subscription:
+			if msg.Kind != "subscribe" && msg.Kind != "psubscribe" {
+				continue
+			}
+			if !subscribed {
+				subscribed = true
+				continue
+			}
+			// A RESUBSCRIPTION: the connection dropped and came back, and
+			// whatever was published in between never reached us.
+			slog.Warn("events: pub/sub resubscribed; dropping this workspace's replay buffer, resumes across the gap will report sync_required",
+				"workspace", workspaceID, "channel", msg.Channel)
+			b.dropWorkspaceCoverage(workspaceID, ResetReasonSubscriptionResumed, gen)
+
+		case *redis.Message:
 			var event Event
 			if err := json.Unmarshal([]byte(msg.Payload), &event); err != nil {
 				slog.Error("failed to unmarshal Redis event", "channel", msg.Channel, "error", err)
 				continue
 			}
-			b.fanOutLocally(event)
+			b.fanOutFromRedis(gen, event)
 		}
 	}
 }
 
-// fanOutLocally distributes an event to all local subscribers for the event's workspace
-// and stores it in the replay buffer.
+// receiveRetryDelay paces redial attempts after a pub/sub receive failure. It
+// is not a timeout on anything — go-redis does the redialing — only a bound on
+// how fast this loop spins while Redis is unreachable.
+const receiveRetryDelay = 200 * time.Millisecond
+
+// dropWorkspaceCoverage ends this instance's coverage of one workspace,
+// because something happened that its buffer cannot account for. The next
+// resume for that workspace answers nil until coverage is re-established.
+//
+// Scoped to the ONE workspace rather than all of them, unlike an ID-space
+// reset: a dropped subscription says nothing about the shared counter or about
+// any other workspace's channel, and dropping the rest would be a resync
+// charged to clients whose stream never broke.
+func (b *RedisBus) dropWorkspaceCoverage(workspaceID, reason string, gen int64) {
+	var report string
+	defer func() {
+		if report != "" {
+			b.reportReset(report)
+		}
+	}()
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	// THE GENERATION CHECK BELONGS HERE TOO, not only in fan-out (codex round
+	// 7). A receive loop can notice its connection died LONG after the
+	// workspace was unsubscribed and resubscribed under it: last viewer
+	// leaves, the buffer is dropped and the subscription torn down, a viewer
+	// returns and a new generation starts buffering — and only then does the
+	// old goroutine reach this line and delete the REPLACEMENT buffer. The
+	// returning client is then told sync_required for an outage that ended
+	// before its subscription began, and the reset counter names an incident
+	// that did not happen to it.
+	if sub, ok := b.wsSubs[workspaceID]; !ok || sub.gen != gen {
+		return
+	}
+
+	if _, ok := b.replayBuffers[workspaceID]; !ok {
+		// Nothing buffered: there is no coverage to end and no client that
+		// could have been told it was current. Reporting here would give the
+		// counter a baseline on every reconnect of an idle workspace.
+		return
+	}
+	delete(b.replayBuffers, workspaceID)
+	report = reason
+}
+
+// currentSubGen reports the generation of the workspace's live subscription,
+// or 0 if it has none. Test seam: a real message carries its generation down
+// from receiveMessages, and a test driving the fan-out directly needs a way to
+// name the same value rather than guessing it.
+func (b *RedisBus) currentSubGen(workspaceID string) int64 {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if sub, ok := b.wsSubs[workspaceID]; ok {
+		return sub.gen
+	}
+	return 0
+}
+
+// fanOutFromRedis is the receive path: a message that arrived on the
+// subscription identified by gen.
+func (b *RedisBus) fanOutFromRedis(gen int64, event Event) {
+	b.fanOut(gen, event)
+}
+
+// fanOutLocally distributes an event to all local subscribers for the event's
+// workspace and stores it in the replay buffer, with no id-space information.
 func (b *RedisBus) fanOutLocally(event Event) {
+	b.fanOut(anySubscription, event)
+}
+
+// anySubscription opts out of the generation check for callers that are not a
+// receive loop — tests driving the fan-out directly. A real message always
+// carries the generation of the subscription it arrived on.
+const anySubscription int64 = 0
+
+func (b *RedisBus) fanOut(gen int64, event Event) {
+	// Registered FIRST so it runs LAST — after the Unlock below, so an
+	// observer may call back into the bus without deadlocking the receive
+	// loop.
+	var reset string
+	defer func() {
+		if reset != "" {
+			b.reportReset(reset)
+		}
+	}()
+
 	// Events received via Redis pub/sub already carry a global ID assigned by
-	// the publishing instance via Redis INCR. We use that ID directly so all
-	// instances share the same ID space for Last-Event-ID replay.
+	// publishScript. We use that ID directly so all instances share the same
+	// ID space for Last-Event-ID replay.
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	// FAN-OUT REFUSES TO APPEND FOR A WORKSPACE WITH NO LIVE SUBSCRIPTION
+	// (BUG-2731). sub.cancel() in stopRedisSubscription signals the receive
+	// goroutine; it does not join it, so a message already in flight can
+	// arrive here after the workspace was dropped. Appending it would
+	// re-create the buffer with knownFrom set to that straggler's ID — a
+	// one-entry buffer vouching for coverage that ended when the
+	// subscription did, which is precisely the state the drop exists to
+	// prevent.
+	//
+	// Checked under the same lock that guards wsSubs, so the answer cannot
+	// go stale between the check and the append.
+	sub, receiving := b.wsSubs[event.WorkspaceID]
+	if !receiving {
+		return
+	}
+	// ...AND THAT THIS MESSAGE BELONGS TO THE SUBSCRIPTION THAT IS LIVE NOW
+	// (codex round 1 F2). Checking only that SOME subscription exists leaves
+	// the same hole one step further along: last subscriber leaves, buffer
+	// dropped, a NEW subscriber arrives and registers a new subscription, and
+	// only THEN does the old receive goroutine's in-flight message land. It
+	// would be appended, setting knownFrom to a pre-outage ID, so a resume
+	// from that ID is answered "caught up" while the outage's events are gone.
+	if gen != anySubscription && sub.gen != gen {
+		return
+	}
 
 	// Store in replay buffer for reconnect replay.
-	b.replayMu.Lock()
 	rb, ok := b.replayBuffers[event.WorkspaceID]
 	if !ok {
 		rb = newReplayBuffer(b.replaySize)
 		b.replayBuffers[event.WorkspaceID] = rb
 	}
 	rb.append(event)
-	b.replayMu.Unlock()
 
-	b.mu.RLock()
-	defer b.mu.RUnlock()
-
-	for _, sub := range b.subscribers {
-		if sub.workspaceID != event.WorkspaceID {
-			continue
-		}
+	for _, sub := range b.subscribers[event.WorkspaceID] {
 		select {
 		case sub.ch <- event:
 		default:
+			// A DROP HERE IS SILENT TO THE SUBSCRIBER, and BUG-2731
+			// deliberately did not change that — see BUG-2730, which owns it
+			// for both buses. Everything BUG-2731 made honest is per-WORKSPACE
+			// state evaluated when a client asks (cold start, stopped
+			// subscription, reconnect, ID-space reset); this is per-SUBSCRIBER
+			// state discovered mid-fan-out about a connection that is still
+			// open, so telling it needs a channel from the bus to one live
+			// consumer that neither bus has.
+			//
+			// The consequence, so nobody reads this as harmless: a later
+			// delivered event advances that client's Last-Event-ID PAST the
+			// dropped IDs, after which no replica will replay them, because
+			// every replica agrees the cursor is current.
 			slog.Warn("dropping event for slow subscriber", "type", event.Type, "workspace", event.WorkspaceID)
 		}
 	}

--- a/internal/events/redis_bus.go
+++ b/internal/events/redis_bus.go
@@ -542,8 +542,8 @@ func (b *RedisBus) fanOut(gen int64, event Event) {
 	}()
 
 	// Events received via Redis pub/sub already carry a global ID assigned by
-	// publishScript. We use that ID directly so all instances share the same
-	// ID space for Last-Event-ID replay.
+	// the publishing instance via Redis INCR. We use that ID directly so all
+	// instances share the same ID space for Last-Event-ID replay.
 	b.mu.Lock()
 	defer b.mu.Unlock()
 

--- a/internal/events/redis_bus.go
+++ b/internal/events/redis_bus.go
@@ -388,16 +388,18 @@ func (b *RedisBus) stopRedisSubscription(workspaceID string) {
 // initHealthCheck), and go-redis owns the redial and backoff, so a hand-rolled
 // retry loop here is machinery this package does not need to maintain.
 //
-// WHAT NEITHER FORM DETECTS, measured rather than assumed: a HALF-OPEN
-// connection — no FIN, no RST, just a route that stopped working. The health
-// check's PubSub.Ping only WRITES the command and never reads a reply
-// (go-redis v9.22.0, pubsub.go), so it succeeds for as long as the socket
-// accepts writes, and the channel path sets no read deadline. A proxy that
-// silently stops forwarding produced no reconnect in 24 seconds of probing.
-// So an instance behind a wedged route still sits there receiving nothing
-// while its buffer keeps looking valid; detecting that needs application-level
-// idle tracking, which is BUG-2730's family and its own decision. Do not
-// assume the health check covers it.
+// WHAT NEITHER FORM DETECTS: a HALF-OPEN connection — no FIN, no RST, just a
+// route that stopped working. Check it in the library rather than believing
+// this comment: PubSub.Ping calls writeCmd and returns, never reading a reply
+// (go-redis v9.22.0, pubsub.go), so the health check's error is nil for as
+// long as the socket accepts writes — which a half-open socket does until its
+// send buffer fills. The channel path sets no read deadline either
+// (Receive → ReceiveTimeout(ctx, 0)).
+//
+// So an instance behind a wedged route sits there receiving nothing while its
+// buffer keeps looking valid. Detecting that needs application-level idle
+// tracking, which is BUG-2730's family and its own decision, because it needs
+// a threshold. Do not assume the health check covers it.
 func (b *RedisBus) receiveMessages(ctx context.Context, pubsub *redis.PubSub, workspaceID string, gen int64) {
 	defer b.reportReceiveLoopExited()
 

--- a/internal/events/redis_reconnect_test.go
+++ b/internal/events/redis_reconnect_test.go
@@ -1,0 +1,304 @@
+package events
+
+import (
+	"io"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+)
+
+// tcpCutter is a pass-through proxy in front of Redis whose connections can be
+// severed on demand. It exists because a pub/sub RESUBSCRIPTION is the thing
+// under test, and nothing short of a real dropped connection produces one:
+// go-redis reconnects and re-subscribes internally, which is exactly the
+// silence BUG-2731's receive loop was changed to break.
+//
+// Testing the decision logic alone — "if we have seen a subscribe before, drop
+// coverage" — would leave the load-bearing half unproven, namely that the loop
+// uses Receive (which surfaces subscription confirmations) rather than Channel
+// (which swallows them). CONVE-19: wiring is a claim.
+type tcpCutter struct {
+	ln    net.Listener
+	mu    sync.Mutex
+	conns []net.Conn
+}
+
+func newTCPCutter(t *testing.T, backend string) *tcpCutter {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	c := &tcpCutter{ln: ln}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	go func() {
+		for {
+			client, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			server, err := net.Dial("tcp", backend)
+			if err != nil {
+				_ = client.Close()
+				return
+			}
+			c.mu.Lock()
+			c.conns = append(c.conns, client, server)
+			c.mu.Unlock()
+			go func() { _, _ = io.Copy(server, client) }()
+			go func() { _, _ = io.Copy(client, server) }()
+		}
+	}()
+	return c
+}
+
+func (c *tcpCutter) addr() string { return c.ln.Addr().String() }
+
+// cut severs every connection opened so far, forcing go-redis to redial and
+// re-subscribe.
+func (c *tcpCutter) cut() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, conn := range c.conns {
+		_ = conn.Close()
+	}
+	c.conns = nil
+}
+
+// codex round 6 O1. A Redis failover drops whatever was published while the
+// subscription was down. Before this, PubSub.Channel resubscribed silently and
+// the replay buffer carried a hole it had no idea about, so a resume across
+// the outage was answered "caught up".
+func TestAResubscriptionEndsThisInstancesCoverage(t *testing.T) {
+	mr := miniredis.RunT(t)
+	cutter := newTCPCutter(t, mr.Addr())
+
+	client := redis.NewClient(&redis.Options{Addr: cutter.addr()})
+	t.Cleanup(func() { _ = client.Close() })
+
+	b := NewRedisBus(client)
+	t.Cleanup(b.Close)
+	obs := &recordingObserver{}
+	b.SetObserver(obs)
+
+	ch := b.Subscribe("ws-1")
+	defer b.Unsubscribe(ch)
+	waitForSubscribers(t, mr, "pad:events:ws-1", true)
+
+	b.Publish(Event{Type: ItemCreated, WorkspaceID: "ws-1"})
+	drain(t, ch, 1)
+
+	// Control: while the connection is healthy, a resume inside our coverage
+	// is served and nothing is reported.
+	if got := b.EventsSince("ws-1", 1); got == nil {
+		t.Fatal("a caught-up cursor must be served while the subscription is healthy")
+	}
+	if _, resets := obs.snapshot(); len(resets) != 0 {
+		t.Fatalf("a healthy subscription must report no reset, got %v", resets)
+	}
+
+	// The failover. Events published while we are down never reach us.
+	cutter.cut()
+
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, resets := obs.snapshot(); len(resets) > 0 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	_, resets := obs.snapshot()
+	if len(resets) == 0 {
+		t.Fatal("a pub/sub resubscription must end this instance's coverage; nothing was reported")
+	}
+	if resets[0] != ResetReasonSubscriptionResumed {
+		t.Fatalf("expected %q, got %q", ResetReasonSubscriptionResumed, resets[0])
+	}
+
+	// And the coverage really is gone: the cursor that was served above is
+	// now a gap, because we cannot account for the outage.
+	if got := b.EventsSince("ws-1", 1); got != nil {
+		t.Fatalf("after a resubscription the buffer must not vouch for the outage, got %d events", len(got))
+	}
+
+	// THE PROPERTY THAT MATTERS MOST, and the one the first version of this
+	// fix got wrong: the loop must RECOVER. Reporting the break and then
+	// exiting would leave the instance publishing fine and receiving nothing
+	// — strictly worse than the silent reconnect it replaced, and invisible
+	// from outside the process.
+	deadline = time.Now().Add(10 * time.Second)
+	var recovered bool
+	for time.Now().Before(deadline) && !recovered {
+		b.Publish(Event{Type: ItemUpdated, WorkspaceID: "ws-1"})
+		select {
+		case <-ch:
+			recovered = true
+		case <-time.After(200 * time.Millisecond):
+		}
+	}
+	if !recovered {
+		t.Fatal("the receive loop must keep receiving after a reconnect; it stopped")
+	}
+
+	// ...and coverage restarts from there, so clients are not stuck resyncing.
+	last := b.EventsSince("ws-1", 0)
+	if len(last) == 0 {
+		t.Fatal("coverage must be re-established after the reconnect")
+	}
+	if got := b.EventsSince("ws-1", last[len(last)-1].ID); got == nil {
+		t.Fatal("a cursor at our newest post-reconnect event must be served")
+	}
+}
+
+// The guard that keeps pad_event_sequence_resets_total meaningful: a
+// reconnect on a workspace this instance has buffered NOTHING for is not a
+// coverage break, because there was no coverage and no client that could have
+// been told it was current. Without this, every idle workspace's reconnect
+// would give the counter a baseline and "no benign baseline" — the sentence
+// the operator table uses to justify alerting on it — would be false.
+//
+// Found by mutation: removing the guard left every existing test green.
+func TestAReconnectOnAnIdleWorkspaceIsNotAReset(t *testing.T) {
+	mr := miniredis.RunT(t)
+	cutter := newTCPCutter(t, mr.Addr())
+
+	client := redis.NewClient(&redis.Options{Addr: cutter.addr()})
+	t.Cleanup(func() { _ = client.Close() })
+
+	b := NewRedisBus(client)
+	t.Cleanup(b.Close)
+	obs := &recordingObserver{}
+	b.SetObserver(obs)
+
+	// Subscribed, but nothing has ever been published here, so there is no
+	// replay buffer for this workspace.
+	ch := b.Subscribe("ws-idle")
+	defer b.Unsubscribe(ch)
+	waitForSubscribers(t, mr, "pad:events:ws-idle", true)
+
+	cutter.cut()
+
+	// Give the loop time to notice, redial, and (wrongly) report.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, resets := obs.snapshot(); len(resets) > 0 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if _, resets := obs.snapshot(); len(resets) != 0 {
+		t.Fatalf("a reconnect with nothing buffered must not report a reset, got %v", resets)
+	}
+
+	// Positive control in the same test, so a bus that never reports anything
+	// at all cannot pass: once something IS buffered, the next reconnect does
+	// report.
+	b.Publish(Event{Type: ItemCreated, WorkspaceID: "ws-idle"})
+	drain(t, ch, 1)
+	cutter.cut()
+
+	deadline = time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, resets := obs.snapshot(); len(resets) > 0 {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("with a buffer in place, a reconnect must report a coverage break")
+}
+
+// The receive-loop-exit counter, wired end to end. It is not a
+// should-never-fire alarm here — unlike the watch stream's twin, this bus has
+// one loop PER WORKSPACE, so a loop exits every time a workspace's last local
+// subscriber leaves. The test pins that reading, because a counter documented
+// as "expected at zero" and one documented as "read it as a rate" lead an
+// operator to opposite conclusions.
+func TestTheReceiveLoopExitIsReported(t *testing.T) {
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+
+	b := NewRedisBus(client)
+	t.Cleanup(b.Close)
+	obs := &recordingObserver{}
+	b.SetObserver(obs)
+
+	ch := b.Subscribe("ws-1")
+	waitForSubscribers(t, mr, "pad:events:ws-1", true)
+
+	// Control: a live subscription's loop has not exited.
+	if got := obs.exits(); got != 0 {
+		t.Fatalf("a live subscription must not report a loop exit, got %d", got)
+	}
+
+	b.Unsubscribe(ch)
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if obs.exits() > 0 {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("the last subscriber leaving must report a loop exit, got %d", obs.exits())
+}
+
+// codex round 7 #4. A receive loop can notice its connection died long after
+// the workspace was unsubscribed and resubscribed under it. Without a
+// generation check in the cleanup, the stale goroutine deletes the
+// REPLACEMENT buffer, and a client that arrived after the outage ended is told
+// to resync for an incident that never touched it.
+//
+// Driven by calling dropWorkspaceCoverage with the OLD generation, which is
+// exactly what that goroutine holds — the race is real but not schedulable, so
+// reproducing it through the transport would be a flake rather than a test.
+func TestAStaleGoroutineCannotDropTheReplacementBuffer(t *testing.T) {
+	b := newTestRedisBus(t)
+	obs := &recordingObserver{}
+	b.SetObserver(obs)
+
+	ch := b.Subscribe("ws-1")
+	oldGen := b.currentSubGen("ws-1")
+
+	// Everyone leaves: subscription torn down, buffer gone.
+	b.Unsubscribe(ch)
+
+	// A viewer returns and the workspace starts buffering again.
+	ch2 := b.Subscribe("ws-1")
+	defer b.Unsubscribe(ch2)
+	newGen := b.currentSubGen("ws-1")
+	if newGen == oldGen {
+		t.Fatal("fixture drifted: resubscribing must produce a new generation")
+	}
+	b.fanOutFromRedis(newGen, Event{ID: 500, Type: ItemUpdated, WorkspaceID: "ws-1"})
+
+	// NOW the old goroutine finally notices its connection died.
+	b.dropWorkspaceCoverage("ws-1", ResetReasonSubscriptionResumed, oldGen)
+
+	got := b.EventsSince("ws-1", 500)
+	if got == nil {
+		t.Fatal("a stale subscription's cleanup must not drop the replacement buffer")
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected caught-up, got %d events", len(got))
+	}
+	if _, resets := obs.snapshot(); len(resets) != 0 {
+		t.Fatalf("a stale cleanup must not report a reset the live client never experienced, got %v", resets)
+	}
+
+	// Control: the CURRENT generation's cleanup still works, or the check
+	// would have disabled the mechanism it guards.
+	b.dropWorkspaceCoverage("ws-1", ResetReasonSubscriptionResumed, newGen)
+	if got := b.EventsSince("ws-1", 500); got != nil {
+		t.Fatalf("the live subscription's cleanup must still end coverage, got %d events", len(got))
+	}
+	if _, resets := obs.snapshot(); len(resets) != 1 {
+		t.Fatalf("expected exactly one reset, from the live generation, got %v", resets)
+	}
+}

--- a/internal/events/redis_resume_coverage_test.go
+++ b/internal/events/redis_resume_coverage_test.go
@@ -1,0 +1,153 @@
+package events
+
+import (
+	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+)
+
+func newTestRedisBus(t *testing.T) *RedisBus {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+	b := NewRedisBus(client)
+	t.Cleanup(b.Close)
+	return b
+}
+
+// BUG-2731 case 4: the per-workspace subscription lifecycle. When the last
+// local subscriber for a workspace leaves, this instance stops receiving that
+// workspace — but the replay buffer used to survive, looking complete, while
+// events published on other instances went past it unrecorded.
+func TestBufferIsDroppedWhenTheWorkspaceSubscriptionStops(t *testing.T) {
+	b := newTestRedisBus(t)
+
+	ch := b.Subscribe("ws-1")
+	// Events arrive from Redis while we are covering the workspace.
+	b.fanOutLocally(Event{ID: 98, Type: ItemUpdated, WorkspaceID: "ws-1"})
+	b.fanOutLocally(Event{ID: 100, Type: ItemUpdated, WorkspaceID: "ws-1"})
+
+	// Positive control for the live case: while subscribed, a resume from
+	// inside the covered range IS served. Without this the test below would
+	// pass on a bus that never buffers anything at all.
+	if got := b.EventsSince("ws-1", 98); got == nil {
+		t.Fatal("while subscribed, a cursor inside the covered range must be served")
+	} else if len(got) != 1 || got[0].ID != 100 {
+		t.Fatalf("expected event 100 replayed, got %+v", got)
+	}
+
+	// The last local subscriber leaves. This instance is no longer receiving
+	// ws-1; ids 101..500 may be published elsewhere and we will not see them.
+	b.Unsubscribe(ch)
+
+	if got := b.EventsSince("ws-1", 100); got != nil {
+		t.Fatalf("after the subscription stopped, a resume must not be served from the stale buffer; got %d events", len(got))
+	}
+}
+
+// The straggler: sub.cancel() signals the receive goroutine, it does not join
+// it, so a message already in flight can land after the workspace was dropped.
+// Appending it would rebuild a one-entry buffer whose knownFrom vouches for
+// coverage that ended when the subscription did.
+func TestAStragglerAfterUnsubscribeDoesNotRebuildTheBuffer(t *testing.T) {
+	b := newTestRedisBus(t)
+
+	ch := b.Subscribe("ws-1")
+	b.fanOutLocally(Event{ID: 100, Type: ItemUpdated, WorkspaceID: "ws-1"})
+	b.Unsubscribe(ch)
+
+	// In flight when the subscription was cancelled.
+	b.fanOutLocally(Event{ID: 101, Type: ItemUpdated, WorkspaceID: "ws-1"})
+
+	// A new client arrives much later, after ids 102..500 were published on
+	// other instances, resuming from the straggler's id.
+	if got := b.EventsSince("ws-1", 101); got != nil {
+		t.Fatalf("a straggler must not rebuild the buffer and vouch for coverage; got %d events", len(got))
+	}
+
+	// And the negative control that keeps this honest: once the workspace is
+	// genuinely subscribed again, coverage restarts and resumes from the new
+	// first-seen id onward are served normally.
+	ch2 := b.Subscribe("ws-1")
+	defer b.Unsubscribe(ch2)
+	b.fanOutLocally(Event{ID: 600, Type: ItemUpdated, WorkspaceID: "ws-1"})
+
+	got := b.EventsSince("ws-1", 599)
+	if got == nil {
+		t.Fatal("after resubscribing, a cursor adjacent to the new first-seen id must be served")
+	}
+	if len(got) != 1 || got[0].ID != 600 {
+		t.Fatalf("expected event 600 replayed, got %+v", got)
+	}
+
+	// ...while a cursor from before the outage is still a gap, because the
+	// events during it are genuinely unrecoverable here.
+	if got := b.EventsSince("ws-1", 101); got != nil {
+		t.Fatalf("a pre-outage cursor must remain a gap after resubscription; got %d events", len(got))
+	}
+}
+
+// A second local subscriber joining and leaving must not drop coverage for the
+// first one — the buffer is dropped when the SUBSCRIPTION stops, not when any
+// subscriber does.
+func TestBufferSurvivesWhileAnyLocalSubscriberRemains(t *testing.T) {
+	b := newTestRedisBus(t)
+
+	ch1 := b.Subscribe("ws-1")
+	defer b.Unsubscribe(ch1)
+	ch2 := b.Subscribe("ws-1")
+
+	b.fanOutLocally(Event{ID: 100, Type: ItemUpdated, WorkspaceID: "ws-1"})
+	b.Unsubscribe(ch2)
+
+	got := b.EventsSince("ws-1", 100)
+	if got == nil {
+		t.Fatal("coverage must survive while a local subscriber remains; got a gap")
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected caught-up, got %d events", len(got))
+	}
+}
+
+// codex round 1 F2. The straggler test above never resubscribes before the
+// stray message lands, so it passes with a fan-out guard that only checks
+// "does SOME subscription exist". This one closes that: the workspace is
+// resubscribed FIRST, and only then does the old subscription's in-flight
+// message arrive.
+func TestAStragglerFromAnEndedSubscriptionCannotVouchForTheNewOne(t *testing.T) {
+	b := newTestRedisBus(t)
+
+	ch := b.Subscribe("ws-1")
+	oldGen := b.currentSubGen("ws-1")
+	b.fanOutFromRedis(oldGen, Event{ID: 100, Type: ItemUpdated, WorkspaceID: "ws-1"})
+
+	// Everyone leaves; ids 101..500 are published elsewhere, unseen.
+	b.Unsubscribe(ch)
+
+	// A new client arrives and the workspace is subscribed again.
+	ch2 := b.Subscribe("ws-1")
+	defer b.Unsubscribe(ch2)
+	newGen := b.currentSubGen("ws-1")
+	if newGen == oldGen {
+		t.Fatal("fixture drifted: resubscribing must produce a new subscription generation")
+	}
+
+	// NOW the old receive goroutine's in-flight message lands.
+	b.fanOutFromRedis(oldGen, Event{ID: 101, Type: ItemUpdated, WorkspaceID: "ws-1"})
+
+	if got := b.EventsSince("ws-1", 101); got != nil {
+		t.Fatalf("a message from an ended subscription must not establish coverage for the new one; got %d events", len(got))
+	}
+
+	// Control: a message on the CURRENT subscription does establish coverage.
+	b.fanOutFromRedis(newGen, Event{ID: 600, Type: ItemUpdated, WorkspaceID: "ws-1"})
+	got := b.EventsSince("ws-1", 600)
+	if got == nil {
+		t.Fatal("a message on the live subscription must establish coverage")
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected caught-up, got %d events", len(got))
+	}
+}

--- a/internal/events/redis_uncovered_test.go
+++ b/internal/events/redis_uncovered_test.go
@@ -8,11 +8,23 @@ import (
 	"github.com/redis/go-redis/v9"
 )
 
-// codex round 9 #1. Publish lost its local-counter fallback when the script
-// fails, and the removal is the fix — the fallback minted an ID from a
-// different space and published it. Nothing tested the resulting branch, so
-// nothing would notice a future "helpful" restoration of it.
-func TestAFailedPublishDeliversNothing(t *testing.T) {
+// codex round 9 #1, ARRANGEMENT CORRECTED after the split. Publish lost its
+// local-counter fallback when the ID assignment fails, and the removal is the
+// fix — the fallback minted an ID from a process-local space and published it,
+// which every receiving instance reads as the counter having been reset.
+//
+// The first version of this test killed Redis outright, and after the split it
+// no longer DISCRIMINATED: with Redis down the fallback's publish fails too, so
+// "returns early" and "continues and fails at PUBLISH" look identical from the
+// outside. Found by re-running the mutation battery on the split tree, which is
+// the point of re-running it — a subtraction hides its defects as absences.
+//
+// The arrangement now reproduces the PARTIAL failure the branch actually
+// exists for: the sequence key holds a non-integer, so INCR fails while PUBLISH
+// keeps working. That is a realistic shape (a key-type collision with another
+// tenant of the same Redis), and it is the only one where a fallback ID would
+// actually reach subscribers.
+func TestAFailedIDAssignmentPublishesNothing(t *testing.T) {
 	mr := miniredis.RunT(t)
 	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
 	t.Cleanup(func() { _ = client.Close() })
@@ -23,34 +35,28 @@ func TestAFailedPublishDeliversNothing(t *testing.T) {
 	defer b.Unsubscribe(ch)
 	waitForSubscribers(t, mr, "pad:events:ws-1", true)
 
-	// Positive control: the same call succeeds while Redis is reachable, so a
-	// failure below cannot be confused with the bus never publishing at all.
+	// Positive control: publishing works before the key is poisoned, so a
+	// silent test below cannot be the bus never publishing at all.
 	b.Publish(Event{Type: ItemCreated, WorkspaceID: "ws-1"})
 	drain(t, ch, 1)
 
-	// Redis goes away. The script cannot run.
-	mr.Close()
+	// INCR now fails; PUBLISH still works.
+	mr.Set("pad:event_seq", "not-a-number")
 
 	b.Publish(Event{Type: ItemUpdated, WorkspaceID: "ws-1"})
 
 	select {
 	case e := <-ch:
-		t.Fatalf("a failed publish must deliver nothing; got an event with id %d "+
-			"(a fallback id from a local counter is exactly the defect the script removed)", e.ID)
+		t.Fatalf("a publish whose ID assignment failed must deliver nothing; got an event with id %d "+
+			"(an ID from a process-local counter is exactly the defect the fallback's removal fixed)", e.ID)
 	case <-time.After(300 * time.Millisecond):
 	}
 
-	// NOT asserting anything about the replay buffer here, and the reason is
-	// worth writing down: killing Redis also kills the subscription, so the
-	// receive loop's error path legitimately drops this workspace's coverage
-	// (BUG-2731's reconnect handling). An empty buffer at this point is that
-	// mechanism working, not evidence about the publish — an assertion on it
-	// would pass or fail for the wrong reason.
-	//
-	// A resume is a gap now, for that same reason, which is correct: we
-	// genuinely cannot vouch for anything across a dead connection.
-	if got := b.EventsSince("ws-1", 1); got != nil {
-		t.Fatalf("with the connection dead, a resume must be a gap, got %d events", len(got))
+	// The replay buffer must not have grown from it either — here the buffer
+	// IS valid evidence, because the subscription is healthy throughout.
+	held := b.EventsSince("ws-1", 0)
+	if len(held) != 1 {
+		t.Fatalf("the failed publish must not reach the replay buffer; buffer holds %d events", len(held))
 	}
 }
 

--- a/internal/events/redis_uncovered_test.go
+++ b/internal/events/redis_uncovered_test.go
@@ -1,0 +1,156 @@
+package events
+
+import (
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+)
+
+// codex round 9 #1. Publish lost its local-counter fallback when the script
+// fails, and the removal is the fix — the fallback minted an ID from a
+// different space and published it. Nothing tested the resulting branch, so
+// nothing would notice a future "helpful" restoration of it.
+func TestAFailedPublishDeliversNothing(t *testing.T) {
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+	b := NewRedisBus(client)
+	t.Cleanup(b.Close)
+
+	ch := b.Subscribe("ws-1")
+	defer b.Unsubscribe(ch)
+	waitForSubscribers(t, mr, "pad:events:ws-1", true)
+
+	// Positive control: the same call succeeds while Redis is reachable, so a
+	// failure below cannot be confused with the bus never publishing at all.
+	b.Publish(Event{Type: ItemCreated, WorkspaceID: "ws-1"})
+	drain(t, ch, 1)
+
+	// Redis goes away. The script cannot run.
+	mr.Close()
+
+	b.Publish(Event{Type: ItemUpdated, WorkspaceID: "ws-1"})
+
+	select {
+	case e := <-ch:
+		t.Fatalf("a failed publish must deliver nothing; got an event with id %d "+
+			"(a fallback id from a local counter is exactly the defect the script removed)", e.ID)
+	case <-time.After(300 * time.Millisecond):
+	}
+
+	// NOT asserting anything about the replay buffer here, and the reason is
+	// worth writing down: killing Redis also kills the subscription, so the
+	// receive loop's error path legitimately drops this workspace's coverage
+	// (BUG-2731's reconnect handling). An empty buffer at this point is that
+	// mechanism working, not evidence about the publish — an assertion on it
+	// would pass or fail for the wrong reason.
+	//
+	// A resume is a gap now, for that same reason, which is correct: we
+	// genuinely cannot vouch for anything across a dead connection.
+	if got := b.EventsSince("ws-1", 1); got != nil {
+		t.Fatalf("with the connection dead, a resume must be a gap, got %d events", len(got))
+	}
+}
+
+// codex round 9 #4. The subscriber map was re-indexed by workspace, so these
+// counts and the admission check run through new code on RedisBus while every
+// existing test for them uses MemoryBus.
+func TestRedisBusSubscriptionAccounting(t *testing.T) {
+	b := newTestRedisBus(t)
+
+	first, ok := b.SubscribeIfAllowed("ws-1", 2)
+	if !ok {
+		t.Fatal("the first subscriber must be admitted")
+	}
+	second, ok := b.SubscribeIfAllowed("ws-1", 2)
+	if !ok {
+		t.Fatal("the second subscriber must be admitted")
+	}
+	if _, ok := b.SubscribeIfAllowed("ws-1", 2); ok {
+		t.Fatal("the third subscriber must be refused at a limit of 2")
+	}
+
+	// A different workspace is accounted separately.
+	other, ok := b.SubscribeIfAllowed("ws-2", 2)
+	if !ok {
+		t.Fatal("a different workspace must have its own budget")
+	}
+	defer b.Unsubscribe(other)
+
+	if got := b.WorkspaceSubscriberCount("ws-1"); got != 2 {
+		t.Fatalf("WorkspaceSubscriberCount(ws-1) = %d, want 2", got)
+	}
+	if got := b.SubscriberCount(); got != 3 {
+		t.Fatalf("SubscriberCount() = %d, want 3", got)
+	}
+
+	// A slot is RELEASED on unsubscribe — the case a per-workspace index can
+	// get wrong by deleting the wrong map entry.
+	b.Unsubscribe(first)
+	if got := b.WorkspaceSubscriberCount("ws-1"); got != 1 {
+		t.Fatalf("after one unsubscribe, WorkspaceSubscriberCount(ws-1) = %d, want 1", got)
+	}
+	third, ok := b.SubscribeIfAllowed("ws-1", 2)
+	if !ok {
+		t.Fatal("the freed slot must be reusable")
+	}
+	defer b.Unsubscribe(third)
+	defer b.Unsubscribe(second)
+
+	if got := b.SubscriberCount(); got != 3 {
+		t.Fatalf("SubscriberCount() = %d, want 3 after the swap", got)
+	}
+}
+
+// codex round 9 #6. Close on a LIVE Redis bus: every subscriber channel closes
+// so handlers exit, and the receive loops stop. Existing coverage only
+// unsubscribes the last subscriber, which is a different path.
+func TestClosingALiveRedisBusReleasesEverything(t *testing.T) {
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+	b := NewRedisBus(client)
+
+	obs := &recordingObserver{}
+	b.SetObserver(obs)
+
+	one := b.Subscribe("ws-1")
+	two := b.Subscribe("ws-2")
+	waitForSubscribers(t, mr, "pad:events:ws-1", true)
+	waitForSubscribers(t, mr, "pad:events:ws-2", true)
+
+	b.Close()
+
+	for name, ch := range map[string]chan Event{"ws-1": one, "ws-2": two} {
+		select {
+		case _, open := <-ch:
+			if open {
+				t.Fatalf("%s: expected a closed channel, got an event", name)
+			}
+		case <-time.After(3 * time.Second):
+			t.Fatalf("%s: Close must close subscriber channels so SSE handlers exit", name)
+		}
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if obs.exits() >= 2 {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("both receive loops must report their exit at shutdown, got %d", obs.exits())
+}
+
+func drain(t *testing.T, ch chan Event, n int) {
+	t.Helper()
+	for i := 0; i < n; i++ {
+		select {
+		case <-ch:
+		case <-time.After(3 * time.Second):
+			t.Fatalf("timed out waiting for event %d of %d", i+1, n)
+		}
+	}
+}

--- a/internal/events/redis_uncovered_test.go
+++ b/internal/events/redis_uncovered_test.go
@@ -19,11 +19,13 @@ import (
 // outside. Found by re-running the mutation battery on the split tree, which is
 // the point of re-running it — a subtraction hides its defects as absences.
 //
-// The arrangement now reproduces the PARTIAL failure the branch actually
+// The arrangement now reproduces a PARTIAL failure of the kind the branch
 // exists for: the sequence key holds a non-integer, so INCR fails while PUBLISH
-// keeps working. That is a realistic shape (a key-type collision with another
-// tenant of the same Redis), and it is the only one where a fallback ID would
-// actually reach subscribers.
+// keeps working. A key-type collision with another tenant of the same Redis is
+// one realistic route to that state and the cheapest to arrange here; an ACL
+// permitting PUBLISH while denying INCR is another. What matters is the shape —
+// ID assignment failing while delivery still works — because that is the only
+// shape in which a fallback ID would actually reach subscribers.
 func TestAFailedIDAssignmentPublishesNothing(t *testing.T) {
 	mr := miniredis.RunT(t)
 	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})

--- a/internal/events/resume_coverage_test.go
+++ b/internal/events/resume_coverage_test.go
@@ -1,0 +1,106 @@
+package events
+
+import "testing"
+
+// The BUG-2731 family: a resume answered from a view that cannot actually
+// vouch for the span the client is asking about.
+//
+// Every test here asserts BOTH halves — that sync_required (a nil return) IS
+// produced where continuity cannot be proven, and that it is NOT produced
+// where it can. The second half is not padding: the failure mode this fix can
+// introduce is the inversion, where a bus that cannot distinguish "empty
+// because nothing happened" from "empty because we just started" resyncs every
+// reconnecting client. A test suite that only pins the first half would pass on
+// a bus that answers nil unconditionally.
+
+func TestResumeAgainstAWorkspaceThisProcessHasNeverPublished(t *testing.T) {
+	// Case 1: cold buffer. The bus assigns its own IDs from 1 on every start,
+	// so a non-zero cursor here belongs to a previous incarnation.
+	bus := New()
+
+	if got := bus.EventsSince("ws-1", 4200); got != nil {
+		t.Fatalf("resuming from 4200 against a workspace with no buffer must be a gap, got %d events", len(got))
+	}
+
+	// Negative control: a FRESH client (no Last-Event-ID) is not resuming from
+	// a position and must not be told to resync.
+	got := bus.EventsSince("ws-1", 0)
+	if got == nil {
+		t.Fatal("a fresh client (sinceID=0) must not be answered with a gap")
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected 0 events for a fresh client on an empty workspace, got %d", len(got))
+	}
+}
+
+func TestResumeBelowThisInstancesFirstSeenID(t *testing.T) {
+	// The instance under-counted in the original report: a buffer that is
+	// NOT full and NOT empty, whose coverage simply starts above the client's
+	// cursor. Reachable on any multi-instance deployment — the client saw
+	// ws-1 events on another replica before this one began receiving them.
+	//
+	// Built through the real bus rather than a hand-made buffer, so the
+	// global-counter / per-workspace-buffer shape is what is actually being
+	// exercised: 49 publishes to another workspace push the counter up, and
+	// ws-1's first event lands at ID 50.
+	bus := New()
+	for i := 0; i < 49; i++ {
+		bus.Publish(Event{Type: ItemUpdated, WorkspaceID: "ws-other"})
+	}
+	bus.Publish(Event{Type: ItemCreated, WorkspaceID: "ws-1"})
+
+	first := bus.EventsSince("ws-1", 0)
+	if len(first) != 1 || first[0].ID != 50 {
+		t.Fatalf("fixture drifted: expected ws-1's only event at ID 50, got %+v", first)
+	}
+
+	// A cursor with room for a missed ws-1 event between it and our first.
+	if got := bus.EventsSince("ws-1", 30); got != nil {
+		t.Fatalf("resuming from 30 when coverage starts at 50 must be a gap, got %d events", len(got))
+	}
+
+	// Negative control, adjacent cursor: no ID lies strictly between 49 and
+	// 50, so nothing can have been missed and this MUST be served.
+	got := bus.EventsSince("ws-1", 49)
+	if got == nil {
+		t.Fatal("resuming from 49 when coverage starts at 50 leaves no room for a missed event; must be served, not a gap")
+	}
+	if len(got) != 1 || got[0].ID != 50 {
+		t.Fatalf("expected event 50 replayed, got %+v", got)
+	}
+
+	// Negative control, cursor inside the received range: fully caught up.
+	got = bus.EventsSince("ws-1", 50)
+	if got == nil {
+		t.Fatal("a cursor at our newest event is caught up, not a gap")
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected 0 events for a caught-up cursor, got %d", len(got))
+	}
+}
+
+func TestSteadyStateResumesAreUndisturbed(t *testing.T) {
+	// The load-posture guard for the whole unit. A client that has been
+	// connected to this instance all along must still be served from the
+	// buffer, and told it is caught up when it is — no new sync_required.
+	bus := New()
+	for i := 0; i < 10; i++ {
+		bus.Publish(Event{Type: ItemUpdated, WorkspaceID: "ws-1"})
+	}
+
+	got := bus.EventsSince("ws-1", 7)
+	if got == nil {
+		t.Fatal("a same-incarnation cursor inside the buffer must be served")
+	}
+	if len(got) != 3 {
+		t.Fatalf("expected events 8,9,10, got %d", len(got))
+	}
+
+	got = bus.EventsSince("ws-1", 10)
+	if got == nil {
+		t.Fatal("a cursor at the newest event must be served as caught up, not as a gap")
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected 0 events, got %d", len(got))
+	}
+}

--- a/internal/metrics/events_observer.go
+++ b/internal/metrics/events_observer.go
@@ -1,0 +1,45 @@
+package metrics
+
+import "github.com/PerpetualSoftware/pad/internal/events"
+
+// EventsObserver adapts a Metrics into an events.Observer (BUG-2731).
+//
+// This package ALREADY wraps events.EventBus with InstrumentedBus, and the two
+// coexist deliberately. A wrapper sees the EventBus interface: publishes,
+// subscribes, subscriber counts. It could see a nil return from EventsSince,
+// but not WHY the bus refused — cold start, eviction, reset — without
+// reimplementing the coverage rules it wraps, and it cannot see a coverage
+// reset at all, since that is detected on the receive path which no caller
+// invokes. Same split, same reason, as WatchEventsObserver.
+type EventsObserver struct {
+	m *Metrics
+}
+
+// NewEventsObserver returns an observer writing into m.
+func NewEventsObserver(m *Metrics) *EventsObserver {
+	return &EventsObserver{m: m}
+}
+
+// Compile-time proof this satisfies the seam it exists for, so a later
+// signature change surfaces here rather than as a wiring error in cmd/pad.
+var _ events.Observer = (*EventsObserver)(nil)
+
+// ResumeGap takes the workspace ID but deliberately does NOT label the metric
+// with it. Workspace count is unbounded and operator-controlled, so a
+// per-workspace label is a cardinality bomb on a busy installation.
+//
+// The argument stays on the interface because the bus knows the workspace and
+// a future observer — a sampling logger, a per-tenant debug hook — would need
+// it; this adapter is simply not that consumer. Dropping it from the interface
+// to match this one implementation would be the harder change to undo.
+func (o *EventsObserver) ResumeGap(string) {
+	o.m.EventResumeGapsTotal.Inc()
+}
+
+func (o *EventsObserver) SequenceReset(reason string) {
+	o.m.EventSequenceResetsTotal.WithLabelValues(reason).Inc()
+}
+
+func (o *EventsObserver) ReceiveLoopExited() {
+	o.m.EventReceiveLoopExitsTotal.Inc()
+}

--- a/internal/metrics/events_observer_test.go
+++ b/internal/metrics/events_observer_test.go
@@ -1,0 +1,101 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/events"
+)
+
+// The ADAPTER test: internal/events proves the bus calls the observer, and the
+// metric names are pinned here. Neither proves the MAPPING — an adapter that
+// incremented the reset counter on a resume gap would pass both suites and
+// send an incident the wrong way. Different counts per wire, so a crossed
+// mapping cannot produce the expected totals by coincidence.
+func TestEventsObserverMapsEachEventToItsOwnCounter(t *testing.T) {
+	t.Parallel()
+
+	m := New()
+	obs := NewEventsObserver(m)
+
+	obs.ResumeGap("ws-1")
+	obs.ResumeGap("ws-2")
+
+	obs.SequenceReset(events.ResetReasonEpochChange)
+	obs.SequenceReset(events.ResetReasonCounterBackward)
+	obs.SequenceReset(events.ResetReasonCounterBackward)
+	obs.SequenceReset(events.ResetReasonCounterBackward)
+
+	obs.SequenceReset(events.ResetReasonSubscriptionResumed)
+	obs.SequenceReset(events.ResetReasonSubscriptionResumed)
+	obs.SequenceReset(events.ResetReasonSubscriptionResumed)
+	obs.SequenceReset(events.ResetReasonSubscriptionResumed)
+
+	obs.ReceiveLoopExited()
+	obs.ReceiveLoopExited()
+	obs.ReceiveLoopExited()
+	obs.ReceiveLoopExited()
+	obs.ReceiveLoopExited()
+
+	assertCounter(t, m, "pad_event_resume_gaps_total", nil, 2)
+	assertCounter(t, m, "pad_event_sequence_resets_total",
+		map[string]string{"reason": events.ResetReasonEpochChange}, 1)
+	assertCounter(t, m, "pad_event_sequence_resets_total",
+		map[string]string{"reason": events.ResetReasonCounterBackward}, 3)
+	// The third reason must land on its OWN series. It is labelled apart
+	// because an operator reads a Redis connection flap and a keyspace
+	// mistake differently, and an adapter that folded it into either of the
+	// others would satisfy every other assertion here.
+	assertCounter(t, m, "pad_event_sequence_resets_total",
+		map[string]string{"reason": events.ResetReasonSubscriptionResumed}, 4)
+	assertCounter(t, m, "pad_event_receive_loop_exits_total", nil, 5)
+}
+
+// TestResumeGapsAreNotLabelledByWorkspace pins a deliberate omission. The bus
+// passes the workspace ID and the adapter drops it: workspace count is
+// unbounded and operator-controlled, so a per-workspace label is a cardinality
+// bomb. Without this test, "helpfully" adding the label later looks like an
+// improvement and passes everything else.
+func TestResumeGapsAreNotLabelledByWorkspace(t *testing.T) {
+	t.Parallel()
+
+	m := New()
+	obs := NewEventsObserver(m)
+	obs.ResumeGap("ws-1")
+	obs.ResumeGap("ws-2")
+	obs.ResumeGap("ws-3")
+
+	// Three different workspaces, one series, value 3. A labelled
+	// implementation would have three series of 1 and no unlabelled series
+	// for assertCounter to find.
+	assertCounter(t, m, "pad_event_resume_gaps_total", nil, 3)
+}
+
+// The bus-to-adapter-to-registry chain end to end: a real MemoryBus, a real
+// EventsObserver, a real registry, so a bus that never calls its observer or an
+// adapter that writes nowhere cannot pass.
+//
+// IT DOES NOT COVER THE PRODUCTION WIRING — it attaches the observer itself, so
+// it stays green with cmd/pad's SetObserver call deleted. That binding is
+// CONVE-19's real subject and lives in cmd/pad's TestBothEventBusShapesReportToMetrics,
+// which is the only test that fails when the wiring goes missing.
+func TestARealBusMovesTheRealCounter(t *testing.T) {
+	t.Parallel()
+
+	m := New()
+	bus := events.New()
+	bus.SetObserver(NewEventsObserver(m))
+
+	// Negative control FIRST, so a counter that was already non-zero for
+	// some unrelated reason cannot be mistaken for this test's work.
+	bus.Publish(events.Event{Type: events.ItemCreated, WorkspaceID: "ws-1"})
+	if got := bus.EventsSince("ws-1", 1); got == nil {
+		t.Fatal("a caught-up cursor must be served")
+	}
+	assertCounter(t, m, "pad_event_resume_gaps_total", nil, 0)
+
+	// A resume this instance genuinely cannot serve.
+	if got := bus.EventsSince("ws-never-seen", 4200); got != nil {
+		t.Fatalf("expected a gap, got %d events", len(got))
+	}
+	assertCounter(t, m, "pad_event_resume_gaps_total", nil, 1)
+}

--- a/internal/metrics/events_observer_test.go
+++ b/internal/metrics/events_observer_test.go
@@ -20,11 +20,6 @@ func TestEventsObserverMapsEachEventToItsOwnCounter(t *testing.T) {
 	obs.ResumeGap("ws-1")
 	obs.ResumeGap("ws-2")
 
-	obs.SequenceReset(events.ResetReasonEpochChange)
-	obs.SequenceReset(events.ResetReasonCounterBackward)
-	obs.SequenceReset(events.ResetReasonCounterBackward)
-	obs.SequenceReset(events.ResetReasonCounterBackward)
-
 	obs.SequenceReset(events.ResetReasonSubscriptionResumed)
 	obs.SequenceReset(events.ResetReasonSubscriptionResumed)
 	obs.SequenceReset(events.ResetReasonSubscriptionResumed)
@@ -37,14 +32,9 @@ func TestEventsObserverMapsEachEventToItsOwnCounter(t *testing.T) {
 	obs.ReceiveLoopExited()
 
 	assertCounter(t, m, "pad_event_resume_gaps_total", nil, 2)
-	assertCounter(t, m, "pad_event_sequence_resets_total",
-		map[string]string{"reason": events.ResetReasonEpochChange}, 1)
-	assertCounter(t, m, "pad_event_sequence_resets_total",
-		map[string]string{"reason": events.ResetReasonCounterBackward}, 3)
-	// The third reason must land on its OWN series. It is labelled apart
-	// because an operator reads a Redis connection flap and a keyspace
-	// mistake differently, and an adapter that folded it into either of the
-	// others would satisfy every other assertion here.
+	// The reason must land on a LABELLED series, not on the bare counter: an
+	// adapter that dropped the label would satisfy a total-only assertion and
+	// silently merge reasons BUG-2736 will add.
 	assertCounter(t, m, "pad_event_sequence_resets_total",
 		map[string]string{"reason": events.ResetReasonSubscriptionResumed}, 4)
 	assertCounter(t, m, "pad_event_receive_loop_exits_total", nil, 5)

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -120,27 +120,18 @@ type Metrics struct {
 	EventResumeGapsTotal prometheus.Counter
 
 	// EventSequenceResetsTotal counts activity-stream coverage resets by
-	// reason. READ THE LABEL — the three mean different incidents:
-	//
-	//   epoch_change — the shared epoch key changed, so the ID space itself
-	//   is new and EVERY replay buffer was dropped. No benign baseline:
-	//   someone flushed the counter key or pointed two installations at one
-	//   endpoint. (A PAD_REDIS_NAMESPACE change does NOT land here — it
-	//   requires a restart, and a fresh instance has no coverage to lose.)
-	//
-	//   counter_backwards — an ID arrived at or below the high-water mark, so
-	//   every buffer was dropped. USUALLY a restarted counter, but during a
-	//   mixed-version rollout it also fires when an old build delivers IDs
-	//   out of order WITHIN the same space. Expect it during a roll; a
-	//   steady rate outside one is the alertable case.
+	// reason. One reason today:
 	//
 	//   subscription_resumed — a pub/sub connection dropped and resubscribed,
-	//   so ONE workspace's buffer was dropped. This one tracks Redis
-	//   connection health, not keyspace mistakes: expect it during a failover
-	//   and expect it to stop afterwards.
+	//   so ONE workspace's replay buffer was dropped and resumes across the
+	//   outage answer sync_required. This tracks Redis connection health:
+	//   expect it during a failover and expect it to stop afterwards.
 	//
-	// An alert on the total conflates a configuration error with a network
-	// blip.
+	// Labelled from the start rather than shipped as a bare counter, because
+	// BUG-2736's ID-space work adds reasons here that an operator diagnoses
+	// completely differently — a changed keyspace is a configuration mistake,
+	// a connection flap is not — and an alert built on an unlabelled total
+	// would have to be rewritten when they arrive.
 	EventSequenceResetsTotal *prometheus.CounterVec
 
 	// EventReceiveLoopExitsTotal counts a workspace's Redis subscription loop
@@ -377,7 +368,7 @@ func New() *Metrics {
 
 	eventSequenceResetsTotal := prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "pad_event_sequence_resets_total",
-		Help: "Times activity-event replay coverage was dropped, by reason. READ THE LABEL: epoch_change means a new id space (no benign baseline); counter_backwards means an id arrived below the high-water mark, expected during a mixed-version roll; subscription_resumed is a Redis connection flap affecting one workspace.",
+		Help: "Times activity-event replay coverage was dropped, by reason. Today: subscription_resumed, a Redis connection flap affecting one workspace's buffer.",
 	}, []string{"reason"})
 
 	eventReceiveLoopExitsTotal := prometheus.NewCounter(prometheus.CounterOpts{

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -127,11 +127,13 @@ type Metrics struct {
 	//   outage answer sync_required. This tracks Redis connection health:
 	//   expect it during a failover and expect it to stop afterwards.
 	//
-	// Labelled from the start rather than shipped as a bare counter, because
-	// BUG-2736's ID-space work adds reasons here that an operator diagnoses
-	// completely differently — a changed keyspace is a configuration mistake,
-	// a connection flap is not — and an alert built on an unlabelled total
-	// would have to be rewritten when they arrive.
+	// LABELLED FROM THE START rather than shipped as a bare counter, with one
+	// value today. BUG-2736's ID-space work adds reasons here, and an
+	// operator acts on the difference: a Redis connection FLAP is expected
+	// during a failover and self-resolves, while a changed KEYSPACE is a
+	// configuration mistake that does not. An alert built on an unlabelled
+	// total cannot separate them and would have to be rewritten the moment
+	// the second reason arrives.
 	EventSequenceResetsTotal *prometheus.CounterVec
 
 	// EventReceiveLoopExitsTotal counts a workspace's Redis subscription loop

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -35,9 +35,18 @@ type Metrics struct {
 	//   - pad_watchevents_notifications_dropped_total moves on a
 	//     single-process binary too — MemoryBus has the same
 	//     slow-subscriber drop and the same observer.
-	//   - Everything sequence-related (gaps, resets, resume gaps, receive
-	//     loop exits) is Redis-only by construction: MemoryBus assigns
-	//     contiguous ids and has no subscription to lose.
+	//   - Sequence GAPS, RESETS and receive-loop exits are Redis-only by
+	//     construction on both buses: a MemoryBus assigns its own contiguous
+	//     ids and has no subscription to lose.
+	//   - RESUME GAPS are NOT, on either bus, and reading them as Redis-only
+	//     would be wrong (BUG-2731). A single-process instance restarts, and
+	//     a resume carrying a cursor from a previous incarnation is
+	//     unservable there for exactly the same reason it is on a cold
+	//     replica. Both pad_event_resume_gaps_total and
+	//     pad_watchevents_resume_gaps_total move without Redis.
+	//   - Resume gaps also have a second source that is not a bus at all:
+	//     a cursor the HANDLER could not parse never reaches one. See
+	//     server.countResumeGap.
 	//   - pad_redis_up is not registered at all without Redis; a zero on
 	//     a gauge named "up" asserts something false.
 	//
@@ -74,8 +83,12 @@ type Metrics struct {
 	// each of which sends a client sync_required. Distinct from
 	// WatchSequenceGapsTotal: that one is a delivery fault, this one is
 	// the user-visible consequence of any cursor this instance cannot
-	// vouch for — a hole, a cold start, an epoch change, or a
-	// disagreeing shared counter.
+	// vouch for — a hole, a cold start, an epoch change, a disagreeing
+	// shared counter, or a cursor that could not be parsed at all.
+	//
+	// Moves on a single-process deployment too (BUG-2731): MemoryBus
+	// restarts its id sequence, so a resume from a previous incarnation is
+	// genuinely unservable there.
 	WatchResumeGapsTotal prometheus.Counter
 
 	// WatchSequenceResetsTotal counts id-space changes (epoch change or
@@ -88,6 +101,53 @@ type Metrics struct {
 	// non-zero value outside a shutdown means an instance that publishes
 	// fine and receives nothing.
 	WatchReceiveLoopExitsTotal prometheus.Counter
+
+	// EventResumeGapsTotal counts activity-stream (/api/v1/events) resumes
+	// this instance could not serve, each of which sends a client
+	// sync_required (BUG-2731). The watch stream's twin is
+	// WatchResumeGapsTotal; they are separate counters because the two
+	// streams have independent id spaces and separate replay machinery, so
+	// one number would make either one's incident undiagnosable.
+	//
+	// EXPECT A STEP AROUND A DEPLOY AND A RETURN TO BASELINE AFTER IT. Each
+	// instance starts with no coverage, so an early resume against a
+	// workspace a replica has not seen yet is a warranted gap. It counts
+	// RESUMES rather than clients — a deploy nobody reconnects through does
+	// not move it, and one client reconnecting repeatedly moves it repeatedly
+	// — so the step's size is not the connected-client count. A rate that
+	// does NOT settle is the evidence against BUG-2731's central claim, that
+	// the syncs it added are only the warranted ones, and is what to alert on.
+	EventResumeGapsTotal prometheus.Counter
+
+	// EventSequenceResetsTotal counts activity-stream coverage resets by
+	// reason. READ THE LABEL — the three mean different incidents:
+	//
+	//   epoch_change — the shared epoch key changed, so the ID space itself
+	//   is new and EVERY replay buffer was dropped. No benign baseline:
+	//   someone flushed the counter key or pointed two installations at one
+	//   endpoint. (A PAD_REDIS_NAMESPACE change does NOT land here — it
+	//   requires a restart, and a fresh instance has no coverage to lose.)
+	//
+	//   counter_backwards — an ID arrived at or below the high-water mark, so
+	//   every buffer was dropped. USUALLY a restarted counter, but during a
+	//   mixed-version rollout it also fires when an old build delivers IDs
+	//   out of order WITHIN the same space. Expect it during a roll; a
+	//   steady rate outside one is the alertable case.
+	//
+	//   subscription_resumed — a pub/sub connection dropped and resubscribed,
+	//   so ONE workspace's buffer was dropped. This one tracks Redis
+	//   connection health, not keyspace mistakes: expect it during a failover
+	//   and expect it to stop afterwards.
+	//
+	// An alert on the total conflates a configuration error with a network
+	// blip.
+	EventSequenceResetsTotal *prometheus.CounterVec
+
+	// EventReceiveLoopExitsTotal counts a workspace's Redis subscription loop
+	// stopping. Expected at shutdown and whenever the last local subscriber
+	// for a workspace leaves, so unlike the watch stream's twin it does NOT
+	// stay at zero — read it as a RATE against a stable subscriber count.
+	EventReceiveLoopExitsTotal prometheus.Counter
 
 	// SessionPresenceFailuresTotal counts failed presence operations by
 	// op. READ THE LABEL — the consequences differ, and in opposite
@@ -310,6 +370,21 @@ func New() *Metrics {
 		Help: "Times the Redis subscription receive loop stopped. Non-zero outside shutdown means this instance receives no notifications at all.",
 	})
 
+	eventResumeGapsTotal := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "pad_event_resume_gaps_total",
+		Help: "Activity-stream resumes this instance could not serve, each sending a client sync_required. Counts resumes, not clients. Expect a step around a deploy (cold buffers) returning to baseline; a rate that does not settle is the signal.",
+	})
+
+	eventSequenceResetsTotal := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "pad_event_sequence_resets_total",
+		Help: "Times activity-event replay coverage was dropped, by reason. READ THE LABEL: epoch_change means a new id space (no benign baseline); counter_backwards means an id arrived below the high-water mark, expected during a mixed-version roll; subscription_resumed is a Redis connection flap affecting one workspace.",
+	}, []string{"reason"})
+
+	eventReceiveLoopExitsTotal := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "pad_event_receive_loop_exits_total",
+		Help: "Times a workspace's activity subscription loop stopped. Expected at shutdown and when a workspace's last local subscriber leaves — read as a rate against a stable subscriber count.",
+	})
+
 	sessionPresenceFailuresTotal := prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "pad_session_presence_failures_total",
 		Help: "Failed session-presence operations by op. READ THE LABEL — register/renew RISK a live session being unlisted and untargetable, deregister risks a DEAD one staying listed, list returns 503, prune is benign. A failure means an error was reported; Redis can fail after applying.",
@@ -322,6 +397,9 @@ func New() *Metrics {
 		watchResumeGapsTotal,
 		watchSequenceResetsTotal,
 		watchReceiveLoopExitsTotal,
+		eventResumeGapsTotal,
+		eventSequenceResetsTotal,
+		eventReceiveLoopExitsTotal,
 		sessionPresenceFailuresTotal,
 		httpRequestsTotal,
 		httpRequestDuration,
@@ -348,6 +426,9 @@ func New() *Metrics {
 		WatchNotificationsMissedTotal:  watchNotificationsMissedTotal,
 		WatchResumeGapsTotal:           watchResumeGapsTotal,
 		WatchSequenceResetsTotal:       watchSequenceResetsTotal,
+		EventResumeGapsTotal:           eventResumeGapsTotal,
+		EventSequenceResetsTotal:       eventSequenceResetsTotal,
+		EventReceiveLoopExitsTotal:     eventReceiveLoopExitsTotal,
 		WatchReceiveLoopExitsTotal:     watchReceiveLoopExitsTotal,
 		SessionPresenceFailuresTotal:   sessionPresenceFailuresTotal,
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -109,7 +109,9 @@ type Metrics struct {
 	// streams have independent id spaces and separate replay machinery, so
 	// one number would make either one's incident undiagnosable.
 	//
-	// EXPECT A STEP AROUND A DEPLOY AND A RETURN TO BASELINE AFTER IT. Each
+	// EXPECT A STEP AROUND A DEPLOY AND A RETURN TO BASELINE AFTER IT — of the
+	// RATE, not of the counter, which only ever increases within a process.
+	// Each
 	// instance starts with no coverage, so an early resume against a
 	// workspace a replica has not seen yet is a warranted gap. It counts
 	// RESUMES rather than clients — a deploy nobody reconnects through does
@@ -117,6 +119,10 @@ type Metrics struct {
 	// — so the step's size is not the connected-client count. A rate that
 	// does NOT settle is the evidence against BUG-2731's central claim, that
 	// the syncs it added are only the warranted ones, and is what to alert on.
+	//
+	// An increment means the client was told to RECONCILE, which is not the
+	// same as a full re-fetch: the web client answers with an incremental
+	// /changes delta first (web/src/lib/services/sync.svelte.ts).
 	EventResumeGapsTotal prometheus.Counter
 
 	// EventSequenceResetsTotal counts activity-stream coverage resets by

--- a/internal/server/handlers_events.go
+++ b/internal/server/handlers_events.go
@@ -254,6 +254,19 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 
 	// Replay missed events if the client provided Last-Event-ID.
 	// The browser's EventSource sends this automatically on reconnect.
+	//
+	// SUBSCRIBING AND READING THE BUFFER ARE TWO STEPS HERE, AND THAT IS A
+	// KNOWN DEFECT — BUG-2730, not an oversight and not fixed by BUG-2731.
+	// An event published in the window between them lands in BOTH the replay
+	// below and the live channel, so the client processes it twice: a
+	// duplicate toast and duplicate work, though never a lost event.
+	//
+	// internal/watchevents closed the same window with SubscribeAndReplaySince,
+	// one atomic operation under the bus's own lock. Doing that here means a
+	// new method on events.EventBus across three implementations, folded
+	// together with the admission check SubscribeIfAllowed already performs —
+	// which is why it is its own unit rather than a rider on a fix about
+	// COVERAGE. BUG-2730 owns the live-stream-honesty family for both buses.
 	if lastIDStr := r.Header.Get("Last-Event-ID"); lastIDStr != "" {
 		lastID, parseErr := strconv.ParseInt(lastIDStr, 10, 64)
 		if parseErr != nil || lastID <= 0 {

--- a/internal/server/handlers_events.go
+++ b/internal/server/handlers_events.go
@@ -782,11 +782,21 @@ func (s *Server) sseSubscriberStillHasAccess(r *http.Request, workspaceID string
 // rare (buffer eviction only); the coverage check makes it common, so the
 // client's cursor has to be retired along with it.
 //
-// Per the EventSource spec the last event ID buffer is assigned from the `id`
-// field whatever its value, and an empty last event ID means no Last-Event-ID
-// header on the next connect — so the client comes back as a fresh subscriber,
-// which is exactly what it now is, having just re-fetched. A client that
-// ignores the empty field is no worse off than before this change.
+// VERIFIED AGAINST THE SPEC, not remembered (WHATWG HTML, server-sent events).
+// Three steps have to hold and all three do:
+//
+//   - "If the field value does not contain U+0000 NULL, then set the last
+//     event ID buffer to the field value" — an empty value qualifies, and the
+//     spec's own example says an id field with no value "resets the last event
+//     ID to the empty string".
+//   - the last event ID string is set from the buffer BEFORE the empty-data
+//     check returns, so a frame that dispatches no event still updates it.
+//   - on reconnect the header is added only "if the EventSource object's last
+//     event ID string is not the empty string".
+//
+// So the client comes back as a fresh subscriber, which is exactly what it now
+// is, having just re-fetched. A client that ignores the empty field is no
+// worse off than before this change.
 func writeSSEResetCursorEvent(w http.ResponseWriter, eventType string, data interface{}) error {
 	jsonData, err := json.Marshal(data)
 	if err != nil {

--- a/internal/server/handlers_events.go
+++ b/internal/server/handlers_events.go
@@ -49,8 +49,12 @@ func init() {
 // than the historical evicted-buffer case: a buffer whose coverage starts
 // above the cursor, no buffer at all (a cold start, a restart, a scale-up, or
 // simply the first connection to this workspace on this instance), a workspace
-// whose subscription was stopped, and an ID-space reset. pad_event_resume_gaps_total
-// counts them; the bus decides which, and from here they are one answer.
+// whose subscription was stopped or reconnected, and a cursor this handler
+// could not parse. pad_event_resume_gaps_total counts them; the bus decides
+// most, and from here they are one answer.
+//
+// NOT an ID-space reset: detecting a restarted Redis counter needs identity
+// the replay buffer does not carry, so that case is still silent. BUG-2736.
 func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 	// SSE requires the event bus
 	if s.events == nil {

--- a/internal/server/handlers_events.go
+++ b/internal/server/handlers_events.go
@@ -41,8 +41,16 @@ func init() {
 // Supports Last-Event-ID: when a client reconnects with a Last-Event-ID header
 // (set automatically by the browser's EventSource), the server replays any
 // missed events from its in-memory replay buffer before entering the live
-// stream. If the requested ID is too old (evicted from the buffer), the server
-// sends a "sync_required" event so the client knows to do a full refresh.
+// stream.
+//
+// When this instance CANNOT VOUCH for the span the client is asking about it
+// sends a "sync_required" event instead, and clears the client's cursor along
+// with it so the next reconnect starts fresh. Since BUG-2731 that covers more
+// than the historical evicted-buffer case: a buffer whose coverage starts
+// above the cursor, no buffer at all (a cold start, a restart, a scale-up, or
+// simply the first connection to this workspace on this instance), a workspace
+// whose subscription was stopped, and an ID-space reset. pad_event_resume_gaps_total
+// counts them; the bus decides which, and from here they are one answer.
 func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 	// SSE requires the event bus
 	if s.events == nil {
@@ -244,14 +252,58 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 	// The browser's EventSource sends this automatically on reconnect.
 	if lastIDStr := r.Header.Get("Last-Event-ID"); lastIDStr != "" {
 		lastID, parseErr := strconv.ParseInt(lastIDStr, 10, 64)
-		if parseErr == nil && lastID > 0 {
+		if parseErr != nil || lastID <= 0 {
+			// AN UNREADABLE CURSOR IS A CURSOR WE CANNOT VOUCH FOR, not an
+			// absent one (BUG-2731, codex round 10). Sending the header at
+			// all means the client believes it has a position; if we cannot
+			// read it — whitespace, quotes, a negative or zero value, an
+			// integer too large — then we cannot serve it, and treating it as
+			// a fresh connection silently drops everything published before
+			// this subscription.
+			//
+			// A genuinely fresh client sends NO header and never reaches
+			// here, so this costs a resync only for clients that are already
+			// broken, which is exactly who needs one.
+			slog.Info("SSE resume carried an unreadable Last-Event-ID, sending sync_required",
+				"workspace", ws.Slug, "last_event_id", lastIDStr)
+			s.countResumeGap(true)
+			if err := writeSSEResetCursorEvent(w, "sync_required", map[string]string{
+				"reason": "Your last event ID could not be read. Full sync required.",
+			}); err != nil {
+				slog.Debug("SSE: sync_required write failed, closing",
+					"workspace", ws.Slug, "error", err)
+				return
+			}
+			flusher.Flush()
+		} else {
 			missed := s.events.EventsSince(ws.ID, lastID)
 			if missed == nil {
-				// Gap too large — buffer evicted. Tell client to do a full sync.
-				slog.Info("SSE replay gap too large, sending sync_required",
+				// This instance cannot vouch for the span the client is
+				// asking about, so it is told to re-fetch rather than left
+				// believing it is current.
+				//
+				// The comment here used to say "buffer evicted", which was
+				// the only case that produced nil BEFORE BUG-2731 and is now
+				// one of several: eviction, a buffer whose coverage starts
+				// above the cursor, no buffer at all (a cold start, a
+				// restart, a scale-up, or simply the first connection to
+				// this workspace on this instance), and an ID-space reset.
+				// The bus decides which; from here they are one answer, and
+				// the pad_event_resume_gaps_total counter is where the mix
+				// is visible.
+				slog.Info("SSE resume could not be served from this instance's view, sending sync_required",
 					"workspace", ws.Slug, "last_event_id", lastID)
-				if err := writeSSEEvent(w, "sync_required", 0, map[string]string{
-					"reason": "Event buffer exceeded. Full sync required.",
+				if err := writeSSEResetCursorEvent(w, "sync_required", map[string]string{
+					// The client dispatches its delta sync on the event NAME
+					// and never reads this string, which is precisely why
+					// correcting it is free — the earlier decision to keep
+					// "Event buffer exceeded" as a deliberate non-change had
+					// it backwards (codex round 6). Eviction is now one of
+					// several reasons this fires, so the old text named the
+					// rarest of them, and anyone who ever did read it — a
+					// curious operator with devtools open — would be misled
+					// for no benefit.
+					"reason": "This instance cannot vouch for events since your last ID. Full sync required.",
 				}); err != nil {
 					slog.Debug("SSE: sync_required write failed, closing",
 						"workspace", ws.Slug, "error", err)
@@ -713,6 +765,32 @@ func (s *Server) sseSubscriberStillHasAccess(r *http.Request, workspaceID string
 		return true
 	}
 	return has
+}
+
+// writeSSEResetCursorEvent writes an event that also CLEARS the client's
+// Last-Event-ID, by carrying an `id:` field with an empty value.
+//
+// Used for sync_required (BUG-2731, codex round 3). Without it the client
+// keeps the cursor that was just declared unservable, so every subsequent
+// reconnect on a quiet workspace is answered with sync_required again and
+// re-runs a full delta sync — a loop that only ends when a live event happens
+// to arrive and refresh the cursor. That was survivable when this response was
+// rare (buffer eviction only); the coverage check makes it common, so the
+// client's cursor has to be retired along with it.
+//
+// Per the EventSource spec the last event ID buffer is assigned from the `id`
+// field whatever its value, and an empty last event ID means no Last-Event-ID
+// header on the next connect — so the client comes back as a fresh subscriber,
+// which is exactly what it now is, having just re-fetched. A client that
+// ignores the empty field is no worse off than before this change.
+func writeSSEResetCursorEvent(w http.ResponseWriter, eventType string, data interface{}) error {
+	jsonData, err := json.Marshal(data)
+	if err != nil {
+		slog.Error("failed to marshal SSE event", "error", err, "event_type", eventType)
+		return nil
+	}
+	_, err = fmt.Fprintf(w, "id: \nevent: %s\ndata: %s\n\n", eventType, jsonData)
+	return err
 }
 
 // writeSSEEvent writes a single SSE event to the response writer.

--- a/internal/server/handlers_events_resume_test.go
+++ b/internal/server/handlers_events_resume_test.go
@@ -1,0 +1,398 @@
+package server
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/events"
+	"github.com/PerpetualSoftware/pad/internal/metrics"
+)
+
+// readRawSSEFrames reads whole SSE frames verbatim, unlike connectSSE which
+// keeps only the event type and data. The `id:` line is the subject here, so
+// it cannot be parsed away.
+func readRawSSEFrames(t *testing.T, ctx context.Context, url, lastEventID string) <-chan string {
+	t.Helper()
+	return readRawSSEFramesAuthed(t, ctx, url, lastEventID, "")
+}
+
+func readRawSSEFramesAuthed(t *testing.T, ctx context.Context, url, lastEventID, token string) <-chan string {
+	t.Helper()
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		t.Fatalf("building the request: %v", err)
+	}
+	if lastEventID != "" {
+		req.Header.Set("Last-Event-ID", lastEventID)
+	}
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("connecting: %v", err)
+	}
+
+	frames := make(chan string, 16)
+	go func() {
+		defer resp.Body.Close()
+		defer close(frames)
+		scanner := bufio.NewScanner(resp.Body)
+		var frame []string
+		for scanner.Scan() {
+			line := scanner.Text()
+			if line == "" {
+				if len(frame) > 0 {
+					frames <- strings.Join(frame, "\n")
+					frame = nil
+				}
+				continue
+			}
+			frame = append(frame, line)
+		}
+	}()
+	return frames
+}
+
+func waitForFrameWithEvent(t *testing.T, frames <-chan string, eventType string) string {
+	t.Helper()
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case f, ok := <-frames:
+			if !ok {
+				t.Fatalf("stream closed before a %q frame arrived", eventType)
+			}
+			if strings.Contains(f, "event: "+eventType) {
+				return f
+			}
+		case <-deadline:
+			t.Fatalf("timed out waiting for a %q frame", eventType)
+		}
+	}
+}
+
+// BUG-2731, codex round 3. A sync_required tells the client its cursor is
+// unservable — and must RETIRE that cursor, or the client keeps sending it and
+// every later reconnect on a quiet workspace is answered with sync_required
+// again, re-running a full delta sync each time. Survivable when the response
+// was rare (buffer eviction only); the coverage check makes it common.
+func TestSyncRequiredClearsTheClientCursor(t *testing.T) {
+	srv := testServerWithEvents(t)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	slug := createTestWorkspace(t, ts.URL, "Test")
+	url := ts.URL + "/api/v1/events?workspace=" + slug
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// A cursor this instance cannot vouch for: nothing has been published
+	// here, so it belongs to a previous incarnation.
+	frames := readRawSSEFrames(t, ctx, url, "4200")
+	frame := waitForFrameWithEvent(t, frames, "sync_required")
+
+	if !strings.Contains(frame, "id: \n") && !strings.HasPrefix(frame, "id:") {
+		t.Fatalf("sync_required must carry an empty id: field to retire the cursor; frame was:\n%s", frame)
+	}
+	for _, line := range strings.Split(frame, "\n") {
+		if strings.HasPrefix(line, "id:") && strings.TrimSpace(strings.TrimPrefix(line, "id:")) != "" {
+			t.Fatalf("sync_required's id: field must be EMPTY, got %q", line)
+		}
+	}
+}
+
+// The control: an ordinary event still carries its real id, or clients would
+// never advance their cursor at all.
+func TestOrdinaryEventsStillCarryTheirID(t *testing.T) {
+	srv := testServerWithEvents(t)
+	bus := events.New()
+	srv.SetEventBus(bus)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	slug := createTestWorkspace(t, ts.URL, "Test")
+	url := ts.URL + "/api/v1/events?workspace=" + slug
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	frames := readRawSSEFrames(t, ctx, url, "")
+	waitForFrameWithEvent(t, frames, "connected")
+
+	ws := workspaceIDForSlug(t, srv, slug)
+	bus.Publish(events.Event{Type: events.ItemCreated, WorkspaceID: ws, Collection: "tasks"})
+
+	frame := waitForFrameWithEvent(t, frames, events.ItemCreated)
+	var sawID bool
+	for _, line := range strings.Split(frame, "\n") {
+		if strings.HasPrefix(line, "id:") {
+			sawID = true
+			if strings.TrimSpace(strings.TrimPrefix(line, "id:")) == "" {
+				t.Fatalf("an ordinary event must carry a real id, got %q", line)
+			}
+		}
+	}
+	if !sawID {
+		t.Fatalf("an ordinary event must carry an id: field; frame was:\n%s", frame)
+	}
+}
+
+// codex round 9 #7. writeSSEResetCursorEvent was exercised only through a
+// happy-path handler. Its two failure branches differ in KIND and the
+// difference is load-bearing: a marshal error is local to one event and must
+// not tear down a healthy stream, while a write error means the peer is gone
+// and the caller must exit so the bus subscription is released.
+func TestWriteSSEResetCursorEventErrorPaths(t *testing.T) {
+	t.Run("write failure is reported so the caller can exit", func(t *testing.T) {
+		err := writeSSEResetCursorEvent(&failingWriter{err: errWriteFailed}, "sync_required", map[string]string{"reason": "x"})
+		if err == nil {
+			t.Fatal("a failed write must be reported; swallowing it leaves the handler pulling events for a dead peer")
+		}
+	})
+
+	t.Run("marshal failure does not tear down the stream", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		// A channel cannot be marshalled to JSON.
+		if err := writeSSEResetCursorEvent(rec, "sync_required", make(chan int)); err != nil {
+			t.Fatalf("a marshal error is local to one event and must not be reported as a stream failure: %v", err)
+		}
+		if rec.Body.Len() != 0 {
+			t.Fatalf("nothing should have been written, got %q", rec.Body.String())
+		}
+	})
+}
+
+// Reuses handlers_events_test.go's failingWriter (BUG-1532), which already
+// exists for exactly this purpose on the sibling function.
+var errWriteFailed = errors.New("connection reset by peer")
+
+// The sync_required payload's reason text, asserted because it was CHANGED by
+// this unit (it used to name buffer eviction, which is now one cause among
+// several) and because nothing else looks at it — the client dispatches on the
+// event name, so a silent regression here would never surface.
+func TestSyncRequiredReasonDescribesTheActualCondition(t *testing.T) {
+	srv := testServerWithEvents(t)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	slug := createTestWorkspace(t, ts.URL, "Test")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	frames := readRawSSEFrames(t, ctx, ts.URL+"/api/v1/events?workspace="+slug, "4200")
+	frame := waitForFrameWithEvent(t, frames, "sync_required")
+
+	if strings.Contains(frame, "buffer exceeded") {
+		t.Fatalf("the reason still names buffer eviction, which is now one cause among several:\n%s", frame)
+	}
+	if !strings.Contains(frame, "cannot vouch") {
+		t.Fatalf("the reason should describe the actual condition; frame was:\n%s", frame)
+	}
+}
+
+// codex round 10 #4. A client that sends Last-Event-ID at all believes it has
+// a position. If the value is unreadable, treating it as a FRESH connection
+// silently drops everything published before this subscription — the same
+// class of lie this unit exists to end, arriving through the parser rather
+// than the buffer.
+func TestAnUnreadableLastEventIDIsAGapNotAFreshConnection(t *testing.T) {
+	srv := testServerWithEvents(t)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	slug := createTestWorkspace(t, ts.URL, "Test")
+	url := ts.URL + "/api/v1/events?workspace=" + slug
+
+	// NOT in this list: a whitespace-only value. HTTP strips optional
+	// whitespace from header values, so the server sees an empty string —
+	// which the EventSource spec defines as "no position", the same as an
+	// absent header. Measured rather than assumed: a client sending "  "
+	// reaches the handler as `Last-Event-ID: ""`. Treating that as fresh is
+	// correct, so there is nothing here to assert.
+	for _, cursor := range []string{"-1", "0", "not-a-number", `"42"`, "99999999999999999999999"} {
+		t.Run(cursor, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			frames := readRawSSEFrames(t, ctx, url, cursor)
+			frame := waitForFrameWithEvent(t, frames, "sync_required")
+			// And it retires the bad cursor, or the client sends it again on
+			// every reconnect forever.
+			for _, line := range strings.Split(frame, "\n") {
+				if strings.HasPrefix(line, "id:") && strings.TrimSpace(strings.TrimPrefix(line, "id:")) != "" {
+					t.Fatalf("the unreadable cursor must be retired, got %q", line)
+				}
+			}
+		})
+	}
+}
+
+// The control: a genuinely fresh client sends NO header and must NOT be told
+// to resync. Without this leg the fix above would be indistinguishable from
+// resyncing everyone on connect.
+func TestAFreshConnectionIsNotToldToResync(t *testing.T) {
+	srv := testServerWithEvents(t)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	slug := createTestWorkspace(t, ts.URL, "Test")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	frames := readRawSSEFrames(t, ctx, ts.URL+"/api/v1/events?workspace="+slug, "")
+	waitForFrameWithEvent(t, frames, "connected")
+
+	select {
+	case f, ok := <-frames:
+		if ok && strings.Contains(f, "event: sync_required") {
+			t.Fatalf("a fresh connection must not be told to resync:\n%s", f)
+		}
+	case <-time.After(500 * time.Millisecond):
+	}
+}
+
+// The watch stream's half of the two contracts this unit aligned (codex round
+// 11). Both were introduced on the activity stream first, which left the two
+// SSE handlers silently disagreeing — the CLI masks it by clearing its own
+// cursor, so the consumer this would bite is a generic SSE client, which is
+// exactly the one nobody tests.
+func TestWatchStreamSharesTheActivityCursorContracts(t *testing.T) {
+	srv := testServerWithWatchEvents(t)
+	_, _, tok, _ := setupWatchTestUser(t, srv)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	token := tok.Token
+	url := ts.URL + "/api/v1/events/stream"
+
+	t.Run("an unreadable cursor is a gap", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		frames := readRawSSEFramesAuthed(t, ctx, url, "not-a-number", token)
+		frame := waitForFrameWithEvent(t, frames, "sync_required")
+		assertCursorRetired(t, frame)
+	})
+
+	t.Run("a cold resume is a gap and retires the cursor", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		frames := readRawSSEFramesAuthed(t, ctx, url, "4200", token)
+		frame := waitForFrameWithEvent(t, frames, "sync_required")
+		assertCursorRetired(t, frame)
+	})
+
+	t.Run("a fresh connection is not told to resync", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		frames := readRawSSEFramesAuthed(t, ctx, url, "", token)
+		waitForFrameWithEvent(t, frames, "connected")
+		select {
+		case f, ok := <-frames:
+			if ok && strings.Contains(f, "event: sync_required") {
+				t.Fatalf("a fresh watch connection must not be told to resync:\n%s", f)
+			}
+		case <-time.After(500 * time.Millisecond):
+		}
+	})
+}
+
+func assertCursorRetired(t *testing.T, frame string) {
+	t.Helper()
+	var sawID bool
+	for _, line := range strings.Split(frame, "\n") {
+		if strings.HasPrefix(line, "id:") {
+			sawID = true
+			if strings.TrimSpace(strings.TrimPrefix(line, "id:")) != "" {
+				t.Fatalf("sync_required must retire the cursor with an EMPTY id, got %q", line)
+			}
+		}
+	}
+	if !sawID {
+		t.Fatalf("sync_required must carry an empty id: field to retire the cursor; frame was:\n%s", frame)
+	}
+}
+
+// codex round 12. The handlers now answer sync_required for a cursor they
+// could not parse — a decision the BUS never sees, so without counting it here
+// the resume-gap counters undercount exactly the resyncs an operator is most
+// likely to be asked about: a client looping because it keeps sending a cursor
+// nobody can read.
+func TestHandlerLevelResumeGapsAreCounted(t *testing.T) {
+	t.Run("activity", func(t *testing.T) {
+		srv := testServerWithEvents(t)
+		m := metrics.New()
+		srv.SetMetrics(m)
+		ts := httptest.NewServer(srv)
+		defer ts.Close()
+
+		slug := createTestWorkspace(t, ts.URL, "Test")
+		url := ts.URL + "/api/v1/events?workspace=" + slug
+
+		// Control first: a fresh connection is not a gap, so a non-zero
+		// reading below cannot be this test's own setup.
+		func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			frames := readRawSSEFrames(t, ctx, url, "")
+			waitForFrameWithEvent(t, frames, "connected")
+		}()
+		assertGapCount(t, m, "pad_event_resume_gaps_total", 0)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		frames := readRawSSEFrames(t, ctx, url, "not-a-number")
+		waitForFrameWithEvent(t, frames, "sync_required")
+		assertGapCount(t, m, "pad_event_resume_gaps_total", 1)
+	})
+
+	t.Run("watch", func(t *testing.T) {
+		srv := testServerWithWatchEvents(t)
+		_, _, tok, _ := setupWatchTestUser(t, srv)
+		m := metrics.New()
+		srv.SetMetrics(m)
+		ts := httptest.NewServer(srv)
+		defer ts.Close()
+
+		url := ts.URL + "/api/v1/events/stream"
+		assertGapCount(t, m, "pad_watchevents_resume_gaps_total", 0)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		frames := readRawSSEFramesAuthed(t, ctx, url, "not-a-number", tok.Token)
+		waitForFrameWithEvent(t, frames, "sync_required")
+		assertGapCount(t, m, "pad_watchevents_resume_gaps_total", 1)
+	})
+}
+
+func assertGapCount(t *testing.T, m *metrics.Metrics, name string, want float64) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	var got float64
+	for time.Now().Before(deadline) {
+		got = 0
+		families, err := m.Registry.Gather()
+		if err != nil {
+			t.Fatalf("gather: %v", err)
+		}
+		for _, f := range families {
+			if f.GetName() != name {
+				continue
+			}
+			for _, metric := range f.GetMetric() {
+				got += metric.GetCounter().GetValue()
+			}
+		}
+		if got == want {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("%s = %v, want %v", name, got, want)
+}

--- a/internal/server/handlers_events_resume_test.go
+++ b/internal/server/handlers_events_resume_test.go
@@ -211,12 +211,17 @@ func TestAnUnreadableLastEventIDIsAGapNotAFreshConnection(t *testing.T) {
 	slug := createTestWorkspace(t, ts.URL, "Test")
 	url := ts.URL + "/api/v1/events?workspace=" + slug
 
-	// NOT in this list: a whitespace-only value. HTTP strips optional
-	// whitespace from header values, so the server sees an empty string —
-	// which the EventSource spec defines as "no position", the same as an
-	// absent header. Measured rather than assumed: a client sending "  "
-	// reaches the handler as `Last-Event-ID: ""`. Treating that as fresh is
-	// correct, so there is nothing here to assert.
+	// WHICH VALUES COUNT AS UNREADABLE IS OUR POLICY, not a spec requirement.
+	// The SSE spec governs what a client SENDS; it says nothing about what a
+	// server should do with a value it cannot use. Pad's contract is that
+	// `id:` is a positive int64, so anything else is a cursor we cannot serve.
+	//
+	// NOT in this list: a whitespace-only value. Measured with a throwaway
+	// server rather than assumed — Go's client trims the value on the way out,
+	// so a client sending "  " reaches the handler as `Last-Event-ID: ""` and
+	// is indistinguishable from an absent header, which is the same state the
+	// spec has a client report when it holds no position. Nothing to assert,
+	// because the input is not representable end to end.
 	for _, cursor := range []string{"-1", "0", "not-a-number", `"42"`, "99999999999999999999999"} {
 		t.Run(cursor, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())

--- a/internal/server/handlers_watch_events.go
+++ b/internal/server/handlers_watch_events.go
@@ -142,10 +142,21 @@ func (s *Server) handleWatchEventsStream(w http.ResponseWriter, r *http.Request)
 	var ch chan watchevents.Notification
 	var missed []watchevents.Notification
 	var lastID int64
+	// unreadableCursor mirrors the activity stream's rule (BUG-2731): sending
+	// this header at all means the client believes it has a position, so a
+	// value we cannot read is a cursor we cannot serve — NOT a fresh
+	// connection. Treating it as fresh silently drops everything published
+	// before this subscription. A genuinely fresh client sends no header.
+	var unreadableCursor bool
 	if lastIDStr := r.Header.Get("Last-Event-ID"); lastIDStr != "" {
 		if parsed, perr := strconv.ParseInt(lastIDStr, 10, 64); perr == nil && parsed > 0 {
 			lastID = parsed
 			ch, missed = s.watchEvents.SubscribeAndReplaySince(lastID)
+		} else {
+			unreadableCursor = true
+			slog.Info("watch-events: resume carried an unreadable Last-Event-ID, sending sync_required",
+				"user_id", user.ID, "last_event_id", lastIDStr)
+			s.countResumeGap(false)
 		}
 	}
 	if ch == nil {
@@ -231,10 +242,26 @@ func (s *Server) handleWatchEventsStream(w http.ResponseWriter, r *http.Request)
 	}
 	flusher.Flush()
 
+	if unreadableCursor {
+		if err := writeSSEResetCursorEvent(w, "sync_required", map[string]string{
+			"reason": "Your last event ID could not be read. Full sync required.",
+		}); err != nil {
+			slog.Debug("watch-events: sync_required write failed, closing", "user_id", user.ID, "error", err)
+			return
+		}
+		flusher.Flush()
+	}
+
 	if lastID > 0 {
 		if missed == nil {
-			if err := writeSSEEvent(w, "sync_required", 0, map[string]string{
-				"reason": "Notification buffer exceeded. Reconnect without Last-Event-ID to resync.",
+			// Carries an empty `id:` so the client RETIRES the cursor we just
+			// refused, matching the activity stream (BUG-2731). Without it a
+			// generic SSE client resends the same unservable cursor on every
+			// reconnect and is answered the same way each time. The pad CLI
+			// masks this by clearing its own cursor; a browser or third-party
+			// consumer does not.
+			if err := writeSSEResetCursorEvent(w, "sync_required", map[string]string{
+				"reason": "This instance cannot vouch for notifications since your last ID. Full sync required.",
 			}); err != nil {
 				slog.Debug("watch-events: sync_required write failed, closing", "user_id", user.ID, "error", err)
 				return

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -940,6 +940,28 @@ func (s *Server) SetSecureCookies(secure bool) {
 	s.secureCookies = secure
 }
 
+// countResumeGap records a resume this instance refused to serve, for the gaps
+// the BUS never sees (BUG-2731, codex round 12).
+//
+// The buses count their own coverage-based refusals, which is where most of
+// them happen. A cursor we could not even PARSE never reaches a bus, so
+// without this the counters undercount exactly the resyncs an operator is most
+// likely to be asked about — a client stuck in a resync loop because it keeps
+// sending a cursor nobody can read. No double counting: these paths return
+// before any bus call.
+//
+// Split by stream, matching the two counters' separate identities.
+func (s *Server) countResumeGap(activity bool) {
+	if s.metrics == nil {
+		return
+	}
+	if activity {
+		s.metrics.EventResumeGapsTotal.Inc()
+		return
+	}
+	s.metrics.WatchResumeGapsTotal.Inc()
+}
+
 // SetMetrics attaches Prometheus metrics to the server.
 // Must be called before the first request is served.
 //

--- a/internal/watchevents/cold_resume_test.go
+++ b/internal/watchevents/cold_resume_test.go
@@ -1,0 +1,142 @@
+package watchevents
+
+import (
+	"sync"
+	"testing"
+)
+
+// BUG-2731's defect, found in this package by a cross-artifact pass on that
+// unit's branch. MemoryBus assigns its own ids from 1 on every process start,
+// so a client resuming with a cursor from a previous incarnation is asking
+// about a sequence this process never had — and an empty buffer answering with
+// a non-nil empty slice tells it, through both SSE handlers, that it missed
+// nothing.
+//
+// Both halves asserted: the gap IS produced where continuity cannot be proven,
+// and is NOT produced where it can. Without the second, a bus that refused
+// every resume would pass.
+func TestAColdBufferCannotVouchForAResume(t *testing.T) {
+	b := New()
+	t.Cleanup(b.Close)
+
+	if got := b.EventsSince(4200); got != nil {
+		t.Fatalf("a resume against a bus that has published nothing must be a gap, got %d notifications", len(got))
+	}
+
+	// A fresh subscriber is not resuming from a position.
+	got := b.EventsSince(0)
+	if got == nil {
+		t.Fatal("sinceID=0 must never be answered with a gap")
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected 0 notifications, got %d", len(got))
+	}
+
+	// And once the bus has published, ordinary resumes are served — the
+	// control that keeps the fix from being "always refuse".
+	if err := b.Publish(Notification{Kind: KindComment, ItemRef: "TASK-1"}); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+	if got := b.EventsSince(1); got == nil {
+		t.Fatal("a cursor at our newest notification must be served")
+	}
+	if got := b.EventsSince(0); got == nil || len(got) != 1 {
+		t.Fatalf("a fresh subscriber must receive the buffered notification, got %v", got)
+	}
+}
+
+// The same rule must reach SubscribeAndReplaySince, which is the path the SSE
+// handler actually uses — EventsSince is documented as the standalone
+// primitive "for tests and any future caller". Testing only the primitive
+// would leave the consumer's path unproven (CONVE-19).
+func TestSubscribeAndReplaySinceRefusesAColdResume(t *testing.T) {
+	b := New()
+	t.Cleanup(b.Close)
+
+	ch, missed := b.SubscribeAndReplaySince(4200)
+	if ch == nil {
+		t.Fatal("the subscription must still be established even when the replay is refused")
+	}
+	if missed != nil {
+		t.Fatalf("a cold resume must be answered as a gap, got %d notifications", len(missed))
+	}
+
+	// Control: a fresh subscriber gets a usable, non-gap answer.
+	ch2, missed2 := b.SubscribeAndReplaySince(0)
+	defer b.Unsubscribe(ch2)
+	if ch2 == nil {
+		t.Fatal("a fresh subscription must be established")
+	}
+	if missed2 == nil {
+		t.Fatal("sinceID=0 must not be answered as a gap")
+	}
+	b.Unsubscribe(ch)
+}
+
+// codex round 12. The cold-resume fix above sends clients sync_required, and
+// MemoryBus reported nothing — RedisBus counts its own unservable resumes, so
+// pad_watchevents_resume_gaps_total read ZERO on a single-process deployment
+// for a path that genuinely resyncs clients.
+//
+// A counter that is structurally blind to one of its two implementations is
+// worse than an absent one: zero reads as evidence of health.
+func TestMemoryBusReportsItsOwnResumeGaps(t *testing.T) {
+	b := New()
+	t.Cleanup(b.Close)
+	obs := &countingObserver{}
+	b.SetObserver(obs)
+
+	// Both entry points, because the handler uses SubscribeAndReplaySince and
+	// EventsSince is the documented standalone primitive.
+	if got := b.EventsSince(4200); got != nil {
+		t.Fatalf("expected a gap, got %d", len(got))
+	}
+	ch, missed := b.SubscribeAndReplaySince(4200)
+	if missed != nil {
+		t.Fatalf("expected a gap, got %d", len(missed))
+	}
+	b.Unsubscribe(ch)
+
+	if got := obs.resumeGaps(); got != 2 {
+		t.Fatalf("both unservable resumes must be counted, got %d", got)
+	}
+
+	// Control: a served resume is NOT counted, or the counter measures
+	// traffic rather than resyncs.
+	if err := b.Publish(Notification{Kind: KindComment, ItemRef: "TASK-1"}); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+	if got := b.EventsSince(1); got == nil {
+		t.Fatal("a caught-up cursor must be served")
+	}
+	ch2, missed2 := b.SubscribeAndReplaySince(0)
+	defer b.Unsubscribe(ch2)
+	if missed2 == nil {
+		t.Fatal("a fresh subscriber must not be answered with a gap")
+	}
+	if got := obs.resumeGaps(); got != 2 {
+		t.Fatalf("served resumes must not be counted, total moved to %d", got)
+	}
+}
+
+type countingObserver struct {
+	mu   sync.Mutex
+	gaps int
+}
+
+func (o *countingObserver) NotificationDropped(string) {}
+func (o *countingObserver) SequenceGap(int64)          {}
+func (o *countingObserver) SequenceReset(string)       {}
+func (o *countingObserver) ReceiveLoopExited()         {}
+
+func (o *countingObserver) ResumeGap() {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.gaps++
+}
+
+func (o *countingObserver) resumeGaps() int {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return o.gaps
+}

--- a/internal/watchevents/watchevents.go
+++ b/internal/watchevents/watchevents.go
@@ -278,8 +278,15 @@ func (rb *replayBuffer) append(n Notification) {
 	}
 }
 
-// since mirrors internal/events.replayBuffer.since (same gap / eviction
-// semantics), scoped to this package's Notification type.
+// since is this package's replay-window query, scoped to Notification.
+//
+// It NO LONGER MIRRORS internal/events.replayBuffer.since, and the difference
+// is deliberate rather than drift: that one also applies a knownFrom coverage
+// check inside `since`, because its buffers are per-workspace and fed by a
+// global counter. Here the coverage question is answered one level up —
+// RedisBus.replaySince applies knownFrom before delegating, and MemoryBus has
+// only the guard below. Eviction and foreign-ID semantics are still the same
+// in both.
 func (rb *replayBuffer) since(sinceID int64) []Notification {
 	// AN EMPTY BUFFER CANNOT PROVE A CLIENT IS CURRENT (BUG-2731, found by a
 	// cross-artifact pass on that unit's branch). This buffer returning a

--- a/internal/watchevents/watchevents.go
+++ b/internal/watchevents/watchevents.go
@@ -278,10 +278,26 @@ func (rb *replayBuffer) append(n Notification) {
 	}
 }
 
-// since mirrors internal/events.replayBuffer.since exactly (same gap /
-// eviction semantics), scoped to this package's Notification type.
+// since mirrors internal/events.replayBuffer.since (same gap / eviction
+// semantics), scoped to this package's Notification type.
 func (rb *replayBuffer) since(sinceID int64) []Notification {
+	// AN EMPTY BUFFER CANNOT PROVE A CLIENT IS CURRENT (BUG-2731, found by a
+	// cross-artifact pass on that unit's branch). This buffer returning a
+	// non-nil empty slice reads as "caught up" to both SSE handlers, and
+	// MemoryBus assigns its own ids from 1 on every process start — so a
+	// client resuming with a cursor from a previous incarnation was told it
+	// had missed nothing.
+	//
+	// RedisBus never had this: replaySince applies the same rule through
+	// knownFrom before delegating here. MemoryBus reached this function
+	// directly, so the guard belongs at this level, where both get it.
+	//
+	// sinceID == 0 is exempt: a fresh subscriber is not resuming from a
+	// position, so there is no span to vouch for.
 	if rb.count == 0 {
+		if sinceID > 0 {
+			return nil
+		}
 		return []Notification{}
 	}
 	oldest := (rb.head - rb.count + rb.size) % rb.size
@@ -459,6 +475,15 @@ func (b *MemoryBus) Subscribe() chan Notification {
 // only in the returned replay slice), or published after (and thus only
 // delivered on the returned channel) — never both.
 func (b *MemoryBus) SubscribeAndReplaySince(sinceID int64) (chan Notification, []Notification) {
+	// Reported with the lock released, like every other report in this
+	// package. RedisBus counts its own unservable resumes; MemoryBus did not,
+	// so pad_watchevents_resume_gaps_total read zero on a single-process
+	// deployment for a path that genuinely sends clients sync_required
+	// (BUG-2731, codex round 12). A counter that is structurally blind to one
+	// of its two implementations is worse than absent: it reads as evidence.
+	var pending pendingReports
+	defer func() { b.flush(&pending) }()
+
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	ch := make(chan Notification, 64)
@@ -469,6 +494,9 @@ func (b *MemoryBus) SubscribeAndReplaySince(sinceID int64) (chan Notification, [
 	}
 	b.subscribers[ch] = struct{}{}
 	missed := b.replay.since(sinceID)
+	if missed == nil {
+		pending.resumeGap()
+	}
 	return ch, missed
 }
 
@@ -482,9 +510,16 @@ func (b *MemoryBus) Unsubscribe(ch chan Notification) {
 }
 
 func (b *MemoryBus) EventsSince(sinceID int64) []Notification {
+	var pending pendingReports
+	defer func() { b.flush(&pending) }()
+
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	return b.replay.since(sinceID)
+	missed := b.replay.since(sinceID)
+	if missed == nil {
+		pending.resumeGap()
+	}
+	return missed
 }
 
 func (b *MemoryBus) Close() {


### PR DESCRIPTION
Fixes BUG-2731.

## What was wrong

`internal/events` answered a `Last-Event-ID` resume with an empty-but-non-nil slice whenever its replay buffer could not actually speak to the span being asked about. The SSE handler reads that as "caught up", so the client sat on a live stream believing it was current while everything between its cursor and now was silently gone.

The filed instance was a cold buffer. Enumerating the class found five reachable shapes — one of which needs no eviction and no restart at all, just a replica that began receiving a workspace after the client's cursor.

## Scope — two packages, and one thing deliberately absent

Most of the diff is `internal/events` (+ `internal/server`, `internal/metrics`, `cmd/pad`). A cross-artifact review round found that **`internal/watchevents` — the package this fix was ported FROM — had the identical cold-resume defect on its `MemoryBus`**, so this fixes that too and aligns two SSE handler contracts that would otherwise have silently diverged. Two packages is expected, not accidental.

**Absent by design:** this branch originally also carried a protocol migration — a Lua publish script, an epoch key, an `<epoch>|<id>|<json>` payload, a dedupe token and a reset floor — to give the ID space an identity. A review round pointed out that a wire migration had been smuggled into a bug fix as a set of documented deployment costs, and it was split out. **Every piece of deployment risk left this branch with it.** That work is scoped on BUG-2736 and its 17-commit seed branch is preserved.

## What it does

**Coverage, not guesswork.** The replay buffer gains `knownFrom`: the lowest ID from which this instance's coverage of a workspace can be vouched for. A resume from below it answers `nil`, which the handler already turns into `sync_required`.

`knownFrom` here means **receiving-continuity, never ID-contiguity**, and that distinction is the most important thing in the diff. `internal/watchevents` has a field of the same name that ALSO detects holes by noticing a non-consecutive ID. Porting that verbatim would have been a serious regression: this bus has a **global counter and per-workspace buffers**, so a workspace's buffer holds non-consecutive IDs by construction — measured, four publishes alternating across two workspaces give `W=[1 4]`, `X=[2 3]`. An ID-contiguity check would fire on nearly every append and turn *every* resume into `sync_required`: the false-positive inversion of the bug being fixed.

**Coverage ends when it really ends.** A stopped workspace subscription drops its replay buffer — keeping it "in case they come back" looks like a free win and is the bug. A pub/sub reconnect ends that workspace's coverage. Subscriptions are generation-numbered, so a straggler from an ended subscription cannot vouch for the one that replaced it.

**Observability.** An `Observer` seam — this bus is instrumented by a *wrapper*, and none of these conditions are visible at that interface. `pad_event_resume_gaps_total` is what makes this fix falsifiable in production: it should step around a deploy and settle, and a rate that does not settle is evidence against the central claim that every added sync is warranted.

## Client-visible behaviour

The wire contract is untouched — `id:` stays an int64, `Last-Event-ID` stays `ParseInt`. Three behaviour changes, all in the honest direction:

- `sync_required` fires in more cases, and every added case is one where the instance genuinely cannot vouch for the span.
- `sync_required` now carries an **empty `id:`**, retiring the cursor it just refused. Without it a client on a quiet workspace is answered `sync_required` on every reconnect forever.
- An **unreadable `Last-Event-ID`** (`-1`, non-numeric, oversized) is a gap rather than silently a fresh connection.

All three apply to **both** SSE streams, because introducing them on one is how parallel surfaces silently diverge.

## Fixed in passing, pre-existing status explicit

`Publish` fell back to a process-local counter when the Redis `INCR` failed, minting an ID from a different space and publishing it — which every receiving instance reads as the counter having been reset. It also bought nothing: this bus has no local fan-out path, so an event that does not reach Redis reaches no subscriber here either.

## Known limits, stated in the code rather than discovered later

- **BUG-2735** — a message lost mid-subscription is undetectable here: per-workspace IDs are non-consecutive, so there is no local discriminator.
- **BUG-2736** — an integer cursor cannot say which incarnation of the counter it belongs to, so a restarted process reusing low IDs can still answer an old low cursor.
- **BUG-2730** — a slow-subscriber drop is silent to that subscriber, and a **half-open** connection is invisible to both this code and go-redis's health check (`PubSub.Ping` only writes and never reads a reply — measured: no reconnect in 24s behind a wedged proxy).

## Review

Sixteen Codex rounds, ~60 findings, all real. Four shared a prompt; the rest were distinct lenses — tests-as-production-code, operator-in-production, end-to-end scenarios plus concurrency, comment truth, what-has-no-test, adversarial, cross-artifact, previous-fix audit, successor-engineer, post-split damage, external-claim verification. The highest-yield lens was **comment truth, at 20 findings, all of them prose I had written to explain my own work**.

Findings that were defects I introduced and had defended in comments: the lock merge serialised fan-out across workspaces ("costs nothing" covered blocking, not contention); the first Redis-failover fix returned from the receive loop on a transient error, which would have left an instance publishing fine and receiving nothing; and a comment asserting go-redis surfaces errors only on close, which was true of `Channel` and false of `Receive`.

One documentation correction is worth naming plainly: `docs/deployment.md` said "Client resync is honest on both streams". **I wrote that sentence in this unit, and it was false for every single-process deployment at the moment I wrote it** — because the sibling bus had the defect I was fixing.

## Gates

| Gate | Result |
|---|---|
| `go build ./...` | clean |
| `make lint` | **0 issues** |
| `go test ./...` | **exit 0** |
| `make test-pg` | **not applicable** — no store SQL changed |
| Web checks | **not applicable** — no `web/` changes |
| Nix / vendorHash | **not applicable** — no `go.mod` / `go.sum` change |
| Codex | 18 rounds, converged on a fresh angle |

The three N/A rows are stated rather than omitted: a gate matrix that lists only what ran reads as complete whether or not the rest exists, and the reader cannot see the absence.

**Mutation matrix: every fix in this diff has been mutation-tested**, and the battery was re-run after the split — which found one survivor. `TestAFailedPublishDeliversNothing` had killed Redis outright to force the publish-failure branch; that discriminated while an atomic script assigned the ID, but after the split both INCR and PUBLISH fail together, so "returns early" and "continues with a fallback ID" looked identical. The arrangement now poisons the sequence key so INCR fails while PUBLISH still works, which is the only shape where a fallback ID reaches subscribers.

## Follow-ups filed

| | |
|---|---|
| **BUG-2736** | ID-space identity on both buses, the two-phase rollout, and the protocol migration split out of this branch. Its seed branch preserves the 17 commits. **Shipping it deletes machinery**, which is recorded there site by site. |
| **BUG-2735** | A message lost mid-subscription is undetectable here — the two non-local options and the load arithmetic that ruled one out. |
| **BUG-2730** | Silent under-delivery to a live subscriber: the slow-subscriber drop, the subscribe-then-replay duplicate window, and the half-open connection neither this code nor go-redis's health check can see. |


---
https://claude.ai/code/session_01JVDBKbgn3Xt7ndW1YoYd8X
