### PR TITLE
fix(watchevents): bound the resume settle window by the request context (BUG-2751)

### DIFF
--- a/internal/server/handlers_push_publish_result_test.go
+++ b/internal/server/handlers_push_publish_result_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -47,7 +48,7 @@ func (b *stubBus) publishAttempts() int {
 }
 
 func (b *stubBus) Subscribe() (chan watchevents.Notification, <-chan struct{}) { return nil, nil }
-func (b *stubBus) SubscribeAndReplaySince(int64) (chan watchevents.Notification, []watchevents.Notification, <-chan struct{}) {
+func (b *stubBus) SubscribeAndReplaySince(context.Context, int64) (chan watchevents.Notification, []watchevents.Notification, <-chan struct{}) {
 	return nil, nil, nil
 }
 func (b *stubBus) Unsubscribe(chan watchevents.Notification) {}

--- a/internal/server/handlers_stream_gap_test.go
+++ b/internal/server/handlers_stream_gap_test.go
@@ -63,8 +63,8 @@ func (b *gapWatchBus) Subscribe() (chan watchevents.Notification, <-chan struct{
 	return ch, b.gaps
 }
 
-func (b *gapWatchBus) SubscribeAndReplaySince(sinceID int64) (chan watchevents.Notification, []watchevents.Notification, <-chan struct{}) {
-	ch, missed, _ := b.Bus.SubscribeAndReplaySince(sinceID)
+func (b *gapWatchBus) SubscribeAndReplaySince(ctx context.Context, sinceID int64) (chan watchevents.Notification, []watchevents.Notification, <-chan struct{}) {
+	ch, missed, _ := b.Bus.SubscribeAndReplaySince(ctx, sinceID)
 	return ch, missed, b.gaps
 }
 

--- a/internal/server/handlers_watch_events.go
+++ b/internal/server/handlers_watch_events.go
@@ -152,7 +152,12 @@ func (s *Server) handleWatchEventsStream(w http.ResponseWriter, r *http.Request)
 	if lastIDStr := r.Header.Get("Last-Event-ID"); lastIDStr != "" {
 		if parsed, perr := strconv.ParseInt(lastIDStr, 10, 64); perr == nil && parsed > 0 {
 			lastID = parsed
-			ch, missed, gaps = s.watchEvents.SubscribeAndReplaySince(lastID)
+			// r.Context() rather than the bus's own lifetime (BUG-2751). The
+			// Redis implementation may wait a settle window plus two round trips
+			// here, and this handler is holding a global AND a per-user admission
+			// slot that only come back on return — so a client that disconnects
+			// mid-wait would otherwise keep both for the remainder of it.
+			ch, missed, gaps = s.watchEvents.SubscribeAndReplaySince(r.Context(), lastID)
 		} else {
 			unreadableCursor = true
 			slog.Info("watch-events: resume carried an unreadable Last-Event-ID, sending sync_required",

--- a/internal/server/handlers_watch_events_cancel_test.go
+++ b/internal/server/handlers_watch_events_cancel_test.go
@@ -1,0 +1,123 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/watchevents"
+)
+
+// slowSettleWatchBus stands in for the Redis watch bus during its resume
+// settle window: a wait that is cancellable, on the caller's context.
+//
+// It reproduces the real contract rather than a stub's. RedisBus's
+// resumeOutrunsLocalView does a Redis GET, waits `settleWindow`, then does a
+// second GET — and until BUG-2751 that wait was bounded by the BUS's lifetime,
+// so a departed client kept paying for it.
+type slowSettleWatchBus struct {
+	watchevents.Bus
+	hold time.Duration
+
+	once    sync.Once
+	entered chan struct{}
+}
+
+func (b *slowSettleWatchBus) SubscribeAndReplaySince(ctx context.Context, sinceID int64) (chan watchevents.Notification, []watchevents.Notification, <-chan struct{}) {
+	b.once.Do(func() { close(b.entered) })
+	select {
+	case <-ctx.Done():
+		// What the real bus does on a cancelled settle: stop waiting and
+		// answer from what it already has. The handler is unwinding anyway.
+		return b.Bus.SubscribeAndReplaySince(ctx, sinceID)
+	case <-time.After(b.hold):
+		return b.Bus.SubscribeAndReplaySince(ctx, sinceID)
+	}
+}
+
+// TestDisconnectDuringTheResumeSettleReleasesTheAdmissionSlot is BUG-2751's
+// BINDING assertion, and the half of the bug that lives in this package.
+//
+// internal/watchevents' own tests vouch for the bus honouring a cancelled
+// context; they say nothing about whether this handler ever hands it one. That
+// is the same gap CONVE-19 names, and the reason BUG-2749 needed a twin of this
+// test for the other stream.
+//
+// The slot is the cost. It is reserved before the subscribe and released by
+// defer, so for as long as the settle window ran to completion for a departed
+// client, a connection that no longer existed counted against both the
+// per-instance and the per-principal bound (BUG-2726).
+//
+// ASSERTS ITS OWN PREMISES, both of them: that the settle was actually entered,
+// and that the slot was actually held at that moment. Without those the timing
+// check below would pass against a handler that refused the connection outright
+// and never reserved anything.
+func TestDisconnectDuringTheResumeSettleReleasesTheAdmissionSlot(t *testing.T) {
+	t.Parallel()
+	srv := testServerWithWatchEvents(t)
+	_, _, tok, _ := setupWatchTestUser(t, srv)
+
+	bus := &slowSettleWatchBus{
+		Bus: watchevents.New(),
+		// Long enough that a handler ignoring the request context cannot
+		// finish inside the release deadline below by luck.
+		hold:    5 * time.Second,
+		entered: make(chan struct{}),
+	}
+	srv.SetWatchEventsBus(bus)
+
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL+"/api/v1/events/stream", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+tok.Token)
+	// A resume, which is the only path that reaches the settle window at all.
+	// Without this header the handler takes plain Subscribe and this test would
+	// pass against every implementation.
+	req.Header.Set("Last-Event-ID", "1")
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		resp, err := http.DefaultClient.Do(req)
+		if err == nil {
+			_ = resp.Body.Close()
+		}
+	}()
+
+	select {
+	case <-bus.entered:
+	case <-time.After(5 * time.Second):
+		cancel()
+		t.Fatal("the resume path was never entered; this test never reached the window it is named for")
+	}
+
+	if held := srv.admission().heldTotal(); held != 1 {
+		cancel()
+		t.Fatalf("admission slots held during the settle = %d, want 1 — the slot this test is about was never reserved", held)
+	}
+
+	// The client goes away mid-settle.
+	cancel()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if srv.admission().heldTotal() == 0 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("the admission slot was still held %v after the client disconnected, with %v of the bus hold left to run: "+
+				"capacity is reserved for a connection that no longer exists",
+				2*time.Second, bus.hold)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	<-done
+}

--- a/internal/watchevents/cold_resume_test.go
+++ b/internal/watchevents/cold_resume_test.go
@@ -1,6 +1,7 @@
 package watchevents
 
 import (
+	"context"
 	"sync"
 	"testing"
 )
@@ -89,7 +90,7 @@ func TestACursorFromAPreviousIncarnationIsAGapEvenWithAWarmBuffer(t *testing.T) 
 	// guard was written inline in EventsSince the handler's path did not have
 	// it, and every assertion above still passed. Both entry points, or the
 	// fix is only true of the one nobody calls.
-	ch, missed, _ := b.SubscribeAndReplaySince(1)
+	ch, missed, _ := b.SubscribeAndReplaySince(context.Background(), 1)
 	defer b.Unsubscribe(ch)
 	if ch == nil {
 		t.Fatal("the subscription must still be established when the replay is refused")
@@ -97,7 +98,7 @@ func TestACursorFromAPreviousIncarnationIsAGapEvenWithAWarmBuffer(t *testing.T) 
 	if missed != nil {
 		t.Fatalf("SubscribeAndReplaySince must refuse a previous incarnation's cursor, got %d notifications", len(missed))
 	}
-	ch2, missed2, _ := b.SubscribeAndReplaySince(b.base + 1)
+	ch2, missed2, _ := b.SubscribeAndReplaySince(context.Background(), b.base+1)
 	defer b.Unsubscribe(ch2)
 	if missed2 == nil {
 		t.Fatal("SubscribeAndReplaySince must serve a cursor this incarnation issued")
@@ -112,7 +113,7 @@ func TestSubscribeAndReplaySinceRefusesAColdResume(t *testing.T) {
 	b := New()
 	t.Cleanup(b.Close)
 
-	ch, missed, _ := b.SubscribeAndReplaySince(b.base + 4200)
+	ch, missed, _ := b.SubscribeAndReplaySince(context.Background(), b.base+4200)
 	if ch == nil {
 		t.Fatal("the subscription must still be established even when the replay is refused")
 	}
@@ -121,7 +122,7 @@ func TestSubscribeAndReplaySinceRefusesAColdResume(t *testing.T) {
 	}
 
 	// Control: a fresh subscriber gets a usable, non-gap answer.
-	ch2, missed2, _ := b.SubscribeAndReplaySince(0)
+	ch2, missed2, _ := b.SubscribeAndReplaySince(context.Background(), 0)
 	defer b.Unsubscribe(ch2)
 	if ch2 == nil {
 		t.Fatal("a fresh subscription must be established")
@@ -150,7 +151,7 @@ func TestMemoryBusReportsItsOwnResumeGaps(t *testing.T) {
 	if got := b.EventsSince(b.base + 4200); got != nil {
 		t.Fatalf("expected a gap, got %d", len(got))
 	}
-	ch, missed, _ := b.SubscribeAndReplaySince(b.base + 4200)
+	ch, missed, _ := b.SubscribeAndReplaySince(context.Background(), b.base+4200)
 	if missed != nil {
 		t.Fatalf("expected a gap, got %d", len(missed))
 	}
@@ -172,7 +173,7 @@ func TestMemoryBusReportsItsOwnResumeGaps(t *testing.T) {
 	if got := b.EventsSince(warm[0].ID); got == nil {
 		t.Fatal("a caught-up cursor must be served")
 	}
-	ch2, missed2, _ := b.SubscribeAndReplaySince(0)
+	ch2, missed2, _ := b.SubscribeAndReplaySince(context.Background(), 0)
 	defer b.Unsubscribe(ch2)
 	if missed2 == nil {
 		t.Fatal("a fresh subscriber must not be answered with a gap")

--- a/internal/watchevents/observer_test.go
+++ b/internal/watchevents/observer_test.go
@@ -1,6 +1,7 @@
 package watchevents
 
 import (
+	"context"
 	"sync"
 	"testing"
 	"time"
@@ -414,7 +415,7 @@ func TestRedisBusReportsResumeGaps(t *testing.T) {
 			t.Fatalf("set counter: %v", err)
 		}
 
-		_, missed, _ := b.SubscribeAndReplaySince(1)
+		_, missed, _ := b.SubscribeAndReplaySince(context.Background(), 1)
 		if missed != nil {
 			t.Fatalf("premise failed: the resume was served rather than reported as a gap; got %+v", missed)
 		}
@@ -455,7 +456,7 @@ func TestRedisBusReportsResumeGaps(t *testing.T) {
 		}
 		before := obs.snapshot().resumeGaps
 
-		_, missed, _ := b.SubscribeAndReplaySince(1)
+		_, missed, _ := b.SubscribeAndReplaySince(context.Background(), 1)
 		if missed != nil {
 			t.Fatalf("premise failed: the resume was served rather than reported as a gap; got %+v", missed)
 		}
@@ -481,7 +482,7 @@ func TestRedisBusReportsResumeGaps(t *testing.T) {
 		}
 		b.Unsubscribe(ch)
 
-		if _, missed, _ := b.SubscribeAndReplaySince(1); missed == nil {
+		if _, missed, _ := b.SubscribeAndReplaySince(context.Background(), 1); missed == nil {
 			t.Fatal("premise failed: a current instance reported a gap")
 		}
 		if got := obs.snapshot(); got.resumeGaps != 0 {

--- a/internal/watchevents/redis_bus.go
+++ b/internal/watchevents/redis_bus.go
@@ -231,6 +231,16 @@ type RedisBus struct {
 	// while proving nothing.
 	afterSubscribeRegister func()
 
+	// beforeSettleWait is a test-only seam, nil in production. It runs in
+	// resumeOutrunsLocalView after the first counter read has DISAGREED and
+	// immediately before the settle wait begins.
+	//
+	// POSITIONAL, like its neighbour. It is the only point at which a test can
+	// land a cancellation strictly inside the window rather than racing it with
+	// a sleep — and a sleep-timed cancellation that lands late does not fail
+	// safe here, it just measures a different path (BUG-2751).
+	beforeSettleWait func()
+
 	// knownFrom / lastAppendedID bound what this instance can HONESTLY
 	// replay — a failure mode MemoryBus structurally cannot have and this
 	// one can (codex rounds 3 and 4).
@@ -493,11 +503,34 @@ func (b *RedisBus) Subscribe() (chan Notification, <-chan struct{}) {
 // and the caller turns that into sync_required.
 //
 // The third return is the subscriber's GAP SIGNAL — see Subscribe.
-func (b *RedisBus) SubscribeAndReplaySince(sinceID int64) (chan Notification, []Notification, <-chan struct{}) {
+func (b *RedisBus) SubscribeAndReplaySince(ctx context.Context, sinceID int64) (chan Notification, []Notification, <-chan struct{}) {
 	// Consulted BEFORE the lock: it sleeps and does network I/O. See its
 	// comment for why that ordering is also the only one that preserves the
 	// subscribe-and-replay guarantee.
-	forceGap := b.resumeOutrunsLocalView(sinceID)
+	//
+	// ctx IS THE CALLER'S, and that is the whole of BUG-2751. This runs on the
+	// request path while the SSE handler holds a global AND a per-user
+	// admission slot (BUG-2726), released by defer when the handler returns —
+	// so every moment spent here is capacity held for a client that may
+	// already be gone.
+	forceGap := b.resumeOutrunsLocalView(ctx, sinceID)
+
+	// A CALLER THAT HAS GONE IS NOT REGISTERED (BUG-2751, codex round 1).
+	// resumeOutrunsLocalView answers false on cancellation — "no forced gap" —
+	// which on its own reads as an ordinary converged resume, so the rest of
+	// this function would go on to register a subscriber and build a replay
+	// slice for a connection that is unwinding. Ending the wait early and then
+	// doing the work anyway is half a fix.
+	//
+	// The shape returned is the SAME one the closed-bus branch below returns:
+	// a closed channel, no replay. That matters at the call site — the handler
+	// falls back to plain Subscribe() when it gets a NIL channel, so returning
+	// nil here would re-register the very caller this is declining to serve.
+	if ctx.Err() != nil {
+		sub := newSubscriber()
+		close(sub.ch)
+		return sub.ch, nil, sub.gaps
+	}
 
 	// Registered FIRST so it runs LAST, after the Unlock — reports fire
 	// with no bus lock held. See Observer.
@@ -537,6 +570,24 @@ func (b *RedisBus) SubscribeAndReplaySince(sinceID int64) (chan Notification, []
 		pending.resumeGap()
 	}
 	return ch, missed, sub.gaps
+}
+
+// whicheverEndsFirst returns a context that ends when EITHER input does, and a
+// cancel that must be called to release the registration on the second one.
+//
+// It exists because the settle wait has two independent reasons to be
+// abandoned that live in different places: the client going away (BUG-2751)
+// and the bus closing. Deriving from one and ignoring the other silently drops
+// half the story — internal/events lost the shutdown half exactly that way in
+// its own first draft, which is why this is written as a merge rather than a
+// swap.
+func whicheverEndsFirst(caller, bus context.Context) (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(caller)
+	stop := context.AfterFunc(bus, cancel)
+	return ctx, func() {
+		stop()
+		cancel()
+	}
 }
 
 // settleWindow is how long resumeOutrunsLocalView waits before deciding that
@@ -590,12 +641,26 @@ const settleWindow = 250 * time.Millisecond
 // out that it is not the per-workspace firehose) and by resumes only
 // happening on reconnect. If a workload ever makes this chatty in practice,
 // the fix is a longer settle window, not a magnitude threshold.
-func (b *RedisBus) resumeOutrunsLocalView(sinceID int64) bool {
+func (b *RedisBus) resumeOutrunsLocalView(ctx context.Context, sinceID int64) bool {
 	if sinceID <= 0 || b.client == nil {
 		return false
 	}
 
-	remote, ok := b.sharedCounter()
+	// BOUNDED BY THE CALLER *AND* BY THE BUS, not by either alone (BUG-2751).
+	//
+	// It used to wait on b.ctx only — the bus's lifetime — so a client that
+	// disconnected during the settle window held its admission slots for the
+	// remainder of it plus two Redis round trips. The connection was gone; the
+	// capacity was not.
+	//
+	// Swapping to the caller's context alone would trade one leak for another:
+	// b.ctx is what lets Close cut a wait short, and dropping it would leave a
+	// shutdown blocked behind a client that is still connected. Both endings
+	// are reasons to stop, so the wait ends on either.
+	ctx, cancel := whicheverEndsFirst(ctx, b.ctx)
+	defer cancel()
+
+	remote, ok := b.sharedCounter(ctx)
 	if !ok {
 		return false
 	}
@@ -626,13 +691,22 @@ func (b *RedisBus) resumeOutrunsLocalView(sinceID int64) bool {
 	//
 	// Agreement between the authority and this instance is the condition, and
 	// it has to be evaluated on two fresh reads or it is not agreement at all.
-	select {
-	case <-b.ctx.Done():
-		return false
-	case <-time.After(settleWindow):
+	if b.beforeSettleWait != nil {
+		b.beforeSettleWait()
 	}
 
-	remote, ok = b.sharedCounter()
+	timer := time.NewTimer(settleWindow)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		// The caller left, or the bus is closing. Either way there is nobody
+		// to answer and no reason to hold the slot: returning false means "no
+		// forced gap", and the caller is about to unwind anyway.
+		return false
+	case <-timer.C:
+	}
+
+	remote, ok = b.sharedCounter(ctx)
 	if !ok {
 		return false
 	}
@@ -654,8 +728,8 @@ func (b *RedisBus) resumeOutrunsLocalView(sinceID int64) bool {
 // sharedCounter reads the authoritative sequence value. The bool is false when
 // it could not be read, which callers treat as "answer from local knowledge" —
 // see resumeOutrunsLocalView for why failing closed here would be worse.
-func (b *RedisBus) sharedCounter() (int64, bool) {
-	v, err := b.client.Get(b.ctx, b.keys.Name(redisWatchSeqSuffix)).Int64()
+func (b *RedisBus) sharedCounter(ctx context.Context) (int64, bool) {
+	v, err := b.client.Get(ctx, b.keys.Name(redisWatchSeqSuffix)).Int64()
 	switch {
 	case err == nil:
 		return v, true

--- a/internal/watchevents/redis_bus.go
+++ b/internal/watchevents/redis_bus.go
@@ -513,6 +513,17 @@ func (b *RedisBus) SubscribeAndReplaySince(ctx context.Context, sinceID int64) (
 	// admission slot (BUG-2726), released by defer when the handler returns —
 	// so every moment spent here is capacity held for a client that may
 	// already be gone.
+	// CHECKED BEFORE THE SETTLE PATH IS ENTERED AT ALL (codex round 2). Placed
+	// after it, an already-cancelled caller still made the first Redis GET —
+	// which fails on the dead context and logs "could not read the sequence
+	// counter to validate a resume" at WARN. That line means "Redis is
+	// unhealthy" to whoever reads it, and it would have fired on every client
+	// that hung up a moment before its resume landed. Ordinary disconnect
+	// churn would have looked like Redis trouble.
+	if ctx.Err() != nil {
+		return b.declineCancelledResume(sinceID)
+	}
+
 	forceGap := b.resumeOutrunsLocalView(ctx, sinceID)
 
 	// A CALLER THAT HAS GONE IS NOT REGISTERED (BUG-2751, codex round 1).
@@ -527,9 +538,7 @@ func (b *RedisBus) SubscribeAndReplaySince(ctx context.Context, sinceID int64) (
 	// falls back to plain Subscribe() when it gets a NIL channel, so returning
 	// nil here would re-register the very caller this is declining to serve.
 	if ctx.Err() != nil {
-		sub := newSubscriber()
-		close(sub.ch)
-		return sub.ch, nil, sub.gaps
+		return b.declineCancelledResume(sinceID)
 	}
 
 	// Registered FIRST so it runs LAST, after the Unlock — reports fire
@@ -570,6 +579,30 @@ func (b *RedisBus) SubscribeAndReplaySince(ctx context.Context, sinceID int64) (
 		pending.resumeGap()
 	}
 	return ch, missed, sub.gaps
+}
+
+// declineCancelledResume answers a caller that has already gone.
+//
+// SAME SHAPE AS THE CLOSED-BUS BRANCH — a closed channel, no replay, never nil.
+// nil is meaningful at the call site: the SSE handler falls back to plain
+// Subscribe() when it gets one, which would re-register the caller this is
+// declining.
+//
+// LOGGED AT DEBUG, AND DELIBERATELY NOT COUNTED (codex round 2). The finding
+// was that an operator cannot distinguish disconnect churn from no resume
+// activity. True, and the honest fix is not a counter: a client hanging up
+// during its own resume is ORDINARY on a mobile network, so a metric for it
+// would be a number nobody can act on, sitting next to
+// pad_watchevents_resume_gaps_total where it would be read as a fault. The
+// condition an operator does act on — capacity held by connections that no
+// longer exist — is already visible in the admission counts, and this change is
+// what keeps those honest.
+func (b *RedisBus) declineCancelledResume(sinceID int64) (chan Notification, []Notification, <-chan struct{}) {
+	slog.Debug("watchevents: resume abandoned before it could be served; the caller is gone",
+		"since_id", sinceID)
+	sub := newSubscriber()
+	close(sub.ch)
+	return sub.ch, nil, sub.gaps
 }
 
 // whicheverEndsFirst returns a context that ends when EITHER input does, and a

--- a/internal/watchevents/redis_bus.go
+++ b/internal/watchevents/redis_bus.go
@@ -781,6 +781,18 @@ func (b *RedisBus) sharedCounter(ctx context.Context) (int64, bool) {
 		// comparison: an instance holding 101 disagrees with an authority at
 		// 0, does not converge, and the resume is answered with a gap.
 		return 0, true
+	case ctx.Err() != nil:
+		// OUR OWN CANCELLATION IS NOT A REDIS FAULT (codex round 3). The
+		// caller can disconnect while this GET is IN FLIGHT, and the error
+		// that comes back is context.Canceled — indistinguishable, at the
+		// WARN below, from Redis being unreachable. That line is read as "the
+		// sequence counter is unhealthy", so on a stream where clients hang up
+		// mid-resume it would manufacture exactly the alarm an operator would
+		// chase. The entry-side decline catches a caller that was already
+		// gone; this catches one that left while we were asking.
+		slog.Debug("watchevents: resume abandoned while reading the sequence counter; the caller is gone",
+			"error", err)
+		return 0, false
 	default:
 		slog.Warn("watchevents: could not read the sequence counter to validate a resume; "+
 			"answering from local knowledge only", "error", err)

--- a/internal/watchevents/redis_bus.go
+++ b/internal/watchevents/redis_bus.go
@@ -581,6 +581,25 @@ func (b *RedisBus) SubscribeAndReplaySince(ctx context.Context, sinceID int64) (
 	return ch, missed, sub.gaps
 }
 
+// callerIsGone reports whether a Redis error is our own cancellation rather
+// than a fault worth telling an operator about.
+//
+// A FUNCTION OF THE ERROR ALONE, AND THAT IS THE FIX (codex round 4, which
+// BLOCKED on the earlier form). The first version asked ctx.Err() instead —
+// which cannot distinguish "the caller left" from "Redis failed while the
+// caller happened to be leaving", so a genuine failure coinciding with a
+// disconnect was downgraded to Debug and disappeared. That is the signal an
+// operator most needs, hidden by the change meant to reduce noise.
+//
+// Written as a predicate rather than inlined so the classification can be
+// tested for what it IS: the racing case cannot be staged deterministically
+// through a live client — go-redis decides, by timing, whether it returns the
+// context error or the server error — so the property is pinned here, where
+// timing plays no part.
+func callerIsGone(err error) bool {
+	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
+}
+
 // declineCancelledResume answers a caller that has already gone.
 //
 // SAME SHAPE AS THE CLOSED-BUS BRANCH — a closed channel, no replay, never nil.
@@ -781,15 +800,22 @@ func (b *RedisBus) sharedCounter(ctx context.Context) (int64, bool) {
 		// comparison: an instance holding 101 disagrees with an authority at
 		// 0, does not converge, and the resume is answered with a gap.
 		return 0, true
-	case ctx.Err() != nil:
+	case callerIsGone(err):
 		// OUR OWN CANCELLATION IS NOT A REDIS FAULT (codex round 3). The
 		// caller can disconnect while this GET is IN FLIGHT, and the error
-		// that comes back is context.Canceled — indistinguishable, at the
-		// WARN below, from Redis being unreachable. That line is read as "the
+		// that comes back is context.Canceled — indistinguishable, at the WARN
+		// below, from Redis being unreachable. That line is read as "the
 		// sequence counter is unhealthy", so on a stream where clients hang up
 		// mid-resume it would manufacture exactly the alarm an operator would
 		// chase. The entry-side decline catches a caller that was already
 		// gone; this catches one that left while we were asking.
+		//
+		// CLASSIFIED ON THE ERROR, NOT ON ctx.Err() (codex round 4, which
+		// BLOCKED on this). Asking the context instead asks the wrong
+		// question: a GENUINE Redis failure that merely coincides with a
+		// cancellation would be downgraded to Debug and vanish — precisely the
+		// signal an operator needs, hidden by the fix meant to reduce noise.
+		// The error itself is the only thing that says which happened.
 		slog.Debug("watchevents: resume abandoned while reading the sequence counter; the caller is gone",
 			"error", err)
 		return 0, false

--- a/internal/watchevents/redis_bus_resume_test.go
+++ b/internal/watchevents/redis_bus_resume_test.go
@@ -14,6 +14,8 @@ package watchevents
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"log/slog"
 	"strings"
 	"sync"
@@ -515,37 +517,54 @@ func TestClosingTheBusStillEndsTheSettleWindow(t *testing.T) {
 	}
 }
 
-// TestAResumeCancelledDuringTheCounterReadDoesNotLookLikeRedisTrouble is the
-// in-flight twin of the entry-path test (codex round 3).
+// TestACancelledCounterReadIsNotReportedAsRedisTrouble covers the in-flight
+// twin of the entry-path decline (codex round 3).
 //
 // The entry-side decline catches a caller that was ALREADY gone. A caller can
-// also leave while the first GET is in flight, and the error that comes back is
-// context.Canceled — which, at the sequence-counter WARN, is indistinguishable
-// from Redis being unreachable. On a stream where clients hang up mid-resume
-// that would manufacture exactly the alarm an operator would chase.
-func TestAResumeCancelledDuringTheCounterReadDoesNotLookLikeRedisTrouble(t *testing.T) {
-	b, mr := newMiniredisBus(t, 64)
-
-	b.Publish(Notification{Kind: KindComment, ItemRef: "TASK-1"})
-	waitFor(t, "the notification to be buffered", func() bool { return len(b.EventsSince(0)) == 1 })
-	if err := mr.Set(b.keys.Name(redisWatchSeqSuffix), "99"); err != nil {
-		t.Fatalf("set counter: %v", err)
-	}
+// also leave while the counter GET is in flight, and the error that comes back
+// is context.Canceled — indistinguishable, at the sequence-counter WARN, from
+// Redis being unreachable. On a stream where clients hang up mid-resume that
+// would manufacture exactly the alarm an operator would chase.
+//
+// DRIVEN AT sharedCounter RATHER THAN THROUGH THE HANDLER, deliberately. What
+// is under test is the CLASSIFICATION of the returned error, and staging a real
+// mid-flight cancellation means racing go-redis's read against a hook — which
+// decides, by timing, whether the error is a context error or a server error.
+// That is the thing being classified, so a test that leaves it to chance
+// measures whichever case it happened to produce.
+func TestACancelledCounterReadIsNotReportedAsRedisTrouble(t *testing.T) {
+	b, _ := newMiniredisBus(t, 64)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	cancel()
 
-	// CANCELLED FROM INSIDE THE COMMAND, which is what makes this the in-flight
-	// case rather than the entry case: the hook runs while the GET is being
-	// served, cancels the caller, and then fails the command so go-redis
-	// surfaces an error with ctx already dead.
+	var logged logCapture
+	restore := captureSlog(&logged)
+	defer restore()
+
+	if _, ok := b.sharedCounter(ctx); ok {
+		t.Fatal("a cancelled read must not be reported as a usable counter value")
+	}
+	if msg := logged.firstAtLeast(slog.LevelWarn); msg != "" {
+		t.Errorf("a cancelled counter read logged %q at WARN or above: disconnect churn is being reported as Redis trouble", msg)
+	}
+}
+
+// TestAGenuineCounterFailureIsStillReported is the control, and the reason the
+// test above is not simply a hole. Codex round 4 BLOCKED the first version of
+// this pair because the suppression keyed on ctx.Err() rather than on the
+// error: a real Redis failure that merely coincided with a cancellation would
+// have been downgraded to Debug and disappeared. Without this leg, "no WARN"
+// is satisfied by a bus that has stopped reporting Redis trouble at all.
+func TestAGenuineCounterFailureIsStillReported(t *testing.T) {
+	b, mr := newMiniredisBus(t, 64)
+
 	var hooked atomic.Bool
 	mr.Server().SetPreHook(func(p *server.Peer, cmd string, _ ...string) bool {
 		if !strings.EqualFold(cmd, "GET") || !hooked.CompareAndSwap(false, true) {
 			return false
 		}
-		cancel()
-		p.WriteError("simulated in-flight failure")
+		p.WriteError("simulated counter failure")
 		return true
 	})
 
@@ -553,14 +572,50 @@ func TestAResumeCancelledDuringTheCounterReadDoesNotLookLikeRedisTrouble(t *test
 	restore := captureSlog(&logged)
 	defer restore()
 
-	_, _, _ = b.SubscribeAndReplaySince(ctx, 1)
-
-	if !hooked.Load() {
-		t.Fatal("the counter read was never intercepted; this test did not reach the in-flight window")
+	if _, ok := b.sharedCounter(context.Background()); ok {
+		t.Fatal("a failed read must not be reported as a usable counter value")
 	}
-	if msg := logged.firstAtLeast(slog.LevelWarn); msg != "" {
-		t.Errorf("a caller that left during the counter read logged %q at WARN or above: "+
-			"disconnect churn is being reported as Redis trouble", msg)
+	if !hooked.Load() {
+		t.Fatal("the counter read was never intercepted; this test did not exercise a failure")
+	}
+	if msg := logged.firstAtLeast(slog.LevelWarn); msg == "" {
+		t.Error("a genuine Redis failure logged nothing at WARN: the cancellation suppression is hiding real trouble")
+	}
+}
+
+// TestCallerIsGoneClassifiesOnTheErrorNotTheContext is the test codex round 4's
+// BLOCK actually calls for, and the two integration legs above cannot provide.
+//
+// The blocked form asked ctx.Err(). Both forms agree on every case a live
+// client can be made to produce on demand — a cancelled context yields a
+// context error, a live one yields a server error — so the integration pair
+// passes against either. They disagree on exactly one case: a GENUINE Redis
+// failure whose error arrives while the context happens to be dead. Staging
+// that through a client is a race by construction, because go-redis decides by
+// timing which error it returns.
+//
+// Pinning it as a predicate removes the timing. The case that matters is the
+// last row.
+func TestCallerIsGoneClassifiesOnTheErrorNotTheContext(t *testing.T) {
+	serverErr := errors.New("READONLY You can't write against a read only replica")
+
+	for _, tc := range []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"a cancelled caller", context.Canceled, true},
+		{"a caller whose deadline passed", context.DeadlineExceeded, true},
+		{"a wrapped cancellation", fmt.Errorf("get counter: %w", context.Canceled), true},
+		{"a redis server error", serverErr, false},
+		// THE ROW THE BLOCK WAS ABOUT. Under the ctx.Err() form this was
+		// suppressed whenever a disconnect coincided with it, which is the one
+		// combination an operator cannot afford to lose.
+		{"a redis failure that merely coincides with a disconnect", fmt.Errorf("counter unreadable: %w", serverErr), false},
+	} {
+		if got := callerIsGone(tc.err); got != tc.want {
+			t.Errorf("%s: callerIsGone = %v, want %v", tc.name, got, tc.want)
+		}
 	}
 }
 

--- a/internal/watchevents/redis_bus_resume_test.go
+++ b/internal/watchevents/redis_bus_resume_test.go
@@ -14,6 +14,8 @@ package watchevents
 
 import (
 	"context"
+	"log/slog"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -383,6 +385,16 @@ func TestAResumeCancelledBeforeItStartsIsDeclinedOutright(t *testing.T) {
 	var reachedSettle atomic.Bool
 	b.beforeSettleWait = func() { reachedSettle.Store(true) }
 
+	// ASSERTED ON THE LOG, not on a proxy for it. Counting Redis reads was the
+	// first instrument and it measured nothing: go-redis short-circuits a
+	// cancelled context before it touches the wire, so no GET reaches miniredis
+	// whether or not the early decline exists, and removing that decline
+	// survived. The misleading WARN is emitted from sharedCounter's error path,
+	// so the log is the only thing that distinguishes the two.
+	var logged logCapture
+	restore := captureSlog(&logged)
+	defer restore()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
@@ -390,6 +402,11 @@ func TestAResumeCancelledBeforeItStartsIsDeclinedOutright(t *testing.T) {
 
 	if reachedSettle.Load() {
 		t.Error("an already-cancelled caller paid for the settle window")
+	}
+	if msg := logged.firstAtLeast(slog.LevelWarn); msg != "" {
+		t.Errorf("an already-cancelled caller logged %q at WARN or above: that line means 'Redis is unhealthy' to "+
+			"whoever reads it, and ordinary disconnect churn would fire it on every client that hung up a moment "+
+			"before its resume landed", msg)
 	}
 	if missed != nil {
 		t.Fatalf("an already-cancelled caller was handed %d replayed notifications", len(missed))
@@ -493,4 +510,42 @@ func TestClosingTheBusStillEndsTheSettleWindow(t *testing.T) {
 		t.Fatalf("a closing bus waited %v, the full settle window of %v: shutdown is blocked behind a connected client",
 			elapsed, settleWindow)
 	}
+}
+
+// logCapture records slog records so a test can assert on what an OPERATOR
+// would see. Used where the defect is a misleading line rather than a wrong
+// value — see TestAResumeCancelledBeforeItStartsIsDeclinedOutright.
+type logCapture struct {
+	mu      sync.Mutex
+	records []slog.Record
+}
+
+func (c *logCapture) Enabled(context.Context, slog.Level) bool { return true }
+
+func (c *logCapture) Handle(_ context.Context, r slog.Record) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.records = append(c.records, r.Clone())
+	return nil
+}
+
+func (c *logCapture) WithAttrs([]slog.Attr) slog.Handler { return c }
+func (c *logCapture) WithGroup(string) slog.Handler      { return c }
+
+// firstAtLeast returns the first message logged at or above level, or "".
+func (c *logCapture) firstAtLeast(level slog.Level) string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, r := range c.records {
+		if r.Level >= level {
+			return r.Message
+		}
+	}
+	return ""
+}
+
+func captureSlog(c *logCapture) func() {
+	prev := slog.Default()
+	slog.SetDefault(slog.New(c))
+	return func() { slog.SetDefault(prev) }
 }

--- a/internal/watchevents/redis_bus_resume_test.go
+++ b/internal/watchevents/redis_bus_resume_test.go
@@ -15,10 +15,13 @@ package watchevents
 import (
 	"context"
 	"log/slog"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/alicebob/miniredis/v2/server"
 )
 
 // TestResumeReportsAGapWhenThisInstanceMissedTheTail is the case the local
@@ -509,6 +512,55 @@ func TestClosingTheBusStillEndsTheSettleWindow(t *testing.T) {
 	if elapsed := time.Since(start); elapsed >= settleWindow {
 		t.Fatalf("a closing bus waited %v, the full settle window of %v: shutdown is blocked behind a connected client",
 			elapsed, settleWindow)
+	}
+}
+
+// TestAResumeCancelledDuringTheCounterReadDoesNotLookLikeRedisTrouble is the
+// in-flight twin of the entry-path test (codex round 3).
+//
+// The entry-side decline catches a caller that was ALREADY gone. A caller can
+// also leave while the first GET is in flight, and the error that comes back is
+// context.Canceled — which, at the sequence-counter WARN, is indistinguishable
+// from Redis being unreachable. On a stream where clients hang up mid-resume
+// that would manufacture exactly the alarm an operator would chase.
+func TestAResumeCancelledDuringTheCounterReadDoesNotLookLikeRedisTrouble(t *testing.T) {
+	b, mr := newMiniredisBus(t, 64)
+
+	b.Publish(Notification{Kind: KindComment, ItemRef: "TASK-1"})
+	waitFor(t, "the notification to be buffered", func() bool { return len(b.EventsSince(0)) == 1 })
+	if err := mr.Set(b.keys.Name(redisWatchSeqSuffix), "99"); err != nil {
+		t.Fatalf("set counter: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// CANCELLED FROM INSIDE THE COMMAND, which is what makes this the in-flight
+	// case rather than the entry case: the hook runs while the GET is being
+	// served, cancels the caller, and then fails the command so go-redis
+	// surfaces an error with ctx already dead.
+	var hooked atomic.Bool
+	mr.Server().SetPreHook(func(p *server.Peer, cmd string, _ ...string) bool {
+		if !strings.EqualFold(cmd, "GET") || !hooked.CompareAndSwap(false, true) {
+			return false
+		}
+		cancel()
+		p.WriteError("simulated in-flight failure")
+		return true
+	})
+
+	var logged logCapture
+	restore := captureSlog(&logged)
+	defer restore()
+
+	_, _, _ = b.SubscribeAndReplaySince(ctx, 1)
+
+	if !hooked.Load() {
+		t.Fatal("the counter read was never intercepted; this test did not reach the in-flight window")
+	}
+	if msg := logged.firstAtLeast(slog.LevelWarn); msg != "" {
+		t.Errorf("a caller that left during the counter read logged %q at WARN or above: "+
+			"disconnect churn is being reported as Redis trouble", msg)
 	}
 }
 

--- a/internal/watchevents/redis_bus_resume_test.go
+++ b/internal/watchevents/redis_bus_resume_test.go
@@ -13,6 +13,8 @@ package watchevents
 // in-flight ids arrive, missed ones never do.
 
 import (
+	"context"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -41,7 +43,7 @@ func TestResumeReportsAGapWhenThisInstanceMissedTheTail(t *testing.T) {
 		t.Fatalf("set counter: %v", err)
 	}
 
-	_, missed, _ := b.SubscribeAndReplaySince(1)
+	_, missed, _ := b.SubscribeAndReplaySince(context.Background(), 1)
 	if missed != nil {
 		t.Fatalf("a resume from 1 must report a gap when id 2 exists and we never saw it; got %+v", missed)
 	}
@@ -66,7 +68,7 @@ func TestResumeDoesNotReportAGapWhenTheInstanceIsCurrent(t *testing.T) {
 	}
 	b.Unsubscribe(ch)
 
-	_, missed, _ := b.SubscribeAndReplaySince(1)
+	_, missed, _ := b.SubscribeAndReplaySince(context.Background(), 1)
 	if missed == nil {
 		t.Fatal("this instance has seen everything the counter knows about; a resume must replay, not resync")
 	}
@@ -102,7 +104,7 @@ func TestResumeToleratesAnInFlightCounter(t *testing.T) {
 		b.fanOutLocally(Notification{ID: 2, Kind: KindComment, ItemRef: "TASK-2"})
 	}()
 
-	_, missed, _ := b.SubscribeAndReplaySince(1)
+	_, missed, _ := b.SubscribeAndReplaySince(context.Background(), 1)
 	if missed == nil {
 		t.Fatal("the id arrived during the settle window, so nothing was missed; " +
 			"reporting a gap here would resync on ordinary in-flight traffic")
@@ -140,7 +142,7 @@ func TestResumeReportsAGapWhenTheCounterAdvancesAgainDuringTheSettle(t *testing.
 		_ = mr.Set(b.keys.Name(redisWatchSeqSuffix), "3")
 	}()
 
-	_, missed, _ := b.SubscribeAndReplaySince(1)
+	_, missed, _ := b.SubscribeAndReplaySince(context.Background(), 1)
 	if missed != nil {
 		t.Fatalf("id 3 exists and never reached this instance; the resume must report a gap "+
 			"rather than converge against a stale counter snapshot; got %+v", missed)
@@ -177,7 +179,7 @@ func TestResumeDoesNotResyncWhenTheCounterReadRacedAPublish(t *testing.T) {
 		_ = mr.Set(b.keys.Name(redisWatchSeqSuffix), "2")
 	}()
 
-	_, missed, _ := b.SubscribeAndReplaySince(1)
+	_, missed, _ := b.SubscribeAndReplaySince(context.Background(), 1)
 	if missed == nil {
 		t.Fatal("this instance holds everything the counter ends up reporting; resyncing here " +
 			"would punish a client that missed nothing")
@@ -214,7 +216,7 @@ func TestResumeFallsBackToLocalKnowledgeWhenTheCounterIsUnreadable(t *testing.T)
 		t.Fatalf("seed a wrong-typed key: %v", err)
 	}
 
-	_, missed, _ := b.SubscribeAndReplaySince(1)
+	_, missed, _ := b.SubscribeAndReplaySince(context.Background(), 1)
 	if missed == nil {
 		t.Fatal("an unreadable counter must fall back to local knowledge, not resync every reconnect")
 	}
@@ -247,7 +249,7 @@ func TestResumeReportsAGapWhenTheCounterKeyDisappears(t *testing.T) {
 
 	mr.Del(b.keys.Name(redisWatchSeqSuffix))
 
-	_, missed, _ := b.SubscribeAndReplaySince(1)
+	_, missed, _ := b.SubscribeAndReplaySince(context.Background(), 1)
 	if missed != nil {
 		t.Fatalf("the counter is gone while this instance holds ids 1-2; replaying a dead id space "+
 			"is exactly what the next publish (starting again at 1) will collide with; got %+v", missed)
@@ -261,7 +263,7 @@ func TestResumeReportsAGapWhenTheCounterKeyDisappears(t *testing.T) {
 func TestResumeOnAVirginDeploymentDoesNotReportAGap(t *testing.T) {
 	b, _ := newMiniredisBus(t, 64)
 
-	if b.resumeOutrunsLocalView(5) {
+	if b.resumeOutrunsLocalView(context.Background(), 5) {
 		t.Error("nothing has ever been published and this instance has seen nothing; " +
 			"there is no gap to report")
 	}
@@ -281,11 +283,214 @@ func TestResumeIsUnaffectedForAFreshSubscriber(t *testing.T) {
 	}
 
 	start := time.Now()
-	_, missed, _ := b.SubscribeAndReplaySince(0)
+	_, missed, _ := b.SubscribeAndReplaySince(context.Background(), 0)
 	if elapsed := time.Since(start); elapsed >= settleWindow {
 		t.Errorf("a fresh subscriber waited %v — it should not pay the settle window at all", elapsed)
 	}
 	if missed == nil {
 		t.Fatal("sinceID=0 is not a resume and must not be answered with a gap")
+	}
+}
+
+// TestACancelledResumeStopsPayingForTheSettleWindow is BUG-2751's regression
+// test.
+//
+// The settle wait used to be bounded by the BUS's lifetime context, never the
+// request's. GET /api/v1/events/stream takes a global AND a per-user admission
+// slot before subscribing (BUG-2726) and releases them by defer when the
+// handler returns — so a resuming client that disconnected during the window
+// held both for the remainder of it plus two Redis round trips. The connection
+// was gone; the capacity was not.
+//
+// THE NEGATIVE CONTROL IS THE POINT, and the bug's own acceptance criteria
+// asked for it: a settle window that is simply short would pass either way.
+// This asserts against `settleWindow` itself, so it fails against unfixed code
+// no matter what that constant is set to — measured before the fix at the full
+// 250ms, and after it at well under a tenth of that.
+func TestACancelledResumeStopsPayingForTheSettleWindow(t *testing.T) {
+	b, mr := newMiniredisBus(t, 64)
+
+	// Put the counter ahead of this instance so the settle path is actually
+	// entered. Without this the function returns on the agreement fast path
+	// and the test would pass against any implementation at all.
+	b.Publish(Notification{Kind: KindComment, ItemRef: "TASK-1"})
+	waitFor(t, "the notification to be buffered", func() bool { return len(b.EventsSince(0)) == 1 })
+	if err := mr.Set(b.keys.Name(redisWatchSeqSuffix), "99"); err != nil {
+		t.Fatalf("set counter: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// CANCELLED FROM THE SEAM, not from a sleep. It has to land strictly
+	// INSIDE the window — a caller that was already gone takes the
+	// declined-on-entry path instead, which is a different assertion — and a
+	// sleep-timed cancellation that lands late does not fail safe here, it
+	// silently measures the wrong path (codex round 1).
+	var entered atomic.Bool
+	b.beforeSettleWait = func() {
+		entered.Store(true)
+		cancel()
+	}
+
+	start := time.Now()
+	ch, missed, _ := b.SubscribeAndReplaySince(ctx, 1)
+	elapsed := time.Since(start)
+
+	if !entered.Load() {
+		t.Fatal("the settle wait was never reached; this test did not exercise the window it is named for")
+	}
+	if elapsed >= settleWindow {
+		t.Fatalf("a cancelled resume waited %v, the full settle window of %v: the caller is gone and its admission slots are still held",
+			elapsed, settleWindow)
+	}
+
+	// ENDING THE WAIT EARLY IS HALF A FIX. resumeOutrunsLocalView answers
+	// false on cancellation, which reads as an ordinary converged resume, so
+	// without an explicit decline the rest of the call registers a subscriber
+	// and builds a replay for a connection that is unwinding.
+	if missed != nil {
+		t.Fatalf("a cancelled resume was handed %d replayed notifications", len(missed))
+	}
+	select {
+	case _, open := <-ch:
+		if open {
+			t.Fatal("a cancelled resume was handed a live subscription channel")
+		}
+	default:
+		t.Fatal("a cancelled resume was registered as a subscriber: the channel is open and empty")
+	}
+	b.mu.Lock()
+	n := len(b.subscribers)
+	b.mu.Unlock()
+	if n != 0 {
+		t.Fatalf("subscriber count = %d after a cancelled resume, want 0", n)
+	}
+}
+
+// TestAResumeCancelledBeforeItStartsIsDeclinedOutright is the entry-path twin.
+// A client can be gone before the handler ever calls in — the request context
+// is cancelled the moment the connection drops, which can precede this call.
+// That path never reaches the settle window, so the test above says nothing
+// about it.
+func TestAResumeCancelledBeforeItStartsIsDeclinedOutright(t *testing.T) {
+	b, mr := newMiniredisBus(t, 64)
+
+	b.Publish(Notification{Kind: KindComment, ItemRef: "TASK-1"})
+	waitFor(t, "the notification to be buffered", func() bool { return len(b.EventsSince(0)) == 1 })
+	if err := mr.Set(b.keys.Name(redisWatchSeqSuffix), "99"); err != nil {
+		t.Fatalf("set counter: %v", err)
+	}
+
+	var reachedSettle atomic.Bool
+	b.beforeSettleWait = func() { reachedSettle.Store(true) }
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	ch, missed, _ := b.SubscribeAndReplaySince(ctx, 1)
+
+	if reachedSettle.Load() {
+		t.Error("an already-cancelled caller paid for the settle window")
+	}
+	if missed != nil {
+		t.Fatalf("an already-cancelled caller was handed %d replayed notifications", len(missed))
+	}
+	select {
+	case _, open := <-ch:
+		if open {
+			t.Fatal("an already-cancelled caller was handed a live subscription channel")
+		}
+	default:
+		t.Fatal("an already-cancelled caller was registered as a subscriber")
+	}
+	b.mu.Lock()
+	n := len(b.subscribers)
+	b.mu.Unlock()
+	if n != 0 {
+		t.Fatalf("subscriber count = %d, want 0", n)
+	}
+}
+
+// TestTheMemoryBusDeclinesACancelledResumeToo pins the parity. The two
+// implementations answer the same question and must not disagree about whether
+// a departed client ends up registered — a divergence there is invisible on a
+// single-process deployment right up until it is a leak on a clustered one.
+func TestTheMemoryBusDeclinesACancelledResumeToo(t *testing.T) {
+	b := New()
+	t.Cleanup(b.Close)
+	b.Publish(Notification{Kind: KindComment, ItemRef: "TASK-1"})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	ch, missed, _ := b.SubscribeAndReplaySince(ctx, 1)
+	if missed != nil {
+		t.Fatalf("MemoryBus handed a cancelled caller %d replayed notifications", len(missed))
+	}
+	select {
+	case _, open := <-ch:
+		if open {
+			t.Fatal("MemoryBus handed a cancelled caller a live subscription channel")
+		}
+	default:
+		t.Fatal("MemoryBus registered a cancelled caller as a subscriber")
+	}
+}
+
+// TestAnUncancelledResumeStillSettles is the counterfactual. Without it, "the
+// wait ended early" is satisfied by an implementation that never waits — which
+// would silently undo the convergence check BUG-2731 built and start resyncing
+// clients that missed nothing.
+func TestAnUncancelledResumeStillSettles(t *testing.T) {
+	b, mr := newMiniredisBus(t, 64)
+
+	b.Publish(Notification{Kind: KindComment, ItemRef: "TASK-1"})
+	waitFor(t, "the notification to be buffered", func() bool { return len(b.EventsSince(0)) == 1 })
+	if err := mr.Set(b.keys.Name(redisWatchSeqSuffix), "99"); err != nil {
+		t.Fatalf("set counter: %v", err)
+	}
+
+	start := time.Now()
+	_, missed, _ := b.SubscribeAndReplaySince(context.Background(), 1)
+	elapsed := time.Since(start)
+
+	if elapsed < settleWindow {
+		t.Fatalf("a live resume returned in %v, less than the %v settle window: propagation is no longer being given its beat",
+			elapsed, settleWindow)
+	}
+	if missed != nil {
+		t.Fatal("the counter never converged, so this resume must be answered with a gap")
+	}
+}
+
+// TestClosingTheBusStillEndsTheSettleWindow pins the half that threading the
+// request context could have silently dropped.
+//
+// b.ctx is what lets Close cut a wait short. Swapping the wait onto the
+// caller's context ALONE would trade one leak for another: a shutdown would
+// block behind a client that is still perfectly connected. Both endings are
+// reasons to stop, which is why the wait is on a merge of the two rather than
+// on either.
+func TestClosingTheBusStillEndsTheSettleWindow(t *testing.T) {
+	b, mr := newMiniredisBus(t, 64)
+
+	b.Publish(Notification{Kind: KindComment, ItemRef: "TASK-1"})
+	waitFor(t, "the notification to be buffered", func() bool { return len(b.EventsSince(0)) == 1 })
+	if err := mr.Set(b.keys.Name(redisWatchSeqSuffix), "99"); err != nil {
+		t.Fatalf("set counter: %v", err)
+	}
+
+	go func() {
+		time.Sleep(settleWindow / 10)
+		b.Close()
+	}()
+
+	start := time.Now()
+	// The caller's context stays live throughout, so only the bus closing can
+	// end this wait.
+	_, _, _ = b.SubscribeAndReplaySince(context.Background(), 1)
+
+	if elapsed := time.Since(start); elapsed >= settleWindow {
+		t.Fatalf("a closing bus waited %v, the full settle window of %v: shutdown is blocked behind a connected client",
+			elapsed, settleWindow)
 	}
 }

--- a/internal/watchevents/redis_bus_test.go
+++ b/internal/watchevents/redis_bus_test.go
@@ -85,7 +85,7 @@ func TestRedisBusSubscribeAndReplayIsAtomic(t *testing.T) {
 		b.fanOutLocally(Notification{ID: i, Kind: KindComment, ItemRef: "TASK-1"})
 	}
 
-	ch, missed, _ := b.SubscribeAndReplaySince(1)
+	ch, missed, _ := b.SubscribeAndReplaySince(context.Background(), 1)
 
 	if len(missed) != 2 {
 		t.Fatalf("replay since 1 should carry ids 2,3; got %d entries: %+v", len(missed), missed)
@@ -149,7 +149,7 @@ func TestRedisBusSubscribeAndReplayHasNoWindowUnderConcurrency(t *testing.T) {
 
 	// Join mid-flight.
 	time.Sleep(2 * time.Millisecond)
-	ch, missed, _ := b.SubscribeAndReplaySince(0)
+	ch, missed, _ := b.SubscribeAndReplaySince(context.Background(), 0)
 
 	wg.Wait()
 
@@ -259,7 +259,7 @@ func TestRedisBusSubscribeAndReplayNeverDoubleDelivers(t *testing.T) {
 			}()
 		}
 
-		ch, missed, _ := b.SubscribeAndReplaySince(0)
+		ch, missed, _ := b.SubscribeAndReplaySince(context.Background(), 0)
 		b.afterSubscribeRegister = nil
 
 		// Block until the forced fan-out has actually completed before

--- a/internal/watchevents/redis_reconnect_test.go
+++ b/internal/watchevents/redis_reconnect_test.go
@@ -18,6 +18,7 @@ package watchevents
 // local state alone, so it can tell this fix apart from that one.
 
 import (
+	"context"
 	"io"
 	"net"
 	"sync"
@@ -168,7 +169,7 @@ func TestCoverageIsReestablishedByTheNextNotification(t *testing.T) {
 	// and must be served — knownFrom was set to exactly that notification's
 	// id by the cold-start arm. If lastAppendedID had survived the drop, this
 	// resume is refused, and it is refused for every id, forever.
-	resumeCh, replay, _ := b.SubscribeAndReplaySince(second.ID - 1)
+	resumeCh, replay, _ := b.SubscribeAndReplaySince(context.Background(), second.ID-1)
 	defer b.Unsubscribe(resumeCh)
 	if replay == nil {
 		t.Fatal("coverage was never re-established: a resume from the id below the first post-outage notification " +
@@ -208,7 +209,7 @@ func TestAResubscriptionEndsThisInstancesCoverage(t *testing.T) {
 	// that refuses every resume and reports a reset on every message — a
 	// differently-broken instrument, indistinguishable from the assertions
 	// below on their own.
-	healthyCh, healthy, _ := b.SubscribeAndReplaySince(first.ID)
+	healthyCh, healthy, _ := b.SubscribeAndReplaySince(context.Background(), first.ID)
 	b.Unsubscribe(healthyCh)
 	if healthy == nil {
 		t.Fatal("a cursor inside our coverage must be served while the subscription is healthy")
@@ -226,7 +227,7 @@ func TestAResubscriptionEndsThisInstancesCoverage(t *testing.T) {
 	}
 
 	// And the coverage really is gone for the pre-outage cursor.
-	refusedCh, refused, _ := b.SubscribeAndReplaySince(first.ID)
+	refusedCh, refused, _ := b.SubscribeAndReplaySince(context.Background(), first.ID)
 	defer b.Unsubscribe(refusedCh)
 	if refused != nil {
 		t.Fatalf("after a resubscription the buffer must not vouch for the outage, got %d notifications", len(refused))
@@ -263,7 +264,7 @@ func TestAResubscriptionEndsThisInstancesCoverage(t *testing.T) {
 	// subscriber is not in the signalled set because it arrived afterwards.
 	// Silent loss, handed out by us. Verified by mutation: keeping the buffer
 	// survives every other assertion here.
-	freshCh, fresh, _ := b.SubscribeAndReplaySince(0)
+	freshCh, fresh, _ := b.SubscribeAndReplaySince(context.Background(), 0)
 	defer b.Unsubscribe(freshCh)
 	if len(fresh) != 0 {
 		t.Fatalf("a subscriber arriving after the outage must not be handed the pre-outage buffer, got %d notifications", len(fresh))
@@ -338,7 +339,7 @@ func TestAnUndecodableMessageEndsCoverage(t *testing.T) {
 	}
 
 	// CONTROL: that cursor is served right now.
-	healthyCh, healthy, _ := b.SubscribeAndReplaySince(first.ID)
+	healthyCh, healthy, _ := b.SubscribeAndReplaySince(context.Background(), first.ID)
 	b.Unsubscribe(healthyCh)
 	if healthy == nil {
 		t.Fatal("a cursor inside our coverage must be served before the undecodable message arrives")
@@ -358,7 +359,7 @@ func TestAnUndecodableMessageEndsCoverage(t *testing.T) {
 	// NOTHING IS PUBLISHED AFTER THIS POINT. The cursor that was inside our
 	// coverage a moment ago is refused now, on a stream that has gone quiet —
 	// the case id arithmetic alone can never reach.
-	refusedCh, refused, _ := b.SubscribeAndReplaySince(first.ID)
+	refusedCh, refused, _ := b.SubscribeAndReplaySince(context.Background(), first.ID)
 	defer b.Unsubscribe(refusedCh)
 	if refused != nil {
 		t.Fatalf("after an undecodable message the buffer must not vouch for the span, got %d notifications", len(refused))

--- a/internal/watchevents/watchevents.go
+++ b/internal/watchevents/watchevents.go
@@ -47,6 +47,7 @@
 package watchevents
 
 import (
+	"context"
 	"errors"
 	"log/slog"
 	"sync"
@@ -258,7 +259,14 @@ type Bus interface {
 	// only the replay is unavailable.
 	//
 	// The third return is the subscriber's GAP SIGNAL — see Subscribe.
-	SubscribeAndReplaySince(sinceID int64) (chan Notification, []Notification, <-chan struct{})
+	//
+	// ctx IS THE CALLER'S REQUEST CONTEXT, and it is load-bearing on the Redis
+	// implementation (BUG-2751): that one may WAIT — a settle window plus two
+	// Redis round trips — while the SSE handler holds admission slots that are
+	// only released when the handler returns. A caller that has gone must not
+	// go on paying for that. MemoryBus does no I/O here and accepts the
+	// parameter to keep one interface; see its implementation.
+	SubscribeAndReplaySince(ctx context.Context, sinceID int64) (chan Notification, []Notification, <-chan struct{})
 	// Unsubscribe removes a subscriber and closes its channel.
 	Unsubscribe(ch chan Notification)
 	// EventsSince returns buffered notifications with ID > sinceID, for
@@ -575,7 +583,24 @@ func (b *MemoryBus) Subscribe() (chan Notification, <-chan struct{}) {
 // means a Notification is either: published before this call (and thus
 // only in the returned replay slice), or published after (and thus only
 // delivered on the returned channel) — never both.
-func (b *MemoryBus) SubscribeAndReplaySince(sinceID int64) (chan Notification, []Notification, <-chan struct{}) {
+// CHECKED RATHER THAN ASSUMED CLEAR (BUG-2751's scope note, which is also how
+// that bug was found — BUG-2749's filing asked for this package to be checked
+// rather than assumed). This path takes no context-bounded WAIT and does no
+// network I/O: it acquires b.mu, reads the local buffer, and returns. There is
+// nothing here for a cancelled caller to stop paying for.
+//
+// It still declines a cancelled caller, for uniformity rather than for cost:
+// the two implementations answer the same question and must not disagree about
+// whether a departed client ends up registered as a subscriber. Same shape as
+// the closed-bus branch — a closed channel, never nil, because the handler
+// treats nil as "fall back to plain Subscribe" and would re-register the very
+// caller this is declining.
+func (b *MemoryBus) SubscribeAndReplaySince(ctx context.Context, sinceID int64) (chan Notification, []Notification, <-chan struct{}) {
+	if ctx.Err() != nil {
+		sub := newSubscriber()
+		close(sub.ch)
+		return sub.ch, nil, sub.gaps
+	}
 	// Reported with the lock released, like every other report in this
 	// package. RedisBus counts its own unservable resumes; MemoryBus did not,
 	// so pad_watchevents_resume_gaps_total read zero on a single-process

--- a/internal/watchevents/watchevents_test.go
+++ b/internal/watchevents/watchevents_test.go
@@ -1,6 +1,7 @@
 package watchevents
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"testing"
@@ -256,7 +257,7 @@ func TestMemoryBus_SubscribeAndReplaySince_NoDuplicateUnderConcurrentPublish(t *
 	seeded := b.EventsSince(0)
 	sinceID := seeded[2].ID // resume from partway through history
 
-	ch, missed, _ := b.SubscribeAndReplaySince(sinceID)
+	ch, missed, _ := b.SubscribeAndReplaySince(context.Background(), sinceID)
 	defer b.Unsubscribe(ch)
 
 	const concurrentPublishes = 20


### PR DESCRIPTION
Fixes BUG-2751.

`GET /api/v1/events/stream` takes a global **and** a per-user admission slot before subscribing (BUG-2726) and releases them by `defer` when the handler returns. The resume path could **wait** inside that window: `resumeOutrunsLocalView` does a Redis `GET`, waits 250ms for propagation, then does a second `GET` — and its select waited on `b.ctx`, the *bus's* lifetime, never the request's. A resuming client that disconnected mid-window held both slots for the remainder of it plus two round trips. The connection was gone; the capacity was not.

Found while sweeping the class for BUG-2749, whose filing asked that this package be checked rather than assumed clear.

## The fix

The caller's context is threaded through `SubscribeAndReplaySince` → `resumeOutrunsLocalView` → `sharedCounter`, and **merged** with the bus context rather than replacing it. Swapping to the caller's alone would trade one leak for another: `b.ctx` is what lets `Close` cut a wait short, so dropping it leaves shutdown blocked behind a client that is still perfectly connected. `internal/events` lost exactly that half in its own first draft. Each half has a test that fails against the other one's implementation.

**Ending the wait early is only half a fix.** `resumeOutrunsLocalView` answers `false` on cancellation, which reads as an ordinary converged resume — so the rest of the call went on to register a subscriber and build a replay slice for a connection that was unwinding. A cancelled caller is now declined outright, returning the same shape as the closed-bus branch (a closed channel, never `nil`, because the handler treats `nil` as "fall back to plain `Subscribe`" and would re-register the caller being declined).

**Our own cancellation is not a Redis fault.** The decline sits ahead of the settle path, so an already-gone caller no longer trips the `could not read the sequence counter` WARN — a line that reads as "Redis is unhealthy" and would have fired on ordinary disconnect churn. The in-flight case is classified by a predicate on the *error*, not on `ctx.Err()`: asking the context downgrades a genuine Redis failure that merely coincides with a disconnect, which is the signal an operator most needs.

`MemoryBus` was **checked rather than assumed clear**. It has no bounded wait and no I/O, so nothing there for a cancelled caller to stop paying for — but it declines one too, because the two implementations must not disagree about whether a departed client ends up registered. That divergence is invisible on a single-process deployment right up until it is a leak on a clustered one.

## A metric was declined

Round 2 asked for a cancellation counter so operators could distinguish disconnect churn from no resume activity. A client hanging up during its own resume is *ordinary* on a mobile network, so that counter would be a number nobody can act on, sitting next to `pad_watchevents_resume_gaps_total` where it would read as a fault. The condition an operator does act on — capacity held by connections that no longer exist — is already visible in the admission counts, and this change is what keeps those honest. Reasoning is at the code.

## Tests

Nine, each failing against the specific thing it names: bus-ctx-only, caller-ctx-only, an implementation that never settles, no decline on `RedisBus`, no decline on `MemoryBus`, the decline placed after the settle path, no WARN suppression, a suppression that swallows real failures, and — the binding one, in `internal/server` — a handler passing `context.Background()`. That last is what CONVE-19 asks for: the bus tests vouch for the bus honouring cancellation and say nothing about whether the handler ever hands it one.

Two instrument corrections are recorded in the commits: a Redis-read counter that measured nothing (go-redis short-circuits a cancelled context before the wire), and an integration pair that could not distinguish the classification it was named for — found by mutation, not by reading.

## Gates

`go build`, `go vet`, `make lint` (0 issues), `go test ./...` (27 packages), and the full suite against Postgres on a private container. `make check` was **not** run: it reaches `npm ci` through this worktree's symlinked `node_modules`. No frontend code is touched.

Five Codex rounds, one of which blocked; CLEAN and approve at round 5.

https://claude.ai/code/session_01JVDBKbgn3Xt7ndW1YoYd8X
