### PR TITLE
fix: timeline can answer has_more=true with zero entries, and the client cannot page past it (BUG-2765)

### DIFF
--- a/internal/models/activity.go
+++ b/internal/models/activity.go
@@ -164,9 +164,25 @@ type TimelineEntry struct {
 }
 
 // TimelineResponse is the paginated response from the timeline endpoint.
+//
+// NextBefore / NextBeforeID are the cursor for the following page, set
+// whenever HasMore is true, and a client must page with THEM rather than with
+// the last entry it received (BUG-2765). The two differ exactly when the
+// server discarded rows: the handler over-fetches per source and drops what
+// cannot render (read/searched actions, empty-metadata updates, activities a
+// version or a comment already stands for, collapsed autosave bursts), so a
+// page can carry fewer entries than the rows it consumed — or none at all,
+// while more history waits behind them. A cursor derived from the last
+// rendered entry then either cannot be formed or does not advance, and the
+// client re-requests the same window forever.
+//
+// The value is the position the next page must start strictly before, in the
+// same (created_at, id) space the store's cursor queries use.
 type TimelineResponse struct {
-	Entries []TimelineEntry `json:"entries"`
-	HasMore bool            `json:"has_more"`
+	Entries      []TimelineEntry `json:"entries"`
+	HasMore      bool            `json:"has_more"`
+	NextBefore   string          `json:"next_before,omitempty"`
+	NextBeforeID string          `json:"next_before_id,omitempty"`
 }
 
 // AgentNameFromMetadata returns the agent display name stamped on an

--- a/internal/server/handlers_timeline.go
+++ b/internal/server/handlers_timeline.go
@@ -142,22 +142,31 @@ func (s *Server) handleListItemTimeline(w http.ResponseWriter, r *http.Request) 
 	// next one starts. The cursor is the server's to compute: it over-fetched
 	// per source and dropped rows above, so the client cannot see the
 	// position it must continue from (BUG-2765).
-	hasMore := false
-	var nextBefore time.Time
-	var nextBeforeID string
+	// Two independent reasons the next page must not start further back than
+	// a given position, and the cursor is the NEWEST of them:
+	//
+	//   - truncation: entries past `limit` were rendered and then cut, so they
+	//     have to be re-delivered — the cursor cannot be older than the last
+	//     entry KEPT.
+	//   - an exhausted window: a source that filled its over-fetch has rows
+	//     older than its tail that were never examined — the cursor cannot be
+	//     older than that tail, or those rows fall between the two pages and
+	//     are never fetched by either (codex round 1).
+	//
+	// Both can hold at once, and the second is not implied by the first: a
+	// source whose rows all DROP contributes nothing to `entries`, so the
+	// truncation cursor can easily sit older than its tail. Taking the newest
+	// candidate re-covers ground the client dedups away; taking anything
+	// older loses rows permanently.
+	cursorAt, cursorID, hasMore := exhaustedWindowCursor(comments, activities, versions, perSource)
 	if len(entries) > limit {
-		// Truncation: the entries beyond `limit` were rendered and then cut,
-		// so the next page resumes at the last one KEPT — anything else would
-		// skip the ones just dropped.
 		entries = entries[:limit]
 		hasMore = true
 		last := entries[len(entries)-1]
-		nextBefore, nextBeforeID = last.CreatedAt, last.ID
-	} else if at, id, ok := exhaustedWindowCursor(comments, activities, versions, perSource); ok {
-		// The merged page fit, but at least one source filled its window, so
-		// rows older than that source's tail were never examined.
-		hasMore = true
-		nextBefore, nextBeforeID = at, id
+		if cursorID == "" || last.CreatedAt.After(cursorAt) ||
+			(last.CreatedAt.Equal(cursorAt) && last.ID > cursorID) {
+			cursorAt, cursorID = last.CreatedAt, last.ID
+		}
 	}
 
 	resp := models.TimelineResponse{
@@ -165,8 +174,8 @@ func (s *Server) handleListItemTimeline(w http.ResponseWriter, r *http.Request) 
 		HasMore: hasMore,
 	}
 	if hasMore {
-		resp.NextBefore = nextBefore.UTC().Format(time.RFC3339Nano)
-		resp.NextBeforeID = nextBeforeID
+		resp.NextBefore = cursorAt.UTC().Format(time.RFC3339Nano)
+		resp.NextBeforeID = cursorID
 	}
 	writeJSON(w, http.StatusOK, resp)
 }

--- a/internal/server/handlers_timeline.go
+++ b/internal/server/handlers_timeline.go
@@ -12,9 +12,25 @@ import (
 	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
-// handleListItemTimeline returns a unified, chronological timeline for an item.
-// It uses cursor-based pagination: pass `before=<RFC3339>` to get entries older
-// than that timestamp, and `limit=N` to control page size (default 50).
+// handleListItemTimeline returns a unified, chronological timeline for an item,
+// newest first, with cursor-based pagination.
+//
+// Request: `limit=N` (default 50) and the cursor pair `before=<RFC3339>` +
+// `before_id=<id>`, which select entries strictly older than that position —
+// created_at first, id as the tie-break, because several entries can share a
+// whole second.
+//
+// Response: when `has_more` is true the body also carries `next_before` and
+// `next_before_id`, and a client MUST page with those two rather than deriving
+// a cursor from the last entry it received. They are not the same value. This
+// handler over-fetches per source and drops rows that cannot render, so a page
+// can carry fewer entries than the rows it consumed — or none, with history
+// still behind them — and it can deliberately resume at a position it has
+// already covered when one source's window ran out before another's. A
+// consumer that pages from its last visible entry therefore either cannot form
+// a cursor at all or re-requests the same window forever (BUG-2765), and one
+// that forwards only `next_before` without `next_before_id` can repeat or skip
+// entries sharing that second. Both fields, or neither.
 func (s *Server) handleListItemTimeline(w http.ResponseWriter, r *http.Request) {
 	workspaceID, ok := s.getWorkspaceID(w, r)
 	if !ok {

--- a/internal/server/handlers_timeline.go
+++ b/internal/server/handlers_timeline.go
@@ -138,21 +138,37 @@ func (s *Server) handleListItemTimeline(w http.ResponseWriter, r *http.Request) 
 
 	entries := buildTimeline(comments, activities, versions, notes, decisions)
 
-	// Determine if there are more entries beyond this page.
+	// Determine if there are more entries beyond this page, and where the
+	// next one starts. The cursor is the server's to compute: it over-fetched
+	// per source and dropped rows above, so the client cannot see the
+	// position it must continue from (BUG-2765).
 	hasMore := false
+	var nextBefore time.Time
+	var nextBeforeID string
 	if len(entries) > limit {
+		// Truncation: the entries beyond `limit` were rendered and then cut,
+		// so the next page resumes at the last one KEPT — anything else would
+		// skip the ones just dropped.
 		entries = entries[:limit]
 		hasMore = true
-	} else {
-		// Even if merged result is <= limit, there may be more in individual sources.
-		// If any source returned its full limit, there's likely more data.
-		hasMore = len(comments) >= perSource || len(activities) >= perSource || len(versions) >= perSource
+		last := entries[len(entries)-1]
+		nextBefore, nextBeforeID = last.CreatedAt, last.ID
+	} else if at, id, ok := exhaustedWindowCursor(comments, activities, versions, perSource); ok {
+		// The merged page fit, but at least one source filled its window, so
+		// rows older than that source's tail were never examined.
+		hasMore = true
+		nextBefore, nextBeforeID = at, id
 	}
 
-	writeJSON(w, http.StatusOK, models.TimelineResponse{
+	resp := models.TimelineResponse{
 		Entries: entries,
 		HasMore: hasMore,
-	})
+	}
+	if hasMore {
+		resp.NextBefore = nextBefore.UTC().Format(time.RFC3339Nano)
+		resp.NextBeforeID = nextBeforeID
+	}
+	writeJSON(w, http.StatusOK, resp)
 }
 
 // structuredTimelineEntries turns the item's implementation notes and
@@ -485,4 +501,59 @@ func collapseAutosaveBursts(entries []models.TimelineEntry) []models.TimelineEnt
 		kept = append(kept, e)
 	}
 	return kept
+}
+
+// exhaustedWindowCursor returns the position the next timeline page must start
+// strictly before, when the merged page fit inside `limit` but at least one
+// source filled its over-fetch window.
+//
+// WHICH tail is the subtle part. A source that returned fewer than `perSource`
+// rows is EXHAUSTED — there is nothing older than its tail to come back for —
+// so it puts no constraint on the cursor. A source that filled its window has
+// unexamined rows strictly older than its own tail. Resuming at the NEWEST
+// such tail therefore skips nothing: every full source is picked up exactly
+// where it stopped, and the sources whose tails are older simply get rows
+// re-examined that this page already rendered. Choosing the oldest tail
+// instead would step over the newer source's unexamined rows and lose them
+// permanently, which is the failure this cursor exists to prevent — repeats
+// are absorbed by the client's dedup-by-id, gaps are not recoverable.
+//
+// Progress is guaranteed because every candidate is a row this page FETCHED,
+// and the store's cursor predicate is strict: any tail is strictly older than
+// the cursor that produced it, so the next request cannot re-ask this one.
+//
+// The structured kinds (notes, decisions) are deliberately absent: they live
+// in the item's fields blob, are filtered by the same cursor predicate, and
+// arrive complete rather than windowed — there is never an unexamined
+// remainder of them to page toward.
+func exhaustedWindowCursor(
+	comments []models.Comment,
+	activities []models.Activity,
+	versions []models.Version,
+	perSource int,
+) (time.Time, string, bool) {
+	var at time.Time
+	var id string
+	found := false
+
+	consider := func(t time.Time, rowID string, full bool) {
+		if !full {
+			return
+		}
+		if !found || t.After(at) || (t.Equal(at) && rowID > id) {
+			at, id, found = t, rowID, true
+		}
+	}
+
+	if n := len(comments); n > 0 {
+		consider(comments[n-1].CreatedAt, comments[n-1].ID, n >= perSource)
+	}
+	if n := len(activities); n > 0 {
+		consider(activities[n-1].CreatedAt, activities[n-1].ID, n >= perSource)
+	}
+	if n := len(versions); n > 0 {
+		consider(versions[n-1].CreatedAt, versions[n-1].ID, n >= perSource)
+	}
+
+	return at, id, found
 }

