### PR TITLE
fix(events): stop the load-fragile tests failing for reasons that are not defects (BUG-2742)

### DIFF
--- a/internal/events/bus.go
+++ b/internal/events/bus.go
@@ -465,12 +465,13 @@ func (s *subscriber) signalGap() {
 	}
 }
 
-// subscriberChanDepth is how many events a subscriber may fall behind before
-// the bus starts dropping for it (and telling it so — see the fan-out in
-// Publish). Named rather than inlined because a test needs to state the
-// premise "fewer events than this cannot be dropped" in terms of the real
-// number: a test that hardcodes 64 alongside this one silently stops proving
-// what it claims the day the depth changes.
+// subscriberChanDepth is how far a subscriber may fall behind before the bus
+// starts dropping events for it — and telling it so; see the fan-out in
+// Publish. Changing it changes how tolerant this process is of a slow SSE
+// consumer before that consumer is asked to resync.
+//
+// Named rather than inlined so the tests that assert the behaviour AT this
+// boundary can derive it instead of restating it.
 const subscriberChanDepth = 64
 
 // newSubscriber builds a subscriber with both of its channels, so no path

--- a/internal/events/bus.go
+++ b/internal/events/bus.go
@@ -465,13 +465,21 @@ func (s *subscriber) signalGap() {
 	}
 }
 
