### PR TITLE
fix(events): guard the generation counter the way the epoch key beside it is guarded (BUG-2740)

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -412,13 +412,13 @@ Alert on these instead:
 | `pad_event_resume_gaps_total` | The ACTIVITY stream's (`/api/v1/events`) twin of the watch resume counter above. **Expect a step around a deploy, with the RATE settling back to baseline** (the counter itself only ever increases) — each instance starts with no replay coverage, so an early resume against a workspace it has not seen yet is a warranted resync. It counts RESUMES, not clients: a deploy with no reconnects does not move it at all, and a client that reconnects several times is counted several times. A rate that does not settle is the thing to alert on |
 | `pad_event_midstream_resyncs_total` | Activity-stream subscribers told MID-STREAM that they missed events, on a connection that stayed open. New in BUG-2730, and the counter to watch when judging whether that fix is costing more resyncs than it is worth. It counts ANNOUNCEMENTS, not causes and not distinct clients: a reset that drops buffers moves it once per live subscriber (and that ratio against `pad_event_sequence_resets_total` is the fan-out); a burst of drops on ONE connection moves it once, because signals coalesce and are rate-limited per connection; and a coverage loss on a workspace with no buffer yet moves it while every cause counter stays flat, because there was no coverage to end but the subscribers still have a hole |
 | `pad_watchevents_midstream_resyncs_total` (see also, listed above) | Same meaning for the watch stream. Its causes are a slow-subscriber drop and a received sequence gap or reset; a gap announces to EVERY subscriber on the instance, so it can exceed all of its cause counters |