--- a/internal/server/handlers_timeline_cursor_test.go
+++ b/internal/server/handlers_timeline_cursor_test.go
@@ -1,0 +1,274 @@
+package server
+
+import (
+	"testing"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// BUG-2765. The timeline over-fetches per source and drops rows that cannot
+// render, so a page can carry fewer entries than the rows it consumed — or
+// none — while `has_more` is true. The client derived its cursor from the last
+// RENDERED entry, which fails in two ways: with no entries it cannot form one
+// at all, and with a fully-dropped later window it re-sends the same one
+// forever. Both are fixed by the server returning the position it actually
+// reached.
+//
+// `read` activities are the cheapest row that always drops. limit=1 makes the
+// per-source window 3, so three of them fill it.
+
+func seedReadActivities(t *testing.T, srv *Server, itemID string, n int) {
+	t.Helper()
+	for i := 0; i < n; i++ {
+		if _, err := srv.store.CreateActivity(models.Activity{
+			DocumentID: itemID,
+			Action:     "read",
+			Actor:      "user",
+			Source:     "web",
+		}); err != nil {
+			t.Fatalf("seed read activity %d: %v", i, err)
+		}
+	}
+}
+
+func seedUpdateActivity(t *testing.T, srv *Server, itemID, changes string) string {
+	t.Helper()
+	id, err := srv.store.CreateActivity(models.Activity{
+		DocumentID: itemID,
+		Action:     "updated",
+		Actor:      "user",
+		Source:     "web",
+		Metadata:   `{"changes":"` + changes + `"}`,
+	})
+	if err != nil {
+		t.Fatalf("seed updated activity: %v", err)
+	}
+	return id
+}
+
+// timelinePage fetches one page, by cursor when one is supplied.
+func timelinePage(t *testing.T, srv *Server, ws, slug, before, beforeID string) models.TimelineResponse {
+	t.Helper()
+	q := "limit=1"
+	if before != "" {
+		q += "&before=" + before + "&before_id=" + beforeID
+	}
+	return fetchTimeline(t, srv, ws, slug, q)
+}
+
+// A window holding only droppable rows must still tell the client where to go.
+func TestTimeline_EmptyPageCarriesAUsableCursor(t *testing.T) {
+	t.Parallel()
+	srv := testServer(t)
+	ws := createTestWorkspaceViaAPI(t, srv)
+	item := timelineItemWithStructured(t, srv, ws, "", "")
+
+	// Strictly newer than the item's own `created` activity: created_at is
+	// whole-second text, and rows sharing a second are ordered by id, which
+	// is a random UUID. Without the gap the read rows might not be the newest
+	// and the window under test would not be the one described.
+	time.Sleep(1100 * time.Millisecond)
+	seedReadActivities(t, srv, item.ID, 3)
+
+	first := timelinePage(t, srv, ws, item.Slug, "", "")
+	if len(first.Entries) != 0 {
+		t.Fatalf("expected a fully-dropped first page, got %d entries", len(first.Entries))
+	}
+	if !first.HasMore {
+		t.Fatal("has_more = false, but the item's own created activity is still behind the read rows")
+	}
+	if first.NextBefore == "" || first.NextBeforeID == "" {
+		t.Fatalf("empty page returned no cursor: next_before=%q next_before_id=%q — the client cannot advance",
+			first.NextBefore, first.NextBeforeID)
+	}
+
+	second := timelinePage(t, srv, ws, item.Slug, first.NextBefore, first.NextBeforeID)
+	if len(second.Entries) == 0 {
+		t.Fatalf("cursor %s/%s did not reach the renderable history behind the dropped window",
+			first.NextBefore, first.NextBeforeID)
+	}
+}
+
+// The advance failure, which is the instance the filing did not name: a
+// fully-dropped window in the MIDDLE of the history. Paging must terminate and
+// yield every renderable entry exactly once.
+func TestTimeline_PagingTraversesADroppedWindow(t *testing.T) {
+	t.Parallel()
+	srv := testServer(t)
+	ws := createTestWorkspaceViaAPI(t, srv)
+	item := timelineItemWithStructured(t, srv, ws, "", "")
+
+	oldest := seedUpdateActivity(t, srv, item.ID, "status: open → in-progress")
+	time.Sleep(1100 * time.Millisecond)
+	seedReadActivities(t, srv, item.ID, 3)
+	time.Sleep(1100 * time.Millisecond)
+	newest := seedUpdateActivity(t, srv, item.ID, "priority: low → high")
+
+	seen := map[string]int{}
+	before, beforeID := "", ""
+	// A page can legitimately be empty, so the loop is bounded by requests
+	// rather than by pages-with-entries. Six is generous for four rows at
+	// limit=1; hitting it means the cursor stopped advancing, which is the
+	// wedge itself.
+	for i := 0; i < 6; i++ {
+		page := timelinePage(t, srv, ws, item.Slug, before, beforeID)
+		for _, e := range page.Entries {
+			seen[e.ID]++
+		}
+		if !page.HasMore {
+			break
+		}
+		if page.NextBefore == before && page.NextBeforeID == beforeID {
+			t.Fatalf("cursor did not advance past %s/%s — paging is wedged", before, beforeID)
+		}
+		before, beforeID = page.NextBefore, page.NextBeforeID
+		if i == 5 {
+			t.Fatal("paging did not terminate within 6 requests")
+		}
+	}
+
+	for _, tc := range []struct {
+		name, id string
+	}{
+		{"newest renderable", newest},
+		{"oldest renderable", oldest},
+	} {
+		switch seen[tc.id] {
+		case 1:
+			// exactly once, as required
+		case 0:
+			t.Errorf("%s activity %s was never returned — paging stepped over it", tc.name, tc.id)
+		default:
+			t.Errorf("%s activity %s returned %d times", tc.name, tc.id, seen[tc.id])
+		}
+	}
+}
+
+// Control: when nothing is dropped, the cursor is the last RENDERED entry.
+// Without this leg, "always resume from the oldest row the window touched"
+// passes both tests above while silently skipping the entries a truncated page
+// cut off.
+func TestTimeline_TruncatedPageResumesAtItsLastEntry(t *testing.T) {
+	t.Parallel()
+	srv := testServer(t)
+	ws := createTestWorkspaceViaAPI(t, srv)
+	item := timelineItemWithStructured(t, srv, ws, "", "")
+
+	time.Sleep(1100 * time.Millisecond)
+	seedUpdateActivity(t, srv, item.ID, "status: open → in-progress")
+	seedUpdateActivity(t, srv, item.ID, "priority: low → high")
+
+	page := timelinePage(t, srv, ws, item.Slug, "", "")
+	if len(page.Entries) != 1 || !page.HasMore {
+		t.Fatalf("want a truncated 1-entry page with more behind it, got %d entries has_more=%v",
+			len(page.Entries), page.HasMore)
+	}
+	last := page.Entries[len(page.Entries)-1]
+	if page.NextBeforeID != last.ID {
+		t.Errorf("next_before_id = %q, want the last rendered entry %q — resuming anywhere older drops what truncation cut",
+			page.NextBeforeID, last.ID)
+	}
+	if got, want := page.NextBefore, last.CreatedAt.UTC().Format(time.RFC3339Nano); got != want {
+		t.Errorf("next_before = %q, want %q", got, want)
+	}
+}
+
+// The tail-selection rule, pinned at the unit level because the handler cannot
+// cheaply reach the case: a source that FILLS its window and whose rows RENDER
+// puts perSource = 3×limit entries on the page, which takes the truncation
+// branch instead. Two full sources therefore only meet here when both are
+// dominated by droppable rows, and comments — the natural second source — never
+// drop. The handler tests above cover the single-full-source path end to end;
+// this covers the choice between two.
+//
+// The choice is not symmetric. Resuming at the NEWEST full tail re-examines
+// rows the older-tailed source already rendered, which the client's dedup
+// absorbs. Resuming at the oldest steps OVER the newer source's unexamined
+// rows, and nothing ever comes back for them.
+func TestExhaustedWindowCursor_PicksTheNewestFullTail(t *testing.T) {
+	t.Parallel()
+	at := func(sec int) time.Time { return time.Date(2026, 8, 25, 12, 0, sec, 0, time.UTC) }
+	full := func(n int, tailAt time.Time, tailID string) []models.Comment {
+		out := make([]models.Comment, n)
+		out[n-1] = models.Comment{ID: tailID, CreatedAt: tailAt}
+		return out
+	}
+	acts := func(n int, tailAt time.Time, tailID string) []models.Activity {
+		out := make([]models.Activity, n)
+		out[n-1] = models.Activity{ID: tailID, CreatedAt: tailAt}
+		return out
+	}
+	vers := func(n int, tailAt time.Time, tailID string) []models.Version {
+		out := make([]models.Version, n)
+		out[n-1] = models.Version{ID: tailID, CreatedAt: tailAt}
+		return out
+	}
+
+	const perSource = 3
+
+	for _, tc := range []struct {
+		name       string
+		comments   []models.Comment
+		activities []models.Activity
+		versions   []models.Version
+		wantID     string
+		wantOK     bool
+	}{
+		{
+			name:       "two full sources — the newer tail wins",
+			comments:   full(3, at(10), "c-old"),
+			activities: acts(3, at(20), "a-new"),
+			wantID:     "a-new", wantOK: true,
+		},
+		{
+			name:       "order of the arguments does not decide it",
+			comments:   full(3, at(30), "c-new"),
+			activities: acts(3, at(20), "a-old"),
+			wantID:     "c-new", wantOK: true,
+		},
+		{
+			// The whole point of the `full` flag: a short source has nothing
+			// older to come back for, so its newer tail must not drag the
+			// cursor forward past the full source's unexamined rows.
+			name:       "a short source does not constrain the cursor",
+			comments:   full(1, at(40), "c-short"),
+			activities: acts(3, at(20), "a-full"),
+			wantID:     "a-full", wantOK: true,
+		},
+		{
+			name:       "same instant — the id breaks the tie the way the query orders it",
+			comments:   full(3, at(20), "b-comment"),
+			activities: acts(3, at(20), "a-activity"),
+			wantID:     "b-comment", wantOK: true,
+		},
+		{
+			name:       "three sources, versions newest",
+			comments:   full(3, at(10), "c"),
+			activities: acts(3, at(20), "a"),
+			versions:   vers(3, at(30), "v"),
+			wantID:     "v", wantOK: true,
+		},
+		{
+			name:       "nothing full — no cursor, and no has_more either",
+			comments:   full(1, at(10), "c"),
+			activities: acts(2, at(20), "a"),
+			wantOK:     false,
+		},
+		{
+			name:   "no rows at all",
+			wantOK: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, id, ok := exhaustedWindowCursor(tc.comments, tc.activities, tc.versions, perSource)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if ok && id != tc.wantID {
+				t.Errorf("cursor id = %q, want %q", id, tc.wantID)
+			}
+		})
+	}
+}

