### PR TITLE
fix(store): activity debounce must not merge across writers (BUG-2763)

### DIFF
--- a/internal/server/handlers_activity_debounce_actor_test.go
+++ b/internal/server/handlers_activity_debounce_actor_test.go
@@ -1,0 +1,166 @@
+package server
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// BUG-2763. The activity debounce coalesced two writes by DIFFERENT writers
+// into one row whenever they shared a user account — which every agent does,
+// because it authenticates as the human it works for. The surviving row kept
+// the first write's `actor` (the UPDATE writes only metadata and created_at)
+// while the merge overlaid the incoming `agent` name last-writer-wins, so both
+// orderings produced a row naming the wrong writer.
+//
+// These drive the real PATCH route with and without X-Pad-Agent and read the
+// timeline endpoint, because that binding is what renders wrong: the store row
+// alone cannot show it — TimelineActivityCard reads the stamped name only when
+// actor == "agent" and otherwise prints the person (CONVE-19).
+
+// patchStatusAs performs the item PATCH the web UI performs, as an agent when
+// `agent` is non-empty and as the plain human account when it is not. Both
+// legs authenticate as the same account either way, which is the whole point.
+func patchStatusAs(t *testing.T, srv *Server, ws, slug, agent, status string) {
+	t.Helper()
+	doAttributionRequest(t, srv, agent, "PATCH",
+		"/api/v1/workspaces/"+ws+"/items/"+slug,
+		map[string]any{"fields": `{"status":"` + status + `"}`})
+}
+
+// updatedActivityEntries returns the timeline's "updated" activity entries.
+// The timeline carries other kinds too (the create activity, versions, notes),
+// none of which this bug touches.
+//
+// Deliberately unordered: both PATCHes land inside the same second, and the
+// timeline's sort breaks a created_at tie on the id, which is a random UUID.
+// Asserting position would have flaked about half the time; each entry is
+// identified below by the change it records instead.
+func updatedActivityEntries(entries []models.TimelineEntry) []models.TimelineEntry {
+	var out []models.TimelineEntry
+	for _, e := range entries {
+		if e.Kind == "activity" && e.Activity != nil && e.Activity.Action == "updated" {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// changesOf reads the human-readable change list the PATCH handler stamps into
+// an activity's metadata, which is what identifies WHICH write a row came from.
+func changesOf(t *testing.T, metadata string) string {
+	t.Helper()
+	var m map[string]any
+	if err := json.Unmarshal([]byte(metadata), &m); err != nil {
+		t.Fatalf("metadata %s: %v", metadata, err)
+	}
+	c, _ := m["changes"].(string)
+	return c
+}
+
+func TestTimeline_DebounceDoesNotMergeAcrossWriters(t *testing.T) {
+	t.Parallel()
+
+	type writer struct {
+		agent string // X-Pad-Agent value; "" is the human
+	}
+	// Each expected entry names the write it must correspond to by the change
+	// that write recorded, so the assertion does not depend on row order.
+	type attribution struct {
+		changes   string
+		actor     string
+		agentName string
+	}
+	const (
+		first  = "status: open → in-progress"
+		second = "status: in-progress → done"
+	)
+
+	for _, tc := range []struct {
+		name    string
+		writers []writer
+		want    []attribution
+	}{
+		{
+			name:    "human then agent",
+			writers: []writer{{""}, {"wren"}},
+			want: []attribution{
+				{changes: first, actor: "user"},
+				{changes: second, actor: "agent", agentName: "wren"},
+			},
+		},
+		{
+			name:    "agent then human",
+			writers: []writer{{"wren"}, {""}},
+			want: []attribution{
+				{changes: first, actor: "agent", agentName: "wren"},
+				{changes: second, actor: "user"},
+			},
+		},
+		{
+			name:    "two agents on one account",
+			writers: []writer{{"wren"}, {"rook"}},
+			want: []attribution{
+				{changes: first, actor: "agent", agentName: "wren"},
+				{changes: second, actor: "agent", agentName: "rook"},
+			},
+		},
+		// Controls. Coalescing is the feature; a fix that simply stopped
+		// debouncing would pass every leg above and fail these. Their single
+		// row carries the run's collapsed changes, so it is matched by
+		// position (there is only one) rather than by change text.
+		{
+			name:    "same agent twice still coalesces (control)",
+			writers: []writer{{"wren"}, {"wren"}},
+			want:    []attribution{{actor: "agent", agentName: "wren"}},
+		},
+		{
+			name:    "same human twice still coalesces (control)",
+			writers: []writer{{""}, {""}},
+			want:    []attribution{{actor: "user"}},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			srv := testServer(t)
+			ws := createTestWorkspaceViaAPI(t, srv)
+			item := timelineItemWithStructured(t, srv, ws, "", "")
+
+			// Distinct status values so each PATCH is a real change and
+			// therefore writes `changes` metadata — an "updated" activity with
+			// empty metadata is dropped by the timeline before it can be read.
+			statuses := []string{"in-progress", "done"}
+			for i, w := range tc.writers {
+				patchStatusAs(t, srv, ws, item.Slug, w.agent, statuses[i])
+			}
+
+			got := updatedActivityEntries(fetchTimeline(t, srv, ws, item.Slug, "").Entries)
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %d updated entries, want %d", len(got), len(tc.want))
+			}
+
+			byChanges := map[string]models.TimelineEntry{}
+			for _, e := range got {
+				byChanges[changesOf(t, e.Activity.Metadata)] = e
+			}
+			for _, w := range tc.want {
+				e := got[0]
+				if w.changes != "" {
+					var ok bool
+					e, ok = byChanges[w.changes]
+					if !ok {
+						t.Fatalf("no entry recording %q; entries: %v", w.changes, byChanges)
+					}
+				}
+				if e.Actor != w.actor {
+					t.Errorf("entry for %q: actor = %q, want %q", w.changes, e.Actor, w.actor)
+				}
+				if name := models.AgentNameFromMetadata(e.Activity.Metadata); name != w.agentName {
+					t.Errorf("entry for %q: agent name = %q, want %q (metadata %s)",
+						w.changes, name, w.agentName, e.Activity.Metadata)
+				}
+			}
+		})
+	}
+}

--- a/internal/server/handlers_activity_debounce_actor_test.go
+++ b/internal/server/handlers_activity_debounce_actor_test.go
@@ -1,7 +1,11 @@
 package server
 
 import (
+	"bytes"
 	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/PerpetualSoftware/pad/internal/models"
@@ -19,12 +23,68 @@ import (
 // alone cannot show it — TimelineActivityCard reads the stamped name only when
 // actor == "agent" and otherwise prints the person (CONVE-19).
 
-// patchStatusAs performs the item PATCH the web UI performs, as an agent when
-// `agent` is non-empty and as the plain human account when it is not. Both
-// legs authenticate as the same account either way, which is the whole point.
-func patchStatusAs(t *testing.T, srv *Server, ws, slug, agent, status string) {
+// authedAgentRequest performs a request as a real logged-in account, optionally
+// declaring an agent. The account is what makes these tests meaningful: the
+// debounce keys on user_id, and an unauthenticated request writes NULL there —
+// which coalesces by a different branch of the predicate and would let a
+// regression in the handler→store user-id flow pass unnoticed (codex round 5).
+func authedAgentRequest(t *testing.T, srv *Server, token, agent, method, path string, body any) *httptest.ResponseRecorder {
 	t.Helper()
-	doAttributionRequest(t, srv, agent, "PATCH",
+	var r io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			t.Fatalf("marshal body: %v", err)
+		}
+		r = bytes.NewReader(data)
+	}
+	req := httptest.NewRequest(method, path, r)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	if agent != "" {
+		req.Header.Set("X-Pad-Agent", agent)
+	}
+	req.RemoteAddr = "192.0.2.1:1234"
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK && rr.Code != http.StatusCreated {
+		t.Fatalf("%s %s = %d: %s", method, path, rr.Code, rr.Body.String())
+	}
+	return rr
+}
+
+// debounceFixture bootstraps one account and gives it a workspace and an item.
+// Every write below rides this one account, which is the shape the bug needs:
+// an agent authenticates as the human it works for, so user_id cannot tell the
+// two apart.
+func debounceFixture(t *testing.T, srv *Server) (token, ws, itemSlug string) {
+	t.Helper()
+	token = bootstrapFirstUser(t, srv, "owner@test.com", "Owner")
+
+	var wsResp struct {
+		Slug string `json:"slug"`
+	}
+	rr := authedAgentRequest(t, srv, token, "", "POST", "/api/v1/workspaces",
+		map[string]any{"name": "Debounce", "slug": "debounce", "template": "startup"})
+	decodeAttributionBody(t, rr, &wsResp)
+
+	var item models.Item
+	rr = authedAgentRequest(t, srv, token, "", "POST",
+		"/api/v1/workspaces/"+wsResp.Slug+"/collections/tasks/items",
+		map[string]any{"title": "debounce subject", "fields": `{"status":"open"}`})
+	decodeAttributionBody(t, rr, &item)
+
+	return token, wsResp.Slug, item.Slug
+}
+
+// patchStatusAs performs the item PATCH the web UI performs, as an agent when
+// `agent` is non-empty and as the plain human otherwise — on the same account
+// either way, which is the whole point.
+func patchStatusAs(t *testing.T, srv *Server, token, ws, slug, agent, status string) {
+	t.Helper()
+	authedAgentRequest(t, srv, token, agent, "PATCH",
 		"/api/v1/workspaces/"+ws+"/items/"+slug,
 		map[string]any{"fields": `{"status":"` + status + `"}`})
 }
@@ -124,18 +184,17 @@ func TestTimeline_DebounceDoesNotMergeAcrossWriters(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			srv := testServer(t)
-			ws := createTestWorkspaceViaAPI(t, srv)
-			item := timelineItemWithStructured(t, srv, ws, "", "")
+			token, ws, itemSlug := debounceFixture(t, srv)
 
 			// Distinct status values so each PATCH is a real change and
 			// therefore writes `changes` metadata — an "updated" activity with
 			// empty metadata is dropped by the timeline before it can be read.
 			statuses := []string{"in-progress", "done"}
 			for i, w := range tc.writers {
-				patchStatusAs(t, srv, ws, item.Slug, w.agent, statuses[i])
+				patchStatusAs(t, srv, token, ws, itemSlug, w.agent, statuses[i])
 			}
 
-			got := updatedActivityEntries(fetchTimeline(t, srv, ws, item.Slug, "").Entries)
+			got := updatedActivityEntries(fetchTimelineAuthed(t, srv, token, ws, itemSlug).Entries)
 			if len(got) != len(tc.want) {
 				t.Fatalf("got %d updated entries, want %d", len(got), len(tc.want))
 			}
@@ -160,7 +219,26 @@ func TestTimeline_DebounceDoesNotMergeAcrossWriters(t *testing.T) {
 					t.Errorf("entry for %q: agent name = %q, want %q (metadata %s)",
 						w.changes, name, w.agentName, e.Activity.Metadata)
 				}
+				// The premise, asserted rather than assumed: every row is the
+				// SAME real account. If the writes landed under NULL user_ids
+				// the split above would prove nothing about writers sharing an
+				// account, which is the only case this bug is about.
+				if e.Activity.UserID == "" || e.Activity.UserID != got[0].Activity.UserID {
+					t.Errorf("entry for %q: user_id = %q, want the one non-empty account %q",
+						w.changes, e.Activity.UserID, got[0].Activity.UserID)
+				}
 			}
 		})
 	}
