### PR TITLE
fix(redis): honour the caller's context on TLS dials (BUG-2754)

### DIFF
--- a/cmd/pad/cmd_server.go
+++ b/cmd/pad/cmd_server.go
@@ -33,6 +33,7 @@ import (
 	"github.com/PerpetualSoftware/pad/internal/metrics"
 	"github.com/PerpetualSoftware/pad/internal/models"
 	oauthpkg "github.com/PerpetualSoftware/pad/internal/oauth"
+	"github.com/PerpetualSoftware/pad/internal/redisdial"
 	"github.com/PerpetualSoftware/pad/internal/redisns"
 	"github.com/PerpetualSoftware/pad/internal/server"
 	"github.com/PerpetualSoftware/pad/internal/store"
@@ -673,6 +674,16 @@ func serveCmd() *cobra.Command {
 				if err != nil {
 					return fmt.Errorf("invalid PAD_REDIS_URL: %w", err)
 				}
+				// A CONTEXT-AWARE DIALER ON EVERY CLIENT (BUG-2754).
+				// go-redis's default hands TLS connections to
+				// tls.DialWithDialer, which takes no context, so on a
+				// rediss:// deployment a cancelled caller could not shorten
+				// the dial — the one segment BUG-2749's request-scoped
+				// establishment could not reach. Installed here rather than
+				// in any consumer because it is a property of the CLIENT: the
+				// same dial serves Publish, the Lua scripts, the presence
+				// registry and the watch bus's reads.
+				opts.Dialer = redisdial.New(opts.TLSConfig, opts.DialTimeout)
 				rc := redis.NewClient(opts)
 				if err := rc.Ping(context.Background()).Err(); err != nil {
 					return fmt.Errorf("redis connection failed: %w", err)

--- a/internal/events/redis_bus.go
+++ b/internal/events/redis_bus.go
@@ -1473,8 +1473,8 @@ func (b *RedisBus) WorkspaceSubscriberCount(workspaceID string) int {
 // each client.Subscribe mints a PubSub whose connection starts nil. A Redis
 // whose route blackholes packets stalled that dial for the client's
 // DialTimeout (5s by default; since BUG-2749 the CALLER's context can cut that
-// short on a plaintext connection, but not under TLS — see
-// defaultSubscribeConfirmTimeout), and for that whole time no other workspace
+// short, and since BUG-2754 on TLS as well — see defaultSubscribeConfirmTimeout),
+// and for that whole time no other workspace
 // could subscribe, unsubscribe, close, or receive a fanned-out event.
 //
 // Exactly one caller per workspace reaches here; the rest wait on pending.
@@ -1504,19 +1504,19 @@ func (b *RedisBus) establishSubscription(ctx context.Context, workspaceID string
 	// conn(ctx) dials when there is no connection yet, then writes the
 	// SUBSCRIBE command. Only the REPLY is unawaited.
 	//
-	//   - Plaintext: dialConn derives its attempt context from the one passed
-	//     in (internal/pool/pool.go, "Apply DialTimeout per attempt, but never
-	//     extend an existing earlier deadline") and the default dialer is
-	//     net.Dialer.DialContext, which honours it. Cancellation aborts the
-	//     dial.
-	//   - TLS: the same dialer returns tls.DialWithDialer(netDialer, ...)
-	//     (options.go), which takes NO context. Under TLS the dial is bounded
-	//     by DialTimeout alone and cancellation cannot shorten it.
+	// dialConn derives its attempt context from the one passed in
+	// (internal/pool/pool.go, "Apply DialTimeout per attempt, but never extend
+	// an existing earlier deadline"), so cancellation aborts the dial.
 	//
-	// So on a TLS deployment this shrinks the held slot from (dial + confirm
-	// bound) to (dial), not to zero. That residual is real and is why the
-	// cancellation check below is repeated after the dial rather than assumed
-	// to have fired during it.
+	// ON TLS TOO, SINCE BUG-2754, and this comment used to say the opposite —
+	// correctly at the time. go-redis's DEFAULT dialer hands TLS connections to
+	// tls.DialWithDialer, which takes no context, so the dial was bounded by
+	// DialTimeout alone and a departing client kept its slots for the rest of
+	// it. Pad installs its own dialer now (internal/redisdial, wired in
+	// cmd/pad/cmd_server.go) that runs the handshake on the caller's context.
+	//
+	// The cancellation check below is repeated after the dial anyway: it costs
+	// nothing and does not depend on the dialer being the one we think it is.
 	pubsub := b.client.Subscribe(dialCtx, channel)
 	subCtx, subCancel := context.WithCancel(b.ctx)
 

--- a/internal/events/redis_bus.go
+++ b/internal/events/redis_bus.go
@@ -1397,8 +1397,9 @@ func (b *RedisBus) eventsSinceLocked(workspaceID string, sinceID int64) []Event 
 // leave anything behind: establishSubscription re-checks b.ctx under its
 // deciding lock and abandons there, closing the PubSub and retiring the record
 // in the same critical section, and the dial dies with b.ctx through
-// mergeCancellation (except under TLS, where DialTimeout bounds it — see that
-// function). Pinned by TestClosingTheBusDuringACycleInstallsNothing.
+// mergeCancellation — on TLS as well as plaintext since BUG-2754 replaced
+// go-redis's context-blind default dialer. Pinned by
+// TestClosingTheBusDuringACycleInstallsNothing.
 func (b *RedisBus) Close() {
 	b.cancel() // signal all subscription goroutines to stop
 
@@ -2369,15 +2370,17 @@ const stragglerWindow = 30 * time.Second
 // wait composes to roughly DialTimeout + this, and anyone reasoning about
 // worst-case connect latency needs both numbers.
 //
-// AMENDED BY BUG-2749 on the context half, which this comment used to state
-// flatly as "not by any context we pass". Since that unit the dial runs on the
-// CALLER's context, and go-redis derives its per-attempt dial deadline from it
-// — so on plaintext a caller that goes away no longer waits out DialTimeout.
-// Under TLS it still does: the default dialer hands a TLS connection to
-// tls.DialWithDialer, which takes no context at all. The composed worst case
-// above is therefore unchanged for a client that STAYS, and unchanged for a
-// TLS deployment whose client leaves; it shrinks only for a departing client
-// on a plaintext connection. See BUG-2754 for the TLS half.
+// AMENDED TWICE, and the second amendment resolves the first one's caveat.
+// BUG-2749 put the dial on the CALLER's context — go-redis derives its
+// per-attempt dial deadline from it — so a client that goes away stopped
+// waiting out DialTimeout, but only on plaintext: the default dialer hands TLS
+// connections to tls.DialWithDialer, which takes no context at all. BUG-2754
+// closed that half by installing Pad's own dialer (internal/redisdial), which
+// runs the handshake on the caller's context while still bounding it by
+// DialTimeout.
+//
+// So the composed worst case above is unchanged for a client that STAYS, on
+// either transport, and no longer applies to a departing client on either.
 //
 // SHORT BECAUSE THE DISTRIBUTION HAS NO MIDDLE, not as a guess at how fast
 // Redis is. Establishment either completes in single-digit milliseconds or does

--- a/internal/events/redis_heartbeat_test.go
+++ b/internal/events/redis_heartbeat_test.go
@@ -1764,8 +1764,8 @@ func TestPhase2CyclesTheSameWorkspace(t *testing.T) {
 // past its own ctx check cannot leave anything behind: establishSubscription
 // re-checks b.ctx under its deciding lock and abandons, closing the PubSub and
 // retiring the record in that same section, and the dial itself dies with
-// b.ctx (BUG-2749's mergeCancellation) except under TLS, where DialTimeout
-// bounds it instead.
+// b.ctx (BUG-2749's mergeCancellation), on TLS as well since BUG-2754 replaced
+// go-redis's context-blind default dialer.
 //
 // The seam runs after the dial and before that decision, which is exactly
 // where the race lives.

--- a/internal/events/redis_subscribe_cancel_test.go
+++ b/internal/events/redis_subscribe_cancel_test.go
@@ -378,11 +378,11 @@ func TestAnAlreadyCancelledCallerRegistersNothing(t *testing.T) {
 // seams that run after the dial has returned.
 //
 // WHAT IT DOES NOT CLAIM: that cancellation actually shortens a real dial.
-// go-redis derives its per-attempt dial deadline from the context passed in
-// and the default dialer is net.Dialer.DialContext, so it does on plaintext;
-// under TLS the same dialer calls tls.DialWithDialer, which takes no context
-// at all, and there the dial stays bounded by DialTimeout alone. That residual
-// is documented on establishSubscription and is not tested here.
+// go-redis derives its per-attempt dial deadline from the context passed in,
+// so it does — on plaintext through net.Dialer.DialContext, and since BUG-2754
+// on TLS too, through the dialer Pad installs (internal/redisdial). Neither is
+// tested here; the TLS half has its own tests in that package, against a server
+// that accepts and then never completes a handshake.
 func TestTheDialUsesTheCallersContext(t *testing.T) {
 	mr := miniredis.RunT(t)
 

--- a/internal/redisdial/keepalive_linux_test.go
+++ b/internal/redisdial/keepalive_linux_test.go
@@ -18,9 +18,15 @@ import (
 //
 // Linux-only by build tag. Reading SO_KEEPALIVE off the accepted socket is the
 // only way to observe this from outside, and the syscall surface is not
-// portable — the Smoke jobs on macOS and Windows simply skip the file. That is
-// an honest partial: the property is platform-independent, the observation is
-// not, and Pad's servers are Linux.
+// portable — the Smoke jobs on macOS and Windows skip the file entirely.
+//
+// WHAT THAT GAP ACTUALLY COSTS, since Pad ships darwin and windows binaries
+// too (codex round 2, P3): nothing in regression terms. The behaviour is
+// platform-independent — net.Dialer applies KeepAliveConfig on every platform
+// Go supports — so a removal would be caught here, on the Go and Go (PostgreSQL)
+// CI jobs, which are the ones that run the full suite. The macOS and Windows
+// Smoke jobs are build-and-start checks and were never the guard for this.
+// The gap is in OBSERVATION on those platforms, not in coverage of the change.
 func TestKeepAliveIsActuallyAppliedToTheSocket(t *testing.T) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {

--- a/internal/redisdial/keepalive_linux_test.go
+++ b/internal/redisdial/keepalive_linux_test.go
@@ -1,0 +1,72 @@
+//go:build linux
+
+package redisdial
+
+import (
+	"context"
+	"net"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestKeepAliveIsActuallyAppliedToTheSocket is the assertion the constant test
+// could not make, and the mutation matrix is what exposed the difference:
+// deleting KeepAliveConfig from the dialer left the value-comparison test
+// green, because comparing our copy against go-redis's published numbers says
+// nothing about whether the dialer USES it.
+//
+// Linux-only by build tag. Reading SO_KEEPALIVE off the accepted socket is the
+// only way to observe this from outside, and the syscall surface is not
+// portable — the Smoke jobs on macOS and Windows simply skip the file. That is
+// an honest partial: the property is platform-independent, the observation is
+// not, and Pad's servers are Linux.
+func TestKeepAliveIsActuallyAppliedToTheSocket(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+	go func() {
+		c, aerr := ln.Accept()
+		if aerr == nil {
+			time.AfterFunc(time.Second, func() { _ = c.Close() })
+		}
+	}()
+
+	conn, err := New(nil, 5*time.Second)(context.Background(), "tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	raw, err := conn.(*net.TCPConn).SyscallConn()
+	if err != nil {
+		t.Fatalf("syscall conn: %v", err)
+	}
+	var (
+		keepalive int
+		idle      int
+		operr     error
+	)
+	if cerr := raw.Control(func(fd uintptr) {
+		keepalive, operr = syscall.GetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_KEEPALIVE)
+		if operr != nil {
+			return
+		}
+		idle, operr = syscall.GetsockoptInt(int(fd), syscall.IPPROTO_TCP, syscall.TCP_KEEPIDLE)
+	}); cerr != nil {
+		t.Fatalf("control: %v", cerr)
+	}
+	if operr != nil {
+		t.Fatalf("getsockopt: %v", operr)
+	}
+
+	if keepalive == 0 {
+		t.Error("SO_KEEPALIVE is off: go-redis's default dialer enables it, and dropping it silently changes how " +
+			"quickly a dead Redis peer is noticed on every connection this process holds")
+	}
+	if want := int(keepAliveConfig.Idle / time.Second); idle != want {
+		t.Errorf("TCP_KEEPIDLE = %ds, want %ds — the configured idle period is not reaching the socket", idle, want)
+	}
+}

--- a/internal/redisdial/redisdial.go
+++ b/internal/redisdial/redisdial.go
@@ -1,0 +1,115 @@
+// Package redisdial supplies the dialer Pad installs on every go-redis client.
+//
+// IT EXISTS FOR ONE DEFECT, and the defect is in go-redis's default dialer
+// rather than in anything Pad wrote (BUG-2754). NewDialer reads, in v9.22.0's
+// options.go:
+//
+//	netDialer := &net.Dialer{Timeout: opt.DialTimeout, KeepAliveConfig: ...}
+//	if opt.TLSConfig == nil {
+//		return netDialer.DialContext(ctx, network, addr)
+//	}
+//	return tls.DialWithDialer(netDialer, network, addr, opt.TLSConfig)
+//
+// The plaintext branch honours the caller's context. The TLS branch does not:
+// tls.DialWithDialer takes no context at all, so a cancelled caller cannot
+// shorten the dial and it is bounded only by DialTimeout.
+//
+// WHY THAT MATTERS TO PAD SPECIFICALLY. BUG-2749 put SSE subscription
+// establishment on the request's context so a client that disconnects stops
+// holding its admission slots, global and per-user. On plaintext that covers
+// the dial. On TLS the dial was the one segment cancellation could not reach,
+// so the guarantee shrank from "released at once" to "released after up to
+// DialTimeout" — and a managed Redis is a rediss:// URL, which is the normal
+// production shape rather than an exotic one.
+//
+// It is a CLIENT-CONSTRUCTION concern, not a subscription one: the same dialer
+// serves Publish, the Lua scripts, the presence registry and the watch bus's
+// reads. Fixing it inside internal/events would have fixed one caller of a
+// shared defect.
+package redisdial
+
+import (
+	"context"
+	"crypto/tls"
+	"net"
+	"strings"
+	"time"
+)
+
+// New returns a dialer that honours the caller's context on TLS as well as
+// plaintext, for the given TLS config and dial timeout.
+//
+// tlsConfig may be nil, which means plaintext; dialTimeout may be zero, which
+// means "no per-dial bound of our own" and matches net.Dialer's semantics.
+//
+// THREE THINGS IT HAS TO GET RIGHT, each of which fails quietly rather than
+// loudly if it does not:
+//
+//  1. SERVERNAME. tls.DialWithDialer infers ServerName from the dialled
+//     address when the config leaves it empty (crypto/tls/tls.go: "If no
+//     ServerName is set, infer the ServerName from the hostname we're
+//     connecting to"). A hand-rolled tls.Client does NOT, and an empty
+//     ServerName means certificate verification has no name to check against.
+//     That would turn a latency fix into a silent authentication regression,
+//     which is the worst trade available here. Replicated below, on a CLONE —
+//     mutating the caller's config would leak one host's name into every
+//     later dial that shares it.
+//
+//     redis.ParseURL does populate ServerName for a rediss:// URL (v9.22.0,
+//     options.go:708), so Pad's own path does not depend on this fallback
+//     today. It is here because the fallback is what the code being replaced
+//     did, and a future construction path that leaves ServerName empty must
+//     not silently lose verification.
+//
+//  2. THE TIMEOUT MUST BOUND THE HANDSHAKE, not just the TCP connect. A TLS
+//     server that accepts and then stalls mid-handshake would otherwise hang
+//     for as long as the context lives — trading a bounded failure for an
+//     unbounded one, which is worse than the bug being fixed.
+//
+//  3. IT MUST NOT EXTEND AN EARLIER DEADLINE. context.WithTimeout takes the
+//     sooner of the two, so a caller that is already closer to giving up keeps
+//     its own bound. go-redis's pool makes the same promise about DialTimeout
+//     ("Apply DialTimeout per attempt, but never extend an existing earlier
+//     deadline") and this must not quietly disagree with it.
+func New(tlsConfig *tls.Config, dialTimeout time.Duration) func(context.Context, string, string) (net.Conn, error) {
+	return func(ctx context.Context, network, addr string) (net.Conn, error) {
+		netDialer := &net.Dialer{Timeout: dialTimeout}
+		conn, err := netDialer.DialContext(ctx, network, addr)
+		if err != nil || tlsConfig == nil {
+			return conn, err
+		}
+
+		cfg := tlsConfig
+		if cfg.ServerName == "" {
+			cfg = cfg.Clone()
+			cfg.ServerName = hostnameFor(addr)
+		}
+
+		handshakeCtx := ctx
+		if dialTimeout > 0 {
+			var cancel context.CancelFunc
+			handshakeCtx, cancel = context.WithTimeout(ctx, dialTimeout)
+			defer cancel()
+		}
+
+		tlsConn := tls.Client(conn, cfg)
+		if err := tlsConn.HandshakeContext(handshakeCtx); err != nil {
+			_ = conn.Close()
+			return nil, err
+		}
+		return tlsConn, nil
+	}
+}
+
+// hostnameFor strips the port from a dial address, matching what
+// crypto/tls.DialWithDialer does — LastIndex on ":", so an IPv6 literal keeps
+// its brackets exactly as the standard library leaves them. Copied in shape
+// rather than improved on: the point is to behave identically to the code this
+// replaces, not better than it.
+func hostnameFor(addr string) string {
+	colon := strings.LastIndex(addr, ":")
+	if colon == -1 {
+		return addr
+	}
+	return addr[:colon]
+}

--- a/internal/redisdial/redisdial.go
+++ b/internal/redisdial/redisdial.go
@@ -72,8 +72,44 @@ import (
 //     ("Apply DialTimeout per attempt, but never extend an existing earlier
 //     deadline") and this must not quietly disagree with it.
 func New(tlsConfig *tls.Config, dialTimeout time.Duration) func(context.Context, string, string) (net.Conn, error) {
+	if dialTimeout <= 0 {
+		// GO-REDIS'S OWN DEFAULT, APPLIED HERE BECAUSE WE CANNOT SEE IT
+		// (codex round 1, P1 — and the first draft of this shipped the bug).
+		// Options.init() sets DialTimeout to 5s when it is zero
+		// (options.go:31), but NewClient CLONES the options first
+		// (redis.go:1924), so a caller reading opt.DialTimeout before
+		// construction — which is the only time it can install a Dialer —
+		// reads zero for the ordinary URL that does not set one.
+		//
+		// A zero here would mean no bound at all, and PubSubPool.NewConn calls
+		// the dialer DIRECTLY without applying DialTimeout of its own
+		// (internal/pool/pubsub.go:45). So an unresolved zero makes SSE
+		// subscription establishment hang indefinitely on a stalled server —
+		// on plaintext as well as TLS, which is strictly worse than the defect
+		// this package exists to fix.
+		dialTimeout = defaultDialTimeout
+	}
+
 	return func(ctx context.Context, network, addr string) (net.Conn, error) {
-		netDialer := &net.Dialer{Timeout: dialTimeout}
+		// ONE BUDGET FOR CONNECT AND HANDSHAKE TOGETHER (codex round 1, P2).
+		// Applying DialTimeout to the TCP connect and then starting a FRESH
+		// one for the handshake allows up to 2×DialTimeout on the pub/sub
+		// path, which has no outer deadline to mask it. tls.DialWithDialer
+		// bounds both as one interval by handing the handshake the net.Dialer's
+		// deadline, and this must not be laxer than the code it replaces.
+		ctx, cancel := context.WithTimeout(ctx, dialTimeout)
+		defer cancel()
+
+		// KeepAliveConfig REPLICATED, not dropped (codex round 1, P2).
+		// go-redis's default dialer sets it (options.go:608) and it governs how
+		// quickly a dead peer is noticed on every Redis connection this process
+		// holds. Silently reverting to OS defaults would change liveness
+		// behaviour across the whole client as a side effect of a cancellation
+		// fix — and would do it invisibly, since nothing here would fail.
+		netDialer := &net.Dialer{
+			Timeout:         dialTimeout,
+			KeepAliveConfig: keepAliveConfig,
+		}
 		conn, err := netDialer.DialContext(ctx, network, addr)
 		if err != nil || tlsConfig == nil {
 			return conn, err
@@ -85,20 +121,28 @@ func New(tlsConfig *tls.Config, dialTimeout time.Duration) func(context.Context,
 			cfg.ServerName = hostnameFor(addr)
 		}
 
-		handshakeCtx := ctx
-		if dialTimeout > 0 {
-			var cancel context.CancelFunc
-			handshakeCtx, cancel = context.WithTimeout(ctx, dialTimeout)
-			defer cancel()
-		}
-
 		tlsConn := tls.Client(conn, cfg)
-		if err := tlsConn.HandshakeContext(handshakeCtx); err != nil {
+		if err := tlsConn.HandshakeContext(ctx); err != nil {
 			_ = conn.Close()
 			return nil, err
 		}
 		return tlsConn, nil
 	}
+}
+
+// defaultDialTimeout mirrors go-redis's own (options.go:31). Named rather than
+// inlined so the coupling is visible: if that default moves, this is the line
+// that has to move with it.
+const defaultDialTimeout = 5 * time.Second
+
+// keepAliveConfig mirrors go-redis's defaultKeepAliveConfig (options.go:608),
+// which is unexported and therefore has to be copied rather than referenced.
+// Same coupling note as defaultDialTimeout.
+var keepAliveConfig = net.KeepAliveConfig{
+	Enable:   true,
+	Idle:     30 * time.Second,
+	Interval: 5 * time.Second,
+	Count:    3,
 }
 
 // hostnameFor strips the port from a dial address, matching what

--- a/internal/redisdial/redisdial.go
+++ b/internal/redisdial/redisdial.go
@@ -72,7 +72,13 @@ import (
 //     ("Apply DialTimeout per attempt, but never extend an existing earlier
 //     deadline") and this must not quietly disagree with it.
 func New(tlsConfig *tls.Config, dialTimeout time.Duration) func(context.Context, string, string) (net.Conn, error) {
-	if dialTimeout <= 0 {
+	// == 0, NOT <= 0 (codex round 2). ParseURL represents an EXPLICIT
+	// dial_timeout of zero or negative as -1, and go-redis preserves that as
+	// "no timeout" rather than treating it as unset. Collapsing every
+	// non-positive value to the default would silently overrule an operator who
+	// had deliberately disabled the bound — a different defect from the one
+	// this branch exists to fix, in the opposite direction.
+	if dialTimeout == 0 {
 		// GO-REDIS'S OWN DEFAULT, APPLIED HERE BECAUSE WE CANNOT SEE IT
 		// (codex round 1, P1 — and the first draft of this shipped the bug).
 		// Options.init() sets DialTimeout to 5s when it is zero
@@ -90,6 +96,13 @@ func New(tlsConfig *tls.Config, dialTimeout time.Duration) func(context.Context,
 		dialTimeout = defaultDialTimeout
 	}
 
+	// A negative value is go-redis's "no timeout at all", so it must not become
+	// a net.Dialer timeout or a context deadline.
+	var budget time.Duration
+	if dialTimeout > 0 {
+		budget = dialTimeout
+	}
+
 	return func(ctx context.Context, network, addr string) (net.Conn, error) {
 		// ONE BUDGET FOR CONNECT AND HANDSHAKE TOGETHER (codex round 1, P2).
 		// Applying DialTimeout to the TCP connect and then starting a FRESH
@@ -97,8 +110,11 @@ func New(tlsConfig *tls.Config, dialTimeout time.Duration) func(context.Context,
 		// path, which has no outer deadline to mask it. tls.DialWithDialer
 		// bounds both as one interval by handing the handshake the net.Dialer's
 		// deadline, and this must not be laxer than the code it replaces.
-		ctx, cancel := context.WithTimeout(ctx, dialTimeout)
-		defer cancel()
+		if budget > 0 {
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithTimeout(ctx, budget)
+			defer cancel()
+		}
 
 		// KeepAliveConfig REPLICATED, not dropped (codex round 1, P2).
 		// go-redis's default dialer sets it (options.go:608) and it governs how
@@ -107,7 +123,7 @@ func New(tlsConfig *tls.Config, dialTimeout time.Duration) func(context.Context,
 		// behaviour across the whole client as a side effect of a cancellation
 		// fix — and would do it invisibly, since nothing here would fail.
 		netDialer := &net.Dialer{
-			Timeout:         dialTimeout,
+			Timeout:         budget,
 			KeepAliveConfig: keepAliveConfig,
 		}
 		conn, err := netDialer.DialContext(ctx, network, addr)

--- a/internal/redisdial/redisdial_test.go
+++ b/internal/redisdial/redisdial_test.go
@@ -298,3 +298,86 @@ func TestTheTimeoutStillBoundsAStalledHandshake(t *testing.T) {
 		t.Fatalf("failed with %v; want context.DeadlineExceeded, which is what proves the TIMEOUT ended it", err)
 	}
 }
+
+// TestAZeroTimeoutStillDialsSuccessfully is codex round 1's P1, restated after
+// the mutation matrix refused to confirm the failure mode it was named for.
+//
+// The setup is real: go-redis's Options.init() defaults DialTimeout to 5s, but
+// NewClient CLONES the options first, so a caller reading opt.DialTimeout in
+// order to build a Dialer — the only time it can — reads ZERO for the ordinary
+// URL that sets none.
+//
+// What an unresolved zero does here is NOT the hang the finding described, and
+// the difference matters because it changes what the test has to assert. This
+// dialer wraps the dial in context.WithTimeout, and a zero duration makes the
+// deadline already past — so every dial would fail INSTANTLY instead of
+// hanging. Worse in a different direction: nothing connects at all. The
+// original draft, which set only net.Dialer.Timeout, would have hung; this one
+// would refuse. Either way the default is required, and the assertion that
+// separates them is that a healthy server is reached, not that a stalled one
+// gives up.
+func TestAZeroTimeoutStillDialsSuccessfully(t *testing.T) {
+	addr, trust := tlsServerFor(t, "127.0.0.1")
+
+	conn, err := New(trust, 0)(context.Background(), "tcp", addr)
+	if err != nil {
+		t.Fatalf("a dial built with DialTimeout=0 failed against a healthy server (%v): the zero is reaching "+
+			"context.WithTimeout as an already-expired deadline, so no Redis connection would ever succeed", err)
+	}
+	_ = conn.Close()
+}
+
+// TestConnectAndHandshakeShareOneBudget is codex round 1's other P2. Applying
+// the timeout to the TCP connect and then starting a fresh one for the
+// handshake allows up to 2x DialTimeout — masked on the pooled path by an outer
+// deadline, but not on the pub/sub path, which has none.
+// tls.DialWithDialer bounds both as one interval, and this must not be laxer
+// than the code it replaces.
+func TestConnectAndHandshakeShareOneBudget(t *testing.T) {
+	addr := stalledTLSServer(t)
+	const dialTimeout = 200 * time.Millisecond
+
+	start := time.Now()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, _ = New(&tls.Config{InsecureSkipVerify: true}, dialTimeout)(context.Background(), "tcp", addr) //nolint:gosec // as above
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("the dial never returned")
+	}
+
+	// The connect succeeds immediately here, so essentially the whole budget is
+	// available to the handshake — but the two together must still fit inside
+	// ONE DialTimeout, with slack for scheduling.
+	if elapsed := time.Since(start); elapsed > 2*dialTimeout {
+		t.Fatalf("connect plus handshake took %v with a %v timeout: the two are being given separate budgets, so the "+
+			"pub/sub path can wait twice as long as tls.DialWithDialer would", elapsed, dialTimeout)
+	}
+}
+
+// TestKeepAliveIsNotSilentlyDropped pins a behaviour this dialer inherited
+// rather than chose. go-redis's default sets KeepAliveConfig on every
+// connection; reverting to OS defaults would change how quickly a dead peer is
+// noticed across the whole client, as an invisible side effect of a
+// cancellation fix — invisible because nothing would fail.
+//
+// Asserted against go-redis's published values rather than against our copy, so
+// the test fails if the copy drifts from what it mirrors.
+func TestKeepAliveIsNotSilentlyDropped(t *testing.T) {
+	if !keepAliveConfig.Enable {
+		t.Error("keep-alive is disabled; go-redis's default enables it")
+	}
+	if keepAliveConfig.Idle != 30*time.Second {
+		t.Errorf("keep-alive Idle = %v, want 30s to match go-redis's default", keepAliveConfig.Idle)
+	}
+	if keepAliveConfig.Interval != 5*time.Second {
+		t.Errorf("keep-alive Interval = %v, want 5s", keepAliveConfig.Interval)
+	}
+	if keepAliveConfig.Count != 3 {
+		t.Errorf("keep-alive Count = %d, want 3", keepAliveConfig.Count)
+	}
+}

--- a/internal/redisdial/redisdial_test.go
+++ b/internal/redisdial/redisdial_test.go
@@ -1,0 +1,300 @@
+package redisdial
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"errors"
+	"math/big"
+	"net"
+	"testing"
+	"time"
+)
+
+// tlsServerFor starts a TLS listener whose certificate is valid for the given
+// names, and returns its address plus a config that trusts it.
+func tlsServerFor(t *testing.T, names ...string) (addr string, trust *tls.Config) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("key: %v", err)
+	}
+	// IP literals belong in IPAddresses, not DNSNames — an IP SAN is a
+	// different field and x509 will not match one against the other.
+	var dnsNames []string
+	var ips []net.IP
+	for _, n := range names {
+		if ip := net.ParseIP(n); ip != nil {
+			ips = append(ips, ip)
+			continue
+		}
+		dnsNames = append(dnsNames, n)
+	}
+
+	tmpl := x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: names[0]},
+		DNSNames:              dnsNames,
+		IPAddresses:           ips,
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("cert: %v", err)
+	}
+	leaf, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("parse cert: %v", err)
+	}
+	pool := x509.NewCertPool()
+	pool.AddCert(leaf)
+
+	ln, err := tls.Listen("tcp", "127.0.0.1:0", &tls.Config{
+		Certificates: []tls.Certificate{{Certificate: [][]byte{der}, PrivateKey: key, Leaf: leaf}},
+	})
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				// Drive the handshake, then hold the connection so the client
+				// side sees a completed one.
+				if tc, ok := c.(*tls.Conn); ok {
+					_ = tc.Handshake()
+				}
+			}()
+		}
+	}()
+	return ln.Addr().String(), &tls.Config{RootCAs: pool}
+}
+
+// TestAWrongNamedCertificateIsRefused is the ServerName assertion, and it is
+// deliberately NOT "the field is set".
+//
+// The hazard this whole dialer has to avoid is turning a latency fix into a
+// silent authentication regression: tls.DialWithDialer infers ServerName from
+// the dialled address when the config leaves it empty, and a hand-rolled
+// tls.Client does not. An empty ServerName leaves verification with no name to
+// check against. Asserting that a field is populated proves the code sets a
+// field; connecting to a certificate issued for the WRONG name and requiring
+// refusal proves the property.
+func TestAWrongNamedCertificateIsRefused(t *testing.T) {
+	addr, trust := tlsServerFor(t, "the-right-name.example")
+
+	// ServerName deliberately EMPTY, so the fallback is what supplies it. The
+	// dialled address is 127.0.0.1, which the certificate does not cover.
+	dial := New(trust, 5*time.Second)
+
+	conn, err := dial(context.Background(), "tcp", addr)
+	if err == nil {
+		_ = conn.Close()
+		t.Fatal("a certificate issued for another name was accepted: with no ServerName the dialer has nothing to verify against, " +
+			"and this fix would have converted certificate verification into a no-op")
+	}
+	var unknown x509.HostnameError
+	if !errors.As(err, &unknown) {
+		t.Fatalf("refused for the wrong reason (%v); want a hostname mismatch, which is what proves the name was actually checked", err)
+	}
+}
+
+// TestAMatchingCertificateIsAccepted is the control. Without it, "wrong names
+// are refused" is satisfied by a dialer that refuses everything — which would
+// pass the test above while breaking every TLS deployment.
+func TestAMatchingCertificateIsAccepted(t *testing.T) {
+	addr, trust := tlsServerFor(t, "127.0.0.1")
+
+	conn, err := dialWithServerName(t, trust, addr, "")
+	if err != nil {
+		t.Fatalf("a certificate valid for the dialled host was refused: %v", err)
+	}
+	_ = conn.Close()
+}
+
+// TestAnExplicitServerNameIsHonoured pins that the fallback does not OVERWRITE
+// a configured name — which is the case Pad actually runs, since
+// redis.ParseURL populates ServerName for a rediss:// URL.
+func TestAnExplicitServerNameIsHonoured(t *testing.T) {
+	addr, trust := tlsServerFor(t, "configured.example")
+
+	conn, err := dialWithServerName(t, trust, addr, "configured.example")
+	if err != nil {
+		t.Fatalf("an explicitly configured ServerName was not honoured: %v", err)
+	}
+	_ = conn.Close()
+}
+
+// TestTheCallersConfigIsNotMutated is the reason the fallback clones. A shared
+// tls.Config is dialled through many times; writing the first host's name into
+// it would make every later dial verify against the wrong name — and would do
+// so only in production, where one config is reused.
+func TestTheCallersConfigIsNotMutated(t *testing.T) {
+	addr, trust := tlsServerFor(t, "127.0.0.1")
+
+	dial := New(trust, 5*time.Second)
+	conn, err := dial(context.Background(), "tcp", addr)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	_ = conn.Close()
+
+	if trust.ServerName != "" {
+		t.Fatalf("the caller's config was mutated (ServerName = %q): a shared config would carry one host's name into every later dial",
+			trust.ServerName)
+	}
+}
+
+func dialWithServerName(t *testing.T, trust *tls.Config, addr, serverName string) (net.Conn, error) {
+	t.Helper()
+	cfg := trust.Clone()
+	cfg.ServerName = serverName
+	return New(cfg, 5*time.Second)(context.Background(), "tcp", addr)
+}
+
+// stalledTLSServer accepts TCP connections and then says nothing. The TCP
+// connect succeeds; the handshake never completes.
+//
+// THIS IS THE SHAPE THE DEFECT AND ITS FIX BOTH LIVE IN. A dial bounded only
+// at the connect looks healthy here and then hangs for as long as whoever is
+// waiting is prepared to wait.
+func stalledTLSServer(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+	go func() {
+		var held []net.Conn
+		defer func() {
+			for _, c := range held {
+				_ = c.Close()
+			}
+		}()
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			held = append(held, c) // accepted, never answered
+		}
+	}()
+	return ln.Addr().String()
+}
+
+// TestACancelledCallerDoesNotWaitOutATLSHandshake is BUG-2754's regression
+// test, and the whole reason this package exists.
+//
+// go-redis's default dialer hands TLS connections to tls.DialWithDialer, which
+// takes NO context — so a cancelled caller could not shorten the dial and paid
+// DialTimeout in full. On the SSE path that is an admission slot, global and
+// per-user, held for a client that has already gone.
+//
+// Asserted against DialTimeout rather than against a wall-clock number, so it
+// fails against the unfixed behaviour whatever that constant is set to.
+func TestACancelledCallerDoesNotWaitOutATLSHandshake(t *testing.T) {
+	addr := stalledTLSServer(t)
+	const dialTimeout = 5 * time.Second
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	// BOUNDED, for the same reason its sibling below is: against the unfixed
+	// dialer this never returns, and a hung test run is not a detection anyone
+	// can act on — it also strands the mutation harness with its edit applied,
+	// which happened here once.
+	type result struct {
+		err     error
+		elapsed time.Duration
+	}
+	done := make(chan result, 1)
+	go func() {
+		start := time.Now()
+		_, err := New(&tls.Config{InsecureSkipVerify: true}, dialTimeout)(ctx, "tcp", addr) //nolint:gosec // the handshake never completes; verification is not what is under test
+		done <- result{err, time.Since(start)}
+	}()
+
+	var got result
+	select {
+	case got = <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatalf("a cancelled caller had not returned after 3s: cancellation cannot reach the handshake, so it will wait "+
+			"out the full DialTimeout of %v", dialTimeout)
+	}
+	err, elapsed := got.err, got.elapsed
+
+	if err == nil {
+		t.Fatal("a handshake against a server that never answers must not succeed")
+	}
+	if elapsed >= dialTimeout {
+		t.Fatalf("a cancelled caller waited %v, the full DialTimeout of %v: cancellation cannot reach the handshake", elapsed, dialTimeout)
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("failed with %v; want context.Canceled, which is what proves the CALLER ended it rather than a timeout", err)
+	}
+}
+
+// TestTheTimeoutStillBoundsAStalledHandshake is the other half, and the
+// direction that is easy to lose while fixing the first.
+//
+// If the timeout bounded only the TCP connect, a server that accepts and then
+// stalls would hang for as long as the CONTEXT lives — trading a bounded
+// failure for an unbounded one, which is worse than the bug being fixed. The
+// caller here never cancels.
+func TestTheTimeoutStillBoundsAStalledHandshake(t *testing.T) {
+	addr := stalledTLSServer(t)
+	const dialTimeout = 150 * time.Millisecond
+
+	// BOUNDED SO A HANG BECOMES A FAILURE. Without the fix this dial never
+	// returns at all, and an unbounded wait turns the detection into a hung
+	// test run — which is not a result anyone can act on, and which strands
+	// the mutation harness with its edit still applied.
+	type result struct {
+		err     error
+		elapsed time.Duration
+	}
+	done := make(chan result, 1)
+	go func() {
+		start := time.Now()
+		_, err := New(&tls.Config{InsecureSkipVerify: true}, dialTimeout)(context.Background(), "tcp", addr) //nolint:gosec // as above
+		done <- result{err, time.Since(start)}
+	}()
+
+	var got result
+	select {
+	case got = <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatalf("a stalled handshake had not returned after 3s with a %v timeout: the bound covers the connect but not "+
+			"the handshake, so an unresponsive TLS server hangs for as long as the context lives", dialTimeout)
+	}
+	err, elapsed := got.err, got.elapsed
+
+	if err == nil {
+		t.Fatal("a handshake against a server that never answers must not succeed")
+	}
+	if elapsed > time.Second {
+		t.Fatalf("a stalled handshake took %v with a %v timeout: the bound is not being applied to the handshake",
+			elapsed, dialTimeout)
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("failed with %v; want context.DeadlineExceeded, which is what proves the TIMEOUT ended it", err)
+	}
+}

--- a/internal/redisdial/redisdial_test.go
+++ b/internal/redisdial/redisdial_test.go
@@ -13,6 +13,8 @@ import (
 	"net"
 	"testing"
 	"time"
+
+	"github.com/redis/go-redis/v9"
 )
 
 // tlsServerFor starts a TLS listener whose certificate is valid for the given
@@ -327,12 +329,23 @@ func TestAZeroTimeoutStillDialsSuccessfully(t *testing.T) {
 	_ = conn.Close()
 }
 
-// TestConnectAndHandshakeShareOneBudget is codex round 1's other P2. Applying
-// the timeout to the TCP connect and then starting a fresh one for the
-// handshake allows up to 2x DialTimeout — masked on the pooled path by an outer
-// deadline, but not on the pub/sub path, which has none.
-// tls.DialWithDialer bounds both as one interval, and this must not be laxer
-// than the code it replaces.
+// TestConnectAndHandshakeShareOneBudget covers codex round 1's other P2:
+// applying the timeout to the TCP connect and then starting a fresh one for the
+// handshake allows up to 2x DialTimeout on the pub/sub path, which has no outer
+// deadline to mask it.
+//
+// IT DOES NOT DISCRIMINATE, and codex round 2 was right to say so. The server
+// here accepts immediately, so the connect consumes none of the budget and the
+// two-budget implementation finishes in the same time as the one-budget one.
+// Making it discriminate needs a connect that is itself slow, which cannot be
+// staged reliably against a local listener — a full backlog is the only lever
+// and it is not deterministic.
+//
+// So what holds the property is STRUCTURAL, not this test: one context is
+// created before the connect and passed through the handshake, which is
+// checkable by reading six lines. This is kept as a smoke check that the dial
+// completes within a sane multiple of the budget, and is labelled rather than
+// left to look like coverage it does not provide.
 func TestConnectAndHandshakeShareOneBudget(t *testing.T) {
 	addr := stalledTLSServer(t)
 	const dialTimeout = 200 * time.Millisecond
@@ -379,5 +392,49 @@ func TestKeepAliveIsNotSilentlyDropped(t *testing.T) {
 	}
 	if keepAliveConfig.Count != 3 {
 		t.Errorf("keep-alive Count = %d, want 3", keepAliveConfig.Count)
+	}
+}
+
+// TestAnExplicitlyDisabledTimeoutIsHonoured is codex round 2's P2. ParseURL
+// turns an explicit dial_timeout of zero or negative into -1, which go-redis
+// preserves as "no timeout"; collapsing every non-positive value to the default
+// would overrule an operator who had deliberately disabled the bound.
+//
+// Asserted through ParseURL rather than by passing -1 directly, so the test
+// pins the actual production path — the value this dialer receives is whatever
+// that function produced.
+func TestAnExplicitlyDisabledTimeoutIsHonoured(t *testing.T) {
+	opts, err := redis.ParseURL("redis://127.0.0.1:6379?dial_timeout=0")
+	if err != nil {
+		t.Fatalf("parse url: %v", err)
+	}
+	if opts.DialTimeout >= 0 {
+		t.Fatalf("fixture: ParseURL gave DialTimeout=%v; this test assumes it encodes an explicit zero as negative",
+			opts.DialTimeout)
+	}
+
+	addr, trust := tlsServerFor(t, "127.0.0.1")
+	conn, err := New(trust, opts.DialTimeout)(context.Background(), "tcp", addr)
+	if err != nil {
+		t.Fatalf("an explicitly disabled timeout broke the dial: %v", err)
+	}
+	_ = conn.Close()
+}
+
+// TestTheCopiedDefaultStillMatchesGoRedis is the drift guard codex round 2
+// asked for (P3). Both constants in this package are copies of unexported or
+// internal go-redis values, and a copy that silently diverges from what it
+// mirrors is exactly the maintenance trap that makes this package worse than
+// no package.
+//
+// Compared against go-redis's RESOLVED options rather than against a literal:
+// NewClient runs init() on its clone, and Options() hands back the result, so
+// this reads the same default the library would have applied.
+func TestTheCopiedDefaultStillMatchesGoRedis(t *testing.T) {
+	resolved := redis.NewClient(&redis.Options{Addr: "127.0.0.1:6379"}).Options()
+	if resolved.DialTimeout != defaultDialTimeout {
+		t.Fatalf("go-redis now defaults DialTimeout to %v, this package still copies %v — the copy has drifted from "+
+			"what it mirrors, so a client built without an explicit timeout gets a different bound than go-redis intends",
+			resolved.DialTimeout, defaultDialTimeout)
 	}
 }


### PR DESCRIPTION
Fixes BUG-2754.

go-redis's default dialer (v9.22.0, `options.go` `NewDialer`) honours the caller's context on plaintext and **not** on TLS — the TLS branch returns `tls.DialWithDialer`, which takes no context at all, so a cancelled caller could not shorten the dial and it was bounded only by `DialTimeout`.

BUG-2749 put SSE subscription establishment on the request's context so a client that disconnects stops holding its admission slots. On plaintext that covered the dial. On TLS the dial was the one segment cancellation could not reach — and a managed Redis is a `rediss://` URL, which is the ordinary production shape.

Fixed at **client construction**, not in any consumer: the same dial serves `Publish`, the Lua scripts, the presence registry and the watch bus's reads. `internal/redisdial` is a small package so the thing is testable directly; `cmd/pad/cmd_server.go` installs it on the one client Pad builds.

## What a replacement dialer has to get right

Each of these fails *quietly*, and each has a test that fails against getting it wrong.

**ServerName.** `tls.DialWithDialer` infers it from the dialled address when the config leaves it empty; a hand-rolled `tls.Client` does not, and an empty `ServerName` leaves certificate verification with no name to check. That would turn a latency fix into a silent authentication regression. Replicated on a **clone** — mutating the caller's config would leak one host's name into every later dial that shares it. Tested by dialling a certificate issued for another name and requiring an `x509.HostnameError`: asserting the field is set proves the code sets a field, not that the name is checked.

**`DialTimeout` read as zero.** `Options.init()` defaults it to 5s, but `NewClient` *clones* the options first, so a caller reading `opt.DialTimeout` in order to install a Dialer — the only time it can — reads zero for the ordinary URL. `PubSubPool.NewConn` calls the dialer directly with no timeout of its own, so nothing downstream supplies one. Resolved in the package, with the coupling named.

**An explicitly disabled timeout.** `ParseURL` encodes `dial_timeout=0` as `-1`, which go-redis preserves as "no timeout". Collapsing every non-positive value to the default would overrule an operator who deliberately disabled the bound.

**`KeepAliveConfig`.** go-redis's default sets it, and it governs how fast a dead peer is noticed on every Redis connection this process holds. Dropping it would change that across the whole client as an invisible side effect.

**One budget, not two.** Applying the timeout to the connect and then starting a fresh one for the handshake allows up to `2×DialTimeout` on the pub/sub path, which has no outer deadline to mask it.

## Prose swept

Five comments across `internal/events` said the TLS dial could not be cancelled, one carrying an explicit *"See BUG-2754 for the TLS half"* forward reference. All now say what is true.

## Honest boundaries, stated at the code

- The single-budget test **does not discriminate** — the local server accepts immediately, so the two-budget implementation finishes in the same time. What holds that property is structural, and the test is labelled rather than left looking like coverage.
- The keep-alive socket assertion is **Linux-only** by build tag. The behaviour is platform-independent and the full suite runs on Linux CI, so a removal is caught; the macOS and Windows Smoke jobs are build-and-start checks and were never the guard.

## Gates

`go build`, `go vet`, `make lint` (0 issues), `go test ./...` (28 packages), and the full suite against Postgres on a private container. `make check` was **not** run: it reaches `npm ci` through this worktree's symlinked `node_modules`. No frontend code is touched.

Three Codex rounds; CLEAN and approve at round 3. Round 1's P1 was a defect this fix's own first draft introduced.

https://claude.ai/code/session_01JVDBKbgn3Xt7ndW1YoYd8X