--- a/internal/server/handlers_timeline_cursor_test.go
+++ b/internal/server/handlers_timeline_cursor_test.go
@@ -128,19 +128,23 @@ func TestTimeline_PagingTraversesADroppedWindow(t *testing.T) {
 		}
 	}
 
-	for _, tc := range []struct {
-		name, id string
-	}{
-		{"newest renderable", newest},
-		{"oldest renderable", oldest},
-	} {
-		switch seen[tc.id] {
-		case 1:
-			// exactly once, as required
-		case 0:
-			t.Errorf("%s activity %s was never returned — paging stepped over it", tc.name, tc.id)
-		default:
-			t.Errorf("%s activity %s returned %d times", tc.name, tc.id, seen[tc.id])
+	// The expected set is DERIVED from the rows, not listed by hand: naming
+	// the two seeded ids would leave the item's own `created` activity free to
+	// vanish or repeat while the test still claimed "every renderable entry
+	// exactly once" (codex round 4).
+	want := renderableActivityIDs(t, srv, item.ID)
+	if len(want) < 3 {
+		t.Fatalf("fixture is thinner than the test assumes: %d renderable rows, want the created activity plus %s and %s",
+			len(want), oldest, newest)
+	}
+	for id := range want {
+		if seen[id] != 1 {
+			t.Errorf("renderable activity %s was returned %d times, want exactly 1", id, seen[id])
+		}
+	}
+	for id, n := range seen {
+		if !want[id] {
+			t.Errorf("paging returned %s (%d times), which is not a renderable activity of this item", id, n)
 		}
 	}
 }
@@ -333,4 +337,24 @@ func TestTimeline_TruncationDoesNotStepOverAnExhaustedWindow(t *testing.T) {
 		t.Errorf("the activity between the truncation point and the dropped window was returned %d times, want 1 — paging stepped over it",
 			seen[atRisk])
 	}
+}
+
+// renderableActivityIDs is every activity on the item that the timeline is
+// expected to render — i.e. all of them except the kinds buildTimeline drops
+// unconditionally. Derived from the store so a fixture that grows a row cannot
+// silently fall outside what a test claims to cover.
+func renderableActivityIDs(t *testing.T, srv *Server, itemID string) map[string]bool {
+	t.Helper()
+	acts, err := srv.store.ListDocumentActivity(itemID, models.ActivityListParams{Limit: 500})
+	if err != nil {
+		t.Fatalf("list activities: %v", err)
+	}
+	out := map[string]bool{}
+	for _, a := range acts {
+		if a.Action == "read" || a.Action == "searched" {
+			continue
+		}
+		out[a.ID] = true
+	}
+	return out
 }