+}
+
+// fetchTimelineAuthed is fetchTimeline with a session, since these tests run on
+// an instance that has an owner and therefore requires auth.
+func fetchTimelineAuthed(t *testing.T, srv *Server, token, wsSlug, itemSlug string) models.TimelineResponse {
+	t.Helper()
+	rr := authedAgentRequest(t, srv, token, "", "GET",
+		"/api/v1/workspaces/"+wsSlug+"/items/"+itemSlug+"/timeline", nil)
+	var resp models.TimelineResponse
+	decodeAttributionBody(t, rr, &resp)
+	return resp
 }

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -1702,9 +1702,12 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 	// create a comment linked to the activity entry. The comment reads its
 	// agent name through that link (TASK-2760); between the activity write
 	// above and the link below the row is still unlinked, so a concurrent
-	// update under the same user can debounce-merge into it and overlay the
-	// agent stamp the comment will then carry. Same non-atomic window as
-	// BUG-2716, which is where the one-transaction fix is tracked.
+	// update under the same user can debounce-merge into it and bump the
+	// created_at the comment will then sit against. It can no longer overlay a
+	// DIFFERENT agent's stamp: since BUG-2763 the debounce refuses to coalesce
+	// across writer identities, so whatever merges here declares the same name
+	// this comment will carry. Same non-atomic window as BUG-2716, which is
+	// where the one-transaction fix is tracked.
 	if input.Comment != nil && strings.TrimSpace(*input.Comment) != "" {
 		commentInput := models.CommentCreate{
 			Body:       strings.TrimSpace(*input.Comment),

--- a/internal/store/activities.go
+++ b/internal/store/activities.go
@@ -17,6 +17,26 @@ import (
 // agent names sharing one user_id (BUG-2763).
 const ActivityDebounceCooldown = 5 * time.Minute
 
+// maxDebounceCandidates bounds how many recent rows CreateActivityDebounced
+// examines when looking for the current writer's own row to extend.
+//
+// It is a scan bound, not a semantic one, and it exists because created_at has
+// WHOLE-SECOND precision: several rows inside the window can carry the same
+// timestamp, and ORDER BY created_at cannot order them — SQLite returns such a
+// tie in a stable-looking order that Postgres does not promise. Reading only
+// the top row would let a rapid human → agent → agent sequence land on the
+// human's row, refuse the merge on identity, and split the agent's run across
+// two rows (codex round 1 on this fix).
+//
+// Ten covers the writers that plausibly interleave on one item inside a
+// five-minute window — a human plus a handful of agents on one account, plus
+// any rows already frozen by a comment link. It is not a correctness bound in
+// either direction: past it the loop simply fails to find the writer's own row
+// and starts a new one, which costs an extra activity row and can never
+// produce a wrong attribution. It does NOT bound how many rows the window can
+// hold, only how many are inspected.
+const maxDebounceCandidates = 10
+
 func (s *Store) CreateActivity(a models.Activity) (string, error) {
 	a.ID = newID()
 	if a.Metadata == "" {
@@ -53,58 +73,70 @@ func (s *Store) CreateActivityDebounced(a models.Activity) (string, error) {
 	ts := now()
 	cutoff := time.Now().UTC().Add(-ActivityDebounceCooldown).Format(time.RFC3339)
 
-	// Look for a recent activity to coalesce with — the newest match. If a
-	// comment links that row (comments.activity_id), the merge below REFUSES
-	// it and a fresh row is written instead: the comment reads its agent
-	// name from the row's metadata, and a merge overlays the incoming `agent`
-	// and bumps created_at, so a later update by a different agent under the
-	// same credentials would otherwise silently re-attribute an earlier
-	// comment (TASK-2760, codex round 3). A linked row therefore ENDS a
-	// coalescing run; the next update starts a new one. The refusal lives in
-	// the UPDATE's own predicate and nowhere else, because a comment can link
-	// the row between this read and that write (codex round 6) — a check
-	// here would be a second guard that only looks load-bearing. What this
-	// does NOT close is the opposite order, an update that completes before
-	// the comment links its row at all: BUG-2716's transaction.
-	var existingID, existingMeta, existingActor string
-	err := s.db.QueryRow(s.q(`
-		SELECT id, metadata, actor FROM activities
-		WHERE document_id = ? AND action = ? AND created_at >= ?
-			AND ((user_id IS NOT NULL AND user_id = ?) OR (user_id IS NULL AND ? = ''))
-		ORDER BY created_at DESC LIMIT 1
-	`), a.DocumentID, a.Action, cutoff, a.UserID, a.UserID).Scan(&existingID, &existingMeta, &existingActor)
+	// Look for a recent activity of THIS WRITER's to coalesce with, newest
+	// first. If a comment links the row we choose (comments.activity_id), the
+	// merge below REFUSES it and a fresh row is written instead: the comment
+	// reads its agent name from the row's metadata, and a merge overlays the
+	// incoming `agent` and bumps created_at, so a later update by a different
+	// agent under the same credentials would otherwise silently re-attribute
+	// an earlier comment (TASK-2760, codex round 3). A linked row therefore
+	// ENDS a coalescing run; the next update starts a new one. That refusal
+	// lives in the UPDATE's own predicate and nowhere else, because a comment
+	// can link the row between this read and that write (codex round 6) — a
+	// check here would be a second guard that only looks load-bearing. What
+	// this does NOT close is the opposite order, an update that completes
+	// before the comment links its row at all: BUG-2716's transaction.
+	//
+	// THE WRITER, NOT THE ACCOUNT (BUG-2763). One account is shared by the
+	// human and by every agent authenticating as them, so user_id does not
+	// identify the writer: `actor` separates a human's write from an agent's,
+	// and the `agent` name inside metadata separates two agents from each
+	// other. Coalescing across either produces a row naming the wrong writer
+	// in both directions, because the UPDATE writes only metadata and
+	// created_at — the surviving row keeps the FIRST write's actor — while
+	// mergeActivityMeta overlays `agent` last-writer-wins. Both are visible:
+	// TimelineActivityCard reads the stamped name only when actor == "agent"
+	// and prints the person otherwise.
+	//
+	// actor is a SQL predicate; the agent name is matched in Go because it
+	// lives inside the metadata JSON and this store targets two dialects
+	// whose JSON accessors differ (the same reason models.AgentNameFromMetadata
+	// exists rather than a json_extract).
+	incomingAgent := models.AgentNameFromMetadata(a.Metadata)
 
-	if err == sql.ErrNoRows {
-		// No recent match — create a new activity.
-		return s.CreateActivity(a)
-	}
+	rows, err := s.db.Query(s.q(`
+		SELECT id, metadata FROM activities
+		WHERE document_id = ? AND action = ? AND created_at >= ? AND actor = ?
+			AND ((user_id IS NOT NULL AND user_id = ?) OR (user_id IS NULL AND ? = ''))
+		ORDER BY created_at DESC LIMIT ?
+	`), a.DocumentID, a.Action, cutoff, a.Actor, a.UserID, a.UserID, maxDebounceCandidates)
 	if err != nil {
 		// Query error — fall back to creating a new activity.
 		return s.CreateActivity(a)
 	}
 
-	// Refuse to coalesce across WRITER IDENTITIES (BUG-2763). One account is
-	// shared by the human and by every agent authenticating as them, so the
-	// user_id predicate above does not identify the writer: `actor`
-	// separates a human's write from an agent's, and the `agent` name inside
-	// metadata separates two agents from each other. Merging across either
-	// produces a row that names the wrong writer, in both directions — the
-	// UPDATE below writes only metadata and created_at, so the surviving row
-	// keeps the FIRST write's actor, while mergeActivityMeta overlays
-	// `agent` last-writer-wins. Both are visible, because
-	// TimelineActivityCard reads the stamped name only when actor ==
-	// "agent" and ignores it otherwise.
-	//
-	// This check is in Go rather than in the UPDATE's predicate, where the
-	// comment-link refusal lives (TASK-2760, codex round 6), because nothing
-	// can invalidate it between this read and that write: `actor` is written
-	// once at INSERT and no statement in this package updates it, and the
-	// metadata `agent` key can only be rewritten by a merge that passed this
-	// same check — which by construction leaves the name equal to what it
-	// already was. A predicate in the UPDATE would be guarding against a
-	// change that cannot happen.
-	if existingActor != a.Actor ||
-		models.AgentNameFromMetadata(existingMeta) != models.AgentNameFromMetadata(a.Metadata) {
+	var existingID, existingMeta string
+	for rows.Next() {
+		var id, meta string
+		if err := rows.Scan(&id, &meta); err != nil {
+			_ = rows.Close()
+			return s.CreateActivity(a)
+		}
+		if models.AgentNameFromMetadata(meta) == incomingAgent {
+			existingID, existingMeta = id, meta
+			break
+		}
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return s.CreateActivity(a)
+	}
+	if err := rows.Close(); err != nil {
+		return s.CreateActivity(a)
+	}
+
+	if existingID == "" {
+		// Nothing recent of this writer's — start a new run.
 		return s.CreateActivity(a)
 	}
 

--- a/internal/store/activities.go
+++ b/internal/store/activities.go
@@ -11,7 +11,10 @@ import (
 )
 
 // ActivityDebounceCooldown is the window during which repeated "updated" actions
-// on the same item by the same user are coalesced into a single activity entry.
+// on the same item by the same writer are coalesced into a single activity
+// entry. "Same writer" is narrower than the account: see
+// CreateActivityDebounced, which refuses to coalesce across actor kinds or
+// agent names sharing one user_id (BUG-2763).
 const ActivityDebounceCooldown = 5 * time.Minute
 
 func (s *Store) CreateActivity(a models.Activity) (string, error) {
@@ -29,8 +32,9 @@ func (s *Store) CreateActivity(a models.Activity) (string, error) {
 }
 
 // CreateActivityDebounced creates a new activity or updates an existing one if a
-// matching activity (same document, same user, same action) was recorded within
-// the cooldown window. Only "updated" actions are debounced; all other actions
+// matching activity (same document, same action, and same WRITER — same user
+// account, same actor kind, and same agent name) was recorded within the
+// cooldown window. Only "updated" actions are debounced; all other actions
 // always create a new entry.
 //
 // When merging, the existing activity's timestamp is bumped to now and its
@@ -62,13 +66,13 @@ func (s *Store) CreateActivityDebounced(a models.Activity) (string, error) {
 	// here would be a second guard that only looks load-bearing. What this
 	// does NOT close is the opposite order, an update that completes before
 	// the comment links its row at all: BUG-2716's transaction.
-	var existingID, existingMeta string
+	var existingID, existingMeta, existingActor string
 	err := s.db.QueryRow(s.q(`
-		SELECT id, metadata FROM activities
+		SELECT id, metadata, actor FROM activities
 		WHERE document_id = ? AND action = ? AND created_at >= ?
 			AND ((user_id IS NOT NULL AND user_id = ?) OR (user_id IS NULL AND ? = ''))
 		ORDER BY created_at DESC LIMIT 1
-	`), a.DocumentID, a.Action, cutoff, a.UserID, a.UserID).Scan(&existingID, &existingMeta)
+	`), a.DocumentID, a.Action, cutoff, a.UserID, a.UserID).Scan(&existingID, &existingMeta, &existingActor)
 
 	if err == sql.ErrNoRows {
 		// No recent match — create a new activity.
@@ -76,6 +80,31 @@ func (s *Store) CreateActivityDebounced(a models.Activity) (string, error) {
 	}
 	if err != nil {
 		// Query error — fall back to creating a new activity.
+		return s.CreateActivity(a)
+	}
+
+	// Refuse to coalesce across WRITER IDENTITIES (BUG-2763). One account is
+	// shared by the human and by every agent authenticating as them, so the
+	// user_id predicate above does not identify the writer: `actor`
+	// separates a human's write from an agent's, and the `agent` name inside
+	// metadata separates two agents from each other. Merging across either
+	// produces a row that names the wrong writer, in both directions — the
+	// UPDATE below writes only metadata and created_at, so the surviving row
+	// keeps the FIRST write's actor, while mergeActivityMeta overlays
+	// `agent` last-writer-wins. Both are visible, because
+	// TimelineActivityCard reads the stamped name only when actor ==
+	// "agent" and ignores it otherwise.
+	//
+	// This check is in Go rather than in the UPDATE's predicate, where the
+	// comment-link refusal lives (TASK-2760, codex round 6), because nothing
+	// can invalidate it between this read and that write: `actor` is written
+	// once at INSERT and no statement in this package updates it, and the
+	// metadata `agent` key can only be rewritten by a merge that passed this
+	// same check — which by construction leaves the name equal to what it
+	// already was. A predicate in the UPDATE would be guarding against a
+	// change that cannot happen.
+	if existingActor != a.Actor ||
+		models.AgentNameFromMetadata(existingMeta) != models.AgentNameFromMetadata(a.Metadata) {
 		return s.CreateActivity(a)
 	}
 

--- a/internal/store/activities.go
+++ b/internal/store/activities.go
@@ -28,13 +28,21 @@ const ActivityDebounceCooldown = 5 * time.Minute
 // human's row, refuse the merge on identity, and split the agent's run across
 // two rows (codex round 1 on this fix).
 //
-// Ten covers the writers that plausibly interleave on one item inside a
-// five-minute window — a human plus a handful of agents on one account, plus
-// any rows already frozen by a comment link. It is not a correctness bound in
-// either direction: past it the loop simply fails to find the writer's own row
+// The rows that can crowd out the writer's own are narrower than "everything
+// in the window": the query already filters to one document, one account and
+// one actor kind, so only rows carrying a DIFFERENT agent name compete. For a
+// human write that is normally none at all (a human write stamps no name), and
+// can only be a row written before this fix, when a merge could overlay an
+// agent name onto a user-actor row. For an agent it is the other agent names
+// on the same account touching the same item inside five minutes.
+//
+// Ten of those is already an implausible load, and the bound is deliberately
+// not a correctness one: past it the loop fails to find the writer's own row
 // and starts a new one, which costs an extra activity row and can never
-// produce a wrong attribution. It does NOT bound how many rows the window can
-// hold, only how many are inspected.
+// produce a wrong attribution — the direction this fix exists to prevent.
+// Raising it costs a longer scan on a write path; the number is a scan
+// ceiling, not a statement about how many rows the window may hold.
+// (Declined codex round 2, which read the bound as incomplete coalescing.)
 const maxDebounceCandidates = 10
 
 func (s *Store) CreateActivity(a models.Activity) (string, error) {
@@ -98,10 +106,15 @@ func (s *Store) CreateActivityDebounced(a models.Activity) (string, error) {
 	// TimelineActivityCard reads the stamped name only when actor == "agent"
 	// and prints the person otherwise.
 	//
-	// actor is a SQL predicate; the agent name is matched in Go because it
-	// lives inside the metadata JSON and this store targets two dialects
-	// whose JSON accessors differ (the same reason models.AgentNameFromMetadata
-	// exists rather than a json_extract).
+	// actor is a SQL predicate; the agent name is matched in Go. Not for want
+	// of a portable accessor — s.dialect.JSONExtractText would render this
+	// column's `agent` key on both backends — but because
+	// models.AgentNameFromMetadata is the twin of the accessor the RENDERER
+	// uses, and the two disagree exactly where a stored value is odd: a
+	// non-string `agent` reads as absent in Go and as its text form in SQL,
+	// and malformed metadata is one skipped row in Go versus a failed query
+	// on SQLite. Matching on the value the timeline will actually display
+	// keeps the merge decision and the rendering in agreement.
 	incomingAgent := models.AgentNameFromMetadata(a.Metadata)
 
 	rows, err := s.db.Query(s.q(`

--- a/internal/store/activities.go
+++ b/internal/store/activities.go
@@ -93,7 +93,10 @@ func (s *Store) CreateActivityDebounced(a models.Activity) (string, error) {
 	// can link the row between this read and that write (codex round 6) — a
 	// check here would be a second guard that only looks load-bearing. What
 	// this does NOT close is the opposite order, an update that completes
-	// before the comment links its row at all: BUG-2716's transaction.
+	// before the link is VISIBLE to it — the comment row is written in its
+	// own transaction, so on Postgres a link committing while this UPDATE's
+	// snapshot is already open is missed exactly as an unwritten one is.
+	// Closing that needs both rows in one transaction: BUG-2716.
 	//
 	// THE WRITER, NOT THE ACCOUNT (BUG-2763). One account is shared by the
 	// human and by every agent authenticating as them, so user_id does not
@@ -102,7 +105,9 @@ func (s *Store) CreateActivityDebounced(a models.Activity) (string, error) {
 	// other. Coalescing across either produces a row naming the wrong writer
 	// in both directions, because the UPDATE writes only metadata and
 	// created_at — the surviving row keeps the FIRST write's actor — while
-	// mergeActivityMeta overlays `agent` last-writer-wins. Both are visible:
+	// mergeActivityMeta overlays `agent` only when the incoming write carries
+	// one and leaves the stale name standing when it does not — which is the
+	// two directions. Both are visible:
 	// TimelineActivityCard reads the stamped name only when actor == "agent"
 	// and prints the person otherwise.
 	//
@@ -111,10 +116,11 @@ func (s *Store) CreateActivityDebounced(a models.Activity) (string, error) {
 	// column's `agent` key on both backends — but because
 	// models.AgentNameFromMetadata is the twin of the accessor the RENDERER
 	// uses, and the two disagree exactly where a stored value is odd: a
-	// non-string `agent` reads as absent in Go and as its text form in SQL,
-	// and malformed metadata is one skipped row in Go versus a failed query
-	// on SQLite. Matching on the value the timeline will actually display
-	// keeps the merge decision and the rendering in agreement.
+	// non-string `agent` reads as absent in Go, while json_extract yields a
+	// native number or boolean that no text comparison matches, and malformed
+	// metadata is one skipped row in Go versus a failed query on SQLite.
+	// Matching on the value the timeline will actually display keeps the
+	// merge decision and the rendering in agreement.
 	incomingAgent := models.AgentNameFromMetadata(a.Metadata)
 
 	rows, err := s.db.Query(s.q(`

--- a/internal/store/activities_test.go
+++ b/internal/store/activities_test.go
@@ -678,21 +678,35 @@ func TestCreateActivityDebounced_WriterIdentitySplitsRuns(t *testing.T) {
 		{
 			name:   "human then agent",
 			writes: []write{{actor: "user", changes: "status: open → active"}, {actor: "agent", agent: "wren", changes: "priority: low → high"}},
-			want:   []write{{actor: "user"}, {actor: "agent", agent: "wren"}},
+			want:   []write{{actor: "user", changes: "status: open → active"}, {actor: "agent", agent: "wren", changes: "priority: low → high"}},
 		},
 		{
 			name:   "agent then human",
 			writes: []write{{actor: "agent", agent: "wren", changes: "status: open → active"}, {actor: "user", changes: "priority: low → high"}},
-			want:   []write{{actor: "agent", agent: "wren"}, {actor: "user"}},
+			want:   []write{{actor: "agent", agent: "wren", changes: "status: open → active"}, {actor: "user", changes: "priority: low → high"}},
 		},
 		{
 			name:   "two agents on one account",
 			writes: []write{{actor: "agent", agent: "wren", changes: "status: open → active"}, {actor: "agent", agent: "rook", changes: "priority: low → high"}},
-			want:   []write{{actor: "agent", agent: "wren"}, {actor: "agent", agent: "rook"}},
+			want:   []write{{actor: "agent", agent: "wren", changes: "status: open → active"}, {actor: "agent", agent: "rook", changes: "priority: low → high"}},
 		},
 		// The control legs. Without them, a "never coalesce" implementation —
 		// or one that split on any difference at all, including the `changes`
 		// text — passes every leg above.
+		{
+			// The leg that makes the actor comparison independently
+			// load-bearing. Through the only production caller today, actor
+			// and agent name both derive from the X-Pad-Agent header, so they
+			// cannot disagree and the agent-name comparison alone would catch
+			// every case above — removing the actor half survives the rest of
+			// this matrix. The store's own API admits the decoupled state, and
+			// this is what it means: a caller declaring an agent write without
+			// stamping a name is still not the human, and must not merge into
+			// the human's row.
+			name:   "agent kind without a name is still not the human",
+			writes: []write{{actor: "user", changes: "status: open → active"}, {actor: "agent", changes: "priority: low → high"}},
+			want:   []write{{actor: "user", changes: "status: open → active"}, {actor: "agent", changes: "priority: low → high"}},
+		},
 		{
 			name:   "same agent twice still coalesces (control)",
 			writes: []write{{actor: "agent", agent: "wren", changes: "status: open → active"}, {actor: "agent", agent: "wren", changes: "priority: low → high"}},
@@ -733,16 +747,44 @@ func TestCreateActivityDebounced_WriterIdentitySplitsRuns(t *testing.T) {
 			if len(activities) != len(tc.want) {
 				t.Fatalf("got %d activity rows, want %d: %+v", len(activities), len(tc.want), activities)
 			}
-			// ListDocumentActivity returns newest first; compare oldest first.
-			for i, w := range tc.want {
-				got := activities[len(activities)-1-i]
+			// Matched by the change each write recorded, never by position:
+			// both writes land in the same second and ListDocumentActivity
+			// orders by created_at alone, so ties come back in whatever order
+			// the driver chooses — stable enough on SQLite to look fine and
+			// unordered on Postgres, where this suite also runs.
+			byChanges := map[string]models.Activity{}
+			for _, a := range activities {
+				byChanges[changesOfActivity(t, a.Metadata)] = a
+			}
+			for _, w := range tc.want {
+				got := activities[0]
+				if w.changes != "" {
+					var ok bool
+					got, ok = byChanges[w.changes]
+					if !ok {
+						t.Fatalf("no row recording %q; rows: %v", w.changes, byChanges)
+					}
+				}
 				if got.Actor != w.actor {
-					t.Errorf("row %d actor = %q, want %q", i, got.Actor, w.actor)
+					t.Errorf("row for %q: actor = %q, want %q", w.changes, got.Actor, w.actor)
 				}
 				if name := models.AgentNameFromMetadata(got.Metadata); name != w.agent {
-					t.Errorf("row %d agent name = %q, want %q (metadata %s)", i, name, w.agent, got.Metadata)
+					t.Errorf("row for %q: agent name = %q, want %q (metadata %s)", w.changes, name, w.agent, got.Metadata)
 				}
 			}
 		})
 	}
+}
+
+// changesOfActivity reads the "changes" string an activity's metadata carries.
+// It identifies WHICH write produced a row, which is what lets the assertions
+// above ignore row order.
+func changesOfActivity(t *testing.T, metadata string) string {
+	t.Helper()
+	var m map[string]any
+	if err := json.Unmarshal([]byte(metadata), &m); err != nil {
+		t.Fatalf("metadata %s: %v", metadata, err)
+	}
+	c, _ := m["changes"].(string)
+	return c
 }

--- a/internal/store/activities_test.go
+++ b/internal/store/activities_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
 
@@ -638,6 +639,108 @@ func TestMergeActivityMeta(t *testing.T) {
 			if tt.wantKey == "" {
 				if _, exists := m["changes"]; exists {
 					t.Errorf("expected no changes key, but found one: %v", m)
+				}
+			}
+		})
+	}
+}
+
+// BUG-2763. The three writer-identity legs the debounce key was missing, all
+// under ONE user account — which is the normal shape, since an agent
+// authenticates as the human it works for, so user_id cannot tell them apart.
+// Each leg asserts the surviving rows' `actor`/`agent` values, not merely the
+// row COUNT: splitting into two rows that both name the same writer would be a
+// different bug wearing this fix's passing test (CONVE-12).
+func TestCreateActivityDebounced_WriterIdentitySplitsRuns(t *testing.T) {
+	oneAccount := func(t *testing.T) (st *Store, wsID, docID, userID string) {
+		t.Helper()
+		st = testStore(t)
+		ws := createTestWorkspace(t, st, "Test")
+		doc := createTestDoc(t, st, ws.ID, "Doc", "content")
+		u, err := st.CreateUser(models.UserCreate{Email: "solo@test.com", Name: "Solo", Password: "pass-solo"})
+		if err != nil {
+			t.Fatalf("create user: %v", err)
+		}
+		return st, ws.ID, doc.ID, u.ID
+	}
+
+	type write struct {
+		actor   string // "user" or "agent"
+		agent   string // agent display name, "" for a human write
+		changes string
+	}
+	// want is the (actor, agent-name) pair per surviving row, oldest first.
+	for _, tc := range []struct {
+		name   string
+		writes []write
+		want   []write
+	}{
+		{
+			name:   "human then agent",
+			writes: []write{{actor: "user", changes: "status: open → active"}, {actor: "agent", agent: "wren", changes: "priority: low → high"}},
+			want:   []write{{actor: "user"}, {actor: "agent", agent: "wren"}},
+		},
+		{
+			name:   "agent then human",
+			writes: []write{{actor: "agent", agent: "wren", changes: "status: open → active"}, {actor: "user", changes: "priority: low → high"}},
+			want:   []write{{actor: "agent", agent: "wren"}, {actor: "user"}},
+		},
+		{
+			name:   "two agents on one account",
+			writes: []write{{actor: "agent", agent: "wren", changes: "status: open → active"}, {actor: "agent", agent: "rook", changes: "priority: low → high"}},
+			want:   []write{{actor: "agent", agent: "wren"}, {actor: "agent", agent: "rook"}},
+		},
+		// The control legs. Without them, a "never coalesce" implementation —
+		// or one that split on any difference at all, including the `changes`
+		// text — passes every leg above.
+		{
+			name:   "same agent twice still coalesces (control)",
+			writes: []write{{actor: "agent", agent: "wren", changes: "status: open → active"}, {actor: "agent", agent: "wren", changes: "priority: low → high"}},
+			want:   []write{{actor: "agent", agent: "wren"}},
+		},
+		{
+			name:   "same human twice still coalesces (control)",
+			writes: []write{{actor: "user", changes: "status: open → active"}, {actor: "user", changes: "priority: low → high"}},
+			want:   []write{{actor: "user"}},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s, wsID, docID, userID := oneAccount(t)
+
+			for i, w := range tc.writes {
+				meta := fmt.Sprintf(`{"changes":%q}`, w.changes)
+				if w.agent != "" {
+					meta = fmt.Sprintf(`{"agent":%q,"changes":%q}`, w.agent, w.changes)
+				}
+				source := "web"
+				if w.actor == "agent" {
+					source = "cli"
+				}
+				if _, err := s.CreateActivityDebounced(models.Activity{
+					WorkspaceID: wsID,
+					DocumentID:  docID,
+					Action:      "updated",
+					Actor:       w.actor,
+					Source:      source,
+					Metadata:    meta,
+					UserID:      userID,
+				}); err != nil {
+					t.Fatalf("write %d (%s/%s): %v", i, w.actor, w.agent, err)
+				}
+			}
+
+			activities, _ := s.ListDocumentActivity(docID, models.ActivityListParams{Action: "updated"})
+			if len(activities) != len(tc.want) {
+				t.Fatalf("got %d activity rows, want %d: %+v", len(activities), len(tc.want), activities)
+			}
+			// ListDocumentActivity returns newest first; compare oldest first.
+			for i, w := range tc.want {
+				got := activities[len(activities)-1-i]
+				if got.Actor != w.actor {
+					t.Errorf("row %d actor = %q, want %q", i, got.Actor, w.actor)
+				}
+				if name := models.AgentNameFromMetadata(got.Metadata); name != w.agent {
+					t.Errorf("row %d agent name = %q, want %q (metadata %s)", i, name, w.agent, got.Metadata)
 				}
 			}
 		})

--- a/internal/store/activities_test.go
+++ b/internal/store/activities_test.go
@@ -3,6 +3,7 @@ package store
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -787,4 +788,75 @@ func changesOfActivity(t *testing.T, metadata string) string {
 	}
 	c, _ := m["changes"].(string)
 	return c
+}
+
+// Codex round 1 on BUG-2763: with the identity guard added but the candidate
+// query still taking only the newest row overall, a writer that returns inside
+// the window lands on the OTHER writer's row, is refused on identity, and
+// starts a third row — so the guard fixed the attribution and broke the
+// coalescing it is guarding.
+//
+// Written with real 1.1s gaps rather than three writes in one second, because
+// created_at is whole-second and the same-second form of this sequence is
+// ordered by whatever the driver happens to return: it would fail on one
+// backend and pass on the other for reasons unrelated to the fix. Strictly
+// increasing timestamps make the WRONG candidate deterministically the newest
+// row, which is what turns this into an instrument. Verified against the
+// pre-fix code, where it produced 3 rows.
+func TestCreateActivityDebounced_WriterRejoinsItsOwnRun(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+	doc := createTestDoc(t, s, ws.ID, "Doc", "content")
+	u, err := s.CreateUser(models.UserCreate{Email: "rejoin@test.com", Name: "Solo", Password: "pass-rejoin"})
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+
+	write := func(actor, agent, changes string) {
+		t.Helper()
+		meta := fmt.Sprintf(`{"changes":%q}`, changes)
+		if agent != "" {
+			meta = fmt.Sprintf(`{"agent":%q,"changes":%q}`, agent, changes)
+		}
+		if _, err := s.CreateActivityDebounced(models.Activity{
+			WorkspaceID: ws.ID,
+			DocumentID:  doc.ID,
+			Action:      "updated",
+			Actor:       actor,
+			Source:      "cli",
+			Metadata:    meta,
+			UserID:      u.ID,
+		}); err != nil {
+			t.Fatalf("write by %s/%s: %v", actor, agent, err)
+		}
+	}
+
+	write("agent", "wren", "status: open → active")
+	time.Sleep(1100 * time.Millisecond)
+	write("user", "", "title: a → b")
+	time.Sleep(1100 * time.Millisecond)
+	// The agent returns. The newest row in the window is now the human's, and
+	// this write must NOT start a third row because of it.
+	write("agent", "wren", "priority: low → high")
+
+	activities, _ := s.ListDocumentActivity(doc.ID, models.ActivityListParams{Action: "updated"})
+	if len(activities) != 2 {
+		t.Fatalf("got %d rows, want 2 (one per writer): %+v", len(activities), activities)
+	}
+
+	var agentRow *models.Activity
+	for i := range activities {
+		if activities[i].Actor == "agent" {
+			agentRow = &activities[i]
+		}
+	}
+	if agentRow == nil {
+		t.Fatalf("no agent row among %+v", activities)
+	}
+	// Both of the agent's writes must be ON that row — the point of rejoining
+	// is that the second one extends the run rather than sitting elsewhere.
+	changes := changesOfActivity(t, agentRow.Metadata)
+	if !strings.Contains(changes, "status") || !strings.Contains(changes, "priority") {
+		t.Errorf("agent row changes = %q, want both of the agent's writes", changes)
+	}
 }

--- a/internal/store/comments_agent_name_test.go
+++ b/internal/store/comments_agent_name_test.go
@@ -289,10 +289,21 @@ func TestListComments_AgentNameNeverReadAcrossItems(t *testing.T) {
 // Codex round 3 on TASK-2760: an item update that carries a comment links the
 // comment to its `updated` activity, and `updated` activities are debounced —
 // a later update by the same user merges INTO the most recent row, overlaying
-// its `agent` and bumping created_at. Two agents under one set of credentials
-// (the common shape: teammates on one account) would silently re-attribute
-// an earlier comment to the later agent. A comment-linked row must therefore
-// never be a merge target; the control leg pins that unlinked rows still are.
+// its `agent` and bumping created_at, silently re-attributing the earlier
+// comment. A comment-linked row must therefore never be a merge target; the
+// control leg pins that unlinked rows still are.
+//
+// EVERY WRITE HERE DECLARES THE SAME AGENT NAME, and that is the point since
+// BUG-2763. The original wrote as two different agents on one account, which
+// can now no longer merge for a SECOND reason — the debounce refuses to
+// coalesce across writer identities — so the second assertion below
+// (`second != first`) was left passing on the identity guard alone. Measured
+// rather than assumed: with the comment-link predicate deleted and the two
+// names restored, that assertion still passed and only the final leg caught
+// the deletion. One name puts the refusal back as the only mechanism that can
+// split those two rows, so each leg fails for its own reason. The cross-agent
+// shape this test used to carry is now the BUG-2763 identity matrix's, in
+// activities_test.go.
 func TestCreateActivityDebounced_NeverMergesIntoCommentLinkedRow(t *testing.T) {
 	s, item := agentNameFixture(t)
 	user, err := s.CreateUser(models.UserCreate{Email: "shared@test.com", Name: "Dave", Password: "correct-horse-battery-staple"})
@@ -318,7 +329,7 @@ func TestCreateActivityDebounced_NeverMergesIntoCommentLinkedRow(t *testing.T) {
 		t.Fatalf("create comment: %v", err)
 	}
 
-	second := update("rook")
+	second := update("wren")
 	if second == first {
 		t.Fatalf("second update merged into the comment-linked activity %s", first)
 	}
@@ -333,7 +344,7 @@ func TestCreateActivityDebounced_NeverMergesIntoCommentLinkedRow(t *testing.T) {
 
 	// Control: with no comment on the newest row, the next update still
 	// coalesces — the refusal is scoped to linked rows, not a debounce switch.
-	third := update("rook")
+	third := update("wren")
 	if third != second {
 		t.Errorf("unlinked recent update did not merge: got %s, want %s", third, second)
 	}


### PR DESCRIPTION
Fixes BUG-2763.

## The defect

`CreateActivityDebounced` coalesced two `updated` writes whenever they shared a document, an action, a user account and the 5-minute cooldown. The account is not the writer: an agent authenticates as the human it works for, so a human's write and an agent's write — and two different agents' writes — matched each other.

The surviving row was wrong in both orderings, because the merge UPDATE writes only `metadata` and `created_at` (so the row keeps the FIRST write's `actor`) while `mergeActivityMeta` overlays an incoming `agent` key and leaves a stale one standing when the incoming write has none:

- **human then agent** — row stays `actor='user'`, the agent's name is ignored, and the agent's edit renders as the person's.
- **agent then human** — row stays `actor='agent'`, nothing overlays the stale name, and the person's edit renders under the agent's.

Both became visible with TASK-2760, which named the actor: `TimelineActivityCard` reads the stamped name only when `actor === 'agent'`.

## What changed

Candidate selection is now scoped to the writer instead of to recency: `actor` is a SQL predicate, and the agent name is matched in Go over the candidates. The first candidate whose name matches is the row to extend; none means a new run.

The Go-side name match is deliberate and its reason is in the comment: `models.AgentNameFromMetadata` is the twin of the accessor the renderer uses, and a SQL predicate would disagree with it wherever a stored value is odd (a non-string `agent`, malformed metadata). `s.dialect.JSONExtractText` exists — portability was not the reason.

`maxDebounceCandidates = 10` bounds the scan, not the semantics. The query already filters to one document, one account and one actor kind, so only rows carrying a *different* agent name compete; past the bound the loop starts a new row, which costs an extra activity row and can never produce a wrong attribution.

## Review

Eight codex rounds with rotated framing. Four produced findings, all addressed:

- **R1** — the guard alone broke the coalescing it guards: with `created_at` at whole-second precision and the candidate query taking the newest row overall, a writer returning inside the window lands on the other writer's row, is refused on identity, and starts a third. Fixed by the identity-scoped selection above.
- **R4** — three comment claims that did not survive checking (the "last-writer-wins" description, the SQLite `json_extract` return type, the comment-link refusal's residual window framed as ordering rather than visibility). Corrected. Its fourth finding — concurrent same-writer calls read-modify-write the same metadata blob and the second UPDATE silently drops the first's change entry — is real and pre-existing: **BUG-2770**.
- **R5** — the server test claimed both writes rode one account and rode none: no session, no token, `user_id` NULL for every row, so a regression in the authenticated handler→store user-id flow would have passed. Now bootstraps an owner and sends every PATCH with its bearer token, and asserts the shared non-empty `user_id` rather than describing it.
- **R7** — prose sweep (CONVE-23) plus the remote-MCP gap: `HTTPHandlerDispatcher` never sets `X-Pad-Agent`, so every write over the remote transport records as the human and no store-side identity fix can see through it. Pre-existing, needs a design call: **BUG-2772**.

R3, R6 and R8 returned CLEAN on fresh angles (blast radius; user-visible rendering incl. legacy rows; confirm + open probe).

## Tests

Handler-path matrix (`internal/server`) drives the real PATCH route with and without `X-Pad-Agent` on one authenticated account and reads the timeline endpoint — the binding, not the store call (CONVE-19). Store-level matrix covers the same cases directly, plus the agent-kind-without-a-name case the handler path cannot produce (actor and agent name both derive from one header there).

Both carry same-writer control legs: without them, "never debounce at all" passes every identity leg.

**Mutation matrix** — every member independently detected:

| mutation | dies on |
|---|---|
| actor predicate removed | store: `agent_kind_without_a_name_is_still_not_the_human` |
| agent-name match removed | store + server: `two_agents_on_one_account` |
| both removed | store: 4 legs + the rejoin test; server: 3 legs |
| candidate selection back to newest-row-only | store: `WriterRejoinsItsOwnRun` (3 rows instead of 2) |
| comment-link predicate removed (pre-existing guard) | store: `NeverMergesIntoCommentLinkedRow`, now at its second leg too |

The last row is why one existing test changed: BUG-2763's guard had left that test's `second != first` assertion passing on the identity split alone. Measured, not assumed — with the link predicate deleted and the old two-agent names restored, that assertion still passed and only the final leg caught it. Every write in it now declares one name.

Assertions are matched by the change each write recorded, never by row position: both writes land in the same second and the ordering of a `created_at` tie is driver-dependent.

## Gates (tip c7283d9a)

- `make lint` — 0 issues
- `go test ./...` (SQLite) — 28 ok, 0 fail
- `go test ./...` on Postgres 17 — 28 ok, 0 fail (private container on port 5447, not the shared 5445 — a sibling seat is live)
- Frontend untouched; no web leg run

## Test plan

- [x] Identity matrix at the handler and the store, both orderings plus two agents on one account
- [x] Same-writer control legs (coalescing still works)
- [x] Writer rejoins its own run across an interleaved write
- [x] Mutation matrix, every member independently detected
- [x] SQLite and Postgres
- [ ] CI green on the tip

Refs: BUG-2763, BUG-2770, BUG-2772
