### PR TITLE
fix(events): release SSE admission slots when a client leaves mid-establishment (BUG-2749)

### DIFF
--- a/cmd/pad/event_bus_wiring_test.go
+++ b/cmd/pad/event_bus_wiring_test.go
@@ -76,7 +76,7 @@ func TestBothEventBusShapesReportToMetrics(t *testing.T) {
 		// through this bus's own subscription — because that is the only path
 		// that fills a Redis bus's replay buffer, and driving the fan-out
 		// directly would skip the decode this shape depends on.
-		ch, _ := bus.Subscribe("ws-1")
+		ch, _, _ := bus.Subscribe(context.Background(), "ws-1")
 		t.Cleanup(func() { bus.Unsubscribe(ch) })
 		bus.Publish(events.Event{Type: events.ItemCreated, WorkspaceID: "ws-1"})
 

--- a/internal/events/bus.go
+++ b/internal/events/bus.go
@@ -1,6 +1,7 @@
 package events
 
 import (
+	"context"
 	"log/slog"
 	"sync"
 	"sync/atomic"
@@ -125,6 +126,51 @@ type Event struct {
 	Count int    `json:"count,omitempty"`
 }
 
+// SubscribeOutcome says how a Subscribe* call ended. It replaces the ok bool
+// those methods used to return, and it is an enum rather than an extra error
+// or a second bool because the distinction it carries is one a caller must not
+// be able to collapse by accident (BUG-2749).
+//
+// A REFUSAL AND A DEPARTURE ARE NOT THE SAME EVENT. The SSE handler answers a
+// refusal with 429 and logs it against the per-workspace limit; doing that for
+// a caller whose context was cancelled would write a limit refusal into the
+// logs and counters for a client that simply left, poisoning the one signal
+// anyone would use to tune those limits. Returning ok=false for both is what
+// made that conflation easy to write, so the shape no longer offers it: there
+// is no false to return, and a switch over this type has to name the case.
+type SubscribeOutcome int
+
+const (
+	// SubscribeOK means the subscriber is registered and its channel is live.
+	// It is the ONLY outcome for which the returned channel is non-nil, and
+	// therefore the only one whose caller owes an Unsubscribe.
+	SubscribeOK SubscribeOutcome = iota
+
+	// SubscribeWorkspaceLimit means maxPerWorkspace was already met, so no
+	// subscriber was registered. This is the old ok=false.
+	SubscribeWorkspaceLimit
+
+	// SubscribeCancelled means the CALLER's context ended before the
+	// subscription could be handed back, so any registration made along the
+	// way has been undone. Nothing is owed to the caller and nothing should
+	// be reported against it: it is not a refusal, not a resume this instance
+	// failed to serve, and not evidence about Redis.
+	SubscribeCancelled
+)
+
+func (o SubscribeOutcome) String() string {
+	switch o {
+	case SubscribeOK:
+		return "ok"
+	case SubscribeWorkspaceLimit:
+		return "workspace_limit"
+	case SubscribeCancelled:
+		return "cancelled"
+	default:
+		return "unknown"
+	}
+}
+
 // EventBus is the interface for pub/sub event distribution.
 // Implementations include MemoryBus (in-process) and RedisBus (cross-instance).
 type EventBus interface {
@@ -138,12 +184,18 @@ type EventBus interface {
 	// something is a silent under-delivery waiting for its first production
 	// caller (codex round 5). Every way of registering a subscriber hands
 	// back the same two things.
-	Subscribe(workspaceID string) (chan Event, <-chan struct{})
+	// ctx is the CALLER's lifetime, not the bus's. When it ends before the
+	// subscription is handed back, any registration made along the way is
+	// undone and the outcome is SubscribeCancelled — this is what stops a
+	// departed client's admission slot being held for the whole of
+	// establishment (BUG-2749).
+	Subscribe(ctx context.Context, workspaceID string) (chan Event, <-chan struct{}, SubscribeOutcome)
 
 	// SubscribeIfAllowed atomically checks the per-workspace subscriber
 	// limit and, only if it is satisfied, subscribes in the same critical
-	// section.  Returns (ch, true) on success or (nil, false) when the
-	// limit would be exceeded.  Pass 0 to disable it.
+	// section.  Returns SubscribeOK with a live channel, or
+	// SubscribeWorkspaceLimit and a nil channel when the limit would be
+	// exceeded.  Pass 0 to disable it.
 	//
 	// There is deliberately NO global limit here any more (BUG-2726). Pad
 	// serves two SSE endpoints backed by two different buses, and a held
@@ -168,7 +220,7 @@ type EventBus interface {
 	// closed, so a consumer may select on it for the subscription's whole
 	// life without the select spinning once the subscription ends; the event
 	// channel closing is the end-of-life signal.
-	SubscribeIfAllowed(workspaceID string, maxPerWorkspace int) (chan Event, <-chan struct{}, bool)
+	SubscribeIfAllowed(ctx context.Context, workspaceID string, maxPerWorkspace int) (chan Event, <-chan struct{}, SubscribeOutcome)
 
 	// SubscribeAndReplaySince atomically checks the per-workspace limit,
 	// registers the subscriber, and captures the buffered events above
@@ -187,7 +239,7 @@ type EventBus interface {
 	// sync_required. Callers must only interpret a nil missed that way when
 	// they actually passed a resuming cursor: sinceID <= 0 means "not
 	// resuming" and always yields a nil missed with nothing wrong.
-	SubscribeAndReplaySince(workspaceID string, sinceID int64, maxPerWorkspace int) (ch chan Event, missed []Event, gaps <-chan struct{}, ok bool)
+	SubscribeAndReplaySince(ctx context.Context, workspaceID string, sinceID int64, maxPerWorkspace int) (ch chan Event, missed []Event, gaps <-chan struct{}, outcome SubscribeOutcome)
 
 	// Unsubscribe removes a subscriber and closes its channel.
 	Unsubscribe(ch chan Event)
@@ -602,17 +654,32 @@ func NewWithReplay(bufferSize int, maxAge time.Duration) *MemoryBus {
 
 // Subscribe registers a new subscriber for the given workspace.
 // Returns a buffered channel that will receive events for that workspace.
-func (b *MemoryBus) Subscribe(workspaceID string) (chan Event, <-chan struct{}) {
+//
+// THE CONTEXT CANNOT BE OBSERVED MID-FLIGHT HERE, AND THAT IS NOT A GAP. This
+// bus does no I/O and never waits: it registers under one lock and returns, so
+// there is no window for a cancellation to arrive during. The check is
+// therefore at ENTRY only, and it exists so the two implementations agree on
+// what an already-dead caller gets back — a handler branch that only the Redis
+// build can reach is a branch nothing tests (BUG-2749).
+func (b *MemoryBus) Subscribe(ctx context.Context, workspaceID string) (chan Event, <-chan struct{}, SubscribeOutcome) {
+	if ctx.Err() != nil {
+		return nil, nil, SubscribeCancelled
+	}
+
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
 	sub := newSubscriber(workspaceID)
 	b.subscribers[sub.ch] = sub
-	return sub.ch, sub.gaps
+	return sub.ch, sub.gaps, SubscribeOK
 }
 
 // SubscribeIfAllowed atomically checks limits and subscribes.
-func (b *MemoryBus) SubscribeIfAllowed(workspaceID string, maxPerWorkspace int) (chan Event, <-chan struct{}, bool) {
+func (b *MemoryBus) SubscribeIfAllowed(ctx context.Context, workspaceID string, maxPerWorkspace int) (chan Event, <-chan struct{}, SubscribeOutcome) {
+	if ctx.Err() != nil {
+		return nil, nil, SubscribeCancelled
+	}
+
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
@@ -624,20 +691,26 @@ func (b *MemoryBus) SubscribeIfAllowed(workspaceID string, maxPerWorkspace int) 
 			}
 		}
 		if count >= maxPerWorkspace {
-			return nil, nil, false
+			return nil, nil, SubscribeWorkspaceLimit
 		}
 	}
 
 	sub := newSubscriber(workspaceID)
 	b.subscribers[sub.ch] = sub
-	return sub.ch, sub.gaps, true
+	return sub.ch, sub.gaps, SubscribeOK
 }
 
 // SubscribeAndReplaySince implements EventBus. See the interface for the
 // guarantee; the mechanism here is the lock order Publish documents — b.mu
 // exclusively, then b.replayMu, so no publish can be between its append and
 // its fan-out while this runs.
-func (b *MemoryBus) SubscribeAndReplaySince(workspaceID string, sinceID int64, maxPerWorkspace int) (chan Event, []Event, <-chan struct{}, bool) {
+func (b *MemoryBus) SubscribeAndReplaySince(ctx context.Context, workspaceID string, sinceID int64, maxPerWorkspace int) (chan Event, []Event, <-chan struct{}, SubscribeOutcome) {
+	if ctx.Err() != nil {
+		// Before the deferred resume-gap report is armed, deliberately: a
+		// caller that has gone is not a resume this instance failed to serve.
+		return nil, nil, nil, SubscribeCancelled
+	}
+
 	// Counted on the way out, with no lock held, and only for a caller that
 	// was actually resuming — mirroring EventsSince, whose own report this
 	// path bypasses because it reads the buffer directly.
@@ -664,7 +737,7 @@ func (b *MemoryBus) SubscribeAndReplaySince(workspaceID string, sinceID int64, m
 			// subscription that never happened: a refused connection is an
 			// admission event, not a resume this instance could not serve.
 			resuming = false
-			return nil, nil, nil, false
+			return nil, nil, nil, SubscribeWorkspaceLimit
 		}
 	}
 
@@ -677,7 +750,7 @@ func (b *MemoryBus) SubscribeAndReplaySince(workspaceID string, sinceID int64, m
 	if resuming {
 		missed = b.eventsSinceLocked(workspaceID, sinceID)
 	}
-	return sub.ch, missed, sub.gaps, true
+	return sub.ch, missed, sub.gaps, SubscribeOK
 }
 
 // Unsubscribe removes a subscriber and closes its channel.

--- a/internal/events/bus_test.go
+++ b/internal/events/bus_test.go
@@ -1,6 +1,7 @@
 package events
 
 import (
+	"context"
 	"sync"
 	"testing"
 	"time"
@@ -9,7 +10,7 @@ import (
 func TestSubscribeAndPublish(t *testing.T) {
 	bus := New()
 
-	ch, _ := bus.Subscribe("ws-1")
+	ch, _, _ := bus.Subscribe(context.Background(), "ws-1")
 	defer bus.Unsubscribe(ch)
 
 	bus.Publish(Event{
@@ -38,8 +39,8 @@ func TestSubscribeAndPublish(t *testing.T) {
 func TestWorkspaceIsolation(t *testing.T) {
 	bus := New()
 
-	ch1, _ := bus.Subscribe("ws-1")
-	ch2, _ := bus.Subscribe("ws-2")
+	ch1, _, _ := bus.Subscribe(context.Background(), "ws-1")
+	ch2, _, _ := bus.Subscribe(context.Background(), "ws-2")
 	defer bus.Unsubscribe(ch1)
 	defer bus.Unsubscribe(ch2)
 
@@ -69,9 +70,9 @@ func TestWorkspaceIsolation(t *testing.T) {
 func TestMultipleSubscribers(t *testing.T) {
 	bus := New()
 
-	ch1, _ := bus.Subscribe("ws-1")
-	ch2, _ := bus.Subscribe("ws-1")
-	ch3, _ := bus.Subscribe("ws-1")
+	ch1, _, _ := bus.Subscribe(context.Background(), "ws-1")
+	ch2, _, _ := bus.Subscribe(context.Background(), "ws-1")
+	ch3, _, _ := bus.Subscribe(context.Background(), "ws-1")
 	defer bus.Unsubscribe(ch1)
 	defer bus.Unsubscribe(ch2)
 	defer bus.Unsubscribe(ch3)
@@ -94,7 +95,7 @@ func TestMultipleSubscribers(t *testing.T) {
 func TestUnsubscribe(t *testing.T) {
 	bus := New()
 
-	ch, _ := bus.Subscribe("ws-1")
+	ch, _, _ := bus.Subscribe(context.Background(), "ws-1")
 	if bus.SubscriberCount() != 1 {
 		t.Fatalf("expected 1 subscriber, got %d", bus.SubscriberCount())
 	}
@@ -114,7 +115,7 @@ func TestUnsubscribe(t *testing.T) {
 func TestUnsubscribeIdempotent(t *testing.T) {
 	bus := New()
 
-	ch, _ := bus.Subscribe("ws-1")
+	ch, _, _ := bus.Subscribe(context.Background(), "ws-1")
 	bus.Unsubscribe(ch)
 	// Second unsubscribe should not panic
 	bus.Unsubscribe(ch)
@@ -123,7 +124,7 @@ func TestUnsubscribeIdempotent(t *testing.T) {
 func TestSlowConsumerDropsEvents(t *testing.T) {
 	bus := New()
 
-	ch, _ := bus.Subscribe("ws-1")
+	ch, _, _ := bus.Subscribe(context.Background(), "ws-1")
 	defer bus.Unsubscribe(ch)
 
 	// Overfill the channel buffer, so the drop path runs.
@@ -153,7 +154,7 @@ done:
 func TestTimestampAutoSet(t *testing.T) {
 	bus := New()
 
-	ch, _ := bus.Subscribe("ws-1")
+	ch, _, _ := bus.Subscribe(context.Background(), "ws-1")
 	defer bus.Unsubscribe(ch)
 
 	before := time.Now().UnixMilli()
@@ -171,7 +172,7 @@ func TestTimestampAutoSet(t *testing.T) {
 func TestTimestampPreserved(t *testing.T) {
 	bus := New()
 
-	ch, _ := bus.Subscribe("ws-1")
+	ch, _, _ := bus.Subscribe(context.Background(), "ws-1")
 	defer bus.Unsubscribe(ch)
 
 	ts := int64(1234567890)
@@ -197,7 +198,7 @@ func TestConcurrentAccess(t *testing.T) {
 		wg.Add(1)
 		go func(idx int) {
 			defer wg.Done()
-			channels[idx], _ = bus.Subscribe("ws-1")
+			channels[idx], _, _ = bus.Subscribe(context.Background(), "ws-1")
 		}(i)
 	}
 	wg.Wait()
@@ -239,9 +240,9 @@ func TestWorkspaceSubscriberCount(t *testing.T) {
 	}
 
 	// Subscribe to ws-1
-	ch1, _ := bus.Subscribe("ws-1")
-	ch2, _ := bus.Subscribe("ws-1")
-	ch3, _ := bus.Subscribe("ws-2")
+	ch1, _, _ := bus.Subscribe(context.Background(), "ws-1")
+	ch2, _, _ := bus.Subscribe(context.Background(), "ws-1")
+	ch3, _, _ := bus.Subscribe(context.Background(), "ws-2")
 
 	if got := bus.WorkspaceSubscriberCount("ws-1"); got != 2 {
 		t.Fatalf("expected 2 for ws-1, got %d", got)
@@ -278,7 +279,7 @@ func TestPublishNoSubscribers(t *testing.T) {
 
 func TestEventIDsAreMonotonic(t *testing.T) {
 	bus := New()
-	ch, _ := bus.Subscribe("ws-1")
+	ch, _, _ := bus.Subscribe(context.Background(), "ws-1")
 	defer bus.Unsubscribe(ch)
 
 	for i := 0; i < 10; i++ {

--- a/internal/events/gap_signal_test.go
+++ b/internal/events/gap_signal_test.go
@@ -1,6 +1,7 @@
 package events
 
 import (
+	"context"
 	"sync"
 	"testing"
 	"time"
@@ -25,12 +26,12 @@ func TestDropSignalsOnlyTheSubscriberItHappenedTo(t *testing.T) {
 	b := New()
 	defer b.Close()
 
-	slow, slowGaps, ok := b.SubscribeIfAllowed("ws-1", 0)
-	if !ok {
+	slow, slowGaps, outcome := b.SubscribeIfAllowed(context.Background(), "ws-1", 0)
+	if outcome != SubscribeOK {
 		t.Fatal("subscribe refused")
 	}
-	fast, fastGaps, ok := b.SubscribeIfAllowed("ws-1", 0)
-	if !ok {
+	fast, fastGaps, outcome := b.SubscribeIfAllowed(context.Background(), "ws-1", 0)
+	if outcome != SubscribeOK {
 		t.Fatal("subscribe refused")
 	}
 	defer b.Unsubscribe(slow)
@@ -70,8 +71,8 @@ func TestDropIsReportedToTheObserver(t *testing.T) {
 	obs := &recordingObserver{}
 	b.SetObserver(obs)
 
-	ch, _, ok := b.SubscribeIfAllowed("ws-1", 0)
-	if !ok {
+	ch, _, outcome := b.SubscribeIfAllowed(context.Background(), "ws-1", 0)
+	if outcome != SubscribeOK {
 		t.Fatal("subscribe refused")
 	}
 	defer b.Unsubscribe(ch)
@@ -133,8 +134,8 @@ func TestSubscribeAndReplayIsAtomic(t *testing.T) {
 		time.Sleep(20 * time.Millisecond)
 	}
 
-	ch, missed, _, ok := b.SubscribeAndReplaySince("ws-1", cursor, 0)
-	if !ok {
+	ch, missed, _, outcome := b.SubscribeAndReplaySince(context.Background(), "ws-1", cursor, 0)
+	if outcome != SubscribeOK {
 		t.Fatal("subscribe refused")
 	}
 	defer b.Unsubscribe(ch)
@@ -171,8 +172,8 @@ func TestTwoStepSubscribeThenReplayDuplicates(t *testing.T) {
 	b.Publish(Event{Type: ItemUpdated, WorkspaceID: "ws-1", ItemID: "before-1"})
 	cursor := b.EventsSince("ws-1", 0)[0].ID
 
-	ch, _, ok := b.SubscribeIfAllowed("ws-1", 0)
-	if !ok {
+	ch, _, outcome := b.SubscribeIfAllowed(context.Background(), "ws-1", 0)
+	if outcome != SubscribeOK {
 		t.Fatal("subscribe refused")
 	}
 	defer b.Unsubscribe(ch)
@@ -220,12 +221,12 @@ func drainContains(t *testing.T, ch chan Event, itemID string) bool {
 func TestRedisBusDropSignalsOnlyTheSubscriberItHappenedTo(t *testing.T) {
 	b := newTestRedisBus(t)
 
-	slow, slowGaps, ok := b.SubscribeIfAllowed("ws-1", 0)
-	if !ok {
+	slow, slowGaps, outcome := b.SubscribeIfAllowed(context.Background(), "ws-1", 0)
+	if outcome != SubscribeOK {
 		t.Fatal("subscribe refused")
 	}
-	fast, fastGaps, ok := b.SubscribeIfAllowed("ws-1", 0)
-	if !ok {
+	fast, fastGaps, outcome := b.SubscribeIfAllowed(context.Background(), "ws-1", 0)
+	if outcome != SubscribeOK {
 		t.Fatal("subscribe refused")
 	}
 	defer b.Unsubscribe(slow)
@@ -260,12 +261,12 @@ func TestRedisBusDropSignalsOnlyTheSubscriberItHappenedTo(t *testing.T) {
 func TestCoverageDropSignalsOnlyThatWorkspace(t *testing.T) {
 	b := newTestRedisBus(t)
 
-	affected, affectedGaps, ok := b.SubscribeIfAllowed("ws-1", 0)
-	if !ok {
+	affected, affectedGaps, outcome := b.SubscribeIfAllowed(context.Background(), "ws-1", 0)
+	if outcome != SubscribeOK {
 		t.Fatal("subscribe refused")
 	}
-	bystander, bystanderGaps, ok := b.SubscribeIfAllowed("ws-2", 0)
-	if !ok {
+	bystander, bystanderGaps, outcome := b.SubscribeIfAllowed(context.Background(), "ws-2", 0)
+	if outcome != SubscribeOK {
 		t.Fatal("subscribe refused")
 	}
 	defer b.Unsubscribe(affected)
@@ -296,12 +297,12 @@ func TestCoverageDropSignalsOnlyThatWorkspace(t *testing.T) {
 func TestIDSpaceResetSignalsEveryWorkspace(t *testing.T) {
 	b := newTestRedisBus(t)
 
-	one, oneGaps, ok := b.SubscribeIfAllowed("ws-1", 0)
-	if !ok {
+	one, oneGaps, outcome := b.SubscribeIfAllowed(context.Background(), "ws-1", 0)
+	if outcome != SubscribeOK {
 		t.Fatal("subscribe refused")
 	}
-	two, twoGaps, ok := b.SubscribeIfAllowed("ws-2", 0)
-	if !ok {
+	two, twoGaps, outcome := b.SubscribeIfAllowed(context.Background(), "ws-2", 0)
+	if outcome != SubscribeOK {
 		t.Fatal("subscribe refused")
 	}
 	defer b.Unsubscribe(one)
@@ -336,8 +337,8 @@ func TestCoverageDropWithNoBufferStillSignals(t *testing.T) {
 	obs := &recordingObserver{}
 	b.SetObserver(obs)
 
-	ch, gaps, ok := b.SubscribeIfAllowed("ws-1", 0)
-	if !ok {
+	ch, gaps, outcome := b.SubscribeIfAllowed(context.Background(), "ws-1", 0)
+	if outcome != SubscribeOK {
 		t.Fatal("subscribe refused")
 	}
 	defer b.Unsubscribe(ch)
@@ -404,8 +405,8 @@ func TestConcurrentPublishesDeliverInIDOrder(t *testing.T) {
 			b := New()
 			defer b.Close()
 
-			ch, _, ok := b.SubscribeIfAllowed("ws-1", 0)
-			if !ok {
+			ch, _, outcome := b.SubscribeIfAllowed(context.Background(), "ws-1", 0)
+			if outcome != SubscribeOK {
 				t.Fatal("subscribe refused")
 			}
 			defer b.Unsubscribe(ch)
@@ -478,8 +479,8 @@ func TestActivityGapSignalCoalesces(t *testing.T) {
 	b := New()
 	defer b.Close()
 
-	ch, gaps, ok := b.SubscribeIfAllowed("ws-1", 0)
-	if !ok {
+	ch, gaps, outcome := b.SubscribeIfAllowed(context.Background(), "ws-1", 0)
+	if outcome != SubscribeOK {
 		t.Fatal("subscribe refused")
 	}
 	defer b.Unsubscribe(ch)
@@ -507,7 +508,7 @@ func TestRedisBusSubscribeAndReplayIsAtomic(t *testing.T) {
 	// A holder first: this bus builds a workspace's replay buffer as part of
 	// COVERING it, and a resume against a workspace it has never covered is
 	// answered "cannot vouch" — correctly, and not what this test is about.
-	holder, _ := b.Subscribe("ws-1")
+	holder, _, _ := b.Subscribe(context.Background(), "ws-1")
 	defer b.Unsubscribe(holder)
 
 	b.fanOutLocally(Event{ID: 10, Type: ItemUpdated, WorkspaceID: "ws-1", ItemID: "before-1"})
@@ -531,8 +532,8 @@ func TestRedisBusSubscribeAndReplayIsAtomic(t *testing.T) {
 		time.Sleep(20 * time.Millisecond)
 	}
 
-	ch, missed, gaps, ok := b.SubscribeAndReplaySince("ws-1", 10, 0)
-	if !ok {
+	ch, missed, gaps, outcome := b.SubscribeAndReplaySince(context.Background(), "ws-1", 10, 0)
+	if outcome != SubscribeOK {
 		t.Fatal("subscribe refused")
 	}
 	defer b.Unsubscribe(ch)
@@ -566,18 +567,18 @@ func TestResumeIsSubjectToTheWorkspaceLimit(t *testing.T) {
 	b := New()
 	defer b.Close()
 
-	first, _, ok := b.SubscribeIfAllowed("ws-1", 1)
-	if !ok {
+	first, _, outcome := b.SubscribeIfAllowed(context.Background(), "ws-1", 1)
+	if outcome != SubscribeOK {
 		t.Fatal("the first subscribe was refused")
 	}
 	defer b.Unsubscribe(first)
 
-	if _, _, _, ok := b.SubscribeAndReplaySince("ws-1", 1, 1); ok {
+	if _, _, _, outcome := b.SubscribeAndReplaySince(context.Background(), "ws-1", 1, 1); outcome != SubscribeWorkspaceLimit {
 		t.Error("a resuming client was admitted past the per-workspace limit")
 	}
 	// Control: the same call succeeds when there is room, so the refusal above
 	// is the limit and not the method being broken.
-	if _, _, _, ok := b.SubscribeAndReplaySince("ws-1", 1, 2); !ok {
+	if _, _, _, outcome := b.SubscribeAndReplaySince(context.Background(), "ws-1", 1, 2); outcome != SubscribeOK {
 		t.Error("a resuming client was refused with room to spare")
 	}
 }
@@ -593,8 +594,8 @@ func TestAtomicResumeReportsAnUnservableSpan(t *testing.T) {
 	b.SetObserver(obs)
 
 	// A cursor for a workspace this process has never published to.
-	ch, missed, _, ok := b.SubscribeAndReplaySince("ws-unknown", b.base+9999, 0)
-	if !ok {
+	ch, missed, _, outcome := b.SubscribeAndReplaySince(context.Background(), "ws-unknown", b.base+9999, 0)
+	if outcome != SubscribeOK {
 		t.Fatal("subscribe refused")
 	}
 	defer b.Unsubscribe(ch)
@@ -609,8 +610,8 @@ func TestAtomicResumeReportsAnUnservableSpan(t *testing.T) {
 	// this leg the report could fire on every subscribe and still pass.
 	obs2 := &recordingObserver{}
 	b.SetObserver(obs2)
-	ch2, _, _, ok := b.SubscribeAndReplaySince("ws-unknown", 0, 0)
-	if !ok {
+	ch2, _, _, outcome := b.SubscribeAndReplaySince(context.Background(), "ws-unknown", 0, 0)
+	if outcome != SubscribeOK {
 		t.Fatal("subscribe refused")
 	}
 	defer b.Unsubscribe(ch2)
@@ -629,12 +630,12 @@ func TestRedisBusDropIsReportedPerSubscriber(t *testing.T) {
 	obs := &recordingObserver{}
 	b.SetObserver(obs)
 
-	slowA, _, ok := b.SubscribeIfAllowed("ws-1", 0)
-	if !ok {
+	slowA, _, outcome := b.SubscribeIfAllowed(context.Background(), "ws-1", 0)
+	if outcome != SubscribeOK {
 		t.Fatal("subscribe refused")
 	}
-	slowB, _, ok := b.SubscribeIfAllowed("ws-1", 0)
-	if !ok {
+	slowB, _, outcome := b.SubscribeIfAllowed(context.Background(), "ws-1", 0)
+	if outcome != SubscribeOK {
 		t.Fatal("subscribe refused")
 	}
 	defer b.Unsubscribe(slowA)
@@ -669,8 +670,8 @@ func TestGapChannelOutlivesUnsubscribe(t *testing.T) {
 	b := New()
 	defer b.Close()
 
-	ch, gaps, ok := b.SubscribeIfAllowed("ws-1", 0)
-	if !ok {
+	ch, gaps, outcome := b.SubscribeIfAllowed(context.Background(), "ws-1", 0)
+	if outcome != SubscribeOK {
 		t.Fatal("subscribe refused")
 	}
 	b.Unsubscribe(ch)
@@ -692,14 +693,15 @@ func TestGapChannelOutlivesUnsubscribe(t *testing.T) {
 func TestEverySubscribeAPIReturnsAGapChannel(t *testing.T) {
 	for name, sub := range map[string]func(b *MemoryBus) (chan Event, <-chan struct{}){
 		"Subscribe": func(b *MemoryBus) (chan Event, <-chan struct{}) {
-			return b.Subscribe("ws-1")
+			ch, gaps, _ := b.Subscribe(context.Background(), "ws-1")
+			return ch, gaps
 		},
 		"SubscribeIfAllowed": func(b *MemoryBus) (chan Event, <-chan struct{}) {
-			ch, gaps, _ := b.SubscribeIfAllowed("ws-1", 0)
+			ch, gaps, _ := b.SubscribeIfAllowed(context.Background(), "ws-1", 0)
 			return ch, gaps
 		},
 		"SubscribeAndReplaySince": func(b *MemoryBus) (chan Event, <-chan struct{}) {
-			ch, _, gaps, _ := b.SubscribeAndReplaySince("ws-1", 0, 0)
+			ch, _, gaps, _ := b.SubscribeAndReplaySince(context.Background(), "ws-1", 0, 0)
 			return ch, gaps
 		},
 	} {

--- a/internal/events/idspace_test.go
+++ b/internal/events/idspace_test.go
@@ -1,6 +1,7 @@
 package events
 
 import (
+	"context"
 	"sync"
 	"testing"
 )
@@ -37,7 +38,7 @@ func publishN(b *MemoryBus, workspaceID string, n int) []int64 {
 // actually assigned.
 func publishTyped(b *MemoryBus, workspaceID string, types ...string) []int64 {
 	ids := make([]int64, 0, len(types))
-	ch, _ := b.Subscribe(workspaceID)
+	ch, _, _ := b.Subscribe(context.Background(), workspaceID)
 	defer b.Unsubscribe(ch)
 	for _, typ := range types {
 		b.Publish(Event{Type: typ, WorkspaceID: workspaceID})

--- a/internal/events/redis_bus.go
+++ b/internal/events/redis_bus.go
@@ -540,11 +540,39 @@ type RedisBus struct {
 	// outright is the ordinary timeout path. With this seam: 10 of 10.
 	beforeUnconfirmedMark func()
 
+	// afterRegisterBeforeEstablish is a TEST SEAM, nil in production. It runs
+	// in subscribeAndReplay after section 1 has registered the subscriber and
+	// (if this caller is the establisher) created the establishment record,
+	// and BEFORE the establish loop runs.
+	//
+	// POSITIONAL, like its siblings (BUG-2749). It exists to place a
+	// cancellation in the one window where the caller OWNS an establishment
+	// record it has not yet begun — the window in which an early return
+	// strands every later subscriber for that workspace. A test that cannot
+	// land a cancellation exactly here cannot tell that regression from a
+	// correct abandon. Receives the workspace.
+	afterRegisterBeforeEstablish func(workspaceID string)
+
 	// beforeInstallSubscription is a TEST SEAM, nil in production. It runs in
 	// establishSubscription after the dial and BEFORE the lock that decides
 	// whether to install or abandon, so a test can make either abandon reason
 	// true at exactly the moment the decision is taken. Receives the workspace.
 	beforeInstallSubscription func(workspaceID string)
+
+	// afterInstallSubscription is a TEST SEAM, nil in production. It runs in
+	// establishSubscription once the subscription is INSTALLED and its receive
+	// loop started, and BEFORE the acknowledgement wait begins.
+	//
+	// ITS VALUE IS ENTIRELY POSITIONAL (BUG-2749), the same way
+	// afterSubscribeRegister's is. The two cancellation cases this unit has to
+	// separate — before the install and during the wait — differ only in where
+	// the caller's context dies relative to this exact point, and a test that
+	// cannot place a cancellation on the far side of it is testing whichever
+	// case the scheduler happened to produce. If the install and the wait are
+	// ever restructured, this call moves with that boundary or the tests named
+	// for the after-install case silently stop exercising it. Receives the
+	// workspace.
+	afterInstallSubscription func(workspaceID string)
 
 	// publishEpoch selects the wire form this instance EMITS: the phase-2
 	// "<epoch>|<id>|<json>" prefix when true, the historical bare JSON body
@@ -680,16 +708,19 @@ func NewRedisBusWithKeys(client *redis.Client, keys redisns.Keys, publishEpoch b
 // Subscribe registers a local subscriber for the given workspace.
 // Starts a Redis subscription for the workspace if this is the first local
 // subscriber, and waits for Redis to acknowledge it before returning. The wait
-// is bounded: past confirmTimeout it returns anyway, counted and logged, and the
-// subscriber is told to reconcile when the acknowledgement lands.
+// is bounded twice over: past confirmTimeout it returns anyway, counted and
+// logged, with the subscriber told to reconcile when the acknowledgement
+// lands; and if ctx ends first it returns SubscribeCancelled having undone its
+// registration, leaving the rest of the wait to run for any joiners
+// (BUG-2749).
 //
 // NO PRODUCTION CALLER, verified repo-wide: the SSE handler reaches
 // SubscribeIfAllowed or SubscribeAndReplaySince. It is interface surface and
 // test surface, routed through the same path as the other two so it cannot
 // drift into being the one door with the old semantics.
-func (b *RedisBus) Subscribe(workspaceID string) (chan Event, <-chan struct{}) {
-	ch, _, gaps, _ := b.subscribeAndReplay(workspaceID, 0, 0)
-	return ch, gaps
+func (b *RedisBus) Subscribe(ctx context.Context, workspaceID string) (chan Event, <-chan struct{}, SubscribeOutcome) {
+	ch, _, gaps, outcome := b.subscribeAndReplay(ctx, workspaceID, 0, 0)
+	return ch, gaps, outcome
 }
 
 // addSubscriberLocked registers a channel for a workspace and bumps its local
@@ -714,9 +745,9 @@ func (b *RedisBus) addSubscriberLocked(workspaceID string) *subscriber {
 // NOTE: the limit is enforced against local (per-pod) subscriber counts
 // only. In multi-replica deployments the effective cap is multiplied by
 // the number of replicas — as is every other streaming limit Pad has.
-func (b *RedisBus) SubscribeIfAllowed(workspaceID string, maxPerWorkspace int) (chan Event, <-chan struct{}, bool) {
-	ch, _, gaps, ok := b.subscribeAndReplay(workspaceID, 0, maxPerWorkspace)
-	return ch, gaps, ok
+func (b *RedisBus) SubscribeIfAllowed(ctx context.Context, workspaceID string, maxPerWorkspace int) (chan Event, <-chan struct{}, SubscribeOutcome) {
+	ch, _, gaps, outcome := b.subscribeAndReplay(ctx, workspaceID, 0, maxPerWorkspace)
+	return ch, gaps, outcome
 }
 
 // SubscribeAndReplaySince implements EventBus. See the interface for the
@@ -727,8 +758,8 @@ func (b *RedisBus) SubscribeIfAllowed(workspaceID string, maxPerWorkspace int) (
 // to live channels. So an event is either fully applied before this call's
 // critical section (in the buffer, not on the new channel) or entirely after
 // it (on the channel, replay already read) — never both, never neither.
-func (b *RedisBus) SubscribeAndReplaySince(workspaceID string, sinceID int64, maxPerWorkspace int) (chan Event, []Event, <-chan struct{}, bool) {
-	return b.subscribeAndReplay(workspaceID, sinceID, maxPerWorkspace)
+func (b *RedisBus) SubscribeAndReplaySince(ctx context.Context, workspaceID string, sinceID int64, maxPerWorkspace int) (chan Event, []Event, <-chan struct{}, SubscribeOutcome) {
+	return b.subscribeAndReplay(ctx, workspaceID, sinceID, maxPerWorkspace)
 }
 
 // subscribeAndReplay is the single body behind all three Subscribe* entry
@@ -759,7 +790,22 @@ func (b *RedisBus) SubscribeAndReplaySince(workspaceID string, sinceID int64, ma
 // so events arriving in the gap were skipped by fan-out and never replayed —
 // dropped outright. Found by codex round 1; keeping the note because the
 // mechanism was locally coherent and the failure was one call path over.
-func (b *RedisBus) subscribeAndReplay(workspaceID string, sinceID int64, maxPerWorkspace int) (chan Event, []Event, <-chan struct{}, bool) {
+func (b *RedisBus) subscribeAndReplay(ctx context.Context, workspaceID string, sinceID int64, maxPerWorkspace int) (chan Event, []Event, <-chan struct{}, SubscribeOutcome) {
+	if ctx.Err() != nil {
+		// Checked before the deferred resume-gap report is armed: a caller
+		// that has already gone is not a resume this instance failed to serve.
+		//
+		// THIS IS THE ONLY EARLY EXIT, deliberately. An earlier draft paired it
+		// with a cancellation break at the top of the establish loop, which
+		// the mutation matrix could only detect when BOTH were removed — and
+		// codex round 2 then found why: the loop-top one could exit while
+		// still owning an unretired establishment record, stranding the next
+		// subscriber forever. It is gone. Past this point a cancelled caller
+		// is unwound by the code that owns the thing being unwound, never by
+		// jumping over it.
+		return nil, nil, nil, SubscribeCancelled
+	}
+
 	// Reported on the way out with the lock released, and only for a caller
 	// that was actually resuming. See the MemoryBus twin.
 	var missed []Event
@@ -777,7 +823,7 @@ func (b *RedisBus) subscribeAndReplay(workspaceID string, sinceID int64, maxPerW
 		// counter's population.
 		resuming = false
 		b.mu.Unlock()
-		return nil, nil, nil, false
+		return nil, nil, nil, SubscribeWorkspaceLimit
 	}
 
 	sub := b.addSubscriberLocked(workspaceID)
@@ -813,6 +859,10 @@ func (b *RedisBus) subscribeAndReplay(workspaceID string, sinceID int64, maxPerW
 	}
 	b.mu.Unlock()
 
+	if b.afterRegisterBeforeEstablish != nil {
+		b.afterRegisterBeforeEstablish(workspaceID)
+	}
+
 	// A JOINER VERIFIES RATHER THAN ASSUMES, and may take the establishment
 	// over once (codex round 2, P1). Waiting on someone else's record proves
 	// only that they FINISHED — not that they succeeded.
@@ -839,6 +889,35 @@ func (b *RedisBus) subscribeAndReplay(workspaceID string, sinceID int64, maxPerW
 	// the emptied-workspace race it lost cannot recur, and any remaining
 	// failure is one a third pass would not fix either.
 	for attempt := range 2 {
+		// NO CANCELLATION CHECK AT THE TOP OF THIS LOOP, and its absence is
+		// load-bearing (BUG-2749, codex round 2 P1).
+		//
+		// An earlier version broke out of the loop here when the caller's
+		// context had ended. On attempt 0 that is a STRAND: section 1 may
+		// already have created this workspace's establishment record and named
+		// us the establisher, and breaking here leaves that record in
+		// pendingSubs with nobody behind it — never retired, its done channel
+		// never closed. The next subscriber for the workspace joins it and
+		// waits forever, and because its own registration keeps wsCounts
+		// non-zero, no later caller establishes either. That is exactly the
+		// permanent silently-dead stream the establishment record exists to
+		// prevent, reintroduced by a guard meant to save a dial.
+		//
+		// A cancelled establisher therefore goes THROUGH establishSubscription,
+		// which is the only code that knows how to put the record down: it
+		// deregisters the departed establisher and abandons-and-retires in one
+		// critical section, or installs for whatever joiners arrived. The dial
+		// it pays for is on the caller's context and aborts at once.
+		//
+		// Retries are guarded instead where the decision is actually made —
+		// see the ctx.Err() term in the re-decide below, which stops a
+		// departed caller MINTING a fresh record rather than abandoning one it
+		// already owns. That term is an OPTIMISATION, not a correctness
+		// guard, and the mutation matrix is what says so: removing it survives
+		// every test here, because a departed caller that does mint a second
+		// record still establishes, still deregisters itself in the deciding
+		// section, and still abandons and retires. It saves a pointless dial
+		// on a path that should already be rare, and nothing more.
 		if attempt > 0 {
 			// Re-decide, and note that the record is created HERE, at the top
 			// of an iteration that is going to use it — never as a trailing
@@ -848,7 +927,7 @@ func (b *RedisBus) subscribeAndReplay(workspaceID string, sinceID int64, maxPerW
 			b.mu.Lock()
 			_, live := b.wsSubs[workspaceID]
 			establish, pending = false, nil
-			if !live && b.ctx.Err() == nil {
+			if !live && b.ctx.Err() == nil && ctx.Err() == nil {
 				if p, inFlight := b.pendingSubs[workspaceID]; inFlight {
 					pending = p
 				} else {
@@ -867,7 +946,7 @@ func (b *RedisBus) subscribeAndReplay(workspaceID string, sinceID int64, maxPerW
 
 		switch {
 		case establish:
-			b.establishSubscription(workspaceID, pending)
+			b.establishSubscription(ctx, workspaceID, sub, pending)
 		case pending != nil:
 			// Someone else is establishing the same workspace. Wait for them
 			// rather than opening a second connection and a second receive
@@ -875,11 +954,29 @@ func (b *RedisBus) subscribeAndReplay(workspaceID string, sinceID int64, maxPerW
 			select {
 			case <-pending.done:
 			case <-b.ctx.Done():
+			case <-ctx.Done():
 			}
 		default:
 			// Already live when we registered: nothing to establish and
 			// nothing to wait for.
 		}
+	}
+
+	// CANCELLATION IS DEREGISTRATION, and everything else falls out of that
+	// (BUG-2749). wsCounts already answers "is anyone still here"; a caller
+	// whose context ended is someone who is not, so the fix is to stop being
+	// counted rather than to add machinery that hands establishment over.
+	//
+	// Unsubscribe is safe to call even when establishSubscription already did
+	// it under its own deciding lock — it returns early on a channel it no
+	// longer holds — so neither path has to know what the other did. And when
+	// this IS the removal that takes the workspace to zero, its existing
+	// count-to-zero branch stops the Redis subscription, so an establishment
+	// completed for a caller who left does not outlive them.
+	if ctx.Err() != nil {
+		b.Unsubscribe(sub.ch)
+		resuming = false
+		return nil, nil, nil, SubscribeCancelled
 	}
 
 	b.mu.Lock()
@@ -890,7 +987,7 @@ func (b *RedisBus) subscribeAndReplay(workspaceID string, sinceID int64, maxPerW
 	if resuming {
 		missed = b.eventsSinceMarkLocked(workspaceID, sinceID, mark)
 	}
-	return sub.ch, missed, sub.gaps, true
+	return sub.ch, missed, sub.gaps, SubscribeOK
 }
 
 // registrationMark records where a workspace's replay buffer stood when a
@@ -937,7 +1034,22 @@ func (b *RedisBus) eventsSinceMarkLocked(workspaceID string, sinceID int64, mark
 func (b *RedisBus) Unsubscribe(ch chan Event) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
+	b.unsubscribeLocked(ch)
+}
 
+// unsubscribeLocked is Unsubscribe's body, split out so a caller that is
+// already inside a critical section can deregister a subscriber without
+// releasing the lock (BUG-2749: establishSubscription must apply a departed
+// establisher's removal in the SAME section that reads wsCounts to decide
+// whether to abandon).
+//
+// IT IS IDEMPOTENT BY THE workspaceOf LOOKUP, which is what lets the
+// cancellation path call Unsubscribe unconditionally afterwards without
+// either side tracking what the other did — a second call finds no entry and
+// returns before it can double-close the channel.
+//
+// Callers must hold b.mu.
+func (b *RedisBus) unsubscribeLocked(ch chan Event) {
 	wsID, ok := b.workspaceOf[ch]
 	if !ok {
 		return
@@ -1162,7 +1274,9 @@ func (b *RedisBus) WorkspaceSubscriberCount(workspaceID string) int {
 }
 
 // establishSubscription opens a workspace's Redis subscription and does not
-// return until Redis has acknowledged it (or the bound expires).
+// return until Redis has acknowledged it, the bound expires, or the CALLER's
+// context ends — in which case the remainder of the wait is handed to a
+// goroutine and this returns at once (BUG-2749).
 //
 // MUST BE CALLED WITHOUT b.mu HELD. That is the whole of BUG-2748: this
 // function's first statement dials a fresh TCP connection, runs go-redis's
@@ -1170,14 +1284,47 @@ func (b *RedisBus) WorkspaceSubscriberCount(workspaceID string) int {
 // used to happen inside the bus's single global mutex — per workspace, since
 // each client.Subscribe mints a PubSub whose connection starts nil. A Redis
 // whose route blackholes packets stalled that dial for the client's
-// DialTimeout (5s by default, and NOT bounded by the context we pass), and
-// for that whole time no other workspace could subscribe, unsubscribe, close,
-// or receive a fanned-out event.
+// DialTimeout (5s by default; since BUG-2749 the CALLER's context can cut that
+// short on a plaintext connection, but not under TLS — see
+// defaultSubscribeConfirmTimeout), and for that whole time no other workspace
+// could subscribe, unsubscribe, close, or receive a fanned-out event.
 //
 // Exactly one caller per workspace reaches here; the rest wait on pending.
-func (b *RedisBus) establishSubscription(workspaceID string, pending *pendingSub) {
+func (b *RedisBus) establishSubscription(ctx context.Context, workspaceID string, establisher *subscriber, pending *pendingSub) {
 	channel := b.keys.Name(redisChannelSuffix) + workspaceID
-	pubsub := b.client.Subscribe(b.ctx, channel)
+	// DIALLED ON THE CALLER'S CONTEXT *AND* THE BUS'S, so a client that leaves
+	// mid-dial stops paying for it (BUG-2749) without taking away Close()'s
+	// ability to interrupt the same dial (codex round 2 P2).
+	//
+	// Passing only the caller's context regressed shutdown: b.ctx used to be
+	// what cut a stalled dial short when the bus closed, and a caller who
+	// stays connected through a shutdown would have left the dial running to
+	// DialTimeout with nothing able to stop it. Either ending is a reason to
+	// abandon, so the dial waits on both.
+	dialCtx, cancelDial := mergeCancellation(ctx, b.ctx)
+	defer cancelDial()
+	//
+	// WHAT THIS DOES AND DOES NOT BOUND, checked in go-redis v9.22.0 rather
+	// than inferred from its doc comment — which says Subscribe "does not wait
+	// on a response from Redis" and so reads as though no dial happens here at
+	// all. It does: Client.Subscribe -> PubSub.Subscribe -> subscribe ->
+	// conn(ctx) dials when there is no connection yet, then writes the
+	// SUBSCRIBE command. Only the REPLY is unawaited.
+	//
+	//   - Plaintext: dialConn derives its attempt context from the one passed
+	//     in (internal/pool/pool.go, "Apply DialTimeout per attempt, but never
+	//     extend an existing earlier deadline") and the default dialer is
+	//     net.Dialer.DialContext, which honours it. Cancellation aborts the
+	//     dial.
+	//   - TLS: the same dialer returns tls.DialWithDialer(netDialer, ...)
+	//     (options.go), which takes NO context. Under TLS the dial is bounded
+	//     by DialTimeout alone and cancellation cannot shorten it.
+	//
+	// So on a TLS deployment this shrinks the held slot from (dial + confirm
+	// bound) to (dial), not to zero. That residual is real and is why the
+	// cancellation check below is repeated after the dial rather than assumed
+	// to have fired during it.
+	pubsub := b.client.Subscribe(dialCtx, channel)
 	subCtx, subCancel := context.WithCancel(b.ctx)
 
 	if b.beforeInstallSubscription != nil {
@@ -1207,6 +1354,23 @@ func (b *RedisBus) establishSubscription(workspaceID string, pending *pendingSub
 	// keep, and returns with a channel wired to nothing — permanently, because
 	// its own registration makes wsCounts non-zero so no later caller
 	// establishes either.
+	// THE ESTABLISHER'S OWN DEPARTURE IS APPLIED BEFORE THE COUNT IS READ, in
+	// this same section (BUG-2749). The count below is the arbiter for "is
+	// anyone still here", and while we were dialling the answer may have
+	// become no — but only if the caller that opened this establishment stops
+	// being counted first. Removing it after the read would install a
+	// subscription and a receive loop for nobody; removing it in a separate
+	// section would let a joiner arrive in between and be counted against a
+	// decision already taken.
+	//
+	// Note what this deliberately does NOT do: it does not abandon because the
+	// establisher left. If joiners registered while we dialled, wsCounts is
+	// still non-zero and the subscription is installed for them, which is the
+	// hand-off the filing asked about — expressed as a count rather than as a
+	// transfer of ownership.
+	if ctx.Err() != nil {
+		b.unsubscribeLocked(establisher.ch)
+	}
 	if b.wsCounts[workspaceID] == 0 || b.ctx.Err() != nil {
 		b.retirePendingLocked(workspaceID, pending)
 		b.mu.Unlock()
@@ -1232,20 +1396,82 @@ func (b *RedisBus) establishSubscription(workspaceID string, pending *pendingSub
 	// very window this function exists to close.
 	go b.receiveMessages(subCtx, pubsub, workspaceID, gen)
 
+	if b.afterInstallSubscription != nil {
+		b.afterInstallSubscription(workspaceID)
+	}
+
 	timer := time.NewTimer(b.confirmTimeout)
-	defer timer.Stop()
 	select {
 	case <-sub.confirmed:
 	case <-b.ctx.Done():
+	case <-ctx.Done():
+		// A CANCELLED ESTABLISHER OWES ITS JOINERS THE REST OF THE WAIT, and
+		// this is the one thing it genuinely does owe them (BUG-2749).
+		//
+		// Not the connection: that is installed above with its receive loop
+		// running, and wsCounts already decides its fate. What cannot simply
+		// be dropped is the WAIT, because finishPending is what releases the
+		// joiners and the acknowledgement is what makes their stream
+		// honest. Returning here and closing pending.done inline would admit
+		// every joiner into a subscription Redis has not acknowledged, telling
+		// them nothing — which is precisely the defect BUG-2747 exists to
+		// close, re-created for the joiner population at the seam between the
+		// two designs.
+		//
+		// So the REMAINDER of the wait moves to a goroutine and finishes
+		// exactly as this caller would have: same three arms, same
+		// markUnconfirmedAdmission on the bound, same finishPending. Only the
+		// caller's context is dropped, because the caller is who left.
+		//
+		// It is bounded by confirmTimeout and needs no reaper: if the departing
+		// establisher was the last subscriber, its Unsubscribe stops the
+		// subscription, and this waiter then falls through to the bound and
+		// finds no wsSubs entry — markUnconfirmedAdmission's gen/liveness guard
+		// makes that a no-op rather than a spurious count.
+		go func() {
+			defer timer.Stop()
+			select {
+			case <-sub.confirmed:
+			case <-b.ctx.Done():
+			case <-timer.C:
+				b.markUnconfirmedAdmission(workspaceID, gen)
+			}
+			if b.afterSubscriptionConfirmed != nil {
+				b.afterSubscriptionConfirmed()
+			}
+			b.finishPending(workspaceID, pending)
+		}()
+		return
 	case <-timer.C:
 		b.markUnconfirmedAdmission(workspaceID, gen)
 	}
+	timer.Stop()
 
 	if b.afterSubscriptionConfirmed != nil {
 		b.afterSubscriptionConfirmed()
 	}
 
 	b.finishPending(workspaceID, pending)
+}
+
+// mergeCancellation returns a context that ends when EITHER input does.
+//
+// It exists because the dial has two legitimate reasons to be abandoned that
+// live in different places: the caller going away (BUG-2749) and the bus
+// closing (BUG-2748's teardown). Deriving from one and ignoring the other
+// silently drops half the shutdown story, which is how the second one was lost
+// in this unit's first draft.
+//
+// The returned cancel must be called to release the AfterFunc registration on
+// the second context; not calling it keeps that registration alive for as long
+// as the second context does.
+func mergeCancellation(primary, also context.Context) (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(primary)
+	stop := context.AfterFunc(also, cancel)
+	return ctx, func() {
+		stop()
+		cancel()
+	}
 }
 
 // finishPending retires a workspace's establishment record and releases every
@@ -1839,11 +2065,19 @@ const stragglerWindow = 30 * time.Second
 // IT BOUNDS THE ACKNOWLEDGEMENT, NOT THE WHOLE OF ESTABLISHMENT (codex round
 // 7). The dial and go-redis's HELLO/AUTH handshake happen inside
 // client.Subscribe, before this timer starts, and they are bounded by the
-// CLIENT's DialTimeout — 5s by default, and not by any context we pass. So a
-// stalled dial followed by this wait composes to roughly DialTimeout + this,
-// and anyone reasoning about worst-case connect latency needs both numbers.
-// BUG-2749 carries the same arithmetic for the admission slot that is held
-// across it.
+// CLIENT's DialTimeout — 5s by default. So a stalled dial followed by this
+// wait composes to roughly DialTimeout + this, and anyone reasoning about
+// worst-case connect latency needs both numbers.
+//
+// AMENDED BY BUG-2749 on the context half, which this comment used to state
+// flatly as "not by any context we pass". Since that unit the dial runs on the
+// CALLER's context, and go-redis derives its per-attempt dial deadline from it
+// — so on plaintext a caller that goes away no longer waits out DialTimeout.
+// Under TLS it still does: the default dialer hands a TLS connection to
+// tls.DialWithDialer, which takes no context at all. The composed worst case
+// above is therefore unchanged for a client that STAYS, and unchanged for a
+// TLS deployment whose client leaves; it shrinks only for a departing client
+// on a plaintext connection. See BUG-2754 for the TLS half.
 //
 // SHORT BECAUSE THE DISTRIBUTION HAS NO MIDDLE, not as a guess at how fast
 // Redis is. Establishment either completes in single-digit milliseconds or does

--- a/internal/events/redis_generation_guard_test.go
+++ b/internal/events/redis_generation_guard_test.go
@@ -471,7 +471,7 @@ func TestACollidingRepairIsCaughtBySequenceRatherThanEpoch(t *testing.T) {
 	epochKey := redisns.Default.Name(redisEpochSuffix)
 	ctx := context.Background()
 
-	ch, _ := b.Subscribe("ws-1")
+	ch, _, _ := b.Subscribe(context.Background(), "ws-1")
 	defer b.Unsubscribe(ch)
 
 	waitFor := func(n int) {

--- a/internal/events/redis_idspace_test.go
+++ b/internal/events/redis_idspace_test.go
@@ -262,7 +262,7 @@ func TestTheDedupeTokenMakesARetriedPublishANoOp(t *testing.T) {
 // than through the anySubscription escape hatch.
 func liveGen(t *testing.T, b *RedisBus, workspaceID string) (chan Event, int64) {
 	t.Helper()
-	ch, _ := b.Subscribe(workspaceID)
+	ch, _, _ := b.Subscribe(context.Background(), workspaceID)
 	t.Cleanup(func() { b.Unsubscribe(ch) })
 	return ch, b.currentSubGen(workspaceID)
 }
@@ -664,7 +664,7 @@ func TestAPrefixedPayloadReachesReconciliationThroughTheRealReceivePath(t *testi
 	// never run in production.
 	b, mr := newFlippedRedisBus(t)
 
-	ch, _ := b.Subscribe("ws-1")
+	ch, _, _ := b.Subscribe(context.Background(), "ws-1")
 	defer b.Unsubscribe(ch)
 	// Subscribe() returns before Redis has REGISTERED the subscription. It
 	// does write the SUBSCRIBE command synchronously, but it does not wait
@@ -907,7 +907,7 @@ func TestAnUndecodableMessageEndsThatWorkspacesCoverage(t *testing.T) {
 	obs := &recordingObserver{}
 	b.SetObserver(obs)
 
-	ch, _ := b.Subscribe("ws-1")
+	ch, _, _ := b.Subscribe(context.Background(), "ws-1")
 	defer b.Unsubscribe(ch)
 	// See TestAPrefixedPayloadReachesReconciliationThroughTheRealReceivePath:
 	// publishing before the subscription is registered loses the event for
@@ -1011,9 +1011,9 @@ func TestAMixedPhaseDeploymentDeliversBothWays(t *testing.T) {
 
 	// Both are subscribed to the same workspace, as two replicas serving
 	// clients would be.
-	ch1, _ := phase1.Subscribe("ws-1")
+	ch1, _, _ := phase1.Subscribe(context.Background(), "ws-1")
 	defer phase1.Unsubscribe(ch1)
-	ch2, _ := phase2.Subscribe("ws-1")
+	ch2, _, _ := phase2.Subscribe(context.Background(), "ws-1")
 	defer phase2.Unsubscribe(ch2)
 	// BOTH must be registered before anything is published: this test's whole
 	// claim is that each replica sees the other's events, and a publish that
@@ -1155,7 +1155,7 @@ func TestAPayloadThatDecodesButIsNotOurEventEndsCoverage(t *testing.T) {
 			obs := &recordingObserver{}
 			b.SetObserver(obs)
 
-			ch, _ := b.Subscribe("ws-1")
+			ch, _, _ := b.Subscribe(context.Background(), "ws-1")
 			defer b.Unsubscribe(ch)
 			// Registration before the first publish — see BUG-2742 and the
 			// note on TestAPrefixedPayloadReachesReconciliation...

--- a/internal/events/redis_namespace_test.go
+++ b/internal/events/redis_namespace_test.go
@@ -1,6 +1,7 @@
 package events
 
 import (
+	"context"
 	"strings"
 	"testing"
 	"time"
@@ -33,7 +34,7 @@ func TestRedisBusHonoursTheNamespace(t *testing.T) {
 	// A local subscriber is what starts the Redis-side subscription for
 	// this workspace, so the channel assertions below have something to
 	// observe.
-	ch, _ := b.Subscribe("ws-1")
+	ch, _, _ := b.Subscribe(context.Background(), "ws-1")
 	defer b.Unsubscribe(ch)
 	// This test only reads KEYS, which the publish writes whether or not
 	// anyone is listening — so it does not NEED the wait. It is here because
@@ -158,7 +159,7 @@ func TestRedisBusDefaultKeepsHistoricalKeys(t *testing.T) {
 	b := NewRedisBus(client)
 	t.Cleanup(b.Close)
 
-	ch, _ := b.Subscribe("ws-1")
+	ch, _, _ := b.Subscribe(context.Background(), "ws-1")
 	defer b.Unsubscribe(ch)
 	// Not needed for the key assertions below; present so the pattern a
 	// reader copies from here is the safe one. See the twin above.

--- a/internal/events/redis_reconnect_test.go
+++ b/internal/events/redis_reconnect_test.go
@@ -1,6 +1,7 @@
 package events
 
 import (
+	"context"
 	"io"
 	"net"
 	"sync"
@@ -86,7 +87,7 @@ func TestAResubscriptionEndsThisInstancesCoverage(t *testing.T) {
 	obs := &recordingObserver{}
 	b.SetObserver(obs)
 
-	ch, _ := b.Subscribe("ws-1")
+	ch, _, _ := b.Subscribe(context.Background(), "ws-1")
 	defer b.Unsubscribe(ch)
 	waitForSubscribers(t, mr, "pad:events:ws-1", true)
 
@@ -178,7 +179,7 @@ func TestAReconnectOnAnIdleWorkspaceIsNotAReset(t *testing.T) {
 
 	// Subscribed, but nothing has ever been published here, so there is no
 	// replay buffer for this workspace.
-	ch, _ := b.Subscribe("ws-idle")
+	ch, _, _ := b.Subscribe(context.Background(), "ws-idle")
 	defer b.Unsubscribe(ch)
 	waitForSubscribers(t, mr, "pad:events:ws-idle", true)
 
@@ -261,7 +262,7 @@ func TestTheReceiveLoopExitIsReported(t *testing.T) {
 	obs := &recordingObserver{}
 	b.SetObserver(obs)
 
-	ch, _ := b.Subscribe("ws-1")
+	ch, _, _ := b.Subscribe(context.Background(), "ws-1")
 	waitForSubscribers(t, mr, "pad:events:ws-1", true)
 
 	// Control: a live subscription's loop has not exited.
@@ -295,14 +296,14 @@ func TestAStaleGoroutineCannotDropTheReplacementBuffer(t *testing.T) {
 	obs := &recordingObserver{}
 	b.SetObserver(obs)
 
-	ch, _ := b.Subscribe("ws-1")
+	ch, _, _ := b.Subscribe(context.Background(), "ws-1")
 	oldGen := b.currentSubGen("ws-1")
 
 	// Everyone leaves: subscription torn down, buffer gone.
 	b.Unsubscribe(ch)
 
 	// A viewer returns and the workspace starts buffering again.
-	ch2, _ := b.Subscribe("ws-1")
+	ch2, _, _ := b.Subscribe(context.Background(), "ws-1")
 	defer b.Unsubscribe(ch2)
 	newGen := b.currentSubGen("ws-1")
 	if newGen == oldGen {

--- a/internal/events/redis_resume_coverage_test.go
+++ b/internal/events/redis_resume_coverage_test.go
@@ -1,6 +1,7 @@
 package events
 
 import (
+	"context"
 	"testing"
 
 	"github.com/alicebob/miniredis/v2"
@@ -24,7 +25,7 @@ func newTestRedisBus(t *testing.T) *RedisBus {
 func TestBufferIsDroppedWhenTheWorkspaceSubscriptionStops(t *testing.T) {
 	b := newTestRedisBus(t)
 
-	ch, _ := b.Subscribe("ws-1")
+	ch, _, _ := b.Subscribe(context.Background(), "ws-1")
 	// Events arrive from Redis while we are covering the workspace.
 	b.fanOutLocally(Event{ID: 98, Type: ItemUpdated, WorkspaceID: "ws-1"})
 	b.fanOutLocally(Event{ID: 100, Type: ItemUpdated, WorkspaceID: "ws-1"})
@@ -54,7 +55,7 @@ func TestBufferIsDroppedWhenTheWorkspaceSubscriptionStops(t *testing.T) {
 func TestAStragglerAfterUnsubscribeDoesNotRebuildTheBuffer(t *testing.T) {
 	b := newTestRedisBus(t)
 
-	ch, _ := b.Subscribe("ws-1")
+	ch, _, _ := b.Subscribe(context.Background(), "ws-1")
 	b.fanOutLocally(Event{ID: 100, Type: ItemUpdated, WorkspaceID: "ws-1"})
 	b.Unsubscribe(ch)
 
@@ -70,7 +71,7 @@ func TestAStragglerAfterUnsubscribeDoesNotRebuildTheBuffer(t *testing.T) {
 	// And the negative control that keeps this honest: once the workspace is
 	// genuinely subscribed again, coverage restarts and resumes from the new
 	// first-seen id onward are served normally.
-	ch2, _ := b.Subscribe("ws-1")
+	ch2, _, _ := b.Subscribe(context.Background(), "ws-1")
 	defer b.Unsubscribe(ch2)
 	b.fanOutLocally(Event{ID: 600, Type: ItemUpdated, WorkspaceID: "ws-1"})
 
@@ -95,9 +96,9 @@ func TestAStragglerAfterUnsubscribeDoesNotRebuildTheBuffer(t *testing.T) {
 func TestBufferSurvivesWhileAnyLocalSubscriberRemains(t *testing.T) {
 	b := newTestRedisBus(t)
 
-	ch1, _ := b.Subscribe("ws-1")
+	ch1, _, _ := b.Subscribe(context.Background(), "ws-1")
 	defer b.Unsubscribe(ch1)
-	ch2, _ := b.Subscribe("ws-1")
+	ch2, _, _ := b.Subscribe(context.Background(), "ws-1")
 
 	b.fanOutLocally(Event{ID: 100, Type: ItemUpdated, WorkspaceID: "ws-1"})
 	b.Unsubscribe(ch2)
@@ -119,7 +120,7 @@ func TestBufferSurvivesWhileAnyLocalSubscriberRemains(t *testing.T) {
 func TestAStragglerFromAnEndedSubscriptionCannotVouchForTheNewOne(t *testing.T) {
 	b := newTestRedisBus(t)
 
-	ch, _ := b.Subscribe("ws-1")
+	ch, _, _ := b.Subscribe(context.Background(), "ws-1")
 	oldGen := b.currentSubGen("ws-1")
 	b.fanOutFromRedis(oldGen, 0, Event{ID: 100, Type: ItemUpdated, WorkspaceID: "ws-1"})
 
@@ -127,7 +128,7 @@ func TestAStragglerFromAnEndedSubscriptionCannotVouchForTheNewOne(t *testing.T) 
 	b.Unsubscribe(ch)
 
 	// A new client arrives and the workspace is subscribed again.
-	ch2, _ := b.Subscribe("ws-1")
+	ch2, _, _ := b.Subscribe(context.Background(), "ws-1")
 	defer b.Unsubscribe(ch2)
 	newGen := b.currentSubGen("ws-1")
 	if newGen == oldGen {

--- a/internal/events/redis_subscribe_cancel_test.go
+++ b/internal/events/redis_subscribe_cancel_test.go
@@ -1,0 +1,571 @@
+package events
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+)
+
+// BUG-2749: a client that disconnects while its workspace's Redis
+// subscription is being established used to hold both admission slots — the
+// process-wide one in internal/server and the per-workspace one here — for the
+// whole of the dial plus the acknowledgement bound. The connection was gone;
+// the capacity was not.
+//
+// The fix is a RULE rather than a mechanism: cancellation is deregistration,
+// and wsCounts — which already answers "is anyone still here" — decides
+// everything downstream of that. These tests pin the two cancellation
+// positions separately, because they take different paths through
+// establishSubscription and only one of them owes the joiners anything.
+
+// newCancelTestBus is newTestRedisBus plus the miniredis handle, which these
+// tests need in order to assert about the SERVER's view of the subscription
+// rather than only the bus's own bookkeeping.
+func newCancelTestBus(t *testing.T) (*RedisBus, *miniredis.Miniredis) {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+	b := NewRedisBus(client)
+	t.Cleanup(b.Close)
+	return b, mr
+}
+
+func (b *RedisBus) pendingCount() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return len(b.pendingSubs)
+}
+
+func (b *RedisBus) hasWorkspaceSub(workspaceID string) bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	_, ok := b.wsSubs[workspaceID]
+	return ok
+}
+
+// TestCancelBeforeInstallReleasesTheSlotAndInstallsNothing is the pre-install
+// half: the caller's context dies after the dial has returned but BEFORE the
+// section that decides whether to install, so that decision finds an
+// establisher who is no longer there.
+//
+// It is deliberately not a test of cancellation DURING the dial. The seam it
+// uses runs once client.Subscribe has returned, and a test that genuinely
+// stalled a TCP connect would be testing the operating system's accept
+// backlog. The dial's own binding to the caller's context is pinned separately
+// and structurally by TestTheDialUsesTheCallersContext.
+//
+// THE ASSERTION IS ABOUT WHAT WAS LEFT BEHIND, not about the return value
+// alone (CONVE-12). A bus that returned SubscribeCancelled and still installed
+// a subscription would satisfy a return-value check while leaking exactly the
+// connection and receive loop this unit is about, so the subscriber count, the
+// wsSubs entry, the establishment record and miniredis's own subscriber count
+// are all pinned.
+//
+// Fails before the fix: the context is not consulted at all, so this returns a
+// live subscription with the workspace count at 1.
+func TestCancelBeforeInstallReleasesTheSlotAndInstallsNothing(t *testing.T) {
+	b, mr := newCancelTestBus(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	b.beforeInstallSubscription = func(string) { cancel() }
+
+	ch, gaps, outcome := b.SubscribeIfAllowed(ctx, "ws-1", 0)
+
+	if outcome != SubscribeCancelled {
+		t.Fatalf("outcome = %v, want SubscribeCancelled", outcome)
+	}
+	if ch != nil || gaps != nil {
+		t.Error("a cancelled subscribe handed back channels; nothing is owed to a caller that left")
+	}
+	if n := b.WorkspaceSubscriberCount("ws-1"); n != 0 {
+		t.Errorf("workspace subscriber count = %d, want 0 — the per-workspace slot is still held", n)
+	}
+	if b.hasWorkspaceSub("ws-1") {
+		t.Error("a Redis subscription was installed for a caller that had already gone")
+	}
+	if n := b.pendingCount(); n != 0 {
+		t.Errorf("pendingSubs = %d, want 0 — an establishment record outlived its establisher, and the next caller will wait on it forever", n)
+	}
+	if n, ok := pollSubscriberCount(mr, "pad:events:ws-1", func(n int) bool { return n == 0 }); !ok {
+		t.Errorf("miniredis still reports %d subscriber(s) on the channel; the connection or its receive loop was left behind", n)
+	}
+}
+
+// TestCancelDuringConfirmationTearsDownWhenNobodyElseIsWaiting is the
+// post-install half with no joiner. The subscription IS installed by the time
+// the context dies — the install deliberately precedes the wait — so the
+// cancellation path has to reach it through the ordinary count-to-zero
+// teardown rather than by abandoning.
+//
+// Fails before the fix: the wait runs to its bound, the caller is handed a
+// live subscription, and both slots stay held for the whole of it.
+func TestCancelDuringConfirmationTearsDownWhenNobodyElseIsWaiting(t *testing.T) {
+	mr := miniredis.RunT(t)
+	// The SUBSCRIBE is parked in flight, so the acknowledgement cannot arrive
+	// and the wait is genuinely running when the cancellation lands. Parking
+	// the command rather than delaying the client's write is what makes this
+	// the production shape — see subscribeDelayProxy.
+	proxy := newSubscribeDelayProxy(t, mr.Addr(), 2*time.Second)
+	client := redis.NewClient(&redis.Options{Addr: proxy.addr()})
+	t.Cleanup(func() { _ = client.Close() })
+
+	b := NewRedisBus(client)
+	t.Cleanup(b.Close)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancelled on the FAR side of the install, which is what separates this
+	// test from the one above. See afterInstallSubscription.
+	b.afterInstallSubscription = func(string) { cancel() }
+
+	start := time.Now()
+	ch, _, outcome := b.SubscribeIfAllowed(ctx, "ws-1", 0)
+	elapsed := time.Since(start)
+
+	if outcome != SubscribeCancelled {
+		t.Fatalf("outcome = %v, want SubscribeCancelled", outcome)
+	}
+	if ch != nil {
+		t.Error("a cancelled subscribe handed back a channel")
+	}
+	// The point of the unit: the caller stops paying for a wait it will never
+	// use. The bound is the bus's own confirmTimeout (1s by default), so
+	// anything close to it means the cancellation was not observed.
+	if elapsed >= b.confirmTimeout {
+		t.Errorf("subscribe took %v, which is at or past the %v confirmation bound — the slot was held for the whole wait", elapsed, b.confirmTimeout)
+	}
+	if n := b.WorkspaceSubscriberCount("ws-1"); n != 0 {
+		t.Errorf("workspace subscriber count = %d, want 0", n)
+	}
+	if b.hasWorkspaceSub("ws-1") {
+		t.Error("the subscription outlived its only subscriber")
+	}
+	// PREMISE, POLLED RATHER THAN READ ONCE. The proxy parks the command on
+	// its own goroutine, and the client's write returns as soon as the bytes
+	// are gone — that asynchrony is the whole design of this instrument — so a
+	// single read here can run before the park is recorded and fail a test
+	// whose subject behaved correctly.
+	deadline := time.Now().Add(3 * time.Second)
+	for proxy.held.Load() == 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("the proxy never parked a SUBSCRIBE, so this test never entered the window it is named for")
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+// TestCancelledEstablisherStillFinishesTheWaitForItsJoiners is the joint
+// between this unit's design and BUG-2747's, which is where a third bug would
+// live.
+//
+// A joiner waits on the establisher's record. If a cancelled establisher
+// simply closed that record and returned, every joiner would be released into
+// a subscription Redis has not acknowledged and told NOTHING about it — which
+// is precisely the silent under-delivery BUG-2747 exists to close, re-created
+// for the joiner population. So the cancelled establisher hands the REMAINDER
+// of the wait to a goroutine, and the joiner's honesty signal must survive its
+// departure.
+//
+// ASSERTS ITS OWN PREMISE: the joiner is confirmed to have been WAITING (the
+// workspace count reaches two while the establishment is still in flight)
+// before the cancellation is fired. Without that, a joiner that arrived after
+// everything settled would pass this test while proving nothing.
+func TestCancelledEstablisherStillFinishesTheWaitForItsJoiners(t *testing.T) {
+	mr := miniredis.RunT(t)
+	// Parked for longer than the confirmation bound below, so the hand-off
+	// runs into the bound and must mark the admission unconfirmed — the state
+	// that later becomes the joiner's sync_required.
+	proxy := newSubscribeDelayProxy(t, mr.Addr(), 3*time.Second)
+	client := redis.NewClient(&redis.Options{Addr: proxy.addr()})
+	t.Cleanup(func() { _ = client.Close() })
+
+	b := NewRedisBus(client)
+	t.Cleanup(b.Close)
+	b.confirmTimeout = 200 * time.Millisecond
+
+	unconfirmed := make(chan struct{}, 1)
+	b.beforeUnconfirmedMark = func() {
+		select {
+		case unconfirmed <- struct{}{}:
+		default:
+		}
+	}
+
+	type joinResult struct {
+		ch      chan Event
+		gaps    <-chan struct{}
+		outcome SubscribeOutcome
+	}
+	joined := make(chan joinResult, 1)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	b.beforeInstallSubscription = func(string) {
+		// Launched here so it finds the establishment record already in the
+		// map and genuinely waits on it.
+		go func() {
+			ch, gaps, outcome := b.SubscribeIfAllowed(context.Background(), "ws-1", 0)
+			joined <- joinResult{ch, gaps, outcome}
+		}()
+	}
+	b.afterInstallSubscription = func(string) {
+		// Premise check: do not cancel until the joiner is registered and
+		// waiting, or this test proves nothing about joiners.
+		deadline := time.Now().Add(3 * time.Second)
+		for b.WorkspaceSubscriberCount("ws-1") < 2 {
+			if time.Now().After(deadline) {
+				t.Error("the joiner never registered; this test never exercised the joiner path")
+				break
+			}
+			time.Sleep(time.Millisecond)
+		}
+		cancel()
+	}
+
+	_, _, outcome := b.SubscribeIfAllowed(ctx, "ws-1", 0)
+	if outcome != SubscribeCancelled {
+		t.Fatalf("establisher outcome = %v, want SubscribeCancelled", outcome)
+	}
+
+	var jr joinResult
+	select {
+	case jr = <-joined:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the joiner never returned — a cancelled establisher stranded it on a promise nobody kept")
+	}
+
+	if jr.outcome != SubscribeOK {
+		t.Fatalf("joiner outcome = %v, want SubscribeOK — the joiner did not leave, and must still be served", jr.outcome)
+	}
+	if jr.ch == nil || jr.gaps == nil {
+		t.Fatal("the joiner was released with no channel behind it")
+	}
+	defer b.Unsubscribe(jr.ch)
+
+	// The hand-off's whole purpose: the wait completed on the joiner's behalf,
+	// so the admission was MARKED unconfirmed rather than passing silently.
+	select {
+	case <-unconfirmed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the confirmation wait was abandoned with the establisher: the joiner was admitted into an unacknowledged subscription and told nothing (BUG-2747's defect, re-created at the seam)")
+	}
+
+	// And it reaches the joiner as a reconcile signal once the acknowledgement
+	// finally lands.
+	select {
+	case <-jr.gaps:
+	case <-time.After(10 * time.Second):
+		t.Error("the joiner was never told to reconcile after the late acknowledgement")
+	}
+}
+
+// TestCancelledJoinerLeavesTheEstablisherAlone is the mirror case: the caller
+// that leaves is a WAITER, not the establisher. It must stop being counted
+// without disturbing an establishment that is still someone else's.
+func TestCancelledJoinerLeavesTheEstablisherAlone(t *testing.T) {
+	mr := miniredis.RunT(t)
+	proxy := newSubscribeDelayProxy(t, mr.Addr(), 300*time.Millisecond)
+	client := redis.NewClient(&redis.Options{Addr: proxy.addr()})
+	t.Cleanup(func() { _ = client.Close() })
+
+	b := NewRedisBus(client)
+	t.Cleanup(b.Close)
+
+	joinerCtx, cancelJoiner := context.WithCancel(context.Background())
+	joined := make(chan SubscribeOutcome, 1)
+
+	b.beforeInstallSubscription = func(string) {
+		go func() {
+			_, _, outcome := b.SubscribeIfAllowed(joinerCtx, "ws-1", 0)
+			joined <- outcome
+		}()
+		// Wait for the joiner to be registered and waiting, then send it away.
+		deadline := time.Now().Add(3 * time.Second)
+		for b.WorkspaceSubscriberCount("ws-1") < 2 {
+			if time.Now().After(deadline) {
+				t.Error("the joiner never registered; this test never exercised the joiner path")
+				break
+			}
+			time.Sleep(time.Millisecond)
+		}
+		cancelJoiner()
+	}
+
+	ch, _, outcome := b.SubscribeIfAllowed(context.Background(), "ws-1", 0)
+	if outcome != SubscribeOK {
+		t.Fatalf("establisher outcome = %v, want SubscribeOK — a joiner leaving must not refuse the establisher", outcome)
+	}
+	defer b.Unsubscribe(ch)
+
+	select {
+	case got := <-joined:
+		if got != SubscribeCancelled {
+			t.Errorf("joiner outcome = %v, want SubscribeCancelled", got)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("the cancelled joiner never returned")
+	}
+
+	if n := b.WorkspaceSubscriberCount("ws-1"); n != 1 {
+		t.Errorf("workspace subscriber count = %d, want 1 (the establisher only) — the departed joiner's slot is still held", n)
+	}
+	if !b.hasWorkspaceSub("ws-1") {
+		t.Error("the joiner's departure tore down the establisher's subscription")
+	}
+}
+
+// TestAnAlreadyCancelledCallerRegistersNothing covers the cheap entry case on
+// both implementations, so the handler's cancellation branch is reachable
+// without Redis.
+//
+// THE END STATE ALONE CANNOT SEE THIS GUARD (CONVE-12). Remove the entry check
+// and a dead caller still ends up with SubscribeCancelled and a zero count —
+// it just registers, establishes a whole Redis subscription, and then undoes
+// all of it on the way out. So the Redis leg asserts what the missing guard
+// would DO rather than what it leaves behind: an establishment attempt that
+// should never have been started.
+func TestAnAlreadyCancelledCallerRegistersNothing(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	t.Run("MemoryBus", func(t *testing.T) {
+		b := New()
+		defer b.Close()
+		if _, _, outcome := b.SubscribeIfAllowed(ctx, "ws-1", 0); outcome != SubscribeCancelled {
+			t.Fatalf("outcome = %v, want SubscribeCancelled", outcome)
+		}
+		if n := b.WorkspaceSubscriberCount("ws-1"); n != 0 {
+			t.Errorf("workspace subscriber count = %d, want 0", n)
+		}
+	})
+
+	t.Run("RedisBus", func(t *testing.T) {
+		b, _ := newCancelTestBus(t)
+		attempted := make(chan struct{}, 1)
+		b.beforeInstallSubscription = func(string) {
+			select {
+			case attempted <- struct{}{}:
+			default:
+			}
+		}
+
+		if _, _, _, outcome := b.SubscribeAndReplaySince(ctx, "ws-1", 5, 0); outcome != SubscribeCancelled {
+			t.Fatalf("outcome = %v, want SubscribeCancelled", outcome)
+		}
+		if n := b.WorkspaceSubscriberCount("ws-1"); n != 0 {
+			t.Errorf("workspace subscriber count = %d, want 0", n)
+		}
+		select {
+		case <-attempted:
+			t.Error("a caller that was already gone still opened a Redis subscription; the entry guard is what stops the dial happening at all")
+		default:
+		}
+	})
+}
+
+// TestTheDialUsesTheCallersContext is a WIRING assertion (CONVE-19): the
+// timing benefit of dialling on the caller's context cannot be observed
+// against a Redis that answers instantly, so this pins the BINDING instead of
+// the duration.
+//
+// It matters because the binding is the whole of what the dial half of this
+// fix does, and it is invisible to every other test here — they all cancel at
+// seams that run after the dial has returned.
+//
+// WHAT IT DOES NOT CLAIM: that cancellation actually shortens a real dial.
+// go-redis derives its per-attempt dial deadline from the context passed in
+// and the default dialer is net.Dialer.DialContext, so it does on plaintext;
+// under TLS the same dialer calls tls.DialWithDialer, which takes no context
+// at all, and there the dial stays bounded by DialTimeout alone. That residual
+// is documented on establishSubscription and is not tested here.
+func TestTheDialUsesTheCallersContext(t *testing.T) {
+	mr := miniredis.RunT(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// ASSERTED FROM INSIDE THE DIALER, because the context handed to the dial
+	// is scoped to establishment and is released as soon as it returns —
+	// inspecting it afterwards would find it Done no matter what it was
+	// derived from, which is a check that cannot fail.
+	var (
+		observedLive   bool
+		observedClosed bool
+		dialled        = make(chan struct{}, 1)
+	)
+	client := redis.NewClient(&redis.Options{
+		Addr: mr.Addr(),
+		Dialer: func(dialCtx context.Context, network, addr string) (net.Conn, error) {
+			select {
+			case dialled <- struct{}{}:
+				// The control: live before the caller is cancelled. Without it
+				// a dial handed an already-dead context would satisfy the
+				// check below for the wrong reason.
+				observedLive = dialCtx.Err() == nil
+				cancel()
+				observedClosed = dialCtx.Err() != nil
+			default:
+			}
+			return (&net.Dialer{}).DialContext(context.Background(), "tcp", mr.Addr())
+		},
+	})
+	t.Cleanup(func() { _ = client.Close() })
+
+	b := NewRedisBus(client)
+	t.Cleanup(b.Close)
+
+	ch, _, outcome := b.SubscribeIfAllowed(ctx, "ws-1", 0)
+	if ch != nil {
+		defer b.Unsubscribe(ch)
+	}
+	_ = outcome
+
+	select {
+	case <-dialled:
+	default:
+		t.Fatal("no dial was observed; this test never exercised the path it is named for")
+	}
+	if !observedLive {
+		t.Fatal("the dial context was already done before the caller was cancelled")
+	}
+	if !observedClosed {
+		t.Error("cancelling the caller did not end the dial's context: the dial is not derived from the caller, so a client leaving mid-dial goes on paying for it")
+	}
+}
+
+// TestACancelledEstablisherNeverStrandsTheNextSubscriber is the regression test
+// for the sharpest failure this unit can produce, and the one its filing named
+// in advance: a caller that owns a workspace's establishment record and returns
+// without putting it down.
+//
+// The record stays in pendingSubs with nobody behind it. The next subscriber
+// for that workspace joins it and waits on a done channel nothing will ever
+// close — permanently, because its own registration keeps wsCounts non-zero, so
+// no later caller becomes an establisher either. A silently dead stream that
+// looks alive.
+//
+// THE CANCELLATION IS PLACED IN THE OWNING WINDOW, between the record's
+// creation and the start of establishment (see afterRegisterBeforeEstablish).
+// Cancelling anywhere else exercises a path that unwinds correctly anyway, and
+// would pass against the defect.
+//
+// Fails against the draft that broke out of the establish loop on a cancelled
+// context: the second subscriber below never returns.
+func TestACancelledEstablisherNeverStrandsTheNextSubscriber(t *testing.T) {
+	b, _ := newCancelTestBus(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var once sync.Once
+	b.afterRegisterBeforeEstablish = func(string) {
+		// Only the first caller — the one that owns the record.
+		once.Do(cancel)
+	}
+
+	if _, _, outcome := b.SubscribeIfAllowed(ctx, "ws-1", 0); outcome != SubscribeCancelled {
+		t.Fatalf("establisher outcome = %v, want SubscribeCancelled", outcome)
+	}
+
+	// Premise: the establisher really did own a record to put down. Without
+	// this the test would pass against a build where the first caller never
+	// became the establisher at all, proving nothing about strands.
+	if n := b.pendingCount(); n != 0 {
+		t.Fatalf("pendingSubs = %d after a cancelled establisher, want 0 — the record was left with nobody behind it", n)
+	}
+	if n := b.WorkspaceSubscriberCount("ws-1"); n != 0 {
+		t.Fatalf("workspace subscriber count = %d, want 0", n)
+	}
+
+	// The consequence, asserted from the next subscriber's side rather than
+	// from the map: a strand is only a bug because of what it does to them.
+	done := make(chan SubscribeOutcome, 1)
+	go func() {
+		ch, _, outcome := b.SubscribeIfAllowed(context.Background(), "ws-1", 0)
+		if ch != nil {
+			b.Unsubscribe(ch)
+		}
+		done <- outcome
+	}()
+
+	select {
+	case outcome := <-done:
+		if outcome != SubscribeOK {
+			t.Errorf("next subscriber outcome = %v, want SubscribeOK", outcome)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("the next subscriber never returned: it is waiting on an establishment record the cancelled establisher abandoned without retiring")
+	}
+}
+
+// TestClosingTheBusStillEndsAnInFlightDial pins the half of the dial's context
+// that BUG-2749 nearly removed (codex round 2 P2).
+//
+// Before this unit the dial ran on the bus's own context, so Close() could cut
+// a stalled one short. Routing it to the caller instead would have handed that
+// power away: a caller who stays connected across a shutdown would leave the
+// dial running to DialTimeout with nothing able to interrupt it. The dial waits
+// on both, and this asserts the bus half specifically — the caller's context
+// here is never cancelled.
+func TestClosingTheBusStillEndsAnInFlightDial(t *testing.T) {
+	mr := miniredis.RunT(t)
+
+	var (
+		b              *RedisBus
+		observedLive   bool
+		observedClosed bool
+		dialled        = make(chan struct{}, 1)
+	)
+	client := redis.NewClient(&redis.Options{
+		Addr: mr.Addr(),
+		Dialer: func(dialCtx context.Context, network, addr string) (net.Conn, error) {
+			select {
+			case dialled <- struct{}{}:
+				observedLive = dialCtx.Err() == nil
+				// The bus shuts down mid-dial. The CALLER's context is never
+				// cancelled in this test, so only the bus half can end this.
+				b.cancel()
+				// The bus half arrives through context.AfterFunc, which runs
+				// its callback on its own goroutine — so this is polled, not
+				// read once.
+				deadline := time.Now().Add(3 * time.Second)
+				for {
+					if dialCtx.Err() != nil {
+						observedClosed = true
+						break
+					}
+					if time.Now().After(deadline) {
+						break
+					}
+					time.Sleep(time.Millisecond)
+				}
+			default:
+			}
+			return (&net.Dialer{}).DialContext(context.Background(), "tcp", mr.Addr())
+		},
+	})
+	t.Cleanup(func() { _ = client.Close() })
+
+	b = NewRedisBus(client)
+	t.Cleanup(b.Close)
+
+	ch, _, _ := b.SubscribeIfAllowed(context.Background(), "ws-1", 0)
+	if ch != nil {
+		b.Unsubscribe(ch)
+	}
+
+	select {
+	case <-dialled:
+	default:
+		t.Fatal("no dial was observed; this test never exercised the path it is named for")
+	}
+	if !observedLive {
+		t.Fatal("the dial context was already done before the bus was closed")
+	}
+	if !observedClosed {
+		t.Error("shutting the bus down did not end the dial's context: a shutdown can no longer interrupt a stalled dial, which it could before this unit")
+	}
+}

--- a/internal/events/redis_subscribe_confirm_test.go
+++ b/internal/events/redis_subscribe_confirm_test.go
@@ -113,8 +113,8 @@ func TestSubscribeDoesNotReturnBeforeRedisHasRegisteredIt(t *testing.T) {
 	b := NewRedisBus(client)
 	t.Cleanup(b.Close)
 
-	ch, _, ok := b.SubscribeIfAllowed("ws-1", 0)
-	if !ok {
+	ch, _, outcome := b.SubscribeIfAllowed(context.Background(), "ws-1", 0)
+	if outcome != SubscribeOK {
 		t.Fatal("SubscribeIfAllowed refused a connection with no limit set")
 	}
 	defer b.Unsubscribe(ch)
@@ -163,8 +163,8 @@ func TestConcurrentFirstSubscribersShareOneRedisSubscription(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			ch, _, ok := b.SubscribeIfAllowed("ws-1", 0)
-			if !ok {
+			ch, _, outcome := b.SubscribeIfAllowed(context.Background(), "ws-1", 0)
+			if outcome != SubscribeOK {
 				t.Errorf("caller %d was refused", i)
 				return
 			}
@@ -242,13 +242,13 @@ func TestSubscribeDoesNotHoldTheBusLockAcrossTheRedisDial(t *testing.T) {
 	// A workspace with a healthy, already-established subscription, whose
 	// stream operations are the thing that must not be held hostage.
 	close(release)
-	quiet, _ := b.Subscribe("ws-quiet")
+	quiet, _, _ := b.Subscribe(context.Background(), "ws-quiet")
 	release = make(chan struct{})
 	stalls.Store(1)
 
 	stalled := make(chan struct{})
 	go func() {
-		ch, _ := b.Subscribe("ws-stalled")
+		ch, _, _ := b.Subscribe(context.Background(), "ws-stalled")
 		b.Unsubscribe(ch)
 		close(stalled)
 	}()
@@ -300,8 +300,8 @@ func TestAnUnconfirmedAdmissionTellsItsSubscribersWhenTheAckLands(t *testing.T) 
 	// Shorter than the delay, so the wait gives up first.
 	b.confirmTimeout = 50 * time.Millisecond
 
-	ch, gaps, ok := b.SubscribeIfAllowed("ws-1", 0)
-	if !ok {
+	ch, gaps, outcome := b.SubscribeIfAllowed(context.Background(), "ws-1", 0)
+	if outcome != SubscribeOK {
 		t.Fatal("an unconfirmed subscription must ADMIT, not refuse")
 	}
 	defer b.Unsubscribe(ch)
@@ -321,7 +321,7 @@ func TestAnUnconfirmedAdmissionTellsItsSubscribersWhenTheAckLands(t *testing.T) 
 	// confirmed before admission.
 	b.confirmTimeout = defaultSubscribeConfirmTimeout
 	before := obs.unconfirmedCount()
-	ch2, gaps2, _ := b.SubscribeIfAllowed("ws-2", 0)
+	ch2, gaps2, _ := b.SubscribeIfAllowed(context.Background(), "ws-2", 0)
 	defer b.Unsubscribe(ch2)
 	if got := obs.unconfirmedCount(); got != before {
 		t.Fatalf("a confirmed subscription reported SubscriptionUnconfirmed (%d -> %d)", before, got)
@@ -385,8 +385,8 @@ func TestAJoinersReplayStopsWhereItsChannelStarts(t *testing.T) {
 		// The joiner registers here. pendingSubs still holds this
 		// establishment, so it waits rather than returning.
 		go func() {
-			ch, missed, _, ok := b.SubscribeAndReplaySince("ws-1", cursor, 0)
-			if !ok {
+			ch, missed, _, outcome := b.SubscribeAndReplaySince(context.Background(), "ws-1", cursor, 0)
+			if outcome != SubscribeOK {
 				t.Error("the joiner was refused")
 			}
 			joined <- joinResult{ch: ch, missed: missed}
@@ -399,7 +399,7 @@ func TestAJoinersReplayStopsWhereItsChannelStarts(t *testing.T) {
 		waitForBufferedCount(t, b, "ws-1", 3)
 	}
 
-	establisher, _ := b.Subscribe("ws-1")
+	establisher, _, _ := b.Subscribe(context.Background(), "ws-1")
 	defer b.Unsubscribe(establisher)
 	if !armed.Load() {
 		t.Fatal("the seam never ran; this test could not have discriminated")
@@ -495,8 +495,8 @@ func TestAFreshSubscriberReceivesAnEventPublishedDuringEstablishment(t *testing.
 		close(buffered)
 	}
 
-	ch, _, ok := b.SubscribeIfAllowed("ws-1", 0)
-	if !ok {
+	ch, _, outcome := b.SubscribeIfAllowed(context.Background(), "ws-1", 0)
+	if outcome != SubscribeOK {
 		t.Fatal("SubscribeIfAllowed refused")
 	}
 	defer b.Unsubscribe(ch)
@@ -534,7 +534,7 @@ func TestASubscriberArrivingMidEstablishmentWaitsForTheAcknowledgement(t *testin
 	// The establishing caller, left in flight.
 	first := make(chan chan Event, 1)
 	go func() {
-		ch, _ := b.Subscribe("ws-1")
+		ch, _, _ := b.Subscribe(context.Background(), "ws-1")
 		first <- ch
 	}()
 
@@ -555,8 +555,8 @@ func TestASubscriberArrivingMidEstablishmentWaitsForTheAcknowledgement(t *testin
 		time.Sleep(time.Millisecond)
 	}
 
-	second, _, ok := b.SubscribeIfAllowed("ws-1", 0)
-	if !ok {
+	second, _, outcome := b.SubscribeIfAllowed(context.Background(), "ws-1", 0)
+	if outcome != SubscribeOK {
 		t.Fatal("the second subscriber was refused")
 	}
 	defer b.Unsubscribe(second)
@@ -614,7 +614,7 @@ func TestAConfirmedSubscriptionIsNeverLeftMarkedUnconfirmed(t *testing.T) {
 		}
 	}
 
-	ch, gaps := b.Subscribe("ws-1")
+	ch, gaps, _ := b.Subscribe(context.Background(), "ws-1")
 	defer b.Unsubscribe(ch)
 
 	// PREMISE: the acknowledgement really did beat the mark, or the interleave
@@ -688,7 +688,7 @@ func TestAJoinerIsNotStrandedByAnAbandonedEstablishment(t *testing.T) {
 		b.mu.Unlock()
 	}
 
-	ch, _ := b.Subscribe("ws-1")
+	ch, _, _ := b.Subscribe(context.Background(), "ws-1")
 	if !abandoned.Load() {
 		t.Fatal("the abandon was never forced; this test could not have discriminated")
 	}
@@ -696,8 +696,8 @@ func TestAJoinerIsNotStrandedByAnAbandonedEstablishment(t *testing.T) {
 
 	// Whatever happened to the first caller, a subscriber that ends up holding
 	// a channel must be connected to Redis.
-	next, _, ok := b.SubscribeIfAllowed("ws-1", 0)
-	if !ok {
+	next, _, outcome := b.SubscribeIfAllowed(context.Background(), "ws-1", 0)
+	if outcome != SubscribeOK {
 		t.Fatal("the next subscriber was refused")
 	}
 	defer b.Unsubscribe(next)
@@ -736,7 +736,7 @@ func TestCloseDuringEstablishmentDoesNotLeakTheSubscription(t *testing.T) {
 		b.Close()
 	}
 
-	ch, _ := b.Subscribe("ws-1")
+	ch, _, _ := b.Subscribe(context.Background(), "ws-1")
 	_ = ch
 	if !closedMidFlight.Load() {
 		t.Fatal("Close never ran mid-establishment; this test could not have discriminated")

--- a/internal/events/redis_uncovered_test.go
+++ b/internal/events/redis_uncovered_test.go
@@ -1,6 +1,7 @@
 package events
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -33,7 +34,7 @@ func TestAFailedIDAssignmentPublishesNothing(t *testing.T) {
 	b := NewRedisBus(client)
 	t.Cleanup(b.Close)
 
-	ch, _ := b.Subscribe("ws-1")
+	ch, _, _ := b.Subscribe(context.Background(), "ws-1")
 	defer b.Unsubscribe(ch)
 	waitForSubscribers(t, mr, "pad:events:ws-1", true)
 
@@ -68,21 +69,21 @@ func TestAFailedIDAssignmentPublishesNothing(t *testing.T) {
 func TestRedisBusSubscriptionAccounting(t *testing.T) {
 	b := newTestRedisBus(t)
 
-	first, _, ok := b.SubscribeIfAllowed("ws-1", 2)
-	if !ok {
+	first, _, outcome := b.SubscribeIfAllowed(context.Background(), "ws-1", 2)
+	if outcome != SubscribeOK {
 		t.Fatal("the first subscriber must be admitted")
 	}
-	second, _, ok := b.SubscribeIfAllowed("ws-1", 2)
-	if !ok {
+	second, _, outcome := b.SubscribeIfAllowed(context.Background(), "ws-1", 2)
+	if outcome != SubscribeOK {
 		t.Fatal("the second subscriber must be admitted")
 	}
-	if _, _, ok := b.SubscribeIfAllowed("ws-1", 2); ok {
+	if _, _, outcome := b.SubscribeIfAllowed(context.Background(), "ws-1", 2); outcome != SubscribeWorkspaceLimit {
 		t.Fatal("the third subscriber must be refused at a limit of 2")
 	}
 
 	// A different workspace is accounted separately.
-	other, _, ok := b.SubscribeIfAllowed("ws-2", 2)
-	if !ok {
+	other, _, outcome := b.SubscribeIfAllowed(context.Background(), "ws-2", 2)
+	if outcome != SubscribeOK {
 		t.Fatal("a different workspace must have its own budget")
 	}
 	defer b.Unsubscribe(other)
@@ -100,8 +101,8 @@ func TestRedisBusSubscriptionAccounting(t *testing.T) {
 	if got := b.WorkspaceSubscriberCount("ws-1"); got != 1 {
 		t.Fatalf("after one unsubscribe, WorkspaceSubscriberCount(ws-1) = %d, want 1", got)
 	}
-	third, _, ok := b.SubscribeIfAllowed("ws-1", 2)
-	if !ok {
+	third, _, outcome := b.SubscribeIfAllowed(context.Background(), "ws-1", 2)
+	if outcome != SubscribeOK {
 		t.Fatal("the freed slot must be reusable")
 	}
 	defer b.Unsubscribe(third)
@@ -124,8 +125,8 @@ func TestClosingALiveRedisBusReleasesEverything(t *testing.T) {
 	obs := &recordingObserver{}
 	b.SetObserver(obs)
 
-	one, _ := b.Subscribe("ws-1")
-	two, _ := b.Subscribe("ws-2")
+	one, _, _ := b.Subscribe(context.Background(), "ws-1")
+	two, _, _ := b.Subscribe(context.Background(), "ws-2")
 	waitForSubscribers(t, mr, "pad:events:ws-1", true)
 	waitForSubscribers(t, mr, "pad:events:ws-2", true)
 

--- a/internal/events/subscribe_if_allowed_test.go
+++ b/internal/events/subscribe_if_allowed_test.go
@@ -1,6 +1,9 @@
 package events
 
-import "testing"
+import (
+	"context"
+	"testing"
+)
 
 // TestSubscribeIfAllowedBounds covers the bus's per-workspace admission
 // bound directly (codex round 5).
@@ -19,15 +22,15 @@ func TestSubscribeIfAllowedBounds(t *testing.T) {
 		b := New()
 		defer b.Close()
 
-		if _, _, ok := b.SubscribeIfAllowed("ws-1", 1); !ok {
+		if _, _, outcome := b.SubscribeIfAllowed(context.Background(), "ws-1", 1); outcome != SubscribeOK {
 			t.Fatal("premise failed: first subscribe refused under a per-workspace limit of 1")
 		}
-		if _, _, ok := b.SubscribeIfAllowed("ws-1", 1); ok {
+		if _, _, outcome := b.SubscribeIfAllowed(context.Background(), "ws-1", 1); outcome != SubscribeWorkspaceLimit {
 			t.Fatal("second subscribe to the same workspace admitted past a limit of 1")
 		}
 		// Another workspace is unaffected — the property that makes this
 		// a per-workspace bound rather than a global one wearing its name.
-		if _, _, ok := b.SubscribeIfAllowed("ws-2", 1); !ok {
+		if _, _, outcome := b.SubscribeIfAllowed(context.Background(), "ws-2", 1); outcome != SubscribeOK {
 			t.Fatal("a different workspace was refused by a per-workspace limit")
 		}
 	})
@@ -38,7 +41,7 @@ func TestSubscribeIfAllowedBounds(t *testing.T) {
 		defer b.Close()
 
 		for i := 0; i < 200; i++ {
-			if _, _, ok := b.SubscribeIfAllowed("ws-1", 0); !ok {
+			if _, _, outcome := b.SubscribeIfAllowed(context.Background(), "ws-1", 0); outcome != SubscribeOK {
 				t.Fatalf("subscribe %d refused with the bound at 0", i)
 			}
 		}
@@ -49,15 +52,15 @@ func TestSubscribeIfAllowedBounds(t *testing.T) {
 		b := New()
 		defer b.Close()
 
-		ch, _, ok := b.SubscribeIfAllowed("ws-1", 1)
-		if !ok {
+		ch, _, outcome := b.SubscribeIfAllowed(context.Background(), "ws-1", 1)
+		if outcome != SubscribeOK {
 			t.Fatal("premise failed: first subscribe refused")
 		}
-		if _, _, ok := b.SubscribeIfAllowed("ws-1", 1); ok {
+		if _, _, outcome := b.SubscribeIfAllowed(context.Background(), "ws-1", 1); outcome != SubscribeWorkspaceLimit {
 			t.Fatal("premise failed: the budget was not actually spent")
 		}
 		b.Unsubscribe(ch)
-		if _, _, ok := b.SubscribeIfAllowed("ws-1", 1); !ok {
+		if _, _, outcome := b.SubscribeIfAllowed(context.Background(), "ws-1", 1); outcome != SubscribeOK {
 			t.Fatal("the slot was never freed by Unsubscribe")
 		}
 	})

--- a/internal/metrics/events_gap_wiring_test.go
+++ b/internal/metrics/events_gap_wiring_test.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"context"
 	"testing"
 
 	"github.com/PerpetualSoftware/pad/internal/events"
@@ -16,8 +17,8 @@ func TestInstrumentedBusPassesTheGapChannelThrough(t *testing.T) {
 	defer inner.Close()
 	b := NewInstrumentedBus(inner, New())
 
-	ch, gaps, ok := b.SubscribeIfAllowed("ws-1", 0)
-	if !ok {
+	ch, gaps, outcome := b.SubscribeIfAllowed(context.Background(), "ws-1", 0)
+	if outcome != events.SubscribeOK {
 		t.Fatal("subscribe refused")
 	}
 	defer b.Unsubscribe(ch)
@@ -50,8 +51,8 @@ func TestInstrumentedBusForwardsTheReplay(t *testing.T) {
 	b.Publish(events.Event{Type: events.ItemUpdated, WorkspaceID: "ws-1", ItemID: "two"})
 	cursor := b.EventsSince("ws-1", 0)[0].ID
 
-	ch, missed, gaps, ok := b.SubscribeAndReplaySince("ws-1", cursor, 0)
-	if !ok {
+	ch, missed, gaps, outcome := b.SubscribeAndReplaySince(context.Background(), "ws-1", cursor, 0)
+	if outcome != events.SubscribeOK {
 		t.Fatal("subscribe refused")
 	}
 	defer b.Unsubscribe(ch)

--- a/internal/metrics/instrumented_bus.go
+++ b/internal/metrics/instrumented_bus.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"context"
 	"sync"
 
 	"github.com/PerpetualSoftware/pad/internal/events"
@@ -30,22 +31,31 @@ func NewInstrumentedBus(inner events.EventBus, m *Metrics) *InstrumentedBus {
 }
 
 // Subscribe delegates to the inner bus and increments the SSE connection gauge.
-func (b *InstrumentedBus) Subscribe(workspaceID string) (chan events.Event, <-chan struct{}) {
-	ch, gaps := b.inner.Subscribe(workspaceID)
+func (b *InstrumentedBus) Subscribe(ctx context.Context, workspaceID string) (chan events.Event, <-chan struct{}, events.SubscribeOutcome) {
+	ch, gaps, outcome := b.inner.Subscribe(ctx, workspaceID)
+	if outcome != events.SubscribeOK {
+		return nil, nil, outcome
+	}
 	b.trackSubscription(ch, workspaceID)
-	return ch, gaps
+	return ch, gaps, outcome
 }
 
 // SubscribeIfAllowed delegates the atomic check-and-subscribe to the inner bus
 // and updates Prometheus gauges on success.
-func (b *InstrumentedBus) SubscribeIfAllowed(workspaceID string, maxPerWorkspace int) (chan events.Event, <-chan struct{}, bool) {
-	ch, gaps, ok := b.inner.SubscribeIfAllowed(workspaceID, maxPerWorkspace)
-	if !ok {
-		return nil, nil, false
+//
+// EVERY NON-OK OUTCOME IS TREATED THE SAME HERE, deliberately: SubscribeOK is
+// the only one that hands back a channel, so it is the only one this wrapper
+// has anything to track. Distinguishing a limit refusal from a cancellation is
+// the HANDLER's job (BUG-2749) — this type counts subscriptions, and there is
+// no subscription in either case.
+func (b *InstrumentedBus) SubscribeIfAllowed(ctx context.Context, workspaceID string, maxPerWorkspace int) (chan events.Event, <-chan struct{}, events.SubscribeOutcome) {
+	ch, gaps, outcome := b.inner.SubscribeIfAllowed(ctx, workspaceID, maxPerWorkspace)
+	if outcome != events.SubscribeOK {
+		return nil, nil, outcome
 	}
 
 	b.trackSubscription(ch, workspaceID)
-	return ch, gaps, true
+	return ch, gaps, outcome
 }
 
 // SubscribeAndReplaySince delegates the atomic check-subscribe-and-replay to
@@ -54,14 +64,14 @@ func (b *InstrumentedBus) SubscribeIfAllowed(workspaceID string, maxPerWorkspace
 // The gap channel and the replay set pass through untouched: both are the
 // inner bus's own knowledge (BUG-2730), and this wrapper exists to count
 // subscriptions, not to have an opinion about coverage.
-func (b *InstrumentedBus) SubscribeAndReplaySince(workspaceID string, sinceID int64, maxPerWorkspace int) (chan events.Event, []events.Event, <-chan struct{}, bool) {
-	ch, missed, gaps, ok := b.inner.SubscribeAndReplaySince(workspaceID, sinceID, maxPerWorkspace)
-	if !ok {
-		return nil, nil, nil, false
+func (b *InstrumentedBus) SubscribeAndReplaySince(ctx context.Context, workspaceID string, sinceID int64, maxPerWorkspace int) (chan events.Event, []events.Event, <-chan struct{}, events.SubscribeOutcome) {
+	ch, missed, gaps, outcome := b.inner.SubscribeAndReplaySince(ctx, workspaceID, sinceID, maxPerWorkspace)
+	if outcome != events.SubscribeOK {
+		return nil, nil, nil, outcome
 	}
 
 	b.trackSubscription(ch, workspaceID)
-	return ch, missed, gaps, true
+	return ch, missed, gaps, outcome
 }
 
 // trackSubscription records the channel's workspace and bumps the gauges, so

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 	"strings"
@@ -387,7 +388,7 @@ func TestInstrumentedBus_SubscribeUnsubscribe(t *testing.T) {
 	bus := NewInstrumentedBus(inner, m)
 
 	// Subscribe to a workspace
-	ch, _ := bus.Subscribe("ws-1")
+	ch, _, _ := bus.Subscribe(context.Background(), "ws-1")
 	if ch == nil {
 		t.Fatal("Subscribe should return a channel")
 	}
@@ -399,14 +400,14 @@ func TestInstrumentedBus_SubscribeUnsubscribe(t *testing.T) {
 	}
 
 	// Subscribe a second connection to same workspace
-	ch2, _ := bus.Subscribe("ws-1")
+	ch2, _, _ := bus.Subscribe(context.Background(), "ws-1")
 	gauge = getGaugeValue(t, *m.SSEConnectionsActive)
 	if gauge != 2 {
 		t.Errorf("Expected SSE active connections = 2, got %v", gauge)
 	}
 
 	// Subscribe to a different workspace
-	ch3, _ := bus.Subscribe("ws-2")
+	ch3, _, _ := bus.Subscribe(context.Background(), "ws-2")
 	gauge = getGaugeValue(t, *m.SSEConnectionsActive)
 	if gauge != 3 {
 		t.Errorf("Expected SSE active connections = 3, got %v", gauge)
@@ -434,7 +435,7 @@ func TestInstrumentedBus_Publish(t *testing.T) {
 	bus := NewInstrumentedBus(inner, m)
 
 	// Subscribe so we can publish
-	ch, _ := bus.Subscribe("ws-1")
+	ch, _, _ := bus.Subscribe(context.Background(), "ws-1")
 	defer bus.Unsubscribe(ch)
 
 	bus.Publish(events.Event{Type: "test", WorkspaceID: "ws-1"})
@@ -458,7 +459,7 @@ func TestInstrumentedBus_SubscriberCount(t *testing.T) {
 		t.Errorf("Expected 0 subscribers initially")
 	}
 
-	ch, _ := bus.Subscribe("ws-1")
+	ch, _, _ := bus.Subscribe(context.Background(), "ws-1")
 	if bus.SubscriberCount() != 1 {
 		t.Errorf("Expected 1 subscriber after subscribe")
 	}

--- a/internal/server/handlers_collections_concurrency_test.go
+++ b/internal/server/handlers_collections_concurrency_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"strings"
@@ -253,7 +254,7 @@ func TestUpdateCollection_PublishesCollectionUpdatedEvent(t *testing.T) {
 	var coll models.Collection
 	parseJSON(t, createRR, &coll)
 
-	ch, _ := srv.events.Subscribe(ws.ID)
+	ch, _, _ := srv.events.Subscribe(context.Background(), ws.ID)
 	defer srv.events.Unsubscribe(ch)
 
 	rr := doRequest(srv, "PATCH", "/api/v1/workspaces/"+slug+"/collections/"+coll.Slug, map[string]interface{}{
@@ -315,7 +316,7 @@ func TestUpdateCollection_RenameEventCarriesNewSlug(t *testing.T) {
 	parseJSON(t, createRR, &coll)
 	oldSlug := coll.Slug
 
-	ch, _ := srv.events.Subscribe(ws.ID)
+	ch, _, _ := srv.events.Subscribe(context.Background(), ws.ID)
 	defer srv.events.Unsubscribe(ch)
 
 	rr := doRequest(srv, "PATCH", "/api/v1/workspaces/"+slug+"/collections/"+oldSlug, map[string]interface{}{
@@ -398,7 +399,7 @@ func TestUpdateCollection_MigrationSetsItemsChanged(t *testing.T) {
 	}
 
 	t.Run("migration touching an item sets items_changed", func(t *testing.T) {
-		ch, _ := srv.events.Subscribe(ws.ID)
+		ch, _, _ := srv.events.Subscribe(context.Background(), ws.ID)
 		defer srv.events.Unsubscribe(ch)
 
 		rr := doRequest(srv, "PATCH", "/api/v1/workspaces/"+slug+"/collections/"+coll.Slug, map[string]interface{}{
@@ -428,7 +429,7 @@ func TestUpdateCollection_MigrationSetsItemsChanged(t *testing.T) {
 	})
 
 	t.Run("migration matching ZERO items still sets items_changed (no row-count leak)", func(t *testing.T) {
-		ch, _ := srv.events.Subscribe(ws.ID)
+		ch, _, _ := srv.events.Subscribe(context.Background(), ws.ID)
 		defer srv.events.Unsubscribe(ch)
 
 		// Rename an option value that NO item currently has → 0 rows migrated.
@@ -450,7 +451,7 @@ func TestUpdateCollection_MigrationSetsItemsChanged(t *testing.T) {
 	})
 
 	t.Run("settings-only update leaves items_changed false", func(t *testing.T) {
-		ch, _ := srv.events.Subscribe(ws.ID)
+		ch, _, _ := srv.events.Subscribe(context.Background(), ws.ID)
 		defer srv.events.Unsubscribe(ch)
 
 		rr := doRequest(srv, "PATCH", "/api/v1/workspaces/"+slug+"/collections/"+coll.Slug, map[string]interface{}{

--- a/internal/server/handlers_events.go
+++ b/internal/server/handlers_events.go
@@ -231,19 +231,40 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// THE REQUEST'S CONTEXT GOES INTO THE SUBSCRIBE, so a client that hangs up
+	// during establishment stops holding the admission slot acquired above
+	// (BUG-2749). Establishing a workspace's Redis subscription dials and then
+	// waits for the acknowledgement, and both used to run to completion for a
+	// connection that was already gone.
 	var ch chan events.Event
 	var missed []events.Event
 	var gaps <-chan struct{}
-	var subscribed bool
+	var outcome events.SubscribeOutcome
 	if lastID > 0 {
-		ch, missed, gaps, subscribed = s.events.SubscribeAndReplaySince(ws.ID, lastID, s.sseMaxPerWorkspace)
+		ch, missed, gaps, outcome = s.events.SubscribeAndReplaySince(r.Context(), ws.ID, lastID, s.sseMaxPerWorkspace)
 	} else {
-		ch, gaps, subscribed = s.events.SubscribeIfAllowed(ws.ID, s.sseMaxPerWorkspace)
+		ch, gaps, outcome = s.events.SubscribeIfAllowed(r.Context(), ws.ID, s.sseMaxPerWorkspace)
 	}
-	if !subscribed {
+	switch outcome {
+	case events.SubscribeOK:
+	case events.SubscribeWorkspaceLimit:
 		slog.Warn("SSE connection limit reached", "workspace", ws.Slug, "refused_by", "per_workspace",
 			"ws_current", s.events.WorkspaceSubscriberCount(ws.ID), "ws_max", s.sseMaxPerWorkspace)
 		writeStreamLimitExceeded(w)
+		return
+	case events.SubscribeCancelled:
+		// NOT a refusal, and deliberately not written to as one. There is
+		// nobody left to read a 429, the connection was never established, and
+		// counting a departure against the per-workspace limit would put a
+		// client that simply left into the one signal used to tune that limit.
+		// The deferred admission release above is the whole point of the path.
+		slog.Debug("SSE client disconnected during subscription establishment",
+			"workspace", ws.Slug)
+		return
+	default:
+		slog.Error("SSE subscribe returned an unknown outcome; refusing rather than guessing",
+			"workspace", ws.Slug, "outcome", outcome.String())
+		writeError(w, http.StatusInternalServerError, "internal_error", "Subscription failed")
 		return
 	}
 	defer s.events.Unsubscribe(ch)

--- a/internal/server/handlers_events_cancel_test.go
+++ b/internal/server/handlers_events_cancel_test.go
@@ -1,0 +1,131 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/events"
+)
+
+// slowEstablishBus stands in for a bus whose establishment is genuinely slow —
+// a cold workspace whose Redis subscription has to be dialled and then
+// acknowledged. It reproduces the real bus's contract rather than a stub's:
+// the wait is cancellable, and cancelling it yields SubscribeCancelled.
+//
+// The hold is what makes the test discriminate. A handler that passes the
+// request's context through returns as soon as the client hangs up; one that
+// passes context.Background() cannot, and pays the whole hold with the
+// admission slot still reserved.
+type slowEstablishBus struct {
+	events.EventBus
+	hold time.Duration
+
+	once    sync.Once
+	entered chan struct{}
+}
+
+func (b *slowEstablishBus) wait(ctx context.Context) (events.SubscribeOutcome, bool) {
+	b.once.Do(func() { close(b.entered) })
+	select {
+	case <-ctx.Done():
+		return events.SubscribeCancelled, false
+	case <-time.After(b.hold):
+		return events.SubscribeOK, true
+	}
+}
+
+func (b *slowEstablishBus) SubscribeIfAllowed(ctx context.Context, workspaceID string, maxPerWorkspace int) (chan events.Event, <-chan struct{}, events.SubscribeOutcome) {
+	if outcome, proceed := b.wait(ctx); !proceed {
+		return nil, nil, outcome
+	}
+	return b.EventBus.SubscribeIfAllowed(ctx, workspaceID, maxPerWorkspace)
+}
+
+func (b *slowEstablishBus) SubscribeAndReplaySince(ctx context.Context, workspaceID string, sinceID int64, maxPerWorkspace int) (chan events.Event, []events.Event, <-chan struct{}, events.SubscribeOutcome) {
+	if outcome, proceed := b.wait(ctx); !proceed {
+		return nil, nil, nil, outcome
+	}
+	return b.EventBus.SubscribeAndReplaySince(ctx, workspaceID, sinceID, maxPerWorkspace)
+}
+
+// TestDisconnectDuringEstablishmentReleasesTheAdmissionSlot is the BINDING
+// assertion for BUG-2749 (CONVE-19): internal/events' own tests vouch for the
+// bus honouring a cancelled context, and say nothing about whether the SSE
+// handler ever hands it one.
+//
+// The admission slot is the half of the bug that lives in this package. It is
+// reserved before the subscribe and released by a defer, so for as long as
+// establishment ran to completion for a departed client, a connection that no
+// longer existed went on counting against both the per-instance and the
+// per-principal bound.
+//
+// ASSERTS ITS OWN PREMISES, both of them: that establishment was actually
+// entered, and that the slot was actually held at that moment. Without those
+// the timing check below would pass against a handler that refused the
+// connection outright and never reserved anything.
+func TestDisconnectDuringEstablishmentReleasesTheAdmissionSlot(t *testing.T) {
+	srv := testServerWithEvents(t)
+	bus := &slowEstablishBus{
+		EventBus: events.New(),
+		// Long enough that a handler ignoring the request context cannot
+		// finish inside the release deadline below by luck.
+		hold:    5 * time.Second,
+		entered: make(chan struct{}),
+	}
+	srv.SetEventBus(bus)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	slug := createTestWorkspace(t, ts.URL, "Test")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL+"/api/v1/events?workspace="+slug, nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		resp, err := http.DefaultClient.Do(req)
+		if err == nil {
+			_ = resp.Body.Close()
+		}
+	}()
+
+	select {
+	case <-bus.entered:
+	case <-time.After(5 * time.Second):
+		cancel()
+		t.Fatal("establishment was never entered; this test never reached the window it is named for")
+	}
+
+	if held := srv.admission().heldTotal(); held != 1 {
+		cancel()
+		t.Fatalf("admission slots held during establishment = %d, want 1 — the slot this test is about was never reserved", held)
+	}
+
+	// The client goes away mid-establishment.
+	cancel()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if srv.admission().heldTotal() == 0 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("the admission slot was still held %v after the client disconnected, with %v of establishment left to run: the handler is not passing the request's context to the bus", 2*time.Second, bus.hold)
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Error("the request never completed")
+	}
+}

--- a/internal/server/handlers_item_versions_test.go
+++ b/internal/server/handlers_item_versions_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 	"net/http"
@@ -294,7 +295,7 @@ func TestRestoreItemVersionEmitsItemUpdatedSSE(t *testing.T) {
 	}
 
 	// Subscribe right before the restore so the next item_updated is the restore's.
-	ch, _ := bus.Subscribe(ws.ID)
+	ch, _, _ := bus.Subscribe(context.Background(), ws.ID)
 	defer bus.Unsubscribe(ch)
 
 	rr = doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/items/"+it.Slug+"/versions/"+versionID+"/restore", nil)
@@ -397,7 +398,7 @@ func TestRestoreVersionHandlerAckLossReconciledEndToEnd(t *testing.T) {
 		return nil
 	}
 
-	ch, _ := ebus.Subscribe(ws.ID)
+	ch, _, _ := ebus.Subscribe(context.Background(), ws.ID)
 	defer ebus.Unsubscribe(ch)
 
 	rr = doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/items/"+it.Slug+"/versions/"+versionID+"/restore", nil)

--- a/internal/server/handlers_items_bulk_test.go
+++ b/internal/server/handlers_items_bulk_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"strings"
@@ -345,7 +346,7 @@ func TestBulkItems_EmitsCollectionScopedBatchEvent(t *testing.T) {
 	if err != nil || wsRow == nil {
 		t.Fatalf("resolve workspace: %v", err)
 	}
-	ch, _ := srv.events.Subscribe(wsRow.ID)
+	ch, _, _ := srv.events.Subscribe(context.Background(), wsRow.ID)
 	defer srv.events.Unsubscribe(ch)
 
 	a := createBulkTestItem(t, srv, ws, "A", `{"status":"open","priority":"low"}`)
@@ -414,7 +415,7 @@ func TestBulkItems_CollectionMoveNotifiesBothScopes(t *testing.T) {
 
 	a := createBulkTestItem(t, srv, ws, "A", `{"status":"open"}`)
 
-	ch, _ := srv.events.Subscribe(wsRow.ID)
+	ch, _, _ := srv.events.Subscribe(context.Background(), wsRow.ID)
 	defer srv.events.Unsubscribe(ch)
 
 	rr := doRequest(srv, "POST", "/api/v1/workspaces/"+ws+"/items/bulk", map[string]any{

--- a/internal/server/handlers_items_copy_preflight_test.go
+++ b/internal/server/handlers_items_copy_preflight_test.go
@@ -900,9 +900,9 @@ func TestCopyPreflight_WritesNothing(t *testing.T) {
 
 	// Subscribe to BOTH workspaces before the snapshot so any publish
 	// lands in a buffer we can inspect afterwards.
-	chA, _ := f.bus.Subscribe(f.wsA.ID)
+	chA, _, _ := f.bus.Subscribe(context.Background(), f.wsA.ID)
 	defer f.bus.Unsubscribe(chA)
-	chB, _ := f.bus.Subscribe(f.wsB.ID)
+	chB, _, _ := f.bus.Subscribe(context.Background(), f.wsB.ID)
 	defer f.bus.Unsubscribe(chB)
 
 	before := f.snapshot()

--- a/internal/server/handlers_items_copy_test.go
+++ b/internal/server/handlers_items_copy_test.go
@@ -556,8 +556,8 @@ type webhookDelivery struct {
 
 func newCopyFanoutObserver(t *testing.T, f *copyPreflightFixture) *copyFanoutObserver {
 	t.Helper()
-	chA, _ := f.bus.Subscribe(f.wsA.ID)
-	chB, _ := f.bus.Subscribe(f.wsB.ID)
+	chA, _, _ := f.bus.Subscribe(context.Background(), f.wsA.ID)
+	chB, _, _ := f.bus.Subscribe(context.Background(), f.wsB.ID)
 	o := &copyFanoutObserver{
 		t: t, f: f,
 		chA:   chA,

--- a/internal/server/handlers_stream_gap_test.go
+++ b/internal/server/handlers_stream_gap_test.go
@@ -37,14 +37,19 @@ type gapEventBus struct {
 	gaps chan struct{}
 }
 
-func (b *gapEventBus) SubscribeIfAllowed(workspaceID string, maxPerWorkspace int) (chan events.Event, <-chan struct{}, bool) {
-	ch, _, ok := b.EventBus.SubscribeIfAllowed(workspaceID, maxPerWorkspace)
-	return ch, b.gaps, ok
+// The context is FORWARDED, not replaced with a Background (BUG-2749). This
+// double sits between the handler and the real bus, so swallowing the
+// request's context here would make every cancellation test in this package
+// pass for the wrong reason: the inner bus would never see the cancellation
+// the handler is being asserted to propagate.
+func (b *gapEventBus) SubscribeIfAllowed(ctx context.Context, workspaceID string, maxPerWorkspace int) (chan events.Event, <-chan struct{}, events.SubscribeOutcome) {
+	ch, _, outcome := b.EventBus.SubscribeIfAllowed(ctx, workspaceID, maxPerWorkspace)
+	return ch, b.gaps, outcome
 }
 
-func (b *gapEventBus) SubscribeAndReplaySince(workspaceID string, sinceID int64, maxPerWorkspace int) (chan events.Event, []events.Event, <-chan struct{}, bool) {
-	ch, missed, _, ok := b.EventBus.SubscribeAndReplaySince(workspaceID, sinceID, maxPerWorkspace)
-	return ch, missed, b.gaps, ok
+func (b *gapEventBus) SubscribeAndReplaySince(ctx context.Context, workspaceID string, sinceID int64, maxPerWorkspace int) (chan events.Event, []events.Event, <-chan struct{}, events.SubscribeOutcome) {
+	ch, missed, _, outcome := b.EventBus.SubscribeAndReplaySince(ctx, workspaceID, sinceID, maxPerWorkspace)
+	return ch, missed, b.gaps, outcome
 }
 
 // gapWatchBus is the same seam for the user-scoped watch stream.

--- a/internal/server/handlers_unparented_test.go
+++ b/internal/server/handlers_unparented_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"net/http"
 	"strings"
 	"testing"
@@ -187,7 +188,7 @@ func TestCreateWithParentPublishesFreshSequence(t *testing.T) {
 	if err != nil || ws == nil {
 		t.Fatalf("workspace: %v", err)
 	}
-	ch, _ := srv.events.Subscribe(ws.ID)
+	ch, _, _ := srv.events.Subscribe(context.Background(), ws.ID)
 	defer srv.events.Unsubscribe(ch)
 
 	rr := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections/tasks/items", map[string]any{
@@ -221,7 +222,7 @@ func TestStructuralLinkHandlersPublishFreshSourceEvent(t *testing.T) {
 	if err != nil || ws == nil {
 		t.Fatalf("workspace: %v", err)
 	}
-	ch, _ := srv.events.Subscribe(ws.ID)
+	ch, _, _ := srv.events.Subscribe(context.Background(), ws.ID)
 	defer srv.events.Unsubscribe(ch)
 
 	rr := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/items/"+source.Slug+"/links", map[string]any{


### PR DESCRIPTION
Fixes BUG-2749.

`GET /api/v1/events` reserved its admission slot, then blocked in `SubscribeAndReplaySince` while the workspace's Redis subscription was dialled and — since BUG-2747 — acknowledged. Nothing propagated the request's cancellation into that wait, so a client that disconnected during establishment left a process-wide slot, a per-principal slot and a per-workspace slot held for the whole of it. The connection was gone; the capacity was not.

## The shape

**Cancellation is deregistration.** `wsCounts` already answers "is anyone still here", so a caller whose context ended simply stops being counted and the existing arbiter decides the rest. No ownership hand-off, no reaper.

The two cancellation positions take different paths, and only one owes the joiners anything:

- **Before the install** — the existing post-dial critical section already abandons and retires correctly when nobody is left. It needed one ordering rule: the departed establisher stops being counted *in that same section*, before the count is read. If joiners registered while we dialled, the count is still non-zero and they get the subscription — the hand-off the filing asked about, expressed as a count rather than a transfer of ownership.
- **During the confirmation wait** — the subscription is already installed with its receive loop running, so the connection is not at risk. The **wait** is what releases the joiners, and dropping it would admit them into a subscription Redis has not acknowledged while telling them nothing — BUG-2747's defect re-created at the seam. So the remainder of the wait moves to a goroutine that finishes exactly as the caller would have. Bounded by `confirmTimeout`; teardown stays count-driven.

**A departure is not a refusal.** `ok bool` becomes a `SubscribeOutcome` enum across the three `EventBus` Subscribe methods, so `SubscribeWorkspaceLimit` and `SubscribeCancelled` cannot be collapsed — answering a departed client with 429 would have written a limit refusal into the very counters used to tune that limit.

## Caller population, with its search boundary

3 production implementations (`events.MemoryBus`, `events.RedisBus`, `metrics.InstrumentedBus`), 1 test double (`server.gapEventBus`, which embeds the interface), 2 production call sites (both `handlers_events.go`). Searched this repo four ways: the three method names, `.Subscribe(`, method declarations, and interface embedding. `collab.OpBus` and `watchevents.Bus` are different interfaces and out of scope; no other repo links this package.

## Known residual

Verified in go-redis v9.22.0 source rather than inferred from its doc comment (which says `Subscribe` "does not wait on a response from Redis", and so reads as though no dial happens on the request path — it does; only the reply is unawaited):

- **Plaintext:** `dialConn` derives its per-attempt deadline from the caller's context and the default dialer is `net.Dialer.DialContext` — cancellation aborts the dial.
- **TLS:** the same dialer calls `tls.DialWithDialer`, which takes no context. The dial stays bounded by `DialTimeout` alone.

So on a TLS deployment this shrinks the held slot from (dial + confirm bound) to (dial), not to zero. Filed as **BUG-2754** — the fix belongs at Redis client construction, where it covers every command rather than just `Subscribe`.

## Class sweep

**BUG-2751**, filed separately by ruling (one region, one design per diff): `internal/watchevents` has no per-request establishment, but its resume path blocks on a 250ms settle window bound to the bus's context rather than the request's, while `/api/v1/events/stream` holds the same admission slots across it. Different mechanism, same class, ~an order of magnitude smaller.

## Tests

Six cancellation cases in `internal/events` — before install; during the wait alone; during the wait with a joiner (asserting the joiner is still told to reconcile when the acknowledgement lands late); a cancelled joiner; an already-dead caller; and a cancelled establisher never stranding the next subscriber. Plus a dial-binding assertion per context half, and the handler-level binding in `internal/server` asserting the admission slot itself is released — the half of the bug that does not live in the bus.

**Mutation matrix: 8 mutations, 7 detected**, each by the test named for it. The survivor is the `ctx` term in the retry re-decide, which survives because it is an optimisation rather than a correctness guard — a departed caller that mints a second record still establishes, deregisters and retires correctly. The code says so rather than implying it is load-bearing.

## Review

Codex CLI, three rounds to CLEAN.

- **Round 2 P1** — a cancellation break at the top of the establish loop could return while the caller still owned an unretired `pendingSub`, stranding the next subscriber forever. Exactly the failure the filing named in advance. Removed; regression test added, and reinstating the break turns it red.
- **Round 2 P2** — routing the dial to the caller's context alone removed `Close()`'s ability to interrupt a stalled dial. The dial now runs on a context ended by either the caller or the bus, with a test per half.
- **Round 1** — the TLS residual (filed as BUG-2754) and a comment sweep: three comments elsewhere in the file still claimed the dial was not context-bounded.

## Gates (final tip 6edd2960)

`make test` 27/27 · `make test-pg` green · `make lint` 0 issues · `make vuln` 0 vulnerabilities · `gofmt` clean · `go test -race` on `internal/events` (×3), `internal/server` and `internal/metrics` green · cancellation matrix ×10 with zero flakes. No `go.mod`/`go.sum`/`nix/` changes.
