### PR TITLE
feat(web): Live view on the activity page — the feed folded into episodes (IDEA-2755)

### DIFF
--- a/web/src/lib/components/activity/EpisodeFeed.svelte
+++ b/web/src/lib/components/activity/EpisodeFeed.svelte
@@ -1,0 +1,259 @@
+<script lang="ts">
+	import { api } from '$lib/api/client';
+	import { relativeTime } from '$lib/utils/markdown';
+	import { foldEpisodes, type Episode } from '$lib/utils/activityEpisodes';
+	import EmptyState from '$lib/components/common/EmptyState.svelte';
+	import type { Activity } from '$lib/types';
+
+	interface Props {
+		activities: Activity[];
+		wsSlug: string;
+		username: string;
+	}
+
+	let { activities, wsSlug, username }: Props = $props();
+
+	let episodes = $derived(foldEpisodes(activities));
+	let liveEpisodes = $derived(episodes.filter((e) => e.live));
+	let earlierEpisodes = $derived(episodes.filter((e) => !e.live));
+
+	function episodeVerb(actions: string[]): string {
+		if (actions.length > 1) return 'working on';
+		switch (actions[0]) {
+			case 'created':
+				return 'created';
+			case 'commented':
+				return 'commenting on';
+			case 'updated':
+			case 'field_changed':
+				return 'working on';
+			default:
+				return actions[0];
+		}
+	}
+
+	// Checkpoint lines (newest comment's first line) keyed by episode key.
+	// Best-effort enrichment for the first few LIVE episodes only; `fetched`
+	// remembers which (episode, latest event id) pairs were already requested,
+	// so a card re-fetches only when its latest.id moves. No polling.
+	let checkpoints = $state<Record<string, string>>({});
+	const fetched = new Set<string>();
+
+	$effect(() => {
+		for (const ep of liveEpisodes.filter((e) => e.itemSlug).slice(0, 4)) {
+			const fetchKey = `${ep.key}:${ep.latest.id}`;
+			if (fetched.has(fetchKey)) continue;
+			fetched.add(fetchKey);
+			loadCheckpoint(ep);
+		}
+	});
+
+	async function loadCheckpoint(ep: Episode) {
+		if (!ep.itemSlug) return;
+		try {
+			const comments = await api.comments.list(wsSlug, ep.itemSlug);
+			if (!comments || comments.length === 0) return;
+			let newest = comments[0];
+			for (const c of comments) {
+				if (c.created_at > newest.created_at) newest = c;
+			}
+			const line = newest.body.split('\n')[0].slice(0, 160).trim();
+			if (line) checkpoints[ep.key] = line;
+		} catch {
+			// best-effort: the card simply renders without a checkpoint line
+		}
+	}
+</script>
+
+{#snippet card(ep: Episode, live: boolean)}
+	<div class="episode-card" class:agent={ep.actorKind === 'agent'} class:earlier={!live}>
+		<div class="ep-main">
+			<span class="ep-actor">{ep.actorLabel}</span>
+			<span class="ep-verb">{episodeVerb(ep.actions)}</span>
+			{#if ep.itemRef}
+				{#if ep.itemSlug && ep.collectionSlug}
+					<a class="ep-ref" href="/{username}/{wsSlug}/{ep.collectionSlug}/{ep.itemSlug}"
+						>{ep.itemRef}</a
+					>
+				{:else}
+					<span class="ep-ref">{ep.itemRef}</span>
+				{/if}
+			{/if}
+			{#if ep.itemTitle}
+				{#if !ep.itemRef && ep.itemSlug && ep.collectionSlug}
+					<a class="ep-title" href="/{username}/{wsSlug}/{ep.collectionSlug}/{ep.itemSlug}"
+						>{ep.itemTitle}</a
+					>
+				{:else}
+					<span class="ep-title">{ep.itemTitle}</span>
+				{/if}
+			{/if}
+			<span class="ep-meta"
+				>{relativeTime(ep.first.created_at)} · {ep.count}
+				{ep.count === 1 ? 'event' : 'events'}</span
+			>
+		</div>
+		{#if live && checkpoints[ep.key]}
+			<div class="ep-checkpoint">latest: {checkpoints[ep.key]}</div>
+		{/if}
+	</div>
+{/snippet}
+
+{#if episodes.length === 0}
+	<EmptyState icon="~" title="No activity yet" />
+{:else}
+	<div class="episode-feed">
+		{#if liveEpisodes.length > 0}
+			<div class="feed-section">
+				<div class="section-label">
+					<span class="live-dot" aria-hidden="true"></span>
+					Happening now
+				</div>
+				<div class="cards">
+					{#each liveEpisodes as ep (ep.key)}
+						{@render card(ep, true)}
+					{/each}
+				</div>
+			</div>
+		{/if}
+		{#if earlierEpisodes.length > 0}
+			<div class="feed-section">
+				<div class="section-label">Earlier</div>
+				<div class="cards">
+					{#each earlierEpisodes as ep (ep.key)}
+						{@render card(ep, false)}
+					{/each}
+				</div>
+			</div>
+		{/if}
+	</div>
+{/if}
+
+<style>
+	.episode-feed {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-6);
+	}
+
+	.feed-section {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-3);
+	}
+
+	.section-label {
+		display: flex;
+		align-items: center;
+		gap: var(--space-2);
+		font-size: 11px;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.06em;
+		color: var(--text-muted);
+	}
+
+	.live-dot {
+		width: 7px;
+		height: 7px;
+		border-radius: 50%;
+		background: var(--accent-green);
+		flex-shrink: 0;
+	}
+
+	.cards {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-2);
+	}
+
+	/* ── Episode Card ─────────────────────────────────────────────────── */
+	.episode-card {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-2);
+		background: var(--card-bg);
+		border: 1px solid var(--card-border);
+		border-left: 3px solid transparent;
+		border-radius: var(--radius-lg);
+		padding: var(--space-3) var(--space-4);
+	}
+	.episode-card.earlier {
+		background: var(--bg-secondary);
+		border-color: var(--border);
+		opacity: 0.85;
+	}
+	/* After .earlier so agent cards keep the accent edge in both sections. */
+	.episode-card.agent {
+		border-left-color: var(--accent-primary);
+	}
+
+	.ep-main {
+		display: flex;
+		align-items: baseline;
+		gap: var(--space-2);
+		min-width: 0;
+	}
+	.ep-actor {
+		font-size: 12.5px;
+		font-weight: 700;
+		color: var(--text-primary);
+		white-space: nowrap;
+	}
+	.ep-verb {
+		font-size: 12.5px;
+		color: var(--text-muted);
+		white-space: nowrap;
+	}
+	.ep-ref {
+		font-family: var(--font-mono);
+		font-size: 11px;
+		color: var(--accent-primary);
+		background: color-mix(in srgb, var(--accent-primary) 12%, transparent);
+		padding: 1px 6px;
+		border-radius: 5px;
+		text-decoration: none;
+		white-space: nowrap;
+		flex-shrink: 0;
+	}
+	a.ep-ref:hover {
+		text-decoration: underline;
+	}
+	a.ep-title {
+		color: inherit;
+	}
+	a.ep-title:hover {
+		text-decoration: underline;
+	}
+	.ep-title {
+		flex: 1;
+		min-width: 0;
+		font-size: 0.875em;
+		font-weight: 600;
+		color: var(--text-primary);
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+	.ep-meta {
+		margin-left: auto;
+		flex-shrink: 0;
+		font-size: 0.8em;
+		color: var(--text-muted);
+		font-variant-numeric: tabular-nums;
+		white-space: nowrap;
+	}
+
+	.ep-checkpoint {
+		font-size: 12px;
+		font-style: italic;
+		color: var(--text-secondary);
+		border-left: 2px solid var(--border);
+		padding-left: 10px;
+		display: -webkit-box;
+		-webkit-line-clamp: 2;
+		line-clamp: 2;
+		-webkit-box-orient: vertical;
+		overflow: hidden;
+	}
+</style>

--- a/web/src/lib/components/activity/EpisodeFeed.svelte.test.ts
+++ b/web/src/lib/components/activity/EpisodeFeed.svelte.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { flushSync, mount, unmount, tick } from 'svelte';
+import type { Activity, Comment } from '$lib/types';
+
+/**
+ * EpisodeFeed renders WORK-grain cards (one per episode from foldEpisodes),
+ * not audit-grain rows — the collapse is the feature, so the first assertion
+ * here is card count vs activity count. The other claims: live vs earlier
+ * sectioning follows `episode.live`, and the checkpoint enrichment (newest
+ * comment's first line) is fetched for LIVE episodes only.
+ */
+
+const commentsListMock = vi.hoisted(() =>
+	vi.fn<(ws: string, slug: string) => Promise<Comment[]>>()
+);
+
+vi.mock('$lib/api/client', () => ({
+	api: {
+		comments: {
+			list: (ws: string, slug: string) => commentsListMock(ws, slug),
+		},
+	},
+}));
+
+const { default: EpisodeFeed } = await import('./EpisodeFeed.svelte');
+
+let seq = 0;
+function act(minutesAgo: number, over: Partial<Activity> = {}): Activity {
+	seq += 1;
+	return {
+		id: `a${seq}`,
+		workspace_id: 'ws',
+		action: 'updated',
+		actor: 'agent',
+		source: 'cli',
+		metadata: '{}',
+		created_at: new Date(Date.now() - minutesAgo * 60_000).toISOString(),
+		document_id: 'item-live',
+		item_ref: 'TASK-1',
+		item_title: 'Live thing',
+		item_slug: 'live-thing',
+		collection_slug: 'tasks',
+		...over,
+	};
+}
+
+function comment(body: string, minutesAgo: number): Comment {
+	return {
+		id: `c${++seq}`,
+		item_id: 'item-live',
+		workspace_id: 'ws',
+		author: 'agent',
+		body,
+		created_by: 'agent',
+		source: 'cli',
+		created_at: new Date(Date.now() - minutesAgo * 60_000).toISOString(),
+		updated_at: new Date(Date.now() - minutesAgo * 60_000).toISOString(),
+	};
+}
+
+/** 5 activities folding into 2 episodes: one live (agent, minutes old) and
+ *  one stale (user, hours old). Newest-first, as the API delivers. */
+function fiveActivitiesTwoEpisodes(): Activity[] {
+	const stale = {
+		actor: 'user',
+		actor_name: 'Dave',
+		source: 'web',
+		document_id: 'item-stale',
+		item_ref: 'DOC-9',
+		item_title: 'Stale thing',
+		item_slug: 'stale-thing',
+		collection_slug: 'docs',
+	};
+	return [act(1), act(3), act(5), act(120, stale), act(125, stale)];
+}
+
+let host: HTMLElement;
+let app: Record<string, unknown> | null = null;
+
+function mountFeed(activities: Activity[]) {
+	app = mount(EpisodeFeed, {
+		target: host,
+		props: { activities, wsSlug: 'ws', username: 'alice' },
+	}) as Record<string, unknown>;
+	flushSync();
+}
+
+/** Let the mount effect fire, the comments fetch resolve, and the checkpoint
+ *  state re-render. */
+async function settle() {
+	flushSync();
+	await Promise.resolve();
+	await Promise.resolve();
+	await tick();
+	flushSync();
+}
+
+beforeEach(() => {
+	host = document.createElement('div');
+	document.body.appendChild(host);
+	commentsListMock.mockReset();
+	commentsListMock.mockResolvedValue([]);
+});
+
+afterEach(() => {
+	if (app) unmount(app as never);
+	app = null;
+	host.remove();
+});
+
+describe('EpisodeFeed', () => {
+	it('renders one card per episode, not per activity', async () => {
+		mountFeed(fiveActivitiesTwoEpisodes());
+		await settle();
+
+		expect(host.querySelectorAll('.episode-card')).toHaveLength(2);
+	});
+
+	it('sections live episodes under "happening now" and stale ones under "earlier"', async () => {
+		mountFeed(fiveActivitiesTwoEpisodes());
+		await settle();
+
+		const sections = Array.from(host.querySelectorAll('.feed-section'));
+		const bySection = (label: string) =>
+			sections.find((s) =>
+				s.querySelector('.section-label')?.textContent?.toLowerCase().includes(label)
+			);
+
+		const happeningNow = bySection('happening now');
+		const earlier = bySection('earlier');
+		expect(happeningNow).toBeDefined();
+		expect(earlier).toBeDefined();
+		expect(happeningNow!.textContent).toContain('Live thing');
+		expect(happeningNow!.textContent).not.toContain('Stale thing');
+		expect(earlier!.textContent).toContain('Stale thing');
+		expect(earlier!.textContent).not.toContain('Live thing');
+	});
+
+	it('fetches the checkpoint line only for live episodes and shows the newest comment first line', async () => {
+		commentsListMock.mockResolvedValue([
+			comment('older note\nnot this line', 30),
+			comment('Checkpoint: wiring the fold\nsecond line stays hidden', 2),
+		]);
+
+		mountFeed(fiveActivitiesTwoEpisodes());
+		await settle();
+
+		// Enrichment ran only for the live episode's item, never the stale one.
+		expect(commentsListMock).toHaveBeenCalledTimes(1);
+		expect(commentsListMock).toHaveBeenCalledWith('ws', 'live-thing');
+
+		const checkpoint = host.querySelector('.ep-checkpoint');
+		expect(checkpoint).not.toBeNull();
+		expect(checkpoint!.textContent).toContain('latest: Checkpoint: wiring the fold');
+		expect(checkpoint!.textContent).not.toContain('second line stays hidden');
+	});
+});

--- a/web/src/lib/components/timeline/timelineActivityDroppedFields.svelte.test.ts
+++ b/web/src/lib/components/timeline/timelineActivityDroppedFields.svelte.test.ts
@@ -17,7 +17,7 @@ function activity(overrides: Partial<Activity> = {}): Activity {
 	return {
 		id: 'act-1',
 		workspace_id: 'ws-1',
-		item_id: 'item-1',
+		document_id: 'item-1',
 		action: 'moved',
 		actor: 'user',
 		actor_name: 'Dave',

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -1329,7 +1329,10 @@ export interface View {
 export interface Activity {
 	id: string;
 	workspace_id: string;
-	item_id?: string;
+	/** The referenced item's UUID. Wire name is `document_id` (the audit
+	 *  trail predates the document→item rename; internal/models/activity.go
+	 *  serializes it as such) — there is no `item_id` on this payload. */
+	document_id?: string;
 	action: string;
 	actor: string;
 	actor_name?: string;

--- a/web/src/lib/utils/activityEpisodes.test.ts
+++ b/web/src/lib/utils/activityEpisodes.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from 'vitest';
+import { foldEpisodes } from './activityEpisodes';
+import type { Activity } from '$lib/types';
+
+// Fixed clock: all tests measure liveness against this instant.
+const NOW = new Date('2026-08-24T12:00:00Z').getTime();
+const now = () => NOW;
+
+let seq = 0;
+function act(minutesAgo: number, over: Partial<Activity> = {}): Activity {
+	seq += 1;
+	return {
+		id: `a${seq}`,
+		workspace_id: 'ws',
+		action: 'updated',
+		actor: 'agent',
+		source: 'cli',
+		metadata: '{"agent":"claude-code"}',
+		created_at: new Date(NOW - minutesAgo * 60_000).toISOString(),
+		document_id: 'item-1',
+		item_ref: 'BUG-1',
+		item_title: 'One',
+		item_slug: 'one',
+		collection_slug: 'bugs',
+		...over
+	};
+}
+
+describe('foldEpisodes', () => {
+	it('folds consecutive same-actor same-item events into one episode', () => {
+		const eps = foldEpisodes([act(1), act(5), act(9)], { now });
+		expect(eps).toHaveLength(1);
+		expect(eps[0].count).toBe(3);
+		expect(eps[0].latest.created_at > eps[0].first.created_at).toBe(true);
+		expect(eps[0].spanMs).toBe(8 * 60_000);
+	});
+
+	it('splits a run when the gap exceeds gapMinutes', () => {
+		const eps = foldEpisodes([act(1), act(5), act(50), act(52)], { now, gapMinutes: 30 });
+		expect(eps).toHaveLength(2);
+		expect(eps[0].count).toBe(2);
+		expect(eps[1].count).toBe(2);
+	});
+
+	it('does NOT split on an interleaved sibling: runs are per (actor,item), not per feed position', () => {
+		// Two items being worked simultaneously — rows interleave in the feed.
+		const eps = foldEpisodes(
+			[
+				act(1),
+				act(2, { document_id: 'item-2', item_ref: 'BUG-2', item_slug: 'two' }),
+				act(3),
+				act(4, { document_id: 'item-2', item_ref: 'BUG-2', item_slug: 'two' })
+			],
+			{ now }
+		);
+		expect(eps).toHaveLength(2);
+		expect(eps.map((e) => e.count)).toEqual([2, 2]);
+	});
+
+	it('separates actors on the same item', () => {
+		const eps = foldEpisodes([act(1), act(2, { actor: 'user', actor_name: 'Dave', source: 'web' })], {
+			now
+		});
+		expect(eps).toHaveLength(2);
+		expect(eps.map((e) => e.actorKind).sort()).toEqual(['agent', 'user']);
+	});
+
+	it('claims live only from event age, and only within liveMinutes', () => {
+		const eps = foldEpisodes([act(3), act(200, { document_id: 'item-2', item_ref: 'BUG-2' })], {
+			now,
+			liveMinutes: 10
+		});
+		expect(eps[0].live).toBe(true);
+		expect(eps[1].live).toBe(false);
+	});
+
+	it('keeps the first non-empty enrichment when the newest row lacks it', () => {
+		const eps = foldEpisodes([act(1, { item_title: undefined, item_ref: undefined }), act(2)], {
+			now
+		});
+		expect(eps).toHaveLength(1);
+		expect(eps[0].itemRef).toBe('BUG-1');
+		expect(eps[0].itemTitle).toBe('One');
+	});
+
+	it('never shows a generic client id as a seat name', () => {
+		const eps = foldEpisodes([act(1, { metadata: '{"agent":"claude-code"}' })], { now });
+		expect(eps[0].actorLabel).toBe('agent');
+	});
+
+	it('surfaces a stamped seat name from metadata and separates seats by it', () => {
+		const eps = foldEpisodes(
+			[
+				act(1, { metadata: '{"agent":"wren"}' }),
+				act(2, { metadata: '{"agent":"rook"}' })
+			],
+			{ now }
+		);
+		expect(eps).toHaveLength(2);
+		expect(eps.map((e) => e.actorLabel).sort()).toEqual(['rook', 'wren']);
+	});
+
+	it('tolerates unparseable metadata and workspace-level rows', () => {
+		const eps = foldEpisodes(
+			[act(1, { metadata: 'not json', document_id: undefined, item_ref: undefined, item_slug: undefined })],
+			{ now }
+		);
+		expect(eps).toHaveLength(1);
+		expect(eps[0].actorLabel).toBe('agent');
+	});
+
+	it('dedupes actions newest-first', () => {
+		const eps = foldEpisodes([act(1), act(2, { action: 'created' }), act(3)], { now });
+		expect(eps[0].actions).toEqual(['updated', 'created']);
+	});
+});

--- a/web/src/lib/utils/activityEpisodes.ts
+++ b/web/src/lib/utils/activityEpisodes.ts
@@ -1,0 +1,146 @@
+import type { Activity } from '$lib/types';
+
+/**
+ * The episode fold behind the activity page's Live view (IDEA-2755).
+ *
+ * An EPISODE is a run of consecutive activities by one actor on one item,
+ * split when the gap between neighbours exceeds `gapMinutes`. The fold turns
+ * an audit-grain feed (one row per event) into work-grain cards (one per
+ * episode) — the collapse operator is the whole feature; rendering is just
+ * the page's existing vocabulary.
+ *
+ * Identity today is (actor kind + name, item). The server stamps
+ * `metadata.agent` from the client's X-Pad-Agent header
+ * (handlers_documents.go auditMeta) — every current seat sends the generic
+ * client id "claude-code", so agent rows collapse to one "agent" label and
+ * seats are distinguishable only by the disjoint items they work, which
+ * multi-seat turf discipline already guarantees. The moment a seat sends
+ * its own name in X-Pad-Agent, its label (and fold key) lights up here with
+ * no further change — concept B's lanes want exactly that.
+ *
+ * LIVENESS is claimed only from evidence: an episode is `live` when its
+ * newest event is younger than `liveMinutes`. The view never says "active
+ * now" — it says how long ago the last event arrived, which is all the feed
+ * actually knows (the delivery-honesty rule, inherited).
+ */
+
+export interface Episode {
+	/** Stable key: actorKey + item key of the run. */
+	key: string;
+	itemRef?: string;
+	itemTitle?: string;
+	itemSlug?: string;
+	collectionSlug?: string;
+	/** Display label for the actor ("Dave", "agent", a seat name when stamped). */
+	actorLabel: string;
+	/** "agent" | "user" — drives the row's border treatment like the audit view. */
+	actorKind: string;
+	/** Newest activity in the episode (activities arrive newest-first). */
+	latest: Activity;
+	/** Oldest activity in the episode. */
+	first: Activity;
+	/** Event count folded into this card. */
+	count: number;
+	/** Distinct actions seen, newest first, deduped (e.g. ["updated","created"]). */
+	actions: string[];
+	/** Milliseconds between first and latest event. */
+	spanMs: number;
+	/** Newest event is younger than liveMinutes. */
+	live: boolean;
+}
+
+export interface FoldOptions {
+	/** Gap that splits two runs on the same (actor, item) into episodes. */
+	gapMinutes?: number;
+	/** Age of the newest event below which an episode renders as live. */
+	liveMinutes?: number;
+	/** Clock injection for tests. */
+	now?: () => number;
+}
+
+/** Client ids that are tools, not seats — never shown as an actor name. */
+const GENERIC_AGENT_IDS = new Set(['claude-code', 'cli', 'agent']);
+
+function metaAgentName(metadata: string): string | undefined {
+	try {
+		const meta = JSON.parse(metadata) as Record<string, unknown>;
+		const name = meta.agent;
+		if (typeof name !== 'string' || name.length === 0) return undefined;
+		return GENERIC_AGENT_IDS.has(name) ? undefined : name;
+	} catch {
+		return undefined;
+	}
+}
+
+function actorKeyOf(a: Activity): { key: string; label: string; kind: string } {
+	const seat = metaAgentName(a.metadata);
+	if (a.actor === 'agent') {
+		const label = seat ?? 'agent';
+		return { key: `agent:${label}`, label, kind: 'agent' };
+	}
+	const label = a.actor_name ?? (a.source === 'cli' ? 'cli' : 'web');
+	return { key: `user:${label}`, label, kind: 'user' };
+}
+
+/**
+ * Fold a newest-first activity list into newest-first episodes.
+ *
+ * Input order is the API's contract (created_at descending); the fold walks
+ * it once and keeps that order for the output, so the newest episode — the
+ * one whose newest event is youngest — is element 0. Splitting compares each
+ * event against the OLDEST event already in the open run for its key, since
+ * walking newest-first means the next same-key event is always older.
+ */
+export function foldEpisodes(activities: Activity[], opts: FoldOptions = {}): Episode[] {
+	const gapMs = (opts.gapMinutes ?? 30) * 60_000;
+	const liveMs = (opts.liveMinutes ?? 10) * 60_000;
+	const now = opts.now ?? Date.now;
+
+	const episodes: Episode[] = [];
+	// Open run per fold key; closed when a same-key event falls past the gap.
+	const open = new Map<string, Episode>();
+
+	for (const a of activities) {
+		const actor = actorKeyOf(a);
+		const itemKey = a.document_id ?? a.item_ref ?? 'workspace';
+		const key = `${actor.key}|${itemKey}`;
+		const t = new Date(a.created_at).getTime();
+
+		const run = open.get(key);
+		if (run && new Date(run.first.created_at).getTime() - t <= gapMs) {
+			run.first = a;
+			run.count += 1;
+			if (!run.actions.includes(a.action)) run.actions.push(a.action);
+			run.spanMs = new Date(run.latest.created_at).getTime() - t;
+			// Enrichment fields can be absent on some rows (e.g. the newest
+			// row lacks item_title); keep the first non-empty value seen.
+			run.itemRef ??= a.item_ref;
+			run.itemTitle ??= a.item_title;
+			run.itemSlug ??= a.item_slug;
+			run.collectionSlug ??= a.collection_slug;
+			continue;
+		}
+
+		// Past the gap: the old run stays closed in `episodes` (it is already
+		// there); this event opens a fresh run under the same key.
+		const ep: Episode = {
+			key: `${key}@${a.id}`,
+			itemRef: a.item_ref,
+			itemTitle: a.item_title,
+			itemSlug: a.item_slug,
+			collectionSlug: a.collection_slug,
+			actorLabel: actor.label,
+			actorKind: actor.kind,
+			latest: a,
+			first: a,
+			count: 1,
+			actions: [a.action],
+			spanMs: 0,
+			live: now() - t <= liveMs
+		};
+		open.set(key, ep);
+		episodes.push(ep);
+	}
+
+	return episodes;
+}

--- a/web/src/routes/[username]/[workspace]/activity/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/activity/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { page } from '$app/state';
+	import { browser } from '$app/environment';
 	import { onMount } from 'svelte';
 	import { api } from '$lib/api/client';
 	import { workspaceStore } from '$lib/stores/workspace.svelte';
@@ -9,6 +10,7 @@
 	import { createScrollRestoration } from '$lib/scroll/restore.svelte';
 	import PageHeader from '$lib/components/common/PageHeader.svelte';
 	import EmptyState from '$lib/components/common/EmptyState.svelte';
+	import EpisodeFeed from '$lib/components/activity/EpisodeFeed.svelte';
 	import type { Activity, Collection } from '$lib/types';
 
 	let wsSlug = $derived(page.params.workspace ?? '');
@@ -41,6 +43,31 @@
 	let filterAction = $state('');
 	let filterSource = $state('');
 	let filterCollection = $state('');
+
+	// View mode: episode cards (Live) vs the raw audit timeline. Persisted so
+	// the choice survives navigation.
+	// Server HTML and the client's hydration pass must agree, and the server
+	// cannot read localStorage — so BOTH default to 'live', and the stored
+	// choice applies in onMount, strictly after hydration. (`browser`, not
+	// `typeof localStorage`: Node 25 ships an experimental global
+	// localStorage, so the typeof probe stops discriminating SSR from the
+	// browser on the runtime this repo actually develops on.)
+	let view = $state<'live' | 'audit'>('live');
+	let viewRestored = false;
+
+	onMount(() => {
+		const stored = localStorage.getItem('pad-activity-view');
+		if (stored === 'audit' || stored === 'live') view = stored;
+		viewRestored = true;
+	});
+
+	$effect(() => {
+		// Persist only after the restore read, or the SSR default clobbers
+		// the stored choice before onMount can apply it.
+		if (browser && viewRestored) {
+			localStorage.setItem('pad-activity-view', view);
+		}
+	});
 
 	const PAGE_SIZE = 30;
 
@@ -241,6 +268,26 @@
 	<!-- Filters -->
 	<div class="filters-row">
 		<div class="filter-group">
+			<span class="filter-label">View</span>
+			<div class="view-toggle" role="group" aria-label="View mode">
+				<button
+					class="view-segment"
+					class:selected={view === 'live'}
+					onclick={() => (view = 'live')}
+				>
+					Live
+				</button>
+				<button
+					class="view-segment"
+					class:selected={view === 'audit'}
+					onclick={() => (view = 'audit')}
+				>
+					Audit
+				</button>
+			</div>
+		</div>
+
+		<div class="filter-group">
 			<label class="filter-label" for="filter-action">Action</label>
 			<select id="filter-action" class="filter-select" bind:value={filterAction}>
 				<option value="">All actions</option>
@@ -296,6 +343,9 @@
 				</div>
 			{/each}
 		</div>
+	{:else if view === 'live'}
+		<EpisodeFeed activities={filteredActivities} {wsSlug} {username} />
+		{@render loadMoreButton()}
 	{:else if filteredActivities.length === 0}
 		<EmptyState
 			icon="~"
@@ -376,19 +426,23 @@
 			{/each}
 		</div>
 
-		{#if hasMore && !filterCollection}
-			<div class="load-more-wrapper">
-				<button class="load-more-btn" onclick={loadMore} disabled={loadingMore}>
-					{#if loadingMore}
-						Loading...
-					{:else}
-						Load more activity
-					{/if}
-				</button>
-			</div>
-		{/if}
+		{@render loadMoreButton()}
 	{/if}
 </div>
+
+{#snippet loadMoreButton()}
+	{#if hasMore && !filterCollection}
+		<div class="load-more-wrapper">
+			<button class="load-more-btn" onclick={loadMore} disabled={loadingMore}>
+				{#if loadingMore}
+					Loading...
+				{:else}
+					Load more activity
+				{/if}
+			</button>
+		</div>
+	{/if}
+{/snippet}
 
 <style>
 	/* ── Page Layout ──────────────────────────────────────────────────── */
@@ -439,6 +493,31 @@
 	.filter-select:focus {
 		outline: none;
 		border-color: var(--accent-blue);
+	}
+	.view-toggle {
+		display: inline-flex;
+		gap: 2px;
+		background: var(--bg-tertiary);
+		border-radius: 8px;
+		padding: 2px;
+	}
+	.view-segment {
+		border: none;
+		background: transparent;
+		color: var(--text-secondary);
+		font-size: 12px;
+		font-weight: 600;
+		padding: 4px 12px;
+		border-radius: 6px;
+		cursor: pointer;
+		transition: background 0.15s, color 0.15s;
+	}
+	.view-segment:hover:not(.selected) {
+		color: var(--text-primary);
+	}
+	.view-segment.selected {
+		background: var(--accent-primary);
+		color: white;
 	}
 	.clear-filters {
 		background: none;


### PR DESCRIPTION
Concept A of IDEA-2755 (design canvas + full decision record on the item): a Live/Audit toggle on the workspace activity page. Live folds the audit-grain feed into work-grain EPISODES — one card per run of consecutive events by one actor on one item (30m gap split), 'happening now' vs 'earlier' sections, liveness claimed only from event age, live cards enriched with the newest comment's first line.

Second commit fixes a wire-contract phantom found en route: Activity's TS type declared item_id where the server serializes document_id; fold, type, and fixtures now match the real contract (Comment.item_id deliberately unchanged — the two types genuinely differ).

Review: 4 codex rounds to convergence, 5 findings fixed — details on IDEA-2755's trail. Unit built by the lead session as gate-window side-work; seats' queues untouched.

https://claude.ai/code/session_01HvAuiZ7JaWyCqqyV99LyWt