--- a/internal/server/handlers_timeline_cursor_test.go
+++ b/internal/server/handlers_timeline_cursor_test.go
@@ -272,3 +272,65 @@ func TestExhaustedWindowCursor_PicksTheNewestFullTail(t *testing.T) {
 		})
 	}
 }
+
+// Codex round 1: truncation and an exhausted window are INDEPENDENT reasons to
+// bound the cursor, and the second is not implied by the first. A source whose
+// rows all drop contributes nothing to the page, so the truncation cursor can
+// sit older than that source's tail — and every unexamined row between the two
+// falls in a gap neither page fetches.
+//
+// The fixture puts one renderable activity in exactly that gap:
+//
+//	t0  item created            (activity, renderable, oldest)
+//	t1  two comments            (render; two entries at limit=1 forces truncation)
+//	t2  one `updated` activity  (renderable — the row at risk)
+//	t3  three `read` activities (fill the activity window, all dropped)
+//
+// The activity window is the three reads, so t2 is never examined; the
+// truncation cursor is a comment at t1, older than the reads' tail at t3.
+// Resuming there steps straight over t2.
+func TestTimeline_TruncationDoesNotStepOverAnExhaustedWindow(t *testing.T) {
+	t.Parallel()
+	srv := testServer(t)
+	ws := createTestWorkspaceViaAPI(t, srv)
+	item := timelineItemWithStructured(t, srv, ws, "", "")
+
+	time.Sleep(1100 * time.Millisecond)
+	for i, body := range []string{"first", "second"} {
+		if _, err := srv.store.CreateComment(item.WorkspaceID, item.ID, "", models.CommentCreate{
+			Body: body, Author: "tester", CreatedBy: "user", Source: "web",
+		}); err != nil {
+			t.Fatalf("seed comment %d: %v", i, err)
+		}
+	}
+
+	time.Sleep(1100 * time.Millisecond)
+	atRisk := seedUpdateActivity(t, srv, item.ID, "status: open → in-progress")
+
+	time.Sleep(1100 * time.Millisecond)
+	seedReadActivities(t, srv, item.ID, 3)
+
+	seen := map[string]int{}
+	before, beforeID := "", ""
+	for i := 0; ; i++ {
+		if i == 8 {
+			t.Fatal("paging did not terminate within 8 requests")
+		}
+		page := timelinePage(t, srv, ws, item.Slug, before, beforeID)
+		for _, e := range page.Entries {
+			seen[e.ID]++
+		}
+		if !page.HasMore {
+			break
+		}
+		if page.NextBefore == before && page.NextBeforeID == beforeID {
+			t.Fatalf("cursor did not advance past %s/%s", before, beforeID)
+		}
+		before, beforeID = page.NextBefore, page.NextBeforeID
+	}
+
+	if seen[atRisk] != 1 {
+		t.Errorf("the activity between the truncation point and the dropped window was returned %d times, want 1 — paging stepped over it",
+			seen[atRisk])
+	}
+}

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -1576,6 +1576,17 @@ export const api = {
 	// ── Timeline ──────────────────────────────────────────────────────────────
 
 	timeline: {
+		/**
+		 * One page of an item's timeline, newest first.
+		 *
+		 * Page with the response's `next_before` + `next_before_id`, never with
+		 * the last entry received: the server drops rows that cannot render, so
+		 * a page can carry fewer entries than the rows it consumed — or none,
+		 * with history behind them — and its cursor can deliberately re-cover
+		 * ground. Deriving one from the last visible entry cannot advance past
+		 * such a page (BUG-2765). Send both fields or neither; the id is the
+		 * tie-break among entries sharing a second.
+		 */
 		list: (ws: string, itemSlug: string, params?: { limit?: number; before?: string; before_id?: string }) => {
 			const qs = new URLSearchParams();
 			if (params?.limit != null) qs.set('limit', String(params.limit));

--- a/web/src/lib/components/timeline/ItemTimeline.svelte
+++ b/web/src/lib/components/timeline/ItemTimeline.svelte
@@ -691,7 +691,26 @@
 				// an earlier page already rendered (see cursorFrom).
 				const existingIds = new Set(entries.map((e) => e.id));
 				const newEntries = resp.entries.filter((e) => !existingIds.has(e.id));
-				entries = [...entries, ...newEntries];
+				// Merge, do not concatenate. The server's cursor deliberately
+				// re-covers ground when one source's window ran out before
+				// another's, so a later page can carry entries NEWER than the
+				// oldest one already shown — appending those would print them
+				// below it (codex round 1). Same order the server sorts by:
+				// created_at descending, id descending as the tie-break.
+				//
+				// Compared as INSTANTS, not as strings: these timestamps do
+				// not all carry the same precision — the store writes whole
+				// seconds, but a structured note or decision can carry a
+				// hand-written sub-second one — and lexicographically
+				// "…:05.123Z" sorts BEFORE "…:05Z", which would place the more
+				// precise entry an hour's worth of rows away from where it
+				// belongs.
+				entries = [...entries, ...newEntries].sort((a, b) => {
+					const at = new Date(a.created_at).getTime();
+					const bt = new Date(b.created_at).getTime();
+					if (at !== bt) return bt - at;
+					return a.id < b.id ? 1 : a.id > b.id ? -1 : 0;
+				});
 				hasMore = resp.has_more;
 				nextCursor = cursorFrom(resp, entries);
 				// Stop as soon as the press produced something to look at.

--- a/web/src/lib/components/timeline/ItemTimeline.svelte
+++ b/web/src/lib/components/timeline/ItemTimeline.svelte
@@ -133,6 +133,8 @@
 	);
 	let showComposer = $derived(!visibleKinds || visibleKinds.includes('comment'));
 	let hasMore: boolean = $state(false);
+	// Server-supplied position of the next page; see cursorFrom (BUG-2765).
+	let nextCursor: { before: string; before_id: string } | null = $state(null);
 	let loading: boolean = $state(false);
 	let loadingMore: boolean = $state(false);
 	let error: string = $state('');
@@ -626,6 +628,7 @@
 			if (reqSlug !== itemSlug || reqWs !== wsSlug) return;
 			entries = resp.entries;
 			hasMore = resp.has_more;
+			nextCursor = cursorFrom(resp, resp.entries);
 			firstPageIds = new Set(resp.entries.map((e) => e.id));
 		} catch (err: any) {
 			if (reqSlug !== itemSlug || reqWs !== wsSlug) return;
@@ -635,25 +638,65 @@
 		}
 	}
 