+// subscriberChanDepth is how many events a subscriber may fall behind before
+// the bus starts dropping for it (and telling it so — see the fan-out in
+// Publish). Named rather than inlined because a test needs to state the
+// premise "fewer events than this cannot be dropped" in terms of the real
+// number: a test that hardcodes 64 alongside this one silently stops proving
+// what it claims the day the depth changes.
+const subscriberChanDepth = 64
+
 // newSubscriber builds a subscriber with both of its channels, so no path
 // can register one that has an event channel and no gap channel — a nil
 // gaps channel would silently discard every signal (a send on nil blocks,
 // and the default arm would take it forever).
 func newSubscriber(workspaceID string) *subscriber {
 	return &subscriber{
-		ch:          make(chan Event, 64),
+		ch:          make(chan Event, subscriberChanDepth),
 		workspaceID: workspaceID,
 		gaps:        make(chan struct{}, 1),
 	}

--- a/internal/events/bus_test.go
+++ b/internal/events/bus_test.go
@@ -126,15 +126,15 @@ func TestSlowConsumerDropsEvents(t *testing.T) {
 	ch, _ := bus.Subscribe("ws-1")
 	defer bus.Unsubscribe(ch)
 
-	// Fill the channel buffer (64 events)
-	for i := 0; i < 100; i++ {
+	// Overfill the channel buffer, so the drop path runs.
+	for i := 0; i < subscriberChanDepth+36; i++ {
 		bus.Publish(Event{
 			Type:        DocumentUpdated,
 			WorkspaceID: "ws-1",
 		})
 	}
 
-	// Should have 64 events (buffer size), rest dropped
+	// Should have exactly a buffer's worth; the rest dropped.
 	count := 0
 	for {
 		select {
@@ -145,8 +145,8 @@ func TestSlowConsumerDropsEvents(t *testing.T) {
 		}
 	}
 done:
-	if count != 64 {
-		t.Fatalf("expected 64 buffered events, got %d", count)
+	if count != subscriberChanDepth {
+		t.Fatalf("expected %d buffered events, got %d", subscriberChanDepth, count)
 	}
 }
 

--- a/internal/events/gap_signal_test.go
+++ b/internal/events/gap_signal_test.go
@@ -366,27 +366,23 @@ func TestCoverageDropWithNoBufferStillSignals(t *testing.T) {
 // scheduling race with no single point to pause at once the fix is in, because
 // the fix is precisely that no such point exists.
 //
-// WHY IT IS SHAPED LIKE THIS, because the obvious shape is the one it replaces
-// (BUG-2742). The first version published 320 events while a goroutine drained
-// concurrently, and guarded against vacuity with "at least half must arrive".
-// That guard is a bet on runner speed: the bus DELIBERATELY drops for a
-// subscriber that cannot keep up, so how many arrive is a continuous function
-// of how much CPU the reader gets. It reddened four CI runs across three PRs
-// reporting 64, 65, 144 and 150 of 320 — and 64 is exactly subscriberChanDepth,
-// one buffer-full and nothing after it.
+// WHY IT IS SHAPED LIKE THIS — the obvious shape is the one it replaces, and
+// that one reddened CI (BUG-2742). Publishing a large burst while a goroutine
+// drains, then guarding vacuity with "at least half must arrive", makes the
+// sample size a bet on runner speed: this bus DELIBERATELY drops for a
+// subscriber that cannot keep up, so the arrival count is a function of how
+// much CPU the reader gets.
 //
-// So the sample is made untruncatable instead of large: no reader runs during
-// the publishes, and no more events than the channel is deep are published, so
-// a drop CANNOT occur and every publish is still in the buffer afterwards. The
-// vacuity guard is then `count == total` — an equality, not a threshold, and
-// not a bet on anything.
+// So the sample is made untruncatable rather than large. No reader runs during
+// the publishes and no more events than the channel is deep are published, so
+// a drop cannot occur — which turns the vacuity guard into `count == total`,
+// an equality rather than a threshold.
 //
-// Detection power comes from REPEATING the round rather than from volume,
-// which is what the bounded channel could not give. Measured against the
-// mutation this test exists to catch (release replayMu after the append, so
-// fan-out runs outside it): the version this replaces caught it 9 times in 30
-// runs; this one caught it 25 times in 25, and costs ~10ms against that
-// version's fixed 0.5s.
+// Detection power then comes from REPEATING the round, which is the thing a
+// bounded channel could not supply. Do not trade rounds back for a bigger
+// burst: the round count was chosen by measuring catch rate against the
+// mutation below, and the burst is what could not be measured reliably. See
+// BUG-2742 for the figures.
 func TestConcurrentPublishesDeliverInIDOrder(t *testing.T) {
 	// Enough publishers to interleave, few enough events that the subscriber
 	// channel cannot overflow.

--- a/internal/events/gap_signal_test.go
+++ b/internal/events/gap_signal_test.go
@@ -374,8 +374,8 @@ func TestCoverageDropWithNoBufferStillSignals(t *testing.T) {
 // one buffer-full and nothing after it.
 //
 // So the sample is made untruncatable instead of large: no reader runs during
-// the publishes, and fewer events than the channel is deep are published, so a
-// drop CANNOT occur and every publish is still in the buffer afterwards. The
+// the publishes, and no more events than the channel is deep are published, so
+// a drop CANNOT occur and every publish is still in the buffer afterwards. The
 // vacuity guard is then `count == total` — an equality, not a threshold, and
 // not a bet on anything.
 //
@@ -387,11 +387,19 @@ func TestCoverageDropWithNoBufferStillSignals(t *testing.T) {
 // version's fixed 0.5s.
 func TestConcurrentPublishesDeliverInIDOrder(t *testing.T) {
 	// Enough publishers to interleave, few enough events that the subscriber
-	// channel cannot overflow. Derived from the real depth so that changing
-	// the depth cannot silently turn the no-drop premise into a false one.
+	// channel cannot overflow.
 	const publishers = 32
-	const each = subscriberChanDepth / publishers
+	const each = 2
 	const total = publishers * each
+
+	// COMPILE-TIME premise check. Deriving `each` from subscriberChanDepth
+	// looks tidier and is a trap: integer division silently yields 0 the day
+	// the depth drops below `publishers`, and then total is 0, nothing is
+	// published, and `count == total` passes as 0 == 0 — the test going
+	// permanently vacuous with no signal at all (codex round 2). Stating the
+	// numbers and failing the BUILD when they stop being compatible is the
+	// version that cannot rot quietly.
+	const _ uint = subscriberChanDepth - total
 
 	for round := range 40 {
 		func() {
@@ -420,6 +428,13 @@ func TestConcurrentPublishesDeliverInIDOrder(t *testing.T) {
 			// the channel is in it now: drain without blocking and without a
 			// timer. Nothing here waits on a goroutine being scheduled, which
 			// is what makes the result load-independent.
+			//
+			// CONTIGUOUS, not merely increasing (codex round 2): one bus, one
+			// workspace and nothing else publishing means the ids assigned are
+			// exactly base+1..base+total, so the delivered sequence must have
+			// no holes. "Increasing" would also be satisfied by a bus that
+			// dropped some of these and delivered something else with a bigger
+			// id, which is a pass for the wrong reason.
 			var prev int64
 			var count int
 		drain:
@@ -427,10 +442,11 @@ func TestConcurrentPublishesDeliverInIDOrder(t *testing.T) {
 				select {
 				case e := <-ch:
 					count++
-					if e.ID <= prev {
-						t.Fatalf("round %d: IDs arrived out of order: %d after %d — a subscriber's "+
-							"cursor regressed, so its next reconnect replays events it already has",
-							round, e.ID, prev)
+					if prev != 0 && e.ID != prev+1 {
+						t.Fatalf("round %d: ids arrived as %d after %d — consecutive publishes on one "+
+							"bus must deliver consecutively; a subscriber whose cursor goes backwards "+
+							"replays on its next reconnect, and one that skips has a hole nothing "+
+							"will fill", round, e.ID, prev)
 					}
 					prev = e.ID
 				default:
@@ -438,8 +454,9 @@ func TestConcurrentPublishesDeliverInIDOrder(t *testing.T) {
 				}
 			}
 
-			// PREMISE, not a tolerance: with no reader draining and fewer
-			// events published than the channel is deep, a drop is impossible.
+			// PREMISE, not a tolerance: with no reader draining and no more
+			// events published than the channel is deep, a drop is impossible
+			// — the channel starts empty and every publish fits.
 			// If this ever fires, the ordering assertion above ran on a
 			// truncated sample and proved less than it claims — which is the
 			// defect this test was rewritten to remove.

--- a/internal/events/gap_signal_test.go
+++ b/internal/events/gap_signal_test.go
@@ -36,10 +36,12 @@ func TestDropSignalsOnlyTheSubscriberItHappenedTo(t *testing.T) {
 	defer b.Unsubscribe(slow)
 	defer b.Unsubscribe(fast)
 
-	// Exactly fills the slow subscriber's 64-deep channel; the fast one is
-	// drained each time, so only one of the two is behind.
-	const chanDepth = 64
-	for range chanDepth {
+	// Exactly fills the slow subscriber's channel; the fast one is drained
+	// each time, so only one of the two is behind. Derived rather than
+	// restated: this test's whole claim is about the boundary AT the depth,
+	// so a literal that drifts from the real one would leave it asserting
+	// something about an arbitrary number instead.
+	for range subscriberChanDepth {
 		b.Publish(Event{Type: ItemUpdated, WorkspaceID: "ws-1"})
 		<-fast
 	}

--- a/internal/events/gap_signal_test.go
+++ b/internal/events/gap_signal_test.go
@@ -362,76 +362,93 @@ func TestCoverageDropWithNoBufferStillSignals(t *testing.T) {
 //
 // A stress test rather than a seam-driven one: the interleaving is a
 // scheduling race with no single point to pause at once the fix is in, because
-// the fix is precisely that no such point exists. Verified to fail against the
-// unserialized version.
+// the fix is precisely that no such point exists.
+//
+// WHY IT IS SHAPED LIKE THIS, because the obvious shape is the one it replaces
+// (BUG-2742). The first version published 320 events while a goroutine drained
+// concurrently, and guarded against vacuity with "at least half must arrive".
+// That guard is a bet on runner speed: the bus DELIBERATELY drops for a
+// subscriber that cannot keep up, so how many arrive is a continuous function
+// of how much CPU the reader gets. It reddened four CI runs across three PRs
+// reporting 64, 65, 144 and 150 of 320 — and 64 is exactly subscriberChanDepth,
+// one buffer-full and nothing after it.
+//
+// So the sample is made untruncatable instead of large: no reader runs during
+// the publishes, and fewer events than the channel is deep are published, so a
+// drop CANNOT occur and every publish is still in the buffer afterwards. The
+// vacuity guard is then `count == total` — an equality, not a threshold, and
+// not a bet on anything.
+//
+// Detection power comes from REPEATING the round rather than from volume,
+// which is what the bounded channel could not give. Measured against the
+// mutation this test exists to catch (release replayMu after the append, so
+// fan-out runs outside it): the version this replaces caught it 9 times in 30
+// runs; this one caught it 25 times in 25, and costs ~10ms against that
+// version's fixed 0.5s.
 func TestConcurrentPublishesDeliverInIDOrder(t *testing.T) {
-	b := New()
-	defer b.Close()
+	// Enough publishers to interleave, few enough events that the subscriber
+	// channel cannot overflow. Derived from the real depth so that changing
+	// the depth cannot silently turn the no-drop premise into a false one.
+	const publishers = 32
+	const each = subscriberChanDepth / publishers
+	const total = publishers * each
 
-	ch, _, ok := b.SubscribeIfAllowed("ws-1", 0)
-	if !ok {
-		t.Fatal("subscribe refused")
-	}
-	defer b.Unsubscribe(ch)
+	for round := range 40 {
+		func() {
+			b := New()
+			defer b.Close()
 
-	const publishers, each = 8, 40
-	total := publishers * each
-
-	// Drained concurrently. The reader may legitimately MISS some — a 64-deep
-	// channel overflows and the bus drops for a slow subscriber, which is the
-	// behaviour tested elsewhere — so this reads until the stream goes quiet
-	// rather than demanding all of them. The claim under test is the ORDER of
-	// what arrives, and a minimum count below keeps it from passing vacuously.
-	received := make(chan int64, total)
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		for {
-			select {
-			case e, ok := <-ch:
-				if !ok {
-					return
-				}
-				received <- e.ID
-			case <-time.After(500 * time.Millisecond):
-				return
+			ch, _, ok := b.SubscribeIfAllowed("ws-1", 0)
+			if !ok {
+				t.Fatal("subscribe refused")
 			}
-		}
-	}()
+			defer b.Unsubscribe(ch)
 
-	var wg sync.WaitGroup
-	for range publishers {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			for range each {
-				b.Publish(Event{Type: ItemUpdated, WorkspaceID: "ws-1"})
+			var wg sync.WaitGroup
+			for range publishers {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					for range each {
+						b.Publish(Event{Type: ItemUpdated, WorkspaceID: "ws-1"})
+					}
+				}()
+			}
+			wg.Wait()
+
+			// Every publish has returned, so everything that will ever be in
+			// the channel is in it now: drain without blocking and without a
+			// timer. Nothing here waits on a goroutine being scheduled, which
+			// is what makes the result load-independent.
+			var prev int64
+			var count int
+		drain:
+			for {
+				select {
+				case e := <-ch:
+					count++
+					if e.ID <= prev {
+						t.Fatalf("round %d: IDs arrived out of order: %d after %d — a subscriber's "+
+							"cursor regressed, so its next reconnect replays events it already has",
+							round, e.ID, prev)
+					}
+					prev = e.ID
+				default:
+					break drain
+				}
+			}
+
+			// PREMISE, not a tolerance: with no reader draining and fewer
+			// events published than the channel is deep, a drop is impossible.
+			// If this ever fires, the ordering assertion above ran on a
+			// truncated sample and proved less than it claims — which is the
+			// defect this test was rewritten to remove.
+			if count != total {
+				t.Fatalf("round %d: %d of %d events arrived; with a %d-deep channel and no "+
+					"concurrent reader nothing may be dropped, so the ordering check above "+
+					"ran on a sample it cannot vouch for", round, count, total, subscriberChanDepth)
 			}
 		}()
-	}
-	wg.Wait()
-
-	select {
-	case <-done:
-	case <-time.After(20 * time.Second):
-		t.Fatal("the reader never went quiet")
-	}
-	close(received)
-
-	var prev int64
-	var count int
-	for id := range received {
-		count++
-		if id <= prev {
-			t.Fatalf("IDs arrived out of order: %d after %d — a subscriber's cursor regressed, "+
-				"so its next reconnect replays events it already has", id, prev)
-		}
-		prev = id
-	}
-	// Not vacuous: an empty or near-empty stream would satisfy the ordering
-	// check trivially.
-	if count < total/2 {
-		t.Fatalf("only %d of %d events arrived; too few to say anything about ordering", count, total)
 	}
 }
 

--- a/internal/events/gap_signal_test.go
+++ b/internal/events/gap_signal_test.go
@@ -426,8 +426,12 @@ func TestConcurrentPublishesDeliverInIDOrder(t *testing.T) {
 
 			// Every publish has returned, so everything that will ever be in
 			// the channel is in it now: drain without blocking and without a
-			// timer. Nothing here waits on a goroutine being scheduled, which
-			// is what makes the result load-independent.
+			// timer. Nothing in the ASSERTION path waits on a goroutine being
+			// scheduled, which is what stops load from truncating the sample.
+			// It does not make detection deterministic: whether a broken bus
+			// actually interleaves on a given round is still up to the
+			// scheduler, which is why the round count above exists and why
+			// the header quotes a measured catch rate rather than a proof.
 			//
 			// CONTIGUOUS, not merely increasing (codex round 2): one bus, one
 			// workspace and nothing else publishing means the ids assigned are

--- a/internal/events/gap_signal_test.go
+++ b/internal/events/gap_signal_test.go
@@ -76,7 +76,7 @@ func TestDropIsReportedToTheObserver(t *testing.T) {
 	}
 	defer b.Unsubscribe(ch)
 
-	for range 64 {
+	for range subscriberChanDepth {
 		b.Publish(Event{Type: ItemUpdated, WorkspaceID: "ws-1"})
 	}
 	if got := obs.dropped(); len(got) != 0 {
@@ -232,7 +232,7 @@ func TestRedisBusDropSignalsOnlyTheSubscriberItHappenedTo(t *testing.T) {
 	defer b.Unsubscribe(fast)
 
 	// Contiguous ids so no coverage arm can fire and take credit.
-	for i := 1; i <= 64; i++ {
+	for i := 1; i <= subscriberChanDepth; i++ {
 		b.fanOutLocally(Event{ID: int64(i), Type: ItemUpdated, WorkspaceID: "ws-1"})
 		<-fast
 	}
@@ -240,7 +240,7 @@ func TestRedisBusDropSignalsOnlyTheSubscriberItHappenedTo(t *testing.T) {
 		t.Fatal("a full-but-not-yet-overflowing channel raised the flag")
 	}
 
-	b.fanOutLocally(Event{ID: 65, Type: ItemUpdated, WorkspaceID: "ws-1"})
+	b.fanOutLocally(Event{ID: subscriberChanDepth + 1, Type: ItemUpdated, WorkspaceID: "ws-1"})
 	<-fast
 
 	if !raised(slowGaps) {
@@ -493,7 +493,7 @@ func TestActivityGapSignalCoalesces(t *testing.T) {
 	}
 
 	if !raised(gaps) {
-		t.Fatal("no gap signal after 200 events into a 64-deep channel")
+		t.Fatalf("no gap signal after 200 events into a %d-deep channel", subscriberChanDepth)
 	}
 	if raised(gaps) {
 		t.Error("more than one signal was queued; the channel must coalesce, not accumulate")
@@ -645,14 +645,14 @@ func TestRedisBusDropIsReportedPerSubscriber(t *testing.T) {
 	defer b.Unsubscribe(slowB)
 
 	// Fill both channels, then overflow both with ONE event.
-	for i := 1; i <= 64; i++ {
+	for i := 1; i <= subscriberChanDepth; i++ {
 		b.fanOutLocally(Event{ID: int64(i), Type: ItemUpdated, WorkspaceID: "ws-1"})
 	}
 	if got := obs.dropped(); len(got) != 0 {
 		t.Fatalf("drops reported before either channel overflowed: %v", got)
 	}
 
-	b.fanOutLocally(Event{ID: 65, Type: ItemUpdated, WorkspaceID: "ws-1"})
+	b.fanOutLocally(Event{ID: subscriberChanDepth + 1, Type: ItemUpdated, WorkspaceID: "ws-1"})
 
 	got := obs.dropped()
 	if len(got) != 2 {

--- a/internal/events/redis_idspace_test.go
+++ b/internal/events/redis_idspace_test.go
@@ -723,29 +723,27 @@ func TestConcurrentPhaseTwoPublishesArriveInIDOrder(t *testing.T) {
 	b, _ := newFlippedRedisBus(t)
 	channel := redisns.Default.Name(redisChannelSuffix) + "ws-1"
 
+	const n = 300
+
 	ps := b.client.Subscribe(context.Background(), channel)
 	defer func() { _ = ps.Close() }()
 	if _, err := ps.Receive(context.Background()); err != nil {
 		t.Fatalf("subscribe: %v", err)
 	}
-	incoming := ps.Channel()
+	// SIZED ABOVE THE MESSAGE COUNT, so truncation is structurally impossible
+	// rather than merely unlikely (codex round 7). go-redis defaults this to
+	// 100 and drops past it, so publishing 300 through a 100-deep buffer makes
+	// the arrival count depend on how much CPU the reader gets — the exact
+	// defect this unit removes elsewhere. Draining early narrows that window;
+	// sizing the buffer closes it.
+	incoming := ps.Channel(redis.WithChannelSize(n * 2))
 
-	const n = 300
-
-	// THE READER STARTS FIRST, and that is not a stylistic choice (BUG-2742).
-	// ps.Channel() is bounded — go-redis buffers ~100 — so publishing all n
-	// before anything drains makes the arrival COUNT a function of how much
-	// CPU the reader gets, which is the exact defect that reddened CI four
-	// times in this package's sibling test. Draining concurrently means the
-	// reader is competing with the publishers rather than starting 300
-	// messages behind them.
-	//
-	// Honest limit: this is a large mitigation, not a guarantee. A reader
-	// starved for long enough can still fall 100 behind, and then this fails
-	// on arrival count again. Unlike the sibling test, the bound here belongs
-	// to go-redis rather than to us, so it cannot be made structurally
-	// impossible the same way — if this one ever does flake, the answer is to
-	// raise ChannelSize, not to lower the assertion.
+	// The reader also starts BEFORE the publishes rather than after them, so
+	// it is competing with the publishers instead of beginning n messages
+	// behind. With the buffer sized above n that is belt and braces, and it
+	// is kept because the two defend different things: the size stops the
+	// buffer truncating the sample, and starting early stops this test
+	// pretending a burst is consumed instantly.
 	//
 	// One reader, so the order it records IS arrival order.
 	ids := make([]int64, 0, n)

--- a/internal/events/redis_idspace_test.go
+++ b/internal/events/redis_idspace_test.go
@@ -736,9 +736,16 @@ func TestConcurrentPhaseTwoPublishesArriveInIDOrder(t *testing.T) {
 	// ps.Channel() is bounded — go-redis buffers ~100 — so publishing all n
 	// before anything drains makes the arrival COUNT a function of how much
 	// CPU the reader gets, which is the exact defect that reddened CI four
-	// times in this package's sibling test. Draining concurrently keeps the
-	// buffer from ever being the constraint, so the assertion below is about
-	// ordering rather than about runner speed.
+	// times in this package's sibling test. Draining concurrently means the
+	// reader is competing with the publishers rather than starting 300
+	// messages behind them.
+	//
+	// Honest limit: this is a large mitigation, not a guarantee. A reader
+	// starved for long enough can still fall 100 behind, and then this fails
+	// on arrival count again. Unlike the sibling test, the bound here belongs
+	// to go-redis rather than to us, so it cannot be made structurally
+	// impossible the same way — if this one ever does flake, the answer is to
+	// raise ChannelSize, not to lower the assertion.
 	//
 	// One reader, so the order it records IS arrival order.
 	ids := make([]int64, 0, n)

--- a/internal/events/redis_idspace_test.go
+++ b/internal/events/redis_idspace_test.go
@@ -3,6 +3,7 @@ package events
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strconv"
 	"strings"
 	"sync"
@@ -730,6 +731,36 @@ func TestConcurrentPhaseTwoPublishesArriveInIDOrder(t *testing.T) {
 	incoming := ps.Channel()
 
 	const n = 300
+
+	// THE READER STARTS FIRST, and that is not a stylistic choice (BUG-2742).
+	// ps.Channel() is bounded — go-redis buffers ~100 — so publishing all n
+	// before anything drains makes the arrival COUNT a function of how much
+	// CPU the reader gets, which is the exact defect that reddened CI four
+	// times in this package's sibling test. Draining concurrently keeps the
+	// buffer from ever being the constraint, so the assertion below is about
+	// ordering rather than about runner speed.
+	//
+	// One reader, so the order it records IS arrival order.
+	ids := make([]int64, 0, n)
+	collected := make(chan error, 1)
+	go func() {
+		for len(ids) < n {
+			select {
+			case msg := <-incoming:
+				_, ev, err := decodePayload(msg.Payload)
+				if err != nil {
+					collected <- fmt.Errorf("message %d: %w", len(ids), err)
+					return
+				}
+				ids = append(ids, ev.ID)
+			case <-time.After(30 * time.Second):
+				collected <- fmt.Errorf("only %d of %d messages arrived", len(ids), n)
+				return
+			}
+		}
+		collected <- nil
+	}()
+
 	var wg sync.WaitGroup
 	for i := 0; i < n; i++ {
 		wg.Add(1)
@@ -740,21 +771,16 @@ func TestConcurrentPhaseTwoPublishesArriveInIDOrder(t *testing.T) {
 	}
 	wg.Wait()
 
+	if err := <-collected; err != nil {
+		t.Fatal(err)
+	}
+
 	var prev int64
-	for i := 0; i < n; i++ {
-		select {
-		case msg := <-incoming:
-			_, ev, err := decodePayload(msg.Payload)
-			if err != nil {
-				t.Fatalf("message %d: %v", i, err)
-			}
-			if ev.ID <= prev {
-				t.Fatalf("message %d arrived out of ID order: %d after %d — publish order must equal ID order", i, ev.ID, prev)
-			}
-			prev = ev.ID
-		case <-time.After(5 * time.Second):
-			t.Fatalf("only %d of %d messages arrived", i, n)
+	for i, id := range ids {
+		if id <= prev {
+			t.Fatalf("message %d arrived out of ID order: %d after %d — publish order must equal ID order", i, id, prev)
 		}
+		prev = id
 	}
 	// PREMISE: all n really were published, so the ordering assertion ran over
 	// the whole set rather than over a handful that happened to be ordered.

--- a/internal/events/redis_idspace_test.go
+++ b/internal/events/redis_idspace_test.go
@@ -751,7 +751,14 @@ func TestConcurrentPhaseTwoPublishesArriveInIDOrder(t *testing.T) {
 	go func() {
 		for len(ids) < n {
 			select {
-			case msg := <-incoming:
+			case msg, open := <-incoming:
+				if !open {
+					// Reported, not dereferenced: a closed channel hands back
+					// a nil *Message, and reading Payload off it panics the
+					// test binary with a stack instead of naming the failure.
+					collected <- fmt.Errorf("the pubsub channel closed after %d of %d messages", len(ids), n)
+					return
+				}
 				_, ev, err := decodePayload(msg.Payload)
 				if err != nil {
 					collected <- fmt.Errorf("message %d: %w", len(ids), err)

--- a/internal/events/redis_idspace_test.go
+++ b/internal/events/redis_idspace_test.go
@@ -661,10 +661,17 @@ func TestAPrefixedPayloadReachesReconciliationThroughTheRealReceivePath(t *testi
 	// so a regression that decoded the epoch correctly and then handed 0 to
 	// the fan-out would pass all of them, and reconciliation would silently
 	// never run in production.
-	b, _ := newFlippedRedisBus(t)
+	b, mr := newFlippedRedisBus(t)
 
 	ch, _ := b.Subscribe("ws-1")
 	defer b.Unsubscribe(ch)
+	// Subscribe() returns before Redis has registered the subscription — the
+	// SUBSCRIBE goes out from the receive goroutine, which has not
+	// necessarily run yet. Publishing into that window loses the event
+	// OUTRIGHT, not slowly: nothing replays a pub/sub message nobody was
+	// listening for, so the wait below is what stands between this test and a
+	// failure no timeout can rescue (BUG-2742).
+	waitForSubscribers(t, mr, redisns.Default.Name(redisChannelSuffix)+"ws-1", true)
 
 	b.Publish(Event{Type: ItemUpdated, WorkspaceID: "ws-1", ItemID: "item-7"})
 
@@ -855,12 +862,17 @@ func TestAnUndecodableMessageEndsThatWorkspacesCoverage(t *testing.T) {
 	// codex round 11. Dropping an unreadable message and carrying on left the
 	// buffer claiming a span with a hole in it: the event gone, the ids either
 	// side contiguous, and a later resume across it answered "caught up".
-	b, _ := newFlippedRedisBus(t)
+	b, mr := newFlippedRedisBus(t)
 	obs := &recordingObserver{}
 	b.SetObserver(obs)
 
 	ch, _ := b.Subscribe("ws-1")
 	defer b.Unsubscribe(ch)
+	// See TestAPrefixedPayloadReachesReconciliationThroughTheRealReceivePath:
+	// publishing before the subscription is registered loses the event for
+	// good, and here it would look like the coverage-establishing publish
+	// simply never arrived (BUG-2742).
+	waitForSubscribers(t, mr, redisns.Default.Name(redisChannelSuffix)+"ws-1", true)
 	b.Publish(Event{Type: ItemUpdated, WorkspaceID: "ws-1"})
 
 	var first Event
@@ -962,6 +974,13 @@ func TestAMixedPhaseDeploymentDeliversBothWays(t *testing.T) {
 	defer phase1.Unsubscribe(ch1)
 	ch2, _ := phase2.Subscribe("ws-1")
 	defer phase2.Unsubscribe(ch2)
+	// BOTH must be registered before anything is published: this test's whole
+	// claim is that each replica sees the other's events, and a publish that
+	// lands while only one of them has registered is lost for the other with
+	// no way to tell that apart from "the phase-2 receiver never got it"
+	// (BUG-2742). Counting is what makes it two — waiting for "a subscriber"
+	// is satisfied by whichever registers first.
+	waitForSubscriberCount(t, mr, redisns.Default.Name(redisChannelSuffix)+"ws-1", 2)
 
 	recv := func(t *testing.T, ch chan Event, who string) Event {
 		t.Helper()
@@ -1091,12 +1110,15 @@ func TestAPayloadThatDecodesButIsNotOurEventEndsCoverage(t *testing.T) {
 		}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			b, _ := newFlippedRedisBus(t)
+			b, mr := newFlippedRedisBus(t)
 			obs := &recordingObserver{}
 			b.SetObserver(obs)
 
 			ch, _ := b.Subscribe("ws-1")
 			defer b.Unsubscribe(ch)
+			// Registration before the first publish — see BUG-2742 and the
+			// note on TestAPrefixedPayloadReachesReconciliation...
+			waitForSubscribers(t, mr, redisns.Default.Name(redisChannelSuffix)+"ws-1", true)
 			b.Publish(Event{Type: ItemUpdated, WorkspaceID: "ws-1"})
 
 			var first Event

--- a/internal/events/redis_idspace_test.go
+++ b/internal/events/redis_idspace_test.go
@@ -665,12 +665,15 @@ func TestAPrefixedPayloadReachesReconciliationThroughTheRealReceivePath(t *testi
 
 	ch, _ := b.Subscribe("ws-1")
 	defer b.Unsubscribe(ch)
-	// Subscribe() returns before Redis has registered the subscription — the
-	// SUBSCRIBE goes out from the receive goroutine, which has not
-	// necessarily run yet. Publishing into that window loses the event
-	// OUTRIGHT, not slowly: nothing replays a pub/sub message nobody was
-	// listening for, so the wait below is what stands between this test and a
-	// failure no timeout can rescue (BUG-2742).
+	// Subscribe() returns before Redis has REGISTERED the subscription. It
+	// does write the SUBSCRIBE command synchronously, but it does not wait
+	// for the server to confirm it (go-redis PubSub.subscribe writes and
+	// returns), and the publish that follows travels on a DIFFERENT
+	// connection — so Redis can process the publish first. Publishing into
+	// that window loses the event OUTRIGHT, not slowly: RedisBus.Publish has
+	// no local fan-out, and nothing replays a pub/sub message nobody was
+	// listening for. Hence a wait rather than a longer timeout — the round
+	// trip here is bimodal, tens of milliseconds or never (BUG-2742).
 	waitForSubscribers(t, mr, redisns.Default.Name(redisChannelSuffix)+"ws-1", true)
 
 	b.Publish(Event{Type: ItemUpdated, WorkspaceID: "ws-1", ItemID: "item-7"})

--- a/internal/events/redis_namespace_test.go
+++ b/internal/events/redis_namespace_test.go
@@ -35,6 +35,12 @@ func TestRedisBusHonoursTheNamespace(t *testing.T) {
 	// observe.
 	ch, _ := b.Subscribe("ws-1")
 	defer b.Unsubscribe(ch)
+	// This test only reads KEYS, which the publish writes whether or not
+	// anyone is listening — so it does not NEED the wait. It is here because
+	// this is one of the two shortest Redis-bus tests in the package and
+	// therefore what the next person copies; leaving Subscribe followed
+	// straight by Publish teaches the race (BUG-2742, codex round 10).
+	waitForSubscribers(t, mr, "pad:inst-b:events:ws-1", true)
 
 	b.Publish(Event{Type: "item.created", WorkspaceID: "ws-1"})
 
@@ -154,6 +160,9 @@ func TestRedisBusDefaultKeepsHistoricalKeys(t *testing.T) {
 
 	ch, _ := b.Subscribe("ws-1")
 	defer b.Unsubscribe(ch)
+	// Not needed for the key assertions below; present so the pattern a
+	// reader copies from here is the safe one. See the twin above.
+	waitForSubscribers(t, mr, "pad:events:ws-1", true)
 
 	b.Publish(Event{Type: "item.created", WorkspaceID: "ws-1"})
 
@@ -169,6 +178,16 @@ func TestRedisBusDefaultKeepsHistoricalKeys(t *testing.T) {
 
 // waitForSubscribers polls until the channel has (or provably lacks)
 // subscribers.
+//
+// CALL IT AFTER Subscribe AND BEFORE THE FIRST Publish, on any test that
+// expects an event to ARRIVE. A publish issued before the subscription is
+// registered is lost outright — not delayed — so a test without this wait
+// fails on a loaded runner roughly once in a hundred runs, with a message
+// about an event that never came and no bound that can rescue it. That is
+// BUG-2742, four CI failures across three pull requests.
+//
+// Not needed by a test that only asserts on Redis KEYS: the publish writes
+// those whether or not anyone is listening.
 //
 // POLLING, not a single check, because a subscription is not registered by
 // the time Subscribe returns. go-redis DOES write the SUBSCRIBE command

--- a/internal/events/redis_namespace_test.go
+++ b/internal/events/redis_namespace_test.go
@@ -230,14 +230,11 @@ func waitForSubscriberCount(t *testing.T, mr *miniredis.Miniredis, channel strin
 // helper they would call to set themselves up. An undecodable message ends
 // this instance's coverage of the workspace.
 //
-// It was harmless in every EXISTING caller, but not for the reason I first
-// wrote here (codex round 7 corrected it): four of the callers do run after a
-// publish, so the old helper really was ending coverage on a live buffer. It
-// did not matter because those four go on to assert about Redis KEYS rather
-// than about coverage or delivery. That is a property of what each call site
-// happens to assert next — the thinnest possible guarantee, and one that stops
-// holding the moment somebody adds a coverage assertion after a wait, or
-// copies the helper into a test that has one.
+// It was harmless in every existing caller, but only because the callers that
+// ran after a publish go on to assert about Redis KEYS rather than about
+// coverage or delivery. That is a property of what each call site happens to
+// assert next — the thinnest possible guarantee, and one that stops holding
+// the moment somebody adds a coverage assertion after a wait.
 //
 // The deadline is a LIVENESS bound, not a latency assertion: registration is
 // a sub-millisecond-to-milliseconds affair, and this number exists so a test

--- a/internal/events/redis_namespace_test.go
+++ b/internal/events/redis_namespace_test.go
@@ -182,18 +182,52 @@ func TestRedisBusDefaultKeepsHistoricalKeys(t *testing.T) {
 // assertion wants; it is deliberately not an event any consumer sees.
 func waitForSubscribers(t *testing.T, mr *miniredis.Miniredis, channel string, want bool) {
 	t.Helper()
+	n, ok := pollSubscriberCount(mr, channel, func(n int) bool { return (n > 0) == want })
+	if ok {
+		return
+	}
+	if want {
+		t.Fatalf("nothing subscribed to %s within the deadline", channel)
+	}
+	t.Fatalf("%s has %d subscribers, want none", channel, n)
+}
+
+// waitForSubscriberCount is waitForSubscribers when the number matters —
+// two replicas on one Redis, where "someone is listening" is satisfied by the
+// first of them and the test needs both.
+func waitForSubscriberCount(t *testing.T, mr *miniredis.Miniredis, channel string, want int) {
+	t.Helper()
+	if n, ok := pollSubscriberCount(mr, channel, func(n int) bool { return n >= want }); !ok {
+		t.Fatalf("%s has %d subscribers, want at least %d, within the deadline", channel, n, want)
+	}
+}
+
+// pollSubscriberCount READS the server's registration state rather than
+// publishing a probe to infer it.
+//
+// The probe version worked and was a trap for the next person to reuse it:
+// "probe" is not a decodable payload, so on a bus that reads the wire prefix
+// it is an UNDECODABLE MESSAGE — the exact condition several tests in this
+// package assert about, injected by the helper they would call to set
+// themselves up. It happened to be harmless where the helper was already used,
+// because an undecodable message only ends coverage that EXISTS and every such
+// call site ran before the first publish. That is a property of the call
+// sites, not of the helper, and it silently stops holding the first time
+// someone waits for a subscriber after establishing coverage.
+//
+// The deadline is a LIVENESS bound, not a latency assertion: registration is
+// a sub-millisecond-to-milliseconds affair, and this number exists so a test
+// that will never see a subscriber fails instead of hanging.
+func pollSubscriberCount(mr *miniredis.Miniredis, channel string, satisfied func(int) bool) (int, bool) {
 	deadline := time.Now().Add(3 * time.Second)
 	for {
-		n := mr.Publish(channel, "probe")
-		if (n > 0) == want {
-			return
+		n := mr.PubSubNumSub(channel)[channel]
+		if satisfied(n) {
+			return n, true
 		}
 		if time.Now().After(deadline) {
-			if want {
-				t.Fatalf("nothing subscribed to %s within the deadline", channel)
-			}
-			t.Fatalf("%s has %d subscribers, want none", channel, n)
+			return n, false
 		}
-		time.Sleep(5 * time.Millisecond)
+		time.Sleep(time.Millisecond)
 	}
 }

--- a/internal/events/redis_namespace_test.go
+++ b/internal/events/redis_namespace_test.go
@@ -170,16 +170,16 @@ func TestRedisBusDefaultKeepsHistoricalKeys(t *testing.T) {
 // waitForSubscribers polls until the channel has (or provably lacks)
 // subscribers.
 //
-// POLLING, not a single check, because go-redis establishes a
-// subscription ASYNCHRONOUSLY: Subscribe returns before the SUBSCRIBE
-// reaches the server, so an immediate assertion races the connection.
+// POLLING, not a single check, because a subscription is not registered by
+// the time Subscribe returns. go-redis DOES write the SUBSCRIBE command
+// synchronously — Client.Subscribe calls PubSub.Subscribe, which writes it —
+// but it does not wait for the server to confirm it, and anything the test
+// does next travels on a different connection. So an immediate assertion
+// races the server's processing of that command.
+//
 // That race made TestRedisBusDefaultKeepsHistoricalKeys fail once in a
 // full-suite run — a flake in the test, not the code, and the kind that
 // would have been blamed on the next unrelated change.
-//
-// The "probe" payload is not valid JSON, so a bus that IS subscribed logs
-// an unmarshal error when it arrives. That noise is the confirmation the
-// assertion wants; it is deliberately not an event any consumer sees.
 func waitForSubscribers(t *testing.T, mr *miniredis.Miniredis, channel string, want bool) {
 	t.Helper()
 	n, ok := pollSubscriberCount(mr, channel, func(n int) bool { return (n > 0) == want })

--- a/internal/events/redis_namespace_test.go
+++ b/internal/events/redis_namespace_test.go
@@ -218,6 +218,15 @@ func waitForSubscriberCount(t *testing.T, mr *miniredis.Miniredis, channel strin
 // The deadline is a LIVENESS bound, not a latency assertion: registration is
 // a sub-millisecond-to-milliseconds affair, and this number exists so a test
 // that will never see a subscriber fails instead of hanging.
+//
+// WHAT WAITING HERE DELIBERATELY STOPS TESTING, so that nobody re-discovers
+// it as a gap: every caller of this helper is no longer exercising the window
+// between subscribing and being registered, and a publish inside that window
+// is lost for good. That window is REAL IN PRODUCTION, where nothing waits —
+// see BUG-2747, which also records that internal/watchevents closes the same
+// window in its constructor and this bus does not. It is tracked there rather
+// than by leaving tests that fail on a loaded runner roughly one time in a
+// hundred, which is a defect detector nobody can act on.
 func pollSubscriberCount(mr *miniredis.Miniredis, channel string, satisfied func(int) bool) (int, bool) {
 	deadline := time.Now().Add(3 * time.Second)
 	for {

--- a/internal/events/redis_namespace_test.go
+++ b/internal/events/redis_namespace_test.go
@@ -206,14 +206,19 @@ func waitForSubscriberCount(t *testing.T, mr *miniredis.Miniredis, channel strin
 // publishing a probe to infer it.
 //
 // The probe version worked and was a trap for the next person to reuse it:
-// "probe" is not a decodable payload, so on a bus that reads the wire prefix
-// it is an UNDECODABLE MESSAGE — the exact condition several tests in this
-// package assert about, injected by the helper they would call to set
-// themselves up. It happened to be harmless where the helper was already used,
-// because an undecodable message only ends coverage that EXISTS and every such
-// call site ran before the first publish. That is a property of the call
-// sites, not of the helper, and it silently stops holding the first time
-// someone waits for a subscriber after establishing coverage.
+// "probe" is not a decodable payload, so it is an UNDECODABLE MESSAGE — the
+// exact condition several tests in this package assert about, injected by the
+// helper they would call to set themselves up. An undecodable message ends
+// this instance's coverage of the workspace.
+//
+// It was harmless in every EXISTING caller, but not for the reason I first
+// wrote here (codex round 7 corrected it): four of the callers do run after a
+// publish, so the old helper really was ending coverage on a live buffer. It
+// did not matter because those four go on to assert about Redis KEYS rather
+// than about coverage or delivery. That is a property of what each call site
+// happens to assert next — the thinnest possible guarantee, and one that stops
+// holding the moment somebody adds a coverage assertion after a wait, or
+// copies the helper into a test that has one.
 //
 // The deadline is a LIVENESS bound, not a latency assertion: registration is
 // a sub-millisecond-to-milliseconds affair, and this number exists so a test

--- a/internal/events/redis_reconnect_test.go
+++ b/internal/events/redis_reconnect_test.go
@@ -199,26 +199,40 @@ func TestAReconnectOnAnIdleWorkspaceIsNotAReset(t *testing.T) {
 	// Positive control in the same test, so a bus that never reports anything
 	// at all cannot pass: once something IS buffered, the next reconnect does
 	// report.
-	// NO REGISTRATION WAIT HERE, and the reason is worth keeping because the
-	// obvious one does not work (BUG-2742, codex round 8).
+	// PUBLISH UNTIL ONE LANDS, because after a reconnect nothing else proves
+	// the REPLACEMENT subscription is live (BUG-2742, codex rounds 8 and 9).
 	//
-	// A publish that beats the REPLACEMENT subscription after a reconnect is
-	// lost outright, so this line looks like it wants waitForSubscribers. But
-	// that helper counts subscribers, and measured across the cut the count
-	// goes 1 -> 0 -> 1 over a couple of milliseconds: the STALE registration
-	// still reads 1 until miniredis notices the closed socket. A wait placed
-	// just after the cut therefore returns immediately on the dead
-	// subscription and guarantees nothing — and in one trial of five the
-	// count never dropped at all within 3s, so waiting for the 1 -> 0
-	// transition instead risks hanging.
+	// A publish that beats the replacement is lost outright, so this wants a
+	// registration wait — but counting subscribers cannot supply one here.
+	// Measured across the cut, the count goes 1 -> 0 -> 1 within a couple of
+	// milliseconds: the STALE registration still reads 1 until miniredis
+	// notices the closed socket, so a count-based wait placed after the cut
+	// returns instantly on the dead subscription. Waiting for the 1 -> 0
+	// transition is not available either — in one trial of five the count
+	// never dropped inside 3s, so that wait can hang.
 	//
-	// What actually protects this publish is the 2s poll above, which runs to
-	// completion whenever no reset is reported — which is the case this test
-	// asserts. That is margin by accident rather than by construction, and
-	// the honest thing is to say so rather than to add a wait that reads as a
-	// guarantee and is not one.
-	b.Publish(Event{Type: ItemCreated, WorkspaceID: "ws-idle"})
-	drain(t, ch, 1)
+	// An event arriving IS the proof, and it is the only one that cannot be
+	// satisfied by the stale connection. Retrying costs nothing when the
+	// subscription is already live (the first publish returns immediately)
+	// and cannot pass early when it is not. The extra events some rounds
+	// publish are harmless: what the rest of the test needs is a buffer with
+	// something in it, not a buffer with exactly one thing in it.
+	//
+	// The outer bound is a LIVENESS bound; the inner one is a retry cadence.
+	// Neither is a latency assertion.
+	live := false
+	for deadline := time.Now().Add(20 * time.Second); time.Now().Before(deadline) && !live; {
+		b.Publish(Event{Type: ItemCreated, WorkspaceID: "ws-idle"})
+		select {
+		case <-ch:
+			live = true
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+	if !live {
+		t.Fatal("no published event ever came back after the reconnect, so the replacement " +
+			"subscription never became live and the assertion below would be about nothing")
+	}
 	cutter.cut()
 
 	deadline = time.Now().Add(10 * time.Second)

--- a/internal/events/redis_reconnect_test.go
+++ b/internal/events/redis_reconnect_test.go
@@ -199,14 +199,24 @@ func TestAReconnectOnAnIdleWorkspaceIsNotAReset(t *testing.T) {
 	// Positive control in the same test, so a bus that never reports anything
 	// at all cannot pass: once something IS buffered, the next reconnect does
 	// report.
-	// The reconnect above re-subscribed, and a publish that beats the
-	// REPLACEMENT registration is lost outright rather than delayed
-	// (BUG-2742). Today the 2s poll before this line happens to leave enough
-	// room, which is safety by accident: the poll exists to prove a reset was
-	// NOT reported and would exit early the moment that changed, taking the
-	// margin with it. Waiting explicitly costs milliseconds and does not
-	// depend on the loop above keeping its current shape.
-	waitForSubscribers(t, mr, "pad:events:ws-idle", true)
+	// NO REGISTRATION WAIT HERE, and the reason is worth keeping because the
+	// obvious one does not work (BUG-2742, codex round 8).
+	//
+	// A publish that beats the REPLACEMENT subscription after a reconnect is
+	// lost outright, so this line looks like it wants waitForSubscribers. But
+	// that helper counts subscribers, and measured across the cut the count
+	// goes 1 -> 0 -> 1 over a couple of milliseconds: the STALE registration
+	// still reads 1 until miniredis notices the closed socket. A wait placed
+	// just after the cut therefore returns immediately on the dead
+	// subscription and guarantees nothing — and in one trial of five the
+	// count never dropped at all within 3s, so waiting for the 1 -> 0
+	// transition instead risks hanging.
+	//
+	// What actually protects this publish is the 2s poll above, which runs to
+	// completion whenever no reset is reported — which is the case this test
+	// asserts. That is margin by accident rather than by construction, and
+	// the honest thing is to say so rather than to add a wait that reads as a
+	// guarantee and is not one.
 	b.Publish(Event{Type: ItemCreated, WorkspaceID: "ws-idle"})
 	drain(t, ch, 1)
 	cutter.cut()

--- a/internal/events/redis_reconnect_test.go
+++ b/internal/events/redis_reconnect_test.go
@@ -199,6 +199,14 @@ func TestAReconnectOnAnIdleWorkspaceIsNotAReset(t *testing.T) {
 	// Positive control in the same test, so a bus that never reports anything
 	// at all cannot pass: once something IS buffered, the next reconnect does
 	// report.
+	// The reconnect above re-subscribed, and a publish that beats the
+	// REPLACEMENT registration is lost outright rather than delayed
+	// (BUG-2742). Today the 2s poll before this line happens to leave enough
+	// room, which is safety by accident: the poll exists to prove a reset was
+	// NOT reported and would exit early the moment that changed, taking the
+	// margin with it. Waiting explicitly costs milliseconds and does not
+	// depend on the loop above keeping its current shape.
+	waitForSubscribers(t, mr, "pad:events:ws-idle", true)
 	b.Publish(Event{Type: ItemCreated, WorkspaceID: "ws-idle"})
 	drain(t, ch, 1)
 	cutter.cut()


### PR DESCRIPTION
Fixes BUG-2742 — the noisiest flake in the shop: four CI failures in one day across three PRs (#1141 Nix, #1180 PG, #1182 Go, #1182 Nix), plus a fifth later. The cost was never the red runs; it was that every unrelated red leg had to be investigated before it could be dismissed.

## Two defects, and the item's framing only fits one of them

**The arrival count.** `TestConcurrentPublishesDeliverInIDOrder` published 320 events while a goroutine drained, then guarded vacuity with "at least half must arrive". That guard is a bet on runner speed — this bus deliberately drops for a subscriber that cannot keep up, so the arrival count is a continuous function of how much CPU the reader gets. It reported 64, 65, 144 and 150 of 320 across instances; 64 is exactly the subscriber channel depth.

The fix stops buying detection power with VOLUME through a bounded channel and buys it with REPETITION over a sample that cannot be truncated: no reader during the publishes, no more events than the channel is deep, so a drop is impossible and the guard becomes `count == total`. Measured against the mutation the test exists to catch (release `replayMu` after the append so fan-out runs outside it): **9/30 before, 25/25 after**, at ~10ms against the old fixed 0.5s. A second mutation (id assigned outside the lock) is also caught 25/25.

**The redis half is not a timeout problem, and raising any bound would have been wasted work.** `RedisBus.Subscribe` returns before Redis has REGISTERED the subscription — go-redis writes the SUBSCRIBE synchronously but does not await the server's confirmation, and the publish that follows travels on a different connection. `RedisBus.Publish` has no local fan-out, so an event Redis processes before the SUBSCRIBE registers is lost OUTRIGHT. The round trip is bimodal: tens of milliseconds, or never. No bound distinguishes the second case from a hang.

## The counterfactual

Unmodified `origin/main` in a scratch worktree, 48 busy loops on 8 cores, the four affected tests at `-count 20`, six rounds each side under the same load:

| | rounds failed |
|---|---|
| `origin/main` | **5 of 6** |
| this branch | **0 of 6** |

and main's failures reproduce the ledger's CI messages verbatim — "the published event never came back through Redis", "the first event never arrived". Not the same family: the same messages.

## Scope, swept as a family rather than test-by-test

The item asked for the family as one unit. CI had named three tests; the class holds **six**, and the two extra instances of each shape were found by sweeping for the shape rather than for the named failures. Both extras are shape fixes — neither reproduced in 50 loaded invocations — and the commits say so.

One production change: `subscriberChanDepth` is named rather than inlined, so the tests asserting behaviour AT that boundary derive it instead of restating it. No runtime behaviour change.

## Review

Thirteen Codex rounds, converged on two fresh-angle CLEANs on different dimensions (can anything still fail for a non-product reason on a loaded runner; do the assertions match what the bus actually guarantees). Rounds 2-10 and 12 all found real things, including two of my own claims that were false and one "fix" of mine that guaranteed nothing and was retracted in place. Three findings were declined on stated technical grounds, two of them arguing against earlier rounds of the same review.

Gates, each run as its own command with the exit code read directly: `go build ./...` 0 · `make lint` 0 issues · `go test ./...` 0 (27 packages) · `make test-pg` 0 · `go test ./internal/events/ -race` green over 12 runs under 48-way CPU contention.

## Filed, not folded in

- **BUG-2747** — the same window exists in PRODUCTION, where nothing waits. `internal/watchevents` closes it in its constructor (`pubsub.Receive`) and this bus does not; the asymmetry is the finding. A resuming client is protected by the coverage check, so the silent case is narrow — a client whose cursor begins after the hole.
- **BUG-2746** — closed `wontfix`, retracted. I filed it claiming watchevents shared the exposure; it does not, and the retraction records why the null result misled me.