-| `pad_event_sequence_resets_total` | Activity replay coverage dropped, by reason. `subscription_resumed` — a pub/sub connection dropped and resubscribed, dropping that workspace's buffer; expect it during a Redis failover and expect it to stop afterwards. `epoch_change` — the shared counter's ID space changed generation, dropping every buffer; expect a handful per cutover. `counter_backward` — an ID arrived at or below a buffer's high-water mark with no generation change; see *Event ID-space migration* for what to expect per phase. `epoch_regressed` — a LOWER generation was seen, so this instance stopped vouching for its buffers. One alongside an `epoch_change` is a message that was in flight when the generation rotated; a RUN of them means the counter itself went backwards, i.e. Redis lost writes. `undecodable_message` — a message on these channels could not be parsed, so that workspace's coverage ended; expect zero, and suspect a namespace collision |
+| `pad_event_sequence_resets_total` | Activity replay coverage dropped, by reason. `subscription_resumed` — a pub/sub connection dropped and resubscribed, dropping that workspace's buffer; expect it during a Redis failover and expect it to stop afterwards. `epoch_change` — the shared counter's ID space changed generation, dropping every buffer; expect a handful per cutover. `counter_backward` — an ID arrived at or below a buffer's high-water mark with no generation change; see *Event ID-space migration* for what to expect per phase. `epoch_regressed` — a LOWER generation was seen, so this instance stopped vouching for its buffers. One alongside an `epoch_change` is a message that was in flight when the generation rotated; a RUN of them means the counter itself went backwards — usually Redis lost writes, and since BUG-2740 possibly a repaired generation key (see *A repaired generation counter*). `undecodable_message` — a message on these channels could not be parsed, so that workspace's coverage ended; expect zero, and suspect a namespace collision |
 | `pad_event_events_dropped_total` | Activity events not delivered to a live subscriber, by reason — today only `slow_subscriber` (that connection's 64-deep channel was full). Per-SUBSCRIBER: every subscriber that was keeping up received the event. Pairs with `pad_event_midstream_resyncs_total`, though not one-for-one in either direction — see that row. New in BUG-2730, along with the fix that stops the drop being silent, so a deploy that starts reporting these is not necessarily a regression — it may be the first time they were countable |
 | `pad_event_receive_loop_exits_total` | A workspace's activity subscription loop stopped. Unlike the watch stream's twin this does **not** stay at zero — it is expected at shutdown and whenever a workspace's last local subscriber leaves. Read it as a rate against a stable subscriber count |
 | `pad_session_presence_failures_total` | Presence operations failing — **read the `op` label**, the risks differ and run in opposite directions: `register`/`renew` may under-report (a live session unlisted and untargetable), `deregister` may over-report (a dead session left listed, and a push aimed at it reaches nobody), `list` returns a 503, `prune` is benign. A failure means the operation reported an error — Redis can fail a pipeline after applying it, so the write may have landed anyway |
 
 
-### A repaired generation counter
+#### A repaired generation counter
 
 `event_epoch_gen` is a shared Redis key, and the same things that corrupt any
 shared key can corrupt it: a namespace collision with another installation, a
@@ -438,9 +438,14 @@ Two operator-visible consequences, neither of which had documentation:
   (ten digits, around 1.7e9) rather than a small count of ID-space resets.
   There is no repair-specific counter or log line, because the repair happens
   inside a Lua script.
-- **Clients resync once.** A repair is an ID-space change like any other, so
-  receivers stop vouching for their buffers and reconcile. One round, not a
-  loop: the repaired key is valid, so the next rotation increments it normally.
+- **Clients reconcile, and normally once.** A repair is an ID-space change
+  like any other, so receivers stop vouching for their buffers. It does not
+  loop, because the repaired key is valid and the next rotation increments it
+  normally. The exception is a repaired generation that lands BELOW the one a
+  receiver already holds: that instance discards the lower epoch as a
+  straggler for its 30-second window rather than adopting it, so the same
+  space can be disclaimed again when it is finally adopted. Bounded by that
+  window, and visible as `epoch_regressed` rather than `epoch_change`.
 
 What a repair does NOT do is merge two ID spaces — that is the outcome the
 whole epoch mechanism exists to prevent, and a rotation, even a backwards one,

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -417,6 +417,36 @@ Alert on these instead:
 | `pad_event_receive_loop_exits_total` | A workspace's activity subscription loop stopped. Unlike the watch stream's twin this does **not** stay at zero — it is expected at shutdown and whenever a workspace's last local subscriber leaves. Read it as a rate against a stable subscriber count |
 | `pad_session_presence_failures_total` | Presence operations failing — **read the `op` label**, the risks differ and run in opposite directions: `register`/`renew` may under-report (a live session unlisted and untargetable), `deregister` may over-report (a dead session left listed, and a push aimed at it reaches nobody), `list` returns a 503, `prune` is benign. A failure means the operation reported an error — Redis can fail a pipeline after applying it, so the write may have landed anyway |
 
+
+### A repaired generation counter
+
+`event_epoch_gen` is a shared Redis key, and the same things that corrupt any
+shared key can corrupt it: a namespace collision with another installation, a
+hand-edit during an incident, a restore that mixed keyspaces. Since BUG-2740 a
+corrupted one is REPAIRED rather than fatal — before that, every phase-2
+publish consumed a sequence ID and then failed, permanently, because the branch
+that would have rotated the generation was the branch that could not run.
+
+Two operator-visible consequences, neither of which had documentation:
+
+- **A repair reseeds the generation from wall-clock SECONDS.** That is above
+  any counted history, so it normally reads as an ordinary `epoch_change`. It
+  is not guaranteed to be above a counter that a collision or a hand-edit had
+  pushed higher, so it can instead surface as `epoch_regressed` — which
+  otherwise means a failover to a replica that lost writes. **The tell is the
+  value**: read the key, and a repaired generation looks like a unix timestamp
+  (ten digits, around 1.7e9) rather than a small count of ID-space resets.
+  There is no repair-specific counter or log line, because the repair happens
+  inside a Lua script.
+- **Clients resync once.** A repair is an ID-space change like any other, so
+  receivers stop vouching for their buffers and reconcile. One round, not a
+  loop: the repaired key is valid, so the next rotation increments it normally.
+
+What a repair does NOT do is merge two ID spaces — that is the outcome the
+whole epoch mechanism exists to prevent, and a rotation, even a backwards one,
+is detected rather than silent.
+
+
 **`pad_watchevents_sequence_resets_total` has no released contract yet, and
 that is why BUG-2739 could change it freely.** The whole metric was introduced
 after `v0.14.0` and no tagged release emits it, so nothing outside a
@@ -552,7 +582,9 @@ format every deployed browser speaks. So this is a substantial mitigation and
 not a closure; the residual case and why it is deferred are at the end of this
 section.
 
-The fix gives each ID space an **epoch** — a monotonic generation number,
+The fix gives each ID space an **epoch** — a generation number (monotonic in
+normal operation; see *A repaired generation counter* below for the one case
+that is not),
 minted by Redis when the space is created and carried as a
 `<epoch>|<id>|<json>` prefix on every message published **by a phase-2
 instance**. Phase-1 instances publish the historical bare JSON and carry no

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -447,9 +447,31 @@ Two operator-visible consequences, neither of which had documentation:
   space can be disclaimed again when it is finally adopted. Bounded by that
   window, and visible as `epoch_regressed` rather than `epoch_change`.
 
-What a repair does NOT do is merge two ID spaces — that is the outcome the
-whole epoch mechanism exists to prevent, and a rotation, even a backwards one,
-is detected rather than silent.
+**Two repairs CAN collide, and what catches it is not the epoch.** The seed is
+above any COUNTED history; it is not a monotonicity guarantee. Corrupt the key
+twice inside one second and both repairs seed the same value, so two genuinely
+different ID spaces carry the identical epoch — and an equal epoch means "same
+space" by design, so neither `epoch_change` nor `epoch_regressed` fires.
+
+The detection chain that does hold, stated so nobody has to rediscover it:
+
+> A merge requires IDs to be REUSED at a receiver. Reuse requires the sequence
+> counter to go BACKWARDS. A backwards counter is detected regardless of what
+> the epoch says — it is the `counter_backward` reason, which drops the
+> affected buffers and refuses cursors below the discarded high-water mark.
+
+So the guarantee is carried by a different detector than the epoch mechanism
+suggests. That is deliberate and it is tested end to end
+(`TestACollidingRepairIsCaughtBySequenceRatherThanEpoch`), because a future
+change that weakened `counter_backward` would remove a protection nothing else
+here advertises.
+
+Two cases that look similar and are not. A sequence counter set FORWARD — say
+to 50, so the next ID is 51 — is a jump inside ONE space: IDs stay unique and
+increasing, nothing is reused, and per-workspace IDs are non-consecutive by
+construction anyway. And a receiver that never held the colliding range has
+nothing to merge; what it experiences is a gap, which is the pre-existing
+undetectable-loss case tracked as BUG-2735.
 
 
 **`pad_watchevents_sequence_resets_total` has no released contract yet, and

--- a/internal/events/redis_bus.go
+++ b/internal/events/redis_bus.go
@@ -275,11 +275,18 @@ local function next_gen()
     -- never merges two id spaces.
     --
     -- The stronger repair would be max(seed, current_epoch + 1), since the
-    -- epoch key is a second witness to the generation in use. It only helps
-    -- where that key is readable — not in the branch that fires BECAUSE the
-    -- epoch is corrupted — so it buys partial monotonicity, which is harder
-    -- to reason about than a bounded, detected residual. Raised with the lead
-    -- rather than taken unilaterally: the seed value is a ruling.
+    -- epoch key is a second witness to the generation in use. RULED AGAINST
+    -- (lead, day-55), and the deciding reason is not that it is partial: a
+    -- repair path that reads a NEIGHBOURING shared key to compute its seed
+    -- takes a dependency on that neighbour's health in exactly the state
+    -- where neighbours are suspect. It would be load-bearing on the thing
+    -- that just failed. It also only helps where the epoch is readable, which
+    -- excludes the branch that fires BECAUSE the epoch is corrupted.
+    --
+    -- The residual is accepted as inside the ruling's intent — orderability
+    -- without coordination — because it is bounded to one resync round,
+    -- detected rather than silent, and never merges two id spaces. Reversible
+    -- in one line if that judgement changes.
     redis.call('SET', KEYS[5], ARGV[3])
     return ARGV[3]
   end
@@ -346,6 +353,12 @@ if not epoch or not string.match(epoch, '^[1-9][0-9]*$') or #epoch > 18 then
   redis.call('SET', KEYS[3], g)
   epoch = g
 end
+-- NOTE (BUG-2744): 'id' is a Lua NUMBER here, so this concatenation has the
+-- same %.14g precision hazard next_gen avoids by reading its value back. Not
+-- fixed with it: id is also this script's return value and is compared
+-- numerically on the Go side, so the remedy has a design question attached.
+-- Reachable by corruption rather than by counting — a hand-edited or collided
+-- event_seq ARRIVES at that magnitude the same way the generation key does.
 redis.call('PUBLISH', KEYS[2], epoch .. '|' .. id .. '|' .. ARGV[1])
 redis.call('SET', KEYS[4], '1', 'EX', ARGV[2])
 return id

--- a/internal/events/redis_bus.go
+++ b/internal/events/redis_bus.go
@@ -109,6 +109,34 @@ end
 return id
 `)
 
+// generationRestartSeed is the value publishScript restarts the generation
+// counter at when it finds that key corrupted (BUG-2740, ARGV[3]).
+//
+// Wall-clock SECONDS, per Dave's day-49 ruling: generations only have to be
+// orderable among themselves, and a corrupted key cannot testify to what the
+// previous generation was, so there is nothing to derive a safe increment
+// from. Seconds are strictly above any plausible increment-from-1 history
+// with no coordination and no stored state to trust.
+//
+// PASSED IN rather than read with redis.call('TIME') inside the script, for
+// two reasons and not for a replication one: the script stays deterministic,
+// and a test can inject a fixed seed and assert the exact restart value —
+// which is what lets the mutation matrix tell "repaired" apart from
+// "repaired to the wrong thing".
+//
+// Clock skew between publishers is harmless here. The script is atomic, so
+// the first publisher to reach a corrupted key repairs it and every other
+// publisher then finds a usable counter and simply increments; no two seeds
+// are ever compared with each other.
+//
+// A seam rather than a direct call so tests can pin it.
+func (b *RedisBus) generationRestartSeed() string {
+	if b.nowUnix != nil {
+		return strconv.FormatInt(b.nowUnix(), 10)
+	}
+	return strconv.FormatInt(time.Now().Unix(), 10)
+}
+
 // publishScript assigns the ID and publishes in ONE atomic Redis call. It is
 // PHASE 2 ONLY: an instance that has not been flipped still publishes through
 // the two-call path in Publish, because the bare wire form carries the ID
@@ -181,6 +209,64 @@ return id
 // — and the client is not told. The token is as durable as Redis replication
 // and no more; this narrows the window rather than closing it.
 var publishScript = redis.NewScript(`
+-- next_gen returns the next generation for the id space, REPAIRING the
+-- generation counter first if it holds something INCR cannot work with
+-- (BUG-2740).
+--
+-- Every INCR of KEYS[5] goes through here, and the reason is that an INCR
+-- against a corrupted key ABORTS THE SCRIPT — after the INCR of KEYS[1] has
+-- already advanced the sequence. Redis is atomic against interleaving but
+-- does not roll back a script's earlier writes on an error, so the failure
+-- burns an id (a hole to every receiver), repeats on the next publish, and
+-- never self-heals, because the branch that would rotate the generation is
+-- the branch that cannot run.
+--
+-- FOUR WAYS IT ABORTS, all measured against the pinned miniredis rather than
+-- assumed, because the filing named only the first two:
+--
+--   list  -> WRONGTYPE
+--   hash  -> WRONGTYPE
+--   string 'abc'                 -> ERR value is not an integer or out of range
+--   string '9223372036854775807' -> ERR increment or decrement would overflow
+--
+-- So a TYPE check alone would have covered half of them. The value has to be
+-- validated too, on exactly the terms the epoch key's guard uses next to it:
+-- a positive integer of at most 18 digits, which is what the RECEIVER's
+-- strconv.ParseInt can read back.
+--
+-- REPAIR IS SET, NOT DEL: SET replaces a key of any type (measured), and
+-- BUG-2736's mutation matrix already established here that a DEL is
+-- removable without any test noticing.
+local function next_gen()
+  local usable = false
+  local t = redis.call('TYPE', KEYS[5])['ok']
+  if t == 'none' then
+    usable = true
+  elseif t == 'string' then
+    local v = redis.call('GET', KEYS[5])
+    if string.match(v, '^[1-9][0-9]*$') and #v <= 18 then
+      usable = true
+    end
+  end
+  if not usable then
+    -- RESTARTED AT WALL-CLOCK SECONDS, not at 1 (Dave's ruling, day-49).
+    -- Generations only have to be orderable among THEMSELVES, and the
+    -- corrupted key is the only witness to what the previous one was, so it
+    -- cannot testify. A wall-clock seed is strictly above any plausible
+    -- increment-from-1 history with no coordination and nothing stored to
+    -- trust. Restarting at 1 would make the new generation LOWER than ones
+    -- receivers have already adopted, which BUG-2736's design reads as a
+    -- regression.
+    --
+    -- The seed arrives as ARGV[3] rather than from redis.call('TIME') so the
+    -- script stays deterministic and the exact restart value is assertable in
+    -- a test. (TIME does work here — measured — but nothing needs it to.)
+    redis.call('SET', KEYS[5], ARGV[3])
+    return ARGV[3]
+  end
+  return tostring(redis.call('INCR', KEYS[5]))
+end
+
 if redis.call('EXISTS', KEYS[4]) == 1 then
   return 0
 end
@@ -193,14 +279,14 @@ if id == 1 then
   -- nothing -- and the numeric check misses it too whenever a receiver's
   -- high-water mark is low enough that the restarted counter climbs past it
   -- before that receiver sees anything.
-  local g = redis.call('INCR', KEYS[5])
-  redis.call('SET', KEYS[3], tostring(g))
+  local g = next_gen()
+  redis.call('SET', KEYS[3], g)
 elseif redis.call('EXISTS', KEYS[3]) == 0 then
   -- No epoch yet for a sequence already in flight: the installation's first
   -- flipped publish, or a phase-1 instance cleared a stale one. Mint the next
   -- generation. Inside the script, so two publishers cannot both mint.
-  local g = redis.call('INCR', KEYS[5])
-  redis.call('SET', KEYS[3], tostring(g))
+  local g = next_gen()
+  redis.call('SET', KEYS[3], g)
 end
 local epoch = false
 if redis.call('TYPE', KEYS[3])['ok'] == 'string' then
@@ -228,9 +314,9 @@ if not epoch or not string.match(epoch, '^[1-9][0-9]*$') or #epoch > 18 then
   -- -- the same total, silent, unrecoverable drop by a different route. Any
   -- 18-digit number fits in an int64, and a generation counts installations'
   -- id-space resets, so 18 digits is not a bound anything real approaches.
-  local g = redis.call('INCR', KEYS[5])
-  redis.call('SET', KEYS[3], tostring(g))
-  epoch = tostring(g)
+  local g = next_gen()
+  redis.call('SET', KEYS[3], g)
+  epoch = g
 end
 redis.call('PUBLISH', KEYS[2], epoch .. '|' .. id .. '|' .. ARGV[1])
 redis.call('SET', KEYS[4], '1', 'EX', ARGV[2])
@@ -245,6 +331,12 @@ type RedisBus struct {
 	observable
 
 	client *redis.Client
+
+	// nowUnix overrides the wall clock behind generationRestartSeed. Nil in
+	// every real construction; set only by tests, so the exact value a
+	// corrupted generation counter is repaired to can be asserted rather than
+	// bounded (BUG-2740).
+	nowUnix func() int64
 
 	// keys builds this installation's Redis names (BUG-2724). The zero
 	// value is the historical un-namespaced keyspace, so a bus constructed
@@ -617,7 +709,7 @@ func (b *RedisBus) publishWithEpoch(channel string, event Event) {
 			b.keys.Name(redisSeqSuffix), channel, b.keys.Name(redisEpochSuffix),
 			dedupeKey, b.keys.Name(redisEpochGenSuffix),
 		},
-		string(data), redisDedupeTTLSeconds).Err(); err != nil {
+		string(data), redisDedupeTTLSeconds, b.generationRestartSeed()).Err(); err != nil {
 		// NO LOCAL-COUNTER FALLBACK, for the same reason the phase-1 path has
 		// none (BUG-2731): an ID minted locally belongs to a different space,
 		// which every receiving instance reads as a counter reset, and this

--- a/internal/events/redis_bus.go
+++ b/internal/events/redis_bus.go
@@ -261,10 +261,38 @@ local function next_gen()
     -- The seed arrives as ARGV[3] rather than from redis.call('TIME') so the
     -- script stays deterministic and the exact restart value is assertable in
     -- a test. (TIME does work here — measured — but nothing needs it to.)
+    --
+    -- WHAT THE SEED DOES NOT GUARANTEE, stated because 'strictly above any
+    -- increment-from-1 history' is the ruling's premise and is not the same
+    -- as monotonic (codex round 2). A host clock stepped BACKWARDS, or the
+    -- key corrupted a second time within the same second, can seed a
+    -- generation at or below the one receivers already hold. Two things bound
+    -- it. Consecutive repairs are already safe without the clock: the first
+    -- one leaves a VALID counter, so the next publisher increments it rather
+    -- than reseeding. And a generation that does go backwards is DETECTED
+    -- rather than silent — BUG-2736's receivers report epoch_regressed and
+    -- stop vouching for their buffers, which costs a round of resyncs and
+    -- never merges two id spaces.
+    --
+    -- The stronger repair would be max(seed, current_epoch + 1), since the
+    -- epoch key is a second witness to the generation in use. It only helps
+    -- where that key is readable — not in the branch that fires BECAUSE the
+    -- epoch is corrupted — so it buys partial monotonicity, which is harder
+    -- to reason about than a bounded, detected residual. Raised with the lead
+    -- rather than taken unilaterally: the seed value is a ruling.
     redis.call('SET', KEYS[5], ARGV[3])
     return ARGV[3]
   end
-  return tostring(redis.call('INCR', KEYS[5]))
+  -- READ THE VALUE BACK rather than stringifying the INCR result. Redis
+  -- returns an integer reply to Lua as a NUMBER, and Lua 5.1 numbers are
+  -- doubles printed with %.14g — so tostring() stops being faithful before
+  -- the 18 digits this guard admits. Measured at the boundary: a counter at
+  -- 999999999999999998 increments to 999999999999999999, and tostring()
+  -- renders it 1000000000000000000 while GET returns it exactly. Publishing
+  -- the stringified form would put a generation on the wire that does not
+  -- match the one in the key.
+  redis.call('INCR', KEYS[5])
+  return redis.call('GET', KEYS[5])
 end
 
 if redis.call('EXISTS', KEYS[4]) == 1 then

--- a/internal/events/redis_bus.go
+++ b/internal/events/redis_bus.go
@@ -1652,6 +1652,27 @@ func (b *RedisBus) fanOut(gen, epoch int64, event Event) {
 		// clients resync repeatedly. Bounded by the roll — once every
 		// publisher is flipped, restarts rotate the epoch, and an epoch change
 		// CLEARS the floor (see dropAllBuffers).
+		// WHY A PER-WORKSPACE CHECK IS ENOUGH FOR A GLOBAL COUNTER, since
+		// two separate reviews have now asked (BUG-2740 rounds 5 and 8) and
+		// the answer is not obvious from here.
+		//
+		// The sequence is shared across workspaces, so a restarted counter
+		// reissues ids that other workspaces may consume — and this compares
+		// only against THIS workspace's high-water mark. That is sufficient
+		// because the unit of coherence is the per-workspace buffer and the
+		// per-workspace cursor: an id can only CORRUPT a buffer by colliding
+		// with one already in it, and an id at or below this workspace's
+		// high-water mark is exactly what this arm catches. A reissued id
+		// that lands in a DIFFERENT workspace collides with nothing here.
+		//
+		// Measured rather than argued, both shapes: a counter DELETED
+		// restarts at 1, which takes publishScript's id == 1 branch and
+		// rotates the epoch unconditionally, so every buffer is dropped
+		// through epoch_change before this arm is reached. A counter SET
+		// backwards above 1 skips that rotation — and then a workspace whose
+		// own ids are reissued sees them as backward and lands here, while a
+		// workspace that never held them keeps a strictly increasing stream
+		// and needs no reset.
 		slog.Warn("event sequence went backwards; dropping replay buffers, resumes below the discarded high-water mark will report sync_required",
 			"high_water_mark", rb.lastAppendedID, "id", event.ID, "workspace", event.WorkspaceID)
 		b.dropAllBuffers(floorRaise)

--- a/internal/events/redis_bus.go
+++ b/internal/events/redis_bus.go
@@ -131,10 +131,48 @@ return id
 //
 // A seam rather than a direct call so tests can pin it.
 func (b *RedisBus) generationRestartSeed() string {
+	now := time.Now().Unix
 	if b.nowUnix != nil {
-		return strconv.FormatInt(b.nowUnix(), 10)
+		now = b.nowUnix
 	}
-	return strconv.FormatInt(time.Now().Unix(), 10)
+	return clampGenerationSeed(now())
+}
+
+// clampGenerationSeed forces the seed into the shape publishScript's guards
+// accept: a positive integer of at most 17 digits.
+//
+// THE CLOCK IS AN INPUT, AND A BROKEN ONE WAS FATAL (BUG-2740, codex round
+// 7). An unset or misconfigured host clock can report zero or a negative
+// second. The repair would then SET that at the generation key and return it
+// as the epoch — and the epoch guard rejects anything not matching
+// ^[1-9][0-9]*$, so it rotates, calls back into the repair, receives the SAME
+// bad seed, and assigns it to the epoch WITHOUT revalidating. The result is
+// an unparseable epoch on the wire, which every receiver rejects: the total,
+// silent, unrecoverable drop the epoch guard exists to prevent, reached
+// through the thing that was supposed to fix it.
+//
+// The floor is 1 rather than anything cleverer. It gives up the ruling's
+// property — a seed above any counted history — because a broken clock cannot
+// deliver that property at all, and the choice is then between a value that
+// is merely LOW and one that is FATAL. A low generation is detected
+// (epoch_regressed) and costs a round of resyncs; an invalid one drops every
+// event until a human intervenes.
+//
+// The ceiling exists for the same reason as next_gen's: a value over 17
+// digits is not usable as a generation, so seeding one would repair the key
+// into a state the very next rotation rejects. Unix seconds cannot reach it
+// by elapsing, but a misconfigured clock is exactly what this function exists
+// to survive.
+func clampGenerationSeed(unix int64) string {
+	const maxSeed = 99999999999999999 // 17 digits, next_gen's ceiling
+	switch {
+	case unix < 1:
+		return "1"
+	case unix > maxSeed:
+		return strconv.FormatInt(maxSeed, 10)
+	default:
+		return strconv.FormatInt(unix, 10)
+	}
 }
 
 // publishScript assigns the ID and publishes in ONE atomic Redis call. It is

--- a/internal/events/redis_bus.go
+++ b/internal/events/redis_bus.go
@@ -244,7 +244,20 @@ local function next_gen()
     usable = true
   elseif t == 'string' then
     local v = redis.call('GET', KEYS[5])
-    if string.match(v, '^[1-9][0-9]*$') and #v <= 18 then
+    -- 17, NOT 18, and the difference is derived rather than chosen (codex
+    -- round 4). This value is about to be INCREMENTED and the result becomes
+    -- the EPOCH, which the guard further down rejects above 18 digits. Accept
+    -- 18 here and a counter at 999999999999999999 increments to a 19-digit
+    -- epoch, that guard fires, and the script rotates a SECOND time inside
+    -- one publish — finding a 19-digit generation, repairing it to the
+    -- wall-clock seed, and publishing a generation far BELOW the one
+    -- receivers hold. Measured: seeded at 18 digits the published epoch came
+    -- back as the seed; at 17 digits it came back as the ordinary increment.
+    --
+    -- So the ceiling for what is USABLE is one digit under the ceiling for
+    -- what is PUBLISHABLE. A value at or above it is treated as corrupted and
+    -- repaired once, which is a single detected rotation instead of two.
+    if string.match(v, '^[1-9][0-9]*$') and #v <= 17 then
       usable = true
     end
   end
@@ -354,11 +367,15 @@ if not epoch or not string.match(epoch, '^[1-9][0-9]*$') or #epoch > 18 then
   epoch = g
 end
 -- NOTE (BUG-2744): 'id' is a Lua NUMBER here, so this concatenation has the
--- same %.14g precision hazard next_gen avoids by reading its value back. Not
--- fixed with it: id is also this script's return value and is compared
--- numerically on the Go side, so the remedy has a design question attached.
+-- same %.14g precision hazard next_gen avoids by reading its value back.
 -- Reachable by corruption rather than by counting — a hand-edited or collided
 -- event_seq ARRIVES at that magnitude the same way the generation key does.
+--
+-- Left for that item rather than fixed here, and the reason is NOT that the
+-- return value constrains it: this caller discards the result (.Err()), so a
+-- wrong id here reaches the wire with nothing on the Go side to notice.
+-- assignScript's id IS consumed, which is why the remedy spans both paths and
+-- is that item's design question.
 redis.call('PUBLISH', KEYS[2], epoch .. '|' .. id .. '|' .. ARGV[1])
 redis.call('SET', KEYS[4], '1', 'EX', ARGV[2])
 return id

--- a/internal/events/redis_generation_guard_test.go
+++ b/internal/events/redis_generation_guard_test.go
@@ -213,10 +213,21 @@ func TestEveryRotationBranchGuardsTheGenerationCounter(t *testing.T) {
 	}{
 		{"sequence starting at 1", func(t *testing.T, b *RedisBus) {
 			ctx := context.Background()
-			// A fresh id space: the seq key gone takes the id == 1 branch,
-			// which rotates unconditionally.
-			if err := b.client.Del(ctx, seqKey, epochKey).Err(); err != nil {
-				t.Fatalf("clear seq and epoch: %v", err)
+			// A fresh id space takes the id == 1 branch, which rotates
+			// unconditionally.
+			//
+			// THE EPOCH IS LEFT IN PLACE AND VALID, which is what ISOLATES
+			// this branch (codex round 3). Clearing it too — the obvious
+			// setup — lets the absent-epoch branch fire instead and produce
+			// an identical result, so the case passed with the id == 1 body
+			// deleted entirely. A stale epoch surviving a restarted sequence
+			// is also the real-world shape: the seq key is what gets evicted,
+			// and the epoch is what is left pointing at the abandoned space.
+			if err := b.client.Del(ctx, seqKey).Err(); err != nil {
+				t.Fatalf("clear the sequence: %v", err)
+			}
+			if got, err := b.client.Get(ctx, epochKey).Result(); err != nil || got == "" {
+				t.Fatalf("fixture: this case needs a live epoch to isolate the branch, got %q (err %v)", got, err)
 			}
 		}},
 		{"absent epoch on a live sequence", func(t *testing.T, b *RedisBus) {

--- a/internal/events/redis_generation_guard_test.go
+++ b/internal/events/redis_generation_guard_test.go
@@ -189,3 +189,92 @@ func TestAHealthyGenerationCounterIsIncrementedNotReseeded(t *testing.T) {
 		t.Fatalf("a healthy counter was reseeded to the wall-clock value %d", fixedSeed)
 	}
 }
+
+// ALL THREE ROTATION BRANCHES, because the table above reaches only one of
+// them and a mutation said so: guarding just the id == 1 site survived the
+// whole suite.
+//
+// publishScript rotates the id space from three places — a sequence starting
+// at 1, an absent epoch on a sequence already in flight, and a corrupted
+// epoch — and each INCRs the generation counter. A guard on one is a guard on
+// none, since the other two abort the script exactly as before. This drives
+// each branch with the counter corrupted underneath it.
+//
+// The branch is selected by the STATE, not by an argument, so each case sets
+// up the state that forces it and then asserts the same repair.
+func TestEveryRotationBranchGuardsTheGenerationCounter(t *testing.T) {
+	genKey := redisns.Default.Name(redisEpochGenSuffix)
+	seqKey := redisns.Default.Name(redisSeqSuffix)
+	epochKey := redisns.Default.Name(redisEpochSuffix)
+
+	for _, tc := range []struct {
+		branch  string
+		arrange func(t *testing.T, b *RedisBus)
+	}{
+		{"sequence starting at 1", func(t *testing.T, b *RedisBus) {
+			ctx := context.Background()
+			// A fresh id space: the seq key gone takes the id == 1 branch,
+			// which rotates unconditionally.
+			if err := b.client.Del(ctx, seqKey, epochKey).Err(); err != nil {
+				t.Fatalf("clear seq and epoch: %v", err)
+			}
+		}},
+		{"absent epoch on a live sequence", func(t *testing.T, b *RedisBus) {
+			ctx := context.Background()
+			if err := b.client.Del(ctx, epochKey).Err(); err != nil {
+				t.Fatalf("clear the epoch: %v", err)
+			}
+		}},
+		{"corrupted epoch", func(t *testing.T, b *RedisBus) {
+			ctx := context.Background()
+			// A wrong-TYPED epoch reaches the recovery branch at the bottom
+			// of the script — the one that rotates because the epoch itself
+			// is unusable. Both shared keys corrupted at once is the shape a
+			// namespace collision or a mixed restore actually produces.
+			if err := b.client.Del(ctx, epochKey).Err(); err != nil {
+				t.Fatalf("clear the epoch: %v", err)
+			}
+			if err := b.client.RPush(ctx, epochKey, "not", "an", "epoch").Err(); err != nil {
+				t.Fatalf("corrupt the epoch: %v", err)
+			}
+		}},
+	} {
+		t.Run(tc.branch, func(t *testing.T) {
+			b, mr := newSeededFlippedBus(t)
+			next := listen(t, b.client, redisns.Default.Name(redisChannelSuffix)+"ws-1")
+			ctx := context.Background()
+
+			// Get the sequence past 1 so the branches that need a live
+			// sequence can be reached; the first case then clears it again.
+			b.Publish(Event{Type: ItemUpdated, WorkspaceID: "ws-1"})
+			if _, _, err := decodePayload(next()); err != nil {
+				t.Fatalf("fixture: the first publish must succeed, got %v", err)
+			}
+
+			tc.arrange(t, b)
+
+			if err := b.client.Del(ctx, genKey).Err(); err != nil {
+				t.Fatalf("clear the generation key: %v", err)
+			}
+			if err := b.client.RPush(ctx, genKey, "not", "a", "counter").Err(); err != nil {
+				t.Fatalf("corrupt the generation key: %v", err)
+			}
+
+			b.Publish(Event{Type: ItemUpdated, WorkspaceID: "ws-1", ItemID: "item-9"})
+
+			epoch, ev, err := decodePayload(next())
+			if err != nil {
+				t.Fatalf("the %s branch must survive a corrupted generation counter: %v", tc.branch, err)
+			}
+			if ev.ItemID != "item-9" {
+				t.Fatalf("the event must still carry its body, got %+v", ev)
+			}
+			if epoch != fixedSeed {
+				t.Fatalf("the %s branch must restart the generation at the seed %d, got %d", tc.branch, fixedSeed, epoch)
+			}
+			if got := mr.Type(genKey); got != "string" {
+				t.Fatalf("the generation key must be repaired to a string, it holds %q", got)
+			}
+		})
+	}
+}

--- a/internal/events/redis_generation_guard_test.go
+++ b/internal/events/redis_generation_guard_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/PerpetualSoftware/pad/internal/redisns"
 	"github.com/alicebob/miniredis/v2"
@@ -437,5 +438,124 @@ func TestTheGenerationCeilingIsOneUnderTheEpochCeiling(t *testing.T) {
 				t.Fatalf("a usable counter must be incremented, not reseeded to %d", fixedSeed)
 			}
 		})
+	}
+}
+
+// A REPAIRED GENERATION CAN COLLIDE, AND WHAT CATCHES IT IS THE SEQUENCE, NOT
+// THE EPOCH (BUG-2740, codex round 5 + the lead's probe request).
+//
+// The repair seeds from wall-clock seconds, which is above any COUNTED
+// history but is not a monotonicity guarantee: corrupt the key twice inside
+// one second and both repairs seed the same value, so two genuinely different
+// id spaces carry the identical epoch. The epoch comparison cannot separate
+// them — equal means "same space" by design, so epoch_regressed does not fire
+// either.
+//
+// It is still not silent, and this test exists because that was folklore
+// until it was measured. A second id space means ids are REISSUED, and a
+// reissued id arrives at or below the receiver's high-water mark with no
+// generation change — which is the counter_backward arm. Buffers dropped,
+// floor raised, old cursors refused.
+//
+// Pinning the chain matters more than pinning the arm: the guarantee is
+// carried by a DIFFERENT detector than the one the epoch mechanism suggests,
+// so a future change that weakens counter_backward would remove a protection
+// nothing here says it provides.
+func TestACollidingRepairIsCaughtBySequenceRatherThanEpoch(t *testing.T) {
+	b, _ := newSeededFlippedBus(t) // nowUnix pinned: both repairs seed the same value
+	obs := &recordingObserver{}
+	b.SetObserver(obs)
+
+	genKey := redisns.Default.Name(redisEpochGenSuffix)
+	seqKey := redisns.Default.Name(redisSeqSuffix)
+	epochKey := redisns.Default.Name(redisEpochSuffix)
+	ctx := context.Background()
+
+	ch, _ := b.Subscribe("ws-1")
+	defer b.Unsubscribe(ch)
+
+	waitFor := func(n int) {
+		t.Helper()
+		for i := 0; i < n; i++ {
+			select {
+			case _, ok := <-ch:
+				if !ok {
+					t.Fatal("subscriber channel closed")
+				}
+			case <-time.After(3 * time.Second):
+				t.Fatalf("timed out waiting for delivery %d of %d", i+1, n)
+			}
+		}
+	}
+	corrupt := func() {
+		t.Helper()
+		if err := b.client.Del(ctx, genKey).Err(); err != nil {
+			t.Fatalf("clear the generation key: %v", err)
+		}
+		if err := b.client.RPush(ctx, genKey, "x").Err(); err != nil {
+			t.Fatalf("corrupt the generation key: %v", err)
+		}
+	}
+
+	// SPACE A, published under a repaired generation.
+	corrupt()
+	for _, id := range []string{"a1", "a2", "a3"} {
+		b.Publish(Event{Type: ItemUpdated, WorkspaceID: "ws-1", ItemID: id})
+	}
+	waitFor(3)
+
+	epochA, err := b.client.Get(ctx, epochKey).Result()
+	if err != nil {
+		t.Fatalf("read the epoch: %v", err)
+	}
+	if _, resets := obs.snapshot(); len(resets) != 0 {
+		t.Fatalf("control: a repaired-but-consistent space must report no reset, got %v", resets)
+	}
+	// Control: the buffer vouches for this span right now.
+	if b.EventsSince("ws-1", 1) == nil {
+		t.Fatal("control: a cursor inside space A must be served before the collision")
+	}
+
+	// SPACE B: the sequence restarts AND the generation is corrupted again
+	// inside the same second, so the repair lands on the same seed.
+	if err := b.client.Del(ctx, seqKey).Err(); err != nil {
+		t.Fatalf("reset the sequence: %v", err)
+	}
+	corrupt()
+	b.Publish(Event{Type: ItemUpdated, WorkspaceID: "ws-1", ItemID: "b1"})
+	waitFor(1)
+
+	epochB, err := b.client.Get(ctx, epochKey).Result()
+	if err != nil {
+		t.Fatalf("read the epoch: %v", err)
+	}
+
+	// THE PREMISE OF THE TEST, asserted rather than assumed: the two spaces
+	// really do collide on the epoch. If a future change makes the seed
+	// monotonic this assertion fails, which is the correct signal — the test
+	// would then be describing a state that can no longer occur.
+	if epochA != epochB {
+		t.Fatalf("this test needs the two spaces to share an epoch; got %s then %s", epochA, epochB)
+	}
+
+	_, resets := obs.snapshot()
+	var sawBackward bool
+	for _, r := range resets {
+		if r == ResetReasonCounterBackward {
+			sawBackward = true
+		}
+		if r == ResetReasonEpochRegressed || r == ResetReasonEpochChange {
+			t.Fatalf("the epoch is unchanged, so no epoch-based reason should fire; got %v", resets)
+		}
+	}
+	if !sawBackward {
+		t.Fatalf("a colliding repair must be caught by the SEQUENCE going backwards (%q), got %v",
+			ResetReasonCounterBackward, resets)
+	}
+
+	// And the consequence, not just the report: the old cursor is refused
+	// rather than replayed the new space's events.
+	if got := b.EventsSince("ws-1", 1); got != nil {
+		t.Fatalf("a cursor from the abandoned space must be refused, got %d events", len(got))
 	}
 }

--- a/internal/events/redis_generation_guard_test.go
+++ b/internal/events/redis_generation_guard_test.go
@@ -301,10 +301,13 @@ func TestEveryRotationBranchGuardsTheGenerationCounter(t *testing.T) {
 // exactly. The published epoch and the stored generation would disagree, and
 // the receiver would adopt a generation the publisher does not hold.
 //
-// 18 digits is not a magnitude a generation counter reaches by counting — it
-// is the magnitude a HAND-EDITED or collided key arrives at, which is the
-// same class of event this whole guard exists for.
-func TestThePublishedGenerationMatchesTheStoredOneAtTheGuardsLimit(t *testing.T) {
+// Divergence starts at 2^53, not at the guard's digit ceiling — doubles are
+// exact only to 9007199254740992 — so this is live for a large part of the
+// range the guard admits, not just at its edge. And such a magnitude is not
+// one a generation counter reaches by counting: it is what a HAND-EDITED or
+// collided key arrives at, which is the same class of event this whole guard
+// exists for.
+func TestThePublishedGenerationMatchesTheStoredOneAboveExactDoubleRange(t *testing.T) {
 	b, _ := newSeededFlippedBus(t)
 	genKey := redisns.Default.Name(redisEpochGenSuffix)
 	epochKey := redisns.Default.Name(redisEpochSuffix)
@@ -316,10 +319,15 @@ func TestThePublishedGenerationMatchesTheStoredOneAtTheGuardsLimit(t *testing.T)
 		t.Fatalf("fixture: the first publish must succeed, got %v", err)
 	}
 
-	// A valid 18-digit generation: inside the guard, so it is INCREMENTED
-	// rather than repaired — which is the path where the stringification
-	// happens.
-	const nearLimit = "999999999999999998"
+	// A valid generation INSIDE the guard, so it is INCREMENTED rather than
+	// repaired — which is the path where the stringification happens.
+	//
+	// The magnitude is chosen, not arbitrary: doubles represent integers
+	// exactly only to 2^53 (9007199254740992, 16 digits), so divergence
+	// begins well below the 17-digit ceiling. Measured — this value
+	// increments to 99999999999999999 in the key while tostring() renders it
+	// 100000000000000000.
+	const nearLimit = "99999999999999998"
 	if err := b.client.Set(ctx, genKey, nearLimit, 0).Err(); err != nil {
 		t.Fatalf("seed the generation: %v", err)
 	}
@@ -342,7 +350,92 @@ func TestThePublishedGenerationMatchesTheStoredOneAtTheGuardsLimit(t *testing.T)
 			"tostring() of the INCR result loses precision at this magnitude; read the value back with GET",
 			published, stored)
 	}
-	if stored != "999999999999999999" {
+	if stored != "99999999999999999" {
 		t.Fatalf("the counter must have incremented exactly once, it holds %s", stored)
+	}
+}
+
+// A generation at or above the guard's ceiling is repaired ONCE, not rotated
+// twice inside one publish (BUG-2740, codex round 4).
+//
+// The two ceilings interact, and that is the whole point of this case. The
+// value next_gen accepts is about to be INCREMENTED and the result becomes the
+// EPOCH — and the epoch guard further down rejects anything over 18 digits. So
+// a generation ceiling of 18 lets a counter at 999999999999999999 increment
+// into a 19-digit epoch, the epoch guard fires, and the script rotates a
+// SECOND time within one publish: it finds a 19-digit generation, repairs it
+// to the wall-clock seed, and publishes a generation far BELOW the one
+// receivers hold.
+//
+// The ceiling for what is USABLE therefore has to sit one digit under the
+// ceiling for what is PUBLISHABLE. This pins both sides of that boundary.
+func TestTheGenerationCeilingIsOneUnderTheEpochCeiling(t *testing.T) {
+	genKey := redisns.Default.Name(redisEpochGenSuffix)
+	epochKey := redisns.Default.Name(redisEpochSuffix)
+
+	for _, tc := range []struct {
+		name     string
+		seed     string
+		want     string
+		repaired bool
+	}{
+		{"at the ceiling, incremented", "99999999999999997", "99999999999999998", false},
+		{"over the ceiling, repaired once", "999999999999999999", strconv.FormatInt(fixedSeed, 10), true},
+		// THE CASE THAT DISCRIMINATES THE CEILING ITSELF, and the reason the
+		// two above do not: an 18-digit value whose increment STAYS 18
+		// digits. With the ceiling at 17 it is over the line and repaired to
+		// the seed; with the ceiling wrongly at 18 it is accepted and simply
+		// incremented, and no second rotation occurs to bring it back to the
+		// seed — so the two settings produce different published values here,
+		// where for 999999999999999999 they produce the same one by different
+		// routes. Found by mutation: without this row, moving the ceiling
+		// back to 18 passes the whole suite.
+		{"just over the ceiling, increment would be clean", "100000000000000000", strconv.FormatInt(fixedSeed, 10), true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			b, _ := newSeededFlippedBus(t)
+			next := listen(t, b.client, redisns.Default.Name(redisChannelSuffix)+"ws-1")
+			ctx := context.Background()
+
+			b.Publish(Event{Type: ItemUpdated, WorkspaceID: "ws-1", ItemID: "a"})
+			if _, _, err := decodePayload(next()); err != nil {
+				t.Fatalf("fixture: %v", err)
+			}
+
+			if err := b.client.Set(ctx, genKey, tc.seed, 0).Err(); err != nil {
+				t.Fatalf("seed the generation: %v", err)
+			}
+			if err := b.client.Del(ctx, epochKey).Err(); err != nil {
+				t.Fatalf("clear the epoch: %v", err)
+			}
+
+			b.Publish(Event{Type: ItemUpdated, WorkspaceID: "ws-1", ItemID: "b"})
+			published, _, err := decodePayload(next())
+			if err != nil {
+				t.Fatalf("publish: %v", err)
+			}
+
+			stored, err := b.client.Get(ctx, genKey).Result()
+			if err != nil {
+				t.Fatalf("read the generation: %v", err)
+			}
+			if stored != tc.want {
+				t.Fatalf("generation: want %s, got %s", tc.want, stored)
+			}
+			if strconv.FormatInt(published, 10) != stored {
+				t.Fatalf("the published epoch %d must equal the stored generation %s", published, stored)
+			}
+
+			// THE LEG THAT CATCHES THE DOUBLE ROTATION. When the value is
+			// repaired, it must land on the seed EXACTLY — a second rotation
+			// would leave seed+1 behind, which is what an 18-digit ceiling
+			// produced.
+			if tc.repaired && stored != strconv.FormatInt(fixedSeed, 10) {
+				t.Fatalf("a repair must rotate exactly once: want the seed %d, got %s", fixedSeed, stored)
+			}
+			if !tc.repaired && published == fixedSeed {
+				t.Fatalf("a usable counter must be incremented, not reseeded to %d", fixedSeed)
+			}
+		})
 	}
 }

--- a/internal/events/redis_generation_guard_test.go
+++ b/internal/events/redis_generation_guard_test.go
@@ -559,3 +559,87 @@ func TestACollidingRepairIsCaughtBySequenceRatherThanEpoch(t *testing.T) {
 		t.Fatalf("a cursor from the abandoned space must be refused, got %d events", len(got))
 	}
 }
+
+// A BROKEN HOST CLOCK MUST NOT BE FATAL (BUG-2740, codex round 7).
+//
+// The seed is an input, and an unset or misconfigured clock can report zero or
+// a negative second. Before the clamp, the repair SET that at the generation
+// key and returned it as the epoch — and because the epoch guard rejects
+// anything not matching ^[1-9][0-9]*$, it rotated, called back into the
+// repair, got the SAME bad seed, and assigned it to the epoch WITHOUT
+// revalidating. An unparseable epoch reached the wire, which every receiver
+// rejects: a total, permanent drop, arrived at through the mechanism meant to
+// prevent it.
+//
+// Each case publishes with the generation key corrupted, so the repair path
+// runs, and asserts the event survives with a USABLE epoch.
+func TestABrokenClockDoesNotProduceAnUnpublishableEpoch(t *testing.T) {
+	genKey := redisns.Default.Name(redisEpochGenSuffix)
+
+	for _, tc := range []struct {
+		name string
+		unix int64
+		want string
+	}{
+		{"zero", 0, "1"},
+		{"negative", -86400, "1"},
+		{"one", 1, "1"},
+		{"ordinary", 1700000000, "1700000000"},
+		{"absurdly far future", 1 << 62, "99999999999999999"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := clampGenerationSeed(tc.unix); got != tc.want {
+				t.Fatalf("clampGenerationSeed(%d) = %s, want %s", tc.unix, got, tc.want)
+			}
+
+			// AND THE END TO END LEG, because the unit assertion above would
+			// pass just as well against a clamp nothing calls.
+			mr := miniredis.RunT(t)
+			client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+			t.Cleanup(func() { _ = client.Close() })
+			b := NewRedisBusWithKeys(client, redisns.Default, true)
+			b.nowUnix = func() int64 { return tc.unix }
+			t.Cleanup(b.Close)
+
+			next := listen(t, b.client, redisns.Default.Name(redisChannelSuffix)+"ws-1")
+			ctx := context.Background()
+
+			b.Publish(Event{Type: ItemUpdated, WorkspaceID: "ws-1", ItemID: "a"})
+			if _, _, err := decodePayload(next()); err != nil {
+				t.Fatalf("fixture: %v", err)
+			}
+
+			// CLEAR THE EPOCH, or no rotation branch fires and the repair
+			// never runs — the second publish would simply reuse the epoch
+			// the fixture minted. Three of these cases passed that way on the
+			// first attempt, because the epoch the fixture mints is 1 and
+			// three of the expected clamps are also 1: vacuous, and only
+			// visible because the other two disagreed.
+			epochKey := redisns.Default.Name(redisEpochSuffix)
+			if err := b.client.Del(ctx, epochKey).Err(); err != nil {
+				t.Fatalf("clear the epoch: %v", err)
+			}
+			if err := b.client.Del(ctx, genKey).Err(); err != nil {
+				t.Fatalf("clear the generation key: %v", err)
+			}
+			if err := b.client.RPush(ctx, genKey, "x").Err(); err != nil {
+				t.Fatalf("corrupt the generation key: %v", err)
+			}
+
+			b.Publish(Event{Type: ItemUpdated, WorkspaceID: "ws-1", ItemID: "b"})
+			epoch, ev, err := decodePayload(next())
+			if err != nil {
+				t.Fatalf("a repair under a %s clock must still publish a decodable event: %v", tc.name, err)
+			}
+			if ev.ItemID != "b" {
+				t.Fatalf("the event must carry its body, got %+v", ev)
+			}
+			if epoch <= 0 {
+				t.Fatalf("the published epoch must be a positive generation, got %d", epoch)
+			}
+			if got := strconv.FormatInt(epoch, 10); got != tc.want {
+				t.Fatalf("published epoch %s, want the clamped seed %s", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/events/redis_generation_guard_test.go
+++ b/internal/events/redis_generation_guard_test.go
@@ -278,3 +278,60 @@ func TestEveryRotationBranchGuardsTheGenerationCounter(t *testing.T) {
 		})
 	}
 }
+
+// The generation reaching the wire must be the one in the key, at every
+// magnitude the guard admits (BUG-2740, codex round 2).
+//
+// Redis hands an integer reply to Lua as a NUMBER, and Lua 5.1 numbers are
+// doubles printed with %.14g — so tostring() stops being faithful BELOW the
+// 18 digits this guard accepts. Measured at the boundary rather than reasoned
+// about: a counter at 999999999999999998 increments to 999999999999999999,
+// and tostring() renders that 1000000000000000000 while GET returns it
+// exactly. The published epoch and the stored generation would disagree, and
+// the receiver would adopt a generation the publisher does not hold.
+//
+// 18 digits is not a magnitude a generation counter reaches by counting — it
+// is the magnitude a HAND-EDITED or collided key arrives at, which is the
+// same class of event this whole guard exists for.
+func TestThePublishedGenerationMatchesTheStoredOneAtTheGuardsLimit(t *testing.T) {
+	b, _ := newSeededFlippedBus(t)
+	genKey := redisns.Default.Name(redisEpochGenSuffix)
+	epochKey := redisns.Default.Name(redisEpochSuffix)
+	next := listen(t, b.client, redisns.Default.Name(redisChannelSuffix)+"ws-1")
+	ctx := context.Background()
+
+	b.Publish(Event{Type: ItemUpdated, WorkspaceID: "ws-1"})
+	if _, _, err := decodePayload(next()); err != nil {
+		t.Fatalf("fixture: the first publish must succeed, got %v", err)
+	}
+
+	// A valid 18-digit generation: inside the guard, so it is INCREMENTED
+	// rather than repaired — which is the path where the stringification
+	// happens.
+	const nearLimit = "999999999999999998"
+	if err := b.client.Set(ctx, genKey, nearLimit, 0).Err(); err != nil {
+		t.Fatalf("seed the generation: %v", err)
+	}
+	if err := b.client.Del(ctx, epochKey).Err(); err != nil {
+		t.Fatalf("clear the epoch: %v", err)
+	}
+
+	b.Publish(Event{Type: ItemUpdated, WorkspaceID: "ws-1", ItemID: "item-11"})
+	published, _, err := decodePayload(next())
+	if err != nil {
+		t.Fatalf("publish at the guard's limit: %v", err)
+	}
+
+	stored, err := b.client.Get(ctx, genKey).Result()
+	if err != nil {
+		t.Fatalf("read the generation back: %v", err)
+	}
+	if strconv.FormatInt(published, 10) != stored {
+		t.Fatalf("the published generation %d must equal the stored one %s — "+
+			"tostring() of the INCR result loses precision at this magnitude; read the value back with GET",
+			published, stored)
+	}
+	if stored != "999999999999999999" {
+		t.Fatalf("the counter must have incremented exactly once, it holds %s", stored)
+	}
+}

--- a/internal/events/redis_generation_guard_test.go
+++ b/internal/events/redis_generation_guard_test.go
@@ -1,0 +1,191 @@
+package events
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/redisns"
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+)
+
+// BUG-2740 — the generation counter had no guard, while the epoch key beside
+// it did.
+//
+// Every branch that rotates the id space INCRs pad:event_epoch_gen, and an
+// INCR against a corrupted key aborts the script AFTER the sequence INCR has
+// already landed. Redis does not roll back a script's earlier writes, so the
+// failure burns an id (a hole to every receiver), repeats on the next publish,
+// and never self-heals — the branch that would rotate the generation is the
+// branch that cannot run.
+//
+// The filing named the two WRONGTYPE cases. A probe against the pinned
+// miniredis found four, and the other two are STRING values that pass any type
+// check: a non-numeric one, and one that overflows int64 on increment. Each
+// gets its own case here for that reason — a guard that checks only TYPE
+// passes half this table.
+
+// seedFn pins the restart seed so the repaired value can be asserted exactly
+// rather than bounded, which is what lets a mutation that repairs to the WRONG
+// value be told apart from one that repairs correctly.
+const fixedSeed int64 = 1700000000
+
+func newSeededFlippedBus(t *testing.T) (*RedisBus, *miniredis.Miniredis) {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+	b := NewRedisBusWithKeys(client, redisns.Default, true)
+	b.nowUnix = func() int64 { return fixedSeed }
+	t.Cleanup(b.Close)
+	return b, mr
+}
+
+func TestACorruptedGenerationCounterIsRepairedRatherThanFatal(t *testing.T) {
+	genKey := redisns.Default.Name(redisEpochGenSuffix)
+	seqKey := redisns.Default.Name(redisSeqSuffix)
+	epochKey := redisns.Default.Name(redisEpochSuffix)
+
+	for _, tc := range []struct {
+		name  string
+		seed  func(t *testing.T, c *redis.Client)
+		abort string
+	}{
+		{"list", func(t *testing.T, c *redis.Client) {
+			if err := c.RPush(context.Background(), genKey, "not", "a", "counter").Err(); err != nil {
+				t.Fatalf("seed: %v", err)
+			}
+		}, "WRONGTYPE"},
+		{"hash", func(t *testing.T, c *redis.Client) {
+			if err := c.HSet(context.Background(), genKey, "f", "v").Err(); err != nil {
+				t.Fatalf("seed: %v", err)
+			}
+		}, "WRONGTYPE"},
+		{"non-numeric string", func(t *testing.T, c *redis.Client) {
+			if err := c.Set(context.Background(), genKey, "abc", 0).Err(); err != nil {
+				t.Fatalf("seed: %v", err)
+			}
+		}, "value is not an integer"},
+		{"string overflowing int64", func(t *testing.T, c *redis.Client) {
+			if err := c.Set(context.Background(), genKey, "9223372036854775807", 0).Err(); err != nil {
+				t.Fatalf("seed: %v", err)
+			}
+		}, "increment would overflow"},
+		{"zero", func(t *testing.T, c *redis.Client) {
+			if err := c.Set(context.Background(), genKey, "0", 0).Err(); err != nil {
+				t.Fatalf("seed: %v", err)
+			}
+		}, "not a positive generation"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			b, mr := newSeededFlippedBus(t)
+			next := listen(t, b.client, redisns.Default.Name(redisChannelSuffix)+"ws-1")
+			ctx := context.Background()
+
+			// PUBLISH ONCE FIRST, load-bearing rather than setup — the same
+			// trap the epoch key's test records. The id == 1 branch rotates
+			// unconditionally, so on a fresh counter the corrupted key would
+			// be repaired on a path this table is not testing. One publish
+			// puts the sequence past 1 so the later publish reaches the
+			// branch under test.
+			b.Publish(Event{Type: ItemUpdated, WorkspaceID: "ws-1"})
+			if _, _, err := decodePayload(next()); err != nil {
+				t.Fatalf("fixture: the first publish must succeed, got %v", err)
+			}
+
+			// Clear the epoch so the SECOND publish takes a rotating branch,
+			// and corrupt the generation counter under it.
+			if err := b.client.Del(ctx, epochKey).Err(); err != nil {
+				t.Fatalf("clear the epoch: %v", err)
+			}
+			if err := b.client.Del(ctx, genKey).Err(); err != nil {
+				t.Fatalf("clear the generation key: %v", err)
+			}
+			tc.seed(t, b.client)
+
+			seqBefore, err := b.client.Get(ctx, seqKey).Int64()
+			if err != nil {
+				t.Fatalf("read the sequence: %v", err)
+			}
+
+			b.Publish(Event{Type: ItemUpdated, WorkspaceID: "ws-1", ItemID: "item-7"})
+
+			epoch, ev, err := decodePayload(next())
+			if err != nil {
+				t.Fatalf("the publish must survive a %s generation key (%s): %v", tc.name, tc.abort, err)
+			}
+			if ev.ItemID != "item-7" {
+				t.Fatalf("the event must still carry its body, got %+v", ev)
+			}
+
+			// THE REPAIRED VALUE, ASSERTED EXACTLY. Bounding it (">0", or
+			// "large") would pass against a repair to 1 — which is the
+			// specific wrong answer the ruling exists to rule out, because a
+			// generation BELOW ones receivers have already adopted reads as a
+			// regression rather than a rotation.
+			if epoch != fixedSeed {
+				t.Fatalf("want the generation restarted at the wall-clock seed %d, got %d", fixedSeed, epoch)
+			}
+			if got := mr.Type(genKey); got != "string" {
+				t.Fatalf("the generation key must be repaired to a string, it holds %q", got)
+			}
+			if got, err := b.client.Get(ctx, genKey).Result(); err != nil || got != strconv.FormatInt(fixedSeed, 10) {
+				t.Fatalf("the generation key must hold the seed, got %q (err %v)", got, err)
+			}
+
+			// AND THE SEQUENCE ADVANCED EXACTLY ONCE. This is the leg that
+			// pins the actual damage: an aborted script leaves the sequence
+			// INCRemented with nothing published, which every receiver reads
+			// as a hole. A repair that merely stopped the error while losing
+			// the publish would satisfy every assertion above.
+			seqAfter, err := b.client.Get(ctx, seqKey).Int64()
+			if err != nil {
+				t.Fatalf("read the sequence: %v", err)
+			}
+			if seqAfter != seqBefore+1 {
+				t.Fatalf("the sequence must advance exactly once per published event: %d -> %d", seqBefore, seqAfter)
+			}
+			if ev.ID != seqAfter {
+				t.Fatalf("the published id %d must be the sequence value %d", ev.ID, seqAfter)
+			}
+		})
+	}
+}
+
+// The control: a HEALTHY generation counter is incremented, not replaced by
+// the seed. Without this leg the table above passes against a guard that
+// repairs unconditionally — which would restart the generation on every
+// rotation and make the counter meaningless.
+func TestAHealthyGenerationCounterIsIncrementedNotReseeded(t *testing.T) {
+	b, _ := newSeededFlippedBus(t)
+	epochKey := redisns.Default.Name(redisEpochSuffix)
+	next := listen(t, b.client, redisns.Default.Name(redisChannelSuffix)+"ws-1")
+	ctx := context.Background()
+
+	b.Publish(Event{Type: ItemUpdated, WorkspaceID: "ws-1"})
+	first, _, err := decodePayload(next())
+	if err != nil {
+		t.Fatalf("first publish: %v", err)
+	}
+	if first != 1 {
+		t.Fatalf("a fresh installation's first generation must be 1, got %d", first)
+	}
+
+	// Force another rotation with the counter intact.
+	if err := b.client.Del(ctx, epochKey).Err(); err != nil {
+		t.Fatalf("clear the epoch: %v", err)
+	}
+	b.Publish(Event{Type: ItemUpdated, WorkspaceID: "ws-1", ItemID: "item-2"})
+	second, _, err := decodePayload(next())
+	if err != nil {
+		t.Fatalf("second publish: %v", err)
+	}
+
+	if second != 2 {
+		t.Fatalf("a healthy counter must INCREMENT: want generation 2, got %d", second)
+	}
+	if second == fixedSeed {
+		t.Fatalf("a healthy counter was reseeded to the wall-clock value %d", fixedSeed)
+	}
+}

--- a/internal/events/redis_generation_guard_test.go
+++ b/internal/events/redis_generation_guard_test.go
@@ -571,10 +571,13 @@ func TestACollidingRepairIsCaughtBySequenceRatherThanEpoch(t *testing.T) {
 // rejects: a total, permanent drop, arrived at through the mechanism meant to
 // prevent it.
 //
-// Each case publishes with the generation key corrupted, so the repair path
-// runs, and asserts the event survives with a USABLE epoch.
-func TestABrokenClockDoesNotProduceAnUnpublishableEpoch(t *testing.T) {
-	genKey := redisns.Default.Name(redisEpochGenSuffix)
+// SPLIT INTO A PURE TABLE PLUS ONE WIRED CASE, deliberately. The clamp's
+// behaviour is arithmetic and needs no Redis; standing up a server per row
+// bought nothing and cost five of them, on a package whose timing-sensitive
+// tests are already load-fragile (BUG-2742). The end-to-end leg below is what
+// stops the table being a unit test for a function nothing calls.
+func TestClampGenerationSeed(t *testing.T) {
+	t.Parallel()
 
 	for _, tc := range []struct {
 		name string
@@ -587,59 +590,56 @@ func TestABrokenClockDoesNotProduceAnUnpublishableEpoch(t *testing.T) {
 		{"ordinary", 1700000000, "1700000000"},
 		{"absurdly far future", 1 << 62, "99999999999999999"},
 	} {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := clampGenerationSeed(tc.unix); got != tc.want {
-				t.Fatalf("clampGenerationSeed(%d) = %s, want %s", tc.unix, got, tc.want)
-			}
+		if got := clampGenerationSeed(tc.unix); got != tc.want {
+			t.Errorf("clampGenerationSeed(%d) = %s, want %s (%s)", tc.unix, got, tc.want, tc.name)
+		}
+	}
+}
 
-			// AND THE END TO END LEG, because the unit assertion above would
-			// pass just as well against a clamp nothing calls.
-			mr := miniredis.RunT(t)
-			client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
-			t.Cleanup(func() { _ = client.Close() })
-			b := NewRedisBusWithKeys(client, redisns.Default, true)
-			b.nowUnix = func() int64 { return tc.unix }
-			t.Cleanup(b.Close)
+// THE WIRING, which the table above cannot prove: a clock that would have been
+// fatal still publishes a decodable event with a usable epoch.
+//
+// Zero is the case to drive end to end — it is the one that reproduced the
+// original failure, since "0" fails the epoch guard's ^[1-9] and sent the
+// script back into the repair for the same bad seed.
+func TestABrokenClockDoesNotProduceAnUnpublishableEpoch(t *testing.T) {
+	genKey := redisns.Default.Name(redisEpochGenSuffix)
+	epochKey := redisns.Default.Name(redisEpochSuffix)
 
-			next := listen(t, b.client, redisns.Default.Name(redisChannelSuffix)+"ws-1")
-			ctx := context.Background()
+	b, _ := newSeededFlippedBus(t)
+	b.nowUnix = func() int64 { return 0 }
 
-			b.Publish(Event{Type: ItemUpdated, WorkspaceID: "ws-1", ItemID: "a"})
-			if _, _, err := decodePayload(next()); err != nil {
-				t.Fatalf("fixture: %v", err)
-			}
+	next := listen(t, b.client, redisns.Default.Name(redisChannelSuffix)+"ws-1")
+	ctx := context.Background()
 
-			// CLEAR THE EPOCH, or no rotation branch fires and the repair
-			// never runs — the second publish would simply reuse the epoch
-			// the fixture minted. Three of these cases passed that way on the
-			// first attempt, because the epoch the fixture mints is 1 and
-			// three of the expected clamps are also 1: vacuous, and only
-			// visible because the other two disagreed.
-			epochKey := redisns.Default.Name(redisEpochSuffix)
-			if err := b.client.Del(ctx, epochKey).Err(); err != nil {
-				t.Fatalf("clear the epoch: %v", err)
-			}
-			if err := b.client.Del(ctx, genKey).Err(); err != nil {
-				t.Fatalf("clear the generation key: %v", err)
-			}
-			if err := b.client.RPush(ctx, genKey, "x").Err(); err != nil {
-				t.Fatalf("corrupt the generation key: %v", err)
-			}
+	b.Publish(Event{Type: ItemUpdated, WorkspaceID: "ws-1", ItemID: "a"})
+	if _, _, err := decodePayload(next()); err != nil {
+		t.Fatalf("fixture: %v", err)
+	}
 
-			b.Publish(Event{Type: ItemUpdated, WorkspaceID: "ws-1", ItemID: "b"})
-			epoch, ev, err := decodePayload(next())
-			if err != nil {
-				t.Fatalf("a repair under a %s clock must still publish a decodable event: %v", tc.name, err)
-			}
-			if ev.ItemID != "b" {
-				t.Fatalf("the event must carry its body, got %+v", ev)
-			}
-			if epoch <= 0 {
-				t.Fatalf("the published epoch must be a positive generation, got %d", epoch)
-			}
-			if got := strconv.FormatInt(epoch, 10); got != tc.want {
-				t.Fatalf("published epoch %s, want the clamped seed %s", got, tc.want)
-			}
-		})
+	// Clear the epoch, or no rotation branch fires and the repair never runs
+	// — the second publish would just reuse the epoch the fixture minted. An
+	// earlier version of this test missed that and passed vacuously wherever
+	// the expected clamp happened to equal that epoch.
+	if err := b.client.Del(ctx, epochKey).Err(); err != nil {
+		t.Fatalf("clear the epoch: %v", err)
+	}
+	if err := b.client.Del(ctx, genKey).Err(); err != nil {
+		t.Fatalf("clear the generation key: %v", err)
+	}
+	if err := b.client.RPush(ctx, genKey, "x").Err(); err != nil {
+		t.Fatalf("corrupt the generation key: %v", err)
+	}
+
+	b.Publish(Event{Type: ItemUpdated, WorkspaceID: "ws-1", ItemID: "b"})
+	epoch, ev, err := decodePayload(next())
+	if err != nil {
+		t.Fatalf("a repair under a zero clock must still publish a decodable event: %v", err)
+	}
+	if ev.ItemID != "b" {
+		t.Fatalf("the event must carry its body, got %+v", ev)
+	}
+	if epoch != 1 {
+		t.Fatalf("want the clamped seed 1 on the wire, got %d", epoch)
 	}
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -205,9 +205,21 @@ type Metrics struct {
 	//   lost.
 	//
 	//   epoch_regressed — the shared generation counter went BACKWARDS and
-	//   stayed there, which realistically means a Redis failover to a replica
-	//   that lost writes. Expect zero; one per failover is the mechanism
-	//   recovering, and a repeating count means the counter is not durable.
+	//   stayed there. Two causes now, and they are diagnosed differently.
+	//   Usually a Redis failover to a replica that lost writes: expect zero,
+	//   one per failover is the mechanism recovering, and a repeating count
+	//   means the counter is not durable. Since BUG-2740 it can ALSO be the
+	//   generation counter having been found corrupted and REPAIRED, which
+	//   reseeds it from wall-clock seconds — above any counted history, but
+	//   not necessarily above a counter that a collision or a hand-edit had
+	//   pushed higher.
+	//
+	//   THERE IS NO REPAIR-SPECIFIC SIGNAL — the repair happens inside a Lua
+	//   script, which cannot log through slog and does not change this
+	//   counter's label. The tell is the VALUE: read the generation key, and
+	//   a repaired one looks like a unix timestamp (ten digits, ~1.7e9)
+	//   rather than a small count of id-space resets. That is a deliberate
+	//   property of the seed rather than a coincidence.
 	//
 	// LABELLED FROM THE START rather than shipped as a bare counter, which
 	// BUG-2736 immediately vindicated by adding two more values. An operator

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -479,7 +479,7 @@ func New() *Metrics {
 
 	eventSequenceResetsTotal := prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "pad_event_sequence_resets_total",
-		Help: "Times activity-event replay coverage was dropped, by reason: subscription_resumed (a Redis connection flap, one workspace's buffer), epoch_change (the shared counter's ID space changed generation, every buffer), counter_backward (an ID at or below a buffer's high-water mark with no generation change), epoch_regressed (the generation counter went backwards and stayed there, i.e. Redis lost writes), undecodable_message (a pub/sub message could not be parsed, so that workspace's coverage ended).",
+		Help: "Times activity-event replay coverage was dropped, by reason: subscription_resumed (a Redis connection flap, one workspace's buffer), epoch_change (the shared counter's ID space changed generation, every buffer), counter_backward (an ID at or below a buffer's high-water mark with no generation change), epoch_regressed (the generation counter went backwards and stayed there — usually a Redis failover to a replica that lost writes, and since BUG-2740 also a corrupted generation key having been repaired and reseeded from wall-clock seconds; read the key to tell them apart, a repaired one looks like a unix timestamp), undecodable_message (a pub/sub message could not be parsed, so that workspace's coverage ended).",
 	}, []string{"reason"})
 
 	eventReceiveLoopExitsTotal := prometheus.NewCounter(prometheus.CounterOpts{


### PR DESCRIPTION
Closes BUG-2740.

## The unit

Every branch of `publishScript` that rotates the id space INCRs `pad:event_epoch_gen`, and none checked the key first — while the **epoch key beside it does**, with a comment saying exactly why.

An INCR against a corrupted key **aborts the script, after the sequence INCR has already landed**. Redis is atomic against interleaving but does not roll back a script's earlier writes, so the failure burns an id (a hole to every receiver), repeats on the next publish, and never self-heals: the branch that would rotate the generation is the branch that cannot run.

## Four abort modes, not the two the filing named

Measured against the pinned miniredis rather than assumed:

```
list                          -> WRONGTYPE
hash                          -> WRONGTYPE
string 'abc'                  -> ERR value is not an integer or out of range
string '9223372036854775807'  -> ERR increment or decrement would overflow
```

A TYPE check alone — the fix the filing describes — covers half. The value is validated on the same terms the epoch guard uses.

## Three things the review loop changed, each measured

**The ceiling is 17 digits, derived from the epoch guard's 18.** The value accepted here is about to be incremented, and the result becomes the *epoch*. Accept 18 and a counter at `999999999999999999` increments into a 19-digit epoch, that guard fires, and the script rotates a **second time inside one publish** — publishing a generation far below the one receivers hold.

**The generation is read back with GET, not stringified.** Redis hands an integer reply to Lua as a NUMBER, and Lua 5.1 doubles print with `%.14g`, so `tostring` diverges from the stored value well below the ceiling — measured at `99999999999999998`, which increments to `99999999999999999` in the key while `tostring` renders `100000000000000000`. Divergence begins at 2^53, not at the digit limit.

**A broken host clock is no longer fatal.** The seed is an input; an unset clock reports zero or a negative second, which the repair wrote to the key and returned as the epoch. The epoch guard rejects it, rotates, calls back into the repair, receives the *same* bad seed, and assigns it **without revalidating** — an unparseable epoch on the wire, rejected by every receiver. `clampGenerationSeed` forces a positive integer of at most 17 digits; the floor is 1 because a broken clock cannot deliver the ruling's property at all, and the real choice is between a value that is merely LOW (detected, one resync) and one that is FATAL.

## The ruling, and the residual it accepted

Restart at wall-clock seconds is **Dave's day-49 ruling**, read from the item's trail. Generations only need to be orderable among themselves, and the corrupted key cannot testify to the previous one.

It is not monotonicity. Two repairs inside one second seed the same value, so two id spaces can share an epoch — and an equal epoch means "same space" by design, so no epoch-based reason fires. **It is still not silent**, and the chain is now tested end to end rather than assumed:

> A merge requires ids REUSED at a receiver. Reuse requires the sequence to go BACKWARDS. A backwards counter is detected regardless of what the epoch says — `counter_backward`, which drops the affected buffers and refuses cursors below the discarded high-water mark.

The lead re-ruled on that probed fact: residual accepted **because it is detected**, with the attribution corrected from `epoch_regressed` to `counter_backward`.

Also recorded, after two reviews raised it: why a per-workspace backward check suffices for a global counter. The unit of coherence is the per-workspace buffer and cursor; a reissued id landing in a different workspace collides with nothing. Both shapes measured — a DELETED counter restarts at 1 and rotates the epoch unconditionally; a counter SET backwards above 1 skips that, and then only the workspace whose own ids are reissued needs a reset, and it gets one.

## Operator-facing

`docs/deployment.md` gains *A repaired generation counter*: a repair can surface as `epoch_change` or, if a collision pushed the counter higher, as `epoch_regressed` — which otherwise means a failover that lost writes. **There is no repair-specific counter or log**, because the repair happens inside Lua; the tell is the value, since a repaired generation looks like a unix timestamp. The exported Prometheus `HELP` and the metrics table say so too.

## Filed rather than fixed

**BUG-2744** — the sequence id is concatenated through the same Lua double. Reached by corruption rather than counting: a hand-edited or collided `event_seq` *arrives* at that magnitude exactly as the generation key does. Not fixed here because `assignScript`'s id IS consumed Go-side, so the remedy spans both paths.

## Gates

`make lint` 0 issues · `go test ./...` green · `-race` green on `internal/events` · `gofmt` clean. No store SQL and no web changes.

## Review

9 codex rounds, converged on the criterion: 6 and 9 CLEAN on broad angles, 8's finding refuted by probe. **17 mutations applied and grep-verified, 17 caught** — four only after a first version survived and exposed a test asserting an end state both the right and wrong code produce, or a table clearing state so uniformly it only ever drove one branch.

https://claude.ai/code/session_01JVDBKbgn3Xt7ndW1YoYd8X