+	/**
+	 * Where the next page starts. The SERVER decides this (BUG-2765): it
+	 * over-fetches per source and drops rows that cannot render, so a page can
+	 * carry fewer entries than the rows it consumed — or none, with more
+	 * history behind them. Deriving the cursor from the last rendered entry
+	 * then either cannot be done (an empty page) or does not advance (a page
+	 * whose rows all dropped), and the same window is requested forever.
+	 *
+	 * The fallback to the last entry is for a server that predates the field;
+	 * it is exactly what this component did before, including its wedge.
+	 */
+	function cursorFrom(
+		resp: TimelineResponse,
+		known: TimelineEntry[]
+	): { before: string; before_id: string } | null {
+		if (!resp.has_more) return null;
+		if (resp.next_before && resp.next_before_id) {
+			return { before: resp.next_before, before_id: resp.next_before_id };
+		}
+		const last = known[known.length - 1];
+		return last ? { before: last.created_at, before_id: last.id } : null;
+	}
+
+	/**
+	 * How many pages one press of Load More may walk through while every row
+	 * comes back droppable. This is a UX bound, not the fix: the cursor above
+	 * is what makes paging complete, and a single hop is already correct. It
+	 * exists so a user crossing a long run of `read` activity sees entries
+	 * appear rather than a spinner and nothing, and it is small so a
+	 * pathological item cannot turn one click into an unbounded request fan.
+	 */
+	const MAX_EMPTY_HOPS = 5;
+
 	async function loadMore() {
-		if (loadingMore || entries.length === 0) return;
+		if (loadingMore || !nextCursor) return;
 		// Capture identity before the await so a switch mid-flight can't append
 		// A's older page onto B's entries (TASK-2112).
 		const reqSlug = itemSlug;
 		const reqWs = wsSlug;
-		const oldest = entries[entries.length - 1];
 		loadingMore = true;
 		try {
-			const resp: TimelineResponse = await api.timeline.list(reqWs, reqSlug, {
-				before: oldest.created_at,
-				before_id: oldest.id
-			});
-			if (reqSlug !== itemSlug || reqWs !== wsSlug) return;
-			// Deduplicate by ID to handle boundary overlap from <= queries.
-			const existingIds = new Set(entries.map((e) => e.id));
-			const newEntries = resp.entries.filter((e) => !existingIds.has(e.id));
-			entries = [...entries, ...newEntries];
-			hasMore = resp.has_more;
+			for (let hop = 0; hop < MAX_EMPTY_HOPS && nextCursor; hop++) {
+				const cursor = nextCursor;
+				const resp: TimelineResponse = await api.timeline.list(reqWs, reqSlug, {
+					before: cursor.before,
+					before_id: cursor.before_id
+				});
+				if (reqSlug !== itemSlug || reqWs !== wsSlug) return;
+				// Deduplicate by ID to handle boundary overlap from <= queries,
+				// and because the server's cursor can deliberately re-cover rows
+				// an earlier page already rendered (see cursorFrom).
+				const existingIds = new Set(entries.map((e) => e.id));
+				const newEntries = resp.entries.filter((e) => !existingIds.has(e.id));
+				entries = [...entries, ...newEntries];
+				hasMore = resp.has_more;
+				nextCursor = cursorFrom(resp, entries);
+				// Stop as soon as the press produced something to look at.
+				if (newEntries.length > 0) break;
+			}
 		} catch (err: any) {
 			if (reqSlug !== itemSlug || reqWs !== wsSlug) return;
 			error = err?.message ?? 'Failed to load more';

--- a/web/src/lib/components/timeline/ItemTimeline.svelte
+++ b/web/src/lib/components/timeline/ItemTimeline.svelte
@@ -623,6 +623,16 @@
 		const reqWs = wsSlug;
 		loading = true;
 		error = '';
+		// Paging state belongs to the page-1 fetch below and is unknown until
+		// it lands. Clearing it BEFORE the await matters because the entries
+		// from the previous load stay on screen while this one is in flight
+		// (`{#if !loading || entries.length > 0}`), so Load More is still
+		// clickable — and its cursor would be the OLD item's position sent
+		// against the NEW one (codex round 6). This function replaces entries
+		// with page 1 when it resolves anyway, so there is no deeper paging
+		// state being thrown away that would have survived.
+		nextCursor = null;
+		hasMore = false;
 		try {
 			const resp: TimelineResponse = await api.timeline.list(reqWs, reqSlug);
 			if (reqSlug !== itemSlug || reqWs !== wsSlug) return;

--- a/web/src/lib/components/timeline/ItemTimeline.svelte
+++ b/web/src/lib/components/timeline/ItemTimeline.svelte
@@ -715,6 +715,19 @@
 				nextCursor = cursorFrom(resp, entries);
 				// Stop as soon as the press produced something to look at.
 				if (newEntries.length > 0) break;
+				// A cursor that did not move cannot make progress, so asking
+				// again would only repeat this request. Reachable against a
+				// server that predates next_before: the fallback re-derives
+				// the same last entry every time, and without this the hop
+				// loop turns one click into five identical requests instead of
+				// the single one this component used to make (codex round 2).
+				if (
+					nextCursor &&
+					nextCursor.before === cursor.before &&
+					nextCursor.before_id === cursor.before_id
+				) {
+					break;
+				}
 			}
 		} catch (err: any) {
 			if (reqSlug !== itemSlug || reqWs !== wsSlug) return;

--- a/web/src/lib/components/timeline/ItemTimeline.svelte
+++ b/web/src/lib/components/timeline/ItemTimeline.svelte
@@ -671,6 +671,26 @@
 	 */
 	const MAX_EMPTY_HOPS = 5;
 
+	/**
+	 * The server's own ordering: created_at descending, id descending as the
+	 * tie-break. Applied wherever entries from two fetches are combined, since
+	 * neither side can assume the other's are strictly older or strictly newer
+	 * — the paging cursor deliberately re-covers ground, and a structured note
+	 * can carry a backdated timestamp.
+	 *
+	 * Compared as INSTANTS, not as strings: precision is not uniform — the
+	 * store writes whole seconds, a hand-written note timestamp need not — and
+	 * lexicographically `…:05.123Z` sorts BEFORE `…:05Z`.
+	 */
+	function byNewestFirst(list: TimelineEntry[]): TimelineEntry[] {
+		return [...list].sort((a, b) => {
+			const at = new Date(a.created_at).getTime();
+			const bt = new Date(b.created_at).getTime();
+			if (at !== bt) return bt - at;
+			return a.id < b.id ? 1 : a.id > b.id ? -1 : 0;
+		});
+	}
+
 	async function loadMore() {
 		if (loadingMore || !nextCursor) return;
 		// Capture identity before the await so a switch mid-flight can't append
@@ -705,12 +725,7 @@
 				// "…:05.123Z" sorts BEFORE "…:05Z", which would place the more
 				// precise entry an hour's worth of rows away from where it
 				// belongs.
-				entries = [...entries, ...newEntries].sort((a, b) => {
-					const at = new Date(a.created_at).getTime();
-					const bt = new Date(b.created_at).getTime();
-					if (at !== bt) return bt - at;
-					return a.id < b.id ? 1 : a.id > b.id ? -1 : 0;
-				});
+				entries = byNewestFirst([...entries, ...newEntries]);
 				hasMore = resp.has_more;
 				nextCursor = cursorFrom(resp, entries);
 				// Stop as soon as the press produced something to look at.
@@ -813,7 +828,11 @@
 			const freshIds = new Set(resp.entries.map((e) => e.id));
 			const existingIds = new Set(entries.map((e) => e.id));
 
-			// Prepend genuinely new entries.
+			// Genuinely new entries. Normally these ARE the newest — the
+			// refresh re-fetches the newest window — but "normally" is not
+			// "always": a structured note or decision carries a hand-written
+			// created_at and can arrive backdated, so they are merged into
+			// order rather than prepended on the assumption (codex round 3).
 			const newEntries = resp.entries.filter((e) => !existingIds.has(e.id));
 
 			// Update existing entries from the fresh response (e.g., reaction changes).
@@ -827,7 +846,7 @@
 				})
 				.map((e) => freshById.get(e.id) ?? e);
 
-			entries = [...newEntries, ...updatedExisting];
+			entries = byNewestFirst([...newEntries, ...updatedExisting]);
 			firstPageIds = freshIds;
 		} catch (err) {
 			// A failed SSE-driven refresh is not fatal — the timeline keeps

--- a/web/src/lib/components/timeline/timelinePagination.svelte.test.ts
+++ b/web/src/lib/components/timeline/timelinePagination.svelte.test.ts
@@ -284,4 +284,42 @@ describe('timeline pagination past dropped windows (BUG-2765)', () => {
 		expect(calls).toHaveLength(2);
 		expect(calls[1]).toEqual({ before: '2026-01-01T00:00:09Z', before_id: 'e-1' });
 	});
+
+	it('does not offer the previous item\'s cursor while a switch is in flight', async () => {
+		// The old entries stay on screen while the new item's page 1 is in
+		// flight, so the button is still clickable. Its cursor must not be the
+		// previous item's position, aimed at the new item.
+		pages.push({
+			entries: [entry('e-a', '2026-01-01T00:00:09Z')],
+			has_more: true,
+			next_before: '2026-01-01T00:00:09Z',
+			next_before_id: 'e-a',
+		});
+
+		app = mount(ItemTimeline, { target: host, props }) as Record<string, unknown>;
+		await settle();
+		expect(loadMoreButton(), 'page one offered Load More').not.toBeNull();
+
+		// Switch items; hold the new load unresolved.
+		let release: (r: TimelineResponse) => void = () => {};
+		const pending = new Promise<TimelineResponse>((r) => {
+			release = r;
+		});
+		timelineListMock.mockImplementationOnce(async (_ws, _slug, params) => {
+			calls.push(params);
+			return pending;
+		});
+		props.itemSlug = 'TASK-2';
+		await settle();
+
+		const callsDuringSwitch = calls.length;
+		expect(loadMoreButton(), 'no paging is offered until the new page lands').toBeNull();
+
+		release({ entries: [entry('e-b', '2026-02-01T00:00:09Z')], has_more: false });
+		await settle();
+
+		// Nothing was requested with the old item's cursor in between.
+		expect(calls).toHaveLength(callsDuringSwitch);
+		props.itemSlug = 'TASK-1';
+	});
 });

