### PR TITLE
fix(store): erase a deleted account's user id from frozen outbox payloads (TASK-2719)

### DIFF
--- a/internal/store/event_outbox.go
+++ b/internal/store/event_outbox.go
@@ -459,11 +459,33 @@ func scrubUserRefsInNode(node any, userID string) bool {
 // is load-bearing: payload is JSONB on Postgres and TEXT on SQLite, and LIKE
 // on jsonb is not a thing. A uuid carries no LIKE metacharacters and is
 // specific enough that false positives are rare — and harmless, because the Go
-// rewrite is a no-op when no matching key holds the id. The scan is bounded by
-// TASK-2714's retention window, not the table's lifetime; its cost inside the
-// deletion transaction is accepted un-measured for a once-per-account-deletion
-// path (option (b) on the TASK-2719 trail, where (a) full-scan and (c) a
-// side-table were weighed).
+// rewrite is a no-op when no matching key holds the id. Two invariants the
+// prefilter leans on, named so they are checkable rather than assumed (codex
+// round 1): user ids are newID() uuids (hex + dashes — no LIKE metacharacters,
+// no characters JSON escapes, so the id appears verbatim in the stored text on
+// both dialects), and a payload is a SINGLE valid JSON value (writeOutboxTx
+// rejects anything json.Valid refuses, which includes concatenated values), so
+// the decoder cannot stop early with unscanned trailing content. The scan is
+// bounded by TASK-2714's retention window, not the table's lifetime; its cost
+// inside the deletion transaction is accepted un-measured for a
+// once-per-account-deletion path (option (b) on the TASK-2719 trail, where (a)
+// full-scan and (c) a side-table were weighed).
+//
+// RESIDUAL WINDOW, stated rather than discovered in an audit (codex round 1):
+// the candidate read is one snapshot inside the deletion transaction, so a row
+// emitted CONCURRENTLY can commit after it and keep the id. On both dialects
+// the paths that would CREATE such a row mostly serialize away — SQLite has
+// one writer at a time, and on Postgres any mutation that FK-references the
+// dying user (a new assignment, membership, authored comment) blocks on the
+// pending DELETE FROM users via its KEY SHARE check and then fails. What
+// survives is the narrow case that re-freezes an EXISTING reference without
+// re-checking it — e.g. a concurrent title update on an item still assigned to
+// the dying user, whose snapshot emit does not touch the users row — committed
+// inside the deletion's own window. Post-commit, the FK cascades have nulled
+// the live references, so new emits are clean. That escape is bounded by
+// TASK-2714's retention exactly like every pre-scrub payload was; closing it
+// outright would take a table lock on a once-per-account path, which is the
+// disproportion this note exists to record.
 //
 // READ FULLY, THEN WRITE. Both halves run on the one deletion transaction, and
 // issuing tx.Exec while a tx.Query cursor is open is the BUG-2409 shape — a
@@ -502,20 +524,8 @@ func (s *Store) ScrubOutboxUserRefsTx(tx *sql.Tx, userID string) error {
 	rows.Close()
 
 	for _, c := range candidates {
-		scrubbed, changed, err := scrubUserRefsFromPayload([]byte(c.payload), userID)
-		if err != nil {
-			// A payload this transaction cannot parse is one the scrub cannot
-			// honestly claim to have erased — fail the deletion rather than
-			// skip the row silently.
-			return fmt.Errorf("outbox: scrub user refs: row %s: %w", c.id, err)
-		}
-		if !changed {
-			continue
-		}
-		if _, err := tx.Exec(s.q(`
-			UPDATE event_outbox SET payload = ? WHERE id = ?
-		`), string(scrubbed), c.id); err != nil {
-			return fmt.Errorf("outbox: scrub user refs: rewrite row %s: %w", c.id, err)
+		if err := s.scrubOutboxRowTx(tx, c.id, c.payload, userID); err != nil {
+			return err
 		}
 	}
 
@@ -530,6 +540,63 @@ func (s *Store) ScrubOutboxUserRefsTx(tx *sql.Tx, userID string) error {
 		return fmt.Errorf("outbox: scrub user refs: clear subject ids: %w", err)
 	}
 	return nil
+}
+
+// scrubOutboxRowTx rewrites one candidate row, retrying against concurrent
+// writers.
+//
+// THE UPDATE IS A COMPARE-AND-SWAP, not a blind write, because two account
+// deletions can hold one payload at once: a bulk payload naming users A and B
+// is a candidate for both, and on Postgres READ COMMITTED both transactions
+// can read the ORIGINAL before either commits — a blind rewrite by the later
+// committer would then reintroduce the earlier deletion's id from its stale
+// copy (codex round 1). Conditioning on the payload we read makes the stale
+// write match zero rows; we re-read and redo against the fresh bytes. SQLite
+// never takes the retry path (one writer at a time), and on Postgres the
+// text parameter coerces to jsonb, so the equality is the column's own.
+// Dialect-uniform on purpose — the same reasoning as claimOutboxIDs' arbiter.
+//
+// The retry bound is generous for its worst case (every concurrent deletion
+// of a user sharing this payload commits between our read and our write, per
+// attempt) and exists so a livelock bug fails loudly instead of spinning.
+func (s *Store) scrubOutboxRowTx(tx *sql.Tx, id, payload, userID string) error {
+	for attempt := 0; attempt < 5; attempt++ {
+		scrubbed, changed, err := scrubUserRefsFromPayload([]byte(payload), userID)
+		if err != nil {
+			// A payload this transaction cannot parse is one the scrub cannot
+			// honestly claim to have erased — fail the deletion rather than
+			// skip the row silently.
+			return fmt.Errorf("outbox: scrub user refs: row %s: %w", id, err)
+		}
+		if !changed {
+			return nil
+		}
+		res, err := tx.Exec(s.q(`
+			UPDATE event_outbox SET payload = ? WHERE id = ? AND payload = ?
+		`), string(scrubbed), id, payload)
+		if err != nil {
+			return fmt.Errorf("outbox: scrub user refs: rewrite row %s: %w", id, err)
+		}
+		n, err := res.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("outbox: scrub user refs: rewrite row %s: %w", id, err)
+		}
+		if n > 0 {
+			return nil
+		}
+		// Lost the race: someone rewrote (or pruned) the row since our read.
+		var fresh sql.NullString
+		err = tx.QueryRow(s.q(`SELECT payload FROM event_outbox WHERE id = ?`), id).Scan(&fresh)
+		if err == sql.ErrNoRows {
+			// Pruned between read and write — nothing left to scrub.
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("outbox: scrub user refs: re-read row %s: %w", id, err)
+		}
+		payload = fresh.String
+	}
+	return fmt.Errorf("outbox: scrub user refs: row %s: contended past retry bound", id)
 }
 
 // emitItemEventTx writes one item-subject event to the outbox on the caller's

--- a/internal/store/event_outbox.go
+++ b/internal/store/event_outbox.go
@@ -471,21 +471,23 @@ func scrubUserRefsInNode(node any, userID string) bool {
 // once-per-account-deletion path (option (b) on the TASK-2719 trail, where (a)
 // full-scan and (c) a side-table were weighed).
 //
-// RESIDUAL WINDOW, stated rather than discovered in an audit (codex round 1):
-// the candidate read is one snapshot inside the deletion transaction, so a row
-// emitted CONCURRENTLY can commit after it and keep the id. On both dialects
-// the paths that would CREATE such a row mostly serialize away — SQLite has
-// one writer at a time, and on Postgres any mutation that FK-references the
-// dying user (a new assignment, membership, authored comment) blocks on the
-// pending DELETE FROM users via its KEY SHARE check and then fails. What
-// survives is the narrow case that re-freezes an EXISTING reference without
-// re-checking it — e.g. a concurrent title update on an item still assigned to
-// the dying user, whose snapshot emit does not touch the users row — committed
-// inside the deletion's own window. Post-commit, the FK cascades have nulled
-// the live references, so new emits are clean. That escape is bounded by
-// TASK-2714's retention exactly like every pre-scrub payload was; closing it
-// outright would take a table lock on a once-per-account path, which is the
-// disproportion this note exists to record.
+// RESIDUAL WINDOW, stated rather than discovered in an audit (codex rounds 1
+// and 2): the candidate read is one snapshot inside the deletion transaction,
+// so a row emitted CONCURRENTLY can commit after it and keep the id. SQLite's
+// single writer serializes the whole race away. On Postgres three paths stay
+// open, all bounded by TASK-2714's retention exactly like every pre-scrub
+// payload was: (a) a mutation that re-freezes an EXISTING reference without
+// re-checking it — a title update on an item still assigned to the dying user
+// touches no users row and sails through; (b) a new FK-checked reference whose
+// KEY SHARE landed BEFORE the deletion reached DELETE FROM users — the
+// deletion is what waits in that ordering, and the emit commits first (with
+// SET NULL FKs the deletion then still succeeds); (c) attachments.uploaded_by
+// has NO foreign key at all (migrations 047/026), so an in-flight upload can
+// emit attachment.added naming the user even after the users row is gone —
+// new emits post-commit are NOT structurally clean, that column just carries
+// whatever the request handler resolved before the account died. Closing any
+// of these outright would take a table lock on a once-per-account path, which
+// is the disproportion this note exists to record.
 //
 // READ FULLY, THEN WRITE. Both halves run on the one deletion transaction, and
 // issuing tx.Exec while a tx.Query cursor is open is the BUG-2409 shape — a

--- a/internal/store/event_outbox.go
+++ b/internal/store/event_outbox.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"bytes"
 	"database/sql"
 	"encoding/json"
 	"fmt"
@@ -315,11 +316,20 @@ type itemEventPayload struct {
 //
 // THE RULE APPLIED, stated as the rule rather than as a proxy for it: remove
 // DIRECTLY IDENTIFYING personal data — a human name, an email address — and
-// keep opaque identifiers and row state. assigned_user_id stays: a binding
-// predicate filters on it, and after the account is gone it is a dangling
-// reference to nobody rather than a way to identify anyone. The name and email
-// are denormalized lookups a consumer can resolve for itself if it is
-// entitled to.
+// keep opaque identifiers and row state. assigned_user_id stays AT EMIT TIME:
+// a binding predicate filters on it, and while the account exists it is the
+// row's own state. The name and email are denormalized lookups a consumer can
+// resolve for itself if it is entitled to.
+//
+// SUPERSEDED AT DELETION TIME (TASK-2719, Dave's ruling day-49). This comment
+// originally kept assigned_user_id unconditionally, reasoning that after the
+// account is gone it is "a dangling reference to nobody rather than a way to
+// identify anyone". That engineering call LOST to the account-deletion ruling:
+// "delete my account" means prompt erasure of the frozen user id too, so
+// ScrubOutboxUserRefsTx (called from DeleteAccountAtomic) removes it — and
+// every other frozen user-id key — from already-written payloads. Emit-time
+// keep and deletion-time scrub are both in force; the deletion ruling is the
+// winner wherever they would disagree.
 //
 // Deliberately NOT scrubbed: collection_*/ref and the parent fields, which are
 // derived metadata rather than identity — predicates address items by
@@ -345,6 +355,181 @@ func scrubItemPII(item *models.Item) *models.Item {
 	clone.AssignedUserName = ""
 	clone.AssignedUserEmail = ""
 	return &clone
+}
+
+// outboxUserRefKeys are the payload keys that can hold a bare user id, per the
+// frozen-user-id population enumerated on TASK-2719 (CONVE-18):
+//
+//	assigned_user_id — item snapshots: single (itemEventPayload embeds
+//	                   models.Item) and batch (bulkItemEventPayload members).
+//	user_id          — comment snapshots (models.Comment) and member payloads
+//	                   (memberEventPayload).
+//	uploaded_by      — attachment snapshots (models.Attachment).
+//
+// The other families carry no user id: ref_only is ids of non-user subjects,
+// and the batch header is op + item ids (member snapshots join it only at fold
+// time, from member rows scrubbed here in their own right).
+//
+// BOUNDARY, stated so the next reader knows what this deliberately does not
+// reach: the scrub matches these keys at any JSON depth, but an item's
+// `fields` value is a JSON-ENCODED STRING and the walk does not enter it — a
+// legacy stray assigned_user_id INSIDE the blob survives, exactly as it
+// survives on the live row (DeleteAccountAtomic's de-identify list does not
+// rewrite fields blobs either). Same-posture-as-live-rows is the contract.
+var outboxUserRefKeys = map[string]bool{
+	"assigned_user_id": true,
+	"user_id":          true,
+	"uploaded_by":      true,
+}
+
+// scrubUserRefsFromPayload returns the payload with every user-ref key whose
+// value IS the given user id removed, and whether anything changed.
+//
+// KEY-SCOPED AND VALUE-MATCHED, both deliberately. Key-scoped so an unrelated
+// field that happens to hold a uuid is never touched; value-matched so a
+// payload naming a DIFFERENT user is returned byte-identical — the negative
+// control the tests pin. Removal rather than emptying: every model behind
+// these keys unmarshals an absent key to its zero value, and an absent key
+// reads as "scrubbed" where an empty string reads as ambiguous data.
+//
+// An unchanged payload is returned as the ORIGINAL bytes. A changed one is
+// re-marshalled, which normalizes key order at the rewritten levels; numeric
+// literals survive verbatim via json.Number, so the rewrite cannot corrupt a
+// seq (or any future int64) by way of float64.
+func scrubUserRefsFromPayload(payload []byte, userID string) ([]byte, bool, error) {
+	dec := json.NewDecoder(bytes.NewReader(payload))
+	dec.UseNumber()
+	var doc any
+	if err := dec.Decode(&doc); err != nil {
+		return nil, false, fmt.Errorf("outbox: parse payload for scrub: %w", err)
+	}
+	if !scrubUserRefsInNode(doc, userID) {
+		return payload, false, nil
+	}
+	out, err := json.Marshal(doc)
+	if err != nil {
+		return nil, false, fmt.Errorf("outbox: re-marshal scrubbed payload: %w", err)
+	}
+	return out, true, nil
+}
+
+func scrubUserRefsInNode(node any, userID string) bool {
+	changed := false
+	switch v := node.(type) {
+	case map[string]any:
+		for k, val := range v {
+			if outboxUserRefKeys[k] {
+				if s, ok := val.(string); ok && s == userID {
+					delete(v, k)
+					changed = true
+					continue
+				}
+			}
+			if scrubUserRefsInNode(val, userID) {
+				changed = true
+			}
+		}
+	case []any:
+		for _, e := range v {
+			if scrubUserRefsInNode(e, userID) {
+				changed = true
+			}
+		}
+	}
+	return changed
+}
+
+// ScrubOutboxUserRefsTx erases a deleted account's user id from every frozen
+// outbox payload and from the subject_id column, on the caller's transaction.
+// The account-deletion counterpart of scrubItemPII's emit-time scrub — see the
+// SUPERSEDED note there for the ruling that reversed emit-time's
+// assigned_user_id decision (TASK-2719).
+//
+// UNIFORM OVER DISPATCHED AND UNDISPATCHED ROWS, deleting neither (lead
+// ruling, TASK-2719): erasure is this scrub's job and row LIFECYCLE is
+// retention's (TASK-2714) — deleting an undispatched row would break the
+// outbox durability guarantee for zero erasure gain over scrubbing it. A
+// scrubbed member row degrades from a delta to a resync signal ("a membership
+// changed in this workspace at this seq"), which stays parseable:
+// memberEventPayload unmarshals an absent user_id to "", and the drain treats
+// payloads as opaque bytes.
+//
+// Candidate rows are found by `subject_id = ?` (indexed — catches every member
+// row, whose subject IS the user) OR a payload substring prefilter. The CAST
+// is load-bearing: payload is JSONB on Postgres and TEXT on SQLite, and LIKE
+// on jsonb is not a thing. A uuid carries no LIKE metacharacters and is
+// specific enough that false positives are rare — and harmless, because the Go
+// rewrite is a no-op when no matching key holds the id. The scan is bounded by
+// TASK-2714's retention window, not the table's lifetime; its cost inside the
+// deletion transaction is accepted un-measured for a once-per-account-deletion
+// path (option (b) on the TASK-2719 trail, where (a) full-scan and (c) a
+// side-table were weighed).
+//
+// READ FULLY, THEN WRITE. Both halves run on the one deletion transaction, and
+// issuing tx.Exec while a tx.Query cursor is open is the BUG-2409 shape — a
+// deadlock on SQLite's single-connection transactions. The collect-then-close
+// ordering is a precondition, not a style choice.
+func (s *Store) ScrubOutboxUserRefsTx(tx *sql.Tx, userID string) error {
+	if userID == "" {
+		// An empty id would value-match nothing but LIKE-match every row —
+		// a full-table parse for a caller bug. Refuse instead.
+		return fmt.Errorf("outbox: scrub user refs: no user id")
+	}
+	rows, err := tx.Query(s.q(`
+		SELECT id, payload FROM event_outbox
+		WHERE subject_id = ? OR CAST(payload AS TEXT) LIKE ?
+	`), userID, "%"+userID+"%")
+	if err != nil {
+		return fmt.Errorf("outbox: scrub user refs: find rows: %w", err)
+	}
+	type candidate struct {
+		id      string
+		payload string
+	}
+	var candidates []candidate
+	for rows.Next() {
+		var c candidate
+		if err := rows.Scan(&c.id, &c.payload); err != nil {
+			rows.Close()
+			return fmt.Errorf("outbox: scrub user refs: scan row: %w", err)
+		}
+		candidates = append(candidates, c)
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return fmt.Errorf("outbox: scrub user refs: iterate rows: %w", err)
+	}
+	rows.Close()
+
+	for _, c := range candidates {
+		scrubbed, changed, err := scrubUserRefsFromPayload([]byte(c.payload), userID)
+		if err != nil {
+			// A payload this transaction cannot parse is one the scrub cannot
+			// honestly claim to have erased — fail the deletion rather than
+			// skip the row silently.
+			return fmt.Errorf("outbox: scrub user refs: row %s: %w", c.id, err)
+		}
+		if !changed {
+			continue
+		}
+		if _, err := tx.Exec(s.q(`
+			UPDATE event_outbox SET payload = ? WHERE id = ?
+		`), string(scrubbed), c.id); err != nil {
+			return fmt.Errorf("outbox: scrub user refs: rewrite row %s: %w", c.id, err)
+		}
+	}
+
+	// The COLUMN half: member rows carry the user id as their subject —
+	// indexed, outside the JSON, and missed by anything that only rewrites
+	// payloads (TASK-2719 recon; ratified in scope by the lead). Value
+	// equality is the precise predicate: item/comment/attachment subjects are
+	// their own row ids, never a user's.
+	if _, err := tx.Exec(s.q(`
+		UPDATE event_outbox SET subject_id = NULL WHERE subject_id = ?
+	`), userID); err != nil {
+		return fmt.Errorf("outbox: scrub user refs: clear subject ids: %w", err)
+	}
+	return nil
 }
 
 // emitItemEventTx writes one item-subject event to the outbox on the caller's

--- a/internal/store/event_outbox_scrub_test.go
+++ b/internal/store/event_outbox_scrub_test.go
@@ -372,6 +372,114 @@ func TestScrubOutboxUserRefs_DispatchedRowsScrubbedNotDeleted(t *testing.T) {
 	}
 }
 
+// TestScrubOutboxUserRefs_KeyScopedAndNumberSafe pins two properties a looser
+// implementation passes every other test without (codex round 1): the walk is
+// KEY-scoped, not value-scoped — a payload field that merely CONTAINS the
+// deleted user's id under an unrelated key survives — and numeric literals
+// cross the rewrite verbatim, so an int64 past float64's 2^53 integer range
+// cannot be corrupted by the re-marshal.
+func TestScrubOutboxUserRefs_KeyScopedAndNumberSafe(t *testing.T) {
+	s := testStore(t)
+	deleted, _ := scrubTestUsers(t, s)
+	ws := createTestWorkspace(t, s, "Scrub scoped")
+	clearOutbox(t, s)
+
+	// A hand-rolled item snapshot: the target key, a decoy string field whose
+	// VALUE is the deleted id under a non-target key, and a seq that float64
+	// cannot represent (2^53 + 1).
+	payload := `{"id":"` + newID() + `","workspace_id":"` + ws.ID + `","title":"decoy","content":"` + deleted.ID + `","assigned_user_id":"` + deleted.ID + `","seq":9007199254740993}`
+	emitInTx(t, s, func(tx *sql.Tx) error {
+		return writeOutboxTx(tx, s, OutboxEvent{
+			WorkspaceID:   ws.ID,
+			EventType:     kernelevents.ItemUpdated,
+			SubjectID:     newID(),
+			Payload:       []byte(payload),
+			PayloadFamily: kernelevents.PayloadItemSnapshot,
+		})
+	})
+
+	scrubInTx(t, s, deleted.ID)
+
+	var after string
+	if err := s.db.QueryRow(s.q(`SELECT payload FROM event_outbox`)).Scan(&after); err != nil {
+		t.Fatalf("read payload: %v", err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal([]byte(after), &decoded); err != nil {
+		t.Fatalf("decode scrubbed payload: %v", err)
+	}
+	if _, present := decoded["assigned_user_id"]; present {
+		t.Fatalf("assigned_user_id survived: %v", decoded["assigned_user_id"])
+	}
+	if decoded["content"] != deleted.ID {
+		t.Fatalf("content damaged — the scrub is not key-scoped: %v", decoded["content"])
+	}
+	if !strings.Contains(after, `9007199254740993`) {
+		t.Fatalf("seq literal corrupted by the rewrite: %s", after)
+	}
+}
+
+// TestScrubOutboxRow_StaleReadRetriesAgainstFreshPayload drives the
+// compare-and-swap's retry leg directly — the concurrent-deletion race it
+// exists for needs two overlapping Postgres transactions to reproduce, but
+// the leg itself is reachable deterministically by handing the helper a STALE
+// copy of the payload: the conditional UPDATE must match zero rows, and the
+// re-read must scrub what is actually stored rather than reintroduce the
+// stale bytes.
+func TestScrubOutboxRow_StaleReadRetriesAgainstFreshPayload(t *testing.T) {
+	s := testStore(t)
+	deleted, bystander := scrubTestUsers(t, s)
+	ws := createTestWorkspace(t, s, "Scrub CAS")
+	clearOutbox(t, s)
+
+	// Stored reality: the payload another deletion already scrubbed — the
+	// bystander's id is gone, the deleted user's remains.
+	stored := `{"id":"` + newID() + `","workspace_id":"` + ws.ID + `","title":"cas","assigned_user_id":"` + deleted.ID + `"}`
+	// Our stale read: the pre-scrub original still naming BOTH users.
+	stale := `{"id":"` + newID() + `","workspace_id":"` + ws.ID + `","title":"cas","assigned_user_id":"` + deleted.ID + `","user_id":"` + bystander.ID + `"}`
+
+	var rowID string
+	emitInTx(t, s, func(tx *sql.Tx) error {
+		ev := OutboxEvent{
+			WorkspaceID:   ws.ID,
+			EventType:     kernelevents.ItemUpdated,
+			SubjectID:     newID(),
+			Payload:       []byte(stored),
+			PayloadFamily: kernelevents.PayloadItemSnapshot,
+		}
+		if err := writeOutboxTx(tx, s, ev); err != nil {
+			return err
+		}
+		return tx.QueryRow(s.q(`SELECT id FROM event_outbox`)).Scan(&rowID)
+	})
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	defer tx.Rollback()
+	if err := s.scrubOutboxRowTx(tx, rowID, stale, deleted.ID); err != nil {
+		t.Fatalf("scrubOutboxRowTx: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	var after string
+	if err := s.db.QueryRow(s.q(`SELECT payload FROM event_outbox WHERE id = ?`), rowID).Scan(&after); err != nil {
+		t.Fatalf("read payload: %v", err)
+	}
+	if strings.Contains(after, deleted.ID) {
+		t.Fatalf("deleted user id survived the retry: %s", after)
+	}
+	// The stale copy's extra key must NOT be reintroduced: the retry scrubbed
+	// the STORED bytes, not our stale ones — this is the lost-update the CAS
+	// prevents, asserted from its observable end.
+	if strings.Contains(after, bystander.ID) {
+		t.Fatalf("stale payload reintroduced the other deletion's id: %s", after)
+	}
+}
+
 func TestScrubOutboxUserRefs_RefusesEmptyUserID(t *testing.T) {
 	s := testStore(t)
 	tx, err := s.db.Begin()

--- a/internal/store/event_outbox_scrub_test.go
+++ b/internal/store/event_outbox_scrub_test.go
@@ -1,0 +1,447 @@
+package store
+
+import (
+	"database/sql"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/kernelevents"
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// Tests for the account-deletion outbox scrub (TASK-2719).
+//
+// The CONVE-18 shape here: one test per payload family that carries a user id,
+// because a scrub that handles four of the five shapes looks exactly like one
+// that handles all five from any single test's point of view. Every positive
+// case is paired with a negative control — a payload naming a DIFFERENT user
+// that must come back byte-identical — because without it, "scrub everything"
+// passes every positive assertion.
+
+// rawOutboxPayload returns the single stored payload for a subject+type,
+// as raw bytes for byte-identity assertions.
+func rawOutboxPayload(t *testing.T, s *Store, subjectID, eventType string) string {
+	t.Helper()
+	rows, err := s.db.Query(s.q(`SELECT payload FROM event_outbox WHERE subject_id = ? AND event_type = ?`), subjectID, eventType)
+	if err != nil {
+		t.Fatalf("query payload: %v", err)
+	}
+	defer rows.Close()
+	var payloads []string
+	for rows.Next() {
+		var p string
+		if err := rows.Scan(&p); err != nil {
+			t.Fatalf("scan payload: %v", err)
+		}
+		payloads = append(payloads, p)
+	}
+	if len(payloads) != 1 {
+		t.Fatalf("outbox rows for subject %s type %s = %d, want exactly 1", subjectID, eventType, len(payloads))
+	}
+	return payloads[0]
+}
+
+// scrubInTx runs the scrub inside its own committed transaction, the way
+// DeleteAccountAtomic does.
+func scrubInTx(t *testing.T, s *Store, userID string) {
+	t.Helper()
+	tx, err := s.db.Begin()
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	defer tx.Rollback()
+	if err := s.ScrubOutboxUserRefsTx(tx, userID); err != nil {
+		t.Fatalf("ScrubOutboxUserRefsTx: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+}
+
+// emitInTx runs one production emitter inside a committed transaction.
+func emitInTx(t *testing.T, s *Store, emit func(tx *sql.Tx) error) {
+	t.Helper()
+	tx, err := s.db.Begin()
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	defer tx.Rollback()
+	if err := emit(tx); err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+}
+
+// scrubTestUsers creates the deleted-account user and the bystander whose
+// data is the negative control.
+func scrubTestUsers(t *testing.T, s *Store) (deleted, bystander *models.User) {
+	t.Helper()
+	deleted = createTestUser(t, s, "scrub-me@test.com", "Scrub Me", "correct-horse-battery-staple")
+	bystander = createTestUser(t, s, "bystander@test.com", "Bystander", "correct-horse-battery-staple")
+	return deleted, bystander
+}
+
+// assignItemSnapshot reads the item back through getItemTx — the same query
+// every production emitter uses — after assigning it to the given user, so
+// the emitted payload is the production shape rather than a hand-built one.
+func assignItemSnapshot(t *testing.T, s *Store, itemID, userID string) *models.Item {
+	t.Helper()
+	if _, err := s.db.Exec(s.q(`UPDATE items SET assigned_user_id = ? WHERE id = ?`), userID, itemID); err != nil {
+		t.Fatalf("assign item: %v", err)
+	}
+	tx, err := s.db.Begin()
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	defer tx.Rollback()
+	item, err := s.getItemTx(tx, itemID)
+	if err != nil {
+		t.Fatalf("getItemTx: %v", err)
+	}
+	if item == nil {
+		t.Fatalf("item %s not found", itemID)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	return item
+}
+
+func TestScrubOutboxUserRefs_ItemSnapshot(t *testing.T) {
+	s := testStore(t)
+	deleted, bystander := scrubTestUsers(t, s)
+	ws := createTestWorkspace(t, s, "Scrub item")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+	mine := createTestItem(t, s, ws.ID, col.ID, "Assigned to deleted", "body")
+	theirs := createTestItem(t, s, ws.ID, col.ID, "Assigned to bystander", "body")
+	clearOutbox(t, s)
+
+	mineSnap := assignItemSnapshot(t, s, mine.ID, deleted.ID)
+	theirsSnap := assignItemSnapshot(t, s, theirs.ID, bystander.ID)
+	emitInTx(t, s, func(tx *sql.Tx) error {
+		if err := s.emitItemEventTx(tx, kernelevents.ItemUpdated, mineSnap, nil, ""); err != nil {
+			return err
+		}
+		return s.emitItemEventTx(tx, kernelevents.ItemUpdated, theirsSnap, nil, "")
+	})
+	theirsBefore := rawOutboxPayload(t, s, theirs.ID, kernelevents.ItemUpdated)
+
+	scrubInTx(t, s, deleted.ID)
+
+	got := outboxPayloadFor(t, s, mine.ID, kernelevents.ItemUpdated)
+	if _, present := got["assigned_user_id"]; present {
+		t.Fatalf("assigned_user_id survived the scrub: %v", got["assigned_user_id"])
+	}
+	// The rest of the snapshot must survive: same id, title, and fields blob.
+	if got["id"] != mine.ID || got["title"] != "Assigned to deleted" {
+		t.Fatalf("scrub damaged non-target fields: id=%v title=%v", got["id"], got["title"])
+	}
+	if got["fields"] != mineSnap.Fields {
+		t.Fatalf("scrub rewrote the fields blob: %v != %v", got["fields"], mineSnap.Fields)
+	}
+
+	// NEGATIVE CONTROL: the bystander's payload is byte-identical. Without
+	// this, a scrub that strips assigned_user_id from every row passes the
+	// positive half.
+	if after := rawOutboxPayload(t, s, theirs.ID, kernelevents.ItemUpdated); after != theirsBefore {
+		t.Fatalf("bystander payload changed:\nbefore %s\nafter  %s", theirsBefore, after)
+	}
+}
+
+func TestScrubOutboxUserRefs_BulkMembers(t *testing.T) {
+	s := testStore(t)
+	deleted, bystander := scrubTestUsers(t, s)
+	ws := createTestWorkspace(t, s, "Scrub bulk")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+	mine := createTestItem(t, s, ws.ID, col.ID, "Bulk mine", "")
+	theirs := createTestItem(t, s, ws.ID, col.ID, "Bulk theirs", "")
+	clearOutbox(t, s)
+
+	mineSnap := assignItemSnapshot(t, s, mine.ID, deleted.ID)
+	theirsSnap := assignItemSnapshot(t, s, theirs.ID, bystander.ID)
+	emitInTx(t, s, func(tx *sql.Tx) error {
+		return s.emitBulkItemEventTx(tx, ws.ID, []*models.Item{scrubItemPII(mineSnap), scrubItemPII(theirsSnap)}, map[string]any{"kind": "test"})
+	})
+
+	scrubInTx(t, s, deleted.ID)
+
+	var payload string
+	if err := s.db.QueryRow(s.q(`SELECT payload FROM event_outbox WHERE event_type = ?`), kernelevents.ItemBulkUpdated).Scan(&payload); err != nil {
+		t.Fatalf("read bulk payload: %v", err)
+	}
+	var decoded struct {
+		Members []map[string]any `json:"members"`
+	}
+	if err := json.Unmarshal([]byte(payload), &decoded); err != nil {
+		t.Fatalf("decode bulk payload: %v", err)
+	}
+	if len(decoded.Members) != 2 {
+		t.Fatalf("members = %d, want 2", len(decoded.Members))
+	}
+	// The scrub reaches NESTED member snapshots, and only the deleted
+	// user's — the bystander's assignment survives inside the same payload,
+	// which is the in-payload negative control a whole-row rewrite would fail.
+	for _, m := range decoded.Members {
+		assigned, present := m["assigned_user_id"]
+		switch m["id"] {
+		case mine.ID:
+			if present {
+				t.Fatalf("deleted user's assigned_user_id survived in bulk member: %v", assigned)
+			}
+		case theirs.ID:
+			if !present || assigned != bystander.ID {
+				t.Fatalf("bystander's assigned_user_id damaged in bulk member: %v", assigned)
+			}
+		default:
+			t.Fatalf("unexpected member id %v", m["id"])
+		}
+	}
+}
+
+func TestScrubOutboxUserRefs_CommentSnapshot(t *testing.T) {
+	s := testStore(t)
+	deleted, bystander := scrubTestUsers(t, s)
+	ws := createTestWorkspace(t, s, "Scrub comment")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+	item := createTestItem(t, s, ws.ID, col.ID, "Commented", "")
+	clearOutbox(t, s)
+
+	mine := &models.Comment{ID: newID(), ItemID: item.ID, WorkspaceID: ws.ID, Author: "Scrub Me", UserID: deleted.ID, Body: "frozen body"}
+	theirs := &models.Comment{ID: newID(), ItemID: item.ID, WorkspaceID: ws.ID, Author: "Bystander", UserID: bystander.ID, Body: "other body"}
+	emitInTx(t, s, func(tx *sql.Tx) error {
+		if err := s.emitCommentEventTx(tx, kernelevents.CommentCreated, mine); err != nil {
+			return err
+		}
+		return s.emitCommentEventTx(tx, kernelevents.CommentCreated, theirs)
+	})
+	theirsBefore := rawOutboxPayload(t, s, theirs.ID, kernelevents.CommentCreated)
+
+	scrubInTx(t, s, deleted.ID)
+
+	got := outboxPayloadFor(t, s, mine.ID, kernelevents.CommentCreated)
+	if _, present := got["user_id"]; present {
+		t.Fatalf("comment user_id survived the scrub: %v", got["user_id"])
+	}
+	// The author DISPLAY STRING stays: live-row de-identification nulls
+	// comments.user_id only, and the scrub matches that posture exactly. The
+	// wider live-rows question is with Dave (TASK-2719 trail), not decided
+	// silently here.
+	if got["author"] != "Scrub Me" || got["body"] != "frozen body" {
+		t.Fatalf("scrub damaged non-target comment fields: author=%v body=%v", got["author"], got["body"])
+	}
+	if after := rawOutboxPayload(t, s, theirs.ID, kernelevents.CommentCreated); after != theirsBefore {
+		t.Fatalf("bystander comment payload changed:\nbefore %s\nafter  %s", theirsBefore, after)
+	}
+}
+
+func TestScrubOutboxUserRefs_AttachmentSnapshot(t *testing.T) {
+	s := testStore(t)
+	deleted, bystander := scrubTestUsers(t, s)
+	ws := createTestWorkspace(t, s, "Scrub attachment")
+	clearOutbox(t, s)
+
+	mine := &models.Attachment{ID: newID(), WorkspaceID: ws.ID, UploadedBy: deleted.ID, StorageKey: "fs:aaa", ContentHash: "aaa", MimeType: "image/png", Filename: "a.png"}
+	theirs := &models.Attachment{ID: newID(), WorkspaceID: ws.ID, UploadedBy: bystander.ID, StorageKey: "fs:bbb", ContentHash: "bbb", MimeType: "image/png", Filename: "b.png"}
+	emitInTx(t, s, func(tx *sql.Tx) error {
+		if err := s.emitAttachmentEventTx(tx, kernelevents.AttachmentAdded, mine); err != nil {
+			return err
+		}
+		return s.emitAttachmentEventTx(tx, kernelevents.AttachmentAdded, theirs)
+	})
+	theirsBefore := rawOutboxPayload(t, s, theirs.ID, kernelevents.AttachmentAdded)
+
+	scrubInTx(t, s, deleted.ID)
+
+	got := outboxPayloadFor(t, s, mine.ID, kernelevents.AttachmentAdded)
+	if _, present := got["uploaded_by"]; present {
+		t.Fatalf("uploaded_by survived the scrub: %v", got["uploaded_by"])
+	}
+	if got["filename"] != "a.png" || got["storage_key"] != "fs:aaa" {
+		t.Fatalf("scrub damaged non-target attachment fields: %v", got)
+	}
+	if after := rawOutboxPayload(t, s, theirs.ID, kernelevents.AttachmentAdded); after != theirsBefore {
+		t.Fatalf("bystander attachment payload changed:\nbefore %s\nafter  %s", theirsBefore, after)
+	}
+}
+
+func TestScrubOutboxUserRefs_MemberRowAndSubjectColumn(t *testing.T) {
+	s := testStore(t)
+	deleted, bystander := scrubTestUsers(t, s)
+	ws := createTestWorkspace(t, s, "Scrub member")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+	item := createTestItem(t, s, ws.ID, col.ID, "Subject control", "")
+	clearOutbox(t, s)
+
+	emitInTx(t, s, func(tx *sql.Tx) error {
+		if err := s.emitMemberEventTx(tx, kernelevents.MemberJoined, ws.ID, deleted.ID, "editor", now()); err != nil {
+			return err
+		}
+		return s.emitMemberEventTx(tx, kernelevents.MemberJoined, ws.ID, bystander.ID, "viewer", now())
+	})
+	// An item-subject row whose subject must NOT be nulled — the column half
+	// of the scrub is value-matched, not kind-wide.
+	snap := assignItemSnapshot(t, s, item.ID, deleted.ID)
+	emitInTx(t, s, func(tx *sql.Tx) error {
+		return s.emitItemEventTx(tx, kernelevents.ItemUpdated, snap, nil, "")
+	})
+
+	scrubInTx(t, s, deleted.ID)
+
+	// The deleted user's member row: subject_id NULL, payload user_id gone,
+	// the rest intact — a resync signal, not a broken row (lead ruling).
+	var subjectNull int
+	if err := s.db.QueryRow(s.q(`
+		SELECT COUNT(*) FROM event_outbox WHERE event_type = ? AND subject_id IS NULL
+	`), kernelevents.MemberJoined).Scan(&subjectNull); err != nil {
+		t.Fatalf("count nulled member subjects: %v", err)
+	}
+	if subjectNull != 1 {
+		t.Fatalf("member rows with NULL subject = %d, want exactly 1 (deleted user's only)", subjectNull)
+	}
+
+	var payload string
+	if err := s.db.QueryRow(s.q(`
+		SELECT payload FROM event_outbox WHERE event_type = ? AND subject_id IS NULL
+	`), kernelevents.MemberJoined).Scan(&payload); err != nil {
+		t.Fatalf("read scrubbed member payload: %v", err)
+	}
+	// The parse condition from the lead's ruling: the scrubbed row must
+	// unmarshal under the member payload shape. It does — user_id is simply
+	// absent — which is what closed the tombstone branch.
+	var member memberEventPayload
+	if err := json.Unmarshal([]byte(payload), &member); err != nil {
+		t.Fatalf("scrubbed member payload does not parse: %v", err)
+	}
+	if member.UserID != "" {
+		t.Fatalf("member user_id survived the scrub: %q", member.UserID)
+	}
+	if member.WorkspaceID != ws.ID || member.Role != "editor" {
+		t.Fatalf("scrub damaged non-target member fields: %+v", member)
+	}
+	if strings.Contains(payload, deleted.ID) {
+		t.Fatalf("deleted user id still legible in member payload: %s", payload)
+	}
+
+	// The bystander's member row keeps its subject and payload.
+	byPayload := rawOutboxPayload(t, s, bystander.ID, kernelevents.MemberJoined)
+	if !strings.Contains(byPayload, bystander.ID) {
+		t.Fatalf("bystander member payload damaged: %s", byPayload)
+	}
+
+	// The item-subject row keeps its subject id: the column scrub is value
+	// equality on the USER id, and an item's subject is the item.
+	if got := rawOutboxPayload(t, s, item.ID, kernelevents.ItemUpdated); strings.Contains(got, deleted.ID) {
+		t.Fatalf("deleted user id still legible in item payload: %s", got)
+	}
+}
+
+func TestScrubOutboxUserRefs_DispatchedRowsScrubbedNotDeleted(t *testing.T) {
+	s := testStore(t)
+	deleted, _ := scrubTestUsers(t, s)
+	ws := createTestWorkspace(t, s, "Scrub dispatched")
+	clearOutbox(t, s)
+
+	emitInTx(t, s, func(tx *sql.Tx) error {
+		return s.emitMemberEventTx(tx, kernelevents.MemberJoined, ws.ID, deleted.ID, "editor", now())
+	})
+	// Mark it dispatched the way the drain would leave it.
+	if _, err := s.db.Exec(s.q(`UPDATE event_outbox SET dispatched_at = ?`), now()); err != nil {
+		t.Fatalf("mark dispatched: %v", err)
+	}
+
+	scrubInTx(t, s, deleted.ID)
+
+	// UNIFORM, DELETE NOTHING (lead ruling): the dispatched-retained row
+	// survives — lifecycle is retention's job — but its id is gone.
+	var count int
+	var payload string
+	if err := s.db.QueryRow(s.q(`SELECT COUNT(*) FROM event_outbox`)).Scan(&count); err != nil {
+		t.Fatalf("count rows: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("outbox rows = %d, want 1 (scrub must not delete)", count)
+	}
+	if err := s.db.QueryRow(s.q(`SELECT payload FROM event_outbox`)).Scan(&payload); err != nil {
+		t.Fatalf("read payload: %v", err)
+	}
+	if strings.Contains(payload, deleted.ID) {
+		t.Fatalf("deleted user id survived in dispatched row: %s", payload)
+	}
+}
+
+func TestScrubOutboxUserRefs_RefusesEmptyUserID(t *testing.T) {
+	s := testStore(t)
+	tx, err := s.db.Begin()
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	defer tx.Rollback()
+	if err := s.ScrubOutboxUserRefsTx(tx, ""); err == nil {
+		t.Fatalf("ScrubOutboxUserRefsTx accepted an empty user id; it would LIKE-match every row")
+	}
+}
+
+// TestDeleteAccountAtomic_ScrubsOutbox is the WIRING test (CONVE-19): the
+// scrub is exercised through the public deletion entry point, not by calling
+// the helper directly — a helper that exists but is never called from
+// DeleteAccountAtomic passes every test above and still ships the bug this
+// task is about.
+func TestDeleteAccountAtomic_ScrubsOutbox(t *testing.T) {
+	s := testStore(t)
+	deleted, bystander := scrubTestUsers(t, s)
+	ws := createTestWorkspace(t, s, "Deletion scrub wiring")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+	item := createTestItem(t, s, ws.ID, col.ID, "Wired", "")
+	clearOutbox(t, s)
+
+	snap := assignItemSnapshot(t, s, item.ID, deleted.ID)
+	emitInTx(t, s, func(tx *sql.Tx) error {
+		if err := s.emitItemEventTx(tx, kernelevents.ItemUpdated, snap, nil, ""); err != nil {
+			return err
+		}
+		if err := s.emitMemberEventTx(tx, kernelevents.MemberJoined, ws.ID, deleted.ID, "editor", now()); err != nil {
+			return err
+		}
+		return s.emitMemberEventTx(tx, kernelevents.MemberJoined, ws.ID, bystander.ID, "viewer", now())
+	})
+
+	if err := s.DeleteAccountAtomic(deleted.ID, nil); err != nil {
+		t.Fatalf("DeleteAccountAtomic: %v", err)
+	}
+
+	// No payload and no subject_id anywhere in the outbox still names the
+	// deleted user — the deletion contract's erasure claim, asserted as the
+	// absence of the id in the BYTES rather than via any helper.
+	rows, err := s.db.Query(s.q(`SELECT COALESCE(subject_id, ''), payload FROM event_outbox`))
+	if err != nil {
+		t.Fatalf("query outbox: %v", err)
+	}
+	defer rows.Close()
+	total := 0
+	for rows.Next() {
+		var subject, payload string
+		if err := rows.Scan(&subject, &payload); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		total++
+		if subject == deleted.ID {
+			t.Fatalf("outbox subject_id still names the deleted user")
+		}
+		if strings.Contains(payload, deleted.ID) {
+			t.Fatalf("outbox payload still names the deleted user: %s", payload)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate: %v", err)
+	}
+	if total != 3 {
+		t.Fatalf("outbox rows = %d, want 3 (deletion must scrub, never delete rows)", total)
+	}
+	// Bystander's member row untouched.
+	if byPayload := rawOutboxPayload(t, s, bystander.ID, kernelevents.MemberJoined); !strings.Contains(byPayload, bystander.ID) {
+		t.Fatalf("bystander member payload damaged: %s", byPayload)
+	}
+}

--- a/internal/store/users.go
+++ b/internal/store/users.go
@@ -1017,6 +1017,16 @@ func (s *Store) DeleteAccountAtomic(userID string, ownedWorkspaceSlugs []string)
 		}
 	}
 
+	// 2b. Erase the user's id from frozen outbox payloads and subject_ids.
+	// The de-identify list above reaches LIVE rows only; outbox payloads froze
+	// the id at emit time and would otherwise keep it legible — in workspaces
+	// the user didn't own — until TASK-2714's retention window closes on the
+	// row. Dave's ruling on TASK-2719: "delete my account" means prompt
+	// erasure, not a bounded window.
+	if err := s.ScrubOutboxUserRefsTx(tx, userID); err != nil {
+		return fmt.Errorf("delete account: %w", err)
+	}
+
 	// 3. Delete rows the user owns or that are transient/audit. CASCADE cleans
 	// the dependents: member_collection_access (off workspace_members),
 	// share_link_views (off deleted share_links), oauth_connection_workspaces


### PR DESCRIPTION
## TASK-2719 — account deletion scrubs frozen outbox payloads

**Ruling (Dave, day-49):** "delete my account" means prompt erasure of the user's id from frozen outbox payloads, not a bounded retention window. **Lead ruling:** scrub uniformly (dispatched + undispatched), delete nothing; row lifecycle stays with TASK-2714 retention.

### What ships

- `ScrubOutboxUserRefsTx` (event_outbox.go), wired into `DeleteAccountAtomic` as step 2b, on the same transaction:
  - key-scoped, **value-matched** recursive payload rewrite — deletes `assigned_user_id` / `user_id` / `uploaded_by` where the value IS the deleted user's id, at any JSON depth (covers `item_batch` member nesting). Go, not SQL: payload is JSONB on PG / TEXT on SQLite, and one implementation beats two.
  - `subject_id` column nulled by value equality (member rows are the only user-subject rows).
  - per-row **compare-and-swap** rewrite with bounded retry: concurrent deletions sharing one bulk payload on PG READ COMMITTED would otherwise reintroduce each other's ids from stale reads (codex r1).
  - read-fully-then-write on the tx (BUG-2409 shape); refuses an empty user id (would LIKE-match every row).
- `scrubItemPII`'s emit-time keep of `assigned_user_id` is now marked SUPERSEDED at deletion time — winner named at both sites (lead condition).
- SPEC-3 parse condition verified: a scrubbed member row unmarshals cleanly (`user_id` absent → ""), the drain treats payloads as opaque bytes — tombstone branch not needed.
- Residual concurrent-emit window documented honestly (codex r1+r2): three PG-only escape paths (re-freeze without FK recheck; KEY SHARE ordering where the deletion waits; FK-less `attachments.uploaded_by`), all retention-bounded; closing them needs a table lock on a once-per-account path.

### Evidence

- Tests: per payload family + byte-identity bystander controls + subject-column-vs-payload separation + dispatched-scrubbed-not-deleted + key-scoping decoy + 2^53+1 `json.Number` pin + deterministic CAS-retry leg + CONVE-19 wiring test through `DeleteAccountAtomic` asserting id absence in raw bytes.
- Mutation matrix: **10/10 detected** (wiring drop, 3 key drops, subject-update drop, value-guard removal, dispatched skip, CAS→blind write, UseNumber drop, key-scope removal).
- Gates on tip 173fa2b9: `go test ./...` green (27 pkgs), `make test-pg` EXIT 0 (`internal/store` ok 329.8s), `make lint` 0 issues, gofmt clean. No go.mod change.
- Codex: 2 rounds, converged (r2: one P2 doc overclaim, fixed in 173fa2b9).

TASK-2719

https://claude.ai/code/session_01Cpr3teiHHsgcTmg2xhHA86