--- a/web/src/lib/components/timeline/timelinePagination.svelte.test.ts
+++ b/web/src/lib/components/timeline/timelinePagination.svelte.test.ts
@@ -263,4 +263,25 @@ describe('timeline pagination past dropped windows (BUG-2765)', () => {
 			[...order].sort((a, b) => a - b)
 		);
 	});
+
+	it('makes ONE request per click when a cursorless server cannot advance', async () => {
+		// The pre-cursor server, on a page it emptied: has_more with no
+		// cursor, so the fallback re-derives the same last entry forever. The
+		// component cannot fix that server — but it must not amplify it into a
+		// request per hop either.
+		pages.push({ entries: [entry('e-1', '2026-01-01T00:00:09Z')], has_more: true });
+		pages.push({ entries: [], has_more: true });
+		pages.push({ entries: [], has_more: true });
+		pages.push({ entries: [], has_more: true });
+
+		app = mount(ItemTimeline, { target: host, props }) as Record<string, unknown>;
+		await settle();
+
+		loadMoreButton()!.click();
+		await settle();
+
+		// Initial load + exactly one Load More request.
+		expect(calls).toHaveLength(2);
+		expect(calls[1]).toEqual({ before: '2026-01-01T00:00:09Z', before_id: 'e-1' });
+	});
 });

--- a/web/src/lib/components/timeline/timelinePagination.svelte.test.ts
+++ b/web/src/lib/components/timeline/timelinePagination.svelte.test.ts
@@ -64,13 +64,13 @@ vi.mock('$lib/components/CommentEditor.svelte', async () => ({
 
 const { default: ItemTimeline } = await import('./ItemTimeline.svelte');
 
-function entry(id: string, createdAt: string): TimelineEntry {
+function entry(id: string, createdAt: string, body = 'hello'): TimelineEntry {
 	const c: Comment = {
 		id,
 		item_id: 'item-a',
 		workspace_id: 'ws-1',
 		author: 'alice',
-		body: 'hello',
+		body,
 		created_by: 'alice',
 		source: 'web',
 		created_at: createdAt,
@@ -220,5 +220,47 @@ describe('timeline pagination past dropped windows (BUG-2765)', () => {
 		await settle();
 
 		expect(calls[1]).toEqual({ before: '2026-01-01T00:00:09Z', before_id: 'e-1' });
+	});
+
+	it('merges a later page into date order instead of appending it', async () => {
+		// The overlap the server's cursor deliberately creates: one source's
+		// window ran out before another's, so page 2 legitimately carries an
+		// entry NEWER than the oldest one page 1 showed. Concatenating prints
+		// it below — a comment from 12:00:07 sitting under one from 12:00:01.
+		pages.push({
+			entries: [
+				entry('e-newest', '2026-01-01T12:00:09Z', 'newest'),
+				entry('e-oldest-shown', '2026-01-01T12:00:01Z', 'oldest shown'),
+			],
+			has_more: true,
+			next_before: '2026-01-01T12:00:08Z',
+			next_before_id: 'raw-tail',
+		});
+		pages.push({
+			entries: [
+				// Newer than the last entry already on screen, older than the
+				// cursor — the shape only the server can produce.
+				entry('e-between', '2026-01-01T12:00:07Z', 'in between'),
+				entry('e-older', '2026-01-01T12:00:00Z', 'older'),
+			],
+			has_more: false,
+		});
+
+		app = mount(ItemTimeline, { target: host, props }) as Record<string, unknown>;
+		await settle();
+
+		loadMoreButton()!.click();
+		await settle();
+
+		const bodies = Array.from(host.querySelectorAll('.comment-card')).map((el) =>
+			(el.textContent ?? '').trim()
+		);
+		const order = ['newest', 'in between', 'oldest shown', 'older'].map((label) =>
+			bodies.findIndex((b) => b.includes(label))
+		);
+		expect(order.every((i) => i >= 0), `all four entries rendered: ${bodies}`).toBe(true);
+		expect(order, 'entries must read newest-first after the merge').toEqual(
+			[...order].sort((a, b) => a - b)
+		);
 	});
 });

--- a/web/src/lib/components/timeline/timelinePagination.svelte.test.ts
+++ b/web/src/lib/components/timeline/timelinePagination.svelte.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { flushSync, mount, unmount, tick } from 'svelte';
+import type { Comment, TimelineEntry, TimelineResponse } from '$lib/types';
+
+/**
+ * BUG-2765 — paging past a window the server dropped.
+ *
+ * The server over-fetches per source and drops rows that cannot render, so a
+ * page can carry fewer entries than the rows it consumed, or none at all with
+ * more history behind them. This component derived its cursor from the last
+ * RENDERED entry, which fails in two ways: an empty page yields no cursor, and
+ * a later all-dropped page yields the SAME cursor, so the next press re-asks
+ * for the window it just got and nothing ever moves.
+ *
+ * These drive Load More against a mock that RECORDS the cursor it was called
+ * with — the assertion is about what the component ASKS FOR, not only what it
+ * ends up displaying, because a component that displays the right thing by
+ * re-fetching page one forever is the bug.
+ */
+
+type ListParams = { limit?: number; before?: string; before_id?: string } | undefined;
+
+const calls: ListParams[] = [];
+const pages: TimelineResponse[] = [];
+
+const timelineListMock = vi.fn(async (_ws: string, _slug: string, params: ListParams) => {
+	calls.push(params);
+	return pages.shift() ?? { entries: [], has_more: false };
+});
+
+vi.mock('$lib/api/client', () => ({
+	api: {
+		timeline: {
+			list: (ws: string, slug: string, params: ListParams) => timelineListMock(ws, slug, params),
+		},
+		comments: {
+			create: vi.fn(),
+			update: vi.fn(),
+			delete: vi.fn(),
+			addReaction: vi.fn(),
+			removeReaction: vi.fn(),
+		},
+		attachments: {
+			downloadUrl: (ws: string, id: string) => `/api/v1/workspaces/${ws}/attachments/${id}`,
+		},
+	},
+}));
+
+vi.mock('$lib/services/sse.svelte', () => ({
+	sseService: { onItemEvent: () => () => {} },
+}));
+
+vi.mock('$lib/stores/auth.svelte', () => ({
+	authStore: { userId: 'user-1', user: { id: 'user-1', role: 'member' } },
+}));
+
+vi.mock('$lib/stores/workspace.svelte', () => ({
+	workspaceStore: { canEditItem: () => false },
+}));
+
+vi.mock('$lib/components/CommentEditor.svelte', async () => ({
+	default: (await import('./fixtures/InertCommentEditor.svelte')).default,
+}));
+
+const { default: ItemTimeline } = await import('./ItemTimeline.svelte');
+
+function entry(id: string, createdAt: string): TimelineEntry {
+	const c: Comment = {
+		id,
+		item_id: 'item-a',
+		workspace_id: 'ws-1',
+		author: 'alice',
+		body: 'hello',
+		created_by: 'alice',
+		source: 'web',
+		created_at: createdAt,
+		updated_at: createdAt,
+	};
+	return { id, kind: 'comment', created_at: createdAt, actor: 'alice', source: 'web', comment: c };
+}
+
+let host: HTMLElement;
+let app: Record<string, unknown> | null = null;
+
+const props = $state({
+	wsSlug: 'ws',
+	username: 'alice',
+	itemSlug: 'TASK-1',
+	currentContent: '',
+	itemId: 'item-a',
+	collectionId: 'coll-1',
+	hostToken: 'host-1',
+	resourceGen: 0,
+	visibleKinds: undefined as Array<'comment' | 'activity' | 'version'> | undefined,
+	mutationsEnabled: false,
+});
+
+async function settle() {
+	for (let i = 0; i < 8; i++) {
+		await tick();
+		flushSync();
+	}
+}
+
+function loadMoreButton(): HTMLButtonElement | null {
+	return host.querySelector<HTMLButtonElement>('.load-more-btn');
+}
+
+beforeEach(() => {
+	host = document.createElement('div');
+	document.body.appendChild(host);
+	calls.length = 0;
+	pages.length = 0;
+	timelineListMock.mockClear();
+});
+
+afterEach(() => {
+	if (app) unmount(app);
+	app = null;
+	host.remove();
+});
+
+describe('timeline pagination past dropped windows (BUG-2765)', () => {
+	it('offers Load More on an empty first page and pages with the server cursor', async () => {
+		// Every row in the first window dropped server-side. Without the
+		// server's cursor there is nothing to page from at all.
+		pages.push({
+			entries: [],
+			has_more: true,
+			next_before: '2026-01-01T00:00:05Z',
+			next_before_id: 'raw-read-row',
+		});
+		pages.push({ entries: [entry('e-old', '2026-01-01T00:00:01Z')], has_more: false });
+
+		app = mount(ItemTimeline, { target: host, props }) as Record<string, unknown>;
+		await settle();
+
+		const btn = loadMoreButton();
+		expect(btn, 'an empty page with has_more must still offer Load More').not.toBeNull();
+
+		btn!.click();
+		await settle();
+
+		expect(calls[1]).toEqual({
+			before: '2026-01-01T00:00:05Z',
+			before_id: 'raw-read-row',
+		});
+		expect(host.textContent).toContain('hello');
+	});
+
+	it('advances past a page whose rows all dropped instead of re-asking for it', async () => {
+		// Page 1 renders. Page 2 comes back empty — the wedge: the last
+		// rendered entry has not moved, so the pre-fix component would send
+		// the page-1 cursor again, forever.
+		pages.push({
+			entries: [entry('e-1', '2026-01-01T00:00:09Z')],
+			has_more: true,
+			next_before: '2026-01-01T00:00:09Z',
+			next_before_id: 'e-1',
+		});
+		pages.push({
+			entries: [],
+			has_more: true,
+			next_before: '2026-01-01T00:00:05Z',
+			next_before_id: 'raw-read-row',
+		});
+		pages.push({ entries: [entry('e-2', '2026-01-01T00:00:01Z')], has_more: false });
+
+		app = mount(ItemTimeline, { target: host, props }) as Record<string, unknown>;
+		await settle();
+
+		loadMoreButton()!.click();
+		await settle();
+
+		// The cursors asked for, in order, are strictly the ones the server
+		// handed back — never a repeat.
+		expect(calls[1]).toEqual({ before: '2026-01-01T00:00:09Z', before_id: 'e-1' });
+		expect(calls[2]).toEqual({ before: '2026-01-01T00:00:05Z', before_id: 'raw-read-row' });
+		expect(calls).toHaveLength(3);
+		// And the press produced something: the entry behind the dropped window.
+		expect(host.querySelectorAll('.comment-card')).toHaveLength(2);
+	});
+
+	it('stops asking after the hop bound rather than fanning out requests', async () => {
+		// Every page empty and every page claiming more. One press must not
+		// turn into an unbounded request loop.
+		for (let i = 0; i < 20; i++) {
+			pages.push({
+				entries: [],
+				has_more: true,
+				next_before: `2026-01-01T00:00:${String(20 - i).padStart(2, '0')}Z`,
+				next_before_id: `raw-${i}`,
+			});
+		}
+
+		app = mount(ItemTimeline, { target: host, props }) as Record<string, unknown>;
+		await settle();
+
+		loadMoreButton()!.click();
+		await settle();
+
+		// 1 initial load + at most the hop bound.
+		expect(calls.length).toBeGreaterThan(1);
+		expect(calls.length).toBeLessThanOrEqual(6);
+		// Still offered, so the user can continue deliberately.
+		expect(loadMoreButton()).not.toBeNull();
+	});
+
+	it('falls back to the last entry when the server sends no cursor', async () => {
+		// A server older than this field. The component must behave exactly as
+		// it did before — including being unable to page an empty page, which
+		// is why the server half is the fix and this is only compatibility.
+		pages.push({ entries: [entry('e-1', '2026-01-01T00:00:09Z')], has_more: true });
+		pages.push({ entries: [entry('e-2', '2026-01-01T00:00:01Z')], has_more: false });
+
+		app = mount(ItemTimeline, { target: host, props }) as Record<string, unknown>;
+		await settle();
+
+		loadMoreButton()!.click();
+		await settle();
+
+		expect(calls[1]).toEqual({ before: '2026-01-01T00:00:09Z', before_id: 'e-1' });
+	});
+});

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -1316,6 +1316,20 @@ export interface TimelineEntry {
 export interface TimelineResponse {
 	entries: TimelineEntry[];
 	has_more: boolean;
+	/**
+	 * Cursor for the next page, set by the server whenever `has_more` is true
+	 * (BUG-2765). Page with THESE, not with the last entry received: the
+	 * server over-fetches and drops rows that cannot render, so a page can
+	 * carry fewer entries than the rows it consumed — or none at all with more
+	 * history behind them. A cursor derived from the last rendered entry then
+	 * either cannot be formed or does not advance, and the same window is
+	 * requested forever.
+	 *
+	 * Optional because a server older than this field omits it; callers fall
+	 * back to the last entry, which is what they did before.
+	 */
+	next_before?: string;
+	next_before_id?: string;
 }
 
 // ─── Views ───────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Fixes BUG-2765.

## The defect

The timeline over-fetches 3× per source and drops rows that cannot render — `read`/`searched` actions, empty-metadata `updated` rows, activities a version or a comment already stands for, collapsed autosave bursts. So a page can carry fewer entries than the rows it consumed, or none at all with history still behind it, while `has_more` is true.

The client derived its next-page cursor from the last **rendered** entry, which fails two ways:

- **Cannot start.** An empty first page gives it nothing to page from; `loadMore` returned early on `entries.length === 0`. This is what the filing named.
- **Cannot advance.** A fully-dropped window *later* in the history leaves the last rendered entry unchanged, so the next press re-sends the same cursor. The button is live, the spinner runs, and paging is wedged at that position permanently. Not in the filing, and the one that bites an ordinary item — a run of `read` activity anywhere in its history is enough.

One root cause: the response said **whether** to continue but not **where**, and only the server knows which rows it examined and discarded.

## What changed

**Server** returns `next_before` / `next_before_id` whenever `has_more` is true. Two independent bounds, and the cursor is the newest of them:

- **truncation** — entries past `limit` were rendered and cut, so the cursor cannot be older than the last one kept;
- **an exhausted window** — a source that filled its over-fetch has unexamined rows older than its tail, so the cursor cannot be older than that tail.

They are not the same bound and neither implies the other: a source whose rows all drop contributes nothing to the page, so the truncation cursor can easily sit older than its tail, and everything in between falls in a gap neither page fetches (codex round 1). Repeats are absorbed by the client's dedup; gaps are not recoverable, which is what makes "newest" the safe choice.

**Client** pages with those fields, merges later pages into date order rather than appending (the cursor deliberately re-covers ground, so a later page can carry entries newer than the oldest one shown), stops when a cursor does not advance, and clears paging state while a reload is in flight. It falls back to the last entry when the server sends no cursor — exactly the old behaviour, for a server older than the field.

## Review

Eight codex rounds, framing rotated. Four found things:

- **R1** — the truncation/exhausted-window bound (above), and appended pages rendering out of order.
- **R2** — against a cursorless server the new hop loop turned one click into five identical requests. The old wedge is not mine to fix; amplifying it was.
- **R3** — the SSE refresh merge had the same ordering assumption. Folded in. Two other findings declined/filed: the refresh not adopting `has_more`/cursor (declined — it re-fetches the *newest* window, which says nothing about the reader's paging frontier), and `firstPageIds` treating any entry missing from a refreshed first page as deleted (**BUG-2773**).
- **R4** — a test claimed "every renderable entry exactly once" while checking two ids. Expectation is now derived from the store.
- **R5** — the cursor contract was documented in the TS type but not in the handler doc comment or the API client, where a REST consumer actually looks.
- **R6** — Load More stayed clickable during an item switch with the previous item's cursor.

R7 (Go cursor internals) and R8 (exposure / hostile input) returned CLEAN. R8 also noted a pre-existing hardening gap — a malformed `before_id` reaches pgx and 500s instead of 400 — filed as **BUG-2774**.

## Tests

Go: an all-dropped window returns a cursor that reaches the history behind it; paging across a dropped middle stretch terminates and yields the derived renderable set exactly once; truncation does not step over an exhausted window (that row comes back **0 times** against the previous commit); and a control leg pins that an untruncated page still resumes at its last rendered entry — without it, "always resume from the oldest row touched" passes while skipping what truncation cut. The two-full-source selection rule is a unit test, because a full source whose rows *render* takes the truncation branch instead, so the handler cannot cheaply reach it.

vitest: the cursors the component **asks for**, not only what it displays — a component that shows the right thing by re-fetching page one forever is the bug.

**Mutation matrix**, every member independently detected:

| mutation | dies on |
|---|---|
| cursor from rendered entries | empty-page + dropped-window Go tests |
| oldest tail instead of newest | tail-selection unit test |
| full-window flag ignored | tail-selection unit test |
| no cursor at all | all three handler tests |
| truncation ignores the exhausted candidate | truncation-gap test (row returned 0 times) |
| client ignores the server cursor | 3 of 4 client legs (the fallback leg survives — it pins that path) |
| single hop | advance leg |
| unbounded hops | bound leg |
| no-advance stop removed | one-request-per-click leg |
| concatenate instead of merge | order leg |
| paging state not cleared on reload | switch leg |

## Gates (tip 2434ca26, rebased onto main after #1200)

- `make lint` — 0 issues
- `go test ./...` (SQLite) — 28 ok, 0 fail
- `go test ./...` on Postgres 17 — 28 ok, 0 fail (private container on 5447, never the shared 5445)
- `npx vitest run` — 109 files, 1865 tests, 0 fail
- `npx vite build` — clean; `svelte-check` 0 errors (6 warnings, pre-existing, other files)

All re-run after the rebase; the pre-rebase run does not count.

## Test plan

- [x] Empty first page is pageable
- [x] Paging advances past a dropped middle window, exactly once per entry
- [x] Truncation does not step over an exhausted window
- [x] Untruncated page still resumes at its last entry (control)
- [x] Client asks with the server cursor, merges in order, bounds its hops
- [x] SQLite + Postgres + vitest + build
- [ ] CI green on the tip

Refs: BUG-2765, BUG-2773, BUG-2774
